### PR TITLE
feat: Zustand store + Sidebar stub wire-up

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "tailwind-merge": "^2.5.5",
-        "zustand": "^5.0.2"
+        "zustand": "^5.0.12"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.0.0-beta.7",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tailwind-merge": "^2.5.5",
-    "zustand": "^5.0.2"
+    "zustand": "^5.0.12"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.0.0-beta.7",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { TooltipProvider } from './components/ui/Tooltip';
 import { ToastProvider } from './components/ui/Toast';
 import { Sidebar } from './components/Sidebar';
@@ -7,99 +7,30 @@ import { InputBar } from './components/InputBar';
 import { StatusBar } from './components/StatusBar';
 import { SettingsDialog } from './components/SettingsDialog';
 import { CommandPalette } from './components/CommandPalette';
-import { mockSessions, mockGroups, activeSessionId as initialSessionId } from './mock/data';
-import type { Session } from './types';
+import { useStore } from './stores/store';
 
 export default function App() {
-  // Local copy of sessions so we can mutate state (waiting → idle on select)
-  // without touching the mock module. Real impl will move this into a store.
-  const [sessions, setSessions] = useState<Session[]>(() => mockSessions.map((s) => ({ ...s })));
-  const [activeId, setActiveId] = useState<string>(initialSessionId);
-  const [focusedGroupId, setFocusedGroupId] = useState<string | null>(null);
-  const [settingsOpen, setSettingsOpen] = useState(false);
-  const [paletteOpen, setPaletteOpen] = useState(false);
-  const [model, setModel] = useState<'claude-opus-4' | 'claude-sonnet-4' | 'claude-haiku-4'>(
-    'claude-opus-4'
-  );
-  const [permission, setPermission] = useState<'auto' | 'ask' | 'plan'>('auto');
+  const sessions = useStore((s) => s.sessions);
+  const activeId = useStore((s) => s.activeId);
+  const focusedGroupId = useStore((s) => s.focusedGroupId);
+  const model = useStore((s) => s.model);
+  const permission = useStore((s) => s.permission);
+
+  const selectSession = useStore((s) => s.selectSession);
+  const focusGroup = useStore((s) => s.focusGroup);
+  const moveSession = useStore((s) => s.moveSession);
+  const createSession = useStore((s) => s.createSession);
+  const changeCwd = useStore((s) => s.changeCwd);
+  const setModel = useStore((s) => s.setModel);
+  const setPermission = useStore((s) => s.setPermission);
+
+  const [settingsOpen, setSettingsOpen] = React.useState(false);
+  const [paletteOpen, setPaletteOpen] = React.useState(false);
 
   const active = useMemo(
     () => sessions.find((s) => s.id === activeId) ?? sessions[0],
     [sessions, activeId]
   );
-
-  useEffect(() => {
-    if (sessions.length === 0) return;
-    if (!sessions.some((s) => s.id === activeId)) {
-      setActiveId(sessions[0].id);
-    }
-  }, [sessions, activeId]);
-
-  function selectSession(id: string) {
-    setActiveId(id);
-    setFocusedGroupId(null);
-    setSessions((prev) =>
-      prev.map((s) => (s.id === id && s.state === 'waiting' ? { ...s, state: 'idle' } : s))
-    );
-  }
-
-  function focusGroup(id: string) {
-    setFocusedGroupId(id);
-  }
-
-  function moveSession(sessionId: string, targetGroupId: string, beforeSessionId: string | null) {
-    setSessions((prev) => {
-      const moving = prev.find((s) => s.id === sessionId);
-      if (!moving) return prev;
-      const without = prev.filter((s) => s.id !== sessionId);
-      const updated: Session = { ...moving, groupId: targetGroupId };
-      const anchorValid =
-        beforeSessionId !== null &&
-        without.some((s) => s.id === beforeSessionId && s.groupId === targetGroupId);
-      if (!anchorValid) {
-        let lastIdx = -1;
-        without.forEach((s, i) => {
-          if (s.groupId === targetGroupId) lastIdx = i;
-        });
-        const insertAt = lastIdx === -1 ? without.length : lastIdx + 1;
-        return [...without.slice(0, insertAt), updated, ...without.slice(insertAt)];
-      }
-      const anchor = without.findIndex((s) => s.id === beforeSessionId);
-      return [...without.slice(0, anchor), updated, ...without.slice(anchor)];
-    });
-  }
-
-  function changeCwd(nextCwd: string) {
-    setSessions((prev) => prev.map((s) => (s.id === activeId ? { ...s, cwd: nextCwd } : s)));
-  }
-
-  function createSession(cwd: string | null) {
-    const isUsableGroup = (gid: string | null | undefined) => {
-      if (!gid) return false;
-      const g = mockGroups.find((x) => x.id === gid);
-      return !!g && g.kind !== 'archive';
-    };
-    const activeGroupId = sessions.find((s) => s.id === activeId)?.groupId;
-    const fallbackGroupId = mockGroups.find((g) => g.kind !== 'archive')?.id ?? 'g1';
-    const targetGroupId = isUsableGroup(focusedGroupId)
-      ? focusedGroupId!
-      : isUsableGroup(activeGroupId)
-      ? activeGroupId!
-      : fallbackGroupId;
-    const id = `s-${Date.now()}`;
-    const newSession: Session = {
-      id,
-      name: 'New session',
-      state: 'idle',
-      cwd: cwd ?? '~',
-      model,
-      groupId: targetGroupId,
-      agentType: 'claude-code'
-    };
-    setSessions((prev) => [newSession, ...prev]);
-    setActiveId(id);
-    setFocusedGroupId(null);
-  }
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -118,12 +49,20 @@ export default function App() {
     return () => window.removeEventListener('keydown', onKey);
   }, []);
 
+  if (!active) {
+    return (
+      <div className="flex h-full w-full items-center justify-center bg-bg-app text-fg-secondary">
+        No sessions
+      </div>
+    );
+  }
+
   return (
     <TooltipProvider delayDuration={400} skipDelayDuration={100}>
       <ToastProvider>
         <div className="flex h-full w-full bg-bg-app text-fg-primary">
           <Sidebar
-            onCreateSession={createSession}
+            onCreateSession={(cwd) => createSession(cwd)}
             onOpenSettings={() => setSettingsOpen(true)}
             onOpenPalette={() => setPaletteOpen(true)}
             activeSessionId={activeId}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -22,7 +22,7 @@ import {
   verticalListSortingStrategy
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { mockGroups } from '../mock/data';
+import { useStore } from '../stores/store';
 import { cn } from '../lib/cn';
 import { IconButton } from './ui/IconButton';
 import { Button } from './ui/Button';
@@ -64,10 +64,14 @@ function GroupRow({
 }) {
   const sessionIds = sessions.map((s) => s.id);
   const hasWaiting = sessions.some((s) => s.state === 'waiting');
-  const [collapsed, setCollapsed] = useState(group.collapsed);
+  const setGroupCollapsed = useStore((s) => s.setGroupCollapsed);
+  const renameGroup = useStore((s) => s.renameGroup);
+  const deleteGroup = useStore((s) => s.deleteGroup);
+  const archiveGroup = useStore((s) => s.archiveGroup);
+  const unarchiveGroup = useStore((s) => s.unarchiveGroup);
+  const collapsed = group.collapsed;
   const [renaming, setRenaming] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
-  const [name, setName] = useState(group.name);
   const isSpecial = group.kind !== 'normal';
   const menuDisabled = group.kind === 'deleted';
   return (
@@ -95,7 +99,7 @@ function GroupRow({
             <button
               onClick={() => {
                 onFocus();
-                if (!renaming) setCollapsed(!collapsed);
+                if (!renaming) setGroupCollapsed(group.id, !collapsed);
               }}
               className="flex flex-1 min-w-0 items-center gap-1.5 text-left text-fg-secondary outline-none rounded-sm focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-border-strong"
               aria-expanded={!collapsed}
@@ -110,9 +114,9 @@ function GroupRow({
               </motion.span>
               {renaming ? (
                 <InlineRename
-                  value={name}
+                  value={group.name}
                   onCommit={(next) => {
-                    setName(next);
+                    renameGroup(group.id, next);
                     setRenaming(false);
                   }}
                   onCancel={() => setRenaming(false)}
@@ -120,7 +124,7 @@ function GroupRow({
                 />
               ) : (
                 <>
-                  <span className="truncate text-sm font-semibold text-fg-secondary">{name}</span>
+                  <span className="truncate text-sm font-semibold text-fg-secondary">{group.name}</span>
                   {hasWaiting && (
                     <span
                       aria-label="Waiting for response"
@@ -136,7 +140,11 @@ function GroupRow({
           </div>
         </ContextMenuTrigger>
         <ContextMenuContent>
-          <ContextMenuItem onSelect={() => { /* wire to store later */ }}>
+          <ContextMenuItem
+            onSelect={() =>
+              group.kind === 'archive' ? unarchiveGroup(group.id) : archiveGroup(group.id)
+            }
+          >
             {group.kind === 'archive' ? 'Unarchive group' : 'Archive group'}
           </ContextMenuItem>
           <ContextMenuItem onSelect={() => setRenaming(true)}>Rename</ContextMenuItem>
@@ -152,7 +160,7 @@ function GroupRow({
             className="mt-px"
             data-group-id={group.id}
             role="listbox"
-          aria-label={name}
+          aria-label={group.name}
           onKeyDown={(e) => {
             const key = e.key;
             if (key !== 'ArrowDown' && key !== 'ArrowUp' && key !== 'Home' && key !== 'End') return;
@@ -189,17 +197,15 @@ function GroupRow({
       <ConfirmDialog
         open={confirmDelete}
         onOpenChange={setConfirmDelete}
-        title={`Delete "${name}"?`}
+        title={`Delete "${group.name}"?`}
         description={
           sessions.length > 0
-            ? `This group contains ${sessions.length} session${sessions.length === 1 ? '' : 's'}. They will be moved to Deleted.`
+            ? `This group contains ${sessions.length} session${sessions.length === 1 ? '' : 's'}. They will be deleted with the group.`
             : 'This group is empty.'
         }
         confirmLabel="Delete group"
         destructive
-        onConfirm={() => {
-          /* wire to store later */
-        }}
+        onConfirm={() => deleteGroup(group.id)}
       />
     </div>
   );
@@ -208,8 +214,11 @@ function GroupRow({
 function SessionRow({ session, active, selected, onSelect }: { session: Session; active: boolean; selected: boolean; onSelect: () => void }) {
   const [renaming, setRenaming] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
-  const [name, setName] = useState(session.name);
-  const groups = mockGroups.filter((g) => g.kind === 'normal');
+  const groups = useStore((s) => s.groups).filter((g) => g.kind === 'normal');
+  const renameSession = useStore((s) => s.renameSession);
+  const deleteSession = useStore((s) => s.deleteSession);
+  const moveSession = useStore((s) => s.moveSession);
+  const createGroup = useStore((s) => s.createGroup);
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: session.id,
     data: { type: 'session', groupId: session.groupId }
@@ -263,16 +272,16 @@ function SessionRow({ session, active, selected, onSelect }: { session: Session;
           <span className="flex-1 min-w-0 leading-tight">
             {renaming ? (
               <InlineRename
-                value={name}
+                value={session.name}
                 onCommit={(next) => {
-                  setName(next);
+                  renameSession(session.id, next);
                   setRenaming(false);
                 }}
                 onCancel={() => setRenaming(false)}
                 inputClassName="text-base"
               />
             ) : (
-              <span className="truncate block">{name}</span>
+              <span className="truncate block">{session.name}</span>
             )}
           </span>
           {active && (
@@ -284,13 +293,11 @@ function SessionRow({ session, active, selected, onSelect }: { session: Session;
           <ConfirmDialog
             open={confirmDelete}
             onOpenChange={setConfirmDelete}
-            title={`Delete "${name}"?`}
+            title={`Delete "${session.name}"?`}
             description="The session and its conversation history will be removed."
             confirmLabel="Delete"
             destructive
-            onConfirm={() => {
-              /* wire to store later */
-            }}
+            onConfirm={() => deleteSession(session.id)}
           />
         </li>
       </ContextMenuTrigger>
@@ -303,9 +310,7 @@ function SessionRow({ session, active, selected, onSelect }: { session: Session;
               <ContextMenuItem
                 key={g.id}
                 disabled={g.id === session.groupId}
-                onSelect={() => {
-                  /* wire to store later */
-                }}
+                onSelect={() => moveSession(session.id, g.id, null)}
               >
                 {g.name}
               </ContextMenuItem>
@@ -313,7 +318,8 @@ function SessionRow({ session, active, selected, onSelect }: { session: Session;
             <ContextMenuSeparator />
             <ContextMenuItem
               onSelect={() => {
-                /* wire to store later — create new group then move */
+                const id = createGroup();
+                moveSession(session.id, id, null);
               }}
             >
               New group…
@@ -356,8 +362,10 @@ function NewSessionButton({ onCreateSession }: { onCreateSession?: (cwd: string 
 }
 
 export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, activeSessionId, focusedGroupId, onSelectSession, onFocusGroup, sessions, onMoveSession }: SidebarProps) {
-  const normal = mockGroups.filter((g) => g.kind === 'normal');
-  const archived = mockGroups.filter((g) => g.kind === 'archive');
+  const groups = useStore((s) => s.groups);
+  const createGroup = useStore((s) => s.createGroup);
+  const normal = groups.filter((g) => g.kind === 'normal');
+  const archived = groups.filter((g) => g.kind === 'archive');
   const [archiveOpen, setArchiveOpen] = useState(false);
   const [draggingId, setDraggingId] = useState<string | null>(null);
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
@@ -430,6 +438,7 @@ export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, active
               tooltip="New group"
               tooltipSide="top"
               aria-label="New group"
+              onClick={() => createGroup()}
             >
               <Plus size={12} className="stroke-[1.75]" />
             </IconButton>

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -1,0 +1,209 @@
+import { create } from 'zustand';
+import {
+  mockGroups,
+  mockSessions,
+  mockRecentProjects,
+  activeSessionId as initialActiveId,
+  type RecentProject
+} from '../mock/data';
+import type { Group, Session } from '../types';
+
+export type ModelId = 'claude-opus-4' | 'claude-sonnet-4' | 'claude-haiku-4';
+export type PermissionMode = 'auto' | 'ask' | 'plan';
+
+type State = {
+  sessions: Session[];
+  groups: Group[];
+  recentProjects: RecentProject[];
+  activeId: string;
+  focusedGroupId: string | null;
+  model: ModelId;
+  permission: PermissionMode;
+};
+
+type Actions = {
+  selectSession: (id: string) => void;
+  focusGroup: (id: string | null) => void;
+  createSession: (cwd: string | null) => void;
+  renameSession: (id: string, name: string) => void;
+  deleteSession: (id: string) => void;
+  moveSession: (sessionId: string, targetGroupId: string, beforeSessionId: string | null) => void;
+  changeCwd: (cwd: string) => void;
+  setModel: (model: ModelId) => void;
+  setPermission: (mode: PermissionMode) => void;
+
+  createGroup: (name?: string) => string;
+  renameGroup: (id: string, name: string) => void;
+  deleteGroup: (id: string) => void;
+  archiveGroup: (id: string) => void;
+  unarchiveGroup: (id: string) => void;
+  setGroupCollapsed: (id: string, collapsed: boolean) => void;
+};
+
+function nextId(prefix: string): string {
+  return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
+function firstUsableGroupId(groups: Group[]): string {
+  const g = groups.find((x) => x.kind === 'normal');
+  return g ? g.id : groups[0]?.id ?? 'g1';
+}
+
+export const useStore = create<State & Actions>((set, get) => ({
+  sessions: mockSessions.map((s) => ({ ...s })),
+  groups: mockGroups.map((g) => ({ ...g })),
+  recentProjects: mockRecentProjects,
+  activeId: initialActiveId,
+  focusedGroupId: null,
+  model: 'claude-opus-4',
+  permission: 'auto',
+
+  selectSession: (id) => {
+    set((s) => ({
+      activeId: id,
+      focusedGroupId: null,
+      sessions: s.sessions.map((x) =>
+        x.id === id && x.state === 'waiting' ? { ...x, state: 'idle' } : x
+      )
+    }));
+  },
+
+  focusGroup: (id) => set({ focusedGroupId: id }),
+
+  createSession: (cwd) => {
+    const { sessions, groups, focusedGroupId, activeId, model } = get();
+    const isUsable = (gid: string | null | undefined) => {
+      if (!gid) return false;
+      const g = groups.find((x) => x.id === gid);
+      return !!g && g.kind === 'normal';
+    };
+    const activeGroupId = sessions.find((s) => s.id === activeId)?.groupId;
+    const targetGroupId = isUsable(focusedGroupId)
+      ? focusedGroupId!
+      : isUsable(activeGroupId)
+      ? activeGroupId!
+      : firstUsableGroupId(groups);
+    const id = nextId('s');
+    const newSession: Session = {
+      id,
+      name: 'New session',
+      state: 'idle',
+      cwd: cwd ?? '~',
+      model,
+      groupId: targetGroupId,
+      agentType: 'claude-code'
+    };
+    set({
+      sessions: [newSession, ...sessions],
+      activeId: id,
+      focusedGroupId: null
+    });
+  },
+
+  renameSession: (id, name) => {
+    set((s) => ({
+      sessions: s.sessions.map((x) => (x.id === id ? { ...x, name } : x))
+    }));
+  },
+
+  deleteSession: (id) => {
+    set((s) => {
+      const remaining = s.sessions.filter((x) => x.id !== id);
+      const nextActive =
+        s.activeId === id ? remaining[0]?.id ?? '' : s.activeId;
+      return { sessions: remaining, activeId: nextActive };
+    });
+  },
+
+  moveSession: (sessionId, targetGroupId, beforeSessionId) => {
+    set((s) => {
+      const moving = s.sessions.find((x) => x.id === sessionId);
+      if (!moving) return s;
+      const targetGroup = s.groups.find((g) => g.id === targetGroupId);
+      if (!targetGroup) return s;
+      const without = s.sessions.filter((x) => x.id !== sessionId);
+      const updated: Session = { ...moving, groupId: targetGroupId };
+      const anchorValid =
+        beforeSessionId !== null &&
+        without.some(
+          (x) => x.id === beforeSessionId && x.groupId === targetGroupId
+        );
+      if (!anchorValid) {
+        let lastIdx = -1;
+        without.forEach((x, i) => {
+          if (x.groupId === targetGroupId) lastIdx = i;
+        });
+        const insertAt = lastIdx === -1 ? without.length : lastIdx + 1;
+        return {
+          sessions: [...without.slice(0, insertAt), updated, ...without.slice(insertAt)]
+        };
+      }
+      const anchor = without.findIndex((x) => x.id === beforeSessionId);
+      return {
+        sessions: [...without.slice(0, anchor), updated, ...without.slice(anchor)]
+      };
+    });
+  },
+
+  changeCwd: (cwd) => {
+    set((s) => ({
+      sessions: s.sessions.map((x) => (x.id === s.activeId ? { ...x, cwd } : x))
+    }));
+  },
+
+  setModel: (model) => set({ model }),
+  setPermission: (permission) => set({ permission }),
+
+  createGroup: (name) => {
+    const id = nextId('g');
+    const newGroup: Group = {
+      id,
+      name: name ?? 'New group',
+      collapsed: false,
+      kind: 'normal'
+    };
+    set((s) => ({ groups: [...s.groups, newGroup] }));
+    return id;
+  },
+
+  renameGroup: (id, name) => {
+    set((s) => ({
+      groups: s.groups.map((g) => (g.id === id ? { ...g, name } : g))
+    }));
+  },
+
+  // Per design principle "don't constrain the user": deleting a group also
+  // deletes its sessions. No soft-delete state in MVP — that's what archive is for.
+  deleteGroup: (id) => {
+    set((s) => {
+      const remainingSessions = s.sessions.filter((x) => x.groupId !== id);
+      const nextActive = remainingSessions.some((x) => x.id === s.activeId)
+        ? s.activeId
+        : remainingSessions[0]?.id ?? '';
+      return {
+        groups: s.groups.filter((g) => g.id !== id),
+        sessions: remainingSessions,
+        activeId: nextActive,
+        focusedGroupId: s.focusedGroupId === id ? null : s.focusedGroupId
+      };
+    });
+  },
+
+  archiveGroup: (id) => {
+    set((s) => ({
+      groups: s.groups.map((g) => (g.id === id ? { ...g, kind: 'archive' } : g))
+    }));
+  },
+
+  unarchiveGroup: (id) => {
+    set((s) => ({
+      groups: s.groups.map((g) => (g.id === id ? { ...g, kind: 'normal' } : g))
+    }));
+  },
+
+  setGroupCollapsed: (id, collapsed) => {
+    set((s) => ({
+      groups: s.groups.map((g) => (g.id === id ? { ...g, collapsed } : g))
+    }));
+  }
+}));


### PR DESCRIPTION
## Summary
- Introduce Zustand store (`src/stores/store.ts`) as single source of truth for sessions/groups/recentProjects/UI state.
- App.tsx now reads from store hooks; component-tree no longer holds session list in useState.
- Sidebar context-menu stubs all wired: group rename/archive/unarchive/delete, session rename/delete/move-to-group/new-group, header "+ New Group" button.

## Test plan
- [x] `npm run typecheck` clean
- [x] Dev server boots, sessions/groups still render
- [ ] Manually exercise: create group, rename, archive/unarchive, delete; rename session, move between groups, delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)