### PR TITLE
feat: SQLite persistence layer (better-sqlite3)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -22,7 +22,7 @@
 | Radix-based 手搓 ui/ 原语 | ✅ | Dialog / DropdownMenu / ContextMenu / Tooltip / Toast / ConfirmDialog / Button / IconButton / InlineRename / StateGlyph。 |
 | framer-motion / lucide-react / @dnd-kit | ✅ | 已装并在 Sidebar 用。 |
 | Zustand store | ✅ | `src/stores/store.ts` 持有 sessions/groups/recentProjects/UI 状态 + 15 actions；App.tsx 全量消费。 |
-| better-sqlite3 持久化 | ⬜ | 依赖已装，未接 IPC、未建 schema。 |
+| better-sqlite3 持久化 | 🟡 | `electron/db.ts` 起 WAL，`app_state(key,value)` 单表；`db:load`/`db:save` IPC + preload bridge；renderer 通过 `hydrateStore()` 启动加载、debounced 250ms 写回。schema 是单 JSON blob，结构化 schema 留给后续。 |
 | Claude Agent SDK 集成 | ⬜ | 未装包，未起 sidecar。 |
 | `~/.claude/projects/` 导入 | ⬜ | |
 | 全局快捷键注册 | 🟡 | `App.tsx` 注册了 Cmd+K / Cmd+,；Cmd+B / Cmd+N / Cmd+Shift+N 未实现。 |
@@ -102,7 +102,7 @@
 
 | 项 | 状态 |
 |---|---|
-| SQLite schema（groups / sessions / ui_state） | ⬜ |
+| SQLite schema（groups / sessions / ui_state） | 🟡 单 JSON blob，未拆表 |
 | Boot：扫 `~/.claude/projects/` 对账 | ⬜ |
 | API key keychain 存储 | ⬜ |
 

--- a/electron/db.ts
+++ b/electron/db.ts
@@ -1,0 +1,44 @@
+import Database from 'better-sqlite3';
+import { app } from 'electron';
+import * as path from 'path';
+import * as fs from 'fs';
+
+let db: Database.Database | null = null;
+
+export function initDb(): Database.Database {
+  if (db) return db;
+  const dir = app.getPath('userData');
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, 'agentory.db');
+  db = new Database(file);
+  db.pragma('journal_mode = WAL');
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS app_state (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+  `);
+  return db;
+}
+
+export function loadState(key: string): string | null {
+  const row = initDb().prepare('SELECT value FROM app_state WHERE key = ?').get(key) as
+    | { value: string }
+    | undefined;
+  return row?.value ?? null;
+}
+
+export function saveState(key: string, value: string): void {
+  initDb()
+    .prepare(
+      `INSERT INTO app_state (key, value, updated_at) VALUES (?, ?, ?)
+       ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`
+    )
+    .run(key, value, Date.now());
+}
+
+export function closeDb(): void {
+  db?.close();
+  db = null;
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,5 +1,6 @@
-import { app, BrowserWindow, Menu } from 'electron';
+import { app, BrowserWindow, Menu, ipcMain } from 'electron';
 import * as path from 'path';
+import { initDb, loadState, saveState, closeDb } from './db';
 
 const isDev = !app.isPackaged;
 
@@ -35,9 +36,15 @@ function createWindow() {
   }
 }
 
-app.whenReady().then(createWindow);
+app.whenReady().then(() => {
+  initDb();
+  ipcMain.handle('db:load', (_e, key: string) => loadState(key));
+  ipcMain.handle('db:save', (_e, key: string, value: string) => saveState(key, value));
+  createWindow();
+});
 
 app.on('window-all-closed', () => {
+  closeDb();
   if (process.platform !== 'darwin') app.quit();
 });
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,2 +1,11 @@
-// preload: exposes a minimal bridge. Empty for the shell-only milestone.
-export {};
+import { contextBridge, ipcRenderer } from 'electron';
+
+const api = {
+  loadState: (key: string): Promise<string | null> => ipcRenderer.invoke('db:load', key),
+  saveState: (key: string, value: string): Promise<void> =>
+    ipcRenderer.invoke('db:save', key, value)
+};
+
+contextBridge.exposeInMainWorld('agentory', api);
+
+export type AgentoryAPI = typeof api;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,10 @@
+declare global {
+  interface Window {
+    agentory?: {
+      loadState: (key: string) => Promise<string | null>;
+      saveState: (key: string, value: string) => Promise<void>;
+    };
+  }
+}
+
+export {};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,11 @@ import { createRoot } from 'react-dom/client';
 import '@fontsource-variable/inter';
 import '@fontsource-variable/jetbrains-mono';
 import App from './App';
+import { hydrateStore } from './stores/store';
 import './styles/global.css';
 
 const root = createRoot(document.getElementById('root')!);
-root.render(<App />);
+
+hydrateStore().finally(() => {
+  root.render(<App />);
+});

--- a/src/stores/persist.ts
+++ b/src/stores/persist.ts
@@ -1,0 +1,38 @@
+import type { Group, Session } from '../types';
+import type { ModelId, PermissionMode } from './store';
+
+export const STATE_KEY = 'main';
+
+export interface PersistedState {
+  version: 1;
+  sessions: Session[];
+  groups: Group[];
+  activeId: string;
+  model: ModelId;
+  permission: PermissionMode;
+}
+
+export async function loadPersisted(): Promise<PersistedState | null> {
+  if (!window.agentory) return null;
+  try {
+    const raw = await window.agentory.loadState(STATE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as PersistedState;
+    if (parsed.version !== 1) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+let writeTimer: ReturnType<typeof setTimeout> | null = null;
+const WRITE_DEBOUNCE_MS = 250;
+
+export function schedulePersist(state: PersistedState): void {
+  if (!window.agentory) return;
+  if (writeTimer) clearTimeout(writeTimer);
+  writeTimer = setTimeout(() => {
+    writeTimer = null;
+    window.agentory!.saveState(STATE_KEY, JSON.stringify(state)).catch(() => {});
+  }, WRITE_DEBOUNCE_MS);
+}

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -7,6 +7,7 @@ import {
   type RecentProject
 } from '../mock/data';
 import type { Group, Session } from '../types';
+import { loadPersisted, schedulePersist, type PersistedState } from './persist';
 
 export type ModelId = 'claude-opus-4' | 'claude-sonnet-4' | 'claude-haiku-4';
 export type PermissionMode = 'auto' | 'ask' | 'plan';
@@ -207,3 +208,33 @@ export const useStore = create<State & Actions>((set, get) => ({
     }));
   }
 }));
+
+let hydrated = false;
+
+export async function hydrateStore(): Promise<void> {
+  if (hydrated) return;
+  const persisted = await loadPersisted();
+  if (persisted) {
+    const stillActive = persisted.sessions.some((s) => s.id === persisted.activeId);
+    useStore.setState({
+      sessions: persisted.sessions,
+      groups: persisted.groups,
+      activeId: stillActive ? persisted.activeId : persisted.sessions[0]?.id ?? '',
+      model: persisted.model,
+      permission: persisted.permission
+    });
+  }
+  hydrated = true;
+  // After (potential) hydration, subscribe to write-through.
+  useStore.subscribe((s) => {
+    const snapshot: PersistedState = {
+      version: 1,
+      sessions: s.sessions,
+      groups: s.groups,
+      activeId: s.activeId,
+      model: s.model,
+      permission: s.permission
+    };
+    schedulePersist(snapshot);
+  });
+}


### PR DESCRIPTION
## Summary
- Add `electron/db.ts` (WAL mode, single-table `app_state(key, value)`) and IPC handlers `db:load` / `db:save`.
- `electron/preload.ts` exposes `window.agentory.{loadState, saveState}`.
- `src/stores/persist.ts` — versioned snapshot, 250ms debounced write-through.
- `src/stores/store.ts` — `hydrateStore()` reads from DB on boot then subscribes for writes.
- `src/index.tsx` — `hydrateStore().finally(render)` so first paint has persisted state.

MVP intentionally uses a single JSON blob row. We can normalize into groups/sessions/ui_state tables when partial reads or multi-window become real needs.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npx electron-rebuild` succeeds for better-sqlite3 on Windows
- [ ] Boot dev: rename a group → kill app → reboot → rename persists