### PR TITLE
feat: Sidebar collapse (Cmd/Ctrl+B)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -25,7 +25,7 @@
 | better-sqlite3 持久化 | 🟡 | `electron/db.ts` 起 WAL，`app_state(key,value)` 单表；`db:load`/`db:save` IPC + preload bridge；renderer 通过 `hydrateStore()` 启动加载、debounced 250ms 写回。schema 是单 JSON blob，结构化 schema 留给后续。 |
 | Claude Agent SDK 集成 | ⬜ | 未装包，未起 sidecar。 |
 | `~/.claude/projects/` 导入 | ⬜ | |
-| 全局快捷键注册 | 🟡 | `App.tsx` 注册了 Cmd+K / Cmd+,；Cmd+B / Cmd+N / Cmd+Shift+N 未实现。 |
+| 全局快捷键注册 | 🟡 | `App.tsx` 注册了 Cmd+K / Cmd+, / Cmd+B；Cmd+N / Cmd+Shift+N 未实现。 |
 
 ## 2. Sidebar（`src/components/Sidebar.tsx`）
 
@@ -46,7 +46,7 @@
 | "+ New Group" 按钮 | ✅ | onClick → `createGroup()`。 |
 | Archived Groups 底部折叠区 | ✅ | UI 已实现；archived 数据来自 mockGroups。 |
 | Deleted Groups 视图 | ⬜ | mvp-design.md §5 提到底部 ⋯ More；当前实现把 Deleted 略掉了，需对齐设计或更新设计。 |
-| Sidebar 折叠（256↔48） | ⬜ | mvp-design.md §5.1 详细规格，未实现。 |
+| Sidebar 折叠（256↔48） | ✅ | Cmd/Ctrl+B 切换，framer-motion 220ms width 动画，折叠态显示 expand/new/search/settings 四个 IconButton；状态持久化到 SQLite。 |
 
 ## 3. ChatStream（`src/components/ChatStream.tsx`）
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ export default function App() {
   const changeCwd = useStore((s) => s.changeCwd);
   const setModel = useStore((s) => s.setModel);
   const setPermission = useStore((s) => s.setPermission);
+  const toggleSidebar = useStore((s) => s.toggleSidebar);
 
   const [settingsOpen, setSettingsOpen] = React.useState(false);
   const [paletteOpen, setPaletteOpen] = React.useState(false);
@@ -40,6 +41,9 @@ export default function App() {
       if (k === 'k' && !e.shiftKey) {
         e.preventDefault();
         setPaletteOpen((p) => !p);
+      } else if (k === 'b' && !e.shiftKey) {
+        e.preventDefault();
+        toggleSidebar();
       } else if (e.key === ',') {
         e.preventDefault();
         setSettingsOpen(true);

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -364,6 +364,8 @@ function NewSessionButton({ onCreateSession }: { onCreateSession?: (cwd: string 
 export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, activeSessionId, focusedGroupId, onSelectSession, onFocusGroup, sessions, onMoveSession }: SidebarProps) {
   const groups = useStore((s) => s.groups);
   const createGroup = useStore((s) => s.createGroup);
+  const collapsed = useStore((s) => s.sidebarCollapsed);
+  const toggleSidebar = useStore((s) => s.toggleSidebar);
   const normal = groups.filter((g) => g.kind === 'normal');
   const archived = groups.filter((g) => g.kind === 'archive');
   const [archiveOpen, setArchiveOpen] = useState(false);
@@ -401,8 +403,59 @@ export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, active
     >
     <motion.aside
       initial={false}
-      className="relative flex flex-col w-64 bg-bg-sidebar/80 backdrop-blur-xl sidebar-edge overflow-hidden"
+      animate={{ width: collapsed ? 48 : 256 }}
+      transition={{ duration: 0.22, ease: [0.32, 0.72, 0, 1] }}
+      className="relative flex flex-col bg-bg-sidebar/80 backdrop-blur-xl sidebar-edge overflow-hidden"
     >
+      {collapsed ? (
+        <div className="flex flex-col items-center w-12 h-full py-3 gap-2">
+          <IconButton
+            variant="raised"
+            size="md"
+            onClick={toggleSidebar}
+            tooltip="Expand sidebar  ⌘B"
+            tooltipSide="right"
+            aria-label="Expand sidebar"
+            className="h-8 w-8"
+          >
+            <ChevronRight size={14} className="stroke-[1.5]" />
+          </IconButton>
+          <IconButton
+            variant="raised"
+            size="md"
+            onClick={() => onCreateSession?.(null)}
+            tooltip="New session"
+            tooltipSide="right"
+            aria-label="New session"
+            className="h-8 w-8"
+          >
+            <Plus size={14} className="stroke-[1.75]" />
+          </IconButton>
+          <IconButton
+            variant="raised"
+            size="md"
+            onClick={onOpenPalette}
+            tooltip="Search  ⌘K"
+            tooltipSide="right"
+            aria-label="Search"
+            className="h-8 w-8"
+          >
+            <Search size={14} className="stroke-[1.5]" />
+          </IconButton>
+          <div className="flex-1" />
+          <IconButton
+            variant="raised"
+            size="md"
+            onClick={onOpenSettings}
+            tooltip="Settings  ⌘,"
+            tooltipSide="right"
+            aria-label="Settings"
+            className="h-8 w-8"
+          >
+            <Settings size={13} className="stroke-[1.5]" />
+          </IconButton>
+        </div>
+      ) : (
       <div className="flex flex-col w-64 h-full">
           {/* Top: action zone — Search + New Session in one row.
               CodePilot-spec: h-8, bg-white/[0.06] semi-transparent on the
@@ -514,6 +567,7 @@ export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, active
             </Button>
           </div>
         </div>
+      )}
     </motion.aside>
     <DragOverlay dropAnimation={{ duration: 150, easing: 'cubic-bezier(0.32,0.72,0,1)' }}>
       {draggingSession ? (

--- a/src/stores/persist.ts
+++ b/src/stores/persist.ts
@@ -10,6 +10,7 @@ export interface PersistedState {
   activeId: string;
   model: ModelId;
   permission: PermissionMode;
+  sidebarCollapsed: boolean;
 }
 
 export async function loadPersisted(): Promise<PersistedState | null> {

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -20,6 +20,7 @@ type State = {
   focusedGroupId: string | null;
   model: ModelId;
   permission: PermissionMode;
+  sidebarCollapsed: boolean;
 };
 
 type Actions = {
@@ -32,6 +33,8 @@ type Actions = {
   changeCwd: (cwd: string) => void;
   setModel: (model: ModelId) => void;
   setPermission: (mode: PermissionMode) => void;
+  setSidebarCollapsed: (collapsed: boolean) => void;
+  toggleSidebar: () => void;
 
   createGroup: (name?: string) => string;
   renameGroup: (id: string, name: string) => void;
@@ -58,6 +61,7 @@ export const useStore = create<State & Actions>((set, get) => ({
   focusedGroupId: null,
   model: 'claude-opus-4',
   permission: 'auto',
+  sidebarCollapsed: false,
 
   selectSession: (id) => {
     set((s) => ({
@@ -154,6 +158,8 @@ export const useStore = create<State & Actions>((set, get) => ({
 
   setModel: (model) => set({ model }),
   setPermission: (permission) => set({ permission }),
+  setSidebarCollapsed: (collapsed) => set({ sidebarCollapsed: collapsed }),
+  toggleSidebar: () => set((s) => ({ sidebarCollapsed: !s.sidebarCollapsed })),
 
   createGroup: (name) => {
     const id = nextId('g');
@@ -221,7 +227,8 @@ export async function hydrateStore(): Promise<void> {
       groups: persisted.groups,
       activeId: stillActive ? persisted.activeId : persisted.sessions[0]?.id ?? '',
       model: persisted.model,
-      permission: persisted.permission
+      permission: persisted.permission,
+      sidebarCollapsed: persisted.sidebarCollapsed ?? false
     });
   }
   hydrated = true;
@@ -233,7 +240,8 @@ export async function hydrateStore(): Promise<void> {
       groups: s.groups,
       activeId: s.activeId,
       model: s.model,
-      permission: s.permission
+      permission: s.permission,
+      sidebarCollapsed: s.sidebarCollapsed
     };
     schedulePersist(snapshot);
   });


### PR DESCRIPTION
## Summary
- 256↔48 collapse animation (framer-motion, 220ms cubic-bezier per design §5.1).
- `Cmd/Ctrl+B` keybinding in App.tsx.
- Collapsed rail: expand / new session / search / settings IconButtons.
- State persists via existing SQLite blob.

## Test plan
- [x] typecheck clean
- [ ] Cmd+B toggles, animation smooth
- [ ] Reload preserves collapsed state