### PR TITLE
PR #7: Wire SettingsDialog to store + IPC

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Implementation Status
 
-最后更新：2026-04-20
+最后更新：2026-04-21
 
 这是 agentory-next 当前实现进度的对账表。每个 PR 合并后必须更新本文件，让"已实现 vs 待实现"始终一目了然。
 
@@ -77,12 +77,12 @@
 
 | 项 | 状态 | 备注 |
 |---|---|---|
-| 弹层骨架 + 分组 tabs | 🟡 | UI 通；所有控件无副作用。 |
-| Theme 切换 | ⬜ | |
-| Anthropic API key（safeStorage） | ⬜ | |
-| Data dir 显示 | ⬜ | |
-| Shortcuts 只读列表 | ⬜ | |
-| Updates "Check for updates" | ⬜ | |
+| 弹层骨架 + 分组 tabs | ✅ | UI 通；tab 切换正常。 |
+| Theme 切换 | ✅ | `theme: system|light|dark` 持久化到 store；App.tsx 监听 `prefers-color-scheme` 并切换 `<html>.dark` class。 |
+| Anthropic API key（safeStorage） | ✅ | `keychain:get/setApiKey` IPC + Electron `safeStorage`，加密文件落 userData，无加密时禁用输入。 |
+| Data dir 显示 | ✅ | `app:getDataDir` IPC 返回真实 `app.getPath('userData')`。 |
+| Shortcuts 只读列表 | ✅ | 静态目录，符合 mvp-design.md "MVP 不开放 remap"。 |
+| Updates "Check for updates" | 🟡 | 版本号通过 `app:getVersion` 读真实 package.json；按钮禁用，等 electron-updater PR。 |
 
 ## 7. CommandPalette（`src/components/CommandPalette.tsx`）
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,6 +1,41 @@
-import { app, BrowserWindow, Menu, ipcMain } from 'electron';
+import { app, BrowserWindow, Menu, ipcMain, safeStorage } from 'electron';
 import * as path from 'path';
+import * as fs from 'fs';
 import { initDb, loadState, saveState, closeDb } from './db';
+
+const KEYCHAIN_FILE = 'anthropic-key.bin';
+
+function keychainPath(): string {
+  return path.join(app.getPath('userData'), KEYCHAIN_FILE);
+}
+
+function readApiKey(): string {
+  try {
+    if (!safeStorage.isEncryptionAvailable()) return '';
+    const p = keychainPath();
+    if (!fs.existsSync(p)) return '';
+    const buf = fs.readFileSync(p);
+    return safeStorage.decryptString(buf);
+  } catch {
+    return '';
+  }
+}
+
+function writeApiKey(value: string): boolean {
+  try {
+    if (!safeStorage.isEncryptionAvailable()) return false;
+    const p = keychainPath();
+    if (!value) {
+      if (fs.existsSync(p)) fs.unlinkSync(p);
+      return true;
+    }
+    const enc = safeStorage.encryptString(value);
+    fs.writeFileSync(p, enc, { mode: 0o600 });
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 const isDev = !app.isPackaged;
 
@@ -40,6 +75,11 @@ app.whenReady().then(() => {
   initDb();
   ipcMain.handle('db:load', (_e, key: string) => loadState(key));
   ipcMain.handle('db:save', (_e, key: string, value: string) => saveState(key, value));
+  ipcMain.handle('app:getDataDir', () => app.getPath('userData'));
+  ipcMain.handle('app:getVersion', () => app.getVersion());
+  ipcMain.handle('keychain:getApiKey', () => readApiKey());
+  ipcMain.handle('keychain:setApiKey', (_e, value: string) => writeApiKey(value));
+  ipcMain.handle('keychain:hasEncryption', () => safeStorage.isEncryptionAvailable());
   createWindow();
 });
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -3,7 +3,12 @@ import { contextBridge, ipcRenderer } from 'electron';
 const api = {
   loadState: (key: string): Promise<string | null> => ipcRenderer.invoke('db:load', key),
   saveState: (key: string, value: string): Promise<void> =>
-    ipcRenderer.invoke('db:save', key, value)
+    ipcRenderer.invoke('db:save', key, value),
+  getDataDir: (): Promise<string> => ipcRenderer.invoke('app:getDataDir'),
+  getVersion: (): Promise<string> => ipcRenderer.invoke('app:getVersion'),
+  getApiKey: (): Promise<string> => ipcRenderer.invoke('keychain:getApiKey'),
+  setApiKey: (value: string): Promise<boolean> => ipcRenderer.invoke('keychain:setApiKey', value),
+  hasEncryption: (): Promise<boolean> => ipcRenderer.invoke('keychain:hasEncryption')
 };
 
 contextBridge.exposeInMainWorld('agentory', api);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,28 @@ export default function App() {
   const setModel = useStore((s) => s.setModel);
   const setPermission = useStore((s) => s.setPermission);
   const toggleSidebar = useStore((s) => s.toggleSidebar);
+  const theme = useStore((s) => s.theme);
+  const fontSize = useStore((s) => s.fontSize);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const apply = () => {
+      const dark =
+        theme === 'dark' ||
+        (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+      root.classList.toggle('dark', dark);
+    };
+    apply();
+    if (theme !== 'system') return;
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    mq.addEventListener('change', apply);
+    return () => mq.removeEventListener('change', apply);
+  }, [theme]);
+
+  useEffect(() => {
+    const px = fontSize === 'sm' ? '12px' : fontSize === 'lg' ? '14px' : '13px';
+    document.documentElement.style.setProperty('--app-font-size', px);
+  }, [fontSize]);
 
   const [settingsOpen, setSettingsOpen] = React.useState(false);
   const [paletteOpen, setPaletteOpen] = React.useState(false);

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { cn } from '../lib/cn';
-import { Dialog, DialogContent, DialogBody } from './ui/Dialog';
+import { Dialog, DialogContent } from './ui/Dialog';
 import { Button } from './ui/Button';
+import { useStore } from '../stores/store';
 
 type Tab = 'general' | 'account' | 'data' | 'shortcuts' | 'updates';
 
@@ -110,8 +111,10 @@ function Select<T extends string>({
 }
 
 function GeneralPane() {
-  const [theme, setTheme] = useState<'system' | 'light' | 'dark'>('system');
-  const [fontSize, setFontSize] = useState<'sm' | 'md' | 'lg'>('md');
+  const theme = useStore((s) => s.theme);
+  const fontSize = useStore((s) => s.fontSize);
+  const setTheme = useStore((s) => s.setTheme);
+  const setFontSize = useStore((s) => s.setFontSize);
   return (
     <>
       <Field label="Theme">
@@ -142,32 +145,75 @@ function GeneralPane() {
 
 function AccountPane() {
   const [key, setKey] = useState('');
+  const [loaded, setLoaded] = useState(false);
+  const [status, setStatus] = useState<string | null>(null);
+  const [encAvailable, setEncAvailable] = useState(true);
+
+  useEffect(() => {
+    const api = window.agentory;
+    if (!api) {
+      setLoaded(true);
+      return;
+    }
+    Promise.all([api.getApiKey(), api.hasEncryption()]).then(([k, enc]) => {
+      setKey(k);
+      setEncAvailable(enc);
+      setLoaded(true);
+    });
+  }, []);
+
+  const save = async () => {
+    const api = window.agentory;
+    if (!api) return;
+    const ok = await api.setApiKey(key.trim());
+    setStatus(ok ? 'Saved.' : 'Failed to save (encryption unavailable).');
+    setTimeout(() => setStatus(null), 2000);
+  };
+
   return (
     <>
-      <Field label="Anthropic API key" hint="Stored in OS keychain. Required for Claude Code sessions.">
+      <Field
+        label="Anthropic API key"
+        hint={
+          encAvailable
+            ? 'Stored in OS keychain. Required for Claude Code sessions.'
+            : 'OS encryption unavailable — key cannot be saved on this system.'
+        }
+      >
         <input
           type="password"
           value={key}
           onChange={(e) => setKey(e.target.value)}
-          placeholder="sk-ant-…"
+          placeholder={loaded ? 'sk-ant-…' : 'Loading…'}
+          disabled={!loaded || !encAvailable}
           className={cn(
             'w-full h-8 px-2 rounded-sm bg-bg-elevated border border-border-default',
             'text-sm font-mono text-fg-primary placeholder:text-fg-disabled outline-none',
-            'focus:border-border-strong focus:shadow-[0_0_0_2px_oklch(0.72_0.14_215_/_0.30)]'
+            'focus:border-border-strong focus:shadow-[0_0_0_2px_oklch(0.72_0.14_215_/_0.30)]',
+            'disabled:opacity-60 disabled:cursor-not-allowed'
           )}
         />
       </Field>
-      <Button variant="secondary" size="md">Test connection</Button>
+      <div className="flex items-center gap-3">
+        <Button variant="primary" size="md" onClick={save} disabled={!loaded || !encAvailable}>
+          Save
+        </Button>
+        {status && <span className="text-xs text-fg-secondary">{status}</span>}
+      </div>
     </>
   );
 }
 
 function DataPane() {
+  const [dataDir, setDataDir] = useState<string>('Loading…');
+  useEffect(() => {
+    window.agentory?.getDataDir().then(setDataDir).catch(() => setDataDir('(unavailable)'));
+  }, []);
   return (
     <>
       <Field label="Data directory" hint="Where Agentory stores groups, sessions, and preferences.">
-        <code className="block px-2 py-1.5 rounded-sm bg-bg-elevated border border-border-subtle text-xs text-fg-secondary font-mono">
-          {'~/.agentory-next/'}
+        <code className="block px-2 py-1.5 rounded-sm bg-bg-elevated border border-border-subtle text-xs text-fg-secondary font-mono break-all">
+          {dataDir}
         </code>
       </Field>
       <Field label="Claude sessions directory" hint="Read-only. Managed by Claude Code SDK.">
@@ -200,12 +246,18 @@ function ShortcutsPane() {
 }
 
 function UpdatesPane() {
+  const [version, setVersion] = useState<string>('…');
+  useEffect(() => {
+    window.agentory?.getVersion().then(setVersion).catch(() => setVersion('unknown'));
+  }, []);
   return (
     <>
       <Field label="Version">
-        <span className="text-sm text-fg-secondary font-mono">0.0.1</span>
+        <span className="text-sm text-fg-secondary font-mono">{version}</span>
       </Field>
-      <Button variant="secondary" size="md">Check for updates</Button>
+      <Button variant="secondary" size="md" disabled title="Auto-update not yet wired">
+        Check for updates
+      </Button>
     </>
   );
 }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -3,6 +3,11 @@ declare global {
     agentory?: {
       loadState: (key: string) => Promise<string | null>;
       saveState: (key: string, value: string) => Promise<void>;
+      getDataDir: () => Promise<string>;
+      getVersion: () => Promise<string>;
+      getApiKey: () => Promise<string>;
+      setApiKey: (value: string) => Promise<boolean>;
+      hasEncryption: () => Promise<boolean>;
     };
   }
 }

--- a/src/stores/persist.ts
+++ b/src/stores/persist.ts
@@ -1,5 +1,5 @@
 import type { Group, Session } from '../types';
-import type { ModelId, PermissionMode } from './store';
+import type { ModelId, PermissionMode, Theme, FontSize } from './store';
 
 export const STATE_KEY = 'main';
 
@@ -11,6 +11,8 @@ export interface PersistedState {
   model: ModelId;
   permission: PermissionMode;
   sidebarCollapsed: boolean;
+  theme?: Theme;
+  fontSize?: FontSize;
 }
 
 export async function loadPersisted(): Promise<PersistedState | null> {

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -11,6 +11,8 @@ import { loadPersisted, schedulePersist, type PersistedState } from './persist';
 
 export type ModelId = 'claude-opus-4' | 'claude-sonnet-4' | 'claude-haiku-4';
 export type PermissionMode = 'auto' | 'ask' | 'plan';
+export type Theme = 'system' | 'light' | 'dark';
+export type FontSize = 'sm' | 'md' | 'lg';
 
 type State = {
   sessions: Session[];
@@ -21,6 +23,8 @@ type State = {
   model: ModelId;
   permission: PermissionMode;
   sidebarCollapsed: boolean;
+  theme: Theme;
+  fontSize: FontSize;
 };
 
 type Actions = {
@@ -35,6 +39,8 @@ type Actions = {
   setPermission: (mode: PermissionMode) => void;
   setSidebarCollapsed: (collapsed: boolean) => void;
   toggleSidebar: () => void;
+  setTheme: (theme: Theme) => void;
+  setFontSize: (size: FontSize) => void;
 
   createGroup: (name?: string) => string;
   renameGroup: (id: string, name: string) => void;
@@ -62,6 +68,8 @@ export const useStore = create<State & Actions>((set, get) => ({
   model: 'claude-opus-4',
   permission: 'auto',
   sidebarCollapsed: false,
+  theme: 'system',
+  fontSize: 'md',
 
   selectSession: (id) => {
     set((s) => ({
@@ -160,6 +168,8 @@ export const useStore = create<State & Actions>((set, get) => ({
   setPermission: (permission) => set({ permission }),
   setSidebarCollapsed: (collapsed) => set({ sidebarCollapsed: collapsed }),
   toggleSidebar: () => set((s) => ({ sidebarCollapsed: !s.sidebarCollapsed })),
+  setTheme: (theme) => set({ theme }),
+  setFontSize: (fontSize) => set({ fontSize }),
 
   createGroup: (name) => {
     const id = nextId('g');
@@ -228,7 +238,9 @@ export async function hydrateStore(): Promise<void> {
       activeId: stillActive ? persisted.activeId : persisted.sessions[0]?.id ?? '',
       model: persisted.model,
       permission: persisted.permission,
-      sidebarCollapsed: persisted.sidebarCollapsed ?? false
+      sidebarCollapsed: persisted.sidebarCollapsed ?? false,
+      theme: persisted.theme ?? 'system',
+      fontSize: persisted.fontSize ?? 'md'
     });
   }
   hydrated = true;
@@ -241,7 +253,9 @@ export async function hydrateStore(): Promise<void> {
       activeId: s.activeId,
       model: s.model,
       permission: s.permission,
-      sidebarCollapsed: s.sidebarCollapsed
+      sidebarCollapsed: s.sidebarCollapsed,
+      theme: s.theme,
+      fontSize: s.fontSize
     };
     schedulePersist(snapshot);
   });


### PR DESCRIPTION
## Summary
- General pane: theme + fontSize wired to Zustand, persisted via SQLite blob; App.tsx applies dark class & font-size CSS var, watches system color scheme
- Account pane: Anthropic API key via Electron safeStorage; new IPC channels keychain:get/setApiKey/hasEncryption; graceful disabled state when OS encryption unavailable
- Data pane: real userData path via new app:getDataDir IPC
- Updates pane: real app version via new app:getVersion IPC; Check-for-updates button disabled until electron-updater lands

## Test plan
- [ ] Open Settings → General → switch theme/fontSize → close/reopen app, value persists
- [ ] Account → paste key → Save → reopen, key still loaded
- [ ] Data → shows real userData path
- [ ] Updates → shows package.json version

🤖 Generated with [Claude Code](https://claude.com/claude-code)