### PR TITLE
PR #9: Toast on persist failure

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -96,7 +96,7 @@
 | 项 | 状态 | 备注 |
 |---|---|---|
 | ToastProvider 已挂 | ✅ | |
-| 实际触发：状态变化 / SDK 错误 / API key 缺失 | ⬜ | 没有任何代码实际 fire toast。 |
+| 实际触发：状态变化 / SDK 错误 / API key 缺失 | 🟡 | persist 写盘失败已接 toast（5s 节流防 spam）；状态变化 / SDK 错误等真实场景不存在数据源前不接，避免无意义 toast。 |
 
 ## 9. 数据持久化（mvp-design.md §10）
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo } from 'react';
 import { TooltipProvider } from './components/ui/Tooltip';
-import { ToastProvider } from './components/ui/Toast';
+import { ToastProvider, useToast } from './components/ui/Toast';
 import { Sidebar } from './components/Sidebar';
 import { ChatStream } from './components/ChatStream';
 import { InputBar } from './components/InputBar';
@@ -8,6 +8,7 @@ import { StatusBar } from './components/StatusBar';
 import { SettingsDialog } from './components/SettingsDialog';
 import { CommandPalette } from './components/CommandPalette';
 import { useStore } from './stores/store';
+import { setPersistErrorHandler } from './stores/persist';
 
 export default function App() {
   const sessions = useStore((s) => s.sessions);
@@ -86,6 +87,7 @@ export default function App() {
   return (
     <TooltipProvider delayDuration={400} skipDelayDuration={100}>
       <ToastProvider>
+        <PersistErrorBridge />
         <div className="flex h-full w-full bg-bg-app text-fg-primary">
           <Sidebar
             onCreateSession={(cwd) => createSession(cwd)}
@@ -127,4 +129,23 @@ export default function App() {
       </ToastProvider>
     </TooltipProvider>
   );
+}
+
+function PersistErrorBridge() {
+  const { push } = useToast();
+  useEffect(() => {
+    let lastShown = 0;
+    setPersistErrorHandler(() => {
+      const now = Date.now();
+      if (now - lastShown < 5000) return;
+      lastShown = now;
+      push({
+        kind: 'error',
+        title: 'Failed to save state',
+        body: 'Your recent changes may not survive restart. Check disk space.'
+      });
+    });
+    return () => setPersistErrorHandler(() => {});
+  }, [push]);
+  return null;
 }

--- a/src/stores/persist.ts
+++ b/src/stores/persist.ts
@@ -31,11 +31,19 @@ export async function loadPersisted(): Promise<PersistedState | null> {
 let writeTimer: ReturnType<typeof setTimeout> | null = null;
 const WRITE_DEBOUNCE_MS = 250;
 
+let onPersistError: ((err: unknown) => void) | null = null;
+
+export function setPersistErrorHandler(handler: (err: unknown) => void): void {
+  onPersistError = handler;
+}
+
 export function schedulePersist(state: PersistedState): void {
   if (!window.agentory) return;
   if (writeTimer) clearTimeout(writeTimer);
   writeTimer = setTimeout(() => {
     writeTimer = null;
-    window.agentory!.saveState(STATE_KEY, JSON.stringify(state)).catch(() => {});
+    window.agentory!.saveState(STATE_KEY, JSON.stringify(state)).catch((err) => {
+      if (onPersistError) onPersistError(err);
+    });
   }, WRITE_DEBOUNCE_MS);
 }


### PR DESCRIPTION
## Summary
- persist.ts: was silently swallowing SQLite write failures (data loss with no signal). Now exposes setPersistErrorHandler.
- App wires a PersistErrorBridge inside ToastProvider that shows a red toast on save failure, throttled to 5s.
- Other toast triggers deferred — no SDK / state-change / API-key data sources exist yet, would just be noise.

## Test plan
- [ ] Simulate SQLite failure (e.g. close DB mid-session) → red toast appears
- [ ] Repeated failures collapse to ≤1 toast per 5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)