### PR TITLE
PR #11: ChatStream wired to live session message stream

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Implementation Status
 
-最后更新：2026-04-21 (PR #10)
+最后更新：2026-04-21 (PR #11)
 
 这是 agentory-next 当前实现进度的对账表。每个 PR 合并后必须更新本文件，让"已实现 vs 待实现"始终一目了然。
 
@@ -52,7 +52,7 @@
 
 | 项 | 状态 | 备注 |
 |---|---|---|
-| Block 渲染（user / assistant / tool / waiting / error） | 🟡 | 渲染规则齐全；数据来自 `mockMessages`，与 active session 无关联。 |
+| Block 渲染（user / assistant / tool / waiting / error） | ✅ | 渲染规则齐全；数据来自 store `messagesBySession[activeId]`，由 `src/agent/lifecycle.ts` 订阅 `agent:event`/`agent:exit` 经 `sdk-to-blocks.ts` 翻译写入。waiting 暂未真接（permission flow 后续 PR）。 |
 | Tool 调用折叠/展开 | ✅ | framer-motion chevron 旋转 + 内容展开。 |
 | Waiting block Allow/Deny 按钮 | 🟡 | 按钮+焦点管理完整；按下后无效果（无 SDK）。 |
 | 自动滚动到底 + "↓ Jump to latest" | ⬜ | mvp-design.md §7 Q4。 |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,9 @@ import { SettingsDialog } from './components/SettingsDialog';
 import { CommandPalette } from './components/CommandPalette';
 import { useStore } from './stores/store';
 import { setPersistErrorHandler } from './stores/persist';
+import { subscribeAgentEvents } from './agent/lifecycle';
+
+subscribeAgentEvents();
 
 export default function App() {
   const sessions = useStore((s) => s.sessions);

--- a/src/agent/lifecycle.ts
+++ b/src/agent/lifecycle.ts
@@ -1,0 +1,23 @@
+import { useStore } from '../stores/store';
+import { sdkMessageToBlocks } from './sdk-to-blocks';
+
+let installed = false;
+
+export function subscribeAgentEvents(): void {
+  if (installed) return;
+  const api = window.agentory;
+  if (!api) return;
+  installed = true;
+
+  api.onAgentEvent((e) => {
+    const blocks = sdkMessageToBlocks(e.message);
+    if (blocks.length > 0) useStore.getState().appendBlocks(e.sessionId, blocks);
+  });
+
+  api.onAgentExit((e) => {
+    if (!e.error) return;
+    useStore.getState().appendBlocks(e.sessionId, [
+      { kind: 'error', id: `exit-${Date.now().toString(36)}`, text: e.error }
+    ]);
+  });
+}

--- a/src/agent/sdk-to-blocks.ts
+++ b/src/agent/sdk-to-blocks.ts
@@ -1,0 +1,103 @@
+import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
+import type { MessageBlock } from '../types';
+
+// Translate one SDK message into zero or more MessageBlocks for ChatStream.
+// Tool calls become collapsed `tool` blocks (result wired up later when the
+// matching tool_result user message arrives — for MVP we keep tool + result
+// in separate blocks rather than reconciling, which keeps this fn pure).
+export function sdkMessageToBlocks(msg: SDKMessage): MessageBlock[] {
+  switch (msg.type) {
+    case 'assistant':
+      return assistantBlocks(msg);
+    case 'user':
+      return userBlocks(msg);
+    case 'system':
+      // SDK system messages (init, compact_boundary, api_retry, …) carry no
+      // user-visible chat content; surfacing them as chat blocks would be noise.
+      return [];
+    case 'result':
+      return resultBlocks(msg);
+    default:
+      return [];
+  }
+}
+
+type AnyContent =
+  | { type: 'text'; text: string }
+  | { type: 'tool_use'; id: string; name: string; input: unknown }
+  | { type: 'tool_result'; tool_use_id: string; content: unknown; is_error?: boolean }
+  | { type: string; [k: string]: unknown };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function assistantBlocks(msg: any): MessageBlock[] {
+  const out: MessageBlock[] = [];
+  const baseId = msg.uuid ?? msg.message?.id ?? cryptoRandom();
+  const content: AnyContent[] = msg.message?.content ?? [];
+  let textIdx = 0;
+  let toolIdx = 0;
+  for (const c of content) {
+    if (c.type === 'text' && typeof (c as { text: string }).text === 'string') {
+      out.push({ kind: 'assistant', id: `${baseId}:t${textIdx++}`, text: (c as { text: string }).text });
+    } else if (c.type === 'tool_use') {
+      const tu = c as { id: string; name: string; input: unknown };
+      out.push({
+        kind: 'tool',
+        id: `${baseId}:tu${toolIdx++}`,
+        name: tu.name,
+        brief: briefForTool(tu.name, tu.input),
+        expanded: false
+      });
+    }
+  }
+  return out;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function userBlocks(msg: any): MessageBlock[] {
+  // User messages can be plain text (from us) or tool_result echoes (from SDK).
+  // Tool-result echoes don't render as separate user turns — the tool block
+  // carries the result. Plain text becomes a `user` block.
+  const baseId = msg.uuid ?? cryptoRandom();
+  const content = msg.message?.content;
+  if (typeof content === 'string') {
+    return [{ kind: 'user', id: baseId, text: content }];
+  }
+  if (Array.isArray(content)) {
+    const texts: string[] = [];
+    for (const c of content as AnyContent[]) {
+      if (c.type === 'text' && typeof (c as { text: string }).text === 'string') {
+        texts.push((c as { text: string }).text);
+      }
+    }
+    if (texts.length === 0) return [];
+    return [{ kind: 'user', id: baseId, text: texts.join('\n') }];
+  }
+  return [];
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function resultBlocks(msg: any): MessageBlock[] {
+  if (msg.subtype === 'success' || msg.is_error === false) return [];
+  const text = typeof msg.error === 'string' ? msg.error : msg.subtype ?? 'Run failed';
+  return [{ kind: 'error', id: msg.uuid ?? cryptoRandom(), text }];
+}
+
+function briefForTool(name: string, input: unknown): string {
+  if (!input || typeof input !== 'object') return '';
+  const i = input as Record<string, unknown>;
+  // Cheap-but-useful summary per common tool. Truncate hard.
+  const pick = (...keys: string[]): string => {
+    for (const k of keys) {
+      const v = i[k];
+      if (typeof v === 'string') return v;
+    }
+    return '';
+  };
+  const v =
+    pick('file_path', 'path', 'pattern', 'command', 'query', 'url', 'description') || JSON.stringify(input);
+  return v.length > 80 ? v.slice(0, 77) + '…' : v;
+}
+
+function cryptoRandom(): string {
+  return Math.random().toString(36).slice(2, 10);
+}

--- a/src/components/ChatStream.tsx
+++ b/src/components/ChatStream.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { ChevronRight, AlertCircle } from 'lucide-react';
-import { mockMessages } from '../mock/data';
 import type { MessageBlock } from '../types';
+import { useStore } from '../stores/store';
 import { Button } from './ui/Button';
 import { StateGlyph } from './ui/StateGlyph';
 
@@ -161,10 +161,11 @@ function renderBlock(b: MessageBlock) {
 }
 
 export function ChatStream() {
+  const blocks = useStore((s) => s.messagesBySession[s.activeId] ?? []);
   return (
     <div className="flex-1 overflow-y-auto min-w-0">
       <div className="px-4 py-3 flex flex-col gap-1.5 max-w-[1100px]">
-        {mockMessages.map((m) => (
+        {blocks.map((m) => (
           <div key={m.id}>{renderBlock(m)}</div>
         ))}
       </div>

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -6,7 +6,7 @@ import {
   activeSessionId as initialActiveId,
   type RecentProject
 } from '../mock/data';
-import type { Group, Session } from '../types';
+import type { Group, Session, MessageBlock } from '../types';
 import { loadPersisted, schedulePersist, type PersistedState } from './persist';
 
 export type ModelId = 'claude-opus-4' | 'claude-sonnet-4' | 'claude-haiku-4';
@@ -25,6 +25,7 @@ type State = {
   sidebarCollapsed: boolean;
   theme: Theme;
   fontSize: FontSize;
+  messagesBySession: Record<string, MessageBlock[]>;
 };
 
 type Actions = {
@@ -48,6 +49,9 @@ type Actions = {
   archiveGroup: (id: string) => void;
   unarchiveGroup: (id: string) => void;
   setGroupCollapsed: (id: string, collapsed: boolean) => void;
+
+  appendBlocks: (sessionId: string, blocks: MessageBlock[]) => void;
+  clearMessages: (sessionId: string) => void;
 };
 
 function nextId(prefix: string): string {
@@ -70,6 +74,7 @@ export const useStore = create<State & Actions>((set, get) => ({
   sidebarCollapsed: false,
   theme: 'system',
   fontSize: 'md',
+  messagesBySession: {},
 
   selectSession: (id) => {
     set((s) => ({
@@ -124,7 +129,9 @@ export const useStore = create<State & Actions>((set, get) => ({
       const remaining = s.sessions.filter((x) => x.id !== id);
       const nextActive =
         s.activeId === id ? remaining[0]?.id ?? '' : s.activeId;
-      return { sessions: remaining, activeId: nextActive };
+      const nextMessages = { ...s.messagesBySession };
+      delete nextMessages[id];
+      return { sessions: remaining, activeId: nextActive, messagesBySession: nextMessages };
     });
   },
 
@@ -222,6 +229,25 @@ export const useStore = create<State & Actions>((set, get) => ({
     set((s) => ({
       groups: s.groups.map((g) => (g.id === id ? { ...g, collapsed } : g))
     }));
+  },
+
+  appendBlocks: (sessionId, blocks) => {
+    if (blocks.length === 0) return;
+    set((s) => {
+      const prev = s.messagesBySession[sessionId] ?? [];
+      return {
+        messagesBySession: { ...s.messagesBySession, [sessionId]: [...prev, ...blocks] }
+      };
+    });
+  },
+
+  clearMessages: (sessionId) => {
+    set((s) => {
+      if (!(sessionId in s.messagesBySession)) return s;
+      const next = { ...s.messagesBySession };
+      delete next[sessionId];
+      return { messagesBySession: next };
+    });
   }
 }));
 


### PR DESCRIPTION
## Summary
- Pure translator `src/agent/sdk-to-blocks.ts`: SDKMessage → MessageBlock[]
- `src/agent/lifecycle.ts`: subscribes `agent:event` / `agent:exit` once, routes into store
- Store: `messagesBySession` + `appendBlocks` + `clearMessages`; `deleteSession` drops transcript
- ChatStream reads from store instead of `mockMessages`

Send/start lifecycle deferred to PR #12. Transcript persistence deferred to PR #13.

## Test plan
- [ ] `npm run typecheck` clean
- [ ] App boots, no console errors
- [ ] After PR #12 lands: send a message, see assistant + tool blocks stream in

🤖 Generated with [Claude Code](https://claude.com/claude-code)