### PR TITLE
PR #12: InputBar wired to agent send / interrupt + running state

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Implementation Status
 
-最后更新：2026-04-21 (PR #11)
+最后更新：2026-04-21 (PR #12)
 
 这是 agentory-next 当前实现进度的对账表。每个 PR 合并后必须更新本文件，让"已实现 vs 待实现"始终一目了然。
 
@@ -62,8 +62,8 @@
 
 | 项 | 状态 | 备注 |
 |---|---|---|
-| 多行 textarea + Enter 发送 / Shift+Enter 换行 | 🟡 | 输入捕获 + 空白校验通；发送行为是 console.log 或 stub。 |
-| Running 时禁用 + Stop 按钮 | ⬜ | 没有 running 状态来源。 |
+| 多行 textarea + Enter 发送 / Shift+Enter 换行 | ✅ | 输入捕获 + 空白校验 + IME 守护；首次发送会 lazy `agent:start`（带当前 cwd/model/permission），后续走 `agent:send`。本地 echo user block，SDK 的 user echo 在翻译层跳过避免重复。 |
+| Running 时禁用 + Stop 按钮 | ✅ | `runningSessions` 在 store；turn 期间 textarea disable + Send 换 Stop（点击调 `agent:interrupt`）；`result` SDK 消息或 `agent:exit` 会清 running。 |
 
 ## 5. StatusBar（`src/components/StatusBar.tsx`）
 

--- a/src/agent/lifecycle.ts
+++ b/src/agent/lifecycle.ts
@@ -11,12 +11,20 @@ export function subscribeAgentEvents(): void {
 
   api.onAgentEvent((e) => {
     const blocks = sdkMessageToBlocks(e.message);
-    if (blocks.length > 0) useStore.getState().appendBlocks(e.sessionId, blocks);
+    const store = useStore.getState();
+    if (blocks.length > 0) store.appendBlocks(e.sessionId, blocks);
+    // Result message means the SDK turn is complete — clear the running flag
+    // so InputBar re-enables. Any other message means a turn is in flight.
+    if (e.message.type === 'result') {
+      store.setRunning(e.sessionId, false);
+    }
   });
 
   api.onAgentExit((e) => {
+    const store = useStore.getState();
+    store.setRunning(e.sessionId, false);
     if (!e.error) return;
-    useStore.getState().appendBlocks(e.sessionId, [
+    store.appendBlocks(e.sessionId, [
       { kind: 'error', id: `exit-${Date.now().toString(36)}`, text: e.error }
     ]);
   });

--- a/src/agent/permission.ts
+++ b/src/agent/permission.ts
@@ -1,0 +1,13 @@
+import type { PermissionMode as SDKPermissionMode } from '@anthropic-ai/claude-agent-sdk';
+import type { PermissionMode } from '../stores/store';
+
+export function toSdkPermissionMode(mode: PermissionMode): SDKPermissionMode {
+  switch (mode) {
+    case 'auto':
+      return 'acceptEdits';
+    case 'ask':
+      return 'default';
+    case 'plan':
+      return 'plan';
+  }
+}

--- a/src/agent/sdk-to-blocks.ts
+++ b/src/agent/sdk-to-blocks.ts
@@ -10,7 +10,12 @@ export function sdkMessageToBlocks(msg: SDKMessage): MessageBlock[] {
     case 'assistant':
       return assistantBlocks(msg);
     case 'user':
-      return userBlocks(msg);
+      // We render the user's outgoing text locally in InputBar for zero-latency
+      // echo. The SDK echoes the same text back as a user message — skip it to
+      // avoid duplicates. Tool_result echoes also live in user messages but
+      // those don't render as separate turns either (the tool block carries
+      // the result).
+      return [];
     case 'system':
       // SDK system messages (init, compact_boundary, api_retry, …) carry no
       // user-visible chat content; surfacing them as chat blocks would be noise.
@@ -50,29 +55,6 @@ function assistantBlocks(msg: any): MessageBlock[] {
     }
   }
   return out;
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function userBlocks(msg: any): MessageBlock[] {
-  // User messages can be plain text (from us) or tool_result echoes (from SDK).
-  // Tool-result echoes don't render as separate user turns — the tool block
-  // carries the result. Plain text becomes a `user` block.
-  const baseId = msg.uuid ?? cryptoRandom();
-  const content = msg.message?.content;
-  if (typeof content === 'string') {
-    return [{ kind: 'user', id: baseId, text: content }];
-  }
-  if (Array.isArray(content)) {
-    const texts: string[] = [];
-    for (const c of content as AnyContent[]) {
-      if (c.type === 'text' && typeof (c as { text: string }).text === 'string') {
-        texts.push((c as { text: string }).text);
-      }
-    }
-    if (texts.length === 0) return [];
-    return [{ kind: 'user', id: baseId, text: texts.join('\n') }];
-  }
-  return [];
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -1,19 +1,30 @@
 import React, { useState } from 'react';
-import { ArrowUp } from 'lucide-react';
+import { ArrowUp, Square } from 'lucide-react';
 import { cn } from '../lib/cn';
 import { Button } from './ui/Button';
+import { useStore } from '../stores/store';
+import { toSdkPermissionMode } from '../agent/permission';
 
 // Per-session draft cache. Survives session switches within a process so
 // users don't lose half-typed prompts when they pop into another session.
 // Cleared on send. Not persisted to disk by design — drafts are ephemeral.
 const draftCache = new Map<string, string>();
 
+function nextLocalId(): string {
+  return `u-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
 export function InputBar({ sessionId }: { sessionId: string }) {
   const [value, setValue] = useState(() => draftCache.get(sessionId) ?? '');
+  const session = useStore((s) => s.sessions.find((x) => x.id === sessionId));
+  const started = useStore((s) => !!s.startedSessions[sessionId]);
+  const running = useStore((s) => !!s.runningSessions[sessionId]);
+  const permission = useStore((s) => s.permission);
+  const model = useStore((s) => s.model);
+  const appendBlocks = useStore((s) => s.appendBlocks);
+  const markStarted = useStore((s) => s.markStarted);
+  const setRunning = useStore((s) => s.setRunning);
 
-  // When sessionId changes, swap the visible draft to that session's cached
-  // value. We persist the previous session's draft into the cache via the
-  // setter below — onChange writes both state and cache in one step.
   React.useEffect(() => {
     setValue(draftCache.get(sessionId) ?? '');
   }, [sessionId]);
@@ -24,9 +35,49 @@ export function InputBar({ sessionId }: { sessionId: string }) {
     else draftCache.delete(sessionId);
   }
 
-  function send() {
-    if (!value.trim()) return;
+  async function send() {
+    const text = value.trim();
+    if (!text || running) return;
+    const api = window.agentory;
+    if (!api || !session) return;
+
+    // Local echo: render the user's turn immediately. We skip the SDK's
+    // own user-message echo in sdk-to-blocks to avoid duplicates.
+    appendBlocks(sessionId, [{ kind: 'user', id: nextLocalId(), text }]);
     update('');
+    setRunning(sessionId, true);
+
+    if (!started) {
+      const res = await api.agentStart(sessionId, {
+        cwd: session.cwd,
+        model,
+        permissionMode: toSdkPermissionMode(permission)
+      });
+      if (!res.ok) {
+        setRunning(sessionId, false);
+        appendBlocks(sessionId, [
+          { kind: 'error', id: `start-${Date.now().toString(36)}`, text: res.error }
+        ]);
+        return;
+      }
+      markStarted(sessionId);
+    }
+
+    const ok = await api.agentSend(sessionId, text);
+    if (!ok) {
+      setRunning(sessionId, false);
+      appendBlocks(sessionId, [
+        { kind: 'error', id: `send-${Date.now().toString(36)}`, text: 'Failed to deliver message to agent.' }
+      ]);
+    }
+  }
+
+  async function stop() {
+    if (!running) return;
+    const api = window.agentory;
+    if (!api) return;
+    await api.agentInterrupt(sessionId);
+    // running flag is cleared when the SDK emits its result message.
   }
 
   function onKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
@@ -48,8 +99,6 @@ export function InputBar({ sessionId }: { sessionId: string }) {
           '[transition-timing-function:cubic-bezier(0.32,0.72,0,1)]',
           'border-border-default',
           'focus-within:border-border-strong',
-          // Apple-blue focus halo (no inner dark inset — that fought the
-          // top-edge highlight). Alpha lifted to 0.30 for visibility.
           'focus-within:shadow-[inset_0_1px_0_0_oklch(1_0_0_/_0.04),0_0_0_3px_oklch(0.72_0.14_215_/_0.30)]'
         )}
       >
@@ -58,25 +107,39 @@ export function InputBar({ sessionId }: { sessionId: string }) {
           onChange={(e) => update(e.target.value)}
           onKeyDown={onKeyDown}
           rows={2}
-          placeholder="Reply…"
+          placeholder={running ? 'Running… (input disabled)' : 'Reply…'}
+          disabled={running}
           className={cn(
             'block w-full resize-none px-3 pt-2 pb-7 text-base leading-[22px]',
             'bg-transparent text-fg-primary placeholder:text-fg-tertiary',
-            'transition-colors duration-150 ease-out'
+            'transition-colors duration-150 ease-out',
+            running && 'cursor-not-allowed opacity-60'
           )}
           style={{ minHeight: 64, maxHeight: 240 }}
         />
         <div className="absolute right-3 bottom-1.5">
-          <Button
-            variant="primary"
-            size="sm"
-            aria-label="Send message"
-            disabled={!value.trim()}
-            onClick={send}
-          >
-            <ArrowUp size={10} className="stroke-[2.25]" />
-            <span>Send</span>
-          </Button>
+          {running ? (
+            <Button
+              variant="secondary"
+              size="sm"
+              aria-label="Stop"
+              onClick={stop}
+            >
+              <Square size={10} className="stroke-[2.25]" />
+              <span>Stop</span>
+            </Button>
+          ) : (
+            <Button
+              variant="primary"
+              size="sm"
+              aria-label="Send message"
+              disabled={!value.trim()}
+              onClick={send}
+            >
+              <ArrowUp size={10} className="stroke-[2.25]" />
+              <span>Send</span>
+            </Button>
+          )}
         </div>
       </div>
     </div>

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -26,6 +26,8 @@ type State = {
   theme: Theme;
   fontSize: FontSize;
   messagesBySession: Record<string, MessageBlock[]>;
+  startedSessions: Record<string, true>;
+  runningSessions: Record<string, true>;
 };
 
 type Actions = {
@@ -52,6 +54,8 @@ type Actions = {
 
   appendBlocks: (sessionId: string, blocks: MessageBlock[]) => void;
   clearMessages: (sessionId: string) => void;
+  markStarted: (sessionId: string) => void;
+  setRunning: (sessionId: string, running: boolean) => void;
 };
 
 function nextId(prefix: string): string {
@@ -75,6 +79,8 @@ export const useStore = create<State & Actions>((set, get) => ({
   theme: 'system',
   fontSize: 'md',
   messagesBySession: {},
+  startedSessions: {},
+  runningSessions: {},
 
   selectSession: (id) => {
     set((s) => ({
@@ -131,7 +137,17 @@ export const useStore = create<State & Actions>((set, get) => ({
         s.activeId === id ? remaining[0]?.id ?? '' : s.activeId;
       const nextMessages = { ...s.messagesBySession };
       delete nextMessages[id];
-      return { sessions: remaining, activeId: nextActive, messagesBySession: nextMessages };
+      const nextStarted = { ...s.startedSessions };
+      delete nextStarted[id];
+      const nextRunning = { ...s.runningSessions };
+      delete nextRunning[id];
+      return {
+        sessions: remaining,
+        activeId: nextActive,
+        messagesBySession: nextMessages,
+        startedSessions: nextStarted,
+        runningSessions: nextRunning
+      };
     });
   },
 
@@ -247,6 +263,25 @@ export const useStore = create<State & Actions>((set, get) => ({
       const next = { ...s.messagesBySession };
       delete next[sessionId];
       return { messagesBySession: next };
+    });
+  },
+
+  markStarted: (sessionId) => {
+    set((s) =>
+      s.startedSessions[sessionId]
+        ? s
+        : { startedSessions: { ...s.startedSessions, [sessionId]: true } }
+    );
+  },
+
+  setRunning: (sessionId, running) => {
+    set((s) => {
+      const has = !!s.runningSessions[sessionId];
+      if (has === running) return s;
+      const next = { ...s.runningSessions };
+      if (running) next[sessionId] = true;
+      else delete next[sessionId];
+      return { runningSessions: next };
     });
   }
 }));


### PR DESCRIPTION
## Summary
- Lazy `agent:start` on first send per session, then `agent:send` for follow-ups
- Local echo of user turn (zero latency); SDK user echo skipped in translator
- `runningSessions` in store; textarea disabled + Send→Stop while a turn is in flight
- Stop calls `agent:interrupt`; running clears on SDK `result` or `agent:exit`
- Permission mode mapping helper (app `auto/ask/plan` → SDK `acceptEdits/default/plan`)

After this PR you can actually open a session, type a message, and watch Claude respond with assistant text + tool calls.

## Test plan
- [ ] `npm run typecheck` clean
- [ ] Set API key in Settings → Account
- [ ] Type message, hit Enter → user turn echoes immediately, agent reply streams in
- [ ] During reply: textarea disabled, Stop button visible
- [ ] Click Stop mid-stream → reply ends, input re-enables
- [ ] Switch sessions mid-run → other session not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)