### PR TITLE
hotfix: ESM lazy-load + ChatStream infinite rerender

### DIFF
--- a/electron/agent/manager.ts
+++ b/electron/agent/manager.ts
@@ -15,7 +15,7 @@ class SessionsManager {
     };
   }
 
-  start(sessionId: string, opts: StartOptions): { ok: true } | { ok: false; error: string } {
+  async start(sessionId: string, opts: StartOptions): Promise<{ ok: true } | { ok: false; error: string }> {
     if (this.runners.has(sessionId)) return { ok: true };
     try {
       const runner = new SessionRunner(
@@ -26,7 +26,7 @@ class SessionsManager {
           this.runners.delete(sessionId);
         }
       );
-      runner.start(opts);
+      await runner.start(opts);
       this.runners.set(sessionId, runner);
       return { ok: true };
     } catch (err) {

--- a/electron/agent/sessions.ts
+++ b/electron/agent/sessions.ts
@@ -1,4 +1,14 @@
-import { query, type Options, type PermissionMode, type Query, type SDKMessage, type SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
+import type { Options, PermissionMode, Query, SDKMessage, SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
+
+// SDK ships ESM-only (sdk.mjs). Electron main bundle is CJS, so a static
+// `import { query }` triggers ERR_REQUIRE_ESM at load. Lazy-load via dynamic
+// import on first start() and cache the module reference.
+type SdkModule = typeof import('@anthropic-ai/claude-agent-sdk');
+let sdkPromise: Promise<SdkModule> | null = null;
+function loadSdk(): Promise<SdkModule> {
+  if (!sdkPromise) sdkPromise = import('@anthropic-ai/claude-agent-sdk');
+  return sdkPromise;
+}
 
 export type StartOptions = {
   cwd: string;
@@ -68,7 +78,7 @@ export class SessionRunner {
     private readonly onExit: ExitHandler
   ) {}
 
-  start(opts: StartOptions): void {
+  async start(opts: StartOptions): Promise<void> {
     if (this.q) return;
     const env: Record<string, string | undefined> = { ...process.env };
     if (opts.apiKey) env.ANTHROPIC_API_KEY = opts.apiKey;
@@ -81,6 +91,7 @@ export class SessionRunner {
       resume: opts.resumeSessionId
     };
 
+    const { query } = await loadSdk();
     this.q = query({ prompt: this.input, options });
 
     this.consumer = (async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "eslint-plugin-react": "^7.37.2",
         "eslint-plugin-react-hooks": "^5.1.0",
         "html-webpack-plugin": "^5.6.3",
+        "playwright": "^1.59.1",
         "postcss": "^8.4.49",
         "postcss-loader": "^8.1.1",
         "style-loader": "^4.0.0",
@@ -10536,6 +10537,53 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "eslint-plugin-react": "^7.37.2",
     "eslint-plugin-react-hooks": "^5.1.0",
     "html-webpack-plugin": "^5.6.3",
+    "playwright": "^1.59.1",
     "postcss": "^8.4.49",
     "postcss-loader": "^8.1.1",
     "style-loader": "^4.0.0",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,16 @@
+# Dev scripts
+
+## probe-render.mjs
+
+Runtime smoke test for the renderer. Launches headless chromium at `http://localhost:4100/`,
+dumps `#root` innerHTML and any console / page errors.
+
+Use after **any** renderer change to catch crashes that typecheck misses
+(e.g. unstable Zustand selectors causing infinite rerenders).
+
+```bash
+npm run dev          # in another terminal
+node scripts/probe-render.mjs
+```
+
+Pass = `#root` non-empty AND no `[error]` / `[pageerror]` lines.

--- a/scripts/probe-render.mjs
+++ b/scripts/probe-render.mjs
@@ -1,0 +1,25 @@
+import { chromium } from 'playwright';
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext();
+const page = await ctx.newPage();
+
+const logs = [];
+page.on('console', (m) => logs.push(`[${m.type()}] ${m.text()}`));
+page.on('pageerror', (e) => logs.push(`[pageerror] ${e.message}\n${e.stack ?? ''}`));
+page.on('requestfailed', (r) => logs.push(`[reqfail] ${r.url()} ${r.failure()?.errorText}`));
+
+await page.goto('http://localhost:4100/', { waitUntil: 'networkidle' });
+await page.waitForTimeout(1500);
+
+const rootHtml = await page.evaluate(() => {
+  const r = document.getElementById('root');
+  return r ? r.innerHTML.slice(0, 800) : '<NO #root>';
+});
+
+console.log('--- root innerHTML (first 800) ---');
+console.log(rootHtml);
+console.log('--- console / errors ---');
+for (const l of logs) console.log(l);
+
+await browser.close();

--- a/src/components/ChatStream.tsx
+++ b/src/components/ChatStream.tsx
@@ -160,8 +160,11 @@ function renderBlock(b: MessageBlock) {
   }
 }
 
+const EMPTY_BLOCKS: readonly MessageBlock[] = [];
+
 export function ChatStream() {
-  const blocks = useStore((s) => s.messagesBySession[s.activeId] ?? []);
+  const activeId = useStore((s) => s.activeId);
+  const blocks = useStore((s) => s.messagesBySession[activeId] ?? EMPTY_BLOCKS);
   return (
     <div className="flex-1 overflow-y-auto min-w-0">
       <div className="px-4 py-3 flex flex-col gap-1.5 max-w-[1100px]">


### PR DESCRIPTION
## Summary
- `electron/agent/sessions.ts`: SDK is ESM-only. Switch from static `import { query }` to dynamic `import()` cached at first `start()`. `start()` becomes async; `manager.ts` awaits.
- `src/components/ChatStream.tsx`: hoisted unstable `?? []` selector to a module-level `EMPTY_BLOCKS` constant. Inline `?? []` returned a new array each render -> Zustand infinite loop -> blank app.
- Added `scripts/probe-render.mjs` (playwright + chromium) so future renderer changes can be runtime-verified, not just typecheck-passed.

Both bugs were blocking dev verification of merged PRs #11/#12.

## Test plan
- [x] `npm run dev` boots without ERR_REQUIRE_ESM
- [x] `node scripts/probe-render.mjs` reports non-empty `#root`, no `[error]` / `[pageerror]`
- [ ] Manual: send a message in a session; assistant blocks stream into ChatStream

🤖 Generated with [Claude Code](https://claude.com/claude-code)