### PR TITLE
PR A: StatusBar cwd chip — real folder picker + persisted recent projects

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, Menu, ipcMain, safeStorage } from 'electron';
+import { app, BrowserWindow, Menu, ipcMain, safeStorage, dialog } from 'electron';
 import * as path from 'path';
 import * as fs from 'fs';
 import { initDb, loadState, saveState, closeDb } from './db';
@@ -84,6 +84,16 @@ app.whenReady().then(() => {
   ipcMain.handle('keychain:getApiKey', () => readApiKey());
   ipcMain.handle('keychain:setApiKey', (_e, value: string) => writeApiKey(value));
   ipcMain.handle('keychain:hasEncryption', () => safeStorage.isEncryptionAvailable());
+
+  ipcMain.handle('dialog:pickDirectory', async () => {
+    const win = BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0];
+    const res = await dialog.showOpenDialog(win, {
+      properties: ['openDirectory'],
+      title: 'Choose working directory'
+    });
+    if (res.canceled || res.filePaths.length === 0) return null;
+    return res.filePaths[0];
+  });
 
   ipcMain.handle(
     'agent:start',

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -22,6 +22,7 @@ const api = {
   getApiKey: (): Promise<string> => ipcRenderer.invoke('keychain:getApiKey'),
   setApiKey: (value: string): Promise<boolean> => ipcRenderer.invoke('keychain:setApiKey', value),
   hasEncryption: (): Promise<boolean> => ipcRenderer.invoke('keychain:hasEncryption'),
+  pickDirectory: (): Promise<string | null> => ipcRenderer.invoke('dialog:pickDirectory'),
 
   agentStart: (sessionId: string, opts: StartOpts): Promise<StartResult> =>
     ipcRenderer.invoke('agent:start', sessionId, opts),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ export default function App() {
   const moveSession = useStore((s) => s.moveSession);
   const createSession = useStore((s) => s.createSession);
   const changeCwd = useStore((s) => s.changeCwd);
+  const pushRecentProject = useStore((s) => s.pushRecentProject);
   const setModel = useStore((s) => s.setModel);
   const setPermission = useStore((s) => s.setPermission);
   const toggleSidebar = useStore((s) => s.toggleSidebar);
@@ -109,7 +110,15 @@ export default function App() {
               cwd={active.cwd}
               model={model}
               permission={permission}
-              onChangeCwd={(p) => p && changeCwd(p)}
+              onChangeCwd={async (p) => {
+                let next = p;
+                if (next === null) {
+                  next = (await window.agentory?.pickDirectory()) ?? null;
+                }
+                if (!next) return;
+                changeCwd(next);
+                pushRecentProject(next);
+              }}
               onChangeModel={setModel}
               onChangePermission={setPermission}
             />

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -9,7 +9,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger
 } from './ui/DropdownMenu';
-import { mockRecentProjects } from '../mock/data';
+import { useStore } from '../stores/store';
 
 type ModelId = 'claude-opus-4' | 'claude-sonnet-4' | 'claude-haiku-4';
 type PermissionMode = 'auto' | 'ask' | 'plan';
@@ -105,20 +105,6 @@ function ChipMenu<V extends string>({
 
 const BROWSE_FOLDER = '__browse__';
 
-const cwdOptions: ChipOption<string>[] = [
-  ...mockRecentProjects.map(
-    (p) =>
-      ({ kind: 'item', value: p.path, primary: p.name, secondary: p.path }) as ChipOption<string>
-  ),
-  { kind: 'separator' },
-  {
-    kind: 'item',
-    value: BROWSE_FOLDER,
-    primary: 'Browse folder…',
-    icon: <Folder size={12} className="stroke-[1.75] mr-2 text-fg-tertiary" />
-  }
-];
-
 const modelOptions: ChipOption<ModelId>[] = [
   { kind: 'item', value: 'claude-opus-4', primary: 'opus-4' },
   { kind: 'item', value: 'claude-sonnet-4', primary: 'sonnet-4' },
@@ -155,6 +141,22 @@ export function StatusBar({
   onChangeModel,
   onChangePermission
 }: StatusBarProps) {
+  const recentProjects = useStore((s) => s.recentProjects);
+  const cwdOptions: ChipOption<string>[] = [
+    ...recentProjects.map(
+      (p) =>
+        ({ kind: 'item', value: p.path, primary: p.name, secondary: p.path }) as ChipOption<string>
+    ),
+    ...(recentProjects.length > 0
+      ? ([{ kind: 'separator' }] as ChipOption<string>[])
+      : []),
+    {
+      kind: 'item',
+      value: BROWSE_FOLDER,
+      primary: 'Browse folder…',
+      icon: <Folder size={12} className="stroke-[1.75] mr-2 text-fg-tertiary" />
+    }
+  ];
   const chips: React.ReactNode[] = [
     <ChipMenu
       key="cwd"

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -21,6 +21,7 @@ declare global {
       getApiKey: () => Promise<string>;
       setApiKey: (value: string) => Promise<boolean>;
       hasEncryption: () => Promise<boolean>;
+      pickDirectory: () => Promise<string | null>;
 
       agentStart: (sessionId: string, opts: StartOpts) => Promise<StartResult>;
       agentSend: (sessionId: string, text: string) => Promise<boolean>;

--- a/src/stores/persist.ts
+++ b/src/stores/persist.ts
@@ -1,5 +1,6 @@
 import type { Group, Session } from '../types';
 import type { ModelId, PermissionMode, Theme, FontSize } from './store';
+import type { RecentProject } from '../mock/data';
 
 export const STATE_KEY = 'main';
 
@@ -13,6 +14,7 @@ export interface PersistedState {
   sidebarCollapsed: boolean;
   theme?: Theme;
   fontSize?: FontSize;
+  recentProjects?: RecentProject[];
 }
 
 export async function loadPersisted(): Promise<PersistedState | null> {

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -38,6 +38,7 @@ type Actions = {
   deleteSession: (id: string) => void;
   moveSession: (sessionId: string, targetGroupId: string, beforeSessionId: string | null) => void;
   changeCwd: (cwd: string) => void;
+  pushRecentProject: (path: string) => void;
   setModel: (model: ModelId) => void;
   setPermission: (mode: PermissionMode) => void;
   setSidebarCollapsed: (collapsed: boolean) => void;
@@ -187,6 +188,19 @@ export const useStore = create<State & Actions>((set, get) => ({
     }));
   },
 
+  pushRecentProject: (p) => {
+    set((s) => {
+      const path = p.replace(/[\\/]+$/, '');
+      if (!path) return s;
+      const segs = path.split(/[\\/]/).filter(Boolean);
+      const name = segs[segs.length - 1] ?? path;
+      const without = s.recentProjects.filter((r) => r.path !== path);
+      const id = `p-${Date.now().toString(36)}`;
+      const next = [{ id, name, path }, ...without].slice(0, 8);
+      return { recentProjects: next };
+    });
+  },
+
   setModel: (model) => set({ model }),
   setPermission: (permission) => set({ permission }),
   setSidebarCollapsed: (collapsed) => set({ sidebarCollapsed: collapsed }),
@@ -301,7 +315,8 @@ export async function hydrateStore(): Promise<void> {
       permission: persisted.permission,
       sidebarCollapsed: persisted.sidebarCollapsed ?? false,
       theme: persisted.theme ?? 'system',
-      fontSize: persisted.fontSize ?? 'md'
+      fontSize: persisted.fontSize ?? 'md',
+      recentProjects: persisted.recentProjects ?? mockRecentProjects
     });
   }
   hydrated = true;
@@ -316,7 +331,8 @@ export async function hydrateStore(): Promise<void> {
       permission: s.permission,
       sidebarCollapsed: s.sidebarCollapsed,
       theme: s.theme,
-      fontSize: s.fontSize
+      fontSize: s.fontSize,
+      recentProjects: s.recentProjects
     };
     schedulePersist(snapshot);
   });


### PR DESCRIPTION
## Summary
- Native folder picker via `dialog:pickDirectory` IPC
- `pushRecentProject` MRU action persisted in store (cap 8, dedup by path)
- StatusBar cwd menu reads from live store instead of mock seed

## Test plan
- [x] typecheck clean
- [x] probe-render shows app loads, no console errors
- [ ] manual: click cwd chip → Browse folder… → pick dir → appears in MRU