### PR TITLE
PR D: drop fake token counter footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -123,9 +123,8 @@ export default function App() {
               onChangePermission={setPermission}
             />
             <InputBar sessionId={active.id} />
-            <div className="px-4 pb-2 flex items-center justify-between font-mono text-xs text-fg-disabled select-none">
+            <div className="px-4 pb-2 font-mono text-xs text-fg-disabled select-none">
               <span>Enter send · Shift+Enter newline</span>
-              <span>12k / 200k tokens · 6% used</span>
             </div>
           </main>
         </div>


### PR DESCRIPTION
Removes hardcoded '12k / 200k tokens · 6% used' that had no data source. Real token tracking belongs to a future PR with SDK usage events.