### PR TITLE
PR B: drop mock seed + first-run empty state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,9 +82,48 @@ export default function App() {
 
   if (!active) {
     return (
-      <div className="flex h-full w-full items-center justify-center bg-bg-app text-fg-secondary">
-        No sessions
-      </div>
+      <TooltipProvider delayDuration={400} skipDelayDuration={100}>
+        <ToastProvider>
+          <PersistErrorBridge />
+          <div className="flex h-full w-full bg-bg-app text-fg-primary">
+            <Sidebar
+              onCreateSession={(cwd) => createSession(cwd)}
+              onOpenSettings={() => setSettingsOpen(true)}
+              onOpenPalette={() => setPaletteOpen(true)}
+              activeSessionId={activeId}
+              focusedGroupId={focusedGroupId}
+              onSelectSession={selectSession}
+              onFocusGroup={focusGroup}
+              sessions={sessions}
+              onMoveSession={moveSession}
+            />
+            <main className="flex-1 flex items-center justify-center my-2 mr-2 ml-0 rounded-lg bg-bg-panel border border-border-subtle surface-card">
+              <div className="flex flex-col items-center gap-3 text-center px-6">
+                <div className="font-mono text-sm text-fg-secondary">No sessions yet</div>
+                <div className="font-mono text-xs text-fg-tertiary max-w-[28ch]">
+                  Create a session to start a Claude Code agent in a working directory.
+                </div>
+                <button
+                  type="button"
+                  onClick={() => createSession(null)}
+                  className="mt-1 inline-flex items-center gap-1.5 h-7 px-3 rounded-sm font-mono text-xs text-fg-primary bg-bg-hover hover:bg-bg-active border border-border-subtle outline-none focus-visible:ring-1 focus-visible:ring-border-strong transition-colors duration-120 ease-out"
+                >
+                  + New session
+                </button>
+              </div>
+            </main>
+          </div>
+          <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} />
+          <CommandPalette
+            open={paletteOpen}
+            onOpenChange={setPaletteOpen}
+            onOpenSettings={() => setSettingsOpen(true)}
+            onNewSession={() => createSession(null)}
+            onSelectSession={selectSession}
+            onFocusGroup={focusGroup}
+          />
+        </ToastProvider>
+      </TooltipProvider>
     );
   }
 

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -1,11 +1,5 @@
 import { create } from 'zustand';
-import {
-  mockGroups,
-  mockSessions,
-  mockRecentProjects,
-  activeSessionId as initialActiveId,
-  type RecentProject
-} from '../mock/data';
+import type { RecentProject } from '../mock/data';
 import type { Group, Session, MessageBlock } from '../types';
 import { loadPersisted, schedulePersist, type PersistedState } from './persist';
 
@@ -68,11 +62,15 @@ function firstUsableGroupId(groups: Group[]): string {
   return g ? g.id : groups[0]?.id ?? 'g1';
 }
 
+const defaultGroups: Group[] = [
+  { id: 'g-default', name: 'Sessions', collapsed: false, kind: 'normal' }
+];
+
 export const useStore = create<State & Actions>((set, get) => ({
-  sessions: mockSessions.map((s) => ({ ...s })),
-  groups: mockGroups.map((g) => ({ ...g })),
-  recentProjects: mockRecentProjects,
-  activeId: initialActiveId,
+  sessions: [],
+  groups: defaultGroups,
+  recentProjects: [],
+  activeId: '',
   focusedGroupId: null,
   model: 'claude-opus-4',
   permission: 'auto',
@@ -316,7 +314,7 @@ export async function hydrateStore(): Promise<void> {
       sidebarCollapsed: persisted.sidebarCollapsed ?? false,
       theme: persisted.theme ?? 'system',
       fontSize: persisted.fontSize ?? 'md',
-      recentProjects: persisted.recentProjects ?? mockRecentProjects
+      recentProjects: persisted.recentProjects ?? []
     });
   }
   hydrated = true;


### PR DESCRIPTION
## Summary
- Store no longer ships with the demo groups/sessions/recent-projects. New install boots with one empty 'Sessions' group.
- App renders the full chrome (sidebar, settings, command palette) plus a centered empty pane with a 'New session' CTA when no session is active.

## Test plan
- [x] typecheck clean
- [x] probe-render shows sidebar + empty pane, no console errors
- [ ] manual: fresh install → empty state, click CTA → session opens