### PR TITLE
PR E: WaitingBlock + canUseTool wiring

### DIFF
--- a/electron/agent/manager.ts
+++ b/electron/agent/manager.ts
@@ -24,7 +24,8 @@ class SessionsManager {
         ({ error }) => {
           this.emit('agent:exit', { sessionId, error });
           this.runners.delete(sessionId);
-        }
+        },
+        (req) => this.emit('agent:permissionRequest', { sessionId, ...req })
       );
       await runner.start(opts);
       this.runners.set(sessionId, runner);
@@ -60,6 +61,12 @@ class SessionsManager {
     if (!r) return false;
     await r.setModel(model);
     return true;
+  }
+
+  resolvePermission(sessionId: string, requestId: string, decision: 'allow' | 'deny'): boolean {
+    const r = this.runners.get(sessionId);
+    if (!r) return false;
+    return r.resolvePermission(requestId, decision);
   }
 
   close(sessionId: string): boolean {

--- a/electron/agent/sessions.ts
+++ b/electron/agent/sessions.ts
@@ -1,4 +1,4 @@
-import type { Options, PermissionMode, Query, SDKMessage, SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
+import type { CanUseTool, Options, PermissionMode, PermissionResult, Query, SDKMessage, SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
 
 // SDK ships ESM-only (sdk.mjs). Electron main bundle is CJS, so a static
 // `import { query }` triggers ERR_REQUIRE_ESM at load. Lazy-load via dynamic
@@ -20,6 +20,11 @@ export type StartOptions = {
 
 export type EventHandler = (msg: SDKMessage) => void;
 export type ExitHandler = (info: { error?: string }) => void;
+export type PermissionRequestHandler = (req: {
+  requestId: string;
+  toolName: string;
+  input: Record<string, unknown>;
+}) => void;
 
 // AsyncIterable queue: pushes messages into the streaming input of `query()`.
 // `query()` consumes via for-await; we resolve a pending waiter when a new
@@ -71,24 +76,46 @@ export class SessionRunner {
   private q: Query | null = null;
   private consumer: Promise<void> | null = null;
   private disposed = false;
+  private pendingPerms = new Map<string, (r: PermissionResult) => void>();
 
   constructor(
     public readonly id: string,
     private readonly onEvent: EventHandler,
-    private readonly onExit: ExitHandler
+    private readonly onExit: ExitHandler,
+    private readonly onPermissionRequest: PermissionRequestHandler
   ) {}
+
+  resolvePermission(requestId: string, decision: 'allow' | 'deny'): boolean {
+    const resolve = this.pendingPerms.get(requestId);
+    if (!resolve) return false;
+    this.pendingPerms.delete(requestId);
+    resolve(
+      decision === 'allow'
+        ? { behavior: 'allow', updatedInput: undefined }
+        : { behavior: 'deny', message: 'User denied tool use.' }
+    );
+    return true;
+  }
 
   async start(opts: StartOptions): Promise<void> {
     if (this.q) return;
     const env: Record<string, string | undefined> = { ...process.env };
     if (opts.apiKey) env.ANTHROPIC_API_KEY = opts.apiKey;
 
+    const canUseTool: CanUseTool = (toolName, input) =>
+      new Promise<PermissionResult>((resolve) => {
+        const requestId = `perm-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+        this.pendingPerms.set(requestId, resolve);
+        this.onPermissionRequest({ requestId, toolName, input });
+      });
+
     const options: Options = {
       cwd: opts.cwd,
       env,
       permissionMode: opts.permissionMode ?? 'default',
       model: opts.model,
-      resume: opts.resumeSessionId
+      resume: opts.resumeSessionId,
+      canUseTool
     };
 
     const { query } = await loadSdk();
@@ -147,6 +174,10 @@ export class SessionRunner {
   close(): void {
     if (this.disposed) return;
     this.disposed = true;
+    for (const resolve of this.pendingPerms.values()) {
+      resolve({ behavior: 'deny', message: 'Session closed.' });
+    }
+    this.pendingPerms.clear();
     this.input.end();
     try {
       this.q?.close();

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -117,6 +117,11 @@ app.whenReady().then(() => {
     sessions.setModel(sessionId, model)
   );
   ipcMain.handle('agent:close', (_e, sessionId: string) => sessions.close(sessionId));
+  ipcMain.handle(
+    'agent:resolvePermission',
+    (_e, sessionId: string, requestId: string, decision: 'allow' | 'deny') =>
+      sessions.resolvePermission(sessionId, requestId, decision)
+  );
 
   createWindow();
 });

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -12,6 +12,12 @@ type StartResult = { ok: true } | { ok: false; error: string };
 
 type AgentEvent = { sessionId: string; message: SDKMessage };
 type AgentExit = { sessionId: string; error?: string };
+type AgentPermissionRequest = {
+  sessionId: string;
+  requestId: string;
+  toolName: string;
+  input: Record<string, unknown>;
+};
 
 const api = {
   loadState: (key: string): Promise<string | null> => ipcRenderer.invoke('db:load', key),
@@ -35,6 +41,12 @@ const api = {
   agentSetModel: (sessionId: string, model?: string): Promise<boolean> =>
     ipcRenderer.invoke('agent:setModel', sessionId, model),
   agentClose: (sessionId: string): Promise<boolean> => ipcRenderer.invoke('agent:close', sessionId),
+  agentResolvePermission: (
+    sessionId: string,
+    requestId: string,
+    decision: 'allow' | 'deny'
+  ): Promise<boolean> =>
+    ipcRenderer.invoke('agent:resolvePermission', sessionId, requestId, decision),
   onAgentEvent: (handler: (e: AgentEvent) => void): (() => void) => {
     const wrap = (_e: IpcRendererEvent, payload: AgentEvent) => handler(payload);
     ipcRenderer.on('agent:event', wrap);
@@ -44,6 +56,11 @@ const api = {
     const wrap = (_e: IpcRendererEvent, payload: AgentExit) => handler(payload);
     ipcRenderer.on('agent:exit', wrap);
     return () => ipcRenderer.removeListener('agent:exit', wrap);
+  },
+  onAgentPermissionRequest: (handler: (e: AgentPermissionRequest) => void): (() => void) => {
+    const wrap = (_e: IpcRendererEvent, payload: AgentPermissionRequest) => handler(payload);
+    ipcRenderer.on('agent:permissionRequest', wrap);
+    return () => ipcRenderer.removeListener('agent:permissionRequest', wrap);
   }
 };
 

--- a/src/agent/lifecycle.ts
+++ b/src/agent/lifecycle.ts
@@ -3,6 +3,18 @@ import { sdkMessageToBlocks } from './sdk-to-blocks';
 
 let installed = false;
 
+function describePermission(toolName: string, input: Record<string, unknown>): string {
+  const pick = (...keys: string[]): string => {
+    for (const k of keys) {
+      const v = input[k];
+      if (typeof v === 'string') return v;
+    }
+    return '';
+  };
+  const detail = pick('command', 'file_path', 'path', 'pattern', 'url') || '';
+  return detail ? `${toolName}: ${detail}` : toolName;
+}
+
 export function subscribeAgentEvents(): void {
   if (installed) return;
   const api = window.agentory;
@@ -13,8 +25,6 @@ export function subscribeAgentEvents(): void {
     const blocks = sdkMessageToBlocks(e.message);
     const store = useStore.getState();
     if (blocks.length > 0) store.appendBlocks(e.sessionId, blocks);
-    // Result message means the SDK turn is complete — clear the running flag
-    // so InputBar re-enables. Any other message means a turn is in flight.
     if (e.message.type === 'result') {
       store.setRunning(e.sessionId, false);
     }
@@ -26,6 +36,19 @@ export function subscribeAgentEvents(): void {
     if (!e.error) return;
     store.appendBlocks(e.sessionId, [
       { kind: 'error', id: `exit-${Date.now().toString(36)}`, text: e.error }
+    ]);
+  });
+
+  api.onAgentPermissionRequest((req) => {
+    const store = useStore.getState();
+    store.appendBlocks(req.sessionId, [
+      {
+        kind: 'waiting',
+        id: `wait-${req.requestId}`,
+        prompt: describePermission(req.toolName, req.input),
+        intent: 'permission',
+        requestId: req.requestId
+      }
     ]);
   });
 }

--- a/src/components/ChatStream.tsx
+++ b/src/components/ChatStream.tsx
@@ -145,7 +145,7 @@ function ErrorBlock({ text }: { text: string }) {
   );
 }
 
-function renderBlock(b: MessageBlock) {
+function renderBlock(b: MessageBlock, activeId: string, resolvePermission: (sid: string, rid: string, d: 'allow' | 'deny') => void) {
   switch (b.kind) {
     case 'user':
       return <UserBlock text={b.text} />;
@@ -154,7 +154,13 @@ function renderBlock(b: MessageBlock) {
     case 'tool':
       return <ToolBlock name={b.name} brief={b.brief} result={b.result} />;
     case 'waiting':
-      return <WaitingBlock prompt={b.prompt} />;
+      return (
+        <WaitingBlock
+          prompt={b.prompt}
+          onAllow={b.requestId ? () => resolvePermission(activeId, b.requestId!, 'allow') : undefined}
+          onDeny={b.requestId ? () => resolvePermission(activeId, b.requestId!, 'deny') : undefined}
+        />
+      );
     case 'error':
       return <ErrorBlock text={b.text} />;
   }
@@ -165,11 +171,12 @@ const EMPTY_BLOCKS: readonly MessageBlock[] = [];
 export function ChatStream() {
   const activeId = useStore((s) => s.activeId);
   const blocks = useStore((s) => s.messagesBySession[activeId] ?? EMPTY_BLOCKS);
+  const resolvePermission = useStore((s) => s.resolvePermission);
   return (
     <div className="flex-1 overflow-y-auto min-w-0">
       <div className="px-4 py-3 flex flex-col gap-1.5 max-w-[1100px]">
         {blocks.map((m) => (
-          <div key={m.id}>{renderBlock(m)}</div>
+          <div key={m.id}>{renderBlock(m, activeId, resolvePermission)}</div>
         ))}
       </div>
     </div>

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -10,6 +10,12 @@ type StartOpts = {
 type StartResult = { ok: true } | { ok: false; error: string };
 type AgentEvent = { sessionId: string; message: SDKMessage };
 type AgentExit = { sessionId: string; error?: string };
+type AgentPermissionRequest = {
+  sessionId: string;
+  requestId: string;
+  toolName: string;
+  input: Record<string, unknown>;
+};
 
 declare global {
   interface Window {
@@ -29,8 +35,14 @@ declare global {
       agentSetPermissionMode: (sessionId: string, mode: PermissionMode) => Promise<boolean>;
       agentSetModel: (sessionId: string, model?: string) => Promise<boolean>;
       agentClose: (sessionId: string) => Promise<boolean>;
+      agentResolvePermission: (
+        sessionId: string,
+        requestId: string,
+        decision: 'allow' | 'deny'
+      ) => Promise<boolean>;
       onAgentEvent: (handler: (e: AgentEvent) => void) => () => void;
       onAgentExit: (handler: (e: AgentExit) => void) => () => void;
+      onAgentPermissionRequest: (handler: (e: AgentPermissionRequest) => void) => () => void;
     };
   }
 }

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -52,6 +52,7 @@ type Actions = {
   clearMessages: (sessionId: string) => void;
   markStarted: (sessionId: string) => void;
   setRunning: (sessionId: string, running: boolean) => void;
+  resolvePermission: (sessionId: string, requestId: string, decision: 'allow' | 'deny') => void;
 };
 
 function nextId(prefix: string): string {
@@ -309,6 +310,20 @@ export const useStore = create<State & Actions>((set, get) => ({
       else delete next[sessionId];
       return { runningSessions: next };
     });
+  },
+
+  resolvePermission: (sessionId, requestId, decision) => {
+    const waitId = `wait-${requestId}`;
+    set((s) => {
+      const prev = s.messagesBySession[sessionId];
+      if (!prev) return s;
+      const next = prev.filter((b) => b.id !== waitId);
+      if (next.length === prev.length) return s;
+      return {
+        messagesBySession: { ...s.messagesBySession, [sessionId]: next }
+      };
+    });
+    void window.agentory?.agentResolvePermission(sessionId, requestId, decision);
   }
 }));
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,5 +25,5 @@ export type MessageBlock =
   | { kind: 'user'; id: string; text: string }
   | { kind: 'assistant'; id: string; text: string }
   | { kind: 'tool'; id: string; name: string; brief: string; expanded: boolean; result?: string }
-  | { kind: 'waiting'; id: string; prompt: string; intent: 'permission' | 'plan' | 'question' }
+  | { kind: 'waiting'; id: string; prompt: string; intent: 'permission' | 'plan' | 'question'; requestId?: string }
   | { kind: 'error'; id: string; text: string };


### PR DESCRIPTION
## Summary
- Wire SDK \`canUseTool\` callback through IPC: main process holds a Promise resolver per requestId and emits a permissionRequest event; renderer shows the existing WaitingBlock; Allow/Deny resolves the pending Promise the SDK is awaiting.
- On session close, deny all pending permissions so SDK turns don't hang.

## Test plan
- [ ] Start a session, run a command that triggers a tool (e.g. Bash) under \`ask\` permission mode.
- [ ] WaitingBlock appears with the tool name + a meaningful detail (command/file_path/url).
- [ ] Click Allow → tool proceeds; click Deny (or Esc) → SDK reports denial.
- [ ] Close session mid-prompt → no hanging Promise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)