### PR TITLE
docs: fix Tailwind version (v4, not v3)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -18,7 +18,7 @@ This file is the reconciliation table for what's actually implemented in agentor
 | Item | Status | Notes |
 |---|---|---|
 | Electron shell (main + preload) | ✅ | `electron/main.ts` boots a single window. |
-| React 18 + TS + Tailwind v3 | ✅ | webpack 5 dev server on port 4100. |
+| React 18 + TS + Tailwind v4 | ✅ | webpack 5 dev server on port 4100; Tailwind v4 CSS-based config via `@import "tailwindcss"` (no `tailwind.config.js`). |
 | Hand-rolled Radix-based ui/ primitives | ✅ | Dialog / DropdownMenu / ContextMenu / Tooltip / Toast / ConfirmDialog / Button / IconButton / InlineRename / StateGlyph. |
 | framer-motion / lucide-react / @dnd-kit | ✅ | Installed and used in Sidebar. |
 | Zustand store | ✅ | `src/stores/store.ts` holds sessions/groups/recentProjects/UI state + actions; consumed across the app. |

--- a/docs/mvp-design.md
+++ b/docs/mvp-design.md
@@ -16,7 +16,7 @@ Status: MVP design locked — single source of truth before scaffolding.
 
 ## 2. Tech stack (locked)
 
-Electron · React 18 · TypeScript · Tailwind v3 · hand-rolled Radix primitives (`src/components/ui/`) · framer-motion · Zustand · @dnd-kit · Claude Agent SDK (main process) · SQLite (better-sqlite3) · custom React renderer (no xterm) · Vitest · Playwright.
+Electron · React 18 · TypeScript · Tailwind v4 (CSS-based config, `@import "tailwindcss"` in `src/styles/global.css`) · hand-rolled Radix primitives (`src/components/ui/`) · framer-motion · Zustand · @dnd-kit · Claude Agent SDK (main process) · SQLite (better-sqlite3) · custom React renderer (no xterm) · Vitest · Playwright.
 
 > Not using shadcn/ui: shell wrapper is ~30 lines, shadcn's high-value components (Dialog/Command/Form) don't cover this project's GUI-style rendering needs, and token mapping cost (`--sidebar-*` ↔ `bg-bg-sidebar`) is high. Build directly on Radix primitives instead.
 


### PR DESCRIPTION
Hot-fix on top of PR #19. Verified against package.json + postcss.config.js + global.css — project uses Tailwind v4 with CSS-based config, not v3.