### PR TITLE
PR H: P1 state toast + Cmd+N / Cmd+Shift+N

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -25,7 +25,7 @@ This file is the reconciliation table for what's actually implemented in agentor
 | better-sqlite3 persistence | 🟡 | `electron/db.ts` opens with WAL, single `app_state(key,value)` table; `db:load`/`db:save` IPC + preload bridge; renderer hydrates on boot, debounced 250ms write-back. Schema is a single JSON blob; structured schema is post-MVP. |
 | Claude Agent SDK integration | ✅ | Main process: `electron/agent/sessions.ts` (`SessionRunner` with streaming-input AsyncIterable) + `electron/agent/manager.ts` (singleton registry); IPC: `agent:start/send/interrupt/setPermissionMode/setModel/close/resolvePermission` + push events `agent:event` / `agent:exit` / `agent:permissionRequest`; preload + global.d.ts extended; API key injected into the SDK env in main process (never crosses renderer); ChatStream + InputBar consume real events; canUseTool round-trips through WaitingBlock. |
 | `~/.claude/projects/` import | ⬜ | |
-| Global shortcut registration | 🟡 | `App.tsx` registers Cmd+K / Cmd+, / Cmd+B; Cmd+N / Cmd+Shift+N not implemented. |
+| Global shortcut registration | ✅ | `App.tsx` registers Cmd+K / Cmd+, / Cmd+B / Cmd+N (new session) / Cmd+Shift+N (new group). |
 
 ## 2. Sidebar (`src/components/Sidebar.tsx`)
 
@@ -95,7 +95,7 @@ This file is the reconciliation table for what's actually implemented in agentor
 | Item | Status | Notes |
 |---|---|---|
 | ToastProvider mounted | ✅ | |
-| Real triggers: state change / SDK error / API key missing | 🟡 | Persist write failure already wired to a toast (5s throttled). Real-world state-change and SDK-error triggers wait until those data sources are live. |
+| Real triggers: state change / SDK error / API key missing | 🟡 | Persist write failure already wired to a toast (5s throttled). Background-session permission requests now toast (`<session> needs your input`) via the lifecycle → `setBackgroundWaitingHandler` bridge. SDK crash + API key missing still pending. |
 
 ## 9. Persistence (mvp-design.md §10)
 
@@ -120,9 +120,9 @@ This file is the reconciliation table for what's actually implemented in agentor
 | **P0** | Markdown rendering for assistant text | Today every reply is raw whitespace-pre-wrap; code blocks and lists are unreadable. Without this, the user's "no reply" complaint stays valid even though replies ARE arriving. |
 | **P0** | Tool result wiring (`tool_use_id` → `tool_result` fold-in) | Tool block currently always says "(no captured output yet)". No way to see what `Read` / `Bash` / `Grep` actually returned. |
 | **P0** | Auto-scroll + "↓ Jump to latest" | Long replies disappear off-screen mid-stream because nothing follows the tail. |
-| P1 | `~/.claude/projects/` import scanner | User has 160+ historical sessions in the old setup. Without import, the new app starts empty and feels like a regression. |
-| P1 | Session state change → Toast | Background sessions entering waiting are currently silent. |
-| P1 | Cmd+N / Cmd+Shift+N shortcuts | Listed in §11 but not registered. |
+| P1 | `~/.claude/projects/` import scanner | User has 160+ historical sessions in the old setup. Without import, the new app starts empty. (Per user 2026-04-20: starting empty is acceptable for now — deferring.) |
+| P1 | ~~Session state change → Toast~~ | ✅ Done in PR #22. Background sessions entering waiting now toast. |
+| P1 | ~~Cmd+N / Cmd+Shift+N shortcuts~~ | ✅ Done in PR #22. |
 | P2 | Waiting indicator: oklch amber breathing glow | Polish, not a blocker. Currently red dot. |
 | P2 | electron-updater wiring | Required before public-ish builds; not for self-use. |
 | P2 | Tests (vitest + playwright) | Should land before any external user. |
@@ -132,6 +132,10 @@ This file is the reconciliation table for what's actually implemented in agentor
 PRs land into `working`, then `working` → `main` via release-tag CI. See git log for the most recent landings.
 
 Most recent landings (newest first):
+- PR #22 — P1 state toast on background sessions + Cmd+N / Cmd+Shift+N shortcuts
+- PR #21 — ChatStream P0: markdown + tool result wiring + auto-scroll
+- PR #20 — docs: fix Tailwind version (v4, not v3)
+- PR #19 — doc realignment (translate to English, fix drifts, update status)
 - PR #18 — wire canUseTool through IPC to WaitingBlock
 - PR #17 — push model / permission changes to all started sessions
 - PR #16 — drop mock seed, render real first-run empty state

--- a/scripts/probe-shortcuts.mjs
+++ b/scripts/probe-shortcuts.mjs
@@ -1,0 +1,88 @@
+import { chromium } from 'playwright';
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext();
+const page = await ctx.newPage();
+
+const logs = [];
+page.on('console', (m) => logs.push(`[${m.type()}] ${m.text()}`));
+page.on('pageerror', (e) => logs.push(`[pageerror] ${e.message}\n${e.stack ?? ''}`));
+page.on('requestfailed', (r) => logs.push(`[reqfail] ${r.url()} ${r.failure()?.errorText}`));
+
+await page.goto('http://localhost:4100/', { waitUntil: 'networkidle' });
+await page.waitForTimeout(1500);
+
+const result = await page.evaluate(async () => {
+  const out = { steps: [], errors: [], checks: {} };
+  try {
+    const useStore = window.__agentoryStore;
+    if (!useStore) throw new Error('window.__agentoryStore missing');
+
+    const before = useStore.getState();
+    const sessionsBefore = before.sessions.length;
+    const groupsBefore = before.groups.length;
+    out.steps.push(`baseline: ${sessionsBefore} sessions, ${groupsBefore} groups`);
+
+    // Cmd+N -> new session (single window dispatch; document+window double-fires)
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'n', code: 'KeyN', ctrlKey: true, bubbles: true }));
+    await new Promise((r) => setTimeout(r, 100));
+
+    const afterN = useStore.getState();
+    out.checks.newSessionCreated = afterN.sessions.length === sessionsBefore + 1;
+    out.steps.push(`after Cmd+N: ${afterN.sessions.length} sessions`);
+
+    // Cmd+Shift+N -> new group
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'N', code: 'KeyN', ctrlKey: true, shiftKey: true, bubbles: true }));
+    await new Promise((r) => setTimeout(r, 100));
+
+    const afterShiftN = useStore.getState();
+    out.checks.newGroupCreated = afterShiftN.groups.length === groupsBefore + 1;
+    out.steps.push(`after Cmd+Shift+N: ${afterShiftN.groups.length} groups`);
+
+    // Background waiting bridge: install a fake permission request via the
+    // store directly. Since there's no live SDK in dev:web, we simulate by
+    // appending a waiting block on a NON-active session and confirm the
+    // toast bridge would fire IF the lifecycle saw a real one.
+    // The bridge sets a global handler; we can call it directly.
+    // The bridge is registered via setBackgroundWaitingHandler — to invoke
+    // we'd need to import lifecycle. Easier: trigger via the lifecycle
+    // exported handler by replicating what onAgentPermissionRequest does.
+
+    // Create a second session so we have a "background" target.
+    useStore.getState().createSession('~/bg-cwd');
+    const bgSid = useStore.getState().activeId;
+    // Make active session something else
+    const otherSid = useStore.getState().sessions.find((s) => s.id !== bgSid)?.id;
+    if (otherSid) useStore.getState().selectSession(otherSid);
+    out.steps.push(`bg session ${bgSid}, active ${useStore.getState().activeId}`);
+
+    // The toast push is encapsulated; easiest E2E check is to look at the
+    // toast region's children count after manually firing a permission
+    // request would arrive. We can't fire onAgentPermissionRequest from the
+    // page (window.agentory is undefined in dev:web). So toast
+    // verification is best-effort: confirm the toast root exists and is
+    // empty, then assert no errors occurred during shortcut handling.
+    const toastRoot = document.querySelector('.pointer-events-none.fixed.bottom-3.right-3');
+    out.checks.toastRootExists = !!toastRoot;
+    out.checks.toastRootEmpty = toastRoot ? toastRoot.children.length === 0 : null;
+  } catch (e) {
+    out.errors.push(String(e?.stack ?? e));
+  }
+  return out;
+});
+
+console.log('=== STEPS ===');
+for (const s of result.steps) console.log('  -', s);
+
+if (result.errors.length) {
+  console.log('=== ERRORS ===');
+  for (const e of result.errors) console.log(e);
+}
+
+console.log('\n=== CHECKS ===');
+console.log(JSON.stringify(result.checks, null, 2));
+
+console.log('\n=== CONSOLE / PAGE ERRORS ===');
+for (const l of logs) console.log(l);
+
+await browser.close();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import { SettingsDialog } from './components/SettingsDialog';
 import { CommandPalette } from './components/CommandPalette';
 import { useStore } from './stores/store';
 import { setPersistErrorHandler } from './stores/persist';
-import { subscribeAgentEvents } from './agent/lifecycle';
+import { subscribeAgentEvents, setBackgroundWaitingHandler } from './agent/lifecycle';
 
 subscribeAgentEvents();
 
@@ -28,6 +28,7 @@ export default function App() {
   const focusGroup = useStore((s) => s.focusGroup);
   const moveSession = useStore((s) => s.moveSession);
   const createSession = useStore((s) => s.createSession);
+  const createGroup = useStore((s) => s.createGroup);
   const changeCwd = useStore((s) => s.changeCwd);
   const pushRecentProject = useStore((s) => s.pushRecentProject);
   const setModel = useStore((s) => s.setModel);
@@ -78,17 +79,25 @@ export default function App() {
       } else if (e.key === ',') {
         e.preventDefault();
         setSettingsOpen(true);
+      } else if (k === 'n' && e.shiftKey) {
+        e.preventDefault();
+        const id = createGroup();
+        focusGroup(id);
+      } else if (k === 'n') {
+        e.preventDefault();
+        createSession(null);
       }
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, []);
+  }, [createSession, createGroup, focusGroup, toggleSidebar]);
 
   if (!active) {
     return (
       <TooltipProvider delayDuration={400} skipDelayDuration={100}>
         <ToastProvider>
           <PersistErrorBridge />
+          <BackgroundWaitingBridge />
           <div className="flex h-full w-full bg-bg-app text-fg-primary">
             <Sidebar
               onCreateSession={(cwd) => createSession(cwd)}
@@ -135,6 +144,7 @@ export default function App() {
     <TooltipProvider delayDuration={400} skipDelayDuration={100}>
       <ToastProvider>
         <PersistErrorBridge />
+        <BackgroundWaitingBridge />
         <div className="flex h-full w-full bg-bg-app text-fg-primary">
           <Sidebar
             onCreateSession={(cwd) => createSession(cwd)}
@@ -201,5 +211,26 @@ function PersistErrorBridge() {
     });
     return () => setPersistErrorHandler(() => {});
   }, [push]);
+  return null;
+}
+
+function BackgroundWaitingBridge() {
+  const { push } = useToast();
+  const selectSession = useStore((s) => s.selectSession);
+  useEffect(() => {
+    setBackgroundWaitingHandler((info) => {
+      push({
+        kind: 'waiting',
+        title: `${info.sessionName} needs your input`,
+        body: info.prompt
+      });
+      // The toast is fire-and-forget; we deliberately do NOT auto-jump on
+      // click here because the dismiss-on-click in Toast.tsx and a
+      // separate "switch session" action would conflict. User clicks the
+      // sidebar row to switch — same as today.
+      void selectSession;
+    });
+    return () => setBackgroundWaitingHandler(() => {});
+  }, [push, selectSession]);
   return null;
 }

--- a/src/agent/lifecycle.ts
+++ b/src/agent/lifecycle.ts
@@ -3,6 +3,13 @@ import { sdkMessageToTranslation } from './sdk-to-blocks';
 
 let installed = false;
 
+type BackgroundWaitingHandler = (info: { sessionId: string; sessionName: string; prompt: string }) => void;
+let backgroundWaitingHandler: BackgroundWaitingHandler = () => {};
+
+export function setBackgroundWaitingHandler(h: BackgroundWaitingHandler): void {
+  backgroundWaitingHandler = h;
+}
+
 function describePermission(toolName: string, input: Record<string, unknown>): string {
   const pick = (...keys: string[]): string => {
     for (const k of keys) {
@@ -44,14 +51,23 @@ export function subscribeAgentEvents(): void {
 
   api.onAgentPermissionRequest((req) => {
     const store = useStore.getState();
+    const prompt = describePermission(req.toolName, req.input);
     store.appendBlocks(req.sessionId, [
       {
         kind: 'waiting',
         id: `wait-${req.requestId}`,
-        prompt: describePermission(req.toolName, req.input),
+        prompt,
         intent: 'permission',
         requestId: req.requestId
       }
     ]);
+    if (req.sessionId !== store.activeId) {
+      const session = store.sessions.find((s) => s.id === req.sessionId);
+      backgroundWaitingHandler({
+        sessionId: req.sessionId,
+        sessionName: session?.name ?? 'Background session',
+        prompt
+      });
+    }
   });
 }


### PR DESCRIPTION
## Summary

Two P1 items from \`docs/STATUS.md\` MVP gap table:

- **Cmd+N / Cmd+Shift+N**: shortcuts listed in mvp-design.md §11 but not registered. Now wired in App.tsx — Cmd+N creates a session in the current group, Cmd+Shift+N creates a new group and focuses it.
- **Background-session waiting toast**: when an SDK \`canUseTool\` permission request arrives for a session that's NOT currently active, push a \"<session name> needs your input\" toast with the prompt detail. Wired via lifecycle's new \`setBackgroundWaitingHandler\` and a \`BackgroundWaitingBridge\` component, mirroring the existing \`PersistErrorBridge\` pattern.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`node scripts/probe-shortcuts.mjs\`: dispatches Ctrl+N and Ctrl+Shift+N via \`window.dispatchEvent\`, asserts session/group counts both bump by exactly +1, no console / page errors
- [ ] Live electron-mode background-toast verification deferred — \`window.agentory\` is undefined in dev:web, so the bridge code path is wired but cannot fire end-to-end until next interactive test session