### PR TITLE
PR I: P2 amber waiting indicator polish

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -36,7 +36,7 @@ This file is the reconciliation table for what's actually implemented in agentor
 | Group collapse/expand + chevron rotation | ✅ | Collapsed flag persisted via store. |
 | Drag-reorder sessions + cross-group migration | ✅ | @dnd-kit + `moveSession`. |
 | Session active 3px accent vertical bar | ✅ | framer-motion enter animation. |
-| Session waiting indicator | 🟡 | Currently a small red dot. `mvp-design.md` §5 calls for an oklch amber breathing glow — visual polish follow-up. |
+| Session waiting indicator | ✅ | Session row uses an oklch amber breathing halo on the AgentIcon (1.6s framer-motion loop) — matches `mvp-design.md` §5. Group row shows a small amber dot when any child session is waiting. |
 | Session right-click Rename | ✅ | InlineRename commit → `renameSession`. |
 | Session right-click Move to group | ✅ | Submenu lists normal groups → `moveSession`; "New group…" creates then moves. |
 | Session right-click Delete | ✅ | ConfirmDialog → `deleteSession`. |
@@ -123,7 +123,7 @@ This file is the reconciliation table for what's actually implemented in agentor
 | P1 | `~/.claude/projects/` import scanner | User has 160+ historical sessions in the old setup. Without import, the new app starts empty. (Per user 2026-04-20: starting empty is acceptable for now — deferring.) |
 | P1 | ~~Session state change → Toast~~ | ✅ Done in PR #22. Background sessions entering waiting now toast. |
 | P1 | ~~Cmd+N / Cmd+Shift+N shortcuts~~ | ✅ Done in PR #22. |
-| P2 | Waiting indicator: oklch amber breathing glow | Polish, not a blocker. Currently red dot. |
+| P2 | ~~Waiting indicator: oklch amber breathing glow~~ | ✅ Already shipped on session row (`AgentIcon` 1.6s halo). Group row dot was red, now amber too (PR #23). |
 | P2 | electron-updater wiring | Required before public-ish builds; not for self-use. |
 | P2 | Tests (vitest + playwright) | Should land before any external user. |
 

--- a/docs/mvp-design.md
+++ b/docs/mvp-design.md
@@ -94,7 +94,7 @@ Agentory                    [«]
   - In nav: group list, New group (quiet row, weekly).
   - Bottom: Archived Groups block, Settings — monthly or rarer.
 - **Group row**: chevron toggles collapse; `[+]` shows on hover at the right; collapsed group shows total session count.
-- **Session row**: agent icon + name; active sessions get a 3px accent vertical bar on the left; waiting sessions show a status dot on the right (MVP: red dot; oklch amber breathing glow is a polish follow-up, not a blocker for MVP). No badges.
+- **Session row**: agent icon + name; active sessions get a 3px accent vertical bar on the left; waiting sessions get an oklch amber breathing halo on the AgentIcon (framer-motion, 1.6s loop). The group row shows a small amber dot when any child session is waiting.
 - **Session ordering inside a group**: user-defined drag order (array order is the truth). Do NOT auto-sort by state.
 - **Drag & drop**: `@dnd-kit`, full-row draggable, `activationConstraint: { distance: 6px }`. Supports reordering within a group + cross-group migration (changes both `groupId` and position). DragOverlay is a clone of the original row, no tilt; original opacity 0.4.
 - **Right-click menus**:

--- a/scripts/probe-waiting-indicator.mjs
+++ b/scripts/probe-waiting-indicator.mjs
@@ -1,0 +1,68 @@
+import { chromium } from 'playwright';
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext();
+const page = await ctx.newPage();
+
+const logs = [];
+page.on('console', (m) => logs.push(`[${m.type()}] ${m.text()}`));
+page.on('pageerror', (e) => logs.push(`[pageerror] ${e.message}\n${e.stack ?? ''}`));
+
+await page.goto('http://localhost:4100/', { waitUntil: 'networkidle' });
+await page.waitForTimeout(1500);
+
+const result = await page.evaluate(async () => {
+  const out = { steps: [], errors: [], checks: {} };
+  try {
+    const useStore = window.__agentoryStore;
+    if (!useStore) throw new Error('window.__agentoryStore missing');
+
+    useStore.getState().createSession('~/probe');
+    const sid = useStore.getState().activeId;
+    out.steps.push(`session ${sid}`);
+
+    // Force the session into waiting state (mimics SDK setting it).
+    useStore.setState((s) => ({
+      sessions: s.sessions.map((x) => (x.id === sid ? { ...x, state: 'waiting' } : x))
+    }));
+    await new Promise((r) => setTimeout(r, 300));
+
+    // Group row dot: aria-label="Waiting for response"
+    const dot = document.querySelector('[aria-label="Waiting for response"]');
+    out.checks.groupDotFound = !!dot;
+    if (dot) {
+      const cs = getComputedStyle(dot);
+      out.checks.groupDotBg = cs.backgroundColor;
+    }
+
+    // AgentIcon halo: framer-motion sets box-shadow inline.
+    const allMotionSpans = document.querySelectorAll('span.relative.inline-flex.shrink-0');
+    let haloFound = false;
+    for (const s of allMotionSpans) {
+      const cs = getComputedStyle(s);
+      if (cs.boxShadow && cs.boxShadow.includes('oklch')) {
+        haloFound = true;
+        out.checks.haloBoxShadow = cs.boxShadow;
+        break;
+      }
+    }
+    out.checks.haloFound = haloFound;
+  } catch (e) {
+    out.errors.push(String(e?.stack ?? e));
+  }
+  return out;
+});
+
+console.log('=== STEPS ===');
+for (const s of result.steps) console.log('  -', s);
+if (result.errors.length) {
+  console.log('=== ERRORS ===');
+  for (const e of result.errors) console.log(e);
+}
+console.log('\n=== CHECKS ===');
+console.log(JSON.stringify(result.checks, null, 2));
+
+console.log('\n=== CONSOLE / PAGE ERRORS ===');
+for (const l of logs) console.log(l);
+
+await browser.close();

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -128,7 +128,7 @@ function GroupRow({
                   {hasWaiting && (
                     <span
                       aria-label="Waiting for response"
-                      className="ml-1.5 shrink-0 inline-block w-1.5 h-1.5 rounded-full bg-state-error"
+                      className="ml-1.5 shrink-0 inline-block w-1.5 h-1.5 rounded-full bg-state-waiting"
                     />
                   )}
                   {!isSpecial && sessions.length > 0 && (


### PR DESCRIPTION
Recolors the group-row waiting dot from red → amber for consistency with the session-row halo (which already shipped, just wasn't documented). Verified via probe — both group dot and AgentIcon halo render `oklch(0.78 0.1 75)` (= `--color-state-waiting`).