### PR TITLE
PR J: tests foundation — vitest + 37 unit tests

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -110,7 +110,7 @@ This file is the reconciliation table for what's actually implemented in agentor
 | Item | Status |
 |---|---|
 | Onboarding first run (Create / Import) | 🟡 PR #16 ships a "no sessions yet" empty state with a Create CTA; Import CTA waits on the import scanner. |
-| Tests (vitest / playwright) | ⬜ |
+| Tests (vitest / playwright) | 🟡 PR #24 lands vitest with 37 unit tests across `sdk-to-blocks` (13), store actions (20), and lifecycle bridge (4). Playwright probes (probe-render / probe-chatstream / probe-shortcuts / probe-waiting-indicator) live in `scripts/`. End-to-end Playwright suite still pending. |
 | Auto-update (electron-updater) | ⬜ |
 
 ## MVP gap table (P0 / P1 / P2)
@@ -125,7 +125,7 @@ This file is the reconciliation table for what's actually implemented in agentor
 | P1 | ~~Cmd+N / Cmd+Shift+N shortcuts~~ | ✅ Done in PR #22. |
 | P2 | ~~Waiting indicator: oklch amber breathing glow~~ | ✅ Already shipped on session row (`AgentIcon` 1.6s halo). Group row dot was red, now amber too (PR #23). |
 | P2 | electron-updater wiring | Required before public-ish builds; not for self-use. |
-| P2 | Tests (vitest + playwright) | Should land before any external user. |
+| P2 | ~~Tests (vitest + playwright)~~ | 🟡 PR #24: vitest unit suite landed (37 tests). Playwright E2E still pending. |
 
 ## PR roadmap
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,8 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.0.0-beta.7",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/better-sqlite3": "^7.6.12",
         "@types/node": "^22.10.0",
         "@types/react": "^18.3.12",
@@ -47,6 +49,7 @@
         "eslint-plugin-react": "^7.37.2",
         "eslint-plugin-react-hooks": "^5.1.0",
         "html-webpack-plugin": "^5.6.3",
+        "jsdom": "^29.0.2",
         "playwright": "^1.59.1",
         "postcss": "^8.4.49",
         "postcss-loader": "^8.1.1",
@@ -60,6 +63,13 @@
         "webpack-cli": "^6.0.1",
         "webpack-dev-server": "^5.2.0"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -223,6 +233,57 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -533,6 +594,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -3753,6 +3967,90 @@
         "tailwindcss": "4.2.2"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -4958,6 +5256,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -5278,6 +5586,16 @@
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -6194,6 +6512,20 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/css-what": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
@@ -6206,6 +6538,13 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -6225,6 +6564,20 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -6296,6 +6649,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -6550,6 +6910,14 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -8373,6 +8741,52 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-encoding-sniffer/node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/html-encoding-sniffer/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -8663,6 +9077,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inherits": {
@@ -9122,6 +9546,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -9400,6 +9831,90 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -9934,6 +10449,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -10258,6 +10784,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -10956,6 +11489,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -11510,6 +12053,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -11952,6 +12521,44 @@
         "renderkid": "^3.0.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -12350,6 +12957,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/reflect-metadata": {
@@ -12799,6 +13420,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
@@ -13560,6 +14194,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -13649,6 +14296,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "2.6.1",
@@ -13854,6 +14508,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -13874,6 +14548,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tree-dump": {
@@ -14160,6 +14860,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -14589,6 +15299,19 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/wait-on": {
       "version": "8.0.5",
       "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-8.0.5.tgz",
@@ -14631,6 +15354,16 @@
       "license": "MIT",
       "dependencies": {
         "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/webpack": {
@@ -14940,6 +15673,64 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/whatwg-url/node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/whatwg-url/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -15139,6 +15930,23 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.0.0-beta.7",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/better-sqlite3": "^7.6.12",
     "@types/node": "^22.10.0",
     "@types/react": "^18.3.12",
@@ -53,6 +55,7 @@
     "eslint-plugin-react": "^7.37.2",
     "eslint-plugin-react-hooks": "^5.1.0",
     "html-webpack-plugin": "^5.6.3",
+    "jsdom": "^29.0.2",
     "playwright": "^1.59.1",
     "postcss": "^8.4.49",
     "postcss-loader": "^8.1.1",

--- a/tests/lifecycle.test.ts
+++ b/tests/lifecycle.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+type PermReq = {
+  sessionId: string;
+  requestId: string;
+  toolName: string;
+  input: Record<string, unknown>;
+};
+
+type AgentEvent = { sessionId: string; message: unknown };
+type AgentExit = { sessionId: string; error?: string };
+
+// Each test reaches into this state to drive the simulated SDK and the store.
+type Harness = {
+  permHandler: (r: PermReq) => void;
+  eventHandler: (e: AgentEvent) => void;
+  exitHandler: (e: AgentExit) => void;
+  store: typeof import('../src/stores/store').useStore;
+  setBackgroundWaitingHandler: typeof import('../src/agent/lifecycle').setBackgroundWaitingHandler;
+};
+
+async function freshHarness(): Promise<Harness> {
+  // Fresh module graph per test — both lifecycle (so `installed` resets) and
+  // store (so its in-memory state starts blank).
+  vi.resetModules();
+  let permHandler: ((r: PermReq) => void) | null = null;
+  let eventHandler: ((e: AgentEvent) => void) | null = null;
+  let exitHandler: ((e: AgentExit) => void) | null = null;
+  (globalThis as unknown as { window: { agentory: unknown } }).window = {
+    agentory: {
+      onAgentEvent: (h: (e: AgentEvent) => void) => {
+        eventHandler = h;
+        return () => {};
+      },
+      onAgentExit: (h: (e: AgentExit) => void) => {
+        exitHandler = h;
+        return () => {};
+      },
+      onAgentPermissionRequest: (h: (r: PermReq) => void) => {
+        permHandler = h;
+        return () => {};
+      }
+    }
+  };
+  const lifecycle = await import('../src/agent/lifecycle');
+  const storeMod = await import('../src/stores/store');
+  lifecycle.subscribeAgentEvents();
+  if (!permHandler || !eventHandler || !exitHandler) {
+    throw new Error('lifecycle did not register all expected handlers');
+  }
+  return {
+    permHandler,
+    eventHandler,
+    exitHandler,
+    store: storeMod.useStore,
+    setBackgroundWaitingHandler: lifecycle.setBackgroundWaitingHandler
+  };
+}
+
+describe('lifecycle: background waiting bridge', () => {
+  it('fires the bridge when permission is requested for a NON-active session', async () => {
+    const h = await freshHarness();
+
+    h.store.getState().createSession('~/active');
+    const activeId = h.store.getState().activeId;
+    h.store.getState().createSession('~/bg');
+    const bgId = h.store.getState().sessions[0].id;
+    h.store.getState().selectSession(activeId);
+
+    const seen: Array<{ sessionId: string; sessionName: string; prompt: string }> = [];
+    h.setBackgroundWaitingHandler((info) => seen.push(info));
+
+    h.permHandler({
+      sessionId: bgId,
+      requestId: 'req-1',
+      toolName: 'Bash',
+      input: { command: 'rm -rf /tmp/x' }
+    });
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].sessionId).toBe(bgId);
+    expect(seen[0].prompt).toBe('Bash: rm -rf /tmp/x');
+  });
+
+  it('does NOT fire the bridge when the request is for the ACTIVE session', async () => {
+    const h = await freshHarness();
+
+    h.store.getState().createSession('~/only');
+    const sid = h.store.getState().activeId;
+
+    const seen: unknown[] = [];
+    h.setBackgroundWaitingHandler((info) => seen.push(info));
+
+    h.permHandler({
+      sessionId: sid,
+      requestId: 'req-2',
+      toolName: 'Read',
+      input: { file_path: '/etc/hosts' }
+    });
+
+    expect(seen).toEqual([]);
+    const blocks = h.store.getState().messagesBySession[sid];
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({ kind: 'waiting', requestId: 'req-2' });
+  });
+
+  it('appends an error block when agent exits with an error', async () => {
+    const h = await freshHarness();
+
+    h.store.getState().createSession('~/x');
+    const sid = h.store.getState().activeId;
+    h.store.getState().setRunning(sid, true);
+
+    h.exitHandler({ sessionId: sid, error: 'boom' });
+
+    expect(h.store.getState().runningSessions[sid]).toBeUndefined();
+    const blocks = h.store.getState().messagesBySession[sid];
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({ kind: 'error', text: 'boom' });
+  });
+
+  it('clears running flag silently on clean exit (no error block)', async () => {
+    const h = await freshHarness();
+
+    h.store.getState().createSession('~/x');
+    const sid = h.store.getState().activeId;
+    h.store.getState().setRunning(sid, true);
+
+    h.exitHandler({ sessionId: sid });
+
+    expect(h.store.getState().runningSessions[sid]).toBeUndefined();
+    expect(h.store.getState().messagesBySession[sid]).toBeUndefined();
+  });
+});

--- a/tests/sdk-to-blocks.test.ts
+++ b/tests/sdk-to-blocks.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from 'vitest';
+import { sdkMessageToTranslation } from '../src/agent/sdk-to-blocks';
+
+// Minimal SDKMessage shapes — the production type is broad and we only need
+// the fields the translator actually inspects. Cast through unknown to avoid
+// having to mock the entire SDK type surface.
+const asSdk = <T>(x: T) => x as unknown as Parameters<typeof sdkMessageToTranslation>[0];
+
+describe('sdkMessageToTranslation', () => {
+  it('drops user echoes (avoids dup with InputBar local echo)', () => {
+    const out = sdkMessageToTranslation(
+      asSdk({
+        type: 'user',
+        message: { content: [{ type: 'text', text: 'hello' }] }
+      })
+    );
+    expect(out.append).toEqual([]);
+    expect(out.toolResults).toEqual([]);
+  });
+
+  it('drops system messages (init / compact_boundary etc.)', () => {
+    const out = sdkMessageToTranslation(asSdk({ type: 'system', subtype: 'init' }));
+    expect(out.append).toEqual([]);
+    expect(out.toolResults).toEqual([]);
+  });
+
+  it('drops successful result messages (no noise on completion)', () => {
+    const out = sdkMessageToTranslation(
+      asSdk({ type: 'result', subtype: 'success', is_error: false })
+    );
+    expect(out.append).toEqual([]);
+  });
+
+  it('emits an error block on failed result', () => {
+    const out = sdkMessageToTranslation(
+      asSdk({ type: 'result', subtype: 'error_max_turns', is_error: true })
+    );
+    expect(out.append).toHaveLength(1);
+    expect(out.append[0]).toMatchObject({ kind: 'error' });
+  });
+
+  it('translates assistant text into one assistant block', () => {
+    const out = sdkMessageToTranslation(
+      asSdk({
+        type: 'assistant',
+        uuid: 'msg-1',
+        message: { content: [{ type: 'text', text: 'Sure, here is the plan.' }] }
+      })
+    );
+    expect(out.append).toEqual([
+      { kind: 'assistant', id: 'msg-1:t0', text: 'Sure, here is the plan.' }
+    ]);
+  });
+
+  it('translates tool_use into a tool block carrying toolUseId, name, brief', () => {
+    const out = sdkMessageToTranslation(
+      asSdk({
+        type: 'assistant',
+        uuid: 'msg-2',
+        message: {
+          content: [
+            {
+              type: 'tool_use',
+              id: 'toolu_001',
+              name: 'Read',
+              input: { file_path: '/a/b/c.ts' }
+            }
+          ]
+        }
+      })
+    );
+    expect(out.append).toHaveLength(1);
+    expect(out.append[0]).toMatchObject({
+      kind: 'tool',
+      toolUseId: 'toolu_001',
+      name: 'Read',
+      brief: '/a/b/c.ts',
+      expanded: false
+    });
+  });
+
+  it('splits mixed text + tool_use into separate blocks in order', () => {
+    const out = sdkMessageToTranslation(
+      asSdk({
+        type: 'assistant',
+        uuid: 'msg-3',
+        message: {
+          content: [
+            { type: 'text', text: 'Looking now.' },
+            { type: 'tool_use', id: 'toolu_002', name: 'Bash', input: { command: 'ls -la' } },
+            { type: 'text', text: 'Done.' }
+          ]
+        }
+      })
+    );
+    expect(out.append).toHaveLength(3);
+    expect(out.append.map((b) => b.kind)).toEqual(['assistant', 'tool', 'assistant']);
+    expect(out.append[1]).toMatchObject({ name: 'Bash', brief: 'ls -la', toolUseId: 'toolu_002' });
+  });
+
+  it('extracts tool_result patches from user messages without appending blocks', () => {
+    const out = sdkMessageToTranslation(
+      asSdk({
+        type: 'user',
+        message: {
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_001',
+              content: [{ type: 'text', text: 'file contents here' }]
+            }
+          ]
+        }
+      })
+    );
+    expect(out.append).toEqual([]);
+    expect(out.toolResults).toEqual([
+      { toolUseId: 'toolu_001', result: 'file contents here', isError: false }
+    ]);
+  });
+
+  it('flags is_error on tool_result patches', () => {
+    const out = sdkMessageToTranslation(
+      asSdk({
+        type: 'user',
+        message: {
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_002',
+              content: 'permission denied',
+              is_error: true
+            }
+          ]
+        }
+      })
+    );
+    expect(out.toolResults).toEqual([
+      { toolUseId: 'toolu_002', result: 'permission denied', isError: true }
+    ]);
+  });
+
+  it('joins multi-part text tool_result content', () => {
+    const out = sdkMessageToTranslation(
+      asSdk({
+        type: 'user',
+        message: {
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_003',
+              content: [
+                { type: 'text', text: 'line one' },
+                { type: 'text', text: 'line two' }
+              ]
+            }
+          ]
+        }
+      })
+    );
+    expect(out.toolResults[0].result).toBe('line one\nline two');
+  });
+
+  it('truncates long brief to 80 chars with ellipsis', () => {
+    const longCmd = 'a'.repeat(200);
+    const out = sdkMessageToTranslation(
+      asSdk({
+        type: 'assistant',
+        uuid: 'msg-4',
+        message: {
+          content: [{ type: 'tool_use', id: 'toolu_004', name: 'Bash', input: { command: longCmd } }]
+        }
+      })
+    );
+    const brief = (out.append[0] as { brief: string }).brief;
+    expect(brief.length).toBe(78); // 77 chars + ellipsis
+    expect(brief.endsWith('…')).toBe(true);
+  });
+
+  it('falls back to JSON.stringify for unknown tool input shape', () => {
+    const out = sdkMessageToTranslation(
+      asSdk({
+        type: 'assistant',
+        uuid: 'msg-5',
+        message: {
+          content: [{ type: 'tool_use', id: 'toolu_005', name: 'Custom', input: { weird: 42 } }]
+        }
+      })
+    );
+    expect((out.append[0] as { brief: string }).brief).toBe('{"weird":42}');
+  });
+
+  it('returns empty translation for unknown SDK message types', () => {
+    const out = sdkMessageToTranslation(asSdk({ type: 'mystery' }));
+    expect(out).toEqual({ append: [], toolResults: [] });
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useStore } from '../src/stores/store';
+
+// The store auto-subscribes to persist via hydrateStore(); since we never call
+// hydrateStore() in tests, the subscriber is never installed, so set() is
+// purely in-memory. We just snapshot the initial state and restore between
+// tests for isolation.
+const initial = useStore.getState();
+
+beforeEach(() => {
+  useStore.setState(
+    {
+      ...initial,
+      sessions: [],
+      groups: [{ id: 'g-default', name: 'Sessions', collapsed: false, kind: 'normal' }],
+      recentProjects: [],
+      activeId: '',
+      focusedGroupId: null,
+      messagesBySession: {},
+      startedSessions: {},
+      runningSessions: {}
+    },
+    true
+  );
+});
+
+describe('store: createSession', () => {
+  it('creates a session in the default group when none focused', () => {
+    useStore.getState().createSession('~/foo');
+    const s = useStore.getState();
+    expect(s.sessions).toHaveLength(1);
+    expect(s.sessions[0].cwd).toBe('~/foo');
+    expect(s.sessions[0].groupId).toBe('g-default');
+    expect(s.activeId).toBe(s.sessions[0].id);
+  });
+
+  it('uses focused group when one is focused', () => {
+    const gid = useStore.getState().createGroup('Custom');
+    useStore.getState().focusGroup(gid);
+    useStore.getState().createSession(null);
+    expect(useStore.getState().sessions[0].groupId).toBe(gid);
+  });
+
+  it('clears focusedGroupId after creating', () => {
+    const gid = useStore.getState().createGroup('Custom');
+    useStore.getState().focusGroup(gid);
+    useStore.getState().createSession(null);
+    expect(useStore.getState().focusedGroupId).toBeNull();
+  });
+
+  it('falls back to active session group when no focus', () => {
+    const gid = useStore.getState().createGroup('Other');
+    useStore.getState().focusGroup(gid);
+    useStore.getState().createSession('~/a');
+    useStore.getState().focusGroup(null);
+    useStore.getState().createSession('~/b');
+    expect(useStore.getState().sessions[0].groupId).toBe(gid);
+    expect(useStore.getState().sessions[1].groupId).toBe(gid);
+  });
+});
+
+describe('store: deleteSession', () => {
+  it('removes the session and shifts active to the next one', () => {
+    useStore.getState().createSession('~/a');
+    useStore.getState().createSession('~/b');
+    const [sNew, sOld] = useStore.getState().sessions;
+    expect(useStore.getState().activeId).toBe(sNew.id);
+    useStore.getState().deleteSession(sNew.id);
+    expect(useStore.getState().sessions.map((s) => s.id)).toEqual([sOld.id]);
+    expect(useStore.getState().activeId).toBe(sOld.id);
+  });
+
+  it('cascades to clear messagesBySession / startedSessions / runningSessions', () => {
+    useStore.getState().createSession('~/a');
+    const sid = useStore.getState().activeId;
+    useStore.getState().appendBlocks(sid, [{ kind: 'user', id: 'u1', text: 'hi' }]);
+    useStore.getState().markStarted(sid);
+    useStore.getState().setRunning(sid, true);
+    useStore.getState().deleteSession(sid);
+    const s = useStore.getState();
+    expect(s.messagesBySession[sid]).toBeUndefined();
+    expect(s.startedSessions[sid]).toBeUndefined();
+    expect(s.runningSessions[sid]).toBeUndefined();
+  });
+
+  it('leaves activeId empty when deleting the last session', () => {
+    useStore.getState().createSession('~/only');
+    const sid = useStore.getState().activeId;
+    useStore.getState().deleteSession(sid);
+    expect(useStore.getState().activeId).toBe('');
+  });
+});
+
+describe('store: createGroup / deleteGroup', () => {
+  it('createGroup returns the new id and appends to groups', () => {
+    const id = useStore.getState().createGroup('Refactors');
+    const g = useStore.getState().groups.find((x) => x.id === id);
+    expect(g).toBeDefined();
+    expect(g?.name).toBe('Refactors');
+    expect(g?.kind).toBe('normal');
+  });
+
+  it('deleteGroup removes its sessions too (no soft-delete)', () => {
+    const gid = useStore.getState().createGroup('Doomed');
+    useStore.getState().focusGroup(gid);
+    useStore.getState().createSession('~/x');
+    useStore.getState().createSession('~/y');
+    expect(useStore.getState().sessions).toHaveLength(2);
+    useStore.getState().deleteGroup(gid);
+    expect(useStore.getState().sessions).toHaveLength(0);
+    expect(useStore.getState().groups.find((g) => g.id === gid)).toBeUndefined();
+  });
+
+  it('deleteGroup picks a remaining session as active when active was inside', () => {
+    const gid = useStore.getState().createGroup('Doomed');
+    // First create a keeper in default group
+    useStore.getState().createSession('~/keeper');
+    const keeperId = useStore.getState().sessions[0].id;
+    // Now focus doomed and create the in-doomed session (becomes active)
+    useStore.getState().focusGroup(gid);
+    useStore.getState().createSession('~/in-doomed');
+    const doomedId = useStore.getState().sessions[0].id;
+    expect(useStore.getState().activeId).toBe(doomedId);
+    useStore.getState().deleteGroup(gid);
+    expect(useStore.getState().activeId).toBe(keeperId);
+  });
+
+  it('archiveGroup / unarchiveGroup flip kind', () => {
+    const gid = useStore.getState().createGroup('Archive me');
+    useStore.getState().archiveGroup(gid);
+    expect(useStore.getState().groups.find((g) => g.id === gid)?.kind).toBe('archive');
+    useStore.getState().unarchiveGroup(gid);
+    expect(useStore.getState().groups.find((g) => g.id === gid)?.kind).toBe('normal');
+  });
+});
+
+describe('store: messages + tool result wiring (PR G regression guard)', () => {
+  it('appendBlocks is a no-op for empty input', () => {
+    useStore.getState().createSession('~/a');
+    const sid = useStore.getState().activeId;
+    useStore.getState().appendBlocks(sid, []);
+    expect(useStore.getState().messagesBySession[sid]).toBeUndefined();
+  });
+
+  it('setToolResult fills result and isError on the matching tool block', () => {
+    useStore.getState().createSession('~/a');
+    const sid = useStore.getState().activeId;
+    useStore.getState().appendBlocks(sid, [
+      {
+        kind: 'tool',
+        id: 't1',
+        toolUseId: 'toolu_001',
+        name: 'Read',
+        brief: 'foo.ts',
+        expanded: false
+      }
+    ]);
+    useStore.getState().setToolResult(sid, 'toolu_001', 'file contents', false);
+    const block = useStore.getState().messagesBySession[sid][0];
+    expect(block).toMatchObject({ result: 'file contents', isError: false });
+  });
+
+  it('setToolResult ignores tool blocks whose toolUseId does not match', () => {
+    useStore.getState().createSession('~/a');
+    const sid = useStore.getState().activeId;
+    useStore.getState().appendBlocks(sid, [
+      { kind: 'tool', id: 't1', toolUseId: 'toolu_xyz', name: 'Bash', brief: 'ls', expanded: false }
+    ]);
+    useStore.getState().setToolResult(sid, 'toolu_other', 'should not land', false);
+    const block = useStore.getState().messagesBySession[sid][0];
+    expect((block as { result?: string }).result).toBeUndefined();
+  });
+
+  it('setToolResult does nothing for unknown sessionId', () => {
+    useStore.getState().setToolResult('does-not-exist', 'toolu_001', 'x', false);
+    expect(useStore.getState().messagesBySession['does-not-exist']).toBeUndefined();
+  });
+});
+
+describe('store: resolvePermission', () => {
+  it('removes the matching waiting block and calls the IPC bridge', () => {
+    const ipc = vi.fn().mockResolvedValue(true);
+    (globalThis as unknown as { window?: { agentory?: unknown } }).window = {
+      agentory: { agentResolvePermission: ipc }
+    };
+
+    useStore.getState().createSession('~/a');
+    const sid = useStore.getState().activeId;
+    useStore.getState().appendBlocks(sid, [
+      { kind: 'waiting', id: 'wait-req1', prompt: 'OK?', intent: 'permission', requestId: 'req1' }
+    ]);
+
+    useStore.getState().resolvePermission(sid, 'req1', 'allow');
+
+    expect(useStore.getState().messagesBySession[sid]).toEqual([]);
+    expect(ipc).toHaveBeenCalledWith(sid, 'req1', 'allow');
+  });
+
+  it('is a no-op when no waiting block matches', () => {
+    useStore.getState().createSession('~/a');
+    const sid = useStore.getState().activeId;
+    const before = useStore.getState();
+    useStore.getState().resolvePermission(sid, 'no-such-req', 'deny');
+    // No throw, state.messagesBySession reference may stay the same (no-op fast path).
+    expect(useStore.getState().sessions).toEqual(before.sessions);
+  });
+});
+
+describe('store: pushRecentProject', () => {
+  it('pushes new path to front, dedups by path, caps at 8', () => {
+    for (let i = 0; i < 10; i++) {
+      useStore.getState().pushRecentProject(`~/repo-${i}`);
+    }
+    expect(useStore.getState().recentProjects).toHaveLength(8);
+    expect(useStore.getState().recentProjects[0].path).toBe('~/repo-9');
+    // Dedup
+    useStore.getState().pushRecentProject('~/repo-5');
+    const paths = useStore.getState().recentProjects.map((r) => r.path);
+    expect(paths.indexOf('~/repo-5')).toBe(0);
+    expect(paths.filter((p) => p === '~/repo-5')).toHaveLength(1);
+  });
+
+  it('strips trailing slashes and ignores empty input', () => {
+    useStore.getState().pushRecentProject('/a/b/c/');
+    expect(useStore.getState().recentProjects[0].path).toBe('/a/b/c');
+    useStore.getState().pushRecentProject('/');
+    // '/' became '' after stripping → ignored
+    expect(useStore.getState().recentProjects.find((r) => r.path === '')).toBeUndefined();
+  });
+});
+
+describe('store: setRunning', () => {
+  it('toggles the running flag and is a no-op when value matches', () => {
+    useStore.getState().createSession('~/a');
+    const sid = useStore.getState().activeId;
+    useStore.getState().setRunning(sid, true);
+    expect(useStore.getState().runningSessions[sid]).toBe(true);
+    const before = useStore.getState().runningSessions;
+    useStore.getState().setRunning(sid, true);
+    expect(useStore.getState().runningSessions).toBe(before);
+    useStore.getState().setRunning(sid, false);
+    expect(useStore.getState().runningSessions[sid]).toBeUndefined();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    include: ['tests/**/*.test.ts', 'tests/**/*.test.tsx'],
+    globals: true,
+    setupFiles: ['tests/setup.ts']
+  }
+});


### PR DESCRIPTION
## Summary

First test pass. Lands vitest config + jsdom + 37 unit tests covering the highest-ROI pure logic in the codebase.

- \`tests/sdk-to-blocks.test.ts\` (13): every dispatch arm of the SDK→Block translator. Guards the PR G fix (tool result wiring via the new \`{append, toolResults}\` shape).
- \`tests/store.test.ts\` (20): createSession / deleteSession cascade / createGroup / deleteGroup cascade / archive flip / setToolResult patching / resolvePermission removal + IPC bridge / pushRecentProject dedup+cap+slash-strip / setRunning toggle.
- \`tests/lifecycle.test.ts\` (4): per-test fresh module graph (\`vi.resetModules\`) so the \`installed\` flag resets. Background-waiting bridge fires only for non-active sessions; agent exit error appends error block + clears running; clean exit silent.

## Test plan
- [x] \`npm test\` — 3 files, 37 tests, passing in ~4s
- [x] \`npm run typecheck\` clean

## Notes

Caught a real test-design bug in \`deleteGroup\` test (active-session shift assumption was wrong because \`createSession\` prepends and inherits active-session group). Fixed by ordering the test correctly. The store code itself was correct.

Eslint v9 config is missing project-wide (pre-existing, not PR-introduced); skipping lint until that's fixed.