### PR TITLE
PR K: electron-updater wiring

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -81,7 +81,7 @@ This file is the reconciliation table for what's actually implemented in agentor
 | Anthropic API key (safeStorage) | ✅ | `keychain:get/setApiKey` IPC + Electron `safeStorage`; encrypted file in userData; input disabled when encryption is unavailable. |
 | Data dir display | ✅ | `app:getDataDir` IPC returns real `app.getPath('userData')`. |
 | Shortcuts read-only list | ✅ | Static catalog; matches "MVP does not allow remap". |
-| Updates "Check for updates" | 🟡 | Version pulled from real package.json via `app:getVersion`; button is disabled pending the electron-updater PR. |
+| Updates "Check for updates" | ✅ | PR #25: electron-updater wired with main-process IPC (`updates:check/download/install/status`) + preload bridge + Settings UI showing version, status (idle/checking/available/downloading/downloaded/error), Check button, Download button (when an update is available), Restart-and-install button (when downloaded). In dev mode the check returns synthetic "not-available" since there is no `app-update.yml` feed. Real feed activates once electron-builder publish lands. |
 
 ## 7. CommandPalette (`src/components/CommandPalette.tsx`)
 
@@ -111,7 +111,7 @@ This file is the reconciliation table for what's actually implemented in agentor
 |---|---|
 | Onboarding first run (Create / Import) | 🟡 PR #16 ships a "no sessions yet" empty state with a Create CTA; Import CTA waits on the import scanner. |
 | Tests (vitest / playwright) | 🟡 PR #24 lands vitest with 37 unit tests across `sdk-to-blocks` (13), store actions (20), and lifecycle bridge (4). Playwright probes (probe-render / probe-chatstream / probe-shortcuts / probe-waiting-indicator) live in `scripts/`. End-to-end Playwright suite still pending. |
-| Auto-update (electron-updater) | ⬜ |
+| Auto-update (electron-updater) | ✅ PR #25 wires IPC + UI; needs electron-builder publish target to actually serve updates. |
 
 ## MVP gap table (P0 / P1 / P2)
 
@@ -124,7 +124,7 @@ This file is the reconciliation table for what's actually implemented in agentor
 | P1 | ~~Session state change → Toast~~ | ✅ Done in PR #22. Background sessions entering waiting now toast. |
 | P1 | ~~Cmd+N / Cmd+Shift+N shortcuts~~ | ✅ Done in PR #22. |
 | P2 | ~~Waiting indicator: oklch amber breathing glow~~ | ✅ Already shipped on session row (`AgentIcon` 1.6s halo). Group row dot was red, now amber too (PR #23). |
-| P2 | electron-updater wiring | Required before public-ish builds; not for self-use. |
+| P2 | ~~electron-updater wiring~~ | ✅ Done in PR #25. Needs an electron-builder publish target before it serves real updates. |
 | P2 | ~~Tests (vitest + playwright)~~ | 🟡 PR #24: vitest unit suite landed (37 tests). Playwright E2E still pending. |
 
 ## PR roadmap

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { initDb, loadState, saveState, closeDb } from './db';
 import { sessions } from './agent/manager';
+import { installUpdaterIpc } from './updater';
 import type { PermissionMode } from '@anthropic-ai/claude-agent-sdk';
 
 const KEYCHAIN_FILE = 'anthropic-key.bin';
@@ -122,6 +123,8 @@ app.whenReady().then(() => {
     (_e, sessionId: string, requestId: string, decision: 'allow' | 'deny') =>
       sessions.resolvePermission(sessionId, requestId, decision)
   );
+
+  installUpdaterIpc();
 
   createWindow();
 });

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -19,6 +19,15 @@ type AgentPermissionRequest = {
   input: Record<string, unknown>;
 };
 
+type UpdateStatus =
+  | { kind: 'idle' }
+  | { kind: 'checking' }
+  | { kind: 'available'; version: string; releaseDate?: string }
+  | { kind: 'not-available'; version: string }
+  | { kind: 'downloading'; percent: number; transferred: number; total: number }
+  | { kind: 'downloaded'; version: string }
+  | { kind: 'error'; message: string };
+
 const api = {
   loadState: (key: string): Promise<string | null> => ipcRenderer.invoke('db:load', key),
   saveState: (key: string, value: string): Promise<void> =>
@@ -61,6 +70,18 @@ const api = {
     const wrap = (_e: IpcRendererEvent, payload: AgentPermissionRequest) => handler(payload);
     ipcRenderer.on('agent:permissionRequest', wrap);
     return () => ipcRenderer.removeListener('agent:permissionRequest', wrap);
+  },
+
+  updatesStatus: (): Promise<UpdateStatus> => ipcRenderer.invoke('updates:status'),
+  updatesCheck: (): Promise<UpdateStatus> => ipcRenderer.invoke('updates:check'),
+  updatesDownload: (): Promise<{ ok: true } | { ok: false; reason: string }> =>
+    ipcRenderer.invoke('updates:download'),
+  updatesInstall: (): Promise<{ ok: true } | { ok: false; reason: string }> =>
+    ipcRenderer.invoke('updates:install'),
+  onUpdateStatus: (handler: (s: UpdateStatus) => void): (() => void) => {
+    const wrap = (_e: IpcRendererEvent, payload: UpdateStatus) => handler(payload);
+    ipcRenderer.on('updates:status', wrap);
+    return () => ipcRenderer.removeListener('updates:status', wrap);
   }
 };
 

--- a/electron/updater.ts
+++ b/electron/updater.ts
@@ -1,0 +1,104 @@
+import { app, BrowserWindow, ipcMain } from 'electron';
+import { autoUpdater } from 'electron-updater';
+
+// All status updates flow through one channel so the renderer doesn't have to
+// subscribe to N separate event names. The shape mirrors electron-updater's
+// own emitter so future fields land naturally.
+export type UpdateStatus =
+  | { kind: 'idle' }
+  | { kind: 'checking' }
+  | { kind: 'available'; version: string; releaseDate?: string }
+  | { kind: 'not-available'; version: string }
+  | { kind: 'downloading'; percent: number; transferred: number; total: number }
+  | { kind: 'downloaded'; version: string }
+  | { kind: 'error'; message: string };
+
+let lastStatus: UpdateStatus = { kind: 'idle' };
+let installed = false;
+
+function broadcast(status: UpdateStatus): void {
+  lastStatus = status;
+  for (const win of BrowserWindow.getAllWindows()) {
+    win.webContents.send('updates:status', status);
+  }
+}
+
+export function installUpdaterIpc(): void {
+  if (installed) return;
+  installed = true;
+
+  // electron-updater is noisy by default; quiet it down — we surface state
+  // through our own channel.
+  autoUpdater.autoDownload = false;
+  autoUpdater.autoInstallOnAppQuit = true;
+  autoUpdater.logger = null;
+
+  autoUpdater.on('checking-for-update', () => broadcast({ kind: 'checking' }));
+  autoUpdater.on('update-available', (info) =>
+    broadcast({
+      kind: 'available',
+      version: info.version,
+      releaseDate: info.releaseDate
+    })
+  );
+  autoUpdater.on('update-not-available', (info) =>
+    broadcast({ kind: 'not-available', version: info.version })
+  );
+  autoUpdater.on('download-progress', (p) =>
+    broadcast({
+      kind: 'downloading',
+      percent: p.percent,
+      transferred: p.transferred,
+      total: p.total
+    })
+  );
+  autoUpdater.on('update-downloaded', (info) =>
+    broadcast({ kind: 'downloaded', version: info.version })
+  );
+  autoUpdater.on('error', (err) =>
+    broadcast({ kind: 'error', message: err?.message ?? String(err) })
+  );
+
+  ipcMain.handle('updates:status', () => lastStatus);
+
+  ipcMain.handle('updates:check', async () => {
+    // In development the autoUpdater throws because there's no app-update.yml.
+    // Returning a synthetic "not-available" keeps the Settings UI behaving
+    // sanely without forcing the renderer to special-case dev mode.
+    if (!app.isPackaged) {
+      const status: UpdateStatus = { kind: 'not-available', version: app.getVersion() };
+      broadcast(status);
+      return status;
+    }
+    try {
+      const res = await autoUpdater.checkForUpdates();
+      // checkForUpdates resolves before update-available fires for the first
+      // time on a cold check; rely on the event broadcaster to push the real
+      // status. Returning lastStatus is best-effort.
+      void res;
+      return lastStatus;
+    } catch (e) {
+      const status: UpdateStatus = { kind: 'error', message: (e as Error).message };
+      broadcast(status);
+      return status;
+    }
+  });
+
+  ipcMain.handle('updates:download', async () => {
+    if (!app.isPackaged) return { ok: false, reason: 'not-packaged' as const };
+    try {
+      await autoUpdater.downloadUpdate();
+      return { ok: true as const };
+    } catch (e) {
+      return { ok: false as const, reason: (e as Error).message };
+    }
+  });
+
+  ipcMain.handle('updates:install', () => {
+    if (!app.isPackaged) return { ok: false as const, reason: 'not-packaged' as const };
+    // quitAndInstall: true (silent run-after install) is too aggressive for
+    // MVP — the user just clicked a button, they expect the install dialog.
+    setImmediate(() => autoUpdater.quitAndInstall(false, true));
+    return { ok: true as const };
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "better-sqlite3": "^11.5.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "electron-updater": "^6.8.3",
         "framer-motion": "^12.38.0",
         "lucide-react": "^0.469.0",
         "react": "^18.3.1",
@@ -5241,7 +5242,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-hidden": {
@@ -5797,6 +5797,19 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/builder-util-runtime": {
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
+      "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/bundle-name": {
       "version": "4.1.0",
@@ -7044,6 +7057,57 @@
       "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/electron-updater": {
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.3.tgz",
+      "integrity": "sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.5.1",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-updater/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-updater/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/electron/node_modules/@types/node": {
       "version": "20.19.39",
@@ -8527,7 +8591,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/handle-thing": {
@@ -9824,7 +9887,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -10054,6 +10116,12 @@
         "picocolors": "^1.1.1",
         "shell-quote": "^1.8.3"
       }
+    },
+    "node_modules/lazy-val": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
+      "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
+      "license": "MIT"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -10372,6 +10440,19 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -13421,6 +13502,15 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -14445,6 +14535,12 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
       "license": "MIT"
     },
     "node_modules/tinybench": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "better-sqlite3": "^11.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "electron-updater": "^6.8.3",
     "framer-motion": "^12.38.0",
     "lucide-react": "^0.469.0",
     "react": "^18.3.1",

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -4,6 +4,15 @@ import { Dialog, DialogContent } from './ui/Dialog';
 import { Button } from './ui/Button';
 import { useStore } from '../stores/store';
 
+type LocalUpdateStatus =
+  | { kind: 'idle' }
+  | { kind: 'checking' }
+  | { kind: 'available'; version: string; releaseDate?: string }
+  | { kind: 'not-available'; version: string }
+  | { kind: 'downloading'; percent: number; transferred: number; total: number }
+  | { kind: 'downloaded'; version: string }
+  | { kind: 'error'; message: string };
+
 type Tab = 'general' | 'account' | 'data' | 'shortcuts' | 'updates';
 
 const TABS: { id: Tab; label: string }[] = [
@@ -247,17 +256,82 @@ function ShortcutsPane() {
 
 function UpdatesPane() {
   const [version, setVersion] = useState<string>('…');
+  const [status, setStatus] = useState<LocalUpdateStatus>({ kind: 'idle' });
+
   useEffect(() => {
     window.agentory?.getVersion().then(setVersion).catch(() => setVersion('unknown'));
+    void window.agentory?.updatesStatus().then(setStatus).catch(() => {});
+    const off = window.agentory?.onUpdateStatus(setStatus);
+    return () => off?.();
   }, []);
+
+  const isChecking = status.kind === 'checking';
+  const isDownloading = status.kind === 'downloading';
+  const canCheck = !isChecking && !isDownloading && status.kind !== 'downloaded';
+
+  async function onCheck() {
+    if (!window.agentory) return;
+    setStatus({ kind: 'checking' });
+    await window.agentory.updatesCheck();
+    // Real status arrives via the push event; nothing to do here.
+  }
+
+  async function onDownload() {
+    await window.agentory?.updatesDownload();
+  }
+
+  function onInstall() {
+    void window.agentory?.updatesInstall();
+  }
+
   return (
     <>
       <Field label="Version">
         <span className="text-sm text-fg-secondary font-mono">{version}</span>
       </Field>
-      <Button variant="secondary" size="md" disabled title="Auto-update not yet wired">
-        Check for updates
-      </Button>
+      <Field label="Status">
+        <span className="text-sm text-fg-secondary font-mono">{describeStatus(status)}</span>
+      </Field>
+      <div className="flex gap-2">
+        <Button variant="secondary" size="md" onClick={onCheck} disabled={!canCheck}>
+          {isChecking ? 'Checking…' : 'Check for updates'}
+        </Button>
+        {status.kind === 'available' && (
+          <Button variant="primary" size="md" onClick={onDownload}>
+            Download {status.version}
+          </Button>
+        )}
+        {status.kind === 'downloaded' && (
+          <Button variant="primary" size="md" onClick={onInstall}>
+            Restart & install
+          </Button>
+        )}
+      </div>
     </>
   );
+}
+
+function describeStatus(s: LocalUpdateStatus): string {
+  switch (s.kind) {
+    case 'idle':
+      return 'No update check performed yet.';
+    case 'checking':
+      return 'Checking for updates…';
+    case 'available':
+      return `Update available: ${s.version}`;
+    case 'not-available':
+      return 'You are on the latest version.';
+    case 'downloading':
+      return `Downloading… ${s.percent.toFixed(1)}% (${formatBytes(s.transferred)} / ${formatBytes(s.total)})`;
+    case 'downloaded':
+      return `Update ${s.version} ready — restart to install.`;
+    case 'error':
+      return `Update check failed: ${s.message}`;
+  }
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
 }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -17,6 +17,15 @@ type AgentPermissionRequest = {
   input: Record<string, unknown>;
 };
 
+type UpdateStatus =
+  | { kind: 'idle' }
+  | { kind: 'checking' }
+  | { kind: 'available'; version: string; releaseDate?: string }
+  | { kind: 'not-available'; version: string }
+  | { kind: 'downloading'; percent: number; transferred: number; total: number }
+  | { kind: 'downloaded'; version: string }
+  | { kind: 'error'; message: string };
+
 declare global {
   interface Window {
     agentory?: {
@@ -43,6 +52,12 @@ declare global {
       onAgentEvent: (handler: (e: AgentEvent) => void) => () => void;
       onAgentExit: (handler: (e: AgentExit) => void) => () => void;
       onAgentPermissionRequest: (handler: (e: AgentPermissionRequest) => void) => () => void;
+
+      updatesStatus: () => Promise<UpdateStatus>;
+      updatesCheck: () => Promise<UpdateStatus>;
+      updatesDownload: () => Promise<{ ok: true } | { ok: false; reason: string }>;
+      updatesInstall: () => Promise<{ ok: true } | { ok: false; reason: string }>;
+      onUpdateStatus: (handler: (s: UpdateStatus) => void) => () => void;
     };
   }
 }


### PR DESCRIPTION
## Summary

Closes the last P2 item on the MVP gap table: auto-update via electron-updater is now wired end-to-end through main → preload → settings UI.

- Single push channel \`updates:status\` with a discriminated union (idle / checking / available / not-available / downloading / downloaded / error).
- Settings UpdatesPane now renders Version + live Status + contextual buttons (Check / Download / Restart-and-install).
- Dev mode synthesises a \`not-available\` response so the UI works without an app-update.yml feed.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 37/37 still passing
- [x] \`probe-render.mjs\` — renderer mounts clean, no console errors

## Follow-up (NOT in this PR)

Needs an electron-builder \`publish\` config (GitHub Releases as feed) and a real release tag before clicking Check actually finds anything. Until then, packaged builds still get the right UX (button works, returns \"on latest version\") and dev builds short-circuit to the same.