### PR TITLE
PR M: local CI runner + git pre-push hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Forwarder — keeps the actual gate definitions in scripts/ci.sh so they
+# stay versioned and visible. Skip with `git push --no-verify` if you must.
+
+set -e
+
+bash "$(git rev-parse --show-toplevel)/scripts/ci.sh"

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Local CI — what would have run on GitHub Actions if quota weren't exhausted.
+# Invoked by .githooks/pre-push (installed via scripts/setup-hooks.sh) and
+# also runnable directly: `bash scripts/ci.sh`.
+#
+# Fails fast on the first broken gate so you don't sit through later steps
+# only to discover lint failed.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+step() {
+  printf '\n\033[1;36m▶ %s\033[0m\n' "$1"
+}
+
+ok() {
+  printf '\033[1;32m✓ %s\033[0m\n' "$1"
+}
+
+step 'typecheck'
+npm run typecheck
+ok 'typecheck'
+
+step 'lint'
+npm run lint
+ok 'lint'
+
+step 'test'
+npm test -- --reporter=dot
+ok 'test'
+
+printf '\n\033[1;32m✅ all gates passed\033[0m\n'

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# One-shot installer: tells git to use .githooks/ as the hooks directory
+# (instead of the default .git/hooks/, which is not under version control).
+# Run once after cloning.
+
+set -e
+
+cd "$(git rev-parse --show-toplevel)"
+
+git config core.hooksPath .githooks
+chmod +x .githooks/* 2>/dev/null || true
+
+echo "✓ git hooks now sourced from .githooks/"
+echo "  Pre-push runs: typecheck → lint → test (skip with --no-verify)"


### PR DESCRIPTION
## Summary
- GitHub Actions quota exhausted; replicate the same gates locally.
- \`scripts/ci.sh\` runs typecheck → lint → test, fail-fast with color-coded steps.
- \`.githooks/pre-push\` forwards to \`scripts/ci.sh\` so nothing reaches the remote without passing.
- \`scripts/setup-hooks.sh\` is the one-shot installer (\`git config core.hooksPath .githooks\`).

## Test plan
- [x] \`bash scripts/setup-hooks.sh\` configures hooks
- [x] \`bash scripts/ci.sh\` passes locally (typecheck + lint + 37/37 tests)
- [x] Pre-push hook fired on \`git push\` for this PR (gates passed)