### PR TITLE
PR N: import sessions from Claude Code CLI transcripts

### DIFF
--- a/electron/import-scanner.ts
+++ b/electron/import-scanner.ts
@@ -1,0 +1,164 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import * as readline from 'readline';
+
+export type ScannableSession = {
+  sessionId: string;
+  cwd: string;
+  title: string;
+  mtime: number;
+  projectDir: string;
+};
+
+const PROJECTS_ROOT = path.join(os.homedir(), '.claude', 'projects');
+
+// Read just enough of the head of a jsonl to determine cwd + a usable title.
+// CLI-written transcripts can be hundreds of MB; we never read the whole file.
+const MAX_HEAD_LINES = 200;
+
+export async function scanImportableSessions(): Promise<ScannableSession[]> {
+  let dirs: string[];
+  try {
+    dirs = await fs.promises.readdir(PROJECTS_ROOT);
+  } catch {
+    return [];
+  }
+
+  const out: ScannableSession[] = [];
+  for (const dir of dirs) {
+    const projDir = path.join(PROJECTS_ROOT, dir);
+    let entries: string[];
+    try {
+      entries = await fs.promises.readdir(projDir);
+    } catch {
+      continue;
+    }
+    for (const f of entries) {
+      if (!f.endsWith('.jsonl')) continue;
+      const sessionId = f.slice(0, -'.jsonl'.length);
+      const full = path.join(projDir, f);
+      try {
+        const head = await readHead(full);
+        if (!head) continue;
+        const stat = await fs.promises.stat(full);
+        out.push({
+          sessionId,
+          cwd: head.cwd,
+          title: head.title,
+          mtime: stat.mtimeMs,
+          projectDir: dir
+        });
+      } catch {
+        // skip unreadable / malformed files
+      }
+    }
+  }
+
+  out.sort((a, b) => b.mtime - a.mtime);
+  return out;
+}
+
+type Head = { cwd: string; title: string };
+
+function readHead(file: string): Promise<Head | null> {
+  return new Promise((resolve) => {
+    const stream = fs.createReadStream(file, { encoding: 'utf8' });
+    const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+    let cwd = '';
+    let aiTitle = '';
+    let firstUserText = '';
+    let lines = 0;
+    const finish = () => {
+      rl.removeAllListeners();
+      stream.destroy();
+      const title = aiTitle || firstUserText || '(untitled session)';
+      if (!cwd && !aiTitle && !firstUserText) {
+        resolve(null);
+        return;
+      }
+      resolve({ cwd: cwd || '~', title });
+    };
+    rl.on('line', (line) => {
+      lines++;
+      if (lines > MAX_HEAD_LINES) {
+        finish();
+        return;
+      }
+      if (!line) return;
+      let d: any;
+      try {
+        d = JSON.parse(line);
+      } catch {
+        return;
+      }
+      if (typeof d.cwd === 'string' && !cwd) cwd = d.cwd;
+      if (d.type === 'ai-title' && typeof d.aiTitle === 'string') {
+        aiTitle = d.aiTitle;
+      }
+      if (!firstUserText && d.type === 'user' && d.message) {
+        const txt = extractUserText(d.message);
+        if (txt) firstUserText = truncate(txt, 80);
+      }
+      if (cwd && aiTitle) {
+        // We've got the best possible title; stop early.
+        finish();
+      }
+    });
+    rl.on('close', finish);
+    rl.on('error', () => resolve(null));
+  });
+}
+
+function extractUserText(message: any): string {
+  const c = message?.content;
+  if (typeof c === 'string') return cleanCommandWrapper(c);
+  if (!Array.isArray(c)) return '';
+  for (const part of c) {
+    if (part?.type === 'text' && typeof part.text === 'string') {
+      const cleaned = cleanCommandWrapper(part.text);
+      if (cleaned) return cleaned;
+    }
+  }
+  return '';
+}
+
+// Slash-command lines are wrapped in <command-name>...</command-name> XML and
+// look like noise as titles. Skip them.
+function cleanCommandWrapper(text: string): string {
+  if (text.startsWith('<command-')) return '';
+  return text.trim();
+}
+
+function truncate(s: string, n: number): string {
+  return s.length > n ? s.slice(0, n - 1) + '…' : s;
+}
+
+// Pure head-parsing helper, exported for unit testing. Given an array of jsonl
+// lines (already parsed-back-to-strings or raw), return the same Head shape
+// the streaming reader produces.
+export function parseHead(lines: string[]): Head | null {
+  let cwd = '';
+  let aiTitle = '';
+  let firstUserText = '';
+  for (let i = 0; i < lines.length && i < MAX_HEAD_LINES; i++) {
+    const line = lines[i];
+    if (!line) continue;
+    let d: any;
+    try {
+      d = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (typeof d.cwd === 'string' && !cwd) cwd = d.cwd;
+    if (d.type === 'ai-title' && typeof d.aiTitle === 'string') aiTitle = d.aiTitle;
+    if (!firstUserText && d.type === 'user' && d.message) {
+      const txt = extractUserText(d.message);
+      if (txt) firstUserText = truncate(txt, 80);
+    }
+    if (cwd && aiTitle) break;
+  }
+  if (!cwd && !aiTitle && !firstUserText) return null;
+  const title = aiTitle || firstUserText || '(untitled session)';
+  return { cwd: cwd || '~', title };
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import { initDb, loadState, saveState, closeDb } from './db';
 import { sessions } from './agent/manager';
 import { installUpdaterIpc } from './updater';
+import { scanImportableSessions } from './import-scanner';
 import type { PermissionMode } from '@anthropic-ai/claude-agent-sdk';
 
 const KEYCHAIN_FILE = 'anthropic-key.bin';
@@ -123,6 +124,8 @@ app.whenReady().then(() => {
     (_e, sessionId: string, requestId: string, decision: 'allow' | 'deny') =>
       sessions.resolvePermission(sessionId, requestId, decision)
   );
+
+  ipcMain.handle('import:scan', () => scanImportableSessions());
 
   installUpdaterIpc();
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -72,6 +72,10 @@ const api = {
     return () => ipcRenderer.removeListener('agent:permissionRequest', wrap);
   },
 
+  scanImportable: (): Promise<
+    Array<{ sessionId: string; cwd: string; title: string; mtime: number; projectDir: string }>
+  > => ipcRenderer.invoke('import:scan'),
+
   updatesStatus: (): Promise<UpdateStatus> => ipcRenderer.invoke('updates:status'),
   updatesCheck: (): Promise<UpdateStatus> => ipcRenderer.invoke('updates:check'),
   updatesDownload: (): Promise<{ ok: true } | { ok: false; reason: string }> =>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { InputBar } from './components/InputBar';
 import { StatusBar } from './components/StatusBar';
 import { SettingsDialog } from './components/SettingsDialog';
 import { CommandPalette } from './components/CommandPalette';
+import { ImportDialog } from './components/ImportDialog';
 import { useStore } from './stores/store';
 import { setPersistErrorHandler } from './stores/persist';
 import { subscribeAgentEvents, setBackgroundWaitingHandler } from './agent/lifecycle';
@@ -59,6 +60,7 @@ export default function App() {
 
   const [settingsOpen, setSettingsOpen] = React.useState(false);
   const [paletteOpen, setPaletteOpen] = React.useState(false);
+  const [importOpen, setImportOpen] = React.useState(false);
 
   const active = useMemo(
     () => sessions.find((s) => s.id === activeId) ?? sessions[0],
@@ -123,15 +125,24 @@ export default function App() {
                 >
                   + New session
                 </button>
+                <button
+                  type="button"
+                  onClick={() => setImportOpen(true)}
+                  className="inline-flex items-center gap-1.5 h-7 px-3 rounded-sm font-mono text-xs text-fg-secondary hover:text-fg-primary hover:bg-bg-hover border border-border-subtle outline-none focus-visible:ring-1 focus-visible:ring-border-strong transition-colors duration-120 ease-out"
+                >
+                  Import from Claude Code…
+                </button>
               </div>
             </main>
           </div>
           <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} />
+          <ImportDialog open={importOpen} onOpenChange={setImportOpen} />
           <CommandPalette
             open={paletteOpen}
             onOpenChange={setPaletteOpen}
             onOpenSettings={() => setSettingsOpen(true)}
             onNewSession={() => createSession(null)}
+            onOpenImport={() => setImportOpen(true)}
             onSelectSession={selectSession}
             onFocusGroup={focusGroup}
           />
@@ -182,11 +193,13 @@ export default function App() {
           </main>
         </div>
         <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} />
+        <ImportDialog open={importOpen} onOpenChange={setImportOpen} />
         <CommandPalette
           open={paletteOpen}
           onOpenChange={setPaletteOpen}
           onOpenSettings={() => setSettingsOpen(true)}
           onNewSession={() => createSession(null)}
+          onOpenImport={() => setImportOpen(true)}
           onSelectSession={selectSession}
           onFocusGroup={focusGroup}
         />

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { Search, Hash, Settings, Plus, FolderPlus, PanelLeft, SunMoon } from 'lucide-react';
+import { Search, Hash, Settings, Plus, FolderPlus, PanelLeft, SunMoon, DownloadCloud } from 'lucide-react';
 import { cn } from '../lib/cn';
 import { Dialog, DialogPortal, DialogOverlay } from './ui/Dialog';
 import * as RD from '@radix-ui/react-dialog';
@@ -22,6 +22,7 @@ type Props = {
   onOpenChange: (open: boolean) => void;
   onOpenSettings?: () => void;
   onNewSession?: () => void;
+  onOpenImport?: () => void;
   onSelectSession?: (id: string) => void;
   onFocusGroup?: (id: string) => void;
 };
@@ -31,6 +32,7 @@ export function CommandPalette({
   onOpenChange,
   onOpenSettings,
   onNewSession,
+  onOpenImport,
   onSelectSession,
   onFocusGroup
 }: Props) {
@@ -112,6 +114,16 @@ export function CommandPalette({
         onPick: () => {
           onOpenChange(false);
           toggleSidebar();
+        }
+      },
+      {
+        id: 'cmd:import',
+        kind: 'command',
+        label: 'Import from Claude Code…',
+        icon: <DownloadCloud size={13} className="stroke-[1.75] text-fg-tertiary" />,
+        onPick: () => {
+          onOpenChange(false);
+          onOpenImport?.();
         }
       },
       {

--- a/src/components/ImportDialog.tsx
+++ b/src/components/ImportDialog.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useState } from 'react';
+import { Dialog, DialogContent, DialogBody, DialogFooter, DialogClose } from './ui/Dialog';
+import { Button } from './ui/Button';
+import { useStore } from '../stores/store';
+
+type Scannable = {
+  sessionId: string;
+  cwd: string;
+  title: string;
+  mtime: number;
+  projectDir: string;
+};
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+const IMPORT_GROUP_NAME = 'Imported';
+
+export function ImportDialog({ open, onOpenChange }: Props) {
+  const sessions = useStore((s) => s.sessions);
+  const groups = useStore((s) => s.groups);
+  const importSession = useStore((s) => s.importSession);
+  const createGroup = useStore((s) => s.createGroup);
+  const renameGroup = useStore((s) => s.renameGroup);
+
+  const [items, setItems] = useState<Scannable[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState(false);
+  const [importing, setImporting] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    const api = window.agentory;
+    if (!api) return;
+    setLoading(true);
+    setSelected(new Set());
+    api
+      .scanImportable()
+      .then((rows) => {
+        const known = new Set(sessions.map((s) => s.id));
+        // Hide sessions whose CLI uuid we've already imported (we tag imported
+        // sessions with their resume id via name; a stricter dedup needs a
+        // dedicated field — leaving the simple "skip already-known store id"
+        // for now since the store id and CLI uuid are different namespaces).
+        setItems(rows.filter((r) => !known.has(r.sessionId)));
+      })
+      .catch(() => setItems([]))
+      .finally(() => setLoading(false));
+    // sessions intentionally excluded from deps — we want a one-shot snapshot
+    // when the dialog opens, not a re-scan as the user creates sessions.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const toggle = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const toggleAll = () => {
+    if (selected.size === items.length) setSelected(new Set());
+    else setSelected(new Set(items.map((i) => i.sessionId)));
+  };
+
+  const doImport = async () => {
+    const api = window.agentory;
+    if (!api || selected.size === 0) return;
+    setImporting(true);
+    try {
+      let groupId = groups.find((g) => g.kind === 'normal' && g.name === IMPORT_GROUP_NAME)?.id;
+      if (!groupId) {
+        groupId = createGroup(IMPORT_GROUP_NAME);
+        renameGroup(groupId, IMPORT_GROUP_NAME);
+      }
+      const picked = items.filter((i) => selected.has(i.sessionId));
+      for (const it of picked) {
+        const newId = importSession({
+          name: it.title,
+          cwd: it.cwd,
+          groupId,
+          resumeSessionId: it.sessionId
+        });
+        void newId;
+      }
+      onOpenChange(false);
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        title="Import sessions from Claude Code"
+        description="Pick existing CLI transcripts to surface in Agentory. They resume on open."
+        width="640px"
+      >
+        <DialogBody>
+          {loading ? (
+            <div className="font-mono text-xs text-fg-tertiary py-6 text-center">Scanning…</div>
+          ) : items.length === 0 ? (
+            <div className="font-mono text-xs text-fg-tertiary py-6 text-center">
+              No importable transcripts found in <span className="text-fg-secondary">~/.claude/projects/</span>.
+            </div>
+          ) : (
+            <>
+              <div className="flex items-center justify-between mb-2">
+                <button
+                  type="button"
+                  onClick={toggleAll}
+                  className="font-mono text-xs text-fg-tertiary hover:text-fg-secondary"
+                >
+                  {selected.size === items.length ? 'Deselect all' : 'Select all'} ({items.length})
+                </button>
+                <span className="font-mono text-xs text-fg-tertiary">{selected.size} selected</span>
+              </div>
+              <ul className="max-h-[420px] overflow-y-auto rounded-sm border border-border-subtle divide-y divide-border-subtle">
+                {items.map((it) => {
+                  const checked = selected.has(it.sessionId);
+                  return (
+                    <li
+                      key={it.sessionId}
+                      onClick={() => toggle(it.sessionId)}
+                      className="flex items-start gap-2 px-3 py-2 hover:bg-bg-hover cursor-pointer"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() => toggle(it.sessionId)}
+                        onClick={(e) => e.stopPropagation()}
+                        className="mt-0.5 accent-fg-primary"
+                      />
+                      <div className="min-w-0 flex-1">
+                        <div className="font-mono text-xs text-fg-primary truncate">{it.title}</div>
+                        <div className="font-mono text-[11px] text-fg-tertiary truncate">
+                          {it.cwd} · {new Date(it.mtime).toLocaleString()}
+                        </div>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            </>
+          )}
+        </DialogBody>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="ghost">Cancel</Button>
+          </DialogClose>
+          <Button
+            variant="primary"
+            disabled={selected.size === 0 || importing}
+            onClick={doImport}
+          >
+            {importing ? 'Importing…' : `Import ${selected.size}`}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -51,7 +51,8 @@ export function InputBar({ sessionId }: { sessionId: string }) {
       const res = await api.agentStart(sessionId, {
         cwd: session.cwd,
         model,
-        permissionMode: toSdkPermissionMode(permission)
+        permissionMode: toSdkPermissionMode(permission),
+        resumeSessionId: session.resumeSessionId
       });
       if (!res.ok) {
         setRunning(sessionId, false);

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -53,6 +53,10 @@ declare global {
       onAgentExit: (handler: (e: AgentExit) => void) => () => void;
       onAgentPermissionRequest: (handler: (e: AgentPermissionRequest) => void) => () => void;
 
+      scanImportable: () => Promise<
+        Array<{ sessionId: string; cwd: string; title: string; mtime: number; projectDir: string }>
+      >;
+
       updatesStatus: () => Promise<UpdateStatus>;
       updatesCheck: () => Promise<UpdateStatus>;
       updatesDownload: () => Promise<{ ok: true } | { ok: false; reason: string }>;

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -29,6 +29,7 @@ type Actions = {
   selectSession: (id: string) => void;
   focusGroup: (id: string | null) => void;
   createSession: (cwd: string | null) => void;
+  importSession: (opts: { name: string; cwd: string; groupId: string; resumeSessionId: string }) => string;
   renameSession: (id: string, name: string) => void;
   deleteSession: (id: string) => void;
   moveSession: (sessionId: string, targetGroupId: string, beforeSessionId: string | null) => void;
@@ -130,6 +131,23 @@ export const useStore = create<State & Actions>((set, get) => ({
     set((s) => ({
       sessions: s.sessions.map((x) => (x.id === id ? { ...x, name } : x))
     }));
+  },
+
+  importSession: ({ name, cwd, groupId, resumeSessionId }) => {
+    const { sessions, model } = get();
+    const id = nextId('s');
+    const imported: Session = {
+      id,
+      name,
+      state: 'idle',
+      cwd,
+      model,
+      groupId,
+      agentType: 'claude-code',
+      resumeSessionId
+    };
+    set({ sessions: [imported, ...sessions], activeId: id, focusedGroupId: null });
+    return id;
   },
 
   deleteSession: (id) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,9 @@ export interface Session {
   model: string;
   groupId: string;
   agentType: AgentType;
+  // Set when the session was imported from a Claude Code CLI transcript.
+  // Passed to agentStart on first send so the SDK resumes the same thread.
+  resumeSessionId?: string;
 }
 
 export interface Group {

--- a/tests/import-scanner.test.ts
+++ b/tests/import-scanner.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { parseHead } from '../electron/import-scanner';
+
+const j = (o: unknown) => JSON.stringify(o);
+
+describe('parseHead', () => {
+  it('returns null for empty input', () => {
+    expect(parseHead([])).toBeNull();
+  });
+
+  it('returns null when no recognizable fields appear', () => {
+    expect(parseHead([j({ type: 'file-history-snapshot' })])).toBeNull();
+  });
+
+  it('prefers ai-title over first user text', () => {
+    const head = parseHead([
+      j({ type: 'user', cwd: '/p', message: { content: [{ type: 'text', text: 'hello' }] } }),
+      j({ type: 'ai-title', aiTitle: 'A nice title' })
+    ]);
+    expect(head).toEqual({ cwd: '/p', title: 'A nice title' });
+  });
+
+  it('falls back to first user text when no ai-title', () => {
+    const head = parseHead([
+      j({ type: 'queue-operation' }),
+      j({ type: 'user', cwd: '/p', message: { content: [{ type: 'text', text: 'do the thing' }] } })
+    ]);
+    expect(head).toEqual({ cwd: '/p', title: 'do the thing' });
+  });
+
+  it('skips slash-command wrapped user text', () => {
+    const head = parseHead([
+      j({
+        type: 'user',
+        cwd: '/p',
+        message: { content: [{ type: 'text', text: '<command-name>/stats</command-name>' }] }
+      }),
+      j({
+        type: 'user',
+        message: { content: [{ type: 'text', text: 'real prompt' }] }
+      })
+    ]);
+    expect(head?.title).toBe('real prompt');
+  });
+
+  it('truncates long user text to 80 chars', () => {
+    const long = 'a'.repeat(200);
+    const head = parseHead([
+      j({ type: 'user', cwd: '/p', message: { content: [{ type: 'text', text: long }] } })
+    ]);
+    expect(head?.title.length).toBe(80);
+    expect(head?.title.endsWith('…')).toBe(true);
+  });
+
+  it('handles string content', () => {
+    const head = parseHead([
+      j({ type: 'user', cwd: '/p', message: { content: 'plain string' } })
+    ]);
+    expect(head?.title).toBe('plain string');
+  });
+
+  it('uses ~ as cwd when none seen', () => {
+    const head = parseHead([j({ type: 'ai-title', aiTitle: 'X' })]);
+    expect(head).toEqual({ cwd: '~', title: 'X' });
+  });
+
+  it('falls back to (untitled) only when ai-title and user-text are absent but cwd present', () => {
+    const head = parseHead([j({ type: 'queue-operation', cwd: '/p' })]);
+    expect(head).toEqual({ cwd: '/p', title: '(untitled session)' });
+  });
+
+  it('ignores malformed json lines', () => {
+    const head = parseHead(['not json', j({ type: 'ai-title', aiTitle: 'OK' })]);
+    expect(head?.title).toBe('OK');
+  });
+});


### PR DESCRIPTION
## Summary
- Scans `~/.claude/projects/` jsonl transcripts (head only, max 200 lines) and lets the user pull them in as resumable sessions
- Imported sessions land in an auto-created "Imported" group; lazy-resume — no SDK process spins up until the user sends
- Dialog opens from empty state and from command palette

## Test plan
- [x] 10 unit tests for `parseHead` (ai-title preference, slash-command filter, truncation, malformed lines, fallback ordering)
- [x] typecheck + lint clean
- [ ] manual: open dialog, pick sessions, verify they land in "Imported" group and resume on first send