### PR TITLE
fix: agent:start crash — force real dynamic import() for ESM-only SDK

### DIFF
--- a/electron/agent/sessions.ts
+++ b/electron/agent/sessions.ts
@@ -1,12 +1,15 @@
 import type { CanUseTool, Options, PermissionMode, PermissionResult, Query, SDKMessage, SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
 
 // SDK ships ESM-only (sdk.mjs). Electron main bundle is CJS, so a static
-// `import { query }` triggers ERR_REQUIRE_ESM at load. Lazy-load via dynamic
-// import on first start() and cache the module reference.
+// `import { query }` triggers ERR_REQUIRE_ESM at load. We need a real
+// dynamic import() — but TS with `module: CommonJS` rewrites import() to
+// require(), which re-triggers the same ESM error. Hide the call inside
+// `new Function` so TS leaves it alone and Node executes a true import().
 type SdkModule = typeof import('@anthropic-ai/claude-agent-sdk');
+const dynamicImport = new Function('s', 'return import(s)') as (s: string) => Promise<SdkModule>;
 let sdkPromise: Promise<SdkModule> | null = null;
 function loadSdk(): Promise<SdkModule> {
-  if (!sdkPromise) sdkPromise = import('@anthropic-ai/claude-agent-sdk');
+  if (!sdkPromise) sdkPromise = dynamicImport('@anthropic-ai/claude-agent-sdk');
   return sdkPromise;
 }
 

--- a/scripts/probe-import-send.mjs
+++ b/scripts/probe-import-send.mjs
@@ -1,0 +1,111 @@
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+const app = await electron.launch({
+  args: ['.'],
+  cwd: root,
+  env: { ...process.env, NODE_ENV: 'development' }
+});
+
+const win = await app.firstWindow();
+const logs = [];
+win.on('console', (m) => logs.push(`[${m.type()}] ${m.text()}`));
+win.on('pageerror', (e) => logs.push(`[pageerror] ${e.message}`));
+
+await win.waitForLoadState('domcontentloaded');
+await win.waitForTimeout(2500);
+
+// 1) Open Import dialog from empty-state OR command palette.
+const empty = await win.locator('text=Import from Claude Code').first();
+const visible = await empty.isVisible().catch(() => false);
+console.log('[probe] empty-state import button visible:', visible);
+
+if (visible) {
+  await empty.click();
+} else {
+  await win.keyboard.press('Control+K');
+  await win.waitForTimeout(300);
+  await win.keyboard.type('Import');
+  await win.waitForTimeout(200);
+  await win.keyboard.press('Enter');
+}
+
+await win.waitForTimeout(1500);
+
+// 2) Read the dialog content.
+const dialogSnapshot = await win.evaluate(() => {
+  const dlg = document.querySelector('[role="dialog"]');
+  return dlg ? dlg.outerHTML.slice(0, 4000) : '<NO DIALOG>';
+});
+console.log('--- import dialog (4000 chars) ---');
+console.log(dialogSnapshot);
+
+// 3) Pick first checkbox row and click Import.
+const rowCount = await win.locator('[role="dialog"] input[type="checkbox"]').count();
+console.log('[probe] checkbox count in dialog:', rowCount);
+
+if (rowCount > 1) {
+  // index 0 might be a select-all; pick index 1 (first item)
+  await win.locator('[role="dialog"] input[type="checkbox"]').nth(1).click();
+  await win.waitForTimeout(200);
+}
+
+// Click the Import action button.
+const importBtn = win.locator('[role="dialog"] button', { hasText: /^Import/ }).last();
+const importBtnExists = await importBtn.count();
+console.log('[probe] import action button count:', importBtnExists);
+if (importBtnExists) {
+  await importBtn.click();
+}
+
+await win.waitForTimeout(1500);
+
+// 4) Inspect store after import.
+const storeAfter = await win.evaluate(() => {
+  const s = window.__agentoryStore?.getState?.();
+  if (!s) return 'NO STORE';
+  return {
+    sessionCount: s.sessions.length,
+    activeId: s.activeId,
+    active: s.sessions.find((x) => x.id === s.activeId),
+    groups: s.groups.map((g) => ({ id: g.id, name: g.name, kind: g.kind }))
+  };
+});
+console.log('--- store after import ---');
+console.log(JSON.stringify(storeAfter, null, 2));
+
+// 5) Send a message in the imported session.
+const textarea = win.locator('textarea').first();
+await textarea.waitFor({ state: 'visible', timeout: 5000 }).catch(() => {});
+await textarea.click();
+await textarea.fill('hello from e2e probe');
+await win.waitForTimeout(200);
+await win.keyboard.press('Enter');
+
+await win.waitForTimeout(8000);
+
+// 6) Inspect post-send state + last error/blocks.
+const sendResult = await win.evaluate(() => {
+  const s = window.__agentoryStore?.getState?.();
+  if (!s) return 'NO STORE';
+  const active = s.sessions.find((x) => x.id === s.activeId);
+  return {
+    activeId: s.activeId,
+    active,
+    started: s.startedSessions[s.activeId],
+    running: s.runningSessions[s.activeId],
+    blockCount: (s.messagesBySession[s.activeId] ?? []).length,
+    lastBlocks: (s.messagesBySession[s.activeId] ?? []).slice(-6)
+  };
+});
+console.log('--- post-send state ---');
+console.log(JSON.stringify(sendResult, null, 2));
+
+console.log('--- console logs ---');
+for (const l of logs.slice(-60)) console.log(l);
+
+await app.close();

--- a/scripts/probe-new-session.mjs
+++ b/scripts/probe-new-session.mjs
@@ -1,0 +1,39 @@
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+const app = await electron.launch({
+  args: ['.'],
+  cwd: root,
+  env: { ...process.env, NODE_ENV: 'development' }
+});
+const win = await app.firstWindow();
+const logs = [];
+win.on('console', (m) => logs.push(`[${m.type()}] ${m.text()}`));
+await win.waitForLoadState('domcontentloaded');
+await win.waitForTimeout(2500);
+
+// Create a fresh session via store action (skip cwd picker dialog).
+await win.evaluate(() => {
+  window.__agentoryStore.getState().createSession('C:\\Users\\jiahuigu\\projects\\agentory-next');
+});
+await win.waitForTimeout(800);
+
+const textarea = win.locator('textarea').first();
+await textarea.click();
+await textarea.fill('hi from new-session probe');
+await win.keyboard.press('Enter');
+await win.waitForTimeout(7000);
+
+const out = await win.evaluate(() => {
+  const s = window.__agentoryStore.getState();
+  return {
+    activeId: s.activeId,
+    blocks: (s.messagesBySession[s.activeId] ?? []).slice(-4)
+  };
+});
+console.log(JSON.stringify(out, null, 2));
+await app.close();


### PR DESCRIPTION
## Summary
- PR #13 added lazy `import('@anthropic-ai/claude-agent-sdk')` to dodge `ERR_REQUIRE_ESM`, but TS with `module: CommonJS` rewrites `import()` back to `require()`. Every `agent:start` since then has thrown.
- Hide the dynamic import inside `new Function('s', 'return import(s)')` so TS leaves it alone and Node runs a true ESM import.
- E2E probes (`probe-new-session.mjs`, `probe-import-send.mjs`) reproduce the failure pre-fix and confirm a real assistant reply post-fix.

## Test plan
- [x] `probe-new-session.mjs` — fresh session sends and receives reply
- [x] `probe-import-send.mjs` — imported CLI session sends and receives reply
- [x] typecheck + lint + 47 unit tests pass via pre-push hook