### PR TITLE
fix(sidebar): horizontal dividers now reach main panel edge

### DIFF
--- a/scripts/probe-sidebar-divider.mjs
+++ b/scripts/probe-sidebar-divider.mjs
@@ -1,0 +1,52 @@
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+const app = await electron.launch({ args: ['.'], cwd: root, env: { ...process.env, NODE_ENV: 'development' } });
+const win = await app.firstWindow();
+await win.waitForLoadState('domcontentloaded');
+await win.waitForTimeout(2500);
+
+// Make sure sidebar is rendered and there is at least one session so main is mounted.
+await win.evaluate(() => {
+  const s = window.__agentoryStore.getState();
+  if (s.sessions.length === 0) s.createSession('C:\\Users\\jiahuigu\\projects\\agentory-next');
+});
+await win.waitForTimeout(600);
+
+// Geometry of every horizontal border in sidebar + main's left border.
+const geom = await win.evaluate(() => {
+  const out = { aside: null, asideStyle: null, inner: null, innerStyle: null, sidebarLines: [], main: null };
+  const aside = document.querySelector('aside');
+  if (aside) {
+    const r = aside.getBoundingClientRect();
+    const cs = getComputedStyle(aside);
+    out.aside = { left: r.left, right: r.right, width: r.width };
+    out.asideStyle = { width: cs.width, padding: cs.padding, border: cs.borderWidth, boxSizing: cs.boxSizing, transform: cs.transform };
+  }
+  const inner = document.querySelector('aside > div');
+  if (inner) {
+    const r = inner.getBoundingClientRect();
+    const cs = getComputedStyle(inner);
+    out.inner = { left: r.left, right: r.right, width: r.width };
+    out.innerStyle = { width: cs.width, padding: cs.padding, boxSizing: cs.boxSizing };
+    inner.querySelectorAll('.border-t').forEach((el, i) => {
+      const rr = el.getBoundingClientRect();
+      out.sidebarLines.push({ i, left: rr.left, right: rr.right, width: rr.width });
+    });
+  }
+  const main = document.querySelector('main');
+  if (main) {
+    const r = main.getBoundingClientRect();
+    out.main = { left: r.left, right: r.right };
+  }
+  return out;
+});
+console.log(JSON.stringify(geom, null, 2));
+
+await win.screenshot({ path: 'scripts/_sidebar-screenshot.png', fullPage: false });
+console.log('screenshot saved to scripts/_sidebar-screenshot.png');
+await app.close();

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -408,7 +408,7 @@ export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, active
       className="relative flex flex-col bg-bg-sidebar/80 backdrop-blur-xl sidebar-edge overflow-hidden"
     >
       {collapsed ? (
-        <div className="flex flex-col items-center w-12 h-full py-3 gap-2">
+        <div className="flex flex-col items-center w-full h-full py-3 gap-2">
           <IconButton
             variant="raised"
             size="md"
@@ -456,7 +456,7 @@ export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, active
           </IconButton>
         </div>
       ) : (
-      <div className="flex flex-col w-64 h-full">
+      <div className="flex flex-col w-full h-full">
           {/* Top: action zone — Search + New Session in one row.
               CodePilot-spec: h-8, bg-white/[0.06] semi-transparent on the
               sidebar's translucent surface, white/[0.08] hairline border,


### PR DESCRIPTION
## Summary
- Sidebar's three horizontal dividers were 32px short of `<main>`'s left edge.
- Root cause: `html { font-size: 14px }` in `global.css` makes Tailwind's `1rem = 14px`. The `motion.aside` uses framer-motion's literal `width: 256` (px), but the inner container was `w-64` = 16rem = **224px** → 32px gap.
- Fix: replace inner `w-64` / `w-12` with `w-full` so it inherits the animated aside width.

## Verification
- `scripts/probe-sidebar-divider.mjs` (new) measures aside, inner, every `.border-t`, and `<main>`.
- Before: divider `right: 224`, main `left: 256` → 32px gap.
- After: divider `right: 256`, main `left: 256` → flush.
- `npm run typecheck` clean; `npm run lint` clean (1 pre-existing warning unrelated).

## Test plan
- [x] Probe shows divider widths == 256
- [x] Visual screenshot saved to `scripts/_sidebar-screenshot.png`
- [x] Collapsed branch (`w-12` → `w-full`) also fixed for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)