### PR TITLE
fix(agent): expand ~ in session cwd before spawning Claude Code

### DIFF
--- a/electron/agent/sessions.ts
+++ b/electron/agent/sessions.ts
@@ -1,4 +1,12 @@
+import os from 'node:os';
+import path from 'node:path';
 import type { CanUseTool, Options, PermissionMode, PermissionResult, Query, SDKMessage, SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
+
+function resolveCwd(cwd: string): string {
+  if (cwd === '~') return os.homedir();
+  if (cwd.startsWith('~/') || cwd.startsWith('~\\')) return path.join(os.homedir(), cwd.slice(2));
+  return cwd;
+}
 
 // SDK ships ESM-only (sdk.mjs). Electron main bundle is CJS, so a static
 // `import { query }` triggers ERR_REQUIRE_ESM at load. We need a real
@@ -113,7 +121,7 @@ export class SessionRunner {
       });
 
     const options: Options = {
-      cwd: opts.cwd,
+      cwd: resolveCwd(opts.cwd),
       env,
       permissionMode: opts.permissionMode ?? 'default',
       model: opts.model,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint . --ext .ts,.tsx",
     "test": "vitest run",
     "test:watch": "vitest",
-    "probe:e2e": "npm run build && node scripts/probe-e2e-send.mjs && node scripts/probe-e2e-switch.mjs"
+    "probe:e2e": "npm run build && node scripts/probe-e2e-send.mjs && node scripts/probe-e2e-switch.mjs && node scripts/probe-e2e-default-cwd.mjs"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.114",

--- a/scripts/probe-e2e-default-cwd.mjs
+++ b/scripts/probe-e2e-default-cwd.mjs
@@ -1,0 +1,78 @@
+// E2E: new session + send WITHOUT touching the cwd chip. The default cwd
+// value is "~" (string literal), and on Windows Node's child_process.spawn
+// rejects that cwd with ENOENT — which the SDK error-template translates
+// into the misleading "Claude Code native binary not found" message.
+//
+// If main-process spawn fails, either:
+//   - an error toast/log surfaces "native binary not found" / "ENOENT", OR
+//   - no assistant block ever renders and the session stays stuck.
+//
+// Pass = assistant block renders within 30s. Fail = any of the above.
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function fail(msg) {
+  console.error(`\n[probe-e2e-default-cwd] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const app = await electron.launch({
+  args: ['.'],
+  cwd: root,
+  env: { ...process.env, NODE_ENV: 'development' }
+});
+
+const win = await app.firstWindow();
+const errors = [];
+win.on('pageerror', (e) => errors.push(`[pageerror] ${e.message}`));
+win.on('console', (m) => {
+  if (m.type() === 'error') errors.push(`[console.error] ${m.text()}`);
+});
+
+await win.waitForLoadState('domcontentloaded');
+await win.waitForTimeout(2500);
+
+const newBtn = win.getByRole('button', { name: /new session/i }).first();
+await newBtn.waitFor({ state: 'visible', timeout: 15_000 });
+await newBtn.click();
+
+const textarea = win.locator('textarea');
+await textarea.waitFor({ state: 'visible', timeout: 5000 });
+
+// DELIBERATELY skip the cwd chip — default cwd is "~".
+await textarea.click();
+await textarea.fill('hi');
+await win.keyboard.press('Enter');
+
+const assistant = win.locator('div.flex.gap-3.text-base').filter({
+  has: win.locator('span:has-text("●")')
+});
+
+try {
+  await assistant.first().waitFor({ state: 'visible', timeout: 30_000 });
+} catch {
+  const dump = await win.evaluate(() => {
+    const main = document.querySelector('main');
+    return main ? main.innerText.slice(0, 1500) : '<no <main>>';
+  });
+  console.error('--- main innerText ---\n' + dump);
+  console.error('--- recent errors ---\n' + errors.slice(-15).join('\n'));
+  await app.close();
+  fail('no assistant block rendered — spawn with default cwd "~" likely failed (ENOENT → misleading "native binary not found")');
+}
+
+// Extra guard: scan collected console errors for the specific symptom.
+const symptom = errors.find((e) => /native binary not found|ENOENT/i.test(e));
+if (symptom) {
+  await app.close();
+  fail(`console reported spawn failure: ${symptom}`);
+}
+
+console.log('\n[probe-e2e-default-cwd] OK');
+console.log('  sending with default cwd "~" produced an assistant reply');
+
+await app.close();


### PR DESCRIPTION
## Summary
- New sessions default cwd to \`~\`. On Windows, \`child_process.spawn\` rejects that with ENOENT and the SDK surfaces it as the misleading \"Claude Code native binary not found\" error.
- Expand \`~\` / \`~/...\` to \`os.homedir()\` right before spawn in \`electron/agent/sessions.ts\`. Single-point fix covers all upstream sources (store default, import-scanner fallback) without changing the display value.
- New probe \`probe-e2e-default-cwd\`: new session → send WITHOUT touching the cwd chip. The previous probes always set cwd via Browse-folder, so the default-cwd path was entirely uncovered.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean (1 pre-existing unrelated warning)
- [x] \`npm test\` — 47 passed
- [x] \`node scripts/probe-e2e-default-cwd.mjs\` — OK (assistant replied with default cwd)
- [x] \`node scripts/probe-e2e-send.mjs\` — OK
- [x] \`node scripts/probe-e2e-switch.mjs\` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)