### PR TITLE
style(dropdown): remove shouty uppercase labels

### DIFF
--- a/src/components/ui/DropdownMenu.tsx
+++ b/src/components/ui/DropdownMenu.tsx
@@ -18,7 +18,7 @@ export const DropdownMenuLabel = forwardRef<
     <RDM.Label
       ref={ref}
       className={cn(
-        'px-3 pt-1.5 pb-1 text-[10px] uppercase tracking-[0.08em] font-medium text-fg-tertiary',
+        'px-3 pt-1.5 pb-1 text-[11px] font-medium text-fg-tertiary',
         className
       )}
       {...rest}


### PR DESCRIPTION
## Summary
Dropdown section labels in the status-bar chip menus (\`Working directory\`, \`Model\`, \`Permission mode\`) rendered as ALL CAPS with 0.08em tracking at 10px. Reads as shouting.

Switch to normal Title Case, 11px, same tertiary weight as the items below.

## Test plan
- [ ] Open the cwd / model / permission chip menus in the status bar and confirm the section label reads as e.g. \`Model\` (not \`MODEL\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)