### PR TITLE
feat(statusbar): describe model and permission-mode options in dropdown

### DIFF
--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -106,15 +106,15 @@ function ChipMenu<V extends string>({
 const BROWSE_FOLDER = '__browse__';
 
 const modelOptions: ChipOption<ModelId>[] = [
-  { kind: 'item', value: 'claude-opus-4', primary: 'opus-4' },
-  { kind: 'item', value: 'claude-sonnet-4', primary: 'sonnet-4' },
-  { kind: 'item', value: 'claude-haiku-4', primary: 'haiku-4' }
+  { kind: 'item', value: 'claude-opus-4', primary: 'opus-4', secondary: 'Most capable, slower and pricier' },
+  { kind: 'item', value: 'claude-sonnet-4', primary: 'sonnet-4', secondary: 'Balanced — recommended default' },
+  { kind: 'item', value: 'claude-haiku-4', primary: 'haiku-4', secondary: 'Fastest and cheapest, lower quality' }
 ];
 
 const permissionOptions: ChipOption<PermissionMode>[] = [
-  { kind: 'item', value: 'auto', primary: 'auto' },
-  { kind: 'item', value: 'ask', primary: 'ask' },
-  { kind: 'item', value: 'plan', primary: 'plan' }
+  { kind: 'item', value: 'auto', primary: 'auto', secondary: 'Auto-approve all tool calls' },
+  { kind: 'item', value: 'ask', primary: 'ask', secondary: 'Ask before each tool call' },
+  { kind: 'item', value: 'plan', primary: 'plan', secondary: 'Plan only, no edits or commands' }
 ];
 
 function primaryOf<V extends string>(options: ChipOption<V>[], value: V): string {


### PR DESCRIPTION
## Summary
The chip menus listed bare values (\`opus-4\`, \`ask\`, \`plan\`) with no hint about what you're picking. Fill in the existing secondary line with a one-liner for each option.

## Follow-up (not in this PR)
The model list is still hard-coded in \`StatusBar.tsx\` (and the IDs are stale — \`claude-opus-4\` instead of the real \`claude-opus-4-7\` etc). A follow-up PR will move the model catalog behind an \`AgentModule.supportedModels()\` call so the UI renders whatever the current session's agent supports.

## Test plan
- [ ] Open model chip menu → three items each show a description line
- [ ] Open permission-mode chip menu → three items each show a description line
- [ ] Selection still works; no layout regression on narrow windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)