### PR TITLE
feat(chat): empty-state hero with starter prompts

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -47,6 +47,8 @@ export default [
         URL: 'readonly',
         AbortController: 'readonly',
         KeyboardEvent: 'readonly',
+        CustomEvent: 'readonly',
+        Event: 'readonly',
         HTMLElement: 'readonly',
         HTMLDivElement: 'readonly',
         HTMLInputElement: 'readonly',

--- a/scripts/probe-e2e-empty-state.mjs
+++ b/scripts/probe-e2e-empty-state.mjs
@@ -1,0 +1,91 @@
+// E2E: fresh session shows an empty state (not a blank pane) and the
+// starter-prompt chips fill the InputBar textarea.
+//
+// Fixture: seed a single session directly into the store via
+// window.__agentoryStore so we don't depend on SDK / spawn.
+//
+// What we verify:
+//   1. With a session selected and no messages yet, the empty-state
+//      hero ("Ready when you are.") is visible and all four starter
+//      prompt cards render.
+//   2. Clicking the first prompt card fills the textarea with the
+//      prompt body (>20 chars sanity) and the textarea is focused.
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function fail(msg) {
+  console.error(`\n[probe-e2e-empty-state] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const app = await electron.launch({
+  args: ['.'],
+  cwd: root,
+  env: { ...process.env, NODE_ENV: 'development' }
+});
+
+const win = await app.firstWindow();
+const errors = [];
+win.on('pageerror', (e) => errors.push(`[pageerror] ${e.message}`));
+win.on('console', (m) => {
+  if (m.type() === 'error') errors.push(`[console.error] ${m.text()}`);
+});
+
+await win.waitForLoadState('domcontentloaded');
+await win.waitForTimeout(1500);
+
+await win.evaluate(() => {
+  const store = window.__agentoryStore;
+  if (!store) throw new Error('__agentoryStore not on window — dev build?');
+  store.setState({
+    groups: [{ id: 'g1', name: 'G1', collapsed: false, kind: 'normal' }],
+    sessions: [
+      {
+        id: 's1',
+        name: 'fresh',
+        state: 'idle',
+        cwd: 'C:/Users/jiahuigu/projects/agentory-next',
+        model: 'claude-opus-4',
+        groupId: 'g1',
+        agentType: 'claude-code'
+      }
+    ],
+    activeId: 's1',
+    messagesBySession: {}
+  });
+});
+
+await win.waitForTimeout(300);
+
+const hero = win.getByText(/Ready when you are\./i);
+try {
+  await hero.first().waitFor({ state: 'visible', timeout: 5000 });
+} catch {
+  await app.close();
+  fail('empty-state hero "Ready when you are." not visible');
+}
+
+const cards = win.locator('button').filter({ hasText: /Explain this codebase|Find and fix a bug|Add tests|Refactor for clarity/ });
+const count = await cards.count();
+if (count < 4) { await app.close(); fail(`expected 4 starter cards, got ${count}`); }
+
+await cards.first().click();
+await win.waitForTimeout(200);
+
+const value = await win.locator('textarea').first().inputValue();
+if (!value || value.length < 20) {
+  await app.close();
+  fail(`textarea did not fill from starter card click (got ${JSON.stringify(value)})`);
+}
+
+const focused = await win.evaluate(() => document.activeElement?.tagName === 'TEXTAREA');
+if (!focused) { await app.close(); fail('textarea not focused after starter click'); }
+
+console.log('\n[probe-e2e-empty-state] OK');
+console.log('  empty-state visible; 4 starter cards render; first card fills + focuses textarea');
+
+await app.close();

--- a/src/components/ChatStream.tsx
+++ b/src/components/ChatStream.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { ChevronRight, AlertCircle, ArrowDown } from 'lucide-react';
+import { ChevronRight, AlertCircle, ArrowDown, Sparkles } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import type { MessageBlock } from '../types';
@@ -245,6 +245,83 @@ function renderBlock(b: MessageBlock, activeId: string, resolvePermission: (sid:
 
 const EMPTY_BLOCKS: readonly MessageBlock[] = [];
 
+// Custom event used by the empty-state prompt chips to hand a starter
+// prompt to the InputBar without introducing a store field just for this.
+// One-way: ChatStream dispatches → InputBar listens.
+export const DRAFT_FILL_EVENT = 'agentory:fill-draft';
+
+function lastPathSegment(p: string): string {
+  const trimmed = p.replace(/[\\/]+$/, '');
+  const segs = trimmed.split(/[\\/]/).filter(Boolean);
+  return segs[segs.length - 1] ?? p;
+}
+
+type StarterPrompt = { title: string; body: string };
+
+const STARTER_PROMPTS: StarterPrompt[] = [
+  {
+    title: 'Explain this codebase',
+    body: 'Give me a tour of this repo: the main entry points, how modules are organized, and the key abstractions I should know about.'
+  },
+  {
+    title: 'Find and fix a bug',
+    body: "Look through recent changes and tests for anything that looks broken, flaky, or inconsistent. Pick the most impactful one and fix it."
+  },
+  {
+    title: 'Add tests',
+    body: 'Identify a file with weak test coverage that I rely on, and add focused tests for the paths most likely to regress.'
+  },
+  {
+    title: 'Refactor for clarity',
+    body: 'Find the most confusing file or function in this repo. Propose a refactor that improves readability without changing behavior.'
+  }
+];
+
+function EmptyState({ cwd }: { cwd: string }) {
+  function pick(body: string) {
+    window.dispatchEvent(new CustomEvent(DRAFT_FILL_EVENT, { detail: body }));
+  }
+  return (
+    <div className="h-full flex items-center justify-center px-6">
+      <div className="w-full max-w-[640px] flex flex-col items-center gap-6">
+        <div className="flex flex-col items-center gap-2 text-center">
+          <div className="inline-flex items-center gap-2 text-fg-secondary">
+            <Sparkles size={14} className="stroke-[1.75] text-accent" />
+            <span className="font-mono text-sm">Ready when you are.</span>
+          </div>
+          <div className="font-mono text-xs text-fg-tertiary truncate max-w-full" title={cwd}>
+            Working in <span className="text-fg-secondary">{lastPathSegment(cwd)}</span>
+          </div>
+        </div>
+        <div className="w-full grid grid-cols-1 sm:grid-cols-2 gap-2">
+          {STARTER_PROMPTS.map((p) => (
+            <button
+              key={p.title}
+              type="button"
+              onClick={() => pick(p.body)}
+              className={
+                'group text-left rounded-md border border-border-subtle bg-bg-elevated/40 ' +
+                'hover:bg-bg-elevated hover:border-border-default ' +
+                'focus-visible:border-border-strong focus-visible:ring-1 focus-visible:ring-border-strong ' +
+                'outline-none transition-colors duration-150 ease-out ' +
+                'px-3 py-2.5'
+              }
+            >
+              <div className="text-sm text-fg-primary">{p.title}</div>
+              <div className="mt-0.5 font-mono text-xs text-fg-tertiary line-clamp-2">
+                {p.body}
+              </div>
+            </button>
+          ))}
+        </div>
+        <div className="font-mono text-xs text-fg-disabled">
+          Or just type below. Enter to send · Shift+Enter for newline.
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // Auto-follow heuristic: consider the user "at the bottom" if they're within
 // this many pixels of the actual scrollHeight. Anything larger and we assume
 // they've scrolled up intentionally and stop following.
@@ -253,6 +330,7 @@ const FOLLOW_THRESHOLD_PX = 32;
 export function ChatStream() {
   const activeId = useStore((s) => s.activeId);
   const blocks = useStore((s) => s.messagesBySession[activeId] ?? EMPTY_BLOCKS);
+  const activeCwd = useStore((s) => s.sessions.find((x) => x.id === activeId)?.cwd ?? '');
   const resolvePermission = useStore((s) => s.resolvePermission);
 
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -297,11 +375,15 @@ export function ChatStream() {
   return (
     <div className="relative flex-1 min-w-0 flex flex-col">
       <div ref={scrollRef} onScroll={onScroll} className="flex-1 overflow-y-auto min-w-0">
-        <div className="px-4 py-3 flex flex-col gap-1.5 max-w-[1100px]">
-          {blocks.map((m) => (
-            <div key={m.id}>{renderBlock(m, activeId, resolvePermission)}</div>
-          ))}
-        </div>
+        {blocks.length === 0 ? (
+          <EmptyState cwd={activeCwd} />
+        ) : (
+          <div className="px-4 py-3 flex flex-col gap-1.5 max-w-[1100px]">
+            {blocks.map((m) => (
+              <div key={m.id}>{renderBlock(m, activeId, resolvePermission)}</div>
+            ))}
+          </div>
+        )}
       </div>
       <AnimatePresence>
         {showJump && (

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { ArrowUp, Square } from 'lucide-react';
 import { cn } from '../lib/cn';
 import { Button } from './ui/Button';
 import { useStore } from '../stores/store';
 import { toSdkPermissionMode } from '../agent/permission';
+import { DRAFT_FILL_EVENT } from './ChatStream';
 
 // Per-session draft cache. Survives session switches within a process so
 // users don't lose half-typed prompts when they pop into another session.
@@ -24,9 +25,31 @@ export function InputBar({ sessionId }: { sessionId: string }) {
   const appendBlocks = useStore((s) => s.appendBlocks);
   const markStarted = useStore((s) => s.markStarted);
   const setRunning = useStore((s) => s.setRunning);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   React.useEffect(() => {
     setValue(draftCache.get(sessionId) ?? '');
+  }, [sessionId]);
+
+  // Starter prompts in the empty state dispatch DRAFT_FILL_EVENT with a
+  // body string. We fill it in, stash in draftCache for consistency with
+  // session-switch behavior, and focus the textarea so the user can edit
+  // or just press Enter.
+  React.useEffect(() => {
+    function onFill(e: Event) {
+      const text = (e as CustomEvent<string>).detail;
+      if (typeof text !== 'string') return;
+      setValue(text);
+      draftCache.set(sessionId, text);
+      requestAnimationFrame(() => {
+        const el = textareaRef.current;
+        if (!el) return;
+        el.focus();
+        el.setSelectionRange(el.value.length, el.value.length);
+      });
+    }
+    window.addEventListener(DRAFT_FILL_EVENT, onFill);
+    return () => window.removeEventListener(DRAFT_FILL_EVENT, onFill);
   }, [sessionId]);
 
   function update(next: string) {
@@ -104,6 +127,7 @@ export function InputBar({ sessionId }: { sessionId: string }) {
         )}
       >
         <textarea
+          ref={textareaRef}
           value={value}
           onChange={(e) => update(e.target.value)}
           onKeyDown={onKeyDown}


### PR DESCRIPTION
## Summary
- Fresh sessions now show a centered "Ready when you are." hero with four starter-prompt cards instead of a blank pane.
- Clicking a card fills + focuses the input textarea (lightweight CustomEvent bus between ChatStream and InputBar).
- Adds Playwright probe seeding a session via `window.__agentoryStore` to verify hero, cards, and fill-on-click.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `node scripts/probe-e2e-empty-state.mjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)