### PR TITLE
feat(electron): wire context menu + edit accelerators

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, Menu, ipcMain, safeStorage, dialog } from 'electron';
+import { app, BrowserWindow, Menu, ipcMain, safeStorage, dialog, type MenuItemConstructorOptions } from 'electron';
 import * as path from 'path';
 import * as fs from 'fs';
 import { initDb, loadState, saveState, closeDb } from './db';
@@ -43,10 +43,53 @@ function writeApiKey(value: string): boolean {
 
 const isDev = !app.isPackaged;
 
-// Hide the default application menu — Agentory is a single-window tool and
-// File/Edit/View/Window/Help adds noise without value. DevTools still opens
-// via openDevTools in dev.
-Menu.setApplicationMenu(null);
+// We don't want a visible File/Edit/View menu bar — Agentory is a single-
+// window tool and those menus add noise. But on Windows/Linux, setting the
+// app menu to null also removes the built-in Edit-role accelerators
+// (Ctrl+C / Ctrl+V / Ctrl+X / Ctrl+A / Ctrl+Z), which makes chat content
+// feel "not copyable". Install a minimal, hidden app menu whose only job
+// is to carry those accelerators, and hide the menu bar so it's not
+// visible. On macOS, the default app menu already handles this.
+if (process.platform === 'darwin') {
+  // Let Electron use its default macOS menu.
+} else {
+  const accelMenu = Menu.buildFromTemplate([
+    {
+      label: '&Edit',
+      submenu: [
+        { role: 'undo' },
+        { role: 'redo' },
+        { type: 'separator' },
+        { role: 'cut' },
+        { role: 'copy' },
+        { role: 'paste' },
+        { role: 'selectAll' }
+      ]
+    }
+  ]);
+  Menu.setApplicationMenu(accelMenu);
+}
+
+// Right-click context menu for the renderer — Copy/Cut/Paste/Select All,
+// contextually enabled based on selection + editable state. Attached per
+// window in createMainWindow().
+function installContextMenu(win: BrowserWindow) {
+  win.webContents.on('context-menu', (_e, params) => {
+    const { selectionText, editFlags, isEditable } = params;
+    const hasSelection = !!selectionText && selectionText.trim().length > 0;
+    const items: MenuItemConstructorOptions[] = [];
+    if (isEditable) {
+      items.push({ role: 'cut', enabled: !!editFlags.canCut });
+    }
+    items.push({ role: 'copy', enabled: hasSelection && !!editFlags.canCopy });
+    if (isEditable) {
+      items.push({ role: 'paste', enabled: !!editFlags.canPaste });
+    }
+    items.push({ type: 'separator' }, { role: 'selectAll', enabled: !!editFlags.canSelectAll });
+    const menu = Menu.buildFromTemplate(items);
+    menu.popup({ window: win });
+  });
+}
 
 function createWindow() {
   const win = new BrowserWindow({
@@ -60,12 +103,15 @@ function createWindow() {
     backgroundColor: '#0B0B0C',
     titleBarStyle: 'default',
     frame: true,
+    autoHideMenuBar: true,
     webPreferences: {
       contextIsolation: true,
       nodeIntegration: false,
       preload: path.join(__dirname, 'preload.js')
     }
   });
+
+  win.setMenuBarVisibility(false);
 
   if (isDev) {
     win.loadURL('http://localhost:4100');
@@ -74,6 +120,7 @@ function createWindow() {
     win.loadFile(path.join(__dirname, '../renderer/index.html'));
   }
 
+  installContextMenu(win);
   sessions.bindSender(win.webContents);
 }
 

--- a/scripts/probe-e2e-chat-copy.mjs
+++ b/scripts/probe-e2e-chat-copy.mjs
@@ -1,0 +1,74 @@
+// Regression: with Menu.setApplicationMenu(null) the Edit-role accelerators
+// (Ctrl+A, Ctrl+C, Ctrl+X, Ctrl+V, Ctrl+Z) are not registered on Windows
+// and Linux, making chat content feel "not copyable". Verify that Ctrl+A
+// actually selects all text in the chat container.
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function fail(msg) {
+  console.error(`\n[probe-e2e-chat-copy] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const app = await electron.launch({
+  args: ['.'],
+  cwd: root,
+  env: { ...process.env, NODE_ENV: 'development' }
+});
+
+const win = await app.firstWindow();
+await win.waitForLoadState('domcontentloaded');
+await win.waitForTimeout(1500);
+await win.waitForFunction(() => !!window.__agentoryStore, null, { timeout: 10000 });
+
+// NOTE: Playwright's keyboard.press dispatches events via CDP, which bypasses
+// Electron's application-menu accelerator system. So the Ctrl+A / Ctrl+C path
+// below proves that chat text is DOM-selectable and copiable via the clipboard
+// API — it does NOT prove that the Edit-role accelerators are wired. The
+// accelerator wiring lives in electron/main.ts and must be verified manually
+// (or via main-process assertions, not renderer-driven ones).
+const SAMPLE = 'COPY_ME_PROBE_TEXT this should land in the clipboard';
+
+await win.evaluate((sample) => {
+  window.__agentoryStore.setState({
+    groups: [{ id: 'g1', name: 'G1', collapsed: false, kind: 'normal' }],
+    sessions: [{ id: 's1', name: 's', state: 'idle', cwd: 'C:/x', model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code' }],
+    activeId: 's1',
+    messagesBySession: {
+      s1: [{ kind: 'assistant', id: 'a1', text: sample }]
+    }
+  });
+}, SAMPLE);
+await win.waitForTimeout(300);
+
+// Click into the chat area so focus is on the renderer (not sidebar).
+const target = win.getByText('COPY_ME_PROBE_TEXT', { exact: false }).first();
+await target.waitFor({ state: 'visible', timeout: 3000 });
+await target.click();
+
+// Ctrl+A via the app's accelerator path — this is what real users hit.
+await win.keyboard.press('Control+a');
+await win.waitForTimeout(100);
+
+const sel = await win.evaluate(() => window.getSelection()?.toString() ?? '');
+if (!sel.includes('COPY_ME_PROBE_TEXT')) {
+  await app.close();
+  fail(`Ctrl+A did not select chat text (selection=${JSON.stringify(sel.slice(0, 80))})`);
+}
+
+// Ctrl+C via accelerator.
+await win.keyboard.press('Control+c');
+await win.waitForTimeout(150);
+const clip = await win.evaluate(() => navigator.clipboard.readText().catch((e) => `ERR:${e.message}`));
+if (!clip.includes('COPY_ME_PROBE_TEXT')) {
+  await app.close();
+  fail(`clipboard missing sample after Ctrl+C (clip=${JSON.stringify(clip.slice(0, 80))})`);
+}
+
+console.log('\n[probe-e2e-chat-copy] OK');
+console.log('  Ctrl+A selects chat, Ctrl+C copies to clipboard');
+await app.close();


### PR DESCRIPTION
## Summary
- Chat content felt "not copyable" (user: 右边窗口的内容现在是不可复制的).
- Root cause: we nulled the application menu to hide File/Edit/View, which on Windows/Linux also removes the built-in Edit-role accelerators (Ctrl+C/V/X/A/Z).
- Fix: install a minimal Edit-only app menu so accelerators register, keep the bar hidden via autoHideMenuBar + setMenuBarVisibility(false). Also wire a right-click context menu with Cut/Copy/Paste/Select All, enabled contextually via editFlags.
- macOS keeps Electron's default menu (already handles this).

## Test plan
- [x] \`npm run typecheck\` / \`npm run lint\`
- [x] \`node scripts/probe-e2e-chat-copy.mjs\` — sanity check that chat text is DOM-selectable + copiable (note in the probe explains why this doesn't validate accelerators)
- [ ] Manual: right-click assistant output → Copy item appears and copies; Ctrl+A / Ctrl+C work in-app; menu bar stays hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)