### PR TITLE
fix(input): 'Ask anything…' placeholder for empty sessions

### DIFF
--- a/scripts/probe-e2e-input-placeholder.mjs
+++ b/scripts/probe-e2e-input-placeholder.mjs
@@ -1,0 +1,52 @@
+// Empty session -> placeholder is "Ask anything…" (not "Reply…").
+// With messages -> placeholder becomes "Reply…".
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function fail(msg) {
+  console.error(`\n[probe-e2e-input-placeholder] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const app = await electron.launch({ args: ['.'], cwd: root, env: { ...process.env, NODE_ENV: 'development' } });
+const win = await app.firstWindow();
+await win.waitForLoadState('domcontentloaded');
+await win.waitForFunction(() => !!window.__agentoryStore, null, { timeout: 10000 });
+
+await win.evaluate(() => {
+  window.__agentoryStore.setState({
+    groups: [{ id: 'g1', name: 'G1', collapsed: false, kind: 'normal' }],
+    sessions: [{ id: 's1', name: 's', state: 'idle', cwd: 'C:/x', model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code' }],
+    activeId: 's1',
+    messagesBySession: {}
+  });
+});
+await win.waitForTimeout(300);
+
+const ta = win.locator('textarea');
+await ta.waitFor({ state: 'visible', timeout: 5000 });
+const emptyPlaceholder = await ta.getAttribute('placeholder');
+if (emptyPlaceholder !== 'Ask anything…') {
+  await app.close();
+  fail(`empty-session placeholder should be "Ask anything…", got ${JSON.stringify(emptyPlaceholder)}`);
+}
+
+await win.evaluate(() => {
+  window.__agentoryStore.setState({
+    messagesBySession: { s1: [{ kind: 'user', id: 'u1', text: 'hi' }] }
+  });
+});
+await win.waitForTimeout(200);
+const replyPlaceholder = await ta.getAttribute('placeholder');
+if (replyPlaceholder !== 'Reply…') {
+  await app.close();
+  fail(`with-messages placeholder should be "Reply…", got ${JSON.stringify(replyPlaceholder)}`);
+}
+
+console.log('\n[probe-e2e-input-placeholder] OK');
+console.log('  empty: "Ask anything…"  with-messages: "Reply…"');
+await app.close();

--- a/scripts/probe-e2e-sidebar-align.mjs
+++ b/scripts/probe-e2e-sidebar-align.mjs
@@ -1,0 +1,62 @@
+// Measure sidebar vs chat-panel top/bottom alignment. Expectation: the two
+// column top edges and bottom edges should match within 1px. Before the fix
+// the sidebar is flush to window (top=0, bottom=vh) while <main> has my-2
+// (~8px gap top and bottom), so the two columns don't line up visually.
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function fail(msg) {
+  console.error(`\n[probe-e2e-sidebar-align] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const app = await electron.launch({
+  args: ['.'],
+  cwd: root,
+  env: { ...process.env, NODE_ENV: 'development' }
+});
+
+const win = await app.firstWindow();
+await win.waitForLoadState('domcontentloaded');
+// The empty ("No sessions yet") main panel exhibits the same my-2 asymmetry
+// as the populated one — no need to seed the store here.
+await win.waitForFunction(() => !!document.querySelector('main') && !!document.querySelector('aside'), null, { timeout: 10000 });
+await win.waitForTimeout(200);
+
+const geo = await win.evaluate(() => {
+  const aside = document.querySelector('aside');
+  const main = document.querySelector('main');
+  if (!aside || !main) return null;
+  const a = aside.getBoundingClientRect();
+  const m = main.getBoundingClientRect();
+  return {
+    aside: { top: a.top, bottom: a.bottom, left: a.left, right: a.right },
+    main: { top: m.top, bottom: m.bottom, left: m.left, right: m.right },
+    vh: window.innerHeight
+  };
+});
+if (!geo) { await app.close(); fail('no aside or main element'); }
+
+const topDelta = Math.abs(geo.aside.top - geo.main.top);
+const botDelta = Math.abs(geo.aside.bottom - geo.main.bottom);
+const tolerance = 1;
+
+console.log('  aside top/bot:', geo.aside.top.toFixed(1), geo.aside.bottom.toFixed(1));
+console.log('  main  top/bot:', geo.main.top.toFixed(1), geo.main.bottom.toFixed(1));
+console.log('  vh =', geo.vh);
+
+if (topDelta > tolerance) {
+  await app.close();
+  fail(`top edges misaligned: aside=${geo.aside.top.toFixed(1)} main=${geo.main.top.toFixed(1)} delta=${topDelta.toFixed(1)}`);
+}
+if (botDelta > tolerance) {
+  await app.close();
+  fail(`bottom edges misaligned: aside=${geo.aside.bottom.toFixed(1)} main=${geo.main.bottom.toFixed(1)} delta=${botDelta.toFixed(1)}`);
+}
+
+console.log('\n[probe-e2e-sidebar-align] OK');
+await app.close();

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -19,6 +19,7 @@ export function InputBar({ sessionId }: { sessionId: string }) {
   const session = useStore((s) => s.sessions.find((x) => x.id === sessionId));
   const started = useStore((s) => !!s.startedSessions[sessionId]);
   const running = useStore((s) => !!s.runningSessions[sessionId]);
+  const hasMessages = useStore((s) => (s.messagesBySession[sessionId]?.length ?? 0) > 0);
   const permission = useStore((s) => s.permission);
   const model = useStore((s) => s.model);
   const appendBlocks = useStore((s) => s.appendBlocks);
@@ -110,7 +111,7 @@ export function InputBar({ sessionId }: { sessionId: string }) {
           onChange={(e) => update(e.target.value)}
           onKeyDown={onKeyDown}
           rows={2}
-          placeholder={running ? 'Running… (input disabled)' : 'Reply…'}
+          placeholder={running ? 'Running… (input disabled)' : hasMessages ? 'Reply…' : 'Ask anything…'}
           disabled={running}
           className={cn(
             'block w-full resize-none px-3 pt-2 pb-7 text-base leading-[22px]',


### PR DESCRIPTION
## Summary
- 'Reply…' implies something to reply to; for a fresh session with no messages the textarea now shows 'Ask anything…'.
- Switches to 'Reply…' once the session has at least one message block.

## Test plan
- [x] typecheck / lint clean
- [x] `scripts/probe-e2e-input-placeholder.mjs` passes (both branches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)