### PR TITLE
feat(no-sessions): two matching CTA buttons on first open

### DIFF
--- a/scripts/probe-e2e-no-sessions-landing.mjs
+++ b/scripts/probe-e2e-no-sessions-landing.mjs
@@ -1,0 +1,49 @@
+// When there are zero sessions, the main panel should render exactly two
+// CTA buttons with identical variant/size/width (secondary / md / w-44).
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function fail(msg) {
+  console.error(`\n[probe-e2e-no-sessions-landing] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const app = await electron.launch({ args: ['.'], cwd: root, env: { ...process.env, NODE_ENV: 'development' } });
+const win = await app.firstWindow();
+await win.waitForLoadState('domcontentloaded');
+await win.waitForFunction(() => !!window.__agentoryStore, null, { timeout: 10000 });
+
+await win.evaluate(() => {
+  window.__agentoryStore.setState({ sessions: [], activeId: undefined });
+});
+await win.waitForTimeout(300);
+
+const main = win.locator('main');
+const newBtn = main.getByRole('button', { name: /^New Session$/ });
+const importBtn = main.getByRole('button', { name: /^Import Session$/ });
+await newBtn.waitFor({ state: 'visible', timeout: 5000 });
+await importBtn.waitFor({ state: 'visible', timeout: 5000 });
+
+const geom = await Promise.all([newBtn.boundingBox(), importBtn.boundingBox()]);
+const [a, b] = geom;
+if (!a || !b) { await app.close(); fail('button box missing'); }
+if (Math.abs(a.width - b.width) > 0.5) {
+  await app.close();
+  fail(`button widths differ: new=${a.width.toFixed(1)} import=${b.width.toFixed(1)}`);
+}
+if (Math.abs(a.height - b.height) > 0.5) {
+  await app.close();
+  fail(`button heights differ: new=${a.height.toFixed(1)} import=${b.height.toFixed(1)}`);
+}
+
+// The old "No sessions yet" / "Create a session to start …" copy must be gone.
+const oldCopy = await win.getByText(/No sessions yet|Create a session to start|Import from Claude Code/i).count();
+if (oldCopy > 0) { await app.close(); fail('legacy no-sessions copy still present'); }
+
+console.log('\n[probe-e2e-no-sessions-landing] OK');
+console.log(`  both buttons ${a.width.toFixed(1)}×${a.height.toFixed(1)}`);
+await app.close();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useMemo } from 'react';
+import { Plus, Download } from 'lucide-react';
 import { TooltipProvider } from './components/ui/Tooltip';
 import { ToastProvider, useToast } from './components/ui/Toast';
+import { Button } from './components/ui/Button';
 import { Sidebar } from './components/Sidebar';
 import { ChatStream } from './components/ChatStream';
 import { InputBar } from './components/InputBar';
@@ -113,25 +115,25 @@ export default function App() {
               onMoveSession={moveSession}
             />
             <main className="flex-1 flex items-center justify-center my-2 mr-2 ml-0 rounded-lg bg-bg-panel border border-border-subtle surface-card">
-              <div className="flex flex-col items-center gap-3 text-center px-6">
-                <div className="font-mono text-sm text-fg-secondary">No sessions yet</div>
-                <div className="font-mono text-xs text-fg-tertiary max-w-[28ch]">
-                  Create a session to start a Claude Code agent in a working directory.
-                </div>
-                <button
-                  type="button"
+              <div className="flex items-center gap-3">
+                <Button
+                  variant="secondary"
+                  size="md"
                   onClick={() => createSession(null)}
-                  className="mt-1 inline-flex items-center gap-1.5 h-7 px-3 rounded-sm font-mono text-xs text-fg-primary bg-bg-hover hover:bg-bg-active border border-border-subtle outline-none focus-visible:ring-1 focus-visible:ring-border-strong transition-colors duration-120 ease-out"
+                  className="w-44 justify-center"
                 >
-                  + New session
-                </button>
-                <button
-                  type="button"
+                  <Plus size={14} className="stroke-[2]" />
+                  <span>New Session</span>
+                </Button>
+                <Button
+                  variant="secondary"
+                  size="md"
                   onClick={() => setImportOpen(true)}
-                  className="inline-flex items-center gap-1.5 h-7 px-3 rounded-sm font-mono text-xs text-fg-secondary hover:text-fg-primary hover:bg-bg-hover border border-border-subtle outline-none focus-visible:ring-1 focus-visible:ring-border-strong transition-colors duration-120 ease-out"
+                  className="w-44 justify-center"
                 >
-                  Import from Claude Code…
-                </button>
+                  <Download size={14} className="stroke-[2]" />
+                  <span>Import Session</span>
+                </Button>
               </div>
             </main>
           </div>


### PR DESCRIPTION
## Summary
- First-open (zero sessions) right panel: drop the explanatory paragraph, show only 'New Session' and 'Import Session'.
- Both buttons now share the same variant/size/width (secondary · md · w-44) instead of two different hand-rolled styles.

## Test plan
- [x] typecheck clean
- [x] probe `scripts/probe-e2e-no-sessions-landing.mjs` — both buttons measure identically, legacy copy gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)