### PR TITLE
feat: self-draw titlebar replacing native window frame

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -101,8 +101,8 @@ function createWindow() {
     // not via Mica/transparency. The user explicitly does not want to see
     // the desktop through the window.
     backgroundColor: '#0B0B0C',
-    titleBarStyle: 'default',
-    frame: true,
+    titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'hidden',
+    frame: process.platform === 'darwin',
     autoHideMenuBar: true,
     webPreferences: {
       contextIsolation: true,
@@ -122,6 +122,10 @@ function createWindow() {
 
   installContextMenu(win);
   sessions.bindSender(win.webContents);
+
+  const emitMax = () => win.webContents.send('window:maximizedChanged', win.isMaximized());
+  win.on('maximize', emitMax);
+  win.on('unmaximize', emitMax);
 }
 
 app.whenReady().then(() => {
@@ -142,6 +146,23 @@ app.whenReady().then(() => {
     });
     if (res.canceled || res.filePaths.length === 0) return null;
     return res.filePaths[0];
+  });
+
+  ipcMain.handle('window:minimize', (e) => {
+    BrowserWindow.fromWebContents(e.sender)?.minimize();
+  });
+  ipcMain.handle('window:toggleMaximize', (e) => {
+    const win = BrowserWindow.fromWebContents(e.sender);
+    if (!win) return false;
+    if (win.isMaximized()) win.unmaximize();
+    else win.maximize();
+    return win.isMaximized();
+  });
+  ipcMain.handle('window:close', (e) => {
+    BrowserWindow.fromWebContents(e.sender)?.close();
+  });
+  ipcMain.handle('window:isMaximized', (e) => {
+    return BrowserWindow.fromWebContents(e.sender)?.isMaximized() ?? false;
   });
 
   ipcMain.handle(

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -86,6 +86,19 @@ const api = {
     const wrap = (_e: IpcRendererEvent, payload: UpdateStatus) => handler(payload);
     ipcRenderer.on('updates:status', wrap);
     return () => ipcRenderer.removeListener('updates:status', wrap);
+  },
+
+  window: {
+    minimize: (): Promise<void> => ipcRenderer.invoke('window:minimize'),
+    toggleMaximize: (): Promise<boolean> => ipcRenderer.invoke('window:toggleMaximize'),
+    close: (): Promise<void> => ipcRenderer.invoke('window:close'),
+    isMaximized: (): Promise<boolean> => ipcRenderer.invoke('window:isMaximized'),
+    onMaximizedChanged: (handler: (max: boolean) => void): (() => void) => {
+      const wrap = (_e: IpcRendererEvent, max: boolean) => handler(max);
+      ipcRenderer.on('window:maximizedChanged', wrap);
+      return () => ipcRenderer.removeListener('window:maximizedChanged', wrap);
+    },
+    platform: process.platform
   }
 };
 

--- a/scripts/probe-e2e-titlebar.mjs
+++ b/scripts/probe-e2e-titlebar.mjs
@@ -1,0 +1,45 @@
+// Verifies: app launches with no native frame, TitleBar is mounted, and on
+// win/linux the three self-drawn window controls are present and clickable.
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function fail(msg) {
+  console.error(`\n[probe-e2e-titlebar] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const app = await electron.launch({ args: ['.'], cwd: root, env: { ...process.env, NODE_ENV: 'development' } });
+const win = await app.firstWindow();
+await win.waitForLoadState('domcontentloaded');
+await win.waitForFunction(() => !!window.__agentoryStore, null, { timeout: 10000 });
+
+const platform = await app.evaluate(({ app: a }) => a ? process.platform : process.platform);
+
+// TitleBar element: h-8 at top of app, has drag region style.
+const titleBar = await win.evaluate(() => {
+  const el = document.querySelector('[style*="app-region"]');
+  if (!el) return null;
+  const r = el.getBoundingClientRect();
+  return { height: r.height, top: r.top };
+});
+if (!titleBar) { await app.close(); fail('TitleBar not mounted'); }
+if (Math.abs(titleBar.height - 32) > 1) { await app.close(); fail(`TitleBar height expected 32, got ${titleBar.height}`); }
+if (titleBar.top !== 0) { await app.close(); fail(`TitleBar not at top, got top=${titleBar.top}`); }
+
+if (platform !== 'darwin') {
+  for (const name of ['Minimize', 'Close']) {
+    const btn = win.getByRole('button', { name });
+    await btn.waitFor({ state: 'visible', timeout: 3000 });
+  }
+  // Maximize OR Restore depending on current state.
+  const maxBtn = win.getByRole('button', { name: /Maximize|Restore/ });
+  await maxBtn.waitFor({ state: 'visible', timeout: 3000 });
+}
+
+console.log('\n[probe-e2e-titlebar] OK');
+console.log(`  platform=${platform} titleBarHeight=${titleBar.height}`);
+await app.close();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { StatusBar } from './components/StatusBar';
 import { SettingsDialog } from './components/SettingsDialog';
 import { CommandPalette } from './components/CommandPalette';
 import { ImportDialog } from './components/ImportDialog';
+import { TitleBar } from './components/TitleBar';
 import { useStore } from './stores/store';
 import { setPersistErrorHandler } from './stores/persist';
 import { subscribeAgentEvents, setBackgroundWaitingHandler } from './agent/lifecycle';
@@ -102,7 +103,9 @@ export default function App() {
         <ToastProvider>
           <PersistErrorBridge />
           <BackgroundWaitingBridge />
-          <div className="flex h-full w-full bg-bg-app text-fg-primary">
+          <div className="flex h-full w-full flex-col bg-bg-app text-fg-primary">
+            <TitleBar />
+            <div className="flex flex-1 min-h-0">
             <Sidebar
               onCreateSession={(cwd) => createSession(cwd)}
               onOpenSettings={() => setSettingsOpen(true)}
@@ -136,6 +139,7 @@ export default function App() {
                 </Button>
               </div>
             </main>
+            </div>
           </div>
           <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} />
           <ImportDialog open={importOpen} onOpenChange={setImportOpen} />
@@ -158,7 +162,9 @@ export default function App() {
       <ToastProvider>
         <PersistErrorBridge />
         <BackgroundWaitingBridge />
-        <div className="flex h-full w-full bg-bg-app text-fg-primary">
+        <div className="flex h-full w-full flex-col bg-bg-app text-fg-primary">
+          <TitleBar />
+          <div className="flex flex-1 min-h-0">
           <Sidebar
             onCreateSession={(cwd) => createSession(cwd)}
             onOpenSettings={() => setSettingsOpen(true)}
@@ -193,6 +199,7 @@ export default function App() {
               <span>Enter send · Shift+Enter newline</span>
             </div>
           </main>
+          </div>
         </div>
         <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} />
         <ImportDialog open={importOpen} onOpenChange={setImportOpen} />

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from 'react';
+import { Minus, Square, Copy, X } from 'lucide-react';
+import { cn } from '../lib/cn';
+
+// macOS uses `hiddenInset` — traffic lights are rendered by the OS.
+// We reserve space for them via a left spacer. On win32/linux we self-draw
+// the three controls on the right to match the Electron frameless window.
+export function TitleBar() {
+  const api = window.agentory;
+  const platform = api?.window.platform ?? 'win32';
+  const isMac = platform === 'darwin';
+  const [isMax, setIsMax] = useState(false);
+
+  useEffect(() => {
+    if (!api) return;
+    api.window.isMaximized().then(setIsMax);
+    return api.window.onMaximizedChanged(setIsMax);
+  }, [api]);
+
+  return (
+    <div
+      className="relative flex shrink-0 select-none items-center bg-bg-app"
+      style={{ WebkitAppRegion: 'drag', height: 32 } as React.CSSProperties}
+    >
+      {isMac ? <div className="w-20" /> : <div className="w-2" />}
+      <div className="flex-1" />
+      {!isMac && (
+        <div
+          className="flex h-full items-stretch"
+          style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+        >
+          <TitleButton onClick={() => api?.window.minimize()} aria-label="Minimize">
+            <Minus size={12} className="stroke-[1.75]" />
+          </TitleButton>
+          <TitleButton onClick={() => api?.window.toggleMaximize()} aria-label={isMax ? 'Restore' : 'Maximize'}>
+            {isMax ? <Copy size={11} className="stroke-[1.75] -scale-x-100" /> : <Square size={11} className="stroke-[1.75]" />}
+          </TitleButton>
+          <TitleButton onClick={() => api?.window.close()} aria-label="Close" danger>
+            <X size={13} className="stroke-[1.75]" />
+          </TitleButton>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TitleButton({
+  children,
+  onClick,
+  danger,
+  ...rest
+}: React.ButtonHTMLAttributes<HTMLButtonElement> & { danger?: boolean }) {
+  return (
+    <button
+      {...rest}
+      onClick={onClick}
+      className={cn(
+        'flex h-full items-center justify-center text-fg-secondary',
+        'transition-colors duration-100 ease-out',
+        'hover:text-fg-primary',
+        danger ? 'hover:bg-[oklch(0.55_0.22_27)] hover:text-white' : 'hover:bg-bg-hover',
+        'focus:outline-none focus-visible:bg-bg-hover'
+      )}
+      style={{ width: 46 }}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -62,6 +62,15 @@ declare global {
       updatesDownload: () => Promise<{ ok: true } | { ok: false; reason: string }>;
       updatesInstall: () => Promise<{ ok: true } | { ok: false; reason: string }>;
       onUpdateStatus: (handler: (s: UpdateStatus) => void) => () => void;
+
+      window: {
+        minimize: () => Promise<void>;
+        toggleMaximize: () => Promise<boolean>;
+        close: () => Promise<void>;
+        isMaximized: () => Promise<boolean>;
+        onMaximizedChanged: (handler: (max: boolean) => void) => () => void;
+        platform: 'aix' | 'android' | 'darwin' | 'freebsd' | 'haiku' | 'linux' | 'openbsd' | 'sunos' | 'win32' | 'cygwin' | 'netbsd';
+      };
     };
   }
 }


### PR DESCRIPTION
## Summary
- Frameless BrowserWindow on win/linux; `hiddenInset` on darwin to keep OS traffic lights.
- New IPC channels `window:minimize|toggleMaximize|close|isMaximized` + `maximizedChanged` event.
- `<TitleBar />` mounted above sidebar+main row; 32px drag region, self-drawn window controls on non-mac.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (pre-existing warning only)
- [x] `npm test` — 47 pass
- [x] `node scripts/probe-e2e-titlebar.mjs` — OK (platform=win32, height=32)
- [ ] Manual: drag the bar to move window; min/max/restore/close all work

🤖 Generated with [Claude Code](https://claude.com/claude-code)