### PR TITLE
fix: default new session cwd to most-recent project

### DIFF
--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -98,7 +98,7 @@ export const useStore = create<State & Actions>((set, get) => ({
   focusGroup: (id) => set({ focusedGroupId: id }),
 
   createSession: (cwd) => {
-    const { sessions, groups, focusedGroupId, activeId, model } = get();
+    const { sessions, groups, focusedGroupId, activeId, model, recentProjects } = get();
     const isUsable = (gid: string | null | undefined) => {
       if (!gid) return false;
       const g = groups.find((x) => x.id === gid);
@@ -111,11 +111,12 @@ export const useStore = create<State & Actions>((set, get) => ({
       ? activeGroupId!
       : firstUsableGroupId(groups);
     const id = nextId('s');
+    const defaultCwd = recentProjects[0]?.path ?? '~';
     const newSession: Session = {
       id,
       name: 'New session',
       state: 'idle',
-      cwd: cwd ?? '~',
+      cwd: cwd ?? defaultCwd,
       model,
       groupId: targetGroupId,
       agentType: 'claude-code'

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -57,6 +57,23 @@ describe('store: createSession', () => {
     expect(useStore.getState().sessions[0].groupId).toBe(gid);
     expect(useStore.getState().sessions[1].groupId).toBe(gid);
   });
+
+  it('defaults cwd to most-recent project when caller passes null', () => {
+    useStore.getState().pushRecentProject('C:/Users/me/projects/alpha');
+    useStore.getState().createSession(null);
+    expect(useStore.getState().sessions[0].cwd).toBe('C:/Users/me/projects/alpha');
+  });
+
+  it('falls back to ~ when recentProjects is empty', () => {
+    useStore.getState().createSession(null);
+    expect(useStore.getState().sessions[0].cwd).toBe('~');
+  });
+
+  it('explicit cwd argument wins over recentProjects default', () => {
+    useStore.getState().pushRecentProject('C:/Users/me/projects/alpha');
+    useStore.getState().createSession('C:/other/path');
+    expect(useStore.getState().sessions[0].cwd).toBe('C:/other/path');
+  });
 });
 
 describe('store: deleteSession', () => {


### PR DESCRIPTION
## Summary
- `createSession(null)` now defaults `cwd` to `recentProjects[0]?.path` instead of the literal `~` — you actually land in a real directory.
- Falls back to `~` only when the MRU list is empty (first launch).
- Explicit cwd argument still wins (sidebar drag/drop, \"new session in …\").

## Test plan
- [x] `npm test` — 50 pass (3 new cases)
- [x] `npm run typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)