### PR TITLE
feat: import dialog groups transcripts by date bucket

### DIFF
--- a/src/components/ImportDialog.tsx
+++ b/src/components/ImportDialog.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { ChevronRight, ChevronDown } from 'lucide-react';
 import { Dialog, DialogContent, DialogBody, DialogFooter, DialogClose } from './ui/Dialog';
 import { Button } from './ui/Button';
 import { useStore } from '../stores/store';
+import { bucketize, type DateBucketKey } from '../utils/date-buckets';
 
 type Scannable = {
   sessionId: string;
@@ -27,6 +29,7 @@ export function ImportDialog({ open, onOpenChange }: Props) {
 
   const [items, setItems] = useState<Scannable[]>([]);
   const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [collapsed, setCollapsed] = useState<Set<DateBucketKey>>(new Set());
   const [loading, setLoading] = useState(false);
   const [importing, setImporting] = useState(false);
 
@@ -36,22 +39,19 @@ export function ImportDialog({ open, onOpenChange }: Props) {
     if (!api) return;
     setLoading(true);
     setSelected(new Set());
+    setCollapsed(new Set());
     api
       .scanImportable()
       .then((rows) => {
         const known = new Set(sessions.map((s) => s.id));
-        // Hide sessions whose CLI uuid we've already imported (we tag imported
-        // sessions with their resume id via name; a stricter dedup needs a
-        // dedicated field — leaving the simple "skip already-known store id"
-        // for now since the store id and CLI uuid are different namespaces).
         setItems(rows.filter((r) => !known.has(r.sessionId)));
       })
       .catch(() => setItems([]))
       .finally(() => setLoading(false));
-    // sessions intentionally excluded from deps — we want a one-shot snapshot
-    // when the dialog opens, not a re-scan as the user creates sessions.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
+
+  const buckets = useMemo(() => bucketize(items), [items]);
 
   const toggle = (id: string) => {
     setSelected((prev) => {
@@ -67,6 +67,25 @@ export function ImportDialog({ open, onOpenChange }: Props) {
     else setSelected(new Set(items.map((i) => i.sessionId)));
   };
 
+  const toggleBucket = (ids: string[]) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      const allSelected = ids.every((id) => next.has(id));
+      if (allSelected) ids.forEach((id) => next.delete(id));
+      else ids.forEach((id) => next.add(id));
+      return next;
+    });
+  };
+
+  const toggleCollapse = (key: DateBucketKey) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
   const doImport = async () => {
     const api = window.agentory;
     if (!api || selected.size === 0) return;
@@ -79,13 +98,12 @@ export function ImportDialog({ open, onOpenChange }: Props) {
       }
       const picked = items.filter((i) => selected.has(i.sessionId));
       for (const it of picked) {
-        const newId = importSession({
+        importSession({
           name: it.title,
           cwd: it.cwd,
           groupId,
           resumeSessionId: it.sessionId
         });
-        void newId;
       }
       onOpenChange(false);
     } finally {
@@ -119,32 +137,70 @@ export function ImportDialog({ open, onOpenChange }: Props) {
                 </button>
                 <span className="font-mono text-xs text-fg-tertiary">{selected.size} selected</span>
               </div>
-              <ul className="max-h-[420px] overflow-y-auto rounded-sm border border-border-subtle divide-y divide-border-subtle">
-                {items.map((it) => {
-                  const checked = selected.has(it.sessionId);
+              <div className="max-h-[420px] overflow-y-auto rounded-sm border border-border-subtle">
+                {buckets.map((bucket, bIdx) => {
+                  const ids = bucket.items.map((i) => i.sessionId);
+                  const pickedCount = ids.filter((id) => selected.has(id)).length;
+                  const allPicked = pickedCount === ids.length;
+                  const isCollapsed = collapsed.has(bucket.key);
                   return (
-                    <li
-                      key={it.sessionId}
-                      onClick={() => toggle(it.sessionId)}
-                      className="flex items-start gap-2 px-3 py-2 hover:bg-bg-hover cursor-pointer"
+                    <div
+                      key={bucket.key}
+                      className={bIdx > 0 ? 'border-t border-border-subtle' : ''}
                     >
-                      <input
-                        type="checkbox"
-                        checked={checked}
-                        onChange={() => toggle(it.sessionId)}
-                        onClick={(e) => e.stopPropagation()}
-                        className="mt-0.5 accent-fg-primary"
-                      />
-                      <div className="min-w-0 flex-1">
-                        <div className="font-mono text-xs text-fg-primary truncate">{it.title}</div>
-                        <div className="font-mono text-[11px] text-fg-tertiary truncate">
-                          {it.cwd} · {new Date(it.mtime).toLocaleString()}
-                        </div>
+                      <div className="flex items-center gap-2 px-2 py-1.5 bg-bg-hover/30">
+                        <button
+                          type="button"
+                          onClick={() => toggleCollapse(bucket.key)}
+                          className="flex items-center justify-center w-4 h-4 text-fg-tertiary hover:text-fg-secondary"
+                          aria-label={isCollapsed ? 'Expand' : 'Collapse'}
+                        >
+                          {isCollapsed ? <ChevronRight size={12} /> : <ChevronDown size={12} />}
+                        </button>
+                        <span className="font-mono text-xs text-fg-secondary flex-1">
+                          {bucket.label} · {bucket.items.length}
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => toggleBucket(ids)}
+                          className="font-mono text-xs text-fg-tertiary hover:text-fg-secondary"
+                        >
+                          {allPicked ? 'Deselect group' : 'Select group'}
+                          {pickedCount > 0 && !allPicked && ` (${pickedCount}/${ids.length})`}
+                        </button>
                       </div>
-                    </li>
+                      {!isCollapsed && (
+                        <ul className="divide-y divide-border-subtle">
+                          {bucket.items.map((it) => {
+                            const checked = selected.has(it.sessionId);
+                            return (
+                              <li
+                                key={it.sessionId}
+                                onClick={() => toggle(it.sessionId)}
+                                className="flex items-start gap-2 px-3 py-2 hover:bg-bg-hover cursor-pointer"
+                              >
+                                <input
+                                  type="checkbox"
+                                  checked={checked}
+                                  onChange={() => toggle(it.sessionId)}
+                                  onClick={(e) => e.stopPropagation()}
+                                  className="mt-0.5 accent-fg-primary"
+                                />
+                                <div className="min-w-0 flex-1">
+                                  <div className="font-mono text-xs text-fg-primary truncate">{it.title}</div>
+                                  <div className="font-mono text-[11px] text-fg-tertiary truncate">
+                                    {it.cwd} · {new Date(it.mtime).toLocaleString()}
+                                  </div>
+                                </div>
+                              </li>
+                            );
+                          })}
+                        </ul>
+                      )}
+                    </div>
                   );
                 })}
-              </ul>
+              </div>
             </>
           )}
         </DialogBody>

--- a/src/utils/date-buckets.ts
+++ b/src/utils/date-buckets.ts
@@ -1,0 +1,49 @@
+export type DateBucketKey = 'today' | 'yesterday' | 'week' | 'month' | 'older';
+
+export const BUCKET_LABEL: Record<DateBucketKey, string> = {
+  today: 'Today',
+  yesterday: 'Yesterday',
+  week: 'This week',
+  month: 'This month',
+  older: 'Older'
+};
+
+const BUCKET_ORDER: DateBucketKey[] = ['today', 'yesterday', 'week', 'month', 'older'];
+
+export function bucketForDate(ts: number, now: number = Date.now()): DateBucketKey {
+  const start = (d: Date) => {
+    const c = new Date(d);
+    c.setHours(0, 0, 0, 0);
+    return c.getTime();
+  };
+  const nowDate = new Date(now);
+  const startToday = start(nowDate);
+  const startYesterday = startToday - 24 * 60 * 60 * 1000;
+  const startWeek = startToday - 6 * 24 * 60 * 60 * 1000; // last 7 days incl. today
+  const startMonth = startToday - 29 * 24 * 60 * 60 * 1000; // last 30 days
+
+  if (ts >= startToday) return 'today';
+  if (ts >= startYesterday) return 'yesterday';
+  if (ts >= startWeek) return 'week';
+  if (ts >= startMonth) return 'month';
+  return 'older';
+}
+
+export function bucketize<T extends { mtime: number }>(
+  items: T[],
+  now: number = Date.now()
+): Array<{ key: DateBucketKey; label: string; items: T[] }> {
+  const map = new Map<DateBucketKey, T[]>();
+  for (const k of BUCKET_ORDER) map.set(k, []);
+  for (const it of items) {
+    map.get(bucketForDate(it.mtime, now))!.push(it);
+  }
+  for (const k of BUCKET_ORDER) {
+    map.get(k)!.sort((a, b) => b.mtime - a.mtime);
+  }
+  return BUCKET_ORDER.filter((k) => map.get(k)!.length > 0).map((k) => ({
+    key: k,
+    label: BUCKET_LABEL[k],
+    items: map.get(k)!
+  }));
+}

--- a/tests/date-buckets.test.ts
+++ b/tests/date-buckets.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { bucketForDate, bucketize } from '../src/utils/date-buckets';
+
+// Reference "now": 2026-04-21 14:00 local.
+const NOW = new Date(2026, 3, 21, 14, 0, 0).getTime();
+const DAY = 24 * 60 * 60 * 1000;
+
+describe('bucketForDate', () => {
+  it('today: same calendar day', () => {
+    expect(bucketForDate(new Date(2026, 3, 21, 0, 1).getTime(), NOW)).toBe('today');
+    expect(bucketForDate(new Date(2026, 3, 21, 13, 59).getTime(), NOW)).toBe('today');
+  });
+
+  it('yesterday: previous calendar day', () => {
+    expect(bucketForDate(new Date(2026, 3, 20, 23, 59).getTime(), NOW)).toBe('yesterday');
+    expect(bucketForDate(new Date(2026, 3, 20, 0, 0).getTime(), NOW)).toBe('yesterday');
+  });
+
+  it('week: 2–6 days ago', () => {
+    expect(bucketForDate(NOW - 2 * DAY, NOW)).toBe('week');
+    expect(bucketForDate(NOW - 6 * DAY, NOW)).toBe('week');
+  });
+
+  it('month: 7–29 days ago', () => {
+    expect(bucketForDate(NOW - 7 * DAY, NOW)).toBe('month');
+    expect(bucketForDate(NOW - 29 * DAY, NOW)).toBe('month');
+  });
+
+  it('older: 30+ days ago', () => {
+    expect(bucketForDate(NOW - 30 * DAY, NOW)).toBe('older');
+    expect(bucketForDate(new Date(2020, 0, 1).getTime(), NOW)).toBe('older');
+  });
+});
+
+describe('bucketize', () => {
+  it('groups items and skips empty buckets', () => {
+    const items = [
+      { id: 'a', mtime: new Date(2026, 3, 21, 10, 0).getTime() }, // today
+      { id: 'b', mtime: new Date(2026, 3, 20, 10, 0).getTime() }, // yesterday
+      { id: 'c', mtime: new Date(2020, 0, 1).getTime() } // older
+    ];
+    const buckets = bucketize(items, NOW);
+    expect(buckets.map((b) => b.key)).toEqual(['today', 'yesterday', 'older']);
+    expect(buckets[0].items.map((i) => i.id)).toEqual(['a']);
+    expect(buckets[2].items.map((i) => i.id)).toEqual(['c']);
+  });
+
+  it('sorts within bucket by mtime desc', () => {
+    const items = [
+      { id: 'a', mtime: new Date(2026, 3, 21, 8, 0).getTime() },
+      { id: 'b', mtime: new Date(2026, 3, 21, 12, 0).getTime() },
+      { id: 'c', mtime: new Date(2026, 3, 21, 2, 0).getTime() }
+    ];
+    const buckets = bucketize(items, NOW);
+    expect(buckets[0].items.map((i) => i.id)).toEqual(['b', 'a', 'c']);
+  });
+
+  it('returns empty list when no items', () => {
+    expect(bucketize([], NOW)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Import Session dialog now groups transcripts into Today / Yesterday / This week / This month / Older.
- Each bucket has its own collapse toggle + 'Select group' button.
- Overall 'Select all' and per-row checkboxes still work.
- Empty buckets hidden so a small import list stays compact.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 58 pass (8 new cases for date-buckets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)