### PR TITLE
feat: first-run tutorial on empty initial launch

### DIFF
--- a/scripts/probe-e2e-no-sessions-landing.mjs
+++ b/scripts/probe-e2e-no-sessions-landing.mjs
@@ -18,7 +18,7 @@ await win.waitForLoadState('domcontentloaded');
 await win.waitForFunction(() => !!window.__agentoryStore, null, { timeout: 10000 });
 
 await win.evaluate(() => {
-  window.__agentoryStore.setState({ sessions: [], activeId: undefined });
+  window.__agentoryStore.setState({ sessions: [], activeId: undefined, tutorialSeen: true });
 });
 await win.waitForTimeout(300);
 

--- a/scripts/probe-e2e-tutorial.mjs
+++ b/scripts/probe-e2e-tutorial.mjs
@@ -1,0 +1,64 @@
+// Verify the first-run tutorial:
+// - Shows when sessions=[] and tutorialSeen=false
+// - Has Step 1/4 indicator and Skip button
+// - Next advances; Done/Skip dismisses (markTutorialSeen → state flips)
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function fail(msg) {
+  console.error(`\n[probe-e2e-tutorial] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const app = await electron.launch({ args: ['.'], cwd: root, env: { ...process.env, NODE_ENV: 'development' } });
+const win = await app.firstWindow();
+await win.waitForLoadState('domcontentloaded');
+await win.waitForFunction(() => !!window.__agentoryStore, null, { timeout: 10000 });
+
+await win.evaluate(() => {
+  window.__agentoryStore.setState({ sessions: [], activeId: undefined, tutorialSeen: false });
+});
+await win.waitForTimeout(200);
+
+// Step 1 visible.
+const stepCounter = win.locator('text=/Step 1 of 4/i').first();
+await stepCounter.waitFor({ state: 'visible', timeout: 5000 });
+await win.locator('text=/A workbench for AI sessions/i').first().waitFor({ state: 'visible', timeout: 3000 });
+
+// Skip button present.
+const skipBtn = win.getByRole('button', { name: /^Skip$/ });
+await skipBtn.waitFor({ state: 'visible', timeout: 3000 });
+
+// Click Next 3 times to reach Step 4.
+const nextBtn = win.getByRole('button', { name: /^Next$/ });
+await nextBtn.click();
+await win.waitForTimeout(150);
+await nextBtn.click();
+await win.waitForTimeout(150);
+await nextBtn.click();
+await win.waitForTimeout(200);
+
+await win.locator('text=/Step 4 of 4/i').first().waitFor({ state: 'visible', timeout: 3000 });
+await win.locator('text=/Ready when you are/i').first().waitFor({ state: 'visible', timeout: 3000 });
+
+// On last step the inline "New Session" / "Import Session" buttons appear.
+await win.getByRole('button', { name: /^New Session$/ }).first().waitFor({ state: 'visible', timeout: 3000 });
+await win.getByRole('button', { name: /^Import Session$/ }).first().waitFor({ state: 'visible', timeout: 3000 });
+
+// Click Done — tutorialSeen should flip and the panel should switch to the
+// two big CTA buttons (no more step counter).
+await win.getByRole('button', { name: /^Done$/ }).click();
+await win.waitForTimeout(300);
+
+const seen = await win.evaluate(() => window.__agentoryStore.getState().tutorialSeen);
+if (!seen) { await app.close(); fail('Done did not set tutorialSeen=true'); }
+
+const stillTutorial = await win.locator('text=/Step \\d of 4/i').count();
+if (stillTutorial > 0) { await app.close(); fail('tutorial still rendered after Done'); }
+
+console.log('\n[probe-e2e-tutorial] OK');
+await app.close();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { SettingsDialog } from './components/SettingsDialog';
 import { CommandPalette } from './components/CommandPalette';
 import { ImportDialog } from './components/ImportDialog';
 import { TitleBar } from './components/TitleBar';
+import { Tutorial } from './components/Tutorial';
 import { useStore } from './stores/store';
 import { setPersistErrorHandler } from './stores/persist';
 import { subscribeAgentEvents, setBackgroundWaitingHandler } from './agent/lifecycle';
@@ -40,6 +41,8 @@ export default function App() {
   const toggleSidebar = useStore((s) => s.toggleSidebar);
   const theme = useStore((s) => s.theme);
   const fontSize = useStore((s) => s.fontSize);
+  const tutorialSeen = useStore((s) => s.tutorialSeen);
+  const markTutorialSeen = useStore((s) => s.markTutorialSeen);
 
   useEffect(() => {
     const root = document.documentElement;
@@ -117,27 +120,41 @@ export default function App() {
               sessions={sessions}
               onMoveSession={moveSession}
             />
-            <main className="flex-1 flex items-center justify-center my-2 mr-2 ml-0 rounded-lg bg-bg-panel border border-border-subtle surface-card">
-              <div className="flex items-center gap-3">
-                <Button
-                  variant="secondary"
-                  size="md"
-                  onClick={() => createSession(null)}
-                  className="w-44 justify-center"
-                >
-                  <Plus size={14} className="stroke-[2]" />
-                  <span>New Session</span>
-                </Button>
-                <Button
-                  variant="secondary"
-                  size="md"
-                  onClick={() => setImportOpen(true)}
-                  className="w-44 justify-center"
-                >
-                  <Download size={14} className="stroke-[2]" />
-                  <span>Import Session</span>
-                </Button>
-              </div>
+            <main className="flex-1 flex items-center justify-center my-2 mr-2 ml-0 rounded-lg bg-bg-panel border border-border-subtle surface-card overflow-hidden">
+              {tutorialSeen ? (
+                <div className="flex items-center gap-3">
+                  <Button
+                    variant="secondary"
+                    size="md"
+                    onClick={() => createSession(null)}
+                    className="w-44 justify-center"
+                  >
+                    <Plus size={14} className="stroke-[2]" />
+                    <span>New Session</span>
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    size="md"
+                    onClick={() => setImportOpen(true)}
+                    className="w-44 justify-center"
+                  >
+                    <Download size={14} className="stroke-[2]" />
+                    <span>Import Session</span>
+                  </Button>
+                </div>
+              ) : (
+                <Tutorial
+                  onNewSession={() => {
+                    markTutorialSeen();
+                    createSession(null);
+                  }}
+                  onImport={() => {
+                    markTutorialSeen();
+                    setImportOpen(true);
+                  }}
+                  onSkip={markTutorialSeen}
+                />
+              )}
             </main>
             </div>
           </div>

--- a/src/components/Tutorial.tsx
+++ b/src/components/Tutorial.tsx
@@ -1,0 +1,261 @@
+import React, { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Plus, Download, Layers, FolderTree, MessageSquare, ArrowRight, ArrowLeft, Check } from 'lucide-react';
+import { Button } from './ui/Button';
+import { cn } from '../lib/cn';
+
+type Step = {
+  key: string;
+  title: string;
+  body: string;
+  visual: React.ReactNode;
+};
+
+type Props = {
+  onNewSession: () => void;
+  onImport: () => void;
+  onSkip: () => void;
+};
+
+export function Tutorial({ onNewSession, onImport, onSkip }: Props) {
+  const [stepIdx, setStepIdx] = useState(0);
+  const steps: Step[] = [
+    {
+      key: 'welcome',
+      title: 'A workbench for AI sessions',
+      body: 'Agentory turns Claude Code transcripts into something you can navigate. Think of it as a desktop client for the same agent — same power, less terminal.',
+      visual: <WelcomeVisual />
+    },
+    {
+      key: 'sessions',
+      title: 'Run many sessions in parallel',
+      body: 'Each session is its own agent thread with its own working directory. Switch between them like tabs — the agents keep working in the background.',
+      visual: <SessionsVisual />
+    },
+    {
+      key: 'groups',
+      title: 'Organize work by task, not by repo',
+      body: 'Group sessions across repositories. A real task usually spans more than one project — Agentory lets you keep them together.',
+      visual: <GroupsVisual />
+    },
+    {
+      key: 'start',
+      title: 'Ready when you are',
+      body: 'Create a fresh session, or import what you already have from the Claude Code CLI.',
+      visual: <StartVisual />
+    }
+  ];
+
+  const step = steps[stepIdx];
+  const isLast = stepIdx === steps.length - 1;
+  const isFirst = stepIdx === 0;
+
+  return (
+    <div className="relative flex h-full w-full flex-col">
+      <button
+        type="button"
+        onClick={onSkip}
+        className="absolute right-4 top-3 z-10 font-mono text-xs text-fg-tertiary hover:text-fg-secondary transition-colors"
+      >
+        Skip
+      </button>
+      <div className="flex-1 flex items-center justify-center px-12">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center max-w-4xl w-full">
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={`copy-${step.key}`}
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -8 }}
+              transition={{ duration: 0.25, ease: [0.32, 0.72, 0, 1] }}
+              className="space-y-4"
+            >
+              <div className="font-mono text-[11px] uppercase tracking-wider text-fg-tertiary">
+                Step {stepIdx + 1} of {steps.length}
+              </div>
+              <h1 className="text-2xl font-semibold text-fg-primary leading-tight">{step.title}</h1>
+              <p className="text-sm text-fg-secondary leading-relaxed">{step.body}</p>
+              {isLast && (
+                <div className="flex items-center gap-3 pt-4">
+                  <Button variant="primary" size="md" onClick={onNewSession} className="w-44 justify-center">
+                    <Plus size={14} className="stroke-[2]" />
+                    <span>New Session</span>
+                  </Button>
+                  <Button variant="secondary" size="md" onClick={onImport} className="w-44 justify-center">
+                    <Download size={14} className="stroke-[2]" />
+                    <span>Import Session</span>
+                  </Button>
+                </div>
+              )}
+            </motion.div>
+          </AnimatePresence>
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={`visual-${step.key}`}
+              initial={{ opacity: 0, scale: 0.96 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.96 }}
+              transition={{ duration: 0.3, ease: [0.32, 0.72, 0, 1] }}
+              className="flex items-center justify-center"
+            >
+              {step.visual}
+            </motion.div>
+          </AnimatePresence>
+        </div>
+      </div>
+      <div className="shrink-0 px-12 py-5 flex items-center justify-between">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setStepIdx((i) => Math.max(0, i - 1))}
+          disabled={isFirst}
+          className={cn(isFirst && 'invisible')}
+        >
+          <ArrowLeft size={12} />
+          <span>Back</span>
+        </Button>
+        <div className="flex items-center gap-1.5">
+          {steps.map((s, i) => (
+            <button
+              key={s.key}
+              type="button"
+              onClick={() => setStepIdx(i)}
+              aria-label={`Go to step ${i + 1}`}
+              className={cn(
+                'h-1.5 rounded-full transition-all duration-200',
+                i === stepIdx ? 'w-6 bg-fg-primary' : 'w-1.5 bg-border-strong hover:bg-fg-tertiary'
+              )}
+            />
+          ))}
+        </div>
+        {isLast ? (
+          <Button variant="ghost" size="sm" onClick={onSkip}>
+            <Check size={12} />
+            <span>Done</span>
+          </Button>
+        ) : (
+          <Button variant="ghost" size="sm" onClick={() => setStepIdx((i) => Math.min(steps.length - 1, i + 1))}>
+            <span>Next</span>
+            <ArrowRight size={12} />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function VisualCard({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="relative w-full max-w-sm aspect-[4/3] rounded-xl border border-border-subtle bg-bg-elevated/60 backdrop-blur p-4 shadow-[0_24px_48px_-12px_oklch(0_0_0_/_0.5)]">
+      {children}
+    </div>
+  );
+}
+
+function WelcomeVisual() {
+  return (
+    <VisualCard>
+      <div className="flex h-full items-center justify-center">
+        <motion.div
+          initial={{ scale: 0.9, opacity: 0 }}
+          animate={{ scale: 1, opacity: 1 }}
+          transition={{ delay: 0.15, duration: 0.4, ease: [0.32, 0.72, 0, 1] }}
+          className="flex h-16 w-16 items-center justify-center rounded-2xl bg-gradient-to-br from-[oklch(0.72_0.14_215)] to-[oklch(0.55_0.18_265)] shadow-lg"
+        >
+          <MessageSquare size={28} className="text-white stroke-[1.5]" />
+        </motion.div>
+      </div>
+    </VisualCard>
+  );
+}
+
+function SessionsVisual() {
+  const rows = [
+    { name: 'Refactor auth middleware', state: 'running' as const },
+    { name: 'Investigate flaky test', state: 'waiting' as const },
+    { name: 'Sketch landing page copy', state: 'idle' as const }
+  ];
+  const dotColor = (s: typeof rows[number]['state']) =>
+    s === 'running' ? 'bg-[oklch(0.78_0.16_145)]' : s === 'waiting' ? 'bg-[oklch(0.78_0.16_70)]' : 'bg-fg-tertiary';
+  return (
+    <VisualCard>
+      <div className="space-y-2">
+        {rows.map((r, i) => (
+          <motion.div
+            key={r.name}
+            initial={{ opacity: 0, x: -12 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ delay: 0.1 + i * 0.07, duration: 0.3 }}
+            className="flex items-center gap-2 rounded-md bg-bg-app/60 px-3 py-2 border border-border-subtle"
+          >
+            <span className={cn('h-1.5 w-1.5 rounded-full', dotColor(r.state))} />
+            <span className="font-mono text-xs text-fg-secondary truncate">{r.name}</span>
+          </motion.div>
+        ))}
+      </div>
+    </VisualCard>
+  );
+}
+
+function GroupsVisual() {
+  const groups = [
+    { name: 'Q2 launch', sessions: ['frontend', 'api', 'infra'] },
+    { name: 'Bug triage', sessions: ['issue #4821', 'issue #4830'] }
+  ];
+  return (
+    <VisualCard>
+      <div className="space-y-3">
+        {groups.map((g, i) => (
+          <motion.div
+            key={g.name}
+            initial={{ opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.1 + i * 0.1, duration: 0.3 }}
+          >
+            <div className="flex items-center gap-2 mb-1.5">
+              <FolderTree size={11} className="text-fg-tertiary" />
+              <span className="font-mono text-[11px] uppercase tracking-wider text-fg-tertiary">
+                {g.name}
+              </span>
+            </div>
+            <div className="ml-4 space-y-1">
+              {g.sessions.map((s) => (
+                <div key={s} className="flex items-center gap-2 rounded-sm px-2 py-1 bg-bg-app/60 border border-border-subtle">
+                  <Layers size={10} className="text-fg-tertiary" />
+                  <span className="font-mono text-[11px] text-fg-secondary">{s}</span>
+                </div>
+              ))}
+            </div>
+          </motion.div>
+        ))}
+      </div>
+    </VisualCard>
+  );
+}
+
+function StartVisual() {
+  return (
+    <VisualCard>
+      <div className="flex h-full items-center justify-center gap-3">
+        <motion.div
+          initial={{ opacity: 0, x: -8 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ delay: 0.1, duration: 0.3 }}
+          className="flex flex-col items-center gap-2 p-4 rounded-lg bg-bg-app/60 border border-border-subtle w-28"
+        >
+          <Plus size={20} className="text-fg-secondary" />
+          <span className="font-mono text-[11px] text-fg-tertiary">New</span>
+        </motion.div>
+        <motion.div
+          initial={{ opacity: 0, x: 8 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ delay: 0.2, duration: 0.3 }}
+          className="flex flex-col items-center gap-2 p-4 rounded-lg bg-bg-app/60 border border-border-subtle w-28"
+        >
+          <Download size={20} className="text-fg-secondary" />
+          <span className="font-mono text-[11px] text-fg-tertiary">Import</span>
+        </motion.div>
+      </div>
+    </VisualCard>
+  );
+}

--- a/src/stores/persist.ts
+++ b/src/stores/persist.ts
@@ -15,6 +15,7 @@ export interface PersistedState {
   theme?: Theme;
   fontSize?: FontSize;
   recentProjects?: RecentProject[];
+  tutorialSeen?: boolean;
 }
 
 export async function loadPersisted(): Promise<PersistedState | null> {

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -20,6 +20,7 @@ type State = {
   sidebarCollapsed: boolean;
   theme: Theme;
   fontSize: FontSize;
+  tutorialSeen: boolean;
   messagesBySession: Record<string, MessageBlock[]>;
   startedSessions: Record<string, true>;
   runningSessions: Record<string, true>;
@@ -41,6 +42,7 @@ type Actions = {
   toggleSidebar: () => void;
   setTheme: (theme: Theme) => void;
   setFontSize: (size: FontSize) => void;
+  markTutorialSeen: () => void;
 
   createGroup: (name?: string) => string;
   renameGroup: (id: string, name: string) => void;
@@ -81,6 +83,7 @@ export const useStore = create<State & Actions>((set, get) => ({
   sidebarCollapsed: false,
   theme: 'system',
   fontSize: 'md',
+  tutorialSeen: false,
   messagesBySession: {},
   startedSessions: {},
   runningSessions: {},
@@ -240,6 +243,7 @@ export const useStore = create<State & Actions>((set, get) => ({
   toggleSidebar: () => set((s) => ({ sidebarCollapsed: !s.sidebarCollapsed })),
   setTheme: (theme) => set({ theme }),
   setFontSize: (fontSize) => set({ fontSize }),
+  markTutorialSeen: () => set({ tutorialSeen: true }),
 
   createGroup: (name) => {
     const id = nextId('g');
@@ -380,7 +384,8 @@ export async function hydrateStore(): Promise<void> {
       sidebarCollapsed: persisted.sidebarCollapsed ?? false,
       theme: persisted.theme ?? 'system',
       fontSize: persisted.fontSize ?? 'md',
-      recentProjects: persisted.recentProjects ?? []
+      recentProjects: persisted.recentProjects ?? [],
+      tutorialSeen: persisted.tutorialSeen ?? false
     });
   }
   hydrated = true;
@@ -396,7 +401,8 @@ export async function hydrateStore(): Promise<void> {
       sidebarCollapsed: s.sidebarCollapsed,
       theme: s.theme,
       fontSize: s.fontSize,
-      recentProjects: s.recentProjects
+      recentProjects: s.recentProjects,
+      tutorialSeen: s.tutorialSeen
     };
     schedulePersist(snapshot);
   });


### PR DESCRIPTION
## Summary
- 4-step walk-through (Welcome → Sessions → Groups → Get Started) shown when there are no sessions and the user has not yet dismissed it.
- Persisted \`tutorialSeen\` flag — once skipped or completed, the regular two-button landing returns and never shows the tutorial again.
- Bonus: gives the cold-start IPC scan time to settle behind a useful first impression.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 58 pass
- [x] probe-e2e-tutorial — step nav + Done flow OK
- [x] probe-e2e-no-sessions-landing — still passes after seeding tutorialSeen=true

🤖 Generated with [Claude Code](https://claude.com/claude-code)