### PR TITLE
feat: ExitPlanMode plan card with Approve/Reject

### DIFF
--- a/src/agent/lifecycle.ts
+++ b/src/agent/lifecycle.ts
@@ -1,5 +1,6 @@
 import { useStore } from '../stores/store';
 import { sdkMessageToTranslation } from './sdk-to-blocks';
+import type { MessageBlock } from '../types';
 
 let installed = false;
 
@@ -20,6 +21,26 @@ function describePermission(toolName: string, input: Record<string, unknown>): s
   };
   const detail = pick('command', 'file_path', 'path', 'pattern', 'url') || '';
   return detail ? `${toolName}: ${detail}` : toolName;
+}
+
+export function permissionRequestToWaitingBlock(req: {
+  requestId: string;
+  toolName: string;
+  input: Record<string, unknown>;
+}): MessageBlock {
+  const isPlan = req.toolName === 'ExitPlanMode';
+  const planText = isPlan && typeof req.input.plan === 'string' ? (req.input.plan as string) : undefined;
+  const prompt = isPlan
+    ? 'Approve this plan to start executing it.'
+    : describePermission(req.toolName, req.input);
+  return {
+    kind: 'waiting',
+    id: `wait-${req.requestId}`,
+    prompt,
+    intent: isPlan ? 'plan' : 'permission',
+    requestId: req.requestId,
+    plan: planText
+  };
 }
 
 export function subscribeAgentEvents(): void {
@@ -51,22 +72,15 @@ export function subscribeAgentEvents(): void {
 
   api.onAgentPermissionRequest((req) => {
     const store = useStore.getState();
-    const prompt = describePermission(req.toolName, req.input);
-    store.appendBlocks(req.sessionId, [
-      {
-        kind: 'waiting',
-        id: `wait-${req.requestId}`,
-        prompt,
-        intent: 'permission',
-        requestId: req.requestId
-      }
-    ]);
+    const block = permissionRequestToWaitingBlock(req);
+    store.appendBlocks(req.sessionId, [block]);
     if (req.sessionId !== store.activeId) {
       const session = store.sessions.find((s) => s.id === req.sessionId);
+      const isPlan = block.kind === 'waiting' && block.intent === 'plan';
       backgroundWaitingHandler({
         sessionId: req.sessionId,
         sessionName: session?.name ?? 'Background session',
-        prompt
+        prompt: isPlan ? 'Plan ready for review' : (block.kind === 'waiting' ? block.prompt : '')
       });
     }
   });

--- a/src/components/ChatStream.tsx
+++ b/src/components/ChatStream.tsx
@@ -207,6 +207,48 @@ function WaitingBlock({ prompt, onAllow, onDeny }: { prompt: string; onAllow?: (
   );
 }
 
+function PlanBlock({ plan, onAllow, onDeny }: { plan: string; onAllow?: () => void; onDeny?: () => void }) {
+  const approveRef = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    const t = window.setTimeout(() => approveRef.current?.focus(), 150);
+    return () => window.clearTimeout(t);
+  }, []);
+
+  return (
+    <motion.div
+      role="alertdialog"
+      aria-modal="false"
+      aria-labelledby="plan-title"
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.22, ease: [0.32, 0.72, 0, 1] }}
+      className="relative my-2 rounded-md border border-state-waiting/40 bg-state-waiting/[0.06] surface-highlight surface-elevated pl-4 pr-4 py-3"
+    >
+      <span
+        aria-hidden
+        className="absolute left-0 top-0 bottom-0 w-[2px] bg-state-waiting rounded-l-md"
+      />
+      <div id="plan-title" className="flex items-center gap-2 text-base text-fg-primary font-semibold">
+        <StateGlyph state="waiting" size="sm" />
+        <span>Plan ready for review</span>
+      </div>
+      <div className="mt-2 max-h-[420px] overflow-y-auto rounded-sm border border-border-subtle bg-bg-app/40 px-3 py-2">
+        <div className="prose prose-invert prose-sm max-w-none font-mono text-sm text-fg-secondary [&_h1]:text-fg-primary [&_h2]:text-fg-primary [&_h3]:text-fg-primary [&_code]:text-fg-primary [&_pre]:bg-bg-elevated [&_pre]:rounded-sm">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{plan}</ReactMarkdown>
+        </div>
+      </div>
+      <div className="mt-3 flex justify-end gap-2">
+        <Button variant="secondary" size="md" onClick={onDeny}>
+          Reject
+        </Button>
+        <Button ref={approveRef} variant="primary" size="md" onClick={onAllow}>
+          Approve plan
+        </Button>
+      </div>
+    </motion.div>
+  );
+}
+
 function ErrorBlock({ text }: { text: string }) {
   return (
     <div
@@ -231,6 +273,15 @@ function renderBlock(b: MessageBlock, activeId: string, resolvePermission: (sid:
     case 'tool':
       return <ToolBlock name={b.name} brief={b.brief} result={b.result} isError={b.isError} />;
     case 'waiting':
+      if (b.intent === 'plan' && b.plan) {
+        return (
+          <PlanBlock
+            plan={b.plan}
+            onAllow={b.requestId ? () => resolvePermission(activeId, b.requestId!, 'allow') : undefined}
+            onDeny={b.requestId ? () => resolvePermission(activeId, b.requestId!, 'deny') : undefined}
+          />
+        );
+      }
       return (
         <WaitingBlock
           prompt={b.prompt}

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,5 +28,5 @@ export type MessageBlock =
   | { kind: 'user'; id: string; text: string }
   | { kind: 'assistant'; id: string; text: string }
   | { kind: 'tool'; id: string; name: string; brief: string; expanded: boolean; toolUseId?: string; result?: string; isError?: boolean }
-  | { kind: 'waiting'; id: string; prompt: string; intent: 'permission' | 'plan' | 'question'; requestId?: string }
+  | { kind: 'waiting'; id: string; prompt: string; intent: 'permission' | 'plan' | 'question'; requestId?: string; plan?: string }
   | { kind: 'error'; id: string; text: string };

--- a/tests/lifecycle.test.ts
+++ b/tests/lifecycle.test.ts
@@ -131,4 +131,44 @@ describe('lifecycle: background waiting bridge', () => {
     expect(h.store.getState().runningSessions[sid]).toBeUndefined();
     expect(h.store.getState().messagesBySession[sid]).toBeUndefined();
   });
+
+  it('ExitPlanMode permission becomes a plan-intent waiting block with the plan markdown', async () => {
+    const h = await freshHarness();
+    h.store.getState().createSession('~/p');
+    const sid = h.store.getState().activeId;
+
+    const planMd = '# Plan\n1. Refactor auth\n2. Add tests';
+    h.permHandler({
+      sessionId: sid,
+      requestId: 'req-plan',
+      toolName: 'ExitPlanMode',
+      input: { plan: planMd }
+    });
+
+    const blocks = h.store.getState().messagesBySession[sid];
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      kind: 'waiting',
+      intent: 'plan',
+      requestId: 'req-plan',
+      plan: planMd
+    });
+  });
+
+  it('non-ExitPlanMode tools still produce a permission-intent block (no plan field)', async () => {
+    const h = await freshHarness();
+    h.store.getState().createSession('~/p');
+    const sid = h.store.getState().activeId;
+
+    h.permHandler({
+      sessionId: sid,
+      requestId: 'req-bash',
+      toolName: 'Bash',
+      input: { command: 'ls' }
+    });
+
+    const block = h.store.getState().messagesBySession[sid][0];
+    expect(block).toMatchObject({ kind: 'waiting', intent: 'permission' });
+    expect((block as { plan?: string }).plan).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- ExitPlanMode permission requests now render as a dedicated plan card with the proposed plan in a scrollable Markdown panel and \`Approve plan\` / \`Reject\` buttons.
- Extracted \`permissionRequestToWaitingBlock()\` from \`lifecycle.ts\` so the plan-detection logic can be unit-tested without IPC mocking.
- Background waiting toast for plan requests reads \"Plan ready for review\" instead of the generic \`ToolName: detail\` summary.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 60 pass (2 new lifecycle cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)