### PR TITLE
feat: AskUserQuestion interactive option list

### DIFF
--- a/src/agent/lifecycle.ts
+++ b/src/agent/lifecycle.ts
@@ -1,6 +1,6 @@
 import { useStore } from '../stores/store';
 import { sdkMessageToTranslation } from './sdk-to-blocks';
-import type { MessageBlock } from '../types';
+import type { MessageBlock, QuestionSpec } from '../types';
 
 let installed = false;
 
@@ -28,6 +28,17 @@ export function permissionRequestToWaitingBlock(req: {
   toolName: string;
   input: Record<string, unknown>;
 }): MessageBlock {
+  if (req.toolName === 'AskUserQuestion') {
+    const questions = parseQuestions(req.input);
+    if (questions.length > 0) {
+      return {
+        kind: 'question',
+        id: `q-${req.requestId}`,
+        requestId: req.requestId,
+        questions
+      };
+    }
+  }
   const isPlan = req.toolName === 'ExitPlanMode';
   const planText = isPlan && typeof req.input.plan === 'string' ? (req.input.plan as string) : undefined;
   const prompt = isPlan
@@ -41,6 +52,35 @@ export function permissionRequestToWaitingBlock(req: {
     requestId: req.requestId,
     plan: planText
   };
+}
+
+function parseQuestions(input: Record<string, unknown>): QuestionSpec[] {
+  const raw = input.questions;
+  if (!Array.isArray(raw)) return [];
+  const out: QuestionSpec[] = [];
+  for (const q of raw) {
+    if (!q || typeof q !== 'object') continue;
+    const obj = q as Record<string, unknown>;
+    const question = typeof obj.question === 'string' ? obj.question : '';
+    if (!question) continue;
+    const options = Array.isArray(obj.options)
+      ? obj.options
+          .filter((o): o is Record<string, unknown> => !!o && typeof o === 'object')
+          .map((o) => ({
+            label: typeof o.label === 'string' ? o.label : '',
+            description: typeof o.description === 'string' ? o.description : undefined
+          }))
+          .filter((o) => o.label)
+      : [];
+    if (options.length === 0) continue;
+    out.push({
+      question,
+      header: typeof obj.header === 'string' ? obj.header : undefined,
+      multiSelect: obj.multiSelect === true,
+      options
+    });
+  }
+  return out;
 }
 
 export function subscribeAgentEvents(): void {
@@ -76,11 +116,16 @@ export function subscribeAgentEvents(): void {
     store.appendBlocks(req.sessionId, [block]);
     if (req.sessionId !== store.activeId) {
       const session = store.sessions.find((s) => s.id === req.sessionId);
-      const isPlan = block.kind === 'waiting' && block.intent === 'plan';
+      let prompt = '';
+      if (block.kind === 'question') {
+        prompt = block.questions[0]?.question ?? 'Question awaiting answer';
+      } else if (block.kind === 'waiting') {
+        prompt = block.intent === 'plan' ? 'Plan ready for review' : block.prompt;
+      }
       backgroundWaitingHandler({
         sessionId: req.sessionId,
         sessionName: session?.name ?? 'Background session',
-        prompt: isPlan ? 'Plan ready for review' : (block.kind === 'waiting' ? block.prompt : '')
+        prompt
       });
     }
   });

--- a/src/components/ChatStream.tsx
+++ b/src/components/ChatStream.tsx
@@ -264,6 +264,123 @@ function ErrorBlock({ text }: { text: string }) {
   );
 }
 
+function QuestionBlock({
+  questions,
+  onSubmit
+}: {
+  questions: import('../types').QuestionSpec[];
+  onSubmit: (answersText: string) => void;
+}) {
+  const [picks, setPicks] = useState<Array<Set<number>>>(() => questions.map(() => new Set()));
+  const submitRef = useRef<HTMLButtonElement>(null);
+  const [submitted, setSubmitted] = useState(false);
+
+  const togglePick = (qIdx: number, optIdx: number, multi: boolean) => {
+    if (submitted) return;
+    setPicks((prev) => {
+      const next = prev.slice();
+      const set = new Set(next[qIdx]);
+      if (multi) {
+        if (set.has(optIdx)) set.delete(optIdx);
+        else set.add(optIdx);
+      } else {
+        set.clear();
+        set.add(optIdx);
+      }
+      next[qIdx] = set;
+      return next;
+    });
+  };
+
+  const allAnswered = questions.every((_, i) => picks[i] && picks[i].size > 0);
+
+  const submit = () => {
+    if (!allAnswered || submitted) return;
+    const lines: string[] = [];
+    questions.forEach((q, i) => {
+      const labels = Array.from(picks[i]).map((j) => q.options[j]?.label).filter(Boolean);
+      lines.push(`Q: ${q.question}`);
+      lines.push(`A: ${labels.join(', ')}`);
+    });
+    setSubmitted(true);
+    onSubmit(lines.join('\n'));
+  };
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.22, ease: [0.32, 0.72, 0, 1] }}
+      className="relative my-2 rounded-md border border-state-waiting/40 bg-state-waiting/[0.06] surface-highlight surface-elevated pl-4 pr-4 py-3"
+    >
+      <span aria-hidden className="absolute left-0 top-0 bottom-0 w-[2px] bg-state-waiting rounded-l-md" />
+      <div className="flex items-center gap-2 text-base text-fg-primary font-semibold">
+        <StateGlyph state="waiting" size="sm" />
+        <span>Question awaiting answer</span>
+      </div>
+      <div className="mt-3 space-y-4">
+        {questions.map((q, qi) => (
+          <div key={qi} className="space-y-2">
+            {q.header && (
+              <div className="font-mono text-[11px] uppercase tracking-wider text-fg-tertiary">{q.header}</div>
+            )}
+            <div className="text-sm text-fg-primary">{q.question}</div>
+            <div className="space-y-1">
+              {q.options.map((opt, oi) => {
+                const selected = picks[qi]?.has(oi) ?? false;
+                return (
+                  <button
+                    key={oi}
+                    type="button"
+                    disabled={submitted}
+                    onClick={() => togglePick(qi, oi, !!q.multiSelect)}
+                    className={
+                      'w-full text-left px-3 py-2 rounded-sm border transition-colors duration-100 ' +
+                      (selected
+                        ? 'border-state-waiting/70 bg-state-waiting/10'
+                        : 'border-border-subtle hover:bg-bg-hover hover:border-border-default') +
+                      (submitted ? ' cursor-not-allowed opacity-70' : '')
+                    }
+                  >
+                    <div className="flex items-start gap-2">
+                      <span
+                        aria-hidden
+                        className={
+                          'mt-1 h-3 w-3 shrink-0 rounded-' +
+                          (q.multiSelect ? 'sm' : 'full') +
+                          ' border ' +
+                          (selected ? 'bg-state-waiting border-state-waiting' : 'border-border-strong')
+                        }
+                      />
+                      <div className="min-w-0 flex-1">
+                        <div className="text-sm text-fg-primary">{opt.label}</div>
+                        {opt.description && (
+                          <div className="text-xs text-fg-tertiary mt-0.5">{opt.description}</div>
+                        )}
+                      </div>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="mt-3 flex justify-end">
+        <Button
+          ref={submitRef}
+          variant="primary"
+          size="md"
+          disabled={!allAnswered || submitted}
+          onClick={submit}
+        >
+          {submitted ? 'Submitted' : 'Submit answer'}
+        </Button>
+      </div>
+    </motion.div>
+  );
+}
+
 function renderBlock(b: MessageBlock, activeId: string, resolvePermission: (sid: string, rid: string, d: 'allow' | 'deny') => void) {
   switch (b.kind) {
     case 'user':
@@ -287,6 +404,22 @@ function renderBlock(b: MessageBlock, activeId: string, resolvePermission: (sid:
           prompt={b.prompt}
           onAllow={b.requestId ? () => resolvePermission(activeId, b.requestId!, 'allow') : undefined}
           onDeny={b.requestId ? () => resolvePermission(activeId, b.requestId!, 'deny') : undefined}
+        />
+      );
+    case 'question':
+      return (
+        <QuestionBlock
+          questions={b.questions}
+          onSubmit={(answersText) => {
+            const api = window.agentory;
+            if (!api) return;
+            // Soft-cancel the SDK's pending tool call, then deliver the user's
+            // answers as a plain message. The agent reads the next user turn
+            // instead of a tool result — slightly lossy compared to a real
+            // tool result, but works without main-process plumbing for now.
+            void api.agentResolvePermission(activeId, b.requestId, 'deny');
+            void api.agentSend(activeId, answersText);
+          }}
         />
       );
     case 'error':

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,9 +24,22 @@ export interface Group {
   kind: 'normal' | 'archive' | 'deleted';
 }
 
+export interface QuestionOption {
+  label: string;
+  description?: string;
+}
+
+export interface QuestionSpec {
+  question: string;
+  header?: string;
+  multiSelect?: boolean;
+  options: QuestionOption[];
+}
+
 export type MessageBlock =
   | { kind: 'user'; id: string; text: string }
   | { kind: 'assistant'; id: string; text: string }
   | { kind: 'tool'; id: string; name: string; brief: string; expanded: boolean; toolUseId?: string; result?: string; isError?: boolean }
   | { kind: 'waiting'; id: string; prompt: string; intent: 'permission' | 'plan' | 'question'; requestId?: string; plan?: string }
+  | { kind: 'question'; id: string; requestId: string; questions: QuestionSpec[] }
   | { kind: 'error'; id: string; text: string };

--- a/tests/lifecycle.test.ts
+++ b/tests/lifecycle.test.ts
@@ -171,4 +171,56 @@ describe('lifecycle: background waiting bridge', () => {
     expect(block).toMatchObject({ kind: 'waiting', intent: 'permission' });
     expect((block as { plan?: string }).plan).toBeUndefined();
   });
+
+  it('AskUserQuestion becomes an interactive question block with parsed options', async () => {
+    const h = await freshHarness();
+    h.store.getState().createSession('~/q');
+    const sid = h.store.getState().activeId;
+
+    h.permHandler({
+      sessionId: sid,
+      requestId: 'req-q',
+      toolName: 'AskUserQuestion',
+      input: {
+        questions: [
+          {
+            header: 'Auth',
+            question: 'Which auth method?',
+            multiSelect: false,
+            options: [
+              { label: 'JWT', description: 'Stateless tokens' },
+              { label: 'Session', description: 'Server-side state' }
+            ]
+          }
+        ]
+      }
+    });
+
+    const block = h.store.getState().messagesBySession[sid][0] as {
+      kind: string;
+      requestId?: string;
+      questions?: Array<{ question: string; options: Array<{ label: string }> }>;
+    };
+    expect(block.kind).toBe('question');
+    expect(block.requestId).toBe('req-q');
+    expect(block.questions).toHaveLength(1);
+    expect(block.questions![0].question).toBe('Which auth method?');
+    expect(block.questions![0].options.map((o) => o.label)).toEqual(['JWT', 'Session']);
+  });
+
+  it('AskUserQuestion with malformed input falls back to a generic permission block', async () => {
+    const h = await freshHarness();
+    h.store.getState().createSession('~/q2');
+    const sid = h.store.getState().activeId;
+
+    h.permHandler({
+      sessionId: sid,
+      requestId: 'req-bad',
+      toolName: 'AskUserQuestion',
+      input: { questions: 'not an array' }
+    });
+
+    const block = h.store.getState().messagesBySession[sid][0];
+    expect(block).toMatchObject({ kind: 'waiting', intent: 'permission' });
+  });
 });


### PR DESCRIPTION
## Summary
- AskUserQuestion permission requests now render as an interactive option list (single- or multi-select per the question spec).
- Submitting answers sends them as a regular user reply and denies the underlying tool call — no main-process changes required for v1.
- Malformed payloads gracefully fall back to the generic permission card.

## Trade-off / follow-up
- The agent receives the answer as a user message rather than a synthetic tool result. Good enough for the UI to escape the \"Permission requested: AskUserQuestion\" dead-end; a follow-up can wire up a real tool-result injection in the main process.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 62 pass (2 new lifecycle cases for parse + fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)