### PR TITLE
feat: status banners for compact_boundary / api_retry / rate_limit

### DIFF
--- a/src/agent/sdk-to-blocks.ts
+++ b/src/agent/sdk-to-blocks.ts
@@ -17,16 +17,83 @@ const EMPTY: SdkTranslation = { append: [], toolResults: [] };
 export function sdkMessageToTranslation(msg: SDKMessage): SdkTranslation {
   switch (msg.type) {
     case 'assistant':
-      return { append: assistantBlocks(msg), toolResults: [] };
+      return { append: assistantBlocksWithError(msg), toolResults: [] };
     case 'user':
       return { append: [], toolResults: extractToolResults(msg) };
     case 'system':
-      return EMPTY;
+      return { append: systemBlocks(msg), toolResults: [] };
     case 'result':
       return { append: resultBlocks(msg), toolResults: [] };
     default:
       return EMPTY;
   }
+}
+
+function assistantBlocksWithError(msg: any): MessageBlock[] {
+  const out = assistantBlocks(msg);
+  if (msg.error === 'rate_limit') {
+    out.push({
+      kind: 'status',
+      id: `${msg.uuid ?? cryptoRandom()}:rate`,
+      tone: 'warn',
+      title: 'Rate limit hit',
+      detail: 'The API is throttling this account. The next request will queue and retry.'
+    });
+  } else if (typeof msg.error === 'string' && msg.error) {
+    out.push({
+      kind: 'status',
+      id: `${msg.uuid ?? cryptoRandom()}:err`,
+      tone: 'warn',
+      title: errorTitle(msg.error),
+      detail: undefined
+    });
+  }
+  return out;
+}
+
+function errorTitle(code: string): string {
+  switch (code) {
+    case 'authentication_failed': return 'Authentication failed';
+    case 'billing_error': return 'Billing error';
+    case 'rate_limit': return 'Rate limit hit';
+    case 'invalid_request': return 'Invalid request';
+    case 'server_error': return 'Server error';
+    case 'max_output_tokens': return 'Hit max output tokens';
+    default: return 'Assistant error';
+  }
+}
+
+function systemBlocks(msg: any): MessageBlock[] {
+  if (msg.subtype === 'compact_boundary') {
+    const m = msg.compact_metadata ?? {};
+    const detail = m.pre_tokens
+      ? `Compacted ${m.pre_tokens.toLocaleString()} → ${m.post_tokens?.toLocaleString() ?? '?'} tokens` +
+        (m.duration_ms ? ` in ${m.duration_ms}ms` : '')
+      : undefined;
+    return [
+      {
+        kind: 'status',
+        id: msg.uuid ?? cryptoRandom(),
+        tone: 'info',
+        title: m.trigger === 'manual' ? 'Conversation compacted (manual)' : 'Conversation auto-compacted',
+        detail
+      }
+    ];
+  }
+  if (msg.subtype === 'api_retry') {
+    const delay = typeof msg.retry_delay_ms === 'number' ? Math.round(msg.retry_delay_ms / 1000) : '?';
+    const max = msg.max_retries ?? '?';
+    return [
+      {
+        kind: 'status',
+        id: msg.uuid ?? cryptoRandom(),
+        tone: 'warn',
+        title: `Retrying API request (${msg.attempt}/${max})`,
+        detail: `Next attempt in ~${delay}s${msg.error_status ? ` · HTTP ${msg.error_status}` : ''}`
+      }
+    ];
+  }
+  return [];
 }
 
 type AnyContent =

--- a/src/components/ChatStream.tsx
+++ b/src/components/ChatStream.tsx
@@ -249,6 +249,36 @@ function PlanBlock({ plan, onAllow, onDeny }: { plan: string; onAllow?: () => vo
   );
 }
 
+function StatusBanner({ tone, title, detail }: { tone: 'info' | 'warn'; title: string; detail?: string }) {
+  const isWarn = tone === 'warn';
+  return (
+    <div
+      role="status"
+      className={
+        'relative my-1.5 rounded-md border pl-3 pr-3 py-1.5 text-xs ' +
+        (isWarn
+          ? 'border-state-waiting/40 bg-state-waiting/[0.06] text-fg-secondary'
+          : 'border-border-subtle bg-bg-elevated/60 text-fg-tertiary')
+      }
+    >
+      <span
+        aria-hidden
+        className={
+          'absolute left-0 top-0 bottom-0 w-[2px] rounded-l-md ' +
+          (isWarn ? 'bg-state-waiting' : 'bg-border-strong')
+        }
+      />
+      <div className="flex items-baseline gap-2">
+        <span className={'font-mono uppercase tracking-wider text-[10px] ' + (isWarn ? 'text-state-waiting' : 'text-fg-tertiary')}>
+          {isWarn ? 'WARN' : 'INFO'}
+        </span>
+        <span className={isWarn ? 'text-fg-primary' : 'text-fg-secondary'}>{title}</span>
+        {detail && <span className="text-fg-tertiary">— {detail}</span>}
+      </div>
+    </div>
+  );
+}
+
 function ErrorBlock({ text }: { text: string }) {
   return (
     <div
@@ -422,6 +452,8 @@ function renderBlock(b: MessageBlock, activeId: string, resolvePermission: (sid:
           }}
         />
       );
+    case 'status':
+      return <StatusBanner tone={b.tone} title={b.title} detail={b.detail} />;
     case 'error':
       return <ErrorBlock text={b.text} />;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,4 +42,5 @@ export type MessageBlock =
   | { kind: 'tool'; id: string; name: string; brief: string; expanded: boolean; toolUseId?: string; result?: string; isError?: boolean }
   | { kind: 'waiting'; id: string; prompt: string; intent: 'permission' | 'plan' | 'question'; requestId?: string; plan?: string }
   | { kind: 'question'; id: string; requestId: string; questions: QuestionSpec[] }
+  | { kind: 'status'; id: string; tone: 'info' | 'warn'; title: string; detail?: string }
   | { kind: 'error'; id: string; text: string };

--- a/tests/sdk-to-blocks.test.ts
+++ b/tests/sdk-to-blocks.test.ts
@@ -18,10 +18,62 @@ describe('sdkMessageToTranslation', () => {
     expect(out.toolResults).toEqual([]);
   });
 
-  it('drops system messages (init / compact_boundary etc.)', () => {
+  it('drops unknown system subtypes (init etc.)', () => {
     const out = sdkMessageToTranslation(asSdk({ type: 'system', subtype: 'init' }));
     expect(out.append).toEqual([]);
     expect(out.toolResults).toEqual([]);
+  });
+
+  it('compact_boundary system message becomes an info status banner', () => {
+    const out = sdkMessageToTranslation(
+      asSdk({
+        type: 'system',
+        subtype: 'compact_boundary',
+        uuid: 'sys-1',
+        compact_metadata: { trigger: 'auto', pre_tokens: 124000, post_tokens: 18000, duration_ms: 950 }
+      })
+    );
+    expect(out.append).toHaveLength(1);
+    expect(out.append[0]).toMatchObject({ kind: 'status', tone: 'info' });
+    const b = out.append[0] as { title: string; detail?: string };
+    expect(b.title).toMatch(/auto-compacted/i);
+    expect(b.detail).toContain('124,000');
+    expect(b.detail).toContain('18,000');
+  });
+
+  it('api_retry system message becomes a warn status banner with attempt + delay', () => {
+    const out = sdkMessageToTranslation(
+      asSdk({
+        type: 'system',
+        subtype: 'api_retry',
+        uuid: 'sys-2',
+        attempt: 2,
+        max_retries: 5,
+        retry_delay_ms: 4000,
+        error_status: 503,
+        error: 'server_error'
+      })
+    );
+    expect(out.append).toHaveLength(1);
+    const b = out.append[0] as { tone: string; title: string; detail?: string };
+    expect(b.tone).toBe('warn');
+    expect(b.title).toContain('2/5');
+    expect(b.detail).toContain('4s');
+    expect(b.detail).toContain('503');
+  });
+
+  it('assistant message with rate_limit error appends a rate-limit warn banner', () => {
+    const out = sdkMessageToTranslation(
+      asSdk({
+        type: 'assistant',
+        uuid: 'asst-1',
+        message: { id: 'm', content: [{ type: 'text', text: 'partial' }] },
+        error: 'rate_limit'
+      })
+    );
+    // text block + status banner
+    expect(out.append).toHaveLength(2);
+    expect(out.append[1]).toMatchObject({ kind: 'status', tone: 'warn', title: 'Rate limit hit' });
   });
 
   it('drops successful result messages (no noise on completion)', () => {


### PR DESCRIPTION
## Summary
- Surface the three system / assistant signals that previously vanished into the void.
- New compact 'status' block variant rendered as inline INFO/WARN banners between assistant turns.
- Banners stay visually quieter than tool calls / errors so they don't dominate the transcript.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 65 pass (3 new sdk-to-blocks cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)