### PR TITLE
feat: result stats footer (turns / time / tokens / cost)

### DIFF
--- a/src/agent/sdk-to-blocks.ts
+++ b/src/agent/sdk-to-blocks.ts
@@ -159,9 +159,48 @@ function stringifyToolResult(content: unknown): string {
 }
 
 function resultBlocks(msg: any): MessageBlock[] {
-  if (msg.subtype === 'success' || msg.is_error === false) return [];
+  if (msg.subtype === 'success' || msg.is_error === false) {
+    return [resultStatsFooter(msg)];
+  }
   const text = typeof msg.error === 'string' ? msg.error : msg.subtype ?? 'Run failed';
   return [{ kind: 'error', id: msg.uuid ?? cryptoRandom(), text }];
+}
+
+function resultStatsFooter(msg: any): MessageBlock {
+  const parts: string[] = [];
+  if (typeof msg.num_turns === 'number') parts.push(`${msg.num_turns} turn${msg.num_turns === 1 ? '' : 's'}`);
+  if (typeof msg.duration_ms === 'number') parts.push(formatDuration(msg.duration_ms));
+  const usage = msg.usage ?? {};
+  const inTok = (usage.input_tokens ?? 0) + (usage.cache_creation_input_tokens ?? 0) + (usage.cache_read_input_tokens ?? 0);
+  const outTok = usage.output_tokens ?? 0;
+  if (inTok || outTok) {
+    parts.push(`${formatTokens(inTok)} in / ${formatTokens(outTok)} out`);
+  }
+  if (typeof msg.total_cost_usd === 'number' && msg.total_cost_usd > 0) {
+    parts.push(`$${msg.total_cost_usd.toFixed(msg.total_cost_usd < 0.01 ? 4 : 3)}`);
+  }
+  return {
+    kind: 'status',
+    id: msg.uuid ?? cryptoRandom(),
+    tone: 'info',
+    title: 'Done',
+    detail: parts.join(' · ')
+  };
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const s = ms / 1000;
+  if (s < 60) return `${s.toFixed(1)}s`;
+  const m = Math.floor(s / 60);
+  const rem = Math.round(s - m * 60);
+  return `${m}m${rem}s`;
+}
+
+function formatTokens(n: number): string {
+  if (n < 1000) return `${n}`;
+  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}k`;
+  return `${(n / 1_000_000).toFixed(1)}M`;
 }
 
 function briefForTool(name: string, input: unknown): string {

--- a/tests/sdk-to-blocks.test.ts
+++ b/tests/sdk-to-blocks.test.ts
@@ -76,11 +76,38 @@ describe('sdkMessageToTranslation', () => {
     expect(out.append[1]).toMatchObject({ kind: 'status', tone: 'warn', title: 'Rate limit hit' });
   });
 
-  it('drops successful result messages (no noise on completion)', () => {
+  it('successful result emits a stats footer status block', () => {
     const out = sdkMessageToTranslation(
-      asSdk({ type: 'result', subtype: 'success', is_error: false })
+      asSdk({
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        uuid: 'res-1',
+        num_turns: 3,
+        duration_ms: 12500,
+        total_cost_usd: 0.0123,
+        usage: { input_tokens: 4500, output_tokens: 1200, cache_read_input_tokens: 8000 }
+      })
     );
-    expect(out.append).toEqual([]);
+    expect(out.append).toHaveLength(1);
+    const b = out.append[0] as { kind: string; tone: string; title: string; detail?: string };
+    expect(b.kind).toBe('status');
+    expect(b.tone).toBe('info');
+    expect(b.title).toBe('Done');
+    expect(b.detail).toContain('3 turns');
+    expect(b.detail).toContain('12.5s');
+    expect(b.detail).toMatch(/13k in/);
+    expect(b.detail).toContain('1.2k out');
+    expect(b.detail).toContain('$0.012');
+  });
+
+  it('successful result with no usage / cost still renders a footer', () => {
+    const out = sdkMessageToTranslation(
+      asSdk({ type: 'result', subtype: 'success', is_error: false, uuid: 'res-2', num_turns: 1, duration_ms: 200 })
+    );
+    expect(out.append).toHaveLength(1);
+    const b = out.append[0] as { detail?: string };
+    expect(b.detail).toBe('1 turn · 200ms');
   });
 
   it('emits an error block on failed result', () => {


### PR DESCRIPTION
## Summary
- Successful result messages now render a tiny INFO footer summarising the turn: turn count, duration, in/out tokens, total cost.
- Visually quiet (re-uses the StatusBanner from #119) so it sits naturally at the end of the transcript without competing with the assistant's last message.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 66 pass (2 new + 1 replaced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)