### PR TITLE
feat: render TodoWrite as a live checklist

### DIFF
--- a/src/agent/sdk-to-blocks.ts
+++ b/src/agent/sdk-to-blocks.ts
@@ -113,14 +113,24 @@ function assistantBlocks(msg: any): MessageBlock[] {
       out.push({ kind: 'assistant', id: `${baseId}:t${textIdx++}`, text: (c as { text: string }).text });
     } else if (c.type === 'tool_use') {
       const tu = c as { id: string; name: string; input: unknown };
-      out.push({
-        kind: 'tool',
-        id: `${baseId}:tu${toolIdx++}`,
-        toolUseId: tu.id,
-        name: tu.name,
-        brief: briefForTool(tu.name, tu.input),
-        expanded: false
-      });
+      if (tu.name === 'TodoWrite') {
+        const todos = parseTodos(tu.input);
+        out.push({
+          kind: 'todo',
+          id: `${baseId}:tu${toolIdx++}`,
+          toolUseId: tu.id,
+          todos
+        });
+      } else {
+        out.push({
+          kind: 'tool',
+          id: `${baseId}:tu${toolIdx++}`,
+          toolUseId: tu.id,
+          name: tu.name,
+          brief: briefForTool(tu.name, tu.input),
+          expanded: false
+        });
+      }
     }
   }
   return out;
@@ -220,4 +230,24 @@ function briefForTool(name: string, input: unknown): string {
 
 function cryptoRandom(): string {
   return Math.random().toString(36).slice(2, 10);
+}
+
+function parseTodos(input: unknown): import('../types').TodoItem[] {
+  if (!input || typeof input !== 'object') return [];
+  const raw = (input as { todos?: unknown }).todos;
+  if (!Array.isArray(raw)) return [];
+  const out: import('../types').TodoItem[] = [];
+  for (const t of raw) {
+    if (!t || typeof t !== 'object') continue;
+    const o = t as Record<string, unknown>;
+    const content = typeof o.content === 'string' ? o.content : '';
+    if (!content) continue;
+    const status = o.status === 'in_progress' || o.status === 'completed' ? o.status : 'pending';
+    out.push({
+      content,
+      status,
+      activeForm: typeof o.activeForm === 'string' ? o.activeForm : undefined
+    });
+  }
+  return out;
 }

--- a/src/components/ChatStream.tsx
+++ b/src/components/ChatStream.tsx
@@ -249,6 +249,66 @@ function PlanBlock({ plan, onAllow, onDeny }: { plan: string; onAllow?: () => vo
   );
 }
 
+function TodoBlock({ todos }: { todos: import('../types').TodoItem[] }) {
+  const total = todos.length;
+  const done = todos.filter((t) => t.status === 'completed').length;
+  return (
+    <div className="my-1.5 rounded-md border border-border-subtle bg-bg-elevated/40 px-3 py-2">
+      <div className="flex items-center justify-between mb-1.5">
+        <span className="font-mono text-[11px] uppercase tracking-wider text-fg-tertiary">Todo</span>
+        <span className="font-mono text-[11px] text-fg-tertiary">
+          {done}/{total}
+        </span>
+      </div>
+      <ul className="space-y-1">
+        {todos.map((t, i) => {
+          const inProgress = t.status === 'in_progress';
+          const completed = t.status === 'completed';
+          return (
+            <li key={i} className="flex items-start gap-2 text-sm">
+              <span
+                aria-hidden
+                className={
+                  'mt-1 inline-flex h-3 w-3 shrink-0 items-center justify-center rounded-sm border ' +
+                  (completed
+                    ? 'bg-state-running border-state-running'
+                    : inProgress
+                    ? 'border-state-waiting'
+                    : 'border-border-strong')
+                }
+              >
+                {completed && (
+                  <svg viewBox="0 0 12 12" className="h-2.5 w-2.5 text-bg-app" aria-hidden>
+                    <path
+                      d="M2.5 6.5L5 9l4.5-5"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      fill="none"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                )}
+                {inProgress && (
+                  <span className="block h-1.5 w-1.5 rounded-full bg-state-waiting animate-pulse" />
+                )}
+              </span>
+              <span
+                className={
+                  (completed ? 'text-fg-tertiary line-through ' : inProgress ? 'text-fg-primary ' : 'text-fg-secondary ') +
+                  'min-w-0 flex-1'
+                }
+              >
+                {inProgress && t.activeForm ? t.activeForm : t.content}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
 function StatusBanner({ tone, title, detail }: { tone: 'info' | 'warn'; title: string; detail?: string }) {
   const isWarn = tone === 'warn';
   return (
@@ -419,6 +479,8 @@ function renderBlock(b: MessageBlock, activeId: string, resolvePermission: (sid:
       return <AssistantBlock text={b.text} />;
     case 'tool':
       return <ToolBlock name={b.name} brief={b.brief} result={b.result} isError={b.isError} />;
+    case 'todo':
+      return <TodoBlock todos={b.todos} />;
     case 'waiting':
       if (b.intent === 'plan' && b.plan) {
         return (

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,10 +36,17 @@ export interface QuestionSpec {
   options: QuestionOption[];
 }
 
+export interface TodoItem {
+  content: string;
+  status: 'pending' | 'in_progress' | 'completed';
+  activeForm?: string;
+}
+
 export type MessageBlock =
   | { kind: 'user'; id: string; text: string }
   | { kind: 'assistant'; id: string; text: string }
   | { kind: 'tool'; id: string; name: string; brief: string; expanded: boolean; toolUseId?: string; result?: string; isError?: boolean }
+  | { kind: 'todo'; id: string; toolUseId?: string; todos: TodoItem[] }
   | { kind: 'waiting'; id: string; prompt: string; intent: 'permission' | 'plan' | 'question'; requestId?: string; plan?: string }
   | { kind: 'question'; id: string; requestId: string; questions: QuestionSpec[] }
   | { kind: 'status'; id: string; tone: 'info' | 'warn'; title: string; detail?: string }

--- a/tests/sdk-to-blocks.test.ts
+++ b/tests/sdk-to-blocks.test.ts
@@ -101,6 +101,49 @@ describe('sdkMessageToTranslation', () => {
     expect(b.detail).toContain('$0.012');
   });
 
+  it('TodoWrite tool_use becomes a todo block (not generic tool)', () => {
+    const out = sdkMessageToTranslation(
+      asSdk({
+        type: 'assistant',
+        uuid: 'msg-todo',
+        message: {
+          content: [
+            {
+              type: 'tool_use',
+              id: 'tu-1',
+              name: 'TodoWrite',
+              input: {
+                todos: [
+                  { content: 'Write tests', status: 'completed' },
+                  { content: 'Implement feature', status: 'in_progress', activeForm: 'Implementing feature' },
+                  { content: 'Open PR', status: 'pending' }
+                ]
+              }
+            }
+          ]
+        }
+      })
+    );
+    expect(out.append).toHaveLength(1);
+    const b = out.append[0] as { kind: string; todos?: Array<{ content: string; status: string; activeForm?: string }> };
+    expect(b.kind).toBe('todo');
+    expect(b.todos).toHaveLength(3);
+    expect(b.todos![1].activeForm).toBe('Implementing feature');
+  });
+
+  it('TodoWrite with malformed input falls back to empty todo list', () => {
+    const out = sdkMessageToTranslation(
+      asSdk({
+        type: 'assistant',
+        uuid: 'msg-empty-todo',
+        message: { content: [{ type: 'tool_use', id: 'tu-x', name: 'TodoWrite', input: { todos: 'no' } }] }
+      })
+    );
+    const b = out.append[0] as { kind: string; todos?: unknown[] };
+    expect(b.kind).toBe('todo');
+    expect(b.todos).toEqual([]);
+  });
+
   it('successful result with no usage / cost still renders a footer', () => {
     const out = sdkMessageToTranslation(
       asSdk({ type: 'result', subtype: 'success', is_error: false, uuid: 'res-2', num_turns: 1, duration_ms: 200 })


### PR DESCRIPTION
## Summary
- TodoWrite tool calls now render as an inline checklist (✓ completed / pulse in-progress / empty pending) instead of an opaque tool name.
- Each call is its own snapshot block — matches CLI semantics and keeps state simple.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 68 pass (2 new sdk-to-blocks cases for TodoWrite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)