### PR TITLE
feat: render Edit/Write/MultiEdit as a colored diff

### DIFF
--- a/src/agent/sdk-to-blocks.ts
+++ b/src/agent/sdk-to-blocks.ts
@@ -128,7 +128,8 @@ function assistantBlocks(msg: any): MessageBlock[] {
           toolUseId: tu.id,
           name: tu.name,
           brief: briefForTool(tu.name, tu.input),
-          expanded: false
+          expanded: false,
+          input: tu.input
         });
       }
     }

--- a/src/components/ChatStream.tsx
+++ b/src/components/ChatStream.tsx
@@ -7,6 +7,7 @@ import type { MessageBlock } from '../types';
 import { useStore } from '../stores/store';
 import { Button } from './ui/Button';
 import { StateGlyph } from './ui/StateGlyph';
+import { diffFromToolInput, type DiffSpec } from '../utils/diff';
 
 function UserBlock({ text }: { text: string }) {
   return (
@@ -88,15 +89,18 @@ function ToolBlock({
   name,
   brief,
   result,
-  isError
+  isError,
+  input
 }: {
   name: string;
   brief: string;
   result?: string;
   isError?: boolean;
+  input?: unknown;
 }) {
   const [open, setOpen] = useState(false);
   const hasResult = typeof result === 'string';
+  const diff = diffFromToolInput(name, input);
   return (
     <div className="font-mono text-sm">
       <button
@@ -138,16 +142,54 @@ function ToolBlock({
             transition={{ duration: 0.18, ease: [0, 0, 0.2, 1] }}
             style={{ overflow: 'hidden' }}
           >
-            <pre
-              className={`mt-1 ml-6 pl-3 border-l text-xs whitespace-pre-wrap font-mono ${
-                isError ? 'border-state-error/40 text-state-error-fg' : 'border-border-subtle text-fg-tertiary'
-              }`}
-            >
-              {hasResult ? result : '(running…)'}
-            </pre>
+            {diff ? (
+              <DiffView diff={diff} />
+            ) : (
+              <pre
+                className={`mt-1 ml-6 pl-3 border-l text-xs whitespace-pre-wrap font-mono ${
+                  isError ? 'border-state-error/40 text-state-error-fg' : 'border-border-subtle text-fg-tertiary'
+                }`}
+              >
+                {hasResult ? result : '(running…)'}
+              </pre>
+            )}
           </motion.div>
         )}
       </AnimatePresence>
+    </div>
+  );
+}
+
+function DiffView({ diff }: { diff: DiffSpec }) {
+  return (
+    <div className="mt-1 ml-6 rounded-sm border border-border-subtle overflow-hidden">
+      <div className="px-3 py-1 bg-bg-elevated/60 border-b border-border-subtle font-mono text-[11px] text-fg-tertiary">
+        {diff.filePath}
+      </div>
+      <div className="font-mono text-xs">
+        {diff.hunks.map((h, i) => (
+          <div key={i} className={i > 0 ? 'border-t border-border-subtle' : ''}>
+            {h.removed.map((line, j) => (
+              <div
+                key={`r-${j}`}
+                className="grid grid-cols-[12px_1fr] bg-[oklch(0.55_0.18_27_/_0.10)] text-state-error-fg"
+              >
+                <span aria-hidden className="pl-1 select-none text-state-error">-</span>
+                <span className="whitespace-pre-wrap pr-2">{line || '\u00A0'}</span>
+              </div>
+            ))}
+            {h.added.map((line, j) => (
+              <div
+                key={`a-${j}`}
+                className="grid grid-cols-[12px_1fr] bg-[oklch(0.55_0.18_145_/_0.08)] text-fg-secondary"
+              >
+                <span aria-hidden className="pl-1 select-none text-state-running">+</span>
+                <span className="whitespace-pre-wrap pr-2">{line || '\u00A0'}</span>
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }
@@ -478,7 +520,7 @@ function renderBlock(b: MessageBlock, activeId: string, resolvePermission: (sid:
     case 'assistant':
       return <AssistantBlock text={b.text} />;
     case 'tool':
-      return <ToolBlock name={b.name} brief={b.brief} result={b.result} isError={b.isError} />;
+      return <ToolBlock name={b.name} brief={b.brief} result={b.result} isError={b.isError} input={b.input} />;
     case 'todo':
       return <TodoBlock todos={b.todos} />;
     case 'waiting':

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,7 +45,7 @@ export interface TodoItem {
 export type MessageBlock =
   | { kind: 'user'; id: string; text: string }
   | { kind: 'assistant'; id: string; text: string }
-  | { kind: 'tool'; id: string; name: string; brief: string; expanded: boolean; toolUseId?: string; result?: string; isError?: boolean }
+  | { kind: 'tool'; id: string; name: string; brief: string; expanded: boolean; toolUseId?: string; result?: string; isError?: boolean; input?: unknown }
   | { kind: 'todo'; id: string; toolUseId?: string; todos: TodoItem[] }
   | { kind: 'waiting'; id: string; prompt: string; intent: 'permission' | 'plan' | 'question'; requestId?: string; plan?: string }
   | { kind: 'question'; id: string; requestId: string; questions: QuestionSpec[] }

--- a/src/utils/diff.ts
+++ b/src/utils/diff.ts
@@ -1,0 +1,80 @@
+// Tiny line-level diff renderer for Edit/Write/MultiEdit tool calls.
+// Not a real Myers diff — for the typical small edits the CLI does, this
+// "split into removed lines + added lines + render side-by-side" view is
+// good enough and matches what people expect to see in the chat.
+
+export interface DiffSpec {
+  filePath: string;
+  hunks: Array<{
+    removed: string[];
+    added: string[];
+  }>;
+}
+
+export function diffFromEditInput(input: unknown): DiffSpec | null {
+  if (!input || typeof input !== 'object') return null;
+  const o = input as Record<string, unknown>;
+  const filePath = typeof o.file_path === 'string' ? o.file_path : '';
+  const oldStr = typeof o.old_string === 'string' ? o.old_string : '';
+  const newStr = typeof o.new_string === 'string' ? o.new_string : '';
+  if (!filePath || (!oldStr && !newStr)) return null;
+  return {
+    filePath,
+    hunks: [
+      {
+        removed: oldStr ? oldStr.split('\n') : [],
+        added: newStr ? newStr.split('\n') : []
+      }
+    ]
+  };
+}
+
+export function diffFromWriteInput(input: unknown): DiffSpec | null {
+  if (!input || typeof input !== 'object') return null;
+  const o = input as Record<string, unknown>;
+  const filePath = typeof o.file_path === 'string' ? o.file_path : '';
+  const content = typeof o.content === 'string' ? o.content : '';
+  if (!filePath) return null;
+  return {
+    filePath,
+    hunks: [
+      {
+        removed: [],
+        added: content ? content.split('\n') : []
+      }
+    ]
+  };
+}
+
+export function diffFromMultiEditInput(input: unknown): DiffSpec | null {
+  if (!input || typeof input !== 'object') return null;
+  const o = input as Record<string, unknown>;
+  const filePath = typeof o.file_path === 'string' ? o.file_path : '';
+  const edits = Array.isArray(o.edits) ? o.edits : [];
+  if (!filePath || edits.length === 0) return null;
+  const hunks: DiffSpec['hunks'] = [];
+  for (const e of edits) {
+    if (!e || typeof e !== 'object') continue;
+    const er = e as Record<string, unknown>;
+    const oldStr = typeof er.old_string === 'string' ? er.old_string : '';
+    const newStr = typeof er.new_string === 'string' ? er.new_string : '';
+    hunks.push({
+      removed: oldStr ? oldStr.split('\n') : [],
+      added: newStr ? newStr.split('\n') : []
+    });
+  }
+  return { filePath, hunks };
+}
+
+export function diffFromToolInput(name: string, input: unknown): DiffSpec | null {
+  switch (name) {
+    case 'Edit':
+      return diffFromEditInput(input);
+    case 'Write':
+      return diffFromWriteInput(input);
+    case 'MultiEdit':
+      return diffFromMultiEditInput(input);
+    default:
+      return null;
+  }
+}

--- a/tests/diff.test.ts
+++ b/tests/diff.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import {
+  diffFromEditInput,
+  diffFromWriteInput,
+  diffFromMultiEditInput,
+  diffFromToolInput
+} from '../src/utils/diff';
+
+describe('diff parsers', () => {
+  it('Edit: splits old/new strings into lines', () => {
+    const d = diffFromEditInput({
+      file_path: '/a/b.ts',
+      old_string: 'const x = 1;\nconst y = 2;',
+      new_string: 'const x = 10;\nconst y = 20;'
+    });
+    expect(d).not.toBeNull();
+    expect(d!.filePath).toBe('/a/b.ts');
+    expect(d!.hunks).toHaveLength(1);
+    expect(d!.hunks[0].removed).toEqual(['const x = 1;', 'const y = 2;']);
+    expect(d!.hunks[0].added).toEqual(['const x = 10;', 'const y = 20;']);
+  });
+
+  it('Edit: returns null on missing file_path', () => {
+    expect(diffFromEditInput({ old_string: 'a', new_string: 'b' })).toBeNull();
+  });
+
+  it('Edit: returns null when both old/new are empty', () => {
+    expect(diffFromEditInput({ file_path: '/a', old_string: '', new_string: '' })).toBeNull();
+  });
+
+  it('Write: produces a single all-added hunk', () => {
+    const d = diffFromWriteInput({ file_path: '/a/c.ts', content: 'line one\nline two' });
+    expect(d!.hunks[0].removed).toEqual([]);
+    expect(d!.hunks[0].added).toEqual(['line one', 'line two']);
+  });
+
+  it('Write: empty content still produces a hunk with empty added', () => {
+    const d = diffFromWriteInput({ file_path: '/a/c.ts', content: '' });
+    expect(d!.hunks[0].added).toEqual([]);
+  });
+
+  it('MultiEdit: one hunk per edit', () => {
+    const d = diffFromMultiEditInput({
+      file_path: '/a/d.ts',
+      edits: [
+        { old_string: 'a', new_string: 'A' },
+        { old_string: 'b\nb2', new_string: 'B\nB2' }
+      ]
+    });
+    expect(d!.hunks).toHaveLength(2);
+    expect(d!.hunks[1].removed).toEqual(['b', 'b2']);
+    expect(d!.hunks[1].added).toEqual(['B', 'B2']);
+  });
+
+  it('MultiEdit: returns null when edits array is empty', () => {
+    expect(diffFromMultiEditInput({ file_path: '/a', edits: [] })).toBeNull();
+  });
+
+  it('diffFromToolInput dispatches by tool name', () => {
+    expect(diffFromToolInput('Edit', { file_path: '/x', old_string: 'a', new_string: 'b' })).not.toBeNull();
+    expect(diffFromToolInput('Write', { file_path: '/x', content: 'a' })).not.toBeNull();
+    expect(diffFromToolInput('MultiEdit', { file_path: '/x', edits: [{ old_string: 'a', new_string: 'b' }] })).not.toBeNull();
+    expect(diffFromToolInput('Bash', { command: 'ls' })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Expanded Edit/Write/MultiEdit tool calls now render a real diff (file path, red removed lines, green added lines) instead of a raw string-replace dump.
- Other tools (Bash, Read, Grep, …) continue to use the existing pre-block fallback.
- Pure parser in \`utils/diff.ts\` so the rendering decision is unit-tested without React.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 76 pass (8 new diff parser cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)