### PR TITLE
feat: OS notification when session needs user input

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, Menu, ipcMain, safeStorage, dialog, type MenuItemConstructorOptions } from 'electron';
+import { app, BrowserWindow, Menu, ipcMain, safeStorage, dialog, Notification, type MenuItemConstructorOptions } from 'electron';
 import * as path from 'path';
 import * as fs from 'fs';
 import { initDb, loadState, saveState, closeDb } from './db';
@@ -129,6 +129,11 @@ function createWindow() {
 }
 
 app.whenReady().then(() => {
+  // On Windows, notifications need a stable AppUserModelID so the OS knows
+  // which app the toast belongs to (otherwise it shows "electron.exe").
+  if (process.platform === 'win32') {
+    app.setAppUserModelId('com.agentory.desktop');
+  }
   initDb();
   ipcMain.handle('db:load', (_e, key: string) => loadState(key));
   ipcMain.handle('db:save', (_e, key: string, value: string) => saveState(key, value));
@@ -194,6 +199,29 @@ app.whenReady().then(() => {
   );
 
   ipcMain.handle('import:scan', () => scanImportableSessions());
+
+  ipcMain.handle(
+    'notification:show',
+    (e, payload: { sessionId: string; title: string; body?: string }) => {
+      if (!Notification.isSupported()) return false;
+      const win = BrowserWindow.fromWebContents(e.sender);
+      const n = new Notification({
+        title: payload.title,
+        body: payload.body ?? '',
+        silent: false
+      });
+      n.on('click', () => {
+        if (win) {
+          if (win.isMinimized()) win.restore();
+          win.show();
+          win.focus();
+          win.webContents.send('notification:focusSession', payload.sessionId);
+        }
+      });
+      n.show();
+      return true;
+    }
+  );
 
   installUpdaterIpc();
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -76,6 +76,14 @@ const api = {
     Array<{ sessionId: string; cwd: string; title: string; mtime: number; projectDir: string }>
   > => ipcRenderer.invoke('import:scan'),
 
+  notify: (payload: { sessionId: string; title: string; body?: string }): Promise<boolean> =>
+    ipcRenderer.invoke('notification:show', payload),
+  onNotificationFocus: (handler: (sessionId: string) => void): (() => void) => {
+    const wrap = (_e: IpcRendererEvent, sessionId: string) => handler(sessionId);
+    ipcRenderer.on('notification:focusSession', wrap);
+    return () => ipcRenderer.removeListener('notification:focusSession', wrap);
+  },
+
   updatesStatus: (): Promise<UpdateStatus> => ipcRenderer.invoke('updates:status'),
   updatesCheck: (): Promise<UpdateStatus> => ipcRenderer.invoke('updates:check'),
   updatesDownload: (): Promise<{ ok: true } | { ok: false; reason: string }> =>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -271,5 +271,15 @@ function BackgroundWaitingBridge() {
     });
     return () => setBackgroundWaitingHandler(() => {});
   }, [push, selectSession]);
+  // Subscribe to OS notification clicks → focus the session.
+  useEffect(() => {
+    const off = window.agentory?.onNotificationFocus((sessionId) => {
+      const exists = useStore.getState().sessions.some((s) => s.id === sessionId);
+      if (exists) selectSession(sessionId);
+    });
+    return () => {
+      if (off) off();
+    };
+  }, [selectSession]);
   return null;
 }

--- a/src/agent/lifecycle.ts
+++ b/src/agent/lifecycle.ts
@@ -114,7 +114,8 @@ export function subscribeAgentEvents(): void {
     const store = useStore.getState();
     const block = permissionRequestToWaitingBlock(req);
     store.appendBlocks(req.sessionId, [block]);
-    if (req.sessionId !== store.activeId) {
+    const isBackground = req.sessionId !== store.activeId;
+    if (isBackground) {
       const session = store.sessions.find((s) => s.id === req.sessionId);
       let prompt = '';
       if (block.kind === 'question') {
@@ -122,11 +123,25 @@ export function subscribeAgentEvents(): void {
       } else if (block.kind === 'waiting') {
         prompt = block.intent === 'plan' ? 'Plan ready for review' : block.prompt;
       }
-      backgroundWaitingHandler({
-        sessionId: req.sessionId,
-        sessionName: session?.name ?? 'Background session',
-        prompt
-      });
+      const sessionName = session?.name ?? 'Background session';
+      backgroundWaitingHandler({ sessionId: req.sessionId, sessionName, prompt });
+    }
+    // OS-level notification when the user almost certainly missed the in-app
+    // toast: window unfocused, or active-session toast suppressed in-app for
+    // a non-active session. Only ping for "needs your attention" requests
+    // (any permission/plan/question), never on routine assistant streaming.
+    const windowFocused = typeof document !== 'undefined' && document.hasFocus();
+    if (isBackground || !windowFocused) {
+      const session = store.sessions.find((s) => s.id === req.sessionId);
+      const sessionName = session?.name ?? 'Background session';
+      let title = `${sessionName} needs your input`;
+      let body: string | undefined;
+      if (block.kind === 'question') {
+        body = block.questions[0]?.question;
+      } else if (block.kind === 'waiting') {
+        body = block.intent === 'plan' ? 'Plan ready for review' : block.prompt;
+      }
+      void api.notify({ sessionId: req.sessionId, title, body });
     }
   });
 }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -57,6 +57,9 @@ declare global {
         Array<{ sessionId: string; cwd: string; title: string; mtime: number; projectDir: string }>
       >;
 
+      notify: (payload: { sessionId: string; title: string; body?: string }) => Promise<boolean>;
+      onNotificationFocus: (handler: (sessionId: string) => void) => () => void;
+
       updatesStatus: () => Promise<UpdateStatus>;
       updatesCheck: () => Promise<UpdateStatus>;
       updatesDownload: () => Promise<{ ok: true } | { ok: false; reason: string }>;

--- a/tests/lifecycle.test.ts
+++ b/tests/lifecycle.test.ts
@@ -17,6 +17,7 @@ type Harness = {
   exitHandler: (e: AgentExit) => void;
   store: typeof import('../src/stores/store').useStore;
   setBackgroundWaitingHandler: typeof import('../src/agent/lifecycle').setBackgroundWaitingHandler;
+  notifyCalls: Array<{ sessionId: string; title: string; body?: string }>;
 };
 
 async function freshHarness(): Promise<Harness> {
@@ -26,6 +27,7 @@ async function freshHarness(): Promise<Harness> {
   let permHandler: ((r: PermReq) => void) | null = null;
   let eventHandler: ((e: AgentEvent) => void) | null = null;
   let exitHandler: ((e: AgentExit) => void) | null = null;
+  const notifyCalls: Array<{ sessionId: string; title: string; body?: string }> = [];
   (globalThis as unknown as { window: { agentory: unknown } }).window = {
     agentory: {
       onAgentEvent: (h: (e: AgentEvent) => void) => {
@@ -39,6 +41,10 @@ async function freshHarness(): Promise<Harness> {
       onAgentPermissionRequest: (h: (r: PermReq) => void) => {
         permHandler = h;
         return () => {};
+      },
+      notify: async (payload: { sessionId: string; title: string; body?: string }) => {
+        notifyCalls.push(payload);
+        return true;
       }
     }
   };
@@ -53,7 +59,8 @@ async function freshHarness(): Promise<Harness> {
     eventHandler,
     exitHandler,
     store: storeMod.useStore,
-    setBackgroundWaitingHandler: lifecycle.setBackgroundWaitingHandler
+    setBackgroundWaitingHandler: lifecycle.setBackgroundWaitingHandler,
+    notifyCalls
   };
 }
 
@@ -222,5 +229,51 @@ describe('lifecycle: background waiting bridge', () => {
 
     const block = h.store.getState().messagesBySession[sid][0];
     expect(block).toMatchObject({ kind: 'waiting', intent: 'permission' });
+  });
+
+  it('fires an OS notification for a NON-active session permission request', async () => {
+    const h = await freshHarness();
+    h.store.getState().createSession('~/active');
+    const activeId = h.store.getState().activeId;
+    h.store.getState().createSession('~/bg');
+    const bgId = h.store.getState().sessions[0].id;
+    h.store.getState().selectSession(activeId);
+    h.store.getState().renameSession(bgId, 'Background work');
+
+    h.permHandler({
+      sessionId: bgId,
+      requestId: 'req-n',
+      toolName: 'Bash',
+      input: { command: 'ls' }
+    });
+
+    expect(h.notifyCalls).toHaveLength(1);
+    expect(h.notifyCalls[0].sessionId).toBe(bgId);
+    expect(h.notifyCalls[0].title).toBe('Background work needs your input');
+    expect(h.notifyCalls[0].body).toBe('Bash: ls');
+  });
+
+  it('does not fire OS notification for the ACTIVE session when window is focused', async () => {
+    const h = await freshHarness();
+    // jsdom defaults to hasFocus()===false; force focused for this test.
+    const orig = (globalThis as unknown as { document?: Document }).document?.hasFocus;
+    if ((globalThis as unknown as { document?: Document }).document) {
+      (globalThis as unknown as { document: Document }).document.hasFocus = () => true;
+    }
+    h.store.getState().createSession('~/only');
+    const sid = h.store.getState().activeId;
+
+    h.permHandler({
+      sessionId: sid,
+      requestId: 'req-q',
+      toolName: 'Read',
+      input: { file_path: '/etc/hosts' }
+    });
+
+    expect(h.notifyCalls).toEqual([]);
+
+    if (orig && (globalThis as unknown as { document?: Document }).document) {
+      (globalThis as unknown as { document: Document }).document.hasFocus = orig;
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Native OS notifications when a session needs user attention (permission/plan/AskUserQuestion).
- Click → restore + focus window + jump to that session.
- Suppressed when the session is already active and the window is focused (no double-bother).
- Sets AppUserModelID on Windows so the toast displays as Agentory, not electron.exe.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 78 pass (2 new lifecycle cases)
- [ ] Manual: trigger background permission with window unfocused → toast appears, click → window focuses + selects session

🤖 Generated with [Claude Code](https://claude.com/claude-code)