### PR TITLE
feat: stream partial assistant tokens (P1)

### DIFF
--- a/electron/agent/sessions.ts
+++ b/electron/agent/sessions.ts
@@ -126,7 +126,8 @@ export class SessionRunner {
       permissionMode: opts.permissionMode ?? 'default',
       model: opts.model,
       resume: opts.resumeSessionId,
-      canUseTool
+      canUseTool,
+      includePartialMessages: true
     };
 
     const { query } = await loadSdk();

--- a/scripts/probe-e2e-streaming.mjs
+++ b/scripts/probe-e2e-streaming.mjs
@@ -1,0 +1,88 @@
+// Verify streaming UX:
+// - calling streamAssistantText creates an assistant block with a streaming caret
+// - subsequent deltas append text in place (no duplicate blocks)
+// - appendBlocks with the same id finalizes (caret disappears, text replaced)
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { appWindow } from './probe-utils.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function fail(msg) {
+  console.error(`\n[probe-e2e-streaming] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const app = await electron.launch({
+  args: ['.'],
+  cwd: root,
+  env: { ...process.env, NODE_ENV: 'development' }
+});
+const win = await appWindow(app);
+await win.waitForLoadState('domcontentloaded');
+await win.waitForFunction(() => !!window.__agentoryStore, null, { timeout: 15000 });
+
+// Make sure there's a session selected.
+const sessionId = await win.evaluate(() => {
+  const s = window.__agentoryStore.getState();
+  if (s.sessions.length === 0) {
+    s.createSession('~/streaming-probe');
+  }
+  return window.__agentoryStore.getState().activeId;
+});
+if (!sessionId) fail('no active session id');
+
+// Simulate streaming: 3 deltas, then a finalize via appendBlocks.
+await win.evaluate((sid) => {
+  const st = window.__agentoryStore.getState();
+  st.streamAssistantText(sid, 'msg-probe:c0', 'Hel', false);
+  st.streamAssistantText(sid, 'msg-probe:c0', 'lo, ', false);
+  st.streamAssistantText(sid, 'msg-probe:c0', 'world!', false);
+}, sessionId);
+
+await new Promise((r) => setTimeout(r, 200));
+
+const midState = await win.evaluate((sid) => {
+  const blocks = window.__agentoryStore.getState().messagesBySession[sid] ?? [];
+  return blocks.map((b) => ({ id: b.id, kind: b.kind, text: b.text, streaming: b.streaming }));
+}, sessionId);
+const streamingBlocks = midState.filter((b) => b.id === 'msg-probe:c0');
+if (streamingBlocks.length !== 1) fail(`expected 1 streaming block, got ${streamingBlocks.length}`);
+if (streamingBlocks[0].text !== 'Hello, world!')
+  fail(`expected text 'Hello, world!', got '${streamingBlocks[0].text}'`);
+if (streamingBlocks[0].streaming !== true) fail('streaming flag not set');
+
+// Caret should be visible in the DOM.
+const caretCount = await win.locator('span.animate-pulse').count();
+if (caretCount < 1) fail('streaming caret not rendered in DOM');
+
+// Finalize via appendBlocks with the same id.
+await win.evaluate((sid) => {
+  window.__agentoryStore.getState().appendBlocks(sid, [
+    { kind: 'assistant', id: 'msg-probe:c0', text: 'Final reply.' }
+  ]);
+}, sessionId);
+
+await new Promise((r) => setTimeout(r, 200));
+
+const finalState = await win.evaluate((sid) => {
+  const blocks = window.__agentoryStore.getState().messagesBySession[sid] ?? [];
+  return blocks.filter((b) => b.id === 'msg-probe:c0').map((b) => ({
+    text: b.text,
+    streaming: b.streaming
+  }));
+}, sessionId);
+if (finalState.length !== 1) fail(`after finalize, expected 1 block, got ${finalState.length}`);
+if (finalState[0].text !== 'Final reply.')
+  fail(`expected finalized text 'Final reply.', got '${finalState[0].text}'`);
+if (finalState[0].streaming) fail('streaming flag should be cleared after finalize');
+
+const finalCaretCount = await win.locator('span.animate-pulse').count();
+if (finalCaretCount !== 0) fail(`caret should disappear after finalize; found ${finalCaretCount}`);
+
+console.log('[probe-e2e-streaming] OK');
+console.log('  3 deltas coalesced into 1 block; caret shown then hidden on finalize');
+
+await app.close();

--- a/src/agent/lifecycle.ts
+++ b/src/agent/lifecycle.ts
@@ -1,8 +1,18 @@
 import { useStore } from '../stores/store';
-import { sdkMessageToTranslation } from './sdk-to-blocks';
+import { sdkMessageToTranslation, PartialAssistantStreamer } from './sdk-to-blocks';
 import type { MessageBlock, QuestionSpec } from '../types';
 
 let installed = false;
+
+const streamers = new Map<string, PartialAssistantStreamer>();
+function streamerFor(sessionId: string): PartialAssistantStreamer {
+  let s = streamers.get(sessionId);
+  if (!s) {
+    s = new PartialAssistantStreamer();
+    streamers.set(sessionId, s);
+  }
+  return s;
+}
 
 type BackgroundWaitingHandler = (info: { sessionId: string; sessionName: string; prompt: string }) => void;
 let backgroundWaitingHandler: BackgroundWaitingHandler = () => {};
@@ -90,6 +100,16 @@ export function subscribeAgentEvents(): void {
   installed = true;
 
   api.onAgentEvent((e) => {
+    if (e.message.type === 'stream_event') {
+      const streamer = streamerFor(e.sessionId);
+      const patch = streamer.consume(e.message);
+      if (patch) {
+        useStore
+          .getState()
+          .streamAssistantText(e.sessionId, patch.blockId, patch.appendText, patch.done);
+      }
+      return;
+    }
     const { append, toolResults } = sdkMessageToTranslation(e.message);
     const store = useStore.getState();
     if (append.length > 0) store.appendBlocks(e.sessionId, append);
@@ -102,6 +122,7 @@ export function subscribeAgentEvents(): void {
   });
 
   api.onAgentExit((e) => {
+    streamers.delete(e.sessionId);
     const store = useStore.getState();
     store.setRunning(e.sessionId, false);
     if (!e.error) return;

--- a/src/agent/sdk-to-blocks.ts
+++ b/src/agent/sdk-to-blocks.ts
@@ -14,6 +14,57 @@ export type SdkTranslation = {
 
 const EMPTY: SdkTranslation = { append: [], toolResults: [] };
 
+// One chunk of streaming-text progress derived from a SDKPartialAssistantMessage.
+// `blockId` matches what assistantBlocks() will emit for the final assistant
+// message, so the eventual finalize replaces this streaming block by id.
+export type AssistantStreamPatch = {
+  blockId: string;
+  appendText: string;
+  done: boolean;
+};
+
+// Per-session streamer. Stateful because the wire protocol emits message_start
+// once (carrying message.id) and downstream content_block_delta events only
+// reference the index — we need to remember the current message.id to derive
+// stable block ids that match the final SDKAssistantMessage.
+export class PartialAssistantStreamer {
+  private currentMessageId: string | null = null;
+
+  consume(msg: any): AssistantStreamPatch | null {
+    const event = msg?.event;
+    if (!event || typeof event !== 'object') return null;
+    if (event.type === 'message_start') {
+      const id = event.message?.id;
+      this.currentMessageId = typeof id === 'string' ? id : null;
+      return null;
+    }
+    if (event.type === 'message_stop') {
+      this.currentMessageId = null;
+      return null;
+    }
+    if (!this.currentMessageId) return null;
+    if (event.type === 'content_block_delta') {
+      const d = event.delta;
+      if (!d || d.type !== 'text_delta') return null;
+      const text = typeof d.text === 'string' ? d.text : '';
+      if (!text) return null;
+      return {
+        blockId: `${this.currentMessageId}:c${event.index}`,
+        appendText: text,
+        done: false
+      };
+    }
+    if (event.type === 'content_block_stop') {
+      return {
+        blockId: `${this.currentMessageId}:c${event.index}`,
+        appendText: '',
+        done: true
+      };
+    }
+    return null;
+  }
+}
+
 export function sdkMessageToTranslation(msg: SDKMessage): SdkTranslation {
   switch (msg.type) {
     case 'assistant':
@@ -104,13 +155,19 @@ type AnyContent =
 
 function assistantBlocks(msg: any): MessageBlock[] {
   const out: MessageBlock[] = [];
-  const baseId = msg.uuid ?? msg.message?.id ?? cryptoRandom();
+  // Prefer the upstream message id so streamed deltas (keyed by message.id +
+  // content index) and the final assistant message's blocks share an id and
+  // coalesce in the store. Fall back to the SDK uuid only when the model
+  // payload didn't carry a message id (shouldn't happen for real responses).
+  const baseId = msg.message?.id ?? msg.uuid ?? cryptoRandom();
   const content: AnyContent[] = msg.message?.content ?? [];
-  let textIdx = 0;
   let toolIdx = 0;
-  for (const c of content) {
+  // Use the raw content-block index so streamed deltas (which carry the same
+  // index from the wire protocol) generate matching block ids.
+  for (let idx = 0; idx < content.length; idx++) {
+    const c = content[idx];
     if (c.type === 'text' && typeof (c as { text: string }).text === 'string') {
-      out.push({ kind: 'assistant', id: `${baseId}:t${textIdx++}`, text: (c as { text: string }).text });
+      out.push({ kind: 'assistant', id: `${baseId}:c${idx}`, text: (c as { text: string }).text });
     } else if (c.type === 'tool_use') {
       const tu = c as { id: string; name: string; input: unknown };
       if (tu.name === 'TodoWrite') {

--- a/src/components/ChatStream.tsx
+++ b/src/components/ChatStream.tsx
@@ -18,7 +18,7 @@ function UserBlock({ text }: { text: string }) {
   );
 }
 
-function AssistantBlock({ text }: { text: string }) {
+function AssistantBlock({ text, streaming }: { text: string; streaming?: boolean }) {
   return (
     <div className="flex gap-3 text-base">
       <span className="text-fg-secondary select-none w-3 shrink-0 font-mono font-semibold leading-[22px]">●</span>
@@ -80,6 +80,12 @@ function AssistantBlock({ text }: { text: string }) {
         >
           {text}
         </ReactMarkdown>
+        {streaming && (
+          <span
+            aria-hidden
+            className="inline-block w-[7px] h-[14px] -mb-[2px] ml-0.5 bg-fg-primary/70 align-middle animate-pulse"
+          />
+        )}
       </div>
     </div>
   );
@@ -518,7 +524,7 @@ function renderBlock(b: MessageBlock, activeId: string, resolvePermission: (sid:
     case 'user':
       return <UserBlock text={b.text} />;
     case 'assistant':
-      return <AssistantBlock text={b.text} />;
+      return <AssistantBlock text={b.text} streaming={b.streaming} />;
     case 'tool':
       return <ToolBlock name={b.name} brief={b.brief} result={b.result} isError={b.isError} input={b.input} />;
     case 'todo':

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -52,6 +52,7 @@ type Actions = {
   setGroupCollapsed: (id: string, collapsed: boolean) => void;
 
   appendBlocks: (sessionId: string, blocks: MessageBlock[]) => void;
+  streamAssistantText: (sessionId: string, blockId: string, appendText: string, done: boolean) => void;
   setToolResult: (sessionId: string, toolUseId: string, result: string, isError: boolean) => void;
   clearMessages: (sessionId: string) => void;
   markStarted: (sessionId: string) => void;
@@ -302,8 +303,50 @@ export const useStore = create<State & Actions>((set, get) => ({
     if (blocks.length === 0) return;
     set((s) => {
       const prev = s.messagesBySession[sessionId] ?? [];
+      // Coalesce by id: if a block with the same id already exists (e.g. an
+      // assistant text block built up by streaming deltas), replace it in
+      // place with the finalized version rather than duplicating it.
+      let next = prev;
+      const toAppend: MessageBlock[] = [];
+      for (const b of blocks) {
+        const idx = next.findIndex((x) => x.id === b.id);
+        if (idx === -1) {
+          toAppend.push(b);
+        } else {
+          if (next === prev) next = prev.slice();
+          next[idx] = b;
+        }
+      }
+      if (toAppend.length === 0 && next === prev) return s;
+      const finalNext = toAppend.length > 0 ? [...next, ...toAppend] : next;
       return {
-        messagesBySession: { ...s.messagesBySession, [sessionId]: [...prev, ...blocks] }
+        messagesBySession: { ...s.messagesBySession, [sessionId]: finalNext }
+      };
+    });
+  },
+
+  streamAssistantText: (sessionId, blockId, appendText, done) => {
+    set((s) => {
+      const prev = s.messagesBySession[sessionId] ?? [];
+      const idx = prev.findIndex((b) => b.id === blockId);
+      if (idx === -1) {
+        // First delta for this content block — create it.
+        const block: MessageBlock = {
+          kind: 'assistant',
+          id: blockId,
+          text: appendText,
+          streaming: !done
+        };
+        return {
+          messagesBySession: { ...s.messagesBySession, [sessionId]: [...prev, block] }
+        };
+      }
+      const existing = prev[idx];
+      if (existing.kind !== 'assistant') return s;
+      const next = prev.slice();
+      next[idx] = { ...existing, text: existing.text + appendText, streaming: !done };
+      return {
+        messagesBySession: { ...s.messagesBySession, [sessionId]: next }
       };
     });
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,7 +44,7 @@ export interface TodoItem {
 
 export type MessageBlock =
   | { kind: 'user'; id: string; text: string }
-  | { kind: 'assistant'; id: string; text: string }
+  | { kind: 'assistant'; id: string; text: string; streaming?: boolean }
   | { kind: 'tool'; id: string; name: string; brief: string; expanded: boolean; toolUseId?: string; result?: string; isError?: boolean; input?: unknown }
   | { kind: 'todo'; id: string; toolUseId?: string; todos: TodoItem[] }
   | { kind: 'waiting'; id: string; prompt: string; intent: 'permission' | 'plan' | 'question'; requestId?: string; plan?: string }

--- a/tests/partial-streamer.test.ts
+++ b/tests/partial-streamer.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { PartialAssistantStreamer, sdkMessageToTranslation } from '../src/agent/sdk-to-blocks';
+
+const asPartial = <T>(x: T) => x as unknown as Parameters<PartialAssistantStreamer['consume']>[0];
+
+function startEvent(messageId: string) {
+  return asPartial({
+    type: 'stream_event',
+    event: { type: 'message_start', message: { id: messageId } }
+  });
+}
+function startBlock(index: number) {
+  return asPartial({
+    type: 'stream_event',
+    event: { type: 'content_block_start', index, content_block: { type: 'text', text: '' } }
+  });
+}
+function deltaEvent(index: number, text: string) {
+  return asPartial({
+    type: 'stream_event',
+    event: { type: 'content_block_delta', index, delta: { type: 'text_delta', text } }
+  });
+}
+function stopBlock(index: number) {
+  return asPartial({
+    type: 'stream_event',
+    event: { type: 'content_block_stop', index }
+  });
+}
+
+describe('PartialAssistantStreamer', () => {
+  it('returns null until message_start arrives', () => {
+    const s = new PartialAssistantStreamer();
+    // A delta arriving before message_start has no message id to anchor to.
+    expect(s.consume(deltaEvent(0, 'Hi'))).toBeNull();
+  });
+
+  it('emits one patch per text_delta keyed by message.id + content index', () => {
+    const s = new PartialAssistantStreamer();
+    s.consume(startEvent('msg-X'));
+    s.consume(startBlock(0));
+    expect(s.consume(deltaEvent(0, 'Hel'))).toEqual({
+      blockId: 'msg-X:c0',
+      appendText: 'Hel',
+      done: false
+    });
+    expect(s.consume(deltaEvent(0, 'lo'))).toEqual({
+      blockId: 'msg-X:c0',
+      appendText: 'lo',
+      done: false
+    });
+  });
+
+  it('marks done on content_block_stop', () => {
+    const s = new PartialAssistantStreamer();
+    s.consume(startEvent('msg-X'));
+    s.consume(startBlock(0));
+    s.consume(deltaEvent(0, 'Hi'));
+    expect(s.consume(stopBlock(0))).toEqual({
+      blockId: 'msg-X:c0',
+      appendText: '',
+      done: true
+    });
+  });
+
+  it('ignores non-text deltas (input_json, thinking, signature)', () => {
+    const s = new PartialAssistantStreamer();
+    s.consume(startEvent('msg-X'));
+    expect(
+      s.consume(
+        asPartial({
+          type: 'stream_event',
+          event: {
+            type: 'content_block_delta',
+            index: 1,
+            delta: { type: 'input_json_delta', partial_json: '{"x"' }
+          }
+        })
+      )
+    ).toBeNull();
+  });
+
+  it('uses content index, not text-only index, so tool_use at index 0 still puts text at index 1', () => {
+    const s = new PartialAssistantStreamer();
+    s.consume(startEvent('msg-Y'));
+    // index 0 is a tool_use (no text deltas); text appears at index 1
+    s.consume(startBlock(1));
+    const patch = s.consume(deltaEvent(1, 'Reply'));
+    expect(patch?.blockId).toBe('msg-Y:c1');
+  });
+
+  it('clears state on message_stop and refuses subsequent deltas', () => {
+    const s = new PartialAssistantStreamer();
+    s.consume(startEvent('msg-X'));
+    s.consume({ type: 'stream_event', event: { type: 'message_stop' } } as never);
+    expect(s.consume(deltaEvent(0, 'leak'))).toBeNull();
+  });
+
+  it('finalized assistant message id matches the streamed block id (so they coalesce)', () => {
+    const s = new PartialAssistantStreamer();
+    s.consume(startEvent('msg-Z'));
+    const partial = s.consume(deltaEvent(0, 'Hi'));
+    const final = sdkMessageToTranslation({
+      type: 'assistant',
+      uuid: 'sdk-uuid-Z',
+      message: { id: 'msg-Z', content: [{ type: 'text', text: 'Hi there' }] }
+    } as never);
+    expect(partial?.blockId).toBe(
+      (final.append[0] as { id: string }).id,
+      'streaming block id and finalized assistant block id must match'
+    );
+  });
+});

--- a/tests/sdk-to-blocks.test.ts
+++ b/tests/sdk-to-blocks.test.ts
@@ -170,7 +170,7 @@ describe('sdkMessageToTranslation', () => {
       })
     );
     expect(out.append).toEqual([
-      { kind: 'assistant', id: 'msg-1:t0', text: 'Sure, here is the plan.' }
+      { kind: 'assistant', id: 'msg-1:c0', text: 'Sure, here is the plan.' }
     ]);
   });
 

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -259,3 +259,59 @@ describe('store: setRunning', () => {
     expect(useStore.getState().runningSessions[sid]).toBeUndefined();
   });
 });
+
+describe('store: streamAssistantText + appendBlocks coalesce', () => {
+  it('streamAssistantText creates a streaming assistant block on first delta', () => {
+    useStore.getState().streamAssistantText('s1', 'msg-1:c0', 'Hel', false);
+    const blocks = useStore.getState().messagesBySession['s1'];
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      kind: 'assistant',
+      id: 'msg-1:c0',
+      text: 'Hel',
+      streaming: true
+    });
+  });
+
+  it('streamAssistantText appends to existing block on subsequent deltas', () => {
+    const s = useStore.getState();
+    s.streamAssistantText('s1', 'msg-1:c0', 'Hel', false);
+    s.streamAssistantText('s1', 'msg-1:c0', 'lo!', false);
+    const blocks = useStore.getState().messagesBySession['s1'];
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({ text: 'Hello!', streaming: true });
+  });
+
+  it('streamAssistantText with done=true clears the streaming flag', () => {
+    const s = useStore.getState();
+    s.streamAssistantText('s1', 'msg-1:c0', 'Hi', false);
+    s.streamAssistantText('s1', 'msg-1:c0', '', true);
+    const block = useStore.getState().messagesBySession['s1'][0] as { streaming?: boolean };
+    expect(block.streaming).toBe(false);
+  });
+
+  it('appendBlocks coalesces by id: finalized assistant block replaces the streamed one in place', () => {
+    const s = useStore.getState();
+    s.streamAssistantText('s1', 'msg-1:c0', 'partial', false);
+    s.appendBlocks('s1', [{ kind: 'assistant', id: 'msg-1:c0', text: 'final' }]);
+    const blocks = useStore.getState().messagesBySession['s1'];
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({ id: 'msg-1:c0', text: 'final' });
+    // streaming flag was set on the streamed block; the finalized version
+    // omits it entirely (undefined).
+    expect((blocks[0] as { streaming?: boolean }).streaming).toBeUndefined();
+  });
+
+  it('appendBlocks still appends new blocks while replacing matched ones', () => {
+    const s = useStore.getState();
+    s.streamAssistantText('s1', 'msg-1:c0', 'partial', false);
+    s.appendBlocks('s1', [
+      { kind: 'assistant', id: 'msg-1:c0', text: 'final' },
+      { kind: 'tool', id: 'msg-1:tu0', name: 'Bash', brief: 'ls', expanded: false }
+    ]);
+    const blocks = useStore.getState().messagesBySession['s1'];
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toMatchObject({ id: 'msg-1:c0', text: 'final' });
+    expect(blocks[1]).toMatchObject({ id: 'msg-1:tu0', kind: 'tool' });
+  });
+});


### PR DESCRIPTION
## Summary
- Enable \`includePartialMessages\` in the SDK options and route \`stream_event\` content_block_delta into a per-session \`PartialAssistantStreamer\`
- New store action \`streamAssistantText\` upserts an assistant block keyed by \`message.id+content_index\`
- Block ids derived from \`message.id\` so the final \`SDKAssistantMessage\`'s blocks coalesce in place via \`appendBlocks\`-by-id
- UI: streaming assistant blocks render with a pulsing caret; finalize clears it
- Tests: 7 streamer + 5 store coalesce + updated 1 sdk-to-blocks id format
- New probe \`probe-e2e-streaming\` verifies caret + dedup end-to-end

## Test plan
- [x] npm run typecheck — clean
- [x] npm run lint — clean (pre-existing warning only)
- [x] npm test — 90/90 pass
- [x] probe-e2e-streaming, probe-e2e-titlebar, probe-e2e-no-sessions-landing — OK
- [ ] Manual: send a real prompt to a Claude Code session and watch tokens stream in