### PR TITLE
feat: autopilot watchdog (don't let the agent stop)

### DIFF
--- a/src/agent/lifecycle.ts
+++ b/src/agent/lifecycle.ts
@@ -14,6 +14,76 @@ function streamerFor(sessionId: string): PartialAssistantStreamer {
   return s;
 }
 
+// Auto-prompt watchdog: when a session finishes a turn without uttering the
+// configured "done token", reply on the user's behalf so the agent keeps
+// going. Capped per-session so a runaway loop can't spam the SDK.
+function maybeFireWatchdog(sessionId: string): void {
+  const store = useStore.getState();
+  const cfg = store.watchdog;
+  if (!cfg.enabled) return;
+
+  // Don't fire while a permission prompt is pending — the agent isn't really
+  // idle, it's waiting on the user to approve a tool call.
+  const blocks = store.messagesBySession[sessionId] ?? [];
+  const hasPendingPermission = blocks.some(
+    (b) => (b.kind === 'waiting' && b.requestId) || (b.kind === 'question' && b.requestId)
+  );
+  if (hasPendingPermission) return;
+
+  // If the latest non-info signal is an error or rate-limit / API failure,
+  // bail too — auto-replying into a broken session just spams the SDK and
+  // racks up failed turns. The user needs to intervene.
+  for (let i = blocks.length - 1; i >= 0; i--) {
+    const b = blocks[i];
+    if (b.kind === 'error') return;
+    if (b.kind === 'status' && b.tone === 'warn') return;
+    if (b.kind === 'assistant') break;
+    if (b.kind === 'user') break;
+  }
+
+  // Find the last assistant text block. Streaming blocks count too — by the
+  // time `result` lands, streaming has been finalized (streaming flag false).
+  let lastAssistantText = '';
+  for (let i = blocks.length - 1; i >= 0; i--) {
+    const b = blocks[i];
+    if (b.kind === 'assistant') {
+      lastAssistantText = b.text;
+      break;
+    }
+  }
+  if (lastAssistantText.includes(cfg.doneToken)) return;
+
+  const count = store.watchdogCountsBySession[sessionId] ?? 0;
+  // maxAutoReplies <= 0 means unlimited.
+  if (cfg.maxAutoReplies > 0 && count >= cfg.maxAutoReplies) {
+    store.appendBlocks(sessionId, [
+      {
+        kind: 'status',
+        id: `watchdog-cap-${Date.now().toString(36)}`,
+        tone: 'warn',
+        title: 'Autopilot paused',
+        detail: `Reached ${cfg.maxAutoReplies} auto-replies without the done token; over to you.`
+      }
+    ]);
+    return;
+  }
+
+  const next = store.bumpWatchdogCount(sessionId);
+  const cap = cfg.maxAutoReplies > 0 ? `${cfg.maxAutoReplies}` : '∞';
+  const prompt = `如果你真的做完了，请回复我：${cfg.doneToken}\n\n否则：${cfg.otherwisePostfix}`;
+  store.appendBlocks(sessionId, [
+    {
+      kind: 'status',
+      id: `watchdog-${Date.now().toString(36)}`,
+      tone: 'info',
+      title: `Autopilot ${next}/${cap}`,
+      detail: 'Sent automatic follow-up because the agent stopped without the done token.'
+    }
+  ]);
+  void window.agentory?.agentSend(sessionId, prompt);
+  store.setRunning(sessionId, true);
+}
+
 type BackgroundWaitingHandler = (info: { sessionId: string; sessionName: string; prompt: string }) => void;
 let backgroundWaitingHandler: BackgroundWaitingHandler = () => {};
 
@@ -118,6 +188,7 @@ export function subscribeAgentEvents(): void {
     }
     if (e.message.type === 'result') {
       store.setRunning(e.sessionId, false);
+      maybeFireWatchdog(e.sessionId);
     }
   });
 

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -25,6 +25,7 @@ export function InputBar({ sessionId }: { sessionId: string }) {
   const appendBlocks = useStore((s) => s.appendBlocks);
   const markStarted = useStore((s) => s.markStarted);
   const setRunning = useStore((s) => s.setRunning);
+  const resetWatchdogCount = useStore((s) => s.resetWatchdogCount);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   React.useEffect(() => {
@@ -48,6 +49,8 @@ export function InputBar({ sessionId }: { sessionId: string }) {
     appendBlocks(sessionId, [{ kind: 'user', id: nextLocalId(), text }]);
     update('');
     setRunning(sessionId, true);
+    // A real human turn resets the autopilot counter.
+    resetWatchdogCount(sessionId);
 
     if (!started) {
       const res = await api.agentStart(sessionId, {

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -13,10 +13,11 @@ type LocalUpdateStatus =
   | { kind: 'downloaded'; version: string }
   | { kind: 'error'; message: string };
 
-type Tab = 'general' | 'account' | 'data' | 'shortcuts' | 'updates';
+type Tab = 'general' | 'autopilot' | 'account' | 'data' | 'shortcuts' | 'updates';
 
 const TABS: { id: Tab; label: string }[] = [
   { id: 'general', label: 'General' },
+  { id: 'autopilot', label: 'Autopilot' },
   { id: 'account', label: 'Account' },
   { id: 'data', label: 'Data' },
   { id: 'shortcuts', label: 'Shortcuts' },
@@ -69,6 +70,7 @@ export function SettingsDialog({
           </nav>
           <div className="flex-1 min-w-0 p-5 overflow-y-auto">
             {tab === 'general' && <GeneralPane />}
+            {tab === 'autopilot' && <AutopilotPane />}
             {tab === 'account' && <AccountPane />}
             {tab === 'data' && <DataPane />}
             {tab === 'shortcuts' && <ShortcutsPane />}
@@ -146,6 +148,73 @@ function GeneralPane() {
             { value: 'md', label: 'Medium (13px, default)' },
             { value: 'lg', label: 'Large (14px)' }
           ]}
+        />
+      </Field>
+    </>
+  );
+}
+
+function AutopilotPane() {
+  const watchdog = useStore((s) => s.watchdog);
+  const setWatchdog = useStore((s) => s.setWatchdog);
+  const inputClass = cn(
+    'w-full h-8 px-2 rounded-sm bg-bg-elevated border border-border-default',
+    'text-sm text-fg-primary placeholder:text-fg-disabled outline-none',
+    'focus:border-border-strong focus:shadow-[0_0_0_2px_oklch(0.72_0.14_215_/_0.30)]'
+  );
+  return (
+    <>
+      <div className="text-xs text-fg-tertiary mb-4">
+        When an agent finishes a turn without saying the done token, Agentory
+        will reply on your behalf so it doesn&apos;t sit idle. Capped per session
+        to keep runaway loops in check.
+      </div>
+      <Field label="Enable autopilot" hint="Auto-reply when the agent stops without the done token.">
+        <label className="inline-flex items-center gap-2 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={watchdog.enabled}
+            onChange={(e) => setWatchdog({ enabled: e.target.checked })}
+            className="h-4 w-4 accent-accent"
+          />
+          <span className="text-sm text-fg-secondary">{watchdog.enabled ? 'On' : 'Off'}</span>
+        </label>
+      </Field>
+      <Field
+        label="Done token"
+        hint="If the agent's last message contains this exact string, autopilot stops for the turn."
+      >
+        <input
+          type="text"
+          value={watchdog.doneToken}
+          onChange={(e) => setWatchdog({ doneToken: e.target.value })}
+          className={inputClass}
+        />
+      </Field>
+      <Field
+        label="Otherwise…"
+        hint="Appended after '如果你真的做完了，请回复我：<token>。\\n\\n否则：' in the auto-reply."
+      >
+        <textarea
+          value={watchdog.otherwisePostfix}
+          onChange={(e) => setWatchdog({ otherwisePostfix: e.target.value })}
+          rows={3}
+          className={cn(inputClass, 'h-auto py-2 resize-y leading-snug')}
+        />
+      </Field>
+      <Field
+        label="Max auto-replies per session"
+        hint="Resets when you send a real message. 0 = unlimited (use with care). Default 20."
+      >
+        <input
+          type="number"
+          min={0}
+          value={watchdog.maxAutoReplies}
+          onChange={(e) => {
+            const n = Number.parseInt(e.target.value, 10);
+            if (Number.isFinite(n) && n >= 0) setWatchdog({ maxAutoReplies: n });
+          }}
+          className={cn(inputClass, 'w-24')}
         />
       </Field>
     </>

--- a/src/stores/persist.ts
+++ b/src/stores/persist.ts
@@ -1,5 +1,5 @@
 import type { Group, Session } from '../types';
-import type { ModelId, PermissionMode, Theme, FontSize } from './store';
+import type { ModelId, PermissionMode, Theme, FontSize, WatchdogConfig } from './store';
 import type { RecentProject } from '../mock/data';
 
 export const STATE_KEY = 'main';
@@ -16,6 +16,7 @@ export interface PersistedState {
   fontSize?: FontSize;
   recentProjects?: RecentProject[];
   tutorialSeen?: boolean;
+  watchdog?: WatchdogConfig;
 }
 
 export async function loadPersisted(): Promise<PersistedState | null> {

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -9,6 +9,24 @@ export type PermissionMode = 'plan' | 'ask' | 'auto' | 'yolo';
 export type Theme = 'system' | 'light' | 'dark';
 export type FontSize = 'sm' | 'md' | 'lg';
 
+// Auto-prompt watchdog: when an agent stops without uttering the done token,
+// the lifecycle replies for the user so the agent doesn't sit idle. Tunables
+// live in user settings; per-session counts cap how many auto-replies fire
+// before a human must actually weigh in.
+export interface WatchdogConfig {
+  enabled: boolean;
+  doneToken: string;
+  otherwisePostfix: string;
+  maxAutoReplies: number;
+}
+
+export const DEFAULT_WATCHDOG: WatchdogConfig = {
+  enabled: false,
+  doneToken: '我真的已经做完了',
+  otherwisePostfix: '继续做，别问我任何事，你来做决策。',
+  maxAutoReplies: 20
+};
+
 type State = {
   sessions: Session[];
   groups: Group[];
@@ -21,6 +39,8 @@ type State = {
   theme: Theme;
   fontSize: FontSize;
   tutorialSeen: boolean;
+  watchdog: WatchdogConfig;
+  watchdogCountsBySession: Record<string, number>;
   messagesBySession: Record<string, MessageBlock[]>;
   startedSessions: Record<string, true>;
   runningSessions: Record<string, true>;
@@ -43,6 +63,9 @@ type Actions = {
   setTheme: (theme: Theme) => void;
   setFontSize: (size: FontSize) => void;
   markTutorialSeen: () => void;
+  setWatchdog: (patch: Partial<WatchdogConfig>) => void;
+  resetWatchdogCount: (sessionId: string) => void;
+  bumpWatchdogCount: (sessionId: string) => number;
 
   createGroup: (name?: string) => string;
   renameGroup: (id: string, name: string) => void;
@@ -85,6 +108,8 @@ export const useStore = create<State & Actions>((set, get) => ({
   theme: 'system',
   fontSize: 'md',
   tutorialSeen: false,
+  watchdog: DEFAULT_WATCHDOG,
+  watchdogCountsBySession: {},
   messagesBySession: {},
   startedSessions: {},
   runningSessions: {},
@@ -245,6 +270,26 @@ export const useStore = create<State & Actions>((set, get) => ({
   setTheme: (theme) => set({ theme }),
   setFontSize: (fontSize) => set({ fontSize }),
   markTutorialSeen: () => set({ tutorialSeen: true }),
+
+  setWatchdog: (patch) =>
+    set((s) => ({ watchdog: { ...s.watchdog, ...patch } })),
+
+  resetWatchdogCount: (sessionId) =>
+    set((s) => {
+      if (!(sessionId in s.watchdogCountsBySession)) return s;
+      const next = { ...s.watchdogCountsBySession };
+      delete next[sessionId];
+      return { watchdogCountsBySession: next };
+    }),
+
+  bumpWatchdogCount: (sessionId) => {
+    const cur = get().watchdogCountsBySession[sessionId] ?? 0;
+    const nextN = cur + 1;
+    set((s) => ({
+      watchdogCountsBySession: { ...s.watchdogCountsBySession, [sessionId]: nextN }
+    }));
+    return nextN;
+  },
 
   createGroup: (name) => {
     const id = nextId('g');
@@ -428,7 +473,8 @@ export async function hydrateStore(): Promise<void> {
       theme: persisted.theme ?? 'system',
       fontSize: persisted.fontSize ?? 'md',
       recentProjects: persisted.recentProjects ?? [],
-      tutorialSeen: persisted.tutorialSeen ?? false
+      tutorialSeen: persisted.tutorialSeen ?? false,
+      watchdog: { ...DEFAULT_WATCHDOG, ...(persisted.watchdog ?? {}) }
     });
   }
   hydrated = true;
@@ -445,7 +491,8 @@ export async function hydrateStore(): Promise<void> {
       theme: s.theme,
       fontSize: s.fontSize,
       recentProjects: s.recentProjects,
-      tutorialSeen: s.tutorialSeen
+      tutorialSeen: s.tutorialSeen,
+      watchdog: s.watchdog
     };
     schedulePersist(snapshot);
   });

--- a/tests/lifecycle.test.ts
+++ b/tests/lifecycle.test.ts
@@ -18,6 +18,7 @@ type Harness = {
   store: typeof import('../src/stores/store').useStore;
   setBackgroundWaitingHandler: typeof import('../src/agent/lifecycle').setBackgroundWaitingHandler;
   notifyCalls: Array<{ sessionId: string; title: string; body?: string }>;
+  sendCalls: Array<{ sessionId: string; text: string }>;
 };
 
 async function freshHarness(): Promise<Harness> {
@@ -28,6 +29,7 @@ async function freshHarness(): Promise<Harness> {
   let eventHandler: ((e: AgentEvent) => void) | null = null;
   let exitHandler: ((e: AgentExit) => void) | null = null;
   const notifyCalls: Array<{ sessionId: string; title: string; body?: string }> = [];
+  const sendCalls: Array<{ sessionId: string; text: string }> = [];
   (globalThis as unknown as { window: { agentory: unknown } }).window = {
     agentory: {
       onAgentEvent: (h: (e: AgentEvent) => void) => {
@@ -45,6 +47,10 @@ async function freshHarness(): Promise<Harness> {
       notify: async (payload: { sessionId: string; title: string; body?: string }) => {
         notifyCalls.push(payload);
         return true;
+      },
+      agentSend: async (sessionId: string, text: string) => {
+        sendCalls.push({ sessionId, text });
+        return true;
       }
     }
   };
@@ -60,7 +66,8 @@ async function freshHarness(): Promise<Harness> {
     exitHandler,
     store: storeMod.useStore,
     setBackgroundWaitingHandler: lifecycle.setBackgroundWaitingHandler,
-    notifyCalls
+    notifyCalls,
+    sendCalls
   };
 }
 
@@ -275,5 +282,117 @@ describe('lifecycle: background waiting bridge', () => {
     if (orig && (globalThis as unknown as { document?: Document }).document) {
       (globalThis as unknown as { document: Document }).document.hasFocus = orig;
     }
+  });
+});
+
+describe('lifecycle: autopilot watchdog', () => {
+  function endTurn(h: Harness, sessionId: string) {
+    h.eventHandler({
+      sessionId,
+      message: { type: 'result', subtype: 'success', usage: {}, num_turns: 1, duration_ms: 100 } as never
+    });
+  }
+
+  it('does NOTHING when watchdog disabled', async () => {
+    const h = await freshHarness();
+    h.store.getState().createSession('~/x');
+    const sid = h.store.getState().activeId;
+    h.store.getState().appendBlocks(sid, [{ kind: 'assistant', id: 'a1', text: 'short reply' }]);
+    endTurn(h, sid);
+    expect(h.sendCalls).toEqual([]);
+  });
+
+  it('does NOTHING when last assistant message contains the done token', async () => {
+    const h = await freshHarness();
+    h.store.getState().setWatchdog({ enabled: true, doneToken: 'DONE!' });
+    h.store.getState().createSession('~/x');
+    const sid = h.store.getState().activeId;
+    h.store.getState().appendBlocks(sid, [{ kind: 'assistant', id: 'a1', text: 'all DONE! goodbye' }]);
+    endTurn(h, sid);
+    expect(h.sendCalls).toEqual([]);
+  });
+
+  it('auto-replies with the configured prompt when token absent', async () => {
+    const h = await freshHarness();
+    h.store.getState().setWatchdog({
+      enabled: true,
+      doneToken: 'DONE!',
+      otherwisePostfix: 'KEEP GOING'
+    });
+    h.store.getState().createSession('~/x');
+    const sid = h.store.getState().activeId;
+    h.store.getState().appendBlocks(sid, [{ kind: 'assistant', id: 'a1', text: 'should I continue?' }]);
+    endTurn(h, sid);
+    expect(h.sendCalls).toHaveLength(1);
+    expect(h.sendCalls[0].sessionId).toBe(sid);
+    expect(h.sendCalls[0].text).toContain('DONE!');
+    expect(h.sendCalls[0].text).toContain('KEEP GOING');
+    // Counter incremented and a status block appended.
+    expect(h.store.getState().watchdogCountsBySession[sid]).toBe(1);
+    const blocks = h.store.getState().messagesBySession[sid];
+    expect(blocks.some((b) => b.kind === 'status' && b.title?.startsWith('Autopilot 1/'))).toBe(true);
+  });
+
+  it('skips when a permission request is pending', async () => {
+    const h = await freshHarness();
+    h.store.getState().setWatchdog({ enabled: true });
+    h.store.getState().createSession('~/x');
+    const sid = h.store.getState().activeId;
+    h.store.getState().appendBlocks(sid, [
+      { kind: 'assistant', id: 'a1', text: 'no token here' },
+      { kind: 'waiting', id: 'w1', prompt: 'Bash: ls', intent: 'permission', requestId: 'req-1' }
+    ]);
+    endTurn(h, sid);
+    expect(h.sendCalls).toEqual([]);
+  });
+
+  it('stops after maxAutoReplies and posts a paused status', async () => {
+    const h = await freshHarness();
+    h.store.getState().setWatchdog({ enabled: true, doneToken: 'ZZZTOKEN', maxAutoReplies: 2 });
+    h.store.getState().createSession('~/x');
+    const sid = h.store.getState().activeId;
+    h.store.getState().appendBlocks(sid, [{ kind: 'assistant', id: 'a1', text: 'no token in this reply' }]);
+    endTurn(h, sid);
+    endTurn(h, sid);
+    endTurn(h, sid); // third should be capped
+    expect(h.sendCalls).toHaveLength(2);
+    const blocks = h.store.getState().messagesBySession[sid];
+    expect(blocks.some((b) => b.kind === 'status' && b.title === 'Autopilot paused')).toBe(true);
+  });
+
+  it('treats maxAutoReplies <= 0 as unlimited', async () => {
+    const h = await freshHarness();
+    h.store.getState().setWatchdog({ enabled: true, doneToken: 'ZZZTOKEN', maxAutoReplies: 0 });
+    h.store.getState().createSession('~/x');
+    const sid = h.store.getState().activeId;
+    h.store.getState().appendBlocks(sid, [{ kind: 'assistant', id: 'a1', text: 'no token' }]);
+    for (let i = 0; i < 5; i++) endTurn(h, sid);
+    expect(h.sendCalls).toHaveLength(5);
+  });
+
+  it('skips when the latest signal is an error block', async () => {
+    const h = await freshHarness();
+    h.store.getState().setWatchdog({ enabled: true });
+    h.store.getState().createSession('~/x');
+    const sid = h.store.getState().activeId;
+    h.store.getState().appendBlocks(sid, [
+      { kind: 'assistant', id: 'a1', text: 'no token' },
+      { kind: 'error', id: 'e1', text: 'rate limit' }
+    ]);
+    endTurn(h, sid);
+    expect(h.sendCalls).toEqual([]);
+  });
+
+  it('skips when the latest signal is a warn status (e.g. api_retry)', async () => {
+    const h = await freshHarness();
+    h.store.getState().setWatchdog({ enabled: true });
+    h.store.getState().createSession('~/x');
+    const sid = h.store.getState().activeId;
+    h.store.getState().appendBlocks(sid, [
+      { kind: 'assistant', id: 'a1', text: 'no token' },
+      { kind: 'status', id: 's1', tone: 'warn', title: 'Rate limit hit' }
+    ]);
+    endTurn(h, sid);
+    expect(h.sendCalls).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
When an agent finishes a turn without uttering a configured \"done token\", Agentory replies on the user's behalf so the agent keeps going.

Auto-prompt template:
\`\`\`
如果你真的做完了，请回复我：<doneToken>

否则：<otherwisePostfix>
\`\`\`

Settings → Autopilot:
- enabled (default off)
- doneToken (default \`我真的已经做完了\`)
- otherwisePostfix (default \`继续做，别问我任何事，你来做决策。\`)
- maxAutoReplies (default 20; **0 = unlimited** — user-controllable cap)

Safety gates:
- Skip while a permission/question prompt is pending
- Skip if the latest signal is an error or warn status (rate limit / api_retry / start failure)
- Counter resets when the user manually sends

## Test plan
- [x] typecheck / lint / 98 tests pass
- [x] probe-e2e-titlebar OK
- [ ] Manual: enable autopilot, confirm auto-reply fires when agent stops; confirm done-token short-circuits; confirm error blocks pause