### PR TITLE
feat(i18n): zh/en localization with system locale detect

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { Tutorial } from './components/Tutorial';
 import { useStore } from './stores/store';
 import { setPersistErrorHandler } from './stores/persist';
 import { subscribeAgentEvents, setBackgroundWaitingHandler } from './agent/lifecycle';
+import { useT } from './i18n/useT';
 
 subscribeAgentEvents();
 
@@ -23,6 +24,7 @@ if (process.env.NODE_ENV !== 'production' && typeof window !== 'undefined') {
 }
 
 export default function App() {
+  const t = useT();
   const sessions = useStore((s) => s.sessions);
   const activeId = useStore((s) => s.activeId);
   const focusedGroupId = useStore((s) => s.focusedGroupId);
@@ -213,7 +215,7 @@ export default function App() {
             />
             <InputBar sessionId={active.id} />
             <div className="px-4 pb-2 font-mono text-xs text-fg-disabled select-none">
-              <span>Enter send · Shift+Enter newline</span>
+              <span>{t('app.sendShortcut')}</span>
             </div>
           </main>
           </div>

--- a/src/agent/lifecycle.ts
+++ b/src/agent/lifecycle.ts
@@ -1,6 +1,13 @@
 import { useStore } from '../stores/store';
 import { sdkMessageToTranslation, PartialAssistantStreamer } from './sdk-to-blocks';
 import type { MessageBlock, QuestionSpec } from '../types';
+import { translate, detectSystemLocale, type Locale } from '../i18n';
+
+function activeLocale(): Locale {
+  const setting = useStore.getState().localeSetting;
+  if (setting === 'system') return detectSystemLocale();
+  return setting;
+}
 
 let installed = false;
 
@@ -56,13 +63,14 @@ function maybeFireWatchdog(sessionId: string): void {
   const count = store.watchdogCountsBySession[sessionId] ?? 0;
   // maxAutoReplies <= 0 means unlimited.
   if (cfg.maxAutoReplies > 0 && count >= cfg.maxAutoReplies) {
+    const loc = activeLocale();
     store.appendBlocks(sessionId, [
       {
         kind: 'status',
         id: `watchdog-cap-${Date.now().toString(36)}`,
         tone: 'warn',
-        title: 'Autopilot paused',
-        detail: `Reached ${cfg.maxAutoReplies} auto-replies without the done token; over to you.`
+        title: translate(loc, 'watchdog.autopilotPaused'),
+        detail: translate(loc, 'watchdog.autopilotPausedDetail', { n: cfg.maxAutoReplies })
       }
     ]);
     return;
@@ -71,13 +79,14 @@ function maybeFireWatchdog(sessionId: string): void {
   const next = store.bumpWatchdogCount(sessionId);
   const cap = cfg.maxAutoReplies > 0 ? `${cfg.maxAutoReplies}` : '∞';
   const prompt = `如果你真的做完了，请回复我：${cfg.doneToken}\n\n否则：${cfg.otherwisePostfix}`;
+  const loc = activeLocale();
   store.appendBlocks(sessionId, [
     {
       kind: 'status',
       id: `watchdog-${Date.now().toString(36)}`,
       tone: 'info',
-      title: `Autopilot ${next}/${cap}`,
-      detail: 'Sent automatic follow-up because the agent stopped without the done token.'
+      title: translate(loc, 'watchdog.autopilotProgress', { n: next, cap }),
+      detail: translate(loc, 'watchdog.autopilotProgressDetail')
     }
   ]);
   void window.agentory?.agentSend(sessionId, prompt);

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -3,6 +3,7 @@ import { ArrowUp, Square } from 'lucide-react';
 import { cn } from '../lib/cn';
 import { Button } from './ui/Button';
 import { useStore } from '../stores/store';
+import { useT } from '../i18n/useT';
 import { toSdkPermissionMode } from '../agent/permission';
 
 // Per-session draft cache. Survives session switches within a process so
@@ -27,6 +28,7 @@ export function InputBar({ sessionId }: { sessionId: string }) {
   const setRunning = useStore((s) => s.setRunning);
   const resetWatchdogCount = useStore((s) => s.resetWatchdogCount);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const t = useT();
 
   React.useEffect(() => {
     setValue(draftCache.get(sessionId) ?? '');
@@ -114,7 +116,7 @@ export function InputBar({ sessionId }: { sessionId: string }) {
           onChange={(e) => update(e.target.value)}
           onKeyDown={onKeyDown}
           rows={2}
-          placeholder={running ? 'Running… (input disabled)' : hasMessages ? 'Reply…' : 'Ask anything…'}
+          placeholder={running ? t('inputBar.placeholderRunning') : hasMessages ? t('inputBar.placeholderReply') : t('inputBar.placeholderEmpty')}
           disabled={running}
           className={cn(
             'block w-full resize-none px-3 pt-2 pb-7 text-base leading-[22px]',
@@ -129,22 +131,22 @@ export function InputBar({ sessionId }: { sessionId: string }) {
             <Button
               variant="secondary"
               size="sm"
-              aria-label="Stop"
+              aria-label={t('inputBar.interrupt')}
               onClick={stop}
             >
               <Square size={10} className="stroke-[2.25]" />
-              <span>Stop</span>
+              <span>{t('inputBar.interrupt')}</span>
             </Button>
           ) : (
             <Button
               variant="primary"
               size="sm"
-              aria-label="Send message"
+              aria-label={t('inputBar.send')}
               disabled={!value.trim()}
               onClick={send}
             >
               <ArrowUp size={10} className="stroke-[2.25]" />
-              <span>Send</span>
+              <span>{t('inputBar.send')}</span>
             </Button>
           )}
         </div>

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -3,6 +3,7 @@ import { cn } from '../lib/cn';
 import { Dialog, DialogContent } from './ui/Dialog';
 import { Button } from './ui/Button';
 import { useStore } from '../stores/store';
+import { useT } from '../i18n/useT';
 
 type LocalUpdateStatus =
   | { kind: 'idle' }
@@ -15,14 +16,7 @@ type LocalUpdateStatus =
 
 type Tab = 'general' | 'autopilot' | 'account' | 'data' | 'shortcuts' | 'updates';
 
-const TABS: { id: Tab; label: string }[] = [
-  { id: 'general', label: 'General' },
-  { id: 'autopilot', label: 'Autopilot' },
-  { id: 'account', label: 'Account' },
-  { id: 'data', label: 'Data' },
-  { id: 'shortcuts', label: 'Shortcuts' },
-  { id: 'updates', label: 'Updates' }
-];
+const TAB_KEYS: Tab[] = ['general', 'autopilot', 'account', 'data', 'shortcuts', 'updates'];
 
 // Shortcut catalog mirrors mvp-design.md §11. Keep in sync when adding keys.
 const SHORTCUTS: { keys: string; desc: string }[] = [
@@ -44,27 +38,28 @@ export function SettingsDialog({
   onOpenChange: (open: boolean) => void;
 }) {
   const [tab, setTab] = useState<Tab>('general');
+  const t = useT();
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent title="Settings" width="720px" hideClose={false}>
+      <DialogContent title={t('settings.title')} width="720px" hideClose={false}>
         <div className="flex min-h-[380px] border-t border-border-subtle">
           <nav className="w-[160px] shrink-0 border-r border-border-subtle py-2">
-            {TABS.map((t) => (
+            {TAB_KEYS.map((id) => (
               <button
-                key={t.id}
-                onClick={() => setTab(t.id)}
+                key={id}
+                onClick={() => setTab(id)}
                 className={cn(
                   'flex w-full items-center h-7 px-3 text-sm rounded-sm mx-1',
                   'transition-[background-color,color] duration-150 ease-out',
                   'outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-border-strong',
-                  tab === t.id
+                  tab === id
                     ? 'bg-bg-active text-fg-primary font-medium'
                     : 'text-fg-secondary hover:bg-bg-hover hover:text-fg-primary'
                 )}
                 style={{ width: 'calc(100% - 0.5rem)' }}
               >
-                {t.label}
+                {t(`settings.tab.${id}`)}
               </button>
             ))}
           </nav>
@@ -122,31 +117,45 @@ function Select<T extends string>({
 }
 
 function GeneralPane() {
+  const t = useT();
   const theme = useStore((s) => s.theme);
   const fontSize = useStore((s) => s.fontSize);
+  const localeSetting = useStore((s) => s.localeSetting);
   const setTheme = useStore((s) => s.setTheme);
   const setFontSize = useStore((s) => s.setFontSize);
+  const setLocale = useStore((s) => s.setLocale);
   return (
     <>
-      <Field label="Theme">
+      <Field label={t('settings.general.language')} hint={t('settings.general.languageHint')}>
+        <Select
+          value={localeSetting}
+          onChange={setLocale}
+          options={[
+            { value: 'system', label: t('settings.general.languageSystem') },
+            { value: 'en', label: t('settings.general.languageEn') },
+            { value: 'zh', label: t('settings.general.languageZh') }
+          ]}
+        />
+      </Field>
+      <Field label={t('settings.general.theme')}>
         <Select
           value={theme}
           onChange={setTheme}
           options={[
-            { value: 'system', label: 'System' },
-            { value: 'light', label: 'Light' },
-            { value: 'dark', label: 'Dark' }
+            { value: 'system', label: t('settings.general.themeSystem') },
+            { value: 'light', label: t('settings.general.themeLight') },
+            { value: 'dark', label: t('settings.general.themeDark') }
           ]}
         />
       </Field>
-      <Field label="Font size" hint="Affects chat stream and sidebar">
+      <Field label={t('settings.general.fontSize')} hint={t('settings.general.fontSizeHint')}>
         <Select
           value={fontSize}
           onChange={setFontSize}
           options={[
-            { value: 'sm', label: 'Small (12px)' },
-            { value: 'md', label: 'Medium (13px, default)' },
-            { value: 'lg', label: 'Large (14px)' }
+            { value: 'sm', label: t('settings.general.fontSizeSm') },
+            { value: 'md', label: t('settings.general.fontSizeMd') },
+            { value: 'lg', label: t('settings.general.fontSizeLg') }
           ]}
         />
       </Field>
@@ -155,6 +164,7 @@ function GeneralPane() {
 }
 
 function AutopilotPane() {
+  const t = useT();
   const watchdog = useStore((s) => s.watchdog);
   const setWatchdog = useStore((s) => s.setWatchdog);
   const inputClass = cn(
@@ -164,12 +174,8 @@ function AutopilotPane() {
   );
   return (
     <>
-      <div className="text-xs text-fg-tertiary mb-4">
-        When an agent finishes a turn without saying the done token, Agentory
-        will reply on your behalf so it doesn&apos;t sit idle. Capped per session
-        to keep runaway loops in check.
-      </div>
-      <Field label="Enable autopilot" hint="Auto-reply when the agent stops without the done token.">
+      <div className="text-xs text-fg-tertiary mb-4">{t('settings.autopilot.intro')}</div>
+      <Field label={t('settings.autopilot.enabled')} hint={t('settings.autopilot.enabledHint')}>
         <label className="inline-flex items-center gap-2 cursor-pointer select-none">
           <input
             type="checkbox"
@@ -177,13 +183,12 @@ function AutopilotPane() {
             onChange={(e) => setWatchdog({ enabled: e.target.checked })}
             className="h-4 w-4 accent-accent"
           />
-          <span className="text-sm text-fg-secondary">{watchdog.enabled ? 'On' : 'Off'}</span>
+          <span className="text-sm text-fg-secondary">
+            {watchdog.enabled ? t('settings.autopilot.on') : t('settings.autopilot.off')}
+          </span>
         </label>
       </Field>
-      <Field
-        label="Done token"
-        hint="If the agent's last message contains this exact string, autopilot stops for the turn."
-      >
+      <Field label={t('settings.autopilot.doneToken')} hint={t('settings.autopilot.doneTokenHint')}>
         <input
           type="text"
           value={watchdog.doneToken}
@@ -191,10 +196,7 @@ function AutopilotPane() {
           className={inputClass}
         />
       </Field>
-      <Field
-        label="Otherwise…"
-        hint="Appended after '如果你真的做完了，请回复我：<token>。\\n\\n否则：' in the auto-reply."
-      >
+      <Field label={t('settings.autopilot.otherwise')} hint={t('settings.autopilot.otherwiseHint')}>
         <textarea
           value={watchdog.otherwisePostfix}
           onChange={(e) => setWatchdog({ otherwisePostfix: e.target.value })}
@@ -202,10 +204,7 @@ function AutopilotPane() {
           className={cn(inputClass, 'h-auto py-2 resize-y leading-snug')}
         />
       </Field>
-      <Field
-        label="Max auto-replies per session"
-        hint="Resets when you send a real message. 0 = unlimited (use with care). Default 20."
-      >
+      <Field label={t('settings.autopilot.maxReplies')} hint={t('settings.autopilot.maxRepliesHint')}>
         <input
           type="number"
           min={0}
@@ -222,6 +221,7 @@ function AutopilotPane() {
 }
 
 function AccountPane() {
+  const t = useT();
   const [key, setKey] = useState('');
   const [loaded, setLoaded] = useState(false);
   const [status, setStatus] = useState<string | null>(null);
@@ -244,25 +244,21 @@ function AccountPane() {
     const api = window.agentory;
     if (!api) return;
     const ok = await api.setApiKey(key.trim());
-    setStatus(ok ? 'Saved.' : 'Failed to save (encryption unavailable).');
+    setStatus(ok ? t('settings.account.saved') : t('settings.account.saveFailed'));
     setTimeout(() => setStatus(null), 2000);
   };
 
   return (
     <>
       <Field
-        label="Anthropic API key"
-        hint={
-          encAvailable
-            ? 'Stored in OS keychain. Required for Claude Code sessions.'
-            : 'OS encryption unavailable — key cannot be saved on this system.'
-        }
+        label={t('settings.account.apiKey')}
+        hint={encAvailable ? t('settings.account.apiKeyHint') : t('settings.account.apiKeyHintNoEnc')}
       >
         <input
           type="password"
           value={key}
           onChange={(e) => setKey(e.target.value)}
-          placeholder={loaded ? 'sk-ant-…' : 'Loading…'}
+          placeholder={loaded ? 'sk-ant-…' : '…'}
           disabled={!loaded || !encAvailable}
           className={cn(
             'w-full h-8 px-2 rounded-sm bg-bg-elevated border border-border-default',
@@ -274,7 +270,7 @@ function AccountPane() {
       </Field>
       <div className="flex items-center gap-3">
         <Button variant="primary" size="md" onClick={save} disabled={!loaded || !encAvailable}>
-          Save
+          {t('settings.account.save')}
         </Button>
         {status && <span className="text-xs text-fg-secondary">{status}</span>}
       </div>
@@ -283,18 +279,19 @@ function AccountPane() {
 }
 
 function DataPane() {
-  const [dataDir, setDataDir] = useState<string>('Loading…');
+  const t = useT();
+  const [dataDir, setDataDir] = useState<string>('…');
   useEffect(() => {
     window.agentory?.getDataDir().then(setDataDir).catch(() => setDataDir('(unavailable)'));
   }, []);
   return (
     <>
-      <Field label="Data directory" hint="Where Agentory stores groups, sessions, and preferences.">
+      <Field label={t('settings.data.dataDir')} hint={t('settings.data.dataDirHint')}>
         <code className="block px-2 py-1.5 rounded-sm bg-bg-elevated border border-border-subtle text-xs text-fg-secondary font-mono break-all">
           {dataDir}
         </code>
       </Field>
-      <Field label="Claude sessions directory" hint="Read-only. Managed by Claude Code SDK.">
+      <Field label={t('settings.data.sessionsDir')} hint={t('settings.data.sessionsDirHint')}>
         <code className="block px-2 py-1.5 rounded-sm bg-bg-elevated border border-border-subtle text-xs text-fg-secondary font-mono">
           {'~/.claude/projects/'}
         </code>
@@ -304,11 +301,10 @@ function DataPane() {
 }
 
 function ShortcutsPane() {
+  const t = useT();
   return (
     <div>
-      <div className="text-xs text-fg-tertiary mb-3">
-        Keybindings are fixed in MVP — remapping adds maintenance burden without clear user value.
-      </div>
+      <div className="text-xs text-fg-tertiary mb-3">{t('settings.shortcuts.hint')}</div>
       <ul className="divide-y divide-border-subtle">
         {SHORTCUTS.map((s) => (
           <li key={s.keys} className="flex items-center justify-between h-8 text-sm">
@@ -324,6 +320,7 @@ function ShortcutsPane() {
 }
 
 function UpdatesPane() {
+  const t = useT();
   const [version, setVersion] = useState<string>('…');
   const [status, setStatus] = useState<LocalUpdateStatus>({ kind: 'idle' });
 
@@ -342,37 +339,34 @@ function UpdatesPane() {
     if (!window.agentory) return;
     setStatus({ kind: 'checking' });
     await window.agentory.updatesCheck();
-    // Real status arrives via the push event; nothing to do here.
   }
-
   async function onDownload() {
     await window.agentory?.updatesDownload();
   }
-
   function onInstall() {
     void window.agentory?.updatesInstall();
   }
 
   return (
     <>
-      <Field label="Version">
+      <Field label={t('settings.updates.version')}>
         <span className="text-sm text-fg-secondary font-mono">{version}</span>
       </Field>
-      <Field label="Status">
-        <span className="text-sm text-fg-secondary font-mono">{describeStatus(status)}</span>
+      <Field label={t('settings.updates.status')}>
+        <span className="text-sm text-fg-secondary font-mono">{describeStatus(t, status)}</span>
       </Field>
       <div className="flex gap-2">
         <Button variant="secondary" size="md" onClick={onCheck} disabled={!canCheck}>
-          {isChecking ? 'Checking…' : 'Check for updates'}
+          {isChecking ? t('settings.updates.checking') : t('settings.updates.check')}
         </Button>
         {status.kind === 'available' && (
           <Button variant="primary" size="md" onClick={onDownload}>
-            Download {status.version}
+            {t('settings.updates.download', { version: status.version })}
           </Button>
         )}
         {status.kind === 'downloaded' && (
           <Button variant="primary" size="md" onClick={onInstall}>
-            Restart & install
+            {t('settings.updates.install')}
           </Button>
         )}
       </div>
@@ -380,22 +374,26 @@ function UpdatesPane() {
   );
 }
 
-function describeStatus(s: LocalUpdateStatus): string {
+function describeStatus(t: (key: string, vars?: Record<string, string | number>) => string, s: LocalUpdateStatus): string {
   switch (s.kind) {
     case 'idle':
-      return 'No update check performed yet.';
+      return t('settings.updates.idle');
     case 'checking':
-      return 'Checking for updates…';
+      return t('settings.updates.checkingDetail');
     case 'available':
-      return `Update available: ${s.version}`;
+      return t('settings.updates.available', { version: s.version });
     case 'not-available':
-      return 'You are on the latest version.';
+      return t('settings.updates.notAvailable');
     case 'downloading':
-      return `Downloading… ${s.percent.toFixed(1)}% (${formatBytes(s.transferred)} / ${formatBytes(s.total)})`;
+      return t('settings.updates.downloading', {
+        percent: s.percent.toFixed(1),
+        transferred: formatBytes(s.transferred),
+        total: formatBytes(s.total)
+      });
     case 'downloaded':
-      return `Update ${s.version} ready — restart to install.`;
+      return t('settings.updates.downloaded', { version: s.version });
     case 'error':
-      return `Update check failed: ${s.message}`;
+      return t('settings.updates.error', { message: s.message });
   }
 }
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -41,6 +41,7 @@ import {
 import { InlineRename } from './ui/InlineRename';
 import { ConfirmDialog } from './ui/ConfirmDialog';
 import type { Group, Session } from '../types';
+import { useT } from '../i18n/useT';
 
 // Session order inside a group is user-controlled (drag to reorder) — not
 // derived from state. The array order handed down from the store is the
@@ -74,6 +75,7 @@ function GroupRow({
   onFocus: () => void;
 }) {
   const sessionIds = sessions.map((s) => s.id);
+  const t = useT();
   const hasWaiting = sessions.some((s) => s.state === 'waiting');
   const setGroupCollapsed = useStore((s) => s.setGroupCollapsed);
   const renameGroup = useStore((s) => s.renameGroup);
@@ -188,10 +190,10 @@ function GroupRow({
           >
             {group.kind === 'archive' ? 'Unarchive group' : 'Archive group'}
           </ContextMenuItem>
-          <ContextMenuItem onSelect={() => setRenaming(true)}>Rename</ContextMenuItem>
+          <ContextMenuItem onSelect={() => setRenaming(true)}>{t('sidebar.rename')}</ContextMenuItem>
           <ContextMenuSeparator />
           <ContextMenuItem danger onSelect={() => setConfirmDelete(true)}>
-            Delete group…
+            {t('sidebar.delete')}…
           </ContextMenuItem>
         </ContextMenuContent>
       </ContextMenu>
@@ -253,6 +255,7 @@ function GroupRow({
 }
 
 function SessionRow({ session, active, selected, onSelect }: { session: Session; active: boolean; selected: boolean; onSelect: () => void }) {
+  const t = useT();
   const [renaming, setRenaming] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const groups = useStore((s) => s.groups).filter((g) => g.kind === 'normal');
@@ -343,9 +346,9 @@ function SessionRow({ session, active, selected, onSelect }: { session: Session;
         </li>
       </ContextMenuTrigger>
       <ContextMenuContent>
-        <ContextMenuItem onSelect={() => setRenaming(true)}>Rename</ContextMenuItem>
+        <ContextMenuItem onSelect={() => setRenaming(true)}>{t('sidebar.rename')}</ContextMenuItem>
         <ContextMenuSub>
-          <ContextMenuSubTrigger>Move to group</ContextMenuSubTrigger>
+          <ContextMenuSubTrigger>{t('sidebar.moveToGroup')}</ContextMenuSubTrigger>
           <ContextMenuSubContent>
             {groups.map((g) => (
               <ContextMenuItem
@@ -363,13 +366,13 @@ function SessionRow({ session, active, selected, onSelect }: { session: Session;
                 moveSession(session.id, id, null);
               }}
             >
-              New group…
+              {t('sidebar.newGroup')}…
             </ContextMenuItem>
           </ContextMenuSubContent>
         </ContextMenuSub>
         <ContextMenuSeparator />
         <ContextMenuItem danger onSelect={() => setConfirmDelete(true)}>
-          Delete
+          {t('sidebar.delete')}
         </ContextMenuItem>
       </ContextMenuContent>
     </ContextMenu>
@@ -403,6 +406,7 @@ function NewSessionButton({ onCreateSession }: { onCreateSession?: (cwd: string 
 }
 
 export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, activeSessionId, focusedGroupId, onSelectSession, onFocusGroup, sessions, onMoveSession }: SidebarProps) {
+  const t = useT();
   const groups = useStore((s) => s.groups);
   const createGroup = useStore((s) => s.createGroup);
   const collapsed = useStore((s) => s.sidebarCollapsed);
@@ -472,9 +476,9 @@ export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, active
             variant="raised"
             size="md"
             onClick={() => onCreateSession?.(null)}
-            tooltip="New session"
+            tooltip={t('sidebar.newSession')}
             tooltipSide="right"
-            aria-label="New session"
+            aria-label={t('sidebar.newSession')}
             className="h-8 w-8"
           >
             <Plus size={14} className="stroke-[1.75]" />
@@ -536,9 +540,9 @@ export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, active
             <IconButton
               size="xs"
               variant="ghost"
-              tooltip="New group"
+              tooltip={t('sidebar.newGroup')}
               tooltipSide="top"
-              aria-label="New group"
+              aria-label={t('sidebar.newGroup')}
               onClick={() => createGroup()}
             >
               <Plus size={12} className="stroke-[1.75]" />

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuTrigger
 } from './ui/DropdownMenu';
 import { useStore } from '../stores/store';
+import { useT } from '../i18n/useT';
 
 type ModelId = 'claude-opus-4' | 'claude-sonnet-4' | 'claude-haiku-4';
 type PermissionMode = 'plan' | 'ask' | 'auto' | 'yolo';
@@ -147,6 +148,11 @@ export function StatusBar({
   onChangePermission
 }: StatusBarProps) {
   const recentProjects = useStore((s) => s.recentProjects);
+  const t = useT();
+  const localizedPermissionOptions: ChipOption<PermissionMode>[] = permissionOptions.map((o) => {
+    if (o.kind !== 'item') return o;
+    return { ...o, primary: t(`permission.${o.value}`), secondary: t(`permission.${o.value}Secondary`) };
+  });
   const cwdOptions: ChipOption<string>[] = [
     ...recentProjects.map(
       (p) =>
@@ -158,14 +164,14 @@ export function StatusBar({
     {
       kind: 'item',
       value: BROWSE_FOLDER,
-      primary: 'Browse folder…',
+      primary: t('statusBar.browseFolder'),
       icon: <Folder size={12} className="stroke-[1.75] mr-2 text-fg-tertiary" />
     }
   ];
   const chips: React.ReactNode[] = [
     <ChipMenu
       key="cwd"
-      label="Working directory"
+      label={t('statusBar.cwd')}
       triggerLabel={lastSegment(cwd)}
       triggerTitle={cwd}
       options={cwdOptions}
@@ -173,17 +179,17 @@ export function StatusBar({
     />,
     <ChipMenu
       key="model"
-      label="Model"
+      label={t('statusBar.model')}
       triggerLabel={primaryOf(modelOptions, model)}
       options={modelOptions}
       onSelect={onChangeModel}
     />,
     <ChipMenu
       key="permission"
-      label="Permission mode"
-      triggerLabel={primaryOf(permissionOptions, permission)}
+      label={t('statusBar.permission')}
+      triggerLabel={primaryOf(localizedPermissionOptions, permission)}
       triggerAccent={permission === 'yolo' ? 'warn' : undefined}
-      options={permissionOptions}
+      options={localizedPermissionOptions}
       onSelect={onChangePermission}
     />
   ];

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1,0 +1,132 @@
+// English dictionary. Add new keys here first; the `Dict` type drives the
+// shape of all other locales. Keep sections grouped by feature so missing
+// translations are easy to spot.
+export default {
+  app: {
+    name: 'Agentory',
+    sendShortcut: 'Enter send · Shift+Enter newline'
+  },
+  inputBar: {
+    placeholderEmpty: 'Ask anything…',
+    placeholderReply: 'Reply…',
+    placeholderRunning: 'Running… (input disabled)',
+    send: 'Send',
+    interrupt: 'Interrupt'
+  },
+  statusBar: {
+    cwd: 'Working directory',
+    model: 'Model',
+    permission: 'Permission mode',
+    browseFolder: 'Browse folder…'
+  },
+  permission: {
+    plan: 'plan',
+    planSecondary: 'Plan only — no edits or commands',
+    ask: 'ask',
+    askSecondary: 'Ask before each tool call',
+    auto: 'auto',
+    autoSecondary: 'Auto-approve edits; ask for shell',
+    yolo: 'yolo',
+    yoloSecondary: 'Approve everything (use with care)'
+  },
+  sidebar: {
+    newSession: 'New session',
+    newGroup: 'New group',
+    importSession: 'Import session',
+    archive: 'Archive',
+    rename: 'Rename',
+    delete: 'Delete',
+    moveToGroup: 'Move to group'
+  },
+  settings: {
+    title: 'Settings',
+    tab: {
+      general: 'General',
+      autopilot: 'Autopilot',
+      account: 'Account',
+      data: 'Data',
+      shortcuts: 'Shortcuts',
+      updates: 'Updates'
+    },
+    general: {
+      theme: 'Theme',
+      themeSystem: 'System',
+      themeLight: 'Light',
+      themeDark: 'Dark',
+      fontSize: 'Font size',
+      fontSizeHint: 'Affects chat stream and sidebar',
+      fontSizeSm: 'Small (12px)',
+      fontSizeMd: 'Medium (13px, default)',
+      fontSizeLg: 'Large (14px)',
+      language: 'Language',
+      languageHint: 'Defaults to system locale on first run.',
+      languageSystem: 'System',
+      languageEn: 'English',
+      languageZh: '简体中文'
+    },
+    autopilot: {
+      intro:
+        "When an agent finishes a turn without saying the done token, Agentory will reply on your behalf so it doesn't sit idle. Capped per session to keep runaway loops in check.",
+      enabled: 'Enable autopilot',
+      enabledHint: "Auto-reply when the agent stops without the done token.",
+      on: 'On',
+      off: 'Off',
+      doneToken: 'Done token',
+      doneTokenHint:
+        "If the agent's last message contains this exact string, autopilot stops for the turn.",
+      otherwise: 'Otherwise…',
+      otherwiseHint:
+        "Appended after '如果你真的做完了，请回复我：<token>。\\n\\n否则：' in the auto-reply.",
+      maxReplies: 'Max auto-replies per session',
+      maxRepliesHint: 'Resets when you send a real message. 0 = unlimited (use with care). Default 20.'
+    },
+    account: {
+      apiKey: 'Anthropic API key',
+      apiKeyHint: 'Stored in OS keychain. Required for Claude Code sessions.',
+      apiKeyHintNoEnc: 'OS encryption unavailable — key cannot be saved on this system.',
+      save: 'Save',
+      saved: 'Saved.',
+      saveFailed: 'Failed to save (encryption unavailable).'
+    },
+    data: {
+      dataDir: 'Data directory',
+      dataDirHint: 'Where Agentory stores groups, sessions, and preferences.',
+      sessionsDir: 'Claude sessions directory',
+      sessionsDirHint: 'Read-only. Managed by Claude Code SDK.'
+    },
+    shortcuts: {
+      hint: 'Keybindings are fixed in MVP — remapping adds maintenance burden without clear user value.'
+    },
+    updates: {
+      version: 'Version',
+      status: 'Status',
+      check: 'Check for updates',
+      checking: 'Checking…',
+      download: 'Download {version}',
+      install: 'Restart & install',
+      idle: 'No update check performed yet.',
+      checkingDetail: 'Checking for updates…',
+      available: 'Update available: {version}',
+      notAvailable: 'You are on the latest version.',
+      downloading: 'Downloading… {percent}% ({transferred} / {total})',
+      downloaded: 'Update {version} ready — restart to install.',
+      error: 'Update check failed: {message}'
+    }
+  },
+  watchdog: {
+    autopilotPaused: 'Autopilot paused',
+    autopilotPausedDetail: 'Reached {n} auto-replies without the done token; over to you.',
+    autopilotProgress: 'Autopilot {n}/{cap}',
+    autopilotProgressDetail: 'Sent automatic follow-up because the agent stopped without the done token.'
+  },
+  notification: {
+    needsInput: '{name} needs your input',
+    backgroundSession: 'Background session'
+  },
+  common: {
+    cancel: 'Cancel',
+    confirm: 'Confirm',
+    close: 'Close',
+    done: 'Done'
+  }
+} as const;

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,38 @@
+import en from './en';
+import zh from './zh';
+
+export type Locale = 'en' | 'zh';
+type Loosen<T> = { [K in keyof T]: T[K] extends string ? string : Loosen<T[K]> };
+export type Dict = Loosen<typeof en>;
+
+const dicts: Record<Locale, Dict> = { en, zh };
+
+export const SUPPORTED_LOCALES: Locale[] = ['en', 'zh'];
+
+export function detectSystemLocale(): Locale {
+  if (typeof navigator === 'undefined') return 'en';
+  const lang = (navigator.language || 'en').toLowerCase();
+  if (lang.startsWith('zh')) return 'zh';
+  return 'en';
+}
+
+// Look up a dotted key with positional {x} interpolation. Falls back to en
+// when the key is missing in the active locale, then to the key itself when
+// it's missing everywhere — so a typo shows visibly in dev rather than
+// rendering blank.
+export function translate(locale: Locale, key: string, vars?: Record<string, string | number>): string {
+  const fromActive = lookup(dicts[locale], key);
+  const raw = fromActive ?? lookup(dicts.en, key) ?? key;
+  if (!vars) return raw;
+  return raw.replace(/\{(\w+)\}/g, (_, k) => (vars[k] != null ? String(vars[k]) : `{${k}}`));
+}
+
+function lookup(dict: unknown, key: string): string | null {
+  const parts = key.split('.');
+  let cur: unknown = dict;
+  for (const p of parts) {
+    if (!cur || typeof cur !== 'object') return null;
+    cur = (cur as Record<string, unknown>)[p];
+  }
+  return typeof cur === 'string' ? cur : null;
+}

--- a/src/i18n/useT.ts
+++ b/src/i18n/useT.ts
@@ -1,0 +1,16 @@
+import { useStore } from '../stores/store';
+import { detectSystemLocale, translate, type Locale } from './index';
+
+// Resolve the active locale from the user setting (which can be the literal
+// 'system' to defer to the OS). Reads through the store so language changes
+// re-render every consumer.
+export function useLocale(): Locale {
+  const setting = useStore((s) => s.localeSetting);
+  if (setting === 'system') return detectSystemLocale();
+  return setting;
+}
+
+export function useT(): (key: string, vars?: Record<string, string | number>) => string {
+  const locale = useLocale();
+  return (key, vars) => translate(locale, key, vars);
+}

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -1,0 +1,132 @@
+// 简体中文。键路径必须与 en.ts 一致；缺失的键会回退到英文。
+import type { Dict } from './index';
+
+const zh: Dict = {
+  app: {
+    name: 'Agentory',
+    sendShortcut: 'Enter 发送 · Shift+Enter 换行'
+  },
+  inputBar: {
+    placeholderEmpty: '想问什么…',
+    placeholderReply: '回复…',
+    placeholderRunning: '运行中…（输入已禁用）',
+    send: '发送',
+    interrupt: '中断'
+  },
+  statusBar: {
+    cwd: '工作目录',
+    model: '模型',
+    permission: '权限模式',
+    browseFolder: '浏览文件夹…'
+  },
+  permission: {
+    plan: '规划',
+    planSecondary: '只规划，不执行编辑或命令',
+    ask: '询问',
+    askSecondary: '每次工具调用前都询问',
+    auto: '自动',
+    autoSecondary: '自动批准编辑；shell 命令仍询问',
+    yolo: '放手',
+    yoloSecondary: '一律放行（请谨慎使用）'
+  },
+  sidebar: {
+    newSession: '新建会话',
+    newGroup: '新建分组',
+    importSession: '导入会话',
+    archive: '归档',
+    rename: '重命名',
+    delete: '删除',
+    moveToGroup: '移至分组'
+  },
+  settings: {
+    title: '设置',
+    tab: {
+      general: '通用',
+      autopilot: '自动驾驶',
+      account: '账户',
+      data: '数据',
+      shortcuts: '快捷键',
+      updates: '更新'
+    },
+    general: {
+      theme: '主题',
+      themeSystem: '跟随系统',
+      themeLight: '浅色',
+      themeDark: '深色',
+      fontSize: '字号',
+      fontSizeHint: '影响聊天区与侧边栏',
+      fontSizeSm: '小 (12px)',
+      fontSizeMd: '中 (13px，默认)',
+      fontSizeLg: '大 (14px)',
+      language: '语言',
+      languageHint: '首次启动时跟随系统语言。',
+      languageSystem: '跟随系统',
+      languageEn: 'English',
+      languageZh: '简体中文'
+    },
+    autopilot: {
+      intro:
+        '当 agent 完成一轮但没说出"完成口令"时，Agentory 会替你回复，让它别停下。每个会话有上限，避免死循环。',
+      enabled: '启用自动驾驶',
+      enabledHint: '当 agent 没说完成口令就停下时，自动回复。',
+      on: '开',
+      off: '关',
+      doneToken: '完成口令',
+      doneTokenHint: '如果 agent 最后一条消息包含此字符串，本轮跳过自动回复。',
+      otherwise: '否则…',
+      otherwiseHint: '会拼接在 "如果你真的做完了，请回复我：<口令>。\\n\\n否则：" 后面。',
+      maxReplies: '每个会话最多自动回复次数',
+      maxRepliesHint: '你手动发消息时会重置。0 = 无限（请谨慎）。默认 20。'
+    },
+    account: {
+      apiKey: 'Anthropic API Key',
+      apiKeyHint: '存于系统钥匙串。运行 Claude Code 会话所必需。',
+      apiKeyHintNoEnc: '当前系统不支持加密存储 — 无法保存 Key。',
+      save: '保存',
+      saved: '已保存。',
+      saveFailed: '保存失败（加密不可用）。'
+    },
+    data: {
+      dataDir: '数据目录',
+      dataDirHint: 'Agentory 存储分组、会话与偏好的位置。',
+      sessionsDir: 'Claude 会话目录',
+      sessionsDirHint: '只读。由 Claude Code SDK 管理。'
+    },
+    shortcuts: {
+      hint: 'MVP 阶段快捷键固定 — 自定义维护成本高，价值不明显。'
+    },
+    updates: {
+      version: '版本',
+      status: '状态',
+      check: '检查更新',
+      checking: '检查中…',
+      download: '下载 {version}',
+      install: '重启并安装',
+      idle: '尚未检查更新。',
+      checkingDetail: '正在检查更新…',
+      available: '有新版本：{version}',
+      notAvailable: '已是最新版本。',
+      downloading: '下载中… {percent}% ({transferred} / {total})',
+      downloaded: '更新 {version} 已就绪 — 请重启安装。',
+      error: '检查失败：{message}'
+    }
+  },
+  watchdog: {
+    autopilotPaused: '自动驾驶已暂停',
+    autopilotPausedDetail: '已自动回复 {n} 次仍未出现完成口令；交还给你。',
+    autopilotProgress: '自动驾驶 {n}/{cap}',
+    autopilotProgressDetail: '由于 agent 未说完成口令就停下，已自动追问。'
+  },
+  notification: {
+    needsInput: '{name} 需要你的输入',
+    backgroundSession: '后台会话'
+  },
+  common: {
+    cancel: '取消',
+    confirm: '确定',
+    close: '关闭',
+    done: '完成'
+  }
+};
+
+export default zh;

--- a/src/stores/persist.ts
+++ b/src/stores/persist.ts
@@ -1,5 +1,5 @@
 import type { Group, Session } from '../types';
-import type { ModelId, PermissionMode, Theme, FontSize, WatchdogConfig } from './store';
+import type { ModelId, PermissionMode, Theme, FontSize, WatchdogConfig, LocaleSetting } from './store';
 import type { RecentProject } from '../mock/data';
 
 export const STATE_KEY = 'main';
@@ -14,6 +14,7 @@ export interface PersistedState {
   sidebarCollapsed: boolean;
   theme?: Theme;
   fontSize?: FontSize;
+  localeSetting?: LocaleSetting;
   recentProjects?: RecentProject[];
   tutorialSeen?: boolean;
   watchdog?: WatchdogConfig;

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -8,6 +8,7 @@ export type ModelId = 'claude-opus-4' | 'claude-sonnet-4' | 'claude-haiku-4';
 export type PermissionMode = 'plan' | 'ask' | 'auto' | 'yolo';
 export type Theme = 'system' | 'light' | 'dark';
 export type FontSize = 'sm' | 'md' | 'lg';
+export type LocaleSetting = 'system' | 'en' | 'zh';
 
 // Auto-prompt watchdog: when an agent stops without uttering the done token,
 // the lifecycle replies for the user so the agent doesn't sit idle. Tunables
@@ -38,6 +39,7 @@ type State = {
   sidebarCollapsed: boolean;
   theme: Theme;
   fontSize: FontSize;
+  localeSetting: LocaleSetting;
   tutorialSeen: boolean;
   watchdog: WatchdogConfig;
   watchdogCountsBySession: Record<string, number>;
@@ -62,6 +64,7 @@ type Actions = {
   toggleSidebar: () => void;
   setTheme: (theme: Theme) => void;
   setFontSize: (size: FontSize) => void;
+  setLocale: (l: LocaleSetting) => void;
   markTutorialSeen: () => void;
   setWatchdog: (patch: Partial<WatchdogConfig>) => void;
   resetWatchdogCount: (sessionId: string) => void;
@@ -107,6 +110,7 @@ export const useStore = create<State & Actions>((set, get) => ({
   sidebarCollapsed: false,
   theme: 'system',
   fontSize: 'md',
+  localeSetting: 'system',
   tutorialSeen: false,
   watchdog: DEFAULT_WATCHDOG,
   watchdogCountsBySession: {},
@@ -269,6 +273,7 @@ export const useStore = create<State & Actions>((set, get) => ({
   toggleSidebar: () => set((s) => ({ sidebarCollapsed: !s.sidebarCollapsed })),
   setTheme: (theme) => set({ theme }),
   setFontSize: (fontSize) => set({ fontSize }),
+  setLocale: (localeSetting) => set({ localeSetting }),
   markTutorialSeen: () => set({ tutorialSeen: true }),
 
   setWatchdog: (patch) =>
@@ -472,6 +477,7 @@ export async function hydrateStore(): Promise<void> {
       sidebarCollapsed: persisted.sidebarCollapsed ?? false,
       theme: persisted.theme ?? 'system',
       fontSize: persisted.fontSize ?? 'md',
+      localeSetting: persisted.localeSetting ?? 'system',
       recentProjects: persisted.recentProjects ?? [],
       tutorialSeen: persisted.tutorialSeen ?? false,
       watchdog: { ...DEFAULT_WATCHDOG, ...(persisted.watchdog ?? {}) }
@@ -490,6 +496,7 @@ export async function hydrateStore(): Promise<void> {
       sidebarCollapsed: s.sidebarCollapsed,
       theme: s.theme,
       fontSize: s.fontSize,
+      localeSetting: s.localeSetting,
       recentProjects: s.recentProjects,
       tutorialSeen: s.tutorialSeen,
       watchdog: s.watchdog


### PR DESCRIPTION
## Summary
- Self-written `translate()` engine in `src/i18n/`: dotted-key lookup, `{var}` interpolation, en fallback.
- `Dict = Loosen<typeof en>` keeps zh values free of literal-type pinning.
- Locale setting (`system|en|zh`) in store, persisted, exposed in Settings → General.
- Localized strings across InputBar, StatusBar, Sidebar, SettingsDialog (all 6 panes), App footer, watchdog status blocks.

## Test plan
- [x] typecheck clean
- [x] lint 0 errors
- [x] vitest 98/98 pass
- [ ] Manual: switch language in Settings, confirm UI flips zh ↔ en without restart