### PR TITLE
feat(agent): translate stream-json events to renderer blocks

### DIFF
--- a/src/agent/stream-to-blocks.ts
+++ b/src/agent/stream-to-blocks.ts
@@ -1,0 +1,307 @@
+import type {
+  AssistantEvent,
+  ClaudeStreamEvent,
+  ContentBlock,
+  ResultEvent,
+  SystemEvent,
+  ToolResultBlock,
+  ToolUseBlock,
+  UserEvent
+} from '../../electron/agent/stream-json-types';
+import type { MessageBlock, TodoItem } from '../types';
+
+export type ToolResultPatch = {
+  toolUseId: string;
+  result: string;
+  isError: boolean;
+};
+
+export type StreamTranslation = {
+  append: MessageBlock[];
+  toolResults: ToolResultPatch[];
+};
+
+const EMPTY: StreamTranslation = { append: [], toolResults: [] };
+
+export type AssistantStreamPatch = {
+  blockId: string;
+  appendText: string;
+  done: boolean;
+};
+
+// Mirrors the SDK-era streamer but consumes stream_event frames coming straight
+// from claude.exe stdout. The wire shape (message_start / content_block_delta /
+// content_block_stop) is identical between SDK and direct spawn — the SDK was a
+// pass-through for these — so the state machine is unchanged.
+export class PartialAssistantStreamer {
+  private currentMessageId: string | null = null;
+
+  consume(msg: unknown): AssistantStreamPatch | null {
+    const event = (msg as { event?: unknown } | null)?.event as
+      | { type?: string; message?: { id?: unknown }; index?: number; delta?: { type?: string; text?: unknown } }
+      | undefined;
+    if (!event || typeof event !== 'object') return null;
+    if (event.type === 'message_start') {
+      const id = event.message?.id;
+      this.currentMessageId = typeof id === 'string' ? id : null;
+      return null;
+    }
+    if (event.type === 'message_stop') {
+      this.currentMessageId = null;
+      return null;
+    }
+    if (!this.currentMessageId) return null;
+    if (event.type === 'content_block_delta') {
+      const d = event.delta;
+      if (!d || d.type !== 'text_delta') return null;
+      const text = typeof d.text === 'string' ? d.text : '';
+      if (!text) return null;
+      return {
+        blockId: `${this.currentMessageId}:c${event.index}`,
+        appendText: text,
+        done: false
+      };
+    }
+    if (event.type === 'content_block_stop') {
+      return {
+        blockId: `${this.currentMessageId}:c${event.index}`,
+        appendText: '',
+        done: true
+      };
+    }
+    return null;
+  }
+}
+
+export function streamEventToTranslation(event: ClaudeStreamEvent | { type: string }): StreamTranslation {
+  switch (event.type) {
+    case 'assistant':
+      return { append: assistantBlocksWithError(event as AssistantEvent), toolResults: [] };
+    case 'user':
+      return { append: [], toolResults: extractToolResults(event as UserEvent) };
+    case 'system':
+      return { append: systemBlocks(event as SystemEvent), toolResults: [] };
+    case 'result':
+      return { append: resultBlocks(event as ResultEvent), toolResults: [] };
+    default:
+      return EMPTY;
+  }
+}
+
+function assistantBlocksWithError(msg: AssistantEvent): MessageBlock[] {
+  const out = assistantBlocks(msg);
+  const err = msg.error;
+  if (err === 'rate_limit') {
+    out.push({
+      kind: 'status',
+      id: `${msg.uuid ?? cryptoRandom()}:rate`,
+      tone: 'warn',
+      title: 'Rate limit hit',
+      detail: 'The API is throttling this account. The next request will queue and retry.'
+    });
+  } else if (typeof err === 'string' && err) {
+    out.push({
+      kind: 'status',
+      id: `${msg.uuid ?? cryptoRandom()}:err`,
+      tone: 'warn',
+      title: errorTitle(err),
+      detail: undefined
+    });
+  }
+  return out;
+}
+
+function errorTitle(code: string): string {
+  switch (code) {
+    case 'authentication_failed': return 'Authentication failed';
+    case 'billing_error': return 'Billing error';
+    case 'rate_limit': return 'Rate limit hit';
+    case 'invalid_request': return 'Invalid request';
+    case 'server_error': return 'Server error';
+    case 'max_output_tokens': return 'Hit max output tokens';
+    default: return 'Assistant error';
+  }
+}
+
+function systemBlocks(msg: SystemEvent): MessageBlock[] {
+  if (msg.subtype === 'compact_boundary') {
+    const m = (msg as { compact_metadata?: { trigger?: string; pre_tokens?: number; post_tokens?: number; duration_ms?: number } }).compact_metadata ?? {};
+    const detail = m.pre_tokens
+      ? `Compacted ${m.pre_tokens.toLocaleString()} → ${m.post_tokens?.toLocaleString() ?? '?'} tokens` +
+        (m.duration_ms ? ` in ${m.duration_ms}ms` : '')
+      : undefined;
+    return [
+      {
+        kind: 'status',
+        id: msg.uuid ?? cryptoRandom(),
+        tone: 'info',
+        title: m.trigger === 'manual' ? 'Conversation compacted (manual)' : 'Conversation auto-compacted',
+        detail
+      }
+    ];
+  }
+  if (msg.subtype === 'api_retry') {
+    const m = msg as { attempt?: number; max_retries?: number; retry_delay_ms?: number; error_status?: number | string };
+    const delay = typeof m.retry_delay_ms === 'number' ? Math.round(m.retry_delay_ms / 1000) : '?';
+    const max = m.max_retries ?? '?';
+    return [
+      {
+        kind: 'status',
+        id: msg.uuid ?? cryptoRandom(),
+        tone: 'warn',
+        title: `Retrying API request (${m.attempt}/${max})`,
+        detail: `Next attempt in ~${delay}s${m.error_status ? ` · HTTP ${m.error_status}` : ''}`
+      }
+    ];
+  }
+  return [];
+}
+
+function assistantBlocks(msg: AssistantEvent): MessageBlock[] {
+  const out: MessageBlock[] = [];
+  const baseId = msg.message?.id ?? msg.uuid ?? cryptoRandom();
+  const content: ContentBlock[] = msg.message?.content ?? [];
+  let toolIdx = 0;
+  for (let idx = 0; idx < content.length; idx++) {
+    const c = content[idx];
+    if (c.type === 'text' && typeof c.text === 'string') {
+      out.push({ kind: 'assistant', id: `${baseId}:c${idx}`, text: c.text });
+    } else if (c.type === 'tool_use') {
+      const tu = c as ToolUseBlock;
+      if (tu.name === 'TodoWrite') {
+        out.push({
+          kind: 'todo',
+          id: `${baseId}:tu${toolIdx++}`,
+          toolUseId: tu.id,
+          todos: parseTodos(tu.input)
+        });
+      } else {
+        out.push({
+          kind: 'tool',
+          id: `${baseId}:tu${toolIdx++}`,
+          toolUseId: tu.id,
+          name: tu.name,
+          brief: briefForTool(tu.name, tu.input),
+          expanded: false,
+          input: tu.input
+        });
+      }
+    }
+  }
+  return out;
+}
+
+function extractToolResults(msg: UserEvent): ToolResultPatch[] {
+  const content = msg.message?.content;
+  if (!Array.isArray(content)) return [];
+  const out: ToolResultPatch[] = [];
+  for (const c of content) {
+    if (!c || typeof c !== 'object' || (c as { type?: string }).type !== 'tool_result') continue;
+    const tr = c as ToolResultBlock;
+    out.push({
+      toolUseId: tr.tool_use_id,
+      result: stringifyToolResult(tr.content),
+      isError: tr.is_error === true
+    });
+  }
+  return out;
+}
+
+function stringifyToolResult(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return JSON.stringify(content ?? '', null, 2);
+  const parts: string[] = [];
+  for (const part of content) {
+    if (part && typeof part === 'object' && (part as { type?: string }).type === 'text') {
+      const t = (part as { text?: unknown }).text;
+      if (typeof t === 'string') parts.push(t);
+    } else {
+      parts.push(JSON.stringify(part));
+    }
+  }
+  return parts.join('\n');
+}
+
+function resultBlocks(msg: ResultEvent): MessageBlock[] {
+  if (msg.subtype === 'success' || msg.is_error === false) {
+    return [resultStatsFooter(msg)];
+  }
+  const text = typeof msg.error === 'string' ? msg.error : msg.subtype ?? 'Run failed';
+  return [{ kind: 'error', id: msg.uuid ?? cryptoRandom(), text }];
+}
+
+function resultStatsFooter(msg: ResultEvent): MessageBlock {
+  const parts: string[] = [];
+  if (typeof msg.num_turns === 'number') parts.push(`${msg.num_turns} turn${msg.num_turns === 1 ? '' : 's'}`);
+  if (typeof msg.duration_ms === 'number') parts.push(formatDuration(msg.duration_ms));
+  const usage = msg.usage ?? {};
+  const inTok = (usage.input_tokens ?? 0) + (usage.cache_creation_input_tokens ?? 0) + (usage.cache_read_input_tokens ?? 0);
+  const outTok = usage.output_tokens ?? 0;
+  if (inTok || outTok) {
+    parts.push(`${formatTokens(inTok)} in / ${formatTokens(outTok)} out`);
+  }
+  if (typeof msg.total_cost_usd === 'number' && msg.total_cost_usd > 0) {
+    parts.push(`$${msg.total_cost_usd.toFixed(msg.total_cost_usd < 0.01 ? 4 : 3)}`);
+  }
+  return {
+    kind: 'status',
+    id: msg.uuid ?? cryptoRandom(),
+    tone: 'info',
+    title: 'Done',
+    detail: parts.join(' · ')
+  };
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const s = ms / 1000;
+  if (s < 60) return `${s.toFixed(1)}s`;
+  const m = Math.floor(s / 60);
+  const rem = Math.round(s - m * 60);
+  return `${m}m${rem}s`;
+}
+
+function formatTokens(n: number): string {
+  if (n < 1000) return `${n}`;
+  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}k`;
+  return `${(n / 1_000_000).toFixed(1)}M`;
+}
+
+function briefForTool(_name: string, input: unknown): string {
+  if (!input || typeof input !== 'object') return '';
+  const i = input as Record<string, unknown>;
+  const pick = (...keys: string[]): string => {
+    for (const k of keys) {
+      const v = i[k];
+      if (typeof v === 'string') return v;
+    }
+    return '';
+  };
+  const v =
+    pick('file_path', 'path', 'pattern', 'command', 'query', 'url', 'description') || JSON.stringify(input);
+  return v.length > 80 ? v.slice(0, 77) + '…' : v;
+}
+
+function cryptoRandom(): string {
+  return Math.random().toString(36).slice(2, 10);
+}
+
+function parseTodos(input: unknown): TodoItem[] {
+  if (!input || typeof input !== 'object') return [];
+  const raw = (input as { todos?: unknown }).todos;
+  if (!Array.isArray(raw)) return [];
+  const out: TodoItem[] = [];
+  for (const t of raw) {
+    if (!t || typeof t !== 'object') continue;
+    const o = t as Record<string, unknown>;
+    const content = typeof o.content === 'string' ? o.content : '';
+    if (!content) continue;
+    const status = o.status === 'in_progress' || o.status === 'completed' ? o.status : 'pending';
+    out.push({
+      content,
+      status,
+      activeForm: typeof o.activeForm === 'string' ? o.activeForm : undefined
+    });
+  }
+  return out;
+}

--- a/tests/stream-to-blocks.test.ts
+++ b/tests/stream-to-blocks.test.ts
@@ -1,0 +1,372 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PartialAssistantStreamer,
+  streamEventToTranslation
+} from '../src/agent/stream-to-blocks';
+
+const asEvent = <T>(x: T) => x as unknown as Parameters<typeof streamEventToTranslation>[0];
+const asPartial = <T>(x: T) => x as unknown as Parameters<PartialAssistantStreamer['consume']>[0];
+
+describe('streamEventToTranslation', () => {
+  it('drops user echoes (avoids dup with InputBar local echo)', () => {
+    const out = streamEventToTranslation(
+      asEvent({
+        type: 'user',
+        session_id: 's1',
+        message: { role: 'user', content: [{ type: 'text', text: 'hello' }] }
+      })
+    );
+    expect(out.append).toEqual([]);
+    expect(out.toolResults).toEqual([]);
+  });
+
+  it('drops system init frames (no banner)', () => {
+    const out = streamEventToTranslation(
+      asEvent({ type: 'system', subtype: 'init', session_id: 's1' })
+    );
+    expect(out).toEqual({ append: [], toolResults: [] });
+  });
+
+  it('compact_boundary system message becomes an info status banner', () => {
+    const out = streamEventToTranslation(
+      asEvent({
+        type: 'system',
+        subtype: 'compact_boundary',
+        uuid: 'sys-1',
+        compact_metadata: { trigger: 'auto', pre_tokens: 124000, post_tokens: 18000, duration_ms: 950 }
+      })
+    );
+    expect(out.append).toHaveLength(1);
+    const b = out.append[0] as { kind: string; tone: string; title: string; detail?: string };
+    expect(b.kind).toBe('status');
+    expect(b.tone).toBe('info');
+    expect(b.title).toMatch(/auto-compacted/i);
+    expect(b.detail).toContain('124,000');
+    expect(b.detail).toContain('18,000');
+  });
+
+  it('api_retry system message becomes a warn status banner with attempt + delay', () => {
+    const out = streamEventToTranslation(
+      asEvent({
+        type: 'system',
+        subtype: 'api_retry',
+        uuid: 'sys-2',
+        attempt: 2,
+        max_retries: 5,
+        retry_delay_ms: 4000,
+        error_status: 503
+      })
+    );
+    expect(out.append).toHaveLength(1);
+    const b = out.append[0] as { tone: string; title: string; detail?: string };
+    expect(b.tone).toBe('warn');
+    expect(b.title).toContain('2/5');
+    expect(b.detail).toContain('4s');
+    expect(b.detail).toContain('503');
+  });
+
+  it('translates assistant text into one assistant block', () => {
+    const out = streamEventToTranslation(
+      asEvent({
+        type: 'assistant',
+        session_id: 's',
+        uuid: 'msg-1',
+        message: { id: 'm-id-1', role: 'assistant', content: [{ type: 'text', text: 'Sure.' }] }
+      })
+    );
+    expect(out.append).toEqual([{ kind: 'assistant', id: 'm-id-1:c0', text: 'Sure.' }]);
+  });
+
+  it('assistant message with rate_limit error appends a rate-limit warn banner', () => {
+    const out = streamEventToTranslation(
+      asEvent({
+        type: 'assistant',
+        session_id: 's',
+        uuid: 'asst-1',
+        message: { id: 'm', role: 'assistant', content: [{ type: 'text', text: 'partial' }] },
+        error: 'rate_limit'
+      })
+    );
+    expect(out.append).toHaveLength(2);
+    expect(out.append[1]).toMatchObject({ kind: 'status', tone: 'warn', title: 'Rate limit hit' });
+  });
+
+  it('assistant message with arbitrary error code emits a generic error banner', () => {
+    const out = streamEventToTranslation(
+      asEvent({
+        type: 'assistant',
+        session_id: 's',
+        uuid: 'asst-2',
+        message: { id: 'm', role: 'assistant', content: [] },
+        error: 'authentication_failed'
+      })
+    );
+    expect(out.append).toHaveLength(1);
+    expect(out.append[0]).toMatchObject({
+      kind: 'status',
+      tone: 'warn',
+      title: 'Authentication failed'
+    });
+  });
+
+  it('translates tool_use into a tool block carrying toolUseId, name, brief', () => {
+    const out = streamEventToTranslation(
+      asEvent({
+        type: 'assistant',
+        session_id: 's',
+        uuid: 'msg-2',
+        message: {
+          id: 'm-id-2',
+          role: 'assistant',
+          content: [
+            { type: 'tool_use', id: 'toolu_001', name: 'Read', input: { file_path: '/a/b/c.ts' } }
+          ]
+        }
+      })
+    );
+    expect(out.append).toHaveLength(1);
+    expect(out.append[0]).toMatchObject({
+      kind: 'tool',
+      toolUseId: 'toolu_001',
+      name: 'Read',
+      brief: '/a/b/c.ts',
+      expanded: false
+    });
+  });
+
+  it('TodoWrite tool_use becomes a todo block (not generic tool)', () => {
+    const out = streamEventToTranslation(
+      asEvent({
+        type: 'assistant',
+        session_id: 's',
+        uuid: 'msg-todo',
+        message: {
+          id: 'm-todo',
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'tu-1',
+              name: 'TodoWrite',
+              input: {
+                todos: [
+                  { content: 'Write tests', status: 'completed' },
+                  { content: 'Implement', status: 'in_progress', activeForm: 'Implementing' }
+                ]
+              }
+            }
+          ]
+        }
+      })
+    );
+    expect(out.append).toHaveLength(1);
+    const b = out.append[0] as { kind: string; todos?: Array<{ status: string; activeForm?: string }> };
+    expect(b.kind).toBe('todo');
+    expect(b.todos).toHaveLength(2);
+    expect(b.todos![1].activeForm).toBe('Implementing');
+  });
+
+  it('extracts tool_result patches from user messages without appending blocks', () => {
+    const out = streamEventToTranslation(
+      asEvent({
+        type: 'user',
+        session_id: 's',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_001',
+              content: [{ type: 'text', text: 'file contents here' }]
+            }
+          ]
+        }
+      })
+    );
+    expect(out.append).toEqual([]);
+    expect(out.toolResults).toEqual([
+      { toolUseId: 'toolu_001', result: 'file contents here', isError: false }
+    ]);
+  });
+
+  it('flags is_error on tool_result patches with plain string content', () => {
+    const out = streamEventToTranslation(
+      asEvent({
+        type: 'user',
+        session_id: 's',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_002',
+              content: 'permission denied',
+              is_error: true
+            }
+          ]
+        }
+      })
+    );
+    expect(out.toolResults).toEqual([
+      { toolUseId: 'toolu_002', result: 'permission denied', isError: true }
+    ]);
+  });
+
+  it('joins multi-part text tool_result content', () => {
+    const out = streamEventToTranslation(
+      asEvent({
+        type: 'user',
+        session_id: 's',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_003',
+              content: [
+                { type: 'text', text: 'line one' },
+                { type: 'text', text: 'line two' }
+              ]
+            }
+          ]
+        }
+      })
+    );
+    expect(out.toolResults[0].result).toBe('line one\nline two');
+  });
+
+  it('successful result emits a stats footer', () => {
+    const out = streamEventToTranslation(
+      asEvent({
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        session_id: 's',
+        uuid: 'res-1',
+        num_turns: 3,
+        duration_ms: 12500,
+        total_cost_usd: 0.0123,
+        usage: { input_tokens: 4500, output_tokens: 1200, cache_read_input_tokens: 8000 }
+      })
+    );
+    expect(out.append).toHaveLength(1);
+    const b = out.append[0] as { kind: string; tone: string; title: string; detail?: string };
+    expect(b.kind).toBe('status');
+    expect(b.tone).toBe('info');
+    expect(b.title).toBe('Done');
+    expect(b.detail).toContain('3 turns');
+    expect(b.detail).toContain('12.5s');
+    expect(b.detail).toMatch(/13k in/);
+    expect(b.detail).toContain('1.2k out');
+    expect(b.detail).toContain('$0.012');
+  });
+
+  it('failed (abnormal end) result emits an error block', () => {
+    const out = streamEventToTranslation(
+      asEvent({
+        type: 'result',
+        subtype: 'error_max_turns',
+        is_error: true,
+        session_id: 's',
+        uuid: 'res-err'
+      })
+    );
+    expect(out.append).toHaveLength(1);
+    expect(out.append[0]).toMatchObject({ kind: 'error' });
+  });
+
+  it('returns empty translation for unknown frame types', () => {
+    const out = streamEventToTranslation(asEvent({ type: 'agent_metadata', agent_id: 'a' }));
+    expect(out).toEqual({ append: [], toolResults: [] });
+  });
+});
+
+function startEvent(messageId: string) {
+  return asPartial({
+    type: 'stream_event',
+    event: { type: 'message_start', message: { id: messageId } }
+  });
+}
+function deltaEvent(index: number, text: string) {
+  return asPartial({
+    type: 'stream_event',
+    event: { type: 'content_block_delta', index, delta: { type: 'text_delta', text } }
+  });
+}
+function stopBlock(index: number) {
+  return asPartial({
+    type: 'stream_event',
+    event: { type: 'content_block_stop', index }
+  });
+}
+
+describe('PartialAssistantStreamer (stream-json)', () => {
+  it('emits one patch per text_delta keyed by message.id + content index', () => {
+    const s = new PartialAssistantStreamer();
+    s.consume(startEvent('msg-X'));
+    expect(s.consume(deltaEvent(0, 'Hel'))).toEqual({
+      blockId: 'msg-X:c0',
+      appendText: 'Hel',
+      done: false
+    });
+    expect(s.consume(deltaEvent(0, 'lo'))).toEqual({
+      blockId: 'msg-X:c0',
+      appendText: 'lo',
+      done: false
+    });
+  });
+
+  it('marks done on content_block_stop', () => {
+    const s = new PartialAssistantStreamer();
+    s.consume(startEvent('msg-X'));
+    expect(s.consume(stopBlock(0))).toEqual({
+      blockId: 'msg-X:c0',
+      appendText: '',
+      done: true
+    });
+  });
+
+  it('returns null for deltas before message_start', () => {
+    const s = new PartialAssistantStreamer();
+    expect(s.consume(deltaEvent(0, 'leak'))).toBeNull();
+  });
+
+  it('clears state on message_stop and ignores subsequent deltas', () => {
+    const s = new PartialAssistantStreamer();
+    s.consume(startEvent('msg-X'));
+    s.consume(asPartial({ type: 'stream_event', event: { type: 'message_stop' } }));
+    expect(s.consume(deltaEvent(0, 'leak'))).toBeNull();
+  });
+
+  it('streamed block id matches the finalized assistant block id (so they coalesce)', () => {
+    const s = new PartialAssistantStreamer();
+    s.consume(startEvent('msg-Z'));
+    const partial = s.consume(deltaEvent(0, 'Hi'));
+    const final = streamEventToTranslation(
+      asEvent({
+        type: 'assistant',
+        session_id: 's',
+        uuid: 'sdk-uuid-Z',
+        message: { id: 'msg-Z', role: 'assistant', content: [{ type: 'text', text: 'Hi there' }] }
+      })
+    );
+    expect(partial?.blockId).toBe((final.append[0] as { id: string }).id);
+  });
+
+  it('ignores non-text deltas (input_json, thinking)', () => {
+    const s = new PartialAssistantStreamer();
+    s.consume(startEvent('msg-X'));
+    expect(
+      s.consume(
+        asPartial({
+          type: 'stream_event',
+          event: {
+            type: 'content_block_delta',
+            index: 1,
+            delta: { type: 'input_json_delta', partial_json: '{"x"' }
+          }
+        })
+      )
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds `src/agent/stream-to-blocks.ts` — the stream-json equivalent of the existing `src/agent/sdk-to-blocks.ts`. Consumes `ClaudeStreamEvent` frames produced by spawning `claude.exe` directly (typed via `electron/agent/stream-json-types.ts`, merged in batch 1) and produces the same `MessageBlock[]` / `ToolResultPatch[]` shapes the renderer already understands.

## Block-API match

The new module exposes the same surface as `sdk-to-blocks.ts`, so no caller (e.g. `lifecycle.ts`) has to change in batch 3 beyond switching the import:

- `streamEventToTranslation(event) -> { append: MessageBlock[]; toolResults: ToolResultPatch[] }` (mirror of `sdkMessageToTranslation`).
- `PartialAssistantStreamer` class with the same `consume()` / patch shape — the inner Anthropic Messages streaming events (`message_start` / `content_block_delta` / `content_block_stop`) are byte-identical between SDK and direct stdout, so the state machine is unchanged.
- Block id derivation (`message.id + ':c' + contentIndex` for text; `:tu<n>` for tool_use) is preserved so streamed deltas still coalesce into the finalized assistant block via `appendBlocks` id-coalesce.

Coverage parity with `sdk-to-blocks`:

- assistant text + tool_use + TodoWrite → todo block
- assistant `error` sibling field (`rate_limit`, `authentication_failed`, etc.) → warn status banner (per SCHEMA-NOTES.md)
- system `init` → no block; `compact_boundary` → info; `api_retry` → warn
- user `tool_result` → `ToolResultPatch[]` (no append)
- result success → stats footer; result error → error block
- unknown frame types (`agent_metadata`, `control_request`, …) → empty translation

`sdk-to-blocks.ts` is left untouched — both files coexist until T9 removes the SDK.

## Gate results

- `npm run typecheck` — 0 errors
- `npm run lint` — 0 errors (1 preexisting `CommandPalette.tsx` warning)
- `npm test -- --run` — 248 passing (21 new in `tests/stream-to-blocks.test.ts`, covering text streaming, tool call/result, error banners, init drop, compact, api_retry, result success/abnormal, partial-streamer coalesce parity)

## Test plan

- [ ] Verify CI green on PR
- [ ] On batch 3 (T9), swap `lifecycle.ts` import from `sdk-to-blocks` to `stream-to-blocks`; renderer behavior should be unchanged.