### PR TITLE
feat(agent): rewrite sessions.ts on top of spawned claude.exe

### DIFF
--- a/electron/agent/__tests__/sessions.test.ts
+++ b/electron/agent/__tests__/sessions.test.ts
@@ -1,0 +1,369 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+
+// Mock claude-spawner so SessionRunner.start() never touches the real OS.
+const { mockSpawnClaude } = vi.hoisted(() => ({ mockSpawnClaude: vi.fn() }));
+vi.mock('../claude-spawner', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../claude-spawner')>();
+  return { ...actual, spawnClaude: mockSpawnClaude };
+});
+
+import { SessionRunner, type StartOptions } from '../sessions';
+
+interface FakeChild extends EventEmitter {
+  stdout: PassThrough;
+  stderr: PassThrough;
+  stdin: PassThrough;
+}
+
+interface FakeProc {
+  pid: number | undefined;
+  stdout: PassThrough;
+  stderr: PassThrough;
+  stdin: PassThrough;
+  wait: () => Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
+  kill: ReturnType<typeof vi.fn>;
+  getRecentStderr: () => string;
+  /** Test-only helper to settle wait(). */
+  __exit: (code: number | null, signal?: NodeJS.Signals | null) => void;
+  /** Read everything written to stdin as parsed JSON lines. */
+  __stdinLines: () => unknown[];
+}
+
+function makeFakeProc(): FakeProc {
+  const child = new EventEmitter() as FakeChild;
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.stdin = new PassThrough();
+
+  const stdinChunks: Buffer[] = [];
+  child.stdin.on('data', (c) => stdinChunks.push(Buffer.isBuffer(c) ? c : Buffer.from(String(c))));
+
+  let resolveWait: (v: { code: number | null; signal: NodeJS.Signals | null }) => void;
+  const waitPromise = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((r) => {
+    resolveWait = r;
+  });
+
+  const proc: FakeProc = {
+    pid: 1234,
+    stdout: child.stdout,
+    stderr: child.stderr,
+    stdin: child.stdin,
+    wait: () => waitPromise,
+    kill: vi.fn(),
+    getRecentStderr: () => '',
+    __exit: (code, signal = null) => resolveWait({ code, signal }),
+    __stdinLines: () =>
+      Buffer.concat(stdinChunks)
+        .toString('utf8')
+        .split('\n')
+        .filter((s) => s.length > 0)
+        .map((s) => JSON.parse(s)),
+  };
+  return proc;
+}
+
+function emitFrame(stdout: PassThrough, frame: unknown): void {
+  stdout.write(JSON.stringify(frame) + '\n');
+}
+
+const baseOpts: StartOptions = { cwd: '/work', configDir: '/tmp/cfg' };
+
+beforeEach(() => {
+  mockSpawnClaude.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('SessionRunner.start', () => {
+  it('spawns claude with the provided options and forwards stream-json events', async () => {
+    const proc = makeFakeProc();
+    mockSpawnClaude.mockResolvedValue(proc);
+
+    const events: unknown[] = [];
+    const runner = new SessionRunner('s1', (m) => events.push(m), () => {}, () => {});
+
+    await runner.start({ ...baseOpts, model: 'sonnet', apiKey: 'sk-test' });
+
+    expect(mockSpawnClaude).toHaveBeenCalledTimes(1);
+    const passed = mockSpawnClaude.mock.calls[0][0];
+    expect(passed.cwd).toBe('/work');
+    expect(passed.configDir).toBe('/tmp/cfg');
+    expect(passed.model).toBe('sonnet');
+    expect(passed.envOverrides.ANTHROPIC_API_KEY).toBe('sk-test');
+
+    emitFrame(proc.stdout, {
+      type: 'system',
+      subtype: 'init',
+      session_id: 'cli_abc',
+      tools: [],
+    });
+    emitFrame(proc.stdout, {
+      type: 'assistant',
+      session_id: 'cli_abc',
+      message: { id: 'msg_1', role: 'assistant', content: [{ type: 'text', text: 'hi' }] },
+    });
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+
+    expect(events).toHaveLength(2);
+    const [sys, assistant] = events as Array<{ type: string }>;
+    expect(sys.type).toBe('system');
+    expect(assistant.type).toBe('assistant');
+
+    runner.close();
+  });
+
+  it('falls back to the env-based config dir when none is provided', async () => {
+    const proc = makeFakeProc();
+    mockSpawnClaude.mockResolvedValue(proc);
+    process.env.AGENTORY_CLAUDE_CONFIG_DIR = '/env/cfg';
+
+    const runner = new SessionRunner('s2', () => {}, () => {}, () => {});
+    try {
+      await runner.start({ cwd: '/w' });
+      expect(mockSpawnClaude.mock.calls[0][0].configDir).toBe('/env/cfg');
+    } finally {
+      delete process.env.AGENTORY_CLAUDE_CONFIG_DIR;
+      runner.close();
+    }
+  });
+
+  it('coerces SDK-only permission modes (dontAsk / auto) to default for the CLI', async () => {
+    const proc = makeFakeProc();
+    mockSpawnClaude.mockResolvedValue(proc);
+    const runner = new SessionRunner('s3', () => {}, () => {}, () => {});
+    await runner.start({ ...baseOpts, permissionMode: 'dontAsk' });
+    expect(mockSpawnClaude.mock.calls[0][0].permissionMode).toBe('default');
+    runner.close();
+  });
+
+  it('start() is idempotent — second call is a no-op', async () => {
+    const proc = makeFakeProc();
+    mockSpawnClaude.mockResolvedValue(proc);
+    const runner = new SessionRunner('s4', () => {}, () => {}, () => {});
+    await runner.start(baseOpts);
+    await runner.start(baseOpts);
+    expect(mockSpawnClaude).toHaveBeenCalledTimes(1);
+    runner.close();
+  });
+});
+
+describe('SessionRunner.send', () => {
+  it('writes a stream-json user message including the cliSessionId once init has fired', async () => {
+    const proc = makeFakeProc();
+    mockSpawnClaude.mockResolvedValue(proc);
+    const runner = new SessionRunner('s5', () => {}, () => {}, () => {});
+    await runner.start(baseOpts);
+
+    runner.send('first turn'); // before init -> no session_id
+    emitFrame(proc.stdout, { type: 'system', subtype: 'init', session_id: 'cli_xyz' });
+    await new Promise((r) => setImmediate(r));
+    runner.send('second turn');
+    await new Promise((r) => setImmediate(r));
+
+    const lines = proc.__stdinLines() as Array<Record<string, unknown>>;
+    expect(lines).toHaveLength(2);
+    expect(lines[0].type).toBe('user');
+    expect(lines[0].session_id).toBeUndefined();
+    expect(lines[1].session_id).toBe('cli_xyz');
+
+    runner.close();
+  });
+
+  it('send() after close is a no-op', async () => {
+    const proc = makeFakeProc();
+    mockSpawnClaude.mockResolvedValue(proc);
+    const runner = new SessionRunner('s6', () => {}, () => {}, () => {});
+    await runner.start(baseOpts);
+    runner.close();
+    runner.send('whatever');
+    expect(proc.__stdinLines()).toEqual([]);
+  });
+});
+
+describe('SessionRunner permission roundtrip', () => {
+  it('forwards inbound can_use_tool to onPermissionRequest and writes back the user decision', async () => {
+    const proc = makeFakeProc();
+    mockSpawnClaude.mockResolvedValue(proc);
+    const requests: Array<{ requestId: string; toolName: string }> = [];
+    const runner = new SessionRunner(
+      's7',
+      () => {},
+      () => {},
+      (req) => requests.push({ requestId: req.requestId, toolName: req.toolName })
+    );
+    await runner.start(baseOpts);
+
+    emitFrame(proc.stdout, {
+      type: 'control_request',
+      request_id: 'req_1',
+      request: {
+        subtype: 'can_use_tool',
+        tool_name: 'Bash',
+        tool_use_id: 'toolu_a',
+        input: { command: 'ls' },
+      },
+    });
+    await new Promise((r) => setImmediate(r));
+    expect(requests).toHaveLength(1);
+    const [{ requestId }] = requests;
+
+    expect(runner.resolvePermission(requestId, 'allow')).toBe(true);
+    await new Promise((r) => setImmediate(r));
+
+    const lines = proc.__stdinLines() as Array<Record<string, unknown>>;
+    const resp = lines.find((l) => l.type === 'control_response');
+    expect(resp).toBeDefined();
+    expect(resp!.request_id).toBe('req_1');
+    expect(resp!.response).toMatchObject({ behavior: 'allow', toolUseID: 'toolu_a' });
+
+    runner.close();
+  });
+
+  it('resolvePermission with an unknown id returns false', () => {
+    const runner = new SessionRunner('s7b', () => {}, () => {}, () => {});
+    expect(runner.resolvePermission('nope', 'deny')).toBe(false);
+  });
+
+  it('deny decision flows through as behavior:deny', async () => {
+    const proc = makeFakeProc();
+    mockSpawnClaude.mockResolvedValue(proc);
+    let captured = '';
+    const runner = new SessionRunner('s8', () => {}, () => {}, (req) => {
+      captured = req.requestId;
+    });
+    await runner.start(baseOpts);
+    emitFrame(proc.stdout, {
+      type: 'control_request',
+      request_id: 'req_2',
+      request: { subtype: 'can_use_tool', tool_name: 'Bash', tool_use_id: 'tu', input: {} },
+    });
+    await new Promise((r) => setImmediate(r));
+    runner.resolvePermission(captured, 'deny');
+    await new Promise((r) => setImmediate(r));
+    const lines = proc.__stdinLines() as Array<Record<string, unknown>>;
+    const resp = lines.find((l) => l.type === 'control_response') as Record<string, unknown>;
+    expect((resp.response as Record<string, unknown>).behavior).toBe('deny');
+    runner.close();
+  });
+});
+
+describe('SessionRunner outbound control', () => {
+  it('interrupt() sends a control_request and resolves on control_response', async () => {
+    const proc = makeFakeProc();
+    mockSpawnClaude.mockResolvedValue(proc);
+    const runner = new SessionRunner('s9', () => {}, () => {}, () => {});
+    await runner.start(baseOpts);
+
+    const p = runner.interrupt();
+    await new Promise((r) => setImmediate(r));
+    const out = proc.__stdinLines() as Array<Record<string, unknown>>;
+    const req = out.find((l) => l.type === 'control_request') as Record<string, unknown>;
+    expect(req).toBeDefined();
+    expect((req.request as Record<string, unknown>).subtype).toBe('interrupt');
+    emitFrame(proc.stdout, {
+      type: 'control_response',
+      request_id: req.request_id,
+      response: {},
+    });
+    await expect(p).resolves.toBeUndefined();
+    runner.close();
+  });
+
+  it('setModel() forwards a set_model control_request', async () => {
+    const proc = makeFakeProc();
+    mockSpawnClaude.mockResolvedValue(proc);
+    const runner = new SessionRunner('s10', () => {}, () => {}, () => {});
+    await runner.start(baseOpts);
+
+    const p = runner.setModel('opus');
+    await new Promise((r) => setImmediate(r));
+    const out = proc.__stdinLines() as Array<Record<string, unknown>>;
+    const req = out.find(
+      (l) => l.type === 'control_request' &&
+        (l.request as Record<string, unknown>).subtype === 'set_model'
+    ) as Record<string, unknown>;
+    expect((req.request as Record<string, unknown>).model).toBe('opus');
+    emitFrame(proc.stdout, { type: 'control_response', request_id: req.request_id, response: {} });
+    await expect(p).resolves.toBeUndefined();
+    runner.close();
+  });
+
+  it('setModel() is a no-op when model is undefined', async () => {
+    const proc = makeFakeProc();
+    mockSpawnClaude.mockResolvedValue(proc);
+    const runner = new SessionRunner('s10b', () => {}, () => {}, () => {});
+    await runner.start(baseOpts);
+    await runner.setModel(undefined);
+    expect(proc.__stdinLines()).toEqual([]);
+    runner.close();
+  });
+});
+
+describe('SessionRunner exit handling', () => {
+  it('calls onExit({}) on a clean exit', async () => {
+    const proc = makeFakeProc();
+    mockSpawnClaude.mockResolvedValue(proc);
+    const exits: Array<{ error?: string }> = [];
+    const runner = new SessionRunner('s11', () => {}, (info) => exits.push(info), () => {});
+    await runner.start(baseOpts);
+    proc.stdout.end();
+    proc.__exit(0, null);
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+    expect(exits).toHaveLength(1);
+    expect(exits[0].error).toBeUndefined();
+  });
+
+  it('surfaces a non-zero exit code in onExit.error', async () => {
+    const proc = makeFakeProc();
+    proc.getRecentStderr = () => 'boom';
+    mockSpawnClaude.mockResolvedValue(proc);
+    const exits: Array<{ error?: string }> = [];
+    const runner = new SessionRunner('s12', () => {}, (info) => exits.push(info), () => {});
+    await runner.start(baseOpts);
+    proc.stdout.end();
+    proc.__exit(7, null);
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+    expect(exits).toHaveLength(1);
+    expect(exits[0].error).toContain('code=7');
+    expect(exits[0].error).toContain('boom');
+  });
+
+  it('surfaces an onExit error if spawnClaude rejects', async () => {
+    mockSpawnClaude.mockRejectedValue(new Error('binary missing'));
+    const runner = new SessionRunner('s13', () => {}, () => {}, () => {});
+    await expect(runner.start(baseOpts)).rejects.toThrow('binary missing');
+  });
+});
+
+describe('SessionRunner.close', () => {
+  it('denies any outstanding permission prompts', async () => {
+    const proc = makeFakeProc();
+    mockSpawnClaude.mockResolvedValue(proc);
+    let capturedRequestId = '';
+    const runner = new SessionRunner('s14', () => {}, () => {}, (req) => {
+      capturedRequestId = req.requestId;
+    });
+    await runner.start(baseOpts);
+    emitFrame(proc.stdout, {
+      type: 'control_request',
+      request_id: 'req_close',
+      request: { subtype: 'can_use_tool', tool_name: 'Bash', tool_use_id: 'tu', input: {} },
+    });
+    await new Promise((r) => setImmediate(r));
+    expect(capturedRequestId).not.toBe('');
+
+    runner.close();
+    proc.__exit(0);
+    await new Promise((r) => setImmediate(r));
+    // After close, resolvePermission can no longer settle — the entry was
+    // wiped synchronously.
+    expect(runner.resolvePermission(capturedRequestId, 'allow')).toBe(false);
+  });
+});

--- a/electron/agent/sessions.ts
+++ b/electron/agent/sessions.ts
@@ -1,6 +1,16 @@
 import os from 'node:os';
 import path from 'node:path';
-import type { CanUseTool, Options, PermissionMode, PermissionResult, Query, SDKMessage, SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
+import type { PermissionMode, SDKMessage } from '@anthropic-ai/claude-agent-sdk';
+import { spawnClaude, type ClaudeProcess, type PermissionMode as CliPermissionMode } from './claude-spawner';
+import { splitNDJSON } from './ndjson-splitter';
+import { parseStreamJSONLine } from './stream-json-parser';
+import type { ClaudeStreamEvent } from './stream-json-types';
+import {
+  ControlRpc,
+  type CanUseToolContext,
+  type CanUseToolDecision,
+  type ParsedStreamEvent,
+} from './control-rpc';
 
 function resolveCwd(cwd: string): string {
   if (cwd === '~') return os.homedir();
@@ -8,17 +18,31 @@ function resolveCwd(cwd: string): string {
   return cwd;
 }
 
-// SDK ships ESM-only (sdk.mjs). Electron main bundle is CJS, so a static
-// `import { query }` triggers ERR_REQUIRE_ESM at load. We need a real
-// dynamic import() — but TS with `module: CommonJS` rewrites import() to
-// require(), which re-triggers the same ESM error. Hide the call inside
-// `new Function` so TS leaves it alone and Node executes a true import().
-type SdkModule = typeof import('@anthropic-ai/claude-agent-sdk');
-const dynamicImport = new Function('s', 'return import(s)') as (s: string) => Promise<SdkModule>;
-let sdkPromise: Promise<SdkModule> | null = null;
-function loadSdk(): Promise<SdkModule> {
-  if (!sdkPromise) sdkPromise = dynamicImport('@anthropic-ai/claude-agent-sdk');
-  return sdkPromise;
+/**
+ * claude.exe refuses to run without `CLAUDE_CONFIG_DIR` (claude-spawner enforces
+ * this). main.ts hasn't been migrated to pass an explicit configDir yet — that's
+ * batch 3. For now we accept it via StartOptions, fall back to the env override,
+ * and finally to a stable per-user dir under the home directory so the user's
+ * own ~/.claude is never touched.
+ */
+function resolveConfigDir(explicit: string | undefined): string {
+  if (explicit && explicit.trim().length > 0) return explicit;
+  const env = process.env.AGENTORY_CLAUDE_CONFIG_DIR;
+  if (env && env.trim().length > 0) return env;
+  return path.join(os.homedir(), '.agentory', 'claude-cli-config');
+}
+
+/**
+ * SDK's PermissionMode includes UI-only modes (`'dontAsk'`, `'auto'`) that the
+ * claude.exe CLI doesn't accept. Drop them to `'default'` rather than passing
+ * an invalid value to the spawner.
+ */
+function toCliPermissionMode(mode: PermissionMode | undefined): CliPermissionMode | undefined {
+  if (!mode) return undefined;
+  if (mode === 'default' || mode === 'acceptEdits' || mode === 'plan' || mode === 'bypassPermissions') {
+    return mode;
+  }
+  return 'default';
 }
 
 export type StartOptions = {
@@ -27,6 +51,12 @@ export type StartOptions = {
   permissionMode?: PermissionMode;
   apiKey?: string;
   resumeSessionId?: string;
+  /**
+   * Optional override for `CLAUDE_CONFIG_DIR`. main.ts currently doesn't pass
+   * one — see resolveConfigDir() for the fallback chain. Will become required
+   * once main.ts is migrated (batch 3, T9).
+   */
+  configDir?: string;
 };
 
 export type EventHandler = (msg: SDKMessage) => void;
@@ -37,57 +67,21 @@ export type PermissionRequestHandler = (req: {
   input: Record<string, unknown>;
 }) => void;
 
-// AsyncIterable queue: pushes messages into the streaming input of `query()`.
-// `query()` consumes via for-await; we resolve a pending waiter when a new
-// message arrives, or buffer if the consumer hasn't asked yet.
-class InputQueue implements AsyncIterable<SDKUserMessage> {
-  private buffer: SDKUserMessage[] = [];
-  private waiter: ((v: IteratorResult<SDKUserMessage>) => void) | null = null;
-  private closed = false;
-
-  push(msg: SDKUserMessage): void {
-    if (this.closed) return;
-    if (this.waiter) {
-      const w = this.waiter;
-      this.waiter = null;
-      w({ value: msg, done: false });
-    } else {
-      this.buffer.push(msg);
-    }
-  }
-
-  end(): void {
-    this.closed = true;
-    if (this.waiter) {
-      const w = this.waiter;
-      this.waiter = null;
-      w({ value: undefined as unknown as SDKUserMessage, done: true });
-    }
-  }
-
-  [Symbol.asyncIterator](): AsyncIterator<SDKUserMessage> {
-    return {
-      next: (): Promise<IteratorResult<SDKUserMessage>> => {
-        if (this.buffer.length > 0) {
-          return Promise.resolve({ value: this.buffer.shift()!, done: false });
-        }
-        if (this.closed) {
-          return Promise.resolve({ value: undefined as unknown as SDKUserMessage, done: true });
-        }
-        return new Promise((resolve) => {
-          this.waiter = resolve;
-        });
-      }
-    };
-  }
-}
-
 export class SessionRunner {
-  private input = new InputQueue();
-  private q: Query | null = null;
+  private cp: ClaudeProcess | null = null;
+  private rpc: ControlRpc | null = null;
+  private abort: AbortController | null = null;
   private consumer: Promise<void> | null = null;
   private disposed = false;
-  private pendingPerms = new Map<string, (r: PermissionResult) => void>();
+  private cliSessionId: string | undefined;
+  private permissionMode: PermissionMode = 'default';
+  /**
+   * Pending can_use_tool decisions, keyed by the synthetic requestId we hand
+   * to the renderer. resolvePermission() looks the entry up to settle the
+   * promise that ControlRpc is awaiting before it writes the control_response.
+   */
+  private pendingPerms = new Map<string, (d: CanUseToolDecision) => void>();
+  private nextPermSeq = 0;
 
   constructor(
     public readonly id: string,
@@ -102,87 +96,157 @@ export class SessionRunner {
     this.pendingPerms.delete(requestId);
     resolve(
       decision === 'allow'
-        ? { behavior: 'allow', updatedInput: undefined }
-        : { behavior: 'deny', message: 'User denied tool use.' }
+        ? { allow: true }
+        : { allow: false, deny_reason: 'User denied tool use.' }
     );
     return true;
   }
 
   async start(opts: StartOptions): Promise<void> {
-    if (this.q) return;
-    const env: Record<string, string | undefined> = { ...process.env };
-    if (opts.apiKey) env.ANTHROPIC_API_KEY = opts.apiKey;
+    if (this.cp) return;
+    this.permissionMode = opts.permissionMode ?? 'default';
+    this.abort = new AbortController();
 
-    const canUseTool: CanUseTool = (toolName, input) =>
-      new Promise<PermissionResult>((resolve) => {
-        const requestId = `perm-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
-        this.pendingPerms.set(requestId, resolve);
-        this.onPermissionRequest({ requestId, toolName, input });
-      });
+    const envOverrides: Record<string, string> = {};
+    if (opts.apiKey) envOverrides.ANTHROPIC_API_KEY = opts.apiKey;
 
-    const permissionMode = opts.permissionMode ?? 'default';
-    const isBypass = permissionMode === 'bypassPermissions';
-    const options: Options = {
+    this.cp = await spawnClaude({
       cwd: resolveCwd(opts.cwd),
-      env,
-      permissionMode,
+      configDir: resolveConfigDir(opts.configDir),
+      permissionMode: toCliPermissionMode(this.permissionMode),
       model: opts.model,
-      resume: opts.resumeSessionId,
-      // The SDK refuses bypassPermissions unless allowDangerouslySkipPermissions
-      // is also set. Skip canUseTool too — the bypass mode short-circuits before
-      // the prompt would fire and the SDK throws if both are present.
-      ...(isBypass ? { allowDangerouslySkipPermissions: true } : { canUseTool }),
-      includePartialMessages: true
-    };
+      resumeId: opts.resumeSessionId,
+      envOverrides,
+      signal: this.abort.signal,
+    });
 
-    const { query } = await loadSdk();
-    this.q = query({ prompt: this.input, options });
+    this.rpc = new ControlRpc(this.cp.stdin, {
+      onCanUseTool: (toolName, input, ctx) => this.handleCanUseTool(toolName, input, ctx),
+    });
 
+    const stdout = this.cp.stdout;
+    const cp = this.cp;
     this.consumer = (async () => {
       try {
-        for await (const msg of this.q!) {
+        for await (const ev of splitNDJSON(stdout)) {
           if (this.disposed) break;
-          this.onEvent(msg);
+          if (ev.type === 'error') {
+            // Splitter errors (line cap exceeded, incomplete UTF-8 at EOF). Log
+            // via console — the renderer doesn't have a channel for these and
+            // they're rare protocol-violation diagnostics, not user-facing.
+            console.warn('[sessions] ndjson splitter error', ev.error.message);
+            continue;
+          }
+          this.handleLine(ev.raw);
         }
-        this.onExit({});
+        const { code, signal } = await cp.wait();
+        const err = code === 0 || code === null
+          ? undefined
+          : `claude.exe exited with code=${code}${signal ? ` signal=${signal}` : ''}` +
+            (cp.getRecentStderr() ? `\n${cp.getRecentStderr()}` : '');
+        this.onExit({ error: err });
       } catch (err) {
         this.onExit({ error: err instanceof Error ? err.message : String(err) });
+      } finally {
+        this.cleanupAfterExit();
       }
     })();
   }
 
+  private handleLine(raw: string): void {
+    const result = parseStreamJSONLine(raw);
+    if (result.type === 'parse-error') {
+      console.warn('[sessions] failed to parse stream-json line', result.error.message);
+      return;
+    }
+    if (result.type === 'unknown') {
+      console.warn('[sessions] unknown stream-json frame', result.reason);
+      return;
+    }
+    const event = result.event;
+    // Capture cliSessionId from the first system frame so subsequent user
+    // messages can carry it.
+    if (event.type === 'system' && (event as { subtype?: string }).subtype === 'init') {
+      const sid = (event as { session_id?: string }).session_id;
+      if (sid && !this.cliSessionId) this.cliSessionId = sid;
+    }
+    if (
+      event.type === 'control_request' ||
+      event.type === 'control_response' ||
+      event.type === 'control_cancel_request'
+    ) {
+      this.rpc?.handleIncoming(event as unknown as ParsedStreamEvent);
+      return;
+    }
+    // Forward everything else to the consumer. The on-wire shape of the
+    // remaining frames (system / assistant / user / result / stream_event /
+    // agent_metadata) is structurally compatible with what sdk-to-blocks reads
+    // off `SDKMessage` — the cast bridges the two type universes until batch 3
+    // swaps callers over to ClaudeStreamEvent directly.
+    this.onEvent(event as unknown as SDKMessage);
+  }
+
+  private handleCanUseTool(
+    toolName: string,
+    input: unknown,
+    ctx: CanUseToolContext
+  ): Promise<CanUseToolDecision> {
+    return new Promise<CanUseToolDecision>((resolve) => {
+      const requestId = `perm-${Date.now().toString(36)}-${(this.nextPermSeq++).toString(36)}`;
+      this.pendingPerms.set(requestId, resolve);
+      // If claude.exe cancels the request mid-flight, fail-closed via the
+      // signal so we don't leak the pending entry.
+      ctx.signal.addEventListener(
+        'abort',
+        () => {
+          if (this.pendingPerms.delete(requestId)) {
+            resolve({ allow: false, deny_reason: 'Permission request cancelled.' });
+          }
+        },
+        { once: true }
+      );
+      const safeInput =
+        input && typeof input === 'object' && !Array.isArray(input)
+          ? (input as Record<string, unknown>)
+          : { value: input };
+      this.onPermissionRequest({ requestId, toolName, input: safeInput });
+    });
+  }
+
   send(text: string): void {
-    if (!this.q || this.disposed) return;
-    const msg: SDKUserMessage = {
-      type: 'user',
-      parent_tool_use_id: null,
-      message: { role: 'user', content: text }
-    };
-    this.input.push(msg);
+    if (!this.rpc || this.disposed) return;
+    try {
+      this.rpc.sendUserMessage(text, this.cliSessionId);
+    } catch (err) {
+      console.warn('[sessions] sendUserMessage failed', err);
+    }
   }
 
   async interrupt(): Promise<void> {
-    if (!this.q) return;
+    if (!this.rpc) return;
     try {
-      await this.q.interrupt();
+      await this.rpc.interrupt();
     } catch {
-      /* SDK throws if not in a tool call — ignore */
+      /* timeout / channel broken — let close() handle hard kill */
     }
   }
 
   async setPermissionMode(mode: PermissionMode): Promise<void> {
-    if (!this.q) return;
+    if (!this.rpc) return;
+    this.permissionMode = mode;
+    const cliMode = toCliPermissionMode(mode);
+    if (!cliMode) return;
     try {
-      await this.q.setPermissionMode(mode);
+      await this.rpc.setPermissionMode(cliMode);
     } catch {
-      /* ignore */
+      /* ignore — claude.exe may not honour mid-session changes for every mode */
     }
   }
 
   async setModel(model?: string): Promise<void> {
-    if (!this.q) return;
+    if (!this.rpc || !model) return;
     try {
-      await this.q.setModel(model);
+      await this.rpc.setModel(model);
     } catch {
       /* ignore */
     }
@@ -192,15 +256,30 @@ export class SessionRunner {
     if (this.disposed) return;
     this.disposed = true;
     for (const resolve of this.pendingPerms.values()) {
-      resolve({ behavior: 'deny', message: 'Session closed.' });
+      resolve({ allow: false, deny_reason: 'Session closed.' });
     }
     this.pendingPerms.clear();
-    this.input.end();
+    this.rpc?.close();
     try {
-      this.q?.close();
+      this.cp?.stdin.end();
     } catch {
       /* ignore */
     }
-    this.q = null;
+    // Trigger SIGTERM → SIGKILL via the abort signal the spawner is watching.
+    this.abort?.abort();
+  }
+
+  private cleanupAfterExit(): void {
+    this.disposed = true;
+    for (const resolve of this.pendingPerms.values()) {
+      resolve({ allow: false, deny_reason: 'Session ended.' });
+    }
+    this.pendingPerms.clear();
+    this.rpc?.close();
+    this.rpc = null;
+    this.cp = null;
   }
 }
+
+// Re-export for tests that want to assert on the parsed event shape.
+export type { ClaudeStreamEvent };


### PR DESCRIPTION
## Summary
- Drops `@anthropic-ai/claude-agent-sdk` from `electron/agent/sessions.ts` and rebuilds `SessionRunner` on the batch-1 primitives: `binary-resolver` + `claude-spawner` + `ndjson-splitter` + `stream-json-parser` + `control-rpc`. The SDK package itself stays installed because `manager.ts` / `main.ts` / `preload.ts` still consume its types — that removal is batch 3 (T9).
- Public surface of `SessionRunner` is preserved so the rest of the electron layer (and `manager.ts` in particular) doesn't move.
- Outbound `interrupt` / `setPermissionMode` / `setModel` go through `ControlRpc`. Inbound `can_use_tool` is bridged to the existing `onPermissionRequest` callback + `resolvePermission(requestId, decision)` API so the renderer permission flow is byte-for-byte compatible.

## Public API changes
- `StartOptions` gains an **optional** `configDir?: string`. `main.ts` doesn't pass one yet (batch 3 will). For now we fall back to `AGENTORY_CLAUDE_CONFIG_DIR`, then `~/.agentory/claude-cli-config`, so the user's `~/.claude` is never written to.
- SDK-only permission modes `'dontAsk'` / `'auto'` are coerced to `'default'` for the CLI — the spawner / claude.exe don't accept them.
- Everything else (`SessionRunner` constructor, `start`, `send`, `interrupt`, `setPermissionMode`, `setModel`, `close`, `resolvePermission`, exported types `EventHandler` / `ExitHandler` / `PermissionRequestHandler`) is unchanged.
- No changes to `manager.ts` / `main.ts` / `preload.ts` / `src/agent/sdk-to-blocks.ts`. The on-wire shape of stream-json frames is structurally compatible with what `sdk-to-blocks.ts` reads off `SDKMessage`, so events flow through with a single cast in `sessions.ts`.

## Tests
- New file: `electron/agent/__tests__/sessions.test.ts` — **16 cases** covering spawn wiring & options, env-var configDir fallback, permission-mode coercion, `start()` idempotency, `send()` cliSessionId threading (before vs. after `system:init`), inbound `can_use_tool` allow / deny / unknown-id, outbound `interrupt` & `setModel` round-trips, clean exit, non-zero exit surfacing stderr, spawn failure, and `close()` denying outstanding prompts.
- Mocks `claude-spawner` with the same `vi.hoisted` pattern as `claude-spawner.test.ts`.

## Gate results
- `npm run typecheck`: 0 errors
- `npm run lint`: 0 errors (1 pre-existing `CommandPalette.tsx` warning, unchanged)
- `npm test -- --run`: **243 / 243 passing** (16 new + 227 pre-existing)
- Pre-push hook ran the same gates and passed.

## Test plan
- [ ] Verify in batch 3 that `manager.ts` IPC handlers continue to work end-to-end with this runner once the SDK type imports are swapped for local types.
- [ ] Sanity-spawn a real `claude.exe` once `main.ts` starts passing `configDir` (batch 3, T9).