### PR TITLE
fix(agent): forward ANTHROPIC_ env vars to spawned claude.exe

### DIFF
--- a/docs/dogfood-report-2026-04-21.md
+++ b/docs/dogfood-report-2026-04-21.md
@@ -96,3 +96,117 @@ Pre-existing issues observed (not T10 scope, but logged for the backlog):
 ## Bug fixes committed in this task
 
 None. Source was not modified. Only addition: `scripts/probe-e2e-tool-call-dogfood.mjs` — a new probe script used to exercise the live claude.exe tool-call path.
+
+---
+
+## Follow-up (same day): real end-to-end — UI send → assistant reply
+
+The original report stopped at "Not logged in" because `CLAUDE_CONFIG_DIR`
+is pinned to an isolated dir with no credentials. That was the correct
+observation of behavior, but it short-circuited the actual e2e. A real
+user never logs in inside the isolated config — they set
+`ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` as env vars (mirror of how
+they use the CLI). Those env vars were being dropped by the SAFE_ENV
+allowlist in `claude-spawner.ts` because the allowlist predates the
+self-host story.
+
+Per MEMORY.md, self-host via custom `ANTHROPIC_BASE_URL` + custom key is
+Agentory's structural moat, so env passthrough is not optional.
+
+### Fix
+
+`electron/agent/claude-spawner.ts` — added two prefixes to `SAFE_ENV.prefixes`:
+
+- `ANTHROPIC_` — covers `ANTHROPIC_BASE_URL`, `ANTHROPIC_API_KEY`,
+  `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_DEFAULT_{HAIKU,SONNET,OPUS}_MODEL`,
+  `ANTHROPIC_SMALL_FAST_MODEL`, `ANTHROPIC_CUSTOM_HEADERS`, and any future
+  `ANTHROPIC_*` the CLI adds.
+- `CLAUDE_CODE_` — covers `CLAUDE_CODE_USE_BEDROCK`,
+  `CLAUDE_CODE_USE_VERTEX`, `CLAUDE_CODE_SKIP_AUTH_LOGIN`, etc.
+
+Also hardened `CLAUDE_CODE_ENTRYPOINT`: previously it conditionally
+preserved the parent's value; now we unconditionally stamp
+`agentory-desktop` so server-side telemetry correctly identifies the
+client even when Agentory is dogfooded from inside a Claude Code session
+(where the parent sets `CLAUDE_CODE_ENTRYPOINT=cli`). `envOverrides` can
+still override it for tests.
+
+`CLAUDE_CONFIG_DIR` remains unconditionally overwritten to the isolated
+path — state isolation is preserved. Env-based credentials take
+precedence, which is exactly what claude.exe expects.
+
+Proxy vars (`HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` / `ALL_PROXY`) were
+already on the exact-match list.
+
+### New tests
+
+5 new tests in `electron/agent/__tests__/claude-spawner.test.ts`:
+
+- forwards `ANTHROPIC_*` credentials + endpoint configuration from parent env
+- forwards `CLAUDE_CODE_*` runtime flags (Bedrock/Vertex)
+- always overwrites `CLAUDE_CONFIG_DIR` with the isolated path
+- `envOverrides` still win over forwarded `ANTHROPIC_*` parent vars
+- existing "injects CLAUDE_CODE_ENTRYPOINT" test updated to reflect
+  unconditional stamping
+
+Total: 242/242 tests green (was 237 before this fix).
+
+### Real end-to-end (UI send → assistant reply)
+
+Script: `scripts/probe-e2e-env-passthrough.mjs`.
+
+Parent env: `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` set (values
+redacted). Launched Electron via Playwright with inherited env, clicked
+"New Session", typed the prompt, pressed Enter, waited up to 60s for an
+assistant block containing "OK".
+
+Prompt:
+
+```
+Reply with exactly the single word OK and nothing else.
+```
+
+Result: PASS in ~3.6s round-trip. Final chat region DOM innerText:
+
+```
+>
+Reply with exactly the single word OK and nothing else.
+●
+
+OK
+
+INFO
+Done
+— 1 turn · 3.6s · 32k in / 1 out · $0.487
+agentory-next
+·
+opus-4
+·
+auto
+Send
+Enter send · Shift+Enter newline
+```
+
+Interpretation:
+
+- `>` and `●` are the user and assistant author glyphs (CLI-visual
+  principle).
+- `OK` is the assistant reply, verbatim, matching the requested format.
+- `INFO Done — 1 turn · 3.6s · 32k in / 1 out · $0.487` is the
+  `StatusBanner` emitted from the `result` stream-json frame —
+  confirming the full turn round-tripped through `buildSpawnEnv` →
+  claude.exe → custom endpoint → stream-json → `streamToBlocks` →
+  renderer.
+- No "Not logged in" banner, no error blocks.
+
+### Updated verdict
+
+**End-to-end passes.** The SDK-removal migration is fully functional for
+the self-host workflow. A user who sets `ANTHROPIC_BASE_URL` +
+`ANTHROPIC_AUTH_TOKEN` in their shell and launches Agentory gets a real
+assistant turn with zero extra configuration and without their
+credentials being written to the isolated `~/.agentory/claude-cli-config/`.
+
+The earlier "Not logged in" observation was an artifact of the SAFE_ENV
+allowlist, not a protocol or spawn-layer bug.
+

--- a/electron/agent/__tests__/claude-spawner.test.ts
+++ b/electron/agent/__tests__/claude-spawner.test.ts
@@ -488,6 +488,56 @@ describe('SAFE_ENV whitelist', () => {
     expect(env.RANDOM_THING).toBeUndefined();
   });
 
+  it('forwards ANTHROPIC_* credentials + endpoint configuration from parent env', () => {
+    process.env.ANTHROPIC_BASE_URL = 'https://gateway.example.com';
+    process.env.ANTHROPIC_API_KEY = 'sk-parent-api';
+    process.env.ANTHROPIC_AUTH_TOKEN = 'sk-parent-auth';
+    process.env.ANTHROPIC_DEFAULT_HAIKU_MODEL = 'haiku-local';
+    process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = 'sonnet-local';
+    process.env.ANTHROPIC_DEFAULT_OPUS_MODEL = 'opus-local';
+    process.env.ANTHROPIC_SMALL_FAST_MODEL = 'fast-local';
+    process.env.ANTHROPIC_CUSTOM_HEADERS = 'X-Org: foo';
+    const env = buildSpawnEnv({ configDir: '/cfg' });
+    expect(ci(env, 'ANTHROPIC_BASE_URL')).toBe('https://gateway.example.com');
+    expect(ci(env, 'ANTHROPIC_API_KEY')).toBe('sk-parent-api');
+    expect(ci(env, 'ANTHROPIC_AUTH_TOKEN')).toBe('sk-parent-auth');
+    expect(ci(env, 'ANTHROPIC_DEFAULT_HAIKU_MODEL')).toBe('haiku-local');
+    expect(ci(env, 'ANTHROPIC_DEFAULT_SONNET_MODEL')).toBe('sonnet-local');
+    expect(ci(env, 'ANTHROPIC_DEFAULT_OPUS_MODEL')).toBe('opus-local');
+    expect(ci(env, 'ANTHROPIC_SMALL_FAST_MODEL')).toBe('fast-local');
+    expect(ci(env, 'ANTHROPIC_CUSTOM_HEADERS')).toBe('X-Org: foo');
+  });
+
+  it('forwards CLAUDE_CODE_* runtime flags (Bedrock/Vertex) from parent env', () => {
+    process.env.CLAUDE_CODE_USE_BEDROCK = '1';
+    process.env.CLAUDE_CODE_USE_VERTEX = '1';
+    process.env.CLAUDE_CODE_SKIP_AUTH_LOGIN = 'true';
+    const env = buildSpawnEnv({ configDir: '/cfg' });
+    expect(ci(env, 'CLAUDE_CODE_USE_BEDROCK')).toBe('1');
+    expect(ci(env, 'CLAUDE_CODE_USE_VERTEX')).toBe('1');
+    expect(ci(env, 'CLAUDE_CODE_SKIP_AUTH_LOGIN')).toBe('true');
+  });
+
+  it('always overwrites CLAUDE_CONFIG_DIR with the isolated path, even if parent sets one', () => {
+    process.env.CLAUDE_CONFIG_DIR = '/home/user/.claude';
+    const env = buildSpawnEnv({ configDir: '/isolated/cfg' });
+    expect(ci(env, 'CLAUDE_CONFIG_DIR')).toBe('/isolated/cfg');
+  });
+
+  it('envOverrides still win over forwarded ANTHROPIC_* parent vars', () => {
+    process.env.ANTHROPIC_BASE_URL = 'https://from-parent';
+    process.env.ANTHROPIC_API_KEY = 'sk-parent';
+    const env = buildSpawnEnv({
+      configDir: '/cfg',
+      envOverrides: {
+        ANTHROPIC_BASE_URL: 'https://from-override',
+        ANTHROPIC_API_KEY: 'sk-override',
+      },
+    });
+    expect(ci(env, 'ANTHROPIC_BASE_URL')).toBe('https://from-override');
+    expect(ci(env, 'ANTHROPIC_API_KEY')).toBe('sk-override');
+  });
+
   it('uses canonical Windows casing (ComSpec, not COMSPEC) for whitelist hits', () => {
     process.env.ComSpec = 'C:\\Windows\\System32\\cmd.exe';
     const env = buildSpawnEnv({ configDir: '/cfg' });

--- a/electron/agent/claude-spawner.ts
+++ b/electron/agent/claude-spawner.ts
@@ -153,6 +153,21 @@ export const SAFE_ENV: { exact: readonly string[]; prefixes: readonly string[] }
     'ProgramFiles',  // ProgramFiles, ProgramFiles(x86), ProgramFilesPath
     'CommonProgram', // CommonProgramFiles, CommonProgramFiles(x86)
     'ProgramData',   // ProgramData, ProgramData(x86) (rare but cheap)
+    // Anthropic / claude.exe credentials + endpoint configuration. This is
+    // the core self-host differentiator: user points ANTHROPIC_BASE_URL at
+    // their own gateway, sets ANTHROPIC_AUTH_TOKEN / ANTHROPIC_API_KEY, and
+    // claude.exe authenticates without needing a stored ~/.claude login.
+    // Covers: ANTHROPIC_BASE_URL, ANTHROPIC_API_KEY, ANTHROPIC_AUTH_TOKEN,
+    // ANTHROPIC_DEFAULT_{HAIKU,SONNET,OPUS}_MODEL, ANTHROPIC_SMALL_FAST_MODEL,
+    // ANTHROPIC_CUSTOM_HEADERS, and any future ANTHROPIC_* the CLI adds.
+    'ANTHROPIC_',
+    // claude.exe runtime flags (Bedrock/Vertex routing, proxy, etc.).
+    // Covers: CLAUDE_CODE_USE_BEDROCK, CLAUDE_CODE_USE_VERTEX,
+    // CLAUDE_CODE_SKIP_AUTH_LOGIN, CLAUDE_CODE_DISABLE_*, etc. We still
+    // force CLAUDE_CONFIG_DIR / CLAUDE_CODE_ENTRYPOINT below to our own
+    // values — prefix inclusion just means we pass them through first,
+    // then overwrite the two we own.
+    'CLAUDE_CODE_',
   ],
 };
 
@@ -202,8 +217,12 @@ export function buildSpawnEnv(opts: {
   // Required: isolate config so we never pollute the user's ~/.claude.
   env.CLAUDE_CONFIG_DIR = opts.configDir;
 
-  // Identifies us in server-side logs.
-  env.CLAUDE_CODE_ENTRYPOINT = env.CLAUDE_CODE_ENTRYPOINT ?? 'agentory-desktop';
+  // Identifies us in server-side logs. We unconditionally overwrite the
+  // parent's CLAUDE_CODE_ENTRYPOINT (which will be `cli` when Agentory is
+  // spawned from a Claude Code session for dogfooding) so every spawn from
+  // Agentory reports as `agentory-desktop`. envOverrides below can still
+  // rename it (e.g. for tests).
+  env.CLAUDE_CODE_ENTRYPOINT = 'agentory-desktop';
 
   // Caller overrides win — this is where ANTHROPIC_BASE_URL /
   // ANTHROPIC_AUTH_TOKEN / CLAUDE_CODE_SKIP_AUTH_LOGIN come in.

--- a/scripts/probe-e2e-env-passthrough.mjs
+++ b/scripts/probe-e2e-env-passthrough.mjs
@@ -1,0 +1,111 @@
+// Real end-to-end for env passthrough: parent ANTHROPIC_BASE_URL +
+// ANTHROPIC_AUTH_TOKEN (or ANTHROPIC_API_KEY) must flow through
+// buildSpawnEnv into claude.exe so the CLI authenticates without needing a
+// ~/.claude login in the isolated CLAUDE_CONFIG_DIR.
+//
+// Pass criteria:
+//   - no error banner / "Not logged in" text in DOM
+//   - at least one assistant text block rendered
+//   - assistant text is non-empty and does not match the auth-failure banner
+//
+// Prints the final chat region innerText so the caller can attach it as
+// evidence in the dogfood report.
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { appWindow } from './probe-utils.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+const hasAuth =
+  (process.env.ANTHROPIC_API_KEY && process.env.ANTHROPIC_API_KEY.length > 0) ||
+  (process.env.ANTHROPIC_AUTH_TOKEN && process.env.ANTHROPIC_AUTH_TOKEN.length > 0);
+if (!hasAuth) {
+  console.error(
+    '[probe-e2e-env-passthrough] FAIL: neither ANTHROPIC_API_KEY nor ANTHROPIC_AUTH_TOKEN is set in the parent env. Cannot run real e2e.'
+  );
+  process.exit(2);
+}
+
+const PROMPT = 'Reply with exactly the single word OK and nothing else.';
+
+function fail(msg, extras) {
+  console.error(`\n[probe-e2e-env-passthrough] FAIL: ${msg}`);
+  if (extras) console.error(extras);
+  process.exit(1);
+}
+
+const app = await electron.launch({
+  args: ['.'],
+  cwd: root,
+  env: { ...process.env, NODE_ENV: 'development' },
+});
+
+const win = await appWindow(app);
+const errors = [];
+win.on('pageerror', (e) => errors.push(`[pageerror] ${e.message}`));
+win.on('console', (m) => {
+  if (m.type() === 'error') errors.push(`[console.error] ${m.text()}`);
+});
+
+await win.waitForLoadState('domcontentloaded');
+await win.waitForTimeout(2500);
+
+const newBtn = win.getByRole('button', { name: /new session/i }).first();
+await newBtn.waitFor({ state: 'visible', timeout: 15_000 });
+await newBtn.click();
+
+const textarea = win.locator('textarea');
+await textarea.waitFor({ state: 'visible', timeout: 5000 });
+await textarea.click();
+await textarea.fill(PROMPT);
+await win.keyboard.press('Enter');
+
+// Wait up to 60s for assistant text. Heuristic: look for either a
+// paragraph inside <main> containing the marker word OK (case-insensitive)
+// or any text chunk past the user's own echoed prompt.
+const deadline = Date.now() + 60_000;
+let lastDump = '';
+let assistantSeen = false;
+while (Date.now() < deadline) {
+  const snapshot = await win.evaluate(() => {
+    const main = document.querySelector('main');
+    return main ? main.innerText : '';
+  });
+  lastDump = snapshot;
+  if (/not logged in/i.test(snapshot) || /please run .*\/login/i.test(snapshot)) {
+    await app.close();
+    fail('"Not logged in" banner present — env did not reach claude.exe', snapshot.slice(0, 1000));
+  }
+  // User message is the prompt. Look for content AFTER that prompt.
+  const idx = snapshot.indexOf(PROMPT);
+  const after = idx >= 0 ? snapshot.slice(idx + PROMPT.length) : snapshot;
+  if (/\bOK\b/i.test(after) && after.trim().length > 2) {
+    assistantSeen = true;
+    break;
+  }
+  await win.waitForTimeout(500);
+}
+
+const finalDump = await win.evaluate(() => {
+  const main = document.querySelector('main');
+  return main ? main.innerText : '<no <main>>';
+});
+
+if (!assistantSeen) {
+  console.error('--- main innerText (last snapshot) ---');
+  console.error(lastDump.slice(0, 2000));
+  console.error('--- console errors (last 10) ---');
+  console.error(errors.slice(-10).join('\n'));
+  await app.close();
+  fail('no assistant "OK" reply within 60s');
+}
+
+console.log('\n[probe-e2e-env-passthrough] OK');
+console.log('  prompt:', PROMPT);
+console.log('  ---- final main innerText ----');
+console.log(finalDump.slice(0, 2000));
+console.log('  ---- end ----');
+
+await app.close();


### PR DESCRIPTION
## Summary

Fix the SAFE_ENV allowlist so `ANTHROPIC_BASE_URL`, `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, and friends flow from the user's shell through `buildSpawnEnv` into the spawned `claude.exe`. Without this, the isolated `CLAUDE_CONFIG_DIR` has no credentials and every session hits "Not logged in" — blocking Agentory's structural moat (self-host via custom `ANTHROPIC_BASE_URL` + custom key).

## What changed

`electron/agent/claude-spawner.ts`:

- Added two prefixes to `SAFE_ENV.prefixes`:
  - `ANTHROPIC_` — covers `ANTHROPIC_BASE_URL`, `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_DEFAULT_{HAIKU,SONNET,OPUS}_MODEL`, `ANTHROPIC_SMALL_FAST_MODEL`, `ANTHROPIC_CUSTOM_HEADERS`, and any future `ANTHROPIC_*`.
  - `CLAUDE_CODE_` — covers `CLAUDE_CODE_USE_BEDROCK`, `CLAUDE_CODE_USE_VERTEX`, `CLAUDE_CODE_SKIP_AUTH_LOGIN`, etc.
- Hardened `CLAUDE_CODE_ENTRYPOINT`: now unconditionally stamped to `agentory-desktop` so the parent's value (e.g. `cli` when Agentory is dogfooded from inside a Claude Code session) can't leak into server-side telemetry. `envOverrides` can still override for tests.
- `CLAUDE_CONFIG_DIR` remains unconditionally overwritten to the isolated path — state isolation is preserved, env-based credentials take precedence.
- Proxy vars (`HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` / `ALL_PROXY`) were already on the exact-match list.

## Tests

5 new tests in `electron/agent/__tests__/claude-spawner.test.ts`; 1 existing test updated. **242/242 green** (was 237).

- forwards `ANTHROPIC_*` credentials + endpoint configuration from parent env
- forwards `CLAUDE_CODE_*` runtime flags (Bedrock/Vertex)
- always overwrites `CLAUDE_CONFIG_DIR` with the isolated path
- `envOverrides` still win over forwarded `ANTHROPIC_*` parent vars
- updated "injects CLAUDE_CODE_ENTRYPOINT" to reflect unconditional stamping

## Real end-to-end (UI send -> assistant reply)

Added `scripts/probe-e2e-env-passthrough.mjs`. Parent env had `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` set. Launched Electron via Playwright with inherited env, typed a prompt, submitted, waited for a reply.

Prompt: `Reply with exactly the single word OK and nothing else.`

Result: **PASS in ~3.6s.** Final chat region DOM:

```
>
Reply with exactly the single word OK and nothing else.
●

OK

INFO
Done
— 1 turn · 3.6s · 32k in / 1 out · $0.487
agentory-next
·
opus-4
·
auto
Send
Enter send · Shift+Enter newline
```

The `INFO Done — 1 turn · 3.6s · 32k in / 1 out` status banner confirms the full round-trip: `buildSpawnEnv` -> spawned `claude.exe` -> user's custom endpoint -> stream-json -> `streamToBlocks` -> renderer. No "Not logged in" banner, no error blocks.

Updated `docs/dogfood-report-2026-04-21.md` with a new "Follow-up (same day): real end-to-end" section documenting the fix and the verified turn.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 errors (1 preexisting CommandPalette warning)
- [x] `npm test -- --run` — 242/242 passing
- [x] Pre-push hook (lint + test) — passed on push
- [x] Real e2e via `scripts/probe-e2e-env-passthrough.mjs` — assistant replied "OK"

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)