### PR TITLE
fix(ui): visual token alignment + suppress per-turn status banner

### DIFF
--- a/src/agent/stream-to-blocks.ts
+++ b/src/agent/stream-to-blocks.ts
@@ -247,13 +247,16 @@ function stringifyToolResult(content: unknown): string {
 
 function resultBlocks(msg: ResultEvent): MessageBlock[] {
   if (msg.subtype === 'success' || msg.is_error === false) {
-    return [resultStatsFooter(msg)];
+    // Suppress the per-turn "Done" status banner — it's noisy and Claude
+    // Desktop doesn't render one. resultStatsFooter() is kept below in case
+    // we want to re-enable a compact footer later.
+    return [];
   }
   const text = typeof msg.error === 'string' ? msg.error : msg.subtype ?? 'Run failed';
   return [{ kind: 'error', id: msg.uuid ?? cryptoRandom(), text }];
 }
 
-function resultStatsFooter(msg: ResultEvent): MessageBlock {
+function _resultStatsFooter(msg: ResultEvent): MessageBlock {
   const parts: string[] = [];
   if (typeof msg.num_turns === 'number') parts.push(`${msg.num_turns} turn${msg.num_turns === 1 ? '' : 's'}`);
   if (typeof msg.duration_ms === 'number') parts.push(formatDuration(msg.duration_ms));

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -101,11 +101,10 @@ export function InputBar({ sessionId }: { sessionId: string }) {
       <div
         className={cn(
           'relative rounded-md border bg-bg-elevated surface-highlight',
-          'transition-[border-color,box-shadow] duration-200',
+          'transition-[border-color] duration-200',
           '[transition-timing-function:cubic-bezier(0.32,0.72,0,1)]',
           'border-border-default',
-          'focus-within:border-border-strong',
-          'focus-within:shadow-[inset_0_1px_0_0_oklch(1_0_0_/_0.04),0_0_0_3px_oklch(0.72_0.14_215_/_0.30)]'
+          'focus-within:border-accent'
         )}
       >
         <textarea

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -122,7 +122,7 @@ function GroupRow({
             className={cn(
               'group/row relative flex items-center h-7 px-2 rounded-sm transition-colors duration-120 ease-out',
               focused
-                ? 'bg-bg-active shadow-[inset_0_1px_0_0_oklch(1_0_0_/_0.05)]'
+                ? 'bg-bg-active'
                 : 'hover:bg-bg-hover',
               isOver && 'ring-1 ring-inset ring-accent bg-bg-active'
             )}
@@ -294,7 +294,7 @@ function SessionRow({ session, active, selected, onSelect }: { session: Session;
             '[transition-timing-function:cubic-bezier(0.32,0.72,0,1)]',
             'outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-accent',
             selected
-              ? 'bg-bg-active text-fg-primary shadow-[inset_0_1px_0_0_oklch(1_0_0_/_0.05)]'
+              ? 'bg-bg-active text-fg-primary'
               : 'text-fg-secondary hover:bg-bg-hover hover:text-fg-primary',
             active && 'font-medium text-fg-primary'
           )}

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -33,7 +33,7 @@ const Chip = React.forwardRef<
       className={cn(
         'inline-flex items-center gap-1 h-5 px-1.5 rounded-sm',
         accent === 'warn'
-          ? 'text-amber-400 hover:text-amber-300 hover:bg-amber-400/10'
+          ? 'text-state-warning hover:text-status-warning-foreground hover:bg-status-warning-muted'
           : 'text-fg-tertiary hover:text-fg-secondary hover:bg-bg-hover',
         'outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-border-strong',
         'transition-colors duration-120 ease-out'

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -58,7 +58,7 @@ function TitleButton({
         'flex h-full items-center justify-center text-fg-secondary',
         'transition-colors duration-100 ease-out',
         'hover:text-fg-primary',
-        danger ? 'hover:bg-[oklch(0.55_0.22_27)] hover:text-white' : 'hover:bg-bg-hover',
+        danger ? 'hover:bg-state-error hover:text-state-error-fg' : 'hover:bg-bg-hover',
         'focus:outline-none focus-visible:bg-bg-hover'
       )}
       style={{ width: 46 }}

--- a/tests/stream-to-blocks.test.ts
+++ b/tests/stream-to-blocks.test.ts
@@ -307,7 +307,7 @@ describe('streamEventToTranslation', () => {
     expect(out.toolResults[0].result).toBe('line one\nline two');
   });
 
-  it('successful result emits a stats footer', () => {
+  it('successful result emits no blocks (done banner suppressed)', () => {
     const out = streamEventToTranslation(
       asEvent({
         type: 'result',
@@ -321,16 +321,8 @@ describe('streamEventToTranslation', () => {
         usage: { input_tokens: 4500, output_tokens: 1200, cache_read_input_tokens: 8000 }
       })
     );
-    expect(out.append).toHaveLength(1);
-    const b = out.append[0] as { kind: string; tone: string; title: string; detail?: string };
-    expect(b.kind).toBe('status');
-    expect(b.tone).toBe('info');
-    expect(b.title).toBe('Done');
-    expect(b.detail).toContain('3 turns');
-    expect(b.detail).toContain('12.5s');
-    expect(b.detail).toMatch(/13k in/);
-    expect(b.detail).toContain('1.2k out');
-    expect(b.detail).toContain('$0.012');
+    expect(out.append).toHaveLength(0);
+    expect(out.toolResults).toHaveLength(0);
   });
 
   it('failed (abnormal end) result emits an error block', () => {


### PR DESCRIPTION
## Summary

Two small, independent visual-polish fixes bundled into one PR.

### Task 1 — Visual token alignment (commit d68f7e5)
Replace hardcoded / off-palette colors with design-system tokens and strip inset shadows that duplicate already-visible affordances.

- **Sidebar.tsx** — drop the ad-hoc `shadow-[inset_0_1px_0_0_oklch(...)]` on focused group rows and selected session rows. The surrounding `bg-bg-active` already carries the hit state; the inner highlight was a banned inset per design-system section 5.
- **StatusBar.tsx** — swap hardcoded `amber-400 / amber-300 / amber-400/10` on the 'yolo' permission chip for `text-state-warning`, `hover:text-status-warning-foreground`, `hover:bg-status-warning-muted`.
- **InputBar.tsx** — collapse the cyan focus-within glow + inset shadow to a clean border color swap (`focus-within:border-accent`).
- **TitleBar.tsx** — swap the hardcoded `oklch(0.55 0.22 27)` close-button hover for `bg-state-error` / `text-state-error-fg`.

No tokens were added to `global.css` — every replacement uses an existing token.

### Task 2 — Suppress per-turn "Done" status banner (commit db97a56)
Claude Desktop does not render a per-turn `INFO Done — N turns · Xs · tokens · $cost` footer, and the banner was noisy and broke the minimalist flow. The success branch of `resultBlocks()` now returns an empty array. Error / abnormal-end banners are untouched. The footer formatter is renamed `_resultStatsFooter` (leading-underscore so lint accepts it) and retained so a compact footer can be re-enabled later without reimplementing the token / duration / cost formatting.

## Test plan
- [x] `npm run typecheck` → 0 errors
- [x] `npm run lint` → 0 errors (1 preexisting CommandPalette warning, unrelated)
- [x] `npm test -- --run` → 273/273 passing, including an updated `stream-to-blocks` test that now asserts the success path emits no blocks
- [ ] Live Electron verify skipped: ports 4100 and 4101 are held by other active worktree dev servers per task instruction "do NOT kill other worktrees' dev servers", and webpack dev-port + electron `wait-on` URL are hardcoded to 4100. Preferred not to introduce repo-level config changes for a one-off local check. All modifications are pure Tailwind class swaps on existing components plus a data-pipeline change covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)