### PR TITLE
fix(chat): clean interrupt handling + unblock text selection

### DIFF
--- a/scripts/probe-e2e-interrupt-banner.mjs
+++ b/scripts/probe-e2e-interrupt-banner.mjs
@@ -1,0 +1,141 @@
+// Verify Bug 1 + Bug 2 fixes without needing a real claude.exe turn.
+//
+// Bug 1 live check: the renderer receives a `result { error_during_execution }`
+//   frame after the user clicks Stop. We fake that path by calling
+//   markInterrupted, then mutating the store exactly as lifecycle.ts would
+//   after translating the result frame — producing an "Interrupted" status
+//   block instead of an ErrorBlock.
+//
+// Bug 2 live check: StatusBanner text, EmptyState text, StatusBar chips and
+//   ErrorBlock text are all selectable (computed user-select !== 'none').
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { appWindow } from './probe-utils.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function fail(msg) {
+  console.error(`\n[probe-e2e-interrupt-banner] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const app = await electron.launch({
+  args: ['.'],
+  cwd: root,
+  env: { ...process.env, NODE_ENV: 'development' }
+});
+const win = await appWindow(app, { timeout: 45000 });
+await win.waitForLoadState('domcontentloaded');
+await win.waitForFunction(() => !!window.__agentoryStore, null, { timeout: 15000 });
+
+// EmptyState check: with no session, the "Ready when you are." line must be
+// selectable. Grab its computed user-select.
+const emptyStateSelectable = await win.evaluate(() => {
+  const el = Array.from(document.querySelectorAll('div')).find(
+    (d) => d.textContent === 'Ready when you are.'
+  );
+  if (!el) return { found: false };
+  const userSelect = getComputedStyle(el).userSelect;
+  return { found: true, userSelect };
+});
+if (!emptyStateSelectable.found) fail('EmptyState "Ready when you are." not rendered');
+if (emptyStateSelectable.userSelect === 'none')
+  fail(`EmptyState user-select is 'none' — text unselectable`);
+
+// Create a session and simulate the interrupt flow.
+const sessionId = await win.evaluate(() => {
+  const st = window.__agentoryStore.getState();
+  st.createSession('~/interrupt-probe');
+  const id = window.__agentoryStore.getState().activeId;
+  // Put it in running + add a partial assistant reply so the Stop path is
+  // plausible even though we never actually spawn claude.exe.
+  st.setRunning(id, true);
+  st.appendBlocks(id, [
+    { kind: 'user', id: 'u-probe', text: 'count slowly from 1 to 100' },
+    { kind: 'assistant', id: 'a-probe', text: '1\n2\n3\n' }
+  ]);
+  return id;
+});
+if (!sessionId) fail('no active session id');
+
+// Simulate the Stop button: mark interrupted, then consume it on the next
+// "result" frame — same sequence lifecycle.ts uses.
+const statusBlock = await win.evaluate((sid) => {
+  const st = window.__agentoryStore.getState();
+  st.markInterrupted(sid);
+  // This is exactly what lifecycle.ts does for a result frame, inlined so
+  // the probe doesn't have to fake an IPC event.
+  const interrupted = st.consumeInterrupted(sid);
+  if (!interrupted) return { ok: false, reason: 'flag not consumed' };
+  st.appendBlocks(sid, [
+    {
+      kind: 'status',
+      id: 'res-probe',
+      tone: 'info',
+      title: 'Interrupted'
+    }
+  ]);
+  st.setRunning(sid, false);
+  return { ok: true };
+}, sessionId);
+if (!statusBlock.ok) fail(`interrupt flag not consumed: ${statusBlock.reason}`);
+
+// The banner is now in the DOM; make sure it's neutral (role="status") and
+// carries the word "Interrupted", and that it is user-selectable.
+await win.waitForSelector('[role="status"]', { timeout: 5000 });
+const banner = await win.evaluate(() => {
+  const nodes = Array.from(document.querySelectorAll('[role="status"]'));
+  const el = nodes.find((n) => n.textContent?.includes('Interrupted'));
+  if (!el) return { found: false };
+  return {
+    found: true,
+    text: el.textContent,
+    userSelect: getComputedStyle(el).userSelect,
+    hasAlert: !!el.closest('[role="alert"]')
+  };
+});
+if (!banner.found) fail('Interrupted banner not rendered');
+if (banner.hasAlert) fail('Interrupted banner is inside a role="alert" — should be neutral status');
+if (banner.userSelect === 'none') fail(`Interrupted banner user-select is 'none'`);
+if (banner.text?.toLowerCase().includes('error_during_execution'))
+  fail('banner text leaked "error_during_execution"');
+
+// Genuine error path still renders an ErrorBlock and is also selectable.
+await win.evaluate((sid) => {
+  window.__agentoryStore.getState().appendBlocks(sid, [
+    { kind: 'error', id: 'err-probe', text: 'Genuine failure details' }
+  ]);
+}, sessionId);
+await win.waitForSelector('[role="alert"]', { timeout: 5000 });
+const errorBlock = await win.evaluate(() => {
+  const el = document.querySelector('[role="alert"]');
+  if (!el) return { found: false };
+  return {
+    found: true,
+    text: el.textContent,
+    userSelect: getComputedStyle(el).userSelect
+  };
+});
+if (!errorBlock.found) fail('ErrorBlock not rendered');
+if (errorBlock.userSelect === 'none') fail(`ErrorBlock user-select is 'none'`);
+if (!errorBlock.text?.includes('Genuine failure details'))
+  fail('ErrorBlock missing expected text');
+
+// StatusBar container selectability.
+const statusBar = await win.evaluate(() => {
+  const el = document.querySelector('.h-6.font-mono');
+  if (!el) return { found: false };
+  return { found: true, userSelect: getComputedStyle(el).userSelect };
+});
+if (statusBar.found && statusBar.userSelect === 'none')
+  fail(`StatusBar user-select still 'none'`);
+
+console.log('[probe-e2e-interrupt-banner] OK');
+console.log('  - EmptyState text selectable');
+console.log('  - Interrupt produces neutral "Interrupted" status (no ErrorBlock)');
+console.log('  - Genuine error still renders as ErrorBlock, text selectable');
+console.log('  - StatusBar container not select-none');
+
+await app.close();

--- a/src/agent/lifecycle.ts
+++ b/src/agent/lifecycle.ts
@@ -152,8 +152,12 @@ export function subscribeAgentEvents(): void {
       }
       return;
     }
-    const { append, toolResults } = streamEventToTranslation(e.message);
     const store = useStore.getState();
+    const ctx =
+      e.message.type === 'result'
+        ? { interrupted: store.consumeInterrupted(e.sessionId) }
+        : {};
+    const { append, toolResults } = streamEventToTranslation(e.message, ctx);
     if (append.length > 0) store.appendBlocks(e.sessionId, append);
     for (const tr of toolResults) {
       store.setToolResult(e.sessionId, tr.toolUseId, tr.result, tr.isError);

--- a/src/agent/stream-to-blocks.ts
+++ b/src/agent/stream-to-blocks.ts
@@ -74,7 +74,17 @@ export class PartialAssistantStreamer {
   }
 }
 
-export function streamEventToTranslation(event: ClaudeStreamEvent | { type: string }): StreamTranslation {
+export type TranslationContext = {
+  // True when the user clicked Stop on this session before the current
+  // frame arrived. Used to demote `error_during_execution` from an error
+  // block to a neutral "Interrupted" status banner.
+  interrupted?: boolean;
+};
+
+export function streamEventToTranslation(
+  event: ClaudeStreamEvent | { type: string },
+  ctx: TranslationContext = {}
+): StreamTranslation {
   switch (event.type) {
     case 'assistant':
       return { append: assistantBlocksWithError(event as AssistantEvent), toolResults: [] };
@@ -83,7 +93,7 @@ export function streamEventToTranslation(event: ClaudeStreamEvent | { type: stri
     case 'system':
       return { append: systemBlocks(event as SystemEvent), toolResults: [] };
     case 'result':
-      return { append: resultBlocks(event as ResultEvent), toolResults: [] };
+      return { append: resultBlocks(event as ResultEvent, ctx), toolResults: [] };
     default:
       return EMPTY;
   }
@@ -245,9 +255,23 @@ function stringifyToolResult(content: unknown): string {
   return parts.join('\n');
 }
 
-function resultBlocks(msg: ResultEvent): MessageBlock[] {
+function resultBlocks(msg: ResultEvent, ctx: TranslationContext): MessageBlock[] {
   if (msg.subtype === 'success' || msg.is_error === false) {
     return [resultStatsFooter(msg)];
+  }
+  // User-initiated interrupt: claude.exe emits `error_during_execution`
+  // when `agentInterrupt` lands mid-turn. Render it as a neutral status,
+  // not a red error block.
+  if (msg.subtype === 'error_during_execution' && ctx.interrupted) {
+    return [
+      {
+        kind: 'status',
+        id: msg.uuid ?? cryptoRandom(),
+        tone: 'info',
+        title: 'Interrupted',
+        detail: undefined
+      }
+    ];
   }
   const text = typeof msg.error === 'string' ? msg.error : msg.subtype ?? 'Run failed';
   return [{ kind: 'error', id: msg.uuid ?? cryptoRandom(), text }];

--- a/src/components/ChatStream.tsx
+++ b/src/components/ChatStream.tsx
@@ -699,7 +699,7 @@ const EMPTY_BLOCKS: readonly MessageBlock[] = [];
 function EmptyState() {
   return (
     <div className="h-full flex items-center justify-center px-6">
-      <div className="font-mono text-sm text-fg-tertiary select-none">Ready when you are.</div>
+      <div className="font-mono text-sm text-fg-tertiary">Ready when you are.</div>
     </div>
   );
 }

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -26,6 +26,7 @@ export function InputBar({ sessionId }: { sessionId: string }) {
   const markStarted = useStore((s) => s.markStarted);
   const setRunning = useStore((s) => s.setRunning);
   const resetWatchdogCount = useStore((s) => s.resetWatchdogCount);
+  const markInterrupted = useStore((s) => s.markInterrupted);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   React.useEffect(() => {
@@ -82,6 +83,10 @@ export function InputBar({ sessionId }: { sessionId: string }) {
     if (!running) return;
     const api = window.agentory;
     if (!api) return;
+    // Flag the session BEFORE the IPC call so the upcoming
+    // `result { error_during_execution }` frame is rendered as a neutral
+    // "Interrupted" banner instead of an error block.
+    markInterrupted(sessionId);
     await api.agentInterrupt(sessionId);
     // running flag is cleared when the SDK emits its result message.
   }

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -189,7 +189,7 @@ export function StatusBar({
   ];
 
   return (
-    <div className="h-6 px-4 pt-0.5 flex items-center gap-1 font-mono text-xs select-none">
+    <div className="h-6 px-4 pt-0.5 flex items-center gap-1 font-mono text-xs">
       {chips.map((c, i) => (
         <React.Fragment key={i}>
           {i > 0 ? <span className="text-fg-disabled px-1">·</span> : null}

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -44,6 +44,10 @@ type State = {
   messagesBySession: Record<string, MessageBlock[]>;
   startedSessions: Record<string, true>;
   runningSessions: Record<string, true>;
+  // Marks sessions where the user clicked Stop. Consumed when the next
+  // `result { error_during_execution }` frame arrives so we can render a
+  // neutral "Interrupted" banner instead of an error block.
+  interruptedSessions: Record<string, true>;
 };
 
 type Actions = {
@@ -80,6 +84,8 @@ type Actions = {
   clearMessages: (sessionId: string) => void;
   markStarted: (sessionId: string) => void;
   setRunning: (sessionId: string, running: boolean) => void;
+  markInterrupted: (sessionId: string) => void;
+  consumeInterrupted: (sessionId: string) => boolean;
   resolvePermission: (sessionId: string, requestId: string, decision: 'allow' | 'deny') => void;
 };
 
@@ -113,6 +119,7 @@ export const useStore = create<State & Actions>((set, get) => ({
   messagesBySession: {},
   startedSessions: {},
   runningSessions: {},
+  interruptedSessions: {},
 
   selectSession: (id) => {
     set((s) => ({
@@ -191,12 +198,15 @@ export const useStore = create<State & Actions>((set, get) => ({
       delete nextStarted[id];
       const nextRunning = { ...s.runningSessions };
       delete nextRunning[id];
+      const nextInterrupted = { ...s.interruptedSessions };
+      delete nextInterrupted[id];
       return {
         sessions: remaining,
         activeId: nextActive,
         messagesBySession: nextMessages,
         startedSessions: nextStarted,
-        runningSessions: nextRunning
+        runningSessions: nextRunning,
+        interruptedSessions: nextInterrupted
       };
     });
   },
@@ -439,6 +449,25 @@ export const useStore = create<State & Actions>((set, get) => ({
       else delete next[sessionId];
       return { runningSessions: next };
     });
+  },
+
+  markInterrupted: (sessionId) => {
+    set((s) =>
+      s.interruptedSessions[sessionId]
+        ? s
+        : { interruptedSessions: { ...s.interruptedSessions, [sessionId]: true } }
+    );
+  },
+
+  consumeInterrupted: (sessionId) => {
+    const was = !!get().interruptedSessions[sessionId];
+    if (!was) return false;
+    set((s) => {
+      const next = { ...s.interruptedSessions };
+      delete next[sessionId];
+      return { interruptedSessions: next };
+    });
+    return true;
   },
 
   resolvePermission: (sessionId, requestId, decision) => {

--- a/tests/stream-to-blocks.test.ts
+++ b/tests/stream-to-blocks.test.ts
@@ -347,6 +347,55 @@ describe('streamEventToTranslation', () => {
     expect(out.append[0]).toMatchObject({ kind: 'error' });
   });
 
+  it('error_during_execution with interrupted context becomes a neutral Interrupted status', () => {
+    const out = streamEventToTranslation(
+      asEvent({
+        type: 'result',
+        subtype: 'error_during_execution',
+        is_error: true,
+        session_id: 's',
+        uuid: 'res-int'
+      }),
+      { interrupted: true }
+    );
+    expect(out.append).toHaveLength(1);
+    const b = out.append[0] as { kind: string; tone?: string; title?: string };
+    expect(b.kind).toBe('status');
+    expect(b.tone).toBe('info');
+    expect(b.title).toBe('Interrupted');
+  });
+
+  it('error_during_execution without interrupt context still renders as error', () => {
+    const out = streamEventToTranslation(
+      asEvent({
+        type: 'result',
+        subtype: 'error_during_execution',
+        is_error: true,
+        session_id: 's',
+        uuid: 'res-err2'
+      })
+    );
+    expect(out.append).toHaveLength(1);
+    expect(out.append[0]).toMatchObject({ kind: 'error' });
+  });
+
+  it('successful result ignores interrupted context (no demotion path taken)', () => {
+    const out = streamEventToTranslation(
+      asEvent({
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        session_id: 's',
+        uuid: 'res-ok',
+        num_turns: 1,
+        duration_ms: 500
+      }),
+      { interrupted: true }
+    );
+    expect(out.append).toHaveLength(1);
+    expect(out.append[0]).toMatchObject({ kind: 'status', title: 'Done' });
+  });
+
   it('returns empty translation for unknown frame types', () => {
     const out = streamEventToTranslation(asEvent({ type: 'agent_metadata', agent_id: 'a' }));
     expect(out).toEqual({ append: [], toolResults: [] });


### PR DESCRIPTION
## Summary

Two UX bugs rolled into one small change, both triggered by the claude.exe migration.

### Bug 1: Stop rendered as a red error

Clicking Stop mid-turn sends `agentInterrupt`; claude.exe then emits `result { subtype: error_during_execution }`. Our renderer treated any non-success subtype as a genuine failure and printed an ErrorBlock with the raw string `error_during_execution`, making a user-initiated cancellation look like a crash.

Fix: track a per-session `interruptedSessions` flag in the store, set it synchronously in the InputBar Stop handler *before* the IPC call, and consume it in `lifecycle.ts` when the next `result` frame arrives. `stream-to-blocks.ts` gains a `TranslationContext` arg; when `subtype === 'error_during_execution'` and the session was interrupted, the frame becomes a neutral `status { tone: 'info', title: 'Interrupted' }` banner. A genuine `error_during_execution` not preceded by Stop still renders as an ErrorBlock.

**Before:** red ErrorBlock reading `error_during_execution`.
**After:** neutral info banner reading `INFO — Interrupted`, selectable.

### Bug 2: Text was not copyable in two spots

`select-none` was applied too broadly. Removed from:
- `src/components/ChatStream.tsx` — EmptyState "Ready when you are." line
- `src/components/StatusBar.tsx` — bottom chip row container (chips themselves are buttons, still fine)

Verified ErrorBlock, StatusBanner, and all other message blocks remain selectable today (no `select-none` on them).

## Test plan

- [x] Unit: added 3 cases in `tests/stream-to-blocks.test.ts` — `error_during_execution + interrupted` → status banner; without interrupt → error; `success` with interrupted flag unchanged.
- [x] Live probe: `scripts/probe-e2e-interrupt-banner.mjs` launches Electron, simulates the interrupt flow, and asserts the DOM contains a `role="status"` "Interrupted" banner (no `role="alert"`), that it doesn't leak the raw subtype, and that computed `user-select` is not `none` on EmptyState / StatusBanner / ErrorBlock / StatusBar.
- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 errors (1 preexisting CommandPalette warning)
- [x] `npm test -- --run` — 285/285 passing (3 new)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>