### PR TITLE
fix(permission): correct chip labels to match CLI permission semantics

### DIFF
--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -115,12 +115,23 @@ const modelOptions: ChipOption<ModelId>[] = [
   { kind: 'item', value: 'claude-haiku-4', primary: 'haiku-4', secondary: 'Fastest and cheapest, lower quality' }
 ];
 
+// Labels describe what claude.exe actually does per mode. There is no CLI
+// setting that prompts on every single tool — reads are always auto-approved
+// below `bypassPermissions` and above `plan`. The chip wording reflects that
+// instead of promising behaviour the CLI can't deliver.
 const permissionOptions: ChipOption<PermissionMode>[] = [
   { kind: 'item', value: 'plan', primary: 'plan', secondary: 'Plan only — no edits or commands' },
-  { kind: 'item', value: 'ask', primary: 'ask', secondary: 'Ask before each tool call' },
-  { kind: 'item', value: 'auto', primary: 'auto', secondary: 'Auto-approve edits; ask for shell' },
-  { kind: 'item', value: 'yolo', primary: 'yolo', secondary: 'Approve everything (use with care)' }
+  { kind: 'item', value: 'ask', primary: 'standard', secondary: 'Auto-approve reads; ask before writes, edits, and shell' },
+  { kind: 'item', value: 'auto', primary: 'auto', secondary: 'Auto-approve reads and edits; ask before shell' },
+  { kind: 'item', value: 'yolo', primary: 'yolo', secondary: 'Auto-approve everything (use with care)' }
 ];
+
+const permissionTooltips: Record<PermissionMode, string> = {
+  plan: 'Plan mode — agent drafts a plan; no file edits or shell until you approve',
+  ask: 'Standard — reads auto-approved; writes, edits, and shell require confirmation',
+  auto: 'Auto-accept edits — reads and file edits auto-approved; shell requires confirmation',
+  yolo: 'Bypass all permission checks — every tool call runs without asking'
+};
 
 function primaryOf<V extends string>(options: ChipOption<V>[], value: V): string {
   for (const o of options) {
@@ -182,6 +193,7 @@ export function StatusBar({
       key="permission"
       label="Permission mode"
       triggerLabel={primaryOf(permissionOptions, permission)}
+      triggerTitle={permissionTooltips[permission]}
       triggerAccent={permission === 'yolo' ? 'warn' : undefined}
       options={permissionOptions}
       onSelect={onChangePermission}

--- a/tests/permission.test.ts
+++ b/tests/permission.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { toSdkPermissionMode } from '../src/agent/permission';
+import type { PermissionMode } from '../src/stores/store';
+
+describe('toSdkPermissionMode', () => {
+  it('maps every UI mode to a CLI-accepted value', () => {
+    const cases: Array<[PermissionMode, string]> = [
+      ['plan', 'plan'],
+      // `ask` is labelled "standard" in the UI; it maps to CLI `default`,
+      // which auto-approves reads and prompts on writes/shell. The CLI has
+      // no "ask on every tool" mode.
+      ['ask', 'default'],
+      ['auto', 'acceptEdits'],
+      ['yolo', 'bypassPermissions']
+    ];
+    for (const [ui, cli] of cases) {
+      expect(toSdkPermissionMode(ui)).toBe(cli);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

The permission chip's middle option was labelled **ask** with the secondary "Ask before each tool call". Users selecting that mode expected every tool call (including Read/Grep/LS) to prompt. In reality, claude.exe's `default` mode auto-approves all read operations and only prompts for writes/edits/shell — so the label was a lie and looked like a bug.

## Investigation

`claude --permission-mode <value>` accepts exactly these values (verbatim from `claude --help`):

```
--permission-mode <mode>  Permission mode to use for the session
                          (choices: "acceptEdits", "auto", "bypassPermissions",
                           "default", "dontAsk", "plan")
```

Empirically verified against `claude --permission-mode dontAsk -p "..."`: `dontAsk` is the CLI's no-prompt flavour (it auto-approved a tool call without gating). `auto` is the classifier-driven mode (see `claude auto-mode defaults`). Neither is "prompt on every tool".

**Conclusion**: the CLI has no mode that routes every tool call through `can_use_tool`. claude.exe only sends `can_use_tool` when its own policy decides a tool needs gating — reads never trigger that below `plan`. Implementing "true ask-for-all" at the control-rpc layer is therefore not possible without intercepting `tool_use` post-hoc (and by then the tool has already run).

The honest fix is to describe the existing modes accurately, so the chip doesn't promise behaviour that the CLI can't deliver.

## Fix

Relabel the chip options to describe actual claude.exe behaviour:

| UI value (persisted) | Old primary | Old secondary | New primary | New secondary |
|---|---|---|---|---|
| `plan` | plan | Plan only — no edits or commands | plan | Plan only — no edits or commands |
| `ask` | ask | Ask before each tool call | **standard** | **Auto-approve reads; ask before writes, edits, and shell** |
| `auto` | auto | Auto-approve edits; ask for shell | auto | Auto-approve reads and edits; ask before shell |
| `yolo` | yolo | Approve everything (use with care) | yolo | Auto-approve everything (use with care) |

UI→CLI mapping (unchanged; stays correct):

| UI value | CLI `--permission-mode` |
|---|---|
| `plan` | `plan` |
| `ask` | `default` |
| `auto` | `acceptEdits` |
| `yolo` | `bypassPermissions` |

Internal value strings stay the same so persisted user preferences survive.

Added trigger tooltips so hover on the chip shows the precise behaviour of the current mode.

## Tests

- New `tests/permission.test.ts` locks in the UI→CLI round-trip mapping.
- All 283 tests pass; typecheck clean; lint clean aside from the pre-existing `CommandPalette` warning.

## Live verify

On dev port 4123 (localhost webpack), default `auto` chip:

- Trigger tooltip: `Auto-accept edits — reads and file edits auto-approved; shell requires confirmation`
- Menu items (primary + secondary concatenated):
  - `planPlan only — no edits or commands`
  - `standardAuto-approve reads; ask before writes, edits, and shell`
  - `autoAuto-approve reads and edits; ask before shell`
  - `yoloAuto-approve everything (use with care)`

## Follow-up

If we ever want true per-tool prompting (including reads), it would require:
- Intercepting `tool_use` events at the agent layer before forwarding to the UI, and
- Issuing a control `interrupt` + resume-with-new-decision dance on each tool.

That's brittle and out of scope for this fix. Filing as a separate thread if/when users ask for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)