### PR TITLE
feat(endpoints): per-endpoint model discovery (Phase 1 Anthropic)

### DIFF
--- a/electron/agent/sessions.ts
+++ b/electron/agent/sessions.ts
@@ -61,6 +61,13 @@ export type StartOptions = {
   apiKey?: string;
   resumeSessionId?: string;
   /**
+   * Per-session env overrides layered onto the spawner's SAFE_ENV baseline
+   * BEFORE `apiKey` is applied. Used to pipe an endpoint's ANTHROPIC_BASE_URL
+   * + ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN into the child so each session
+   * can target a different endpoint.
+   */
+  envOverrides?: Record<string, string>;
+  /**
    * Optional override for `CLAUDE_CONFIG_DIR`. main.ts currently doesn't pass
    * one — see resolveConfigDir() for the fallback chain. Will become required
    * once main.ts is migrated (batch 3, T9).
@@ -116,7 +123,7 @@ export class SessionRunner {
     this.permissionMode = opts.permissionMode ?? 'default';
     this.abort = new AbortController();
 
-    const envOverrides: Record<string, string> = {};
+    const envOverrides: Record<string, string> = { ...(opts.envOverrides ?? {}) };
     if (opts.apiKey) envOverrides.ANTHROPIC_API_KEY = opts.apiKey;
 
     this.cp = await spawnClaude({

--- a/electron/db.ts
+++ b/electron/db.ts
@@ -12,6 +12,7 @@ export function initDb(): Database.Database {
   const file = path.join(dir, 'agentory.db');
   db = new Database(file);
   db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
   db.exec(`
     CREATE TABLE IF NOT EXISTS app_state (
       key TEXT PRIMARY KEY,
@@ -26,6 +27,31 @@ export function initDb(): Database.Database {
       createdAt INTEGER NOT NULL
     );
     CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(sessionId);
+
+    CREATE TABLE IF NOT EXISTS endpoints (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      base_url TEXT NOT NULL,
+      kind TEXT NOT NULL DEFAULT 'anthropic',
+      api_key_encrypted BLOB,
+      is_default INTEGER NOT NULL DEFAULT 0,
+      last_status TEXT,
+      last_error TEXT,
+      last_refreshed_at INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS endpoint_models (
+      id TEXT PRIMARY KEY,
+      endpoint_id TEXT NOT NULL REFERENCES endpoints(id) ON DELETE CASCADE,
+      model_id TEXT NOT NULL,
+      display_name TEXT,
+      discovered_at INTEGER NOT NULL,
+      UNIQUE(endpoint_id, model_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_endpoint_models_endpoint
+      ON endpoint_models(endpoint_id);
   `);
   return db;
 }
@@ -52,6 +78,56 @@ export function saveMessages(sessionId: string, blocks: Array<{ id: string; kind
     });
   });
   tx();
+}
+
+// Test-only: swap in an in-memory database. Never call from app code.
+export function __setDbForTests(instance: Database.Database | null): void {
+  db = instance;
+  if (instance) {
+    instance.pragma('foreign_keys = ON');
+    instance.exec(`
+      CREATE TABLE IF NOT EXISTS app_state (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS messages (
+        id TEXT PRIMARY KEY,
+        sessionId TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        content TEXT NOT NULL,
+        createdAt INTEGER NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(sessionId);
+      CREATE TABLE IF NOT EXISTS endpoints (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        base_url TEXT NOT NULL,
+        kind TEXT NOT NULL DEFAULT 'anthropic',
+        api_key_encrypted BLOB,
+        is_default INTEGER NOT NULL DEFAULT 0,
+        last_status TEXT,
+        last_error TEXT,
+        last_refreshed_at INTEGER,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS endpoint_models (
+        id TEXT PRIMARY KEY,
+        endpoint_id TEXT NOT NULL REFERENCES endpoints(id) ON DELETE CASCADE,
+        model_id TEXT NOT NULL,
+        display_name TEXT,
+        discovered_at INTEGER NOT NULL,
+        UNIQUE(endpoint_id, model_id)
+      );
+      CREATE INDEX IF NOT EXISTS idx_endpoint_models_endpoint
+        ON endpoint_models(endpoint_id);
+    `);
+  }
+}
+
+export function getDb(): Database.Database {
+  return initDb();
 }
 
 export function loadState(key: string): string | null {

--- a/electron/endpoints-manager.ts
+++ b/electron/endpoints-manager.ts
@@ -1,0 +1,467 @@
+import { randomUUID } from 'node:crypto';
+import { getDb } from './db';
+
+/**
+ * Phase 1 supports Anthropic-native protocol only. Other kinds are reserved
+ * for Phase 2 (OpenAI-compat, Ollama, Bedrock, Vertex). Stored as a free TEXT
+ * column so Phase 2 can add values without a schema migration.
+ */
+export type EndpointKind = 'anthropic';
+
+export type EndpointStatus = 'ok' | 'error' | 'unchecked';
+
+export interface EndpointRow {
+  id: string;
+  name: string;
+  baseUrl: string;
+  kind: EndpointKind;
+  isDefault: boolean;
+  lastStatus: EndpointStatus;
+  lastError: string | null;
+  lastRefreshedAt: number | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface ModelRow {
+  id: string;
+  endpointId: string;
+  modelId: string;
+  displayName: string | null;
+  discoveredAt: number;
+}
+
+export interface EndpointWithModels extends EndpointRow {
+  models: ModelRow[];
+}
+
+export interface AddEndpointInput {
+  name: string;
+  baseUrl: string;
+  kind?: EndpointKind;
+  apiKey?: string;
+  isDefault?: boolean;
+}
+
+export interface UpdateEndpointInput {
+  name?: string;
+  baseUrl?: string;
+  apiKey?: string | null; // null = clear, undefined = leave as-is
+  isDefault?: boolean;
+}
+
+/**
+ * Abstraction over Electron's `safeStorage`. We inject it so unit tests can
+ * run the DB layer without spinning up Electron, and so the codebase has a
+ * single plaintext→ciphertext boundary we can audit.
+ */
+export interface KeyCrypto {
+  isAvailable: () => boolean;
+  encrypt: (plain: string) => Buffer;
+  decrypt: (cipher: Buffer) => string;
+}
+
+type FetchLike = typeof fetch;
+
+export interface EndpointsManagerDeps {
+  crypto: KeyCrypto;
+  fetchImpl?: FetchLike;
+  now?: () => number;
+}
+
+interface RawEndpoint {
+  id: string;
+  name: string;
+  base_url: string;
+  kind: string;
+  api_key_encrypted: Buffer | null;
+  is_default: number;
+  last_status: string | null;
+  last_error: string | null;
+  last_refreshed_at: number | null;
+  created_at: number;
+  updated_at: number;
+}
+
+interface RawModel {
+  id: string;
+  endpoint_id: string;
+  model_id: string;
+  display_name: string | null;
+  discovered_at: number;
+}
+
+/**
+ * Anthropic's `GET /v1/models` response page.
+ * https://docs.anthropic.com/en/api/models-list
+ */
+interface AnthropicModelsPage {
+  data: Array<{
+    id: string;
+    display_name?: string;
+    type?: string;
+    created_at?: string;
+  }>;
+  has_more: boolean;
+  first_id?: string | null;
+  last_id?: string | null;
+}
+
+export class EndpointsManager {
+  private readonly crypto: KeyCrypto;
+  private readonly fetchImpl: FetchLike;
+  private readonly now: () => number;
+
+  constructor(deps: EndpointsManagerDeps) {
+    this.crypto = deps.crypto;
+    this.fetchImpl = deps.fetchImpl ?? (globalThis.fetch as FetchLike);
+    this.now = deps.now ?? (() => Date.now());
+  }
+
+  // ---------- CRUD ----------
+
+  listEndpoints(): EndpointRow[] {
+    const rows = getDb()
+      .prepare(
+        `SELECT id, name, base_url, kind, api_key_encrypted, is_default,
+                last_status, last_error, last_refreshed_at, created_at, updated_at
+         FROM endpoints ORDER BY is_default DESC, created_at ASC`
+      )
+      .all() as RawEndpoint[];
+    return rows.map(toEndpointRow);
+  }
+
+  getEndpoint(id: string): EndpointRow | null {
+    const row = getDb()
+      .prepare(
+        `SELECT id, name, base_url, kind, api_key_encrypted, is_default,
+                last_status, last_error, last_refreshed_at, created_at, updated_at
+         FROM endpoints WHERE id = ?`
+      )
+      .get(id) as RawEndpoint | undefined;
+    return row ? toEndpointRow(row) : null;
+  }
+
+  /**
+   * Plaintext key read. Main-process only — never expose via IPC to the
+   * renderer. Used by session spawn to set per-session env.
+   */
+  getPlainKey(id: string): string | null {
+    const row = getDb()
+      .prepare('SELECT api_key_encrypted FROM endpoints WHERE id = ?')
+      .get(id) as { api_key_encrypted: Buffer | null } | undefined;
+    if (!row || !row.api_key_encrypted) return null;
+    if (!this.crypto.isAvailable()) return null;
+    try {
+      return this.crypto.decrypt(row.api_key_encrypted);
+    } catch {
+      return null;
+    }
+  }
+
+  addEndpoint(input: AddEndpointInput): EndpointRow {
+    const id = randomUUID();
+    const now = this.now();
+    const enc = this.encryptKey(input.apiKey);
+    const kind: EndpointKind = input.kind ?? 'anthropic';
+    const isDefault = input.isDefault ? 1 : 0;
+
+    const db = getDb();
+    const run = db.transaction(() => {
+      if (isDefault) {
+        db.prepare('UPDATE endpoints SET is_default = 0').run();
+      }
+      db.prepare(
+        `INSERT INTO endpoints (
+          id, name, base_url, kind, api_key_encrypted, is_default,
+          last_status, last_error, last_refreshed_at, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, 'unchecked', NULL, NULL, ?, ?)`
+      ).run(id, input.name, input.baseUrl, kind, enc, isDefault, now, now);
+    });
+    run();
+
+    const row = this.getEndpoint(id);
+    if (!row) throw new Error('addEndpoint: insert succeeded but row missing');
+    return row;
+  }
+
+  updateEndpoint(id: string, patch: UpdateEndpointInput): EndpointRow | null {
+    const existing = this.getEndpoint(id);
+    if (!existing) return null;
+    const now = this.now();
+    const name = patch.name ?? existing.name;
+    const baseUrl = patch.baseUrl ?? existing.baseUrl;
+    const isDefault = patch.isDefault === undefined ? existing.isDefault : patch.isDefault;
+
+    let enc: Buffer | null | 'keep' = 'keep';
+    if (patch.apiKey === null) enc = null;
+    else if (typeof patch.apiKey === 'string') enc = this.encryptKey(patch.apiKey);
+
+    const db = getDb();
+    const run = db.transaction(() => {
+      if (isDefault && !existing.isDefault) {
+        db.prepare('UPDATE endpoints SET is_default = 0').run();
+      }
+      if (enc === 'keep') {
+        db.prepare(
+          `UPDATE endpoints SET name = ?, base_url = ?, is_default = ?, updated_at = ?
+           WHERE id = ?`
+        ).run(name, baseUrl, isDefault ? 1 : 0, now, id);
+      } else {
+        db.prepare(
+          `UPDATE endpoints SET name = ?, base_url = ?, api_key_encrypted = ?, is_default = ?, updated_at = ?
+           WHERE id = ?`
+        ).run(name, baseUrl, enc, isDefault ? 1 : 0, now, id);
+      }
+    });
+    run();
+    return this.getEndpoint(id);
+  }
+
+  removeEndpoint(id: string): boolean {
+    const db = getDb();
+    const target = this.getEndpoint(id);
+    if (!target) return false;
+    const run = db.transaction(() => {
+      db.prepare('DELETE FROM endpoints WHERE id = ?').run(id);
+      // Promote the oldest remaining endpoint to default if we removed the default.
+      if (target.isDefault) {
+        const next = db
+          .prepare('SELECT id FROM endpoints ORDER BY created_at ASC LIMIT 1')
+          .get() as { id: string } | undefined;
+        if (next) {
+          db.prepare('UPDATE endpoints SET is_default = 1, updated_at = ? WHERE id = ?').run(
+            this.now(),
+            next.id
+          );
+        }
+      }
+    });
+    run();
+    return true;
+  }
+
+  // ---------- Models ----------
+
+  listModels(endpointId: string): ModelRow[] {
+    const rows = getDb()
+      .prepare(
+        `SELECT id, endpoint_id, model_id, display_name, discovered_at
+         FROM endpoint_models WHERE endpoint_id = ? ORDER BY model_id ASC`
+      )
+      .all(endpointId) as RawModel[];
+    return rows.map(toModelRow);
+  }
+
+  listModelsAll(): EndpointWithModels[] {
+    const endpoints = this.listEndpoints();
+    return endpoints.map((e) => ({ ...e, models: this.listModels(e.id) }));
+  }
+
+  // ---------- Network: test + refresh ----------
+
+  /**
+   * Lightweight connectivity probe. Issues `GET {baseUrl}/v1/models?limit=1`
+   * with the provided key and surfaces a structured result. Does NOT write to
+   * the DB — caller decides whether to persist status.
+   */
+  async testConnection(args: {
+    baseUrl: string;
+    apiKey: string;
+  }): Promise<{ ok: true } | { ok: false; status?: number; error: string }> {
+    const url = buildModelsUrl(args.baseUrl, { limit: 1 });
+    try {
+      const res = await this.fetchImpl(url, {
+        method: 'GET',
+        headers: buildAnthropicHeaders(args.apiKey),
+      });
+      if (!res.ok) {
+        const body = await safeReadText(res);
+        return {
+          ok: false,
+          status: res.status,
+          error: describeHttpError(res.status, body),
+        };
+      }
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  /**
+   * Fetch all pages of `GET /v1/models`, upsert into `endpoint_models`, and
+   * prune rows no longer present upstream. Updates endpoint last_status.
+   */
+  async refreshModels(
+    endpointId: string
+  ): Promise<{ ok: true; count: number } | { ok: false; error: string; status?: number }> {
+    const endpoint = this.getEndpoint(endpointId);
+    if (!endpoint) return { ok: false, error: 'Endpoint not found' };
+    const apiKey = this.getPlainKey(endpointId) ?? '';
+
+    const collected: AnthropicModelsPage['data'] = [];
+    let afterId: string | undefined;
+    const pageLimit = 1000; // 100 models/page × 10 pages ceiling — plenty
+
+    for (let page = 0; page < 10; page++) {
+      const url = buildModelsUrl(endpoint.baseUrl, {
+        limit: 100,
+        after_id: afterId,
+      });
+      let res: Response;
+      try {
+        res = await this.fetchImpl(url, {
+          method: 'GET',
+          headers: buildAnthropicHeaders(apiKey),
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        this.markEndpointStatus(endpointId, 'error', msg);
+        return { ok: false, error: msg };
+      }
+      if (!res.ok) {
+        const body = await safeReadText(res);
+        const msg = describeHttpError(res.status, body);
+        this.markEndpointStatus(endpointId, 'error', msg);
+        return { ok: false, error: msg, status: res.status };
+      }
+      let payload: AnthropicModelsPage;
+      try {
+        payload = (await res.json()) as AnthropicModelsPage;
+      } catch (err) {
+        const msg = `Malformed /v1/models response: ${err instanceof Error ? err.message : String(err)}`;
+        this.markEndpointStatus(endpointId, 'error', msg);
+        return { ok: false, error: msg };
+      }
+      if (!payload || !Array.isArray(payload.data)) {
+        const msg = 'Malformed /v1/models response: missing data array';
+        this.markEndpointStatus(endpointId, 'error', msg);
+        return { ok: false, error: msg };
+      }
+      collected.push(...payload.data);
+      if (collected.length >= pageLimit) break;
+      if (!payload.has_more) break;
+      afterId = payload.last_id ?? payload.data[payload.data.length - 1]?.id;
+      if (!afterId) break;
+    }
+
+    const now = this.now();
+    const db = getDb();
+    const run = db.transaction(() => {
+      db.prepare('DELETE FROM endpoint_models WHERE endpoint_id = ?').run(endpointId);
+      const insert = db.prepare(
+        `INSERT INTO endpoint_models (id, endpoint_id, model_id, display_name, discovered_at)
+         VALUES (?, ?, ?, ?, ?)`
+      );
+      for (const m of collected) {
+        if (!m || typeof m.id !== 'string' || !m.id) continue;
+        insert.run(randomUUID(), endpointId, m.id, m.display_name ?? null, now);
+      }
+      db.prepare(
+        `UPDATE endpoints SET last_status = 'ok', last_error = NULL, last_refreshed_at = ?, updated_at = ?
+         WHERE id = ?`
+      ).run(now, now, endpointId);
+    });
+    run();
+    return { ok: true, count: collected.length };
+  }
+
+  // ---------- Helpers ----------
+
+  private encryptKey(plain: string | undefined | null): Buffer | null {
+    if (!plain) return null;
+    if (!this.crypto.isAvailable()) return null;
+    return this.crypto.encrypt(plain);
+  }
+
+  private markEndpointStatus(
+    endpointId: string,
+    status: EndpointStatus,
+    error: string | null
+  ): void {
+    const now = this.now();
+    getDb()
+      .prepare(
+        `UPDATE endpoints SET last_status = ?, last_error = ?, updated_at = ? WHERE id = ?`
+      )
+      .run(status, error, now, endpointId);
+  }
+}
+
+function toEndpointRow(r: RawEndpoint): EndpointRow {
+  return {
+    id: r.id,
+    name: r.name,
+    baseUrl: r.base_url,
+    kind: (r.kind as EndpointKind) ?? 'anthropic',
+    isDefault: !!r.is_default,
+    lastStatus: (r.last_status as EndpointStatus) ?? 'unchecked',
+    lastError: r.last_error,
+    lastRefreshedAt: r.last_refreshed_at,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+  };
+}
+
+function toModelRow(r: RawModel): ModelRow {
+  return {
+    id: r.id,
+    endpointId: r.endpoint_id,
+    modelId: r.model_id,
+    displayName: r.display_name,
+    discoveredAt: r.discovered_at,
+  };
+}
+
+function normaliseBaseUrl(baseUrl: string): string {
+  let u = baseUrl.trim();
+  // Strip trailing /v1 or /v1/ so callers can paste either form.
+  u = u.replace(/\/+$/, '');
+  u = u.replace(/\/v1$/i, '');
+  return u;
+}
+
+function buildModelsUrl(
+  baseUrl: string,
+  query: { limit?: number; after_id?: string }
+): string {
+  const base = normaliseBaseUrl(baseUrl);
+  const params = new URLSearchParams();
+  if (query.limit != null) params.set('limit', String(query.limit));
+  if (query.after_id) params.set('after_id', query.after_id);
+  const qs = params.toString();
+  return `${base}/v1/models${qs ? `?${qs}` : ''}`;
+}
+
+function buildAnthropicHeaders(apiKey: string): Record<string, string> {
+  // `x-api-key` is the canonical header for Anthropic's REST API. Proxies that
+  // emulate the Anthropic API generally accept it too. `anthropic-version` is
+  // required by the official API; we use the baseline GA version for model
+  // listing which has been stable since 2023-06-01.
+  const headers: Record<string, string> = {
+    'anthropic-version': '2023-06-01',
+    accept: 'application/json',
+  };
+  if (apiKey) headers['x-api-key'] = apiKey;
+  return headers;
+}
+
+async function safeReadText(res: Response): Promise<string> {
+  try {
+    const t = await res.text();
+    return t.slice(0, 512);
+  } catch {
+    return '';
+  }
+}
+
+function describeHttpError(status: number, body: string): string {
+  if (status === 401 || status === 403) return `Authentication failed (HTTP ${status})`;
+  if (status === 404) return `Endpoint does not expose /v1/models (HTTP 404)`;
+  if (status === 429) return `Rate limited by upstream (HTTP 429)`;
+  if (status >= 500) return `Upstream error (HTTP ${status})`;
+  return body ? `HTTP ${status}: ${body}` : `HTTP ${status}`;
+}
+
+export const __test__ = { buildModelsUrl, normaliseBaseUrl, buildAnthropicHeaders };

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -6,6 +6,7 @@ import { sessions } from './agent/manager';
 import { installUpdaterIpc } from './updater';
 import { scanImportableSessions } from './import-scanner';
 import type { PermissionMode } from './agent/sessions';
+import { EndpointsManager, type KeyCrypto } from './endpoints-manager';
 
 const KEYCHAIN_FILE = 'anthropic-key.bin';
 
@@ -200,6 +201,20 @@ app.whenReady().then(() => {
     app.setAppUserModelId('com.agentory.desktop');
   }
   initDb();
+
+  const cryptoAdapter: KeyCrypto = {
+    isAvailable: () => safeStorage.isEncryptionAvailable(),
+    encrypt: (plain) => safeStorage.encryptString(plain),
+    decrypt: (cipher) => safeStorage.decryptString(cipher),
+  };
+  const endpoints = new EndpointsManager({ crypto: cryptoAdapter });
+
+  // First-run migration: if the parent env has ANTHROPIC_BASE_URL set and no
+  // endpoints exist yet, seed a "Default" endpoint with the env key so the
+  // self-host user flow Just Works on first launch. If neither is set, stay
+  // empty — the user will add endpoints via Settings.
+  void seedDefaultEndpointFromEnv(endpoints);
+
   ipcMain.handle('db:load', (_e, key: string) => loadState(key));
   ipcMain.handle('db:save', (_e, key: string, value: string) => saveState(key, value));
   ipcMain.handle('db:loadMessages', (_e, sessionId: string) => loadMessages(sessionId));
@@ -208,6 +223,52 @@ app.whenReady().then(() => {
     (_e, sessionId: string, blocks: Array<{ id: string; kind: string }>) =>
       saveMessages(sessionId, blocks)
   );
+
+  // Endpoints + models IPC
+  ipcMain.handle('endpoints:list', () => endpoints.listEndpoints());
+  ipcMain.handle(
+    'endpoints:add',
+    (_e, input: { name: string; baseUrl: string; kind?: 'anthropic'; apiKey?: string; isDefault?: boolean }) =>
+      endpoints.addEndpoint(input)
+  );
+  ipcMain.handle(
+    'endpoints:update',
+    (
+      _e,
+      id: string,
+      patch: { name?: string; baseUrl?: string; apiKey?: string | null; isDefault?: boolean }
+    ) => endpoints.updateEndpoint(id, patch)
+  );
+  ipcMain.handle('endpoints:remove', (_e, id: string) => endpoints.removeEndpoint(id));
+  ipcMain.handle(
+    'endpoints:testConnection',
+    (_e, args: { baseUrl: string; apiKey: string }) => endpoints.testConnection(args)
+  );
+  ipcMain.handle('endpoints:refreshModels', (_e, id: string) => endpoints.refreshModels(id));
+  ipcMain.handle('models:listByEndpoint', (_e, id: string) => endpoints.listModels(id));
+  ipcMain.handle('models:listAll', () => endpoints.listModelsAll());
+
+  // Main-process helper: resolve a session's endpoint env (base URL + plain
+  // key) so the spawner can inject them per-session without the renderer ever
+  // touching the plaintext key. Returns null if endpointId is unknown.
+  function resolveSessionEndpointEnv(
+    endpointId: string | undefined
+  ): Record<string, string> | undefined {
+    if (!endpointId) return undefined;
+    const ep = endpoints.getEndpoint(endpointId);
+    if (!ep) return undefined;
+    const overrides: Record<string, string> = {};
+    overrides.ANTHROPIC_BASE_URL = ep.baseUrl;
+    const key = endpoints.getPlainKey(endpointId);
+    if (key) {
+      overrides.ANTHROPIC_API_KEY = key;
+      overrides.ANTHROPIC_AUTH_TOKEN = key;
+    }
+    return overrides;
+  }
+  // Expose for agent:start below.
+  (global as unknown as { __agentoryEndpointEnv?: typeof resolveSessionEndpointEnv }).__agentoryEndpointEnv =
+    resolveSessionEndpointEnv;
   ipcMain.handle('app:getDataDir', () => app.getPath('userData'));
   ipcMain.handle('app:getVersion', () => app.getVersion());
   ipcMain.handle('keychain:getApiKey', () => readApiKey());
@@ -246,10 +307,20 @@ app.whenReady().then(() => {
     (
       _e,
       sessionId: string,
-      opts: { cwd: string; model?: string; permissionMode?: PermissionMode; resumeSessionId?: string }
+      opts: {
+        cwd: string;
+        model?: string;
+        permissionMode?: PermissionMode;
+        resumeSessionId?: string;
+        endpointId?: string;
+      }
     ) => {
-      const apiKey = readApiKey();
-      return sessions.start(sessionId, { ...opts, apiKey });
+      const envOverrides = resolveSessionEndpointEnv(opts.endpointId);
+      // Fall back to the global keychain key only when no endpoint was chosen
+      // or the endpoint has no stored key (user is still relying on parent
+      // env). Per-endpoint keys always win.
+      const apiKey = envOverrides?.ANTHROPIC_API_KEY ? undefined : readApiKey();
+      return sessions.start(sessionId, { ...opts, apiKey, envOverrides });
     }
   );
   ipcMain.handle('agent:send', (_e, sessionId: string, text: string) =>
@@ -320,3 +391,28 @@ app.on('window-all-closed', () => {
 app.on('activate', () => {
   if (BrowserWindow.getAllWindows().length === 0) createWindow();
 });
+
+async function seedDefaultEndpointFromEnv(mgr: EndpointsManager): Promise<void> {
+  try {
+    const existing = mgr.listEndpoints();
+    if (existing.length > 0) return;
+    const baseUrl = process.env.ANTHROPIC_BASE_URL?.trim();
+    if (!baseUrl) return;
+    const envKey =
+      process.env.ANTHROPIC_API_KEY?.trim() ||
+      process.env.ANTHROPIC_AUTH_TOKEN?.trim() ||
+      '';
+    const row = mgr.addEndpoint({
+      name: 'Default',
+      baseUrl,
+      kind: 'anthropic',
+      apiKey: envKey || undefined,
+      isDefault: true,
+    });
+    // Best-effort initial refresh. Failures are surfaced via the row's
+    // last_status — we don't block startup on this.
+    void mgr.refreshModels(row.id).catch(() => {});
+  } catch (err) {
+    console.warn('[main] seedDefaultEndpointFromEnv failed', err);
+  }
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -6,6 +6,7 @@ type StartOpts = {
   model?: string;
   permissionMode?: PermissionMode;
   resumeSessionId?: string;
+  endpointId?: string;
 };
 
 type StartResult = { ok: true } | { ok: false; error: string };
@@ -18,6 +19,35 @@ type AgentPermissionRequest = {
   toolName: string;
   input: Record<string, unknown>;
 };
+
+type EndpointKind = 'anthropic';
+type EndpointStatus = 'ok' | 'error' | 'unchecked';
+type EndpointRow = {
+  id: string;
+  name: string;
+  baseUrl: string;
+  kind: EndpointKind;
+  isDefault: boolean;
+  lastStatus: EndpointStatus;
+  lastError: string | null;
+  lastRefreshedAt: number | null;
+  createdAt: number;
+  updatedAt: number;
+};
+type ModelRow = {
+  id: string;
+  endpointId: string;
+  modelId: string;
+  displayName: string | null;
+  discoveredAt: number;
+};
+type EndpointWithModels = EndpointRow & { models: ModelRow[] };
+type TestConnectionResult =
+  | { ok: true }
+  | { ok: false; status?: number; error: string };
+type RefreshResult =
+  | { ok: true; count: number }
+  | { ok: false; error: string; status?: number };
 
 type UpdateStatus =
   | { kind: 'idle' }
@@ -111,6 +141,32 @@ const api = {
       return () => ipcRenderer.removeListener('window:maximizedChanged', wrap);
     },
     platform: process.platform
+  },
+
+  endpoints: {
+    list: (): Promise<EndpointRow[]> => ipcRenderer.invoke('endpoints:list'),
+    add: (input: {
+      name: string;
+      baseUrl: string;
+      kind?: EndpointKind;
+      apiKey?: string;
+      isDefault?: boolean;
+    }): Promise<EndpointRow> => ipcRenderer.invoke('endpoints:add', input),
+    update: (
+      id: string,
+      patch: { name?: string; baseUrl?: string; apiKey?: string | null; isDefault?: boolean }
+    ): Promise<EndpointRow | null> => ipcRenderer.invoke('endpoints:update', id, patch),
+    remove: (id: string): Promise<boolean> => ipcRenderer.invoke('endpoints:remove', id),
+    testConnection: (args: { baseUrl: string; apiKey: string }): Promise<TestConnectionResult> =>
+      ipcRenderer.invoke('endpoints:testConnection', args),
+    refreshModels: (id: string): Promise<RefreshResult> =>
+      ipcRenderer.invoke('endpoints:refreshModels', id),
+  },
+
+  models: {
+    listByEndpoint: (id: string): Promise<ModelRow[]> =>
+      ipcRenderer.invoke('models:listByEndpoint', id),
+    listAll: (): Promise<EndpointWithModels[]> => ipcRenderer.invoke('models:listAll'),
   }
 };
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -128,7 +128,11 @@ export default [
         clearInterval: 'readonly',
         setImmediate: 'readonly',
         clearImmediate: 'readonly',
-        globalThis: 'readonly'
+        globalThis: 'readonly',
+        global: 'readonly',
+        fetch: 'readonly',
+        Response: 'readonly',
+        URLSearchParams: 'readonly'
       }
     }
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -197,7 +197,7 @@ export default function App() {
             <ChatStream />
             <StatusBar
               cwd={active.cwd}
-              model={model}
+              model={active.model || model}
               permission={permission}
               onChangeCwd={async (p) => {
                 let next = p;

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -21,7 +21,7 @@ export function InputBar({ sessionId }: { sessionId: string }) {
   const running = useStore((s) => !!s.runningSessions[sessionId]);
   const hasMessages = useStore((s) => (s.messagesBySession[sessionId]?.length ?? 0) > 0);
   const permission = useStore((s) => s.permission);
-  const model = useStore((s) => s.model);
+  const defaultEndpointId = useStore((s) => s.defaultEndpointId);
   const appendBlocks = useStore((s) => s.appendBlocks);
   const markStarted = useStore((s) => s.markStarted);
   const setRunning = useStore((s) => s.setRunning);
@@ -54,11 +54,13 @@ export function InputBar({ sessionId }: { sessionId: string }) {
     resetWatchdogCount(sessionId);
 
     if (!started) {
+      const endpointId = session.endpointId ?? defaultEndpointId ?? undefined;
       const res = await api.agentStart(sessionId, {
         cwd: session.cwd,
-        model,
+        model: session.model || undefined,
         permissionMode: toSdkPermissionMode(permission),
-        resumeSessionId: session.resumeSessionId
+        resumeSessionId: session.resumeSessionId,
+        endpointId
       });
       if (!res.ok) {
         setRunning(sessionId, false);

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -13,10 +13,11 @@ type LocalUpdateStatus =
   | { kind: 'downloaded'; version: string }
   | { kind: 'error'; message: string };
 
-type Tab = 'general' | 'autopilot' | 'account' | 'data' | 'shortcuts' | 'updates';
+type Tab = 'general' | 'endpoints' | 'autopilot' | 'account' | 'data' | 'shortcuts' | 'updates';
 
 const TABS: { id: Tab; label: string }[] = [
   { id: 'general', label: 'General' },
+  { id: 'endpoints', label: 'Endpoints' },
   { id: 'autopilot', label: 'Autopilot' },
   { id: 'account', label: 'Account' },
   { id: 'data', label: 'Data' },
@@ -70,6 +71,7 @@ export function SettingsDialog({
           </nav>
           <div className="flex-1 min-w-0 p-5 overflow-y-auto">
             {tab === 'general' && <GeneralPane />}
+            {tab === 'endpoints' && <EndpointsPane />}
             {tab === 'autopilot' && <AutopilotPane />}
             {tab === 'account' && <AccountPane />}
             {tab === 'data' && <DataPane />}
@@ -403,4 +405,355 @@ function formatBytes(n: number): string {
   if (n < 1024) return `${n} B`;
   if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
   return `${(n / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function relativeTime(ts: number | null): string {
+  if (!ts) return 'never';
+  const delta = Date.now() - ts;
+  if (delta < 60_000) return 'just now';
+  if (delta < 3_600_000) return `${Math.floor(delta / 60_000)}m ago`;
+  if (delta < 86_400_000) return `${Math.floor(delta / 3_600_000)}h ago`;
+  return `${Math.floor(delta / 86_400_000)}d ago`;
+}
+
+type EditingEndpoint = {
+  id?: string;
+  name: string;
+  baseUrl: string;
+  apiKey: string;
+  isDefault: boolean;
+  hasExistingKey?: boolean;
+};
+
+function EndpointsPane() {
+  const endpoints = useStore((s) => s.endpoints);
+  const modelsByEndpoint = useStore((s) => s.modelsByEndpoint);
+  const endpointsLoaded = useStore((s) => s.endpointsLoaded);
+  const reloadEndpoints = useStore((s) => s.reloadEndpoints);
+  const refreshEndpointModels = useStore((s) => s.refreshEndpointModels);
+
+  const [editor, setEditor] = useState<EditingEndpoint | null>(null);
+  const [refreshingId, setRefreshingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onRefresh(id: string) {
+    setRefreshingId(id);
+    setError(null);
+    const res = await refreshEndpointModels(id);
+    setRefreshingId(null);
+    if (!res.ok) setError(res.error ?? 'Refresh failed');
+  }
+
+  async function onRemove(id: string) {
+    const api = window.agentory;
+    if (!api) return;
+    await api.endpoints.remove(id);
+    await reloadEndpoints();
+  }
+
+  return (
+    <>
+      <div className="flex items-center justify-between mb-4">
+        <div className="text-xs text-fg-tertiary max-w-[440px]">
+          Agentory talks to any server that speaks the Anthropic REST API:
+          anthropic.com, a self-hosted gateway, or a LiteLLM / Kimi / DeepSeek
+          shim. Add one here and Agentory will discover its models via
+          <code className="font-mono text-fg-secondary mx-1">GET /v1/models</code>.
+        </div>
+        <Button variant="primary" size="md" onClick={() => setEditor(emptyEditor())}>
+          Add endpoint
+        </Button>
+      </div>
+
+      {error && (
+        <div className="mb-3 px-3 py-2 rounded-sm border border-state-error/40 bg-state-error/10 text-xs text-state-error">
+          {error}
+        </div>
+      )}
+
+      {!endpointsLoaded ? (
+        <div className="text-sm text-fg-tertiary">Loading endpoints…</div>
+      ) : endpoints.length === 0 ? (
+        <div className="text-sm text-fg-tertiary">
+          No endpoints yet. Click &quot;Add endpoint&quot; to point Agentory at Anthropic
+          or your own gateway.
+        </div>
+      ) : (
+        <ul className="divide-y divide-border-subtle rounded-sm border border-border-subtle bg-bg-elevated">
+          {endpoints.map((e) => {
+            const models = modelsByEndpoint[e.id] ?? [];
+            return (
+              <li key={e.id} className="flex items-center gap-3 px-3 py-2.5">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium text-fg-primary truncate">{e.name}</span>
+                    {e.isDefault && (
+                      <span className="text-[10px] uppercase tracking-wide px-1 rounded-sm bg-accent/15 text-accent">
+                        default
+                      </span>
+                    )}
+                    <StatusBadge status={e.lastStatus} />
+                  </div>
+                  <div className="text-[11px] font-mono text-fg-tertiary truncate" title={e.baseUrl}>
+                    {e.baseUrl}
+                  </div>
+                  <div className="text-[11px] text-fg-tertiary mt-0.5">
+                    {models.length} model{models.length === 1 ? '' : 's'} · refreshed{' '}
+                    {relativeTime(e.lastRefreshedAt)}
+                    {e.lastStatus === 'error' && e.lastError ? ` · ${e.lastError}` : ''}
+                  </div>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => onRefresh(e.id)}
+                    disabled={refreshingId === e.id}
+                  >
+                    {refreshingId === e.id ? 'Refreshing…' : 'Refresh'}
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() =>
+                      setEditor({
+                        id: e.id,
+                        name: e.name,
+                        baseUrl: e.baseUrl,
+                        apiKey: '',
+                        isDefault: e.isDefault,
+                        hasExistingKey: true,
+                      })
+                    }
+                  >
+                    Edit
+                  </Button>
+                  <Button
+                    variant="danger"
+                    size="sm"
+                    onClick={() => {
+                      if (window.confirm(`Remove endpoint "${e.name}"?`)) void onRemove(e.id);
+                    }}
+                  >
+                    Remove
+                  </Button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {editor && (
+        <EndpointEditorDialog
+          value={editor}
+          onClose={() => setEditor(null)}
+          onSaved={async () => {
+            setEditor(null);
+            await reloadEndpoints();
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+function emptyEditor(): EditingEndpoint {
+  return { name: '', baseUrl: 'https://api.anthropic.com', apiKey: '', isDefault: false };
+}
+
+function StatusBadge({ status }: { status: 'ok' | 'error' | 'unchecked' }) {
+  const cls =
+    status === 'ok'
+      ? 'bg-state-success/15 text-state-success'
+      : status === 'error'
+      ? 'bg-state-error/15 text-state-error'
+      : 'bg-bg-hover text-fg-tertiary';
+  const label = status === 'ok' ? 'connected' : status === 'error' ? 'error' : 'unchecked';
+  return (
+    <span className={cn('text-[10px] uppercase tracking-wide px-1 rounded-sm', cls)}>{label}</span>
+  );
+}
+
+function EndpointEditorDialog({
+  value,
+  onClose,
+  onSaved,
+}: {
+  value: EditingEndpoint;
+  onClose: () => void;
+  onSaved: () => void | Promise<void>;
+}) {
+  const [name, setName] = useState(value.name);
+  const [baseUrl, setBaseUrl] = useState(value.baseUrl);
+  const [apiKey, setApiKey] = useState('');
+  const [isDefault, setIsDefault] = useState(value.isDefault);
+  const [revealKey, setRevealKey] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const isEdit = !!value.id;
+  const keyRequired = !isEdit;
+  const canTest = baseUrl.trim().length > 0 && (apiKey.length > 0 || value.hasExistingKey);
+
+  async function onTest() {
+    if (!window.agentory) return;
+    setTesting(true);
+    setTestResult(null);
+    const res = await window.agentory.endpoints.testConnection({
+      baseUrl: baseUrl.trim(),
+      apiKey: apiKey || '',
+    });
+    setTesting(false);
+    setTestResult(res.ok ? 'ok' : res.error);
+  }
+
+  async function onSave() {
+    if (!window.agentory) return;
+    if (!name.trim() || !baseUrl.trim()) return;
+    if (keyRequired && !apiKey) return;
+    setSaving(true);
+    try {
+      if (isEdit && value.id) {
+        await window.agentory.endpoints.update(value.id, {
+          name: name.trim(),
+          baseUrl: baseUrl.trim(),
+          apiKey: apiKey ? apiKey : undefined,
+          isDefault,
+        });
+        await window.agentory.endpoints.refreshModels(value.id);
+      } else {
+        const row = await window.agentory.endpoints.add({
+          name: name.trim(),
+          baseUrl: baseUrl.trim(),
+          kind: 'anthropic',
+          apiKey: apiKey || undefined,
+          isDefault,
+        });
+        await window.agentory.endpoints.refreshModels(row.id);
+      }
+      await onSaved();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const inputClass = cn(
+    'w-full h-8 px-2 rounded-sm bg-bg-elevated border border-border-default',
+    'text-sm text-fg-primary placeholder:text-fg-disabled outline-none',
+    'focus:border-border-strong focus:shadow-[0_0_0_2px_oklch(0.72_0.14_215_/_0.30)]'
+  );
+
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent title={isEdit ? 'Edit endpoint' : 'Add endpoint'} width="520px">
+        <div className="px-5 pb-4">
+          <Field label="Name">
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Anthropic, My LiteLLM"
+              className={inputClass}
+              autoFocus
+            />
+          </Field>
+          <Field label="Base URL" hint="Agentory appends /v1/models. Paste the root or include /v1.">
+            <input
+              type="text"
+              value={baseUrl}
+              onChange={(e) => setBaseUrl(e.target.value)}
+              placeholder="https://api.anthropic.com"
+              className={cn(inputClass, 'font-mono')}
+            />
+          </Field>
+          <Field label="Protocol">
+            <div className="flex items-center gap-3 text-sm">
+              <label className="inline-flex items-center gap-1.5 cursor-pointer">
+                <input type="radio" checked readOnly className="accent-accent" />
+                <span className="text-fg-primary">Anthropic</span>
+              </label>
+              <label
+                title="Phase 2 — not yet supported"
+                className="inline-flex items-center gap-1.5 opacity-50 cursor-not-allowed"
+              >
+                <input type="radio" disabled className="accent-accent" />
+                <span>OpenAI-compatible</span>
+              </label>
+              <label
+                title="Phase 2 — not yet supported"
+                className="inline-flex items-center gap-1.5 opacity-50 cursor-not-allowed"
+              >
+                <input type="radio" disabled className="accent-accent" />
+                <span>Ollama</span>
+              </label>
+            </div>
+          </Field>
+          <Field
+            label="API key"
+            hint={
+              value.hasExistingKey
+                ? 'Leave blank to keep the existing key.'
+                : 'Stored encrypted via the OS keychain. Never sent to the renderer.'
+            }
+          >
+            <div className="flex items-center gap-2">
+              <input
+                type={revealKey ? 'text' : 'password'}
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                placeholder={value.hasExistingKey ? '••••••• (unchanged)' : 'sk-ant-…'}
+                className={cn(inputClass, 'font-mono')}
+              />
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setRevealKey((r) => !r)}
+                aria-label={revealKey ? 'Hide key' : 'Reveal key'}
+              >
+                {revealKey ? 'Hide' : 'Show'}
+              </Button>
+            </div>
+          </Field>
+          <Field label="Default endpoint" hint="Used for new sessions that don't pick one.">
+            <label className="inline-flex items-center gap-2 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={isDefault}
+                onChange={(e) => setIsDefault(e.target.checked)}
+                className="h-4 w-4 accent-accent"
+              />
+              <span className="text-sm text-fg-secondary">Make default</span>
+            </label>
+          </Field>
+          <div className="flex items-center gap-3 mt-4">
+            <Button variant="secondary" size="md" onClick={onTest} disabled={!canTest || testing}>
+              {testing ? 'Testing…' : 'Test connection'}
+            </Button>
+            {testResult === 'ok' && (
+              <span className="text-xs text-state-success">Connected.</span>
+            )}
+            {testResult && testResult !== 'ok' && (
+              <span className="text-xs text-state-error">{testResult}</span>
+            )}
+          </div>
+        </div>
+        <div className="flex items-center justify-end gap-2 px-5 py-3 border-t border-border-subtle">
+          <Button variant="ghost" size="md" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            size="md"
+            onClick={onSave}
+            disabled={
+              !name.trim() || !baseUrl.trim() || saving || (keyRequired && !apiKey)
+            }
+          >
+            {saving ? 'Saving…' : isEdit ? 'Save' : 'Add'}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
 }

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -11,7 +11,6 @@ import {
 } from './ui/DropdownMenu';
 import { useStore } from '../stores/store';
 
-type ModelId = 'claude-opus-4' | 'claude-sonnet-4' | 'claude-haiku-4';
 type PermissionMode = 'plan' | 'ask' | 'auto' | 'yolo';
 
 function lastSegment(path: string): string {
@@ -53,7 +52,8 @@ type ChipOption<V extends string> =
       secondary?: string;
       icon?: React.ReactNode;
     }
-  | { kind: 'separator' };
+  | { kind: 'separator' }
+  | { kind: 'label'; primary: string };
 
 type ChipMenuProps<V extends string> = {
   label: string;
@@ -77,10 +77,17 @@ function ChipMenu<V extends string>({
       <DropdownMenuTrigger asChild>
         <Chip title={triggerTitle} accent={triggerAccent}>{triggerLabel}</Chip>
       </DropdownMenuTrigger>
-      <DropdownMenuContent side="top" align="start" className="min-w-[240px]">
+      <DropdownMenuContent side="top" align="start" className="min-w-[240px] max-h-[360px] overflow-y-auto">
         <DropdownMenuLabel>{label}</DropdownMenuLabel>
         {options.map((o, i) => {
           if (o.kind === 'separator') return <DropdownMenuSeparator key={`sep-${i}`} />;
+          if (o.kind === 'label') {
+            return (
+              <DropdownMenuLabel key={`lbl-${i}`} className="pt-2">
+                {o.primary}
+              </DropdownMenuLabel>
+            );
+          }
           if (o.secondary) {
             return (
               <DropdownMenuItem
@@ -109,12 +116,6 @@ function ChipMenu<V extends string>({
 
 const BROWSE_FOLDER = '__browse__';
 
-const modelOptions: ChipOption<ModelId>[] = [
-  { kind: 'item', value: 'claude-opus-4', primary: 'opus-4', secondary: 'Most capable, slower and pricier' },
-  { kind: 'item', value: 'claude-sonnet-4', primary: 'sonnet-4', secondary: 'Balanced — recommended default' },
-  { kind: 'item', value: 'claude-haiku-4', primary: 'haiku-4', secondary: 'Fastest and cheapest, lower quality' }
-];
-
 // Labels describe what claude.exe actually does per mode. There is no CLI
 // setting that prompts on every single tool — reads are always auto-approved
 // below `bypassPermissions` and above `plan`. The chip wording reflects that
@@ -142,10 +143,10 @@ function primaryOf<V extends string>(options: ChipOption<V>[], value: V): string
 
 export type StatusBarProps = {
   cwd: string;
-  model: ModelId;
+  model: string;
   permission: PermissionMode;
   onChangeCwd: (cwd: string | null) => void;
-  onChangeModel: (model: ModelId) => void;
+  onChangeModel: (model: string) => void;
   onChangePermission: (mode: PermissionMode) => void;
 };
 
@@ -158,6 +159,10 @@ export function StatusBar({
   onChangePermission
 }: StatusBarProps) {
   const recentProjects = useStore((s) => s.recentProjects);
+  const endpoints = useStore((s) => s.endpoints);
+  const modelsByEndpoint = useStore((s) => s.modelsByEndpoint);
+  const endpointsLoaded = useStore((s) => s.endpointsLoaded);
+
   const cwdOptions: ChipOption<string>[] = [
     ...recentProjects.map(
       (p) =>
@@ -173,6 +178,51 @@ export function StatusBar({
       icon: <Folder size={12} className="stroke-[1.75] mr-2 text-fg-tertiary" />
     }
   ];
+
+  // Build the grouped model option list: one `label` row per endpoint,
+  // followed by that endpoint's discovered models, separated between groups.
+  const modelOptions: ChipOption<string>[] = [];
+  if (!endpointsLoaded) {
+    modelOptions.push({ kind: 'label', primary: 'Loading…' });
+  } else if (endpoints.length === 0) {
+    modelOptions.push({ kind: 'label', primary: 'No endpoints configured' });
+  } else {
+    endpoints.forEach((e, idx) => {
+      if (idx > 0) modelOptions.push({ kind: 'separator' });
+      modelOptions.push({
+        kind: 'label',
+        primary: `${e.name}${e.isDefault ? ' (default)' : ''}`
+      });
+      const models = modelsByEndpoint[e.id] ?? [];
+      if (models.length === 0) {
+        modelOptions.push({
+          kind: 'label',
+          primary: e.lastStatus === 'error' ? e.lastError ?? 'Error' : 'No models yet — click Refresh in Settings'
+        });
+      } else {
+        for (const m of models) {
+          modelOptions.push({
+            kind: 'item',
+            value: m.modelId,
+            primary: m.displayName ?? m.modelId,
+            secondary: m.displayName ? m.modelId : undefined
+          });
+        }
+      }
+    });
+  }
+
+  // Render the trigger as the model's display name when known, else its id,
+  // else a friendly placeholder.
+  let modelTriggerLabel = model || '(pick model)';
+  for (const list of Object.values(modelsByEndpoint)) {
+    const found = list.find((m) => m.modelId === model);
+    if (found) {
+      modelTriggerLabel = found.displayName ?? found.modelId;
+      break;
+    }
+  }
+
   const chips: React.ReactNode[] = [
     <ChipMenu
       key="cwd"
@@ -185,7 +235,7 @@ export function StatusBar({
     <ChipMenu
       key="model"
       label="Model"
-      triggerLabel={primaryOf(modelOptions, model)}
+      triggerLabel={modelTriggerLabel}
       options={modelOptions}
       onSelect={onChangeModel}
     />,

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -9,6 +9,7 @@ type StartOpts = {
   model?: string;
   permissionMode?: PermissionMode;
   resumeSessionId?: string;
+  endpointId?: string;
 };
 
 type StartResult = { ok: true } | { ok: false; error: string };
@@ -29,6 +30,35 @@ type UpdateStatus =
   | { kind: 'downloading'; percent: number; transferred: number; total: number }
   | { kind: 'downloaded'; version: string }
   | { kind: 'error'; message: string };
+
+type EndpointKindDecl = 'anthropic';
+type EndpointStatusDecl = 'ok' | 'error' | 'unchecked';
+type EndpointRowDecl = {
+  id: string;
+  name: string;
+  baseUrl: string;
+  kind: EndpointKindDecl;
+  isDefault: boolean;
+  lastStatus: EndpointStatusDecl;
+  lastError: string | null;
+  lastRefreshedAt: number | null;
+  createdAt: number;
+  updatedAt: number;
+};
+type ModelRowDecl = {
+  id: string;
+  endpointId: string;
+  modelId: string;
+  displayName: string | null;
+  discoveredAt: number;
+};
+type EndpointWithModelsDecl = EndpointRowDecl & { models: ModelRowDecl[] };
+type TestConnectionResultDecl =
+  | { ok: true }
+  | { ok: false; status?: number; error: string };
+type RefreshResultDecl =
+  | { ok: true; count: number }
+  | { ok: false; error: string; status?: number };
 
 declare global {
   interface Window {
@@ -79,6 +109,29 @@ declare global {
         isMaximized: () => Promise<boolean>;
         onMaximizedChanged: (handler: (max: boolean) => void) => () => void;
         platform: 'aix' | 'android' | 'darwin' | 'freebsd' | 'haiku' | 'linux' | 'openbsd' | 'sunos' | 'win32' | 'cygwin' | 'netbsd';
+      };
+
+      endpoints: {
+        list: () => Promise<EndpointRowDecl[]>;
+        add: (input: {
+          name: string;
+          baseUrl: string;
+          kind?: EndpointKindDecl;
+          apiKey?: string;
+          isDefault?: boolean;
+        }) => Promise<EndpointRowDecl>;
+        update: (
+          id: string,
+          patch: { name?: string; baseUrl?: string; apiKey?: string | null; isDefault?: boolean }
+        ) => Promise<EndpointRowDecl | null>;
+        remove: (id: string) => Promise<boolean>;
+        testConnection: (args: { baseUrl: string; apiKey: string }) => Promise<TestConnectionResultDecl>;
+        refreshModels: (id: string) => Promise<RefreshResultDecl>;
+      };
+
+      models: {
+        listByEndpoint: (id: string) => Promise<ModelRowDecl[]>;
+        listAll: () => Promise<EndpointWithModelsDecl[]>;
       };
     };
   }

--- a/src/stores/persist.ts
+++ b/src/stores/persist.ts
@@ -1,5 +1,5 @@
 import type { Group, Session } from '../types';
-import type { ModelId, PermissionMode, Theme, FontSize, WatchdogConfig } from './store';
+import type { PermissionMode, Theme, FontSize, WatchdogConfig } from './store';
 import type { RecentProject } from '../mock/data';
 
 export const STATE_KEY = 'main';
@@ -9,7 +9,7 @@ export interface PersistedState {
   sessions: Session[];
   groups: Group[];
   activeId: string;
-  model: ModelId;
+  model: string;
   permission: PermissionMode;
   sidebarCollapsed: boolean;
   theme?: Theme;
@@ -17,6 +17,11 @@ export interface PersistedState {
   recentProjects?: RecentProject[];
   tutorialSeen?: boolean;
   watchdog?: WatchdogConfig;
+  /**
+   * Default endpoint id for new sessions. Persisted so the user's pick survives
+   * restarts. Falls back to the endpoint with is_default=1 if missing.
+   */
+  defaultEndpointId?: string | null;
 }
 
 export async function loadPersisted(): Promise<PersistedState | null> {

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -4,10 +4,34 @@ import { toSdkPermissionMode } from '../agent/permission';
 import type { Group, Session, MessageBlock } from '../types';
 import { loadPersisted, schedulePersist, type PersistedState } from './persist';
 
-export type ModelId = 'claude-opus-4' | 'claude-sonnet-4' | 'claude-haiku-4';
+export type ModelId = string;
 export type PermissionMode = 'plan' | 'ask' | 'auto' | 'yolo';
 export type Theme = 'system' | 'light' | 'dark';
 export type FontSize = 'sm' | 'md' | 'lg';
+
+export type EndpointKind = 'anthropic';
+export type EndpointStatus = 'ok' | 'error' | 'unchecked';
+
+export interface Endpoint {
+  id: string;
+  name: string;
+  baseUrl: string;
+  kind: EndpointKind;
+  isDefault: boolean;
+  lastStatus: EndpointStatus;
+  lastError: string | null;
+  lastRefreshedAt: number | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface ModelInfo {
+  id: string;
+  endpointId: string;
+  modelId: string;
+  displayName: string | null;
+  discoveredAt: number;
+}
 
 // Auto-prompt watchdog: when an agent stops without uttering the done token,
 // the lifecycle replies for the user so the agent doesn't sit idle. Tunables
@@ -48,6 +72,10 @@ type State = {
   // `result { error_during_execution }` frame arrives so we can render a
   // neutral "Interrupted" banner instead of an error block.
   interruptedSessions: Record<string, true>;
+  endpoints: Endpoint[];
+  modelsByEndpoint: Record<string, ModelInfo[]>;
+  defaultEndpointId: string | null;
+  endpointsLoaded: boolean;
 };
 
 type Actions = {
@@ -88,6 +116,13 @@ type Actions = {
   markInterrupted: (sessionId: string) => void;
   consumeInterrupted: (sessionId: string) => boolean;
   resolvePermission: (sessionId: string, requestId: string, decision: 'allow' | 'deny') => void;
+
+  setEndpoints: (list: Endpoint[]) => void;
+  setModelsForEndpoint: (endpointId: string, models: ModelInfo[]) => void;
+  setDefaultEndpointId: (id: string | null) => void;
+  refreshAllEndpointModels: () => Promise<void>;
+  refreshEndpointModels: (endpointId: string) => Promise<{ ok: boolean; error?: string }>;
+  reloadEndpoints: () => Promise<void>;
 };
 
 function nextId(prefix: string): string {
@@ -113,7 +148,7 @@ export const useStore = create<State & Actions>((set, get) => ({
   recentProjects: [],
   activeId: '',
   focusedGroupId: null,
-  model: 'claude-opus-4',
+  model: '',
   permission: 'auto',
   sidebarCollapsed: false,
   theme: 'system',
@@ -125,6 +160,10 @@ export const useStore = create<State & Actions>((set, get) => ({
   startedSessions: {},
   runningSessions: {},
   interruptedSessions: {},
+  endpoints: [],
+  modelsByEndpoint: {},
+  defaultEndpointId: null,
+  endpointsLoaded: false,
 
   selectSession: (id) => {
     set((s) => ({
@@ -146,7 +185,17 @@ export const useStore = create<State & Actions>((set, get) => ({
   focusGroup: (id) => set({ focusedGroupId: id }),
 
   createSession: (cwd) => {
-    const { sessions, groups, focusedGroupId, activeId, model, recentProjects } = get();
+    const {
+      sessions,
+      groups,
+      focusedGroupId,
+      activeId,
+      model,
+      recentProjects,
+      defaultEndpointId,
+      modelsByEndpoint,
+      endpoints,
+    } = get();
     const isUsable = (gid: string | null | undefined) => {
       if (!gid) return false;
       const g = groups.find((x) => x.id === gid);
@@ -160,14 +209,23 @@ export const useStore = create<State & Actions>((set, get) => ({
       : firstUsableGroupId(groups);
     const id = nextId('s');
     const defaultCwd = recentProjects[0]?.path ?? '~';
+    const endpointId =
+      defaultEndpointId ?? endpoints.find((e) => e.isDefault)?.id ?? endpoints[0]?.id;
+    // Pick a sensible initial model: global `model` if set, else the default
+    // endpoint's first discovered model, else empty (user picks on first send).
+    let initialModel = model;
+    if (!initialModel && endpointId) {
+      initialModel = modelsByEndpoint[endpointId]?.[0]?.modelId ?? '';
+    }
     const newSession: Session = {
       id,
       name: 'New session',
       state: 'idle',
       cwd: cwd ?? defaultCwd,
-      model,
+      model: initialModel,
       groupId: targetGroupId,
-      agentType: 'claude-code'
+      agentType: 'claude-code',
+      endpointId,
     };
     set({
       sessions: [newSession, ...sessions],
@@ -183,16 +241,23 @@ export const useStore = create<State & Actions>((set, get) => ({
   },
 
   importSession: ({ name, cwd, groupId, resumeSessionId }) => {
-    const { sessions, model } = get();
+    const { sessions, model, defaultEndpointId, endpoints, modelsByEndpoint } = get();
     const id = nextId('s');
+    const endpointId =
+      defaultEndpointId ?? endpoints.find((e) => e.isDefault)?.id ?? endpoints[0]?.id;
+    let initialModel = model;
+    if (!initialModel && endpointId) {
+      initialModel = modelsByEndpoint[endpointId]?.[0]?.modelId ?? '';
+    }
     const imported: Session = {
       id,
       name,
       state: 'idle',
       cwd,
-      model,
+      model: initialModel,
       groupId,
       agentType: 'claude-code',
+      endpointId,
       resumeSessionId
     };
     set({ sessions: [imported, ...sessions], activeId: id, focusedGroupId: null });
@@ -276,11 +341,16 @@ export const useStore = create<State & Actions>((set, get) => ({
   },
 
   setModel: (model) => {
-    set({ model });
+    set((s) => ({
+      model,
+      sessions: s.sessions.map((x) => (x.id === s.activeId ? { ...x, model } : x))
+    }));
     const api = window.agentory;
     if (!api) return;
-    const started = Object.keys(get().startedSessions);
-    for (const id of started) void api.agentSetModel(id, model);
+    const activeId = get().activeId;
+    if (activeId && get().startedSessions[activeId]) {
+      void api.agentSetModel(activeId, model);
+    }
   },
   setPermission: (permission) => {
     set({ permission });
@@ -520,6 +590,67 @@ export const useStore = create<State & Actions>((set, get) => ({
       };
     });
     void window.agentory?.agentResolvePermission(sessionId, requestId, decision);
+  },
+
+  setEndpoints: (list) => set({ endpoints: list }),
+  setModelsForEndpoint: (endpointId, models) =>
+    set((s) => ({ modelsByEndpoint: { ...s.modelsByEndpoint, [endpointId]: models } })),
+  setDefaultEndpointId: (id) => set({ defaultEndpointId: id }),
+
+  reloadEndpoints: async () => {
+    const api = window.agentory;
+    if (!api) return;
+    const all = await api.models.listAll();
+    const endpoints: Endpoint[] = all.map((e) => ({
+      id: e.id,
+      name: e.name,
+      baseUrl: e.baseUrl,
+      kind: e.kind,
+      isDefault: e.isDefault,
+      lastStatus: e.lastStatus,
+      lastError: e.lastError,
+      lastRefreshedAt: e.lastRefreshedAt,
+      createdAt: e.createdAt,
+      updatedAt: e.updatedAt
+    }));
+    const modelsByEndpoint: Record<string, ModelInfo[]> = {};
+    for (const e of all) modelsByEndpoint[e.id] = e.models;
+    set((s) => {
+      const currentDefault = s.defaultEndpointId;
+      const stillExists = currentDefault && endpoints.some((e) => e.id === currentDefault);
+      const nextDefault = stillExists
+        ? currentDefault
+        : endpoints.find((e) => e.isDefault)?.id ?? endpoints[0]?.id ?? null;
+      return {
+        endpoints,
+        modelsByEndpoint,
+        defaultEndpointId: nextDefault,
+        endpointsLoaded: true
+      };
+    });
+  },
+
+  refreshEndpointModels: async (endpointId) => {
+    const api = window.agentory;
+    if (!api) return { ok: false, error: 'IPC unavailable' };
+    const res = await api.endpoints.refreshModels(endpointId);
+    // Re-read from DB regardless of outcome so last_status / last_error land.
+    await get().reloadEndpoints();
+    return res.ok ? { ok: true } : { ok: false, error: res.error };
+  },
+
+  refreshAllEndpointModels: async () => {
+    const api = window.agentory;
+    if (!api) return;
+    const list = get().endpoints;
+    for (const e of list) {
+      // Don't thrash: refresh only if never refreshed OR older than 24h.
+      const stale =
+        !e.lastRefreshedAt || Date.now() - e.lastRefreshedAt > 24 * 60 * 60 * 1000;
+      if (!stale) continue;
+      await api.endpoints.refreshModels(e.id);
+    }
+    await get().reloadEndpoints();
   }
 }));
 
@@ -541,7 +672,8 @@ export async function hydrateStore(): Promise<void> {
       fontSize: persisted.fontSize ?? 'md',
       recentProjects: persisted.recentProjects ?? [],
       tutorialSeen: persisted.tutorialSeen ?? false,
-      watchdog: { ...DEFAULT_WATCHDOG, ...(persisted.watchdog ?? {}) }
+      watchdog: { ...DEFAULT_WATCHDOG, ...(persisted.watchdog ?? {}) },
+      defaultEndpointId: persisted.defaultEndpointId ?? null
     });
   }
   hydrated = true;
@@ -549,6 +681,15 @@ export async function hydrateStore(): Promise<void> {
   // history immediately on boot, not on the next click.
   const active = useStore.getState().activeId;
   if (active) void useStore.getState().loadMessages(active);
+
+  // Load endpoints + models from the main process. Keeps the IPC round-trip
+  // off the critical path for reading persisted state, but still runs before
+  // the first createSession / send.
+  await useStore.getState().reloadEndpoints();
+  // Auto-refresh stale endpoints opportunistically. Don't block hydration on
+  // network — fire-and-forget.
+  void useStore.getState().refreshAllEndpointModels();
+
   // After (potential) hydration, subscribe to write-through.
   useStore.subscribe((s) => {
     const snapshot: PersistedState = {
@@ -563,7 +704,8 @@ export async function hydrateStore(): Promise<void> {
       fontSize: s.fontSize,
       recentProjects: s.recentProjects,
       tutorialSeen: s.tutorialSeen,
-      watchdog: s.watchdog
+      watchdog: s.watchdog,
+      defaultEndpointId: s.defaultEndpointId
     };
     schedulePersist(snapshot);
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,12 @@ export interface Session {
   model: string;
   groupId: string;
   agentType: AgentType;
+  /**
+   * Endpoint this session spawns against. Missing = fall back to the store's
+   * defaultEndpointId at spawn time. Intentionally optional so existing
+   * persisted sessions (pre-endpoint-discovery) continue to work.
+   */
+  endpointId?: string;
   // Set when the session was imported from a Claude Code CLI transcript.
   // Passed to agentStart on first send so the SDK resumes the same thread.
   resumeSessionId?: string;

--- a/tests/endpoints-manager.test.ts
+++ b/tests/endpoints-manager.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import {
+  EndpointsManager,
+  type KeyCrypto,
+  __test__,
+} from '../electron/endpoints-manager';
+import { __setDbForTests } from '../electron/db';
+
+// XOR "encryption" stand-in so tests don't need Electron's safeStorage. Round-
+// trip fidelity is all that matters here; we're exercising DB + manager logic.
+function makeCrypto(available = true): KeyCrypto {
+  const MASK = 0x5a;
+  return {
+    isAvailable: () => available,
+    encrypt: (plain) => {
+      const buf = Buffer.from(plain, 'utf8');
+      return Buffer.from(buf.map((b) => b ^ MASK));
+    },
+    decrypt: (cipher) =>
+      Buffer.from(Array.from(cipher).map((b) => b ^ MASK)).toString('utf8'),
+  };
+}
+
+function freshDb(): Database.Database {
+  const db = new Database(':memory:');
+  __setDbForTests(db);
+  return db;
+}
+
+describe('EndpointsManager: CRUD + encryption roundtrip', () => {
+  beforeEach(() => {
+    freshDb();
+  });
+
+  it('adds an endpoint and stores the key encrypted', () => {
+    const crypto = makeCrypto();
+    const mgr = new EndpointsManager({ crypto });
+    const row = mgr.addEndpoint({
+      name: 'Anthropic',
+      baseUrl: 'https://api.anthropic.com',
+      apiKey: 'sk-ant-abc',
+      isDefault: true,
+    });
+    expect(row.id).toBeTruthy();
+    expect(row.isDefault).toBe(true);
+    expect(row.lastStatus).toBe('unchecked');
+
+    // Round-trip the key via the manager (no plaintext columns read from DB).
+    const plain = mgr.getPlainKey(row.id);
+    expect(plain).toBe('sk-ant-abc');
+  });
+
+  it('lists endpoints with defaults first', () => {
+    const mgr = new EndpointsManager({ crypto: makeCrypto() });
+    mgr.addEndpoint({ name: 'A', baseUrl: 'https://a' });
+    mgr.addEndpoint({ name: 'B', baseUrl: 'https://b', isDefault: true });
+    const list = mgr.listEndpoints();
+    expect(list[0].name).toBe('B');
+    expect(list[0].isDefault).toBe(true);
+    expect(list[1].isDefault).toBe(false);
+  });
+
+  it('setting a new default unsets the previous one', () => {
+    const mgr = new EndpointsManager({ crypto: makeCrypto() });
+    const a = mgr.addEndpoint({ name: 'A', baseUrl: 'https://a', isDefault: true });
+    const b = mgr.addEndpoint({ name: 'B', baseUrl: 'https://b', isDefault: true });
+    const after = mgr.listEndpoints();
+    expect(after.find((x) => x.id === a.id)?.isDefault).toBe(false);
+    expect(after.find((x) => x.id === b.id)?.isDefault).toBe(true);
+  });
+
+  it('updateEndpoint with apiKey=null clears the key', () => {
+    const mgr = new EndpointsManager({ crypto: makeCrypto() });
+    const row = mgr.addEndpoint({ name: 'A', baseUrl: 'https://a', apiKey: 'sk-1' });
+    expect(mgr.getPlainKey(row.id)).toBe('sk-1');
+    mgr.updateEndpoint(row.id, { apiKey: null });
+    expect(mgr.getPlainKey(row.id)).toBeNull();
+  });
+
+  it('removeEndpoint cascades to endpoint_models and promotes a new default', () => {
+    const mgr = new EndpointsManager({ crypto: makeCrypto() });
+    const a = mgr.addEndpoint({ name: 'A', baseUrl: 'https://a', isDefault: true });
+    const b = mgr.addEndpoint({ name: 'B', baseUrl: 'https://b' });
+    // Mock a refresh for A so models exist to cascade-delete.
+    const fetchMock = vi.fn().mockResolvedValue(fakeResponse(200, anthropicPage(['m-1'])));
+    const mgr2 = new EndpointsManager({ crypto: makeCrypto(), fetchImpl: fetchMock });
+    // reuse the existing DB — mgr and mgr2 share the in-memory DB
+    return (async () => {
+      await mgr2.refreshModels(a.id);
+      expect(mgr.listModels(a.id).length).toBe(1);
+      mgr.removeEndpoint(a.id);
+      expect(mgr.getEndpoint(a.id)).toBeNull();
+      expect(mgr.listModels(a.id).length).toBe(0);
+      // b should now be default
+      expect(mgr.getEndpoint(b.id)?.isDefault).toBe(true);
+    })();
+  });
+
+  it('does not persist a key when encryption is unavailable', () => {
+    const mgr = new EndpointsManager({ crypto: makeCrypto(false) });
+    const row = mgr.addEndpoint({ name: 'A', baseUrl: 'https://a', apiKey: 'sk-1' });
+    expect(mgr.getPlainKey(row.id)).toBeNull();
+  });
+});
+
+function anthropicPage(ids: string[], has_more = false, last_id?: string) {
+  return {
+    data: ids.map((id) => ({ id, display_name: id.toUpperCase(), type: 'model' })),
+    has_more,
+    last_id: last_id ?? ids[ids.length - 1] ?? null,
+  };
+}
+
+function fakeResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as Response;
+}
+
+describe('EndpointsManager: refreshModels with pagination', () => {
+  beforeEach(() => freshDb());
+
+  it('paginates through has_more and writes every model', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(fakeResponse(200, anthropicPage(['m-1', 'm-2'], true, 'm-2')))
+      .mockResolvedValueOnce(fakeResponse(200, anthropicPage(['m-3'], false, 'm-3')));
+    const mgr = new EndpointsManager({ crypto: makeCrypto(), fetchImpl: fetchMock });
+    const row = mgr.addEndpoint({ name: 'A', baseUrl: 'https://a', apiKey: 'sk' });
+    const res = await mgr.refreshModels(row.id);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.count).toBe(3);
+    const models = mgr.listModels(row.id).map((m) => m.modelId).sort();
+    expect(models).toEqual(['m-1', 'm-2', 'm-3']);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // Second call must include after_id from the first page's last_id.
+    const secondUrl = fetchMock.mock.calls[1][0] as string;
+    expect(secondUrl).toContain('after_id=m-2');
+  });
+
+  it('marks endpoint error on 401 and keeps cached models', async () => {
+    const goodFetch = vi.fn().mockResolvedValueOnce(
+      fakeResponse(200, anthropicPage(['m-1']))
+    );
+    const mgrGood = new EndpointsManager({ crypto: makeCrypto(), fetchImpl: goodFetch });
+    const row = mgrGood.addEndpoint({ name: 'A', baseUrl: 'https://a', apiKey: 'sk' });
+    await mgrGood.refreshModels(row.id);
+    expect(mgrGood.listModels(row.id).length).toBe(1);
+
+    const badFetch = vi
+      .fn()
+      .mockResolvedValueOnce(fakeResponse(401, { error: 'bad key' }));
+    const mgrBad = new EndpointsManager({ crypto: makeCrypto(), fetchImpl: badFetch });
+    const res = await mgrBad.refreshModels(row.id);
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.status).toBe(401);
+      expect(res.error).toContain('Authentication failed');
+    }
+    // Cached models preserved.
+    expect(mgrGood.listModels(row.id).length).toBe(1);
+    const after = mgrGood.getEndpoint(row.id);
+    expect(after?.lastStatus).toBe('error');
+  });
+
+  it('handles network errors without throwing', async () => {
+    const fetchMock = vi.fn().mockRejectedValueOnce(new Error('ECONNREFUSED'));
+    const mgr = new EndpointsManager({ crypto: makeCrypto(), fetchImpl: fetchMock });
+    const row = mgr.addEndpoint({ name: 'A', baseUrl: 'https://a', apiKey: 'sk' });
+    const res = await mgr.refreshModels(row.id);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('ECONNREFUSED');
+    expect(mgr.getEndpoint(row.id)?.lastStatus).toBe('error');
+  });
+});
+
+describe('EndpointsManager: testConnection', () => {
+  beforeEach(() => freshDb());
+
+  it('returns ok on 200', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(fakeResponse(200, anthropicPage([])));
+    const mgr = new EndpointsManager({ crypto: makeCrypto(), fetchImpl: fetchMock });
+    const res = await mgr.testConnection({ baseUrl: 'https://a', apiKey: 'sk' });
+    expect(res.ok).toBe(true);
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toBe('https://a/v1/models?limit=1');
+    const init = fetchMock.mock.calls[0][1] as { headers: Record<string, string> };
+    expect(init.headers['x-api-key']).toBe('sk');
+    expect(init.headers['anthropic-version']).toBeTruthy();
+  });
+
+  it('surfaces HTTP 401 as structured error without writing DB', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(fakeResponse(401, { error: 'nope' }));
+    const mgr = new EndpointsManager({ crypto: makeCrypto(), fetchImpl: fetchMock });
+    const res = await mgr.testConnection({ baseUrl: 'https://a', apiKey: 'wrong' });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.status).toBe(401);
+      expect(res.error).toContain('Authentication failed');
+    }
+  });
+});
+
+describe('buildModelsUrl', () => {
+  it('strips trailing /v1 from baseUrl', () => {
+    expect(__test__.buildModelsUrl('https://a/v1', { limit: 1 })).toBe('https://a/v1/models?limit=1');
+  });
+  it('strips trailing slash', () => {
+    expect(__test__.buildModelsUrl('https://a/', { limit: 1 })).toBe('https://a/v1/models?limit=1');
+  });
+});


### PR DESCRIPTION
## Summary

Replace the hardcoded `claude-opus-4 / sonnet-4 / haiku-4` model trio with a real per-endpoint model registry. Each endpoint stores its base URL + (encrypted) key, exposes `GET /v1/models` discovery, and the renderer lets the user pick from a grouped dropdown across all endpoints. This is the **core differentiator** from Claude Desktop: Agentory now works against arbitrary Anthropic-compatible servers (Anthropic, LiteLLM, Kimi, DeepSeek shims, self-hosted gateways) with whatever models that server actually exposes.

## Schema

Two new SQLite tables alongside `app_state`:

- `endpoints(id, name, base_url, kind, api_key_encrypted, is_default, last_status, last_error, last_refreshed_at, created_at, updated_at)`
- `endpoint_models(id, endpoint_id, model_id, display_name, discovered_at)` with an FK + unique `(endpoint_id, model_id)` and an index on `endpoint_id`.

Keys are encrypted via Electron's `safeStorage` and stored as BLOB. Plaintext is read only inside the main process to inject `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` env vars into the per-session `claude.exe` spawn — never crosses IPC.

## Architecture

- `electron/endpoints-manager.ts` (new) — pure-ish manager taking an injected `KeyCrypto` adapter and `fetch`; testable without Electron.
- `electron/main.ts` — IPC handlers (`endpoints:*`, `models:*`), first-run env-seeded migration, per-session endpoint env override on `agent:start`.
- `electron/agent/sessions.ts` — accepts `envOverrides` from manager; layered before the spawner's apiKey override.
- `src/stores/store.ts` — new endpoints slice + `reloadEndpoints` / `refreshEndpointModels` / `refreshAllEndpointModels`. `ModelId` widened to `string`. Sessions carry an optional `endpointId`.
- `src/components/SettingsDialog.tsx` — new "Endpoints" tab + Add/Edit dialog (Test Connection, encrypted key, default toggle).
- `src/components/StatusBar.tsx` — model chip becomes a grouped dropdown (one section per endpoint).

## First-run migration

If the parent env has `ANTHROPIC_BASE_URL` set and no endpoints row exists, seed a "Default" endpoint pointing at it (key from `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` if present) and refresh models. Otherwise leave empty — user adds via Settings.

## Phase 2 (explicit non-goals)

- OpenAI-compatible / Ollama / Bedrock / Vertex protocols (radio buttons rendered disabled with tooltip)
- Auto-detect endpoint kind
- Key rotation while sessions running
- Migration of existing hardcoded model values → first refresh handles match-by-id

## Test plan

- [x] Typecheck (0 errors)
- [x] Lint (0 errors, 1 preexisting CommandPalette warning)
- [x] Tests: 286/286 (13 new in `tests/endpoints-manager.test.ts` covering CRUD + encryption roundtrip, pagination, 401 handling preserves cached models, network error, testConnection, URL normalisation)
- [x] Pre-push gate green
- [ ] Live verify in dev build with parent env `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN`: Default endpoint auto-seeded, model list non-empty in StatusBar dropdown — pending manual run

🤖 Generated with [Claude Code](https://claude.com/claude-code)