### PR TITLE
fix(chat): auto-expand permission prompt + keyboard operation

### DIFF
--- a/scripts/probe-e2e-permission-prompt.mjs
+++ b/scripts/probe-e2e-permission-prompt.mjs
@@ -1,0 +1,152 @@
+// Live e2e (renderer-only): inject a `waiting` permission block into the
+// running renderer store and verify the new PermissionPromptBlock component
+// renders EXPANDED with the expected keyboard behaviour. Bypasses the actual
+// agent/claude.exe path since the sandbox intercepts destructive bash before
+// the permission callback fires — that flow is covered by unit tests. This
+// probe locks down the RENDER contract end-to-end in a real Electron window.
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { appWindow } from './probe-utils.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function fail(msg, app) {
+  console.error(`\n[probe-e2e-permission-prompt] FAIL: ${msg}`);
+  if (app) app.close().catch(() => {});
+  process.exit(1);
+}
+
+const app = await electron.launch({
+  args: ['.'],
+  cwd: root,
+  env: { ...process.env, NODE_ENV: 'development', AGENTORY_DEV_PORT: process.env.AGENTORY_DEV_PORT ?? '4102' }
+});
+app.process().stderr?.on('data', (d) => process.stderr.write(`[electron-stderr] ${d}`));
+
+await app.evaluate(async ({ dialog }, fakeCwd) => {
+  dialog.showOpenDialog = async () => ({ canceled: false, filePaths: [fakeCwd] });
+}, root);
+
+const win = await appWindow(app, { timeout: 30_000 });
+const errors = [];
+win.on('pageerror', (e) => errors.push(`[pageerror] ${e.message}`));
+win.on('console', (m) => {
+  if (m.type() === 'error') errors.push(`[console.error] ${m.text()}`);
+});
+
+await win.waitForLoadState('domcontentloaded');
+await win.waitForTimeout(2500);
+
+// Ensure at least one session exists — click New Session if the empty state
+// is showing.
+const newBtn = win.getByRole('button', { name: /new session/i }).first();
+if (await newBtn.isVisible().catch(() => false)) {
+  await newBtn.click();
+  await win.waitForTimeout(1500);
+}
+
+// Inject a fake permission block into the renderer store directly. Uses the
+// public zustand hook on window for test access.
+const injectResult = await win.evaluate(() => {
+  const store = window.__agentoryStore;
+  if (!store) return { ok: false, reason: 'no __agentoryStore on window' };
+  const state = store.getState();
+  const activeId = state.activeId;
+  if (!activeId) return { ok: false, reason: 'no active session' };
+  state.appendBlocks(activeId, [
+    {
+      kind: 'waiting',
+      id: 'wait-PROBE-RID',
+      prompt: 'Bash: rm -rf /tmp/probe',
+      intent: 'permission',
+      requestId: 'PROBE-RID',
+      toolName: 'Bash',
+      toolInput: { command: 'rm -rf /tmp/probe', description: 'Remove probe tmp dir' }
+    }
+  ]);
+  return { ok: true, activeId };
+});
+
+if (!injectResult.ok) {
+  const preloaded = await win.evaluate(() => typeof window.agentory !== 'undefined');
+  fail(`cannot inject: ${injectResult.reason}, preload=${preloaded}`, app);
+}
+
+await win.waitForTimeout(500);
+
+const heading = win.locator('text=Permission required').first();
+try {
+  await heading.waitFor({ state: 'visible', timeout: 5_000 });
+} catch {
+  const dump = await win.evaluate(() => document.body.innerText.slice(0, 2500));
+  console.error('--- body ---\n' + dump);
+  console.error('--- errors ---\n' + errors.slice(-10).join('\n'));
+  fail('no Permission required heading rendered', app);
+}
+
+const snapshot = await win.evaluate(() => {
+  const btns = Array.from(document.querySelectorAll('[data-perm-action]')).map((b) => ({
+    action: b.getAttribute('data-perm-action'),
+    label: b.textContent?.trim(),
+    focused: b === document.activeElement
+  }));
+  const heading = Array.from(document.querySelectorAll('*')).find(
+    (n) => n.textContent?.trim() === 'Permission required'
+  );
+  const container = heading?.closest('[role="alertdialog"]');
+  return {
+    buttons: btns,
+    containerHTML: container ? container.outerHTML.slice(0, 2500) : '<no container>'
+  };
+});
+
+console.log('\n=== Permission prompt DOM (first 2.5KB) ===');
+console.log(snapshot.containerHTML);
+console.log('\n[probe-e2e-permission-prompt] buttons:', JSON.stringify(snapshot.buttons));
+
+if (snapshot.buttons.length !== 2) fail(`expected 2 perm buttons, got ${snapshot.buttons.length}`, app);
+const reject = snapshot.buttons.find((b) => b.action === 'reject');
+const allow = snapshot.buttons.find((b) => b.action === 'allow');
+if (!reject || !/Reject \(N\)/i.test(reject.label ?? '')) fail(`bad reject label: ${reject?.label}`, app);
+if (!allow || !/Allow \(Y\)/i.test(allow.label ?? '')) fail(`bad allow label: ${allow?.label}`, app);
+if (!reject.focused) fail(`expected Reject focused; got ${JSON.stringify(snapshot.buttons)}`, app);
+
+// Press N -> Reject. Block should disappear from DOM after resolvePermission removes it.
+await win.keyboard.press('n');
+
+try {
+  await heading.waitFor({ state: 'detached', timeout: 3_000 });
+} catch {
+  fail('prompt still visible after pressing N', app);
+}
+
+// Now inject a second one and press Y.
+await win.evaluate(() => {
+  const store = window.__agentoryStore;
+  const s = store.getState();
+  s.appendBlocks(s.activeId, [
+    {
+      kind: 'waiting',
+      id: 'wait-PROBE-RID-2',
+      prompt: 'Bash: echo allowed',
+      intent: 'permission',
+      requestId: 'PROBE-RID-2',
+      toolName: 'Bash',
+      toolInput: { command: 'echo allowed' }
+    }
+  ]);
+});
+await win.waitForTimeout(400);
+await heading.waitFor({ state: 'visible', timeout: 3_000 });
+await win.keyboard.press('y');
+try {
+  await heading.waitFor({ state: 'detached', timeout: 3_000 });
+} catch {
+  fail('prompt still visible after pressing Y', app);
+}
+
+console.log('\n[probe-e2e-permission-prompt] OK: expanded=yes rejectFocused=yes keyboard Y/N works');
+
+await app.close();

--- a/src/agent/lifecycle.ts
+++ b/src/agent/lifecycle.ts
@@ -131,7 +131,9 @@ export function permissionRequestToWaitingBlock(req: {
     prompt,
     intent: isPlan ? 'plan' : 'permission',
     requestId: req.requestId,
-    plan: planText
+    plan: planText,
+    toolName: req.toolName,
+    toolInput: req.input
   };
 }
 

--- a/src/components/ChatStream.tsx
+++ b/src/components/ChatStream.tsx
@@ -12,6 +12,7 @@ import { FileTree } from './FileTree';
 import { Terminal } from './Terminal';
 import { CodeBlock, HighlightedLine, languageFromPath } from './CodeBlock';
 import { QuestionBlock } from './QuestionBlock';
+import { PermissionPromptBlock } from './PermissionPromptBlock';
 
 const FILE_TREE_TOOLS = new Set(['Glob', 'LS']);
 
@@ -436,61 +437,6 @@ function DiffView({ diff }: { diff: DiffSpec }) {
   );
 }
 
-const denyStack: Array<() => void> = [];
-
-if (typeof window !== 'undefined') {
-  window.addEventListener('keydown', (e) => {
-    if (e.key !== 'Escape' || denyStack.length === 0) return;
-    e.preventDefault();
-    denyStack[denyStack.length - 1]();
-  });
-}
-
-function WaitingBlock({ prompt, onAllow, onDeny }: { prompt: string; onAllow?: () => void; onDeny?: () => void }) {
-  const denyRef = useRef<HTMLButtonElement>(null);
-  useEffect(() => {
-    const t = window.setTimeout(() => denyRef.current?.focus(), 150);
-    const handler = () => onDeny?.();
-    denyStack.push(handler);
-    return () => {
-      window.clearTimeout(t);
-      const i = denyStack.lastIndexOf(handler);
-      if (i !== -1) denyStack.splice(i, 1);
-    };
-  }, [onDeny]);
-
-  return (
-    <motion.div
-      role="alertdialog"
-      aria-modal="false"
-      aria-labelledby="perm-title"
-      aria-describedby="perm-desc"
-      initial={{ opacity: 0, y: 8 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.22, ease: [0.32, 0.72, 0, 1] }}
-      className="relative my-2 rounded-md border border-state-waiting/40 bg-state-waiting/[0.06] surface-highlight surface-elevated pl-4 pr-4 py-3"
-    >
-      <span
-        aria-hidden
-        className="absolute left-0 top-0 bottom-0 w-[2px] bg-state-waiting rounded-l-md"
-      />
-      <div id="perm-title" className="flex items-center gap-2 text-base text-fg-primary font-semibold">
-        <StateGlyph state="waiting" size="sm" />
-        <span>Permission requested</span>
-      </div>
-      <div id="perm-desc" className="mt-1.5 font-mono text-sm text-fg-secondary">{prompt}</div>
-      <div className="mt-3 flex justify-end gap-2">
-        <Button ref={denyRef} variant="secondary" size="md" onClick={onDeny}>
-          Deny
-        </Button>
-        <Button variant="primary" size="md" onClick={onAllow}>
-          Allow
-        </Button>
-      </div>
-    </motion.div>
-  );
-}
-
 function PlanBlock({ plan, onAllow, onDeny }: { plan: string; onAllow?: () => void; onDeny?: () => void }) {
   const approveRef = useRef<HTMLButtonElement>(null);
   useEffect(() => {
@@ -639,7 +585,12 @@ function ErrorBlock({ text }: { text: string }) {
 }
 
 
-function renderBlock(b: MessageBlock, activeId: string, resolvePermission: (sid: string, rid: string, d: 'allow' | 'deny') => void) {
+function renderBlock(
+  b: MessageBlock,
+  activeId: string,
+  resolvePermission: (sid: string, rid: string, d: 'allow' | 'deny') => void,
+  opts: { permissionAutoFocus?: boolean } = {}
+) {
   switch (b.kind) {
     case 'user':
       return <UserBlock text={b.text} />;
@@ -660,10 +611,13 @@ function renderBlock(b: MessageBlock, activeId: string, resolvePermission: (sid:
         );
       }
       return (
-        <WaitingBlock
+        <PermissionPromptBlock
           prompt={b.prompt}
+          toolName={b.toolName}
+          toolInput={b.toolInput}
+          autoFocus={opts.permissionAutoFocus ?? true}
           onAllow={b.requestId ? () => resolvePermission(activeId, b.requestId!, 'allow') : undefined}
-          onDeny={b.requestId ? () => resolvePermission(activeId, b.requestId!, 'deny') : undefined}
+          onReject={b.requestId ? () => resolvePermission(activeId, b.requestId!, 'deny') : undefined}
         />
       );
     case 'question':
@@ -769,9 +723,26 @@ export function ChatStream() {
           <EmptyState />
         ) : (
           <div className="px-4 py-3 flex flex-col gap-1.5 max-w-[1100px]">
-            {blocks.map((m) => (
-              <div key={m.id}>{renderBlock(m, activeId, resolvePermission)}</div>
-            ))}
+            {(() => {
+              // Only the LAST pending permission block gets auto-focus. Older
+              // ones (unlikely but possible) stay put so we don't rip focus
+              // off the user mid-interaction.
+              let lastPermIdx = -1;
+              for (let i = blocks.length - 1; i >= 0; i--) {
+                const b = blocks[i];
+                if (b.kind === 'waiting' && b.intent === 'permission') {
+                  lastPermIdx = i;
+                  break;
+                }
+              }
+              return blocks.map((m, i) => (
+                <div key={m.id}>
+                  {renderBlock(m, activeId, resolvePermission, {
+                    permissionAutoFocus: i === lastPermIdx
+                  })}
+                </div>
+              ));
+            })()}
           </div>
         )}
       </div>

--- a/src/components/PermissionPromptBlock.tsx
+++ b/src/components/PermissionPromptBlock.tsx
@@ -1,0 +1,188 @@
+import React, { useEffect, useRef } from 'react';
+import { motion } from 'framer-motion';
+import { ShieldAlert } from 'lucide-react';
+import { Button } from './ui/Button';
+
+export interface PermissionPromptBlockProps {
+  /** Short human description, e.g. "Bash: ls -la". Used as the fallback summary. */
+  prompt: string;
+  /** Raw tool name the agent is requesting permission for (e.g. "Bash"). */
+  toolName?: string;
+  /** Raw tool input arguments for detailed display. */
+  toolInput?: Record<string, unknown>;
+  onAllow?: () => void;
+  onReject?: () => void;
+  /** When false, suppress the auto-focus-on-mount behaviour. */
+  autoFocus?: boolean;
+}
+
+const PREVIEW_KEYS = ['command', 'file_path', 'path', 'pattern', 'url', 'plan'];
+
+function formatToolInputSummary(
+  input: Record<string, unknown> | undefined
+): Array<{ key: string; value: string }> {
+  if (!input) return [];
+  const out: Array<{ key: string; value: string }> = [];
+  // Show a curated subset first for predictable ordering, then any remaining
+  // string/number keys. Skip giant blobs so the prompt stays one screen.
+  const seen = new Set<string>();
+  for (const key of PREVIEW_KEYS) {
+    if (key in input) {
+      const v = input[key];
+      if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') {
+        out.push({ key, value: String(v) });
+        seen.add(key);
+      }
+    }
+  }
+  for (const [key, v] of Object.entries(input)) {
+    if (seen.has(key)) continue;
+    if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') {
+      out.push({ key, value: String(v) });
+    }
+  }
+  return out;
+}
+
+export function PermissionPromptBlock({
+  prompt,
+  toolName,
+  toolInput,
+  onAllow,
+  onReject,
+  autoFocus = true
+}: PermissionPromptBlockProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const allowRef = useRef<HTMLButtonElement>(null);
+  const rejectRef = useRef<HTMLButtonElement>(null);
+
+  // Focus Reject on mount — safer default. Never steal focus away from an
+  // input the user is already typing in.
+  useEffect(() => {
+    if (!autoFocus) return;
+    const id = requestAnimationFrame(() => {
+      const active = document.activeElement;
+      const isInteractiveElsewhere =
+        active instanceof HTMLElement &&
+        active !== document.body &&
+        !rootRef.current?.contains(active) &&
+        (active.tagName === 'INPUT' ||
+          active.tagName === 'TEXTAREA' ||
+          active.isContentEditable ||
+          active.getAttribute('role') === 'combobox' ||
+          active.getAttribute('role') === 'textbox');
+      if (isInteractiveElsewhere) return;
+      rejectRef.current?.focus({ preventScroll: true });
+    });
+    return () => cancelAnimationFrame(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Global-ish Y/N hotkeys, scoped to this prompt: we only listen while
+  // mounted and only fire if the user isn't currently typing into an input /
+  // textarea / contenteditable.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.defaultPrevented) return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      const active = document.activeElement;
+      const typing =
+        active instanceof HTMLElement &&
+        (active.tagName === 'INPUT' ||
+          active.tagName === 'TEXTAREA' ||
+          active.isContentEditable);
+      // If typing AND focus is outside our prompt, don't hijack.
+      if (typing && !rootRef.current?.contains(active)) return;
+      const key = e.key.toLowerCase();
+      if (key === 'y') {
+        e.preventDefault();
+        onAllow?.();
+      } else if (key === 'n') {
+        e.preventDefault();
+        onReject?.();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onAllow, onReject]);
+
+  const summary = formatToolInputSummary(toolInput);
+
+  return (
+    <motion.div
+      ref={rootRef}
+      role="alertdialog"
+      aria-modal="false"
+      aria-labelledby="perm-title"
+      aria-describedby="perm-desc"
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.22, ease: [0.32, 0.72, 0, 1] }}
+      className="relative my-2 rounded-md border border-accent/50 bg-accent/[0.06] surface-highlight surface-elevated pl-4 pr-4 py-3"
+    >
+      <span
+        aria-hidden
+        className="absolute left-0 top-0 bottom-0 w-[2px] bg-accent rounded-l-md"
+      />
+      <div
+        id="perm-title"
+        className="flex items-center gap-2 text-base text-fg-primary font-semibold"
+      >
+        <ShieldAlert size={14} className="text-accent" aria-hidden />
+        <span>Permission required</span>
+        {toolName && (
+          <span className="font-mono text-xs text-fg-tertiary uppercase tracking-wider">
+            {toolName}
+          </span>
+        )}
+      </div>
+      <div id="perm-desc" className="mt-2 font-mono text-sm text-fg-secondary whitespace-pre-wrap break-words">
+        {prompt}
+      </div>
+      {summary.length > 0 && (
+        <dl className="mt-2 rounded-sm border border-border-subtle bg-bg-app/40 px-3 py-2 font-mono text-xs text-fg-secondary">
+          {summary.map(({ key, value }) => (
+            <div key={key} className="flex gap-2 py-0.5">
+              <dt className="text-fg-tertiary shrink-0">{key}</dt>
+              <dd className="min-w-0 break-words whitespace-pre-wrap text-fg-primary">
+                {value.length > 400 ? value.slice(0, 400) + '…' : value}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      )}
+      <div className="mt-3 flex items-center justify-end gap-2">
+        <Button
+          ref={rejectRef}
+          variant="secondary"
+          size="md"
+          data-perm-action="reject"
+          onClick={onReject}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              onReject?.();
+            }
+          }}
+        >
+          Reject (N)
+        </Button>
+        <Button
+          ref={allowRef}
+          variant="primary"
+          size="md"
+          data-perm-action="allow"
+          onClick={onAllow}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              onAllow?.();
+            }
+          }}
+        >
+          Allow (Y)
+        </Button>
+      </div>
+    </motion.div>
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,7 +47,16 @@ export type MessageBlock =
   | { kind: 'assistant'; id: string; text: string; streaming?: boolean }
   | { kind: 'tool'; id: string; name: string; brief: string; expanded: boolean; toolUseId?: string; result?: string; isError?: boolean; input?: unknown }
   | { kind: 'todo'; id: string; toolUseId?: string; todos: TodoItem[] }
-  | { kind: 'waiting'; id: string; prompt: string; intent: 'permission' | 'plan' | 'question'; requestId?: string; plan?: string }
+  | {
+      kind: 'waiting';
+      id: string;
+      prompt: string;
+      intent: 'permission' | 'plan' | 'question';
+      requestId?: string;
+      plan?: string;
+      toolName?: string;
+      toolInput?: Record<string, unknown>;
+    }
   | { kind: 'question'; id: string; requestId?: string; toolUseId?: string; questions: QuestionSpec[] }
   | { kind: 'status'; id: string; tone: 'info' | 'warn'; title: string; detail?: string }
   | { kind: 'error'; id: string; text: string };

--- a/tests/permission-prompt-block.test.tsx
+++ b/tests/permission-prompt-block.test.tsx
@@ -1,0 +1,219 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { PermissionPromptBlock } from '../src/components/PermissionPromptBlock';
+
+function flush() {
+  return act(async () => {
+    await new Promise((r) => setTimeout(r, 20));
+  });
+}
+
+describe('<PermissionPromptBlock />', () => {
+  it('renders EXPANDED on mount with tool name and input summary', async () => {
+    render(
+      <PermissionPromptBlock
+        prompt="Bash: ls -la"
+        toolName="Bash"
+        toolInput={{ command: 'ls -la', description: 'list files' }}
+        onAllow={() => {}}
+        onReject={() => {}}
+      />
+    );
+    await flush();
+    expect(screen.getByText(/Permission required/i)).toBeInTheDocument();
+    expect(screen.getByText('Bash')).toBeInTheDocument();
+    // The summary dl shows the command directly — no expand step.
+    expect(screen.getByText('command')).toBeInTheDocument();
+    expect(screen.getByText('ls -la')).toBeInTheDocument();
+    // Both buttons rendered from the start (no collapsed/click-to-expand).
+    expect(screen.getByRole('button', { name: /allow \(y\)/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reject \(n\)/i })).toBeInTheDocument();
+  });
+
+  it('auto-focuses the Reject button on mount', async () => {
+    render(
+      <PermissionPromptBlock
+        prompt="Bash: rm -rf"
+        toolName="Bash"
+        toolInput={{ command: 'rm -rf /' }}
+        onAllow={() => {}}
+        onReject={() => {}}
+      />
+    );
+    await flush();
+    const reject = screen.getByRole('button', { name: /reject \(n\)/i });
+    expect(document.activeElement).toBe(reject);
+  });
+
+  it('pressing Y triggers Allow (case-insensitive)', async () => {
+    const onAllow = vi.fn();
+    const onReject = vi.fn();
+    render(
+      <PermissionPromptBlock
+        prompt="Bash: ls"
+        toolName="Bash"
+        onAllow={onAllow}
+        onReject={onReject}
+      />
+    );
+    await flush();
+    fireEvent.keyDown(window, { key: 'y' });
+    expect(onAllow).toHaveBeenCalledTimes(1);
+    expect(onReject).not.toHaveBeenCalled();
+    fireEvent.keyDown(window, { key: 'Y' });
+    expect(onAllow).toHaveBeenCalledTimes(2);
+  });
+
+  it('pressing N triggers Reject (case-insensitive)', async () => {
+    const onAllow = vi.fn();
+    const onReject = vi.fn();
+    render(
+      <PermissionPromptBlock
+        prompt="Bash: ls"
+        toolName="Bash"
+        onAllow={onAllow}
+        onReject={onReject}
+      />
+    );
+    await flush();
+    fireEvent.keyDown(window, { key: 'N' });
+    expect(onReject).toHaveBeenCalledTimes(1);
+    expect(onAllow).not.toHaveBeenCalled();
+  });
+
+  it('Enter on focused Allow button fires Allow', async () => {
+    const onAllow = vi.fn();
+    const onReject = vi.fn();
+    render(
+      <PermissionPromptBlock
+        prompt="Bash: ls"
+        toolName="Bash"
+        onAllow={onAllow}
+        onReject={onReject}
+      />
+    );
+    await flush();
+    const allow = screen.getByRole('button', { name: /allow \(y\)/i });
+    allow.focus();
+    fireEvent.keyDown(allow, { key: 'Enter' });
+    // Button also triggers native click on Enter, but our onKeyDown fires
+    // first and calls onAllow. Guard against double-firing with a range.
+    expect(onAllow).toHaveBeenCalled();
+    expect(onReject).not.toHaveBeenCalled();
+  });
+
+  it('Tab moves focus to Allow (and cycles back)', async () => {
+    render(
+      <PermissionPromptBlock
+        prompt="Bash: ls"
+        toolName="Bash"
+        onAllow={() => {}}
+        onReject={() => {}}
+      />
+    );
+    await flush();
+    const reject = screen.getByRole('button', { name: /reject \(n\)/i });
+    const allow = screen.getByRole('button', { name: /allow \(y\)/i });
+    expect(document.activeElement).toBe(reject);
+    // jsdom doesn't implement Tab natively — just verify both are in the tab
+    // order (tabindex 0 or no explicit tabindex) so focus CAN reach them.
+    expect(reject.tabIndex).not.toBe(-1);
+    expect(allow.tabIndex).not.toBe(-1);
+  });
+
+  it('Escape is a no-op (forces active choice)', async () => {
+    const onAllow = vi.fn();
+    const onReject = vi.fn();
+    render(
+      <PermissionPromptBlock
+        prompt="Bash: ls"
+        toolName="Bash"
+        onAllow={onAllow}
+        onReject={onReject}
+      />
+    );
+    await flush();
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onAllow).not.toHaveBeenCalled();
+    expect(onReject).not.toHaveBeenCalled();
+  });
+
+  it('does not steal focus when user is typing in a textarea', async () => {
+    const external = document.createElement('textarea');
+    document.body.appendChild(external);
+    external.focus();
+    expect(document.activeElement).toBe(external);
+
+    render(
+      <PermissionPromptBlock
+        prompt="Bash: ls"
+        toolName="Bash"
+        onAllow={() => {}}
+        onReject={() => {}}
+      />
+    );
+    await flush();
+    // External textarea still has focus — permission block didn't steal.
+    expect(document.activeElement).toBe(external);
+    document.body.removeChild(external);
+  });
+
+  it('does not hijack Y/N hotkeys while user is typing in an external textarea', async () => {
+    const external = document.createElement('textarea');
+    document.body.appendChild(external);
+    external.focus();
+    const onAllow = vi.fn();
+    const onReject = vi.fn();
+    render(
+      <PermissionPromptBlock
+        prompt="Bash: ls"
+        toolName="Bash"
+        onAllow={onAllow}
+        onReject={onReject}
+      />
+    );
+    await flush();
+    fireEvent.keyDown(external, { key: 'y' });
+    fireEvent.keyDown(external, { key: 'n' });
+    expect(onAllow).not.toHaveBeenCalled();
+    expect(onReject).not.toHaveBeenCalled();
+    document.body.removeChild(external);
+  });
+
+  it('respects autoFocus={false} for older (non-latest) prompts', async () => {
+    const external = document.createElement('input');
+    document.body.appendChild(external);
+    external.focus();
+    render(
+      <PermissionPromptBlock
+        prompt="Bash: ls"
+        toolName="Bash"
+        autoFocus={false}
+        onAllow={() => {}}
+        onReject={() => {}}
+      />
+    );
+    await flush();
+    expect(document.activeElement).toBe(external);
+    document.body.removeChild(external);
+  });
+
+  it('renders long input values truncated', async () => {
+    const long = 'x'.repeat(600);
+    render(
+      <PermissionPromptBlock
+        prompt="Write: file"
+        toolName="Write"
+        toolInput={{ file_path: '/tmp/a.txt', content: long }}
+        onAllow={() => {}}
+        onReject={() => {}}
+      />
+    );
+    await flush();
+    expect(screen.getByText('file_path')).toBeInTheDocument();
+    // content truncated with ellipsis
+    const truncated = screen.getByText(/^x+…$/);
+    expect(truncated.textContent!.length).toBeLessThanOrEqual(401);
+  });
+});


### PR DESCRIPTION
## Summary

The permission prompt that fires on `can_use_tool` was visually expanded but missing the keyboard contract a CLI-style UI demands: no Y/N hotkeys, no labels hinting that activation was supported, no input summary, and no clear safer-default focus story. This PR closes those gaps without touching the agent / electron side.

- Extracts `PermissionPromptBlock.tsx` from `ChatStream.tsx` (matches the `QuestionBlock` pattern from #70).
- Pipes `toolName` + `toolInput` through the `waiting` block so the prompt can show a curated argument summary inline (no expand step).
- Wires the keyboard contract end-to-end.

## Keybinds

| Key | Action |
|---|---|
| `Y` / `y` | Allow |
| `N` / `n` | Reject |
| `Enter` | Activate focused button |
| `Tab` / `Shift+Tab` | Move between Reject and Allow |
| `Escape` | No-op (force an active choice) |

Y/N hotkeys are suppressed while the user is typing in an external input/textarea/contenteditable so they don't hijack ordinary typing in the chat composer.

## Focus rules

- On mount, focus the **Reject** button — safer default.
- Only the LATEST unanswered permission block grabs focus. Older prompts (rare, but possible if multiple back-to-back) stay put.
- Skip auto-focus entirely when the user is already typing into an input/textarea elsewhere.

## Visual

- Accent border + accent bar (vs. the previous yellow `state-waiting` tone) so the prompt is immediately distinguishable from non-blocking waiting/streaming UI.
- `ShieldAlert` glyph + tool name uppercase in the headline.
- Input summary as a `dl`, curated key order (`command`, `file_path`, `path`, `pattern`, `url`, `plan` first), values truncated past 400 chars.
- Framer-motion fade-in (`opacity 0 → 1`, `y 8 → 0`, 220ms) consistent with `QuestionBlock` / `PlanBlock`.
- Buttons reuse `Button` `primary` (Allow) and `secondary` (Reject) variants — same focus-visible halo as elsewhere.

## Tests

- New unit tests: `tests/permission-prompt-block.test.tsx` — 11 tests covering autofocus Reject, Y triggers Allow (case-insensitive), N triggers Reject (case-insensitive), Enter on focused button, Tab tab-order, Escape no-op, no-focus-steal vs external textarea, no-Y/N-hijack while typing, `autoFocus={false}` for non-latest, long input value truncation.
- Live probe: `scripts/probe-e2e-permission-prompt.mjs` injects a fake `waiting` block into the running renderer and confirms in a real Electron window — Reject autofocused, both buttons present with `Allow (Y)` / `Reject (N)` labels, pressing N then Y dispatches and dismisses.

Full suite: **293 / 293 passing**, typecheck clean, lint clean (the pre-existing `CommandPalette` `useMemo` warning is unrelated).

## Test plan

- [x] `npm run typecheck` (0 errors)
- [x] `npm run lint` (0 errors, 1 unrelated warning)
- [x] `npm test` (293/293)
- [x] Live verification via probe in Electron window