### PR TITLE
fix(ux): focus InputBar when selecting a session

### DIFF
--- a/scripts/probe-click-session-focus.mjs
+++ b/scripts/probe-click-session-focus.mjs
@@ -1,0 +1,120 @@
+// Probe: clicking a session in the sidebar should move keyboard focus into
+// the InputBar textarea (matching Claude Desktop's behavior).
+//
+// Strategy: render against the webpack dev server (no Electron, no agent
+// IPC needed — this is pure DOM/state behavior). Seed the zustand store
+// with two synthetic sessions so we can click between them, then assert
+// `document.activeElement === textarea` after each click.
+//
+// Usage: AGENTORY_DEV_PORT=4181 npm run dev:web (background), then
+//   node scripts/probe-click-session-focus.mjs
+import { chromium } from 'playwright';
+
+const PORT = process.env.AGENTORY_DEV_PORT ?? '4181';
+const URL = `http://localhost:${PORT}/`;
+
+function fail(msg) {
+  console.error(`\n[probe-click-session-focus] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext();
+const page = await ctx.newPage();
+
+const errors = [];
+page.on('pageerror', (e) => errors.push(`[pageerror] ${e.message}`));
+page.on('console', (m) => {
+  if (m.type() === 'error') errors.push(`[console.error] ${m.text()}`);
+});
+
+await page.goto(URL, { waitUntil: 'networkidle' });
+await page.waitForSelector('aside', { timeout: 15_000 });
+
+// Seed two sessions via the store directly so we don't need a real agent.
+await page.evaluate(() => {
+  const w = window;
+  // Bypass the createSession helper because it triggers IPC paths in the
+  // renderer; we only want sidebar rows to click.
+  const useStore = w.__useStore || (w.useStore);
+  // Fallback: trigger two clicks on the visible "New session" button.
+});
+
+// Trigger via the visible UI: two New Session clicks → two rows in sidebar.
+// (createSession in the store doesn't bump focusInputNonce — only selecting
+// existing sessions does — so the textarea won't auto-focus on creation,
+// which is exactly what we want as a control case.)
+const newBtn = page.getByRole('button', { name: /new session/i }).first();
+await newBtn.waitFor({ state: 'visible', timeout: 10_000 });
+await newBtn.click();
+await page.waitForTimeout(150);
+await newBtn.click();
+await page.waitForTimeout(250);
+
+// Sanity: textarea exists.
+const textarea = page.locator('textarea');
+await textarea.waitFor({ state: 'visible', timeout: 5000 });
+
+// Park focus somewhere benign (sidebar aside element) so we can detect
+// that subsequent session clicks DO move focus into the textarea.
+await page.evaluate(() => {
+  const ta = document.querySelector('textarea');
+  if (ta) ta.blur();
+  document.body.focus();
+});
+
+const rows = page.locator('aside li[role="option"]');
+const rowCount = await rows.count();
+if (rowCount < 2) {
+  await browser.close();
+  fail(`expected ≥2 session rows in sidebar, got ${rowCount}`);
+}
+
+async function clickRowAndAssertFocus(idx, label) {
+  await rows.nth(idx).click();
+  // Give the React effect a tick to run.
+  await page.waitForTimeout(120);
+  const focused = await page.evaluate(() => {
+    const ae = document.activeElement;
+    return {
+      tag: ae ? ae.tagName : null,
+      isTextarea: !!ae && ae.tagName === 'TEXTAREA'
+    };
+  });
+  if (!focused.isTextarea) {
+    await browser.close();
+    fail(`after clicking session ${label}, expected TEXTAREA to be focused, got ${focused.tag}`);
+  }
+  console.log(`  click session ${label}: activeElement=TEXTAREA OK`);
+}
+
+// Click row 0 (the second session, since createSession unshifts).
+await clickRowAndAssertFocus(0, '#0');
+
+// Move focus away again, then click the OTHER row to prove the behavior
+// repeats per click (not just on activeId change).
+await page.evaluate(() => {
+  const ta = document.querySelector('textarea');
+  if (ta) ta.blur();
+  document.body.focus();
+});
+await clickRowAndAssertFocus(1, '#1');
+
+// Re-clicking the SAME (already-active) session should still re-focus the
+// textarea — the user clicked, the input should respond.
+await page.evaluate(() => {
+  const ta = document.querySelector('textarea');
+  if (ta) ta.blur();
+  document.body.focus();
+});
+await clickRowAndAssertFocus(1, '#1 (re-click same)');
+
+if (errors.length > 0) {
+  console.error('--- console / page errors ---');
+  for (const e of errors) console.error(e);
+}
+
+console.log('\n[probe-click-session-focus] OK');
+console.log('  sidebar click → InputBar textarea focused, verified for 2 rows + re-click');
+
+await browser.close();

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -27,11 +27,42 @@ export function InputBar({ sessionId }: { sessionId: string }) {
   const setRunning = useStore((s) => s.setRunning);
   const resetWatchdogCount = useStore((s) => s.resetWatchdogCount);
   const markInterrupted = useStore((s) => s.markInterrupted);
+  const focusInputNonce = useStore((s) => s.focusInputNonce);
+  // True iff there's a pending permission/plan/question prompt for this
+  // session — those blocks auto-focus their own primary control (see the
+  // setTimeout(..., 150) in WaitingBlock/PlanBlock/QuestionBlock). We let
+  // them win and skip stealing focus into the textarea.
+  const hasPendingWaiting = useStore((s) =>
+    (s.messagesBySession[sessionId] ?? []).some((b) => b.kind === 'waiting')
+  );
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  // Skip the very first observation of focusInputNonce so app mount doesn't
+  // steal focus from wherever the user (or some other auto-focus) put it.
+  const focusNonceSeenRef = useRef<number | null>(null);
 
   React.useEffect(() => {
     setValue(draftCache.get(sessionId) ?? '');
   }, [sessionId]);
+
+  React.useEffect(() => {
+    if (focusNonceSeenRef.current === null) {
+      focusNonceSeenRef.current = focusInputNonce;
+      return;
+    }
+    if (focusNonceSeenRef.current === focusInputNonce) return;
+    focusNonceSeenRef.current = focusInputNonce;
+    if (hasPendingWaiting) return;
+    // Don't yank focus out of another text-entry surface the user is
+    // actively typing in (e.g. the inline-rename input on a session row,
+    // a settings dialog field, etc.). Sidebar clicks land focus on the
+    // session <li> (role="option"), which is fine to override.
+    const ae = document.activeElement as HTMLElement | null;
+    if (ae && ae !== textareaRef.current) {
+      const tag = ae.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || ae.isContentEditable) return;
+    }
+    textareaRef.current?.focus();
+  }, [focusInputNonce, hasPendingWaiting]);
 
   function update(next: string) {
     setValue(next);

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -76,6 +76,13 @@ type State = {
   modelsByEndpoint: Record<string, ModelInfo[]>;
   defaultEndpointId: string | null;
   endpointsLoaded: boolean;
+  // Monotonic counter bumped whenever a user-driven action requests that the
+  // InputBar textarea take focus (e.g. clicking a session in the sidebar,
+  // matching Claude Desktop's behavior). InputBar `useEffect`s on this and
+  // calls `.focus()`. Initial value is 0 so first-render comparisons are
+  // trivial — InputBar skips the first observation to avoid stealing focus
+  // on app mount. Don't bump from background/system events; only user clicks.
+  focusInputNonce: number;
 };
 
 type Actions = {
@@ -164,6 +171,7 @@ export const useStore = create<State & Actions>((set, get) => ({
   modelsByEndpoint: {},
   defaultEndpointId: null,
   endpointsLoaded: false,
+  focusInputNonce: 0,
 
   selectSession: (id) => {
     set((s) => ({
@@ -171,7 +179,12 @@ export const useStore = create<State & Actions>((set, get) => ({
       focusedGroupId: null,
       sessions: s.sessions.map((x) =>
         x.id === id && x.state === 'waiting' ? { ...x, state: 'idle' } : x
-      )
+      ),
+      // Bump so the InputBar pulls focus — matches Claude Desktop's UX
+      // when clicking a session in the sidebar. Other entry points that
+      // ultimately route through selectSession (tray/notification click,
+      // command palette) get the same behavior for free.
+      focusInputNonce: s.focusInputNonce + 1
     }));
     // Lazy-load persisted history on first view after app restart. The store
     // only holds messages in memory; on fresh boot messagesBySession[id] is

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -18,7 +18,8 @@ beforeEach(() => {
       focusedGroupId: null,
       messagesBySession: {},
       startedSessions: {},
-      runningSessions: {}
+      runningSessions: {},
+      focusInputNonce: 0
     },
     true
   );
@@ -381,5 +382,36 @@ describe('store: loadMessages + selectSession autoload (session restore)', () =>
     });
     useStore.getState().selectSession('s-y');
     expect(load).not.toHaveBeenCalled();
+  });
+});
+
+describe('store: selectSession bumps focusInputNonce', () => {
+  it('increments focusInputNonce on every selectSession call', () => {
+    useStore.getState().createSession('~/a');
+    useStore.getState().createSession('~/b');
+    const [sB, sA] = useStore.getState().sessions;
+    const start = useStore.getState().focusInputNonce;
+    useStore.getState().selectSession(sA.id);
+    const after1 = useStore.getState().focusInputNonce;
+    expect(after1).toBe(start + 1);
+    // Re-selecting the same session still bumps — the user clicked, so the
+    // input should re-focus regardless of whether activeId actually changed.
+    useStore.getState().selectSession(sA.id);
+    expect(useStore.getState().focusInputNonce).toBe(after1 + 1);
+    useStore.getState().selectSession(sB.id);
+    expect(useStore.getState().focusInputNonce).toBe(after1 + 2);
+  });
+
+  it('also flips a waiting session to idle while bumping the nonce', () => {
+    useStore.getState().createSession('~/a');
+    const sid = useStore.getState().activeId;
+    useStore.setState((s) => ({
+      sessions: s.sessions.map((x) => (x.id === sid ? { ...x, state: 'waiting' } : x))
+    }));
+    const start = useStore.getState().focusInputNonce;
+    useStore.getState().selectSession(sid);
+    const s = useStore.getState();
+    expect(s.sessions.find((x) => x.id === sid)?.state).toBe('idle');
+    expect(s.focusInputNonce).toBe(start + 1);
   });
 });


### PR DESCRIPTION
## Summary
- Clicking a session in the sidebar now moves keyboard focus to the InputBar textarea, matching Claude Desktop's behavior so the user can start typing immediately.
- Implemented via a `focusInputNonce` counter on the zustand store, bumped inside `selectSession`. `InputBar` `useEffect`s on the counter and calls `.focus()` on its textarea ref. No global DOM querying.
- Edge cases handled: skips the first observation (so app mount doesn't steal focus); no-op when a `waiting` permission/plan/question block is pending (let the prompt's own auto-focus win); no-op if the user is currently typing in another INPUT/TEXTAREA/contenteditable surface (e.g. inline rename, settings field).

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (only pre-existing `CommandPalette` warning)
- [x] `npm test` green (308/308)
- [x] New unit tests in `tests/store.test.ts`: covers nonce bump on every `selectSession` call (including re-select) and interop with the existing waiting→idle flip
- [x] Live probe `scripts/probe-click-session-focus.mjs` on `AGENTORY_DEV_PORT=4181 npm run dev`: asserts `document.activeElement === textarea` after two different session clicks and a re-click

🤖 Generated with [Claude Code](https://claude.com/claude-code)