### PR TITLE
feat(notifications): system notifications with focus-aware suppression

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,10 +1,11 @@
-import { app, BrowserWindow, Menu, Tray, nativeImage, ipcMain, safeStorage, dialog, Notification, type MenuItemConstructorOptions } from 'electron';
+import { app, BrowserWindow, Menu, Tray, nativeImage, ipcMain, safeStorage, dialog, type MenuItemConstructorOptions } from 'electron';
 import * as path from 'path';
 import * as fs from 'fs';
 import { initDb, loadState, saveState, loadMessages, saveMessages, closeDb } from './db';
 import { sessions } from './agent/manager';
 import { installUpdaterIpc } from './updater';
 import { scanImportableSessions } from './import-scanner';
+import { showNotification, type ShowNotificationPayload } from './notifications';
 import type { PermissionMode } from './agent/sessions';
 import { EndpointsManager, type KeyCrypto } from './endpoints-manager';
 
@@ -198,7 +199,7 @@ app.whenReady().then(() => {
   // On Windows, notifications need a stable AppUserModelID so the OS knows
   // which app the toast belongs to (otherwise it shows "electron.exe").
   if (process.platform === 'win32') {
-    app.setAppUserModelId('com.agentory.desktop');
+    app.setAppUserModelId('com.agentory.next');
   }
   initDb();
 
@@ -344,24 +345,9 @@ app.whenReady().then(() => {
 
   ipcMain.handle(
     'notification:show',
-    (e, payload: { sessionId: string; title: string; body?: string }) => {
-      if (!Notification.isSupported()) return false;
+    (e, payload: ShowNotificationPayload) => {
       const win = BrowserWindow.fromWebContents(e.sender);
-      const n = new Notification({
-        title: payload.title,
-        body: payload.body ?? '',
-        silent: false
-      });
-      n.on('click', () => {
-        if (win) {
-          if (win.isMinimized()) win.restore();
-          win.show();
-          win.focus();
-          win.webContents.send('notification:focusSession', payload.sessionId);
-        }
-      });
-      n.show();
-      return true;
+      return showNotification(payload, win);
     }
   );
 

--- a/electron/notifications.ts
+++ b/electron/notifications.ts
@@ -1,0 +1,33 @@
+import { BrowserWindow, Notification } from 'electron';
+
+export type NotificationEventType = 'permission' | 'question' | 'turn_done' | 'test';
+
+export interface ShowNotificationPayload {
+  sessionId: string;
+  title: string;
+  body?: string;
+  eventType?: NotificationEventType;
+  silent?: boolean;
+}
+
+// Show an OS-level notification. Click brings the window forward and asks the
+// renderer to navigate to the originating session. Returns whether a toast was
+// actually shown (false if the platform reports notifications unsupported).
+export function showNotification(payload: ShowNotificationPayload, win: BrowserWindow | null): boolean {
+  if (!Notification.isSupported()) return false;
+  const n = new Notification({
+    title: payload.title,
+    body: payload.body ?? '',
+    silent: !!payload.silent
+  });
+  n.on('click', () => {
+    const target = win && !win.isDestroyed() ? win : BrowserWindow.getAllWindows()[0];
+    if (!target || target.isDestroyed()) return;
+    if (target.isMinimized()) target.restore();
+    if (!target.isVisible()) target.show();
+    target.focus();
+    target.webContents.send('notification:focusSession', payload.sessionId);
+  });
+  n.show();
+  return true;
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -110,8 +110,13 @@ const api = {
     Array<{ sessionId: string; cwd: string; title: string; mtime: number; projectDir: string }>
   > => ipcRenderer.invoke('import:scan'),
 
-  notify: (payload: { sessionId: string; title: string; body?: string }): Promise<boolean> =>
-    ipcRenderer.invoke('notification:show', payload),
+  notify: (payload: {
+    sessionId: string;
+    title: string;
+    body?: string;
+    eventType?: 'permission' | 'question' | 'turn_done' | 'test';
+    silent?: boolean;
+  }): Promise<boolean> => ipcRenderer.invoke('notification:show', payload),
   onNotificationFocus: (handler: (sessionId: string) => void): (() => void) => {
     const wrap = (_e: IpcRendererEvent, sessionId: string) => handler(sessionId);
     ipcRenderer.on('notification:focusSession', wrap);

--- a/scripts/probe-notifications.mjs
+++ b/scripts/probe-notifications.mjs
@@ -1,0 +1,134 @@
+// Probe: OS notifications IPC wiring and click routing.
+//
+// Scope: black-box verification that
+//   a) the renderer->main IPC path for `notification:show` is reachable and
+//      delivers the full payload (sessionId, title, eventType, silent),
+//   b) main listens for window close/focus events and a click-through would
+//      route via `notification:focusSession` (we bypass the real OS toast).
+//
+// Focus-suppression and debounce rules are exhaustively covered by
+// tests/notifications-dispatch.test.ts; this probe intentionally does NOT
+// re-run those in the live app — the renderer doesn't expose the dispatch
+// module on `window`, and the unit tests already pin the logic.
+//
+// Run: `AGENTORY_DEV_PORT=4182 npm run dev` in one terminal, then
+//      `node scripts/probe-notifications.mjs` in another.
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { appWindow } from './probe-utils.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function fail(msg) {
+  console.error(`\n[probe-notifications] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const app = await electron.launch({
+  args: ['.'],
+  cwd: root,
+  env: {
+    ...process.env,
+    NODE_ENV: 'development',
+    AGENTORY_DEV_PORT: process.env.AGENTORY_DEV_PORT ?? '4182'
+  }
+});
+
+const win = await appWindow(app);
+await win.waitForLoadState('domcontentloaded');
+await win.waitForTimeout(2500);
+
+// Replace `notification:show` with a recorder. This both prevents a real OS
+// toast during the probe and gives the probe a way to assert the payload.
+await app.evaluate(async ({ ipcMain, BrowserWindow }) => {
+  /** @type {Array<any>} */
+  const calls = [];
+  /** @type {Array<string>} */
+  const focusSent = [];
+  ipcMain.removeHandler('notification:show');
+  ipcMain.handle('notification:show', (e, payload) => {
+    calls.push(payload);
+    // Simulate the click-through branch: send `notification:focusSession`
+    // back to the renderer immediately. In real life this happens only on
+    // the user clicking the toast, but we want to verify the round-trip.
+    const win = BrowserWindow.fromWebContents(e.sender);
+    if (win) {
+      win.webContents.send('notification:focusSession', payload.sessionId);
+      focusSent.push(payload.sessionId);
+    }
+    return true;
+  });
+  /** @type {any} */ (globalThis).__probeNotifyCalls = calls;
+  /** @type {any} */ (globalThis).__probeFocusSent = focusSent;
+});
+
+// Prime: have the renderer install a listener for notification:focusSession so
+// we can verify the round-trip arrives back in the renderer.
+await win.evaluate(() => {
+  /** @type {any} */
+  const w = window;
+  w.__probeFocusReceived = [];
+  if (w.agentory?.onNotificationFocus) {
+    w.agentory.onNotificationFocus((sessionId) => {
+      w.__probeFocusReceived.push(sessionId);
+    });
+  }
+});
+
+// Drive: fire the IPC call the same way dispatch does after passing its gates.
+const drive = await win.evaluate(async () => {
+  /** @type {any} */
+  const w = window;
+  if (!w.agentory || typeof w.agentory.notify !== 'function') {
+    return { ok: false, reason: 'window.agentory.notify missing' };
+  }
+  await w.agentory.notify({
+    sessionId: 's-probe-1',
+    title: 'probe permission',
+    body: 'renderer -> main',
+    eventType: 'permission',
+    silent: true
+  });
+  return { ok: true };
+});
+if (!drive.ok) {
+  await app.close();
+  fail(`renderer drive failed: ${drive.reason}`);
+}
+
+// Give the round-trip IPC a beat to land.
+await win.waitForTimeout(300);
+
+const mainCalls = await app.evaluate(
+  () => /** @type {any} */ (globalThis).__probeNotifyCalls ?? []
+);
+if (!Array.isArray(mainCalls) || mainCalls.length !== 1) {
+  await app.close();
+  fail(`expected 1 IPC call to main, got ${mainCalls?.length ?? 0}`);
+}
+const call = mainCalls[0];
+if (
+  call.sessionId !== 's-probe-1' ||
+  call.eventType !== 'permission' ||
+  call.silent !== true ||
+  call.title !== 'probe permission'
+) {
+  await app.close();
+  fail(`main received unexpected payload: ${JSON.stringify(call)}`);
+}
+
+const received = await win.evaluate(
+  () => /** @type {any} */ (window).__probeFocusReceived ?? []
+);
+if (!Array.isArray(received) || received[0] !== 's-probe-1') {
+  await app.close();
+  fail(`renderer did not receive focusSession round-trip: ${JSON.stringify(received)}`);
+}
+
+console.log('[probe-notifications] OK');
+console.log(`  main notify payload:        ${JSON.stringify(call)}`);
+console.log(`  focus round-trip received:  ${JSON.stringify(received)}`);
+
+await app.close();

--- a/src/agent/lifecycle.ts
+++ b/src/agent/lifecycle.ts
@@ -1,11 +1,18 @@
 import { useStore } from '../stores/store';
 import { streamEventToTranslation, PartialAssistantStreamer } from './stream-to-blocks';
 import { parseQuestions } from './ask-user-question';
+import { dispatchNotification, handleNotificationFocus } from '../notifications/dispatch';
 import type { MessageBlock } from '../types';
 
 let installed = false;
 
 const streamers = new Map<string, PartialAssistantStreamer>();
+// Wall-clock timestamps for currently-running turns. We use elapsed time as
+// one of the signals for whether a `turn_done` is worth notifying about — a
+// fast turn that wraps in <15s is rarely worth surfacing, but a long-running
+// one almost always is.
+const turnStartedAt = new Map<string, number>();
+const TURN_DONE_THRESHOLD_MS = 15_000;
 function streamerFor(sessionId: string): PartialAssistantStreamer {
   let s = streamers.get(sessionId);
   if (!s) {
@@ -144,6 +151,14 @@ export function subscribeAgentEvents(): void {
   installed = true;
 
   api.onAgentEvent((e) => {
+    // Record the wall-clock start of the current turn so we can decide later
+    // whether `turn_done` is worth a toast. We treat the first non-result
+    // message after a result (or the very first ever) as the turn start.
+    if (e.message.type !== 'stream_event' && e.message.type !== 'result') {
+      if (!turnStartedAt.has(e.sessionId)) {
+        turnStartedAt.set(e.sessionId, Date.now());
+      }
+    }
     if (e.message.type === 'stream_event') {
       const streamer = streamerFor(e.sessionId);
       const patch = streamer.consume(e.message);
@@ -172,6 +187,35 @@ export function subscribeAgentEvents(): void {
       const blocks = useStore.getState().messagesBySession[e.sessionId];
       if (blocks && blocks.length > 0 && typeof window.agentory?.saveMessages === 'function') {
         void window.agentory.saveMessages(e.sessionId, blocks);
+      }
+      // `turn_done` notification policy: only ping when the turn meaningfully
+      // consumed the user's patience — long (>15s), or errored, or this
+      // session isn't the one being watched. Fast, successful, focused turns
+      // are noise; we skip them.
+      const startedAt = turnStartedAt.get(e.sessionId);
+      turnStartedAt.delete(e.sessionId);
+      const durationMs = startedAt ? Date.now() - startedAt : 0;
+      const result = e.message as { subtype?: string; is_error?: boolean };
+      const errored =
+        !!result.is_error ||
+        result.subtype === 'error_max_turns' ||
+        result.subtype === 'error_during_execution';
+      const isActive = store.activeId === e.sessionId;
+      const windowFocused = typeof document !== 'undefined' && document.hasFocus();
+      const sessionFocused = isActive && windowFocused;
+      if (errored || durationMs >= TURN_DONE_THRESHOLD_MS || !sessionFocused) {
+        const session = store.sessions.find((s) => s.id === e.sessionId);
+        const sessionName = session?.name ?? 'Session';
+        const title = errored
+          ? `${sessionName} finished with an error`
+          : `${sessionName} is done`;
+        const body = errored ? 'Turn ended in error - check the chat.' : undefined;
+        void dispatchNotification({
+          sessionId: e.sessionId,
+          eventType: 'turn_done',
+          title,
+          body
+        });
       }
       maybeFireWatchdog(e.sessionId);
     }
@@ -203,22 +247,26 @@ export function subscribeAgentEvents(): void {
       const sessionName = session?.name ?? 'Background session';
       backgroundWaitingHandler({ sessionId: req.sessionId, sessionName, prompt });
     }
-    // OS-level notification when the user almost certainly missed the in-app
-    // toast: window unfocused, or active-session toast suppressed in-app for
-    // a non-active session. Only ping for "needs your attention" requests
-    // (any permission/plan/question), never on routine assistant streaming.
-    const windowFocused = typeof document !== 'undefined' && document.hasFocus();
-    if (isBackground || !windowFocused) {
-      const session = store.sessions.find((s) => s.id === req.sessionId);
-      const sessionName = session?.name ?? 'Background session';
-      let title = `${sessionName} needs your input`;
-      let body: string | undefined;
-      if (block.kind === 'question') {
-        body = block.questions[0]?.question;
-      } else if (block.kind === 'waiting') {
-        body = block.intent === 'plan' ? 'Plan ready for review' : block.prompt;
-      }
-      void api.notify({ sessionId: req.sessionId, title, body });
+    // OS-level notification dispatch is deduped/suppressed inside dispatch:
+    // mute, focus, debounce, and per-event-type toggles all live there. We
+    // just hand it the semantic event and let it decide whether to ping the OS.
+    const session = store.sessions.find((s) => s.id === req.sessionId);
+    const sessionName = session?.name ?? 'Background session';
+    const eventType = block.kind === 'question' ? 'question' : 'permission';
+    const titleSuffix = block.kind === 'question' ? 'has a question' : 'needs your input';
+    let body: string | undefined;
+    if (block.kind === 'question') {
+      body = block.questions[0]?.question;
+    } else if (block.kind === 'waiting') {
+      body = block.intent === 'plan' ? 'Plan ready for review' : block.prompt;
     }
+    void dispatchNotification({
+      sessionId: req.sessionId,
+      eventType,
+      title: `${sessionName} ${titleSuffix}`,
+      body
+    });
   });
+
+  api.onNotificationFocus?.(handleNotificationFocus);
 }

--- a/src/components/ChatStream.tsx
+++ b/src/components/ChatStream.tsx
@@ -718,7 +718,7 @@ export function ChatStream() {
 
   return (
     <div className="relative flex-1 min-h-0 min-w-0 flex flex-col">
-      <div ref={scrollRef} onScroll={onScroll} className="flex-1 overflow-y-auto min-w-0">
+      <div ref={scrollRef} onScroll={onScroll} data-chat-stream className="flex-1 overflow-y-auto min-w-0">
         {blocks.length === 0 ? (
           <EmptyState />
         ) : (

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -147,6 +147,7 @@ export function InputBar({ sessionId }: { sessionId: string }) {
       >
         <textarea
           ref={textareaRef}
+          data-input-bar
           value={value}
           onChange={(e) => update(e.target.value)}
           onKeyDown={onKeyDown}

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -13,10 +13,11 @@ type LocalUpdateStatus =
   | { kind: 'downloaded'; version: string }
   | { kind: 'error'; message: string };
 
-type Tab = 'general' | 'endpoints' | 'autopilot' | 'account' | 'data' | 'shortcuts' | 'updates';
+type Tab = 'general' | 'notifications' | 'endpoints' | 'autopilot' | 'account' | 'data' | 'shortcuts' | 'updates';
 
 const TABS: { id: Tab; label: string }[] = [
   { id: 'general', label: 'General' },
+  { id: 'notifications', label: 'Notifications' },
   { id: 'endpoints', label: 'Endpoints' },
   { id: 'autopilot', label: 'Autopilot' },
   { id: 'account', label: 'Account' },
@@ -71,6 +72,7 @@ export function SettingsDialog({
           </nav>
           <div className="flex-1 min-w-0 p-5 overflow-y-auto">
             {tab === 'general' && <GeneralPane />}
+            {tab === 'notifications' && <NotificationsPane />}
             {tab === 'endpoints' && <EndpointsPane />}
             {tab === 'autopilot' && <AutopilotPane />}
             {tab === 'account' && <AccountPane />}
@@ -152,6 +154,112 @@ function GeneralPane() {
           ]}
         />
       </Field>
+    </>
+  );
+}
+
+function NotificationsPane() {
+  const settings = useStore((s) => s.notificationSettings);
+  const setNotificationSettings = useStore((s) => s.setNotificationSettings);
+  const activeId = useStore((s) => s.activeId);
+  const [testStatus, setTestStatus] = useState<string | null>(null);
+
+  const Toggle = ({
+    checked,
+    onChange,
+    disabled
+  }: {
+    checked: boolean;
+    onChange: (v: boolean) => void;
+    disabled?: boolean;
+  }) => (
+    <label
+      className={cn(
+        'inline-flex items-center gap-2 select-none',
+        disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'
+      )}
+    >
+      <input
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.checked)}
+        className="h-4 w-4 accent-accent"
+      />
+      <span className="text-sm text-fg-secondary">{checked ? 'On' : 'Off'}</span>
+    </label>
+  );
+
+  const onTest = async () => {
+    const api = window.agentory;
+    if (!api) {
+      setTestStatus('IPC unavailable.');
+      setTimeout(() => setTestStatus(null), 2000);
+      return;
+    }
+    const ok = await api.notify({
+      sessionId: activeId,
+      title: 'Agentory test notification',
+      body: 'If you can read this, OS notifications are working.',
+      eventType: 'test',
+      silent: !settings.sound
+    });
+    setTestStatus(ok ? 'Sent.' : 'Failed - OS notifications unavailable.');
+    setTimeout(() => setTestStatus(null), 2500);
+  };
+
+  const disableChildren = !settings.enabled;
+
+  return (
+    <>
+      <div className="text-xs text-fg-tertiary mb-4">
+        OS-level toasts when a session needs your attention. Suppressed when
+        the window is focused on that same session, and debounced per session
+        per event type so a chatty agent cannot spam you.
+      </div>
+      <Field label="Enable notifications">
+        <Toggle
+          checked={settings.enabled}
+          onChange={(v) => setNotificationSettings({ enabled: v })}
+        />
+      </Field>
+      <Field label="Permission prompts" hint="When a tool call is waiting on your approval.">
+        <Toggle
+          checked={settings.permission}
+          disabled={disableChildren}
+          onChange={(v) => setNotificationSettings({ permission: v })}
+        />
+      </Field>
+      <Field label="Questions" hint="When the agent uses AskUserQuestion to ask you something.">
+        <Toggle
+          checked={settings.question}
+          disabled={disableChildren}
+          onChange={(v) => setNotificationSettings({ question: v })}
+        />
+      </Field>
+      <Field
+        label="Turn done"
+        hint="Only fires for long (>15s), errored, or unfocused turns - routine fast turns are skipped."
+      >
+        <Toggle
+          checked={settings.turnDone}
+          disabled={disableChildren}
+          onChange={(v) => setNotificationSettings({ turnDone: v })}
+        />
+      </Field>
+      <Field label="Sound" hint="Play the OS default notification sound.">
+        <Toggle
+          checked={settings.sound}
+          disabled={disableChildren}
+          onChange={(v) => setNotificationSettings({ sound: v })}
+        />
+      </Field>
+      <div className="flex items-center gap-3">
+        <Button variant="secondary" size="md" onClick={onTest} disabled={disableChildren}>
+          Test notification
+        </Button>
+        {testStatus && <span className="text-xs text-fg-secondary">{testStatus}</span>}
+      </div>
     </>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -4,7 +4,8 @@ import {
   ChevronRight,
   Plus,
   Search,
-  Settings
+  Settings,
+  BellOff
 } from 'lucide-react';
 import {
   DndContext,
@@ -260,6 +261,7 @@ function SessionRow({ session, active, selected, onSelect }: { session: Session;
   const deleteSession = useStore((s) => s.deleteSession);
   const moveSession = useStore((s) => s.moveSession);
   const createGroup = useStore((s) => s.createGroup);
+  const setSessionNotificationsMuted = useStore((s) => s.setSessionNotificationsMuted);
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: session.id,
     data: { type: 'session', groupId: session.groupId }
@@ -325,6 +327,13 @@ function SessionRow({ session, active, selected, onSelect }: { session: Session;
               <span className="truncate block">{session.name}</span>
             )}
           </span>
+          {session.notificationsMuted && (
+            <BellOff
+              size={12}
+              className="stroke-[1.5] text-fg-tertiary shrink-0"
+              aria-label="Notifications muted"
+            />
+          )}
           {active && (
             <span
               aria-label="Open in chat"
@@ -344,6 +353,13 @@ function SessionRow({ session, active, selected, onSelect }: { session: Session;
       </ContextMenuTrigger>
       <ContextMenuContent>
         <ContextMenuItem onSelect={() => setRenaming(true)}>Rename</ContextMenuItem>
+        <ContextMenuItem
+          onSelect={() =>
+            setSessionNotificationsMuted(session.id, !session.notificationsMuted)
+          }
+        >
+          {session.notificationsMuted ? 'Unmute notifications' : 'Mute notifications'}
+        </ContextMenuItem>
         <ContextMenuSub>
           <ContextMenuSubTrigger>Move to group</ContextMenuSubTrigger>
           <ContextMenuSubContent>

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -93,7 +93,13 @@ declare global {
         Array<{ sessionId: string; cwd: string; title: string; mtime: number; projectDir: string }>
       >;
 
-      notify: (payload: { sessionId: string; title: string; body?: string }) => Promise<boolean>;
+      notify: (payload: {
+        sessionId: string;
+        title: string;
+        body?: string;
+        eventType?: 'permission' | 'question' | 'turn_done' | 'test';
+        silent?: boolean;
+      }) => Promise<boolean>;
       onNotificationFocus: (handler: (sessionId: string) => void) => () => void;
 
       updatesStatus: () => Promise<UpdateStatus>;

--- a/src/notifications/dispatch.ts
+++ b/src/notifications/dispatch.ts
@@ -1,0 +1,127 @@
+import { useStore } from '../stores/store';
+
+export type NotificationEventType = 'permission' | 'question' | 'turn_done';
+
+export interface DispatchInput {
+  sessionId: string;
+  eventType: NotificationEventType;
+  title: string;
+  body?: string;
+}
+
+export type DispatchSkipReason =
+  | 'no-api'
+  | 'global-disabled'
+  | 'event-disabled'
+  | 'session-muted'
+  | 'focused-active'
+  | 'debounced';
+
+export interface DispatchResult {
+  dispatched: boolean;
+  reason?: DispatchSkipReason;
+}
+
+const DEBOUNCE_MS = 30_000;
+// Last-fired timestamp per (sessionId|eventType). Module-level on purpose:
+// the lifecycle module is a singleton in the renderer, so this map naturally
+// scopes to one window. A bounded LRU is overkill — a typical user has at
+// most a few dozen sessions × 3 event types.
+const lastFiredAt = new Map<string, number>();
+
+function cacheKey(sessionId: string, eventType: NotificationEventType): string {
+  return `${sessionId}|${eventType}`;
+}
+
+// Test seam: probe-notifications.mjs and unit tests can override these to
+// simulate window focus / active session without driving real DOM events.
+export interface DispatchEnv {
+  hasFocus: () => boolean;
+  now: () => number;
+}
+
+const defaultEnv: DispatchEnv = {
+  hasFocus: () => (typeof document !== 'undefined' ? document.hasFocus() : false),
+  now: () => Date.now()
+};
+
+let env: DispatchEnv = defaultEnv;
+
+export function setDispatchEnv(next: Partial<DispatchEnv>): void {
+  env = { ...defaultEnv, ...env, ...next };
+}
+
+export function resetDispatchState(): void {
+  env = defaultEnv;
+  lastFiredAt.clear();
+}
+
+// Apply suppression rules then call the main-process notification IPC. The
+// rules are intentionally conservative: a notification is a heavy, OS-level
+// interruption, so when in doubt we skip rather than spam. Returns a structured
+// result so callers (and tests) can see *why* something was suppressed.
+export async function dispatchNotification(input: DispatchInput): Promise<DispatchResult> {
+  const api = window.agentory;
+  if (!api) return { dispatched: false, reason: 'no-api' };
+
+  const state = useStore.getState();
+  const settings = state.notificationSettings;
+  if (!settings.enabled) return { dispatched: false, reason: 'global-disabled' };
+
+  const eventEnabled =
+    (input.eventType === 'permission' && settings.permission) ||
+    (input.eventType === 'question' && settings.question) ||
+    (input.eventType === 'turn_done' && settings.turnDone);
+  if (!eventEnabled) return { dispatched: false, reason: 'event-disabled' };
+
+  const session = state.sessions.find((s) => s.id === input.sessionId);
+  if (session?.notificationsMuted) {
+    return { dispatched: false, reason: 'session-muted' };
+  }
+
+  // Suppress when the user is already looking at this exact session — they
+  // will see the in-app affordance, no need to ping the OS too.
+  const focused = env.hasFocus();
+  const isActive = state.activeId === input.sessionId;
+  if (focused && isActive) {
+    return { dispatched: false, reason: 'focused-active' };
+  }
+
+  const key = cacheKey(input.sessionId, input.eventType);
+  const last = lastFiredAt.get(key) ?? 0;
+  const now = env.now();
+  if (now - last < DEBOUNCE_MS) {
+    return { dispatched: false, reason: 'debounced' };
+  }
+  lastFiredAt.set(key, now);
+
+  await api.notify({
+    sessionId: input.sessionId,
+    title: input.title,
+    body: input.body,
+    eventType: input.eventType,
+    silent: !settings.sound
+  });
+  return { dispatched: true };
+}
+
+// Triggered by clicking a notification (main → renderer IPC). Selects the
+// session and tries to focus the input bar so the user can act immediately.
+// The input-focus path piggybacks on the same DOM affordance the sidebar
+// click uses; if the dedicated focusInputNonce pattern lands later from
+// fix/click-session-focus-input, swap to it then.
+export function handleNotificationFocus(sessionId: string): void {
+  const state = useStore.getState();
+  if (!state.sessions.some((s) => s.id === sessionId)) return;
+  state.selectSession(sessionId);
+  // TODO: replace with focusInputNonce bump once fix/click-session-focus-input
+  // merges. Until then, find the textarea in the DOM and focus it directly so
+  // the user can type without an extra click.
+  if (typeof window === 'undefined') return;
+  window.requestAnimationFrame(() => {
+    const ta = document.querySelector<HTMLTextAreaElement>('textarea[data-input-bar]');
+    if (ta) ta.focus();
+    const stream = document.querySelector<HTMLElement>('[data-chat-stream]');
+    if (stream) stream.scrollTop = stream.scrollHeight;
+  });
+}

--- a/src/stores/persist.ts
+++ b/src/stores/persist.ts
@@ -1,5 +1,11 @@
 import type { Group, Session } from '../types';
-import type { PermissionMode, Theme, FontSize, WatchdogConfig } from './store';
+import type {
+  PermissionMode,
+  Theme,
+  FontSize,
+  WatchdogConfig,
+  NotificationSettings
+} from './store';
 import type { RecentProject } from '../mock/data';
 
 export const STATE_KEY = 'main';
@@ -22,6 +28,7 @@ export interface PersistedState {
    * restarts. Falls back to the endpoint with is_default=1 if missing.
    */
   defaultEndpointId?: string | null;
+  notificationSettings?: NotificationSettings;
 }
 
 export async function loadPersisted(): Promise<PersistedState | null> {

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -51,6 +51,24 @@ export const DEFAULT_WATCHDOG: WatchdogConfig = {
   maxAutoReplies: 20
 };
 
+// OS-level notification preferences. Persisted as a single JSON blob alongside
+// the rest of app state — same envelope as `watchdog`.
+export interface NotificationSettings {
+  enabled: boolean;
+  permission: boolean;
+  question: boolean;
+  turnDone: boolean;
+  sound: boolean;
+}
+
+export const DEFAULT_NOTIFICATION_SETTINGS: NotificationSettings = {
+  enabled: true,
+  permission: true,
+  question: true,
+  turnDone: true,
+  sound: true
+};
+
 type State = {
   sessions: Session[];
   groups: Group[];
@@ -65,6 +83,7 @@ type State = {
   tutorialSeen: boolean;
   watchdog: WatchdogConfig;
   watchdogCountsBySession: Record<string, number>;
+  notificationSettings: NotificationSettings;
   messagesBySession: Record<string, MessageBlock[]>;
   startedSessions: Record<string, true>;
   runningSessions: Record<string, true>;
@@ -105,6 +124,8 @@ type Actions = {
   setWatchdog: (patch: Partial<WatchdogConfig>) => void;
   resetWatchdogCount: (sessionId: string) => void;
   bumpWatchdogCount: (sessionId: string) => number;
+  setNotificationSettings: (patch: Partial<NotificationSettings>) => void;
+  setSessionNotificationsMuted: (sessionId: string, muted: boolean) => void;
 
   createGroup: (name?: string) => string;
   renameGroup: (id: string, name: string) => void;
@@ -163,6 +184,7 @@ export const useStore = create<State & Actions>((set, get) => ({
   tutorialSeen: false,
   watchdog: DEFAULT_WATCHDOG,
   watchdogCountsBySession: {},
+  notificationSettings: DEFAULT_NOTIFICATION_SETTINGS,
   messagesBySession: {},
   startedSessions: {},
   runningSessions: {},
@@ -398,6 +420,16 @@ export const useStore = create<State & Actions>((set, get) => ({
     }));
     return nextN;
   },
+
+  setNotificationSettings: (patch) =>
+    set((s) => ({ notificationSettings: { ...s.notificationSettings, ...patch } })),
+
+  setSessionNotificationsMuted: (sessionId, muted) =>
+    set((s) => ({
+      sessions: s.sessions.map((x) =>
+        x.id === sessionId ? { ...x, notificationsMuted: muted } : x
+      )
+    })),
 
   createGroup: (name) => {
     const id = nextId('g');
@@ -686,7 +718,11 @@ export async function hydrateStore(): Promise<void> {
       recentProjects: persisted.recentProjects ?? [],
       tutorialSeen: persisted.tutorialSeen ?? false,
       watchdog: { ...DEFAULT_WATCHDOG, ...(persisted.watchdog ?? {}) },
-      defaultEndpointId: persisted.defaultEndpointId ?? null
+      defaultEndpointId: persisted.defaultEndpointId ?? null,
+      notificationSettings: {
+        ...DEFAULT_NOTIFICATION_SETTINGS,
+        ...(persisted.notificationSettings ?? {})
+      }
     });
   }
   hydrated = true;
@@ -718,7 +754,8 @@ export async function hydrateStore(): Promise<void> {
       recentProjects: s.recentProjects,
       tutorialSeen: s.tutorialSeen,
       watchdog: s.watchdog,
-      defaultEndpointId: s.defaultEndpointId
+      defaultEndpointId: s.defaultEndpointId,
+      notificationSettings: s.notificationSettings
     };
     schedulePersist(snapshot);
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,9 @@ export interface Session {
   // Set when the session was imported from a Claude Code CLI transcript.
   // Passed to agentStart on first send so the SDK resumes the same thread.
   resumeSessionId?: string;
+  // Per-session OS notification mute. When true, dispatch suppresses all
+  // notification events for this session regardless of global settings.
+  notificationsMuted?: boolean;
 }
 
 export interface Group {

--- a/tests/notifications-dispatch.test.ts
+++ b/tests/notifications-dispatch.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+type NotifyPayload = {
+  sessionId: string;
+  title: string;
+  body?: string;
+  eventType?: string;
+  silent?: boolean;
+};
+
+// Each test rebuilds the module graph so module-level dispatch state (the
+// per-(session,event) debounce map) starts clean. We also stub out
+// window.agentory minimally — dispatch only needs `notify`.
+async function freshDispatch(): Promise<{
+  dispatch: typeof import('../src/notifications/dispatch');
+  store: typeof import('../src/stores/store').useStore;
+  notifyCalls: NotifyPayload[];
+}> {
+  vi.resetModules();
+  const notifyCalls: NotifyPayload[] = [];
+  (globalThis as unknown as { window: { agentory: unknown } }).window = {
+    agentory: {
+      notify: async (payload: NotifyPayload) => {
+        notifyCalls.push(payload);
+        return true;
+      }
+    }
+  };
+  const dispatch = await import('../src/notifications/dispatch');
+  const storeMod = await import('../src/stores/store');
+  dispatch.resetDispatchState();
+  return { dispatch, store: storeMod.useStore, notifyCalls };
+}
+
+function setupSession(
+  store: typeof import('../src/stores/store').useStore,
+  opts: { active?: boolean } = {}
+): string {
+  store.getState().createSession('~/x');
+  const sid = store.getState().activeId;
+  if (opts.active === false) {
+    // createSession auto-selects; deselect by creating another and selecting it.
+    store.getState().createSession('~/y');
+    const other = store.getState().activeId;
+    store.getState().selectSession(other);
+  }
+  return sid;
+}
+
+describe('dispatchNotification', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fires when window unfocused and all settings default (enabled)', async () => {
+    const h = await freshDispatch();
+    h.dispatch.setDispatchEnv({ hasFocus: () => false });
+    const sid = setupSession(h.store);
+
+    const res = await h.dispatch.dispatchNotification({
+      sessionId: sid,
+      eventType: 'permission',
+      title: 'Needs input'
+    });
+
+    expect(res.dispatched).toBe(true);
+    expect(h.notifyCalls).toHaveLength(1);
+    expect(h.notifyCalls[0].eventType).toBe('permission');
+    expect(h.notifyCalls[0].silent).toBe(false); // sound default on
+  });
+
+  it('suppresses when window focused AND session is active', async () => {
+    const h = await freshDispatch();
+    h.dispatch.setDispatchEnv({ hasFocus: () => true });
+    const sid = setupSession(h.store);
+
+    const res = await h.dispatch.dispatchNotification({
+      sessionId: sid,
+      eventType: 'permission',
+      title: 'x'
+    });
+
+    expect(res).toEqual({ dispatched: false, reason: 'focused-active' });
+    expect(h.notifyCalls).toEqual([]);
+  });
+
+  it('fires when window focused but the event is for a different session', async () => {
+    const h = await freshDispatch();
+    h.dispatch.setDispatchEnv({ hasFocus: () => true });
+    const bg = setupSession(h.store, { active: false });
+
+    const res = await h.dispatch.dispatchNotification({
+      sessionId: bg,
+      eventType: 'permission',
+      title: 'bg session needs you'
+    });
+
+    expect(res.dispatched).toBe(true);
+    expect(h.notifyCalls).toHaveLength(1);
+  });
+
+  it('debounces a second notification within 30s for the same (session,event)', async () => {
+    const h = await freshDispatch();
+    let fakeNow = 1_000_000;
+    h.dispatch.setDispatchEnv({ hasFocus: () => false, now: () => fakeNow });
+    const sid = setupSession(h.store);
+
+    const first = await h.dispatch.dispatchNotification({
+      sessionId: sid,
+      eventType: 'permission',
+      title: 'first'
+    });
+    expect(first.dispatched).toBe(true);
+
+    fakeNow += 10_000;
+    const second = await h.dispatch.dispatchNotification({
+      sessionId: sid,
+      eventType: 'permission',
+      title: 'second'
+    });
+    expect(second).toEqual({ dispatched: false, reason: 'debounced' });
+
+    // Past the 30s window, it fires again.
+    fakeNow += 25_000;
+    const third = await h.dispatch.dispatchNotification({
+      sessionId: sid,
+      eventType: 'permission',
+      title: 'third'
+    });
+    expect(third.dispatched).toBe(true);
+    expect(h.notifyCalls).toHaveLength(2);
+  });
+
+  it('debounce is scoped per event type — different event types do not share a quota', async () => {
+    const h = await freshDispatch();
+    const fakeNow = 1_000_000;
+    h.dispatch.setDispatchEnv({ hasFocus: () => false, now: () => fakeNow });
+    const sid = setupSession(h.store);
+
+    const a = await h.dispatch.dispatchNotification({
+      sessionId: sid,
+      eventType: 'permission',
+      title: 'a'
+    });
+    const b = await h.dispatch.dispatchNotification({
+      sessionId: sid,
+      eventType: 'question',
+      title: 'b'
+    });
+    expect(a.dispatched).toBe(true);
+    expect(b.dispatched).toBe(true);
+    expect(h.notifyCalls).toHaveLength(2);
+  });
+
+  it('respects the global enabled toggle', async () => {
+    const h = await freshDispatch();
+    h.dispatch.setDispatchEnv({ hasFocus: () => false });
+    const sid = setupSession(h.store);
+    h.store.getState().setNotificationSettings({ enabled: false });
+
+    const res = await h.dispatch.dispatchNotification({
+      sessionId: sid,
+      eventType: 'permission',
+      title: 'x'
+    });
+    expect(res).toEqual({ dispatched: false, reason: 'global-disabled' });
+  });
+
+  it('respects the per-event-type toggle', async () => {
+    const h = await freshDispatch();
+    h.dispatch.setDispatchEnv({ hasFocus: () => false });
+    const sid = setupSession(h.store);
+    h.store.getState().setNotificationSettings({ turnDone: false });
+
+    const res = await h.dispatch.dispatchNotification({
+      sessionId: sid,
+      eventType: 'turn_done',
+      title: 'done'
+    });
+    expect(res).toEqual({ dispatched: false, reason: 'event-disabled' });
+  });
+
+  it('respects per-session mute', async () => {
+    const h = await freshDispatch();
+    h.dispatch.setDispatchEnv({ hasFocus: () => false });
+    const sid = setupSession(h.store);
+    h.store.getState().setSessionNotificationsMuted(sid, true);
+
+    const res = await h.dispatch.dispatchNotification({
+      sessionId: sid,
+      eventType: 'permission',
+      title: 'x'
+    });
+    expect(res).toEqual({ dispatched: false, reason: 'session-muted' });
+  });
+
+  it('passes silent=true when sound setting is off', async () => {
+    const h = await freshDispatch();
+    h.dispatch.setDispatchEnv({ hasFocus: () => false });
+    const sid = setupSession(h.store);
+    h.store.getState().setNotificationSettings({ sound: false });
+
+    await h.dispatch.dispatchNotification({
+      sessionId: sid,
+      eventType: 'permission',
+      title: 'x'
+    });
+    expect(h.notifyCalls[0].silent).toBe(true);
+  });
+});
+
+describe('notification settings persistence', () => {
+  it('round-trips notificationSettings through the persisted snapshot shape', async () => {
+    vi.resetModules();
+    (globalThis as unknown as { window: unknown }).window = { agentory: undefined };
+    const storeMod = await import('../src/stores/store');
+    const store = storeMod.useStore;
+
+    store.getState().setNotificationSettings({
+      enabled: false,
+      permission: false,
+      turnDone: false,
+      sound: false
+    });
+
+    // Simulate the persist snapshot builder (matches store.ts subscribe).
+    const s = store.getState();
+    const snapshot = {
+      version: 1 as const,
+      sessions: s.sessions,
+      groups: s.groups,
+      activeId: s.activeId,
+      model: s.model,
+      permission: s.permission,
+      sidebarCollapsed: s.sidebarCollapsed,
+      theme: s.theme,
+      fontSize: s.fontSize,
+      recentProjects: s.recentProjects,
+      tutorialSeen: s.tutorialSeen,
+      watchdog: s.watchdog,
+      notificationSettings: s.notificationSettings
+    };
+    const json = JSON.parse(JSON.stringify(snapshot));
+    expect(json.notificationSettings).toEqual({
+      enabled: false,
+      permission: false,
+      question: true,
+      turnDone: false,
+      sound: false
+    });
+  });
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,7 @@ module.exports = {
     new HtmlWebpackPlugin({ template: './src/index.html' })
   ],
   devServer: {
-    port: 4100,
+    port: Number(process.env.AGENTORY_DEV_PORT) || 4100,
     hot: true,
     historyApiFallback: true
   }


### PR DESCRIPTION
## Summary
- OS-level notifications for the three events worth interrupting the user over: **permission prompts**, **AskUserQuestion**, and **turn_done** (only when errored, turn >= 15s, or session unfocused — routine fast turns are noise).
- Renderer-side dispatch (\`src/notifications/dispatch.ts\`) applies suppression rules **before** the IPC call: global toggle, per-event-type toggle, per-session mute, focused-active suppression, and a 30s per-(sessionId, eventType) debounce.
- Click-through: the main process wires \`notification.on('click')\` to \`win.show() + win.focus() + webContents.send('notification:focusSession')\`. Renderer listens and selects the session + focuses InputBar + scrolls to bottom.
- Settings: new \"Notifications\" tab in \`SettingsDialog\` with global toggle, per-event toggles, sound toggle (maps to \`silent\`), and a Test button.
- Per-session mute: bell toggle in session context menu; muted sessions get a \`BellOff\` glyph in the sidebar row.
- Windows attribution: \`app.setAppUserModelId('com.agentory.next')\` in main bootstrap so toasts attribute to Agentory, not electron.exe.

## Suppression rules (dispatch order)
1. \`no-api\` — \`window.agentory\` missing (renderer-only unit-test guard).
2. \`global-disabled\` — \`notificationSettings.enabled === false\`.
3. \`event-disabled\` — per-event-type toggle off.
4. \`session-muted\` — \`session.notificationsMuted === true\`.
5. \`focused-active\` — \`document.hasFocus() && activeId === eventSession\`. This is the big one: if you're watching the session, no OS toast.
6. \`debounced\` — last fire for the same (sessionId, eventType) was within 30s.

Each rule surfaces as a structured \`DispatchSkipReason\` so tests and the probe can assert **why** a toast was (or wasn't) shown.

## Files
- \`electron/notifications.ts\` (new) — \`showNotification({title, body, sessionId, eventType, silent})\` + click routing.
- \`electron/main.ts\` — use the new module; AppUserModelID fix.
- \`electron/preload.ts\` / \`src/global.d.ts\` — extend \`notify\` payload (\`eventType\`, \`silent\`).
- \`src/notifications/dispatch.ts\` (new) — suppression + debounce + test env seam.
- \`src/agent/lifecycle.ts\` — wire dispatch for permission/question/turn_done, track turn start time.
- \`src/components/SettingsDialog.tsx\` — Notifications tab.
- \`src/components/Sidebar.tsx\` — per-session mute menu + BellOff indicator.
- \`src/components/InputBar.tsx\` / \`src/components/ChatStream.tsx\` — add \`data-input-bar\` / \`data-chat-stream\` hooks for notification-click focus.
- \`src/stores/store.ts\` + \`src/stores/persist.ts\` — \`notificationSettings\` round-trip, \`setSessionNotificationsMuted\` action.
- \`src/types.ts\` — \`Session.notificationsMuted?: boolean\`.
- \`webpack.config.js\` — honor \`AGENTORY_DEV_PORT\` so the probe doesn't collide on 4100.

## Tests
- \`tests/notifications-dispatch.test.ts\` (10 new) — every suppression branch + settings persistence round-trip.
- \`tests/lifecycle.test.ts\` (18 existing) — all still pass; the inline notify-on-background path is now funneled through dispatch with the same external contract.
- \`scripts/probe-notifications.mjs\` (new) — live end-to-end: launches the app, replaces \`notification:show\` with a recorder, fires through \`window.agentory.notify\`, asserts main received full payload + renderer received \`notification:focusSession\` round-trip. Run with \`AGENTORY_DEV_PORT=4182\`.

All CI gates green on the commit (\`typecheck\`, \`lint\`, \`test\` — 331/331 pass). Probe verified manually on \`AGENTORY_DEV_PORT=4182 npm run dev\`.

## Test plan
- [ ] Run \`npm test\` — expect 331/331 green.
- [ ] Open Settings -> Notifications -> click **Test notification**; see OS toast with \"Agentory test notification\". Toggle **Sound** off, re-test, confirm silent.
- [ ] Start a session, let it hit a permission prompt while the app is minimized or on another desktop. Expect a toast. Click it: app foregrounds, that session becomes active, input is focused.
- [ ] With the session focused, trigger another permission prompt — expect **no** toast (focused-active rule).
- [ ] Two permission prompts within 30s on the same session → only the first fires (debounce).
- [ ] Right-click a session → **Mute notifications**; trigger a prompt there → no toast, BellOff icon shows on the row.
- [ ] \`AGENTORY_DEV_PORT=4182 npm run dev\`, then \`node scripts/probe-notifications.mjs\` in another terminal → expect \`[probe-notifications] OK\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)