### PR TITLE
feat(input): slash-command picker with pass-through to claude.exe

### DIFF
--- a/scripts/probe-slash-commands.mjs
+++ b/scripts/probe-slash-commands.mjs
@@ -1,0 +1,138 @@
+// Probe: in-chat slash-command picker.
+//
+// Strategy: render against the webpack dev server on AGENTORY_DEV_PORT
+// (defaults to 4184), create a session, and exercise the picker purely
+// through keyboard + DOM. No Electron / no agent IPC needed — the picker
+// is pure DOM/state.
+//
+// Coverage:
+//   1. Typing `/` at start of input opens the picker with all commands.
+//   2. Typing `cl` filters down to /clear and highlights it.
+//   3. ArrowDown + Enter replaces textarea value with `/<name> ` and closes
+//      the picker (value NOT sent).
+//   4. A space after the command keeps the picker closed (composing args).
+//   5. Escape closes the picker without wiping the textarea value.
+//   6. A mid-sentence `/` does NOT open the picker.
+//
+// Usage:
+//   AGENTORY_DEV_PORT=4184 npm run dev:web   # in another shell
+//   node scripts/probe-slash-commands.mjs
+import { chromium } from 'playwright';
+
+const PORT = process.env.AGENTORY_DEV_PORT ?? '4184';
+const URL = `http://localhost:${PORT}/`;
+
+function fail(msg) {
+  console.error(`\n[probe-slash-commands] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext();
+const page = await ctx.newPage();
+
+const errors = [];
+page.on('pageerror', (e) => errors.push(`[pageerror] ${e.message}`));
+page.on('console', (m) => {
+  if (m.type() === 'error') errors.push(`[console.error] ${m.text()}`);
+});
+
+await page.goto(URL, { waitUntil: 'networkidle' });
+await page.waitForSelector('aside', { timeout: 15_000 });
+
+const newBtn = page.getByRole('button', { name: /new session/i }).first();
+await newBtn.waitFor({ state: 'visible', timeout: 10_000 });
+await newBtn.click();
+
+const textarea = page.locator('textarea');
+await textarea.waitFor({ state: 'visible', timeout: 5000 });
+await textarea.click();
+
+// --- 1. Type `/` → picker opens with all commands ---------------------
+await page.keyboard.type('/');
+const picker = page.locator('[role="listbox"][aria-label="Slash commands"]');
+await picker.waitFor({ state: 'visible', timeout: 2000 }).catch(() => {
+  fail('picker did not appear after typing "/"');
+});
+const allOptions = await picker.locator('[role="option"]').count();
+if (allOptions < 5) {
+  fail(`expected many commands in picker, got ${allOptions}`);
+}
+
+// --- 2. Type `cl` → filter narrows, /clear visible & highlighted ------
+await page.keyboard.type('cl');
+await page.waitForTimeout(80);
+const clearRow = picker.getByText('/clear');
+if (!(await clearRow.isVisible())) fail('/clear not visible after filtering by "cl"');
+const selected = await picker.locator('[role="option"][aria-selected="true"]').innerText();
+if (!selected.includes('/clear')) {
+  fail(`expected /clear highlighted, got "${selected}"`);
+}
+
+// --- 3. ArrowDown + Enter commits (caveat: /clear is first, ArrowDown
+//        would move OFF it — so just hit Enter on the already-highlighted
+//        row). Then assert textarea = "/clear " and picker closed. -----
+await page.keyboard.press('Enter');
+await page.waitForTimeout(80);
+const valueAfterEnter = await textarea.inputValue();
+if (valueAfterEnter !== '/clear ') {
+  fail(`expected textarea value "/clear ", got "${valueAfterEnter}"`);
+}
+const pickerVisibleAfterEnter = await picker.isVisible().catch(() => false);
+if (pickerVisibleAfterEnter) {
+  fail('picker should have closed after Enter-commit');
+}
+
+// --- 4. Space-in-first-token closes picker. Already closed due to the
+//        trailing space from commit. Type more text, assert still closed.
+await page.keyboard.type('now');
+await page.waitForTimeout(50);
+if (await picker.isVisible().catch(() => false)) {
+  fail('picker should stay closed after commit + arg typing');
+}
+
+// --- 5. Escape closes the picker without wiping textarea value --------
+await textarea.fill('/he');
+await picker.waitFor({ state: 'visible', timeout: 1000 });
+await page.keyboard.press('Escape');
+await page.waitForTimeout(50);
+if (await picker.isVisible().catch(() => false)) {
+  fail('picker should close on Escape');
+}
+const valueAfterEsc = await textarea.inputValue();
+if (valueAfterEsc !== '/he') {
+  fail(`expected textarea to retain "/he" after Escape, got "${valueAfterEsc}"`);
+}
+
+// --- 6. Mid-sentence `/` does NOT open picker --------------------------
+await textarea.fill('hey /help me');
+await page.waitForTimeout(50);
+if (await picker.isVisible().catch(() => false)) {
+  fail('picker must not open for a mid-sentence "/"');
+}
+
+// Also: a message that starts with `/` but has a space already closes the
+// picker (covered by step 4, repeated for clarity).
+await textarea.fill('/help ');
+await page.waitForTimeout(50);
+if (await picker.isVisible().catch(() => false)) {
+  fail('picker must not stay open once user typed a space after /name');
+}
+
+// Filter down to nothing → empty-state message ------------------------
+await textarea.fill('/xyznope');
+await picker.waitFor({ state: 'visible', timeout: 1000 });
+const emptyVisible = await picker.getByText(/No matching commands/i).isVisible();
+if (!emptyVisible) fail('empty-state message missing for no-match query');
+
+if (errors.length > 0) {
+  console.error('--- console / page errors ---');
+  for (const e of errors) console.error(e);
+}
+
+console.log('\n[probe-slash-commands] OK');
+console.log(`  ${allOptions} commands rendered on bare slash`);
+console.log('  /cl → /clear highlighted; Enter → textarea="/clear "');
+console.log('  Escape keeps value, mid-sentence / stays closed');
+
+await browser.close();

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -1,9 +1,16 @@
-import React, { useRef, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import { ArrowUp, Square } from 'lucide-react';
 import { cn } from '../lib/cn';
 import { Button } from './ui/Button';
 import { useStore } from '../stores/store';
 import { toSdkPermissionMode } from '../agent/permission';
+import { SlashCommandPicker } from './SlashCommandPicker';
+import {
+  SLASH_COMMANDS,
+  detectSlashTrigger,
+  filterSlashCommands,
+  type SlashCommand
+} from '../slash-commands/registry';
 
 // Per-session draft cache. Survives session switches within a process so
 // users don't lose half-typed prompts when they pop into another session.
@@ -40,6 +47,28 @@ export function InputBar({ sessionId }: { sessionId: string }) {
   // steal focus from wherever the user (or some other auto-focus) put it.
   const focusNonceSeenRef = useRef<number | null>(null);
 
+  // --- Slash-command picker state --------------------------------------
+  // We derive picker openness from (value, caret) rather than storing a
+  // separate `open` flag, so the picker cannot drift out of sync with the
+  // textarea content. `caret` is updated on every keyup/click/select.
+  const [caret, setCaret] = useState(0);
+  // `dismissed` lets the user Esc-out of the picker without needing to
+  // change the textarea content. Any edit re-arms it.
+  const [pickerDismissed, setPickerDismissed] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const trigger = useMemo(() => detectSlashTrigger(value, caret), [value, caret]);
+  const filtered = useMemo<SlashCommand[]>(
+    () => (trigger.active ? filterSlashCommands(SLASH_COMMANDS, trigger.query) : []),
+    [trigger]
+  );
+  const pickerOpen = trigger.active && !pickerDismissed && !running;
+  // Clamp activeIndex whenever the filtered list shrinks.
+  React.useEffect(() => {
+    if (!pickerOpen) return;
+    if (activeIndex >= filtered.length) setActiveIndex(Math.max(0, filtered.length - 1));
+  }, [pickerOpen, filtered.length, activeIndex]);
+
   React.useEffect(() => {
     setValue(draftCache.get(sessionId) ?? '');
   }, [sessionId]);
@@ -66,8 +95,34 @@ export function InputBar({ sessionId }: { sessionId: string }) {
 
   function update(next: string) {
     setValue(next);
+    // Any edit re-arms the picker (so the user can dismiss with Esc, then
+    // keep typing to reopen it if they're still in the `/...` prefix).
+    setPickerDismissed(false);
+    setActiveIndex(0);
+    // Keep caret in sync with the edit — textarea may not have fired
+    // onSelect/onKeyUp yet when onChange lands (and programmatic fills
+    // from Playwright skip those entirely).
+    const el = textareaRef.current;
+    if (el) setCaret(el.selectionStart ?? next.length);
+    else setCaret(next.length);
     if (next) draftCache.set(sessionId, next);
     else draftCache.delete(sessionId);
+  }
+
+  function commitSlashCommand(cmd: SlashCommand) {
+    const next = `/${cmd.name} `;
+    setValue(next);
+    draftCache.set(sessionId, next);
+    setCaret(next.length);
+    setPickerDismissed(true);
+    setActiveIndex(0);
+    // Restore caret to end after React re-renders the textarea.
+    requestAnimationFrame(() => {
+      const el = textareaRef.current;
+      if (!el) return;
+      el.focus();
+      el.setSelectionRange(next.length, next.length);
+    });
   }
 
   async function send() {
@@ -128,10 +183,60 @@ export function InputBar({ sessionId }: { sessionId: string }) {
     // Skip Enter handling while IME composition is active — otherwise CJK
     // candidate selection accidentally sends the message.
     if (e.nativeEvent.isComposing || (e.nativeEvent as { keyCode?: number }).keyCode === 229) return;
+
+    // Slash picker navigation takes precedence when open.
+    if (pickerOpen && filtered.length > 0) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setActiveIndex((i) => (i + 1) % filtered.length);
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setActiveIndex((i) => (i - 1 + filtered.length) % filtered.length);
+        return;
+      }
+      if (e.key === 'Tab') {
+        e.preventDefault();
+        const cmd = filtered[activeIndex];
+        if (cmd) {
+          // Tab = complete-in-place, keep picker open so user can keep
+          // browsing. Insert `/<name>` without trailing space.
+          const next = `/${cmd.name}`;
+          setValue(next);
+          draftCache.set(sessionId, next);
+          setCaret(next.length);
+          requestAnimationFrame(() => {
+            const el = textareaRef.current;
+            if (!el) return;
+            el.setSelectionRange(next.length, next.length);
+          });
+        }
+        return;
+      }
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        const cmd = filtered[activeIndex];
+        if (cmd) commitSlashCommand(cmd);
+        return;
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        setPickerDismissed(true);
+        return;
+      }
+    }
+
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       send();
     }
+  }
+
+  function syncCaret() {
+    const el = textareaRef.current;
+    if (!el) return;
+    setCaret(el.selectionStart ?? 0);
   }
 
   return (
@@ -145,11 +250,21 @@ export function InputBar({ sessionId }: { sessionId: string }) {
           'focus-within:border-accent'
         )}
       >
+        <SlashCommandPicker
+          open={pickerOpen}
+          query={trigger.active ? trigger.query : ''}
+          activeIndex={activeIndex}
+          onActiveIndexChange={setActiveIndex}
+          onSelect={commitSlashCommand}
+        />
         <textarea
           ref={textareaRef}
           value={value}
           onChange={(e) => update(e.target.value)}
           onKeyDown={onKeyDown}
+          onKeyUp={syncCaret}
+          onClick={syncCaret}
+          onSelect={syncCaret}
           rows={2}
           placeholder={running ? 'Running… (input disabled)' : hasMessages ? 'Reply…' : 'Ask anything…'}
           disabled={running}

--- a/src/components/SlashCommandPicker.tsx
+++ b/src/components/SlashCommandPicker.tsx
@@ -1,0 +1,136 @@
+import React, { useEffect, useMemo, useRef } from 'react';
+import { cn } from '../lib/cn';
+import { SLASH_COMMANDS, filterSlashCommands, type SlashCommand } from '../slash-commands/registry';
+
+type Props = {
+  open: boolean;
+  query: string;
+  // Controlled highlighted index into the FILTERED list. The parent owns
+  // this so keyboard navigation fired in the textarea's onKeyDown can
+  // update it without going through focus.
+  activeIndex: number;
+  onActiveIndexChange: (i: number) => void;
+  // Called when user clicks a row — parent then commits the selection
+  // (replace textarea value with `/<name> `).
+  onSelect: (cmd: SlashCommand) => void;
+  onFilteredChange?: (cmds: SlashCommand[]) => void;
+};
+
+// In-chat slash-command picker. Anchored visually above the InputBar by
+// the caller; the component itself is position-relative and fills parent
+// width. Uses no new runtime deps.
+export function SlashCommandPicker({
+  open,
+  query,
+  activeIndex,
+  onActiveIndexChange,
+  onSelect,
+  onFilteredChange
+}: Props) {
+  const listRef = useRef<HTMLDivElement>(null);
+  const rowsRef = useRef<Array<HTMLButtonElement | null>>([]);
+
+  const filtered = useMemo(() => filterSlashCommands(SLASH_COMMANDS, query), [query]);
+
+  useEffect(() => {
+    onFilteredChange?.(filtered);
+  }, [filtered, onFilteredChange]);
+
+  // Auto-scroll the highlighted row into view when navigation moves
+  // outside the visible window.
+  useEffect(() => {
+    if (!open) return;
+    const row = rowsRef.current[activeIndex];
+    if (row && typeof row.scrollIntoView === 'function') {
+      row.scrollIntoView({ block: 'nearest' });
+    }
+  }, [activeIndex, open]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="listbox"
+      aria-label="Slash commands"
+      className={cn(
+        'absolute left-0 right-0 bottom-full mb-1.5 z-30',
+        'rounded-md border border-border-default bg-bg-elevated',
+        'surface-highlight shadow-[var(--surface-shadow)]',
+        'text-sm text-fg-secondary overflow-hidden',
+        'animate-[menuIn_140ms_cubic-bezier(0.32,0.72,0,1)]'
+      )}
+    >
+      <div
+        ref={listRef}
+        className="max-h-[300px] overflow-y-auto py-1"
+      >
+        {filtered.length === 0 ? (
+          <div className="px-3 py-2 text-fg-tertiary text-[12px] leading-[16px]">
+            No matching commands — press Enter to send as a regular message.
+          </div>
+        ) : (
+          filtered.map((cmd, i) => {
+            const Icon = cmd.icon;
+            const active = i === activeIndex;
+            return (
+              <button
+                key={cmd.name}
+                ref={(el) => { rowsRef.current[i] = el; }}
+                role="option"
+                aria-selected={active}
+                type="button"
+                // Use onMouseDown so the textarea doesn't blur before we
+                // get the click — prevents the picker from closing on
+                // focus-out before onSelect fires.
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  onSelect(cmd);
+                }}
+                onMouseEnter={() => onActiveIndexChange(i)}
+                className={cn(
+                  'w-full flex items-center gap-2.5 h-8 pl-3 pr-3',
+                  'text-left select-none outline-none',
+                  'transition-[background-color,box-shadow,border-color] duration-150',
+                  '[transition-timing-function:cubic-bezier(0.32,0.72,0,1)]',
+                  'border-l-2 border-transparent',
+                  active
+                    ? 'bg-bg-hover text-fg-primary border-l-accent shadow-[inset_0_1px_0_0_oklch(1_0_0_/_0.05)]'
+                    : 'hover:bg-bg-hover/60'
+                )}
+              >
+                {Icon ? (
+                  <Icon
+                    size={14}
+                    className={cn(
+                      'shrink-0 stroke-[1.75]',
+                      active ? 'text-accent' : 'text-fg-tertiary'
+                    )}
+                  />
+                ) : (
+                  <span className="w-[14px] shrink-0" />
+                )}
+                <span className="font-mono text-[12.5px] text-fg-primary shrink-0">
+                  /{cmd.name}
+                </span>
+                <span className="text-fg-tertiary text-[12px] leading-[16px] truncate">
+                  {cmd.description}
+                </span>
+                {cmd.category && cmd.category !== 'built-in' ? (
+                  <span className="ml-auto shrink-0 text-[10px] uppercase tracking-wider text-fg-tertiary px-1.5 py-0.5 rounded-sm border border-border-subtle">
+                    {cmd.category}
+                  </span>
+                ) : null}
+              </button>
+            );
+          })
+        )}
+      </div>
+      <div className="px-3 py-1.5 border-t border-border-subtle text-[11px] text-fg-tertiary flex items-center gap-3 select-none bg-bg-panel/40">
+        <span><kbd className="font-mono">↑↓</kbd> navigate</span>
+        <span><kbd className="font-mono">Enter</kbd> select</span>
+        <span><kbd className="font-mono">Tab</kbd> complete</span>
+        <span><kbd className="font-mono">Esc</kbd> close</span>
+      </div>
+    </div>
+  );
+}

--- a/src/slash-commands/registry.ts
+++ b/src/slash-commands/registry.ts
@@ -1,0 +1,102 @@
+// Slash command registry.
+//
+// IMPORTANT: we do NOT interpret or execute these commands. This registry
+// exists purely to drive the in-chat discoverability picker. When the user
+// picks a command, we drop `/<name> ` into the textarea and let them hit
+// Enter — the raw text (including the slash) is passed through to the
+// underlying claude.exe process via the normal user-message path.
+//
+// Which commands actually *respond meaningfully* when sent through
+// `--input-format stream-json` is a separate question (see PR body). For
+// the picker, any command that the CLI exposes at a `/`-prompt is fair
+// game to advertise.
+import {
+  HelpCircle,
+  Eraser,
+  Minimize2,
+  Cpu,
+  Settings,
+  CircleDollarSign,
+  History,
+  Brain,
+  FolderPlus,
+  LogIn,
+  LogOut,
+  Activity,
+  Stethoscope,
+  Bug,
+  Plug,
+  Webhook,
+  Users,
+  FileSearch,
+  type LucideIcon
+} from 'lucide-react';
+
+export type SlashCommandCategory = 'built-in' | 'skill';
+
+export type SlashCommand = {
+  name: string;
+  description: string;
+  icon?: LucideIcon;
+  category?: SlashCommandCategory;
+};
+
+// Order = display order. Keep the most-used ones near the top.
+// Names verified against `claude.exe` interactive REPL prompt (typing `/`).
+export const SLASH_COMMANDS: SlashCommand[] = [
+  { name: 'help',    description: 'List available commands',                       icon: HelpCircle,       category: 'built-in' },
+  { name: 'clear',   description: 'Start a new conversation and clear context',    icon: Eraser,           category: 'built-in' },
+  { name: 'compact', description: 'Summarize conversation to free context',        icon: Minimize2,        category: 'built-in' },
+  { name: 'model',   description: 'Switch model for this session',                 icon: Cpu,              category: 'built-in' },
+  { name: 'config',  description: 'Open settings',                                 icon: Settings,         category: 'built-in' },
+  { name: 'cost',    description: 'Show session cost and token usage',             icon: CircleDollarSign, category: 'built-in' },
+  { name: 'resume',  description: 'Resume a previous session',                     icon: History,          category: 'built-in' },
+  { name: 'memory',  description: 'Manage CLAUDE.md memory',                       icon: Brain,            category: 'built-in' },
+  { name: 'init',    description: 'Initialize CLAUDE.md in current project',       icon: FolderPlus,       category: 'built-in' },
+  { name: 'login',   description: 'Sign in to Claude',                             icon: LogIn,            category: 'built-in' },
+  { name: 'logout',  description: 'Sign out',                                      icon: LogOut,           category: 'built-in' },
+  { name: 'status',  description: 'Show auth and session status',                  icon: Activity,         category: 'built-in' },
+  { name: 'doctor',  description: 'Check installation health',                     icon: Stethoscope,      category: 'built-in' },
+  { name: 'bug',     description: 'Report a bug',                                  icon: Bug,              category: 'built-in' },
+  { name: 'mcp',     description: 'Manage MCP servers',                            icon: Plug,             category: 'built-in' },
+  { name: 'hooks',   description: 'Manage hooks',                                  icon: Webhook,          category: 'built-in' },
+  { name: 'agents',  description: 'Manage custom agents',                          icon: Users,            category: 'built-in' },
+  { name: 'review',  description: 'Review a pull request',                         icon: FileSearch,       category: 'built-in' }
+];
+
+// Pure filter used by the picker and unit tests. Matches a substring against
+// both `name` and `description` (case-insensitive). No fuzzy; MVP.
+export function filterSlashCommands(all: SlashCommand[], query: string): SlashCommand[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return all;
+  return all.filter(
+    (c) => c.name.toLowerCase().includes(q) || c.description.toLowerCase().includes(q)
+  );
+}
+
+// Detects whether the textarea content is currently "typing a slash
+// command" — i.e. it starts with `/` on the first line and the caret sits
+// within that first token (no space encountered yet).
+//
+// Returns { active: true, query } if the picker should open, else
+// { active: false }. Keeping this pure makes it trivial to unit test.
+export type SlashTriggerState =
+  | { active: false }
+  | { active: true; query: string };
+
+export function detectSlashTrigger(value: string, caret: number): SlashTriggerState {
+  if (!value.startsWith('/')) return { active: false };
+  // Must be on the first line — if the user has a multi-line message
+  // starting with `/`, that's almost certainly a real message, not a
+  // command.
+  const firstNewline = value.indexOf('\n');
+  const firstLineEnd = firstNewline === -1 ? value.length : firstNewline;
+  // Caret must fall within the first line.
+  if (caret > firstLineEnd) return { active: false };
+  const firstLine = value.slice(0, firstLineEnd);
+  // No space in the first line = still composing the command name.
+  const firstSpace = firstLine.indexOf(' ');
+  if (firstSpace !== -1) return { active: false };
+  // query = everything after the leading `/` on the first line
+  return { active: true, query: firstLine.slice(1) };
+}

--- a/tests/slash-command-picker.test.tsx
+++ b/tests/slash-command-picker.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SlashCommandPicker } from '../src/components/SlashCommandPicker';
+
+describe('<SlashCommandPicker />', () => {
+  it('renders nothing when closed', () => {
+    const { container } = render(
+      <SlashCommandPicker
+        open={false}
+        query=""
+        activeIndex={0}
+        onActiveIndexChange={() => {}}
+        onSelect={() => {}}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders filtered commands by query', () => {
+    render(
+      <SlashCommandPicker
+        open
+        query="cl"
+        activeIndex={0}
+        onActiveIndexChange={() => {}}
+        onSelect={() => {}}
+      />
+    );
+    expect(screen.getByText('/clear')).toBeInTheDocument();
+    // 'cl' must not match /compact
+    expect(screen.queryByText('/compact')).not.toBeInTheDocument();
+  });
+
+  it('marks the active row as aria-selected', () => {
+    render(
+      <SlashCommandPicker
+        open
+        query=""
+        activeIndex={2}
+        onActiveIndexChange={() => {}}
+        onSelect={() => {}}
+      />
+    );
+    const options = screen.getAllByRole('option');
+    expect(options[2].getAttribute('aria-selected')).toBe('true');
+    expect(options[0].getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('shows the empty state when no commands match', () => {
+    render(
+      <SlashCommandPicker
+        open
+        query="xxxxxnope"
+        activeIndex={0}
+        onActiveIndexChange={() => {}}
+        onSelect={() => {}}
+      />
+    );
+    expect(screen.getByText(/No matching commands/i)).toBeInTheDocument();
+  });
+
+  it('fires onSelect when a row is clicked', () => {
+    const onSelect = vi.fn();
+    render(
+      <SlashCommandPicker
+        open
+        query="help"
+        activeIndex={0}
+        onActiveIndexChange={() => {}}
+        onSelect={onSelect}
+      />
+    );
+    fireEvent.mouseDown(screen.getByText('/help'));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0][0].name).toBe('help');
+  });
+});

--- a/tests/slash-commands-registry.test.ts
+++ b/tests/slash-commands-registry.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SLASH_COMMANDS,
+  filterSlashCommands,
+  detectSlashTrigger
+} from '../src/slash-commands/registry';
+
+describe('filterSlashCommands', () => {
+  it('returns the full list for an empty query', () => {
+    expect(filterSlashCommands(SLASH_COMMANDS, '')).toEqual(SLASH_COMMANDS);
+    expect(filterSlashCommands(SLASH_COMMANDS, '   ')).toEqual(SLASH_COMMANDS);
+  });
+
+  it('matches on command name (case-insensitive substring)', () => {
+    const r = filterSlashCommands(SLASH_COMMANDS, 'cl');
+    expect(r.some((c) => c.name === 'clear')).toBe(true);
+    // 'cl' should NOT accidentally match 'compact'
+    expect(r.some((c) => c.name === 'compact')).toBe(false);
+  });
+
+  it('matches on description words too', () => {
+    const r = filterSlashCommands(SLASH_COMMANDS, 'token');
+    // /cost advertises "token usage" in its description
+    expect(r.some((c) => c.name === 'cost')).toBe(true);
+  });
+
+  it('returns an empty array when nothing matches', () => {
+    expect(filterSlashCommands(SLASH_COMMANDS, 'zzzzzqqq')).toEqual([]);
+  });
+
+  it('does not mutate the input array', () => {
+    const snapshot = [...SLASH_COMMANDS];
+    filterSlashCommands(SLASH_COMMANDS, 'help');
+    expect(SLASH_COMMANDS).toEqual(snapshot);
+  });
+});
+
+describe('detectSlashTrigger', () => {
+  it('is inactive for empty input', () => {
+    expect(detectSlashTrigger('', 0)).toEqual({ active: false });
+  });
+
+  it('is inactive for non-slash input', () => {
+    expect(detectSlashTrigger('hello', 3)).toEqual({ active: false });
+  });
+
+  it('activates on a bare slash', () => {
+    expect(detectSlashTrigger('/', 1)).toEqual({ active: true, query: '' });
+  });
+
+  it('extracts the partial command name as query', () => {
+    expect(detectSlashTrigger('/cl', 3)).toEqual({ active: true, query: 'cl' });
+    expect(detectSlashTrigger('/clear', 6)).toEqual({ active: true, query: 'clear' });
+  });
+
+  it('closes once the user types a space (now composing args)', () => {
+    expect(detectSlashTrigger('/clear ', 7)).toEqual({ active: false });
+    expect(detectSlashTrigger('/clear arg1', 11)).toEqual({ active: false });
+  });
+
+  it('does not activate when slash is mid-sentence', () => {
+    // e.g. "hey /help me" — leading char isn't `/`
+    expect(detectSlashTrigger('hey /help', 9)).toEqual({ active: false });
+  });
+
+  it('does not activate when caret is on a later line', () => {
+    // Value starts with `/`, but the caret is already past the first line →
+    // they're writing a multi-line message, not still naming the command.
+    const v = '/foo\nmore text';
+    const caret = v.length;
+    expect(detectSlashTrigger(v, caret)).toEqual({ active: false });
+  });
+
+  it('activates when slash is on first line and caret is still on it', () => {
+    const v = '/foo\nmore text';
+    expect(detectSlashTrigger(v, 3)).toEqual({ active: true, query: 'foo' });
+  });
+});


### PR DESCRIPTION
## Summary

Adds an in-chat slash-command picker to `InputBar`. When the user types `/` at the start of the textarea, a listbox of commands appears above the input; `/name ` is inserted on Enter/Tab/click and the raw text is passed through to `claude.exe` via the existing `agentSend` path. **We do not interpret or execute commands ourselves** — this is pure discoverability UX, matching Claude Desktop / VS Code.

## Design notes

- **Trigger**: textarea starts with `/`, caret is on the first line, no space in the first token. Space, newline, or mid-sentence `/` keeps the picker closed. `Esc` dismisses without wiping text; further edits re-arm.
- **Keybinds**: `ArrowUp`/`Down` navigate (wrap). `Enter` commits `/<name> ` and closes. `Tab` completes in place without the trailing space (keeps picker open). `Esc` dismisses. Normal `Enter`-to-send is suppressed while the picker is open.
- **Caret sync**: tracked via `onKeyUp`/`onClick`/`onSelect` AND inside `onChange` — the second path matters because programmatic fills (Playwright, paste-like operations) do not fire the keyboard/selection events, and the picker would otherwise think the caret hadn't moved.
- **Visual**: mono command names, muted descriptions, left-border accent on active row, 300px max height with auto-scroll-into-view, keyboard hint footer. Uses existing `menuIn` keyframe and app tokens; no new runtime deps.
- **Registry**: 18 commands verified from `claude.exe --help` + REPL (`/help /clear /compact /model /config /cost /resume /memory /init /login /logout /status /doctor /bug /mcp /hooks /agents /review`).

## stream-json pass-through caveat

I ran a sanity probe piping `{ type: 'user', message: { role: 'user', content: '/<name>' } }` into `claude.exe -p --input-format stream-json --output-format stream-json`. **Slash commands appear to be silently dropped** in stream-json mode: the run emits only `SessionStart` hook frames and exits cleanly with no `assistant`/`result` frames. A normal user message (`reply with pong`) through the same harness produced the expected `system / assistant / message / text / result` frame sequence.

So for now, the picker is useful purely for **typing assistance and discoverability** — pressing Enter on `/clear` in Agentory sends the text to claude.exe, but claude.exe does not act on it. This is a claude.exe limitation, not ours; re-evaluate once CLI exposes a stream-json control surface for slash commands.

## Follow-ups (out of scope for this PR)

- Fuzzy matching (cmdk or similar) once the command list grows.
- Dynamic skill discovery from `claude.exe` / user plugin dirs.
- Inline arg hints (`/model <name>` etc.) once stream-json honors commands.
- Renderer-side shims for high-value commands (`/clear` as a local session-reset) if claude.exe never picks up stream-json slashes.

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — clean (pre-existing `CommandPalette` warning unchanged).
- [x] `npm test` — 339/339 green; new suites: `slash-commands-registry` (13) and `slash-command-picker` (5).
- [x] Live probe `scripts/probe-slash-commands.mjs` against `AGENTORY_DEV_PORT=4184 npm run dev:web` — all six scenarios pass (open, filter, commit, space-closes, Esc-preserves, mid-sentence-no-open, empty-state).

Generated with [Claude Code](https://claude.com/claude-code)