### PR TITLE
fix(permission): align mode names with official CLI flags

### DIFF
--- a/electron/agent/sessions.ts
+++ b/electron/agent/sessions.ts
@@ -11,12 +11,21 @@ import {
   type ParsedStreamEvent,
 } from './control-rpc';
 
-// Permission mode accepted across the IPC boundary. The renderer translates
-// its UI-level modes (`plan`/`ask`/`auto`/`yolo`) via `toSdkPermissionMode`
-// in `src/agent/permission.ts` before calling agent:start / set-permission.
-// We still accept SDK-only legacy modes here so an older renderer build
-// doesn't break the spawner; unknown modes coerce to `'default'`.
-export type PermissionMode = CliPermissionMode | 'dontAsk' | 'auto';
+// Permission mode accepted across the IPC boundary. Values match the CLI's
+// `--permission-mode` flag 1:1 — the renderer's `PermissionMode` enum is
+// already aligned, so no translation is needed.
+//
+// We still accept legacy UI-only modes (`'dontAsk'`, `'auto'`, and the older
+// `'ask'` / `'yolo'` / `'standard'`) here so an older renderer build doesn't
+// break the spawner. Unknown values coerce to `'default'` in
+// `toCliPermissionMode` below.
+export type PermissionMode =
+  | CliPermissionMode
+  | 'dontAsk'
+  | 'auto'
+  | 'ask'
+  | 'yolo'
+  | 'standard';
 
 // IPC payload mirrors the on-wire stream-json events from claude.exe stdout.
 export type AgentMessage = ClaudeStreamEvent;
@@ -42,16 +51,35 @@ function resolveConfigDir(explicit: string | undefined): string {
 }
 
 /**
- * `PermissionMode` includes UI-only modes (`'dontAsk'`, `'auto'`) that the
- * claude.exe CLI doesn't accept. Drop them to `'default'` rather than passing
- * an invalid value to the spawner.
+ * Coerce any incoming permission mode to a CLI-accepted value. Handles:
+ *   - current UI enum (already CLI-aligned): passes through
+ *   - legacy UI aliases (`ask` → `default`, `yolo` → `bypassPermissions`, ...)
+ *   - SDK-only literals (`dontAsk` → `default`, `auto` → `acceptEdits`*)
+ *     *Note: the CLI's real classifier-driven `auto` mode is NOT accepted
+ *     here by design — we never surface it in the UI, so an `auto` on the
+ *     wire must be our legacy alias for `acceptEdits`.
+ * Unknown strings coerce to `'default'` rather than passing an invalid flag
+ * value to claude.exe.
  */
 function toCliPermissionMode(mode: PermissionMode | undefined): CliPermissionMode | undefined {
   if (!mode) return undefined;
-  if (mode === 'default' || mode === 'acceptEdits' || mode === 'plan' || mode === 'bypassPermissions') {
-    return mode;
+  switch (mode) {
+    case 'default':
+    case 'acceptEdits':
+    case 'plan':
+    case 'bypassPermissions':
+      return mode;
+    case 'ask':
+    case 'standard':
+    case 'dontAsk':
+      return 'default';
+    case 'auto':
+      return 'acceptEdits';
+    case 'yolo':
+      return 'bypassPermissions';
+    default:
+      return 'default';
   }
-  return 'default';
 }
 
 export type StartOptions = {

--- a/scripts/probe-permission-mode-chip.mjs
+++ b/scripts/probe-permission-mode-chip.mjs
@@ -1,0 +1,154 @@
+// Probe: the StatusBar permission-mode chip shows the official CLI names.
+//
+// Strategy: render against the webpack dev server (no Electron needed — this
+// is pure DOM/state). Seed one session, open each menu option, and assert the
+// chip label + tooltip match the target table. Finally screenshot the chip
+// in its default state for visual review.
+//
+// Usage: AGENTORY_DEV_PORT=4185 npm run dev:web (background), then
+//   node scripts/probe-permission-mode-chip.mjs
+import { chromium } from 'playwright';
+
+const PORT = process.env.AGENTORY_DEV_PORT ?? '4185';
+const URL = `http://localhost:${PORT}/`;
+
+const EXPECTED = [
+  { value: 'plan', primary: 'Plan', secondary: /Read-only analysis/i },
+  { value: 'default', primary: 'Default', secondary: /Auto-approve reads\. Ask before edits and shell/i },
+  { value: 'acceptEdits', primary: 'Accept Edits', secondary: /Auto-approve reads and edits\. Ask before shell/i },
+  { value: 'bypassPermissions', primary: 'Bypass Permissions', secondary: /Auto-approve everything/i }
+];
+
+function fail(msg) {
+  console.error(`\n[probe-permission-mode-chip] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext();
+const page = await ctx.newPage();
+
+const errors = [];
+page.on('pageerror', (e) => errors.push(`[pageerror] ${e.message}`));
+page.on('console', (m) => {
+  if (m.type() === 'error') errors.push(`[console.error] ${m.text()}`);
+});
+
+await page.goto(URL, { waitUntil: 'networkidle' });
+await page.waitForSelector('aside', { timeout: 15_000 });
+
+// Seed one session so the StatusBar chip renders.
+const newBtn = page.getByRole('button', { name: /new session/i }).first();
+await newBtn.waitFor({ state: 'visible', timeout: 10_000 });
+await newBtn.click();
+await page.waitForTimeout(300);
+
+// Iterate over each expected permission value, set it in the store, then
+// confirm the chip's visible label matches. This catches both the option
+// table AND the chip's `primaryOf` rendering in one pass.
+for (const { value, primary, secondary } of EXPECTED) {
+  await page.evaluate((v) => {
+    const s = window.__agentoryStore.getState();
+    s.setPermission(v);
+  }, value);
+  await page.waitForTimeout(80);
+
+  const chipLabel = await page.evaluate(() => {
+    // Find the permission chip: it's the third ChipMenu in the status bar.
+    // Grab all buttons inside the status bar (the .h-6 font-mono row) and
+    // pluck the last one — cwd / model / permission, in that order.
+    const bar = document.querySelector('div.h-6.px-4');
+    if (!bar) return null;
+    const btns = bar.querySelectorAll('button');
+    const last = btns[btns.length - 1];
+    if (!last) return null;
+    // The chip renders: <text> + <ChevronDown /> — ChevronDown is SVG so
+    // textContent is just the label. Trim to be safe.
+    return { text: last.textContent?.trim() ?? '', title: last.getAttribute('title') ?? '' };
+  });
+
+  if (!chipLabel) {
+    await browser.close();
+    fail(`could not locate permission chip for value=${value}`);
+  }
+  if (chipLabel.text !== primary) {
+    await browser.close();
+    fail(`value=${value}: chip label expected ${JSON.stringify(primary)}, got ${JSON.stringify(chipLabel.text)}`);
+  }
+  if (!chipLabel.title || chipLabel.title.length < 10) {
+    await browser.close();
+    fail(`value=${value}: chip tooltip missing or too short: ${JSON.stringify(chipLabel.title)}`);
+  }
+  console.log(`  ${value}: chip="${chipLabel.text}" tooltip OK`);
+
+  // Also open the dropdown and verify the corresponding item's secondary
+  // copy is present (no friendlier relabelling).
+  // Click the chip to open the menu.
+  const bar = page.locator('div.h-6.px-4');
+  await bar.locator('button').last().click();
+  // Menu is in a portal — wait for any item bearing the primary text.
+  const item = page.getByRole('menuitem', { name: new RegExp(`^${primary}`, 'i') }).first();
+  await item.waitFor({ state: 'visible', timeout: 5000 });
+  const itemText = (await item.textContent()) ?? '';
+  if (!secondary.test(itemText)) {
+    await browser.close();
+    fail(`value=${value}: menu item secondary copy mismatch. full itemText=${JSON.stringify(itemText)}, expected to match ${secondary}`);
+  }
+  console.log(`    menu item secondary OK: ${JSON.stringify(itemText.replace(primary, '').trim())}`);
+  // Close the menu by pressing Escape so the next iteration starts clean.
+  await page.keyboard.press('Escape');
+  await page.waitForTimeout(80);
+}
+
+// Verify the `bypassPermissions` chip gets the warn accent class.
+await page.evaluate(() => {
+  window.__agentoryStore.getState().setPermission('bypassPermissions');
+});
+await page.waitForTimeout(80);
+const warnClassFound = await page.evaluate(() => {
+  const bar = document.querySelector('div.h-6.px-4');
+  if (!bar) return false;
+  const btns = bar.querySelectorAll('button');
+  const last = btns[btns.length - 1];
+  return !!last && last.className.includes('state-warning');
+});
+if (!warnClassFound) {
+  await browser.close();
+  fail('expected `bypassPermissions` chip to wear the warn accent (text-state-warning class)');
+}
+console.log('  bypassPermissions chip wears the warn accent OK');
+
+// Confirm no UI references to the retired literals `standard` / `yolo` / `ask`
+// leak through. Scan the status bar + any open menus.
+await page.evaluate(() => window.__agentoryStore.getState().setPermission('default'));
+await page.waitForTimeout(80);
+// Open the menu one last time to scan all four items at once.
+await page.locator('div.h-6.px-4 button').last().click();
+await page.waitForTimeout(150);
+const leaked = await page.evaluate(() => {
+  const text = document.body.innerText;
+  const offenders = [];
+  for (const bad of [/\byolo\b/i, /\bstandard\b/i, /\bask-all\b/i]) {
+    const m = text.match(bad);
+    if (m) offenders.push(m[0]);
+  }
+  return offenders;
+});
+if (leaked.length > 0) {
+  await browser.close();
+  fail(`found retired permission wording in UI: ${leaked.join(', ')}`);
+}
+await page.keyboard.press('Escape');
+console.log('  no retired literals (yolo/standard/ask-all) present OK');
+
+// Screenshot the status bar in its default permission state for visual review.
+await page.screenshot({ path: 'scripts/_permission-mode-chip.png', fullPage: false });
+console.log('screenshot saved to scripts/_permission-mode-chip.png');
+
+if (errors.length > 0) {
+  console.error('--- console / page errors ---');
+  for (const e of errors) console.error(e);
+}
+
+console.log('\n[probe-permission-mode-chip] OK');
+await browser.close();

--- a/src/agent/permission.ts
+++ b/src/agent/permission.ts
@@ -1,19 +1,8 @@
-import type { PermissionMode } from '../stores/store';
-
 // CLI-accepted permission modes (claude.exe `--permission-mode` flag and the
 // `set_permission_mode` control_request). Local copy so the renderer doesn't
 // drag in the SDK just for a string union.
+//
+// The CLI also accepts `auto` (classifier-driven research-preview) and
+// `dontAsk` (legacy alias for `default`). We don't surface them in the UI;
+// see `PermissionMode` in `src/stores/store.ts` for the rationale.
 export type CliPermissionMode = 'default' | 'acceptEdits' | 'plan' | 'bypassPermissions';
-
-export function toSdkPermissionMode(mode: PermissionMode): CliPermissionMode {
-  switch (mode) {
-    case 'plan':
-      return 'plan';
-    case 'ask':
-      return 'default';
-    case 'auto':
-      return 'acceptEdits';
-    case 'yolo':
-      return 'bypassPermissions';
-  }
-}

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -3,7 +3,6 @@ import { ArrowUp, Square } from 'lucide-react';
 import { cn } from '../lib/cn';
 import { Button } from './ui/Button';
 import { useStore } from '../stores/store';
-import { toSdkPermissionMode } from '../agent/permission';
 import { SlashCommandPicker } from './SlashCommandPicker';
 import {
   SLASH_COMMANDS,
@@ -144,7 +143,7 @@ export function InputBar({ sessionId }: { sessionId: string }) {
       const res = await api.agentStart(sessionId, {
         cwd: session.cwd,
         model: session.model || undefined,
-        permissionMode: toSdkPermissionMode(permission),
+        permissionMode: permission,
         resumeSessionId: session.resumeSessionId,
         endpointId
       });

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -11,7 +11,15 @@ import {
 } from './ui/DropdownMenu';
 import { useStore } from '../stores/store';
 
-type PermissionMode = 'plan' | 'ask' | 'auto' | 'yolo';
+// Permission mode values match claude.exe's `--permission-mode` flag 1:1.
+// We intentionally use the official CLI names (title-cased for display)
+// rather than invented shortnames like `yolo` / `standard`. The CLI also
+// accepts `auto` (classifier-driven, research-preview, requires account
+// enablement) and `dontAsk` (legacy alias for `default`). We omit `auto`
+// from the chip to keep the picker simple and avoid exposing a mode most
+// users can't enable; we omit `dontAsk` because it's redundant with
+// `default`.
+type PermissionMode = 'plan' | 'default' | 'acceptEdits' | 'bypassPermissions';
 
 function lastSegment(path: string): string {
   const trimmed = path.replace(/[\\/]+$/, '');
@@ -116,22 +124,22 @@ function ChipMenu<V extends string>({
 
 const BROWSE_FOLDER = '__browse__';
 
-// Labels describe what claude.exe actually does per mode. There is no CLI
-// setting that prompts on every single tool — reads are always auto-approved
-// below `bypassPermissions` and above `plan`. The chip wording reflects that
-// instead of promising behaviour the CLI can't deliver.
+// Labels describe what claude.exe actually does per mode, and the `primary`
+// string is the official CLI flag value title-cased. `default` prompts before
+// any tool use that isn't a read; reads are auto-approved. `acceptEdits` adds
+// file-edit auto-approval on top. `bypassPermissions` skips every check.
 const permissionOptions: ChipOption<PermissionMode>[] = [
-  { kind: 'item', value: 'plan', primary: 'plan', secondary: 'Plan only — no edits or commands' },
-  { kind: 'item', value: 'ask', primary: 'standard', secondary: 'Auto-approve reads; ask before writes, edits, and shell' },
-  { kind: 'item', value: 'auto', primary: 'auto', secondary: 'Auto-approve reads and edits; ask before shell' },
-  { kind: 'item', value: 'yolo', primary: 'yolo', secondary: 'Auto-approve everything (use with care)' }
+  { kind: 'item', value: 'plan', primary: 'Plan', secondary: 'Read-only analysis. No edits, no shell.' },
+  { kind: 'item', value: 'default', primary: 'Default', secondary: 'Auto-approve reads. Ask before edits and shell.' },
+  { kind: 'item', value: 'acceptEdits', primary: 'Accept Edits', secondary: 'Auto-approve reads and edits. Ask before shell.' },
+  { kind: 'item', value: 'bypassPermissions', primary: 'Bypass Permissions', secondary: 'Auto-approve everything. Use with care.' }
 ];
 
 const permissionTooltips: Record<PermissionMode, string> = {
-  plan: 'Plan mode — agent drafts a plan; no file edits or shell until you approve',
-  ask: 'Standard — reads auto-approved; writes, edits, and shell require confirmation',
-  auto: 'Auto-accept edits — reads and file edits auto-approved; shell requires confirmation',
-  yolo: 'Bypass all permission checks — every tool call runs without asking'
+  plan: 'Plan mode — read-only analysis; no file edits or shell until you approve.',
+  default: 'Default — auto-approve reads; ask before edits and shell.',
+  acceptEdits: 'Accept Edits — auto-approve reads and file edits; ask before shell.',
+  bypassPermissions: 'Bypass Permissions — every tool call runs without asking. Use with care.'
 };
 
 function primaryOf<V extends string>(options: ChipOption<V>[], value: V): string {
@@ -244,7 +252,7 @@ export function StatusBar({
       label="Permission mode"
       triggerLabel={primaryOf(permissionOptions, permission)}
       triggerTitle={permissionTooltips[permission]}
-      triggerAccent={permission === 'yolo' ? 'warn' : undefined}
+      triggerAccent={permission === 'bypassPermissions' ? 'warn' : undefined}
       options={permissionOptions}
       onSelect={onChangePermission}
     />

--- a/src/stores/persist.ts
+++ b/src/stores/persist.ts
@@ -16,7 +16,10 @@ export interface PersistedState {
   groups: Group[];
   activeId: string;
   model: string;
-  permission: PermissionMode;
+  // Loose type: older builds persisted legacy literals like `standard` /
+  // `ask` / `auto` / `yolo`. `migratePermission` in store.ts normalises on
+  // read. Writes always use the current `PermissionMode`.
+  permission: PermissionMode | string;
   sidebarCollapsed: boolean;
   theme?: Theme;
   fontSize?: FontSize;

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -1,11 +1,17 @@
 import { create } from 'zustand';
 import type { RecentProject } from '../mock/data';
-import { toSdkPermissionMode } from '../agent/permission';
 import type { Group, Session, MessageBlock } from '../types';
 import { loadPersisted, schedulePersist, type PersistedState } from './persist';
 
 export type ModelId = string;
-export type PermissionMode = 'plan' | 'ask' | 'auto' | 'yolo';
+// Values match the CLI's `--permission-mode` flag 1:1 so we can pass the enum
+// value straight through to claude.exe without a translation table. The CLI
+// also accepts `auto` (classifier-driven research-preview, gated on
+// Sonnet 4.6+ / account flag) and `dontAsk` (legacy alias for `default`). We
+// intentionally do NOT expose either here: `auto` requires capabilities users
+// can't self-enable today and would collide with our old UI value of the same
+// name; `dontAsk` is legacy and redundant.
+export type PermissionMode = 'plan' | 'default' | 'acceptEdits' | 'bypassPermissions';
 export type Theme = 'system' | 'light' | 'dark';
 export type FontSize = 'sm' | 'md' | 'lg';
 
@@ -157,6 +163,31 @@ function nextId(prefix: string): string {
   return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
 }
 
+// One-shot migration for persisted permission values. Legacy builds wrote
+// `standard` / `ask` / `auto` / `yolo` into the JSON blob; map them to the
+// official CLI names so no user sees an "undefined" permission chip after
+// upgrading. Unknown strings coerce to `default`.
+export function migratePermission(raw: unknown): PermissionMode {
+  switch (raw) {
+    case 'plan':
+    case 'default':
+    case 'acceptEdits':
+    case 'bypassPermissions':
+      return raw;
+    case 'standard':
+    case 'ask':
+      return 'default';
+    // Legacy `auto` was our alias for `acceptEdits`, NOT the CLI's
+    // classifier-driven `auto`. Migrate to what the user actually had.
+    case 'auto':
+      return 'acceptEdits';
+    case 'yolo':
+      return 'bypassPermissions';
+    default:
+      return 'default';
+  }
+}
+
 function firstUsableGroupId(groups: Group[]): string {
   const g = groups.find((x) => x.kind === 'normal');
   return g ? g.id : groups[0]?.id ?? 'g1';
@@ -177,7 +208,7 @@ export const useStore = create<State & Actions>((set, get) => ({
   activeId: '',
   focusedGroupId: null,
   model: '',
-  permission: 'auto',
+  permission: 'default',
   sidebarCollapsed: false,
   theme: 'system',
   fontSize: 'md',
@@ -391,9 +422,9 @@ export const useStore = create<State & Actions>((set, get) => ({
     set({ permission });
     const api = window.agentory;
     if (!api) return;
-    const sdkMode = toSdkPermissionMode(permission);
+    // The enum value IS the CLI flag value — no translation needed.
     const started = Object.keys(get().startedSessions);
-    for (const id of started) void api.agentSetPermissionMode(id, sdkMode);
+    for (const id of started) void api.agentSetPermissionMode(id, permission);
   },
   setSidebarCollapsed: (collapsed) => set({ sidebarCollapsed: collapsed }),
   toggleSidebar: () => set((s) => ({ sidebarCollapsed: !s.sidebarCollapsed })),
@@ -711,7 +742,7 @@ export async function hydrateStore(): Promise<void> {
       groups: persisted.groups,
       activeId: stillActive ? persisted.activeId : persisted.sessions[0]?.id ?? '',
       model: persisted.model,
-      permission: persisted.permission,
+      permission: migratePermission(persisted.permission),
       sidebarCollapsed: persisted.sidebarCollapsed ?? false,
       theme: persisted.theme ?? 'system',
       fontSize: persisted.fontSize ?? 'md',

--- a/tests/permission.test.ts
+++ b/tests/permission.test.ts
@@ -1,20 +1,44 @@
 import { describe, it, expect } from 'vitest';
-import { toSdkPermissionMode } from '../src/agent/permission';
 import type { PermissionMode } from '../src/stores/store';
+import { migratePermission } from '../src/stores/store';
+import type { CliPermissionMode } from '../src/agent/permission';
 
-describe('toSdkPermissionMode', () => {
-  it('maps every UI mode to a CLI-accepted value', () => {
-    const cases: Array<[PermissionMode, string]> = [
-      ['plan', 'plan'],
-      // `ask` is labelled "standard" in the UI; it maps to CLI `default`,
-      // which auto-approves reads and prompts on writes/shell. The CLI has
-      // no "ask on every tool" mode.
-      ['ask', 'default'],
-      ['auto', 'acceptEdits'],
-      ['yolo', 'bypassPermissions']
-    ];
-    for (const [ui, cli] of cases) {
-      expect(toSdkPermissionMode(ui)).toBe(cli);
+// The renderer's PermissionMode values match the CLI's `--permission-mode`
+// flag 1:1 — we no longer translate between them. This test enforces the
+// alignment so a future rename can't silently desync UI and CLI again.
+describe('PermissionMode is CLI-aligned', () => {
+  it('every UI enum value is a valid CLI flag value', () => {
+    const uiValues: PermissionMode[] = ['plan', 'default', 'acceptEdits', 'bypassPermissions'];
+    const cliValues: CliPermissionMode[] = ['default', 'acceptEdits', 'plan', 'bypassPermissions'];
+    for (const v of uiValues) {
+      expect(cliValues).toContain(v);
     }
+  });
+});
+
+describe('migratePermission (legacy persisted values)', () => {
+  const cases: Array<[unknown, PermissionMode]> = [
+    // Identity for current enum values.
+    ['plan', 'plan'],
+    ['default', 'default'],
+    ['acceptEdits', 'acceptEdits'],
+    ['bypassPermissions', 'bypassPermissions'],
+    // Legacy UI literals → official CLI names.
+    ['standard', 'default'],
+    ['ask', 'default'],
+    // Legacy UI `auto` was our alias for `acceptEdits`, NOT the CLI's
+    // classifier-driven `auto`. Must migrate to `acceptEdits`.
+    ['auto', 'acceptEdits'],
+    ['yolo', 'bypassPermissions'],
+    // Unknown / malformed → safe fallback.
+    ['something-weird', 'default'],
+    ['', 'default'],
+    [null, 'default'],
+    [undefined, 'default'],
+    [42, 'default']
+  ];
+
+  it.each(cases)('migrates %p → %p', (raw, want) => {
+    expect(migratePermission(raw)).toBe(want);
   });
 });


### PR DESCRIPTION
## Summary
Align our permission-mode names with `claude.exe`'s `--permission-mode` flag values 1:1. Retires invented labels (`yolo`, `standard`) and fixes a name collision where our UI `auto` mapped to CLI `acceptEdits` while the CLI itself has a real (but different) `auto` mode.

### Before / after labels

| Old UI value | Old label  | Mapped CLI value     | New UI value         | New label             |
|--------------|------------|----------------------|----------------------|-----------------------|
| `plan`       | plan       | `plan`               | `plan`               | Plan                  |
| `ask`        | standard   | `default`            | `default`            | Default               |
| `auto`       | auto       | `acceptEdits`        | `acceptEdits`        | Accept Edits          |
| `yolo`       | yolo       | `bypassPermissions`  | `bypassPermissions`  | Bypass Permissions    |

### Why
- Official alignment: CLI docs, VS Code extension, and Desktop all use these names. Inventing `yolo` / `standard` was a divergence with no upside.
- Fixes the **`auto` name collision**: our UI's `auto` meant "auto-approve edits", but the CLI's real `auto` is a classifier-driven mode. Users reading docs and toggling our UI would get mismatched mental models.
- With the enum already CLI-aligned, `toSdkPermissionMode` becomes redundant and goes away — the chip value passes straight through IPC as the flag value. One fewer translation table, one fewer bug surface.

### Migration for existing installs
`hydrateStore` runs `migratePermission` over the persisted `permission` value on first boot after upgrade:

| Persisted value | New value            |
|-----------------|----------------------|
| `plan`          | `plan`               |
| `standard`      | `default`            |
| `ask`           | `default`            |
| `auto`          | `acceptEdits`        |
| `yolo`          | `bypassPermissions`  |
| anything else   | `default`            |

`sessions.ts::toCliPermissionMode` also widened to accept legacy literals from the wire, in case an older renderer build talks to a newer main process mid-rollout.

### Decision: do we expose CLI's `auto` (classifier mode)?
**No, not in this PR.** It's a research-preview requiring Sonnet 4.6+ and account-level enablement, so surfacing it without subtitle gating would break for most users. Comment left in `src/stores/store.ts` and `src/components/StatusBar.tsx` so the next person considering it has context.

## Test plan
- [x] `npm run typecheck` clean (both renderer and electron tsconfigs)
- [x] `npm run lint` clean (no new warnings; pre-existing CommandPalette warning unchanged)
- [x] `npm test` all 334 tests green, including 14 new/updated cases in `tests/permission.test.ts` (CLI alignment assertion + exhaustive legacy migration table)
- [x] Live probe `scripts/probe-permission-mode-chip.mjs`:
  - Iterates all four enum values, asserts chip label + tooltip + menu secondary copy
  - Asserts `bypassPermissions` wears the warn accent class
  - Fails if any retired literal (`yolo` / `standard` / `ask-all`) leaks into the rendered UI
- [x] `--permission-mode` argv build continues to be covered by `electron/agent/__tests__/claude-spawner.test.ts` (already tests `acceptEdits` and `plan` as flag values). Full E2E of "Bypass → destructive tool runs without prompt, Default → prompt appears" deferred to manual verification — requires a real CLI auth in the probe env, which our probe setup doesn't have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)