### PR TITLE
feat(input): drag-drop and paste image attachments

### DIFF
--- a/electron/agent/__tests__/control-rpc.test.ts
+++ b/electron/agent/__tests__/control-rpc.test.ts
@@ -345,6 +345,27 @@ describe('ControlRpc — user messages and lifecycle', () => {
     expect(typeof frame.uuid).toBe('string');
   });
 
+  it('sendUserMessageContent forwards a content-block array verbatim', () => {
+    const m = makeStdin();
+    const rpc = new ControlRpc(m.stdin, { onCanUseTool: allowAll });
+    const content = [
+      { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'AAAA' } },
+      { type: 'text', text: 'what is this?' },
+    ];
+    rpc.sendUserMessageContent(content, 'cli_session_99');
+    const [frame] = m.lines() as Array<Record<string, unknown>>;
+    expect(frame.type).toBe('user');
+    expect(frame.session_id).toBe('cli_session_99');
+    expect((frame.message as { content: unknown }).content).toEqual(content);
+  });
+
+  it('sendUserMessageContent throws after close', () => {
+    const m = makeStdin();
+    const rpc = new ControlRpc(m.stdin, { onCanUseTool: allowAll });
+    rpc.close();
+    expect(() => rpc.sendUserMessageContent([{ type: 'text', text: 'x' }])).toThrow(/closed/);
+  });
+
   it('sending after close throws a friendly error (not EPIPE)', () => {
     const m = makeStdin();
     const rpc = new ControlRpc(m.stdin, { onCanUseTool: allowAll });

--- a/electron/agent/control-rpc.ts
+++ b/electron/agent/control-rpc.ts
@@ -479,6 +479,20 @@ export class ControlRpc {
    * `UserMessageEventSchema.session_id` is OPTIONAL in stream-json types.)
    */
   sendUserMessage(text: string, sessionId?: string): void {
+    this.sendUserMessageContent([{ type: 'text', text }], sessionId);
+  }
+
+  /**
+   * Send a user message whose `content` is a pre-built array of Anthropic
+   * content blocks (text / image / etc.). Used by the image drop/paste flows
+   * where the renderer assembles `{type:'image', source:{type:'base64', ...}}`
+   * alongside the text block.
+   *
+   * `UserMessageEventSchema.content` already accepts `z.array(ContentBlockSchema)`,
+   * and `ContentBlockSchema` uses `.passthrough()` with unknown types falling
+   * through, so `image` blocks flow end-to-end without schema changes.
+   */
+  sendUserMessageContent(content: readonly unknown[], sessionId?: string): void {
     if (this.closed) {
       throw new Error('ControlRpc: closed; cannot send user message');
     }
@@ -493,7 +507,7 @@ export class ControlRpc {
       ...(sessionId ? { session_id: sessionId } : {}),
       parent_tool_use_id: null,
       isSynthetic: false,
-      message: { role: 'user', content: [{ type: 'text', text }] },
+      message: { role: 'user', content },
     });
   }
 

--- a/electron/agent/manager.ts
+++ b/electron/agent/manager.ts
@@ -41,6 +41,17 @@ class SessionsManager {
     return true;
   }
 
+  /**
+   * Forward a prebuilt Anthropic content-block array (text + image blocks
+   * etc.) to the session's stdin. Used by image drop/paste flows.
+   */
+  sendContent(sessionId: string, content: readonly unknown[]): boolean {
+    const r = this.runners.get(sessionId);
+    if (!r) return false;
+    r.sendContent(content);
+    return true;
+  }
+
   async interrupt(sessionId: string): Promise<boolean> {
     const r = this.runners.get(sessionId);
     if (!r) return false;

--- a/electron/agent/sessions.ts
+++ b/electron/agent/sessions.ts
@@ -235,6 +235,20 @@ export class SessionRunner {
     }
   }
 
+  /**
+   * Send a user message carrying a prebuilt Anthropic content-block array
+   * (e.g. text + image blocks). Image drop/paste flows route through here
+   * instead of `send(text)`.
+   */
+  sendContent(content: readonly unknown[]): void {
+    if (!this.rpc || this.disposed) return;
+    try {
+      this.rpc.sendUserMessageContent(content, this.cliSessionId);
+    } catch (err) {
+      console.warn('[sessions] sendUserMessageContent failed', err);
+    }
+  }
+
   async interrupt(): Promise<void> {
     if (!this.rpc) return;
     try {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -335,6 +335,11 @@ app.whenReady().then(() => {
   ipcMain.handle('agent:send', (_e, sessionId: string, text: string) =>
     sessions.send(sessionId, text)
   );
+  ipcMain.handle(
+    'agent:sendContent',
+    (_e, sessionId: string, content: unknown[]) =>
+      sessions.sendContent(sessionId, Array.isArray(content) ? content : [])
+  );
   ipcMain.handle('agent:interrupt', (_e, sessionId: string) => sessions.interrupt(sessionId));
   ipcMain.handle('agent:setPermissionMode', (_e, sessionId: string, mode: PermissionMode) =>
     sessions.setPermissionMode(sessionId, mode)

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -77,6 +77,12 @@ const api = {
     ipcRenderer.invoke('agent:start', sessionId, opts),
   agentSend: (sessionId: string, text: string): Promise<boolean> =>
     ipcRenderer.invoke('agent:send', sessionId, text),
+  /**
+   * Send a user message carrying a prebuilt Anthropic content-block array
+   * (text + image blocks etc.). Image drop/paste goes through this channel.
+   */
+  agentSendContent: (sessionId: string, content: unknown[]): Promise<boolean> =>
+    ipcRenderer.invoke('agent:sendContent', sessionId, content),
   agentInterrupt: (sessionId: string): Promise<boolean> =>
     ipcRenderer.invoke('agent:interrupt', sessionId),
   agentSetPermissionMode: (sessionId: string, mode: PermissionMode): Promise<boolean> =>

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -63,6 +63,12 @@ export default [
         MouseEvent: 'readonly',
         FocusEvent: 'readonly',
         DragEvent: 'readonly',
+        File: 'readonly',
+        FileList: 'readonly',
+        FileReader: 'readonly',
+        Blob: 'readonly',
+        btoa: 'readonly',
+        atob: 'readonly',
         getComputedStyle: 'readonly',
         requestAnimationFrame: 'readonly',
         cancelAnimationFrame: 'readonly'

--- a/scripts/probe-image-attachment.mjs
+++ b/scripts/probe-image-attachment.mjs
@@ -1,0 +1,158 @@
+// E2E: image drag-drop + paste attachment flow. Covers the UI contract —
+// drops a synthesized PNG into the window, pastes another one, asserts chips
+// appear, removes one via the × button, then sends the turn and asserts the
+// user block in the chat stream carries a rendered <img>. No network is
+// required: we intercept window.agentory.agentSendContent in the renderer so
+// we can assert the shape of the content-block array without depending on a
+// live claude.exe + key.
+//
+// Run: `AGENTORY_DEV_PORT=4186 npm run dev` in one terminal, then:
+// `node scripts/probe-image-attachment.mjs`
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { appWindow } from './probe-utils.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function fail(msg) {
+  console.error(`\n[probe-image-attachment] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+// Smallest valid PNG: 1x1 red pixel. 67 bytes, pre-encoded as base64 so the
+// renderer can dispatch a File(Blob) built from it without touching disk.
+const PNG_1X1_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
+
+const app = await electron.launch({
+  args: ['.'],
+  cwd: root,
+  env: { ...process.env, NODE_ENV: 'development', AGENTORY_DEV_PORT: '4186' }
+});
+
+const win = await appWindow(app);
+const errors = [];
+win.on('pageerror', (e) => errors.push(`[pageerror] ${e.message}`));
+win.on('console', (m) => {
+  if (m.type() === 'error') errors.push(`[console.error] ${m.text()}`);
+});
+
+await win.waitForLoadState('domcontentloaded');
+await win.waitForTimeout(2500);
+
+// Stub the native folder-picker so New Session + cwd Browse don't pop a dialog.
+await app.evaluate(async ({ dialog }, fakeCwd) => {
+  dialog.showOpenDialog = async () => ({ canceled: false, filePaths: [fakeCwd] });
+}, root);
+
+// Intercept agent IPC in the MAIN process so we can observe the payload the
+// renderer sent without depending on a live claude.exe + key. contextBridge
+// freezes window.agentory so we can't monkey-patch on the renderer side.
+await app.evaluate(async ({ ipcMain, webContents }) => {
+  // Remove the live handlers and reinstall stubs.
+  ipcMain.removeHandler('agent:start');
+  ipcMain.removeHandler('agent:send');
+  ipcMain.removeHandler('agent:sendContent');
+  globalThis.__probeCaptured = { content: null, text: null };
+  ipcMain.handle('agent:start', async () => ({ ok: true }));
+  ipcMain.handle('agent:send', async (_e, _sid, text) => {
+    globalThis.__probeCaptured.text = text;
+    return true;
+  });
+  ipcMain.handle('agent:sendContent', async (_e, _sid, content) => {
+    globalThis.__probeCaptured.content = content;
+    // Mirror into the renderer via an arbitrary webContents notify. Easier:
+    // just stash on globalThis; the probe reads it via app.evaluate.
+    return true;
+  });
+  // Silence the unused-var lint for webContents.
+  void webContents;
+});
+
+// 1) New session → textarea visible
+const newBtn = win.getByRole('button', { name: /new session/i }).first();
+await newBtn.waitFor({ state: 'visible', timeout: 15_000 }).catch(() => fail('no New Session button'));
+await newBtn.click();
+
+const textarea = win.locator('textarea');
+await textarea.waitFor({ state: 'visible', timeout: 5000 });
+
+// 2) Drag a synthesized PNG file onto the window.
+await win.evaluate(async (b64) => {
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  const file = new File([bytes], 'dropped.png', { type: 'image/png' });
+  const dt = new DataTransfer();
+  dt.items.add(file);
+  // Simulate the full drag sequence so the overlay + intake path both run.
+  window.dispatchEvent(new DragEvent('dragenter', { bubbles: true, dataTransfer: dt }));
+  window.dispatchEvent(new DragEvent('dragover', { bubbles: true, dataTransfer: dt }));
+  window.dispatchEvent(new DragEvent('drop', { bubbles: true, dataTransfer: dt }));
+}, PNG_1X1_BASE64);
+
+// Chip shows filename.
+const chip1 = win.getByText('dropped.png').first();
+await chip1.waitFor({ state: 'visible', timeout: 5000 }).catch(() => fail('drag chip missing'));
+
+// 3) Paste a clipboard PNG into the textarea.
+await textarea.focus();
+await win.evaluate(async (b64) => {
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  const file = new File([bytes], 'pasted.png', { type: 'image/png' });
+  const dt = new DataTransfer();
+  dt.items.add(file);
+  const ta = document.querySelector('textarea');
+  if (!ta) throw new Error('textarea gone');
+  const ev = new ClipboardEvent('paste', { bubbles: true, cancelable: true, clipboardData: dt });
+  ta.dispatchEvent(ev);
+}, PNG_1X1_BASE64);
+
+const chip2 = win.getByText('pasted.png').first();
+await chip2.waitFor({ state: 'visible', timeout: 5000 }).catch(() => fail('paste chip missing'));
+
+// 4) Remove the first chip via its × button.
+const removeDropped = win.getByRole('button', { name: /remove dropped\.png/i }).first();
+await removeDropped.click();
+await chip1.waitFor({ state: 'hidden', timeout: 2000 }).catch(() => fail('dropped.png chip did not disappear after remove'));
+
+// 5) Type text and send.
+await textarea.fill('what is in this image?');
+await win.keyboard.press('Enter');
+
+// 6) Assert the CAPTURED content-blocks carry an image block + the text.
+const captured = await app.evaluate(() => globalThis.__probeCaptured);
+if (!captured.content || !Array.isArray(captured.content)) {
+  // Dump DOM + captured state to help debug.
+  const dump = await win.evaluate(() => ({
+    chips: Array.from(document.querySelectorAll('img')).map((i) => i.alt || i.src.slice(0, 40)),
+    bodyText: document.body.innerText.slice(0, 800)
+  }));
+  console.error('--- probe dump ---\n' + JSON.stringify({ ...dump, captured }, null, 2));
+  console.error('--- page errors ---\n' + errors.slice(-10).join('\n'));
+  fail('agentSendContent was never called with a content-block array');
+}
+const hasImage = captured.content.some(
+  (b) => b && b.type === 'image' && b.source && b.source.type === 'base64' && b.source.media_type === 'image/png'
+);
+const hasText = captured.content.some(
+  (b) => b && b.type === 'text' && typeof b.text === 'string' && b.text.includes('what is in this image')
+);
+if (!hasImage) fail(`missing image block; got ${JSON.stringify(captured.content).slice(0, 300)}`);
+if (!hasText) fail(`missing text block; got ${JSON.stringify(captured.content).slice(0, 300)}`);
+
+// 7) Assert the user block in chat shows a thumbnail <img> with the data URL.
+const userImg = win.locator('img[alt="pasted.png"]').first();
+await userImg.waitFor({ state: 'visible', timeout: 3000 }).catch(() => fail('user message thumbnail not rendered'));
+
+console.log(`\n[probe-image-attachment] OK`);
+console.log(`  drag chip:    visible → removed`);
+console.log(`  paste chip:   visible`);
+console.log(`  content blocks: ${captured.content.length} (image + text)`);
+console.log(`  user thumbnail: rendered`);
+
+await app.close();

--- a/src/components/ChatStream.tsx
+++ b/src/components/ChatStream.tsx
@@ -3,8 +3,9 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { ChevronRight, AlertCircle, ArrowDown } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import type { MessageBlock } from '../types';
+import type { MessageBlock, ImageAttachment } from '../types';
 import { useStore } from '../stores/store';
+import { attachmentToDataUrl, formatSize } from '../lib/attachments';
 import { Button } from './ui/Button';
 import { StateGlyph } from './ui/StateGlyph';
 import { diffFromToolInput, type DiffSpec } from '../utils/diff';
@@ -21,11 +22,34 @@ const FILE_TREE_TOOLS = new Set(['Glob', 'LS']);
 // instead of leaking as literal `\u001b[...m` noise.
 const SHELL_OUTPUT_TOOLS = new Set(['Bash', 'BashOutput']);
 
-function UserBlock({ text }: { text: string }) {
+function UserBlock({ text, images }: { text: string; images?: ImageAttachment[] }) {
   return (
     <div className="flex gap-3 text-base">
       <span className="text-fg-tertiary select-none w-3 shrink-0 font-mono">&gt;</span>
-      <span className="text-fg-secondary whitespace-pre-wrap min-w-0">{text}</span>
+      <div className="min-w-0 flex-1 flex flex-col gap-1.5">
+        {images && images.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {images.map((img) => (
+              <a
+                key={img.id}
+                href={attachmentToDataUrl(img)}
+                target="_blank"
+                rel="noreferrer"
+                title={`${img.name} · ${formatSize(img.size)}`}
+                className="group relative block overflow-hidden rounded-sm border border-border-subtle hover:border-border-strong transition-colors duration-150 ease-out"
+              >
+                <img
+                  src={attachmentToDataUrl(img)}
+                  alt={img.name}
+                  className="h-20 w-20 object-cover transition-transform duration-200 ease-out group-hover:scale-[1.02]"
+                  draggable={false}
+                />
+              </a>
+            ))}
+          </div>
+        )}
+        {text && <span className="text-fg-secondary whitespace-pre-wrap">{text}</span>}
+      </div>
     </div>
   );
 }
@@ -593,7 +617,7 @@ function renderBlock(
 ) {
   switch (b.kind) {
     case 'user':
-      return <UserBlock text={b.text} />;
+      return <UserBlock text={b.text} images={b.images} />;
     case 'assistant':
       return <AssistantBlock text={b.text} streaming={b.streaming} />;
     case 'tool':

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -1,5 +1,6 @@
-import React, { useMemo, useRef, useState } from 'react';
-import { ArrowUp, Square } from 'lucide-react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { AlertCircle, ArrowUp, ImagePlus, Square, X } from 'lucide-react';
 import { cn } from '../lib/cn';
 import { Button } from './ui/Button';
 import { useStore } from '../stores/store';
@@ -11,18 +12,118 @@ import {
   filterSlashCommands,
   type SlashCommand
 } from '../slash-commands/registry';
+import type { ImageAttachment } from '../types';
+import {
+  attachmentToDataUrl,
+  buildUserContentBlocks,
+  formatSize,
+  intakeFiles,
+  MAX_IMAGE_BYTES,
+  MAX_IMAGES_PER_MESSAGE,
+  SUPPORTED_IMAGE_TYPES,
+  type AttachmentRejection
+} from '../lib/attachments';
 
 // Per-session draft cache. Survives session switches within a process so
 // users don't lose half-typed prompts when they pop into another session.
 // Cleared on send. Not persisted to disk by design — drafts are ephemeral.
 const draftCache = new Map<string, string>();
 
+// Per-session attachment cache. Same rationale as the text draft: stays in
+// memory across session switches, cleared on send. Data URLs are ephemeral
+// too — users can always re-drop if the process restarts.
+const attachmentCache = new Map<string, ImageAttachment[]>();
+
 function nextLocalId(): string {
   return `u-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
 }
 
+function AttachmentChip({
+  attachment,
+  onRemove
+}: {
+  attachment: ImageAttachment;
+  onRemove: () => void;
+}) {
+  const url = useMemo(() => attachmentToDataUrl(attachment), [attachment]);
+  return (
+    <motion.div
+      layout
+      initial={{ opacity: 0, y: 4, scale: 0.96 }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      exit={{ opacity: 0, y: -2, scale: 0.96 }}
+      transition={{ duration: 0.18, ease: [0.32, 0.72, 0, 1] }}
+      className="group relative flex items-center gap-2 rounded-md border border-border-subtle bg-bg-elevated/80 pl-1 pr-2 py-1 hover:border-border-strong transition-colors duration-150 ease-out"
+    >
+      <img
+        src={url}
+        alt={attachment.name}
+        className="h-12 w-12 shrink-0 rounded-sm object-cover"
+        draggable={false}
+      />
+      <div className="min-w-0 flex flex-col">
+        <span className="text-xs text-fg-primary truncate max-w-[180px]" title={attachment.name}>
+          {attachment.name}
+        </span>
+        <span className="text-[10px] text-fg-tertiary font-mono uppercase tracking-wider">
+          {attachment.mediaType.replace('image/', '')} · {formatSize(attachment.size)}
+        </span>
+      </div>
+      <button
+        type="button"
+        onClick={onRemove}
+        aria-label={`Remove ${attachment.name}`}
+        className="ml-1 inline-flex h-5 w-5 items-center justify-center rounded-full text-fg-tertiary hover:text-fg-primary hover:bg-bg-hover active:scale-95 transition-all duration-150 ease-out outline-none focus-visible:ring-1 focus-visible:ring-border-strong"
+      >
+        <X size={12} className="stroke-[2.25]" />
+      </button>
+    </motion.div>
+  );
+}
+
+function DropOverlay({ show }: { show: boolean }) {
+  return (
+    <AnimatePresence>
+      {show && (
+        <motion.div
+          key="drop-overlay"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.14, ease: [0, 0, 0.2, 1] }}
+          className="pointer-events-none absolute inset-2 z-10 rounded-lg border-2 border-dashed border-accent bg-accent/[0.08] backdrop-blur-[1px] flex flex-col items-center justify-center gap-2"
+          aria-hidden
+        >
+          <ImagePlus size={28} className="text-accent" />
+          <span className="font-mono text-sm text-accent tracking-wide">Drop image to attach</span>
+          <span className="font-mono text-[10px] uppercase tracking-wider text-accent/70">
+            PNG · JPEG · GIF · WebP · up to {formatSize(MAX_IMAGE_BYTES)}
+          </span>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+function hasDraggedFiles(e: DragEvent): boolean {
+  // `types` is the cross-browser way to peek at DataTransfer during dragover
+  // without reading `files` (which browsers intentionally blank until drop).
+  const types = e.dataTransfer?.types;
+  if (!types) return false;
+  // In Chromium, file drags include a 'Files' entry.
+  for (let i = 0; i < types.length; i++) {
+    if (types[i] === 'Files') return true;
+  }
+  return false;
+}
+
 export function InputBar({ sessionId }: { sessionId: string }) {
   const [value, setValue] = useState(() => draftCache.get(sessionId) ?? '');
+  const [attachments, setAttachments] = useState<ImageAttachment[]>(
+    () => attachmentCache.get(sessionId) ?? []
+  );
+  const [rejections, setRejections] = useState<AttachmentRejection[]>([]);
+  const [isDragging, setIsDragging] = useState(false);
   const session = useStore((s) => s.sessions.find((x) => x.id === sessionId));
   const started = useStore((s) => !!s.startedSessions[sessionId]);
   const running = useStore((s) => !!s.runningSessions[sessionId]);
@@ -43,9 +144,13 @@ export function InputBar({ sessionId }: { sessionId: string }) {
     (s.messagesBySession[sessionId] ?? []).some((b) => b.kind === 'waiting')
   );
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   // Skip the very first observation of focusInputNonce so app mount doesn't
   // steal focus from wherever the user (or some other auto-focus) put it.
   const focusNonceSeenRef = useRef<number | null>(null);
+  // Counts nested dragenter/dragleave events at window level so sub-element
+  // drags don't flicker the overlay off before the user drops.
+  const dragDepthRef = useRef(0);
 
   // --- Slash-command picker state --------------------------------------
   // We derive picker openness from (value, caret) rather than storing a
@@ -64,16 +169,18 @@ export function InputBar({ sessionId }: { sessionId: string }) {
   );
   const pickerOpen = trigger.active && !pickerDismissed && !running;
   // Clamp activeIndex whenever the filtered list shrinks.
-  React.useEffect(() => {
+  useEffect(() => {
     if (!pickerOpen) return;
     if (activeIndex >= filtered.length) setActiveIndex(Math.max(0, filtered.length - 1));
   }, [pickerOpen, filtered.length, activeIndex]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setValue(draftCache.get(sessionId) ?? '');
+    setAttachments(attachmentCache.get(sessionId) ?? []);
+    setRejections([]);
   }, [sessionId]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (focusNonceSeenRef.current === null) {
       focusNonceSeenRef.current = focusInputNonce;
       return;
@@ -125,16 +232,125 @@ export function InputBar({ sessionId }: { sessionId: string }) {
     });
   }
 
+  function setAttachmentsAndCache(next: ImageAttachment[]): void {
+    setAttachments(next);
+    if (next.length > 0) attachmentCache.set(sessionId, next);
+    else attachmentCache.delete(sessionId);
+  }
+
+  const intake = useCallback(
+    async (files: File[]): Promise<void> => {
+      if (files.length === 0) return;
+      const current = attachmentCache.get(sessionId) ?? [];
+      const { accepted, rejected } = await intakeFiles(files, current.length);
+      if (accepted.length > 0) {
+        const next = [...current, ...accepted];
+        setAttachmentsAndCache(next);
+      }
+      if (rejected.length > 0) {
+        setRejections(rejected);
+        // Auto-clear rejection banner after 6s so it doesn't pile up if the
+        // user drags another batch.
+        window.setTimeout(() => setRejections([]), 6000);
+      }
+    },
+    // setAttachmentsAndCache is stable across renders (closes over setAttachments),
+    // and attachmentCache is a module singleton. sessionId is the only real dep.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [sessionId]
+  );
+
+  // Window-level drag tracking so the overlay lights up as soon as the user
+  // drags a file anywhere over the app, not only when they hover the input.
+  useEffect(() => {
+    function onDragEnter(e: DragEvent) {
+      if (!hasDraggedFiles(e)) return;
+      dragDepthRef.current += 1;
+      setIsDragging(true);
+    }
+    function onDragLeave(e: DragEvent) {
+      if (!hasDraggedFiles(e)) return;
+      dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+      if (dragDepthRef.current === 0) setIsDragging(false);
+    }
+    function onDragOver(e: DragEvent) {
+      if (!hasDraggedFiles(e)) return;
+      e.preventDefault(); // allow drop
+    }
+    function onDrop(e: DragEvent) {
+      dragDepthRef.current = 0;
+      setIsDragging(false);
+      if (!hasDraggedFiles(e)) return;
+      e.preventDefault();
+      const files = e.dataTransfer?.files;
+      if (!files || files.length === 0) return;
+      void intake(Array.from(files));
+    }
+    window.addEventListener('dragenter', onDragEnter);
+    window.addEventListener('dragleave', onDragLeave);
+    window.addEventListener('dragover', onDragOver);
+    window.addEventListener('drop', onDrop);
+    return () => {
+      window.removeEventListener('dragenter', onDragEnter);
+      window.removeEventListener('dragleave', onDragLeave);
+      window.removeEventListener('dragover', onDragOver);
+      window.removeEventListener('drop', onDrop);
+    };
+  }, [intake]);
+
+  async function onPaste(e: React.ClipboardEvent<HTMLTextAreaElement>) {
+    const items = e.clipboardData?.items;
+    if (!items || items.length === 0) return;
+    const files: File[] = [];
+    for (let i = 0; i < items.length; i++) {
+      const it = items[i];
+      if (it.kind === 'file' && it.type.startsWith('image/')) {
+        const f = it.getAsFile();
+        if (f) files.push(f);
+      }
+    }
+    if (files.length === 0) return;
+    // Stop the browser from also pasting the filename / blob URL as text.
+    e.preventDefault();
+    await intake(files);
+  }
+
+  async function onPickFiles(e: React.ChangeEvent<HTMLInputElement>) {
+    const files = e.target.files ? Array.from(e.target.files) : [];
+    if (files.length === 0) return;
+    // Let the user pick the same file twice in a row if they want.
+    e.target.value = '';
+    await intake(files);
+  }
+
+  function removeAttachment(id: string) {
+    const next = attachments.filter((a) => a.id !== id);
+    setAttachmentsAndCache(next);
+  }
+
   async function send() {
     const text = value.trim();
-    if (!text || running) return;
+    const imgs = attachments;
+    if (running) return;
+    // Valid turns: text with or without images, OR images with no text. Empty
+    // text + no images is a no-op (same as before).
+    if (!text && imgs.length === 0) return;
     const api = window.agentory;
     if (!api || !session) return;
 
     // Local echo: render the user's turn immediately. We skip the SDK's
     // own user-message echo in sdk-to-blocks to avoid duplicates.
-    appendBlocks(sessionId, [{ kind: 'user', id: nextLocalId(), text }]);
+    appendBlocks(sessionId, [
+      {
+        kind: 'user',
+        id: nextLocalId(),
+        text,
+        ...(imgs.length > 0 ? { images: imgs } : {})
+      }
+    ]);
     update('');
+    setAttachmentsAndCache([]);
+    setRejections([]);
     setRunning(sessionId, true);
     // A real human turn resets the autopilot counter.
     resetWatchdogCount(sessionId);
@@ -158,7 +374,13 @@ export function InputBar({ sessionId }: { sessionId: string }) {
       markStarted(sessionId);
     }
 
-    const ok = await api.agentSend(sessionId, text);
+    let ok: boolean;
+    if (imgs.length > 0) {
+      const content = buildUserContentBlocks(text, imgs);
+      ok = await api.agentSendContent(sessionId, content);
+    } else {
+      ok = await api.agentSend(sessionId, text);
+    }
     if (!ok) {
       setRunning(sessionId, false);
       appendBlocks(sessionId, [
@@ -239,15 +461,55 @@ export function InputBar({ sessionId }: { sessionId: string }) {
     setCaret(el.selectionStart ?? 0);
   }
 
+  const sendDisabled = !value.trim() && attachments.length === 0;
+  const remainingSlots = Math.max(0, MAX_IMAGES_PER_MESSAGE - attachments.length);
+
   return (
-    <div className="px-3 pt-2 pb-3">
+    <div className="relative px-3 pt-2 pb-3">
+      <DropOverlay show={isDragging} />
+
+      <AnimatePresence>
+        {rejections.length > 0 && (
+          <motion.div
+            key="rejections"
+            initial={{ opacity: 0, y: 4 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -2 }}
+            transition={{ duration: 0.18, ease: [0.32, 0.72, 0, 1] }}
+            role="alert"
+            className="mb-2 rounded-md border border-state-error/40 bg-state-error-soft/60 px-3 py-2 text-xs text-state-error-fg"
+          >
+            <div className="flex items-start gap-2">
+              <AlertCircle size={12} className="text-state-error mt-0.5 shrink-0" />
+              <div className="flex-1 min-w-0 space-y-0.5">
+                {rejections.map((r, i) => (
+                  <div key={i} className="truncate" title={r.detail}>
+                    {r.detail}
+                  </div>
+                ))}
+              </div>
+              <button
+                type="button"
+                onClick={() => setRejections([])}
+                aria-label="Dismiss"
+                className="shrink-0 text-state-error/70 hover:text-state-error transition-colors duration-150 ease-out"
+              >
+                <X size={12} />
+              </button>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
       <div
         className={cn(
           'relative rounded-md border bg-bg-elevated surface-highlight',
-          'transition-[border-color] duration-200',
+          'transition-[border-color,box-shadow] duration-200',
           '[transition-timing-function:cubic-bezier(0.32,0.72,0,1)]',
-          'border-border-default',
-          'focus-within:border-accent'
+          isDragging
+            ? 'border-accent shadow-[0_0_0_3px_oklch(0.62_0.14_258_/_0.15)]'
+            : 'border-border-default',
+          !isDragging && 'focus-within:border-accent'
         )}
       >
         <SlashCommandPicker
@@ -257,6 +519,19 @@ export function InputBar({ sessionId }: { sessionId: string }) {
           onActiveIndexChange={setActiveIndex}
           onSelect={commitSlashCommand}
         />
+        {attachments.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 px-2 pt-2">
+            <AnimatePresence initial={false}>
+              {attachments.map((a) => (
+                <AttachmentChip
+                  key={a.id}
+                  attachment={a}
+                  onRemove={() => removeAttachment(a.id)}
+                />
+              ))}
+            </AnimatePresence>
+          </div>
+        )}
         <textarea
           ref={textareaRef}
           data-input-bar
@@ -266,6 +541,7 @@ export function InputBar({ sessionId }: { sessionId: string }) {
           onKeyUp={syncCaret}
           onClick={syncCaret}
           onSelect={syncCaret}
+          onPaste={onPaste}
           rows={2}
           placeholder={running ? 'Running… (input disabled)' : hasMessages ? 'Reply…' : 'Ask anything…'}
           disabled={running}
@@ -277,6 +553,40 @@ export function InputBar({ sessionId }: { sessionId: string }) {
           )}
           style={{ minHeight: 64, maxHeight: 240 }}
         />
+        <div className="absolute left-2 bottom-1.5 flex items-center gap-1">
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            accept={SUPPORTED_IMAGE_TYPES.join(',')}
+            className="hidden"
+            onChange={onPickFiles}
+          />
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={running || remainingSlots === 0}
+            aria-label="Attach image"
+            title={
+              remainingSlots === 0
+                ? `Attachment cap reached (${MAX_IMAGES_PER_MESSAGE})`
+                : 'Attach image (also supports drag-drop & paste)'
+            }
+            className={cn(
+              'inline-flex h-6 w-6 items-center justify-center rounded-sm text-fg-tertiary',
+              'hover:text-fg-primary hover:bg-bg-hover active:scale-95',
+              'disabled:opacity-40 disabled:pointer-events-none',
+              'transition-all duration-150 ease-out outline-none focus-visible:ring-1 focus-visible:ring-border-strong'
+            )}
+          >
+            <ImagePlus size={14} className="stroke-[2.25]" />
+          </button>
+          {attachments.length > 0 && (
+            <span className="font-mono text-[10px] uppercase tracking-wider text-fg-tertiary">
+              {attachments.length}/{MAX_IMAGES_PER_MESSAGE}
+            </span>
+          )}
+        </div>
         <div className="absolute right-3 bottom-1.5">
           {running ? (
             <Button
@@ -293,7 +603,7 @@ export function InputBar({ sessionId }: { sessionId: string }) {
               variant="primary"
               size="sm"
               aria-label="Send message"
-              disabled={!value.trim()}
+              disabled={sendDisabled}
               onClick={send}
             >
               <ArrowUp size={10} className="stroke-[2.25]" />

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -76,6 +76,7 @@ declare global {
 
       agentStart: (sessionId: string, opts: StartOpts) => Promise<StartResult>;
       agentSend: (sessionId: string, text: string) => Promise<boolean>;
+      agentSendContent: (sessionId: string, content: unknown[]) => Promise<boolean>;
       agentInterrupt: (sessionId: string) => Promise<boolean>;
       agentSetPermissionMode: (sessionId: string, mode: PermissionMode) => Promise<boolean>;
       agentSetModel: (sessionId: string, model?: string) => Promise<boolean>;

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -1,0 +1,194 @@
+/**
+ * Image attachment plumbing: MIME filtering, size limits, base64 encoding, and
+ * Anthropic content-block assembly. Centralized here so both InputBar (drop /
+ * paste) and tests poke at the same primitives.
+ *
+ * Limits match what Anthropic's Messages API accepts — see
+ * https://docs.anthropic.com/en/docs/build-with-claude/vision: PNG / JPEG /
+ * GIF / WebP, up to 5MB per image on the server. We cap the renderer at 10MB
+ * per image to match the UX surface (chips, thumbnails) and give users a
+ * reasonable window to paste hi-res screenshots; the SDK will reject anything
+ * oversize with a clear error.
+ */
+
+import type { ImageAttachment, ImageMediaType } from '../types';
+
+export const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+export const MAX_IMAGES_PER_MESSAGE = 10;
+
+export const SUPPORTED_IMAGE_TYPES: readonly ImageMediaType[] = [
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp'
+];
+
+export function isSupportedImageType(t: string): t is ImageMediaType {
+  return (SUPPORTED_IMAGE_TYPES as readonly string[]).includes(t);
+}
+
+export interface FileLike {
+  name: string;
+  size: number;
+  type: string;
+  arrayBuffer(): Promise<ArrayBuffer>;
+}
+
+export type AttachmentRejection =
+  | { kind: 'unsupported-type'; file: FileLike; detail: string }
+  | { kind: 'too-large'; file: FileLike; detail: string }
+  | { kind: 'over-limit'; file: FileLike; detail: string };
+
+export interface AttachmentIntakeResult {
+  accepted: ImageAttachment[];
+  rejected: AttachmentRejection[];
+}
+
+export function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+let attachmentSeq = 0;
+function nextAttachmentId(): string {
+  attachmentSeq += 1;
+  return `att-${Date.now().toString(36)}-${attachmentSeq.toString(36)}`;
+}
+
+// Browsers encode arbitrary bytes as base64 via FileReader → data URL. We
+// strip the `data:<mime>;base64,` prefix so downstream consumers (Anthropic
+// API, stream-json outbound) get raw base64 they can put in `source.data`.
+function arrayBufferToBase64(buf: ArrayBuffer): string {
+  const bytes = new Uint8Array(buf);
+  // Chunked to avoid `Maximum call stack size exceeded` on >~100KB buffers
+  // when we'd otherwise spread `bytes` into String.fromCharCode.
+  const CHUNK = 0x8000;
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    const slice = bytes.subarray(i, i + CHUNK);
+    binary += String.fromCharCode(...slice);
+  }
+  // `btoa` is available in renderer + jsdom-backed vitest. Safe here.
+  return btoa(binary);
+}
+
+/**
+ * Normalize a single dropped / pasted file into either an `ImageAttachment`
+ * ready to render, or an `AttachmentRejection` explaining why we skipped it.
+ *
+ * Never throws — filesystem / decode errors surface as rejections.
+ */
+export async function intakeFile(file: FileLike): Promise<ImageAttachment | AttachmentRejection> {
+  if (!isSupportedImageType(file.type)) {
+    return {
+      kind: 'unsupported-type',
+      file,
+      detail: file.type
+        ? `"${file.name}" is ${file.type}; only PNG / JPEG / GIF / WebP are supported.`
+        : `"${file.name}" has no detectable image type.`
+    };
+  }
+  if (file.size > MAX_IMAGE_BYTES) {
+    return {
+      kind: 'too-large',
+      file,
+      detail: `"${file.name}" is ${formatSize(file.size)}; limit is ${formatSize(MAX_IMAGE_BYTES)}.`
+    };
+  }
+  try {
+    const buf = await file.arrayBuffer();
+    const data = arrayBufferToBase64(buf);
+    return {
+      id: nextAttachmentId(),
+      name: file.name || 'pasted-image',
+      mediaType: file.type,
+      data,
+      size: file.size
+    };
+  } catch (err) {
+    return {
+      kind: 'unsupported-type',
+      file,
+      detail: `Failed to read "${file.name}": ${err instanceof Error ? err.message : String(err)}`
+    };
+  }
+}
+
+/**
+ * Intake a batch, enforcing MAX_IMAGES_PER_MESSAGE across the existing count.
+ * `existingCount` is how many attachments the user already has in the
+ * composer. Anything over the cap returns an `over-limit` rejection.
+ */
+export async function intakeFiles(
+  files: FileLike[],
+  existingCount: number
+): Promise<AttachmentIntakeResult> {
+  const accepted: ImageAttachment[] = [];
+  const rejected: AttachmentRejection[] = [];
+  for (const file of files) {
+    if (existingCount + accepted.length >= MAX_IMAGES_PER_MESSAGE) {
+      rejected.push({
+        kind: 'over-limit',
+        file,
+        detail: `Attachment cap is ${MAX_IMAGES_PER_MESSAGE} images per message.`
+      });
+      continue;
+    }
+    const result = await intakeFile(file);
+    if ('kind' in result) rejected.push(result);
+    else accepted.push(result);
+  }
+  return { accepted, rejected };
+}
+
+/** Render an attachment as a data URL suitable for an <img src="..."> tag. */
+export function attachmentToDataUrl(a: Pick<ImageAttachment, 'mediaType' | 'data'>): string {
+  return `data:${a.mediaType};base64,${a.data}`;
+}
+
+/**
+ * Anthropic content block for an image attachment. Matches
+ * https://docs.anthropic.com/en/api/messages#body-messages-content —
+ * `{ type: 'image', source: { type: 'base64', media_type, data } }`.
+ */
+export interface AnthropicImageBlock {
+  type: 'image';
+  source: {
+    type: 'base64';
+    media_type: ImageMediaType;
+    data: string;
+  };
+}
+
+export interface AnthropicTextBlock {
+  type: 'text';
+  text: string;
+}
+
+export type AnthropicUserContentBlock = AnthropicImageBlock | AnthropicTextBlock;
+
+export function attachmentToImageBlock(a: ImageAttachment): AnthropicImageBlock {
+  return {
+    type: 'image',
+    source: { type: 'base64', media_type: a.mediaType, data: a.data }
+  };
+}
+
+/**
+ * Build the `content` array sent to claude.exe as a user message. Image
+ * blocks precede the text block so Anthropic's vision model sees them as
+ * context for the text prompt, matching their official examples. An
+ * image-only turn (no text) is valid and returns a content array of just
+ * image blocks.
+ */
+export function buildUserContentBlocks(
+  text: string,
+  images: ImageAttachment[]
+): AnthropicUserContentBlock[] {
+  const blocks: AnthropicUserContentBlock[] = [];
+  for (const img of images) blocks.push(attachmentToImageBlock(img));
+  const trimmed = text.trim();
+  if (trimmed.length > 0) blocks.push({ type: 'text', text: trimmed });
+  return blocks;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,8 +51,22 @@ export interface TodoItem {
   activeForm?: string;
 }
 
+export type ImageMediaType = 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp';
+
+// A single image attached to a user message. `data` is raw base64 (no
+// `data:...;base64,` prefix) so it can be dropped directly into an Anthropic
+// content block as `source.data`. Persisted inline with the message block —
+// ChatStream reconstructs a data-URL for thumbnail rendering on demand.
+export interface ImageAttachment {
+  id: string;
+  name: string;
+  mediaType: ImageMediaType;
+  data: string;
+  size: number;
+}
+
 export type MessageBlock =
-  | { kind: 'user'; id: string; text: string }
+  | { kind: 'user'; id: string; text: string; images?: ImageAttachment[] }
   | { kind: 'assistant'; id: string; text: string; streaming?: boolean }
   | { kind: 'tool'; id: string; name: string; brief: string; expanded: boolean; toolUseId?: string; result?: string; isError?: boolean; input?: unknown }
   | { kind: 'todo'; id: string; toolUseId?: string; todos: TodoItem[] }

--- a/tests/attachments.test.ts
+++ b/tests/attachments.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Unit tests for the attachments plumbing — size / MIME filtering + Anthropic
+ * content-block assembly. DB round-trip is covered indirectly via db.test.ts
+ * (which stringifies whatever MessageBlock it's handed).
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  buildUserContentBlocks,
+  intakeFile,
+  intakeFiles,
+  isSupportedImageType,
+  MAX_IMAGE_BYTES,
+  MAX_IMAGES_PER_MESSAGE,
+  type FileLike
+} from '../src/lib/attachments';
+
+function fakeFile(opts: {
+  name?: string;
+  size?: number;
+  type?: string;
+  bytes?: Uint8Array;
+}): FileLike {
+  const bytes = opts.bytes ?? new Uint8Array(opts.size ?? 4);
+  return {
+    name: opts.name ?? 'test.png',
+    size: opts.size ?? bytes.byteLength,
+    type: opts.type ?? 'image/png',
+    arrayBuffer: () =>
+      Promise.resolve(
+        bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer
+      )
+  };
+}
+
+describe('isSupportedImageType', () => {
+  it('accepts all four Anthropic media types', () => {
+    for (const t of ['image/png', 'image/jpeg', 'image/gif', 'image/webp']) {
+      expect(isSupportedImageType(t)).toBe(true);
+    }
+  });
+  it('rejects others', () => {
+    for (const t of ['image/bmp', 'image/svg+xml', 'application/pdf', 'text/plain', '']) {
+      expect(isSupportedImageType(t)).toBe(false);
+    }
+  });
+});
+
+describe('intakeFile', () => {
+  it('rejects unsupported MIME with a helpful message', async () => {
+    const r = await intakeFile(fakeFile({ type: 'image/bmp', name: 'x.bmp' }));
+    expect('kind' in r && r.kind).toBe('unsupported-type');
+  });
+
+  it('rejects oversize files', async () => {
+    const r = await intakeFile(fakeFile({ size: MAX_IMAGE_BYTES + 1, type: 'image/png' }));
+    expect('kind' in r && r.kind).toBe('too-large');
+  });
+
+  it('base64-encodes accepted files and strips the data-URL prefix', async () => {
+    const bytes = new Uint8Array([137, 80, 78, 71]); // PNG magic
+    const r = await intakeFile(fakeFile({ bytes, size: 4, type: 'image/png', name: 'p.png' }));
+    expect('kind' in r).toBe(false);
+    if ('kind' in r) return;
+    expect(r.mediaType).toBe('image/png');
+    expect(r.size).toBe(4);
+    expect(r.name).toBe('p.png');
+    // Plain base64, no "data:...;base64," prefix:
+    expect(r.data.startsWith('data:')).toBe(false);
+    // And it should decode back to the original bytes via atob (available in
+    // vitest's jsdom env).
+    const decoded = Uint8Array.from(atob(r.data), (c) => c.charCodeAt(0));
+    expect(Array.from(decoded)).toEqual([137, 80, 78, 71]);
+  });
+});
+
+describe('intakeFiles', () => {
+  it('enforces MAX_IMAGES_PER_MESSAGE across existing + batch', async () => {
+    const files = Array.from({ length: 3 }, (_, i) =>
+      fakeFile({ name: `f${i}.png`, bytes: new Uint8Array([1, 2, 3]) })
+    );
+    const { accepted, rejected } = await intakeFiles(files, MAX_IMAGES_PER_MESSAGE - 1);
+    expect(accepted.length).toBe(1); // only 1 slot left
+    expect(rejected.length).toBe(2);
+    expect(rejected.every((r) => r.kind === 'over-limit')).toBe(true);
+  });
+
+  it('partitions accepted / rejected independently', async () => {
+    const files = [
+      fakeFile({ name: 'ok.png', type: 'image/png' }),
+      fakeFile({ name: 'bad.bmp', type: 'image/bmp' })
+    ];
+    const { accepted, rejected } = await intakeFiles(files, 0);
+    expect(accepted.length).toBe(1);
+    expect(rejected.length).toBe(1);
+    expect(rejected[0].kind).toBe('unsupported-type');
+  });
+});
+
+describe('buildUserContentBlocks', () => {
+  const img = {
+    id: 'a1',
+    name: 'x.png',
+    mediaType: 'image/png' as const,
+    data: 'AAAA',
+    size: 3
+  };
+
+  it('builds image-then-text blocks when both are present', () => {
+    const blocks = buildUserContentBlocks('describe this', [img]);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toEqual({
+      type: 'image',
+      source: { type: 'base64', media_type: 'image/png', data: 'AAAA' }
+    });
+    expect(blocks[1]).toEqual({ type: 'text', text: 'describe this' });
+  });
+
+  it('allows image-only turns (no text)', () => {
+    const blocks = buildUserContentBlocks('', [img]);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({ type: 'image' });
+  });
+
+  it('allows text-only (returns one text block, no empty image block)', () => {
+    const blocks = buildUserContentBlocks('hello', []);
+    expect(blocks).toEqual([{ type: 'text', text: 'hello' }]);
+  });
+
+  it('trims text but preserves internal whitespace', () => {
+    const blocks = buildUserContentBlocks('  hello  world  ', []);
+    expect(blocks).toEqual([{ type: 'text', text: 'hello  world' }]);
+  });
+
+  it('drops pure-whitespace text to empty array when no images', () => {
+    const blocks = buildUserContentBlocks('   \n  ', []);
+    expect(blocks).toEqual([]);
+  });
+
+  it('preserves ordering across multiple images', () => {
+    const img2 = { ...img, id: 'a2', data: 'BBBB' };
+    const blocks = buildUserContentBlocks('two', [img, img2]);
+    expect(blocks).toHaveLength(3);
+    expect(blocks[0]).toMatchObject({ source: { data: 'AAAA' } });
+    expect(blocks[1]).toMatchObject({ source: { data: 'BBBB' } });
+    expect(blocks[2]).toEqual({ type: 'text', text: 'two' });
+  });
+});
+
+describe('DB JSON round-trip (via JSON.stringify/parse)', () => {
+  it('preserves image attachments through serialize/deserialize', () => {
+    const block = {
+      kind: 'user' as const,
+      id: 'u1',
+      text: 'whats this?',
+      images: [
+        { id: 'a1', name: 'p.png', mediaType: 'image/png' as const, data: 'AAAA', size: 3 }
+      ]
+    };
+    const round = JSON.parse(JSON.stringify(block));
+    expect(round).toEqual(block);
+  });
+});


### PR DESCRIPTION
## Summary

Users can drag images from disk, paste clipboard screenshots, or click the paperclip into the InputBar. Images flow end-to-end to claude.exe as Anthropic content blocks (`{type:'image', source:{type:'base64', media_type, data}}`) via the existing stream-json stdin channel — no CLI schema changes needed; `ContentBlockSchema` already passes through unknown block types.

## Behavior matrix

| Dimension | Behavior |
|---|---|
| **MIME types** | PNG / JPEG / GIF / WebP (matches Anthropic Messages API `media_type` surface) |
| **Size limit** | 10 MB per image; rejected with an inline dismissable banner |
| **Count limit** | 10 images per message; over-limit batches return typed rejections |
| **Drop target** | Whole window — window-level `dragenter/leave/over/drop` listeners with nested enter-count to avoid overlay flicker |
| **Drop feedback** | Full-pane dashed accent overlay with `ImagePlus` glyph + supported-types footnote, framer-motion fade |
| **Paste** | `onPaste` on textarea; image files in clipboard flow through the same intake; plain-text paste untouched |
| **File picker** | Paperclip button next to Send; `accept` restricts OS dialog to supported types |
| **Image-only turn** | Valid (sends content array with just image blocks + no text block) |
| **Remove** | Per-chip `×` button; instant state update, framer-motion exit animation |
| **Persistence** | Attachments persist inline on the user `MessageBlock` (existing messages table JSON round-trip). Restart/reload restores thumbnails |

## Stream-json schema note

`UserMessageEventSchema.message.content` already accepts `z.array(ContentBlockSchema)` and `ContentBlockSchema` is `.passthrough()` — so `{type:'image', source:{...}}` flows through unchanged. No schema bump. `ControlRpc` grew `sendUserMessageContent(content, sessionId)` alongside the existing text-only `sendUserMessage`; the raw `content` array is forwarded verbatim onto stdin.

## Wiring

- New `ImageAttachment` type + `src/lib/attachments.ts` (MIME filter, size limit, base64 encoding, Anthropic content-block assembly)
- New `agent:sendContent` IPC surface: main → manager → SessionRunner → ControlRpc → stdin
- `window.agentory.agentSendContent(sessionId, content)` in preload + `global.d.ts`
- `InputBar` gains attachment chip stack, drop overlay, paperclip, paste handler; `send()` branches to `agentSendContent` when attachments present, falls back to `agentSend` for plain text
- `ChatStream` user block renders thumbnails above text; click opens the full-size image in a new window via the data URL

## CD research findings

`claude-desktop-rev-eng/sections/` doesn't document CD's image UX directly — grep hits were unrelated (PKCE base64, device id, `og:image`). Behavior choices (drop-target scope, overlay copy, chip size, limits) were derived from Anthropic Messages API docs plus common product conventions. CD's own drop-behavior can be revisited later if the CLI surface changes.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (only pre-existing unrelated warning)
- [x] `npm test` — 365 passed (26 test files); new coverage:
  - `tests/attachments.test.ts`: MIME filter, size limit, batch cap enforcement, content-block assembly (text+image, image-only, text-only, ordering), DB JSON round-trip
  - `electron/agent/__tests__/control-rpc.test.ts`: `sendUserMessageContent` forwards array verbatim; throws after close
- [x] `scripts/probe-image-attachment.mjs` (Playwright + electron): drag synthesized PNG → chip visible; paste another PNG → second chip; remove via × → chip hidden; send → captured content-block array carries both an `image` block (base64, `media_type: image/png`) and the typed text; user block renders an `<img alt="…">` thumbnail
- [ ] Manual verify with live endpoint (multimodal assistant round-trip) — reviewer can run dev + drop an image

🤖 Generated with [Claude Code](https://claude.com/claude-code)