### PR TITLE
feat(ui): appearance polish — theme, font size, density, pane resize, CLAUDE.md editor

### DIFF
--- a/electron/__tests__/memory.test.ts
+++ b/electron/__tests__/memory.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  isAllowedMemoryPath,
+  readMemoryFile,
+  writeMemoryFile,
+  memoryFileExists,
+} from '../memory';
+
+describe('isAllowedMemoryPath', () => {
+  it('accepts absolute paths ending in CLAUDE.md', () => {
+    const p = path.join(os.tmpdir(), 'repo', 'CLAUDE.md');
+    expect(isAllowedMemoryPath(p)).toBe(true);
+  });
+
+  it('rejects files with different basename', () => {
+    expect(isAllowedMemoryPath(path.join(os.tmpdir(), 'NOTES.md'))).toBe(false);
+    expect(isAllowedMemoryPath(path.join(os.tmpdir(), 'claude.md'))).toBe(false);
+    expect(isAllowedMemoryPath(path.join(os.tmpdir(), 'Claude.md'))).toBe(false);
+    expect(isAllowedMemoryPath(path.join(os.tmpdir(), 'CLAUDE.MD'))).toBe(false);
+  });
+
+  it('rejects relative paths', () => {
+    expect(isAllowedMemoryPath('CLAUDE.md')).toBe(false);
+    expect(isAllowedMemoryPath('./CLAUDE.md')).toBe(false);
+    expect(isAllowedMemoryPath('sub/CLAUDE.md')).toBe(false);
+  });
+
+  it('rejects non-string / empty inputs', () => {
+    expect(isAllowedMemoryPath(undefined)).toBe(false);
+    expect(isAllowedMemoryPath(null)).toBe(false);
+    expect(isAllowedMemoryPath(42)).toBe(false);
+    expect(isAllowedMemoryPath('')).toBe(false);
+  });
+
+  it('rejects traversal segments even inside basename', () => {
+    // After normalization these collapse, but the defense-in-depth check
+    // catches any that would still contain `..`.
+    expect(isAllowedMemoryPath('/a/..b/CLAUDE.md')).toBe(true); // ..b is not ..
+    // This is the real attack shape — note the middle segment.
+    const crafted = '/a/b/../c/CLAUDE.md';
+    // path.normalize collapses to /a/c/CLAUDE.md which is fine.
+    expect(isAllowedMemoryPath(crafted)).toBe(true);
+  });
+
+  it('trailing slash is tolerated (Node normalizes the basename)', () => {
+    // path.basename trims trailing separators, so this still resolves to
+    // the `CLAUDE.md` segment. Allowing it is fine — fs operations will
+    // follow the same normalization, we can't accidentally write elsewhere.
+    expect(isAllowedMemoryPath('/a/b/CLAUDE.md/')).toBe(true);
+  });
+});
+
+describe('memory read/write security', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agentory-memory-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('readMemoryFile rejects non-CLAUDE.md paths', () => {
+    const evil = path.join(tmpDir, 'secrets.env');
+    fs.writeFileSync(evil, 'API_KEY=nope');
+    const res = readMemoryFile(evil);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe('invalid_path');
+  });
+
+  it('writeMemoryFile rejects non-CLAUDE.md paths', () => {
+    const evil = path.join(tmpDir, 'secrets.env');
+    const res = writeMemoryFile(evil, 'overwritten');
+    expect(res.ok).toBe(false);
+    expect(fs.existsSync(evil)).toBe(false);
+  });
+
+  it('writeMemoryFile rejects non-absolute paths', () => {
+    const res = writeMemoryFile('CLAUDE.md', 'hi');
+    expect(res.ok).toBe(false);
+  });
+
+  it('memoryFileExists returns false for disallowed paths even if the file exists', () => {
+    const evil = path.join(tmpDir, 'secrets.env');
+    fs.writeFileSync(evil, 'x');
+    expect(memoryFileExists(evil)).toBe(false);
+  });
+
+  it('read + write roundtrip for a valid CLAUDE.md path', () => {
+    const p = path.join(tmpDir, 'CLAUDE.md');
+    const r1 = readMemoryFile(p);
+    expect(r1.ok).toBe(true);
+    if (r1.ok) {
+      expect(r1.exists).toBe(false);
+      expect(r1.content).toBe('');
+    }
+    const w = writeMemoryFile(p, '# project rules\nbe terse');
+    expect(w.ok).toBe(true);
+    const r2 = readMemoryFile(p);
+    expect(r2.ok).toBe(true);
+    if (r2.ok) {
+      expect(r2.exists).toBe(true);
+      expect(r2.content).toContain('be terse');
+    }
+  });
+
+  it('writeMemoryFile creates missing parent directories', () => {
+    const p = path.join(tmpDir, 'nested', 'dir', 'CLAUDE.md');
+    const w = writeMemoryFile(p, 'hello');
+    expect(w.ok).toBe(true);
+    expect(fs.existsSync(p)).toBe(true);
+  });
+});

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, Menu, Tray, nativeImage, ipcMain, safeStorage, dialog, shell, type MenuItemConstructorOptions } from 'electron';
 import * as path from 'path';
 import * as fs from 'fs';
+import * as os from 'os';
 import { initDb, loadState, saveState, loadMessages, saveMessages, closeDb, loadClaudeBinPath, saveClaudeBinPath } from './db';
 import { sessions } from './agent/manager';
 import { installUpdaterIpc } from './updater';
@@ -9,6 +10,7 @@ import { showNotification, type ShowNotificationPayload } from './notifications'
 import type { PermissionMode } from './agent/sessions';
 import { EndpointsManager, type KeyCrypto } from './endpoints-manager';
 import { ClaudeNotFoundError, detectClaudeVersion, resolveClaudeBinary } from './agent/binary-resolver';
+import { readMemoryFile, writeMemoryFile, memoryFileExists } from './memory';
 
 const KEYCHAIN_FILE = 'anthropic-key.bin';
 
@@ -520,6 +522,29 @@ app.whenReady().then(() => {
     }
   );
   // ────────────────────────── end CLI wizard ───────────────────────────────
+
+  // Memory (CLAUDE.md) editor IPC. Paths are validated inside the memory
+  // module — see isAllowedMemoryPath(). Only files named CLAUDE.md are
+  // accepted; anything else returns an error so a compromised renderer can't
+  // use us as an arbitrary-file-read primitive.
+  ipcMain.handle('memory:read', (_e, p: string) => readMemoryFile(p));
+  ipcMain.handle('memory:write', (_e, p: string, content: string) =>
+    writeMemoryFile(p, content)
+  );
+  ipcMain.handle('memory:exists', (_e, p: string) => memoryFileExists(p));
+  ipcMain.handle('memory:userPath', () => {
+    // ~/.claude/CLAUDE.md. Resolved here so the renderer never has to know
+    // about homedir semantics (different on Windows vs Unix).
+    return path.join(os.homedir(), '.claude', 'CLAUDE.md');
+  });
+  ipcMain.handle('memory:projectPath', (_e, cwd: string) => {
+    // We still force CLAUDE.md basename in the *write* path, but we compose
+    // the full path here so the renderer doesn't have to remember the
+    // filename. If cwd is empty or not absolute, return null so the UI can
+    // show the "open a session" hint.
+    if (typeof cwd !== 'string' || !cwd || !path.isAbsolute(cwd)) return null;
+    return path.join(cwd, 'CLAUDE.md');
+  });
 
   ipcMain.handle(
     'notification:show',

--- a/electron/memory.ts
+++ b/electron/memory.ts
@@ -1,0 +1,87 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Security boundary for the renderer-exposed memory:* IPC family.
+ *
+ * The renderer can ask us to read/write only files named `CLAUDE.md`.
+ * Anything else — a parent directory traversal attempt, a different
+ * filename, a UNC path on Windows — MUST be rejected. We do the check
+ * here, not at the IPC layer, so unit tests can cover it directly.
+ *
+ * Accepted shapes:
+ *   - Absolute path whose basename is exactly `CLAUDE.md`.
+ *
+ * Rejected shapes:
+ *   - Relative paths (no way to resolve without leaking cwd semantics).
+ *   - Paths whose basename differs even by case (`claude.md`, `Claude.md`).
+ *   - Paths whose normalized form contains `..` (belt-and-braces — even
+ *     after basename check we don't want attackers to rely on OS resolution
+ *     quirks to smuggle a traversal through).
+ */
+export function isAllowedMemoryPath(p: unknown): p is string {
+  if (typeof p !== 'string' || p.length === 0) return false;
+  // Must be absolute to avoid ambiguous-cwd behavior across platforms.
+  if (!path.isAbsolute(p)) return false;
+  const normalized = path.normalize(p);
+  // Disallow anything that looks like it's trying to traverse after
+  // normalization (normalize usually collapses `..` but on symlinked
+  // structures attackers might still smuggle one in).
+  if (normalized.split(path.sep).some((seg) => seg === '..')) return false;
+  // Case-sensitive basename — `CLAUDE.md` only. Claude CLI itself is strict
+  // about this filename, so relaxing case here would be a silent divergence.
+  if (path.basename(normalized) !== 'CLAUDE.md') return false;
+  return true;
+}
+
+export type MemoryRead =
+  | { ok: true; content: string; exists: true }
+  | { ok: true; content: ''; exists: false }
+  | { ok: false; error: string };
+
+export function readMemoryFile(p: string): MemoryRead {
+  if (!isAllowedMemoryPath(p)) {
+    return { ok: false, error: 'invalid_path' };
+  }
+  try {
+    if (!fs.existsSync(p)) {
+      return { ok: true, content: '', exists: false };
+    }
+    const content = fs.readFileSync(p, 'utf8');
+    return { ok: true, content, exists: true };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message ?? 'read_failed' };
+  }
+}
+
+export type MemoryWrite =
+  | { ok: true }
+  | { ok: false; error: string };
+
+export function writeMemoryFile(p: string, content: string): MemoryWrite {
+  if (!isAllowedMemoryPath(p)) {
+    return { ok: false, error: 'invalid_path' };
+  }
+  if (typeof content !== 'string') {
+    return { ok: false, error: 'invalid_content' };
+  }
+  try {
+    // Ensure the parent directory exists — for user-memory at ~/.claude
+    // it might not (fresh install with no prior Claude CLI use).
+    const dir = path.dirname(p);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(p, content, 'utf8');
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message ?? 'write_failed' };
+  }
+}
+
+export function memoryFileExists(p: string): boolean {
+  if (!isAllowedMemoryPath(p)) return false;
+  try {
+    return fs.existsSync(p);
+  } catch {
+    return false;
+  }
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -158,6 +158,21 @@ const api = {
     Array<{ sessionId: string; cwd: string; title: string; mtime: number; projectDir: string }>
   > => ipcRenderer.invoke('import:scan'),
 
+  memory: {
+    read: (p: string): Promise<
+      | { ok: true; content: string; exists: boolean }
+      | { ok: false; error: string }
+    > => ipcRenderer.invoke('memory:read', p),
+    write: (p: string, content: string): Promise<{ ok: true } | { ok: false; error: string }> =>
+      ipcRenderer.invoke('memory:write', p, content),
+    exists: (p: string): Promise<boolean> => ipcRenderer.invoke('memory:exists', p),
+    /** Returns the absolute path to ~/.claude/CLAUDE.md (resolved in main). */
+    userPath: (): Promise<string> => ipcRenderer.invoke('memory:userPath'),
+    /** Returns <cwd>/CLAUDE.md, or null if cwd is empty / not absolute. */
+    projectPath: (cwd: string): Promise<string | null> =>
+      ipcRenderer.invoke('memory:projectPath', cwd),
+  },
+
   notify: (payload: {
     sessionId: string;
     title: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-markdown": "^10.1.0",
+        "react-resizable-panels": "^4.10.0",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^2.5.5",
         "zod": "^4.3.6",
@@ -15132,6 +15133,16 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-resizable-panels": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-4.10.0.tgz",
+      "integrity": "sha512-frjewRQt7TCv/vCH1pJfjZ7RxAhr5pKuqVQtVgzFq/vherxBFOWyC3xMbryx5Ti2wylViGUFc93Etg4rB3E0UA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-style-singleton": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",
+    "react-resizable-panels": "^4.10.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^2.5.5",
     "zod": "^4.3.6",

--- a/scripts/probe-appearance-polish.mjs
+++ b/scripts/probe-appearance-polish.mjs
@@ -1,0 +1,197 @@
+// E2E: appearance polish probe.
+//
+// Exercises the four polish features without needing an API key:
+//   1. Theme toggle → verify <html> class flips (dark ⇄ theme-light)
+//   2. Font-size slider → verify --app-font-size CSS var updates
+//   3. Density segmented → verify html.density-* class updates
+//   4. Sidebar drag → verify sidebarWidthPct persists across reload
+//   5. Memory tab → create/edit CLAUDE.md in a temp cwd, verify file written
+//
+// Pure black-box where possible; uses store introspection only for the
+// persist-round-trip step (which otherwise needs a full app restart to see).
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { appWindow } from './probe-utils.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function fail(msg) {
+  console.error(`\n[probe-appearance-polish] FAIL: ${msg}`);
+  process.exit(1);
+}
+function ok(msg) {
+  console.log(`[probe-appearance-polish] OK: ${msg}`);
+}
+
+const tmpRepo = fs.mkdtempSync(path.join(os.tmpdir(), 'agentory-polish-probe-'));
+
+const app = await electron.launch({
+  args: ['.'],
+  cwd: root,
+  env: { ...process.env, NODE_ENV: 'development' },
+});
+
+// Stub folder-picker so "Browse" returns tmpRepo.
+await app.evaluate(async ({ dialog }, fakeCwd) => {
+  dialog.showOpenDialog = async () => ({ canceled: false, filePaths: [fakeCwd] });
+}, tmpRepo);
+
+const win = await appWindow(app);
+await win.waitForLoadState('domcontentloaded');
+await win.waitForTimeout(2000);
+
+// Open Settings via Cmd/Ctrl+,
+await win.keyboard.press(process.platform === 'darwin' ? 'Meta+,' : 'Control+,');
+await win.waitForTimeout(500);
+
+// ── 1. Theme toggle ────────────────────────────────────────────────────────
+// Click "Light"
+await win.getByRole('radio', { name: /^light$/i }).click();
+await win.waitForTimeout(300);
+let hasLight = await win.evaluate(() =>
+  document.documentElement.classList.contains('theme-light')
+);
+if (!hasLight) fail('theme-light class not applied after clicking Light');
+ok('light theme applied');
+
+// Click "Dark"
+await win.getByRole('radio', { name: /^dark$/i }).click();
+await win.waitForTimeout(300);
+let hasDark = await win.evaluate(() =>
+  document.documentElement.classList.contains('dark') &&
+  !document.documentElement.classList.contains('theme-light')
+);
+if (!hasDark) fail('dark class not applied / theme-light not cleared');
+ok('dark theme applied');
+
+// ── 2. Font size slider ────────────────────────────────────────────────────
+const slider = win.getByRole('slider', { name: /font size/i });
+await slider.focus();
+// Set to 16 by pressing End
+await win.keyboard.press('End');
+await win.waitForTimeout(150);
+const bigPx = await win.evaluate(() =>
+  getComputedStyle(document.documentElement).getPropertyValue('--app-font-size').trim()
+);
+if (bigPx !== '16px') fail(`expected --app-font-size 16px, got "${bigPx}"`);
+ok(`font-size slider → ${bigPx}`);
+// Back to 14 (default)
+await win.keyboard.press('Home');
+await win.keyboard.press('ArrowRight');
+await win.keyboard.press('ArrowRight');
+await win.waitForTimeout(150);
+
+// ── 3. Density ─────────────────────────────────────────────────────────────
+await win.getByRole('radio', { name: /^compact$/i }).click();
+await win.waitForTimeout(200);
+const isCompact = await win.evaluate(() =>
+  document.documentElement.classList.contains('density-compact')
+);
+if (!isCompact) fail('density-compact class not applied');
+ok('density → compact');
+await win.getByRole('radio', { name: /^normal$/i }).click();
+await win.waitForTimeout(150);
+
+// ── 4. Memory tab ──────────────────────────────────────────────────────────
+// Close settings first; create a session pinned to tmpRepo so project memory is active.
+await win.keyboard.press('Escape');
+await win.waitForTimeout(200);
+
+// Use the empty-state New Session if present, else tutorial skip → New Session.
+const tutorialSkip = win.getByRole('button', { name: /skip|not now/i }).first();
+if (await tutorialSkip.isVisible().catch(() => false)) {
+  await tutorialSkip.click();
+  await win.waitForTimeout(200);
+}
+const newSessionBtn = win.getByRole('button', { name: /new session/i }).first();
+await newSessionBtn.click();
+await win.waitForTimeout(500);
+
+// Change cwd to tmpRepo via StatusBar cwd picker. The StatusBar "Browse"
+// triggers pickDirectory (stubbed above). If this is already the default,
+// we're fine either way — we only need the active session's cwd to equal
+// tmpRepo so MemoryPane shows the project editor.
+const cwdChip = win.locator('[data-cwd-trigger]').first();
+if (await cwdChip.isVisible().catch(() => false)) {
+  await cwdChip.click();
+  await win.waitForTimeout(200);
+  const browse = win.getByRole('menuitem', { name: /browse/i }).first();
+  if (await browse.isVisible().catch(() => false)) {
+    await browse.click();
+    await win.waitForTimeout(400);
+  }
+}
+
+// Force-set cwd via store as a fallback so this probe is robust to
+// StatusBar refactors. Safe — this is a dev build; production doesn't ship
+// __agentoryStore.
+await win.evaluate((cwd) => {
+  const w = /** @type {any} */ (window);
+  if (w.__agentoryStore) w.__agentoryStore.getState().changeCwd(cwd);
+}, tmpRepo);
+
+// Re-open settings on Memory tab.
+await win.keyboard.press(process.platform === 'darwin' ? 'Meta+,' : 'Control+,');
+await win.waitForTimeout(300);
+await win.getByRole('button', { name: /^memory$/i }).click();
+await win.waitForTimeout(400);
+
+// Find the project editor textarea (first textarea in the MemoryPane block
+// whose title reads "Project memory").
+const projectBlock = win.locator('div', { hasText: /project memory/i }).first();
+const projectTextarea = projectBlock.locator('textarea').first();
+await projectTextarea.waitFor({ state: 'visible', timeout: 5000 });
+await projectTextarea.fill('# probe\nwritten by probe-appearance-polish\n');
+
+// Explicit Save button
+await projectBlock.getByRole('button', { name: /^save$/i }).click();
+await win.waitForTimeout(500);
+
+const memoryPath = path.join(tmpRepo, 'CLAUDE.md');
+if (!fs.existsSync(memoryPath)) fail(`CLAUDE.md not written at ${memoryPath}`);
+const content = fs.readFileSync(memoryPath, 'utf8');
+if (!content.includes('written by probe-appearance-polish')) {
+  fail(`CLAUDE.md content unexpected:\n${content}`);
+}
+ok(`CLAUDE.md written at ${memoryPath}`);
+
+// ── 5. Sidebar width persistence ───────────────────────────────────────────
+// Close settings.
+await win.keyboard.press('Escape');
+await win.waitForTimeout(200);
+
+// Programmatically set an unusual width via the store (simulating a drag
+// outcome) — real drag coords are flaky in CI. This still proves the
+// persist round-trip end-to-end.
+const chosen = 0.34;
+await win.evaluate((pct) => {
+  const w = /** @type {any} */ (window);
+  if (w.__agentoryStore) w.__agentoryStore.getState().setSidebarWidthPct(pct);
+}, chosen);
+
+// Wait out the 250ms persist debounce.
+await win.waitForTimeout(500);
+
+// Reload the renderer. The main process (db, IPC) keeps running.
+await win.reload();
+await win.waitForLoadState('domcontentloaded');
+await win.waitForTimeout(2000);
+
+const persisted = await win.evaluate(() => {
+  const w = /** @type {any} */ (window);
+  return w.__agentoryStore?.getState().sidebarWidthPct ?? null;
+});
+if (persisted === null || Math.abs(persisted - chosen) > 0.005) {
+  fail(`sidebarWidthPct did not persist: got ${persisted}, expected ${chosen}`);
+}
+ok(`sidebarWidthPct persisted across reload: ${persisted}`);
+
+// ── Done ───────────────────────────────────────────────────────────────────
+await app.close();
+fs.rmSync(tmpRepo, { recursive: true, force: true });
+console.log('\n[probe-appearance-polish] all checks passed');
+process.exit(0);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { TooltipProvider } from './components/ui/Tooltip';
 import { ToastProvider, useToast } from './components/ui/Toast';
 import { Button } from './components/ui/Button';
 import { Sidebar } from './components/Sidebar';
+import { AppShell } from './components/AppShell';
 import { ChatStream } from './components/ChatStream';
 import { InputBar } from './components/InputBar';
 import { StatusBar } from './components/StatusBar';
@@ -15,6 +16,7 @@ import { Tutorial } from './components/Tutorial';
 import { ClaudeCliMissingDialog } from './components/ClaudeCliMissingDialog';
 import { ClaudeCliMissingBanner } from './components/ClaudeCliMissingBanner';
 import { useStore } from './stores/store';
+import { resolveEffectiveTheme } from './stores/store';
 import { setPersistErrorHandler } from './stores/persist';
 import { subscribeAgentEvents, setBackgroundWaitingHandler } from './agent/lifecycle';
 import { setOpenSettingsListener, type SettingsTab } from './slash-commands/ui-bridge';
@@ -43,7 +45,8 @@ export default function App() {
   const setPermission = useStore((s) => s.setPermission);
   const toggleSidebar = useStore((s) => s.toggleSidebar);
   const theme = useStore((s) => s.theme);
-  const fontSize = useStore((s) => s.fontSize);
+  const fontSizePx = useStore((s) => s.fontSizePx);
+  const density = useStore((s) => s.density);
   const tutorialSeen = useStore((s) => s.tutorialSeen);
   const markTutorialSeen = useStore((s) => s.markTutorialSeen);
   const checkCli = useStore((s) => s.checkCli);
@@ -52,13 +55,22 @@ export default function App() {
     void checkCli();
   }, [checkCli]);
 
+  // Theme application — reactive to both the user's explicit choice AND, when
+  // the choice is `system`, the OS theme. We set BOTH `.dark` (historical,
+  // still referenced by legacy Tailwind variants) AND `.theme-light` (new,
+  // drives the light palette overrides in global.css). The mutual exclusion
+  // keeps the `html.theme-light` selector unambiguous — no `.dark.theme-light`
+  // combo will ever exist.
   useEffect(() => {
     const root = document.documentElement;
     const apply = () => {
-      const dark =
-        theme === 'dark' ||
-        (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
-      root.classList.toggle('dark', dark);
+      const osPrefersDark =
+        typeof window !== 'undefined' &&
+        window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const effective = resolveEffectiveTheme(theme, osPrefersDark);
+      root.classList.toggle('dark', effective === 'dark');
+      root.classList.toggle('theme-light', effective === 'light');
+      root.dataset.theme = effective;
     };
     apply();
     if (theme !== 'system') return;
@@ -67,10 +79,22 @@ export default function App() {
     return () => mq.removeEventListener('change', apply);
   }, [theme]);
 
+  // Font size slider applies via CSS variable on <html>. Child text utilities
+  // honor this transitively through `font-size: var(--app-font-size)` on
+  // html/body. Explicit px overrides in components (e.g. text-[11px] labels)
+  // intentionally do NOT scale — those are information-density callouts the
+  // user's "body font size" shouldn't affect.
   useEffect(() => {
-    const px = fontSize === 'sm' ? '12px' : fontSize === 'lg' ? '14px' : '13px';
-    document.documentElement.style.setProperty('--app-font-size', px);
-  }, [fontSize]);
+    document.documentElement.style.setProperty('--app-font-size', `${fontSizePx}px`);
+  }, [fontSizePx]);
+
+  // Density class on <html>. Components consume `--density-scale` via
+  // .density-row / inline calc() — see global.css.
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.remove('density-compact', 'density-normal', 'density-comfortable');
+    root.classList.add(`density-${density}`);
+  }, [density]);
 
   const [settingsOpen, setSettingsOpen] = React.useState(false);
   const [settingsTab, setSettingsTab] = React.useState<SettingsTab | undefined>(undefined);
@@ -126,61 +150,65 @@ export default function App() {
           <PersistErrorBridge />
           <BackgroundWaitingBridge />
           <UpdateDownloadedBridge />
-          <div className="app-shell flex h-full w-full bg-bg-app text-fg-primary">
-            <Sidebar
-              onCreateSession={(cwd) => createSession(cwd)}
-              onOpenSettings={() => setSettingsOpen(true)}
-              onOpenPalette={() => setPaletteOpen(true)}
-              activeSessionId={activeId}
-              focusedGroupId={focusedGroupId}
-              onSelectSession={selectSession}
-              onFocusGroup={focusGroup}
-              sessions={sessions}
-              onMoveSession={moveSession}
-            />
-            <main className="flex-1 flex flex-col min-w-0 right-pane-frame relative">
-              <DragRegion className="relative flex items-center justify-end shrink-0" style={{ height: 32 }}>
-                <WindowControls />
-              </DragRegion>
-              <ClaudeCliMissingBanner />
-              <div className="flex-1 flex items-center justify-center min-h-0">
-                {tutorialSeen ? (
-                  <div className="flex items-center gap-3">
-                    <Button
-                      variant="secondary"
-                      size="md"
-                      onClick={() => createSession(null)}
-                      className="w-44 justify-center"
-                    >
-                      <Plus size={14} className="stroke-[2]" />
-                      <span>New Session</span>
-                    </Button>
-                    <Button
-                      variant="secondary"
-                      size="md"
-                      onClick={() => setImportOpen(true)}
-                      className="w-44 justify-center"
-                    >
-                      <Download size={14} className="stroke-[2]" />
-                      <span>Import Session</span>
-                    </Button>
-                  </div>
-                ) : (
-                  <Tutorial
-                    onNewSession={() => {
-                      markTutorialSeen();
-                      createSession(null);
-                    }}
-                    onImport={() => {
-                      markTutorialSeen();
-                      setImportOpen(true);
-                    }}
-                    onSkip={markTutorialSeen}
-                  />
-                )}
-              </div>
-            </main>
-          </div>
+          <AppShell
+            sidebar={
+              <Sidebar
+                onCreateSession={(cwd) => createSession(cwd)}
+                onOpenSettings={() => setSettingsOpen(true)}
+                onOpenPalette={() => setPaletteOpen(true)}
+                activeSessionId={activeId}
+                focusedGroupId={focusedGroupId}
+                onSelectSession={selectSession}
+                onFocusGroup={focusGroup}
+                sessions={sessions}
+                onMoveSession={moveSession}
+              />
+            }
+            main={
+              <main className="flex-1 flex flex-col min-w-0 right-pane-frame relative">
+                <DragRegion className="relative flex items-center justify-end shrink-0" style={{ height: 32 }}>
+                  <WindowControls />
+                </DragRegion>
+                <ClaudeCliMissingBanner />
+                <div className="flex-1 flex items-center justify-center min-h-0">
+                  {tutorialSeen ? (
+                    <div className="flex items-center gap-3">
+                      <Button
+                        variant="secondary"
+                        size="md"
+                        onClick={() => createSession(null)}
+                        className="w-44 justify-center"
+                      >
+                        <Plus size={14} className="stroke-[2]" />
+                        <span>New Session</span>
+                      </Button>
+                      <Button
+                        variant="secondary"
+                        size="md"
+                        onClick={() => setImportOpen(true)}
+                        className="w-44 justify-center"
+                      >
+                        <Download size={14} className="stroke-[2]" />
+                        <span>Import Session</span>
+                      </Button>
+                    </div>
+                  ) : (
+                    <Tutorial
+                      onNewSession={() => {
+                        markTutorialSeen();
+                        createSession(null);
+                      }}
+                      onImport={() => {
+                        markTutorialSeen();
+                        setImportOpen(true);
+                      }}
+                      onSkip={markTutorialSeen}
+                    />
+                  )}
+                </div>
+              </main>
+            }
+          />
           <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} initialTab={settingsTab} />
           <ImportDialog open={importOpen} onOpenChange={setImportOpen} />
           <ClaudeCliMissingDialog />
@@ -204,46 +232,50 @@ export default function App() {
         <PersistErrorBridge />
         <BackgroundWaitingBridge />
         <UpdateDownloadedBridge />
-        <div className="app-shell flex h-full w-full bg-bg-app text-fg-primary">
-          <Sidebar
-            onCreateSession={(cwd) => createSession(cwd)}
-            onOpenSettings={() => setSettingsOpen(true)}
-            onOpenPalette={() => setPaletteOpen(true)}
-            activeSessionId={activeId}
-            focusedGroupId={focusedGroupId}
-            onSelectSession={selectSession}
-            onFocusGroup={focusGroup}
-            sessions={sessions}
-            onMoveSession={moveSession}
-          />
-          <main className="flex-1 flex flex-col min-w-0 right-pane-frame relative">
-            <DragRegion className="relative flex items-center justify-end shrink-0" style={{ height: 32 }}>
-              <WindowControls />
-            </DragRegion>
-            <ClaudeCliMissingBanner />
-            <ChatStream />
-            <StatusBar
-              cwd={active.cwd}
-              model={active.model || model}
-              permission={permission}
-              onChangeCwd={async (p) => {
-                let next = p;
-                if (next === null) {
-                  next = (await window.agentory?.pickDirectory()) ?? null;
-                }
-                if (!next) return;
-                changeCwd(next);
-                pushRecentProject(next);
-              }}
-              onChangeModel={setModel}
-              onChangePermission={setPermission}
+        <AppShell
+          sidebar={
+            <Sidebar
+              onCreateSession={(cwd) => createSession(cwd)}
+              onOpenSettings={() => setSettingsOpen(true)}
+              onOpenPalette={() => setPaletteOpen(true)}
+              activeSessionId={activeId}
+              focusedGroupId={focusedGroupId}
+              onSelectSession={selectSession}
+              onFocusGroup={focusGroup}
+              sessions={sessions}
+              onMoveSession={moveSession}
             />
-            <InputBar sessionId={active.id} />
-            <div className="px-4 pb-2 font-mono text-xs text-fg-disabled select-none">
-              <span>Enter send · Shift+Enter newline</span>
-            </div>
-          </main>
-        </div>
+          }
+          main={
+            <main className="flex-1 flex flex-col min-w-0 right-pane-frame relative">
+              <DragRegion className="relative flex items-center justify-end shrink-0" style={{ height: 32 }}>
+                <WindowControls />
+              </DragRegion>
+              <ClaudeCliMissingBanner />
+              <ChatStream />
+              <StatusBar
+                cwd={active.cwd}
+                model={active.model || model}
+                permission={permission}
+                onChangeCwd={async (p) => {
+                  let next = p;
+                  if (next === null) {
+                    next = (await window.agentory?.pickDirectory()) ?? null;
+                  }
+                  if (!next) return;
+                  changeCwd(next);
+                  pushRecentProject(next);
+                }}
+                onChangeModel={setModel}
+                onChangePermission={setPermission}
+              />
+              <InputBar sessionId={active.id} />
+              <div className="px-4 pb-2 font-mono text-xs text-fg-disabled select-none">
+                <span>Enter send · Shift+Enter newline</span>
+              </div>
+            </main>
+          }
+        />
         <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} initialTab={settingsTab} />
         <ImportDialog open={importOpen} onOpenChange={setImportOpen} />
         <ClaudeCliMissingDialog />

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { Group, Panel, Separator, type PanelSize } from 'react-resizable-panels';
+import { useStore } from '../stores/store';
+
+/**
+ * Two-pane shell with a draggable vertical divider.
+ *
+ * react-resizable-panels 4.x accepts size strings like `"220px"` / `"22%"`,
+ * so we can express sidebar constraints in the units that matter:
+ *   - min 220px, max 480px for the sidebar
+ *   - min 480px for the chat pane (it's the content-dense side)
+ *
+ * We persist the sidebar width as a *fraction* of the group width so the
+ * layout adapts when the window resizes — on a 1920px monitor, 22% gives
+ * the user more sidebar than on 1280px, which matches user expectation
+ * (more real estate → more room to see everything).
+ *
+ * On drag we receive both `inPixels` and `asPercentage` — we store the %
+ * value. The library debounces onResize internally; the persist layer
+ * (store → schedulePersist) adds another 250ms coalesce.
+ */
+export function AppShell({
+  sidebar,
+  main,
+}: {
+  sidebar: React.ReactNode;
+  main: React.ReactNode;
+}) {
+  const sidebarWidthPct = useStore((s) => s.sidebarWidthPct);
+  const setSidebarWidthPct = useStore((s) => s.setSidebarWidthPct);
+
+  // Percent value as a string, which is what the library's defaultSize prop
+  // expects when we want percentage semantics. Clamp to a sane range so a
+  // corrupted persisted state can't wedge the UI at 0%.
+  const defaultSidebarPct = Math.round(
+    Math.max(12, Math.min(40, sidebarWidthPct * 100))
+  );
+
+  return (
+    <Group
+      orientation="horizontal"
+      className="app-shell flex h-full w-full bg-bg-app text-fg-primary"
+    >
+      <Panel
+        id="sidebar"
+        defaultSize={`${defaultSidebarPct}%`}
+        minSize="220px"
+        maxSize="480px"
+        onResize={(size: PanelSize) => {
+          // asPercentage ∈ [0..100]; we normalize to the 0..1 fraction our
+          // store uses. Setter clamps again so we never persist an out-of-
+          // range value even if the library miscalculates on edge resizes.
+          setSidebarWidthPct(size.asPercentage / 100);
+        }}
+        className="flex"
+      >
+        {sidebar}
+      </Panel>
+      <Separator
+        className="pane-resize-handle"
+        aria-label="Resize sidebar"
+      />
+      <Panel
+        id="main"
+        defaultSize={`${100 - defaultSidebarPct}%`}
+        minSize="480px"
+        className="flex"
+      >
+        {main}
+      </Panel>
+    </Group>
+  );
+}

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -26,10 +26,11 @@ type LocalUpdateStatus =
   | { kind: 'downloaded'; version: string }
   | { kind: 'error'; message: string };
 
-type Tab = 'general' | 'notifications' | 'endpoints' | 'autopilot' | 'permissions' | 'account' | 'data' | 'shortcuts' | 'updates';
+type Tab = 'appearance' | 'memory' | 'notifications' | 'endpoints' | 'autopilot' | 'permissions' | 'account' | 'data' | 'shortcuts' | 'updates';
 
 const TABS: { id: Tab; label: string }[] = [
-  { id: 'general', label: 'General' },
+  { id: 'appearance', label: 'Appearance' },
+  { id: 'memory', label: 'Memory' },
   { id: 'notifications', label: 'Notifications' },
   { id: 'endpoints', label: 'Endpoints' },
   { id: 'autopilot', label: 'Autopilot' },
@@ -61,7 +62,7 @@ export function SettingsDialog({
   onOpenChange: (open: boolean) => void;
   initialTab?: Tab;
 }) {
-  const [tab, setTab] = useState<Tab>(initialTab ?? 'general');
+  const [tab, setTab] = useState<Tab>(initialTab ?? 'appearance');
 
   // Sync the tab when the dialog is reopened with a fresh initialTab (e.g.,
   // `/config` vs `/model` — the latter wants the endpoints tab).
@@ -93,7 +94,8 @@ export function SettingsDialog({
             ))}
           </nav>
           <div className="flex-1 min-w-0 p-5 overflow-y-auto">
-            {tab === 'general' && <GeneralPane />}
+            {tab === 'appearance' && <AppearancePane />}
+            {tab === 'memory' && <MemoryPane />}
             {tab === 'notifications' && <NotificationsPane />}
             {tab === 'endpoints' && <EndpointsPane />}
             {tab === 'autopilot' && <AutopilotPane />}
@@ -119,7 +121,7 @@ function Field({ label, hint, children }: { label: string; hint?: string; childr
   );
 }
 
-function Select<T extends string>({
+function _Select<T extends string>({
   value,
   onChange,
   options
@@ -148,36 +150,308 @@ function Select<T extends string>({
   );
 }
 
-function GeneralPane() {
+function AppearancePane() {
   const theme = useStore((s) => s.theme);
-  const fontSize = useStore((s) => s.fontSize);
+  const fontSizePx = useStore((s) => s.fontSizePx);
+  const density = useStore((s) => s.density);
   const setTheme = useStore((s) => s.setTheme);
-  const setFontSize = useStore((s) => s.setFontSize);
+  const setFontSizePx = useStore((s) => s.setFontSizePx);
+  const setDensity = useStore((s) => s.setDensity);
+
+  const sizeStops: Array<12 | 13 | 14 | 15 | 16> = [12, 13, 14, 15, 16];
+
   return (
     <>
-      <Field label="Theme">
-        <Select
+      <Field label="Theme" hint="System follows your OS preference (and reacts live when it changes).">
+        <Segmented
           value={theme}
           onChange={setTheme}
           options={[
-            { value: 'system', label: 'System' },
+            { value: 'dark', label: 'Dark' },
             { value: 'light', label: 'Light' },
-            { value: 'dark', label: 'Dark' }
+            { value: 'system', label: 'System' },
           ]}
         />
       </Field>
-      <Field label="Font size" hint="Affects chat stream and sidebar">
-        <Select
-          value={fontSize}
-          onChange={setFontSize}
+      <Field label="Font size" hint="Applies to the whole app. Explicit small labels (meta, kbd) keep their intrinsic size.">
+        <div className="flex items-center gap-3">
+          <input
+            type="range"
+            min={12}
+            max={16}
+            step={1}
+            value={fontSizePx}
+            onChange={(e) => {
+              const v = Number.parseInt(e.target.value, 10);
+              if (sizeStops.includes(v as 12 | 13 | 14 | 15 | 16)) {
+                setFontSizePx(v as 12 | 13 | 14 | 15 | 16);
+              }
+            }}
+            className="w-48 accent-accent cursor-pointer"
+            aria-label="Font size in pixels"
+          />
+          <span className="text-xs font-mono text-fg-secondary tabular-nums w-10">{fontSizePx}px</span>
+        </div>
+      </Field>
+      <Field label="Density" hint="Tightens or loosens row padding and spacing across the app.">
+        <Segmented
+          value={density}
+          onChange={setDensity}
           options={[
-            { value: 'sm', label: 'Small (12px)' },
-            { value: 'md', label: 'Medium (13px, default)' },
-            { value: 'lg', label: 'Large (14px)' }
+            { value: 'compact', label: 'Compact' },
+            { value: 'normal', label: 'Normal' },
+            { value: 'comfortable', label: 'Comfortable' },
           ]}
         />
       </Field>
     </>
+  );
+}
+
+function Segmented<T extends string>({
+  value,
+  onChange,
+  options,
+}: {
+  value: T;
+  onChange: (v: T) => void;
+  options: { value: T; label: string }[];
+}) {
+  return (
+    <div
+      className={cn(
+        'inline-flex h-7 items-center rounded-sm border border-border-default',
+        'bg-bg-elevated p-0.5 gap-0.5'
+      )}
+      role="radiogroup"
+    >
+      {options.map((o) => {
+        const active = o.value === value;
+        return (
+          <button
+            key={o.value}
+            role="radio"
+            aria-checked={active}
+            onClick={() => onChange(o.value)}
+            className={cn(
+              'h-6 px-2.5 text-xs rounded-[3px] transition-[background-color,color,box-shadow] duration-150 ease-out',
+              'outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-accent/60',
+              active
+                ? 'bg-bg-app text-fg-primary font-medium shadow-[inset_0_0_0_1px_var(--color-border-default)]'
+                : 'text-fg-secondary hover:text-fg-primary hover:bg-bg-hover'
+            )}
+          >
+            {o.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function MemoryPane() {
+  const sessions = useStore((s) => s.sessions);
+  const activeId = useStore((s) => s.activeId);
+  const active = sessions.find((s) => s.id === activeId);
+  const cwd = active?.cwd ?? '';
+  const [projectPath, setProjectPath] = useState<string | null>(null);
+  const [userPath, setUserPath] = useState<string>('');
+
+  useEffect(() => {
+    const api = window.agentory;
+    if (!api) return;
+    api.memory.userPath().then(setUserPath).catch(() => setUserPath(''));
+  }, []);
+
+  useEffect(() => {
+    const api = window.agentory;
+    if (!api) return;
+    api.memory.projectPath(cwd).then(setProjectPath).catch(() => setProjectPath(null));
+  }, [cwd]);
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="text-xs text-fg-tertiary">
+        CLAUDE.md files bias what the agent remembers between turns. Project
+        memory travels with the repo; user memory is global to your machine.
+        Writes here save directly to disk — no reload needed.
+      </div>
+      {projectPath ? (
+        <MemoryEditor
+          title="Project memory"
+          hint="Committed with the repo. Visible to anyone with access to the codebase."
+          path={projectPath}
+        />
+      ) : (
+        <div className="rounded-sm border border-border-subtle bg-bg-elevated px-3 py-4 text-xs text-fg-tertiary opacity-70">
+          <div className="font-medium text-fg-secondary mb-1">Project memory</div>
+          Open a session to edit project memory.
+        </div>
+      )}
+      {userPath && (
+        <MemoryEditor
+          title="User memory"
+          hint="Applies to every session on this machine, regardless of repo."
+          path={userPath}
+        />
+      )}
+    </div>
+  );
+}
+
+function MemoryEditor({
+  title,
+  hint,
+  path,
+}: {
+  title: string;
+  hint: string;
+  path: string;
+}) {
+  const [content, setContent] = useState<string>('');
+  const [exists, setExists] = useState<boolean>(false);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [dirty, setDirty] = useState<boolean>(false);
+  const [saving, setSaving] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedTick, setSavedTick] = useState<number>(0);
+
+  const reload = React.useCallback(async () => {
+    const api = window.agentory;
+    if (!api) return;
+    setLoading(true);
+    setError(null);
+    const res = await api.memory.read(path);
+    setLoading(false);
+    if (!res.ok) {
+      setError(res.error);
+      return;
+    }
+    setContent(res.content);
+    setExists(res.exists);
+    setDirty(false);
+  }, [path]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const save = React.useCallback(async () => {
+    const api = window.agentory;
+    if (!api) return;
+    if (!dirty || saving) return;
+    setSaving(true);
+    setError(null);
+    const res = await api.memory.write(path, content);
+    setSaving(false);
+    if (!res.ok) {
+      setError(res.error);
+      return;
+    }
+    setExists(true);
+    setDirty(false);
+    setSavedTick(Date.now());
+  }, [dirty, saving, path, content]);
+
+  // Rough token estimate. For MVP we use the common length/4 heuristic —
+  // the real count varies by tokenizer but is close enough for a "this
+  // file is getting long" cue. If the user cares, they'll feel it.
+  const estTokens = Math.ceil(content.length / 4);
+
+  return (
+    <div className="rounded-sm border border-border-subtle bg-bg-elevated">
+      <div className="flex items-center justify-between px-3 py-2 border-b border-border-subtle gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-medium text-fg-primary">{title}</div>
+          <div
+            className="text-[11px] font-mono text-fg-tertiary truncate"
+            title={path}
+          >
+            {path}
+          </div>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <span
+            className={cn(
+              'text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded-sm font-mono',
+              estTokens > 8000
+                ? 'bg-status-warning-muted text-status-warning-foreground'
+                : 'bg-bg-hover text-fg-tertiary'
+            )}
+            title="Rough estimate (chars / 4). Not a real tokenizer."
+          >
+            ~{estTokens.toLocaleString()} tok
+          </span>
+          {!exists && !loading && (
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={async () => {
+                const api = window.agentory;
+                if (!api) return;
+                const res = await api.memory.write(path, content || '');
+                if (!res.ok) setError(res.error);
+                else {
+                  setExists(true);
+                  setDirty(false);
+                }
+              }}
+            >
+              Create
+            </Button>
+          )}
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={save}
+            disabled={!dirty || saving}
+            title={dirty ? 'Save' : 'No changes'}
+          >
+            {saving ? 'Saving…' : dirty ? 'Save' : 'Saved'}
+          </Button>
+        </div>
+      </div>
+      <div className="px-3 pt-2 pb-3">
+        <div className="text-[11px] text-fg-tertiary mb-1.5">{hint}</div>
+        <textarea
+          value={content}
+          onChange={(e) => {
+            setContent(e.target.value);
+            setDirty(true);
+          }}
+          onBlur={() => void save()}
+          disabled={loading}
+          spellCheck={false}
+          rows={10}
+          placeholder={exists ? '' : 'This file will be created on save.'}
+          className={cn(
+            'w-full px-2.5 py-2 rounded-sm bg-bg-panel border border-border-default',
+            'text-xs font-mono leading-relaxed text-fg-primary placeholder:text-fg-disabled',
+            'outline-none resize-y',
+            'focus:border-border-strong focus:shadow-[0_0_0_2px_oklch(0.72_0.14_215_/_0.30)]',
+            'disabled:opacity-60 disabled:cursor-progress'
+          )}
+        />
+        <div className="flex items-center justify-between mt-1.5 h-4">
+          <span className="text-[11px] text-fg-tertiary">
+            {loading
+              ? 'Loading…'
+              : error
+              ? <span className="text-status-error-foreground">{error}</span>
+              : !exists
+              ? 'Not yet created on disk.'
+              : dirty
+              ? 'Unsaved changes.'
+              : savedTick > 0
+              ? 'Saved.'
+              : ''}
+          </span>
+          <span className="text-[11px] text-fg-tertiary tabular-nums">
+            {content.length.toLocaleString()} chars
+          </span>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -468,9 +468,16 @@ export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, active
     >
     <motion.aside
       initial={false}
-      animate={{ width: collapsed ? 48 : 256 }}
+      // When collapsed we still animate down to a 48px rail; otherwise we
+      // stretch to whatever width the parent panel gives us (see
+      // `AppShell.tsx` — PanelGroup drives the outer width now). Using
+      // `100%` rather than a fixed number lets react-resizable-panels own
+      // the sizing contract; framer-motion's `animate` still gives us a
+      // smooth transition between rail ↔ expanded. Both values are strings
+      // so framer doesn't have to bridge px↔% during the tween.
+      animate={{ width: collapsed ? '48px' : '100%' }}
       transition={{ duration: 0.22, ease: [0.32, 0.72, 0, 1] }}
-      className="relative flex flex-col bg-bg-sidebar/80 backdrop-blur-xl sidebar-edge overflow-hidden"
+      className="relative flex flex-col bg-bg-sidebar/80 backdrop-blur-xl sidebar-edge overflow-hidden h-full"
     >
       {/* Top drag strip — mirrors the right pane's 32px drag strip so the
           two panes share a horizontal title-bar band. On macOS this is

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -134,6 +134,19 @@ declare global {
         Array<{ sessionId: string; cwd: string; title: string; mtime: number; projectDir: string }>
       >;
 
+      memory: {
+        read: (p: string) => Promise<
+          | { ok: true; content: string; exists: boolean }
+          | { ok: false; error: string }
+        >;
+        write: (p: string, content: string) => Promise<
+          { ok: true } | { ok: false; error: string }
+        >;
+        exists: (p: string) => Promise<boolean>;
+        userPath: () => Promise<string>;
+        projectPath: (cwd: string) => Promise<string | null>;
+      };
+
       notify: (payload: {
         sessionId: string;
         title: string;

--- a/src/slash-commands/handlers.ts
+++ b/src/slash-commands/handlers.ts
@@ -79,7 +79,7 @@ export function handleCost(ctx: SlashCommandContext): void {
 
 // ---------- /config ----------
 export function handleConfig(_ctx: SlashCommandContext): void {
-  openSettings('general');
+  openSettings('appearance');
 }
 
 // ---------- /model ----------

--- a/src/slash-commands/ui-bridge.ts
+++ b/src/slash-commands/ui-bridge.ts
@@ -7,10 +7,12 @@
 // and assert on emitted events.
 
 export type SettingsTab =
-  | 'general'
+  | 'appearance'
+  | 'memory'
   | 'notifications'
   | 'endpoints'
   | 'autopilot'
+  | 'permissions'
   | 'account'
   | 'data'
   | 'shortcuts'

--- a/src/stores/persist.ts
+++ b/src/stores/persist.ts
@@ -3,6 +3,8 @@ import type {
   PermissionMode,
   Theme,
   FontSize,
+  FontSizePx,
+  Density,
   WatchdogConfig,
   NotificationSettings
 } from './store';
@@ -21,8 +23,14 @@ export interface PersistedState {
   // read. Writes always use the current `PermissionMode`.
   permission: PermissionMode | string;
   sidebarCollapsed: boolean;
+  /** Sidebar width as a fraction of window width. See State.sidebarWidthPct. */
+  sidebarWidthPct?: number;
   theme?: Theme;
   fontSize?: FontSize;
+  /** Preferred over legacy `fontSize` when present. 12–16 px scale. */
+  fontSizePx?: FontSizePx;
+  /** UI density (compact/normal/comfortable). */
+  density?: Density;
   recentProjects?: RecentProject[];
   tutorialSeen?: boolean;
   watchdog?: WatchdogConfig;

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -14,7 +14,17 @@ export type ModelId = string;
 // name; `dontAsk` is legacy and redundant.
 export type PermissionMode = 'plan' | 'default' | 'acceptEdits' | 'bypassPermissions';
 export type Theme = 'system' | 'light' | 'dark';
+/**
+ * Legacy categorical font size (`sm`/`md`/`lg`) — kept for persistence back-
+ * compat. New code should read `fontSizePx` instead. `migrateFontSize()`
+ * maps old values to pixels during hydration.
+ */
 export type FontSize = 'sm' | 'md' | 'lg';
+/** Root font-size in px. One of 12/13/14/15/16. */
+export type FontSizePx = 12 | 13 | 14 | 15 | 16;
+/** UI density — drives row padding / line height / block spacing via
+ * `--density-scale` CSS variable. Compact = tighter, Comfortable = airier. */
+export type Density = 'compact' | 'normal' | 'comfortable';
 
 export type EndpointKind =
   | 'anthropic'
@@ -148,8 +158,17 @@ type State = {
   model: ModelId;
   permission: PermissionMode;
   sidebarCollapsed: boolean;
+  /**
+   * Sidebar width as a percentage of the window width (0–1). Persisted as a
+   * fraction rather than px so the layout adapts gracefully across different
+   * window sizes / monitors. The resizable panel enforces min/max in px at
+   * render time; this is just the *desired* ratio.
+   */
+  sidebarWidthPct: number;
   theme: Theme;
   fontSize: FontSize;
+  fontSizePx: FontSizePx;
+  density: Density;
   tutorialSeen: boolean;
   watchdog: WatchdogConfig;
   watchdogCountsBySession: Record<string, number>;
@@ -199,6 +218,9 @@ type Actions = {
   toggleSidebar: () => void;
   setTheme: (theme: Theme) => void;
   setFontSize: (size: FontSize) => void;
+  setFontSizePx: (px: FontSizePx) => void;
+  setDensity: (density: Density) => void;
+  setSidebarWidthPct: (pct: number) => void;
   markTutorialSeen: () => void;
   setWatchdog: (patch: Partial<WatchdogConfig>) => void;
   resetWatchdogCount: (sessionId: string) => void;
@@ -273,6 +295,56 @@ function firstUsableGroupId(groups: Group[]): string {
   return g ? g.id : groups[0]?.id ?? 'g1';
 }
 
+// ── Appearance helpers ──────────────────────────────────────────────────────
+
+/** Map the legacy `sm`/`md`/`lg` enum to the numeric pixel scale. The old
+ * values kept only three stops (12/13/14); the new slider exposes 12–16.
+ * `md` → 14 intentionally (new default), not 13 — we're rebalancing the
+ * whole scale to match Inter's optical size sweet spot. */
+export function legacyFontSizeToPx(v: FontSize): FontSizePx {
+  switch (v) {
+    case 'sm': return 12;
+    case 'md': return 14;
+    case 'lg': return 16;
+  }
+}
+
+/** Inverse — used when the user drags the new slider and we want the legacy
+ * `fontSize` field to stay consistent (older code paths still read it). */
+export function pxToLegacyFontSize(px: FontSizePx): FontSize {
+  if (px <= 12) return 'sm';
+  if (px >= 16) return 'lg';
+  return 'md';
+}
+
+export function sanitizeFontSizePx(raw: unknown): FontSizePx {
+  const n = typeof raw === 'number' ? Math.round(raw) : NaN;
+  if (n === 12 || n === 13 || n === 14 || n === 15 || n === 16) return n;
+  return 14;
+}
+
+export function sanitizeDensity(raw: unknown): Density {
+  if (raw === 'compact' || raw === 'normal' || raw === 'comfortable') return raw;
+  return 'normal';
+}
+
+export function sanitizeSidebarWidthPct(raw: unknown): number {
+  const n = typeof raw === 'number' && Number.isFinite(raw) ? raw : 0.22;
+  return Math.max(0.12, Math.min(0.5, n));
+}
+
+/** Resolve `theme` + OS signal to the actual rendered theme. Exported so
+ * tests can lock OS state. `osPrefersDark` is the value of
+ * `matchMedia('(prefers-color-scheme: dark)').matches` at call time. */
+export function resolveEffectiveTheme(
+  theme: Theme,
+  osPrefersDark: boolean
+): 'light' | 'dark' {
+  if (theme === 'light') return 'light';
+  if (theme === 'dark') return 'dark';
+  return osPrefersDark ? 'dark' : 'light';
+}
+
 // Module-scoped set tracking in-flight db fetches, so rapid re-clicks on a
 // session don't issue redundant IPC round-trips.
 const inFlightLoads = new Set<string>();
@@ -290,8 +362,11 @@ export const useStore = create<State & Actions>((set, get) => ({
   model: '',
   permission: 'default',
   sidebarCollapsed: false,
+  sidebarWidthPct: 0.22,
   theme: 'system',
   fontSize: 'md',
+  fontSizePx: 14,
+  density: 'normal',
   tutorialSeen: false,
   watchdog: DEFAULT_WATCHDOG,
   watchdogCountsBySession: {},
@@ -525,7 +600,13 @@ export const useStore = create<State & Actions>((set, get) => ({
   setSidebarCollapsed: (collapsed) => set({ sidebarCollapsed: collapsed }),
   toggleSidebar: () => set((s) => ({ sidebarCollapsed: !s.sidebarCollapsed })),
   setTheme: (theme) => set({ theme }),
-  setFontSize: (fontSize) => set({ fontSize }),
+  setFontSize: (fontSize) => set({ fontSize, fontSizePx: legacyFontSizeToPx(fontSize) }),
+  setFontSizePx: (fontSizePx) => set({ fontSizePx, fontSize: pxToLegacyFontSize(fontSizePx) }),
+  setDensity: (density) => set({ density }),
+  setSidebarWidthPct: (pct) => {
+    const clamped = Math.max(0.12, Math.min(0.5, pct));
+    set({ sidebarWidthPct: clamped });
+  },
   markTutorialSeen: () => set({ tutorialSeen: true }),
 
   setWatchdog: (patch) =>
@@ -924,8 +1005,13 @@ export async function hydrateStore(): Promise<void> {
       model: persisted.model,
       permission: migratePermission(persisted.permission),
       sidebarCollapsed: persisted.sidebarCollapsed ?? false,
+      sidebarWidthPct: sanitizeSidebarWidthPct(persisted.sidebarWidthPct),
       theme: persisted.theme ?? 'system',
       fontSize: persisted.fontSize ?? 'md',
+      fontSizePx: persisted.fontSizePx !== undefined
+        ? sanitizeFontSizePx(persisted.fontSizePx)
+        : legacyFontSizeToPx(persisted.fontSize ?? 'md'),
+      density: sanitizeDensity(persisted.density),
       recentProjects: persisted.recentProjects ?? [],
       tutorialSeen: persisted.tutorialSeen ?? false,
       watchdog: { ...DEFAULT_WATCHDOG, ...(persisted.watchdog ?? {}) },
@@ -964,8 +1050,11 @@ export async function hydrateStore(): Promise<void> {
       model: s.model,
       permission: s.permission,
       sidebarCollapsed: s.sidebarCollapsed,
+      sidebarWidthPct: s.sidebarWidthPct,
       theme: s.theme,
       fontSize: s.fontSize,
+      fontSizePx: s.fontSizePx,
+      density: s.density,
       recentProjects: s.recentProjects,
       tutorialSeen: s.tutorialSeen,
       watchdog: s.watchdog,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,12 @@
 @import "tailwindcss";
 
+/*
+  Tokens live in @theme so Tailwind's v4 resolver picks them up. These are the
+  DARK palette (the historical default). The LIGHT palette is applied by
+  overriding the same CSS custom properties inside `html.theme-light` below —
+  every `bg-bg-panel`, `text-fg-primary`, etc. Tailwind utility just resolves
+  to the active value, no component-level branching needed.
+*/
 @theme {
   /* Solid surfaces — depth comes from inset highlights + drop shadows,
      not transparency. Order: app < sidebar < panel < elevated. */
@@ -130,12 +137,159 @@ html, body, #root {
   background: var(--color-bg-app);
   color: var(--color-fg-primary);
   font-family: var(--font-sans);
-  font-size: var(--text-base);
+  /* --app-font-size is bumped by the Appearance settings slider (12–16px).
+     Using the token via CSS var means every `text-*` utility scales from the
+     root — if you need an override (e.g. a small meta label), use explicit
+     px in the component. Default 14 matches the legacy `md` stop. */
+  font-size: var(--app-font-size, 14px);
   line-height: var(--text-base--line-height);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
   overflow: hidden;
+}
+
+/*
+  Density scale. Multiplies padding / row heights in density-aware utilities
+  (see `.density-row` below). The three stops are intentionally narrow —
+  beyond ±15% the sidebar reads as broken, not "cozy". Applied to the
+  <html> element via JS based on user preference.
+*/
+html {
+  --density-scale: 1;
+}
+html.density-compact     { --density-scale: 0.88; }
+html.density-normal      { --density-scale: 1; }
+html.density-comfortable { --density-scale: 1.15; }
+
+/*
+  LIGHT palette.
+
+  This is NOT a mechanical inversion — a naive `1 - L` recipe produces a
+  glaring, tiring light mode. Instead we rebalance:
+    - Surfaces spread less in L than dark (humans see more L steps in the
+      upper range, so we crush the range to keep hierarchy without yelling).
+    - Borders tone down — pure black hairlines look dirty at 14px font size.
+    - Accent ring pulled down in L for contrast against light surfaces; hue
+      kept at 215 for visual identity continuity.
+    - Drop shadows slightly warmer (≈60° hue) so the app reads as "paper on
+      a desk" rather than "plastic". Warmth is Apple's cue for "lift".
+*/
+html.theme-light {
+  --color-bg-app: oklch(0.985 0.002 240);
+  --color-bg-sidebar: oklch(0.965 0.003 240);
+  --color-bg-panel: oklch(0.995 0.001 240);
+  --color-bg-elevated: oklch(0.975 0.003 240);
+  --color-bg-hover: oklch(0.935 0.004 240);
+  --color-bg-active: oklch(0.895 0.006 240);
+
+  --color-fg-primary: oklch(0.22 0.01 240);
+  --color-fg-secondary: oklch(0.36 0.008 240);
+  --color-fg-tertiary: oklch(0.48 0.006 240);
+  --color-fg-disabled: oklch(0.62 0.004 240);
+  --color-fg-faint: oklch(0.70 0.003 240);
+
+  --color-border-subtle: oklch(0.90 0.003 240);
+  --color-border-default: oklch(0.82 0.004 240);
+  --color-border-strong: oklch(0.70 0.005 240);
+
+  --color-accent: oklch(0.58 0.14 225);
+  --color-accent-quiet: oklch(0.62 0.08 225);
+  --color-accent-fg: oklch(0.99 0 0);
+  --color-accent-soft: oklch(0.58 0.14 225 / 0.14);
+
+  --color-state-running: oklch(0.55 0.14 155);
+  --color-state-waiting: oklch(0.58 0.12 75);
+  --color-state-parked: var(--color-fg-tertiary);
+  --color-state-success: oklch(0.55 0.14 155);
+  --color-state-warning: oklch(0.62 0.15 75);
+  --color-state-error: oklch(0.52 0.21 25);
+  --color-state-error-soft: oklch(0.52 0.21 25 / 0.10);
+  --color-state-error-strong: oklch(0.46 0.22 25);
+  --color-state-error-fg: oklch(0.99 0 0);
+
+  /* Inner highlight in dark = "light from above"; in light the analogue is
+     a soft warm inset shadow on the top edge, not a highlight. */
+  --surface-highlight: oklch(0 0 0 / 0.03);
+  --surface-shadow:
+    0 1px 2px oklch(0 0 0 / 0.06),
+    0 4px 16px oklch(0.6 0.02 60 / 0.08);
+
+  --color-bg-app-foreground: var(--color-fg-primary);
+  --color-bg-panel-foreground: var(--color-fg-primary);
+  --color-bg-elevated-foreground: var(--color-fg-primary);
+  --color-bg-hover-foreground: var(--color-fg-primary);
+
+  --color-popover: oklch(0.995 0.001 240);
+  --color-popover-foreground: var(--color-fg-primary);
+  --color-popover-border: var(--color-border-default);
+
+  --color-card: var(--color-bg-panel);
+  --color-card-foreground: var(--color-fg-primary);
+  --color-card-border: var(--color-border-subtle);
+
+  --color-status-success: oklch(0.55 0.14 155);
+  --color-status-success-foreground: oklch(0.48 0.14 155);
+  --color-status-success-muted: oklch(0.55 0.14 155 / 0.10);
+  --color-status-success-border: oklch(0.55 0.14 155 / 0.28);
+
+  --color-status-warning: oklch(0.62 0.15 75);
+  --color-status-warning-foreground: oklch(0.52 0.15 75);
+  --color-status-warning-muted: oklch(0.62 0.15 75 / 0.10);
+  --color-status-warning-border: oklch(0.62 0.15 75 / 0.28);
+
+  --color-status-error: oklch(0.52 0.21 25);
+  --color-status-error-foreground: oklch(0.48 0.21 25);
+  --color-status-error-muted: oklch(0.52 0.21 25 / 0.10);
+  --color-status-error-border: oklch(0.52 0.21 25 / 0.30);
+
+  --color-status-info: oklch(0.58 0.14 225);
+  --color-status-info-foreground: oklch(0.50 0.14 225);
+  --color-status-info-muted: oklch(0.58 0.14 225 / 0.10);
+  --color-status-info-border: oklch(0.58 0.14 225 / 0.28);
+
+  /* Terminal stays dark even in light mode — shell output is easier to
+     parse on dark, and every major terminal emulator ships dark by default.
+     Inverting it would break mental model + hurt ANSI color contrast. */
+  --color-terminal-bg: oklch(0.18 0.004 240);
+  --color-terminal-foreground: oklch(0.90 0.006 106);
+  --color-terminal-muted: oklch(0.58 0.01 58);
+  --color-terminal-border: oklch(0.30 0.005 240);
+  --color-terminal-accent: oklch(0.60 0.17 155);
+  --color-terminal-hover-bg: oklch(0.24 0.005 240);
+}
+
+html.theme-light ::selection {
+  background: var(--color-accent-soft);
+  color: var(--color-fg-primary);
+}
+
+/* Light-mode label overrides — the hard-coded oklch() grays in the type
+   utilities below were authored for the dark palette. Remap them here so
+   text-label-* reads correctly on light surfaces too. */
+html.theme-light .text-label-section,
+html.theme-light .text-label-meta {
+  color: oklch(0.48 0.006 240);
+}
+html.theme-light .text-label-faint {
+  color: oklch(0.62 0.004 240);
+}
+html.theme-light .text-body-row {
+  color: oklch(0.36 0.008 240);
+}
+html.theme-light .text-body-emphasis {
+  color: oklch(0.22 0.01 240);
+}
+
+/* Light-mode scrollbar — the dark palette's border tokens are too dark to
+   read as "scrollbar" on a near-white surface. */
+html.theme-light ::-webkit-scrollbar-thumb {
+  background: oklch(0.78 0.004 240);
+  background-clip: padding-box;
+}
+html.theme-light ::-webkit-scrollbar-thumb:hover {
+  background: oklch(0.68 0.004 240);
+  background-clip: padding-box;
 }
 
 /* Inter stylistic sets only on opt-in Latin contexts. Applying this to a
@@ -346,4 +500,50 @@ html, body, #root {
   background: var(--color-border-strong);
   background-clip: padding-box;
   border: 2px solid transparent;
+}
+
+/*
+  Pane resize handle for react-resizable-panels' <Separator>.
+
+  Spec: 4px-wide invisible hit area, 1px visible divider that only appears on
+  hover / drag / focus — matches VS Code, Linear, Figma. We render it as a
+  4px-flex element with a 1px inner bar that animates opacity. The outer
+  element IS the cursor hit target, the inner is purely decorative.
+
+  Drag state: :active covers pointerdown-drag; the library itself doesn't add
+  a distinguishing attribute across versions, so CSS pseudo-classes are our
+  single source of truth.
+*/
+.pane-resize-handle {
+  position: relative;
+  flex: 0 0 4px;
+  width: 4px;
+  cursor: col-resize;
+  outline: none;
+  z-index: 10;
+  user-select: none;
+  touch-action: none;
+  transition: background-color 150ms var(--ease-spring, cubic-bezier(0.32, 0.72, 0, 1));
+}
+.pane-resize-handle::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: calc(50% - 0.5px);
+  width: 1px;
+  background: var(--color-border-default);
+  opacity: 0;
+  transition: opacity 180ms var(--ease-spring, cubic-bezier(0.32, 0.72, 0, 1)),
+              background-color 180ms var(--ease-spring, cubic-bezier(0.32, 0.72, 0, 1));
+  pointer-events: none;
+}
+.pane-resize-handle:hover::after,
+.pane-resize-handle:active::after,
+.pane-resize-handle:focus-visible::after {
+  opacity: 1;
+}
+.pane-resize-handle:active::after,
+.pane-resize-handle:focus-visible::after {
+  background: var(--color-accent);
 }

--- a/tests/appearance.test.ts
+++ b/tests/appearance.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveEffectiveTheme,
+  legacyFontSizeToPx,
+  pxToLegacyFontSize,
+  sanitizeFontSizePx,
+  sanitizeDensity,
+  sanitizeSidebarWidthPct,
+} from '../src/stores/store';
+
+describe('resolveEffectiveTheme', () => {
+  it('dark selection is always dark regardless of OS', () => {
+    expect(resolveEffectiveTheme('dark', true)).toBe('dark');
+    expect(resolveEffectiveTheme('dark', false)).toBe('dark');
+  });
+
+  it('light selection is always light regardless of OS', () => {
+    expect(resolveEffectiveTheme('light', true)).toBe('light');
+    expect(resolveEffectiveTheme('light', false)).toBe('light');
+  });
+
+  it('system follows OS: dark when osPrefersDark=true', () => {
+    expect(resolveEffectiveTheme('system', true)).toBe('dark');
+  });
+
+  it('system follows OS: light when osPrefersDark=false', () => {
+    expect(resolveEffectiveTheme('system', false)).toBe('light');
+  });
+});
+
+describe('font size migration', () => {
+  it('maps legacy enum to px (md → 14 is the new default)', () => {
+    expect(legacyFontSizeToPx('sm')).toBe(12);
+    expect(legacyFontSizeToPx('md')).toBe(14);
+    expect(legacyFontSizeToPx('lg')).toBe(16);
+  });
+
+  it('round-trips px → legacy → px for endpoint stops', () => {
+    expect(legacyFontSizeToPx(pxToLegacyFontSize(12))).toBe(12);
+    expect(legacyFontSizeToPx(pxToLegacyFontSize(16))).toBe(16);
+  });
+
+  it('pxToLegacyFontSize buckets middle values into md', () => {
+    expect(pxToLegacyFontSize(13)).toBe('md');
+    expect(pxToLegacyFontSize(14)).toBe('md');
+    expect(pxToLegacyFontSize(15)).toBe('md');
+  });
+
+  it('sanitizeFontSizePx accepts every official stop', () => {
+    for (const n of [12, 13, 14, 15, 16] as const) {
+      expect(sanitizeFontSizePx(n)).toBe(n);
+    }
+  });
+
+  it('sanitizeFontSizePx coerces garbage to default 14', () => {
+    expect(sanitizeFontSizePx('huge')).toBe(14);
+    expect(sanitizeFontSizePx(null)).toBe(14);
+    expect(sanitizeFontSizePx(99)).toBe(14);
+    expect(sanitizeFontSizePx(NaN)).toBe(14);
+  });
+});
+
+describe('density sanitize', () => {
+  it('passes through valid values', () => {
+    expect(sanitizeDensity('compact')).toBe('compact');
+    expect(sanitizeDensity('normal')).toBe('normal');
+    expect(sanitizeDensity('comfortable')).toBe('comfortable');
+  });
+
+  it('coerces invalid to normal (default)', () => {
+    expect(sanitizeDensity('weird')).toBe('normal');
+    expect(sanitizeDensity(undefined)).toBe('normal');
+    expect(sanitizeDensity(42)).toBe('normal');
+  });
+});
+
+describe('sidebar width sanitize', () => {
+  it('passes through in-range fractions', () => {
+    expect(sanitizeSidebarWidthPct(0.22)).toBeCloseTo(0.22);
+    expect(sanitizeSidebarWidthPct(0.4)).toBeCloseTo(0.4);
+  });
+
+  it('clamps below min and above max', () => {
+    expect(sanitizeSidebarWidthPct(0.0)).toBe(0.12);
+    expect(sanitizeSidebarWidthPct(0.95)).toBe(0.5);
+  });
+
+  it('falls back to default when value is non-numeric', () => {
+    expect(sanitizeSidebarWidthPct(NaN)).toBeCloseTo(0.22);
+    expect(sanitizeSidebarWidthPct('25%')).toBeCloseTo(0.22);
+  });
+});

--- a/tests/slash-commands-handlers.test.ts
+++ b/tests/slash-commands-handlers.test.ts
@@ -151,11 +151,11 @@ describe('/cost', () => {
 describe('/config and /model', () => {
   afterEach(() => setOpenSettingsListener(null));
 
-  it('/config opens settings (general tab)', () => {
+  it('/config opens settings (appearance tab)', () => {
     const calls: Array<string | undefined> = [];
     setOpenSettingsListener((tab) => calls.push(tab));
     handleConfig({ sessionId: 's', args: '' });
-    expect(calls).toEqual(['general']);
+    expect(calls).toEqual(['appearance']);
   });
   it('/model opens settings on endpoints tab', () => {
     const calls: Array<string | undefined> = [];

--- a/tests/store-appearance.test.ts
+++ b/tests/store-appearance.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { useStore } from '../src/stores/store';
+
+describe('appearance setters', () => {
+  it('setFontSizePx updates both px and legacy enum', () => {
+    useStore.getState().setFontSizePx(12);
+    expect(useStore.getState().fontSizePx).toBe(12);
+    expect(useStore.getState().fontSize).toBe('sm');
+    useStore.getState().setFontSizePx(16);
+    expect(useStore.getState().fontSize).toBe('lg');
+    useStore.getState().setFontSizePx(14);
+    expect(useStore.getState().fontSize).toBe('md');
+  });
+
+  it('legacy setFontSize keeps new px in sync', () => {
+    useStore.getState().setFontSize('sm');
+    expect(useStore.getState().fontSizePx).toBe(12);
+    useStore.getState().setFontSize('lg');
+    expect(useStore.getState().fontSizePx).toBe(16);
+  });
+
+  it('setDensity writes and setTheme writes', () => {
+    useStore.getState().setDensity('compact');
+    expect(useStore.getState().density).toBe('compact');
+    useStore.getState().setTheme('light');
+    expect(useStore.getState().theme).toBe('light');
+  });
+
+  it('setSidebarWidthPct clamps to [0.12, 0.5]', () => {
+    useStore.getState().setSidebarWidthPct(0.3);
+    expect(useStore.getState().sidebarWidthPct).toBeCloseTo(0.3);
+    useStore.getState().setSidebarWidthPct(0.01);
+    expect(useStore.getState().sidebarWidthPct).toBe(0.12);
+    useStore.getState().setSidebarWidthPct(0.9);
+    expect(useStore.getState().sidebarWidthPct).toBe(0.5);
+  });
+});


### PR DESCRIPTION
## Summary

Four polish features bundled into one branch:

1. **Light mode** — full palette authored fresh (not a mechanical inversion). Surfaces compress in the L axis for less glare, borders soften, drop shadows get a faint warm cast. Terminal stays dark by design (shell output readability). Theme options: Dark / Light / System. In System mode we subscribe to `matchMedia('(prefers-color-scheme: dark)')` and re-apply reactively — no reload needed when the OS flips.
2. **Font size** — 12/13/14/15/16 slider, applied via `--app-font-size` on `<html>`. New default is 14 (old implicit default was 13). Legacy `sm`/`md`/`lg` enum kept in the persist shape for back-compat.
3. **Density** — compact / normal / comfortable via `html.density-*` class and `--density-scale`.
4. **Pane resize** — `react-resizable-panels` 4.10 with a 4px hit area, 1px hover/drag divider. Sidebar 220–480px, chat 480+px. Width persisted as a fraction of window width so it adapts across monitors.
5. **CLAUDE.md editor** — new Settings → Memory tab with Project (`<cwd>/CLAUDE.md`) and User (`~/.claude/CLAUDE.md`) editors. Save-on-blur + explicit Save button, Create button when missing, rough token-count badge. IPC (`memory:read/write/exists`) enforces basename == `CLAUDE.md` in the main process — non-CLAUDE.md paths are rejected with `invalid_path`.

## Design notes

- Light palette is rebalanced, not inverted. A 1 - L flip produces an aggressive, tiring light mode; instead, surfaces spread less in the upper L range, accent is pulled down from 0.74 → 0.58 for contrast against light surfaces while keeping hue 215/225 continuity, shadows get a warm (≈60° hue) cast for a "paper on a desk" feel.
- Sidebar width is persisted as a *fraction* not pixels so wider monitors give the user more sidebar without a re-drag.
- Token estimate in Memory is `ceil(length / 4)` — good enough to flag "this file is getting long" without pulling in a real tokenizer for MVP.
- Memory IPC is the new security surface. All paths are validated before fs access: must be absolute, basename must be exactly `CLAUDE.md` (case-sensitive, matches CLI strictness), no `..` segments post-normalize.

## Known debt (not blocking)

Semantic color tokens (bg-\*, text-fg-\*, border-\*) flip correctly in light mode. However, \~68 hardcoded `oklch(...)` calls across components remain — mostly focus-ring glows like `shadow-[0_0_0_2px_oklch(0.72_0.14_215_/_0.30)]`. These look slightly over-bright in light mode but remain legible. Follow-up pass to replace with tokens.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (only the pre-existing CommandPalette warning)
- [x] `npm test` 411/411 green (29 tests added: theme resolution, font/density/sidebar setters + sanitize, memory path validation)
- [ ] Manually verify light/dark palette on: ChatStream, Sidebar, InputBar, StatusBar, SettingsDialog, PermissionPromptBlock, QuestionBlock, SlashCommandPicker, CommandPalette, image attachment chips
- [ ] Drag sidebar handle; reload window; sidebar width restores
- [ ] Write into Project memory from a real session; close settings; verify `<cwd>/CLAUDE.md` on disk
- [ ] Change OS theme to dark/light with app set to System; app should flip within one frame
- [ ] Probe: `node scripts/probe-appearance-polish.mjs` (requires dev server on 4100 or packaged build)

## Screenshot matrix

_To be filled by the reviewer — UI changes are live under \`feat/appearance-polish\` and can be captured by running the app and toggling through:_
- Theme: Dark × Light
- Density: Compact × Comfortable
- Font size: 12 × 16