### PR TITLE
feat(slash): /pr command — open PR and monitor CI

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -11,6 +11,12 @@ import type { PermissionMode } from './agent/sessions';
 import { EndpointsManager, type KeyCrypto } from './endpoints-manager';
 import { ClaudeNotFoundError, detectClaudeVersion, resolveClaudeBinary } from './agent/binary-resolver';
 import { readMemoryFile, writeMemoryFile, memoryFileExists } from './memory';
+import {
+  runPreflight,
+  createPr,
+  fetchPrChecks,
+  type CreatePrArgs
+} from './pr';
 
 const KEYCHAIN_FILE = 'anthropic-key.bin';
 
@@ -378,6 +384,32 @@ app.whenReady().then(() => {
   );
 
   ipcMain.handle('import:scan', () => scanImportableSessions());
+
+  // ───────────────────────────── /pr flow ──────────────────────────────────
+  //
+  // Renderer → main IPC for preflight checks, PR creation, and CI polling.
+  // All spawn() happens in main; the renderer never touches git / gh /
+  // process.env.PATH directly. See electron/pr.ts for the helpers.
+  ipcMain.handle('pr:preflight', (_e, cwd: string | null | undefined) => runPreflight(cwd));
+  ipcMain.handle(
+    'pr:create',
+    (_e, args: CreatePrArgs) => createPr(args)
+  );
+  ipcMain.handle(
+    'pr:checks',
+    (_e, cwd: string, number: number) => fetchPrChecks(cwd, number)
+  );
+  ipcMain.handle('shell:openExternal', async (_e, url: string) => {
+    // Only http(s). Everything else is a potential shell hijack.
+    if (!/^https?:\/\//i.test(url)) return false;
+    try {
+      await shell.openExternal(url);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+  // ──────────────────────────── end /pr flow ───────────────────────────────
 
   // ───────────────────────────── CLI wizard ────────────────────────────────
   //

--- a/electron/pr.ts
+++ b/electron/pr.ts
@@ -1,0 +1,595 @@
+// /pr slash-command main-process helpers.
+//
+// Shape of the flow:
+//   preflight -> (renderer shows form) -> create -> poll CI checks.
+//
+// Everything that touches `child_process.spawn` is kept here so the
+// renderer stays sandboxed. Pure helpers (body generation, CI state
+// aggregation, gh-missing-install-hint) are exported so unit tests can
+// exercise them without mocking spawn.
+
+import { spawn, type SpawnOptionsWithoutStdio } from 'child_process';
+import { promises as fsp } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// ---------------------------------------------------------------------------
+// Shared types — mirrored in the renderer via IPC.
+// ---------------------------------------------------------------------------
+
+export type PreflightError =
+  | { code: 'no-cwd'; detail: string }
+  | { code: 'not-git'; detail: string }
+  | { code: 'no-gh'; detail: string }
+  | { code: 'on-default-branch'; detail: string; branch: string }
+  | { code: 'dirty-tree'; detail: string }
+  | { code: 'no-commits'; detail: string };
+
+export type PreflightResult =
+  | {
+      ok: true;
+      branch: string;
+      base: string;
+      availableBases: string[];
+      repoRoot: string;
+      suggestedTitle: string;
+      suggestedBody: string;
+    }
+  | { ok: false; errors: PreflightError[] };
+
+export type CreatePrArgs = {
+  cwd: string;
+  branch: string;
+  base: string;
+  title: string;
+  body: string;
+  draft: boolean;
+};
+
+export type CreatePrResult =
+  | { ok: true; url: string; number: number }
+  | { ok: false; error: string };
+
+export type CheckState = 'queued' | 'in_progress' | 'completed' | 'waiting' | 'pending';
+export type CheckConclusion =
+  | 'success'
+  | 'failure'
+  | 'cancelled'
+  | 'skipped'
+  | 'timed_out'
+  | 'neutral'
+  | 'action_required'
+  | null;
+
+export interface PrCheck {
+  name: string;
+  status: CheckState;
+  conclusion: CheckConclusion;
+  detailsUrl?: string;
+}
+
+export type ChecksResult =
+  | { ok: true; checks: PrCheck[] }
+  | { ok: false; error: string };
+
+// ---------------------------------------------------------------------------
+// Pure helpers (unit-testable without spawn).
+// ---------------------------------------------------------------------------
+
+export const PR_BODY_FOOTER =
+  '\n\n---\nGenerated with [agentory-next](https://github.com/Jiahui-Gu/Agentory-next).';
+
+// Canonical set of branch names we consider "default". If the user is on
+// one of these we refuse to open a PR from it back into itself — that's
+// the shape of mistakes worth blocking. `trunk` is in there for older Git
+// shops; `develop` is NOT because many flows legitimately branch off it.
+export const DEFAULT_BRANCH_NAMES = new Set(['main', 'master', 'trunk']);
+
+export function isDefaultBranch(branch: string): boolean {
+  return DEFAULT_BRANCH_NAMES.has(branch);
+}
+
+export function buildPrBody(options: {
+  commitSummaries: string[]; // one line per commit since base, freshest last
+  title: string;
+}): string {
+  const { commitSummaries, title } = options;
+  const sectionTitle = '## Summary';
+  if (commitSummaries.length === 0) {
+    return `${sectionTitle}\n\n- ${title}${PR_BODY_FOOTER}`;
+  }
+  // De-dup exact-match summary lines while preserving first-seen order.
+  const seen = new Set<string>();
+  const lines: string[] = [];
+  for (const s of commitSummaries) {
+    const trimmed = s.trim();
+    if (!trimmed) continue;
+    if (seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    lines.push(`- ${trimmed}`);
+  }
+  return `${sectionTitle}\n\n${lines.join('\n')}${PR_BODY_FOOTER}`;
+}
+
+export type AggregateState =
+  | 'pending' // at least one check still running / queued
+  | 'passing' // all completed AND conclusion in {success, skipped, neutral}
+  | 'failing' // any conclusion in {failure, cancelled, timed_out, action_required}
+  | 'empty'; // zero checks reported by gh (common for brand-new PRs before CI registers)
+
+export function aggregateChecks(checks: PrCheck[]): AggregateState {
+  if (checks.length === 0) return 'empty';
+  let hasIncomplete = false;
+  for (const c of checks) {
+    if (c.status !== 'completed') {
+      hasIncomplete = true;
+      continue;
+    }
+    const conc = c.conclusion;
+    if (
+      conc === 'failure' ||
+      conc === 'cancelled' ||
+      conc === 'timed_out' ||
+      conc === 'action_required'
+    ) {
+      return 'failing';
+    }
+  }
+  return hasIncomplete ? 'pending' : 'passing';
+}
+
+export function formatGhInstallHint(): string {
+  // Keep this short — renderer wraps it in a status block. Platform-specific
+  // install lines come from gh's own docs and match what the CLI prints.
+  const platform = process.platform;
+  const base = 'The GitHub CLI (`gh`) is required to open PRs.';
+  if (platform === 'win32') {
+    return `${base} Install with: winget install --id GitHub.cli    (or: choco install gh)`;
+  }
+  if (platform === 'darwin') {
+    return `${base} Install with: brew install gh`;
+  }
+  return `${base} See https://cli.github.com/ for install instructions.`;
+}
+
+// ---------------------------------------------------------------------------
+// Spawn helpers.
+// ---------------------------------------------------------------------------
+
+export interface SpawnResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+  // True if the binary could not be located at all (ENOENT-class error).
+  notFound?: boolean;
+}
+
+// Thin, promise-returning wrapper over child_process.spawn. Explicit
+// (non-shell) argv so we don't need to quote anything ourselves — the
+// shell is never involved, so there's nothing for the user's title /
+// body to break out of.
+export function runCommand(
+  cmd: string,
+  args: string[],
+  opts: SpawnOptionsWithoutStdio & { input?: string; timeoutMs?: number } = {}
+): Promise<SpawnResult> {
+  return _runner(cmd, args, opts);
+}
+
+// Test seam. Production callers never override this; unit tests swap it
+// to a pure function so they can assert preflight / create behavior
+// without actually spawning processes.
+type Runner = (
+  cmd: string,
+  args: string[],
+  opts: SpawnOptionsWithoutStdio & { input?: string; timeoutMs?: number }
+) => Promise<SpawnResult>;
+
+let _runner: Runner = defaultRunner;
+
+export function _setRunner(r: Runner | null): void {
+  _runner = r ?? defaultRunner;
+}
+
+function defaultRunner(
+  cmd: string,
+  args: string[],
+  opts: SpawnOptionsWithoutStdio & { input?: string; timeoutMs?: number }
+): Promise<SpawnResult> {
+  const { input, timeoutMs, ...spawnOpts } = opts;
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(cmd, args, { ...spawnOpts, shell: false });
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException;
+      resolve({
+        code: -1,
+        stdout: '',
+        stderr: e.message ?? String(err),
+        notFound: e.code === 'ENOENT'
+      });
+      return;
+    }
+    let stdout = '';
+    let stderr = '';
+    let done = false;
+    let timer: NodeJS.Timeout | undefined;
+
+    const finish = (res: SpawnResult) => {
+      if (done) return;
+      done = true;
+      if (timer) clearTimeout(timer);
+      resolve(res);
+    };
+
+    if (timeoutMs && timeoutMs > 0) {
+      timer = setTimeout(() => {
+        try {
+          child.kill();
+        } catch {
+          /* noop */
+        }
+        finish({ code: -1, stdout, stderr: stderr + `\n[timeout after ${timeoutMs}ms]` });
+      }, timeoutMs);
+    }
+
+    child.stdout?.on('data', (d) => {
+      stdout += d.toString('utf8');
+    });
+    child.stderr?.on('data', (d) => {
+      stderr += d.toString('utf8');
+    });
+    child.on('error', (err) => {
+      const e = err as NodeJS.ErrnoException;
+      finish({
+        code: -1,
+        stdout,
+        stderr: stderr + (e.message ?? String(err)),
+        notFound: e.code === 'ENOENT'
+      });
+    });
+    child.on('close', (code) => {
+      finish({ code: code ?? -1, stdout, stderr });
+    });
+
+    if (input !== undefined && child.stdin) {
+      child.stdin.end(input);
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Preflight — called when the user types /pr and hits Enter.
+// ---------------------------------------------------------------------------
+
+async function gitInRepo(cwd: string, args: string[], timeoutMs = 10_000): Promise<SpawnResult> {
+  return runCommand('git', args, { cwd, timeoutMs });
+}
+
+export async function runPreflight(cwd: string | null | undefined): Promise<PreflightResult> {
+  const errors: PreflightError[] = [];
+
+  if (!cwd) {
+    return {
+      ok: false,
+      errors: [
+        {
+          code: 'no-cwd',
+          detail: 'This session has no working directory. Set one via the session header.'
+        }
+      ]
+    };
+  }
+
+  // git repo?
+  const top = await gitInRepo(cwd, ['rev-parse', '--show-toplevel']);
+  if (top.code !== 0 || !top.stdout.trim()) {
+    if (top.notFound) {
+      return {
+        ok: false,
+        errors: [
+          {
+            code: 'not-git',
+            detail: '`git` executable not found on PATH. Install Git and retry.'
+          }
+        ]
+      };
+    }
+    return {
+      ok: false,
+      errors: [
+        {
+          code: 'not-git',
+          detail: `${cwd} is not inside a git repository.`
+        }
+      ]
+    };
+  }
+  const repoRoot = top.stdout.trim();
+
+  // gh installed?
+  const ghVer = await runCommand('gh', ['--version'], { cwd, timeoutMs: 10_000 });
+  if (ghVer.notFound || ghVer.code !== 0) {
+    return {
+      ok: false,
+      errors: [{ code: 'no-gh', detail: formatGhInstallHint() }]
+    };
+  }
+
+  // current branch
+  const br = await gitInRepo(repoRoot, ['rev-parse', '--abbrev-ref', 'HEAD']);
+  const branch = br.stdout.trim();
+  if (br.code !== 0 || !branch || branch === 'HEAD') {
+    return {
+      ok: false,
+      errors: [
+        {
+          code: 'not-git',
+          detail: 'Detached HEAD. Check out a named branch before opening a PR.'
+        }
+      ]
+    };
+  }
+
+  if (isDefaultBranch(branch)) {
+    errors.push({
+      code: 'on-default-branch',
+      branch,
+      detail: `You are on "${branch}". Create a feature branch first: git switch -c feat/your-change`
+    });
+  }
+
+  // Working tree clean?
+  const st = await gitInRepo(repoRoot, ['status', '--porcelain']);
+  if (st.code === 0 && st.stdout.trim().length > 0) {
+    errors.push({
+      code: 'dirty-tree',
+      detail: 'Uncommitted changes detected. Commit them first — `/pr` does not auto-commit.'
+    });
+  }
+
+  // Resolve base branch. Prefer origin/HEAD if set (upstream default).
+  let base = 'main';
+  const defaultRef = await gitInRepo(repoRoot, [
+    'symbolic-ref',
+    '--quiet',
+    '--short',
+    'refs/remotes/origin/HEAD'
+  ]);
+  if (defaultRef.code === 0 && defaultRef.stdout.trim().startsWith('origin/')) {
+    base = defaultRef.stdout.trim().slice('origin/'.length);
+  } else {
+    // Fallback: if origin/main exists use it, else origin/master.
+    const hasMain = await gitInRepo(repoRoot, ['rev-parse', '--verify', 'origin/main']);
+    if (hasMain.code === 0) base = 'main';
+    else {
+      const hasMaster = await gitInRepo(repoRoot, ['rev-parse', '--verify', 'origin/master']);
+      if (hasMaster.code === 0) base = 'master';
+    }
+  }
+
+  // List all local + remote branches for the dropdown, dedupe on short name.
+  const brList = await gitInRepo(repoRoot, [
+    'for-each-ref',
+    '--format=%(refname:short)',
+    'refs/heads',
+    'refs/remotes'
+  ]);
+  const availableBases = Array.from(
+    new Set(
+      brList.stdout
+        .split(/\r?\n/)
+        .map((n) => n.trim())
+        .filter(Boolean)
+        .map((n) => (n.startsWith('origin/') ? n.slice('origin/'.length) : n))
+        .filter((n) => n !== 'HEAD' && n !== branch)
+    )
+  ).sort();
+
+  // Latest commit subject → suggested title.
+  const subj = await gitInRepo(repoRoot, ['log', '-1', '--pretty=%s']);
+  const suggestedTitle = subj.code === 0 ? subj.stdout.trim() : '';
+
+  // Commits between base and HEAD → body summary. Use `origin/<base>..HEAD`
+  // if the remote base is known; else `<base>..HEAD`.
+  const refCandidates = [`origin/${base}`, base];
+  let summaryLines: string[] = [];
+  for (const ref of refCandidates) {
+    const exists = await gitInRepo(repoRoot, ['rev-parse', '--verify', ref]);
+    if (exists.code !== 0) continue;
+    const log = await gitInRepo(repoRoot, [
+      'log',
+      `${ref}..HEAD`,
+      '--pretty=format:%s',
+      '--reverse'
+    ]);
+    if (log.code === 0) {
+      summaryLines = log.stdout
+        .split(/\r?\n/)
+        .map((s) => s.trim())
+        .filter(Boolean);
+      break;
+    }
+  }
+  if (summaryLines.length === 0 && suggestedTitle) {
+    // Brand-new branch with no merge base found yet — use the latest subject.
+    summaryLines = [suggestedTitle];
+    errors.push({
+      code: 'no-commits',
+      detail:
+        `Could not compute commits between "${base}" and HEAD. The PR body will use the latest commit only.`
+    });
+  }
+
+  const suggestedBody = buildPrBody({
+    commitSummaries: summaryLines,
+    title: suggestedTitle || 'Update'
+  });
+
+  if (errors.filter((e) => e.code !== 'no-commits').length > 0) {
+    return { ok: false, errors };
+  }
+
+  return {
+    ok: true,
+    branch,
+    base,
+    availableBases,
+    repoRoot,
+    suggestedTitle,
+    suggestedBody
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Create PR.
+// ---------------------------------------------------------------------------
+
+const GH_PR_URL_RE = /https:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/pull\/(\d+)/;
+
+export function parsePrUrl(
+  text: string
+): { url: string; owner: string; repo: string; number: number } | null {
+  const m = text.match(GH_PR_URL_RE);
+  if (!m) return null;
+  return { url: m[0], owner: m[1], repo: m[2], number: Number(m[3]) };
+}
+
+export async function createPr(args: CreatePrArgs): Promise<CreatePrResult> {
+  const { cwd, branch, base, title, body, draft } = args;
+
+  // Safety: the renderer already checks isDefaultBranch via preflight, but we
+  // re-check in main so an adversarial renderer can't bypass it.
+  if (isDefaultBranch(branch)) {
+    return { ok: false, error: `Refusing to open a PR from default branch "${branch}".` };
+  }
+
+  // Push the branch first. -u sets upstream if it isn't already.
+  const push = await runCommand('git', ['push', '-u', 'origin', branch], {
+    cwd,
+    timeoutMs: 120_000
+  });
+  if (push.code !== 0) {
+    const hint =
+      /rejected|non-fast-forward/i.test(push.stderr)
+        ? '\nRemote has commits you do not. If your rebase is intentional, consider `git push --force-with-lease`.'
+        : '';
+    return {
+      ok: false,
+      error: `git push failed (exit ${push.code}):\n${push.stderr.trim()}${hint}`
+    };
+  }
+
+  // Write body to a tmpfile so we never have to escape shell-special chars.
+  const tmp = path.join(os.tmpdir(), `agentory-pr-body-${Date.now()}-${process.pid}.md`);
+  await fsp.writeFile(tmp, body, 'utf8');
+  try {
+    const ghArgs = [
+      'pr',
+      'create',
+      '--head',
+      branch,
+      '--base',
+      base,
+      '--title',
+      title,
+      '--body-file',
+      tmp
+    ];
+    if (draft) ghArgs.push('--draft');
+    const res = await runCommand('gh', ghArgs, { cwd, timeoutMs: 120_000 });
+    if (res.code !== 0) {
+      return {
+        ok: false,
+        error: `gh pr create failed (exit ${res.code}):\n${(res.stderr || res.stdout).trim()}`
+      };
+    }
+    const parsed = parsePrUrl(res.stdout) ?? parsePrUrl(res.stderr);
+    if (!parsed) {
+      return {
+        ok: false,
+        error: `gh pr create succeeded but no PR URL was found in output:\n${res.stdout.trim()}`
+      };
+    }
+    return { ok: true, url: parsed.url, number: parsed.number };
+  } finally {
+    await fsp.unlink(tmp).catch(() => {});
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CI polling.
+// ---------------------------------------------------------------------------
+
+interface GhCheckJson {
+  name?: string;
+  state?: string;
+  status?: string;
+  conclusion?: string | null;
+  link?: string;
+}
+
+function normalizeState(raw: string | undefined): CheckState {
+  const v = (raw ?? '').toLowerCase();
+  if (v === 'queued') return 'queued';
+  if (v === 'in_progress' || v === 'pending') return 'in_progress';
+  if (v === 'waiting') return 'waiting';
+  if (v === 'completed' || v === 'success' || v === 'fail' || v === 'failure' || v === 'skipping')
+    return 'completed';
+  return 'pending';
+}
+
+function normalizeConclusion(raw: string | null | undefined, state: CheckState): CheckConclusion {
+  if (state !== 'completed') return null;
+  const v = (raw ?? '').toLowerCase();
+  if (v === 'success' || v === 'pass' || v === 'passing') return 'success';
+  if (v === 'failure' || v === 'fail' || v === 'failing') return 'failure';
+  if (v === 'cancelled') return 'cancelled';
+  if (v === 'skipped' || v === 'skipping') return 'skipped';
+  if (v === 'timed_out') return 'timed_out';
+  if (v === 'neutral') return 'neutral';
+  if (v === 'action_required') return 'action_required';
+  return null;
+}
+
+export function parseGhChecks(stdout: string): PrCheck[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  const out: PrCheck[] = [];
+  for (const raw of parsed as GhCheckJson[]) {
+    const name = typeof raw?.name === 'string' ? raw.name : 'check';
+    // gh has used both `state` and `status`; map either.
+    const rawState = raw.state ?? raw.status;
+    const status = normalizeState(rawState);
+    const conclusion = normalizeConclusion(raw.conclusion, status);
+    const detailsUrl = typeof raw.link === 'string' && raw.link.length > 0 ? raw.link : undefined;
+    out.push({ name, status, conclusion, detailsUrl });
+  }
+  return out;
+}
+
+export async function fetchPrChecks(cwd: string, prNumber: number): Promise<ChecksResult> {
+  const res = await runCommand(
+    'gh',
+    ['pr', 'checks', String(prNumber), '--json', 'name,state,conclusion,link'],
+    { cwd, timeoutMs: 30_000 }
+  );
+  if (res.code !== 0) {
+    // `gh pr checks` exits non-zero when at least one check is failing OR
+    // when checks haven't been registered yet. Parse stdout anyway — a valid
+    // JSON array means we have a real snapshot.
+    const checks = parseGhChecks(res.stdout);
+    if (checks.length > 0) return { ok: true, checks };
+    return {
+      ok: false,
+      error: `gh pr checks exited ${res.code}: ${(res.stderr || res.stdout).trim()}`
+    };
+  }
+  return { ok: true, checks: parseGhChecks(res.stdout) };
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -173,6 +173,24 @@ const api = {
       ipcRenderer.invoke('memory:projectPath', cwd),
   },
 
+  pr: {
+    preflight: (cwd: string | null | undefined): Promise<unknown> =>
+      ipcRenderer.invoke('pr:preflight', cwd),
+    create: (args: {
+      cwd: string;
+      branch: string;
+      base: string;
+      title: string;
+      body: string;
+      draft: boolean;
+    }): Promise<unknown> => ipcRenderer.invoke('pr:create', args),
+    checks: (cwd: string, number: number): Promise<unknown> =>
+      ipcRenderer.invoke('pr:checks', cwd, number)
+  },
+
+  openExternal: (url: string): Promise<boolean> =>
+    ipcRenderer.invoke('shell:openExternal', url),
+
   notify: (payload: {
     sessionId: string;
     title: string;

--- a/scripts/probe-slash-pr.mjs
+++ b/scripts/probe-slash-pr.mjs
@@ -1,0 +1,236 @@
+// Probe: /pr slash command end-to-end (renderer-only).
+//
+// Strategy: we don't need a real git repo or gh binary — the IPC surface is
+// the only thing separating the renderer from those. We stub window.agentory.pr
+// inside the page before the user types, then drive the UI via keyboard/DOM:
+//
+//   1. Type /pr + Enter → PrDialog appears with seeded title / body / base.
+//   2. Click "Open PR" → dialog closes, a pr-status block appears in chat,
+//      the block carries the URL returned by the stub, CI checks render from
+//      the stub's /checks response.
+//
+// Runs against the webpack dev server on AGENTORY_DEV_PORT (default 4100).
+// See rules: this repo's user prefers 4194 for AI-driven dev, so we surface
+// that in the help.
+//
+// Usage:
+//   AGENTORY_DEV_PORT=4194 npm run dev:web   # in another shell
+//   AGENTORY_DEV_PORT=4194 node scripts/probe-slash-pr.mjs
+import { chromium } from 'playwright';
+
+const PORT = process.env.AGENTORY_DEV_PORT ?? '4100';
+const URL = `http://localhost:${PORT}/`;
+
+function fail(msg) {
+  console.error(`\n[probe-slash-pr] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext();
+const page = await ctx.newPage();
+
+const errors = [];
+page.on('pageerror', (e) => errors.push(`[pageerror] ${e.message}`));
+page.on('console', (m) => {
+  if (m.type() === 'error') errors.push(`[console.error] ${m.text()}`);
+});
+
+// Install the PR-flow stub + IPC shim BEFORE the app code runs, so the
+// orchestrator sees `window.agentory.pr` on first render.
+await page.addInitScript(() => {
+  const pr = {
+    preflight: async () => ({
+      ok: true,
+      branch: 'feat/probe-demo',
+      base: 'main',
+      availableBases: ['main', 'working'],
+      repoRoot: '/fake/repo',
+      suggestedTitle: 'feat: probe demo',
+      suggestedBody: '## Summary\n\n- feat: probe demo\n\n---\nGenerated with agentory-next.'
+    }),
+    create: async () => ({
+      ok: true,
+      url: 'https://github.com/acme/widgets/pull/99',
+      number: 99
+    }),
+    checks: async () => ({
+      ok: true,
+      checks: [
+        { name: 'test', status: 'completed', conclusion: 'success', detailsUrl: 'https://ci/test' },
+        { name: 'lint', status: 'completed', conclusion: 'success' }
+      ]
+    })
+  };
+  const base = {
+    loadState: async (key) => {
+      // Pre-mark tutorialSeen so the empty-state CTAs render immediately
+      // instead of the multi-step onboarding overlay (which doesn't have
+      // a visible "New Session" button on its first step).
+      if (key === 'main') {
+        return JSON.stringify({
+          version: 1,
+          sessions: [],
+          groups: [{ id: 'g-default', name: 'Sessions', collapsed: false, kind: 'normal' }],
+          activeId: '',
+          model: '',
+          permission: 'default',
+          sidebarCollapsed: false,
+          theme: 'system',
+          fontSize: 'md',
+          recentProjects: [],
+          tutorialSeen: true
+        });
+      }
+      return null;
+    },
+    saveState: async () => {},
+    loadMessages: async () => [],
+    saveMessages: async () => {},
+    getDataDir: async () => '/tmp',
+    getVersion: async () => '0.0.0-probe',
+    getApiKey: async () => '',
+    setApiKey: async () => true,
+    hasEncryption: async () => true,
+    pickDirectory: async () => null,
+    agentStart: async () => ({ ok: true }),
+    agentSend: async () => true,
+    agentSendContent: async () => true,
+    agentInterrupt: async () => true,
+    agentSetPermissionMode: async () => true,
+    agentSetModel: async () => true,
+    agentClose: async () => true,
+    agentResolvePermission: async () => true,
+    onAgentEvent: () => () => {},
+    onAgentExit: () => () => {},
+    onAgentPermissionRequest: () => () => {},
+    scanImportable: async () => [],
+    notify: async () => true,
+    onNotificationFocus: () => () => {},
+    updatesStatus: async () => ({ kind: 'idle' }),
+    updatesCheck: async () => ({ kind: 'idle' }),
+    updatesDownload: async () => ({ ok: true }),
+    updatesInstall: async () => ({ ok: true }),
+    updatesGetAutoCheck: async () => true,
+    updatesSetAutoCheck: async () => true,
+    onUpdateStatus: () => () => {},
+    onUpdateDownloaded: () => () => {},
+    cli: {
+      retryDetect: async () => ({ found: true, path: '/fake/claude', version: '1.0.0' }),
+      getInstallHints: async () => ({ os: 'win32', arch: 'x64', commands: {}, docsUrl: '' }),
+      browseBinary: async () => null,
+      setBinaryPath: async () => ({ ok: true, version: '1.0.0' }),
+      openDocs: async () => true
+    },
+    window: {
+      minimize: async () => {},
+      toggleMaximize: async () => false,
+      close: async () => {},
+      isMaximized: async () => false,
+      onMaximizedChanged: () => () => {},
+      platform: 'win32'
+    },
+    endpoints: {
+      list: async () => [],
+      add: async () => ({}),
+      update: async () => null,
+      remove: async () => true,
+      testConnection: async () => ({ ok: true }),
+      refreshModels: async () => ({ ok: true, count: 0, detectedKind: 'unknown', sourceStats: {} }),
+      setManualModels: async () => null
+    },
+    models: {
+      listByEndpoint: async () => [],
+      listAll: async () => []
+    },
+    pr,
+    openExternal: async () => true
+  };
+  Object.defineProperty(window, 'agentory', { value: base, writable: true, configurable: true });
+});
+
+await page.goto(URL, { waitUntil: 'networkidle' });
+
+// Create a session so the input bar + chat surface mount.
+const newBtn = page.getByRole('button', { name: /new session/i }).first();
+await newBtn.waitFor({ state: 'visible', timeout: 15_000 });
+await newBtn.click();
+
+const textarea = page.locator('textarea');
+await textarea.waitFor({ state: 'visible', timeout: 5000 });
+await textarea.click();
+
+// --- 1. Type /pr and hit Enter → dialog opens --------------------------
+await page.keyboard.type('/pr');
+await page.waitForTimeout(80);
+await page.keyboard.press('Enter');
+
+const dialog = page.locator('[data-testid="pr-dialog"]');
+await dialog.waitFor({ state: 'visible', timeout: 5000 }).catch(() => {
+  fail('PrDialog did not open after /pr + Enter');
+});
+
+// Seeded title from preflight stub. The seed runs in a useEffect after
+// dialog mounts, so we wait for a non-empty value rather than reading
+// the input synchronously.
+const titleInput = page.locator('[data-testid="pr-title"]');
+await page
+  .waitForFunction(
+    () => {
+      const el = document.querySelector('[data-testid="pr-title"]');
+      return el && (el).value && (el).value.length > 0;
+    },
+    null,
+    { timeout: 3000 }
+  )
+  .catch(() => {});
+const seeded = await titleInput.inputValue();
+if (seeded !== 'feat: probe demo') {
+  fail(`expected seeded title "feat: probe demo", got "${seeded}"`);
+}
+
+// Base is defaulted to main.
+const baseSel = page.locator('[data-testid="pr-base"]');
+const baseVal = await baseSel.inputValue();
+if (baseVal !== 'main') fail(`expected base "main", got "${baseVal}"`);
+
+// --- 2. Submit → status block lands in chat ----------------------------
+const submit = page.locator('[data-testid="pr-submit"]');
+await submit.click();
+
+// Dialog should close.
+await dialog.waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {
+  fail('PrDialog did not close after Open PR');
+});
+
+const statusBlock = page.locator('[data-testid="pr-status-block"]');
+await statusBlock.waitFor({ state: 'visible', timeout: 5000 }).catch(() => {
+  fail('pr-status block did not render');
+});
+
+const link = page.locator('[data-testid="pr-status-link"]');
+const linkText = await link.innerText();
+if (!linkText.includes('/pull/99')) fail(`expected PR URL in block, got "${linkText}"`);
+
+// First poll is immediate → checks should render.
+await page.waitForTimeout(400);
+const checksText = await statusBlock.innerText();
+if (!checksText.includes('test') || !checksText.includes('lint')) {
+  fail(`expected checks "test" and "lint" in block, got:\n${checksText}`);
+}
+
+// Phase should be "done" since both checks are completed + success.
+const phase = await statusBlock.getAttribute('data-pr-phase');
+if (phase !== 'done') fail(`expected phase "done" after passing checks, got "${phase}"`);
+
+if (errors.length > 0) {
+  console.error('--- console / page errors ---');
+  for (const e of errors) console.error(e);
+}
+
+console.log('\n[probe-slash-pr] OK');
+console.log('  /pr + Enter opens dialog with seeded title/base');
+console.log('  Submit renders pr-status block with URL');
+console.log('  Poll aggregates checks → phase=done');
+
+await browser.close();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { StatusBar } from './components/StatusBar';
 import { SettingsDialog } from './components/SettingsDialog';
 import { CommandPalette } from './components/CommandPalette';
 import { ImportDialog } from './components/ImportDialog';
+import { PrFlowProvider } from './components/PrFlowProvider';
 import { DragRegion, WindowControls } from './components/WindowControls';
 import { Tutorial } from './components/Tutorial';
 import { ClaudeCliMissingDialog } from './components/ClaudeCliMissingDialog';
@@ -279,6 +280,7 @@ export default function App() {
         <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} initialTab={settingsTab} />
         <ImportDialog open={importOpen} onOpenChange={setImportOpen} />
         <ClaudeCliMissingDialog />
+        <PrFlowProvider />
         <CommandPalette
           open={paletteOpen}
           onOpenChange={setPaletteOpen}

--- a/src/components/ChatStream.tsx
+++ b/src/components/ChatStream.tsx
@@ -1,9 +1,18 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { ChevronRight, AlertCircle, ArrowDown } from 'lucide-react';
+import {
+  ChevronRight,
+  AlertCircle,
+  ArrowDown,
+  CheckCircle2,
+  XCircle,
+  Loader2,
+  ExternalLink,
+  GitPullRequest
+} from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import type { MessageBlock, ImageAttachment } from '../types';
+import type { MessageBlock, ImageAttachment, PrCheckStatus } from '../types';
 import { useStore } from '../stores/store';
 import { attachmentToDataUrl, formatSize } from '../lib/attachments';
 import { Button } from './ui/Button';
@@ -608,6 +617,116 @@ function ErrorBlock({ text }: { text: string }) {
   );
 }
 
+type PrStatusBlockType = Extract<MessageBlock, { kind: 'pr-status' }>;
+
+function PrStatusBlock({ block }: { block: PrStatusBlockType }) {
+  const { phase, number, url, base, branch, checks = [], error } = block;
+  const openExternal = (u: string) => {
+    void window.agentory?.openExternal(u);
+  };
+  return (
+    <motion.div
+      layout
+      initial={{ opacity: 0, y: 2 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.18, ease: [0.32, 0.72, 0, 1] }}
+      role="status"
+      data-testid="pr-status-block"
+      data-pr-phase={phase}
+      className="relative my-1.5 rounded-md border border-border-subtle bg-bg-elevated/60 px-3 py-2 text-xs text-fg-secondary"
+    >
+      <span
+        aria-hidden
+        className="absolute left-0 top-0 bottom-0 w-[2px] rounded-l-md bg-accent"
+      />
+      <div className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-wider text-fg-tertiary">
+        <GitPullRequest size={12} className="text-accent" aria-hidden />
+        <span className="text-accent">PR</span>
+        {number !== undefined && <span className="text-fg-secondary">#{number}</span>}
+        {branch && base && (
+          <span className="text-fg-tertiary normal-case tracking-normal">
+            {branch} <span className="opacity-60">→</span> {base}
+          </span>
+        )}
+        <span className="ml-auto">{labelForPhase(phase)}</span>
+      </div>
+      {url && (
+        <div className="mt-1">
+          <button
+            type="button"
+            onClick={() => openExternal(url)}
+            className="inline-flex items-center gap-1 text-fg-primary hover:text-accent transition-colors duration-150 ease-out underline-offset-2 hover:underline"
+            data-testid="pr-status-link"
+          >
+            <span className="font-mono text-[11px]">{url}</span>
+            <ExternalLink size={10} className="opacity-60" aria-hidden />
+          </button>
+        </div>
+      )}
+      {error && (
+        <div className="mt-1.5 whitespace-pre-wrap font-mono text-[11px] leading-[16px] text-state-error-fg">
+          {error}
+        </div>
+      )}
+      {checks.length > 0 && (
+        <ul className="mt-1.5 space-y-0.5">
+          {checks.map((c) => (
+            <li key={c.name} className="flex items-center gap-1.5 font-mono text-[11px]">
+              <CheckGlyph status={c.status} conclusion={c.conclusion} />
+              <span className="text-fg-secondary">{c.name}</span>
+              {c.detailsUrl && (
+                <button
+                  type="button"
+                  onClick={() => openExternal(c.detailsUrl!)}
+                  className="text-fg-tertiary hover:text-accent transition-colors duration-150 ease-out"
+                  aria-label={`Open details for ${c.name}`}
+                >
+                  <ExternalLink size={10} aria-hidden />
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </motion.div>
+  );
+}
+
+function labelForPhase(phase: PrStatusBlockType['phase']): string {
+  switch (phase) {
+    case 'opening':
+      return 'opening…';
+    case 'open':
+      return 'open';
+    case 'polling':
+      return 'CI running…';
+    case 'done':
+      return 'CI complete';
+    case 'failed':
+      return 'failed';
+  }
+}
+
+function CheckGlyph({
+  status,
+  conclusion
+}: {
+  status: PrCheckStatus['status'];
+  conclusion: PrCheckStatus['conclusion'];
+}) {
+  if (status !== 'completed') {
+    return <Loader2 size={11} className="animate-spin text-fg-tertiary" aria-label="running" />;
+  }
+  if (
+    conclusion === 'success' ||
+    conclusion === 'skipped' ||
+    conclusion === 'neutral'
+  ) {
+    return <CheckCircle2 size={11} className="text-state-success" aria-label="passed" />;
+  }
+  return <XCircle size={11} className="text-state-error" aria-label="failed" />;
+}
+
 
 function renderBlock(
   b: MessageBlock,
@@ -667,6 +786,8 @@ function renderBlock(
       );
     case 'status':
       return <StatusBanner tone={b.tone} title={b.title} detail={b.detail} />;
+    case 'pr-status':
+      return <PrStatusBlock block={b} />;
     case 'error':
       return <ErrorBlock text={b.text} />;
   }

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -219,6 +219,20 @@ export function InputBar({ sessionId }: { sessionId: string }) {
   }
 
   function commitSlashCommand(cmd: SlashCommand) {
+    // Client-handled commands that take no arguments (all current ones —
+    // /pr, /clear, /cost, /config, /model, /help, /compact) should run
+    // immediately on commit rather than leaving `/name<space>` parked in
+    // the textarea waiting for another Enter press. Dispatch handles the
+    // per-command logic (openSettings, triggerPrFlow, etc.).
+    if (cmd.clientHandler) {
+      void dispatchSlashCommand(`/${cmd.name}`, { sessionId, args: '' });
+      setValue('');
+      draftCache.delete(sessionId);
+      setCaret(0);
+      setPickerDismissed(true);
+      setActiveIndex(0);
+      return;
+    }
     const next = `/${cmd.name} `;
     setValue(next);
     draftCache.set(sessionId, next);

--- a/src/components/PrDialog.tsx
+++ b/src/components/PrDialog.tsx
@@ -1,0 +1,173 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Dialog, DialogContent, DialogBody, DialogFooter } from './ui/Dialog';
+import { Button } from './ui/Button';
+
+type PreflightOk = {
+  ok: true;
+  branch: string;
+  base: string;
+  availableBases: string[];
+  repoRoot: string;
+  suggestedTitle: string;
+  suggestedBody: string;
+};
+
+export type PrFormSubmit = {
+  title: string;
+  body: string;
+  base: string;
+  draft: boolean;
+};
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  preflight: PreflightOk | null;
+  submitting: boolean;
+  submitError?: string | null;
+  onSubmit: (v: PrFormSubmit) => void;
+};
+
+export function PrDialog({ open, onOpenChange, preflight, submitting, submitError, onSubmit }: Props) {
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [base, setBase] = useState('');
+  const [draft, setDraft] = useState(false);
+
+  // Seed from preflight each time the dialog opens.
+  useEffect(() => {
+    if (!open || !preflight) return;
+    setTitle(preflight.suggestedTitle);
+    setBody(preflight.suggestedBody);
+    setBase(preflight.base);
+    setDraft(false);
+  }, [open, preflight]);
+
+  const baseOptions = useMemo(() => {
+    if (!preflight) return [] as string[];
+    // Always include the chosen base even if it isn't in availableBases
+    // (e.g. preflight fell back to "main" but the user's repo has no
+    // origin/main listed — happens on fresh forks).
+    const set = new Set<string>(preflight.availableBases);
+    if (preflight.base) set.add(preflight.base);
+    return Array.from(set).sort();
+  }, [preflight]);
+
+  const canSubmit = !submitting && title.trim().length > 0 && base.length > 0 && !!preflight;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        title="Create Pull Request"
+        description={
+          preflight
+            ? `Push ${preflight.branch} → ${base || preflight.base} and open a PR on GitHub.`
+            : 'Running preflight checks…'
+        }
+        width="560px"
+        data-testid="pr-dialog"
+      >
+        <DialogBody>
+          {preflight && (
+            <div className="flex flex-col gap-3">
+              <Field label="Title">
+                <input
+                  type="text"
+                  data-testid="pr-title"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  disabled={submitting}
+                  className={inputCx}
+                />
+              </Field>
+
+              <Field label="Base branch">
+                <select
+                  data-testid="pr-base"
+                  value={base}
+                  onChange={(e) => setBase(e.target.value)}
+                  disabled={submitting}
+                  className={inputCx}
+                >
+                  {baseOptions.map((b) => (
+                    <option key={b} value={b}>
+                      {b}
+                    </option>
+                  ))}
+                </select>
+              </Field>
+
+              <Field label="Body">
+                <textarea
+                  data-testid="pr-body"
+                  value={body}
+                  onChange={(e) => setBody(e.target.value)}
+                  disabled={submitting}
+                  rows={10}
+                  className={inputCx + ' font-mono text-xs leading-[18px] resize-y min-h-[180px]'}
+                />
+              </Field>
+
+              <label className="flex items-center gap-2 text-sm text-fg-secondary select-none">
+                <input
+                  type="checkbox"
+                  data-testid="pr-draft"
+                  checked={draft}
+                  onChange={(e) => setDraft(e.target.checked)}
+                  disabled={submitting}
+                  className="h-3.5 w-3.5 accent-accent"
+                />
+                Open as draft
+              </label>
+
+              {submitError && (
+                <div
+                  role="alert"
+                  className="rounded-md border border-state-error/40 bg-state-error-soft/60 px-3 py-2 font-mono text-[11px] leading-[16px] text-state-error-fg whitespace-pre-wrap max-h-[160px] overflow-auto"
+                >
+                  {submitError}
+                </div>
+              )}
+            </div>
+          )}
+        </DialogBody>
+        <DialogFooter>
+          <Button variant="secondary" size="sm" onClick={() => onOpenChange(false)} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            data-testid="pr-submit"
+            onClick={() =>
+              onSubmit({
+                title: title.trim(),
+                body,
+                base,
+                draft
+              })
+            }
+            disabled={!canSubmit}
+          >
+            {submitting ? 'Opening…' : 'Open PR'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+const inputCx =
+  'block w-full rounded-sm border border-border-default bg-bg-elevated px-2 py-1 text-sm ' +
+  'text-fg-primary outline-none transition-colors duration-150 ease-out ' +
+  'hover:border-border-strong focus:border-accent focus-visible:ring-1 focus-visible:ring-accent ' +
+  'disabled:opacity-60 disabled:cursor-not-allowed';
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="flex flex-col gap-1">
+      <span className="font-mono text-[10px] uppercase tracking-wider text-fg-tertiary">{label}</span>
+      {children}
+    </label>
+  );
+}

--- a/src/components/PrFlowProvider.tsx
+++ b/src/components/PrFlowProvider.tsx
@@ -1,0 +1,42 @@
+import { useEffect } from 'react';
+import { PrDialog } from './PrDialog';
+import { usePrFlow, registerPrFlowTrigger } from '../lib/pr-flow';
+
+// App-level mount point for the /pr flow:
+//   - Owns dialog state.
+//   - Registers a module-scoped trigger so the InputBar send-path can
+//     fire /pr without prop-drilling a handler through every component.
+//   - Renders the dialog; the post-submit "open PR" status block is
+//     injected into the chat stream via the store, not rendered here.
+export function PrFlowProvider() {
+  const flow = usePrFlow();
+
+  useEffect(() => {
+    registerPrFlowTrigger((sessionId) => {
+      void flow.startFromSlash(sessionId);
+    });
+    return () => registerPrFlowTrigger(null);
+  }, [flow]);
+
+  const preflight =
+    flow.dialog.phase === 'form' || flow.dialog.phase === 'submitting'
+      ? flow.dialog.preflight
+      : null;
+  const submitting = flow.dialog.phase === 'submitting';
+  const submitError =
+    flow.dialog.phase === 'submitting' ? flow.dialog.error ?? null : null;
+  const open = flow.dialog.phase === 'form' || flow.dialog.phase === 'submitting';
+
+  return (
+    <PrDialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) flow.cancel();
+      }}
+      preflight={preflight}
+      submitting={submitting}
+      submitError={submitError}
+      onSubmit={(v) => void flow.submit(v)}
+    />
+  );
+}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -100,6 +100,43 @@ type CliSetBinaryResultDecl =
   | { ok: true; version: string | null }
   | { ok: false; error: string };
 
+type PrPreflightErrorDecl = {
+  code: 'no-cwd' | 'not-git' | 'no-gh' | 'on-default-branch' | 'dirty-tree' | 'no-commits';
+  detail: string;
+  branch?: string;
+};
+type PrPreflightResultDecl =
+  | {
+      ok: true;
+      branch: string;
+      base: string;
+      availableBases: string[];
+      repoRoot: string;
+      suggestedTitle: string;
+      suggestedBody: string;
+    }
+  | { ok: false; errors: PrPreflightErrorDecl[] };
+type PrCreateResultDecl =
+  | { ok: true; url: string; number: number }
+  | { ok: false; error: string };
+type PrCheckDecl = {
+  name: string;
+  status: 'queued' | 'in_progress' | 'completed' | 'waiting' | 'pending';
+  conclusion:
+    | 'success'
+    | 'failure'
+    | 'cancelled'
+    | 'skipped'
+    | 'timed_out'
+    | 'neutral'
+    | 'action_required'
+    | null;
+  detailsUrl?: string;
+};
+type PrChecksResultDecl =
+  | { ok: true; checks: PrCheckDecl[] }
+  | { ok: false; error: string };
+
 declare global {
   interface Window {
     agentory?: {
@@ -146,6 +183,21 @@ declare global {
         userPath: () => Promise<string>;
         projectPath: (cwd: string) => Promise<string | null>;
       };
+
+      pr: {
+        preflight: (cwd: string | null | undefined) => Promise<PrPreflightResultDecl>;
+        create: (args: {
+          cwd: string;
+          branch: string;
+          base: string;
+          title: string;
+          body: string;
+          draft: boolean;
+        }) => Promise<PrCreateResultDecl>;
+        checks: (cwd: string, number: number) => Promise<PrChecksResultDecl>;
+      };
+
+      openExternal: (url: string) => Promise<boolean>;
 
       notify: (payload: {
         sessionId: string;

--- a/src/lib/pr-flow.ts
+++ b/src/lib/pr-flow.ts
@@ -1,0 +1,309 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useStore } from '../stores/store';
+import type { MessageBlock, PrCheckStatus } from '../types';
+
+// Module-scoped registry of timers keyed by session id so the orchestrator
+// can cancel polling on unmount / session switch. Polling is per-PR; one
+// active poll per session is the design (you don't open two PRs at once
+// from the same worktree).
+const pollTimers = new Map<string, ReturnType<typeof setTimeout>>();
+const pollStopFlags = new Map<string, boolean>();
+
+const POLL_INTERVAL_MS = 30_000;
+const POLL_TIMEOUT_MS = 30 * 60 * 1000;
+
+// Shape returned by the preflight IPC, mirroring electron/pr.ts.
+type PreflightOk = {
+  ok: true;
+  branch: string;
+  base: string;
+  availableBases: string[];
+  repoRoot: string;
+  suggestedTitle: string;
+  suggestedBody: string;
+};
+type PreflightErr = { ok: false; errors: Array<{ code: string; detail: string; branch?: string }> };
+type PreflightResult = PreflightOk | PreflightErr;
+
+type CreateResult =
+  | { ok: true; url: string; number: number }
+  | { ok: false; error: string };
+
+type ChecksResult = { ok: true; checks: PrCheckStatus[] } | { ok: false; error: string };
+
+export type DialogState =
+  | { phase: 'idle' }
+  | { phase: 'preflight'; sessionId: string }
+  | {
+      phase: 'form';
+      sessionId: string;
+      preflight: PreflightOk;
+    }
+  | {
+      phase: 'submitting';
+      sessionId: string;
+      preflight: PreflightOk;
+      error?: string;
+    };
+
+export interface PrFlowApi {
+  dialog: DialogState;
+  startFromSlash: (sessionId: string) => Promise<void>;
+  submit: (v: { title: string; body: string; base: string; draft: boolean }) => Promise<void>;
+  cancel: () => void;
+}
+
+// Module-scoped registered handler so non-React code (e.g. the InputBar's
+// send-path on receipt of /pr) can invoke the flow without threading a
+// React context through every call site. Populated by PrFlowProvider on
+// mount, cleared on unmount.
+let registeredTrigger: ((sessionId: string) => void) | null = null;
+export function triggerPrFlow(sessionId: string): boolean {
+  if (!registeredTrigger) return false;
+  registeredTrigger(sessionId);
+  return true;
+}
+export function registerPrFlowTrigger(fn: ((sessionId: string) => void) | null): void {
+  registeredTrigger = fn;
+}
+
+function nextBlockId(prefix: string): string {
+  return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
+// All chat-block mutations go through the zustand store so persistence and
+// re-renders fall out for free.
+function appendBlock(sessionId: string, block: MessageBlock): void {
+  useStore.getState().appendBlocks(sessionId, [block]);
+}
+
+function replaceBlock(sessionId: string, blockId: string, patch: Partial<MessageBlock>): void {
+  const prev = useStore.getState().messagesBySession[sessionId] ?? [];
+  const existing = prev.find((b) => b.id === blockId);
+  if (!existing) return;
+  const merged = { ...existing, ...patch } as MessageBlock;
+  useStore.getState().appendBlocks(sessionId, [merged]);
+}
+
+function pushError(sessionId: string, title: string, detail?: string): void {
+  appendBlock(sessionId, {
+    kind: 'status',
+    id: nextBlockId('pr-err'),
+    tone: 'warn',
+    title,
+    detail
+  });
+}
+
+export function usePrFlow(): PrFlowApi {
+  const [dialog, setDialog] = useState<DialogState>({ phase: 'idle' });
+  // Mirror in a ref so async callbacks can read the latest phase without
+  // retrigger-ing via effect deps.
+  const dialogRef = useRef<DialogState>(dialog);
+  dialogRef.current = dialog;
+
+  useEffect(() => {
+    return () => {
+      // Stop all polls on unmount.
+      for (const [sid, t] of pollTimers) {
+        clearTimeout(t);
+        pollStopFlags.set(sid, true);
+      }
+      pollTimers.clear();
+    };
+  }, []);
+
+  const startFromSlash = useCallback(async (sessionId: string) => {
+    const sess = useStore.getState().sessions.find((s) => s.id === sessionId);
+    setDialog({ phase: 'preflight', sessionId });
+    const api = window.agentory;
+    if (!api?.pr) {
+      pushError(sessionId, 'PR helpers unavailable', 'The main-process IPC for /pr is not wired up.');
+      setDialog({ phase: 'idle' });
+      return;
+    }
+    const res = (await api.pr.preflight(sess?.cwd ?? null)) as PreflightResult;
+    if (!res.ok) {
+      for (const e of res.errors) {
+        pushError(sessionId, labelForPreflightError(e.code), e.detail);
+      }
+      setDialog({ phase: 'idle' });
+      return;
+    }
+    setDialog({ phase: 'form', sessionId, preflight: res });
+  }, []);
+
+  const submit = useCallback(
+    async (v: { title: string; body: string; base: string; draft: boolean }) => {
+      const cur = dialogRef.current;
+      if (cur.phase !== 'form' && cur.phase !== 'submitting') return;
+      const { sessionId, preflight } = cur;
+      setDialog({ phase: 'submitting', sessionId, preflight });
+
+      // Pre-create a status block that we'll update in-place.
+      const blockId = nextBlockId('pr');
+      appendBlock(sessionId, {
+        kind: 'pr-status',
+        id: blockId,
+        phase: 'opening',
+        base: v.base,
+        branch: preflight.branch
+      });
+
+      const api = window.agentory;
+      if (!api?.pr) {
+        replaceBlock(sessionId, blockId, {
+          kind: 'pr-status',
+          id: blockId,
+          phase: 'failed',
+          error: 'PR helpers unavailable'
+        } as MessageBlock);
+        setDialog({ phase: 'idle' });
+        return;
+      }
+
+      const res = (await api.pr.create({
+        cwd: preflight.repoRoot,
+        branch: preflight.branch,
+        base: v.base,
+        title: v.title,
+        body: v.body,
+        draft: v.draft
+      })) as CreateResult;
+
+      if (!res.ok) {
+        // Keep the dialog open so the user can tweak and retry.
+        replaceBlock(sessionId, blockId, {
+          kind: 'pr-status',
+          id: blockId,
+          phase: 'failed',
+          error: res.error,
+          base: v.base,
+          branch: preflight.branch
+        } as MessageBlock);
+        setDialog({ phase: 'submitting', sessionId, preflight, error: res.error });
+        // Bounce back to the form so buttons become active again.
+        setTimeout(() => setDialog({ phase: 'form', sessionId, preflight }), 0);
+        return;
+      }
+
+      // Success: close dialog, render the PR block, start polling.
+      replaceBlock(sessionId, blockId, {
+        kind: 'pr-status',
+        id: blockId,
+        phase: 'polling',
+        number: res.number,
+        url: res.url,
+        base: v.base,
+        branch: preflight.branch,
+        checks: []
+      } as MessageBlock);
+      setDialog({ phase: 'idle' });
+      startPolling(sessionId, blockId, preflight.repoRoot, res.number);
+    },
+    []
+  );
+
+  const cancel = useCallback(() => {
+    setDialog({ phase: 'idle' });
+  }, []);
+
+  return { dialog, startFromSlash, submit, cancel };
+}
+
+function labelForPreflightError(code: string): string {
+  switch (code) {
+    case 'no-cwd':
+      return 'No working directory set';
+    case 'not-git':
+      return 'Not a git repository';
+    case 'no-gh':
+      return 'GitHub CLI missing';
+    case 'on-default-branch':
+      return 'Refusing to PR from the default branch';
+    case 'dirty-tree':
+      return 'Uncommitted changes';
+    default:
+      return 'Preflight check failed';
+  }
+}
+
+function startPolling(sessionId: string, blockId: string, cwd: string, prNumber: number): void {
+  const startedAt = Date.now();
+  pollStopFlags.set(sessionId, false);
+
+  const tick = async () => {
+    if (pollStopFlags.get(sessionId)) return;
+    const api = window.agentory;
+    if (!api?.pr) return;
+    const res = (await api.pr.checks(cwd, prNumber)) as ChecksResult;
+    if (pollStopFlags.get(sessionId)) return;
+
+    // Fetch current block so we can patch it. Store-level append coalesces
+    // by id so this round-trip is safe.
+    const cur = useStore
+      .getState()
+      .messagesBySession[sessionId]?.find((b) => b.id === blockId);
+    if (!cur || cur.kind !== 'pr-status') {
+      stopPolling(sessionId);
+      return;
+    }
+
+    let checks: PrCheckStatus[] = cur.checks ?? [];
+    if (res.ok) {
+      checks = res.checks;
+    }
+    const agg = aggregateClient(checks);
+    const done = agg === 'passing' || agg === 'failing';
+    replaceBlock(sessionId, blockId, {
+      ...cur,
+      checks,
+      phase: done ? 'done' : 'polling',
+      lastPollAt: Date.now()
+    } as MessageBlock);
+
+    if (done) {
+      stopPolling(sessionId);
+      return;
+    }
+    if (Date.now() - startedAt > POLL_TIMEOUT_MS) {
+      stopPolling(sessionId);
+      return;
+    }
+    const t = setTimeout(tick, POLL_INTERVAL_MS);
+    pollTimers.set(sessionId, t);
+  };
+
+  // First tick fires immediately so the block shows live checks within a
+  // second of PR creation, not 30s later.
+  void tick();
+}
+
+function stopPolling(sessionId: string): void {
+  const t = pollTimers.get(sessionId);
+  if (t) clearTimeout(t);
+  pollTimers.delete(sessionId);
+  pollStopFlags.set(sessionId, true);
+}
+
+// Mirror of electron/pr.ts `aggregateChecks`, minus the 'empty' state —
+// during polling an empty list just means "waiting for CI to register".
+export function aggregateClient(checks: PrCheckStatus[]): 'pending' | 'passing' | 'failing' {
+  if (checks.length === 0) return 'pending';
+  let hasIncomplete = false;
+  for (const c of checks) {
+    if (c.status !== 'completed') {
+      hasIncomplete = true;
+      continue;
+    }
+    const conc = c.conclusion;
+    if (
+      conc === 'failure' ||
+      conc === 'cancelled' ||
+      conc === 'timed_out' ||
+      conc === 'action_required'
+    )
+      return 'failing';
+  }
+  return hasIncomplete ? 'pending' : 'passing';
+}

--- a/src/slash-commands/handlers.ts
+++ b/src/slash-commands/handlers.ts
@@ -11,6 +11,7 @@ import { useStore } from '../stores/store';
 import type { MessageBlock } from '../types';
 import { SLASH_COMMANDS, type SlashCommandContext } from './registry';
 import { openSettings } from './ui-bridge';
+import { triggerPrFlow } from '../lib/pr-flow';
 
 function nextId(prefix: string): string {
   return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
@@ -224,6 +225,21 @@ export function blocksToTranscript(blocks: MessageBlock[]): string {
   return lines.join('\n');
 }
 
+// ---------- /pr ----------
+// Owned end-to-end by PrFlowProvider — preflight, Radix form, gh pr create,
+// CI polling. This handler just fires the trigger the provider registered
+// on mount. If the provider isn't mounted (e.g. early in boot), surface an
+// error block so the user knows why nothing happened.
+export function handlePr(ctx: SlashCommandContext): void {
+  const dispatched = triggerPrFlow(ctx.sessionId);
+  if (!dispatched) {
+    appendError(
+      ctx.sessionId,
+      '/pr flow is not available (PrFlowProvider not mounted).'
+    );
+  }
+}
+
 // Attach handlers to registry entries. Module side-effect; imported once by
 // the app bootstrap (src/index.tsx or wherever we kick things off) and once
 // by the unit tests that exercise dispatch.
@@ -238,3 +254,4 @@ attach('config', handleConfig);
 attach('model', handleModel);
 attach('help', handleHelp);
 attach('compact', handleCompact);
+attach('pr', handlePr);

--- a/src/slash-commands/registry.ts
+++ b/src/slash-commands/registry.ts
@@ -1,15 +1,10 @@
 // Slash command registry.
 //
-// IMPORTANT: we do NOT interpret or execute these commands. This registry
-// exists purely to drive the in-chat discoverability picker. When the user
-// picks a command, we drop `/<name> ` into the textarea and let them hit
-// Enter — the raw text (including the slash) is passed through to the
-// underlying claude.exe process via the normal user-message path.
-//
-// Which commands actually *respond meaningfully* when sent through
-// `--input-format stream-json` is a separate question (see PR body). For
-// the picker, any command that the CLI exposes at a `/`-prompt is fair
-// game to advertise.
+// Entries here drive the in-chat discoverability picker AND dispatch. A
+// command with `passThrough: true` is forwarded to claude.exe as a normal
+// user message; one with `passThrough: false` must have a `clientHandler`
+// attached (see ./handlers.ts) because we intentionally do NOT forward it.
+// The handler owns UX and must not touch claude.exe directly.
 import {
   HelpCircle,
   Eraser,
@@ -29,10 +24,15 @@ import {
   Webhook,
   Users,
   FileSearch,
+  GitPullRequest,
   type LucideIcon
 } from 'lucide-react';
 
-export type SlashCommandCategory = 'built-in' | 'skill';
+// 'built-in' commands map 1:1 to the CLI's `/`-prompt menu.
+// 'skill' is reserved for future skill-based commands.
+// 'client' commands are fully handled inside Agentory — the agent never
+// sees them. Typically paired with `passThrough: false`.
+export type SlashCommandCategory = 'built-in' | 'skill' | 'client';
 
 // Context handed to a client-side handler. Intentionally minimal — we pass
 // only what the current MVP handlers need; expand if a future command warrants
@@ -74,6 +74,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: 'model',   description: 'Switch model for this session',                 icon: Cpu,              category: 'built-in', passThrough: false },
   { name: 'config',  description: 'Open settings',                                 icon: Settings,         category: 'built-in', passThrough: false },
   { name: 'cost',    description: 'Show session cost and token usage',             icon: CircleDollarSign, category: 'built-in', passThrough: false },
+  { name: 'pr',      description: 'Create a GitHub PR for the current worktree',   icon: GitPullRequest,   category: 'client',   passThrough: false },
   { name: 'resume',  description: 'Resume a previous session',                     icon: History,          category: 'built-in', passThrough: true  },
   { name: 'memory',  description: 'Manage CLAUDE.md memory',                       icon: Brain,            category: 'built-in', passThrough: true  },
   { name: 'init',    description: 'Initialize CLAUDE.md in current project',       icon: FolderPlus,       category: 'built-in', passThrough: true  },
@@ -136,13 +137,30 @@ export async function dispatchSlashCommand(
 }
 
 // Pure filter used by the picker and unit tests. Matches a substring against
-// both `name` and `description` (case-insensitive). No fuzzy; MVP.
+// both `name` and `description` (case-insensitive). Results are ranked so
+// the most "obviously meant" match is first — an exact name match beats a
+// name-prefix match beats a description hit. The activeIndex-defaulting-to-0
+// behavior then lines up with user intent: typing `/pr` + Enter commits
+// `/pr`, not the first entry that happens to contain "pr" in its description.
 export function filterSlashCommands(all: SlashCommand[], query: string): SlashCommand[] {
   const q = query.trim().toLowerCase();
   if (!q) return all;
-  return all.filter(
-    (c) => c.name.toLowerCase().includes(q) || c.description.toLowerCase().includes(q)
-  );
+  type Ranked = { cmd: SlashCommand; rank: number; index: number };
+  const ranked: Ranked[] = [];
+  for (let i = 0; i < all.length; i++) {
+    const c = all[i];
+    const name = c.name.toLowerCase();
+    const desc = c.description.toLowerCase();
+    let rank: number;
+    if (name === q) rank = 0;
+    else if (name.startsWith(q)) rank = 1;
+    else if (name.includes(q)) rank = 2;
+    else if (desc.includes(q)) rank = 3;
+    else continue;
+    ranked.push({ cmd: c, rank, index: i });
+  }
+  ranked.sort((a, b) => (a.rank - b.rank) || (a.index - b.index));
+  return ranked.map((r) => r.cmd);
 }
 
 // Detects whether the textarea content is currently "typing a slash

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,4 +105,38 @@ export type MessageBlock =
     }
   | { kind: 'question'; id: string; requestId?: string; toolUseId?: string; questions: QuestionSpec[] }
   | { kind: 'status'; id: string; tone: 'info' | 'warn'; title: string; detail?: string }
+  | {
+      kind: 'pr-status';
+      id: string;
+      // Progress through the state machine: opening -> open -> polling ->
+      // (done | failed). Rendered as a live-updating block in chat.
+      phase: 'opening' | 'open' | 'polling' | 'done' | 'failed';
+      number?: number;
+      url?: string;
+      base?: string;
+      branch?: string;
+      checks?: PrCheckStatus[];
+      lastPollAt?: number;
+      // Populated when any check reaches a terminal failing conclusion, so
+      // the user can see log excerpts without opening the browser.
+      failedLogs?: Array<{ name: string; snippet: string }>;
+      error?: string;
+    }
   | { kind: 'error'; id: string; text: string };
+
+// Mirrors electron/pr.ts `PrCheck` — duplicated here because the renderer
+// can't import main-process types.
+export interface PrCheckStatus {
+  name: string;
+  status: 'queued' | 'in_progress' | 'completed' | 'waiting' | 'pending';
+  conclusion:
+    | 'success'
+    | 'failure'
+    | 'cancelled'
+    | 'skipped'
+    | 'timed_out'
+    | 'neutral'
+    | 'action_required'
+    | null;
+  detailsUrl?: string;
+}

--- a/tests/pr.test.ts
+++ b/tests/pr.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as pr from '../electron/pr';
+
+describe('buildPrBody', () => {
+  it('renders the Summary header with bulleted commits (newest first order preserved)', () => {
+    const body = pr.buildPrBody({
+      commitSummaries: ['feat: add thing', 'fix: tweak'],
+      title: 'ignored when summaries present'
+    });
+    expect(body).toContain('## Summary');
+    expect(body).toContain('- feat: add thing');
+    expect(body).toContain('- fix: tweak');
+    expect(body).toContain('Generated with');
+  });
+
+  it('falls back to the title bullet when no commits are given', () => {
+    const body = pr.buildPrBody({ commitSummaries: [], title: 'my PR title' });
+    expect(body).toContain('- my PR title');
+    expect(body).toContain('Generated with');
+  });
+
+  it('deduplicates repeated commit subjects while preserving first-seen order', () => {
+    const body = pr.buildPrBody({
+      commitSummaries: ['x', 'y', 'x', '', 'z', 'y'],
+      title: 't'
+    });
+    const lines = body.split('\n').filter((l) => l.startsWith('- '));
+    expect(lines).toEqual(['- x', '- y', '- z']);
+  });
+});
+
+describe('aggregateChecks', () => {
+  it('returns empty for no checks', () => {
+    expect(pr.aggregateChecks([])).toBe('empty');
+  });
+  it('returns passing when all completed with success/skipped/neutral', () => {
+    expect(
+      pr.aggregateChecks([
+        { name: 'a', status: 'completed', conclusion: 'success' },
+        { name: 'b', status: 'completed', conclusion: 'skipped' },
+        { name: 'c', status: 'completed', conclusion: 'neutral' }
+      ])
+    ).toBe('passing');
+  });
+  it('returns failing as soon as one check fails', () => {
+    expect(
+      pr.aggregateChecks([
+        { name: 'a', status: 'completed', conclusion: 'success' },
+        { name: 'b', status: 'completed', conclusion: 'failure' }
+      ])
+    ).toBe('failing');
+  });
+  it('treats cancelled / timed_out / action_required as failing', () => {
+    expect(
+      pr.aggregateChecks([{ name: 'a', status: 'completed', conclusion: 'cancelled' }])
+    ).toBe('failing');
+    expect(
+      pr.aggregateChecks([{ name: 'a', status: 'completed', conclusion: 'timed_out' }])
+    ).toBe('failing');
+    expect(
+      pr.aggregateChecks([{ name: 'a', status: 'completed', conclusion: 'action_required' }])
+    ).toBe('failing');
+  });
+  it('returns pending while any check is not yet completed', () => {
+    expect(
+      pr.aggregateChecks([
+        { name: 'a', status: 'completed', conclusion: 'success' },
+        { name: 'b', status: 'in_progress', conclusion: null }
+      ])
+    ).toBe('pending');
+  });
+});
+
+describe('parseGhChecks', () => {
+  it('parses a typical gh pr checks --json array', () => {
+    const stdout = JSON.stringify([
+      { name: 'test', state: 'completed', conclusion: 'success', link: 'https://x/1' },
+      { name: 'lint', state: 'in_progress', conclusion: null }
+    ]);
+    const checks = pr.parseGhChecks(stdout);
+    expect(checks).toHaveLength(2);
+    expect(checks[0]).toMatchObject({ name: 'test', status: 'completed', conclusion: 'success' });
+    expect(checks[0].detailsUrl).toBe('https://x/1');
+    expect(checks[1]).toMatchObject({ name: 'lint', status: 'in_progress', conclusion: null });
+  });
+  it('returns empty array for malformed JSON', () => {
+    expect(pr.parseGhChecks('not-json')).toEqual([]);
+    expect(pr.parseGhChecks('{}')).toEqual([]);
+  });
+});
+
+describe('parsePrUrl', () => {
+  it('extracts owner / repo / number', () => {
+    const parsed = pr.parsePrUrl(
+      'Creating pull request...\nhttps://github.com/acme/widgets/pull/42\n'
+    );
+    expect(parsed).toEqual({
+      url: 'https://github.com/acme/widgets/pull/42',
+      owner: 'acme',
+      repo: 'widgets',
+      number: 42
+    });
+  });
+  it('returns null when no URL is present', () => {
+    expect(pr.parsePrUrl('boom')).toBeNull();
+  });
+});
+
+describe('isDefaultBranch', () => {
+  it('recognizes main/master/trunk', () => {
+    expect(pr.isDefaultBranch('main')).toBe(true);
+    expect(pr.isDefaultBranch('master')).toBe(true);
+    expect(pr.isDefaultBranch('trunk')).toBe(true);
+  });
+  it('treats feature branches as non-default', () => {
+    expect(pr.isDefaultBranch('feat/slash-pr-command')).toBe(false);
+    expect(pr.isDefaultBranch('develop')).toBe(false);
+  });
+});
+
+describe('formatGhInstallHint', () => {
+  it('returns a non-empty string mentioning gh', () => {
+    const s = pr.formatGhInstallHint();
+    expect(s.length).toBeGreaterThan(0);
+    expect(s.toLowerCase()).toContain('gh');
+  });
+});
+
+// --- Preflight unit tests (spawn is mocked) --------------------------------
+
+type MockResp = { code: number; stdout?: string; stderr?: string; notFound?: boolean };
+
+function makeRunner(table: Array<{ match: (cmd: string, args: string[]) => boolean; resp: MockResp }>) {
+  const calls: Array<{ cmd: string; args: string[] }> = [];
+  const runner = async (cmd: string, args: string[]) => {
+    calls.push({ cmd, args });
+    for (const row of table) {
+      if (row.match(cmd, args)) {
+        return {
+          code: row.resp.code,
+          stdout: row.resp.stdout ?? '',
+          stderr: row.resp.stderr ?? '',
+          notFound: row.resp.notFound
+        };
+      }
+    }
+    return { code: 0, stdout: '', stderr: '' };
+  };
+  return { runner, calls };
+}
+
+describe('runPreflight', () => {
+  afterEach(() => {
+    pr._setRunner(null);
+  });
+
+  it('fails when cwd is missing', async () => {
+    const res = await pr.runPreflight(null);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.errors[0].code).toBe('no-cwd');
+  });
+
+  it('reports not-git when git rev-parse fails', async () => {
+    const { runner } = makeRunner([
+      {
+        match: (cmd, args) => cmd === 'git' && args[0] === 'rev-parse',
+        resp: { code: 128, stderr: 'fatal: not a git repository' }
+      }
+    ]);
+    pr._setRunner(runner);
+    const res = await pr.runPreflight('/tmp/nope');
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.errors[0].code).toBe('not-git');
+  });
+
+  it('reports no-gh when gh binary is missing', async () => {
+    const { runner } = makeRunner([
+      {
+        match: (cmd, args) => cmd === 'git' && args[0] === 'rev-parse' && args[1] === '--show-toplevel',
+        resp: { code: 0, stdout: '/repo' }
+      },
+      {
+        match: (cmd) => cmd === 'gh',
+        resp: { code: -1, stderr: 'ENOENT', notFound: true }
+      }
+    ]);
+    pr._setRunner(runner);
+    const res = await pr.runPreflight('/repo/sub');
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.errors[0].code).toBe('no-gh');
+  });
+
+  it('reports on-default-branch when branch is main', async () => {
+    const { runner } = makeRunner([
+      {
+        match: (cmd, args) => cmd === 'git' && args[0] === 'rev-parse' && args[1] === '--show-toplevel',
+        resp: { code: 0, stdout: '/repo' }
+      },
+      {
+        match: (cmd) => cmd === 'gh',
+        resp: { code: 0, stdout: 'gh version 2.0' }
+      },
+      {
+        match: (cmd, args) => cmd === 'git' && args[0] === 'rev-parse' && args[1] === '--abbrev-ref',
+        resp: { code: 0, stdout: 'main' }
+      },
+      {
+        match: (cmd, args) => cmd === 'git' && args[0] === 'status',
+        resp: { code: 0, stdout: '' }
+      }
+    ]);
+    pr._setRunner(runner);
+    const res = await pr.runPreflight('/repo');
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.errors.some((e) => e.code === 'on-default-branch')).toBe(true);
+    }
+  });
+
+  it('reports dirty-tree when working copy has changes', async () => {
+    const { runner } = makeRunner([
+      {
+        match: (cmd, args) => cmd === 'git' && args[0] === 'rev-parse' && args[1] === '--show-toplevel',
+        resp: { code: 0, stdout: '/repo' }
+      },
+      { match: (cmd) => cmd === 'gh', resp: { code: 0, stdout: 'v' } },
+      {
+        match: (cmd, args) => cmd === 'git' && args[0] === 'rev-parse' && args[1] === '--abbrev-ref',
+        resp: { code: 0, stdout: 'feat/x' }
+      },
+      {
+        match: (cmd, args) => cmd === 'git' && args[0] === 'status',
+        resp: { code: 0, stdout: ' M src/foo.ts\n' }
+      }
+    ]);
+    pr._setRunner(runner);
+    const res = await pr.runPreflight('/repo');
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.errors.some((e) => e.code === 'dirty-tree')).toBe(true);
+    }
+  });
+
+  it('returns ok with suggested title/body for a healthy feature branch', async () => {
+    const { runner } = makeRunner([
+      {
+        match: (cmd, args) => cmd === 'git' && args[0] === 'rev-parse' && args[1] === '--show-toplevel',
+        resp: { code: 0, stdout: '/repo' }
+      },
+      { match: (cmd) => cmd === 'gh', resp: { code: 0, stdout: 'v' } },
+      {
+        match: (cmd, args) => cmd === 'git' && args[0] === 'rev-parse' && args[1] === '--abbrev-ref',
+        resp: { code: 0, stdout: 'feat/slash-pr' }
+      },
+      {
+        match: (cmd, args) => cmd === 'git' && args[0] === 'status',
+        resp: { code: 0, stdout: '' }
+      },
+      {
+        match: (cmd, args) => cmd === 'git' && args[0] === 'symbolic-ref',
+        resp: { code: 0, stdout: 'origin/main' }
+      },
+      {
+        match: (cmd, args) =>
+          cmd === 'git' && args[0] === 'for-each-ref',
+        resp: { code: 0, stdout: 'main\norigin/main\nfeat/slash-pr\norigin/working\n' }
+      },
+      {
+        match: (cmd, args) => cmd === 'git' && args[0] === 'log' && args[1] === '-1',
+        resp: { code: 0, stdout: 'feat(slash): /pr command' }
+      },
+      {
+        match: (cmd, args) =>
+          cmd === 'git' && args[0] === 'rev-parse' && args[1] === '--verify',
+        resp: { code: 0, stdout: 'deadbeef' }
+      },
+      {
+        match: (cmd, args) => cmd === 'git' && args[0] === 'log' && args[1] === 'origin/main..HEAD',
+        resp: { code: 0, stdout: 'feat(slash): /pr command\nchore: add tests\n' }
+      }
+    ]);
+    pr._setRunner(runner);
+    const res = await pr.runPreflight('/repo');
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.branch).toBe('feat/slash-pr');
+      expect(res.base).toBe('main');
+      expect(res.suggestedTitle).toBe('feat(slash): /pr command');
+      expect(res.suggestedBody).toContain('- feat(slash): /pr command');
+      expect(res.suggestedBody).toContain('- chore: add tests');
+      expect(res.availableBases).toContain('main');
+      expect(res.availableBases).toContain('working');
+      expect(res.availableBases).not.toContain('feat/slash-pr');
+    }
+  });
+});

--- a/tests/slash-commands-registry.test.ts
+++ b/tests/slash-commands-registry.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect } from 'vitest';
 import {
   SLASH_COMMANDS,
   filterSlashCommands,
-  detectSlashTrigger
+  detectSlashTrigger,
+  parseSlashInvocation,
+  findSlashCommand
 } from '../src/slash-commands/registry';
 
 describe('filterSlashCommands', () => {
@@ -74,5 +76,41 @@ describe('detectSlashTrigger', () => {
   it('activates when slash is on first line and caret is still on it', () => {
     const v = '/foo\nmore text';
     expect(detectSlashTrigger(v, 3)).toEqual({ active: true, query: 'foo' });
+  });
+});
+
+describe('/pr registry entry', () => {
+  it('is registered as a client command with passThrough false', () => {
+    const pr = findSlashCommand('pr');
+    expect(pr).toBeDefined();
+    expect(pr?.category).toBe('client');
+    expect(pr?.passThrough).toBe(false);
+  });
+
+  it('parses "/pr" as a bare invocation', () => {
+    expect(parseSlashInvocation('/pr')).toEqual({ name: 'pr', args: '' });
+  });
+
+  it('captures args after /pr for future extensibility', () => {
+    expect(parseSlashInvocation('/pr open draft')).toEqual({
+      name: 'pr',
+      args: 'open draft'
+    });
+  });
+});
+
+describe('filterSlashCommands ranking', () => {
+  it('places exact name match first for /pr', () => {
+    const r = filterSlashCommands(SLASH_COMMANDS, 'pr');
+    // Anything matching 'pr' could include "PR" in descriptions (e.g. /review).
+    // The exact name /pr must come first so activeIndex=0 picks it.
+    expect(r[0]?.name).toBe('pr');
+  });
+
+  it('prefers prefix over description matches', () => {
+    // Adding "co" hits /compact (prefix) and /cost (prefix), but descriptions
+    // don't trigger either ahead of them.
+    const r = filterSlashCommands(SLASH_COMMANDS, 'com');
+    expect(r[0]?.name).toBe('compact');
   });
 });


### PR DESCRIPTION
## Summary

`/pr` is the first **client-handled** slash command that owns a multi-step UX: preflight → form → push + create → live CI polling. Replaces the "alt-tab to terminal, type git push, then `gh pr create --title …`" loop with a single `/pr`-Enter inside the chat.

## Flow

```
User types /pr + Enter
        │
        ▼
┌─────────────────┐    fail   ┌────────────────────────┐
│   preflight     │ ────────▶ │ status block in chat   │
│  (electron/pr)  │           │ with specific fix hint │
└─────────────────┘           └────────────────────────┘
        │ ok
        ▼
┌─────────────────────────────┐
│ Radix dialog (PrDialog)     │
│  • title  ← latest commit   │
│  • body   ← commits..base   │
│  • base   ← origin/HEAD     │
│  • draft? □                 │
└─────────────────────────────┘
        │ Open PR
        ▼
git push -u origin <branch>
gh pr create --body-file <tmp>
        │
        ▼
┌────────────────────────────────────┐
│ pr-status block (live updates)     │
│ ✓ test   ⏳ build   ✗ lint         │
│ poll every 30s, stop on terminal   │
│ state or 30min timeout             │
└────────────────────────────────────┘
```

## Architecture

- `electron/pr.ts` — preflight, create, checks. All `child_process.spawn` lives here; renderer never touches git/gh. Exposes a `_setRunner` test seam so all flows are unit-testable without spawning.
- `src/slash-commands/handlers.ts` — `/pr` registered as a `clientHandler` alongside `/clear`, `/cost`, etc. (via the dispatch system from #86), so `dispatchSlashCommand` routes `/pr` to `handlePr` → `triggerPrFlow` → `PrFlowProvider`.
- `src/lib/pr-flow.ts` — the orchestrator hook. Owns dialog state, persists status into the chat-stream block store, runs the polling loop with stop-flags so session unmount cancels cleanly.
- `src/components/PrDialog.tsx` — Radix dialog with autofocus / Apple-tier hover/active/focus-visible.
- `src/components/ChatStream.tsx` — new `pr-status` block kind renders inline; updates in place via the store's coalesce-by-id `appendBlocks`.
- IPC: `pr:preflight`, `pr:create`, `pr:checks`, `shell:openExternal` (http(s)-only guard).

## Security notes

- **No shell.** `child_process.spawn` is called with explicit argv and `shell: false`, so titles / branch names are not subject to quoting attacks.
- **Body via tmpfile.** `gh pr create --body-file` reads from a temp file we write directly (no shell escaping needed for body content).
- **`shell.openExternal` allowlist.** Renderer can only ask main to open `http://` or `https://` URLs; non-http schemes rejected.
- **Default-branch guard.** Both renderer (preflight) and main (`createPr`) refuse `git push` when on `main` / `master` / `trunk`. Adversarial renderer can't bypass.
- **Dirty tree refusal.** Per the requirement, `/pr` aborts with a clear error if there are uncommitted changes — no auto-commit.
- **No `--no-verify`.** Pre-push hook failures surface verbatim; never bypassed.

## Extensibility

- The slash registry's `clientHandler` field (from #86) is the seam — future client commands (`/issue`, `/release`, …) plug in by adding a registry row + a handler. No new dispatch plumbing needed.
- `electron/pr.ts` is `gh`-specific today; for future GitLab / Gitea support, swap the `gh` calls inside `createPr` / `fetchPrChecks`. Preflight is VCS-agnostic apart from the `gh --version` probe.
- Polling cadence (30s / 30min cap) and check-state aggregation are pure functions (`aggregateChecks`) — easy to tune and test.

## Tests

39 new + existing untouched.

- `tests/pr.test.ts` (21): `buildPrBody` (dedup + footer + fallback), `aggregateChecks` (pending / passing / failing / empty), `parseGhChecks`, `parsePrUrl`, `isDefaultBranch`, `formatGhInstallHint`, and `runPreflight` covering every branch (no cwd / not git / no gh / on default branch / dirty tree / healthy).
- `tests/slash-commands-registry.test.ts` (+5): `/pr` is registered as `client` + `passThrough: false`; `parseSlashInvocation` handles bare `/pr` and `/pr open draft`; `filterSlashCommands` ranking now puts exact-name match first so `/pr` lands on `/pr` not `/resume`.
- `scripts/probe-slash-pr.mjs`: stubs `window.agentory.pr.*`, asserts dialog opens with seeded values, submit renders status block with URL, polling aggregates checks → `phase=done`.

## Quality gates

- `npm run typecheck` — clean
- `npm run lint` — 0 errors, 0 new warnings
- `npm test` — 476 passed; 22 pre-existing failures are all better-sqlite3 native-module version mismatches (NODE_MODULE_VERSION 130 vs 127) that exist on `origin/working` HEAD too
- Live probe — passes against the dev server

## UX polish notes

- Typing `/pr` + Enter dispatches the handler immediately rather than the legacy "/pr<space>, then Enter" two-step. Generalized in `commitSlashCommand` so any client command with `clientHandler` benefits.
- Filter ranking (exact > prefix > name-substring > description) means `activeIndex=0` always lands on what the user meant.
- Status block uses `motion.div` with the same easing as other chat blocks; check rows use `Loader2` (animate-spin) for in-progress, `CheckCircle2` for pass, `XCircle` for fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)