### PR TITLE
feat(worktree): core manager + session spawner wiring

### DIFF
--- a/electron/agent/__tests__/worktree-manager.test.ts
+++ b/electron/agent/__tests__/worktree-manager.test.ts
@@ -1,0 +1,347 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as path from 'node:path';
+import {
+  WorktreeManager,
+  type WorktreeStorage,
+  type WorktreeRecord,
+  type GitSurface,
+  generateName,
+  resolveWorktreePath,
+  branchNameForWorktree,
+} from '../worktree-manager';
+import type { WorktreeListEntry, CreateWorktreeArgs } from '../git-helpers';
+
+// ───────────────────────────── helpers ─────────────────────────────────
+
+function createMemoryStorage(): WorktreeStorage & { rows: Map<string, WorktreeRecord> } {
+  const rows = new Map<string, WorktreeRecord>();
+  return {
+    rows,
+    save: (rec) => {
+      rows.set(rec.sessionId, { ...rec });
+    },
+    remove: (sessionId) => {
+      rows.delete(sessionId);
+    },
+    getBySession: (sessionId) => {
+      const r = rows.get(sessionId);
+      return r ? { ...r } : null;
+    },
+    listAll: () => Array.from(rows.values()).map((r) => ({ ...r })),
+  };
+}
+
+function createFakeGit(): GitSurface & {
+  fetchOrigin: ReturnType<typeof vi.fn>;
+  getCurrentBranch: ReturnType<typeof vi.fn>;
+  createWorktree: ReturnType<typeof vi.fn>;
+  removeWorktree: ReturnType<typeof vi.fn>;
+  listWorktrees: ReturnType<typeof vi.fn>;
+  pruneWorktrees: ReturnType<typeof vi.fn>;
+} {
+  return {
+    fetchOrigin: vi.fn(async () => ({ fetched: true })),
+    getCurrentBranch: vi.fn(async () => 'main'),
+    createWorktree: vi.fn(async (_args: CreateWorktreeArgs) => {}),
+    removeWorktree: vi.fn(async (_p: string) => {}),
+    listWorktrees: vi.fn(async (_repo: string): Promise<WorktreeListEntry[]> => []),
+    pruneWorktrees: vi.fn(async (_repo: string) => {}),
+  };
+}
+
+// A deterministic "random" source: we hand it a canned sequence and it
+// serves picks/hex in that order. Lets us assert generated names exactly.
+function scriptedRandom(
+  picks: number[],
+  hexes: string[]
+): { pick: (max: number) => number; hex: (bytes: number) => string } {
+  let pi = 0;
+  let hi = 0;
+  return {
+    pick: (max) => {
+      const v = picks[pi++];
+      return v % max;
+    },
+    hex: (_bytes) => hexes[hi++],
+  };
+}
+
+// ────────────────────────────── name generator ───────────────────────
+
+describe('generateName', () => {
+  it('produces <adj>-<noun>-<hex>', () => {
+    const random = scriptedRandom([0, 0], ['deadbe']);
+    const name = generateName(random);
+    expect(name).toMatch(/^[a-z]+-[a-z]+-[0-9a-f]{6}$/);
+    expect(name.endsWith('-deadbe')).toBe(true);
+  });
+
+  it('varies across calls when random is real crypto', () => {
+    const a = generateName();
+    const b = generateName();
+    // Not a bulletproof test, but 1/100 * 1/16^6 collision is ~6e-11.
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('resolveWorktreePath', () => {
+  it('always returns an absolute path under .claude/worktrees/', () => {
+    const p = resolveWorktreePath('/tmp/repo', 'swift-falcon-abc123');
+    expect(path.isAbsolute(p)).toBe(true);
+    expect(p).toContain(path.join('.claude', 'worktrees', 'swift-falcon-abc123'));
+  });
+
+  it('resolves relative repoRoot to absolute', () => {
+    const p = resolveWorktreePath('./repo', 'x');
+    expect(path.isAbsolute(p)).toBe(true);
+  });
+});
+
+describe('branchNameForWorktree', () => {
+  it('prefixes the name so it never shadows a user branch', () => {
+    expect(branchNameForWorktree('swift-falcon-abc123')).toBe('worktree-swift-falcon-abc123');
+  });
+});
+
+// ───────────────────────────── create() ──────────────────────────────
+
+describe('WorktreeManager.create', () => {
+  let storage: ReturnType<typeof createMemoryStorage>;
+  let git: ReturnType<typeof createFakeGit>;
+  let mgr: WorktreeManager;
+
+  beforeEach(() => {
+    storage = createMemoryStorage();
+    git = createFakeGit();
+    mgr = new WorktreeManager({
+      storage,
+      git,
+      random: scriptedRandom([0, 0], ['abcdef']),
+      now: () => 1_700_000_000_000,
+      warn: () => {},
+    });
+  });
+
+  it('fetches origin, creates the worktree, and persists a record', async () => {
+    const rec = await mgr.create('sess-1', '/tmp/repo', 'working');
+
+    expect(git.fetchOrigin).toHaveBeenCalledWith(path.resolve('/tmp/repo'));
+    expect(git.createWorktree).toHaveBeenCalledTimes(1);
+    const callArg = git.createWorktree.mock.calls[0][0] as CreateWorktreeArgs;
+    expect(callArg.repoRoot).toBe(path.resolve('/tmp/repo'));
+    expect(callArg.sourceBranch).toBe('working');
+    expect(callArg.branch).toBe(rec.branch);
+    expect(rec.name).toMatch(/^[a-z]+-[a-z]+-abcdef$/);
+    expect(rec.path).toBe(callArg.worktreePath);
+    expect(rec.createdAt).toBe(1_700_000_000_000);
+
+    expect(storage.rows.get('sess-1')).toEqual(rec);
+  });
+
+  it('defaults sourceBranch to getCurrentBranch() when caller omits it', async () => {
+    git.getCurrentBranch.mockResolvedValue('feature-x');
+    await mgr.create('sess-1', '/tmp/repo');
+    const callArg = git.createWorktree.mock.calls[0][0] as CreateWorktreeArgs;
+    expect(callArg.sourceBranch).toBe('feature-x');
+  });
+
+  it('falls back to "main" when HEAD is detached and caller omits sourceBranch', async () => {
+    git.getCurrentBranch.mockResolvedValue(null);
+    await mgr.create('sess-1', '/tmp/repo');
+    const callArg = git.createWorktree.mock.calls[0][0] as CreateWorktreeArgs;
+    expect(callArg.sourceBranch).toBe('main');
+  });
+
+  it('is idempotent — second call returns the first record and does not touch git', async () => {
+    const first = await mgr.create('sess-1', '/tmp/repo', 'working');
+    git.createWorktree.mockClear();
+    git.fetchOrigin.mockClear();
+    const second = await mgr.create('sess-1', '/tmp/repo', 'working');
+    expect(second).toEqual(first);
+    expect(git.createWorktree).not.toHaveBeenCalled();
+    expect(git.fetchOrigin).not.toHaveBeenCalled();
+  });
+
+  it('proceeds even when fetchOrigin rejects', async () => {
+    git.fetchOrigin.mockRejectedValue(new Error('network down'));
+    const rec = await mgr.create('sess-1', '/tmp/repo', 'working');
+    expect(rec.sessionId).toBe('sess-1');
+    expect(git.createWorktree).toHaveBeenCalled();
+  });
+
+  it('rolls back on storage failure by removing the freshly-made worktree', async () => {
+    const badStorage: WorktreeStorage = {
+      save: () => {
+        throw new Error('disk full');
+      },
+      remove: () => {},
+      getBySession: () => null,
+      listAll: () => [],
+    };
+    const rollbackMgr = new WorktreeManager({
+      storage: badStorage,
+      git,
+      random: scriptedRandom([0, 0], ['abcdef']),
+      now: () => 1,
+      warn: () => {},
+    });
+    await expect(rollbackMgr.create('s', '/tmp/repo', 'main')).rejects.toThrow('disk full');
+    expect(git.removeWorktree).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ───────────────────────────── remove() ──────────────────────────────
+
+describe('WorktreeManager.remove', () => {
+  it('deletes the git worktree and the sqlite row', async () => {
+    const storage = createMemoryStorage();
+    const git = createFakeGit();
+    storage.save({
+      sessionId: 'sess-1',
+      name: 'swift-falcon-aaa111',
+      path: '/tmp/repo/.claude/worktrees/swift-falcon-aaa111',
+      baseRepo: '/tmp/repo',
+      branch: 'worktree-swift-falcon-aaa111',
+      sourceBranch: 'main',
+      createdAt: 1,
+    });
+    const mgr = new WorktreeManager({ storage, git, warn: () => {} });
+
+    await mgr.remove('sess-1');
+
+    expect(git.removeWorktree).toHaveBeenCalledWith('/tmp/repo/.claude/worktrees/swift-falcon-aaa111');
+    expect(storage.rows.has('sess-1')).toBe(false);
+  });
+
+  it('no-ops when no record exists', async () => {
+    const storage = createMemoryStorage();
+    const git = createFakeGit();
+    const mgr = new WorktreeManager({ storage, git, warn: () => {} });
+    await expect(mgr.remove('unknown')).resolves.toBeUndefined();
+    expect(git.removeWorktree).not.toHaveBeenCalled();
+  });
+
+  it('still drops the sqlite row even if removeWorktree fails', async () => {
+    const storage = createMemoryStorage();
+    const git = createFakeGit();
+    git.removeWorktree.mockRejectedValue(new Error('git borked'));
+    storage.save({
+      sessionId: 'sess-1',
+      name: 'n',
+      path: '/tmp/repo/.claude/worktrees/n',
+      baseRepo: '/tmp/repo',
+      branch: 'worktree-n',
+      sourceBranch: 'main',
+      createdAt: 1,
+    });
+    const mgr = new WorktreeManager({ storage, git, warn: () => {} });
+    await mgr.remove('sess-1');
+    expect(storage.rows.has('sess-1')).toBe(false);
+  });
+});
+
+// ───────────────────────── reconcileOrphans() ────────────────────────
+
+describe('WorktreeManager.reconcileOrphans', () => {
+  it('drops sqlite rows for worktrees git no longer knows about, keeps live ones', async () => {
+    const storage = createMemoryStorage();
+    const git = createFakeGit();
+
+    storage.save({
+      sessionId: 'live',
+      name: 'live-one',
+      path: '/tmp/repo/.claude/worktrees/live-one',
+      baseRepo: '/tmp/repo',
+      branch: 'worktree-live-one',
+      sourceBranch: 'main',
+      createdAt: 1,
+    });
+    storage.save({
+      sessionId: 'dead',
+      name: 'dead-one',
+      path: '/tmp/repo/.claude/worktrees/dead-one',
+      baseRepo: '/tmp/repo',
+      branch: 'worktree-dead-one',
+      sourceBranch: 'main',
+      createdAt: 2,
+    });
+
+    git.listWorktrees.mockResolvedValue([
+      { path: '/tmp/repo', isMain: true },
+      { path: '/tmp/repo/.claude/worktrees/live-one' },
+    ]);
+
+    const mgr = new WorktreeManager({ storage, git, warn: () => {} });
+    await mgr.reconcileOrphans();
+
+    expect(storage.rows.has('live')).toBe(true);
+    expect(storage.rows.has('dead')).toBe(false);
+    expect(git.pruneWorktrees).toHaveBeenCalledWith(path.resolve('/tmp/repo'));
+  });
+
+  it('groups by repoRoot and continues to the next repo if one throws', async () => {
+    const storage = createMemoryStorage();
+    const git = createFakeGit();
+
+    storage.save({
+      sessionId: 'r1',
+      name: 'r1',
+      path: '/tmp/repoA/.claude/worktrees/r1',
+      baseRepo: '/tmp/repoA',
+      branch: 'worktree-r1',
+      sourceBranch: 'main',
+      createdAt: 1,
+    });
+    storage.save({
+      sessionId: 'r2',
+      name: 'r2',
+      path: '/tmp/repoB/.claude/worktrees/r2',
+      baseRepo: '/tmp/repoB',
+      branch: 'worktree-r2',
+      sourceBranch: 'main',
+      createdAt: 2,
+    });
+
+    git.listWorktrees.mockImplementation(async (repo: string) => {
+      if (repo.endsWith('repoA')) throw new Error('A boom');
+      return [{ path: '/tmp/repoB', isMain: true }]; // repoB's r2 is orphaned
+    });
+
+    const mgr = new WorktreeManager({ storage, git, warn: () => {} });
+    await mgr.reconcileOrphans();
+
+    // repoA skipped → row stays; repoB reconciled → r2 dropped.
+    expect(storage.rows.has('r1')).toBe(true);
+    expect(storage.rows.has('r2')).toBe(false);
+  });
+
+  it('no-ops cleanly when there are no records', async () => {
+    const storage = createMemoryStorage();
+    const git = createFakeGit();
+    const mgr = new WorktreeManager({ storage, git, warn: () => {} });
+    await mgr.reconcileOrphans();
+    expect(git.listWorktrees).not.toHaveBeenCalled();
+  });
+});
+
+// ─────────────── generateUniqueName collision avoidance ──────────────
+
+describe('WorktreeManager.generateUniqueName', () => {
+  it('skips names already present in storage', () => {
+    const storage = createMemoryStorage();
+    storage.save({
+      sessionId: 's',
+      name: 'brisk-badger-aaaaaa',
+      path: '/p',
+      baseRepo: '/r',
+      branch: 'worktree-brisk-badger-aaaaaa',
+      sourceBranch: 'main',
+      createdAt: 1,
+    });
+    // picks [0,0] maps adjectives[0]=brisk nouns[0]=badger.
+    // First hex collides with the stored name; second hex is fresh.
+    const random = scriptedRandom([0, 0, 0, 0], ['aaaaaa', 'bbbbbb']);
+    const mgr = new WorktreeManager({ storage, random, warn: () => {} });
+    expect(mgr.generateUniqueName()).toBe('brisk-badger-bbbbbb');
+  });
+});

--- a/electron/agent/git-helpers.ts
+++ b/electron/agent/git-helpers.ts
@@ -1,0 +1,309 @@
+// Git helpers for worktree support. Every shell-out goes through `execFile`
+// (not `exec`) with `shell: false` so user-supplied paths / branch names can't
+// trigger shell interpretation. Errors are re-thrown as structured
+// `GitCommandError` instances so callers can surface the failing argv + stderr
+// to the UI without having to parse raw strings.
+//
+// Scope: only what worktree-manager needs. Anything more general-purpose
+// (diffs, commits, etc.) lives elsewhere — keep this file small.
+
+import { execFile } from 'node:child_process';
+import * as path from 'node:path';
+
+/**
+ * Structured error thrown by every exported helper. Wraps the underlying
+ * spawn / non-zero-exit failure with the exact argv we ran and whatever
+ * stderr we captured, so callers can log or display diagnostics without
+ * having to reach into a raw Error message.
+ */
+export class GitCommandError extends Error {
+  constructor(
+    message: string,
+    public readonly args: readonly string[],
+    public readonly stderr: string,
+    public readonly code: number | null
+  ) {
+    super(message);
+    this.name = 'GitCommandError';
+  }
+}
+
+/** Minimum timeout applied to every git invocation. */
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+/** Default per-repo-root rate-limit window for fetchOrigin. */
+const FETCH_THROTTLE_MS = 5 * 60 * 1000;
+
+/**
+ * Long-paths is always on on Windows to survive nested worktree dirs in
+ * `.claude/worktrees/<name>`. LFS smudge/process is disabled for worktree
+ * creation specifically — large-file pulls on every branch add minutes to
+ * what should be a subsecond operation, and the user doesn't need LFS
+ * artefacts materialised in the worktree to run most dev workflows.
+ */
+const WIN_LONGPATH_ARG = ['-c', 'core.longpaths=true'];
+const LFS_SKIP_ARGS = [
+  '-c',
+  'filter.lfs.smudge=',
+  '-c',
+  'filter.lfs.process=',
+  '-c',
+  'filter.lfs.required=false',
+];
+
+interface RunGitOptions {
+  cwd?: string;
+  timeoutMs?: number;
+}
+
+/**
+ * Low-level wrapper around `execFile('git', args)`. Always uses `shell: false`;
+ * callers must never interpolate user input into a single string here.
+ */
+function runGit(
+  args: readonly string[],
+  opts: RunGitOptions = {}
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      'git',
+      args as string[],
+      {
+        cwd: opts.cwd,
+        shell: false,
+        timeout: opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+        maxBuffer: 32 * 1024 * 1024,
+        windowsHide: true,
+      },
+      (err, stdout, stderr) => {
+        if (err) {
+          const exitCode = (err as NodeJS.ErrnoException & { code?: number | string }).code;
+          const numericCode =
+            typeof exitCode === 'number' ? exitCode : null;
+          reject(
+            new GitCommandError(
+              `git ${args.join(' ')} failed: ${err.message}`,
+              args,
+              typeof stderr === 'string' ? stderr : String(stderr ?? ''),
+              numericCode
+            )
+          );
+          return;
+        }
+        resolve({
+          stdout: typeof stdout === 'string' ? stdout : String(stdout),
+          stderr: typeof stderr === 'string' ? stderr : String(stderr),
+        });
+      }
+    );
+  });
+}
+
+/**
+ * `git rev-parse --show-toplevel` for the given cwd. Returns the absolute
+ * path of the enclosing git repo, or null if cwd is not inside a repo.
+ */
+export async function resolveRepoRoot(cwd: string): Promise<string | null> {
+  try {
+    const { stdout } = await runGit(['rev-parse', '--show-toplevel'], { cwd });
+    const p = stdout.trim();
+    return p.length > 0 ? path.resolve(p) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * `git rev-parse --git-dir`. Cheap probe for "is this inside a git repo?".
+ */
+export async function isGitRepo(cwd: string): Promise<boolean> {
+  try {
+    await runGit(['rev-parse', '--git-dir'], { cwd });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * In-memory rate-limit table for fetchOrigin. Keyed by the absolute repoRoot.
+ * A module-level Map is fine: this file is loaded once per main-process
+ * lifecycle, and the limit is purely a nice-to-have to avoid hammering
+ * origin every time the user opens the new-session dialog.
+ *
+ * Exposed for tests via `__resetFetchThrottleForTests`.
+ */
+const lastFetchAt = new Map<string, number>();
+
+/** Test-only: clear the throttle state between cases. */
+export function __resetFetchThrottleForTests(): void {
+  lastFetchAt.clear();
+}
+
+/**
+ * `git fetch origin`, rate-limited to once per repo root per 5 minutes.
+ * Best-effort: returns `{ fetched: false }` without throwing if fetch fails,
+ * since a missing network or permission error shouldn't block worktree
+ * creation from a local branch.
+ */
+export async function fetchOrigin(
+  repoRoot: string,
+  opts: { now?: number; throttleMs?: number } = {}
+): Promise<{ fetched: boolean; throttled?: boolean; error?: string }> {
+  const abs = path.resolve(repoRoot);
+  const now = opts.now ?? Date.now();
+  const throttleMs = opts.throttleMs ?? FETCH_THROTTLE_MS;
+  const last = lastFetchAt.get(abs);
+  if (last !== undefined && now - last < throttleMs) {
+    return { fetched: false, throttled: true };
+  }
+  try {
+    await runGit(['fetch', 'origin'], { cwd: abs, timeoutMs: 120_000 });
+    lastFetchAt.set(abs, now);
+    return { fetched: true };
+  } catch (err) {
+    // Don't surface as a hard failure — origin might be offline, unconfigured,
+    // or forbidden. Caller treats this as non-fatal.
+    lastFetchAt.set(abs, now);
+    return {
+      fetched: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+/**
+ * Current branch name (short form). Returns null if HEAD is detached.
+ */
+export async function getCurrentBranch(repoRoot: string): Promise<string | null> {
+  const { stdout } = await runGit(['rev-parse', '--abbrev-ref', 'HEAD'], {
+    cwd: repoRoot,
+  });
+  const name = stdout.trim();
+  if (name.length === 0 || name === 'HEAD') return null;
+  return name;
+}
+
+/**
+ * List local + origin remote branches (short names). Deduplicated, sorted.
+ * Remote HEAD pointers (`origin/HEAD`) are filtered out.
+ */
+export async function listBranches(repoRoot: string): Promise<string[]> {
+  const { stdout } = await runGit(
+    ['branch', '--all', '--format=%(refname:short)'],
+    { cwd: repoRoot }
+  );
+  const names = stdout
+    .split(/\r?\n/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .filter((s) => !s.endsWith('/HEAD'));
+  return Array.from(new Set(names)).sort();
+}
+
+export interface CreateWorktreeArgs {
+  repoRoot: string;
+  worktreePath: string;
+  /** New branch name to create at the worktree. */
+  branch: string;
+  /** Upstream branch to fork from — `origin/<sourceBranch>` is passed to git. */
+  sourceBranch: string;
+}
+
+/**
+ * `git worktree add -b <branch> <path> origin/<sourceBranch>`, with our
+ * standard longpath + LFS-skip overrides. Both paths are resolved to absolute
+ * form before being passed to git so relative-path ambiguity can't bite us.
+ */
+export async function createWorktree(args: CreateWorktreeArgs): Promise<void> {
+  const absRoot = path.resolve(args.repoRoot);
+  const absPath = path.resolve(args.worktreePath);
+  await runGit(
+    [
+      ...WIN_LONGPATH_ARG,
+      ...LFS_SKIP_ARGS,
+      'worktree',
+      'add',
+      '-b',
+      args.branch,
+      absPath,
+      `origin/${args.sourceBranch}`,
+    ],
+    { cwd: absRoot, timeoutMs: 300_000 }
+  );
+}
+
+/**
+ * `git worktree remove --force <path>`. `--force` because we expect to nuke
+ * worktrees on session teardown regardless of dirty state — the session is
+ * gone, so the local edits inside its worktree go with it.
+ */
+export async function removeWorktree(worktreePath: string): Promise<void> {
+  const absPath = path.resolve(worktreePath);
+  // We can't cwd into the worktree we're removing, so run from the worktree's
+  // parent. git figures out the repo root from the path argument.
+  await runGit(['worktree', 'remove', '--force', absPath]);
+}
+
+export interface WorktreeListEntry {
+  /** Absolute path. */
+  path: string;
+  /** Commit SHA the worktree currently points at. */
+  head?: string;
+  /** Short branch name (if attached). */
+  branch?: string;
+  /** true for the main working tree. */
+  isMain?: boolean;
+  /** Detached HEAD. */
+  detached?: boolean;
+}
+
+/**
+ * Parse `git worktree list --porcelain`. Porcelain output has blank-line
+ * separated records; each record is key/value-ish lines.
+ */
+export async function listWorktrees(repoRoot: string): Promise<WorktreeListEntry[]> {
+  const { stdout } = await runGit(['worktree', 'list', '--porcelain'], {
+    cwd: repoRoot,
+  });
+  const entries: WorktreeListEntry[] = [];
+  let cur: WorktreeListEntry | null = null;
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trimEnd();
+    if (line.length === 0) {
+      if (cur) {
+        entries.push(cur);
+        cur = null;
+      }
+      continue;
+    }
+    if (line.startsWith('worktree ')) {
+      if (cur) entries.push(cur);
+      cur = { path: path.resolve(line.slice('worktree '.length)) };
+      continue;
+    }
+    if (!cur) continue;
+    if (line.startsWith('HEAD ')) {
+      cur.head = line.slice('HEAD '.length);
+    } else if (line.startsWith('branch ')) {
+      const ref = line.slice('branch '.length);
+      // Porcelain uses full refname (`refs/heads/foo`); normalise to short.
+      cur.branch = ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref;
+    } else if (line === 'bare') {
+      cur.isMain = true;
+    } else if (line === 'detached') {
+      cur.detached = true;
+    }
+  }
+  if (cur) entries.push(cur);
+  if (entries.length > 0) entries[0].isMain = true;
+  return entries;
+}
+
+/**
+ * `git worktree prune`. Best-effort — used during reconcile to clean up
+ * metadata for worktrees whose directories were deleted out-of-band.
+ */
+export async function pruneWorktrees(repoRoot: string): Promise<void> {
+  await runGit(['worktree', 'prune'], { cwd: repoRoot });
+}

--- a/electron/agent/worktree-manager.ts
+++ b/electron/agent/worktree-manager.ts
@@ -1,0 +1,326 @@
+// WorktreeManager — the singleton responsible for binding a session to a
+// disposable git worktree. Lifecycle:
+//
+//   SessionRunner.start()  →  (optional) worktreeManager.create(sessionId, ...)
+//   SessionRunner close    →  worktreeManager.remove(sessionId)
+//
+// The manager persists a `WorktreeRecord` per session in SQLite via the
+// injectable storage adapter; at boot, `reconcileOrphans()` walks every
+// known repoRoot and reconciles sqlite rows against `git worktree list`,
+// pruning anything that's drifted (directory vanished out-of-band, or
+// directory exists without a record).
+//
+// Injection: storage + git are passed in at construction time so the unit
+// tests can substitute in-memory / fake implementations without spinning up
+// SQLite or shelling out to git. Production wiring (see main.ts in Commit
+// B) hands in the real sqlite-backed adapter and the real git helpers.
+
+import * as path from 'node:path';
+import { randomBytes } from 'node:crypto';
+import * as GitHelpers from './git-helpers';
+
+export interface WorktreeRecord {
+  sessionId: string;
+  name: string;
+  path: string;
+  baseRepo: string;
+  branch: string;
+  sourceBranch: string | null;
+  createdAt: number;
+}
+
+/**
+ * Storage adapter contract. The production adapter in Commit B thin-wraps
+ * better-sqlite3; tests use an in-memory Map. Kept synchronous because the
+ * underlying sqlite calls are synchronous and we want `getBySession()` to
+ * be cheap to call from anywhere.
+ */
+export interface WorktreeStorage {
+  save(rec: WorktreeRecord): void;
+  remove(sessionId: string): void;
+  getBySession(sessionId: string): WorktreeRecord | null;
+  listAll(): WorktreeRecord[];
+}
+
+/** Git surface the manager depends on. Mirrors `git-helpers` 1:1 so tests can
+ * stub per-method without having to spawn a subprocess. */
+export interface GitSurface {
+  fetchOrigin(repoRoot: string): Promise<{ fetched: boolean; throttled?: boolean; error?: string }>;
+  getCurrentBranch(repoRoot: string): Promise<string | null>;
+  createWorktree(args: GitHelpers.CreateWorktreeArgs): Promise<void>;
+  removeWorktree(worktreePath: string): Promise<void>;
+  listWorktrees(repoRoot: string): Promise<GitHelpers.WorktreeListEntry[]>;
+  pruneWorktrees(repoRoot: string): Promise<void>;
+}
+
+/** Production git surface — delegates straight through. */
+export const defaultGitSurface: GitSurface = {
+  fetchOrigin: GitHelpers.fetchOrigin,
+  getCurrentBranch: GitHelpers.getCurrentBranch,
+  createWorktree: GitHelpers.createWorktree,
+  removeWorktree: GitHelpers.removeWorktree,
+  listWorktrees: GitHelpers.listWorktrees,
+  pruneWorktrees: GitHelpers.pruneWorktrees,
+};
+
+// ─────────────────────────── name generator ───────────────────────────────
+//
+// adjective-noun-<hex6>. 10×10=100 adjective/noun combos × 16^6 hex tails =
+// enough entropy that collisions on the same host are astronomically rare
+// for a dev's session count. The dictionary is intentionally small and
+// English-safe: every pair yields a pronounceable, lowercase identifier
+// that's also a valid directory name on every supported OS.
+
+const ADJECTIVES = [
+  'brisk', 'calm', 'dusky', 'eager', 'fair',
+  'glad', 'keen', 'mild', 'proud', 'swift',
+];
+
+const NOUNS = [
+  'badger', 'cedar', 'delta', 'ember', 'falcon',
+  'grove', 'harbor', 'iris', 'juniper', 'kestrel',
+];
+
+interface RandomSource {
+  pick(max: number): number;
+  hex(bytes: number): string;
+}
+
+const cryptoRandom: RandomSource = {
+  pick: (max) => {
+    // Bias-safe: reject samples ≥ floor(256/max)*max. For our max=10, the
+    // bias without rejection would be negligible, but it's two lines to do
+    // this right.
+    if (max <= 0) throw new Error('pick(max<=0)');
+    const limit = Math.floor(256 / max) * max;
+    for (;;) {
+      const b = randomBytes(1)[0];
+      if (b < limit) return b % max;
+    }
+  },
+  hex: (bytes) => randomBytes(bytes).toString('hex'),
+};
+
+/**
+ * Generate a `<adj>-<noun>-<hex>` name. Exposed for tests — callers should
+ * normally go through `WorktreeManager.generateUniqueName()`.
+ */
+export function generateName(random: RandomSource = cryptoRandom): string {
+  const adj = ADJECTIVES[random.pick(ADJECTIVES.length)];
+  const noun = NOUNS[random.pick(NOUNS.length)];
+  const tail = random.hex(3); // 3 bytes = 6 hex chars
+  return `${adj}-${noun}-${tail}`;
+}
+
+/**
+ * Resolve the filesystem parent dir under which a worktree `<name>` will be
+ * created. MVP: always `<repoRoot>/.claude/worktrees/<name>`. Exposed for
+ * tests and for Commit B's future settings override path.
+ */
+export function resolveWorktreePath(repoRoot: string, name: string): string {
+  return path.resolve(repoRoot, '.claude', 'worktrees', name);
+}
+
+/**
+ * Branch name we hand to `git worktree add -b <branch>`. Using the same
+ * string as the worktree name keeps things traceable without adding another
+ * identifier axis.
+ */
+export function branchNameForWorktree(name: string): string {
+  return `worktree-${name}`;
+}
+
+// ─────────────────────────────── manager ──────────────────────────────────
+
+export interface WorktreeManagerOptions {
+  storage: WorktreeStorage;
+  git?: GitSurface;
+  random?: RandomSource;
+  /** Clock override for tests. Defaults to `Date.now`. */
+  now?: () => number;
+  /** Injection point for logger spies; defaults to console.warn. */
+  warn?: (msg: string, err?: unknown) => void;
+}
+
+export class WorktreeManager {
+  private readonly storage: WorktreeStorage;
+  private readonly git: GitSurface;
+  private readonly random: RandomSource;
+  private readonly now: () => number;
+  private readonly warn: (msg: string, err?: unknown) => void;
+
+  constructor(opts: WorktreeManagerOptions) {
+    this.storage = opts.storage;
+    this.git = opts.git ?? defaultGitSurface;
+    this.random = opts.random ?? cryptoRandom;
+    this.now = opts.now ?? (() => Date.now());
+    this.warn = opts.warn ?? ((msg, err) => console.warn('[worktree]', msg, err));
+  }
+
+  /**
+   * Pick a name that doesn't already exist in storage. Retries a small number
+   * of times before falling back to the raw hex suffix — even at thousands
+   * of worktrees the two-word dictionary only collides on the hex tail, so
+   * in practice one try is enough.
+   */
+  generateUniqueName(): string {
+    const known = new Set(this.storage.listAll().map((r) => r.name));
+    for (let i = 0; i < 8; i++) {
+      const candidate = generateName(this.random);
+      if (!known.has(candidate)) return candidate;
+    }
+    // Pathological fallback: pure hex, longer.
+    return `wt-${this.random.hex(8)}`;
+  }
+
+  /** Existing record for a session, or null. */
+  getBySession(sessionId: string): WorktreeRecord | null {
+    return this.storage.getBySession(sessionId);
+  }
+
+  /**
+   * Create a worktree for the given session. Idempotent: calling twice for
+   * the same sessionId returns the existing record without re-creating.
+   * Rolls back the sqlite row if `git worktree add` throws.
+   */
+  async create(
+    sessionId: string,
+    repoRoot: string,
+    sourceBranch?: string
+  ): Promise<WorktreeRecord> {
+    const existing = this.storage.getBySession(sessionId);
+    if (existing) return existing;
+
+    const absRepo = path.resolve(repoRoot);
+
+    // Best-effort fetch; don't block creation on a failure (offline dev,
+    // private mirror, etc.). The throttle lives inside fetchOrigin itself.
+    await this.git.fetchOrigin(absRepo).catch((err) => {
+      this.warn('fetchOrigin failed — proceeding without remote refresh', err);
+      return { fetched: false };
+    });
+
+    const resolvedSource =
+      sourceBranch?.trim() ||
+      (await this.git.getCurrentBranch(absRepo)) ||
+      'main';
+
+    const name = this.generateUniqueName();
+    const worktreePath = resolveWorktreePath(absRepo, name);
+    const branch = branchNameForWorktree(name);
+
+    await this.git.createWorktree({
+      repoRoot: absRepo,
+      worktreePath,
+      branch,
+      sourceBranch: resolvedSource,
+    });
+
+    const record: WorktreeRecord = {
+      sessionId,
+      name,
+      path: worktreePath,
+      baseRepo: absRepo,
+      branch,
+      sourceBranch: resolvedSource,
+      createdAt: this.now(),
+    };
+
+    try {
+      this.storage.save(record);
+    } catch (err) {
+      // Storage failed post-create — nuke the worktree so we don't leak disk.
+      await this.git.removeWorktree(worktreePath).catch((cleanupErr) => {
+        this.warn('rollback: removeWorktree failed', cleanupErr);
+      });
+      throw err;
+    }
+
+    return record;
+  }
+
+  /**
+   * Remove a session's worktree. Safe to call even if no record exists
+   * (returns without error). Continues to delete the sqlite row even if
+   * `git worktree remove` fails, so a stale sqlite entry never blocks the
+   * session from being closed.
+   */
+  async remove(sessionId: string): Promise<void> {
+    const record = this.storage.getBySession(sessionId);
+    if (!record) return;
+    try {
+      await this.git.removeWorktree(record.path);
+    } catch (err) {
+      this.warn(`removeWorktree(${record.path}) failed — dropping DB row anyway`, err);
+    }
+    this.storage.remove(sessionId);
+  }
+
+  /**
+   * Boot-time cleanup. For every distinct baseRepo we know about:
+   *   1. `git worktree list --porcelain` → set of currently-registered paths
+   *   2. For each sqlite record:
+   *        - record.path NOT in the list → delete the sqlite row (the dir
+   *          was already nuked externally; nothing to clean on disk).
+   *   3. `git worktree prune` to sweep the git-side metadata for any
+   *      directories users deleted by hand.
+   *
+   * We deliberately DON'T remove unknown worktrees that git knows about but
+   * sqlite doesn't — those might be the user's own manual worktrees, and
+   * this manager has no claim on them.
+   *
+   * Best-effort: any per-repo failure is logged and the next repo continues.
+   */
+  async reconcileOrphans(): Promise<void> {
+    const records = this.storage.listAll();
+    if (records.length === 0) return;
+
+    const byRepo = new Map<string, WorktreeRecord[]>();
+    for (const rec of records) {
+      const key = path.resolve(rec.baseRepo);
+      const list = byRepo.get(key) ?? [];
+      list.push(rec);
+      byRepo.set(key, list);
+    }
+
+    for (const [repoRoot, recs] of byRepo) {
+      try {
+        const live = await this.git.listWorktrees(repoRoot);
+        const livePaths = new Set(live.map((e) => path.resolve(e.path)));
+        for (const rec of recs) {
+          if (!livePaths.has(path.resolve(rec.path))) {
+            this.storage.remove(rec.sessionId);
+          }
+        }
+        await this.git.pruneWorktrees(repoRoot).catch((err) => {
+          this.warn(`pruneWorktrees(${repoRoot}) failed`, err);
+        });
+      } catch (err) {
+        this.warn(`reconcileOrphans: repo ${repoRoot} skipped`, err);
+      }
+    }
+  }
+}
+
+// ────────────────────────────── singleton ─────────────────────────────────
+//
+// Lazily initialised so main.ts can construct and install the sqlite-backed
+// storage before anyone asks for the manager. Commit B wires the init.
+
+let _instance: WorktreeManager | null = null;
+
+export function installWorktreeManager(instance: WorktreeManager): void {
+  _instance = instance;
+}
+
+export function getWorktreeManager(): WorktreeManager {
+  if (!_instance) {
+    throw new Error('WorktreeManager not installed — call installWorktreeManager() from main.ts');
+  }
+  return _instance;
+}
+
+/** Test-only — wipe the singleton between cases. */
+export function __resetWorktreeManagerForTests(): void {
+  _instance = null;
+}

--- a/electron/db.ts
+++ b/electron/db.ts
@@ -56,6 +56,17 @@ export function initDb(): Database.Database {
     );
     CREATE INDEX IF NOT EXISTS idx_endpoint_models_endpoint
       ON endpoint_models(endpoint_id);
+
+    CREATE TABLE IF NOT EXISTS worktrees (
+      sessionId TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      path TEXT NOT NULL UNIQUE,
+      baseRepo TEXT NOT NULL,
+      branch TEXT NOT NULL,
+      sourceBranch TEXT,
+      createdAt INTEGER NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_worktrees_baseRepo ON worktrees(baseRepo);
   `);
   migrateEndpointDiscoveryColumns(db);
   return db;
@@ -148,6 +159,17 @@ export function __setDbForTests(instance: Database.Database | null): void {
       );
       CREATE INDEX IF NOT EXISTS idx_endpoint_models_endpoint
         ON endpoint_models(endpoint_id);
+
+      CREATE TABLE IF NOT EXISTS worktrees (
+        sessionId TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        path TEXT NOT NULL UNIQUE,
+        baseRepo TEXT NOT NULL,
+        branch TEXT NOT NULL,
+        sourceBranch TEXT,
+        createdAt INTEGER NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_worktrees_baseRepo ON worktrees(baseRepo);
     `);
     migrateEndpointDiscoveryColumns(instance);
   }
@@ -195,4 +217,62 @@ export function saveClaudeBinPath(value: string | null): void {
     return;
   }
   saveState(CLAUDE_BIN_PATH_KEY, value);
+}
+
+// ───────────────────────────── worktrees ──────────────────────────────────
+//
+// Per-session git worktree records. Consumed by WorktreeManager via the
+// storage adapter wired up in electron/main.ts. Schema lives in `initDb`
+// above; these helpers are just the CRUD surface so the manager doesn't
+// hand out raw SQL strings.
+
+export interface WorktreeRow {
+  sessionId: string;
+  name: string;
+  path: string;
+  baseRepo: string;
+  branch: string;
+  sourceBranch: string | null;
+  createdAt: number;
+}
+
+export function saveWorktree(row: WorktreeRow): void {
+  initDb()
+    .prepare(
+      `INSERT INTO worktrees (sessionId, name, path, baseRepo, branch, sourceBranch, createdAt)
+       VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(sessionId) DO UPDATE SET
+         name = excluded.name,
+         path = excluded.path,
+         baseRepo = excluded.baseRepo,
+         branch = excluded.branch,
+         sourceBranch = excluded.sourceBranch,
+         createdAt = excluded.createdAt`
+    )
+    .run(
+      row.sessionId,
+      row.name,
+      row.path,
+      row.baseRepo,
+      row.branch,
+      row.sourceBranch,
+      row.createdAt
+    );
+}
+
+export function loadWorktree(sessionId: string): WorktreeRow | null {
+  const row = initDb()
+    .prepare('SELECT * FROM worktrees WHERE sessionId = ?')
+    .get(sessionId) as WorktreeRow | undefined;
+  return row ?? null;
+}
+
+export function deleteWorktree(sessionId: string): void {
+  initDb().prepare('DELETE FROM worktrees WHERE sessionId = ?').run(sessionId);
+}
+
+export function listWorktreesDb(): WorktreeRow[] {
+  return initDb()
+    .prepare('SELECT * FROM worktrees ORDER BY createdAt ASC')
+    .all() as WorktreeRow[];
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -2,7 +2,21 @@ import { app, BrowserWindow, Menu, Tray, nativeImage, ipcMain, safeStorage, dial
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import { initDb, loadState, saveState, loadMessages, saveMessages, closeDb, loadClaudeBinPath, saveClaudeBinPath } from './db';
+import {
+  initDb,
+  loadState,
+  saveState,
+  loadMessages,
+  saveMessages,
+  closeDb,
+  loadClaudeBinPath,
+  saveClaudeBinPath,
+  saveWorktree,
+  loadWorktree,
+  deleteWorktree,
+  listWorktreesDb,
+  type WorktreeRow,
+} from './db';
 import { sessions } from './agent/manager';
 import { installUpdaterIpc } from './updater';
 import { scanImportableSessions } from './import-scanner';
@@ -17,6 +31,17 @@ import {
   fetchPrChecks,
   type CreatePrArgs
 } from './pr';
+import {
+  WorktreeManager,
+  installWorktreeManager,
+  type WorktreeStorage,
+  type WorktreeRecord,
+} from './agent/worktree-manager';
+import {
+  resolveRepoRoot,
+  isGitRepo,
+  listBranches as gitListBranches,
+} from './agent/git-helpers';
 
 const KEYCHAIN_FILE = 'anthropic-key.bin';
 
@@ -220,6 +245,26 @@ app.whenReady().then(() => {
   }
   initDb();
 
+  // ── WorktreeManager ────────────────────────────────────────────────────
+  // Sqlite-backed storage adapter. Marshals between WorktreeRecord (manager
+  // surface, with `sourceBranch: string | null`) and WorktreeRow (db surface,
+  // identical shape) — they're isomorphic right now, but keeping the marshal
+  // in one place means the db schema can drift later (renames, extra cols)
+  // without rippling into the manager.
+  const worktreeStorage: WorktreeStorage = {
+    save: (rec: WorktreeRecord) => saveWorktree(rec satisfies WorktreeRow),
+    remove: (sessionId) => deleteWorktree(sessionId),
+    getBySession: (sessionId) => loadWorktree(sessionId),
+    listAll: () => listWorktreesDb(),
+  };
+  const worktreeManager = new WorktreeManager({ storage: worktreeStorage });
+  installWorktreeManager(worktreeManager);
+  // Best-effort orphan reconcile on boot. We don't await — a slow `git
+  // worktree list` shouldn't block the first window from opening.
+  void worktreeManager.reconcileOrphans().catch((err) => {
+    console.warn('[main] worktree reconcileOrphans failed', err);
+  });
+
   const cryptoAdapter: KeyCrypto = {
     isAvailable: () => safeStorage.isEncryptionAvailable(),
     encrypt: (plain) => safeStorage.encryptString(plain),
@@ -339,7 +384,7 @@ app.whenReady().then(() => {
 
   ipcMain.handle(
     'agent:start',
-    (
+    async (
       _e,
       sessionId: string,
       opts: {
@@ -350,6 +395,13 @@ app.whenReady().then(() => {
         endpointId?: string;
         allowedTools?: readonly string[];
         disallowedTools?: readonly string[];
+        // Worktree opt-in. When true, the spawner creates (or reuses) a
+        // disposable git worktree under the resolved repo root and runs
+        // claude.exe inside it. The renderer is informed of the resolved
+        // path via the `agent:worktreeReady` event so it can update its
+        // local Session record.
+        useWorktree?: boolean;
+        sourceBranch?: string;
       }
     ) => {
       const envOverrides = resolveSessionEndpointEnv(opts.endpointId);
@@ -358,7 +410,58 @@ app.whenReady().then(() => {
       // env). Per-endpoint keys always win.
       const apiKey = envOverrides?.ANTHROPIC_API_KEY ? undefined : readApiKey();
       const binaryPath = loadClaudeBinPath() ?? undefined;
-      return sessions.start(sessionId, { ...opts, apiKey, envOverrides, binaryPath });
+
+      // ── Worktree binding ─────────────────────────────────────────────
+      // If the session opted into a worktree, swap `cwd` for the worktree
+      // path BEFORE spawning. We surface a structured failure to the
+      // renderer instead of starting in the wrong dir; the user is told
+      // exactly which git step blew up.
+      let effectiveCwd = opts.cwd;
+      let worktreeInfo: { path: string; name: string; branch: string; sourceBranch: string | null } | null = null;
+      if (opts.useWorktree) {
+        try {
+          const repoRoot = await resolveRepoRoot(opts.cwd);
+          if (!repoRoot) {
+            return {
+              ok: false as const,
+              error: `Cannot create worktree: ${opts.cwd} is not inside a git repository.`,
+            };
+          }
+          const rec = await worktreeManager.create(sessionId, repoRoot, opts.sourceBranch);
+          effectiveCwd = rec.path;
+          worktreeInfo = {
+            path: rec.path,
+            name: rec.name,
+            branch: rec.branch,
+            sourceBranch: rec.sourceBranch,
+          };
+        } catch (err) {
+          return {
+            ok: false as const,
+            error: `Worktree create failed: ${err instanceof Error ? err.message : String(err)}`,
+          };
+        }
+      }
+
+      const result = await sessions.start(sessionId, {
+        ...opts,
+        cwd: effectiveCwd,
+        apiKey,
+        envOverrides,
+        binaryPath,
+      });
+
+      // Inform the renderer of the resolved worktree so it can persist the
+      // path/name/branch onto the Session. Only emitted on success — failure
+      // flows return early above and the renderer learns via the rejected
+      // start result.
+      if (result.ok && worktreeInfo) {
+        const win = BrowserWindow.fromWebContents(_e.sender);
+        if (win && !win.webContents.isDestroyed()) {
+          win.webContents.send('agent:worktreeReady', { sessionId, ...worktreeInfo });
+        }
+      }
+      return result;
     }
   );
   ipcMain.handle('agent:send', (_e, sessionId: string, text: string) =>
@@ -376,7 +479,37 @@ app.whenReady().then(() => {
   ipcMain.handle('agent:setModel', (_e, sessionId: string, model?: string) =>
     sessions.setModel(sessionId, model)
   );
-  ipcMain.handle('agent:close', (_e, sessionId: string) => sessions.close(sessionId));
+  ipcMain.handle('agent:close', async (_e, sessionId: string) => {
+    const closed = sessions.close(sessionId);
+    // Tear down the bound worktree, if any. We do this AFTER asking the
+    // session to close so the child process is no longer holding file
+    // handles inside the worktree on Windows. Errors are logged inside
+    // the manager — close() should never reject from the renderer's POV.
+    await worktreeManager.remove(sessionId).catch((err) => {
+      console.warn('[main] worktree remove failed', err);
+    });
+    return closed;
+  });
+
+  // ── Worktree IPC (read-only surface) ─────────────────────────────────
+  // create / remove are NOT exposed: they're driven by the session lifecycle
+  // (agent:start with useWorktree, agent:close). The renderer only needs
+  // to read branches for the new-session dialog and look up a session's
+  // current binding for status / display.
+  ipcMain.handle('worktree:listBranches', async (_e, repoRoot: string) => {
+    if (typeof repoRoot !== 'string' || repoRoot.length === 0) return [];
+    try {
+      if (!(await isGitRepo(repoRoot))) return [];
+      return await gitListBranches(repoRoot);
+    } catch (err) {
+      console.warn('[main] worktree:listBranches failed', err);
+      return [];
+    }
+  });
+  ipcMain.handle('worktree:getForSession', (_e, sessionId: string) => {
+    if (typeof sessionId !== 'string' || sessionId.length === 0) return null;
+    return worktreeManager.getBySession(sessionId);
+  });
   ipcMain.handle(
     'agent:resolvePermission',
     (_e, sessionId: string, requestId: string, decision: 'allow' | 'deny') =>

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -9,6 +9,30 @@ type StartOpts = {
   endpointId?: string;
   allowedTools?: readonly string[];
   disallowedTools?: readonly string[];
+  // Worktree opt-in. When true, the main process creates a disposable git
+  // worktree under the resolved repo root and runs claude.exe inside it;
+  // an `agent:worktreeReady` event lands shortly after with the resolved
+  // path/name/branch so the renderer can update its Session.
+  useWorktree?: boolean;
+  sourceBranch?: string;
+};
+
+type WorktreeReady = {
+  sessionId: string;
+  path: string;
+  name: string;
+  branch: string;
+  sourceBranch: string | null;
+};
+
+type WorktreeRecordIpc = {
+  sessionId: string;
+  name: string;
+  path: string;
+  baseRepo: string;
+  branch: string;
+  sourceBranch: string | null;
+  createdAt: number;
 };
 
 type StartResult =
@@ -299,6 +323,18 @@ const api = {
       ipcRenderer.invoke('cli:setBinaryPath', p),
     openDocs: (): Promise<boolean> => ipcRenderer.invoke('cli:openDocs'),
     retryDetect: (): Promise<CliRetryResult> => ipcRenderer.invoke('cli:retryDetect'),
+  },
+
+  worktree: {
+    listBranches: (repoRoot: string): Promise<string[]> =>
+      ipcRenderer.invoke('worktree:listBranches', repoRoot),
+    getForSession: (sessionId: string): Promise<WorktreeRecordIpc | null> =>
+      ipcRenderer.invoke('worktree:getForSession', sessionId),
+    onReady: (handler: (e: WorktreeReady) => void): (() => void) => {
+      const wrap = (_e: IpcRendererEvent, payload: WorktreeReady) => handler(payload);
+      ipcRenderer.on('agent:worktreeReady', wrap);
+      return () => ipcRenderer.removeListener('agent:worktreeReady', wrap);
+    },
   }
 };
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -12,6 +12,26 @@ type StartOpts = {
   endpointId?: string;
   allowedTools?: readonly string[];
   disallowedTools?: readonly string[];
+  useWorktree?: boolean;
+  sourceBranch?: string;
+};
+
+type WorktreeReadyDecl = {
+  sessionId: string;
+  path: string;
+  name: string;
+  branch: string;
+  sourceBranch: string | null;
+};
+
+type WorktreeRecordDecl = {
+  sessionId: string;
+  name: string;
+  path: string;
+  baseRepo: string;
+  branch: string;
+  sourceBranch: string | null;
+  createdAt: number;
 };
 
 type StartResult =
@@ -273,6 +293,12 @@ declare global {
         setBinaryPath: (p: string) => Promise<CliSetBinaryResultDecl>;
         openDocs: () => Promise<boolean>;
         retryDetect: () => Promise<CliRetryResultDecl>;
+      };
+
+      worktree: {
+        listBranches: (repoRoot: string) => Promise<string[]>;
+        getForSession: (sessionId: string) => Promise<WorktreeRecordDecl | null>;
+        onReady: (handler: (e: WorktreeReadyDecl) => void) => () => void;
       };
     };
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,16 @@ export interface Session {
   // passed to claude.exe via `--allowedTools` / `--disallowedTools`.
   // Omit to fall back to global rules untouched.
   permissionRules?: PermissionRules;
+  // ── Optional git-worktree binding ───────────────────────────────────────
+  // When `useWorktree` is true, the spawner asks WorktreeManager to create a
+  // disposable worktree for this session on first start, and tears it down
+  // on session close. The remaining fields are populated by the backend
+  // after creation; the renderer only sets `useWorktree` (and optionally
+  // `sourceBranch`) up front.
+  useWorktree?: boolean;
+  worktreePath?: string;
+  worktreeName?: string;
+  sourceBranch?: string;
 }
 
 // Fine-grained per-tool permission rules layered on top of `PermissionMode`.


### PR DESCRIPTION
## Summary

Backend + data-layer half of the disposable git-worktree feature (Claude Desktop clone). Each session can optionally bind 1:1 to a freshly-created worktree under `<repoRoot>/.claude/worktrees/<name>`; teardown cleans it up. UI and `/pr` integration land in sibling PRs.

### Commit A: git helpers + WorktreeManager core

- `electron/agent/git-helpers.ts` (new): `execFile`-based wrappers for `rev-parse`, `fetch`, `branch`, `worktree add/remove/list/prune`. Always `shell: false`, always passes `-c core.longpaths=true`, and disables LFS smudge on `worktree add` so creation stays sub-second on LFS-heavy repos. `fetchOrigin` is rate-limited to once per repoRoot per 5 minutes via an in-memory Map.
- `electron/agent/worktree-manager.ts` (new): singleton with injectable storage + git surface, so unit tests don't touch sqlite or shell out. Public surface is `create / remove / getBySession / reconcileOrphans / generateUniqueName`. Names are `<adj>-<noun>-<hex6>` from a small built-in dictionary. `create` rolls back the freshly-made worktree on storage failure; `remove` still drops the sqlite row even if `git worktree remove` fails so a stale entry never blocks teardown.
- `electron/agent/__tests__/worktree-manager.test.ts` (new): 18 tests covering name generator, path resolver, create idempotency + rollback, remove failure tolerance, reconcile orphan-drop with per-repo error isolation.

### Commit B: schema + spawner wiring + renderer IPC

- `electron/db.ts`: adds `worktrees` table (sessionId PK, path UNIQUE, baseRepo index) plus CRUD helpers, mirrored in `__setDbForTests`.
- `electron/main.ts`: constructs the manager with a sqlite-backed storage adapter, installs the singleton, fires `reconcileOrphans()` best-effort on boot. `agent:start` now accepts `useWorktree` + `sourceBranch`; on opt-in it resolves the repo root, creates a worktree, swaps the spawn cwd for the worktree path, and emits `agent:worktreeReady` so the renderer can persist the resolved name/path/branch. `agent:close` removes the bound worktree after the child has been signalled. Adds read-only IPC `worktree:listBranches` + `worktree:getForSession`. `create` / `remove` deliberately not exposed — they're lifecycle-driven.
- `electron/preload.ts` + `src/global.d.ts`: mirrors the new fields, exposes `window.agentory.worktree.{ listBranches, getForSession, onReady }`.
- `src/types.ts`: extends `Session` with optional `useWorktree`, `worktreePath`, `worktreeName`, `sourceBranch`. All optional → existing persisted sessions deserialize unchanged.

### Out of scope (other PRs / post-MVP)

- UI (sibling subagent)
- `/pr` integration (sibling subagent)
- Custom parent-dir / settings UI
- Sparse / deferred checkout, remote SSH worktrees, "Open in VS Code" menu
- Submodule special-casing, workspace config override

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (only pre-existing CommandPalette warning)
- [x] `npm test` 490/490 pass (incl. 18 new worktree-manager tests)
- [ ] Manual: launch app on a real repo, confirm reconcile boot path doesn't crash with empty `worktrees` table
- [ ] Manual: opt a session into `useWorktree`, confirm `.claude/worktrees/<name>/` appears, claude.exe runs there, and closing the session removes the dir
- [ ] Manual: hand-delete a worktree dir then reboot the app, confirm `reconcileOrphans` drops the orphaned sqlite row
- [ ] Manual: `worktree:listBranches` returns expected local + `origin/*` for a known repo