### PR TITLE
feat(ipc): shell:openPath for Reveal in Explorer/Finder

### DIFF
--- a/electron/__tests__/shell-open.test.ts
+++ b/electron/__tests__/shell-open.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest';
+import * as path from 'path';
+import * as os from 'os';
+import { openPathSafe, type ShellLike } from '../shell-open';
+
+function makeShell(returnValue = '') {
+  const openPath = vi.fn(async (_p: string) => returnValue);
+  const shell: ShellLike = { openPath };
+  return { shell, openPath };
+}
+
+const okFs = { access: async (_: string) => undefined };
+const missingFs = {
+  access: async (_: string) => {
+    throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+  },
+};
+
+describe('openPathSafe', () => {
+  it('rejects non-string input as invalid_path', async () => {
+    const { shell, openPath } = makeShell();
+    expect(await openPathSafe(undefined, shell, okFs)).toEqual({
+      ok: false,
+      error: 'invalid_path',
+    });
+    expect(await openPathSafe(null, shell, okFs)).toEqual({
+      ok: false,
+      error: 'invalid_path',
+    });
+    expect(await openPathSafe(42, shell, okFs)).toEqual({
+      ok: false,
+      error: 'invalid_path',
+    });
+    expect(openPath).not.toHaveBeenCalled();
+  });
+
+  it('rejects empty string as invalid_path', async () => {
+    const { shell, openPath } = makeShell();
+    expect(await openPathSafe('', shell, okFs)).toEqual({
+      ok: false,
+      error: 'invalid_path',
+    });
+    expect(openPath).not.toHaveBeenCalled();
+  });
+
+  it('rejects relative paths as invalid_path', async () => {
+    const { shell, openPath } = makeShell();
+    expect(await openPathSafe('foo/bar', shell, okFs)).toEqual({
+      ok: false,
+      error: 'invalid_path',
+    });
+    expect(await openPathSafe('./repo', shell, okFs)).toEqual({
+      ok: false,
+      error: 'invalid_path',
+    });
+    expect(openPath).not.toHaveBeenCalled();
+  });
+
+  it('returns not_found when the path does not exist', async () => {
+    const { shell, openPath } = makeShell();
+    const abs = path.join(os.tmpdir(), 'agentory-openpath-missing-' + Date.now());
+    expect(await openPathSafe(abs, shell, missingFs)).toEqual({
+      ok: false,
+      error: 'not_found',
+    });
+    expect(openPath).not.toHaveBeenCalled();
+  });
+
+  it('returns ok on a successful shell.openPath call', async () => {
+    const { shell, openPath } = makeShell('');
+    const abs = path.join(os.tmpdir(), 'agentory-openpath-ok');
+    const res = await openPathSafe(abs, shell, okFs);
+    expect(res).toEqual({ ok: true });
+    expect(openPath).toHaveBeenCalledWith(abs);
+  });
+
+  it('surfaces shell.openPath error string as open_failed/detail', async () => {
+    const { shell } = makeShell('Failed to open');
+    const abs = path.join(os.tmpdir(), 'agentory-openpath-fail');
+    const res = await openPathSafe(abs, shell, okFs);
+    expect(res).toEqual({
+      ok: false,
+      error: 'open_failed',
+      detail: 'Failed to open',
+    });
+  });
+});

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -25,6 +25,7 @@ import type { PermissionMode } from './agent/sessions';
 import { EndpointsManager, type KeyCrypto } from './endpoints-manager';
 import { ClaudeNotFoundError, detectClaudeVersion, resolveClaudeBinary } from './agent/binary-resolver';
 import { readMemoryFile, writeMemoryFile, memoryFileExists } from './memory';
+import { openPathSafe } from './shell-open';
 import {
   runPreflight,
   createPr,
@@ -542,6 +543,12 @@ app.whenReady().then(() => {
       return false;
     }
   });
+  // Reveal a directory (or file) in the OS file manager — Explorer on
+  // Windows, Finder on macOS, the user's default file manager on Linux.
+  // Backs the Sidebar context menu's "Reveal in Finder / Open in Explorer".
+  // Validation lives in `openPathSafe` so it can be unit-tested without
+  // pulling Electron in.
+  ipcMain.handle('shell:openPath', (_e, p: unknown) => openPathSafe(p, shell));
   // ──────────────────────────── end /pr flow ───────────────────────────────
 
   // ───────────────────────────── CLI wizard ────────────────────────────────

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -124,6 +124,10 @@ type CliSetBinaryResult =
   | { ok: true; version: string | null }
   | { ok: false; error: string };
 
+type OpenPathResult =
+  | { ok: true }
+  | { ok: false; error: 'invalid_path' | 'not_found' | 'open_failed'; detail?: string };
+
 const api = {
   loadState: (key: string): Promise<string | null> => ipcRenderer.invoke('db:load', key),
   saveState: (key: string, value: string): Promise<void> =>
@@ -214,6 +218,14 @@ const api = {
 
   openExternal: (url: string): Promise<boolean> =>
     ipcRenderer.invoke('shell:openExternal', url),
+
+  /**
+   * Reveal a path in the OS file manager (Explorer on Windows, Finder on
+   * macOS, the user's default file manager on Linux). Path must be
+   * absolute and exist on disk; otherwise resolves with a structured error.
+   */
+  openPath: (p: string): Promise<OpenPathResult> =>
+    ipcRenderer.invoke('shell:openPath', p),
 
   notify: (payload: {
     sessionId: string;

--- a/electron/shell-open.ts
+++ b/electron/shell-open.ts
@@ -1,0 +1,54 @@
+import * as path from 'path';
+import { promises as fsp } from 'fs';
+
+/**
+ * Result of an `openPath` IPC call. Mirrors the discriminated-union shape
+ * the rest of the codebase uses (memory:*, pr:*, etc.) so the renderer
+ * can branch on `ok` without sniffing strings.
+ */
+export type OpenPathResult =
+  | { ok: true }
+  | { ok: false; error: 'invalid_path' | 'not_found' | 'open_failed'; detail?: string };
+
+/**
+ * Minimal slice of Electron's `shell` we depend on. Declared so unit tests
+ * can pass a stub without dragging the real `electron` runtime in.
+ *
+ * `shell.openPath` returns an empty string on success and an error message
+ * on failure (Electron's quirk — not a thrown error).
+ */
+export interface ShellLike {
+  openPath(p: string): Promise<string>;
+}
+
+/**
+ * Pure, testable core of the `shell:openPath` IPC handler.
+ *
+ * Security boundary:
+ *   - Reject any non-string / empty input.
+ *   - Reject relative paths — we never want to resolve against the main
+ *     process's cwd, which is undefined from the renderer's POV.
+ *   - Reject paths that don't exist on disk. `shell.openPath` would
+ *     otherwise silently no-op or open the OS's "file not found" dialog,
+ *     both of which are worse than a structured error.
+ *
+ * On success the OS file manager opens with the target revealed
+ * (Explorer / Finder / GNOME Files / etc.).
+ */
+export async function openPathSafe(
+  rawPath: unknown,
+  shell: ShellLike,
+  fs: { access: (p: string) => Promise<void> } = { access: fsp.access }
+): Promise<OpenPathResult> {
+  if (typeof rawPath !== 'string' || rawPath.length === 0 || !path.isAbsolute(rawPath)) {
+    return { ok: false, error: 'invalid_path' };
+  }
+  try {
+    await fs.access(rawPath);
+  } catch {
+    return { ok: false, error: 'not_found' };
+  }
+  const err = await shell.openPath(rawPath);
+  if (err) return { ok: false, error: 'open_failed', detail: err };
+  return { ok: true };
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -385,11 +385,11 @@ function SessionRow({ session, active, selected, onSelect }: { session: Session;
       <ContextMenuContent>
         <ContextMenuItem onSelect={() => setRenaming(true)}>Rename</ContextMenuItem>
         <ContextMenuItem
-          disabled={!window.agentory?.openPath || !(session.worktreePath || session.cwd)}
+          disabled={!(session.worktreePath || session.cwd)}
           onSelect={() => {
             const path = session.worktreePath || session.cwd;
             if (!path) return;
-            void window.agentory?.openPath?.(path);
+            void window.agentory?.openPath(path);
           }}
         >
           <FolderOpen size={12} className="stroke-[1.75] mr-2 text-fg-tertiary" />

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -120,6 +120,10 @@ type CliSetBinaryResultDecl =
   | { ok: true; version: string | null }
   | { ok: false; error: string };
 
+type OpenPathResultDecl =
+  | { ok: true }
+  | { ok: false; error: 'invalid_path' | 'not_found' | 'open_failed'; detail?: string };
+
 type PrPreflightErrorDecl = {
   code: 'no-cwd' | 'not-git' | 'no-gh' | 'on-default-branch' | 'dirty-tree' | 'no-commits';
   detail: string;
@@ -302,11 +306,12 @@ declare global {
       };
 
       /**
-       * Reveal a filesystem path in the OS file manager (Explorer / Finder /
-       * Nautilus). Optional — main process has not wired this handler yet;
-       * tracked as a follow-up to feat/worktree-core. Callers MUST null-check.
+       * Reveal a filesystem path in the OS file manager (Explorer on Windows,
+       * Finder on macOS, the user's default file manager on Linux). Path must
+       * be absolute and exist on disk; otherwise resolves with a structured
+       * error. Backed by `shell:openPath` IPC in the main process.
        */
-      openPath?: (path: string) => Promise<{ ok: true } | { ok: false; error: string }>;
+      openPath: (path: string) => Promise<OpenPathResultDecl>;
     };
   }
 }


### PR DESCRIPTION
## Summary

Wires `window.agentory.openPath(path)` end-to-end so the Sidebar context
menu's "Reveal in Finder / Open in Explorer" actually works. The renderer
was already calling it with optional chaining because the main-process
handler hadn't been implemented yet — left as a follow-up to the
worktree-ui PR (#92).

- `electron/shell-open.ts` — pure `openPathSafe(path, shell)` helper.
  Validates input (non-string / empty / relative rejected), `fs.access`
  checks the target exists, then delegates to `shell.openPath`. Normalizes
  Electron's empty-string-on-success quirk into a discriminated union:
  `{ ok: true } | { ok: false; error: 'invalid_path' | 'not_found' | 'open_failed'; detail? }`.
- `electron/main.ts` — registers `ipcMain.handle('shell:openPath', ...)`
  next to the existing `shell:openExternal` handler.
- `electron/preload.ts` — exposes `openPath` on `window.agentory` with the
  typed result.
- `src/global.d.ts` — drops the `?` on `openPath` (it's now mandatory),
  switches to the structured result type, refreshes the doc comment.
- `src/components/Sidebar.tsx` — removes the `!window.agentory?.openPath`
  guard from the context-menu `disabled` condition and drops `?.` at the
  call site.

Refs #92.

## Test plan

- [x] `npm test -- shell-open` — 6/6 pass; covers `invalid_path` (non-string,
      empty, relative), `not_found` (`fs.access` throws), success, and
      `open_failed` (shell returns an error string).
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — no new errors introduced (pre-existing errors all
      live under `.claude/worktrees/**`, untouched here).
- [x] Full `npm test` — only pre-existing failures remain
      (`session-create-dialog.test.tsx`), none caused by this PR.
- [ ] Manual: right-click a session in the Sidebar -> "Open in Explorer"
      (Win) / "Reveal in Finder" (mac) / "Open in Files" (Linux) opens the
      OS file manager at the session's `worktreePath` or `cwd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)