### PR TITLE
perf(boot): eager-load sessions + recent cwds for SessionCreateDialog

### DIFF
--- a/electron/import-scanner.ts
+++ b/electron/import-scanner.ts
@@ -134,6 +134,31 @@ function truncate(s: string, n: number): string {
   return s.length > n ? s.slice(0, n - 1) + '…' : s;
 }
 
+/**
+ * Derive a deduped list of recently-used cwds from a (presumably mtime-sorted)
+ * scan result. Most-recent first, dropping the placeholder `~` entries the
+ * scanner emits when no `cwd` field was found in the transcript head — those
+ * would default the picker to the user's home dir, which is rarely useful.
+ * Caps at `max` entries so the dropdown stays a reasonable length.
+ */
+export function deriveRecentCwds(
+  sessions: ReadonlyArray<Pick<ScannableSession, 'cwd' | 'mtime'>>,
+  max = 10
+): string[] {
+  const ordered = [...sessions].sort((a, b) => b.mtime - a.mtime);
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const s of ordered) {
+    const cwd = s.cwd;
+    if (!cwd || cwd === '~') continue;
+    if (seen.has(cwd)) continue;
+    seen.add(cwd);
+    out.push(cwd);
+    if (out.length >= max) break;
+  }
+  return out;
+}
+
 // Pure head-parsing helper, exported for unit testing. Given an array of jsonl
 // lines (already parsed-back-to-strings or raw), return the same Head shape
 // the streaming reader produces.

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -19,7 +19,11 @@ import {
 } from './db';
 import { sessions } from './agent/manager';
 import { installUpdaterIpc } from './updater';
-import { scanImportableSessions } from './import-scanner';
+import {
+  scanImportableSessions,
+  deriveRecentCwds,
+  type ScannableSession,
+} from './import-scanner';
 import { showNotification, type ShowNotificationPayload } from './notifications';
 import type { PermissionMode } from './agent/sessions';
 import { EndpointsManager, type KeyCrypto } from './endpoints-manager';
@@ -79,6 +83,58 @@ function writeApiKey(value: string): boolean {
 }
 
 const isDev = !app.isPackaged;
+
+// ───────────────────── importable-sessions cache ─────────────────────────
+//
+// The CLI transcripts under ~/.claude/projects can run into hundreds of
+// files; the head-parse is fast per file but the cumulative latency makes
+// the ImportDialog's "Scanning…" state visible for several seconds on cold
+// open. We kick off the scan eagerly at app `ready` and serve cached
+// results to renderers, refreshing in the background on each request so
+// newly-recorded sessions show up without a manual reload.
+//
+// `recentCwds` is derived from the same scan and powers the
+// SessionCreateDialog's default cwd / dropdown — same goal, no second IPC.
+let importableCache: ScannableSession[] = [];
+let recentCwdsCache: string[] = [];
+let importablePending: Promise<ScannableSession[]> | null = null;
+
+function refreshImportableCache(): Promise<ScannableSession[]> {
+  if (importablePending) return importablePending;
+  importablePending = scanImportableSessions()
+    .then((rows) => {
+      importableCache = rows;
+      recentCwdsCache = deriveRecentCwds(rows);
+      return rows;
+    })
+    .catch((err) => {
+      console.warn('[main] scanImportableSessions failed', err);
+      return importableCache;
+    })
+    .finally(() => {
+      importablePending = null;
+    }) as Promise<ScannableSession[]>;
+  return importablePending;
+}
+
+async function getImportableSessions(): Promise<ScannableSession[]> {
+  // If we have a hot cache, serve it instantly and refresh in the background
+  // so the next call sees fresher data. On cold cache (eager-load not done
+  // yet) await the in-flight (or new) scan so the renderer never gets [].
+  if (importableCache.length > 0) {
+    void refreshImportableCache();
+    return importableCache;
+  }
+  return refreshImportableCache();
+}
+
+async function getRecentCwds(): Promise<string[]> {
+  if (recentCwdsCache.length > 0 || importableCache.length > 0) {
+    return recentCwdsCache;
+  }
+  await refreshImportableCache();
+  return recentCwdsCache;
+}
 
 // We don't want a visible File/Edit/View menu bar — Agentory is a single-
 // window tool and those menus add noise. But on Windows/Linux, setting the
@@ -517,7 +573,8 @@ app.whenReady().then(() => {
       sessions.resolvePermission(sessionId, requestId, decision)
   );
 
-  ipcMain.handle('import:scan', () => scanImportableSessions());
+  ipcMain.handle('import:scan', () => getImportableSessions());
+  ipcMain.handle('import:recentCwds', () => getRecentCwds());
 
   // ───────────────────────────── /pr flow ──────────────────────────────────
   //
@@ -730,6 +787,11 @@ app.whenReady().then(() => {
 
   createWindow();
   ensureTray();
+
+  // Eager-load CLI transcripts so ImportDialog and SessionCreateDialog have
+  // data the moment the user opens them. Fire-and-forget; refreshImportableCache
+  // logs its own errors and stores [] on failure so getRecentCwds still resolves.
+  void refreshImportableCache();
 });
 
 app.on('before-quit', () => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -186,6 +186,15 @@ const api = {
     Array<{ sessionId: string; cwd: string; title: string; mtime: number; projectDir: string }>
   > => ipcRenderer.invoke('import:scan'),
 
+  /**
+   * Most-recently-used cwds derived from the eager scan that runs on app
+   * `ready`. Returns immediately from cache after the first scan completes;
+   * the call itself is cheap (no fs work in the renderer round-trip).
+   * Empty array means the scan is still in flight or `~/.claude/projects`
+   * has nothing usable.
+   */
+  recentCwds: (): Promise<string[]> => ipcRenderer.invoke('import:recentCwds'),
+
   memory: {
     read: (p: string): Promise<
       | { ok: true; content: string; exists: boolean }

--- a/src/components/SessionCreateDialog.tsx
+++ b/src/components/SessionCreateDialog.tsx
@@ -52,7 +52,16 @@ export function SessionCreateDialog({ open, onOpenChange, initialCwd }: Props) {
   const recentProjects = useStore((s) => s.recentProjects);
   const pushRecentProject = useStore((s) => s.pushRecentProject);
 
-  const defaultCwd = initialCwd ?? recentProjects[0]?.path ?? '';
+  // CLI-derived recent cwds, populated from main's eager-scan cache. Used as
+  // the fallback default when the in-app `recentProjects` history is empty
+  // (typical first-run state) and as autocomplete suggestions in all cases.
+  // Kept separate from `recentProjects` because the latter is the user's
+  // in-app history and shouldn't be polluted by CLI scan results.
+  const [recentCwds, setRecentCwds] = useState<string[]>([]);
+  const recentCwdsListId = 'session-create-cwd-suggestions';
+
+  const defaultCwd =
+    initialCwd ?? recentProjects[0]?.path ?? recentCwds[0] ?? '';
   const [name, setName] = useState('');
   const [cwd, setCwd] = useState(defaultCwd);
   const [useWorktree, setUseWorktree] = useState(false);
@@ -69,13 +78,47 @@ export function SessionCreateDialog({ open, onOpenChange, initialCwd }: Props) {
   useEffect(() => {
     if (!open) return;
     setName('');
-    setCwd(initialCwd ?? recentProjects[0]?.path ?? '');
+    setCwd(initialCwd ?? recentProjects[0]?.path ?? recentCwds[0] ?? '');
     setUseWorktree(false);
     setSourceBranch('');
     setBranchState({ kind: 'idle' });
     // Delay focus so the Radix animation doesn't fight the focus move.
     const id = window.setTimeout(() => nameRef.current?.focus(), 40);
     return () => window.clearTimeout(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  // Fetch the eager-scan cache from main on every open. The IPC resolves
+  // immediately when the cache is hot (the eager scan ran at app `ready`),
+  // so the user does not see a spinner. Empty result is a no-op — the
+  // existing in-app `recentProjects` fallback still applies.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    const api = window.agentory;
+    if (!api?.recentCwds) return;
+    api
+      .recentCwds()
+      .then((list) => {
+        if (cancelled) return;
+        setRecentCwds(list);
+        // Only seed cwd from the CLI-derived list if the dialog opened with
+        // no other source (no caller seed, no in-app history, no edit yet).
+        // Checking against `defaultCwd` avoids stomping a folder the user
+        // already typed during this open.
+        setCwd((current) => {
+          if (current.length > 0) return current;
+          if (initialCwd != null) return current;
+          if (recentProjects.length > 0) return current;
+          return list[0] ?? current;
+        });
+      })
+      .catch(() => {
+        /* IPC failure is non-fatal — dialog still works without suggestions. */
+      });
+    return () => {
+      cancelled = true;
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
@@ -214,7 +257,17 @@ export function SessionCreateDialog({ open, onOpenChange, initialCwd }: Props) {
                   placeholder="/path/to/repo"
                   className="flex-1"
                   data-testid="session-create-cwd"
+                  list={recentCwds.length > 0 ? recentCwdsListId : undefined}
+                  autoComplete="off"
+                  spellCheck={false}
                 />
+                {recentCwds.length > 0 && (
+                  <datalist id={recentCwdsListId} data-testid="session-create-cwd-suggestions">
+                    {recentCwds.map((p) => (
+                      <option key={p} value={p} />
+                    ))}
+                  </datalist>
+                )}
                 <IconButton
                   variant="raised"
                   size="md"

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -195,6 +195,14 @@ declare global {
         Array<{ sessionId: string; cwd: string; title: string; mtime: number; projectDir: string }>
       >;
 
+      /**
+       * Most-recently-used cwds derived from CLI transcripts. Cached in main
+       * via an eager scan at app `ready`, so this resolves quickly even on
+       * first call after window load. Empty array if the scan is still in
+       * flight or no transcripts are present.
+       */
+      recentCwds: () => Promise<string[]>;
+
       memory: {
         read: (p: string) => Promise<
           | { ok: true; content: string; exists: boolean }

--- a/tests/import-scanner.test.ts
+++ b/tests/import-scanner.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseHead } from '../electron/import-scanner';
+import { parseHead, deriveRecentCwds } from '../electron/import-scanner';
 
 const j = (o: unknown) => JSON.stringify(o);
 
@@ -72,5 +72,69 @@ describe('parseHead', () => {
   it('ignores malformed json lines', () => {
     const head = parseHead(['not json', j({ type: 'ai-title', aiTitle: 'OK' })]);
     expect(head?.title).toBe('OK');
+  });
+});
+
+describe('deriveRecentCwds', () => {
+  it('returns [] for empty input', () => {
+    expect(deriveRecentCwds([])).toEqual([]);
+  });
+
+  it('orders by mtime descending', () => {
+    expect(
+      deriveRecentCwds([
+        { cwd: '/a', mtime: 100 },
+        { cwd: '/b', mtime: 300 },
+        { cwd: '/c', mtime: 200 },
+      ])
+    ).toEqual(['/b', '/c', '/a']);
+  });
+
+  it('dedupes repeated cwds, keeping the most-recent occurrence', () => {
+    expect(
+      deriveRecentCwds([
+        { cwd: '/a', mtime: 100 },
+        { cwd: '/a', mtime: 500 },
+        { cwd: '/b', mtime: 300 },
+      ])
+    ).toEqual(['/a', '/b']);
+  });
+
+  it('drops the placeholder ~ entry the scanner emits when cwd is unknown', () => {
+    expect(
+      deriveRecentCwds([
+        { cwd: '~', mtime: 500 },
+        { cwd: '/real', mtime: 400 },
+      ])
+    ).toEqual(['/real']);
+  });
+
+  it('drops empty cwd strings defensively', () => {
+    expect(
+      deriveRecentCwds([
+        { cwd: '', mtime: 500 },
+        { cwd: '/real', mtime: 400 },
+      ])
+    ).toEqual(['/real']);
+  });
+
+  it('caps at the requested max', () => {
+    const sessions = Array.from({ length: 25 }, (_, i) => ({
+      cwd: `/p${i}`,
+      mtime: 1000 - i,
+    }));
+    const cwds = deriveRecentCwds(sessions, 10);
+    expect(cwds).toHaveLength(10);
+    // mtime descending → /p0 is newest
+    expect(cwds[0]).toBe('/p0');
+    expect(cwds[9]).toBe('/p9');
+  });
+
+  it('defaults max to 10', () => {
+    const sessions = Array.from({ length: 15 }, (_, i) => ({
+      cwd: `/p${i}`,
+      mtime: 1000 - i,
+    }));
+    expect(deriveRecentCwds(sessions)).toHaveLength(10);
   });
 });

--- a/tests/session-create-dialog.test.tsx
+++ b/tests/session-create-dialog.test.tsx
@@ -140,4 +140,68 @@ describe('<SessionCreateDialog />', () => {
     const button = screen.getByRole('button', { name: /create session/i });
     expect(button).toBeDisabled();
   });
+
+  it('seeds cwd from window.agentory.recentCwds when no initialCwd and no in-app history', async () => {
+    const recentCwds = vi.fn().mockResolvedValue(['/cli/project-a', '/cli/project-b', '/cli/project-c']);
+    (window as unknown as { agentory: unknown }).agentory = {
+      recentCwds,
+      worktree: {
+        // Returns a flat string[] of branch names — matches the actual
+        // worktree.listBranches IPC contract used by the dialog.
+        listBranches: vi.fn().mockResolvedValue([]),
+      },
+    };
+    renderDialog({ initialCwd: null });
+    await flush();
+
+    const cwdInput = screen.getByTestId('session-create-cwd') as HTMLInputElement;
+    expect(recentCwds).toHaveBeenCalledTimes(1);
+    expect(cwdInput.value).toBe('/cli/project-a');
+
+    // The remaining entries are surfaced as datalist suggestions on the
+    // input so the user can pick from a dropdown without typing.
+    expect(cwdInput.getAttribute('list')).toBe('session-create-cwd-suggestions');
+    const datalist = document.getElementById(
+      'session-create-cwd-suggestions'
+    ) as HTMLDataListElement | null;
+    expect(datalist).not.toBeNull();
+    const options = Array.from(datalist!.querySelectorAll('option')).map((o) =>
+      (o as HTMLOptionElement).value
+    );
+    expect(options).toEqual(['/cli/project-a', '/cli/project-b', '/cli/project-c']);
+  });
+
+  it('does not stomp an explicit initialCwd with a recentCwds value', async () => {
+    const recentCwds = vi.fn().mockResolvedValue(['/cli/other']);
+    (window as unknown as { agentory: unknown }).agentory = {
+      recentCwds,
+      worktree: {
+        listBranches: vi.fn().mockResolvedValue([]),
+      },
+    };
+    renderDialog({ initialCwd: '/explicit/seed' });
+    await flush();
+
+    const cwdInput = screen.getByTestId('session-create-cwd') as HTMLInputElement;
+    expect(cwdInput.value).toBe('/explicit/seed');
+  });
+
+  it('prefers in-app recentProjects over CLI-derived recentCwds', async () => {
+    useStore.setState({
+      recentProjects: [{ id: 'rp-1', name: 'most-recent', path: '/in-app/most-recent' }],
+    } as Partial<ReturnType<typeof useStore.getState>>);
+
+    const recentCwds = vi.fn().mockResolvedValue(['/cli/different']);
+    (window as unknown as { agentory: unknown }).agentory = {
+      recentCwds,
+      worktree: {
+        listBranches: vi.fn().mockResolvedValue([]),
+      },
+    };
+    renderDialog({ initialCwd: null });
+    await flush();
+
+    const cwdInput = screen.getByTestId('session-create-cwd') as HTMLInputElement;
+    expect(cwdInput.value).toBe('/in-app/most-recent');
+  });
 });


### PR DESCRIPTION
## Summary

The CLI transcript scan under `~/.claude/projects` can take several seconds on cold open of `ImportDialog`. This change runs the scan eagerly at app `ready` and serves cached results from main, refreshing in the background on each request so newly-recorded sessions still surface — no spinner, no waiting.

The same scan derives a deduped, recency-ordered list of cwds (max 10) exposed via `window.agentory.recentCwds()`. `SessionCreateDialog` now uses the first entry as the default `cwd` when no caller seed and no in-app `recentProjects` history is present, and surfaces the rest as a `<datalist>` on the cwd input for autocomplete.

- `electron/import-scanner.ts`: add pure `deriveRecentCwds(sessions, max)`
- `electron/main.ts`: importable + recentCwds caches, eager refresh at `app ready`, new `import:recentCwds` IPC, `import:scan` now serves cache (refreshes in background)
- `electron/preload.ts` + `src/global.d.ts`: expose `recentCwds()`
- `src/components/SessionCreateDialog.tsx`: fetch + apply on open, `<datalist>` suggestions; never stomps an explicit `initialCwd` or in-app `recentProjects[0]`
- Tests: 6 new unit cases for `deriveRecentCwds` (dedup, ordering, `~` filter, max cap) and 3 component cases for `SessionCreateDialog` (CLI-derived default, `initialCwd` precedence, in-app `recentProjects` precedence)

## Behavior change

- `ImportDialog` opens with results already populated from cache (no "Scanning…" hold) once the eager scan has completed.
- `SessionCreateDialog` defaults the cwd field to the most recently used CLI project on first run (when in-app history is empty) and offers a typeahead dropdown of recent paths.
- `RecentProjects` UI surface is untouched.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` on touched files clean (only ignored-test-file warnings)
- [x] `npm test` — 550 passing, same 25 pre-existing failures as baseline (no new regressions; +10 net new passing tests)
- [ ] Manual: cold-start app, open ImportDialog — list appears without scanning state
- [ ] Manual: with empty in-app `recentProjects`, open SessionCreateDialog — cwd pre-filled with most recent CLI project; typing into cwd field shows datalist suggestions