### PR TITLE
feat(discovery): hardcode Claude Code CLI model picker list (sonnet/opus/haiku + 1M variants + legacy)

### DIFF
--- a/electron/agent/__tests__/cli-picker-models.test.ts
+++ b/electron/agent/__tests__/cli-picker-models.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CLI_PICKER_MODELS,
+  getCustomEnvOverrides,
+  type CliPickerModel,
+} from '../cli-picker-models';
+
+describe('CLI_PICKER_MODELS', () => {
+  it('contains at least the 7 picker entries from claude.exe v2.1.114', () => {
+    expect(CLI_PICKER_MODELS.length).toBeGreaterThanOrEqual(7);
+  });
+
+  it('exposes the canonical alias entries', () => {
+    const ids = CLI_PICKER_MODELS.map((m) => m.id);
+    for (const id of [
+      'sonnet',
+      'opus',
+      'haiku',
+      'sonnet[1m]',
+      'opus[1m]',
+      'claude-opus-4-6[1m]',
+      'claude-opus-4-1',
+    ]) {
+      expect(ids).toContain(id);
+    }
+  });
+
+  it('every entry has non-empty id, label, description (shape check)', () => {
+    for (const m of CLI_PICKER_MODELS) {
+      expect(typeof m.id).toBe('string');
+      expect(m.id.trim().length).toBeGreaterThan(0);
+      expect(typeof m.label).toBe('string');
+      expect(m.label.trim().length).toBeGreaterThan(0);
+      expect(typeof m.description).toBe('string');
+      expect(m.description.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it('is readonly at runtime — entries cannot be mutated', () => {
+    const first = CLI_PICKER_MODELS[0] as CliPickerModel;
+    expect(() => {
+      // Bypass TS to verify runtime freeze
+      (first as unknown as Record<string, string>).id = 'mutated';
+    }).toThrow(TypeError);
+    expect(CLI_PICKER_MODELS[0].id).not.toBe('mutated');
+  });
+
+  it('the array itself is frozen (cannot push)', () => {
+    expect(() => {
+      (CLI_PICKER_MODELS as unknown as CliPickerModel[]).push({
+        id: 'x',
+        label: 'x',
+        description: 'x',
+      });
+    }).toThrow(TypeError);
+  });
+});
+
+describe('getCustomEnvOverrides', () => {
+  it('returns empty array when no tier env vars are set', () => {
+    expect(getCustomEnvOverrides({})).toEqual([]);
+  });
+
+  it('emits a single Sonnet override when only ANTHROPIC_DEFAULT_SONNET_MODEL is set', () => {
+    const out = getCustomEnvOverrides({
+      ANTHROPIC_DEFAULT_SONNET_MODEL: 'my-sonnet-id',
+    });
+    expect(out).toEqual([
+      { id: 'my-sonnet-id', label: 'Custom Sonnet model', description: '' },
+    ]);
+  });
+
+  it('emits all three when all tier vars are set, in Sonnet/Opus/Haiku order', () => {
+    const out = getCustomEnvOverrides({
+      ANTHROPIC_DEFAULT_SONNET_MODEL: 's',
+      ANTHROPIC_DEFAULT_OPUS_MODEL: 'o',
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: 'h',
+    });
+    expect(out.map((m) => m.id)).toEqual(['s', 'o', 'h']);
+    expect(out[0].label).toBe('Custom Sonnet model');
+    expect(out[1].label).toBe('Custom Opus model');
+    expect(out[2].label).toBe('Custom Haiku model');
+  });
+
+  it('honours optional NAME and DESCRIPTION companion vars', () => {
+    const out = getCustomEnvOverrides({
+      ANTHROPIC_DEFAULT_OPUS_MODEL: 'opus-id',
+      ANTHROPIC_DEFAULT_OPUS_MODEL_NAME: 'My Opus',
+      ANTHROPIC_DEFAULT_OPUS_MODEL_DESCRIPTION: 'Tuned for code',
+    });
+    expect(out).toEqual([
+      { id: 'opus-id', label: 'My Opus', description: 'Tuned for code' },
+    ]);
+  });
+
+  it('treats whitespace-only tier values as unset', () => {
+    expect(
+      getCustomEnvOverrides({
+        ANTHROPIC_DEFAULT_SONNET_MODEL: '   ',
+      }),
+    ).toEqual([]);
+  });
+
+  it('falls back to default label when only DESCRIPTION companion is set', () => {
+    const out = getCustomEnvOverrides({
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: 'h',
+      ANTHROPIC_DEFAULT_HAIKU_MODEL_DESCRIPTION: 'fast',
+    });
+    expect(out).toEqual([
+      { id: 'h', label: 'Custom Haiku model', description: 'fast' },
+    ]);
+  });
+
+  it('trims id / label / description values', () => {
+    const out = getCustomEnvOverrides({
+      ANTHROPIC_DEFAULT_SONNET_MODEL: '  trimmed-id  ',
+      ANTHROPIC_DEFAULT_SONNET_MODEL_NAME: '  Trimmed Name  ',
+      ANTHROPIC_DEFAULT_SONNET_MODEL_DESCRIPTION: '  desc  ',
+    });
+    expect(out).toEqual([
+      { id: 'trimmed-id', label: 'Trimmed Name', description: 'desc' },
+    ]);
+  });
+});

--- a/electron/agent/__tests__/list-models-from-settings.test.ts
+++ b/electron/agent/__tests__/list-models-from-settings.test.ts
@@ -6,6 +6,7 @@ import {
   listModelsFromSettings,
   FALLBACK_MODELS,
 } from '../list-models-from-settings';
+import { CLI_PICKER_MODELS } from '../cli-picker-models';
 
 async function mkTmpDir(): Promise<string> {
   return await fsp.mkdtemp(path.join(os.tmpdir(), 'agentory-list-models-test-'));
@@ -26,19 +27,31 @@ describe('listModelsFromSettings', () => {
     await fsp.rm(configDir, { recursive: true, force: true }).catch(() => {});
   });
 
-  it('returns only fallback when settings file does not exist', async () => {
+  it('returns cli-picker + fallback when settings file does not exist', async () => {
     const missingDir = path.join(configDir, 'does-not-exist');
     const res = await listModelsFromSettings({ configDir: missingDir, env: {} });
     expect(res.ok).toBe(true);
-    expect(res.models.map((m) => m.id)).toEqual([...FALLBACK_MODELS]);
-    expect(res.models.every((m) => m.source === 'fallback')).toBe(true);
+    const ids = res.models.map((m) => m.id);
+    // CLI picker entries appear first, then fallback (minus any already
+    // contributed by cli-picker — but the v2.1.114 picker shares no ids with
+    // the fallback triple, so all of both are present).
+    expect(ids).toEqual([
+      ...CLI_PICKER_MODELS.map((m) => m.id),
+      ...FALLBACK_MODELS,
+    ]);
+    const sources = new Set(res.models.map((m) => m.source));
+    expect(sources).toEqual(new Set(['cli-picker', 'fallback']));
   });
 
-  it('does not throw on malformed JSON; returns fallback only', async () => {
+  it('does not throw on malformed JSON; returns cli-picker + fallback only', async () => {
     await fsp.writeFile(path.join(configDir, 'settings.json'), '{not valid', 'utf8');
     const res = await listModelsFromSettings({ configDir, env: {} });
     expect(res.ok).toBe(true);
-    expect(res.models.map((m) => m.id)).toEqual([...FALLBACK_MODELS]);
+    const ids = res.models.map((m) => m.id);
+    expect(ids).toEqual([
+      ...CLI_PICKER_MODELS.map((m) => m.id),
+      ...FALLBACK_MODELS,
+    ]);
   });
 
   it('picks up settings.model as source=settings', async () => {
@@ -143,14 +156,20 @@ describe('listModelsFromSettings', () => {
     expect(res.models.find((m) => m.id === '   ')).toBeUndefined();
   });
 
-  it('insertion order: settings entries come before env, env before manual, manual before fallback', async () => {
+  it('insertion order: settings → env → manual → cli-picker → env-override → fallback', async () => {
     await writeSettings(configDir, {
       model: 'from-settings-1',
       env: { ANTHROPIC_DEFAULT_OPUS_MODEL: 'from-settings-2' },
     });
     const res = await listModelsFromSettings({
       configDir,
-      env: { ANTHROPIC_DEFAULT_SONNET_MODEL: 'from-env-1' },
+      env: {
+        ANTHROPIC_DEFAULT_SONNET_MODEL: 'from-env-1',
+        // env-override tier var (also surfaces via 'env' source for the same
+        // id; first-write-wins keeps it as 'env'). Use a distinct tier var so
+        // we get a separate 'env-override' entry.
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: 'from-haiku-override',
+      },
       manualModelIds: ['from-manual-1'],
     });
     const ids = res.models.map((m) => m.id);
@@ -158,6 +177,41 @@ describe('listModelsFromSettings', () => {
     expect(idx('from-settings-1')).toBeLessThan(idx('from-env-1'));
     expect(idx('from-settings-2')).toBeLessThan(idx('from-env-1'));
     expect(idx('from-env-1')).toBeLessThan(idx('from-manual-1'));
-    expect(idx('from-manual-1')).toBeLessThan(idx(FALLBACK_MODELS[0]));
+    expect(idx('from-manual-1')).toBeLessThan(idx(CLI_PICKER_MODELS[0].id));
+    expect(idx(CLI_PICKER_MODELS[0].id)).toBeLessThan(idx(FALLBACK_MODELS[0]));
+  });
+
+  it('CLI picker hardcoded ids appear in the result with source=cli-picker', async () => {
+    const res = await listModelsFromSettings({ configDir, env: {} });
+    for (const expected of CLI_PICKER_MODELS) {
+      const found = res.models.find((m) => m.id === expected.id);
+      expect(found).toBeDefined();
+      expect(found?.source).toBe('cli-picker');
+    }
+  });
+
+  it('settings model wins source-tag when same id appears in cli-picker', async () => {
+    // 'sonnet' is a hardcoded picker entry — but if the user also has it as
+    // their settings.json model, settings should win the tag (precedence).
+    await writeSettings(configDir, { model: 'sonnet' });
+    const res = await listModelsFromSettings({ configDir, env: {} });
+    const matches = res.models.filter((m) => m.id === 'sonnet');
+    expect(matches.length).toBe(1);
+    expect(matches[0].source).toBe('settings');
+  });
+
+  it('tier env vars are claimed by the general env pass (env wins over env-override by precedence)', async () => {
+    // ANTHROPIC_DEFAULT_<TIER>_MODEL is scanned by both the general env pass
+    // (as a known model-key) and the per-tier env-override pass. First-write
+    // -wins → 'env'. The env-override pass exists for richer label/description
+    // metadata via companion vars; its source-tag only ever surfaces if the
+    // general env scan ever stops covering the tier keys. Documented here so
+    // a future reorganisation doesn't silently break the precedence rule.
+    const res = await listModelsFromSettings({
+      configDir,
+      env: { ANTHROPIC_DEFAULT_SONNET_MODEL: 'shared-sonnet' },
+    });
+    const m = res.models.find((x) => x.id === 'shared-sonnet');
+    expect(m?.source).toBe('env');
   });
 });

--- a/electron/agent/cli-picker-models.ts
+++ b/electron/agent/cli-picker-models.ts
@@ -1,0 +1,140 @@
+/**
+ * Hardcoded mirror of Claude Code CLI's `/model` slash-command picker list.
+ *
+ * Why this exists:
+ *   - The CLI's `/model` picker is built from a factory function compiled into
+ *     the `claude.exe` bundle (extracted from v2.1.114). It does NOT come from
+ *     ~/.claude/settings.json, does NOT come from any HTTP endpoint, and does
+ *     NOT depend on the active relay — that is precisely why these aliases
+ *     keep working when users point claude.exe at a third-party gateway.
+ *   - PR #97 reads settings.json + ANTHROPIC_*_MODEL env vars to find ids the
+ *     user has configured. That's the right signal for "what has this user
+ *     wired up", but it misses the canonical alias set every CLI install
+ *     ships with (sonnet / opus / haiku + 1M variants + legacy entries). The
+ *     model picker should always offer those, even on a fresh install with
+ *     no settings.json model overrides.
+ *
+ * This file is a pure data table — no spawning, no I/O, no network. Update
+ * when a new claude.exe bundle ships a new picker entry.
+ */
+
+export interface CliPickerModel {
+  /** The id passed via `--model` / written into settings.json (e.g. `sonnet`,
+   *  `opus[1m]`, `claude-opus-4-1`). For the alias entries (`sonnet`/`opus`/
+   *  `haiku`) the CLI later resolves to a concrete model id internally; we
+   *  keep the alias because that's what the picker shows and what users type. */
+  id: string;
+  /** Short label shown as the primary text in the picker. */
+  label: string;
+  /** One-line description shown under the label in the picker. */
+  description: string;
+}
+
+/**
+ * The CLI's hardcoded picker entries (claude.exe v2.1.114). The "Default
+ * (recommended)" entry is intentionally omitted — that's a sentinel for
+ * "use whatever the CLI decides" and is not a model id we can pass through.
+ *
+ * Frozen so callers cannot mutate the shared instance at runtime.
+ */
+export const CLI_PICKER_MODELS: ReadonlyArray<CliPickerModel> = Object.freeze([
+  Object.freeze({
+    id: 'sonnet',
+    label: 'Sonnet',
+    description: 'Sonnet 4.6 \u00B7 Best for everyday tasks',
+  }),
+  Object.freeze({
+    id: 'opus',
+    label: 'Opus',
+    description: 'Opus 4.7 \u00B7 Most capable for complex work',
+  }),
+  Object.freeze({
+    id: 'haiku',
+    label: 'Haiku',
+    description: 'Haiku 4.5 \u00B7 Fast and lightweight',
+  }),
+  Object.freeze({
+    id: 'sonnet[1m]',
+    label: 'Sonnet (1M context)',
+    description: 'Sonnet 4.6 with 1M context window',
+  }),
+  Object.freeze({
+    id: 'opus[1m]',
+    label: 'Opus 4.7 (1M context)',
+    description: 'Opus 4.7 with 1M context window',
+  }),
+  Object.freeze({
+    id: 'claude-opus-4-6[1m]',
+    label: 'Opus 4.6 (1M context)',
+    description: 'Opus 4.6 with 1M context window',
+  }),
+  Object.freeze({
+    id: 'claude-opus-4-1',
+    label: 'Opus 4.1',
+    description: 'Opus 4.1 \u00B7 Legacy',
+  }),
+]) as ReadonlyArray<CliPickerModel>;
+
+/**
+ * Per-tier env-var triples consulted by the CLI for "default <tier> model"
+ * overrides. Order matters only for stable iteration (tests assert on it).
+ */
+interface TierEnvSpec {
+  tier: 'Sonnet' | 'Opus' | 'Haiku';
+  modelKey: string;
+  nameKey: string;
+  descriptionKey: string;
+}
+
+const TIER_ENV_SPECS: ReadonlyArray<TierEnvSpec> = [
+  {
+    tier: 'Sonnet',
+    modelKey: 'ANTHROPIC_DEFAULT_SONNET_MODEL',
+    nameKey: 'ANTHROPIC_DEFAULT_SONNET_MODEL_NAME',
+    descriptionKey: 'ANTHROPIC_DEFAULT_SONNET_MODEL_DESCRIPTION',
+  },
+  {
+    tier: 'Opus',
+    modelKey: 'ANTHROPIC_DEFAULT_OPUS_MODEL',
+    nameKey: 'ANTHROPIC_DEFAULT_OPUS_MODEL_NAME',
+    descriptionKey: 'ANTHROPIC_DEFAULT_OPUS_MODEL_DESCRIPTION',
+  },
+  {
+    tier: 'Haiku',
+    modelKey: 'ANTHROPIC_DEFAULT_HAIKU_MODEL',
+    nameKey: 'ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME',
+    descriptionKey: 'ANTHROPIC_DEFAULT_HAIKU_MODEL_DESCRIPTION',
+  },
+];
+
+function readTrimmedString(env: NodeJS.ProcessEnv, key: string): string | null {
+  const raw = env[key];
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  return trimmed ? trimmed : null;
+}
+
+/**
+ * Surface user-defined overrides of the CLI's default tier models. When the
+ * user sets e.g. `ANTHROPIC_DEFAULT_SONNET_MODEL=foo-model`, the CLI uses
+ * that whenever it would otherwise resolve `sonnet`. Optional companion vars
+ * `..._MODEL_NAME` / `..._MODEL_DESCRIPTION` let users brand the entry; if
+ * absent we fall back to "Custom <Tier> model" / empty description.
+ *
+ * These are intentionally separate from the static {@link CLI_PICKER_MODELS}
+ * list — the CLI shows both, and so do we. Returns an empty array when no
+ * tier vars are set.
+ */
+export function getCustomEnvOverrides(
+  env: NodeJS.ProcessEnv = process.env,
+): CliPickerModel[] {
+  const out: CliPickerModel[] = [];
+  for (const spec of TIER_ENV_SPECS) {
+    const id = readTrimmedString(env, spec.modelKey);
+    if (!id) continue;
+    const label = readTrimmedString(env, spec.nameKey) ?? `Custom ${spec.tier} model`;
+    const description = readTrimmedString(env, spec.descriptionKey) ?? '';
+    out.push({ id, label, description });
+  }
+  return out;
+}

--- a/electron/agent/list-models-from-settings.ts
+++ b/electron/agent/list-models-from-settings.ts
@@ -14,13 +14,28 @@
  *
  * This module is pure — no spawning, no HTTP, no writes — so it is fast,
  * deterministic, and safe to call from anywhere on the main process.
+ *
+ * Sources surfaced (in priority order):
+ *   - 'settings'     — `settings.json` `model` field or `env.ANTHROPIC_*_MODEL`
+ *   - 'env'          — process env `ANTHROPIC_*_MODEL` not already in settings
+ *   - 'manual'       — user-typed ids from the endpoint Settings UI
+ *   - 'cli-picker'   — hardcoded mirror of claude.exe's `/model` picker
+ *   - 'env-override' — per-tier `ANTHROPIC_DEFAULT_<TIER>_MODEL` overrides
+ *   - 'fallback'     — static last-resort triple
  */
 
 import { promises as fsp } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { CLI_PICKER_MODELS, getCustomEnvOverrides } from './cli-picker-models';
 
-export type ModelSource = 'settings' | 'env' | 'manual' | 'fallback';
+export type ModelSource =
+  | 'settings'
+  | 'env'
+  | 'manual'
+  | 'cli-picker'
+  | 'env-override'
+  | 'fallback';
 
 export interface DiscoveredModel {
   id: string;
@@ -118,7 +133,13 @@ export async function listModelsFromSettings(
   const settings = await readSettings(configDir);
 
   // Dedupe by id, first-source-wins. Insertion order = priority order:
-  //   settings → env → manual → fallback.
+  //   settings → env → manual → cli-picker → env-override → fallback.
+  // Rationale: anything the user has actually configured (settings/env/manual)
+  // should keep its precise source tag; the hardcoded CLI picker entries fill
+  // in the canonical alias set every install ships with; the env-override
+  // entries (ANTHROPIC_DEFAULT_<TIER>_MODEL with companion NAME/DESCRIPTION)
+  // come last among "synthetic" sources so a user-typed manual id wins; the
+  // static fallback triple guarantees the picker is never empty.
   const merged = new Map<string, DiscoveredModel>();
   const add = (id: string | undefined, source: ModelSource): void => {
     if (!id) return;
@@ -156,7 +177,21 @@ export async function listModelsFromSettings(
     add(id, 'manual');
   }
 
-  // 4) Static fallback so the picker is never empty.
+  // 4) Hardcoded CLI picker list (claude.exe bundle factory). These are the
+  // aliases every CLI install offers via `/model`; they don't depend on
+  // settings.json or the active relay.
+  for (const m of CLI_PICKER_MODELS) {
+    add(m.id, 'cli-picker');
+  }
+
+  // 5) Per-tier env-var overrides (ANTHROPIC_DEFAULT_<TIER>_MODEL etc.).
+  // Tagged distinctly from 'env' so the UI can show "user customized this
+  // tier's default" separately from a raw ANTHROPIC_MODEL setting.
+  for (const m of getCustomEnvOverrides(env)) {
+    add(m.id, 'env-override');
+  }
+
+  // 6) Static fallback so the picker is never empty.
   for (const id of FALLBACK_MODELS) {
     add(id, 'fallback');
   }

--- a/electron/endpoints-manager.ts
+++ b/electron/endpoints-manager.ts
@@ -21,21 +21,35 @@ export type EndpointKind =
   | 'unknown';
 
 /**
- * Model row source — `'listed'` is anything discovered from
- * `~/.claude/settings.json` or matching ANTHROPIC_* env vars (i.e. models the
- * user has actually configured the CLI to know about); `'fallback'` is the
- * hardcoded triple from {@link listModelsFromSettings}; `'manual'` is anything
- * the user typed into the "Manual model IDs" box on the endpoint page.
+ * Model row source — one of:
+ *   - 'listed'      — discovered from `~/.claude/settings.json` or matching
+ *                     ANTHROPIC_* env vars (i.e. models the user has actually
+ *                     configured the CLI to know about; collapses
+ *                     `settings`/`env` from the discovery module).
+ *   - 'cli-picker'  — entry from claude.exe's hardcoded `/model` picker list
+ *                     (mirrored in `cli-picker-models.ts`). Always available
+ *                     regardless of the active relay.
+ *   - 'env-override'— per-tier `ANTHROPIC_DEFAULT_<TIER>_MODEL` override that
+ *                     supplies a custom id + optional NAME/DESCRIPTION.
+ *   - 'fallback'    — hardcoded triple from {@link listModelsFromSettings}.
+ *   - 'manual'      — user-typed id from the endpoint Settings UI.
  *
  * Older rows may carry `'probe'` from before PR #95 — UI code treats unknown
  * variants as `'listed'`.
  */
-export type DiscoverySource = 'listed' | 'fallback' | 'manual';
+export type DiscoverySource =
+  | 'listed'
+  | 'cli-picker'
+  | 'env-override'
+  | 'fallback'
+  | 'manual';
 
 /** Map the discovery module's source taxonomy onto our DB row taxonomy. */
 function mapSource(s: ModelSource): DiscoverySource {
   if (s === 'manual') return 'manual';
   if (s === 'fallback') return 'fallback';
+  if (s === 'cli-picker') return 'cli-picker';
+  if (s === 'env-override') return 'env-override';
   // 'settings' and 'env' both mean "the CLI is configured to know about this
   // model" — collapse onto 'listed' which is what the UI surfaces.
   return 'listed';
@@ -424,9 +438,11 @@ export class EndpointsManager {
    * the underlying lister guarantees a non-empty result.
    *
    * Source taxonomy after this runs:
-   *   - 'listed'   — discovered from settings.json or env (`settings`/`env`).
-   *   - 'manual'   — user-typed id from the Settings UI.
-   *   - 'fallback' — from the hardcoded `FALLBACK_MODELS` list.
+   *   - 'listed'       — discovered from settings.json or env (`settings`/`env`).
+   *   - 'cli-picker'   — claude.exe's hardcoded `/model` picker entries.
+   *   - 'env-override' — `ANTHROPIC_DEFAULT_<TIER>_MODEL` per-tier overrides.
+   *   - 'manual'       — user-typed id from the Settings UI.
+   *   - 'fallback'     — from the hardcoded `FALLBACK_MODELS` list.
    *
    * Note: this does NOT touch the network. The endpoint argument is used
    * only to scope DB writes / `lastRefreshedAt`. Reachability is a separate
@@ -448,7 +464,13 @@ export class EndpointsManager {
     const now = this.now();
     const db = getDb();
     const detectedKind: EndpointKind = endpoint.kind ?? 'anthropic';
-    const sourceStats: Record<DiscoverySource, number> = { listed: 0, fallback: 0, manual: 0 };
+    const sourceStats: Record<DiscoverySource, number> = {
+      listed: 0,
+      'cli-picker': 0,
+      'env-override': 0,
+      fallback: 0,
+      manual: 0,
+    };
     const run = db.transaction(() => {
       db.prepare('DELETE FROM endpoint_models WHERE endpoint_id = ?').run(endpointId);
       const insert = db.prepare(
@@ -457,10 +479,13 @@ export class EndpointsManager {
       );
       for (const m of result.models) {
         const source = mapSource(m.source);
-        // Confirm only entries that came from a real signal (settings/env).
-        // Manual + fallback stay unconfirmed so the UI can show "user-typed"
-        // / "guessed" hints if it wants to.
-        const confirmed = source === 'listed';
+        // Confirm entries that came from a real signal (settings/env/cli-picker
+        // /env-override). Manual + fallback stay unconfirmed so the UI can
+        // show "user-typed" / "guessed" hints if it wants to.
+        const confirmed =
+          source === 'listed' ||
+          source === 'cli-picker' ||
+          source === 'env-override';
         insert.run(
           randomUUID(),
           endpointId,

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -1194,14 +1194,22 @@ function SourceBreakdown({
   counts,
   total,
 }: {
-  counts: { fallback: number; listed: number; manual: number };
+  counts: {
+    fallback: number;
+    listed: number;
+    manual: number;
+    cliPicker: number;
+    envOverride: number;
+  };
   total: number;
 }) {
   const parts: string[] = [];
   if (counts.listed) parts.push(`${counts.listed} listed`);
+  if (counts.cliPicker) parts.push(`${counts.cliPicker} CLI picker`);
+  if (counts.envOverride) parts.push(`${counts.envOverride} env override`);
   if (counts.fallback) parts.push(`${counts.fallback} fallback`);
   if (counts.manual) parts.push(`${counts.manual} manual`);
-  const tooltip = parts.length ? parts.join(' · ') : 'no discovery data yet';
+  const tooltip = parts.length ? parts.join(' \u00B7 ') : 'no discovery data yet';
   return (
     <span title={tooltip} className="cursor-help">
       {total} model{total === 1 ? '' : 's'}
@@ -1270,6 +1278,8 @@ function EndpointsPane() {
               fallback: models.filter((m) => m.source === 'fallback').length,
               listed: models.filter((m) => m.source === 'listed').length,
               manual: models.filter((m) => m.source === 'manual').length,
+              cliPicker: models.filter((m) => m.source === 'cli-picker').length,
+              envOverride: models.filter((m) => m.source === 'env-override').length,
             };
             const is401 = e.lastStatus === 'error' && (e.lastError ?? '').toLowerCase().includes('auth');
             const noneFound = e.lastStatus === 'ok' && models.length === 0;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -63,7 +63,7 @@ type EndpointKindDecl =
   | 'vertex'
   | 'unknown';
 type EndpointStatusDecl = 'ok' | 'error' | 'unchecked';
-type DiscoverySourceDecl = 'listed' | 'fallback' | 'manual';
+type DiscoverySourceDecl = 'listed' | 'cli-picker' | 'env-override' | 'fallback' | 'manual';
 type EndpointRowDecl = {
   id: string;
   name: string;

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -34,7 +34,7 @@ export type EndpointKind =
   | 'vertex'
   | 'unknown';
 export type EndpointStatus = 'ok' | 'error' | 'unchecked';
-export type DiscoverySource = 'listed' | 'fallback' | 'manual';
+export type DiscoverySource = 'listed' | 'cli-picker' | 'env-override' | 'fallback' | 'manual';
 
 // Cumulative cost / token / turn counters for a single session. Aggregated
 // from `result` frames as they arrive (see agent/lifecycle). Used by the


### PR DESCRIPTION
## Summary

PR #97 reads model ids from `~/.claude/settings.json` + `ANTHROPIC_*_MODEL` env vars. That captures what the user has configured, but it misses the canonical alias set every CLI install ships — `sonnet`, `opus`, `haiku`, their `[1m]` variants, and the legacy `claude-opus-4-1`. The CLI's `/model` slash-command picker builds those entries from a factory function compiled into the `claude.exe` bundle (extracted from v2.1.114); they don't depend on settings.json or the active relay, which is why they keep working through Claude-Code-Router / LiteLLM / Kimi shims.

This change mirrors the picker as a static data table inside agentory so the model dropdown always offers the same set the CLI does.

## Source: where the list comes from

Extracted from the `claude.exe` v2.1.114 bundle's `/model` picker factory function. Kept as plain data in `electron/agent/cli-picker-models.ts`; update when a new bundle ships a new entry. No spawning, no HTTP — pure data table, frozen at runtime so callers can't mutate it.

| value | label | description |
|---|---|---|
| `sonnet` | Sonnet | Sonnet 4.6 - Best for everyday tasks |
| `opus` | Opus | Opus 4.7 - Most capable for complex work |
| `haiku` | Haiku | Haiku 4.5 - Fast and lightweight |
| `sonnet[1m]` | Sonnet (1M context) | Sonnet 4.6 with 1M context window |
| `opus[1m]` | Opus 4.7 (1M context) | Opus 4.7 with 1M context window |
| `claude-opus-4-6[1m]` | Opus 4.6 (1M context) | Opus 4.6 with 1M context window |
| `claude-opus-4-1` | Opus 4.1 | Opus 4.1 - Legacy |

The "Default (recommended)" sentinel is intentionally NOT mirrored — it's a CLI-internal "use whatever the CLI decides" marker, not a model id we can pass through.

## Relationship to PR #97 (settings.json discovery)

This list is a **superset, not a replacement**. The discovery merge order is now:

```
settings -> env -> manual -> cli-picker -> env-override -> fallback
```

User-configured ids (settings/env/manual) keep their precise source tag (first-source-wins via the existing dedup map). CLI-picker entries fill in the canonical alias set. Per-tier `ANTHROPIC_DEFAULT_<TIER>_MODEL` overrides — with optional companion `_NAME` / `_DESCRIPTION` vars for branding — surface as `'env-override'`. The static fallback triple still guarantees a non-empty result for the picker.

## New `source` values

The discovery module's `ModelSource` and the DB-side `DiscoverySource` taxonomy gain two values, threaded through `electron/endpoints-manager.ts` (mapper + `sourceStats` shape + `existsConfirmed` rule), `electron/preload.ts` (via global types), `src/global.d.ts`, and `src/stores/store.ts`:

- `'cli-picker'` — entry from claude.exe's hardcoded `/model` picker.
- `'env-override'` — `ANTHROPIC_DEFAULT_<TIER>_MODEL` per-tier override.

`SettingsDialog`'s `SourceBreakdown` hover tooltip now surfaces the new buckets. `existsConfirmed` is `true` for cli-picker / env-override entries (they're real signals), false for manual / fallback.

## Test plan

- [x] `electron/agent/__tests__/cli-picker-models.test.ts` — list shape, length >= 7, runtime freeze, env-override matrix (no env / single tier / all tiers / NAME+DESCRIPTION overrides / whitespace handling / trim).
- [x] `electron/agent/__tests__/list-models-from-settings.test.ts` — cli-picker entries appear with source=cli-picker; settings model wins source-tag when same id appears in cli-picker; updated insertion-order test covers the new pipeline; documents env vs env-override precedence.
- [x] `tests/endpoints-manager.test.ts` — existing tests pass against the widened `DiscoverySource` (sourceStats.listed/fallback unchanged; cli-picker/env-override buckets added to record).
- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean (1 unrelated pre-existing warning).
- [x] `npm test` — 594 passed; 3 pre-existing failures in `tests/session-create-dialog.test.tsx` (`branchOptions.map is not a function`, unrelated).