### PR TITLE
feat(discovery): auto-refresh endpoint models on boot and on add/update

### DIFF
--- a/electron/endpoints-manager.ts
+++ b/electron/endpoints-manager.ts
@@ -233,6 +233,11 @@ export class EndpointsManager {
 
     const row = this.getEndpoint(id);
     if (!row) throw new Error('addEndpoint: insert succeeded but row missing');
+    // Fire-and-forget: the UI calls this synchronously through IPC and
+    // expects the new row back immediately; model discovery (local-only —
+    // settings.json + env) runs in the background and writes sqlite for
+    // the next `models:listByEndpoint` read.
+    this.kickOffRefresh(id);
     return row;
   }
 
@@ -267,6 +272,10 @@ export class EndpointsManager {
       }
     });
     run();
+    // Fire-and-forget refresh: any of name/baseUrl/apiKey could affect what
+    // the discovery sees (e.g. a newly-added key may unlock a relay that
+    // gates model listings). Background it so the IPC call returns instantly.
+    this.kickOffRefresh(id);
     return this.getEndpoint(id);
   }
 
@@ -302,6 +311,9 @@ export class EndpointsManager {
     getDb()
       .prepare('UPDATE endpoints SET manual_model_ids = ?, updated_at = ? WHERE id = ?')
       .run(encoded, this.now(), id);
+    // Fire-and-forget refresh: manual ids feed directly into the discovery
+    // merge, so the persisted model set must be re-derived immediately.
+    this.kickOffRefresh(id);
     return this.getEndpoint(id);
   }
 
@@ -514,6 +526,20 @@ export class EndpointsManager {
   }
 
   // ---------- Helpers ----------
+
+  /**
+   * Schedule a background `refreshModels(id)`. Used by `addEndpoint`,
+   * `updateEndpoint`, and `setManualModelIds` so the persisted model set
+   * stays current without forcing IPC handlers to await network/local-IO
+   * work. Errors are logged and swallowed — the original mutation already
+   * succeeded; a failed refresh is non-fatal (the row will be re-tried on
+   * next boot or via the manual "Refresh models" button).
+   */
+  private kickOffRefresh(endpointId: string): void {
+    void this.refreshModels(endpointId).catch((err) => {
+      console.warn(`[endpoints] background refresh failed for ${endpointId}:`, err);
+    });
+  }
 
   private encryptKey(plain: string | undefined | null): Buffer | null {
     if (!plain) return null;

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -820,6 +820,27 @@ app.whenReady().then(() => {
   // data the moment the user opens them. Fire-and-forget; refreshImportableCache
   // logs its own errors and stores [] on failure so getRecentCwds still resolves.
   void refreshImportableCache();
+
+  // Boot-time model discovery: kick off `refreshModels` for every persisted
+  // endpoint so the UI sees model lists without the user having to click
+  // "Refresh models" first. Run sequentially (one endpoint at a time) — the
+  // discovery is local-only (settings.json + env), but serialising avoids any
+  // pathological file-read contention if a relay sets up many endpoints.
+  // setImmediate so we don't add to the synchronous boot path; everything
+  // here is fire-and-forget — results land in sqlite, IPC `models:listByEndpoint`
+  // picks them up on next read.
+  setImmediate(() => {
+    void (async () => {
+      const allEndpoints = endpoints.listEndpoints();
+      for (const ep of allEndpoints) {
+        try {
+          await endpoints.refreshModels(ep.id);
+        } catch (err) {
+          console.warn(`[boot-discover] refresh failed for ${ep.id}:`, err);
+        }
+      }
+    })();
+  });
 });
 
 app.on('before-quit', () => {

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -1327,7 +1327,7 @@ function EndpointsPane() {
                     onClick={() => onRefresh(e.id)}
                     disabled={refreshingId === e.id}
                   >
-                    {refreshingId === e.id ? 'Discovering…' : 'Discover models'}
+                    {refreshingId === e.id ? 'Refreshing…' : 'Refresh models'}
                   </Button>
                   <Button
                     variant="secondary"

--- a/tests/endpoints-manager.test.ts
+++ b/tests/endpoints-manager.test.ts
@@ -60,9 +60,16 @@ describe('EndpointsManager: CRUD + encryption roundtrip', () => {
     freshDb();
   });
 
+  // CRUD-focused tests don't care about discovery; addEndpoint / updateEndpoint
+  // / setManualModelIds now schedule a background refresh, so we inject a
+  // no-op lister to keep the in-flight promise from racing against the next
+  // test's fresh db. The auto-refresh behaviour itself is exercised in its
+  // own describe block below.
+  const NOOP_LISTER: ListModelsFn = makeListModels([]);
+
   it('adds an endpoint and stores the key encrypted', () => {
     const crypto = makeCrypto();
-    const mgr = new EndpointsManager({ crypto });
+    const mgr = new EndpointsManager({ crypto, listModels: NOOP_LISTER });
     const row = mgr.addEndpoint({
       name: 'Anthropic',
       baseUrl: 'https://api.anthropic.com',
@@ -78,7 +85,7 @@ describe('EndpointsManager: CRUD + encryption roundtrip', () => {
   });
 
   it('lists endpoints with defaults first', () => {
-    const mgr = new EndpointsManager({ crypto: makeCrypto() });
+    const mgr = new EndpointsManager({ crypto: makeCrypto(), listModels: NOOP_LISTER });
     mgr.addEndpoint({ name: 'A', baseUrl: 'https://a' });
     mgr.addEndpoint({ name: 'B', baseUrl: 'https://b', isDefault: true });
     const list = mgr.listEndpoints();
@@ -88,7 +95,7 @@ describe('EndpointsManager: CRUD + encryption roundtrip', () => {
   });
 
   it('setting a new default unsets the previous one', () => {
-    const mgr = new EndpointsManager({ crypto: makeCrypto() });
+    const mgr = new EndpointsManager({ crypto: makeCrypto(), listModels: NOOP_LISTER });
     const a = mgr.addEndpoint({ name: 'A', baseUrl: 'https://a', isDefault: true });
     const b = mgr.addEndpoint({ name: 'B', baseUrl: 'https://b', isDefault: true });
     const after = mgr.listEndpoints();
@@ -97,7 +104,7 @@ describe('EndpointsManager: CRUD + encryption roundtrip', () => {
   });
 
   it('updateEndpoint with apiKey=null clears the key', () => {
-    const mgr = new EndpointsManager({ crypto: makeCrypto() });
+    const mgr = new EndpointsManager({ crypto: makeCrypto(), listModels: NOOP_LISTER });
     const row = mgr.addEndpoint({ name: 'A', baseUrl: 'https://a', apiKey: 'sk-1' });
     expect(mgr.getPlainKey(row.id)).toBe('sk-1');
     mgr.updateEndpoint(row.id, { apiKey: null });
@@ -120,13 +127,13 @@ describe('EndpointsManager: CRUD + encryption roundtrip', () => {
   });
 
   it('does not persist a key when encryption is unavailable', () => {
-    const mgr = new EndpointsManager({ crypto: makeCrypto(false) });
+    const mgr = new EndpointsManager({ crypto: makeCrypto(false), listModels: NOOP_LISTER });
     const row = mgr.addEndpoint({ name: 'A', baseUrl: 'https://a', apiKey: 'sk-1' });
     expect(mgr.getPlainKey(row.id)).toBeNull();
   });
 
   it('adds an endpoint with empty apiKey and persists without a stored key', () => {
-    const mgr = new EndpointsManager({ crypto: makeCrypto() });
+    const mgr = new EndpointsManager({ crypto: makeCrypto(), listModels: NOOP_LISTER });
     const row = mgr.addEndpoint({
       name: 'Local relay',
       baseUrl: 'http://127.0.0.1:8080',
@@ -136,6 +143,44 @@ describe('EndpointsManager: CRUD + encryption roundtrip', () => {
     expect(mgr.getPlainKey(row.id)).toBeNull();
     const list = mgr.listEndpoints();
     expect(list.find((e) => e.id === row.id)?.name).toBe('Local relay');
+  });
+});
+
+describe('EndpointsManager: auto-refresh on mutation', () => {
+  beforeEach(() => freshDb());
+
+  it('addEndpoint triggers a background refreshModels', async () => {
+    const lister = makeListModels(['m-1']);
+    const mgr = new EndpointsManager({ crypto: makeCrypto(), listModels: lister });
+    const row = mgr.addEndpoint({ name: 'A', baseUrl: 'https://a' });
+    expect(row.id).toBeTruthy();
+    // The refresh fires microtask-asynchronously; wait until the lister
+    // observes the call before asserting.
+    await vi.waitFor(() => expect(lister).toHaveBeenCalled());
+    await vi.waitFor(() =>
+      expect(mgr.listModels(row.id).map((m) => m.modelId)).toContain('m-1'),
+    );
+  });
+
+  it('updateEndpoint triggers a background refreshModels', async () => {
+    const lister = makeListModels(['m-1']);
+    const mgr = new EndpointsManager({ crypto: makeCrypto(), listModels: lister });
+    const row = mgr.addEndpoint({ name: 'A', baseUrl: 'https://a' });
+    await vi.waitFor(() => expect(lister).toHaveBeenCalledTimes(1));
+    mgr.updateEndpoint(row.id, { name: 'A2' });
+    await vi.waitFor(() => expect(lister).toHaveBeenCalledTimes(2));
+  });
+
+  it('setManualModelIds triggers a background refreshModels with the new ids', async () => {
+    const lister = makeListModels([
+      { id: 'custom-x', source: 'manual' },
+    ]);
+    const mgr = new EndpointsManager({ crypto: makeCrypto(), listModels: lister });
+    const row = mgr.addEndpoint({ name: 'A', baseUrl: 'https://a' });
+    await vi.waitFor(() => expect(lister).toHaveBeenCalledTimes(1));
+    mgr.setManualModelIds(row.id, ['custom-x']);
+    await vi.waitFor(() => expect(lister).toHaveBeenCalledTimes(2));
+    expect(lister).toHaveBeenLastCalledWith({ manualModelIds: ['custom-x'] });
   });
 });
 


### PR DESCRIPTION
## Behaviour change

Model discovery used to require the user to click **Discover models** in the Settings dialog before any model list appeared. Now the persisted sqlite catalogue stays current automatically — the picker is populated from first launch and reacts to endpoint edits without manual action.

## Trigger points

- **Boot** (`electron/main.ts`): after Electron's `ready` handler completes, a `setImmediate` task walks every persisted endpoint and calls `refreshModels` **sequentially**. Per-endpoint errors are logged and skipped; boot is never blocked.
- **addEndpoint** / **updateEndpoint** / **setManualModelIds** (`electron/endpoints-manager.ts`): each schedules a fire-and-forget `refreshModels(id)` via a new `kickOffRefresh` helper. The IPC handler returns the row immediately; discovery writes sqlite in the background. Renderer's next `models:listByEndpoint` call sees the fresh data.
- **Manual** (unchanged): the button in `SettingsDialog` is still wired to `endpoints:refreshModels`. Copy changed from `Discover models` to `Refresh models` because the default state now already has a list — the button is for retry, not bootstrap.

## Notes

- Discovery is local-only (reads `~/.claude/settings.json` + `ANTHROPIC_*` env via `listModelsFromSettings`); no network on boot.
- Boot loop is sequential to avoid any pathological file-read contention; in practice users have <5 endpoints so latency is negligible.
- IPC handlers never `await` the background refresh — the user-visible mutation completes immediately.

## Tests

- 3 new cases in `tests/endpoints-manager.test.ts` cover the auto-refresh behaviour on `addEndpoint` / `updateEndpoint` / `setManualModelIds` (use `vi.waitFor` against the lister stub).
- Existing CRUD tests now pass a no-op lister so the new background refresh doesn't race the next test's fresh in-memory db.
- Boot-time behaviour in `main.ts` is intentionally not unit-tested (IPC + `setImmediate` against the Electron `app` object is brittle).

## Test plan

- [ ] `npm run typecheck` — clean
- [ ] `npm test` — only pre-existing 3 failures in `session-create-dialog.test.tsx`
- [ ] `npm run lint` — clean
- [ ] Manual: launch app with one or more endpoints persisted; verify Settings shows model list immediately without clicking the refresh button.
- [ ] Manual: add a new endpoint; verify model list appears within a moment without manual refresh.