### PR TITLE
feat(worktree): auto-create on git cwd, drop opt-in checkbox

### DIFF
--- a/electron/agent/__tests__/worktree-manager.test.ts
+++ b/electron/agent/__tests__/worktree-manager.test.ts
@@ -145,11 +145,11 @@ describe('WorktreeManager.create', () => {
     expect(callArg.sourceBranch).toBe('feature-x');
   });
 
-  it('falls back to "main" when HEAD is detached and caller omits sourceBranch', async () => {
+  it('falls back to "HEAD" when the branch is detached and caller omits sourceBranch', async () => {
     git.getCurrentBranch.mockResolvedValue(null);
     await mgr.create('sess-1', '/tmp/repo');
     const callArg = git.createWorktree.mock.calls[0][0] as CreateWorktreeArgs;
-    expect(callArg.sourceBranch).toBe('main');
+    expect(callArg.sourceBranch).toBe('HEAD');
   });
 
   it('is idempotent — second call returns the first record and does not touch git', async () => {

--- a/electron/agent/git-helpers.ts
+++ b/electron/agent/git-helpers.ts
@@ -184,36 +184,25 @@ export async function getCurrentBranch(repoRoot: string): Promise<string | null>
   return name;
 }
 
-/**
- * List local + origin remote branches (short names). Deduplicated, sorted.
- * Remote HEAD pointers (`origin/HEAD`) are filtered out.
- */
-export async function listBranches(repoRoot: string): Promise<string[]> {
-  const { stdout } = await runGit(
-    ['branch', '--all', '--format=%(refname:short)'],
-    { cwd: repoRoot }
-  );
-  const names = stdout
-    .split(/\r?\n/)
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0)
-    .filter((s) => !s.endsWith('/HEAD'));
-  return Array.from(new Set(names)).sort();
-}
-
 export interface CreateWorktreeArgs {
   repoRoot: string;
   worktreePath: string;
   /** New branch name to create at the worktree. */
   branch: string;
-  /** Upstream branch to fork from — `origin/<sourceBranch>` is passed to git. */
+  /**
+   * Local start point — typically the source repo's current HEAD (branch
+   * name returned by `getCurrentBranch`, or `HEAD` for detached state).
+   * Passed verbatim to `git worktree add` as the start ref so worktrees
+   * always branch off whatever the user currently has checked out, with
+   * no dependency on `origin/` being reachable.
+   */
   sourceBranch: string;
 }
 
 /**
- * `git worktree add -b <branch> <path> origin/<sourceBranch>`, with our
- * standard longpath + LFS-skip overrides. Both paths are resolved to absolute
- * form before being passed to git so relative-path ambiguity can't bite us.
+ * `git worktree add -b <branch> <path> <sourceBranch>`, with our standard
+ * longpath + LFS-skip overrides. Both paths are resolved to absolute form
+ * before being passed to git so relative-path ambiguity can't bite us.
  */
 export async function createWorktree(args: CreateWorktreeArgs): Promise<void> {
   const absRoot = path.resolve(args.repoRoot);
@@ -227,7 +216,7 @@ export async function createWorktree(args: CreateWorktreeArgs): Promise<void> {
       '-b',
       args.branch,
       absPath,
-      `origin/${args.sourceBranch}`,
+      args.sourceBranch,
     ],
     { cwd: absRoot, timeoutMs: 300_000 }
   );

--- a/electron/agent/worktree-manager.ts
+++ b/electron/agent/worktree-manager.ts
@@ -203,7 +203,7 @@ export class WorktreeManager {
     const resolvedSource =
       sourceBranch?.trim() ||
       (await this.git.getCurrentBranch(absRepo)) ||
-      'main';
+      'HEAD';
 
     const name = this.generateUniqueName();
     const worktreePath = resolveWorktreePath(absRepo, name);

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -42,11 +42,7 @@ import {
   type WorktreeStorage,
   type WorktreeRecord,
 } from './agent/worktree-manager';
-import {
-  resolveRepoRoot,
-  isGitRepo,
-  listBranches as gitListBranches,
-} from './agent/git-helpers';
+import { isGitRepo, resolveRepoRoot } from './agent/git-helpers';
 
 const KEYCHAIN_FILE = 'anthropic-key.bin';
 
@@ -480,13 +476,6 @@ app.whenReady().then(() => {
         endpointId?: string;
         allowedTools?: readonly string[];
         disallowedTools?: readonly string[];
-        // Worktree opt-in. When true, the spawner creates (or reuses) a
-        // disposable git worktree under the resolved repo root and runs
-        // claude.exe inside it. The renderer is informed of the resolved
-        // path via the `agent:worktreeReady` event so it can update its
-        // local Session record.
-        useWorktree?: boolean;
-        sourceBranch?: string;
       }
     ) => {
       const envOverrides = resolveSessionEndpointEnv(opts.endpointId);
@@ -496,23 +485,19 @@ app.whenReady().then(() => {
       const apiKey = envOverrides?.ANTHROPIC_API_KEY ? undefined : readApiKey();
       const binaryPath = loadClaudeBinPath() ?? undefined;
 
-      // ── Worktree binding ─────────────────────────────────────────────
-      // If the session opted into a worktree, swap `cwd` for the worktree
-      // path BEFORE spawning. We surface a structured failure to the
-      // renderer instead of starting in the wrong dir; the user is told
-      // exactly which git step blew up.
+      // ── Auto worktree binding ────────────────────────────────────────
+      // If the cwd is inside a git repo, transparently provision a
+      // disposable worktree branched off the current HEAD and run claude
+      // inside it. Non-git cwds run in place. Failure to create the
+      // worktree is surfaced as a structured error so the user knows which
+      // git step blew up — we do NOT silently fall back to running on the
+      // main checkout, which could mix unrelated changes into their tree.
       let effectiveCwd = opts.cwd;
       let worktreeInfo: { path: string; name: string; branch: string; sourceBranch: string | null } | null = null;
-      if (opts.useWorktree) {
+      if (await isGitRepo(opts.cwd)) {
         try {
-          const repoRoot = await resolveRepoRoot(opts.cwd);
-          if (!repoRoot) {
-            return {
-              ok: false as const,
-              error: `Cannot create worktree: ${opts.cwd} is not inside a git repository.`,
-            };
-          }
-          const rec = await worktreeManager.create(sessionId, repoRoot, opts.sourceBranch);
+          const repoRoot = (await resolveRepoRoot(opts.cwd)) ?? opts.cwd;
+          const rec = await worktreeManager.create(sessionId, repoRoot);
           effectiveCwd = rec.path;
           worktreeInfo = {
             path: rec.path,
@@ -537,9 +522,9 @@ app.whenReady().then(() => {
       });
 
       // Inform the renderer of the resolved worktree so it can persist the
-      // path/name/branch onto the Session. Only emitted on success — failure
-      // flows return early above and the renderer learns via the rejected
-      // start result.
+      // path/name/branch onto the Session for sidebar / status bar display.
+      // Only emitted on success — failure flows return early above and the
+      // renderer learns via the rejected start result.
       if (result.ok && worktreeInfo) {
         const win = BrowserWindow.fromWebContents(_e.sender);
         if (win && !win.webContents.isDestroyed()) {
@@ -578,19 +563,9 @@ app.whenReady().then(() => {
 
   // ── Worktree IPC (read-only surface) ─────────────────────────────────
   // create / remove are NOT exposed: they're driven by the session lifecycle
-  // (agent:start with useWorktree, agent:close). The renderer only needs
-  // to read branches for the new-session dialog and look up a session's
-  // current binding for status / display.
-  ipcMain.handle('worktree:listBranches', async (_e, repoRoot: string) => {
-    if (typeof repoRoot !== 'string' || repoRoot.length === 0) return [];
-    try {
-      if (!(await isGitRepo(repoRoot))) return [];
-      return await gitListBranches(repoRoot);
-    } catch (err) {
-      console.warn('[main] worktree:listBranches failed', err);
-      return [];
-    }
-  });
+  // (auto-provisioned in agent:start when cwd is a git repo, torn down in
+  // agent:close). The renderer only needs to look up a session's current
+  // binding for status / display.
   ipcMain.handle('worktree:getForSession', (_e, sessionId: string) => {
     if (typeof sessionId !== 'string' || sessionId.length === 0) return null;
     return worktreeManager.getBySession(sessionId);

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -9,12 +9,6 @@ type StartOpts = {
   endpointId?: string;
   allowedTools?: readonly string[];
   disallowedTools?: readonly string[];
-  // Worktree opt-in. When true, the main process creates a disposable git
-  // worktree under the resolved repo root and runs claude.exe inside it;
-  // an `agent:worktreeReady` event lands shortly after with the resolved
-  // path/name/branch so the renderer can update its Session.
-  useWorktree?: boolean;
-  sourceBranch?: string;
 };
 
 type WorktreeReady = {
@@ -358,8 +352,6 @@ const api = {
   },
 
   worktree: {
-    listBranches: (repoRoot: string): Promise<string[]> =>
-      ipcRenderer.invoke('worktree:listBranches', repoRoot),
     getForSession: (sessionId: string): Promise<WorktreeRecordIpc | null> =>
       ipcRenderer.invoke('worktree:getForSession', sessionId),
     onReady: (handler: (e: WorktreeReady) => void): (() => void) => {

--- a/src/agent/lifecycle.ts
+++ b/src/agent/lifecycle.ts
@@ -254,6 +254,19 @@ export function subscribeAgentEvents(): void {
     ]);
   });
 
+  // Auto-worktree completion: main fires `agent:worktreeReady` once the
+  // disposable worktree is provisioned (and the underlying claude.exe
+  // process spawned). Mirror the metadata onto the Session so the sidebar
+  // pill / status bar can show the branch + path immediately.
+  api.worktree?.onReady((info) => {
+    useStore.getState().applyWorktreeReady(info.sessionId, {
+      path: info.path,
+      name: info.name,
+      branch: info.branch,
+      sourceBranch: info.sourceBranch,
+    });
+  });
+
   api.onAgentPermissionRequest((req) => {
     const store = useStore.getState();
     const block = permissionRequestToWaitingBlock(req);

--- a/src/components/SessionCreateDialog.tsx
+++ b/src/components/SessionCreateDialog.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Folder, GitBranch, Loader2 } from 'lucide-react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Folder } from 'lucide-react';
 import { Dialog, DialogContent, DialogBody, DialogFooter, DialogClose } from './ui/Dialog';
 import { Button } from './ui/Button';
 import { IconButton } from './ui/IconButton';
@@ -14,25 +14,6 @@ type Props = {
   initialCwd?: string | null;
 };
 
-type BranchLoadState =
-  | { kind: 'idle' }
-  | { kind: 'loading' }
-  | { kind: 'non-repo' }
-  | {
-      kind: 'loaded';
-      branches: string[];
-      currentBranch: string | null;
-      repoRoot: string;
-    }
-  | { kind: 'error'; message: string }
-  | { kind: 'unavailable' };
-
-function lastSegment(path: string): string {
-  const trimmed = path.replace(/[\\/]+$/, '');
-  const segs = trimmed.split(/[\\/]/).filter(Boolean);
-  return segs[segs.length - 1] ?? path;
-}
-
 /**
  * SessionCreateDialog — Radix Dialog that collects the minimum set of fields
  * for a new session. MVP contract:
@@ -40,10 +21,11 @@ function lastSegment(path: string): string {
  *  - `name` is optional; empty falls back to the store's "New session" default.
  *  - `cwd` is required; defaults to the caller-provided seed or the top of
  *    `recentProjects`. Browse opens an OS picker via `window.agentory.pickDirectory`.
- *  - `sourceBranch` dropdown is populated via `window.agentory.worktree.listBranches`
- *    if that IPC is available; otherwise the dropdown hides (dev on this UI
- *    is unblocked while `feat/worktree-core` is in-flight).
- *  - `useWorktree` can only be toggled when the cwd is a git repo.
+ *
+ * Worktree handling is no longer surfaced in this dialog: the main process
+ * decides automatically — if `cwd` is a git repo it spawns the session inside
+ * a fresh worktree branched off the current HEAD; otherwise it runs in `cwd`
+ * directly. The user does not need to think about it.
  *
  * Interaction: Enter submits (unless focus is already on the Create button),
  * Esc closes, focus lands on the name input on open.
@@ -57,8 +39,6 @@ export function SessionCreateDialog({ open, onOpenChange, initialCwd }: Props) {
   // CLI-derived recent cwds, populated from main's eager-scan cache. Used as
   // the fallback default when the in-app `recentProjects` history is empty
   // (typical first-run state) and as autocomplete suggestions in all cases.
-  // Kept separate from `recentProjects` because the latter is the user's
-  // in-app history and shouldn't be polluted by CLI scan results.
   const [recentCwds, setRecentCwds] = useState<string[]>([]);
   const recentCwdsListId = 'session-create-cwd-suggestions';
 
@@ -66,14 +46,7 @@ export function SessionCreateDialog({ open, onOpenChange, initialCwd }: Props) {
     initialCwd ?? recentProjects[0]?.path ?? recentCwds[0] ?? '';
   const [name, setName] = useState('');
   const [cwd, setCwd] = useState(defaultCwd);
-  const [useWorktree, setUseWorktree] = useState(false);
-  const [sourceBranch, setSourceBranch] = useState<string>('');
-  const [branchState, setBranchState] = useState<BranchLoadState>({ kind: 'idle' });
   const nameRef = useRef<HTMLInputElement>(null);
-  // Track in-flight listBranches calls so we drop stale responses after the
-  // user switches cwd (or closes the dialog) before a slow `git` shell-out
-  // resolves.
-  const branchFetchIdRef = useRef(0);
 
   // Reset on open so reopening gets a clean form (browse-folder side effects
   // between opens shouldn't leak).
@@ -81,9 +54,6 @@ export function SessionCreateDialog({ open, onOpenChange, initialCwd }: Props) {
     if (!open) return;
     setName('');
     setCwd(initialCwd ?? recentProjects[0]?.path ?? recentCwds[0] ?? '');
-    setUseWorktree(false);
-    setSourceBranch('');
-    setBranchState({ kind: 'idle' });
     // Delay focus so the Radix animation doesn't fight the focus move.
     const id = window.setTimeout(() => nameRef.current?.focus(), 40);
     return () => window.clearTimeout(id);
@@ -106,8 +76,6 @@ export function SessionCreateDialog({ open, onOpenChange, initialCwd }: Props) {
         setRecentCwds(list);
         // Only seed cwd from the CLI-derived list if the dialog opened with
         // no other source (no caller seed, no in-app history, no edit yet).
-        // Checking against `defaultCwd` avoids stomping a folder the user
-        // already typed during this open.
         setCwd((current) => {
           if (current.length > 0) return current;
           if (initialCwd != null) return current;
@@ -124,67 +92,6 @@ export function SessionCreateDialog({ open, onOpenChange, initialCwd }: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
-  // Load branches whenever cwd changes. Empty cwd = idle (nothing to probe).
-  useEffect(() => {
-    if (!open) return;
-    const trimmed = cwd.trim();
-    if (!trimmed) {
-      setBranchState({ kind: 'idle' });
-      return;
-    }
-    const api = window.agentory;
-    if (!api?.worktree?.listBranches) {
-      // Data layer not wired yet — don't crash, just gray out the dropdown.
-      setBranchState({ kind: 'unavailable' });
-      return;
-    }
-    const fetchId = ++branchFetchIdRef.current;
-    setBranchState({ kind: 'loading' });
-    // The backend (feat/worktree-core) returns a flat `string[]` of branch
-    // names and throws on non-git cwds. We surface "not a git repo" as a
-    // distinct state by catching that error. `currentBranch` / `repoRoot`
-    // are not exposed by the current IPC — leave them unset and let the UI
-    // degrade gracefully (first branch wins as the default selection).
-    api.worktree
-      .listBranches(trimmed)
-      .then((branches) => {
-        if (fetchId !== branchFetchIdRef.current) return;
-        setBranchState({
-          kind: 'loaded',
-          branches,
-          currentBranch: null,
-          repoRoot: trimmed
-        });
-        setSourceBranch((prev) => {
-          if (prev && branches.includes(prev)) return prev;
-          return branches[0] ?? '';
-        });
-      })
-      .catch((err) => {
-        if (fetchId !== branchFetchIdRef.current) return;
-        const message = err instanceof Error ? err.message : String(err);
-        // Heuristic: git complains about "not a git repository" on non-repo
-        // cwds. Bucket those into the dedicated non-repo state so the hint
-        // reads correctly and the worktree checkbox is disabled.
-        if (/not a git repository/i.test(message)) {
-          setBranchState({ kind: 'non-repo' });
-          return;
-        }
-        setBranchState({ kind: 'error', message });
-      });
-  }, [cwd, open]);
-
-  // Worktrees require a git repo. If the cwd isn't one, force the checkbox
-  // off so the user can't submit an invalid combination.
-  const worktreeAllowed = branchState.kind === 'loaded';
-  useEffect(() => {
-    if (!worktreeAllowed && useWorktree) setUseWorktree(false);
-  }, [worktreeAllowed, useWorktree]);
-
-  const branchOptions = useMemo(() => {
-    return branchState.kind === 'loaded' ? branchState.branches : [];
-  }, [branchState]);
-
   const browse = useCallback(async () => {
     const picked = await window.agentory?.pickDirectory();
     if (picked) setCwd(picked);
@@ -198,32 +105,11 @@ export function SessionCreateDialog({ open, onOpenChange, initialCwd }: Props) {
     const opts: CreateSessionOptions = {
       cwd: trimmedCwd,
       name: name.trim() || undefined,
-      useWorktree: useWorktree && worktreeAllowed,
-      sourceBranch: useWorktree && worktreeAllowed ? sourceBranch || undefined : undefined
     };
     createSession(opts);
     pushRecentProject(trimmedCwd);
     onOpenChange(false);
-  }, [cwd, name, useWorktree, worktreeAllowed, sourceBranch, createSession, pushRecentProject, onOpenChange]);
-
-  const branchHint = (() => {
-    switch (branchState.kind) {
-      case 'idle':
-        return t('sessionCreate.branchIdle');
-      case 'loading':
-        return t('sessionCreate.branchLoading');
-      case 'non-repo':
-        return t('sessionCreate.branchNonRepo');
-      case 'unavailable':
-        return t('sessionCreate.branchUnavailable');
-      case 'error':
-        return t('sessionCreate.branchError', { message: branchState.message });
-      case 'loaded':
-        return branchState.branches.length === 0
-          ? t('sessionCreate.branchEmpty')
-          : t('sessionCreate.branchRepository', { name: lastSegment(branchState.repoRoot) });
-    }
-  })();
+  }, [cwd, name, createSession, pushRecentProject, onOpenChange]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -283,76 +169,6 @@ export function SessionCreateDialog({ open, onOpenChange, initialCwd }: Props) {
                 </IconButton>
               </div>
             </FormField>
-
-            <FormField label={t('sessionCreate.baseBranch')} hint={branchHint}>
-              <div className="flex items-center gap-2">
-                <GitBranch
-                  size={13}
-                  className={cn(
-                    'stroke-[1.75] shrink-0',
-                    worktreeAllowed ? 'text-fg-tertiary' : 'text-fg-disabled'
-                  )}
-                />
-                <select
-                  value={sourceBranch}
-                  onChange={(e) => setSourceBranch(e.target.value)}
-                  disabled={!worktreeAllowed || branchOptions.length === 0}
-                  aria-label={t('sessionCreate.baseBranch')}
-                  data-testid="session-create-branch"
-                  className={cn(
-                    'flex-1 h-7 px-2 pr-6 rounded-sm bg-bg-elevated border border-border-default',
-                    'text-sm text-fg-primary outline-none cursor-pointer',
-                    'hover:border-border-strong',
-                    'focus-visible:border-border-strong focus-visible:shadow-[0_0_0_2px_oklch(0.72_0.14_215_/_0.30)]',
-                    'disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:border-border-default'
-                  )}
-                >
-                  {branchState.kind === 'loading' && <option value="">{t('sessionCreate.branchOptionLoading')}</option>}
-                  {branchState.kind === 'loaded' && branchOptions.length === 0 && (
-                    <option value="">{t('sessionCreate.branchOptionNoBranches')}</option>
-                  )}
-                  {branchState.kind === 'loaded' && branchState.currentBranch && !branchOptions.includes(branchState.currentBranch) && (
-                    <option value={branchState.currentBranch}>{branchState.currentBranch}</option>
-                  )}
-                  {branchOptions.map((b) => (
-                    <option key={b} value={b}>
-                      {b}
-                    </option>
-                  ))}
-                  {!worktreeAllowed && branchState.kind !== 'loading' && (
-                    <option value="">{t('sessionCreate.branchOptionUnavailable')}</option>
-                  )}
-                </select>
-                {branchState.kind === 'loading' && (
-                  <Loader2
-                    size={13}
-                    className="stroke-[1.75] shrink-0 text-fg-tertiary animate-spin"
-                    aria-hidden
-                  />
-                )}
-              </div>
-            </FormField>
-
-            <label
-              className={cn(
-                'inline-flex items-center gap-2 select-none',
-                worktreeAllowed ? 'cursor-pointer' : 'cursor-not-allowed opacity-60'
-              )}
-              data-testid="session-create-use-worktree-label"
-            >
-              <input
-                type="checkbox"
-                checked={useWorktree}
-                disabled={!worktreeAllowed}
-                onChange={(e) => setUseWorktree(e.target.checked)}
-                className="accent-fg-primary"
-                data-testid="session-create-use-worktree"
-              />
-              <span className="text-sm text-fg-primary">{t('sessionCreate.useWorktree')}</span>
-              <span className="text-xs text-fg-tertiary">
-                {t('sessionCreate.useWorktreeHint')}
-              </span>
-            </label>
           </form>
         </DialogBody>
         <DialogFooter>

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -12,8 +12,6 @@ type StartOpts = {
   endpointId?: string;
   allowedTools?: readonly string[];
   disallowedTools?: readonly string[];
-  useWorktree?: boolean;
-  sourceBranch?: string;
 };
 
 type WorktreeReadyDecl = {
@@ -308,7 +306,6 @@ declare global {
       };
 
       worktree: {
-        listBranches: (repoRoot: string) => Promise<string[]>;
         getForSession: (sessionId: string) => Promise<WorktreeRecordDecl | null>;
         onReady: (handler: (e: WorktreeReadyDecl) => void) => () => void;
       };

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -337,7 +337,7 @@ const en = {
   },
   sessionCreate: {
     title: 'New session',
-    description: 'Pick a working directory; optionally isolate the agent on a fresh git worktree.',
+    description: 'Pick a working directory. Git repos automatically run inside a fresh worktree.',
     name: 'Name',
     nameHint: 'Optional — defaults to \u201cNew session\u201d.',
     namePlaceholder: 'New session',
@@ -345,21 +345,8 @@ const en = {
     cwdHint: 'Where the agent should run.',
     cwdPlaceholder: '/path/to/repo',
     browseFolder: 'Browse folder',
-    baseBranch: 'Base branch',
-    useWorktree: 'Use git worktree',
-    useWorktreeHint: '— isolate this session on its own branch',
     cancel: 'Cancel',
-    create: 'Create session',
-    branchIdle: 'Pick a working directory to list branches.',
-    branchLoading: 'Reading branches…',
-    branchNonRepo: 'Not a git repository — worktrees disabled.',
-    branchUnavailable: 'Worktree support not loaded yet (data layer pending).',
-    branchError: 'Could not read branches: {{message}}',
-    branchEmpty: 'Repository has no branches yet.',
-    branchRepository: 'Repository: {{name}}',
-    branchOptionLoading: 'Loading…',
-    branchOptionNoBranches: '(no branches)',
-    branchOptionUnavailable: '(unavailable)'
+    create: 'Create session'
   },
   commandPalette: {
     title: 'Command palette',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -327,7 +327,7 @@ const zh: EnCatalog = {
   },
   sessionCreate: {
     title: '新建会话',
-    description: '选择一个工作目录；可选地用新的 git worktree 隔离 agent。',
+    description: '选择一个工作目录；如果是 git 仓库会自动在新的 worktree 中运行。',
     name: '名称',
     nameHint: '可选 — 默认为"新会话"。',
     namePlaceholder: '新会话',
@@ -335,21 +335,8 @@ const zh: EnCatalog = {
     cwdHint: 'agent 在这个目录下运行。',
     cwdPlaceholder: '/path/to/repo',
     browseFolder: '选择文件夹',
-    baseBranch: '基础分支',
-    useWorktree: '使用 git worktree',
-    useWorktreeHint: '— 在独立分支上隔离这个会话',
     cancel: '取消',
-    create: '创建会话',
-    branchIdle: '先选一个工作目录，再列出分支。',
-    branchLoading: '读取分支…',
-    branchNonRepo: '不是 git 仓库 — worktree 不可用。',
-    branchUnavailable: 'Worktree 支持尚未加载（数据层未就绪）。',
-    branchError: '无法读取分支：{{message}}',
-    branchEmpty: '仓库还没有分支。',
-    branchRepository: '仓库：{{name}}',
-    branchOptionLoading: '加载中…',
-    branchOptionNoBranches: '（无分支）',
-    branchOptionUnavailable: '（不可用）'
+    create: '创建会话'
   },
   commandPalette: {
     title: '命令面板',

--- a/src/stores/persist.ts
+++ b/src/stores/persist.ts
@@ -6,8 +6,7 @@ import type {
   FontSizePx,
   Density,
   WatchdogConfig,
-  NotificationSettings,
-  CcWorktreeParentDir
+  NotificationSettings
 } from './store';
 import type { RecentProject } from '../mock/data';
 
@@ -47,12 +46,6 @@ export interface PersistedState {
    * the CLI flags are simply omitted (identical to legacy behavior).
    */
   permissionRules?: PermissionRules;
-  /** Branch prefix used by the worktree spawner when generating branch names. */
-  ccBranchPrefix?: string;
-  /** Parent directory mode/path for newly provisioned worktrees. */
-  ccWorktreeParentDir?: CcWorktreeParentDir;
-  /** Auto-archive a session's group after its associated PR is closed/merged. */
-  ccAutoArchiveOnPrClose?: boolean;
 }
 
 export async function loadPersisted(): Promise<PersistedState | null> {

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -114,16 +114,8 @@ export const DEFAULT_NOTIFICATION_SETTINGS: NotificationSettings = {
   sound: true
 };
 
-// Claude Code worktree integration settings. All optional / have defaults so
-// existing persisted blobs upgrade cleanly. Wired to UI in a future Settings
-// dialog section; this PR only adds the store plumbing + defaults.
-export type CcWorktreeParentDir =
-  | { mode: 'default' }
-  | { mode: 'custom'; path: string };
-
-export const DEFAULT_CC_BRANCH_PREFIX = 'claude';
-export const DEFAULT_CC_WORKTREE_PARENT_DIR: CcWorktreeParentDir = { mode: 'default' };
-export const DEFAULT_CC_AUTO_ARCHIVE_ON_PR_CLOSE = false;
+// Claude Code worktree integration: behavior is now hard-wired (cwd is git
+// → auto worktree; otherwise → cwd in place). No user-facing settings here.
 
 // First-run gate: we block session spawn until we've confirmed the Claude CLI
 // exists on the user's machine. The dialog is non-dismissable but can be
@@ -209,18 +201,11 @@ type State = {
   // on app mount. Don't bump from background/system events; only user clicks.
   focusInputNonce: number;
   cliStatus: CliStatus;
-  // Claude Code worktree settings (no UI in this PR — Settings section is a
-  // later iteration). Defaults mirror `DEFAULT_CC_*` constants above.
-  ccBranchPrefix: string;
-  ccWorktreeParentDir: CcWorktreeParentDir;
-  ccAutoArchiveOnPrClose: boolean;
 };
 
 export interface CreateSessionOptions {
   cwd?: string | null;
   name?: string;
-  useWorktree?: boolean;
-  sourceBranch?: string;
 }
 
 type Actions = {
@@ -283,9 +268,15 @@ type Actions = {
   openCliDialog: () => void;
   closeCliDialog: () => void;
 
-  setCcBranchPrefix: (prefix: string) => void;
-  setCcWorktreeParentDir: (dir: CcWorktreeParentDir) => void;
-  setCcAutoArchiveOnPrClose: (enabled: boolean) => void;
+  /**
+   * Wires the `agent:worktreeReady` IPC payload onto the matching Session so
+   * the sidebar pill / status bar can show the branch + worktree path. No-op
+   * if the session is gone (deleted before the IPC landed).
+   */
+  applyWorktreeReady: (
+    sessionId: string,
+    info: { path: string; name: string; branch: string; sourceBranch: string | null }
+  ) => void;
 };
 
 function nextId(prefix: string): string {
@@ -410,9 +401,6 @@ export const useStore = create<State & Actions>((set, get) => ({
   permissionRules: EMPTY_PERMISSION_RULES,
   focusInputNonce: 0,
   cliStatus: DEFAULT_CLI_STATUS,
-  ccBranchPrefix: DEFAULT_CC_BRANCH_PREFIX,
-  ccWorktreeParentDir: DEFAULT_CC_WORKTREE_PARENT_DIR,
-  ccAutoArchiveOnPrClose: DEFAULT_CC_AUTO_ARCHIVE_ON_PR_CLOSE,
 
   selectSession: (id) => {
     set((s) => ({
@@ -484,8 +472,6 @@ export const useStore = create<State & Actions>((set, get) => ({
       groupId: targetGroupId,
       agentType: 'claude-code',
       endpointId,
-      ...(opts.useWorktree ? { useWorktree: true } : {}),
-      ...(opts.sourceBranch ? { sourceBranch: opts.sourceBranch } : {}),
     };
     set({
       sessions: [newSession, ...sessions],
@@ -1026,14 +1012,20 @@ export const useStore = create<State & Actions>((set, get) => ({
     });
   },
 
-  setCcBranchPrefix: (prefix) => {
-    // Trim + collapse whitespace. Empty string falls back to default so a
-    // cleared field doesn't yield `/<name>` branches.
-    const trimmed = prefix.trim();
-    set({ ccBranchPrefix: trimmed || DEFAULT_CC_BRANCH_PREFIX });
-  },
-  setCcWorktreeParentDir: (dir) => set({ ccWorktreeParentDir: dir }),
-  setCcAutoArchiveOnPrClose: (enabled) => set({ ccAutoArchiveOnPrClose: enabled })
+  applyWorktreeReady: (sessionId, info) => {
+    set((s) => {
+      const idx = s.sessions.findIndex((x) => x.id === sessionId);
+      if (idx === -1) return s;
+      const next = s.sessions.slice();
+      next[idx] = {
+        ...next[idx],
+        worktreePath: info.path,
+        worktreeName: info.name,
+        sourceBranch: info.sourceBranch ?? undefined,
+      };
+      return { sessions: next };
+    });
+  }
 }));
 
 let hydrated = false;
@@ -1068,10 +1060,7 @@ export async function hydrateStore(): Promise<void> {
       permissionRules: {
         allowedTools: persisted.permissionRules?.allowedTools ?? [],
         disallowedTools: persisted.permissionRules?.disallowedTools ?? []
-      },
-      ccBranchPrefix: persisted.ccBranchPrefix?.trim() || DEFAULT_CC_BRANCH_PREFIX,
-      ccWorktreeParentDir: persisted.ccWorktreeParentDir ?? DEFAULT_CC_WORKTREE_PARENT_DIR,
-      ccAutoArchiveOnPrClose: persisted.ccAutoArchiveOnPrClose ?? DEFAULT_CC_AUTO_ARCHIVE_ON_PR_CLOSE
+      }
     });
   }
   hydrated = true;
@@ -1108,10 +1097,7 @@ export async function hydrateStore(): Promise<void> {
       watchdog: s.watchdog,
       defaultEndpointId: s.defaultEndpointId,
       notificationSettings: s.notificationSettings,
-      permissionRules: s.permissionRules,
-      ccBranchPrefix: s.ccBranchPrefix,
-      ccWorktreeParentDir: s.ccWorktreeParentDir,
-      ccAutoArchiveOnPrClose: s.ccAutoArchiveOnPrClose
+      permissionRules: s.permissionRules
     };
     schedulePersist(snapshot);
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,12 +30,11 @@ export interface Session {
   // Omit to fall back to global rules untouched.
   permissionRules?: PermissionRules;
   // ── Optional git-worktree binding ───────────────────────────────────────
-  // When `useWorktree` is true, the spawner asks WorktreeManager to create a
-  // disposable worktree for this session on first start, and tears it down
-  // on session close. The remaining fields are populated by the backend
-  // after creation; the renderer only sets `useWorktree` (and optionally
-  // `sourceBranch`) up front.
-  useWorktree?: boolean;
+  // When the session's cwd is inside a git repo, the main process
+  // auto-provisions a disposable worktree on first start (branched off the
+  // current HEAD) and tears it down on session close. The fields below are
+  // populated by the backend after creation via the `agent:worktreeReady`
+  // IPC; they remain undefined for sessions whose cwd was not a git repo.
   /**
    * Absolute filesystem path of the provisioned worktree. Populated by the
    * main process after the worktree is created; remains undefined for
@@ -43,14 +42,14 @@ export interface Session {
    */
   worktreePath?: string;
   /**
-   * Friendly/branch name of the worktree (e.g. `claude/brave-turing-a1b2c3`).
+   * Friendly/branch name of the worktree (e.g. `worktree-brisk-falcon-a1b2c3`).
    * Drives the branch pill shown in the sidebar row and status bar.
    */
   worktreeName?: string;
   /**
-   * The branch the worktree was branched off from (user-selected at create
-   * time). Purely informational — used in tooltips and future "merge back"
-   * flows.
+   * The branch the worktree was branched off from (the current HEAD at
+   * session-start time). Purely informational — used in tooltips and future
+   * "merge back" flows.
    */
   sourceBranch?: string;
 }

--- a/tests/session-create-dialog.test.tsx
+++ b/tests/session-create-dialog.test.tsx
@@ -49,14 +49,8 @@ function renderDialog(props?: Partial<React.ComponentProps<typeof SessionCreateD
 }
 
 describe('<SessionCreateDialog />', () => {
-  it('renders all fields and creates a session on submit', async () => {
-    (window as unknown as { agentory: unknown }).agentory = {
-      worktree: {
-        listBranches: vi
-          .fn()
-          .mockResolvedValue({ ok: true, isRepo: false })
-      }
-    };
+  it('renders name + cwd fields and creates a session on submit', async () => {
+    (window as unknown as { agentory: unknown }).agentory = {};
     const onOpenChange = vi.fn();
     renderDialog({ onOpenChange, initialCwd: '/tmp/repo' });
     await flush();
@@ -69,68 +63,24 @@ describe('<SessionCreateDialog />', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /create session/i }));
     expect(useStore.getState().sessions).toHaveLength(1);
-    expect(useStore.getState().sessions[0].name).toBe('My session');
-    expect(useStore.getState().sessions[0].cwd).toBe('/tmp/repo');
-    expect(useStore.getState().sessions[0].useWorktree).toBeUndefined();
+    const created = useStore.getState().sessions[0];
+    expect(created.name).toBe('My session');
+    expect(created.cwd).toBe('/tmp/repo');
+    // Worktree fields are populated by the backend post-spawn, never by the
+    // dialog itself — verify the dialog hasn't tried to set them up front.
+    expect(created.worktreePath).toBeUndefined();
+    expect(created.worktreeName).toBeUndefined();
+    expect(created.sourceBranch).toBeUndefined();
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
-  it('disables the worktree checkbox when cwd is not a git repo', async () => {
-    (window as unknown as { agentory: unknown }).agentory = {
-      worktree: {
-        listBranches: vi.fn().mockResolvedValue({ ok: true, isRepo: false })
-      }
-    };
-    renderDialog({ initialCwd: '/tmp/not-repo' });
-    await flush();
-
-    const checkbox = screen.getByTestId('session-create-use-worktree') as HTMLInputElement;
-    expect(checkbox.disabled).toBe(true);
-    expect(screen.getByText(/not a git repository/i)).toBeInTheDocument();
-  });
-
-  it('disables the worktree checkbox when worktree IPC is unavailable', async () => {
-    // No window.agentory.worktree at all — simulates pre-data-layer state.
+  it('does not surface a worktree checkbox or branch select', async () => {
     (window as unknown as { agentory: unknown }).agentory = {};
-    renderDialog({ initialCwd: '/tmp/anywhere' });
+    renderDialog({ initialCwd: '/tmp/repo' });
     await flush();
 
-    const checkbox = screen.getByTestId('session-create-use-worktree') as HTMLInputElement;
-    expect(checkbox.disabled).toBe(true);
-    expect(screen.getByText(/worktree support not loaded/i)).toBeInTheDocument();
-  });
-
-  it('enables the worktree checkbox and lets the user pick a base branch when cwd is a repo', async () => {
-    (window as unknown as { agentory: unknown }).agentory = {
-      worktree: {
-        listBranches: vi.fn().mockResolvedValue({
-          ok: true,
-          isRepo: true,
-          repoRoot: '/tmp/repo',
-          currentBranch: 'main',
-          branches: [
-            { name: 'main', isCurrent: true, isRemote: false },
-            { name: 'feature/x', isCurrent: false, isRemote: false }
-          ]
-        })
-      }
-    };
-    renderDialog({ initialCwd: '/tmp/repo' });
-    await flush(80);
-
-    const checkbox = screen.getByTestId('session-create-use-worktree') as HTMLInputElement;
-    expect(checkbox.disabled).toBe(false);
-    fireEvent.click(checkbox);
-    expect(checkbox.checked).toBe(true);
-
-    const branchSelect = screen.getByTestId('session-create-branch') as HTMLSelectElement;
-    expect(branchSelect.value).toBe('main');
-    fireEvent.change(branchSelect, { target: { value: 'feature/x' } });
-
-    fireEvent.click(screen.getByRole('button', { name: /create session/i }));
-    const created = useStore.getState().sessions[0];
-    expect(created.useWorktree).toBe(true);
-    expect(created.sourceBranch).toBe('feature/x');
+    expect(screen.queryByTestId('session-create-use-worktree')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('session-create-branch')).not.toBeInTheDocument();
   });
 
   it('blocks submit when cwd is empty', async () => {
@@ -143,14 +93,7 @@ describe('<SessionCreateDialog />', () => {
 
   it('seeds cwd from window.agentory.recentCwds when no initialCwd and no in-app history', async () => {
     const recentCwds = vi.fn().mockResolvedValue(['/cli/project-a', '/cli/project-b', '/cli/project-c']);
-    (window as unknown as { agentory: unknown }).agentory = {
-      recentCwds,
-      worktree: {
-        // Returns a flat string[] of branch names — matches the actual
-        // worktree.listBranches IPC contract used by the dialog.
-        listBranches: vi.fn().mockResolvedValue([]),
-      },
-    };
+    (window as unknown as { agentory: unknown }).agentory = { recentCwds };
     renderDialog({ initialCwd: null });
     await flush();
 
@@ -173,12 +116,7 @@ describe('<SessionCreateDialog />', () => {
 
   it('does not stomp an explicit initialCwd with a recentCwds value', async () => {
     const recentCwds = vi.fn().mockResolvedValue(['/cli/other']);
-    (window as unknown as { agentory: unknown }).agentory = {
-      recentCwds,
-      worktree: {
-        listBranches: vi.fn().mockResolvedValue([]),
-      },
-    };
+    (window as unknown as { agentory: unknown }).agentory = { recentCwds };
     renderDialog({ initialCwd: '/explicit/seed' });
     await flush();
 
@@ -192,12 +130,7 @@ describe('<SessionCreateDialog />', () => {
     } as Partial<ReturnType<typeof useStore.getState>>);
 
     const recentCwds = vi.fn().mockResolvedValue(['/cli/different']);
-    (window as unknown as { agentory: unknown }).agentory = {
-      recentCwds,
-      worktree: {
-        listBranches: vi.fn().mockResolvedValue([]),
-      },
-    };
+    (window as unknown as { agentory: unknown }).agentory = { recentCwds };
     renderDialog({ initialCwd: null });
     await flush();
 

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -76,25 +76,26 @@ describe('store: createSession', () => {
     expect(useStore.getState().sessions[0].cwd).toBe('C:/other/path');
   });
 
-  it('accepts an options object with name + worktree fields', () => {
+  it('accepts an options object with a name override', () => {
     useStore.getState().createSession({
       cwd: '/tmp/repo',
-      name: '  Worktree spike  ',
-      useWorktree: true,
-      sourceBranch: 'main'
+      name: '  Worktree spike  '
     });
     const s = useStore.getState().sessions[0];
     expect(s.cwd).toBe('/tmp/repo');
     expect(s.name).toBe('Worktree spike');
-    expect(s.useWorktree).toBe(true);
-    expect(s.sourceBranch).toBe('main');
+    // Worktree fields are populated by the backend after spawn, never by
+    // createSession itself — verify they stay untouched here.
+    expect(s.worktreePath).toBeUndefined();
+    expect(s.worktreeName).toBeUndefined();
+    expect(s.sourceBranch).toBeUndefined();
   });
 
-  it('options object without useWorktree leaves the flag unset', () => {
+  it('options object without a name falls back to "New session"', () => {
     useStore.getState().createSession({ cwd: '/tmp/x' });
     const s = useStore.getState().sessions[0];
-    expect(s.useWorktree).toBeUndefined();
-    expect(s.sourceBranch).toBeUndefined();
+    expect(s.name).toBe('New session');
+    expect(s.worktreePath).toBeUndefined();
   });
 });
 
@@ -282,36 +283,44 @@ describe('store: setRunning', () => {
   });
 });
 
-describe('store: cc worktree settings', () => {
-  it('exposes default values out of the box', () => {
-    const s = useStore.getState();
-    expect(s.ccBranchPrefix).toBe('claude');
-    expect(s.ccWorktreeParentDir).toEqual({ mode: 'default' });
-    expect(s.ccAutoArchiveOnPrClose).toBe(false);
-  });
-
-  it('setCcBranchPrefix trims and falls back to the default on empty input', () => {
-    useStore.getState().setCcBranchPrefix('  feature  ');
-    expect(useStore.getState().ccBranchPrefix).toBe('feature');
-    useStore.getState().setCcBranchPrefix('   ');
-    expect(useStore.getState().ccBranchPrefix).toBe('claude');
-  });
-
-  it('setCcWorktreeParentDir flips between default and custom modes', () => {
-    useStore.getState().setCcWorktreeParentDir({ mode: 'custom', path: '/work/wt' });
-    expect(useStore.getState().ccWorktreeParentDir).toEqual({
-      mode: 'custom',
-      path: '/work/wt'
+describe('store: applyWorktreeReady', () => {
+  it('mirrors backend worktree info onto the matching Session', () => {
+    useStore.getState().createSession('/tmp/repo');
+    const sid = useStore.getState().activeId;
+    useStore.getState().applyWorktreeReady(sid, {
+      path: '/tmp/repo/.claude/worktrees/brisk-falcon-abc123',
+      name: 'brisk-falcon-abc123',
+      branch: 'worktree-brisk-falcon-abc123',
+      sourceBranch: 'working'
     });
-    useStore.getState().setCcWorktreeParentDir({ mode: 'default' });
-    expect(useStore.getState().ccWorktreeParentDir).toEqual({ mode: 'default' });
+    const s = useStore.getState().sessions.find((x) => x.id === sid)!;
+    expect(s.worktreePath).toBe('/tmp/repo/.claude/worktrees/brisk-falcon-abc123');
+    expect(s.worktreeName).toBe('brisk-falcon-abc123');
+    expect(s.sourceBranch).toBe('working');
   });
 
-  it('setCcAutoArchiveOnPrClose toggles the boolean', () => {
-    useStore.getState().setCcAutoArchiveOnPrClose(true);
-    expect(useStore.getState().ccAutoArchiveOnPrClose).toBe(true);
-    useStore.getState().setCcAutoArchiveOnPrClose(false);
-    expect(useStore.getState().ccAutoArchiveOnPrClose).toBe(false);
+  it('coerces a null sourceBranch (detached HEAD) to undefined', () => {
+    useStore.getState().createSession('/tmp/repo');
+    const sid = useStore.getState().activeId;
+    useStore.getState().applyWorktreeReady(sid, {
+      path: '/tmp/repo/.claude/worktrees/n',
+      name: 'n',
+      branch: 'worktree-n',
+      sourceBranch: null
+    });
+    const s = useStore.getState().sessions.find((x) => x.id === sid)!;
+    expect(s.sourceBranch).toBeUndefined();
+  });
+
+  it('is a no-op for an unknown sessionId', () => {
+    const before = useStore.getState().sessions;
+    useStore.getState().applyWorktreeReady('does-not-exist', {
+      path: '/x',
+      name: 'x',
+      branch: 'worktree-x',
+      sourceBranch: 'main'
+    });
+    expect(useStore.getState().sessions).toBe(before);
   });
 });
 


### PR DESCRIPTION
## Behavior

- **cwd is a git repo** → main auto-provisions a disposable worktree branched off the **current HEAD** and runs the session inside it.
- **cwd is not a git repo** → session runs in cwd directly, no worktree.

The user no longer chooses; SessionCreateDialog only collects name + cwd.

## Removed

- `Use worktree` checkbox + `Base branch` select in `SessionCreateDialog`
- `worktree:listBranches` IPC handler + preload + `global.d.ts` surface
- `CreateSessionOptions.{useWorktree, sourceBranch}`
- `Session.useWorktree` (now derived from `worktreePath !== undefined`)
- Dead settings: `ccBranchPrefix` / `ccWorktreeParentDir` / `ccAutoArchiveOnPrClose` (never wired to any UI)
- `listBranches` helper in `git-helpers`
- All `sessionCreate.{useWorktree, baseBranch, branch*}` i18n keys

## Kept

- Worktree pill in Sidebar / branch chip in StatusBar (driven by `Session.worktreeName` + `worktreePath`)
- `worktree.getForSession` IPC + `worktree.onReady` event

## Wired

- `lifecycle.ts` subscribes to `worktree.onReady` and applies the resolved `path/name/branch` onto the matching Session via the new `applyWorktreeReady` store action.
- `createWorktree` now branches off the local `sourceBranch` verbatim (no implicit `origin/` prefix) so worktrees work offline and don't require the source ref to exist on origin. `HEAD` is the safe fallback when the source repo's HEAD is detached.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm test` — `session-create-dialog` (6) and `statusbar-worktree` (2) green; the 3 pre-existing `branchOptions.map` failures are now gone since the dialog no longer renders that select. Remaining 24 failures are pre-existing `better-sqlite3` native-binding mismatches unrelated to this PR.
- [ ] Manual: create a session pointing at a git cwd → confirm worktree appears under `<repo>/.claude/worktrees/<name>`, sidebar pill shows the branch.
- [ ] Manual: create a session pointing at a non-git cwd → confirm session runs in cwd directly, no pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)