### PR TITLE
fix(theme): light mode contrast for CommandPalette trigger and Settings button

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -286,6 +286,45 @@ html.theme-light .text-body-emphasis {
   color: oklch(0.22 0.01 240);
 }
 
+/* Light-mode `raised` button overrides — Button/IconButton ship hardcoded
+   dark oklch(0.40) bg + border for the dark palette (see Button.tsx /
+   IconButton.tsx `raised` variant). In light mode that renders as
+   dark-on-dark (text-fg-primary is oklch 0.22), making the Sidebar's
+   New Session, palette search, and Settings buttons unreadable. Re-skin
+   the same tile here as a near-white surface that lifts off the
+   bg-sidebar (0.965) with a hairline border + soft shadow, so the dark
+   foreground text/icon reads cleanly. Hover/active mirror the dark-mode
+   ladder direction (hover lighter, active recessed). Dark mode is
+   untouched. */
+html.theme-light [data-variant="raised"] {
+  background-color: oklch(1 0 0);
+  border-color: var(--color-border-default);
+  box-shadow:
+    inset 0 1px 0 0 oklch(1 0 0 / 0.6),
+    0 1px 2px 0 oklch(0 0 0 / 0.05),
+    0 1px 3px 0 oklch(0 0 0 / 0.04);
+}
+html.theme-light [data-variant="raised"]:hover {
+  background-color: oklch(0.985 0.002 240);
+  border-color: var(--color-border-strong);
+}
+html.theme-light [data-variant="raised"]:active {
+  background-color: oklch(0.945 0.003 240);
+}
+html.theme-light [data-variant="raised"]:focus-visible {
+  box-shadow:
+    inset 0 1px 0 0 oklch(1 0 0 / 0.6),
+    0 1px 2px 0 oklch(0 0 0 / 0.05),
+    0 1px 3px 0 oklch(0 0 0 / 0.04),
+    0 0 0 3px var(--color-focus-ring);
+}
+html.theme-light [data-variant="raised"]:disabled {
+  background-color: var(--color-bg-elevated);
+  border-color: var(--color-border-default);
+  color: var(--color-fg-disabled);
+  box-shadow: none;
+}
+
 /* Light-mode scrollbar — the dark palette's border tokens are too dark to
    read as "scrollbar" on a near-white surface. */
 html.theme-light ::-webkit-scrollbar-thumb {


### PR DESCRIPTION
## Summary

PR #105 fixed light-mode contrast inside dialogs/palettes, but the chrome buttons that *open* them — Sidebar's New Session, palette search trigger (magnifier), and Settings button — still rendered as a dark plate with dark text on a near-white sidebar in light mode.

**Root cause**: `Button.tsx` and `IconButton.tsx` `raised` variants hardcode dark-palette OKLCH values (`bg-[oklch(0.40_0.003_240)]` etc.). In dark mode that's a deliberate "tile" against `bg-sidebar` (0.225). In light mode the bg stays oklch 0.40 (dark grey) while `text-fg-primary` flips to oklch 0.22 (near-black) — icon and label disappear.

**Fix** (CSS only, dark mode untouched): in `src/styles/global.css`, add `html.theme-light [data-variant=\"raised\"]` overrides keyed off the `data-variant` attribute already emitted by both Button and IconButton. Light skin = near-white tile + hairline `border-default` + soft warm shadow + matching hover/active/focus-visible/disabled states that mirror the dark-mode interaction ladder direction.

Specificity (0,2,1) wins over Tailwind utility arbitrary-value classes (0,1,0) including `:hover` variants (0,2,0). Color intentionally left to existing utility — dark `text-fg-primary` / `text-fg-secondary` already reads cleanly on white.

## Affected elements (Sidebar.tsx)

- L425  `NewSessionButton` (Button raised)
- L527-537  collapsed-rail palette search IconButton (raised)
- L539-549  collapsed-rail Settings IconButton (raised)
- L562-570  expanded palette search IconButton (raised)
- L651-660  bottom Settings Button (raised)

## Test plan

- [ ] Toggle to light mode, verify Sidebar's **New Session** button text is readable
- [ ] Verify the **search/magnifier** IconButton next to it (palette trigger) is readable
- [ ] Verify the **Settings** button at the bottom of the sidebar is readable
- [ ] Verify hover lifts (slightly off-white), active recesses, focus-visible shows accent ring
- [ ] Toggle back to dark mode — all `raised` buttons unchanged from before

## Notes

- `npm run typecheck` clean, `npm run lint` clean.
- Pre-existing test failures (`better-sqlite3` native binding `NODE_MODULE_VERSION` mismatch) are unrelated to this CSS-only change.