### PR TITLE
feat(statusbar): cwd typeahead popover with recent + browse fallback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -306,13 +306,16 @@ export default function App() {
               <ChatStream />
               <StatusBar
                 cwd={active.cwd}
+                cwdMissing={active.cwdMissing}
                 model={active.model || model}
                 permission={permission}
-                onChangeCwd={async (p) => {
-                  let next = p;
-                  if (next === null) {
-                    next = (await window.agentory?.pickDirectory()) ?? null;
-                  }
+                onChangeCwdToPath={(p) => {
+                  if (!p) return;
+                  changeCwd(p);
+                  pushRecentProject(p);
+                }}
+                onBrowseForCwd={async () => {
+                  const next = (await window.agentory?.pickDirectory()) ?? null;
                   if (!next) return;
                   changeCwd(next);
                   pushRecentProject(next);

--- a/src/components/CwdPopover.tsx
+++ b/src/components/CwdPopover.tsx
@@ -1,0 +1,298 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ChevronDown, Folder, AlertTriangle } from 'lucide-react';
+import { cn } from '../lib/cn';
+import { useTranslation } from '../i18n/useTranslation';
+
+// Typeahead popover for the StatusBar `cwd` chip.
+//
+// History: PR #94 introduced a typeahead dropdown inside the (since-removed)
+// SessionCreateDialog so users could pick a recent cwd by typing. PR #106
+// dropped the dialog in favour of in-place session creation, which also
+// dropped the typeahead — leaving the native directory picker as the only
+// way to switch cwd. This popover restores the typeahead by mounting it on
+// the StatusBar cwd chip and keeps the native picker as a "Browse..." entry
+// point at the bottom of the list.
+//
+// Implementation notes:
+//   - We deliberately don't pull in `@radix-ui/react-popover` because the
+//     project doesn't have it as a direct dependency and the brief forbids
+//     adding new ones. Positioning is a simple absolute layout anchored to
+//     the trigger; click-outside + Escape close the popover.
+//   - The recent list comes from `window.agentory.recentCwds()` which the
+//     main process eager-scans at boot from `~/.claude/projects` (PR #94).
+//     The IPC is best-effort: if it fails or returns empty we render a
+//     friendly "no recent cwds" hint and still expose Browse.
+//   - Filtering is plain case-insensitive substring — no fuzzy match. The
+//     query input is seeded with the current cwd so users can edit a path
+//     fragment instead of starting from scratch.
+
+const RECENT_LIMIT = 10;
+
+type Props = {
+  /** Current working directory. Used to label the trigger and seed the query. */
+  cwd: string;
+  /** When true, show a dim ⚠ next to the trigger label and explain via tooltip. */
+  cwdMissing?: boolean;
+  /** Optional async loader override — useful for tests. Defaults to the IPC. */
+  loadRecent?: () => Promise<string[]>;
+  /** Switch the active session to `path`. */
+  onPick: (path: string) => void;
+  /** Open the OS folder picker; called when "Browse..." is clicked. */
+  onBrowse: () => void;
+};
+
+function lastSegment(path: string): string {
+  const trimmed = path.replace(/[\\/]+$/, '');
+  const segs = trimmed.split(/[\\/]/).filter(Boolean);
+  return segs[segs.length - 1] ?? path;
+}
+
+function truncateMiddle(path: string, max = 56): string {
+  if (path.length <= max) return path;
+  const head = Math.ceil((max - 1) / 2);
+  const tail = Math.floor((max - 1) / 2);
+  return `${path.slice(0, head)}…${path.slice(path.length - tail)}`;
+}
+
+async function defaultLoadRecent(): Promise<string[]> {
+  type Bridge = { recentCwds?: () => Promise<string[]> };
+  const bridge = (typeof window !== 'undefined'
+    ? (window as unknown as { agentory?: Bridge }).agentory
+    : undefined);
+  try {
+    const list = await bridge?.recentCwds?.();
+    return Array.isArray(list) ? list : [];
+  } catch {
+    return [];
+  }
+}
+
+export function CwdPopover({ cwd, cwdMissing, loadRecent, onPick, onBrowse }: Props) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState(cwd);
+  const [recent, setRecent] = useState<string[]>([]);
+  const [active, setActive] = useState(0);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const popRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  // Reset query each time we re-open so users can start from the current cwd.
+  useEffect(() => {
+    if (!open) return;
+    setQuery(cwd);
+    setActive(0);
+    const id = window.setTimeout(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }, 0);
+    return () => window.clearTimeout(id);
+  }, [open, cwd]);
+
+  // Lazy-load recent cwds on first open. We refetch every open so newly-used
+  // cwds show up without forcing the user to restart the app — the IPC is
+  // cheap (returns from an in-memory cache).
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    const loader = loadRecent ?? defaultLoadRecent;
+    void loader().then((list) => {
+      if (cancelled) return;
+      setRecent(list.slice(0, RECENT_LIMIT));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, loadRecent]);
+
+  // Click-outside / Escape both close the popover. We use mousedown so the
+  // popover collapses before any click handlers on background controls fire,
+  // matching the SlashCommandPicker pattern elsewhere in the app.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      const target = e.target as Node | null;
+      if (!target) return;
+      if (popRef.current?.contains(target)) return;
+      if (triggerRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return recent;
+    return recent.filter((p) => p.toLowerCase().includes(needle));
+  }, [recent, query]);
+
+  // Clamp active row whenever the filtered list shrinks.
+  useEffect(() => {
+    if (active >= filtered.length) setActive(0);
+  }, [filtered.length, active]);
+
+  const commit = useCallback(
+    (path: string) => {
+      setOpen(false);
+      onPick(path);
+    },
+    [onPick]
+  );
+
+  const onListKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActive((a) => Math.min(a + 1, Math.max(0, filtered.length - 1)));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActive((a) => Math.max(0, a - 1));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const choice = filtered[active] ?? (query.trim() ? query.trim() : null);
+      if (choice) commit(choice);
+    }
+  };
+
+  const triggerLabel = lastSegment(cwd);
+
+  return (
+    <span className="relative inline-flex">
+      <button
+        ref={triggerRef}
+        type="button"
+        title={cwdMissing ? t('cwdPopover.cwdMissingTooltip', { cwd }) : cwd}
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        className={cn(
+          'inline-flex items-center gap-1 h-5 px-1.5 rounded-sm',
+          cwdMissing
+            ? 'text-state-warning hover:text-status-warning-foreground hover:bg-status-warning-muted'
+            : 'text-fg-tertiary hover:text-fg-secondary hover:bg-bg-hover',
+          'outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-border-strong',
+          'transition-colors duration-120 ease-out'
+        )}
+      >
+        <span>{triggerLabel}</span>
+        {cwdMissing ? (
+          <AlertTriangle
+            size={10}
+            className="stroke-[1.75] opacity-80"
+            aria-label={t('cwdPopover.cwdMissingShort')}
+          />
+        ) : null}
+        <ChevronDown size={10} className="stroke-[1.75] opacity-70" />
+      </button>
+
+      {open ? (
+        <div
+          ref={popRef}
+          role="dialog"
+          aria-label={t('statusBar.workingDirectory')}
+          // Anchor above the chip — StatusBar lives at the bottom of the
+          // window so a top-aligned popover would collide with the input
+          // bar above it. `bottom-full` puts us above the trigger; `mb-1`
+          // matches the breathing room used by the slash-command picker.
+          className={cn(
+            'absolute left-0 bottom-full mb-1 z-40 min-w-[320px] max-w-[480px]',
+            'rounded-md border border-border-default bg-bg-elevated',
+            'surface-highlight shadow-[var(--surface-shadow)]',
+            'text-sm text-fg-secondary overflow-hidden',
+            'animate-[menuIn_140ms_cubic-bezier(0.32,0.72,0,1)]'
+          )}
+        >
+          <div className="px-2 pt-2 pb-1.5 border-b border-border-subtle">
+            <input
+              ref={inputRef}
+              type="text"
+              value={query}
+              spellCheck={false}
+              autoComplete="off"
+              placeholder={t('cwdPopover.placeholder')}
+              onChange={(e) => {
+                setQuery(e.target.value);
+                setActive(0);
+              }}
+              onKeyDown={onListKeyDown}
+              className={cn(
+                'w-full h-7 px-2 rounded-sm bg-bg-panel border border-border-subtle',
+                'font-mono text-[12.5px] text-fg-primary placeholder:text-fg-tertiary',
+                'outline-none focus:border-border-strong'
+              )}
+            />
+          </div>
+
+          <div className="px-3 pt-1.5 pb-1 text-[11px] uppercase tracking-wider text-fg-tertiary">
+            {t('cwdPopover.recent')}
+          </div>
+          <ul className="max-h-[260px] overflow-y-auto pb-1" role="listbox">
+            {filtered.length === 0 ? (
+              <li className="px-3 py-2 text-fg-tertiary text-[12px] leading-[16px]">
+                {t('cwdPopover.empty')}
+              </li>
+            ) : (
+              filtered.map((path, i) => {
+                const isActive = i === active;
+                return (
+                  <li
+                    key={path}
+                    role="option"
+                    aria-selected={isActive}
+                    onMouseEnter={() => setActive(i)}
+                    // onMouseDown so the input doesn't blur first and close us.
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      commit(path);
+                    }}
+                    title={path}
+                    className={cn(
+                      'flex items-center h-7 px-3 mx-1 rounded-sm cursor-pointer select-none',
+                      'transition-colors duration-120 ease-out',
+                      isActive
+                        ? 'bg-bg-hover text-fg-primary'
+                        : 'text-fg-secondary hover:bg-bg-hover/60'
+                    )}
+                  >
+                    <span className="font-mono text-[12px] truncate">
+                      {truncateMiddle(path)}
+                    </span>
+                  </li>
+                );
+              })
+            )}
+          </ul>
+
+          <div className="border-t border-border-subtle px-1 py-1">
+            <button
+              type="button"
+              onMouseDown={(e) => {
+                e.preventDefault();
+                setOpen(false);
+                onBrowse();
+              }}
+              className={cn(
+                'w-full flex items-center gap-2 h-7 px-2 mx-0 rounded-sm',
+                'text-fg-secondary hover:bg-bg-hover hover:text-fg-primary',
+                'outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-border-strong',
+                'transition-colors duration-120 ease-out text-left text-[12.5px]'
+              )}
+            >
+              <Folder size={12} className="stroke-[1.75] text-fg-tertiary" />
+              <span>{t('cwdPopover.browse')}</span>
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </span>
+  );
+}

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ChevronDown, Folder } from 'lucide-react';
+import { ChevronDown } from 'lucide-react';
 import { cn } from '../lib/cn';
 import {
   DropdownMenu,
@@ -11,6 +11,7 @@ import {
 } from './ui/DropdownMenu';
 import { useStore } from '../stores/store';
 import { useTranslation } from '../i18n/useTranslation';
+import { CwdPopover } from './CwdPopover';
 
 // Permission mode values match claude.exe's `--permission-mode` flag 1:1.
 // We intentionally use the official CLI names (title-cased for display)
@@ -21,12 +22,6 @@ import { useTranslation } from '../i18n/useTranslation';
 // users can't enable; we omit `dontAsk` because it's redundant with
 // `default`.
 type PermissionMode = 'plan' | 'default' | 'acceptEdits' | 'bypassPermissions';
-
-function lastSegment(path: string): string {
-  const trimmed = path.replace(/[\\/]+$/, '');
-  const segs = trimmed.split(/[\\/]/).filter(Boolean);
-  return segs[segs.length - 1] ?? path;
-}
 
 const Chip = React.forwardRef<
   HTMLButtonElement,
@@ -123,8 +118,6 @@ function ChipMenu<V extends string>({
   );
 }
 
-const BROWSE_FOLDER = '__browse__';
-
 function primaryOf<V extends string>(options: ChipOption<V>[], value: V): string {
   for (const o of options) {
     if (o.kind === 'item' && o.value === value) return o.primary;
@@ -134,23 +127,26 @@ function primaryOf<V extends string>(options: ChipOption<V>[], value: V): string
 
 export type StatusBarProps = {
   cwd: string;
+  cwdMissing?: boolean;
   model: string;
   permission: PermissionMode;
-  onChangeCwd: (cwd: string | null) => void;
+  onChangeCwdToPath: (cwd: string) => void;
+  onBrowseForCwd: () => void;
   onChangeModel: (model: string) => void;
   onChangePermission: (mode: PermissionMode) => void;
 };
 
 export function StatusBar({
   cwd,
+  cwdMissing,
   model,
   permission,
-  onChangeCwd,
+  onChangeCwdToPath,
+  onBrowseForCwd,
   onChangeModel,
   onChangePermission
 }: StatusBarProps) {
   const { t } = useTranslation();
-  const recentProjects = useStore((s) => s.recentProjects);
   const endpoints = useStore((s) => s.endpoints);
   const modelsByEndpoint = useStore((s) => s.modelsByEndpoint);
   const endpointsLoaded = useStore((s) => s.endpointsLoaded);
@@ -172,21 +168,15 @@ export function StatusBar({
     bypassPermissions: t('statusBar.modeBypassTooltip')
   };
 
-  const cwdOptions: ChipOption<string>[] = [
-    ...recentProjects.map(
-      (p) =>
-        ({ kind: 'item', value: p.path, primary: p.name, secondary: p.path }) as ChipOption<string>
-    ),
-    ...(recentProjects.length > 0
-      ? ([{ kind: 'separator' }] as ChipOption<string>[])
-      : []),
-    {
-      kind: 'item',
-      value: BROWSE_FOLDER,
-      primary: t('statusBar.browseFolder'),
-      icon: <Folder size={12} className="stroke-[1.75] mr-2 text-fg-tertiary" />
-    }
-  ];
+  const cwdChip = (
+    <CwdPopover
+      key="cwd"
+      cwd={cwd}
+      cwdMissing={cwdMissing}
+      onPick={onChangeCwdToPath}
+      onBrowse={onBrowseForCwd}
+    />
+  );
 
   // Build the grouped model option list: one `label` row per endpoint,
   // followed by that endpoint's discovered models, separated between groups.
@@ -233,14 +223,7 @@ export function StatusBar({
   }
 
   const chips: React.ReactNode[] = [
-    <ChipMenu
-      key="cwd"
-      label={t('statusBar.workingDirectory')}
-      triggerLabel={lastSegment(cwd)}
-      triggerTitle={cwd}
-      options={cwdOptions}
-      onSelect={(v) => onChangeCwd(v === BROWSE_FOLDER ? null : v)}
-    />,
+    cwdChip,
     <ChipMenu
       key="model"
       label={t('statusBar.model')}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -385,6 +385,14 @@ const en = {
     modeDefaultTooltip: 'Default \u2014 auto-approve reads; ask before edits and shell.',
     modeAcceptEditsTooltip: 'Accept Edits \u2014 auto-approve reads and file edits; ask before shell.',
     modeBypassTooltip: 'Bypass Permissions \u2014 every tool call runs without asking. Use with care.'
+  },
+  cwdPopover: {
+    placeholder: 'Type to filter or paste a path…',
+    recent: 'Recent',
+    empty: 'No matching recent directories',
+    browse: 'Browse folder…',
+    cwdMissingShort: 'missing',
+    cwdMissingTooltip: 'Working directory no longer exists: {{cwd}}. Pick a different folder before sending.'
   }
 } as const;
 

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -373,6 +373,14 @@ const zh: EnCatalog = {
     modeDefaultTooltip: '默认 \u2014 自动批准读取；编辑和 shell 先询问。',
     modeAcceptEditsTooltip: '接受编辑 \u2014 自动批准读取与文件编辑；shell 先询问。',
     modeBypassTooltip: '跳过校验 \u2014 所有工具调用直接放行。请谨慎使用。'
+  },
+  cwdPopover: {
+    placeholder: '输入筛选或粘贴路径…',
+    recent: '最近使用',
+    empty: '没有匹配的最近目录',
+    browse: '选择文件夹…',
+    cwdMissingShort: '已不存在',
+    cwdMissingTooltip: '工作目录已不存在: {{cwd}}。请选择另一个目录后再发送。'
   }
 };
 

--- a/tests/cwd-popover.test.tsx
+++ b/tests/cwd-popover.test.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import { CwdPopover } from '../src/components/CwdPopover';
+
+const SAMPLE = [
+  '/home/alice/projects/agentory',
+  '/home/alice/projects/agentory-next',
+  '/home/alice/work/cli-tools',
+  '/tmp/scratch-pad'
+];
+
+function renderPopover(
+  overrides: Partial<React.ComponentProps<typeof CwdPopover>> = {}
+) {
+  const onPick = vi.fn();
+  const onBrowse = vi.fn();
+  const loadRecent = vi.fn(async () => SAMPLE);
+  const utils = render(
+    <CwdPopover
+      cwd="/home/alice/projects/agentory"
+      onPick={onPick}
+      onBrowse={onBrowse}
+      loadRecent={loadRecent}
+      {...overrides}
+    />
+  );
+  return { ...utils, onPick, onBrowse, loadRecent };
+}
+
+async function openPopover() {
+  // Trigger renders the last segment of the cwd; click it to open.
+  const trigger = screen.getByRole('button', { name: /agentory/i });
+  await act(async () => {
+    fireEvent.click(trigger);
+  });
+  // Allow the loadRecent promise to resolve.
+  await waitFor(() => {
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+}
+
+describe('<CwdPopover />', () => {
+  it('renders the trigger labelled with the last cwd path segment', () => {
+    renderPopover();
+    expect(screen.getByRole('button', { name: /agentory/i })).toBeInTheDocument();
+  });
+
+  it('opens on click and lists recent cwds from loadRecent (filtered by seeded query)', async () => {
+    const { loadRecent } = renderPopover();
+    await openPopover();
+    expect(loadRecent).toHaveBeenCalled();
+    // The input is seeded with the current cwd, so only entries containing
+    // "agentory" should be visible — that's two of the four sample paths.
+    await waitFor(() => {
+      const options = screen.getAllByRole('option');
+      expect(options.length).toBe(2);
+    });
+  });
+
+  it('clearing the input reveals every recent cwd', async () => {
+    renderPopover();
+    await openPopover();
+    const input = screen.getByPlaceholderText(/type to filter/i);
+    await act(async () => {
+      fireEvent.change(input, { target: { value: '' } });
+    });
+    await waitFor(() => {
+      expect(screen.getAllByRole('option').length).toBe(SAMPLE.length);
+    });
+  });
+
+  it('filters the recent list as the user types in the input', async () => {
+    renderPopover();
+    await openPopover();
+    const input = screen.getByPlaceholderText(/type to filter/i);
+    // Replace the seeded query with a substring matching only one entry.
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'cli' } });
+    });
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(1);
+    expect(options[0].textContent).toMatch(/cli-tools/);
+  });
+
+  it('clicking a recent entry calls onPick with the full path', async () => {
+    const { onPick } = renderPopover();
+    await openPopover();
+    const input = screen.getByPlaceholderText(/type to filter/i);
+    await act(async () => {
+      fireEvent.change(input, { target: { value: '' } });
+    });
+    await waitFor(() => {
+      expect(screen.getAllByRole('option').length).toBe(SAMPLE.length);
+    });
+    const options = screen.getAllByRole('option');
+    // Use mousedown — the component listens on mousedown so the input
+    // doesn't blur before commit fires.
+    await act(async () => {
+      fireEvent.mouseDown(options[2]);
+    });
+    expect(onPick).toHaveBeenCalledWith(SAMPLE[2]);
+  });
+
+  it('clicking the Browse button calls onBrowse and closes the popover', async () => {
+    const { onBrowse, onPick } = renderPopover();
+    await openPopover();
+    const browse = screen.getByRole('button', { name: /browse/i });
+    await act(async () => {
+      fireEvent.mouseDown(browse);
+    });
+    expect(onBrowse).toHaveBeenCalledTimes(1);
+    expect(onPick).not.toHaveBeenCalled();
+    // Popover should be closed (dialog removed from the tree).
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('Escape closes the popover without picking', async () => {
+    const { onPick } = renderPopover();
+    await openPopover();
+    await act(async () => {
+      fireEvent.keyDown(document, { key: 'Escape' });
+    });
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(onPick).not.toHaveBeenCalled();
+  });
+
+  it('shows the empty hint when no recent path matches the query', async () => {
+    renderPopover();
+    await openPopover();
+    const input = screen.getByPlaceholderText(/type to filter/i);
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'zzz-no-match-zzz' } });
+    });
+    expect(screen.queryAllByRole('option')).toHaveLength(0);
+    expect(screen.getByText(/no matching recent/i)).toBeInTheDocument();
+  });
+
+  it('Enter on the input commits the highlighted recent entry', async () => {
+    const { onPick } = renderPopover();
+    await openPopover();
+    const input = screen.getByPlaceholderText(/type to filter/i);
+    // Clear the seeded query so the full list is shown, then arrow down once.
+    await act(async () => {
+      fireEvent.change(input, { target: { value: '' } });
+    });
+    await waitFor(() => {
+      expect(screen.getAllByRole('option').length).toBe(SAMPLE.length);
+    });
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+    });
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Enter' });
+    });
+    expect(onPick).toHaveBeenCalledWith(SAMPLE[1]);
+  });
+
+  it('renders the missing-cwd warning glyph when cwdMissing is true', () => {
+    renderPopover({ cwdMissing: true });
+    // The trigger gains the warning aria-label on its inner glyph.
+    expect(screen.getByLabelText(/missing/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Why

PR #94 added a recent-cwd typeahead inside `SessionCreateDialog`. PR #106 dropped that dialog in favor of in-place session creation, which silently took the typeahead with it — leaving the OS folder picker as the only way to switch a session's `cwd`. Switching to a project you already use in Claude (i.e., something already in `~/.claude/projects`) became a folder-tree click-fest.

## What

Restore the typeahead, but mount it on the existing StatusBar `cwd` chip so it lives where `cwd` is already displayed:

- Click the chip → popover opens with an editable input (seeded with the current `cwd`) and a list of recent cwds from `window.agentory.recentCwds()` (the IPC main-process eager-scans on boot, max 10).
- Substring filter (case-insensitive, no fuzzy). Arrow keys + Enter to pick. Esc / outside click to close.
- A `Browse folder…` entry at the bottom keeps the native picker as a fallback.
- The `cwdMissing` flag from PR #106 surfaces as a dim warning glyph on the trigger with a tooltip explaining the directory is gone.
- `App.tsx`'s `onChangeCwd` is split into `onChangeCwdToPath` (used by popover picks) and `onBrowseForCwd` (used by the Browse button).
- New i18n keys `cwdPopover.{placeholder,recent,empty,browse,cwdMissingShort,cwdMissingTooltip}` for `en` + `zh`.

No new npm deps. Positioning is a simple absolute layout anchored to the chip with a mousedown click-outside listener, matching the `SlashCommandPicker` pattern already in the codebase.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `tests/cwd-popover.test.tsx` — 10/10 green (covers open, filter, click-pick, Browse, Esc, empty hint, ArrowDown+Enter, missing-cwd glyph)
- [x] `tests/i18n-key-parity.test.ts` green
- [ ] Manual: click cwd chip → popover opens with current cwd in input, recent list shown
- [ ] Manual: type a substring → list filters; clear input → full list returns
- [ ] Manual: click an entry → session cwd switches; chip label updates
- [ ] Manual: Browse… → native folder dialog opens; pick → cwd switches
- [ ] Manual: Esc / click outside → popover closes without switching

Pre-existing failures in `electron/__tests__/db.test.ts` and `tests/endpoints-manager.test.ts` are environmental (`better-sqlite3` Node ABI mismatch on host) and unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)