### PR TITLE
feat: seed new-session cwd + model from CLI history

### DIFF
--- a/electron/import-scanner.ts
+++ b/electron/import-scanner.ts
@@ -9,6 +9,7 @@ export type ScannableSession = {
   title: string;
   mtime: number;
   projectDir: string;
+  model: string | null;
 };
 
 const PROJECTS_ROOT = path.join(os.homedir(), '.claude', 'projects');
@@ -47,7 +48,8 @@ export async function scanImportableSessions(): Promise<ScannableSession[]> {
           cwd: head.cwd,
           title: head.title,
           mtime: stat.mtimeMs,
-          projectDir: dir
+          projectDir: dir,
+          model: head.model
         });
       } catch {
         // skip unreadable / malformed files
@@ -59,7 +61,7 @@ export async function scanImportableSessions(): Promise<ScannableSession[]> {
   return out;
 }
 
-type Head = { cwd: string; title: string };
+type Head = { cwd: string; title: string; model: string | null };
 
 function readHead(file: string): Promise<Head | null> {
   return new Promise((resolve) => {
@@ -68,16 +70,17 @@ function readHead(file: string): Promise<Head | null> {
     let cwd = '';
     let aiTitle = '';
     let firstUserText = '';
+    let model: string | null = null;
     let lines = 0;
     const finish = () => {
       rl.removeAllListeners();
       stream.destroy();
       const title = aiTitle || firstUserText || '(untitled session)';
-      if (!cwd && !aiTitle && !firstUserText) {
+      if (!cwd && !aiTitle && !firstUserText && !model) {
         resolve(null);
         return;
       }
-      resolve({ cwd: cwd || '~', title });
+      resolve({ cwd: cwd || '~', title, model });
     };
     rl.on('line', (line) => {
       lines++;
@@ -100,8 +103,11 @@ function readHead(file: string): Promise<Head | null> {
         const txt = extractUserText(d.message);
         if (txt) firstUserText = truncate(txt, 80);
       }
-      if (cwd && aiTitle) {
-        // We've got the best possible title; stop early.
+      if (!model) {
+        const m = extractModel(d);
+        if (m) model = m;
+      }
+      if (cwd && aiTitle && model) {
         finish();
       }
     });
@@ -166,6 +172,7 @@ export function parseHead(lines: string[]): Head | null {
   let cwd = '';
   let aiTitle = '';
   let firstUserText = '';
+  let model: string | null = null;
   for (let i = 0; i < lines.length && i < MAX_HEAD_LINES; i++) {
     const line = lines[i];
     if (!line) continue;
@@ -181,9 +188,55 @@ export function parseHead(lines: string[]): Head | null {
       const txt = extractUserText(d.message);
       if (txt) firstUserText = truncate(txt, 80);
     }
-    if (cwd && aiTitle) break;
+    if (!model) {
+      const m = extractModel(d);
+      if (m) model = m;
+    }
+    if (cwd && aiTitle && model) break;
   }
-  if (!cwd && !aiTitle && !firstUserText) return null;
+  if (!cwd && !aiTitle && !firstUserText && !model) return null;
   const title = aiTitle || firstUserText || '(untitled session)';
-  return { cwd: cwd || '~', title };
+  return { cwd: cwd || '~', title, model };
+}
+
+// CLI transcripts carry the model on assistant frames as `message.model`.
+// Some older / synthetic frames may put it at the top level — accept both.
+function extractModel(d: any): string | null {
+  if (typeof d?.message?.model === 'string' && d.message.model) return d.message.model;
+  if (typeof d?.model === 'string' && d.model) return d.model;
+  return null;
+}
+
+/**
+ * Most-frequently-observed model across the (presumably mtime-sorted) recent
+ * `max` sessions. Ties broken by most-recent occurrence so a model the user
+ * just switched to wins over a stale historical favourite. Returns null on
+ * empty input or when no session carries a model.
+ */
+export function deriveTopModel(
+  sessions: ReadonlyArray<Pick<ScannableSession, 'model' | 'mtime'>>,
+  max = 50
+): string | null {
+  if (sessions.length === 0) return null;
+  const ordered = [...sessions].sort((a, b) => b.mtime - a.mtime).slice(0, max);
+  const counts = new Map<string, number>();
+  const lastSeen = new Map<string, number>();
+  for (const s of ordered) {
+    if (!s.model) continue;
+    counts.set(s.model, (counts.get(s.model) ?? 0) + 1);
+    if (!lastSeen.has(s.model)) lastSeen.set(s.model, s.mtime);
+  }
+  if (counts.size === 0) return null;
+  let best: string | null = null;
+  let bestCount = -1;
+  let bestSeen = -Infinity;
+  for (const [m, c] of counts) {
+    const seen = lastSeen.get(m) ?? 0;
+    if (c > bestCount || (c === bestCount && seen > bestSeen)) {
+      best = m;
+      bestCount = c;
+      bestSeen = seen;
+    }
+  }
+  return best;
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -18,6 +18,7 @@ import { installUpdaterIpc } from './updater';
 import {
   scanImportableSessions,
   deriveRecentCwds,
+  deriveTopModel,
   type ScannableSession,
 } from './import-scanner';
 import { showNotification, type ShowNotificationPayload } from './notifications';
@@ -47,6 +48,7 @@ const isDev = !app.isPackaged;
 // default cwd (via the renderer store) — same goal, no second IPC.
 let importableCache: ScannableSession[] = [];
 let recentCwdsCache: string[] = [];
+let topModelCache: string | null = null;
 let importablePending: Promise<ScannableSession[]> | null = null;
 
 function refreshImportableCache(): Promise<ScannableSession[]> {
@@ -55,6 +57,7 @@ function refreshImportableCache(): Promise<ScannableSession[]> {
     .then((rows) => {
       importableCache = rows;
       recentCwdsCache = deriveRecentCwds(rows);
+      topModelCache = deriveTopModel(rows);
       return rows;
     })
     .catch((err) => {
@@ -84,6 +87,14 @@ async function getRecentCwds(): Promise<string[]> {
   }
   await refreshImportableCache();
   return recentCwdsCache;
+}
+
+async function getTopModel(): Promise<string | null> {
+  if (topModelCache !== null || importableCache.length > 0) {
+    return topModelCache;
+  }
+  await refreshImportableCache();
+  return topModelCache;
 }
 
 // We don't want a visible File/Edit/View menu bar — Agentory is a single-
@@ -463,6 +474,7 @@ app.whenReady().then(() => {
 
   ipcMain.handle('import:scan', () => getImportableSessions());
   ipcMain.handle('import:recentCwds', () => getRecentCwds());
+  ipcMain.handle('import:topModel', () => getTopModel());
 
   // Batched best-effort existence probe for arbitrary filesystem paths.
   // The renderer uses this on hydration to flag sessions whose persisted

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -168,7 +168,7 @@ const api = {
   },
 
   scanImportable: (): Promise<
-    Array<{ sessionId: string; cwd: string; title: string; mtime: number; projectDir: string }>
+    Array<{ sessionId: string; cwd: string; title: string; mtime: number; projectDir: string; model: string | null }>
   > => ipcRenderer.invoke('import:scan'),
 
   /**
@@ -179,6 +179,13 @@ const api = {
    * has nothing usable.
    */
   recentCwds: (): Promise<string[]> => ipcRenderer.invoke('import:recentCwds'),
+
+  /**
+   * Most-frequently-observed model across recent CLI transcripts. Seeds the
+   * new-session model picker on fresh installs / fresh userData where the
+   * persisted `model` field is empty. Null if no model could be derived.
+   */
+  topModel: (): Promise<string | null> => ipcRenderer.invoke('import:topModel'),
 
   /**
    * Best-effort batched existence check. Returns a map keyed by the input

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -170,7 +170,7 @@ declare global {
       onAgentPermissionRequest: (handler: (e: AgentPermissionRequest) => void) => () => void;
 
       scanImportable: () => Promise<
-        Array<{ sessionId: string; cwd: string; title: string; mtime: number; projectDir: string }>
+        Array<{ sessionId: string; cwd: string; title: string; mtime: number; projectDir: string; model: string | null }>
       >;
 
       /**
@@ -180,6 +180,12 @@ declare global {
        * flight or no transcripts are present.
        */
       recentCwds: () => Promise<string[]>;
+
+      /**
+       * Most-frequently-used model across recent CLI transcripts. Seeds the
+       * new-session model default on fresh userData. Null if undeterminable.
+       */
+      topModel: () => Promise<string | null>;
 
       /**
        * Best-effort batched existence check. Returns a map keyed by the

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -153,6 +153,18 @@ type State = {
   sessions: Session[];
   groups: Group[];
   recentProjects: RecentProject[];
+  /**
+   * Recent cwds derived from CLI transcripts at boot — fallback for fresh
+   * userData where `recentProjects` is empty. Not persisted; rederived each
+   * boot from `~/.claude/projects` via `window.agentory.recentCwds()`.
+   */
+  historyRecentCwds: string[];
+  /**
+   * Most-used model across recent CLI transcripts. Same rationale as
+   * `historyRecentCwds` — seeds the new-session model picker on fresh
+   * userData. Null until the boot scan resolves or if undeterminable.
+   */
+  historyTopModel: string | null;
   activeId: string;
   focusedGroupId: string | null;
   model: ModelId;
@@ -366,6 +378,8 @@ export const useStore = create<State & Actions>((set, get) => ({
   sessions: [],
   groups: defaultGroups,
   recentProjects: [],
+  historyRecentCwds: [],
+  historyTopModel: null,
   activeId: '',
   focusedGroupId: null,
   model: '',
@@ -429,6 +443,8 @@ export const useStore = create<State & Actions>((set, get) => ({
       activeId,
       model,
       recentProjects,
+      historyRecentCwds,
+      historyTopModel,
       defaultEndpointId,
       modelsByEndpoint,
       endpoints,
@@ -445,12 +461,12 @@ export const useStore = create<State & Actions>((set, get) => ({
       ? activeGroupId!
       : firstUsableGroupId(groups);
     const id = nextId('s');
-    const defaultCwd = recentProjects[0]?.path ?? '~';
+    const defaultCwd =
+      recentProjects[0]?.path ?? historyRecentCwds[0] ?? '~';
     const endpointId =
       defaultEndpointId ?? endpoints.find((e) => e.isDefault)?.id ?? endpoints[0]?.id;
-    // Pick a sensible initial model: global `model` if set, else the default
-    // endpoint's first discovered model, else empty (user picks on first send).
     let initialModel = model;
+    if (!initialModel) initialModel = historyTopModel ?? '';
     if (!initialModel && endpointId) {
       initialModel = modelsByEndpoint[endpointId]?.[0]?.modelId ?? '';
     }
@@ -1085,6 +1101,26 @@ export async function hydrateStore(): Promise<void> {
       ),
     }));
   })();
+
+  // Seed history-derived defaults from CLI transcripts. Fresh Electron
+  // userData starts with empty `recentProjects` and no `model`; without this
+  // the new-session picker falls back to `~` and the first endpoint's first
+  // model regardless of what the user actually uses in the CLI.
+  try {
+    const api = window.agentory;
+    if (api?.recentCwds && api?.topModel) {
+      const [recentCwds, topModel] = await Promise.all([
+        api.recentCwds(),
+        api.topModel(),
+      ]);
+      useStore.setState({
+        historyRecentCwds: Array.isArray(recentCwds) ? recentCwds : [],
+        historyTopModel: typeof topModel === 'string' ? topModel : null,
+      });
+    }
+  } catch {
+    /* IPC unavailable — boot continues with empty defaults */
+  }
 
   // Load endpoints + models from the main process. Keeps the IPC round-trip
   // off the critical path for reading persisted state, but still runs before

--- a/tests/import-scanner.test.ts
+++ b/tests/import-scanner.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseHead, deriveRecentCwds } from '../electron/import-scanner';
+import { parseHead, deriveRecentCwds, deriveTopModel } from '../electron/import-scanner';
 
 const j = (o: unknown) => JSON.stringify(o);
 
@@ -17,7 +17,7 @@ describe('parseHead', () => {
       j({ type: 'user', cwd: '/p', message: { content: [{ type: 'text', text: 'hello' }] } }),
       j({ type: 'ai-title', aiTitle: 'A nice title' })
     ]);
-    expect(head).toEqual({ cwd: '/p', title: 'A nice title' });
+    expect(head).toEqual({ cwd: '/p', title: 'A nice title', model: null });
   });
 
   it('falls back to first user text when no ai-title', () => {
@@ -25,7 +25,7 @@ describe('parseHead', () => {
       j({ type: 'queue-operation' }),
       j({ type: 'user', cwd: '/p', message: { content: [{ type: 'text', text: 'do the thing' }] } })
     ]);
-    expect(head).toEqual({ cwd: '/p', title: 'do the thing' });
+    expect(head).toEqual({ cwd: '/p', title: 'do the thing', model: null });
   });
 
   it('skips slash-command wrapped user text', () => {
@@ -61,12 +61,12 @@ describe('parseHead', () => {
 
   it('uses ~ as cwd when none seen', () => {
     const head = parseHead([j({ type: 'ai-title', aiTitle: 'X' })]);
-    expect(head).toEqual({ cwd: '~', title: 'X' });
+    expect(head).toEqual({ cwd: '~', title: 'X', model: null });
   });
 
   it('falls back to (untitled) only when ai-title and user-text are absent but cwd present', () => {
     const head = parseHead([j({ type: 'queue-operation', cwd: '/p' })]);
-    expect(head).toEqual({ cwd: '/p', title: '(untitled session)' });
+    expect(head).toEqual({ cwd: '/p', title: '(untitled session)', model: null });
   });
 
   it('ignores malformed json lines', () => {
@@ -136,5 +136,79 @@ describe('deriveRecentCwds', () => {
       mtime: 1000 - i,
     }));
     expect(deriveRecentCwds(sessions)).toHaveLength(10);
+  });
+});
+
+describe('parseHead model extraction', () => {
+  it('extracts model from message.model on assistant frames', () => {
+    const head = parseHead([
+      j({ type: 'user', cwd: '/p', message: { role: 'user', content: 'hello' } }),
+      j({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'hi' }],
+          model: 'claude-haiku-4.5',
+        },
+      }),
+    ]);
+    expect(head?.model).toBe('claude-haiku-4.5');
+  });
+
+  it('also accepts top-level model field', () => {
+    const head = parseHead([
+      j({ type: 'user', cwd: '/p', message: { content: 'hi' } }),
+      j({ type: 'system', model: 'claude-sonnet-4.5' }),
+    ]);
+    expect(head?.model).toBe('claude-sonnet-4.5');
+  });
+});
+
+describe('deriveTopModel', () => {
+  it('returns null on empty input', () => {
+    expect(deriveTopModel([])).toBeNull();
+  });
+
+  it('returns null when no entry has a model', () => {
+    expect(
+      deriveTopModel([
+        { model: null, mtime: 1 },
+        { model: null, mtime: 2 },
+      ])
+    ).toBeNull();
+  });
+
+  it('returns the most-frequent model', () => {
+    expect(
+      deriveTopModel([
+        { model: 'claude-sonnet-4.5', mtime: 100 },
+        { model: 'claude-haiku-4.5', mtime: 90 },
+        { model: 'claude-haiku-4.5', mtime: 80 },
+        { model: 'claude-haiku-4.5', mtime: 70 },
+        { model: 'claude-sonnet-4.5', mtime: 60 },
+      ])
+    ).toBe('claude-haiku-4.5');
+  });
+
+  it('breaks ties by most-recent occurrence', () => {
+    expect(
+      deriveTopModel([
+        { model: 'claude-sonnet-4.5', mtime: 200 },
+        { model: 'claude-haiku-4.5', mtime: 100 },
+        { model: 'claude-sonnet-4.5', mtime: 50 },
+        { model: 'claude-haiku-4.5', mtime: 10 },
+      ])
+    ).toBe('claude-sonnet-4.5');
+  });
+
+  it('honours the max window — older entries past the cap are ignored', () => {
+    const sessions = [
+      { model: 'recent-model', mtime: 500 },
+      ...Array.from({ length: 60 }, (_, i) => ({
+        model: 'old-model',
+        mtime: 100 - i,
+      })),
+    ];
+    expect(deriveTopModel(sessions, 1)).toBe('recent-model');
   });
 });


### PR DESCRIPTION
## Context

Verifying the app with a fresh isolated `--user-data-dir` exposes two papercuts on the new-session path: with empty Electron userData both defaults are wrong.

- **cwd** falls back to `~` because `recentProjects` is the persisted (userData-backed) list and is empty.
- **model** falls back to whatever happens to be `modelsByEndpoint[endpointId][0]` because `state.model` (also persisted) is empty.

Meanwhile main already eagerly scans `~/.claude/projects` at app `ready` for the import dialog, so the data we need is sitting right there — just never connected to the renderer's createSession path.

## What changed

- `electron/import-scanner.ts` — head parser also extracts `message.model` from assistant frames (verified shape against a real jsonl); new `deriveTopModel(sessions, max=50)` returns the most-frequent model with ties broken by recency.
- `electron/main.ts` — `recentCwdsCache` derivation extended with `topModelCache`; new `import:topModel` IPC + `getTopModel()` reuses the same cache.
- `electron/preload.ts` + `src/global.d.ts` — `window.agentory.topModel(): Promise<string | null>`.
- `src/stores/store.ts`:
  - New non-persisted state `historyRecentCwds: string[]` / `historyTopModel: string | null`.
  - `hydrateStore` awaits `recentCwds()` + `topModel()` in parallel between the persisted setState and `reloadEndpoints`. Wrapped in try/catch so IPC unavailability doesn't block boot.
  - `createSession` fallback chains:
    - `cwd: opts.cwd -> recentProjects[0] -> historyRecentCwds[0] -> '~'`
    - `model: persisted.model -> historyTopModel -> modelsByEndpoint[endpointId][0] -> ''`
  - Persisted `recentProjects` still wins so the user's manual cwd picks survive; history is the fallback for fresh installs / new userData.

## How to verify

- [ ] Launch with a brand new `--user-data-dir` pointed at an empty folder.
- [ ] Create a new session — its `cwd` should match the most-recent CLI cwd (visible in StatusBar), not `~`.
- [ ] Same session's model picker should show the model you most often use in the CLI, not the alphabetically-first registered model.
- [ ] Existing users with persisted `recentProjects` see no behaviour change (persisted entry still wins).

## Tests

- `tests/import-scanner.test.ts` — `parseHead` now asserts model extraction (`message.model` and top-level `model`); existing `toEqual` shapes updated for the new `model: null` field; new `deriveTopModel` block covers empty input, all-null input, most-frequent, tie-by-recency, and the `max` window cap.
- `npm run typecheck`, `npm test` (578/578), `npm run build` all green locally.

Generated with [Claude Code](https://claude.com/claude-code)