### PR TITLE
fix(sessions): pulse sidebar icon when agent awaits input

### DIFF
--- a/src/agent/lifecycle.ts
+++ b/src/agent/lifecycle.ts
@@ -226,6 +226,12 @@ export function subscribeAgentEvents(): void {
       const isActive = store.activeId === e.sessionId;
       const windowFocused = typeof document !== 'undefined' && document.hasFocus();
       const sessionFocused = isActive && windowFocused;
+      // Pulse the sidebar icon when the user isn't actively watching this
+      // session's chat. Cleared by selectSession on click. Same focus rule as
+      // the OS notification below — if the user has eyes on it, no pulse.
+      if (!sessionFocused) {
+        store.setSessionState(e.sessionId, 'waiting');
+      }
       if (errored || durationMs >= TURN_DONE_THRESHOLD_MS || !sessionFocused) {
         const session = store.sessions.find((s) => s.id === e.sessionId);
         const sessionName = session?.name ?? 'Session';
@@ -260,6 +266,10 @@ export function subscribeAgentEvents(): void {
     store.appendBlocks(req.sessionId, [block]);
     const isBackground = req.sessionId !== store.activeId;
     if (isBackground) {
+      // Pulse the sidebar icon — same signal as turn_done, but raised
+      // immediately because a permission request is the highest-priority
+      // "agent needs you" event.
+      store.setSessionState(req.sessionId, 'waiting');
       const session = store.sessions.find((s) => s.id === req.sessionId);
       let prompt = '';
       if (block.kind === 'question') {

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -264,6 +264,7 @@ type Actions = {
   loadMessages: (sessionId: string) => Promise<void>;
   markStarted: (sessionId: string) => void;
   setRunning: (sessionId: string, running: boolean) => void;
+  setSessionState: (sessionId: string, state: Session['state']) => void;
   markInterrupted: (sessionId: string) => void;
   consumeInterrupted: (sessionId: string) => boolean;
   resolvePermission: (sessionId: string, requestId: string, decision: 'allow' | 'deny') => void;
@@ -867,6 +868,18 @@ export const useStore = create<State & Actions>((set, get) => ({
       if (running) next[sessionId] = true;
       else delete next[sessionId];
       return { runningSessions: next };
+    });
+  },
+
+  setSessionState: (sessionId, state) => {
+    set((s) => {
+      let changed = false;
+      const next = s.sessions.map((x) => {
+        if (x.id !== sessionId || x.state === state) return x;
+        changed = true;
+        return { ...x, state };
+      });
+      return changed ? { sessions: next } : s;
     });
   },
 

--- a/tests/lifecycle.test.ts
+++ b/tests/lifecycle.test.ts
@@ -396,3 +396,59 @@ describe('lifecycle: autopilot watchdog', () => {
     expect(h.sendCalls).toEqual([]);
   });
 });
+
+describe('lifecycle: sidebar pulse on agent waiting for input', () => {
+  function endTurn(h: Harness, sessionId: string) {
+    h.eventHandler({
+      sessionId,
+      message: { type: 'result', subtype: 'success', usage: {}, num_turns: 1, duration_ms: 100 } as never
+    });
+  }
+
+  it("flips a background session's state to 'waiting' when its turn ends", async () => {
+    const h = await freshHarness();
+    h.store.getState().createSession('~/active');
+    const activeId = h.store.getState().activeId;
+    h.store.getState().createSession('~/bg');
+    const bgId = h.store.getState().sessions[0].id;
+    h.store.getState().selectSession(activeId);
+
+    endTurn(h, bgId);
+
+    const bg = h.store.getState().sessions.find((s) => s.id === bgId);
+    expect(bg?.state).toBe('waiting');
+  });
+
+  it("does not flip the focused session's state when its turn ends", async () => {
+    const h = await freshHarness();
+    if ((globalThis as unknown as { document?: Document }).document) {
+      (globalThis as unknown as { document: Document }).document.hasFocus = () => true;
+    }
+    h.store.getState().createSession('~/only');
+    const sid = h.store.getState().activeId;
+
+    endTurn(h, sid);
+
+    const s = h.store.getState().sessions.find((x) => x.id === sid);
+    expect(s?.state).toBe('idle');
+  });
+
+  it("flips state to 'waiting' on a background permission request", async () => {
+    const h = await freshHarness();
+    h.store.getState().createSession('~/active');
+    const activeId = h.store.getState().activeId;
+    h.store.getState().createSession('~/bg');
+    const bgId = h.store.getState().sessions[0].id;
+    h.store.getState().selectSession(activeId);
+
+    h.permHandler({
+      sessionId: bgId,
+      requestId: 'req-pulse',
+      toolName: 'Bash',
+      input: { command: 'ls' }
+    });
+
+    const bg = h.store.getState().sessions.find((s) => s.id === bgId);
+    expect(bg?.state).toBe('waiting');
+  });
+});

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -271,6 +271,20 @@ describe('store: setRunning', () => {
   });
 });
 
+describe('store: setSessionState', () => {
+  it("flips a session's state and is a no-op when value matches", () => {
+    useStore.getState().createSession('~/a');
+    const sid = useStore.getState().activeId;
+    expect(useStore.getState().sessions.find((x) => x.id === sid)?.state).toBe('idle');
+    useStore.getState().setSessionState(sid, 'waiting');
+    const before = useStore.getState().sessions;
+    expect(before.find((x) => x.id === sid)?.state).toBe('waiting');
+    useStore.getState().setSessionState(sid, 'waiting');
+    // Same value → array reference must not change (downstream selectors rely on this).
+    expect(useStore.getState().sessions).toBe(before);
+  });
+});
+
 describe('store: streamAssistantText + appendBlocks coalesce', () => {
   it('streamAssistantText creates a streaming assistant block on first delta', () => {
     useStore.getState().streamAssistantText('s1', 'msg-1:c0', 'Hel', false);


### PR DESCRIPTION
## Summary

The sidebar icon was supposed to pulse amber when an agent finished a turn and was awaiting user input. The pulse code in `AgentIcon` (gates on `state === 'waiting'`) is correct, but **nothing in the runtime ever set `Session.state` to `'waiting'`** — lifecycle only tracked turn state via the separate `runningSessions` map. The `'waiting'` value was effectively dead; it only ever fired for the seed mock data.

## Where the bug lived

`src/agent/lifecycle.ts` — `result` handler called `setRunning(false)` but did not touch `Session.state`. Same for the permission-request handler.

## What changed

- `src/stores/store.ts`: added `setSessionState(sessionId, state)` action (no-op when value matches, so React selectors don't churn).
- `src/agent/lifecycle.ts`:
  - On `result`, mark the session `'waiting'` when it's not focused (same `!sessionFocused` rule already used for OS notification dispatch — if the user has eyes on it, no pulse).
  - On permission/question requests for non-active sessions, mark `'waiting'` immediately (highest-priority "needs you" signal).

`selectSession` already flips waiting -> idle on click, so the pulse self-resolves the moment the user looks at the session. No other state machine touched.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` — 582 passed (added 4 new tests: `setSessionState` no-op semantics; result on background session sets waiting; result on focused session leaves idle; background permission request sets waiting)
- [x] `npm run build`
- [ ] Manual: open a session, send a message, switch to another session before it finishes, wait — the original session's sidebar icon pulses amber until you click it.

Generated with [Claude Code](https://claude.com/claude-code)