### PR TITLE
feat(settings): cleanup memory/data/shortcuts + protocol field + autopilot UX

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -375,7 +375,6 @@ app.whenReady().then(() => {
   // Expose for agent:start below.
   (global as unknown as { __agentoryEndpointEnv?: typeof resolveSessionEndpointEnv }).__agentoryEndpointEnv =
     resolveSessionEndpointEnv;
-  ipcMain.handle('app:getDataDir', () => app.getPath('userData'));
   ipcMain.handle('app:getVersion', () => app.getVersion());
 
   ipcMain.handle('dialog:pickDirectory', async () => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -124,7 +124,6 @@ const api = {
     ipcRenderer.invoke('db:loadMessages', sessionId),
   saveMessages: (sessionId: string, blocks: Array<{ id: string; kind: string }>): Promise<void> =>
     ipcRenderer.invoke('db:saveMessages', sessionId, blocks),
-  getDataDir: (): Promise<string> => ipcRenderer.invoke('app:getDataDir'),
   getVersion: (): Promise<string> => ipcRenderer.invoke('app:getVersion'),
   pickDirectory: (): Promise<string | null> => ipcRenderer.invoke('dialog:pickDirectory'),
 

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -140,6 +140,8 @@ export function InputBar({ sessionId }: { sessionId: string }) {
   const markStarted = useStore((s) => s.markStarted);
   const setRunning = useStore((s) => s.setRunning);
   const resetWatchdogCount = useStore((s) => s.resetWatchdogCount);
+  const watchdogEnabled = useStore((s) => s.watchdog.enabled);
+  const setWatchdog = useStore((s) => s.setWatchdog);
   const markInterrupted = useStore((s) => s.markInterrupted);
   const focusInputNonce = useStore((s) => s.focusInputNonce);
   // True iff there's a pending permission/plan/question prompt for this
@@ -645,6 +647,27 @@ export function InputBar({ sessionId }: { sessionId: string }) {
             )}
           >
             <ImagePlus size={14} className="stroke-[2.25]" />
+          </button>
+          <button
+            type="button"
+            onClick={() => setWatchdog({ enabled: !watchdogEnabled })}
+            aria-pressed={watchdogEnabled}
+            aria-label={`Autopilot ${watchdogEnabled ? 'on' : 'off'}`}
+            title={
+              watchdogEnabled
+                ? 'Autopilot on — auto-replies when the agent stops without the done token. Click to disable.'
+                : 'Autopilot off — click to enable auto-replies when the agent stalls.'
+            }
+            className={cn(
+              'inline-flex h-6 items-center px-1.5 rounded-sm text-[10px] font-mono uppercase tracking-wider',
+              'transition-[background-color,color,border-color] duration-150 ease-out',
+              'outline-none focus-visible:ring-1 focus-visible:ring-border-strong active:scale-95',
+              watchdogEnabled
+                ? 'bg-accent/15 text-accent border border-accent/40 hover:bg-accent/20'
+                : 'bg-transparent text-fg-tertiary border border-border-default hover:text-fg-primary hover:bg-bg-hover'
+            )}
+          >
+            Autopilot
           </button>
           {attachments.length > 0 && (
             <span className="font-mono text-[10px] uppercase tracking-wider text-fg-tertiary">

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -29,32 +29,17 @@ type LocalUpdateStatus =
   | { kind: 'downloaded'; version: string }
   | { kind: 'error'; message: string };
 
-type Tab = 'appearance' | 'memory' | 'notifications' | 'endpoints' | 'autopilot' | 'permissions' | 'data' | 'shortcuts' | 'updates';
+type Tab = 'appearance' | 'notifications' | 'endpoints' | 'autopilot' | 'permissions' | 'updates';
 
 // Tab catalog. Labels are i18n keys under `settings:tabs.*` rather than
 // literal strings, so the nav re-renders when the user flips language.
 const TABS: { id: Tab; tabKey: string }[] = [
   { id: 'appearance', tabKey: 'appearance' },
-  { id: 'memory', tabKey: 'memory' },
   { id: 'notifications', tabKey: 'notifications' },
   { id: 'endpoints', tabKey: 'endpoints' },
   { id: 'autopilot', tabKey: 'autopilot' },
   { id: 'permissions', tabKey: 'permissions' },
-  { id: 'data', tabKey: 'data' },
-  { id: 'shortcuts', tabKey: 'shortcuts' },
   { id: 'updates', tabKey: 'updates' }
-];
-
-// Shortcut catalog mirrors mvp-design.md §11. Keep in sync when adding keys.
-const SHORTCUTS: { keys: string; desc: string }[] = [
-  { keys: '⌘K', desc: 'Search / Command Palette' },
-  { keys: '⌘,', desc: 'Settings' },
-  { keys: '⌘N', desc: 'New session' },
-  { keys: '⌘⇧N', desc: 'New group' },
-  { keys: '⌘B', desc: 'Toggle sidebar' },
-  { keys: 'Enter', desc: 'Send message' },
-  { keys: '⇧Enter', desc: 'Newline in input' },
-  { keys: 'Esc', desc: 'Close dialog / cancel rename' }
 ];
 
 export function SettingsDialog({
@@ -109,13 +94,10 @@ export function SettingsDialog({
           </nav>
           <div className="flex-1 min-w-0 p-5 overflow-y-auto">
             {tab === 'appearance' && <AppearancePane />}
-            {tab === 'memory' && <MemoryPane />}
             {tab === 'notifications' && <NotificationsPane />}
             {tab === 'endpoints' && <EndpointsPane />}
             {tab === 'autopilot' && <AutopilotPane />}
             {tab === 'permissions' && <PermissionsPane />}
-            {tab === 'data' && <DataPane />}
-            {tab === 'shortcuts' && <ShortcutsPane />}
             {tab === 'updates' && <UpdatesPane />}
           </div>
         </div>
@@ -276,211 +258,6 @@ function Segmented<T extends string>({
   );
 }
 
-function MemoryPane() {
-  const sessions = useStore((s) => s.sessions);
-  const activeId = useStore((s) => s.activeId);
-  const active = sessions.find((s) => s.id === activeId);
-  const cwd = active?.cwd ?? '';
-  const [projectPath, setProjectPath] = useState<string | null>(null);
-  const [userPath, setUserPath] = useState<string>('');
-
-  useEffect(() => {
-    const api = window.agentory;
-    if (!api) return;
-    api.memory.userPath().then(setUserPath).catch(() => setUserPath(''));
-  }, []);
-
-  useEffect(() => {
-    const api = window.agentory;
-    if (!api) return;
-    api.memory.projectPath(cwd).then(setProjectPath).catch(() => setProjectPath(null));
-  }, [cwd]);
-
-  return (
-    <div className="flex flex-col gap-5">
-      <div className="text-xs text-fg-tertiary">
-        CLAUDE.md files bias what the agent remembers between turns. Project
-        memory travels with the repo; user memory is global to your machine.
-        Writes here save directly to disk — no reload needed.
-      </div>
-      {projectPath ? (
-        <MemoryEditor
-          title="Project memory"
-          hint="Committed with the repo. Visible to anyone with access to the codebase."
-          path={projectPath}
-        />
-      ) : (
-        <div className="rounded-sm border border-border-subtle bg-bg-elevated px-3 py-4 text-xs text-fg-tertiary opacity-70">
-          <div className="font-medium text-fg-secondary mb-1">Project memory</div>
-          Open a session to edit project memory.
-        </div>
-      )}
-      {userPath && (
-        <MemoryEditor
-          title="User memory"
-          hint="Applies to every session on this machine, regardless of repo."
-          path={userPath}
-        />
-      )}
-    </div>
-  );
-}
-
-function MemoryEditor({
-  title,
-  hint,
-  path,
-}: {
-  title: string;
-  hint: string;
-  path: string;
-}) {
-  const [content, setContent] = useState<string>('');
-  const [exists, setExists] = useState<boolean>(false);
-  const [loading, setLoading] = useState<boolean>(true);
-  const [dirty, setDirty] = useState<boolean>(false);
-  const [saving, setSaving] = useState<boolean>(false);
-  const [error, setError] = useState<string | null>(null);
-  const [savedTick, setSavedTick] = useState<number>(0);
-
-  const reload = React.useCallback(async () => {
-    const api = window.agentory;
-    if (!api) return;
-    setLoading(true);
-    setError(null);
-    const res = await api.memory.read(path);
-    setLoading(false);
-    if (!res.ok) {
-      setError(res.error);
-      return;
-    }
-    setContent(res.content);
-    setExists(res.exists);
-    setDirty(false);
-  }, [path]);
-
-  useEffect(() => {
-    void reload();
-  }, [reload]);
-
-  const save = React.useCallback(async () => {
-    const api = window.agentory;
-    if (!api) return;
-    if (!dirty || saving) return;
-    setSaving(true);
-    setError(null);
-    const res = await api.memory.write(path, content);
-    setSaving(false);
-    if (!res.ok) {
-      setError(res.error);
-      return;
-    }
-    setExists(true);
-    setDirty(false);
-    setSavedTick(Date.now());
-  }, [dirty, saving, path, content]);
-
-  // Rough token estimate. For MVP we use the common length/4 heuristic —
-  // the real count varies by tokenizer but is close enough for a "this
-  // file is getting long" cue. If the user cares, they'll feel it.
-  const estTokens = Math.ceil(content.length / 4);
-
-  return (
-    <div className="rounded-sm border border-border-subtle bg-bg-elevated">
-      <div className="flex items-center justify-between px-3 py-2 border-b border-border-subtle gap-3">
-        <div className="min-w-0 flex-1">
-          <div className="text-sm font-medium text-fg-primary">{title}</div>
-          <div
-            className="text-[11px] font-mono text-fg-tertiary truncate"
-            title={path}
-          >
-            {path}
-          </div>
-        </div>
-        <div className="flex items-center gap-2 shrink-0">
-          <span
-            className={cn(
-              'text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded-sm font-mono',
-              estTokens > 8000
-                ? 'bg-status-warning-muted text-status-warning-foreground'
-                : 'bg-bg-hover text-fg-tertiary'
-            )}
-            title="Rough estimate (chars / 4). Not a real tokenizer."
-          >
-            ~{estTokens.toLocaleString()} tok
-          </span>
-          {!exists && !loading && (
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={async () => {
-                const api = window.agentory;
-                if (!api) return;
-                const res = await api.memory.write(path, content || '');
-                if (!res.ok) setError(res.error);
-                else {
-                  setExists(true);
-                  setDirty(false);
-                }
-              }}
-            >
-              Create
-            </Button>
-          )}
-          <Button
-            variant="primary"
-            size="sm"
-            onClick={save}
-            disabled={!dirty || saving}
-            title={dirty ? 'Save' : 'No changes'}
-          >
-            {saving ? 'Saving…' : dirty ? 'Save' : 'Saved'}
-          </Button>
-        </div>
-      </div>
-      <div className="px-3 pt-2 pb-3">
-        <div className="text-[11px] text-fg-tertiary mb-1.5">{hint}</div>
-        <textarea
-          value={content}
-          onChange={(e) => {
-            setContent(e.target.value);
-            setDirty(true);
-          }}
-          onBlur={() => void save()}
-          disabled={loading}
-          spellCheck={false}
-          rows={10}
-          placeholder={exists ? '' : 'This file will be created on save.'}
-          className={cn(
-            'w-full px-2.5 py-2 rounded-sm bg-bg-panel border border-border-default',
-            'text-xs font-mono leading-relaxed text-fg-primary placeholder:text-fg-disabled',
-            'outline-none resize-y',
-            'focus:border-border-strong focus:shadow-[0_0_0_2px_var(--color-focus-ring)]',
-            'disabled:opacity-60 disabled:cursor-progress'
-          )}
-        />
-        <div className="flex items-center justify-between mt-1.5 h-4">
-          <span className="text-[11px] text-fg-tertiary">
-            {loading
-              ? 'Loading…'
-              : error
-              ? <span className="text-status-error-foreground">{error}</span>
-              : !exists
-              ? 'Not yet created on disk.'
-              : dirty
-              ? 'Unsaved changes.'
-              : savedTick > 0
-              ? 'Saved.'
-              : ''}
-          </span>
-          <span className="text-[11px] text-fg-tertiary tabular-nums">
-            {content.length.toLocaleString()} chars
-          </span>
-        </div>
-      </div>
-    </div>
-  );
-}
 
 function NotificationsPane() {
   const settings = useStore((s) => s.notificationSettings);
@@ -627,7 +404,7 @@ function AutopilotPane() {
       </Field>
       <Field
         label="Otherwise…"
-        hint="Appended after '如果你真的做完了，请回复我：<token>。\\n\\n否则：' in the auto-reply."
+        hint="Appended after the prompt asking the agent to reply with the done token (line break separates). Use to nudge it to keep going."
       >
         <textarea
           value={watchdog.otherwisePostfix}
@@ -945,47 +722,6 @@ function arraysEqualSet(a: readonly string[], b: readonly string[]): boolean {
 // resetPermissionRules() but kept visible so a future PR that wants to diff
 // against "known empty" doesn't have to hunt. Pure doc aid; no behavior.
 void EMPTY_PERMISSION_RULES;
-
-function DataPane() {
-  const [dataDir, setDataDir] = useState<string>('Loading…');
-  useEffect(() => {
-    window.agentory?.getDataDir().then(setDataDir).catch(() => setDataDir('(unavailable)'));
-  }, []);
-  return (
-    <>
-      <Field label="Data directory" hint="Where Agentory stores groups, sessions, and preferences.">
-        <code className="block px-2 py-1.5 rounded-sm bg-bg-elevated border border-border-subtle text-xs text-fg-secondary font-mono break-all">
-          {dataDir}
-        </code>
-      </Field>
-      <Field label="Claude sessions directory" hint="Read-only. Managed by Claude Code SDK.">
-        <code className="block px-2 py-1.5 rounded-sm bg-bg-elevated border border-border-subtle text-xs text-fg-secondary font-mono">
-          {'~/.claude/projects/'}
-        </code>
-      </Field>
-    </>
-  );
-}
-
-function ShortcutsPane() {
-  return (
-    <div>
-      <div className="text-xs text-fg-tertiary mb-3">
-        Keybindings are fixed in MVP — remapping adds maintenance burden without clear user value.
-      </div>
-      <ul className="divide-y divide-border-subtle">
-        {SHORTCUTS.map((s) => (
-          <li key={s.keys} className="flex items-center justify-between h-8 text-sm">
-            <span className="text-fg-secondary">{s.desc}</span>
-            <kbd className="font-mono text-xs px-1.5 py-0.5 rounded-sm border border-border-subtle bg-bg-elevated text-fg-tertiary">
-              {s.keys}
-            </kbd>
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-}
 
 function UpdatesPane() {
   const [version, setVersion] = useState<string>('…');
@@ -1432,7 +1168,10 @@ function EndpointEditorDialog({
               autoFocus
             />
           </Field>
-          <Field label="Base URL" hint="Agentory appends /v1/models. Paste the root or include /v1.">
+          <Field label="Protocol">
+            <span className="text-sm text-fg-secondary">Anthropic-compatible (REST)</span>
+          </Field>
+          <Field label="Base URL" hint="Paste the API root, e.g. https://api.anthropic.com — Agentory uses it as-is for /v1/messages and probes /v1/models for discovery.">
             <input
               type="text"
               value={baseUrl}
@@ -1440,28 +1179,6 @@ function EndpointEditorDialog({
               placeholder="https://api.anthropic.com"
               className={cn(inputClass, 'font-mono')}
             />
-          </Field>
-          <Field label="Protocol">
-            <div className="flex items-center gap-3 text-sm">
-              <label className="inline-flex items-center gap-1.5 cursor-pointer">
-                <input type="radio" checked readOnly className="accent-accent" />
-                <span className="text-fg-primary">Anthropic</span>
-              </label>
-              <label
-                title="Phase 2 — not yet supported"
-                className="inline-flex items-center gap-1.5 opacity-50 cursor-not-allowed"
-              >
-                <input type="radio" disabled className="accent-accent" />
-                <span>OpenAI-compatible</span>
-              </label>
-              <label
-                title="Phase 2 — not yet supported"
-                className="inline-flex items-center gap-1.5 opacity-50 cursor-not-allowed"
-              >
-                <input type="radio" disabled className="accent-accent" />
-                <span>Ollama</span>
-              </label>
-            </div>
           </Field>
           <Field
             label="API key (optional)"

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -149,7 +149,6 @@ declare global {
       saveState: (key: string, value: string) => Promise<void>;
       loadMessages: (sessionId: string) => Promise<unknown[]>;
       saveMessages: (sessionId: string, blocks: Array<{ id: string; kind: string }>) => Promise<void>;
-      getDataDir: () => Promise<string>;
       getVersion: () => Promise<string>;
       pickDirectory: () => Promise<string | null>;
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -140,13 +140,10 @@ const en = {
     tabs: {
       general: 'General',
       appearance: 'Appearance',
-      memory: 'Memory',
       notifications: 'Notifications',
       endpoints: 'Endpoints',
       autopilot: 'Autopilot',
       permissions: 'Permissions',
-      data: 'Data',
-      shortcuts: 'Shortcuts',
       updates: 'Updates'
     },
     theme: 'Theme',
@@ -173,24 +170,8 @@ const en = {
     apiKeyHint: 'Stored in OS keychain. Required for Claude Code sessions.',
     apiKeyPlaceholder: 'sk-ant-…',
     testConnection: 'Test connection',
-    dataDirectory: 'Data directory',
-    dataDirectoryHint: 'Where Agentory stores groups, sessions, and preferences.',
-    claudeSessionsDirectory: 'Claude sessions directory',
-    claudeSessionsDirectoryHint: 'Read-only. Managed by Claude Code SDK.',
-    shortcutsHint:
-      'Keybindings are fixed in MVP — remapping adds maintenance burden without clear user value.',
     version: 'Version',
-    checkForUpdates: 'Check for updates',
-    shortcutDescriptions: {
-      palette: 'Search / Command Palette',
-      settings: 'Settings',
-      newSession: 'New session',
-      newGroup: 'New group',
-      toggleSidebar: 'Toggle sidebar',
-      send: 'Send message',
-      newline: 'Newline in input',
-      escape: 'Close dialog / cancel rename'
-    }
+    checkForUpdates: 'Check for updates'
   },
   permissions: {
     promptTitle: 'Permission requested',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -134,13 +134,10 @@ const zh: EnCatalog = {
     tabs: {
       general: '通用',
       appearance: '外观',
-      memory: '记忆',
       notifications: '通知',
       endpoints: '端点',
       autopilot: '自动驾驶',
       permissions: '权限',
-      data: '数据',
-      shortcuts: '快捷键',
       updates: '更新'
     },
     theme: '主题',
@@ -167,23 +164,8 @@ const zh: EnCatalog = {
     apiKeyHint: '保存在系统钥匙串中。运行 Claude Code 会话所必需。',
     apiKeyPlaceholder: 'sk-ant-…',
     testConnection: '测试连接',
-    dataDirectory: '数据目录',
-    dataDirectoryHint: 'Agentory 存放分组、会话和偏好的位置。',
-    claudeSessionsDirectory: 'Claude 会话目录',
-    claudeSessionsDirectoryHint: '只读。由 Claude Code SDK 管理。',
-    shortcutsHint: 'MVP 阶段快捷键固定 — 自定义带来的维护成本不抵价值。',
     version: '版本',
-    checkForUpdates: '检查更新',
-    shortcutDescriptions: {
-      palette: '搜索 / 命令面板',
-      settings: '设置',
-      newSession: '新会话',
-      newGroup: '新建分组',
-      toggleSidebar: '切换侧边栏',
-      send: '发送消息',
-      newline: '在输入框换行',
-      escape: '关闭对话框 / 取消重命名'
-    }
+    checkForUpdates: '检查更新'
   },
   permissions: {
     promptTitle: '请求权限',

--- a/src/slash-commands/ui-bridge.ts
+++ b/src/slash-commands/ui-bridge.ts
@@ -8,13 +8,10 @@
 
 export type SettingsTab =
   | 'appearance'
-  | 'memory'
   | 'notifications'
   | 'endpoints'
   | 'autopilot'
   | 'permissions'
-  | 'data'
-  | 'shortcuts'
   | 'updates';
 
 type Listener = (tab?: SettingsTab) => void;


### PR DESCRIPTION
## Summary

Owner-maintainer feedback round on Settings. All changes share `SettingsDialog.tsx`, so they ship as one PR.

### Changes mapped to feedback items

1. **Drop the Memory tab** — pane, helpers (`MemoryEditor`), tab dispatch, i18n keys (`settings.tabs.memory`). The `agentory.memory` IPC surface stays — it backed only this pane but is harmless, and removing it is broader scope.
2. **Drop the Data tab** — pane, tab dispatch, i18n keys (`dataDirectory*`, `claudeSessionsDirectory*`), plus the `app:getDataDir` IPC handler in `electron/main.ts`, the preload binding, and the `Window.agentory.getDataDir` declaration in `src/global.d.ts`.
3. **Drop the Shortcuts tab** — pane, the `SHORTCUTS` array, tab dispatch, i18n keys (`shortcutsHint`, `shortcutDescriptions`).
4. **Endpoint form: Protocol field** — replaced the half-built radio group (one selected, two disabled) with a non-interactive plain-text row reading `Anthropic-compatible (REST)`, placed between Name and Base URL. The on-save `kind: 'anthropic'` stays hardcoded.
5. **Endpoint form: Base URL hint** — rewritten to describe what the API root is used for: `/v1/messages` direct, `/v1/models` for discovery. URL-joining code in `electron/endpoints-manager.ts` is unchanged.
6. **Autopilot pane fix + InputBar toggle**
   - Removed the CN-mixed `"Otherwise…"` hint that contained literal Chinese and `\n\n` escape artifacts; replaced with a clean English description.
   - Added an `Autopilot` pill toggle next to the attach button in `InputBar.tsx`. Reads `watchdog.enabled` from the store and toggles via `setWatchdog`. Accent-tinted when on, neutral when off.

## Test plan

- [ ] Open Settings; verify Memory, Data, and Shortcuts tabs are gone; remaining tabs render normally.
- [ ] Open the endpoint editor; verify Name → Protocol (read-only `Anthropic-compatible (REST)`) → Base URL (with the new hint) → API key order.
- [ ] Open the Autopilot pane; verify the Otherwise hint reads in English with no escape artifacts.
- [ ] In the input bar, click the new `Autopilot` pill; verify it tints accent, persists across reload, and matches the Autopilot pane checkbox state.
- [ ] `npm run typecheck`, `npm test`, `npm run build` — all green locally.

## Verification commands run

- `npm run typecheck` — clean
- `npm test` — 578/578 passing (after `npm rebuild better-sqlite3` to fix a NODE_MODULE_VERSION mismatch from the worktree's pre-built native binding)
- `npm run build` — webpack + electron tsc both succeed