### PR TITLE
feat(sessions): focus input + expand group on new session

### DIFF
--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -481,11 +481,22 @@ export const useStore = create<State & Actions>((set, get) => ({
       agentType: 'claude-code',
       endpointId,
     };
-    set({
+    // If the target group is currently collapsed, expand it in the same
+    // atomic update so the new row is visible the moment activeId flips.
+    // Bumping focusInputNonce here mirrors selectSession — clicking
+    // "New Session" should also land focus in the composer.
+    const targetGroup = groups.find((g) => g.id === targetGroupId);
+    const nextGroups =
+      targetGroup && targetGroup.collapsed
+        ? groups.map((g) => (g.id === targetGroupId ? { ...g, collapsed: false } : g))
+        : groups;
+    set((s) => ({
       sessions: [newSession, ...sessions],
       activeId: id,
-      focusedGroupId: null
-    });
+      focusedGroupId: null,
+      groups: nextGroups,
+      focusInputNonce: s.focusInputNonce + 1
+    }));
   },
 
   renameSession: (id, name) => {

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -85,6 +85,21 @@ describe('store: createSession', () => {
     expect(s.cwd).toBe('/tmp/repo');
     expect(s.name).toBe('Spike');
   });
+
+  it('expands the target group when it was collapsed', () => {
+    const gid = useStore.getState().createGroup('Hidden');
+    useStore.getState().setGroupCollapsed(gid, true);
+    useStore.getState().focusGroup(gid);
+    useStore.getState().createSession(null);
+    const g = useStore.getState().groups.find((x) => x.id === gid);
+    expect(g?.collapsed).toBe(false);
+  });
+
+  it('bumps focusInputNonce so the InputBar pulls focus', () => {
+    const before = useStore.getState().focusInputNonce;
+    useStore.getState().createSession('~/a');
+    expect(useStore.getState().focusInputNonce).toBe(before + 1);
+  });
 });
 
 describe('store: deleteSession', () => {


### PR DESCRIPTION
## Summary

Clicking **New Session** (sidebar button, command palette, or any future entry point that calls `createSession`) now does three things atomically in a single store update:

1. **Active session** — the new row becomes active (`activeId = id`). _Already worked; preserved._
2. **Input focus** — `focusInputNonce` is bumped, so `InputBar`'s existing `useEffect` pulls focus into the textarea. Same mechanism `selectSession` uses for sidebar clicks.
3. **Group expand** — if the target group was collapsed, it is flipped to expanded in the same `set({...})` call, so the new row is visible the moment `activeId` flips. No race where the input is focused but the group is still folded.

All three land in one `set` call inside `createSession` — no split updates.

## Files

- `src/stores/store.ts` — extended `createSession`'s single `set` to also flip target group's `collapsed: false` (when needed) and bump `focusInputNonce`. `InputBar` already focuses on `focusInputNonce` change, so no renderer-side change was needed.
- `tests/store.test.ts` — two new tests: collapsed target group expands; `focusInputNonce` bumps on create.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (584/584 pass; including 2 new)
- [x] `npm run build`
- [ ] Manual: collapse a group, click **New Session** while that group is the active group's parent — group expands, new row highlighted, cursor in composer.
- [ ] Manual: open command palette, run **New Session** — same three behaviors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)