### PR TITLE
style(sidebar): tighten top spacing

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -557,7 +557,7 @@ export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, active
               bg-bg-sidebar/80 + backdrop-blur, so the buttons read as
               "frosted glass on frosted glass" without ever transparent-ing
               to the desktop. */}
-          <div className="px-3 pt-3 pb-2 flex items-center gap-2">
+          <div className="px-3 pt-1 pb-2 flex items-center gap-2">
             <NewSessionButton onCreateSession={onCreateSession} />
             <IconButton
               variant="raised"


### PR DESCRIPTION
## Summary
The sidebar's action zone (New Session button + Search button) sat 12px below the 32px drag region, leaving a visibly empty band at the top of the sidebar. Reduced the wrapper padding from `pt-3` (12px) to `pt-1` (4px) so the button sits snugly under the drag region.

- Before: 12px gap between drag region and New Session button
- After: 4px gap
- Drag region (32px) preserved so Windows users can still drag-to-move the window

Only the expanded sidebar's action row was changed; the collapsed rail's `py-3` is untouched (different concern, would also affect bottom Settings spacing).

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (584/584)
- [x] `npm run build` passes
- [ ] Visual: dev server restart by manager, confirm New Session button sits ~4px under the OS title bar / drag region