### PR TITLE
refactor: drop autopilot feature

### DIFF
--- a/src/agent/lifecycle.ts
+++ b/src/agent/lifecycle.ts
@@ -22,76 +22,6 @@ function streamerFor(sessionId: string): PartialAssistantStreamer {
   return s;
 }
 
-// Auto-prompt watchdog: when a session finishes a turn without uttering the
-// configured "done token", reply on the user's behalf so the agent keeps
-// going. Capped per-session so a runaway loop can't spam the SDK.
-function maybeFireWatchdog(sessionId: string): void {
-  const store = useStore.getState();
-  const cfg = store.watchdog;
-  if (!cfg.enabled) return;
-
-  // Don't fire while a permission prompt is pending — the agent isn't really
-  // idle, it's waiting on the user to approve a tool call.
-  const blocks = store.messagesBySession[sessionId] ?? [];
-  const hasPendingPermission = blocks.some(
-    (b) => (b.kind === 'waiting' && b.requestId) || (b.kind === 'question' && b.requestId)
-  );
-  if (hasPendingPermission) return;
-
-  // If the latest non-info signal is an error or rate-limit / API failure,
-  // bail too — auto-replying into a broken session just spams the SDK and
-  // racks up failed turns. The user needs to intervene.
-  for (let i = blocks.length - 1; i >= 0; i--) {
-    const b = blocks[i];
-    if (b.kind === 'error') return;
-    if (b.kind === 'status' && b.tone === 'warn') return;
-    if (b.kind === 'assistant') break;
-    if (b.kind === 'user') break;
-  }
-
-  // Find the last assistant text block. Streaming blocks count too — by the
-  // time `result` lands, streaming has been finalized (streaming flag false).
-  let lastAssistantText = '';
-  for (let i = blocks.length - 1; i >= 0; i--) {
-    const b = blocks[i];
-    if (b.kind === 'assistant') {
-      lastAssistantText = b.text;
-      break;
-    }
-  }
-  if (lastAssistantText.includes(cfg.doneToken)) return;
-
-  const count = store.watchdogCountsBySession[sessionId] ?? 0;
-  // maxAutoReplies <= 0 means unlimited.
-  if (cfg.maxAutoReplies > 0 && count >= cfg.maxAutoReplies) {
-    store.appendBlocks(sessionId, [
-      {
-        kind: 'status',
-        id: `watchdog-cap-${Date.now().toString(36)}`,
-        tone: 'warn',
-        title: 'Autopilot paused',
-        detail: `Reached ${cfg.maxAutoReplies} auto-replies without the done token; over to you.`
-      }
-    ]);
-    return;
-  }
-
-  const next = store.bumpWatchdogCount(sessionId);
-  const cap = cfg.maxAutoReplies > 0 ? `${cfg.maxAutoReplies}` : '∞';
-  const prompt = `如果你真的做完了，请回复我：${cfg.doneToken}\n\n否则：${cfg.otherwisePostfix}`;
-  store.appendBlocks(sessionId, [
-    {
-      kind: 'status',
-      id: `watchdog-${Date.now().toString(36)}`,
-      tone: 'info',
-      title: `Autopilot ${next}/${cap}`,
-      detail: 'Sent automatic follow-up because the agent stopped without the done token.'
-    }
-  ]);
-  void window.agentory?.agentSend(sessionId, prompt);
-  store.setRunning(sessionId, true);
-}
-
 type BackgroundWaitingHandler = (info: { sessionId: string; sessionName: string; prompt: string }) => void;
 let backgroundWaitingHandler: BackgroundWaitingHandler = () => {};
 
@@ -246,7 +176,6 @@ export function subscribeAgentEvents(): void {
           body
         });
       }
-      maybeFireWatchdog(e.sessionId);
     }
   });
 

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -139,9 +139,6 @@ export function InputBar({ sessionId }: { sessionId: string }) {
   const appendBlocks = useStore((s) => s.appendBlocks);
   const markStarted = useStore((s) => s.markStarted);
   const setRunning = useStore((s) => s.setRunning);
-  const resetWatchdogCount = useStore((s) => s.resetWatchdogCount);
-  const watchdogEnabled = useStore((s) => s.watchdog.enabled);
-  const setWatchdog = useStore((s) => s.setWatchdog);
   const markInterrupted = useStore((s) => s.markInterrupted);
   const focusInputNonce = useStore((s) => s.focusInputNonce);
   // True iff there's a pending permission/plan/question prompt for this
@@ -390,8 +387,6 @@ export function InputBar({ sessionId }: { sessionId: string }) {
     setAttachmentsAndCache([]);
     setRejections([]);
     setRunning(sessionId, true);
-    // A real human turn resets the autopilot counter.
-    resetWatchdogCount(sessionId);
 
     if (!started) {
       const endpointId = session.endpointId ?? defaultEndpointId ?? undefined;
@@ -647,27 +642,6 @@ export function InputBar({ sessionId }: { sessionId: string }) {
             )}
           >
             <ImagePlus size={14} className="stroke-[2.25]" />
-          </button>
-          <button
-            type="button"
-            onClick={() => setWatchdog({ enabled: !watchdogEnabled })}
-            aria-pressed={watchdogEnabled}
-            aria-label={`Autopilot ${watchdogEnabled ? 'on' : 'off'}`}
-            title={
-              watchdogEnabled
-                ? 'Autopilot on — auto-replies when the agent stops without the done token. Click to disable.'
-                : 'Autopilot off — click to enable auto-replies when the agent stalls.'
-            }
-            className={cn(
-              'inline-flex h-6 items-center px-1.5 rounded-sm text-[10px] font-mono uppercase tracking-wider',
-              'transition-[background-color,color,border-color] duration-150 ease-out',
-              'outline-none focus-visible:ring-1 focus-visible:ring-border-strong active:scale-95',
-              watchdogEnabled
-                ? 'bg-accent/15 text-accent border border-accent/40 hover:bg-accent/20'
-                : 'bg-transparent text-fg-tertiary border border-border-default hover:text-fg-primary hover:bg-bg-hover'
-            )}
-          >
-            Autopilot
           </button>
           {attachments.length > 0 && (
             <span className="font-mono text-[10px] uppercase tracking-wider text-fg-tertiary">

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -29,7 +29,7 @@ type LocalUpdateStatus =
   | { kind: 'downloaded'; version: string }
   | { kind: 'error'; message: string };
 
-type Tab = 'appearance' | 'notifications' | 'endpoints' | 'autopilot' | 'permissions' | 'updates';
+type Tab = 'appearance' | 'notifications' | 'endpoints' | 'permissions' | 'updates';
 
 // Tab catalog. Labels are i18n keys under `settings:tabs.*` rather than
 // literal strings, so the nav re-renders when the user flips language.
@@ -37,7 +37,6 @@ const TABS: { id: Tab; tabKey: string }[] = [
   { id: 'appearance', tabKey: 'appearance' },
   { id: 'notifications', tabKey: 'notifications' },
   { id: 'endpoints', tabKey: 'endpoints' },
-  { id: 'autopilot', tabKey: 'autopilot' },
   { id: 'permissions', tabKey: 'permissions' },
   { id: 'updates', tabKey: 'updates' }
 ];
@@ -96,7 +95,6 @@ export function SettingsDialog({
             {tab === 'appearance' && <AppearancePane />}
             {tab === 'notifications' && <NotificationsPane />}
             {tab === 'endpoints' && <EndpointsPane />}
-            {tab === 'autopilot' && <AutopilotPane />}
             {tab === 'permissions' && <PermissionsPane />}
             {tab === 'updates' && <UpdatesPane />}
           </div>
@@ -361,73 +359,6 @@ function NotificationsPane() {
         </Button>
         {testStatus && <span className="text-xs text-fg-secondary">{testStatus}</span>}
       </div>
-    </>
-  );
-}
-
-function AutopilotPane() {
-  const watchdog = useStore((s) => s.watchdog);
-  const setWatchdog = useStore((s) => s.setWatchdog);
-  const inputClass = cn(
-    'w-full h-8 px-2 rounded-sm bg-bg-elevated border border-border-default',
-    'text-sm text-fg-primary placeholder:text-fg-disabled outline-none',
-    'focus:border-border-strong focus:shadow-[0_0_0_2px_var(--color-focus-ring)]'
-  );
-  return (
-    <>
-      <div className="text-xs text-fg-tertiary mb-4">
-        When an agent finishes a turn without saying the done token, Agentory
-        will reply on your behalf so it doesn&apos;t sit idle. Capped per session
-        to keep runaway loops in check.
-      </div>
-      <Field label="Enable autopilot" hint="Auto-reply when the agent stops without the done token.">
-        <label className="inline-flex items-center gap-2 cursor-pointer select-none">
-          <input
-            type="checkbox"
-            checked={watchdog.enabled}
-            onChange={(e) => setWatchdog({ enabled: e.target.checked })}
-            className="h-4 w-4 accent-accent"
-          />
-          <span className="text-sm text-fg-secondary">{watchdog.enabled ? 'On' : 'Off'}</span>
-        </label>
-      </Field>
-      <Field
-        label="Done token"
-        hint="If the agent's last message contains this exact string, autopilot stops for the turn."
-      >
-        <input
-          type="text"
-          value={watchdog.doneToken}
-          onChange={(e) => setWatchdog({ doneToken: e.target.value })}
-          className={inputClass}
-        />
-      </Field>
-      <Field
-        label="Otherwise…"
-        hint="Appended after the prompt asking the agent to reply with the done token (line break separates). Use to nudge it to keep going."
-      >
-        <textarea
-          value={watchdog.otherwisePostfix}
-          onChange={(e) => setWatchdog({ otherwisePostfix: e.target.value })}
-          rows={3}
-          className={cn(inputClass, 'h-auto py-2 resize-y leading-snug')}
-        />
-      </Field>
-      <Field
-        label="Max auto-replies per session"
-        hint="Resets when you send a real message. 0 = unlimited (use with care). Default 20."
-      >
-        <input
-          type="number"
-          min={0}
-          value={watchdog.maxAutoReplies}
-          onChange={(e) => {
-            const n = Number.parseInt(e.target.value, 10);
-            if (Number.isFinite(n) && n >= 0) setWatchdog({ maxAutoReplies: n });
-          }}
-          className={cn(inputClass, 'w-24')}
-        />
-      </Field>
     </>
   );
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -142,7 +142,6 @@ const en = {
       appearance: 'Appearance',
       notifications: 'Notifications',
       endpoints: 'Endpoints',
-      autopilot: 'Autopilot',
       permissions: 'Permissions',
       updates: 'Updates'
     },

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -136,7 +136,6 @@ const zh: EnCatalog = {
       appearance: '外观',
       notifications: '通知',
       endpoints: '端点',
-      autopilot: '自动驾驶',
       permissions: '权限',
       updates: '更新'
     },

--- a/src/slash-commands/ui-bridge.ts
+++ b/src/slash-commands/ui-bridge.ts
@@ -10,7 +10,6 @@ export type SettingsTab =
   | 'appearance'
   | 'notifications'
   | 'endpoints'
-  | 'autopilot'
   | 'permissions'
   | 'updates';
 

--- a/src/stores/persist.ts
+++ b/src/stores/persist.ts
@@ -5,7 +5,6 @@ import type {
   FontSize,
   FontSizePx,
   Density,
-  WatchdogConfig,
   NotificationSettings
 } from './store';
 import type { RecentProject } from '../mock/data';
@@ -33,7 +32,6 @@ export interface PersistedState {
   density?: Density;
   recentProjects?: RecentProject[];
   tutorialSeen?: boolean;
-  watchdog?: WatchdogConfig;
   /**
    * Default endpoint id for new sessions. Persisted so the user's pick survives
    * restarts. Falls back to the endpoint with is_default=1 if missing.

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -78,26 +78,8 @@ export interface ModelInfo {
   existsConfirmed: boolean;
 }
 
-// Auto-prompt watchdog: when an agent stops without uttering the done token,
-// the lifecycle replies for the user so the agent doesn't sit idle. Tunables
-// live in user settings; per-session counts cap how many auto-replies fire
-// before a human must actually weigh in.
-export interface WatchdogConfig {
-  enabled: boolean;
-  doneToken: string;
-  otherwisePostfix: string;
-  maxAutoReplies: number;
-}
-
-export const DEFAULT_WATCHDOG: WatchdogConfig = {
-  enabled: false,
-  doneToken: '我真的已经做完了',
-  otherwisePostfix: '继续做，别问我任何事，你来做决策。',
-  maxAutoReplies: 20
-};
-
 // OS-level notification preferences. Persisted as a single JSON blob alongside
-// the rest of app state — same envelope as `watchdog`.
+// the rest of app state.
 export interface NotificationSettings {
   enabled: boolean;
   permission: boolean;
@@ -182,8 +164,6 @@ type State = {
   fontSizePx: FontSizePx;
   density: Density;
   tutorialSeen: boolean;
-  watchdog: WatchdogConfig;
-  watchdogCountsBySession: Record<string, number>;
   notificationSettings: NotificationSettings;
   messagesBySession: Record<string, MessageBlock[]>;
   startedSessions: Record<string, true>;
@@ -243,9 +223,6 @@ type Actions = {
   setDensity: (density: Density) => void;
   setSidebarWidthPct: (pct: number) => void;
   markTutorialSeen: () => void;
-  setWatchdog: (patch: Partial<WatchdogConfig>) => void;
-  resetWatchdogCount: (sessionId: string) => void;
-  bumpWatchdogCount: (sessionId: string) => number;
   setNotificationSettings: (patch: Partial<NotificationSettings>) => void;
   setSessionNotificationsMuted: (sessionId: string, muted: boolean) => void;
 
@@ -392,8 +369,6 @@ export const useStore = create<State & Actions>((set, get) => ({
   fontSizePx: 14,
   density: 'normal',
   tutorialSeen: false,
-  watchdog: DEFAULT_WATCHDOG,
-  watchdogCountsBySession: {},
   notificationSettings: DEFAULT_NOTIFICATION_SETTINGS,
   messagesBySession: {},
   startedSessions: {},
@@ -659,26 +634,6 @@ export const useStore = create<State & Actions>((set, get) => ({
     set({ sidebarWidthPct: clamped });
   },
   markTutorialSeen: () => set({ tutorialSeen: true }),
-
-  setWatchdog: (patch) =>
-    set((s) => ({ watchdog: { ...s.watchdog, ...patch } })),
-
-  resetWatchdogCount: (sessionId) =>
-    set((s) => {
-      if (!(sessionId in s.watchdogCountsBySession)) return s;
-      const next = { ...s.watchdogCountsBySession };
-      delete next[sessionId];
-      return { watchdogCountsBySession: next };
-    }),
-
-  bumpWatchdogCount: (sessionId) => {
-    const cur = get().watchdogCountsBySession[sessionId] ?? 0;
-    const nextN = cur + 1;
-    set((s) => ({
-      watchdogCountsBySession: { ...s.watchdogCountsBySession, [sessionId]: nextN }
-    }));
-    return nextN;
-  },
 
   setNotificationSettings: (patch) =>
     set((s) => ({ notificationSettings: { ...s.notificationSettings, ...patch } })),
@@ -1077,7 +1032,6 @@ export async function hydrateStore(): Promise<void> {
       density: sanitizeDensity(persisted.density),
       recentProjects: persisted.recentProjects ?? [],
       tutorialSeen: persisted.tutorialSeen ?? false,
-      watchdog: { ...DEFAULT_WATCHDOG, ...(persisted.watchdog ?? {}) },
       defaultEndpointId: persisted.defaultEndpointId ?? null,
       notificationSettings: {
         ...DEFAULT_NOTIFICATION_SETTINGS,
@@ -1171,7 +1125,6 @@ export async function hydrateStore(): Promise<void> {
       density: s.density,
       recentProjects: s.recentProjects,
       tutorialSeen: s.tutorialSeen,
-      watchdog: s.watchdog,
       defaultEndpointId: s.defaultEndpointId,
       notificationSettings: s.notificationSettings,
       permissionRules: s.permissionRules

--- a/tests/lifecycle.test.ts
+++ b/tests/lifecycle.test.ts
@@ -18,7 +18,6 @@ type Harness = {
   store: typeof import('../src/stores/store').useStore;
   setBackgroundWaitingHandler: typeof import('../src/agent/lifecycle').setBackgroundWaitingHandler;
   notifyCalls: Array<{ sessionId: string; title: string; body?: string }>;
-  sendCalls: Array<{ sessionId: string; text: string }>;
 };
 
 async function freshHarness(): Promise<Harness> {
@@ -29,7 +28,6 @@ async function freshHarness(): Promise<Harness> {
   let eventHandler: ((e: AgentEvent) => void) | null = null;
   let exitHandler: ((e: AgentExit) => void) | null = null;
   const notifyCalls: Array<{ sessionId: string; title: string; body?: string }> = [];
-  const sendCalls: Array<{ sessionId: string; text: string }> = [];
   (globalThis as unknown as { window: { agentory: unknown } }).window = {
     agentory: {
       onAgentEvent: (h: (e: AgentEvent) => void) => {
@@ -47,10 +45,6 @@ async function freshHarness(): Promise<Harness> {
       notify: async (payload: { sessionId: string; title: string; body?: string }) => {
         notifyCalls.push(payload);
         return true;
-      },
-      agentSend: async (sessionId: string, text: string) => {
-        sendCalls.push({ sessionId, text });
-        return true;
       }
     }
   };
@@ -66,8 +60,7 @@ async function freshHarness(): Promise<Harness> {
     exitHandler,
     store: storeMod.useStore,
     setBackgroundWaitingHandler: lifecycle.setBackgroundWaitingHandler,
-    notifyCalls,
-    sendCalls
+    notifyCalls
   };
 }
 
@@ -282,118 +275,6 @@ describe('lifecycle: background waiting bridge', () => {
     if (orig && (globalThis as unknown as { document?: Document }).document) {
       (globalThis as unknown as { document: Document }).document.hasFocus = orig;
     }
-  });
-});
-
-describe('lifecycle: autopilot watchdog', () => {
-  function endTurn(h: Harness, sessionId: string) {
-    h.eventHandler({
-      sessionId,
-      message: { type: 'result', subtype: 'success', usage: {}, num_turns: 1, duration_ms: 100 } as never
-    });
-  }
-
-  it('does NOTHING when watchdog disabled', async () => {
-    const h = await freshHarness();
-    h.store.getState().createSession('~/x');
-    const sid = h.store.getState().activeId;
-    h.store.getState().appendBlocks(sid, [{ kind: 'assistant', id: 'a1', text: 'short reply' }]);
-    endTurn(h, sid);
-    expect(h.sendCalls).toEqual([]);
-  });
-
-  it('does NOTHING when last assistant message contains the done token', async () => {
-    const h = await freshHarness();
-    h.store.getState().setWatchdog({ enabled: true, doneToken: 'DONE!' });
-    h.store.getState().createSession('~/x');
-    const sid = h.store.getState().activeId;
-    h.store.getState().appendBlocks(sid, [{ kind: 'assistant', id: 'a1', text: 'all DONE! goodbye' }]);
-    endTurn(h, sid);
-    expect(h.sendCalls).toEqual([]);
-  });
-
-  it('auto-replies with the configured prompt when token absent', async () => {
-    const h = await freshHarness();
-    h.store.getState().setWatchdog({
-      enabled: true,
-      doneToken: 'DONE!',
-      otherwisePostfix: 'KEEP GOING'
-    });
-    h.store.getState().createSession('~/x');
-    const sid = h.store.getState().activeId;
-    h.store.getState().appendBlocks(sid, [{ kind: 'assistant', id: 'a1', text: 'should I continue?' }]);
-    endTurn(h, sid);
-    expect(h.sendCalls).toHaveLength(1);
-    expect(h.sendCalls[0].sessionId).toBe(sid);
-    expect(h.sendCalls[0].text).toContain('DONE!');
-    expect(h.sendCalls[0].text).toContain('KEEP GOING');
-    // Counter incremented and a status block appended.
-    expect(h.store.getState().watchdogCountsBySession[sid]).toBe(1);
-    const blocks = h.store.getState().messagesBySession[sid];
-    expect(blocks.some((b) => b.kind === 'status' && b.title?.startsWith('Autopilot 1/'))).toBe(true);
-  });
-
-  it('skips when a permission request is pending', async () => {
-    const h = await freshHarness();
-    h.store.getState().setWatchdog({ enabled: true });
-    h.store.getState().createSession('~/x');
-    const sid = h.store.getState().activeId;
-    h.store.getState().appendBlocks(sid, [
-      { kind: 'assistant', id: 'a1', text: 'no token here' },
-      { kind: 'waiting', id: 'w1', prompt: 'Bash: ls', intent: 'permission', requestId: 'req-1' }
-    ]);
-    endTurn(h, sid);
-    expect(h.sendCalls).toEqual([]);
-  });
-
-  it('stops after maxAutoReplies and posts a paused status', async () => {
-    const h = await freshHarness();
-    h.store.getState().setWatchdog({ enabled: true, doneToken: 'ZZZTOKEN', maxAutoReplies: 2 });
-    h.store.getState().createSession('~/x');
-    const sid = h.store.getState().activeId;
-    h.store.getState().appendBlocks(sid, [{ kind: 'assistant', id: 'a1', text: 'no token in this reply' }]);
-    endTurn(h, sid);
-    endTurn(h, sid);
-    endTurn(h, sid); // third should be capped
-    expect(h.sendCalls).toHaveLength(2);
-    const blocks = h.store.getState().messagesBySession[sid];
-    expect(blocks.some((b) => b.kind === 'status' && b.title === 'Autopilot paused')).toBe(true);
-  });
-
-  it('treats maxAutoReplies <= 0 as unlimited', async () => {
-    const h = await freshHarness();
-    h.store.getState().setWatchdog({ enabled: true, doneToken: 'ZZZTOKEN', maxAutoReplies: 0 });
-    h.store.getState().createSession('~/x');
-    const sid = h.store.getState().activeId;
-    h.store.getState().appendBlocks(sid, [{ kind: 'assistant', id: 'a1', text: 'no token' }]);
-    for (let i = 0; i < 5; i++) endTurn(h, sid);
-    expect(h.sendCalls).toHaveLength(5);
-  });
-
-  it('skips when the latest signal is an error block', async () => {
-    const h = await freshHarness();
-    h.store.getState().setWatchdog({ enabled: true });
-    h.store.getState().createSession('~/x');
-    const sid = h.store.getState().activeId;
-    h.store.getState().appendBlocks(sid, [
-      { kind: 'assistant', id: 'a1', text: 'no token' },
-      { kind: 'error', id: 'e1', text: 'rate limit' }
-    ]);
-    endTurn(h, sid);
-    expect(h.sendCalls).toEqual([]);
-  });
-
-  it('skips when the latest signal is a warn status (e.g. api_retry)', async () => {
-    const h = await freshHarness();
-    h.store.getState().setWatchdog({ enabled: true });
-    h.store.getState().createSession('~/x');
-    const sid = h.store.getState().activeId;
-    h.store.getState().appendBlocks(sid, [
-      { kind: 'assistant', id: 'a1', text: 'no token' },
-      { kind: 'status', id: 's1', tone: 'warn', title: 'Rate limit hit' }
-    ]);
-    endTurn(h, sid);
-    expect(h.sendCalls).toEqual([]);
   });
 });
 

--- a/tests/notifications-dispatch.test.ts
+++ b/tests/notifications-dispatch.test.ts
@@ -237,7 +237,6 @@ describe('notification settings persistence', () => {
       fontSize: s.fontSize,
       recentProjects: s.recentProjects,
       tutorialSeen: s.tutorialSeen,
-      watchdog: s.watchdog,
       notificationSettings: s.notificationSettings
     };
     const json = JSON.parse(JSON.stringify(snapshot));


### PR DESCRIPTION
## Summary

Removes the Autopilot (auto-reply watchdog) feature end-to-end.

The watchdog was meant to keep the agent moving when it stopped without uttering a configured "done token", but in practice it:
- fought with permission prompts and error states (mitigated by ad-hoc bail-outs that themselves were brittle),
- shipped a Chinese-only default prompt (`如果你真的做完了，请回复我：…`) that confused English-speaking users,
- duplicated UI surfaces (Settings tab + InputBar pill) without a coherent story for when each was the right entry point.

Cleaner to drop than to redesign inside the MVP timeframe. If we want this capability back later it should be a deliberate redesign, not a continuation of the current surface.

### What's gone

- `SettingsDialog` Autopilot tab + `AutopilotPane` (and the `'autopilot'` `Tab` union member).
- `InputBar` Autopilot toggle pill and the per-turn `resetWatchdogCount` call.
- `useStore` fields `watchdog`, `watchdogCountsBySession`; actions `setWatchdog`, `resetWatchdogCount`, `bumpWatchdogCount`; const `DEFAULT_WATCHDOG`; type `WatchdogConfig`. Removed from initial state, hydrate, and persist write-through.
- `PersistedState.watchdog` (no backwards-compat shim — extra keys in old persisted JSON are simply ignored on load).
- `lifecycle.maybeFireWatchdog` and its `result`-frame call site. Sessions still flip to `waiting` on background turn-done; nothing else changes.
- `SettingsTab` union in `slash-commands/ui-bridge.ts`.
- `settings.tabs.autopilot` from en/zh i18n.
- `tests/lifecycle.test.ts` autopilot watchdog describe block (and the now-unused `sendCalls` / `agentSend` mock plumbing).
- `tests/notifications-dispatch.test.ts` — removed `watchdog: s.watchdog` from the persist snapshot shape assertion.

### Notes

- No migration logic for the dropped persisted field per the project's "no backwards-compat shims for removed persisted fields" rule.
- After removal the lifecycle `result` handler is what the docstring implied all along: record stats, persist messages, optionally pulse + notify, done.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 576 / 576 pass (after `npm rebuild better-sqlite3 --update-binary` for the local node_modules)
- [x] `npm run build` — webpack builds cleanly (only pre-existing bundle-size warnings)