### PR TITLE
style(palette): empty state shows only search input

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -151,11 +151,13 @@ export function CommandPalette({
       }
     ];
     const needle = q.trim().toLowerCase();
-    if (!needle) return all;
+    if (!needle) return [];
     return all.filter(
       (r) => r.label.toLowerCase().includes(needle) || r.hint?.toLowerCase().includes(needle)
     );
   }, [q, sessions, groups, theme, onOpenChange, onNewSession, onOpenSettings, onSelectSession, onFocusGroup, createGroup, toggleSidebar, setTheme, onOpenImport, t]);
+
+  const hasQuery = q.trim().length > 0;
 
   useEffect(() => {
     if (active >= results.length) setActive(0);
@@ -208,33 +210,37 @@ export function CommandPalette({
             </kbd>
           </div>
           <ul className="max-h-[340px] overflow-y-auto py-1" role="listbox">
-            {results.length === 0 && (
+            {!hasQuery && (
+              <li className="px-4 py-6 text-center text-sm text-fg-tertiary">{t('commandPalette.emptyHint')}</li>
+            )}
+            {hasQuery && results.length === 0 && (
               <li className="px-4 py-6 text-center text-sm text-fg-tertiary">{t('commandPalette.noMatches')}</li>
             )}
-            {results.map((r, i) => (
-              <li
-                key={r.id}
-                role="option"
-                aria-selected={i === active}
-                onMouseEnter={() => setActive(i)}
-                onClick={() => r.onPick()}
-                className={cn(
-                  'flex items-center gap-2.5 h-8 px-3 mx-1 rounded-sm cursor-pointer',
-                  'text-sm',
-                  i === active
-                    ? 'bg-bg-hover text-fg-primary surface-highlight'
-                    : 'text-fg-secondary'
-                )}
-              >
-                <span className="shrink-0 inline-flex w-4 justify-center">{r.icon}</span>
-                <span className="flex-1 min-w-0 truncate">{r.label}</span>
-                {r.hint && (
-                  <span className="text-xs text-fg-disabled font-mono tabular-nums truncate max-w-[180px]">
-                    {r.hint}
-                  </span>
-                )}
-              </li>
-            ))}
+            {hasQuery &&
+              results.map((r, i) => (
+                <li
+                  key={r.id}
+                  role="option"
+                  aria-selected={i === active}
+                  onMouseEnter={() => setActive(i)}
+                  onClick={() => r.onPick()}
+                  className={cn(
+                    'flex items-center gap-2.5 h-8 px-3 mx-1 rounded-sm cursor-pointer',
+                    'text-sm',
+                    i === active
+                      ? 'bg-bg-hover text-fg-primary surface-highlight'
+                      : 'text-fg-secondary'
+                  )}
+                >
+                  <span className="shrink-0 inline-flex w-4 justify-center">{r.icon}</span>
+                  <span className="flex-1 min-w-0 truncate">{r.label}</span>
+                  {r.hint && (
+                    <span className="text-xs text-fg-disabled font-mono tabular-nums truncate max-w-[180px]">
+                      {r.hint}
+                    </span>
+                  )}
+                </li>
+              ))}
           </ul>
         </RD.Content>
       </DialogPortal>

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -311,6 +311,7 @@ const en = {
     searchPlaceholder: 'Search sessions, groups, commands…',
     escKey: 'Esc',
     noMatches: 'No matches',
+    emptyHint: 'Type to search sessions, groups, commands…',
     groupHint: 'Group',
     cmdNewSession: 'New session',
     cmdNewGroup: 'New group',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -300,6 +300,7 @@ const zh: EnCatalog = {
     searchPlaceholder: '搜索会话、分组、命令…',
     escKey: 'Esc',
     noMatches: '无匹配项',
+    emptyHint: '输入以搜索会话、分组、命令…',
     groupHint: '分组',
     cmdNewSession: '新会话',
     cmdNewGroup: '新建分组',


### PR DESCRIPTION
## Summary
When the command palette opens, the previous behavior listed every session, group, and built-in command (new session, new group, toggle sidebar, import, settings, switch theme). That was a lot of noise for an interface whose primary use is "type to find a thing".

This PR gates the entire results region on `query.length > 0`. Empty state now shows only the search input plus a single-line hint: `Type to search sessions, groups, commands…` (i18n key `commandPalette.emptyHint`, EN + ZH provided).

The results list element stays mounted (preserves keyboard scope); only its rows are conditional. Arrow / Enter / Esc behavior is unchanged.

## How to verify
- Open the palette (sidebar search button or shortcut)
- Confirm only the search input + hint are visible (no recents, no command list)
- Type one character → results appear and behave as before
- Esc closes; Enter on a highlighted result still navigates

## Checks
- `npm run typecheck`: pass
- `npm test`: 576/576 pass
- `npm run build`: pass