### PR TITLE
feat(sidebar): import button next to settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -207,6 +207,7 @@ export default function App() {
                 onCreateSession={newSession}
                 onOpenSettings={() => setSettingsOpen(true)}
                 onOpenPalette={() => setPaletteOpen(true)}
+                onOpenImport={() => setImportOpen(true)}
                 activeSessionId={activeId}
                 focusedGroupId={focusedGroupId}
                 onSelectSession={selectSession}
@@ -289,6 +290,7 @@ export default function App() {
               onCreateSession={newSession}
               onOpenSettings={() => setSettingsOpen(true)}
               onOpenPalette={() => setPaletteOpen(true)}
+              onOpenImport={() => setImportOpen(true)}
               activeSessionId={activeId}
               focusedGroupId={focusedGroupId}
               onSelectSession={selectSession}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
 import {
   ChevronRight,
+  Download,
   Plus,
   Search,
   Settings,
@@ -411,6 +412,7 @@ export type SidebarProps = {
   onCreateSession?: () => void;
   onOpenSettings?: () => void;
   onOpenPalette?: () => void;
+  onOpenImport?: () => void;
   activeSessionId: string;
   focusedGroupId: string | null;
   onSelectSession: (id: string) => void;
@@ -434,7 +436,7 @@ function NewSessionButton({ onCreateSession }: { onCreateSession?: () => void })
   );
 }
 
-export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, activeSessionId, focusedGroupId, onSelectSession, onFocusGroup, sessions, onMoveSession }: SidebarProps) {
+export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, onOpenImport, activeSessionId, focusedGroupId, onSelectSession, onFocusGroup, sessions, onMoveSession }: SidebarProps) {
   const { t } = useTranslation();
   const groups = useStore((s) => s.groups);
   const createGroup = useStore((s) => s.createGroup);
@@ -536,6 +538,17 @@ export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, active
             <Search size={14} className="stroke-[1.5]" />
           </IconButton>
           <div className="flex-1" />
+          <IconButton
+            variant="raised"
+            size="md"
+            onClick={onOpenImport}
+            tooltip={t('sidebar.importTooltip')}
+            tooltipSide="right"
+            aria-label={t('sidebar.importAriaShort')}
+            className="h-8 w-8"
+          >
+            <Download size={13} className="stroke-[1.5]" />
+          </IconButton>
           <IconButton
             variant="raised"
             size="md"
@@ -647,17 +660,30 @@ export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, active
             </nav>
           )}
 
-          {/* Settings — its own zone at the bottom. */}
-          <div className="px-3 pt-2 pb-3 border-t border-border-subtle">
+          {/* Settings — its own zone at the bottom. Mirrors the top zone's
+              two-button rhythm (flex-1 text Button + fixed-width IconButton)
+              so the sidebar's top and bottom action rows feel symmetrical. */}
+          <div className="px-3 pt-2 pb-3 border-t border-border-subtle flex items-center gap-2">
             <Button
               variant="raised"
               size="md"
               onClick={onOpenSettings}
-              className="w-full h-8 text-xs gap-1.5"
+              className="flex-1 h-8 text-xs gap-1.5"
             >
               <Settings size={13} className="stroke-[1.5]" />
               <span>{t('common.settings')}</span>
             </Button>
+            <IconButton
+              variant="raised"
+              size="md"
+              onClick={onOpenImport}
+              tooltip={t('sidebar.importTooltip')}
+              tooltipSide="top"
+              aria-label={t('sidebar.importAriaShort')}
+              className="h-8 w-8 shrink-0"
+            >
+              <Download size={13} className="stroke-[1.5]" />
+            </IconButton>
           </div>
         </div>
       )}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -127,6 +127,8 @@ const en = {
     newSessionAria: 'New session',
     searchTooltip: 'Search  ⌘K',
     searchAriaShort: 'Search',
+    importTooltip: 'Import session',
+    importAriaShort: 'Import session',
     settingsTooltip: 'Settings  ⌘,',
     settingsAria: 'Settings',
     notificationsMutedAria: 'Notifications muted',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -122,6 +122,8 @@ const zh: EnCatalog = {
     newSessionAria: '新会话',
     searchTooltip: '搜索  ⌘K',
     searchAriaShort: '搜索',
+    importTooltip: '导入会话',
+    importAriaShort: '导入会话',
     settingsTooltip: '设置  ⌘,',
     settingsAria: '设置',
     notificationsMutedAria: '通知已静音',


### PR DESCRIPTION
## Summary
- Bottom action zone now mirrors the top zone's two-button layout: Settings (flex-1 text Button) + Import (w-8 h-8 IconButton with Download icon), matching the New Session + Search pair above. Same gap-2, same h-8, same `variant="raised"`.
- Wire `onOpenImport` through `Sidebar` to the existing `setImportOpen(true)` flow in App.tsx (both render sites).
- Collapsed rail also gains a Download IconButton above Settings so the import action is reachable when the sidebar is collapsed.
- New i18n keys `sidebar.importTooltip` / `sidebar.importAriaShort` in en + zh.

## Rationale
The top of the sidebar has two buttons in a row; the bottom previously had a single full-width Settings button. The asymmetry felt off, and Import Session was only reachable from the empty-state hero / command palette / tutorial. Putting it next to Settings makes the global "manage / bring sessions in" affordance discoverable from the sidebar at all times.

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm test` — 576/576 passes (i18n key parity covered)
- [x] `npm run build` — passes
- [ ] Visual: confirm bottom row reads as a sibling of the top row (same rhythm), Download icon click opens ImportDialog, collapsed rail shows the new icon above Settings.