### PR TITLE
feat(focus): centralized composer focus orchestration

### DIFF
--- a/src/components/ChatStream.tsx
+++ b/src/components/ChatStream.tsx
@@ -742,6 +742,7 @@ function renderBlock(
   b: MessageBlock,
   activeId: string,
   resolvePermission: (sid: string, rid: string, d: 'allow' | 'deny') => void,
+  bumpComposerFocus: () => void,
   opts: { permissionAutoFocus?: boolean } = {}
 ) {
   switch (b.kind) {
@@ -791,6 +792,9 @@ function renderBlock(
               void api.agentResolvePermission(activeId, b.requestId, 'deny');
             }
             void api.agentSend(activeId, answersText);
+            // Return focus to the composer so the user's next keystroke types
+            // into chat instead of being eaten by the now-disabled options.
+            bumpComposerFocus();
           }}
         />
       );
@@ -824,6 +828,7 @@ export function ChatStream() {
   const activeId = useStore((s) => s.activeId);
   const blocks = useStore((s) => s.messagesBySession[activeId] ?? EMPTY_BLOCKS);
   const resolvePermission = useStore((s) => s.resolvePermission);
+  const bumpComposerFocus = useStore((s) => s.bumpComposerFocus);
   const loadMessages = useStore((s) => s.loadMessages);
 
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -894,7 +899,7 @@ export function ChatStream() {
               }
               return blocks.map((m, i) => (
                 <div key={m.id}>
-                  {renderBlock(m, activeId, resolvePermission, {
+                  {renderBlock(m, activeId, resolvePermission, bumpComposerFocus, {
                     permissionAutoFocus: i === lastPermIdx
                   })}
                 </div>

--- a/src/notifications/dispatch.ts
+++ b/src/notifications/dispatch.ts
@@ -106,21 +106,14 @@ export async function dispatchNotification(input: DispatchInput): Promise<Dispat
 }
 
 // Triggered by clicking a notification (main → renderer IPC). Selects the
-// session and tries to focus the input bar so the user can act immediately.
-// The input-focus path piggybacks on the same DOM affordance the sidebar
-// click uses; if the dedicated focusInputNonce pattern lands later from
-// fix/click-session-focus-input, swap to it then.
+// session, which bumps focusInputNonce so the InputBar pulls focus, and
+// scrolls the chat stream to the bottom so the latest activity is visible.
 export function handleNotificationFocus(sessionId: string): void {
   const state = useStore.getState();
   if (!state.sessions.some((s) => s.id === sessionId)) return;
   state.selectSession(sessionId);
-  // TODO: replace with focusInputNonce bump once fix/click-session-focus-input
-  // merges. Until then, find the textarea in the DOM and focus it directly so
-  // the user can type without an extra click.
   if (typeof window === 'undefined') return;
   window.requestAnimationFrame(() => {
-    const ta = document.querySelector<HTMLTextAreaElement>('textarea[data-input-bar]');
-    if (ta) ta.focus();
     const stream = document.querySelector<HTMLElement>('[data-chat-stream]');
     if (stream) stream.scrollTop = stream.scrollHeight;
   });

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -245,6 +245,11 @@ type Actions = {
   markInterrupted: (sessionId: string) => void;
   consumeInterrupted: (sessionId: string) => boolean;
   resolvePermission: (sessionId: string, requestId: string, decision: 'allow' | 'deny') => void;
+  /** Increment `focusInputNonce` to ask the InputBar to take focus. Use after
+   *  any user-driven action in the chat stream that should return focus to the
+   *  composer (question submit, etc.). Permission/plan paths bump implicitly
+   *  via `resolvePermission`. */
+  bumpComposerFocus: () => void;
   addSessionStats: (sessionId: string, delta: Partial<SessionStats>) => void;
 
   setEndpoints: (list: Endpoint[]) => void;
@@ -876,10 +881,20 @@ export const useStore = create<State & Actions>((set, get) => ({
       const next = prev.filter((b) => b.id !== waitId);
       if (next.length === prev.length) return s;
       return {
-        messagesBySession: { ...s.messagesBySession, [sessionId]: next }
+        messagesBySession: { ...s.messagesBySession, [sessionId]: next },
+        // Centralized focus policy: after the user resolves any in-stream
+        // permission/plan prompt, focus returns to the composer so the next
+        // keystroke types into the chat. InputBar's effect guards against
+        // stealing focus from other text-entry surfaces (rename input,
+        // dialog field, IME composition).
+        focusInputNonce: s.focusInputNonce + 1
       };
     });
     void window.agentory?.agentResolvePermission(sessionId, requestId, decision);
+  },
+
+  bumpComposerFocus: () => {
+    set((s) => ({ focusInputNonce: s.focusInputNonce + 1 }));
   },
 
   setEndpoints: (list) => set({ endpoints: list }),

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -539,3 +539,36 @@ describe('store: checkCli / CLI missing flow', () => {
     expect(s.state).toBe('found');
   });
 });
+
+describe('store: composer focus orchestration', () => {
+  it('bumpComposerFocus increments focusInputNonce', () => {
+    const start = useStore.getState().focusInputNonce;
+    useStore.getState().bumpComposerFocus();
+    expect(useStore.getState().focusInputNonce).toBe(start + 1);
+    useStore.getState().bumpComposerFocus();
+    expect(useStore.getState().focusInputNonce).toBe(start + 2);
+  });
+
+  it('resolvePermission bumps focusInputNonce when a matching block is removed', () => {
+    const ipc = vi.fn().mockResolvedValue(true);
+    (globalThis as unknown as { window?: { agentory?: unknown } }).window = {
+      agentory: { agentResolvePermission: ipc }
+    };
+    useStore.getState().createSession('~/a');
+    const sid = useStore.getState().activeId;
+    useStore.getState().appendBlocks(sid, [
+      { kind: 'waiting', id: 'wait-req1', prompt: 'OK?', intent: 'permission', requestId: 'req1' }
+    ]);
+    const before = useStore.getState().focusInputNonce;
+    useStore.getState().resolvePermission(sid, 'req1', 'allow');
+    expect(useStore.getState().focusInputNonce).toBe(before + 1);
+  });
+
+  it('resolvePermission does NOT bump when no matching block exists (no-op fast path)', () => {
+    useStore.getState().createSession('~/a');
+    const sid = useStore.getState().activeId;
+    const before = useStore.getState().focusInputNonce;
+    useStore.getState().resolvePermission(sid, 'no-such', 'deny');
+    expect(useStore.getState().focusInputNonce).toBe(before);
+  });
+});


### PR DESCRIPTION
## Summary
Systematic fix for the chat-composer focus problem. Reported case: after submitting a `QuestionBlock` answer (arrow + Enter), focus did not return to the chat input. Audit found the same gap on `PermissionPromptBlock` and `PlanBlock` resolutions. This PR centralizes the focus-back-to-composer policy through a single store affordance.

## Audit (every focus transition site)

| Site | File:line | Before | After |
|---|---|---|---|
| Click session in sidebar | `store.ts:386` `selectSession` | bumps `focusInputNonce` | unchanged |
| Sidebar arrow+Enter on session | `Sidebar.tsx:291` `SessionRow.onKeyDown` -> `selectSession` | bumps (via selectSession) | unchanged |
| Sidebar arrow nav within list | `Sidebar.tsx:209` `<ul>.onKeyDown` | moves DOM focus between rows | unchanged (intentional) |
| Click "New Session" | `store.ts:410` `createSession` | bumps | unchanged |
| Notification click | `notifications/dispatch.ts:113` -> `selectSession` | bumps + redundant DOM `.focus()` | bumps; redundant DOM call removed |
| Command palette pick session | `CommandPalette.tsx` -> `selectSession` | bumps | unchanged |
| Command palette pick command | -> `createSession` / `createGroup` etc. | bumps where appropriate | unchanged |
| Resolve permission (Allow/Deny) | `ChatStream.tsx:761,772` -> `resolvePermission` | did NOT bump | **bumps** (in `resolvePermission`) |
| Approve / Reject plan | `ChatStream.tsx:761,762` -> `resolvePermission` | did NOT bump | **bumps** (same path) |
| Submit `QuestionBlock` answer | `ChatStream.tsx:780` `onSubmit` | did NOT bump | **bumps** via new `bumpComposerFocus()` |
| Modal open/close (Settings, Import, CommandPalette, ClaudeCliMissing) | Radix Dialog | manages own focus | unchanged |
| Inline rename input in sidebar | `ui/InlineRename.tsx` | manages own focus, InputBar guard skips text-entry surfaces | unchanged |
| App boot | InputBar effect skips first nonce observation | no steal | unchanged |
| Diff hunk accept/reject | n/a (no diff blocks in current codebase) | n/a | n/a |

## Policy (single source of truth)

**Default rule.** After any non-modal interactive submission inside the chat stream, focus returns to the chat composer. The mechanism is a monotonic `focusInputNonce` counter in the Zustand store; `InputBar`'s existing effect watches it and calls `.focus()`, with battle-tested guards for IME composition, modal open, and other text-entry surfaces.

**Two ways to bump:**
1. `resolvePermission(sessionId, requestId, decision)` — bumps when it actually removes a waiting block (so the no-op fast path stays a no-op). Covers PermissionPromptBlock and PlanBlock.
2. `bumpComposerFocus()` — explicit action for sites that don't go through `resolvePermission`. Currently used by `QuestionBlock.onSubmit`.

**Modals & text-entry surfaces:** untouched. The InputBar effect already refuses to steal focus from `INPUT` / `TEXTAREA` / `contenteditable` elsewhere in the DOM, which covers Radix dialogs, the inline rename, and IME state.

## Why not invoke `bumpComposerFocus` everywhere
Folding the bump into `resolvePermission` keeps callers from having to remember the focus contract. New permission/plan UIs added later get the right behavior for free.

## Test plan
- `npm run typecheck` — green.
- `npm test` — 579/579 passing, including the new `store: composer focus orchestration` describe (3 cases) and the existing `selectSession bumps focusInputNonce` and `createSession bumps focusInputNonce` cases.
- `npm run build` — green (only pre-existing bundle-size warnings).

Manual verification:
- [ ] In a running session, when the agent renders an interactive question, use arrow keys to choose an option, press Enter — chat input immediately receives focus.
- [ ] When a permission prompt appears, click Allow or Deny — chat input immediately receives focus.
- [ ] When a plan prompt appears, click Approve or Reject — chat input immediately receives focus.
- [ ] Sidebar: arrow up/down to a session, Enter — chat input immediately receives focus.
- [ ] Open Settings dialog — focus moves into dialog (Radix), close it — focus returns to opener.
- [ ] Inline-rename a session in the sidebar — focus stays in the rename input while typing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)