### PR TITLE
feat(layout): draggable sidebar resizer

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,23 +1,14 @@
 import React from 'react';
-import { Group, Panel, Separator, type PanelSize } from 'react-resizable-panels';
 import { useStore } from '../stores/store';
+import { SidebarResizer } from './SidebarResizer';
 
 /**
  * Two-pane shell with a draggable vertical divider.
  *
- * react-resizable-panels 4.x accepts size strings like `"220px"` / `"22%"`,
- * so we can express sidebar constraints in the units that matter:
- *   - min 220px, max 480px for the sidebar
- *   - min 480px for the chat pane (it's the content-dense side)
- *
- * We persist the sidebar width as a *fraction* of the group width so the
- * layout adapts when the window resizes — on a 1920px monitor, 22% gives
- * the user more sidebar than on 1280px, which matches user expectation
- * (more real estate → more room to see everything).
- *
- * On drag we receive both `inPixels` and `asPercentage` — we store the %
- * value. The library debounces onResize internally; the persist layer
- * (store → schedulePersist) adds another 250ms coalesce.
+ * Sidebar width is persisted in pixels (see store.sidebarWidth) — for a fixed-
+ * content sidebar, px matches user intuition better than a fraction of the
+ * window. The resizer (SidebarResizer) clamps to [200, 480]; double-click
+ * resets to the default. Hidden when the sidebar is collapsed.
  */
 export function AppShell({
   sidebar,
@@ -26,48 +17,13 @@ export function AppShell({
   sidebar: React.ReactNode;
   main: React.ReactNode;
 }) {
-  const sidebarWidthPct = useStore((s) => s.sidebarWidthPct);
-  const setSidebarWidthPct = useStore((s) => s.setSidebarWidthPct);
-
-  // Percent value as a string, which is what the library's defaultSize prop
-  // expects when we want percentage semantics. Clamp to a sane range so a
-  // corrupted persisted state can't wedge the UI at 0%.
-  const defaultSidebarPct = Math.round(
-    Math.max(12, Math.min(40, sidebarWidthPct * 100))
-  );
+  const sidebarCollapsed = useStore((s) => s.sidebarCollapsed);
 
   return (
-    <Group
-      orientation="horizontal"
-      className="app-shell flex h-full w-full bg-bg-app text-fg-primary"
-    >
-      <Panel
-        id="sidebar"
-        defaultSize={`${defaultSidebarPct}%`}
-        minSize="220px"
-        maxSize="480px"
-        onResize={(size: PanelSize) => {
-          // asPercentage ∈ [0..100]; we normalize to the 0..1 fraction our
-          // store uses. Setter clamps again so we never persist an out-of-
-          // range value even if the library miscalculates on edge resizes.
-          setSidebarWidthPct(size.asPercentage / 100);
-        }}
-        className="flex"
-      >
-        {sidebar}
-      </Panel>
-      <Separator
-        className="pane-resize-handle"
-        aria-label="Resize sidebar"
-      />
-      <Panel
-        id="main"
-        defaultSize={`${100 - defaultSidebarPct}%`}
-        minSize="480px"
-        className="flex"
-      >
-        {main}
-      </Panel>
-    </Group>
+    <div className="app-shell flex h-full w-full bg-bg-app text-fg-primary">
+      {sidebar}
+      {!sidebarCollapsed && <SidebarResizer />}
+      {main}
+    </div>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -439,6 +439,7 @@ export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, active
   const groups = useStore((s) => s.groups);
   const createGroup = useStore((s) => s.createGroup);
   const collapsed = useStore((s) => s.sidebarCollapsed);
+  const sidebarWidth = useStore((s) => s.sidebarWidth);
   const toggleSidebar = useStore((s) => s.toggleSidebar);
   const normal = groups.filter((g) => g.kind === 'normal');
   const archived = groups.filter((g) => g.kind === 'archive');
@@ -484,16 +485,12 @@ export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, active
     >
     <motion.aside
       initial={false}
-      // When collapsed we still animate down to a 48px rail; otherwise we
-      // stretch to whatever width the parent panel gives us (see
-      // `AppShell.tsx` — PanelGroup drives the outer width now). Using
-      // `100%` rather than a fixed number lets react-resizable-panels own
-      // the sizing contract; framer-motion's `animate` still gives us a
-      // smooth transition between rail ↔ expanded. Both values are strings
-      // so framer doesn't have to bridge px↔% during the tween.
-      animate={{ width: collapsed ? '48px' : '100%' }}
+      // Collapsed → 48px rail. Expanded → user-resizable px width persisted in
+      // the store (see SidebarResizer + store.sidebarWidth). framer-motion
+      // tweens the change so collapse/expand stays smooth.
+      animate={{ width: collapsed ? 48 : sidebarWidth }}
       transition={{ duration: 0.22, ease: [0.32, 0.72, 0, 1] }}
-      className="relative flex flex-col bg-bg-sidebar/80 backdrop-blur-xl sidebar-edge overflow-hidden h-full"
+      className="relative flex flex-col shrink-0 bg-bg-sidebar/80 backdrop-blur-xl sidebar-edge overflow-hidden h-full"
     >
       {/* Top drag strip — mirrors the right pane's 32px drag strip so the
           two panes share a horizontal title-bar band. On macOS this is

--- a/src/components/SidebarResizer.tsx
+++ b/src/components/SidebarResizer.tsx
@@ -1,0 +1,71 @@
+import React, { useCallback, useRef } from 'react';
+import {
+  useStore,
+  sanitizeSidebarWidth,
+  SIDEBAR_WIDTH_DEFAULT,
+  SIDEBAR_WIDTH_MIN,
+  SIDEBAR_WIDTH_MAX
+} from '../stores/store';
+
+/**
+ * 4px wide draggable handle between Sidebar and main pane.
+ *
+ *  - Pointer drag updates `sidebarWidth` (px), clamped to [200, 480].
+ *  - Double-click resets to the default width.
+ *  - Listeners attach on `pointerdown` and detach on `pointerup`/`pointercancel`
+ *    so we never leak.
+ *  - Body cursor + select are locked during drag so the cursor doesn't flicker
+ *    over child elements and text doesn't get accidentally selected.
+ */
+export function SidebarResizer() {
+  const sidebarWidth = useStore((s) => s.sidebarWidth);
+  const setSidebarWidth = useStore((s) => s.setSidebarWidth);
+  const resetSidebarWidth = useStore((s) => s.resetSidebarWidth);
+  const dragging = useRef(false);
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (e.button !== 0) return;
+      e.preventDefault();
+      const startX = e.clientX;
+      const startWidth = useStore.getState().sidebarWidth;
+      const previousCursor = document.body.style.cursor;
+      const previousSelect = document.body.style.userSelect;
+      document.body.style.cursor = 'col-resize';
+      document.body.style.userSelect = 'none';
+      dragging.current = true;
+
+      const move = (ev: PointerEvent) => {
+        setSidebarWidth(sanitizeSidebarWidth(startWidth + (ev.clientX - startX)));
+      };
+      const up = () => {
+        document.removeEventListener('pointermove', move);
+        document.removeEventListener('pointerup', up);
+        document.removeEventListener('pointercancel', up);
+        document.body.style.cursor = previousCursor;
+        document.body.style.userSelect = previousSelect;
+        dragging.current = false;
+      };
+
+      document.addEventListener('pointermove', move);
+      document.addEventListener('pointerup', up);
+      document.addEventListener('pointercancel', up);
+    },
+    [setSidebarWidth]
+  );
+
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-label="Resize sidebar"
+      aria-valuemin={SIDEBAR_WIDTH_MIN}
+      aria-valuemax={SIDEBAR_WIDTH_MAX}
+      aria-valuenow={sidebarWidth}
+      onPointerDown={onPointerDown}
+      onDoubleClick={resetSidebarWidth}
+      title={`Drag to resize · double-click to reset (${SIDEBAR_WIDTH_DEFAULT}px)`}
+      className="group/resizer relative w-1 shrink-0 cursor-col-resize bg-transparent hover:bg-border-strong active:bg-accent transition-colors duration-150 select-none"
+    />
+  );
+}

--- a/src/stores/persist.ts
+++ b/src/stores/persist.ts
@@ -22,7 +22,13 @@ export interface PersistedState {
   // read. Writes always use the current `PermissionMode`.
   permission: PermissionMode | string;
   sidebarCollapsed: boolean;
-  /** Sidebar width as a fraction of window width. See State.sidebarWidthPct. */
+  /** Sidebar width in pixels. See State.sidebarWidth. */
+  sidebarWidth?: number;
+  /**
+   * Legacy: sidebar width as a fraction of window width. Migrated to px
+   * (`sidebarWidth`) on hydrate via `resolvePersistedSidebarWidth`. Read-only
+   * — new writes always populate `sidebarWidth`.
+   */
   sidebarWidthPct?: number;
   theme?: Theme;
   fontSize?: FontSize;

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -152,12 +152,13 @@ type State = {
   permission: PermissionMode;
   sidebarCollapsed: boolean;
   /**
-   * Sidebar width as a percentage of the window width (0–1). Persisted as a
-   * fraction rather than px so the layout adapts gracefully across different
-   * window sizes / monitors. The resizable panel enforces min/max in px at
-   * render time; this is just the *desired* ratio.
+   * Sidebar width in pixels. Persisted as px (not %) — for a fixed-content
+   * sidebar this is the unit users actually have intuition for, and avoids
+   * the "sidebar mysteriously grew/shrank when I docked the window" trap of
+   * percentage-based persistence. Clamped at runtime to [SIDEBAR_WIDTH_MIN,
+   * SIDEBAR_WIDTH_MAX] in `setSidebarWidth`.
    */
-  sidebarWidthPct: number;
+  sidebarWidth: number;
   theme: Theme;
   fontSize: FontSize;
   fontSizePx: FontSizePx;
@@ -213,7 +214,8 @@ type Actions = {
   setFontSize: (size: FontSize) => void;
   setFontSizePx: (px: FontSizePx) => void;
   setDensity: (density: Density) => void;
-  setSidebarWidthPct: (pct: number) => void;
+  setSidebarWidth: (px: number) => void;
+  resetSidebarWidth: () => void;
   markTutorialSeen: () => void;
   setNotificationSettings: (patch: Partial<NotificationSettings>) => void;
   setSessionNotificationsMuted: (sessionId: string, muted: boolean) => void;
@@ -319,9 +321,33 @@ export function sanitizeDensity(raw: unknown): Density {
   return 'normal';
 }
 
-export function sanitizeSidebarWidthPct(raw: unknown): number {
-  const n = typeof raw === 'number' && Number.isFinite(raw) ? raw : 0.22;
-  return Math.max(0.12, Math.min(0.5, n));
+export const SIDEBAR_WIDTH_DEFAULT = 260;
+export const SIDEBAR_WIDTH_MIN = 200;
+export const SIDEBAR_WIDTH_MAX = 480;
+
+export function sanitizeSidebarWidth(raw: unknown): number {
+  const n = typeof raw === 'number' && Number.isFinite(raw) ? raw : SIDEBAR_WIDTH_DEFAULT;
+  return Math.min(SIDEBAR_WIDTH_MAX, Math.max(SIDEBAR_WIDTH_MIN, Math.round(n)));
+}
+
+// Older builds persisted sidebar width as a fraction of window width
+// (`sidebarWidthPct`). Convert any leftover value to px on first hydration
+// after upgrade so the user's prior layout choice survives the unit change.
+export function resolvePersistedSidebarWidth(persisted: {
+  sidebarWidth?: number;
+  sidebarWidthPct?: number;
+}): number {
+  if (typeof persisted.sidebarWidth === 'number') {
+    return sanitizeSidebarWidth(persisted.sidebarWidth);
+  }
+  if (typeof persisted.sidebarWidthPct === 'number') {
+    const winWidth =
+      typeof window !== 'undefined' && Number.isFinite(window.innerWidth)
+        ? window.innerWidth
+        : 1440;
+    return sanitizeSidebarWidth(persisted.sidebarWidthPct * winWidth);
+  }
+  return SIDEBAR_WIDTH_DEFAULT;
 }
 
 /** Resolve `theme` + OS signal to the actual rendered theme. Exported so
@@ -355,7 +381,7 @@ export const useStore = create<State & Actions>((set, get) => ({
   model: '',
   permission: 'default',
   sidebarCollapsed: false,
-  sidebarWidthPct: 0.22,
+  sidebarWidth: SIDEBAR_WIDTH_DEFAULT,
   theme: 'system',
   fontSize: 'md',
   fontSizePx: 14,
@@ -607,10 +633,8 @@ export const useStore = create<State & Actions>((set, get) => ({
   setFontSize: (fontSize) => set({ fontSize, fontSizePx: legacyFontSizeToPx(fontSize) }),
   setFontSizePx: (fontSizePx) => set({ fontSizePx, fontSize: pxToLegacyFontSize(fontSizePx) }),
   setDensity: (density) => set({ density }),
-  setSidebarWidthPct: (pct) => {
-    const clamped = Math.max(0.12, Math.min(0.5, pct));
-    set({ sidebarWidthPct: clamped });
-  },
+  setSidebarWidth: (px) => set({ sidebarWidth: sanitizeSidebarWidth(px) }),
+  resetSidebarWidth: () => set({ sidebarWidth: SIDEBAR_WIDTH_DEFAULT }),
   markTutorialSeen: () => set({ tutorialSeen: true }),
 
   setNotificationSettings: (patch) =>
@@ -1001,7 +1025,7 @@ export async function hydrateStore(): Promise<void> {
       model: persisted.model,
       permission: migratePermission(persisted.permission),
       sidebarCollapsed: persisted.sidebarCollapsed ?? false,
-      sidebarWidthPct: sanitizeSidebarWidthPct(persisted.sidebarWidthPct),
+      sidebarWidth: resolvePersistedSidebarWidth(persisted),
       theme: persisted.theme ?? 'system',
       fontSize: persisted.fontSize ?? 'md',
       fontSizePx: persisted.fontSizePx !== undefined
@@ -1092,7 +1116,7 @@ export async function hydrateStore(): Promise<void> {
       model: s.model,
       permission: s.permission,
       sidebarCollapsed: s.sidebarCollapsed,
-      sidebarWidthPct: s.sidebarWidthPct,
+      sidebarWidth: s.sidebarWidth,
       theme: s.theme,
       fontSize: s.fontSize,
       fontSizePx: s.fontSizePx,

--- a/tests/appearance.test.ts
+++ b/tests/appearance.test.ts
@@ -5,7 +5,11 @@ import {
   pxToLegacyFontSize,
   sanitizeFontSizePx,
   sanitizeDensity,
-  sanitizeSidebarWidthPct,
+  sanitizeSidebarWidth,
+  resolvePersistedSidebarWidth,
+  SIDEBAR_WIDTH_DEFAULT,
+  SIDEBAR_WIDTH_MIN,
+  SIDEBAR_WIDTH_MAX,
 } from '../src/stores/store';
 
 describe('resolveEffectiveTheme', () => {
@@ -75,18 +79,44 @@ describe('density sanitize', () => {
 });
 
 describe('sidebar width sanitize', () => {
-  it('passes through in-range fractions', () => {
-    expect(sanitizeSidebarWidthPct(0.22)).toBeCloseTo(0.22);
-    expect(sanitizeSidebarWidthPct(0.4)).toBeCloseTo(0.4);
+  it('passes through in-range pixel values, rounding fractions', () => {
+    expect(sanitizeSidebarWidth(260)).toBe(260);
+    expect(sanitizeSidebarWidth(312.6)).toBe(313);
   });
 
   it('clamps below min and above max', () => {
-    expect(sanitizeSidebarWidthPct(0.0)).toBe(0.12);
-    expect(sanitizeSidebarWidthPct(0.95)).toBe(0.5);
+    expect(sanitizeSidebarWidth(0)).toBe(SIDEBAR_WIDTH_MIN);
+    expect(sanitizeSidebarWidth(50)).toBe(SIDEBAR_WIDTH_MIN);
+    expect(sanitizeSidebarWidth(9999)).toBe(SIDEBAR_WIDTH_MAX);
   });
 
   it('falls back to default when value is non-numeric', () => {
-    expect(sanitizeSidebarWidthPct(NaN)).toBeCloseTo(0.22);
-    expect(sanitizeSidebarWidthPct('25%')).toBeCloseTo(0.22);
+    expect(sanitizeSidebarWidth(NaN)).toBe(SIDEBAR_WIDTH_DEFAULT);
+    expect(sanitizeSidebarWidth('25%')).toBe(SIDEBAR_WIDTH_DEFAULT);
+    expect(sanitizeSidebarWidth(undefined)).toBe(SIDEBAR_WIDTH_DEFAULT);
+  });
+});
+
+describe('resolvePersistedSidebarWidth', () => {
+  it('prefers a persisted px value', () => {
+    expect(resolvePersistedSidebarWidth({ sidebarWidth: 320 })).toBe(320);
+  });
+
+  it('clamps a persisted px value out of range', () => {
+    expect(resolvePersistedSidebarWidth({ sidebarWidth: 50 })).toBe(SIDEBAR_WIDTH_MIN);
+    expect(resolvePersistedSidebarWidth({ sidebarWidth: 9999 })).toBe(SIDEBAR_WIDTH_MAX);
+  });
+
+  it('migrates legacy sidebarWidthPct to px using window width', () => {
+    const winWidth = typeof window !== 'undefined' ? window.innerWidth : 1440;
+    const expected = Math.min(
+      SIDEBAR_WIDTH_MAX,
+      Math.max(SIDEBAR_WIDTH_MIN, Math.round(0.22 * winWidth))
+    );
+    expect(resolvePersistedSidebarWidth({ sidebarWidthPct: 0.22 })).toBe(expected);
+  });
+
+  it('returns the default when nothing is persisted', () => {
+    expect(resolvePersistedSidebarWidth({})).toBe(SIDEBAR_WIDTH_DEFAULT);
   });
 });

--- a/tests/store-appearance.test.ts
+++ b/tests/store-appearance.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { useStore } from '../src/stores/store';
+import {
+  useStore,
+  SIDEBAR_WIDTH_DEFAULT,
+  SIDEBAR_WIDTH_MIN,
+  SIDEBAR_WIDTH_MAX
+} from '../src/stores/store';
 
 describe('appearance setters', () => {
   it('setFontSizePx updates both px and legacy enum', () => {
@@ -26,12 +31,18 @@ describe('appearance setters', () => {
     expect(useStore.getState().theme).toBe('light');
   });
 
-  it('setSidebarWidthPct clamps to [0.12, 0.5]', () => {
-    useStore.getState().setSidebarWidthPct(0.3);
-    expect(useStore.getState().sidebarWidthPct).toBeCloseTo(0.3);
-    useStore.getState().setSidebarWidthPct(0.01);
-    expect(useStore.getState().sidebarWidthPct).toBe(0.12);
-    useStore.getState().setSidebarWidthPct(0.9);
-    expect(useStore.getState().sidebarWidthPct).toBe(0.5);
+  it('setSidebarWidth clamps to [200, 480] px', () => {
+    useStore.getState().setSidebarWidth(312);
+    expect(useStore.getState().sidebarWidth).toBe(312);
+    useStore.getState().setSidebarWidth(50);
+    expect(useStore.getState().sidebarWidth).toBe(SIDEBAR_WIDTH_MIN);
+    useStore.getState().setSidebarWidth(9999);
+    expect(useStore.getState().sidebarWidth).toBe(SIDEBAR_WIDTH_MAX);
+  });
+
+  it('resetSidebarWidth restores the default', () => {
+    useStore.getState().setSidebarWidth(400);
+    useStore.getState().resetSidebarWidth();
+    expect(useStore.getState().sidebarWidth).toBe(SIDEBAR_WIDTH_DEFAULT);
   });
 });


### PR DESCRIPTION
## Summary

Replaces the existing `react-resizable-panels`-driven shell with a custom 4px draggable handle (`SidebarResizer`) sitting between the Sidebar and the chat pane.

## Behavior

- **Visual**: 4px-wide handle, transparent by default, `border-strong` on hover, `accent` while dragging. Cursor turns `col-resize` on hover.
- **Drag**: pointer down captures `pointermove`/`pointerup`/`pointercancel` on `document` and detaches them on release. Body cursor + `user-select` are locked during drag to prevent flicker / accidental selection.
- **Clamp**: `[200px, 480px]`. Default `260px`.
- **Double-click**: resets to default width.
- **Collapsed state**: resizer is hidden when the sidebar is collapsed (the collapsed rail is a fixed 48px).

## Persistence

- Sidebar width is stored as **pixels** (`sidebarWidth: number`) in the existing zustand store and persisted via the existing write-through subscription (`schedulePersist`).
- The previous `sidebarWidthPct` (fraction of window width) field is removed. Existing persisted values migrate on first hydrate via `resolvePersistedSidebarWidth(persisted)`: it reads `pct * window.innerWidth` and clamps into the new range, so users don't lose their prior width.

## Tests

- `tests/store-appearance.test.ts` — `setSidebarWidth` clamps to [200, 480]; `resetSidebarWidth` restores default.
- `tests/appearance.test.ts` — `sanitizeSidebarWidth` and `resolvePersistedSidebarWidth` (in-range, out-of-range, NaN, missing, legacy `sidebarWidthPct` migration).
- All 552 tests pass; `npm run typecheck` and `npm run build` are green.

## Test plan

- [ ] Drag the handle — sidebar grows/shrinks within [200, 480].
- [ ] Double-click the handle — sidebar snaps back to 260.
- [ ] Restart app — width persists.
- [ ] Collapse sidebar — handle disappears; expand it — handle returns.
- [ ] Old install with persisted `sidebarWidthPct` — first launch produces a sane px width, no NaN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)