### PR TITLE
feat(sidebar): per-group + button + reorder context menu

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -85,6 +85,7 @@ function GroupRow({
   const deleteGroup = useStore((s) => s.deleteGroup);
   const archiveGroup = useStore((s) => s.archiveGroup);
   const unarchiveGroup = useStore((s) => s.unarchiveGroup);
+  const createSession = useStore((s) => s.createSession);
   const collapsed = group.collapsed;
   const [renaming, setRenaming] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
@@ -183,6 +184,22 @@ function GroupRow({
                 </>
               )}
             </button>
+            {group.kind === 'normal' && !renaming && (
+              <IconButton
+                size="xs"
+                variant="ghost"
+                aria-label={t('sidebar.newSessionInThisGroup')}
+                tooltip={t('sidebar.newSessionInThisGroup')}
+                tooltipSide="top"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  createSession({ groupId: group.id });
+                }}
+                className="ml-1 shrink-0 h-5 w-5"
+              >
+                <Plus size={12} className="stroke-[1.75]" />
+              </IconButton>
+            )}
           </div>
         </ContextMenuTrigger>
         <ContextMenuContent>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -186,6 +186,8 @@ function GroupRow({
           </div>
         </ContextMenuTrigger>
         <ContextMenuContent>
+          <ContextMenuItem onSelect={() => setRenaming(true)}>{t('common.rename')}</ContextMenuItem>
+          <ContextMenuSeparator />
           <ContextMenuItem
             onSelect={() =>
               group.kind === 'archive' ? unarchiveGroup(group.id) : archiveGroup(group.id)
@@ -193,8 +195,6 @@ function GroupRow({
           >
             {group.kind === 'archive' ? t('sidebar.unarchiveGroup') : t('sidebar.archiveGroup')}
           </ContextMenuItem>
-          <ContextMenuItem onSelect={() => setRenaming(true)}>{t('common.rename')}</ContextMenuItem>
-          <ContextMenuSeparator />
           <ContextMenuItem danger onSelect={() => setConfirmDelete(true)}>
             {t('sidebar.deleteGroupEllipsis')}
           </ContextMenuItem>

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -97,6 +97,7 @@ const en = {
   },
   sidebar: {
     newSession: 'New Session',
+    newSessionInThisGroup: 'New session in this group',
     newGroup: 'New group',
     newGroupEllipsis: 'New group…',
     groups: 'Groups',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -96,6 +96,7 @@ const zh: EnCatalog = {
   },
   sidebar: {
     newSession: '新会话',
+    newSessionInThisGroup: '在此 Group 新建 Session',
     newGroup: '新建分组',
     newGroupEllipsis: '新建分组…',
     groups: '分组',

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -190,6 +190,10 @@ type State = {
 export interface CreateSessionOptions {
   cwd?: string | null;
   name?: string;
+  /** Force the new session into this group, overriding the
+   *  focused/active-group fallback chain. Ignored if the id doesn't
+   *  resolve to a normal (non-special) group. */
+  groupId?: string;
 }
 
 type Actions = {
@@ -453,7 +457,9 @@ export const useStore = create<State & Actions>((set, get) => ({
       return !!g && g.kind === 'normal';
     };
     const activeGroupId = sessions.find((s) => s.id === activeId)?.groupId;
-    const targetGroupId = isUsable(focusedGroupId)
+    const targetGroupId = isUsable(opts.groupId)
+      ? opts.groupId!
+      : isUsable(focusedGroupId)
       ? focusedGroupId!
       : isUsable(activeGroupId)
       ? activeGroupId!


### PR DESCRIPTION
## Changes

- **Reorder group context menu**: Rename moves to the top, separator, then Archive/Unarchive and Delete grouped together. Less click-distance to the most common action (rename) and isolates the destructive one below the divider.
- **Per-group + button**: Each normal group header gets a small Plus IconButton on the right (xs ghost). Clicking creates a new session in THAT group, regardless of which group is currently focused/active. `createSession` now accepts an explicit `groupId` on its options object; the existing focused-then-active-then-first fallback chain is preserved when no `groupId` is passed. Special groups (archive/deleted) do not show the button. Click stops propagation so the row's collapse toggle is not triggered.

## i18n

- `sidebar.newSessionInThisGroup` added to en (`New session in this group`) and zh (`在此 Group 新建 Session`).

## Verification

- `npm run typecheck` — green
- `npm test` — 555 passed
- `npm run build` — green (only pre-existing bundle-size warnings)

Manual checks to do post-merge:
- [ ] Hover any normal group, click +, new session appears under that group, becomes active, composer focused.
- [ ] Right-click a normal group: order is Rename / --- / Archive / Delete.
- [ ] Right-click Archived group: shows Unarchive in slot 2.
- [ ] Special groups (Archived list) don't show + button.
- [ ] Clicking + does NOT collapse/expand the group.