### PR TITLE
chore(ci): disable CI triggers (billing)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,14 @@
 name: CI
 
+# Disabled — billing issues on the GitHub account. Re-enable by restoring
+# the pull_request / push triggers below. Manual runs still possible via
+# the Actions tab.
 on:
-  pull_request:
-    branches: [working, main]
-  push:
-    branches: [working, main]
+  workflow_dispatch:
+#  pull_request:
+#    branches: [working, main]
+#  push:
+#    branches: [working, main]
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
Account billing issue makes every push/PR fail at startup. Disable triggers; keep workflow_dispatch so we can run manually when needed. Re-enable by uncommenting the pull_request/push lines.