### PR TITLE
chore(e2e): unified probe runner

### DIFF
--- a/docs/e2e-runner.md
+++ b/docs/e2e-runner.md
@@ -1,0 +1,41 @@
+# E2E probe runner
+
+`scripts/run-all-e2e.mjs` runs every `scripts/probe-e2e-*.mjs` serially and
+prints a summary table. `npm run probe:e2e` builds the app then invokes it.
+
+## Adding a new probe
+
+1. Create `scripts/probe-e2e-<name>.mjs`. Follow the existing pattern (launch
+   Electron via `playwright._electron`, drive the UI, exit non-zero on failure).
+2. That's it. The runner picks it up by glob on next run; no registration.
+
+Conventions:
+- Exit `0` on success, non-zero on failure.
+- Keep total runtime under 30 seconds (per-probe timeout — runner SIGKILLs
+  beyond that).
+- Don't assume parallel safety. Probes run one at a time.
+
+## Skipping a flaky/known-broken probe
+
+Set `E2E_SKIP` to a comma-separated list of names (the part after
+`probe-e2e-`, without `.mjs`):
+
+```bash
+E2E_SKIP=streaming,tray npm run probe:e2e
+```
+
+Skipped probes are reported as `[--]` in the summary and don't affect the
+exit code.
+
+## Running a single probe
+
+The per-file scripts still work directly:
+
+```bash
+node scripts/probe-e2e-send.mjs
+```
+
+## Exit code
+
+The runner exits with the worst child exit code (or `1` if any probe failed
+or timed out). CI can consume it as-is.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint": "eslint . --ext .ts,.tsx",
     "test": "vitest run",
     "test:watch": "vitest",
-    "probe:e2e": "npm run build && node scripts/probe-e2e-send.mjs && node scripts/probe-e2e-switch.mjs && node scripts/probe-e2e-default-cwd.mjs",
+    "probe:e2e": "npm run build && node scripts/run-all-e2e.mjs",
     "make": "npm run build && electron-builder --publish never",
     "make:win": "npm run build && electron-builder --win --publish never",
     "make:mac": "npm run build && electron-builder --mac --publish never",

--- a/scripts/run-all-e2e.mjs
+++ b/scripts/run-all-e2e.mjs
@@ -1,0 +1,162 @@
+// Batch runner for every `scripts/probe-e2e-*.mjs`.
+//
+// - Discovers probes by glob, sorts deterministically.
+// - Runs them serially (Electron can't share its singleton lock — parallel
+//   launches race on user-data-dir and port allocation).
+// - 30s wall-clock timeout per probe (kill tree on overrun).
+// - Prints a final table; exit code = max child exit code (0 if all green).
+// - Skip list via `E2E_SKIP=name1,name2` (matches the suffix after
+//   `probe-e2e-` and before `.mjs`, e.g. `E2E_SKIP=streaming,tray`).
+//
+// Run: `node scripts/run-all-e2e.mjs`
+
+import { spawn } from 'node:child_process';
+import { readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPTS_DIR = __dirname;
+const TIMEOUT_MS = 30_000;
+const PROBE_PREFIX = 'probe-e2e-';
+
+const skipRaw = (process.env.E2E_SKIP || '').trim();
+const skipSet = new Set(
+  skipRaw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+);
+
+function probeName(file) {
+  return file.slice(PROBE_PREFIX.length, -'.mjs'.length);
+}
+
+const allFiles = readdirSync(SCRIPTS_DIR)
+  .filter((f) => f.startsWith(PROBE_PREFIX) && f.endsWith('.mjs'))
+  .sort();
+
+if (allFiles.length === 0) {
+  console.error('[run-all-e2e] no probes found');
+  process.exit(1);
+}
+
+console.log(`[run-all-e2e] discovered ${allFiles.length} probe(s)`);
+if (skipSet.size > 0) {
+  console.log(`[run-all-e2e] skipping: ${[...skipSet].join(', ')}`);
+}
+
+/** @type {Array<{name: string, status: 'passed'|'failed'|'skipped'|'timeout', code: number, ms: number, stderrTail: string}>} */
+const results = [];
+
+for (const file of allFiles) {
+  const name = probeName(file);
+  if (skipSet.has(name)) {
+    results.push({ name, status: 'skipped', code: 0, ms: 0, stderrTail: '' });
+    console.log(`\n[run-all-e2e] SKIP  ${name}`);
+    continue;
+  }
+
+  const full = path.join(SCRIPTS_DIR, file);
+  console.log(`\n[run-all-e2e] RUN   ${name}`);
+
+  const started = Date.now();
+  const { code, timedOut, stderrTail } = await runOne(full);
+  const ms = Date.now() - started;
+
+  let status;
+  if (timedOut) status = 'timeout';
+  else if (code === 0) status = 'passed';
+  else status = 'failed';
+
+  results.push({ name, status, code, ms, stderrTail });
+  console.log(`[run-all-e2e] ${status.toUpperCase().padEnd(6)} ${name} (${ms}ms, exit=${code})`);
+}
+
+// --- summary ---
+const nameWidth = Math.max(...results.map((r) => r.name.length), 4);
+const symbol = (s) => (s === 'passed' ? '[OK]' : s === 'skipped' ? '[--]' : '[XX]');
+
+console.log('\n=== E2E summary ===');
+for (const r of results) {
+  console.log(
+    `${symbol(r.status)} ${r.name.padEnd(nameWidth)}  ${r.status.padEnd(7)} ${String(r.ms).padStart(6)}ms  exit=${r.code}`
+  );
+}
+
+const failed = results.filter((r) => r.status === 'failed' || r.status === 'timeout');
+if (failed.length > 0) {
+  console.log(`\n=== failures (${failed.length}) ===`);
+  for (const r of failed) {
+    console.log(`\n--- ${r.name} (${r.status}) ---`);
+    console.log(r.stderrTail || '<no stderr captured>');
+  }
+}
+
+const passed = results.filter((r) => r.status === 'passed').length;
+const skipped = results.filter((r) => r.status === 'skipped').length;
+console.log(
+  `\n=== totals: ${passed} passed, ${failed.length} failed, ${skipped} skipped, ${results.length} total ===`
+);
+
+const exit = results.reduce((acc, r) => {
+  if (r.status === 'skipped' || r.status === 'passed') return acc;
+  return Math.max(acc, r.code === 0 ? 1 : r.code);
+}, 0);
+process.exit(exit);
+
+/**
+ * Spawn one probe with `process.execPath` (the Node binary running this
+ * runner). `shell: false` keeps Windows path quoting predictable.
+ *
+ * @param {string} scriptPath
+ * @returns {Promise<{code: number, timedOut: boolean, stderrTail: string}>}
+ */
+function runOne(scriptPath) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [scriptPath], {
+      shell: false,
+      stdio: ['ignore', 'inherit', 'pipe'],
+      env: process.env,
+    });
+
+    /** @type {string[]} */
+    const stderrLines = [];
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', (chunk) => {
+      // Mirror to our stderr so live tailing works…
+      process.stderr.write(chunk);
+      // …and remember the last few lines for the summary table.
+      for (const line of chunk.split(/\r?\n/)) {
+        if (line.length > 0) stderrLines.push(line);
+        if (stderrLines.length > 200) stderrLines.shift();
+      }
+    });
+
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      try {
+        // SIGKILL: probes spawn Electron, which won't always honor SIGTERM in 30s.
+        child.kill('SIGKILL');
+      } catch {
+        /* ignore */
+      }
+    }, TIMEOUT_MS);
+
+    child.on('exit', (code, signal) => {
+      clearTimeout(timer);
+      const tail = stderrLines.slice(-5).join('\n');
+      resolve({
+        code: code ?? (signal ? 1 : 1),
+        timedOut,
+        stderrTail: timedOut ? `(killed after ${TIMEOUT_MS}ms)\n${tail}` : tail,
+      });
+    });
+
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      resolve({ code: 1, timedOut: false, stderrTail: `spawn error: ${err.message}` });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- New `scripts/run-all-e2e.mjs` discovers every `scripts/probe-e2e-*.mjs` by glob, runs them serially (Electron can't share its singleton lock), with a 30s per-probe timeout (SIGKILL on overrun).
- Final summary table: passed / failed / skipped + last 5 stderr lines per failure. Exit code = max child exit code.
- `npm run probe:e2e` now goes through the runner instead of hard-coding 3 probes. Per-probe `node scripts/probe-e2e-<name>.mjs` invocations still work.
- `E2E_SKIP=name1,name2` env var skips probes by short name (the part after `probe-e2e-`).
- `docs/e2e-runner.md` documents how to add a probe and how to skip.

No probe files were modified.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (548/548)
- [x] Dry-run (`E2E_SKIP=<all> node scripts/run-all-e2e.mjs`) discovers all 22 probes, prints summary, exits 0
- [ ] Manual `npm run probe:e2e` on a workstation with valid `~/.claude/settings.json` (out of scope for CI box)