### PR TITLE
fix(slash): /model picker + /config opens settings

### DIFF
--- a/scripts/probe-slash-config.mjs
+++ b/scripts/probe-slash-config.mjs
@@ -1,0 +1,97 @@
+// Probe: `/config` slash-command opens the Settings dialog (equivalent to
+// clicking the gear icon in the sidebar). Renders against the webpack dev
+// server on AGENTORY_DEV_PORT (default 4193) — pure DOM/state, no Electron
+// needed.
+//
+// Usage:
+//   AGENTORY_DEV_PORT=4193 npm run dev:web   # in another shell
+//   node scripts/probe-slash-config.mjs
+import { chromium } from 'playwright';
+
+const PORT = process.env.AGENTORY_DEV_PORT ?? '4193';
+const URL = `http://localhost:${PORT}/`;
+
+function fail(msg) {
+  console.error(`\n[probe-slash-config] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext();
+const page = await ctx.newPage();
+
+const errors = [];
+page.on('pageerror', (e) => errors.push(`[pageerror] ${e.message}`));
+page.on('console', (m) => {
+  if (m.type() === 'error') errors.push(`[console.error] ${m.text()}`);
+});
+
+await page.goto(URL, { waitUntil: 'networkidle' });
+await page.waitForSelector('aside', { timeout: 15_000 });
+
+// Need a session for InputBar to mount.
+const newBtn = page.getByRole('button', { name: /new session/i }).first();
+await newBtn.waitFor({ state: 'visible', timeout: 10_000 });
+await newBtn.click();
+
+const textarea = page.locator('textarea');
+await textarea.waitFor({ state: 'visible', timeout: 5000 });
+
+// --- 1. Type `/config`, dismiss picker, send → Settings dialog opens --
+await textarea.click();
+await textarea.fill('/config');
+await page.waitForTimeout(60);
+await page.keyboard.press('Escape');
+await page.waitForTimeout(60);
+await page.keyboard.press('Enter');
+
+const dialog = page.getByRole('dialog');
+await dialog.waitFor({ state: 'visible', timeout: 2000 }).catch(() => {
+  fail('/config did not open the Settings dialog');
+});
+
+// --- 2. The Settings dialog must be the gear-equivalent — i.e. show the
+//        General / Appearance tab labels, not the model picker. ---------
+const dialogText = await dialog.innerText();
+if (/switch model/i.test(dialogText)) {
+  fail('/config opened the model picker instead of the Settings dialog');
+}
+const hasGeneralOrAppearance = /general|appearance/i.test(dialogText);
+if (!hasGeneralOrAppearance) {
+  fail(`Settings dialog opened but missing General/Appearance content; got: ${dialogText.slice(0, 200)}`);
+}
+
+// --- 3. Close, then click the gear icon → opens the SAME dialog. ------
+//        Asserts /config is equivalent to the gear button.
+await page.keyboard.press('Escape');
+await page.waitForTimeout(200);
+const stillVisible = await dialog.isVisible().catch(() => false);
+if (stillVisible) fail('Settings dialog did not close on Escape');
+
+const gear = page
+  .getByRole('button', { name: /settings/i })
+  .first();
+const gearExists = await gear.isVisible().catch(() => false);
+if (gearExists) {
+  await gear.click();
+  await dialog.waitFor({ state: 'visible', timeout: 2000 }).catch(() => {
+    fail('clicking gear icon did not open Settings dialog (parity check)');
+  });
+  const gearDialogText = await dialog.innerText();
+  if (!/general|appearance/i.test(gearDialogText)) {
+    fail('gear-opened dialog missing expected General/Appearance content');
+  }
+} else {
+  console.warn('[probe-slash-config] note: gear button not found, parity check skipped');
+}
+
+if (errors.length > 0) {
+  console.error('--- console / page errors ---');
+  for (const e of errors) console.error(e);
+}
+
+console.log('\n[probe-slash-config] OK');
+console.log('  /config → Settings dialog opened with General/Appearance content');
+console.log('  parity with gear-icon click verified');
+
+await browser.close();

--- a/scripts/probe-slash-exec.mjs
+++ b/scripts/probe-slash-exec.mjs
@@ -97,8 +97,8 @@ const settings = page.getByRole('dialog');
 await settings.waitFor({ state: 'visible', timeout: 2000 }).catch(() => {
   fail('/config did not open the Settings dialog');
 });
-const hasGeneral = await settings.getByText(/general/i).first().isVisible().catch(() => false);
-if (!hasGeneral) fail('Settings dialog missing General tab label');
+const hasTab = await settings.getByText(/appearance|connection|notifications/i).first().isVisible().catch(() => false);
+if (!hasTab) fail('Settings dialog missing tab labels (appearance/connection/notifications)');
 
 if (errors.length > 0) {
   console.error('--- console / page errors ---');

--- a/scripts/probe-slash-model.mjs
+++ b/scripts/probe-slash-model.mjs
@@ -1,0 +1,161 @@
+// Probe: `/model` slash-command opens the in-chat model picker, lists every
+// model from the store (which is what `loadModels()` populates from
+// ~/.claude/settings.json + env), lets the user select one, and surfaces the
+// choice through `setModel` so subsequent messages use the new model.
+//
+// Renders against the webpack dev server on AGENTORY_DEV_PORT (default 4192)
+// and seeds the renderer store directly via `window.__agentoryStore` since
+// the dev server has no Electron / no `models:list` IPC behind it.
+//
+// Usage:
+//   AGENTORY_DEV_PORT=4192 npm run dev:web   # in another shell
+//   node scripts/probe-slash-model.mjs
+import { chromium } from 'playwright';
+
+const PORT = process.env.AGENTORY_DEV_PORT ?? '4192';
+const URL = `http://localhost:${PORT}/`;
+
+function fail(msg) {
+  console.error(`\n[probe-slash-model] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext();
+const page = await ctx.newPage();
+
+const errors = [];
+page.on('pageerror', (e) => errors.push(`[pageerror] ${e.message}`));
+page.on('console', (m) => {
+  if (m.type() === 'error') errors.push(`[console.error] ${m.text()}`);
+});
+
+await page.goto(URL, { waitUntil: 'networkidle' });
+await page.waitForSelector('aside', { timeout: 15_000 });
+
+// Seed models into the store so the picker has something to render. In real
+// runs this comes from `loadModels()` reading ~/.claude/settings.json (the
+// `settings`-source entries) plus env-derived ones — we mimic both sources
+// here. The picker doesn't care where they came from; it just lists `.id`
+// and `.source`.
+await page.evaluate(() => {
+  const store = window.__agentoryStore;
+  if (!store) throw new Error('window.__agentoryStore not exposed (dev only)');
+  store.setState({
+    models: [
+      { id: 'claude-opus-4-5-20251101', source: 'settings' },
+      { id: 'claude-sonnet-4-5-20250929', source: 'settings' },
+      { id: 'claude-haiku-4-5-20251001', source: 'env' }
+    ],
+    modelsLoaded: true
+  });
+});
+
+// Open / create a session so InputBar exists. The slash dispatcher needs a
+// session id to invoke the handler against.
+const newBtn = page.getByRole('button', { name: /new session/i }).first();
+await newBtn.waitFor({ state: 'visible', timeout: 10_000 });
+await newBtn.click();
+
+const textarea = page.locator('textarea');
+await textarea.waitFor({ state: 'visible', timeout: 5000 });
+
+// Type `/model`, dismiss the picker (so Enter sends instead of selecting a
+// row), then send.
+await textarea.click();
+await textarea.fill('/model');
+await page.waitForTimeout(60);
+await page.keyboard.press('Escape');
+await page.waitForTimeout(60);
+await page.keyboard.press('Enter');
+
+// --- 1. Picker dialog appears -----------------------------------------
+const dialog = page.getByRole('dialog');
+await dialog.waitFor({ state: 'visible', timeout: 2000 }).catch(() => {
+  fail('/model did not open a model picker dialog');
+});
+
+const titleVisible = await dialog
+  .getByText(/switch model/i)
+  .first()
+  .isVisible()
+  .catch(() => false);
+if (!titleVisible) fail('model picker dialog missing the "Switch model" title');
+
+// --- 2. Lists exactly the 3 seeded models with their source tags ------
+const listbox = dialog.locator('[role="listbox"]');
+await listbox.waitFor({ state: 'visible', timeout: 2000 });
+const options = listbox.locator('[role="option"]');
+const count = await options.count();
+if (count !== 3) fail(`expected 3 model rows, got ${count}`);
+
+const listText = await listbox.innerText();
+for (const id of ['claude-opus-4-5-20251101', 'claude-sonnet-4-5-20250929', 'claude-haiku-4-5-20251001']) {
+  if (!listText.includes(id)) fail(`model "${id}" missing from picker`);
+}
+if (!/settings/.test(listText)) fail('source tag "settings" missing from picker');
+if (!/env/.test(listText)) fail('source tag "env" missing from picker');
+
+// --- 3. Click the second model → store.model + active session model
+//        update, dialog closes, no settings-dialog gets opened. ---------
+const before = await page.evaluate(() => {
+  const s = window.__agentoryStore.getState();
+  return {
+    model: s.model,
+    activeModel: s.sessions.find((x) => x.id === s.activeId)?.model ?? null
+  };
+});
+
+await options.nth(1).click();
+await page.waitForTimeout(150);
+
+const dialogVisibleAfter = await dialog.isVisible().catch(() => false);
+if (dialogVisibleAfter) fail('model picker did not close after selection');
+
+const after = await page.evaluate(() => {
+  const s = window.__agentoryStore.getState();
+  return {
+    model: s.model,
+    activeModel: s.sessions.find((x) => x.id === s.activeId)?.model ?? null
+  };
+});
+
+if (after.model !== 'claude-sonnet-4-5-20250929') {
+  fail(`store.model not updated; before=${before.model} after=${after.model}`);
+}
+if (after.activeModel !== 'claude-sonnet-4-5-20250929') {
+  fail(`active session model not updated; before=${before.activeModel} after=${after.activeModel}`);
+}
+
+// --- 4. /model must NOT have opened the Settings dialog ---------------
+//        (regression: previous handler routed to Settings → Connection.)
+//        At this point the model-picker dialog is closed; if Settings had
+//        opened it would still be in the DOM as role=dialog with the
+//        "General" / "Appearance" headings.
+const stillOpenDialog = page.getByRole('dialog');
+const stillOpen = await stillOpenDialog.isVisible().catch(() => false);
+if (stillOpen) {
+  const txt = await stillOpenDialog.innerText().catch(() => '');
+  if (/general|appearance|connection/i.test(txt)) {
+    fail(`/model leaked into Settings dialog; saw "${txt.slice(0, 80)}…"`);
+  }
+}
+
+// --- 5. Sanity: the StatusBar model chip now shows the picked model ---
+const chipText = await page.locator('button:has-text("claude-sonnet-4-5-20250929")').first().isVisible().catch(() => false);
+if (!chipText) {
+  // Non-fatal: chip rendering is covered elsewhere. Log only.
+  console.warn('[probe-slash-model] note: status-bar chip did not show new model id (non-fatal)');
+}
+
+if (errors.length > 0) {
+  console.error('--- console / page errors ---');
+  for (const e of errors) console.error(e);
+}
+
+console.log('\n[probe-slash-model] OK');
+console.log('  /model → picker opened with 3 models (settings + env sources)');
+console.log('  click → store.model + active session model updated');
+console.log('  no Settings dialog leak');
+
+await browser.close();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,11 +16,12 @@ import { DragRegion, WindowControls } from './components/WindowControls';
 import { Tutorial } from './components/Tutorial';
 import { ClaudeCliMissingDialog } from './components/ClaudeCliMissingDialog';
 import { ClaudeCliMissingBanner } from './components/ClaudeCliMissingBanner';
+import { ModelPickerDialog } from './components/ModelPickerDialog';
 import { useStore } from './stores/store';
 import { resolveEffectiveTheme } from './stores/store';
 import { setPersistErrorHandler } from './stores/persist';
 import { subscribeAgentEvents, setBackgroundWaitingHandler } from './agent/lifecycle';
-import { setOpenSettingsListener, type SettingsTab } from './slash-commands/ui-bridge';
+import { setOpenSettingsListener, setOpenModelPickerListener, type SettingsTab } from './slash-commands/ui-bridge';
 import { initI18n } from './i18n';
 import { usePreferences } from './store/preferences';
 
@@ -144,6 +145,7 @@ export default function App() {
   const [settingsTab, setSettingsTab] = React.useState<SettingsTab | undefined>(undefined);
   const [paletteOpen, setPaletteOpen] = React.useState(false);
   const [importOpen, setImportOpen] = React.useState(false);
+  const [modelPickerOpen, setModelPickerOpen] = React.useState(false);
 
   // New sessions are created in-place — no modal. The store seeds `cwd`
   // from `recentProjects[0]?.path ?? '~'`; users repick later via the
@@ -160,6 +162,14 @@ export default function App() {
       setSettingsOpen(true);
     });
     return () => setOpenSettingsListener(null);
+  }, []);
+
+  // `/model` opens the in-chat model picker dialog (mirrors clicking the
+  // model chip in the StatusBar). Kept separate from the settings bridge so
+  // the two surfaces don't fight over a single open flag.
+  useEffect(() => {
+    setOpenModelPickerListener(() => setModelPickerOpen(true));
+    return () => setOpenModelPickerListener(null);
   }, []);
 
   const active = useMemo(
@@ -264,6 +274,7 @@ export default function App() {
           <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} initialTab={settingsTab} />
           <ImportDialog open={importOpen} onOpenChange={setImportOpen} />
           <ClaudeCliMissingDialog />
+          <ModelPickerDialog open={modelPickerOpen} onOpenChange={setModelPickerOpen} />
           <CommandPalette
             open={paletteOpen}
             onOpenChange={setPaletteOpen}
@@ -335,6 +346,7 @@ export default function App() {
         <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} initialTab={settingsTab} />
         <ImportDialog open={importOpen} onOpenChange={setImportOpen} />
         <ClaudeCliMissingDialog />
+        <ModelPickerDialog open={modelPickerOpen} onOpenChange={setModelPickerOpen} />
         <PrFlowProvider />
         <CommandPalette
           open={paletteOpen}

--- a/src/components/ModelPickerDialog.tsx
+++ b/src/components/ModelPickerDialog.tsx
@@ -1,0 +1,166 @@
+// In-chat model picker. Opened by `/model` (via the slash-command UI bridge)
+// or programmatically. Lists every model the renderer has discovered from
+// `~/.claude/settings.json` + env (see store.loadModels) and writes the
+// selection back through `setModel`, which also notifies the running agent.
+//
+// Visually a roving Radix Dialog: arrow keys move the highlight, Enter
+// commits, Escape closes. Non-destructive — closing without picking leaves
+// the current model untouched.
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Cpu, Check } from 'lucide-react';
+import { Dialog, DialogContent } from './ui/Dialog';
+import { useStore } from '../stores/store';
+import { cn } from '../lib/cn';
+import { useTranslation } from '../i18n/useTranslation';
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export function ModelPickerDialog({ open, onOpenChange }: Props) {
+  const { t } = useTranslation();
+  const models = useStore((s) => s.models);
+  const modelsLoaded = useStore((s) => s.modelsLoaded);
+  const sessions = useStore((s) => s.sessions);
+  const activeId = useStore((s) => s.activeId);
+  const fallbackModel = useStore((s) => s.model);
+  const setModel = useStore((s) => s.setModel);
+
+  const active = useMemo(
+    () => sessions.find((s) => s.id === activeId),
+    [sessions, activeId]
+  );
+  const currentModel = active?.model || fallbackModel;
+
+  // Highlight starts on the current model when known, else first row.
+  const initialIndex = useMemo(() => {
+    if (!currentModel) return 0;
+    const i = models.findIndex((m) => m.id === currentModel);
+    return i === -1 ? 0 : i;
+  }, [models, currentModel]);
+
+  const [activeIndex, setActiveIndex] = useState(initialIndex);
+  useEffect(() => {
+    if (open) setActiveIndex(initialIndex);
+  }, [open, initialIndex]);
+
+  // Each row gets a ref so we can scroll the highlighted one into view.
+  const rowRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  useEffect(() => {
+    if (!open) return;
+    rowRefs.current[activeIndex]?.scrollIntoView({ block: 'nearest' });
+  }, [open, activeIndex]);
+
+  function commit(id: string) {
+    setModel(id);
+    onOpenChange(false);
+  }
+
+  function onKey(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (models.length === 0) return;
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveIndex((i) => (i + 1) % models.length);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIndex((i) => (i - 1 + models.length) % models.length);
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      setActiveIndex(0);
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      setActiveIndex(models.length - 1);
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const m = models[activeIndex];
+      if (m) commit(m.id);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        title={t('modelPicker.title')}
+        description={t('modelPicker.description')}
+        width="520px"
+        // Keep keyboard focus on the dialog content so arrow keys / Enter work
+        // immediately without a per-row tab dance.
+        onOpenAutoFocus={(e) => {
+          e.preventDefault();
+          // Defer so the dialog is mounted before we focus it.
+          requestAnimationFrame(() => {
+            const el = document.querySelector<HTMLElement>(
+              '[data-model-picker-listbox]'
+            );
+            el?.focus();
+          });
+        }}
+      >
+        <div
+          role="listbox"
+          aria-label={t('modelPicker.title')}
+          tabIndex={0}
+          data-model-picker-listbox
+          onKeyDown={onKey}
+          className="max-h-[360px] overflow-y-auto px-2 pb-3 outline-none"
+        >
+          {!modelsLoaded && (
+            <div className="px-3 py-6 text-sm text-fg-tertiary text-center">
+              {t('statusBar.loading')}
+            </div>
+          )}
+          {modelsLoaded && models.length === 0 && (
+            <div className="px-3 py-6 text-sm text-fg-tertiary text-center">
+              {t('statusBar.noModelsHint')}
+            </div>
+          )}
+          {modelsLoaded &&
+            models.map((m, i) => {
+              const selected = m.id === currentModel;
+              const highlighted = i === activeIndex;
+              return (
+                <button
+                  key={m.id}
+                  ref={(el) => {
+                    rowRefs.current[i] = el;
+                  }}
+                  type="button"
+                  role="option"
+                  aria-selected={highlighted}
+                  data-current={selected || undefined}
+                  onMouseEnter={() => setActiveIndex(i)}
+                  onClick={() => commit(m.id)}
+                  className={cn(
+                    'w-full flex items-center gap-2 px-3 py-2 rounded-sm',
+                    'text-left text-sm font-mono',
+                    'transition-colors duration-120 ease-out outline-none',
+                    highlighted
+                      ? 'bg-bg-hover text-fg-primary'
+                      : 'text-fg-secondary hover:bg-bg-hover'
+                  )}
+                >
+                  <Cpu
+                    size={13}
+                    className="stroke-[1.75] shrink-0 text-fg-tertiary"
+                  />
+                  <span className="flex-1 truncate">{m.id}</span>
+                  <span className="text-[11px] text-fg-disabled font-mono shrink-0">
+                    {m.source}
+                  </span>
+                  {selected && (
+                    <Check
+                      size={13}
+                      className="stroke-[2] shrink-0 text-state-success"
+                      aria-label={t('modelPicker.current')}
+                    />
+                  )}
+                </button>
+              );
+            })}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -344,6 +344,11 @@ const en = {
     waitingOutput: 'waiting for output…',
     noOutput: '(no output)'
   },
+  modelPicker: {
+    title: 'Switch model',
+    description: 'Pick a model for this session.',
+    current: 'Current model'
+  },
   statusBar: {
     workingDirectory: 'Working directory',
     model: 'Model',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -333,6 +333,11 @@ const zh: EnCatalog = {
     waitingOutput: '等待输出…',
     noOutput: '（无输出）'
   },
+  modelPicker: {
+    title: '切换模型',
+    description: '为当前会话选择模型。',
+    current: '当前模型'
+  },
   statusBar: {
     workingDirectory: '工作目录',
     model: '模型',

--- a/src/slash-commands/handlers.ts
+++ b/src/slash-commands/handlers.ts
@@ -10,7 +10,7 @@
 import { useStore } from '../stores/store';
 import type { MessageBlock } from '../types';
 import { SLASH_COMMANDS, type SlashCommandContext } from './registry';
-import { openSettings } from './ui-bridge';
+import { openSettings, openModelPicker } from './ui-bridge';
 import { triggerPrFlow } from '../lib/pr-flow';
 
 function nextId(prefix: string): string {
@@ -84,10 +84,12 @@ export function handleConfig(_ctx: SlashCommandContext): void {
 }
 
 // ---------- /model ----------
-// No in-chat model dropdown exposed yet; route to the Connection tab where
-// the model defaults live.
+// Pop open the in-chat model picker (mirrors clicking the model chip in the
+// status bar). The picker reads `models[]` from the store and writes the
+// chosen id back through `setModel`, which both updates the active session
+// and notifies the running agent (see store.setModel).
 export function handleModel(_ctx: SlashCommandContext): void {
-  openSettings('connection');
+  openModelPicker();
 }
 
 // ---------- /help ----------

--- a/src/slash-commands/ui-bridge.ts
+++ b/src/slash-commands/ui-bridge.ts
@@ -12,14 +12,27 @@ export type SettingsTab =
   | 'connection'
   | 'updates';
 
-type Listener = (tab?: SettingsTab) => void;
+type SettingsListener = (tab?: SettingsTab) => void;
+type ModelPickerListener = () => void;
 
-let openSettingsListener: Listener | null = null;
+let openSettingsListener: SettingsListener | null = null;
+let openModelPickerListener: ModelPickerListener | null = null;
 
-export function setOpenSettingsListener(fn: Listener | null): void {
+export function setOpenSettingsListener(fn: SettingsListener | null): void {
   openSettingsListener = fn;
 }
 
 export function openSettings(tab?: SettingsTab): void {
   if (openSettingsListener) openSettingsListener(tab);
+}
+
+// Model picker bridge — used by `/model` to pop open an in-chat picker
+// (rather than dragging the user into the Settings → Connection pane just
+// to flip a default they want to change for this session only).
+export function setOpenModelPickerListener(fn: ModelPickerListener | null): void {
+  openModelPickerListener = fn;
+}
+
+export function openModelPicker(): void {
+  if (openModelPickerListener) openModelPickerListener();
 }

--- a/tests/slash-commands-handlers.test.ts
+++ b/tests/slash-commands-handlers.test.ts
@@ -14,7 +14,7 @@ import {
   handleHelp,
   blocksToTranscript
 } from '../src/slash-commands/handlers';
-import { setOpenSettingsListener } from '../src/slash-commands/ui-bridge';
+import { setOpenSettingsListener, setOpenModelPickerListener } from '../src/slash-commands/ui-bridge';
 
 // Snapshot of the pristine store so we can reset between tests. The store
 // module auto-attaches handlers via its own side-effects; handlers.ts also
@@ -149,7 +149,10 @@ describe('/cost', () => {
 });
 
 describe('/config and /model', () => {
-  afterEach(() => setOpenSettingsListener(null));
+  afterEach(() => {
+    setOpenSettingsListener(null);
+    setOpenModelPickerListener(null);
+  });
 
   it('/config opens settings (appearance tab)', () => {
     const calls: Array<string | undefined> = [];
@@ -157,11 +160,16 @@ describe('/config and /model', () => {
     handleConfig({ sessionId: 's', args: '' });
     expect(calls).toEqual(['appearance']);
   });
-  it('/model opens settings on connection tab', () => {
-    const calls: Array<string | undefined> = [];
-    setOpenSettingsListener((tab) => calls.push(tab));
+  it('/model opens the in-chat model picker (does NOT open settings)', () => {
+    const settingsCalls: Array<string | undefined> = [];
+    setOpenSettingsListener((tab) => settingsCalls.push(tab));
+    let pickerOpens = 0;
+    setOpenModelPickerListener(() => {
+      pickerOpens += 1;
+    });
     handleModel({ sessionId: 's', args: '' });
-    expect(calls).toEqual(['connection']);
+    expect(pickerOpens).toBe(1);
+    expect(settingsCalls).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

- **/model** previously routed to Settings → Connection. Now opens an in-chat **ModelPickerDialog** (Radix) listing every model from the store (populated by `loadModels()` from `~/.claude/settings.json` + env). Arrow-key nav, Enter-to-commit, current-model checkmark. Selection goes through `setModel` so the running agent is notified via `agentSetModel` — same path as the StatusBar chip, so the next message uses the new model.
- **/config** keeps opening the Settings dialog (gear-icon parity), now covered by a dedicated probe so it can't silently regress.
- New `openModelPicker` bridge in `slash-commands/ui-bridge.ts`, mirroring `openSettings`. App.tsx subscribes once and mounts the dialog in both the no-active-session and active-session render branches.

## Files

- `src/slash-commands/ui-bridge.ts` — added `setOpenModelPickerListener` / `openModelPicker`.
- `src/slash-commands/handlers.ts` — `handleModel` now calls `openModelPicker()`.
- `src/components/ModelPickerDialog.tsx` — new dialog (Radix Dialog + roving listbox keyboard nav).
- `src/App.tsx` — wires the new bridge + mounts the dialog.
- `src/i18n/locales/{en,zh}.ts` — `modelPicker.title/description/current`.
- `tests/slash-commands-handlers.test.ts` — `/model` test asserts picker opens (not Settings).
- `scripts/probe-slash-model.mjs`, `scripts/probe-slash-config.mjs` — new probes.
- `scripts/probe-slash-exec.mjs` — fixed pre-existing assertion that looked for the now-removed "General" tab label.

## Test plan

- [x] `npm run typecheck` passes.
- [x] `npm test` — slash-commands tests (registry / handlers / picker) all green (40 tests). Pre-existing native-module failures in `electron/__tests__/db.test.ts` unrelated to this PR (better-sqlite3 ABI mismatch).
- [x] `node scripts/probe-slash-model.mjs` against dev server: picker opens with seeded models, selection updates `store.model` + active session model, no Settings dialog leak.
- [x] `node scripts/probe-slash-config.mjs`: Settings dialog opens, content matches the gear-button click.
- [x] `node scripts/probe-slash-exec.mjs` continues to pass after the assertion update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)