### PR TITLE
fix(slash): /clear must not create new session + /help local renderer

### DIFF
--- a/scripts/probe-slash-clear.mjs
+++ b/scripts/probe-slash-clear.mjs
@@ -1,0 +1,152 @@
+// Probe: /clear must wipe the current session in place.
+//
+// Bug fixed: handleClear used to call store.createSession(...), so each
+// `/clear` added a sidebar row. CLI semantics demand the opposite — same
+// session, empty transcript, fresh next-turn context.
+//
+// Coverage:
+//   1. Send a few user messages so the transcript has content.
+//   2. Run /clear.
+//   3. Sidebar count is unchanged (no new session created).
+//   4. The original session is still active.
+//   5. Transcript was wiped — only the "Context cleared" status remains.
+//      The previously-sent user blocks are gone.
+//   6. Persisted resumeSessionId is dropped (next message starts fresh).
+//
+// Usage:
+//   AGENTORY_DEV_PORT=4192 npm run dev:web   # in another shell
+//   AGENTORY_DEV_PORT=4192 node scripts/probe-slash-clear.mjs
+import { chromium } from 'playwright';
+
+const PORT = process.env.AGENTORY_DEV_PORT ?? '4192';
+const URL = `http://localhost:${PORT}/`;
+
+function fail(msg) {
+  console.error(`\n[probe-slash-clear] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext();
+const page = await ctx.newPage();
+
+const errors = [];
+page.on('pageerror', (e) => errors.push(`[pageerror] ${e.message}`));
+page.on('console', (m) => {
+  if (m.type() === 'error') errors.push(`[console.error] ${m.text()}`);
+});
+
+await page.goto(URL, { waitUntil: 'networkidle' });
+await page.waitForSelector('aside', { timeout: 15_000 });
+
+// Create a session so the input bar is wired up.
+const newBtn = page.getByRole('button', { name: /new session/i }).first();
+await newBtn.waitFor({ state: 'visible', timeout: 10_000 });
+await newBtn.click();
+
+const textarea = page.locator('textarea');
+await textarea.waitFor({ state: 'visible', timeout: 5000 });
+
+// Reach into the renderer store: easier and more reliable than driving DOM
+// for the "send some messages" setup (no real claude.exe available in the
+// browser-only probe). We append local user blocks + flag startedSessions
+// the same way a real turn would, then assert /clear undoes all of it.
+const sidebarItems = page.locator('[role="option"]');
+const beforeCount = await sidebarItems.count();
+if (beforeCount < 1) fail(`expected at least one session in sidebar, got ${beforeCount}`);
+
+const beforeState = await page.evaluate(() => {
+  const w = /** @type {any} */ (window);
+  const store = w.__agentoryStore ?? null;
+  if (!store) return null;
+  const s = store.getState();
+  const sid = s.activeId;
+  // Seed transcript and "started" state so we can assert /clear wipes them.
+  store.setState((cur) => ({
+    messagesBySession: {
+      ...cur.messagesBySession,
+      [sid]: [
+        { kind: 'user', id: 'probe-u1', text: 'hello world' },
+        { kind: 'assistant', id: 'probe-a1', text: 'hi back' },
+        { kind: 'user', id: 'probe-u2', text: 'second turn' }
+      ]
+    },
+    startedSessions: { ...cur.startedSessions, [sid]: true },
+    statsBySession: {
+      ...cur.statsBySession,
+      [sid]: { turns: 2, inputTokens: 200, outputTokens: 100, costUsd: 0.005 }
+    },
+    sessions: cur.sessions.map((x) =>
+      x.id === sid ? { ...x, resumeSessionId: 'cc-fake-resume' } : x
+    )
+  }));
+  return { sid, count: s.sessions.length };
+});
+
+if (!beforeState) {
+  fail('window.__agentoryStore not exposed; the dev build must expose it (see App.tsx).');
+}
+
+// Run /clear via the textarea so we exercise the real dispatch path.
+await textarea.click();
+await textarea.fill('/clear');
+await page.waitForTimeout(60);
+await page.keyboard.press('Escape'); // dismiss picker so Enter sends
+await page.waitForTimeout(40);
+await page.keyboard.press('Enter');
+await page.waitForTimeout(250);
+
+const afterCount = await sidebarItems.count();
+if (afterCount !== beforeCount) {
+  fail(`/clear must NOT add a session (had ${beforeCount}, now ${afterCount})`);
+}
+
+const afterState = await page.evaluate(() => {
+  const store = /** @type {any} */ (window).__agentoryStore;
+  const s = store.getState();
+  const session = s.sessions.find((x) => x.id === s.activeId);
+  return {
+    activeId: s.activeId,
+    sessionCount: s.sessions.length,
+    blocks: s.messagesBySession[s.activeId] ?? [],
+    started: s.startedSessions[s.activeId] === true,
+    stats: s.statsBySession[s.activeId] ?? null,
+    resumeSessionId: session?.resumeSessionId ?? null
+  };
+});
+
+if (afterState.activeId !== beforeState.sid) {
+  fail(`activeId changed: was ${beforeState.sid}, now ${afterState.activeId}`);
+}
+if (afterState.sessionCount !== beforeState.count) {
+  fail(`session count changed: was ${beforeState.count}, now ${afterState.sessionCount}`);
+}
+if (afterState.blocks.length !== 1 || afterState.blocks[0].kind !== 'status' || afterState.blocks[0].title !== 'Context cleared') {
+  fail(`expected exactly one status "Context cleared" block; got ${JSON.stringify(afterState.blocks)}`);
+}
+if (afterState.started) fail('startedSessions[id] should be cleared');
+if (afterState.stats !== null) fail('statsBySession[id] should be cleared');
+if (afterState.resumeSessionId) fail(`resumeSessionId should be dropped; still ${afterState.resumeSessionId}`);
+
+// And the visible chat stream must not contain the old user text.
+const stillSeesOld = await page.getByText('hello world').first().isVisible().catch(() => false);
+if (stillSeesOld) fail('old transcript text still visible after /clear');
+
+// Visible breadcrumb confirms /clear ran.
+const banner = page.locator('[role="status"]').filter({ hasText: 'Context cleared' });
+if (!(await banner.first().isVisible().catch(() => false))) {
+  fail('"Context cleared" status banner not visible');
+}
+
+if (errors.length > 0) {
+  console.error('--- console / page errors ---');
+  for (const e of errors) console.error(e);
+}
+
+console.log('\n[probe-slash-clear] OK');
+console.log(`  sidebar count unchanged at ${afterCount}`);
+console.log(`  activeId preserved (${afterState.activeId})`);
+console.log('  transcript wiped, "Context cleared" breadcrumb shown');
+console.log('  startedSessions / statsBySession / resumeSessionId all dropped');
+
+await browser.close();

--- a/scripts/probe-slash-exec.mjs
+++ b/scripts/probe-slash-exec.mjs
@@ -78,13 +78,19 @@ await costBanner.first().waitFor({ state: 'visible', timeout: 3000 }).catch(() =
 });
 
 // --- 3. /clear --------------------------------------------------------
+// /clear must wipe transcript in-place: same session, same id, no new
+// sidebar entry. Detailed assertions live in scripts/probe-slash-clear.mjs.
 const sidebarItems = page.locator('[role="option"]');
 const beforeCount = await sidebarItems.count();
 await sendSlash('/clear');
 await page.waitForTimeout(200);
 const afterCount = await sidebarItems.count();
-if (afterCount !== beforeCount + 1) {
-  fail(`/clear should add a session (had ${beforeCount}, now ${afterCount})`);
+if (afterCount !== beforeCount) {
+  fail(`/clear must NOT add a session (had ${beforeCount}, now ${afterCount})`);
+}
+const clearBanner = page.locator('[role="status"]').filter({ hasText: 'Context cleared' });
+if (!(await clearBanner.isVisible().catch(() => false))) {
+  fail('/clear did not render a "Context cleared" status block');
 }
 // Confirm textarea is empty (send cleared the draft).
 const postClearValue = await textarea.inputValue();
@@ -108,7 +114,7 @@ if (errors.length > 0) {
 console.log('\n[probe-slash-exec] OK');
 console.log('  /help → banner lists registry with client/passthru tags');
 console.log('  /cost → banner rendered (no data yet path)');
-console.log('  /clear → new session created and active');
+console.log('  /clear → context wiped in place, sidebar count unchanged');
 console.log('  /config → Settings dialog opened');
 
 await browser.close();

--- a/scripts/probe-slash-help.mjs
+++ b/scripts/probe-slash-help.mjs
@@ -1,0 +1,106 @@
+// Probe: /help renders the registry locally and is NOT forwarded to claude.exe.
+//
+// Coverage:
+//   1. Send `/help`.
+//   2. A "Slash commands" status block appears in the chat stream.
+//   3. The block lists at least the well-known commands: /help, /clear,
+//      /config, /model, /cost, /pr, plus a pass-through example like /doctor.
+//   4. Both `(client)` and `(passthru)` tags are present so users can tell
+//      which commands hit Agentory vs the agent.
+//   5. /help did NOT take the normal-message send path: no `user` block was
+//      appended to the transcript (the dispatcher returned 'handled' before
+//      the local-echo `appendBlocks` ran). This proves the command stayed
+//      client-side and was not forwarded to claude.exe.
+//   6. The textarea is empty afterwards (the /help text was consumed).
+//
+// Usage:
+//   AGENTORY_DEV_PORT=4193 npm run dev:web   # in another shell
+//   AGENTORY_DEV_PORT=4193 node scripts/probe-slash-help.mjs
+import { chromium } from 'playwright';
+
+const PORT = process.env.AGENTORY_DEV_PORT ?? '4193';
+const URL = `http://localhost:${PORT}/`;
+
+function fail(msg) {
+  console.error(`\n[probe-slash-help] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext();
+const page = await ctx.newPage();
+
+const errors = [];
+page.on('pageerror', (e) => errors.push(`[pageerror] ${e.message}`));
+page.on('console', (m) => {
+  if (m.type() === 'error') errors.push(`[console.error] ${m.text()}`);
+});
+
+await page.goto(URL, { waitUntil: 'networkidle' });
+await page.waitForSelector('aside', { timeout: 15_000 });
+
+const newBtn = page.getByRole('button', { name: /new session/i }).first();
+await newBtn.waitFor({ state: 'visible', timeout: 10_000 });
+await newBtn.click();
+
+const textarea = page.locator('textarea');
+await textarea.waitFor({ state: 'visible', timeout: 5000 });
+
+await textarea.click();
+await textarea.fill('/help');
+await page.waitForTimeout(60);
+await page.keyboard.press('Escape'); // dismiss the picker so Enter sends
+await page.waitForTimeout(40);
+await page.keyboard.press('Enter');
+await page.waitForTimeout(300);
+
+// 1. Banner appears.
+const banner = page.locator('[role="status"]').filter({ hasText: 'Slash commands' });
+await banner.first().waitFor({ state: 'visible', timeout: 3000 }).catch(() => {
+  fail('"Slash commands" status banner did not appear');
+});
+
+// 2. Banner lists key commands and category tags.
+const text = await banner.first().innerText();
+for (const needle of ['/help', '/clear', '/config', '/model', '/cost', '/pr', '/doctor']) {
+  if (!text.includes(needle)) fail(`/help banner missing ${needle}`);
+}
+if (!text.includes('(client)')) fail('/help banner missing (client) tag');
+if (!text.includes('(passthru)')) fail('/help banner missing (passthru) tag');
+if (!/Commands starting with/.test(text)) {
+  fail('/help banner missing the legend explaining the ⚠ marker');
+}
+
+// 3. Inspect the store: the only block in the transcript should be the
+// "Slash commands" status. If /help had been forwarded, InputBar would have
+// appended a `user` block (local echo) before invoking agentSend.
+const blocks = await page.evaluate(() => {
+  const store = /** @type {any} */ (window).__agentoryStore;
+  const s = store.getState();
+  return s.messagesBySession[s.activeId] ?? [];
+});
+if (!blocks) fail('window.__agentoryStore not exposed; cannot inspect transcript');
+const userBlocks = blocks.filter((b) => b.kind === 'user');
+if (userBlocks.length > 0) {
+  fail(`/help must not echo a user block (forwarded path). Found: ${JSON.stringify(userBlocks)}`);
+}
+const statusBlocks = blocks.filter((b) => b.kind === 'status' && b.title === 'Slash commands');
+if (statusBlocks.length !== 1) {
+  fail(`expected exactly one "Slash commands" status block; got ${statusBlocks.length}`);
+}
+
+// 4. Textarea is empty.
+const value = await textarea.inputValue();
+if (value !== '') fail(`textarea should be empty after /help, got "${value}"`);
+
+if (errors.length > 0) {
+  console.error('--- console / page errors ---');
+  for (const e of errors) console.error(e);
+}
+
+console.log('\n[probe-slash-help] OK');
+console.log('  /help rendered the registry banner with client + passthru tags');
+console.log('  no user block echoed → handler stayed local (no claude.exe forward)');
+console.log('  textarea cleared');
+
+await browser.close();

--- a/src/slash-commands/handlers.ts
+++ b/src/slash-commands/handlers.ts
@@ -46,20 +46,37 @@ function formatCost(usd: number): string {
 }
 
 // ---------- /clear ----------
-// Create a fresh session in the same group and switch to it. The old session
-// gets an info banner so the user has a breadcrumb if they want to flip back.
+// Wipe the CURRENT session's conversation context (transcript, queue, stats,
+// resume id) without removing the session row. The CLI's `/clear` keeps you
+// in the same prompt — Agentory must do the same so the sidebar count stays
+// stable. After this runs the next user message triggers a fresh `agentStart`
+// (no `--resume`), giving claude.exe an empty context window.
+//
+// Earlier implementations called `store.createSession(...)` here, which made
+// the sidebar count jump by one on every /clear — surprising users into
+// thinking the command misfired. Don't do that.
 export function handleClear(ctx: SlashCommandContext): void {
   const store = useStore.getState();
-  const current = store.sessions.find((s) => s.id === ctx.sessionId);
-  // Leave a breadcrumb in the OLD session before switching away.
+  const session = store.sessions.find((s) => s.id === ctx.sessionId);
+  if (!session) return;
+  const wasRunning = !!store.runningSessions[ctx.sessionId];
+  // Tear down any in-flight claude.exe conversation so the next message
+  // triggers `agentStart`, not `agentSend` against a stale process.
+  // Fire-and-forget — the IPC bridge may be absent in browser-only probes.
+  if (wasRunning) {
+    void window.agentory?.agentClose?.(ctx.sessionId);
+  }
+  store.resetSessionContext(ctx.sessionId);
+  // Drop a single breadcrumb so the user can see /clear actually ran.
   store.appendBlocks(ctx.sessionId, [
-    { kind: 'status', id: nextId('clear'), tone: 'info', title: 'New session created', detail: 'Context cleared — switched to a fresh session.' }
+    {
+      kind: 'status',
+      id: nextId('clear'),
+      tone: 'info',
+      title: 'Context cleared',
+      detail: 'Conversation history wiped. The next message starts a fresh turn.'
+    }
   ]);
-  // `createSession` picks the focused / active group automatically and flips
-  // activeId. We don't need to pass cwd — it'll inherit from the active
-  // session's recent projects / defaults. If we DO know the old cwd though,
-  // use it so the fresh session starts in the same folder.
-  store.createSession(current?.cwd ?? null);
 }
 
 // ---------- /cost ----------

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -245,6 +245,13 @@ type Actions = {
   streamAssistantText: (sessionId: string, blockId: string, appendText: string, done: boolean) => void;
   setToolResult: (sessionId: string, toolUseId: string, result: string, isError: boolean) => void;
   clearMessages: (sessionId: string) => void;
+  /** Wipe everything that pins a session to a specific claude.exe conversation
+   *  (transcript, queue, started/running/interrupted flags, stats, resume id)
+   *  WITHOUT removing the session row itself. After this runs the next user
+   *  message triggers a fresh `agentStart` with no `--resume` — exactly what
+   *  the CLI's `/clear` does. The Session entity (id, name, group, cwd) is
+   *  preserved so the sidebar count is unchanged. */
+  resetSessionContext: (sessionId: string) => void;
   replaceMessages: (sessionId: string, blocks: MessageBlock[]) => void;
   loadMessages: (sessionId: string) => Promise<void>;
   markStarted: (sessionId: string) => void;
@@ -790,6 +797,43 @@ export const useStore = create<State & Actions>((set, get) => ({
       delete next[sessionId];
       return { messagesBySession: next };
     });
+  },
+
+  resetSessionContext: (sessionId) => {
+    set((s) => {
+      // Bail early if the session vanished (race against deleteSession).
+      if (!s.sessions.some((x) => x.id === sessionId)) return s;
+      const nextMessages = { ...s.messagesBySession };
+      delete nextMessages[sessionId];
+      const nextStarted = { ...s.startedSessions };
+      delete nextStarted[sessionId];
+      const nextRunning = { ...s.runningSessions };
+      delete nextRunning[sessionId];
+      const nextInterrupted = { ...s.interruptedSessions };
+      delete nextInterrupted[sessionId];
+      const nextQueues = { ...s.messageQueues };
+      delete nextQueues[sessionId];
+      const nextStats = { ...s.statsBySession };
+      delete nextStats[sessionId];
+      // Drop resumeSessionId so the next agentStart spawns a fresh
+      // claude.exe conversation rather than continuing the old one.
+      const nextSessions = s.sessions.map((x) => {
+        if (x.id !== sessionId || x.resumeSessionId === undefined) return x;
+        const { resumeSessionId: _drop, ...rest } = x;
+        return rest as typeof x;
+      });
+      return {
+        sessions: nextSessions,
+        messagesBySession: nextMessages,
+        startedSessions: nextStarted,
+        runningSessions: nextRunning,
+        interruptedSessions: nextInterrupted,
+        messageQueues: nextQueues,
+        statsBySession: nextStats
+      };
+    });
+    // Wipe persisted transcript so a reload doesn't resurrect history.
+    void window.agentory?.saveMessages(sessionId, []);
   },
 
   replaceMessages: (sessionId, blocks) => {

--- a/tests/slash-commands-handlers.test.ts
+++ b/tests/slash-commands-handlers.test.ts
@@ -104,15 +104,37 @@ describe('registry shape', () => {
 });
 
 describe('/clear', () => {
-  it('creates a new session and switches to it, leaving a breadcrumb on the old', () => {
+  it('wipes the current session context without changing session count or activeId', () => {
     useStore.getState().createSession('/tmp/old');
     const oldId = useStore.getState().activeId;
+    // Seed transcript + state that /clear must wipe.
+    useStore.getState().appendBlocks(oldId, [
+      { kind: 'user', id: 'u1', text: 'hi' },
+      { kind: 'assistant', id: 'a1', text: 'hello' }
+    ]);
+    useStore.getState().markStarted(oldId);
+    useStore.getState().addSessionStats(oldId, { turns: 1, inputTokens: 100, outputTokens: 50, costUsd: 0.001 });
+    useStore.setState((s) => ({
+      sessions: s.sessions.map((x) => (x.id === oldId ? { ...x, resumeSessionId: 'cc-abc' } : x))
+    }));
+    const sessionCountBefore = useStore.getState().sessions.length;
+
     handleClear({ sessionId: oldId, args: '' });
+
     const s = useStore.getState();
-    expect(s.sessions.length).toBe(2);
-    expect(s.activeId).not.toBe(oldId);
-    const oldBlocks = s.messagesBySession[oldId] ?? [];
-    expect(oldBlocks.some((b) => b.kind === 'status' && b.title === 'New session created')).toBe(true);
+    expect(s.sessions.length).toBe(sessionCountBefore); // no new session
+    expect(s.activeId).toBe(oldId); // active session unchanged
+    const session = s.sessions.find((x) => x.id === oldId)!;
+    expect(session.resumeSessionId).toBeUndefined(); // resume id dropped
+    expect(s.startedSessions[oldId]).toBeUndefined();
+    expect(s.statsBySession[oldId]).toBeUndefined();
+    // Transcript only contains the new "Context cleared" breadcrumb.
+    const blocks = s.messagesBySession[oldId] ?? [];
+    expect(blocks.length).toBe(1);
+    expect(blocks[0].kind).toBe('status');
+    if (blocks[0].kind === 'status') {
+      expect(blocks[0].title).toBe('Context cleared');
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- **/clear bug fix**: `handleClear` previously called `store.createSession(...)`, so each invocation pushed a new row into the sidebar (5 → 6 in the user report) instead of clearing the current conversation. Replaced with an in-place reset that matches CLI semantics.
- **New store action `resetSessionContext(sessionId)`**: wipes transcript, queue, started/running/interrupted flags, stats, and `resumeSessionId` while preserving the `Session` row (id, name, group, cwd) so the sidebar count is unchanged. Persisted transcript is also cleared.
- **/clear flow**: if a turn is running, `agentClose` first; then `resetSessionContext`; then a single `Context cleared` status breadcrumb. The next user message triggers a fresh `agentStart` (no `--resume`).
- **/help confirmed local**: handler was already a `clientHandler` that appends a status block; the new probe locks in that behavior and proves it isn't forwarded to `claude.exe`.

## Tests / probes

- Updated `tests/slash-commands-handlers.test.ts` `/clear` case (it was asserting the buggy behavior). 17/17 handlers tests pass.
- New `scripts/probe-slash-clear.mjs`:
  - sidebar count unchanged after `/clear`
  - `activeId` preserved
  - transcript reduced to just the breadcrumb
  - `startedSessions` / `statsBySession` / `resumeSessionId` all dropped
- New `scripts/probe-slash-help.mjs`:
  - "Slash commands" status banner appears with all key commands and both `(client)` / `(passthru)` tags
  - no `user` block is echoed → dispatcher returned `handled` and InputBar never forwarded the text to `claude.exe`
  - textarea cleared
- Updated `scripts/probe-slash-exec.mjs` to assert the new in-place behavior instead of the old "adds a session" expectation.

Both new probes verified green against `npm run dev:web`.

## Test plan

- [ ] `npm test` (slash handlers suite green; pre-existing better-sqlite3 native-binding failures are unrelated to this change)
- [ ] `npm run typecheck`
- [ ] `AGENTORY_DEV_PORT=4292 npm run dev:web` then `node scripts/probe-slash-clear.mjs` → OK
- [ ] same dev server, then `node scripts/probe-slash-help.mjs` → OK
- [ ] manual: send a few messages, run `/clear`, confirm sidebar count is unchanged and transcript is wiped
- [ ] manual: run `/help`, confirm the registry banner appears and `claude.exe` is not invoked

🤖 Generated with [Claude Code](https://claude.com/claude-code)