### PR TITLE
feat(slash): /cost local render + /compact handler

### DIFF
--- a/scripts/probe-slash-compact.mjs
+++ b/scripts/probe-slash-compact.mjs
@@ -1,0 +1,203 @@
+// Probe: /compact end-to-end (renderer-only).
+//
+// Verifies the pass-through path for /compact:
+//   1. Stub window.agentory so we can capture both the registered
+//      onAgentEvent listener AND every agentSend call.
+//   2. Type `/compact` + Enter — the dispatcher returns 'pass-through' so
+//      InputBar runs the normal send path, which forwards the literal text
+//      to claude.exe via api.agentSend.
+//   3. Confirm the captured agentSend call carries `/compact`. (This is the
+//      whole point of pass-through: the SDK accepts /compact in stream-json
+//      mode per https://code.claude.com/docs/en/agent-sdk/slash-commands.)
+//   4. Fire a fake `system { subtype: 'compact_boundary' }` frame at the
+//      captured listener — this is exactly what the SDK emits when /compact
+//      finishes. Verify the existing systemBlocks() translator renders the
+//      "Conversation compacted (manual) — Compacted N → M tokens" banner.
+//
+// Why no client-side compact handler: the SDK already owns this flow. Adding
+// our own would duplicate the summarisation prompt the CLI already runs and
+// drift out of sync with upstream improvements. Pass-through is the correct
+// answer; this probe is the proof.
+//
+// Usage:
+//   AGENTORY_DEV_PORT=4193 npm run dev:web   # in another shell
+//   AGENTORY_DEV_PORT=4193 node scripts/probe-slash-compact.mjs
+import { chromium } from 'playwright';
+
+const PORT = process.env.AGENTORY_DEV_PORT ?? '4193';
+const URL = `http://localhost:${PORT}/`;
+
+function fail(msg) {
+  console.error(`\n[probe-slash-compact] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext();
+const page = await ctx.newPage();
+
+const errors = [];
+page.on('pageerror', (e) => errors.push(`[pageerror] ${e.message}`));
+page.on('console', (m) => {
+  if (m.type() === 'error') errors.push(`[console.error] ${m.text()}`);
+});
+
+await page.addInitScript(() => {
+  /** @type {Array<(e: any) => void>} */
+  const listeners = [];
+  /** @type {Array<{sessionId: string; text: string}>} */
+  const sends = [];
+  const base = {
+    loadState: async (key) => {
+      if (key !== 'main') return null;
+      return JSON.stringify({
+        version: 1,
+        sessions: [],
+        groups: [{ id: 'g-default', name: 'Sessions', collapsed: false, kind: 'normal' }],
+        activeId: '',
+        model: '',
+        permission: 'default',
+        sidebarCollapsed: false,
+        theme: 'system',
+        fontSize: 'md',
+        recentProjects: [],
+        tutorialSeen: true
+      });
+    },
+    saveState: async () => {},
+    loadMessages: async () => [],
+    saveMessages: async () => {},
+    getDataDir: async () => '/tmp',
+    getVersion: async () => '0.0.0-probe',
+    pickDirectory: async () => null,
+    agentStart: async () => ({ ok: true }),
+    agentSend: async (sessionId, text) => {
+      sends.push({ sessionId, text });
+      return true;
+    },
+    agentSendContent: async () => true,
+    agentInterrupt: async () => true,
+    agentSetPermissionMode: async () => true,
+    agentSetModel: async () => true,
+    agentClose: async () => true,
+    agentResolvePermission: async () => true,
+    onAgentEvent: (cb) => {
+      listeners.push(cb);
+      return () => {};
+    },
+    onAgentExit: () => () => {},
+    onAgentPermissionRequest: () => () => {},
+    scanImportable: async () => [],
+    notify: async () => true,
+    onNotificationFocus: () => () => {},
+    updatesStatus: async () => ({ kind: 'idle' }),
+    updatesCheck: async () => ({ kind: 'idle' }),
+    updatesDownload: async () => ({ ok: true }),
+    updatesInstall: async () => ({ ok: true }),
+    updatesGetAutoCheck: async () => true,
+    updatesSetAutoCheck: async () => true,
+    onUpdateStatus: () => () => {},
+    onUpdateDownloaded: () => () => {},
+    cli: {
+      retryDetect: async () => ({ found: true, path: '/fake/claude', version: '2.1.0' }),
+      getInstallHints: async () => ({ os: 'win32', arch: 'x64', commands: {}, docsUrl: '' }),
+      browseBinary: async () => null,
+      setBinaryPath: async () => ({ ok: true, version: '2.1.0' }),
+      openDocs: async () => true
+    },
+    window: {
+      minimize: async () => {},
+      toggleMaximize: async () => false,
+      close: async () => {},
+      isMaximized: async () => false,
+      onMaximizedChanged: () => () => {},
+      platform: 'win32'
+    },
+    connection: {
+      read: async () => ({ baseUrl: null, model: null, hasAuthToken: false }),
+      openSettingsFile: async () => ({ ok: true })
+    },
+    models: { list: async () => [] },
+    openExternal: async () => true
+  };
+  Object.defineProperty(window, 'agentory', { value: base, writable: true, configurable: true });
+  /** @type {any} */ (window).__probeAgentEmit = (e) => {
+    for (const l of listeners) l(e);
+  };
+  /** @type {any} */ (window).__probeAgentSends = sends;
+});
+
+await page.goto(URL, { waitUntil: 'networkidle' });
+await page.waitForSelector('aside', { timeout: 15_000 });
+
+const newBtn = page.getByRole('button', { name: /new session/i }).first();
+await newBtn.waitFor({ state: 'visible', timeout: 10_000 });
+await newBtn.click();
+
+const textarea = page.locator('textarea');
+await textarea.waitFor({ state: 'visible', timeout: 5000 });
+
+const sid = await page.evaluate(() => /** @type {any} */ (window).__agentoryStore.getState().activeId);
+if (!sid) fail('no active session id after createSession');
+
+// --- 1. Type /compact + Enter. Dismiss the picker first so Enter sends.
+await textarea.click();
+await textarea.fill('/compact');
+await page.waitForTimeout(60);
+await page.keyboard.press('Escape');
+await page.waitForTimeout(60);
+await page.keyboard.press('Enter');
+await page.waitForTimeout(200);
+
+// --- 2. Confirm the literal /compact text was forwarded via agentSend.
+const sends = await page.evaluate(() => /** @type {any} */ (window).__probeAgentSends);
+if (!Array.isArray(sends) || sends.length === 0) fail('agentSend was never called for /compact');
+const last = sends[sends.length - 1];
+if (last.text !== '/compact') {
+  fail(`expected agentSend text "/compact", got "${last.text}"`);
+}
+if (last.sessionId !== sid) {
+  fail(`expected agentSend sessionId="${sid}", got "${last.sessionId}"`);
+}
+
+// --- 3. Inject the compact_boundary system frame the SDK emits when the
+//        compaction completes. systemBlocks() should render a status banner.
+await page.evaluate((sessionId) => {
+  /** @type {any} */ (window).__probeAgentEmit({
+    sessionId,
+    message: {
+      type: 'system',
+      subtype: 'compact_boundary',
+      session_id: sessionId,
+      uuid: 'probe-compact-boundary-1',
+      compact_metadata: {
+        trigger: 'manual',
+        pre_tokens: 98700,
+        post_tokens: 21450,
+        duration_ms: 960
+      }
+    }
+  });
+}, sid);
+await page.waitForTimeout(150);
+
+const banner = page.locator('[role="status"]').filter({ hasText: 'Conversation compacted' });
+await banner.first().waitFor({ state: 'visible', timeout: 3000 }).catch(() => {
+  fail('compact_boundary did not render a "Conversation compacted" status banner');
+});
+const text = await banner.first().innerText();
+if (!/manual/i.test(text)) fail(`expected "manual" trigger label in banner, got: ${text}`);
+if (!/98,?700/.test(text)) fail(`expected pre_tokens 98700 in banner, got: ${text}`);
+if (!/21,?450/.test(text)) fail(`expected post_tokens 21450 in banner, got: ${text}`);
+if (!/960\s*ms/.test(text)) fail(`expected duration "960ms" in banner, got: ${text}`);
+
+if (errors.length > 0) {
+  console.error('--- console / page errors ---');
+  for (const e of errors) console.error(e);
+}
+
+console.log('\n[probe-slash-compact] OK');
+console.log('  /compact forwarded literally to agentSend (pass-through verified)');
+console.log('  compact_boundary frame -> "Conversation compacted (manual)" banner');
+
+await browser.close();

--- a/scripts/probe-slash-cost.mjs
+++ b/scripts/probe-slash-cost.mjs
@@ -1,0 +1,216 @@
+// Probe: /cost end-to-end (renderer-only).
+//
+// Verifies the full /cost loop:
+//   1. Stub window.agentory so we can capture the registered onAgentEvent
+//      listener and trigger the pieces of the agent flow without a live
+//      claude.exe.
+//   2. Create a session, type a user message, send it.
+//   3. Fire a fake `result` frame at the captured listener carrying realistic
+//      `usage` + `total_cost_usd` numbers — agent/lifecycle.ts feeds these
+//      into store.addSessionStats().
+//   4. Type `/cost` + Enter and confirm the rendered status banner contains
+//      both the formatted token counts and the cost.
+//
+// Strategy mirrors probe-slash-pr / probe-slash-exec: we run against the
+// webpack dev server (no Electron / no IPC). The renderer's
+// subscribeAgentEvents() runs once at module load, so by stubbing
+// window.agentory.onAgentEvent inside addInitScript we observe the real
+// listener that will be invoked in production.
+//
+// Usage:
+//   AGENTORY_DEV_PORT=4192 npm run dev:web   # in another shell
+//   AGENTORY_DEV_PORT=4192 node scripts/probe-slash-cost.mjs
+import { chromium } from 'playwright';
+
+const PORT = process.env.AGENTORY_DEV_PORT ?? '4192';
+const URL = `http://localhost:${PORT}/`;
+
+function fail(msg) {
+  console.error(`\n[probe-slash-cost] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext();
+const page = await ctx.newPage();
+
+const errors = [];
+page.on('pageerror', (e) => errors.push(`[pageerror] ${e.message}`));
+page.on('console', (m) => {
+  if (m.type() === 'error') errors.push(`[console.error] ${m.text()}`);
+});
+
+// Install the agentory stub BEFORE app code runs so subscribeAgentEvents()
+// captures *our* onAgentEvent. We expose the captured listener back on
+// window.__probeAgentEmit so the probe can shoot synthetic events into it
+// from the page later.
+await page.addInitScript(() => {
+  /** @type {Array<(e: any) => void>} */
+  const listeners = [];
+  /** @type {Array<{sessionId: string; text: string}>} */
+  const sends = [];
+  const base = {
+    loadState: async (key) => {
+      if (key !== 'main') return null;
+      return JSON.stringify({
+        version: 1,
+        sessions: [],
+        groups: [{ id: 'g-default', name: 'Sessions', collapsed: false, kind: 'normal' }],
+        activeId: '',
+        model: '',
+        permission: 'default',
+        sidebarCollapsed: false,
+        theme: 'system',
+        fontSize: 'md',
+        recentProjects: [],
+        tutorialSeen: true
+      });
+    },
+    saveState: async () => {},
+    loadMessages: async () => [],
+    saveMessages: async () => {},
+    getDataDir: async () => '/tmp',
+    getVersion: async () => '0.0.0-probe',
+    pickDirectory: async () => null,
+    agentStart: async () => ({ ok: true }),
+    agentSend: async (sessionId, text) => {
+      sends.push({ sessionId, text });
+      return true;
+    },
+    agentSendContent: async () => true,
+    agentInterrupt: async () => true,
+    agentSetPermissionMode: async () => true,
+    agentSetModel: async () => true,
+    agentClose: async () => true,
+    agentResolvePermission: async () => true,
+    onAgentEvent: (cb) => {
+      listeners.push(cb);
+      return () => {};
+    },
+    onAgentExit: () => () => {},
+    onAgentPermissionRequest: () => () => {},
+    scanImportable: async () => [],
+    notify: async () => true,
+    onNotificationFocus: () => () => {},
+    updatesStatus: async () => ({ kind: 'idle' }),
+    updatesCheck: async () => ({ kind: 'idle' }),
+    updatesDownload: async () => ({ ok: true }),
+    updatesInstall: async () => ({ ok: true }),
+    updatesGetAutoCheck: async () => true,
+    updatesSetAutoCheck: async () => true,
+    onUpdateStatus: () => () => {},
+    onUpdateDownloaded: () => () => {},
+    cli: {
+      retryDetect: async () => ({ found: true, path: '/fake/claude', version: '2.1.0' }),
+      getInstallHints: async () => ({ os: 'win32', arch: 'x64', commands: {}, docsUrl: '' }),
+      browseBinary: async () => null,
+      setBinaryPath: async () => ({ ok: true, version: '2.1.0' }),
+      openDocs: async () => true
+    },
+    window: {
+      minimize: async () => {},
+      toggleMaximize: async () => false,
+      close: async () => {},
+      isMaximized: async () => false,
+      onMaximizedChanged: () => () => {},
+      platform: 'win32'
+    },
+    connection: {
+      read: async () => ({ baseUrl: null, model: null, hasAuthToken: false }),
+      openSettingsFile: async () => ({ ok: true })
+    },
+    models: { list: async () => [] },
+    openExternal: async () => true
+  };
+  Object.defineProperty(window, 'agentory', { value: base, writable: true, configurable: true });
+  /** @type {any} */ (window).__probeAgentEmit = (e) => {
+    for (const l of listeners) l(e);
+  };
+  /** @type {any} */ (window).__probeAgentSends = sends;
+});
+
+await page.goto(URL, { waitUntil: 'networkidle' });
+await page.waitForSelector('aside', { timeout: 15_000 });
+
+const newBtn = page.getByRole('button', { name: /new session/i }).first();
+await newBtn.waitFor({ state: 'visible', timeout: 10_000 });
+await newBtn.click();
+
+const textarea = page.locator('textarea');
+await textarea.waitFor({ state: 'visible', timeout: 5000 });
+
+// Capture the active session id from the dev-mode store shim.
+const sid = await page.evaluate(() => /** @type {any} */ (window).__agentoryStore.getState().activeId);
+if (!sid) fail('no active session id after createSession');
+
+// --- 1. Send a real user message via the InputBar so the agent flow runs.
+await textarea.click();
+await textarea.fill('hello cost probe');
+await page.keyboard.press('Enter');
+// Wait for the local-echo user block to land + InputBar to flip running=true.
+await page.waitForTimeout(150);
+
+// --- 2. Inject a synthetic `result` frame that lifecycle aggregates into
+//        statsBySession. Numbers are deliberately big enough that the
+//        formatTokens helper renders "12k" / "678" / "$0.023" etc.
+await page.evaluate((sessionId) => {
+  /** @type {any} */ (window).__probeAgentEmit({
+    sessionId,
+    message: {
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      num_turns: 1,
+      total_cost_usd: 0.0234,
+      usage: {
+        input_tokens: 12000,
+        output_tokens: 678,
+        cache_creation_input_tokens: 200,
+        cache_read_input_tokens: 145
+      }
+    }
+  });
+}, sid);
+
+// Give React a tick to flush the addSessionStats setState.
+await page.waitForTimeout(120);
+
+// Sanity: the store actually got the stats.
+const stats = await page.evaluate(
+  (sessionId) => /** @type {any} */ (window).__agentoryStore.getState().statsBySession[sessionId]
+, sid);
+if (!stats) fail('statsBySession entry missing after injecting result');
+if (stats.outputTokens !== 678) fail(`expected outputTokens=678, got ${stats.outputTokens}`);
+if (stats.inputTokens !== 12345) fail(`expected inputTokens=12345 (12000+200+145), got ${stats.inputTokens}`);
+if (Math.abs(stats.costUsd - 0.0234) > 1e-9) fail(`expected costUsd=0.0234, got ${stats.costUsd}`);
+
+// --- 3. Type `/cost` and submit. The picker opens for `/`; press Escape
+//        first so Enter sends instead of selecting the highlighted row.
+await textarea.click();
+await textarea.fill('/cost');
+await page.waitForTimeout(60);
+await page.keyboard.press('Escape');
+await page.waitForTimeout(60);
+await page.keyboard.press('Enter');
+await page.waitForTimeout(200);
+
+const banner = page.locator('[role="status"]').filter({ hasText: 'Session cost' });
+await banner.first().waitFor({ state: 'visible', timeout: 3000 }).catch(() => {
+  fail('/cost did not render a "Session cost" status banner');
+});
+const text = await banner.first().innerText();
+if (!/12k in/.test(text)) fail(`expected "12k in" token format in banner, got: ${text}`);
+if (!/678 out/.test(text)) fail(`expected "678 out" in banner, got: ${text}`);
+if (!/\$0\.023/.test(text)) fail(`expected formatted cost "$0.023" in banner, got: ${text}`);
+if (!/1 turn\b/.test(text)) fail(`expected "1 turn" in banner, got: ${text}`);
+
+if (errors.length > 0) {
+  console.error('--- console / page errors ---');
+  for (const e of errors) console.error(e);
+}
+
+console.log('\n[probe-slash-cost] OK');
+console.log('  injected result frame -> statsBySession aggregated correctly');
+console.log('  /cost banner shows tokens + cost +' + ' turn count');
+
+await browser.close();

--- a/src/slash-commands/handlers.ts
+++ b/src/slash-commands/handlers.ts
@@ -121,10 +121,13 @@ export function handleHelp(ctx: SlashCommandContext): void {
 }
 
 // ---------- /compact ----------
-// Pass-through to claude.exe — Agentory no longer owns a one-off summarise
-// path now that endpoints/keys live in ~/.claude/settings.json (the renderer
-// has no API key to call /v1/messages with). The CLI's own /compact handles
-// it natively.
+// Pass-through to claude.exe. The Agent SDK natively handles `/compact` when
+// sent as a prompt in stream-json mode — see
+// https://code.claude.com/docs/en/agent-sdk/slash-commands. The CLI emits a
+// `system { subtype: 'compact_boundary', compact_metadata }` frame which our
+// systemBlocks() translator already renders as a status banner ("Conversation
+// compacted (manual) — Compacted N → M tokens in T ms"). No client-side work
+// needed; we just trust the SDK and let the existing translator surface it.
 //
 // `blocksToTranscript` is still exported below for tests and future reuse.
 

--- a/src/slash-commands/registry.ts
+++ b/src/slash-commands/registry.ts
@@ -63,10 +63,13 @@ export type SlashCommand = {
 //
 // `passThrough: false` = we handle locally (see src/slash-commands/handlers.ts).
 // `passThrough: true`  = forwarded to claude.exe via the normal message path.
-//   Note: claude.exe in --input-format stream-json mode silently drops most
-//   slash commands. We still forward them because (a) the list may grow or
-//   be fixed upstream, and (b) silently eating the `/foo` text is less bad
-//   than pretending it isn't a command.
+//   Per the Agent SDK slash-commands docs, the SDK *does* dispatch slash
+//   commands sent as the prompt body in stream-json mode — `/compact`,
+//   `/context`, etc. are all honoured. The `init` system frame's
+//   `slash_commands` field lists what the current session supports. Anything
+//   we forward that the SDK doesn't recognise lands as a no-op user message
+//   (visible in the local echo but not actioned), which is preferable to
+//   silently swallowing the `/foo` text on our side.
 export const SLASH_COMMANDS: SlashCommand[] = [
   { name: 'help',    description: 'List available commands',                       icon: HelpCircle,       category: 'built-in', passThrough: false },
   { name: 'clear',   description: 'Start a new conversation and clear context',    icon: Eraser,           category: 'built-in', passThrough: false },


### PR DESCRIPTION
## Summary

- **/cost**: already wired to render per-session token / cost / turn counters from aggregated `result` frames. Added `scripts/probe-slash-cost.mjs` that injects a synthetic `result` frame at the captured `onAgentEvent` listener and verifies the rendered status banner contains the formatted tokens (`12k in / 678 out`), cost (`\$0.023`), and turn count.
- **/compact**: stays pass-through. Per the [Agent SDK slash-commands docs](https://code.claude.com/docs/en/agent-sdk/slash-commands), the SDK natively handles `/compact` when sent as a prompt in stream-json input mode and emits a `system { subtype: 'compact_boundary' }` frame on completion. Our `systemBlocks()` translator already renders that frame as a status banner ("Conversation compacted (manual) — Compacted N → M tokens in T ms"). Added `scripts/probe-slash-compact.mjs` that verifies (a) the literal `/compact` text reaches `api.agentSend`, and (b) the injected `compact_boundary` frame produces the expected banner.
- Updated comments in `registry.ts` / `handlers.ts` — the prior text claimed claude.exe silently drops slash commands in stream-json mode, which contradicts the docs and is no longer accurate.

## Why no client-side compact handler

Researched the SDK first. The CLI owns the summarisation prompt and emits the `compact_boundary` boundary frame; reimplementing that in the renderer would duplicate logic and drift from upstream. Pass-through is the correct answer; the probe is the proof.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 41 files / 548 tests passing (existing /cost handler unit tests already cover the formatter / placeholder paths)
- [x] `AGENTORY_DEV_PORT=4192 npm run dev:web` + `node scripts/probe-slash-cost.mjs` → OK (banner shows `1 turn · 12k in / 678 out · \$0.023`)
- [x] `node scripts/probe-slash-compact.mjs` → OK (`/compact` forwarded literally; compact_boundary frame produces "Conversation compacted (manual)" banner with pre/post tokens + duration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)