### PR TITLE
test(e2e): batch E — palette/import/shortcuts

### DIFF
--- a/scripts/probe-e2e-import-session.mjs
+++ b/scripts/probe-e2e-import-session.mjs
@@ -1,0 +1,159 @@
+// E2E: import session via the sidebar Import button + ImportDialog.
+//
+// Flow under test:
+//   1. User clicks the sidebar Import button.
+//   2. ImportDialog mounts and calls `import:scan` IPC; we mock that handler
+//      in the MAIN process so the test does not depend on the user's real
+//      ~/.claude/projects folder.
+//   3. The fixture row appears in the dialog. User selects it, clicks Import.
+//   4. Dialog closes. Sidebar gains a new session whose name = fixture title,
+//      and the store reflects the new session backed by importSession() with
+//      the resumeSessionId we mocked.
+//
+// Pure black-box for the dialog UI; the post-condition assertion uses the
+// public __agentoryStore handle.
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import fs from 'node:fs';
+import os from 'node:os';
+import { appWindow } from './probe-utils.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function fail(msg) {
+  console.error(`\n[probe-e2e-import-session] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agentory-probe-import-'));
+
+const FIXTURE = {
+  sessionId: 'fixture-resume-id-12345',
+  cwd: '/tmp/fixture-cwd',
+  title: 'Fixture imported session',
+  // mtime: ~ now, so it lands in the "Today" bucket.
+  mtime: Date.now(),
+  projectDir: '-tmp-fixture-cwd',
+  model: 'claude-opus-4'
+};
+
+const app = await electron.launch({
+  args: ['.', `--user-data-dir=${userDataDir}`],
+  cwd: root,
+  env: { ...process.env, NODE_ENV: 'development' }
+});
+
+// Wait for the renderer window to mount FIRST — that guarantees the main
+// process has finished registering the original `import:scan` IPC handler
+// (those registrations sit inside whenReady → before createWindow). Only then
+// is it safe to remove + re-register with our fixture.
+const errors = [];
+const win = await appWindow(app);
+win.on('pageerror', (e) => errors.push(`[pageerror] ${e.message}`));
+win.on('console', (m) => {
+  if (m.type() === 'error') errors.push(`[console.error] ${m.text()}`);
+});
+
+await win.waitForLoadState('domcontentloaded');
+await win.waitForFunction(() => !!window.__agentoryStore, null, { timeout: 10_000 });
+
+// Replace the `import:scan` IPC handler with one that returns our fixture.
+// The renderer-side ImportDialog does no transformation beyond filtering out
+// sessionIds that already exist in the store, so the fixture passes through.
+await app.evaluate(async ({ ipcMain }, fixture) => {
+  try { ipcMain.removeHandler('import:scan'); } catch {}
+  ipcMain.handle('import:scan', () => [fixture]);
+}, FIXTURE);
+
+// Force a known starting state: zero sessions, tutorial seen — so the
+// landing page renders the sidebar Import button and the dialog opens
+// against a clean slate.
+await win.evaluate(() => {
+  window.__agentoryStore.setState({
+    sessions: [],
+    groups: [{ id: 'g-default', name: 'Sessions', collapsed: false, kind: 'normal' }],
+    activeId: '',
+    tutorialSeen: true
+  });
+});
+await win.waitForTimeout(200);
+
+const sessionsBefore = await win.evaluate(() => window.__agentoryStore.getState().sessions.length);
+if (sessionsBefore !== 0) {
+  await app.close();
+  fail(`expected 0 sessions before import, got ${sessionsBefore}`);
+}
+
+// 1. Click the sidebar Import button (aria-label "Import session").
+const importBtn = win.locator('aside').getByRole('button', { name: /import session/i }).first();
+await importBtn.waitFor({ state: 'visible', timeout: 10_000 }).catch(async () => {
+  const html = await win.evaluate(() => document.body.innerText.slice(0, 800));
+  console.error('--- body text ---\n' + html);
+  await app.close();
+  fail('sidebar Import button not visible');
+});
+await importBtn.click();
+
+// 2. Dialog opens, fixture row should appear (title = "Fixture imported session").
+const fixtureRow = win.getByText('Fixture imported session').first();
+await fixtureRow.waitFor({ state: 'visible', timeout: 5000 }).catch(async () => {
+  const dump = await win.evaluate(() => document.body.innerText.slice(0, 1500));
+  console.error('--- body at failure ---\n' + dump);
+  console.error('--- errors ---\n' + errors.slice(-10).join('\n'));
+  await app.close();
+  fail('fixture session row never appeared in ImportDialog');
+});
+
+// 3. Select it (clicking the row toggles the checkbox via the <li> handler).
+await fixtureRow.click();
+await win.waitForTimeout(120);
+
+// 4. Click Import button. The dialog footer shows "Import 1" — match the
+//    primary CTA by name (uses the i18n importN key, English template
+//    "Import {{count}}").
+const confirmBtn = win.getByRole('button', { name: /^Import 1$/ });
+await confirmBtn.waitFor({ state: 'visible', timeout: 3000 });
+await confirmBtn.click();
+
+// 5. Wait for dialog to close + store to gain a new session.
+await win.waitForFunction(
+  () => window.__agentoryStore.getState().sessions.length === 1,
+  null,
+  { timeout: 5000 }
+).catch(async () => {
+  const sessions = await win.evaluate(() => window.__agentoryStore.getState().sessions);
+  console.error('--- sessions after import ---\n' + JSON.stringify(sessions, null, 2));
+  console.error('--- errors ---\n' + errors.slice(-10).join('\n'));
+  await app.close();
+  fail('importing fixture did not produce exactly 1 session');
+});
+
+const newSession = await win.evaluate(() => window.__agentoryStore.getState().sessions[0]);
+if (newSession.name !== FIXTURE.title) {
+  await app.close();
+  fail(`imported session name=${newSession.name}, expected ${FIXTURE.title}`);
+}
+if (newSession.cwd !== FIXTURE.cwd) {
+  await app.close();
+  fail(`imported session cwd=${newSession.cwd}, expected ${FIXTURE.cwd}`);
+}
+
+// 6. Sidebar should now show the imported session row.
+const sidebarRow = win.locator('aside').getByText(FIXTURE.title).first();
+const sidebarVisible = await sidebarRow.isVisible().catch(() => false);
+if (!sidebarVisible) {
+  await app.close();
+  fail('imported session not visible in sidebar after import');
+}
+
+console.log('\n[probe-e2e-import-session] OK');
+console.log('  sidebar Import button → ImportDialog opened');
+console.log('  fixture row rendered, selected, Import (1) committed');
+console.log(`  store gained 1 session: name="${newSession.name}", cwd="${newSession.cwd}"`);
+console.log('  sidebar shows the imported session');
+
+await app.close();
+
+try { fs.rmSync(userDataDir, { recursive: true, force: true }); } catch {}

--- a/scripts/probe-e2e-palette-empty.mjs
+++ b/scripts/probe-e2e-palette-empty.mjs
@@ -1,0 +1,140 @@
+// E2E: command palette empty state.
+//
+// When the user opens the palette (Cmd/Ctrl+K), it must show ONLY the search
+// input — no results list, no command suggestions. Results appear only after
+// the user types at least one non-whitespace character. Esc closes it.
+//
+// This is the literal repro of #117 ("show only search input until user
+// types"): a regression there would render the full command list immediately
+// on open, defeating the point of a search-driven palette.
+//
+// Pure black-box: keyboard + DOM reads. Isolated userData per run.
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import fs from 'node:fs';
+import os from 'node:os';
+import { appWindow } from './probe-utils.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function fail(msg) {
+  console.error(`\n[probe-e2e-palette-empty] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agentory-probe-palette-empty-'));
+
+const app = await electron.launch({
+  args: ['.', `--user-data-dir=${userDataDir}`],
+  cwd: root,
+  env: { ...process.env, NODE_ENV: 'development' }
+});
+
+const errors = [];
+const win = await appWindow(app);
+win.on('pageerror', (e) => errors.push(`[pageerror] ${e.message}`));
+win.on('console', (m) => {
+  if (m.type() === 'error') errors.push(`[console.error] ${m.text()}`);
+});
+
+await win.waitForLoadState('domcontentloaded');
+await win.waitForFunction(() => !!window.__agentoryStore, null, { timeout: 10_000 });
+
+// Seed a session + group so the palette has something it COULD show — that
+// way the empty-state assertion is meaningful (we're saying "even though
+// matches exist, none should render until the user types").
+await win.evaluate(() => {
+  window.__agentoryStore.setState({
+    sessions: [
+      {
+        id: 's-palette-1',
+        name: 'Alpha session',
+        state: 'idle',
+        cwd: '~/alpha',
+        model: 'claude-opus-4',
+        groupId: 'g-default',
+        agentType: 'claude-code'
+      }
+    ],
+    groups: [{ id: 'g-default', name: 'Sessions', collapsed: false, kind: 'normal' }],
+    activeId: 's-palette-1',
+    tutorialSeen: true
+  });
+});
+await win.waitForTimeout(200);
+
+// 1. Open palette via Cmd+K (Ctrl+K on Win/Linux). The App.tsx handler
+//    listens on window 'keydown' with metaKey || ctrlKey, so synthesizing the
+//    DOM event is the closest analogue to a real keypress.
+await win.evaluate(() => {
+  window.dispatchEvent(
+    new KeyboardEvent('keydown', { key: 'k', code: 'KeyK', ctrlKey: true, bubbles: true })
+  );
+});
+
+// Search input is the only <input> rendered by CommandPalette.
+const searchInput = win.locator('input[placeholder*="Search"]');
+await searchInput.waitFor({ state: 'visible', timeout: 3000 }).catch(async () => {
+  await app.close();
+  fail('palette did not open via Ctrl+K — search input never appeared');
+});
+
+// 2. Empty state: NO option rows should be present INSIDE the palette. The
+//    sidebar also exposes session items as role="option" (DnD-kit sortable),
+//    so we must scope the query to the palette dialog. The CommandPalette
+//    portals into a Radix Dialog (role="dialog") and renders a <ul
+//    role="listbox"> inside it.
+const paletteDialog = win.locator('[role="dialog"]').filter({ has: win.locator('input[placeholder*="Search"]') });
+const paletteOptions = paletteDialog.locator('[role="option"]');
+const optionsBeforeType = await paletteOptions.count();
+if (optionsBeforeType !== 0) {
+  await app.close();
+  fail(`palette rendered ${optionsBeforeType} option(s) on open; expected 0 until user types`);
+}
+
+// The empty hint string from i18n (en) — sanity check the empty-state copy is
+// actually what greets the user (not a stale "No matches" or worse).
+const hintVisible = await win.getByText(/Type to search/i).isVisible().catch(() => false);
+if (!hintVisible) {
+  await app.close();
+  fail('empty-state hint "Type to search…" not visible on freshly-opened palette');
+}
+
+// 3. Type a character that matches the seeded session. Results should appear.
+await searchInput.click();
+await searchInput.fill('alpha');
+await win.waitForTimeout(150);
+
+const optionsAfterType = await paletteOptions.count();
+if (optionsAfterType < 1) {
+  await app.close();
+  fail(`after typing "alpha", expected ≥1 option, got ${optionsAfterType}`);
+}
+const alphaRowVisible = await paletteOptions.filter({ hasText: 'Alpha session' }).first().isVisible();
+if (!alphaRowVisible) {
+  await app.close();
+  fail('typing "alpha" did not surface the seeded "Alpha session" row');
+}
+
+// 4. Esc closes the palette. Radix Dialog handles Esc itself; press it on
+//    the focused search input to ensure the event reaches the dialog tree.
+await searchInput.focus();
+await searchInput.press('Escape');
+await win.waitForTimeout(400);
+const stillOpen = await searchInput.isVisible().catch(() => false);
+if (stillOpen) {
+  await app.close();
+  fail('palette did not close on Esc');
+}
+
+console.log('\n[probe-e2e-palette-empty] OK');
+console.log('  Ctrl+K opens palette');
+console.log('  empty state: 0 options, "Type to search…" hint visible');
+console.log(`  typing "alpha" surfaces ${optionsAfterType} option(s) including "Alpha session"`);
+console.log('  Esc closes palette');
+
+await app.close();
+
+try { fs.rmSync(userDataDir, { recursive: true, force: true }); } catch {}

--- a/scripts/probe-e2e-palette-nav.mjs
+++ b/scripts/probe-e2e-palette-nav.mjs
@@ -1,0 +1,183 @@
+// E2E: command palette keyboard navigation.
+//
+// 1. Cmd/Ctrl+K opens the palette.
+// 2. After typing, ↓ moves the active row, ↑ moves it back.
+// 3. Enter on an active session row closes the palette AND selects that
+//    session (activeId in the store flips).
+//
+// Catches regressions in CommandPalette.onKeyDown (active index math) and in
+// the picker plumbing (App.tsx onSelectSession wiring).
+//
+// Pure black-box for the palette UI; the activeId assertion uses the
+// public __agentoryStore handle the app already exposes for E2E.
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import fs from 'node:fs';
+import os from 'node:os';
+import { appWindow } from './probe-utils.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function fail(msg) {
+  console.error(`\n[probe-e2e-palette-nav] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agentory-probe-palette-nav-'));
+
+const app = await electron.launch({
+  args: ['.', `--user-data-dir=${userDataDir}`],
+  cwd: root,
+  env: { ...process.env, NODE_ENV: 'development' }
+});
+
+const errors = [];
+const win = await appWindow(app);
+win.on('pageerror', (e) => errors.push(`[pageerror] ${e.message}`));
+win.on('console', (m) => {
+  if (m.type() === 'error') errors.push(`[console.error] ${m.text()}`);
+});
+
+await win.waitForLoadState('domcontentloaded');
+await win.waitForFunction(() => !!window.__agentoryStore, null, { timeout: 10_000 });
+
+// Seed: TWO sessions whose names share the prefix "session" so the palette
+// produces ≥2 result rows when we type "session", letting us exercise both
+// ↓ and ↑.
+await win.evaluate(() => {
+  window.__agentoryStore.setState({
+    sessions: [
+      {
+        id: 's-nav-A',
+        name: 'session alpha',
+        state: 'idle',
+        cwd: '~/a',
+        model: 'claude-opus-4',
+        groupId: 'g-default',
+        agentType: 'claude-code'
+      },
+      {
+        id: 's-nav-B',
+        name: 'session bravo',
+        state: 'idle',
+        cwd: '~/b',
+        model: 'claude-opus-4',
+        groupId: 'g-default',
+        agentType: 'claude-code'
+      }
+    ],
+    groups: [{ id: 'g-default', name: 'Sessions', collapsed: false, kind: 'normal' }],
+    activeId: 's-nav-A',
+    tutorialSeen: true
+  });
+});
+await win.waitForTimeout(200);
+
+// 1. Open palette via global shortcut.
+await win.evaluate(() => {
+  window.dispatchEvent(
+    new KeyboardEvent('keydown', { key: 'k', code: 'KeyK', ctrlKey: true, bubbles: true })
+  );
+});
+
+const searchInput = win.locator('input[placeholder*="Search"]');
+await searchInput.waitFor({ state: 'visible', timeout: 3000 }).catch(async () => {
+  await app.close();
+  fail('palette did not open via Ctrl+K');
+});
+
+// 2. Type "session bravo" and confirm Enter routes to bravo by checking
+//    activeId AFTER Enter — but first verify ↑/↓ navigation works.
+await searchInput.click();
+await searchInput.fill('session');
+await win.waitForTimeout(150);
+
+const paletteDialog = win.locator('[role="dialog"]').filter({ has: win.locator('input[placeholder*="Search"]') });
+const options = paletteDialog.locator('[role="option"]');
+const optionCount = await options.count();
+if (optionCount < 2) {
+  await app.close();
+  fail(`expected ≥2 option rows after typing "session", got ${optionCount}`);
+}
+
+// Initial active = index 0 (first row, "session alpha").
+async function activeIndex() {
+  const flags = await options.evaluateAll((els) =>
+    els.map((el) => el.getAttribute('aria-selected') === 'true')
+  );
+  return flags.indexOf(true);
+}
+
+let idx = await activeIndex();
+if (idx !== 0) {
+  await app.close();
+  fail(`initial active index expected 0, got ${idx}`);
+}
+
+// ↓ should move to row 1.
+await searchInput.press('ArrowDown');
+await win.waitForTimeout(80);
+idx = await activeIndex();
+if (idx !== 1) {
+  await app.close();
+  fail(`after ArrowDown, expected active=1, got ${idx}`);
+}
+
+// ↑ should move back to row 0.
+await searchInput.press('ArrowUp');
+await win.waitForTimeout(80);
+idx = await activeIndex();
+if (idx !== 0) {
+  await app.close();
+  fail(`after ArrowUp, expected active=0, got ${idx}`);
+}
+
+// 3. Move to "session bravo" specifically and Enter to commit. We can't
+//    blindly trust order — locate bravo's index and arrow-down to it.
+const labels = await options.evaluateAll((els) =>
+  els.map((el) => el.textContent?.trim() ?? '')
+);
+const bravoIdx = labels.findIndex((l) => l.includes('bravo'));
+if (bravoIdx < 0) {
+  await app.close();
+  fail(`"session bravo" row not present in palette results: ${JSON.stringify(labels)}`);
+}
+const steps = bravoIdx - (await activeIndex());
+for (let i = 0; i < steps; i++) await searchInput.press('ArrowDown');
+await win.waitForTimeout(80);
+
+// Confirm.
+await searchInput.press('Enter');
+await win.waitForTimeout(400);
+
+// Palette should have closed AND activeId should be 's-nav-B'. Check activeId
+// first — that's the load-bearing assertion (the dialog close is incidental).
+const activeId = await win.evaluate(() => window.__agentoryStore.getState().activeId);
+if (activeId !== 's-nav-B') {
+  const dump = await win.evaluate(() => ({
+    listboxes: Array.from(document.querySelectorAll('[role="dialog"] [role="option"]')).map((el) => ({
+      label: el.textContent?.trim(),
+      selected: el.getAttribute('aria-selected')
+    }))
+  }));
+  console.error('--- palette options at failure ---\n' + JSON.stringify(dump, null, 2));
+  await app.close();
+  fail(`Enter on "session bravo" did not select s-nav-B; activeId=${activeId}`);
+}
+
+const stillOpen = await searchInput.isVisible().catch(() => false);
+if (stillOpen) {
+  await app.close();
+  fail('palette did not close after Enter');
+}
+
+console.log('\n[probe-e2e-palette-nav] OK');
+console.log('  Ctrl+K opens palette');
+console.log('  ArrowDown/ArrowUp move active row');
+console.log('  Enter on "session bravo" closes palette and sets activeId=s-nav-B');
+
+await app.close();
+
+try { fs.rmSync(userDataDir, { recursive: true, force: true }); } catch {}

--- a/scripts/probe-shortcuts.mjs
+++ b/scripts/probe-shortcuts.mjs
@@ -39,6 +39,31 @@ const result = await page.evaluate(async () => {
     out.checks.newGroupCreated = afterShiftN.groups.length === groupsBefore + 1;
     out.steps.push(`after Cmd+Shift+N: ${afterShiftN.groups.length} groups`);
 
+    // Cmd+K -> open command palette. The palette mounts a search input with
+    // the placeholder text from i18n; we use that as a reliable visibility
+    // probe (Radix Dialog adds it as a portal under <body>, not <main>).
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', code: 'KeyK', ctrlKey: true, bubbles: true }));
+    await new Promise((r) => setTimeout(r, 150));
+    const paletteInput = document.querySelector('input[placeholder*="Search"]');
+    out.checks.paletteOpenedByCmdK = !!paletteInput;
+    out.steps.push(`after Cmd+K: palette input ${paletteInput ? 'visible' : 'MISSING'}`);
+
+    // Cmd+K again should toggle the palette closed.
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', code: 'KeyK', ctrlKey: true, bubbles: true }));
+    await new Promise((r) => setTimeout(r, 200));
+    out.checks.paletteToggleClosed = !document.querySelector('input[placeholder*="Search"]');
+    out.steps.push(`after second Cmd+K: palette ${out.checks.paletteToggleClosed ? 'closed' : 'still open'}`);
+
+    // Cmd+, -> open Settings dialog. Radix portals the dialog under <body>;
+    // we look for the dialog title "Settings" rendered inside role=dialog.
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: ',', code: 'Comma', ctrlKey: true, bubbles: true }));
+    await new Promise((r) => setTimeout(r, 200));
+    const settingsDialog = Array.from(document.querySelectorAll('[role="dialog"]')).find((el) =>
+      /Settings/i.test(el.textContent ?? '')
+    );
+    out.checks.settingsOpenedByCmdComma = !!settingsDialog;
+    out.steps.push(`after Cmd+,: settings dialog ${settingsDialog ? 'visible' : 'MISSING'}`);
+
     // Background waiting bridge: install a fake permission request via the
     // store directly. Since there's no live SDK in dev:web, we simulate by
     // appending a waiting block on a NON-active session and confirm the
@@ -86,3 +111,20 @@ console.log('\n=== CONSOLE / PAGE ERRORS ===');
 for (const l of logs) console.log(l);
 
 await browser.close();
+
+// Hard-fail the script if any required check is false. The toast-root checks
+// are best-effort (see comment in evaluate block above) and intentionally
+// excluded from the gate.
+const required = [
+  'newSessionCreated',
+  'newGroupCreated',
+  'paletteOpenedByCmdK',
+  'paletteToggleClosed',
+  'settingsOpenedByCmdComma'
+];
+const failed = required.filter((k) => result.checks[k] !== true);
+if (result.errors.length || failed.length) {
+  console.error(`\n[probe-shortcuts] FAIL: ${failed.length ? 'failed checks=' + failed.join(',') : 'errors during evaluate'}`);
+  process.exit(1);
+}
+console.log('\n[probe-shortcuts] OK');


### PR DESCRIPTION
## Summary
- New probes: `probe-e2e-palette-empty`, `probe-e2e-palette-nav`, `probe-e2e-import-session`
- Extended `probe-shortcuts` with Cmd+K (palette open/toggle) and Cmd+, (Settings); now hard-fails on missing checks
- Each Electron-based probe runs in an isolated `--user-data-dir` tmpdir; `import:scan` IPC is mocked in the main process to avoid touching `~/.claude/projects/`
- Pins the #117 invariant (palette shows only the search input until the user types)

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` (548 passed)
- [x] `node scripts/probe-e2e-palette-empty.mjs` → OK
- [x] `node scripts/probe-e2e-palette-nav.mjs` → OK
- [x] `node scripts/probe-e2e-import-session.mjs` → OK
- [x] `node scripts/probe-shortcuts.mjs` → OK (all 5 required checks pass)

Note for reviewer: probe-shortcuts is the existing chromium/dev:web probe (kept that way intentionally — global shortcut wiring is in App.tsx, no Electron-only surface to exercise). The three new probes use the Electron harness pattern to isolate userData and to mock the `import:scan` IPC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)