### PR TITLE
refactor(slash): prune dead passthroughs + add local handlers

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -648,6 +648,92 @@ app.whenReady().then(() => {
     // about homedir semantics (different on Windows vs Unix).
     return path.join(os.homedir(), '.claude', 'CLAUDE.md');
   });
+  // Open ~/.claude/CLAUDE.md in the OS-default editor. Creates an empty
+  // stub if the file does not yet exist so first-time users land in a
+  // ready-to-edit document instead of a "file not found" toast. Used by
+  // the `/memory` client handler — no claude.exe round-trip needed.
+  ipcMain.handle('memory:openUserFile', async () => {
+    const file = path.join(os.homedir(), '.claude', 'CLAUDE.md');
+    if (!fs.existsSync(file)) {
+      try {
+        fs.mkdirSync(path.dirname(file), { recursive: true });
+        fs.writeFileSync(file, '# Memory\n\n', 'utf8');
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : String(err) };
+      }
+    }
+    const result = await shell.openPath(file);
+    return result === '' ? { ok: true } : { ok: false, error: result };
+  });
+
+  // Local health checks for `/doctor`. Cheap probes only — no network, no
+  // spawn. Each probe returns `{ ok, detail }`; the renderer renders the
+  // bundle as a single status block.
+  ipcMain.handle('doctor:run', async () => {
+    const checks: Array<{ name: string; ok: boolean; detail: string }> = [];
+
+    // 1. ~/.claude/settings.json present and parseable
+    try {
+      const file = path.join(os.homedir(), '.claude', 'settings.json');
+      if (!fs.existsSync(file)) {
+        checks.push({ name: 'settings.json', ok: false, detail: `not found at ${file}` });
+      } else {
+        const raw = fs.readFileSync(file, 'utf8');
+        JSON.parse(raw);
+        checks.push({ name: 'settings.json', ok: true, detail: file });
+      }
+    } catch (err) {
+      checks.push({
+        name: 'settings.json',
+        ok: false,
+        detail: `parse error: ${err instanceof Error ? err.message : String(err)}`
+      });
+    }
+
+    // 2. claude binary discoverable (persisted path or PATH)
+    try {
+      const persisted = loadClaudeBinPath();
+      if (persisted && fs.existsSync(persisted)) {
+        const v = await detectClaudeVersion(persisted);
+        checks.push({
+          name: 'claude binary',
+          ok: v !== null,
+          detail: v ? `${persisted} (v${v})` : `${persisted} (version probe failed)`
+        });
+      } else {
+        const p = await resolveClaudeBinary();
+        const v = await detectClaudeVersion(p);
+        checks.push({
+          name: 'claude binary',
+          ok: v !== null,
+          detail: v ? `${p} (v${v})` : `${p} (version probe failed)`
+        });
+      }
+    } catch (err) {
+      checks.push({
+        name: 'claude binary',
+        ok: false,
+        detail: err instanceof Error ? err.message : String(err)
+      });
+    }
+
+    // 3. data directory writable (sqlite lives in app.getPath('userData'))
+    try {
+      const dir = app.getPath('userData');
+      const probe = path.join(dir, '.doctor-probe');
+      fs.writeFileSync(probe, 'ok', 'utf8');
+      fs.unlinkSync(probe);
+      checks.push({ name: 'data dir writable', ok: true, detail: dir });
+    } catch (err) {
+      checks.push({
+        name: 'data dir writable',
+        ok: false,
+        detail: err instanceof Error ? err.message : String(err)
+      });
+    }
+
+    return { checks };
+  });
   ipcMain.handle('memory:projectPath', (_e, cwd: string) => {
     // We still force CLAUDE.md basename in the *write* path, but we compose
     // the full path here so the renderer doesn't have to remember the

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -169,9 +169,25 @@ const api = {
     exists: (p: string): Promise<boolean> => ipcRenderer.invoke('memory:exists', p),
     /** Returns the absolute path to ~/.claude/CLAUDE.md (resolved in main). */
     userPath: (): Promise<string> => ipcRenderer.invoke('memory:userPath'),
+    /**
+     * Open ~/.claude/CLAUDE.md in the OS-default editor. Creates the file
+     * (with a `# Memory` stub) if it does not exist. Used by `/memory`.
+     */
+    openUserFile: (): Promise<{ ok: true } | { ok: false; error: string }> =>
+      ipcRenderer.invoke('memory:openUserFile'),
     /** Returns <cwd>/CLAUDE.md, or null if cwd is empty / not absolute. */
     projectPath: (cwd: string): Promise<string | null> =>
       ipcRenderer.invoke('memory:projectPath', cwd),
+  },
+
+  /**
+   * Local health checks for `/doctor` — verifies settings.json,
+   * claude binary discoverability, and data dir writability. Pure local
+   * probes; no network.
+   */
+  doctor: {
+    run: (): Promise<{ checks: Array<{ name: string; ok: boolean; detail: string }> }> =>
+      ipcRenderer.invoke('doctor:run')
   },
 
   pr: {

--- a/scripts/probe-slash-audit.mjs
+++ b/scripts/probe-slash-audit.mjs
@@ -1,0 +1,155 @@
+// Probe: slash-command audit.
+//
+// Walks the registry by reading the SlashCommandPicker DOM, then for every
+// entry sends `/<name>` through the textarea and reports what (if anything)
+// happens within AUDIT_WAIT_MS. The point is to keep the registry honest:
+// if a command is marked `passThrough: true` but claude.exe silently drops
+// it under `--input-format stream-json`, we want a hard signal so we can
+// either promote it to a client handler or remove the entry.
+//
+// Output: a markdown table on stdout, plus an exit code (0 if every
+// command produced *some* response, 1 otherwise).
+//
+// Usage:
+//   AGENTORY_DEV_PORT=4194 npm run dev:web   # in another shell
+//   node scripts/probe-slash-audit.mjs
+import { chromium } from 'playwright';
+import { makeSlashStubInit, devServerUp } from './probe-slash-stub.mjs';
+
+const PORT = process.env.AGENTORY_DEV_PORT ?? '4100';
+const URL = `http://localhost:${PORT}/`;
+const AUDIT_WAIT_MS = Number(process.env.AUDIT_WAIT_MS ?? 1500);
+
+if (!(await devServerUp(URL))) {
+  console.log('[probe-slash-audit] skipped: dev server not reachable at', URL);
+  console.log('  hint: AGENTORY_DEV_PORT=4194 npm run dev:web');
+  process.exit(0);
+}
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext();
+const page = await ctx.newPage();
+await page.addInitScript(makeSlashStubInit());
+
+await page.goto(URL, { waitUntil: 'networkidle' });
+
+const newBtn = page.getByRole('button', { name: /new session/i }).first();
+await newBtn.waitFor({ state: 'visible', timeout: 15000 });
+await newBtn.click();
+const textarea = page.locator('textarea');
+await textarea.waitFor({ state: 'visible', timeout: 5000 });
+await textarea.click();
+await textarea.fill('/');
+await page.waitForTimeout(150);
+
+// Scope to the slash-command picker (its own listbox) — the sidebar uses
+// role="option" too, which would otherwise pollute results.
+const picker = page.locator('[role="listbox"]').filter({ hasText: '/help' }).first();
+await picker.waitFor({ state: 'visible', timeout: 3000 }).catch(() => {});
+const rows = await picker.locator('[role="option"]').allTextContents();
+await page.keyboard.press('Escape');
+await textarea.fill('');
+
+// Each picker row renders the name and description with no whitespace
+// between them in plain text content (`/help` + `List available commands`
+// → `/helpList…`). The valid-name part is the longest sequence we can
+// take while staying entirely lowercase letters/digits/_/- — once we hit
+// an uppercase letter (start of the description's first word) we stop.
+const commandNames = rows
+  .map((r) => {
+    const m = r.trim().match(/^\/([a-z][a-z0-9_-]*?)(?=[A-Z]|\s|$)/);
+    return m ? m[1] : null;
+  })
+  .filter((n) => typeof n === 'string');
+
+if (commandNames.length === 0) {
+  console.error('[probe-slash-audit] could not enumerate registry from picker DOM');
+  await browser.close();
+  process.exit(1);
+}
+
+const results = [];
+for (const name of commandNames) {
+  // Snapshot baseline counts so we can detect *new* output for this command.
+  const baseStatus = await page.locator('[role="status"]').count();
+  const baseError = await page.locator('[data-block-kind="error"]').count();
+  const baseSent = await page.evaluate(() => window.__sentMessages?.length ?? 0);
+  const baseExternal = await page.evaluate(() => window.__externalUrls?.length ?? 0);
+  const baseMemoryOpen = await page.evaluate(() => window.__memoryOpenCalls?.length ?? 0);
+
+  await textarea.click();
+  await textarea.fill(`/${name}`);
+  await page.waitForTimeout(60);
+  await page.keyboard.press('Escape');
+  await page.waitForTimeout(40);
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(AUDIT_WAIT_MS);
+
+  const newStatus = (await page.locator('[role="status"]').count()) - baseStatus;
+  const newError = (await page.locator('[data-block-kind="error"]').count()) - baseError;
+  const dialogVisible = await page.getByRole('dialog').isVisible().catch(() => false);
+  const newSent =
+    (await page.evaluate(() => window.__sentMessages?.length ?? 0)) - baseSent;
+  const newExternal =
+    (await page.evaluate(() => window.__externalUrls?.length ?? 0)) - baseExternal;
+  const newMemoryOpen =
+    (await page.evaluate(() => window.__memoryOpenCalls?.length ?? 0)) - baseMemoryOpen;
+
+  results.push({
+    name,
+    statuses: newStatus,
+    errors: newError,
+    dialogOpen: dialogVisible,
+    sentToAgent: newSent,
+    openExternal: newExternal,
+    memoryOpen: newMemoryOpen
+  });
+
+  if (dialogVisible) {
+    await page.keyboard.press('Escape').catch(() => {});
+    await page.waitForTimeout(80);
+  }
+  await textarea.fill('');
+}
+
+console.log('\n[probe-slash-audit] results');
+console.log('| command | status+ | err+ | dialog | sent | openExt | memOpen | verdict |');
+console.log('|---|---|---|---|---|---|---|---|');
+let deadCount = 0;
+for (const r of results) {
+  const responded =
+    r.statuses > 0 ||
+    r.errors > 0 ||
+    r.dialogOpen ||
+    r.sentToAgent > 0 ||
+    r.openExternal > 0 ||
+    r.memoryOpen > 0;
+  const verdict = responded ? 'ok' : 'DEAD?';
+  if (!responded) deadCount += 1;
+  console.log(
+    `| /${r.name} | ${r.statuses} | ${r.errors} | ${r.dialogOpen ? 'yes' : 'no'} | ${r.sentToAgent} | ${r.openExternal} | ${r.memoryOpen} | ${verdict} |`
+  );
+}
+
+console.log('');
+console.log(
+  `Summary: ${results.length - deadCount}/${results.length} commands produced a visible response.`
+);
+console.log(
+  'Notes: /clear shows status+ = -1 because it switches to a fresh session whose'
+);
+console.log(
+  '       banner count is 0; verify it via scripts/probe-slash-exec.mjs instead.'
+);
+console.log(
+  '       /init is pass-through; if "sent" is 0 the session may not have started'
+);
+console.log(
+  '       in time — re-run with AUDIT_WAIT_MS=4000 to give agentStart more room.'
+);
+
+await browser.close();
+// Exit 0 always — this probe is for human review, not CI gate-keeping.
+// Use the per-command probes (probe-slash-exec, probe-slash-status, etc.)
+// for assertions in CI.
+process.exit(0);

--- a/scripts/probe-slash-bug.mjs
+++ b/scripts/probe-slash-bug.mjs
@@ -1,0 +1,61 @@
+// Probe: /bug client handler.
+//
+// Asserts the handler calls window.agentory.openExternal with a github
+// new-issue URL containing pre-filled environment metadata.
+import { chromium } from 'playwright';
+import { makeSlashStubInit, devServerUp } from './probe-slash-stub.mjs';
+
+const PORT = process.env.AGENTORY_DEV_PORT ?? '4100';
+const URL = `http://localhost:${PORT}/`;
+
+if (!(await devServerUp(URL))) {
+  console.log('[probe-slash-bug] skipped: dev server not reachable at', URL);
+  process.exit(0);
+}
+
+function fail(msg) {
+  console.error(`\n[probe-slash-bug] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext();
+const page = await ctx.newPage();
+await page.addInitScript(makeSlashStubInit());
+
+await page.goto(URL, { waitUntil: 'networkidle' });
+await page.evaluate(() => {
+  window.__getVersionOverride = () => '9.9.9-probe';
+});
+
+await page.getByRole('button', { name: /new session/i }).first().click();
+const textarea = page.locator('textarea');
+await textarea.waitFor({ state: 'visible' });
+await textarea.click();
+await textarea.fill('/bug');
+await page.waitForTimeout(80);
+await page.keyboard.press('Escape');
+await page.keyboard.press('Enter');
+
+await page
+  .waitForFunction(() => (window.__externalUrls?.length ?? 0) > 0, null, { timeout: 3000 })
+  .catch(() => fail('/bug did not call openExternal'));
+
+const urls = await page.evaluate(() => window.__externalUrls);
+if (urls.length !== 1) fail(`expected 1 url, got ${urls.length}`);
+const url = urls[0];
+if (!url.includes('github.com/Jiahui-Gu/Agentory-next/issues/new')) {
+  fail(`expected GitHub issue URL, got: ${url}`);
+}
+const decoded = decodeURIComponent(url);
+if (!decoded.includes('Agentory: 9.9.9-probe')) {
+  fail(`expected version in body, got: ${decoded}`);
+}
+
+const banner = page.locator('[role="status"]').filter({ hasText: 'Bug report' });
+await banner.waitFor({ state: 'visible', timeout: 2000 }).catch(() => {
+  fail('/bug did not render confirmation banner');
+});
+
+console.log('[probe-slash-bug] OK');
+await browser.close();

--- a/scripts/probe-slash-doctor.mjs
+++ b/scripts/probe-slash-doctor.mjs
@@ -1,0 +1,58 @@
+// Probe: /doctor client handler.
+//
+// Stubs window.agentory.doctor.run to return a mixed-result bundle and
+// asserts the renderer formats it as a warn-tone banner with [ok]/[fail]
+// markers.
+import { chromium } from 'playwright';
+import { makeSlashStubInit, devServerUp } from './probe-slash-stub.mjs';
+
+const PORT = process.env.AGENTORY_DEV_PORT ?? '4100';
+const URL = `http://localhost:${PORT}/`;
+
+if (!(await devServerUp(URL))) {
+  console.log('[probe-slash-doctor] skipped: dev server not reachable at', URL);
+  process.exit(0);
+}
+
+function fail(msg) {
+  console.error(`\n[probe-slash-doctor] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext();
+const page = await ctx.newPage();
+await page.addInitScript(makeSlashStubInit());
+
+await page.goto(URL, { waitUntil: 'networkidle' });
+// Override doctor.run with a mixed-result bundle.
+await page.evaluate(() => {
+  window.__doctorOverride = () => ({
+    checks: [
+      { name: 'settings.json', ok: true, detail: '/home/u/.claude/settings.json' },
+      { name: 'claude binary', ok: false, detail: 'not found on PATH' },
+      { name: 'data dir writable', ok: true, detail: '/data' }
+    ]
+  });
+});
+
+await page.getByRole('button', { name: /new session/i }).first().click();
+const textarea = page.locator('textarea');
+await textarea.waitFor({ state: 'visible' });
+await textarea.click();
+await textarea.fill('/doctor');
+await page.waitForTimeout(80);
+await page.keyboard.press('Escape');
+await page.keyboard.press('Enter');
+
+const banner = page.locator('[role="status"]').filter({ hasText: /Doctor:/ });
+await banner.waitFor({ state: 'visible', timeout: 3000 }).catch(() => {
+  fail('/doctor did not render a banner');
+});
+const text = await banner.innerText();
+if (!text.includes('issues found')) fail(`expected "issues found" header, got:\n${text}`);
+if (!text.includes('[fail]')) fail('missing [fail] marker for failing check');
+if (!text.includes('[ok]')) fail('missing [ok] marker for passing check');
+
+console.log('[probe-slash-doctor] OK');
+await browser.close();

--- a/scripts/probe-slash-memory.mjs
+++ b/scripts/probe-slash-memory.mjs
@@ -1,0 +1,44 @@
+// Probe: /memory client handler.
+//
+// Asserts the handler invokes window.agentory.memory.openUserFile and
+// renders a confirmation banner.
+import { chromium } from 'playwright';
+import { makeSlashStubInit, devServerUp } from './probe-slash-stub.mjs';
+
+const PORT = process.env.AGENTORY_DEV_PORT ?? '4100';
+const URL = `http://localhost:${PORT}/`;
+
+if (!(await devServerUp(URL))) {
+  console.log('[probe-slash-memory] skipped: dev server not reachable at', URL);
+  process.exit(0);
+}
+
+function fail(msg) {
+  console.error(`\n[probe-slash-memory] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext();
+const page = await ctx.newPage();
+await page.addInitScript(makeSlashStubInit());
+
+await page.goto(URL, { waitUntil: 'networkidle' });
+await page.getByRole('button', { name: /new session/i }).first().click();
+const textarea = page.locator('textarea');
+await textarea.waitFor({ state: 'visible' });
+await textarea.click();
+await textarea.fill('/memory');
+await page.waitForTimeout(80);
+await page.keyboard.press('Escape');
+await page.keyboard.press('Enter');
+
+const banner = page.locator('[role="status"]').filter({ hasText: 'Opened user memory' });
+await banner.waitFor({ state: 'visible', timeout: 3000 }).catch(() => {
+  fail('/memory did not render the confirmation banner');
+});
+const calls = await page.evaluate(() => window.__memoryOpenCalls?.length ?? 0);
+if (calls !== 1) fail(`expected exactly 1 openUserFile call, got ${calls}`);
+
+console.log('[probe-slash-memory] OK');
+await browser.close();

--- a/scripts/probe-slash-status.mjs
+++ b/scripts/probe-slash-status.mjs
@@ -1,0 +1,46 @@
+// Probe: /status client handler.
+//
+// Sends `/status` and asserts a banner mentions Cwd / Model / Endpoint.
+// Skips gracefully when the dev server is not reachable.
+import { chromium } from 'playwright';
+import { makeSlashStubInit, devServerUp } from './probe-slash-stub.mjs';
+
+const PORT = process.env.AGENTORY_DEV_PORT ?? '4100';
+const URL = `http://localhost:${PORT}/`;
+
+if (!(await devServerUp(URL))) {
+  console.log('[probe-slash-status] skipped: dev server not reachable at', URL);
+  process.exit(0);
+}
+
+function fail(msg) {
+  console.error(`\n[probe-slash-status] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext();
+const page = await ctx.newPage();
+await page.addInitScript(makeSlashStubInit());
+
+await page.goto(URL, { waitUntil: 'networkidle' });
+await page.getByRole('button', { name: /new session/i }).first().click();
+const textarea = page.locator('textarea');
+await textarea.waitFor({ state: 'visible' });
+await textarea.click();
+await textarea.fill('/status');
+await page.waitForTimeout(80);
+await page.keyboard.press('Escape');
+await page.keyboard.press('Enter');
+
+const banner = page.locator('[role="status"]').filter({ hasText: 'Session status' });
+await banner.waitFor({ state: 'visible', timeout: 3000 }).catch(() => {
+  fail('/status did not render a "Session status" banner');
+});
+const text = await banner.innerText();
+for (const needle of ['Cwd', 'Model', 'Endpoint']) {
+  if (!text.includes(needle)) fail(`/status banner missing "${needle}":\n${text}`);
+}
+
+console.log('[probe-slash-status] OK');
+await browser.close();

--- a/scripts/probe-slash-stub.mjs
+++ b/scripts/probe-slash-stub.mjs
@@ -1,0 +1,150 @@
+// Shared init-script for slash-command probes: install a complete
+// window.agentory stub so renderer mounts cleanly (no tutorial overlay,
+// no CLI-missing dialog), and let individual probes layer on overrides.
+//
+// Usage in a probe:
+//   await page.addInitScript(slashStubInit, { extra });
+// Then any function on the stub can be re-stubbed via `page.evaluate`.
+export function makeSlashStubInit(extras = {}) {
+  // Returns a string the page evaluates. We can't pass a closure to
+  // addInitScript across the playwright bridge with non-serializable bits,
+  // so we bake everything to JSON-safe primitives + reconstitute in-page.
+  return `(${stubFn.toString()})(${JSON.stringify(extras)});`;
+}
+
+function stubFn(_extras) {
+  const sentMessages = [];
+  const externalUrls = [];
+  const memoryOpenCalls = [];
+  Object.defineProperty(window, '__sentMessages', { value: sentMessages, writable: true });
+  Object.defineProperty(window, '__externalUrls', { value: externalUrls, writable: true });
+  Object.defineProperty(window, '__memoryOpenCalls', { value: memoryOpenCalls, writable: true });
+  Object.defineProperty(window, '__doctorOverride', { value: null, writable: true });
+  Object.defineProperty(window, '__memoryOverride', { value: null, writable: true });
+  Object.defineProperty(window, '__externalOverride', { value: null, writable: true });
+  Object.defineProperty(window, '__getVersionOverride', { value: null, writable: true });
+
+  const stub = {
+    loadState: async (key) => {
+      if (key === 'main') {
+        return JSON.stringify({
+          version: 1,
+          sessions: [],
+          groups: [{ id: 'g-default', name: 'Sessions', collapsed: false, kind: 'normal' }],
+          activeId: '',
+          model: '',
+          permission: 'default',
+          sidebarCollapsed: false,
+          theme: 'system',
+          fontSize: 'md',
+          recentProjects: [],
+          tutorialSeen: true
+        });
+      }
+      return null;
+    },
+    saveState: async () => {},
+    loadMessages: async () => [],
+    saveMessages: async () => {},
+    getVersion: async () => (window.__getVersionOverride ? window.__getVersionOverride() : '0.0.0-probe'),
+    pickDirectory: async () => null,
+    agentStart: async () => ({ ok: true }),
+    agentSend: async (_id, text) => {
+      sentMessages.push(text);
+      return true;
+    },
+    agentSendContent: async () => true,
+    agentInterrupt: async () => true,
+    agentSetPermissionMode: async () => true,
+    agentSetModel: async () => true,
+    agentClose: async () => true,
+    agentResolvePermission: async () => true,
+    onAgentEvent: () => () => {},
+    onAgentExit: () => () => {},
+    onAgentPermissionRequest: () => () => {},
+    scanImportable: async () => [],
+    recentCwds: async () => [],
+    topModel: async () => null,
+    pathsExist: async () => ({}),
+    memory: {
+      read: async () => ({ ok: true, content: '', exists: false }),
+      write: async () => ({ ok: true }),
+      exists: async () => false,
+      userPath: async () => '/tmp/CLAUDE.md',
+      openUserFile: async () => {
+        memoryOpenCalls.push(Date.now());
+        return window.__memoryOverride ? window.__memoryOverride() : { ok: true };
+      },
+      projectPath: async () => null
+    },
+    doctor: {
+      run: async () => {
+        if (window.__doctorOverride) return window.__doctorOverride();
+        return {
+          checks: [
+            { name: 'settings.json', ok: true, detail: '/x' },
+            { name: 'claude binary', ok: true, detail: '/bin/claude' },
+            { name: 'data dir writable', ok: true, detail: '/data' }
+          ]
+        };
+      }
+    },
+    pr: {
+      preflight: async () => ({ ok: false, errors: [{ code: 'no-gh', detail: 'stub' }] }),
+      create: async () => ({ ok: false, error: 'stub' }),
+      checks: async () => ({ ok: false, error: 'stub' })
+    },
+    notify: async () => true,
+    onNotificationFocus: () => () => {},
+    updatesStatus: async () => ({ kind: 'idle' }),
+    updatesCheck: async () => ({ kind: 'idle' }),
+    updatesDownload: async () => ({ ok: true }),
+    updatesInstall: async () => ({ ok: true }),
+    updatesGetAutoCheck: async () => true,
+    updatesSetAutoCheck: async () => true,
+    onUpdateStatus: () => () => {},
+    onUpdateAvailable: () => () => {},
+    onUpdateDownloaded: () => () => {},
+    onUpdateError: () => () => {},
+    cli: {
+      retryDetect: async () => ({ found: true, path: '/fake/claude', version: '1.0.0' }),
+      getInstallHints: async () => ({ os: 'win32', arch: 'x64', commands: { npm: '' }, docsUrl: '' }),
+      browseBinary: async () => null,
+      setBinaryPath: async () => ({ ok: true, version: '1.0.0' }),
+      openDocs: async () => true
+    },
+    window: {
+      minimize: async () => {},
+      toggleMaximize: async () => false,
+      close: async () => {},
+      isMaximized: async () => false,
+      onMaximizedChanged: () => () => {},
+      platform: 'win32'
+    },
+    connection: {
+      read: async () => ({ baseUrl: null, model: null, hasAuthToken: false }),
+      openSettingsFile: async () => ({ ok: true })
+    },
+    models: {
+      list: async () => []
+    },
+    openExternal: async (url) => {
+      externalUrls.push(url);
+      return window.__externalOverride ? window.__externalOverride(url) : true;
+    },
+    i18n: {
+      getSystemLocale: async () => 'en-US',
+      setLanguage: () => {}
+    }
+  };
+  Object.defineProperty(window, 'agentory', { value: stub, writable: true, configurable: true });
+}
+
+export async function devServerUp(url) {
+  try {
+    const res = await fetch(url, { method: 'HEAD' });
+    return res.ok || res.status === 200;
+  } catch {
+    return false;
+  }
+}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -168,7 +168,14 @@ declare global {
         >;
         exists: (p: string) => Promise<boolean>;
         userPath: () => Promise<string>;
+        openUserFile: () => Promise<{ ok: true } | { ok: false; error: string }>;
         projectPath: (cwd: string) => Promise<string | null>;
+      };
+
+      doctor: {
+        run: () => Promise<{
+          checks: Array<{ name: string; ok: boolean; detail: string }>;
+        }>;
       };
 
       pr: {

--- a/src/slash-commands/handlers.ts
+++ b/src/slash-commands/handlers.ts
@@ -176,6 +176,152 @@ export function handlePr(ctx: SlashCommandContext): void {
   }
 }
 
+// ---------- /status ----------
+// Render a snapshot of the current session's runtime state: connection (from
+// settings.json), active model, cwd, lifetime token usage. No network calls
+// — everything comes from store + the connection info loaded at boot.
+export function handleStatus(ctx: SlashCommandContext): void {
+  const state = useStore.getState();
+  const session = state.sessions.find((s) => s.id === ctx.sessionId);
+  const conn = state.connection;
+  const stats = state.statsBySession[ctx.sessionId];
+  const running = !!state.runningSessions[ctx.sessionId];
+  const started = !!state.startedSessions[ctx.sessionId];
+
+  const lines: string[] = [];
+  lines.push(`Session    ${session?.name ?? ctx.sessionId} (${ctx.sessionId})`);
+  lines.push(`State      ${running ? 'running' : started ? 'idle' : 'not started'}`);
+  lines.push(`Cwd        ${session?.cwd ?? '(unset)'}`);
+  lines.push(`Model      ${session?.model || state.model || '(default)'}`);
+  lines.push(`Permission ${state.permission}`);
+  lines.push(
+    `Endpoint   ${conn?.baseUrl ?? '(default Anthropic)'}` +
+      ` · token ${conn?.hasAuthToken ? 'present' : 'missing'}`
+  );
+  if (stats && (stats.turns > 0 || stats.inputTokens > 0)) {
+    lines.push(
+      `Usage      ${stats.turns} turn${stats.turns === 1 ? '' : 's'} · ` +
+        `${formatTokens(stats.inputTokens)} in / ${formatTokens(stats.outputTokens)} out · ` +
+        formatCost(stats.costUsd)
+    );
+  } else {
+    lines.push(`Usage      no turns yet`);
+  }
+  appendStatus(ctx.sessionId, 'Session status', lines.join('\n'));
+}
+
+// ---------- /doctor ----------
+// Run a small bundle of local health checks via the main process. Renders a
+// status block per check; uses 'warn' tone if any check failed so the row
+// stands out.
+export async function handleDoctor(ctx: SlashCommandContext): Promise<void> {
+  const api = window.agentory;
+  if (!api?.doctor?.run) {
+    appendError(ctx.sessionId, '/doctor is not available (renderer not connected to main).');
+    return;
+  }
+  let result: { checks: Array<{ name: string; ok: boolean; detail: string }> };
+  try {
+    result = await api.doctor.run();
+  } catch (err) {
+    appendError(
+      ctx.sessionId,
+      `/doctor failed: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return;
+  }
+  const checks = result.checks ?? [];
+  const lines = checks.map((c) => `${c.ok ? '[ok]  ' : '[fail]'} ${c.name.padEnd(20)} ${c.detail}`);
+  const anyFailed = checks.some((c) => !c.ok);
+  useStore.getState().appendBlocks(ctx.sessionId, [
+    {
+      kind: 'status',
+      id: nextId('local'),
+      tone: anyFailed ? 'warn' : 'info',
+      title: anyFailed ? 'Doctor: issues found' : 'Doctor: all checks passed',
+      detail: lines.join('\n')
+    }
+  ]);
+}
+
+// ---------- /memory ----------
+// Open ~/.claude/CLAUDE.md in the OS-default editor (Notepad / TextEdit /
+// xdg-open's pick). Creating the file if missing happens in main.
+export async function handleMemory(ctx: SlashCommandContext): Promise<void> {
+  const api = window.agentory;
+  if (!api?.memory?.openUserFile) {
+    appendError(ctx.sessionId, '/memory is not available (renderer not connected to main).');
+    return;
+  }
+  const res = await api.memory.openUserFile();
+  if (res.ok) {
+    appendStatus(
+      ctx.sessionId,
+      'Opened user memory',
+      'Editing ~/.claude/CLAUDE.md in your default editor.'
+    );
+  } else {
+    appendError(ctx.sessionId, `Could not open CLAUDE.md: ${res.error}`);
+  }
+}
+
+// ---------- /bug ----------
+// Open a prefilled GitHub issue. We pre-populate Agentory version, OS, and
+// active model so the user does not have to copy-paste their own metadata.
+// All redaction stays in the user's hands — they choose what to send.
+export async function handleBug(ctx: SlashCommandContext): Promise<void> {
+  const api = window.agentory;
+  if (!api?.openExternal || !api?.getVersion) {
+    appendError(ctx.sessionId, '/bug is not available (renderer not connected to main).');
+    return;
+  }
+  const state = useStore.getState();
+  const session = state.sessions.find((s) => s.id === ctx.sessionId);
+  let appVersion = 'unknown';
+  try {
+    appVersion = await api.getVersion();
+  } catch {
+    /* ignore — we'll send 'unknown' */
+  }
+  const platform = api.window?.platform ?? 'unknown';
+  const cliState = state.cliStatus.state;
+  const cliDetail =
+    state.cliStatus.state === 'found'
+      ? `${state.cliStatus.binaryPath} (v${state.cliStatus.version ?? '?'})`
+      : state.cliStatus.state;
+  const body = [
+    '### Environment',
+    '',
+    `- Agentory: ${appVersion}`,
+    `- Platform: ${platform}`,
+    `- CLI: ${cliState} — ${cliDetail}`,
+    `- Model: ${session?.model || state.model || '(default)'}`,
+    '',
+    '### What happened',
+    '',
+    '<!-- describe the bug -->',
+    '',
+    '### Steps to reproduce',
+    '',
+    '1. ',
+    '2. ',
+    '3. ',
+    '',
+    '### Expected vs actual',
+    '',
+    ''
+  ].join('\n');
+  const url =
+    'https://github.com/Jiahui-Gu/Agentory-next/issues/new?' +
+    `title=${encodeURIComponent('[bug] ')}&body=${encodeURIComponent(body)}`;
+  const ok = await api.openExternal(url);
+  if (ok) {
+    appendStatus(ctx.sessionId, 'Bug report', 'Opened GitHub issue form in your browser.');
+  } else {
+    appendError(ctx.sessionId, 'Could not open external URL.');
+  }
+}
+
 // Attach handlers to registry entries. Module side-effect; imported once by
 // the app bootstrap (src/index.tsx or wherever we kick things off) and once
 // by the unit tests that exercise dispatch.
@@ -190,3 +336,7 @@ attach('config', handleConfig);
 attach('model', handleModel);
 attach('help', handleHelp);
 attach('pr', handlePr);
+attach('status', handleStatus);
+attach('doctor', handleDoctor);
+attach('memory', handleMemory);
+attach('bug', handleBug);

--- a/src/slash-commands/registry.ts
+++ b/src/slash-commands/registry.ts
@@ -12,18 +12,11 @@ import {
   Cpu,
   Settings,
   CircleDollarSign,
-  History,
   Brain,
   FolderPlus,
-  LogIn,
-  LogOut,
   Activity,
   Stethoscope,
   Bug,
-  Plug,
-  Webhook,
-  Users,
-  FileSearch,
   GitPullRequest,
   type LucideIcon
 } from 'lucide-react';
@@ -63,10 +56,21 @@ export type SlashCommand = {
 //
 // `passThrough: false` = we handle locally (see src/slash-commands/handlers.ts).
 // `passThrough: true`  = forwarded to claude.exe via the normal message path.
-//   Note: claude.exe in --input-format stream-json mode silently drops most
-//   slash commands. We still forward them because (a) the list may grow or
-//   be fixed upstream, and (b) silently eating the `/foo` text is less bad
-//   than pretending it isn't a command.
+//   Reality check: claude.exe in --input-format stream-json mode silently
+//   drops most slash commands, so we are aggressive about either (a) wiring
+//   a client handler that does something useful in the GUI, or (b) removing
+//   the entry entirely so users do not press a button that does nothing.
+//
+//   Audit history (run scripts/probe-slash-audit.mjs to refresh):
+//     • Removed: /resume (GUI sidebar already lists sessions)
+//                /login, /logout (Agentory does not own auth — auth lives in
+//                  ~/.claude/settings.json; surfaced via Settings → Connection
+//                  which `/config` already opens)
+//                /mcp, /hooks, /agents, /review (silently dropped by stream-
+//                  json mode; no GUI surface yet — would mislead users)
+//     • Promoted to client handlers: /status, /doctor, /bug, /memory
+//     • Kept as pass-through: /compact (CLI handles natively in interactive
+//                  mode), /init (writes a CLAUDE.md — useful even if quiet)
 export const SLASH_COMMANDS: SlashCommand[] = [
   { name: 'help',    description: 'List available commands',                       icon: HelpCircle,       category: 'built-in', passThrough: false },
   { name: 'clear',   description: 'Start a new conversation and clear context',    icon: Eraser,           category: 'built-in', passThrough: false },
@@ -75,18 +79,11 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: 'config',  description: 'Open settings',                                 icon: Settings,         category: 'built-in', passThrough: false },
   { name: 'cost',    description: 'Show session cost and token usage',             icon: CircleDollarSign, category: 'built-in', passThrough: false },
   { name: 'pr',      description: 'Create a GitHub PR for the current worktree',   icon: GitPullRequest,   category: 'client',   passThrough: false },
-  { name: 'resume',  description: 'Resume a previous session',                     icon: History,          category: 'built-in', passThrough: true  },
-  { name: 'memory',  description: 'Manage CLAUDE.md memory',                       icon: Brain,            category: 'built-in', passThrough: true  },
-  { name: 'init',    description: 'Initialize CLAUDE.md in current project',       icon: FolderPlus,       category: 'built-in', passThrough: true  },
-  { name: 'login',   description: 'Sign in to Claude',                             icon: LogIn,            category: 'built-in', passThrough: true  },
-  { name: 'logout',  description: 'Sign out',                                      icon: LogOut,           category: 'built-in', passThrough: true  },
-  { name: 'status',  description: 'Show auth and session status',                  icon: Activity,         category: 'built-in', passThrough: true  },
-  { name: 'doctor',  description: 'Check installation health',                     icon: Stethoscope,      category: 'built-in', passThrough: true  },
-  { name: 'bug',     description: 'Report a bug',                                  icon: Bug,              category: 'built-in', passThrough: true  },
-  { name: 'mcp',     description: 'Manage MCP servers',                            icon: Plug,             category: 'built-in', passThrough: true  },
-  { name: 'hooks',   description: 'Manage hooks',                                  icon: Webhook,          category: 'built-in', passThrough: true  },
-  { name: 'agents',  description: 'Manage custom agents',                          icon: Users,            category: 'built-in', passThrough: true  },
-  { name: 'review',  description: 'Review a pull request',                         icon: FileSearch,       category: 'built-in', passThrough: true  }
+  { name: 'status',  description: 'Show connection, model, and session status',    icon: Activity,         category: 'client',   passThrough: false },
+  { name: 'doctor',  description: 'Run local installation health checks',          icon: Stethoscope,      category: 'client',   passThrough: false },
+  { name: 'memory',  description: 'Open user CLAUDE.md memory file',               icon: Brain,            category: 'client',   passThrough: false },
+  { name: 'bug',     description: 'Report a bug on GitHub',                        icon: Bug,              category: 'client',   passThrough: false },
+  { name: 'init',    description: 'Initialize CLAUDE.md in current project',       icon: FolderPlus,       category: 'built-in', passThrough: true  }
 ];
 
 // Parse a raw input line into a slash command + args. Returns null when the

--- a/tests/slash-commands-handlers.test.ts
+++ b/tests/slash-commands-handlers.test.ts
@@ -12,6 +12,10 @@ import {
   handleConfig,
   handleModel,
   handleHelp,
+  handleStatus,
+  handleDoctor,
+  handleMemory,
+  handleBug,
   blocksToTranscript
 } from '../src/slash-commands/handlers';
 import { setOpenSettingsListener } from '../src/slash-commands/ui-bridge';
@@ -75,18 +79,26 @@ describe('dispatchSlashCommand', () => {
     expect(outcome).toBe('handled');
   });
   it('returns pass-through for commands with no handler', async () => {
-    const outcome = await dispatchSlashCommand('/doctor', { sessionId: 's1', args: '' });
+    // /compact + /init are the only remaining pass-through entries.
+    const outcome = await dispatchSlashCommand('/compact', { sessionId: 's1', args: '' });
     expect(outcome).toBe('pass-through');
   });
   it('returns unknown for unrecognised names', async () => {
     const outcome = await dispatchSlashCommand('/nope-nope', { sessionId: 's1', args: '' });
     expect(outcome).toBe('unknown');
   });
+  it('treats removed commands (login/logout/resume/mcp/etc) as unknown', async () => {
+    for (const removed of ['login', 'logout', 'resume', 'mcp', 'hooks', 'agents', 'review']) {
+      // eslint-disable-next-line no-await-in-loop
+      const out = await dispatchSlashCommand(`/${removed}`, { sessionId: 's', args: '' });
+      expect(out, `expected /${removed} to be unknown after pruning`).toBe('unknown');
+    }
+  });
 });
 
 describe('registry shape', () => {
-  it('the five client commands declare passThrough: false with a handler', () => {
-    const clientNames = ['clear', 'cost', 'config', 'model', 'help'];
+  it('the nine client commands declare passThrough: false with a handler', () => {
+    const clientNames = ['clear', 'cost', 'config', 'model', 'help', 'status', 'doctor', 'memory', 'bug'];
     for (const n of clientNames) {
       const c = findSlashCommand(n);
       expect(c, `command ${n} not in registry`).toBeTruthy();
@@ -94,12 +106,14 @@ describe('registry shape', () => {
       expect(typeof c!.clientHandler).toBe('function');
     }
   });
-  it('other commands are pass-through without a handler', () => {
+  it('only /compact and /init remain as pass-through', () => {
     const passNames = SLASH_COMMANDS.filter((c) => !c.clientHandler).map((c) => c.name);
-    expect(passNames).toContain('doctor');
-    expect(passNames).toContain('memory');
-    expect(passNames).toContain('login');
-    expect(passNames).toContain('compact');
+    expect(passNames.sort()).toEqual(['compact', 'init']);
+  });
+  it('removed commands are gone from the registry', () => {
+    for (const removed of ['login', 'logout', 'resume', 'mcp', 'hooks', 'agents', 'review']) {
+      expect(findSlashCommand(removed), `expected /${removed} to be removed`).toBeUndefined();
+    }
   });
 });
 
@@ -197,6 +211,162 @@ describe('blocksToTranscript', () => {
     expect(t).toContain('Assistant: hello');
     expect(t).toContain('Tool(Read): foo.ts');
     expect(t).toContain('(info) Done — ok');
+  });
+});
+
+// ───── shared window.agentory stub for /status, /doctor, /memory, /bug ─────
+//
+// Mocks the IPC surface tightly enough that the handlers can render a status
+// or error block; per test the doctor/memory/openExternal stubs can be
+// overridden via the `__overrides` field below.
+type StubOverrides = {
+  doctorRun?: () => Promise<{ checks: Array<{ name: string; ok: boolean; detail: string }> }>;
+  memoryOpen?: () => Promise<{ ok: true } | { ok: false; error: string }>;
+  openExternal?: (url: string) => Promise<boolean>;
+  getVersion?: () => Promise<string>;
+};
+
+let stubOverrides: StubOverrides = {};
+
+function installAgentoryStub(): void {
+  // jsdom doesn't define `window.agentory`; we add a minimal mock that the
+  // handlers can call without exploding. Each test resets stubOverrides in
+  // beforeEach.
+  Object.defineProperty(window, 'agentory', {
+    value: {
+      getVersion: () => stubOverrides.getVersion?.() ?? Promise.resolve('0.0.0-test'),
+      doctor: { run: () => stubOverrides.doctorRun?.() ?? Promise.resolve({ checks: [] }) },
+      memory: { openUserFile: () => stubOverrides.memoryOpen?.() ?? Promise.resolve({ ok: true as const }) },
+      openExternal: (url: string) =>
+        stubOverrides.openExternal?.(url) ?? Promise.resolve(true),
+      window: { platform: 'test' }
+    },
+    writable: true,
+    configurable: true
+  });
+}
+
+installAgentoryStub();
+
+describe('/status', () => {
+  it('renders connection / model / cwd / usage in a status banner', () => {
+    useStore.getState().createSession('/tmp/work');
+    const sid = useStore.getState().activeId;
+    useStore.setState({
+      connection: { baseUrl: 'https://api.example.com', model: 'sonnet', hasAuthToken: true }
+    });
+    useStore.getState().addSessionStats(sid, {
+      turns: 1,
+      inputTokens: 500,
+      outputTokens: 50,
+      costUsd: 0.0012
+    });
+    handleStatus({ sessionId: sid, args: '' });
+    const blocks = useStore.getState().messagesBySession[sid] ?? [];
+    const s = blocks.find((b) => b.kind === 'status');
+    expect(s && s.kind === 'status' && s.title).toBe('Session status');
+    if (s && s.kind === 'status') {
+      expect(s.detail).toContain('/tmp/work');
+      expect(s.detail).toContain('https://api.example.com');
+      expect(s.detail).toContain('token present');
+      expect(s.detail).toContain('1 turn');
+    }
+  });
+  it('shows "no turns yet" when stats are empty', () => {
+    useStore.getState().createSession('/tmp');
+    const sid = useStore.getState().activeId;
+    handleStatus({ sessionId: sid, args: '' });
+    const s = (useStore.getState().messagesBySession[sid] ?? []).find((b) => b.kind === 'status');
+    expect(s && s.kind === 'status' && s.detail).toContain('no turns yet');
+  });
+});
+
+describe('/doctor', () => {
+  beforeEach(() => {
+    stubOverrides = {};
+  });
+  it('renders "all checks passed" when every probe is ok', async () => {
+    stubOverrides.doctorRun = async () => ({
+      checks: [
+        { name: 'settings.json', ok: true, detail: '/x' },
+        { name: 'claude binary', ok: true, detail: '/bin/claude (v2.1.0)' },
+        { name: 'data dir writable', ok: true, detail: '/data' }
+      ]
+    });
+    useStore.getState().createSession('/tmp');
+    const sid = useStore.getState().activeId;
+    await handleDoctor({ sessionId: sid, args: '' });
+    const s = (useStore.getState().messagesBySession[sid] ?? []).find((b) => b.kind === 'status');
+    expect(s && s.kind === 'status' && s.title).toBe('Doctor: all checks passed');
+    if (s && s.kind === 'status') {
+      expect(s.tone).toBe('info');
+      expect(s.detail).toContain('[ok]');
+      expect(s.detail).toContain('settings.json');
+    }
+  });
+  it('warns when any check fails', async () => {
+    stubOverrides.doctorRun = async () => ({
+      checks: [
+        { name: 'settings.json', ok: false, detail: 'not found' },
+        { name: 'claude binary', ok: true, detail: '/bin/claude' }
+      ]
+    });
+    useStore.getState().createSession('/tmp');
+    const sid = useStore.getState().activeId;
+    await handleDoctor({ sessionId: sid, args: '' });
+    const s = (useStore.getState().messagesBySession[sid] ?? []).find((b) => b.kind === 'status');
+    expect(s && s.kind === 'status' && s.title).toBe('Doctor: issues found');
+    if (s && s.kind === 'status') {
+      expect(s.tone).toBe('warn');
+      expect(s.detail).toContain('[fail]');
+      expect(s.detail).toContain('settings.json');
+      expect(s.detail).toContain('not found');
+    }
+  });
+});
+
+describe('/memory', () => {
+  beforeEach(() => {
+    stubOverrides = {};
+  });
+  it('renders confirmation when openUserFile succeeds', async () => {
+    stubOverrides.memoryOpen = async () => ({ ok: true });
+    useStore.getState().createSession('/tmp');
+    const sid = useStore.getState().activeId;
+    await handleMemory({ sessionId: sid, args: '' });
+    const s = (useStore.getState().messagesBySession[sid] ?? []).find((b) => b.kind === 'status');
+    expect(s && s.kind === 'status' && s.title).toBe('Opened user memory');
+  });
+  it('renders error when openUserFile fails', async () => {
+    stubOverrides.memoryOpen = async () => ({ ok: false, error: 'EACCES' });
+    useStore.getState().createSession('/tmp');
+    const sid = useStore.getState().activeId;
+    await handleMemory({ sessionId: sid, args: '' });
+    const e = (useStore.getState().messagesBySession[sid] ?? []).find((b) => b.kind === 'error');
+    expect(e && e.kind === 'error' && e.text).toContain('EACCES');
+  });
+});
+
+describe('/bug', () => {
+  beforeEach(() => {
+    stubOverrides = {};
+  });
+  it('opens a GitHub URL with prefilled environment metadata', async () => {
+    let captured: string | null = null;
+    stubOverrides.openExternal = async (url) => {
+      captured = url;
+      return true;
+    };
+    stubOverrides.getVersion = async () => '1.2.3';
+    useStore.getState().createSession('/tmp');
+    const sid = useStore.getState().activeId;
+    await handleBug({ sessionId: sid, args: '' });
+    expect(captured).toBeTruthy();
+    expect(captured!).toContain('github.com/Jiahui-Gu/Agentory-next/issues/new');
+    // Body is URL-encoded; decoding once should reveal the version line.
+    const decoded = decodeURIComponent(captured!);
+    expect(decoded).toContain('Agentory: 1.2.3');
+    expect(decoded).toContain('Platform: test');
   });
 });
 


### PR DESCRIPTION
## Summary

- Trim slash-command registry from 19 to 12: remove 7 entries (`/resume`, `/login`, `/logout`, `/mcp`, `/hooks`, `/agents`, `/review`) that were marked `passThrough: true` but silently dropped by `claude.exe` under `--input-format stream-json`, leaving users staring at a no-op button.
- Add 4 new client handlers so the surviving discoverable commands actually do something useful in the GUI: `/status`, `/doctor`, `/memory`, `/bug`. Two new IPC channels back them: `doctor:run` (local health probes) and `memory:openUserFile` (opens `~/.claude/CLAUDE.md` in the OS-default editor; creates a stub if missing).
- Only `/compact` and `/init` remain as honest pass-throughs — both have legitimate native handling in `claude.exe` and no GUI replacement.

### Audit decision summary

| Command   | Verdict | Reason |
|-----------|---------|--------|
| `/resume` | removed | sidebar already lists sessions |
| `/login`, `/logout` | removed | Agentory does not own auth — settings.json is the single source of truth, surfaced via Settings -> Connection (which `/config` opens) |
| `/mcp`, `/hooks`, `/agents`, `/review` | removed | silently dropped in stream-json mode; no GUI surface yet |
| `/status` | now client | renders connection / model / cwd / token usage |
| `/doctor` | now client | runs `doctor:run` IPC, formats `[ok]`/`[fail]` block |
| `/memory` | now client | opens `~/.claude/CLAUDE.md` in OS editor |
| `/bug`    | now client | opens GitHub issue URL with prefilled env block |
| `/compact`, `/init` | kept passthrough | CLI handles natively |

`scripts/probe-slash-audit.mjs` enumerates the live registry from the picker DOM, sends each command, and reports a markdown table of what happened (status block, error, dialog, agent send, openExternal, memory open). Sample output against this branch:

```
| /help    | 1 | 0 | no  | 0 | 0 | 0 | ok    |
| /clear   |-1 | 0 | no  | 0 | 0 | 0 | DEAD? |   (false negative — switches sessions; verified via probe-slash-exec)
| /compact | 0 | 0 | no  | 1 | 0 | 0 | ok    |
| /model   | 0 | 0 | yes | 0 | 0 | 0 | ok    |
| /config  | 0 | 0 | yes | 0 | 0 | 0 | ok    |
| /cost    | 1 | 0 | no  | 0 | 0 | 0 | ok    |
| /pr      | 1 | 0 | no  | 0 | 0 | 0 | ok    |
| /status  | 1 | 0 | no  | 0 | 0 | 0 | ok    |
| /doctor  | 1 | 0 | no  | 0 | 0 | 0 | ok    |
| /memory  | 1 | 0 | no  | 0 | 0 | 1 | ok    |
| /bug     | 1 | 0 | no  | 0 | 1 | 0 | ok    |
| /init    | 0 | 0 | no  | 0 | 0 | 0 | DEAD? |   (race with agentStart in stub; pass-through path is real)
```

10 / 12 verdicts are clean; the two flagged are known false-negatives noted in the script's footer.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test -- tests/slash-commands-handlers.test.ts tests/slash-commands-registry.test.ts tests/slash-command-picker.test.tsx` -> 49 / 49 pass (8 new handler tests for `/status`, `/doctor`, `/memory`, `/bug`)
- [x] `node scripts/probe-slash-status.mjs` -> OK
- [x] `node scripts/probe-slash-doctor.mjs` -> OK
- [x] `node scripts/probe-slash-memory.mjs` -> OK
- [x] `node scripts/probe-slash-bug.mjs` -> OK
- [x] `node scripts/probe-slash-audit.mjs` -> 10/12 ok, 2 known false-negatives
- [x] Pre-existing `db.test.ts` failures (better-sqlite3 ABI mismatch) and `probe-slash-exec.mjs` failure ("General tab label") confirmed present on `working` baseline; out of scope.