### PR TITLE
test(e2e): batch B — sidebar dnd/rename/group-add/resize

### DIFF
--- a/scripts/probe-e2e-dnd.mjs
+++ b/scripts/probe-e2e-dnd.mjs
@@ -1,7 +1,7 @@
-// E2E: cross-group drag & drop.
+// E2E: cross-group drag & drop, plus drag-handle vs inline-rename coexistence.
 //
 // Fixture: seed sessions directly into the store (window.__agentoryStore
-// is exposed in dev). Seeding pre-existing sessions is equivalent to "user
+// is exposed on window). Seeding pre-existing sessions is equivalent to "user
 // had these from prior runs" — the start point we care about is the drag
 // gesture, the end point is the DOM after drop. No SDK / API key involved.
 //
@@ -10,14 +10,25 @@
 //      session now lives inside that group's <ul> in the DOM.
 //   2. Drag a session onto a COLLAPSED group's header → after 400ms hover,
 //      the group auto-expands, and on release the session lands inside it.
+//   3. With a session row in inline-rename mode, the rename input must
+//      remain interactive (typing reaches the input) — i.e. dnd-kit's
+//      pointer listeners on the row don't swallow the rename input's
+//      focus/keystrokes.
+//
+// IMPORTANT: dnd-kit's PointerSensor listens for native PointerEvents.
+// Playwright's `mouse.down/move/up` API dispatches MouseEvents, which
+// Chromium does not synthesize PointerEvents from in a way the sensor
+// picks up. We use the dndDrag helper which dispatches real
+// PointerEvents on document — this is what makes the drag actually move.
 //
 // This catches the class of bug: cross-container moves are ignored because
 // the target container isn't registered as a droppable (or collapsed groups
-// can't receive drops at all).
+// can't receive drops at all), AND the class of bug: rename UI breaks
+// because the dragHandle on the row eats input events.
 import { _electron as electron } from 'playwright';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { appWindow } from './probe-utils.mjs';
+import { appWindow, dndDrag, isolatedUserData, seedStore } from './probe-utils.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
@@ -27,10 +38,13 @@ function fail(msg) {
   process.exit(1);
 }
 
+const ud = isolatedUserData('agentory-probe-dnd');
+console.log(`[probe-e2e-dnd] userData = ${ud.dir}`);
+
 const app = await electron.launch({
-  args: ['.'],
+  args: ['.', `--user-data-dir=${ud.dir}`],
   cwd: root,
-  env: { ...process.env, NODE_ENV: 'development' }
+  env: { ...process.env, AGENTORY_PROD_BUNDLE: '1' }
 });
 
 const win = await appWindow(app);
@@ -41,7 +55,6 @@ win.on('console', (m) => {
 });
 
 await win.waitForLoadState('domcontentloaded');
-await win.waitForTimeout(1500);
 
 // Wipe any persisted state from the user's dev DB and seed a clean fixture:
 //   Group G1 (custom, open):    s1, s2
@@ -50,32 +63,24 @@ await win.waitForTimeout(1500);
 // We want to:
 //   - drag s1 from G1 → G2 (open→open header drop)
 //   - drag s2 from G1 → G3 (open→collapsed header, triggers hover-expand)
-await win.evaluate(() => {
-  const store = window.__agentoryStore;
-  if (!store) throw new Error('__agentoryStore not on window — dev build?');
-  store.setState({
-    groups: [
-      { id: 'g1', name: 'G1', collapsed: false, kind: 'normal' },
-      { id: 'g2', name: 'G2', collapsed: false, kind: 'normal' },
-      { id: 'g3', name: 'G3', collapsed: true, kind: 'normal' }
-    ],
-    sessions: [
-      { id: 's1', name: 'session one',   state: 'waiting', cwd: '~', model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code' },
-      { id: 's2', name: 'session two',   state: 'waiting', cwd: '~', model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code' },
-      { id: 's3', name: 'session three', state: 'waiting', cwd: '~', model: 'claude-opus-4', groupId: 'g2', agentType: 'claude-code' }
-    ],
-    activeId: 's1'
-  });
+await seedStore(win, {
+  groups: [
+    { id: 'g1', name: 'G1', collapsed: false, kind: 'normal' },
+    { id: 'g2', name: 'G2', collapsed: false, kind: 'normal' },
+    { id: 'g3', name: 'G3', collapsed: true, kind: 'normal' }
+  ],
+  sessions: [
+    { id: 's1', name: 'session one',   state: 'waiting', cwd: '~', model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code' },
+    { id: 's2', name: 'session two',   state: 'waiting', cwd: '~', model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code' },
+    { id: 's3', name: 'session three', state: 'waiting', cwd: '~', model: 'claude-opus-4', groupId: 'g2', agentType: 'claude-code' }
+  ],
+  activeId: 's1'
 });
-await win.waitForTimeout(300);
 
-// Sanity: sidebar reflects fixture.
 async function groupContains(groupId, sessionId) {
   return await win.evaluate(
     ({ groupId, sessionId }) => {
-      const header = document.querySelector(`[data-group-header-id="${groupId}"]`);
-      if (!header) return null;
-      const ul = header.parentElement?.querySelector('ul[data-group-id="' + groupId + '"]');
+      const ul = document.querySelector(`ul[data-group-id="${groupId}"]`);
       if (!ul) return null;
       return !!ul.querySelector(`li[data-session-id="${sessionId}"]`);
     },
@@ -91,77 +96,65 @@ async function groupIsOpen(groupId) {
   }, groupId);
 }
 
-if (!(await groupContains('g1', 's1'))) { await app.close(); fail('fixture: s1 not in g1'); }
-if (!(await groupContains('g2', 's3'))) { await app.close(); fail('fixture: s3 not in g2'); }
-if (await groupIsOpen('g3')) { await app.close(); fail('fixture: g3 should start collapsed'); }
-
-// --- Helper: hand-driven drag via PointerSensor (activation distance = 8px).
-// Playwright's mouse.down/move/up with multiple intermediate moves makes
-// dnd-kit's activation constraint kick in; a single move is too fast.
-async function dragTo(sourceSelector, targetSelector) {
-  const src = win.locator(sourceSelector).first();
-  const tgt = win.locator(targetSelector).first();
-  await src.waitFor({ state: 'visible', timeout: 5000 });
-  await tgt.waitFor({ state: 'visible', timeout: 5000 });
-  const sb = await src.boundingBox();
-  const tb = await tgt.boundingBox();
-  if (!sb || !tb) throw new Error('dragTo: missing boundingBox');
-  const sx = sb.x + sb.width / 2;
-  const sy = sb.y + sb.height / 2;
-  const tx = tb.x + tb.width / 2;
-  const ty = tb.y + tb.height / 2;
-  await win.mouse.move(sx, sy);
-  await win.mouse.down();
-  // wiggle to satisfy activationConstraint.distance (8px)
-  await win.mouse.move(sx + 10, sy + 10, { steps: 5 });
-  await win.mouse.move(tx, ty, { steps: 15 });
-  return { release: async () => { await win.mouse.up(); } };
+async function bail(msg) {
+  await app.close();
+  ud.cleanup();
+  fail(msg);
 }
+
+if (!(await groupContains('g1', 's1'))) await bail('fixture: s1 not in g1');
+if (!(await groupContains('g2', 's3'))) await bail('fixture: s3 not in g2');
+if (await groupIsOpen('g3')) await bail('fixture: g3 should start collapsed');
 
 // === Case 1: open → open. s1 (g1) → g2 header. ===
-{
-  const handle = await dragTo(
-    'li[data-session-id="s1"]',
-    '[data-group-header-id="g2"]'
-  );
-  await win.waitForTimeout(150);
-  await handle.release();
-  await win.waitForTimeout(300);
-
-  if (await groupContains('g1', 's1')) { await app.close(); fail('s1 still in g1 after drag to g2 header'); }
-  if (!(await groupContains('g2', 's1'))) { await app.close(); fail('s1 did not land in g2 after cross-group drag'); }
-}
+await dndDrag(
+  win,
+  'li[data-session-id="s1"]',
+  '[data-group-header-id="g2"]'
+);
+if (await groupContains('g1', 's1')) await bail('s1 still in g1 after drag to g2 header');
+if (!(await groupContains('g2', 's1'))) await bail('s1 did not land in g2 after cross-group drag');
 
 // === Case 2: open → collapsed. s2 (g1) → g3 header. Hover must auto-expand. ===
-{
-  const src = win.locator('li[data-session-id="s2"]').first();
-  const tgt = win.locator('[data-group-header-id="g3"]').first();
-  const sb = await src.boundingBox();
-  const tb = await tgt.boundingBox();
-  if (!sb || !tb) { await app.close(); fail('case2: missing boundingBox'); }
-  await win.mouse.move(sb.x + sb.width / 2, sb.y + sb.height / 2);
-  await win.mouse.down();
-  await win.mouse.move(sb.x + sb.width / 2 + 10, sb.y + sb.height / 2 + 10, { steps: 5 });
-  // Hover on g3 header and HOLD >400ms so the auto-expand timer fires.
-  await win.mouse.move(tb.x + tb.width / 2, tb.y + tb.height / 2, { steps: 15 });
-  await win.waitForTimeout(700);
+await dndDrag(
+  win,
+  'li[data-session-id="s2"]',
+  '[data-group-header-id="g3"]',
+  { holdMs: 700 }
+);
+if (!(await groupIsOpen('g3'))) await bail('g3 did NOT auto-expand after 400ms hover');
+if (await groupContains('g1', 's2')) await bail('s2 still in g1 after drag to g3 header');
+if (!(await groupContains('g3', 's2'))) await bail('s2 did not land in g3 after hover-expand drop');
 
-  if (!(await groupIsOpen('g3'))) {
-    await win.mouse.up();
-    await app.close();
-    fail('g3 did NOT auto-expand after 400ms hover');
-  }
-
-  // Still holding — now release on the (now-open) header to drop into g3.
-  await win.mouse.up();
-  await win.waitForTimeout(300);
-
-  if (await groupContains('g1', 's2')) { await app.close(); fail('s2 still in g1 after drag to g3 header'); }
-  if (!(await groupContains('g3', 's2'))) { await app.close(); fail('s2 did not land in g3 after hover-expand drop'); }
+// === Case 3: dragHandle vs inline rename coexistence. ===
+// The whole <li> is the dnd dragHandle (useSortable spreads {...listeners}
+// on the row). When the user enters rename mode, the inline <input> sits
+// INSIDE that li — typing must still reach the input despite the listeners.
+// Right-click the row → "Rename", type a new name, press Enter, verify the
+// store reflects the new name (not "swallowed" by the drag handle).
+await win.locator('li[data-session-id="s3"]').click();
+await win.locator('li[data-session-id="s3"]').click({ button: 'right' });
+const renameItem = win.getByRole('menuitem', { name: /rename/i }).first();
+await renameItem.waitFor({ state: 'visible', timeout: 3000 });
+await renameItem.click();
+const renameInput = win.locator('li[data-session-id="s3"] input').first();
+await renameInput.waitFor({ state: 'visible', timeout: 3000 });
+// Clear via select-all + type.
+await renameInput.fill('renamed via probe');
+await renameInput.press('Enter');
+await win.waitForTimeout(300);
+const after = await win.evaluate(() => {
+  const s = window.__agentoryStore.getState().sessions.find((x) => x.id === 's3');
+  return s ? s.name : null;
+});
+if (after !== 'renamed via probe') {
+  await bail(`rename did not commit; expected "renamed via probe", got "${after}"`);
 }
 
 console.log('\n[probe-e2e-dnd] OK');
 console.log('  s1: g1 → g2 via header drop');
 console.log('  s2: g1 → g3 via collapsed-header hover-expand drop');
+console.log('  s3: inline rename works while dragHandle listeners are bound');
 
 await app.close();
+ud.cleanup();

--- a/scripts/probe-e2e-group-add.mjs
+++ b/scripts/probe-e2e-group-add.mjs
@@ -1,0 +1,95 @@
+// E2E: per-group + button creates a session in THAT group and selects it.
+//
+// Each normal-kind group's header has a small Plus IconButton on the right
+// (added in commit dac3f43 / `feat(sidebar): per-group + button + reorder
+// context menu`). Click should:
+//   1. Create a new Session whose `groupId` equals the clicked group's id —
+//      not whatever the focused/active group is.
+//   2. Select the newly-created session (so the chat pane swaps to it).
+//   3. NOT collapse/expand the group it lives in.
+//   4. Be hidden on special groups (archive/deleted) — verified for archive.
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { appWindow, isolatedUserData, seedStore } from './probe-utils.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function fail(msg) {
+  console.error(`\n[probe-e2e-group-add] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const ud = isolatedUserData('agentory-probe-group-add');
+console.log(`[probe-e2e-group-add] userData = ${ud.dir}`);
+
+const app = await electron.launch({
+  args: ['.', `--user-data-dir=${ud.dir}`],
+  cwd: root,
+  env: { ...process.env, AGENTORY_PROD_BUNDLE: '1' }
+});
+const win = await appWindow(app);
+const errors = [];
+win.on('pageerror', (e) => errors.push(`[pageerror] ${e.message}`));
+win.on('console', (m) => {
+  if (m.type() === 'error') errors.push(`[console.error] ${m.text()}`);
+});
+await win.waitForLoadState('domcontentloaded');
+
+await seedStore(win, {
+  groups: [
+    { id: 'g1', name: 'Alpha', collapsed: false, kind: 'normal' },
+    { id: 'g2', name: 'Bravo', collapsed: false, kind: 'normal' },
+    { id: 'gA', name: 'Archived', collapsed: false, kind: 'archive' }
+  ],
+  sessions: [
+    { id: 's1', name: 'a-only', state: 'idle', cwd: '~', model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code' }
+  ],
+  // Active session lives in g1; we click the +button on g2 and assert the
+  // new session goes to g2 anyway, NOT to the focused/active group.
+  activeId: 's1',
+  focusedGroupId: 'g1'
+});
+
+async function bail(msg) {
+  console.error('--- pageerrors ---\n' + errors.slice(-10).join('\n'));
+  await app.close();
+  ud.cleanup();
+  fail(msg);
+}
+
+// === Case 1: clicking g2's + creates a session in g2 (not in g1). ===
+const before = await win.evaluate(() => window.__agentoryStore.getState().sessions.map((s) => ({ id: s.id, groupId: s.groupId })));
+const g2Plus = win.locator('[data-group-header-id="g2"] button[aria-label*="new session" i], [data-group-header-id="g2"] button[aria-label*="新建" i]').first();
+await g2Plus.waitFor({ state: 'visible', timeout: 3000 });
+await g2Plus.click();
+await win.waitForTimeout(300);
+const after = await win.evaluate(() => window.__agentoryStore.getState().sessions.map((s) => ({ id: s.id, groupId: s.groupId })));
+const beforeIds = new Set(before.map((s) => s.id));
+const fresh = after.filter((s) => !beforeIds.has(s.id));
+if (fresh.length !== 1) await bail(`expected exactly 1 new session, got ${fresh.length}`);
+if (fresh[0].groupId !== 'g2') await bail(`new session should land in g2, got ${fresh[0].groupId}`);
+
+// === Case 2: the new session is now active. ===
+const activeId = await win.evaluate(() => window.__agentoryStore.getState().activeId);
+if (activeId !== fresh[0].id) await bail(`new session should be active; activeId=${activeId}, fresh.id=${fresh[0].id}`);
+
+// === Case 3: g2 stays expanded (the + click must not toggle collapse). ===
+const g2Open = await win.evaluate(() => {
+  const header = document.querySelector('[data-group-header-id="g2"]');
+  return header?.querySelector('button[aria-expanded]')?.getAttribute('aria-expanded') === 'true';
+});
+if (!g2Open) await bail('g2 collapsed after + click — the click should not propagate to header toggle');
+
+// === Case 4: archived group has no + button. ===
+const archivedPlus = await win.locator('[data-group-header-id="gA"] button[aria-label*="new session" i]').count();
+if (archivedPlus !== 0) await bail(`archived group should not have a + button (got ${archivedPlus})`);
+
+console.log('\n[probe-e2e-group-add] OK');
+console.log(`  + on g2 created session ${fresh[0].id} in g2 (not g1) and made it active`);
+console.log('  click did not collapse g2');
+console.log('  archived group has no + button');
+
+await app.close();
+ud.cleanup();

--- a/scripts/probe-e2e-rename.mjs
+++ b/scripts/probe-e2e-rename.mjs
@@ -1,0 +1,228 @@
+// E2E: inline rename for sessions and groups via context menu.
+//
+// Covers the four exit paths the InlineRename input supports:
+//   1. Enter → commits the trimmed draft to the store.
+//   2. Escape → cancels; the store keeps the original name.
+//   3. Empty / whitespace-only draft + Enter → cancels (treated as no-op).
+//   4. Click outside → commits (mousedown capture-phase, since dnd-kit's
+//      pointer listeners on ancestor rows can swallow the input's blur).
+//   5. IME composition: pressing Enter while `isComposing` is true must NOT
+//      commit (CJK candidate selection only). After composition ends,
+//      Enter commits as usual.
+//
+// We exercise both session rename (under SessionRow) and group rename
+// (under GroupRow) since they share InlineRename but live inside different
+// host elements (li vs div) with different surrounding handlers.
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { appWindow, isolatedUserData, seedStore } from './probe-utils.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function fail(msg) {
+  console.error(`\n[probe-e2e-rename] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const ud = isolatedUserData('agentory-probe-rename');
+console.log(`[probe-e2e-rename] userData = ${ud.dir}`);
+
+const app = await electron.launch({
+  args: ['.', `--user-data-dir=${ud.dir}`],
+  cwd: root,
+  env: { ...process.env, AGENTORY_PROD_BUNDLE: '1' }
+});
+const win = await appWindow(app);
+const errors = [];
+win.on('pageerror', (e) => errors.push(`[pageerror] ${e.message}`));
+win.on('console', (m) => {
+  if (m.type() === 'error') errors.push(`[console.error] ${m.text()}`);
+});
+await win.waitForLoadState('domcontentloaded');
+
+await seedStore(win, {
+  groups: [
+    { id: 'g1', name: 'Alpha',  collapsed: false, kind: 'normal' },
+    { id: 'g2', name: 'Bravo',  collapsed: false, kind: 'normal' }
+  ],
+  sessions: [
+    { id: 's1', name: 'first',  state: 'idle', cwd: '~', model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code' },
+    { id: 's2', name: 'second', state: 'idle', cwd: '~', model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code' },
+    { id: 's3', name: 'third',  state: 'idle', cwd: '~', model: 'claude-opus-4', groupId: 'g2', agentType: 'claude-code' }
+  ],
+  activeId: 's1'
+});
+
+async function bail(msg) {
+  console.error('--- pageerrors ---\n' + errors.slice(-10).join('\n'));
+  await app.close();
+  ud.cleanup();
+  fail(msg);
+}
+
+async function sessionName(id) {
+  return await win.evaluate(
+    (sid) => window.__agentoryStore.getState().sessions.find((s) => s.id === sid)?.name ?? null,
+    id
+  );
+}
+async function groupName(id) {
+  return await win.evaluate(
+    (gid) => window.__agentoryStore.getState().groups.find((g) => g.id === gid)?.name ?? null,
+    id
+  );
+}
+
+async function openSessionRename(sessionId) {
+  const row = win.locator(`li[data-session-id="${sessionId}"]`).first();
+  await row.click({ button: 'right' });
+  await win.getByRole('menuitem', { name: /^Rename$/ }).first().click();
+  const input = win.locator(`li[data-session-id="${sessionId}"] input`).first();
+  await input.waitFor({ state: 'visible', timeout: 3000 });
+  // InlineRename's mount effect runs focus()+select() asynchronously after
+  // first paint. If we go straight to fill(), Playwright's value-set racing
+  // the React-controlled re-render leaves the field stuck at the original
+  // value. A real click() forces focus to settle in the input first.
+  await input.click();
+  return input;
+}
+
+async function openGroupRename(groupId) {
+  const header = win.locator(`[data-group-header-id="${groupId}"]`).first();
+  await header.click({ button: 'right' });
+  await win.getByRole('menuitem', { name: /^Rename$/ }).first().click();
+  const input = win.locator(`[data-group-header-id="${groupId}"] input`).first();
+  await input.waitFor({ state: 'visible', timeout: 3000 });
+  await input.click();
+  return input;
+}
+
+// === Case 1: session Enter commits ===
+{
+  const input = await openSessionRename('s1');
+  await input.fill('first renamed');
+  await input.press('Enter');
+  await win.waitForTimeout(200);
+  const after = await sessionName('s1');
+  if (after !== 'first renamed') await bail(`session Enter commit: expected "first renamed", got "${after}"`);
+  // Input should be gone (rename mode exited).
+  const stillEditing = await win.locator('li[data-session-id="s1"] input').count();
+  if (stillEditing !== 0) await bail('session Enter commit: input still visible after commit');
+}
+
+// === Case 2: session Escape cancels ===
+{
+  const input = await openSessionRename('s2');
+  await input.fill('should not stick');
+  await input.press('Escape');
+  await win.waitForTimeout(200);
+  const after = await sessionName('s2');
+  if (after !== 'second') await bail(`session Escape cancel: expected "second", got "${after}"`);
+}
+
+// === Case 3: empty / whitespace draft + Enter cancels (treated as no-op) ===
+{
+  const input = await openSessionRename('s2');
+  await input.fill('   ');
+  await input.press('Enter');
+  await win.waitForTimeout(200);
+  const after = await sessionName('s2');
+  if (after !== 'second') await bail(`session whitespace Enter: expected name unchanged, got "${after}"`);
+}
+
+// === Case 4: click outside commits ===
+{
+  const input = await openSessionRename('s3');
+  await input.fill('clicked away');
+  // Click somewhere clearly outside — the new-session button at the top.
+  await win.locator('aside button:has-text("New session")').first().click({ force: true });
+  await win.waitForTimeout(250);
+  const after = await sessionName('s3');
+  if (after !== 'clicked away') await bail(`session click-outside commit: expected "clicked away", got "${after}"`);
+}
+
+// === Case 5: IME composition — Enter during isComposing must NOT commit ===
+{
+  const input = await openSessionRename('s1');
+  // Start with empty so we can see typed composition.
+  await input.fill('');
+  // Manually fire compositionstart so React thinks IME is active; then a
+  // keydown with isComposing=true; assert no commit; then compositionend +
+  // Enter and assert commit.
+  await win.evaluate(() => {
+    const el = document.querySelector('li[data-session-id="s1"] input');
+    el.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+  });
+  // Type a candidate visually; the InlineRename's onChange fires when React
+  // detects the input value has changed via its tracker. We must use the
+  // native value setter, otherwise React skips the change because its
+  // synthetic tracker still holds the prior value.
+  await win.evaluate(() => {
+    const el = document.querySelector('li[data-session-id="s1"] input');
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
+    setter.call(el, 'ni hao');
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+  // Send Enter with isComposing=true; per the input's handler it should
+  // bail out and NOT commit.
+  await win.evaluate(() => {
+    const el = document.querySelector('li[data-session-id="s1"] input');
+    const ev = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      code: 'Enter',
+      bubbles: true,
+      cancelable: true,
+      isComposing: true,
+      keyCode: 229
+    });
+    el.dispatchEvent(ev);
+  });
+  await win.waitForTimeout(150);
+  // Store name should still be the previous committed value, NOT "ni hao".
+  const midComp = await sessionName('s1');
+  if (midComp !== 'first renamed') {
+    await bail(`session IME composition Enter must not commit; expected "first renamed", got "${midComp}"`);
+  }
+  // End composition, then a normal Enter commits.
+  await win.evaluate(() => {
+    const el = document.querySelector('li[data-session-id="s1"] input');
+    el.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: 'ni hao' }));
+  });
+  const valBefore = await win.locator('li[data-session-id="s1"] input').inputValue();
+  if (valBefore !== 'ni hao') await bail(`session post-IME: input value should be "ni hao" before Enter, got "${valBefore}"`);
+  await win.locator('li[data-session-id="s1"] input').focus();
+  await win.locator('li[data-session-id="s1"] input').press('Enter');
+  await win.waitForTimeout(200);
+  const afterComp = await sessionName('s1');
+  if (afterComp !== 'ni hao') {
+    await bail(`session post-IME Enter commit: expected "ni hao", got "${afterComp}"`);
+  }
+}
+
+// === Case 6: group Enter commits + Escape cancels ===
+{
+  const input = await openGroupRename('g1');
+  await input.fill('Alpha+');
+  await input.press('Enter');
+  await win.waitForTimeout(200);
+  const after = await groupName('g1');
+  if (after !== 'Alpha+') await bail(`group Enter commit: expected "Alpha+", got "${after}"`);
+}
+{
+  const input = await openGroupRename('g2');
+  await input.fill('Charlie');
+  await input.press('Escape');
+  await win.waitForTimeout(200);
+  const after = await groupName('g2');
+  if (after !== 'Bravo') await bail(`group Escape cancel: expected "Bravo", got "${after}"`);
+}
+
+console.log('\n[probe-e2e-rename] OK');
+console.log('  session: Enter commits / Escape cancels / whitespace cancels / click-outside commits');
+console.log('  session: IME composition Enter does not commit; post-composition Enter does');
+console.log('  group:   Enter commits / Escape cancels');
+
+await app.close();
+ud.cleanup();

--- a/scripts/probe-e2e-sidebar-resize.mjs
+++ b/scripts/probe-e2e-sidebar-resize.mjs
@@ -1,0 +1,210 @@
+// E2E: sidebar/chat resizer.
+//
+// What we verify:
+//   1. The vertical separator between Sidebar and the main pane responds to
+//      a pointer drag, updating the sidebar's rendered width and the
+//      store's `sidebarWidth`.
+//   2. The width is clamped to [SIDEBAR_WIDTH_MIN, SIDEBAR_WIDTH_MAX] —
+//      dragging way past the max should park at the max.
+//   3. Double-click resets to SIDEBAR_WIDTH_DEFAULT.
+//   4. The chosen width survives an electron restart with the same
+//      userData dir — i.e. it's persisted, not just in-memory.
+//
+// SidebarResizer uses native pointer events on the document, so Playwright's
+// `mouse.down/move/up` works here (unlike dnd-kit's PointerSensor).
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { appWindow, isolatedUserData } from './probe-utils.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function fail(msg) {
+  console.error(`\n[probe-e2e-sidebar-resize] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const ud = isolatedUserData('agentory-probe-sidebar-resize');
+console.log(`[probe-e2e-sidebar-resize] userData = ${ud.dir}`);
+
+const commonArgs = ['.', `--user-data-dir=${ud.dir}`];
+const commonEnv = { ...process.env, AGENTORY_PROD_BUNDLE: '1' };
+
+async function asideWidth(win) {
+  return await win.evaluate(() => {
+    const a = document.querySelector('aside');
+    return a ? Math.round(a.getBoundingClientRect().width) : -1;
+  });
+}
+async function storeWidth(win) {
+  return await win.evaluate(() => window.__agentoryStore.getState().sidebarWidth);
+}
+async function constants(win) {
+  return await win.evaluate(() => {
+    // Constants aren't on the store; read indirectly via a setter probe:
+    // setSidebarWidth clamps to [MIN, MAX], so we round-trip extreme values
+    // to recover the bounds. Cheaper than threading constants through the
+    // window.
+    const s = window.__agentoryStore;
+    const before = s.getState().sidebarWidth;
+    s.getState().setSidebarWidth(99999);
+    const max = s.getState().sidebarWidth;
+    s.getState().setSidebarWidth(0);
+    const min = s.getState().sidebarWidth;
+    s.getState().setSidebarWidth(before); // restore
+    return { min, max };
+  });
+}
+
+let chosenWidth;
+
+// ---------- Launch #1: drag, verify, double-click reset, drag again ----------
+{
+  const app = await electron.launch({ args: commonArgs, cwd: root, env: commonEnv });
+  const win = await appWindow(app);
+  await win.waitForLoadState('domcontentloaded');
+  await win.waitForFunction(() => !!window.__agentoryStore && document.querySelector('aside') !== null, null, { timeout: 20_000 });
+
+  const { min, max } = await constants(win);
+  console.log(`[probe-e2e-sidebar-resize] bounds: min=${min} max=${max}`);
+
+  const initialW = await asideWidth(win);
+  const initialStore = await storeWidth(win);
+  if (initialW <= 0) {
+    await app.close();
+    ud.cleanup();
+    fail(`fixture: aside width <=0 (${initialW})`);
+  }
+
+  // Locate the resizer (role="separator" aria-orientation="vertical").
+  const resizer = win.locator('div[role="separator"][aria-orientation="vertical"]').first();
+  await resizer.waitFor({ state: 'visible', timeout: 3000 });
+  const rb = await resizer.boundingBox();
+  if (!rb) {
+    await app.close();
+    ud.cleanup();
+    fail('resizer has no bounding box');
+  }
+  const startX = rb.x + rb.width / 2;
+  const y = rb.y + rb.height / 2;
+
+  // === Case 1: drag right by +60px → store + DOM both grow by ~60. ===
+  await win.mouse.move(startX, y);
+  await win.mouse.down();
+  await win.mouse.move(startX + 60, y, { steps: 10 });
+  await win.mouse.up();
+  await win.waitForTimeout(500); // let framer-motion's width tween settle
+  const grownStore = await storeWidth(win);
+  const grownDom = await asideWidth(win);
+  if (Math.abs(grownStore - (initialStore + 60)) > 2) {
+    await app.close();
+    ud.cleanup();
+    fail(`drag +60: storeWidth expected ~${initialStore + 60}, got ${grownStore}`);
+  }
+  if (Math.abs(grownDom - grownStore) > 4) {
+    await app.close();
+    ud.cleanup();
+    fail(`drag +60: aside DOM width ${grownDom} doesn't track storeWidth ${grownStore}`);
+  }
+
+  // === Case 2: drag past the max — width should park at max. ===
+  // Move toward the right edge of the window (not 5000px off-screen — once
+  // the cursor leaves the window, pointermove stops firing on the
+  // document-level listener and we'd stall mid-drag). Dispatch real
+  // PointerEvents: SidebarResizer.onPointerDown is a React handler bound
+  // to the separator and listens for `pointerdown` (button=0).
+  const winSize = await win.evaluate(() => ({ w: window.innerWidth, h: window.innerHeight }));
+  const rb2 = await resizer.boundingBox();
+  const startX2 = rb2.x + rb2.width / 2;
+  await resizer.dispatchEvent('pointerdown', {
+    button: 0, clientX: startX2, clientY: y, pointerType: 'mouse', pointerId: 1, isPrimary: true
+  });
+  const endX2 = winSize.w - 4;
+  for (let i = 1; i <= 25; i++) {
+    const px = startX2 + ((endX2 - startX2) * i) / 25;
+    await win.evaluate(({ px, y }) => document.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: px, clientY: y, bubbles: true, pointerType: 'mouse', pointerId: 1, isPrimary: true
+    })), { px, y });
+    await win.waitForTimeout(8);
+  }
+  await win.evaluate(({ x, y }) => document.dispatchEvent(new PointerEvent('pointerup', {
+    clientX: x, clientY: y, bubbles: true, pointerType: 'mouse', pointerId: 1, isPrimary: true
+  })), { x: endX2, y });
+  await win.waitForTimeout(200);
+  const clamped = await storeWidth(win);
+  if (clamped !== max) {
+    await app.close();
+    ud.cleanup();
+    fail(`drag past max: storeWidth expected ${max}, got ${clamped} (winW=${winSize.w})`);
+  }
+
+  // === Case 3: double-click resets to default. ===
+  // SIDEBAR_WIDTH_DEFAULT isn't exposed; round-trip via store (resetter).
+  const defaultW = await win.evaluate(() => {
+    const s = window.__agentoryStore;
+    s.getState().resetSidebarWidth();
+    return s.getState().sidebarWidth;
+  });
+  // Re-grow first, then double-click the resizer to reset back. Wait long
+  // enough for the framer-motion width tween to settle so the resizer's
+  // reported boundingBox matches its real hit-testing position.
+  await win.evaluate((w) => window.__agentoryStore.getState().setSidebarWidth(w + 80), defaultW);
+  await win.waitForTimeout(500);
+  const rb3 = await resizer.boundingBox();
+  await resizer.dblclick();
+  await win.waitForTimeout(300);
+  const reset = await storeWidth(win);
+  if (reset !== defaultW) {
+    await app.close();
+    ud.cleanup();
+    fail(`double-click reset: expected ${defaultW}, got ${reset} (rb3=${JSON.stringify(rb3)})`);
+  }
+
+  // === Case 4: choose a non-default width and confirm before quit. ===
+  chosenWidth = Math.min(max, Math.max(min, defaultW + 73));
+  await win.evaluate((w) => window.__agentoryStore.getState().setSidebarWidth(w), chosenWidth);
+  // Persistence is debounced by `schedulePersist` — wait long enough for
+  // the write to flush before we close the app, otherwise the next launch
+  // will see the prior value.
+  await win.waitForTimeout(1500);
+  const finalStore = await storeWidth(win);
+  if (finalStore !== chosenWidth) {
+    await app.close();
+    ud.cleanup();
+    fail(`pre-quit storeWidth expected ${chosenWidth}, got ${finalStore}`);
+  }
+  console.log(`[probe-e2e-sidebar-resize] launch #1: chose width=${chosenWidth}`);
+
+  await app.close();
+}
+
+// ---------- Launch #2: same userData → width restores to chosenWidth ----------
+{
+  const app = await electron.launch({ args: commonArgs, cwd: root, env: commonEnv });
+  const win = await appWindow(app);
+  await win.waitForLoadState('domcontentloaded');
+  await win.waitForFunction(() => !!window.__agentoryStore && document.querySelector('aside') !== null, null, { timeout: 20_000 });
+  const restored = await storeWidth(win);
+  const restoredDom = await asideWidth(win);
+  if (restored !== chosenWidth) {
+    await app.close();
+    ud.cleanup();
+    fail(`after restart: storeWidth expected ${chosenWidth}, got ${restored}`);
+  }
+  if (Math.abs(restoredDom - chosenWidth) > 4) {
+    await app.close();
+    ud.cleanup();
+    fail(`after restart: aside DOM width ${restoredDom} doesn't match restored store ${chosenWidth}`);
+  }
+  console.log(`[probe-e2e-sidebar-resize] launch #2: restored width=${restored} (DOM=${restoredDom})`);
+  await app.close();
+}
+
+console.log('\n[probe-e2e-sidebar-resize] OK');
+console.log('  drag updates sidebar width and store in lockstep');
+console.log('  width clamps at the configured max');
+console.log('  double-click resets to the default');
+console.log('  width persists across app restart');
+
+ud.cleanup();

--- a/scripts/probe-utils.mjs
+++ b/scripts/probe-utils.mjs
@@ -2,6 +2,7 @@
 // dev mode opens DevTools detached and the order of windows is racy.
 import http from 'node:http';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 
 export async function appWindow(app, { timeout = 15000 } = {}) {
@@ -57,4 +58,109 @@ export async function startBundleServer(rootDir) {
     server.listen(0, '127.0.0.1', () => resolve(server.address().port));
   });
   return { port, close: () => server.close() };
+}
+
+// dnd-kit's PointerSensor listens for native PointerEvents. Playwright's
+// `mouse.down/move/up` API dispatches MouseEvents — Chromium does not
+// synthesize PointerEvents from those in a way dnd-kit picks up reliably,
+// so the sensor's activation constraint never trips. We dispatch real
+// PointerEvent instances on the document instead, which routes through
+// React's synthetic event system and into dnd-kit's listeners.
+//
+// `holdMs` keeps the press alive over the target before release — needed
+// for collapsed-group hover-to-expand (default 400ms in Sidebar).
+export async function dndDrag(win, sourceSelector, targetSelector, opts = {}) {
+  const { holdMs = 0, steps = 18, settleMs = 250, postReleaseMs = 350 } = opts;
+  const src = win.locator(sourceSelector).first();
+  const tgt = win.locator(targetSelector).first();
+  await src.waitFor({ state: 'visible', timeout: 5000 });
+  await tgt.waitFor({ state: 'visible', timeout: 5000 });
+  const sb = await src.boundingBox();
+  const tb = await tgt.boundingBox();
+  if (!sb || !tb) throw new Error('dndDrag: missing boundingBox');
+  const sx = sb.x + sb.width / 2;
+  const sy = sb.y + sb.height / 2;
+  const tx = tb.x + tb.width / 2;
+  const ty = tb.y + tb.height / 2;
+  // Press on the source itself so the listeners on that element wire up.
+  await src.dispatchEvent('pointerdown', {
+    button: 0,
+    clientX: sx,
+    clientY: sy,
+    pointerType: 'mouse',
+    pointerId: 1,
+    isPrimary: true
+  });
+  // dnd-kit attaches pointermove/pointerup on the document after activation —
+  // dispatch on document to satisfy both pre- and post-activation listeners.
+  for (let i = 1; i <= steps; i++) {
+    const px = sx + ((tx - sx) * i) / steps;
+    const py = sy + ((ty - sy) * i) / steps;
+    await win.evaluate(
+      ({ px, py }) =>
+        document.dispatchEvent(
+          new PointerEvent('pointermove', {
+            clientX: px,
+            clientY: py,
+            bubbles: true,
+            pointerType: 'mouse',
+            pointerId: 1,
+            isPrimary: true
+          })
+        ),
+      { px, py }
+    );
+    await win.waitForTimeout(15);
+  }
+  await win.waitForTimeout(settleMs);
+  if (holdMs > 0) await win.waitForTimeout(holdMs);
+  await win.evaluate(
+    ({ tx, ty }) =>
+      document.dispatchEvent(
+        new PointerEvent('pointerup', {
+          clientX: tx,
+          clientY: ty,
+          bubbles: true,
+          pointerType: 'mouse',
+          pointerId: 1,
+          isPrimary: true
+        })
+      ),
+    { tx, ty }
+  );
+  await win.waitForTimeout(postReleaseMs);
+}
+
+// Allocate an isolated electron userData directory under os.tmpdir so probes
+// never share persisted state with the dev user or each other. Returns the
+// path plus a cleanup function the caller can invoke in finally.
+export function isolatedUserData(prefix) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix + '-'));
+  return {
+    dir,
+    cleanup() {
+      try {
+        fs.rmSync(dir, { recursive: true, force: true });
+      } catch {}
+    }
+  };
+}
+
+// Wait for the renderer's zustand store to finish hydration (rendering
+// implies React has mounted, which implies hydrateStore().finally() has run).
+// Then forcibly replace state with the fixture and yield long enough for
+// React to flush. Use this instead of raw setState — the store is async-
+// hydrated and a bare setState can race the persisted-state apply.
+export async function seedStore(win, state) {
+  await win.waitForFunction(
+    () => !!window.__agentoryStore && document.querySelector('aside') !== null,
+    null,
+    { timeout: 20_000 }
+  );
+  await win.evaluate((s) => {
+    const store = window.__agentoryStore;
+    if (!store) throw new Error('__agentoryStore missing on window — App.tsx no longer exposes it?');
+    store.setState(s);
+  }, state);
+  await win.waitForTimeout(200);
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -307,6 +307,12 @@ function SessionRow({ session, active, selected, onSelect }: { session: Session;
           data-session-id={session.id}
           onClick={onSelect}
           onKeyDown={(e) => {
+            // Only handle keys when the <li> itself is the focused element.
+            // Without this guard, typing a space in the inline-rename <input>
+            // bubbles up here and gets preventDefault()-ed → spaces silently
+            // disappear from the new name. Same risk for Enter, which we want
+            // the input to commit on.
+            if (e.target !== e.currentTarget) return;
             if (e.key === 'Enter' || e.key === ' ') {
               e.preventDefault();
               onSelect();


### PR DESCRIPTION
## Summary
- Rewrite `scripts/probe-e2e-dnd.mjs` so the drag actually fires under Playwright (dnd-kit's PointerSensor needs real PointerEvents — `mouse.down/move/up` synthesizes only MouseEvents). Added a third case asserting inline rename works while the row is also a dragHandle.
- Add `scripts/probe-e2e-rename.mjs` covering Enter/Escape/whitespace/click-outside + IME composition Enter (must not commit during `isComposing`).
- Add `scripts/probe-e2e-group-add.mjs` for the per-group `+` button: creates a session in THAT group, selects it, no collapse, hidden on archived groups.
- Add `scripts/probe-e2e-sidebar-resize.mjs`: drag updates store + DOM, clamps at max, double-click resets, width persists across electron restart with isolated userData.
- New shared helpers in `scripts/probe-utils.mjs`: `dndDrag`, `isolatedUserData`, `seedStore`.
- Real bug found while writing the dnd probe (separate commit `db1366f`): SessionRow's `<li onKeyDown>` was preventDefault-ing Space/Enter that bubbled up from the inline rename input — silently dropping spaces from the new name. Guarded with `e.target !== e.currentTarget`.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` 548/548 passing (after `npm rebuild better-sqlite3` for node ABI)
- [x] All 4 e2e probes green across 3 sequential runs (after `npx @electron/rebuild -f -w better-sqlite3` for electron ABI)
- [ ] CI (currently disabled per `cd0db90`) — verify locally via `bash scripts/ci.sh` if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)