### PR TITLE
fix(permissions): show prompt dialog when agent requests tool

### DIFF
--- a/electron/agent/__tests__/claude-spawner.test.ts
+++ b/electron/agent/__tests__/claude-spawner.test.ts
@@ -69,6 +69,15 @@ describe('buildSpawnArgs', () => {
     ]);
   });
 
+  it('always includes --permission-prompt-tool stdio so claude.exe delegates can_use_tool over the IPC bridge', () => {
+    const args = buildSpawnArgs({});
+    expect(args.join(' ')).toContain('--permission-prompt-tool stdio');
+    // And the value is the literal "stdio" — that's the magic token the CLI
+    // recognises (any other string would be treated as an MCP tool name and
+    // make spawn fail at first use). Don't accidentally i18n / format this.
+    expect(args[args.indexOf('--permission-prompt-tool') + 1]).toBe('stdio');
+  });
+
   it('appends --resume <id> when resumeId is set', () => {
     const args = buildSpawnArgs({ resumeId: 'sess_abc' });
     expect(args).toContain('--resume');
@@ -175,6 +184,7 @@ describe('spawnClaude', () => {
     expect(argvJoined).toContain('--output-format stream-json');
     expect(argvJoined).toContain('--verbose');
     expect(argvJoined).toContain('--input-format stream-json');
+    expect(argvJoined).toContain('--permission-prompt-tool stdio');
     expect(argvJoined).toContain('--resume sess_xyz');
     expect(argvJoined).toContain('--permission-mode plan');
     expect(argvJoined).toContain('--model sonnet');

--- a/electron/agent/__tests__/sessions.test.ts
+++ b/electron/agent/__tests__/sessions.test.ts
@@ -27,8 +27,10 @@ interface FakeProc {
   getRecentStderr: () => string;
   /** Test-only helper to settle wait(). */
   __exit: (code: number | null, signal?: NodeJS.Signals | null) => void;
-  /** Read everything written to stdin as parsed JSON lines. */
+  /** Read stdin as parsed JSON lines, EXCLUDING the protocol initialize frame. */
   __stdinLines: () => unknown[];
+  /** Read every JSON line written to stdin (initialize included). */
+  __rawStdinLines: () => unknown[];
 }
 
 function makeFakeProc(): FakeProc {
@@ -55,6 +57,22 @@ function makeFakeProc(): FakeProc {
     getRecentStderr: () => '',
     __exit: (code, signal = null) => resolveWait({ code, signal }),
     __stdinLines: () =>
+      Buffer.concat(stdinChunks)
+        .toString('utf8')
+        .split('\n')
+        .filter((s) => s.length > 0)
+        .map((s) => JSON.parse(s))
+        // Filter out the `initialize` handshake SessionRunner sends right
+        // after spawn — most tests assert on user messages / outbound control
+        // requests and don't care about this protocol-level frame. The dedicated
+        // "sends an `initialize` control_request" test reads the unfiltered
+        // stream via __rawStdinLines below.
+        .filter((m) => {
+          if (typeof m !== 'object' || m === null) return true;
+          const obj = m as { type?: string; request?: { subtype?: string } };
+          return !(obj.type === 'control_request' && obj.request?.subtype === 'initialize');
+        }),
+    __rawStdinLines: () =>
       Buffer.concat(stdinChunks)
         .toString('utf8')
         .split('\n')
@@ -149,6 +167,32 @@ describe('SessionRunner.start', () => {
     await runner.start(baseOpts);
     expect(mockSpawnClaude).toHaveBeenCalledTimes(1);
     runner.close();
+  });
+
+  it('sends an `initialize` control_request immediately after spawn so claude.exe knows we handle can_use_tool over stdio', async () => {
+    const proc = makeFakeProc();
+    mockSpawnClaude.mockResolvedValue(proc);
+    const runner = new SessionRunner('s-init', () => {}, () => {}, () => {});
+    try {
+      await runner.start(baseOpts);
+      // Allow the queued control_request write to flush.
+      await new Promise((r) => setImmediate(r));
+      const lines = proc.__rawStdinLines();
+      const init = lines.find(
+        (l): l is { type: string; request: { subtype: string; hooks: unknown } } =>
+          typeof l === 'object' &&
+          l !== null &&
+          (l as { type?: string }).type === 'control_request' &&
+          (l as { request?: { subtype?: string } }).request?.subtype === 'initialize',
+      );
+      expect(init, 'expected an initialize control_request on stdin').toBeDefined();
+      // We send `hooks: {}` for now — no host-side hook handlers wired up. The
+      // exact value doesn't matter to claude.exe, but it MUST be present per
+      // the SDK schema (hooks is `record(string, array(...)).optional()`).
+      expect(init?.request.hooks).toEqual({});
+    } finally {
+      runner.close();
+    }
   });
 });
 

--- a/electron/agent/claude-spawner.ts
+++ b/electron/agent/claude-spawner.ts
@@ -255,6 +255,18 @@ export function buildSpawnArgs(opts: {
     '--verbose',
     '--input-format',
     'stream-json',
+    // Delegate per-tool permission decisions to the host over the same stdio
+    // channel. Without this flag, claude.exe never emits `can_use_tool`
+    // control_requests for tools that would otherwise prompt (Write/Edit/etc.) —
+    // it falls back to the local rule engine and silently auto-allows or auto-
+    // denies based on settings + permissionMode. The literal value `"stdio"`
+    // (rather than an MCP tool name) is the magic token the CLI recognises as
+    // "the SDK consumer on the other side handles permissions"; this is what
+    // `@anthropic-ai/claude-agent-sdk` injects when a `canUseTool` callback is
+    // provided. The companion handshake (an `initialize` control_request) is
+    // sent by SessionRunner once the child is up.
+    '--permission-prompt-tool',
+    'stdio',
   ];
   if (opts.permissionMode) {
     args.push('--permission-mode', opts.permissionMode);

--- a/electron/agent/sessions.ts
+++ b/electron/agent/sessions.ts
@@ -173,6 +173,25 @@ export class SessionRunner {
       onCanUseTool: (toolName, input, ctx) => this.handleCanUseTool(toolName, input, ctx),
     });
 
+    // Tell claude.exe we're an SDK-style consumer that handles permission
+    // decisions over stdio. Pairs with the `--permission-prompt-tool stdio`
+    // flag set by claude-spawner: without BOTH the flag AND this `initialize`
+    // control_request, the CLI falls back to the local rule engine and never
+    // emits `can_use_tool` requests, so the renderer never sees a permission
+    // prompt for tools like Write/Edit/NotebookEdit. We send `hooks: {}` for
+    // now (no host-side hook handlers); future work can extend this to wire up
+    // hook callbacks if/when we build a hook UI. Fire-and-forget — claude.exe
+    // responds with its commands list which we don't currently consume.
+    void this.rpc
+      .sendControlRequest({ subtype: 'initialize', hooks: {} })
+      .catch((err) => {
+        // Quietly ignore failures during teardown — close() races the
+        // initialize round-trip in tests / fast-cancel flows. Only log
+        // when we genuinely lost the handshake on a live session.
+        if (this.disposed) return;
+        console.warn('[sessions] initialize handshake failed', err);
+      });
+
     const stdout = this.cp.stdout;
     const cp = this.cp;
     this.consumer = (async () => {

--- a/scripts/probe-permission-prompt-stdio.mjs
+++ b/scripts/probe-permission-prompt-stdio.mjs
@@ -1,0 +1,58 @@
+// Probe: the spawn pipeline tells claude.exe to delegate per-tool permission
+// decisions over stdio.
+//
+// Why this exists: pre-fix, agentory removed the @anthropic-ai/claude-agent-sdk
+// dependency but did not replicate the two SDK behaviours that turn on
+// `can_use_tool` control_requests:
+//
+//   1. Pass `--permission-prompt-tool stdio` on the claude.exe command line.
+//   2. Send an `initialize` control_request as the first frame on stdin.
+//
+// Without BOTH, the CLI silently falls back to its local rule engine and never
+// emits a single `can_use_tool` request — so the renderer's perfectly good
+// PermissionPromptBlock never had anything to render. This probe locks down
+// both signals at the spawn / SessionRunner layer using mocks (no claude.exe
+// needed) so any future refactor that drops the flag or skips the handshake
+// fails loudly.
+//
+// Usage: node scripts/probe-permission-prompt-stdio.mjs
+
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function fail(msg) {
+  console.error(`\n[probe-permission-prompt-stdio] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+// Run two focused tests via vitest. We use two separate invocations rather
+// than a single regex/glob because Windows cmd.exe interprets `|` as a pipe
+// before vitest sees it (and quoting the regex as a single argv string
+// confuses vitest's CLI parser inconsistently across PowerShell/cmd/bash).
+function runTest(testNameSubstring, file) {
+  const r = spawnSync(
+    'npx',
+    ['vitest', 'run', '--reporter=basic', '-t', testNameSubstring, file],
+    { cwd: root, stdio: 'inherit', shell: true }
+  );
+  if (r.status !== 0) fail(`vitest exited ${r.status} for ${file} :: ${testNameSubstring}`);
+}
+
+runTest(
+  'permission-prompt-tool stdio',
+  'electron/agent/__tests__/claude-spawner.test.ts'
+);
+runTest(
+  'initialize control_request',
+  'electron/agent/__tests__/sessions.test.ts'
+);
+
+console.log('\n[probe-permission-prompt-stdio] OK');
+console.log('  - claude-spawner adds `--permission-prompt-tool stdio` to argv');
+console.log('  - SessionRunner sends `initialize` control_request on start');
+console.log('Together these make claude.exe emit `can_use_tool` for tools like Write/Edit,');
+console.log('which the renderer turns into the existing PermissionPromptBlock.');


### PR DESCRIPTION
## Root cause

The renderer-side permission prompt UI (`PermissionPromptBlock`, IPC bridge, store slice) is fine — it just never had anything to render. PR #64 dropped `@anthropic-ai/claude-agent-sdk` and reimplemented the spawn pipeline directly, but missed the two SDK behaviours that turn on host-delegated permission decisions in claude.exe:

1. Pass **`--permission-prompt-tool stdio`** on argv. The literal `\"stdio\"` is the magic token the CLI recognises as "the SDK consumer on the other side handles permissions"; any other value is treated as an MCP tool name.
2. Send a **`control_request` with `subtype: \"initialize\"`** (carrying at least `hooks: {}`) as the first stdin frame. Without this handshake the CLI never wires up its `createCanUseTool` path.

With only one of the two, the CLI silently falls back to its local rule engine and `can_use_tool` is never emitted — so the renderer never sees a permission request, even for tools that should always prompt (Write / Edit / NotebookEdit).

### Empirical confirmation

Spawned the user's installed claude.exe with the exact agentory args and asked it to use the Write tool:

| Args                                                              | `can_use_tool` emitted? |
|-------------------------------------------------------------------|-------------------------|
| Pre-fix (no flag, no initialize)                                  | NO — Write ran silently |
| `--permission-prompt-tool stdio` only                             | NO                      |
| `initialize` only                                                 | NO                      |
| Both (post-fix configuration)                                     | YES — prompt fires      |

Bash stays auto-allowed in `permissionMode: 'default'` (matching the SDK's own behaviour). Write / Edit / NotebookEdit now prompt as expected.

## Fix

- `electron/agent/claude-spawner.ts` — append `--permission-prompt-tool stdio` to `buildSpawnArgs`
- `electron/agent/sessions.ts` — send the `initialize` `control_request` immediately after spawn (fire-and-forget, suppressed-on-teardown)
- `electron/agent/__tests__/claude-spawner.test.ts` — lock down the new argv flag
- `electron/agent/__tests__/sessions.test.ts` — assert the `initialize` frame is written; introduces a `__rawStdinLines` helper so all the existing user-message / control-command tests keep filtering it out
- `scripts/probe-permission-prompt-stdio.mjs` — runs the two new test cases via vitest so any regression in argv or the handshake fails loudly

No renderer changes. The existing `probe-e2e-permission-prompt.mjs` (which injects a fake `waiting` block into the renderer store) already proved the UI works end-to-end given a permission event.

## Test plan

- [x] `npm run typecheck`
- [x] `npx vitest run electron/agent/__tests__/sessions.test.ts` — 17/17 pass
- [x] `npx vitest run electron/agent/__tests__/claude-spawner.test.ts` — 37/37 pass
- [x] `node scripts/probe-permission-prompt-stdio.mjs` — passes
- [ ] Manual verify: launch agentory, ask agent to use Write/Edit, confirm prompt dialog appears with Allow/Deny buttons
- [ ] Manual verify: clicking Allow lets the tool proceed; Deny aborts the turn cleanly

Note: `electron/__tests__/db.test.ts` has 8 failures unrelated to this change (`better-sqlite3` ABI mismatch — same on `origin/working`, see dogfood-report-2026-04-21.md).