### PR TITLE
i18n(zh): complete coverage + preserve reserved nouns

### DIFF
--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -201,9 +201,9 @@ const zh: EnCatalog = {
     runsLocally: '本地运行 — 不会转发给 claude.exe',
     clientTag: '本地',
     groupBuiltIn: '内置',
-    groupUser: 'User commands',
-    groupProject: 'Project commands',
-    groupPlugin: 'Plugin commands'
+    groupUser: '用户 Commands',
+    groupProject: '项目 Commands',
+    groupPlugin: 'Plugin Commands'
   },
   notifications: {
     sessionWaitingTitle: '会话等待中',


### PR DESCRIPTION
## Summary

Audited zh.ts against en.ts. Parity test was already green (0 missing keys), and almost every value was already translated. Only 3 leaves in `slashCommands` were still English; translated them while preserving reserved nouns per the spec.

## Changes

`src/i18n/locales/zh.ts` (3 lines):

- `slashCommands.groupUser`: `User commands` -> `用户 Commands`
- `slashCommands.groupProject`: `Project commands` -> `项目 Commands`
- `slashCommands.groupPlugin`: `Plugin commands` -> `Plugin Commands`

`Command` and `Plugin` are on the reserved-noun list, so the noun stays in English while the modifier is translated. This keeps the picker labels readable while honoring the policy.

## Reserved nouns kept English in zh

MCP, CLI, IPC, API, URL, JSON, JSONL, SDK, REST, Claude, Anthropic, Agentory, Electron, GitHub, Settings, Sidebar, Session, Group, Tab, Endpoint, Model, Plugin, Command, Skill, Slash command.

Existing zh strings already honored these (`在此 Group 新建 Session`, `Claude Code CLI`, `Pull Request`, etc.) so no further edits were needed.

## Scope

- Only `src/i18n/locales/zh.ts` changed.
- `en.ts` untouched.
- No component or test changes.

## Test plan

- [x] `npm test -- i18n-key-parity` (2/2 pass)
- [x] `npm run typecheck` (clean)
- [x] `npm run build` (clean)
- [x] `npm test` (540 pass; 8 pre-existing `better-sqlite3` ABI failures in `electron/__tests__/db.test.ts` ignored per task instructions)