### PR TITLE
docs: README + MIT LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jiahui Gu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,84 @@
+# Agentory
+
+A desktop GUI for [Claude Code](https://docs.anthropic.com/claude/docs/claude-code) — manage multiple parallel agent sessions across repos with the visual density of a CLI and the interaction model of a native app.
+
+<!-- TODO: screenshot here -->
+
+## What it is
+
+Claude Code is a powerful CLI, but switching between 5+ active sessions in different repos becomes tab-juggling. Agentory groups your sessions by task (not by repo) and gives them a sidebar — you stay in flow across multiple parallel conversations.
+
+- **Groups, not projects** — a group is your task; sessions inside it can live in different repos
+- **Native interactions** — drag to reorder, right-click context menus, keyboard shortcuts, inline rename
+- **CLI-grade information density** — block-based message rendering (`>` user, `●` assistant, `⏺` tool), collapsed tool calls, no chat-bubble fluff
+- **Permission prompts as UI** — answer Allow / Deny inline, see the tool input as structured data
+- **Two-state lifecycle** — `idle` / `waiting`; the sidebar breathes amber when an agent needs you, no manual status to maintain
+
+## Requirements
+
+- **Claude Code CLI** installed and authenticated. Agentory delegates 100% of agent execution to the CLI:
+  - Install: `npm i -g @anthropic-ai/claude-code` (or your platform package manager)
+  - First-time login: run `claude` once to complete OAuth (or set `ANTHROPIC_API_KEY` in your environment)
+  - **If `claude` works in your terminal, Agentory will work. If it doesn't, Agentory won't either.**
+  - Override the binary location with `AGENTORY_CLAUDE_BIN=/path/to/claude` if needed.
+- **OS**: Windows 10+, macOS 11+ (Big Sur), or Linux (glibc 2.17+)
+- **Disk**: ~200 MB
+
+Agentory does **not** make any HTTP calls to Anthropic itself. All API traffic goes through your local `claude` binary, with your existing credentials.
+
+## Install
+
+1. Download the latest `.exe` (Windows) / `.dmg` (macOS) / `.AppImage` / `.deb` / `.rpm` (Linux) from [Releases](https://github.com/Jiahui-Gu/Agentory-next/releases).
+2. Run the installer.
+3. Launch Agentory. If the Claude CLI isn't found, you'll see an actionable error showing every path Agentory searched.
+
+## Quickstart
+
+1. Click **+ New Group** in the sidebar to create a task bucket (or skip — Agentory auto-creates a default group on the first session).
+2. Click **+ New Session** inside a group. Pick a working directory (any repo). The session spawns `claude` in that cwd.
+3. Type in the composer at the bottom. **Enter** to send, **Shift+Enter** for newline, **Esc** to cancel inline edits.
+4. When the agent requests a tool, a permission block appears at the tail of the conversation — Allow / Deny.
+5. Switch between sessions with the sidebar. Background sessions keep streaming and surface a breathing amber dot when they need you.
+
+### Shortcuts
+
+- `Cmd/Ctrl+K` — Search / Command Palette
+- `Cmd/Ctrl+,` — Settings
+- `Cmd/Ctrl+N` — New session
+- `Cmd/Ctrl+Shift+N` — New group
+- `Cmd/Ctrl+B` — Toggle sidebar
+
+## Data location
+
+Local SQLite database (groups, sessions, user-defined order, sidebar state, theme):
+
+- **Windows**: `%APPDATA%\Agentory\`
+- **macOS**: `~/Library/Application Support/Agentory/`
+- **Linux**: `~/.config/Agentory/`
+
+Conversation history is **not** duplicated — Agentory reads it directly from the Claude CLI's `~/.claude/projects/` jsonl files. Anthropic credentials are stored by the CLI itself; Agentory never touches them.
+
+## Development
+
+Requires Node 20+ and `npm`. The native module `better-sqlite3` is rebuilt for Electron's ABI on `npm install` via `electron-builder install-app-deps`.
+
+```bash
+npm install
+npm run dev          # webpack-dev-server + electron, concurrently
+npm test             # vitest
+npm run typecheck    # tsc --noEmit (renderer + electron)
+npm run lint         # eslint
+npm run make:win     # build Windows installer (NSIS)
+npm run make:mac     # build macOS .dmg + .zip
+npm run make:linux   # build AppImage / .deb / .rpm
+```
+
+The architecture has a hard rule: **frontend code under `src/` may not import from `electron`**. The only backend entry point is `window.agentory` (declared in `src/global.d.ts`), exposed via `electron/preload.ts`. This keeps the door open for a future remote daemon. See `docs/mvp-design.md` §15.
+
+## Status
+
+This is **MVP**. The author uses it daily as a personal driver. Public release pending.
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "Group-first manager for many Claude Code sessions",
   "productName": "Agentory",
+  "license": "MIT",
   "author": {
     "name": "Jiahui Gu",
     "email": "noreply@agentory.dev"


### PR DESCRIPTION
## Summary

- Adds `README.md` with Requirements / Install / Quickstart / Data location / Development / License sections.
- Adds `LICENSE` (MIT) and `"license": "MIT"` in `package.json`.
- Required before sharing private GitHub Releases with coworkers.

## Notes on accuracy

README facts were verified against the codebase (not recited):

- Claude CLI integration / `AGENTORY_CLAUDE_BIN` override comes from `electron/agent/binary-resolver.ts`.
- Two-state lifecycle, group-first model, shortcut list, and `window.agentory` boundary come from `docs/mvp-design.md`.
- Build targets (NSIS / dmg+zip / AppImage+deb+rpm) come from `package.json` `build.*`.
- Dropped the Sentry / crash reports section — no Sentry SDK is wired into the app code (only mentioned in `docs/release.md` as a future plan). Will add back when actually shipped.

## Test plan

- [ ] Render README on GitHub and skim for broken links / formatting
- [ ] Confirm `Releases` link target exists once the first release is cut