### PR TITLE
fix(agent): read user's ~/.claude config directly

### DIFF
--- a/electron/agent/__tests__/claude-spawner.test.ts
+++ b/electron/agent/__tests__/claude-spawner.test.ts
@@ -529,10 +529,10 @@ describe('SAFE_ENV whitelist', () => {
     expect(ci(env, 'CLAUDE_CODE_SKIP_AUTH_LOGIN')).toBe('true');
   });
 
-  it('always overwrites CLAUDE_CONFIG_DIR with the isolated path, even if parent sets one', () => {
+  it('always overwrites CLAUDE_CONFIG_DIR with the caller-provided path, even if parent sets one', () => {
     process.env.CLAUDE_CONFIG_DIR = '/home/user/.claude';
-    const env = buildSpawnEnv({ configDir: '/isolated/cfg' });
-    expect(ci(env, 'CLAUDE_CONFIG_DIR')).toBe('/isolated/cfg');
+    const env = buildSpawnEnv({ configDir: '/explicit/cfg' });
+    expect(ci(env, 'CLAUDE_CONFIG_DIR')).toBe('/explicit/cfg');
   });
 
   it('envOverrides still win over forwarded ANTHROPIC_* parent vars', () => {

--- a/electron/agent/__tests__/sessions.test.ts
+++ b/electron/agent/__tests__/sessions.test.ts
@@ -150,6 +150,27 @@ describe('SessionRunner.start', () => {
     }
   });
 
+  it("defaults configDir to the user's ~/.claude so login state is shared with the CLI", async () => {
+    const proc = makeFakeProc();
+    mockSpawnClaude.mockResolvedValue(proc);
+    // Make sure the env override is not set for this test.
+    const prev = process.env.AGENTORY_CLAUDE_CONFIG_DIR;
+    delete process.env.AGENTORY_CLAUDE_CONFIG_DIR;
+
+    const os = await import('node:os');
+    const path = await import('node:path');
+    const expected = path.join(os.homedir(), '.claude');
+
+    const runner = new SessionRunner('s2b', () => {}, () => {}, () => {});
+    try {
+      await runner.start({ cwd: '/w' });
+      expect(mockSpawnClaude.mock.calls[0][0].configDir).toBe(expected);
+    } finally {
+      if (prev !== undefined) process.env.AGENTORY_CLAUDE_CONFIG_DIR = prev;
+      runner.close();
+    }
+  });
+
   it('coerces SDK-only permission modes (dontAsk / auto) to default for the CLI', async () => {
     const proc = makeFakeProc();
     mockSpawnClaude.mockResolvedValue(proc);

--- a/electron/agent/claude-spawner.ts
+++ b/electron/agent/claude-spawner.ts
@@ -214,7 +214,9 @@ export function buildSpawnEnv(opts: {
     if (envKeyAllowed(k)) env[k] = v;
   }
 
-  // Required: isolate config so we never pollute the user's ~/.claude.
+  // Required: point claude.exe at the configured CLAUDE_CONFIG_DIR. By default
+  // this is the user's real ~/.claude/ (see sessions.ts → resolveClaudeConfigDir)
+  // so Agentory shares login state with the user's existing CLI install.
   env.CLAUDE_CONFIG_DIR = opts.configDir;
 
   // Identifies us in server-side logs. We unconditionally overwrite the
@@ -431,7 +433,7 @@ class ClaudeProcessImpl implements ClaudeProcess {
 export async function spawnClaude(opts: SpawnOpts): Promise<ClaudeProcess> {
   if (!opts.configDir || opts.configDir.trim().length === 0) {
     throw new Error(
-      'spawnClaude: configDir is required (caller must pass an isolated CLAUDE_CONFIG_DIR path, e.g. <userData>/claude-cli-config)'
+      'spawnClaude: configDir is required (caller must pass a CLAUDE_CONFIG_DIR path; defaults to the user\'s ~/.claude via sessions.ts → resolveClaudeConfigDir)'
     );
   }
 

--- a/electron/agent/sessions.ts
+++ b/electron/agent/sessions.ts
@@ -38,16 +38,20 @@ export function resolveCwd(cwd: string): string {
 
 /**
  * claude.exe refuses to run without `CLAUDE_CONFIG_DIR` (claude-spawner enforces
- * this). main.ts hasn't been migrated to pass an explicit configDir yet — that's
- * batch 3. For now we accept it via StartOptions, fall back to the env override,
- * and finally to a stable per-user dir under the home directory so the user's
- * own ~/.claude is never touched.
+ * this). Agentory deliberately points it at the user's real `~/.claude/` so we
+ * share state (login tokens, settings.json with relay-mode credentials, MCP
+ * config) with the user's existing CLI install. Boundary: "if `claude` works in
+ * your terminal, Agentory works." Sessions still register in Agentory's own DB —
+ * only the claude CLI config dir is shared.
+ *
+ * Callers may still pass an explicit `configDir` (e.g. tests) or override via
+ * the `AGENTORY_CLAUDE_CONFIG_DIR` env var for special-case isolation.
  */
-function resolveConfigDir(explicit: string | undefined): string {
+function resolveClaudeConfigDir(explicit: string | undefined): string {
   if (explicit && explicit.trim().length > 0) return explicit;
   const env = process.env.AGENTORY_CLAUDE_CONFIG_DIR;
   if (env && env.trim().length > 0) return env;
-  return path.join(os.homedir(), '.agentory', 'claude-cli-config');
+  return path.join(os.homedir(), '.claude');
 }
 
 /**
@@ -95,9 +99,9 @@ export type StartOptions = {
    */
   envOverrides?: Record<string, string>;
   /**
-   * Optional override for `CLAUDE_CONFIG_DIR`. main.ts currently doesn't pass
-   * one — see resolveConfigDir() for the fallback chain. Will become required
-   * once main.ts is migrated (batch 3, T9).
+   * Optional override for `CLAUDE_CONFIG_DIR`. When unset, Agentory uses the
+   * user's real `~/.claude/` so login state is shared with the CLI — see
+   * resolveClaudeConfigDir() for the full fallback chain.
    */
   configDir?: string;
   /**
@@ -160,7 +164,7 @@ export class SessionRunner {
 
     this.cp = await spawnClaude({
       cwd: resolveCwd(opts.cwd),
-      configDir: resolveConfigDir(opts.configDir),
+      configDir: resolveClaudeConfigDir(opts.configDir),
       permissionMode: toCliPermissionMode(this.permissionMode),
       model: opts.model,
       resumeId: opts.resumeSessionId,


### PR DESCRIPTION
## Summary

- Packaged Agentory was showing "Not logged in - Please run /login" because `electron/agent/sessions.ts:50` defaulted `CLAUDE_CONFIG_DIR` to `~/.agentory/claude-cli-config/`, an empty isolated dir. The spawned `claude.exe` therefore could not find the user's relay-mode credentials (`ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL`, `CLAUDE_CODE_SKIP_AUTH_LOGIN`) in `~/.claude/settings.json`.
- Decision (locked): drop the isolation. Agentory now reads the user's real `~/.claude/` directly. Boundary: "if `claude` works in your terminal, Agentory works." Agentory's own data dirs (DB at `~/.agentory/agentory.db`, drafts, app_state) are untouched.
- Renamed helper `resolveConfigDir` -> `resolveClaudeConfigDir`; refreshed doc comments + spawner error message; updated one stale test title; added a unit test asserting the default resolves to `os.homedir() + '/.claude'`.
- The existing `~/.agentory/claude-cli-config/` directory on user disks is intentionally left in place (no auto-delete of user data, even though it is no longer read or written).

## Files changed

- `electron/agent/sessions.ts`
- `electron/agent/claude-spawner.ts`
- `electron/agent/__tests__/sessions.test.ts`
- `electron/agent/__tests__/claude-spawner.test.ts`

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` -> 544 passed / 8 pre-existing better-sqlite3 ABI failures (acceptable per spec); new sessions.ts test passes (18/18 in that file)
- [x] `npm run build` clean (warnings are pre-existing bundle-size advisories)
- [ ] Manual: launch packaged build, confirm `/login` no longer appears when the user's CLI is already logged in via `~/.claude/`