### PR TITLE
chore: fix repo URLs + ignore release artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,10 @@ dist/
 agentory-data.db
 agentory-data.db-journal
 scripts/spike-*
+release/
+*.exe
+*.dmg
+*.AppImage
+*.deb
+*.rpm
+*.blockmap

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Agentory does **not** make any HTTP calls to Anthropic itself. All API traffic g
 
 ## Install
 
-1. Download the latest `.exe` (Windows) / `.dmg` (macOS) / `.AppImage` / `.deb` / `.rpm` (Linux) from [Releases](https://github.com/Jiahui-Gu/Agentory-next/releases).
+1. Download the latest `.exe` (Windows) / `.dmg` (macOS) / `.AppImage` / `.deb` / `.rpm` (Linux) from [Releases](https://github.com/Jiahui-Gu/agentory/releases).
 2. Run the installer.
 3. Launch Agentory. If the Claude CLI isn't found, you'll see an actionable error showing every path Agentory searched.
 

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "name": "Jiahui Gu",
     "email": "noreply@agentory.dev"
   },
-  "homepage": "https://github.com/Jiahui-Gu/Agentory-next",
+  "homepage": "https://github.com/Jiahui-Gu/agentory",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Jiahui-Gu/Agentory-next.git"
+    "url": "https://github.com/Jiahui-Gu/agentory.git"
   },
   "main": "dist/electron/main.js",
   "scripts": {
@@ -127,7 +127,7 @@
       {
         "provider": "github",
         "owner": "Jiahui-Gu",
-        "repo": "Agentory-next"
+        "repo": "agentory"
       }
     ],
     "win": {


### PR DESCRIPTION
Two pre-public blockers:

1. **Repo URLs**: package.json (homepage, repository.url, build.publish.repo) and README all reference the old `Jiahui-Gu/Agentory-next` URL. Now updated to `Jiahui-Gu/agentory`. Critical because electron-updater publishing and the Releases link in README break otherwise.
2. **release/ in .gitignore**: 380MB of built installers under release/ is currently untracked but unignored — one stray `git add .` ships them. Added `release/`, `*.exe`, `*.dmg`, `*.AppImage`, `*.deb`, `*.rpm`, `*.blockmap`.