### PR TITLE
chore(public): re-enable CI, rename, SECURITY.md, bump 0.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,11 @@
 name: CI
 
-# Disabled — billing issues on the GitHub account. Re-enable by restoring
-# the pull_request / push triggers below. Manual runs still possible via
-# the Actions tab.
 on:
   workflow_dispatch:
-#  pull_request:
-#    branches: [working, main]
-#  push:
-#    branches: [working, main]
+  pull_request:
+    branches: [working, main]
+  push:
+    branches: [working, main]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security issue in Agentory, please report it privately by emailing the maintainer (see `package.json` `author` field) or by opening a draft security advisory on this repository (`Security` tab → `Advisories` → `New draft`). Do **not** open a public issue for security reports.
+
+I aim to acknowledge reports within 7 days. There is no bug bounty — this is a personal project. Response is best-effort.
+
+## Supported Versions
+
+Only the latest tagged release is supported. Older releases will not receive security updates.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,14 @@
 {
-  "name": "agentory-next",
-  "version": "0.0.1",
+  "name": "agentory",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "agentory-next",
-      "version": "0.0.1",
+      "name": "agentory",
+      "version": "0.1.0",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/sortable": "^8.0.0",
@@ -5071,6 +5072,70 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "agentory-next",
-  "version": "0.0.1",
+  "name": "agentory",
+  "version": "0.1.0",
   "description": "Group-first manager for many Claude Code sessions",
   "productName": "Agentory",
   "license": "MIT",
@@ -8,10 +8,10 @@
     "name": "Jiahui Gu",
     "email": "noreply@agentory.dev"
   },
-  "homepage": "https://github.com/Jiahui-Gu/Agentory-next",
+  "homepage": "https://github.com/Jiahui-Gu/agentory",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Jiahui-Gu/Agentory-next.git"
+    "url": "https://github.com/Jiahui-Gu/agentory.git"
   },
   "main": "dist/electron/main.js",
   "scripts": {
@@ -127,7 +127,7 @@
       {
         "provider": "github",
         "owner": "Jiahui-Gu",
-        "repo": "Agentory-next"
+        "repo": "agentory"
       }
     ],
     "win": {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -260,7 +260,7 @@ const en = {
     tutorialNextLabel: 'Next',
     tutorialDoneLabel: "I'm ready",
     dialogTitle: 'Claude CLI not found',
-    dialogDescriptionPrefix: 'agentory-next wraps the Claude Code CLI. We couldn\u2019t find',
+    dialogDescriptionPrefix: 'Agentory wraps the Claude Code CLI. We couldn\u2019t find',
     dialogDescriptionSuffix: 'on your system.',
     whereWeLooked: 'Where we looked',
     tabInstall: 'Install',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -249,7 +249,7 @@ const zh: EnCatalog = {
     tutorialNextLabel: '下一步',
     tutorialDoneLabel: '我准备好了',
     dialogTitle: '未找到 Claude CLI',
-    dialogDescriptionPrefix: 'agentory-next 包装了 Claude Code CLI。我们没在系统中找到',
+    dialogDescriptionPrefix: 'Agentory 包装了 Claude Code CLI。我们没在系统中找到',
     dialogDescriptionSuffix: '。',
     whereWeLooked: '查找过的位置',
     tabInstall: '安装',

--- a/src/mock/data.ts
+++ b/src/mock/data.ts
@@ -48,7 +48,7 @@ export const activeSessionId = 's2';
 export type RecentProject = { id: string; name: string; path: string };
 
 export const mockRecentProjects: RecentProject[] = [
-  { id: 'p1', name: 'agentory-next', path: '~/projects/agentory-next' },
+  { id: 'p1', name: 'agentory', path: '~/projects/agentory' },
   { id: 'p2', name: 'payments-api', path: '~/projects/payments-api' },
   { id: 'p3', name: 'inference-svc', path: '~/projects/inference-svc' },
   { id: 'p4', name: 'identity-svc', path: '~/projects/identity-svc' },


### PR DESCRIPTION
Pre-public-flip polish bundle:

- Re-enables CI on push + PR (was workflow_dispatch only due to old billing issue; public repos get unlimited Linux/Windows minutes)
- Renames `agentory-next` -> `agentory` in user-facing strings (package.json name, homepage/repository URLs, electron-builder publish.repo, i18n catalogs, mock data)
- Adds SECURITY.md with reporting policy
- Bumps version 0.0.1 -> 0.1.0 to match release notes

## Notes / deviations
- Also updated `package.json` `homepage`, `repository.url`, and `build.publish.repo` from `Agentory-next` -> `agentory` since the actual GitHub repo is `Jiahui-Gu/agentory`. The `publish.repo` change is important: electron-updater would otherwise look for releases at the wrong slug. URLs to the old name still redirect, but cleaning them up is consistent with the rename.
- `tests/cwd-popover.test.tsx` references `agentory-next` as a fixture path — left as-is (test data, not user-facing).
- `docs/` historical references left untouched per instructions.
- No `updaterCacheDirName` in source; electron-builder auto-derives it from app name on next build, so the stale `release/win-*-unpacked/resources/app-update.yml` will regenerate.

## Verify
- typecheck: pass
- test: 545 passed, 8 failed (pre-existing better-sqlite3 ABI mismatch under vitest, expected)
- build: pass (3 webpack bundle-size warnings, pre-existing)