### PR TITLE
docs: README crash reports section + GitHub repo metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Local SQLite database (groups, sessions, user-defined order, sidebar state, them
 
 Conversation history is **not** duplicated — Agentory reads it directly from the Claude CLI's `~/.claude/projects/` jsonl files. Anthropic credentials are stored by the CLI itself; Agentory never touches them.
 
+## Crash reports
+
+Agentory automatically sends crash reports and unhandled errors to the project's Sentry to help fix bugs. Reports include error stack traces and the app version; they do NOT include the contents of your conversations, file paths inside your projects, or environment variables.
+
+To disable: open Settings → Notifications and uncheck "Send crash reports to developer".
+
 ## Development
 
 Requires Node 20+ and `npm`. The native module `better-sqlite3` is rebuilt for Electron's ABI on `npm install` via `electron-builder install-app-deps`.


### PR DESCRIPTION
## Part 1 — README crash reports section

Adds a `## Crash reports` section to `README.md` (between "Data location" and "Development") documenting that Sentry crash reporting is on by default, what is and is not sent, and how to opt out.

Wording verified against the actual code:

- `electron/main.ts` — `Sentry.init({ ..., sendDefaultPii: false, ... })` confirmed.
- `src/i18n/locales/en.ts` — toggle label is `"Send crash reports to developer"`, matches the README opt-out instruction.
- Settings location verified in `src/components/SettingsDialog.tsx` (Notifications tab → `CrashReportingField`).

## Part 2 — GitHub repo metadata

Set on `Jiahui-Gu/agentory` via `gh repo edit` (changes live on GitHub directly, not in this diff).

Verification — `gh repo view Jiahui-Gu/agentory --json description,homepageUrl,repositoryTopics`:

```json
{"description":"Desktop GUI for running multiple Claude Code agents in parallel, organized by task","homepageUrl":"https://github.com/Jiahui-Gu/agentory","repositoryTopics":[{"name":"agent"},{"name":"claude-code"},{"name":"developer-tools"},{"name":"electron"},{"name":"react"},{"name":"typescript"}]}
```

All requested topics present: electron, react, typescript, claude-code, agent, developer-tools.

## Test plan

- [ ] Render README on GitHub and confirm the new section sits cleanly between "Data location" and "Development".
- [ ] Confirm repo card on github.com/Jiahui-Gu/agentory shows new description + topics.