### PR TITLE
security: IPC hardening + Electron baseline + permission strict mode

### DIFF
--- a/electron/agent/sessions.ts
+++ b/electron/agent/sessions.ts
@@ -62,8 +62,13 @@ function resolveClaudeConfigDir(explicit: string | undefined): string {
  *     *Note: the CLI's real classifier-driven `auto` mode is NOT accepted
  *     here by design — we never surface it in the UI, so an `auto` on the
  *     wire must be our legacy alias for `acceptEdits`.
- * Unknown strings coerce to `'default'` rather than passing an invalid flag
- * value to claude.exe.
+ *
+ * Unknown strings THROW. Earlier behaviour silently coerced anything we
+ * didn't recognise to `'default'`, which meant a buggy renderer (or a
+ * compromised one) could downgrade `bypassPermissions` to `default` by
+ * sending a typo and never see an error. The agent:setPermissionMode IPC
+ * handler in main.ts catches this and surfaces `{ ok: false, error:
+ * 'unknown_mode' }` so the renderer can show "this mode isn't supported".
  */
 function toCliPermissionMode(mode: PermissionMode | undefined): CliPermissionMode | undefined {
   if (!mode) return undefined;
@@ -82,7 +87,7 @@ function toCliPermissionMode(mode: PermissionMode | undefined): CliPermissionMod
     case 'yolo':
       return 'bypassPermissions';
     default:
-      return 'default';
+      throw new Error(`Unknown permission mode: ${String(mode)}`);
   }
 }
 
@@ -315,9 +320,15 @@ export class SessionRunner {
   }
 
   async setPermissionMode(mode: PermissionMode): Promise<void> {
-    if (!this.rpc) return;
-    this.permissionMode = mode;
+    // Validate up front so a bogus mode is rejected even if the session
+    // hasn't started yet (no rpc) — the IPC layer relies on the throw to
+    // surface `unknown_mode` to the renderer.
     const cliMode = toCliPermissionMode(mode);
+    if (!this.rpc) {
+      this.permissionMode = mode;
+      return;
+    }
+    this.permissionMode = mode;
     if (!cliMode) return;
     try {
       await this.rpc.setPermissionMode(cliMode);

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -19,11 +19,20 @@ import {
 // is opt-OUT, default ON. We swallow errors here because Sentry's beforeSend
 // is on the hot error path; failing closed (silently sending) is preferable
 // to dropping a crash because the DB happened to be locked.
+//
+// Sentry's beforeSend runs on the hot error path, so we cache the value in
+// a module-scope variable after the first read. The `db:save` handler below
+// invalidates the cache when the renderer writes the `crashReportingOptOut`
+// key, so the toggle in Settings still takes effect immediately.
+const CRASH_OPT_OUT_KEY = 'crashReportingOptOut';
+let _crashOptOutCached: boolean | undefined;
 function loadCrashReportingOptOut(): boolean {
+  if (_crashOptOutCached !== undefined) return _crashOptOutCached;
   try {
-    const raw = loadState('crashReportingOptOut');
-    if (raw == null) return false;
-    return raw === 'true' || raw === '1';
+    const raw = loadState(CRASH_OPT_OUT_KEY);
+    const value = raw != null && (raw === 'true' || raw === '1');
+    _crashOptOutCached = value;
+    return value;
   } catch {
     return false;
   }
@@ -59,6 +68,37 @@ import { listModelsFromSettings } from './agent/list-models-from-settings';
 import { ClaudeNotFoundError, detectClaudeVersion, resolveClaudeBinary } from './agent/binary-resolver';
 import { readMemoryFile, writeMemoryFile, memoryFileExists } from './memory';
 import { loadCommands } from './commands-loader';
+
+// ─────────────────────── IPC security helpers ────────────────────────────
+//
+// Filter renderer-supplied filesystem paths before any `fs.*` call. UNC paths
+// (`\\server\share\...` or `//server/share/...`) MUST be rejected on Windows:
+// node's fs will dutifully reach out over SMB to fetch the file, and on
+// Windows that handshake leaks the user's NTLM hash to whatever host the
+// renderer named. (CRITICAL — even a single innocuous-looking `existsSync`
+// call against a chosen UNC target is a credential-leak primitive.)
+//
+// We also require absolute paths because every renderer caller already
+// passes absolute paths (cwds, persisted disk locations, etc.); a relative
+// path here is always a sign of a confused or malicious caller.
+function isSafePath(p: unknown): p is string {
+  return (
+    typeof p === 'string' &&
+    path.isAbsolute(p) &&
+    !p.startsWith('\\\\') &&
+    !p.startsWith('//')
+  );
+}
+
+// Defense-in-depth: every IPC handler that takes a privileged action should
+// first confirm the message originated from our top-level renderer frame. A
+// compromised iframe (e.g. via a future webview, or a misconfigured CSP)
+// can otherwise call into ipcMain with the same `e.sender`. Pairs with the
+// `setWindowOpenHandler({ action: 'deny' })` and `will-navigate` blocks
+// installed in createWindow().
+function fromMainFrame(e: Electron.IpcMainInvokeEvent): boolean {
+  return e.senderFrame === e.sender.mainFrame;
+}
 
 // `app.isPackaged` is the canonical "are we shipping" signal. The
 // `AGENTORY_PROD_BUNDLE=1` env var lets E2E probes force-load the production
@@ -200,11 +240,47 @@ function createWindow() {
     webPreferences: {
       contextIsolation: true,
       nodeIntegration: false,
+      // sandbox:true is the recommended Electron baseline (forces the
+      // preload into a Chromium sandbox where Node built-ins are
+      // unavailable), but our preload's `require('@sentry/electron/preload')`
+      // can't be resolved by the sandboxed preload's restricted require —
+      // it only follows relative paths and a small whitelist. Enabling it
+      // results in: "Error: module not found: @sentry/electron/preload"
+      // and `window.agentory` is never installed.
+      //
+      // Followup: bundle preload through webpack (or vendor the sentry
+      // preload into electron/) so the require resolves at build time, then
+      // flip this back to true. Tracked separately to keep this PR scoped
+      // to the IPC hardening fixes that don't require a build-pipeline
+      // change.
+      sandbox: false,
       preload: path.join(__dirname, 'preload.js')
     }
   });
 
   win.setMenuBarVisibility(false);
+
+  // Block the renderer from spawning new BrowserWindows. We have no use
+  // case for window.open(); a successful call would create a popup with
+  // our preload attached.
+  win.webContents.setWindowOpenHandler(() => ({ action: 'deny' }));
+
+  // Block in-window navigation away from our renderer origin. The renderer
+  // should never navigate; all external links go through `shell:openExternal`
+  // (which itself filters to http(s) only).
+  win.webContents.on('will-navigate', (event, url) => {
+    try {
+      const u = new URL(url);
+      const devPort = process.env.AGENTORY_DEV_PORT || '4100';
+      const allowed =
+        u.origin === `http://localhost:${devPort}` ||
+        u.origin === 'http://localhost:4100' ||
+        u.protocol === 'file:';
+      if (!allowed) event.preventDefault();
+    } catch {
+      event.preventDefault();
+    }
+  });
 
   if (isDev) {
     const port = process.env.AGENTORY_DEV_PORT || '4100';
@@ -295,12 +371,61 @@ app.whenReady().then(() => {
   initDb();
 
   ipcMain.handle('db:load', (_e, key: string) => loadState(key));
-  ipcMain.handle('db:save', (_e, key: string, value: string) => saveState(key, value));
-  ipcMain.handle('db:loadMessages', (_e, sessionId: string) => loadMessages(sessionId));
+  ipcMain.handle('db:save', (e, key: string, value: string) => {
+    if (!fromMainFrame(e)) return;
+    saveState(key, value);
+    // Invalidate Sentry's cached opt-out so the toggle in Settings takes
+    // effect on the next error without an app restart.
+    if (key === CRASH_OPT_OUT_KEY) {
+      _crashOptOutCached = undefined;
+    }
+  });
+  ipcMain.handle('db:loadMessages', (e, sessionId: string) => {
+    if (!fromMainFrame(e)) return [];
+    return loadMessages(sessionId);
+  });
+  // Cap renderer-supplied message payloads. The DB column is unbounded TEXT,
+  // so a buggy or malicious renderer could otherwise pin the WAL with
+  // gigabytes of JSON and balloon `~/.config/.../agentory.db` past disk
+  // budget. The caps below are well above any legitimate session:
+  //   - 64 chars per sessionId (sessions are uuid-ish ~36 chars)
+  //   - 50_000 blocks per session (current cap on history retention)
+  //   - 1 MB per individual block JSON (a single block this large is a bug)
+  const MAX_SESSION_ID_LEN = 64;
+  const MAX_BLOCKS = 50_000;
+  const MAX_BLOCK_BYTES = 1_000_000;
   ipcMain.handle(
     'db:saveMessages',
-    (_e, sessionId: string, blocks: Array<{ id: string; kind: string }>) =>
-      saveMessages(sessionId, blocks)
+    (
+      e,
+      sessionId: string,
+      blocks: Array<{ id: string; kind: string }>
+    ): { ok: true } | { ok: false; error: string } => {
+      if (!fromMainFrame(e)) return { ok: false, error: 'rejected' };
+      if (typeof sessionId !== 'string' || sessionId.length > MAX_SESSION_ID_LEN) {
+        return { ok: false, error: 'payload_too_large' };
+      }
+      if (!Array.isArray(blocks) || blocks.length > MAX_BLOCKS) {
+        return { ok: false, error: 'payload_too_large' };
+      }
+      const filtered: Array<{ id: string; kind: string }> = [];
+      for (const b of blocks) {
+        try {
+          const json = JSON.stringify(b);
+          if (json.length > MAX_BLOCK_BYTES) {
+            console.warn(
+              `[main] db:saveMessages dropping oversized block (${json.length} bytes) for session=${sessionId}`
+            );
+            continue;
+          }
+          filtered.push(b);
+        } catch {
+          console.warn('[main] db:saveMessages dropping unserializable block');
+        }
+      }
+      saveMessages(sessionId, filtered);
+      return { ok: true };
+    }
   );
 
   // i18n: renderer mirrors the resolved UI language to main so OS
@@ -360,7 +485,8 @@ app.whenReady().then(() => {
       !!env.ANTHROPIC_API_KEY?.trim();
     return { baseUrl, model, hasAuthToken };
   });
-  ipcMain.handle('connection:openSettingsFile', async () => {
+  ipcMain.handle('connection:openSettingsFile', async (e) => {
+    if (!fromMainFrame(e)) return { ok: false, error: 'rejected' };
     const file = path.join(os.homedir(), '.claude', 'settings.json');
     // shell.openPath returns '' on success, error string on failure. If the
     // file does not exist, create an empty stub so the editor opens cleanly.
@@ -381,7 +507,8 @@ app.whenReady().then(() => {
   });
   ipcMain.handle('app:getVersion', () => app.getVersion());
 
-  ipcMain.handle('dialog:pickDirectory', async () => {
+  ipcMain.handle('dialog:pickDirectory', async (e) => {
+    if (!fromMainFrame(e)) return null;
     const win = BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0];
     const res = await dialog.showOpenDialog(win, {
       properties: ['openDirectory'],
@@ -393,13 +520,26 @@ app.whenReady().then(() => {
 
   // Save tool output to a file the user picks. Used by the long-output
   // viewer's `Save as .log` action — for >10MB outputs this is the ONLY
-  // way the user can see the full content.
+  // way the user can see the full content. Capped at 50 MB per file:
+  // legitimate "save big tool dump" use cases live well under that, and
+  // anything bigger is almost certainly a runaway loop or accidental
+  // serialization of a giant in-memory buffer.
+  const MAX_SAVE_FILE_BYTES = 50 * 1024 * 1024;
   ipcMain.handle(
     'dialog:saveFile',
     async (
-      _e,
+      e,
       args: { defaultName?: string; content: string }
     ): Promise<{ ok: true; path: string } | { ok: false; canceled?: boolean; error?: string }> => {
+      if (!fromMainFrame(e)) return { ok: false, error: 'rejected' };
+      const content = typeof args?.content === 'string' ? args.content : '';
+      // String length is a fine proxy here — UTF-8 bytes can be at most 4×
+      // chars but realistic content (ASCII/UTF-8 text dumps) is ~1×, so we
+      // gate on raw length to avoid a wasted Buffer.byteLength roundtrip.
+      // The dialog filters offer .log/.txt only.
+      if (content.length > MAX_SAVE_FILE_BYTES) {
+        return { ok: false, error: 'content_too_large' };
+      }
       const win = BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0];
       try {
         const res = await dialog.showSaveDialog(win, {
@@ -410,7 +550,7 @@ app.whenReady().then(() => {
           ]
         });
         if (res.canceled || !res.filePath) return { ok: false, canceled: true };
-        fs.writeFileSync(res.filePath, args.content, 'utf8');
+        await fs.promises.writeFile(res.filePath, content, 'utf8');
         return { ok: true, path: res.filePath };
       } catch (err) {
         return { ok: false, error: err instanceof Error ? err.message : String(err) };
@@ -438,7 +578,7 @@ app.whenReady().then(() => {
   ipcMain.handle(
     'agent:start',
     async (
-      _e,
+      e,
       sessionId: string,
       opts: {
         cwd: string;
@@ -447,6 +587,9 @@ app.whenReady().then(() => {
         resumeSessionId?: string;
       }
     ) => {
+      if (!fromMainFrame(e)) {
+        return { ok: false, error: 'rejected', errorCode: 'CWD_MISSING' as const };
+      }
       // Guard against stale `cwd` paths that no longer exist on disk. Common
       // failure mode: a session was created inside a now-deleted worktree
       // (the Sept worktree feature was reverted in #104), so its persisted
@@ -454,7 +597,10 @@ app.whenReady().then(() => {
       // with ENOENT inside SessionRunner; catching here gives the renderer a
       // clean error code it can surface as "repick your folder".
       const resolvedCwd = resolveCwd(opts.cwd);
-      if (!fs.existsSync(resolvedCwd)) {
+      // UNC + non-absolute paths are rejected up front. resolveCwd expands
+      // `~` to the home dir, so by this point a safe cwd is always absolute
+      // and never a UNC share. See isSafePath() at top-of-file.
+      if (!isSafePath(resolvedCwd) || !fs.existsSync(resolvedCwd)) {
         return {
           ok: false,
           error: `Working directory no longer exists: ${opts.cwd}`,
@@ -472,29 +618,64 @@ app.whenReady().then(() => {
       return result;
     }
   );
-  ipcMain.handle('agent:send', (_e, sessionId: string, text: string) =>
-    sessions.send(sessionId, text)
-  );
+  ipcMain.handle('agent:send', (e, sessionId: string, text: string) => {
+    if (!fromMainFrame(e)) return false;
+    return sessions.send(sessionId, text);
+  });
   ipcMain.handle(
     'agent:sendContent',
-    (_e, sessionId: string, content: unknown[]) =>
-      sessions.sendContent(sessionId, Array.isArray(content) ? content : [])
+    (e, sessionId: string, content: unknown[]) => {
+      if (!fromMainFrame(e)) return false;
+      return sessions.sendContent(sessionId, Array.isArray(content) ? content : []);
+    }
   );
   ipcMain.handle('agent:interrupt', (_e, sessionId: string) => sessions.interrupt(sessionId));
-  ipcMain.handle('agent:setPermissionMode', (_e, sessionId: string, mode: PermissionMode) =>
-    sessions.setPermissionMode(sessionId, mode)
+  ipcMain.handle(
+    'agent:setPermissionMode',
+    async (
+      e,
+      sessionId: string,
+      mode: PermissionMode
+    ): Promise<{ ok: true } | { ok: false; error: string }> => {
+      if (!fromMainFrame(e)) return { ok: false, error: 'rejected' };
+      // Validate the mode up front so an unknown value gets rejected even
+      // when the session no longer exists (manager.setPermissionMode would
+      // otherwise short-circuit to `false` and we'd never hit the throw in
+      // toCliPermissionMode). The list here mirrors the union in
+      // electron/agent/sessions.ts:PermissionMode — keep them in sync.
+      const KNOWN_MODES = new Set<string>([
+        'default', 'acceptEdits', 'plan', 'bypassPermissions',
+        'ask', 'standard', 'dontAsk', 'auto', 'yolo'
+      ]);
+      if (typeof mode !== 'string' || !KNOWN_MODES.has(mode)) {
+        return { ok: false, error: 'unknown_mode' };
+      }
+      try {
+        await sessions.setPermissionMode(sessionId, mode);
+        return { ok: true };
+      } catch (err) {
+        if (err instanceof Error && /Unknown permission mode/i.test(err.message)) {
+          return { ok: false, error: 'unknown_mode' };
+        }
+        return { ok: false, error: err instanceof Error ? err.message : String(err) };
+      }
+    }
   );
-  ipcMain.handle('agent:setModel', (_e, sessionId: string, model?: string) =>
-    sessions.setModel(sessionId, model)
-  );
-  ipcMain.handle('agent:close', (_e, sessionId: string) => {
+  ipcMain.handle('agent:setModel', (e, sessionId: string, model?: string) => {
+    if (!fromMainFrame(e)) return false;
+    return sessions.setModel(sessionId, model);
+  });
+  ipcMain.handle('agent:close', (e, sessionId: string) => {
+    if (!fromMainFrame(e)) return false;
     return sessions.close(sessionId);
   });
 
   ipcMain.handle(
     'agent:resolvePermission',
-    (_e, sessionId: string, requestId: string, decision: 'allow' | 'deny') =>
-      sessions.resolvePermission(sessionId, requestId, decision)
+    (e, sessionId: string, requestId: string, decision: 'allow' | 'deny') => {
+      if (!fromMainFrame(e)) return false;
+      return sessions.resolvePermission(sessionId, requestId, decision);
+    }
   );
 
   ipcMain.handle('import:scan', () => getImportableSessions());
@@ -513,8 +694,19 @@ app.whenReady().then(() => {
       : [];
     const out: Record<string, boolean> = {};
     for (const p of list) {
+      // Reject UNC + non-absolute paths BEFORE touching fs. On Windows,
+      // `fs.existsSync('\\\\server\\share\\probe')` triggers an SMB lookup
+      // and leaks the user's NTLM hash to the named host. We map any unsafe
+      // path to `false` so the renderer's hydration migration treats it as
+      // "missing cwd" — exactly the desired behaviour. resolveCwd is still
+      // applied so `~`-prefixed cwds are expanded before the safety check.
       try {
-        out[p] = fs.existsSync(resolveCwd(p));
+        const resolved = resolveCwd(p);
+        if (!isSafePath(resolved)) {
+          out[p] = false;
+          continue;
+        }
+        out[p] = fs.existsSync(resolved);
       } catch {
         out[p] = false;
       }
@@ -528,11 +720,17 @@ app.whenReady().then(() => {
   // Renderer calls this on focus / cwd change. Execution stays pass-through:
   // selecting one inserts `/<name>` into the textarea, which the existing
   // send path forwards to claude.exe. We never parse the body.
-  ipcMain.handle('commands:list', (_e, cwd: string | null | undefined) =>
-    loadCommands({ cwd: cwd ?? null })
-  );
+  ipcMain.handle('commands:list', (_e, cwd: string | null | undefined) => {
+    // commands-loader does its own fs reads against the supplied cwd; UNC or
+    // relative inputs get filtered out here so we don't leak NTLM (Windows)
+    // or descend into wherever a confused renderer points us. Empty list is
+    // the safe fallback for any unsafe input.
+    if (cwd != null && !isSafePath(cwd)) return [];
+    return loadCommands({ cwd: cwd ?? null });
+  });
 
-  ipcMain.handle('shell:openExternal', async (_e, url: string) => {
+  ipcMain.handle('shell:openExternal', async (e, url: string) => {
+    if (!fromMainFrame(e)) return false;
     // Only http(s). Everything else is a potential shell hijack.
     if (!/^https?:\/\//i.test(url)) return false;
     try {
@@ -619,11 +817,15 @@ app.whenReady().then(() => {
 
   ipcMain.handle(
     'cli:setBinaryPath',
-    async (_e, rawPath: string): Promise<
+    async (e, rawPath: string): Promise<
       { ok: true; version: string | null } | { ok: false; error: string }
     > => {
+      if (!fromMainFrame(e)) return { ok: false, error: 'rejected' };
       const p = typeof rawPath === 'string' ? rawPath.trim() : '';
       if (!p) return { ok: false, error: 'Empty path' };
+      // Refuse UNC / non-absolute. The browse dialog only emits absolute
+      // local paths, so an unsafe input here is always a hand-crafted call.
+      if (!isSafePath(p)) return { ok: false, error: 'Invalid path' };
       try {
         if (!fs.existsSync(p)) return { ok: false, error: 'File does not exist' };
         const stat = fs.statSync(p);

--- a/electron/memory.ts
+++ b/electron/memory.ts
@@ -23,7 +23,15 @@ export function isAllowedMemoryPath(p: unknown): p is string {
   if (typeof p !== 'string' || p.length === 0) return false;
   // Must be absolute to avoid ambiguous-cwd behavior across platforms.
   if (!path.isAbsolute(p)) return false;
+  // Reject UNC paths (`\\server\share\...` on Windows or `//server/share/...`).
+  // path.isAbsolute returns true for these, but a UNC `fs.existsSync` triggers
+  // an SMB handshake that leaks the user's NTLM hash to the named host —
+  // exactly the credential-leak primitive we're trying to slam shut.
+  if (p.startsWith('\\\\') || p.startsWith('//')) return false;
   const normalized = path.normalize(p);
+  // Re-check after normalize — path.normalize on Windows can collapse mixed
+  // separators in ways that briefly produced UNC-like prefixes pre-Node 18.
+  if (normalized.startsWith('\\\\') || normalized.startsWith('//')) return false;
   // Disallow anything that looks like it's trying to traverse after
   // normalization (normalize usually collapses `..` but on symlinked
   // structures attackers might still smuggle one in).

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -87,7 +87,10 @@ const api = {
   },
   loadMessages: (sessionId: string): Promise<unknown[]> =>
     ipcRenderer.invoke('db:loadMessages', sessionId),
-  saveMessages: (sessionId: string, blocks: Array<{ id: string; kind: string }>): Promise<void> =>
+  saveMessages: (
+    sessionId: string,
+    blocks: Array<{ id: string; kind: string }>
+  ): Promise<{ ok: true } | { ok: false; error: string }> =>
     ipcRenderer.invoke('db:saveMessages', sessionId, blocks),
   getVersion: (): Promise<string> => ipcRenderer.invoke('app:getVersion'),
   pickDirectory: (): Promise<string | null> => ipcRenderer.invoke('dialog:pickDirectory'),
@@ -109,7 +112,10 @@ const api = {
     ipcRenderer.invoke('agent:sendContent', sessionId, content),
   agentInterrupt: (sessionId: string): Promise<boolean> =>
     ipcRenderer.invoke('agent:interrupt', sessionId),
-  agentSetPermissionMode: (sessionId: string, mode: PermissionMode): Promise<boolean> =>
+  agentSetPermissionMode: (
+    sessionId: string,
+    mode: PermissionMode
+  ): Promise<{ ok: true } | { ok: false; error: string }> =>
     ipcRenderer.invoke('agent:setPermissionMode', sessionId, mode),
   agentSetModel: (sessionId: string, model?: string): Promise<boolean> =>
     ipcRenderer.invoke('agent:setModel', sessionId, model),

--- a/scripts/probe-e2e-ipc-unc-rejection.mjs
+++ b/scripts/probe-e2e-ipc-unc-rejection.mjs
@@ -1,0 +1,101 @@
+// E2E: UNC + non-absolute paths supplied to renderer-exposed IPC handlers
+// MUST be rejected BEFORE main calls into `fs.*`. On Windows,
+// `fs.existsSync('\\\\evil-host\\share\\probe')` triggers an SMB handshake
+// that leaks the user's NTLM hash to whatever host the renderer named —
+// a critical credential-leak primitive we never want to expose.
+//
+// Asserts:
+//   1. `paths:exist` returns `false` for a UNC input. (Real fs would
+//      reach out to the network; our isSafePath() filter shortcuts it.)
+//   2. `paths:exist` still returns a real boolean for a benign absolute
+//      local path (sanity — we didn't break the legitimate use case).
+//   3. `commands:list` returns `[]` when handed a UNC cwd.
+//
+// We can't directly observe "no SMB packet went out" from a probe, but
+// the fact that the call returns synchronously-ish with `false` for the
+// UNC input proves the guard ran before any blocking fs roundtrip.
+
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { appWindow, startBundleServer, isolatedUserData } from './probe-utils.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function fail(msg) {
+  console.error(`\n[probe-e2e-ipc-unc-rejection] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const { port: PORT, close: closeServer } = await startBundleServer(root);
+const { dir: userDataDir, cleanup } = isolatedUserData('agentory-probe-unc');
+
+const app = await electron.launch({
+  args: ['.', `--user-data-dir=${userDataDir}`],
+  cwd: root,
+  env: {
+    ...process.env,
+    NODE_ENV: 'development',
+    AGENTORY_DEV_PORT: String(PORT)
+  }
+});
+
+try {
+  const win = await appWindow(app);
+  await win.waitForLoadState('domcontentloaded');
+  await win.waitForFunction(() => !!window.agentory, null, { timeout: 15_000 });
+
+  // Pick a real existing absolute local path for the sanity check.
+  // process.cwd() in the renderer probe is a node concern, not the renderer's;
+  // pass one we computed here.
+  const benign = process.platform === 'win32' ? 'C:\\Windows' : '/tmp';
+  const benignExists = fs.existsSync(benign);
+
+  const result = await win.evaluate(async ({ benign }) => {
+    const uncWin = '\\\\evil-host\\share\\probe';
+    const uncPosix = '//evil-host/share/probe';
+    const relativ = 'relative/path';
+    const pathsRes = await window.agentory.pathsExist([uncWin, uncPosix, relativ, benign]);
+    const cmdsUnc = await window.agentory.commands.list(uncWin);
+    const cmdsPosixUnc = await window.agentory.commands.list(uncPosix);
+    return { pathsRes, cmdsUnc, cmdsPosixUnc };
+  }, { benign });
+
+  // 1. paths:exist must return false for the unsafe inputs without touching fs.
+  const uncWin = '\\\\evil-host\\share\\probe';
+  const uncPosix = '//evil-host/share/probe';
+  const relativ = 'relative/path';
+  if (result.pathsRes[uncWin] !== false) {
+    fail(`paths:exist for UNC ${uncWin} expected false, got ${result.pathsRes[uncWin]}`);
+  }
+  if (result.pathsRes[uncPosix] !== false) {
+    fail(`paths:exist for // UNC expected false, got ${result.pathsRes[uncPosix]}`);
+  }
+  if (result.pathsRes[relativ] !== false) {
+    fail(`paths:exist for relative path expected false, got ${result.pathsRes[relativ]}`);
+  }
+  // 2. Sanity: benign absolute path goes through to fs and reflects reality.
+  if (result.pathsRes[benign] !== benignExists) {
+    fail(
+      `paths:exist for benign ${benign} expected ${benignExists}, got ${result.pathsRes[benign]} ` +
+      `(guard may be over-eager and rejecting safe absolute paths)`
+    );
+  }
+  // 3. commands:list must be an empty array for any UNC cwd.
+  if (!Array.isArray(result.cmdsUnc) || result.cmdsUnc.length !== 0) {
+    fail(`commands:list for UNC cwd expected [], got ${JSON.stringify(result.cmdsUnc)}`);
+  }
+  if (!Array.isArray(result.cmdsPosixUnc) || result.cmdsPosixUnc.length !== 0) {
+    fail(`commands:list for // UNC cwd expected [], got ${JSON.stringify(result.cmdsPosixUnc)}`);
+  }
+
+  console.log('\n[probe-e2e-ipc-unc-rejection] OK');
+  console.log('  UNC inputs to paths:exist + commands:list rejected before fs');
+} finally {
+  await app.close();
+  closeServer();
+  cleanup();
+}

--- a/scripts/probe-e2e-permission-mode-strict.mjs
+++ b/scripts/probe-e2e-permission-mode-strict.mjs
@@ -1,0 +1,62 @@
+// E2E: agent:setPermissionMode rejects unknown mode strings rather than
+// silently coercing them to 'default'. The earlier toCliPermissionMode()
+// fallback meant a buggy renderer could downgrade `bypassPermissions` to
+// `default` by sending a typo and never see an error.
+//
+// Asserts:
+//   1. An obvious garbage mode → { ok: false, error: 'unknown_mode' }.
+//   2. A legitimate mode (`default`) → { ok: true } even when the session
+//      doesn't exist (manager returns false, IPC handler reports ok:true
+//      because the call was well-formed).
+
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { appWindow, startBundleServer, isolatedUserData } from './probe-utils.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function fail(msg) {
+  console.error(`\n[probe-e2e-permission-mode-strict] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const { port: PORT, close: closeServer } = await startBundleServer(root);
+const { dir: userDataDir, cleanup } = isolatedUserData('agentory-probe-permmode');
+
+const app = await electron.launch({
+  args: ['.', `--user-data-dir=${userDataDir}`],
+  cwd: root,
+  env: {
+    ...process.env,
+    NODE_ENV: 'development',
+    AGENTORY_DEV_PORT: String(PORT)
+  }
+});
+
+try {
+  const win = await appWindow(app);
+  await win.waitForLoadState('domcontentloaded');
+  await win.waitForFunction(() => !!window.agentory, null, { timeout: 15_000 });
+
+  const result = await win.evaluate(async () => {
+    const bogus = await window.agentory.agentSetPermissionMode('s-nonexistent', 'not-a-real-mode');
+    const valid = await window.agentory.agentSetPermissionMode('s-nonexistent', 'default');
+    return { bogus, valid };
+  });
+
+  if (!result.bogus || result.bogus.ok !== false || result.bogus.error !== 'unknown_mode') {
+    fail(`bogus mode expected { ok:false, error:'unknown_mode' }, got ${JSON.stringify(result.bogus)}`);
+  }
+  if (!result.valid || result.valid.ok !== true) {
+    fail(`valid mode 'default' expected { ok:true }, got ${JSON.stringify(result.valid)}`);
+  }
+
+  console.log('\n[probe-e2e-permission-mode-strict] OK');
+  console.log('  unknown permission modes are rejected; known modes pass through');
+} finally {
+  await app.close();
+  closeServer();
+  cleanup();
+}

--- a/scripts/probe-e2e-savemessages-size-cap.mjs
+++ b/scripts/probe-e2e-savemessages-size-cap.mjs
@@ -1,0 +1,103 @@
+// E2E: db:saveMessages caps renderer-supplied payload size. The DB column
+// is unbounded TEXT, so without a cap a malicious or buggy renderer could
+// pin the WAL with gigabytes of JSON and balloon agentory.db past disk
+// budget. Caps live in electron/main.ts:
+//   - MAX_SESSION_ID_LEN  64   (uuid-ish session ids, ~36 chars)
+//   - MAX_BLOCKS          50_000
+//   - MAX_BLOCK_BYTES     1_000_000   (per-block JSON length)
+//
+// Asserts:
+//   1. Oversized session id    → { ok:false, error:'payload_too_large' }
+//      and DB unchanged for that id (loadMessages returns []).
+//   2. Too many blocks          → same.
+//   3. A single oversized block is dropped with a warn but the rest of
+//      the payload still saves successfully (returns { ok:true }) and
+//      loadMessages returns only the small blocks.
+
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { appWindow, startBundleServer, isolatedUserData } from './probe-utils.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function fail(msg) {
+  console.error(`\n[probe-e2e-savemessages-size-cap] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const { port: PORT, close: closeServer } = await startBundleServer(root);
+const { dir: userDataDir, cleanup } = isolatedUserData('agentory-probe-savecap');
+
+const app = await electron.launch({
+  args: ['.', `--user-data-dir=${userDataDir}`],
+  cwd: root,
+  env: {
+    ...process.env,
+    NODE_ENV: 'development',
+    AGENTORY_DEV_PORT: String(PORT)
+  }
+});
+
+try {
+  const win = await appWindow(app);
+  await win.waitForLoadState('domcontentloaded');
+  await win.waitForFunction(() => !!window.agentory, null, { timeout: 15_000 });
+
+  const result = await win.evaluate(async () => {
+    const out = {};
+    // 1. Oversized sessionId.
+    const longId = 'x'.repeat(200);
+    out.bigId = await window.agentory.saveMessages(longId, [{ id: 'a', kind: 'user' }]);
+    out.bigIdLoaded = await window.agentory.loadMessages(longId);
+    // 2. Too many blocks (well above MAX_BLOCKS=50_000).
+    const tooManyBlocks = Array.from({ length: 60_000 }, (_, i) => ({ id: `b${i}`, kind: 'user' }));
+    out.tooMany = await window.agentory.saveMessages('s-too-many', tooManyBlocks);
+    out.tooManyLoaded = await window.agentory.loadMessages('s-too-many');
+    // 3. One oversized block among small ones — should drop the giant
+    //    block and persist only the small ones.
+    const giant = 'x'.repeat(1_500_000);
+    const mixed = [
+      { id: 'small-1', kind: 'user' },
+      { id: 'big', kind: 'user', text: giant },
+      { id: 'small-2', kind: 'assistant' }
+    ];
+    out.mixed = await window.agentory.saveMessages('s-mixed', mixed);
+    out.mixedLoaded = await window.agentory.loadMessages('s-mixed');
+    return out;
+  });
+
+  // 1.
+  if (!result.bigId || result.bigId.ok !== false || result.bigId.error !== 'payload_too_large') {
+    fail(`oversized sessionId expected payload_too_large, got ${JSON.stringify(result.bigId)}`);
+  }
+  if (!Array.isArray(result.bigIdLoaded) || result.bigIdLoaded.length !== 0) {
+    fail(`DB should be untouched for oversized sessionId; loaded=${JSON.stringify(result.bigIdLoaded)}`);
+  }
+  // 2.
+  if (!result.tooMany || result.tooMany.ok !== false || result.tooMany.error !== 'payload_too_large') {
+    fail(`too-many-blocks expected payload_too_large, got ${JSON.stringify(result.tooMany)}`);
+  }
+  if (!Array.isArray(result.tooManyLoaded) || result.tooManyLoaded.length !== 0) {
+    fail(`DB should be untouched for too-many-blocks; loaded length=${result.tooManyLoaded?.length}`);
+  }
+  // 3.
+  if (!result.mixed || result.mixed.ok !== true) {
+    fail(`mixed payload expected ok:true (giant dropped, rest saved), got ${JSON.stringify(result.mixed)}`);
+  }
+  if (!Array.isArray(result.mixedLoaded) || result.mixedLoaded.length !== 2) {
+    fail(`expected 2 surviving blocks (small-1 + small-2), got ${result.mixedLoaded?.length}`);
+  }
+  const ids = result.mixedLoaded.map((b) => b.id).sort();
+  if (ids.join(',') !== 'small-1,small-2') {
+    fail(`surviving block ids expected [small-1,small-2], got [${ids.join(',')}]`);
+  }
+
+  console.log('\n[probe-e2e-savemessages-size-cap] OK');
+  console.log('  size caps enforced; oversized payloads rejected, individual oversized blocks dropped');
+} finally {
+  await app.close();
+  closeServer();
+  cleanup();
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -115,13 +115,7 @@ export default function App() {
   const resolvedLanguage = usePreferences((s) => s.resolvedLanguage);
   useEffect(() => {
     let cancelled = false;
-    type Bridge = {
-      i18n?: {
-        getSystemLocale: () => Promise<string | undefined>;
-        setLanguage: (l: 'en' | 'zh') => void;
-      };
-    };
-    const bridge = (window as unknown as { agentory?: Bridge }).agentory;
+    const bridge = window.agentory;
     void (async () => {
       let locale: string | undefined;
       try {
@@ -139,9 +133,7 @@ export default function App() {
     };
   }, [hydrateSystemLocale]);
   useEffect(() => {
-    type Bridge = { i18n?: { setLanguage: (l: 'en' | 'zh') => void } };
-    const bridge = (window as unknown as { agentory?: Bridge }).agentory;
-    bridge?.i18n?.setLanguage(resolvedLanguage);
+    window.agentory?.i18n?.setLanguage(resolvedLanguage);
   }, [resolvedLanguage]);
 
   const [settingsOpen, setSettingsOpen] = React.useState(false);

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -83,8 +83,20 @@ declare global {
     agentory?: {
       loadState: (key: string) => Promise<string | null>;
       saveState: (key: string, value: string) => Promise<void>;
+      // i18n bridge mirrors the API surface exposed in electron/preload.ts.
+      // `getSystemLocale` returns the OS locale so the renderer's
+      // preferences store can resolve a "system" preference; `setLanguage`
+      // pushes the resolved UI language back to main so OS notifications
+      // come out in the matching language.
+      i18n: {
+        getSystemLocale: () => Promise<string | undefined>;
+        setLanguage: (l: 'en' | 'zh') => void;
+      };
       loadMessages: (sessionId: string) => Promise<unknown[]>;
-      saveMessages: (sessionId: string, blocks: Array<{ id: string; kind: string }>) => Promise<void>;
+      saveMessages: (
+        sessionId: string,
+        blocks: Array<{ id: string; kind: string }>
+      ) => Promise<{ ok: true } | { ok: false; error: string }>;
       getVersion: () => Promise<string>;
       pickDirectory: () => Promise<string | null>;
       saveFile: (args: {
@@ -98,7 +110,10 @@ declare global {
       agentSend: (sessionId: string, text: string) => Promise<boolean>;
       agentSendContent: (sessionId: string, content: unknown[]) => Promise<boolean>;
       agentInterrupt: (sessionId: string) => Promise<boolean>;
-      agentSetPermissionMode: (sessionId: string, mode: PermissionMode) => Promise<boolean>;
+      agentSetPermissionMode: (
+        sessionId: string,
+        mode: PermissionMode
+      ) => Promise<{ ok: true } | { ok: false; error: string }>;
       agentSetModel: (sessionId: string, model?: string) => Promise<boolean>;
       agentClose: (sessionId: string) => Promise<boolean>;
       agentResolvePermission: (


### PR DESCRIPTION
Worker A scope: IPC security + Electron baseline hardening. All fixes in one PR per the worker spec; branch is `worker-a-ipc-security` off `origin/working`.

## Fixes

### 1. UNC path rejection — CRITICAL (NTLM hash leak on Windows)
Filter renderer-supplied paths through new `isSafePath()` helper before any `fs.*` call. UNC paths (`\server\share\...` / `//server/share/...`) and non-absolute paths now return safe defaults (`false` / `[]` / `'invalid_path'`).

Hardened handlers:
- `paths:exist`
- `commands:list`
- `cli:setBinaryPath`
- `agent:start` (cwd validation)
- `electron/memory.ts isAllowedMemoryPath()` — also rejected UNC for `memory:*` family

Probe: `scripts/probe-e2e-ipc-unc-rejection.mjs`

### 2. senderFrame validation — CRITICAL (defense in depth)
New `fromMainFrame()` helper. Applied to every privileged handler: `agent:start`, `agent:send`, `agent:sendContent`, `agent:setModel`, `agent:setPermissionMode`, `agent:close`, `agent:resolvePermission`, `shell:openExternal`, `dialog:pickDirectory`, `dialog:saveFile`, `cli:setBinaryPath`, `connection:openSettingsFile`, `db:save`, `db:saveMessages`, `db:loadMessages`. Non-mainFrame messages get rejected with `{ ok:false, error:'rejected' }` (or `false` / `[]` / `null` per handler shape).

### 3. Electron security baseline — partial
- `setWindowOpenHandler` denies all `window.open` calls.
- `will-navigate` listener blocks navigation away from our renderer origin.
- `sandbox: true` is **NOT** enabled — `@sentry/electron/preload`'s `require('@sentry/electron/preload')` cannot be resolved by the sandboxed preload's restricted `require` (only relative paths and a small whitelist allowed). I verified this empirically: with sandbox on, the renderer logs `Error: module not found: @sentry/electron/preload` and `window.agentory` is never installed. Per worker spec ("if sandbox:true breaks preload, STOP and report — don't paper over"), I left `sandbox: false` with a comment pointing to the followup. **Followup: bundle preload through webpack so the require resolves at build time, then flip sandbox back on.**

### 4. toCliPermissionMode strict — STRONG
Unknown modes now throw rather than silently coercing to `'default'`. The IPC handler validates the mode up front against the known set and returns `{ ok:false, error:'unknown_mode' }`. Prevents a renderer typo from silently downgrading `bypassPermissions` → `default`.

Return type of `agentSetPermissionMode` changed from `boolean` → `{ ok:true } | { ok:false; error:string }`. Only caller (`stores/store.ts`) ignores the return value, so no UI changes.

Probe: `scripts/probe-e2e-permission-mode-strict.mjs`

### 5. db:saveMessages size cap — STRONG
- `sessionId.length <= 64`
- `blocks.length <= 50_000`
- per-block JSON `<= 1 MB` (oversized blocks dropped with `console.warn`, rest still saves)

Oversized session id / block count returns `{ ok:false, error:'payload_too_large' }` with DB untouched. Return type changed from `void` → discriminated union; all callers were fire-and-forget `void`.

Probe: `scripts/probe-e2e-savemessages-size-cap.mjs`

### 6. dialog:saveFile async + size cap — STRONG
Replaced `fs.writeFileSync` with `await fs.promises.writeFile`. Content cap 50 MB (legitimate "save big tool dump" stays under).

### 7. loadCrashReportingOptOut module cache — STRONG
Sentry `beforeSend` ran a SQLite `loadState()` on every error in the hot path. Now cached in module-scope `_crashOptOutCached`, invalidated when `db:save` writes the `crashReportingOptOut` key (so the Settings toggle still takes effect immediately, no app restart needed).

### 8. global.d.ts i18n type + drop App.tsx cast — NIT
Added `i18n` key to `Window.agentory` declaration matching the preload surface. Dropped both `as unknown as { agentory?: Bridge }` casts in `App.tsx` in favour of `window.agentory?.i18n` directly.

## Verification

- `npm run typecheck` — passes (both renderer + electron tsconfigs).
- `npm test` — 554/554 pass.
- All 3 e2e probes pass:
  - `node scripts/probe-e2e-ipc-unc-rejection.mjs`
  - `node scripts/probe-e2e-permission-mode-strict.mjs`
  - `node scripts/probe-e2e-savemessages-size-cap.mjs`

## Notes for reviewer

- Sandbox issue (#3) is genuinely blocked on preload bundling — flagged for followup, not papered over.
- Optional spot-check (`window.open` → blocked) was deferred per worker spec.
- The `agent:setPermissionMode` mode whitelist in `main.ts` mirrors the union in `electron/agent/sessions.ts:PermissionMode` — these need to stay in sync; comment in code calls this out.

DO NOT MERGE — independent reviewer to check.