### PR TITLE
fix(agent): subprocess lifecycle + error surfacing

### DIFF
--- a/electron/agent/binary-resolver.ts
+++ b/electron/agent/binary-resolver.ts
@@ -252,6 +252,13 @@ function runLookup(tool: string, target: string): Promise<string | null> {
     }
 
     child.stdout?.setEncoding('utf8');
+    // `error` listeners are required on each Readable we touch: if the child
+    // dies before we read the pipe (SIGPIPE etc.), Node throws "Unhandled
+    // 'error' event" and crashes main. No remediation — the lookup already
+    // resolves to null on child error below.
+    child.stdout?.on('error', () => {
+      /* ignore — surface via `close` handler below */
+    });
     child.stdout?.on('data', (chunk: string) => {
       stdout += chunk;
     });
@@ -345,6 +352,13 @@ export function detectClaudeVersion(binPath: string): Promise<string | null> {
 
     child.stdout?.setEncoding('utf8');
     child.stderr?.setEncoding('utf8');
+    // See runLookup() for why we need explicit `error` handlers on each pipe.
+    child.stdout?.on('error', () => {
+      /* ignore — `close` below settles with null */
+    });
+    child.stderr?.on('error', () => {
+      /* ignore — `close` below settles with null */
+    });
     child.stdout?.on('data', (c: string) => (stdout += c));
     child.stderr?.on('data', (c: string) => (stderr += c));
     child.on('error', () => done(null));

--- a/electron/agent/manager.ts
+++ b/electron/agent/manager.ts
@@ -4,6 +4,19 @@ import { ClaudeNotFoundError } from './binary-resolver';
 
 type Sender = (channel: string, payload: unknown) => void;
 
+/**
+ * Diagnostic surfaced from the agent subsystem that the renderer can toast.
+ * Emitted on new `agent:diagnostic` channel — separate from `agent:exit` so
+ * transient warnings (init-handshake failure, outbound control_request timeout)
+ * don't look like hard session termination.
+ */
+export type AgentDiagnostic = {
+  sessionId: string;
+  level: 'warn' | 'error';
+  code: string;
+  message: string;
+};
+
 export type StartResult =
   | { ok: true }
   | {
@@ -19,9 +32,46 @@ class SessionsManager {
 
   bindSender(wc: WebContents): void {
     this.sender = (channel, payload) => {
+      // Guard every send: the WebContents may be torn down mid-flight (window
+      // hidden→destroyed on minimize-to-tray → reshow creates a new one; the
+      // old reference here dangles until we rebind). wc.send on a destroyed
+      // WebContents throws, which would propagate into the sessions event
+      // loop and potentially kill an otherwise-healthy runner.
       if (wc.isDestroyed()) return;
-      wc.send(channel, payload);
+      try {
+        wc.send(channel, payload);
+      } catch {
+        /* WebContents went away between isDestroyed() and send() — swallow */
+      }
     };
+  }
+
+  /**
+   * Point future emits at a fresh WebContents. Called from main.ts whenever a
+   * BrowserWindow is (re)created so sessions that outlived a window hide/show
+   * cycle keep streaming into the live renderer instead of into a dead
+   * reference. Idempotent; replaces any prior sender.
+   */
+  rebindSender(wc: WebContents): void {
+    this.bindSender(wc);
+  }
+
+  /**
+   * Expose runner metadata for the dev-only debug backdoor in main.ts.
+   * Never call from production code — this is strictly for E2E probes that
+   * need to assert on the live child pid set. Returns a snapshot; mutating
+   * the array has no effect on the real runner map.
+   */
+  activeRunnerPids(): Array<{ sessionId: string; pid: number | undefined }> {
+    const out: Array<{ sessionId: string; pid: number | undefined }> = [];
+    for (const [sessionId, runner] of this.runners) {
+      out.push({ sessionId, pid: runner.getPid() });
+    }
+    return out;
+  }
+
+  activeSessionCount(): number {
+    return this.runners.size;
   }
 
   async start(sessionId: string, opts: StartOptions): Promise<StartResult> {
@@ -34,7 +84,14 @@ class SessionsManager {
           this.emit('agent:exit', { sessionId, error });
           this.runners.delete(sessionId);
         },
-        (req) => this.emit('agent:permissionRequest', { sessionId, ...req })
+        (req) => this.emit('agent:permissionRequest', { sessionId, ...req }),
+        (diag) =>
+          this.emit('agent:diagnostic', {
+            sessionId,
+            level: diag.level,
+            code: diag.code,
+            message: diag.message,
+          } satisfies AgentDiagnostic)
       );
       await runner.start(opts);
       this.runners.set(sessionId, runner);

--- a/electron/agent/sessions.ts
+++ b/electron/agent/sessions.ts
@@ -124,6 +124,18 @@ export type PermissionRequestHandler = (req: {
   toolName: string;
   input: Record<string, unknown>;
 }) => void;
+/**
+ * Transient diagnostics surfaced from the agent layer — things the user may
+ * want to see as a toast (init handshake failed, outbound control_request
+ * timed out) but which aren't hard session-ending errors. Kept deliberately
+ * minimal: `code` is a stable machine-readable key (e.g. `init_failed`,
+ * `control_timeout`), `message` is a one-liner suitable for toast copy.
+ */
+export type DiagnosticHandler = (d: {
+  level: 'warn' | 'error';
+  code: string;
+  message: string;
+}) => void;
 
 /**
  * Single shared callback id for the `PreToolUse` hook we register at
@@ -167,8 +179,14 @@ export class SessionRunner {
     public readonly id: string,
     private readonly onEvent: EventHandler,
     private readonly onExit: ExitHandler,
-    private readonly onPermissionRequest: PermissionRequestHandler
+    private readonly onPermissionRequest: PermissionRequestHandler,
+    private readonly onDiagnostic: DiagnosticHandler = () => {}
   ) {}
+
+  /** Test-only backdoor: expose the child pid for dev probes. */
+  getPid(): number | undefined {
+    return this.cp?.pid;
+  }
 
   resolvePermission(requestId: string, decision: 'allow' | 'deny'): boolean {
     const resolve = this.pendingPerms.get(requestId);
@@ -217,6 +235,12 @@ export class SessionRunner {
     // `can_use_tool`. The callback id is opaque to the CLI; we use a single
     // shared id so the handler in handleHookCallback is unambiguous. Fire-and-
     // forget — the response carries a `commands` list we don't consume.
+    //
+    // Failure surfacing: a lost handshake means the CLI falls through to its
+    // local rule engine, which is security-relevant (the user may expect
+    // prompts that never arrive for edits/writes). We emit `init_failed` as
+    // a diagnostic so the renderer can toast — the user should at least know
+    // their permission UX is degraded.
     void this.rpc
       .sendControlRequest({
         subtype: 'initialize',
@@ -231,7 +255,13 @@ export class SessionRunner {
         // initialize round-trip in tests / fast-cancel flows. Only log
         // when we genuinely lost the handshake on a live session.
         if (this.disposed) return;
+        const msg = err instanceof Error ? err.message : String(err);
         console.warn('[sessions] initialize handshake failed', err);
+        this.onDiagnostic({
+          level: 'error',
+          code: 'init_failed',
+          message: `Agent initialize handshake failed — permission prompts may be degraded: ${msg}`,
+        });
       });
 
     const stdout = this.cp.stdout;
@@ -437,8 +467,18 @@ export class SessionRunner {
     if (!this.rpc) return;
     try {
       await this.rpc.interrupt();
-    } catch {
-      /* timeout / channel broken — let close() handle hard kill */
+    } catch (err) {
+      // Timeout / channel broken. close() will escalate via SIGTERM/SIGKILL
+      // through the abort signal; the user still deserves a heads-up that
+      // the soft interrupt didn't land so a "Stop" click that appears to do
+      // nothing gets explained.
+      this.onDiagnostic({
+        level: 'warn',
+        code: 'interrupt_timeout',
+        message: `Agent didn't acknowledge interrupt (${
+          err instanceof Error ? err.message : String(err)
+        }). Force-killing.`,
+      });
     }
   }
 
@@ -455,8 +495,14 @@ export class SessionRunner {
     if (!cliMode) return;
     try {
       await this.rpc.setPermissionMode(cliMode);
-    } catch {
-      /* ignore — claude.exe may not honour mid-session changes for every mode */
+    } catch (err) {
+      this.onDiagnostic({
+        level: 'warn',
+        code: 'set_permission_mode_timeout',
+        message: `Agent unresponsive to permission-mode change (${
+          err instanceof Error ? err.message : String(err)
+        }).`,
+      });
     }
   }
 
@@ -464,8 +510,14 @@ export class SessionRunner {
     if (!this.rpc || !model) return;
     try {
       await this.rpc.setModel(model);
-    } catch {
-      /* ignore */
+    } catch (err) {
+      this.onDiagnostic({
+        level: 'warn',
+        code: 'set_model_timeout',
+        message: `Agent unresponsive to model change (${
+          err instanceof Error ? err.message : String(err)
+        }).`,
+      });
     }
   }
 
@@ -494,6 +546,37 @@ export class SessionRunner {
     this.pendingPerms.clear();
     this.rpc?.close();
     this.rpc = null;
+    // Stream listeners attached by the splitter + stderr ring buffer in
+    // claude-spawner can outlive the exit (the child's `exit` event fires
+    // before its stdio pipes emit `close`). Left dangling they either (a)
+    // pin the Readable's internal buffer in memory per-session forever, or
+    // (b) fire a late `data` event that races our disposed guard. Explicit
+    // teardown: drop listeners first, THEN destroy the streams so any
+    // in-flight `data`/`error` from the destroy path doesn't re-invoke a
+    // consumer we already nulled out.
+    const cp = this.cp;
+    if (cp) {
+      try {
+        cp.stdout.removeAllListeners();
+        cp.stdout.destroy();
+      } catch {
+        /* ignore */
+      }
+      try {
+        cp.stderr.removeAllListeners();
+        cp.stderr.destroy();
+      } catch {
+        /* ignore */
+      }
+      try {
+        cp.stdin.removeAllListeners();
+        // stdin was end()'d in close(); destroy() is a cheap idempotent
+        // double-check for the abnormal-exit path (consumer loop threw).
+        cp.stdin.destroy();
+      } catch {
+        /* ignore */
+      }
+    }
     this.cp = null;
   }
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -305,6 +305,18 @@ function createWindow() {
   installContextMenu(win);
   sessions.bindSender(win.webContents);
 
+  // If a prior window was hidden then had its WebContents destroyed (can
+  // happen under aggressive GC on minimize-to-tray), subsequent `wc.send`
+  // calls from the sessions manager no-op silently. Rebinding on `show` and
+  // on the fresh window's `did-finish-load` picks up any still-live sessions
+  // and routes their events at the live renderer.
+  win.on('show', () => {
+    if (!win.webContents.isDestroyed()) sessions.rebindSender(win.webContents);
+  });
+  win.webContents.on('did-finish-load', () => {
+    if (!win.webContents.isDestroyed()) sessions.rebindSender(win.webContents);
+  });
+
   const emitMax = () => win.webContents.send('window:maximizedChanged', win.isMaximized());
   win.on('maximize', emitMax);
   win.on('unmaximize', emitMax);
@@ -958,6 +970,18 @@ app.whenReady().then(() => {
 
   installUpdaterIpc();
 
+  // Dev-only debug backdoor for E2E probes. Probes call this via
+  // `app.evaluate(() => globalThis.__agentoryDebug.activeSessionPids())` on
+  // the Electron main process (NOT the renderer — we intentionally don't
+  // widen preload.ts's surface for a test-only affordance). Guarded behind
+  // `!app.isPackaged` so prod bundles never expose it.
+  if (!app.isPackaged) {
+    (globalThis as unknown as Record<string, unknown>).__agentoryDebug = {
+      activeSessionPids: () => sessions.activeRunnerPids(),
+      activeSessionCount: () => sessions.activeSessionCount(),
+    };
+  }
+
   createWindow();
   ensureTray();
 
@@ -970,6 +994,17 @@ app.whenReady().then(() => {
 
 app.on('before-quit', () => {
   isQuitting = true;
+  // Kill any live claude.exe children before the event loop is torn down.
+  // `window-all-closed` already runs closeAll() on Windows/Linux, but on
+  // macOS (and on the tray→Quit path that invokes app.quit() directly while
+  // windows are hidden-not-closed) before-quit is our only guaranteed hook.
+  // closeAll() is idempotent and synchronous (abort signals fire SIGTERM via
+  // the spawner); a duplicate call from window-all-closed is a no-op.
+  try {
+    sessions.closeAll();
+  } catch {
+    /* ignore — best-effort cleanup on quit */
+  }
 });
 
 app.on('window-all-closed', () => {

--- a/scripts/probe-e2e-close-window-aborts-sessions.mjs
+++ b/scripts/probe-e2e-close-window-aborts-sessions.mjs
@@ -1,0 +1,174 @@
+// Regression probe for Worker D finding #3 (subprocess lifecycle):
+// closing the app window (the real-quit path, not minimize-to-tray) must
+// tear down every live claude.exe child before the Electron process exits.
+// Before the fix, `app.before-quit` only flipped `isQuitting=true`; cleanup
+// happened inside `window-all-closed`, which could miss the tray→Quit path
+// (windows hidden, not closed). The fix pulls `sessions.closeAll()` forward
+// into `before-quit` as a belt-and-suspenders guarantee.
+//
+// Strategy:
+//   - Launch Electron with an isolated userData dir.
+//   - Spawn a real claude.exe via agentStart; capture pid through the
+//     `globalThis.__agentoryDebug` backdoor.
+//   - Set `isQuitting=true` equivalent by calling `app.quit()` on the main
+//     process — this bypasses the minimize-to-tray window.close hook and
+//     drives the real shutdown path.
+//   - After `app.close()` resolves, the probe's own node runtime polls
+//     `process.kill(pid, 0)` until the child is gone or we time out.
+//
+// Falls back to SKIP if claude isn't resolvable on this host (same policy as
+// the companion delete-session probe).
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { appWindow } from './probe-utils.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function fail(msg, app) {
+  console.error(`\n[probe-e2e-close-window-aborts-sessions] FAIL: ${msg}`);
+  if (app) app.close().catch(() => {});
+  process.exit(1);
+}
+
+function skip(msg) {
+  console.log(`\n[probe-e2e-close-window-aborts-sessions] SKIP: ${msg}`);
+  process.exit(0);
+}
+
+function isPidAlive(pid) {
+  if (!pid || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agentory-probe-close-'));
+console.log(`[probe-e2e-close-window-aborts-sessions] userData = ${userDataDir}`);
+
+const app = await electron.launch({
+  args: ['.', `--user-data-dir=${userDataDir}`],
+  cwd: root,
+  // AGENTORY_PROD_BUNDLE=1 avoids a running webpack-dev-server dependency —
+  // main.ts loads dist/renderer/index.html directly. The backdoor we rely on
+  // is guarded by !app.isPackaged, so it still installs under this flag
+  // because we're launched via `electron .` (never packaged).
+  env: { ...process.env, NODE_ENV: 'development', AGENTORY_PROD_BUNDLE: '1' }
+});
+
+try {
+  const win = await appWindow(app);
+  await win.waitForLoadState('domcontentloaded');
+  await win.waitForFunction(() => !!window.__agentoryStore && !!window.agentory, null, {
+    timeout: 15_000
+  });
+
+  const cwd = root;
+  const sessionId = 's-close-probe';
+  await win.evaluate(
+    ({ sid, cwd }) => {
+      const store = window.__agentoryStore;
+      store.setState({
+        groups: [{ id: 'g1', name: 'G1', collapsed: false, kind: 'normal' }],
+        sessions: [
+          {
+            id: sid,
+            name: 'close-probe',
+            state: 'idle',
+            cwd,
+            model: 'claude-sonnet-4',
+            groupId: 'g1',
+            agentType: 'claude-code'
+          }
+        ],
+        activeId: sid,
+        messagesBySession: { [sid]: [] },
+        startedSessions: {},
+        runningSessions: {}
+      });
+    },
+    { sid: sessionId, cwd }
+  );
+
+  const startRes = await win.evaluate(
+    async ({ sid, cwd }) =>
+      await window.agentory.agentStart(sid, { cwd, permissionMode: 'default' }),
+    { sid: sessionId, cwd }
+  );
+  if (!startRes || startRes.ok !== true) {
+    if (startRes && startRes.errorCode === 'CLAUDE_NOT_FOUND') {
+      skip(`claude CLI not resolvable on PATH (${startRes.error})`);
+    }
+    fail(`agentStart failed: ${JSON.stringify(startRes)}`, app);
+  }
+
+  // Wait for a real pid to appear in the main-process map.
+  let pid = null;
+  for (let i = 0; i < 30; i++) {
+    const pids = await app.evaluate(() => {
+      const dbg = globalThis.__agentoryDebug;
+      return dbg ? dbg.activeSessionPids() : null;
+    });
+    if (!pids) fail('globalThis.__agentoryDebug missing in main process', app);
+    const row = pids.find((r) => r.sessionId === sessionId);
+    if (row && typeof row.pid === 'number') {
+      pid = row.pid;
+      break;
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  if (!pid) fail('never observed a pid for the spawned session', app);
+  console.log(`[probe-e2e-close-window-aborts-sessions] live pid = ${pid}`);
+  if (!isPidAlive(pid)) {
+    fail(`reported pid ${pid} was already dead before quit — spawner smoke failed`, app);
+  }
+
+  // Drive the real-quit path. app.quit() emits `before-quit` → our hook
+  // fires `sessions.closeAll()`, then window-all-closed + closeDb + actual
+  // process exit. This mirrors the tray menu's Quit item, not a plain
+  // window close (which minimize-to-tray would intercept).
+  await app.evaluate(({ app: a }) => {
+    a.quit();
+  });
+
+  // Let playwright's wrapper observe the electron process exit.
+  await app.close().catch(() => {});
+
+  // Poll from the probe's own runtime — claude.exe is a grandchild of this
+  // process, so it outlives app.close() only if the parent leaked it. Give
+  // the kernel up to 8s to reap on Windows (WMI reaping can be slow).
+  const deadline = Date.now() + 8_000;
+  let dead = false;
+  while (Date.now() < deadline) {
+    if (!isPidAlive(pid)) {
+      dead = true;
+      break;
+    }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  if (!dead) {
+    // Best-effort cleanup before failing so we don't leave a token-burning
+    // zombie behind after a regression.
+    try {
+      process.kill(pid, 'SIGKILL');
+    } catch {
+      /* ignore */
+    }
+    fail(`pid ${pid} still alive 8s after app.quit() — orphan claude.exe regression`);
+  }
+
+  console.log('\n[probe-e2e-close-window-aborts-sessions] OK');
+  console.log(`  spawned claude pid=${pid} died within 8s of app.quit()`);
+} catch (err) {
+  console.error('[probe-e2e-close-window-aborts-sessions] threw:', err);
+  await app.close().catch(() => {});
+  process.exit(1);
+} finally {
+  fs.rmSync(userDataDir, { recursive: true, force: true });
+}

--- a/scripts/probe-e2e-delete-session-kills-process.mjs
+++ b/scripts/probe-e2e-delete-session-kills-process.mjs
@@ -1,0 +1,195 @@
+// Regression probe for Worker D finding #1 (subprocess lifecycle):
+// deleting a session while its claude.exe child is live must kill the child.
+// Before the fix, `deleteSession()` in the store cleared renderer state but
+// never dispatched `agent:close`, so the spawned process kept running (and
+// burning tokens) as a zombie until the app quit.
+//
+// Strategy:
+//   - Launch Electron with an isolated userData dir + a real CLI present on
+//     the machine (resolved through AGENTORY_CLAUDE_BIN / PATH by main).
+//   - Seed a session and trigger agentStart through the live IPC bridge.
+//     claude.exe sits at the stdio prompt waiting for a `user` frame — it
+//     doesn't need a real prompt or network to exist as a process.
+//   - Snapshot the pid via the dev-only `globalThis.__agentoryDebug` backdoor
+//     installed in electron/main.ts (guarded by !app.isPackaged).
+//   - Call the store's deleteSession action and then poll
+//     `process.kill(pid, 0)` from the probe's node runtime — on Windows this
+//     uses OpenProcess under the hood, and throws ESRCH once the child is
+//     gone. If it still responds after 3 seconds we fail.
+//
+// If claude.exe is not installed/resolvable in this environment we exit 0
+// with a SKIP banner — running this probe in CI without the binary should
+// not fail the matrix, and dev machines always have it.
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { appWindow } from './probe-utils.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function fail(msg, app) {
+  console.error(`\n[probe-e2e-delete-session-kills-process] FAIL: ${msg}`);
+  if (app) app.close().catch(() => {});
+  process.exit(1);
+}
+
+function skip(msg) {
+  console.log(`\n[probe-e2e-delete-session-kills-process] SKIP: ${msg}`);
+  process.exit(0);
+}
+
+function isPidAlive(pid) {
+  if (!pid || pid <= 0) return false;
+  try {
+    // Signal 0 is a liveness check on POSIX; on Windows Node maps it to
+    // OpenProcess + check status. Throws on dead / missing process.
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agentory-probe-delete-'));
+console.log(`[probe-e2e-delete-session-kills-process] userData = ${userDataDir}`);
+
+const app = await electron.launch({
+  args: ['.', `--user-data-dir=${userDataDir}`],
+  cwd: root,
+  // AGENTORY_PROD_BUNDLE=1 routes main.ts to load the built renderer from
+  // dist/renderer instead of webpack-dev-server on :4100 — lets this probe
+  // run without a live `npm run dev:web` in the background.
+  env: { ...process.env, NODE_ENV: 'development', AGENTORY_PROD_BUNDLE: '1' }
+});
+
+try {
+  const win = await appWindow(app);
+  await win.waitForLoadState('domcontentloaded');
+  await win.waitForFunction(() => !!window.__agentoryStore && !!window.agentory, null, {
+    timeout: 15_000
+  });
+
+  // Seed a real session with a cwd that actually exists on disk so
+  // `agent:start` in main.ts doesn't bounce us with CWD_MISSING.
+  const cwd = root;
+  const sessionId = 's-delete-probe';
+  await win.evaluate(
+    ({ sid, cwd }) => {
+      const store = window.__agentoryStore;
+      store.setState({
+        groups: [{ id: 'g1', name: 'G1', collapsed: false, kind: 'normal' }],
+        sessions: [
+          {
+            id: sid,
+            name: 'delete-probe',
+            state: 'idle',
+            cwd,
+            model: 'claude-sonnet-4',
+            groupId: 'g1',
+            agentType: 'claude-code'
+          }
+        ],
+        activeId: sid,
+        messagesBySession: { [sid]: [] },
+        startedSessions: {},
+        runningSessions: {}
+      });
+    },
+    { sid: sessionId, cwd }
+  );
+
+  // Kick off the real agent spawn through the live IPC bridge.
+  const startRes = await win.evaluate(
+    async ({ sid, cwd }) =>
+      await window.agentory.agentStart(sid, {
+        cwd,
+        permissionMode: 'default'
+      }),
+    { sid: sessionId, cwd }
+  );
+  if (!startRes || startRes.ok !== true) {
+    // CLAUDE_NOT_FOUND → treat as skip (no binary on this host).
+    if (startRes && startRes.errorCode === 'CLAUDE_NOT_FOUND') {
+      skip(`claude CLI not resolvable on PATH; cannot verify subprocess lifecycle (${startRes.error})`);
+    }
+    fail(`agentStart failed: ${JSON.stringify(startRes)}`, app);
+  }
+
+  // Flip started/running in the store so deleteSession actually dispatches
+  // agentClose (it short-circuits for never-spawned sessions).
+  await win.evaluate((sid) => {
+    const st = window.__agentoryStore.getState();
+    st.markStarted(sid);
+    st.setRunning(sid, true);
+  }, sessionId);
+
+  // Grab the child pid via the main-process debug backdoor. Poll briefly
+  // because claude.exe's spawn-through-cmd-shim path on Windows has a tiny
+  // lag between agentStart resolving and the pid becoming readable.
+  let pid = null;
+  for (let i = 0; i < 30; i++) {
+    const pids = await app.evaluate(() => {
+      const dbg = globalThis.__agentoryDebug;
+      return dbg ? dbg.activeSessionPids() : null;
+    });
+    if (!pids) fail('globalThis.__agentoryDebug missing in main process', app);
+    const row = pids.find((r) => r.sessionId === sessionId);
+    if (row && typeof row.pid === 'number') {
+      pid = row.pid;
+      break;
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  if (!pid) fail('never observed a pid for the spawned session', app);
+  console.log(`[probe-e2e-delete-session-kills-process] live pid = ${pid}`);
+
+  if (!isPidAlive(pid)) {
+    fail(`reported pid ${pid} was already dead before delete — spawner smoke failed`, app);
+  }
+
+  // Trigger the store's deleteSession — the path under test. This should
+  // dispatch window.agentory.agentClose(sid) as a side effect.
+  await win.evaluate((sid) => {
+    window.__agentoryStore.getState().deleteSession(sid);
+  }, sessionId);
+
+  // Poll for the pid to go away. The spawner escalates SIGTERM → SIGKILL
+  // after killGracePeriodMs (default 5s), but a soft interrupt usually lands
+  // within a second.
+  const deadline = Date.now() + 8_000;
+  let dead = false;
+  while (Date.now() < deadline) {
+    if (!isPidAlive(pid)) {
+      dead = true;
+      break;
+    }
+    await new Promise((r) => setTimeout(r, 150));
+  }
+  if (!dead) {
+    fail(`pid ${pid} still alive 8s after deleteSession — zombie regression`, app);
+  }
+
+  // Double-check the main-process map also forgot the runner.
+  const remaining = await app.evaluate(() => {
+    const dbg = globalThis.__agentoryDebug;
+    return dbg ? dbg.activeSessionCount() : -1;
+  });
+  if (remaining !== 0) {
+    fail(`activeSessionCount=${remaining} after deleteSession; expected 0`, app);
+  }
+
+  console.log('\n[probe-e2e-delete-session-kills-process] OK');
+  console.log(`  spawned claude pid=${pid} killed within 8s of deleteSession`);
+  console.log('  activeSessionCount went to 0');
+
+  await app.close();
+} catch (err) {
+  console.error('[probe-e2e-delete-session-kills-process] threw:', err);
+  await app.close().catch(() => {});
+  process.exit(1);
+} finally {
+  fs.rmSync(userDataDir, { recursive: true, force: true });
+}

--- a/src/agent/lifecycle.ts
+++ b/src/agent/lifecycle.ts
@@ -24,6 +24,17 @@ function streamerFor(sessionId: string): PartialAssistantStreamer {
   return s;
 }
 
+/**
+ * Drop the streamer accumulator for a session. Called from deleteSession() so
+ * a deleted session doesn't leave its partial-assistant-streamer state hanging
+ * around forever (tiny leak, but piles up on sessions that never emit a final
+ * `result` frame — e.g. force-killed via delete). Idempotent.
+ */
+export function disposeStreamer(sessionId: string): void {
+  streamers.delete(sessionId);
+  turnStartedAt.delete(sessionId);
+}
+
 type BackgroundWaitingHandler = (info: { sessionId: string; sessionName: string; prompt: string }) => void;
 let backgroundWaitingHandler: BackgroundWaitingHandler = () => {};
 

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -5,6 +5,7 @@ import { loadPersisted, schedulePersist, type PersistedState } from './persist';
 import { hydrateDrafts, deleteDrafts, snapshotDraft, restoreDraft } from './drafts';
 import { i18next } from '../i18n';
 import type { ConnectionInfo } from '../shared/ipc-types';
+import { disposeStreamer } from '../agent/lifecycle';
 
 // Resolve the localized default-group name with a hard-coded English fallback
 // so non-renderer call paths (tests, eager hydration before initI18n runs)
@@ -704,6 +705,22 @@ export const useStore = create<State & Actions>((set, get) => ({
       stats: prev.statsBySession[id],
       prevActiveId: prev.activeId
     };
+    // Kill the spawned claude.exe BEFORE we clear store state. Without this,
+    // deleting an actively-streaming session leaves a zombie child that
+    // keeps burning tokens and whose stream events land on a removed id
+    // (noisy warns + memory growth until the user quits the app). The IPC
+    // is fire-and-forget because the cleanup in main.ts is synchronous from
+    // our POV — it returns before the child fully exits, but the abort
+    // signal has already fired by then. Guarded on `started || running` to
+    // avoid a no-op round-trip for never-spawned sessions (restored ones).
+    if (prev.startedSessions[id] || prev.runningSessions[id]) {
+      void window.agentory?.agentClose(id);
+    }
+    // Drop the renderer-side streamer accumulator. Without this, a deleted
+    // session's PartialAssistantStreamer lingers in the lifecycle module map
+    // — a tiny leak per delete, but adds up on long-running users who churn
+    // sessions. Idempotent on never-streamed ids.
+    disposeStreamer(id);
     set((s) => {
       const remaining = s.sessions.filter((x) => x.id !== id);
       // Same-group sibling fallback (J5): when the active row is being

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -825,7 +825,13 @@ describe('store: createSession auto-creates default group when none usable', () 
 describe('store: restoreSession round-trip', () => {
   beforeEach(() => {
     (globalThis as unknown as { window?: { agentory?: unknown } }).window = {
-      agentory: { saveMessages: vi.fn().mockResolvedValue(undefined) }
+      agentory: {
+        saveMessages: vi.fn().mockResolvedValue(undefined),
+        // deleteSession fires agent:close over IPC when the session had a
+        // live child. Stubbed as a no-op here — the unit test cares about
+        // store-state transitions, not whether main.ts tore down a pid.
+        agentClose: vi.fn().mockResolvedValue(true)
+      }
     };
   });
 


### PR DESCRIPTION
Worker D findings — kills zombie claude.exe, stops stdio leaks, surfaces silent RPC failures, and adds two subprocess E2E probes.

## Findings addressed

### Critical
1. **deleteSession leaves zombie claude.exe** (store.ts / lifecycle.ts)
   - `deleteSession` now dispatches `window.agentory.agentClose(id)` when the session had a live child (guarded on `started || running`).
   - New `disposeStreamer(id)` in `src/agent/lifecycle.ts` clears the renderer-side `PartialAssistantStreamer` accumulator so deleted ids stop leaking.
2. **stdout/stderr listeners outlive consumer** (sessions.ts)
   - `cleanupAfterExit()` now `removeAllListeners()` then `destroy()`s stdout/stderr/stdin; post-exit `data` bursts can no longer re-invoke a nulled consumer.
3. **minimize-to-tray / close races session cleanup** (main.ts, manager.ts)
   - `bindSender` now swallows a destroyed-wc send instead of throwing into the sessions event loop.
   - New `sessions.rebindSender(wc)` is called on window `show` and `did-finish-load` so sessions that outlive a hide→reshow cycle route into the live renderer.
   - `app.before-quit` now calls `sessions.closeAll()` (belt-and-suspenders for the tray→Quit / macOS paths where `window-all-closed` doesn't fire in the same order).

### Strong
4. **initialize handshake fire-and-forget** (sessions.ts)
   - On failure (while not disposed) emits an `agent:diagnostic` event with code `init_failed` so the renderer can toast — lost handshake silently falls back to the CLI's local rule engine, which is security-relevant for permission prompts.
5. **stale bindSender after hide/reshow** (manager.ts / main.ts) — see #3.
6. **binary-resolver stream error listeners** (binary-resolver.ts)
   - Added no-op `error` listeners on child stdout/stderr in both `findClaudeOnPath` (`runLookup`) and `detectClaudeVersion`. Prevents main-process crashes on EPIPE / child-died-early races.

### Nit
7. **control-rpc outbound timeout silent** (sessions.ts)
   - interrupt / setPermissionMode / setModel now emit `warn`-level `agent:diagnostic` events alongside the existing swallow so a no-op Stop click or unresponsive model swap is explainable.
8. Covered by #6.
9. **messageQueues not cleared on deleteSession** — already cleared in prior code; confirmed by test.

## New E2E probes
- `scripts/probe-e2e-delete-session-kills-process.mjs` — spawns real claude.exe, captures pid via the dev-only `globalThis.__agentoryDebug` backdoor, deletes the session, polls `process.kill(pid, 0)` until ESRCH (8s budget).
- `scripts/probe-e2e-close-window-aborts-sessions.mjs` — same spawn + pid capture, then `app.quit()` and polls the pid from the probe's own runtime.

Both skip with exit 0 when claude isn't resolvable on PATH.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean for diffed files (2 pre-existing errors in `electron/main.ts:99` and `src/components/SidebarResizer.tsx:40` unrelated to this PR)
- [x] `npm test` — 570/570 green (rebuild better-sqlite3 for Node first)
- [x] `node scripts/probe-e2e-delete-session-kills-process.mjs` — OK (killed real pid within 8s)
- [x] `node scripts/probe-e2e-close-window-aborts-sessions.mjs` — OK (pid gone after app.quit)
- [x] `node scripts/probe-e2e-empty-group-new-session.mjs` — OK
- [x] `node scripts/probe-e2e-restore-session-undo.mjs` — OK
- [x] `node scripts/probe-e2e-restore-group-undo.mjs` — OK

Note: the new `agent:diagnostic` event is emitted on the main side; wiring the renderer listener + toast component is Worker E / follow-up work (preload + global.d.ts + src/components are out of this PR's scope).

CI is blocked on the org-level GitHub Actions billing pause; local green confirmed against the same gates the workflow runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)