### PR TITLE
fix(cwd-popover): show full recent list on open, move cwd to placeholder

### DIFF
--- a/scripts/probe-e2e-cwd-popover-recent-unfiltered.mjs
+++ b/scripts/probe-e2e-cwd-popover-recent-unfiltered.mjs
@@ -1,0 +1,166 @@
+// Regression probe: opening the StatusBar cwd popover must show the FULL
+// Recent list, regardless of the active session's current cwd.
+//
+// Bug (pre-fix): `CwdPopover` seeded its query input with the current cwd
+// AND ran filtering against that query, so opening the popover instantly
+// collapsed Recent down to entries whose path contained the current cwd
+// substring (often just the one entry equal to the current cwd).
+//
+// Fix: query starts empty on every open; the current cwd is shown as the
+// input's placeholder so users still see "where am I" without it acting
+// as a filter.
+//
+// Strategy:
+//   1. Override the `import:recentCwds` IPC handler to return a known list
+//      of 3 distinct paths.
+//   2. Seed the renderer store with one session whose cwd matches the FIRST
+//      recent entry — this is the worst case for the bug (the seeded query
+//      would have matched exactly one item).
+//   3. Click the cwd chip → assert dialog open + 3 options visible.
+//   4. Type a substring matching ONE entry → assert it filters to 1.
+//   5. Clear the input → assert all 3 visible again.
+//
+// Pre-fix verification (manual): change `useState('')` back to `useState(cwd)`
+// in `src/components/CwdPopover.tsx:75` and rerun — step 3 will fail because
+// only the matching entry is shown.
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { appWindow, seedStore } from './probe-utils.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function fail(msg) {
+  console.error(`\n[probe-e2e-cwd-popover-recent-unfiltered] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+// Use POSIX-style paths so the substring "bar" assertion is unambiguous on
+// any host. The popover treats paths as opaque strings so this is safe.
+const RECENT = ['/proj/foo', '/work/bar', '/code/baz'];
+const ACTIVE_CWD = RECENT[0];
+
+const app = await electron.launch({
+  args: ['.'],
+  cwd: root,
+  env: { ...process.env, NODE_ENV: 'development' }
+});
+const win = await appWindow(app);
+await win.waitForLoadState('domcontentloaded');
+await win.waitForFunction(() => !!window.__agentoryStore, null, { timeout: 15_000 });
+
+// Replace the IPC handler so `defaultLoadRecent` returns our fixture.
+await app.evaluate(async ({ ipcMain }, list) => {
+  try { ipcMain.removeHandler('import:recentCwds'); } catch {}
+  ipcMain.handle('import:recentCwds', () => list);
+}, RECENT);
+
+// Sanity-check the override took effect (renderer side).
+const ipcReturn = await win.evaluate(async () => {
+  return await window.agentory.recentCwds();
+});
+if (!Array.isArray(ipcReturn) || ipcReturn.length !== RECENT.length) {
+  await app.close();
+  fail(`IPC override failed: expected ${RECENT.length} entries, got ${JSON.stringify(ipcReturn)}`);
+}
+
+// Seed a single normal group + session with the active cwd.
+await seedStore(win, {
+  groups: [{ id: 'g1', name: 'Sessions', collapsed: false, kind: 'normal' }],
+  sessions: [{
+    id: 's1',
+    groupId: 'g1',
+    name: 'Test',
+    state: 'idle',
+    cwd: ACTIVE_CWD,
+    cwdMissing: false,
+    model: 'claude-sonnet-4-5',
+    agentType: 'claude-code'
+  }],
+  activeId: 's1',
+  tutorialSeen: true
+});
+
+// Find and click the cwd chip. CwdPopover's trigger has `data-cwd-chip`.
+const trigger = win.locator('[data-cwd-chip]').first();
+await trigger.waitFor({ state: 'visible', timeout: 10_000 });
+await trigger.click();
+
+const dialog = win.getByRole('dialog');
+await dialog.waitFor({ state: 'visible', timeout: 5_000 });
+
+// Wait for the loadRecent promise to resolve and options to render.
+// Scope the option count to the dialog so other listboxes (e.g. Radix
+// dropdowns elsewhere on the StatusBar) can't pollute the count.
+await win.waitForFunction(
+  (expected) => {
+    const dlg = document.querySelector('[role="dialog"]');
+    if (!dlg) return false;
+    return dlg.querySelectorAll('[role="option"]').length === expected;
+  },
+  RECENT.length,
+  { timeout: 5_000 }
+).catch(async () => {
+  const count = await dialog.locator('[role="option"]').count();
+  const texts = await dialog.locator('[role="option"]').allTextContents();
+  await app.close();
+  fail(`expected ${RECENT.length} recent options on open, got ${count}: ${JSON.stringify(texts)}`);
+});
+
+// Verify each fixture path is rendered (truncateMiddle keeps short paths intact).
+for (const p of RECENT) {
+  const found = await dialog.locator('[role="option"]').filter({ hasText: p }).count();
+  if (found === 0) { await app.close(); fail(`recent entry "${p}" not visible on open`); }
+}
+
+// Verify the input is empty and shows the cwd as placeholder.
+const input = dialog.getByRole('textbox');
+const initialValue = await input.inputValue();
+if (initialValue !== '') { await app.close(); fail(`input value should be empty on open, got "${initialValue}"`); }
+const placeholder = await input.getAttribute('placeholder');
+if (!placeholder || !placeholder.includes('foo')) {
+  await app.close();
+  fail(`expected placeholder to surface current cwd "${ACTIVE_CWD}", got "${placeholder}"`);
+}
+
+// Type "bar" → expect 1 option.
+await input.fill('bar');
+await win.waitForFunction(
+  () => {
+    const dlg = document.querySelector('[role="dialog"]');
+    return dlg && dlg.querySelectorAll('[role="option"]').length === 1;
+  },
+  null,
+  { timeout: 3_000 }
+).catch(async () => {
+  const count = await dialog.locator('[role="option"]').count();
+  await app.close();
+  fail(`typing "bar" should filter to 1 option, got ${count}`);
+});
+const filteredText = await dialog.locator('[role="option"]').first().textContent();
+if (!filteredText || !filteredText.includes('bar')) {
+  await app.close();
+  fail(`filtered option should contain "bar", got "${filteredText}"`);
+}
+
+// Clear → expect all 3 again.
+await input.fill('');
+await win.waitForFunction(
+  (expected) => {
+    const dlg = document.querySelector('[role="dialog"]');
+    return dlg && dlg.querySelectorAll('[role="option"]').length === expected;
+  },
+  RECENT.length,
+  { timeout: 3_000 }
+).catch(async () => {
+  const count = await dialog.locator('[role="option"]').count();
+  await app.close();
+  fail(`clearing input should restore all ${RECENT.length} options, got ${count}`);
+});
+
+console.log('\n[probe-e2e-cwd-popover-recent-unfiltered] OK');
+console.log(`  open with active cwd "${ACTIVE_CWD}" → all ${RECENT.length} recent visible`);
+console.log('  type "bar" → filters to 1; clear → restores 3');
+console.log('  input value empty on open; placeholder surfaces current cwd');
+await app.close();

--- a/src/components/CwdPopover.tsx
+++ b/src/components/CwdPopover.tsx
@@ -23,13 +23,15 @@ import { useTranslation } from '../i18n/useTranslation';
 //     The IPC is best-effort: if it fails or returns empty we render a
 //     friendly "no recent cwds" hint and still expose Browse.
 //   - Filtering is plain case-insensitive substring — no fuzzy match. The
-//     query input is seeded with the current cwd so users can edit a path
-//     fragment instead of starting from scratch.
+//     query input starts empty on every open so the Recent list is shown
+//     in full; the current cwd is surfaced as the input placeholder so
+//     users still see "where they are" without it acting as a filter
+//     (regression fix — see PR `fix(cwd-popover)`).
 
 const RECENT_LIMIT = 10;
 
 type Props = {
-  /** Current working directory. Used to label the trigger and seed the query. */
+  /** Current working directory. Used to label the trigger and shown as the input placeholder. */
   cwd: string;
   /** When true, show a dim ⚠ next to the trigger label and explain via tooltip. */
   cwdMissing?: boolean;
@@ -70,21 +72,21 @@ async function defaultLoadRecent(): Promise<string[]> {
 export function CwdPopover({ cwd, cwdMissing, loadRecent, onPick, onBrowse }: Props) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
-  const [query, setQuery] = useState(cwd);
+  const [query, setQuery] = useState('');
   const [recent, setRecent] = useState<string[]>([]);
   const [active, setActive] = useState(0);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const popRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
-  // Reset query each time we re-open so users can start from the current cwd.
+  // Reset query each time we re-open so the Recent list shows in full;
+  // the current cwd is surfaced as the input placeholder instead.
   useEffect(() => {
     if (!open) return;
-    setQuery(cwd);
+    setQuery('');
     setActive(0);
     const id = window.setTimeout(() => {
       inputRef.current?.focus();
-      inputRef.current?.select();
     }, 0);
     return () => window.clearTimeout(id);
   }, [open, cwd]);
@@ -219,7 +221,7 @@ export function CwdPopover({ cwd, cwdMissing, loadRecent, onPick, onBrowse }: Pr
               value={query}
               spellCheck={false}
               autoComplete="off"
-              placeholder={t('cwdPopover.placeholder')}
+              placeholder={cwd ? truncateMiddle(cwd, 48) : t('cwdPopover.placeholder')}
               onChange={(e) => {
                 setQuery(e.target.value);
                 setActive(0);

--- a/tests/cwd-popover.test.tsx
+++ b/tests/cwd-popover.test.tsx
@@ -46,22 +46,31 @@ describe('<CwdPopover />', () => {
     expect(screen.getByRole('button', { name: /agentory/i })).toBeInTheDocument();
   });
 
-  it('opens on click and lists recent cwds from loadRecent (filtered by seeded query)', async () => {
+  it('opens on click and lists ALL recent cwds (no seeded filter)', async () => {
     const { loadRecent } = renderPopover();
     await openPopover();
     expect(loadRecent).toHaveBeenCalled();
-    // The input is seeded with the current cwd, so only entries containing
-    // "agentory" should be visible — that's two of the four sample paths.
+    // Regression: the input must NOT be seeded with the current cwd, so the
+    // full Recent list is visible on open. (Previously seeding `cwd` filtered
+    // recent down to entries containing the current path substring.)
     await waitFor(() => {
       const options = screen.getAllByRole('option');
-      expect(options.length).toBe(2);
+      expect(options.length).toBe(SAMPLE.length);
     });
   });
 
-  it('clearing the input reveals every recent cwd', async () => {
+  it('shows the current cwd as the input placeholder on open', async () => {
     renderPopover();
     await openPopover();
-    const input = screen.getByPlaceholderText(/type to filter/i);
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveValue('');
+    expect((input as HTMLInputElement).placeholder).toContain('agentory');
+  });
+
+  it('clearing the input still shows every recent cwd', async () => {
+    renderPopover();
+    await openPopover();
+    const input = screen.getByRole('textbox');
     await act(async () => {
       fireEvent.change(input, { target: { value: '' } });
     });
@@ -73,8 +82,7 @@ describe('<CwdPopover />', () => {
   it('filters the recent list as the user types in the input', async () => {
     renderPopover();
     await openPopover();
-    const input = screen.getByPlaceholderText(/type to filter/i);
-    // Replace the seeded query with a substring matching only one entry.
+    const input = screen.getByRole('textbox');
     await act(async () => {
       fireEvent.change(input, { target: { value: 'cli' } });
     });
@@ -86,10 +94,6 @@ describe('<CwdPopover />', () => {
   it('clicking a recent entry calls onPick with the full path', async () => {
     const { onPick } = renderPopover();
     await openPopover();
-    const input = screen.getByPlaceholderText(/type to filter/i);
-    await act(async () => {
-      fireEvent.change(input, { target: { value: '' } });
-    });
     await waitFor(() => {
       expect(screen.getAllByRole('option').length).toBe(SAMPLE.length);
     });
@@ -128,7 +132,7 @@ describe('<CwdPopover />', () => {
   it('shows the empty hint when no recent path matches the query', async () => {
     renderPopover();
     await openPopover();
-    const input = screen.getByPlaceholderText(/type to filter/i);
+    const input = screen.getByRole('textbox');
     await act(async () => {
       fireEvent.change(input, { target: { value: 'zzz-no-match-zzz' } });
     });
@@ -139,11 +143,9 @@ describe('<CwdPopover />', () => {
   it('Enter on the input commits the highlighted recent entry', async () => {
     const { onPick } = renderPopover();
     await openPopover();
-    const input = screen.getByPlaceholderText(/type to filter/i);
-    // Clear the seeded query so the full list is shown, then arrow down once.
-    await act(async () => {
-      fireEvent.change(input, { target: { value: '' } });
-    });
+    const input = screen.getByRole('textbox');
+    // Query starts empty so the full list is shown; arrow down once to move
+    // off the first row.
     await waitFor(() => {
       expect(screen.getAllByRole('option').length).toBe(SAMPLE.length);
     });


### PR DESCRIPTION
## Summary
- `CwdPopover` was seeding its query input with the active session's cwd and filtering Recent against that query, so opening the popover collapsed Recent to entries containing the current path substring (often only the current cwd itself). User-reported regression on 2026-04-23.
- Initialize and re-open-seed `query` to `''` so Recent renders unfiltered. Surface the current cwd via the input's `placeholder` so users still see "where am I" without it acting as a filter.
- Update file header note + Props doc to reflect the new contract; update unit tests that asserted the buggy seeded-filter behavior; switch placeholder-based selectors to `role="textbox"` since the placeholder text is now path-dependent.
- New probe `scripts/probe-e2e-cwd-popover-recent-unfiltered.mjs` overrides the `import:recentCwds` IPC with a 3-path fixture, seeds an active session whose cwd matches one entry, and asserts the open popover shows all 3. Verified pre-fix the probe FAILS at the open step (got 1) and post-fix passes.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` clean (571/571 after rebuilding better-sqlite3 for Node)
- [x] `npx eslint` on diffed files clean
- [x] `node scripts/probe-e2e-cwd-popover-recent-unfiltered.mjs` passes (after `npx electron-rebuild -f -w better-sqlite3`)
- [x] Pre-fix verification: temporarily reverted `useState('')` to `useState(cwd)` (and matching re-open seed), confirmed probe failed with "expected 3 recent options on open, got 1: [\"/proj/foo\"]", then restored fix
- [x] Existing baseline probes still pass: `probe-e2e-empty-group-new-session.mjs`, `probe-e2e-no-sessions-landing.mjs`

## Notes for reviewer
- Tests file (`tests/cwd-popover.test.tsx`) was outside the originally-scoped diff but had to be updated because two existing tests asserted the now-removed buggy behavior ("filtered by seeded query") and four others queried the input via its old placeholder text. Selectors switched to `getByRole('textbox')` (only one textbox in the dialog).
- No new i18n strings introduced; existing `cwdPopover.placeholder` is still used as the fallback when `cwd` is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)