### PR TITLE
feat(shortcut): bind search to Cmd/Ctrl+F (was K)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Agentory does **not** make any HTTP calls to Anthropic itself. All API traffic g
 
 ### Shortcuts
 
-- `Cmd/Ctrl+K` — Search / Command Palette
+- `Cmd/Ctrl+F` — Search / Command Palette
 - `Cmd/Ctrl+,` — Settings
 - `Cmd/Ctrl+N` — New session
 - `Cmd/Ctrl+Shift+N` — New group

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -25,7 +25,7 @@ This file is the reconciliation table for what's actually implemented in agentor
 | better-sqlite3 persistence | 🟡 | `electron/db.ts` opens with WAL, single `app_state(key,value)` table; `db:load`/`db:save` IPC + preload bridge; renderer hydrates on boot, debounced 250ms write-back. Schema is a single JSON blob; structured schema is post-MVP. |
 | Claude Agent SDK integration | ✅ | Main process: `electron/agent/sessions.ts` (`SessionRunner` with streaming-input AsyncIterable) + `electron/agent/manager.ts` (singleton registry); IPC: `agent:start/send/interrupt/setPermissionMode/setModel/close/resolvePermission` + push events `agent:event` / `agent:exit` / `agent:permissionRequest`; preload + global.d.ts extended; API key injected into the SDK env in main process (never crosses renderer); ChatStream + InputBar consume real events; canUseTool round-trips through WaitingBlock. |
 | `~/.claude/projects/` import | ⬜ | |
-| Global shortcut registration | ✅ | `App.tsx` registers Cmd+K / Cmd+, / Cmd+B / Cmd+N (new session) / Cmd+Shift+N (new group). |
+| Global shortcut registration | ✅ | `App.tsx` registers Cmd+F / Cmd+, / Cmd+B / Cmd+N (new session) / Cmd+Shift+N (new group). |
 
 ## 2. Sidebar (`src/components/Sidebar.tsx`)
 
@@ -86,7 +86,7 @@ This file is the reconciliation table for what's actually implemented in agentor
 
 | Item | Status | Notes |
 |---|---|---|
-| Cmd+K to open | ✅ | App.tsx global keydown. |
+| Cmd+F to open | ✅ | App.tsx global keydown. |
 | Sessions / Groups / Commands tri-search | ✅ | Data from store; commands fully wired: New session / New group / Toggle sidebar / Open settings / Switch theme (cycles system→dark→light). |
 
 ## 8. Toast (`src/components/ui/Toast.tsx`)

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -406,7 +406,7 @@ div: h-7 px-4 flex items-center justify-between
 
 No background fill different from chat pane — only the top border separates it. Reads as part of the stream, not a control bar.
 
-### 7.7 Command palette (Cmd+K)
+### 7.7 Command palette (Cmd+F)
 
 ```
 Overlay: fixed inset-0 bg-black/40 backdrop-blur-[2px]

--- a/docs/mvp-design.md
+++ b/docs/mvp-design.md
@@ -31,7 +31,7 @@ In:
 4. Cross-repo sessions inside one group
 5. CLI-visual-style structured rendering of the conversation stream
 6. Import: scan `~/.claude/projects/` for historical sessions
-7. Global search / Command Palette (Cmd/Ctrl+K)
+7. Global search / Command Palette (Cmd/Ctrl+F)
 8. Settings (API key, data dir, theme, font, shortcuts, auto-update)
 9. Sidebar collapse
 10. Session right-click menu (rename + move-to-group + delete) — operate inline in the sidebar; no standalone Session header
@@ -71,7 +71,7 @@ Two-column layout, expandable tree on the left. Visually minimal: no section bor
 
 ```
 Agentory                    [«]
-[🔍 Search…            ⌘K]
+[🔍 Search…            ⌘F]
 [+  New Session]
 
 ▾ Group A                  [+]
@@ -90,7 +90,7 @@ Agentory                    [«]
 - **No section visuals**: no `border-t` / section header / background-color blocks. Hierarchy via weight + color + whitespace.
 - **Archive as a bottom pinned collapsible block**: positioned at the end of the nav, above Settings, collapsed by default. MVP does NOT ship a Deleted view (delete is a hard delete; soft-delete + Deleted view is post-MVP).
 - **High-frequency vs low-frequency action layering**:
-  - Top: Search (⌘K), New Session — daily.
+  - Top: Search (⌘F), New Session — daily.
   - In nav: group list, New group (quiet row, weekly).
   - Bottom: Archived Groups block, Settings — monthly or rarer.
 - **Group row**: chevron toggles collapse; `[+]` shows on hover at the right; collapsed group shows total session count.
@@ -125,7 +125,7 @@ Agentory                    [«]
 
 ## 6. Global search / Command Palette
 
-- Single entry: Cmd/Ctrl+K, or click the sidebar top search box.
+- Single entry: Cmd/Ctrl+F, or click the sidebar top search box.
 - Single popover, mixed results:
   - Sessions (fuzzy match on name, group, cwd)
   - Groups
@@ -194,7 +194,7 @@ bottom-right, auto-dismiss in 3s, max 3 stacked. Triggered by:
 
 ## 11. Shortcuts (MVP full set)
 
-- Cmd/Ctrl+K: Search / Command Palette
+- Cmd/Ctrl+F: Search / Command Palette
 - Cmd/Ctrl+,: Settings
 - Cmd/Ctrl+N: New session (in current group, or auto-create default group)
 - Cmd/Ctrl+Shift+N: New group
@@ -236,7 +236,7 @@ Not doing: custom shortcuts, vim mode, multi-chord.
 
 ```
 ┌──────────────────────────────────┬────────────────────────────────────────────────────────┐
-│ [«]  Search…              ⌘K     │                                                        │
+│ [«]  Search…              ⌘F     │                                                        │
 │ [+ New Session]                  │  > make the webhook handler async                       │
 │ ─────────────────────────────    │                                                        │
 │ ▾ Backend Refactor        [+]    │  ● Let me look at the current handler first.            │

--- a/scripts/probe-e2e-palette-empty.mjs
+++ b/scripts/probe-e2e-palette-empty.mjs
@@ -1,6 +1,6 @@
 // E2E: command palette empty state.
 //
-// When the user opens the palette (Cmd/Ctrl+K), it must show ONLY the search
+// When the user opens the palette (Cmd/Ctrl+F), it must show ONLY the search
 // input — no results list, no command suggestions. Results appear only after
 // the user types at least one non-whitespace character. Esc closes it.
 //
@@ -65,12 +65,12 @@ await win.evaluate(() => {
 });
 await win.waitForTimeout(200);
 
-// 1. Open palette via Cmd+K (Ctrl+K on Win/Linux). The App.tsx handler
+// 1. Open palette via Cmd+F (Ctrl+F on Win/Linux). The App.tsx handler
 //    listens on window 'keydown' with metaKey || ctrlKey, so synthesizing the
 //    DOM event is the closest analogue to a real keypress.
 await win.evaluate(() => {
   window.dispatchEvent(
-    new KeyboardEvent('keydown', { key: 'k', code: 'KeyK', ctrlKey: true, bubbles: true })
+    new KeyboardEvent('keydown', { key: 'f', code: 'KeyF', ctrlKey: true, bubbles: true })
   );
 });
 
@@ -78,7 +78,7 @@ await win.evaluate(() => {
 const searchInput = win.locator('input[placeholder*="Search"]');
 await searchInput.waitFor({ state: 'visible', timeout: 3000 }).catch(async () => {
   await app.close();
-  fail('palette did not open via Ctrl+K — search input never appeared');
+  fail('palette did not open via Ctrl+F — search input never appeared');
 });
 
 // 2. Empty state: NO option rows should be present INSIDE the palette. The
@@ -130,7 +130,7 @@ if (stillOpen) {
 }
 
 console.log('\n[probe-e2e-palette-empty] OK');
-console.log('  Ctrl+K opens palette');
+console.log('  Ctrl+F opens palette');
 console.log('  empty state: 0 options, "Type to search…" hint visible');
 console.log(`  typing "alpha" surfaces ${optionsAfterType} option(s) including "Alpha session"`);
 console.log('  Esc closes palette');

--- a/scripts/probe-e2e-palette-nav.mjs
+++ b/scripts/probe-e2e-palette-nav.mjs
@@ -1,6 +1,6 @@
 // E2E: command palette keyboard navigation.
 //
-// 1. Cmd/Ctrl+K opens the palette.
+// 1. Cmd/Ctrl+F opens the palette.
 // 2. After typing, ↓ moves the active row, ↑ moves it back.
 // 3. Enter on an active session row closes the palette AND selects that
 //    session (activeId in the store flips).
@@ -78,14 +78,14 @@ await win.waitForTimeout(200);
 // 1. Open palette via global shortcut.
 await win.evaluate(() => {
   window.dispatchEvent(
-    new KeyboardEvent('keydown', { key: 'k', code: 'KeyK', ctrlKey: true, bubbles: true })
+    new KeyboardEvent('keydown', { key: 'f', code: 'KeyF', ctrlKey: true, bubbles: true })
   );
 });
 
 const searchInput = win.locator('input[placeholder*="Search"]');
 await searchInput.waitFor({ state: 'visible', timeout: 3000 }).catch(async () => {
   await app.close();
-  fail('palette did not open via Ctrl+K');
+  fail('palette did not open via Ctrl+F');
 });
 
 // 2. Type "session bravo" and confirm Enter routes to bravo by checking
@@ -174,7 +174,7 @@ if (stillOpen) {
 }
 
 console.log('\n[probe-e2e-palette-nav] OK');
-console.log('  Ctrl+K opens palette');
+console.log('  Ctrl+F opens palette');
 console.log('  ArrowDown/ArrowUp move active row');
 console.log('  Enter on "session bravo" closes palette and sets activeId=s-nav-B');
 

--- a/scripts/probe-e2e-search-shortcut-f.mjs
+++ b/scripts/probe-e2e-search-shortcut-f.mjs
@@ -1,0 +1,93 @@
+// E2E: Search / Command Palette is bound to Cmd/Ctrl+F (was K).
+//
+// Asserts the rebind landed correctly:
+//  1. Ctrl+F (Cmd+F on darwin) opens the palette — the search input becomes
+//     visible.
+//  2. Ctrl+F again toggles the palette closed.
+//  3. Ctrl+K does NOT open the palette — that key is now unbound for the
+//     search action. (Our app doesn't register Ctrl+K for anything else;
+//     this guards against the old K binding being re-added accidentally.)
+//
+// Loads the freshly-built `dist/renderer/` via an isolated bundle server,
+// matching the pattern in `probe-e2e-settings-open.mjs`. This is critical:
+// pointing at a developer's running `npm run dev:web` would test STALE
+// pre-rebuild code and produce a confusing pass/fail.
+
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { appWindow, startBundleServer } from './probe-utils.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function fail(msg) {
+  console.error(`\n[probe-e2e-search-shortcut-f] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const { port: PORT, close: closeServer } = await startBundleServer(root);
+const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agentory-probe-shortcut-f-'));
+
+const app = await electron.launch({
+  args: ['.', `--user-data-dir=${userDataDir}`],
+  cwd: root,
+  env: { ...process.env, NODE_ENV: 'development', AGENTORY_DEV_PORT: String(PORT) }
+});
+
+let exitCode = 0;
+try {
+  const win = await appWindow(app);
+  await win.waitForLoadState('domcontentloaded');
+  await win.waitForFunction(() => !!window.__agentoryStore, null, { timeout: 15_000 });
+  await win.waitForTimeout(500);
+
+  // The search input is the only <input> the CommandPalette renders. Its
+  // placeholder comes from i18n (`commandPalette.searchPlaceholder`) — both
+  // en + zh start the visible string with "Search" / "搜索", so a generic
+  // selector wouldn't be locale-stable. We use the en string because the
+  // app boots with English on a fresh userData dir (no preferences yet).
+  const searchInput = win.locator('input[placeholder*="Search"]');
+
+  const accel = process.platform === 'darwin' ? 'Meta' : 'Control';
+
+  // 1. Cmd/Ctrl+F opens palette. App.tsx attaches the keydown listener on
+  // window, so any focus is fine — but we wait a beat for React to settle
+  // before pressing.
+  await win.keyboard.press(`${accel}+f`);
+  await searchInput.waitFor({ state: 'visible', timeout: 5000 }).catch(() => {
+    fail('palette did not open via Ctrl+F — search input never appeared');
+  });
+
+  // 2. Cmd/Ctrl+F again closes it (App.tsx toggles paletteOpen on each press).
+  // Press it on the input itself so the keydown reaches the global handler;
+  // the palette's internal handlers shouldn't swallow F.
+  await searchInput.focus();
+  await win.keyboard.press(`${accel}+f`);
+  await searchInput.waitFor({ state: 'hidden', timeout: 1500 }).catch(() => {
+    fail('palette did not close on second Ctrl+F (toggle broken)');
+  });
+
+  // 3. Cmd/Ctrl+K must NOT open the palette anymore.
+  await win.keyboard.press(`${accel}+k`);
+  await win.waitForTimeout(500);
+  const openedByK = await searchInput.isVisible().catch(() => false);
+  if (openedByK) {
+    fail('Ctrl+K opened the palette — the K binding for search should be removed');
+  }
+
+  console.log('\n[probe-e2e-search-shortcut-f] OK');
+  console.log('  Ctrl+F opens palette');
+  console.log('  Ctrl+F toggles it closed');
+  console.log('  Ctrl+K does NOT open palette');
+} catch (err) {
+  console.error(err);
+  exitCode = 1;
+} finally {
+  await app.close();
+  closeServer();
+  try { fs.rmSync(userDataDir, { recursive: true, force: true }); } catch {}
+}
+process.exit(exitCode);

--- a/scripts/probe-shortcuts.mjs
+++ b/scripts/probe-shortcuts.mjs
@@ -39,20 +39,20 @@ const result = await page.evaluate(async () => {
     out.checks.newGroupCreated = afterShiftN.groups.length === groupsBefore + 1;
     out.steps.push(`after Cmd+Shift+N: ${afterShiftN.groups.length} groups`);
 
-    // Cmd+K -> open command palette. The palette mounts a search input with
+    // Cmd+F -> open command palette. The palette mounts a search input with
     // the placeholder text from i18n; we use that as a reliable visibility
     // probe (Radix Dialog adds it as a portal under <body>, not <main>).
-    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', code: 'KeyK', ctrlKey: true, bubbles: true }));
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'f', code: 'KeyF', ctrlKey: true, bubbles: true }));
     await new Promise((r) => setTimeout(r, 150));
     const paletteInput = document.querySelector('input[placeholder*="Search"]');
-    out.checks.paletteOpenedByCmdK = !!paletteInput;
-    out.steps.push(`after Cmd+K: palette input ${paletteInput ? 'visible' : 'MISSING'}`);
+    out.checks.paletteOpenedByCmdF = !!paletteInput;
+    out.steps.push(`after Cmd+F: palette input ${paletteInput ? 'visible' : 'MISSING'}`);
 
-    // Cmd+K again should toggle the palette closed.
-    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', code: 'KeyK', ctrlKey: true, bubbles: true }));
+    // Cmd+F again should toggle the palette closed.
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'f', code: 'KeyF', ctrlKey: true, bubbles: true }));
     await new Promise((r) => setTimeout(r, 200));
     out.checks.paletteToggleClosed = !document.querySelector('input[placeholder*="Search"]');
-    out.steps.push(`after second Cmd+K: palette ${out.checks.paletteToggleClosed ? 'closed' : 'still open'}`);
+    out.steps.push(`after second Cmd+F: palette ${out.checks.paletteToggleClosed ? 'closed' : 'still open'}`);
 
     // Cmd+, -> open Settings dialog. Radix portals the dialog under <body>;
     // we look for the dialog title "Settings" rendered inside role=dialog.
@@ -118,7 +118,7 @@ await browser.close();
 const required = [
   'newSessionCreated',
   'newGroupCreated',
-  'paletteOpenedByCmdK',
+  'paletteOpenedByCmdF',
   'paletteToggleClosed',
   'settingsOpenedByCmdComma'
 ];

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -158,7 +158,10 @@ export default function App() {
       const mod = e.metaKey || e.ctrlKey;
       if (!mod) return;
       const k = e.key.toLowerCase();
-      if (k === 'k' && !e.shiftKey) {
+      if (k === 'f' && !e.shiftKey) {
+        // Cmd/Ctrl+F opens the global Search / Command Palette. We
+        // explicitly preventDefault so the browser/Electron's default
+        // find-in-page (when present) doesn't also fire.
         e.preventDefault();
         setPaletteOpen((p) => !p);
       } else if (k === 'b' && !e.shiftKey) {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -145,7 +145,7 @@ const en = {
     expandSidebarAria: 'Expand sidebar',
     newSessionTooltip: 'New session',
     newSessionAria: 'New session',
-    searchTooltip: 'Search  ⌘K',
+    searchTooltip: 'Search  ⌘F',
     searchAriaShort: 'Search',
     importTooltip: 'Import session',
     importAriaShort: 'Import session',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -140,7 +140,7 @@ const zh: EnCatalog = {
     expandSidebarAria: '展开侧边栏',
     newSessionTooltip: '新会话',
     newSessionAria: '新会话',
-    searchTooltip: '搜索  ⌘K',
+    searchTooltip: '搜索  ⌘F',
     searchAriaShort: '搜索',
     importTooltip: '导入会话',
     importAriaShort: '导入会话',


### PR DESCRIPTION
## Summary

Move the global Search / Command Palette accelerator from `Cmd/Ctrl+K` to `Cmd/Ctrl+F` per user request.

- `src/App.tsx` keydown handler now matches `f` (was `k`); still `preventDefault` to suppress Electron find-in-page.
- Tooltip strings (en + zh) and docs (README, STATUS, design-system, mvp-design) updated.
- Existing palette probes (`probe-e2e-palette-empty`, `probe-e2e-palette-nav`, `probe-shortcuts`) updated to dispatch `KeyF`.
- New probe `scripts/probe-e2e-search-shortcut-f.mjs` asserts Ctrl+F opens / toggles closed, and Ctrl+K does NOT open the palette.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 570 passing
- [x] `npm run lint` — only the 2 pre-existing errors (Electron / PointerEvent globals)
- [x] `node scripts/probe-e2e-search-shortcut-f.mjs` green (hermetic via `startBundleServer`)
- [ ] Manual: smoke-test Ctrl+F in dev electron