### PR TITLE
fix(question): dedupe AskUserQuestion blocks + correct answer routing

### DIFF
--- a/scripts/probe-e2e-askuserquestion-no-dup-and-resolves.mjs
+++ b/scripts/probe-e2e-askuserquestion-no-dup-and-resolves.mjs
@@ -1,0 +1,286 @@
+// E2E regression for Bugs A+B (2026-04-23 dogfood):
+//   A) `AskUserQuestion` rendered TWO question cards for one tool_use; the
+//      second card's buttons were disabled.
+//   B) Clicking Submit on the active card → runningSessions[sid] stuck true,
+//      no agent response, claude.exe exited with code=1 shortly after.
+//
+// Root cause: AskUserQuestion arrives via TWO renderer paths in the current
+// architecture:
+//   1. `lifecycle.onAgentPermissionRequest` (via can_use_tool control RPC)
+//      → block id `q-${requestId}`, carries `requestId`, routes submit
+//      through `agentResolvePermission(deny)` to release the can_use_tool
+//      promise so claude.exe can write back its synthetic tool_result.
+//   2. `streamEventToTranslation` for the assistant `tool_use` event
+//      → block id `${msgId}:tu${idx}`, carries `toolUseId` only.
+//
+// Both ids differ → `appendBlocks`'s id-based merge can't dedupe → 2 cards
+// render. Worse, only path-1 has the routing wire-up; if the user submits
+// on a path-2 block, the can_use_tool promise never settles → claude.exe
+// blocks indefinitely → exits with code 1 → UI stuck "running".
+//
+// Strategy: bypass real claude.exe by injecting fake `question` blocks via
+// `useStore.getState().appendBlocks` and stubbing `agentResolvePermission`
+// + `agentSend` IPC handlers on the main side. Verifies:
+//   * A duplicate dispatch (two question blocks sharing a join key) collapses
+//     to ONE rendered card AND ONE store entry.
+//   * Submitting that single card routes through `agentResolvePermission`
+//     EXACTLY ONCE (and `agentSend` exactly once for the answer text).
+//   * After the stubbed IPCs return, `runningSessions[sid]` is cleared
+//     (this probe simulates the lifecycle drop directly via setRunning so
+//     we don't need a live agent).
+
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { appWindow, isolatedUserData } from './probe-utils.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+const failures = [];
+function fail(j, msg) {
+  console.log(`[no-dup-resolves] FAIL  ${j}  — ${msg}`);
+  failures.push(`${j}: ${msg}`);
+}
+function pass(j, msg) {
+  console.log(`[no-dup-resolves] OK    ${j}  — ${msg}`);
+}
+
+const ud = isolatedUserData('agentory-probe-aq-nodup');
+const app = await electron.launch({
+  args: ['.', `--user-data-dir=${ud.dir}`],
+  cwd: root,
+  env: { ...process.env, AGENTORY_PROD_BUNDLE: '1' },
+});
+const win = await appWindow(app);
+const errors = [];
+win.on('pageerror', (e) => errors.push(`[pageerror] ${e.message}`));
+win.on('console', (m) => {
+  if (m.type() === 'error') errors.push(`[console.error] ${m.text()}`);
+});
+
+try {
+  await win.waitForLoadState('domcontentloaded');
+  await win.waitForFunction(
+    () => !!window.__agentoryStore && document.querySelector('aside') !== null,
+    null,
+    { timeout: 20_000 }
+  );
+  // Suppress the "Claude CLI missing" first-run dialog so it can't trap focus.
+  await win.evaluate(() => {
+    window.__agentoryStore.setState({
+      cliStatus: { state: 'found', binaryPath: '<probe-stub>', version: '2.1.0' },
+    });
+  });
+  await win.waitForTimeout(150);
+
+  // Install IPC capture stubs on main: replace the real handlers so we can
+  // count exactly how many times each fires WITHOUT spawning claude.exe.
+  await app.evaluate(({ ipcMain }) => {
+    if (!global.__probeNoDup) {
+      global.__probeNoDup = { resolved: [], sent: [] };
+    }
+    const cap = global.__probeNoDup;
+    cap.resolved.length = 0;
+    cap.sent.length = 0;
+    try { ipcMain.removeHandler('agent:resolvePermission'); } catch {}
+    ipcMain.handle('agent:resolvePermission', (_e, sessionId, requestId, decision) => {
+      cap.resolved.push({ sessionId, requestId, decision });
+      return true;
+    });
+    try { ipcMain.removeHandler('agent:send'); } catch {}
+    ipcMain.handle('agent:send', (_e, sessionId, text) => {
+      cap.sent.push({ sessionId, text });
+      return true;
+    });
+  });
+
+  const sessionId = await win.evaluate(() => {
+    const s = window.__agentoryStore.getState();
+    if (s.activeId && s.sessions.some((x) => x.id === s.activeId)) return s.activeId;
+    s.createSession({ name: 'no-dup probe' });
+    return window.__agentoryStore.getState().activeId;
+  });
+
+  // Mark session as running so we can verify it gets cleared after submit.
+  await win.evaluate((sid) => {
+    window.__agentoryStore.getState().setRunning(sid, true);
+  }, sessionId);
+
+  // ── J1: SAME `requestId` duplicate ──────────────────────────────────────
+  // Mirrors the "two appendBlocks for one logical question" crash mode.
+  const Q1 = [
+    { question: 'Pick a stack', options: [{ label: 'TypeScript' }, { label: 'Rust' }, { label: 'Go' }] },
+  ];
+  await win.evaluate(
+    ({ sid, q }) => {
+      const store = window.__agentoryStore.getState();
+      // First dispatch: the can_use_tool path emits a question block keyed
+      // by `q-${requestId}` and carries the `requestId` so submit can route
+      // through agentResolvePermission.
+      store.appendBlocks(sid, [
+        { kind: 'question', id: 'q-perm-J1', requestId: 'perm-J1', questions: q },
+      ]);
+      // Second dispatch with the SAME requestId — a duplicate would otherwise
+      // sail past the id-based merge if it happened to also pick a different id.
+      store.appendBlocks(sid, [
+        { kind: 'question', id: 'q-perm-J1-DUP', requestId: 'perm-J1', questions: q },
+      ]);
+    },
+    { sid: sessionId, q: Q1 }
+  );
+
+  await win.waitForSelector('[data-question-option]', { timeout: 5000 });
+  await win.waitForTimeout(150);
+
+  // Assertion: exactly ONE question card in DOM.
+  const cardCountJ1 = await win.evaluate(() => {
+    const opts = document.querySelectorAll('[data-question-option]');
+    // The QuestionBlock wraps each card in a div with role=group via Radix
+    // RadioGroup. Counting roving-focus groups is more reliable than guessing
+    // at the wrapper class. Fall back to counting Submit buttons if no groups.
+    const groups = document.querySelectorAll('[role="radiogroup"], [role="group"]');
+    return {
+      optsTotal: opts.length,
+      groupsTotal: groups.length,
+    };
+  });
+  if (cardCountJ1.groupsTotal !== 1) {
+    fail(
+      'J1',
+      `expected 1 question card (radiogroup/group) for one logical question, got ${cardCountJ1.groupsTotal} (opts=${cardCountJ1.optsTotal})`
+    );
+  } else {
+    pass('J1', `single card rendered for duplicate-dispatch with same requestId (groups=${cardCountJ1.groupsTotal}, opts=${cardCountJ1.optsTotal})`);
+  }
+
+  // Assertion: store has 1 question block.
+  const storeQCountJ1 = await win.evaluate((sid) => {
+    const blocks = window.__agentoryStore.getState().messagesBySession[sid] || [];
+    return blocks.filter((b) => b.kind === 'question').length;
+  }, sessionId);
+  if (storeQCountJ1 !== 1) {
+    fail('J1', `expected 1 question block in store, got ${storeQCountJ1}`);
+  } else {
+    pass('J1', 'store has exactly 1 question block after duplicate dispatch');
+  }
+
+  // ── Submit + verify resolve routing ────────────────────────────────────
+  // Default-pick is index 0 (TypeScript); click the SUBMIT button.
+  const submitBtn = win
+    .locator('div.relative', { has: win.locator('[data-question-option]') })
+    .last()
+    .locator('button')
+    .last();
+  if (await submitBtn.isDisabled()) {
+    fail('J1', 'Submit button disabled — block was rendered as read-only/duplicate');
+  } else {
+    await submitBtn.click();
+    await win.waitForTimeout(400);
+
+    const captured = await app.evaluate(() => ({
+      resolved: global.__probeNoDup.resolved.slice(),
+      sent: global.__probeNoDup.sent.slice(),
+    }));
+
+    // Expect exactly ONE resolve (deny on perm-J1) and ONE send (the answer text).
+    if (captured.resolved.length !== 1) {
+      fail('J1', `expected 1 agentResolvePermission call, got ${captured.resolved.length}: ${JSON.stringify(captured.resolved)}`);
+    } else if (captured.resolved[0].requestId !== 'perm-J1' || captured.resolved[0].decision !== 'deny') {
+      fail('J1', `wrong resolve payload: ${JSON.stringify(captured.resolved[0])}`);
+    } else {
+      pass('J1', 'submit fired exactly 1 agentResolvePermission(perm-J1, deny)');
+    }
+    if (captured.sent.length !== 1) {
+      fail('J1', `expected 1 agentSend call, got ${captured.sent.length}: ${JSON.stringify(captured.sent)}`);
+    } else if (!/TypeScript/.test(captured.sent[0].text || '')) {
+      fail('J1', `agentSend did not contain TypeScript: ${JSON.stringify(captured.sent[0])}`);
+    } else {
+      pass('J1', 'submit fired exactly 1 agentSend with the answer text');
+    }
+  }
+
+  // Simulate the lifecycle drop (would normally arrive via the `result` frame
+  // after claude.exe processes the resolve + answer round-trip).
+  await win.evaluate((sid) => {
+    window.__agentoryStore.getState().setRunning(sid, false);
+  }, sessionId);
+  const stillRunning = await win.evaluate((sid) => {
+    return !!window.__agentoryStore.getState().runningSessions[sid];
+  }, sessionId);
+  if (stillRunning) {
+    fail('J1', 'runningSessions[sid] still true after setRunning(false) — store regression');
+  } else {
+    pass('J1', 'runningSessions cleared (would clear naturally on real result frame)');
+  }
+
+  // ── J2: SAME `toolUseId` duplicate ─────────────────────────────────────
+  // Validates the other half of the dedupe predicate.
+  await win.evaluate((sid) => {
+    const store = window.__agentoryStore.getState();
+    store.clearMessages(sid);
+  }, sessionId);
+  await app.evaluate(() => {
+    global.__probeNoDup.resolved.length = 0;
+    global.__probeNoDup.sent.length = 0;
+  });
+  await win.waitForTimeout(120);
+
+  const Q2 = [
+    { question: 'Pick a build tool', options: [{ label: 'esbuild' }, { label: 'rollup' }] },
+  ];
+  await win.evaluate(
+    ({ sid, q }) => {
+      const store = window.__agentoryStore.getState();
+      // Two blocks with different ids but the SAME toolUseId — exactly
+      // what the assistant `tool_use` path would have emitted in addition
+      // to a (here-omitted) can_use_tool block, before the fix.
+      store.appendBlocks(sid, [
+        { kind: 'question', id: 'q-J2-A', toolUseId: 'tu-J2', questions: q },
+      ]);
+      store.appendBlocks(sid, [
+        { kind: 'question', id: 'q-J2-B', toolUseId: 'tu-J2', questions: q },
+      ]);
+    },
+    { sid: sessionId, q: Q2 }
+  );
+  await win.waitForSelector('[data-question-option]', { timeout: 5000 });
+  await win.waitForTimeout(150);
+
+  const groupsJ2 = await win.evaluate(() =>
+    document.querySelectorAll('[role="radiogroup"], [role="group"]').length
+  );
+  const storeQCountJ2 = await win.evaluate((sid) => {
+    const blocks = window.__agentoryStore.getState().messagesBySession[sid] || [];
+    return blocks.filter((b) => b.kind === 'question').length;
+  }, sessionId);
+  if (groupsJ2 !== 1) {
+    fail('J2', `expected 1 question card for same-toolUseId duplicate, got ${groupsJ2}`);
+  } else {
+    pass('J2', `single card rendered for duplicate-dispatch with same toolUseId`);
+  }
+  if (storeQCountJ2 !== 1) {
+    fail('J2', `expected 1 question block in store, got ${storeQCountJ2}`);
+  } else {
+    pass('J2', 'store has exactly 1 question block after toolUseId duplicate');
+  }
+} catch (e) {
+  fail('runner', `unhandled exception: ${e.message?.slice(0, 300)}`);
+} finally {
+  await app.close().catch(() => {});
+  ud.cleanup();
+}
+
+console.log('\n=== askuserquestion-no-dup-and-resolves summary ===');
+if (failures.length === 0) {
+  console.log('[no-dup-resolves] all assertions passed');
+  process.exit(0);
+} else {
+  console.log(`[no-dup-resolves] ${failures.length} failure(s):`);
+  for (const f of failures) console.log('  - ' + f);
+  if (errors.length > 0) {
+    console.log('\n--- console / page errors ---');
+    for (const e of errors.slice(-10)) console.log('  ' + e);
+  }
+  process.exit(1);
+}

--- a/src/agent/stream-to-blocks.ts
+++ b/src/agent/stream-to-blocks.ts
@@ -187,17 +187,33 @@ function assistantBlocks(msg: AssistantEvent): MessageBlock[] {
           todos: parseTodos(tu.input)
         });
       } else if (tu.name === 'AskUserQuestion') {
+        // Suppressed on purpose: every tool — including AskUserQuestion —
+        // is intercepted by `can_use_tool` first (we send
+        // `--permission-prompt-tool stdio` + the SDK-style `initialize`
+        // control request when starting claude.exe). That path has already
+        // appended a question block keyed by `requestId` via
+        // `permissionRequestToWaitingBlock` in lifecycle.ts, with the
+        // requestId wired so submit can resolve the pending permission
+        // promise on the main side.
+        //
+        // If we ALSO emitted a question block here, two cards would render
+        // for one logical AskUserQuestion: the second card has no
+        // requestId, so submitting it would route through `agentSend`
+        // (raw user message) instead of `agentResolvePermission`, leaving
+        // claude.exe blocked on a permission promise that never settles.
+        // claude.exe then exits with code 1 and the UI stays "running"
+        // forever waiting for a `result` frame that never arrives.
+        // (See feedback_bugfix_requires_e2e — Bugs A+B reported 2026-04-23.)
+        //
+        // We only fall back to a generic tool block when the input is so
+        // malformed that `parseQuestions` returns nothing AND the
+        // permission path also wouldn't have rendered a usable card —
+        // gives the user at least SOMETHING to inspect rather than a
+        // silent skip. The permission-path block in this case is a
+        // generic Allow/Reject prompt, which we keep too; the tool block
+        // here is purely diagnostic.
         const questions = parseQuestions(tu.input);
-        if (questions.length > 0) {
-          out.push({
-            kind: 'question',
-            id: `${baseId}:tu${toolIdx++}`,
-            toolUseId: tu.id,
-            questions
-          });
-        } else {
-          // Malformed AskUserQuestion input — fall back to a regular tool block
-          // so the user at least sees the raw payload instead of nothing.
+        if (questions.length === 0) {
           out.push({
             kind: 'tool',
             id: `${baseId}:tu${toolIdx++}`,
@@ -207,6 +223,11 @@ function assistantBlocks(msg: AssistantEvent): MessageBlock[] {
             expanded: false,
             input: tu.input
           });
+        } else {
+          // Skip the index bump-and-continue so subsequent tool_use blocks
+          // in the same message get sequential ids — they share the
+          // numbering namespace with this suppressed slot.
+          toolIdx++;
         }
       } else {
         out.push({

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -1086,16 +1086,53 @@ export const useStore = create<State & Actions>((set, get) => ({
       // Coalesce by id: if a block with the same id already exists (e.g. an
       // assistant text block built up by streaming deltas), replace it in
       // place with the finalized version rather than duplicating it.
+      //
+      // Defense-in-depth dedupe for AskUserQuestion: claude.exe surfaces the
+      // SAME logical question twice — once via `can_use_tool` (becomes a
+      // `question` block keyed by `q-${requestId}` carrying `requestId`) and
+      // once via the assistant `tool_use` event (would key by
+      // `${msgId}:tu${idx}` carrying `toolUseId`). Different ids, identical
+      // intent. The id-based merge above can't catch this because the keys
+      // differ. We additionally collapse a new `question` whose `toolUseId`
+      // matches one already present, OR whose `requestId` matches. The
+      // primary fix is to suppress the assistant-tool_use emission entirely
+      // (see `assistantBlocks` in `stream-to-blocks.ts`); this guard is
+      // belt-and-suspenders so a future regression — or a CLI version that
+      // bypasses can_use_tool for AskUserQuestion — never causes two cards
+      // to render and split the user's submit between two routing paths
+      // (one of which leaves claude.exe blocked on a permission promise
+      // that never settles, exits with code 1, and strands the UI in a
+      // perpetual "running" state).
       let next = prev;
       const toAppend: MessageBlock[] = [];
       for (const b of blocks) {
         const idx = next.findIndex((x) => x.id === b.id);
-        if (idx === -1) {
-          toAppend.push(b);
-        } else {
+        if (idx !== -1) {
           if (next === prev) next = prev.slice();
           next[idx] = b;
+          continue;
         }
+        if (b.kind === 'question') {
+          const dupIdx = next.findIndex((x) => {
+            if (x.kind !== 'question') return false;
+            const xTu = (x as { toolUseId?: string }).toolUseId;
+            const xReq = (x as { requestId?: string }).requestId;
+            const bTu = (b as { toolUseId?: string }).toolUseId;
+            const bReq = (b as { requestId?: string }).requestId;
+            if (xTu && bTu && xTu === bTu) return true;
+            if (xReq && bReq && xReq === bReq) return true;
+            return false;
+          });
+          if (dupIdx !== -1) {
+            // Keep the EXISTING block (it already carries any user state /
+            // requestId wiring) — drop the new one. Don't replace, because
+            // the can_use_tool path's block has the requestId we need for
+            // routing, and we want to preserve that even if the assistant-
+            // event block arrives later.
+            continue;
+          }
+        }
+        toAppend.push(b);
       }
       if (toAppend.length === 0 && next === prev) return s;
       const finalNext = toAppend.length > 0 ? [...next, ...toAppend] : next;

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -219,6 +219,67 @@ describe('store: messages + tool result wiring (PR G regression guard)', () => {
     useStore.getState().setToolResult('does-not-exist', 'toolu_001', 'x', false);
     expect(useStore.getState().messagesBySession['does-not-exist']).toBeUndefined();
   });
+
+  it('appendBlocks dedupes a second `question` block with the same toolUseId', () => {
+    // Bug A+B fix (2026-04-23): defense in depth. The PRIMARY fix is in
+    // stream-to-blocks.ts (suppress the assistant tool_use AskUserQuestion
+    // emission), but if anything ever lets two question blocks slip through
+    // for one logical question we must collapse them so submit only fires
+    // ONE round-trip — otherwise claude.exe is left blocked on a
+    // can_use_tool promise that never settles, exits with code 1, and the
+    // UI is stranded "running" forever.
+    useStore.getState().createSession('~/q');
+    const sid = useStore.getState().activeId;
+    useStore.getState().appendBlocks(sid, [
+      {
+        kind: 'question',
+        id: 'q-1',
+        toolUseId: 'tu-q-1',
+        questions: [{ question: 'Pick a stack', options: [{ label: 'TS' }, { label: 'Rust' }] }]
+      }
+    ]);
+    // Same logical question, different block id, same toolUseId — the
+    // assistant tool_use path used to emit this duplicate.
+    useStore.getState().appendBlocks(sid, [
+      {
+        kind: 'question',
+        id: 'q-2-different-id-same-toolUseId',
+        toolUseId: 'tu-q-1',
+        questions: [{ question: 'Pick a stack', options: [{ label: 'TS' }, { label: 'Rust' }] }]
+      }
+    ]);
+    const qBlocks = useStore
+      .getState()
+      .messagesBySession[sid].filter((b) => b.kind === 'question');
+    expect(qBlocks).toHaveLength(1);
+    expect(qBlocks[0].id).toBe('q-1');
+  });
+
+  it('appendBlocks dedupes a second `question` block with the same requestId', () => {
+    useStore.getState().createSession('~/q');
+    const sid = useStore.getState().activeId;
+    useStore.getState().appendBlocks(sid, [
+      {
+        kind: 'question',
+        id: 'q-perm-A',
+        requestId: 'perm-A',
+        questions: [{ question: 'Pick', options: [{ label: 'X' }] }]
+      }
+    ]);
+    useStore.getState().appendBlocks(sid, [
+      {
+        kind: 'question',
+        id: 'q-perm-A-dup',
+        requestId: 'perm-A',
+        questions: [{ question: 'Pick', options: [{ label: 'X' }] }]
+      }
+    ]);
+    const qBlocks = useStore
+      .getState()
+      .messagesBySession[sid].filter((b) => b.kind === 'question');
+    expect(qBlocks).toHaveLength(1);
+    expect(qBlocks[0].id).toBe('q-perm-A');
+  });
 });
 
 describe('store: resolvePermission', () => {

--- a/tests/stream-to-blocks.test.ts
+++ b/tests/stream-to-blocks.test.ts
@@ -134,7 +134,13 @@ describe('streamEventToTranslation', () => {
     });
   });
 
-  it('AskUserQuestion tool_use becomes a question block with parsed options', () => {
+  it('AskUserQuestion tool_use is suppressed (the can_use_tool path renders the question)', () => {
+    // Bug A+B fix (2026-04-23): every tool — including AskUserQuestion — is
+    // intercepted by the can_use_tool control RPC, which drives the
+    // permission/question render via lifecycle.permissionRequestToWaitingBlock.
+    // If we ALSO emitted a question block from the assistant tool_use, two
+    // cards would render for one logical question and the second card's
+    // submit would bypass agentResolvePermission, hanging claude.exe.
     const out = streamEventToTranslation(
       asEvent({
         type: 'assistant',
@@ -166,18 +172,7 @@ describe('streamEventToTranslation', () => {
         }
       })
     );
-    expect(out.append).toHaveLength(1);
-    const b = out.append[0] as {
-      kind: string;
-      toolUseId?: string;
-      questions?: Array<{ question: string; multiSelect?: boolean; options: Array<{ label: string }> }>;
-    };
-    expect(b.kind).toBe('question');
-    expect(b.toolUseId).toBe('tu-q1');
-    expect(b.questions).toHaveLength(1);
-    expect(b.questions![0].question).toBe('Pick a stack');
-    expect(b.questions![0].multiSelect).toBe(false);
-    expect(b.questions![0].options.map((o) => o.label)).toEqual(['TypeScript', 'Rust']);
+    expect(out.append).toHaveLength(0);
   });
 
   it('AskUserQuestion with malformed input falls back to a generic tool block', () => {


### PR DESCRIPTION
## Root cause

`AskUserQuestion` was rendering TWO question cards per tool_use because it arrives via two renderer paths in the current architecture:

1. **`lifecycle.onAgentPermissionRequest`** (via `can_use_tool` control RPC) — appends a `question` block keyed by `q-${requestId}`, carrying `requestId` so submit can route through `agentResolvePermission(deny)` to release the pending can_use_tool promise so claude.exe writes back its synthetic tool_result.
2. **`streamEventToTranslation`** for the assistant `tool_use` event — appends another `question` block keyed by `${msgId}:tu${idx}`, carrying `toolUseId` only.

Both ids differ, so `appendBlocks`'s id-based merge couldn't dedupe → 2 cards. Worse, only path-1 has the routing wire-up; clicking Submit on a path-2 card called `agentSend` (raw user message) instead of `agentResolvePermission`, leaving claude.exe blocked on a permission promise that never settled. claude.exe then exited with code 1 and the UI was stuck "running" forever waiting for a `result` frame that never arrived. That's both Bug A (duplicate card) and Bug B (stuck running) from the 2026-04-23 dogfood report.

## Fix

- **Root-cause fix** (`src/agent/stream-to-blocks.ts`): suppress the assistant `tool_use` AskUserQuestion path entirely — the can_use_tool path always renders the question. Falls back to a generic tool block ONLY when `parseQuestions` returns nothing (malformed input), so the user still sees the raw payload rather than a silent skip.
- **Defense in depth** (`src/stores/store.ts`): `appendBlocks` now collapses `question` blocks that share a `toolUseId` or `requestId` even when their ids differ. The existing block wins (it carries the routing wire-up).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` clean (572 pass)
- [x] New probe `probe-e2e-askuserquestion-no-dup-and-resolves.mjs` passes
- [x] Pre-fix verification: stashed the fix, re-ran the probe → 4 assertions fail (2 cards rendered, 2 store entries) for both same-requestId and same-toolUseId duplicate shapes. Restored fix → all 7 assertions pass.
- [x] Existing `probe-e2e-askuserquestion-full.mjs` (7 journeys) still green
- [x] `probe-e2e-empty-group-new-session.mjs` green
- [x] `probe-e2e-no-sessions-landing.mjs` green
- [x] Lint clean for diff

## Files

- `src/agent/stream-to-blocks.ts` — suppress duplicate question emission
- `src/stores/store.ts` — defense-in-depth dedupe in `appendBlocks`
- `tests/stream-to-blocks.test.ts` — updated AskUserQuestion expectation
- `tests/store.test.ts` — new dedupe unit tests
- `scripts/probe-e2e-askuserquestion-no-dup-and-resolves.mjs` — new e2e regression probe

🤖 Generated with [Claude Code](https://claude.com/claude-code)