### PR TITLE
chore(db): startup integrity check + safer parse + statement cache + size cap + schema versioning

### DIFF
--- a/electron/__tests__/db-hardening.test.ts
+++ b/electron/__tests__/db-hardening.test.ts
@@ -117,3 +117,75 @@ describe('db hardening: prepared statement cache', () => {
     spy.mockRestore();
   });
 });
+
+describe('db hardening: db:save size cap validation', () => {
+  // We test the validator directly rather than booting the IPC handler:
+  // the handler in main.ts is registered inside `app.whenReady` and gated
+  // by `fromMainFrame(e)`, neither of which is reachable from a Vitest
+  // process. The validator is the entire decision surface — once it
+  // returns `{ok:true}`, the handler unconditionally writes via
+  // `saveState`, which already has end-to-end coverage in db.test.ts.
+  it('rejects values larger than 1 MB with value_too_large', async () => {
+    const { validateSaveStateInput, MAX_STATE_VALUE_BYTES } = await import('../db-validate');
+    // One byte past the cap — boundary should be exclusive of the cap.
+    const oversize = 'x'.repeat(MAX_STATE_VALUE_BYTES + 1);
+    expect(validateSaveStateInput('appPersist', oversize)).toEqual({
+      ok: false,
+      error: 'value_too_large'
+    });
+  });
+
+  it('rejects keys longer than 128 chars with invalid_key', async () => {
+    const { validateSaveStateInput, MAX_STATE_KEY_LEN } = await import('../db-validate');
+    const tooLong = 'k'.repeat(MAX_STATE_KEY_LEN + 1);
+    expect(validateSaveStateInput(tooLong, 'value')).toEqual({
+      ok: false,
+      error: 'invalid_key'
+    });
+    // Empty string also rejected — the row's PRIMARY KEY can't be ''.
+    expect(validateSaveStateInput('', 'value')).toEqual({
+      ok: false,
+      error: 'invalid_key'
+    });
+  });
+
+  it('accepts a valid key/value pair', async () => {
+    const { validateSaveStateInput, MAX_STATE_VALUE_BYTES, MAX_STATE_KEY_LEN } = await import(
+      '../db-validate'
+    );
+    expect(validateSaveStateInput('appPersist', JSON.stringify({ a: 1 }))).toEqual({ ok: true });
+    // Exactly at the cap is allowed (cap is inclusive on accept side).
+    const atCap = 'x'.repeat(MAX_STATE_VALUE_BYTES);
+    expect(validateSaveStateInput('k', atCap)).toEqual({ ok: true });
+    const maxKey = 'k'.repeat(MAX_STATE_KEY_LEN);
+    expect(validateSaveStateInput(maxKey, 'v')).toEqual({ ok: true });
+  });
+});
+
+describe('db hardening: preload re-throws on {ok:false}', () => {
+  // Regression for the silent-data-loss bug: the IPC handler returns a
+  // resolved `{ok:false}` on oversize, but the renderer-side persister
+  // uses `.catch(onPersistError)`, which only fires on Promise REJECTION.
+  // The preload wrapper must convert `{ok:false}` into a thrown Error so
+  // the existing `.catch` handlers fire and the user actually sees the
+  // failure (instead of silently losing the snapshot).
+  it('preload saveState wrapper throws when handler returns {ok:false}', async () => {
+    // Replicate the wrapper in isolation — importing electron/preload.ts
+    // pulls in `contextBridge`/`ipcRenderer` which aren't available
+    // outside a renderer process, so we rebuild the same shape here.
+    async function saveStateWrapper(
+      invoke: () => Promise<{ ok: true } | { ok: false; error: string }>
+    ): Promise<void> {
+      const result = await invoke();
+      if (!result.ok) {
+        throw new Error(result.error);
+      }
+    }
+
+    await expect(
+      saveStateWrapper(async () => ({ ok: false, error: 'value_too_large' }))
+    ).rejects.toThrow('value_too_large');
+
+    await expect(saveStateWrapper(async () => ({ ok: true }))).resolves.toBeUndefined();
+  });
+});

--- a/electron/__tests__/db-hardening.test.ts
+++ b/electron/__tests__/db-hardening.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+
+// Mirror db.test.ts: redirect electron's userData to a per-test tmp dir so
+// (a) we never touch the real app data and (b) each test gets a clean slate.
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agentory-db-hardening-'));
+let tmpDir = tmpRoot;
+
+vi.mock('electron', () => ({
+  app: { getPath: () => tmpDir }
+}));
+
+async function freshDb() {
+  const mod = await import('../db');
+  mod.closeDb();
+  tmpDir = fs.mkdtempSync(path.join(tmpRoot, 'run-'));
+  return mod;
+}
+
+beforeEach(async () => {
+  await freshDb();
+});
+
+describe('db hardening: corrupt JSON in messages', () => {
+  it('loadMessages skips a row whose content is not valid JSON', async () => {
+    const mod = await freshDb();
+    const { saveMessages, loadMessages, getDb } = mod;
+
+    saveMessages('s-1', [
+      { id: 'b1', kind: 'user', text: 'good before' },
+      { id: 'b2', kind: 'user', text: 'good after' }
+    ]);
+
+    // Inject corruption directly into the row that already exists. Bypasses
+    // the cached prepared statements so we know loadMessages re-reads the
+    // raw column on each call.
+    getDb().prepare('UPDATE messages SET content = ? WHERE id = ?').run('{not valid json', 'b1');
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    let rows: unknown[] = [];
+    expect(() => {
+      rows = loadMessages('s-1');
+    }).not.toThrow();
+    expect(rows).toHaveLength(1);
+    expect((rows[0] as { id: string }).id).toBe('b2');
+    expect(warn).toHaveBeenCalledWith(
+      '[db] corrupt message row sessionId=%s id=%s',
+      's-1',
+      'b1'
+    );
+    warn.mockRestore();
+  });
+});
+
+describe('db hardening: startup integrity check', () => {
+  it('initDb backs up a corrupt file and opens a fresh empty database', async () => {
+    const mod = await freshDb();
+    mod.closeDb();
+
+    // Pre-seed the userData dir with a garbage file under the canonical
+    // name. SQLite will accept the open() (it's lazy) but the first pragma
+    // call inside ensureHealthyDb() will report corruption.
+    const file = path.join(tmpDir, 'agentory.db');
+    fs.writeFileSync(file, Buffer.from('not a sqlite database, just bytes'));
+
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { initDb, loadMessages, saveState, loadState } = mod;
+    expect(() => initDb()).not.toThrow();
+
+    // Original file got renamed aside.
+    const siblings = fs.readdirSync(tmpDir);
+    const backup = siblings.find((n) => n.startsWith('agentory.db.corrupt-'));
+    expect(backup, `expected a *.corrupt-* backup, saw ${siblings.join(', ')}`).toBeTruthy();
+
+    // Fresh DB is usable end-to-end.
+    expect(loadMessages('any')).toEqual([]);
+    saveState('hello', 'world');
+    expect(loadState('hello')).toBe('world');
+
+    // Loud log so a real-world incident leaves a breadcrumb.
+    expect(err).toHaveBeenCalled();
+    err.mockRestore();
+  });
+});
+
+describe('db hardening: schema versioning', () => {
+  it('stamps user_version=1 on a freshly-created database', async () => {
+    const { initDb } = await freshDb();
+    const handle = initDb();
+    const v = handle.pragma('user_version', { simple: true }) as number;
+    expect(v).toBe(1);
+  });
+});
+
+describe('db hardening: prepared statement cache', () => {
+  it('reuses the same Statement across repeated calls', async () => {
+    const mod = await freshDb();
+    const { getDb, loadMessages, saveState } = mod;
+
+    const realPrepare = getDb().prepare.bind(getDb());
+    const spy = vi.spyOn(getDb(), 'prepare').mockImplementation((sql: string) => realPrepare(sql));
+
+    // First touch compiles.
+    loadMessages('s-x');
+    saveState('k', 'v');
+    const callsAfterFirst = spy.mock.calls.length;
+
+    // Subsequent touches must NOT recompile — the cache should serve them.
+    for (let i = 0; i < 5; i++) {
+      loadMessages('s-x');
+      saveState('k', `v${i}`);
+    }
+    expect(spy.mock.calls.length).toBe(callsAfterFirst);
+
+    spy.mockRestore();
+  });
+});

--- a/electron/db-validate.ts
+++ b/electron/db-validate.ts
@@ -1,0 +1,30 @@
+// Small, pure validators for renderer-supplied DB writes. Extracted from
+// the `db:save` IPC handler in `main.ts` so the size caps can be unit-tested
+// without booting Electron's IPC plumbing or `app.whenReady`.
+//
+// These caps mirror the comments in main.ts:
+//   - keys are short identifiers (e.g. `appPersist`, `drafts`, `crashReportingOptOut`)
+//     so 128 chars is well above any legitimate use.
+//   - app_state values hold drafts/persist snapshots; a single row over
+//     1 MB indicates a bug in the persister, and silently committing it
+//     would balloon the WAL.
+
+export const MAX_STATE_KEY_LEN = 128;
+export const MAX_STATE_VALUE_BYTES = 1_000_000;
+
+export type SaveStateValidation =
+  | { ok: true }
+  | { ok: false; error: 'invalid_key' | 'invalid_value' | 'value_too_large' };
+
+export function validateSaveStateInput(key: unknown, value: unknown): SaveStateValidation {
+  if (typeof key !== 'string' || key.length === 0 || key.length > MAX_STATE_KEY_LEN) {
+    return { ok: false, error: 'invalid_key' };
+  }
+  if (typeof value !== 'string') {
+    return { ok: false, error: 'invalid_value' };
+  }
+  if (value.length > MAX_STATE_VALUE_BYTES) {
+    return { ok: false, error: 'value_too_large' };
+  }
+  return { ok: true };
+}

--- a/electron/db.ts
+++ b/electron/db.ts
@@ -5,59 +5,221 @@ import * as fs from 'fs';
 
 let db: Database.Database | null = null;
 
+// Schema version for the on-disk SQLite layout. Bumped only when the table
+// shapes change in a way readers care about. Use `PRAGMA user_version` so
+// SQLite stores it for us — no extra metadata table required.
+//
+// Migration policy: on a fresh DB (`user_version === 0`), we run the current
+// schema and stamp it. On a downgrade (stored > current) we log a warning
+// and proceed; better-sqlite3 will tolerate unknown columns/indexes added by
+// a future version. Real upgrades land in `migrate()` below — empty for now
+// because v1 is the only shipped version.
+const SCHEMA_VERSION = 1;
+
+// ── Cached prepared statements ───────────────────────────────────────────────
+// better-sqlite3 caches compiled SQL inside each Statement object, but the
+// JavaScript-side allocation/lookup still costs ~10 microseconds per call.
+// For hot paths (loadMessages on session switch, saveState on every keystroke
+// in the composer draft persister) that adds up. Cache the Statement once
+// per process lifetime; reset to null when the underlying db closes so the
+// next initDb() rebuilds them.
+type PreparedCache = {
+  loadMessages: Database.Statement<[string]> | null;
+  deleteMessagesForSession: Database.Statement<[string]> | null;
+  insertMessage: Database.Statement<[string, string, string, string, number]> | null;
+  loadState: Database.Statement<[string]> | null;
+  upsertState: Database.Statement<[string, string, number]> | null;
+  deleteState: Database.Statement<[string]> | null;
+};
+
+const stmts: PreparedCache = {
+  loadMessages: null,
+  deleteMessagesForSession: null,
+  insertMessage: null,
+  loadState: null,
+  upsertState: null,
+  deleteState: null
+};
+
+function resetStmts(): void {
+  stmts.loadMessages = null;
+  stmts.deleteMessagesForSession = null;
+  stmts.insertMessage = null;
+  stmts.loadState = null;
+  stmts.upsertState = null;
+  stmts.deleteState = null;
+}
+
+const SCHEMA_SQL = `
+  CREATE TABLE IF NOT EXISTS app_state (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    updated_at INTEGER NOT NULL
+  );
+  CREATE TABLE IF NOT EXISTS messages (
+    id TEXT PRIMARY KEY,
+    sessionId TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    content TEXT NOT NULL,
+    createdAt INTEGER NOT NULL
+  );
+  CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(sessionId);
+`;
+
+/**
+ * Schema migration stub. Empty for v1 — the only shipped schema. Future
+ * upgrades (e.g. adding a column or index) will go here as a switch on
+ * `from`. Kept as a function (not a no-op inline) so unit tests can spy
+ * on it once we have real migrations.
+ */
+function migrate(_from: number, _to: number): void {
+  // No migrations defined yet. When SCHEMA_VERSION bumps to 2+, branch on
+  // `_from` and apply the deltas inside a single transaction. Always bump
+  // user_version at the end so a partial migration doesn't leave the DB
+  // claiming to be on the new version.
+}
+
+/**
+ * Run SQLite's `quick_check` and, if the file is corrupt, move it aside
+ * and replace it with a fresh empty database. Returns the (possibly new)
+ * Database handle.
+ *
+ * `quick_check` skips the cross-table consistency phase that
+ * `integrity_check` runs, which is fine as a startup gate: we only need to
+ * detect torn-page or header corruption that would cause every subsequent
+ * read to throw. Cost is roughly proportional to db size; on a fresh DB
+ * (the common case) it returns in microseconds.
+ */
+function ensureHealthyDb(file: string, current: Database.Database): Database.Database {
+  let result: string | null = null;
+  try {
+    const row = current.pragma('quick_check', { simple: true });
+    result = typeof row === 'string' ? row : null;
+  } catch (err) {
+    // The pragma itself threw — treat the same as corruption.
+    console.error('[db] quick_check threw, treating as corruption:', err);
+  }
+  if (result === 'ok') return current;
+
+  console.error(
+    `[db] integrity check failed (result=${JSON.stringify(result)}); backing up and starting fresh`
+  );
+  try {
+    current.close();
+  } catch {
+    // already closed / never opened cleanly — ignore
+  }
+  const ts = Date.now();
+  const backup = `${file}.corrupt-${ts}`;
+  try {
+    fs.renameSync(file, backup);
+    console.error(`[db] corrupt database moved to ${backup}`);
+  } catch (err) {
+    // If we can't rename (file locked, missing, etc.) fall back to deleting
+    // so the next `new Database()` gets a clean slate. Logging both paths
+    // helps post-mortem when a user reports "my data vanished".
+    console.error('[db] failed to back up corrupt db, removing instead:', err);
+    try {
+      fs.unlinkSync(file);
+    } catch {
+      // ignore — `new Database` will create one
+    }
+  }
+  // Also clear sidecar WAL/SHM files so SQLite doesn't try to replay a
+  // journal pointing at the now-renamed main file.
+  for (const ext of ['-wal', '-shm']) {
+    try {
+      fs.unlinkSync(file + ext);
+    } catch {
+      // ignore — they may not exist
+    }
+  }
+  return new Database(file);
+}
+
 export function initDb(): Database.Database {
   if (db) return db;
   const dir = app.getPath('userData');
   fs.mkdirSync(dir, { recursive: true });
   const file = path.join(dir, 'agentory.db');
-  db = new Database(file);
-  db.pragma('journal_mode = WAL');
-  db.pragma('foreign_keys = ON');
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS app_state (
-      key TEXT PRIMARY KEY,
-      value TEXT NOT NULL,
-      updated_at INTEGER NOT NULL
+
+  let handle = new Database(file);
+  handle = ensureHealthyDb(file, handle);
+  handle.pragma('journal_mode = WAL');
+  handle.pragma('foreign_keys = ON');
+  handle.exec(SCHEMA_SQL);
+
+  // Schema versioning. `user_version` defaults to 0 on a brand-new file.
+  const stored = handle.pragma('user_version', { simple: true }) as number;
+  if (stored === 0) {
+    handle.pragma(`user_version = ${SCHEMA_VERSION}`);
+  } else if (stored < SCHEMA_VERSION) {
+    migrate(stored, SCHEMA_VERSION);
+    handle.pragma(`user_version = ${SCHEMA_VERSION}`);
+  } else if (stored > SCHEMA_VERSION) {
+    // Downgrade scenario (user installed v0.3, then rolled back to v0.2).
+    // We don't refuse to boot — that's worse than risking a stale read —
+    // but we shout in the log so a bug report includes the breadcrumb.
+    console.warn(
+      `[db] on-disk schema version ${stored} is newer than app's ${SCHEMA_VERSION}; proceeding read-as-is`
     );
-    CREATE TABLE IF NOT EXISTS messages (
-      id TEXT PRIMARY KEY,
-      sessionId TEXT NOT NULL,
-      kind TEXT NOT NULL,
-      content TEXT NOT NULL,
-      createdAt INTEGER NOT NULL
-    );
-    CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(sessionId);
-  `);
+  }
+
   // Drop legacy endpoints tables if they exist from a pre-refactor install.
   // The app no longer reads them — connection config now comes from
   // ~/.claude/settings.json. Cheap to issue at every boot; SQLite ignores
   // missing tables.
-  db.exec(`
+  handle.exec(`
     DROP TABLE IF EXISTS endpoint_models;
     DROP TABLE IF EXISTS endpoints;
   `);
+
+  db = handle;
   return db;
 }
 
 export function loadMessages(sessionId: string): unknown[] {
-  const rows = initDb()
-    .prepare('SELECT content FROM messages WHERE sessionId = ? ORDER BY createdAt ASC')
-    .all(sessionId) as Array<{ content: string }>;
-  return rows.map((r) => JSON.parse(r.content));
+  const d = initDb();
+  if (!stmts.loadMessages) {
+    stmts.loadMessages = d.prepare(
+      'SELECT id, content FROM messages WHERE sessionId = ? ORDER BY createdAt ASC'
+    );
+  }
+  const rows = stmts.loadMessages.all(sessionId) as Array<{ id: string; content: string }>;
+  // A corrupt or hand-edited row should not crash the entire session load —
+  // skip the offender and surface a console warning so we can grep logs
+  // post-mortem. The user sees a session with N-1 messages, not a blank
+  // pane and a stuck "Loading…" spinner.
+  const out: unknown[] = [];
+  for (const r of rows) {
+    try {
+      out.push(JSON.parse(r.content));
+    } catch {
+      console.warn('[db] corrupt message row sessionId=%s id=%s', sessionId, r.id);
+    }
+  }
+  return out;
 }
 
 export function saveMessages(sessionId: string, blocks: Array<{ id: string; kind: string }>): void {
-  const db = initDb();
-  const tx = db.transaction(() => {
-    db.prepare('DELETE FROM messages WHERE sessionId = ?').run(sessionId);
-    const insert = db.prepare(
+  const d = initDb();
+  if (!stmts.deleteMessagesForSession) {
+    stmts.deleteMessagesForSession = d.prepare('DELETE FROM messages WHERE sessionId = ?');
+  }
+  if (!stmts.insertMessage) {
+    stmts.insertMessage = d.prepare(
       'INSERT INTO messages (id, sessionId, kind, content, createdAt) VALUES (?, ?, ?, ?, ?)'
     );
+  }
+  const del = stmts.deleteMessagesForSession;
+  const ins = stmts.insertMessage;
+  const tx = d.transaction(() => {
+    del.run(sessionId);
     const now = Date.now();
     blocks.forEach((block, i) => {
       // Use index-based createdAt tiebreaker so ordering is stable even when
       // many blocks land in the same millisecond.
-      insert.run(block.id, sessionId, block.kind, JSON.stringify(block), now + i);
+      ins.run(block.id, sessionId, block.kind, JSON.stringify(block), now + i);
     });
   });
   tx();
@@ -66,23 +228,10 @@ export function saveMessages(sessionId: string, blocks: Array<{ id: string; kind
 // Test-only: swap in an in-memory database. Never call from app code.
 export function __setDbForTests(instance: Database.Database | null): void {
   db = instance;
+  resetStmts();
   if (instance) {
     instance.pragma('foreign_keys = ON');
-    instance.exec(`
-      CREATE TABLE IF NOT EXISTS app_state (
-        key TEXT PRIMARY KEY,
-        value TEXT NOT NULL,
-        updated_at INTEGER NOT NULL
-      );
-      CREATE TABLE IF NOT EXISTS messages (
-        id TEXT PRIMARY KEY,
-        sessionId TEXT NOT NULL,
-        kind TEXT NOT NULL,
-        content TEXT NOT NULL,
-        createdAt INTEGER NOT NULL
-      );
-      CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(sessionId);
-    `);
+    instance.exec(SCHEMA_SQL);
   }
 }
 
@@ -91,24 +240,29 @@ export function getDb(): Database.Database {
 }
 
 export function loadState(key: string): string | null {
-  const row = initDb().prepare('SELECT value FROM app_state WHERE key = ?').get(key) as
-    | { value: string }
-    | undefined;
+  const d = initDb();
+  if (!stmts.loadState) {
+    stmts.loadState = d.prepare('SELECT value FROM app_state WHERE key = ?');
+  }
+  const row = stmts.loadState.get(key) as { value: string } | undefined;
   return row?.value ?? null;
 }
 
 export function saveState(key: string, value: string): void {
-  initDb()
-    .prepare(
+  const d = initDb();
+  if (!stmts.upsertState) {
+    stmts.upsertState = d.prepare(
       `INSERT INTO app_state (key, value, updated_at) VALUES (?, ?, ?)
        ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`
-    )
-    .run(key, value, Date.now());
+    );
+  }
+  stmts.upsertState.run(key, value, Date.now());
 }
 
 export function closeDb(): void {
   db?.close();
   db = null;
+  resetStmts();
 }
 
 const CLAUDE_BIN_PATH_KEY = 'claudeBinPath';
@@ -124,7 +278,11 @@ export function loadClaudeBinPath(): string | null {
 
 export function saveClaudeBinPath(value: string | null): void {
   if (value == null || value.length === 0) {
-    initDb().prepare('DELETE FROM app_state WHERE key = ?').run(CLAUDE_BIN_PATH_KEY);
+    const d = initDb();
+    if (!stmts.deleteState) {
+      stmts.deleteState = d.prepare('DELETE FROM app_state WHERE key = ?');
+    }
+    stmts.deleteState.run(CLAUDE_BIN_PATH_KEY);
     return;
   }
   saveState(CLAUDE_BIN_PATH_KEY, value);

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -13,6 +13,7 @@ import {
   loadClaudeBinPath,
   saveClaudeBinPath,
 } from './db';
+import { validateSaveStateInput } from './db-validate';
 
 // Reads the user's opt-out preference for crash reporting from app_state.
 // Returns false when the row is missing or the read errors — i.e. reporting
@@ -386,9 +387,8 @@ app.whenReady().then(() => {
   // db:saveMessages but tighter (1 MB vs 1 MB-per-block × N blocks): a
   // single app_state row holds drafts/persist snapshots that should never
   // approach this size — if one does, it's a bug in the persister and we
-  // refuse to commit it rather than silently growing the WAL.
-  const MAX_STATE_KEY_LEN = 128;
-  const MAX_STATE_VALUE_BYTES = 1_000_000;
+  // refuse to commit it rather than silently growing the WAL. Validation
+  // logic lives in `./db-validate` so it's unit-testable without IPC.
   ipcMain.handle(
     'db:save',
     (
@@ -397,17 +397,14 @@ app.whenReady().then(() => {
       value: string
     ): { ok: true } | { ok: false; error: string } => {
       if (!fromMainFrame(e)) return { ok: false, error: 'rejected' };
-      if (typeof key !== 'string' || key.length === 0 || key.length > MAX_STATE_KEY_LEN) {
-        return { ok: false, error: 'invalid_key' };
-      }
-      if (typeof value !== 'string') {
-        return { ok: false, error: 'invalid_value' };
-      }
-      if (value.length > MAX_STATE_VALUE_BYTES) {
-        console.warn(
-          `[main] db:save rejecting oversized value (${value.length} bytes) for key=${key}`
-        );
-        return { ok: false, error: 'value_too_large' };
+      const v = validateSaveStateInput(key, value);
+      if (!v.ok) {
+        if (v.error === 'value_too_large') {
+          console.warn(
+            `[main] db:save rejecting oversized value (${(value as string).length} bytes) for key=${key}`
+          );
+        }
+        return v;
       }
       saveState(key, value);
       // Invalidate Sentry's cached opt-out so the toggle in Settings takes

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -382,15 +382,42 @@ app.whenReady().then(() => {
   initDb();
 
   ipcMain.handle('db:load', (_e, key: string) => loadState(key));
-  ipcMain.handle('db:save', (e, key: string, value: string) => {
-    if (!fromMainFrame(e)) return;
-    saveState(key, value);
-    // Invalidate Sentry's cached opt-out so the toggle in Settings takes
-    // effect on the next error without an app restart.
-    if (key === CRASH_OPT_OUT_KEY) {
-      _crashOptOutCached = undefined;
+  // Cap renderer-supplied state values. Mirrors the per-block cap in
+  // db:saveMessages but tighter (1 MB vs 1 MB-per-block × N blocks): a
+  // single app_state row holds drafts/persist snapshots that should never
+  // approach this size — if one does, it's a bug in the persister and we
+  // refuse to commit it rather than silently growing the WAL.
+  const MAX_STATE_KEY_LEN = 128;
+  const MAX_STATE_VALUE_BYTES = 1_000_000;
+  ipcMain.handle(
+    'db:save',
+    (
+      e,
+      key: string,
+      value: string
+    ): { ok: true } | { ok: false; error: string } => {
+      if (!fromMainFrame(e)) return { ok: false, error: 'rejected' };
+      if (typeof key !== 'string' || key.length === 0 || key.length > MAX_STATE_KEY_LEN) {
+        return { ok: false, error: 'invalid_key' };
+      }
+      if (typeof value !== 'string') {
+        return { ok: false, error: 'invalid_value' };
+      }
+      if (value.length > MAX_STATE_VALUE_BYTES) {
+        console.warn(
+          `[main] db:save rejecting oversized value (${value.length} bytes) for key=${key}`
+        );
+        return { ok: false, error: 'value_too_large' };
+      }
+      saveState(key, value);
+      // Invalidate Sentry's cached opt-out so the toggle in Settings takes
+      // effect on the next error without an app restart.
+      if (key === CRASH_OPT_OUT_KEY) {
+        _crashOptOutCached = undefined;
+      }
+      return { ok: true };
     }
-  });
+  );
   ipcMain.handle('db:loadMessages', (e, sessionId: string) => {
     if (!fromMainFrame(e)) return [];
     return loadMessages(sessionId);

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -47,7 +47,10 @@ type UpdateStatus =
 
 const api = {
   loadState: (key: string): Promise<string | null> => ipcRenderer.invoke('db:load', key),
-  saveState: (key: string, value: string): Promise<void> =>
+  saveState: (
+    key: string,
+    value: string
+  ): Promise<{ ok: true } | { ok: false; error: string }> =>
     ipcRenderer.invoke('db:save', key, value),
   // i18n: renderer reads OS locale to seed its "system" preference, and
   // pushes the resolved UI language to main so OS notifications match.

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -47,11 +47,21 @@ type UpdateStatus =
 
 const api = {
   loadState: (key: string): Promise<string | null> => ipcRenderer.invoke('db:load', key),
-  saveState: (
-    key: string,
-    value: string
-  ): Promise<{ ok: true } | { ok: false; error: string }> =>
-    ipcRenderer.invoke('db:save', key, value),
+  // The IPC handler returns a `{ok}` shape so it never crosses the IPC
+  // boundary as a thrown Error (Electron surfaces those as ugly stack
+  // dumps in the renderer console). We unwrap here and re-throw on
+  // failure so the existing `.catch(onPersistError)` callers in
+  // src/stores/persist.ts and src/stores/drafts.ts actually fire — a
+  // resolved `{ok:false}` would otherwise slip past `.catch` silently
+  // and produce data loss with zero renderer signal.
+  saveState: async (key: string, value: string): Promise<void> => {
+    const result = (await ipcRenderer.invoke('db:save', key, value)) as
+      | { ok: true }
+      | { ok: false; error: string };
+    if (!result.ok) {
+      throw new Error(result.error);
+    }
+  },
   // i18n: renderer reads OS locale to seed its "system" preference, and
   // pushes the resolved UI language to main so OS notifications match.
   // Lives under `i18n` to keep the bridge surface organised; renderer

--- a/scripts/probe-e2e-db-corruption-recovery.mjs
+++ b/scripts/probe-e2e-db-corruption-recovery.mjs
@@ -1,0 +1,121 @@
+// E2E: pre-corrupt the on-disk SQLite file before launch and verify
+// Agentory boots without crashing, the corrupt file is moved aside to
+// `agentory.db.corrupt-*`, and a brand-new empty database takes its place.
+//
+// Strategy:
+//   1. Create an isolated userData dir with `--user-data-dir=…` (matches
+//      the pattern used by probe-e2e-connection-pane and friends).
+//   2. Write 256 bytes of random garbage to `agentory.db` inside that dir
+//      BEFORE launching electron. SQLite will accept the open() — it's
+//      lazy — and the first read pragma inside initDb() will trip
+//      `quick_check`, which is our corruption gate.
+//   3. Launch electron and wait for the renderer to mount (sidebar visible
+//      = main process didn't crash on db init).
+//   4. Inspect the userData dir: assert (a) at least one file matching
+//      `agentory.db.corrupt-*` exists (the backup) and (b) the new
+//      `agentory.db` is a valid SQLite header (starts with "SQLite format 3\0").
+//
+// Pre-fix verification: if `ensureHealthyDb` is removed from electron/db.ts,
+// `new Database(file)` succeeds but the first `pragma('journal_mode = WAL')`
+// throws SqliteError "file is not a database", crashing the main process
+// before the renderer ever loads — playwright's appWindow() then times out.
+
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import crypto from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+import { appWindow } from './probe-utils.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function fail(msg) {
+  console.error(`\n[probe-e2e-db-corruption-recovery] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const userDataDir = fs.mkdtempSync(
+  path.join(os.tmpdir(), 'agentory-probe-db-corrupt-')
+);
+console.log(`[probe-e2e-db-corruption-recovery] userData = ${userDataDir}`);
+
+// Pre-seed the userData dir with garbage at the canonical db path. 256 bytes
+// is enough to defeat SQLite's header check while staying small enough that
+// the test suite stays snappy.
+const dbFile = path.join(userDataDir, 'agentory.db');
+fs.writeFileSync(dbFile, crypto.randomBytes(256));
+
+const app = await electron.launch({
+  args: ['.', `--user-data-dir=${userDataDir}`],
+  cwd: root,
+  // AGENTORY_PROD_BUNDLE=1 forces main to loadFile() the bundled renderer
+  // instead of trying to loadURL(http://localhost:4100). This probe is
+  // about main-process db init, not renderer hot reload — we don't want to
+  // require a webpack-dev-server side-process.
+  env: { ...process.env, AGENTORY_PROD_BUNDLE: '1' }
+});
+
+// Surface main-process stderr so a crash inside initDb shows up here
+// instead of silently timing out the renderer wait below.
+app.process().stderr?.on('data', (b) => {
+  process.stderr.write(`[main-stderr] ${b.toString()}`);
+});
+
+let win;
+try {
+  win = await appWindow(app);
+  await win.waitForLoadState('domcontentloaded');
+  // Renderer mounted = main process survived db init. We don't care which
+  // pane shows because the DB is empty anyway; checking for ANY top-level
+  // app shell (sidebar OR main empty-state CTA) is the loosest "alive"
+  // signal we can use without coupling to current copy.
+  await win.waitForFunction(
+    () =>
+      document.querySelector('aside') !== null ||
+      document.querySelector('main button') !== null,
+    null,
+    { timeout: 15_000 }
+  );
+} catch (err) {
+  await app.close().catch(() => {});
+  fail(`app failed to boot after pre-corrupted db: ${err?.message ?? err}`);
+}
+
+// Give initDb a beat to flush the rename + recreate. The pragma + rename
+// are synchronous inside initDb so this is paranoia, but cheap.
+await win.waitForTimeout(250);
+
+const siblings = fs.readdirSync(userDataDir);
+const backups = siblings.filter((n) => n.startsWith('agentory.db.corrupt-'));
+if (backups.length === 0) {
+  await app.close();
+  fail(
+    `expected at least one agentory.db.corrupt-* backup; saw ${JSON.stringify(siblings)}`
+  );
+}
+
+// New db must be a real SQLite file. The magic header is the literal ASCII
+// "SQLite format 3\0" — 16 bytes at offset 0.
+if (!fs.existsSync(dbFile)) {
+  await app.close();
+  fail('expected a fresh agentory.db to exist after recovery');
+}
+const header = fs.readFileSync(dbFile).subarray(0, 16);
+const expected = Buffer.concat([Buffer.from('SQLite format 3'), Buffer.from([0])]);
+if (!header.equals(expected)) {
+  await app.close();
+  fail(`new agentory.db is not a SQLite file; header=${header.toString('hex')}`);
+}
+
+await app.close();
+try {
+  fs.rmSync(userDataDir, { recursive: true, force: true });
+} catch {
+  // best-effort cleanup
+}
+
+console.log('\n[probe-e2e-db-corruption-recovery] OK');
+console.log(`  pre-corrupted ${dbFile} (256 random bytes)`);
+console.log(`  app booted, backup created (${backups.join(', ')}), fresh db is valid SQLite`);


### PR DESCRIPTION
## Summary
- Hardens the on-disk SQLite layer per the recent DB findings: corrupt JSON rows no longer blank a session pane, a corrupt file at startup is moved aside and replaced atomically, prepared statements are cached, and `db:saveState` now has the same renderer-input cap pattern PR #157 added for `db:saveMessages`.
- Stamps `PRAGMA user_version = 1` and lands a `migrate(from,to)` stub so the next schema bump has a hook.
- All findings are in the HIGH/MEDIUM bands; LOW items (FK cascade, statement-finalize-on-close, export-data path) explicitly deferred per scope.

## Changes
- `electron/db.ts` — `ensureHealthyDb()` runs `PRAGMA quick_check`, renames `agentory.db` to `agentory.db.corrupt-<ts>` (plus `-wal`/`-shm` sidecars) on failure, reopens fresh; module-scope `PreparedCache` reused across calls; `loadMessages` skips + warns on unparseable rows; schema versioning via `user_version`.
- `electron/main.ts` — `db:save` IPC handler now validates key/value sizes (1 MB / 128 chars) via the extracted `db-validate` module and returns `{ok:true}|{ok:false; error}`; mirrors the shape from `db:saveMessages`.
- `electron/db-validate.ts` — pure validator extracted from `main.ts` so the size caps are unit-testable without booting Electron's IPC plumbing.
- `electron/preload.ts` — `saveState` wrapper unwraps the IPC `{ok}` result and **throws on `{ok:false}`** so renderer-side `.catch(onPersistError)` handlers in `src/stores/persist.ts` and `src/stores/drafts.ts` actually fire (a resolved `{ok:false}` would otherwise slip past `.catch` silently and lose the snapshot). Renderer-facing API stays `Promise<void>`, matching `src/global.d.ts:53`.
- `electron/__tests__/db-hardening.test.ts` — 8 unit tests: corrupt row skip + warn signature, integrity check + backup + fresh-db usability, `user_version=1` stamp, prepared-statement cache reuse, oversize-value rejection, oversize/empty key rejection, valid payload acceptance, preload re-throw regression.
- `scripts/probe-e2e-db-corruption-recovery.mjs` — pre-seeds an isolated `--user-data-dir` with 256 bytes of garbage at `agentory.db`, launches via `AGENTORY_PROD_BUNDLE=1` (no dev-server dependency), asserts main survives + a `*.corrupt-*` backup exists + the replacement file has the SQLite magic header.

## Local verification
- `npm run typecheck` — clean
- `npm test` — **579/579 passing** (8 in db-hardening, all existing db tests still green; required `npm rebuild better-sqlite3 --build-from-source` for Node ABI)
- `node scripts/probe-e2e-db-corruption-recovery.mjs` — passes after `npx electron-rebuild -f -w better-sqlite3`
- `npx eslint electron/db.ts electron/preload.ts electron/__tests__/db-hardening.test.ts` — clean
- `electron/main.ts` lint warning at line 110 (`'Electron' is not defined`) and unused-disable at line 64 are **pre-existing** on `origin/working`, untouched by this PR

## Test plan
- [ ] Reviewer: skim `ensureHealthyDb` for the rename ordering — file rename happens BEFORE `new Database(file)` so we can't end up with two handles on the same path.
- [ ] Reviewer: verify the prepared-statement cache is reset in BOTH `closeDb` and `__setDbForTests` (test isolation invariant).
- [ ] Reviewer: confirm the new `db:save` preload wrapper preserves the `Promise<void>` API surface in `src/global.d.ts:53` and that all renderer callers (`src/stores/drafts.ts`, `src/stores/persist.ts`, `src/components/SettingsDialog.tsx`) get a thrown Error on oversize, not a swallowed `{ok:false}`.
- [ ] CI / clean env: re-run `probe-e2e-empty-group-new-session.mjs` and `probe-e2e-no-sessions-landing.mjs`. They could not run in my local sandbox because the user's daily-driver Electron is holding the default userData lock; both probes use shared userData so they need a clean machine. Behaviorally untouched by this diff (no changes to the renderer or to non-DB IPC).

## Notes
- Do NOT merge — Worker I scope explicitly excludes merge.