### PR TITLE
fix(permission): wire default-mode tool prompt to UI

### DIFF
--- a/electron/agent/__tests__/sessions.test.ts
+++ b/electron/agent/__tests__/sessions.test.ts
@@ -190,7 +190,7 @@ describe('SessionRunner.start', () => {
     runner.close();
   });
 
-  it('sends an `initialize` control_request immediately after spawn so claude.exe knows we handle can_use_tool over stdio', async () => {
+  it('sends an `initialize` control_request immediately after spawn registering the PreToolUse permission hook', async () => {
     const proc = makeFakeProc();
     mockSpawnClaude.mockResolvedValue(proc);
     const runner = new SessionRunner('s-init', () => {}, () => {}, () => {});
@@ -200,17 +200,23 @@ describe('SessionRunner.start', () => {
       await new Promise((r) => setImmediate(r));
       const lines = proc.__rawStdinLines();
       const init = lines.find(
-        (l): l is { type: string; request: { subtype: string; hooks: unknown } } =>
+        (l): l is { type: string; request: { subtype: string; hooks: Record<string, Array<{ matcher?: string; hookCallbackIds: string[] }>> } } =>
           typeof l === 'object' &&
           l !== null &&
           (l as { type?: string }).type === 'control_request' &&
           (l as { request?: { subtype?: string } }).request?.subtype === 'initialize',
       );
       expect(init, 'expected an initialize control_request on stdin').toBeDefined();
-      // We send `hooks: {}` for now — no host-side hook handlers wired up. The
-      // exact value doesn't matter to claude.exe, but it MUST be present per
-      // the SDK schema (hooks is `record(string, array(...)).optional()`).
-      expect(init?.request.hooks).toEqual({});
+      // The CLI 2.x rule engine handles built-in tools entirely client-side
+      // and only emits `can_use_tool` for ask-style tools. We register a
+      // PreToolUse hook with matcher `.*` so EVERY tool invocation routes
+      // back through the host for a permission decision. Without this,
+      // Bash/Write/Edit run silently in `default` mode with no UI prompt.
+      expect(init?.request.hooks).toEqual({
+        PreToolUse: [
+          { matcher: '.*', hookCallbackIds: ['agentory-permission'] },
+        ],
+      });
     } finally {
       runner.close();
     }
@@ -313,6 +319,185 @@ describe('SessionRunner permission roundtrip', () => {
     const lines = proc.__stdinLines() as Array<Record<string, unknown>>;
     const resp = lines.find((l) => l.type === 'control_response') as Record<string, unknown>;
     expect((resp.response as Record<string, unknown>).behavior).toBe('deny');
+    runner.close();
+  });
+});
+
+describe('SessionRunner PreToolUse hook permission', () => {
+  it('routes a hook_callback for a Bash tool through onPermissionRequest and writes back permissionDecision:allow', async () => {
+    const proc = makeFakeProc();
+    mockSpawnClaude.mockResolvedValue(proc);
+    const seen: Array<{ requestId: string; toolName: string; input: Record<string, unknown> }> = [];
+    const runner = new SessionRunner('s-hook-1', () => {}, () => {}, (req) => seen.push(req));
+    await runner.start(baseOpts);
+
+    emitFrame(proc.stdout, {
+      type: 'control_request',
+      request_id: 'req_hk_1',
+      request: {
+        subtype: 'hook_callback',
+        callback_id: 'agentory-permission',
+        input: {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Bash',
+          tool_input: { command: 'echo hi' },
+          tool_use_id: 'tu_hk',
+          permission_mode: 'default',
+        },
+        tool_use_id: 'tu_hk',
+      },
+    });
+    await new Promise((r) => setImmediate(r));
+    expect(seen).toHaveLength(1);
+    expect(seen[0].toolName).toBe('Bash');
+    expect(seen[0].input.command).toBe('echo hi');
+
+    expect(runner.resolvePermission(seen[0].requestId, 'allow')).toBe(true);
+    await new Promise((r) => setImmediate(r));
+
+    const lines = proc.__stdinLines() as Array<Record<string, unknown>>;
+    const resp = lines.find((l) => l.type === 'control_response' && l.request_id === 'req_hk_1') as Record<string, unknown>;
+    expect(resp).toBeDefined();
+    expect(resp.response).toEqual({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'allow',
+      },
+    });
+
+    runner.close();
+  });
+
+  it('writes back permissionDecision:deny with reason when user denies', async () => {
+    const proc = makeFakeProc();
+    mockSpawnClaude.mockResolvedValue(proc);
+    let captured = '';
+    const runner = new SessionRunner('s-hook-2', () => {}, () => {}, (req) => {
+      captured = req.requestId;
+    });
+    await runner.start(baseOpts);
+
+    emitFrame(proc.stdout, {
+      type: 'control_request',
+      request_id: 'req_hk_2',
+      request: {
+        subtype: 'hook_callback',
+        callback_id: 'agentory-permission',
+        input: {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Write',
+          tool_input: { file_path: '/x', content: 'y' },
+          permission_mode: 'default',
+        },
+      },
+    });
+    await new Promise((r) => setImmediate(r));
+    runner.resolvePermission(captured, 'deny');
+    await new Promise((r) => setImmediate(r));
+
+    const lines = proc.__stdinLines() as Array<Record<string, unknown>>;
+    const resp = lines.find((l) => l.type === 'control_response' && l.request_id === 'req_hk_2') as Record<string, unknown>;
+    expect(resp.response).toMatchObject({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+      },
+    });
+    const out = resp.response as { hookSpecificOutput: { permissionDecisionReason?: string } };
+    expect(out.hookSpecificOutput.permissionDecisionReason).toMatch(/denied/i);
+    runner.close();
+  });
+
+  it('passes through (no UI prompt) for AskUserQuestion / ExitPlanMode so the legacy can_use_tool path renders specialized UI', async () => {
+    const proc = makeFakeProc();
+    mockSpawnClaude.mockResolvedValue(proc);
+    const seen: Array<{ toolName: string }> = [];
+    const runner = new SessionRunner('s-hook-3', () => {}, () => {}, (req) => seen.push(req));
+    await runner.start(baseOpts);
+
+    emitFrame(proc.stdout, {
+      type: 'control_request',
+      request_id: 'req_hk_3',
+      request: {
+        subtype: 'hook_callback',
+        callback_id: 'agentory-permission',
+        input: {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'AskUserQuestion',
+          tool_input: { questions: [] },
+          permission_mode: 'default',
+        },
+      },
+    });
+    await new Promise((r) => setImmediate(r));
+    expect(seen).toHaveLength(0);
+
+    const lines = proc.__stdinLines() as Array<Record<string, unknown>>;
+    const resp = lines.find((l) => l.type === 'control_response' && l.request_id === 'req_hk_3') as Record<string, unknown>;
+    // Empty `{}` response means "no opinion, continue" — the CLI then fires
+    // can_use_tool which the existing handler treats as a questions block.
+    expect(resp.response).toEqual({});
+    runner.close();
+  });
+
+  it('auto-allows (no UI prompt) when permission_mode is bypassPermissions or acceptEdits', async () => {
+    const proc = makeFakeProc();
+    mockSpawnClaude.mockResolvedValue(proc);
+    const seen: Array<{ toolName: string }> = [];
+    const runner = new SessionRunner('s-hook-4', () => {}, () => {}, (req) => seen.push(req));
+    await runner.start(baseOpts);
+
+    for (const [reqId, mode] of [
+      ['req_hk_bp', 'bypassPermissions'],
+      ['req_hk_ae', 'acceptEdits'],
+    ] as const) {
+      emitFrame(proc.stdout, {
+        type: 'control_request',
+        request_id: reqId,
+        request: {
+          subtype: 'hook_callback',
+          callback_id: 'agentory-permission',
+          input: {
+            hook_event_name: 'PreToolUse',
+            tool_name: 'Bash',
+            tool_input: { command: 'rm -rf /tmp/x' },
+            permission_mode: mode,
+          },
+        },
+      });
+    }
+    await new Promise((r) => setImmediate(r));
+    expect(seen).toHaveLength(0);
+
+    const lines = proc.__stdinLines() as Array<Record<string, unknown>>;
+    const responses = lines.filter((l) => l.type === 'control_response');
+    expect(responses).toHaveLength(2);
+    for (const r of responses) expect(r.response).toEqual({});
+    runner.close();
+  });
+
+  it('ignores hook_callback frames with an unknown callback id (defensive)', async () => {
+    const proc = makeFakeProc();
+    mockSpawnClaude.mockResolvedValue(proc);
+    const seen: unknown[] = [];
+    const runner = new SessionRunner('s-hook-5', () => {}, () => {}, (req) => seen.push(req));
+    await runner.start(baseOpts);
+
+    emitFrame(proc.stdout, {
+      type: 'control_request',
+      request_id: 'req_hk_unknown',
+      request: {
+        subtype: 'hook_callback',
+        callback_id: 'some-other-hook',
+        input: { hook_event_name: 'PreToolUse', tool_name: 'Bash', tool_input: {}, permission_mode: 'default' },
+      },
+    });
+    await new Promise((r) => setImmediate(r));
+    expect(seen).toHaveLength(0);
+
+    const lines = proc.__stdinLines() as Array<Record<string, unknown>>;
+    const resp = lines.find((l) => l.type === 'control_response' && l.request_id === 'req_hk_unknown') as Record<string, unknown>;
+    expect(resp.response).toEqual({});
     runner.close();
   });
 });

--- a/electron/agent/sessions.ts
+++ b/electron/agent/sessions.ts
@@ -125,6 +125,28 @@ export type PermissionRequestHandler = (req: {
   input: Record<string, unknown>;
 }) => void;
 
+/**
+ * Single shared callback id for the `PreToolUse` hook we register at
+ * `initialize` time. The CLI echoes this string back in every
+ * `hook_callback` request, letting our control-rpc dispatcher route the
+ * call into the host permission UI.
+ */
+const HOOK_PERMISSION_CALLBACK_ID = 'agentory-permission';
+
+/**
+ * Tools whose permission UX is already handled via the legacy `can_use_tool`
+ * code path (which the CLI still emits for these specific "ask"-style tools).
+ * For these we let the `PreToolUse` hook pass through with `{}` — the CLI
+ * then proceeds to fire `can_use_tool`, which routes to handleCanUseTool and
+ * the existing renderer treatment (questions UI, plan-approval UI). Surfacing
+ * a generic permission prompt for these would double-prompt the user with a
+ * less informative dialog.
+ */
+const HOOK_PASSTHROUGH_TOOLS: ReadonlySet<string> = new Set([
+  'AskUserQuestion',
+  'ExitPlanMode',
+]);
+
 export class SessionRunner {
   private cp: ClaudeProcess | null = null;
   private rpc: ControlRpc | null = null;
@@ -180,19 +202,30 @@ export class SessionRunner {
 
     this.rpc = new ControlRpc(this.cp.stdin, {
       onCanUseTool: (toolName, input, ctx) => this.handleCanUseTool(toolName, input, ctx),
+      onHookCallback: (callbackId, input, signal) =>
+        this.handleHookCallback(callbackId, input, signal),
     });
 
     // Tell claude.exe we're an SDK-style consumer that handles permission
-    // decisions over stdio. Pairs with the `--permission-prompt-tool stdio`
-    // flag set by claude-spawner: without BOTH the flag AND this `initialize`
-    // control_request, the CLI falls back to the local rule engine and never
-    // emits `can_use_tool` requests, so the renderer never sees a permission
-    // prompt for tools like Write/Edit/NotebookEdit. We send `hooks: {}` for
-    // now (no host-side hook handlers); future work can extend this to wire up
-    // hook callbacks if/when we build a hook UI. Fire-and-forget — claude.exe
-    // responds with its commands list which we don't currently consume.
+    // decisions over stdio. The CLI 2.x rule engine handles built-in tools
+    // (Bash/Write/Edit/...) entirely client-side and never emits
+    // `can_use_tool` for them — `--permission-prompt-tool stdio` only kicks in
+    // for the small subset of "ask" tools (AskUserQuestion, ExitPlanMode). To
+    // restore host-driven permission prompts for the built-in destructive
+    // tools, we register a `PreToolUse` hook with matcher `.*` and route the
+    // resulting `hook_callback` requests into the same UI flow as
+    // `can_use_tool`. The callback id is opaque to the CLI; we use a single
+    // shared id so the handler in handleHookCallback is unambiguous. Fire-and-
+    // forget — the response carries a `commands` list we don't consume.
     void this.rpc
-      .sendControlRequest({ subtype: 'initialize', hooks: {} })
+      .sendControlRequest({
+        subtype: 'initialize',
+        hooks: {
+          PreToolUse: [
+            { matcher: '.*', hookCallbackIds: [HOOK_PERMISSION_CALLBACK_ID] },
+          ],
+        },
+      })
       .catch((err) => {
         // Quietly ignore failures during teardown — close() races the
         // initialize round-trip in tests / fast-cancel flows. Only log
@@ -284,6 +317,96 @@ export class SessionRunner {
           ? (input as Record<string, unknown>)
           : { value: input };
       this.onPermissionRequest({ requestId, toolName, input: safeInput });
+    });
+  }
+
+  /**
+   * Handle a `PreToolUse` hook_callback from the CLI. The hook fires for
+   * every tool invocation (matcher `.*` was registered at initialize time);
+   * we use it as the host-side permission gate that `--permission-prompt-tool
+   * stdio` no longer reliably provides for built-in tools in CLI 2.x.
+   *
+   * Decision rules:
+   *   - Wrong callback id → `{}` (no-op continue). Defensive — we only ever
+   *     register one callback so this should not happen, but a future
+   *     extension that registers more hooks should not silently auto-allow.
+   *   - `bypassPermissions` mode → continue (the user explicitly asked us
+   *     not to prompt).
+   *   - `acceptEdits` mode → continue. The CLI itself already auto-accepts
+   *     edits in this mode; surfacing a prompt would contradict the mode.
+   *   - Tool is in HOOK_PASSTHROUGH_TOOLS → continue. The CLI will then fire
+   *     `can_use_tool` for these tools and the existing handler renders the
+   *     specialized UI (AskUserQuestion → questions block; ExitPlanMode →
+   *     plan-approval block).
+   *   - Otherwise → surface to the renderer as a permission prompt and wait
+   *     for the user's allow / deny decision.
+   *
+   * On cancel (signal aborts because the CLI sent `control_cancel_request`
+   * or the channel broke), we resolve with `{}` continue — the response is
+   * dropped by ControlRpc anyway since the inbound entry is already gone,
+   * but cleaning up the pendingPerms entry prevents a leak.
+   */
+  private handleHookCallback(
+    callbackId: string,
+    input: unknown,
+    signal: AbortSignal
+  ): Promise<unknown> {
+    if (callbackId !== HOOK_PERMISSION_CALLBACK_ID) return Promise.resolve({});
+
+    const payload =
+      input && typeof input === 'object' && !Array.isArray(input)
+        ? (input as Record<string, unknown>)
+        : {};
+    const toolName = typeof payload.tool_name === 'string' ? payload.tool_name : 'tool';
+    const toolInputRaw = payload.tool_input;
+    const toolInput =
+      toolInputRaw && typeof toolInputRaw === 'object' && !Array.isArray(toolInputRaw)
+        ? (toolInputRaw as Record<string, unknown>)
+        : {};
+    // The CLI passes the live permission_mode inside the hook payload — we
+    // honour that rather than our own cached `this.permissionMode` since a
+    // mid-session set_permission_mode could have changed it on either side
+    // and the CLI's value is the authoritative one for THIS tool call.
+    const liveMode =
+      typeof payload.permission_mode === 'string' ? payload.permission_mode : 'default';
+
+    if (liveMode === 'bypassPermissions' || liveMode === 'acceptEdits') {
+      return Promise.resolve({});
+    }
+    if (HOOK_PASSTHROUGH_TOOLS.has(toolName)) return Promise.resolve({});
+
+    return new Promise<unknown>((resolve) => {
+      const requestId = `perm-${Date.now().toString(36)}-${(this.nextPermSeq++).toString(36)}`;
+      this.pendingPerms.set(requestId, (decision: CanUseToolDecision) => {
+        if (decision.allow) {
+          resolve({
+            hookSpecificOutput: {
+              hookEventName: 'PreToolUse',
+              permissionDecision: 'allow',
+            },
+          });
+        } else {
+          resolve({
+            hookSpecificOutput: {
+              hookEventName: 'PreToolUse',
+              permissionDecision: 'deny',
+              permissionDecisionReason: decision.deny_reason ?? 'User denied tool use.',
+            },
+          });
+        }
+      });
+      signal.addEventListener(
+        'abort',
+        () => {
+          if (this.pendingPerms.delete(requestId)) {
+            // Hook handler is allowed to no-op on cancel — the CLI has
+            // already moved on. Don't write a deny here; let it fall through.
+            resolve({});
+          }
+        },
+        { once: true }
+      );
+      this.onPermissionRequest({ requestId, toolName, input: toolInput });
     });
   }
 

--- a/scripts/probe-e2e-permission-prompt-default-mode.mjs
+++ b/scripts/probe-e2e-permission-prompt-default-mode.mjs
@@ -1,0 +1,235 @@
+// E2E probe — bug fix: in `default` permission mode the Bash tool ran with
+// NO permission prompt UI within 30s.
+//
+// Root cause: CLI 2.x's local rule engine handles built-in tools
+// (Bash/Write/Edit/...) entirely client-side; the SDK-style
+// `--permission-prompt-tool stdio` flag is only consulted for "ask" tools
+// (AskUserQuestion / ExitPlanMode). For everything else the CLI auto-allows
+// based on its safe-command heuristics and never emits `can_use_tool`. So
+// the renderer's PermissionPromptBlock had nothing to render.
+//
+// Fix: at `initialize` time we now register a `PreToolUse` hook with matcher
+// `.*`. The CLI sends a `hook_callback` request for every tool invocation;
+// our handler routes it through the same `onPermissionRequest` flow that
+// `can_use_tool` used. AskUserQuestion / ExitPlanMode are still handled via
+// can_use_tool (we no-op the hook for them so we don't double-prompt).
+//
+// Probe strategy: launch a fresh prod-bundle Electron with an isolated
+// userData dir, seed a single session with cwd=~ and permission='default',
+// open a Bash prompt, assert the permission UI appears, click Allow, assert
+// the marker output appears.
+//
+// Pre-fix verification: `git stash` your sessions.ts edit, rerun this
+// probe, expect FAIL ("no [role=alertdialog] permission prompt UI within
+// 30s"). Restore, expect PASS.
+
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { appWindow } from './probe-utils.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+const MARKER = 'permhook-perm-test-91827';
+const NAME = 'probe-e2e-permission-prompt-default-mode';
+const SESSION_ID = 's-perm-default-1';
+const GROUP_ID = 'g-default';
+
+const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agentory-perm-default-'));
+console.log(`[${NAME}] userData = ${userDataDir}`);
+
+const commonArgs = ['.', `--user-data-dir=${userDataDir}`];
+// Strip CLAUDECODE so the spawned claude.exe doesn't refuse-to-launch with
+// "cannot run inside another Claude Code session". Probes that drive a real
+// CLI must do this — the dogfood guide called it out repeatedly.
+const env = { ...process.env, AGENTORY_PROD_BUNDLE: '1' };
+delete env.CLAUDECODE;
+delete env.CLAUDE_CODE_ENTRYPOINT;
+
+let appRef = null;
+function fail(msg, extra) {
+  console.error(`\n[${NAME}] FAIL: ${msg}`);
+  if (extra) console.error(extra);
+  if (appRef) appRef.close().catch(() => {});
+  process.exit(1);
+}
+
+const app = await electron.launch({ args: commonArgs, cwd: root, env });
+appRef = app;
+app.process().stderr?.on('data', (d) => process.stderr.write(`[electron-stderr] ${d}`));
+
+const win = await appWindow(app, { timeout: 30_000 });
+const errors = [];
+win.on('pageerror', (e) => errors.push(`[pageerror] ${e.message}`));
+win.on('console', (m) => {
+  if (m.type() === 'error') errors.push(`[console.error] ${m.text()}`);
+});
+
+await win.waitForLoadState('domcontentloaded');
+await win.waitForTimeout(1500);
+
+// 1. Seed an active session in default permission mode + skip first-run UI.
+const seeded = await win.evaluate(
+  async ({ sid, gid }) => {
+    const api = window.agentory;
+    if (!api) return { ok: false, err: 'no window.agentory' };
+    const state = {
+      version: 1,
+      sessions: [
+        {
+          id: sid,
+          name: 'Permission default-mode probe',
+          state: 'idle',
+          cwd: '~',
+          model: 'claude-opus-4',
+          groupId: gid,
+          agentType: 'claude-code',
+        },
+      ],
+      groups: [{ id: gid, name: 'Sessions', collapsed: false, kind: 'normal' }],
+      activeId: sid,
+      model: 'claude-opus-4',
+      permission: 'default',
+      sidebarCollapsed: false,
+      theme: 'system',
+      fontSize: 'md',
+      recentProjects: [],
+      tutorialSeen: true,
+    };
+    await api.saveState('main', JSON.stringify(state));
+    return { ok: true };
+  },
+  { sid: SESSION_ID, gid: GROUP_ID }
+);
+if (!seeded.ok) fail(`seed failed: ${seeded.err}`);
+await app.close();
+
+// 2. Relaunch — the seeded state restores. permission chip should read
+//    "default", and the InputBar/textarea should render.
+const app2 = await electron.launch({ args: commonArgs, cwd: root, env });
+appRef = app2;
+app2.process().stderr?.on('data', (d) => process.stderr.write(`[electron-stderr-2] ${d}`));
+
+const win2 = await appWindow(app2, { timeout: 30_000 });
+win2.on('pageerror', (e) => errors.push(`[pageerror] ${e.message}`));
+win2.on('console', (m) => {
+  if (m.type() === 'error') errors.push(`[console.error] ${m.text()}`);
+});
+await win2.waitForLoadState('domcontentloaded');
+await win2.waitForTimeout(3500);
+
+// Explicit selectSession in case the restored state didn't auto-activate.
+await win2.evaluate((sid) => {
+  const s = window.__agentoryStore?.getState();
+  if (s && typeof s.selectSession === 'function' && s.activeId !== sid) {
+    s.selectSession(sid);
+  }
+}, SESSION_ID);
+await win2.waitForTimeout(500);
+
+const verifyMode = await win2.evaluate(() => {
+  const s = window.__agentoryStore?.getState();
+  return { permission: s?.permission, activeId: s?.activeId };
+});
+if (verifyMode.permission !== 'default') {
+  fail(`permission mode did not restore to 'default'; got ${verifyMode.permission}`);
+}
+if (verifyMode.activeId !== SESSION_ID) {
+  fail(`activeId did not restore; got ${verifyMode.activeId}`);
+}
+
+// 3. Submit a Bash prompt that auto-allowed before the fix.
+const textarea = win2.locator('textarea').first();
+await textarea.waitFor({ state: 'visible', timeout: 15_000 });
+await textarea.click();
+await textarea.fill(
+  `Please run the bash command \`echo ${MARKER}\` using the Bash tool. I want to verify the permission prompt works.`
+);
+await win2.keyboard.press('Enter');
+
+// 4. Within 30s, the permission UI must appear. PermissionPromptBlock renders
+//    a [role="alertdialog"] container with a "Permission required" heading.
+const dialog = win2.locator('[role="alertdialog"]').first();
+try {
+  await dialog.waitFor({ state: 'visible', timeout: 30_000 });
+} catch {
+  const snapshot = await win2.evaluate(() => {
+    const main = document.querySelector('main');
+    const s = window.__agentoryStore?.getState();
+    const id = s?.activeId;
+    const blocks = id ? s?.messagesBySession?.[id] ?? [] : [];
+    return {
+      bodyText: (main ? main.innerText : document.body.innerText).slice(0, 2500),
+      waitingBlocks: blocks
+        .filter((b) => b && b.kind === 'waiting')
+        .map((b) => ({ id: b.id, intent: b.intent, prompt: b.prompt, toolName: b.toolName })),
+    };
+  });
+  console.error('--- main innerText ---');
+  console.error(snapshot.bodyText);
+  console.error('--- waiting blocks ---');
+  console.error(JSON.stringify(snapshot.waitingBlocks, null, 2));
+  console.error('--- console errors (last 15) ---');
+  console.error(errors.slice(-15).join('\n'));
+  fail('no [role="alertdialog"] permission prompt UI within 30s');
+}
+
+const headingCount = await dialog.locator('text=Permission required').first().count();
+if (headingCount === 0) fail('alertdialog visible but no "Permission required" heading');
+const dialogText = (await dialog.innerText()).toLowerCase();
+if (!dialogText.includes('bash') && !dialogText.includes(MARKER)) {
+  fail(`prompt does not mention Bash or the marker; saw: ${dialogText.slice(0, 400)}`);
+}
+
+// 5. Click Allow.
+const allowBtn = win2.locator('[data-perm-action="allow"]').first();
+await allowBtn.waitFor({ state: 'visible', timeout: 5_000 });
+await allowBtn.click();
+
+// 6. Prompt detaches; bash output (marker) appears within 30s.
+try {
+  await dialog.waitFor({ state: 'detached', timeout: 10_000 });
+} catch {
+  fail('alertdialog still attached 10s after clicking Allow');
+}
+
+const markerSeen = await (async () => {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const has = await win2.evaluate((m) => document.body.innerText.includes(m), MARKER);
+    if (has) return true;
+    await win2.waitForTimeout(500);
+  }
+  return false;
+})();
+if (!markerSeen) {
+  const dump = await win2.evaluate(() => document.body.innerText.slice(0, 2500));
+  console.error('--- final body text ---');
+  console.error(dump);
+  fail(`marker "${MARKER}" never appeared in conversation within 30s of Allow click`);
+}
+
+// 7. Best-effort: running state should clear within 20s.
+const stoppedRunning = await (async () => {
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    const running = await win2.evaluate(() => {
+      const s = window.__agentoryStore?.getState();
+      if (!s) return false;
+      const id = s.activeId;
+      return id ? !!s.runningSessions?.[id] : false;
+    });
+    if (!running) return true;
+    await win2.waitForTimeout(500);
+  }
+  return false;
+})();
+if (!stoppedRunning) console.warn(`[${NAME}] WARN: still in running state 20s after marker appeared`);
+
+console.log(`\n[${NAME}] OK`);
+console.log(`  - permission prompt rendered, allow clicked, marker "${MARKER}" appeared in chat`);
+
+await app2.close();


### PR DESCRIPTION
## Root cause

In CLI 2.1.114, the local rule engine handles permission decisions for built-in tools (Bash / Write / Edit / NotebookEdit / ...) entirely client-side. The legacy SDK-style \`--permission-prompt-tool stdio\` flag we still pass on the command line is silently ignored for those built-ins -- it only fires \`can_use_tool\` for ask-style tools (\`AskUserQuestion\`, \`ExitPlanMode\`). Verified by replicating the exact spawner argv against \`claude.exe\` 2.1.114 outside Agentory: \`echo\` and \`Write\` ran with no \`control_request\` ever emitted, regardless of \`-p\` / \`--permission-prompt-tool stdio\` / sending the \`initialize\` handshake. Decompiling the binary confirms: \`function u17(H,$,q,K){if(H==="stdio")return $.createCanUseTool(K);...}\` returns a callable that internally calls the rule engine first (\`AP\`) and only falls through to the host on \`ask\`. \`AP\` auto-allows safe commands like \`echo\` in \`default\` mode.

The mechanism that DOES still let us intercept every tool call is the \`PreToolUse\` hook. The CLI's \`initialize\` control_request schema accepts \`hooks: Record<HookEvent, HookConfig[]>\`; for each registered \`PreToolUse\` hook, the CLI sends a \`hook_callback\` control_request before tool execution. Replying with \`hookSpecificOutput.permissionDecision: "allow" | "deny"\` is an authoritative override that the rule engine respects.

## Fix

\`SessionRunner\` now sends an \`initialize\` payload that registers a \`PreToolUse\` hook with matcher \`.*\` and a single callback id. \`ControlRpc\` already supported \`onHookCallback\` -- we wire it to a new \`handleHookCallback\` method that mirrors the existing \`handleCanUseTool\` flow:

  - Render-time decision: route the request as \`onPermissionRequest\` to the renderer; user clicks Allow / Deny; respond with the matching \`permissionDecision\`.
  - \`bypassPermissions\` / \`acceptEdits\` modes return \`{}\` (continue) so the CLI's own auto-accept fires.
  - \`AskUserQuestion\` / \`ExitPlanMode\` tools return \`{}\` (continue); \`can_use_tool\` then fires for them with the existing specialized UI.
  - Unknown callback id returns \`{}\` (defensive; we only register one).

## Out-of-scope blocker observed

Outbound \`control_request\` round-trips against the real CLI never resolve because \`stream-json-types.ts\` declares \`control_response.request_id\` at the top level, but the real CLI puts \`request_id\` *inside* \`response\`. Every outbound control request (\`initialize\`, \`set_permission_mode\`, \`set_model\`, \`interrupt\`) currently times out 5s later with a benign warning. The hook still gets registered server-side -- the CLI processes the body before sending its (rejected) response -- so the bug fix works. Schema fix should be a follow-up; deliberately not touched here per task scope.

## Verification

  - \`npm run typecheck\`: clean
  - \`npm test\`: 41/42 test files pass; only the pre-existing \`electron/__tests__/db.test.ts\` failures (\`better-sqlite3\` ABI mismatch in \`vitest\`'s Node runtime) remain, identical on origin/working
  - New unit tests: 5 \`SessionRunner\` cases covering allow / deny / passthrough / mode-bypass / unknown-id (all pass)
  - Existing \`electron/agent/__tests__/sessions.test.ts\`: 23 tests pass
  - \`scripts/probe-permission-prompt-stdio.mjs\` (the existing tool-call dogfood probe): still passes
  - \`scripts/probe-e2e-permission-prompt-default-mode.mjs\` (NEW, real claude.exe): pre-fix FAILS (\"no [role=alertdialog] within 30s\", and the bash marker appears unprompted); post-fix PASSES (prompt shown, Allow clicked, marker appears)

## Test plan

  - [ ] Reviewer: rebuild (\`npm i\` if needed) and run \`node scripts/probe-e2e-permission-prompt-default-mode.mjs\` to see the green path.
  - [ ] Reviewer: \`git stash push electron/agent/sessions.ts\`, \`npm run build\`, rerun the probe -- expect FAIL with bash marker present and no prompt.
  - [ ] Smoke an interactive session in dev: send a Bash prompt in \`default\` mode, see the permission UI; switch to \`bypassPermissions\` mid-session, send another -- no prompt, runs immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)