### PR TITLE
fix(agent): correct ControlResponseEventSchema to match CLI wire format

### DIFF
--- a/electron/agent/__tests__/control-rpc.test.ts
+++ b/electron/agent/__tests__/control-rpc.test.ts
@@ -229,11 +229,14 @@ describe('ControlRpc — outbound control commands', () => {
     expect((frame.request as { subtype: string }).subtype).toBe('interrupt');
     expect(typeof frame.request_id).toBe('string');
 
-    // Simulate ack.
+    // Simulate ack. The CLI nests request_id and subtype inside `response`.
     rpc.handleIncoming({
       type: 'control_response',
-      request_id: frame.request_id as string,
-      response: { ok: true },
+      response: {
+        subtype: 'success',
+        request_id: frame.request_id as string,
+        response: { ok: true },
+      },
     });
     await expect(p).resolves.toBeUndefined();
   });
@@ -247,8 +250,11 @@ describe('ControlRpc — outbound control commands', () => {
     expect(frame.request).toEqual({ subtype: 'set_permission_mode', mode: 'acceptEdits' });
     rpc.handleIncoming({
       type: 'control_response',
-      request_id: frame.request_id as string,
-      response: {},
+      response: {
+        subtype: 'success',
+        request_id: frame.request_id as string,
+        response: {},
+      },
     });
     await expect(p).resolves.toBeUndefined();
   });
@@ -261,8 +267,11 @@ describe('ControlRpc — outbound control commands', () => {
     expect(frame.request).toEqual({ subtype: 'set_model', model: 'sonnet' });
     rpc.handleIncoming({
       type: 'control_response',
-      request_id: frame.request_id as string,
-      response: {},
+      response: {
+        subtype: 'success',
+        request_id: frame.request_id as string,
+        response: {},
+      },
     });
     await expect(p).resolves.toBeUndefined();
   });
@@ -275,8 +284,11 @@ describe('ControlRpc — outbound control commands', () => {
     expect(frame.request).toEqual({ subtype: 'set_max_thinking_tokens', tokens: 16000 });
     rpc.handleIncoming({
       type: 'control_response',
-      request_id: frame.request_id as string,
-      response: {},
+      response: {
+        subtype: 'success',
+        request_id: frame.request_id as string,
+        response: {},
+      },
     });
     await expect(p).resolves.toBeUndefined();
   });
@@ -300,8 +312,14 @@ describe('ControlRpc — outbound control commands', () => {
     const idA = out[0].request_id as string;
     const idB = out[1].request_id as string;
     // Respond to B first, then A — order shouldn't matter.
-    rpc.handleIncoming({ type: 'control_response', request_id: idB, response: {} });
-    rpc.handleIncoming({ type: 'control_response', request_id: idA, response: {} });
+    rpc.handleIncoming({
+      type: 'control_response',
+      response: { subtype: 'success', request_id: idB, response: {} },
+    });
+    rpc.handleIncoming({
+      type: 'control_response',
+      response: { subtype: 'success', request_id: idA, response: {} },
+    });
     await expect(pA).resolves.toBeUndefined();
     await expect(pB).resolves.toBeUndefined();
   });
@@ -320,11 +338,60 @@ describe('ControlRpc — outbound control commands', () => {
     // Late response arrives — should be treated as orphan, not throw.
     rpc.handleIncoming({
       type: 'control_response',
-      request_id: frame.request_id as string,
-      response: { ok: true },
+      response: {
+        subtype: 'success',
+        request_id: frame.request_id as string,
+        response: { ok: true },
+      },
     });
     expect(warn).toHaveBeenCalled();
     expect(warn.mock.calls.some((c) => /orphan control_response/.test(String(c[0])))).toBe(true);
+  });
+
+  // Bug K / Task #142: regression guard. The CLI nests request_id INSIDE
+  // `response`, not at the top level. Earlier code tried to read
+  // `frame.request_id` and silently ignored every response, so every outbound
+  // control_request 5s-timed-out. This test FAILS against the pre-fix shape.
+  it('resolves outbound control_request with CLI nested wire shape (Bug K)', async () => {
+    const m = makeStdin();
+    const warn = vi.fn();
+    const rpc = new ControlRpc(m.stdin, {
+      onCanUseTool: allowAll,
+      outboundResponseTimeoutMs: 50,
+      logger: { warn },
+    });
+    const p = rpc.sendControlRequest({ subtype: 'set_permission_mode', mode: 'default' });
+    const [frame] = m.lines() as Array<Record<string, unknown>>;
+    rpc.handleIncoming({
+      type: 'control_response',
+      response: {
+        subtype: 'success',
+        request_id: frame.request_id as string,
+        response: { mode: 'default' },
+      },
+    });
+    await expect(p).resolves.toEqual({ mode: 'default' });
+    // No "orphan" or "timed out" warnings should have fired.
+    expect(warn.mock.calls.some((c) => /orphan|timed out/i.test(String(c[0])))).toBe(false);
+  });
+
+  it('rejects outbound on subtype:error wire shape (Bug K)', async () => {
+    const m = makeStdin();
+    const rpc = new ControlRpc(m.stdin, {
+      onCanUseTool: allowAll,
+      outboundResponseTimeoutMs: 50,
+    });
+    const p = rpc.sendControlRequest({ subtype: 'set_model', model: 'bogus' });
+    const [frame] = m.lines() as Array<Record<string, unknown>>;
+    rpc.handleIncoming({
+      type: 'control_response',
+      response: {
+        subtype: 'error',
+        request_id: frame.request_id as string,
+        error: 'Unsupported model: bogus',
+      },
+    });
+    await expect(p).rejects.toThrow(/Unsupported model: bogus/);
   });
 });
 

--- a/electron/agent/__tests__/fixtures/stream-json/SCHEMA-NOTES.md
+++ b/electron/agent/__tests__/fixtures/stream-json/SCHEMA-NOTES.md
@@ -96,6 +96,16 @@ real samples and update the schemas.
   top-level `type` literal is the same string but the discriminator that
   matters is `request.subtype`. Don't try to merge them — direction is the
   context, not a wire field.
+- **Inbound `control_response` (CLI → us) is NESTED, not flat.** Bug K /
+  Task #142: pre-fix the schema expected `{ type, request_id, response }` but
+  captured wire frames look like:
+    success: `{ type: "control_response", response: { subtype: "success", request_id, response: {...payload} } }`
+    error:   `{ type: "control_response", response: { subtype: "error",   request_id, error: "..." } }`
+  This is the OPPOSITE direction from outbound `control_response` (us → CLI),
+  which uses the FLAT `{ type, request_id, response }` shape — confirmed by
+  the fact that `can_use_tool` / `hook_callback` ack flows have always
+  worked. Don't unify the two: outbound stays flat, inbound is nested.
+  Discriminate on `response.subtype` to distinguish success vs error.
 - **`ControlRequestPayloadSchema` is `z.union`, not `discriminatedUnion`.**
   `discriminatedUnion('subtype')` would reject any unknown subtype and force
   the parser into the `'unknown'` bucket — meaning control-rpc would never

--- a/electron/agent/__tests__/sessions.test.ts
+++ b/electron/agent/__tests__/sessions.test.ts
@@ -517,8 +517,11 @@ describe('SessionRunner outbound control', () => {
     expect((req.request as Record<string, unknown>).subtype).toBe('interrupt');
     emitFrame(proc.stdout, {
       type: 'control_response',
-      request_id: req.request_id,
-      response: {},
+      response: {
+        subtype: 'success',
+        request_id: req.request_id,
+        response: {},
+      },
     });
     await expect(p).resolves.toBeUndefined();
     runner.close();
@@ -538,7 +541,14 @@ describe('SessionRunner outbound control', () => {
         (l.request as Record<string, unknown>).subtype === 'set_model'
     ) as Record<string, unknown>;
     expect((req.request as Record<string, unknown>).model).toBe('opus');
-    emitFrame(proc.stdout, { type: 'control_response', request_id: req.request_id, response: {} });
+    emitFrame(proc.stdout, {
+      type: 'control_response',
+      response: {
+        subtype: 'success',
+        request_id: req.request_id,
+        response: {},
+      },
+    });
     await expect(p).resolves.toBeUndefined();
     runner.close();
   });

--- a/electron/agent/control-rpc.ts
+++ b/electron/agent/control-rpc.ts
@@ -85,8 +85,21 @@ export interface McpMessageRequest {
 
 export interface ControlResponseFrame {
   type: 'control_response';
-  request_id: string;
-  response: unknown;
+  // The Claude CLI nests `request_id` and `subtype` INSIDE `response`, not at
+  // the top level. The previous shape (`request_id` at top level) was based on
+  // an early reverse-engineering doc; captured wire frames look like:
+  //   success: { type: "control_response",
+  //              response: { subtype: "success", request_id, response: {...} } }
+  //   error:   { type: "control_response",
+  //              response: { subtype: "error",   request_id, error: "..." } }
+  // See ControlResponseEventSchema and Bug K / Task #142.
+  response: {
+    subtype: string;
+    request_id: string;
+    response?: unknown;
+    error?: string;
+    [k: string]: unknown;
+  };
 }
 
 export interface ControlCancelRequestFrame {
@@ -371,19 +384,39 @@ export class ControlRpc {
   }
 
   private handleControlResponse(frame: ControlResponseFrame): void {
-    const pending = this.outbound.get(frame.request_id);
+    // The CLI nests both request_id and subtype inside `response` — see the
+    // ControlResponseFrame type comment for the wire shape.
+    const envelope = frame.response;
+    const requestId = envelope?.request_id;
+    if (!requestId) {
+      this.logger.warn('[control-rpc] control_response missing nested request_id', {
+        keys: envelope && typeof envelope === 'object' ? Object.keys(envelope) : null,
+      });
+      return;
+    }
+    const pending = this.outbound.get(requestId);
     if (!pending) {
       // Either an orphan from claude.exe (unlikely), or a late response that
       // arrived after we already timed out / rejected and cleared the entry.
       // Either way, nothing to settle — log and move on.
       this.logger.warn('[control-rpc] orphan control_response (no pending or already settled)', {
-        request_id: frame.request_id,
+        request_id: requestId,
       });
       return;
     }
-    this.outbound.delete(frame.request_id);
+    this.outbound.delete(requestId);
     clearTimeout(pending.timer);
-    pending.resolve(frame.response);
+    if (envelope.subtype === 'error') {
+      pending.reject(
+        new Error(
+          `ControlRpc: claude.exe returned error for control_request: ${envelope.error ?? 'unknown error'}`,
+        ),
+      );
+      return;
+    }
+    // success path: hand back the inner payload (or the whole envelope as a
+    // fallback if `response` was omitted).
+    pending.resolve(envelope.response ?? envelope);
   }
 
   private handleControlCancel(frame: ControlCancelRequestFrame): void {

--- a/electron/agent/stream-json-types.ts
+++ b/electron/agent/stream-json-types.ts
@@ -347,8 +347,28 @@ export type ControlRequestEvent = z.infer<typeof ControlRequestEventSchema>;
 export const ControlResponseEventSchema = z
   .object({
     type: z.literal('control_response'),
-    request_id: z.string(),
-    response: z.unknown()
+    // The Claude CLI nests `request_id` AND `subtype` INSIDE the `response`
+    // envelope, NOT at the top level. Earlier reverse-engineering docs showed
+    // `{ type, request_id, response }` which turned out to be wrong — captured
+    // wire frames look like:
+    //   success: { type: "control_response",
+    //              response: { subtype: "success", request_id, response: {...} } }
+    //   error:   { type: "control_response",
+    //              response: { subtype: "error",   request_id, error: "..." } }
+    // The pre-fix schema accepted the frame (top-level passthrough swallowed
+    // the unknown nesting and `request_id` was missing) but the value of
+    // `request_id` on the parsed frame was `undefined`, so every outbound
+    // control_request silently 5s-timed-out. See Bug K / Task #142.
+    response: z
+      .object({
+        subtype: z.string(),
+        request_id: z.string(),
+        // success path: arbitrary inner payload
+        response: z.unknown().optional(),
+        // error path
+        error: z.string().optional(),
+      })
+      .passthrough(),
   })
   .passthrough();
 export type ControlResponseEvent = z.infer<typeof ControlResponseEventSchema>;

--- a/scripts/probe-e2e-control-response-no-timeout.mjs
+++ b/scripts/probe-e2e-control-response-no-timeout.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+// E2E probe — Bug K / Task #142: ControlResponseEventSchema must match the
+// real CLI wire format.
+//
+// Pre-fix bug: the schema expected `{ type, request_id, response }` but the
+// real CLI sends `{ type, response: { subtype, request_id, response } }`.
+// Result: every outbound control_request (interrupt, set_permission_mode,
+// set_model, initialize hooks) silently 5s-timed-out. The caller didn't
+// notice because the timeout was logged as a benign warning and the CLI did
+// in fact apply the change.
+//
+// What this probe does:
+//   1. Spawns a real `claude` process with stream-json IO (no mocks).
+//   2. Sends an `initialize` control_request followed by a
+//      `set_permission_mode` control_request.
+//   3. Asserts that each control_response arrives well under the 5s timeout
+//      (3000ms budget — initialize takes ~1.3s in practice because it triggers
+//      command enumeration; set_permission_mode takes <100ms). Pre-fix the
+//      pending promise would have hit the 5s fallback every single time.
+//   4. Asserts that no "control_request timed out" diagnostic is emitted.
+//
+// Pre-fix verification:
+//   - revert electron/agent/control-rpc.ts:handleControlResponse to read
+//     `frame.request_id` instead of `frame.response.request_id`, OR
+//   - revert ControlResponseEventSchema to expect `request_id` at top level.
+//   With either revert, this probe FAILS — the response is never matched and
+//   the 1s assertion budget elapses.
+//
+// Usage: node scripts/probe-e2e-control-response-no-timeout.mjs
+
+import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import os from 'node:os';
+import path from 'node:path';
+
+const NAME = 'probe-e2e-control-response-no-timeout';
+const HOME = process.env.HOME || process.env.USERPROFILE || os.homedir();
+const CONFIG_DIR = process.env.AGENTORY_CLAUDE_CONFIG_DIR || path.join(HOME, '.claude');
+const ROUND_TRIP_BUDGET_MS = 3000;
+const HARD_TIMEOUT_MS = 15_000;
+
+function fail(msg) {
+  console.error(`\n[${NAME}] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+function ok(msg) {
+  console.log(`[${NAME}] OK: ${msg}`);
+}
+
+// Strip CLAUDECODE so claude.exe doesn't refuse to launch when the probe
+// itself is run inside a Claude Code session.
+const env = { ...process.env, CLAUDE_CONFIG_DIR: CONFIG_DIR };
+delete env.CLAUDECODE;
+delete env.CLAUDE_CODE_ENTRYPOINT;
+
+const args = [
+  '--output-format', 'stream-json',
+  '--verbose',
+  '--input-format', 'stream-json',
+  '--permission-prompt-tool', 'stdio',
+];
+
+console.log(`[${NAME}] spawning claude with ${args.join(' ')}`);
+const child = spawn('claude', args, {
+  cwd: process.cwd(),
+  env,
+  shell: true,
+  stdio: ['pipe', 'pipe', 'pipe'],
+});
+
+const pending = new Map(); // request_id -> { sentAt, label }
+
+const initId = `req_${randomUUID()}`;
+const modeId = `req_${randomUUID()}`;
+const diagnostics = [];
+let finished = false;
+
+const hardTimer = setTimeout(() => {
+  finished = true;
+  child.kill();
+  fail(`hard timeout (${HARD_TIMEOUT_MS}ms) — at least one control_request never came back`);
+}, HARD_TIMEOUT_MS);
+
+child.stderr.on('data', (d) => {
+  const s = d.toString('utf8');
+  if (/control_request.*timed out/i.test(s)) {
+    diagnostics.push(s.trim());
+  }
+  // Keep stderr quiet but print on failure for forensics.
+});
+
+let buf = '';
+child.stdout.on('data', (chunk) => {
+  buf += chunk.toString('utf8');
+  let idx;
+  while ((idx = buf.indexOf('\n')) !== -1) {
+    const line = buf.slice(0, idx).trim();
+    buf = buf.slice(idx + 1);
+    if (!line) continue;
+    let parsed;
+    try { parsed = JSON.parse(line); } catch { continue; }
+    if (parsed.type !== 'control_response') continue;
+
+    // The CLI nests request_id and subtype inside `response`. If this probe
+    // ran against the pre-fix code, the inbound dispatcher would look at
+    // top-level `request_id` (undefined) and never match — but here we are
+    // verifying the wire shape directly, independent of the dispatcher, so
+    // we read from the documented nested location.
+    const env = parsed.response;
+    if (!env || typeof env !== 'object') {
+      fail(`control_response without response envelope: ${line}`);
+    }
+    const { request_id, subtype, error } = env;
+    if (typeof request_id !== 'string') {
+      fail(`control_response.response.request_id missing: ${line}`);
+    }
+    const entry = pending.get(request_id);
+    if (!entry) continue; // not for us
+    pending.delete(request_id);
+    const elapsed = Date.now() - entry.sentAt;
+    if (elapsed > ROUND_TRIP_BUDGET_MS) {
+      fail(
+        `${entry.label} took ${elapsed}ms (> ${ROUND_TRIP_BUDGET_MS}ms budget) — ` +
+          `pre-fix this would have been ~5000ms (timeout fallback)`,
+      );
+    }
+    if (subtype === 'error') {
+      fail(`${entry.label} returned error from CLI: ${error ?? 'unknown'}`);
+    }
+    ok(`${entry.label} resolved in ${elapsed}ms (subtype=${subtype}, request_id=${request_id})`);
+
+    if (pending.size === 0) {
+      // All requests answered; check no timeout diagnostics.
+      if (diagnostics.length > 0) {
+        fail(`saw "control_request timed out" diagnostics:\n  ${diagnostics.join('\n  ')}`);
+      }
+      finished = true;
+      clearTimeout(hardTimer);
+      child.kill();
+      console.log(`\n[${NAME}] PASS — both control_requests resolved within ${ROUND_TRIP_BUDGET_MS}ms each, no timeout diagnostics`);
+      process.exit(0);
+    }
+  }
+});
+
+child.on('exit', (code, signal) => {
+  if (finished) return;
+  fail(`claude exited unexpectedly (code=${code}, signal=${signal}) before all responses arrived; pending=${[...pending.keys()].join(',')}`);
+});
+
+// 1) Send `initialize` (this is the same one SessionRunner sends on start).
+const initFrame = {
+  type: 'control_request',
+  request_id: initId,
+  request: { subtype: 'initialize', hooks: {} },
+};
+pending.set(initId, { sentAt: Date.now(), label: 'initialize' });
+child.stdin.write(JSON.stringify(initFrame) + '\n');
+
+// 2) Shortly after, send `set_permission_mode` — this is the canonical case
+//    where the 5s phantom timeout was observed in PR #167.
+setTimeout(() => {
+  if (finished) return;
+  const modeFrame = {
+    type: 'control_request',
+    request_id: modeId,
+    request: { subtype: 'set_permission_mode', mode: 'default' },
+  };
+  pending.set(modeId, { sentAt: Date.now(), label: 'set_permission_mode' });
+  child.stdin.write(JSON.stringify(modeFrame) + '\n');
+}, 200);


### PR DESCRIPTION
## The bug (Task #142 / Bug K)

`ControlResponseEventSchema` and `ControlRpc.handleControlResponse` expected the inbound `control_response` frame to carry `request_id` at the top level:

```json
{ "type": "control_response", "request_id": "...", "response": {...} }
```

But the real Claude CLI (verified against 2.1.114) emits a NESTED envelope:

```json
// success
{ "type": "control_response",
  "response": { "subtype": "success", "request_id": "...", "response": {...payload} } }

// error
{ "type": "control_response",
  "response": { "subtype": "error",   "request_id": "...", "error": "..." } }
```

The dispatcher therefore looked up `pending.get(undefined)`, never matched, and EVERY outbound `control_request` hit the 5s `outboundResponseTimeoutMs` fallback with a benign `"timed out after 5000ms"` warning — even though the CLI had already responded successfully. This affects `interrupt`, `set_permission_mode`, `set_model`, `set_max_thinking_tokens`, `rewind_files`, and the `initialize` hooks-registration handshake. Discovered while building #167 (default-mode permission prompt).

## The fix

- `ControlResponseEventSchema`: replace the flat shape with a nested envelope discriminated on `response.subtype` (`"success"` carries `response.response`, `"error"` carries `response.error`).
- `ControlRpc.handleControlResponse`: read `request_id` from the nested envelope; reject the pending promise on `subtype: "error"` instead of silently resolving.
- `ControlResponseFrame` interface in `control-rpc.ts`: updated to match.
- Existing unit tests updated to use the nested wire shape; **two new regression tests** under "Bug K" cover the success and error paths and FAIL against the pre-fix dispatcher.

## Asymmetry note (do not unify)

OUTBOUND `control_response` (us → CLI, replying to `can_use_tool` / `hook_callback`) keeps the FLAT `{ type, request_id, response }` shape — it has always worked and the CLI accepts it. Only the INBOUND direction (CLI → us, replying to our outbound `control_request`) is nested. `SCHEMA-NOTES.md` now documents this explicitly so the next refactor doesn't try to merge them.

## Verification

- `npx vitest run electron/agent/__tests__/control-rpc.test.ts electron/agent/__tests__/sessions.test.ts electron/agent/__tests__/stream-json-parser.test.ts` — all 84 tests pass.
- New e2e probe `scripts/probe-e2e-control-response-no-timeout.mjs` spawns the real `claude` binary, sends `initialize` + `set_permission_mode`, and asserts both round-trips complete in <3000ms (well below the 5000ms timeout) with no `timed out` diagnostics. Pre-fix this would fail with a 5s timeout for the second request.
- Reverting just `handleControlResponse` to read `frame.request_id` makes both new "Bug K" unit tests fail with `timed out after 50ms`, confirming the regression guards bite.
- `npm run typecheck` — clean.
- `npm run build` — clean.
- `scripts/probe-e2e-permission-prompt-default-mode.mjs` — passes.
- `scripts/probe-e2e-askuserquestion-no-dup-and-resolves.mjs` — passes.