### PR TITLE
refactor(persist): make PERSISTED_KEYS the single source of truth

### DIFF
--- a/src/stores/persist.ts
+++ b/src/stores/persist.ts
@@ -11,9 +11,46 @@ import type { RecentProject } from '../mock/data';
 
 export const STATE_KEY = 'main';
 
-// runningSessions, interruptedSessions, messageQueues are intentionally NOT
-// persisted — they're runtime flags tied to the current agent process.
-// Restoring them would block recovery on next launch. See PR #156.
+/**
+ * Single source of truth for the set of store fields that flow into the
+ * persisted JSON snapshot. Both the write path (subscriber in
+ * `hydrateStore`) and the reference-equality early-bail comparator
+ * (perf optimisation from PR #166) iterate this list, so adding a new
+ * persisted field only requires editing this array (plus `PersistedState`
+ * for the on-disk type).
+ *
+ * `version` is intentionally NOT included — it's a fixed literal stamped
+ * onto every snapshot, not a store field.
+ *
+ * `sidebarWidthPct` is also NOT included — it's a legacy on-disk-only
+ * field consumed by `resolvePersistedSidebarWidth` during hydration. New
+ * writes always populate `sidebarWidth` (px) instead.
+ *
+ * runningSessions, interruptedSessions, messageQueues, messagesBySession,
+ * statsBySession, focusInputNonce, models, connection, cliStatus etc. are
+ * intentionally NOT persisted — they're runtime state tied to the current
+ * agent process / IPC layer. Restoring them would block recovery on next
+ * launch. See PR #156.
+ */
+export const PERSISTED_KEYS = [
+  'sessions',
+  'groups',
+  'activeId',
+  'model',
+  'permission',
+  'sidebarCollapsed',
+  'sidebarWidth',
+  'theme',
+  'fontSize',
+  'fontSizePx',
+  'density',
+  'recentProjects',
+  'tutorialSeen',
+  'notificationSettings'
+] as const;
+
+export type PersistedKey = typeof PERSISTED_KEYS[number];
+
 export interface PersistedState {
   version: 1;
   sessions: Session[];

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import type { RecentProject } from '../mock/data';
 import type { Group, Session, MessageBlock, ImageAttachment } from '../types';
-import { loadPersisted, schedulePersist, type PersistedState } from './persist';
+import { loadPersisted, schedulePersist, PERSISTED_KEYS, type PersistedState, type PersistedKey } from './persist';
 import { hydrateDrafts, deleteDrafts, snapshotDraft, restoreDraft } from './drafts';
 import { i18next } from '../i18n';
 import type { ConnectionInfo } from '../shared/ipc-types';
@@ -1574,6 +1574,18 @@ export const useStore = create<State & Actions>((set, get) => ({
 
 let hydrated = false;
 
+// Compile-time guard: every key in PERSISTED_KEYS must exist on State (so the
+// subscriber's `s[k]` read is well-typed) AND on PersistedState (so the
+// snapshot we hand to schedulePersist is structurally valid). If a key is
+// added to PERSISTED_KEYS that doesn't exist on either, this assertion fails
+// at typecheck — keeping the source-of-truth array honest.
+type _AssertPersistedKeysOnState = PersistedKey extends keyof State ? true : never;
+type _AssertPersistedKeysOnPersisted = PersistedKey extends keyof PersistedState ? true : never;
+const _persistedKeysOnState: _AssertPersistedKeysOnState = true;
+const _persistedKeysOnPersisted: _AssertPersistedKeysOnPersisted = true;
+void _persistedKeysOnState;
+void _persistedKeysOnPersisted;
+
 export async function hydrateStore(): Promise<void> {
   if (hydrated) return;
   // Drafts live alongside the main snapshot but in their own key — load both
@@ -1678,45 +1690,31 @@ export async function hydrateStore(): Promise<void> {
   // mutations that wouldn't change disk state anyway. Fields are checked by
   // reference — every persisted field is either a primitive or an immutable
   // array we replace on update, so reference equality is correct.
+  //
+  // Both the comparator and the snapshot iterate `PERSISTED_KEYS` (defined
+  // in persist.ts) so adding a new persisted field only requires editing
+  // that one array.
   let prevSnap: State | null = null;
   useStore.subscribe((s) => {
-    if (
-      prevSnap !== null &&
-      prevSnap.sessions === s.sessions &&
-      prevSnap.groups === s.groups &&
-      prevSnap.activeId === s.activeId &&
-      prevSnap.model === s.model &&
-      prevSnap.permission === s.permission &&
-      prevSnap.sidebarCollapsed === s.sidebarCollapsed &&
-      prevSnap.sidebarWidth === s.sidebarWidth &&
-      prevSnap.theme === s.theme &&
-      prevSnap.fontSize === s.fontSize &&
-      prevSnap.fontSizePx === s.fontSizePx &&
-      prevSnap.density === s.density &&
-      prevSnap.recentProjects === s.recentProjects &&
-      prevSnap.tutorialSeen === s.tutorialSeen &&
-      prevSnap.notificationSettings === s.notificationSettings
-    ) {
-      return;
+    if (prevSnap !== null) {
+      let changed = false;
+      for (const k of PERSISTED_KEYS) {
+        if (prevSnap[k] !== s[k]) {
+          changed = true;
+          break;
+        }
+      }
+      if (!changed) return;
     }
     prevSnap = s;
-    const snapshot: PersistedState = {
-      version: 1,
-      sessions: s.sessions,
-      groups: s.groups,
-      activeId: s.activeId,
-      model: s.model,
-      permission: s.permission,
-      sidebarCollapsed: s.sidebarCollapsed,
-      sidebarWidth: s.sidebarWidth,
-      theme: s.theme,
-      fontSize: s.fontSize,
-      fontSizePx: s.fontSizePx,
-      density: s.density,
-      recentProjects: s.recentProjects,
-      tutorialSeen: s.tutorialSeen,
-      notificationSettings: s.notificationSettings
-    };
+    const snapshot = { version: 1 as const } as PersistedState;
+    for (const k of PERSISTED_KEYS) {
+      // The PERSISTED_KEYS list is statically derived from State and matches
+      // PersistedState 1:1 (modulo `version`, which is a literal stamped
+      // above). The cast keeps the per-key assignment narrow without forcing
+      // every call site to spell out the union.
+      (snapshot as unknown as Record<string, unknown>)[k] = s[k];
+    }
     schedulePersist(snapshot);
   });
 }

--- a/tests/persisted-keys-source-of-truth.test.ts
+++ b/tests/persisted-keys-source-of-truth.test.ts
@@ -1,0 +1,146 @@
+// Locks the PERSISTED_KEYS contract introduced as the single source of truth
+// for the persist subscriber. Both the early-bail comparator and the snapshot
+// builder in `hydrateStore` iterate `PERSISTED_KEYS`, so adding a new key
+// only requires editing that one array.
+//
+// This test guards two things:
+//  1. Every key listed in PERSISTED_KEYS lands in the serialized snapshot
+//     (the write path includes it).
+//  2. Mutating any field listed in PERSISTED_KEYS triggers a fresh debounced
+//     write (the comparator does NOT early-bail on it).
+//
+// If a future change adds a key to PERSISTED_KEYS but accidentally skips it
+// in the comparator or snapshot loop, both halves of this test catch it.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { PERSISTED_KEYS } from '../src/stores/persist';
+
+// `hydrateStore` is the only path that installs the persist subscriber, and
+// it does so as a module-level side effect once per process. We need a fresh
+// store + fresh subscriber for each test, so we re-import via `vi.resetModules`
+// between scenarios.
+async function freshStore(saveState: ReturnType<typeof vi.fn>) {
+  vi.resetModules();
+  (globalThis as unknown as { window?: unknown }).window = {
+    agentory: {
+      saveState,
+      loadState: vi.fn().mockResolvedValue(null),
+      saveMessages: vi.fn().mockResolvedValue(undefined),
+      loadMessages: vi.fn().mockResolvedValue([]),
+      pathsExist: vi.fn().mockResolvedValue({}),
+      recentCwds: vi.fn().mockResolvedValue([]),
+      topModel: vi.fn().mockResolvedValue(null),
+      models: { list: vi.fn().mockResolvedValue([]) },
+      connection: { read: vi.fn().mockResolvedValue(null) },
+      cli: { retryDetect: vi.fn().mockResolvedValue({ found: true, path: '/x', version: '2.1.0' }) }
+    }
+  };
+  const storeMod = await import('../src/stores/store');
+  const persistMod = await import('../src/stores/persist');
+  await storeMod.hydrateStore();
+  return { storeMod, persistMod };
+}
+
+describe('persist: PERSISTED_KEYS is the single source of truth', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.resetModules();
+  });
+
+  it('every key in PERSISTED_KEYS lands in the serialized snapshot', async () => {
+    const saveState = vi.fn().mockResolvedValue(undefined);
+    const { storeMod } = await freshStore(saveState);
+    // Force a write by replacing the whole sessions array (a persisted field).
+    storeMod.useStore.setState({ sessions: [] });
+    storeMod.useStore.setState({
+      sessions: [
+        {
+          id: 's-test',
+          name: 't',
+          state: 'idle',
+          cwd: '~',
+          model: '',
+          groupId: 'g-default',
+          agentType: 'claude-code'
+        }
+      ]
+    });
+    vi.advanceTimersByTime(500);
+    expect(saveState).toHaveBeenCalled();
+    const lastCall = saveState.mock.calls[saveState.mock.calls.length - 1] as [string, string];
+    const parsed = JSON.parse(lastCall[1]);
+    for (const k of PERSISTED_KEYS) {
+      expect(parsed, `missing persisted key ${k}`).toHaveProperty(k);
+    }
+    expect(parsed).toHaveProperty('version', 1);
+  });
+
+  it('mutating any PERSISTED_KEYS field triggers a fresh write (comparator covers all keys)', async () => {
+    const saveState = vi.fn().mockResolvedValue(undefined);
+    const { storeMod } = await freshStore(saveState);
+    // Warm up the comparator so prevSnap !== null. Without this the first
+    // setState below would unconditionally write (bypassing the comparator)
+    // and one key would be tested trivially.
+    storeMod.useStore.setState({ activeId: 'warmup' });
+    vi.advanceTimersByTime(500);
+    saveState.mockClear();
+
+    // For each persisted key, replace its value with a fresh reference and
+    // assert that the subscriber DID NOT early-bail (i.e. saveState fires).
+    const fresh: Record<string, unknown> = {
+      sessions: [],
+      groups: [{ id: 'g-x', name: 'x', collapsed: false, kind: 'normal' }],
+      activeId: 'a',
+      model: 'm',
+      permission: 'plan',
+      sidebarCollapsed: true,
+      sidebarWidth: 321,
+      theme: 'dark',
+      fontSize: 'lg',
+      fontSizePx: 16,
+      density: 'compact',
+      recentProjects: [{ id: 'p1', name: 'n', path: '/x' }],
+      tutorialSeen: true,
+      notificationSettings: {
+        enabled: false,
+        permission: false,
+        question: false,
+        turnDone: false,
+        sound: false
+      }
+    };
+
+    for (const k of PERSISTED_KEYS) {
+      saveState.mockClear();
+      storeMod.useStore.setState({ [k]: fresh[k] } as Partial<typeof fresh>);
+      vi.advanceTimersByTime(500);
+      expect(
+        saveState,
+        `comparator early-bailed on persisted key "${k}" — comparator and PERSISTED_KEYS are out of sync`
+      ).toHaveBeenCalled();
+    }
+  });
+
+  it('mutating a non-persisted field does NOT trigger a write (early-bail still works)', async () => {
+    const saveState = vi.fn().mockResolvedValue(undefined);
+    const { storeMod } = await freshStore(saveState);
+    // Warm up the comparator: the very first subscriber call has
+    // prevSnap === null and unconditionally writes. Trigger one persisted
+    // mutation so prevSnap is populated, then start asserting non-writes.
+    storeMod.useStore.setState({ activeId: 'warmup' });
+    vi.advanceTimersByTime(500);
+    saveState.mockClear();
+
+    // focusInputNonce is intentionally NOT in PERSISTED_KEYS — bumping it on
+    // every session click must not write to disk.
+    storeMod.useStore.setState({ focusInputNonce: 42 });
+    vi.advanceTimersByTime(500);
+    expect(saveState).not.toHaveBeenCalled();
+
+    storeMod.useStore.setState({ runningSessions: { foo: true } });
+    vi.advanceTimersByTime(500);
+    expect(saveState).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Non-blocking follow-up flagged by PR #166's reviewer.

PR #166 added a perf optimisation in the persist subscriber: reference-compare every persisted store field and early-bail if nothing changed. The list of 14 persisted fields ended up living in two places inside `src/stores/store.ts`:

1. The reference-equality comparator (`prevSnap.X === s.X` for each X).
2. The snapshot builder (`{ version: 1, sessions: s.sessions, ... }`).

Adding a new persisted field required editing both spots in lockstep. Forgetting one half meant either silently dropping the new field on disk or silently early-bailing on its updates — both subtle and easy to miss in review.

## Change

- Introduce `PERSISTED_KEYS` (`as const`) and `PersistedKey` in `src/stores/persist.ts` as the single source of truth.
- Comparator now iterates `PERSISTED_KEYS` and bails when no key's reference changed.
- Snapshot builder iterates `PERSISTED_KEYS` and copies each field from the live store.
- Compile-time guards in `store.ts`: `PersistedKey extends keyof State` and `PersistedKey extends keyof PersistedState`. If a key is added to `PERSISTED_KEYS` that doesn't exist on either type, `tsc` fails.
- Pure refactor — the set of persisted fields is unchanged (sessions, groups, activeId, model, permission, sidebarCollapsed, sidebarWidth, theme, fontSize, fontSizePx, density, recentProjects, tutorialSeen, notificationSettings).
- `version: 1` stays inlined as a literal (it is not a store field).
- `sidebarWidthPct` stays out (legacy on-disk-only field, migrated on hydrate).

## Test plan

- [x] `npm run typecheck` passes (compile-time guards green).
- [x] New `tests/persisted-keys-source-of-truth.test.ts` covers:
  - every key in `PERSISTED_KEYS` lands in the serialized JSON snapshot;
  - mutating any `PERSISTED_KEYS` field triggers a write (comparator does not early-bail);
  - mutating a non-persisted field (`focusInputNonce`, `runningSessions`) does NOT trigger a write (early-bail still works).
- [x] Existing `tests/persist-shape.test.ts` still passes.