### PR TITLE
refactor(e2e): introduce themed harnesses (B+C phase 1+2 — AGENT cluster)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist/
 agentory-data.db
 agentory-data.db-journal
 scripts/spike-*
+scripts/e2e-artifacts/
 release/
 *.exe
 *.dmg

--- a/docs/e2e-runner.md
+++ b/docs/e2e-runner.md
@@ -1,41 +1,111 @@
-# E2E probe runner
+# E2E runner
 
-`scripts/run-all-e2e.mjs` runs every `scripts/probe-e2e-*.mjs` serially and
-prints a summary table. `npm run probe:e2e` builds the app then invokes it.
+Two test surfaces share one runner:
 
-## Adding a new probe
+- **Per-file probes** (`scripts/probe-e2e-*.mjs`) — one Electron launch per
+  file, ~10–30 s cold start, isolated by tmp `--user-data-dir`. Best for
+  cases that need cold-start, custom DB seeding, or singleton main-process
+  state (tray, titlebar, db-corruption recovery).
+- **Themed harnesses** (`scripts/harness-*.mjs`) — one Electron launch packs
+  many cases. Cases share the renderer + main process and rely on
+  `scripts/probe-helpers/reset-between-cases.mjs` to scrub state between
+  cases. Best for cases that are session-scoped and don't need a fresh
+  process. Currently:
+  - `harness-agent.mjs` — agent / streaming / inputbar UI (Phase-2 pilot).
 
-1. Create `scripts/probe-e2e-<name>.mjs`. Follow the existing pattern (launch
-   Electron via `playwright._electron`, drive the UI, exit non-zero on failure).
-2. That's it. The runner picks it up by glob on next run; no registration.
+`scripts/run-all-e2e.mjs` runs harnesses first, then the remaining per-file
+probes. Probes whose case has been moved into a harness are skipped via the
+in-file `MERGED_INTO_HARNESS` set; the source files stay as breadcrumbs with
+a top-of-file `// MERGED INTO scripts/harness-…mjs` marker.
 
-Conventions:
-- Exit `0` on success, non-zero on failure.
-- Keep total runtime under 30 seconds (per-probe timeout — runner SIGKILLs
-  beyond that).
-- Don't assume parallel safety. Probes run one at a time.
+## Adding a new case
 
-## Skipping a flaky/known-broken probe
+1. **Pick the right surface.**
+   - If the case touches only renderer state + a session, add it as a case
+     in an existing themed harness.
+   - If the case needs cold-start, app-icon assets, tray init, db corruption,
+     window-shutdown semantics, or other singleton main-process state, write
+     a per-file probe (see “Cases that can’t be merged” below).
+2. **For a harness case**: open the harness file, write a named function
+   `caseFoo({ app, win, log, registerDispose })`, and register it in the
+   `cases:` array.
+   - Use `log()` instead of `console.log` so output is prefixed
+     `[case=<id>] …`.
+   - Throw on failure — the runner records the message + per-case Playwright
+     trace under `scripts/e2e-artifacts/<harness>/<case>/trace.zip`.
+   - If the case mounts a monkey-patch on `dialog`/`shell` or sets a global
+     side effect (i18n language, theme, …), pass a restore function to
+     `registerDispose(...)`. The runner drains these inside
+     `resetBetweenCases` before the next case.
+3. **Update the runner skip list.** Add the suffix of the original
+   per-file probe (if any) to `MERGED_INTO_HARNESS` in
+   `scripts/run-all-e2e.mjs`, and prepend the breadcrumb header to the
+   source file.
 
-Set `E2E_SKIP` to a comma-separated list of names (the part after
-`probe-e2e-`, without `.mjs`):
+## Running locally
 
 ```bash
-E2E_SKIP=streaming,tray npm run probe:e2e
+npm run probe:e2e            # build + every harness + every non-merged probe
+node scripts/harness-agent.mjs                       # one harness, all cases
+node scripts/harness-agent.mjs --only=streaming      # one case
+node scripts/harness-agent.mjs --only=streaming,chat-copy  # subset
 ```
 
-Skipped probes are reported as `[--]` in the summary and don't affect the
-exit code.
+`E2E_SKIP=streaming,tray` (or any comma list of probe / harness suffixes)
+skips entries from `run-all-e2e.mjs` end-to-end.
 
-## Running a single probe
+## Artifacts
 
-The per-file scripts still work directly:
+On case failure, the harness runner persists:
 
-```bash
-node scripts/probe-e2e-send.mjs
-```
+- `scripts/e2e-artifacts/<harness>/<case>/trace.zip` — Playwright trace
+  (open with `npx playwright show-trace …`).
+- `scripts/e2e-artifacts/<harness>/<case>/failure.png` — full-page
+  screenshot for fast triage without unzipping.
 
-## Exit code
+Successful runs leave nothing behind.
 
-The runner exits with the worst child exit code (or `1` if any probe failed
-or timed out). CI can consume it as-is.
+## Cases that can’t be merged (keep one Electron per file)
+
+Per `docs/e2e/single-harness-brainstorm.md` §9, the following exercise
+singleton main-process state or first-launch UI and **must stay as
+per-file probes** (one Electron launch per case):
+
+- `probe-e2e-app-icon-present`
+- `probe-e2e-tray`
+- `probe-e2e-titlebar` (window chrome init)
+- `probe-e2e-tutorial`, `probe-e2e-no-sessions-landing`,
+  `probe-e2e-empty-state-minimal` (first-launch UI)
+- `probe-e2e-db-corruption-recovery` (pre-seeds garbage DB before launch)
+- `probe-e2e-import-session`, `probe-e2e-import-empty-groups`
+  (depends on userData state at launch)
+- `probe-e2e-close-window-aborts-sessions` (asserts on app shutdown)
+- `probe-e2e-ipc-unc-rejection`, `probe-e2e-env-passthrough`
+  (process-launch concerns)
+- `probe-e2e-restore*` family (specifically test "what happens after
+  restart" — they require a relaunch by definition)
+
+If you’re tempted to merge one of these, re-read the brainstorm §3
+(shared-state inventory) and §9 first.
+
+## What the reset between cases actually does
+
+`scripts/probe-helpers/reset-between-cases.mjs` runs in this order:
+
+1. Drains caller-supplied disposers (monkey-patch restore, listener removal).
+2. Calls `agentClose` for every session in the renderer store (kills the
+   per-session claude.exe subprocess via the same IPC the user’s Delete
+   Session button uses).
+3. Resets the zustand store to an empty baseline (sessions, groups,
+   activeId, queues, running flags, dialogs, focus nonce, recentProjects).
+   Settings (theme/language/font) are NOT touched — cases that flip them
+   must restore via `registerDispose`.
+4. Wipes `messages` table and the `app_state.main` row in SQLite via
+   `app.evaluate` against the shared DB handle.
+5. Clears DOM selection, blurs `document.activeElement`, and removes any
+   stray Radix portal containers (`[data-radix-popper-content-wrapper]`
+   and `[role="dialog"]` direct children of `document.body`).
+
+If a new global state surfaces (e.g. a fresh singleton `Map` in main.ts), add
+the corresponding reset step here. Flake rate >5% on a converted harness is
+the signal that this helper is missing something.

--- a/scripts/harness-agent.mjs
+++ b/scripts/harness-agent.mjs
@@ -1,0 +1,358 @@
+// Themed harness — AGENT cluster, Phase-2 pilot.
+//
+// Per docs/e2e/single-harness-brainstorm.md §8 (option B + C). Each case
+// below is the de-duplicated body of one of the per-file probes in
+// scripts/probe-e2e-*.mjs. The original probe files have been left in place
+// with a `// MERGED INTO harness-agent.mjs` marker on line 1 and are
+// excluded from the per-file runner via scripts/run-all-e2e.mjs's
+// MERGED_INTO_HARNESS skip list.
+//
+// Pilot scope (5 cases, all pure-store / no real claude.exe required):
+//   - streaming
+//   - streaming-caret-lifecycle
+//   - inputbar-visible
+//   - chat-copy
+//   - input-placeholder
+//
+// Add new AGENT cases here by:
+//   1. Wrap the case body in a named function `case<Name>({ win, log, ... })`.
+//   2. Use `log()` instead of `console.log()` for the case-id prefix.
+//   3. Throw on failure — the runner catches and records.
+//   4. If your case mounts a monkey-patch on main (`dialog.showOpenDialog`,
+//      `shell.openPath`, ...), call `registerDispose(() => app.evaluate(...))`
+//      so the runner restores the original before the next case.
+//   5. Keep cases independent. Don't read state set by an earlier case.
+//
+// Run: `node scripts/harness-agent.mjs`
+// Run one case: `node scripts/harness-agent.mjs --only=streaming`
+
+import { runHarness } from './probe-helpers/harness-runner.mjs';
+
+// ---------- streaming ----------
+async function caseStreaming({ win, log }) {
+  // Seed a session directly (instead of `createSession`, which triggers the
+  // CLI check and pops the "Claude CLI not found" dialog when claude.exe
+  // isn't on PATH — which is the default in CI). Same observable behaviour
+  // for the streamAssistantText/appendBlocks code path the case actually
+  // exercises.
+  const sessionId = 's-stream';
+  await win.evaluate((sid) => {
+    window.__agentoryStore.setState({
+      groups: [{ id: 'g1', name: 'G1', collapsed: false, kind: 'normal' }],
+      sessions: [{ id: sid, name: 'streaming-probe', state: 'idle', cwd: 'C:/x', model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code' }],
+      activeId: sid,
+      messagesBySession: { [sid]: [] }
+    });
+  }, sessionId);
+  await win.waitForTimeout(150);
+
+  await win.evaluate((sid) => {
+    const st = window.__agentoryStore.getState();
+    st.streamAssistantText(sid, 'msg-probe:c0', 'Hel', false);
+    st.streamAssistantText(sid, 'msg-probe:c0', 'lo, ', false);
+    st.streamAssistantText(sid, 'msg-probe:c0', 'world!', false);
+  }, sessionId);
+  await win.waitForTimeout(200);
+
+  const midState = await win.evaluate((sid) => {
+    const blocks = window.__agentoryStore.getState().messagesBySession[sid] ?? [];
+    return blocks.map((b) => ({ id: b.id, kind: b.kind, text: b.text, streaming: b.streaming }));
+  }, sessionId);
+  const streamingBlocks = midState.filter((b) => b.id === 'msg-probe:c0');
+  if (streamingBlocks.length !== 1) throw new Error(`expected 1 streaming block, got ${streamingBlocks.length}`);
+  if (streamingBlocks[0].text !== 'Hello, world!') throw new Error(`expected 'Hello, world!', got '${streamingBlocks[0].text}'`);
+  if (streamingBlocks[0].streaming !== true) throw new Error('streaming flag not set');
+
+  const caretCount = await win.locator('span.animate-pulse').count();
+  if (caretCount < 1) throw new Error('streaming caret not rendered in DOM');
+
+  await win.evaluate((sid) => {
+    window.__agentoryStore.getState().appendBlocks(sid, [
+      { kind: 'assistant', id: 'msg-probe:c0', text: 'Final reply.' }
+    ]);
+  }, sessionId);
+  await win.waitForTimeout(200);
+
+  const finalState = await win.evaluate((sid) => {
+    const blocks = window.__agentoryStore.getState().messagesBySession[sid] ?? [];
+    return blocks.filter((b) => b.id === 'msg-probe:c0').map((b) => ({ text: b.text, streaming: b.streaming }));
+  }, sessionId);
+  if (finalState.length !== 1) throw new Error(`after finalize, expected 1 block, got ${finalState.length}`);
+  if (finalState[0].text !== 'Final reply.') throw new Error(`expected 'Final reply.', got '${finalState[0].text}'`);
+  if (finalState[0].streaming) throw new Error('streaming flag should be cleared after finalize');
+
+  const finalCaretCount = await win.locator('span.animate-pulse').count();
+  if (finalCaretCount !== 0) throw new Error(`caret should disappear after finalize; found ${finalCaretCount}`);
+
+  log('3 deltas coalesced into 1 block; caret shown then hidden on finalize');
+}
+
+// ---------- streaming-caret-lifecycle ----------
+async function caseStreamingCaretLifecycle({ win, log }) {
+  const SID1 = 's-caret-final';
+  const BID1 = 'msg-caret:final';
+  await win.evaluate((sid) => {
+    window.__agentoryStore.setState({
+      groups: [{ id: 'g1', name: 'G1', collapsed: false, kind: 'normal' }],
+      sessions: [{ id: sid, name: 'caret-final', state: 'idle', cwd: 'C:/x', model: 'm', groupId: 'g1', agentType: 'claude-code' }],
+      activeId: sid,
+      messagesBySession: { [sid]: [{ kind: 'user', id: 'u-1', text: 'hi' }] },
+      startedSessions: { [sid]: true },
+      runningSessions: { [sid]: true }
+    });
+  }, SID1);
+
+  await win.evaluate(([sid, bid]) => {
+    const st = window.__agentoryStore.getState();
+    st.streamAssistantText(sid, bid, 'partial ', false);
+    st.streamAssistantText(sid, bid, 'reply ', false);
+  }, [SID1, BID1]);
+  await win.waitForTimeout(150);
+
+  const caretDuring = await win.locator('span.animate-pulse').count();
+  if (caretDuring < 1) throw new Error('Part 1: expected caret during stream, found 0');
+
+  await win.evaluate(([sid, bid]) => {
+    window.__agentoryStore.getState().appendBlocks(sid, [{ kind: 'assistant', id: bid, text: 'final reply' }]);
+    window.__agentoryStore.getState().setRunning(sid, false);
+  }, [SID1, BID1]);
+  await win.waitForTimeout(150);
+
+  const caretAfterFinal = await win.locator('span.animate-pulse').count();
+  if (caretAfterFinal !== 0) throw new Error(`Part 2: expected caret gone after finalize, found ${caretAfterFinal}`);
+
+  const blockAfterFinal = await win.evaluate(([sid, bid]) => {
+    const blocks = window.__agentoryStore.getState().messagesBySession[sid] ?? [];
+    return blocks.find((b) => b.id === bid);
+  }, [SID1, BID1]);
+  if (!blockAfterFinal) throw new Error('Part 2: finalized block missing');
+  if (blockAfterFinal.streaming) throw new Error('Part 2: block.streaming should be false after finalize');
+
+  // Part 3: Esc-interrupt mid-stream — distinct session in same renderer.
+  const SID2 = 's-caret-int';
+  const BID2 = 'msg-caret:int';
+  await win.evaluate((sid) => {
+    const cur = window.__agentoryStore.getState();
+    const sessions = cur.sessions.some((s) => s.id === sid)
+      ? cur.sessions
+      : [{ id: sid, name: 'caret-int', state: 'idle', cwd: 'C:/x', model: 'm', groupId: 'g1', agentType: 'claude-code' }, ...cur.sessions];
+    window.__agentoryStore.setState({
+      sessions,
+      activeId: sid,
+      messagesBySession: { ...cur.messagesBySession, [sid]: [{ kind: 'user', id: 'u-2', text: 'count' }] },
+      startedSessions: { ...cur.startedSessions, [sid]: true },
+      runningSessions: { ...cur.runningSessions, [sid]: true }
+    });
+  }, SID2);
+
+  await win.evaluate(([sid, bid]) => {
+    const st = window.__agentoryStore.getState();
+    st.streamAssistantText(sid, bid, '1 ', false);
+    st.streamAssistantText(sid, bid, '2 ', false);
+    st.streamAssistantText(sid, bid, '3 ', false);
+  }, [SID2, BID2]);
+  await win.waitForTimeout(150);
+
+  const caretMid = await win.locator('span.animate-pulse').count();
+  if (caretMid < 1) throw new Error('Part 3: caret should be visible mid-stream before interrupt');
+
+  await win.evaluate(() => {
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+  });
+  await win.waitForTimeout(150);
+
+  await win.evaluate(([sid, bid]) => {
+    const st = window.__agentoryStore.getState();
+    st.consumeInterrupted(sid);
+    const open = (st.messagesBySession[sid] ?? []).find((b) => b.id === bid);
+    if (open) {
+      st.appendBlocks(sid, [{ kind: 'assistant', id: bid, text: open.text ?? '' }]);
+    }
+    st.appendBlocks(sid, [{ kind: 'status', id: 'res-int', tone: 'info', title: 'Interrupted' }]);
+    st.setRunning(sid, false);
+  }, [SID2, BID2]);
+  await win.waitForTimeout(200);
+
+  const caretAfterInt = await win.locator('span.animate-pulse').count();
+  if (caretAfterInt !== 0) throw new Error(`Part 3: caret should be 0 after interrupt, found ${caretAfterInt}`);
+
+  log('Part 1 caret-during, Part 2 caret-gone-after-finalize, Part 3 caret-gone-after-interrupt');
+}
+
+// ---------- inputbar-visible ----------
+async function caseInputbarVisible({ win, log }) {
+  await win.evaluate(() => {
+    const store = window.__agentoryStore;
+    const many = [];
+    for (let i = 0; i < 80; i++) {
+      many.push({ kind: 'user', id: `u-${i}`, text: `message ${i} — ${'lorem '.repeat(12)}` });
+      many.push({
+        kind: 'assistant-md',
+        id: `a-${i}`,
+        text: `reply ${i}\n\n${'paragraph body '.repeat(20)}\n\n${'second paragraph '.repeat(15)}`
+      });
+    }
+    store.setState({
+      groups: [{ id: 'g1', name: 'G1', collapsed: false, kind: 'normal' }],
+      sessions: [
+        { id: 's1', name: 's', state: 'idle', cwd: 'C:/x', model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code' }
+      ],
+      activeId: 's1',
+      messagesBySession: { s1: many }
+    });
+  });
+  await win.waitForTimeout(400);
+
+  const ta = win.locator('textarea').first();
+  await ta.waitFor({ state: 'visible', timeout: 3000 });
+
+  const { box, vh } = await win.evaluate(() => {
+    const el = document.querySelector('textarea');
+    if (!el) return { box: null, vh: window.innerHeight };
+    const r = el.getBoundingClientRect();
+    return { box: { top: r.top, bottom: r.bottom }, vh: window.innerHeight };
+  });
+  if (!box) throw new Error('no textarea element');
+  if (box.bottom > vh + 1) throw new Error(`textarea extends below viewport: bottom=${box.bottom.toFixed(1)} vh=${vh}`);
+  if (box.top < 0 || box.top > vh) throw new Error(`textarea top=${box.top.toFixed(1)} outside viewport (vh=${vh})`);
+
+  // Clear any leftover draft text. The InputBar persists per-session drafts
+  // via src/stores/drafts.ts (module-scope cache, not in zustand) so a
+  // previous case that typed into a session with the same id can leak its
+  // text into ours. fill('') is the cheap fix.
+  await ta.fill('');
+  await ta.click();
+  await win.keyboard.type('hello');
+  const value = await ta.inputValue();
+  if (value !== 'hello') throw new Error(`type failed, got ${JSON.stringify(value)}`);
+
+  log(`textarea within viewport: top=${box.top.toFixed(1)} bottom=${box.bottom.toFixed(1)} vh=${vh}`);
+}
+
+// ---------- chat-copy ----------
+async function caseChatCopy({ win, log }) {
+  const SAMPLE = 'COPY_ME_PROBE_TEXT this should land in the clipboard';
+  await win.evaluate((sample) => {
+    window.__agentoryStore.setState({
+      groups: [{ id: 'g1', name: 'G1', collapsed: false, kind: 'normal' }],
+      sessions: [{ id: 's1', name: 's', state: 'idle', cwd: 'C:/x', model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code' }],
+      activeId: 's1',
+      messagesBySession: { s1: [{ kind: 'assistant', id: 'a1', text: sample }] }
+    });
+  }, SAMPLE);
+  await win.waitForTimeout(300);
+
+  const target = win.getByText('COPY_ME_PROBE_TEXT', { exact: false }).first();
+  await target.waitFor({ state: 'visible', timeout: 3000 });
+  await target.click();
+
+  await win.keyboard.press('Control+a');
+  await win.waitForTimeout(100);
+  const sel = await win.evaluate(() => window.getSelection()?.toString() ?? '');
+  if (!sel.includes('COPY_ME_PROBE_TEXT')) throw new Error(`Ctrl+A did not select chat text (selection=${JSON.stringify(sel.slice(0, 80))})`);
+
+  await win.keyboard.press('Control+c');
+  await win.waitForTimeout(150);
+  const clip = await win.evaluate(() => navigator.clipboard.readText().catch((e) => `ERR:${e.message}`));
+  if (!clip.includes('COPY_ME_PROBE_TEXT')) throw new Error(`clipboard missing sample after Ctrl+C (clip=${JSON.stringify(clip.slice(0, 80))})`);
+
+  log('Ctrl+A selects chat, Ctrl+C copies to clipboard');
+}
+
+// ---------- input-placeholder ----------
+async function caseInputPlaceholder({ win, log, registerDispose }) {
+  // i18n is a global side effect; restore en at case end via dispose.
+  registerDispose(async () => {
+    await win.evaluate(async () => {
+      try { if (window.__agentoryI18n) await window.__agentoryI18n.changeLanguage('en'); } catch {}
+    });
+  });
+
+  await win.evaluate(() => {
+    window.__agentoryStore.setState({
+      groups: [{ id: 'g1', name: 'G1', collapsed: false, kind: 'normal' }],
+      sessions: [{ id: 's1', name: 's', state: 'idle', cwd: 'C:/x', model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code' }],
+      activeId: 's1',
+      messagesBySession: {}
+    });
+  });
+  await win.waitForTimeout(300);
+
+  const ta = win.locator('textarea');
+  await ta.waitFor({ state: 'visible', timeout: 5000 });
+  const emptyPlaceholder = await ta.getAttribute('placeholder');
+  if (emptyPlaceholder !== 'Ask anything…') throw new Error(`empty-session placeholder should be "Ask anything…", got ${JSON.stringify(emptyPlaceholder)}`);
+
+  await win.evaluate(() => {
+    window.__agentoryStore.setState({
+      messagesBySession: { s1: [{ kind: 'user', id: 'u1', text: 'hi' }] }
+    });
+  });
+  await win.waitForTimeout(200);
+  const replyPlaceholder = await ta.getAttribute('placeholder');
+  if (replyPlaceholder !== 'Reply…') throw new Error(`with-messages placeholder should be "Reply…", got ${JSON.stringify(replyPlaceholder)}`);
+
+  // Long stream + running toggle.
+  await win.evaluate(() => {
+    const many = [];
+    for (let i = 0; i < 200; i++) {
+      many.push({ kind: i % 2 ? 'assistant' : 'user', id: `b-${i}`, text: `block ${i}` });
+    }
+    window.__agentoryStore.setState({ messagesBySession: { s1: many } });
+  });
+  await win.waitForTimeout(200);
+  const longReplyPh = await ta.getAttribute('placeholder');
+  if (longReplyPh !== 'Reply…') throw new Error(`after long stream, placeholder should still be "Reply…", got ${JSON.stringify(longReplyPh)}`);
+
+  await win.evaluate(() => window.__agentoryStore.getState().setRunning('s1', true));
+  await win.waitForTimeout(150);
+  const runningPh = await ta.getAttribute('placeholder');
+  if (!runningPh || !runningPh.includes('Esc')) throw new Error(`running placeholder should mention Esc, got ${JSON.stringify(runningPh)}`);
+  await win.evaluate(() => window.__agentoryStore.getState().setRunning('s1', false));
+  await win.waitForTimeout(150);
+  const backToReply = await ta.getAttribute('placeholder');
+  if (backToReply !== 'Reply…') throw new Error(`after running off, placeholder should return to "Reply…", got ${JSON.stringify(backToReply)}`);
+
+  // zh.
+  const switched = await win.evaluate(async () => {
+    for (let i = 0; i < 20 && !window.__agentoryI18n; i++) await new Promise((r) => setTimeout(r, 100));
+    if (!window.__agentoryI18n) return { ok: false, err: 'window.__agentoryI18n missing' };
+    await window.__agentoryI18n.changeLanguage('zh');
+    return { ok: true, lang: window.__agentoryI18n.language };
+  });
+  if (switched.ok) {
+    await win.waitForTimeout(200);
+    const zhPlaceholder = await ta.getAttribute('placeholder');
+    if (zhPlaceholder !== '回复…') throw new Error(`zh with-messages placeholder should be "回复…", got ${JSON.stringify(zhPlaceholder)}`);
+    await win.evaluate(() => window.__agentoryStore.setState({ messagesBySession: { s1: [] } }));
+    await win.waitForTimeout(150);
+    const zhEmpty = await ta.getAttribute('placeholder');
+    if (zhEmpty !== '问点什么…') throw new Error(`zh empty placeholder should be "问点什么…", got ${JSON.stringify(zhEmpty)}`);
+  } else {
+    log(`[skip] could not switch language dynamically: ${switched.err}`);
+  }
+
+  log('en+zh placeholder transitions verified');
+}
+
+// ---------- harness spec ----------
+await runHarness({
+  name: 'agent',
+  setup: async ({ win }) => {
+    // Suppress the "Claude CLI not found" first-launch dialog. Cases below
+    // never invoke claude.exe (they drive the renderer state machine
+    // directly), so claiming the CLI is found is a safe fixture.
+    await win.evaluate(() => {
+      window.__agentoryStore?.setState({
+        cliStatus: { state: 'found', binaryPath: '<harness>', version: null }
+      });
+    });
+  },
+  cases: [
+    { id: 'streaming', run: caseStreaming },
+    { id: 'streaming-caret-lifecycle', run: caseStreamingCaretLifecycle },
+    { id: 'inputbar-visible', run: caseInputbarVisible },
+    { id: 'chat-copy', run: caseChatCopy },
+    { id: 'input-placeholder', run: caseInputPlaceholder }
+  ]
+});

--- a/scripts/harness-agent.mjs
+++ b/scripts/harness-agent.mjs
@@ -176,7 +176,14 @@ async function caseStreamingCaretLifecycle({ win, log }) {
   const caretAfterInt = await win.locator('span.animate-pulse').count();
   if (caretAfterInt !== 0) throw new Error(`Part 3: caret should be 0 after interrupt, found ${caretAfterInt}`);
 
-  log('Part 1 caret-during, Part 2 caret-gone-after-finalize, Part 3 caret-gone-after-interrupt');
+  const blockAfterInt = await win.evaluate(([sid, bid]) => {
+    const blocks = window.__agentoryStore.getState().messagesBySession[sid] ?? [];
+    return blocks.find((b) => b.id === bid);
+  }, [SID2, BID2]);
+  if (!blockAfterInt) throw new Error('Part 3: in-flight block missing after interrupt — should remain with partial text');
+  if (blockAfterInt.streaming) throw new Error('Part 3: block.streaming should be false after interrupt-finalize');
+
+  log('Part 1 caret-during, Part 2 caret-gone-after-finalize, Part 3 caret-gone-after-interrupt + block-survived + streaming-cleared');
 }
 
 // ---------- inputbar-visible ----------

--- a/scripts/probe-e2e-chat-copy.mjs
+++ b/scripts/probe-e2e-chat-copy.mjs
@@ -1,3 +1,5 @@
+// MERGED INTO scripts/harness-agent.mjs (case id=chat-copy; see harness file).
+// This per-file probe is kept as a breadcrumb. The runner skips it via MERGED_INTO_HARNESS.
 // Regression: with Menu.setApplicationMenu(null) the Edit-role accelerators
 // (Ctrl+A, Ctrl+C, Ctrl+X, Ctrl+V, Ctrl+Z) are not registered on Windows
 // and Linux, making chat content feel "not copyable". Verify that Ctrl+A

--- a/scripts/probe-e2e-input-placeholder.mjs
+++ b/scripts/probe-e2e-input-placeholder.mjs
@@ -1,3 +1,5 @@
+// MERGED INTO scripts/harness-agent.mjs (case id=input-placeholder; see harness file).
+// This per-file probe is kept as a breadcrumb. The runner skips it via MERGED_INTO_HARNESS.
 // Empty session -> placeholder is "Ask anything…" (not "Reply…").
 // With messages -> placeholder becomes "Reply…".
 // Robustness extensions:

--- a/scripts/probe-e2e-inputbar-visible.mjs
+++ b/scripts/probe-e2e-inputbar-visible.mjs
@@ -1,3 +1,5 @@
+// MERGED INTO scripts/harness-agent.mjs (case id=inputbar-visible; see harness file).
+// This per-file probe is kept as a breadcrumb. The runner skips it via MERGED_INTO_HARNESS.
 // Regression: a long chat (content taller than viewport) must NOT push the
 // InputBar textarea off-screen. The root cause was ChatStream's scroll
 // container being `flex-1` without `min-h-0` inside a `flex flex-col` main,

--- a/scripts/probe-e2e-streaming-journey-caret-lifecycle.mjs
+++ b/scripts/probe-e2e-streaming-journey-caret-lifecycle.mjs
@@ -1,3 +1,5 @@
+// MERGED INTO scripts/harness-agent.mjs (case id=streaming-caret-lifecycle; see harness file).
+// This per-file probe is kept as a breadcrumb. The runner skips it via MERGED_INTO_HARNESS.
 // Journey 5: streaming caret lifecycle.
 //
 // Expectation:

--- a/scripts/probe-e2e-streaming.mjs
+++ b/scripts/probe-e2e-streaming.mjs
@@ -1,3 +1,5 @@
+// MERGED INTO scripts/harness-agent.mjs (case id=streaming; see harness file).
+// This per-file probe is kept as a breadcrumb. The runner skips it via MERGED_INTO_HARNESS.
 // Verify streaming UX:
 // - calling streamAssistantText creates an assistant block with a streaming caret
 // - subsequent deltas append text in place (no duplicate blocks)

--- a/scripts/probe-helpers/harness-runner.mjs
+++ b/scripts/probe-helpers/harness-runner.mjs
@@ -1,0 +1,203 @@
+// Shared runner for themed harnesses (harness-agent.mjs, harness-permission.mjs,
+// ...). Implements the Phase-1 deliverables from
+// docs/e2e/single-harness-brainstorm.md §8:
+//
+//   1. case-id logging — every console line a case emits is wrapped in
+//      `[case=<id>] ...` so a tail of mixed output is bisectable.
+//   2. `--only=<id>[,<id>]` flag — caller can filter cases when iterating
+//      locally on a single regression.
+//   3. per-case trace artifact — Playwright tracing is started before each
+//      case and only persisted to `scripts/e2e-artifacts/<harness>/<case>/`
+//      when the case throws (success path discards to keep CI green-runs
+//      light).
+//   4. caseScope — gives each case (a) a `log()` that adds the prefix,
+//      (b) a `dispose()` registry the runner drains in `resetBetweenCases`.
+//
+// Each harness file imports `runHarness` and provides:
+//   - `name`: harness id used as artifact subdir + log tag.
+//   - `setup({ app, win })`: optional one-time prep after Electron launches
+//     and before the first case (e.g. seed an empty group).
+//   - `cases`: array of `{ id, run({ app, win, log, registerDispose }) }`.
+//
+// The runner returns a non-zero exit if ANY case fails (after attempting to
+// run the rest, so one regression doesn't mask another).
+
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { appWindow } from '../probe-utils.mjs';
+import { resetBetweenCases } from './reset-between-cases.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const ARTIFACTS_ROOT = path.join(REPO_ROOT, 'scripts/e2e-artifacts');
+
+/**
+ * Parse `--only=a,b,c` from argv. Returns null when absent (= run all).
+ *
+ * @returns {Set<string> | null}
+ */
+function parseOnly(argv) {
+  for (const a of argv) {
+    if (a.startsWith('--only=')) {
+      const parts = a.slice('--only='.length).split(',').map((s) => s.trim()).filter(Boolean);
+      return new Set(parts);
+    }
+  }
+  return null;
+}
+
+/**
+ * @typedef {object} HarnessCase
+ * @property {string} id  Unique within the harness; goes into log prefix +
+ *                        artifact path.
+ * @property {(ctx: HarnessCaseCtx) => Promise<void>} run
+ */
+
+/**
+ * @typedef {object} HarnessCaseCtx
+ * @property {import('playwright').ElectronApplication} app
+ * @property {import('playwright').Page} win
+ * @property {(...args: unknown[]) => void} log  Emits `[case=<id>] ...` to
+ *                                              stdout; use instead of console.log.
+ * @property {(fn: () => void | Promise<void>) => void} registerDispose
+ *           Push a cleanup; runner awaits all of these in reverse order
+ *           inside resetBetweenCases.
+ */
+
+/**
+ * @typedef {object} HarnessSpec
+ * @property {string} name
+ * @property {(ctx: { app: import('playwright').ElectronApplication, win: import('playwright').Page }) => Promise<void>} [setup]
+ * @property {HarnessCase[]} cases
+ * @property {{ args?: string[], env?: Record<string, string> }} [launch]
+ */
+
+/**
+ * Drive a themed harness. See file comment.
+ *
+ * @param {HarnessSpec} spec
+ */
+export async function runHarness(spec) {
+  const only = parseOnly(process.argv.slice(2));
+  const filtered = spec.cases.filter((c) => !only || only.has(c.id));
+
+  if (only && filtered.length === 0) {
+    console.error(`[harness=${spec.name}] --only matched no cases. Available: ${spec.cases.map((c) => c.id).join(', ')}`);
+    process.exit(2);
+  }
+
+  const harnessArtifactDir = path.join(ARTIFACTS_ROOT, spec.name);
+  fs.mkdirSync(harnessArtifactDir, { recursive: true });
+
+  console.log(`[harness=${spec.name}] launching electron — ${filtered.length}/${spec.cases.length} case(s)`);
+
+  const launchArgs = ['.', ...(spec.launch?.args ?? [])];
+  // AGENTORY_PROD_BUNDLE=1 forces electron/main.ts to loadFile from
+  // dist/renderer instead of expecting a dev server on localhost:4100.
+  // Harness runs are CI-like by definition — no dev server is up.
+  const launchEnv = {
+    ...process.env,
+    NODE_ENV: 'production',
+    AGENTORY_PROD_BUNDLE: '1',
+    ...(spec.launch?.env ?? {})
+  };
+
+  const tStart = Date.now();
+  const app = await electron.launch({ args: launchArgs, cwd: REPO_ROOT, env: launchEnv });
+
+  /** @type {Array<{ id: string, status: 'passed'|'failed', ms: number, error?: string }>} */
+  const results = [];
+
+  let win;
+  try {
+    win = await appWindow(app);
+    await win.waitForLoadState('domcontentloaded');
+    await win.waitForFunction(() => !!window.__agentoryStore, null, { timeout: 20_000 });
+
+    if (spec.setup) {
+      await spec.setup({ app, win });
+    }
+
+    for (const c of filtered) {
+      /** @type {Array<() => void | Promise<void>>} */
+      const disposers = [];
+      const log = (...args) => console.log(`[case=${c.id}]`, ...args);
+      const registerDispose = (fn) => { disposers.push(fn); };
+
+      const caseDir = path.join(harnessArtifactDir, c.id);
+      const caseStart = Date.now();
+      console.log(`\n[harness=${spec.name}] >>> case ${c.id}`);
+
+      // Per-case Playwright trace. Only persisted on failure (see catch below).
+      const ctx = win.context();
+      try {
+        await ctx.tracing.start({ screenshots: true, snapshots: true, sources: false, title: c.id });
+      } catch {
+        // Tracing may already be active if a previous case crashed mid-stop;
+        // ignore and continue without trace.
+      }
+
+      let caseError = null;
+      try {
+        await c.run({ app, win, log, registerDispose });
+        log('OK');
+      } catch (err) {
+        caseError = err instanceof Error ? err : new Error(String(err));
+        console.error(`[case=${c.id}] FAIL: ${caseError.message}`);
+      }
+
+      // Stop tracing — keep zip only on failure.
+      try {
+        if (caseError) {
+          fs.mkdirSync(caseDir, { recursive: true });
+          await ctx.tracing.stop({ path: path.join(caseDir, 'trace.zip') });
+          // Also dump page screenshot for fast triage without unzipping.
+          try { await win.screenshot({ path: path.join(caseDir, 'failure.png'), fullPage: true }); } catch {}
+        } else {
+          await ctx.tracing.stop();
+        }
+      } catch {
+        // Ignore tracing teardown errors — they shouldn't mask the case status.
+      }
+
+      // Reset BEFORE recording the next case start, so reset cost is attributed
+      // to the case that produced the mess. Do it even if the case failed:
+      // we still want subsequent cases to start clean.
+      try {
+        await resetBetweenCases(app, win, { disposers });
+      } catch (err) {
+        console.error(`[harness=${spec.name}] reset after ${c.id} threw:`, err);
+      }
+
+      const ms = Date.now() - caseStart;
+      if (caseError) {
+        results.push({ id: c.id, status: 'failed', ms, error: caseError.stack ?? caseError.message });
+      } else {
+        results.push({ id: c.id, status: 'passed', ms });
+      }
+    }
+  } finally {
+    try { await app.close(); } catch {}
+  }
+
+  const wallMs = Date.now() - tStart;
+  const passed = results.filter((r) => r.status === 'passed').length;
+  const failed = results.filter((r) => r.status === 'failed');
+
+  console.log(`\n=== harness=${spec.name} summary (${wallMs}ms wall) ===`);
+  for (const r of results) {
+    const tag = r.status === 'passed' ? '[OK]' : '[XX]';
+    console.log(`  ${tag} ${r.id.padEnd(40)} ${String(r.ms).padStart(6)}ms`);
+  }
+  if (failed.length > 0) {
+    console.log(`\n=== failures (${failed.length}) ===`);
+    for (const r of failed) {
+      console.log(`\n--- ${r.id} ---\n${r.error}`);
+    }
+  }
+  console.log(`\n=== totals: ${passed} passed, ${failed.length} failed, ${results.length} total ===`);
+
+  process.exit(failed.length === 0 ? 0 : 1);
+}

--- a/scripts/probe-helpers/reset-between-cases.mjs
+++ b/scripts/probe-helpers/reset-between-cases.mjs
@@ -1,0 +1,173 @@
+// Shared helper: reset shared Electron + renderer state between harness cases.
+//
+// Background — see docs/e2e/single-harness-brainstorm.md §3.
+// One Electron process serves multiple cases inside a "themed harness"
+// (harness-agent.mjs, harness-permission.mjs, ...). The brainstorm enumerates
+// what *isn't* per-session and therefore must be reset by hand:
+//
+//   1. zustand store singleton (sessions, groups, activeId, dialogs, queues,
+//      focus nonce, ...). Settings (theme/language/font) are KEPT — switching
+//      them is a per-case concern, the case is responsible for restoring.
+//   2. agent subprocesses owned by main (`agent:close` IPC for each session).
+//   3. SQLite `app_state` rows outside the persisted-keys allowlist + all
+//      rows in `messages`. The DB handle is shared across cases; leftover
+//      rows from case N would re-hydrate into case N+1 on a renderer reload.
+//   4. Renderer-side global side effects: open Radix portals (dialog /
+//      popover / dropdown / context-menu), DOM selection, document.activeElement.
+//   5. Caller-supplied dispose functions for monkey-patches the case set up
+//      (`dialog.showOpenDialog`, `shell.openPath`, ...) — caller passes them
+//      via `registerDispose` returned from `caseScope`.
+//
+// What this helper INTENTIONALLY does NOT do:
+//   - It does NOT reload the renderer. That would cost a ~500ms hydrate cycle
+//     per case and re-introduce cold-start noise we're trying to avoid.
+//   - It does NOT reset i18n language or theme. Those are persisted user
+//     preferences; cases that flip them must restore in their own dispose.
+//   - It does NOT kill the Electron process. That defeats the whole point.
+//
+// `app_state` actually stores ONE row keyed `main` with the entire persisted
+// snapshot as a JSON blob (see src/stores/persist.ts STATE_KEY). So we can't
+// "keep theme but wipe sessions" via a row-level DELETE — we'd have to read,
+// rewrite, and re-save the JSON. The cleaner answer for the harness model is:
+// reset the renderer store to a known empty baseline, let the debounced
+// persister overwrite the `main` row with that empty snapshot, and additionally
+// wipe `messages` (which IS row-per-session-keyed). Keeping the keep-list as
+// a future-proof spot in case persist.ts ever splits keys into rows.
+const APP_STATE_KEEP = new Set([
+  // currently empty — see comment above. If/when persist.ts splits keys, list
+  // the survivors here (e.g. 'theme', 'fontSize', 'fontSizePx', 'density').
+]);
+
+/**
+ * Reset shared state so the next case starts from a clean baseline.
+ *
+ * @param {import('playwright').ElectronApplication} app
+ * @param {import('playwright').Page} win
+ * @param {object} [opts]
+ * @param {Array<() => (void | Promise<void>)>} [opts.disposers]
+ *   Caller-collected dispose callbacks for monkey-patches / listeners
+ *   registered by the previous case. Each is awaited; errors are swallowed
+ *   so one bad disposer can't strand the harness.
+ */
+export async function resetBetweenCases(app, win, opts = {}) {
+  const disposers = opts.disposers ?? [];
+
+  // 1. Run caller disposers FIRST so monkey-patched main-process modules are
+  //    restored before we ask main for the live session list.
+  for (const fn of disposers.splice(0)) {
+    try { await fn(); } catch { /* swallow */ }
+  }
+
+  // 2. Close every open agent subprocess via IPC. Iterate from the renderer
+  //    so we hit the exact same code path the user does (Delete Session).
+  await win.evaluate(async () => {
+    const ids = (window.__agentoryStore?.getState().sessions ?? []).map((s) => s.id);
+    for (const id of ids) {
+      try { await window.agentory?.agentClose?.(id); } catch { /* ignore */ }
+    }
+  }).catch(() => { /* renderer may have just navigated; not fatal */ });
+
+  // 3. Reset zustand store to a minimal clean baseline. We can't call a
+  //    "resetAll()" because the store doesn't expose one — but setState with
+  //    explicit empty maps is sufficient for the keys cases actually exercise.
+  //    Settings keys (theme/language/font) are deliberately not touched.
+  //    cliStatus is forced to `found` so the "Claude CLI not found" modal
+  //    doesn't bleed into the next case in CI environments where claude.exe
+  //    isn't on PATH.
+  await win.evaluate(() => {
+    const store = window.__agentoryStore;
+    if (!store) return;
+    store.setState({
+      sessions: [],
+      groups: [],
+      activeId: '',
+      messagesBySession: {},
+      messageQueues: {},
+      runningSessions: {},
+      startedSessions: {},
+      interruptedSessions: {},
+      statsBySession: {},
+      focusInputNonce: 0,
+      focusTarget: null,
+      paletteOpen: false,
+      dialogOpen: null,
+      recentProjects: [],
+      cliStatus: { state: 'found', binaryPath: '<harness>', version: null }
+    });
+  }).catch(() => {});
+
+  // 4. Truncate DB tables. `messages` is row-per-session, safe to fully wipe.
+  //    `app_state` stores both the main store snapshot (key=`main`) AND the
+  //    composer-draft cache (key=`drafts`, see src/stores/drafts.ts). We
+  //    delete both so a subsequent reload (or a case that re-uses an old
+  //    session id) doesn't pick up leftover drafts. The `drafts` cache is
+  //    module-scope inside the renderer, so even after this delete an
+  //    in-flight case will need to call `ta.fill('')` to scrub the live
+  //    cache — DB cleanup only protects against next-launch hydration.
+  await app.evaluate(async (_main, keepKeys) => {
+    try {
+      const path = require('node:path');
+      const Database = require('better-sqlite3');
+      const { app: electronApp } = require('electron');
+      const dbPath = path.join(electronApp.getPath('userData'), 'agentory.db');
+      const db = new Database(dbPath);
+      db.exec('DELETE FROM messages;');
+      if (keepKeys.length === 0) {
+        db.exec('DELETE FROM app_state;');
+      } else {
+        const placeholders = keepKeys.map(() => '?').join(',');
+        db.prepare(`DELETE FROM app_state WHERE key NOT IN (${placeholders});`).run(...keepKeys);
+      }
+      db.close();
+    } catch {
+      // DB may not exist yet for the very first case; not fatal.
+    }
+  }, [...APP_STATE_KEEP]).catch(() => {});
+
+  // 5. Renderer-side globals: dismiss open Radix portals, blur active element,
+  //    clear DOM selection. Radix mounts portals (Dialog, Popover, Dropdown,
+  //    ContextMenu) as direct children of <body>. We attack them three ways:
+  //      a) press Escape to give Radix a chance to close cleanly (drives
+  //         onOpenChange and unmounts via the normal lifecycle).
+  //      b) flip every `data-state="open"` to `closed` so animation handlers
+  //         tear down trees that ignored Escape.
+  //      c) hard-remove any leftover overlay/portal containers as a backstop —
+  //         a stuck `fixed inset-0` overlay swallows pointer events for the
+  //         next case, which is the most insidious failure mode we've seen.
+  await win.evaluate(async () => {
+    try { window.getSelection()?.removeAllRanges?.(); } catch {}
+    try {
+      const el = document.activeElement;
+      if (el && typeof el.blur === 'function') el.blur();
+    } catch {}
+    try {
+      // (a) Escape twice — covers stacked portals (e.g. context menu in dialog).
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+    } catch {}
+    // Yield a microtask + animation frame so React effects run.
+    await new Promise((r) => setTimeout(r, 60));
+    try {
+      // (b) Force-close anything still open by data-state, then (c) yank the
+      // portal nodes themselves. We do BOTH because some Radix components
+      // remount on next open while others rely on the existing node staying
+      // around — covering both is cheap.
+      document.querySelectorAll('[data-state="open"]').forEach((n) => {
+        try { n.setAttribute('data-state', 'closed'); } catch {}
+      });
+      document.querySelectorAll('[data-radix-popper-content-wrapper]').forEach((n) => n.remove());
+      // Radix Dialog overlay + content sit under <body> with role=dialog or
+      // a class containing `inset-0`. Only remove direct body children to
+      // avoid blowing up the app's own layout.
+      Array.from(document.body.children).forEach((n) => {
+        const role = n.getAttribute('role');
+        const cls = (n.getAttribute('class') ?? '').toString();
+        const isOverlay = cls.includes('inset-0') && (cls.includes('bg-black') || cls.includes('backdrop'));
+        const isDialog = role === 'dialog' || role === 'alertdialog';
+        if (isOverlay || isDialog) {
+          try { n.remove(); } catch {}
+        }
+      });
+    } catch {}
+  }).catch(() => {});
+}

--- a/scripts/run-all-e2e.mjs
+++ b/scripts/run-all-e2e.mjs
@@ -1,12 +1,18 @@
-// Batch runner for every `scripts/probe-e2e-*.mjs`.
+// Batch runner for every `scripts/probe-e2e-*.mjs` AND every
+// `scripts/harness-*.mjs` themed harness.
 //
 // - Discovers probes by glob, sorts deterministically.
 // - Runs them serially (Electron can't share its singleton lock — parallel
 //   launches race on user-data-dir and port allocation).
-// - 30s wall-clock timeout per probe (kill tree on overrun).
+// - 30s wall-clock timeout per probe; 5min for harness-* (they pack many
+//   cases into one launch).
 // - Prints a final table; exit code = max child exit code (0 if all green).
 // - Skip list via `E2E_SKIP=name1,name2` (matches the suffix after
 //   `probe-e2e-` and before `.mjs`, e.g. `E2E_SKIP=streaming,tray`).
+// - Probes whose suffix is listed in `MERGED_INTO_HARNESS` are skipped here
+//   because their cases now live inside a `harness-*.mjs`. Keep the source
+//   files around as breadcrumbs (top of file says where they moved); delete
+//   them in a follow-up once the harness has stabilised.
 //
 // Run: `node scripts/run-all-e2e.mjs`
 
@@ -17,8 +23,21 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SCRIPTS_DIR = __dirname;
-const TIMEOUT_MS = 30_000;
+const PROBE_TIMEOUT_MS = 30_000;
+const HARNESS_TIMEOUT_MS = 5 * 60_000;
 const PROBE_PREFIX = 'probe-e2e-';
+const HARNESS_PREFIX = 'harness-';
+
+// Cases now living inside a themed harness — their per-file probe is a
+// breadcrumb only. Keep this list in sync with the harness `cases:` arrays.
+const MERGED_INTO_HARNESS = new Set([
+  // harness-agent.mjs (Phase-2 pilot)
+  'streaming',
+  'streaming-journey-caret-lifecycle',
+  'inputbar-visible',
+  'chat-copy',
+  'input-placeholder'
+]);
 
 const skipRaw = (process.env.E2E_SKIP || '').trim();
 const skipSet = new Set(
@@ -29,21 +48,32 @@ const skipSet = new Set(
 );
 
 function probeName(file) {
+  if (file.startsWith(HARNESS_PREFIX)) return file.slice(0, -'.mjs'.length);
   return file.slice(PROBE_PREFIX.length, -'.mjs'.length);
 }
 
-const allFiles = readdirSync(SCRIPTS_DIR)
+const probeFiles = readdirSync(SCRIPTS_DIR)
   .filter((f) => f.startsWith(PROBE_PREFIX) && f.endsWith('.mjs'))
   .sort();
+const harnessFiles = readdirSync(SCRIPTS_DIR)
+  .filter((f) => f.startsWith(HARNESS_PREFIX) && f.endsWith('.mjs'))
+  .sort();
+// Run harnesses FIRST — they're slower per-file but pack many cases, so
+// failing fast on a regression in a merged case beats waiting for 70 cold
+// launches.
+const allFiles = [...harnessFiles, ...probeFiles];
 
 if (allFiles.length === 0) {
-  console.error('[run-all-e2e] no probes found');
+  console.error('[run-all-e2e] no probes or harnesses found');
   process.exit(1);
 }
 
-console.log(`[run-all-e2e] discovered ${allFiles.length} probe(s)`);
+console.log(`[run-all-e2e] discovered ${harnessFiles.length} harness(es) + ${probeFiles.length} probe(s)`);
 if (skipSet.size > 0) {
-  console.log(`[run-all-e2e] skipping: ${[...skipSet].join(', ')}`);
+  console.log(`[run-all-e2e] skipping (E2E_SKIP): ${[...skipSet].join(', ')}`);
+}
+if (MERGED_INTO_HARNESS.size > 0) {
+  console.log(`[run-all-e2e] skipping (merged into harness): ${[...MERGED_INTO_HARNESS].join(', ')}`);
 }
 
 /** @type {Array<{name: string, status: 'passed'|'failed'|'skipped'|'timeout', code: number, ms: number, stderrTail: string}>} */
@@ -51,7 +81,9 @@ const results = [];
 
 for (const file of allFiles) {
   const name = probeName(file);
-  if (skipSet.has(name)) {
+  const isHarness = file.startsWith(HARNESS_PREFIX);
+  const probeSuffix = isHarness ? null : file.slice(PROBE_PREFIX.length, -'.mjs'.length);
+  if (skipSet.has(name) || (probeSuffix && MERGED_INTO_HARNESS.has(probeSuffix))) {
     results.push({ name, status: 'skipped', code: 0, ms: 0, stderrTail: '' });
     console.log(`\n[run-all-e2e] SKIP  ${name}`);
     continue;
@@ -61,7 +93,8 @@ for (const file of allFiles) {
   console.log(`\n[run-all-e2e] RUN   ${name}`);
 
   const started = Date.now();
-  const { code, timedOut, stderrTail } = await runOne(full);
+  const timeoutMs = isHarness ? HARNESS_TIMEOUT_MS : PROBE_TIMEOUT_MS;
+  const { code, timedOut, stderrTail } = await runOne(full, timeoutMs);
   const ms = Date.now() - started;
 
   let status;
@@ -110,9 +143,10 @@ process.exit(exit);
  * runner). `shell: false` keeps Windows path quoting predictable.
  *
  * @param {string} scriptPath
+ * @param {number} timeoutMs
  * @returns {Promise<{code: number, timedOut: boolean, stderrTail: string}>}
  */
-function runOne(scriptPath) {
+function runOne(scriptPath, timeoutMs) {
   return new Promise((resolve) => {
     const child = spawn(process.execPath, [scriptPath], {
       shell: false,
@@ -142,7 +176,7 @@ function runOne(scriptPath) {
       } catch {
         /* ignore */
       }
-    }, TIMEOUT_MS);
+    }, timeoutMs);
 
     child.on('exit', (code, signal) => {
       clearTimeout(timer);
@@ -150,7 +184,7 @@ function runOne(scriptPath) {
       resolve({
         code: code ?? (signal ? 1 : 1),
         timedOut,
-        stderrTail: timedOut ? `(killed after ${TIMEOUT_MS}ms)\n${tail}` : tail,
+        stderrTail: timedOut ? `(killed after ${timeoutMs}ms)\n${tail}` : tail,
       });
     });
 


### PR DESCRIPTION
## Summary

Lands the brainstorm doc's **Option B (themed harnesses) + cultural rule from C** (extend existing, don't add a new file per bug). Design discussion: `docs/e2e/single-harness-brainstorm.md`.

### Phase 1 — infra prerequisites

- **Case-id logging convention**: every harness case logs `[case=<id>] …` so a tail of mixed output is bisectable.
- **`scripts/probe-helpers/reset-between-cases.mjs`**: closes sessions via IPC, resets zustand store to empty baseline, wipes `messages` + `app_state` rows in SQLite, dismisses Radix portals + clears DOM selection, drains caller-supplied disposers (monkey-patch restores).
- **`--only=<case>[,<case>]` flag** on `harness-runner` for local single-case dev.
- **Per-case Playwright tracing** — only persisted to `scripts/e2e-artifacts/<harness>/<case>/trace.zip` on failure (success path discards to keep CI green-runs light); also dumps `failure.png` for fast triage.

### Phase 2 — pilot `harness-agent.mjs`

5 store-only AGENT cases merged into one Electron launch:

- `streaming`
- `streaming-caret-lifecycle` (was `probe-e2e-streaming-journey-caret-lifecycle.mjs`)
- `inputbar-visible`
- `chat-copy`
- `input-placeholder`

Per-file probes left as breadcrumbs with top-of-file `// MERGED INTO scripts/harness-agent.mjs` marker. Runner skips them via the in-file `MERGED_INTO_HARNESS` set in `scripts/run-all-e2e.mjs`.

### Runner update

`scripts/run-all-e2e.mjs` now:
- discovers `harness-*.mjs` alongside `probe-e2e-*.mjs` (harnesses run first — fail-fast on regressions in merged cases),
- uses 5min timeout for harnesses (probes still 30s),
- skips merged probes via `MERGED_INTO_HARNESS`.

### Docs

`docs/e2e-runner.md` rewritten to cover both surfaces: how to add a new case (which surface + naming conventions + dispose responsibility), the cases that **can't** be merged (cold-start cluster from brainstorm §9), and how `--only` works locally.

## Measurements (this branch, headless prod-bundle on Windows)

| Metric | Value |
|---|---|
| typecheck | PASS |
| build | PASS |
| harness-agent — 5 cases wall clock | 13.8–16.4s, avg **15.6s** over 20 runs |
| same 5 probes individually (standalone, when they pass) | ~47s total |
| **wall-clock reduction for pilot cluster** | **~67%** |
| **flake rate** | **0/20 (0%)** vs brainstorm's <5% bar |
| case count before/after | 5/5 (no coverage loss) |

Pre-existing unit-test failures (12, all in `electron/__tests__/db-hardening.test.ts` due to `better-sqlite3` Node ABI mismatch in this env) are present on `working` HEAD too — unaffected by this PR.

## Test plan

- [ ] Reviewer runs `node scripts/harness-agent.mjs` and gets 5/5 PASS
- [ ] Reviewer runs `node scripts/harness-agent.mjs --only=streaming` and gets 1/1 PASS
- [ ] Reviewer runs `node scripts/run-all-e2e.mjs` end-to-end and confirms harness-agent runs first, then non-merged probes (the 5 merged ones show as SKIP).
- [ ] Reviewer skims `docs/e2e-runner.md` — onboarding read should make the "where do I put a new case?" question obvious.
- [ ] Reviewer confirms `scripts/probe-e2e-{streaming,streaming-journey-caret-lifecycle,inputbar-visible,chat-copy,input-placeholder}.mjs` carry the `// MERGED INTO …` breadcrumb on line 1.

## Follow-up (Phase 3, separate PRs)

- Convert remaining ~22 AGENT probes — real-API ones gated on token env, do those once the harness pattern is settled.
- `harness-permission.mjs` (~10 cases, similar shape).
- `harness-ui-runtime.mjs` (UI cases that survive a store reset).
- Cold-start probes stay one-launch-each per brainstorm §9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)