### PR TITLE
ux(startup): remove "Claude CLI detected" toast on every launch

### DIFF
--- a/scripts/probe-e2e-empty-state-minimal.mjs
+++ b/scripts/probe-e2e-empty-state-minimal.mjs
@@ -1,6 +1,11 @@
 // Verifies the minimal empty state: "Ready when you are." is visible and the
 // four starter prompt cards are GONE (regression guard against reintroducing
 // them). A fresh session shouldn't tell the user what to do — they know.
+//
+// Also guards: on automatic startup detection of Claude CLI, the success
+// flash "Claude CLI detected" must NOT appear. That modal blip on every
+// launch was noise — the success pane is reserved for in-dialog Retry/Browse
+// feedback when the CLI was previously missing.
 import { _electron as electron } from 'playwright';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -23,6 +28,30 @@ const app = await electron.launch({
 const win = await appWindow(app);
 await win.waitForLoadState('domcontentloaded');
 await win.waitForFunction(() => !!window.__agentoryStore, null, { timeout: 10000 });
+
+// Wait for the startup CLI check to settle (state leaves 'checking'). If the
+// regression returns, the success flash pops here — give it a real chance to
+// appear before we assert absence.
+await win.waitForFunction(
+  () => window.__agentoryStore.getState().cliStatus.state !== 'checking',
+  null,
+  { timeout: 10000 }
+).catch(() => { /* fall through — assertion below will catch a stuck state if relevant */ });
+await win.waitForTimeout(800);
+
+const cliState = await win.evaluate(() => window.__agentoryStore.getState().cliStatus.state);
+if (cliState === 'found') {
+  // Only assert absence when CLI was actually detected — if CLI is genuinely
+  // missing on this machine, the wizard is supposed to be visible and we
+  // should not flag that as a regression.
+  for (const phrase of ['Claude CLI detected', '已检测到 Claude CLI']) {
+    const n = await win.getByText(phrase, { exact: false }).count();
+    if (n > 0) {
+      await app.close();
+      fail(`startup success flash "${phrase}" leaked on automatic launch (count=${n}) — should only show after manual Retry/Browse from missing dialog`);
+    }
+  }
+}
 
 await win.evaluate(() => {
   window.__agentoryStore.setState({
@@ -54,5 +83,6 @@ if (workingIn > 0) { await app.close(); fail('old "Working in …" line still re
 
 console.log('\n[probe-e2e-empty-state-minimal] OK');
 console.log('  hero visible, no starter cards, no "Working in" line');
+console.log('  no startup "Claude CLI detected" flash');
 
 await app.close();

--- a/src/components/ClaudeCliMissingDialog.tsx
+++ b/src/components/ClaudeCliMissingDialog.tsx
@@ -64,10 +64,23 @@ export function ClaudeCliMissingDialog() {
     void api.getInstallHints().then(setHints).catch(() => {});
   }, [open, hints]);
 
-  // When the store flips into "found" after a successful retry / browse, we
-  // show a brief success flash and then auto-close.
+  // Track whether the missing-CLI dialog was open just before the store
+  // flipped to "found". The success flash should only fire as feedback for an
+  // in-dialog action (Retry detect / Browse for binary). On automatic startup
+  // detection, the dialog is never open, so we must NOT pop the flash — that
+  // turned every app launch into a noisy "Claude CLI detected" modal blip.
+  const wasMissingDialogOpen = useRef(false);
+  useEffect(() => {
+    if (open) wasMissingDialogOpen.current = true;
+  }, [open]);
+
+  // When the store flips into "found" after a successful retry / browse from
+  // inside the dialog, show a brief success flash and then auto-close. Suppress
+  // the flash entirely when the transition wasn't user-initiated from the
+  // dialog (e.g. the automatic checkCli() that runs on App mount).
   useEffect(() => {
     if (cliStatus.state !== 'found') return;
+    if (!wasMissingDialogOpen.current) return;
     if (!successTimer.current) {
       setSuccessVersion(cliStatus.version);
       setFoundBinary(cliStatus.binaryPath);
@@ -75,6 +88,7 @@ export function ClaudeCliMissingDialog() {
         setSuccessVersion(null);
         setFoundBinary(null);
         successTimer.current = null;
+        wasMissingDialogOpen.current = false;
       }, 1500);
     }
     return () => {


### PR DESCRIPTION
## Summary

User feedback: every app launch popped a brief "已检测到 Claude CLI" / "Claude CLI detected" modal flash. Noise on a happy path that needs no celebration.

**Root cause**: `ClaudeCliMissingDialog`'s success-flash effect fires whenever `cliStatus.state === 'found'`, with no guard for whether the user was actually looking at the missing-CLI dialog. On every cold start `checkCli()` runs from `App.tsx` → state goes `checking → found` → effect fires → success pane mounts for 1500ms even though the dialog was never visible.

**Fix scope** (per task brief): only suppress the flash on the *automatic startup* path. Keep it intact when the user clicks Retry detect / Browse for binary inside the missing dialog — that is genuine in-context feedback.

## Changes

- `src/components/ClaudeCliMissingDialog.tsx`: add a `wasMissingDialogOpen` ref that flips true while `open` is true, and gate the success-flash effect on it. Resets after the flash auto-closes so a future missing → found cycle still flashes.
- `scripts/probe-e2e-empty-state-minimal.mjs`: extend (not new file, per `feedback_e2e_extend_existing.md`) with an absence assertion that "Claude CLI detected" / "已检测到 Claude CLI" never appears on automatic launch. Skipped when CLI is genuinely missing on the host so the probe still works on bare machines.

i18n string `cli.detected` is still referenced (manual Browse path), so it stays.

## Verification

- `probe-e2e-empty-state-minimal.mjs` PASSES with fix → success flash absent on launch.
- Reverse-verified: `git stash` the dialog fix → rebuild → probe FAILS with `startup success flash "Claude CLI detected" leaked on automatic launch (count=1)`.
- `probe-cli-missing.mjs` PASSES → manual Browse path still shows the success pane with detected version.
- Missing-CLI banner / blocking dialog logic untouched (`ClaudeCliMissingBanner.tsx`, `cliStatus.state === 'missing'` branches unchanged).

## Test plan

- [x] Build succeeds (tsc + webpack)
- [x] `node scripts/probe-e2e-empty-state-minimal.mjs` (with `AGENTORY_PROD_BUNDLE=1`) — passes
- [x] `node scripts/probe-cli-missing.mjs` — passes (manual flash still works)
- [x] Reverse-verify: probe fails without fix