### PR TITLE
fix(perm): resolve all N parallel Allow clicks individually (Bug L follow-up)

### DIFF
--- a/scripts/probe-e2e-permission-allow-parallel-batch.mjs
+++ b/scripts/probe-e2e-permission-allow-parallel-batch.mjs
@@ -1,15 +1,29 @@
 // E2E regression probe for Bug L / A2-NEW-3 — parallel tool batch variant.
 //
-// Refined repro from Dogfood G: when the agent emits N tool_use blocks in a
-// single turn (parallel tool batch), the harness's permission delivery path
-// must handle N independent permission decisions concurrently. Pre-fix only
-// the first one's response shape was accepted by claude.exe (and even then
-// often only by accident); the remaining N-1 were silently dropped, leaving
-// most tool_use blocks without a tool_result and the agent silent on the
-// follow-up turn.
+// Background: when the agent emits N tool_use blocks in a single turn
+// (parallel tool batch), the harness must (a) deliver N independent permission
+// decisions back to claude.exe, (b) keep N independent tool blocks in the
+// renderer store so the N tool_results can be attached. Two distinct
+// regressions have been seen:
 //
-// Asserts: after Allow on each prompt, EVERY parallel tool_use block in the
-// store gains a `result`. Not just the first.
+//   1. PR #172 (Bug L): outbound `control_response` envelope shape was wrong
+//      so claude.exe silently dropped hook_callback responses. Fixed there;
+//      this probe still guards against regression.
+//   2. Bug L follow-up (this file's primary subject): even after #172,
+//      claude.exe streams parallel tool batches as N SEPARATE assistant
+//      events that share `message.id` but each carry a single tool_use in
+//      `content[]`. The renderer numbered tool block ids by per-event
+//      position (`${msgId}:tu0`), so all N collapsed to one block id and
+//      `appendBlocks` coalesced them — N-1 of N tool_results then had no
+//      block to attach to. Fix: derive the block id from the globally
+//      unique `tool_use.id`. See `assistantBlocks` in
+//      `src/agent/stream-to-blocks.ts`.
+//
+// Two cases below cover both the Bash and Read parallel-batch shapes seen
+// in the wild (Bash from the original probe; Read from Dogfood G's
+// REPORT-RERUN.md §A2-NEW-3-PARALLEL-V2). Tightened assertion:
+// `succeeded.length === clicks` — every Allow click must produce a
+// resolved tool_result, not just one.
 import { _electron as electron } from 'playwright';
 import path from 'node:path';
 import fs from 'node:fs';
@@ -20,19 +34,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
 const TS = new Date().toISOString().replace(/[:.]/g, '-');
 const UDD = path.join(os.tmpdir(), `agentory-bugl-par-${TS}`);
-const PROJ = path.join(os.tmpdir(), `agentory-bugl-par-proj-${TS}`);
 fs.mkdirSync(UDD, { recursive: true });
-fs.mkdirSync(PROJ, { recursive: true });
-
-// Seed several files for the agent to Read in parallel. Read normally
-// triggers the PreToolUse hook and a permission prompt unless allowlisted.
-const FILES = ['a.txt', 'b.txt', 'c.txt', 'd.txt'];
-for (const [i, f] of FILES.entries()) {
-  fs.writeFileSync(path.join(PROJ, f), `file-${i}-content\n`);
-}
-
-const PROMPT =
-  `Run these four bash commands IN PARALLEL in a SINGLE message containing FOUR tool_use blocks (do NOT serialize, do NOT wait between them, issue all four together): \`cat a.txt\`, \`cat b.txt\`, \`cat c.txt\`, \`cat d.txt\`. Then summarize each output. Critical: emit all four Bash tool_use blocks in the SAME assistant message.`;
 
 function log(m) {
   process.stderr.write(`[probe-bugl-parallel ${new Date().toISOString()}] ${m}\n`);
@@ -43,7 +45,7 @@ function fail(msg, app) {
   process.exit(1);
 }
 
-log(`START PROJ=${PROJ} UDD=${UDD}`);
+log(`START UDD=${UDD}`);
 
 const app = await electron.launch({
   args: ['.', `--user-data-dir=${UDD}`],
@@ -69,120 +71,310 @@ if (!win) fail('no Electron window appeared in 30s', app);
 await win.waitForLoadState('domcontentloaded');
 await win.waitForTimeout(2500);
 
-await win.getByRole('button', { name: /new session/i }).first().click();
-await win.waitForTimeout(1000);
-
-await win.evaluate((p) => {
-  const st = window.__agentoryStore?.getState?.();
-  if (st && typeof st.changeCwd === 'function') st.changeCwd(p);
-}, PROJ);
-await win.waitForTimeout(400);
-
-const ta = win.locator('textarea').first();
-await ta.waitFor({ state: 'visible', timeout: 8000 });
-await ta.click();
-await ta.fill(PROMPT);
-await win.keyboard.press('Enter');
-log('prompt sent');
-
-// Click Allow on every prompt that appears. We expect up to FILES.length
-// prompts in rapid succession (parallel tool batch). Keep clicking until no
-// new Allow button shows up for several consecutive polls.
-const allowSel = '[data-perm-action="allow"]';
-const totalDl = Date.now() + 120_000;
-let lastClickAt = 0;
-let clicks = 0;
-while (Date.now() < totalDl) {
-  await win.waitForTimeout(750);
-  const visible = await win
-    .locator(allowSel)
-    .first()
-    .isVisible({ timeout: 200 })
-    .catch(() => false);
-  if (visible) {
-    await win.locator(allowSel).first().click();
-    clicks += 1;
-    lastClickAt = Date.now();
-    log(`clicked Allow #${clicks}`);
-    continue;
+/**
+ * Run a single parallel-batch case end-to-end.
+ *
+ *   - Creates a fresh project dir seeded with `files`.
+ *   - Opens a NEW session (so every case starts with an empty store).
+ *   - Sends `prompt`.
+ *   - Clicks every Allow that appears.
+ *   - Polls the store for tool blocks matching `toolName`.
+ *   - Asserts `clicks === expectedClicks`, every Allow produced a
+ *     permission-resolved trace, AND every tool block ended up with a
+ *     non-empty `result` (`succeeded.length === clicks`).
+ *
+ * Returns the final snapshot for caller logging.
+ */
+async function runCase({ caseName, files, prompt, toolName, expectedClicks }) {
+  log(`--- case: ${caseName} ---`);
+  const proj = path.join(os.tmpdir(), `agentory-bugl-par-proj-${caseName}-${TS}`);
+  fs.mkdirSync(proj, { recursive: true });
+  for (const [i, f] of files.entries()) {
+    fs.writeFileSync(path.join(proj, f), `file-${i}-content\n`);
   }
-  // No visible Allow. If we already clicked at least once and 8s have passed
-  // since the last click without a new prompt, consider the prompt sequence
-  // exhausted.
-  if (clicks > 0 && Date.now() - lastClickAt > 8_000) break;
-}
-if (clicks === 0) fail('never saw any Allow button within 120s', app);
-log(`total Allow clicks: ${clicks}`);
 
-// Observation window. Bug L's specific failure: when N permission prompts
-// are issued in close succession, the harness must deliver the user's
-// decision back to claude.exe N times. Pre-fix the broken control_response
-// shape was silently dropped, so claude.exe never executed any of the N
-// tool calls and no tool_result ever arrived. Post-fix at least one
-// tool_use must end with a populated `result` AND every system
-// `permission-resolved` trace from the N Allow clicks must be present
-// (proving the renderer state machine processed all N).
-//
-// We deliberately do NOT assert that the agent emitted exactly N parallel
-// tool_use blocks. The store/parser path that surfaces tool_use blocks
-// from streamed assistant messages has its own quirks (some bundles
-// surface only the first tool_use of a parallel batch as a stable block
-// even though all N execute) — that is orthogonal to Bug L's IPC
-// propagation regression. What L proves is: every Allow click reaches
-// claude.exe in a shape it accepts, and at least one tool gets a result
-// back. That's the binary that flipped pre/post fix.
-const obsStart = Date.now();
-let snap;
-while (Date.now() - obsStart < 30_000) {
-  await win.waitForTimeout(2000);
-  snap = await win
-    .evaluate(() => {
-      const st = window.__agentoryStore?.getState?.();
-      const sid = st?.activeId;
-      const blocks = st?.messagesBySession?.[sid] || [];
-      const bashes = blocks
-        .filter((b) => {
-          const tn = b.toolName || b.name;
-          return b.kind === 'tool' && tn === 'Bash';
-        })
-        .map((b) => ({
-          toolUseId: b.toolUseId,
-          hasResult: typeof b.result === 'string' && b.result.length > 0,
-          isError: b.isError === true,
-          resultLen: typeof b.result === 'string' ? b.result.length : 0,
-        }));
-      const resolvedTraces = blocks.filter(
-        (b) => b.kind === 'system' && b.subkind === 'permission-resolved' && (b.decision === 'allowed' || b.decision === 'allow'),
-      ).length;
-      const allBlockKinds = blocks.map((b) => `${b.kind}:${b.toolName || b.name || ''}:${b.toolUseId || b.id || ''}`);
-      return { reads: bashes, resolvedTraces, totalBlocks: blocks.length, allBlockKinds };
-    })
-    .catch(() => null);
-  if (snap && snap.resolvedTraces >= clicks && snap.reads.some((r) => r.hasResult)) break;
-}
+  await win.getByRole('button', { name: /new session/i }).first().click();
+  await win.waitForTimeout(1000);
 
-if (!snap) fail('could not snapshot store', app);
-log(`final snapshot: reads=${JSON.stringify(snap.reads)} resolvedTraces=${snap.resolvedTraces}`);
+  await win.evaluate((p) => {
+    const st = window.__agentoryStore?.getState?.();
+    if (st && typeof st.changeCwd === 'function') st.changeCwd(p);
+  }, proj);
+  await win.waitForTimeout(400);
 
-if (snap.resolvedTraces < clicks)
-  fail(
-    `Bug L parallel regression: clicked Allow ${clicks}x but only ${snap.resolvedTraces} permission-resolved traces appeared in store. Some Allow decisions never made it into the renderer state machine.`,
-    app,
+  const ta = win.locator('textarea').first();
+  await ta.waitFor({ state: 'visible', timeout: 8000 });
+  await ta.click();
+  await ta.fill(prompt);
+  await win.keyboard.press('Enter');
+  log(`[${caseName}] prompt sent`);
+
+  const allowSel = '[data-perm-action="allow"]';
+  const totalDl = Date.now() + 120_000;
+  let lastClickAt = 0;
+  let clicks = 0;
+  while (Date.now() < totalDl) {
+    await win.waitForTimeout(750);
+    const visible = await win
+      .locator(allowSel)
+      .first()
+      .isVisible({ timeout: 200 })
+      .catch(() => false);
+    if (visible) {
+      await win.locator(allowSel).first().click();
+      clicks += 1;
+      lastClickAt = Date.now();
+      log(`[${caseName}] clicked Allow #${clicks}`);
+      continue;
+    }
+    if (clicks > 0 && Date.now() - lastClickAt > 8_000) break;
+  }
+  if (clicks === 0) fail(`[${caseName}] never saw any Allow button within 120s`, app);
+  log(`[${caseName}] total Allow clicks: ${clicks}`);
+
+  const obsStart = Date.now();
+  let snap;
+  while (Date.now() - obsStart < 60_000) {
+    await win.waitForTimeout(2000);
+    snap = await win
+      .evaluate((tn) => {
+        const st = window.__agentoryStore?.getState?.();
+        const sid = st?.activeId;
+        const blocks = st?.messagesBySession?.[sid] || [];
+        const tools = blocks
+          .filter((b) => {
+            const name = b.toolName || b.name;
+            return b.kind === 'tool' && name === tn;
+          })
+          .map((b) => ({
+            toolUseId: b.toolUseId,
+            id: b.id,
+            hasResult: typeof b.result === 'string' && b.result.length > 0,
+            isError: b.isError === true,
+            resultLen: typeof b.result === 'string' ? b.result.length : 0,
+          }));
+        const resolvedTraces = blocks.filter(
+          (b) =>
+            b.kind === 'system' &&
+            b.subkind === 'permission-resolved' &&
+            (b.decision === 'allowed' || b.decision === 'allow'),
+        ).length;
+        const allBlockKinds = blocks.map(
+          (b) => `${b.kind}:${b.toolName || b.name || ''}:${b.toolUseId || b.id || ''}`,
+        );
+        return { tools, resolvedTraces, totalBlocks: blocks.length, allBlockKinds };
+      }, toolName)
+      .catch(() => null);
+    if (
+      snap &&
+      snap.resolvedTraces >= clicks &&
+      snap.tools.length >= clicks &&
+      snap.tools.filter((t) => t.hasResult).length >= clicks
+    )
+      break;
+  }
+
+  if (!snap) fail(`[${caseName}] could not snapshot store`, app);
+  log(`[${caseName}] final snapshot: tools=${JSON.stringify(snap.tools)} resolvedTraces=${snap.resolvedTraces}`);
+  log(`[${caseName}] final allBlocks=${JSON.stringify(snap.allBlockKinds)}`);
+
+  if (expectedClicks && clicks !== expectedClicks)
+    fail(
+      `[${caseName}] expected ${expectedClicks} Allow clicks but observed ${clicks}. Did the model serialize the calls instead of issuing them in parallel?`,
+      app,
+    );
+
+  if (snap.resolvedTraces < clicks)
+    fail(
+      `[${caseName}] Bug L renderer regression: clicked Allow ${clicks}x but only ${snap.resolvedTraces} permission-resolved traces appeared in store.`,
+      app,
+    );
+
+  if (snap.tools.length < clicks)
+    fail(
+      `[${caseName}] Bug L parallel-batch RENDERER regression: ${clicks} Allow clicks but only ${snap.tools.length} \`tool:${toolName}\` blocks exist in store. ` +
+        `Parallel tool_use blocks are being coalesced by id (see assistantBlocks). allBlocks=${JSON.stringify(snap.allBlockKinds)}`,
+      app,
+    );
+
+  const succeeded = snap.tools.filter((t) => t.hasResult);
+  if (succeeded.length !== clicks)
+    fail(
+      `[${caseName}] Bug L parallel-batch IPC/RENDERER regression: ${clicks} Allow clicks but only ${succeeded.length}/${clicks} \`tool:${toolName}\` blocks received a tool_result. ` +
+        `tools=${JSON.stringify(snap.tools)} allBlocks=${JSON.stringify(snap.allBlockKinds)}`,
+      app,
+    );
+
+  const errored = snap.tools.filter((t) => t.isError);
+  if (errored.length > 0)
+    fail(`[${caseName}] one or more ${toolName} tool blocks errored: ${JSON.stringify(errored)}`, app);
+
+  log(
+    `[${caseName}] OK: ${clicks} Allow clicks → ${snap.resolvedTraces} resolved traces, ${succeeded.length}/${clicks} ${toolName} blocks have tool_result.`,
   );
+  return { clicks, snap };
+}
 
-const succeeded = snap.reads.filter((r) => r.hasResult);
-if (succeeded.length === 0)
-  fail(
-    `Bug L parallel regression: ${clicks} Allow clicks resolved in renderer but ZERO Bash tool_use blocks received a tool_result. claude.exe never executed any tool. allBlocks=${JSON.stringify(snap.allBlockKinds)}`,
-    app,
+// === case: parallel-bash-N4 ===
+// Original Bug L probe shape — 4 parallel `cat` Bash calls. Verifies the
+// IPC envelope fix from PR #172 still holds AND the renderer-side block-id
+// fix correctly creates 4 distinct tool blocks.
+const BASH_FILES = ['a.txt', 'b.txt', 'c.txt', 'd.txt'];
+const BASH_PROMPT =
+  `Run these four bash commands IN PARALLEL in a SINGLE message containing FOUR tool_use blocks (do NOT serialize, do NOT wait between them, issue all four together): \`cat a.txt\`, \`cat b.txt\`, \`cat c.txt\`, \`cat d.txt\`. Then summarize each output. Critical: emit all four Bash tool_use blocks in the SAME assistant message.`;
+await runCase({
+  caseName: 'parallel-bash-N4',
+  files: BASH_FILES,
+  prompt: BASH_PROMPT,
+  toolName: 'Bash',
+  expectedClicks: 4,
+});
+
+// === case: parallel-read-N5 ===
+// Dogfood G repro shape — 5 parallel Read tool calls (REPORT-RERUN.md
+// §A2-NEW-3-PARALLEL-V2). This was the case that pre-fix surfaced ONE
+// `tool:Read` block plus N-1 empty `system:Read` blocks. Tightened
+// assertion: ALL 5 Read blocks must end up with a tool_result.
+const READ_FILES = ['README.md', 'package.json', 'src/strings.js', 'src/math.js', 'src/cart.js'];
+// Need to actually create these (some have subdirs).
+// runCase seeds files at the top level only; for nested paths we just write
+// them in the seeded dir, the case handler creates the directory tree below.
+const READ_PROMPT =
+  `Use the Read tool to read README.md, package.json, src/strings.js, src/math.js, src/cart.js IN PARALLEL — emit FIVE Read tool_use blocks in a SINGLE assistant message. Do NOT serialize. After all five reads come back, give a 5-line summary, one bullet per file.`;
+
+// runCase only handles flat files; do a tiny inline variant that supports
+// nested paths so we can hit the exact dogfood shape.
+{
+  const caseName = 'parallel-read-N5';
+  log(`--- case: ${caseName} ---`);
+  const proj = path.join(os.tmpdir(), `agentory-bugl-par-proj-${caseName}-${TS}`);
+  fs.mkdirSync(path.join(proj, 'src'), { recursive: true });
+  for (const [i, f] of READ_FILES.entries()) {
+    fs.writeFileSync(path.join(proj, f), `// file-${i}: ${path.basename(f)} placeholder body for parallel-read probe\n`);
+  }
+
+  await win.getByRole('button', { name: /new session/i }).first().click();
+  await win.waitForTimeout(1000);
+  await win.evaluate((p) => {
+    const st = window.__agentoryStore?.getState?.();
+    if (st && typeof st.changeCwd === 'function') st.changeCwd(p);
+  }, proj);
+  await win.waitForTimeout(400);
+
+  const ta = win.locator('textarea').first();
+  await ta.waitFor({ state: 'visible', timeout: 8000 });
+  await ta.click();
+  await ta.fill(READ_PROMPT);
+  await win.keyboard.press('Enter');
+  log(`[${caseName}] prompt sent`);
+
+  const allowSel = '[data-perm-action="allow"]';
+  const totalDl = Date.now() + 120_000;
+  let lastClickAt = 0;
+  let clicks = 0;
+  while (Date.now() < totalDl) {
+    await win.waitForTimeout(750);
+    const visible = await win
+      .locator(allowSel)
+      .first()
+      .isVisible({ timeout: 200 })
+      .catch(() => false);
+    if (visible) {
+      await win.locator(allowSel).first().click();
+      clicks += 1;
+      lastClickAt = Date.now();
+      log(`[${caseName}] clicked Allow #${clicks}`);
+      continue;
+    }
+    if (clicks > 0 && Date.now() - lastClickAt > 8_000) break;
+  }
+  if (clicks === 0) fail(`[${caseName}] never saw any Allow button within 120s`, app);
+  log(`[${caseName}] total Allow clicks: ${clicks}`);
+
+  const obsStart = Date.now();
+  let snap;
+  while (Date.now() - obsStart < 60_000) {
+    await win.waitForTimeout(2000);
+    snap = await win
+      .evaluate(() => {
+        const st = window.__agentoryStore?.getState?.();
+        const sid = st?.activeId;
+        const blocks = st?.messagesBySession?.[sid] || [];
+        const reads = blocks
+          .filter((b) => b.kind === 'tool' && (b.toolName || b.name) === 'Read')
+          .map((b) => ({
+            toolUseId: b.toolUseId,
+            id: b.id,
+            hasResult: typeof b.result === 'string' && b.result.length > 0,
+            isError: b.isError === true,
+            resultLen: typeof b.result === 'string' ? b.result.length : 0,
+          }));
+        const resolvedTraces = blocks.filter(
+          (b) =>
+            b.kind === 'system' &&
+            b.subkind === 'permission-resolved' &&
+            (b.decision === 'allowed' || b.decision === 'allow'),
+        ).length;
+        const allBlockKinds = blocks.map(
+          (b) => `${b.kind}:${b.toolName || b.name || ''}:${b.toolUseId || b.id || ''}`,
+        );
+        return { reads, resolvedTraces, totalBlocks: blocks.length, allBlockKinds };
+      })
+      .catch(() => null);
+    if (
+      snap &&
+      snap.resolvedTraces >= clicks &&
+      snap.reads.length >= clicks &&
+      snap.reads.filter((r) => r.hasResult).length >= clicks
+    )
+      break;
+  }
+
+  if (!snap) fail(`[${caseName}] could not snapshot store`, app);
+  log(`[${caseName}] final snapshot: reads=${JSON.stringify(snap.reads)} resolvedTraces=${snap.resolvedTraces}`);
+  log(`[${caseName}] final allBlocks=${JSON.stringify(snap.allBlockKinds)}`);
+
+  // We expect 5 parallel Read clicks. The model occasionally folds two reads
+  // into one batch with sequential follow-ups; tolerate a small undercount
+  // (>=4) but require strict equality between clicks and resolved tool blocks.
+  if (clicks < 4)
+    fail(
+      `[${caseName}] expected ~5 parallel Allow clicks (model declined to parallelize?); only saw ${clicks}.`,
+      app,
+    );
+
+  if (snap.resolvedTraces < clicks)
+    fail(
+      `[${caseName}] renderer regression: clicked Allow ${clicks}x but only ${snap.resolvedTraces} permission-resolved traces appeared.`,
+      app,
+    );
+
+  if (snap.reads.length < clicks)
+    fail(
+      `[${caseName}] Bug L parallel-batch RENDERER regression: ${clicks} Allow clicks but only ${snap.reads.length} \`tool:Read\` blocks exist in store. ` +
+        `Parallel tool_use blocks are being coalesced by id (see assistantBlocks). allBlocks=${JSON.stringify(snap.allBlockKinds)}`,
+      app,
+    );
+
+  const succeeded = snap.reads.filter((r) => r.hasResult);
+  if (succeeded.length !== clicks)
+    fail(
+      `[${caseName}] Bug L parallel-batch IPC/RENDERER regression: ${clicks} Allow clicks but only ${succeeded.length}/${clicks} \`tool:Read\` blocks received a tool_result. ` +
+        `reads=${JSON.stringify(snap.reads)} allBlocks=${JSON.stringify(snap.allBlockKinds)}`,
+      app,
+    );
+
+  const errored = snap.reads.filter((r) => r.isError);
+  if (errored.length > 0)
+    fail(`[${caseName}] one or more Read tool blocks errored: ${JSON.stringify(errored)}`, app);
+
+  log(
+    `[${caseName}] OK: ${clicks} Allow clicks → ${snap.resolvedTraces} resolved traces, ${succeeded.length}/${clicks} Read blocks have tool_result.`,
   );
-
-const errored = snap.reads.filter((r) => r.isError);
-if (errored.length > 0)
-  fail(`one or more Bash tool blocks errored: ${JSON.stringify(errored)}`, app);
+}
 
 console.log(
-  `[probe-bugl-parallel] OK: ${clicks} parallel Allow clicks delivered to claude.exe (${snap.resolvedTraces} resolved traces), ${succeeded.length} tool_use blocks received tool_result`,
+  `[probe-bugl-parallel] OK: parallel-bash-N4 + parallel-read-N5 both pass with strict equality (clicks === results).`,
 );
 await app.close();
 process.exit(0);

--- a/src/agent/stream-to-blocks.ts
+++ b/src/agent/stream-to-blocks.ts
@@ -172,17 +172,27 @@ function assistantBlocks(msg: AssistantEvent): MessageBlock[] {
   const out: MessageBlock[] = [];
   const baseId = msg.message?.id ?? msg.uuid ?? cryptoRandom();
   const content: ContentBlock[] = msg.message?.content ?? [];
-  let toolIdx = 0;
   for (let idx = 0; idx < content.length; idx++) {
     const c = content[idx];
     if (c.type === 'text' && typeof c.text === 'string') {
       out.push({ kind: 'assistant', id: `${baseId}:c${idx}`, text: c.text });
     } else if (c.type === 'tool_use') {
       const tu = c as ToolUseBlock;
+      // Block id MUST be derived from the globally-unique `tool_use.id`
+      // (e.g. `toolu_vrtx_…`), NOT from a per-event positional counter.
+      // Reason: claude.exe streams parallel tool batches as MULTIPLE
+      // assistant events with the SAME `message.id` but each carrying only
+      // ONE tool_use in `content[]`. A positional counter resets to 0 in
+      // every event, so all N parallel tool blocks would receive the same
+      // id `${msgId}:tu0` and `appendBlocks` (which coalesces by id) would
+      // collapse them into a single block — N-1 of N tool_results then have
+      // nowhere to attach. (Bug L parallel-batch follow-up; PR #172 fixed
+      // the IPC envelope, this fixes the renderer-side block id collision.)
+      const blockId = `${baseId}:${tu.id}`;
       if (tu.name === 'TodoWrite') {
         out.push({
           kind: 'todo',
-          id: `${baseId}:tu${toolIdx++}`,
+          id: blockId,
           toolUseId: tu.id,
           todos: parseTodos(tu.input)
         });
@@ -216,23 +226,18 @@ function assistantBlocks(msg: AssistantEvent): MessageBlock[] {
         if (questions.length === 0) {
           out.push({
             kind: 'tool',
-            id: `${baseId}:tu${toolIdx++}`,
+            id: blockId,
             toolUseId: tu.id,
             name: tu.name,
             brief: briefForTool(tu.name, tu.input),
             expanded: false,
             input: tu.input
           });
-        } else {
-          // Skip the index bump-and-continue so subsequent tool_use blocks
-          // in the same message get sequential ids — they share the
-          // numbering namespace with this suppressed slot.
-          toolIdx++;
         }
       } else {
         out.push({
           kind: 'tool',
-          id: `${baseId}:tu${toolIdx++}`,
+          id: blockId,
           toolUseId: tu.id,
           name: tu.name,
           brief: briefForTool(tu.name, tu.input),


### PR DESCRIPTION
## Summary

Second fix in the Bug L series. PR #172 fixed the outbound `control_response` envelope so parallel `hook_callback` responses reach claude.exe; this PR fixes a **renderer-side** block-id collision that was swallowing N-1 of N `tool_result` patches for parallel batches.

Closes Dogfood G `REPORT-RERUN.md` §A2-NEW-3-PARALLEL-V2.

## Diagnosis (instrumented inside the worktree, logs stripped before commit)

Added temporary `console.warn` tracers in `electron/agent/control-rpc.ts`, `electron/agent/sessions.ts` (inbound `handleLine`), `src/agent/stream-to-blocks.ts` (`assistantBlocks`), and `src/stores/store.ts` (`appendBlocks`). Ran the probe with 4x parallel `cat`:

```
[BUGL-DBG] handleLine inbound tool_use { id: toolu_vrtx_01954XJdvW6VZw6hnQPdJ8mi, name: Bash }
[BUGL-DBG] handleLine inbound tool_use { id: toolu_vrtx_01BryDUjq3RJsHVwDFaVnVqP, name: Bash }
[BUGL-DBG] handleLine inbound tool_use { id: toolu_vrtx_01YAt1y9xrnrD3toCV7yfgnj, name: Bash }
[BUGL-DBG] handleLine inbound tool_use { id: toolu_vrtx_01VJZFWr8f4kobqLV2RsUADw, name: Bash }
...
[BUGL-DBG] inbound control_request x4  (hook_callback)
[BUGL-DBG] finish() WRITE x4            (all 4 responses written)
[BUGL-DBG] handleLine inbound tool_result x4  (claude returned all 4)
```

So the IPC path is correct — all 4 hook_callback responses reach claude.exe and all 4 tool_results come back. But the store snapshot showed only **one** `tool:Bash` block. The renderer-side `appendBlocks` trace revealed why:

```
[BUGL-DBG] assistantBlocks {baseId: msg_17..., contentLen: 1, toolUseIds: Array(1)}
[BUGL-DBG] appendBlocks [{"id":"msg_17...:tu0","toolUseId":"toolu_vrtx_01Lp..."}]
[BUGL-DBG] assistantBlocks {baseId: msg_17..., contentLen: 1, toolUseIds: Array(1)}
[BUGL-DBG] appendBlocks [{"id":"msg_17...:tu0","toolUseId":"toolu_vrtx_016q..."}]  <- same id!
[BUGL-DBG] appendBlocks [{"id":"msg_17...:tu0","toolUseId":"toolu_vrtx_01G9..."}]  <- same id!
[BUGL-DBG] appendBlocks [{"id":"msg_17...:tu0","toolUseId":"toolu_vrtx_013j..."}]  <- same id!
```

claude.exe streams parallel tool batches as **N separate assistant events** that share `message.id` but each carry a single tool_use in `content[]`. The per-event positional counter (`let toolIdx = 0`) resets in every event, so all N blocks collided on id `${msgId}:tu0`. `appendBlocks` coalesces by id and kept only the last one. N-1 of N `tool_result` patches then had no block to attach to.

## Fix

One-site change in `src/agent/stream-to-blocks.ts:assistantBlocks`. Derive block id from the globally-unique `tool_use.id` instead of a positional counter:

```ts
// before:  id: `${baseId}:tu${toolIdx++}`
// after:   id: `${baseId}:${tu.id}`
```

The `tu.id` (e.g. `toolu_vrtx_…`) is stable across re-emissions AND unique across parallel siblings, so `appendBlocks` now sees N distinct blocks.

## E2E regression probe

Extended `scripts/probe-e2e-permission-allow-parallel-batch.mjs` per the `e2e-extend-existing` rule:

- `// === case: parallel-bash-N4 ===` (original Bug L shape).
- `// === case: parallel-read-N5 ===` (Dogfood G shape from REPORT-RERUN.md).
- Tightened assertion from `succeeded.length >= 1` to `succeeded.length === clicks` — strict equality. Folds in backlog item #162.
- Adds `clicks === expectedClicks` guard for the Bash case (drops any run where the model serialized instead of parallelizing).

## Reverse-verify (feedback_bugfix_requires_e2e)

| Step | Command | Result |
|---|---|---|
| 1. Fix applied | `node scripts/probe-e2e-permission-allow-parallel-batch.mjs` | **PASS**: `parallel-bash-N4 + parallel-read-N5 both pass with strict equality (clicks === results).` (4/4 Bash, 5/5 Read) |
| 2. Fix stashed | `git stash push -- src/agent/stream-to-blocks.ts` then re-run | **FAIL** on parallel-bash-N4: `"Bug L parallel-batch RENDERER regression: 4 Allow clicks but only 1 \`tool:Bash\` blocks exist in store. Parallel tool_use blocks are being coalesced by id (see assistantBlocks)."` exit=1 |
| 3. Fix restored | `git stash pop`, rebuild, re-run | **PASS**: 4/4 + 5/5 |

Snapshot evidence pre-fix (parallel-bash-N4, fix stashed):
```
allBlocks=["user::u-…","assistant::msg_…:c0",
  "tool:Bash:toolu_vrtx_01JmoN3rCkzw84LLu781qPba",   <- only one block
  "system:Bash:perm-resolved-…","system:Bash:perm-resolved-…",
  "system:Bash:perm-resolved-…","system:Bash:perm-resolved-…"]
```

Snapshot evidence post-fix (parallel-read-N5):
```
allBlocks=["user::u-…","assistant::msg_…:c0",
  "tool:Read:toolu_vrtx_01TFVpBCk2Xg8DKbmC7kQKm2",
  "tool:Read:toolu_vrtx_017WdCmhHDCo5pUXgZKh6197",
  "tool:Read:toolu_vrtx_01RcxG33Cb9P8yaLwYFE98nx",
  "tool:Read:toolu_vrtx_01Dc4AGcUyXfx9BTE2Ku9uBz",
  "tool:Read:toolu_vrtx_01KmeP5DKHH6vT4Q6AbYJCNx",
  "system:Read:perm-resolved-… x5"]
```

## Previous worker's checkpoint (context)

> Renderer correctly passes per-block `b.requestId` through `agent:resolvePermission` IPC. Single-tool path works fine after PR #172. Multi-tool parallel breaks.

The previous worker (task `adef4957…`) traced the IPC wiring and correctly escalated rather than guessing at `continue: true`. Logs above confirm IPC is fine; the bug was one level up in the renderer's block-id scheme.

## Scope / non-changes

- `control-rpc.ts` envelope shape unchanged (PR #172 locked it; all 4 finish() writes succeed and claude.exe responds with 4 tool_results).
- No new `continue`/`async` fields in `handleHookCallback` — the log evidence disproved that hypothesis.
- No unit-test changes; existing `tests/store.test.ts` hardcodes `'msg-1:tu0'` but that test constructs blocks directly without going through `assistantBlocks`, so it still passes.
- Local `npm test` shows 586 pass / 12 pre-existing native-binding failures (`better-sqlite3` NODE_MODULE_VERSION mismatch in the worktree's env — unrelated to this fix).

## Test plan

- [ ] CI passes
- [ ] Reviewer runs `probe-e2e-permission-allow-parallel-batch.mjs` reverse-verify once more (stash the stream-to-blocks change and confirm parallel-bash-N4 fails with the exact `only 1 \`tool:Bash\` blocks exist` diagnostic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)