### PR TITLE
refactor(e2e): themed harnesses phase 3 (PERM + UI clusters)

### DIFF
--- a/scripts/harness-perm.mjs
+++ b/scripts/harness-perm.mjs
@@ -1,0 +1,461 @@
+// Themed harness — PERMISSION cluster, Phase-3.
+//
+// Per docs/e2e/single-harness-brainstorm.md §8 (option B + C). Each case
+// below is the de-duplicated body of one of the per-file probes in
+// scripts/probe-e2e-*.mjs. The original probe files have been left in
+// place with a `// MERGED INTO harness-perm.mjs` marker on line 1 and are
+// excluded from the per-file runner via scripts/run-all-e2e.mjs's
+// MERGED_INTO_HARNESS skip list.
+//
+// Scope (7 cases — all pure-store / no real claude.exe required):
+//   - permission-prompt              (probe-e2e-permission-prompt)
+//   - permission-mode-strict         (probe-e2e-permission-mode-strict)
+//   - permission-focus-not-stolen    (probe-e2e-permission-focus-not-stolen)
+//   - permission-shortcut-scope      (probe-e2e-permission-shortcut-scope)
+//   - permission-nested-input        (probe-e2e-permission-nested-input)
+//   - permission-truncate-width      (probe-e2e-permission-truncate-width)
+//   - permission-sequential-focus    (probe-e2e-permission-sequential-focus)
+//
+// Probes intentionally NOT merged (require real claude.exe subprocess):
+//   - permission-allow-write, permission-allow-bash,
+//     permission-allow-parallel-batch, permission-reject-stops-agent,
+//     permission-prompt-default-mode
+//
+// Run: `node scripts/harness-perm.mjs`
+// Run one case: `node scripts/harness-perm.mjs --only=permission-prompt`
+
+import { runHarness } from './probe-helpers/harness-runner.mjs';
+
+// Shared helper: ensure a session exists with a usable cwd so InputBar enables
+// the textarea. Mirrors the seed pattern used across the source probes.
+async function seedSession(win, { sid = 's-perm', cwd = 'C:/x' } = {}) {
+  await win.evaluate(({ sid, cwd }) => {
+    window.__agentoryStore.setState({
+      groups: [{ id: 'g1', name: 'G1', collapsed: false, kind: 'normal' }],
+      sessions: [{ id: sid, name: 'perm-probe', state: 'idle', cwd, model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code' }],
+      activeId: sid,
+      messagesBySession: { [sid]: [] }
+    });
+  }, { sid, cwd });
+  await win.waitForTimeout(200);
+  return sid;
+}
+
+async function injectWaiting(win, { id, requestId, toolName = 'Bash', toolInput, prompt = 'Bash op' }) {
+  await win.evaluate((args) => {
+    const s = window.__agentoryStore.getState();
+    s.appendBlocks(s.activeId, [{
+      kind: 'waiting',
+      id: args.id,
+      prompt: args.prompt,
+      intent: 'permission',
+      requestId: args.requestId,
+      toolName: args.toolName,
+      toolInput: args.toolInput
+    }]);
+  }, { id, requestId, toolName, toolInput, prompt });
+}
+
+// ---------- permission-prompt ----------
+async function casePermissionPrompt({ win, log }) {
+  await seedSession(win);
+  await injectWaiting(win, {
+    id: 'wait-PROBE-RID',
+    requestId: 'PROBE-RID',
+    toolInput: { command: 'rm -rf /tmp/probe', description: 'Remove probe tmp dir' },
+    prompt: 'Bash: rm -rf /tmp/probe'
+  });
+
+  const heading = win.locator('text=Permission required').first();
+  await heading.waitFor({ state: 'visible', timeout: 5_000 });
+
+  const snapshot = await win.evaluate(() => {
+    const btns = Array.from(document.querySelectorAll('[data-perm-action]')).map((b) => ({
+      action: b.getAttribute('data-perm-action'),
+      label: b.textContent?.trim(),
+      focused: b === document.activeElement
+    }));
+    return { buttons: btns };
+  });
+
+  if (snapshot.buttons.length !== 2) throw new Error(`expected 2 perm buttons, got ${snapshot.buttons.length}`);
+  const reject = snapshot.buttons.find((b) => b.action === 'reject');
+  const allow = snapshot.buttons.find((b) => b.action === 'allow');
+  if (!reject || !/Reject \(N\)/i.test(reject.label ?? '')) throw new Error(`bad reject label: ${reject?.label}`);
+  if (!allow || !/Allow \(Y\)/i.test(allow.label ?? '')) throw new Error(`bad allow label: ${allow?.label}`);
+  if (!reject.focused) throw new Error(`expected Reject focused; got ${JSON.stringify(snapshot.buttons)}`);
+
+  // Press N -> Reject. Block should disappear.
+  await win.keyboard.press('n');
+  try {
+    await heading.waitFor({ state: 'detached', timeout: 3_000 });
+  } catch {
+    throw new Error('prompt still visible after pressing N');
+  }
+
+  // Inject a second one and press Y.
+  await injectWaiting(win, {
+    id: 'wait-PROBE-RID-2',
+    requestId: 'PROBE-RID-2',
+    toolInput: { command: 'echo allowed' },
+    prompt: 'Bash: echo allowed'
+  });
+  await win.waitForTimeout(400);
+  await heading.waitFor({ state: 'visible', timeout: 3_000 });
+  // Wait for autoFocus effect to move focus onto the block's Reject button —
+  // otherwise a just-launched InputBar can still hold focus and the Y keystroke
+  // gets typed into the textarea instead of resolving the permission.
+  await win.waitForFunction(() => {
+    const el = document.activeElement;
+    return el?.getAttribute?.('data-perm-action') === 'reject';
+  }, null, { timeout: 2000 }).catch(() => {});
+  await win.keyboard.press('y');
+  try {
+    await heading.waitFor({ state: 'detached', timeout: 3_000 });
+  } catch {
+    throw new Error('prompt still visible after pressing Y');
+  }
+
+  log('expanded=yes rejectFocused=yes keyboard Y/N works');
+}
+
+// ---------- permission-mode-strict ----------
+async function casePermissionModeStrict({ win, log }) {
+  // Pure IPC contract test — no DOM.
+  const result = await win.evaluate(async () => {
+    const bogus = await window.agentory.agentSetPermissionMode('s-nonexistent', 'not-a-real-mode');
+    const valid = await window.agentory.agentSetPermissionMode('s-nonexistent', 'default');
+    return { bogus, valid };
+  });
+
+  if (!result.bogus || result.bogus.ok !== false || result.bogus.error !== 'unknown_mode') {
+    throw new Error(`bogus mode expected { ok:false, error:'unknown_mode' }, got ${JSON.stringify(result.bogus)}`);
+  }
+  if (!result.valid || result.valid.ok !== true) {
+    throw new Error(`valid mode 'default' expected { ok:true }, got ${JSON.stringify(result.valid)}`);
+  }
+  log('unknown permission modes are rejected; known modes pass through');
+}
+
+// ---------- permission-focus-not-stolen ----------
+async function casePermissionFocusNotStolen({ win, log }) {
+  await seedSession(win);
+
+  const textarea = win.locator('textarea').first();
+  await textarea.waitFor({ state: 'visible', timeout: 5000 });
+
+  // Focus + start typing a partial command.
+  await textarea.click();
+  await textarea.fill('docker rmi xxx');
+
+  const focusedBefore = await win.evaluate(() => document.activeElement?.tagName?.toLowerCase());
+  if (focusedBefore !== 'textarea') throw new Error(`pre-inject focus expected textarea, got ${focusedBefore}`);
+
+  await injectWaiting(win, {
+    id: 'wait-PROBE-FOCUS',
+    requestId: 'PROBE-FOCUS',
+    toolInput: { command: 'docker rmi xxx' },
+    prompt: 'Bash: docker rmi xxx'
+  });
+
+  const heading = win.locator('text=Permission required').first();
+  await heading.waitFor({ state: 'visible', timeout: 5000 });
+  await win.waitForTimeout(250);
+
+  const focusedAfter = await win.evaluate(() => {
+    const el = document.activeElement;
+    return {
+      tag: el?.tagName?.toLowerCase() ?? null,
+      isTextarea: el instanceof HTMLTextAreaElement,
+      insideAlertdialog: !!el?.closest('[role="alertdialog"]')
+    };
+  });
+  if (!focusedAfter.isTextarea) throw new Error(`focus stolen: activeElement=${JSON.stringify(focusedAfter)}`);
+  if (focusedAfter.insideAlertdialog) throw new Error('focus moved into permission alertdialog');
+
+  await win.keyboard.type(' more');
+  await win.waitForTimeout(150);
+  const afterType = await textarea.inputValue();
+  if (afterType !== 'docker rmi xxx more') throw new Error(`textarea content changed unexpectedly: ${JSON.stringify(afterType)}`);
+
+  const stillVisible = await heading.isVisible();
+  if (!stillVisible) throw new Error('permission block disappeared while user was typing');
+
+  log('focus retained on textarea, typing not intercepted by permission block');
+}
+
+// ---------- permission-shortcut-scope ----------
+async function casePermissionShortcutScope({ win, log }) {
+  await seedSession(win);
+
+  // Wrap the store's resolvePermission action to spy on calls.
+  await win.evaluate(() => {
+    window.__permCalls = [];
+    const store = window.__agentoryStore;
+    const origAction = store.getState().resolvePermission;
+    store.setState({
+      resolvePermission: (sessionId, requestId, decision) => {
+        window.__permCalls.push({ sessionId, requestId, decision });
+        return origAction(sessionId, requestId, decision);
+      }
+    });
+  });
+
+  const textarea = win.locator('textarea').first();
+  await textarea.waitFor({ state: 'visible', timeout: 5000 });
+
+  // Case A: focus outside textarea, press Y -> Allow.
+  await injectWaiting(win, {
+    id: 'wait-PROBE-SCOPE-A',
+    requestId: 'PROBE-SCOPE-A',
+    toolInput: { command: 'echo a' },
+    prompt: 'Bash A'
+  });
+  const heading = win.locator('text=Permission required').first();
+  await heading.waitFor({ state: 'visible', timeout: 5000 });
+
+  await win.evaluate(() => {
+    if (document.activeElement instanceof HTMLElement) document.activeElement.blur();
+    document.body.focus?.();
+  });
+  await win.waitForTimeout(150);
+  const focusedTagA = await win.evaluate(() => document.activeElement?.tagName?.toLowerCase() ?? null);
+  if (focusedTagA === 'textarea') throw new Error(`A: could not move focus off textarea (still ${focusedTagA})`);
+
+  await win.keyboard.press('y');
+  try {
+    await heading.waitFor({ state: 'detached', timeout: 3000 });
+  } catch {
+    throw new Error('A: pressing Y outside textarea did not resolve the permission');
+  }
+  const callsAfterA = await win.evaluate(() => window.__permCalls.slice());
+  const allowCall = callsAfterA.find((c) => c.requestId === 'PROBE-SCOPE-A');
+  if (!allowCall || allowCall.decision !== 'allow') {
+    throw new Error(`A: expected allow IPC for PROBE-SCOPE-A, got ${JSON.stringify(callsAfterA)}`);
+  }
+
+  // Case B: focus INSIDE textarea, press Y -> textarea gets "Y", perm stays pending.
+  await win.evaluate(() => { window.__permCalls = []; });
+  await injectWaiting(win, {
+    id: 'wait-PROBE-SCOPE-B',
+    requestId: 'PROBE-SCOPE-B',
+    toolInput: { command: 'echo b' },
+    prompt: 'Bash B'
+  });
+  await heading.waitFor({ state: 'visible', timeout: 5000 });
+
+  await textarea.click();
+  await textarea.fill('hello');
+  const focusB = await win.evaluate(() => document.activeElement?.tagName?.toLowerCase());
+  if (focusB !== 'textarea') throw new Error(`B: could not focus textarea (got ${focusB})`);
+
+  await win.keyboard.type('Y');
+  await win.waitForTimeout(250);
+
+  const taValue = await textarea.inputValue();
+  if (taValue !== 'helloY') throw new Error(`B: expected textarea to receive literal "Y" (helloY), got ${JSON.stringify(taValue)}`);
+  const stillVisible = await heading.isVisible();
+  if (!stillVisible) throw new Error('B: permission resolved while typing into textarea');
+  const callsAfterB = await win.evaluate(() => window.__permCalls.slice());
+  const leakedB = callsAfterB.find((c) => c.requestId === 'PROBE-SCOPE-B');
+  if (leakedB) throw new Error(`B: hotkey fired despite focus inside textarea: ${JSON.stringify(leakedB)}`);
+
+  log('A=Y triggers allow off-textarea; B=Y types literal in-textarea');
+}
+
+// ---------- permission-nested-input ----------
+async function casePermissionNestedInput({ win, log }) {
+  await seedSession(win);
+  await injectWaiting(win, {
+    id: 'wait-PROBE-NESTED',
+    requestId: 'PROBE-NESTED',
+    toolInput: { command: 'ls', flags: { a: true, l: true } },
+    prompt: 'Bash ls'
+  });
+
+  const heading = win.locator('text=Permission required').first();
+  await heading.waitFor({ state: 'visible', timeout: 5000 });
+  await win.waitForTimeout(300);
+
+  const inspect = await win.evaluate(() => {
+    const heading = Array.from(document.querySelectorAll('*')).find(
+      (n) => n.textContent?.trim() === 'Permission required'
+    );
+    const container = heading?.closest('[role="alertdialog"]');
+    if (!container) return { ok: false };
+    const text = container.textContent ?? '';
+    return {
+      ok: true,
+      text,
+      hasObjectObject: text.includes('[object Object]'),
+      hasCommand: text.includes('ls'),
+      mentionsFlags: /flags/i.test(text),
+      hasFlagA: /\ba\b/.test(text) && /true/i.test(text),
+      hasFlagL: /\bl\b/.test(text)
+    };
+  });
+
+  if (!inspect.ok) throw new Error('container missing');
+  if (inspect.hasObjectObject) throw new Error(`rendered "[object Object]" — nested toolInput not properly serialized. Text: ${inspect.text.slice(0, 500)}`);
+  if (!inspect.hasCommand) throw new Error(`command "ls" not visible in permission body. Text: ${inspect.text.slice(0, 500)}`);
+  if (!inspect.mentionsFlags) throw new Error(`nested key "flags" not surfaced in permission body. Text: ${inspect.text.slice(0, 500)}`);
+  if (!(inspect.hasFlagA && inspect.hasFlagL)) throw new Error(`nested flag values not summarised (need keys a/l + true visible). Text: ${inspect.text.slice(0, 500)}`);
+
+  log('nested toolInput rendered without [object Object]');
+}
+
+// ---------- permission-truncate-width ----------
+async function casePermissionTruncateWidth({ win, log }) {
+  await seedSession(win);
+
+  const MARKER = 'ZZUNIQUEMARKERZZ';
+  const longSql = 'SELECT ' +
+    Array.from({ length: 60 }, (_, i) => `col_${i}`).join(', ') +
+    ' FROM users WHERE ' +
+    Array.from({ length: 30 }, (_, i) => `flag_${i}=1`).join(' AND ') +
+    ` -- ${MARKER}`;
+  const padded = longSql.length < 800
+    ? longSql + ' /* ' + 'x'.repeat(800 - longSql.length - 5) + ' */'
+    : longSql;
+
+  await injectWaiting(win, {
+    id: 'wait-PROBE-LONG',
+    requestId: 'PROBE-LONG',
+    toolInput: { command: padded, description: 'huge query' },
+    prompt: 'Bash: long sql'
+  });
+
+  const heading = win.locator('text=Permission required').first();
+  await heading.waitFor({ state: 'visible', timeout: 5000 });
+  await win.waitForTimeout(300);
+
+  const measure = await win.evaluate(({ marker, padded }) => {
+    const heading = Array.from(document.querySelectorAll('*')).find(
+      (n) => n.textContent?.trim() === 'Permission required'
+    );
+    const container = heading?.closest('[role="alertdialog"]');
+    if (!container) return { ok: false };
+    const rect = container.getBoundingClientRect();
+    const text = container.textContent ?? '';
+    const body = document.body.getBoundingClientRect();
+    return {
+      ok: true,
+      width: rect.width,
+      bodyWidth: body.width,
+      overflowsViewport: rect.right > body.right + 1,
+      fullSqlLen: padded.length,
+      rawTextHasFullSql: text.includes(padded),
+      rawTextHasMarker: text.includes(marker),
+      hasEllipsis: /[…]|\.{3}/.test(text),
+      horizontalScroll: document.documentElement.scrollWidth > document.documentElement.clientWidth + 1
+    };
+  }, { marker: MARKER, padded });
+
+  if (!measure.ok) throw new Error('could not locate permission alertdialog container');
+  if (measure.rawTextHasFullSql) throw new Error('full 800-char toolInput rendered verbatim — no truncation');
+  if (!measure.hasEllipsis) throw new Error('no ellipsis ("…" or "...") in permission body — truncation not signalled');
+  if (measure.overflowsViewport) throw new Error(`container right edge ${measure.width} overflows viewport (body ${measure.bodyWidth})`);
+  if (measure.horizontalScroll) throw new Error('document developed a horizontal scrollbar after rendering long permission');
+
+  log(`long toolInput truncated (len=${measure.fullSqlLen}), container fits viewport (${measure.width.toFixed(0)} ≤ ${measure.bodyWidth.toFixed(0)})`);
+}
+
+// ---------- permission-sequential-focus ----------
+async function casePermissionSequentialFocus({ win, log }) {
+  await seedSession(win);
+
+  // Reset draft-cache + blur textarea so a prior case's leftover text
+  // (e.g. shortcut-scope leaves "helloY") doesn't steal focus during
+  // subsequent autoFocus assertions. The drafts cache is module-scope and
+  // DB cleanup alone can't reach it.
+  const ta = win.locator('textarea').first();
+  await ta.waitFor({ state: 'visible', timeout: 5000 });
+  await ta.fill('');
+  await win.evaluate(() => {
+    if (document.activeElement instanceof HTMLElement) document.activeElement.blur();
+    document.body.focus?.();
+  });
+  await win.waitForTimeout(100);
+
+  // Inject first permission.
+  await injectWaiting(win, {
+    id: 'wait-PROBE-SEQ-1',
+    requestId: 'PROBE-SEQ-1',
+    toolInput: { command: 'echo first' },
+    prompt: 'Bash 1'
+  });
+
+  const heading = win.locator('text=Permission required').first();
+  await heading.waitFor({ state: 'visible', timeout: 5000 });
+  await win.waitForTimeout(200);
+
+  const firstFocus = await win.evaluate(() => {
+    const el = document.activeElement;
+    return {
+      action: el?.getAttribute?.('data-perm-action') ?? null,
+      inWaitingBlock: el?.closest?.('[data-block-id]')?.getAttribute('data-block-id') ?? null
+    };
+  });
+  if (firstFocus.action !== 'reject') throw new Error(`first block: expected Reject focused, got ${JSON.stringify(firstFocus)}`);
+
+  await win.keyboard.press('y');
+  try {
+    await heading.waitFor({ state: 'detached', timeout: 3000 });
+  } catch {
+    throw new Error('first block did not unmount after Y');
+  }
+
+  // Inject second permission.
+  await injectWaiting(win, {
+    id: 'wait-PROBE-SEQ-2',
+    requestId: 'PROBE-SEQ-2',
+    toolInput: { command: 'echo second' },
+    prompt: 'Bash 2'
+  });
+
+  await heading.waitFor({ state: 'visible', timeout: 5000 });
+  await win.waitForTimeout(400);
+
+  const secondFocus = await win.evaluate(() => {
+    const el = document.activeElement;
+    return {
+      tag: el?.tagName?.toLowerCase() ?? null,
+      action: el?.getAttribute?.('data-perm-action') ?? null,
+      text: el?.textContent?.trim() ?? null,
+      isConnected: !!el?.isConnected
+    };
+  });
+  if (!secondFocus.isConnected) throw new Error(`focus is on a detached element: ${JSON.stringify(secondFocus)}`);
+  if (secondFocus.action !== 'reject') throw new Error(`second block: expected Reject focused, got ${JSON.stringify(secondFocus)}`);
+
+  await win.keyboard.press('n');
+  try {
+    await heading.waitFor({ state: 'detached', timeout: 3000 });
+  } catch {
+    throw new Error('second block did not unmount after N');
+  }
+
+  log('focus correctly transfers to second block\'s Reject');
+}
+
+// ---------- harness spec ----------
+await runHarness({
+  name: 'perm',
+  setup: async ({ win }) => {
+    // Suppress the "Claude CLI not found" first-launch dialog.
+    await win.evaluate(() => {
+      window.__agentoryStore?.setState({
+        cliStatus: { state: 'found', binaryPath: '<harness>', version: null }
+      });
+    });
+  },
+  cases: [
+    { id: 'permission-prompt', run: casePermissionPrompt },
+    { id: 'permission-mode-strict', run: casePermissionModeStrict },
+    { id: 'permission-focus-not-stolen', run: casePermissionFocusNotStolen },
+    { id: 'permission-shortcut-scope', run: casePermissionShortcutScope },
+    { id: 'permission-nested-input', run: casePermissionNestedInput },
+    { id: 'permission-truncate-width', run: casePermissionTruncateWidth },
+    { id: 'permission-sequential-focus', run: casePermissionSequentialFocus }
+  ]
+});

--- a/scripts/harness-ui.mjs
+++ b/scripts/harness-ui.mjs
@@ -1,0 +1,268 @@
+// Themed harness — UI cluster, Phase-3.
+//
+// Per docs/e2e/single-harness-brainstorm.md §8 (option B + C). Each case
+// below is the de-duplicated body of one of the per-file probes in
+// scripts/probe-e2e-*.mjs. The original probe files have been left in
+// place with a `// MERGED INTO harness-ui.mjs` marker on line 1 and are
+// excluded from the per-file runner via scripts/run-all-e2e.mjs's
+// MERGED_INTO_HARNESS skip list.
+//
+// Scope (4 cases — pure UI / store-driven, no real claude.exe required):
+//   - sidebar-align             (probe-e2e-sidebar-align)
+//   - no-sessions-landing       (probe-e2e-no-sessions-landing)
+//   - empty-state-minimal       (probe-e2e-empty-state-minimal)
+//   - a11y-focus-restore        (probe-e2e-a11y-focus-restore)
+//
+// Related UI probes already absorbed into harness-agent.mjs:
+//   - inputbar-visible, chat-copy, input-placeholder
+//
+// Run: `node scripts/harness-ui.mjs`
+// Run one case: `node scripts/harness-ui.mjs --only=sidebar-align`
+
+import { runHarness } from './probe-helpers/harness-runner.mjs';
+
+// ---------- sidebar-align ----------
+async function caseSidebarAlign({ win, log }) {
+  // The empty ("No sessions yet") main panel exhibits the same geometry as
+  // the populated one — no need to seed sessions here.
+  await win.waitForFunction(
+    () => !!document.querySelector('main') && !!document.querySelector('aside'),
+    null,
+    { timeout: 10000 }
+  );
+  await win.waitForTimeout(200);
+
+  const geo = await win.evaluate(() => {
+    const aside = document.querySelector('aside');
+    const main = document.querySelector('main');
+    if (!aside || !main) return null;
+    const a = aside.getBoundingClientRect();
+    const m = main.getBoundingClientRect();
+    return {
+      aside: { top: a.top, bottom: a.bottom, left: a.left, right: a.right },
+      main: { top: m.top, bottom: m.bottom, left: m.left, right: m.right },
+      vh: window.innerHeight
+    };
+  });
+  if (!geo) throw new Error('no aside or main element');
+
+  const topDelta = Math.abs(geo.aside.top - geo.main.top);
+  const botDelta = Math.abs(geo.aside.bottom - geo.main.bottom);
+  const tolerance = 1;
+
+  if (topDelta > tolerance) {
+    throw new Error(`top edges misaligned: aside=${geo.aside.top.toFixed(1)} main=${geo.main.top.toFixed(1)} delta=${topDelta.toFixed(1)}`);
+  }
+  if (botDelta > tolerance) {
+    throw new Error(`bottom edges misaligned: aside=${geo.aside.bottom.toFixed(1)} main=${geo.main.bottom.toFixed(1)} delta=${botDelta.toFixed(1)}`);
+  }
+
+  log(`aside=${geo.aside.top.toFixed(1)}/${geo.aside.bottom.toFixed(1)} main=${geo.main.top.toFixed(1)}/${geo.main.bottom.toFixed(1)} vh=${geo.vh}`);
+}
+
+// ---------- no-sessions-landing ----------
+async function caseNoSessionsLanding({ win, log }) {
+  await win.evaluate(() => {
+    window.__agentoryStore.setState({ sessions: [], activeId: undefined, tutorialSeen: true });
+  });
+  await win.waitForTimeout(300);
+
+  const main = win.locator('main');
+  const newBtn = main.getByRole('button', { name: /^New Session$/ });
+  const importBtn = main.getByRole('button', { name: /^Import Session$/ });
+  await newBtn.waitFor({ state: 'visible', timeout: 5000 });
+  await importBtn.waitFor({ state: 'visible', timeout: 5000 });
+
+  const [a, b] = await Promise.all([newBtn.boundingBox(), importBtn.boundingBox()]);
+  if (!a || !b) throw new Error('button box missing');
+  if (Math.abs(a.width - b.width) > 0.5) throw new Error(`button widths differ: new=${a.width.toFixed(1)} import=${b.width.toFixed(1)}`);
+  if (Math.abs(a.height - b.height) > 0.5) throw new Error(`button heights differ: new=${a.height.toFixed(1)} import=${b.height.toFixed(1)}`);
+
+  // The old "No sessions yet" / "Create a session to start …" copy must be gone.
+  const oldCopy = await win.getByText(/No sessions yet|Create a session to start|Import from Claude Code/i).count();
+  if (oldCopy > 0) throw new Error('legacy no-sessions copy still present');
+
+  log(`both buttons ${a.width.toFixed(1)}x${a.height.toFixed(1)}`);
+}
+
+// ---------- empty-state-minimal ----------
+async function caseEmptyStateMinimal({ win, log }) {
+  // Note: the source probe additionally asserts that the "Claude CLI detected"
+  // flash doesn't leak on automatic startup when cliStatus==='found'. In the
+  // harness environment the reset between cases unconditionally sets
+  // cliStatus to {state:'found', binaryPath:'<harness>'} WITHOUT going through
+  // the startup detection pipeline that produces the flash — so the CLI flash
+  // assertion degenerates to "startup flow never ran", which is always true
+  // here and therefore not a meaningful guard. The one-per-file probe remains
+  // the canonical guard for that specific regression; see the SKIPPED note in
+  // run-all-e2e.mjs. The minimal-empty-state (hero + no starter cards + no
+  // "Working in" line) contract IS absorbed here.
+
+  await win.evaluate(() => {
+    window.__agentoryStore.setState({
+      groups: [{ id: 'g1', name: 'G1', collapsed: false, kind: 'normal' }],
+      sessions: [{ id: 's1', name: 's', state: 'idle', cwd: 'C:/x', model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code' }],
+      activeId: 's1',
+      messagesBySession: {}
+    });
+  });
+  await win.waitForTimeout(300);
+
+  const hero = win.getByText(/Ready when you are\./i);
+  try {
+    await hero.first().waitFor({ state: 'visible', timeout: 5000 });
+  } catch {
+    throw new Error('empty-state hero "Ready when you are." not visible');
+  }
+
+  for (const removed of ['Explain this codebase', 'Find and fix a bug', 'Add tests', 'Refactor for clarity']) {
+    const n = await win.getByText(removed, { exact: false }).count();
+    if (n > 0) throw new Error(`starter card "${removed}" still rendered (count=${n})`);
+  }
+
+  const workingIn = await win.getByText(/Working in /i).count();
+  if (workingIn > 0) throw new Error('old "Working in …" line still rendered');
+
+  log('hero visible, no starter cards, no "Working in" line');
+}
+
+// ---------- a11y-focus-restore ----------
+async function caseA11yFocusRestore({ win, log }) {
+  await win.evaluate(() => {
+    window.__agentoryStore.setState({
+      groups: [{ id: 'g1', name: 'Group One', collapsed: false, kind: 'normal' }],
+      sessions: [
+        { id: 'sA', name: 'session-a', state: 'idle', cwd: 'C:/x', model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code' },
+        { id: 'sB', name: 'session-b', state: 'idle', cwd: 'C:/y', model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code' }
+      ],
+      activeId: 'sA',
+      messagesBySession: { sA: [], sB: [] }
+    });
+  });
+  await win.waitForTimeout(300);
+
+  // Contract 4: aria-live on chat stream.
+  const liveAttrs = await win.evaluate(() => {
+    const el = document.querySelector('[data-chat-stream]');
+    if (!el) return null;
+    return {
+      live: el.getAttribute('aria-live'),
+      relevant: el.getAttribute('aria-relevant'),
+      role: el.getAttribute('role')
+    };
+  });
+  if (!liveAttrs) throw new Error('chat stream container [data-chat-stream] not found');
+  if (liveAttrs.live !== 'polite') throw new Error(`expected aria-live=polite on chat stream, got ${liveAttrs.live}`);
+  if (liveAttrs.relevant !== 'additions') throw new Error(`expected aria-relevant="additions" on chat stream, got ${liveAttrs.relevant}`);
+
+  // Contract 1: clicking a session row wires a11y attributes.
+  const sessionLi = win.locator('[data-session-id="sA"]');
+  await sessionLi.waitFor({ state: 'visible', timeout: 5000 });
+  await win.locator('textarea[data-input-bar]').waitFor({ state: 'visible', timeout: 5000 });
+  await sessionLi.click();
+
+  const sessionAttrs = await win.evaluate(() => {
+    const el = document.querySelector('[data-session-id="sA"]');
+    if (!el) return null;
+    return {
+      tabindex: el.getAttribute('tabindex'),
+      ariaSelected: el.getAttribute('aria-selected'),
+      role: el.getAttribute('role')
+    };
+  });
+  if (!sessionAttrs) throw new Error('session sA li missing after click');
+  if (sessionAttrs.role !== 'option') throw new Error(`expected role=option on session row, got ${sessionAttrs.role}`);
+  if (sessionAttrs.tabindex !== '0') throw new Error(`expected tabindex=0 on selected session, got ${sessionAttrs.tabindex}`);
+  if (sessionAttrs.ariaSelected !== 'true') throw new Error(`expected aria-selected=true on active session, got ${sessionAttrs.ariaSelected}`);
+
+  // Precondition for contracts 2/3: focus the chat textarea directly.
+  const textarea = win.locator('textarea[data-input-bar]');
+  await textarea.focus();
+  const textareaReady = await win.waitForFunction(
+    () => {
+      const el = document.activeElement;
+      return el instanceof HTMLTextAreaElement && el.hasAttribute('data-input-bar');
+    },
+    null,
+    { timeout: 1500 }
+  ).then(() => true).catch(() => false);
+  if (!textareaReady) throw new Error('expected chat textarea focused after focus() precondition');
+
+  // Contract 2: Settings dialog focus restore.
+  await win.keyboard.press('Control+,');
+  await win.locator('[role="tablist"]').first().waitFor({ state: 'visible', timeout: 5000 });
+
+  const tablistOk = await win.evaluate(() => {
+    const list = document.querySelector('[role="tablist"]');
+    if (!list) return null;
+    const tabs = list.querySelectorAll('[role="tab"]');
+    if (tabs.length === 0) return null;
+    let selected = 0;
+    let withControls = 0;
+    for (const t of tabs) {
+      if (t.getAttribute('aria-selected') === 'true') selected++;
+      if (t.getAttribute('aria-controls')) withControls++;
+    }
+    return { count: tabs.length, selected, withControls };
+  });
+  if (!tablistOk) throw new Error('settings tablist missing or empty');
+  if (tablistOk.selected !== 1) throw new Error(`expected exactly one tab with aria-selected=true, got ${tablistOk.selected}`);
+  if (tablistOk.withControls !== tablistOk.count) throw new Error(`expected every tab to have aria-controls, got ${tablistOk.withControls}/${tablistOk.count}`);
+
+  await win.keyboard.press('Escape');
+  const settingsRestored = await win.waitForFunction(
+    () => {
+      const el = document.activeElement;
+      return el instanceof HTMLTextAreaElement && el.hasAttribute('data-input-bar');
+    },
+    null,
+    { timeout: 1500 }
+  ).then(() => true).catch(() => false);
+  if (!settingsRestored) throw new Error('expected focus restored to chat textarea after Settings close within 1.5s');
+
+  // Contract 3: CommandPalette focus restore.
+  await textarea.focus();
+  await win.waitForFunction(
+    () => {
+      const el = document.activeElement;
+      return el instanceof HTMLTextAreaElement && el.hasAttribute('data-input-bar');
+    },
+    null,
+    { timeout: 1000 }
+  ).catch(() => { throw new Error('expected chat textarea focused before opening CommandPalette'); });
+
+  await win.keyboard.press('Control+f');
+  await win.locator('input[placeholder]').first().waitFor({ state: 'visible', timeout: 5000 });
+  await win.waitForTimeout(50);
+  await win.keyboard.press('Escape');
+  const paletteRestored = await win.waitForFunction(
+    () => {
+      const el = document.activeElement;
+      return el instanceof HTMLTextAreaElement && el.hasAttribute('data-input-bar');
+    },
+    null,
+    { timeout: 1500 }
+  ).then(() => true).catch(() => false);
+  if (!paletteRestored) throw new Error('expected focus restored to chat textarea after CommandPalette close within 1.5s');
+
+  log('contracts 1-4: session-row attrs, Settings restore, Palette restore, chat-stream aria-live');
+}
+
+// ---------- harness spec ----------
+await runHarness({
+  name: 'ui',
+  setup: async ({ win }) => {
+    // Suppress the "Claude CLI not found" first-launch dialog.
+    await win.evaluate(() => {
+      window.__agentoryStore?.setState({
+        cliStatus: { state: 'found', binaryPath: '<harness>', version: null }
+      });
+    });
+  },
+  cases: [
+    { id: 'sidebar-align', run: caseSidebarAlign },
+    { id: 'no-sessions-landing', run: caseNoSessionsLanding },
+    { id: 'empty-state-minimal', run: caseEmptyStateMinimal },
+    { id: 'a11y-focus-restore', run: caseA11yFocusRestore }
+  ]
+});

--- a/scripts/probe-e2e-a11y-focus-restore.mjs
+++ b/scripts/probe-e2e-a11y-focus-restore.mjs
@@ -1,3 +1,5 @@
+// MERGED INTO scripts/harness-ui.mjs (case id=a11y-focus-restore; see harness file).
+// This per-file probe is kept as a breadcrumb. The runner skips it via MERGED_INTO_HARNESS.
 // E2E: a11y focus restore + ChatStream live region.
 //
 // Contracts under test:

--- a/scripts/probe-e2e-no-sessions-landing.mjs
+++ b/scripts/probe-e2e-no-sessions-landing.mjs
@@ -1,3 +1,5 @@
+// MERGED INTO scripts/harness-ui.mjs (case id=no-sessions-landing; see harness file).
+// This per-file probe is kept as a breadcrumb. The runner skips it via MERGED_INTO_HARNESS.
 // When there are zero sessions, the main panel should render exactly two
 // CTA buttons with identical variant/size/width (secondary / md / w-44).
 import { _electron as electron } from 'playwright';

--- a/scripts/probe-e2e-permission-focus-not-stolen.mjs
+++ b/scripts/probe-e2e-permission-focus-not-stolen.mjs
@@ -1,3 +1,5 @@
+// MERGED INTO scripts/harness-perm.mjs (case id=permission-focus-not-stolen; see harness file).
+// This per-file probe is kept as a breadcrumb. The runner skips it via MERGED_INTO_HARNESS.
 // Journey 1: when a permission request appears asynchronously while the user
 // is mid-typing in the composer textarea, focus MUST remain on the textarea so
 // the next keystroke continues the in-progress message. The permission block

--- a/scripts/probe-e2e-permission-mode-strict.mjs
+++ b/scripts/probe-e2e-permission-mode-strict.mjs
@@ -1,3 +1,5 @@
+// MERGED INTO scripts/harness-perm.mjs (case id=permission-mode-strict; see harness file).
+// This per-file probe is kept as a breadcrumb. The runner skips it via MERGED_INTO_HARNESS.
 // E2E: agent:setPermissionMode rejects unknown mode strings rather than
 // silently coercing them to 'default'. The earlier toCliPermissionMode()
 // fallback meant a buggy renderer could downgrade `bypassPermissions` to

--- a/scripts/probe-e2e-permission-nested-input.mjs
+++ b/scripts/probe-e2e-permission-nested-input.mjs
@@ -1,3 +1,5 @@
+// MERGED INTO scripts/harness-perm.mjs (case id=permission-nested-input; see harness file).
+// This per-file probe is kept as a breadcrumb. The runner skips it via MERGED_INTO_HARNESS.
 // Journey 6: nested toolInput object renders as readable summary.
 //
 // Expected user experience: when toolInput is `{ command: 'ls', flags: { a:

--- a/scripts/probe-e2e-permission-prompt.mjs
+++ b/scripts/probe-e2e-permission-prompt.mjs
@@ -1,3 +1,5 @@
+// MERGED INTO scripts/harness-perm.mjs (case id=permission-prompt; see harness file).
+// This per-file probe is kept as a breadcrumb. The runner skips it via MERGED_INTO_HARNESS.
 // Live e2e (renderer-only): inject a `waiting` permission block into the
 // running renderer store and verify the new PermissionPromptBlock component
 // renders EXPANDED with the expected keyboard behaviour. Bypasses the actual

--- a/scripts/probe-e2e-permission-sequential-focus.mjs
+++ b/scripts/probe-e2e-permission-sequential-focus.mjs
@@ -1,3 +1,5 @@
+// MERGED INTO scripts/harness-perm.mjs (case id=permission-sequential-focus; see harness file).
+// This per-file probe is kept as a breadcrumb. The runner skips it via MERGED_INTO_HARNESS.
 // Journey 4: focus transfers cleanly from one permission to the next.
 //
 // Scenario: a permission appears, user resolves it (Y -> Allow), then before

--- a/scripts/probe-e2e-permission-shortcut-scope.mjs
+++ b/scripts/probe-e2e-permission-shortcut-scope.mjs
@@ -1,3 +1,5 @@
+// MERGED INTO scripts/harness-perm.mjs (case id=permission-shortcut-scope; see harness file).
+// This per-file probe is kept as a breadcrumb. The runner skips it via MERGED_INTO_HARNESS.
 // Journey 2: Y/N hotkey scope.
 //
 // Expected user experience:

--- a/scripts/probe-e2e-permission-truncate-width.mjs
+++ b/scripts/probe-e2e-permission-truncate-width.mjs
@@ -1,3 +1,5 @@
+// MERGED INTO scripts/harness-perm.mjs (case id=permission-truncate-width; see harness file).
+// This per-file probe is kept as a breadcrumb. The runner skips it via MERGED_INTO_HARNESS.
 // Journey 3: long toolInput truncation + container width.
 //
 // Expected user experience: a permission whose toolInput is an 800-char SQL

--- a/scripts/probe-e2e-sidebar-align.mjs
+++ b/scripts/probe-e2e-sidebar-align.mjs
@@ -1,3 +1,5 @@
+// MERGED INTO scripts/harness-ui.mjs (case id=sidebar-align; see harness file).
+// This per-file probe is kept as a breadcrumb. The runner skips it via MERGED_INTO_HARNESS.
 // Measure sidebar vs chat-panel top/bottom alignment. Expectation: the two
 // column top edges and bottom edges should match within 1px. Before the fix
 // the sidebar is flush to window (top=0, bottom=vh) while <main> has my-2

--- a/scripts/run-all-e2e.mjs
+++ b/scripts/run-all-e2e.mjs
@@ -36,7 +36,25 @@ const MERGED_INTO_HARNESS = new Set([
   'streaming-journey-caret-lifecycle',
   'inputbar-visible',
   'chat-copy',
-  'input-placeholder'
+  'input-placeholder',
+  // harness-perm.mjs (Phase-3)
+  'permission-prompt',
+  'permission-mode-strict',
+  'permission-focus-not-stolen',
+  'permission-shortcut-scope',
+  'permission-nested-input',
+  'permission-truncate-width',
+  'permission-sequential-focus',
+  // harness-ui.mjs (Phase-3)
+  'sidebar-align',
+  'no-sessions-landing',
+  'a11y-focus-restore'
+  // NOTE: 'empty-state-minimal' is only PARTIALLY absorbed into harness-ui.mjs.
+  // The hero/no-starter-cards/no-"Working in" assertions are in the harness,
+  // but the "Claude CLI detected startup flash" guard needs a cold launch
+  // through the real startup pipeline (the harness sets cliStatus=found out of
+  // band in setup()). Kept as a per-file probe so that regression is still
+  // covered — do NOT add it here.
 ]);
 
 const skipRaw = (process.env.E2E_SKIP || '').trim();


### PR DESCRIPTION
## Summary

Phase 3 of the single-harness refactor (follow-up to #173). Absorbs 11 per-file `probe-e2e-*.mjs` probes into two themed harnesses that share a single Electron launch via `scripts/probe-helpers/harness-runner.mjs`.

- **`scripts/harness-perm.mjs`** — 7 PERM cases
- **`scripts/harness-ui.mjs`** — 4 UI cases

Same pattern as `harness-agent.mjs` (PR #173): shared runner, case-id log prefix on failure, per-case reset via `reset-between-cases.mjs`, per-case Playwright trace persisted only on fail, `--only=<id>` filter.

## Source probe -> harness case map

| Harness | Case id | Source probe |
| --- | --- | --- |
| perm | `permission-prompt` | `probe-e2e-permission-prompt.mjs` |
| perm | `permission-mode-strict` | `probe-e2e-permission-mode-strict.mjs` |
| perm | `permission-focus-not-stolen` | `probe-e2e-permission-focus-not-stolen.mjs` |
| perm | `permission-shortcut-scope` | `probe-e2e-permission-shortcut-scope.mjs` |
| perm | `permission-nested-input` | `probe-e2e-permission-nested-input.mjs` |
| perm | `permission-truncate-width` | `probe-e2e-permission-truncate-width.mjs` |
| perm | `permission-sequential-focus` | `probe-e2e-permission-sequential-focus.mjs` |
| ui | `sidebar-align` | `probe-e2e-sidebar-align.mjs` |
| ui | `no-sessions-landing` | `probe-e2e-no-sessions-landing.mjs` |
| ui | `empty-state-minimal` | `probe-e2e-empty-state-minimal.mjs` (partial, see below) |
| ui | `a11y-focus-restore` | `probe-e2e-a11y-focus-restore.mjs` |

Each absorbed probe has a `// MERGED INTO scripts/harness-<cluster>.mjs (case id=<id>; ...)` breadcrumb on line 1 and is skipped by `run-all-e2e.mjs` via `MERGED_INTO_HARNESS`.

## Probes intentionally NOT merged

- `probe-e2e-permission-allow-write` / `-allow-bash` / `-allow-parallel-batch` / `-reject-stops-agent` / `-prompt-default-mode` — all require a real `claude.exe` subprocess and a 60-90s observation window (FS + renderer store + DOM). The harness model (shared renderer, no per-case Electron boot, no real CLI) cannot host these without becoming fragile. Per instructions + `feedback_e2e_extend_existing.md`: quality over quantity.
- `probe-e2e-empty-state-minimal` — only PARTIALLY absorbed. The hero / no-starter-cards / no "Working in" assertions are in the `empty-state-minimal` case. The "Claude CLI detected startup flash" guard in the source probe requires a cold boot through the real startup pipeline (the harness sets `cliStatus={state:'found',...}` out of band in `setup()`, which skips the pipeline that produces the flash). The per-file probe is kept live as the canonical guard for that specific regression; documented with a comment in `run-all-e2e.mjs`.

## Wall-clock comparison

Sum of individual source probe cold launches vs single harness run (one Electron boot per harness).

| Cluster | Source probes (sum, cold) | Harness (3-run median) | Speedup |
| --- | --- | --- | --- |
| PERM (7 cases) | ~79.5s (33.2 + 4.0 + 8.6 + 8.5 + 8.3 + 8.3 + 8.6) | **~14.0s** | ~5.7x |
| UI (4 cases) | ~89.0s (17.9 + 18.0 + 18.0 + 35.1) | **~10.6s** | ~8.4x |

## 3-run flake counts

Both harnesses ran 3 times back-to-back after the final fix. Numbers below are wall-clock per run.

| Run | PERM | UI |
| --- | --- | --- |
| 1 | 14164ms pass | 10715ms pass |
| 2 | 14054ms pass | 10804ms pass |
| 3 | 13927ms pass | 10563ms pass |
| **Flake** | **0/3** | **0/3** |

## Reverse-verify (one load-bearing case per harness)

**PERM — `permission-nested-input`**
Sabotage: force the `formatToolInputSummary` object branch in `src/components/PermissionPromptBlock.tsx` to fall through to `String(v)` (coerces objects to `[object Object]`).
Harness output (restored after):
```
[harness=perm] >>> case permission-nested-input
[case=permission-nested-input] FAIL: rendered "[object Object]" — nested toolInput not properly serialized. Text: Permission requiredBashBash lscommandlsflags[object Object]Reject (N)Allow (Y)
  [XX] permission-nested-input                     998ms
```
The specific case-id failed with the expected diagnostic. No other cases ran (used `--only=permission-nested-input`).

**UI — `sidebar-align`**
Sabotage: add `my-2` to the `<main>` className in `src/App.tsx` (reintroduces the 8px vertical offset the fix removed).
Harness output (restored after):
```
[harness=ui] >>> case sidebar-align
[case=sidebar-align] FAIL: top edges misaligned: aside=0.0 main=8.0 delta=8.0
  [XX] sidebar-align                               530ms
```
The specific case-id failed with the expected 8px delta diagnostic.

Production code restored to origin/working in both cases; `git diff src/` is empty (modulo CRLF line endings on the Windows worktree checkout).

## Test plan

- [x] Both harnesses 3/3 PASS on a clean checkout.
- [x] Reverse-verify: one load-bearing case per harness fails by case-id when its production dep is broken.
- [x] `run-all-e2e.mjs` skip-list updated; absorbed probes still on disk as breadcrumbs.
- [x] `harness-agent.mjs` (Phase-2) untouched and still passes.
- [ ] Independent reviewer to re-confirm reverse-verify per `feedback_independent_reviewer.md` and `feedback_bugfix_requires_e2e.md`.

## Notes for reviewer

- The harness reset flow (`reset-between-cases.mjs`) is inherited unchanged from Phase 1/2. One minor per-case hazard surfaced during bring-up: the module-scope drafts cache (`src/stores/drafts.ts`) leaks textarea content across cases. The PERM `permission-sequential-focus` case explicitly `ta.fill('')` + blur to scrub it — same workaround as `inputbar-visible` in `harness-agent.mjs`.
- A small ordering gap on `permission-prompt`: the second-injection branch needed an explicit `waitForFunction` on `data-perm-action=reject` being the `activeElement` before pressing Y. Without it the keystroke races a slow InputBar mount on cold launch and gets typed into the textarea. Fix is a short wait, already in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)