### PR TITLE
chore: small follow-ups (focus-restore test, PERSISTED_KEYS drift, aria-describedby)

### DIFF
--- a/src/components/ClaudeCliMissingDialog.tsx
+++ b/src/components/ClaudeCliMissingDialog.tsx
@@ -495,6 +495,13 @@ function SuccessPane({
         <RD.Title className="text-base font-semibold text-fg-primary leading-tight">
           {t('cli.detected')}
         </RD.Title>
+        {/* Radix requires a Description (or explicit aria-describedby) on
+            DialogContent. The visible summary below carries the same info
+            but isn't wired to Radix, so we render an sr-only Description
+            to satisfy the contract and silence the console warning. */}
+        <RD.Description className="sr-only">
+          {version ? t('cli.foundVersion') + ' ' + version : t('cli.foundBinaryUnknown')}
+        </RD.Description>
         <div className="mt-1 text-sm text-fg-tertiary">
           {version ? (
             <>

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
 import { Check } from 'lucide-react';
 import * as Checkbox from '@radix-ui/react-checkbox';
+import * as RD from '@radix-ui/react-dialog';
 import { cn } from '../lib/cn';
 import { Dialog, DialogContent } from './ui/Dialog';
 import { Button } from './ui/Button';
@@ -106,6 +107,11 @@ export function SettingsDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent title={tt('title')} width="720px" hideClose={false} onCloseAutoFocus={handleCloseAutoFocus}>
+        {/* Radix requires either a Description or explicit aria-describedby
+            on DialogContent for a11y. Visible layout of Settings is driven
+            by the tab list + panel heading, so the description is sr-only;
+            screen readers announce it when focus lands in the dialog. */}
+        <RD.Description className="sr-only">{tt('description')}</RD.Description>
         <div className="flex min-h-[380px] border-t border-border-subtle">
           <nav
             className="w-[160px] shrink-0 border-r border-border-subtle py-2"

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -161,6 +161,7 @@ const en = {
   },
   settings: {
     title: 'Settings',
+    description: 'Configure appearance, notifications, connection, and updates.',
     tabs: {
       general: 'General',
       appearance: 'Appearance',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -155,6 +155,7 @@ const zh: EnCatalog = {
   },
   settings: {
     title: '设置',
+    description: '配置外观、通知、连接与更新。',
     tabs: {
       general: '通用',
       appearance: '外观',

--- a/tests/persisted-keys-source-of-truth.test.ts
+++ b/tests/persisted-keys-source-of-truth.test.ts
@@ -49,6 +49,44 @@ describe('persist: PERSISTED_KEYS is the single source of truth', () => {
     vi.resetModules();
   });
 
+  // Drift guard: any time a key is added/removed/reordered in PERSISTED_KEYS
+  // this snapshot flips, which surfaces the change as a visible diff in the
+  // PR touching PERSISTED_KEYS. Without this the only drift signal was a
+  // behavioral test failing with "comparator early-bailed on persisted key
+  // X" — correct but less obvious at review time. Update the snapshot in
+  // the same commit that changes PERSISTED_KEYS; reviewers should verify
+  // the new key is genuinely meant to be persisted.
+  it('PERSISTED_KEYS shape matches snapshot (update together with source)', () => {
+    expect(PERSISTED_KEYS).toMatchInlineSnapshot(`
+      [
+        "sessions",
+        "groups",
+        "activeId",
+        "model",
+        "permission",
+        "sidebarCollapsed",
+        "sidebarWidth",
+        "theme",
+        "fontSize",
+        "fontSizePx",
+        "density",
+        "recentProjects",
+        "tutorialSeen",
+        "notificationSettings",
+      ]
+    `);
+    // Structural invariants that any future key must satisfy. Catches a
+    // mechanically-broken entry even if the snapshot is updated carelessly.
+    expect(PERSISTED_KEYS.length).toBeGreaterThan(0);
+    for (const k of PERSISTED_KEYS) {
+      expect(typeof k, `PERSISTED_KEYS entry must be a string, got ${String(k)}`).toBe('string');
+      expect(k.length, 'PERSISTED_KEYS entry must be non-empty').toBeGreaterThan(0);
+    }
+    expect(new Set(PERSISTED_KEYS).size, 'PERSISTED_KEYS must be duplicate-free').toBe(
+      PERSISTED_KEYS.length
+    );
+  });
+
   it('every key in PERSISTED_KEYS lands in the serialized snapshot', async () => {
     const saveState = vi.fn().mockResolvedValue(undefined);
     const { storeMod } = await freshStore(saveState);

--- a/tests/use-focus-restore.test.tsx
+++ b/tests/use-focus-restore.test.tsx
@@ -1,12 +1,13 @@
-// Unit test for `useFocusRestore` covering the fallback-selector path.
-//
-// Why a unit test (not an e2e probe): the fallback fires only when the
-// previously-focused element is `document.body` / `document.documentElement`
-// or is no longer in the DOM. In normal product flow the user always has
-// SOMETHING focused before opening a dialog (clicking a session row leaves
-// focus on the chat textarea, see selectSession + InputBar nonce effect),
-// so this branch is unreachable from a click flow. JSDOM lets us drive
-// the synthetic state directly.
+// Unit tests for `useFocusRestore` — these assertions must be strong enough
+// that removing ONLY our custom restore logic (not Radix) causes each test to
+// fail. The old version of this file had one trivially-passing case: it
+// focused `prior` before opening and asserted focus was still on `prior`
+// after close, without ever moving focus elsewhere in between. A no-op
+// `onCloseAutoFocus` handler would have passed that assertion. We now
+// simulate what Radix (or the user) does between open and close — move focus
+// to an element inside the dialog — so that "focus lands back on prior" is
+// only true if our hook actively restored it. We also pin the preventDefault
+// contract that keeps Radix's built-in restore from racing us.
 import React, { useState } from 'react';
 import { describe, it, expect } from 'vitest';
 import { render, act } from '@testing-library/react';
@@ -77,15 +78,17 @@ describe('useFocusRestore fallback selector', () => {
     expect(document.activeElement).toBe(getByTestId('session-row'));
   });
 
-  it('restores the previously-focused element when one exists, ignoring fallback', () => {
+  it('restores the captured previous element even when focus has moved INSIDE the dialog in between', () => {
     const { getByTestId } = render(
       <div>
         <input data-testid="prior" />
+        <input data-testid="inside-dialog" />
         <Harness fallbackSelector='[data-session-id]' />
       </div>
     );
 
     const prior = getByTestId('prior') as HTMLInputElement;
+    const insideDialog = getByTestId('inside-dialog') as HTMLInputElement;
     prior.focus();
     expect(document.activeElement).toBe(prior);
 
@@ -93,10 +96,66 @@ describe('useFocusRestore fallback selector', () => {
       getByTestId('open').click();
     });
 
+    // Simulate Radix's focus trap (or the user tabbing around inside the
+    // dialog) moving focus somewhere other than `prior` between open and
+    // close. Without this, a no-op `handleCloseAutoFocus` would trivially
+    // "pass" because nothing ever moved focus away from `prior`.
+    insideDialog.focus();
+    expect(document.activeElement).toBe(insideDialog);
+
+    // Now close. Only our hook's restore logic puts focus back on `prior`;
+    // a no-op handler leaves focus on `insideDialog`.
     act(() => {
       getByTestId('close').click();
     });
 
     expect(document.activeElement).toBe(prior);
+    // Paranoid: catch a hypothetical buggy restore that targets the wrong
+    // element (e.g. fallback-selector match) by pinning the negative.
+    expect(document.activeElement).not.toBe(insideDialog);
+  });
+});
+
+// Pinning the preventDefault contract separately: a hook that restores focus
+// but forgets `event.preventDefault()` would pass the focus-outcome tests
+// above, yet in real usage Radix would still race it and sometimes land
+// focus on document.body. JSDOM-with-plain-Harness can't reproduce that
+// race, so we assert the contract directly on the Event object.
+describe('useFocusRestore contract: suppresses Radix default restore', () => {
+  function HarnessExposed({
+    onHandler
+  }: {
+    onHandler: (h: (e: Event) => void) => void;
+  }) {
+    const [open, setOpen] = useState(false);
+    const { handleCloseAutoFocus } = useFocusRestore(open, {
+      fallbackSelector: '[data-session-id]'
+    });
+    onHandler(handleCloseAutoFocus);
+    return (
+      <button data-testid="open-x" onClick={() => setOpen(true)}>
+        open
+      </button>
+    );
+  }
+
+  it('handleCloseAutoFocus calls event.preventDefault()', () => {
+    let handler: ((e: Event) => void) | null = null;
+    const { getByTestId } = render(
+      <HarnessExposed onHandler={(h) => (handler = h)} />
+    );
+    act(() => {
+      getByTestId('open-x').click();
+    });
+    expect(handler).toBeTruthy();
+    const ev = new Event('test', { cancelable: true });
+    act(() => {
+      handler!(ev);
+    });
+    // If the hook forgets preventDefault, Radix's built-in focus return
+    // runs and can land focus on document.body. Pin the contract here so
+    // a regression is caught even though JSDOM doesn't execute Radix's
+    // focus scope.
+    expect(ev.defaultPrevented).toBe(true);
   });
 });


### PR DESCRIPTION
Three independent small follow-ups bundled into one PR (each <15 min, unrelated files, skipping per-PR review overhead).

---

## #149 — tighten useFocusRestore unit tests

**Problem.** The prior "prior focus" case focused `prior` before opening the dialog and asserted focus was still on `prior` after close — but nothing ever moved focus away in between. A no-op `onCloseAutoFocus` handler would have passed too, so the test did not actually discriminate our hook from Radix's default behavior.

**Fix.** In `tests/use-focus-restore.test.tsx`:
- Between open and close, move focus to an input *inside* the dialog simulating Radix's focus trap. "Focus lands back on prior" is now only true if our hook actively restores it.
- Add a third test that pins the `event.preventDefault()` contract directly on the Event object — the Radix-race suppression that JSDOM can't otherwise exercise.

**Reverse-verify.** Neutered `handleCloseAutoFocus` body to `(_event) => {}`:
```
Test Files  1 failed (1)
     Tests  3 failed (3)
```
Restored body → 3/3 passing.

---

## #152 — PERSISTED_KEYS inline-snapshot drift surface

**Problem.** The existing behavioral tests iterate `PERSISTED_KEYS` from source, so they do fail when a key drifts out of sync — but reviewers only see a message like `comparator early-bailed on persisted key "X"`. No at-a-glance diff of the list itself.

**Fix.** Add `toMatchInlineSnapshot(PERSISTED_KEYS)` plus structural invariants (non-empty, all strings, no duplicates). Any change to `PERSISTED_KEYS` now produces a visible list diff in the same PR that touches it.

**Reverse-verify.** Appended `'fakeDriftKey'` to PERSISTED_KEYS → 3 failures including the snapshot mismatch showing the new entry. Reverted → 4/4 passing.

---

## #165 — aria-describedby for Dialog.Content

**Problem.** Radix logs `Missing Description or aria-describedby={undefined} for {DialogContent}` for any Dialog.Content rendered without a Description child.

**Fix.**
- `SettingsDialog`: added sr-only `<RD.Description>` wired to new i18n key `settings.description` (en + zh).
- `ClaudeCliMissingDialog.SuccessPane`: swaps in when detection succeeds and had Title only → added an sr-only Description built from the version/binary strings.

Scope stayed tight — these are the two already-flagged cases. `ImportDialog` already passes `description`; the main `ClaudeCliMissingDialog` Header also already has a Description.

**Verify.** `npx tsc --noEmit` clean; `npm run build` clean (3 webpack perf warnings, pre-existing). No probe per task instructions; visual layout unchanged.

---

### Out of scope / notes
- `db.test.ts` / `db-hardening.test.ts` fail in the worktree with `NODE_MODULE_VERSION` mismatch on better-sqlite3 — pre-existing, unrelated.
- Per the task doc, no probe was added for #165 (removes a console warning only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)