### PR TITLE
chore(probes): harden permission-allow-* + unmask harness-perm flake

### DIFF
--- a/scripts/harness-perm.mjs
+++ b/scripts/harness-perm.mjs
@@ -105,10 +105,15 @@ async function casePermissionPrompt({ win, log }) {
   // Wait for autoFocus effect to move focus onto the block's Reject button —
   // otherwise a just-launched InputBar can still hold focus and the Y keystroke
   // gets typed into the textarea instead of resolving the permission.
+  // Surface the timeout loudly (was `.catch(() => {})` — silently swallowed
+  // the race so the test continued and falsely "passed" even when the 2nd Y
+  // didn't resolve the prompt). Per PR #178 reviewer feedback.
   await win.waitForFunction(() => {
     const el = document.activeElement;
     return el?.getAttribute?.('data-perm-action') === 'reject';
-  }, null, { timeout: 2000 }).catch(() => {});
+  }, null, { timeout: 2000 }).catch((err) => {
+    throw new Error(`[case=permission-prompt] autoFocus never moved to Reject before 2nd Y press: ${err.message}`);
+  });
   await win.keyboard.press('y');
   try {
     await heading.waitFor({ state: 'detached', timeout: 3_000 });

--- a/scripts/probe-e2e-permission-allow-write.mjs
+++ b/scripts/probe-e2e-permission-allow-write.mjs
@@ -34,8 +34,14 @@ const PROJ = path.join(os.tmpdir(), `agentory-bugl-write-proj-${TS}`);
 fs.mkdirSync(UDD, { recursive: true });
 fs.mkdirSync(PROJ, { recursive: true });
 
+// Anchor the model on the Write tool explicitly. Earlier wording
+// ("Write a file called ...") let the model occasionally pick Edit /
+// MultiEdit instead, which made the downstream `tn === 'Write'` store
+// assertion flake. We also widen that assertion below to accept any
+// file-mutating tool (Write/Edit/MultiEdit) since all three exercise the
+// same Bug L permission/control_response path.
 const PROMPT =
-  "Write a file called hello.txt with the content 'world' in the current working directory.";
+  "Use the Write tool to create a NEW file at ./hello.txt with exactly the content 'world' (no trailing newline). Do not use Edit or MultiEdit.";
 
 function log(m) {
   process.stderr.write(`[probe-bugl-write ${new Date().toISOString()}] ${m}\n`);
@@ -142,12 +148,17 @@ while (Date.now() - obsStart < 60_000) {
       const st = window.__agentoryStore?.getState?.();
       const sid = st?.activeId;
       const blocks = st?.messagesBySession?.[sid] || [];
+      // Accept any file-mutating tool — the prompt anchors on Write but if
+      // the model picks Edit/MultiEdit they exercise the SAME Bug L
+      // permission round-trip path, so the test is still valid. The fs
+      // assertion below independently verifies the file content.
+      const writeLike = new Set(['Write', 'Edit', 'MultiEdit']);
       const w = blocks.find((b) => {
         const tn = b.toolName || b.name;
-        return b.kind === 'tool' && tn === 'Write';
+        return b.kind === 'tool' && writeLike.has(tn);
       });
       return w
-        ? { hasResult: typeof w.result === 'string' && w.result.length > 0, isError: w.isError === true, resultHead: typeof w.result === 'string' ? w.result.slice(0, 120) : null }
+        ? { hasResult: typeof w.result === 'string' && w.result.length > 0, isError: w.isError === true, toolName: w.toolName || w.name, resultHead: typeof w.result === 'string' ? w.result.slice(0, 120) : null }
         : { allBlocks: blocks.map((b) => ({ kind: b.kind, toolName: b.toolName || b.name, hasResult: typeof b.result === 'string' && b.result.length > 0 })) };
     })
     .catch(() => null);


### PR DESCRIPTION
Bundles two script-only probe-hardening items from recent PR reviews. Both low risk; no production code touched.

## Item #161 — tool-choice flake in probe-e2e-permission-allow-write

Closes #161. Related: PR #172 (Bug L fix), #162 (already closed, same area).

**Flake**: After #172 landed, the probe's store assertion hard-matched `toolName === 'Write'`. The model occasionally picked Edit or MultiEdit for the same prompt, and the test flaked even though Bug L's permission round-trip was functioning.

**Fix** (belt + suspenders):
1. Tightened prompt to explicitly anchor on the Write tool (\`Use the Write tool... Do not use Edit or MultiEdit\`).
2. Widened the store-block lookup to accept \`Write | Edit | MultiEdit\` as a safety net. All three exercise the same Bug L \`control_response\` envelope path, so the test remains valid. The fs assertion (file content == \`world\`) independently guards correctness.

**Flake rates** (local, Windows, real \`claude.exe\`):
- Before fix: not reliably reproducible in short runs (intermittent on CI, per #161 report).
- After fix: **9/11 pass** for tool-name-related failures. The 2 failures observed were a **different** flake class — Allow gets clicked, DOM shows \`File created successfully\`, but no file lands in PROJ dir (likely cwd propagation race or model writing to wrong path). Flagged as follow-up; out of scope here.

## Item PR-#178 follow-up — silent timeout in harness-perm

Addresses reviewer comment on PR #178 (just merged).

**Before**:
\`\`\`js
await win.waitForFunction(() => {
  const el = document.activeElement;
  return el?.getAttribute?.('data-perm-action') === 'reject';
}, null, { timeout: 2000 }).catch(() => {});
\`\`\`

**After**:
\`\`\`js
await win.waitForFunction(() => {
  const el = document.activeElement;
  return el?.getAttribute?.('data-perm-action') === 'reject';
}, null, { timeout: 2000 }).catch((err) => {
  throw new Error(\`[case=permission-prompt] autoFocus never moved to Reject before 2nd Y press: \${err.message}\`);
});
\`\`\`

**Rationale**: the 2nd \`Y\` press can race the autoFocus raf. The old swallowed catch let the test continue and falsely \"pass\" even when Y was typed into the textarea instead of resolving the permission. Now the race surfaces loudly as a FAIL.

This PR does NOT fix the underlying race — it just makes it observable. If the error starts firing in CI, a separate race-condition fix (e.g. wait on a dedicated \`data-perm-focused\` signal) is warranted.

**Verification**: \`harness-perm --only=permission-prompt\` passes 5/5 with the throw in place. No spurious failures on the happy path.

## Test plan
- [ ] \`node scripts/harness-perm.mjs --only=permission-prompt\` — passes 5/5 on CI
- [ ] \`node scripts/probe-e2e-permission-allow-write.mjs\` — passes when the model emits Write/Edit/MultiEdit
- [ ] Reviewer runs reverse-verify: revert the throw in harness-perm, confirm the silent-pass path is reachable

DO NOT merge — independent reviewer dispatched separately.

Generated with [Claude Code](https://claude.com/claude-code)