### PR TITLE
style(sidebar): focus ring + size + archive tokens

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -163,7 +163,7 @@ function GroupRow({
                 onFocus();
                 if (!renaming) setGroupCollapsed(group.id, !collapsed);
               }}
-              className="flex flex-1 min-w-0 items-center gap-1.5 text-left text-fg-secondary outline-none rounded-sm focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-border-strong"
+              className="flex flex-1 min-w-0 items-center gap-1.5 text-left text-fg-secondary outline-none rounded-sm focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-accent"
               aria-expanded={!collapsed}
             >
               <motion.span
@@ -211,7 +211,7 @@ function GroupRow({
                     e.stopPropagation();
                     createSession({ groupId: group.id });
                   }}
-                  className="shrink-0 h-5 w-5"
+                  className="shrink-0"
                 >
                   <Plus size={12} className="stroke-[1.75]" />
                 </IconButton>
@@ -744,19 +744,19 @@ export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, onOpen
             className={cn(
               'flex w-full items-center gap-1.5 px-3 py-2 outline-none shrink-0',
               'text-label-faint transition-colors duration-150',
-              'hover:[&]:text-[oklch(0.60_0_0)]'
+              'hover:[&]:text-fg-tertiary'
             )}
           >
             <motion.span
               initial={false}
               animate={{ rotate: archiveOpen ? 90 : 0 }}
               transition={{ duration: 0.2, ease: [0, 0, 0.2, 1] }}
-              className="inline-flex shrink-0 text-[oklch(0.46_0_0)]"
+              className="inline-flex shrink-0 text-fg-faint"
             >
               <ChevronRight size={12} className="stroke-[1.75]" />
             </motion.span>
             <span>{t('sidebar.archivedGroups')}</span>
-            <span className="ml-1 text-mono-sm leading-[14px] font-normal text-[oklch(0.46_0_0)] tabular-nums">
+            <span className="ml-1 text-mono-sm leading-[14px] font-normal text-fg-faint tabular-nums">
               {archived.length}
             </span>
           </button>


### PR DESCRIPTION
Closes #199, #200, #212.

Three small polish items from `docs/design/ui-review-sidebar.md`, batched into one PR. All changes in `src/components/Sidebar.tsx`; no token additions needed.

## Changes

- **#199 (H1) — Group-header focus ring → `ring-accent`.** The collapse-toggle `<button>` on each group row previously used `focus-visible:ring-border-strong`, which is near-invisible on `bg-sidebar` / `bg-bg-active`. Swapped to `ring-accent` to match the session-row focus pattern (`Sidebar.tsx:396`) and the rest of the app. Keyboard-nav users can now actually see where focus is.
- **#200 (M2) — Remove `h-5 w-5` override on per-group `+` IconButton.** The override was forcing the button below its `size="xs"` default, producing a 20x20 hit target with a hover surface too small to register. Dropping the override lets `xs` stand (24x24), which still fits inside the `h-7` group header with 2px vertical breathing room.
- **#212 (M3) — Inline `oklch()` in archive section → tokens.** Three literal `oklch()` values (chevron color, count color, hover color) replaced with `text-fg-faint` and `hover:text-fg-tertiary`. Existing tokens; no css changes. This also fixes a silent light-mode regression (the inline oklchs bypassed the light-theme remap of `.text-label-faint`).

## Self-verification

Run from the worktree checkout after `npm install --legacy-peer-deps`.

- `npm run build` → webpack 5.106.2 compiled with 3 warnings (pre-existing bundle size warnings, unrelated).
- `node scripts/harness-ui.mjs` → **4 passed, 0 failed, 4 total** (`sidebar-align`, `no-sessions-landing`, `empty-state-minimal`, `a11y-focus-restore`).
- `node scripts/harness-agent.mjs` → **8 passed, 0 failed, 8 total** (full agent regression sweep clean).

No Sidebar-specific e2e required — these are visual/polish changes, not bug fixes. Harness regression sweep confirms nothing broke.