### PR TITLE
fix(dialog): small fixes (Esc cancel + cli-missing timing)

### DIFF
--- a/src/components/ClaudeCliMissingDialog.tsx
+++ b/src/components/ClaudeCliMissingDialog.tsx
@@ -487,10 +487,20 @@ function SuccessPane({
   const { t } = useTranslation();
   const belowMin = isVersionBelow(version, CLI_MIN_VERSION_SOFT);
   return (
-    <div className="px-5 py-6 flex items-start gap-3">
-      <div className="mt-0.5 text-status-success-foreground">
+    <motion.div
+      initial={{ opacity: 0, y: 4 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.22, ease: [0.32, 0.72, 0, 1] }}
+      className="px-5 py-6 flex items-start gap-3"
+    >
+      <motion.div
+        initial={{ scale: 0.6, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        transition={{ delay: 0.08, duration: 0.24, ease: [0.32, 0.72, 0, 1] }}
+        className="mt-0.5 text-status-success-foreground"
+      >
         <Check size={18} className="stroke-[2]" />
-      </div>
+      </motion.div>
       <div className="flex-1 min-w-0">
         <RD.Title className="text-base font-semibold text-fg-primary leading-tight">
           {t('cli.detected')}
@@ -521,6 +531,6 @@ function SuccessPane({
           <div className="mt-1 truncate font-mono text-mono-sm text-fg-disabled">{binaryPath}</div>
         )}
       </div>
-    </div>
+    </motion.div>
   );
 }

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -11,6 +11,13 @@ type ConfirmDialogProps = {
   cancelLabel?: string;
   destructive?: boolean;
   onConfirm: () => void;
+  /**
+   * Optional explicit cancel handler. Fires when the user cancels via Esc,
+   * clicks the Cancel button, clicks outside, or hits the close (X) button.
+   * For non-destructive dialogs this runs alongside the close (onOpenChange
+   * still fires). Leave undefined if you only need close behavior.
+   */
+  onCancel?: () => void;
 };
 
 // Focus lands on Cancel by default — an accidental Enter/Space mustn't
@@ -24,31 +31,60 @@ export function ConfirmDialog({
   confirmLabel = 'Confirm',
   cancelLabel = 'Cancel',
   destructive = false,
-  onConfirm
+  onConfirm,
+  onCancel
 }: ConfirmDialogProps) {
   const cancelRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     if (!open) return;
+    // Reset the confirm marker each time the dialog opens so a prior
+    // confirm doesn't suppress onCancel on the next cancel.
+    confirmingRef.current = false;
     // Delay focus so dialog entrance animation settles before the ring
     // lands — otherwise the ring looks like it jumps into place mid-anim.
     const t = window.setTimeout(() => cancelRef.current?.focus(), 150);
     return () => window.clearTimeout(t);
   }, [open]);
 
+  // Track whether the last close was triggered by the Confirm button so we
+  // can distinguish it from a cancel path (Esc, Cancel, X, outside click).
+  const confirmingRef = useRef(false);
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        // Route every "close without confirming" path through the cancel
+        // handler: Esc, clicking the X button, clicking outside (when not
+        // destructive), and clicking the Cancel button (DialogClose).
+        if (!next && open && !confirmingRef.current) onCancel?.();
+        confirmingRef.current = false;
+        onOpenChange(next);
+      }}
+    >
       <DialogContent
         title={title}
         description={description}
         width="440px"
         hideClose={destructive}
         onInteractOutside={destructive ? (e) => e.preventDefault() : undefined}
+        // Esc behavior:
+        //   - destructive: block Esc so a stray keypress can't silently
+        //     trigger a destructive cancel/close path. User must click
+        //     Cancel or confirm explicitly. Documented here so future
+        //     readers don't "fix" it.
+        //   - otherwise: let Esc propagate through Radix's default close,
+        //     which flows into onOpenChange above and calls onCancel.
         onEscapeKeyDown={destructive ? (e) => e.preventDefault() : undefined}
       >
         <DialogFooter>
           <DialogClose asChild>
-            <Button ref={cancelRef} variant="secondary" size="md">
+            <Button
+              ref={cancelRef}
+              variant="secondary"
+              size="md"
+            >
               {cancelLabel}
             </Button>
           </DialogClose>
@@ -56,6 +92,7 @@ export function ConfirmDialog({
             variant={destructive ? 'danger' : 'primary'}
             size="md"
             onClick={() => {
+              confirmingRef.current = true;
               onConfirm();
               onOpenChange(false);
             }}


### PR DESCRIPTION
Closes #191, #205.

## Summary
- **UI-12 (#191) ConfirmDialog — Esc always cancels**: added optional `onCancel` prop. Esc, X, outside-click, and the Cancel button now all route through `onCancel` before closing. Destructive variant still blocks Esc by design (documented inline) so a stray keypress can't silently dismiss a destructive flow. Cancel-via-confirm is not double-fired: a ref guards against the confirm path entering the cancel branch, and the ref resets on each open so subsequent cancels still fire.
- **UI-13 (#205) ClaudeCliMissingDialog — success pane polish**: auto-dismiss timing kept at 1500ms (already in the target 1–2s band per review). Added a framer-motion fade-in/slide on the pane plus a subtle scale-in on the checkmark, using the same easing as the dialog entrance so it doesn't feel bolted on.

## Files
- `src/components/ui/ConfirmDialog.tsx`
- `src/components/ClaudeCliMissingDialog.tsx`

## Self-verification
- `npm run build` — OK (webpack compiled with only the pre-existing bundle-size warnings)
- `node scripts/harness-ui.mjs` — 4/4 PASS
- `node scripts/harness-agent.mjs` — 6/6 PASS (note: harness currently has 6 cases, not 8; all green)
- `node scripts/harness-perm.mjs` — 7/7 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)