### PR TITLE
style(inputbar): polish bundle (3 fixes)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -319,9 +319,6 @@ export default function App() {
                 onChangePermission={setPermission}
               />
               <InputBar sessionId={active.id} />
-              <div className="px-4 pb-2 font-mono text-xs text-fg-disabled select-none">
-                <span>Enter send · Shift+Enter newline</span>
-              </div>
             </main>
           }
         />

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { AlertCircle, ArrowUp, ImagePlus, Square, X } from 'lucide-react';
 import { cn } from '../lib/cn';
@@ -577,6 +577,27 @@ export function InputBar({ sessionId }: { sessionId: string }) {
   const sendDisabled = !value.trim() && attachments.length === 0;
   const remainingSlots = Math.max(0, MAX_IMAGES_PER_MESSAGE - attachments.length);
 
+  // Auto-resize the textarea: grow from ~2 lines up to ~10 lines, then scroll.
+  // useLayoutEffect so the height is corrected before the browser paints,
+  // avoiding a one-frame flicker on every keystroke. Matches the line-height
+  // declared on the <textarea> (22px) and the composer's vertical padding
+  // (pt-2 = 8px, pb-7 = 28px) so min/max map cleanly to "N lines of text".
+  const MIN_LINES = 2;
+  const MAX_LINES = 10;
+  const LINE_HEIGHT = 22;
+  const VPAD = 8 + 28; // pt-2 + pb-7
+  const MIN_HEIGHT = MIN_LINES * LINE_HEIGHT + VPAD; // 80
+  const MAX_HEIGHT = MAX_LINES * LINE_HEIGHT + VPAD; // 256
+  useLayoutEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    // Reset first so shrinking (after deleting lines) actually takes effect —
+    // scrollHeight is always >= current height.
+    el.style.height = 'auto';
+    const next = Math.min(MAX_HEIGHT, Math.max(MIN_HEIGHT, el.scrollHeight));
+    el.style.height = `${next}px`;
+  }, [value, attachments.length, MIN_HEIGHT, MAX_HEIGHT]);
+
   return (
     <div className="relative px-3 pt-2 pb-3">
       <DropOverlay show={isDragging} />
@@ -666,9 +687,10 @@ export function InputBar({ sessionId }: { sessionId: string }) {
           className={cn(
             'block w-full resize-none px-3 pt-2 pb-7 text-base leading-[22px]',
             'bg-transparent text-fg-primary placeholder:text-fg-tertiary',
-            'transition-colors duration-150 ease-out'
+            'transition-colors duration-150 ease-out',
+            'overflow-y-auto'
           )}
-          style={{ minHeight: 64, maxHeight: 240 }}
+          style={{ minHeight: MIN_HEIGHT, maxHeight: MAX_HEIGHT }}
         />
         <div className="absolute left-2 bottom-1.5 flex items-center gap-1">
           <input
@@ -727,7 +749,7 @@ export function InputBar({ sessionId }: { sessionId: string }) {
                 </Button>
               )}
               <Button
-                variant="secondary"
+                variant="danger"
                 size="sm"
                 aria-label={t('chat.stopAria')}
                 onClick={stop}
@@ -749,6 +771,16 @@ export function InputBar({ sessionId }: { sessionId: string }) {
             </Button>
           )}
         </div>
+      </div>
+
+      {/* Shortcut hints — one terse muted line below the composer. Swaps to
+          "Esc to stop" while a turn is running so the user always sees the
+          most relevant shortcut for the current state. */}
+      <div
+        className="mt-1 px-1 font-mono text-mono-xs text-fg-disabled select-none"
+        aria-hidden
+      >
+        {running ? t('chat.escToStop') : t('chat.enterToSend')}
       </div>
     </div>
   );

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -52,6 +52,7 @@ const en = {
     sendButton: 'Send',
     inputPlaceholder: 'Reply…',
     enterToSend: 'Enter send · Shift+Enter newline',
+    escToStop: 'Esc to stop · Enter to queue',
     tokenUsage: '{{used}}k / {{total}}k tokens · {{percent}}% used',
     emptyTitle: 'No messages yet',
     emptySubtitle: 'Start typing to begin a conversation.',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -52,6 +52,7 @@ const zh: EnCatalog = {
     sendButton: '发送',
     inputPlaceholder: '回复…',
     enterToSend: 'Enter 发送 · Shift+Enter 换行',
+    escToStop: 'Esc 中断 · Enter 排队',
     tokenUsage: '{{used}}k / {{total}}k tokens · 已用 {{percent}}%',
     emptyTitle: '暂无消息',
     emptySubtitle: '开始输入即可发起对话。',


### PR DESCRIPTION
## Summary

Three InputBar polish fixes bundled into one PR (per review `docs/design/ui-review-inputbar.md`).

- **UI-7 (#189): Composer textarea auto-resize** — grows from 2 to 10 lines via `useLayoutEffect` measuring `scrollHeight`, then scrolls. Min/max tied to line-height (22px) + vertical padding so the mapping to "N lines" is explicit.
- **UI-8 (#198): Shortcut hints visible in the composer** — a terse muted line below the textarea that swaps between `Enter send · Shift+Enter newline` and `Esc 中断 · Enter 排队` / `Esc to stop · Enter to queue` when a turn is running. Added `chat.escToStop` to both en + zh. The old duplicate hint block in `App.tsx` is removed.
- **UI-9 (#210): Stop is now primary, Queue stays secondary** — while running, Stop uses the `danger` variant (the dominant destructive-colored button), Queue uses `secondary`.

Closes #189, #198, #210.

## Self-verification

- `npm run build` — success (3 pre-existing bundle-size warnings only)
- `node scripts/harness-agent.mjs` — 8/8 PASS (includes `inputbar-visible`, `input-placeholder`)
- `node scripts/harness-ui.mjs` — 4/4 PASS

## Test plan

- [ ] Empty composer: height matches ~2 lines; placeholder visible.
- [ ] Paste 20 lines: grows to 10-line cap, then scrolls.
- [ ] Delete back to 1 line: shrinks to min without flicker.
- [ ] Idle state: hint reads `Enter send · Shift+Enter newline`.
- [ ] While running: hint switches to `Esc to stop · Enter to queue`; Stop button is danger-colored; Queue button appears (secondary) when there is text to queue.
- [ ] zh locale: hint strings render in Chinese.

🤖 Generated with [Claude Code](https://claude.com/claude-code)