### PR TITLE
style(motion): coordinate sidebar + right-pane on session switch

### DIFF
--- a/src/components/ChatStream.tsx
+++ b/src/components/ChatStream.tsx
@@ -13,6 +13,10 @@ import remarkGfm from 'remark-gfm';
 import type { MessageBlock, ImageAttachment } from '../types';
 import { useStore } from '../stores/store';
 import { attachmentToDataUrl, formatSize } from '../lib/attachments';
+import {
+  MOTION_SESSION_SWITCH_DURATION,
+  MOTION_STANDARD_EASING
+} from '../lib/motion';
 import { Button } from './ui/Button';
 import { StateGlyph } from './ui/StateGlyph';
 import { diffFromToolInput, type DiffSpec } from '../utils/diff';
@@ -1261,11 +1265,17 @@ export function ChatStream() {
         {blocks.length === 0 && !showThinkingDots && !loadError ? (
           <AnimatePresence mode="wait" initial={false}>
             <motion.div
-              key="empty"
+              // Key includes activeId so switching sessions (sidebar click)
+              // re-mounts and crossfades the right pane in sync with the
+              // sidebar selection-ring animation -- see src/lib/motion.ts.
+              key={`empty:${activeId}`}
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
-              transition={{ duration: 0.18, ease: [0, 0, 0.2, 1] }}
+              transition={{
+                duration: MOTION_SESSION_SWITCH_DURATION,
+                ease: MOTION_STANDARD_EASING
+              }}
               className="h-full"
             >
               <EmptyState />
@@ -1274,11 +1284,17 @@ export function ChatStream() {
         ) : (
           <AnimatePresence mode="wait" initial={false}>
             <motion.div
-              key="blocks"
+              // Same coordination as the empty branch above: key on activeId
+              // so a session switch crossfades the content pane alongside
+              // the sidebar selection ring (shared timing in src/lib/motion).
+              key={`blocks:${activeId}`}
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
-              transition={{ duration: 0.18, ease: [0, 0, 0.2, 1] }}
+              transition={{
+                duration: MOTION_SESSION_SWITCH_DURATION,
+                ease: MOTION_STANDARD_EASING
+              }}
               className="px-4 py-3 flex flex-col gap-1.5 max-w-[1100px]"
             >
               {loadError && (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -45,7 +45,12 @@ import { InlineRename } from './ui/InlineRename';
 import { ConfirmDialog } from './ui/ConfirmDialog';
 import { useToast } from './ui/Toast';
 import { useTranslation } from '../i18n/useTranslation';
-import { DURATION_RAW, EASING } from '../lib/motion';
+import {
+  DURATION_RAW,
+  EASING,
+  MOTION_SESSION_SWITCH_DURATION,
+  MOTION_STANDARD_EASING,
+} from '../lib/motion';
 import type { Group, Session } from '../types';
 
 // Session order inside a group is user-controlled (drag to reorder) — not
@@ -392,7 +397,11 @@ function SessionRow({ session, active, selected, onSelect, normalGroups }: { ses
           }
           className={cn(
             'group/sess relative flex items-center gap-2.5 pl-3 pr-2 rounded-sm cursor-pointer text-base h-9',
-            'transition-[background-color,color,box-shadow] duration-150',
+            // Keep duration/easing in sync with the selection ring below and
+            // with the right-pane content crossfade in ChatStream so clicking
+            // a session reads as ONE coordinated motion across panes. See
+            // src/lib/motion.ts (MOTION_SESSION_SWITCH_DURATION / EASING).
+            'transition-[background-color,color,box-shadow] duration-[180ms]',
             '[transition-timing-function:cubic-bezier(0.32,0.72,0,1)]',
             'outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-accent',
             selected
@@ -407,7 +416,10 @@ function SessionRow({ session, active, selected, onSelect, normalGroups }: { ses
               aria-hidden
               initial={{ scaleY: 0, opacity: 0, x: -2 }}
               animate={{ scaleY: 1, opacity: 1, x: 0 }}
-              transition={{ duration: DURATION_RAW.ms220, ease: EASING.standard }}
+              transition={{
+                duration: MOTION_SESSION_SWITCH_DURATION,
+                ease: MOTION_STANDARD_EASING
+              }}
               style={{ originY: 0.5 }}
               className="absolute left-0 top-0 bottom-0 w-[3px] bg-accent rounded-r-sm"
             />


### PR DESCRIPTION
Closes #192.

## Summary
Clicking a session in the sidebar fired three out-of-sync animations (sidebar row bg 150ms, selection ring 220ms with a custom ease, right-pane content 180ms with a different ease) AND the right pane did not re-crossfade on `activeId` change. The result read as jittery.

This PR introduces two shared motion constants and applies them to both panes so a session switch reads as one coordinated beat:

- `src/lib/motion.ts` (new): `MOTION_SESSION_SWITCH_DURATION = 0.18`, `MOTION_STANDARD_EASING = [0.32, 0.72, 0, 1]`, plus a CSS-string variant.
- `Sidebar.tsx`: session row bg transition `150ms -> 180ms`; selection ring `220ms -> 180ms` with the shared easing.
- `ChatStream.tsx`: right-pane empty/blocks crossfades keep 180ms but use the shared snappy easing, and the `AnimatePresence` children are now keyed on `activeId` so session switches actually trigger the crossfade (previously only empty<->non-empty did).

## Scope
- Minimal, surgical. No animation code restructured.
- No global token system refactor -- #190 (motion-token-kit) is the natural consumer of this module; the filename `src/lib/motion.ts` was deliberately chosen so that PR can extend in-place instead of duplicating.
- No ChatStream structural changes (#207 unaffected).

## Self-verification
- `npm run build`: OK (3 pre-existing bundle-size warnings only).
- `node scripts/harness-ui.mjs`: **4/4 PASS**.
- `node scripts/harness-perm.mjs`: **7/7 PASS**.
- `node scripts/harness-agent.mjs`: 7/8 (1 failure `streaming-caret-lifecycle` confirmed pre-existing on `origin/working` via a `git stash` baseline run -- unrelated to this change).

## Test plan
- [ ] Click between sessions in the sidebar. Selection ring + right-pane content fade together as one motion (no staggered ring-then-fade feel).
- [ ] Switching from a non-empty session to an empty one still crossfades cleanly via `EmptyState`.
- [ ] No regression in sidebar row hover/selection visuals.