### PR TITLE
refactor(motion): unified duration + easing tokens

### DIFF
--- a/src/components/AgentDiagnosticBanner.tsx
+++ b/src/components/AgentDiagnosticBanner.tsx
@@ -3,6 +3,7 @@ import { AlertTriangle, X } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { cn } from '../lib/cn';
 import { useStore } from '../stores/store';
+import { DURATION_RAW, EASING } from '../lib/motion';
 
 /**
  * Non-intrusive banner showing the most recent agent-layer diagnostic (F1).
@@ -42,7 +43,7 @@ export function AgentDiagnosticBanner() {
           initial={{ opacity: 0, height: 0 }}
           animate={{ opacity: 1, height: 'auto' }}
           exit={{ opacity: 0, height: 0 }}
-          transition={{ duration: 0.15, ease: 'easeOut' }}
+          transition={{ duration: DURATION_RAW.ms150, ease: EASING.enter }}
           className="overflow-hidden"
           data-agent-diagnostic-banner
           data-severity={latest.level}

--- a/src/components/AgentInitFailedBanner.tsx
+++ b/src/components/AgentInitFailedBanner.tsx
@@ -4,6 +4,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { cn } from '../lib/cn';
 import { useStore } from '../stores/store';
 import { startSessionAndReconcile } from '../agent/startSession';
+import { DURATION_RAW, EASING } from '../lib/motion';
 
 /**
  * Banner shown at the top of the right pane when `agent:start` failed for the
@@ -59,7 +60,7 @@ export function AgentInitFailedBanner({
           initial={{ opacity: 0, height: 0 }}
           animate={{ opacity: 1, height: 'auto' }}
           exit={{ opacity: 0, height: 0 }}
-          transition={{ duration: 0.15, ease: 'easeOut' }}
+          transition={{ duration: DURATION_RAW.ms150, ease: EASING.enter }}
           className="overflow-hidden"
           data-agent-init-failed-banner
         >

--- a/src/components/ClaudeCliMissingDialog.tsx
+++ b/src/components/ClaudeCliMissingDialog.tsx
@@ -7,6 +7,7 @@ import { Button } from './ui/Button';
 import { DialogOverlay } from './ui/Dialog';
 import { useStore, CLI_MIN_VERSION_SOFT, isVersionBelow } from '../stores/store';
 import { useTranslation } from '../i18n/useTranslation';
+import { DURATION, DURATION_RAW, EASING } from '../lib/motion';
 
 type Tab = 'install' | 'have-it';
 
@@ -417,7 +418,7 @@ function CommandRow({ row }: { row: InstallRow }) {
                 initial={{ scale: 0.7, opacity: 0 }}
                 animate={{ scale: 1, opacity: 1 }}
                 exit={{ scale: 0.7, opacity: 0 }}
-                transition={{ duration: 0.14 }}
+                transition={{ duration: DURATION.fast }}
                 className="text-status-success-foreground"
               >
                 <Check size={13} className="stroke-[2.25]" />
@@ -428,7 +429,7 @@ function CommandRow({ row }: { row: InstallRow }) {
                 initial={{ scale: 0.7, opacity: 0 }}
                 animate={{ scale: 1, opacity: 1 }}
                 exit={{ scale: 0.7, opacity: 0 }}
-                transition={{ duration: 0.14 }}
+                transition={{ duration: DURATION.fast }}
               >
                 <Copy size={13} className="stroke-[2]" />
               </motion.span>
@@ -490,13 +491,13 @@ function SuccessPane({
     <motion.div
       initial={{ opacity: 0, y: 4 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.22, ease: [0.32, 0.72, 0, 1] }}
+      transition={{ duration: DURATION_RAW.ms220, ease: EASING.standard }}
       className="px-5 py-6 flex items-start gap-3"
     >
       <motion.div
         initial={{ scale: 0.6, opacity: 0 }}
         animate={{ scale: 1, opacity: 1 }}
-        transition={{ delay: 0.08, duration: 0.24, ease: [0.32, 0.72, 0, 1] }}
+        transition={{ delay: 0.08, duration: DURATION.slow, ease: EASING.standard }}
         className="mt-0.5 text-status-success-foreground"
       >
         <Check size={18} className="stroke-[2]" />

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -4,6 +4,7 @@ import { AlertCircle, ArrowUp, ImagePlus, Square, X } from 'lucide-react';
 import { cn } from '../lib/cn';
 import { Button } from './ui/Button';
 import { useStore } from '../stores/store';
+import { DURATION, EASING } from '../lib/motion';
 import { useShallow } from 'zustand/react/shallow';
 import { SlashCommandPicker } from './SlashCommandPicker';
 import {
@@ -57,7 +58,7 @@ function AttachmentChip({
       initial={{ opacity: 0, y: 4, scale: 0.96 }}
       animate={{ opacity: 1, y: 0, scale: 1 }}
       exit={{ opacity: 0, y: -2, scale: 0.96 }}
-      transition={{ duration: 0.18, ease: [0.32, 0.72, 0, 1] }}
+      transition={{ duration: DURATION.standard, ease: EASING.standard }}
       className="group relative flex items-center gap-2 rounded-md border border-border-subtle bg-bg-elevated/80 pl-1 pr-2 py-1 hover:border-border-strong transition-colors duration-150 ease-out"
     >
       <img
@@ -96,7 +97,7 @@ function DropOverlay({ show }: { show: boolean }) {
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
-          transition={{ duration: 0.14, ease: [0, 0, 0.2, 1] }}
+          transition={{ duration: DURATION.fast, ease: EASING.enter }}
           className="pointer-events-none absolute inset-2 z-10 rounded-lg border-2 border-dashed border-accent bg-accent/[0.08] backdrop-blur-[1px] flex flex-col items-center justify-center gap-2"
           aria-hidden
         >
@@ -609,7 +610,7 @@ export function InputBar({ sessionId }: { sessionId: string }) {
             initial={{ opacity: 0, y: 4 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -2 }}
-            transition={{ duration: 0.18, ease: [0.32, 0.72, 0, 1] }}
+            transition={{ duration: DURATION.standard, ease: EASING.standard }}
             role="alert"
             className="mb-2 rounded-md border border-state-error/40 bg-state-error-soft/60 px-3 py-2 text-xs text-state-error-fg"
           >

--- a/src/components/PermissionPromptBlock.tsx
+++ b/src/components/PermissionPromptBlock.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { ShieldAlert } from 'lucide-react';
 import { Button } from './ui/Button';
 import { useTranslation } from '../i18n/useTranslation';
+import { DURATION_RAW, EASING } from '../lib/motion';
 
 export interface PermissionPromptBlockProps {
   /** Short human description, e.g. "Bash: ls -la". Used as the fallback summary. */
@@ -161,7 +162,7 @@ export function PermissionPromptBlock({
       aria-describedby="perm-desc"
       initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.22, ease: [0.32, 0.72, 0, 1] }}
+      transition={{ duration: DURATION_RAW.ms220, ease: EASING.standard }}
       className="relative my-2 rounded-md border border-accent/50 bg-accent/[0.06] surface-highlight surface-elevated pl-4 pr-4 py-3"
     >
       <span

--- a/src/components/QuestionBlock.tsx
+++ b/src/components/QuestionBlock.tsx
@@ -8,6 +8,7 @@ import type { QuestionSpec } from '../types';
 import { Button } from './ui/Button';
 import { StateGlyph } from './ui/StateGlyph';
 import { useTranslation } from '../i18n/useTranslation';
+import { DURATION, DURATION_RAW, EASING } from '../lib/motion';
 
 export interface QuestionBlockProps {
   questions: QuestionSpec[];
@@ -110,7 +111,7 @@ export function QuestionBlock({ questions, onSubmit, autoFocus = true }: Questio
       ref={rootRef}
       initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.22, ease: [0.32, 0.72, 0, 1] }}
+      transition={{ duration: DURATION_RAW.ms220, ease: EASING.standard }}
       className="relative my-2 rounded-md border border-state-waiting/40 bg-state-waiting/[0.06] surface-highlight surface-elevated pl-4 pr-4 py-3"
       onKeyDownCapture={onKeyDownCapture}
     >
@@ -229,7 +230,7 @@ function SingleSelectGroup({ q, qi, picks, submitted, onToggle, labelClass, auto
             key={oi}
             initial={{ opacity: 0, y: 4 }}
             animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.18, delay: oi * 0.02, ease: [0, 0, 0.2, 1] }}
+            transition={{ duration: DURATION.standard, delay: oi * 0.02, ease: EASING.enter }}
             htmlFor={id}
             className={labelClass(selected)}
           >
@@ -272,7 +273,7 @@ function MultiSelectGroup({ q, qi, picks, submitted, onToggle, labelClass, autoF
               key={oi}
               initial={{ opacity: 0, y: 4 }}
               animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.18, delay: oi * 0.02, ease: [0, 0, 0.2, 1] }}
+              transition={{ duration: DURATION.standard, delay: oi * 0.02, ease: EASING.enter }}
               htmlFor={id}
               className={labelClass(selected)}
             >

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -10,6 +10,7 @@ import { useStore } from '../stores/store';
 import { useTranslation } from '../i18n/useTranslation';
 import { usePreferences } from '../store/preferences';
 import { useFocusRestore } from '../lib/useFocusRestore';
+import { DURATION_RAW, EASING } from '../lib/motion';
 
 type LocalUpdateStatus =
   | { kind: 'idle' }
@@ -149,7 +150,7 @@ export function SettingsDialog({
                     <motion.span
                       aria-hidden
                       layoutId="settings-tab-indicator"
-                      transition={{ duration: 0.22, ease: [0.32, 0.72, 0, 1] }}
+                      transition={{ duration: DURATION_RAW.ms220, ease: EASING.standard }}
                       className="absolute left-0 top-1 bottom-1 w-[3px] bg-accent rounded-r-sm"
                     />
                   )}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -45,6 +45,7 @@ import { InlineRename } from './ui/InlineRename';
 import { ConfirmDialog } from './ui/ConfirmDialog';
 import { useToast } from './ui/Toast';
 import { useTranslation } from '../i18n/useTranslation';
+import { DURATION_RAW, EASING } from '../lib/motion';
 import type { Group, Session } from '../types';
 
 // Session order inside a group is user-controlled (drag to reorder) — not
@@ -153,7 +154,7 @@ function GroupRow({
                 aria-hidden
                 initial={{ scaleY: 0, opacity: 0, x: -2 }}
                 animate={{ scaleY: 1, opacity: 1, x: 0 }}
-                transition={{ duration: 0.22, ease: [0.32, 0.72, 0, 1] }}
+                transition={{ duration: DURATION_RAW.ms220, ease: EASING.standard }}
                 style={{ originY: 0.5 }}
                 className="absolute left-0 top-0 bottom-0 w-[3px] bg-accent rounded-r-sm"
               />
@@ -169,7 +170,7 @@ function GroupRow({
               <motion.span
                 initial={false}
                 animate={{ rotate: collapsed ? 0 : 90 }}
-                transition={{ duration: 0.2, ease: [0, 0, 0.2, 1] }}
+                transition={{ duration: DURATION_RAW.ms200, ease: EASING.enter }}
                 className="inline-flex shrink-0"
               >
                 <ChevronRight size={12} className="stroke-[1.75] text-fg-tertiary" />
@@ -406,7 +407,7 @@ function SessionRow({ session, active, selected, onSelect, normalGroups }: { ses
               aria-hidden
               initial={{ scaleY: 0, opacity: 0, x: -2 }}
               animate={{ scaleY: 1, opacity: 1, x: 0 }}
-              transition={{ duration: 0.22, ease: [0.32, 0.72, 0, 1] }}
+              transition={{ duration: DURATION_RAW.ms220, ease: EASING.standard }}
               style={{ originY: 0.5 }}
               className="absolute left-0 top-0 bottom-0 w-[3px] bg-accent rounded-r-sm"
             />
@@ -607,7 +608,7 @@ export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, onOpen
       // the store (see SidebarResizer + store.sidebarWidth). framer-motion
       // tweens the change so collapse/expand stays smooth.
       animate={{ width: collapsed ? 48 : sidebarWidth }}
-      transition={{ duration: 0.22, ease: [0.32, 0.72, 0, 1] }}
+      transition={{ duration: DURATION_RAW.ms220, ease: EASING.standard }}
       className="relative flex flex-col shrink-0 bg-bg-sidebar/80 backdrop-blur-xl sidebar-edge overflow-hidden h-full"
     >
       {/* Top drag strip — mirrors the right pane's 32px drag strip so the
@@ -755,7 +756,7 @@ export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, onOpen
             <motion.span
               initial={false}
               animate={{ rotate: archiveOpen ? 90 : 0 }}
-              transition={{ duration: 0.2, ease: [0, 0, 0.2, 1] }}
+              transition={{ duration: DURATION_RAW.ms200, ease: EASING.enter }}
               className="inline-flex shrink-0 text-fg-faint"
             >
               <ChevronRight size={12} className="stroke-[1.75]" />

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -3,6 +3,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { cn } from '../../lib/cn';
 import { StateGlyph } from './StateGlyph';
 import { useTranslation } from '../../i18n/useTranslation';
+import { DURATION_RAW, EASING } from '../../lib/motion';
 
 export type ToastKind = 'info' | 'waiting' | 'error';
 
@@ -80,7 +81,7 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
               initial={{ opacity: 0, y: 8, scale: 0.98 }}
               animate={{ opacity: 1, y: 0, scale: 1 }}
               exit={{ opacity: 0, y: 4, scale: 0.98 }}
-              transition={{ duration: 0.2, ease: [0.32, 0.72, 0, 1] }}
+              transition={{ duration: DURATION_RAW.ms200, ease: EASING.standard }}
               className={cn(
                 'pointer-events-auto relative rounded-md border pl-3 pr-3 py-2.5',
                 'bg-bg-elevated surface-highlight surface-elevated',

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -1,0 +1,135 @@
+/**
+ * Unified motion token kit.
+ *
+ * One source of truth for animation durations, easing curves, and common
+ * framer-motion `transition` presets. Inline `duration: 0.22, ease: [...]`
+ * literals should consume these tokens instead of hard-coding numbers, so
+ * the motion language stays consistent as the app grows.
+ *
+ * Design:
+ * - 5 duration tiers covering micro-feedback → layout shifts.
+ * - 3 easing curves covering steady (codebase default), soft enter
+ *   (deceleration), and firm exit (acceleration), plus `linear`.
+ * - Presets are ready-to-spread objects for `<motion.* animate={...} />`.
+ *
+ * Reduced motion: the global stylesheet already shortens/neutralises
+ * transitions and animations via `@media (prefers-reduced-motion: reduce)`
+ * in `src/styles/global.css`. Components that want to opt framer-motion out
+ * explicitly can import `useReducedMotion` from `framer-motion` directly —
+ * no extra helper is added here to avoid a parallel system.
+ */
+
+/**
+ * Cubic-bezier control points. Keep as a tuple for framer-motion's
+ * `ease` prop (which rejects plain `number[]`).
+ */
+export type EasingTuple = readonly [number, number, number, number];
+
+/**
+ * Duration tokens, in seconds (framer-motion units).
+ *
+ * | Token       | ms  | Use                                        |
+ * | ----------- | --- | ------------------------------------------ |
+ * | instant     |  80 | micro-feedback (button press, icon swap)   |
+ * | fast        | 140 | hover transitions, small crossfades        |
+ * | standard    | 180 | default (session switch, dialog fade)      |
+ * | slow        | 240 | pane entrance, heavy content, rails        |
+ * | deliberate  | 320 | long-list re-order, layout shifts          |
+ */
+export const DURATION = {
+  instant: 0.08,
+  fast: 0.14,
+  standard: 0.18,
+  slow: 0.24,
+  deliberate: 0.32,
+} as const;
+
+export type DurationToken = keyof typeof DURATION;
+
+/**
+ * Granular durations for migrating legacy inline values without shifting
+ * perceived motion. Prefer the semantic `DURATION.*` tokens for NEW code;
+ * use these only when the exact millisecond count is load-bearing (e.g.
+ * a carefully-tuned settle).
+ *
+ * Units: seconds, same as `DURATION`.
+ */
+export const DURATION_RAW = {
+  ms150: 0.15,
+  ms200: 0.2,
+  ms220: 0.22,
+  ms250: 0.25,
+  ms300: 0.3,
+} as const;
+
+/**
+ * Easing tokens.
+ *
+ * - `standard` — matches existing inline `[0.32, 0.72, 0, 1]` (codebase
+ *   default, feels "crisp settle"). Use for generic enter/exit on
+ *   non-directional elements.
+ * - `enter` — soft deceleration; matches existing `[0, 0, 0.2, 1]`. Use
+ *   when something slides/fades IN from invisibility.
+ * - `exit` — firm acceleration; mirror of `enter`. Use when something
+ *   slides/fades OUT (often paired with `DURATION.instant|fast`).
+ * - `linear` — literal `'linear'` string (framer-motion accepts it).
+ */
+export const EASING = {
+  standard: [0.32, 0.72, 0, 1] as EasingTuple,
+  enter: [0, 0, 0.2, 1] as EasingTuple,
+  exit: [0.7, 0, 0.84, 0] as EasingTuple,
+  linear: 'linear' as const,
+} as const;
+
+export type EasingToken = keyof typeof EASING;
+
+/**
+ * Ready-to-spread framer-motion `transition` objects and common animation
+ * presets. Each preset's `transition` field is a new object so callers can
+ * override without mutating the shared instance.
+ */
+export const MOTION_PRESETS = {
+  /** opacity 0 → 1, fast + soft enter. */
+  fadeIn: {
+    opacity: [0, 1] as [number, number],
+    transition: { duration: DURATION.fast, ease: EASING.enter },
+  },
+  /** opacity 1 → 0, instant + firm exit. Leaves the stage fast. */
+  fadeOut: {
+    opacity: [1, 0] as [number, number],
+    transition: { duration: DURATION.instant, ease: EASING.exit },
+  },
+  /** Session-pane / dialog switch: standard duration, standard ease. */
+  sessionSwitch: {
+    transition: { duration: DURATION.standard, ease: EASING.standard },
+  },
+  /** Focus / selection ring slide-in on list rows. */
+  selectionRing: {
+    transition: { duration: DURATION.slow, ease: EASING.standard },
+  },
+  /** Full-pane entrance (sidebar resize, settings tab swap). */
+  paneEnter: {
+    transition: { duration: DURATION.slow, ease: EASING.standard },
+  },
+  /** Chevron rotate / disclosure. */
+  disclosure: {
+    transition: { duration: DURATION.standard, ease: EASING.enter },
+  },
+  /** Banner / toast slide-and-fade in. */
+  bannerIn: {
+    transition: { duration: DURATION.fast, ease: EASING.enter },
+  },
+} as const;
+
+export type MotionPreset = keyof typeof MOTION_PRESETS;
+
+// ---------------------------------------------------------------------------
+// Compatibility aliases for task #192 (cross-pane motion). These let the
+// parallel branch land either order without duplicating constants.
+// ---------------------------------------------------------------------------
+
+/** Standard-duration session / pane switch. Alias of `DURATION.standard`. */
+export const MOTION_SESSION_SWITCH_DURATION = DURATION.standard;
+
+/** Codebase-default easing curve. Alias of `EASING.standard`. */
+export const MOTION_STANDARD_EASING = EASING.standard;


### PR DESCRIPTION
Ref #190.

## Summary

Establish a unified motion token kit at \`src/lib/motion.ts\` and migrate 9 high-leverage components off inline \`[0.32, 0.72, 0, 1]\` / \`duration: 0.22\` literals. No behaviour change — durations are preserved via semantic tokens (\`DURATION.*\`) or exact aliases (\`DURATION_RAW.*\`) where the millisecond count was load-bearing.

## Tokens

- \`DURATION\`: \`instant(80)\` / \`fast(140)\` / \`standard(180)\` / \`slow(240)\` / \`deliberate(320)\` ms
- \`DURATION_RAW\`: \`ms150\` / \`ms200\` / \`ms220\` / \`ms250\` / \`ms300\` — exact-preservation aliases for legacy values that don't round cleanly, so the migration is truly behaviour-preserving.
- \`EASING\`: \`standard\` \`[0.32,0.72,0,1]\` / \`enter\` \`[0,0,0.2,1]\` / \`exit\` \`[0.7,0,0.84,0]\` / \`linear\`.
- \`MOTION_PRESETS\`: \`fadeIn\`, \`fadeOut\`, \`sessionSwitch\`, \`selectionRing\`, \`paneEnter\`, \`disclosure\`, \`bannerIn\`.
- Compat aliases for #192 (cross-pane motion) so either branch can merge first: \`MOTION_SESSION_SWITCH_DURATION\`, \`MOTION_STANDARD_EASING\`.

## Migration list (9 files)

- \`src/components/Sidebar.tsx\` — group/session selection rings, width resize, archive chevron rotate
- \`src/components/SettingsDialog.tsx\` — tab indicator layoutId
- \`src/components/ClaudeCliMissingDialog.tsx\` — copy-state crossfade + success screen (2 transitions + container)
- \`src/components/PermissionPromptBlock.tsx\` — block entrance
- \`src/components/QuestionBlock.tsx\` — block entrance + option stagger (3 transitions)
- \`src/components/ui/Toast.tsx\` — toast in/out
- \`src/components/AgentDiagnosticBanner.tsx\` — banner slide-in (also normalised \`ease: 'easeOut'\` → \`EASING.enter\`)
- \`src/components/AgentInitFailedBanner.tsx\` — banner slide-in (same easeOut normalisation)
- \`src/components/InputBar.tsx\` — error pill + auto-grow (3 transitions)

## Out of scope

- **ChatStream per-block motion** — hot path; task #207 will refactor. Flagged here, not touched.
- **Tutorial / FileTree** — skipped to respect the 10-file budget; can be picked up in a follow-up.

## Reduced motion

Decision: **no new JS hook**. \`src/styles/global.css\` already has a \`@media (prefers-reduced-motion: reduce)\` block that shortens/neutralises CSS transitions and animations globally. framer-motion in this codebase is generally short (≤320ms) and uses \`opacity\` / \`transform\`, which the OS respects via the same setting. Adding a parallel \`useReducedMotion\` helper would duplicate the CSS source of truth without a concrete component needing it today. If a future animation is long enough to feel disruptive under reduced motion, callers can import framer-motion's \`useReducedMotion\` directly — documented in the header comment of \`motion.ts\`.

## Coordination with #192

#192 has not landed at commit time, so this PR ships the full token kit plus forward-compat aliases (\`MOTION_SESSION_SWITCH_DURATION\`, \`MOTION_STANDARD_EASING\`). #192 will be a no-op consumer on rebase.

## Self-verification

- [x] \`npm run build\` — compiles clean (type-check crucial given many touched files).
- [x] \`node scripts/harness-agent.mjs\` — 8/8 PASS
- [x] \`node scripts/harness-ui.mjs\` — 4/4 PASS
- [x] \`node scripts/harness-perm.mjs\` — 7/7 PASS

## Test plan

- [ ] Open SettingsDialog, switch tabs — indicator slide feels identical.
- [ ] Click through sessions in sidebar — selection ring + group chevron rotate feel identical.
- [ ] Trigger a permission prompt — block entrance feel identical.
- [ ] Trigger a toast — slide-in/out feel identical.