### PR TITLE
feat(ui): keyboard shortcut overlay (? / Cmd+/)

### DIFF
--- a/scripts/harness-ui.mjs
+++ b/scripts/harness-ui.mjs
@@ -7,11 +7,12 @@
 // excluded from the per-file runner via scripts/run-all-e2e.mjs's
 // MERGED_INTO_HARNESS skip list.
 //
-// Scope (4 cases — pure UI / store-driven, no real claude.exe required):
+// Scope (5 cases — pure UI / store-driven, no real claude.exe required):
 //   - sidebar-align             (probe-e2e-sidebar-align)
 //   - no-sessions-landing       (probe-e2e-no-sessions-landing)
 //   - empty-state-minimal       (probe-e2e-empty-state-minimal)
 //   - a11y-focus-restore        (probe-e2e-a11y-focus-restore)
+//   - shortcut-overlay-opens    (new — UI-1 / #188)
 //
 // Related UI probes already absorbed into harness-agent.mjs:
 //   - inputbar-visible, chat-copy, input-placeholder
@@ -248,6 +249,74 @@ async function caseA11yFocusRestore({ win, log }) {
   log('contracts 1-4: session-row attrs, Settings restore, Palette restore, chat-stream aria-live');
 }
 
+// ---------- shortcut-overlay-opens ----------
+async function caseShortcutOverlayOpens({ win, log }) {
+  // Seed a normal active session so the full App branch renders (the
+  // overlay is wired into both branches, but this keeps the test closer
+  // to real usage).
+  await win.evaluate(() => {
+    window.__agentoryStore.setState({
+      groups: [{ id: 'g1', name: 'G1', collapsed: false, kind: 'normal' }],
+      sessions: [{ id: 's1', name: 's', state: 'idle', cwd: 'C:/x', model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code' }],
+      activeId: 's1',
+      messagesBySession: { s1: [] }
+    });
+  });
+  await win.waitForTimeout(200);
+
+  // Press `?` on the body (not in any input) → overlay should open.
+  await win.evaluate(() => {
+    if (document.activeElement instanceof HTMLElement) document.activeElement.blur();
+    document.body.focus();
+  });
+  await win.keyboard.press('Shift+Slash');
+
+  const overlay = win.locator('[data-shortcut-overlay]');
+  try {
+    await overlay.waitFor({ state: 'visible', timeout: 3000 });
+  } catch {
+    throw new Error('shortcut overlay did not appear after pressing ?');
+  }
+
+  // Title (rendered via DialogContent's title prop) must be present.
+  const hasTitle = await overlay.evaluate((el) => {
+    const id = el.getAttribute('aria-labelledby');
+    if (!id) return false;
+    const t = document.getElementById(id);
+    return !!t && /Keyboard shortcuts/i.test(t.textContent || '');
+  });
+  if (!hasTitle) {
+    const dump = await overlay.evaluate((el) => {
+      const id = el.getAttribute('aria-labelledby');
+      const t = id ? document.getElementById(id) : null;
+      return { id, text: t?.textContent, bodyText: el.textContent?.slice(0, 200), html: el.innerHTML.slice(0, 500) };
+    });
+    throw new Error('overlay title "Keyboard shortcuts" missing; dump=' + JSON.stringify(dump));
+  }
+  const kbdCount = await overlay.locator('kbd').count();
+  if (kbdCount < 6) throw new Error(`expected >=6 kbd chips in overlay, got ${kbdCount}`);
+
+  // Escape dismisses.
+  await win.keyboard.press('Escape');
+  const closed = await win.waitForFunction(
+    () => !document.querySelector('[data-shortcut-overlay]'),
+    null,
+    { timeout: 2000 }
+  ).then(() => true).catch(() => false);
+  if (!closed) throw new Error('overlay still present after Escape');
+
+  // Cmd/Ctrl+/ as the alternative trigger — Control on all harness hosts.
+  await win.keyboard.press('Control+/');
+  try {
+    await overlay.waitFor({ state: 'visible', timeout: 3000 });
+  } catch {
+    throw new Error('shortcut overlay did not appear after Ctrl+/');
+  }
+  await win.keyboard.press('Escape');
+
+  log(`overlay opened via ? and Ctrl+/, ${kbdCount} kbd chips`);
+}
+
 // ---------- harness spec ----------
 await runHarness({
   name: 'ui',
@@ -263,6 +332,7 @@ await runHarness({
     { id: 'sidebar-align', run: caseSidebarAlign },
     { id: 'no-sessions-landing', run: caseNoSessionsLanding },
     { id: 'empty-state-minimal', run: caseEmptyStateMinimal },
-    { id: 'a11y-focus-restore', run: caseA11yFocusRestore }
+    { id: 'a11y-focus-restore', run: caseA11yFocusRestore },
+    { id: 'shortcut-overlay-opens', run: caseShortcutOverlayOpens }
   ]
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { StatusBar } from './components/StatusBar';
 import { SettingsDialog } from './components/SettingsDialog';
 import { CommandPalette } from './components/CommandPalette';
 import { ImportDialog } from './components/ImportDialog';
+import { ShortcutOverlay } from './components/ShortcutOverlay';
 import { DragRegion, WindowControls } from './components/WindowControls';
 import { Tutorial } from './components/Tutorial';
 import { ClaudeCliMissingDialog } from './components/ClaudeCliMissingDialog';
@@ -40,6 +41,27 @@ subscribeAgentEvents();
 // security boundary; same trade-off as `window.__agentoryI18n`.
 if (typeof window !== 'undefined') {
   (window as unknown as { __agentoryStore?: typeof useStore }).__agentoryStore = useStore;
+}
+
+/**
+ * True when the event target is a text-editable surface where printable
+ * keys (like "?") should remain composition input rather than trigger a
+ * global shortcut. Checked by the document-level `keydown` listener in
+ * `App` to gate the modifier-free "?" shortcut-overlay binding.
+ */
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+  const tag = target.tagName;
+  if (tag === 'TEXTAREA') return true;
+  if (tag === 'INPUT') {
+    const type = (target as HTMLInputElement).type;
+    // checkbox/radio/button-like inputs don't capture printable keys;
+    // treat them as non-editable so "?" still opens the overlay there.
+    const nonText = new Set(['checkbox', 'radio', 'button', 'submit', 'reset', 'range', 'color', 'file']);
+    return !nonText.has(type);
+  }
+  return false;
 }
 
 export default function App() {
@@ -142,6 +164,7 @@ export default function App() {
   const [settingsOpen, setSettingsOpen] = React.useState(false);
   const [paletteOpen, setPaletteOpen] = React.useState(false);
   const [importOpen, setImportOpen] = React.useState(false);
+  const [shortcutsOpen, setShortcutsOpen] = React.useState(false);
 
   // New sessions are created in-place — no modal. The store seeds `cwd`
   // from `recentProjects[0]?.path ?? '~'`; users repick later via the
@@ -158,7 +181,27 @@ export default function App() {
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       const mod = e.metaKey || e.ctrlKey;
-      if (!mod) return;
+      // Cmd/Ctrl+/ opens the shortcuts overlay. We handle it BEFORE the
+      // `if (!mod) return` guard below so it sits alongside the other
+      // modified-key bindings, even though the `?` alternative handled
+      // further down is modifier-free.
+      if (mod && e.key === '/' && !e.shiftKey) {
+        e.preventDefault();
+        setShortcutsOpen((p) => !p);
+        return;
+      }
+      if (!mod) {
+        // Modifier-free bindings: the "?" shortcut for the shortcuts
+        // overlay. We deliberately DO NOT fire when the user is typing
+        // into a text field — "?" is a printable glyph and must not be
+        // stolen mid-composition. Activating only when focus is on body
+        // or a non-editable element matches macOS/GitHub conventions.
+        if (e.key === '?' && !isEditableTarget(e.target)) {
+          e.preventDefault();
+          setShortcutsOpen((p) => !p);
+        }
+        return;
+      }
       const k = e.key.toLowerCase();
       if (k === 'f' && !e.shiftKey) {
         // Cmd/Ctrl+F opens the global Search / Command Palette. We
@@ -264,6 +307,7 @@ export default function App() {
             onSelectSession={selectSession}
             onFocusGroup={focusGroup}
           />
+          <ShortcutOverlay open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
         </ToastProvider>
       </TooltipProvider>
     );
@@ -334,6 +378,7 @@ export default function App() {
           onSelectSession={selectSession}
           onFocusGroup={focusGroup}
         />
+        <ShortcutOverlay open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
       </ToastProvider>
     </TooltipProvider>
   );

--- a/src/components/ShortcutOverlay.tsx
+++ b/src/components/ShortcutOverlay.tsx
@@ -1,0 +1,159 @@
+import React, { useMemo } from 'react';
+import { Dialog, DialogContent } from './ui/Dialog';
+import { useTranslation } from '../i18n/useTranslation';
+
+// Platform-aware modifier glyph. We detect once on module eval — the platform
+// doesn't change during a session. Falls back to "Ctrl" for anything that
+// isn't obviously macOS (Windows, Linux, unknown UA).
+const IS_MAC =
+  typeof navigator !== 'undefined' &&
+  /Mac|iPhone|iPad|iPod/i.test(navigator.platform || navigator.userAgent || '');
+
+const MOD = IS_MAC ? '\u2318' : 'Ctrl'; // ⌘ on mac, Ctrl elsewhere
+const SHIFT = IS_MAC ? '\u21E7' : 'Shift'; // ⇧ on mac
+
+type Row = { keys: string; actionKey: string };
+type Group = { titleKey: string; rows: Row[] };
+
+// Shortcuts discovered by grepping the codebase. Keep this list in sync
+// with the real handlers — comment next to each row points at the source.
+// Platform modifier is resolved at render time so the overlay always
+// shows the keys the user actually needs to press.
+function buildGroups(): Group[] {
+  return [
+    {
+      titleKey: 'shortcuts.groupChat',
+      rows: [
+        // InputBar.tsx — Enter (no shift) sends, shift+Enter inserts newline.
+        { keys: 'Enter', actionKey: 'shortcuts.actionSend' },
+        { keys: `${SHIFT} + Enter`, actionKey: 'shortcuts.actionNewline' },
+        // InputBar.tsx — document-level Esc interrupts the running turn.
+        { keys: 'Esc', actionKey: 'shortcuts.actionStop' },
+        // InputBar.tsx:558 — Esc in slash-command picker dismisses it.
+        { keys: 'Esc', actionKey: 'shortcuts.actionDismissPicker' }
+      ]
+    },
+    {
+      titleKey: 'shortcuts.groupSidebar',
+      rows: [
+        // App.tsx:169 — Cmd/Ctrl+B toggles the sidebar.
+        { keys: `${MOD} + B`, actionKey: 'shortcuts.actionToggleSidebar' },
+        // App.tsx:179 — Cmd/Ctrl+N creates a new session.
+        { keys: `${MOD} + N`, actionKey: 'shortcuts.actionNewSession' },
+        // App.tsx:175 — Cmd/Ctrl+Shift+N creates a new group.
+        { keys: `${MOD} + ${SHIFT} + N`, actionKey: 'shortcuts.actionNewGroup' }
+      ]
+    },
+    {
+      titleKey: 'shortcuts.groupNavigation',
+      rows: [
+        // App.tsx:163 — Cmd/Ctrl+F opens the palette.
+        { keys: `${MOD} + F`, actionKey: 'shortcuts.actionSearch' },
+        // App.tsx:172 — Cmd/Ctrl+, opens Settings.
+        { keys: `${MOD} + ,`, actionKey: 'shortcuts.actionSettings' },
+        // This PR — ? or Cmd/Ctrl+/ opens this overlay.
+        { keys: `?  ·  ${MOD} + /`, actionKey: 'shortcuts.actionShortcuts' }
+      ]
+    }
+  ];
+}
+
+export type ShortcutOverlayProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export function ShortcutOverlay({ open, onOpenChange }: ShortcutOverlayProps) {
+  const { t } = useTranslation();
+  const groups = useMemo(() => buildGroups(), []);
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        width="560px"
+        title={t('shortcuts.title')}
+        description={t('shortcuts.description')}
+        data-shortcut-overlay
+      >
+        <div className="px-5 pb-5 pt-1">
+          {groups.map((g, gi) => (
+            <section key={g.titleKey} className={gi === 0 ? '' : 'mt-5'}>
+              <h3 className="text-[11px] font-semibold uppercase tracking-wider text-fg-tertiary mb-2">
+                {t(g.titleKey)}
+              </h3>
+              <table className="w-full text-sm">
+                <thead className="sr-only">
+                  <tr>
+                    <th>{t('shortcuts.colShortcut')}</th>
+                    <th>{t('shortcuts.colAction')}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {g.rows.map((r, ri) => (
+                    <tr
+                      key={`${g.titleKey}-${ri}`}
+                      className="border-t border-border-subtle first:border-t-0"
+                    >
+                      <td className="py-1.5 pr-4 w-[180px] align-top">
+                        <KeyChips combo={r.keys} />
+                      </td>
+                      <td className="py-1.5 text-fg-secondary align-top">
+                        {t(r.actionKey)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </section>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * Renders a shortcut combo like "Ctrl + Shift + N" as a row of
+ * monospace chips separated by a dim "+". Multiple combos can be
+ * separated with " · " (middle-dot) and render as distinct chip groups.
+ */
+function KeyChips({ combo }: { combo: string }) {
+  // Split on the middle-dot separator first (multi-binding row),
+  // then each binding on " + ".
+  const bindings = combo.split(/\s+\u00B7\s+/);
+  return (
+    <span className="inline-flex items-center gap-2 flex-wrap">
+      {bindings.map((binding, bi) => {
+        const parts = binding.split(/\s*\+\s*/);
+        return (
+          <span key={bi} className="inline-flex items-center gap-1">
+            {parts.map((p, pi) => (
+              <React.Fragment key={pi}>
+                {pi > 0 && (
+                  <span aria-hidden="true" className="text-fg-tertiary text-xs">
+                    +
+                  </span>
+                )}
+                <kbd
+                  className={
+                    'inline-flex items-center justify-center ' +
+                    'min-w-[22px] h-[22px] px-1.5 ' +
+                    'rounded border border-border-default bg-bg-elevated ' +
+                    'font-mono text-[11px] leading-none text-fg-primary ' +
+                    'shadow-[inset_0_-1px_0_0_oklch(0_0_0_/_0.25)]'
+                  }
+                >
+                  {p}
+                </kbd>
+              </React.Fragment>
+            ))}
+            {bi < bindings.length - 1 && (
+              <span aria-hidden="true" className="text-fg-tertiary">
+                ·
+              </span>
+            )}
+          </span>
+        );
+      })}
+    </span>
+  );
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -489,6 +489,26 @@ const en = {
     maximize: 'Maximize',
     restore: 'Restore',
     close: 'Close'
+  },
+  shortcuts: {
+    title: 'Keyboard shortcuts',
+    description: 'Press Esc or click outside to close. Press ? to reopen.',
+    openHint: 'Shortcuts',
+    groupChat: 'Chat',
+    groupSidebar: 'Sidebar & Sessions',
+    groupNavigation: 'Navigation',
+    actionSend: 'Send message',
+    actionNewline: 'Insert newline',
+    actionStop: 'Interrupt running turn',
+    actionDismissPicker: 'Dismiss slash-command picker',
+    actionToggleSidebar: 'Toggle sidebar',
+    actionNewSession: 'New session',
+    actionNewGroup: 'New group',
+    actionSearch: 'Open search / command palette',
+    actionSettings: 'Open settings',
+    actionShortcuts: 'Show this shortcuts overlay',
+    colShortcut: 'Shortcut',
+    colAction: 'Action'
   }
 } as const;
 

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -476,6 +476,26 @@ const zh: EnCatalog = {
     maximize: '最大化',
     restore: '还原',
     close: '关闭'
+  },
+  shortcuts: {
+    title: '键盘快捷键',
+    description: '按 Esc 或点击外部关闭。按 ? 重新打开。',
+    openHint: '快捷键',
+    groupChat: '聊天',
+    groupSidebar: '侧边栏与会话',
+    groupNavigation: '导航',
+    actionSend: '发送消息',
+    actionNewline: '插入换行',
+    actionStop: '中断当前回合',
+    actionDismissPicker: '关闭斜杠命令选择器',
+    actionToggleSidebar: '切换侧边栏',
+    actionNewSession: '新建会话',
+    actionNewGroup: '新建分组',
+    actionSearch: '打开搜索 / 命令面板',
+    actionSettings: '打开设置',
+    actionShortcuts: '显示快捷键面板',
+    colShortcut: '快捷键',
+    colAction: '动作'
   }
 };
 


### PR DESCRIPTION
## Summary

Implements **UI-1** from `docs/design/ui-review-holistic.md` (GH #188): a
global keyboard-shortcut overlay triggered by `?` or `Cmd/Ctrl+/`, showing
every real shortcut the app already has, grouped by area, rendered as a
monospace two-column table with chip-styled `<kbd>` glyphs. Dialog-backed
(Radix), so focus trap / Esc / focus-restore come for free.

## Shortcuts displayed (all grepped from existing code — none invented)

| Group | Keys | Action | Source |
|---|---|---|---|
| Chat | `Enter` | Send message | `InputBar.tsx:565` |
| Chat | `Shift+Enter` | Insert newline | `InputBar.tsx:565` (!shiftKey branch) |
| Chat | `Esc` | Interrupt running turn | `InputBar.tsx:365` |
| Chat | `Esc` | Dismiss slash-command picker | `InputBar.tsx:558` |
| Sidebar | `Cmd/Ctrl+B` | Toggle sidebar | `App.tsx:169` |
| Sidebar | `Cmd/Ctrl+N` | New session | `App.tsx:179` |
| Sidebar | `Cmd/Ctrl+Shift+N` | New group | `App.tsx:175` |
| Navigation | `Cmd/Ctrl+F` | Search / command palette | `App.tsx:163` |
| Navigation | `Cmd/Ctrl+,` | Open settings | `App.tsx:172` |
| Navigation | `?` / `Cmd/Ctrl+/` | Open this overlay | **new** |

## Design notes

- **Modifier-free `?` is gated on a non-editable event target** (textarea,
  input, contentEditable). Without this guard, `Shift+/` mid-composition
  in the chat input would steal the glyph and pop the overlay — classic
  footgun. Matches macOS / GitHub conventions.
- **Platform glyph resolution**: `⌘` on macOS, `Ctrl` elsewhere. Detected
  once from `navigator.platform` — doesn't change mid-session.
- **No new deps**. Uses existing `@radix-ui/react-dialog` via the repo's
  `DialogContent` wrapper, so the chrome / shadows / entrance animation
  are consistent with Settings and CommandPalette.
- **Tooltip chips on buttons — deferred.** `@radix-ui/react-tooltip` IS
  already installed, but wiring chips onto sidebar / inputbar buttons
  would require editing those components, which the task brief explicitly
  scopes out. Tracking as follow-up.

## Files

- `src/components/ShortcutOverlay.tsx` (new, 159 LOC)
- `src/App.tsx` — register the overlay, extend the global keydown handler
  with `?` and `Cmd/Ctrl+/`, add `isEditableTarget()` helper
- `src/i18n/locales/{en,zh}.ts` — `shortcuts.*` namespace (19 keys each,
  parity test green)
- `scripts/harness-ui.mjs` — new `shortcut-overlay-opens` case

## Test plan

- [x] `npm run build` — succeeded (3 pre-existing webpack size warnings)
- [x] `node scripts/harness-ui.mjs` — 5/5 PASS (incl. new case)
- [x] `node scripts/harness-agent.mjs` — 8/8 PASS
- [x] `node scripts/harness-perm.mjs` — 7/7 PASS
- [x] `vitest run tests/i18n-key-parity.test.ts` — 2/2 PASS
- [x] Manual: `?` opens overlay, Esc closes, clicking outside closes, focus
      trap while open, focus returns to trigger (via Radix Dialog).
- [x] Manual: `Cmd/Ctrl+/` alternative trigger also opens it.
- [x] Manual: typing `?` inside the chat input composes normally.

Refs: #188, `docs/design/ui-review-holistic.md` UI-1

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>