### PR TITLE
feat(perm): Allow-always + PermissionPromptBlock a11y completion

### DIFF
--- a/scripts/harness-perm.mjs
+++ b/scripts/harness-perm.mjs
@@ -78,11 +78,13 @@ async function casePermissionPrompt({ win, log }) {
     return { buttons: btns };
   });
 
-  if (snapshot.buttons.length !== 2) throw new Error(`expected 2 perm buttons, got ${snapshot.buttons.length}`);
+  if (snapshot.buttons.length !== 3) throw new Error(`expected 3 perm buttons, got ${snapshot.buttons.length}`);
   const reject = snapshot.buttons.find((b) => b.action === 'reject');
   const allow = snapshot.buttons.find((b) => b.action === 'allow');
+  const allowAlways = snapshot.buttons.find((b) => b.action === 'allow-always');
   if (!reject || !/Reject \(N\)/i.test(reject.label ?? '')) throw new Error(`bad reject label: ${reject?.label}`);
   if (!allow || !/Allow \(Y\)/i.test(allow.label ?? '')) throw new Error(`bad allow label: ${allow?.label}`);
+  if (!allowAlways || !/Allow always/i.test(allowAlways.label ?? '')) throw new Error(`bad allow-always label: ${allowAlways?.label}`);
   if (!reject.focused) throw new Error(`expected Reject focused; got ${JSON.stringify(snapshot.buttons)}`);
 
   // Press N -> Reject. Block should disappear.
@@ -443,6 +445,210 @@ async function casePermissionSequentialFocus({ win, log }) {
   log('focus correctly transfers to second block\'s Reject');
 }
 
+// ---------- permission-allow-always ----------
+// Covers UI-6 (#214) and guards the session-scoped auto-resolve fast-path:
+//   1. First prompt arrives, user clicks "Allow always" -> store records the
+//      tool name AND dispatches Allow IPC.
+//   2. Second prompt for the same tool name must NOT render a waiting block
+//      and must dispatch Allow IPC automatically via the lifecycle fast-path
+//      (`maybeAutoResolveAllowAlways`).
+async function casePermissionAllowAlways({ win, log }) {
+  await seedSession(win);
+
+  // Spy on the store action so we can confirm allow decisions reach the
+  // resolve path (which in turn fires the preload IPC). Mirrors the pattern
+  // used by permission-shortcut-scope — direct assignment to the
+  // contextBridge proxy is a no-op.
+  await win.evaluate(() => {
+    window.__permIpcCalls = [];
+    const store = window.__agentoryStore;
+    const orig = store.getState().resolvePermission;
+    store.setState({
+      resolvePermission: (sessionId, requestId, decision) => {
+        window.__permIpcCalls.push({ sessionId, requestId, decision });
+        return orig(sessionId, requestId, decision);
+      }
+    });
+  });
+
+  // 1. Inject first prompt and click "Allow always".
+  await injectWaiting(win, {
+    id: 'wait-PROBE-AA-1',
+    requestId: 'PROBE-AA-1',
+    toolName: 'Bash',
+    toolInput: { command: 'echo first' },
+    prompt: 'Bash: echo first'
+  });
+
+  const heading = win.locator('text=Permission required').first();
+  await heading.waitFor({ state: 'visible', timeout: 5000 });
+
+  const allowAlwaysBtn = win.locator('[data-perm-action="allow-always"]').first();
+  await allowAlwaysBtn.waitFor({ state: 'visible', timeout: 3000 });
+  await allowAlwaysBtn.click();
+
+  try {
+    await heading.waitFor({ state: 'detached', timeout: 3000 });
+  } catch {
+    throw new Error('first block did not unmount after clicking Allow always');
+  }
+
+  const firstIpc = await win.evaluate(() => window.__permIpcCalls.slice());
+  const firstCall = firstIpc.find((c) => c.requestId === 'PROBE-AA-1');
+  if (!firstCall || firstCall.decision !== 'allow') {
+    throw new Error(`first Allow always did not fire IPC allow: ${JSON.stringify(firstIpc)}`);
+  }
+
+  const snapshot1 = await win.evaluate(() => {
+    const s = window.__agentoryStore.getState();
+    return { list: s.allowAlwaysTools.slice() };
+  });
+  if (!snapshot1.list.includes('Bash')) {
+    throw new Error(`allowAlwaysTools missing Bash after click: ${JSON.stringify(snapshot1)}`);
+  }
+
+  // 2. Second prompt via the real lifecycle fast-path. Must auto-resolve
+  // (Allow IPC) and must NOT append any waiting block.
+  await win.evaluate(() => { window.__permIpcCalls = []; });
+  const blocksBefore = await win.evaluate(() => {
+    const s = window.__agentoryStore.getState();
+    return (s.messagesBySession[s.activeId] || []).filter((b) => b.kind === 'waiting').length;
+  });
+
+  const autoResolved = await win.evaluate(() => {
+    const fn = window.__agentoryMaybeAutoResolveAllowAlways;
+    if (typeof fn !== 'function') return null;
+    const sid = window.__agentoryStore.getState().activeId;
+    return fn({ sessionId: sid, requestId: 'PROBE-AA-2', toolName: 'Bash' });
+  });
+  if (autoResolved !== true) {
+    throw new Error(`expected fast-path to auto-resolve (returned true), got ${JSON.stringify(autoResolved)}`);
+  }
+
+  await win.waitForTimeout(200);
+
+  const blocksAfter = await win.evaluate(() => {
+    const s = window.__agentoryStore.getState();
+    return (s.messagesBySession[s.activeId] || []).filter((b) => b.kind === 'waiting').length;
+  });
+  if (blocksAfter !== blocksBefore) {
+    throw new Error(`expected 0 new waiting blocks on second allow-always tool use; before=${blocksBefore} after=${blocksAfter}`);
+  }
+
+  const stillHidden = await heading.isVisible().catch(() => false);
+  if (stillHidden) throw new Error('permission block rendered for allow-always tool (should have been auto-resolved)');
+
+  const secondIpc = await win.evaluate(() => window.__permIpcCalls.slice());
+  const secondCall = secondIpc.find((c) => c.requestId === 'PROBE-AA-2');
+  if (!secondCall || secondCall.decision !== 'allow') {
+    throw new Error(`fast-path did not dispatch Allow IPC for PROBE-AA-2: ${JSON.stringify(secondIpc)}`);
+  }
+
+  // 3. Guard: a non-allow-listed tool still renders a prompt.
+  await injectWaiting(win, {
+    id: 'wait-PROBE-AA-3',
+    requestId: 'PROBE-AA-3',
+    toolName: 'Write',
+    toolInput: { file_path: '/tmp/x', content: 'x' },
+    prompt: 'Write: /tmp/x'
+  });
+  await heading.waitFor({ state: 'visible', timeout: 5000 });
+  // dismiss via reject to keep state clean
+  await win.keyboard.press('n');
+  try {
+    await heading.waitFor({ state: 'detached', timeout: 3000 });
+  } catch {
+    // non-fatal — tool-not-in-list still shows a prompt, which was the point.
+  }
+
+  log('allow-always persists for Bash in-session; Write still prompts; IPC allow dispatched');
+}
+
+// ---------- permission-a11y ----------
+// Covers UI-11 (#194): role=alertdialog + aria-modal + labelled/described.
+async function casePermissionA11y({ win, log }) {
+  await seedSession(win);
+  await injectWaiting(win, {
+    id: 'wait-PROBE-A11Y',
+    requestId: 'PROBE-A11Y',
+    toolInput: { command: 'echo a11y' },
+    prompt: 'Bash a11y'
+  });
+
+  const heading = win.locator('text=Permission required').first();
+  await heading.waitFor({ state: 'visible', timeout: 5000 });
+
+  const attrs = await win.evaluate(() => {
+    const heading = Array.from(document.querySelectorAll('*')).find(
+      (n) => n.textContent?.trim() === 'Permission required'
+    );
+    const container = heading?.closest('[role="alertdialog"]');
+    if (!container) return null;
+    const labelId = container.getAttribute('aria-labelledby');
+    const descId = container.getAttribute('aria-describedby');
+    const labelEl = labelId ? document.getElementById(labelId) : null;
+    const descEl = descId ? document.getElementById(descId) : null;
+    return {
+      role: container.getAttribute('role'),
+      ariaModal: container.getAttribute('aria-modal'),
+      labelId,
+      descId,
+      labelHasText: !!labelEl?.textContent?.trim(),
+      descHasText: !!descEl?.textContent?.trim()
+    };
+  });
+
+  if (!attrs) throw new Error('container with role=alertdialog missing');
+  if (attrs.role !== 'alertdialog') throw new Error(`role must be alertdialog, got ${attrs.role}`);
+  if (attrs.ariaModal !== 'true') throw new Error(`aria-modal must be "true", got ${attrs.ariaModal}`);
+  if (!attrs.labelId) throw new Error('aria-labelledby missing');
+  if (!attrs.descId) throw new Error('aria-describedby missing');
+  if (!attrs.labelHasText) throw new Error(`aria-labelledby target #${attrs.labelId} has no text`);
+  if (!attrs.descHasText) throw new Error(`aria-describedby target #${attrs.descId} has no text`);
+
+  // Esc dismisses (acts as reject). Focus must be inside the prompt first.
+  const rejectBtn = win.locator('[data-perm-action="reject"]').first();
+  await rejectBtn.focus();
+  await win.keyboard.press('Escape');
+  try {
+    await heading.waitFor({ state: 'detached', timeout: 3000 });
+  } catch {
+    throw new Error('Escape did not dismiss the alertdialog');
+  }
+
+  // Focus trap: inject a new prompt, verify Tab cycles between perm buttons
+  // when focus is inside the prompt.
+  await injectWaiting(win, {
+    id: 'wait-PROBE-A11Y-2',
+    requestId: 'PROBE-A11Y-2',
+    toolInput: { command: 'echo cycle' },
+    prompt: 'Bash cycle'
+  });
+  await heading.waitFor({ state: 'visible', timeout: 5000 });
+  await win.waitForFunction(() => {
+    return document.activeElement?.getAttribute?.('data-perm-action') === 'reject';
+  }, null, { timeout: 2000 });
+
+  await win.keyboard.press('Tab');
+  const afterTab1 = await win.evaluate(() => document.activeElement?.getAttribute('data-perm-action'));
+  if (afterTab1 !== 'allow-always') throw new Error(`Tab from reject expected allow-always, got ${afterTab1}`);
+  await win.keyboard.press('Tab');
+  const afterTab2 = await win.evaluate(() => document.activeElement?.getAttribute('data-perm-action'));
+  if (afterTab2 !== 'allow') throw new Error(`Tab from allow-always expected allow, got ${afterTab2}`);
+  await win.keyboard.press('Tab');
+  const afterTab3 = await win.evaluate(() => document.activeElement?.getAttribute('data-perm-action'));
+  if (afterTab3 !== 'reject') throw new Error(`Tab cycle should wrap to reject, got ${afterTab3}`);
+
+  await win.keyboard.press('n');
+  try {
+    await heading.waitFor({ state: 'detached', timeout: 3000 });
+  } catch {
+    // cleanup, non-fatal
+  }
+
+  log('role=alertdialog + aria-modal=true + labelled/described; Esc dismisses; Tab cycles');
+}
+
 // ---------- harness spec ----------
 await runHarness({
   name: 'perm',
@@ -461,6 +667,8 @@ await runHarness({
     { id: 'permission-shortcut-scope', run: casePermissionShortcutScope },
     { id: 'permission-nested-input', run: casePermissionNestedInput },
     { id: 'permission-truncate-width', run: casePermissionTruncateWidth },
-    { id: 'permission-sequential-focus', run: casePermissionSequentialFocus }
+    { id: 'permission-sequential-focus', run: casePermissionSequentialFocus },
+    { id: 'permission-allow-always', run: casePermissionAllowAlways },
+    { id: 'permission-a11y', run: casePermissionA11y }
   ]
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ import { AgentInitFailedBanner } from './components/AgentInitFailedBanner';
 import { useStore } from './stores/store';
 import { resolveEffectiveTheme } from './stores/store';
 import { setPersistErrorHandler } from './stores/persist';
-import { subscribeAgentEvents, setBackgroundWaitingHandler } from './agent/lifecycle';
+import { subscribeAgentEvents, setBackgroundWaitingHandler, maybeAutoResolveAllowAlways } from './agent/lifecycle';
 import { initI18n } from './i18n';
 import { i18next } from './i18n';
 import { usePreferences } from './store/preferences';
@@ -41,6 +41,9 @@ subscribeAgentEvents();
 // security boundary; same trade-off as `window.__agentoryI18n`.
 if (typeof window !== 'undefined') {
   (window as unknown as { __agentoryStore?: typeof useStore }).__agentoryStore = useStore;
+  (window as unknown as {
+    __agentoryMaybeAutoResolveAllowAlways?: typeof maybeAutoResolveAllowAlways;
+  }).__agentoryMaybeAutoResolveAllowAlways = maybeAutoResolveAllowAlways;
 }
 
 /**

--- a/src/agent/lifecycle.ts
+++ b/src/agent/lifecycle.ts
@@ -144,6 +144,35 @@ export function permissionRequestToWaitingBlock(req: {
   };
 }
 
+/**
+ * If the user previously ticked "Allow always" for this tool in the current
+ * app session, dispatch an Allow decision and return true so the caller can
+ * skip rendering a waiting block. `AskUserQuestion` / `ExitPlanMode` are
+ * always treated as user-interaction — they never auto-resolve.
+ *
+ * Exported so probes can exercise the fast-path without wiring a real
+ * `onAgentPermissionRequest` IPC payload.
+ */
+export function maybeAutoResolveAllowAlways(req: {
+  sessionId: string;
+  requestId: string;
+  toolName: string;
+}): boolean {
+  const interactive = req.toolName === 'AskUserQuestion' || req.toolName === 'ExitPlanMode';
+  if (interactive) return false;
+  const store = useStore.getState();
+  if (!store.allowAlwaysTools.includes(req.toolName)) return false;
+  // Route through the store action rather than calling the preload IPC
+  // directly — keeps the decision path consistent (single callsite for
+  // `agent:resolvePermission` IPC) and lets tests / future listeners observe
+  // the decision by wrapping the store action. `resolvePermission` no-ops on
+  // the messagesBySession branch when no matching waiting block exists
+  // (idx === -1), then still fires the preload IPC, which is exactly what we
+  // want here — we intentionally never appended a waiting block.
+  store.resolvePermission(req.sessionId, req.requestId, 'allow');
+  return true;
+}
+
 export function subscribeAgentEvents(): void {
   if (installed) return;
   const api = window.agentory;
@@ -278,6 +307,10 @@ export function subscribeAgentEvents(): void {
   });
 
   api.onAgentPermissionRequest((req) => {
+    // Session-scoped "Allow always" fast-path: if the user previously ticked
+    // "Allow always" for this tool name, auto-resolve Allow and skip rendering
+    // a waiting block.
+    if (maybeAutoResolveAllowAlways(req)) return;
     const store = useStore.getState();
     const block = permissionRequestToWaitingBlock(req);
     store.appendBlocks(req.sessionId, [block]);

--- a/src/components/ChatStream.tsx
+++ b/src/components/ChatStream.tsx
@@ -1069,6 +1069,7 @@ function renderBlock(
   activeId: string,
   resolvePermission: (sid: string, rid: string, d: 'allow' | 'deny') => void,
   bumpComposerFocus: () => void,
+  addAllowAlways: (toolName: string) => void,
   opts: { permissionAutoFocus?: boolean; now?: number } = {}
 ) {
   switch (b.kind) {
@@ -1098,6 +1099,14 @@ function renderBlock(
           autoFocus={opts.permissionAutoFocus ?? true}
           onAllow={b.requestId ? () => resolvePermission(activeId, b.requestId!, 'allow') : undefined}
           onReject={b.requestId ? () => resolvePermission(activeId, b.requestId!, 'deny') : undefined}
+          onAllowAlways={
+            b.requestId && b.toolName
+              ? () => {
+                  addAllowAlways(b.toolName!);
+                  resolvePermission(activeId, b.requestId!, 'allow');
+                }
+              : undefined
+          }
         />
       );
     case 'question':
@@ -1156,6 +1165,7 @@ export function ChatStream() {
   const running = useStore((s) => !!s.runningSessions[activeId]);
   const resolvePermission = useStore((s) => s.resolvePermission);
   const bumpComposerFocus = useStore((s) => s.bumpComposerFocus);
+  const addAllowAlways = useStore((s) => s.addAllowAlways);
   const loadMessages = useStore((s) => s.loadMessages);
   const loadError = useStore((s) => s.loadMessageErrors[activeId]);
 
@@ -1330,7 +1340,7 @@ export function ChatStream() {
                 }
                 return blocks.map((m, i) => (
                   <div key={m.id}>
-                    {renderBlock(m, activeId, resolvePermission, bumpComposerFocus, {
+                    {renderBlock(m, activeId, resolvePermission, bumpComposerFocus, addAllowAlways, {
                       permissionAutoFocus: i === lastPermIdx,
                       now
                     })}

--- a/src/components/PermissionPromptBlock.tsx
+++ b/src/components/PermissionPromptBlock.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useId, useRef } from 'react';
 import { motion } from 'framer-motion';
 import { ShieldAlert } from 'lucide-react';
 import { Button } from './ui/Button';
@@ -14,6 +14,8 @@ export interface PermissionPromptBlockProps {
   toolInput?: Record<string, unknown>;
   onAllow?: () => void;
   onReject?: () => void;
+  /** Third option: allow now AND remember for the rest of this app session. */
+  onAllowAlways?: () => void;
   /** When false, suppress the auto-focus-on-mount behaviour. */
   autoFocus?: boolean;
 }
@@ -69,11 +71,16 @@ export function PermissionPromptBlock({
   toolInput,
   onAllow,
   onReject,
+  onAllowAlways,
   autoFocus = true
 }: PermissionPromptBlockProps) {
   const { t } = useTranslation();
+  const reactId = useId();
+  const titleId = `perm-title-${reactId}`;
+  const descId = `perm-desc-${reactId}`;
   const rootRef = useRef<HTMLDivElement>(null);
   const allowRef = useRef<HTMLButtonElement>(null);
+  const allowAlwaysRef = useRef<HTMLButtonElement>(null);
   const rejectRef = useRef<HTMLButtonElement>(null);
 
   // Focus Reject on mount — safer default. Never steal focus away from any
@@ -125,19 +132,56 @@ export function PermissionPromptBlock({
 
   // Global-ish Y/N hotkeys, scoped to this prompt: we only listen while
   // mounted and only fire if the user isn't currently typing into an input /
-  // textarea / contenteditable.
+  // textarea / contenteditable. Also wires Esc -> reject and a minimal focus
+  // trap (Tab cycles only between the prompt's own buttons while focus is
+  // already inside the prompt — doesn't lock focus globally so the user can
+  // still click back into the composer).
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.defaultPrevented) return;
-      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      const root = rootRef.current;
+      if (!root) return;
       const active = document.activeElement;
+      const focusInside =
+        active instanceof HTMLElement && root.contains(active);
+
+      // Focus trap: Tab cycling between Reject / Allow always / Allow while
+      // focus is inside the prompt. Plain `.focus()` is enough — the buttons
+      // share DOM order (Reject -> [Allow always] -> Allow).
+      if (e.key === 'Tab' && focusInside && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        const focusables = [rejectRef.current, allowAlwaysRef.current, allowRef.current].filter(
+          (b): b is HTMLButtonElement => !!b
+        );
+        if (focusables.length > 0) {
+          const idx = focusables.indexOf(active as HTMLButtonElement);
+          if (idx !== -1) {
+            e.preventDefault();
+            const nextIdx = e.shiftKey
+              ? (idx - 1 + focusables.length) % focusables.length
+              : (idx + 1) % focusables.length;
+            focusables[nextIdx]?.focus({ preventScroll: true });
+            return;
+          }
+        }
+      }
+
+      // Esc -> reject (standard alertdialog dismiss).
+      if (e.key === 'Escape' && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        if (focusInside) {
+          e.preventDefault();
+          onReject?.();
+          return;
+        }
+      }
+
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
       const typing =
         active instanceof HTMLElement &&
         (active.tagName === 'INPUT' ||
           active.tagName === 'TEXTAREA' ||
           active.isContentEditable);
       // If typing AND focus is outside our prompt, don't hijack.
-      if (typing && !rootRef.current?.contains(active)) return;
+      if (typing && !focusInside) return;
       const key = e.key.toLowerCase();
       if (key === 'y') {
         e.preventDefault();
@@ -157,9 +201,9 @@ export function PermissionPromptBlock({
     <motion.div
       ref={rootRef}
       role="alertdialog"
-      aria-modal="false"
-      aria-labelledby="perm-title"
-      aria-describedby="perm-desc"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      aria-describedby={descId}
       initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: DURATION_RAW.ms220, ease: EASING.standard }}
@@ -170,7 +214,7 @@ export function PermissionPromptBlock({
         className="absolute left-0 top-0 bottom-0 w-[2px] bg-accent rounded-l-md"
       />
       <div
-        id="perm-title"
+        id={titleId}
         className="flex items-center gap-2 text-base text-fg-primary font-semibold"
       >
         <ShieldAlert size={14} className="text-accent" aria-hidden />
@@ -181,7 +225,7 @@ export function PermissionPromptBlock({
           </span>
         )}
       </div>
-      <div id="perm-desc" className="mt-2 font-mono text-sm text-fg-secondary whitespace-pre-wrap break-words">
+      <div id={descId} className="mt-2 font-mono text-sm text-fg-secondary whitespace-pre-wrap break-words">
         {prompt}
       </div>
       {summary.length > 0 && (
@@ -212,6 +256,23 @@ export function PermissionPromptBlock({
         >
           {t('permissionPrompt.rejectBtn')}
         </Button>
+        {onAllowAlways && (
+          <Button
+            ref={allowAlwaysRef}
+            variant="secondary"
+            size="md"
+            data-perm-action="allow-always"
+            onClick={onAllowAlways}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                onAllowAlways?.();
+              }
+            }}
+          >
+            {t('permissionPrompt.allowAlwaysBtn')}
+          </Button>
+        )}
         <Button
           ref={allowRef}
           variant="primary"

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -290,6 +290,7 @@ const en = {
   permissionPrompt: {
     title: 'Permission required',
     allowBtn: 'Allow (Y)',
+    allowAlwaysBtn: 'Allow always',
     rejectBtn: 'Reject (N)'
   },
   questionBlock: {

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -278,6 +278,7 @@ const zh: EnCatalog = {
   permissionPrompt: {
     title: '需要授权',
     allowBtn: '允许 (Y)',
+    allowAlwaysBtn: '始终允许',
     rejectBtn: '拒绝 (N)'
   },
   questionBlock: {

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -261,6 +261,17 @@ type State = {
   /** Per-session init-failure state. See `SessionInitFailure` for semantics.
    *  Cleared on successful retry via `clearSessionInitFailure`. */
   sessionInitFailures: Record<string, SessionInitFailure>;
+  /**
+   * Tool names the user has granted a session-scoped "allow always" decision
+   * for. A permission request whose `toolName` is in this set auto-resolves
+   * Allow without rendering a waiting block.
+   *
+   * Session-scoped (NOT persisted): resets on app restart. See PR discussion —
+   * persisting across restarts risks a rarely-revisited allowlist leaking
+   * privileges into future workdays. User explicitly re-confirms after each
+   * launch.
+   */
+  allowAlwaysTools: string[];
 };
 
 export interface CreateSessionOptions {
@@ -372,6 +383,11 @@ type Actions = {
   dequeueMessage: (sessionId: string) => QueuedMessage | undefined;
   clearQueue: (sessionId: string) => void;
   resolvePermission: (sessionId: string, requestId: string, decision: 'allow' | 'deny') => void;
+  /** Mark `toolName` as always-allowed for the rest of this app session. Future
+   *  permission requests with the same `toolName` will auto-resolve Allow in
+   *  `onAgentPermissionRequest` (see `agent/lifecycle.ts`). No-op if already
+   *  present. Not persisted across restarts. */
+  addAllowAlways: (toolName: string) => void;
   /** Increment `focusInputNonce` to ask the InputBar to take focus. Use after
    *  any user-driven action in the chat stream that should return focus to the
    *  composer (question submit, etc.). Permission/plan paths bump implicitly
@@ -622,6 +638,7 @@ export const useStore = create<State & Actions>((set, get) => ({
   cliStatus: DEFAULT_CLI_STATUS,
   diagnostics: [],
   sessionInitFailures: {},
+  allowAlwaysTools: [],
 
   selectSession: (id) => {
     set((s) => ({
@@ -1554,6 +1571,14 @@ export const useStore = create<State & Actions>((set, get) => ({
       };
     });
     void window.agentory?.agentResolvePermission(sessionId, requestId, decision);
+  },
+
+  addAllowAlways: (toolName) => {
+    if (!toolName) return;
+    set((s) => {
+      if (s.allowAlwaysTools.includes(toolName)) return s;
+      return { allowAlwaysTools: [...s.allowAlwaysTools, toolName] };
+    });
   },
 
   bumpComposerFocus: () => {

--- a/tests/permission-prompt-block.test.tsx
+++ b/tests/permission-prompt-block.test.tsx
@@ -122,7 +122,7 @@ describe('<PermissionPromptBlock />', () => {
     expect(allow.tabIndex).not.toBe(-1);
   });
 
-  it('Escape is a no-op (forces active choice)', async () => {
+  it('Escape triggers Reject (standard alertdialog dismiss)', async () => {
     const onAllow = vi.fn();
     const onReject = vi.fn();
     render(
@@ -134,9 +134,35 @@ describe('<PermissionPromptBlock />', () => {
       />
     );
     await flush();
-    fireEvent.keyDown(window, { key: 'Escape' });
+    // Focus is auto-moved to the Reject button on mount, so focus is inside
+    // the prompt — Esc should dispatch reject.
+    const reject = screen.getByRole('button', { name: /reject \(n\)/i });
+    fireEvent.keyDown(reject, { key: 'Escape' });
+    expect(onReject).toHaveBeenCalledTimes(1);
     expect(onAllow).not.toHaveBeenCalled();
+  });
+
+  it('Escape is a no-op when focus is outside the prompt', async () => {
+    const external = document.createElement('textarea');
+    document.body.appendChild(external);
+    const onAllow = vi.fn();
+    const onReject = vi.fn();
+    render(
+      <PermissionPromptBlock
+        prompt="Bash: ls"
+        toolName="Bash"
+        autoFocus={false}
+        onAllow={onAllow}
+        onReject={onReject}
+      />
+    );
+    await flush();
+    external.focus();
+    expect(document.activeElement).toBe(external);
+    fireEvent.keyDown(external, { key: 'Escape' });
     expect(onReject).not.toHaveBeenCalled();
+    expect(onAllow).not.toHaveBeenCalled();
+    document.body.removeChild(external);
   });
 
   it('does not steal focus when user is typing in a textarea', async () => {


### PR DESCRIPTION
Closes #194, closes #214.

## Summary

### UI-11 (#194) PermissionPromptBlock a11y completion
- `aria-modal` flipped from `"false"` to `"true"` (was a latent bug).
- `aria-labelledby` / `aria-describedby` now use `useId()`-scoped ids so sequential prompts never collide on the legacy `perm-title` / `perm-desc` literals.
- Esc -> reject (standard alertdialog dismiss) when focus is inside the prompt.
- Minimal focus trap: Tab / Shift-Tab cycle between Reject / Allow always / Allow while focus is already inside the prompt. Does **not** lock focus globally — the user can still click back into the composer. No new dependency (no `focus-trap-react`); plain `keydown` + refs.

### UI-6 (#214) Allow always
- Third button alongside Allow / Reject. On click it:
  1. Adds the tool name to `store.allowAlwaysTools`.
  2. Dispatches Allow for the current `tool_use_id` (same path as the existing Allow button).
- `onAgentPermissionRequest` (agent/lifecycle.ts) gains `maybeAutoResolveAllowAlways(req)` fast-path. Subsequent permission requests whose `toolName` is on the list auto-resolve Allow and **do not** render a waiting block.
- `AskUserQuestion` / `ExitPlanMode` never auto-resolve (they are user-interaction tools, not side-effecting).

### Session-scope decision (NOT persisted across app restart)
`allowAlwaysTools` is intentionally omitted from `PERSISTED_KEYS`. Reasoning: persisting a privilege grant across restarts silently extends authority into future workdays. User re-confirms after each launch. This matches the safer default for security-adjacent UX; flipping to persisted later is a one-line change to `PERSISTED_KEYS` + `PersistedState`.

## E2E regression guard

Per `feedback_bugfix_requires_e2e` + `feedback_e2e_extend_existing`, extended `scripts/harness-perm.mjs` (no new probe file) with:

- `permission-allow-always` — guards the full UI-6 flow: click Allow always -> IPC allow fires, tool name lands on store list; inject a second prompt for the same tool via `maybeAutoResolveAllowAlways` -> zero new waiting blocks, IPC allow fires automatically; an off-list tool (`Write`) still renders a prompt.
- `permission-a11y` — asserts `role=alertdialog`, `aria-modal=true`, `aria-labelledby` + `aria-describedby` point at real labelled/described elements, Esc dismisses, Tab cycles through the 3 buttons.

Also updated the existing `permission-prompt` case to expect 3 buttons (was 2).

## Reverse-verify
Stashed all behavior changes in `src/`, rebuilt, re-ran the probe:
```
[XX] permission-allow-always   3872ms
locator.waitFor: Timeout 3000ms exceeded.
waiting for locator('[data-perm-action="allow-always"]').first() to be visible
=== totals: 0 passed, 1 failed, 1 total ===
```
Restored + rebuilt -> PASS. Evidence that the probe actually exercises the new behavior.

## Self-verification
- `npm run build` -> OK (3 pre-existing size warnings)
- `node scripts/harness-agent.mjs` -> 8/8 PASS
- `node scripts/harness-ui.mjs` -> 4/4 PASS
- `node scripts/harness-perm.mjs` -> 9/9 PASS (incl. 2 new cases)

Manual a11y grep on `src/components/PermissionPromptBlock.tsx` confirms all four required attrs are present: `role=`, `aria-modal`, `aria-labelledby`, `aria-describedby`.

## Test plan
- [ ] Start a session, trigger a Bash permission prompt, click "Allow always". Confirm the next Bash prompt in the same session resolves without a UI prompt.
- [ ] Restart the app, trigger the same Bash — confirm a prompt reappears (session-scope, not persisted).
- [ ] Screen reader: confirm the prompt announces as a modal dialog with title + description.
- [ ] Keyboard: Tab cycles through the 3 buttons; Esc rejects; Y / N shortcuts still work when focus is outside a text input.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>