### PR TITLE
fix(probe): Allow-click loop resolves skill-injection flake

### DIFF
--- a/scripts/probe-e2e-permission-allow-write.mjs
+++ b/scripts/probe-e2e-permission-allow-write.mjs
@@ -145,40 +145,106 @@ async function snapDiag(label) {
 }
 const filePath = path.join(PROJ, 'hello.txt');
 
-// Wait up to 90s for the Allow button to appear.
+// Allow-click loop. Earlier probe revision clicked Allow exactly once and
+// assumed the first permission prompt belonged to Write. But the user's
+// `~/.claude` can inject `Skill` (using-superpowers / slash-command adapter)
+// or other preamble tools (Bash for mkdir, etc) as the FIRST tool the model
+// runs, which means the first permission prompt can be for something other
+// than Write/Edit/MultiEdit. Probabilistic injection caused ~20% flake
+// (see dogfood-logs/BUG-186-REPRO.md).
+//
+// Fix: loop — click Allow on any permission prompt that appears, track
+// which tool_use_id got resolved, and keep going until either the
+// Write/Edit/MultiEdit tool_result lands in the store OR a 90s timeout
+// elapses. For each non-Write/Edit/MultiEdit prompt, log a warning so
+// future flake classes are diagnosable.
 const allowSel = '[data-perm-action="allow"]';
-const waitDl = Date.now() + 90_000;
-let allowClicked = false;
-while (Date.now() < waitDl) {
-  await win.waitForTimeout(1000);
-  const visible = await win
-    .locator(allowSel)
-    .first()
-    .isVisible({ timeout: 200 })
-    .catch(() => false);
-  if (visible) {
-    await snapDiag('pre-allow');
-    await win.locator(allowSel).first().click();
-    allowClicked = true;
-    log('clicked Allow (Y)');
-    await snapDiag('post-allow');
-    break;
-  }
-}
-if (!allowClicked) fail('never saw Allow button within 90s', app);
-
-// 60s observation window for the three signals.
-const obsStart = Date.now();
+const WRITE_LIKE = new Set(['Write', 'Edit', 'MultiEdit']);
+const resolvedIds = new Set();
+const overallDl = Date.now() + 90_000;
+let firstAllowAt = null;
 let fsHit = null;
 let domHit = null;
 let storeHit = null;
 let snappedShort = false;
-while (Date.now() - obsStart < 60_000) {
-  await win.waitForTimeout(1500);
-  if (!snappedShort && Date.now() - obsStart >= 500) {
+
+async function getWaitingPrompt() {
+  // Return { toolName, toolUseId } of the currently-waiting permission
+  // block, if any. Best-effort — shape matches what snapDiag reads.
+  return await win
+    .evaluate(() => {
+      const st = window.__agentoryStore?.getState?.();
+      const sid = st?.activeId;
+      const blocks = st?.messagesBySession?.[sid] || [];
+      // Waiting permission blocks surface as kind 'tool' with a
+      // permissionState === 'waiting' marker, OR the renderer creates
+      // a dedicated wait-perm block. Walk in reverse for the most recent.
+      for (let i = blocks.length - 1; i >= 0; i--) {
+        const b = blocks[i];
+        const ps = b.permissionState || b.permission || null;
+        if (ps === 'waiting' || (b.kind === 'tool' && ps === 'waiting')) {
+          return {
+            toolName: b.toolName || b.name || null,
+            toolUseId: b.toolUseId || b.id || null,
+          };
+        }
+      }
+      // Fallback: last tool block with no result (likely the one the
+      // prompt belongs to).
+      for (let i = blocks.length - 1; i >= 0; i--) {
+        const b = blocks[i];
+        if (b.kind === 'tool' && !(typeof b.result === 'string' && b.result.length > 0)) {
+          return {
+            toolName: b.toolName || b.name || null,
+            toolUseId: b.toolUseId || b.id || null,
+          };
+        }
+      }
+      return null;
+    })
+    .catch(() => null);
+}
+
+while (Date.now() < overallDl) {
+  await win.waitForTimeout(1000);
+  if (firstAllowAt && !snappedShort && Date.now() - firstAllowAt >= 500) {
     await snapDiag('post-allow+500ms');
     snappedShort = true;
   }
+  // Check for a visible Allow button and click it (loop, not single-shot).
+  const allowVisible = await win
+    .locator(allowSel)
+    .first()
+    .isVisible({ timeout: 200 })
+    .catch(() => false);
+  if (allowVisible) {
+    const waiting = await getWaitingPrompt();
+    const toolName = waiting?.toolName || '(unknown)';
+    const toolUseId = waiting?.toolUseId || null;
+    // Dedup only when we have a real id; without one, click anyway — the
+    // button's visibility is the source of truth.
+    if (!toolUseId || !resolvedIds.has(toolUseId)) {
+      if (!firstAllowAt) {
+        await snapDiag('pre-allow');
+        firstAllowAt = Date.now();
+      }
+      await win.locator(allowSel).first().click().catch(() => {});
+      if (toolUseId) resolvedIds.add(toolUseId);
+      if (WRITE_LIKE.has(toolName)) {
+        log(`[probe] clicked Allow for Write-like tool: ${toolName} (id=${toolUseId || 'n/a'})`);
+      } else {
+        // Preamble tool (Skill / Bash / etc). Warn so env-injection flake
+        // classes are visible to anyone running the probe.
+        console.warn(`[probe] clicked Allow for preamble tool: ${toolName} (id=${toolUseId || 'n/a'})`);
+        log(`[probe] preamble tool prompt answered: ${toolName}`);
+      }
+      if (!snappedShort) await snapDiag('post-allow');
+      // Give the renderer a beat to clear the button before next iteration
+      // so we don't double-click the same prompt.
+      await win.waitForTimeout(500);
+    }
+  }
+  // Signal checks, each loop iteration.
   if (!fsHit && fs.existsSync(filePath)) {
     fsHit = { content: fs.readFileSync(filePath, 'utf8') };
     log(`FS HIT: ${JSON.stringify(fsHit)}`);
@@ -186,7 +252,10 @@ while (Date.now() - obsStart < 60_000) {
   const domFound = await win
     .evaluate(() => {
       const text = document.body?.innerText || '';
-      return /File created successfully|File written|hello\.txt/.test(text);
+      // Tightened: the old regex (`hello\.txt` alone) matched the probe's
+      // own user prompt text, producing a false positive even when Write
+      // never ran. Anchor on the success sentence the model emits.
+      return /File created successfully at[^\n]*hello\.txt/.test(text);
     })
     .catch(() => false);
   if (!domHit && domFound) {
@@ -198,10 +267,6 @@ while (Date.now() - obsStart < 60_000) {
       const st = window.__agentoryStore?.getState?.();
       const sid = st?.activeId;
       const blocks = st?.messagesBySession?.[sid] || [];
-      // Accept any file-mutating tool — the prompt anchors on Write but if
-      // the model picks Edit/MultiEdit they exercise the SAME Bug L
-      // permission round-trip path, so the test is still valid. The fs
-      // assertion below independently verifies the file content.
       const writeLike = new Set(['Write', 'Edit', 'MultiEdit']);
       const w = blocks.find((b) => {
         const tn = b.toolName || b.name;
@@ -218,6 +283,7 @@ while (Date.now() - obsStart < 60_000) {
   }
   if (fsHit && storeHit) break;
 }
+if (!firstAllowAt) fail('never saw Allow button within 90s', app);
 
 const projFiles = (() => {
   try {


### PR DESCRIPTION
## Summary

Fixes task #216 — the ~20% flake in `scripts/probe-e2e-permission-allow-write.mjs` diagnosed by #192.

**Root cause (from #192 / `dogfood-logs/BUG-186-REPRO.md`):** the probe clicked `[data-perm-action=\"allow\"]` exactly once and assumed the first permission prompt belonged to Write. The user's `~/.claude` probabilistically injects a `Skill` (using-superpowers / slash-command adapter) as the first tool the model runs. When that happens, the single Allow resolves the Skill prompt, and the subsequent Write permission prompt sits unanswered until the probe times out.

**Fix direction:** reviewer preferred Option 1 (Allow-click loop) over HOME sanitization. Implemented here.

### What the fix does

- Loops Allow clicks inside a 90s overall window; reads the store's waiting-block `toolName` / `toolUseId` before each click and dedups by id to avoid double-clicks on the same prompt.
- Continues until Write/Edit/MultiEdit's tool_result lands in the store (fs + store hit), or timeout.
- Logs `console.warn` when Allow is clicked for a non-Write/Edit/MultiEdit tool, so future env-injection flake classes are immediately visible.
- Tightens the DOM success regex from `/File created successfully|File written|hello\.txt/` (which matched the probe's own user prompt text `hello.txt` — false positive) to `/File created successfully at[^\n]*hello\.txt/`, matching the actual Write tool success sentence.

### No production code changed

Only `scripts/probe-e2e-permission-allow-write.mjs`.

## Flake rate

| Condition | Pass | Fail | Rate |
|---|---|---|---|
| Before fix (baseline in #192) | 16/20 | 4/20 | 80% |
| Before fix (this run, stashed) | 14/20 | 6/20 | 70% |
| After fix (run 1) | 20/20 | 0/20 | **100%** |
| After fix (run 2) | 20/20 | 0/20 | **100%** |

### Reverse-verify (mandatory per bug-fix rule)

1. Applied fix → ran probe 20× → 20/20 PASS.
2. `git stash push -- scripts/probe-e2e-permission-allow-write.mjs` → ran 20× → 14/20 PASS (flake returned, confirmed fix is load-bearing).
3. `git stash pop` → ran 20× again → 20/20 PASS.

## Harness check

- `harness-perm` 7/7 PASS (the 2 cases #191 was supposed to add haven't landed on working yet — this branch matches origin/working's 7-case suite).
- `harness-ui` 5/5 PASS (includes `shortcut-overlay-opens`).
- `harness-agent` 8/8 PASS (including `streaming-caret-lifecycle`, which is tracked as flaky in #215).
- `npm run build` — succeeds.

## Refs

- Diagnostic PR: #192 (merged at 8a464ed) — provides `snapDiag` / `dumpBug186Artifact` helpers reused here.
- Task: #216.

## Test plan

- [x] 20 consecutive probe runs all PASS (done, twice)
- [x] Reverse-verify: stash → flake returns; restore → clean (done)
- [x] harness-perm / harness-ui / harness-agent (done)
- [x] npm run build (done)
- [ ] Reviewer: re-run 20× on their machine to confirm 20/20

🤖 Generated with [Claude Code](https://claude.com/claude-code)