### PR TITLE
refactor(tokens): consolidate state-* / status-* token families

### DIFF
--- a/src/components/ClaudeCliMissingDialog.tsx
+++ b/src/components/ClaudeCliMissingDialog.tsx
@@ -256,7 +256,7 @@ function Header({ searchedPaths }: { searchedPaths: string[] }) {
   return (
     <div className="px-5 pt-5 pb-3">
       <div className="flex items-start gap-3">
-        <div className="mt-0.5 text-status-warning-foreground">
+        <div className="mt-0.5 text-state-warning-text">
           <AlertTriangle size={16} className="stroke-[1.75]" />
         </div>
         <div className="flex-1 min-w-0">
@@ -419,7 +419,7 @@ function CommandRow({ row }: { row: InstallRow }) {
                 animate={{ scale: 1, opacity: 1 }}
                 exit={{ scale: 0.7, opacity: 0 }}
                 transition={{ duration: DURATION.fast }}
-                className="text-status-success-foreground"
+                className="text-state-success-text"
               >
                 <Check size={13} className="stroke-[2.25]" />
               </motion.span>
@@ -466,7 +466,7 @@ function HaveItPane({
         <span>{configuring ? t('cli.verifying') : t('cli.browseBinary')}</span>
       </Button>
       {error && (
-        <div className="text-xs text-status-error-foreground">
+        <div className="text-xs text-state-error-text">
           {error}
         </div>
       )}
@@ -498,7 +498,7 @@ function SuccessPane({
         initial={{ scale: 0.6, opacity: 0 }}
         animate={{ scale: 1, opacity: 1 }}
         transition={{ delay: 0.08, duration: DURATION.slow, ease: EASING.standard }}
-        className="mt-0.5 text-status-success-foreground"
+        className="mt-0.5 text-state-success-text"
       >
         <Check size={18} className="stroke-[2]" />
       </motion.div>
@@ -518,7 +518,7 @@ function SuccessPane({
             <>
               {t('cli.foundVersion')} <span className="text-fg-secondary font-mono">{version}</span>
               {belowMin && (
-                <span className="ml-1 text-status-warning-foreground">
+                <span className="ml-1 text-state-warning-text">
                   {t('cli.belowRecommended', { min: CLI_MIN_VERSION_SOFT })}
                 </span>
               )}

--- a/src/components/CwdPopover.tsx
+++ b/src/components/CwdPopover.tsx
@@ -180,7 +180,7 @@ export function CwdPopover({ cwd, cwdMissing, loadRecent, onPick, onBrowse }: Pr
         className={cn(
           'inline-flex items-center gap-1 h-5 px-1.5 rounded-sm',
           cwdMissing
-            ? 'text-state-warning hover:text-status-warning-foreground hover:bg-status-warning-muted'
+            ? 'text-state-warning hover:text-state-warning-text hover:bg-state-warning-soft'
             : 'text-fg-tertiary hover:text-fg-secondary hover:bg-bg-hover',
           'outline-none focus-ring',
           'transition-colors duration-120 ease-out'

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -36,7 +36,7 @@ const Chip = React.forwardRef<
       className={cn(
         'inline-flex items-center gap-1 h-5 px-1.5 rounded-sm',
         accent === 'warn'
-          ? 'text-state-warning hover:text-status-warning-foreground hover:bg-status-warning-muted'
+          ? 'text-state-warning hover:text-state-warning-text hover:bg-state-warning-soft'
           : 'text-fg-tertiary hover:text-fg-secondary hover:bg-bg-hover',
         'outline-none focus-ring',
         'transition-colors duration-120 ease-out'

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -62,7 +62,7 @@ export const buttonVariants = cva(
           'disabled:bg-bg-elevated disabled:border-border-default disabled:text-fg-disabled disabled:shadow-none'
         ),
         danger: cn(
-          'text-status-error-foreground font-medium',
+          'text-state-error-text font-medium',
           'border border-[oklch(0.50_0.20_25)]',
           'bg-[linear-gradient(to_bottom,oklch(0.68_0.22_25),oklch(0.56_0.22_25))]',
           'shadow-[inset_0_1px_0_0_oklch(1_0_0_/_0.22),0_1px_0_0_oklch(0_0_0_/_0.18)]',

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -38,14 +38,26 @@
   --color-accent-fg: oklch(0.18 0 0);
   --color-accent-soft: oklch(0.45 0.10 215 / 0.18);
 
-  /* State scale — error gets soft/default/strong/fg facets so danger weighting
-     is a token choice, not a magic number. */
+  /* State scale — the single source of truth for "what is this process/thing
+     doing right now" coloring. Suffix convention:
+       (bare)   = the signal color itself (glyphs, dot indicators)
+       -text    = AA-contrast text color on a neutral bg (colored label)
+       -soft    = translucent fill for row/pill backgrounds
+       -strong  = denser variant for heavy-weight affordances
+       -fg      = high-contrast foreground designed to sit ON the bare color
+                  (e.g. white text on a red button)
+     `error` carries the full scale because destructive weighting needs it;
+     other states add facets only when a consumer needs them. */
   --color-state-running: oklch(0.78 0.13 155);
   --color-state-waiting: oklch(0.78 0.10 75);
   --color-state-parked: var(--color-fg-tertiary);
   --color-state-success: oklch(0.72 0.14 155);
+  --color-state-success-text: oklch(0.78 0.14 155);
   --color-state-warning: oklch(0.78 0.16 75);
+  --color-state-warning-text: oklch(0.82 0.16 75);
+  --color-state-warning-soft: oklch(0.78 0.16 75 / 0.12);
   --color-state-error: oklch(0.65 0.20 25);
+  --color-state-error-text: oklch(0.72 0.20 25);
   --color-state-error-soft: oklch(0.65 0.20 25 / 0.14);
   --color-state-error-strong: oklch(0.60 0.22 25);
   --color-state-error-fg: oklch(0.97 0 0);
@@ -99,29 +111,6 @@
   --color-card: var(--color-bg-panel);
   --color-card-foreground: var(--color-fg-primary);
   --color-card-border: var(--color-border-subtle);
-
-  /* ── Status × facet matrix. Each status gets {base, foreground, muted,
-     border} so `bg-status-error-muted text-status-error border-status-error-border`
-     composes without inventing new shades inline. ── */
-  --color-status-success: oklch(0.72 0.14 155);
-  --color-status-success-foreground: oklch(0.78 0.14 155);
-  --color-status-success-muted: oklch(0.72 0.14 155 / 0.12);
-  --color-status-success-border: oklch(0.72 0.14 155 / 0.30);
-
-  --color-status-warning: oklch(0.78 0.16 75);
-  --color-status-warning-foreground: oklch(0.82 0.16 75);
-  --color-status-warning-muted: oklch(0.78 0.16 75 / 0.12);
-  --color-status-warning-border: oklch(0.78 0.16 75 / 0.30);
-
-  --color-status-error: oklch(0.65 0.20 25);
-  --color-status-error-foreground: oklch(0.72 0.20 25);
-  --color-status-error-muted: oklch(0.65 0.20 25 / 0.14);
-  --color-status-error-border: oklch(0.65 0.20 25 / 0.32);
-
-  --color-status-info: oklch(0.74 0.13 215);
-  --color-status-info-foreground: oklch(0.80 0.13 215);
-  --color-status-info-muted: oklch(0.74 0.13 215 / 0.12);
-  --color-status-info-border: oklch(0.74 0.13 215 / 0.30);
 
   /* ── Terminal palette. Bash/shell tool output renders into this surface;
      keeping it as its own token set means we can re-theme terminals
@@ -237,8 +226,12 @@ html.theme-light {
   --color-state-waiting: oklch(0.58 0.12 75);
   --color-state-parked: var(--color-fg-tertiary);
   --color-state-success: oklch(0.55 0.14 155);
+  --color-state-success-text: oklch(0.48 0.14 155);
   --color-state-warning: oklch(0.62 0.15 75);
+  --color-state-warning-text: oklch(0.52 0.15 75);
+  --color-state-warning-soft: oklch(0.62 0.15 75 / 0.10);
   --color-state-error: oklch(0.52 0.21 25);
+  --color-state-error-text: oklch(0.48 0.21 25);
   --color-state-error-soft: oklch(0.52 0.21 25 / 0.10);
   --color-state-error-strong: oklch(0.46 0.22 25);
   --color-state-error-fg: oklch(0.99 0 0);
@@ -263,26 +256,6 @@ html.theme-light {
   --color-card: var(--color-bg-panel);
   --color-card-foreground: var(--color-fg-primary);
   --color-card-border: var(--color-border-subtle);
-
-  --color-status-success: oklch(0.55 0.14 155);
-  --color-status-success-foreground: oklch(0.48 0.14 155);
-  --color-status-success-muted: oklch(0.55 0.14 155 / 0.10);
-  --color-status-success-border: oklch(0.55 0.14 155 / 0.28);
-
-  --color-status-warning: oklch(0.62 0.15 75);
-  --color-status-warning-foreground: oklch(0.52 0.15 75);
-  --color-status-warning-muted: oklch(0.62 0.15 75 / 0.10);
-  --color-status-warning-border: oklch(0.62 0.15 75 / 0.28);
-
-  --color-status-error: oklch(0.52 0.21 25);
-  --color-status-error-foreground: oklch(0.48 0.21 25);
-  --color-status-error-muted: oklch(0.52 0.21 25 / 0.10);
-  --color-status-error-border: oklch(0.52 0.21 25 / 0.30);
-
-  --color-status-info: oklch(0.58 0.14 225);
-  --color-status-info-foreground: oklch(0.50 0.14 225);
-  --color-status-info-muted: oklch(0.58 0.14 225 / 0.10);
-  --color-status-info-border: oklch(0.58 0.14 225 / 0.28);
 
   /* Terminal stays dark even in light mode — shell output is easier to
      parse on dark, and every major terminal emulator ships dark by default.


### PR DESCRIPTION
Refs #209 (UI-4).

## Problem

`src/styles/global.css` shipped two similar-sounding color families:

- `--color-state-*` — running, waiting, parked, success, warning, error (+ error-soft/strong/fg)
- `--color-status-*` — success, warning, error, info × {base, foreground, muted, border}

Writing a new component, it was ambiguous which one to reach for. Worse, `status-*` was mostly unused — of its 16 declared tokens only 4 sub-tokens were ever consumed.

## Before inventory

`status-*` consumers found (only 4 tokens actually used):

| Token                           | Used in                                                         |
| ------------------------------- | --------------------------------------------------------------- |
| `text-status-warning-foreground` | `ClaudeCliMissingDialog.tsx`, `CwdPopover.tsx`, `StatusBar.tsx` |
| `text-status-success-foreground` | `ClaudeCliMissingDialog.tsx`                                    |
| `text-status-error-foreground`   | `ClaudeCliMissingDialog.tsx`, `ui/Button.tsx` (danger)          |
| `bg-status-warning-muted`        | `CwdPopover.tsx`, `StatusBar.tsx`                               |

Everything else in `status-*` (bases, borders, info-*, success/error muted) was dead.

## Mapping (exact value preservation, zero visual change)

| Old                              | New                         |
| -------------------------------- | --------------------------- |
| `status-success-foreground`      | `state-success-text`        |
| `status-warning-foreground`      | `state-warning-text`        |
| `status-error-foreground`        | `state-error-text`          |
| `status-warning-muted`           | `state-warning-soft`        |
| `status-{success,warning,error,info}` (base) | deleted (unused) |
| `status-*-border`                | deleted (unused)            |
| `status-{success,error}-muted`   | deleted (unused)            |
| `status-info-*`                  | deleted (unused)            |

Dark and light palettes both migrated identically.

### Naming convention (now documented in global.css)

```
(bare)   signal color (glyphs, dot indicators)
-text    AA-contrast text color on neutral bg (colored label)
-soft    translucent fill for row/pill backgrounds
-strong  denser variant for heavy affordances
-fg      high-contrast foreground that sits ON the bare color
         (e.g. white text on red button bg — distinct from -text)
```

Why `-text` instead of reusing `-fg`: `state-error-fg` already exists and means "near-white foreground to put on top of state-error red bg" (used in ChatStream, WindowControls). The `status-error-foreground` token meant "red text color on a neutral bg". Same word, different semantic — kept them separate via the `-text` suffix.

## Files touched (5)

- `src/styles/global.css`                  — token defs, both themes, updated comment
- `src/components/ClaudeCliMissingDialog.tsx`
- `src/components/CwdPopover.tsx`
- `src/components/StatusBar.tsx`
- `src/components/ui/Button.tsx`

## Self-verification

- [x] `npm run build` PASS (Tailwind resolves every class — missing tokens would fail fast here)
- [x] `harness-agent.mjs` 8/8 PASS (streaming-caret-lifecycle flake #215 passed on re-run)
- [x] `harness-ui.mjs` 5/5 PASS
- [x] `harness-perm.mjs` 9/9 PASS (permission-prompt flake passed on re-run)
- [x] `grep "status-"` in `src/` after migration: **0 usages**

## Scope guardrails

- No visual tuning — every value mapped 1:1 in both dark and light palettes.
- No new tokens beyond the 4 required to preserve consumer behavior.
- Did not touch `focus-ring-*` utilities (#211 merged separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)