### PR TITLE
fix(probe): stabilize streaming-caret-lifecycle harness case

### DIFF
--- a/scripts/harness-agent.mjs
+++ b/scripts/harness-agent.mjs
@@ -225,6 +225,16 @@ async function caseStreaming({ win, log }) {
   if (streamingBlocks[0].text !== 'Hello, world!') throw new Error(`expected 'Hello, world!', got '${streamingBlocks[0].text}'`);
   if (streamingBlocks[0].streaming !== true) throw new Error('streaming flag not set');
 
+  // ChatStream's AnimatePresence keyed on `blocks:${activeId}` runs a
+  // ~180ms exit+enter transition (MOTION_SESSION_SWITCH_DURATION =
+  // DURATION.standard = 0.18s) when entering a session — on the FIRST
+  // case entry the empty-state pane exits while the blocks pane enters,
+  // so for ~180ms no block children are mounted. A blind 150ms sleep
+  // races that transition and the caret count transiently reads 0. Wait
+  // for the caret to attach instead.
+  try {
+    await win.locator('span.animate-pulse').first().waitFor({ state: 'attached', timeout: 2000 });
+  } catch { /* fall through to richer assertion message below */ }
   const caretCount = await win.locator('span.animate-pulse').count();
   if (caretCount < 1) throw new Error('streaming caret not rendered in DOM');
 
@@ -271,6 +281,11 @@ async function caseStreamingCaretLifecycle({ win, log }) {
   }, [SID1, BID1]);
   await win.waitForTimeout(150);
 
+  // Same AnimatePresence session-switch race as caseStreaming above — wait
+  // for the caret to attach rather than relying on a fixed 150ms sleep.
+  try {
+    await win.locator('span.animate-pulse').first().waitFor({ state: 'attached', timeout: 2000 });
+  } catch { /* fall through */ }
   const caretDuring = await win.locator('span.animate-pulse').count();
   if (caretDuring < 1) throw new Error('Part 1: expected caret during stream, found 0');
 
@@ -315,6 +330,19 @@ async function caseStreamingCaretLifecycle({ win, log }) {
   }, [SID2, BID2]);
   await win.waitForTimeout(150);
 
+  // Part 3 started by switching activeId from SID1 → SID2; ChatStream's
+  // AnimatePresence keyed on `blocks:${activeId}` runs a ~180ms exit+enter
+  // transition (MOTION_SESSION_SWITCH_DURATION = DURATION.standard = 0.18s)
+  // during which the new session's blocks are not yet mounted. A fixed
+  // 150ms sleep races that transition — at 150ms the old pane is still
+  // exiting and the new pane hasn't mounted, so caret count is 0 even
+  // though the store has streaming:true on the block. Wait for the caret
+  // to actually appear in the DOM instead of a blind sleep.
+  try {
+    await win.locator('span.animate-pulse').first().waitFor({ state: 'attached', timeout: 2000 });
+  } catch {
+    // fall through so the assertion below produces the richer error message
+  }
   const caretMid = await win.locator('span.animate-pulse').count();
   if (caretMid < 1) throw new Error('Part 3: caret should be visible mid-stream before interrupt');
 


### PR DESCRIPTION
Fixes #215.

## Root cause

`scripts/harness-agent.mjs` asserts caret DOM presence (`span.animate-pulse`) after a fixed 150ms sleep. ChatStream wraps its blocks pane in an AnimatePresence keyed on `blocks:${activeId}`, so entering a session (first case start) or switching activeId between Part 2 and Part 3 triggers a ~180ms exit+enter transition (MOTION_SESSION_SWITCH_DURATION = DURATION.standard = 0.18s). During that window the old pane is still exiting and the new pane has not yet mounted — the caret span is not in the DOM, `count()` reads 0, and the case fails.

This is a probe timing bug, not a production race. Production code is untouched.

## Fix

Before each caret-presence assertion in `caseStreaming` (Part 1 of that case) and `caseStreamingCaretLifecycle` (Part 1 first-mount, Part 3 session-switch), wait for `span.animate-pulse` to attach (up to 2s) and then read the count. Race-free, cheap, minimal diff.

Files touched: `scripts/harness-agent.mjs` only.

## Pass rates on my machine

Before:
- `streaming-caret-lifecycle` alone: 0/10 (100% fail on Part 3 caret assertion).
- Full `harness-agent.mjs`: 14/15 (one run also took down `caseStreaming` Part 1 with the same race).

After:
- `streaming-caret-lifecycle` alone: 20/20.
- Full `harness-agent.mjs`: 20/20, all 8 cases per run.

## Test plan

- [x] Single-case reproduction confirms root cause (AnimatePresence exit+enter on activeId change)
- [x] `node scripts/harness-agent.mjs --only=streaming-caret-lifecycle` × 20 passes (20/20)
- [x] `node scripts/harness-agent.mjs` × 20 full runs, 8/8 cases each (20/20)
- [x] Rebased on latest `working` (includes recent ChatStream + probe-allow-write refactors) and re-ran 20 full runs — still 20/20