### PR TITLE
ux(window): exit fade animation (#213 partial)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -312,6 +312,11 @@ function createWindow() {
   // and routes their events at the live renderer.
   win.on('show', () => {
     if (!win.webContents.isDestroyed()) sessions.rebindSender(win.webContents);
+    // Reset the renderer's fade-opacity in case the window was just
+    // restored after a fade-to-hide (see `window:beforeHide` below).
+    if (!win.webContents.isDestroyed()) {
+      win.webContents.send('window:afterShow');
+    }
   });
   win.webContents.on('did-finish-load', () => {
     if (!win.webContents.isDestroyed()) sessions.rebindSender(win.webContents);
@@ -325,12 +330,40 @@ function createWindow() {
   // close button via window:close IPC) hides the window instead of quitting.
   // The user can still really quit via the tray menu's Quit item, the
   // app menu's Quit, or Cmd/Ctrl-Q.
+  //
+  // Fade-to-hide: before actually calling `win.hide()` we send a
+  // `window:beforeHide` event so the renderer can run a short opacity
+  // fade-out. `HIDE_FADE_MS` matches `DURATION.standard` (180ms) from the
+  // shared motion tokens — kept short so closing still feels responsive.
+  // Guarded by `fadePending` so repeated Cmd/Ctrl+W presses don't stack
+  // timers. On real quit (`isQuitting === true`) we skip the fade entirely
+  // so shutdown stays fast.
+  const HIDE_FADE_MS = 180;
+  let fadePending = false;
   win.on('close', (e) => {
     if (isQuitting) return;
     e.preventDefault();
-    win.hide();
-    if (process.platform === 'darwin') app.dock?.hide?.();
+    if (fadePending) return;
+    fadePending = true;
+    try {
+      if (!win.webContents.isDestroyed()) {
+        win.webContents.send('window:beforeHide', { durationMs: HIDE_FADE_MS });
+      }
+    } catch {
+      /* renderer unreachable — fall through to immediate hide */
+    }
+    setTimeout(() => {
+      fadePending = false;
+      if (win.isDestroyed()) return;
+      win.hide();
+      if (process.platform === 'darwin') app.dock?.hide?.();
+    }, HIDE_FADE_MS);
   });
+
+  // After the window is shown again (tray click, dock click on macOS) the
+  // renderer's opacity may still be 0 from the previous fade-out. The
+  // existing `win.on('show')` handler above dispatches `window:afterShow`
+  // to reset it.
 }
 
 let tray: Tray | null = null;

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -254,6 +254,19 @@ const api = {
       ipcRenderer.on('window:maximizedChanged', wrap);
       return () => ipcRenderer.removeListener('window:maximizedChanged', wrap);
     },
+    onBeforeHide: (
+      handler: (info: { durationMs: number }) => void
+    ): (() => void) => {
+      const wrap = (_e: IpcRendererEvent, payload: { durationMs: number }) =>
+        handler(payload);
+      ipcRenderer.on('window:beforeHide', wrap);
+      return () => ipcRenderer.removeListener('window:beforeHide', wrap);
+    },
+    onAfterShow: (handler: () => void): (() => void) => {
+      const wrap = () => handler();
+      ipcRenderer.on('window:afterShow', wrap);
+      return () => ipcRenderer.removeListener('window:afterShow', wrap);
+    },
     platform: process.platform
   },
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import { subscribeAgentEvents, setBackgroundWaitingHandler, maybeAutoResolveAllo
 import { initI18n } from './i18n';
 import { i18next } from './i18n';
 import { usePreferences } from './store/preferences';
+import { DURATION, EASING } from './lib/motion';
 
 // Initialise i18next once, before any component renders. Subsequent
 // language changes flow through `applyLanguage` (called by the store
@@ -163,6 +164,41 @@ export default function App() {
   useEffect(() => {
     window.agentory?.i18n?.setLanguage(resolvedLanguage);
   }, [resolvedLanguage]);
+
+  // Exit animation (UI-10 / #213):
+  // When the user closes the window (Cmd/Ctrl+W, X button, OS X red dot)
+  // the Electron main process hides-to-tray instead of destroying. It sends
+  // `window:beforeHide` with a duration first so we can fade the whole
+  // document out, then hides ~180ms later — giving the user a graceful
+  // exit rather than an abrupt disappearance. On restore, `window:afterShow`
+  // resets opacity. Uses the shared motion tokens (DURATION.standard /
+  // EASING.exit) for consistency with the rest of the app.
+  //
+  // Implementation note: we drive `document.documentElement.style.opacity`
+  // directly instead of wrapping the React tree in a `<motion.div>` — a
+  // root-level wrapper would be invasive and risk layout regressions,
+  // while this approach is zero-DOM, zero-rerender, and survives when
+  // React state is about to be torn down.
+  useEffect(() => {
+    const bridge = window.agentory?.window;
+    if (!bridge?.onBeforeHide || !bridge?.onAfterShow) return;
+    const root = document.documentElement;
+    const transition = `opacity ${DURATION.standard}s cubic-bezier(${EASING.exit.join(',')})`;
+    const offHide = bridge.onBeforeHide(() => {
+      root.style.transition = transition;
+      root.style.opacity = '0';
+    });
+    const offShow = bridge.onAfterShow(() => {
+      root.style.transition = transition;
+      root.style.opacity = '1';
+    });
+    return () => {
+      offHide();
+      offShow();
+      root.style.transition = '';
+      root.style.opacity = '';
+    };
+  }, []);
 
   const [settingsOpen, setSettingsOpen] = React.useState(false);
   const [paletteOpen, setPaletteOpen] = React.useState(false);

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -173,6 +173,8 @@ declare global {
         close: () => Promise<void>;
         isMaximized: () => Promise<boolean>;
         onMaximizedChanged: (handler: (max: boolean) => void) => () => void;
+        onBeforeHide: (handler: (info: { durationMs: number }) => void) => () => void;
+        onAfterShow: (handler: () => void) => () => void;
         platform: 'aix' | 'android' | 'darwin' | 'freebsd' | 'haiku' | 'linux' | 'openbsd' | 'sunos' | 'win32' | 'cygwin' | 'netbsd';
       };
 


### PR DESCRIPTION
## Summary

UI-10 polish bundle for per-instance identity. Ships the exit animation; investigates and closes out the hotkey concern; defers the tint.

- **(b) Exit fade animation — shipped.** A 180ms opacity fade-out runs before the window hides-to-tray. Main sends `window:beforeHide` with a duration, delays, then hides; renderer drives `documentElement.style.opacity` using shared motion tokens (`DURATION.standard` + `EASING.exit`). On restore `window:afterShow` resets opacity. Same path serves Cmd/Ctrl+W, the renderer X button, and the OS close box. Real quit (`isQuitting`) skips the fade so shutdown stays fast.
- **(a) Per-instance hotkey — investigated, no change needed.** No `globalShortcut.register` anywhere; no `Menu.setApplicationMenu` accelerators; no BrowserWindow-level shortcuts. All hotkeys are `window.addEventListener('keydown', ...)` in `App.tsx`, naturally scoped to each BrowserWindow's document. No cross-window leak possible.
- **(c) Per-instance tint — deferred.** Requires a new settings entry + UI surface; keeping this PR scoped. Track as a follow-up PR.

## Implementation notes

Rendering approach: we mutate `document.documentElement.style.opacity` directly rather than wrapping the React tree in a `<motion.div>`. A root wrapper would be invasive (layout risk, style cascade surprises) and redundant — we only need one numeric value to change. The direct DOM write is zero-rerender and survives teardown.

Files:
- `electron/main.ts` — fade gate in `win.on('close')`, merged `window:afterShow` into existing `win.on('show')` handler.
- `electron/preload.ts` — exposed `window.onBeforeHide` / `window.onAfterShow` subscriptions.
- `src/global.d.ts` — typed the new bridge methods.
- `src/App.tsx` — effect that subscribes to both events and animates `<html>` opacity.

## Test plan

- [x] `npm run build` — OK
- [x] `node scripts/harness-ui.mjs` — 5/5
- [x] `node scripts/harness-perm.mjs` — 9/9
- [x] `node scripts/harness-agent.mjs` — 7/8. `streaming-caret-lifecycle` fails identically on clean `origin/working` (verified via stash); known flake tracked in #215, not introduced by this PR.
- [ ] Manual: Cmd/Ctrl+W triggers a visible fade before the window disappears; tray click restores with opacity reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)