### PR TITLE
style(button): danger variant text contrast

### DIFF
--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -62,7 +62,7 @@ export const buttonVariants = cva(
           'disabled:bg-bg-elevated disabled:border-border-default disabled:text-fg-disabled disabled:shadow-none'
         ),
         danger: cn(
-          'text-state-error-text font-medium',
+          'text-state-error-fg font-medium',
           'border border-[oklch(0.50_0.20_25)]',
           'bg-[linear-gradient(to_bottom,oklch(0.68_0.22_25),oklch(0.56_0.22_25))]',
           'shadow-[inset_0_1px_0_0_oklch(1_0_0_/_0.22),0_1px_0_0_oklch(0_0_0_/_0.18)]',


### PR DESCRIPTION
Closes #217 (flagged during PR #195 review).

## Summary
- `Button.tsx` `danger` variant rendered `text-state-error-text` (red) on a red gradient bg — preserved verbatim from the pre-#195 token rename, but visually low-contrast.
- Switch to `text-state-error-fg` (near-white token) per the `-fg` convention #195 established for foregrounds on colored backgrounds.

## Diff
1 line in `src/components/ui/Button.tsx` (line 65).

## Self-verification
- `npm run build` — succeeded
- `node scripts/harness-agent.mjs` — 8/8 PASS
- `node scripts/harness-ui.mjs` — 5/5 PASS
- `node scripts/harness-perm.mjs` — 9/9 PASS (Reject button uses danger variant; visible style intact)