### PR TITLE
style(blocks): flatten Plan/Perm/Todo to tool-row rhythm

### DIFF
--- a/src/components/ChatStream.tsx
+++ b/src/components/ChatStream.tsx
@@ -832,26 +832,26 @@ function PlanBlock({ plan, onAllow, onDeny }: { plan: string; onAllow?: () => vo
       initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.22, ease: [0.32, 0.72, 0, 1] }}
-      className="relative my-2 rounded-md border border-state-waiting/40 bg-state-waiting/[0.06] surface-highlight surface-elevated pl-4 pr-4 py-3"
+      className="relative my-1 pl-3 pr-2 py-1.5 font-mono text-sm"
     >
       <span
         aria-hidden
-        className="absolute left-0 top-0 bottom-0 w-[2px] bg-state-waiting rounded-l-md"
+        className="absolute left-0 top-0 bottom-0 w-[2px] bg-state-waiting rounded-l-sm"
       />
-      <div id="plan-title" className="flex items-center gap-2 text-base text-fg-primary font-semibold">
+      <div id="plan-title" className="flex items-baseline gap-2">
         <StateGlyph state="waiting" size="sm" />
-        <span>{t('chat.planTitle')}</span>
+        <span className="font-mono uppercase tracking-wider text-mono-xs text-state-waiting">{t('chat.planTitle')}</span>
       </div>
-      <div className="mt-2 max-h-[420px] overflow-y-auto rounded-sm border border-border-subtle bg-bg-app/40 px-3 py-2">
+      <div className="mt-1 max-h-[420px] overflow-y-auto border-l border-border-subtle pl-2">
         <div className="prose prose-invert prose-sm max-w-none font-mono text-sm text-fg-secondary [&_h1]:text-fg-primary [&_h2]:text-fg-primary [&_h3]:text-fg-primary [&_code]:text-fg-primary [&_pre]:bg-bg-elevated [&_pre]:rounded-sm">
           <ReactMarkdown remarkPlugins={[remarkGfm]}>{plan}</ReactMarkdown>
         </div>
       </div>
-      <div className="mt-3 flex justify-end gap-2">
-        <Button ref={rejectRef} variant="secondary" size="md" onClick={onDeny}>
+      <div className="mt-2 flex justify-end gap-2">
+        <Button ref={rejectRef} variant="secondary" size="sm" onClick={onDeny}>
           {t('chat.planReject')}
         </Button>
-        <Button variant="primary" size="md" onClick={onAllow}>
+        <Button variant="primary" size="sm" onClick={onAllow}>
           {t('chat.planApprove')}
         </Button>
       </div>
@@ -864,14 +864,14 @@ function TodoBlock({ todos }: { todos: import('../types').TodoItem[] }) {
   const total = todos.length;
   const done = todos.filter((t) => t.status === 'completed').length;
   return (
-    <div className="my-1.5 rounded-md border border-border-subtle bg-bg-elevated/40 px-3 py-2">
-      <div className="flex items-center justify-between mb-1.5">
-        <span className="font-mono text-mono-sm uppercase tracking-wider text-fg-tertiary">{t('chat.todoLabel')}</span>
-        <span className="font-mono text-mono-sm text-fg-tertiary">
+    <div className="my-1 pl-3 pr-2 font-mono text-sm">
+      <div className="flex items-baseline justify-between mb-1">
+        <span className="font-mono text-mono-xs uppercase tracking-wider text-fg-tertiary">{t('chat.todoLabel')}</span>
+        <span className="font-mono text-mono-xs text-fg-tertiary">
           {done}/{total}
         </span>
       </div>
-      <ul className="space-y-1">
+      <ul className="space-y-0.5">
         {todos.map((t, i) => {
           const inProgress = t.status === 'in_progress';
           const completed = t.status === 'completed';

--- a/src/components/PermissionPromptBlock.tsx
+++ b/src/components/PermissionPromptBlock.tsx
@@ -207,29 +207,31 @@ export function PermissionPromptBlock({
       initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: DURATION_RAW.ms220, ease: EASING.standard }}
-      className="relative my-2 rounded-md border border-accent/50 bg-accent/[0.06] surface-highlight surface-elevated pl-4 pr-4 py-3"
+      className="relative my-1 pl-3 pr-2 py-1.5 font-mono text-sm"
     >
       <span
         aria-hidden
-        className="absolute left-0 top-0 bottom-0 w-[2px] bg-accent rounded-l-md"
+        className="absolute left-0 top-0 bottom-0 w-[2px] bg-accent rounded-l-sm"
       />
       <div
         id={titleId}
-        className="flex items-center gap-2 text-base text-fg-primary font-semibold"
+        className="flex items-baseline gap-2"
       >
-        <ShieldAlert size={14} className="text-accent" aria-hidden />
-        <span>{t('permissionPrompt.title')}</span>
+        <ShieldAlert size={12} className="text-accent self-center shrink-0" aria-hidden />
+        <span className="font-mono uppercase tracking-wider text-mono-xs text-accent">
+          {t('permissionPrompt.title')}
+        </span>
         {toolName && (
-          <span className="font-mono text-xs text-fg-tertiary uppercase tracking-wider">
+          <span className="font-mono text-mono-xs text-fg-tertiary">
             {toolName}
           </span>
         )}
       </div>
-      <div id={descId} className="mt-2 font-mono text-sm text-fg-secondary whitespace-pre-wrap break-words">
+      <div id={descId} className="mt-1 font-mono text-sm text-fg-secondary whitespace-pre-wrap break-words">
         {prompt}
       </div>
       {summary.length > 0 && (
-        <dl className="mt-2 rounded-sm border border-border-subtle bg-bg-app/40 px-3 py-2 font-mono text-xs text-fg-secondary">
+        <dl className="mt-1 border-l border-border-subtle pl-2 font-mono text-xs text-fg-secondary">
           {summary.map(({ key, value }) => (
             <div key={key} className="flex gap-2 py-0.5">
               <dt className="text-fg-tertiary shrink-0">{key}</dt>
@@ -240,11 +242,11 @@ export function PermissionPromptBlock({
           ))}
         </dl>
       )}
-      <div className="mt-3 flex items-center justify-end gap-2">
+      <div className="mt-2 flex items-center justify-end gap-2">
         <Button
           ref={rejectRef}
           variant="secondary"
-          size="md"
+          size="sm"
           data-perm-action="reject"
           onClick={onReject}
           onKeyDown={(e) => {
@@ -260,7 +262,7 @@ export function PermissionPromptBlock({
           <Button
             ref={allowAlwaysRef}
             variant="secondary"
-            size="md"
+            size="sm"
             data-perm-action="allow-always"
             onClick={onAllowAlways}
             onKeyDown={(e) => {
@@ -276,7 +278,7 @@ export function PermissionPromptBlock({
         <Button
           ref={allowRef}
           variant="primary"
-          size="md"
+          size="sm"
           data-perm-action="allow"
           onClick={onAllow}
           onKeyDown={(e) => {


### PR DESCRIPTION
Closes part of #206 (UI-25).

## Why
Per `docs/design/ui-review-chatstream.md` H2 entry — "card rhythm" was the top issue. Plan, PermissionPromptBlock and Todo were the only blocks rendering with thick padding, full borders and `bg-*` panel backgrounds. Everything else (assistant text, tool calls, StatusBanner) uses a lean stripe-on-flat-chrome rhythm. Per memory rule (CLI visual + GUI interaction): no fluffy padding/cards, high information density.

## What
Pure visual chrome flatten — no behavior, handler, focus-order or a11y change.

### Before / After class diff

PermissionPromptBlock outer (alertdialog):
- BEFORE `relative my-2 rounded-md border border-accent/50 bg-accent/[0.06] surface-highlight surface-elevated pl-4 pr-4 py-3`
- AFTER  `relative my-1 pl-3 pr-2 py-1.5 font-mono text-sm` (+ unchanged 2px accent stripe)

PermissionPromptBlock title:
- BEFORE `text-base text-fg-primary font-semibold`
- AFTER  `font-mono uppercase tracking-wider text-mono-xs text-accent`

PermissionPromptBlock input-summary `dl`:
- BEFORE `mt-2 rounded-sm border border-border-subtle bg-bg-app/40 px-3 py-2 …`
- AFTER  `mt-1 border-l border-border-subtle pl-2 …`

PlanBlock outer:
- BEFORE `relative my-2 rounded-md border border-state-waiting/40 bg-state-waiting/[0.06] surface-highlight surface-elevated pl-4 pr-4 py-3`
- AFTER  `relative my-1 pl-3 pr-2 py-1.5 font-mono text-sm`

PlanBlock markdown viewport:
- BEFORE `mt-2 max-h-[420px] overflow-y-auto rounded-sm border border-border-subtle bg-bg-app/40 px-3 py-2`
- AFTER  `mt-1 max-h-[420px] overflow-y-auto border-l border-border-subtle pl-2`

TodoBlock outer:
- BEFORE `my-1.5 rounded-md border border-border-subtle bg-bg-elevated/40 px-3 py-2`
- AFTER  `my-1 pl-3 pr-2 font-mono text-sm`

Buttons in Plan + Perm: `size="md"` → `size="sm"` (matches lean rhythm, still meets a11y target size).

## Self-verification
- `npm run build` — succeeded (only the standard 3 bundle-size warnings, unrelated)
- `node scripts/harness-agent.mjs` — 8/8 PASS
- `node scripts/harness-ui.mjs`    — 5/5 PASS
- `node scripts/harness-perm.mjs`  — 9/9 PASS (covers a11y `role=alertdialog`, allow-always persistence, Esc dismiss, Tab cycle, sequential focus, truncate-width — all preserved by the new flat chrome)

## Out of scope
- ChatStream.tsx structural refactor → reserved for #207
- No changes to ToolBlock or assistant text rendering
- No new deps