### PR TITLE
feat(window): per-instance tint setting (#218)

### DIFF
--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from '../i18n/useTranslation';
 import { usePreferences } from '../store/preferences';
 import { useFocusRestore } from '../lib/useFocusRestore';
 import { DURATION_RAW, EASING } from '../lib/motion';
+import { useWindowTint, WINDOW_TINT_PRESETS, type WindowTint } from '../lib/windowTint';
 
 type LocalUpdateStatus =
   | { kind: 'idle' }
@@ -225,6 +226,7 @@ function AppearancePane() {
   const setDensity = useStore((s) => s.setDensity);
   const language = usePreferences((s) => s.language);
   const setLanguage = usePreferences((s) => s.setLanguage);
+  const [windowTint, setWindowTint] = useWindowTint();
   const { t } = useTranslation('settings');
 
   const sizeStops: Array<12 | 13 | 14 | 15 | 16> = [12, 13, 14, 15, 16];
@@ -284,7 +286,70 @@ function AppearancePane() {
           ]}
         />
       </Field>
+      <Field label={t('windowTint')} hint={t('windowTintHint')}>
+        <WindowTintPicker value={windowTint} onChange={setWindowTint} t={t} />
+      </Field>
     </>
+  );
+}
+
+// Tint picker — small horizontal swatch row. Each preset shows the actual
+// CSS var color so the user can preview before committing. The `none` slot
+// is rendered as a diagonal-stripe "no fill" affordance (Apple-style "none"
+// chip) rather than an empty box.
+function WindowTintPicker({
+  value,
+  onChange,
+  t,
+}: {
+  value: WindowTint;
+  onChange: (next: WindowTint) => void;
+  t: (key: string) => string;
+}) {
+  return (
+    <div role="radiogroup" aria-label={t('windowTint')} className="inline-flex items-center gap-1.5">
+      {WINDOW_TINT_PRESETS.map((preset) => {
+        const active = preset === value;
+        const isNone = preset === 'none';
+        const label = t(`windowTintOptions.${preset}`);
+        return (
+          <button
+            key={preset}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            aria-label={label}
+            title={label}
+            onClick={() => onChange(preset)}
+            data-tint-option={preset}
+            data-tint-active={active ? 'true' : 'false'}
+            className={cn(
+              'relative h-6 w-6 rounded-full',
+              'border border-border-default bg-bg-elevated',
+              'transition-[transform,box-shadow,border-color] duration-150 ease-out',
+              'outline-none focus-ring',
+              'hover:border-border-strong hover:scale-[1.06]',
+              active && 'border-accent shadow-[0_0_0_2px_var(--color-accent-soft)]'
+            )}
+          >
+            {/* Inner color disc. For `none` we draw a diagonal stripe so the
+                chip reads as "no fill" instead of an empty white circle. */}
+            <span
+              aria-hidden
+              className="absolute inset-0.5 rounded-full"
+              style={
+                isNone
+                  ? {
+                      background:
+                        'linear-gradient(135deg, transparent calc(50% - 0.5px), var(--color-fg-tertiary) calc(50% - 0.5px), var(--color-fg-tertiary) calc(50% + 0.5px), transparent calc(50% + 0.5px))',
+                    }
+                  : { background: `var(--color-tint-${preset})` }
+              }
+            />
+          </button>
+        );
+      })}
+    </div>
   );
 }
 

--- a/src/components/WindowControls.tsx
+++ b/src/components/WindowControls.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { Minus, Square, Copy, X } from 'lucide-react';
 import { cn } from '../lib/cn';
 import { useTranslation } from '../i18n/useTranslation';
+import { useWindowTint, tintCssVar } from '../lib/windowTint';
+import { DURATION, EASING } from '../lib/motion';
 
 // Cross-platform window chrome pieces.
 //
@@ -29,12 +31,48 @@ export function DragRegion({
   children?: React.ReactNode;
   style?: React.CSSProperties;
 }) {
+  // Per-window tint overlay (UI-10c). Sits underneath the children so window
+  // controls / icons are never washed out, and uses a CSS opacity transition
+  // tuned to the shared motion tokens (DURATION.standard / EASING.standard
+  // ≈ 180ms — the same fade timing used elsewhere for crossfades). When the
+  // tint is `none` the overlay collapses to opacity 0; the div stays mounted
+  // so the fade-out animates instead of popping. The `pointer-events: none`
+  // means the underlying `-webkit-app-region: drag` on the parent is still
+  // what receives drag input.
+  const [tint] = useWindowTint();
+  const tintBg = tintCssVar(tint);
+  const transitionMs = Math.round(DURATION.standard * 1000);
+  const easing = `cubic-bezier(${EASING.standard.join(',')})`;
+
   return (
     <div
       aria-hidden
-      className={cn('select-none', className)}
+      className={cn('select-none relative', className)}
       style={{ WebkitAppRegion: 'drag', ...style } as React.CSSProperties}
     >
+      <div
+        aria-hidden
+        data-window-tint={tint}
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background: tintBg ?? 'transparent',
+          opacity: tintBg ? 1 : 0,
+          transition: `opacity ${transitionMs}ms ${easing}, background-color ${transitionMs}ms ${easing}`,
+        }}
+      />
+      {/* 2px accent rule at the very top of the strip — secondary cue that
+          the window has a tint applied. Same fade timing. Sits above the
+          wash so the line stays crisp against the rest of the chrome. */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute top-0 left-0 right-0"
+        style={{
+          height: 2,
+          background: tintBg ?? 'transparent',
+          opacity: tintBg ? 1 : 0,
+          transition: `opacity ${transitionMs}ms ${easing}, background-color ${transitionMs}ms ${easing}`,
+        }}
+      />
       {children}
     </div>
   );

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -200,6 +200,18 @@ const en = {
       normal: 'Normal',
       comfortable: 'Comfortable'
     },
+    windowTint: 'Window tint',
+    windowTintHint:
+      'Faint accent on this window\u2019s title bar to tell parallel Agentory windows apart at a glance. Local to this window only.',
+    windowTintOptions: {
+      none: 'None',
+      slate: 'Slate',
+      sky: 'Sky',
+      mint: 'Mint',
+      amber: 'Amber',
+      rose: 'Rose',
+      violet: 'Violet'
+    },
     language: 'Language',
     languageHint: 'Choose the interface language. Changes apply immediately.',
     languageOptions: {

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -194,6 +194,17 @@ const zh: EnCatalog = {
       normal: '常规',
       comfortable: '宽松'
     },
+    windowTint: '窗口色调',
+    windowTintHint: '为当前窗口的标题栏添加一抹淡色，便于在多开 Agentory 窗口时一眼区分。仅作用于当前窗口。',
+    windowTintOptions: {
+      none: '无',
+      slate: '石板',
+      sky: '天蓝',
+      mint: '薄荷',
+      amber: '琥珀',
+      rose: '玫瑰',
+      violet: '紫罗兰'
+    },
     language: '语言',
     languageHint: '选择界面语言。修改立即生效。',
     languageOptions: {

--- a/src/lib/windowTint.ts
+++ b/src/lib/windowTint.ts
@@ -1,0 +1,176 @@
+/**
+ * Per-window tint setting (UI-10c).
+ *
+ * When the user runs more than one Agentory window at the same time (a
+ * thing per-instance hotkey/exit-anim work in #213 enabled), it can be hard
+ * to tell at a glance which window is which. This module gives each window
+ * an opt-in faint accent tint applied to the title-bar drag strip — purely
+ * a *visual* aid, never the sole signal (the window title still shows the
+ * active session).
+ *
+ * Scope decisions:
+ *
+ *   - Per-window-instance, NOT global. We deliberately do NOT persist this
+ *     in the main zustand store: that one round-trips through the shared
+ *     userData db which every BrowserWindow shares, so a global setter
+ *     would paint every window the same color and defeat the feature.
+ *
+ *   - Per-window identity. The app today only ever creates a single
+ *     BrowserWindow per Electron process (see `electron/main.ts ::
+ *     createWindow`), so "per window" effectively means "per OS process".
+ *     We mint a stable id at first read using `sessionStorage` — it
+ *     survives a renderer reload but resets when the window itself closes
+ *     (or a fresh process is launched), which matches the user's mental
+ *     model of "this window".
+ *
+ *   - Persistence. The active tint is keyed by the per-window id and
+ *     stored in localStorage so a renderer reload (devtools, hot-reload)
+ *     keeps the choice. localStorage is shared across windows in the same
+ *     userData dir, but the per-window key namespacing keeps choices
+ *     isolated, and stale entries from prior windows naturally fall out of
+ *     use because the next window mints a fresh id.
+ *
+ *   - A11y. Tint is intentionally low-opacity (≈8%) and rides on top of
+ *     the existing chrome — it never replaces a label. The 2px accent bar
+ *     at the very top of the strip is a secondary visual cue, but the
+ *     window title (set elsewhere via the OS) remains the load-bearing
+ *     identifier.
+ */
+
+import { useEffect, useState } from 'react';
+
+/** Stable list of preset tints. `none` means "no tint" (the default). */
+export const WINDOW_TINT_PRESETS = [
+  'none',
+  'slate',
+  'sky',
+  'mint',
+  'amber',
+  'rose',
+  'violet',
+] as const;
+
+export type WindowTint = typeof WINDOW_TINT_PRESETS[number];
+
+export const DEFAULT_WINDOW_TINT: WindowTint = 'none';
+
+const SESSION_KEY = 'agentory:windowId';
+const TINT_KEY_PREFIX = 'agentory:windowTint:';
+
+/** Same shape as `crypto.randomUUID` falls back to when crypto is missing. */
+function mintId(): string {
+  try {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+  } catch {
+    /* fall through */
+  }
+  return `w-${Math.random().toString(36).slice(2, 10)}-${Date.now().toString(36)}`;
+}
+
+/**
+ * Read or mint the per-window id. Stored in `sessionStorage` so it survives
+ * a renderer reload but is naturally fresh on each new BrowserWindow /
+ * Electron process. SSR-safe: returns a static id if `sessionStorage` is
+ * unavailable (test/server) so callers don't crash.
+ */
+export function getWindowId(): string {
+  if (typeof window === 'undefined' || typeof window.sessionStorage === 'undefined') {
+    return 'ssr';
+  }
+  try {
+    const existing = window.sessionStorage.getItem(SESSION_KEY);
+    if (existing && existing.length > 0) return existing;
+    const fresh = mintId();
+    window.sessionStorage.setItem(SESSION_KEY, fresh);
+    return fresh;
+  } catch {
+    // Some sandboxed environments throw on storage access. Fall back to a
+    // process-local id so the app still renders.
+    return 'unavailable';
+  }
+}
+
+function tintStorageKey(windowId: string): string {
+  return `${TINT_KEY_PREFIX}${windowId}`;
+}
+
+/** Validate a stored value before trusting it. */
+export function isWindowTint(v: unknown): v is WindowTint {
+  return typeof v === 'string' && (WINDOW_TINT_PRESETS as readonly string[]).includes(v);
+}
+
+/** Read the persisted tint for the current window, or the default. */
+export function loadWindowTint(): WindowTint {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+    return DEFAULT_WINDOW_TINT;
+  }
+  try {
+    const raw = window.localStorage.getItem(tintStorageKey(getWindowId()));
+    return isWindowTint(raw) ? raw : DEFAULT_WINDOW_TINT;
+  } catch {
+    return DEFAULT_WINDOW_TINT;
+  }
+}
+
+/** Persist + broadcast a tint change to every subscriber in this window. */
+export function saveWindowTint(tint: WindowTint): void {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+    return;
+  }
+  try {
+    if (tint === DEFAULT_WINDOW_TINT) {
+      window.localStorage.removeItem(tintStorageKey(getWindowId()));
+    } else {
+      window.localStorage.setItem(tintStorageKey(getWindowId()), tint);
+    }
+  } catch {
+    /* ignore — quota errors are non-fatal for a cosmetic preference */
+  }
+  // Notify in-window subscribers. We use a CustomEvent on the window so the
+  // settings dialog and the drag-region overlay stay in sync without
+  // standing up a full pub/sub system. localStorage's `storage` event only
+  // fires on OTHER documents, never the one that wrote — hence the manual
+  // dispatch.
+  try {
+    window.dispatchEvent(new CustomEvent<WindowTint>('agentory:windowTintChange', { detail: tint }));
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * React hook: returns `[tint, setTint]` for the current window. Subscribes
+ * to in-window changes so flipping the setting in one place repaints every
+ * consumer (drag region, future debug overlays, etc.).
+ */
+export function useWindowTint(): [WindowTint, (next: WindowTint) => void] {
+  const [tint, setTint] = useState<WindowTint>(() => loadWindowTint());
+
+  useEffect(() => {
+    const onChange = (e: Event) => {
+      const detail = (e as CustomEvent<WindowTint>).detail;
+      if (isWindowTint(detail)) setTint(detail);
+    };
+    window.addEventListener('agentory:windowTintChange', onChange);
+    return () => window.removeEventListener('agentory:windowTintChange', onChange);
+  }, []);
+
+  return [tint, (next) => {
+    saveWindowTint(next);
+    // Also update locally — the event roundtrip is async-ish in some
+    // browsers and we want React state to settle this tick.
+    setTint(next);
+  }];
+}
+
+/**
+ * The CSS custom property name for a tint. `none` returns null so callers
+ * can branch off rather than apply `var(--color-tint-none)` (which doesn't
+ * exist).
+ */
+export function tintCssVar(tint: WindowTint): string | null {
+  if (tint === 'none') return null;
+  return `var(--color-tint-${tint})`;
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -121,6 +121,25 @@
   --color-terminal-border: oklch(0.30 0.005 240);
   --color-terminal-accent: oklch(0.55 0.17 155);
   --color-terminal-hover-bg: oklch(0.22 0.005 240);
+
+  /* ── Per-window tint palette (UI-10c). Faint accent washes layered on
+     top of the title-bar drag strip so users can tell parallel Agentory
+     windows apart at a glance. Six hues plus `none` (handled by JS as
+     "no overlay"). Alphas are deliberately tiny — tint is a *secondary*
+     cue, the window title is still the load-bearing identifier.
+
+     Each color carries its own alpha so vivid hues (rose, violet) don't
+     visually outweigh muted ones (slate, mint). Calibrated against the
+     dark `--color-bg-app` (oklch 0.16) so the tint reads as a wash, not
+     a highlight. Light mode uses higher chroma/lower lightness in the
+     `html.theme-light` block below to land roughly the same perceived
+     intensity on a white sidebar. ── */
+  --color-tint-slate: oklch(0.78 0.04 240 / 0.10);
+  --color-tint-sky: oklch(0.78 0.13 215 / 0.10);
+  --color-tint-mint: oklch(0.82 0.13 165 / 0.09);
+  --color-tint-amber: oklch(0.82 0.13 75 / 0.09);
+  --color-tint-rose: oklch(0.74 0.16 15 / 0.08);
+  --color-tint-violet: oklch(0.72 0.15 295 / 0.10);
 }
 
 html, body, #root {
@@ -266,6 +285,16 @@ html.theme-light {
   --color-terminal-border: oklch(0.30 0.005 240);
   --color-terminal-accent: oklch(0.60 0.17 155);
   --color-terminal-hover-bg: oklch(0.24 0.005 240);
+
+  /* Per-window tint palette — light mode. Boost chroma and drop lightness
+     vs. the dark block so the wash holds up on a near-white sidebar. Same
+     alpha-per-hue calibration logic. */
+  --color-tint-slate: oklch(0.55 0.04 240 / 0.10);
+  --color-tint-sky: oklch(0.55 0.16 225 / 0.10);
+  --color-tint-mint: oklch(0.58 0.14 165 / 0.09);
+  --color-tint-amber: oklch(0.62 0.15 75 / 0.10);
+  --color-tint-rose: oklch(0.55 0.20 15 / 0.09);
+  --color-tint-violet: oklch(0.52 0.18 295 / 0.10);
 }
 
 html.theme-light ::selection {

--- a/tests/window-tint.test.ts
+++ b/tests/window-tint.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  WINDOW_TINT_PRESETS,
+  DEFAULT_WINDOW_TINT,
+  isWindowTint,
+  loadWindowTint,
+  saveWindowTint,
+  getWindowId,
+  tintCssVar,
+} from '../src/lib/windowTint';
+
+// jsdom gives us a real window/localStorage/sessionStorage. Wipe between
+// tests so per-window-id minting and persistence are deterministic.
+beforeEach(() => {
+  window.sessionStorage.clear();
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  window.sessionStorage.clear();
+  window.localStorage.clear();
+});
+
+describe('window tint presets', () => {
+  it('exposes none plus six named hues', () => {
+    expect(WINDOW_TINT_PRESETS).toEqual([
+      'none',
+      'slate',
+      'sky',
+      'mint',
+      'amber',
+      'rose',
+      'violet',
+    ]);
+  });
+
+  it("default is 'none'", () => {
+    expect(DEFAULT_WINDOW_TINT).toBe('none');
+  });
+
+  it('isWindowTint accepts presets and rejects everything else', () => {
+    for (const p of WINDOW_TINT_PRESETS) expect(isWindowTint(p)).toBe(true);
+    expect(isWindowTint('purple')).toBe(false);
+    expect(isWindowTint('')).toBe(false);
+    expect(isWindowTint(null)).toBe(false);
+    expect(isWindowTint(undefined)).toBe(false);
+    expect(isWindowTint(7)).toBe(false);
+    expect(isWindowTint({})).toBe(false);
+  });
+
+  it('tintCssVar maps named tints to CSS vars and none to null', () => {
+    expect(tintCssVar('none')).toBeNull();
+    expect(tintCssVar('sky')).toBe('var(--color-tint-sky)');
+    expect(tintCssVar('rose')).toBe('var(--color-tint-rose)');
+  });
+});
+
+describe('per-window id', () => {
+  it('mints a stable id and reuses it within a window', () => {
+    const a = getWindowId();
+    const b = getWindowId();
+    expect(a).toBe(b);
+    expect(a.length).toBeGreaterThan(0);
+    expect(window.sessionStorage.getItem('agentory:windowId')).toBe(a);
+  });
+
+  it('a fresh sessionStorage means a fresh id (mimics a new window)', () => {
+    const first = getWindowId();
+    window.sessionStorage.clear();
+    const second = getWindowId();
+    expect(second).not.toBe(first);
+  });
+});
+
+describe('tint persistence', () => {
+  it("loadWindowTint defaults to 'none' when nothing is stored", () => {
+    expect(loadWindowTint()).toBe('none');
+  });
+
+  it('round-trips through save/load', () => {
+    saveWindowTint('sky');
+    expect(loadWindowTint()).toBe('sky');
+    saveWindowTint('amber');
+    expect(loadWindowTint()).toBe('amber');
+  });
+
+  it("saving 'none' clears the storage entry rather than persisting it", () => {
+    saveWindowTint('mint');
+    const id = getWindowId();
+    expect(window.localStorage.getItem(`agentory:windowTint:${id}`)).toBe('mint');
+    saveWindowTint('none');
+    expect(window.localStorage.getItem(`agentory:windowTint:${id}`)).toBeNull();
+    expect(loadWindowTint()).toBe('none');
+  });
+
+  it('rejects bogus persisted values and falls back to the default', () => {
+    const id = getWindowId();
+    window.localStorage.setItem(`agentory:windowTint:${id}`, 'plaid');
+    expect(loadWindowTint()).toBe('none');
+  });
+
+  it('saveWindowTint dispatches an in-window change event', () => {
+    const handler = vi.fn();
+    window.addEventListener('agentory:windowTintChange', handler);
+    saveWindowTint('violet');
+    expect(handler).toHaveBeenCalledTimes(1);
+    const ev = handler.mock.calls[0][0] as CustomEvent;
+    expect(ev.detail).toBe('violet');
+    window.removeEventListener('agentory:windowTintChange', handler);
+  });
+
+  it('isolates one window from another (different ids → different keys)', () => {
+    saveWindowTint('rose');
+    const idA = getWindowId();
+    expect(window.localStorage.getItem(`agentory:windowTint:${idA}`)).toBe('rose');
+
+    // Simulate a second window: fresh sessionStorage mints a new id, and
+    // its load must NOT see window A's choice.
+    window.sessionStorage.clear();
+    expect(loadWindowTint()).toBe('none');
+    const idB = getWindowId();
+    expect(idB).not.toBe(idA);
+
+    // Window A's persisted value is still present under its own key.
+    expect(window.localStorage.getItem(`agentory:windowTint:${idA}`)).toBe('rose');
+  });
+});


### PR DESCRIPTION
## Summary

Picks up the deferred (c) item from #213 (UI-10c). Per-window tint setting so users running multiple Agentory windows in parallel can tell them apart at a glance via a faint accent on the title-bar drag strip. Opt-in, default off.

- 7 presets: `none` (default) + slate / sky / mint / amber / rose / violet
- Per-window-instance scope (NOT global). Per-window id minted via `sessionStorage`, persisted tint keyed by that id in `localStorage`. Two windows on the same userData dir get independent choices.
- Title-bar drag strip gets a low-alpha (~8–10%) wash + 2px accent rule at the very top, both fade via shared motion tokens (`DURATION.standard` / `EASING.standard` ≈ 180ms).
- New `--color-tint-{name}` tokens in `global.css` for both dark and light blocks; alphas / chroma calibrated per hue.
- Settings → Appearance gains a swatch-row picker. `none` chip uses an Apple-style diagonal-stripe "no fill" affordance. Full radio semantics + per-option `aria-label`.
- A11y: tint is a *secondary* cue. The OS window title remains the load-bearing identifier.

## Files changed

- `src/lib/windowTint.ts` (new) — per-window id, persistence, hook
- `src/components/WindowControls.tsx` — `<DragRegion />` overlay + accent rule
- `src/components/SettingsDialog.tsx` — Window tint field + `<WindowTintPicker />`
- `src/styles/global.css` — `--color-tint-*` tokens (dark + light)
- `src/i18n/locales/en.ts` + `src/i18n/locales/zh.ts` — `settings.windowTint*`
- `tests/window-tint.test.ts` (new) — 12 unit tests

## Test plan

- [x] `npm run build` — OK
- [x] `npm test` — 613 passed; 12 failures isolated to `electron/__tests__/db*.ts` are a pre-existing `better-sqlite3` NODE_MODULE_VERSION mismatch in local env (verified same failures reproduce on clean `origin/working` — not introduced here)
- [x] `npm run lint` on touched files — clean
- [ ] Reviewer: `npm run probe:e2e` / `harness-ui` (skipped here per task brief — two other workers are using electron right now)
- [ ] Reviewer: visual smoke — open Settings → Appearance, click each swatch, verify drag strip wash + 2px top rule fade in/out smoothly. Reload window, choice persists. Open a second Electron instance, verify it starts with `none` and is independent.

## Notes for reviewer

- The current app only ever spawns one BrowserWindow per process (`electron/main.ts :: createWindow`), so "per window" effectively means "per OS process / app launch" today. The id scheme is forward-compatible with multi-window if/when that lands.
- Tint storage key is `agentory:windowTint:{windowId}` in localStorage; `none` is represented as "no entry" rather than a stored "none" string.
- No mandatory probe per `feedback_bugfix_requires_e2e.md` — this is a feature, not a bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)