### PR TITLE
fix(import): load .jsonl history + filter sub-agent + filter agentory-temp cwds (#219)

### DIFF
--- a/electron/import-history.ts
+++ b/electron/import-history.ts
@@ -1,0 +1,78 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import * as readline from 'readline';
+
+const PROJECTS_ROOT = path.join(os.homedir(), '.claude', 'projects');
+
+// Cap on the number of frames we'll return to the renderer. Some historical
+// transcripts are huge (hundreds of MB / tens of thousands of frames). We
+// already accept this on the agent stream path because the user is the one
+// generating it, but on import we're asked to materialize the whole thing
+// at once. Cap defensively — well past anything a typical session generates,
+// while still bounding memory for pathological cases.
+const MAX_FRAMES = 50_000;
+
+// `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl` — read line-by-line,
+// JSON-parse each, return the resulting frames. Filename is constrained to
+// the sessionId we got back from `import:scan`, which is itself derived from
+// a directory listing of `~/.claude/projects/<encoded-cwd>/`, so there's no
+// renderer-controlled path component beyond the projectDir we already
+// accepted at scan time.
+//
+// We deliberately do NOT do block translation here — that lives in the
+// renderer (`stream-to-blocks`) and is shared with the live agent path.
+// Keeping this main-side read as raw-frames means the conversion logic has
+// exactly one home.
+export async function loadImportableHistory(
+  projectDir: string,
+  sessionId: string
+): Promise<unknown[]> {
+  // Reject any path component that would let a malicious renderer break out
+  // of `~/.claude/projects/`. `path.basename` strips traversal but accepting
+  // an unsanitized projectDir would still let `..` slip past on Windows. We
+  // lock both to a leaf segment.
+  const safeProj = path.basename(String(projectDir ?? ''));
+  const safeSid = path.basename(String(sessionId ?? ''));
+  if (!safeProj || !safeSid) return [];
+  if (safeProj.includes('..') || safeSid.includes('..')) return [];
+  const file = path.join(PROJECTS_ROOT, safeProj, `${safeSid}.jsonl`);
+  // Ensure the resolved path is still inside PROJECTS_ROOT — defense in depth
+  // against any encoding tricks `basename` might miss on a future Node.
+  const resolved = path.resolve(file);
+  if (!resolved.startsWith(path.resolve(PROJECTS_ROOT) + path.sep)) return [];
+  let stat: fs.Stats;
+  try {
+    stat = await fs.promises.stat(resolved);
+  } catch {
+    return [];
+  }
+  if (!stat.isFile()) return [];
+
+  return new Promise((resolve) => {
+    const stream = fs.createReadStream(resolved, { encoding: 'utf8' });
+    const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+    const out: unknown[] = [];
+    let count = 0;
+    const finish = () => {
+      rl.removeAllListeners();
+      stream.destroy();
+      resolve(out);
+    };
+    rl.on('line', (line) => {
+      if (!line) return;
+      if (count >= MAX_FRAMES) {
+        finish();
+        return;
+      }
+      count++;
+      try {
+        out.push(JSON.parse(line));
+      } catch {
+        // skip malformed lines — same as the streaming agent parser
+      }
+    });
+    rl.on('close', finish);
+    rl.on('error', finish);
+  });
+}

--- a/electron/import-scanner.ts
+++ b/electron/import-scanner.ts
@@ -14,6 +14,58 @@ export type ScannableSession = {
 
 const PROJECTS_ROOT = path.join(os.homedir(), '.claude', 'projects');
 
+// `os.tmpdir()` is platform-aware: returns `%LOCALAPPDATA%\Temp` on Windows,
+// `/tmp` on Linux, `/var/folders/.../T/` on macOS. We capture it at module
+// load — it's a process-wide constant for any given user.
+const TMP_ROOT = os.tmpdir();
+
+/**
+ * Heuristic filter for agentory's own short-lived spawn cwds. Dogfood H found
+ * 92% of `~/.claude/projects/` entries on a real user's machine were
+ * agentory-spawned temporary dirs (paths like `<tmpdir>/agentory-…`), drowning
+ * the import picker in noise.
+ *
+ * Match conditions (any one):
+ *   1. cwd starts with the platform temp dir AND a path segment begins with
+ *      `agentory-` (the prefix our own spawn helpers use).
+ *   2. cwd appears under common cross-platform temp roots and matches the
+ *      same `agentory-` segment rule. Belt-and-suspenders for cases where
+ *      `os.tmpdir()` resolves to a path that doesn't match the on-disk cwd
+ *      verbatim (symlinks, drive-letter casing on Windows).
+ *
+ * Exported for unit testing.
+ */
+export function isAgentoryTempCwd(cwd: string): boolean {
+  if (!cwd || typeof cwd !== 'string') return false;
+  // Normalise separators so the segment check works on both Windows-style
+  // (`\`) and POSIX (`/`) inputs without case-folding the whole path.
+  const normalized = cwd.replace(/\\/g, '/');
+  // Look for any path segment that starts with `agentory-` — this matches
+  // every spawn flavour we use today (`agentory-A2N1-…`, `agentory-bugl-bash`,
+  // `agentory-probe-import-…`, etc.). The leading `/` rules out matching a
+  // user-named directory like `my-agentory-project`.
+  const hasAgentorySegment = /(^|\/)agentory-/.test(normalized);
+  if (!hasAgentorySegment) return false;
+  const tmpNorm = TMP_ROOT.replace(/\\/g, '/');
+  // Case-insensitive prefix on Windows (drive letter case can differ between
+  // `os.tmpdir()` and what the CLI recorded). Cheap on every other platform —
+  // file paths there are case-sensitive but `os.tmpdir()` returns the same
+  // casing the kernel does, so the lower-cased compare still matches.
+  const cwdLow = normalized.toLowerCase();
+  const tmpLow = tmpNorm.toLowerCase();
+  if (cwdLow.startsWith(tmpLow)) return true;
+  // Belt-and-suspenders for common temp roots that `os.tmpdir()` might not
+  // surface (e.g. `/tmp` on macOS where it's actually `/var/folders/...`).
+  const COMMON_TEMP_PREFIXES = ['/tmp/', '/private/tmp/', '/var/folders/'];
+  for (const p of COMMON_TEMP_PREFIXES) {
+    if (cwdLow.startsWith(p)) return true;
+  }
+  // Windows fallback: detect `…/AppData/Local/Temp/` regardless of drive
+  // (some users' OS install lives on D: but tmpdir resolves to C:).
+  if (/\/appdata\/local\/temp\//i.test(cwdLow)) return true;
+  return false;
+}
+
 // Read just enough of the head of a jsonl to determine cwd + a usable title.
 // CLI-written transcripts can be hundreds of MB; we never read the whole file.
 const MAX_HEAD_LINES = 200;
@@ -42,6 +94,9 @@ export async function scanImportableSessions(): Promise<ScannableSession[]> {
       try {
         const head = await readHead(full);
         if (!head) continue;
+        // Drop agentory's own short-lived spawn cwds — they're noise to the
+        // user. See `isAgentoryTempCwd` for the heuristic.
+        if (isAgentoryTempCwd(head.cwd)) continue;
         const stat = await fs.promises.stat(full);
         out.push({
           sessionId,
@@ -72,9 +127,20 @@ function readHead(file: string): Promise<Head | null> {
     let firstUserText = '';
     let model: string | null = null;
     let lines = 0;
+    let firstFrameInspected = false;
+    let isSidechain = false;
     const finish = () => {
       rl.removeAllListeners();
       stream.destroy();
+      // Sub-agent transcripts (those spawned by the Task tool) are not
+      // independently importable — they're a slice of a parent run and
+      // resuming them out of context produces nonsense. The CLI marks them
+      // by setting `parentUuid` non-null OR `isSidechain: true` on the very
+      // first frame. Skip those.
+      if (isSidechain) {
+        resolve(null);
+        return;
+      }
       const title = aiTitle || firstUserText || '(untitled session)';
       if (!cwd && !aiTitle && !firstUserText && !model) {
         resolve(null);
@@ -94,6 +160,14 @@ function readHead(file: string): Promise<Head | null> {
         d = JSON.parse(line);
       } catch {
         return;
+      }
+      if (!firstFrameInspected) {
+        firstFrameInspected = true;
+        if (isSidechainFrame(d)) {
+          isSidechain = true;
+          finish();
+          return;
+        }
       }
       if (typeof d.cwd === 'string' && !cwd) cwd = d.cwd;
       if (d.type === 'ai-title' && typeof d.aiTitle === 'string') {
@@ -165,6 +239,18 @@ export function deriveRecentCwds(
   return out;
 }
 
+// A frame written by the CLI for a sub-agent (Task tool spawn) carries either
+// `parentUuid` (non-null string) or `isSidechain: true` on its first line.
+// Keep this loose — the CLI only sets the field on sub-agent transcripts and
+// regular sessions emit `parentUuid: null` (or omit it entirely).
+export function isSidechainFrame(d: unknown): boolean {
+  if (!d || typeof d !== 'object') return false;
+  const o = d as Record<string, unknown>;
+  if (o.isSidechain === true) return true;
+  if (typeof o.parentUuid === 'string' && o.parentUuid.length > 0) return true;
+  return false;
+}
+
 // Pure head-parsing helper, exported for unit testing. Given an array of jsonl
 // lines (already parsed-back-to-strings or raw), return the same Head shape
 // the streaming reader produces.
@@ -173,6 +259,7 @@ export function parseHead(lines: string[]): Head | null {
   let aiTitle = '';
   let firstUserText = '';
   let model: string | null = null;
+  let firstFrameInspected = false;
   for (let i = 0; i < lines.length && i < MAX_HEAD_LINES; i++) {
     const line = lines[i];
     if (!line) continue;
@@ -181,6 +268,10 @@ export function parseHead(lines: string[]): Head | null {
       d = JSON.parse(line);
     } catch {
       continue;
+    }
+    if (!firstFrameInspected) {
+      firstFrameInspected = true;
+      if (isSidechainFrame(d)) return null;
     }
     if (typeof d.cwd === 'string' && !cwd) cwd = d.cwd;
     if (d.type === 'ai-title' && typeof d.aiTitle === 'string') aiTitle = d.aiTitle;

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -74,6 +74,7 @@ import {
   deriveTopModel,
   type ScannableSession,
 } from './import-scanner';
+import { loadImportableHistory } from './import-history';
 import { showNotification, type ShowNotificationPayload } from './notifications';
 import type { PermissionMode } from './agent/sessions';
 import { listModelsFromSettings } from './agent/list-models-from-settings';
@@ -761,6 +762,20 @@ app.whenReady().then(() => {
   ipcMain.handle('import:scan', () => getImportableSessions());
   ipcMain.handle('import:recentCwds', () => getRecentCwds());
   ipcMain.handle('import:topModel', () => getTopModel());
+  ipcMain.handle(
+    'import:loadHistory',
+    async (e, projectDir: unknown, sessionId: unknown) => {
+      if (!fromMainFrame(e)) return [];
+      if (typeof projectDir !== 'string' || typeof sessionId !== 'string') return [];
+      try {
+        return await loadImportableHistory(projectDir, sessionId);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn('[main] import:loadHistory failed', err);
+        return [];
+      }
+    }
+  );
 
   // Batched best-effort existence probe for arbitrary filesystem paths.
   // The renderer uses this on hydration to flag sessions whose persisted

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -162,6 +162,15 @@ const api = {
   topModel: (): Promise<string | null> => ipcRenderer.invoke('import:topModel'),
 
   /**
+   * Read the raw frames of an importable session's `.jsonl` transcript so the
+   * renderer can hydrate `messagesBySession` immediately on import (otherwise
+   * the imported chat looks empty until the user sends a follow-up that
+   * triggers `--resume` history replay).
+   */
+  loadImportHistory: (projectDir: string, sessionId: string): Promise<unknown[]> =>
+    ipcRenderer.invoke('import:loadHistory', projectDir, sessionId),
+
+  /**
    * Best-effort batched existence check. Returns a map keyed by the input
    * path; permission errors and ENOENT both map to `false`. Used by the
    * renderer's hydration migration to flag sessions whose persisted `cwd`

--- a/scripts/probe-e2e-import-session.mjs
+++ b/scripts/probe-e2e-import-session.mjs
@@ -1,23 +1,28 @@
 // E2E: import session via the sidebar Import button + ImportDialog.
 //
-// Flow under test:
-//   1. User clicks the sidebar Import button.
-//   2. ImportDialog mounts and calls `import:scan` IPC; we mock that handler
-//      in the MAIN process so the test does not depend on the user's real
-//      ~/.claude/projects folder.
-//   3. The fixture row appears in the dialog. User selects it, clicks Import.
-//   4. Dialog closes. Sidebar gains a new session whose name = fixture title,
-//      and the store reflects the new session backed by importSession() with
-//      the resumeSessionId we mocked.
+// Three cases under test (one PR fixes all three — Task #219):
 //
-// Pure black-box for the dialog UI; the post-condition assertion uses the
-// public __agentoryStore handle.
+//   Case 1 (Bug A): import a planted CLI .jsonl and verify the imported chat
+//     is hydrated immediately with the prior history blocks (NOT empty until
+//     the user sends a follow-up — that was the whole regression).
+//
+//   Case 2 (Bug B): plant a sub-agent transcript (parentUuid set on first
+//     frame) AND a sidechain transcript (isSidechain:true) alongside a clean
+//     one. Only the clean one should appear in the dialog.
+//
+//   Case 3 (Bug C / Dogfood-H): plant a transcript whose cwd lives under the
+//     platform temp dir AND has an `agentory-` segment (e.g. our own bash
+//     spawn cwds). Should be filtered from the picker.
+//
+// All cases sandbox HOME / USERPROFILE per project_probe_skill_injection.md
+// so the test never touches the developer's real ~/.claude/projects/ and
+// never picks up locally-installed skills.
 import { _electron as electron } from 'playwright';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import fs from 'node:fs';
 import os from 'node:os';
-import { appWindow } from './probe-utils.mjs';
+import { appWindow, isolatedUserData } from './probe-utils.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
@@ -27,28 +32,122 @@ function fail(msg) {
   process.exit(1);
 }
 
-const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agentory-probe-import-'));
+// ─── Plant a sandboxed HOME with a mix of fixtures ─────────────────────────
+const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agentory-probe-import-home-'));
+const projectsRoot = path.join(fakeHome, '.claude', 'projects');
+fs.mkdirSync(projectsRoot, { recursive: true });
 
-const FIXTURE = {
-  sessionId: 'fixture-resume-id-12345',
-  cwd: '/tmp/fixture-cwd',
-  title: 'Fixture imported session',
-  // mtime: ~ now, so it lands in the "Today" bucket.
-  mtime: Date.now(),
-  projectDir: '-tmp-fixture-cwd',
-  model: 'claude-opus-4'
-};
+function plantSession(projDirName, sessionId, frames) {
+  const dir = path.join(projectsRoot, projDirName);
+  fs.mkdirSync(dir, { recursive: true });
+  const lines = frames.map((f) => JSON.stringify(f)).join('\n') + '\n';
+  fs.writeFileSync(path.join(dir, sessionId + '.jsonl'), lines);
+}
+
+const now = Date.now();
+const TS = new Date(now).toISOString();
+
+// (1) Clean top-level session — what the user actually wants to import.
+//     Carries a real user→assistant turn so we can verify history hydration.
+const CLEAN_SID = 'aaaaaaa1-1111-1111-1111-111111111111';
+const CLEAN_CWD = '/tmp/probe-fixture-clean';
+plantSession('-tmp-probe-fixture-clean', CLEAN_SID, [
+  { type: 'permission-mode', permissionMode: 'default', sessionId: CLEAN_SID },
+  {
+    type: 'user',
+    parentUuid: null,
+    isSidechain: false,
+    uuid: 'u-clean-1',
+    cwd: CLEAN_CWD,
+    sessionId: CLEAN_SID,
+    timestamp: TS,
+    message: { role: 'user', content: [{ type: 'text', text: 'PROBE_USER_TEXT_HELLO' }] }
+  },
+  {
+    type: 'assistant',
+    session_id: CLEAN_SID,
+    parentUuid: 'u-clean-1',
+    isSidechain: false,
+    uuid: 'a-clean-1',
+    cwd: CLEAN_CWD,
+    timestamp: TS,
+    message: {
+      id: 'msg-clean-1',
+      role: 'assistant',
+      model: 'claude-opus-4-7',
+      content: [{ type: 'text', text: 'PROBE_ASSISTANT_TEXT_REPLY' }]
+    }
+  }
+]);
+
+// (2) Sub-agent transcript: first frame carries parentUuid (Task tool spawn).
+const SUBAGENT_SID = 'bbbbbbb2-2222-2222-2222-222222222222';
+plantSession('-tmp-probe-fixture-clean', SUBAGENT_SID, [
+  {
+    type: 'user',
+    parentUuid: 'parent-real-uuid-123',
+    isSidechain: false,
+    uuid: 'u-sub-1',
+    cwd: CLEAN_CWD,
+    sessionId: SUBAGENT_SID,
+    timestamp: TS,
+    message: { role: 'user', content: [{ type: 'text', text: 'PROBE_SUBAGENT_LEAK' }] }
+  }
+]);
+
+// (3) Sidechain transcript: isSidechain:true on the first frame.
+const SIDECHAIN_SID = 'ccccccc3-3333-3333-3333-333333333333';
+plantSession('-tmp-probe-fixture-clean', SIDECHAIN_SID, [
+  {
+    type: 'user',
+    parentUuid: null,
+    isSidechain: true,
+    uuid: 'u-side-1',
+    cwd: CLEAN_CWD,
+    sessionId: SIDECHAIN_SID,
+    timestamp: TS,
+    message: { role: 'user', content: [{ type: 'text', text: 'PROBE_SIDECHAIN_LEAK' }] }
+  }
+]);
+
+// (4) Agentory-temp cwd transcript: top-level (parentUuid null) but the cwd
+//     lives under the platform tmp dir with an `agentory-` segment. This is
+//     dogfood-H's noise category — should be filtered.
+const TEMP_SID = 'ddddddd4-4444-4444-4444-444444444444';
+const TEMP_CWD = path.join(os.tmpdir(), 'agentory-probe-spawn-fixture');
+// Encode the cwd the way the CLI would (every non-alnum → '-').
+const tempProjDir = TEMP_CWD.replace(/[^a-zA-Z0-9]/g, '-');
+plantSession(tempProjDir, TEMP_SID, [
+  {
+    type: 'user',
+    parentUuid: null,
+    isSidechain: false,
+    uuid: 'u-temp-1',
+    cwd: TEMP_CWD,
+    sessionId: TEMP_SID,
+    timestamp: TS,
+    message: { role: 'user', content: [{ type: 'text', text: 'PROBE_TEMP_LEAK' }] }
+  }
+]);
+
+console.log(`[probe] planted 4 fixtures under ${projectsRoot}`);
+
+// ─── Launch the app with a sandboxed HOME ──────────────────────────────────
+const ud = isolatedUserData('agentory-probe-import-userdata');
 
 const app = await electron.launch({
-  args: ['.', `--user-data-dir=${userDataDir}`],
+  args: ['.', `--user-data-dir=${ud.dir}`],
   cwd: root,
-  env: { ...process.env, NODE_ENV: 'development' }
+  env: {
+    ...process.env,
+    NODE_ENV: 'production',
+    AGENTORY_PROD_BUNDLE: '1',
+    HOME: fakeHome,
+    USERPROFILE: fakeHome,
+    CLAUDE_HOME: fakeHome
+  }
 });
 
-// Wait for the renderer window to mount FIRST — that guarantees the main
-// process has finished registering the original `import:scan` IPC handler
-// (those registrations sit inside whenReady → before createWindow). Only then
-// is it safe to remove + re-register with our fixture.
 const errors = [];
 const win = await appWindow(app);
 win.on('pageerror', (e) => errors.push(`[pageerror] ${e.message}`));
@@ -57,19 +156,9 @@ win.on('console', (m) => {
 });
 
 await win.waitForLoadState('domcontentloaded');
-await win.waitForFunction(() => !!window.__agentoryStore, null, { timeout: 10_000 });
+await win.waitForFunction(() => !!window.__agentoryStore, null, { timeout: 15_000 });
 
-// Replace the `import:scan` IPC handler with one that returns our fixture.
-// The renderer-side ImportDialog does no transformation beyond filtering out
-// sessionIds that already exist in the store, so the fixture passes through.
-await app.evaluate(async ({ ipcMain }, fixture) => {
-  try { ipcMain.removeHandler('import:scan'); } catch {}
-  ipcMain.handle('import:scan', () => [fixture]);
-}, FIXTURE);
-
-// Force a known starting state: zero sessions, tutorial seen — so the
-// landing page renders the sidebar Import button and the dialog opens
-// against a clean slate.
+// Force a known starting state.
 await win.evaluate(() => {
   window.__agentoryStore.setState({
     sessions: [],
@@ -78,7 +167,7 @@ await win.evaluate(() => {
     tutorialSeen: true
   });
 });
-await win.waitForTimeout(200);
+await win.waitForTimeout(300);
 
 const sessionsBefore = await win.evaluate(() => window.__agentoryStore.getState().sessions.length);
 if (sessionsBefore !== 0) {
@@ -86,7 +175,7 @@ if (sessionsBefore !== 0) {
   fail(`expected 0 sessions before import, got ${sessionsBefore}`);
 }
 
-// 1. Click the sidebar Import button (aria-label "Import session").
+// 1. Click the sidebar Import button.
 const importBtn = win.locator('aside').getByRole('button', { name: /import session/i }).first();
 await importBtn.waitFor({ state: 'visible', timeout: 10_000 }).catch(async () => {
   const html = await win.evaluate(() => document.body.innerText.slice(0, 800));
@@ -96,64 +185,99 @@ await importBtn.waitFor({ state: 'visible', timeout: 10_000 }).catch(async () =>
 });
 await importBtn.click();
 
-// 2. Dialog opens, fixture row should appear (title = "Fixture imported session").
-const fixtureRow = win.getByText('Fixture imported session').first();
-await fixtureRow.waitFor({ state: 'visible', timeout: 5000 }).catch(async () => {
-  const dump = await win.evaluate(() => document.body.innerText.slice(0, 1500));
-  console.error('--- body at failure ---\n' + dump);
-  console.error('--- errors ---\n' + errors.slice(-10).join('\n'));
-  await app.close();
-  fail('fixture session row never appeared in ImportDialog');
+// 2. Wait for dialog content to render.
+await win.waitForTimeout(500);
+
+// ─── Case 2 + Case 3: only the clean fixture should appear ────────────────
+const visibleSids = await win.evaluate(() => {
+  const text = document.body.innerText;
+  return {
+    clean: text.includes('PROBE_USER_TEXT_HELLO'),
+    sub: text.includes('PROBE_SUBAGENT_LEAK'),
+    side: text.includes('PROBE_SIDECHAIN_LEAK'),
+    temp: text.includes('PROBE_TEMP_LEAK'),
+    fullText: text.slice(0, 2000)
+  };
 });
 
-// 3. Select it (clicking the row toggles the checkbox via the <li> handler).
-await fixtureRow.click();
-await win.waitForTimeout(120);
+if (!visibleSids.clean) {
+  console.error('--- dialog text ---\n' + visibleSids.fullText);
+  await app.close();
+  fail('clean fixture row never appeared in ImportDialog (Case 1 setup failure)');
+}
+if (visibleSids.sub) {
+  await app.close();
+  fail('Bug B regression: sub-agent (parentUuid) transcript leaked into import list');
+}
+if (visibleSids.side) {
+  await app.close();
+  fail('Bug B regression: sidechain transcript leaked into import list');
+}
+if (visibleSids.temp) {
+  await app.close();
+  fail('Bug C regression: agentory-temp cwd transcript leaked into import list');
+}
+console.log('[probe] case 2+3 OK: only clean fixture visible (sub-agent + sidechain + agentory-temp filtered)');
 
-// 4. Click Import button. The dialog footer shows "Import 1" — match the
-//    primary CTA by name (uses the i18n importN key, English template
-//    "Import {{count}}").
+// ─── Case 1: import the clean fixture and verify history is hydrated ──────
+const fixtureRow = win.getByText('PROBE_USER_TEXT_HELLO').first();
+await fixtureRow.click();
+await win.waitForTimeout(150);
+
 const confirmBtn = win.getByRole('button', { name: /^Import 1$/ });
 await confirmBtn.waitFor({ state: 'visible', timeout: 3000 });
 await confirmBtn.click();
 
-// 5. Wait for dialog to close + store to gain a new session.
+// Wait for the imported session to appear AND for its messagesBySession entry
+// to be hydrated from the .jsonl (Bug A — the regression was that this stayed
+// empty until the user sent a follow-up).
 await win.waitForFunction(
-  () => window.__agentoryStore.getState().sessions.length === 1,
+  () => {
+    const s = window.__agentoryStore.getState();
+    if (s.sessions.length !== 1) return false;
+    const id = s.sessions[0].id;
+    const msgs = s.messagesBySession[id];
+    return Array.isArray(msgs) && msgs.length >= 2;
+  },
   null,
-  { timeout: 5000 }
+  { timeout: 8000 }
 ).catch(async () => {
-  const sessions = await win.evaluate(() => window.__agentoryStore.getState().sessions);
-  console.error('--- sessions after import ---\n' + JSON.stringify(sessions, null, 2));
+  const dump = await win.evaluate(() => {
+    const s = window.__agentoryStore.getState();
+    return {
+      sessions: s.sessions,
+      messagesBySession: s.messagesBySession
+    };
+  });
+  console.error('--- store after import ---\n' + JSON.stringify(dump, null, 2));
   console.error('--- errors ---\n' + errors.slice(-10).join('\n'));
   await app.close();
-  fail('importing fixture did not produce exactly 1 session');
+  fail('Bug A regression: imported session did not hydrate history blocks from .jsonl');
 });
 
-const newSession = await win.evaluate(() => window.__agentoryStore.getState().sessions[0]);
-if (newSession.name !== FIXTURE.title) {
+const hydrated = await win.evaluate(() => {
+  const s = window.__agentoryStore.getState();
+  const sid = s.sessions[0].id;
+  return {
+    sid,
+    blocks: s.messagesBySession[sid].map((b) => ({ kind: b.kind, text: b.text }))
+  };
+});
+const hasUser = hydrated.blocks.some((b) => b.kind === 'user' && /PROBE_USER_TEXT_HELLO/.test(b.text ?? ''));
+const hasAssistant = hydrated.blocks.some((b) => b.kind === 'assistant' && /PROBE_ASSISTANT_TEXT_REPLY/.test(b.text ?? ''));
+if (!hasUser || !hasAssistant) {
+  console.error('--- hydrated blocks ---\n' + JSON.stringify(hydrated.blocks, null, 2));
   await app.close();
-  fail(`imported session name=${newSession.name}, expected ${FIXTURE.title}`);
+  fail(`Bug A: hydrated blocks missing expected text (user=${hasUser}, assistant=${hasAssistant})`);
 }
-if (newSession.cwd !== FIXTURE.cwd) {
-  await app.close();
-  fail(`imported session cwd=${newSession.cwd}, expected ${FIXTURE.cwd}`);
-}
-
-// 6. Sidebar should now show the imported session row.
-const sidebarRow = win.locator('aside').getByText(FIXTURE.title).first();
-const sidebarVisible = await sidebarRow.isVisible().catch(() => false);
-if (!sidebarVisible) {
-  await app.close();
-  fail('imported session not visible in sidebar after import');
-}
+console.log('[probe] case 1 OK: imported session hydrated user + assistant blocks from .jsonl');
 
 console.log('\n[probe-e2e-import-session] OK');
-console.log('  sidebar Import button → ImportDialog opened');
-console.log('  fixture row rendered, selected, Import (1) committed');
-console.log(`  store gained 1 session: name="${newSession.name}", cwd="${newSession.cwd}"`);
-console.log('  sidebar shows the imported session');
+console.log('  case 1 (Bug A): history blocks hydrated immediately on import');
+console.log('  case 2 (Bug B): sub-agent (parentUuid) + sidechain (isSidechain) filtered');
+console.log('  case 3 (Bug C): agentory-temp cwd transcripts filtered');
 
 await app.close();
 
-try { fs.rmSync(userDataDir, { recursive: true, force: true }); } catch {}
+try { fs.rmSync(fakeHome, { recursive: true, force: true }); } catch {}
+try { fs.rmSync(ud.dir, { recursive: true, force: true }); } catch {}

--- a/src/components/ImportDialog.tsx
+++ b/src/components/ImportDialog.tsx
@@ -111,7 +111,8 @@ export function ImportDialog({ open, onOpenChange }: Props) {
           name: it.title,
           cwd: it.cwd,
           groupId,
-          resumeSessionId: it.sessionId
+          resumeSessionId: it.sessionId,
+          projectDir: it.projectDir
         });
       }
       onOpenChange(false);

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -119,6 +119,14 @@ declare global {
       topModel: () => Promise<string | null>;
 
       /**
+       * Read the raw frames of an importable `.jsonl` so the renderer can
+       * project them through `streamEventToTranslation` and hydrate
+       * `messagesBySession` immediately at import time. Returns [] on any
+       * read error so the caller can fall back to the empty-chat behavior.
+       */
+      loadImportHistory: (projectDir: string, sessionId: string) => Promise<unknown[]>;
+
+      /**
        * Best-effort batched existence check. Returns a map keyed by the
        * input path; permission errors and ENOENT both map to `false`.
        * Used by the renderer's hydration migration to flag sessions whose

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -6,6 +6,7 @@ import { hydrateDrafts, deleteDrafts, snapshotDraft, restoreDraft } from './draf
 import { i18next } from '../i18n';
 import type { ConnectionInfo } from '../shared/ipc-types';
 import { disposeStreamer } from '../agent/lifecycle';
+import { streamEventToTranslation } from '../agent/stream-to-blocks';
 
 // Resolve the localized default-group name with a hard-coded English fallback
 // so non-renderer call paths (tests, eager hydration before initI18n runs)
@@ -317,7 +318,7 @@ type Actions = {
   selectSession: (id: string) => void;
   focusGroup: (id: string | null) => void;
   createSession: (cwd: string | null | CreateSessionOptions) => void;
-  importSession: (opts: { name: string; cwd: string; groupId: string; resumeSessionId: string }) => string;
+  importSession: (opts: { name: string; cwd: string; groupId: string; resumeSessionId: string; projectDir?: string }) => string;
   renameSession: (id: string, name: string) => void;
   deleteSession: (id: string) => SessionSnapshot | null;
   /** Re-insert a session previously removed by `deleteSession`. Restores the
@@ -574,6 +575,85 @@ export function resolveEffectiveTheme(
 const inFlightLoads = new Set<string>();
 
 /**
+ * Project a sequence of CLI .jsonl frames (assistant / user / system / result)
+ * into our store's MessageBlock format. Mirrors the live agent's reduction
+ * (lifecycle.ts → streamEventToTranslation + setToolResult patches) but runs
+ * synchronously over a finished transcript instead of subscribing to a stream.
+ *
+ * Used by importSession() to hydrate `messagesBySession[id]` immediately on
+ * import — without this the imported chat looks empty until the user sends a
+ * follow-up that triggers `--resume` and replays history. We deliberately
+ * skip stream_event / control_request / control_response / agent_metadata
+ * frames: those are runtime-only artifacts with no rendered representation.
+ */
+export function framesToBlocks(frames: unknown[]): MessageBlock[] {
+  const out: MessageBlock[] = [];
+  for (const raw of frames) {
+    if (!raw || typeof raw !== 'object') continue;
+    const f = raw as { type?: unknown };
+    if (typeof f.type !== 'string') continue;
+    // streamEventToTranslation already silently no-ops on unrecognized
+    // types, so this is safe to feed everything to it.
+    const { append, toolResults } = streamEventToTranslation(f as { type: string });
+    if (append.length > 0) {
+      // Coalesce by id — assistant messages spread across multiple frames
+      // (parallel tool batches share the same message.id with different
+      // tool_use ids in our block-id scheme, so this is mostly a defensive
+      // dedupe rather than load-bearing). Skip duplicates by id.
+      for (const b of append) {
+        const idx = out.findIndex((x) => x.id === b.id);
+        if (idx === -1) out.push(b);
+      }
+    }
+    for (const tr of toolResults) {
+      const idx = out.findIndex(
+        (b) => (b.kind === 'tool' || b.kind === 'todo') && b.toolUseId === tr.toolUseId
+      );
+      if (idx === -1) continue;
+      const target = out[idx];
+      if (target.kind === 'tool') {
+        out[idx] = { ...target, result: tr.result, isError: tr.isError };
+      }
+      // todo blocks don't carry result text, skip — TodoWrite returns void.
+    }
+    // Plain user-text frames aren't emitted by streamEventToTranslation
+    // (the live path renders them via local-echo on send). For imported
+    // history we DO need to surface them, otherwise the chat shows only
+    // assistant turns. Pull text out of `message.content` here.
+    if (f.type === 'user') {
+      const userBlock = userFrameToBlock(raw);
+      if (userBlock) out.push(userBlock);
+    }
+  }
+  return out;
+}
+
+function userFrameToBlock(raw: unknown): MessageBlock | null {
+  const f = raw as { uuid?: unknown; message?: { content?: unknown } };
+  const content = f.message?.content;
+  let text = '';
+  if (typeof content === 'string') {
+    text = content;
+  } else if (Array.isArray(content)) {
+    for (const part of content) {
+      if (!part || typeof part !== 'object') continue;
+      const p = part as { type?: unknown; text?: unknown };
+      if (p.type === 'text' && typeof p.text === 'string') {
+        text += (text ? '\n' : '') + p.text;
+      }
+      // Skip tool_result parts — those become tool block patches above.
+    }
+  }
+  if (!text) return null;
+  // Slash-command wrappers like `<command-name>...</command-name>` carry
+  // synthetic metadata, not user-typed text. Filter them so the imported
+  // chat looks like the user remembers it.
+  if (text.startsWith('<command-')) return null;
+  const id = typeof f.uuid === 'string' && f.uuid ? `u-${f.uuid}` : `u-${Math.random().toString(36).slice(2, 10)}`;
+  return { kind: 'user', id, text };
+}
+
+/**
  * Compact one-line summary of a tool input for the post-resolution trace
  * block. Picks the most descriptive scalar field (command/path/url/...) and
  * truncates aggressively — the user just needs a hint of what was decided,
@@ -740,7 +820,7 @@ export const useStore = create<State & Actions>((set, get) => ({
     }));
   },
 
-  importSession: ({ name, cwd, groupId, resumeSessionId }) => {
+  importSession: ({ name, cwd, groupId, resumeSessionId, projectDir }) => {
     const { sessions, groups, model, models, connection } = get();
     const id = nextId('s');
     let initialModel = model;
@@ -767,6 +847,37 @@ export const useStore = create<State & Actions>((set, get) => ({
       focusedGroupId: null,
       groups: ensured.groups
     });
+    // Hydrate the imported session's chat from its `.jsonl` so the user sees
+    // the real history immediately, instead of an empty pane until they send
+    // a follow-up. We need both `projectDir` (for the on-disk path) and the
+    // resume sessionId; without `projectDir` we can't safely guess the
+    // encoded directory, so we just leave the chat empty (graceful degrade).
+    if (projectDir && typeof window !== 'undefined' && window.agentory?.loadImportHistory) {
+      const api = window.agentory;
+      void (async () => {
+        try {
+          const frames = await api.loadImportHistory(projectDir, resumeSessionId);
+          if (!Array.isArray(frames) || frames.length === 0) return;
+          const blocks = framesToBlocks(frames);
+          if (blocks.length === 0) return;
+          set((s) => ({
+            messagesBySession: {
+              ...s.messagesBySession,
+              [id]: blocks
+            }
+          }));
+          // Persist to our DB so subsequent loads come from sqlite without
+          // re-parsing the .jsonl. saveMessages is a bulk DELETE+INSERT and
+          // is idempotent.
+          if (typeof api.saveMessages === 'function') {
+            void api.saveMessages(id, blocks);
+          }
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.warn('[store] importSession history load failed', err);
+        }
+      })();
+    }
     return id;
   },
 

--- a/tests/import-scanner.test.ts
+++ b/tests/import-scanner.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { parseHead, deriveRecentCwds, deriveTopModel } from '../electron/import-scanner';
+import * as os from 'os';
+import * as path from 'path';
+import { parseHead, deriveRecentCwds, deriveTopModel, isSidechainFrame, isAgentoryTempCwd } from '../electron/import-scanner';
 
 const j = (o: unknown) => JSON.stringify(o);
 
@@ -72,6 +74,110 @@ describe('parseHead', () => {
   it('ignores malformed json lines', () => {
     const head = parseHead(['not json', j({ type: 'ai-title', aiTitle: 'OK' })]);
     expect(head?.title).toBe('OK');
+  });
+
+  it('returns null when the first frame has parentUuid set (sub-agent transcript)', () => {
+    // CLI marks Task-tool sub-agent transcripts with parentUuid on the first
+    // frame. These should be filtered out so they don't pollute the import
+    // picker — resuming one out of context produces nonsense.
+    const head = parseHead([
+      j({
+        type: 'user',
+        cwd: '/p',
+        parentUuid: 'parent-abc-123',
+        message: { content: [{ type: 'text', text: 'sub-agent prompt' }] }
+      }),
+      j({ type: 'ai-title', aiTitle: 'leaks if not filtered' })
+    ]);
+    expect(head).toBeNull();
+  });
+
+  it('returns null when the first frame has isSidechain: true', () => {
+    const head = parseHead([
+      j({
+        type: 'user',
+        cwd: '/p',
+        isSidechain: true,
+        message: { content: [{ type: 'text', text: 'sidechain' }] }
+      })
+    ]);
+    expect(head).toBeNull();
+  });
+
+  it('does NOT filter when only later frames carry parentUuid', () => {
+    // Defensive: only the FIRST frame is inspected. A normal session might
+    // legitimately reference parent uuids in later frames (e.g. when it
+    // itself spawns sub-agents) and we don't want to drop those.
+    const head = parseHead([
+      j({
+        type: 'user',
+        cwd: '/p',
+        parentUuid: null,
+        message: { content: [{ type: 'text', text: 'top-level prompt' }] }
+      }),
+      j({ type: 'user', parentUuid: 'sub-1', message: { content: 'nested' } }),
+      j({ type: 'ai-title', aiTitle: 'real session' })
+    ]);
+    expect(head?.title).toBe('real session');
+  });
+});
+
+describe('isSidechainFrame', () => {
+  it('returns true on isSidechain: true', () => {
+    expect(isSidechainFrame({ isSidechain: true })).toBe(true);
+  });
+  it('returns true on a non-empty parentUuid string', () => {
+    expect(isSidechainFrame({ parentUuid: 'abc' })).toBe(true);
+  });
+  it('returns false on parentUuid: null', () => {
+    expect(isSidechainFrame({ parentUuid: null })).toBe(false);
+  });
+  it('returns false on empty parentUuid', () => {
+    expect(isSidechainFrame({ parentUuid: '' })).toBe(false);
+  });
+  it('returns false on a missing parentUuid field', () => {
+    expect(isSidechainFrame({ type: 'user' })).toBe(false);
+  });
+  it('returns false on non-objects', () => {
+    expect(isSidechainFrame(null)).toBe(false);
+    expect(isSidechainFrame('str')).toBe(false);
+    expect(isSidechainFrame(42)).toBe(false);
+  });
+});
+
+describe('isAgentoryTempCwd', () => {
+  it('matches a Windows AppData/Local/Temp cwd with agentory- prefix', () => {
+    expect(
+      isAgentoryTempCwd('C:\\Users\\x\\AppData\\Local\\Temp\\agentory-bugl-bash-proj')
+    ).toBe(true);
+  });
+  it('matches a /tmp cwd with agentory- prefix (POSIX)', () => {
+    expect(isAgentoryTempCwd('/tmp/agentory-A2N1-changeCwd-proj-1234')).toBe(true);
+  });
+  it('matches a macOS /var/folders cwd', () => {
+    expect(
+      isAgentoryTempCwd('/var/folders/xy/abc/T/agentory-probe-foo-9999')
+    ).toBe(true);
+  });
+  it('matches the real os.tmpdir() prefix on this platform', () => {
+    const cwd = path.join(os.tmpdir(), 'agentory-test-suite-fixture');
+    expect(isAgentoryTempCwd(cwd)).toBe(true);
+  });
+  it('does NOT match a user-named directory that contains "agentory" mid-segment', () => {
+    expect(isAgentoryTempCwd('C:\\Users\\me\\my-agentory-project')).toBe(false);
+    expect(isAgentoryTempCwd('/home/me/projects/agentory-next')).toBe(false);
+  });
+  it('does NOT match a non-temp cwd even if it has the agentory- prefix', () => {
+    // The agent worktrees live under projects/, NOT temp — they ARE
+    // legitimate places the user might have done real CLI work.
+    expect(
+      isAgentoryTempCwd('C:\\Users\\me\\projects\\agentory-next\\.claude\\worktrees\\agent-deadbeef')
+    ).toBe(false);
+  });
+  it('returns false on empty / non-string input', () => {
+    expect(isAgentoryTempCwd('')).toBe(false);
+    // @ts-expect-error — runtime guard
+    expect(isAgentoryTempCwd(null)).toBe(false);
   });
 });
 

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useStore } from '../src/stores/store';
+import { framesToBlocks } from '../src/stores/store';
 
 // The store auto-subscribes to persist via hydrateStore(); since we never call
 // hydrateStore() in tests, the subscriber is never installed, so set() is
@@ -1036,6 +1037,89 @@ describe('store: importSession synthesis path', () => {
     expect(session).toBeDefined();
     expect(session!.groupId).toBe(s.groups[0].id);
     expect(session!.resumeSessionId).toBe('resume-abc');
+  });
+});
+
+describe('framesToBlocks', () => {
+  it('returns [] for empty input', () => {
+    expect(framesToBlocks([])).toEqual([]);
+  });
+
+  it('projects a user → assistant turn into matching blocks in order', () => {
+    const blocks = framesToBlocks([
+      {
+        type: 'user',
+        uuid: 'u-1',
+        message: { role: 'user', content: [{ type: 'text', text: 'hello' }] }
+      },
+      {
+        type: 'assistant',
+        session_id: 's',
+        message: {
+          id: 'msg-1',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'hi back' }]
+        }
+      }
+    ]);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toMatchObject({ kind: 'user', text: 'hello' });
+    expect(blocks[1]).toMatchObject({ kind: 'assistant', text: 'hi back' });
+  });
+
+  it('attaches tool_result content to the matching tool block', () => {
+    const blocks = framesToBlocks([
+      {
+        type: 'assistant',
+        session_id: 's',
+        message: {
+          id: 'msg-1',
+          role: 'assistant',
+          content: [
+            { type: 'tool_use', id: 'tu-1', name: 'Bash', input: { command: 'ls' } }
+          ]
+        }
+      },
+      {
+        type: 'user',
+        uuid: 'u-2',
+        message: {
+          role: 'user',
+          content: [
+            { type: 'tool_result', tool_use_id: 'tu-1', content: 'file1\nfile2' }
+          ]
+        }
+      }
+    ]);
+    const tool = blocks.find((b) => b.kind === 'tool');
+    expect(tool).toBeDefined();
+    expect(tool && (tool as { result?: string }).result).toBe('file1\nfile2');
+  });
+
+  it('skips slash-command wrapped user frames', () => {
+    const blocks = framesToBlocks([
+      {
+        type: 'user',
+        uuid: 'u-1',
+        message: { content: [{ type: 'text', text: '<command-name>/cost</command-name>' }] }
+      },
+      {
+        type: 'user',
+        uuid: 'u-2',
+        message: { content: [{ type: 'text', text: 'real prompt' }] }
+      }
+    ]);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({ kind: 'user', text: 'real prompt' });
+  });
+
+  it('ignores stream_event / control_request / agent_metadata noise', () => {
+    const blocks = framesToBlocks([
+      { type: 'stream_event', event: { type: 'content_block_delta' } },
+      { type: 'control_request', request_id: 'r' },
+      { type: 'agent_metadata', agent_id: 'a' }
+    ]);
+    expect(blocks).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

Three import-session bugs reported on dogfood, all in the same code path — fixed together (Task #219).

- **Bug A** — Imported sessions render EMPTY until the user sends a follow-up. `importSession()` created a row with `resumeSessionId` but never loaded the on-disk transcript into `messagesBySession`. Now hydrates immediately via a new `import:loadHistory` IPC + `framesToBlocks` reducer (reuses `streamEventToTranslation`), and persists to sqlite via `saveMessages` so subsequent loads come from DB.
- **Bug B** — Sub-agent (Task tool) transcripts leaked into the import picker. They carry `parentUuid` non-null OR `isSidechain: true` on the first frame; resuming one out of context produces nonsense. `readHead()` now inspects the first frame and skips the file.
- **Bug C** — Dogfood-H found 92% (169/184) of `~/.claude/projects/` entries on the user's real machine were agentory-spawned temporary dirs (paths like `<tmpdir>/agentory-…`). New `isAgentoryTempCwd` heuristic filters them in the scan loop.

## Reverse-verify (each fix independently)

For each of the three fixes, the relevant call site was temporarily disabled and the extended probe re-run:

| Bug | Disabled | Probe result |
|---|---|---|
| A | `importSession` skips the `loadImportHistory` IPC (ImportDialog stops passing `projectDir`) | `FAIL: Bug A regression: imported session did not hydrate history blocks from .jsonl` |
| B | `readHead` no longer calls `isSidechainFrame()` on the first frame | `FAIL: Bug B regression: sub-agent (parentUuid) transcript leaked into import list` |
| C | `scanImportableSessions` skips the `isAgentoryTempCwd(head.cwd)` filter | `FAIL: Bug C regression: agentory-temp cwd transcript leaked into import list` |

After restoring all three: probe passes all three cases cleanly.

## Test plan

- [x] `npm run build` — clean (renderer + electron tsc, no errors)
- [x] `npm test` — 622/634 pass; the 12 failures are pre-existing better-sqlite3 NODE_MODULE_VERSION 130 vs 127 mismatch, unrelated to this PR (same failures on `working`).
- [x] `tests/import-scanner.test.ts` — extended with parentUuid + isSidechain + isAgentoryTempCwd cases (40 tests pass)
- [x] `tests/store.test.ts` — extended with `framesToBlocks` cases (79 tests pass)
- [x] `scripts/probe-e2e-import-session.mjs` — **extended in place** per `feedback_e2e_extend_existing.md` (no new probe file). Covers all 3 bugs with planted fixtures under sandboxed HOME (per `project_probe_skill_injection.md`). Passes.
- [x] `node scripts/harness-agent.mjs` — 9/9 pass (one flake on first run, clean on retry; confirmed unrelated — flakes are in streaming caret rendering, no code touched here)
- [x] `node scripts/harness-ui.mjs` — 5/5 pass
- [x] `node scripts/harness-perm.mjs` — 9/9 pass

## Files touched

- `electron/import-history.ts` (new) — main-side `.jsonl` reader with path-traversal guards
- `electron/import-scanner.ts` — `isSidechainFrame` + `isAgentoryTempCwd` exported helpers, applied in `readHead` / `scanImportableSessions`
- `electron/main.ts` — register `import:loadHistory` IPC handler
- `electron/preload.ts` + `src/global.d.ts` — bind/type `loadImportHistory`
- `src/stores/store.ts` — `framesToBlocks` reducer + async history hydration in `importSession`
- `src/components/ImportDialog.tsx` — pass `projectDir` to `importSession`
- `tests/import-scanner.test.ts`, `tests/store.test.ts` — unit coverage
- `scripts/probe-e2e-import-session.mjs` — extended with all 3 cases + sandboxed HOME

🤖 Generated with [Claude Code](https://claude.com/claude-code)