### PR TITLE
fix(popover): global openPopoverId mutex to auto-close on cross-popover click (#221)

### DIFF
--- a/scripts/harness-ui.mjs
+++ b/scripts/harness-ui.mjs
@@ -7,12 +7,13 @@
 // excluded from the per-file runner via scripts/run-all-e2e.mjs's
 // MERGED_INTO_HARNESS skip list.
 //
-// Scope (5 cases — pure UI / store-driven, no real claude.exe required):
+// Scope (6 cases — pure UI / store-driven, no real claude.exe required):
 //   - sidebar-align             (probe-e2e-sidebar-align)
 //   - no-sessions-landing       (probe-e2e-no-sessions-landing)
 //   - empty-state-minimal       (probe-e2e-empty-state-minimal)
 //   - a11y-focus-restore        (probe-e2e-a11y-focus-restore)
 //   - shortcut-overlay-opens    (new — UI-1 / #188)
+//   - popover-cross-dismiss     (new — popover-mutex / #221)
 //
 // Related UI probes already absorbed into harness-agent.mjs:
 //   - inputbar-visible, chat-copy, input-placeholder
@@ -317,6 +318,79 @@ async function caseShortcutOverlayOpens({ win, log }) {
   log(`overlay opened via ? and Ctrl+/, ${kbdCount} kbd chips`);
 }
 
+// ---------- popover-cross-dismiss ----------
+async function casePopoverCrossDismiss({ win, log }) {
+  // Seed an active session so the StatusBar renders with the cwd chip and
+  // the model + permission ChipMenus. The model id is the trigger label,
+  // so a fixed value gives us a stable selector.
+  await win.evaluate(() => {
+    window.__agentoryStore.setState({
+      groups: [{ id: 'g1', name: 'G1', collapsed: false, kind: 'normal' }],
+      sessions: [{ id: 's1', name: 's', state: 'idle', cwd: 'C:/x', model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code' }],
+      activeId: 's1',
+      model: 'claude-opus-4',
+      models: [{ id: 'claude-opus-4', source: 'manual' }, { id: 'claude-sonnet-4', source: 'manual' }],
+      modelsLoaded: true,
+      messagesBySession: { s1: [] },
+      openPopoverId: null
+    });
+  });
+  await win.waitForTimeout(200);
+
+  const cwdChip = win.locator('[data-cwd-chip]');
+  await cwdChip.waitFor({ state: 'visible', timeout: 5000 });
+
+  // Step 1: open the cwd popover, assert visible.
+  await cwdChip.click();
+  const cwdPopover = win.locator('[role="dialog"][aria-label="Working directory"]');
+  await cwdPopover.waitFor({ state: 'visible', timeout: 3000 });
+  let openId = await win.evaluate(() => window.__agentoryStore.getState().openPopoverId);
+  if (openId !== 'cwd') throw new Error(`expected openPopoverId=cwd after cwd click, got ${openId}`);
+
+  // Step 2: click the model selector trigger.
+  const modelChip = win.locator('button', { hasText: 'claude-opus-4' });
+  await modelChip.first().click();
+
+  // Step 3: cwd popover must be hidden, model menu must be visible.
+  await win.waitForFunction(
+    () => !document.querySelector('[role="dialog"][aria-label="Working directory"]'),
+    null,
+    { timeout: 2000 }
+  ).catch(() => { throw new Error('cwd popover did not auto-close after clicking model chip'); });
+  const modelMenu = win.locator('[role="menu"]');
+  await modelMenu.first().waitFor({ state: 'visible', timeout: 3000 });
+  openId = await win.evaluate(() => window.__agentoryStore.getState().openPopoverId);
+  if (openId !== 'model') throw new Error(`expected openPopoverId=model after model click, got ${openId}`);
+
+  // Step 4: click the cwd selector trigger again.
+  await cwdChip.click();
+
+  // Step 5: model menu must be hidden, cwd popover visible.
+  await win.waitForFunction(
+    () => document.querySelectorAll('[role="menu"]').length === 0,
+    null,
+    { timeout: 2000 }
+  ).catch(() => { throw new Error('model menu did not auto-close after clicking cwd chip') });
+  await cwdPopover.waitFor({ state: 'visible', timeout: 3000 });
+  openId = await win.evaluate(() => window.__agentoryStore.getState().openPopoverId);
+  if (openId !== 'cwd') throw new Error(`expected openPopoverId=cwd after re-clicking cwd, got ${openId}`);
+
+  // Step 6 (bonus): Escape closes the cwd popover (CwdPopover's onKey
+  // listener calls closePopover('cwd')). After Escape, openPopoverId is null
+  // and no popover/menu is mounted.
+  await win.keyboard.press('Escape');
+  await win.waitForFunction(
+    () => !document.querySelector('[role="dialog"][aria-label="Working directory"]') &&
+          document.querySelectorAll('[role="menu"]').length === 0,
+    null,
+    { timeout: 2000 }
+  ).catch(() => { throw new Error('Escape did not close all popovers') });
+  openId = await win.evaluate(() => window.__agentoryStore.getState().openPopoverId);
+  if (openId !== null) throw new Error(`expected openPopoverId=null after Escape, got ${openId}`);
+
+  log('cwd→model→cwd cross-dismiss + Escape clears mutex slot');
+}
+
 // ---------- harness spec ----------
 await runHarness({
   name: 'ui',
@@ -333,6 +407,7 @@ await runHarness({
     { id: 'no-sessions-landing', run: caseNoSessionsLanding },
     { id: 'empty-state-minimal', run: caseEmptyStateMinimal },
     { id: 'a11y-focus-restore', run: caseA11yFocusRestore },
-    { id: 'shortcut-overlay-opens', run: caseShortcutOverlayOpens }
+    { id: 'shortcut-overlay-opens', run: caseShortcutOverlayOpens },
+    { id: 'popover-cross-dismiss', run: casePopoverCrossDismiss }
   ]
 });

--- a/src/components/CwdPopover.tsx
+++ b/src/components/CwdPopover.tsx
@@ -2,6 +2,13 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { ChevronDown, Folder, AlertTriangle } from 'lucide-react';
 import { cn } from '../lib/cn';
 import { useTranslation } from '../i18n/useTranslation';
+import { useStore } from '../stores/store';
+
+// Stable id for this popover in the global mutex slot. See
+// `openPopoverId` in src/stores/store.ts: opening any popover sets the id
+// (closing whatever else was open), so clicking a different chip while the
+// cwd popover is open auto-dismisses this one.
+const POPOVER_ID = 'cwd';
 
 // Typeahead popover for the StatusBar `cwd` chip.
 //
@@ -71,7 +78,13 @@ async function defaultLoadRecent(): Promise<string[]> {
 
 export function CwdPopover({ cwd, cwdMissing, loadRecent, onPick, onBrowse }: Props) {
   const { t } = useTranslation();
-  const [open, setOpen] = useState(false);
+  // Open state is owned by the store so opening any other popover (or this
+  // one's trigger again) flips us shut without local listeners. The mousedown
+  // fallback below still calls closePopover for outside clicks that don't
+  // hit another mutex-aware trigger (e.g. blank chrome).
+  const open = useStore((s) => s.openPopoverId === POPOVER_ID);
+  const openPopover = useStore((s) => s.openPopover);
+  const closePopover = useStore((s) => s.closePopover);
   const [query, setQuery] = useState('');
   const [recent, setRecent] = useState<string[]>([]);
   const [active, setActive] = useState(0);
@@ -117,11 +130,11 @@ export function CwdPopover({ cwd, cwdMissing, loadRecent, onPick, onBrowse }: Pr
       if (!target) return;
       if (popRef.current?.contains(target)) return;
       if (triggerRef.current?.contains(target)) return;
-      setOpen(false);
+      closePopover(POPOVER_ID);
     };
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
-        setOpen(false);
+        closePopover(POPOVER_ID);
       }
     };
     document.addEventListener('mousedown', onDown);
@@ -130,7 +143,7 @@ export function CwdPopover({ cwd, cwdMissing, loadRecent, onPick, onBrowse }: Pr
       document.removeEventListener('mousedown', onDown);
       document.removeEventListener('keydown', onKey);
     };
-  }, [open]);
+  }, [open, closePopover]);
 
   const filtered = useMemo(() => {
     const needle = query.trim().toLowerCase();
@@ -145,10 +158,10 @@ export function CwdPopover({ cwd, cwdMissing, loadRecent, onPick, onBrowse }: Pr
 
   const commit = useCallback(
     (path: string) => {
-      setOpen(false);
+      closePopover(POPOVER_ID);
       onPick(path);
     },
-    [onPick]
+    [onPick, closePopover]
   );
 
   const onListKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -174,7 +187,7 @@ export function CwdPopover({ cwd, cwdMissing, loadRecent, onPick, onBrowse }: Pr
         type="button"
         data-cwd-chip
         title={cwdMissing ? t('cwdPopover.cwdMissingTooltip', { cwd }) : cwd}
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => (open ? closePopover(POPOVER_ID) : openPopover(POPOVER_ID))}
         aria-haspopup="dialog"
         aria-expanded={open}
         className={cn(
@@ -280,7 +293,7 @@ export function CwdPopover({ cwd, cwdMissing, loadRecent, onPick, onBrowse }: Pr
               type="button"
               onMouseDown={(e) => {
                 e.preventDefault();
-                setOpen(false);
+                closePopover(POPOVER_ID);
                 onBrowse();
               }}
               className={cn(

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -205,6 +205,24 @@ export function InputBar({ sessionId }: { sessionId: string }) {
     if (activeIndex >= filtered.length) setActiveIndex(Math.max(0, filtered.length - 1));
   }, [pickerOpen, filtered.length, activeIndex]);
 
+  // Wire the slash picker into the global popover mutex (id: 'slash'). When
+  // the user opens any other popover (cwd / model chip / permission chip),
+  // openPopoverId moves off 'slash' and we dismiss the picker so it can't
+  // visually overlap a sibling. Conversely, opening the picker claims the
+  // slot, which auto-closes whichever popover was previously open.
+  const openPopoverId = useStore((s) => s.openPopoverId);
+  const openPopover = useStore((s) => s.openPopover);
+  const closePopover = useStore((s) => s.closePopover);
+  useEffect(() => {
+    if (pickerOpen) openPopover('slash');
+    else closePopover('slash');
+  }, [pickerOpen, openPopover, closePopover]);
+  useEffect(() => {
+    if (pickerOpen && openPopoverId !== null && openPopoverId !== 'slash') {
+      setPickerDismissed(true);
+    }
+  }, [openPopoverId, pickerOpen]);
+
   useEffect(() => {
     setValue(getDraft(sessionId));
     setAttachments(attachmentCache.get(sessionId) ?? []);

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -60,6 +60,9 @@ type ChipOption<V extends string> =
   | { kind: 'label'; primary: string };
 
 type ChipMenuProps<V extends string> = {
+  /** Stable id for the global popover-mutex slot. Two ChipMenu instances must
+   *  not share the same id. */
+  popoverId: string;
   label: string;
   triggerLabel: string;
   triggerTitle?: string;
@@ -69,6 +72,7 @@ type ChipMenuProps<V extends string> = {
 };
 
 function ChipMenu<V extends string>({
+  popoverId,
   label,
   triggerLabel,
   triggerTitle,
@@ -76,8 +80,26 @@ function ChipMenu<V extends string>({
   options,
   onSelect
 }: ChipMenuProps<V>) {
+  // Bind Radix's controlled `open` to the global mutex slot so opening any
+  // other popover (or another ChipMenu) auto-closes this one. Radix would
+  // otherwise own its open state internally and never react to a sibling's
+  // openPopoverId change.
+  const open = useStore((s) => s.openPopoverId === popoverId);
+  const openPopover = useStore((s) => s.openPopover);
+  const closePopover = useStore((s) => s.closePopover);
   return (
-    <DropdownMenu>
+    <DropdownMenu
+      open={open}
+      // Non-modal: clicks on other StatusBar chips (cwd, sibling chip) must
+      // reach their triggers and route through the global popover mutex —
+      // the default modal=true installs a pointer-events guard on <body> that
+      // blocks every click outside the menu, breaking cross-popover dismiss.
+      modal={false}
+      onOpenChange={(next) => {
+        if (next) openPopover(popoverId);
+        else closePopover(popoverId);
+      }}
+    >
       <DropdownMenuTrigger asChild>
         <Chip title={triggerTitle} accent={triggerAccent}>{triggerLabel}</Chip>
       </DropdownMenuTrigger>
@@ -197,6 +219,7 @@ export function StatusBar({
     cwdChip,
     <ChipMenu
       key="model"
+      popoverId="model"
       label={t('statusBar.model')}
       triggerLabel={modelTriggerLabel}
       options={modelOptions}
@@ -204,6 +227,7 @@ export function StatusBar({
     />,
     <ChipMenu
       key="permission"
+      popoverId="permission"
       label={t('statusBar.permissionMode')}
       triggerLabel={primaryOf(permissionOptions, permission)}
       triggerTitle={permissionTooltips[permission]}

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -273,6 +273,17 @@ type State = {
    * launch.
    */
   allowAlwaysTools: string[];
+  /**
+   * Id of the currently-open popover/menu, or null when nothing is open. A
+   * single global slot enforces mutual exclusion: opening any popover sets
+   * the id (implicitly closing whatever was previously open), closing sets
+   * it back to null. Each popover binds its open state to
+   * `useStore(s => s.openPopoverId === '<my-id>')`.
+   *
+   * NOT persisted — popover open state must not survive reload (would land
+   * the user on a randomly-open menu after restart).
+   */
+  openPopoverId: string | null;
 };
 
 export interface CreateSessionOptions {
@@ -416,6 +427,19 @@ type Actions = {
   setSessionInitFailure: (sessionId: string, fail: Omit<SessionInitFailure, 'timestamp'>) => void;
   /** Clear the init-failure flag after a successful retry or cwd/model repick. */
   clearSessionInitFailure: (sessionId: string) => void;
+
+  /**
+   * Open the popover/menu identified by `id`. Sets `openPopoverId` to `id`,
+   * which implicitly closes any other popover currently bound to the same
+   * slot. Safe to call when already open (no-op).
+   */
+  openPopover: (id: string) => void;
+  /**
+   * Close the popover/menu identified by `id`, but ONLY if it's currently the
+   * open one. Idempotent: a stale close from a popover that was already
+   * superseded by another opener won't clobber the new owner's slot.
+   */
+  closePopover: (id: string) => void;
 };
 
 function nextId(prefix: string): string {
@@ -719,6 +743,7 @@ export const useStore = create<State & Actions>((set, get) => ({
   diagnostics: [],
   sessionInitFailures: {},
   allowAlwaysTools: [],
+  openPopoverId: null,
 
   selectSession: (id) => {
     set((s) => ({
@@ -1694,6 +1719,14 @@ export const useStore = create<State & Actions>((set, get) => ({
 
   bumpComposerFocus: () => {
     set((s) => ({ focusInputNonce: s.focusInputNonce + 1 }));
+  },
+
+  openPopover: (id) => {
+    set((s) => (s.openPopoverId === id ? s : { openPopoverId: id }));
+  },
+
+  closePopover: (id) => {
+    set((s) => (s.openPopoverId === id ? { openPopoverId: null } : s));
   },
 
   loadModels: async () => {

--- a/tests/cwd-popover.test.tsx
+++ b/tests/cwd-popover.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import { CwdPopover } from '../src/components/CwdPopover';
+import { useStore } from '../src/stores/store';
 
 const SAMPLE = [
   '/home/alice/projects/agentory',
@@ -41,6 +42,13 @@ async function openPopover() {
 }
 
 describe('<CwdPopover />', () => {
+  // The popover's open state now lives on the global store (PR #221:
+  // openPopoverId mutex). Reset between tests so a leftover "cwd" slot from
+  // the previous case doesn't make the next click toggle the popover shut.
+  beforeEach(() => {
+    useStore.setState({ openPopoverId: null });
+  });
+
   it('renders the trigger labelled with the last cwd path segment', () => {
     renderPopover();
     expect(screen.getByRole('button', { name: /agentory/i })).toBeInTheDocument();

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -1261,3 +1261,51 @@ describe('store: appendBlocks perf path (concat)', () => {
   });
 });
 
+
+describe('store: openPopover / closePopover (global popover mutex)', () => {
+  it('initial openPopoverId is null', () => {
+    expect(useStore.getState().openPopoverId).toBeNull();
+  });
+
+  it('openPopover sets the slot to the requested id', () => {
+    useStore.getState().openPopover('cwd');
+    expect(useStore.getState().openPopoverId).toBe('cwd');
+  });
+
+  it('opening a different popover replaces the previous (mutual exclusion)', () => {
+    useStore.getState().openPopover('cwd');
+    useStore.getState().openPopover('model');
+    expect(useStore.getState().openPopoverId).toBe('model');
+  });
+
+  it('closePopover only clears when the requested id matches', () => {
+    useStore.getState().openPopover('model');
+    // Stale close from a popover that was already superseded must NOT clobber
+    // the active owner's slot. This is the key invariant that prevents
+    // race-y unmount cleanups from closing the popover the user just opened.
+    useStore.getState().closePopover('cwd');
+    expect(useStore.getState().openPopoverId).toBe('model');
+    useStore.getState().closePopover('model');
+    expect(useStore.getState().openPopoverId).toBeNull();
+  });
+
+  it('opening the same id twice is a no-op (no state churn)', () => {
+    useStore.getState().openPopover('cwd');
+    const before = useStore.getState();
+    useStore.getState().openPopover('cwd');
+    const after = useStore.getState();
+    // Reference equality: the action returns the same state object, so
+    // subscribers don't get a spurious re-render.
+    expect(after).toBe(before);
+    expect(after.openPopoverId).toBe('cwd');
+  });
+
+  it('closePopover when nothing is open is a no-op', () => {
+    expect(useStore.getState().openPopoverId).toBeNull();
+    const before = useStore.getState();
+    useStore.getState().closePopover('cwd');
+    const after = useStore.getState();
+    expect(after).toBe(before);
+    expect(after.openPopoverId).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the systemic popover mutual-exclusion bug (issue #221): opening CwdPopover and then clicking the model selector left CwdPopover stuck open. Audit found the root cause is structural — every popover owned its own local open state, so siblings had no way to dismiss each other.

**Approach:** lift a single global `openPopoverId: string | null` slot to the zustand store. Each popover binds its open flag to `useStore(s => s.openPopoverId === '<my-id>')`. Opening any popover sets the slot (implicitly closing whichever was previously open); closing only clears when the requested id matches (idempotent — a stale unmount cleanup can't clobber the new owner).

## Files changed

- `src/stores/store.ts` — `openPopoverId` state + `openPopover(id)` / `closePopover(id)` actions. NOT in `PERSISTED_KEYS` (popover state must not survive reload — `persisted-keys-source-of-truth` guard already enforces).
- `src/components/CwdPopover.tsx` — replaces local `useState(open)` with the store binding. Click-outside + Escape listener still calls `closePopover('cwd')` as a fallback.
- `src/components/StatusBar.tsx` — `ChipMenu` (model + permission) converted to controlled Radix `DropdownMenu` with `open`/`onOpenChange`. `modal={false}` so clicks on sibling status-bar chips reach their triggers and route through the mutex (default modal=true installs a body pointer-events guard that swallows cross-chip clicks).
- `src/components/InputBar.tsx` — slash picker joins the mutex via two effects: claim/release on `pickerOpen`, dismiss when `openPopoverId` moves to a non-slash owner.
- `tests/store.test.ts` — 6 new cases for openPopover/closePopover semantics.
- `tests/cwd-popover.test.tsx` — reset `openPopoverId` in `beforeEach` (shared store).
- `scripts/harness-ui.mjs` — new `popover-cross-dismiss` case (extended existing harness per `feedback_e2e_extend_existing.md`).

## E2E case — `popover-cross-dismiss`

1. Open cwd popover, assert visible + `openPopoverId === 'cwd'`.
2. Click model chip → assert cwd popover hidden, model menu visible, `openPopoverId === 'model'`.
3. Re-click cwd chip → assert model menu gone, cwd popover visible, `openPopoverId === 'cwd'`.
4. Escape → assert both gone, `openPopoverId === null`.

## Reverse-verify

`git stash push -- src/stores/store.ts` (only) → rebuild → run `node scripts/harness-ui.mjs --only=popover-cross-dismiss`:

- **Without the fix:** FAIL at step 1 (`locator('[data-cwd-chip]')` never visible — renderer crashes during render because `openPopover` / `closePopover` are undefined).
- **Restore stash + rebuild:** PASS.

## Test counts

- vitest: 640 passed / 12 pre-existing better-sqlite3 native ABI failures in `electron/__tests__/db*.test.ts` (unrelated env issue).
- harness-ui: 6/6 (added `popover-cross-dismiss`).
- harness-agent: 9/9.
- harness-perm: 9/9.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` (only pre-existing native module failures remain)
- [x] `node scripts/harness-ui.mjs` — 6/6
- [x] `node scripts/harness-agent.mjs` — 9/9
- [x] `node scripts/harness-perm.mjs` — 9/9
- [x] Reverse-verify: stash store.ts → harness FAIL; restore → PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)