### PR TITLE
fix(agent): validate persisted claudeBinPath, self-heal stale value (P0 blocker)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -689,7 +689,18 @@ app.whenReady().then(() => {
         };
       }
 
-      const binaryPath = loadClaudeBinPath() ?? undefined;
+      // Validate the persisted path exists on disk. A stale entry (e.g. from a
+      // dev probe whose temp dir was GC'd) would otherwise be passed to the
+      // spawner verbatim, bypassing resolveClaudeBinary() and producing an
+      // opaque "system cannot find the path specified" exit instead of the
+      // CLI-missing dialog. Self-heal by clearing the dead value so subsequent
+      // launches fall through to PATH lookup / first-run wizard.
+      const persisted = loadClaudeBinPath();
+      const binaryPath =
+        persisted && fs.existsSync(persisted) ? persisted : undefined;
+      if (persisted && !binaryPath) {
+        saveClaudeBinPath(null);
+      }
 
       const result = await sessions.start(sessionId, {
         ...opts,

--- a/scripts/probe-cli-missing.mjs
+++ b/scripts/probe-cli-missing.mjs
@@ -1,12 +1,23 @@
 // Live probe for the "Claude CLI not found" first-run wizard.
 //
-// Runs against the built app with AGENTORY_CLAUDE_BIN pointing at a non-
-// existent file so the resolver falls back to a scrubbed PATH and flips the
-// store into `missing` state. Asserts:
+// Case A (original): Runs against the built app with AGENTORY_CLAUDE_BIN
+// pointing at a non-existent file so the resolver falls back to a scrubbed
+// PATH and flips the store into `missing` state. Asserts:
 //   - The blocking modal renders with title + body.
 //   - OS-appropriate install commands are visible.
 //   - Copy button writes the command to the clipboard.
 //   - Browse (stubbed via dialog monkey-patch) succeeds and closes the modal.
+//
+// Case B (stale persisted binPath, P0 regression — see fix/stale-binpath-p0):
+//   - Pre-seeds the SQLite `app_state` table with `claudeBinPath` pointing
+//     at a path that does not exist on disk (mimics a dev probe whose temp
+//     dir was GC'd).
+//   - Calls `agent:start` directly with empty PATH.
+//   - Asserts `errorCode === 'CLAUDE_NOT_FOUND'` (NOT a generic spawn
+//     error) and that the stale row was self-healed (DB row cleared).
+//   - Reverse-verify: stash the validation block in electron/main.ts → this
+//     case must FAIL because spawn dies via cmd.exe with "system cannot
+//     find the path specified" and CLAUDE_NOT_FOUND is never raised.
 //
 // Env vars understood:
 //   AGENTORY_FAKE_CLAUDE   path to a fake binary whose `--version` outputs
@@ -19,7 +30,7 @@ import path from 'node:path';
 import fs from 'node:fs';
 import os from 'node:os';
 import { fileURLToPath } from 'node:url';
-import { appWindow } from './probe-utils.mjs';
+import { appWindow, isolatedUserData } from './probe-utils.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
@@ -151,4 +162,130 @@ try {
   fs.rmSync(tmp, { recursive: true, force: true });
 } catch {
   /* ignore */
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Case B: stale persisted claudeBinPath self-heals on agent:start.
+// ─────────────────────────────────────────────────────────────────────────────
+// Regression guard for the P0 first-message-fails-on-prod-install bug.
+// Pre-condition: SQLite has `claudeBinPath = <non-existent path>`. Without
+// the fix, agent:start would forward this to spawnClaude(), which routes a
+// `.cmd` extension through cmd.exe and exits with a generic "system cannot
+// find the path specified" — CLAUDE_NOT_FOUND is never raised, so the
+// CliMissingDialog never shows and the user is stuck. The fix validates the
+// persisted path before forwarding and clears the dead row.
+{
+  const ud = isolatedUserData('probe-cli-missing-stalebinpath');
+
+  // Pre-seed parameters: a path that points at a definitely-non-existent
+  // file. Using a Windows-style fake .cmd path mirrors the real-world repro
+  // (a leftover entry from a probe like Case A above).
+  const stalePath =
+    process.platform === 'win32'
+      ? path.join(ud.dir, 'gone', 'fake-claude.cmd')
+      : path.join(ud.dir, 'gone', 'fake-claude.sh');
+
+  // Sanitize HOME / USERPROFILE so the developer's ~/.claude skills do not
+  // leak into the spawned CLI's environment (per
+  // memory/project_probe_skill_injection.md — relevant for any probe that
+  // launches electron and may end up spawning the real CLI).
+  const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'probe-binpath-home-'));
+
+  const app2 = await electron.launch({
+    args: ['.', `--user-data-dir=${ud.dir}`],
+    cwd: root,
+    env: {
+      ...process.env,
+      NODE_ENV: 'development',
+      HOME: fakeHome,
+      USERPROFILE: fakeHome,
+    },
+  });
+
+  // Empty PATH so resolveClaudeBinary throws ClaudeNotFoundError after the
+  // self-heal fires. Otherwise a real claude on PATH could mask the bug by
+  // succeeding through the resolver fall-through.
+  await app2.evaluate(async () => {
+    process.env.PATH = '';
+    process.env.path = '';
+    if (process.platform === 'win32') process.env.PATHEXT = '';
+    delete process.env.AGENTORY_CLAUDE_BIN;
+  });
+
+  const win2 = await appWindow(app2);
+  await win2.waitForLoadState('domcontentloaded');
+  await win2.waitForFunction(() => !!window.agentory?.agentStart, null, {
+    timeout: 10_000,
+  });
+
+  // Seed claudeBinPath via the same IPC the renderer uses for state writes.
+  // This mirrors how the production app would have ended up with a stale
+  // value (the first-run wizard's saveClaudeBinPath path under the hood
+  // routes through the same app_state row).
+  await win2.evaluate(async (p) => {
+    await window.agentory.saveState('claudeBinPath', p);
+  }, stalePath);
+
+  // Sanity: the seed actually landed.
+  const seeded = await win2.evaluate(async () => {
+    return await window.agentory.loadState('claudeBinPath');
+  });
+  if (seeded !== stalePath) {
+    await app2.close();
+    ud.cleanup();
+    try { fs.rmSync(fakeHome, { recursive: true, force: true }); } catch {}
+    fail(`pre-seed failed: claudeBinPath read back as ${JSON.stringify(seeded)}`);
+  }
+
+  // Drive agent:start directly so we observe its return shape — this is
+  // exactly the path InputBar takes on first message send. We pass `cwd:
+  // root` (this repo) so the CWD existsSync guard is satisfied; the only
+  // thing under test is binaryPath validation + CLAUDE_NOT_FOUND surfacing.
+  const startResult = await win2.evaluate(async (cwd) => {
+    return await window.agentory.agentStart('probe-stale-binpath-session', { cwd });
+  }, root);
+
+  if (startResult.ok) {
+    await app2.close();
+    ud.cleanup();
+    try { fs.rmSync(fakeHome, { recursive: true, force: true }); } catch {}
+    fail(
+      'agent:start unexpectedly succeeded with stale binPath + empty PATH; ' +
+        'expected ok:false errorCode:CLAUDE_NOT_FOUND'
+    );
+  }
+  if (startResult.errorCode !== 'CLAUDE_NOT_FOUND') {
+    await app2.close();
+    ud.cleanup();
+    try { fs.rmSync(fakeHome, { recursive: true, force: true }); } catch {}
+    fail(
+      `agent:start returned the wrong errorCode for stale binPath. ` +
+        `Expected CLAUDE_NOT_FOUND, got ${JSON.stringify(startResult)}. ` +
+        `This is the P0 regression: stale binPath bypasses resolveClaudeBinary().`
+    );
+  }
+
+  // Self-heal assertion: the stale row must have been cleared from the DB so
+  // a subsequent launch falls cleanly into the resolver / first-run wizard
+  // instead of hitting the same dead path forever.
+  const after = await win2.evaluate(async () => {
+    return await window.agentory.loadState('claudeBinPath');
+  });
+  if (after !== null) {
+    await app2.close();
+    ud.cleanup();
+    try { fs.rmSync(fakeHome, { recursive: true, force: true }); } catch {}
+    fail(
+      `stale claudeBinPath was NOT self-healed after agent:start. ` +
+        `Read back: ${JSON.stringify(after)}`
+    );
+  }
+
+  await app2.close();
+  ud.cleanup();
+  try { fs.rmSync(fakeHome, { recursive: true, force: true }); } catch {}
+
+  console.log('\n[probe-cli-missing] OK (case B: stale binPath)');
+  console.log('  agent:start: returned errorCode CLAUDE_NOT_FOUND as expected');
+  console.log('  self-heal:   stale claudeBinPath row cleared from DB');
 }


### PR DESCRIPTION
**P0 — first message fails on prod install. Reviewer: please prioritize.**

## Summary
- `electron/main.ts` `agent:start` was forwarding the persisted `claudeBinPath` from SQLite to `spawnClaude()` without checking whether the file still exists.
- A stale entry (e.g. a fake `.cmd` left behind by a dev probe whose temp dir was GC'd, like `C:\...\Temp\probe-cli-missing-Aesr8Z\fake-claude.cmd`) bypasses `resolveClaudeBinary()` entirely. On Windows the `.cmd` extension routes through `cmd.exe`, which exits with `"The system cannot find the path specified"`. `CLAUDE_NOT_FOUND` is **never** raised, so `CliMissingDialog` never fires and the user is permanently stuck.
- Reverse-verify revealed an even nastier surface: without the fix, `agent:start` returns `ok:true` (the spawn-side error doesn't propagate to start), so there is no banner either — silent failure.
- Fix at the call site: validate `existsSync` and self-heal the dead row. Only one unsafe consumer; `cli:retryDetect` already does this check (electron/main.ts:967).

## Diff
- `electron/main.ts` (+13/-2): existsSync guard + `saveClaudeBinPath(null)` self-heal in the `agent:start` handler.
- `scripts/probe-cli-missing.mjs` (+140/-5): extend the existing CLI-missing probe with **Case B** — pre-seed `claudeBinPath` via `saveState` IPC, drive `agent:start`, assert `errorCode === 'CLAUDE_NOT_FOUND'` and DB row cleared. HOME/USERPROFILE sanitized per `project_probe_skill_injection.md`.

## Reverse-verify (per `feedback_bugfix_requires_e2e.md`)
| step | result |
|---|---|
| `git stash push electron/main.ts` (revert fix only) | done |
| `npx tsc -p tsconfig.electron.json` | done |
| `node scripts/probe-cli-missing.mjs` | **FAIL** as expected: `agent:start unexpectedly succeeded with stale binPath + empty PATH; expected ok:false errorCode:CLAUDE_NOT_FOUND` |
| `git stash pop` + rebuild | restored |
| `node scripts/probe-cli-missing.mjs` | **PASS** both Case A + Case B |

## Harness counts
- agent: **9/9** pass
- ui: **5/5** pass
- perm: **8/9** pass — `permission-a11y` flake is pre-existing on `working` baseline (verified by stashing the fix and re-running). Not introduced by this PR.

## Test plan
- [x] Existing `probe-cli-missing.mjs` Case A still passes
- [x] New Case B passes with fix
- [x] Reverse-verified: Case B fails without fix
- [x] All three harnesses run; only pre-existing failures remain
- [ ] Reviewer: confirm reverse-verify by repeating stash/probe locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)