### PR TITLE
fix(a11y): derive TopBanner role from variant (alert vs status)

### DIFF
--- a/src/components/chrome/TopBanner.tsx
+++ b/src/components/chrome/TopBanner.tsx
@@ -25,7 +25,7 @@ export interface TopBannerProps {
   /**
    * Short, sentence-case headline (e.g. "Agent failed to start").
    * Required because every banner needs a scannable label for the
-   * `role="alert"` announcement.
+   * live-region announcement (role derived from `variant`).
    */
   title: string;
   /**
@@ -81,12 +81,13 @@ const VARIANT_STYLES: Record<TopBannerVariant, string> = {
  * dismiss-button placement stay consistent.
  *
  * Accessibility:
- *   - `role="alert"` on the inner row so screen readers announce the
- *     contents when the banner appears, even though it's outside the
- *     focused element.
- *   - `aria-live="polite"` so a NEW banner replacing an existing one
- *     gets re-announced without interrupting whatever the user is
- *     currently typing/reading.
+ *   - ARIA role is derived from `variant` so screen readers don't
+ *     over-announce non-critical state:
+ *       error            → `role="alert"`   (assertive semantics; blocking failure)
+ *       warning | info   → `role="status"`  (advisory; politely announced)
+ *     Both roles pair with `aria-live="polite"` so a NEW banner
+ *     replacing an existing one gets re-announced without interrupting
+ *     whatever the user is currently typing/reading.
  *   - Dismiss button has an explicit `aria-label` (defaulting to
  *     "Dismiss") so it isn't announced as just "×".
  *
@@ -106,6 +107,12 @@ export function TopBanner({
   testId,
   className,
 }: TopBannerProps) {
+  // Match ARIA role to severity. `alert` is assertive and intended for
+  // blocking failures; warning/info are advisory and should use the
+  // gentler `status` role so screen readers don't treat them as
+  // interruptions. `aria-live="polite"` is kept for both so the queued
+  // announcement still happens.
+  const role = variant === 'error' ? 'alert' : 'status';
   return (
     <motion.div
       key={presenceKey}
@@ -119,7 +126,7 @@ export function TopBanner({
       data-testid={testId}
     >
       <div
-        role="alert"
+        role={role}
         aria-live="polite"
         className={cn(
           'flex items-center gap-2 px-3 py-2 border-b border-border-subtle',

--- a/tests/top-banner.test.tsx
+++ b/tests/top-banner.test.tsx
@@ -23,7 +23,7 @@ afterEach(() => {
 });
 
 describe('<TopBanner />', () => {
-  it('renders title, body, actions, and dismiss with role="alert" + aria-live="polite"', () => {
+  it('renders title, body, actions, and dismiss with role="alert" + aria-live="polite" for error variant', () => {
     const onDismiss = vi.fn();
     const onAction = vi.fn();
     render(
@@ -55,6 +55,23 @@ describe('<TopBanner />', () => {
     const dismiss = screen.getByRole('button', { name: 'Dismiss' });
     fireEvent.click(dismiss);
     expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses role="status" (not "alert") for warning variant so screen readers do not over-announce', () => {
+    render(<TopBanner variant="warning" title="Heads up" />);
+    const status = screen.getByRole('status');
+    expect(status).toHaveAttribute('aria-live', 'polite');
+    expect(status).toHaveTextContent('Heads up');
+    // Warning must NOT register as an assertive alert.
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('uses role="status" (not "alert") for info variant so screen readers do not over-announce', () => {
+    render(<TopBanner variant="info" title="FYI" />);
+    const status = screen.getByRole('status');
+    expect(status).toHaveAttribute('aria-live', 'polite');
+    expect(status).toHaveTextContent('FYI');
+    expect(screen.queryByRole('alert')).toBeNull();
   });
 
   it('omits the dismiss button when onDismiss is not supplied', () => {
@@ -124,7 +141,7 @@ describe('banner trio integration', () => {
       true
     );
     render(<AgentDiagnosticBanner />);
-    const alert = screen.getByRole('alert');
+    const alert = screen.getByRole('status');
     expect(alert).toHaveAttribute('aria-live', 'polite');
     expect(document.querySelector('[data-top-banner]')).toHaveAttribute('data-variant', 'warning');
     expect(screen.getByText('Agent warning')).toBeInTheDocument();
@@ -168,7 +185,7 @@ describe('banner trio integration', () => {
       true
     );
     render(<ClaudeCliMissingBanner />);
-    const alert = screen.getByRole('alert');
+    const alert = screen.getByRole('status');
     expect(alert).toHaveAttribute('aria-live', 'polite');
     expect(document.querySelector('[data-top-banner]')).toHaveAttribute('data-variant', 'warning');
     // Set-up CTA exists; dismiss button does NOT (banner is state-driven, not user-dismissible).


### PR DESCRIPTION
## Summary
- Address PR #207 reviewer feedback (Task #261): `TopBanner` applied `role=\"alert\"` to every variant. `alert` is assertive semantics meant for blocking failures; using it for warning/info caused screen readers to over-announce non-critical state.
- Derive role from `variant`:
  - `error` -> `role=\"alert\"`
  - `warning` | `info` -> `role=\"status\"`
- `aria-live=\"polite\"` is kept on both roles so newly-swapped banners still get re-announced.
- Updated JSDoc on `TopBanner` to document the role mapping; updated `title` prop comment to drop the now-misleading `role=\"alert\"` reference.

## Test plan
- [x] `npx vitest run tests/top-banner.test.tsx` -> 10 passed (added 2 new cases asserting warning/info expose `role=\"status\"` and NOT `alert`; updated 2 integration cases that previously queried the wrong role).
- [ ] No visual change -> no screenshots needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)