### PR TITLE
chore(mock): rename agentory fixtures to ccsm in mock/data (#262)

### DIFF
--- a/src/mock/data.ts
+++ b/src/mock/data.ts
@@ -48,10 +48,10 @@ export const activeSessionId = 's2';
 export type RecentProject = { id: string; name: string; path: string };
 
 export const mockRecentProjects: RecentProject[] = [
-  { id: 'p1', name: 'agentory', path: '~/projects/agentory' },
+  { id: 'p1', name: 'ccsm', path: '~/projects/ccsm' },
   { id: 'p2', name: 'payments-api', path: '~/projects/payments-api' },
   { id: 'p3', name: 'inference-svc', path: '~/projects/inference-svc' },
   { id: 'p4', name: 'identity-svc', path: '~/projects/identity-svc' },
-  { id: 'p5', name: 'agentory', path: '~/projects/agentory' },
+  { id: 'p5', name: 'ccsm', path: '~/projects/ccsm' },
   { id: 'p6', name: 'webhook-gateway', path: '~/projects/webhook-gateway' }
 ];


### PR DESCRIPTION
## Summary
- Replaces the two remaining `agentory` literals in `src/mock/data.ts` (`mockRecentProjects` entries `p1` and `p5`) with `ccsm` equivalents.
- Closes the leftover from PR #208 reviewer feedback. These fixtures are not referenced at runtime (only the `RecentProject` type is imported elsewhere), but they leaked the old brand.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — all 660 tests pass (50 files); current tree is 660, not the 652 referenced in the task brief (additional tests landed on `working`).

Task: #262

Generated with Claude Code