### PR TITLE
fix(i18n): require ConfirmDialog confirmLabel/cancelLabel (U5 #257)

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -291,6 +291,7 @@ function GroupRow({
             : t('sidebar.deleteGroupEmpty')
         }
         confirmLabel={t('sidebar.deleteGroup')}
+        cancelLabel={t('common.cancel')}
         destructive
         onConfirm={() => {
           const snap = deleteGroup(group.id);

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -7,8 +7,10 @@ type ConfirmDialogProps = {
   onOpenChange: (open: boolean) => void;
   title: string;
   description?: React.ReactNode;
-  confirmLabel?: string;
-  cancelLabel?: string;
+  // Required so callers cannot fall back to English literals and silently
+  // leak en into other locales. Always pass via the i18n hook (t(...)).
+  confirmLabel: string;
+  cancelLabel: string;
   destructive?: boolean;
   onConfirm: () => void;
   /**
@@ -28,8 +30,8 @@ export function ConfirmDialog({
   onOpenChange,
   title,
   description,
-  confirmLabel = 'Confirm',
-  cancelLabel = 'Cancel',
+  confirmLabel,
+  cancelLabel,
   destructive = false,
   onConfirm,
   onCancel
@@ -84,6 +86,7 @@ export function ConfirmDialog({
               ref={cancelRef}
               variant="secondary"
               size="md"
+              data-testid="confirm-dialog-cancel"
             >
               {cancelLabel}
             </Button>
@@ -91,6 +94,7 @@ export function ConfirmDialog({
           <Button
             variant={destructive ? 'danger' : 'primary'}
             size="md"
+            data-testid="confirm-dialog-confirm"
             onClick={() => {
               confirmingRef.current = true;
               onConfirm();


### PR DESCRIPTION
## Summary
- Make `confirmLabel` and `cancelLabel` required props on `ConfirmDialog` so TypeScript blocks any caller that would silently fall back to English `'Confirm'`/`'Cancel'` literals.
- Add `data-testid=\"confirm-dialog-confirm\"` and `data-testid=\"confirm-dialog-cancel\"` on the two action buttons for future e2e probes.
- Update the only existing caller (Sidebar delete-group dialog) to pass `t('common.cancel')` explicitly. `common.cancel` already exists in both en/zh locales.

Refs U5 audit task #257.

## Test plan
- [x] `npx tsc --noEmit` clean (renderer + electron tsconfigs)
- [x] `npm test` -> 660/660 passing
- [ ] Manual: open Sidebar -> right-click a normal group -> Delete; verify both buttons render localized text in zh and en.