### PR TITLE
fix(a11y): announce Test notification result via aria-live (audit SD6)

### DIFF
--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -493,7 +493,15 @@ function NotificationsPane() {
         <Button variant="secondary" size="md" onClick={onTest} disabled={disableChildren}>
           {t('notifications.testButton')}
         </Button>
-        {testStatus && <span className="text-meta text-fg-secondary">{testStatus}</span>}
+        <span
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          data-testid="notifications-test-status"
+          className="text-meta text-fg-secondary"
+        >
+          {testStatus ?? ''}
+        </span>
       </div>
       <div className="mt-6 pt-5 border-t border-border-subtle">
         <CrashReportingField />

--- a/tests/settings-test-notification.test.tsx
+++ b/tests/settings-test-notification.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import React from 'react';
+import { useStore } from '../src/stores/store';
+import { SettingsDialog } from '../src/components/SettingsDialog';
+
+const initial = useStore.getState();
+
+function resetStore() {
+  useStore.setState({ ...initial }, true);
+}
+
+beforeEach(() => {
+  resetStore();
+  (window as unknown as { ccsm: unknown }).ccsm = {
+    notify: vi.fn(async () => true),
+    loadState: vi.fn(async () => null),
+    saveState: vi.fn(async () => undefined),
+  };
+});
+
+afterEach(() => {
+  delete (window as { ccsm?: unknown }).ccsm;
+});
+
+describe('SettingsDialog notifications test-notification status (SD6)', () => {
+  it('exposes the status text via role="status" + aria-live="polite" so screen readers announce it', async () => {
+    await act(async () => {
+      render(<SettingsDialog open onOpenChange={() => {}} initialTab="notifications" />);
+    });
+
+    // Live region must be present in the DOM before the click so the
+    // assistive-tech reader registers it as a live area; otherwise nodes
+    // that mount with the message are often missed.
+    const live = screen.getByTestId('notifications-test-status');
+    expect(live).toHaveAttribute('role', 'status');
+    expect(live).toHaveAttribute('aria-live', 'polite');
+    expect(live.textContent).toBe('');
+
+    const btn = (await screen.findByRole('button', { name: /test notification/i })) as HTMLButtonElement;
+    await act(async () => {
+      btn.click();
+    });
+
+    await waitFor(() => {
+      expect(live.textContent).toMatch(/sent\./i);
+    });
+    // Attributes must remain present after the status updates so the
+    // announcement is delivered as a polite live-region update, not a
+    // separate node insertion the screen reader could miss.
+    expect(live).toHaveAttribute('role', 'status');
+    expect(live).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('announces the failure message via the same live region when notify returns false', async () => {
+    (window.ccsm as { notify: ReturnType<typeof vi.fn> }).notify = vi.fn(async () => false);
+
+    await act(async () => {
+      render(<SettingsDialog open onOpenChange={() => {}} initialTab="notifications" />);
+    });
+
+    const live = screen.getByTestId('notifications-test-status');
+    const btn = (await screen.findByRole('button', { name: /test notification/i })) as HTMLButtonElement;
+    await act(async () => {
+      btn.click();
+    });
+
+    await waitFor(() => {
+      expect(live.textContent).toMatch(/failed/i);
+    });
+    expect(live).toHaveAttribute('aria-live', 'polite');
+  });
+});


### PR DESCRIPTION
## Summary
- SettingsDialog's Notifications tab updates a transient status string (Sent / Failed / IPC unavailable) on the Test notification button. Previously it lived in a plain `<span>` that only mounted while the message was visible — no `role="status"`, no `aria-live`, so screen readers never announced the outcome.
- Render the status span unconditionally with `role=\"status\"`, `aria-live=\"polite\"` and `aria-atomic=\"true\"`. Empty content when idle keeps the visual layout untouched.
- Adds `tests/settings-test-notification.test.tsx` covering both success and failure paths through the same live region.

## Before / after

```jsx
// before
{testStatus && <span className=\"text-meta text-fg-secondary\">{testStatus}</span>}

// after
<span
  role=\"status\"
  aria-live=\"polite\"
  aria-atomic=\"true\"
  data-testid=\"notifications-test-status\"
  className=\"text-meta text-fg-secondary\"
>
  {testStatus ?? ''}
</span>
```

## Test plan
- [x] `npm test` — 662 passed, 51 files green.
- [x] New test asserts attrs are present both before and after click, and covers `notify -> true` (Sent.) and `notify -> false` (Failed - OS notifications unavailable.) via the same live region.
- [ ] Manual SR pass (VoiceOver / NVDA): open Settings → Notifications → press Test notification → SR announces "Sent." (or failure copy).

## Notes
- DO NOT MERGE — task spec asks for PR-only handoff.
- No new UI strings; existing i18n copy is already sentence case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)