### PR TITLE
i18n(electron): localize tray menu and tooltip (#271)

### DIFF
--- a/electron/__tests__/i18n.test.ts
+++ b/electron/__tests__/i18n.test.ts
@@ -8,6 +8,7 @@ import {
   setMainLanguage,
   getMainLanguage,
   tNotification,
+  tTray,
   resolveSystemLanguage
 } from '../i18n';
 
@@ -45,5 +46,22 @@ describe('main process i18n', () => {
     expect(resolveSystemLanguage('en-US')).toBe('en');
     expect(resolveSystemLanguage(undefined)).toBe('en');
     expect(resolveSystemLanguage('fr-FR')).toBe('en');
+  });
+
+  it('localizes tray menu strings (en)', () => {
+    setMainLanguage('en');
+    expect(tTray('show')).toBe('Show CCSM');
+    expect(tTray('quit')).toBe('Quit');
+    expect(tTray('tooltip')).toBe('CCSM');
+  });
+
+  it('localizes tray menu strings (zh)', () => {
+    setMainLanguage('zh');
+    const labels = [tTray('show'), tTray('quit'), tTray('tooltip')];
+    // Spot-check Chinese characters appear in the localized menu so a
+    // future "oops, English literal slipped in" regression fails loud.
+    expect(labels.some((s) => /[\u4e00-\u9fff]/.test(s))).toBe(true);
+    expect(tTray('show')).toBe('显示 CCSM');
+    expect(tTray('quit')).toBe('退出');
   });
 });

--- a/electron/i18n.ts
+++ b/electron/i18n.ts
@@ -22,7 +22,14 @@ type NotificationCatalog = {
   permissionRequestBody: string;
 };
 
+type TrayCatalog = {
+  show: string;
+  quit: string;
+  tooltip: string;
+};
+
 type NotificationKey = keyof NotificationCatalog;
+type TrayKey = keyof TrayCatalog;
 
 // IMPORTANT: keep these strings byte-identical to the renderer catalog
 // `notifications` namespace. The renderer catalog is the source of truth.
@@ -42,6 +49,22 @@ const catalogs: Record<SupportedLanguage, NotificationCatalog> = {
     sessionDoneBody: '{{name}} 完成了任务',
     permissionRequestTitle: '请求权限',
     permissionRequestBody: '{{name}} 想要 {{action}}'
+  }
+};
+
+// Tray menu / tooltip strings. Same parity rule as the notifications
+// catalog above: keep these byte-identical to the renderer catalog
+// `tray` namespace in `src/i18n/locales/{en,zh}.ts`.
+const trayCatalogs: Record<SupportedLanguage, TrayCatalog> = {
+  en: {
+    show: 'Show CCSM',
+    quit: 'Quit',
+    tooltip: 'CCSM'
+  },
+  zh: {
+    show: '显示 CCSM',
+    quit: '退出',
+    tooltip: 'CCSM'
   }
 };
 
@@ -71,6 +94,11 @@ export function tNotification(
   const catalog = catalogs[activeLanguage] ?? catalogs.en;
   const template = catalog[key] ?? catalogs.en[key] ?? key;
   return interpolate(template, vars);
+}
+
+export function tTray(key: TrayKey): string {
+  const catalog = trayCatalogs[activeLanguage] ?? trayCatalogs.en;
+  return catalog[key] ?? trayCatalogs.en[key] ?? key;
 }
 
 // Resolve a system locale tag into one of the two supported languages.

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -388,29 +388,19 @@ function buildTrayIcon() {
   return img;
 }
 
-function ensureTray() {
-  if (tray) return tray;
-  tray = new Tray(buildTrayIcon());
-  tray.setToolTip('CCSM');
-  const showWindow = () => {
-    const win = BrowserWindow.getAllWindows()[0];
-    if (!win) {
-      createWindow();
-      return;
-    }
-    if (win.isMinimized()) win.restore();
-    win.show();
-    win.focus();
-    if (process.platform === 'darwin') app.dock?.show?.();
-  };
-  tray.on('click', showWindow);
-  tray.on('double-click', showWindow);
+function applyTrayLocale() {
+  if (!tray) return;
+  // Local require keeps the import graph linear (see the longer comment
+  // near the `ccsm:set-language` handler below).
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const i18n = require('./i18n') as typeof import('./i18n');
+  tray.setToolTip(i18n.tTray('tooltip'));
   tray.setContextMenu(
     Menu.buildFromTemplate([
-      { label: 'Show CCSM', click: showWindow },
+      { label: i18n.tTray('show'), click: showTrayWindow },
       { type: 'separator' },
       {
-        label: 'Quit',
+        label: i18n.tTray('quit'),
         click: () => {
           isQuitting = true;
           app.quit();
@@ -418,6 +408,26 @@ function ensureTray() {
       }
     ])
   );
+}
+
+function showTrayWindow() {
+  const win = BrowserWindow.getAllWindows()[0];
+  if (!win) {
+    createWindow();
+    return;
+  }
+  if (win.isMinimized()) win.restore();
+  win.show();
+  win.focus();
+  if (process.platform === 'darwin') app.dock?.show?.();
+}
+
+function ensureTray() {
+  if (tray) return tray;
+  tray = new Tray(buildTrayIcon());
+  tray.on('click', showTrayWindow);
+  tray.on('double-click', showTrayWindow);
+  applyTrayLocale();
   return tray;
 }
 
@@ -525,7 +535,12 @@ app.whenReady().then(() => {
     }
   });
   ipcMain.on('ccsm:set-language', (_e, lang: unknown) => {
-    if (lang === 'en' || lang === 'zh') i18n.setMainLanguage(lang);
+    if (lang === 'en' || lang === 'zh') {
+      i18n.setMainLanguage(lang);
+      // Tray menu / tooltip are built once on app ready; rebuild so a
+      // language switch from Settings is reflected immediately.
+      applyTrayLocale();
+    }
   });
   // Seed the active language from the OS at boot, before any window is
   // created — first notification fires with the right copy even if the

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -348,6 +348,11 @@ const en = {
     backgroundSessionFallback: 'Background session',
     backgroundWaitingToastTitle: '{{name}} needs your input'
   },
+  tray: {
+    show: 'Show CCSM',
+    quit: 'Quit',
+    tooltip: 'CCSM'
+  },
   errors: {
     generic: 'Something went wrong.',
     network: 'Network error. Check your connection.',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -335,6 +335,11 @@ const zh: EnCatalog = {
     backgroundSessionFallback: '后台会话',
     backgroundWaitingToastTitle: '{{name}} 需要你的输入'
   },
+  tray: {
+    show: '显示 CCSM',
+    quit: '退出',
+    tooltip: 'CCSM'
+  },
   errors: {
     generic: '出错了。',
     network: '网络错误。请检查连接。',


### PR DESCRIPTION
## Summary

Closes Wave 2 P0 W2-04 (task #271). The tray context menu still shipped English literals at `electron/main.ts:393,409,412` even though `electron/i18n.ts` had been added for OS notifications.

- Extend `electron/i18n.ts` with a `tray` namespace and a new `tTray()` helper alongside `tNotification()`.
- Mirror the same three keys into `src/i18n/locales/{en,zh}.ts` under `tray:` so the renderer catalog stays the source of truth and the i18n key-parity test passes.
- Replace the literals in `ensureTray()` with `tTray('show' | 'quit' | 'tooltip')`. Refactored the click handler out so the menu can be rebuilt without leaking listeners.
- **Runtime relocalization**: `ipcMain.on('ccsm:set-language', ...)` now also calls `applyTrayLocale()` so switching language in Settings rebuilds the tray menu immediately — no restart needed. Verified by reading the existing handler at `electron/main.ts:527`.

## Keys added

| Namespace | Key | en | zh |
|---|---|---|---|
| `tray` | `show` | Show CCSM | 显示 CCSM |
| `tray` | `quit` | Quit | 退出 |
| `tray` | `tooltip` | CCSM | CCSM |

## Test plan

- [x] `npx vitest run electron/__tests__/i18n.test.ts tests/i18n-key-parity.test.ts` — 8/8 pass (added 2 new tests for tray strings, both en + zh, with a regex Chinese-character spot check).
- [x] `npx tsc -p tsconfig.electron.json --noEmit` — clean.
- [ ] Manual: build, switch language in Settings, right-click tray icon, confirm menu items + tooltip update without restart.

## Notes

- Did NOT merge — leaving for reviewer per task instructions.
- Tray icon is created once in `app.whenReady()`, after the boot-time `setMainLanguage(resolveSystemLanguage(...))` seed, so the first-paint case already works without the IPC path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)