### PR TITLE
fix(i18n): translate AgentInitFailedBanner + AgentDiagnosticBanner (#270)

### DIFF
--- a/src/components/AgentDiagnosticBanner.tsx
+++ b/src/components/AgentDiagnosticBanner.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { AlertTriangle } from 'lucide-react';
 import { useStore } from '../stores/store';
+import { useTranslation } from '../i18n/useTranslation';
 import { TopBanner, TopBannerPresence } from './chrome/TopBanner';
 
 /**
@@ -16,6 +17,7 @@ import { TopBanner, TopBannerPresence } from './chrome/TopBanner';
  * just maps store state → variant + copy.
  */
 export function AgentDiagnosticBanner() {
+  const { t } = useTranslation();
   const diagnostics = useStore((s) => s.diagnostics);
   const activeId = useStore((s) => s.activeId);
   const dismiss = useStore((s) => s.dismissDiagnostic);
@@ -40,10 +42,10 @@ export function AgentDiagnosticBanner() {
           presenceKey={latest.id}
           testId="agent-diagnostic-banner"
           icon={<AlertTriangle size={13} className="stroke-[2]" />}
-          title={latest.level === 'error' ? 'Agent error' : 'Agent warning'}
+          title={latest.level === 'error' ? t('banner.agentDiagnostic.titleError') : t('banner.agentDiagnostic.titleWarning')}
           body={latest.message}
           onDismiss={() => dismiss(latest.id)}
-          dismissLabel="Dismiss diagnostic"
+          dismissLabel={t('banner.agentDiagnostic.dismiss')}
         />
       )}
     </TopBannerPresence>

--- a/src/components/AgentInitFailedBanner.tsx
+++ b/src/components/AgentInitFailedBanner.tsx
@@ -3,6 +3,7 @@ import { AlertOctagon, RotateCw, Settings } from 'lucide-react';
 import { cn } from '../lib/cn';
 import { useStore } from '../stores/store';
 import { startSessionAndReconcile } from '../agent/startSession';
+import { useTranslation } from '../i18n/useTranslation';
 import { TopBanner, TopBannerAction, TopBannerPresence } from './chrome/TopBanner';
 
 /**
@@ -28,6 +29,7 @@ export function AgentInitFailedBanner({
 }: {
   onRequestReconfigure: () => void;
 }) {
+  const { t } = useTranslation();
   const activeId = useStore((s) => s.activeId);
   const failure = useStore((s) => (activeId ? s.sessionInitFailures[activeId] : undefined));
   const clearFailure = useStore((s) => s.clearSessionInitFailure);
@@ -62,7 +64,7 @@ export function AgentInitFailedBanner({
           presenceKey={activeId ?? 'agent-init-failed'}
           testId="agent-init-failed-banner"
           icon={<AlertOctagon size={14} className="stroke-[2]" />}
-          title="Failed to start Claude"
+          title={t('banner.agentInitFailed.title')}
           body={failure.error}
           onDismiss={onDismiss}
           actions={
@@ -74,7 +76,7 @@ export function AgentInitFailedBanner({
                 data-agent-init-failed-retry
               >
                 <RotateCw size={12} className={cn('stroke-[2]', retrying && 'animate-spin')} />
-                <span>{retrying ? 'Retrying…' : 'Retry'}</span>
+                <span>{retrying ? t('banner.agentInitFailed.retrying') : t('banner.agentInitFailed.retry')}</span>
               </TopBannerAction>
               <TopBannerAction
                 tone="secondary"
@@ -82,7 +84,7 @@ export function AgentInitFailedBanner({
                 data-agent-init-failed-reconfigure
               >
                 <Settings size={12} className="stroke-[2]" />
-                <span>Reconfigure</span>
+                <span>{t('banner.agentInitFailed.reconfigure')}</span>
               </TopBannerAction>
             </>
           }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -537,6 +537,19 @@ const en = {
     actionShortcuts: 'Show this shortcuts overlay',
     colShortcut: 'Shortcut',
     colAction: 'Action'
+  },
+  banner: {
+    agentInitFailed: {
+      title: 'Failed to start Claude',
+      retry: 'Retry',
+      retrying: 'Retrying\u2026',
+      reconfigure: 'Reconfigure'
+    },
+    agentDiagnostic: {
+      titleError: 'Agent error',
+      titleWarning: 'Agent warning',
+      dismiss: 'Dismiss diagnostic'
+    }
   }
 } as const;
 

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -523,6 +523,19 @@ const zh: EnCatalog = {
     actionShortcuts: '显示快捷键面板',
     colShortcut: '快捷键',
     colAction: '动作'
+  },
+  banner: {
+    agentInitFailed: {
+      title: '无法启动 Claude',
+      retry: '重试',
+      retrying: '重试中\u2026',
+      reconfigure: '重新配置'
+    },
+    agentDiagnostic: {
+      titleError: 'Agent 错误',
+      titleWarning: 'Agent 警告',
+      dismiss: '关闭诊断信息'
+    }
   }
 };
 

--- a/tests/top-banner.test.tsx
+++ b/tests/top-banner.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react';
 
 // startSessionAndReconcile reaches into the IPC layer; stub it so the
 // AgentInitFailedBanner retry path doesn't try to spawn a real session.
@@ -13,6 +13,7 @@ import { AgentInitFailedBanner } from '../src/components/AgentInitFailedBanner';
 import { AgentDiagnosticBanner } from '../src/components/AgentDiagnosticBanner';
 import { ClaudeCliMissingBanner } from '../src/components/ClaudeCliMissingBanner';
 import { useStore } from '../src/stores/store';
+import { usePreferences } from '../src/store/preferences';
 
 const initial = useStore.getState();
 
@@ -277,5 +278,82 @@ describe('banner trio integration', () => {
     );
     const { container } = render(<ClaudeCliMissingBanner />);
     expect(container.querySelector('[data-top-banner]')).toBeNull();
+  });
+});
+
+describe('banner trio i18n (zh locale)', () => {
+  beforeEach(async () => {
+    useStore.setState(initial, true);
+    await act(async () => {
+      usePreferences.getState().setLanguage('zh');
+    });
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      usePreferences.getState().setLanguage('en');
+    });
+  });
+
+  it('AgentInitFailedBanner renders Chinese title + CTAs when locale=zh', () => {
+    useStore.setState(
+      {
+        ...initial,
+        activeId: 's1',
+        sessionInitFailures: {
+          s1: { error: 'spawn ENOENT', timestamp: Date.now() },
+        },
+      },
+      true
+    );
+    render(<AgentInitFailedBanner onRequestReconfigure={() => {}} />);
+    expect(screen.getByText('无法启动 Claude')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '重试' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '重新配置' })).toBeInTheDocument();
+  });
+
+  it('AgentDiagnosticBanner renders Chinese warning title + dismiss label when locale=zh', () => {
+    useStore.setState(
+      {
+        ...initial,
+        activeId: 's1',
+        diagnostics: [
+          {
+            id: 'd1',
+            sessionId: 's1',
+            level: 'warn',
+            code: 'init.timeout',
+            message: '初始化握手超时',
+            timestamp: Date.now(),
+          },
+        ],
+      },
+      true
+    );
+    render(<AgentDiagnosticBanner />);
+    expect(screen.getByText('Agent 警告')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '关闭诊断信息' })).toBeInTheDocument();
+  });
+
+  it('AgentDiagnosticBanner renders Chinese error title when level=error and locale=zh', () => {
+    useStore.setState(
+      {
+        ...initial,
+        activeId: 's1',
+        diagnostics: [
+          {
+            id: 'd2',
+            sessionId: 's1',
+            level: 'error',
+            code: 'init.crash',
+            message: 'agent 在初始化阶段崩溃',
+            timestamp: Date.now(),
+          },
+        ],
+      },
+      true
+    );
+    render(<AgentDiagnosticBanner />);
+    expect(screen.getByText('Agent 错误')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- #207/#237 banner trio unification regressed i18n. `AgentInitFailedBanner.tsx` and `AgentDiagnosticBanner.tsx` kept inlined English literals while only `ClaudeCliMissingBanner` went through `useTranslation()`. Chinese users saw English on every CLI failure path.
- Add `banner.agentInitFailed.*` and `banner.agentDiagnostic.*` keys (7 entries) to both `src/i18n/locales/en.ts` and `zh.ts`, sentence case, no SCREAMING.
- Wire both banners through `useTranslation()` mirroring `ClaudeCliMissingBanner`.
- Extend `tests/top-banner.test.tsx` with a zh-locale describe block (3 new tests) asserting Chinese strings render via `usePreferences().setLanguage('zh')` — same pattern as `language-switch.test.tsx`.

## Keys added
- `banner.agentInitFailed.title` / `.retry` / `.retrying` / `.reconfigure`
- `banner.agentDiagnostic.titleError` / `.titleWarning` / `.dismiss`

## Test plan
- [x] `npx vitest run tests/top-banner.test.tsx tests/i18n-key-parity.test.ts` → 15/15 pass (10 existing en + 3 new zh + 2 parity)
- [x] `npx tsc --noEmit` clean
- [ ] Manual: switch language to 中文 in Settings, force a CLI init failure, confirm banner reads "无法启动 Claude" / "重试" / "重新配置"
- [ ] Manual: trigger an agent diagnostic (e.g. init handshake timeout), confirm "Agent 警告" / "关闭诊断信息"

DO NOT MERGE — awaiting independent reviewer per memory rules.