### PR TITLE
chore: tighten sessions docstring + electron i18n sweep + README aumid (#268 #294 #299)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,20 @@ the renderer (per-session focus check) and in the main process
 (`BrowserWindow.isFocused()`), so devtools / debuggers / playwright
 sessions can't bypass it.
 
+### Dev mode notifications
+
+Adaptive Toast notifications require a registered AppUserModelID (AUMID)
+plus a Start Menu shortcut that points at the same AUMID. NSIS installs of
+CCSM register both automatically. For `npm run dev` (no installer is run),
+register them once per machine:
+
+```powershell
+pwsh node_modules/@ccsm/notify/scripts/setup-aumid.ps1
+```
+
+Without this, the Adaptive Toast pipeline silently no-ops in dev mode and
+CCSM falls back to plain Electron notifications.
+
 ## Status
 
 This is **MVP**. The author uses it daily as a personal driver. Public release pending.

--- a/electron/__tests__/i18n.test.ts
+++ b/electron/__tests__/i18n.test.ts
@@ -9,6 +9,8 @@ import {
   getMainLanguage,
   tNotification,
   tTray,
+  tMenu,
+  tDialog,
   resolveSystemLanguage
 } from '../i18n';
 
@@ -63,5 +65,28 @@ describe('main process i18n', () => {
     expect(labels.some((s) => /[\u4e00-\u9fff]/.test(s))).toBe(true);
     expect(tTray('show')).toBe('显示 CCSM');
     expect(tTray('quit')).toBe('退出');
+  });
+
+  it('localizes the app accelerator menu Edit label (en + zh)', () => {
+    setMainLanguage('en');
+    expect(tMenu('edit')).toBe('&Edit');
+    setMainLanguage('zh');
+    // Localized label must contain Chinese characters and preserve the
+    // `&E` accelerator marker so Alt+E still opens the submenu on
+    // Windows/Linux.
+    const zhEdit = tMenu('edit');
+    expect(/[\u4e00-\u9fff]/.test(zhEdit)).toBe(true);
+    expect(zhEdit).toContain('&E');
+  });
+
+  it('localizes native dialog titles (en + zh)', () => {
+    setMainLanguage('en');
+    expect(tDialog('chooseCwd')).toBe('Choose working directory');
+    expect(tDialog('selectClaude')).toBe('Select claude binary');
+    setMainLanguage('zh');
+    const zhCwd = tDialog('chooseCwd');
+    const zhClaude = tDialog('selectClaude');
+    expect(/[\u4e00-\u9fff]/.test(zhCwd)).toBe(true);
+    expect(/[\u4e00-\u9fff]/.test(zhClaude)).toBe(true);
   });
 });

--- a/electron/agent/sessions.ts
+++ b/electron/agent/sessions.ts
@@ -163,18 +163,26 @@ const HOOK_PASSTHROUGH_TOOLS: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * How long we wait, after `spawn()` returns, before declaring the child has
- * "successfully started". Two race winners declare success early:
- *   - first byte arriving on the child's stdout or stderr (proves the binary
- *     launched and is producing output);
- *   - the timer expiring with the child still alive (no exit/error event).
- * Failure (`exit` with non-zero code, or libuv `error` event surfaced by the
- * spawner as exitCode -1) inside the window throws a typed
- * `ClaudeSpawnFailedError` instead of returning `{ ok: true }`.
+ * How long `detectEarlyFailure()` waits, after `spawn()` returns, before
+ * concluding the child has "successfully started". The window is a three-way
+ * race resolved in `detectEarlyFailure()`:
+ *   - stdout `'readable'` with bytes queued — proves the binary launched and
+ *     is producing protocol output → resolve healthy. **Stdout only**: stderr
+ *     is intentionally NOT a liveness signal, since a binary can print a
+ *     warning to stderr and still exit non-zero (see contract in the
+ *     `detectEarlyFailure()` doc comment).
+ *   - `cp.wait()` resolving inside the window — process exited (or libuv
+ *     `error` surfaced as exitCode -1). Non-zero/-1 → throw
+ *     `ClaudeSpawnFailedError`; code 0 → resolve healthy.
+ *   - the timer (this constant) firing with the child still alive and silent
+ *     — assume healthy.
  *
- * 800ms is a comfortable upper bound on Windows shim + cmd.exe wrap-up; the
- * common case resolves in <50ms once the CLI's first stdout frame lands, so
- * the success path no longer pays the full window.
+ * Important: the 800ms is **not** awaited on the success path. PR #209 P1
+ * removed the implicit full-window wait by racing stdout against the timer;
+ * the common case now resolves in <50ms once the CLI's first stdout frame
+ * lands. The window only bounds the failure-detection path (waiting long
+ * enough to catch an immediate exit/error). 800ms is a comfortable upper
+ * bound on Windows shim + cmd.exe wrap-up.
  */
 const SPAWN_EARLY_FAILURE_WINDOW_MS = 800;
 

--- a/electron/i18n.ts
+++ b/electron/i18n.ts
@@ -28,8 +28,19 @@ type TrayCatalog = {
   tooltip: string;
 };
 
+type MenuCatalog = {
+  edit: string;
+};
+
+type DialogCatalog = {
+  chooseCwd: string;
+  selectClaude: string;
+};
+
 type NotificationKey = keyof NotificationCatalog;
 type TrayKey = keyof TrayCatalog;
+type MenuKey = keyof MenuCatalog;
+type DialogKey = keyof DialogCatalog;
 
 // IMPORTANT: keep these strings byte-identical to the renderer catalog
 // `notifications` namespace. The renderer catalog is the source of truth.
@@ -68,6 +79,32 @@ const trayCatalogs: Record<SupportedLanguage, TrayCatalog> = {
   }
 };
 
+// Application accelerator menu (Edit submenu carrying Cut/Copy/Paste/Undo
+// shortcuts). Single label since the submenu items use Electron `role`s and
+// are localized by the OS. Keep parity with the renderer catalog `menu`
+// namespace.
+const menuCatalogs: Record<SupportedLanguage, MenuCatalog> = {
+  en: {
+    edit: '&Edit'
+  },
+  zh: {
+    edit: '编辑(&E)'
+  }
+};
+
+// Native file/directory picker dialog titles. Keep parity with the renderer
+// catalog `dialog` namespace.
+const dialogCatalogs: Record<SupportedLanguage, DialogCatalog> = {
+  en: {
+    chooseCwd: 'Choose working directory',
+    selectClaude: 'Select claude binary'
+  },
+  zh: {
+    chooseCwd: '选择工作目录',
+    selectClaude: '选择 claude 程序'
+  }
+};
+
 let activeLanguage: SupportedLanguage = 'en';
 
 export function setMainLanguage(lang: SupportedLanguage): void {
@@ -99,6 +136,16 @@ export function tNotification(
 export function tTray(key: TrayKey): string {
   const catalog = trayCatalogs[activeLanguage] ?? trayCatalogs.en;
   return catalog[key] ?? trayCatalogs.en[key] ?? key;
+}
+
+export function tMenu(key: MenuKey): string {
+  const catalog = menuCatalogs[activeLanguage] ?? menuCatalogs.en;
+  return catalog[key] ?? menuCatalogs.en[key] ?? key;
+}
+
+export function tDialog(key: DialogKey): string {
+  const catalog = dialogCatalogs[activeLanguage] ?? dialogCatalogs.en;
+  return catalog[key] ?? dialogCatalogs.en[key] ?? key;
 }
 
 // Resolve a system locale tag into one of the two supported languages.

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -194,12 +194,23 @@ async function getTopModel(): Promise<string | null> {
 // feel "not copyable". Install a minimal, hidden app menu whose only job
 // is to carry those accelerators, and hide the menu bar so it's not
 // visible. On macOS, the default app menu already handles this.
-if (process.platform === 'darwin') {
-  // Let Electron use its default macOS menu.
-} else {
+//
+// Wrapped in a function so language switches via `ccsm:set-language` can
+// rebuild the menu with the localized "Edit" label (mirrors the
+// `applyTrayLocale()` pattern below). The submenu items use Electron
+// `role`s and are localized by the OS automatically.
+function applyAppMenuLocale() {
+  if (process.platform === 'darwin') {
+    // Let Electron use its default macOS menu.
+    return;
+  }
+  // Local require keeps the import graph linear (see the longer comment
+  // near the `ccsm:set-language` handler below).
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const i18n = require('./i18n') as typeof import('./i18n');
   const accelMenu = Menu.buildFromTemplate([
     {
-      label: '&Edit',
+      label: i18n.tMenu('edit'),
       submenu: [
         { role: 'undo' },
         { role: 'redo' },
@@ -213,6 +224,7 @@ if (process.platform === 'darwin') {
   ]);
   Menu.setApplicationMenu(accelMenu);
 }
+applyAppMenuLocale();
 
 // Right-click context menu for the renderer — Copy/Cut/Paste/Select All,
 // contextually enabled based on selection + editable state. Attached per
@@ -596,9 +608,11 @@ app.whenReady().then(() => {
   ipcMain.on('ccsm:set-language', (_e, lang: unknown) => {
     if (lang === 'en' || lang === 'zh') {
       i18n.setMainLanguage(lang);
-      // Tray menu / tooltip are built once on app ready; rebuild so a
-      // language switch from Settings is reflected immediately.
+      // Tray menu / tooltip + app accelerator menu are built once on app
+      // ready; rebuild both so a language switch from Settings is reflected
+      // immediately (Edit label, tray show/quit, tooltip).
       applyTrayLocale();
+      applyAppMenuLocale();
     }
   });
   // Seed the active language from the OS at boot, before any window is
@@ -606,6 +620,10 @@ app.whenReady().then(() => {
   // renderer hasn't dispatched yet.
   try {
     i18n.setMainLanguage(i18n.resolveSystemLanguage(app.getLocale()));
+    // Rebuild the app menu now that the seed has flipped the active
+    // language; otherwise the top-level `applyAppMenuLocale()` call left
+    // it stuck on English.
+    applyAppMenuLocale();
   } catch {
     /* ignore — falls through to the default 'en' */
   }
@@ -668,7 +686,7 @@ app.whenReady().then(() => {
     const win = BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0];
     const res = await dialog.showOpenDialog(win, {
       properties: ['openDirectory'],
-      title: 'Choose working directory'
+      title: i18n.tDialog('chooseCwd')
     });
     if (res.canceled || res.filePaths.length === 0) return null;
     return res.filePaths[0];
@@ -989,7 +1007,7 @@ app.whenReady().then(() => {
         : [{ name: 'All files', extensions: ['*'] }];
     const res = await dialog.showOpenDialog(win, {
       properties: ['openFile'],
-      title: 'Select claude binary',
+      title: i18n.tDialog('selectClaude'),
       filters,
     });
     if (res.canceled || res.filePaths.length === 0) return null;

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -359,6 +359,13 @@ const en = {
     quit: 'Quit',
     tooltip: 'CCSM'
   },
+  menu: {
+    edit: '&Edit'
+  },
+  dialog: {
+    chooseCwd: 'Choose working directory',
+    selectClaude: 'Select claude binary'
+  },
   errors: {
     generic: 'Something went wrong.',
     network: 'Network error. Check your connection.',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -346,6 +346,13 @@ const zh: EnCatalog = {
     quit: '退出',
     tooltip: 'CCSM'
   },
+  menu: {
+    edit: '编辑(&E)'
+  },
+  dialog: {
+    chooseCwd: '选择工作目录',
+    selectClaude: '选择 claude 程序'
+  },
   errors: {
     generic: '出错了。',
     network: '网络错误。请检查连接。',


### PR DESCRIPTION
Bundles three small, low-risk fixes into one PR.

## Summary

### #268 — `SPAWN_EARLY_FAILURE_WINDOW_MS` docstring (electron/agent/sessions.ts)
The previous comment said the success-decider race winner was "first byte arriving on stdout *or stderr*", which contradicts the actual implementation in `detectEarlyFailure()` (stdout-only — see existing comment at lines 246–251). It also didn't make clear that the 800ms window is NOT awaited on the success path post-#209 P1.

Rewrote the docstring to spell out:
- The three-way race resolved in `detectEarlyFailure()`: stdout `'readable'` (alive) / `cp.wait()` (dead) / timer.
- **Stdout only** is a liveness signal — stderr can come from binaries that print a warning then die non-zero.
- 800ms is **not** awaited on success; it only bounds the failure-detection path. References PR #209 P1.

### #294 — Localize remaining hardcoded strings in `electron/main.ts`
Three OS-visible strings were still English-only:
- App accelerator menu label `'&Edit'` (line ~202)
- `'Choose working directory'` dialog title (line ~671)
- `'Select claude binary'` dialog title (line ~992)

Added three new keys (`menu.edit`, `dialog.chooseCwd`, `dialog.selectClaude`) to both `electron/i18n.ts` and `src/i18n/locales/{en,zh}.ts`. The renderer-side parity test (`tests/i18n-key-parity.test.ts`) already enforces catalog sync.

The Edit menu is built before `app.whenReady()`, so I extracted it into `applyAppMenuLocale()` (mirroring `applyTrayLocale()` from #271):
- Called once at top-level (default 'en' is fine pre-seed).
- Re-called inside `whenReady` after seeding the language from `app.getLocale()` (so a zh OS user sees `编辑(&E)` immediately).
- Re-called from the `ccsm:set-language` IPC handler (so changing language in Settings rebuilds the menu live).

zh translation `编辑(&E)` preserves the `&E` accelerator marker so Alt+E still opens the submenu on Windows/Linux.

### #299 — README dev-mode AUMID setup note
Added a `### Dev mode notifications` subsection under `## Notifications` documenting the one-time `pwsh node_modules/@ccsm/notify/scripts/setup-aumid.ps1` step required for `npm run dev` (NSIS installs handle it automatically). Verified the script path against `Jiahui-Gu/ccsm-notify@v0.1.1/scripts/setup-aumid.ps1`.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` (renderer) — clean.
- [x] `npx tsc --noEmit -p tsconfig.electron.json` (electron) — clean.
- [x] `npm run lint` — same 46 pre-existing errors in `verification/*.mjs` baseline; **no new errors introduced** by this PR.
- [x] `npx vitest run electron/__tests__/i18n.test.ts tests/i18n-key-parity.test.ts` — **10 / 10 passing** (added 2 new test cases for menu.edit + dialog.* keys, en + zh).
- [ ] Caveat: `npm test` shows 12 db test failures (`electron/__tests__/db.test.ts`, `db-hardening.test.ts`) due to a `better-sqlite3` NODE_MODULE_VERSION 130 vs 127 ABI mismatch in this environment — confirmed pre-existing on baseline `working`, unrelated to this PR.

## Files

- `electron/agent/sessions.ts` — docstring only.
- `electron/i18n.ts` — added `tMenu`, `tDialog` + catalogs.
- `electron/main.ts` — extracted `applyAppMenuLocale()`, wired dialog titles, extended `ccsm:set-language` handler.
- `electron/__tests__/i18n.test.ts` — 2 new test cases.
- `src/i18n/locales/{en,zh}.ts` — added `menu` + `dialog` namespaces.
- `README.md` — Dev mode notifications subsection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)