### PR TITLE
feat: IPC for partial diff write (#251)

### DIFF
--- a/electron/agent/__tests__/sessions.test.ts
+++ b/electron/agent/__tests__/sessions.test.ts
@@ -538,6 +538,153 @@ describe('SessionRunner PreToolUse hook permission', () => {
     expect(resp.response.response).toEqual({});
     runner.close();
   });
+
+  // Regression for the PR #242 reviewer-flagged bug: Edit/Write/MultiEdit in
+  // CLI 2.x route through the PreToolUse hook path, NOT can_use_tool. The
+  // hook resolver was emitting `permissionDecision: 'allow'` only and
+  // discarding `decision.updatedInput`, so a MultiEdit subset selection
+  // silently caused the CLI to run ALL edits.
+  it('forwards updatedInput on the hook response when resolvePermissionPartial picks a subset of MultiEdit hunks (PR #242 fix)', async () => {
+    const proc = makeFakeProc();
+    mockSpawnClaude.mockResolvedValue(proc);
+    let captured = '';
+    const runner = new SessionRunner('s-hook-partial', () => {}, () => {}, (req) => {
+      captured = req.requestId;
+    });
+    await runner.start(baseOpts);
+
+    const originalEdits = [
+      { old_string: 'a', new_string: 'A' },
+      { old_string: 'b', new_string: 'B' },
+      { old_string: 'c', new_string: 'C' },
+    ];
+    emitFrame(proc.stdout, {
+      type: 'control_request',
+      request_id: 'req_hk_partial',
+      request: {
+        subtype: 'hook_callback',
+        callback_id: 'ccsm-permission',
+        input: {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'MultiEdit',
+          tool_input: { file_path: '/x', edits: originalEdits },
+          permission_mode: 'default',
+        },
+      },
+    });
+    await new Promise((r) => setImmediate(r));
+    expect(captured).not.toBe('');
+
+    // User accepts hunks 0 and 2, rejects hunk 1.
+    expect(runner.resolvePermissionPartial(captured, [0, 2])).toBe(true);
+    await new Promise((r) => setImmediate(r));
+
+    const lines = proc.__stdinLines() as Array<Record<string, unknown>>;
+    const resp = lines.find(
+      (l) =>
+        l.type === 'control_response' &&
+        (l.response as { request_id?: string } | undefined)?.request_id === 'req_hk_partial',
+    ) as { response: { subtype: string; request_id: string; response: Record<string, unknown> } } | undefined;
+    expect(resp).toBeDefined();
+    expect(resp!.response.subtype).toBe('success');
+    const out = resp!.response.response as {
+      hookSpecificOutput: {
+        hookEventName: string;
+        permissionDecision: string;
+        updatedInput?: { edits?: Array<Record<string, unknown>>; file_path?: string };
+      };
+    };
+    expect(out.hookSpecificOutput.hookEventName).toBe('PreToolUse');
+    expect(out.hookSpecificOutput.permissionDecision).toBe('allow');
+    // The critical assertion: the hook response MUST include updatedInput
+    // so the CLI rewrites the tool call to the trimmed edits list.
+    expect(out.hookSpecificOutput.updatedInput).toBeDefined();
+    expect(out.hookSpecificOutput.updatedInput!.file_path).toBe('/x');
+    expect(out.hookSpecificOutput.updatedInput!.edits).toEqual([
+      originalEdits[0],
+      originalEdits[2],
+    ]);
+    runner.close();
+  });
+
+  // Integration: full path from a CLI-emitted PreToolUse hook_callback for
+  // MultiEdit through resolvePermissionPartial back to a control_response
+  // the SDK/CLI consumes. Reviewer flagged "no integration test covers the
+  // hook resolve path" — this is it. Asserts both the trimmed input AND
+  // that all unmodified peer fields (replace_all, etc.) are preserved.
+  it('integration: MultiEdit with 3 hunks + partial-accept (2 of 3) emits a hook control_response carrying the trimmed updatedInput (PR #242 fix)', async () => {
+    const proc = makeFakeProc();
+    mockSpawnClaude.mockResolvedValue(proc);
+    const seen: Array<{ requestId: string; toolName: string; input: Record<string, unknown> }> = [];
+    const runner = new SessionRunner(
+      's-hook-partial-int',
+      () => {},
+      () => {},
+      (req) => seen.push(req),
+    );
+    await runner.start(baseOpts);
+
+    const inputEdits = [
+      { old_string: 'foo', new_string: 'FOO', replace_all: false },
+      { old_string: 'bar', new_string: 'BAR', replace_all: true },
+      { old_string: 'baz', new_string: 'BAZ', replace_all: false },
+    ];
+    emitFrame(proc.stdout, {
+      type: 'control_request',
+      request_id: 'req_hk_int_partial',
+      request: {
+        subtype: 'hook_callback',
+        callback_id: 'ccsm-permission',
+        input: {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'MultiEdit',
+          tool_input: { file_path: '/repo/file.ts', edits: inputEdits },
+          tool_use_id: 'tu_int',
+          permission_mode: 'default',
+        },
+        tool_use_id: 'tu_int',
+      },
+    });
+    await new Promise((r) => setImmediate(r));
+
+    // The renderer sees a permission prompt with the full MultiEdit input.
+    expect(seen).toHaveLength(1);
+    expect(seen[0].toolName).toBe('MultiEdit');
+    expect((seen[0].input.edits as unknown[])).toHaveLength(3);
+
+    // User picks hunks 0 and 2 (indices match DiffSpec ordering).
+    expect(runner.resolvePermissionPartial(seen[0].requestId, [0, 2])).toBe(true);
+    await new Promise((r) => setImmediate(r));
+
+    // Inspect what we wrote back to claude.exe stdin.
+    const lines = proc.__stdinLines() as Array<Record<string, unknown>>;
+    const resp = lines.find(
+      (l) =>
+        l.type === 'control_response' &&
+        (l.response as { request_id?: string } | undefined)?.request_id === 'req_hk_int_partial',
+    ) as { response: { subtype: string; request_id: string; response: Record<string, unknown> } } | undefined;
+    expect(resp).toBeDefined();
+    expect(resp!.response.subtype).toBe('success');
+
+    const out = resp!.response.response as {
+      hookSpecificOutput: {
+        hookEventName: string;
+        permissionDecision: string;
+        updatedInput?: { file_path?: string; edits?: Array<Record<string, unknown>> };
+      };
+    };
+    expect(out.hookSpecificOutput).toMatchObject({
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'allow',
+    });
+    // SDK/CLI must receive a trimmed input — exactly 2 edits, in original
+    // order, with all per-edit fields (replace_all etc.) preserved.
+    expect(out.hookSpecificOutput.updatedInput).toEqual({
+      file_path: '/repo/file.ts',
+      edits: [inputEdits[0], inputEdits[2]],
+    });
+    runner.close();
+  });
 });
 
 describe('SessionRunner outbound control', () => {

--- a/electron/agent/manager.ts
+++ b/electron/agent/manager.ts
@@ -156,6 +156,21 @@ class SessionsManager {
     return r.resolvePermission(requestId, decision);
   }
 
+  /**
+   * Per-hunk partial-accept variant of resolvePermission (#251).
+   * `acceptedHunks` indices map to the `DiffSpec.hunks` produced by
+   * `src/utils/diff.ts` for the original tool call.
+   */
+  resolvePermissionPartial(
+    sessionId: string,
+    requestId: string,
+    acceptedHunks: number[]
+  ): boolean {
+    const r = this.runners.get(sessionId);
+    if (!r) return false;
+    return r.resolvePermissionPartial(requestId, acceptedHunks);
+  }
+
   close(sessionId: string): boolean {
     const r = this.runners.get(sessionId);
     if (!r) return false;

--- a/electron/agent/partial-write.ts
+++ b/electron/agent/partial-write.ts
@@ -1,0 +1,85 @@
+/**
+ * Partial-accept filter for Edit / Write / MultiEdit tool calls (#251).
+ *
+ * The renderer can offer the user per-hunk Allow / Reject in the permission
+ * prompt. When only a subset is accepted, we don't pass the full original
+ * input back to claude.exe — instead we hand it an `updatedInput` containing
+ * just the accepted hunks, using the `updatedInput` channel that the
+ * `can_use_tool` control_response already supports.
+ *
+ * Hunk indices map directly to `DiffSpec.hunks` ordering produced by
+ * `src/utils/diff.ts`:
+ *   - Edit:      always 1 hunk (index 0).
+ *   - Write:     always 1 hunk (index 0).
+ *   - MultiEdit: one hunk per entry in `edits`, in array order.
+ *
+ * Behaviour:
+ *   - All hunks accepted (or `acceptedHunks === undefined`) -> return the
+ *     original input unchanged. Callers should treat this as "no rewrite".
+ *   - Empty `acceptedHunks` -> returns null. The caller MUST translate that
+ *     into a reject decision; an empty Edit/Write would otherwise corrupt
+ *     the file or no-op silently.
+ *   - Subset accepted on MultiEdit -> returns a new input with `edits`
+ *     filtered to the chosen indices in their original order.
+ *   - Subset accepted on Edit/Write -> only meaningful values are 0/all or
+ *     none; we treat "the only hunk accepted" as full-allow and "0 hunks"
+ *     as null (reject). Per-line slicing inside the single hunk is out of
+ *     scope for this PR — see the UI follow-up.
+ *
+ * Returns:
+ *   - The (possibly rewritten) tool input object suitable for
+ *     `CanUseToolDecision.updatedInput`.
+ *   - `null` when the partial selection means "deny entirely".
+ *   - The original input untouched when no filtering is needed (caller
+ *     should pass `updatedInput: undefined` in that case).
+ */
+
+export type PartialFilterResult =
+  | { kind: 'unchanged' }
+  | { kind: 'updated'; updatedInput: Record<string, unknown> }
+  | { kind: 'reject' };
+
+export function filterToolInputByAcceptedHunks(
+  toolName: string,
+  input: unknown,
+  acceptedHunks: number[] | undefined
+): PartialFilterResult {
+  // No selection provided -> caller wants the legacy whole-tool allow.
+  if (acceptedHunks === undefined) return { kind: 'unchanged' };
+
+  // Defensive: only objects can be filtered. Anything else falls through
+  // unchanged (Bash etc. should never go through this code path, but if a
+  // caller mis-routes we fail-open to "no rewrite" rather than crash).
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    return { kind: 'unchanged' };
+  }
+
+  // Normalize + dedupe accepted indices.
+  const accepted = Array.from(new Set(acceptedHunks)).sort((a, b) => a - b);
+
+  switch (toolName) {
+    case 'Edit':
+    case 'Write': {
+      // Single-hunk tools: empty selection -> reject; otherwise unchanged.
+      // (Index value irrelevant — there's only hunk 0.)
+      if (accepted.length === 0) return { kind: 'reject' };
+      return { kind: 'unchanged' };
+    }
+    case 'MultiEdit': {
+      const o = input as Record<string, unknown>;
+      const edits = Array.isArray(o.edits) ? o.edits : [];
+      if (edits.length === 0) return { kind: 'unchanged' };
+      const filtered = accepted
+        .filter((i) => Number.isInteger(i) && i >= 0 && i < edits.length)
+        .map((i) => edits[i]);
+      if (filtered.length === 0) return { kind: 'reject' };
+      if (filtered.length === edits.length) return { kind: 'unchanged' };
+      return {
+        kind: 'updated',
+        updatedInput: { ...o, edits: filtered },
+      };
+    }
+    default:
+      return { kind: 'unchanged' };
+  }
+}

--- a/electron/agent/sessions.ts
+++ b/electron/agent/sessions.ts
@@ -622,10 +622,21 @@ export class SessionRunner {
       this.pendingPerms.set(requestId, {
         resolve: (decision: CanUseToolDecision) => {
           if (decision.allow) {
+            // CLI 2.x routes Edit/Write/MultiEdit through the PreToolUse hook
+            // path, NOT the can_use_tool path, so the partial-accept rewrite
+            // (#251) only takes effect if the hook response forwards
+            // `updatedInput` here. Per the official hook protocol, a
+            // PreToolUse hookSpecificOutput may include `updatedInput` which
+            // replaces the entire tool_input before execution. Without this
+            // line a MultiEdit subset selection is silently dropped and the
+            // CLI runs ALL edits.
             resolve({
               hookSpecificOutput: {
                 hookEventName: 'PreToolUse',
                 permissionDecision: 'allow',
+                ...(decision.updatedInput !== undefined
+                  ? { updatedInput: decision.updatedInput }
+                  : {}),
               },
             });
           } else {

--- a/electron/agent/sessions.ts
+++ b/electron/agent/sessions.ts
@@ -11,6 +11,7 @@ import {
   type ParsedStreamEvent,
 } from './control-rpc';
 import type { StartErrorCode } from './start-result-types';
+import { filterToolInputByAcceptedHunks } from './partial-write';
 
 export type { StartErrorCode, StartResult } from './start-result-types';
 
@@ -219,7 +220,19 @@ export class SessionRunner {
    * to the renderer. resolvePermission() looks the entry up to settle the
    * promise that ControlRpc is awaiting before it writes the control_response.
    */
-  private pendingPerms = new Map<string, (d: CanUseToolDecision) => void>();
+  private pendingPerms = new Map<
+    string,
+    {
+      resolve: (d: CanUseToolDecision) => void;
+      /**
+       * Captured at handleCanUseTool() time so resolvePermissionPartial()
+       * can build an `updatedInput` containing only the user-accepted hunks
+       * without an extra renderer round-trip. See electron/agent/partial-write.ts (#251).
+       */
+      toolName: string;
+      input: unknown;
+    }
+  >();
   private nextPermSeq = 0;
 
   constructor(
@@ -323,14 +336,48 @@ export class SessionRunner {
   }
 
   resolvePermission(requestId: string, decision: 'allow' | 'deny'): boolean {
-    const resolve = this.pendingPerms.get(requestId);
-    if (!resolve) return false;
+    const entry = this.pendingPerms.get(requestId);
+    if (!entry) return false;
     this.pendingPerms.delete(requestId);
-    resolve(
+    entry.resolve(
       decision === 'allow'
         ? { allow: true }
         : { allow: false, deny_reason: 'User denied tool use.' }
     );
+    return true;
+  }
+
+  /**
+   * Partial-accept variant of resolvePermission (#251).
+   *
+   * `acceptedHunks` is the list of hunk indices the user accepted in the
+   * permission prompt's diff view. Index ordering matches the `DiffSpec`
+   * produced by `src/utils/diff.ts` for this tool name.
+   *
+   * Behaviour:
+   *   - Empty `acceptedHunks` -> denies the call (passing an empty Edit /
+   *     Write to claude.exe would corrupt the file silently).
+   *   - All hunks accepted -> equivalent to plain `resolvePermission(allow)`.
+   *   - Subset -> sends `{ allow: true, updatedInput }` so claude.exe runs
+   *     a rewritten tool call containing only the accepted hunks.
+   *
+   * Returns false if no pending permission matches `requestId` (race with
+   * cancel / session close), true on a successful resolve.
+   */
+  resolvePermissionPartial(requestId: string, acceptedHunks: number[]): boolean {
+    const entry = this.pendingPerms.get(requestId);
+    if (!entry) return false;
+    this.pendingPerms.delete(requestId);
+    const result = filterToolInputByAcceptedHunks(entry.toolName, entry.input, acceptedHunks);
+    if (result.kind === 'reject') {
+      entry.resolve({ allow: false, deny_reason: 'User rejected all proposed hunks.' });
+      return true;
+    }
+    if (result.kind === 'updated') {
+      entry.resolve({ allow: true, updatedInput: result.updatedInput });
+      return true;
+    }
+    entry.resolve({ allow: true });
     return true;
   }
 
@@ -495,7 +542,7 @@ export class SessionRunner {
   ): Promise<CanUseToolDecision> {
     return new Promise<CanUseToolDecision>((resolve) => {
       const requestId = `perm-${Date.now().toString(36)}-${(this.nextPermSeq++).toString(36)}`;
-      this.pendingPerms.set(requestId, resolve);
+      this.pendingPerms.set(requestId, { resolve, toolName, input });
       // If claude.exe cancels the request mid-flight, fail-closed via the
       // signal so we don't leak the pending entry.
       ctx.signal.addEventListener(
@@ -572,23 +619,27 @@ export class SessionRunner {
 
     return new Promise<unknown>((resolve) => {
       const requestId = `perm-${Date.now().toString(36)}-${(this.nextPermSeq++).toString(36)}`;
-      this.pendingPerms.set(requestId, (decision: CanUseToolDecision) => {
-        if (decision.allow) {
-          resolve({
-            hookSpecificOutput: {
-              hookEventName: 'PreToolUse',
-              permissionDecision: 'allow',
-            },
-          });
-        } else {
-          resolve({
-            hookSpecificOutput: {
-              hookEventName: 'PreToolUse',
-              permissionDecision: 'deny',
-              permissionDecisionReason: decision.deny_reason ?? 'User denied tool use.',
-            },
-          });
-        }
+      this.pendingPerms.set(requestId, {
+        resolve: (decision: CanUseToolDecision) => {
+          if (decision.allow) {
+            resolve({
+              hookSpecificOutput: {
+                hookEventName: 'PreToolUse',
+                permissionDecision: 'allow',
+              },
+            });
+          } else {
+            resolve({
+              hookSpecificOutput: {
+                hookEventName: 'PreToolUse',
+                permissionDecision: 'deny',
+                permissionDecisionReason: decision.deny_reason ?? 'User denied tool use.',
+              },
+            });
+          }
+        },
+        toolName,
+        input: toolInput,
       });
       signal.addEventListener(
         'abort',
@@ -689,8 +740,8 @@ export class SessionRunner {
   close(): void {
     if (this.disposed) return;
     this.disposed = true;
-    for (const resolve of this.pendingPerms.values()) {
-      resolve({ allow: false, deny_reason: 'Session closed.' });
+    for (const entry of this.pendingPerms.values()) {
+      entry.resolve({ allow: false, deny_reason: 'Session closed.' });
     }
     this.pendingPerms.clear();
     this.rpc?.close();
@@ -705,8 +756,8 @@ export class SessionRunner {
 
   private cleanupAfterExit(): void {
     this.disposed = true;
-    for (const resolve of this.pendingPerms.values()) {
-      resolve({ allow: false, deny_reason: 'Session ended.' });
+    for (const entry of this.pendingPerms.values()) {
+      entry.resolve({ allow: false, deny_reason: 'Session ended.' });
     }
     this.pendingPerms.clear();
     this.rpc?.close();

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -845,6 +845,20 @@ app.whenReady().then(() => {
     }
   );
 
+  // Per-hunk partial accept for Edit / Write / MultiEdit (#251). Additive —
+  // the legacy `agent:resolvePermission` channel above stays as the whole-tool
+  // allow/deny path. Renderer should validate `acceptedHunks` is a non-empty
+  // subset of available hunk indices before invoking.
+  ipcMain.handle(
+    'agent:resolvePermissionPartial',
+    (e, sessionId: string, requestId: string, acceptedHunks: unknown) => {
+      if (!fromMainFrame(e)) return false;
+      if (!Array.isArray(acceptedHunks)) return false;
+      const indices = acceptedHunks.filter((n): n is number => Number.isInteger(n) && n >= 0);
+      return sessions.resolvePermissionPartial(sessionId, requestId, indices);
+    }
+  );
+
   ipcMain.handle('import:scan', () => getImportableSessions());
   ipcMain.handle('import:recentCwds', () => getRecentCwds());
   ipcMain.handle('import:topModel', () => getTopModel());

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -112,6 +112,17 @@ const api = {
     decision: 'allow' | 'deny'
   ): Promise<boolean> =>
     ipcRenderer.invoke('agent:resolvePermission', sessionId, requestId, decision),
+  /**
+   * Per-hunk partial accept (#251). `acceptedHunks` indices map to
+   * `DiffSpec.hunks` from `src/utils/diff.ts`. Empty array => deny.
+   * UI follow-up (#TBD) will surface this in PermissionPromptBlock.
+   */
+  agentResolvePermissionPartial: (
+    sessionId: string,
+    requestId: string,
+    acceptedHunks: number[]
+  ): Promise<boolean> =>
+    ipcRenderer.invoke('agent:resolvePermissionPartial', sessionId, requestId, acceptedHunks),
   onAgentEvent: (handler: (e: AgentEvent) => void): (() => void) => {
     const wrap = (_e: IpcRendererEvent, payload: AgentEvent) => handler(payload);
     ipcRenderer.on('agent:event', wrap);

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -99,6 +99,11 @@ declare global {
         requestId: string,
         decision: 'allow' | 'deny'
       ) => Promise<boolean>;
+      agentResolvePermissionPartial: (
+        sessionId: string,
+        requestId: string,
+        acceptedHunks: number[]
+      ) => Promise<boolean>;
       onAgentEvent: (handler: (e: AgentEvent) => void) => () => void;
       onAgentExit: (handler: (e: AgentExit) => void) => () => void;
       onAgentDiagnostic: (handler: (e: AgentDiagnostic) => void) => () => void;

--- a/tests/partial-write.test.ts
+++ b/tests/partial-write.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { filterToolInputByAcceptedHunks } from '../electron/agent/partial-write';
+
+describe('filterToolInputByAcceptedHunks (#251)', () => {
+  describe('legacy / no selection', () => {
+    it('undefined acceptedHunks => unchanged (legacy whole-allow path)', () => {
+      const r = filterToolInputByAcceptedHunks('Edit', { file_path: '/a', old_string: 'a', new_string: 'b' }, undefined);
+      expect(r).toEqual({ kind: 'unchanged' });
+    });
+
+    it('non-object input => unchanged (defensive)', () => {
+      expect(filterToolInputByAcceptedHunks('Edit', null, [0])).toEqual({ kind: 'unchanged' });
+      expect(filterToolInputByAcceptedHunks('Edit', 'string', [0])).toEqual({ kind: 'unchanged' });
+      expect(filterToolInputByAcceptedHunks('Edit', [], [0])).toEqual({ kind: 'unchanged' });
+    });
+
+    it('unknown tool => unchanged', () => {
+      expect(filterToolInputByAcceptedHunks('Bash', { command: 'ls' }, [])).toEqual({ kind: 'unchanged' });
+    });
+  });
+
+  describe('Edit (single hunk)', () => {
+    const editInput = { file_path: '/a', old_string: 'a', new_string: 'b' };
+    it('hunk 0 accepted => unchanged (full allow)', () => {
+      expect(filterToolInputByAcceptedHunks('Edit', editInput, [0])).toEqual({ kind: 'unchanged' });
+    });
+    it('empty selection => reject', () => {
+      expect(filterToolInputByAcceptedHunks('Edit', editInput, [])).toEqual({ kind: 'reject' });
+    });
+  });
+
+  describe('Write (single hunk)', () => {
+    const writeInput = { file_path: '/a', content: 'hello' };
+    it('hunk 0 accepted => unchanged', () => {
+      expect(filterToolInputByAcceptedHunks('Write', writeInput, [0])).toEqual({ kind: 'unchanged' });
+    });
+    it('empty selection => reject (would otherwise write empty file)', () => {
+      expect(filterToolInputByAcceptedHunks('Write', writeInput, [])).toEqual({ kind: 'reject' });
+    });
+  });
+
+  describe('MultiEdit', () => {
+    const meInput = {
+      file_path: '/a',
+      edits: [
+        { old_string: 'a', new_string: 'A' },
+        { old_string: 'b', new_string: 'B' },
+        { old_string: 'c', new_string: 'C' },
+      ],
+    };
+
+    it('all indices accepted => unchanged', () => {
+      expect(filterToolInputByAcceptedHunks('MultiEdit', meInput, [0, 1, 2])).toEqual({ kind: 'unchanged' });
+    });
+
+    it('subset accepted => updated input with only those edits, in order', () => {
+      const r = filterToolInputByAcceptedHunks('MultiEdit', meInput, [0, 2]);
+      expect(r.kind).toBe('updated');
+      if (r.kind !== 'updated') return;
+      expect(r.updatedInput.file_path).toBe('/a');
+      expect(r.updatedInput.edits).toEqual([
+        { old_string: 'a', new_string: 'A' },
+        { old_string: 'c', new_string: 'C' },
+      ]);
+    });
+
+    it('subset preserves array ordering even if indices given out of order', () => {
+      const r = filterToolInputByAcceptedHunks('MultiEdit', meInput, [2, 0]);
+      expect(r.kind).toBe('updated');
+      if (r.kind !== 'updated') return;
+      expect(r.updatedInput.edits).toEqual([
+        { old_string: 'a', new_string: 'A' },
+        { old_string: 'c', new_string: 'C' },
+      ]);
+    });
+
+    it('duplicate indices are deduped', () => {
+      const r = filterToolInputByAcceptedHunks('MultiEdit', meInput, [1, 1, 1]);
+      expect(r.kind).toBe('updated');
+      if (r.kind !== 'updated') return;
+      expect(r.updatedInput.edits).toEqual([{ old_string: 'b', new_string: 'B' }]);
+    });
+
+    it('empty selection => reject', () => {
+      expect(filterToolInputByAcceptedHunks('MultiEdit', meInput, [])).toEqual({ kind: 'reject' });
+    });
+
+    it('out-of-range / negative / non-integer indices are dropped', () => {
+      const r = filterToolInputByAcceptedHunks('MultiEdit', meInput, [-1, 99, 1.5, 1]);
+      expect(r.kind).toBe('updated');
+      if (r.kind !== 'updated') return;
+      expect(r.updatedInput.edits).toEqual([{ old_string: 'b', new_string: 'B' }]);
+    });
+
+    it('all indices invalid => reject', () => {
+      expect(filterToolInputByAcceptedHunks('MultiEdit', meInput, [99])).toEqual({ kind: 'reject' });
+    });
+
+    it('preserves other keys on the input object', () => {
+      const r = filterToolInputByAcceptedHunks(
+        'MultiEdit',
+        { ...meInput, replace_all: false },
+        [0]
+      );
+      expect(r.kind).toBe('updated');
+      if (r.kind !== 'updated') return;
+      expect(r.updatedInput.replace_all).toBe(false);
+      expect(r.updatedInput.file_path).toBe('/a');
+    });
+
+    it('does not mutate the caller-provided edits array', () => {
+      const original = JSON.parse(JSON.stringify(meInput));
+      filterToolInputByAcceptedHunks('MultiEdit', meInput, [1]);
+      expect(meInput).toEqual(original);
+    });
+
+    it('empty edits array => unchanged (nothing to filter)', () => {
+      expect(
+        filterToolInputByAcceptedHunks('MultiEdit', { file_path: '/a', edits: [] }, [0])
+      ).toEqual({ kind: 'unchanged' });
+    });
+  });
+});


### PR DESCRIPTION
Closes #251 (IPC scope only — see Follow-up below for UI).

## Scope chosen: IPC + main-side filter logic, NOT the renderer UI

Spike of `PermissionPromptBlock` confirmed there is currently **no diff visualization at all** in the permission prompt — the tool input is rendered as a flat key/value summary. Adding per-hunk checkboxes therefore requires:

1. Embedding `DiffView` (or a new hunk-list component) inside the prompt
2. Local hunk-selection state + "select all / none"
3. Replacing the single `Allow` button with `Apply selected (N/M)` + edge cases (0 selected -> Reject, all selected -> existing Allow path)
4. Keyboard model rework (current `y`/`n` global hotkey doesn't map cleanly onto a multi-select UI)
5. New e2e probe driving checkboxes via Playwright

That is a non-trivial UX change with its own design/review surface and would dwarf the IPC work. This PR ships the wire-level mechanism so the UI follow-up can be a pure-renderer change.

## What this PR does

- **`electron/agent/partial-write.ts`** — new pure helper `filterToolInputByAcceptedHunks(toolName, input, acceptedHunks)` returning `{ unchanged | updated | reject }`. Hunk indices map 1:1 to `DiffSpec.hunks` ordering produced by `src/utils/diff.ts`:
  - `Edit`/`Write` -> 1 hunk; empty selection -> `reject` (an empty Write would silently corrupt the file).
  - `MultiEdit` -> one hunk per `edits[]` entry; subset -> new input with `edits` filtered to chosen indices in original array order.
  - `undefined` acceptedHunks -> `unchanged` (legacy whole-tool allow).
- **`ClaudeRunner.resolvePermissionPartial(requestId, acceptedHunks)`** — uses the existing `updatedInput` channel of `can_use_tool` (already plumbed through `ControlRpc`) to forward the filtered input back to `claude.exe`.
- **PreToolUse hook resolver also forwards `updatedInput`** (added during reviewer follow-up; see "Reviewer-flagged bug fix" below). No protocol changes to the CLI side.
- **IPC `agent:resolvePermissionPartial`** in `electron/main.ts`, additive — `agent:resolvePermission` still works for the legacy whole-allow path. Preload bridge + `global.d.ts` typing updated.
- **Pending-perm bookkeeping** changed from `Map<string, resolve>` to `Map<string, { resolve, toolName, input }>` so the partial-resolve path can build `updatedInput` without an extra renderer round-trip.

## Reviewer-flagged bug fix (latest commit)

Reviewer found that `resolvePermissionPartial` resolves with `{ allow: true, updatedInput }` and `ControlRpc` correctly forwards `updatedInput` on the `can_use_tool` path — but Edit/Write/MultiEdit in CLI 2.x route through the **PreToolUse hook** path instead (matcher `.*` registered at `electron/agent/sessions.ts:456`). The hook resolver at `sessions.ts:622-643` only read `decision.allow` and emitted a static `permissionDecision: 'allow'`, **silently discarding `updatedInput`**. Result: a MultiEdit subset selection would still cause the CLI to run ALL edits.

**SDK path chosen: (a)** — the official PreToolUse hook protocol supports `hookSpecificOutput.updatedInput`, which the CLI uses to rewrite the tool's input before execution (same field semantics as the can_use_tool branch). This is the documented contract — no need to bypass the hook or scope the matcher.

**Fix** in `electron/agent/sessions.ts` (handleHookCallback resolve path):

```ts
resolve({
  hookSpecificOutput: {
    hookEventName: 'PreToolUse',
    permissionDecision: 'allow',
    ...(decision.updatedInput !== undefined
      ? { updatedInput: decision.updatedInput }
      : {}),
  },
});
```

The reject branch was already correct.

## Tests

- **17 unit tests** in `tests/partial-write.test.ts` (filter helper).
- **2 new tests** in `electron/agent/__tests__/sessions.test.ts` for the PreToolUse hook resolve path (reviewer gap):
  - Unit: hook resolver emits `hookSpecificOutput.updatedInput` when `resolvePermissionPartial` selects a subset of MultiEdit hunks.
  - **Integration**: full path from CLI-emitted `hook_callback` (MultiEdit, 3 hunks) through `resolvePermissionPartial([0,2])` to the outbound `control_response`, asserting trimmed `edits` AND that peer fields (`replace_all`, etc.) are preserved.

**Reverse-verify**: stashing the new `updatedInput`-forwarding line makes both new tests fail with "expected updatedInput to be defined / equal {...}, received undefined". Restoring -> 25/25 sessions tests pass.

Run results (latest):
- `npx tsc --noEmit`: clean
- `npm test`: 703/715 pass. The 12 failures are all in `electron/__tests__/db.test.ts` and `db-hardening.test.ts` — `better-sqlite3` `NODE_MODULE_VERSION 130 vs 127` native module mismatch, pre-existing infra issue, unrelated.

## Backwards compatibility

- `agent:resolvePermission` IPC + `agentResolvePermission` preload + `ClaudeRunner.resolvePermission` all unchanged.
- All pre-existing permission probes untouched and unaffected.
- The added `updatedInput` field is omitted when `decision.updatedInput` is undefined, so the legacy whole-allow hook payload is byte-identical.

## Follow-up

> **Renderer UI for per-hunk partial accept (#251 follow-up)**
> Wire `agentResolvePermissionPartial` into `PermissionPromptBlock`:
> - For Edit/Write/MultiEdit tool calls, render the diff via `DiffView` with a checkbox per hunk
> - Replace `Allow` with `Apply selected (N/M)`; disable when 0 selected and route to `Reject` when user clicks; route to legacy `agentResolvePermission` allow when all selected
> - Add a `probe-e2e-permission-partial-accept.mjs` driving the checkboxes
> - Reverse-verify: stash the partial-IPC fix and confirm the probe fails

## Test plan

- [x] Reviewer: confirm `filterToolInputByAcceptedHunks` matches `src/utils/diff.ts` hunk ordering for all three tool names
- [x] Reviewer: verify `updatedInput` actually forwards through `ControlRpc` (`electron/agent/control-rpc.ts:339-344`)
- [x] Reviewer: confirm `updatedInput` also forwards through the PreToolUse hook path (`electron/agent/sessions.ts:622-647`) — fixed in latest commit
- [x] Reviewer: integration test covers hook resolve path end-to-end (`sessions.test.ts` "integration: MultiEdit with 3 hunks + partial-accept")

Generated with [Claude Code](https://claude.com/claude-code)
