### PR TITLE
test+chore: e2e probes for tray/banner/toast i18n+a11y + text-meta naming align (#295 #296 #298 #300)

### DIFF
--- a/electron/__tests__/i18n.test.ts
+++ b/electron/__tests__/i18n.test.ts
@@ -89,4 +89,55 @@ describe('main process i18n', () => {
     expect(/[\u4e00-\u9fff]/.test(zhCwd)).toBe(true);
     expect(/[\u4e00-\u9fff]/.test(zhClaude)).toBe(true);
   });
+
+  // E2E coverage for #295 (tray-menu i18n).
+  //
+  // We can't drive the real Tray.setContextMenu() in CI: Electron's tray
+  // surface is OS-native (Windows shell notification area, GNOME indicator,
+  // macOS NSStatusItem) and exposes no scriptable accessor for the resolved
+  // menu items. Playwright sees the BrowserWindow tree, not the OS chrome.
+  //
+  // Instead this case asserts the underlying string source that
+  // `applyTrayLocale()` in electron/main.ts feeds into the menu template
+  // (`i18n.tTray(key)`). Coverage chain:
+  //   IPC ccsm:set-language → setMainLanguage → tTray returns localized →
+  //   Menu.buildFromTemplate uses those labels.
+  // The IPC handler itself is verified by the language-toggle E2E probe
+  // (scripts/probe-e2e-language-toggle.mjs) which calls
+  // window.ccsm.i18n.setLanguage and observes the renderer flip.
+  describe('#295 tray-menu i18n end-to-end via setMainLanguage', () => {
+    it('flipping language flips every tray catalog key, with no English bleed in zh', () => {
+      setMainLanguage('en');
+      const enLabels = {
+        show: tTray('show'),
+        quit: tTray('quit'),
+        tooltip: tTray('tooltip')
+      };
+      expect(enLabels.show).toBe('Show CCSM');
+      expect(enLabels.quit).toBe('Quit');
+
+      setMainLanguage('zh');
+      const zhLabels = {
+        show: tTray('show'),
+        quit: tTray('quit'),
+        tooltip: tTray('tooltip')
+      };
+      // Every menu item (show, quit) MUST contain CJK once switched.
+      // 'tooltip' is the brand 'CCSM' in both locales by design — exclude.
+      expect(/[\u4e00-\u9fff]/.test(zhLabels.show)).toBe(true);
+      expect(/[\u4e00-\u9fff]/.test(zhLabels.quit)).toBe(true);
+      // No English-only fallback leaked through.
+      expect(zhLabels.show).not.toBe(enLabels.show);
+      expect(zhLabels.quit).not.toBe(enLabels.quit);
+      expect(zhLabels.show).not.toMatch(/^Show /);
+      expect(zhLabels.quit).not.toMatch(/^Quit$/);
+
+      // Reverse-verify: revert to en and assert the English literals come
+      // back. This guards against a regression where setMainLanguage gets
+      // wired to a constant.
+      setMainLanguage('en');
+      expect(tTray('show')).toBe('Show CCSM');
+      expect(tTray('quit')).toBe('Quit');
+    });
+  });
 });

--- a/scripts/harness-ui.mjs
+++ b/scripts/harness-ui.mjs
@@ -469,6 +469,208 @@ async function caseTypeScaleSnapshot({ win, log }) {
   log(`sidebar=${sizes.sidebar.px}px assistant=${sizes.assistant.px}px tool=${sizes.tool.px}px dialog=${sizes.dialog.px}px`);
 }
 
+// ---------- banner-i18n-toggle ----------
+// Asserts AgentInitFailedBanner + AgentDiagnosticBanner re-render with the
+// active i18n catalog when the language preference flips. The banners read
+// their copy from the `banner.*` namespace via `useTranslation()`; if any
+// future regression hard-codes one of those strings, the corresponding
+// title check below will keep showing the English literal in zh and trip.
+//
+// Reverse-verify: temporarily change `<TopBanner title={t('banner...')}>`
+// in either AgentInitFailedBanner.tsx or AgentDiagnosticBanner.tsx to a
+// hardcoded English literal — this case must FAIL.
+async function caseBannerI18nToggle({ win, log }) {
+  // Seed an active session + a sessionInitFailures entry + a diagnostic
+  // entry so both banners mount above the chat surface.
+  await win.evaluate(() => {
+    window.__ccsmStore.setState({
+      groups: [{ id: 'g1', name: 'G1', collapsed: false, kind: 'normal' }],
+      sessions: [{ id: 's1', name: 'session-one', state: 'idle', cwd: 'C:/x', model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code' }],
+      activeId: 's1',
+      messagesBySession: { s1: [] },
+      sessionInitFailures: {
+        s1: { error: 'spawn ENOENT', errorCode: 'EUNKNOWN', timestamp: Date.now() }
+      },
+      diagnostics: [
+        { id: 'd1', sessionId: 's1', level: 'warn', code: 'INIT_HANDSHAKE_TIMEOUT', message: 'init handshake timed out', timestamp: Date.now(), dismissed: false }
+      ]
+    });
+  });
+  // Wait for the chat surface to render so the banners are mounted.
+  await win.locator('textarea[data-input-bar]').waitFor({ state: 'visible', timeout: 5000 });
+  await win.waitForTimeout(250);
+
+  async function setLang(lang) {
+    // Drive through window.ccsm.i18n.setLanguage which mirrors what
+    // SettingsDialog calls when the user picks a language. Also update
+    // the renderer i18next directly through __ccsmI18n to ensure the
+    // catalog swap is observed before the banner re-render assertion.
+    await win.evaluate((l) => {
+      window.ccsm?.i18n?.setLanguage?.(l);
+      const i18n = window.__ccsmI18n;
+      if (i18n && typeof i18n.changeLanguage === 'function') {
+        return i18n.changeLanguage(l);
+      }
+      return undefined;
+    }, lang);
+    await win.waitForTimeout(200);
+  }
+
+  async function readBannerTitles() {
+    return await win.evaluate(() => {
+      const initEl = document.querySelector('[data-testid="agent-init-failed-banner"]');
+      const diagEl = document.querySelector('[data-testid="agent-diagnostic-banner"]');
+      // The title slot inside <TopBanner /> is the first text element
+      // inside the grow column (font-semibold text-meta).
+      const text = (el) => (el?.textContent || '').trim();
+      return {
+        initText: text(initEl),
+        diagText: text(diagEl),
+        initFound: !!initEl,
+        diagFound: !!diagEl
+      };
+    });
+  }
+
+  // ---- English baseline ----
+  await setLang('en');
+  const en = await readBannerTitles();
+  if (!en.initFound) throw new Error('agent-init-failed-banner not mounted (en); did seeding miss sessionInitFailures?');
+  if (!en.diagFound) throw new Error('agent-diagnostic-banner not mounted (en); did seeding miss diagnostics?');
+  if (!/Failed to start Claude/i.test(en.initText)) {
+    throw new Error(`expected init banner to contain English title in en, got: ${en.initText}`);
+  }
+  if (!/Agent warning/i.test(en.diagText)) {
+    throw new Error(`expected diagnostic banner to contain English title in en, got: ${en.diagText}`);
+  }
+  if (/[\u4e00-\u9fff]/.test(en.initText) || /[\u4e00-\u9fff]/.test(en.diagText)) {
+    throw new Error(`unexpected CJK in en banners: init=${en.initText} diag=${en.diagText}`);
+  }
+
+  // ---- Switch to Chinese ----
+  await setLang('zh');
+  const zh = await readBannerTitles();
+  if (!zh.initFound || !zh.diagFound) {
+    throw new Error('banners disappeared after language switch (should re-render, not unmount)');
+  }
+  if (!/[\u4e00-\u9fff]/.test(zh.initText)) {
+    throw new Error(`expected CJK in init banner after zh switch, got: ${zh.initText}`);
+  }
+  if (!/[\u4e00-\u9fff]/.test(zh.diagText)) {
+    throw new Error(`expected CJK in diagnostic banner after zh switch, got: ${zh.diagText}`);
+  }
+  // Source-of-truth strings from src/i18n/locales/zh.ts. If these change
+  // intentionally update the assertions; if they change unintentionally
+  // the parity test will trip elsewhere.
+  if (!/无法启动 Claude/.test(zh.initText)) {
+    throw new Error(`expected zh init title '无法启动 Claude' in: ${zh.initText}`);
+  }
+  if (!/Agent 警告/.test(zh.diagText)) {
+    throw new Error(`expected zh diag title 'Agent 警告' in: ${zh.diagText}`);
+  }
+
+  // ---- Flip back to English ----
+  await setLang('en');
+  const en2 = await readBannerTitles();
+  if (!/Failed to start Claude/i.test(en2.initText)) {
+    throw new Error(`flip back to en: init banner did not revert, got: ${en2.initText}`);
+  }
+  if (/[\u4e00-\u9fff]/.test(en2.initText)) {
+    throw new Error(`flip back to en: CJK still present, got: ${en2.initText}`);
+  }
+
+  log('banners flip en→zh→en (init: "Failed to start Claude" ↔ "无法启动 Claude"; diag: "Agent warning" ↔ "Agent 警告")');
+}
+
+// ---------- toast-a11y ----------
+// Asserts the Toast a11y contract (#298 follow-up):
+//   - Error toasts live inside a region with role=alert + aria-live=assertive
+//     AND render a glyph icon (currently AlertCircle from lucide).
+//   - Default/info/waiting toasts live inside role=status + aria-live=polite.
+//   - Body click does NOT dismiss the toast (clicks anywhere outside the
+//     close button + outside the action button must be no-ops).
+//   - Close button DOES dismiss the toast.
+//
+// Reverse-verify: flip the error region role to "status" in
+// src/components/ui/Toast.tsx — this case must FAIL on the role check.
+async function caseToastA11y({ win, log }) {
+  // Wait for the ToastProvider to expose its bridge.
+  await win.waitForFunction(() => !!window.__ccsmToast, null, { timeout: 5000 });
+
+  // Push one of each variant. Use unique titles so we can locate them
+  // by text after.
+  const ids = await win.evaluate(() => {
+    const tx = window.__ccsmToast;
+    return {
+      errId: tx.push({ kind: 'error', title: 'TOAST-A11Y-ERR', body: 'boom', persistent: true }),
+      infoId: tx.push({ kind: 'info', title: 'TOAST-A11Y-INFO', persistent: true })
+    };
+  });
+  await win.waitForTimeout(200);
+
+  const regions = await win.evaluate(() => {
+    const errToast = document.querySelector('[data-testid="toast-error"]');
+    const infoToast = document.querySelector('[data-testid="toast-info"]');
+    const climb = (el) => {
+      let cur = el?.parentElement || null;
+      while (cur) {
+        const role = cur.getAttribute('role');
+        if (role === 'alert' || role === 'status') {
+          return { role, live: cur.getAttribute('aria-live') };
+        }
+        cur = cur.parentElement;
+      }
+      return null;
+    };
+    return {
+      errFound: !!errToast,
+      infoFound: !!infoToast,
+      errRegion: climb(errToast),
+      infoRegion: climb(infoToast),
+      errIcon: !!errToast?.querySelector('svg'),
+      errCloseBtn: !!errToast?.querySelector('button[aria-label]')
+    };
+  });
+
+  if (!regions.errFound) throw new Error('error toast did not render after push()');
+  if (!regions.infoFound) throw new Error('info toast did not render after push()');
+  if (!regions.errRegion) throw new Error('error toast has no ancestor live region');
+  if (!regions.infoRegion) throw new Error('info toast has no ancestor live region');
+  if (regions.errRegion.role !== 'alert' || regions.errRegion.live !== 'assertive') {
+    throw new Error(`error toast region expected role=alert + aria-live=assertive, got role=${regions.errRegion.role} live=${regions.errRegion.live}`);
+  }
+  if (regions.infoRegion.role !== 'status' || regions.infoRegion.live !== 'polite') {
+    throw new Error(`info toast region expected role=status + aria-live=polite, got role=${regions.infoRegion.role} live=${regions.infoRegion.live}`);
+  }
+  if (!regions.errIcon) throw new Error('error toast missing glyph icon (svg)');
+  if (!regions.errCloseBtn) throw new Error('error toast missing aria-labeled close button');
+
+  // Body-click does NOT dismiss. Click on the title element specifically.
+  await win.evaluate(() => {
+    const errToast = document.querySelector('[data-testid="toast-error"]');
+    const title = errToast?.querySelector('div.text-chrome, div.font-medium');
+    title?.click();
+  });
+  await win.waitForTimeout(150);
+  const stillThere = await win.evaluate(() => !!document.querySelector('[data-testid="toast-error"]'));
+  if (!stillThere) throw new Error('error toast was dismissed by body click — should be sticky to close button + Esc');
+
+  // Close button DOES dismiss.
+  await win.evaluate(() => {
+    const errToast = document.querySelector('[data-testid="toast-error"]');
+    const btn = errToast?.querySelector('button[aria-label]');
+    btn?.click();
+  });
+  await win.waitForTimeout(250);
+  const gone = await win.evaluate(() => !document.querySelector('[data-testid="toast-error"]'));
+  if (!gone) throw new Error('error toast survived close-button click');
+
+  // Cleanup the persistent info toast.
+  await win.evaluate((id) => window.__ccsmToast?.dismiss(id), ids.infoId);
+
+  log('error: role=alert/assertive + glyph + close-only dismiss; info: role=status/polite');
+}
+
 // ---------- harness spec ----------
 await runHarness({
   name: 'ui',
@@ -487,6 +689,8 @@ await runHarness({
     { id: 'a11y-focus-restore', run: caseA11yFocusRestore },
     { id: 'shortcut-overlay-opens', run: caseShortcutOverlayOpens },
     { id: 'popover-cross-dismiss', run: casePopoverCrossDismiss },
-    { id: 'type-scale-snapshot', run: caseTypeScaleSnapshot }
+    { id: 'type-scale-snapshot', run: caseTypeScaleSnapshot },
+    { id: 'banner-i18n-toggle', run: caseBannerI18nToggle },
+    { id: 'toast-a11y', run: caseToastA11y }
   ]
 });

--- a/src/components/ui/MetaLabel.tsx
+++ b/src/components/ui/MetaLabel.tsx
@@ -18,6 +18,12 @@ import { cn } from '../../lib/cn';
 //     "Recent" header where the larger leading reads better above a list
 //     row).
 //
+// Naming note (#300): MetaLabel rides the **mono** micro-scale
+// (`text-mono-xs` = 10/14, `text-mono-sm` = 11/15). It is NOT interchangeable
+// with the proportional `text-meta` (11px Inter) used for banner subtitles
+// and toast bodies. See the comment block above the `.text-mono-*` rules in
+// `src/styles/global.css` for the full rationale.
+//
 // We deliberately keep this as a thin wrapper rather than a styled span:
 // callers can still pass `className` to add layout (margins, padding,
 // alignment) without re-asserting the type recipe.

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -71,6 +71,18 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
 
   const value = useMemo(() => ({ push, dismiss }), [push, dismiss]);
 
+  // Expose toast push/dismiss on `window` for E2E probes (#298 toast-a11y
+  // case in scripts/harness-ui.mjs). Same debug-affordance pattern as
+  // `window.__ccsmStore` / `window.__ccsmI18n` — set unconditionally
+  // because production builds dead-strip NODE_ENV-gated branches.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    (window as unknown as { __ccsmToast?: ToastCtx }).__ccsmToast = value;
+    return () => {
+      delete (window as unknown as { __ccsmToast?: ToastCtx }).__ccsmToast;
+    };
+  }, [value]);
+
   // Esc dismisses the most recent toast — keyboard parity for users who
   // can't reach the close button via mouse. Only fires when at least one
   // toast is mounted so it doesn't swallow Esc elsewhere in the app.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -670,6 +670,25 @@ html.theme-light ::-webkit-scrollbar-thumb:hover {
        mono-sm : 11/15 — code paths, terminal headers, hint chips
        mono-md : 12/16 — popover input text, inline command labels
        mono-lg : 13/18 — palette command text (matches body-row)
+
+     ── Naming convention (#300, finalized) ──
+     `text-meta` (11px proportional) and `text-mono-xs` (10px mono) are
+     intentionally separate utilities, not interchangeable:
+       - `text-meta`   = 11px, line-height 14px, **proportional Inter**.
+                         Use for status pills, durations, hint chips, and
+                         anywhere a micro-label sits inside a body-text
+                         flow (banner subtitles, toast bodies). Defined
+                         in the semantic 4-step scale above.
+       - `text-mono-xs` = 10px, line-height 14px, **monospace**. Use for
+                         tool chip buttons, code byte counters, mono
+                         micro-labels (inside ToolBlock, DiffView,
+                         PrettyInput, etc).
+     They differ in BOTH font family AND size (11 vs 10), so composing
+     `text-meta font-mono` would silently bump 10px → 11px and break the
+     mono micro-scale alignment with mono-sm/md/lg. Keep them split.
+     The shared `MetaLabel` primitive (src/components/ui/MetaLabel.tsx)
+     wraps the mono variant; bare `text-meta` is the right choice when
+     the surrounding text is already proportional.
   */
   .text-mono-xs { font-size: 10px; line-height: 14px; }
   .text-mono-sm { font-size: 11px; line-height: 15px; }


### PR DESCRIPTION
## Summary

Bundle of four small follow-ups, each extending an existing probe rather than creating a new file (per `feedback_e2e_extend_existing.md`).

### Extended probe list

| Issue | File extended | Strategy |
| --- | --- | --- |
| #295 tray i18n | `electron/__tests__/i18n.test.ts` | Added `#295 tray-menu i18n end-to-end via setMainLanguage` describe block. Headless OS-tray inspection isn't viable (Win shell / GNOME indicator / NSStatusItem aren't scriptable from Playwright), so the assertion targets the underlying `tTray()` source that `applyTrayLocale()` feeds into `Menu.buildFromTemplate`. |
| #296 banner i18n | `scripts/harness-ui.mjs` | Added `banner-i18n-toggle` case. Seeds `sessionInitFailures` + `diagnostics`, drives `__ccsmI18n.changeLanguage` en→zh→en, asserts AgentInitFailedBanner + AgentDiagnosticBanner titles swap verbatim. |
| #298 toast a11y | `scripts/harness-ui.mjs` | Added `toast-a11y` case. Exposed `window.__ccsmToast` debug bridge (sibling of `__ccsmStore` / `__ccsmI18n`), asserts error region role=alert/aria-live=assertive + glyph + close-only dismiss, info region role=status/polite. |
| #300 text-meta naming | `src/styles/global.css` + `src/components/ui/MetaLabel.tsx` | Picked option 2 (document the split). `text-meta` (11px proportional) and `text-mono-xs` (10px mono) are intentionally separate — composing `text-meta font-mono` would silently bump 10→11px and break the mono micro-scale ladder. No callsite churn. |

### Reverse-verify (per `feedback_bugfix_requires_e2e.md`)

All three new e2e assertions reverse-verified locally:

- Hardcode `AgentInitFailedBanner` title to a literal → `banner-i18n-toggle` case FAILS with `expected zh init title '无法启动 Claude' in: Failed to start Claude…`. Restored.
- Flip error toast region role from `alert` to `status` → `toast-a11y` case FAILS with `expected role=alert + aria-live=assertive, got role=status live=polite`. Restored.
- Stub `setMainLanguage` to a no-op → new `#295` test FAILS with `expected false to be true` on the CJK regex check. Restored.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run electron/__tests__/i18n.test.ts` — 7/7 pass (was 6 before, +1 new test)
- [x] `npm run build` succeeds (renderer + electron main)
- [x] `node scripts/harness-ui.mjs --only=banner-i18n-toggle` — PASS
- [x] `node scripts/harness-ui.mjs --only=toast-a11y` — PASS
- [x] Lint baseline unchanged (29 pre-existing errors in `verification/*.mjs`, no new errors introduced)
- [x] Reverse-verify all three assertions

Note: full `npm test` has 12 pre-existing failures from a `better-sqlite3` Node ABI mismatch (NODE_MODULE_VERSION 130 vs 127 — not introduced by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)