### PR TITLE
fix(notify): retry rechecks gates + toast reject cancels retry (#307 #308)

### DIFF
--- a/electron/__tests__/notify-retry.test.ts
+++ b/electron/__tests__/notify-retry.test.ts
@@ -7,6 +7,35 @@ import {
   __resetRetryStateForTests,
 } from '../notify-retry';
 import * as notifyMod from '../notify';
+import {
+  setNotifyRuntimeState,
+  __resetNotifyRuntimeStateForTests,
+} from '../notify-bootstrap';
+
+vi.mock('electron', () => {
+  const fakeWindows: Array<{
+    isDestroyed: () => boolean;
+    isFocused: () => boolean;
+    isVisible: () => boolean;
+  }> = [];
+  return {
+    BrowserWindow: {
+      getAllWindows: () => fakeWindows,
+      __setFakeWindows: (
+        wins: Array<{ focused: boolean; visible: boolean; destroyed?: boolean }>,
+      ) => {
+        fakeWindows.length = 0;
+        for (const w of wins) {
+          fakeWindows.push({
+            isDestroyed: () => !!w.destroyed,
+            isFocused: () => w.focused,
+            isVisible: () => w.visible,
+          });
+        }
+      },
+    },
+  };
+});
 
 // We run the retry logic against a virtual scheduler so the 30s timer is
 // observable instantly. Real setTimeout would either slow tests by 30s or
@@ -45,6 +74,7 @@ describe('notify-retry', () => {
   afterEach(() => {
     __setRetrySchedulerForTests(null, null);
     __resetRetryStateForTests();
+    __resetNotifyRuntimeStateForTests();
     vi.restoreAllMocks();
   });
 
@@ -140,5 +170,111 @@ describe('notify-retry', () => {
     fireDueTimers();
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy.mock.calls[0][0].toastId).toBe('q-b');
+  });
+
+  // Fire-time gate rechecks (#307). The retry timer fires in main ~30s
+  // after schedule; by then the user could have toggled notifications off
+  // or focused the question's session. Schedule-time gates are NOT
+  // sufficient — fire-time MUST recheck.
+  describe('fire-time gate rechecks (#307)', () => {
+    it('suppresses fire when notifications were disabled during the window', () => {
+      const spy = vi
+        .spyOn(notifyMod, 'notifyQuestion')
+        .mockResolvedValue(undefined);
+      // Schedule with state that would normally allow the retry.
+      setNotifyRuntimeState({ notificationsEnabled: true, activeSessionId: null });
+      scheduleQuestionRetry(basePayload, 'session-a');
+      // Simulate the user toggling notifications off during the 30s window.
+      setNotifyRuntimeState({ notificationsEnabled: false });
+      fireDueTimers();
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('fires when notifications stay enabled and the user is on a different session', () => {
+      const spy = vi
+        .spyOn(notifyMod, 'notifyQuestion')
+        .mockResolvedValue(undefined);
+      setNotifyRuntimeState({
+        notificationsEnabled: true,
+        activeSessionId: 'session-other',
+      });
+      scheduleQuestionRetry(basePayload, 'session-a');
+      fireDueTimers();
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(basePayload);
+    });
+
+    it('fires when sessionId is unknown (null) regardless of focus state', () => {
+      // No sessionId carried (legacy callers / defensive default) — only
+      // the global notifications-enabled gate applies. Without sessionId,
+      // we can't compare against activeSessionId so the focus check is
+      // skipped and the retry proceeds.
+      const spy = vi
+        .spyOn(notifyMod, 'notifyQuestion')
+        .mockResolvedValue(undefined);
+      setNotifyRuntimeState({
+        notificationsEnabled: true,
+        activeSessionId: 'session-a',
+      });
+      scheduleQuestionRetry(basePayload, null);
+      fireDueTimers();
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('suppresses fire when window is focused AND activeSessionId matches', async () => {
+      const spy = vi
+        .spyOn(notifyMod, 'notifyQuestion')
+        .mockResolvedValue(undefined);
+      // Reach in to flip the fake BrowserWindow into a focused state.
+      const electron = await import('electron');
+      (electron.BrowserWindow as unknown as {
+        __setFakeWindows: (
+          wins: Array<{ focused: boolean; visible: boolean }>,
+        ) => void;
+      }).__setFakeWindows([{ focused: true, visible: true }]);
+      setNotifyRuntimeState({
+        notificationsEnabled: true,
+        activeSessionId: 'session-a',
+      });
+      scheduleQuestionRetry(basePayload, 'session-a');
+      fireDueTimers();
+      expect(spy).not.toHaveBeenCalled();
+      // Reset the fake windows so other tests aren't affected.
+      (electron.BrowserWindow as unknown as {
+        __setFakeWindows: (
+          wins: Array<{ focused: boolean; visible: boolean }>,
+        ) => void;
+      }).__setFakeWindows([]);
+    });
+  });
+
+  // Toast-action reject must cancel any pending question retry (#308).
+  // The toast-action router in main.ts calls `cancelQuestionRetry` on both
+  // `q-${requestId}` and the bare `requestId` so a defensive future change
+  // routing question activations through the same path doesn't leak the
+  // timer past the user's explicit reject.
+  describe('toast-action reject cancellation (#308)', () => {
+    it('cancelQuestionRetry on matching q-prefixed id removes a scheduled retry before it fires', () => {
+      const spy = vi
+        .spyOn(notifyMod, 'notifyQuestion')
+        .mockResolvedValue(undefined);
+      // Simulate a question scheduled with the lifecycle's q-${requestId}
+      // toast id.
+      const requestId = 'req-reject-1';
+      const toastId = `q-${requestId}`;
+      scheduleQuestionRetry({ ...basePayload, toastId }, 'session-a');
+      expect(__pendingRetryCountForTests()).toBe(1);
+
+      // Mirror the main.ts toast-action reject branch — cancel against both
+      // keys (`q-${requestId}` and the bare requestId). The bare-id call is
+      // a safe no-op when no entry exists; the q-prefixed call hits the
+      // pending entry and removes it.
+      cancelQuestionRetry(`q-${requestId}`);
+      cancelQuestionRetry(requestId);
+
+      expect(__pendingRetryCountForTests()).toBe(0);
+      fireDueTimers();
+      expect(spy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -79,8 +79,8 @@ import { showNotification, type ShowNotificationPayload } from './notifications'
 import { probeNotifyAvailability, notifyLastError } from './notify';
 import {
   bootstrapNotify,
-  lookupToastTarget,
-  consumeToastTarget,
+  setNotifyRuntimeState,
+  createDefaultToastActionRouter,
 } from './notify-bootstrap';
 import { cancelQuestionRetry } from './notify-retry';
 import type { PermissionMode } from './agent/sessions';
@@ -464,44 +464,15 @@ app.whenReady().then(() => {
   // button clicks (Allow / Allow always / Reject / Focus) back into the same
   // code paths the in-app prompts use.
   try {
-    bootstrapNotify((event) => {
-      const target = lookupToastTarget(event.toastId);
-      if (!target) return;
-      const win = BrowserWindow.getAllWindows().find((w) => !w.isDestroyed());
-      if (target.kind === 'permission') {
-        // The toastId for permission events IS the requestId (see lifecycle.ts
-        // → permissionRequestToWaitingBlock). Resolve the underlying CLI
-        // permission gate and notify the renderer so it can update its
-        // waiting-block UI + (for `allow-always`) seed `allowAlwaysTools`.
-        const requestId = event.toastId;
-        if (event.action === 'allow' || event.action === 'allow-always') {
-          sessions.resolvePermission(target.sessionId, requestId, 'allow');
-        } else if (event.action === 'reject') {
-          sessions.resolvePermission(target.sessionId, requestId, 'deny');
-        }
-        if (win) {
-          win.webContents.send('notify:toastAction', {
-            sessionId: target.sessionId,
-            requestId,
-            action: event.action,
-          });
-        }
-        consumeToastTarget(event.toastId);
-      } else if (target.kind === 'question' || target.kind === 'turn_done') {
-        // Questions + turn_done only carry `focus`; other actions are no-ops
-        // here (the renderer drives the actual answer flow once focused).
-        consumeToastTarget(event.toastId);
-      }
-      // Always raise the window on any action — the user clicked the toast,
-      // they want to see ccsm. Mirrors the existing `notification:focusSession`
-      // path used by the legacy Electron Notification.
-      if (win) {
-        if (win.isMinimized()) win.restore();
-        if (!win.isVisible()) win.show();
-        win.focus();
-        win.webContents.send('notification:focusSession', target.sessionId);
-      }
-    });
+    bootstrapNotify(
+      createDefaultToastActionRouter({
+        resolvePermission: (sessionId, requestId, decision) =>
+          sessions.resolvePermission(sessionId, requestId, decision),
+        cancelQuestionRetry,
+        getMainWindow: () =>
+          BrowserWindow.getAllWindows().find((w) => !w.isDestroyed()) ?? null,
+      }),
+    );
   } catch (err) {
     // bootstrapNotify already swallows internally; this is belt-and-suspenders
     // so an unexpected throw still can't take down app startup.
@@ -1179,6 +1150,25 @@ app.whenReady().then(() => {
     const available = await probeNotifyAvailability();
     return { available, error: notifyLastError() };
   });
+
+  // Renderer → main mirror of notification runtime state (#307). The
+  // ask-question retry timer fires in main ~30s after the original toast;
+  // by then the user may have toggled notifications off or focused the
+  // question's session. The renderer's store is the source of truth, so
+  // it pushes the two fields the retry gate needs (`notificationsEnabled`,
+  // `activeSessionId`) whenever they change. Partial payload — both fields
+  // are independently optional.
+  ipcMain.handle(
+    'notify:setRuntimeState',
+    (
+      e,
+      patch: { notificationsEnabled?: boolean; activeSessionId?: string | null },
+    ): { ok: true } | { ok: false } => {
+      if (!fromMainFrame(e)) return { ok: false };
+      setNotifyRuntimeState(patch);
+      return { ok: true };
+    },
+  );
 
   installUpdaterIpc();
 

--- a/electron/notifications.ts
+++ b/electron/notifications.ts
@@ -179,7 +179,10 @@ async function emitAdaptiveToast(payload: ShowNotificationPayload): Promise<void
       // `agent:resolvePermission` IPC handler when the question is answered
       // (in-app QuestionBlock submit calls agentResolvePermission with
       // decision='deny' to release the underlying CLI gate).
-      scheduleQuestionRetry(questionPayload);
+      // sessionId is forwarded so the retry's fire-time gate (#307) can
+      // suppress the re-emit when the user has since focused this session
+      // or globally disabled notifications.
+      scheduleQuestionRetry(questionPayload, payload.sessionId);
       return;
     }
     case 'turn_done': {

--- a/electron/notify-bootstrap.ts
+++ b/electron/notify-bootstrap.ts
@@ -112,6 +112,146 @@ export function shouldSuppressForFocus(): boolean {
   return false;
 }
 
+// ── Runtime-state mirror (#307) ──────────────────────────────────────────
+//
+// The renderer-side `dispatchNotification` evaluates the user's notification
+// preferences (global enabled toggle, per-event toggles, per-session mute,
+// debounce) BEFORE asking main to fire a toast. Initial emits therefore
+// honour those gates by construction. The ask-question retry timer (#252),
+// however, lives in main and re-emits ~30s later — by which time the user
+// may have toggled notifications off or focused the question's session.
+// Without a mirror of the relevant renderer state, the retry would happily
+// fire through that closed gate.
+//
+// Mirror is push-based: the renderer subscribes to its own store and pushes
+// the two fields that matter for retry gating (`notificationsEnabled`,
+// `activeSessionId`) via `notify:setRuntimeState` whenever they change.
+// Defaults are conservative — we assume notifications are enabled until the
+// renderer tells us otherwise so a renderer that never wires the bridge
+// doesn't accidentally suppress every toast.
+interface NotifyRuntimeState {
+  notificationsEnabled: boolean;
+  activeSessionId: string | null;
+}
+
+const runtimeState: NotifyRuntimeState = {
+  notificationsEnabled: true,
+  activeSessionId: null,
+};
+
+/**
+ * Update the main-process mirror of renderer notification state. Called
+ * via the `notify:setRuntimeState` IPC handler. Partial — fields not
+ * present are left unchanged so the renderer can push deltas.
+ */
+export function setNotifyRuntimeState(patch: Partial<NotifyRuntimeState>): void {
+  if (typeof patch.notificationsEnabled === 'boolean') {
+    runtimeState.notificationsEnabled = patch.notificationsEnabled;
+  }
+  if (patch.activeSessionId === null || typeof patch.activeSessionId === 'string') {
+    runtimeState.activeSessionId = patch.activeSessionId;
+  }
+}
+
+/** Read-only snapshot for gate-checks at toast-fire time. */
+export function getNotifyRuntimeState(): Readonly<NotifyRuntimeState> {
+  return runtimeState;
+}
+
+/**
+ * Combined gate evaluated at retry-fire time (#307). Returns true when the
+ * caller should NOT fire — either the user globally disabled notifications,
+ * or the user is focused on the question's own session (so the in-app
+ * affordance is already visible and a fresh OS toast would be noise).
+ *
+ * Pure read against `runtimeState` + `BrowserWindow.isFocused()`; safe to
+ * call repeatedly and from any module without circular-import risk.
+ */
+export function shouldSuppressRetry(sessionId: string | null | undefined): boolean {
+  if (!runtimeState.notificationsEnabled) return true;
+  if (sessionId && runtimeState.activeSessionId === sessionId) {
+    if (shouldSuppressForFocus()) return true;
+  }
+  return false;
+}
+
+/** Test-only — restore mirror to defaults between unit tests. */
+export function __resetNotifyRuntimeStateForTests(): void {
+  runtimeState.notificationsEnabled = true;
+  runtimeState.activeSessionId = null;
+}
+
+// ── Default toast-action router factory (#308) ───────────────────────────
+//
+// Extracted from main.ts so the e2e probe can install the EXACT same
+// router behaviour rather than a hand-rolled copy that drifts from
+// production. The router consumes a few host capabilities (resolve
+// permission against the live session manager, cancel pending question
+// retries, look up the foreground window) injected as functions so this
+// module stays free of cyclic imports against `agent/sessions` and
+// `notify-retry`.
+export interface ToastActionRouterDeps {
+  /** Resolve a CLI permission gate (typically `sessions.resolvePermission`). */
+  resolvePermission: (sessionId: string, requestId: string, decision: 'allow' | 'deny') => unknown;
+  /** Cancel a scheduled question retry (typically from `notify-retry`). */
+  cancelQuestionRetry: (toastId: string) => void;
+  /** Returns the window to send `notify:toastAction` to, or null. */
+  getMainWindow: () => { isDestroyed?: () => boolean; webContents?: { send: (channel: string, payload: unknown) => void }; isMinimized?: () => boolean; restore?: () => void; isVisible?: () => boolean; show?: () => void; focus?: () => void } | null;
+}
+
+export function createDefaultToastActionRouter(
+  deps: ToastActionRouterDeps,
+): (event: { toastId: string; action: 'allow' | 'allow-always' | 'reject' | 'focus'; args: Record<string, string> }) => void {
+  return (event) => {
+    const target = lookupToastTarget(event.toastId);
+    if (!target) return;
+    const win = deps.getMainWindow();
+    if (target.kind === 'permission') {
+      // The toastId for permission events IS the requestId (see lifecycle.ts
+      // → permissionRequestToWaitingBlock). Resolve the underlying CLI
+      // permission gate and notify the renderer so it can update its
+      // waiting-block UI + (for `allow-always`) seed `allowAlwaysTools`.
+      const requestId = event.toastId;
+      if (event.action === 'allow' || event.action === 'allow-always') {
+        deps.resolvePermission(target.sessionId, requestId, 'allow');
+      } else if (event.action === 'reject') {
+        deps.resolvePermission(target.sessionId, requestId, 'deny');
+        // Defensive cancel (#308): permission toasts don't schedule a retry
+        // today (only question events do), but if a future change ever
+        // routes question activations through the same toast-action path,
+        // a forgotten cancel would leak the timer past the user's explicit
+        // reject. Cheap belt-and-suspenders — `cancelQuestionRetry` is a
+        // safe no-op when no entry exists. Both id shapes are tried so
+        // either lifecycle convention (`q-${requestId}` or bare requestId)
+        // is covered.
+        deps.cancelQuestionRetry(`q-${requestId}`);
+        deps.cancelQuestionRetry(requestId);
+      }
+      if (win && win.webContents) {
+        win.webContents.send('notify:toastAction', {
+          sessionId: target.sessionId,
+          requestId,
+          action: event.action,
+        });
+      }
+      consumeToastTarget(event.toastId);
+    } else if (target.kind === 'question' || target.kind === 'turn_done') {
+      // Questions + turn_done only carry `focus`; other actions are no-ops
+      // here (the renderer drives the actual answer flow once focused).
+      consumeToastTarget(event.toastId);
+    }
+    // Always raise the window on any action — the user clicked the toast,
+    // they want to see ccsm. Mirrors the existing `notification:focusSession`
+    // path used by the legacy Electron Notification.
+    if (win) {
+      if (win.isMinimized?.()) win.restore?.();
+      if (!win.isVisible?.()) win.show?.();
+      win.focus?.();
+      win.webContents?.send('notification:focusSession', target.sessionId);
+    }
+  };
+}
+
 /**
  * Track which session a given toastId belongs to so the onAction router can
  * call back into the agent runner with the right sessionId. Populated by

--- a/electron/notify-retry.ts
+++ b/electron/notify-retry.ts
@@ -27,6 +27,7 @@
 // instead of two).
 
 import { notifyQuestion, type QuestionPayload } from './notify';
+import { shouldSuppressRetry } from './notify-bootstrap';
 
 const DEFAULT_RETRY_DELAY_MS = 30_000;
 const MAX_RETRIES = 1;
@@ -35,6 +36,11 @@ interface PendingRetry {
   remaining: number;
   timer: ReturnType<typeof setTimeout>;
   payload: QuestionPayload;
+  // sessionId captured at schedule time so the fire-time gate
+  // (`shouldSuppressRetry`) can compare against the renderer's current
+  // activeSessionId. QuestionPayload itself doesn't carry sessionId — it's
+  // a wrapper-shaped type — so we keep it alongside.
+  sessionId: string | null;
 }
 
 const pending = new Map<string, PendingRetry>();
@@ -62,9 +68,15 @@ export function __setRetrySchedulerForTests(
  * `delayMs` (default 30s). Idempotent per `payload.toastId`: a second call
  * for the same id while a retry is still pending is a no-op (the original
  * scheduling stands; we don't want overlapping timers).
+ *
+ * `sessionId` is captured for fire-time gate evaluation (#307) — the retry
+ * checks `shouldSuppressRetry(sessionId)` before re-emitting so a user who
+ * disabled notifications or focused the question's session during the
+ * 30s window doesn't get a stale toast.
  */
 export function scheduleQuestionRetry(
   payload: QuestionPayload,
+  sessionId: string | null = null,
   delayMs: number = DEFAULT_RETRY_DELAY_MS,
 ): void {
   const id = payload.toastId;
@@ -73,6 +85,7 @@ export function scheduleQuestionRetry(
   const entry: PendingRetry = {
     remaining: MAX_RETRIES,
     payload,
+    sessionId,
     // The timer body is set after entry-creation so the cleanup path
     // (`pending.delete(id)`) runs unconditionally even if `notifyQuestion`
     // throws synchronously (it shouldn't — wrapper is async-no-throw — but
@@ -90,6 +103,12 @@ function fireRetry(id: string): void {
   // the entry while the wrapper runs, but be explicit).
   entry.remaining -= 1;
   pending.delete(id);
+  // Recheck gates at fire time (#307). Settings could have flipped or the
+  // user could have focused the originating session during the 30s window;
+  // either way the retry should NOT re-emit. We do this here (not at
+  // schedule time) because the gate state lives outside this module and
+  // can change at any moment between schedule and fire.
+  if (shouldSuppressRetry(entry.sessionId)) return;
   void notifyQuestion(entry.payload).catch(() => {
     /* wrapper logs internally */
   });
@@ -113,6 +132,11 @@ export function cancelQuestionRetry(toastId: string): void {
  */
 export function __pendingRetryCountForTests(): number {
   return pending.size;
+}
+
+/** Test-only inspector — returns the toastId keys of the pending map. */
+export function __pendingRetryKeysForTests(): string[] {
+  return Array.from(pending.keys());
 }
 
 /** Test-only reset — clears all pending entries (timers leaked intentionally

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -246,6 +246,16 @@ const api = {
   }): Promise<boolean> => ipcRenderer.invoke('notification:show', payload),
   notifyAvailability: (): Promise<{ available: boolean; error: string | null }> =>
     ipcRenderer.invoke('notify:availability'),
+  /**
+   * Push the renderer's notification runtime state into the main process
+   * mirror so the ask-question retry timer (#307) can recheck gates at
+   * fire time. Both fields independently optional. Returns `{ok}` mainly
+   * for parity with other handlers; renderers fire-and-forget.
+   */
+  notifySetRuntimeState: (
+    patch: { notificationsEnabled?: boolean; activeSessionId?: string | null },
+  ): Promise<{ ok: true } | { ok: false }> =>
+    ipcRenderer.invoke('notify:setRuntimeState', patch),
   onNotificationFocus: (handler: (sessionId: string) => void): (() => void) => {
     const wrap = (_e: IpcRendererEvent, sessionId: string) => handler(sessionId);
     ipcRenderer.on('notification:focusSession', wrap);

--- a/scripts/probe-e2e-notify-integration.mjs
+++ b/scripts/probe-e2e-notify-integration.mjs
@@ -26,6 +26,14 @@
 // (only one notifyQuestion call instead of two). Stash the
 // `cancelQuestionRetry(...)` calls in `electron/main.ts` ⇒ assertion 10
 // trips (timer not cancelled).
+// For task #307 / #308:
+//   * Stash `if (shouldSuppressRetry(entry.sessionId)) return;` in
+//     `electron/notify-retry.ts:fireRetry` ⇒ case 10b trips (the retry
+//     fires through the closed gate and produces an extra question call).
+//   * Stash the `cancelQuestionRetry(\`q-\${requestId}\`)` /
+//     `cancelQuestionRetry(requestId)` lines in the toast-action reject
+//     branch of `electron/main.ts` ⇒ case 10c trips (live retry timer
+//     count does NOT decrease after reject).
 
 import { _electron as electron } from 'playwright';
 import path from 'node:path';
@@ -102,20 +110,14 @@ try {
     bootstrapMod.__resetBootstrapForTests();
     bootstrapMod.bootstrapNotify((event) => {
       g.__notifyCalls.push({ kind: 'router', event });
-      const target = bootstrapMod.lookupToastTarget(event.toastId);
-      if (target && target.kind === 'permission') {
-        const decision = event.action === 'reject' ? 'deny' : 'allow';
-        dbg.sessions.resolvePermission(target.sessionId, event.toastId, decision);
-        const w = BrowserWindow.getAllWindows().find((x) => !x.isDestroyed());
-        if (w) {
-          w.webContents.send('notify:toastAction', {
-            sessionId: target.sessionId,
-            requestId: event.toastId,
-            action: event.action,
-          });
-        }
-        bootstrapMod.consumeToastTarget(event.toastId);
-      }
+      // Delegate to the production router (#308) so we test the actual
+      // wiring rather than a probe-local copy. createDefaultToastActionRouter
+      // returns the same logic main.ts installs (cancel-on-reject etc.).
+      bootstrapMod.createDefaultToastActionRouter({
+        resolvePermission: dbg.sessions.resolvePermission.bind(dbg.sessions),
+        cancelQuestionRetry: dbg.notifyRetry.cancelQuestionRetry,
+        getMainWindow: () => BrowserWindow.getAllWindows().find((x) => !x.isDestroyed()) ?? null,
+      })(event);
     });
     await notifyMod.probeNotifyAvailability();
     return notifyMod.isNotifyAvailable();
@@ -506,6 +508,218 @@ try {
   if (afterCancel !== beforeCancel + 1) fail(`expected exactly 1 question call (no retry) after cancellation, got ${afterCancel - beforeCancel}`);
   console.log('[probe-e2e-notify-integration] question retry cancellation OK');
 
+  // ── 10b. Fire-time gate (#307): notifications-disabled suppresses retry ─
+  //
+  // The retry timer fires in main process ~30s after the original toast.
+  // If the user toggled notifications off during that window, the retry
+  // MUST NOT re-emit. We push the runtime-state mirror via the renderer
+  // bridge (`window.ccsm.notifySetRuntimeState`) so this exercises the
+  // full IPC path the production renderer uses.
+  //
+  // Reverse-verify: stash the `if (shouldSuppressRetry(entry.sessionId)) return;`
+  // line in `electron/notify-retry.ts:fireRetry` and re-run; this case
+  // FAILS (the retry fires through the closed gate ⇒ extra question call).
+  const GATE_REQ = 'probe-q-gate-1';
+  const GATE_TOAST_ID = `q-${GATE_REQ}`;
+  // Reset state: notifications enabled, no active session collision.
+  await win.evaluate(() =>
+    window.ccsm.notifySetRuntimeState({
+      notificationsEnabled: true,
+      activeSessionId: null,
+    }),
+  );
+  const beforeGate = await app.evaluate(() => (globalThis.__notifyCalls || []).filter((c) => c.kind === 'question').length);
+
+  await win.evaluate((args) => {
+    return window.ccsm.notify({
+      sessionId: args.sessionId,
+      title: 'Question (gate)',
+      body: 'Pick one',
+      eventType: 'question',
+      extras: {
+        toastId: args.toastId,
+        sessionName: 'Test Session',
+        question: 'Pick one',
+        selectionKind: 'single',
+        optionCount: 2,
+        cwd: '/tmp/probe-cwd',
+      },
+    });
+  }, { sessionId, toastId: GATE_TOAST_ID });
+
+  // Wait for the initial question call + queued retry timer.
+  await app.evaluate(async () => {
+    const deadline = Date.now() + 3000;
+    while (Date.now() < deadline) {
+      const qCount = (globalThis.__notifyCalls || []).filter((c) => c.kind === 'question').length;
+      const retryCount = globalThis.__retryQueue.filter((q) => !q.entry.cancelled).length;
+      if (qCount >= 1 && retryCount >= 1) return;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    throw new Error('timeout waiting for gate-case initial question + retry schedule');
+  });
+
+  // Now flip notifications OFF before firing the retry timer.
+  await win.evaluate(() =>
+    window.ccsm.notifySetRuntimeState({ notificationsEnabled: false }),
+  );
+  // Round-trip beat for the IPC.
+  await new Promise((r) => setTimeout(r, 200));
+
+  // Manually fire the retry timer that was scheduled for THIS toast id.
+  await app.evaluate((toastId) => {
+    const live = globalThis.__retryQueue.filter(
+      (q) => !q.entry.cancelled && q.entry.cb,
+    );
+    // We can't see the toastId from inside the timer cb (it's closed-over),
+    // so we fire the most-recent live timer — which corresponds to the
+    // gate-case schedule because it was the last `notify` we made.
+    const last = live[live.length - 1];
+    if (!last) throw new Error('no live retry timer to fire for gate case');
+    last.entry.cb();
+    void toastId;
+  }, GATE_TOAST_ID);
+
+  // Give fireRetry a beat to either emit (bug) or no-op (correct).
+  await new Promise((r) => setTimeout(r, 200));
+  const afterGate = await app.evaluate(() => (globalThis.__notifyCalls || []).filter((c) => c.kind === 'question').length);
+  if (afterGate !== beforeGate + 1) {
+    fail(`expected exactly 1 question call when notifications disabled at fire-time, got ${afterGate - beforeGate}`);
+  }
+  // Restore enabled for subsequent assertions.
+  await win.evaluate(() =>
+    window.ccsm.notifySetRuntimeState({ notificationsEnabled: true }),
+  );
+  await new Promise((r) => setTimeout(r, 100));
+  console.log('[probe-e2e-notify-integration] fire-time settings gate OK');
+
+  // ── 10c. Toast-action reject cancels pending retry (#308) ────────────────
+  //
+  // The toast-action router in main.ts (`bootstrapNotify` onAction
+  // callback) routes permission-toast rejects through
+  // `sessions.resolvePermission(... 'deny')`. Today permission events
+  // don't schedule retries (only question events do, and those are routed
+  // separately), but the reject branch must defensively call
+  // `cancelQuestionRetry` so a future change wiring questions through the
+  // same path can't leak the timer past the user's explicit reject.
+  //
+  // Note on the assertion strategy: the reject path already goes through
+  // the renderer IPC `agent:resolvePermission` handler as a SIDE EFFECT
+  // (via `store.resolvePermission` called from `onNotifyToastAction`), and
+  // THAT handler ALSO calls `cancelQuestionRetry`. So observing "did the
+  // pending retry drop?" alone doesn't distinguish the router's own cancel
+  // call from the IPC's cancel call. Instead we wrap
+  // `cancelQuestionRetry` in a spy and assert the router invokes it
+  // directly at least once.
+  //
+  // Reverse-verify: stash the `deps.cancelQuestionRetry(...)` lines inside
+  // `createDefaultToastActionRouter` (`electron/notify-bootstrap.ts`, reject
+  // branch) and re-run; this case FAILS because the wrapped spy only
+  // observes the IPC-side call (if any), never the router-direct call.
+  const REJECT_REQ = 'probe-q-reject-1';
+  // Ensure the window is blurred so focus suppression doesn't gate the
+  // initial emit (case 8 above re-focused it).
+  await app.evaluate(({ BrowserWindow }) => {
+    for (const w of BrowserWindow.getAllWindows()) {
+      try { w.blur(); } catch {}
+    }
+  });
+
+  // Install a spy on `cancelQuestionRetry` that flags calls coming from
+  // the router by wrapping the deps-injected reference, not the module
+  // export. The router's call path is: bootstrapNotify onAction →
+  // probe wrapper → createDefaultToastActionRouter(deps)(event) →
+  // deps.cancelQuestionRetry. The IPC's call path is:
+  // `agent:resolvePermission` handler → imported `cancelQuestionRetry`
+  // from notify-retry. These are separate bindings so we can
+  // independently wrap the router's to record its calls.
+  await app.evaluate(() => {
+    globalThis.__routerCancelCalls = [];
+  });
+
+  // Re-install the bootstrap with a router whose `deps.cancelQuestionRetry`
+  // goes through our router-side spy. This lets us observe the router's
+  // own direct invocation separately from any IPC-path invocation.
+  await app.evaluate(({ BrowserWindow }) => {
+    const g = globalThis;
+    const dbg = g.__ccsmDebug;
+    dbg.notifyBootstrap.__resetBootstrapForTests();
+    const wrapCancel = (toastId) => {
+      (g.__routerCancelCalls ||= []).push(toastId);
+      dbg.notifyRetry.cancelQuestionRetry(toastId);
+    };
+    dbg.notifyBootstrap.bootstrapNotify((event) => {
+      g.__notifyCalls.push({ kind: 'router', event });
+      dbg.notifyBootstrap.createDefaultToastActionRouter({
+        resolvePermission: dbg.sessions.resolvePermission.bind(dbg.sessions),
+        cancelQuestionRetry: wrapCancel,
+        getMainWindow: () =>
+          BrowserWindow.getAllWindows().find((x) => !x.isDestroyed()) ?? null,
+      })(event);
+    });
+  });
+
+  await win.evaluate((args) => {
+    // First: schedule a fresh question retry (toastId = `q-${args.req}`).
+    return window.ccsm.notify({
+      sessionId: args.sessionId,
+      title: 'Question (reject)',
+      body: 'Pick one',
+      eventType: 'question',
+      extras: {
+        toastId: `q-${args.req}`,
+        sessionName: 'Test Session',
+        question: 'Pick one',
+        selectionKind: 'single',
+        optionCount: 2,
+        cwd: '/tmp/probe-cwd',
+      },
+    });
+  }, { sessionId, req: REJECT_REQ });
+
+  // Wait for initial question call + scheduled retry.
+  await app.evaluate(async (_electron, args) => {
+    const toastId = args.toastId;
+    const deadline = Date.now() + 3000;
+    while (Date.now() < deadline) {
+      const has = (globalThis.__notifyCalls || []).some((c) => c.kind === 'question' && c.payload.toastId === toastId);
+      const pendingHas = globalThis.__ccsmDebug.notifyRetry.__pendingRetryKeysForTests().includes(toastId);
+      if (has && pendingHas) return;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    throw new Error('timeout waiting for reject-case initial question + retry schedule');
+  }, { toastId: `q-${REJECT_REQ}` });
+
+  // Register a permission target sharing the bare requestId so the router
+  // treats the synthesized reject as a permission reject.
+  await app.evaluate((_e, args) => {
+    const dbg = globalThis.__ccsmDebug;
+    dbg.notifyBootstrap.registerToastTarget(args.req, args.sessionId, 'permission');
+    // Synthesize a toast reject for the permission target. The
+    // bootstrap's onAction wraps the router (`g.__notifyOnAction`).
+    const cb = globalThis.__notifyOnAction;
+    if (!cb) throw new Error('onAction not captured');
+    cb({ toastId: args.req, action: 'reject', args: {} });
+  }, { sessionId, req: REJECT_REQ });
+
+  // Beat for sync calls inside the router + any renderer IPC round-trip.
+  await new Promise((r) => setTimeout(r, 300));
+
+  // Assert the router invoked cancelQuestionRetry directly (not just via
+  // the IPC round-trip). The task #308 fix adds two direct calls in the
+  // router's reject branch (`q-${requestId}` + bare requestId). Our spy
+  // only records the router's deps-injected path, so a hit means the
+  // router itself made the call.
+  const routerCancelCalls = await app.evaluate(() => globalThis.__routerCancelCalls ?? []);
+  if (routerCancelCalls.length === 0) {
+    fail(`expected toast-action reject router to call cancelQuestionRetry directly (#308); got zero router-side calls`);
+  }
+  const hasQPrefix = routerCancelCalls.includes(`q-${REJECT_REQ}`);
+  if (!hasQPrefix) {
+    fail(`router called cancelQuestionRetry but not with q-${REJECT_REQ}: ${JSON.stringify(routerCancelCalls)}`);
+  }
+  console.log('[probe-e2e-notify-integration] toast-action reject cancellation OK');
+
   // ── 11. Wave 3 polish (#252): rich done payload composition ─────────────
   //
   // Assert that when notifyDone fires, the wrapper sees the assistant
@@ -513,6 +727,14 @@ try {
   // and the groupName + sessionName are passed through so the SDK can
   // render "{groupName} · {sessionName}" as the toast title.
   const longAssistant = 'x'.repeat(200);
+  // The toast-action reject path (case 10c) routes through the default
+  // router which focuses the main window. Blur again before firing the
+  // next emit so focus suppression doesn't gate it.
+  await app.evaluate(({ BrowserWindow }) => {
+    for (const w of BrowserWindow.getAllWindows()) {
+      try { w.blur(); } catch {}
+    }
+  });
   await win.evaluate((args) => {
     return window.ccsm.notify({
       sessionId: args.sessionId,

--- a/src/agent/lifecycle.ts
+++ b/src/agent/lifecycle.ts
@@ -433,4 +433,29 @@ export function subscribeAgentEvents(): void {
     // `focus` carries no decision — the click already raised the window via
     // `notification:focusSession`, no further action needed here.
   });
+
+  // Mirror notification runtime state into main (#307). The ask-question
+  // retry timer fires in main ~30s after the original toast; by then the
+  // user may have toggled notifications off or focused the question's
+  // session. We push the two fields the retry gate needs whenever they
+  // change. Push initial values immediately so a renderer that wires this
+  // before the user touches anything still has a true mirror.
+  const pushRuntimeState = (s: ReturnType<typeof useStore.getState>) => {
+    void api.notifySetRuntimeState?.({
+      notificationsEnabled: s.notificationSettings.enabled,
+      activeSessionId: s.activeId || null,
+    });
+  };
+  pushRuntimeState(useStore.getState());
+  let lastEnabled = useStore.getState().notificationSettings.enabled;
+  let lastActive = useStore.getState().activeId;
+  useStore.subscribe((state) => {
+    const enabled = state.notificationSettings.enabled;
+    const active = state.activeId;
+    if (enabled !== lastEnabled || active !== lastActive) {
+      lastEnabled = enabled;
+      lastActive = active;
+      pushRuntimeState(state);
+    }
+  });
 }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -193,6 +193,9 @@ declare global {
         };
       }) => Promise<boolean>;
       notifyAvailability: () => Promise<{ available: boolean; error: string | null }>;
+      notifySetRuntimeState: (
+        patch: { notificationsEnabled?: boolean; activeSessionId?: string | null },
+      ) => Promise<{ ok: true } | { ok: false }>;
       onNotificationFocus: (handler: (sessionId: string) => void) => () => void;
       onNotifyToastAction?: (
         handler: (e: {


### PR DESCRIPTION
## Summary

Bundles two notify-hardening fixes that emerged from reviewer follow-ups on #243.

### Fix #307 — retry fire-time gate recheck
The ask-question retry timer fires in main ~30s after the original toast. Until now it re-emitted blindly even when the user had meanwhile (a) globally disabled notifications or (b) focused the question's own session during the 30s window — both conditions under which the initial emit would have been suppressed.

Main now holds a push-mirrored snapshot of the renderer's `notificationsEnabled` + `activeSessionId`. `scheduleQuestionRetry` captures the `sessionId` alongside the payload so `fireRetry` can run the same focus + settings gate that `showNotification`/`dispatchNotification` apply on the initial emit.

### Fix #308 — toast-action reject cancels pending retry
The toast-action router's permission-reject branch now unconditionally calls `cancelQuestionRetry` on both `q-${requestId}` and the bare requestId. Today only permission events route through this path, so the direct cancel is a no-op (the renderer IPC round-trip `agent:resolvePermission` already cancels). It's defense-in-depth: if a future change routes question activations through the same toast-action path, the retry will not leak past the explicit user reject.

Side effect: the router logic was extracted from `electron/main.ts` into `createDefaultToastActionRouter` in `electron/notify-bootstrap.ts` so main and the e2e probe share one definition instead of drifting hand-rolled copies (the probe previously had its own router that didn't know about #308).

## Checklist
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` — baseline 47 problems, 0 new (pre-existing in `verification/*` + `dogfood-logs/*`)
- [x] `npm test` — 756 tests pass (751 baseline + 5 new in `notify-retry.test.ts`)
- [x] `scripts/probe-e2e-notify-integration.mjs` passes with new cases 10b + 10c
- [x] Reverse-verify done for BOTH fixes (see below)
- [x] HOME sanitized during build/tests/e2e

## Reverse-verify

**#307 — stash the fire-time gate**
Edit `electron/notify-retry.ts:fireRetry`, comment out `if (shouldSuppressRetry(entry.sessionId)) return;`, rebuild, rerun the probe → case 10b fails with `expected exactly 1 question call when notifications disabled at fire-time, got 2`. Confirmed.

**#308 — stash the router cancel calls**
Edit `electron/notify-bootstrap.ts:createDefaultToastActionRouter`, comment out the two `deps.cancelQuestionRetry(...)` lines in the reject branch, rebuild, rerun the probe → case 10c fails with `expected toast-action reject router to call cancelQuestionRetry directly (#308); got zero router-side calls`. Confirmed.

The probe uses a spy around the router's deps-injected `cancelQuestionRetry`, so the assertion isolates the router's direct call from the IPC round-trip's cancel call (which is what made a naive `pendingAfter < pendingBefore` check hollow under reverse-verify).

## Test plan
- [ ] Reviewer: pull branch, run `scripts/probe-e2e-notify-integration.mjs`, confirm all 11 cases pass
- [ ] Reviewer: run the two reverse-verify stashes above and confirm both trip the expected probe case
- [ ] Reviewer: confirm `createDefaultToastActionRouter` factory hasn't changed behaviour for permission allow / allow-always / focus paths (diff main.ts before/after vs the factory body)

## Files changed
- `electron/notify-retry.ts` — gate check at fire time, sessionId param on schedule
- `electron/notify-bootstrap.ts` — runtime-state mirror, `shouldSuppressRetry`, `createDefaultToastActionRouter` factory
- `electron/notifications.ts` — forwards sessionId to `scheduleQuestionRetry`
- `electron/main.ts` — IPC handler `notify:setRuntimeState`; uses the extracted router factory
- `electron/preload.ts` + `src/global.d.ts` — `notifySetRuntimeState` exposed
- `src/agent/lifecycle.ts` — renderer-side store subscription pushes runtime state on change
- `electron/__tests__/notify-retry.test.ts` — 5 new unit tests
- `scripts/probe-e2e-notify-integration.mjs` — cases 10b (#307) + 10c (#308)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>