### PR TITLE
ux: kill SCREAMING UI strings flagged in PR #248 Gap #1 (#315)

### DIFF
--- a/scripts/probe-e2e-connection-pane.mjs
+++ b/scripts/probe-e2e-connection-pane.mjs
@@ -125,6 +125,26 @@ try {
   const configured = await dialog.getByText(/^configured$/i).first().isVisible().catch(() => false);
   if (!configured) fail('expected "Configured" status for auth token');
 
+  // SCREAMING-strings guard (PR #248 Gap #1, task #315). Discovered-models
+  // source badges (`settings`, `cli-picker`, `fallback`) must NOT be
+  // CSS-uppercased. Walk every element inside the discovered-models list and
+  // assert computed `text-transform !== uppercase`.
+  const screamingBadges = await win.evaluate(() => {
+    const list = document.querySelector('[data-connection-models]');
+    if (!list) return [];
+    const offenders = [];
+    list.querySelectorAll('*').forEach((el) => {
+      const txt = (el.textContent || '').trim();
+      if (!txt || el.children.length > 0) return;
+      const tt = window.getComputedStyle(el).textTransform;
+      if (tt === 'uppercase') offenders.push(`${el.tagName}: ${txt.slice(0, 60)}`);
+    });
+    return offenders;
+  });
+  if (screamingBadges.length > 0) {
+    fail(`discovered-models list has CSS-uppercased text (forbidden):\n  ${screamingBadges.join('\n  ')}`);
+  }
+
   // CRITICAL: the literal token must NOT appear anywhere in the rendered DOM.
   const fullText = await win.evaluate(() => document.body.innerText);
   if (fullText.includes(FIXTURE_TOKEN)) {

--- a/scripts/probe-e2e-cwd-popover-recent-unfiltered.mjs
+++ b/scripts/probe-e2e-cwd-popover-recent-unfiltered.mjs
@@ -159,6 +159,19 @@ await win.waitForFunction(
   fail(`clearing input should restore all ${RECENT.length} options, got ${count}`);
 });
 
+// SCREAMING-strings guard (PR #248 Gap #1, task #315). The "Recent" header
+// must NOT be CSS-uppercased.
+const recentHeader = await dialog.locator('text=/^Recent$/').first();
+const recentOffender = await recentHeader.evaluate((el) => {
+  return window.getComputedStyle(el).textTransform === 'uppercase'
+    ? el.textContent
+    : null;
+});
+if (recentOffender) {
+  await app.close();
+  fail(`"Recent" header is CSS-uppercased — forbidden per feedback_no_uppercase_ui_strings.md`);
+}
+
 console.log('\n[probe-e2e-cwd-popover-recent-unfiltered] OK');
 console.log(`  open with active cwd "${ACTIVE_CWD}" → all ${RECENT.length} recent visible`);
 console.log('  type "bar" → filters to 1; clear → restores 3');

--- a/scripts/probe-e2e-tutorial.mjs
+++ b/scripts/probe-e2e-tutorial.mjs
@@ -30,6 +30,34 @@ const stepCounter = win.locator('text=/Step 1 of 4/i').first();
 await stepCounter.waitFor({ state: 'visible', timeout: 5000 });
 await win.locator('text=/A workbench for AI sessions/i').first().waitFor({ state: 'visible', timeout: 3000 });
 
+// SCREAMING-strings guard (PR #248 Gap #1, task #315). The step counter and
+// any demo group/section labels in the tutorial must NOT be CSS-uppercased —
+// per `feedback_no_uppercase_ui_strings.md`. Walk every visible text node
+// inside the tutorial root and assert computed `text-transform !== uppercase`.
+const screaming = await win.evaluate(() => {
+  const root = document.querySelector('[data-testid="tutorial"], main, body');
+  if (!root) return [];
+  const offenders = [];
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT);
+  let node = walker.currentNode;
+  while (node) {
+    const el = node;
+    if (el && el.textContent && el.children.length === 0) {
+      const txt = el.textContent.trim();
+      if (txt && /[a-zA-Z]/.test(txt)) {
+        const tt = window.getComputedStyle(el).textTransform;
+        if (tt === 'uppercase') offenders.push(`${el.tagName}: ${txt.slice(0, 60)}`);
+      }
+    }
+    node = walker.nextNode();
+  }
+  return offenders;
+});
+if (screaming.length > 0) {
+  await app.close();
+  fail(`tutorial has CSS-uppercased text (forbidden):\n  ${screaming.join('\n  ')}`);
+}
+
 // Skip button present.
 const skipBtn = win.getByRole('button', { name: /^Skip$/ });
 await skipBtn.waitFor({ state: 'visible', timeout: 3000 });

--- a/src/components/CwdPopover.tsx
+++ b/src/components/CwdPopover.tsx
@@ -3,7 +3,6 @@ import { ChevronDown, Folder, AlertTriangle } from 'lucide-react';
 import { cn } from '../lib/cn';
 import { useTranslation } from '../i18n/useTranslation';
 import { useStore } from '../stores/store';
-import { MetaLabel } from './ui/MetaLabel';
 
 // Stable id for this popover in the global mutex slot. See
 // `openPopoverId` in src/stores/store.ts: opening any popover sets the id
@@ -249,9 +248,9 @@ export function CwdPopover({ cwd, cwdMissing, loadRecent, onPick, onBrowse }: Pr
             />
           </div>
 
-          <MetaLabel size="sm" className="block px-3 pt-1.5 pb-1">
+          <span className="block px-3 pt-1.5 pb-1 font-mono text-mono-sm text-fg-tertiary select-none">
             {t('cwdPopover.recent')}
-          </MetaLabel>
+          </span>
           <ul className="max-h-[260px] overflow-y-auto pb-1" role="listbox">
             {filtered.length === 0 ? (
               <li className="px-3 py-2 text-fg-tertiary text-mono-md leading-[16px]">

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -851,8 +851,14 @@ function ConnectionPane() {
                 className="flex items-center justify-between px-3 py-1.5 text-meta"
               >
                 <span className="font-mono text-fg-primary truncate">{m.id}</span>
-                <span className="text-mono-xs uppercase tracking-wide text-fg-tertiary ml-2 shrink-0">
-                  {m.source}
+                <span className="text-mono-xs tracking-wide text-fg-tertiary ml-2 shrink-0">
+                  {m.source === 'settings'
+                    ? t('connection.modelSourceSettings')
+                    : m.source === 'cli-picker'
+                      ? t('connection.modelSourceCliPicker')
+                      : m.source === 'fallback'
+                        ? t('connection.modelSourceFallback')
+                        : m.source}
                 </span>
               </li>
             ))}

--- a/src/components/Tutorial.tsx
+++ b/src/components/Tutorial.tsx
@@ -53,7 +53,7 @@ export function Tutorial({ onNewSession, onImport, onSkip }: Props) {
   const isFirst = stepIdx === 0;
 
   return (
-    <div className="relative flex h-full w-full flex-col">
+    <div className="relative flex h-full w-full flex-col" data-testid="tutorial">
       <button
         type="button"
         onClick={onSkip}
@@ -72,7 +72,7 @@ export function Tutorial({ onNewSession, onImport, onSkip }: Props) {
               transition={{ duration: 0.25, ease: [0.32, 0.72, 0, 1] }}
               className="space-y-4"
             >
-              <div className="font-mono text-mono-sm uppercase tracking-wider text-fg-tertiary">
+              <div className="font-mono text-mono-sm text-fg-tertiary">
                 {t('tutorial.stepXofY', { current: stepIdx + 1, total: steps.length })}
               </div>
               <h1 className="text-display font-semibold text-fg-primary leading-tight">{step.title}</h1>
@@ -220,7 +220,7 @@ function GroupsVisual() {
           >
             <div className="flex items-center gap-2 mb-1.5">
               <FolderTree size={11} className="text-fg-tertiary" />
-              <span className="font-mono text-mono-sm uppercase tracking-wider text-fg-tertiary">
+              <span className="font-mono text-mono-sm text-fg-tertiary">
                 {g.name}
               </span>
             </div>

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -277,7 +277,10 @@ const en = {
       opening: 'Opening…',
       copyBaseUrl: 'Copy URL',
       copyModel: 'Copy model',
-      copied: 'Copied'
+      copied: 'Copied',
+      modelSourceSettings: 'Settings',
+      modelSourceCliPicker: 'CLI picker',
+      modelSourceFallback: 'Fallback'
     },
     updates: {
       version: 'Version',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -269,7 +269,10 @@ const zh: EnCatalog = {
       opening: '打开中…',
       copyBaseUrl: '复制 URL',
       copyModel: '复制模型',
-      copied: '已复制'
+      copied: '已复制',
+      modelSourceSettings: '设置',
+      modelSourceCliPicker: 'CLI 选择列表',
+      modelSourceFallback: '兜底'
     },
     updates: {
       version: '版本',


### PR DESCRIPTION
## Summary

Fixes PR #248 Gap #1 (P1): five UI surfaces were rendering text in
all-caps via Tailwind `uppercase`, violating
`feedback_no_uppercase_ui_strings.md`.

| Surface | Before (rendered) | After |
|---|---|---|
| Tutorial step counter | `STEP 1 OF 4` | `Step 1 of 4` |
| Tutorial demo group names | `Q2 LAUNCH` / `BUG TRIAGE` | `Q2 launch` / `Bug triage` |
| Cwd popover header | `RECENT` | `Recent` |
| Settings → Connection badges | `SETTINGS` / `CLI-PICKER` / `FALLBACK` | `Settings` / `CLI picker` / `Fallback` |

The literal strings were already lowercase in source — the all-caps
came purely from Tailwind `uppercase` classes (`text-mono-sm uppercase
tracking-wider …`). Fix removes those classes from the four offending
surfaces. The `MetaLabel` primitive (which bakes `uppercase` in by
design for chrome elsewhere) is left alone; the cwd-popover callsite
swaps to a plain span.

The Settings badge previously rendered the raw enum identifier
(`m.source`) — fix maps it through new i18n keys
`connection.modelSource{Settings,CliPicker,Fallback}` (zh: `设置` /
`CLI 选择列表` / `兜底`).

## Files changed (8)

Source (5):
- `src/components/Tutorial.tsx` — drop `uppercase tracking-wider` on
  step counter + demo group names; add `data-testid="tutorial"`.
- `src/components/CwdPopover.tsx` — swap `<MetaLabel>` for a plain
  span without `uppercase` for the Recent header.
- `src/components/SettingsDialog.tsx` — drop `uppercase`; map
  `m.source` → localized label.
- `src/i18n/locales/en.ts` — +3 keys.
- `src/i18n/locales/zh.ts` — +3 keys.

Probes (3) — extended with assertions that walk the surface and fail
on any element whose computed `text-transform === 'uppercase'`:
- `scripts/probe-e2e-tutorial.mjs`
- `scripts/probe-e2e-cwd-popover-recent-unfiltered.mjs`
- `scripts/probe-e2e-connection-pane.mjs`

## Verification

- `npm run typecheck` — clean
- `npx vitest run tests/connection-pane.test.tsx tests/cwd-popover.test.tsx tests/i18n-key-parity.test.ts` — 17 passed
- E2E probes self-verify the regression cannot recur (worker did not
  spin up Electron locally; the probes carry the assertion forward
  for CI).

Visual probe screenshots not captured for this PR — the assertion is
deterministic computed-style enforcement, not a pixel-diff comparison.
Reverse-verify: stash the source edits, rerun the three probes, they
will print the offending element list and fail.

## Dogfood self-fix eligibility

NOT eligible for ≤3-line self-fix path. Total source diff is 21 lines
across 5 files (Tutorial drop-uppercase x2 + add testid, CwdPopover
swap MetaLabel → span + drop import, SettingsDialog source-mapping +
6 i18n keys across en/zh). Probe assertions add another 60 lines.
Independent reviewer required per `feedback_independent_reviewer.md`.

## Test plan

- [ ] Reviewer runs `npm run typecheck` — expect clean
- [ ] Reviewer runs targeted vitest suites — expect green
- [ ] Reviewer runs `node scripts/probe-e2e-tutorial.mjs` — expect OK
- [ ] Reviewer runs `node scripts/probe-e2e-cwd-popover-recent-unfiltered.mjs` — expect OK
- [ ] Reviewer runs `node scripts/probe-e2e-connection-pane.mjs` — expect OK
- [ ] Reviewer reverse-verifies: re-add an `uppercase` class to one
  surface and confirms the corresponding probe now fails

Refs #315, PR #248 Gap #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)