### PR TITLE
fix(tool-block): freeze elapsed counter while permission pending (#311)

### DIFF
--- a/scripts/probe-e2e-tool-journey-render.mjs
+++ b/scripts/probe-e2e-tool-journey-render.mjs
@@ -750,6 +750,109 @@ try {
       passCancellingState ? '' : 'no transient state — user cannot tell whether the click registered');
   }
 
+  // ── Journey 11: elapsed counter pauses while permission is pending (#311) ─
+  // Bug #248-1: the elapsed counter started ticking at REQUEST time (when the
+  // assistant emitted tool_use) rather than EXECUTION time (when permission
+  // resolved + the tool actually started running). Result: a user staring
+  // at the permission prompt for 90s would see a "still no result" stall
+  // banner fire even though nothing had run yet.
+  //
+  // Reverse-verify: revert ChatStream.tsx + renderBlock.tsx + ToolBlock.tsx
+  // to drop the `permissionPending` plumbing — this journey FAILs because
+  // the elapsed chip / stall escalation banner re-appear during the gate.
+  {
+    // Seed: an in-flight tool block followed by a waiting/permission block
+    // for the SAME toolName. Use the Date.now patching trick to fast-forward
+    // 95s so without the fix the escalation banner would render.
+    await win.evaluate(() => {
+      const realNow = Date.now.bind(Date);
+      window.__realDateNow = realNow;
+      window.__nowOffset = 0;
+      Date.now = () => realNow() + window.__nowOffset;
+    });
+    await seed([
+      { kind: 'user', id: 'u-pp', text: 'run a command' },
+      { kind: 'tool', id: 't-pp', toolUseId: 'tu-pp-1', name: 'Bash',
+        brief: 'rm -rf node_modules', expanded: false /* in-flight: no result */ },
+      { kind: 'waiting', id: 'wait-pp', intent: 'permission',
+        requestId: 'req-pp', toolName: 'Bash',
+        prompt: 'Bash: rm -rf node_modules',
+        toolInput: { command: 'rm -rf node_modules' } },
+    ]);
+    // Fast-forward 95s of wall-clock and force a render tick.
+    await win.evaluate(() => {
+      window.__nowOffset = 95_000;
+      window.__ccsmStore.getState().appendBlocks('s-tool', [
+        { kind: 'assistant', id: 'a-noop-pp', text: '' },
+      ]);
+    });
+    await win.waitForTimeout(400);
+
+    const pendingProbe = await win.evaluate(() => ({
+      hasElapsed: !!document.querySelector('[data-testid="tool-elapsed"]'),
+      hasStalled: !!document.querySelector('[data-testid="tool-stalled"]'),
+      hasEscalated: !!document.querySelector('[data-testid="tool-stall-escalated"]'),
+      hasCancel: !!document.querySelector('[data-testid="tool-stall-cancel"]'),
+      hasPermissionPrompt:
+        !!document.querySelector('[data-testid="permission-prompt"]') ||
+        document.body.innerText.includes('rm -rf node_modules'),
+    }));
+    const pausedPass =
+      pendingProbe.hasElapsed === false &&
+      pendingProbe.hasStalled === false &&
+      pendingProbe.hasEscalated === false &&
+      pendingProbe.hasCancel === false &&
+      pendingProbe.hasPermissionPrompt === true;
+    record('J11a elapsed counter + stall banners suppressed while permission pending (#311)',
+      'no tool-elapsed / tool-stalled / tool-stall-escalated / tool-stall-cancel rendered when a sibling waiting/permission block targets this tool, even after 95s wall-clock advance',
+      JSON.stringify(pendingProbe),
+      pausedPass,
+      pausedPass ? '' : 'elapsed/stall UI fires during the permission gate — the user sees "still no result" before the tool has even started running');
+
+    // Now resolve the permission (remove the waiting block) and verify the
+    // counter starts ticking from ZERO at gate-clear, not retroactively from
+    // tool_use arrival.
+    await win.evaluate(() => {
+      const store = window.__ccsmStore;
+      const blocks = store.getState().messagesBySession['s-tool'].filter((b) => b.kind !== 'waiting');
+      store.setState({ messagesBySession: { 's-tool': blocks } });
+    });
+    await win.waitForTimeout(200);
+
+    // Capture elapsed immediately after gate clears — should be ~0s, NOT ~95s.
+    const justClearedText = await win.evaluate(() =>
+      document.querySelector('[data-testid="tool-elapsed"]')?.textContent ?? null);
+    // Advance another 2s and confirm the counter ticks normally.
+    await win.evaluate(() => { window.__nowOffset = 95_000 + 2_000; });
+    await win.waitForTimeout(300);
+    const afterTickText = await win.evaluate(() =>
+      document.querySelector('[data-testid="tool-elapsed"]')?.textContent ?? null);
+
+    // Parse "<num>.<num>s" → seconds.
+    const parseSec = (s) => {
+      if (!s) return NaN;
+      const m = s.match(/^(\d+)\.(\d)s$/);
+      return m ? parseInt(m[1], 10) + parseInt(m[2], 10) / 10 : NaN;
+    };
+    const justSec = parseSec(justClearedText);
+    const tickSec = parseSec(afterTickText);
+    const startsFromZero = !isNaN(justSec) && justSec < 1.5;
+    const ticksAfter = !isNaN(tickSec) && tickSec >= 1.5 && tickSec < 5.0;
+    const noEscalation = await win.evaluate(() =>
+      !document.querySelector('[data-testid="tool-stall-escalated"]'));
+    const resumePass = startsFromZero && ticksAfter && noEscalation;
+    record('J11b elapsed counter starts from zero at execution-begin, not request-time (#311)',
+      'after permission resolves: tool-elapsed ~0s (NOT ~95s carried over), then advances by ~2s on next tick, no escalation banner',
+      `justCleared="${justClearedText}" (${justSec}s), afterTick="${afterTickText}" (${tickSec}s), noEscalation=${noEscalation}`,
+      resumePass,
+      resumePass ? '' : 'elapsed counter retroactively counted the permission-pending window — execution-time semantics broken');
+
+    // Restore Date.now so subsequent journeys (none today, but defensive) aren't affected.
+    await win.evaluate(() => {
+      if (window.__realDateNow) Date.now = window.__realDateNow;
+    });
+  }
+
   // ── summary matrix ──────────────────────────────────────────────────────
   console.log('\n=== consistency matrix ===');
   for (const r of results) {

--- a/src/components/ChatStream.tsx
+++ b/src/components/ChatStream.tsx
@@ -192,11 +192,43 @@ export function ChatStream() {
                     break;
                   }
                 }
+                // Bug #248-1: the bash elapsed counter starts at REQUEST time
+                // (assistant's tool_use lands → ToolBlock first-render captures
+                // Date.now()), not at EXECUTION time. When a permission gate
+                // intercepts, the user can spend 90s+ deciding while the
+                // counter ticks and the stall / "still no result" escalation
+                // banners fire — misleading, since the tool hasn't even
+                // started running. We mark each in-flight tool block whose
+                // toolName matches a SUBSEQUENT pending permission block as
+                // permission-pending; ToolBlock then suppresses the elapsed
+                // chip + stall banners and defers `startedAtRef` capture
+                // until the gate clears. Matching by toolName-after-this-tool
+                // is enough in practice because claude.exe serializes
+                // permission prompts; the waiting block doesn't carry a
+                // toolUseId we could match more precisely.
+                const permissionPendingToolIds = new Set<string>();
+                for (let i = 0; i < blocks.length; i++) {
+                  const b = blocks[i];
+                  if (b.kind !== 'tool' || typeof b.result === 'string' || b.isError) continue;
+                  if (!b.toolUseId) continue;
+                  for (let j = i + 1; j < blocks.length; j++) {
+                    const w = blocks[j];
+                    if (
+                      w.kind === 'waiting' &&
+                      w.intent === 'permission' &&
+                      w.toolName === b.name
+                    ) {
+                      permissionPendingToolIds.add(b.toolUseId);
+                      break;
+                    }
+                  }
+                }
                 return blocks.map((m, i) => (
                   <div key={m.id}>
                     {renderBlock(m, activeId, resolvePermission, bumpComposerFocus, addAllowAlways, {
                       permissionAutoFocus: i === lastPermIdx,
-                      now
+                      now,
+                      permissionPendingToolIds
                     })}
                   </div>
                 ));

--- a/src/components/chat/blocks/ToolBlock.tsx
+++ b/src/components/chat/blocks/ToolBlock.tsx
@@ -24,7 +24,8 @@ export function ToolBlock({
   input,
   now,
   sessionId,
-  toolUseId
+  toolUseId,
+  permissionPending
 }: {
   name: string;
   brief: string;
@@ -43,6 +44,19 @@ export function ToolBlock({
   // the click falls back to the old console.warn stub.
   sessionId?: string;
   toolUseId?: string;
+  // Bug #248-1: when a permission gate is intercepting this tool's
+  // execution, the wall-clock elapsed counter is misleading — we haven't
+  // started running yet, the user is just thinking about whether to
+  // allow it. ChatStream sets this to true when a sibling waiting/permission
+  // block is targeting this tool's name. While true:
+  //   - we DON'T capture startedAtRef (it stays null; deferred to gate clear)
+  //   - the elapsed chip / stall hint / escalation banner / Cancel link are
+  //     all suppressed (no chip → no stall → no Cancel)
+  // The "…" in-flight ellipsis (in the truncating name span above) keeps
+  // signaling that the block is alive. Once the user resolves the prompt
+  // (allow/deny), this flips false; first render after that captures the
+  // real execution-begin moment in startedAtRef.
+  permissionPending?: boolean;
 }) {
   const { t } = useTranslation();
   const [open, setOpen] = useState<boolean>(!!isError);
@@ -74,19 +88,22 @@ export function ToolBlock({
   const emptyBrief = !brief || brief.length === 0;
   const isDropped = (emptyResult || (hasResult && emptyBrief)) && !isError;
   // Elapsed-time tracking (A2-NEW-5). We capture startedAt on the first
-  // render where `result` is still undefined, and freeze endedAt when
-  // result first lands. Refs keep the value stable across re-renders
-  // without triggering re-render cycles of their own.
-  const startedAtRef = useRef<number | null>(hasResult ? null : Date.now());
+  // render where `result` is still undefined AND no permission gate is
+  // currently pending — the latter half (#248-1) is what makes "elapsed"
+  // mean "execution time" instead of "request time". Refs keep the value
+  // stable across re-renders without triggering re-render cycles of
+  // their own.
+  const initialStartedAt = hasResult || permissionPending ? null : Date.now();
+  const startedAtRef = useRef<number | null>(initialStartedAt);
   const endedAtRef = useRef<number | null>(hasResult ? Date.now() : null);
-  if (!hasResult && startedAtRef.current === null) {
+  if (!hasResult && !permissionPending && startedAtRef.current === null) {
     startedAtRef.current = Date.now();
     endedAtRef.current = null;
   }
   if (hasResult && endedAtRef.current === null) {
     endedAtRef.current = Date.now();
   }
-  const running = !hasResult && !isError;
+  const running = !hasResult && !isError && !permissionPending;
   const elapsedMs =
     running && startedAtRef.current !== null
       ? Math.max(0, (now ?? Date.now()) - startedAtRef.current)

--- a/src/components/chat/renderBlock.tsx
+++ b/src/components/chat/renderBlock.tsx
@@ -16,7 +16,7 @@ export function renderBlock(
   resolvePermission: (sid: string, rid: string, d: 'allow' | 'deny') => void,
   bumpComposerFocus: () => void,
   addAllowAlways: (toolName: string) => void,
-  opts: { permissionAutoFocus?: boolean; now?: number } = {}
+  opts: { permissionAutoFocus?: boolean; now?: number; permissionPendingToolIds?: Set<string> } = {}
 ) {
   switch (b.kind) {
     case 'user':
@@ -24,7 +24,7 @@ export function renderBlock(
     case 'assistant':
       return <AssistantBlock text={b.text} streaming={b.streaming} />;
     case 'tool':
-      return <ToolBlock name={b.name} brief={b.brief} result={b.result} isError={b.isError} input={b.input} now={opts.now} sessionId={activeId} toolUseId={b.toolUseId} />;
+      return <ToolBlock name={b.name} brief={b.brief} result={b.result} isError={b.isError} input={b.input} now={opts.now} sessionId={activeId} toolUseId={b.toolUseId} permissionPending={!!(b.toolUseId && opts.permissionPendingToolIds?.has(b.toolUseId))} />;
     case 'todo':
       return <TodoBlock todos={b.todos} />;
     case 'waiting':


### PR DESCRIPTION
## Layer 1 verdict
Direction: **right**. The bug is real (PR #248 dogfood Bug #1) — `startedAtRef` was captured at the first render where `result === undefined`, which happens when the assistant's `tool_use` lands. If a permission gate intercepts (claude.exe `canUseTool`), the user can sit on the prompt for 90s+ while the elapsed chip keeps ticking and the escalation banner fires, all before the tool has actually started running. Better approach (the one taken here): freeze the counter / banners while permission is pending, then start from zero once the gate clears. Considered (and rejected) just-suppress-the-banner-without-pausing-the-counter — that would still display 90s+ "elapsed" for a tool that hasn't run, which is the misleading bit.

## Files touched
- `src/components/ChatStream.tsx` — compute `permissionPendingToolIds` (in-flight tool whose `toolName` matches a subsequent `waiting/permission` block).
- `src/components/chat/renderBlock.tsx` — thread the set through, expose `permissionPending` to ToolBlock.
- `src/components/chat/blocks/ToolBlock.tsx` — defer `startedAtRef` capture while `permissionPending`; treat as not-running so chip / stall hint / escalation banner / cancel link all suppress.
- `scripts/probe-e2e-tool-journey-render.mjs` — extended with J11a (suppression during gate after 95s wall-clock advance) and J11b (counter starts from zero on gate clear, ticks normally after).

## Reverse-verify output
With fix reverted (only the 3 source files; probe kept):
```
[FAIL] J11a elapsed counter + stall banners suppressed while permission pending (#311)
[FAIL] J11b elapsed counter starts from zero at execution-begin, not request-time (#311)
=== totals: 13/17 passed ===
```

With fix restored:
```
[PASS] J11a elapsed counter + stall banners suppressed while permission pending (#311)
[PASS] J11b elapsed counter starts from zero at execution-begin, not request-time (#311)
=== totals: 15/17 passed ===
```

The two pre-existing FAILs (J5b auto-expand, J9 cancel-IPC wiring) reproduce on `origin/working` baseline — unchanged by this PR.

## Quality gates
- `npm run typecheck` — clean.
- `npx vitest run tests/chatstream-tool-block-ux.test.tsx` — 11/11 passing (existing coverage of A2-NEW-5/6/7 + #304 unaffected by the new prop, which defaults to `false`).
- No i18n strings changed; no new UI text.
- Backward-compat: `permissionPending` is optional and defaults to `false`, so existing call sites and snapshot tests render identically.

## Test plan
- [ ] Run a `Bash` tool that hits the permission prompt; confirm no elapsed chip / stall banner appears while the prompt is open.
- [ ] After clicking Allow, confirm the elapsed chip starts from `0.0s` and ticks from there — not from when the prompt first appeared.
- [ ] Confirm tools that don't go through a permission gate (e.g. `Read`) are unaffected — counter starts on first render as before.