### PR TITLE
feat(chat): per-line comment affordance in DiffView (#303)

### DIFF
--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -777,11 +777,38 @@ export function InputBar({ sessionId }: { sessionId: string }) {
         </div>
         <div className="absolute right-3 bottom-1.5 flex items-center gap-2">
           {pendingDiffCommentsCount > 0 && (
-            <MetaLabel
+            <Button
+              variant="ghost"
+              size="xs"
               title={t('task303.diffCommentsPendingChip', { count: pendingDiffCommentsCount })}
+              onClick={() => {
+                // Locate the first pending diff comment for this session
+                // (sorted by file path asc, then line asc, then createdAt asc —
+                // matches the deterministic order used by
+                // serializeDiffCommentsForPrompt) and scroll the chip into
+                // view. If the chip isn't currently mounted (chat scrolled
+                // away, file collapsed, etc.) we silently no-op rather than
+                // log — there's no useful action the user could take.
+                const bucket = useStore.getState().pendingDiffComments[sessionId];
+                if (!bucket) return;
+                const list = Object.values(bucket);
+                if (list.length === 0) return;
+                list.sort((a, b) => {
+                  if (a.file !== b.file) return a.file < b.file ? -1 : 1;
+                  if (a.line !== b.line) return a.line - b.line;
+                  return a.createdAt - b.createdAt;
+                });
+                const first = list[0];
+                const el = document.querySelector(
+                  `[data-diff-comment-id="${first.id}"]`
+                ) as HTMLElement | null;
+                if (!el) return;
+                el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+              }}
+              className="font-mono text-mono-xs tracking-wider text-fg-tertiary"
             >
               {t('task303.diffCommentsPendingChip', { count: pendingDiffCommentsCount })}
-            </MetaLabel>
+            </Button>
           )}
           {queueLength > 0 && (
             <MetaLabel title={t('chat.queueChip', { count: queueLength })}>

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -5,6 +5,7 @@ import { cn } from '../lib/cn';
 import { Button } from './ui/Button';
 import { MetaLabel } from './ui/MetaLabel';
 import { useStore } from '../stores/store';
+import { serializeDiffCommentsForPrompt } from '../stores/store';
 import { DURATION, EASING } from '../lib/motion';
 import { useShallow } from 'zustand/react/shallow';
 import { SlashCommandPicker } from './SlashCommandPicker';
@@ -137,7 +138,7 @@ export function InputBar({ sessionId }: { sessionId: string }) {
   // Perf: subscribe to all reactive per-session signals via useShallow so this
   // component only re-renders when one of these specific values changes
   // (instead of once per any store mutation, like an appendBlocks chunk).
-  const { session, started, running, queueLength, hasMessages, hasPendingWaiting, permission, focusInputNonce } = useStore(
+  const { session, started, running, queueLength, hasMessages, hasPendingWaiting, permission, focusInputNonce, pendingDiffCommentsCount } = useStore(
     useShallow((s) => ({
       session: s.sessions.find((x) => x.id === sessionId),
       started: !!s.startedSessions[sessionId],
@@ -151,11 +152,16 @@ export function InputBar({ sessionId }: { sessionId: string }) {
       hasPendingWaiting: (s.messagesBySession[sessionId] ?? []).some((b) => b.kind === 'waiting'),
       permission: s.permission,
       focusInputNonce: s.focusInputNonce,
+      // Count of pending per-line diff comments queued up to ride the next
+      // user prompt as `<diff-feedback>` blocks (#303). Drives the "N diff
+      // comments will be sent" indicator + lets the send path skip the
+      // serialization round-trip when there are none.
+      pendingDiffCommentsCount: Object.keys(s.pendingDiffComments[sessionId] ?? {}).length,
     }))
   );
   // Action references are stable across renders in Zustand v5, so reading them
   // via getState() avoids registering listeners that would never fire anyway.
-  const { appendBlocks, markStarted, setRunning, markInterrupted, enqueueMessage, clearQueue, bumpComposerFocus } =
+  const { appendBlocks, markStarted, setRunning, markInterrupted, enqueueMessage, clearQueue, bumpComposerFocus, clearDiffComments } =
     useStore.getState();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -458,11 +464,33 @@ export function InputBar({ sessionId }: { sessionId: string }) {
       // 'pass-through' and 'unknown' fall through to the normal send path.
     }
 
+    // #303: bake any pending per-line diff comments into the outgoing prompt
+    // body BEFORE the user text. Comments are session-scoped; we serialize
+    // and clear in one shot so the same comments can never ride two turns.
+    // Done here (before the queueing branch) so a turn enqueued during a
+    // running session captures exactly the comments visible at the moment
+    // the user pressed Enter — not whatever is left over when the queue
+    // eventually drains. Override (slash-command pass-through, command
+    // panel) skips comments: an override is a programmatic send, not a
+    // user composing in the textarea.
+    let outgoingText = text;
+    if (override === undefined) {
+      const { pendingDiffComments } = useStore.getState();
+      const prefix = serializeDiffCommentsForPrompt(pendingDiffComments[sessionId]);
+      if (prefix) {
+        // Two newlines between prefix and user text so a markdown-rendering
+        // model treats them as separate paragraphs even if it ignores the
+        // structured tag.
+        outgoingText = `${prefix}\n\n${text}`;
+        clearDiffComments(sessionId);
+      }
+    }
+
     // Queue non-slash messages while a turn is in flight. The drain happens
     // in agent/lifecycle.ts when `result` arrives. Clear the composer so the
     // user can keep typing the next thought immediately.
     if (running) {
-      enqueueMessage(sessionId, { text, attachments: imgs });
+      enqueueMessage(sessionId, { text: outgoingText, attachments: imgs });
       update('');
       setAttachmentsAndCache([]);
       setRejections([]);
@@ -478,7 +506,7 @@ export function InputBar({ sessionId }: { sessionId: string }) {
       {
         kind: 'user',
         id: nextLocalId(),
-        text,
+        text: outgoingText,
         ...(imgs.length > 0 ? { images: imgs } : {})
       }
     ]);
@@ -501,10 +529,10 @@ export function InputBar({ sessionId }: { sessionId: string }) {
 
     let ok: boolean;
     if (imgs.length > 0) {
-      const content = buildUserContentBlocks(text, imgs);
+      const content = buildUserContentBlocks(outgoingText, imgs);
       ok = await api.agentSendContent(sessionId, content);
     } else {
-      ok = await api.agentSend(sessionId, text);
+      ok = await api.agentSend(sessionId, outgoingText);
     }
     if (!ok) {
       setRunning(sessionId, false);
@@ -748,6 +776,13 @@ export function InputBar({ sessionId }: { sessionId: string }) {
           )}
         </div>
         <div className="absolute right-3 bottom-1.5 flex items-center gap-2">
+          {pendingDiffCommentsCount > 0 && (
+            <MetaLabel
+              title={t('task303.diffCommentsPendingChip', { count: pendingDiffCommentsCount })}
+            >
+              {t('task303.diffCommentsPendingChip', { count: pendingDiffCommentsCount })}
+            </MetaLabel>
+          )}
           {queueLength > 0 && (
             <MetaLabel title={t('chat.queueChip', { count: queueLength })}>
               {t('chat.queueChip', { count: queueLength })}

--- a/src/components/chat/DiffView.tsx
+++ b/src/components/chat/DiffView.tsx
@@ -1,10 +1,12 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import * as Checkbox from '@radix-ui/react-checkbox';
-import { Check, ChevronRight } from 'lucide-react';
+import { Check, ChevronRight, MessageSquare, MessageSquarePlus, Trash2 } from 'lucide-react';
 import { useTranslation } from '../../i18n/useTranslation';
 import type { DiffSpec } from '../../utils/diff';
 import { HighlightedLine, languageFromPath } from '../CodeBlock';
+import { useStore } from '../../stores/store';
+import type { PendingDiffComment } from '../../stores/store';
 
 // Threshold above which multi-file diffs default to collapsed sections (#249).
 // Picked at 3 to keep the common Edit/Write/MultiEdit case (almost always
@@ -41,6 +43,76 @@ interface FileSectionProps {
   onSelectionChange?: (next: Set<number>) => void;
   /** Disable interaction (e.g. while the parent is resolving the IPC). */
   disabled?: boolean;
+}
+
+// Inline composer that opens below a diff line on "+" click (#303). Two-row
+// textarea, Enter to save, Esc to dismiss. Save is also exposed as a button
+// for mouse-only users / a11y. We deliberately don't autosize beyond two
+// rows — feedback to the agent is meant to be a sentence, not a thesis.
+function InlineCommentComposer({
+  initialText,
+  onSave,
+  onCancel,
+}: {
+  initialText: string;
+  onSave: (text: string) => void;
+  onCancel: () => void;
+}) {
+  const { t } = useTranslation();
+  const [value, setValue] = useState(initialText);
+  const ref = useRef<HTMLTextAreaElement>(null);
+  useEffect(() => {
+    // Defer focus a frame so the AnimatePresence height transition has
+    // started — focusing into a 0-height element scrolls jankily on Chromium.
+    const id = requestAnimationFrame(() => ref.current?.focus());
+    return () => cancelAnimationFrame(id);
+  }, []);
+  const trimmed = value.trim();
+  return (
+    <div
+      className="px-2 py-1.5 bg-bg-elevated border-t border-border-subtle"
+      data-diff-comment-composer=""
+      // Stop click bubbling so opening the composer doesn't also re-toggle
+      // the file section header (the entire FileSection sits inside an
+      // outer button-less div, but defensive against future refactors).
+      onClick={(e) => e.stopPropagation()}
+    >
+      <textarea
+        ref={ref}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            if (trimmed) onSave(trimmed);
+          } else if (e.key === 'Escape') {
+            e.preventDefault();
+            onCancel();
+          }
+        }}
+        rows={2}
+        placeholder={t('task303.diffCommentPlaceholder')}
+        className="block w-full resize-none rounded-sm border border-border-default bg-bg-app px-2 py-1 text-meta font-sans text-fg-primary placeholder:text-fg-tertiary outline-none focus-visible:border-accent transition-colors duration-150 ease-out"
+      />
+      <div className="mt-1 flex items-center justify-end gap-1.5">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-2 py-0.5 rounded-sm text-mono-xs font-mono text-fg-tertiary hover:text-fg-secondary active:bg-bg-hover transition-colors duration-150 ease-out outline-none focus-ring"
+        >
+          {t('common.cancel')}
+        </button>
+        <button
+          type="button"
+          disabled={!trimmed}
+          onClick={() => trimmed && onSave(trimmed)}
+          className="px-2 py-0.5 rounded-sm border border-border-subtle text-mono-xs font-mono text-fg-tertiary hover:text-accent hover:border-accent/60 active:bg-bg-hover transition-colors duration-150 ease-out outline-none focus-ring disabled:opacity-40 disabled:pointer-events-none"
+        >
+          {t('task303.diffCommentSave')}
+        </button>
+      </div>
+    </div>
+  );
 }
 
 // One file's worth of hunks. Header chip = chevron + path + +N/-M counts (#249);
@@ -82,6 +154,46 @@ function FileSection({
       next.add(idx);
     }
     onSelectionChange(next);
+  };
+
+  // ─── #303 per-line comments ─────────────────────────────────────────────
+  // Composer state is local to the FileSection (only one composer can be
+  // open per file at a time — opening a second one closes the first). The
+  // saved comments live in the global store, scoped to the active session.
+  // Keying by `lineIndex` (sequential within this FileSection across all
+  // hunks, removed-then-added, matching DiffView's render order) means the
+  // composer + chip stay attached to the line the user clicked, not to a
+  // shifting source-file line number.
+  const activeId = useStore((s) => s.activeId);
+  const sessionComments = useStore((s) => s.pendingDiffComments[activeId]);
+  const { addDiffComment, updateDiffComment, deleteDiffComment } = useStore.getState();
+  // Bucket the saved comments by lineIndex for O(1) per-row lookup. We
+  // recompute on every render — diff comment counts in a single file are
+  // tiny (typically 0–3) so the cost is irrelevant compared to the
+  // syntax-highlighting work happening on the same lines.
+  const commentsForFile: Record<number, PendingDiffComment> = {};
+  if (sessionComments) {
+    for (const c of Object.values(sessionComments)) {
+      // Encode `(file, line)` as the row key on save; here we just match
+      // back. lineIndex is stored as `line`; file path must match exactly.
+      if (c.file === spec.filePath) commentsForFile[c.line] = c;
+    }
+  }
+  // Composer opens on a specific lineIndex. `null` = no composer open.
+  // Note: opening the composer for a line that already has a comment puts
+  // the composer into edit mode (initialText preloaded from the comment).
+  const [composerLine, setComposerLine] = useState<number | null>(null);
+  const openComposer = (lineIndex: number) => {
+    setComposerLine((prev) => (prev === lineIndex ? null : lineIndex));
+  };
+  const commitComment = (lineIndex: number, text: string) => {
+    const existing = commentsForFile[lineIndex];
+    if (existing) {
+      updateDiffComment(activeId, existing.id, text);
+    } else if (activeId) {
+      addDiffComment(activeId, { file: spec.filePath, line: lineIndex, text });
+    }
+    setComposerLine(null);
   };
   return (
     <div className="border-b last:border-b-0 border-border-subtle">
@@ -128,7 +240,12 @@ function FileSection({
             className="overflow-hidden"
           >
             <div className="font-mono text-meta">
-              {spec.hunks.map((h, i) => {
+              {(() => {
+                // Sequential line counter across all hunks of this file —
+                // the unit we attach comments to. Reset per-FileSection so
+                // it never collides across files in a multi-file render.
+                let lineIndex = 0;
+                return spec.hunks.map((h, i) => {
                 const decision = decisions[i];
                 const isChecked = selectMode ? selection!.has(i) : false;
                 return (
@@ -155,28 +272,48 @@ function FileSection({
                         />
                       )}
                     </AnimatePresence>
-                    {h.removed.map((line, j) => (
-                      <div
-                        key={`r-${j}`}
-                        className="grid grid-cols-[12px_1fr] bg-[oklch(0.55_0.18_27_/_0.10)] text-state-error-fg"
-                      >
-                        <span aria-hidden className="pl-1 select-none text-state-error">-</span>
-                        <span className="pr-2 font-mono">
-                          {line ? <HighlightedLine code={line} language={lang} /> : '\u00A0'}
-                        </span>
-                      </div>
-                    ))}
-                    {h.added.map((line, j) => (
-                      <div
-                        key={`a-${j}`}
-                        className="grid grid-cols-[12px_1fr] bg-[oklch(0.55_0.18_145_/_0.08)] text-fg-secondary"
-                      >
-                        <span aria-hidden className="pl-1 select-none text-state-running">+</span>
-                        <span className="pr-2 font-mono">
-                          {line ? <HighlightedLine code={line} language={lang} /> : '\u00A0'}
-                        </span>
-                      </div>
-                    ))}
+                    {h.removed.map((line, j) => {
+                      const myLine = lineIndex++;
+                      const comment = commentsForFile[myLine];
+                      const composerOpen = composerLine === myLine;
+                      return (
+                        <DiffLineRow
+                          key={`r-${j}`}
+                          tone="removed"
+                          line={line}
+                          lang={lang}
+                          comment={comment}
+                          composerOpen={composerOpen}
+                          onOpenComposer={() => openComposer(myLine)}
+                          onSaveComment={(text) => commitComment(myLine, text)}
+                          onCancelComposer={() => setComposerLine(null)}
+                          onDeleteComment={() => {
+                            if (comment && activeId) deleteDiffComment(activeId, comment.id);
+                          }}
+                        />
+                      );
+                    })}
+                    {h.added.map((line, j) => {
+                      const myLine = lineIndex++;
+                      const comment = commentsForFile[myLine];
+                      const composerOpen = composerLine === myLine;
+                      return (
+                        <DiffLineRow
+                          key={`a-${j}`}
+                          tone="added"
+                          line={line}
+                          lang={lang}
+                          comment={comment}
+                          composerOpen={composerOpen}
+                          onOpenComposer={() => openComposer(myLine)}
+                          onSaveComment={(text) => commitComment(myLine, text)}
+                          onCancelComposer={() => setComposerLine(null)}
+                          onDeleteComment={() => {
+                            if (comment && activeId) deleteDiffComment(activeId, comment.id);
+                          }}
+                        />
+                      );
+                    })}
                     <div className="relative flex items-center justify-end gap-1.5 px-2 py-1 bg-bg-elevated/50 border-t border-border-subtle">
                       {selectMode ? (
                         <label
@@ -248,12 +385,140 @@ function FileSection({
                     </div>
                   </div>
                 );
-              })}
+              });
+              })()}
             </div>
           </motion.div>
         )}
       </AnimatePresence>
     </div>
+  );
+}
+
+// One rendered diff line + its (optional) inline comment composer / chip
+// affordance (#303). Pulled out of FileSection so the +/chip/composer logic
+// lives next to the row markup it decorates, rather than ballooning the
+// hunk-loop inline.
+//
+// Layout per row: gutter (12px) + line content. The hover affordance lives
+// inside the gutter, absolutely positioned over the +/- glyph, so it doesn't
+// shift the line content when it appears. When a comment is saved we leave
+// the chip visible to the right of the line content; when the composer is
+// open we render it directly below the line.
+function DiffLineRow({
+  tone,
+  line,
+  lang,
+  comment,
+  composerOpen,
+  onOpenComposer,
+  onSaveComment,
+  onCancelComposer,
+  onDeleteComment,
+}: {
+  tone: 'removed' | 'added';
+  line: string;
+  lang: string;
+  comment: PendingDiffComment | undefined;
+  composerOpen: boolean;
+  onOpenComposer: () => void;
+  onSaveComment: (text: string) => void;
+  onCancelComposer: () => void;
+  onDeleteComment: () => void;
+}) {
+  const { t } = useTranslation();
+  const tonePalette =
+    tone === 'removed'
+      ? 'bg-[oklch(0.55_0.18_27_/_0.10)] text-state-error-fg'
+      : 'bg-[oklch(0.55_0.18_145_/_0.08)] text-fg-secondary';
+  const glyphTone = tone === 'removed' ? 'text-state-error' : 'text-state-running';
+  const glyph = tone === 'removed' ? '-' : '+';
+  return (
+    <>
+      <div
+        className={`group/row relative grid grid-cols-[12px_1fr_auto] items-center ${tonePalette}`}
+        data-diff-line=""
+        data-diff-line-tone={tone}
+      >
+        {/* Gutter: shows the diff sign by default; on row hover (or when
+            this row already owns a comment / composer), the +-comment
+            button overlays it. We keep both glyphs in the same 12px column
+            so the line content never shifts. */}
+        <span className="relative pl-1 select-none">
+          {/* Default sign — visually hidden when the action button is up. */}
+          <span
+            aria-hidden
+            className={`${glyphTone} ${composerOpen || comment ? 'opacity-0' : 'group-hover/row:opacity-0'} transition-opacity duration-150`}
+          >
+            {glyph}
+          </span>
+          <button
+            type="button"
+            onClick={onOpenComposer}
+            aria-label={
+              comment
+                ? t('task303.diffEditCommentAria')
+                : t('task303.diffAddCommentAria')
+            }
+            data-diff-add-comment=""
+            className={`absolute inset-0 inline-flex items-center justify-center text-fg-tertiary hover:text-accent transition-opacity duration-150 outline-none focus-visible:opacity-100 focus-ring rounded-sm ${
+              composerOpen || comment ? 'opacity-100' : 'opacity-0 group-hover/row:opacity-100'
+            }`}
+          >
+            <MessageSquarePlus size={10} className="stroke-[2]" />
+          </button>
+        </span>
+        <span className="pr-2 font-mono min-w-0 truncate">
+          {line ? <HighlightedLine code={line} language={lang} /> : '\u00A0'}
+        </span>
+        {/* Saved-comment chip. Click → reopen composer in edit mode (the
+            FileSection toggles composerLine on the same lineIndex). */}
+        {comment && !composerOpen && (
+          <button
+            type="button"
+            onClick={onOpenComposer}
+            data-diff-comment-chip=""
+            title={comment.text}
+            aria-label={t('task303.diffEditCommentAria')}
+            className="mr-2 inline-flex items-center gap-1 px-1.5 py-0.5 rounded-sm border border-border-subtle bg-bg-elevated text-fg-tertiary hover:text-fg-secondary hover:border-border-default transition-colors duration-150 ease-out outline-none focus-ring text-mono-xs font-mono"
+          >
+            <MessageSquare size={10} className="stroke-[2]" />
+            <span className="max-w-[14ch] truncate">{comment.text}</span>
+          </button>
+        )}
+      </div>
+      <AnimatePresence initial={false}>
+        {composerOpen && (
+          <motion.div
+            key="composer"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.16, ease: [0, 0, 0.2, 1] }}
+            className="overflow-hidden"
+          >
+            <div className="relative">
+              <InlineCommentComposer
+                initialText={comment?.text ?? ''}
+                onSave={onSaveComment}
+                onCancel={onCancelComposer}
+              />
+              {comment && (
+                <button
+                  type="button"
+                  onClick={onDeleteComment}
+                  data-diff-comment-delete=""
+                  aria-label={t('task303.diffDeleteCommentAria')}
+                  className="absolute right-2 top-1.5 inline-flex h-5 w-5 items-center justify-center rounded-sm text-fg-tertiary hover:text-state-error hover:bg-bg-hover transition-colors duration-150 ease-out outline-none focus-ring-destructive"
+                >
+                  <Trash2 size={11} className="stroke-[2]" />
+                </button>
+              )}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </>
   );
 }
 

--- a/src/components/chat/DiffView.tsx
+++ b/src/components/chat/DiffView.tsx
@@ -478,6 +478,7 @@ function DiffLineRow({
             type="button"
             onClick={onOpenComposer}
             data-diff-comment-chip=""
+            data-diff-comment-id={comment.id}
             title={comment.text}
             aria-label={t('task303.diffEditCommentAria')}
             className="mr-2 inline-flex items-center gap-1 px-1.5 py-0.5 rounded-sm border border-border-subtle bg-bg-elevated text-fg-tertiary hover:text-fg-secondary hover:border-border-default transition-colors duration-150 ease-out outline-none focus-ring text-mono-xs font-mono"

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -596,6 +596,20 @@ const en = {
       titleWarning: 'Agent warning',
       dismiss: 'Dismiss diagnostic'
     }
+  },
+  // task #303 — per-line diff comment affordance.
+  // Comments queue locally on a DiffView line, then ride the next user
+  // prompt as `<diff-feedback file="…" line="N">…</diff-feedback>` blocks
+  // prepended to the prompt body. Kept as a separate top-level namespace
+  // (rather than added inline to `chat`) so the append site is at EOF and
+  // future task workers can see at a glance which strings #303 owns.
+  task303: {
+    diffAddCommentAria: 'Add a comment for the agent on this line',
+    diffEditCommentAria: 'Edit comment',
+    diffDeleteCommentAria: 'Delete comment',
+    diffCommentPlaceholder: 'Add a comment for the agent\u2026',
+    diffCommentSave: 'Save',
+    diffCommentsPendingChip: '{{count}} diff comments will be sent'
   }
 } as const;
 

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -573,6 +573,15 @@ const zh: EnCatalog = {
       titleWarning: 'Agent 警告',
       dismiss: '关闭诊断信息'
     }
+  },
+  // task #303
+  task303: {
+    diffAddCommentAria: '在这一行给 agent 添加备注',
+    diffEditCommentAria: '编辑备注',
+    diffDeleteCommentAria: '删除备注',
+    diffCommentPlaceholder: '给 agent 留一条备注\u2026',
+    diffCommentSave: '保存',
+    diffCommentsPendingChip: '将随下条消息发送 {{count}} 条 diff 备注'
   }
 };
 

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -274,6 +274,17 @@ type State = {
    */
   allowAlwaysTools: string[];
   /**
+   * Per-session pending diff comments (#303). Keyed by sessionId then by
+   * commentId. Each comment ties a free-text note to a specific
+   * `(filePath, line)` in a DiffView the user is reviewing. On the next
+   * `send()` from InputBar these are serialized as `<diff-feedback file=…
+   * line=…>…</diff-feedback>` blocks prepended to the user's prompt body
+   * and then cleared. Session-scoped + in-memory only — comments are lost
+   * on app reload by design (avoids the "old draft feedback resurfaces
+   * later in a new conversation" surprise).
+   */
+  pendingDiffComments: Record<string, Record<string, PendingDiffComment>>;
+  /**
    * Id of the currently-open popover/menu, or null when nothing is open. A
    * single global slot enforces mutual exclusion: opening any popover sets
    * the id (implicitly closing whatever was previously open), closing sets
@@ -285,6 +296,61 @@ type State = {
    */
   openPopoverId: string | null;
 };
+
+/**
+ * One pending per-line comment attached to a DiffView (#303). Created when
+ * the user opens the inline composer in a diff gutter and saves text. The
+ * `file` + `line` pair locate the comment for serialization on send; `id`
+ * is opaque (used as the React key + delete handle).
+ *
+ * `line` is the 1-based index of the changed line WITHIN the diff hunk's
+ * combined removed-then-added stream as rendered by DiffView (which is the
+ * unit the user sees and points at). It is NOT a source-file line number —
+ * the agent gets enough context from the surrounding diff in the same turn
+ * to map it back, and trying to compute real source-file line numbers from
+ * a non-Myers diff would be brittle for the typical Edit/Write/MultiEdit
+ * shape this app renders.
+ */
+export interface PendingDiffComment {
+  id: string;
+  file: string;
+  line: number;
+  text: string;
+  createdAt: number;
+}
+
+/**
+ * Serialize a session's pending diff comments into the structured prefix
+ * we prepend to the next user prompt body. Each comment becomes one
+ * `<diff-feedback file="…" line="N">text</diff-feedback>` block on its own
+ * line; comments are sorted by (file, line, createdAt) so the prefix is
+ * deterministic across renders. Returns '' when there are no comments,
+ * which lets callers append unconditionally without a length check.
+ */
+export function serializeDiffCommentsForPrompt(
+  comments: Record<string, PendingDiffComment> | undefined,
+): string {
+  if (!comments) return '';
+  const list = Object.values(comments);
+  if (list.length === 0) return '';
+  // Stable order: file path asc, then line asc, then createdAt asc. Keeps
+  // the serialized output identical across renders so test assertions on
+  // exact string output don't flap on Object.values insertion order.
+  list.sort((a, b) => {
+    if (a.file !== b.file) return a.file < b.file ? -1 : 1;
+    if (a.line !== b.line) return a.line - b.line;
+    return a.createdAt - b.createdAt;
+  });
+  return list
+    .map((c) => {
+      // Escape the attribute value so a path with `"` can't break out of
+      // the file= attribute. We don't need a full XML escape on the body —
+      // the agent receives it as plain text inside the structured tag.
+      const file = c.file.replace(/"/g, '&quot;');
+      return `<diff-feedback file="${file}" line="${c.line}">${c.text}</diff-feedback>`;
+    })
+    .join('\n');
+}
 
 export interface CreateSessionOptions {
   cwd?: string | null;
@@ -447,6 +513,24 @@ type Actions = {
    * superseded by another opener won't clobber the new owner's slot.
    */
   closePopover: (id: string) => void;
+
+  /**
+   * Add a per-line diff comment to `sessionId` (#303). Returns the new
+   * comment id so callers can immediately put the chip into edit mode if
+   * they want. Empty/whitespace text is rejected (no-op + returns '').
+   */
+  addDiffComment: (
+    sessionId: string,
+    args: { file: string; line: number; text: string },
+  ) => string;
+  /** Update an existing comment's text. No-op if the id is unknown.
+   *  Trimmed-empty text deletes the comment instead. */
+  updateDiffComment: (sessionId: string, commentId: string, text: string) => void;
+  /** Remove a single comment. No-op if the id is unknown. */
+  deleteDiffComment: (sessionId: string, commentId: string) => void;
+  /** Drop ALL pending comments for `sessionId`. Called from the send path
+   *  after a prompt has been consumed. */
+  clearDiffComments: (sessionId: string) => void;
 };
 
 function nextId(prefix: string): string {
@@ -761,6 +845,7 @@ export const useStore = create<State & Actions>((set, get) => ({
   sessionInitFailures: {},
   allowAlwaysTools: [],
   openPopoverId: null,
+  pendingDiffComments: {},
 
   selectSession: (id) => {
     set((s) => ({
@@ -1782,6 +1867,87 @@ export const useStore = create<State & Actions>((set, get) => ({
 
   closePopover: (id) => {
     set((s) => (s.openPopoverId === id ? { openPopoverId: null } : s));
+  },
+
+  // ─── #303 per-line diff comments ────────────────────────────────────────
+  // Storage shape: pendingDiffComments[sessionId][commentId] = comment.
+  // Per-session because multiple sessions can each have their own pending
+  // feedback; the InputBar.send path of the active session consumes only
+  // its own bucket. Comments survive session-switch (so the user can keep
+  // typing on session B then return to A and still see the chips), but not
+  // app reload (in-memory only — see State.pendingDiffComments doc).
+  addDiffComment: (sessionId, args) => {
+    const text = args.text.trim();
+    if (!sessionId || !text) return '';
+    const id = nextId('dfc');
+    set((s) => {
+      const prev = s.pendingDiffComments[sessionId] ?? {};
+      return {
+        pendingDiffComments: {
+          ...s.pendingDiffComments,
+          [sessionId]: {
+            ...prev,
+            [id]: {
+              id,
+              file: args.file,
+              line: args.line,
+              text,
+              createdAt: Date.now(),
+            },
+          },
+        },
+      };
+    });
+    return id;
+  },
+
+  updateDiffComment: (sessionId, commentId, text) => {
+    const trimmed = text.trim();
+    set((s) => {
+      const bucket = s.pendingDiffComments[sessionId];
+      if (!bucket || !bucket[commentId]) return s;
+      // Empty body = delete: matches the "trash icon" semantics of clearing
+      // the textarea and saving. Saves the user one extra click.
+      if (!trimmed) {
+        const nextBucket = { ...bucket };
+        delete nextBucket[commentId];
+        const nextAll = { ...s.pendingDiffComments };
+        if (Object.keys(nextBucket).length === 0) delete nextAll[sessionId];
+        else nextAll[sessionId] = nextBucket;
+        return { pendingDiffComments: nextAll };
+      }
+      return {
+        pendingDiffComments: {
+          ...s.pendingDiffComments,
+          [sessionId]: {
+            ...bucket,
+            [commentId]: { ...bucket[commentId], text: trimmed },
+          },
+        },
+      };
+    });
+  },
+
+  deleteDiffComment: (sessionId, commentId) => {
+    set((s) => {
+      const bucket = s.pendingDiffComments[sessionId];
+      if (!bucket || !bucket[commentId]) return s;
+      const nextBucket = { ...bucket };
+      delete nextBucket[commentId];
+      const nextAll = { ...s.pendingDiffComments };
+      if (Object.keys(nextBucket).length === 0) delete nextAll[sessionId];
+      else nextAll[sessionId] = nextBucket;
+      return { pendingDiffComments: nextAll };
+    });
+  },
+
+  clearDiffComments: (sessionId) => {
+    set((s) => {
+      if (!s.pendingDiffComments[sessionId]) return s;
+      const nextAll = { ...s.pendingDiffComments };
+      delete nextAll[sessionId];
+      return { pendingDiffComments: nextAll };
+    });
   },
 
   loadModels: async () => {

--- a/tests/diff-view-line-comments.test.tsx
+++ b/tests/diff-view-line-comments.test.tsx
@@ -1,0 +1,227 @@
+// Per-line diff comment affordance (#303).
+//
+// Three layers under test:
+//   1. Store: addDiffComment / updateDiffComment / deleteDiffComment /
+//      clearDiffComments behave as documented (delete on empty body, etc.).
+//   2. Serialization: serializeDiffCommentsForPrompt produces the exact
+//      `<diff-feedback ...>` block format the InputBar will prepend, in a
+//      stable order across renders.
+//   3. Render: DiffView shows a "+" affordance per line, opens an inline
+//      composer on click, saves the comment, and surfaces a chip; the chip
+//      is removable + editable.
+//
+// What we deliberately do NOT exercise here:
+//   - InputBar.send wiring is covered by the dedicated `inputbar-diff-comments`
+//     integration test (stubs window.ccsm and asserts the prepended payload
+//     hits agentSend). Splitting keeps each test honest about its scope.
+import React from 'react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent, within, act } from '@testing-library/react';
+import { DiffView } from '../src/components/chat/DiffView';
+import type { DiffSpec } from '../src/utils/diff';
+import {
+  useStore,
+  serializeDiffCommentsForPrompt,
+  type PendingDiffComment,
+} from '../src/stores/store';
+
+const SID = 'sess-303';
+
+beforeEach(() => {
+  // Clear diff comments + ensure the active session id matches the bucket we
+  // probe. We do NOT reset the rest of the store — other slices are immaterial
+  // to this surface and we want to mirror the "comments live alongside real
+  // session state" production shape.
+  act(() => {
+    useStore.setState({ activeId: SID, pendingDiffComments: {} });
+  });
+});
+
+function spec(file: string, removed: string[], added: string[]): DiffSpec {
+  return { filePath: file, hunks: [{ removed, added }] };
+}
+
+// Helper: pick the gutter "+" affordance for the Nth diff line (0-indexed)
+// in the rendered DiffView. Each line carries `data-diff-line=""` and the
+// affordance carries `data-diff-add-comment=""`.
+function addCommentButtonForLine(n: number): HTMLButtonElement {
+  const lines = document.querySelectorAll('[data-diff-line]');
+  const row = lines[n] as HTMLElement | undefined;
+  if (!row) throw new Error(`no diff line at index ${n}`);
+  const btn = row.querySelector('[data-diff-add-comment]');
+  if (!btn) throw new Error(`no add-comment button at line ${n}`);
+  return btn as HTMLButtonElement;
+}
+
+describe('store: diff comment slice', () => {
+  it('addDiffComment trims, assigns an id, and stores under the session bucket', () => {
+    const id = useStore.getState().addDiffComment(SID, {
+      file: '/a/x.ts',
+      line: 2,
+      text: '   use X instead of Y   ',
+    });
+    expect(id).toMatch(/^dfc-/);
+    const bucket = useStore.getState().pendingDiffComments[SID];
+    expect(bucket).toBeDefined();
+    expect(Object.keys(bucket!)).toHaveLength(1);
+    const c = bucket![id];
+    expect(c.file).toBe('/a/x.ts');
+    expect(c.line).toBe(2);
+    expect(c.text).toBe('use X instead of Y');
+    expect(typeof c.createdAt).toBe('number');
+  });
+
+  it('addDiffComment rejects empty / whitespace text and returns ""', () => {
+    const id = useStore.getState().addDiffComment(SID, { file: '/a.ts', line: 0, text: '   ' });
+    expect(id).toBe('');
+    expect(useStore.getState().pendingDiffComments[SID]).toBeUndefined();
+  });
+
+  it('updateDiffComment with empty text deletes the comment (matches trash semantics)', () => {
+    const id = useStore.getState().addDiffComment(SID, { file: '/a.ts', line: 0, text: 'first' });
+    useStore.getState().updateDiffComment(SID, id, '   ');
+    expect(useStore.getState().pendingDiffComments[SID]).toBeUndefined();
+  });
+
+  it('deleteDiffComment removes only the targeted comment, removes empty bucket', () => {
+    const id1 = useStore.getState().addDiffComment(SID, { file: '/a.ts', line: 0, text: 'one' });
+    const id2 = useStore.getState().addDiffComment(SID, { file: '/a.ts', line: 1, text: 'two' });
+    useStore.getState().deleteDiffComment(SID, id1);
+    const bucket = useStore.getState().pendingDiffComments[SID];
+    expect(bucket).toBeDefined();
+    expect(Object.keys(bucket!)).toEqual([id2]);
+    useStore.getState().deleteDiffComment(SID, id2);
+    expect(useStore.getState().pendingDiffComments[SID]).toBeUndefined();
+  });
+
+  it('clearDiffComments wipes the whole session bucket but leaves siblings', () => {
+    useStore.getState().addDiffComment(SID, { file: '/a.ts', line: 0, text: 'mine' });
+    useStore.getState().addDiffComment('other-sess', { file: '/b.ts', line: 0, text: 'theirs' });
+    useStore.getState().clearDiffComments(SID);
+    expect(useStore.getState().pendingDiffComments[SID]).toBeUndefined();
+    expect(useStore.getState().pendingDiffComments['other-sess']).toBeDefined();
+  });
+});
+
+describe('serializeDiffCommentsForPrompt', () => {
+  function mk(file: string, line: number, text: string, createdAt: number, id = `c-${line}`): PendingDiffComment {
+    return { id, file, line, text, createdAt };
+  }
+
+  it('returns "" for empty / undefined input so callers can append unconditionally', () => {
+    expect(serializeDiffCommentsForPrompt(undefined)).toBe('');
+    expect(serializeDiffCommentsForPrompt({})).toBe('');
+  });
+
+  it('emits one <diff-feedback> per comment, joined by single newlines', () => {
+    const out = serializeDiffCommentsForPrompt({
+      a: mk('/x.ts', 1, 'rename foo', 100),
+      b: mk('/x.ts', 2, 'use const', 200),
+    });
+    expect(out).toBe(
+      '<diff-feedback file="/x.ts" line="1">rename foo</diff-feedback>\n' +
+      '<diff-feedback file="/x.ts" line="2">use const</diff-feedback>'
+    );
+  });
+
+  it('orders by (file, line, createdAt) regardless of insertion order', () => {
+    const out = serializeDiffCommentsForPrompt({
+      // Inserted out of order on purpose to prove the sort.
+      late: mk('/z.ts', 0, 'last', 999),
+      mid: mk('/m.ts', 5, 'mid-5', 100),
+      early: mk('/m.ts', 1, 'mid-1', 100),
+      tie: mk('/m.ts', 1, 'mid-1-newer', 200),
+    });
+    const lines = out.split('\n');
+    expect(lines[0]).toContain('file="/m.ts" line="1">mid-1<');
+    expect(lines[1]).toContain('file="/m.ts" line="1">mid-1-newer<');
+    expect(lines[2]).toContain('file="/m.ts" line="5">mid-5<');
+    expect(lines[3]).toContain('file="/z.ts" line="0">last<');
+  });
+
+  it('escapes embedded double quotes in the file attribute so the tag stays parsable', () => {
+    const out = serializeDiffCommentsForPrompt({
+      a: mk('/quirky"name.ts', 0, 'text', 100),
+    });
+    expect(out).toBe('<diff-feedback file="/quirky&quot;name.ts" line="0">text</diff-feedback>');
+  });
+});
+
+describe('<DiffView /> per-line comment affordance', () => {
+  it('renders an "Add a comment" button per diff line', () => {
+    render(<DiffView diff={spec('/a/x.ts', ['old'], ['new1', 'new2'])} />);
+    // 1 removed + 2 added = 3 diff lines, so 3 add-comment buttons.
+    const buttons = document.querySelectorAll('[data-diff-add-comment]');
+    expect(buttons).toHaveLength(3);
+    // Each button has the localized aria-label so screen readers can find it.
+    for (const b of Array.from(buttons)) {
+      expect(b.getAttribute('aria-label')).toMatch(/add a comment/i);
+    }
+  });
+
+  it('clicking the gutter "+" opens the composer; Save persists into the store', async () => {
+    render(<DiffView diff={spec('/a/y.ts', [], ['HELLO'])} />);
+    fireEvent.click(addCommentButtonForLine(0));
+    // Composer textarea should appear with the localized placeholder.
+    const composer = document.querySelector('[data-diff-comment-composer]');
+    expect(composer).not.toBeNull();
+    const ta = within(composer as HTMLElement).getByPlaceholderText(/add a comment for the agent/i);
+    fireEvent.change(ta, { target: { value: 'rename HELLO to HI' } });
+    // Click the localized Save button (rendered next to "Cancel").
+    const saveBtn = within(composer as HTMLElement).getByRole('button', { name: /^save$/i });
+    fireEvent.click(saveBtn);
+    // The composer has begun its AnimatePresence exit animation — under
+    // jsdom the wrapper may still be in the DOM for a tick. The contract
+    // we actually care about is "the comment is in the store now", which
+    // is observable immediately via the synchronous setState.
+    const bucket = useStore.getState().pendingDiffComments[SID];
+    expect(bucket).toBeDefined();
+    const list = Object.values(bucket!);
+    expect(list).toHaveLength(1);
+    expect(list[0].file).toBe('/a/y.ts');
+    expect(list[0].text).toBe('rename HELLO to HI');
+  });
+
+  it('lines with a saved comment expose a chip that re-opens the composer in edit mode', () => {
+    // Seed a comment for the only diff line ("ALPHA" at lineIndex=0).
+    act(() => {
+      useStore.getState().addDiffComment(SID, {
+        file: '/a/z.ts',
+        line: 0,
+        text: 'use BETA',
+      });
+    });
+    render(<DiffView diff={spec('/a/z.ts', [], ['ALPHA'])} />);
+    const chip = document.querySelector('[data-diff-comment-chip]');
+    expect(chip).not.toBeNull();
+    expect((chip as HTMLElement).textContent).toContain('use BETA');
+    // Click the chip → composer opens preloaded with the existing text.
+    fireEvent.click(chip as HTMLElement);
+    const composer = document.querySelector('[data-diff-comment-composer]');
+    expect(composer).not.toBeNull();
+    const ta = within(composer as HTMLElement).getByDisplayValue('use BETA');
+    expect(ta).toBeInTheDocument();
+    // Saving with empty body deletes (per updateDiffComment doc).
+    fireEvent.change(ta, { target: { value: '   ' } });
+    // Save button should be disabled when trimmed text is empty — instead the
+    // dedicated Trash button on the composer (data-diff-comment-delete) is
+    // the contract for explicit removal.
+    const trash = document.querySelector('[data-diff-comment-delete]');
+    expect(trash).not.toBeNull();
+    fireEvent.click(trash as HTMLElement);
+    expect(useStore.getState().pendingDiffComments[SID]).toBeUndefined();
+  });
+
+  it('Esc inside the composer cancels without saving', () => {
+    render(<DiffView diff={spec('/a/k.ts', [], ['LINE'])} />);
+    fireEvent.click(addCommentButtonForLine(0));
+    const composer = document.querySelector('[data-diff-comment-composer]') as HTMLElement;
+    const ta = within(composer).getByPlaceholderText(/add a comment/i) as HTMLTextAreaElement;
+    fireEvent.change(ta, { target: { value: 'half-typed' } });
+    fireEvent.keyDown(ta, { key: 'Escape' });
+    // Same caveat as the Save test: framer-motion exit animation may still
+    // hold the composer wrapper in the DOM under jsdom. The actual contract
+    // is "no comment was persisted", which is observable on the store.
+    expect(useStore.getState().pendingDiffComments[SID]).toBeUndefined();
+  });
+});

--- a/tests/inputbar-diff-comments.test.tsx
+++ b/tests/inputbar-diff-comments.test.tsx
@@ -1,0 +1,162 @@
+// InputBar wiring for #303 per-line diff comments.
+//
+// Asserts the contract between `pendingDiffComments` (in-store) and the
+// outgoing user prompt:
+//   1. With no pending comments, send() forwards the raw text unchanged.
+//   2. With pending comments, send() prepends `<diff-feedback>` blocks
+//      followed by a blank line, then clears the comments from the store.
+//   3. While the agent is running, the same prepend is baked into the
+//      QUEUED message (so the comment travels with the exact user turn the
+//      author was looking at when they pressed Enter, even if the queue
+//      drains many seconds later).
+//   4. The pending-comments indicator chip surfaces the count and disappears
+//      after send.
+//
+// Stubs `window.ccsm.agentSend` to capture the payload the IPC bridge
+// would receive — this is the same edge the real agent process sees.
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, act, cleanup } from '@testing-library/react';
+import { InputBar } from '../src/components/InputBar';
+import { useStore } from '../src/stores/store';
+
+const initial = useStore.getState();
+
+function freshStoreWithSession(
+  sessionId: string,
+  opts: { running?: boolean; started?: boolean } = {}
+) {
+  useStore.setState(
+    {
+      ...initial,
+      sessions: [
+        {
+          id: sessionId,
+          name: sessionId,
+          state: 'idle',
+          cwd: '~',
+          model: 'claude',
+          groupId: 'g-default',
+          agentType: 'claude-code',
+        },
+      ],
+      groups: [{ id: 'g-default', name: 'Sessions', collapsed: false, kind: 'normal' }],
+      activeId: sessionId,
+      messagesBySession: {},
+      startedSessions: opts.started ? { [sessionId]: true } : {},
+      runningSessions: opts.running ? { [sessionId]: true } : {},
+      messageQueues: {},
+      pendingDiffComments: {},
+      focusInputNonce: 0,
+    },
+    true
+  );
+}
+
+function stubCCSM(overrides: Partial<Record<string, unknown>> = {}) {
+  const api = {
+    agentInterrupt: vi.fn().mockResolvedValue(undefined),
+    agentSend: vi.fn().mockResolvedValue(true),
+    agentSendContent: vi.fn().mockResolvedValue(true),
+    agentStart: vi.fn().mockResolvedValue({ ok: true }),
+    ...overrides,
+  };
+  (globalThis as unknown as { window: Window & { ccsm?: unknown } }).window.ccsm = api;
+  return api;
+}
+
+beforeEach(() => {
+  cleanup();
+  (globalThis as unknown as { window: Window & { ccsm?: unknown } }).window.ccsm = undefined;
+});
+
+const SID = 's-303';
+
+describe('InputBar: diff-comment prepend on send', () => {
+  it('forwards the raw text unchanged when there are no pending comments', async () => {
+    freshStoreWithSession(SID, { started: true });
+    const api = stubCCSM();
+    render(<InputBar sessionId={SID} />);
+    const ta = screen.getByRole('textbox');
+    fireEvent.change(ta, { target: { value: 'hello' } });
+    await act(async () => {
+      fireEvent.keyDown(ta, { key: 'Enter' });
+      // Let the async send() resolve.
+      await Promise.resolve();
+    });
+    expect(api.agentSend).toHaveBeenCalledTimes(1);
+    expect(api.agentSend).toHaveBeenCalledWith(SID, 'hello');
+  });
+
+  it('prepends one <diff-feedback> per pending comment, then clears them', async () => {
+    freshStoreWithSession(SID, { started: true });
+    act(() => {
+      useStore.getState().addDiffComment(SID, { file: '/a/x.ts', line: 0, text: 'use X' });
+      useStore.getState().addDiffComment(SID, { file: '/a/x.ts', line: 3, text: 'rename Y' });
+    });
+    const api = stubCCSM();
+    render(<InputBar sessionId={SID} />);
+    const ta = screen.getByRole('textbox');
+    fireEvent.change(ta, { target: { value: 'fix it' } });
+    await act(async () => {
+      fireEvent.keyDown(ta, { key: 'Enter' });
+      await Promise.resolve();
+    });
+    expect(api.agentSend).toHaveBeenCalledTimes(1);
+    const [, payload] = api.agentSend.mock.calls[0];
+    // Exact format: each block on its own line, then blank line, then user text.
+    expect(payload).toBe(
+      '<diff-feedback file="/a/x.ts" line="0">use X</diff-feedback>\n' +
+      '<diff-feedback file="/a/x.ts" line="3">rename Y</diff-feedback>\n' +
+      '\n' +
+      'fix it'
+    );
+    // Comments are consumed — second send must NOT re-prepend.
+    expect(useStore.getState().pendingDiffComments[SID]).toBeUndefined();
+  });
+
+  it('bakes the prepend into the QUEUED message when the agent is running', () => {
+    // Started + running — Enter should enqueue, not call agentSend.
+    freshStoreWithSession(SID, { started: true, running: true });
+    act(() => {
+      useStore.getState().addDiffComment(SID, { file: '/q.ts', line: 1, text: 'less code' });
+    });
+    const api = stubCCSM();
+    render(<InputBar sessionId={SID} />);
+    const ta = screen.getByRole('textbox');
+    fireEvent.change(ta, { target: { value: 'follow-up' } });
+    act(() => {
+      fireEvent.keyDown(ta, { key: 'Enter' });
+    });
+    // No IPC fired — message went into the queue.
+    expect(api.agentSend).not.toHaveBeenCalled();
+    const queue = useStore.getState().messageQueues[SID];
+    expect(queue).toHaveLength(1);
+    // Queued payload carries the full prepend so the eventual drain sends
+    // exactly what the user expected at Enter time.
+    expect(queue![0].text).toBe(
+      '<diff-feedback file="/q.ts" line="1">less code</diff-feedback>\n\nfollow-up'
+    );
+    // Comments cleared synchronously on enqueue.
+    expect(useStore.getState().pendingDiffComments[SID]).toBeUndefined();
+  });
+
+  it('renders the "{n} diff comments will be sent" indicator and hides it after send', async () => {
+    freshStoreWithSession(SID, { started: true });
+    act(() => {
+      useStore.getState().addDiffComment(SID, { file: '/a.ts', line: 0, text: 'a' });
+      useStore.getState().addDiffComment(SID, { file: '/a.ts', line: 1, text: 'b' });
+      useStore.getState().addDiffComment(SID, { file: '/a.ts', line: 2, text: 'c' });
+    });
+    stubCCSM();
+    render(<InputBar sessionId={SID} />);
+    expect(screen.getByText(/3 diff comments will be sent/i)).toBeInTheDocument();
+    const ta = screen.getByRole('textbox');
+    fireEvent.change(ta, { target: { value: 'go' } });
+    await act(async () => {
+      fireEvent.keyDown(ta, { key: 'Enter' });
+      await Promise.resolve();
+    });
+    expect(screen.queryByText(/diff comments will be sent/i)).toBeNull();
+  });
+});

--- a/tests/inputbar-diff-comments.test.tsx
+++ b/tests/inputbar-diff-comments.test.tsx
@@ -159,4 +159,49 @@ describe('InputBar: diff-comment prepend on send', () => {
     });
     expect(screen.queryByText(/diff comments will be sent/i)).toBeNull();
   });
+
+  it('clicking the indicator scrolls the FIRST pending comment (smallest line) into view', () => {
+    freshStoreWithSession(SID, { started: true });
+    // Add comments out of order — the indicator must still scroll the
+    // smallest-line one (matches serializeDiffCommentsForPrompt order).
+    act(() => {
+      useStore.getState().addDiffComment(SID, { file: '/a.ts', line: 5, text: 'fifth' });
+      useStore.getState().addDiffComment(SID, { file: '/a.ts', line: 1, text: 'first' });
+      useStore.getState().addDiffComment(SID, { file: '/a.ts', line: 3, text: 'third' });
+    });
+    // Resolve the comment ids the way the click handler will: by walking the
+    // store and picking (file asc, line asc, createdAt asc).
+    const bucket = useStore.getState().pendingDiffComments[SID]!;
+    const sorted = Object.values(bucket).sort((a, b) => a.line - b.line);
+    const firstId = sorted[0].id;
+
+    // Mount fake chip elements representing the rendered DiffView. We mount
+    // them in DOM order DIFFERENT from line order so a naive
+    // `querySelector('[data-diff-comment-chip]')` would pick the wrong one.
+    const wrap = document.createElement('div');
+    sorted
+      .slice()
+      .reverse()
+      .forEach((c) => {
+        const chip = document.createElement('button');
+        chip.setAttribute('data-diff-comment-chip', '');
+        chip.setAttribute('data-diff-comment-id', c.id);
+        wrap.appendChild(chip);
+      });
+    document.body.appendChild(wrap);
+    const firstEl = wrap.querySelector(
+      `[data-diff-comment-id="${firstId}"]`
+    ) as HTMLElement;
+    const scrollSpy = vi.fn();
+    firstEl.scrollIntoView = scrollSpy as unknown as Element['scrollIntoView'];
+
+    stubCCSM();
+    render(<InputBar sessionId={SID} />);
+    const indicator = screen.getByText(/3 diff comments will be sent/i);
+    fireEvent.click(indicator);
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+    expect(scrollSpy).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' });
+
+    document.body.removeChild(wrap);
+  });
 });


### PR DESCRIPTION
## Summary

Lets the user attach a per-line note to any DiffView (historical
Edit/Write/MultiEdit results AND pending permission diffs) and ride those
notes back to the agent on the next user prompt as structured
`<diff-feedback file="…" line="N">…</diff-feedback>` blocks.

**Submit-mechanism (manager-decided, option d+b):**
- buffer comments in-memory, session-scoped
- prepend serialized blocks to the next user prompt body, separated by a blank line
- clear the bucket synchronously on send (or on enqueue when the agent is running)
- NEVER auto-submit, NEVER inject as a system message, NEVER persist beyond the app session

## Layer 1 push-back history

Manager confirmed the submit-mechanism, scope (all diffs, not just pending), no-persistence, single-comment-per-line, and the no-bloat rules (no markdown, no draft save, etc.). Worker proceeded to implement after the answers landed.

## Surfaces touched

- `src/components/chat/DiffView.tsx` — gutter `+` per line, inline composer, chip + edit + delete. DiffView reads `activeId` from the store directly, avoiding prop plumbing through ToolBlock + PermissionPromptBlock.
- `src/components/InputBar.tsx` — pending-comments indicator chip, send-path prepend + clear (covers both immediate-send and enqueue-while-running paths).
- `src/stores/store.ts` — `pendingDiffComments` slice, add/update/delete/clear actions, and `serializeDiffCommentsForPrompt(bucket)` helper with stable (file, line, createdAt) sort + attribute escape.
- `src/i18n/locales/{en,zh}.ts` — appended at EOF in a fresh `task303` namespace per the task brief's anchor convention.

## Test plan

- [x] `tests/diff-view-line-comments.test.tsx` — store slice semantics, serializer format + ordering + double-quote escape in `file=`, render flow (gutter +, composer open, save, chip, edit-via-chip, trash, Esc cancel). 13 specs.
- [x] `tests/inputbar-diff-comments.test.tsx` — no-comment passthrough, two-comment prepend + bucket clear, queued-payload prepend while running, chip visibility before/after send. 4 specs.
- [x] `tests/i18n-key-parity.test.ts` still green — en/zh `task303` keys at parity.
- [x] `tests/diff-view-per-file-collapse.test.tsx` (#302) still green — confirms the DiffView refactor didn't regress per-file collapse semantics.
- [x] `tests/permission-prompt-block.test.tsx` (#306) still green — confirms select-mode interop intact (24 specs).
- [x] `tests/inputbar.test.tsx` still green — confirms Esc-to-interrupt + queue-while-running paths still work alongside the new prepend (7 specs).
- [ ] **Screenshots NOT captured by the worker.** Per `feedback_visual_fix_screenshots.md` this is a functional feature PR (net new behavior), not a type/color/spacing PR — render tests + integration test cover the contract. The reviewer's dogfood pass is the right place to capture before/after of: empty DiffView (no chips), hover-shows-+, composer-open, line-with-chip, InputBar `{n} diff comments will be sent` indicator. Suggested target dir: `dogfood-logs/task-303/`.
- [ ] **No new playwright probe.** A real prepend-payload probe would need a live LLM turn; the integration test stubs `window.ccsm.agentSend` and asserts the same payload at the same edge for free. Manager dogfood pass should still try the flow end-to-end against a real session.

## Pre-existing test environment failures (NOT introduced by this PR)

Verified by stashing my changes — same failures on baseline `origin/working`:
- `electron/__tests__/db.test.ts`, `db-hardening.test.ts` — `better-sqlite3` `NODE_MODULE_VERSION 130 vs 127` mismatch in the worktree's linked `node_modules` (needs `npm rebuild`).
- `tests/switch.test.tsx`, `connection-pane.test.tsx`, `settings-test-notification.test.tsx` — missing `@radix-ui/react-switch` install.
- Same two TypeScript errors on baseline (`SettingsDialog.tsx:638`, `ui/Switch.tsx:2`).

## Notes for reviewer

- The `<diff-feedback>` block format is invented for this PR — no upstream contract. Format is documented inline at `serializeDiffCommentsForPrompt` and tested for exact byte-for-byte output. If the manager wants a different tag name or a JSON envelope instead, that's a one-line change in `serializeDiffCommentsForPrompt`.
- "Line index" on the comment is the sequential 0-based row inside the FileSection's removed-then-added render order — NOT a source-file line number. Documented on `PendingDiffComment.line`. The agent gets enough context from the surrounding diff in the same turn to map it back.
- DiffView reads `useStore(s => s.activeId)` to find which session bucket to write to. Works because DiffView only renders inside a ChatStream that's already pinned to the active session. If multi-session-side-by-side ever ships, this needs revisiting.