### PR TITLE
fix(probe): J5b finder + J9 IPC stub for tool-journey-render (#333)

### DIFF
--- a/scripts/probe-e2e-tool-journey-render.mjs
+++ b/scripts/probe-e2e-tool-journey-render.mjs
@@ -497,15 +497,19 @@ try {
     await win.waitForTimeout(200);
     const probe = await win.evaluate(() => {
       const btns = Array.from(document.querySelectorAll('main button[aria-expanded]'));
-      // Find the button whose row contains our tokens.
+      // Find the button whose OWN ToolBlock root contains the token. The
+      // previous `find` walked up 6 ancestor levels and matched the first
+      // ancestor whose textContent contained the token — but with two tool
+      // blocks rendered as siblings under the chat stream, both buttons
+      // share an ancestor (the stream root) whose textContent contains
+      // BOTH tokens. That made `find('ok-auto')` resolve to whichever
+      // button was iterated first (the error block), masking real bugs.
+      // The precise anchor is the ToolBlock root (`div.font-mono.text-chrome`)
+      // — each block's root contains exactly its own brief + result body.
       function find(token) {
         for (const b of btns) {
-          // Walk up to the block container, then check its text body.
-          let cur = b.parentElement;
-          for (let i = 0; i < 6 && cur; i++) {
-            if (cur.textContent && cur.textContent.includes(token)) return b;
-            cur = cur.parentElement;
-          }
+          const root = b.closest('div.font-mono.text-chrome');
+          if (root && root.textContent && root.textContent.includes(token)) return b;
         }
         return null;
       }
@@ -647,23 +651,23 @@ try {
     // ChatStream already passes as `now` — set the system clock forward in
     // the store after seeding so the elapsedMs counter crosses the
     // escalation threshold.
-    await win.evaluate(() => {
-      const calls = [];
-      window.__ccsm = window.ccsm ?? {};
-      window.__cancelCalls = calls;
-      // Replace just the one method we want to observe; preserve the rest
-      // of the bridge so unrelated renderer code (notify, settings, etc.)
-      // still works.
-      window.ccsm = new Proxy(window.ccsm ?? {}, {
-        get(target, prop) {
-          if (prop === 'agentCancelToolUse') {
-            return (args) => {
-              calls.push(args);
-              return Promise.resolve({ ok: true });
-            };
-          }
-          return Reflect.get(target, prop);
-        },
+    // Stub the cancel IPC at the MAIN-process side, not on `window.ccsm`.
+    // The renderer bridge is exposed via `contextBridge.exposeInMainWorld`
+    // (`electron/preload.ts:366`), which makes `window.ccsm` non-writable
+    // and non-configurable. The previous probe stubbed it with
+    // `window.ccsm = new Proxy(...)` — that assignment silently no-ops in
+    // non-strict mode, so the original preload-bound `agentCancelToolUse`
+    // kept firing and the probe's `__cancelCalls` array stayed empty even
+    // though the click was reaching the bridge for real (proven by J9b
+    // passing). Overriding `ipcMain.handle('agent:cancelToolUse', ...)`
+    // from main bypasses the contextBridge guard entirely; same pattern
+    // already used by probe-e2e-askuserquestion-full.mjs.
+    await app.evaluate(({ ipcMain }) => {
+      const calls = (global.__cancelCalls = []);
+      try { ipcMain.removeHandler('agent:cancelToolUse'); } catch {}
+      ipcMain.handle('agent:cancelToolUse', (_e, args) => {
+        calls.push(args);
+        return { ok: true };
       });
     });
 
@@ -714,12 +718,14 @@ try {
       }
       await cancelEl.click();
       await win.waitForTimeout(150);
+      // The cancel-call list now lives in main (see app.evaluate stub above);
+      // text/aria are still renderer-side state on the same DOM node.
+      const calls = await app.evaluate(() => (global.__cancelCalls || []).slice());
       const observed = await win.evaluate(() => ({
-        calls: window.__cancelCalls.slice(),
         text: document.querySelector('[data-testid="tool-stall-cancel"]')?.textContent ?? null,
         aria: document.querySelector('[data-testid="tool-stall-cancel"]')?.getAttribute('aria-disabled') ?? null,
       }));
-      invokedWith = observed.calls[0] ?? null;
+      invokedWith = calls[0] ?? null;
       cancellingTextAfter = observed.text;
       ariaDisabledAfter = observed.aria;
     }


### PR DESCRIPTION
## Summary

Two probe-only fixes for `scripts/probe-e2e-tool-journey-render.mjs`. Both J5b and the J9 wiring case were exercising correct production behavior, but their observation channels had silently rotted as surrounding code hardened. Triage at `dogfood-logs/task-333/triage.md`.

- **J5b finder**: replaced the 6-level ancestor-walk in `find(token)` with `b.closest('div.font-mono.text-chrome')` (the ToolBlock root). The old walk matched the chat-stream root whose textContent contained both `fail-auto` and `ok-auto`, so `find('ok-auto')` returned the error block's button. Scoping to each block's own root resolves correctly.
- **J9 IPC stub**: replaced `window.ccsm = new Proxy(...)` (which silently no-ops because `contextBridge.exposeInMainWorld` makes `ccsm` non-writable / non-configurable) with main-side `ipcMain.handle('agent:cancelToolUse', ...)` override via `app.evaluate(({ ipcMain }) => ...)`. Same pattern already used by `probe-e2e-askuserquestion-full.mjs`.

No production code changes. No i18n changes.

## Probe results

| | Before | After |
|---|---|---|
| `node scripts/probe-e2e-tool-journey-render.mjs` | 15/17 | 17/17 |

Failures before: J5b (errored block auto-expand check read wrong button) + J9 wiring (cancel-IPC stub never observed the call).

## Reverse-verify

- **J5b**: forced `useState(false)` in `ToolBlock.tsx:62` (removed auto-expand-on-mount). Result: J5b FAILED, J9 PASSED. Restored.
- **J9**: replaced the cancel IPC body in `onCancelStalled` with an early `return` (no-op'd the IPC call). Result: J5b PASSED, J9 FAILED. Restored.
- Final clean run after restoring both: 17/17 PASS.

## Test plan

- [x] Baseline: 15/17 (matches triage)
- [x] After fixes: 17/17
- [x] J5b reverse-verify (production bug introduced -> case fails)
- [x] J9 reverse-verify (production bug introduced -> case fails)
- [x] No other cases regressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)