### PR TITLE
fix(diff): empty-text Enter in inline composer = Cancel (#340)

### DIFF
--- a/src/components/chat/DiffView.tsx
+++ b/src/components/chat/DiffView.tsx
@@ -84,7 +84,11 @@ function InlineCommentComposer({
         onKeyDown={(e) => {
           if (e.key === 'Enter' && !e.shiftKey) {
             e.preventDefault();
+            // Empty Enter is treated as cancel (#340) — pressing Enter on a
+            // blank composer was creating empty comments, which is junk.
+            // Esc and empty-Enter now share the same close-without-save path.
             if (trimmed) onSave(trimmed);
+            else onCancel();
           } else if (e.key === 'Escape') {
             e.preventDefault();
             onCancel();

--- a/src/components/chat/DiffView.tsx
+++ b/src/components/chat/DiffView.tsx
@@ -84,9 +84,9 @@ function InlineCommentComposer({
         onKeyDown={(e) => {
           if (e.key === 'Enter' && !e.shiftKey) {
             e.preventDefault();
-            // Empty Enter is treated as cancel (#340) — pressing Enter on a
-            // blank composer was creating empty comments, which is junk.
-            // Esc and empty-Enter now share the same close-without-save path.
+            // Empty Enter dismisses the composer (#340) — previously it was a
+            // silent no-op that left a blank composer hanging open. Aligns
+            // with Esc so blank Enter no longer feels broken.
             if (trimmed) onSave(trimmed);
             else onCancel();
           } else if (e.key === 'Escape') {

--- a/tests/diff-view-line-comments.test.tsx
+++ b/tests/diff-view-line-comments.test.tsx
@@ -224,4 +224,36 @@ describe('<DiffView /> per-line comment affordance', () => {
     // is "no comment was persisted", which is observable on the store.
     expect(useStore.getState().pendingDiffComments[SID]).toBeUndefined();
   });
+
+  it('Enter on an empty composer cancels (no junk comment) and closes it (#340)', () => {
+    render(<DiffView diff={spec('/a/e.ts', [], ['LINE'])} />);
+    fireEvent.click(addCommentButtonForLine(0));
+    const composer = document.querySelector('[data-diff-comment-composer]') as HTMLElement;
+    expect(composer).not.toBeNull();
+    const ta = within(composer).getByPlaceholderText(/add a comment/i) as HTMLTextAreaElement;
+    // Whitespace-only counts as empty.
+    fireEvent.change(ta, { target: { value: '   ' } });
+    fireEvent.keyDown(ta, { key: 'Enter' });
+    // No comment persisted (addDiffComment / updateDiffComment never fired).
+    expect(useStore.getState().pendingDiffComments[SID]).toBeUndefined();
+    // Composer is dismissed — its wrapper is no longer in the DOM (the
+    // store is the source of truth for "is there a comment", and composer
+    // close is observable via composerLine being reset on the parent
+    // FileSection, which removes the wrapper synchronously up to the
+    // exit animation. Mirror the Esc test's contract: no persisted state.
+  });
+
+  it('Enter on a non-empty composer still saves (regression guard for #340)', () => {
+    render(<DiffView diff={spec('/a/n.ts', [], ['LINE'])} />);
+    fireEvent.click(addCommentButtonForLine(0));
+    const composer = document.querySelector('[data-diff-comment-composer]') as HTMLElement;
+    const ta = within(composer).getByPlaceholderText(/add a comment/i) as HTMLTextAreaElement;
+    fireEvent.change(ta, { target: { value: 'real feedback' } });
+    fireEvent.keyDown(ta, { key: 'Enter' });
+    const bucket = useStore.getState().pendingDiffComments[SID];
+    expect(bucket).toBeDefined();
+    const list = Object.values(bucket!);
+    expect(list).toHaveLength(1);
+    expect(list[0].text).toBe('real feedback');
+  });
 });

--- a/tests/diff-view-line-comments.test.tsx
+++ b/tests/diff-view-line-comments.test.tsx
@@ -16,7 +16,7 @@
 //     hits agentSend). Splitting keeps each test honest about its scope.
 import React from 'react';
 import { describe, it, expect, beforeEach } from 'vitest';
-import { render, screen, fireEvent, within, act } from '@testing-library/react';
+import { render, screen, fireEvent, within, act, waitFor } from '@testing-library/react';
 import { DiffView } from '../src/components/chat/DiffView';
 import type { DiffSpec } from '../src/utils/diff';
 import {
@@ -225,7 +225,7 @@ describe('<DiffView /> per-line comment affordance', () => {
     expect(useStore.getState().pendingDiffComments[SID]).toBeUndefined();
   });
 
-  it('Enter on an empty composer cancels (no junk comment) and closes it (#340)', () => {
+  it('Enter on an empty composer cancels (no junk comment) and closes it (#340)', async () => {
     render(<DiffView diff={spec('/a/e.ts', [], ['LINE'])} />);
     fireEvent.click(addCommentButtonForLine(0));
     const composer = document.querySelector('[data-diff-comment-composer]') as HTMLElement;
@@ -236,11 +236,13 @@ describe('<DiffView /> per-line comment affordance', () => {
     fireEvent.keyDown(ta, { key: 'Enter' });
     // No comment persisted (addDiffComment / updateDiffComment never fired).
     expect(useStore.getState().pendingDiffComments[SID]).toBeUndefined();
-    // Composer is dismissed — its wrapper is no longer in the DOM (the
-    // store is the source of truth for "is there a comment", and composer
-    // close is observable via composerLine being reset on the parent
-    // FileSection, which removes the wrapper synchronously up to the
-    // exit animation. Mirror the Esc test's contract: no persisted state.
+    // Composer is dismissed. This is the load-bearing assertion for #340 —
+    // before the fix, empty Enter was a silent no-op that left the composer
+    // hanging open. AnimatePresence exit may take a tick under jsdom, so
+    // waitFor handles the brief window before the wrapper unmounts.
+    await waitFor(() => {
+      expect(document.querySelector('[data-diff-comment-composer]')).toBeNull();
+    });
   });
 
   it('Enter on a non-empty composer still saves (regression guard for #340)', () => {


### PR DESCRIPTION
Empty Enter on the inline diff-comment composer now closes it (matches Esc), instead of being a silent no-op that left a blank composer hanging.

## Test plan
- [x] `npm test -- diff-view-line-comments` (15/15 pass; 2 new cases for empty-Enter cancel + non-empty-Enter save)
- [x] `npm run typecheck` (no new errors; 2 pre-existing on `working` unchanged)