### PR TITLE
fix(store): dedupe per-line diff comments at store layer (#338)

### DIFF
--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -317,6 +317,11 @@ export interface PendingDiffComment {
   line: number;
   text: string;
   createdAt: number;
+  // Bumped when an existing (file, line) comment is overwritten by a fresh
+  // addDiffComment call. Sort order still keys on createdAt so the prompt
+  // serialization stays deterministic across the replace; updatedAt is
+  // informational only.
+  updatedAt?: number;
 }
 
 /**
@@ -1933,6 +1938,33 @@ export const useStore = create<State & Actions>((set, get) => ({
   addDiffComment: (sessionId, args) => {
     const text = args.text.trim();
     if (!sessionId || !text) return '';
+    // Dedupe: at most one comment per (sessionId, file, line). A second
+    // addDiffComment for the same anchor REPLACES the existing entry
+    // (overwrite text, bump updatedAt, keep id + createdAt) instead of
+    // stacking. Reusing the id keeps DiffView's data-diff-comment-id DOM
+    // lookups stable across the replace.
+    const existing = get().pendingDiffComments[sessionId];
+    if (existing) {
+      const dup = Object.values(existing).find(
+        (c) => c.file === args.file && c.line === args.line,
+      );
+      if (dup) {
+        set((s) => {
+          const bucket = s.pendingDiffComments[sessionId];
+          if (!bucket || !bucket[dup.id]) return s;
+          return {
+            pendingDiffComments: {
+              ...s.pendingDiffComments,
+              [sessionId]: {
+                ...bucket,
+                [dup.id]: { ...bucket[dup.id], text, updatedAt: Date.now() },
+              },
+            },
+          };
+        });
+        return dup.id;
+      }
+    }
     const id = nextId('dfc');
     set((s) => {
       const prev = s.pendingDiffComments[sessionId] ?? {};

--- a/tests/store-pending-diff-comments.test.ts
+++ b/tests/store-pending-diff-comments.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useStore } from '../src/stores/store';
+
+// Snapshot/restore initial state for isolation. The store auto-subscribes
+// to persist via hydrateStore(); we never call it in tests, so all set()
+// calls are purely in-memory.
+const initial = useStore.getState();
+
+beforeEach(() => {
+  useStore.setState({ ...initial, pendingDiffComments: {} }, true);
+});
+
+describe('store: addDiffComment dedupe', () => {
+  const sid = 's-1';
+  const file = 'src/foo.ts';
+  const line = 42;
+
+  it('replaces an existing (file, line) comment instead of stacking', () => {
+    const id1 = useStore.getState().addDiffComment(sid, { file, line, text: 'first' });
+    const id2 = useStore.getState().addDiffComment(sid, { file, line, text: 'second' });
+
+    const bucket = useStore.getState().pendingDiffComments[sid] ?? {};
+    const list = Object.values(bucket);
+
+    expect(list).toHaveLength(1);
+    expect(list[0].text).toBe('second');
+    // Reusing the id keeps DiffView's data-diff-comment-id DOM lookups stable.
+    expect(id2).toBe(id1);
+    expect(bucket[id1].file).toBe(file);
+    expect(bucket[id1].line).toBe(line);
+    expect(typeof bucket[id1].updatedAt).toBe('number');
+  });
+
+  it('keeps separate entries for different lines in the same file', () => {
+    useStore.getState().addDiffComment(sid, { file, line: 1, text: 'a' });
+    useStore.getState().addDiffComment(sid, { file, line: 2, text: 'b' });
+
+    const list = Object.values(useStore.getState().pendingDiffComments[sid] ?? {});
+    expect(list).toHaveLength(2);
+  });
+
+  it('keeps separate entries for the same line in different files', () => {
+    useStore.getState().addDiffComment(sid, { file: 'a.ts', line, text: 'a' });
+    useStore.getState().addDiffComment(sid, { file: 'b.ts', line, text: 'b' });
+
+    const list = Object.values(useStore.getState().pendingDiffComments[sid] ?? {});
+    expect(list).toHaveLength(2);
+  });
+
+  it('trims the replacement text', () => {
+    const id1 = useStore.getState().addDiffComment(sid, { file, line, text: 'first' });
+    useStore.getState().addDiffComment(sid, { file, line, text: '  second  ' });
+
+    const bucket = useStore.getState().pendingDiffComments[sid] ?? {};
+    expect(bucket[id1].text).toBe('second');
+  });
+});


### PR DESCRIPTION
## Summary
Layer 2 hardening for #303: `addDiffComment` now replaces any existing (sessionId, file, line) entry instead of stacking a duplicate. The original id is reused so DiffView's `data-diff-comment-id` DOM lookups stay stable across the replace.

## Test plan
- [x] `tests/store-pending-diff-comments.test.ts` — 4 new unit tests (replace, distinct lines, distinct files, trim)
- [x] `npm run typecheck` clean
- [x] `tests/diff-view-line-comments.test.tsx`, `tests/inputbar-diff-comments.test.tsx`, `tests/store.test.ts` still pass (103/103)