### PR TITLE
chore(probe): add tool-block-root testid + tighten J5b locator (#341)

### DIFF
--- a/scripts/probe-e2e-tool-journey-render.mjs
+++ b/scripts/probe-e2e-tool-journey-render.mjs
@@ -504,11 +504,15 @@ try {
       // share an ancestor (the stream root) whose textContent contains
       // BOTH tokens. That made `find('ok-auto')` resolve to whichever
       // button was iterated first (the error block), masking real bugs.
-      // The precise anchor is the ToolBlock root (`div.font-mono.text-chrome`)
-      // — each block's root contains exactly its own brief + result body.
+      // The precise anchor is the ToolBlock root carrying
+      // `data-testid="tool-block-root"` (#341) — each block's root contains
+      // exactly its own brief + result body. Previously we matched the
+      // Tailwind class string `div.font-mono.text-chrome`, but that coupled
+      // the probe to styling decisions that change frequently; the testid is
+      // the stable contract.
       function find(token) {
         for (const b of btns) {
-          const root = b.closest('div.font-mono.text-chrome');
+          const root = b.closest('[data-testid="tool-block-root"]');
           if (root && root.textContent && root.textContent.includes(token)) return b;
         }
         return null;

--- a/src/components/chat/blocks/ToolBlock.tsx
+++ b/src/components/chat/blocks/ToolBlock.tsx
@@ -176,6 +176,7 @@ export function ToolBlock({
   const isShellTool = SHELL_OUTPUT_TOOLS.has(name);
   return (
     <div
+      data-testid="tool-block-root"
       className={
         'font-mono text-chrome ' +
         (isError


### PR DESCRIPTION
## Summary
- Add `data-testid="tool-block-root"` to ToolBlock's outermost `<div>` so probes have a stable per-block handle (the same root covers error + healthy variants).
- Update the J5b case in `probe-e2e-tool-journey-render.mjs` to walk up via `closest('[data-testid="tool-block-root"]')` instead of the Tailwind class string `div.font-mono.text-chrome` introduced in #263.
- Decouples the probe from styling decisions; testid is the long-term contract.

## Why
PR #263 made J5b correct but fragile — `font-mono text-chrome` will change as ToolBlock styling evolves, silently breaking the probe again. A `data-testid` is the right long-term contract.

## Test plan
- [x] `node scripts/probe-e2e-tool-journey-render.mjs` — 17/17 pass (J5b uses the new testid)
- [x] `npm run typecheck` — only pre-existing baseline errors (SettingsDialog/Switch), unrelated
- [x] No ToolBlock unit tests exist; broader suite shows only pre-existing better-sqlite3 NODE_MODULE_VERSION failures unrelated to this change

Closes #341