### PR TITLE
feat(input): continue-after-interrupt affordance (#322)

### DIFF
--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -138,7 +138,7 @@ export function InputBar({ sessionId }: { sessionId: string }) {
   // Perf: subscribe to all reactive per-session signals via useShallow so this
   // component only re-renders when one of these specific values changes
   // (instead of once per any store mutation, like an appendBlocks chunk).
-  const { session, started, running, queueLength, hasMessages, hasPendingWaiting, permission, focusInputNonce, pendingDiffCommentsCount } = useStore(
+  const { session, started, running, queueLength, hasMessages, hasPendingWaiting, permission, focusInputNonce, pendingDiffCommentsCount, lastTurnEnd } = useStore(
     useShallow((s) => ({
       session: s.sessions.find((x) => x.id === sessionId),
       started: !!s.startedSessions[sessionId],
@@ -157,11 +157,14 @@ export function InputBar({ sessionId }: { sessionId: string }) {
       // comments will be sent" indicator + lets the send path skip the
       // serialization round-trip when there are none.
       pendingDiffCommentsCount: Object.keys(s.pendingDiffComments[sessionId] ?? {}).length,
+      // task322: 'interrupted' iff the last turn for this session ended via
+      // user-initiated stop. Drives the continue-hint affordance below.
+      lastTurnEnd: s.lastTurnEnd[sessionId] ?? null,
     }))
   );
   // Action references are stable across renders in Zustand v5, so reading them
   // via getState() avoids registering listeners that would never fire anyway.
-  const { appendBlocks, markStarted, setRunning, markInterrupted, enqueueMessage, clearQueue, bumpComposerFocus, clearDiffComments } =
+  const { appendBlocks, markStarted, setRunning, markInterrupted, enqueueMessage, clearQueue, bumpComposerFocus, clearDiffComments, clearLastTurnEnd } =
     useStore.getState();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -237,6 +240,36 @@ export function InputBar({ sessionId }: { sessionId: string }) {
     setRejections([]);
   }, [sessionId]);
 
+  // task322: continue-after-interrupt — show a one-line hint above the
+  // composer after the user stops a turn, telling them they can press Enter
+  // (with empty composer) to send the literal `continue`. Gate conditions:
+  //   (a) last turn ended via interrupt (store: lastTurnEnd === 'interrupted')
+  //   (b) composer is empty (no draft, no attachments)
+  //   (c) user hasn't typed anything since the interrupt (typedSinceInterrupt
+  //       latches true on the first keystroke, resets on a fresh interrupt)
+  //   (d) agent is not currently running
+  // The hint dismisses when any of (b)/(c)/(d) flips, when the user sends a
+  // message (clearLastTurnEnd in `send()`), or when a new turn starts
+  // (setRunning(true) clears lastTurnEnd in the store).
+  const [typedSinceInterrupt, setTypedSinceInterrupt] = useState(false);
+  // Reset the typed-since-interrupt latch every time we observe a new
+  // 'interrupted' transition. The session-id change effect above also resets
+  // this implicitly (component unmount/remount), but session switches reuse
+  // the same component instance — so we re-arm explicitly here.
+  const lastSeenInterruptRef = useRef<string | null>(null);
+  useEffect(() => {
+    const key = `${sessionId}:${lastTurnEnd ?? 'none'}`;
+    if (lastSeenInterruptRef.current === key) return;
+    lastSeenInterruptRef.current = key;
+    if (lastTurnEnd === 'interrupted') setTypedSinceInterrupt(false);
+  }, [sessionId, lastTurnEnd]);
+  const showContinueHint =
+    lastTurnEnd === 'interrupted' &&
+    !running &&
+    value === '' &&
+    attachments.length === 0 &&
+    !typedSinceInterrupt;
+
   useEffect(() => {
     if (focusNonceSeenRef.current === null) {
       focusNonceSeenRef.current = focusInputNonce;
@@ -259,6 +292,12 @@ export function InputBar({ sessionId }: { sessionId: string }) {
 
   function update(next: string) {
     setValue(next);
+    // task322: any keystroke (even one that lands an empty string back —
+    // e.g. paste-then-undo) counts as user activity that dismisses the
+    // continue-after-interrupt hint. We only flip the latch when the value
+    // actually has content; pure deletions back to "" leave the hint armed
+    // (the user might still hit Enter to continue).
+    if (next !== '') setTypedSinceInterrupt(true);
     // Any edit re-arms the picker (so the user can dismiss with Esc, then
     // keep typing to reopen it if they're still in the `/...` prefix).
     setPickerDismissed(false);
@@ -442,6 +481,11 @@ export function InputBar({ sessionId }: { sessionId: string }) {
     // Valid turns: text with or without images, OR images with no text. Empty
     // text + no images is a no-op (same as before).
     if (!text && imgs.length === 0) return;
+    // task322: any send dismisses the continue-after-interrupt hint
+    // synchronously. setRunning(true) below would also clear it via the
+    // store, but doing it here covers the queued-while-running branch (which
+    // doesn't flip running) and avoids a one-frame flash of the hint.
+    clearLastTurnEnd(sessionId);
 
     // Slash-command fast path: if the whole message is `/<name> [args]` and
     // a client-side handler is registered, run it locally and return. This
@@ -613,6 +657,13 @@ export function InputBar({ sessionId }: { sessionId: string }) {
 
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
+      // task322: empty composer + active continue-hint → send literal
+      // 'continue' through the normal send path. This is the affordance the
+      // hint advertises; without it, empty-Enter would no-op as before.
+      if (showContinueHint) {
+        void send('continue');
+        return;
+      }
       send();
     }
   }
@@ -683,6 +734,18 @@ export function InputBar({ sessionId }: { sessionId: string }) {
           </motion.div>
         )}
       </AnimatePresence>
+
+      {/* task322: continue-after-interrupt hint. One-line muted row above
+          the composer; empty-Enter while it's visible sends `continue`. */}
+      {showContinueHint && (
+        <div
+          data-testid="continue-after-interrupt-hint"
+          className="mb-1 px-1 text-meta text-fg-tertiary select-none"
+          aria-live="polite"
+        >
+          {t('chat.continueAfterInterruptHint')}
+        </div>
+      )}
 
       <div
         className={cn(

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -131,7 +131,9 @@ const en = {
     runningPlaceholderDefault: 'Running… will ask for permission on tool use (Esc to interrupt, Enter to queue)',
     runningPlaceholderAcceptEdits: 'Running… auto-accepting edits (Esc to interrupt, Enter to queue)',
     runningPlaceholderBypass: 'Running… bypassing permission prompts (Esc to interrupt, Enter to queue)',
-    runningPlaceholderPlan: 'Running… planning only, no edits (Esc to interrupt, Enter to queue)'
+    runningPlaceholderPlan: 'Running… planning only, no edits (Esc to interrupt, Enter to queue)',
+    // task322: continue-after-interrupt
+    continueAfterInterruptHint: 'Press Enter to continue, or type a new message'
   },
   chatStream: {
     emptyHint: 'Type a message and press'

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -126,7 +126,9 @@ const zh: EnCatalog = {
     runningPlaceholderDefault: '执行中… 工具调用前会询问权限（Esc 中断，Enter 排队）',
     runningPlaceholderAcceptEdits: '执行中… 自动接受编辑（Esc 中断，Enter 排队）',
     runningPlaceholderBypass: '执行中… 跳过所有权限询问（Esc 中断，Enter 排队）',
-    runningPlaceholderPlan: '执行中… 仅规划，不进行编辑（Esc 中断，Enter 排队）'
+    runningPlaceholderPlan: '执行中… 仅规划，不进行编辑（Esc 中断，Enter 排队）',
+    // task322: continue-after-interrupt
+    continueAfterInterruptHint: '按 Enter 继续，或输入新消息'
   },
   chatStream: {
     emptyHint: '输入消息后按'

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -295,6 +295,12 @@ type State = {
    * the user on a randomly-open menu after restart).
    */
   openPopoverId: string | null;
+  // task322: continue-after-interrupt — per-session record of how the most
+  // recent turn ended. 'interrupted' triggers the InputBar continue-hint;
+  // 'ok' / missing = no hint. Set in `markInterrupted`, cleared in
+  // `setRunning(id, true)` when a fresh turn begins. Not persisted — a hint
+  // surviving an app reload would feel stale.
+  lastTurnEnd: Record<string, 'ok' | 'interrupted'>;
 };
 
 /**
@@ -545,6 +551,10 @@ type Actions = {
   /** Drop ALL pending comments for `sessionId`. Called from the send path
    *  after a prompt has been consumed. */
   clearDiffComments: (sessionId: string) => void;
+  // task322: continue-after-interrupt — explicit clear used when the user
+  // sends any message (continue or otherwise) so the hint dismisses
+  // immediately, before the round-trip that would clear it via setRunning.
+  clearLastTurnEnd: (sessionId: string) => void;
 };
 
 function nextId(prefix: string): string {
@@ -859,6 +869,8 @@ export const useStore = create<State & Actions>((set, get) => ({
   sessionInitFailures: {},
   allowAlwaysTools: [],
   openPopoverId: null,
+  // task322: continue-after-interrupt
+  lastTurnEnd: {},
   pendingDiffComments: {},
 
   selectSession: (id) => {
@@ -1743,7 +1755,17 @@ export const useStore = create<State & Actions>((set, get) => ({
       const next = { ...s.runningSessions };
       if (running) next[sessionId] = true;
       else delete next[sessionId];
-      return { runningSessions: next };
+      // task322: a fresh turn starting clears any prior interrupt-hint state
+      // for this session. The hint is meant to bridge the gap between Stop
+      // and the next user keystroke — once a turn is back in flight, it's
+      // stale by definition.
+      const patch: Partial<State> = { runningSessions: next };
+      if (running && s.lastTurnEnd[sessionId]) {
+        const nextLte = { ...s.lastTurnEnd };
+        delete nextLte[sessionId];
+        patch.lastTurnEnd = nextLte;
+      }
+      return patch;
     });
   },
 
@@ -1760,11 +1782,19 @@ export const useStore = create<State & Actions>((set, get) => ({
   },
 
   markInterrupted: (sessionId) => {
-    set((s) =>
-      s.interruptedSessions[sessionId]
-        ? s
-        : { interruptedSessions: { ...s.interruptedSessions, [sessionId]: true } }
-    );
+    set((s) => {
+      const patch: Partial<State> = {};
+      if (!s.interruptedSessions[sessionId]) {
+        patch.interruptedSessions = { ...s.interruptedSessions, [sessionId]: true };
+      }
+      // task322: record interrupt as the turn-end disposition so the InputBar
+      // can offer a "press Enter to continue" hint. Survives the imminent
+      // result-frame which only consumes `interruptedSessions`.
+      if (s.lastTurnEnd[sessionId] !== 'interrupted') {
+        patch.lastTurnEnd = { ...s.lastTurnEnd, [sessionId]: 'interrupted' };
+      }
+      return Object.keys(patch).length === 0 ? s : patch;
+    });
   },
 
   consumeInterrupted: (sessionId) => {
@@ -2129,6 +2159,17 @@ export const useStore = create<State & Actions>((set, get) => ({
       const next = { ...s.sessionInitFailures };
       delete next[sessionId];
       return { sessionInitFailures: next };
+    });
+  },
+  // task322: continue-after-interrupt — explicit clear used when the user
+  // sends any message so the hint dismisses without waiting for the next
+  // turn to start (which is when setRunning(true) would otherwise wipe it).
+  clearLastTurnEnd: (sessionId) => {
+    set((s) => {
+      if (!s.lastTurnEnd[sessionId]) return s;
+      const next = { ...s.lastTurnEnd };
+      delete next[sessionId];
+      return { lastTurnEnd: next };
     });
   },
 }));

--- a/tests/inputbar-continue-after-interrupt.test.tsx
+++ b/tests/inputbar-continue-after-interrupt.test.tsx
@@ -1,0 +1,174 @@
+// InputBar wiring for #322 continue-after-interrupt affordance.
+//
+// Asserts the contract between `lastTurnEnd` (in-store) and the InputBar's
+// post-stop hint:
+//   1. After markInterrupted, the hint row appears above the composer when
+//      the textarea is empty + agent is idle.
+//   2. Typing any char hides the hint (latches dismissed even if the user
+//      backspaces back to empty).
+//   3. Pressing Enter while the hint is visible + textarea empty sends the
+//      literal `continue` through the normal send path.
+//   4. A fresh interrupt re-arms the hint after a previous send.
+//
+// Stubs `window.ccsm.agentSend` to capture the payload the IPC bridge would
+// receive — same edge the real agent process sees.
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, act, cleanup } from '@testing-library/react';
+import { InputBar } from '../src/components/InputBar';
+import { useStore } from '../src/stores/store';
+
+const initial = useStore.getState();
+
+function freshStoreWithSession(
+  sessionId: string,
+  opts: { running?: boolean; started?: boolean } = {}
+) {
+  useStore.setState(
+    {
+      ...initial,
+      sessions: [
+        {
+          id: sessionId,
+          name: sessionId,
+          state: 'idle',
+          cwd: '~',
+          model: 'claude',
+          groupId: 'g-default',
+          agentType: 'claude-code',
+        },
+      ],
+      groups: [{ id: 'g-default', name: 'Sessions', collapsed: false, kind: 'normal' }],
+      activeId: sessionId,
+      messagesBySession: {},
+      startedSessions: opts.started ? { [sessionId]: true } : {},
+      runningSessions: opts.running ? { [sessionId]: true } : {},
+      messageQueues: {},
+      pendingDiffComments: {},
+      lastTurnEnd: {},
+      interruptedSessions: {},
+      focusInputNonce: 0,
+    },
+    true
+  );
+}
+
+function stubCCSM(overrides: Partial<Record<string, unknown>> = {}) {
+  const api = {
+    agentInterrupt: vi.fn().mockResolvedValue(undefined),
+    agentSend: vi.fn().mockResolvedValue(true),
+    agentSendContent: vi.fn().mockResolvedValue(true),
+    agentStart: vi.fn().mockResolvedValue({ ok: true }),
+    saveMessages: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+  (globalThis as unknown as { window: Window & { ccsm?: unknown } }).window.ccsm = api;
+  return api;
+}
+
+beforeEach(() => {
+  cleanup();
+  (globalThis as unknown as { window: Window & { ccsm?: unknown } }).window.ccsm = undefined;
+});
+
+const SID = 's-322';
+const HINT_TID = 'continue-after-interrupt-hint';
+
+describe('InputBar: continue-after-interrupt hint (#322)', () => {
+  it('does not show the hint when the last turn has not been interrupted', () => {
+    freshStoreWithSession(SID, { started: true });
+    stubCCSM();
+    render(<InputBar sessionId={SID} />);
+    expect(screen.queryByTestId(HINT_TID)).toBeNull();
+  });
+
+  it('shows the hint after markInterrupted while composer is empty + agent idle', () => {
+    freshStoreWithSession(SID, { started: true });
+    stubCCSM();
+    render(<InputBar sessionId={SID} />);
+    act(() => {
+      useStore.getState().markInterrupted(SID);
+    });
+    expect(screen.getByTestId(HINT_TID)).toBeInTheDocument();
+    // Sanity: the store recorded the disposition the hint reads from.
+    expect(useStore.getState().lastTurnEnd[SID]).toBe('interrupted');
+  });
+
+  it('hides the hint as soon as the user types a character', () => {
+    freshStoreWithSession(SID, { started: true });
+    stubCCSM();
+    render(<InputBar sessionId={SID} />);
+    act(() => {
+      useStore.getState().markInterrupted(SID);
+    });
+    expect(screen.getByTestId(HINT_TID)).toBeInTheDocument();
+    const ta = screen.getByRole('textbox');
+    fireEvent.change(ta, { target: { value: 'h' } });
+    expect(screen.queryByTestId(HINT_TID)).toBeNull();
+    // Backspacing to empty does NOT re-show — the typed-since-interrupt latch
+    // stays dismissed until a fresh interrupt arrives.
+    fireEvent.change(ta, { target: { value: '' } });
+    expect(screen.queryByTestId(HINT_TID)).toBeNull();
+  });
+
+  it('sends the literal `continue` when the hint is visible and Enter is pressed on empty composer', async () => {
+    freshStoreWithSession(SID, { started: true });
+    const api = stubCCSM();
+    render(<InputBar sessionId={SID} />);
+    act(() => {
+      useStore.getState().markInterrupted(SID);
+    });
+    const ta = screen.getByRole('textbox');
+    expect(screen.getByTestId(HINT_TID)).toBeInTheDocument();
+    await act(async () => {
+      fireEvent.keyDown(ta, { key: 'Enter' });
+      await Promise.resolve();
+    });
+    expect(api.agentSend).toHaveBeenCalledTimes(1);
+    expect(api.agentSend).toHaveBeenCalledWith(SID, 'continue');
+    // Hint dismisses synchronously on send.
+    expect(screen.queryByTestId(HINT_TID)).toBeNull();
+    expect(useStore.getState().lastTurnEnd[SID]).toBeUndefined();
+  });
+
+  it('does not show the hint when the agent is currently running', () => {
+    freshStoreWithSession(SID, { started: true, running: true });
+    stubCCSM();
+    render(<InputBar sessionId={SID} />);
+    // Even if some prior turn was marked interrupted, a running session is
+    // not an "interrupted, awaiting continue" state.
+    act(() => {
+      useStore.setState((s) => ({ lastTurnEnd: { ...s.lastTurnEnd, [SID]: 'interrupted' as const } }));
+    });
+    expect(screen.queryByTestId(HINT_TID)).toBeNull();
+  });
+
+  it('re-arms after a fresh interrupt following a normal send', async () => {
+    freshStoreWithSession(SID, { started: true });
+    const api = stubCCSM();
+    render(<InputBar sessionId={SID} />);
+    act(() => {
+      useStore.getState().markInterrupted(SID);
+    });
+    expect(screen.getByTestId(HINT_TID)).toBeInTheDocument();
+    // Type + send a real message — hint hides because typed-since-interrupt
+    // latched, and lastTurnEnd is cleared in send().
+    const ta = screen.getByRole('textbox');
+    fireEvent.change(ta, { target: { value: 'something else' } });
+    await act(async () => {
+      fireEvent.keyDown(ta, { key: 'Enter' });
+      await Promise.resolve();
+    });
+    expect(api.agentSend).toHaveBeenLastCalledWith(SID, 'something else');
+    expect(screen.queryByTestId(HINT_TID)).toBeNull();
+    // Simulate the agent finishing the turn (lifecycle would call
+    // setRunning(false) on the result frame), then a fresh interrupt on the
+    // next turn. The hint should re-arm with the typed-since-interrupt latch
+    // reset.
+    act(() => {
+      useStore.getState().setRunning(SID, false);
+      useStore.getState().markInterrupted(SID);
+    });
+    expect(screen.getByTestId(HINT_TID)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- After Stop, show a one-line ghost hint above the composer (`Press Enter to continue, or type a new message` / `按 Enter 继续，或输入新消息`).
- Empty composer + Enter while hint visible sends the literal `continue` through the normal send path.
- Hint dismisses on first keystroke (latched, doesn't re-show on backspace-to-empty), on send, or when a new turn begins.
- Store gets a per-session `lastTurnEnd: 'ok' | 'interrupted'` slice. Written by `markInterrupted`, cleared by `setRunning(true)` and the explicit `clearLastTurnEnd` action used in the send path. Not persisted (a stale post-reload hint would feel weird).

## Files
- `src/stores/store.ts` — new `lastTurnEnd` state, `clearLastTurnEnd` action; `markInterrupted` and `setRunning` updated.
- `src/components/InputBar.tsx` — hint row + Enter handler + typed-since-interrupt latch.
- `src/i18n/locales/{en,zh}.ts` — `chat.continueAfterInterruptHint` appended at end of namespace with anchor comment.
- `tests/inputbar-continue-after-interrupt.test.tsx` — 6 cases covering visibility gates, dismiss behavior, `continue` payload, and re-arming.

## Test plan
- [x] `npx vitest run tests/inputbar-continue-after-interrupt.test.tsx` — 6/6 pass.
- [x] `npx vitest run tests/inputbar.test.tsx tests/inputbar-diff-comments.test.tsx` — 12/12 pass (no regressions).
- [x] `npm run typecheck` — no new errors (2 pre-existing errors in SettingsDialog and Switch unchanged).
- [ ] Manual: start a turn, press Stop, observe hint; Enter sends `continue`; typing a char hides the hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)