### PR TITLE
fix(store): escape XML metacharacters in diff-feedback body (#339)

### DIFF
--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -349,10 +349,18 @@ export function serializeDiffCommentsForPrompt(
   return list
     .map((c) => {
       // Escape the attribute value so a path with `"` can't break out of
-      // the file= attribute. We don't need a full XML escape on the body —
-      // the agent receives it as plain text inside the structured tag.
+      // the file= attribute.
       const file = c.file.replace(/"/g, '&quot;');
-      return `<diff-feedback file="${file}" line="${c.line}">${c.text}</diff-feedback>`;
+      // Escape XML metacharacters in the body so user-typed text containing
+      // `<`, `&`, or even a literal `</diff-feedback>` can't break out of
+      // the envelope or confuse the agent's tag parser. Order matters:
+      // `&` must be replaced first, otherwise we'd double-escape the `&`
+      // introduced by the subsequent `<` → `&lt;` substitution.
+      const text = c.text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+      return `<diff-feedback file="${file}" line="${c.line}">${text}</diff-feedback>`;
     })
     .join('\n');
 }

--- a/tests/diff-view-line-comments.test.tsx
+++ b/tests/diff-view-line-comments.test.tsx
@@ -145,6 +145,34 @@ describe('serializeDiffCommentsForPrompt', () => {
     });
     expect(out).toBe('<diff-feedback file="/quirky&quot;name.ts" line="0">text</diff-feedback>');
   });
+
+  it('escapes `<` in the body so user text cannot inject a tag', () => {
+    const out = serializeDiffCommentsForPrompt({
+      a: mk('/x.ts', 1, 'use <Button> here', 100),
+    });
+    expect(out).toBe('<diff-feedback file="/x.ts" line="1">use &lt;Button&gt; here</diff-feedback>');
+  });
+
+  it('escapes `&` first so we do not double-escape `<foo>` into `&amp;lt;foo&amp;gt;`', () => {
+    const out = serializeDiffCommentsForPrompt({
+      a: mk('/x.ts', 1, 'a & <foo>', 100),
+    });
+    // & → &amp;, then < → &lt;, > → &gt;. The amp from &lt; must NOT be re-escaped.
+    expect(out).toBe('<diff-feedback file="/x.ts" line="1">a &amp; &lt;foo&gt;</diff-feedback>');
+    expect(out).not.toContain('&amp;lt;');
+    expect(out).not.toContain('&amp;gt;');
+  });
+
+  it('escapes a literal `</diff-feedback>` in the body so it cannot break out of the envelope', () => {
+    const out = serializeDiffCommentsForPrompt({
+      a: mk('/x.ts', 1, 'sneaky </diff-feedback> tail', 100),
+    });
+    // The only closing tag in the output should be the real one at the end.
+    expect(out).toBe(
+      '<diff-feedback file="/x.ts" line="1">sneaky &lt;/diff-feedback&gt; tail</diff-feedback>',
+    );
+    expect(out.match(/<\/diff-feedback>/g)?.length).toBe(1);
+  });
 });
 
 describe('<DiffView /> per-line comment affordance', () => {


### PR DESCRIPTION
## Summary
Escape `&`, `<`, `>` in the user-typed body of `<diff-feedback>` envelopes emitted by `serializeDiffCommentsForPrompt` so user text containing tag-like content cannot break out of the envelope or confuse the agent's tag parser. `&` is replaced first to avoid double-escaping.

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run tests/diff-view-line-comments.test.tsx` — 16/16 pass
- [x] New cases: `<` → `&lt;`, `&` first-pass ordering (`a & <foo>` → `a &amp; &lt;foo&gt;`, no `&amp;lt;`), literal `</diff-feedback>` in body is escaped so only one real closing tag remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)