### PR TITLE
feat(input): cwd chip discoverability + per-group default (#328)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -209,8 +209,10 @@ export default function App() {
   const [shortcutsOpen, setShortcutsOpen] = React.useState(false);
 
   // New sessions are created in-place — no modal. The store seeds `cwd`
-  // from `recentProjects[0]?.path ?? '~'`; users repick later via the
-  // StatusBar cwd chip in chat. See createSession() in stores/store.ts.
+  // from the per-group last-used cwd, falling through to
+  // `recentProjects[0]?.path ?? historyRecentCwds[0] ?? ''` (empty → chip
+  // renders the `(none)` placeholder). Users repick via the StatusBar cwd
+  // chip. See createSession() in stores/store.ts.
   const newSession = React.useCallback(() => {
     createSession(null);
   }, [createSession]);

--- a/src/components/CwdPopover.tsx
+++ b/src/components/CwdPopover.tsx
@@ -92,6 +92,30 @@ export function CwdPopover({ cwd, cwdMissing, loadRecent, onPick, onBrowse }: Pr
   const popRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
+  // task328: discoverability — pulse a faint accent ring on the FIRST hover
+  // after mount so brand-new users notice the chip is interactive. Sticky:
+  // once shown (or once the popover is opened by any path), we never replay
+  // for the lifetime of this mount. Keyed off mount, not session id, so
+  // switching between sessions in the same lifetime doesn't re-pulse.
+  const [hoverHintShown, setHoverHintShown] = useState(false);
+  const [hoverHintActive, setHoverHintActive] = useState(false);
+  const triggerOnHoverHint = useCallback(() => {
+    if (hoverHintShown) return;
+    setHoverHintShown(true);
+    setHoverHintActive(true);
+    // Pulse duration matches the menuIn ease (~600ms). After it expires we
+    // detach the class so subsequent renders are clean.
+    window.setTimeout(() => setHoverHintActive(false), 600);
+  }, [hoverHintShown]);
+  // Opening the popover (via click, keyboard, whatever) also retires the
+  // hint — the user has discovered the chip.
+  useEffect(() => {
+    if (open && !hoverHintShown) {
+      setHoverHintShown(true);
+      setHoverHintActive(false);
+    }
+  }, [open, hoverHintShown]);
+
   // Reset query each time we re-open so the Recent list shows in full;
   // the current cwd is surfaced as the input placeholder instead.
   useEffect(() => {
@@ -178,7 +202,12 @@ export function CwdPopover({ cwd, cwdMissing, loadRecent, onPick, onBrowse }: Pr
     }
   };
 
-  const triggerLabel = lastSegment(cwd);
+  // task328: when the active session has no cwd (empty string), surface a
+  // muted `(none)` placeholder instead of letting `lastSegment('')` fall back
+  // to the raw input — and skip auto-opening the popover (corner case: only
+  // happens when there's no CLI history AND no per-group prior cwd).
+  const hasCwd = !!cwd;
+  const triggerLabel = hasCwd ? lastSegment(cwd) : t('chat.cwdChipNoneLabel');
 
   return (
     <span className="relative inline-flex">
@@ -186,16 +215,25 @@ export function CwdPopover({ cwd, cwdMissing, loadRecent, onPick, onBrowse }: Pr
         ref={triggerRef}
         type="button"
         data-cwd-chip
-        title={cwdMissing ? t('cwdPopover.cwdMissingTooltip', { cwd }) : cwd}
+        data-hover-hint={hoverHintActive ? 'on' : undefined}
+        title={cwdMissing ? t('cwdPopover.cwdMissingTooltip', { cwd }) : (hasCwd ? cwd : undefined)}
         onClick={() => (open ? closePopover(POPOVER_ID) : openPopover(POPOVER_ID))}
+        onMouseEnter={triggerOnHoverHint}
+        onFocus={triggerOnHoverHint}
         aria-haspopup="dialog"
         aria-expanded={open}
         className={cn(
           'inline-flex items-center gap-1 h-5 px-1.5 rounded-sm',
           cwdMissing
             ? 'text-state-warning hover:text-state-warning-text hover:bg-state-warning-soft'
+            : !hasCwd
+            ? 'text-fg-tertiary italic hover:text-fg-secondary hover:bg-bg-hover'
             : 'text-fg-tertiary hover:text-fg-secondary hover:bg-bg-hover',
           'outline-none focus-ring',
+          // task328: first-hover discoverability pulse. Uses the existing
+          // --color-focus-ring token so we don't introduce a new color.
+          hoverHintActive &&
+            'shadow-[0_0_0_2px_var(--color-focus-ring)] transition-shadow duration-300',
           'transition-colors duration-120 ease-out'
         )}
       >

--- a/src/components/CwdPopover.tsx
+++ b/src/components/CwdPopover.tsx
@@ -103,10 +103,15 @@ export function CwdPopover({ cwd, cwdMissing, loadRecent, onPick, onBrowse }: Pr
     if (hoverHintShown) return;
     setHoverHintShown(true);
     setHoverHintActive(true);
-    // Pulse duration matches the menuIn ease (~600ms). After it expires we
-    // detach the class so subsequent renders are clean.
-    window.setTimeout(() => setHoverHintActive(false), 600);
   }, [hoverHintShown]);
+  // Pulse duration matches the menuIn ease (~600ms). Driven from an effect so
+  // the timer is cleared on unmount (or if the popover opens and we retire
+  // the hint early), avoiding a setState-after-unmount warning in tests.
+  useEffect(() => {
+    if (!hoverHintActive) return;
+    const id = window.setTimeout(() => setHoverHintActive(false), 600);
+    return () => window.clearTimeout(id);
+  }, [hoverHintActive]);
   // Opening the popover (via click, keyboard, whatever) also retires the
   // hint — the user has discovered the chip.
   useEffect(() => {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -502,9 +502,10 @@ function SessionRow({ session, active, selected, onSelect, normalGroups }: { ses
 }
 
 export type SidebarProps = {
-  /** Create a new session in-place. The store seeds `cwd` from
-   *  `recentProjects[0]?.path ?? '~'`; the user repicks via the StatusBar
-   *  cwd chip. No modal involved — see App.tsx::newSession. */
+  /** Create a new session in-place. The store seeds `cwd` from the
+   *  per-group last-used cwd (falling through to recentProjects, then ''
+   *  which renders the chip's `(none)` placeholder); the user repicks via
+   *  the StatusBar cwd chip. No modal involved — see App.tsx::newSession. */
   onCreateSession?: () => void;
   onOpenSettings?: () => void;
   onOpenPalette?: () => void;

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -133,7 +133,11 @@ const en = {
     runningPlaceholderBypass: 'Running… bypassing permission prompts (Esc to interrupt, Enter to queue)',
     runningPlaceholderPlan: 'Running… planning only, no edits (Esc to interrupt, Enter to queue)',
     // task322: continue-after-interrupt
-    continueAfterInterruptHint: 'Press Enter to continue, or type a new message'
+    continueAfterInterruptHint: 'Press Enter to continue, or type a new message',
+    // task328: shown in the cwd chip when the active session has no cwd set
+    // (no recent CLI history to default from, no per-group prior cwd). The
+    // popover does NOT auto-open in this state — the chip stays clickable.
+    cwdChipNoneLabel: '(none)'
   },
   chatStream: {
     emptyHint: 'Type a message and press'

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -128,7 +128,10 @@ const zh: EnCatalog = {
     runningPlaceholderBypass: '执行中… 跳过所有权限询问（Esc 中断，Enter 排队）',
     runningPlaceholderPlan: '执行中… 仅规划，不进行编辑（Esc 中断，Enter 排队）',
     // task322: continue-after-interrupt
-    continueAfterInterruptHint: '按 Enter 继续，或输入新消息'
+    continueAfterInterruptHint: '按 Enter 继续，或输入新消息',
+    // task328: 当前会话没有工作目录时（无最近 CLI 记录可作默认、所在分组无历史 cwd）
+    // 在 cwd 标签处显示。此时弹层不会自动展开，仍可点击。
+    cwdChipNoneLabel: '（无）'
   },
   chatStream: {
     emptyHint: '输入消息后按'

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -947,8 +947,18 @@ export const useStore = create<State & Actions>((set, get) => ({
     const targetGroupId = ensured.groupId;
     const baseGroups = ensured.groups;
     const id = nextId('s');
+    // task328: per-group cwd default — when the caller doesn't pin a cwd,
+    // prefer the most-recent session in the target group that has a usable
+    // cwd. `sessions` is ordered newest-first (createSession prepends), so
+    // the first match is the most recent. Falls through to the global
+    // recentProjects/historyRecentCwds defaults when the group is empty or
+    // none of its sessions have a cwd. `(none)` chip placeholder appears
+    // only when ALL of these resolve to empty.
+    const groupRecentCwd = sessions.find(
+      (x) => x.groupId === targetGroupId && !!x.cwd
+    )?.cwd;
     const defaultCwd =
-      recentProjects[0]?.path ?? historyRecentCwds[0] ?? '~';
+      groupRecentCwd ?? recentProjects[0]?.path ?? historyRecentCwds[0] ?? '';
     let initialModel = model;
     if (!initialModel) initialModel = historyTopModel ?? '';
     if (!initialModel) initialModel = connection?.model ?? '';

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -2308,8 +2308,9 @@ export async function hydrateStore(): Promise<void> {
 
   // Seed history-derived defaults from CLI transcripts. Fresh Electron
   // userData starts with empty `recentProjects` and no `model`; without this
-  // the new-session picker falls back to `~` and the first endpoint's first
-  // model regardless of what the user actually uses in the CLI.
+  // the new-session picker falls back to '' (chip `(none)` placeholder) and
+  // the first endpoint's first model regardless of what the user actually
+  // uses in the CLI.
   try {
     const api = window.ccsm;
     if (api?.recentCwds && api?.topModel) {

--- a/tests/cwd-popover.test.tsx
+++ b/tests/cwd-popover.test.tsx
@@ -171,4 +171,53 @@ describe('<CwdPopover />', () => {
     // The trigger gains the warning aria-label on its inner glyph.
     expect(screen.getByLabelText(/missing/i)).toBeInTheDocument();
   });
+
+  // task328: discoverability + (none) fallback ----------------------------
+
+  it('renders `(none)` placeholder label when cwd is empty (task328)', () => {
+    renderPopover({ cwd: '' });
+    // The trigger should now read the i18n placeholder, not the lastSegment
+    // of an empty string. We assert by querying the chip via its data attr
+    // since `getByRole('button', { name: /none/i })` is locale-coupled.
+    const chip = document.querySelector('[data-cwd-chip]') as HTMLElement;
+    expect(chip).toBeTruthy();
+    expect(chip.textContent).toMatch(/\(none\)/);
+    // Spec T4.b: do NOT auto-open the popover in the empty-cwd state.
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('does NOT auto-open popover on hover when cwd is empty (task328)', () => {
+    renderPopover({ cwd: '' });
+    const chip = document.querySelector('[data-cwd-chip]') as HTMLElement;
+    fireEvent.mouseEnter(chip);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('flashes a first-hover accent ring on the chip after mount, then retires (task328)', async () => {
+    vi.useFakeTimers();
+    try {
+      renderPopover();
+      const chip = document.querySelector('[data-cwd-chip]') as HTMLElement;
+      // Before any hover: no hint marker.
+      expect(chip.getAttribute('data-hover-hint')).toBeNull();
+      // First hover: hint flag goes on.
+      act(() => {
+        fireEvent.mouseEnter(chip);
+      });
+      expect(chip.getAttribute('data-hover-hint')).toBe('on');
+      // After ~600ms the pulse retires.
+      act(() => {
+        vi.advanceTimersByTime(700);
+      });
+      expect(chip.getAttribute('data-hover-hint')).toBeNull();
+      // Subsequent hovers do NOT replay the hint (sticky-once).
+      act(() => {
+        fireEvent.mouseLeave(chip);
+        fireEvent.mouseEnter(chip);
+      });
+      expect(chip.getAttribute('data-hover-hint')).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -67,9 +67,12 @@ describe('store: createSession', () => {
     expect(useStore.getState().sessions[0].cwd).toBe('C:/Users/me/projects/alpha');
   });
 
-  it('falls back to ~ when recentProjects is empty', () => {
+  it('falls back to empty cwd (chip renders `(none)` placeholder) when recentProjects + historyRecentCwds are both empty', () => {
+    // task328: previously fell back to '~'. Per T4.b, an unset cwd is now an
+    // explicit empty string so the cwd chip renders the `(none)` placeholder
+    // and the popover does NOT auto-open — the user picks deliberately.
     useStore.getState().createSession(null);
-    expect(useStore.getState().sessions[0].cwd).toBe('~');
+    expect(useStore.getState().sessions[0].cwd).toBe('');
   });
 
   it('explicit cwd argument wins over recentProjects default', () => {
@@ -1307,5 +1310,80 @@ describe('store: openPopover / closePopover (global popover mutex)', () => {
     const after = useStore.getState();
     expect(after).toBe(before);
     expect(after.openPopoverId).toBeNull();
+  });
+});
+
+// task328: per-group cwd default — when the user creates a new session in a
+// group, prefill the chip with the most-recent prior cwd from that group.
+// Empty group → fall through to the existing global default chain.
+describe('store: createSession — per-group cwd default (task328)', () => {
+  it('prefills new session cwd with the most-recent session cwd in the same group', () => {
+    const gid = useStore.getState().createGroup('Repo A');
+    useStore.getState().focusGroup(gid);
+    useStore.getState().createSession('/repo/a');
+    useStore.getState().focusGroup(gid);
+    useStore.getState().createSession('/repo/a/sub');
+    // Newest-first ordering: index 0 should be the latest, index 1 the
+    // earlier '/repo/a'. Now create a third session in the same group with
+    // no explicit cwd — it should pick up '/repo/a/sub'.
+    useStore.getState().focusGroup(gid);
+    useStore.getState().createSession(null);
+    const created = useStore.getState().sessions[0];
+    expect(created.groupId).toBe(gid);
+    expect(created.cwd).toBe('/repo/a/sub');
+  });
+
+  it('does not bleed cwd across groups', () => {
+    const gA = useStore.getState().createGroup('A');
+    const gB = useStore.getState().createGroup('B');
+    useStore.getState().focusGroup(gA);
+    useStore.getState().createSession('/repo/a');
+    useStore.getState().focusGroup(gB);
+    useStore.getState().createSession(null);
+    // Group B has no prior sessions and no recentProjects — should fall
+    // through to '' (chip renders `(none)` placeholder), NOT '/repo/a'.
+    const created = useStore.getState().sessions[0];
+    expect(created.groupId).toBe(gB);
+    expect(created.cwd).toBe('');
+  });
+
+  it('explicit cwd argument still wins over per-group default', () => {
+    const gid = useStore.getState().createGroup('A');
+    useStore.getState().focusGroup(gid);
+    useStore.getState().createSession('/repo/a');
+    useStore.getState().focusGroup(gid);
+    useStore.getState().createSession('/explicit/path');
+    expect(useStore.getState().sessions[0].cwd).toBe('/explicit/path');
+  });
+
+  it('per-group default loses to recentProjects only when group is empty', () => {
+    useStore.getState().pushRecentProject('/recent/proj');
+    const gid = useStore.getState().createGroup('Fresh');
+    useStore.getState().focusGroup(gid);
+    useStore.getState().createSession(null);
+    // No prior sessions in 'Fresh' → recentProjects[0] wins.
+    expect(useStore.getState().sessions[0].cwd).toBe('/recent/proj');
+    // Now create a second session in the same group; per-group default
+    // should now win over recentProjects.
+    useStore.getState().focusGroup(gid);
+    useStore.getState().createSession('/repo/inside-group');
+    useStore.getState().focusGroup(gid);
+    useStore.getState().createSession(null);
+    expect(useStore.getState().sessions[0].cwd).toBe('/repo/inside-group');
+  });
+
+  it('skips sessions with empty cwd when scanning the group', () => {
+    const gid = useStore.getState().createGroup('Mixed');
+    useStore.getState().focusGroup(gid);
+    useStore.getState().createSession('/repo/has-cwd');
+    useStore.getState().focusGroup(gid);
+    // Force an empty-cwd session into the group — simulates a previous
+    // `(none)`-state session.
+    useStore.getState().createSession('');
+    useStore.getState().focusGroup(gid);
+    useStore.getState().createSession(null);
+    // The most-recent (index 0) session has empty cwd; we should skip it
+    // and pick up '/repo/has-cwd'.
+    expect(useStore.getState().sessions[0].cwd).toBe('/repo/has-cwd');
   });
 });


### PR DESCRIPTION
T4 follow-ups from the cwd brainstorm (#326). Closes #328.

## Summary
- First-hover accent-ring pulse on the cwd chip (sticky once-per-mount) so brand-new users notice it's interactive.
- `(none)` placeholder when the active session has no cwd; popover does NOT auto-open per T4.b.
- Per-group cwd default: new session in a group prefills with the most-recent cwd from that group; falls through to `recentProjects` then `''` when empty.
- New i18n key `chat.cwdChipNoneLabel` (en + zh).

## Test plan
- [x] `npm run typecheck` clean
- [x] `tests/store.test.ts` — 5 new cases covering per-group default + cross-group isolation + recentProjects fallback + skip-empty-cwd + explicit-cwd wins
- [x] `tests/cwd-popover.test.tsx` — 3 new cases: `(none)` label render + no-auto-open + first-hover pulse retire+sticky
- [x] `tests/i18n-key-parity.test.ts` passes
- [ ] Manual: hover the chip on a fresh session, confirm faint pulse, doesn't replay on re-hover, retires on popover open
- [ ] Manual: pick a cwd in group A, create new session in same group, confirm chip prefills
- [ ] Manual: empty group + empty `recentProjects` → chip reads `(none)`, popover stays closed on hover, opens on click