### PR TITLE
feat(agent): SDK adapter layer (PR-A)

### DIFF
--- a/electron/agent-sdk/__tests__/runner-factory.test.ts
+++ b/electron/agent-sdk/__tests__/runner-factory.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock the legacy + SDK runners so the factory can be exercised without
+// touching real spawn / SDK code paths.
+vi.mock('../../agent/sessions', () => {
+  return {
+    SessionRunner: vi.fn().mockImplementation((id: string) => ({ __kind: 'legacy', id })),
+  };
+});
+vi.mock('../sessions', () => {
+  return {
+    SdkSessionRunner: vi.fn().mockImplementation((id: string) => ({ __kind: 'sdk', id })),
+  };
+});
+
+import { createRunner, isSdkRunnerEnabled } from '../runner-factory';
+
+describe('agent-sdk/runner-factory', () => {
+  const orig = process.env.CCSM_USE_SDK;
+
+  beforeEach(() => {
+    delete process.env.CCSM_USE_SDK;
+  });
+
+  afterEach(() => {
+    if (orig === undefined) delete process.env.CCSM_USE_SDK;
+    else process.env.CCSM_USE_SDK = orig;
+  });
+
+  describe('isSdkRunnerEnabled', () => {
+    it('returns false when env var is unset', () => {
+      delete process.env.CCSM_USE_SDK;
+      expect(isSdkRunnerEnabled()).toBe(false);
+    });
+
+    it('returns false for empty string', () => {
+      process.env.CCSM_USE_SDK = '';
+      expect(isSdkRunnerEnabled()).toBe(false);
+    });
+
+    it.each(['1', 'true', 'TRUE', 'yes', '  yes  '])('returns true for %s', (v) => {
+      process.env.CCSM_USE_SDK = v;
+      expect(isSdkRunnerEnabled()).toBe(true);
+    });
+
+    it.each(['0', 'false', 'no', 'random'])('returns false for %s', (v) => {
+      process.env.CCSM_USE_SDK = v;
+      expect(isSdkRunnerEnabled()).toBe(false);
+    });
+  });
+
+  describe('createRunner', () => {
+    const noop = () => {};
+
+    it('returns the legacy runner by default', () => {
+      const r = createRunner('s1', noop, noop, noop, noop) as unknown as { __kind: string };
+      expect(r.__kind).toBe('legacy');
+    });
+
+    it('returns the SDK runner when flag is on', () => {
+      process.env.CCSM_USE_SDK = '1';
+      const r = createRunner('s2', noop, noop, noop, noop) as unknown as { __kind: string };
+      expect(r.__kind).toBe('sdk');
+    });
+
+    it('falls back to the legacy runner when flag becomes off again', () => {
+      process.env.CCSM_USE_SDK = '1';
+      const a = createRunner('a', noop, noop, noop, noop) as unknown as { __kind: string };
+      expect(a.__kind).toBe('sdk');
+
+      process.env.CCSM_USE_SDK = '0';
+      const b = createRunner('b', noop, noop, noop, noop) as unknown as { __kind: string };
+      expect(b.__kind).toBe('legacy');
+    });
+  });
+});

--- a/electron/agent-sdk/__tests__/sdk-message-translator.test.ts
+++ b/electron/agent-sdk/__tests__/sdk-message-translator.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from 'vitest';
+import { translateSdkMessage, type SdkMessageLike } from '../sdk-message-translator';
+
+describe('agent-sdk/sdk-message-translator', () => {
+  it('passes through system init', () => {
+    const msg: SdkMessageLike = {
+      type: 'system',
+      subtype: 'init',
+      session_id: 'abc-123',
+      cwd: '/x',
+      tools: [],
+      mcp_servers: [],
+      model: 'claude-x',
+      permissionMode: 'default',
+      apiKeySource: 'env',
+    };
+    const out = translateSdkMessage(msg);
+    expect(out).toBeTruthy();
+    expect((out as { type?: string }).type).toBe('system');
+    expect((out as { subtype?: string }).subtype).toBe('init');
+    expect((out as { session_id?: string }).session_id).toBe('abc-123');
+  });
+
+  it('passes through compact_boundary', () => {
+    const msg: SdkMessageLike = { type: 'system', subtype: 'compact_boundary', session_id: 's' };
+    expect(translateSdkMessage(msg)).toBeTruthy();
+  });
+
+  it('passes through api_retry', () => {
+    const msg: SdkMessageLike = { type: 'system', subtype: 'api_retry', session_id: 's' };
+    expect(translateSdkMessage(msg)).toBeTruthy();
+  });
+
+  it('passes through assistant', () => {
+    const msg: SdkMessageLike = {
+      type: 'assistant',
+      session_id: 's',
+      message: { role: 'assistant', content: [] },
+    };
+    expect((translateSdkMessage(msg) as { type?: string }).type).toBe('assistant');
+  });
+
+  it('passes through user', () => {
+    const msg: SdkMessageLike = {
+      type: 'user',
+      session_id: 's',
+      message: { role: 'user', content: 'hi' },
+    };
+    expect((translateSdkMessage(msg) as { type?: string }).type).toBe('user');
+  });
+
+  it('passes through result', () => {
+    const msg: SdkMessageLike = {
+      type: 'result',
+      subtype: 'success',
+      session_id: 's',
+      duration_ms: 1,
+    };
+    expect((translateSdkMessage(msg) as { type?: string }).type).toBe('result');
+  });
+
+  it('passes through stream_event partial frames', () => {
+    const msg: SdkMessageLike = {
+      type: 'stream_event',
+      session_id: 's',
+      event: { type: 'content_block_delta' },
+    };
+    expect(translateSdkMessage(msg)).not.toBeNull();
+  });
+
+  it('drops unknown system subtypes silently', () => {
+    const msg: SdkMessageLike = { type: 'system', subtype: 'status', session_id: 's' };
+    expect(translateSdkMessage(msg)).toBeNull();
+  });
+
+  it.each([
+    'status',
+    'hook_started',
+    'hook_progress',
+    'hook_response',
+    'tool_progress',
+    'tool_use_summary',
+    'auth_status',
+    'memory_recall',
+    'rate_limit',
+    'elicitation_complete',
+    'prompt_suggestion',
+    'plugin_install',
+    'mirror_error',
+    'files_persisted',
+    'session_state_changed',
+    'notification',
+    'local_command_output',
+  ])('drops SDK-only message %s', (type) => {
+    expect(translateSdkMessage({ type })).toBeNull();
+  });
+
+  it('drops unknown types and warns', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(translateSdkMessage({ type: 'totally_made_up' })).toBeNull();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/electron/agent-sdk/__tests__/sessions.test.ts
+++ b/electron/agent-sdk/__tests__/sessions.test.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// The runner pulls binary-resolver to find a system claude binary. Mock so
+// start() never touches the filesystem.
+vi.mock('../../agent/binary-resolver', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../agent/binary-resolver')>();
+  return {
+    ...actual,
+    resolveClaudeInvocation: vi.fn().mockResolvedValue({ kind: 'binary', path: '/fake/claude' }),
+  };
+});
+
+import { SdkSessionRunner, __setSdkModuleForTests } from '../sessions';
+import type { StartOptions } from '../../agent/sessions';
+
+/**
+ * Build a fake SDK whose query() returns an async-iterable that we drive
+ * manually plus a stub for interrupt / setPermissionMode / setModel / close.
+ */
+function makeFakeSdk() {
+  let lastOptions: unknown = null;
+  let queueResolve: ((v: IteratorResult<unknown>) => void) | null = null;
+  const buffer: unknown[] = [];
+  let closed = false;
+
+  const interrupt = vi.fn().mockResolvedValue(undefined);
+  const setPermissionMode = vi.fn().mockResolvedValue(undefined);
+  const setModel = vi.fn().mockResolvedValue(undefined);
+  const close = vi.fn();
+
+  const query = (args: unknown) => {
+    lastOptions = args;
+    const iter = {
+      [Symbol.asyncIterator]() {
+        return {
+          next(): Promise<IteratorResult<unknown>> {
+            if (buffer.length > 0) return Promise.resolve({ value: buffer.shift(), done: false });
+            if (closed) return Promise.resolve({ value: undefined, done: true });
+            return new Promise((resolve) => {
+              queueResolve = resolve;
+            });
+          },
+        };
+      },
+      interrupt,
+      setPermissionMode,
+      setModel,
+      close,
+    };
+    return iter;
+  };
+
+  return {
+    sdk: { query },
+    push(msg: unknown) {
+      if (queueResolve) {
+        const r = queueResolve;
+        queueResolve = null;
+        r({ value: msg, done: false });
+      } else {
+        buffer.push(msg);
+      }
+    },
+    finish() {
+      closed = true;
+      if (queueResolve) {
+        const r = queueResolve;
+        queueResolve = null;
+        r({ value: undefined, done: true });
+      }
+    },
+    getOptions: () => lastOptions as { options?: Record<string, unknown> } | null,
+    interrupt,
+    setPermissionMode,
+    setModel,
+    close,
+  };
+}
+
+const noop = () => {};
+const baseStart: StartOptions = { cwd: '/tmp/fake' };
+
+describe('agent-sdk/SdkSessionRunner', () => {
+  let fake: ReturnType<typeof makeFakeSdk>;
+
+  beforeEach(() => {
+    fake = makeFakeSdk();
+    __setSdkModuleForTests(
+      fake.sdk as unknown as typeof import('@anthropic-ai/claude-agent-sdk'),
+    );
+  });
+
+  afterEach(() => {
+    __setSdkModuleForTests(null);
+  });
+
+  it('start() forwards cwd, model, resume, binary path, and permission mode', async () => {
+    const runner = new SdkSessionRunner('s1', noop, noop, noop, noop);
+    await runner.start({
+      cwd: '/work',
+      model: 'claude-3-5',
+      resumeSessionId: 'sess-prev',
+      binaryPath: '/usr/local/bin/claude',
+      permissionMode: 'acceptEdits',
+    });
+
+    const opts = fake.getOptions()?.options ?? {};
+    expect(opts.cwd).toBe('/work');
+    expect(opts.model).toBe('claude-3-5');
+    expect(opts.resume).toBe('sess-prev');
+    expect(opts.pathToClaudeCodeExecutable).toBe('/usr/local/bin/claude');
+    expect(opts.permissionMode).toBe('acceptEdits');
+    expect(opts.includePartialMessages).toBe(true);
+    runner.close();
+  });
+
+  it('coerces legacy permission mode aliases into SDK modes', async () => {
+    const runner = new SdkSessionRunner('s2', noop, noop, noop, noop);
+    await runner.start({ ...baseStart, permissionMode: 'yolo' });
+    const opts = fake.getOptions()?.options ?? {};
+    expect(opts.permissionMode).toBe('bypassPermissions');
+    expect(opts.allowDangerouslySkipPermissions).toBe(true);
+    runner.close();
+  });
+
+  it('emits translated SDK messages to onEvent and captures cliSessionId from init', async () => {
+    const events: unknown[] = [];
+    const runner = new SdkSessionRunner('s3', (e) => events.push(e), noop, noop, noop);
+    await runner.start(baseStart);
+
+    fake.push({
+      type: 'system',
+      subtype: 'init',
+      session_id: 'cli-xyz',
+      cwd: '/work',
+      tools: [],
+      mcp_servers: [],
+      model: 'claude',
+      permissionMode: 'default',
+      apiKeySource: 'env',
+    });
+    fake.push({
+      type: 'assistant',
+      session_id: 'cli-xyz',
+      message: { role: 'assistant', content: [] },
+    });
+    fake.push({ type: 'status' }); // dropped
+    // wait one microtask cycle so the consumer drains
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(events).toHaveLength(2);
+    expect((events[0] as { type?: string }).type).toBe('system');
+    expect((events[1] as { type?: string }).type).toBe('assistant');
+    runner.close();
+  });
+
+  it('onExit fires on iterator completion with no error', async () => {
+    const exits: Array<{ error?: string }> = [];
+    const runner = new SdkSessionRunner('s4', noop, (info) => exits.push(info), noop, noop);
+    await runner.start(baseStart);
+    fake.finish();
+    await new Promise((r) => setTimeout(r, 10));
+    expect(exits).toHaveLength(1);
+    expect(exits[0].error).toBeUndefined();
+  });
+
+  it('interrupt() delegates to Query.interrupt()', async () => {
+    const runner = new SdkSessionRunner('s5', noop, noop, noop, noop);
+    await runner.start(baseStart);
+    await runner.interrupt();
+    expect(fake.interrupt).toHaveBeenCalledTimes(1);
+    runner.close();
+  });
+
+  it('setPermissionMode() delegates to Query.setPermissionMode()', async () => {
+    const runner = new SdkSessionRunner('s6', noop, noop, noop, noop);
+    await runner.start(baseStart);
+    await runner.setPermissionMode('plan');
+    expect(fake.setPermissionMode).toHaveBeenCalledWith('plan');
+    runner.close();
+  });
+
+  it('setModel() delegates only if model is provided', async () => {
+    const runner = new SdkSessionRunner('s7', noop, noop, noop, noop);
+    await runner.start(baseStart);
+    await runner.setModel(undefined);
+    expect(fake.setModel).not.toHaveBeenCalled();
+    await runner.setModel('claude-x');
+    expect(fake.setModel).toHaveBeenCalledWith('claude-x');
+    runner.close();
+  });
+
+  it('cancelToolUse() emits diagnostic and falls back to interrupt', async () => {
+    const diags: Array<{ code: string }> = [];
+    const runner = new SdkSessionRunner(
+      's8',
+      noop,
+      noop,
+      noop,
+      (d) => diags.push(d),
+    );
+    await runner.start(baseStart);
+    await runner.cancelToolUse('toolUse-42');
+    expect(diags.some((d) => d.code === 'tool_cancel_fallback')).toBe(true);
+    expect(fake.interrupt).toHaveBeenCalled();
+    runner.close();
+  });
+
+  it('canUseTool routes to onPermissionRequest and resolvePermission settles allow', async () => {
+    let capturedReq: { requestId: string; toolName: string; input: unknown } | null = null;
+    const runner = new SdkSessionRunner(
+      's9',
+      noop,
+      noop,
+      (req) => {
+        capturedReq = req;
+      },
+      noop,
+    );
+    await runner.start({ ...baseStart, permissionMode: 'default' });
+
+    // Pluck the canUseTool callback off the options the SDK received.
+    const canUseTool = (fake.getOptions()?.options as { canUseTool?: (toolName: string, input: unknown, ctx: { signal: AbortSignal; toolUseID: string }) => Promise<unknown> }).canUseTool!;
+    const ac = new AbortController();
+    const decisionP = canUseTool('Bash', { command: 'ls' }, { signal: ac.signal, toolUseID: 't1' });
+
+    // Wait for the request to land in the host.
+    await new Promise((r) => setTimeout(r, 5));
+    expect(capturedReq).not.toBeNull();
+
+    runner.resolvePermission(capturedReq!.requestId, 'allow');
+    const decision = (await decisionP) as { behavior: string };
+    expect(decision.behavior).toBe('allow');
+    runner.close();
+  });
+
+  it('canUseTool deny path produces a behaviour:deny decision', async () => {
+    let capturedReq: { requestId: string } | null = null;
+    const runner = new SdkSessionRunner(
+      's10',
+      noop,
+      noop,
+      (req) => {
+        capturedReq = req;
+      },
+      noop,
+    );
+    await runner.start({ ...baseStart, permissionMode: 'default' });
+
+    const canUseTool = (fake.getOptions()?.options as { canUseTool?: (toolName: string, input: unknown, ctx: { signal: AbortSignal; toolUseID: string }) => Promise<unknown> }).canUseTool!;
+    const ac = new AbortController();
+    const decisionP = canUseTool('Bash', {}, { signal: ac.signal, toolUseID: 't2' });
+    await new Promise((r) => setTimeout(r, 5));
+
+    runner.resolvePermission(capturedReq!.requestId, 'deny');
+    const decision = (await decisionP) as { behavior: string };
+    expect(decision.behavior).toBe('deny');
+    runner.close();
+  });
+
+  it('canUseTool short-circuits to allow in bypassPermissions mode', async () => {
+    const onPerm = vi.fn();
+    const runner = new SdkSessionRunner('s11', noop, noop, onPerm, noop);
+    await runner.start({ ...baseStart, permissionMode: 'bypassPermissions' });
+
+    const canUseTool = (fake.getOptions()?.options as { canUseTool?: (toolName: string, input: unknown, ctx: { signal: AbortSignal; toolUseID: string }) => Promise<unknown> }).canUseTool!;
+    const ac = new AbortController();
+    const decision = (await canUseTool('Bash', {}, { signal: ac.signal, toolUseID: 't3' })) as {
+      behavior: string;
+    };
+    expect(decision.behavior).toBe('allow');
+    expect(onPerm).not.toHaveBeenCalled();
+    runner.close();
+  });
+
+  it('canUseTool short-circuits AskUserQuestion (passthrough tool)', async () => {
+    const onPerm = vi.fn();
+    const runner = new SdkSessionRunner('s12', noop, noop, onPerm, noop);
+    await runner.start({ ...baseStart, permissionMode: 'default' });
+
+    const canUseTool = (fake.getOptions()?.options as { canUseTool?: (toolName: string, input: unknown, ctx: { signal: AbortSignal; toolUseID: string }) => Promise<unknown> }).canUseTool!;
+    const ac = new AbortController();
+    const decision = (await canUseTool(
+      'AskUserQuestion',
+      {},
+      { signal: ac.signal, toolUseID: 't4' },
+    )) as { behavior: string };
+    expect(decision.behavior).toBe('allow');
+    expect(onPerm).not.toHaveBeenCalled();
+    runner.close();
+  });
+
+  it('close() resolves outstanding permission requests as denied', async () => {
+    let capturedReq: { requestId: string } | null = null;
+    const runner = new SdkSessionRunner(
+      's13',
+      noop,
+      noop,
+      (req) => {
+        capturedReq = req;
+      },
+      noop,
+    );
+    await runner.start({ ...baseStart, permissionMode: 'default' });
+    const canUseTool = (fake.getOptions()?.options as { canUseTool?: (toolName: string, input: unknown, ctx: { signal: AbortSignal; toolUseID: string }) => Promise<unknown> }).canUseTool!;
+    const ac = new AbortController();
+    const p = canUseTool('Bash', {}, { signal: ac.signal, toolUseID: 't5' });
+    await new Promise((r) => setTimeout(r, 5));
+    expect(capturedReq).not.toBeNull();
+
+    runner.close();
+    const decision = (await p) as { behavior: string };
+    expect(decision.behavior).toBe('deny');
+  });
+
+  it('getPid() returns undefined (SDK does not expose child pid)', () => {
+    const runner = new SdkSessionRunner('s14', noop, noop, noop, noop);
+    expect(runner.getPid()).toBeUndefined();
+  });
+});

--- a/electron/agent-sdk/runner-factory.ts
+++ b/electron/agent-sdk/runner-factory.ts
@@ -1,0 +1,101 @@
+/**
+ * Feature-flag dispatch between the legacy hand-written runner
+ * (electron/agent/sessions.ts SessionRunner) and the SDK-backed runner
+ * (electron/agent-sdk/sessions.ts SdkSessionRunner).
+ *
+ * Why a single factory function (not if/else inside manager.ts):
+ *   - One place reads the env var, so the flag can't be partially applied
+ *     across IPC handlers.
+ *   - Read at runtime (not module load) so tests can flip the env var per
+ *     test case via vi.stubEnv without re-importing the manager.
+ *   - The `Runner` type below is the contract the manager actually uses;
+ *     either implementation must satisfy it. If a method drifts on one side
+ *     a TS error fires here, not at the call site.
+ *
+ * Default behaviour: legacy path. The new path activates only when
+ * `CCSM_USE_SDK` is set to a truthy value (`1` / `true` / `yes`). Anything
+ * else — unset, empty, `0`, `false`, `no` — keeps the legacy runner.
+ */
+
+import {
+  SessionRunner,
+  type StartOptions,
+  type PermissionMode,
+  type AgentMessage,
+  type EventHandler,
+  type ExitHandler,
+  type PermissionRequestHandler,
+  type DiagnosticHandler,
+} from '../agent/sessions';
+import { SdkSessionRunner } from './sessions';
+
+/**
+ * Duck-typed runner contract used by SessionsManager. Both
+ * `SessionRunner` (legacy) and `SdkSessionRunner` (SDK) satisfy this
+ * structurally — the type assertion in createRunner enforces that at
+ * compile time.
+ */
+export interface Runner {
+  readonly id: string;
+  getPid(): number | undefined;
+  start(opts: StartOptions): Promise<void>;
+  send(text: string): void;
+  sendContent(content: readonly unknown[]): void;
+  interrupt(): Promise<void>;
+  cancelToolUse(toolUseId: string): Promise<void>;
+  setPermissionMode(mode: PermissionMode): Promise<void>;
+  setModel(model?: string): Promise<void>;
+  resolvePermission(requestId: string, decision: 'allow' | 'deny'): boolean;
+  resolvePermissionPartial(requestId: string, acceptedHunks: number[]): boolean;
+  close(): void;
+}
+
+/**
+ * Re-export the types the manager already imports so call sites can stay
+ * agnostic to which runner is in play.
+ */
+export type {
+  StartOptions,
+  PermissionMode,
+  AgentMessage,
+  EventHandler,
+  ExitHandler,
+  PermissionRequestHandler,
+  DiagnosticHandler,
+};
+
+/**
+ * Returns true when the SDK-backed runner should be used. Re-evaluated on
+ * each call so tests can flip the env between sessions.
+ */
+export function isSdkRunnerEnabled(): boolean {
+  const v = process.env.CCSM_USE_SDK;
+  if (!v) return false;
+  const norm = v.trim().toLowerCase();
+  return norm === '1' || norm === 'true' || norm === 'yes';
+}
+
+export function createRunner(
+  sessionId: string,
+  onEvent: EventHandler,
+  onExit: ExitHandler,
+  onPermissionRequest: PermissionRequestHandler,
+  onDiagnostic: DiagnosticHandler = () => {},
+): Runner {
+  if (isSdkRunnerEnabled()) {
+    return new SdkSessionRunner(
+      sessionId,
+      onEvent,
+      onExit,
+      onPermissionRequest,
+      onDiagnostic,
+    );
+  }
+  return new SessionRunner(
+    sessionId,
+    onEvent,
+    onExit,
+    onPermissionRequest,
+    onDiagnostic,
+  );
+}

--- a/electron/agent-sdk/sdk-message-translator.ts
+++ b/electron/agent-sdk/sdk-message-translator.ts
@@ -1,0 +1,116 @@
+/**
+ * Translate `SDKMessage` (the @anthropic-ai/claude-agent-sdk surface) into
+ * `ClaudeStreamEvent` (the wire-shape ccsm's renderer / stream-to-blocks
+ * pipeline already consumes).
+ *
+ * Why translate at all: ccsm's existing render path was built against the
+ * spawn-claude wire protocol (M1 §3, see electron/agent/stream-json-types.ts).
+ * The SDK's `SDKMessage` is the SAME protocol re-typed by Anthropic's SDK,
+ * with a few field renames and added housekeeping events (status, hook
+ * lifecycle, tool progress, etc.).
+ *
+ * Strategy:
+ *   - For the four "big bucket" frames (`system`, `assistant`, `user`,
+ *     `result`) the shape is structurally identical — we cast through unknown
+ *     so TypeScript doesn't reject incidental field-presence differences
+ *     (e.g. SDK includes `claude_code_version` on init that ccsm's schema
+ *     marks as passthrough).
+ *   - SDK-specific bookkeeping messages (status, hook_started, hook_progress,
+ *     hook_response, partial_assistant, tool_progress, task_*, etc.) have no
+ *     ccsm-side consumer today and we filter them out (return null).
+ *   - Compact_boundary maps directly onto ccsm's existing system event with
+ *     subtype `'compact_boundary'`.
+ *
+ * Anything we can't map gets dropped with a console.warn — better than
+ * pushing a malformed frame the renderer might crash on. We deliberately
+ * never throw: a single unknown SDK message type must not kill the session.
+ */
+import type {
+  ClaudeStreamEvent,
+  SystemEvent,
+  AssistantEvent,
+  UserEvent,
+  ResultEvent,
+} from '../agent/stream-json-types';
+
+// We intentionally use a structural type for SDKMessage rather than importing
+// the SDK's types at module-load: the SDK is ESM and ccsm is CJS, so importing
+// types eagerly would tangle the build. Dynamic import in the runner gives us
+// the runtime; here we only need the shape.
+export type SdkMessageLike = {
+  type: string;
+  subtype?: string;
+  // Anything else is preserved by passthrough.
+  [k: string]: unknown;
+};
+
+/**
+ * Translate one SDK message into the ccsm ClaudeStreamEvent shape, or return
+ * `null` to drop the message (no renderer consumer today).
+ */
+export function translateSdkMessage(msg: SdkMessageLike): ClaudeStreamEvent | null {
+  switch (msg.type) {
+    case 'system':
+      // All system subtypes ccsm already understands (init, compact_boundary,
+      // api_retry) pass straight through. New SDK system subtypes (status,
+      // task_notification, hook_started, etc.) have no ccsm consumer — drop
+      // them quietly so they don't show up as `unknown` warnings in dogfood.
+      if (
+        msg.subtype === 'init' ||
+        msg.subtype === 'compact_boundary' ||
+        msg.subtype === 'api_retry'
+      ) {
+        return msg as unknown as SystemEvent;
+      }
+      return null;
+
+    case 'assistant':
+      return msg as unknown as AssistantEvent;
+
+    case 'user':
+      // SDK emits both `user` (live) and `user_replay` via the same `type:
+      // 'user'` discriminator (replay carries `isReplay: true`). ccsm's
+      // UserEvent passthrough shape accepts the extra fields; renderer
+      // currently treats replays the same as live user messages.
+      return msg as unknown as UserEvent;
+
+    case 'result':
+      return msg as unknown as ResultEvent;
+
+    // SDK-only messages with no ccsm renderer wiring today. Listed
+    // exhaustively (rather than a default-drop) so a future SDK addition
+    // shows up as an `unknown` warning in dev — that's how we'll discover
+    // we need to add a translation.
+    case 'stream_event':
+      // Partial assistant streaming. ccsm's PartialAssistantStreamer in the
+      // renderer consumes `stream_event` frames; pass through.
+      return msg as unknown as ClaudeStreamEvent;
+    case 'agent_metadata':
+      return msg as unknown as ClaudeStreamEvent;
+
+    case 'status':
+    case 'hook_started':
+    case 'hook_progress':
+    case 'hook_response':
+    case 'tool_progress':
+    case 'tool_use_summary':
+    case 'auth_status':
+    case 'memory_recall':
+    case 'rate_limit':
+    case 'elicitation_complete':
+    case 'prompt_suggestion':
+    case 'plugin_install':
+    case 'mirror_error':
+    case 'files_persisted':
+    case 'session_state_changed':
+    case 'notification':
+    case 'local_command_output':
+      return null;
+
+    default:
+      // Unknown SDK message type — log so we notice in dev, but don't break
+      // the session. Renderer would reject it as malformed anyway.
+      console.warn('[agent-sdk] dropping unknown SDK message type', msg.type);
+      return null;
+  }
+}

--- a/electron/agent-sdk/sessions.ts
+++ b/electron/agent-sdk/sessions.ts
@@ -1,0 +1,579 @@
+/**
+ * SDK-backed session runner. Implements the same surface as
+ * `electron/agent/sessions.ts` SessionRunner so `manager.ts` can swap
+ * between them via the `CCSM_USE_SDK` feature flag without changing any
+ * other code.
+ *
+ * Why a separate runner (not a refactor of the existing sessions.ts):
+ *   - Lets us A/B-gate the SDK migration on real users via env var. If the
+ *     SDK has any behaviour drift (message timing, error semantics, hook
+ *     payload shape, interrupt latency) the user can `unset CCSM_USE_SDK`
+ *     and immediately fall back to the proven hand-written wrapper.
+ *   - Forces us to make the contract between manager.ts and a runner
+ *     explicit (it's the duck-typed surface used in createRunner below).
+ *     The old runner's interface previously only existed implicitly inside
+ *     manager.ts.
+ *   - Once the SDK path is validated in dogfood, the cutover is a one-line
+ *     manager.ts change (drop the flag) plus deletion of the legacy code —
+ *     not a half-merged refactor.
+ *
+ * What this runner deliberately does NOT do (kept consistent with the legacy
+ * runner so this PR is behaviour-equivalent under the flag):
+ *   - Per-tool cancel: still falls back to a turn-level interrupt because the
+ *     SDK control surface has no scoped cancel today (mirrors the rationale
+ *     in sessions.ts cancelToolUse).
+ *   - Explicit sessionId management (UUID v4 via SDK's `sessionId` option):
+ *     deferred to a follow-up task. PR-A keeps the implicit cliSessionId
+ *     captured from the first system frame, matching the legacy flow.
+ *   - Bundled binary: PR-A still resolves the user's system claude binary
+ *     via binary-resolver and passes it through `pathToClaudeCodeExecutable`.
+ *     PR-B will swap in the SDK-bundled binary.
+ */
+
+import os from 'node:os';
+import path from 'node:path';
+import { resolveClaudeInvocation, ClaudeNotFoundError } from '../agent/binary-resolver';
+import type {
+  StartOptions,
+  PermissionMode,
+  EventHandler,
+  ExitHandler,
+  PermissionRequestHandler,
+  DiagnosticHandler,
+  AgentMessage,
+} from '../agent/sessions';
+import { translateSdkMessage, type SdkMessageLike } from './sdk-message-translator';
+
+export type { StartOptions, PermissionMode, EventHandler, ExitHandler };
+
+// Re-export so the manager-side import in createRunner type-checks against the
+// same shape the legacy runner uses.
+export type { AgentMessage };
+
+/**
+ * `CanUseToolDecision` mirrors the shape from `electron/agent/control-rpc.ts`
+ * — see partial-write integration in resolvePermissionPartial below. We
+ * redefine it locally rather than importing to keep the SDK runner free of
+ * any control-rpc dependency (control-rpc is the legacy code path).
+ */
+type CanUseToolDecision =
+  | { allow: true; updatedInput?: unknown }
+  | { allow: false; deny_reason?: string };
+
+import { filterToolInputByAcceptedHunks } from '../agent/partial-write';
+
+/**
+ * Resolve `~`-prefixed paths the way the legacy runner does. Kept identical
+ * (not factored into a shared util) because we don't want PR-A touching any
+ * file outside electron/agent-sdk/.
+ */
+function resolveCwd(cwd: string): string {
+  if (cwd === '~') return os.homedir();
+  if (cwd.startsWith('~/') || cwd.startsWith('~\\')) {
+    return path.join(os.homedir(), cwd.slice(2));
+  }
+  return cwd;
+}
+
+function resolveClaudeConfigDir(explicit: string | undefined): string {
+  if (explicit && explicit.trim().length > 0) return explicit;
+  const env = process.env.CCSM_CLAUDE_CONFIG_DIR;
+  if (env && env.trim().length > 0) return env;
+  return path.join(os.homedir(), '.claude');
+}
+
+/**
+ * Coerce ccsm's superset of permission modes (which still carries legacy UI
+ * aliases like 'yolo' / 'ask') into the strict 4-value SDK mode. Throws on
+ * unknown values — the manager.ts catch translates that into `unknown_mode`
+ * for the renderer.
+ */
+function toSdkPermissionMode(
+  mode: PermissionMode | undefined,
+): 'default' | 'acceptEdits' | 'plan' | 'bypassPermissions' | undefined {
+  if (!mode) return undefined;
+  switch (mode) {
+    case 'default':
+    case 'acceptEdits':
+    case 'plan':
+    case 'bypassPermissions':
+      return mode;
+    case 'ask':
+    case 'standard':
+    case 'dontAsk':
+      return 'default';
+    case 'auto':
+      return 'acceptEdits';
+    case 'yolo':
+      return 'bypassPermissions';
+    default:
+      throw new Error(`Unknown permission mode: ${String(mode)}`);
+  }
+}
+
+/**
+ * Build the env passed to the SDK-spawned subprocess. Mirrors
+ * `electron/agent/claude-spawner.ts` buildSpawnEnv exactly: deny-by-default
+ * baseline, layer required values (CLAUDE_CONFIG_DIR + CLAUDE_CODE_ENTRYPOINT),
+ * apply overrides last, then strip Electron poisons.
+ *
+ * NOTE: we duplicate the SAFE_ENV logic (instead of importing from
+ * claude-spawner) because the file-boundary rule for PR-A says we can't
+ * reach into electron/agent/ for anything beyond binary-resolver +
+ * partial-write. Once PR-B lands and the legacy path is removed, this can
+ * collapse back into a shared module.
+ */
+function buildSdkEnv(opts: {
+  configDir: string;
+  envOverrides?: Record<string, string>;
+}): Record<string, string> {
+  // Allowlist mirrors claude-spawner.ts SAFE_ENV. Kept narrow so smuggled
+  // shell vars from the Electron parent (NODE_OPTIONS, ELECTRON_RUN_AS_NODE,
+  // etc.) never reach the child.
+  const SAFE_EXACT = new Set([
+    'PATH',
+    'HOME',
+    'USER',
+    'USERNAME',
+    'USERPROFILE',
+    'APPDATA',
+    'LOCALAPPDATA',
+    'PROGRAMDATA',
+    'PROGRAMFILES',
+    'PROGRAMFILES(X86)',
+    'SYSTEMROOT',
+    'WINDIR',
+    'TEMP',
+    'TMP',
+    'TMPDIR',
+    'COMSPEC',
+    'PATHEXT',
+    'SHELL',
+    'LANG',
+    'LC_ALL',
+    'LC_CTYPE',
+    'TZ',
+    'COLORTERM',
+    'TERM',
+  ]);
+  const SAFE_PREFIXES = ['ANTHROPIC_', 'CLAUDE_', 'CCSM_', 'AWS_', 'GOOGLE_', 'GCLOUD_', 'XDG_'];
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v == null) continue;
+    if (SAFE_EXACT.has(k.toUpperCase()) || SAFE_PREFIXES.some((p) => k.startsWith(p))) {
+      env[k] = v;
+    }
+  }
+  env.CLAUDE_CONFIG_DIR = opts.configDir;
+  env.CLAUDE_CODE_ENTRYPOINT = 'ccsm-desktop';
+  env.CLAUDE_AGENT_SDK_CLIENT_APP = 'ccsm-desktop/0.1.0';
+  if (opts.envOverrides) {
+    for (const [k, v] of Object.entries(opts.envOverrides)) {
+      env[k] = v;
+    }
+  }
+  delete env.NODE_OPTIONS;
+  delete env.ELECTRON_RUN_AS_NODE;
+  return env;
+}
+
+/**
+ * Tools whose permission UX is owned by the renderer's question / plan UI —
+ * the SDK runner must not surface a generic permission prompt for these.
+ * Mirrors HOOK_PASSTHROUGH_TOOLS in the legacy runner.
+ */
+const PASSTHROUGH_TOOLS: ReadonlySet<string> = new Set([
+  'AskUserQuestion',
+  'ExitPlanMode',
+]);
+
+// Module-level handle to the dynamically-loaded SDK. Lazy-loaded the first
+// time start() runs so unit tests that don't exercise start() can run without
+// the SDK on the require path. We never re-import — once loaded the handle is
+// reused across sessions.
+let sdkModulePromise: Promise<typeof import('@anthropic-ai/claude-agent-sdk')> | null = null;
+function loadSdk(): Promise<typeof import('@anthropic-ai/claude-agent-sdk')> {
+  if (!sdkModulePromise) {
+    sdkModulePromise = import('@anthropic-ai/claude-agent-sdk');
+  }
+  return sdkModulePromise;
+}
+
+/**
+ * Test seam: lets unit tests inject a fake SDK module without going through
+ * the real ESM import. Production code never calls this.
+ */
+export function __setSdkModuleForTests(
+  mod: typeof import('@anthropic-ai/claude-agent-sdk') | null,
+): void {
+  sdkModulePromise = mod ? Promise.resolve(mod) : null;
+}
+
+export class SdkSessionRunner {
+  private query: import('@anthropic-ai/claude-agent-sdk').Query | null = null;
+  private abort: AbortController | null = null;
+  private consumer: Promise<void> | null = null;
+  private disposed = false;
+  private cliSessionId: string | undefined;
+  private permissionMode: PermissionMode = 'default';
+
+  /**
+   * Outbound user-message queue. The SDK consumes user input via an
+   * AsyncIterable<SDKUserMessage> we hand to `query({ prompt })`. We push
+   * messages onto this queue from `send()` / `sendContent()` and the
+   * iterator yields them.
+   */
+  private inputQueue: Array<{
+    role: 'user';
+    content: string | readonly unknown[];
+  }> = [];
+  private inputResolve: ((v: void) => void) | null = null;
+  private inputClosed = false;
+
+  /**
+   * Pending permission decisions, keyed by a synthetic requestId. The SDK's
+   * `canUseTool` callback awaits the matching entry's resolve(); the
+   * renderer settles it via resolvePermission / resolvePermissionPartial.
+   */
+  private pendingPerms = new Map<
+    string,
+    {
+      resolve: (d: CanUseToolDecision) => void;
+      toolName: string;
+      input: unknown;
+    }
+  >();
+  private nextPermSeq = 0;
+
+  constructor(
+    public readonly id: string,
+    private readonly onEvent: EventHandler,
+    private readonly onExit: ExitHandler,
+    private readonly onPermissionRequest: PermissionRequestHandler,
+    private readonly onDiagnostic: DiagnosticHandler = () => {},
+  ) {}
+
+  /**
+   * Mirrors SessionRunner.getPid() but the SDK doesn't expose the child pid
+   * today. Returns undefined so dev probes degrade gracefully (the assertion
+   * "runner exists" still passes, the pid sub-assertion just sees undefined).
+   */
+  getPid(): number | undefined {
+    return undefined;
+  }
+
+  resolvePermission(requestId: string, decision: 'allow' | 'deny'): boolean {
+    const entry = this.pendingPerms.get(requestId);
+    if (!entry) return false;
+    this.pendingPerms.delete(requestId);
+    entry.resolve(
+      decision === 'allow'
+        ? { allow: true }
+        : { allow: false, deny_reason: 'User denied tool use.' },
+    );
+    return true;
+  }
+
+  resolvePermissionPartial(requestId: string, acceptedHunks: number[]): boolean {
+    const entry = this.pendingPerms.get(requestId);
+    if (!entry) return false;
+    this.pendingPerms.delete(requestId);
+    const result = filterToolInputByAcceptedHunks(entry.toolName, entry.input, acceptedHunks);
+    if (result.kind === 'reject') {
+      entry.resolve({ allow: false, deny_reason: 'User rejected all proposed hunks.' });
+      return true;
+    }
+    if (result.kind === 'updated') {
+      entry.resolve({ allow: true, updatedInput: result.updatedInput });
+      return true;
+    }
+    entry.resolve({ allow: true });
+    return true;
+  }
+
+  async start(opts: StartOptions): Promise<void> {
+    if (this.query) return;
+    this.permissionMode = opts.permissionMode ?? 'default';
+    this.abort = new AbortController();
+
+    // Resolve the user's system claude binary up front (PR-A scope: PR-B
+    // will swap in the SDK-bundled binary). Throws ClaudeNotFoundError
+    // surfaced by manager.ts as `{ ok: false, errorCode: 'CLAUDE_NOT_FOUND' }`.
+    let binaryPath: string | undefined = opts.binaryPath;
+    if (!binaryPath) {
+      try {
+        const inv = await resolveClaudeInvocation();
+        // The SDK only takes a single executable path; if the resolver
+        // returned a `node-script` (npm shim), point at the node script
+        // itself — the SDK will spawn it via the configured `executable`.
+        // For `cmd-shell` (last-resort .cmd shim), we still pass the .cmd
+        // path; modern Node accepts it on Windows when the SDK uses
+        // shell-quoted spawn (see SDK's pathToClaudeCodeExecutable docs).
+        binaryPath = inv.kind === 'node-script' ? inv.script : inv.path;
+      } catch (err) {
+        if (err instanceof ClaudeNotFoundError) throw err;
+        throw err;
+      }
+    }
+
+    const sdk = await loadSdk();
+
+    const sdkPermissionMode = toSdkPermissionMode(this.permissionMode);
+
+    this.query = sdk.query({
+      prompt: this.makeInputIterable(),
+      options: {
+        cwd: resolveCwd(opts.cwd),
+        env: buildSdkEnv({
+          configDir: resolveClaudeConfigDir(opts.configDir),
+          envOverrides: opts.envOverrides,
+        }),
+        model: opts.model,
+        permissionMode: sdkPermissionMode,
+        allowDangerouslySkipPermissions: sdkPermissionMode === 'bypassPermissions' ? true : undefined,
+        resume: opts.resumeSessionId,
+        pathToClaudeCodeExecutable: binaryPath,
+        canUseTool: (toolName, input, ctx) => this.handleCanUseTool(toolName, input, ctx),
+        // Match the legacy spawner: we want partial-message streaming so
+        // long replies don't appear frozen.
+        includePartialMessages: true,
+        abortController: this.abort,
+      },
+    });
+
+    // Drain the SDK's outbound stream into ccsm's renderer event channel.
+    // Errors from the iterator are surfaced via onExit; see the catch below.
+    const query = this.query;
+    this.consumer = (async () => {
+      try {
+        for await (const msg of query) {
+          if (this.disposed) break;
+          // Capture cliSessionId from the first system init frame so a
+          // future #22 task that pins explicit session IDs has a known
+          // value to thread through.
+          const m = msg as SdkMessageLike;
+          if (m.type === 'system' && m.subtype === 'init' && !this.cliSessionId) {
+            const sid = (m as { session_id?: unknown }).session_id;
+            if (typeof sid === 'string') this.cliSessionId = sid;
+          }
+          const translated = translateSdkMessage(m);
+          if (translated) this.onEvent(translated);
+        }
+        this.onExit({ error: undefined });
+      } catch (err) {
+        // The SDK throws AbortError on intentional close — don't surface that
+        // as a user-visible error. Anything else propagates with its message.
+        const isAbort =
+          err instanceof Error &&
+          (err.name === 'AbortError' || /aborted/i.test(err.message));
+        if (isAbort && this.disposed) {
+          this.onExit({ error: undefined });
+        } else {
+          this.onExit({ error: err instanceof Error ? err.message : String(err) });
+        }
+      } finally {
+        this.cleanupAfterExit();
+      }
+    })();
+  }
+
+  /**
+   * AsyncIterable that yields user messages as they're pushed via send() /
+   * sendContent(). The SDK calls `next()` on this iterable for every
+   * outbound user turn; we resolve the next pending Promise when a message
+   * arrives, or wait if the queue is empty.
+   */
+  private async *makeInputIterable(): AsyncIterable<
+    import('@anthropic-ai/claude-agent-sdk').SDKUserMessage
+  > {
+    while (!this.inputClosed) {
+      while (this.inputQueue.length > 0) {
+        const item = this.inputQueue.shift()!;
+        // Intentional `as`: SDK's SDKUserMessage requires `parent_tool_use_id:
+        // string | null` and uses MessageParam from @anthropic-ai/sdk for
+        // `message`. Our content shape (string | content-block array) matches
+        // MessageParam.content and the SDK accepts the looser typing on input.
+        yield {
+          type: 'user',
+          message: { role: 'user', content: item.content as string },
+          parent_tool_use_id: null,
+        } as unknown as import('@anthropic-ai/claude-agent-sdk').SDKUserMessage;
+      }
+      if (this.inputClosed) break;
+      await new Promise<void>((resolve) => {
+        this.inputResolve = resolve;
+      });
+      this.inputResolve = null;
+    }
+  }
+
+  private wakeInput(): void {
+    const r = this.inputResolve;
+    if (r) {
+      this.inputResolve = null;
+      r();
+    }
+  }
+
+  send(text: string): void {
+    if (this.disposed) return;
+    this.inputQueue.push({ role: 'user', content: text });
+    this.wakeInput();
+  }
+
+  sendContent(content: readonly unknown[]): void {
+    if (this.disposed) return;
+    this.inputQueue.push({ role: 'user', content });
+    this.wakeInput();
+  }
+
+  /**
+   * Bridge SDK canUseTool callback into the host permission UI. The decision
+   * shape returned to the SDK is `PermissionResult` (allow/deny union). We
+   * translate ccsm's pendingPerms decision into that shape and forward
+   * `updatedInput` for partial-accept (#251).
+   */
+  private async handleCanUseTool(
+    toolName: string,
+    input: Record<string, unknown>,
+    ctx: { signal: AbortSignal; toolUseID: string },
+  ): Promise<import('@anthropic-ai/claude-agent-sdk').PermissionResult> {
+    // Mirror the legacy runner's mode-driven shortcuts: bypass + acceptEdits
+    // never prompt; passthrough tools delegate to the renderer's own UI.
+    if (
+      this.permissionMode === 'bypassPermissions' ||
+      this.permissionMode === 'yolo' ||
+      this.permissionMode === 'acceptEdits' ||
+      this.permissionMode === 'auto'
+    ) {
+      return { behavior: 'allow' };
+    }
+    if (PASSTHROUGH_TOOLS.has(toolName)) {
+      return { behavior: 'allow' };
+    }
+
+    const decision = await new Promise<CanUseToolDecision>((resolve) => {
+      const requestId = `perm-${Date.now().toString(36)}-${(this.nextPermSeq++).toString(36)}`;
+      this.pendingPerms.set(requestId, { resolve, toolName, input });
+      ctx.signal.addEventListener(
+        'abort',
+        () => {
+          if (this.pendingPerms.delete(requestId)) {
+            resolve({ allow: false, deny_reason: 'Permission request cancelled.' });
+          }
+        },
+        { once: true },
+      );
+      this.onPermissionRequest({ requestId, toolName, input });
+    });
+
+    if (decision.allow) {
+      return {
+        behavior: 'allow',
+        updatedInput: decision.updatedInput as Record<string, unknown> | undefined,
+      };
+    }
+    return {
+      behavior: 'deny',
+      message: decision.deny_reason ?? 'User denied tool use.',
+    };
+  }
+
+  async interrupt(): Promise<void> {
+    if (!this.query) return;
+    try {
+      await this.query.interrupt();
+    } catch (err) {
+      // Match the legacy behaviour: surface a soft warning so a Stop click
+      // that didn't land gets explained. Hard kill happens via this.abort.
+      this.onDiagnostic({
+        level: 'warn',
+        code: 'interrupt_timeout',
+        message: `Agent didn't acknowledge interrupt (${
+          err instanceof Error ? err.message : String(err)
+        }). Force-killing.`,
+      });
+    }
+  }
+
+  async cancelToolUse(toolUseId: string): Promise<void> {
+    if (!this.query) return;
+    // Same fallback as the legacy runner: SDK has no per-tool cancel today,
+    // so a per-tool Cancel falls back to a turn-level interrupt. The
+    // diagnostic is emitted so the per-tool fallback shows in dogfood logs.
+    this.onDiagnostic({
+      level: 'warn',
+      code: 'tool_cancel_fallback',
+      message: `Per-tool cancel for ${toolUseId} fell back to turn interrupt (SDK lacks scoped cancel).`,
+    });
+    await this.interrupt();
+  }
+
+  async setPermissionMode(mode: PermissionMode): Promise<void> {
+    const sdkMode = toSdkPermissionMode(mode);
+    this.permissionMode = mode;
+    if (!this.query || !sdkMode) return;
+    try {
+      await this.query.setPermissionMode(sdkMode);
+    } catch (err) {
+      this.onDiagnostic({
+        level: 'warn',
+        code: 'set_permission_mode_timeout',
+        message: `Agent unresponsive to permission-mode change (${
+          err instanceof Error ? err.message : String(err)
+        }).`,
+      });
+    }
+  }
+
+  async setModel(model?: string): Promise<void> {
+    if (!this.query || !model) return;
+    try {
+      await this.query.setModel(model);
+    } catch (err) {
+      this.onDiagnostic({
+        level: 'warn',
+        code: 'set_model_timeout',
+        message: `Agent unresponsive to model change (${
+          err instanceof Error ? err.message : String(err)
+        }).`,
+      });
+    }
+  }
+
+  close(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    for (const entry of this.pendingPerms.values()) {
+      entry.resolve({ allow: false, deny_reason: 'Session closed.' });
+    }
+    this.pendingPerms.clear();
+    this.inputClosed = true;
+    this.wakeInput();
+    // Trigger the SDK's abort path. The SDK's Query.close() also exists but
+    // the abort signal is a single source of truth that the SDK already
+    // wires through to the subprocess.
+    try {
+      this.abort?.abort();
+    } catch {
+      /* ignore */
+    }
+    try {
+      this.query?.close();
+    } catch {
+      /* ignore — close() may throw if abort already tore the query down */
+    }
+  }
+
+  private cleanupAfterExit(): void {
+    this.disposed = true;
+    this.inputClosed = true;
+    this.wakeInput();
+    for (const entry of this.pendingPerms.values()) {
+      entry.resolve({ allow: false, deny_reason: 'Session ended.' });
+    }
+    this.pendingPerms.clear();
+    this.query = null;
+    this.abort = null;
+  }
+}

--- a/electron/agent/manager.ts
+++ b/electron/agent/manager.ts
@@ -1,7 +1,8 @@
 import type { WebContents } from 'electron';
-import { SessionRunner, ClaudeSpawnFailedError, type StartOptions, type PermissionMode, type AgentMessage } from './sessions';
+import { ClaudeSpawnFailedError, type StartOptions, type PermissionMode, type AgentMessage } from './sessions';
 import { ClaudeNotFoundError } from './binary-resolver';
 import type { StartResult } from './start-result-types';
+import { createRunner, type Runner } from '../agent-sdk/runner-factory';
 
 export type { StartErrorCode, StartResult } from './start-result-types';
 
@@ -21,7 +22,7 @@ export type AgentDiagnostic = {
 };
 
 class SessionsManager {
-  private runners = new Map<string, SessionRunner>();
+  private runners = new Map<string, Runner>();
   private sender: Sender | null = null;
 
   bindSender(wc: WebContents): void {
@@ -71,7 +72,7 @@ class SessionsManager {
   async start(sessionId: string, opts: StartOptions): Promise<StartResult> {
     if (this.runners.has(sessionId)) return { ok: true };
     try {
-      const runner = new SessionRunner(
+      const runner = createRunner(
         sessionId,
         (msg: AgentMessage) => this.emit('agent:event', { sessionId, message: msg }),
         ({ error }) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.2.119",
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/sortable": "^8.0.0",
         "@dnd-kit/utilities": "^3.2.2",
@@ -104,6 +105,168 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.119.tgz",
+      "integrity": "sha512-6AvthpsaOTlkn514brSGOcCSLHDXODnU+ExN1O3CJCjxr5RBcmzR057C9EIM0G7IchnXsRfMZgRO1QKsjTXdbA==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.81.0",
+        "@modelcontextprotocol/sdk": "^1.29.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.119",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.119",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.119",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.119",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.119",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.119",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.119",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.119"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.119.tgz",
+      "integrity": "sha512-kxnG37SZqUata2Jcp/YQ0n9Y7o/sinE/8LdG4ltM1gePh+z+0Mfa4vBUUTEBMBFth9PTovKoesIuVuyFpvO/Cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.119.tgz",
+      "integrity": "sha512-9Aj8g3ELsmZuOFg17TCkikeg/Wt2ucVT8hOOPQUatzLd7BKhydrHLA0RP42nBpWECO1B/n/mPdQ4iS/LS3s2Fg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.119.tgz",
+      "integrity": "sha512-v3o464XkiYehp/OKidQQirxdVb+aGSvdJvHF2zH9p33W8M/NC21zwwh4dhwDnKsyrtBIgkt2CcMwzIl30r0OtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.119.tgz",
+      "integrity": "sha512-IPGWgtz+gGnD7fxKAvSf913EUT/lYBTBE8EZ7lh3+x5ZP2859LWLmrCm053Lf3nMWo/CWikZsVPwkDVwpz6tIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.119.tgz",
+      "integrity": "sha512-9ePt4ZN+hsqDw4AgS4KtcWIGKfL9Oq28kwkrTER/QAcSrVKxiLonp81cCLzg7Ok/IUJu4Cfd71GZbFv/WE54zw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.119.tgz",
+      "integrity": "sha512-QYxFNAe4FFridPkKhGlNcNBJ0TaIygWYyvfI9g4kX0i+RVbresUWuZVkWY06ioJ0fXoixFJ+HNQBMB7dLrIp8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.119.tgz",
+      "integrity": "sha512-p/TjcKQvkCYtXGPlR+mdyNwqCmvRcQL34Wtq0yUZ+iqmI/eyCe59IJ3AZrE0EZoqmiAevEYzatPIt9sncC9uxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.119.tgz",
+      "integrity": "sha512-k98Ju0wtktm6FhqTE/cXlVr6K4kGqBolVjEGzeKkW6ZILc7124euwNapAvkQCwMAavAxS/ZnO3jdKMtHtwTVTA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.81.0.tgz",
+      "integrity": "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -1834,6 +1997,18 @@
         "@hapi/hoek": "^11.0.2"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -2556,17 +2731,360 @@
         "node": ">=10"
       }
     },
-    "node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
-      "dev": true,
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
       "engines": {
-        "node": ">= 16"
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
-        "url": "https://paulmillr.com/funding/"
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/@nodert-win10-au/windows.applicationmodel": {
@@ -6326,7 +6844,6 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "~2.1.34",
@@ -6340,7 +6857,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6861,7 +7377,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/array-includes": {
@@ -7275,7 +7790,6 @@
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
       "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -7300,7 +7814,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -7310,7 +7823,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -7323,7 +7835,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/bonjour-service": {
@@ -7512,7 +8023,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -7630,7 +8140,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7644,7 +8153,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -8312,7 +8820,6 @@
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.2.1"
@@ -8325,7 +8832,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -8342,7 +8848,6 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -8352,7 +8857,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/core-util-is": {
@@ -8361,6 +8865,23 @@
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "9.0.1",
@@ -8433,7 +8954,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -8831,7 +9351,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -8850,7 +9369,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8",
@@ -9135,7 +9653,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -9157,7 +9674,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/ejs": {
@@ -9327,7 +9843,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -9493,7 +10008,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9503,7 +10017,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9548,7 +10061,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -9665,7 +10177,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
@@ -10013,7 +10524,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -10034,6 +10544,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/expand-template": {
@@ -10066,7 +10597,6 @@
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
@@ -10109,11 +10639,28 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -10123,7 +10670,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/extend": {
@@ -10168,7 +10714,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -10189,7 +10734,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10329,7 +10873,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
       "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -10348,7 +10891,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -10358,7 +10900,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/find-up": {
@@ -10497,7 +11038,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -10554,7 +11094,6 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -10619,7 +11158,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -10711,7 +11249,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -10745,7 +11282,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -10936,7 +11472,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11040,7 +11575,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11076,7 +11610,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
       "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -11133,6 +11666,15 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/hosted-git-info": {
@@ -11366,7 +11908,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "depd": "~2.0.0",
@@ -11745,7 +12286,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
       "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -12199,6 +12739,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -12397,7 +12943,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/isobject": {
@@ -12522,6 +13067,15 @@
         "node": ">= 20"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -12618,12 +13172,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -13368,7 +13941,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -13667,7 +14239,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -13707,7 +14278,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
       "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -13724,7 +14294,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -14337,7 +14906,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -14347,7 +14915,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -14873,7 +15440,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -14883,7 +15449,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -14988,7 +15553,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -15299,7 +15863,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -15340,7 +15903,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -15391,7 +15953,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/pathe": {
@@ -15484,6 +16045,15 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -15569,6 +16139,19 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/pkijs/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/playwright": {
@@ -15982,7 +16565,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
@@ -15996,7 +16578,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -16056,7 +16637,6 @@
       "version": "6.14.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
       "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -16085,7 +16665,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -16095,7 +16674,6 @@
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
       "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -16111,7 +16689,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -16610,7 +17187,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -16889,6 +17465,32 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/run-applescript": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
@@ -16991,7 +17593,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/sanitize-filename": {
@@ -17147,7 +17748,6 @@
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
       "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -17172,7 +17772,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -17182,14 +17781,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/send/node_modules/mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "mime": "cli.js"
@@ -17296,7 +17893,6 @@
       "version": "1.16.3",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
       "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "~2.0.0",
@@ -17368,7 +17964,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/shallow-clone": {
@@ -17388,7 +17983,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -17401,7 +17995,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -17424,7 +18017,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -17444,7 +18036,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -17461,7 +18052,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -17480,7 +18070,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -17775,7 +18364,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -18408,7 +18996,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
@@ -18496,6 +19083,12 @@
       "dependencies": {
         "utf8-byte-length": "^1.0.1"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
@@ -18610,7 +19203,6 @@
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "media-typer": "0.3.0",
@@ -18873,7 +19465,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -18996,7 +19587,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
@@ -19017,7 +19607,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -19653,7 +20242,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -20095,6 +20683,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "postinstall": "node scripts/postinstall.mjs"
   },
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.119",
     "@dnd-kit/core": "^6.1.0",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",


### PR DESCRIPTION
Adds a parallel SDK-backed session runner behind the `CCSM_USE_SDK` env flag. Legacy hand-written wrapper stays the default, so flag-off behaviour is byte-identical to before this PR.

## Layer 1 (high-level review)

1. **Necessity**: Yes. SDK and current wrapper differ in subtle ways (message timing, hook payload shape, interrupt latency); a hard cut-over carries unknown regression risk. Strangler-fig migration is the standard answer.
2. **Better approach?** Refactoring `electron/agent/sessions.ts` in place would lose A/B-gating and rollback capability and force a single large PR. Parallel implementation + flag is correct.
3. **Direction (SDK + bundled binary + flag rollout)**: Aligns with the goal of letting Anthropic own the wire protocol. PR-A keeps user's system binary; PR-B will swap in the bundled one once the SDK path is validated.
4. **Blast radius of the manager.ts change**: ~5 lines (`Map<string, SessionRunner>` -> `Map<string, Runner>`, `new SessionRunner` -> `createRunner`). With flag off, `createRunner` returns `new SessionRunner(...)` with identical args -> behaviour-equivalent. The `Runner` contract is enforced structurally at compile time, so any drift on either implementation surfaces as a TS error in the factory rather than at the call site.

## Files changed

New (all under `electron/agent-sdk/`, ~600 LOC + 54 tests):
- `sessions.ts` - `SdkSessionRunner` using `@anthropic-ai/claude-agent-sdk` `query()`. Same surface as `electron/agent/sessions.ts` `SessionRunner` (id, getPid, start, send, sendContent, interrupt, cancelToolUse, setPermissionMode, setModel, resolvePermission, resolvePermissionPartial, close).
- `sdk-message-translator.ts` - `SDKMessage` -> `ClaudeStreamEvent`. Big-bucket frames (system/assistant/user/result/stream_event) pass through; SDK-only bookkeeping events (status, hook_*, tool_progress, etc.) are dropped.
- `runner-factory.ts` - `createRunner()` reads `CCSM_USE_SDK` per call (re-evaluated, not cached) so tests can flip it via `vi.stubEnv`. Truthy values: `1`, `true`, `yes` (case-insensitive). The duck-typed `Runner` interface is the contract `manager.ts` actually uses.
- `__tests__/{runner-factory,sdk-message-translator,sessions}.test.ts` - 54 tests covering env parsing, translator coverage of every SDK message type, and SdkSessionRunner start/canUseTool/permission/interrupt/setModel/setPermissionMode/close paths via an injected fake SDK module.

Modified:
- `electron/agent/manager.ts` - 2-line swap (import + constructor call) to use `createRunner`. No other behaviour change.
- `package.json` / `package-lock.json` - add `@anthropic-ai/claude-agent-sdk@^0.2.119` to dependencies. `build` field untouched.

No files deleted. None of `electron/agent/{claude-spawner,control-rpc,ndjson-splitter,stream-json-*,partial-write,binary-resolver,sessions,cli-picker-models,list-models-from-settings}.ts` are touched.

## Test coverage

- `npm run typecheck` passes
- `npm run lint` no new errors/warnings on changed files
- `npx vitest run electron/agent-sdk` -> 54/54 pass
- Full `npm test` -> 890 pass, 12 pre-existing `better-sqlite3` native-binding failures in `electron/__tests__/db*.test.ts` unrelated to this change (worktree node_modules not rebuilt for Electron ABI; same failures on `origin/working`)

## Validation method

1. **Default path (flag off)**: Sessions go through legacy `SessionRunner` exactly as before. The factory call site is the only difference vs. main.
2. **SDK path (flag on)**: Set `CCSM_USE_SDK=1` then start ccsm. New sessions use `SdkSessionRunner`; binary is resolved via existing `binary-resolver` and passed to the SDK as `pathToClaudeCodeExecutable`. `CLAUDE_CONFIG_DIR`, `CLAUDE_CODE_ENTRYPOINT`, `SAFE_ENV` allowlist, and per-session `envOverrides` are all forwarded to the SDK via `Options.env`.

## Known limitations (PR-A scope)

- `cancelToolUse`: still falls back to a turn-level `interrupt()` because the SDK has no scoped cancel today. Mirrors the legacy runner's behaviour; emits a `tool_cancel_fallback` diagnostic.
- `getPid()`: returns `undefined` because the SDK doesn't expose the spawned child PID. Dev probes that assert "runner exists" still pass; pid sub-assertions see `undefined`.
- Bundled binary: PR-A still uses the user's system claude binary (#PR-B follow-up).
- Explicit UUID session IDs: deferred to follow-up #22. Today the SDK runner captures the implicit `cliSessionId` from the first system init frame, matching the legacy flow.

## Risks

- **SDK message-type drift**: a new SDK message type would log a `[agent-sdk] dropping unknown SDK message type` warning rather than crash. Acceptable for a flagged path.
- **Permission mode coercion**: legacy aliases (`yolo`/`auto`/`ask`/`standard`/`dontAsk`) are mapped to the strict 4-value SDK mode. Unknown modes throw and surface to the renderer via the existing `start()` catch path.