### PR TITLE
feat(build): bundle SDK binary into win-x64 installer (PR-B)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -108,9 +108,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.119",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.119.tgz",
-      "integrity": "sha512-6AvthpsaOTlkn514brSGOcCSLHDXODnU+ExN1O3CJCjxr5RBcmzR057C9EIM0G7IchnXsRfMZgRO1QKsjTXdbA==",
+      "version": "0.2.120",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.120.tgz",
+      "integrity": "sha512-4HqVK9SZtlowlpX0LyXX0vlGU9Wkygmgoov/GFya/yMfg89wSECkkkUAwKt7wi3Xg+378QLpDHwiO+cyxYY7NQ==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.81.0",
@@ -120,23 +120,23 @@
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.119",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.119",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.119",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.119",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.119",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.119",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.119",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.119"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.120",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.120",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.120",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.120",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.120",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.120",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.120",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.120"
       },
       "peerDependencies": {
         "zod": "^4.0.0"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.2.119",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.119.tgz",
-      "integrity": "sha512-kxnG37SZqUata2Jcp/YQ0n9Y7o/sinE/8LdG4ltM1gePh+z+0Mfa4vBUUTEBMBFth9PTovKoesIuVuyFpvO/Cw==",
+      "version": "0.2.120",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.120.tgz",
+      "integrity": "sha512-oB6UAXNDGqW3vjTphmDTuQmzSW/VrdHKLLLD8jioshVVN99KfW5ZQ27w+btWLnqOYW7iYdF/EBOuLg2d5rXvsQ==",
       "cpu": [
         "arm64"
       ],
@@ -147,9 +147,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.2.119",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.119.tgz",
-      "integrity": "sha512-9Aj8g3ELsmZuOFg17TCkikeg/Wt2ucVT8hOOPQUatzLd7BKhydrHLA0RP42nBpWECO1B/n/mPdQ4iS/LS3s2Fg==",
+      "version": "0.2.120",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.120.tgz",
+      "integrity": "sha512-ilRxVnWwY9oym0dhVfqPLuH2IFyxzAGQ/n3GY6X/eOKL96niTtqHUV5tu+cprTx2ZioROkFu1I6zi5GQESoakg==",
       "cpu": [
         "x64"
       ],
@@ -160,9 +160,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.2.119",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.119.tgz",
-      "integrity": "sha512-v3o464XkiYehp/OKidQQirxdVb+aGSvdJvHF2zH9p33W8M/NC21zwwh4dhwDnKsyrtBIgkt2CcMwzIl30r0OtA==",
+      "version": "0.2.120",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.120.tgz",
+      "integrity": "sha512-tjVZUIYhjQQM5OzS+SEiDt1KdRm0HlzsDmNbNY1wWjcJfXMepGnJ183p0f8InX5tBfFotCGsiFzWNNORHTAysg==",
       "cpu": [
         "arm64"
       ],
@@ -176,9 +176,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.2.119",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.119.tgz",
-      "integrity": "sha512-IPGWgtz+gGnD7fxKAvSf913EUT/lYBTBE8EZ7lh3+x5ZP2859LWLmrCm053Lf3nMWo/CWikZsVPwkDVwpz6tIQ==",
+      "version": "0.2.120",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.120.tgz",
+      "integrity": "sha512-uKRkNJlK9PcNJw1UlOnQD0yoTIwRbo7ZC8AOwF7E1Gj3Tvwwef7d8Z1KjSuj9WPum4f8yOLqKEgIE5UniVlT6w==",
       "cpu": [
         "arm64"
       ],
@@ -192,9 +192,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.2.119",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.119.tgz",
-      "integrity": "sha512-9ePt4ZN+hsqDw4AgS4KtcWIGKfL9Oq28kwkrTER/QAcSrVKxiLonp81cCLzg7Ok/IUJu4Cfd71GZbFv/WE54zw==",
+      "version": "0.2.120",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.120.tgz",
+      "integrity": "sha512-H3++eOwVOa02iW/IAIZEWEwBFmDoersA6oxNXAqGnhqI5twYCWFquZu5oear8PMoc3JAhKrxJqi7C3hVxXxJ/Q==",
       "cpu": [
         "x64"
       ],
@@ -208,9 +208,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.2.119",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.119.tgz",
-      "integrity": "sha512-QYxFNAe4FFridPkKhGlNcNBJ0TaIygWYyvfI9g4kX0i+RVbresUWuZVkWY06ioJ0fXoixFJ+HNQBMB7dLrIp8Q==",
+      "version": "0.2.120",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.120.tgz",
+      "integrity": "sha512-0h/1Eh9vu7QWmO8JoRVS4p36Ldvut5OaUIDUl7xQNYQ8tEdg3PyZPg7vTaS3+IAYWH+WOqCWP59YuhasV5hOXQ==",
       "cpu": [
         "x64"
       ],
@@ -224,9 +224,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.2.119",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.119.tgz",
-      "integrity": "sha512-p/TjcKQvkCYtXGPlR+mdyNwqCmvRcQL34Wtq0yUZ+iqmI/eyCe59IJ3AZrE0EZoqmiAevEYzatPIt9sncC9uxw==",
+      "version": "0.2.120",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.120.tgz",
+      "integrity": "sha512-aig+wXSbJ8/28I1kxz2L0cxgzmaCdwtMQTcg2zzuSa+BE7Ujomnhr/ryC21PYhLzMdgXXgIGTwXU0I8BON5zUw==",
       "cpu": [
         "arm64"
       ],
@@ -237,9 +237,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.2.119",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.119.tgz",
-      "integrity": "sha512-k98Ju0wtktm6FhqTE/cXlVr6K4kGqBolVjEGzeKkW6ZILc7124euwNapAvkQCwMAavAxS/ZnO3jdKMtHtwTVTA==",
+      "version": "0.2.120",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.120.tgz",
+      "integrity": "sha512-ViESybhqCXI8aq2NaE/U08i2wW4tYVrYMt+KVN+a5+lyqbsaYDHTvaizYU0wOoKBVJuXOWDQaBmsCdiBTkdZOw==",
       "cpu": [
         "x64"
       ],
@@ -5579,6 +5579,70 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.4",

--- a/package.json
+++ b/package.json
@@ -113,11 +113,15 @@
     "copyright": "Copyright (c) 2026 Jiahui Gu",
     "asar": true,
     "asarUnpack": [
-      "**/node_modules/better-sqlite3/**"
+      "**/node_modules/better-sqlite3/**",
+      "**/node_modules/@anthropic-ai/claude-agent-sdk-*/**"
     ],
+    "afterPack": "scripts/after-pack.cjs",
     "files": [
       "dist/**/*",
       "package.json",
+      "node_modules/@anthropic-ai/claude-agent-sdk/**",
+      "node_modules/@anthropic-ai/claude-agent-sdk-*/**",
       "!**/*.map",
       "!**/*.ts",
       "!**/__tests__/**",
@@ -139,8 +143,7 @@
         {
           "target": "nsis",
           "arch": [
-            "x64",
-            "arm64"
+            "x64"
           ]
         }
       ],

--- a/scripts/after-pack.cjs
+++ b/scripts/after-pack.cjs
@@ -1,0 +1,92 @@
+// electron-builder afterPack hook (PR-B, win-x64 only).
+//
+// Verify the @anthropic-ai/claude-agent-sdk-win32-x64/claude.exe binary
+// actually landed inside app.asar.unpacked. Shipping an installer with no
+// `claude.exe` is the worst possible regression: app starts, every session
+// crashes with "Native CLI binary not found". A glob typo in asarUnpack or
+// a missing optional-dep on disk are silent failures otherwise; this hook
+// turns them into a hard build failure.
+//
+// SDK lookup (sdk.mjs `V7`):
+//   createRequire(<sdk.mjs>).resolve(
+//     '@anthropic-ai/claude-agent-sdk-win32-x64/claude.exe'
+//   )
+// resolved relative to claude-agent-sdk/sdk.mjs at runtime. sdk.mjs itself
+// stays inside app.asar (it's pure JS, no need to unpack); Electron's asar
+// shim transparently redirects file-system reads of unpacked-glob-matched
+// paths to app.asar.unpacked. So the binary MUST exist on disk under
+// app.asar.unpacked at one of the two layouts npm produces:
+//   (a) <unpacked>/node_modules/@anthropic-ai/claude-agent-sdk-win32-x64/
+//   (b) <unpacked>/node_modules/@anthropic-ai/claude-agent-sdk/
+//          node_modules/@anthropic-ai/claude-agent-sdk-win32-x64/
+// Both satisfy Node's resolution from sdk.mjs (it walks parent
+// node_modules). On this codebase npm currently produces (b) — the
+// platform sub-package is hoisted into the SDK's own node_modules — so we
+// accept either.
+//
+// Scope: only win32-x64. Other platforms/arches are out of scope for PR-B
+// and will land in a follow-up PR; the hook no-ops for them so local dev
+// runs of `make:mac` etc. don't surprise people with red builds for an
+// orthogonal reason.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+exports.default = async function afterPack(context) {
+  const { appOutDir, electronPlatformName, arch } = context;
+  // electron-builder Arch enum: 0=ia32, 1=x64, 2=armv7l, 3=arm64
+  const archName = ({ 0: 'ia32', 1: 'x64', 2: 'armv7l', 3: 'arm64' })[arch] ?? String(arch);
+
+  if (electronPlatformName !== 'win32' || archName !== 'x64') {
+    console.log(
+      `[after-pack] Skipping SDK binary check for ${electronPlatformName}/${archName} ` +
+        `(PR-B scope is win32/x64 only).`,
+    );
+    return;
+  }
+
+  const unpackedRoot = path.join(
+    appOutDir,
+    'resources',
+    'app.asar.unpacked',
+    'node_modules',
+    '@anthropic-ai',
+  );
+  const candidates = [
+    // Layout (a): top-level peer of claude-agent-sdk
+    path.join(unpackedRoot, 'claude-agent-sdk-win32-x64', 'claude.exe'),
+    // Layout (b): nested under claude-agent-sdk's own node_modules
+    path.join(
+      unpackedRoot,
+      'claude-agent-sdk',
+      'node_modules',
+      '@anthropic-ai',
+      'claude-agent-sdk-win32-x64',
+      'claude.exe',
+    ),
+  ];
+
+  const found = candidates.find((p) => fs.existsSync(p));
+
+  if (!found) {
+    let listing = '<missing>';
+    try {
+      listing = fs.readdirSync(unpackedRoot).join(', ') || '<empty>';
+    } catch {
+      // unpackedRoot may not exist at all — listing stays <missing>
+    }
+    throw new Error(
+      `[after-pack] Expected SDK binary at one of:\n` +
+        candidates.map((p) => `  - ${p}`).join('\n') +
+        `\n  but none exist on disk.\n` +
+        `  unpacked @anthropic-ai contents: ${listing}\n` +
+        `Hint: check that build.asarUnpack covers ` +
+        `**/node_modules/@anthropic-ai/claude-agent-sdk-*/** and that ` +
+        `@anthropic-ai/claude-agent-sdk-win32-x64 is installed in node_modules.`,
+    );
+  }
+
+  const sizeMB = (fs.statSync(found).size / 1024 / 1024).toFixed(1);
+  console.log(`[after-pack] OK win32/x64: claude.exe present (${sizeMB} MB) at ${found}`);
+};
+


### PR DESCRIPTION
## Layer 1 (high-level review)

**1. Necessity — is bundling the binary actually right?**
Yes. The SDK's `claude.exe` is a spawn-based runtime that must exist on disk and be findable by `require.resolve('@anthropic-ai/claude-agent-sdk-win32-x64/claude.exe')`. Without it every session start crashes with "Native CLI binary not found." Alternatives (runtime download / require-user-installs-CLI) violate ccsm's "works out of the box" product direction and the 8-week-to-self-use deadline. Bundling is the correct option.

**2. Better mechanism?**
The standard electron-builder mechanism for shipping native binaries is `asarUnpack` + `files` allowlist — same pattern `better-sqlite3` already uses in this repo. `extraResources` can also place files but breaks the SDK's `require.resolve` path expectation (it resolves relative to `claude-agent-sdk/sdk.mjs`'s neighbouring `node_modules`), forcing SDK monkey-patches. `asarUnpack` is strictly the cleanest option. The `afterPack` hook is not a replacement mechanism — it's a hard assertion to prevent silent miss.

**3. Is this aligned with `op7418/CodePilot`?**
Yes. CodePilot ships its CLI through `electron-builder` + `asarUnpack` putting the binary into `app.asar.unpacked/node_modules/...`. Same pattern, different package name.

**4. Blast radius?**
- Installer size +~250 MB (≈70 MB → ≈138 MB compressed; uncompressed dir ≈573 MB total). Necessary cost.
- One extra unpacked directory; cold-start I/O impact negligible.
- If a future SDK upgrade renames the binary or restructures sub-packages, the asarUnpack glob silently misses → exactly the case `after-pack.cjs` is there to catch.
- Cross-platform release (mac / linux / win-arm64) is **out of scope for this PR** and will land in a follow-up; `win.target` narrowed to x64 only here so `make:win` doesn't try to ship an arm64 installer with no arm64 binary.

## Changes

- `package.json` — `dependencies`: add `@anthropic-ai/claude-agent-sdk@^0.2.120`.
- `package.json` — `build.asarUnpack`: add `**/node_modules/@anthropic-ai/claude-agent-sdk-*/**`.
- `package.json` — `build.files`: explicitly include `node_modules/@anthropic-ai/claude-agent-sdk/**` and `claude-agent-sdk-*/**` so the dist-only file filter doesn't strip them.
- `package.json` — `build.afterPack`: point at `scripts/after-pack.cjs`.
- `package.json` — `build.win.target.arch`: `["x64", "arm64"]` → `["x64"]`. Scope-tightening for this PR.
- `scripts/after-pack.cjs` — new. Verifies `claude.exe` exists at one of the two layouts npm produces; throws with a diagnostic listing if missing. No-ops for non-win32-x64 targets (so dev runs of `make:mac` / `make:linux` don't fail for an orthogonal reason).

## Scope

**Only `win-x64`.** mac, mac-arm64, win-arm64, linux are explicitly out of scope and will be addressed in a follow-up PR. The `after-pack` hook explicitly skips non-win32-x64 targets so it won't false-fail on dev runs of other platforms.

## Verification (local, win32/x64)

```
$ npm run make:win
…
[after-pack] OK win32/x64: claude.exe present (240.2 MB) at
  …\release\win-unpacked\resources\app.asar.unpacked\node_modules\
  @anthropic-ai\claude-agent-sdk\node_modules\@anthropic-ai\
  claude-agent-sdk-win32-x64\claude.exe
• building target=nsis file=release\CCSM-Setup-0.1.0-x64.exe archs=x64
• building block map blockMapFile=release\CCSM-Setup-0.1.0-x64.exe.blockmap
```

| Check | Result |
| --- | --- |
| Installer produced | `release/CCSM-Setup-0.1.0-x64.exe` 144,661,348 B (≈138 MB compressed) |
| Unpacked install size | 573 MB |
| SDK contribution to install | 241 MB |
| `claude.exe` on disk | `app.asar.unpacked/.../claude-agent-sdk-win32-x64/claude.exe` (240.2 MB) |
| Binary listed inside asar (electron asar shim points to unpacked) | yes |
| `CCSM.exe` launches | yes — 4 Electron procs running, ~178 MB main process |
| `npm run typecheck` | passes |
| `npm run lint` | 41 errors / 15 warnings — **all pre-existing on `working`**, none in changed files |
| `npm test` | 12 failing / 836 passing — **all pre-existing on `working`** (better-sqlite3 native binding mismatch in this worktree, unrelated to PR) |

## Known risks / follow-ups

- **Silent SDK upgrade risk**: future SDK release that changes the platform-package naming will break the asarUnpack glob. `after-pack.cjs` turns this into a hard build failure, not a runtime crash.
- **Cross-platform packaging** (mac, mac-arm64, linux, win-arm64): not handled here. Each will need its own platform sub-package install + build-time arch matrix; needs CI plumbing because cross-arch native dep install isn't trivial.
- **Local make:win prerequisites**: contributor needs Python 3.x with `setuptools` (for distutils, since 3.12 dropped it), VS Build Tools, and ideally to drop the `@nodert-win10-au/windows.applicationmodel` source-build issue (currently surfaced via `@ccsm/notify` optional dep). CI release workflow handles all of these via setup-python@v5 and Windows runner. Local workaround for now: temporarily remove `node_modules/@ccsm` and `node_modules/@nodert-win10-au` before `make:win`.
- **`@ccsm/notify` source-build incompat with VS 2022** is unrelated to this PR but blocks local make:win unless the optional dep is removed. Worth a separate fix.

## Test plan

- [x] `make:win` produces installer with claude.exe unpacked at expected path
- [x] `after-pack` hook fires and verifies binary
- [x] `CCSM.exe` from `win-unpacked` launches without crashing
- [ ] Reviewer: install the installer onto a clean machine and start a session that calls into the SDK
- [ ] Reviewer: confirm `after-pack` hook fails the build when asarUnpack glob is broken (stash the asarUnpack line, rerun, expect red)