### PR TITLE
feat(picker): Tab/Shift+Tab cross-section navigation

### DIFF
--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -15,6 +15,7 @@ import {
   dispatchSlashCommand,
   filterSlashCommands,
   loadDynamicCommands,
+  nextSectionIndex,
   type SlashCommand
 } from '../slash-commands/registry';
 import type { ImageAttachment } from '../types';
@@ -626,20 +627,12 @@ export function InputBar({ sessionId }: { sessionId: string }) {
       }
       if (e.key === 'Tab') {
         e.preventDefault();
-        const cmd = filtered[activeIndex];
-        if (cmd) {
-          // Tab = complete-in-place, keep picker open so user can keep
-          // browsing. Insert `/<name>` without trailing space.
-          const next = `/${cmd.name}`;
-          setValue(next);
-          setDraft(sessionId, next);
-          setCaret(next.length);
-          requestAnimationFrame(() => {
-            const el = textareaRef.current;
-            if (!el) return;
-            el.setSelectionRange(next.length, next.length);
-          });
-        }
+        // Tab / Shift+Tab = jump to first row of the next / previous
+        // non-empty section. Wraps at the ends. With ≤1 visible section
+        // the helper returns the current index unchanged.
+        setActiveIndex((i) =>
+          nextSectionIndex(filtered, i, e.shiftKey ? -1 : 1)
+        );
         return;
       }
       if (e.key === 'Enter') {

--- a/src/components/SlashCommandPicker.tsx
+++ b/src/components/SlashCommandPicker.tsx
@@ -201,7 +201,7 @@ export function SlashCommandPicker({
           <kbd className="font-mono">Enter</kbd> {t('slashCommands.select')}
         </span>
         <span>
-          <kbd className="font-mono">Tab</kbd> {t('slashCommands.complete')}
+          <kbd className="font-mono">Tab</kbd> {t('slashCommands.section')}
         </span>
         <span>
           <kbd className="font-mono">Esc</kbd> {t('slashCommands.close')}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -369,7 +369,7 @@ const en = {
     noneHint: 'No matching commands — press Enter to send as a regular message.',
     navigate: 'navigate',
     select: 'select',
-    complete: 'complete',
+    section: 'section',
     close: 'close',
     runsLocally: 'Runs locally — not forwarded to claude.exe',
     clientTag: 'client',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -346,7 +346,7 @@ const zh: EnCatalog = {
     noneHint: '没有匹配的命令 — 按 Enter 作为普通消息发送。',
     navigate: '上下移动',
     select: '选择',
-    complete: '补全',
+    section: '切换分组',
     close: '关闭',
     runsLocally: '本地运行 — 不会转发给 claude.exe',
     clientTag: '本地',

--- a/src/slash-commands/registry.ts
+++ b/src/slash-commands/registry.ts
@@ -264,3 +264,46 @@ export function groupSlashCommands(all: SlashCommand[]): SlashCommandGroup[] {
     .map((source) => ({ source, commands: buckets.get(source) ?? [] }))
     .filter((g) => g.commands.length > 0);
 }
+
+// Cross-section keyboard navigation. Given the current flat highlighted
+// index into `filtered` (the same array fed to `groupSlashCommands`),
+// return the flat index of the FIRST item in the next (`direction: 1`) or
+// previous (`direction: -1`) non-empty group, with wraparound at the ends.
+//
+// Used by Tab / Shift+Tab in the picker so users can hop between the six
+// source sections (built-in / user / project / plugin / skill / agent)
+// without ↓-spamming through dozens of rows. Empty groups are already
+// dropped by `groupSlashCommands`, so wraparound math doesn't need to skip
+// anything beyond what's returned.
+//
+// Returns the input index unchanged when there are 0 or 1 visible groups —
+// nothing to jump to.
+export function nextSectionIndex(
+  filtered: SlashCommand[],
+  currentIndex: number,
+  direction: 1 | -1
+): number {
+  if (filtered.length === 0) return currentIndex;
+  const groups = groupSlashCommands(filtered);
+  if (groups.length <= 1) return currentIndex;
+
+  // Compute the [start, end) flat range of each group, in display order.
+  const ranges: { source: SlashCommandSource; start: number }[] = [];
+  let cursor = 0;
+  for (const g of groups) {
+    ranges.push({ source: g.source, start: cursor });
+    cursor += g.commands.length;
+  }
+
+  // Find which group the current index belongs to.
+  let currentGroup = 0;
+  for (let i = ranges.length - 1; i >= 0; i--) {
+    if (currentIndex >= ranges[i].start) {
+      currentGroup = i;
+      break;
+    }
+  }
+
+  const nextGroup = (currentGroup + direction + ranges.length) % ranges.length;
+  return ranges[nextGroup].start;
+}

--- a/tests/slash-commands-registry.test.ts
+++ b/tests/slash-commands-registry.test.ts
@@ -6,6 +6,7 @@ import {
   parseSlashInvocation,
   findSlashCommand,
   groupSlashCommands,
+  nextSectionIndex,
   type SlashCommand,
 } from '../src/slash-commands/registry';
 
@@ -163,5 +164,78 @@ describe('filterSlashCommands fuzzy matching', () => {
     ];
     const r = filterSlashCommands(merged, 'clear');
     expect(r[0].name).toBe('clear');
+  });
+});
+
+describe('nextSectionIndex', () => {
+  // Two built-ins (clear, compact), then user, project, plugin sections.
+  // Flat layout:
+  //   [0] clear           built-in
+  //   [1] compact         built-in
+  //   [2] u1              user
+  //   [3] u2              user
+  //   [4] p1              project
+  //   [5] pl1             plugin
+  //   [6] pl2             plugin
+  const fixture: SlashCommand[] = [
+    ...BUILT_IN_COMMANDS,
+    mkDynamic('u1', 'user'),
+    mkDynamic('u2', 'user'),
+    mkDynamic('p1', 'project'),
+    mkDynamic('pl1', 'plugin'),
+    mkDynamic('pl2', 'plugin'),
+  ];
+
+  it('Tab from inside built-in jumps to first row of next section (user)', () => {
+    expect(nextSectionIndex(fixture, 0, 1)).toBe(2);
+    expect(nextSectionIndex(fixture, 1, 1)).toBe(2);
+  });
+
+  it('Tab from inside user jumps to first row of project', () => {
+    expect(nextSectionIndex(fixture, 2, 1)).toBe(4);
+    expect(nextSectionIndex(fixture, 3, 1)).toBe(4);
+  });
+
+  it('Tab from the last section wraps to the first section', () => {
+    // Plugin is the last group in fixture; wrap → built-in (idx 0).
+    expect(nextSectionIndex(fixture, 5, 1)).toBe(0);
+    expect(nextSectionIndex(fixture, 6, 1)).toBe(0);
+  });
+
+  it('Shift+Tab from inside a section jumps to the start of the previous section', () => {
+    // From plugin → project.
+    expect(nextSectionIndex(fixture, 6, -1)).toBe(4);
+    // From project → user.
+    expect(nextSectionIndex(fixture, 4, -1)).toBe(2);
+    // From user → built-in.
+    expect(nextSectionIndex(fixture, 2, -1)).toBe(0);
+  });
+
+  it('Shift+Tab from the first section wraps to the last section', () => {
+    expect(nextSectionIndex(fixture, 0, -1)).toBe(5);
+    expect(nextSectionIndex(fixture, 1, -1)).toBe(5);
+  });
+
+  it('skips groups that are empty after filtering', () => {
+    // Filter so only built-in (clear) and plugin (pl1) survive — user /
+    // project / pl2 are gone. Tab from clear (idx 0) should jump straight
+    // to pl1 (idx 1 in the filtered flat list), bypassing the dropped
+    // user / project sections entirely.
+    const filtered = filterSlashCommands(fixture, 'clear').concat(
+      mkDynamic('pl1', 'plugin')
+    );
+    // Sanity: only built-in + plugin remain after groupSlashCommands drops
+    // empty buckets.
+    const groups = groupSlashCommands(filtered);
+    expect(groups.map((g) => g.source)).toEqual(['built-in', 'plugin']);
+    expect(nextSectionIndex(filtered, 0, 1)).toBe(1);
+    expect(nextSectionIndex(filtered, 1, 1)).toBe(0);
+  });
+
+  it('returns the input index when fewer than two sections are visible', () => {
+    const onlyBuiltIn = [...BUILT_IN_COMMANDS];
+    expect(nextSectionIndex(onlyBuiltIn, 0, 1)).toBe(0);
+    expect(nextSectionIndex(onlyBuiltIn, 1, -1)).toBe(1);
+    expect(nextSectionIndex([], 0, 1)).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- Replace `Tab=complete-in-place` with `Tab=jump to first row of next non-empty section` in the slash-command palette; `Shift+Tab` walks backward; both wrap at the ends.
- Closes the keyboard-nav gap PR-E flagged after the picker grew six source-grouped sections (built-in / user / project / plugin / skill / agent) — `↑↓` was the only way to move between groups, painful with ~30+ commands.
- Land the section-boundary math as a pure helper `nextSectionIndex(filtered, currentIndex, direction)` in `src/slash-commands/registry.ts`. InputBar's `onKeyDown` is just wiring; the helper owns range derivation, wraparound, and post-filter empty-group skipping (groups already dropped by `groupSlashCommands`).
- Footer hint copy: `Tab complete` → `Tab section` (en + zh). No new i18n keys; the `complete` value was repurposed and renamed to `section`. `↑↓` still browses inside a section, `Enter` still commits, `Esc` still closes.

## Layer 1 notes
- Considered keeping `Tab=complete` and using a different shortcut for section nav; rejected because Enter already commits the highlighted row, so `Tab=complete` was a near-duplicate. The new behavior is the dominant ask.
- VS Code extension uses a native picker with no analogous six-section grouping, so there is no upstream behavior to mirror; this is a CCSM-side affordance for our richer palette.

## Test plan
- [x] `npx vitest run tests/slash-commands-registry.test.ts tests/slash-command-picker.test.tsx` — 34/34 pass, including 7 new `nextSectionIndex` cases.
- [x] `npx tsc --noEmit` and `npx tsc --noEmit -p tsconfig.electron.json` — clean.
- [ ] Reviewer dev smoke: type `/` → palette opens → `Tab` jumps to first row of the next section → `Shift+Tab` walks back → wrap at both ends → filter to `cl` (only built-in matches survive) → `Tab` no-ops since one section visible.

> Note: dev smoke not run by author — `better-sqlite3` native build fails in this environment (Python toolchain missing). Logic is fully exercised by the new helper tests; reviewer to confirm in a built dev shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)