### PR TITLE
feat: load session history from CLI JSONL, delete messages table (PR-H)

### DIFF
--- a/electron/__tests__/db-hardening.test.ts
+++ b/electron/__tests__/db-hardening.test.ts
@@ -23,37 +23,6 @@ beforeEach(async () => {
   await freshDb();
 });
 
-describe('db hardening: corrupt JSON in messages', () => {
-  it('loadMessages skips a row whose content is not valid JSON', async () => {
-    const mod = await freshDb();
-    const { saveMessages, loadMessages, getDb } = mod;
-
-    saveMessages('s-1', [
-      { id: 'b1', kind: 'user', text: 'good before' },
-      { id: 'b2', kind: 'user', text: 'good after' }
-    ]);
-
-    // Inject corruption directly into the row that already exists. Bypasses
-    // the cached prepared statements so we know loadMessages re-reads the
-    // raw column on each call.
-    getDb().prepare('UPDATE messages SET content = ? WHERE id = ?').run('{not valid json', 'b1');
-
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    let rows: unknown[] = [];
-    expect(() => {
-      rows = loadMessages('s-1');
-    }).not.toThrow();
-    expect(rows).toHaveLength(1);
-    expect((rows[0] as { id: string }).id).toBe('b2');
-    expect(warn).toHaveBeenCalledWith(
-      '[db] corrupt message row sessionId=%s id=%s',
-      's-1',
-      'b1'
-    );
-    warn.mockRestore();
-  });
-});
-
 describe('db hardening: startup integrity check', () => {
   it('initDb backs up a corrupt file and opens a fresh empty database', async () => {
     const mod = await freshDb();
@@ -66,7 +35,7 @@ describe('db hardening: startup integrity check', () => {
     fs.writeFileSync(file, Buffer.from('not a sqlite database, just bytes'));
 
     const err = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { initDb, loadMessages, saveState, loadState } = mod;
+    const { initDb, saveState, loadState } = mod;
     expect(() => initDb()).not.toThrow();
 
     // Original file got renamed aside.
@@ -74,8 +43,7 @@ describe('db hardening: startup integrity check', () => {
     const backup = siblings.find((n) => n.startsWith('ccsm.db.corrupt-'));
     expect(backup, `expected a *.corrupt-* backup, saw ${siblings.join(', ')}`).toBeTruthy();
 
-    // Fresh DB is usable end-to-end.
-    expect(loadMessages('any')).toEqual([]);
+    // Fresh DB is usable end-to-end via the surviving app_state surface.
     saveState('hello', 'world');
     expect(loadState('hello')).toBe('world');
 
@@ -97,20 +65,21 @@ describe('db hardening: schema versioning', () => {
 describe('db hardening: prepared statement cache', () => {
   it('reuses the same Statement across repeated calls', async () => {
     const mod = await freshDb();
-    const { getDb, loadMessages, saveState } = mod;
+    const { getDb, saveState, loadState } = mod;
 
     const realPrepare = getDb().prepare.bind(getDb());
     const spy = vi.spyOn(getDb(), 'prepare').mockImplementation((sql: string) => realPrepare(sql));
 
-    // First touch compiles.
-    loadMessages('s-x');
+    // First touch compiles the prepared statements for the only surviving
+    // user-side surface (app_state).
     saveState('k', 'v');
+    loadState('k');
     const callsAfterFirst = spy.mock.calls.length;
 
     // Subsequent touches must NOT recompile — the cache should serve them.
     for (let i = 0; i < 5; i++) {
-      loadMessages('s-x');
       saveState('k', `v${i}`);
+      loadState('k');
     }
     expect(spy.mock.calls.length).toBe(callsAfterFirst);
 

--- a/electron/__tests__/db.test.ts
+++ b/electron/__tests__/db.test.ts
@@ -24,50 +24,6 @@ beforeEach(async () => {
   await freshDb();
 });
 
-describe('db: messages table', () => {
-  it('returns [] for an unknown session', async () => {
-    const { loadMessages } = await freshDb();
-    expect(loadMessages('s-none')).toEqual([]);
-  });
-
-  it('roundtrips blocks in insertion order', async () => {
-    const { loadMessages, saveMessages } = await freshDb();
-    const blocks = [
-      { id: 'b1', kind: 'user', text: 'hello' },
-      { id: 'b2', kind: 'assistant', text: 'hi' },
-      { id: 'b3', kind: 'tool', name: 'Bash', brief: 'ls' }
-    ];
-    saveMessages('s-1', blocks);
-    expect(loadMessages('s-1')).toEqual(blocks);
-  });
-
-  it('bulk-save replaces prior rows for that session', async () => {
-    const { loadMessages, saveMessages } = await freshDb();
-    saveMessages('s-1', [{ id: 'a', kind: 'user', text: 'first' }]);
-    saveMessages('s-1', [
-      { id: 'b', kind: 'user', text: 'second' },
-      { id: 'c', kind: 'assistant', text: 'reply' }
-    ]);
-    const rows = loadMessages('s-1') as Array<{ id: string }>;
-    expect(rows.map((r) => r.id)).toEqual(['b', 'c']);
-  });
-
-  it('isolates rows by sessionId', async () => {
-    const { loadMessages, saveMessages } = await freshDb();
-    saveMessages('s-A', [{ id: 'x', kind: 'user', text: 'A' }]);
-    saveMessages('s-B', [{ id: 'y', kind: 'user', text: 'B' }]);
-    expect((loadMessages('s-A') as Array<{ id: string }>).map((r) => r.id)).toEqual(['x']);
-    expect((loadMessages('s-B') as Array<{ id: string }>).map((r) => r.id)).toEqual(['y']);
-  });
-
-  it('saving [] clears existing rows (used on delete)', async () => {
-    const { loadMessages, saveMessages } = await freshDb();
-    saveMessages('s-1', [{ id: 'a', kind: 'user', text: 'hi' }]);
-    saveMessages('s-1', []);
-    expect(loadMessages('s-1')).toEqual([]);
-  });
-});
-
 describe('db: claudeBinPath', () => {
   it('returns null when unset', async () => {
     const { loadClaudeBinPath } = await freshDb();

--- a/electron/__tests__/jsonl-loader.test.ts
+++ b/electron/__tests__/jsonl-loader.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+
+// Sandbox HOME so PROJECTS_ROOT in jsonl-loader resolves into a temp dir.
+// MUST mutate env BEFORE the module imports — vitest hoists static `import`
+// statements above all top-level code, so we use a dynamic import inside
+// `beforeAll` and reset modules to ensure module-level constants snapshot
+// the override.
+const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ccsm-jsonl-test-'));
+const origHome = process.env.HOME;
+const origUserProfile = process.env.USERPROFILE;
+
+let loadHistoryFromJsonl: typeof import('../jsonl-loader').loadHistoryFromJsonl;
+let projectKeyFromCwd: typeof import('../jsonl-loader').projectKeyFromCwd;
+
+beforeAll(async () => {
+  process.env.HOME = tmpHome;
+  process.env.USERPROFILE = tmpHome;
+  vi.resetModules();
+  const mod = await import('../jsonl-loader');
+  loadHistoryFromJsonl = mod.loadHistoryFromJsonl;
+  projectKeyFromCwd = mod.projectKeyFromCwd;
+});
+
+beforeEach(() => {
+  // Make sure fixtures from a prior test don't leak between cases.
+  const root = path.join(tmpHome, '.claude', 'projects');
+  if (fs.existsSync(root)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+afterEach(() => {
+  // No-op; cleanup is in beforeEach so the fixtures of the LAST test in the
+  // file are still visible if a developer wants to inspect them post-run.
+});
+
+// Cleanup at process exit; restores HOME so a subsequent test file in the
+// same vitest run sees its own environment.
+process.on('exit', () => {
+  if (origHome !== undefined) process.env.HOME = origHome;
+  else delete process.env.HOME;
+  if (origUserProfile !== undefined) process.env.USERPROFILE = origUserProfile;
+  else delete process.env.USERPROFILE;
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+function seedJsonl(cwd: string, sessionId: string, lines: string[]) {
+  const key = projectKeyFromCwd(cwd);
+  const dir = path.join(tmpHome, '.claude', 'projects', key);
+  fs.mkdirSync(dir, { recursive: true });
+  const body = lines.length === 0 ? '' : lines.join('\n') + '\n';
+  fs.writeFileSync(path.join(dir, `${sessionId}.jsonl`), body);
+}
+
+describe('projectKeyFromCwd', () => {
+  it('replaces / \\ : with -', () => {
+    expect(projectKeyFromCwd('C:\\Users\\x\\proj')).toBe('C--Users-x-proj');
+    expect(projectKeyFromCwd('/Users/x/proj')).toBe('-Users-x-proj');
+    expect(projectKeyFromCwd('/tmp/y')).toBe('-tmp-y');
+  });
+  it('returns "" for empty / non-string input', () => {
+    expect(projectKeyFromCwd('')).toBe('');
+    expect(projectKeyFromCwd(undefined as unknown as string)).toBe('');
+  });
+});
+
+describe('loadHistoryFromJsonl', () => {
+  it('returns ok:true with parsed frames for a valid file', async () => {
+    seedJsonl('/tmp/proj', 'sid-1', [
+      JSON.stringify({ type: 'user', uuid: 'u1', message: { content: 'hello' } }),
+      JSON.stringify({ type: 'assistant', message: { id: 'a1', content: [{ type: 'text', text: 'hi' }] } })
+    ]);
+    const r = await loadHistoryFromJsonl('/tmp/proj', 'sid-1');
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.frames).toHaveLength(2);
+      expect((r.frames[0] as { type: string }).type).toBe('user');
+      expect((r.frames[1] as { type: string }).type).toBe('assistant');
+    }
+  });
+
+  it('returns ok:true frames=[] when the file is empty', async () => {
+    seedJsonl('/tmp/proj', 'sid-empty', []);
+    const r = await loadHistoryFromJsonl('/tmp/proj', 'sid-empty');
+    expect(r).toEqual({ ok: true, frames: [] });
+  });
+
+  it('returns not_found when the JSONL does not exist', async () => {
+    const r = await loadHistoryFromJsonl('/tmp/missing', 'no-such-sid');
+    expect(r).toEqual({ ok: false, error: 'not_found' });
+  });
+
+  it('skips malformed lines but keeps the valid ones', async () => {
+    seedJsonl('/tmp/proj', 'sid-mix', [
+      JSON.stringify({ type: 'user', uuid: 'u-good-1' }),
+      'not json at all',
+      JSON.stringify({ type: 'assistant', message: { id: 'a-good' } }),
+      '{ broken: ',
+      JSON.stringify({ type: 'user', uuid: 'u-good-2' })
+    ]);
+    const r = await loadHistoryFromJsonl('/tmp/proj', 'sid-mix');
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.frames).toHaveLength(3);
+      expect((r.frames[0] as { uuid: string }).uuid).toBe('u-good-1');
+      expect((r.frames[1] as { type: string }).type).toBe('assistant');
+      expect((r.frames[2] as { uuid: string }).uuid).toBe('u-good-2');
+    }
+  });
+
+  it('rejects path traversal in sessionId', async () => {
+    seedJsonl('/tmp/proj', 'sid-x', [JSON.stringify({ type: 'user' })]);
+    // basename strips traversal — `..` collapses to `..`, which we explicitly
+    // reject. Empty / dot-only sids also rejected.
+    const r1 = await loadHistoryFromJsonl('/tmp/proj', '../../../etc/passwd');
+    expect(r1.ok).toBe(false);
+    const r2 = await loadHistoryFromJsonl('', 'sid-x');
+    expect(r2.ok).toBe(false);
+    if (!r2.ok) expect(r2.error).toBe('invalid_args');
+  });
+
+  it('returns invalid_args for non-string args', async () => {
+    const r = await loadHistoryFromJsonl(undefined as unknown as string, 'sid');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toBe('invalid_args');
+  });
+});

--- a/electron/db.ts
+++ b/electron/db.ts
@@ -19,32 +19,22 @@ const SCHEMA_VERSION = 1;
 // ── Cached prepared statements ───────────────────────────────────────────────
 // better-sqlite3 caches compiled SQL inside each Statement object, but the
 // JavaScript-side allocation/lookup still costs ~10 microseconds per call.
-// For hot paths (loadMessages on session switch, saveState on every keystroke
-// in the composer draft persister) that adds up. Cache the Statement once
-// per process lifetime; reset to null when the underlying db closes so the
-// next initDb() rebuilds them.
+// For hot paths (saveState on every keystroke in the composer draft persister)
+// that adds up. Cache the Statement once per process lifetime; reset to null
+// when the underlying db closes so the next initDb() rebuilds them.
 type PreparedCache = {
-  loadMessages: Database.Statement<[string]> | null;
-  deleteMessagesForSession: Database.Statement<[string]> | null;
-  insertMessage: Database.Statement<[string, string, string, string, number]> | null;
   loadState: Database.Statement<[string]> | null;
   upsertState: Database.Statement<[string, string, number]> | null;
   deleteState: Database.Statement<[string]> | null;
 };
 
 const stmts: PreparedCache = {
-  loadMessages: null,
-  deleteMessagesForSession: null,
-  insertMessage: null,
   loadState: null,
   upsertState: null,
   deleteState: null
 };
 
 function resetStmts(): void {
-  stmts.loadMessages = null;
-  stmts.deleteMessagesForSession = null;
-  stmts.insertMessage = null;
   stmts.loadState = null;
   stmts.upsertState = null;
   stmts.deleteState = null;
@@ -56,14 +46,6 @@ const SCHEMA_SQL = `
     value TEXT NOT NULL,
     updated_at INTEGER NOT NULL
   );
-  CREATE TABLE IF NOT EXISTS messages (
-    id TEXT PRIMARY KEY,
-    sessionId TEXT NOT NULL,
-    kind TEXT NOT NULL,
-    content TEXT NOT NULL,
-    createdAt INTEGER NOT NULL
-  );
-  CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(sessionId);
 `;
 
 /**
@@ -165,64 +147,28 @@ export function initDb(): Database.Database {
     );
   }
 
-  // Drop legacy endpoints tables if they exist from a pre-refactor install.
-  // The app no longer reads them — connection config now comes from
-  // ~/.claude/settings.json. Cheap to issue at every boot; SQLite ignores
-  // missing tables.
+  // Drop legacy tables that earlier ccsm versions wrote but the app no
+  // longer reads:
+  //   - `endpoints` / `endpoint_models`: connection config now comes from
+  //     ~/.claude/settings.json.
+  //   - `messages`: session history now reads from CLI's
+  //     ~/.claude/projects/<key>/<sid>.jsonl (PR-H). The SQLite copy was a
+  //     redundant secondary write. We deliberately do NOT migrate the old
+  //     rows — for users who never persisted via ccsm pre-rename, JSONL
+  //     already has the canonical history; for users who somehow have rows
+  //     in `messages` but missing JSONL, a one-line fallback isn't worth
+  //     the migration footprint (per project decision: "no migration for
+  //     old users").
+  // Cheap to issue at every boot; SQLite ignores missing tables.
   handle.exec(`
     DROP TABLE IF EXISTS endpoint_models;
     DROP TABLE IF EXISTS endpoints;
+    DROP INDEX IF EXISTS idx_messages_session;
+    DROP TABLE IF EXISTS messages;
   `);
 
   db = handle;
   return db;
-}
-
-export function loadMessages(sessionId: string): unknown[] {
-  const d = initDb();
-  if (!stmts.loadMessages) {
-    stmts.loadMessages = d.prepare(
-      'SELECT id, content FROM messages WHERE sessionId = ? ORDER BY createdAt ASC'
-    );
-  }
-  const rows = stmts.loadMessages.all(sessionId) as Array<{ id: string; content: string }>;
-  // A corrupt or hand-edited row should not crash the entire session load —
-  // skip the offender and surface a console warning so we can grep logs
-  // post-mortem. The user sees a session with N-1 messages, not a blank
-  // pane and a stuck "Loading…" spinner.
-  const out: unknown[] = [];
-  for (const r of rows) {
-    try {
-      out.push(JSON.parse(r.content));
-    } catch {
-      console.warn('[db] corrupt message row sessionId=%s id=%s', sessionId, r.id);
-    }
-  }
-  return out;
-}
-
-export function saveMessages(sessionId: string, blocks: Array<{ id: string; kind: string }>): void {
-  const d = initDb();
-  if (!stmts.deleteMessagesForSession) {
-    stmts.deleteMessagesForSession = d.prepare('DELETE FROM messages WHERE sessionId = ?');
-  }
-  if (!stmts.insertMessage) {
-    stmts.insertMessage = d.prepare(
-      'INSERT INTO messages (id, sessionId, kind, content, createdAt) VALUES (?, ?, ?, ?, ?)'
-    );
-  }
-  const del = stmts.deleteMessagesForSession;
-  const ins = stmts.insertMessage;
-  const tx = d.transaction(() => {
-    del.run(sessionId);
-    const now = Date.now();
-    blocks.forEach((block, i) => {
-      // Use index-based createdAt tiebreaker so ordering is stable even when
-      // many blocks land in the same millisecond.
-      ins.run(block.id, sessionId, block.kind, JSON.stringify(block), now + i);
-    });
-  });
-  tx();
 }
 
 // Test-only: swap in an in-memory database. Never call from app code.

--- a/electron/jsonl-loader.ts
+++ b/electron/jsonl-loader.ts
@@ -1,0 +1,122 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import * as readline from 'readline';
+
+/**
+ * Stream-parse a session's JSONL transcript from `~/.claude/projects/<key>/<sid>.jsonl`
+ * and return the raw frames (one per non-empty line). The CLI / Agent SDK
+ * is the writer — ccsm just reads. This replaces the SQLite `messages`
+ * table that ccsm used to maintain alongside the on-disk transcript: the
+ * SQLite copy was always a redundant secondary write of data the CLI was
+ * already persisting. Renderer projects these frames into MessageBlock via
+ * `framesToBlocks` (same path as the import flow).
+ *
+ * Returned shape is `unknown[]`: each element is whatever JSON.parse of one
+ * JSONL line yielded. The renderer's `framesToBlocks` already tolerates
+ * mixed/unknown frame types and silently no-ops on anything it doesn't
+ * recognise, so we don't pre-filter here. Malformed lines are skipped with
+ * a console warning rather than aborting the whole load — a single bad
+ * line shouldn't blank an otherwise-valid session.
+ */
+const PROJECTS_ROOT = path.join(os.homedir(), '.claude', 'projects');
+
+// Cap per session. Mirrors the cap in `import-history.ts` — well past any
+// realistic conversation length while still bounding memory if a JSONL
+// happens to be pathological. Same value, same rationale.
+const MAX_FRAMES = 50_000;
+
+/**
+ * Convert a session's `cwd` into the project-key folder name the CLI uses
+ * under `~/.claude/projects/`. The CLI's slug rule (verified empirically
+ * against a real `~/.claude/projects/` listing on Windows + macOS) replaces
+ * `/`, `\`, and `:` with `-`. Examples:
+ *   `C:\Users\jiahuigu\ccsm-research\ccsm` → `C--Users-jiahuigu-ccsm-research-ccsm`
+ *   `/Users/x/proj`                        → `-Users-x-proj`
+ * Exported for unit testing — also used on the renderer side via IPC so we
+ * keep the slug logic in exactly one place.
+ */
+export function projectKeyFromCwd(cwd: string): string {
+  if (!cwd || typeof cwd !== 'string') return '';
+  return cwd.replace(/[\\/:]/g, '-');
+}
+
+export type LoadHistoryResult =
+  | { ok: true; frames: unknown[] }
+  | { ok: false; error: 'invalid_args' | 'not_found' | 'read_error'; detail?: string };
+
+/**
+ * Load a session's JSONL frames given its `cwd` (used to derive the project
+ * folder) and `sessionId` (the JSONL filename, sans extension). Returns a
+ * tagged result so the renderer can distinguish "no transcript yet" (newly
+ * spawned session that hasn't received its first frame) from a real read
+ * error (permission, malformed path).
+ *
+ *   - `not_found` — file doesn't exist (newly spawned session, or the user
+ *     never ran this session through the CLI). Renderer treats as empty.
+ *   - `read_error` — fs error other than ENOENT. Renderer surfaces via
+ *     `LoadHistoryErrorBlock`.
+ */
+export async function loadHistoryFromJsonl(
+  cwd: string,
+  sessionId: string
+): Promise<LoadHistoryResult> {
+  // Reject any path component that would let a malicious renderer break out
+  // of `~/.claude/projects/`. Same defense-in-depth as `import-history.ts`.
+  const safeKey = path.basename(projectKeyFromCwd(cwd));
+  const safeSid = path.basename(String(sessionId ?? ''));
+  if (!safeKey || !safeSid) return { ok: false, error: 'invalid_args' };
+  if (safeKey.includes('..') || safeSid.includes('..')) {
+    return { ok: false, error: 'invalid_args' };
+  }
+  const file = path.join(PROJECTS_ROOT, safeKey, `${safeSid}.jsonl`);
+  const resolved = path.resolve(file);
+  if (!resolved.startsWith(path.resolve(PROJECTS_ROOT) + path.sep)) {
+    return { ok: false, error: 'invalid_args' };
+  }
+  let stat: fs.Stats;
+  try {
+    stat = await fs.promises.stat(resolved);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code === 'ENOENT') return { ok: false, error: 'not_found' };
+    return { ok: false, error: 'read_error', detail: code ?? String(err) };
+  }
+  if (!stat.isFile()) return { ok: false, error: 'not_found' };
+
+  return new Promise((resolve) => {
+    const stream = fs.createReadStream(resolved, { encoding: 'utf8' });
+    const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+    const out: unknown[] = [];
+    let count = 0;
+    let errored = false;
+    const finish = () => {
+      rl.removeAllListeners();
+      stream.destroy();
+      if (errored) return; // already resolved
+      resolve({ ok: true, frames: out });
+    };
+    rl.on('line', (line) => {
+      if (!line) return;
+      if (count >= MAX_FRAMES) {
+        finish();
+        return;
+      }
+      count++;
+      try {
+        out.push(JSON.parse(line));
+      } catch {
+        // Skip malformed lines — same policy as scan / import readers.
+      }
+    });
+    rl.on('close', finish);
+    stream.on('error', (err) => {
+      if (errored) return;
+      errored = true;
+      rl.removeAllListeners();
+      stream.destroy();
+      const code = (err as NodeJS.ErrnoException)?.code;
+      resolve({ ok: false, error: 'read_error', detail: code ?? err.message });
+    });
+  });
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -7,12 +7,11 @@ import {
   initDb,
   loadState,
   saveState,
-  loadMessages,
-  saveMessages,
   closeDb,
   loadClaudeBinPath,
   saveClaudeBinPath,
 } from './db';
+import { loadHistoryFromJsonl } from './jsonl-loader';
 import { validateSaveStateInput } from './db-validate';
 
 // Reads the user's opt-out preference for crash reporting from app_state.
@@ -515,51 +514,30 @@ app.whenReady().then(() => {
       return { ok: true };
     }
   );
-  ipcMain.handle('db:loadMessages', (e, sessionId: string) => {
-    if (!fromMainFrame(e)) return [];
-    return loadMessages(sessionId);
-  });
-  // Cap renderer-supplied message payloads. The DB column is unbounded TEXT,
-  // so a buggy or malicious renderer could otherwise pin the WAL with
-  // gigabytes of JSON and balloon `~/.config/.../ccsm.db` past disk
-  // budget. The caps below are well above any legitimate session:
-  //   - 64 chars per sessionId (sessions are uuid-ish ~36 chars)
-  //   - 50_000 blocks per session (current cap on history retention)
-  //   - 1 MB per individual block JSON (a single block this large is a bug)
-  const MAX_SESSION_ID_LEN = 64;
-  const MAX_BLOCKS = 50_000;
-  const MAX_BLOCK_BYTES = 1_000_000;
+  // Session message history is no longer persisted by ccsm — the CLI/Agent
+  // SDK already writes every frame to `~/.claude/projects/<key>/<sid>.jsonl`,
+  // and ccsm now reads from there via `agent:load-history`. The previous
+  // `db:loadMessages` / `db:saveMessages` IPC + SQLite `messages` table were
+  // a redundant secondary copy.
   ipcMain.handle(
-    'db:saveMessages',
-    (
-      e,
-      sessionId: string,
-      blocks: Array<{ id: string; kind: string }>
-    ): { ok: true } | { ok: false; error: string } => {
-      if (!fromMainFrame(e)) return { ok: false, error: 'rejected' };
-      if (typeof sessionId !== 'string' || sessionId.length > MAX_SESSION_ID_LEN) {
-        return { ok: false, error: 'payload_too_large' };
+    'agent:load-history',
+    async (e, cwd: unknown, sessionId: unknown) => {
+      if (!fromMainFrame(e)) {
+        return { ok: false, error: 'rejected' as const };
       }
-      if (!Array.isArray(blocks) || blocks.length > MAX_BLOCKS) {
-        return { ok: false, error: 'payload_too_large' };
+      if (typeof cwd !== 'string' || typeof sessionId !== 'string') {
+        return { ok: false, error: 'invalid_args' as const };
       }
-      const filtered: Array<{ id: string; kind: string }> = [];
-      for (const b of blocks) {
-        try {
-          const json = JSON.stringify(b);
-          if (json.length > MAX_BLOCK_BYTES) {
-            console.warn(
-              `[main] db:saveMessages dropping oversized block (${json.length} bytes) for session=${sessionId}`
-            );
-            continue;
-          }
-          filtered.push(b);
-        } catch {
-          console.warn('[main] db:saveMessages dropping unserializable block');
-        }
+      try {
+        return await loadHistoryFromJsonl(cwd, sessionId);
+      } catch (err) {
+        console.warn('[main] agent:load-history failed', err);
+        return {
+          ok: false as const,
+          error: 'read_error' as const,
+          detail: err instanceof Error ? err.message : String(err)
+        };
       }
-      saveMessages(sessionId, filtered);
-      return { ok: true };
     }
   );
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -78,13 +78,23 @@ const api = {
       ipcRenderer.send('ccsm:set-language', lang);
     }
   },
-  loadMessages: (sessionId: string): Promise<unknown[]> =>
-    ipcRenderer.invoke('db:loadMessages', sessionId),
-  saveMessages: (
-    sessionId: string,
-    blocks: Array<{ id: string; kind: string }>
-  ): Promise<{ ok: true } | { ok: false; error: string }> =>
-    ipcRenderer.invoke('db:saveMessages', sessionId, blocks),
+  /**
+   * Load a session's message history from the CLI's on-disk JSONL transcript
+   * (`~/.claude/projects/<key>/<sid>.jsonl`). Returns a tagged result so the
+   * renderer can distinguish "no transcript yet" (e.g. fresh session before
+   * the first frame lands) from a real read error. The renderer projects
+   * the raw frames through `framesToBlocks` to get its MessageBlock[].
+   * Replaces the previous `db:loadMessages` / `db:saveMessages` round-trip
+   * which mirrored CLI's transcript into ccsm's SQLite (PR-H removed that
+   * redundant copy).
+   */
+  loadHistory: (
+    cwd: string,
+    sessionId: string
+  ): Promise<
+    | { ok: true; frames: unknown[] }
+    | { ok: false; error: string; detail?: string }
+  > => ipcRenderer.invoke('agent:load-history', cwd, sessionId),
   getVersion: (): Promise<string> => ipcRenderer.invoke('app:getVersion'),
   pickDirectory: (): Promise<string | null> => ipcRenderer.invoke('dialog:pickDirectory'),
   saveFile: (

--- a/src/agent/lifecycle.ts
+++ b/src/agent/lifecycle.ts
@@ -262,13 +262,11 @@ export function subscribeAgentEvents(): void {
         outputTokens: usage.output_tokens ?? 0,
         costUsd: typeof r.total_cost_usd === 'number' ? r.total_cost_usd : 0
       });
-      // Persist the finalized turn so reloading the app restores history.
-      // Saving on `result` rather than on every delta avoids writing partial
-      // streaming blocks; the bulk DELETE+INSERT is idempotent.
-      const blocks = useStore.getState().messagesBySession[e.sessionId];
-      if (blocks && blocks.length > 0 && typeof window.ccsm?.saveMessages === 'function') {
-        void window.ccsm.saveMessages(e.sessionId, blocks);
-      }
+      // PR-H: ccsm no longer persists message history. The CLI / Agent SDK
+      // already writes every frame to ~/.claude/projects/<key>/<sid>.jsonl
+      // as it streams; we just read from there on load. The previous
+      // `saveMessages` call here was a redundant secondary write that
+      // mirrored the SDK's own transcript into ccsm's SQLite.
       // `turn_done` notification policy: only ping when the turn meaningfully
       // consumed the user's patience — long (>15s), or errored, or this
       // session isn't the one being watched. Fast, successful, focused turns

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -79,11 +79,20 @@ declare global {
         getSystemLocale: () => Promise<string | undefined>;
         setLanguage: (l: 'en' | 'zh') => void;
       };
-      loadMessages: (sessionId: string) => Promise<unknown[]>;
-      saveMessages: (
-        sessionId: string,
-        blocks: Array<{ id: string; kind: string }>
-      ) => Promise<{ ok: true } | { ok: false; error: string }>;
+      /**
+       * Load a session's message history from the CLI's JSONL transcript at
+       * `~/.claude/projects/<projectKey(cwd)>/<sessionId>.jsonl`. The
+       * renderer projects the returned frames through `framesToBlocks`. PR-H
+       * removed the previous SQLite-backed `loadMessages`/`saveMessages`
+       * pair — ccsm no longer maintains a redundant secondary copy.
+       */
+      loadHistory: (
+        cwd: string,
+        sessionId: string
+      ) => Promise<
+        | { ok: true; frames: unknown[] }
+        | { ok: false; error: string; detail?: string }
+      >;
       getVersion: () => Promise<string>;
       pickDirectory: () => Promise<string | null>;
       saveFile: (args: {

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -1083,12 +1083,10 @@ export const useStore = create<State & Actions>((set, get) => ({
               [id]: blocks
             }
           }));
-          // Persist to our DB so subsequent loads come from sqlite without
-          // re-parsing the .jsonl. saveMessages is a bulk DELETE+INSERT and
-          // is idempotent.
-          if (typeof api.saveMessages === 'function') {
-            void api.saveMessages(id, blocks);
-          }
+          // PR-H: ccsm no longer mirrors history into SQLite, so on import
+          // we just hydrate the in-memory store. Subsequent loads come
+          // straight from the CLI's JSONL via `loadHistory`, which is the
+          // same source we just read from.
         } catch (err) {
           // eslint-disable-next-line no-console
           console.warn('[store] importSession history load failed', err);
@@ -1184,9 +1182,12 @@ export const useStore = create<State & Actions>((set, get) => ({
         messageQueues: nextQueues
       };
     });
-    // Wipe the persisted rows so a deleted session can't resurrect its
-    // history if a new session happens to reuse the id.
-    void window.ccsm?.saveMessages(id, []);
+    // PR-H: ccsm no longer persists message history. The CLI's JSONL at
+    // ~/.claude/projects/<key>/<sid>.jsonl is the canonical record and we
+    // intentionally don't delete it here — losing the user's CLI-side
+    // transcript when they remove a session from ccsm's UI would be a
+    // surprising, lossy side-effect. The session is gone from ccsm's view,
+    // which is what the user asked for.
     // Also drop any persisted draft for this session.
     deleteDrafts([id]);
     return snapshot;
@@ -1232,12 +1233,9 @@ export const useStore = create<State & Actions>((set, get) => ({
         statsBySession
       };
     });
-    // Restore persisted history so a restart after undo retains the
-    // conversation. Empty arrays are skipped — saveMessages([]) is the
-    // wipe path used by deleteSession.
-    if (snapshot.messages && snapshot.messages.length > 0) {
-      void window.ccsm?.saveMessages(snapshot.session.id, snapshot.messages);
-    }
+    // PR-H: history lives in the CLI's JSONL; restore is a no-op for it.
+    // The in-memory reseed above is what makes undo instant; on a future
+    // page reload, history reloads from the JSONL like any other session.
     restoreDraft(snapshot.session.id, snapshot.draft);
   },
 
@@ -1414,7 +1412,8 @@ export const useStore = create<State & Actions>((set, get) => ({
         delete nextRunning[did];
         delete nextInterrupted[did];
         delete nextQueues[did];
-        void window.ccsm?.saveMessages(did, []);
+        // PR-H: ccsm no longer persists per-session history; nothing to wipe.
+        // The CLI's JSONL stays on disk, mirroring deleteSession's policy.
       }
       return {
         groups: s.groups.filter((g) => g.id !== id),
@@ -1479,11 +1478,9 @@ export const useStore = create<State & Actions>((set, get) => ({
         statsBySession
       };
     });
-    // Re-persist messages + drafts for each restored session.
+    // PR-H: snapshot.messages is in-memory state; the JSONL on disk is
+    // unchanged and remains the source of truth for future reloads.
     for (const snap of snapshot.sessions) {
-      if (snap.messages && snap.messages.length > 0) {
-        void window.ccsm?.saveMessages(snap.session.id, snap.messages);
-      }
       restoreDraft(snap.session.id, snap.draft);
     }
   },
@@ -1702,8 +1699,9 @@ export const useStore = create<State & Actions>((set, get) => ({
         statsBySession: nextStats
       };
     });
-    // Wipe persisted transcript so a reload doesn't resurrect history.
-    void window.ccsm?.saveMessages(sessionId, []);
+    // PR-H: ccsm no longer persists message history. The CLI's JSONL stays
+    // on disk untouched — a reset clears ccsm's view but doesn't delete the
+    // user's CLI-side transcript.
   },
 
   replaceMessages: (sessionId, blocks) => {
@@ -1732,8 +1730,29 @@ export const useStore = create<State & Actions>((set, get) => ({
 
   loadMessages: async (sessionId) => {
     const api = window.ccsm;
-    if (!api || typeof api.loadMessages !== 'function') return;
+    if (!api || typeof api.loadHistory !== 'function') return;
     if (inFlightLoads.has(sessionId)) return;
+    // Look up the session so we can derive the on-disk JSONL location.
+    // CLI writes to ~/.claude/projects/<slug(cwd)>/<sid>.jsonl; we need
+    // both cwd and the right sid (resumed imports keep the original CLI
+    // sid in `resumeSessionId`; fresh sessions use ccsm's local id which
+    // we forwarded to the SDK as its `sessionId`, so the filenames match).
+    const session = get().sessions.find((s) => s.id === sessionId);
+    if (!session) return;
+    const cwd = session.cwd ?? '';
+    const sidOnDisk = session.resumeSessionId || session.id;
+    if (!cwd) {
+      // No cwd → no project key → can't locate the JSONL. Treat as empty
+      // (don't surface an error; cwd-less sessions are a transient state
+      // during creation and the renderer handles `[]` gracefully).
+      set((s) => ({
+        messagesBySession:
+          sessionId in s.messagesBySession
+            ? s.messagesBySession
+            : { ...s.messagesBySession, [sessionId]: [] }
+      }));
+      return;
+    }
     inFlightLoads.add(sessionId);
     // Clear any stale load error for this session before attempting.
     set((s) => {
@@ -1743,18 +1762,14 @@ export const useStore = create<State & Actions>((set, get) => ({
       return { loadMessageErrors: next };
     });
     try {
-      let rows: MessageBlock[] = [];
+      let result: Awaited<ReturnType<typeof api.loadHistory>>;
       try {
-        rows = (await api.loadMessages(sessionId)) as MessageBlock[];
+        result = await api.loadHistory(cwd, sidOnDisk);
       } catch (err) {
-        // IPC failure (db locked, disk full, schema mismatch). Without a
-        // sentinel write, every subsequent selectSession would re-trigger
-        // the load — an infinite retry loop on a permanent failure. Seed
-        // an empty array so the key is "known" and we leave a breadcrumb
-        // for the user / Sentry instead of failing silently. Also surface
-        // the failure as an inline error so the user sees "Failed to load
-        // history — Retry" in the chat scroll (UI-17).
-        console.warn(`[store] loadMessages(${sessionId}) failed:`, err);
+        // IPC-layer failure (preload missing, channel unregistered). Seed
+        // a sentinel so we don't infinite-retry, and surface the error so
+        // the user sees the inline retry banner instead of a stuck pane.
+        console.warn(`[store] loadHistory(${sessionId}) IPC failed:`, err);
         const message = err instanceof Error ? err.message : String(err);
         set((s) => ({
           messagesBySession:
@@ -1765,10 +1780,36 @@ export const useStore = create<State & Actions>((set, get) => ({
         }));
         return;
       }
-      // Sanitize: a row persisted with streaming=true means the previous run
-      // crashed/quit mid-stream. On restore, the stream is no longer active,
-      // so clear the flag to prevent the UI from showing a perpetual pulse.
-      const sanitized: MessageBlock[] = rows.map((r) =>
+      let frames: unknown[] = [];
+      if (result.ok) {
+        frames = result.frames;
+      } else if (result.error === 'not_found') {
+        // No JSONL on disk yet — fresh session that hasn't received its
+        // first frame, or one that was never run via the CLI. Empty array
+        // is the right answer; not an error.
+        frames = [];
+      } else {
+        // Real read error (permission, malformed path, fs failure).
+        const detail = 'detail' in result && result.detail ? `: ${result.detail}` : '';
+        const message = `${result.error}${detail}`;
+        console.warn(`[store] loadHistory(${sessionId}) failed: ${message}`);
+        set((s) => ({
+          messagesBySession:
+            sessionId in s.messagesBySession
+              ? s.messagesBySession
+              : { ...s.messagesBySession, [sessionId]: [] },
+          loadMessageErrors: { ...s.loadMessageErrors, [sessionId]: message }
+        }));
+        return;
+      }
+      // Project raw CLI frames into MessageBlock[] using the same reducer
+      // the import path uses. JSONL is the canonical persistence format
+      // now (PR-H), so we always go through this projection.
+      const projected = framesToBlocks(frames);
+      // Sanitize: a streaming=true assistant block inside the JSONL means
+      // a previous run crashed mid-stream. Drop the flag so the UI doesn't
+      // show a perpetual pulse on restore.
+      const sanitized: MessageBlock[] = projected.map((r) =>
         r.kind === 'assistant' && (r as { streaming?: boolean }).streaming
           ? { ...r, streaming: false }
           : r
@@ -1785,10 +1826,8 @@ export const useStore = create<State & Actions>((set, get) => ({
           };
         }
         // Merge path: streaming may have appended blocks while we awaited
-        // the db round-trip. The previous "skip if already set" guard
-        // dropped the persisted history entirely in that race. Instead,
-        // prepend the persisted blocks whose ids aren't already present —
-        // every MessageBlock variant carries an id, so de-duping is exact.
+        // the disk round-trip. Prepend persisted blocks whose ids aren't
+        // already present — every MessageBlock variant carries an id.
         const existingIds = new Set(existing.map((b) => b.id));
         const additions = sanitized.filter((b) => !existingIds.has(b.id));
         if (additions.length === 0) return s;

--- a/tests/inputbar-continue-after-interrupt.test.tsx
+++ b/tests/inputbar-continue-after-interrupt.test.tsx
@@ -59,7 +59,7 @@ function stubCCSM(overrides: Partial<Record<string, unknown>> = {}) {
     agentSend: vi.fn().mockResolvedValue(true),
     agentSendContent: vi.fn().mockResolvedValue(true),
     agentStart: vi.fn().mockResolvedValue({ ok: true }),
-    saveMessages: vi.fn().mockResolvedValue(undefined),
+    loadHistory: vi.fn().mockResolvedValue({ ok: true, frames: [] }),
     ...overrides,
   };
   (globalThis as unknown as { window: Window & { ccsm?: unknown } }).window.ccsm = api;

--- a/tests/persisted-keys-source-of-truth.test.ts
+++ b/tests/persisted-keys-source-of-truth.test.ts
@@ -24,8 +24,7 @@ async function freshStore(saveState: ReturnType<typeof vi.fn>) {
     ccsm: {
       saveState,
       loadState: vi.fn().mockResolvedValue(null),
-      saveMessages: vi.fn().mockResolvedValue(undefined),
-      loadMessages: vi.fn().mockResolvedValue([]),
+      loadHistory: vi.fn().mockResolvedValue({ ok: true, frames: [] }),
       pathsExist: vi.fn().mockResolvedValue({}),
       recentCwds: vi.fn().mockResolvedValue([]),
       topModel: vi.fn().mockResolvedValue(null),

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -474,91 +474,117 @@ describe('store: streamAssistantText + appendBlocks coalesce', () => {
 });
 
 describe('store: loadMessages + selectSession autoload (session restore)', () => {
+  // Helper: seed a session with the given id + cwd so the store's
+  // loadMessages action can derive the JSONL path.
+  function seedSession(id: string, cwd = '/tmp/x') {
+    useStore.setState({
+      sessions: [
+        { id, name: id, state: 'idle', cwd, model: 'claude-opus-4', groupId: 'g-default', agentType: 'claude-code' }
+      ]
+    });
+  }
+
   it('loadMessages pulls from the IPC bridge and writes to messagesBySession', async () => {
-    const persisted = [
-      { kind: 'user', id: 'u1', text: 'hi' },
-      { kind: 'assistant', id: 'a1', text: 'hello there' }
+    // PR-H: the IPC now returns raw CLI frames, which framesToBlocks
+    // projects into MessageBlock[]. We feed user/assistant frames so the
+    // projection produces the expected blocks.
+    const frames = [
+      { type: 'user', uuid: 'u1', message: { content: 'hi' } },
+      {
+        type: 'assistant',
+        message: { id: 'msg-load-1', content: [{ type: 'text', text: 'hello there' }] }
+      }
     ];
-    const load = vi.fn().mockResolvedValue(persisted);
+    const load = vi.fn().mockResolvedValue({ ok: true, frames });
     (globalThis as unknown as { window?: { ccsm?: unknown } }).window = {
-      ccsm: { loadMessages: load }
+      ccsm: { loadHistory: load }
     };
+    seedSession('s-ghost');
 
     await useStore.getState().loadMessages('s-ghost');
-    expect(load).toHaveBeenCalledWith('s-ghost');
-    expect(useStore.getState().messagesBySession['s-ghost']).toEqual(persisted);
+    expect(load).toHaveBeenCalledWith('/tmp/x', 's-ghost');
+    const blocks = useStore.getState().messagesBySession['s-ghost'];
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toMatchObject({ id: 'u-u1', kind: 'user' });
+    expect(blocks[1]).toMatchObject({ kind: 'assistant' });
   });
 
-  it('loadMessages merges persisted blocks (by id) with mid-flight streaming', async () => {
-    let resolve!: (v: unknown[]) => void;
+  it('loadMessages merges streamed blocks (by id) with persisted history', async () => {
+    let resolve!: (v: unknown) => void;
     const load = vi.fn(
-      () => new Promise<unknown[]>((r) => { resolve = r; })
+      () => new Promise<unknown>((r) => { resolve = r; })
     );
     (globalThis as unknown as { window?: { ccsm?: unknown } }).window = {
-      ccsm: { loadMessages: load }
+      ccsm: { loadHistory: load }
     };
+    seedSession('s-race');
 
     const promise = useStore.getState().loadMessages('s-race');
-    // Simulate a streaming block landing before the db fetch resolves.
+    // Simulate a streaming block landing before the disk read resolves.
     useStore.getState().appendBlocks('s-race', [
       { kind: 'assistant', id: 'live-1', text: 'streaming' }
     ]);
-    // Persisted history has a block with a different id (real history) — it
-    // should be prepended. The previous "skip entirely" guard dropped this
-    // valid history; the new merge keeps both.
-    resolve([{ kind: 'user', id: 'persisted-1', text: 'older turn' }]);
+    // Persisted history (different id) should be prepended.
+    resolve({
+      ok: true,
+      frames: [{ type: 'user', uuid: 'persisted-1', message: { content: 'older turn' } }]
+    });
     await promise;
 
     const blocks = useStore.getState().messagesBySession['s-race'];
     expect(blocks).toHaveLength(2);
-    expect(blocks[0]).toMatchObject({ id: 'persisted-1' });
+    expect(blocks[0]).toMatchObject({ id: 'u-persisted-1' });
     expect(blocks[1]).toMatchObject({ id: 'live-1' });
   });
 
   it('loadMessages dedupes persisted blocks whose id already streamed in', async () => {
-    let resolve!: (v: unknown[]) => void;
+    let resolve!: (v: unknown) => void;
     const load = vi.fn(
-      () => new Promise<unknown[]>((r) => { resolve = r; })
+      () => new Promise<unknown>((r) => { resolve = r; })
     );
     (globalThis as unknown as { window?: { ccsm?: unknown } }).window = {
-      ccsm: { loadMessages: load }
+      ccsm: { loadHistory: load }
     };
+    seedSession('s-dup');
 
     const promise = useStore.getState().loadMessages('s-dup');
     useStore.getState().appendBlocks('s-dup', [
-      { kind: 'assistant', id: 'dup-1', text: 'fresh' }
+      { kind: 'user', id: 'u-dup-1', text: 'fresh' }
     ]);
-    resolve([{ kind: 'assistant', id: 'dup-1', text: 'stale' }]);
+    resolve({
+      ok: true,
+      frames: [{ type: 'user', uuid: 'dup-1', message: { content: 'stale' } }]
+    });
     await promise;
 
     const blocks = useStore.getState().messagesBySession['s-dup'];
     expect(blocks).toHaveLength(1);
     // The streaming version wins (stays put at the end of the array).
-    expect(blocks[0]).toMatchObject({ id: 'dup-1', text: 'fresh' });
+    expect(blocks[0]).toMatchObject({ id: 'u-dup-1', text: 'fresh' });
   });
 
   it('selectSession triggers loadMessages when history is missing', () => {
-    const load = vi.fn().mockResolvedValue([]);
+    const load = vi.fn().mockResolvedValue({ ok: true, frames: [] });
     (globalThis as unknown as { window?: { ccsm?: unknown } }).window = {
-      ccsm: { loadMessages: load }
+      ccsm: { loadHistory: load }
     };
     useStore.setState({
       sessions: [
-        { id: 's-x', name: 's-x', state: 'idle', cwd: '~', model: 'claude-opus-4', groupId: 'g-default', agentType: 'claude-code' }
+        { id: 's-x', name: 's-x', state: 'idle', cwd: '/tmp/x', model: 'claude-opus-4', groupId: 'g-default', agentType: 'claude-code' }
       ]
     });
     useStore.getState().selectSession('s-x');
-    expect(load).toHaveBeenCalledWith('s-x');
+    expect(load).toHaveBeenCalledWith('/tmp/x', 's-x');
   });
 
   it('selectSession skips the load when messagesBySession already has an entry', () => {
-    const load = vi.fn().mockResolvedValue([]);
+    const load = vi.fn().mockResolvedValue({ ok: true, frames: [] });
     (globalThis as unknown as { window?: { ccsm?: unknown } }).window = {
-      ccsm: { loadMessages: load }
+      ccsm: { loadHistory: load }
     };
     useStore.setState({
       sessions: [
-        { id: 's-y', name: 's-y', state: 'idle', cwd: '~', model: 'claude-opus-4', groupId: 'g-default', agentType: 'claude-code' }
+        { id: 's-y', name: 's-y', state: 'idle', cwd: '/tmp/y', model: 'claude-opus-4', groupId: 'g-default', agentType: 'claude-code' }
       ],
       messagesBySession: { 's-y': [] }
     });
@@ -1184,15 +1210,15 @@ describe('store: setGlobalModel / setSessionModel split', () => {
 
 describe('store: loadMessages failure seeds [] and clears in-flight', () => {
   it('IPC reject leaves an empty array and the next selectSession does not retry', async () => {
-    const load = vi.fn().mockRejectedValue(new Error('db locked'));
+    const load = vi.fn().mockRejectedValue(new Error('preload missing'));
     (globalThis as unknown as { window?: { ccsm?: unknown } }).window = {
-      ccsm: { loadMessages: load, saveMessages: vi.fn() }
+      ccsm: { loadHistory: load }
     };
     // Suppress the expected console.warn in test output.
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     useStore.setState({
       sessions: [
-        { id: 's-fail', name: '?', state: 'idle', cwd: '~', model: '', groupId: 'g-default', agentType: 'claude-code' }
+        { id: 's-fail', name: '?', state: 'idle', cwd: '/tmp/fail', model: '', groupId: 'g-default', agentType: 'claude-code' }
       ]
     });
 
@@ -1210,6 +1236,38 @@ describe('store: loadMessages failure seeds [] and clears in-flight', () => {
     await new Promise((r) => setTimeout(r, 0));
     expect(load).toHaveBeenCalledTimes(1);
     warn.mockRestore();
+  });
+
+  it('read_error result surfaces an inline error banner', async () => {
+    const load = vi.fn().mockResolvedValue({ ok: false, error: 'read_error', detail: 'EACCES' });
+    (globalThis as unknown as { window?: { ccsm?: unknown } }).window = {
+      ccsm: { loadHistory: load }
+    };
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    useStore.setState({
+      sessions: [
+        { id: 's-perm', name: '?', state: 'idle', cwd: '/tmp/perm', model: '', groupId: 'g-default', agentType: 'claude-code' }
+      ]
+    });
+    await useStore.getState().loadMessages('s-perm');
+    expect(useStore.getState().messagesBySession['s-perm']).toEqual([]);
+    expect(useStore.getState().loadMessageErrors['s-perm']).toContain('read_error');
+    warn.mockRestore();
+  });
+
+  it('not_found result is treated as empty (no error banner)', async () => {
+    const load = vi.fn().mockResolvedValue({ ok: false, error: 'not_found' });
+    (globalThis as unknown as { window?: { ccsm?: unknown } }).window = {
+      ccsm: { loadHistory: load }
+    };
+    useStore.setState({
+      sessions: [
+        { id: 's-new', name: '?', state: 'idle', cwd: '/tmp/new', model: '', groupId: 'g-default', agentType: 'claude-code' }
+      ]
+    });
+    await useStore.getState().loadMessages('s-new');
+    expect(useStore.getState().messagesBySession['s-new']).toEqual([]);
+    expect(useStore.getState().loadMessageErrors['s-new']).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

PR-C follow-up. Removes ccsm's redundant SQLite `messages` table; the CLI / Agent SDK already writes every frame to `~/.claude/projects/<key>/<sid>.jsonl` as it streams, so ccsm now reads from there. Closes Task #29.

## Layer 1 (necessity + direction)

1. **Zero-dependency on `messages` table?** Verified. Production callers of `loadMessages`/`saveMessages` are limited to:
   - `electron/db.ts` (the impl itself)
   - `electron/main.ts` (IPC handlers)
   - `electron/preload.ts` (bridge)
   - `src/global.d.ts` (types)
   - `src/stores/store.ts` (`loadMessages` action + 6 `saveMessages` call sites)
   - `src/agent/lifecycle.ts` (one `saveMessages` on `result`)
   All other matches in the repo are tests/probes/comments. The earlier "47 files" figure conflated string-grep matches (mostly `s.loadMessageErrors`, comments, mocks); the real production graph is small and removable.

2. **JSONL format stable / 1:1 with renderer's MessageBlock?** JSONL = SDK frames (`SDKMessage`-ish). The renderer already has `framesToBlocks` (used by the import flow) which projects raw frames → MessageBlock with the same reducer the live agent uses (`streamEventToTranslation`). We reuse it as-is — projection logic stays in exactly one place.

3. **Project key from cwd?** CLI uses a slug rule (`/`, `\`, `:` → `-`). Verified empirically against a real `~/.claude/projects/` listing on Windows + macOS. Implemented in `projectKeyFromCwd` (electron/jsonl-loader.ts) so the slug logic is one-place.

4. **JSONL absent (fresh session, no first frame yet)?** Returns `{ ok: false, error: 'not_found' }`; renderer treats it as `[]` (no error banner).

5. **Performance / cache?** No cache. Reads are streamed line-by-line via `readline` (no full-file load); typical session is a few hundred frames. The 50k-frame cap mirrors the import path. If profiling later shows session-switch latency, an LRU on the main side is a small additive change — not worth pre-engineering per the design-density rule.

## Changes

- `electron/jsonl-loader.ts` (new) — streaming loader + `projectKeyFromCwd` + path-traversal hardening, mirrors `import-history.ts` structure.
- `electron/main.ts` — registers `agent:load-history`; removes `db:loadMessages` / `db:saveMessages` handlers and their imports.
- `electron/preload.ts` / `src/global.d.ts` — replaces `loadMessages`/`saveMessages` bridge methods with `loadHistory(cwd, sessionId)`.
- `electron/db.ts` — drops `messages` table from schema, drops legacy table at boot via `DROP TABLE IF EXISTS messages` (per "no migration" decision), removes `loadMessages` / `saveMessages` exports + their prepared-statement slots. `app_state` / `claudeBinPath` / integrity check / schema versioning unchanged.
- `src/stores/store.ts` — `loadMessages` action now calls `loadHistory(cwd, sid)`, derives sid from `session.resumeSessionId || session.id` (PR-D unify-friendly), projects frames via `framesToBlocks`. All 6 `saveMessages` call sites removed; deleteSession / deleteGroup / resetSessionContext / restoreSession / restoreGroup intentionally do NOT touch the JSONL on disk (it's the user's CLI-side history; ccsm shouldn't mutate it).
- `src/agent/lifecycle.ts` — `saveMessages` on `result` removed.
- `electron/__tests__/jsonl-loader.test.ts` (new) — happy path, empty file, not_found, malformed-line skipping, path traversal, invalid args. 8 tests, all green.
- `electron/__tests__/db.test.ts` / `db-hardening.test.ts` — messages-table cases removed; remaining cases (claudeBinPath, integrity check, schema version, prepared-statement cache) keep coverage.
- `tests/store.test.ts` — `loadMessages` autoload + merge + dedupe tests rewritten to mock `loadHistory` and exercise the framesToBlocks projection. Two new tests cover `not_found` (no banner) and `read_error` (inline banner).
- `tests/persisted-keys-source-of-truth.test.ts` / `tests/inputbar-continue-after-interrupt.test.tsx` — stale `loadMessages`/`saveMessages` mocks replaced with `loadHistory`.

## Test results

- `npm run typecheck`: pass.
- `npm test`: 735 pass / 6 fail. The 6 failures are all `db.test.ts` + `db-hardening.test.ts` cases hitting the pre-existing better-sqlite3 native-binding rebuild issue in this dev env (Python toolchain not available — same root cause as the 12 pre-existing failures called out in the task spec). New `jsonl-loader.test.ts` 8/8 green; `store.test.ts` 92/92 green.

## Smoke (deferred to reviewer env)

This worktree's better-sqlite3 binding can't be rebuilt (no Python toolchain). Smoke checklist for reviewer:

- [ ] Create a session, send a message, restart ccsm, reopen the session — history loads from JSONL.
- [ ] Newly-created session before first message — empty pane, no error banner.
- [ ] Permission-denied JSONL (chmod 000) — inline error banner with `read_error` shown; Retry recovers after fixing perms.
- [ ] On boot with an existing pre-PR ccsm.db, the `messages` table is dropped (sqlite3 ccsm.db ".tables" should not list it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)