### PR TITLE
feat(question): sticky AskUserQuestion widget — upstream parity (#37)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { Sidebar } from './components/Sidebar';
 import { AppShell } from './components/AppShell';
 import { ChatStream } from './components/ChatStream';
 import { InputBar } from './components/InputBar';
+import { QuestionStickyHost } from './components/QuestionStickyHost';
 import { StatusBar } from './components/StatusBar';
 import { SettingsDialog } from './components/SettingsDialog';
 import { CommandPalette } from './components/CommandPalette';
@@ -436,6 +437,7 @@ export default function App() {
                 onChangeModel={(m) => setSessionModel(active.id, m)}
                 onChangePermission={setPermission}
               />
+              <QuestionStickyHost sessionId={active.id} />
               <InputBar sessionId={active.id} />
             </main>
           }

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -147,9 +147,14 @@ export function InputBar({ sessionId }: { sessionId: string }) {
       hasMessages: (s.messagesBySession[sessionId]?.length ?? 0) > 0,
       // True iff there's a pending permission/plan/question prompt for this
       // session — those blocks auto-focus their own primary control (see the
-      // setTimeout(..., 150) in WaitingBlock/PlanBlock/QuestionBlock). We let
-      // them win and skip stealing focus into the textarea.
-      hasPendingWaiting: (s.messagesBySession[sessionId] ?? []).some((b) => b.kind === 'waiting'),
+      // setTimeout(..., 150) in WaitingBlock/PlanBlock, plus the sticky
+      // <QuestionStickyHost /> for AskUserQuestion). We let them win and
+      // skip stealing focus into the textarea. Unanswered `question` blocks
+      // count too — even though they no longer render in the timeline, the
+      // sticky widget owns focus until the user submits or dismisses it.
+      hasPendingWaiting: (s.messagesBySession[sessionId] ?? []).some(
+        (b) => b.kind === 'waiting' || (b.kind === 'question' && !b.answered)
+      ),
       permission: s.permission,
       focusInputNonce: s.focusInputNonce,
       // Count of pending per-line diff comments queued up to ride the next

--- a/src/components/QuestionBlock.tsx
+++ b/src/components/QuestionBlock.tsx
@@ -1,324 +1,425 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
-import { Check } from 'lucide-react';
-import * as RadioGroup from '@radix-ui/react-radio-group';
-import * as Checkbox from '@radix-ui/react-checkbox';
-import * as RovingFocusGroup from '@radix-ui/react-roving-focus';
+import { Check, X } from 'lucide-react';
 import type { QuestionSpec } from '../types';
-import { Button } from './ui/Button';
-import { StateGlyph } from './ui/StateGlyph';
 import { useTranslation } from '../i18n/useTranslation';
-import { DURATION, DURATION_RAW, EASING } from '../lib/motion';
+import { DURATION_RAW, EASING } from '../lib/motion';
+
+/**
+ * AskUserQuestion sticky widget.
+ *
+ * Mirrors the upstream Claude VS Code extension component (`o30` in
+ * webview/index.js, around line 1519): a single sticky card that floats
+ * above the composer while at least one question in the current
+ * AskUserQuestion call is unanswered. Multiple questions inside the same
+ * call are paged via chip tabs at the top, with ←/→ to navigate questions
+ * and ↑/↓ to move between options inside the active question.
+ *
+ * Behaviors implemented (one-to-one with upstream):
+ *  - Top chip-tab bar lists every question in the call. The active tab
+ *    has a stronger ring; tabs with at least one selected option are
+ *    marked "answered" (subtler accent).
+ *  - ←/→ pages question (clamped at the ends).
+ *  - ↑/↓ moves option focus inside the active question (loops at edges).
+ *  - Single-select: clicking an option sets it AND, if this isn't the
+ *    last question, schedules a 300ms "confirming" highlight then auto-
+ *    advances to the next question (matches upstream's optionConfirming
+ *    timing, line 1519).
+ *  - Multi-select: clicking toggles the option, never auto-advances.
+ *  - We always append a synthetic "Other" option (last). Selecting it
+ *    expands an inline contenteditable input. Submission swaps the
+ *    literal "Other" label for the user's typed text.
+ *  - Submit fires only when EVERY question has at least one option
+ *    selected (or "Other" with non-empty text).
+ *  - Submit payload: `answers[question] = labels.join("\n ")`, with the
+ *    literal "Other" replaced by the user's typed text. Newline-space
+ *    separator matches upstream so multi-select answers render naturally
+ *    in the assistant's tool_result body.
+ *  - Esc anywhere inside the widget invokes `onReject` — the can_use_tool
+ *    permission is denied and no answer is sent.
+ */
 
 export interface QuestionBlockProps {
   questions: QuestionSpec[];
-  onSubmit: (answersText: string) => void;
-  /** When false, this widget will not auto-focus its first option on mount. */
+  /**
+   * Receives the per-question answer map: keys are the original `question`
+   * strings, values are the labels (Other replaced with the typed text)
+   * joined by `"\n "`. Caller routes this to `agentSend` (and resolves
+   * any pending permission as deny first).
+   */
+  onSubmit: (answersByQuestion: Record<string, string>) => void;
+  /**
+   * Esc / explicit close — caller must reject the pending can_use_tool
+   * promise (no follow-up agentSend). Optional so older callers (tests)
+   * can omit it.
+   */
+  onReject?: () => void;
+  /** When false, the widget will not auto-focus its first option on mount. */
   autoFocus?: boolean;
 }
 
-export function QuestionBlock({ questions, onSubmit, autoFocus = true }: QuestionBlockProps) {
+const OTHER_LABEL = 'Other';
+const ANSWER_JOIN = '\n ';
+const AUTO_ADVANCE_MS = 300;
+
+export function QuestionBlock({ questions, onSubmit, onReject, autoFocus = true }: QuestionBlockProps) {
   const { t } = useTranslation();
-  const [picks, setPicks] = useState<Array<Set<number>>>(() =>
-    questions.map((q) => {
-      // Single-select: pre-select the first option so Radix RadioGroup has a
-      // clear initial tab stop and the Submit button is active immediately
-      // (matches Claude Desktop behaviour). Multi-select stays empty.
-      if (q.multiSelect) return new Set<number>();
-      return new Set<number>([0]);
-    })
-  );
+
+  // Page index (active question).
+  const [active, setActive] = useState(0);
+  // Per-question selection set. Key = question.question, value = Set of
+  // labels (NOT indices — matches upstream's `selectedAnswers` shape; lets
+  // "Other" coexist with named options without index tricks).
+  const [picks, setPicks] = useState<Record<string, Set<string>>>(() => {
+    const init: Record<string, Set<string>> = {};
+    for (const q of questions) init[q.question] = new Set();
+    return init;
+  });
+  // Per-question free-text for the synthetic "Other" option.
+  const [otherText, setOtherText] = useState<Record<string, string>>({});
+  // Transient highlight on the option that triggered an auto-advance.
+  const [confirming, setConfirming] = useState<string | null>(null);
+  // While the inline Other input has focus, suppress arrow-key handling so
+  // typing arrows inside the input doesn't page the widget.
+  const [otherFocused, setOtherFocused] = useState(false);
   const [submitted, setSubmitted] = useState(false);
-  const submitRef = useRef<HTMLButtonElement>(null);
+
   const rootRef = useRef<HTMLDivElement>(null);
+  const optionsRef = useRef<HTMLDivElement>(null);
+  const otherInputRef = useRef<HTMLDivElement>(null);
 
-  const togglePick = (qIdx: number, optIdx: number, multi: boolean) => {
-    if (submitted) return;
-    setPicks((prev) => {
-      const next = prev.slice();
-      const set = new Set(next[qIdx]);
-      if (multi) {
-        if (set.has(optIdx)) set.delete(optIdx);
-        else set.add(optIdx);
-      } else {
-        set.clear();
-        set.add(optIdx);
+  const current = questions[active];
+
+  const isSelected = useCallback(
+    (label: string) => picks[current?.question ?? '']?.has(label) === true,
+    [picks, current?.question]
+  );
+
+  // Whether every question has at least one valid selection (Other counts
+  // only when the typed text is non-empty).
+  const allAnswered = useMemo(() => {
+    for (const q of questions) {
+      const set = picks[q.question];
+      if (!set || set.size === 0) return false;
+      if (set.has(OTHER_LABEL)) {
+        const txt = otherText[q.question]?.trim() ?? '';
+        if (!txt && set.size === 1) return false;
       }
-      next[qIdx] = set;
-      return next;
-    });
-  };
+    }
+    return true;
+  }, [questions, picks, otherText]);
 
-  const allAnswered = questions.every((_, i) => picks[i] && picks[i].size > 0);
+  // Build the submit payload per upstream:
+  //   answers[question] = labels.join("\n "), Other → typed text.
+  const buildAnswers = useCallback((): Record<string, string> => {
+    const out: Record<string, string> = {};
+    for (const q of questions) {
+      const set = picks[q.question];
+      if (!set || set.size === 0) continue;
+      const labels = Array.from(set);
+      const final = labels
+        .map((l) => (l === OTHER_LABEL ? otherText[q.question]?.trim() || '' : l))
+        .filter(Boolean);
+      if (final.length === 0) continue;
+      out[q.question] = final.join(ANSWER_JOIN);
+    }
+    return out;
+  }, [questions, picks, otherText]);
 
-  const submit = () => {
+  const submit = useCallback(() => {
     if (!allAnswered || submitted) return;
-    const lines: string[] = [];
-    questions.forEach((q, i) => {
-      const labels = Array.from(picks[i]).map((j) => q.options[j]?.label).filter(Boolean);
-      lines.push(`Q: ${q.question}`);
-      lines.push(`A: ${labels.join(', ')}`);
-    });
     setSubmitted(true);
-    onSubmit(lines.join('\n'));
-  };
+    onSubmit(buildAnswers());
+  }, [allAnswered, submitted, onSubmit, buildAnswers]);
 
-  // Auto-focus the first interactive option on mount so the user can press
-  // Enter immediately. Only the LATEST mounted question grabs focus (the older
-  // ones are already mounted and won't re-fire this effect).
+  // Auto-focus first option of the active question on mount + on every page
+  // change. Mirrors upstream's "切题自动 focus 第一个" behavior.
   useEffect(() => {
     if (!autoFocus || submitted) return;
-    const root = rootRef.current;
+    const root = optionsRef.current;
     if (!root) return;
-    // Defer to next frame so Radix has wired up roving tabindex.
     const id = requestAnimationFrame(() => {
-      const target = root.querySelector<HTMLElement>(
-        '[data-question-option][data-question-first="true"]'
-      );
+      const target = root.querySelector<HTMLElement>('[data-question-option]');
       if (!target) return;
-      // Don't steal focus if the user has already moved focus to a real
-      // interactive element somewhere else (e.g. the InputBar textarea).
-      const active = document.activeElement;
-      if (active && active !== document.body && !root.contains(active)) return;
+      const ae = document.activeElement as HTMLElement | null;
+      if (ae && ae !== document.body && ae.tagName === 'INPUT') return;
+      if (ae && ae.isContentEditable && ae !== target) return;
       target.focus({ preventScroll: true });
     });
     return () => cancelAnimationFrame(id);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [active, autoFocus, submitted]);
 
-  const onKeyDownCapture = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (submitted) return;
-    if (e.key === 'Enter') {
-      const target = e.target as HTMLElement;
-      // Only intercept Enter on option buttons. The Submit button handles its
-      // own Enter via native click, and we don't want to double-fire.
-      if (target.closest('[data-question-option]')) {
-        e.preventDefault();
-        e.stopPropagation();
-        submit();
+  // ---- Selection + auto-advance -------------------------------------------
+  const togglePick = useCallback(
+    (q: QuestionSpec, label: string) => {
+      if (submitted) return;
+      let didSelectFresh = false;
+      setPicks((prev) => {
+        const next = { ...prev };
+        const set = new Set(next[q.question] ?? []);
+        if (q.multiSelect) {
+          if (set.has(label)) set.delete(label);
+          else set.add(label);
+        } else {
+          if (!set.has(label)) didSelectFresh = true;
+          set.clear();
+          set.add(label);
+        }
+        next[q.question] = set;
+        return next;
+      });
+      if (label === OTHER_LABEL) {
+        setTimeout(() => otherInputRef.current?.focus(), 0);
       }
-    } else if (e.key === 'Escape') {
-      const active = document.activeElement as HTMLElement | null;
-      if (active && rootRef.current?.contains(active)) {
-        e.preventDefault();
-        active.blur();
+      if (
+        !q.multiSelect &&
+        didSelectFresh &&
+        label !== OTHER_LABEL &&
+        active < questions.length - 1 &&
+        confirming === null
+      ) {
+        setConfirming(label);
+        setTimeout(() => {
+          setConfirming(null);
+          setActive((a) => Math.min(a + 1, questions.length - 1));
+        }, AUTO_ADVANCE_MS);
+      }
+    },
+    [active, confirming, questions.length, submitted]
+  );
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (submitted) return;
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      onReject?.();
+      return;
+    }
+    if (otherFocused) return;
+    if (e.key === 'ArrowLeft' && active > 0) {
+      e.preventDefault();
+      e.stopPropagation();
+      setActive((a) => Math.max(0, a - 1));
+      return;
+    }
+    if (e.key === 'ArrowRight' && active < questions.length - 1) {
+      e.preventDefault();
+      e.stopPropagation();
+      setActive((a) => Math.min(questions.length - 1, a + 1));
+      return;
+    }
+    if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+      const root = optionsRef.current;
+      if (!root) return;
+      const opts = Array.from(root.querySelectorAll<HTMLElement>('[data-question-option]'));
+      if (opts.length === 0) return;
+      const cur = opts.findIndex((el) => el === document.activeElement);
+      let nextIdx: number;
+      if (e.key === 'ArrowUp') nextIdx = cur <= 0 ? opts.length - 1 : cur - 1;
+      else nextIdx = cur >= opts.length - 1 ? 0 : cur + 1;
+      e.preventDefault();
+      e.stopPropagation();
+      opts[nextIdx]?.focus();
+      return;
+    }
+    if (e.key === 'Enter') {
+      const ae = document.activeElement as HTMLElement | null;
+      if (ae && ae.closest('[data-question-option]')) {
+        const label = (ae as HTMLElement).dataset.questionLabel;
+        if (label !== undefined) {
+          e.preventDefault();
+          e.stopPropagation();
+          togglePick(current, label);
+        }
       }
     }
   };
 
+  if (!current) return null;
+
+  const optionsToRender: Array<{ label: string; description?: string; isOther: boolean }> = [
+    ...current.options.map((o) => ({ label: o.label, description: o.description, isOther: false })),
+    { label: OTHER_LABEL, isOther: true }
+  ];
+
   return (
     <motion.div
       ref={rootRef}
+      data-question-sticky
+      role="dialog"
+      aria-label={t('questionBlock.title')}
       initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: DURATION_RAW.ms220, ease: EASING.standard }}
-      className="relative my-2 rounded-md border border-state-waiting/40 bg-state-waiting/[0.06] surface-highlight surface-elevated pl-4 pr-4 py-3"
-      onKeyDownCapture={onKeyDownCapture}
+      className="relative mx-3 mb-2 rounded-md border border-state-waiting/40 bg-state-waiting/[0.06] surface-highlight surface-elevated"
+      onKeyDown={onKeyDown}
     >
       <span aria-hidden className="absolute left-0 top-0 bottom-0 w-[2px] bg-state-waiting rounded-l-md" />
-      <div className="flex items-center gap-2 text-heading text-fg-primary font-semibold">
-        <StateGlyph state="waiting" size="sm" />
-        <span>{t('questionBlock.title')}</span>
-      </div>
-      <div className="mt-3 space-y-4">
-        {questions.map((q, qi) => (
-          <QuestionRow
-            key={qi}
-            q={q}
-            qi={qi}
-            picks={picks[qi] ?? new Set<number>()}
-            submitted={submitted}
-            onToggle={togglePick}
-            isFirstQuestion={qi === 0}
-          />
-        ))}
-      </div>
-      <div className="mt-3 flex justify-end">
-        <Button
-          ref={submitRef}
-          variant="primary"
-          size="md"
-          className="focus-ring"
-          disabled={!allAnswered || submitted}
-          onClick={submit}
-        >
-          {submitted ? t('questionBlock.submitted') : t('questionBlock.submit')}
-        </Button>
-      </div>
-    </motion.div>
-  );
-}
 
-interface QuestionRowProps {
-  q: QuestionSpec;
-  qi: number;
-  picks: Set<number>;
-  submitted: boolean;
-  onToggle: (qIdx: number, optIdx: number, multi: boolean) => void;
-  isFirstQuestion: boolean;
-}
-
-function QuestionRow({ q, qi, picks, submitted, onToggle, isFirstQuestion }: QuestionRowProps) {
-  // Once submitted the prompt is read-only / confirmed; flip the amber
-  // waiting halo to the success-green halo so the surface visibly settles
-  // (matches DiffView Accept's success ring after a hunk is accepted).
-  const ringClass = submitted ? 'focus-ring-success' : 'focus-ring-waiting';
-  const labelClass = (selected: boolean) =>
-    'flex items-start gap-2 w-full text-left px-3 py-2 rounded-sm border cursor-pointer transition-colors duration-150 ease-out outline-none ' +
-    ringClass + ' ' +
-    (selected
-      ? 'border-state-waiting/70 bg-state-waiting/10'
-      : 'border-border-subtle hover:bg-bg-hover hover:border-border-default active:bg-bg-hover/80') +
-    (submitted ? ' cursor-not-allowed opacity-70' : '');
-
-  return (
-    <div className="space-y-2">
-      {q.header && (
-        <div className="font-mono text-mono-sm uppercase tracking-wider text-fg-tertiary">{q.header}</div>
-      )}
-      <div className="text-body text-fg-primary">{q.question}</div>
-      {q.multiSelect ? (
-        <MultiSelectGroup
-          q={q}
-          qi={qi}
-          picks={picks}
-          submitted={submitted}
-          onToggle={onToggle}
-          labelClass={labelClass}
-          autoFocusFirst={isFirstQuestion}
-        />
-      ) : (
-        <SingleSelectGroup
-          q={q}
-          qi={qi}
-          picks={picks}
-          submitted={submitted}
-          onToggle={onToggle}
-          labelClass={labelClass}
-          autoFocusFirst={isFirstQuestion}
-        />
-      )}
-    </div>
-  );
-}
-
-interface GroupProps {
-  q: QuestionSpec;
-  qi: number;
-  picks: Set<number>;
-  submitted: boolean;
-  onToggle: (qIdx: number, optIdx: number, multi: boolean) => void;
-  labelClass: (selected: boolean) => string;
-  autoFocusFirst: boolean;
-}
-
-function SingleSelectGroup({ q, qi, picks, submitted, onToggle, labelClass, autoFocusFirst }: GroupProps) {
-  const value = useMemo(() => (picks.size > 0 ? String(Array.from(picks)[0]) : ''), [picks]);
-  // The label wrapper carries focus-within: tone via labelClass; the radio
-  // dot itself rides the matching utility on its own focus-visible so a
-  // direct keyboard tab onto the control still shows a halo.
-  const innerRing = submitted ? 'focus-ring-success' : 'focus-ring-waiting';
-  return (
-    <RadioGroup.Root
-      value={value}
-      onValueChange={(v) => {
-        const idx = parseInt(v, 10);
-        if (!Number.isNaN(idx)) onToggle(qi, idx, false);
-      }}
-      disabled={submitted}
-      orientation="vertical"
-      loop
-      className="space-y-1"
-      aria-label={q.question}
-    >
-      {q.options.map((opt, oi) => {
-        const selected = picks.has(oi);
-        const id = `q${qi}-o${oi}`;
-        const isFirst = autoFocusFirst && oi === 0;
-        return (
-          <motion.label
-            key={oi}
-            initial={{ opacity: 0, y: 4 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: DURATION.standard, delay: oi * 0.02, ease: EASING.enter }}
-            htmlFor={id}
-            className={labelClass(selected)}
-          >
-            <RadioGroup.Item
-              id={id}
-              value={String(oi)}
-              data-question-option=""
-              data-question-first={isFirst ? 'true' : 'false'}
-              className={
-                'mt-[3px] h-3.5 w-3.5 shrink-0 rounded-full border border-border-strong data-[state=checked]:border-state-waiting outline-none transition-colors duration-150 ' +
-                innerRing
-              }
-            >
-              <RadioGroup.Indicator className="flex items-center justify-center h-full w-full relative after:content-[''] after:block after:h-1.5 after:w-1.5 after:rounded-full after:bg-state-waiting" />
-            </RadioGroup.Item>
-            <div className="min-w-0 flex-1">
-              <div className="text-body text-fg-primary break-words [overflow-wrap:anywhere]">{opt.label}</div>
-              {opt.description && (
-                <div className="text-meta text-fg-tertiary mt-0.5 break-words [overflow-wrap:anywhere]">{opt.description}</div>
-              )}
-            </div>
-          </motion.label>
-        );
-      })}
-    </RadioGroup.Root>
-  );
-}
-
-function MultiSelectGroup({ q, qi, picks, submitted, onToggle, labelClass, autoFocusFirst }: GroupProps) {
-  const innerRing = submitted ? 'focus-ring-success' : 'focus-ring-waiting';
-  return (
-    <RovingFocusGroup.Root
-      asChild
-      orientation="vertical"
-      loop
-    >
-      <div className="space-y-1" role="group" aria-label={q.question}>
-        {q.options.map((opt, oi) => {
-          const selected = picks.has(oi);
-          const id = `q${qi}-o${oi}`;
-          const isFirst = autoFocusFirst && oi === 0;
+      {/* Chip-tab navigation bar. */}
+      <div
+        data-testid="question-nav-bar"
+        className="flex items-center gap-1.5 px-3 py-2 border-b border-border-subtle"
+      >
+        {questions.map((q, i) => {
+          const answered = (picks[q.question]?.size ?? 0) > 0;
+          const isActive = i === active;
+          const label = q.header || t('questionBlock.tabFallback', { n: i + 1 });
           return (
-            <motion.label
-              key={oi}
-              initial={{ opacity: 0, y: 4 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: DURATION.standard, delay: oi * 0.02, ease: EASING.enter }}
-              htmlFor={id}
-              className={labelClass(selected)}
+            <button
+              key={i}
+              type="button"
+              data-testid={`question-tab-${i}`}
+              data-active={isActive ? 'true' : 'false'}
+              data-answered={answered ? 'true' : 'false'}
+              onClick={() => setActive(i)}
+              className={
+                'inline-flex items-center gap-1.5 px-2 py-0.5 rounded-sm text-meta font-mono tracking-wider uppercase outline-none focus-ring-waiting transition-colors duration-150 ease-out ' +
+                (isActive
+                  ? 'bg-state-waiting/15 text-fg-primary border border-state-waiting/60'
+                  : answered
+                    ? 'bg-state-waiting/[0.06] text-fg-secondary border border-state-waiting/30 hover:bg-state-waiting/10'
+                    : 'border border-border-subtle text-fg-tertiary hover:text-fg-secondary hover:border-border-default')
+              }
+              aria-current={isActive ? 'step' : undefined}
             >
-              <RovingFocusGroup.Item asChild focusable={!submitted} active={isFirst}>
-                <Checkbox.Root
-                  id={id}
-                  checked={selected}
-                  disabled={submitted}
-                  onCheckedChange={() => onToggle(qi, oi, true)}
-                  data-question-option=""
-                  data-question-first={isFirst ? 'true' : 'false'}
-                  className={
-                    'mt-[3px] h-3.5 w-3.5 shrink-0 rounded-sm border border-border-strong data-[state=checked]:bg-state-waiting data-[state=checked]:border-state-waiting outline-none transition-colors duration-150 ' +
-                    innerRing
-                  }
-                >
-                  <Checkbox.Indicator className="flex items-center justify-center text-bg-app">
-                    <Check size={10} strokeWidth={3} />
-                  </Checkbox.Indicator>
-                </Checkbox.Root>
-              </RovingFocusGroup.Item>
-              <div className="min-w-0 flex-1">
-                <div className="text-body text-fg-primary break-words [overflow-wrap:anywhere]">{opt.label}</div>
-                {opt.description && (
-                  <div className="text-meta text-fg-tertiary mt-0.5 break-words [overflow-wrap:anywhere]">{opt.description}</div>
-                )}
-              </div>
-            </motion.label>
+              {answered && <Check size={10} className="stroke-[2.5]" aria-hidden />}
+              <span className="truncate max-w-[160px]">{label}</span>
+            </button>
           );
         })}
+        <div className="flex-1" />
+        {onReject && (
+          <button
+            type="button"
+            aria-label={t('questionBlock.cancel')}
+            title={t('questionBlock.cancel')}
+            onClick={() => onReject()}
+            className="inline-flex h-5 w-5 items-center justify-center rounded-sm text-fg-tertiary hover:text-fg-primary hover:bg-bg-hover outline-none focus-ring transition-colors duration-150 ease-out"
+          >
+            <X size={12} className="stroke-[2.25]" />
+          </button>
+        )}
       </div>
-    </RovingFocusGroup.Root>
+
+      {/* Active question body */}
+      <div className="px-4 py-3">
+        <div className="text-body text-fg-primary mb-3">{current.question}</div>
+        <div
+          ref={optionsRef}
+          className="space-y-1"
+          role={current.multiSelect ? 'group' : 'radiogroup'}
+          aria-label={current.question}
+        >
+          {optionsToRender.map((opt, oi) => {
+            const selected = isSelected(opt.label);
+            const isConfirming = confirming === opt.label;
+            const role = current.multiSelect ? 'checkbox' : 'radio';
+            return (
+              <div
+                key={`${active}-${oi}`}
+                data-question-option=""
+                data-question-label={opt.label}
+                role={role}
+                aria-checked={selected}
+                tabIndex={0}
+                onClick={() => togglePick(current, opt.label)}
+                onKeyDown={(e) => {
+                  if (e.key === ' ') {
+                    e.preventDefault();
+                    togglePick(current, opt.label);
+                  }
+                }}
+                className={
+                  'flex items-start gap-2 w-full text-left px-3 py-2 rounded-sm border cursor-pointer transition-colors duration-150 ease-out outline-none focus-ring-waiting ' +
+                  (selected
+                    ? 'border-state-waiting/70 bg-state-waiting/10'
+                    : 'border-border-subtle hover:bg-bg-hover hover:border-border-default') +
+                  (isConfirming ? ' ring-2 ring-state-waiting/60' : '')
+                }
+              >
+                <span
+                  aria-hidden
+                  className={
+                    (current.multiSelect
+                      ? 'mt-[3px] h-3.5 w-3.5 shrink-0 rounded-sm border flex items-center justify-center '
+                      : 'mt-[3px] h-3.5 w-3.5 shrink-0 rounded-full border flex items-center justify-center ') +
+                    (selected ? 'border-state-waiting bg-state-waiting/20' : 'border-border-strong')
+                  }
+                >
+                  {selected && current.multiSelect && (
+                    <Check size={10} strokeWidth={3} className="text-state-waiting" />
+                  )}
+                  {selected && !current.multiSelect && (
+                    <span className="block h-1.5 w-1.5 rounded-full bg-state-waiting" />
+                  )}
+                </span>
+                <div className="min-w-0 flex-1">
+                  <div className="text-body text-fg-primary break-words [overflow-wrap:anywhere]">
+                    {opt.label === OTHER_LABEL ? t('questionBlock.other') : opt.label}
+                  </div>
+                  {opt.description && (
+                    <div className="text-meta text-fg-tertiary mt-0.5 break-words [overflow-wrap:anywhere]">
+                      {opt.description}
+                    </div>
+                  )}
+                  {opt.isOther && selected && (
+                    <div
+                      ref={otherInputRef}
+                      role="textbox"
+                      aria-label={t('questionBlock.otherPlaceholder')}
+                      contentEditable
+                      suppressContentEditableWarning
+                      data-testid="question-other-input"
+                      spellCheck={false}
+                      onFocus={() => setOtherFocused(true)}
+                      onBlur={() => setOtherFocused(false)}
+                      onClick={(e) => e.stopPropagation()}
+                      onInput={(e) => {
+                        const txt = (e.currentTarget.textContent ?? '').replace(/\n/g, '');
+                        setOtherText((prev) => ({ ...prev, [current.question]: txt }));
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.nativeEvent.isComposing) return;
+                        e.stopPropagation();
+                        if (e.key === 'Enter' && !e.shiftKey) {
+                          e.preventDefault();
+                          if (active < questions.length - 1) setActive(active + 1);
+                        }
+                      }}
+                      className="mt-2 min-h-[28px] px-2 py-1 rounded-sm border border-border-default bg-bg-app text-body text-fg-primary outline-none focus-ring-waiting empty:before:content-[attr(data-placeholder)] empty:before:text-fg-tertiary"
+                      data-placeholder={t('questionBlock.otherPlaceholder')}
+                    />
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="px-3 pb-3 flex items-center justify-between gap-2">
+        <span className="text-meta text-fg-tertiary font-mono">
+          {questions.length > 1
+            ? t('questionBlock.pageHint', { current: active + 1, total: questions.length })
+            : t('questionBlock.singleHint')}
+        </span>
+        <button
+          type="button"
+          data-testid="question-submit"
+          disabled={!allAnswered || submitted}
+          onClick={submit}
+          className={
+            'inline-flex items-center px-3 py-1.5 rounded-sm text-body font-medium outline-none focus-ring-waiting transition-colors duration-150 ease-out ' +
+            (allAnswered && !submitted
+              ? 'bg-state-waiting/20 text-fg-primary border border-state-waiting/60 hover:bg-state-waiting/30'
+              : 'border border-border-subtle text-fg-disabled cursor-not-allowed')
+          }
+        >
+          {submitted ? t('questionBlock.submitted') : t('questionBlock.submit')}
+        </button>
+      </div>
+    </motion.div>
   );
 }

--- a/src/components/QuestionStickyHost.tsx
+++ b/src/components/QuestionStickyHost.tsx
@@ -1,0 +1,110 @@
+import { useMemo } from 'react';
+import { useStore } from '../stores/store';
+import { QuestionBlock } from './QuestionBlock';
+import type { MessageBlock } from '../types';
+
+/**
+ * Sticky host for the AskUserQuestion widget.
+ *
+ * Rendered between `<ChatStream />` and `<InputBar />` in `App.tsx`.
+ * Picks the FIRST unanswered `kind: 'question'` block in the active
+ * session and renders it via `<QuestionBlock />`. Only one card is shown
+ * even if multiple `question` blocks have queued (cross-turn queue —
+ * each card drains in order as the user submits / rejects).
+ *
+ * Rationale: this matches the upstream Claude VS Code extension layout
+ * (webview/index.js around line 2043 — `permissionsContainer` lives in
+ * the input/composer region, not in the messages list, and only the
+ * first request in `permissionRequests.value` is rendered). Sticky
+ * placement also means the prompt never scrolls away when the agent
+ * keeps streaming text BELOW it (which can happen between the AskUser
+ * tool_use frame and the model's awaiting-answer pause).
+ */
+export function QuestionStickyHost({ sessionId }: { sessionId: string }) {
+  const blocks = useStore((s) => s.messagesBySession[sessionId]);
+  const markQuestionAnswered = useStore((s) => s.markQuestionAnswered);
+  const bumpComposerFocus = useStore((s) => s.bumpComposerFocus);
+
+  // First UNANSWERED question block is the only one we expose. If the
+  // user clears the queue mid-flight or the session changes between
+  // renders this becomes undefined and the host renders nothing.
+  const pending = useMemo(() => {
+    if (!blocks) return undefined;
+    for (const b of blocks) {
+      if (b.kind === 'question' && !b.answered) return b;
+    }
+    return undefined;
+  }, [blocks]);
+
+  if (!pending) return null;
+  const block = pending as Extract<MessageBlock, { kind: 'question' }>;
+
+  return (
+    <QuestionBlock
+      key={block.id}
+      questions={block.questions}
+      onSubmit={(answersByQuestion) => {
+        const api = window.ccsm;
+        if (!api) return;
+        // Two flows land here:
+        //  1. can_use_tool path (current claude.exe spawn): the question
+        //     block carries `requestId`. We deny the pending permission
+        //     promise on the main side so claude.exe stops blocking on
+        //     it, then send the answers as a fresh user turn so the
+        //     model receives them. This is intentionally lossy in the
+        //     CLI sense (we don't write back to the AskUserQuestion
+        //     tool_result), but it matches what the user actually wants
+        //     and unblocks the turn cleanly. Mirrors upstream's submit
+        //     path semantics — see PermissionPromptBlock for the
+        //     analogous wiring.
+        //  2. tool_use-only path (no requestId): the bogus tool_result
+        //     has already landed via the dedicated AskUserQuestion
+        //     handler; just send the user's answers as the next turn.
+        if (block.requestId) {
+          void api.agentResolvePermission(sessionId, block.requestId, 'deny');
+        }
+        // Serialize the per-question Q→A map into a single user-message
+        // body. Keeps the wire format simple (one agentSend call) and
+        // produces a chat history that reads naturally if the user
+        // scrolls back. We use upstream's "\n " separator to split
+        // multi-select answers inside a single question's value; here
+        // we pre-split each value back to per-line answers under the Q
+        // for the prompt body.
+        const lines: string[] = [];
+        for (const q of block.questions) {
+          const a = answersByQuestion[q.question];
+          if (!a) continue;
+          lines.push(`Q: ${q.question}`);
+          // Each "\n " in `a` already implies a separate line in the
+          // outgoing prompt — emit them as `A: <first>` then bare lines.
+          const parts = a.split(/\n\s*/);
+          lines.push(`A: ${parts[0]}`);
+          for (let i = 1; i < parts.length; i++) lines.push(`   ${parts[i]}`);
+        }
+        const text = lines.join('\n');
+        void api.agentSend(sessionId, text);
+        markQuestionAnswered(sessionId, block.id, {
+          answers: answersByQuestion,
+          rejected: false
+        });
+        bumpComposerFocus();
+      }}
+      onReject={() => {
+        const api = window.ccsm;
+        // Reject path: only the can_use_tool flow has a requestId we can
+        // settle. For the tool_use-only path there's nothing on the main
+        // side to deny — we just drop the card from the sticky and leave
+        // the bogus tool_result already in the timeline. Either way the
+        // timeline keeps a "rejected" trace row.
+        if (api && block.requestId) {
+          void api.agentResolvePermission(sessionId, block.requestId, 'deny');
+        }
+        markQuestionAnswered(sessionId, block.id, {
+          answers: {},
+          rejected: true
+        });
+        bumpComposerFocus();
+      }}
+    />
+  );
+}

--- a/src/components/chat/blocks/QuestionAnsweredRow.tsx
+++ b/src/components/chat/blocks/QuestionAnsweredRow.tsx
@@ -1,0 +1,57 @@
+import type { QuestionSpec } from '../../../types';
+import { useTranslation } from '../../../i18n/useTranslation';
+
+/**
+ * Compact summary row left in the timeline AFTER the user submits or
+ * rejects an AskUserQuestion prompt. Mirrors the upstream Claude VS Code
+ * extension behavior of "card 出队 / timeline 留 ToolBlock result row":
+ * the live sticky widget vanishes the moment the user commits, but the
+ * chat retains a scrollable trace of what was asked and what was sent
+ * back so the conversation history reads naturally on scrollback.
+ */
+export function QuestionAnsweredRow({
+  questions,
+  answers,
+  rejected
+}: {
+  questions: QuestionSpec[];
+  answers?: Record<string, string>;
+  rejected: boolean;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div
+      data-testid="question-answered-row"
+      data-rejected={rejected ? 'true' : 'false'}
+      role="status"
+      className="relative my-1.5 rounded-md border border-border-subtle bg-bg-elevated/60 pl-3 pr-3 py-1.5 text-meta text-fg-tertiary"
+    >
+      <span aria-hidden className="absolute left-0 top-0 bottom-0 w-[2px] rounded-l-md bg-border-strong" />
+      <div className="flex items-baseline gap-2 mb-0.5">
+        <span className="font-mono uppercase tracking-wider text-mono-xs text-fg-tertiary">
+          {t('questionBlock.timelineLabel')}
+        </span>
+        <span className="text-fg-secondary">
+          {rejected ? t('questionBlock.timelineRejected') : t('questionBlock.timelineAnswered')}
+        </span>
+      </div>
+      {!rejected && answers && (
+        <ul className="mt-1 space-y-0.5">
+          {questions.map((q, i) => {
+            const a = answers[q.question];
+            if (!a) return null;
+            // Render multi-line "Other" answers cleanly: replace the upstream
+            // join separator ("\n ") with a comma for the compact summary.
+            const compact = a.replace(/\n\s*/g, ', ');
+            return (
+              <li key={i} className="text-fg-secondary break-words [overflow-wrap:anywhere]">
+                <span className="text-fg-tertiary">{q.question} </span>
+                <span className="text-fg-primary">→ {compact}</span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/chat/renderBlock.tsx
+++ b/src/components/chat/renderBlock.tsx
@@ -1,6 +1,5 @@
 import type { MessageBlock } from '../../types';
 import { PermissionPromptBlock } from '../PermissionPromptBlock';
-import { QuestionBlock } from '../QuestionBlock';
 import { UserBlock } from './blocks/UserBlock';
 import { AssistantBlock } from './blocks/AssistantBlock';
 import { ToolBlock } from './blocks/ToolBlock';
@@ -9,12 +8,13 @@ import { PlanBlock } from './blocks/PlanBlock';
 import { StatusBanner } from './blocks/StatusBanner';
 import { SystemTraceBlock } from './blocks/SystemTraceBlock';
 import { ErrorBlock } from './blocks/ErrorBlock';
+import { QuestionAnsweredRow } from './blocks/QuestionAnsweredRow';
 
 export function renderBlock(
   b: MessageBlock,
   activeId: string,
   resolvePermission: (sid: string, rid: string, d: 'allow' | 'deny') => void,
-  bumpComposerFocus: () => void,
+  _bumpComposerFocus: () => void,
   addAllowAlways: (toolName: string) => void,
   opts: {
     permissionAutoFocus?: boolean;
@@ -67,29 +67,17 @@ export function renderBlock(
         />
       );
     case 'question':
-      return (
-        <QuestionBlock
-          questions={b.questions}
-          onSubmit={(answersText) => {
-            const api = window.ccsm;
-            if (!api) return;
-            // Two flows land here:
-            //  1. can_use_tool path (SDK-era / possible future): answers the
-            //     pending permission with "deny" and sends the answer as a
-            //     fresh user message — slightly lossy but unblocks the turn.
-            //  2. tool_use path (current claude.exe spawn): no requestId, the
-            //     bogus tool_result has already landed, agent is waiting on
-            //     the next user turn. Just send the answer text.
-            if (b.requestId) {
-              void api.agentResolvePermission(activeId, b.requestId, 'deny');
-            }
-            void api.agentSend(activeId, answersText);
-            // Return focus to the composer so the user's next keystroke types
-            // into chat instead of being eaten by the now-disabled options.
-            bumpComposerFocus();
-          }}
-        />
-      );
+      // Live (unanswered) question cards no longer render in the timeline —
+      // they're handled by the sticky `<QuestionStickyHost />` above the
+      // composer, mirroring the upstream Claude VS Code extension's
+      // permission-request placement (webview/index.js → permissionsContainer
+      // host between the messages list and the inputContainer). Once the
+      // user submits or rejects, we leave a compact summary row in the
+      // timeline so the chat retains a scrollable record of the prompt and
+      // the answer that was sent — matches upstream's "card 出队 / timeline
+      // 留 ToolBlock result row" outcome.
+      if (!b.answered) return null;
+      return <QuestionAnsweredRow questions={b.questions} answers={b.answers} rejected={!!b.rejected} />;
     case 'status':
       return <StatusBanner tone={b.tone} title={b.title} detail={b.detail} />;
     case 'system':

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -360,7 +360,16 @@ const en = {
   questionBlock: {
     title: 'Question awaiting answer',
     submit: 'Submit answer',
-    submitted: 'Submitted'
+    submitted: 'Submitted',
+    cancel: 'Dismiss',
+    other: 'Other',
+    otherPlaceholder: 'Type your answer…',
+    pageHint: 'Question {{current}} of {{total}}',
+    singleHint: '↑/↓ option · Enter select · Esc dismiss',
+    tabFallback: 'Q{{n}}',
+    timelineLabel: 'Asked',
+    timelineAnswered: 'You answered',
+    timelineRejected: 'Dismissed without answer'
   },
   slashCommands: {
     pickerTitle: 'Slash commands',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -337,7 +337,16 @@ const zh: EnCatalog = {
   questionBlock: {
     title: '等待你的回答',
     submit: '提交回答',
-    submitted: '已提交'
+    submitted: '已提交',
+    cancel: '关闭',
+    other: '其他',
+    otherPlaceholder: '输入你的回答…',
+    pageHint: '第 {{current}} / {{total}} 题',
+    singleHint: '↑/↓ 切选项 · Enter 选中 · Esc 关闭',
+    tabFallback: '第 {{n}} 题',
+    timelineLabel: '已询问',
+    timelineAnswered: '你已回答',
+    timelineRejected: '未回答即关闭'
   },
   slashCommands: {
     pickerTitle: '斜杠命令',

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -459,6 +459,16 @@ type Actions = {
   setGroupCollapsed: (id: string, collapsed: boolean) => void;
 
   appendBlocks: (sessionId: string, blocks: MessageBlock[]) => void;
+  /** Mark a `kind: 'question'` block as answered (or rejected via Esc). The
+   *  sticky AskUserQuestion widget hides for this block once `answered`
+   *  flips true; the timeline keeps the block in place but renders a
+   *  compact summary row instead of the live card. Mirrors upstream's
+   *  "card 出队 / timeline 留 result row" behavior. */
+  markQuestionAnswered: (
+    sessionId: string,
+    blockId: string,
+    payload: { answers: Record<string, string>; rejected: boolean }
+  ) => void;
   streamAssistantText: (sessionId: string, blockId: string, appendText: string, done: boolean) => void;
   // (#336) Stream the in-flight `command` arg of a Bash tool_use as the
   // model types it. Creates a placeholder tool block on the first delta
@@ -1567,6 +1577,28 @@ export const useStore = create<State & Actions>((set, get) => ({
       const finalNext = toAppend.length > 0 ? next.concat(toAppend) : next;
       return {
         messagesBySession: { ...s.messagesBySession, [sessionId]: finalNext }
+      };
+    });
+  },
+
+  markQuestionAnswered: (sessionId, blockId, payload) => {
+    set((s) => {
+      const prev = s.messagesBySession[sessionId] ?? [];
+      const idx = prev.findIndex((b) => b.id === blockId);
+      if (idx === -1) return s;
+      const existing = prev[idx];
+      if (existing.kind !== 'question') return s;
+      // Idempotent: ignore double-submit (StrictMode, race with re-render).
+      if (existing.answered) return s;
+      const next = prev.slice();
+      next[idx] = {
+        ...existing,
+        answered: true,
+        answers: payload.answers,
+        rejected: payload.rejected
+      };
+      return {
+        messagesBySession: { ...s.messagesBySession, [sessionId]: next }
       };
     });
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,7 +130,24 @@ export type MessageBlock =
       toolName?: string;
       toolInput?: Record<string, unknown>;
     }
-  | { kind: 'question'; id: string; requestId?: string; toolUseId?: string; questions: QuestionSpec[] }
+  | {
+      kind: 'question';
+      id: string;
+      requestId?: string;
+      toolUseId?: string;
+      questions: QuestionSpec[];
+      // Set true once the user submits or rejects via Esc. The sticky
+      // widget hides and the timeline renders a compact summary row in
+      // place of the live card. Mirrors upstream's "card 出队, timeline 留
+      // result row" behavior.
+      answered?: boolean;
+      // Per-question answers as a Q→A map (Other replaced with the typed
+      // text, multi-select labels joined by `"\n "`). Absent when the user
+      // rejected via Esc.
+      answers?: Record<string, string>;
+      // True when the user dismissed the prompt via Esc / X with no answer.
+      rejected?: boolean;
+    }
   | { kind: 'status'; id: string; tone: 'info' | 'warn'; title: string; detail?: string }
   | {
       kind: 'system';

--- a/tests/question-block.test.tsx
+++ b/tests/question-block.test.tsx
@@ -1,160 +1,184 @@
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent, act, within } from '@testing-library/react';
 import { QuestionBlock } from '../src/components/QuestionBlock';
 import type { QuestionSpec } from '../src/types';
 
-function flushRaf() {
-  return act(async () => {
-    await new Promise((r) => setTimeout(r, 20));
+// Lets the rAF that schedules option auto-focus run, plus the 300ms
+// auto-advance timer when single-select picks fire.
+async function flushTimers(ms = 350) {
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, ms));
   });
 }
 
-describe('<QuestionBlock />', () => {
-  const singleSelect: QuestionSpec[] = [
-    {
-      question: 'Which language?',
-      options: [
-        { label: 'Python' },
-        { label: 'TypeScript' },
-        { label: 'Rust' }
-      ]
-    }
-  ];
+const SINGLE: QuestionSpec[] = [
+  {
+    question: 'Which language?',
+    header: 'Language',
+    options: [{ label: 'Python' }, { label: 'TypeScript' }, { label: 'Rust' }]
+  }
+];
 
-  const multiSelect: QuestionSpec[] = [
-    {
-      question: 'Which tools?',
-      multiSelect: true,
-      options: [
-        { label: 'ESLint' },
-        { label: 'Prettier' },
-        { label: 'Vitest' }
-      ]
-    }
-  ];
+const MULTI: QuestionSpec[] = [
+  {
+    question: 'Which tools?',
+    header: 'Tools',
+    multiSelect: true,
+    options: [{ label: 'ESLint' }, { label: 'Prettier' }, { label: 'Vitest' }]
+  }
+];
 
-  it('auto-focuses the first option on mount (single-select)', async () => {
-    render(<QuestionBlock questions={singleSelect} onSubmit={() => {}} />);
-    await flushRaf();
-    const radios = screen.getAllByRole('radio');
-    expect(document.activeElement).toBe(radios[0]);
+const TRIPLE: QuestionSpec[] = [
+  {
+    question: 'Q1?',
+    header: 'One',
+    options: [{ label: 'A' }, { label: 'B' }]
+  },
+  {
+    question: 'Q2?',
+    header: 'Two',
+    options: [{ label: 'X' }, { label: 'Y' }]
+  },
+  {
+    question: 'Q3?',
+    header: 'Three',
+    multiSelect: true,
+    options: [{ label: 'Cat' }, { label: 'Dog' }]
+  }
+];
+
+describe('<QuestionBlock /> upstream parity', () => {
+  it('always appends an Other option to every question', async () => {
+    render(<QuestionBlock questions={SINGLE} onSubmit={() => {}} />);
+    await flushTimers(50);
+    const opts = screen.getAllByRole('radio');
+    // 3 model options + Other.
+    expect(opts).toHaveLength(4);
+    expect(opts[3].dataset.questionLabel).toBe('Other');
   });
 
-  it('wires arrow-key navigation via Radix RadioGroup (orientation=vertical)', async () => {
-    const { container } = render(<QuestionBlock questions={singleSelect} onSubmit={() => {}} />);
-    await flushRaf();
-    const group = container.querySelector('[role="radiogroup"]');
-    expect(group).not.toBeNull();
-    expect(group?.getAttribute('aria-orientation')).toBe('vertical');
-    const radios = screen.getAllByRole('radio');
-    // All three options rendered, and one is tabbable (the roving tab stop).
-    expect(radios).toHaveLength(3);
-    const tabbable = radios.filter((r) => r.getAttribute('tabindex') === '0');
-    expect(tabbable.length).toBe(1);
-  });
-
-  it('Enter on a focused option submits the currently-selected option', async () => {
+  it('Submit is disabled until every question has a selection (multi-question)', async () => {
     const onSubmit = vi.fn();
-    render(<QuestionBlock questions={singleSelect} onSubmit={onSubmit} />);
-    await flushRaf();
+    render(<QuestionBlock questions={TRIPLE} onSubmit={onSubmit} />);
+    await flushTimers(50);
+    expect(screen.getByTestId('question-submit')).toBeDisabled();
+  });
+
+  it('single-select auto-advances to next question after a 300ms confirm', async () => {
+    render(<QuestionBlock questions={TRIPLE} onSubmit={() => {}} />);
+    await flushTimers(50);
+    expect(screen.getByTestId('question-tab-0').dataset.active).toBe('true');
+    fireEvent.click(screen.getAllByRole('radio')[0]);
+    await flushTimers(350);
+    expect(screen.getByTestId('question-tab-1').dataset.active).toBe('true');
+  });
+
+  it('does NOT auto-advance on the last question', async () => {
+    render(<QuestionBlock questions={TRIPLE} onSubmit={() => {}} />);
+    await flushTimers(50);
+    fireEvent.click(screen.getByTestId('question-tab-2'));
+    await flushTimers(50);
+    fireEvent.click(screen.getAllByRole('checkbox')[0]);
+    await flushTimers(400);
+    expect(screen.getByTestId('question-tab-2').dataset.active).toBe('true');
+  });
+
+  it('multi-select toggles options and never auto-advances', async () => {
+    render(<QuestionBlock questions={MULTI} onSubmit={() => {}} />);
+    await flushTimers(50);
+    const boxes = screen.getAllByRole('checkbox');
+    fireEvent.click(boxes[0]);
+    fireEvent.click(boxes[1]);
+    expect(boxes[0].getAttribute('aria-checked')).toBe('true');
+    expect(boxes[1].getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('left/right arrow keys page between questions and preserve answers', async () => {
+    render(<QuestionBlock questions={TRIPLE} onSubmit={() => {}} />);
+    await flushTimers(50);
+    fireEvent.click(screen.getByTestId('question-tab-1'));
+    await flushTimers(50);
+    fireEvent.click(screen.getAllByRole('radio')[1]); // pick Y on Q2
+    await flushTimers(350);
+    const root = screen.getByRole('dialog');
+    fireEvent.keyDown(root, { key: 'ArrowLeft' });
+    fireEvent.keyDown(root, { key: 'ArrowLeft' });
+    expect(screen.getByTestId('question-tab-0').dataset.active).toBe('true');
+    fireEvent.keyDown(root, { key: 'ArrowRight' });
+    expect(screen.getByTestId('question-tab-1').dataset.active).toBe('true');
     const radios = screen.getAllByRole('radio');
-    // Simulate user clicking option 2 (TypeScript) then pressing Enter while focused.
-    fireEvent.click(radios[1]);
-    radios[1].focus();
-    fireEvent.keyDown(radios[1], { key: 'Enter' });
+    expect(radios[1].getAttribute('aria-checked')).toBe('true');
+    expect(screen.getByTestId('question-tab-1').dataset.answered).toBe('true');
+  });
+
+  it('Other selection expands an inline input; submit replaces label with the typed text', async () => {
+    const onSubmit = vi.fn();
+    render(<QuestionBlock questions={SINGLE} onSubmit={onSubmit} />);
+    await flushTimers(50);
+    const opts = screen.getAllByRole('radio');
+    fireEvent.click(opts[3]);
+    await flushTimers(20);
+    const input = screen.getByTestId('question-other-input');
+    input.textContent = 'Haskell, Lisp';
+    fireEvent.input(input);
+    fireEvent.click(screen.getByTestId('question-submit'));
     expect(onSubmit).toHaveBeenCalledTimes(1);
-    expect(onSubmit.mock.calls[0][0]).toMatch(/TypeScript/);
+    const payload = onSubmit.mock.calls[0][0] as Record<string, string>;
+    expect(payload['Which language?']).toBe('Haskell, Lisp');
   });
 
-  it('Escape blurs the focused option without submitting', async () => {
+  it('multi-select payload joins labels with "\\n " (matches upstream)', async () => {
     const onSubmit = vi.fn();
-    render(<QuestionBlock questions={singleSelect} onSubmit={onSubmit} />);
-    await flushRaf();
-    const radios = screen.getAllByRole('radio');
-    radios[0].focus();
-    expect(document.activeElement).toBe(radios[0]);
-    fireEvent.keyDown(radios[0], { key: 'Escape' });
-    expect(document.activeElement).not.toBe(radios[0]);
+    render(<QuestionBlock questions={MULTI} onSubmit={onSubmit} />);
+    await flushTimers(50);
+    const boxes = screen.getAllByRole('checkbox');
+    fireEvent.click(boxes[0]);
+    fireEvent.click(boxes[2]);
+    fireEvent.click(screen.getByTestId('question-submit'));
+    const payload = onSubmit.mock.calls[0][0] as Record<string, string>;
+    expect(payload['Which tools?']).toBe('ESLint\n Vitest');
+  });
+
+  it('Esc invokes onReject and does NOT submit', async () => {
+    const onSubmit = vi.fn();
+    const onReject = vi.fn();
+    render(<QuestionBlock questions={SINGLE} onSubmit={onSubmit} onReject={onReject} />);
+    await flushTimers(50);
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+    expect(onReject).toHaveBeenCalledTimes(1);
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it('pre-selects the first option so Submit is enabled immediately (single-select)', async () => {
-    render(<QuestionBlock questions={singleSelect} onSubmit={() => {}} />);
-    await flushRaf();
-    const submit = screen.getByRole('button', { name: /submit answer/i });
-    expect(submit).not.toBeDisabled();
+  it('chip tabs reflect per-question answered state', async () => {
+    render(<QuestionBlock questions={TRIPLE} onSubmit={() => {}} />);
+    await flushTimers(50);
+    expect(screen.getByTestId('question-tab-0').dataset.answered).toBe('false');
+    fireEvent.click(screen.getAllByRole('radio')[0]);
+    await flushTimers(350);
+    expect(screen.getByTestId('question-tab-0').dataset.answered).toBe('true');
   });
 
-  it('Submit is disabled until at least one box is checked (multi-select)', async () => {
-    render(<QuestionBlock questions={multiSelect} onSubmit={() => {}} />);
-    await flushRaf();
-    const submit = screen.getByRole('button', { name: /submit answer/i });
-    expect(submit).toBeDisabled();
-    const boxes = screen.getAllByRole('checkbox');
-    fireEvent.click(boxes[1]);
-    expect(submit).not.toBeDisabled();
+  it('renders nothing if questions is empty', () => {
+    const { container } = render(<QuestionBlock questions={[]} onSubmit={() => {}} />);
+    expect(container.firstChild).toBeNull();
   });
 
-  it('multi-select: Space toggles the focused checkbox', async () => {
-    render(<QuestionBlock questions={multiSelect} onSubmit={() => {}} />);
-    await flushRaf();
-    const boxes = screen.getAllByRole('checkbox');
-    boxes[0].focus();
-    expect(boxes[0].getAttribute('data-state')).toBe('unchecked');
-    // Radix Checkbox toggles on Space via native button activation.
-    fireEvent.keyDown(boxes[0], { key: ' ', code: 'Space' });
-    fireEvent.keyUp(boxes[0], { key: ' ', code: 'Space' });
-    // jsdom doesn't always dispatch click on keyup-space for buttons; fall
-    // back to a direct click to assert the wiring via onCheckedChange.
-    if (boxes[0].getAttribute('data-state') !== 'checked') {
-      fireEvent.click(boxes[0]);
-    }
-    expect(boxes[0].getAttribute('data-state')).toBe('checked');
+  it('options expose role=radio (single) or role=checkbox (multi)', async () => {
+    const { rerender } = render(<QuestionBlock questions={SINGLE} onSubmit={() => {}} />);
+    await flushTimers(50);
+    expect(screen.getAllByRole('radio').length).toBeGreaterThan(0);
+    rerender(<QuestionBlock questions={MULTI} onSubmit={() => {}} />);
+    await flushTimers(50);
+    expect(screen.getAllByRole('checkbox').length).toBeGreaterThan(0);
   });
 
-  it('does not auto-focus when autoFocus={false} (older widgets stay put)', async () => {
-    const { container } = render(
-      <div>
-        <QuestionBlock questions={singleSelect} onSubmit={() => {}} autoFocus={false} />
-      </div>
-    );
-    await flushRaf();
-    // No option should have grabbed focus.
-    const radios = container.querySelectorAll('[role="radio"]');
-    expect(document.activeElement).not.toBe(radios[0]);
-  });
-
-  it('older widget keeps focus away when a new widget mounts later (no focus steal)', async () => {
-    const { rerender } = render(
-      <div>
-        <QuestionBlock questions={singleSelect} onSubmit={() => {}} autoFocus={false} />
-      </div>
-    );
-    await flushRaf();
-    // Simulate user focusing an external element (the document body here).
-    const external = document.createElement('input');
-    document.body.appendChild(external);
-    external.focus();
-    expect(document.activeElement).toBe(external);
-
-    rerender(
-      <div>
-        <QuestionBlock questions={singleSelect} onSubmit={() => {}} autoFocus={false} />
-        <QuestionBlock
-          questions={[
-            {
-              question: 'Second?',
-              options: [{ label: 'A' }, { label: 'B' }]
-            }
-          ]}
-          onSubmit={() => {}}
-        />
-      </div>
-    );
-    await flushRaf();
-    // External element still has focus — the new widget must not steal.
-    expect(document.activeElement).toBe(external);
-    document.body.removeChild(external);
+  it('navbar exposes a chip per question with the header label', async () => {
+    render(<QuestionBlock questions={TRIPLE} onSubmit={() => {}} />);
+    await flushTimers(50);
+    const nav = screen.getByTestId('question-nav-bar');
+    expect(within(nav).getByText('One')).toBeTruthy();
+    expect(within(nav).getByText('Two')).toBeTruthy();
+    expect(within(nav).getByText('Three')).toBeTruthy();
   });
 });

--- a/tests/question-sticky-host.test.tsx
+++ b/tests/question-sticky-host.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react';
+import React from 'react';
+import { QuestionStickyHost } from '../src/components/QuestionStickyHost';
+import { useStore } from '../src/stores/store';
+import type { MessageBlock } from '../src/types';
+
+const initial = useStore.getState();
+
+afterEach(() => cleanup());
+
+const QSPEC = {
+  question: 'Pick one',
+  options: [{ label: 'A' }, { label: 'B' }]
+};
+
+function seedBlocks(blocks: MessageBlock[]) {
+  useStore.setState(
+    {
+      ...initial,
+      activeId: 's1',
+      messagesBySession: { s1: blocks }
+    },
+    true
+  );
+}
+
+const ccsmStub = {
+  agentSend: vi.fn().mockResolvedValue(true),
+  agentResolvePermission: vi.fn().mockResolvedValue(undefined),
+  agentSendContent: vi.fn().mockResolvedValue(true),
+  agentInterrupt: vi.fn().mockResolvedValue(undefined)
+};
+
+beforeEach(() => {
+  ccsmStub.agentSend.mockClear();
+  ccsmStub.agentResolvePermission.mockClear();
+  (window as unknown as { ccsm?: typeof ccsmStub }).ccsm = ccsmStub;
+});
+
+async function flush(ms = 50) {
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, ms));
+  });
+}
+
+describe('<QuestionStickyHost />', () => {
+  it('renders nothing when no question block exists', () => {
+    seedBlocks([{ kind: 'user', id: 'u1', text: 'hi' }]);
+    const { container } = render(<QuestionStickyHost sessionId="s1" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders only the FIRST unanswered question block (cross-turn queue)', async () => {
+    seedBlocks([
+      { kind: 'question', id: 'q1', questions: [{ ...QSPEC, header: 'First' }] },
+      { kind: 'question', id: 'q2', questions: [{ ...QSPEC, header: 'Second' }] }
+    ]);
+    render(<QuestionStickyHost sessionId="s1" />);
+    await flush();
+    // Only one nav bar (so only one card).
+    expect(screen.getAllByTestId('question-nav-bar').length).toBe(1);
+    expect(screen.getByText('First')).toBeTruthy();
+    expect(screen.queryByText('Second')).toBeNull();
+  });
+
+  it('on submit: marks block answered, advances queue, calls agentSend', async () => {
+    seedBlocks([
+      { kind: 'question', id: 'q1', questions: [{ ...QSPEC, header: 'First' }] },
+      { kind: 'question', id: 'q2', questions: [{ ...QSPEC, header: 'Second' }] }
+    ]);
+    render(<QuestionStickyHost sessionId="s1" />);
+    await flush();
+    fireEvent.click(screen.getAllByRole('radio')[0]); // pick A
+    await flush(50);
+    fireEvent.click(screen.getByTestId('question-submit'));
+    await flush(50);
+    expect(ccsmStub.agentSend).toHaveBeenCalledTimes(1);
+    const sent = ccsmStub.agentSend.mock.calls[0][1] as string;
+    expect(sent).toContain('Pick one');
+    expect(sent).toContain('A');
+    // Store should now flag q1 answered, exposing q2 as the active card.
+    const state = useStore.getState();
+    const blocks = state.messagesBySession.s1;
+    const q1 = blocks.find((b) => b.id === 'q1');
+    expect(q1?.kind === 'question' && q1.answered).toBe(true);
+    // Queue advances: now Second is the only sticky card.
+    expect(screen.getByText('Second')).toBeTruthy();
+  });
+
+  it('on Esc reject: marks block rejected without sending answers', async () => {
+    seedBlocks([
+      {
+        kind: 'question',
+        id: 'q1',
+        questions: [QSPEC],
+        requestId: 'rid-1'
+      }
+    ]);
+    render(<QuestionStickyHost sessionId="s1" />);
+    await flush();
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+    await flush(50);
+    expect(ccsmStub.agentSend).not.toHaveBeenCalled();
+    expect(ccsmStub.agentResolvePermission).toHaveBeenCalledWith('s1', 'rid-1', 'deny');
+    const blocks = useStore.getState().messagesBySession.s1;
+    const q1 = blocks.find((b) => b.id === 'q1');
+    expect(q1?.kind === 'question' && q1.answered && q1.rejected).toBe(true);
+  });
+});


### PR DESCRIPTION
## Layer 1 (necessity / approach)

**Why this PR.** Task #37 — bring ccsm's AskUserQuestion UI to 1:1 parity with the upstream Claude VS Code extension's `o30` permission component (`webview/index.js` ~line 1519). Today ccsm renders the question card inline in the timeline, with no chip-tab navigation, no auto-advance, no synthetic Other option, and no cross-turn queue. That diverges from upstream behaviour the user already knows from the official extension and forces extra clicks for multi-question prompts.

**Direction check.** Upstream behaviour is the canonical reference for this surface — there is no novel design to invent here. The host-side wiring (sticky placement above composer, queue of `permissionRequests.value[0]`) is also already locked in upstream's chat shell. Implementing it the same way removes a custom code path rather than adding one.

**Approach.** Out-of-timeline sticky host (`QuestionStickyHost`) reads the first unanswered `kind: 'question'` block for the active session and renders the rewritten `QuestionBlock` between `<ChatStream />` and `<InputBar />`. Submit/reject mark the underlying block `answered` (new state) so the sticky vanishes and a compact "Asked → answered" trace row stays in the timeline — mirrors upstream's "card 出队 / timeline 留 result row" outcome without needing to invent a new system block subkind.

## What changed

Behaviour (one-to-one with upstream `o30`):
- Sticky placement above composer, never in scroll.
- Cross-turn queue: only the first unanswered question block surfaces.
- Chip-tab nav across questions inside one AskUserQuestion call.
- ←/→ pages question, ↑/↓ moves option focus, Enter activates.
- Single-select: 300ms confirm highlight then auto-advance (last question stays put).
- Multi-select: toggle, never auto-advance.
- Synthetic `Other` option appended to every question; selecting expands inline contenteditable input.
- Submit payload: `answers[question] = labels.join("\n ")`, `Other` replaced by typed text. Submit gated on every question being answered.
- Esc anywhere = reject path: denies pending `can_use_tool` permission, no answer sent.

Touched files:
- `src/components/QuestionBlock.tsx` — full rewrite.
- `src/components/QuestionStickyHost.tsx` — new sticky host.
- `src/App.tsx` — wires the host between `ChatStream` and `InputBar`.
- `src/components/chat/renderBlock.tsx` — `kind: 'question'` returns null while live, summary row once answered.
- `src/components/chat/blocks/QuestionAnsweredRow.tsx` — new compact trace.
- `src/types.ts` — `question` block gains `answered`, `answers`, `rejected`.
- `src/stores/store.ts` — new `markQuestionAnswered` action.
- `src/components/InputBar.tsx` — `hasPendingWaiting` honours unanswered questions too.
- `src/i18n/locales/{en,zh}.ts` — chip / hint / Other / timeline strings (en+zh parity).
- `tests/question-block.test.tsx` — suite rewritten for the new behaviour.
- `tests/question-sticky-host.test.tsx` — new suite for queue / submit / Esc.

## Test plan
- [x] `npm run typecheck` — passes (web + electron projects)
- [x] Vitest: 19 question-related tests pass (13 widget + 4 sticky-host + 2 i18n parity)
- [x] Full vitest run: 733 passed; 12 failures are all in `electron/__tests__/db*.test.ts` and trace to better-sqlite3 native binding not built in this dev install (`--ignore-scripts`). Unrelated to this PR.
- [ ] Reviewer: dev-smoke "Ask me 3 questions via AskUserQuestion" then verify single-select auto-advance, multi-select toggle, Other expansion, Esc reject, and queue ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)