### PR TITLE
feat(composer): up/down history recall on empty composer

### DIFF
--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -139,6 +139,31 @@ export function InputBar({ sessionId }: { sessionId: string }) {
   // Perf: subscribe to all reactive per-session signals via useShallow so this
   // component only re-renders when one of these specific values changes
   // (instead of once per any store mutation, like an appendBlocks chunk).
+  // PR-N: ↑/↓ history recall. Subscribe to a derived array of user-prompt
+  // texts (newest first) via useShallow so the component only re-renders when
+  // the recall list itself changes — not on every per-token assistant chunk.
+  // The selector skips slash-command echoes and image-only turns since those
+  // can't be re-sent through the textarea anyway.
+  const userPromptHistory = useStore(
+    useShallow((s) => {
+      const blocks = s.messagesBySession[sessionId] ?? [];
+      const out: string[] = [];
+      for (let i = blocks.length - 1; i >= 0; i--) {
+        const b = blocks[i];
+        if (b.kind !== 'user') continue;
+        if (!b.text || !b.text.trim()) continue;
+        out.push(b.text);
+      }
+      return out;
+    })
+  );
+  // recallIndex semantics:
+  //   0       → idle (composer reflects the user's own draft / empty)
+  //   1..N    → recall mode, value === userPromptHistory[index - 1]
+  // Reset on session switch (the sessionId effect below) and on any user edit
+  // that diverges from the recalled prompt.
+  const [recallIndex, setRecallIndex] = useState(0);
+
   const { session, started, running, queueLength, hasMessages, hasPendingWaiting, permission, focusInputNonce, pendingDiffCommentsCount, lastTurnEnd } = useStore(
     useShallow((s) => ({
       session: s.sessions.find((x) => x.id === sessionId),
@@ -239,6 +264,9 @@ export function InputBar({ sessionId }: { sessionId: string }) {
     setValue(getDraft(sessionId));
     setAttachments(attachmentCache.get(sessionId) ?? []);
     setRejections([]);
+    // PR-N: history recall is per-session — wipe the index when switching so
+    // ↑ on a fresh session always starts at the most recent prompt.
+    setRecallIndex(0);
   }, [sessionId]);
 
   // task322: continue-after-interrupt — show a one-line hint above the
@@ -293,6 +321,14 @@ export function InputBar({ sessionId }: { sessionId: string }) {
 
   function update(next: string) {
     setValue(next);
+    // PR-N: any user-initiated edit that diverges from the recalled prompt
+    // exits recall mode. Compare against the prompt at the current index so
+    // a programmatic recall fill (which routes through setValue directly,
+    // not update()) doesn't accidentally trip this guard.
+    if (recallIndex > 0) {
+      const recalled = userPromptHistory[recallIndex - 1];
+      if (next !== recalled) setRecallIndex(0);
+    }
     // task322: any keystroke (even one that lands an empty string back —
     // e.g. paste-then-undo) counts as user activity that dismisses the
     // continue-after-interrupt hint. We only flip the latch when the value
@@ -658,6 +694,60 @@ export function InputBar({ sessionId }: { sessionId: string }) {
         return;
       }
       send();
+      return;
+    }
+
+    // PR-N: ↑/↓ history recall. Strict guard so we never steal arrow keys
+    // from in-textarea caret movement during multi-line editing.
+    //   ↑ triggers iff value is exactly '' (idle) OR we're already in recall
+    //     mode (so ↑ keeps walking backwards through history).
+    //   ↓ triggers iff we're already in recall mode (idle ↓ is a no-op).
+    // Once a key is intercepted we preventDefault so the textarea doesn't
+    // also move the caret — relevant when value === '' (caret at 0 anyway,
+    // but the browser would still scroll the empty textarea to its top edge).
+    if (e.key === 'ArrowUp') {
+      const inRecall = recallIndex > 0;
+      if (value !== '' && !inRecall) return;
+      if (userPromptHistory.length === 0) return;
+      // Already at the oldest prompt — stop walking, swallow the keystroke
+      // so the textarea doesn't try to move the caret either.
+      if (recallIndex >= userPromptHistory.length) {
+        e.preventDefault();
+        return;
+      }
+      e.preventDefault();
+      const nextIndex = recallIndex + 1;
+      const recalled = userPromptHistory[nextIndex - 1];
+      setRecallIndex(nextIndex);
+      setValue(recalled);
+      setCaret(recalled.length);
+      // Place caret at the end after React commits the new value.
+      requestAnimationFrame(() => {
+        const el = textareaRef.current;
+        if (!el) return;
+        el.setSelectionRange(recalled.length, recalled.length);
+      });
+      return;
+    }
+    if (e.key === 'ArrowDown') {
+      if (recallIndex === 0) return; // idle — let textarea handle it
+      e.preventDefault();
+      const nextIndex = recallIndex - 1;
+      setRecallIndex(nextIndex);
+      if (nextIndex === 0) {
+        setValue('');
+        setCaret(0);
+      } else {
+        const recalled = userPromptHistory[nextIndex - 1];
+        setValue(recalled);
+        setCaret(recalled.length);
+        requestAnimationFrame(() => {
+          const el = textareaRef.current;
+          if (!el) return;
+          el.setSelectionRange(recalled.length, recalled.length);
+        });
+      }
+      return;
     }
   }
 

--- a/tests/inputbar-recall.test.tsx
+++ b/tests/inputbar-recall.test.tsx
@@ -1,0 +1,247 @@
+// PR-N: ↑/↓ history recall on the composer.
+//
+// Contract under test (strict — must NOT trip during normal multi-line edits):
+//   - ↑ on an exactly-empty composer fills the most recent user prompt.
+//   - Repeated ↑ walks backwards; ↑ at the oldest prompt is a no-op.
+//   - ↓ walks forward; ↓ at index 0 is a no-op (we never enter recall from
+//     idle via ↓).
+//   - ↓ from the most recent prompt clears the composer back to idle.
+//   - ↑ on a non-empty composer (and not already in recall) does nothing —
+//     the textarea handles it as a normal caret movement.
+//   - Any user edit while in recall mode that diverges from the recalled
+//     text exits recall mode (so the next ↑ restarts from the newest prompt).
+//   - Switching sessionId resets the recall index.
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, act, cleanup } from '@testing-library/react';
+import { InputBar } from '../src/components/InputBar';
+import { useStore } from '../src/stores/store';
+import { clearDraft } from '../src/stores/drafts';
+import type { MessageBlock } from '../src/types';
+
+const initial = useStore.getState();
+
+function freshStoreWithSession(
+  sessionId: string,
+  userTexts: string[] = [],
+  opts: { running?: boolean; started?: boolean } = {}
+) {
+  const messages: MessageBlock[] = userTexts.map((text, i) => ({
+    kind: 'user',
+    id: `u-${sessionId}-${i}`,
+    text,
+  }));
+  useStore.setState(
+    {
+      ...initial,
+      sessions: [
+        {
+          id: sessionId,
+          name: sessionId,
+          state: 'idle',
+          cwd: '~',
+          model: 'claude',
+          groupId: 'g-default',
+          agentType: 'claude-code',
+        },
+      ],
+      groups: [{ id: 'g-default', name: 'Sessions', collapsed: false, kind: 'normal' }],
+      activeId: sessionId,
+      messagesBySession: { [sessionId]: messages },
+      startedSessions: opts.started ? { [sessionId]: true } : {},
+      runningSessions: opts.running ? { [sessionId]: true } : {},
+      messageQueues: {},
+      pendingDiffComments: {},
+      lastTurnEnd: {},
+      interruptedSessions: {},
+      focusInputNonce: 0,
+    },
+    true
+  );
+}
+
+function stubCCSM(overrides: Partial<Record<string, unknown>> = {}) {
+  const api = {
+    agentInterrupt: vi.fn().mockResolvedValue(undefined),
+    agentSend: vi.fn().mockResolvedValue(true),
+    agentSendContent: vi.fn().mockResolvedValue(true),
+    agentStart: vi.fn().mockResolvedValue({ ok: true }),
+    saveMessages: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+  (globalThis as unknown as { window: Window & { ccsm?: unknown } }).window.ccsm = api;
+  return api;
+}
+
+beforeEach(() => {
+  cleanup();
+  (globalThis as unknown as { window: Window & { ccsm?: unknown } }).window.ccsm = undefined;
+  // The drafts cache is module-singleton in-memory state; tests can leak
+  // earlier `setDraft` calls into each other. Wipe both session ids we use.
+  clearDraft('s-recall');
+  clearDraft('s-other');
+});
+
+const SID = 's-recall';
+
+function getTextarea(): HTMLTextAreaElement {
+  return screen.getByRole('textbox') as HTMLTextAreaElement;
+}
+
+describe('InputBar: ↑/↓ history recall (PR-N)', () => {
+  it('↑ on empty composer fills the most recent user prompt', () => {
+    freshStoreWithSession(SID, ['first prompt', 'second prompt', 'third prompt'], { started: true });
+    stubCCSM();
+    render(<InputBar sessionId={SID} />);
+    const ta = getTextarea();
+    expect(ta.value).toBe('');
+    fireEvent.keyDown(ta, { key: 'ArrowUp' });
+    expect(ta.value).toBe('third prompt');
+  });
+
+  it('repeated ↑ walks backwards through history', () => {
+    freshStoreWithSession(SID, ['first', 'second', 'third'], { started: true });
+    stubCCSM();
+    render(<InputBar sessionId={SID} />);
+    const ta = getTextarea();
+    fireEvent.keyDown(ta, { key: 'ArrowUp' });
+    expect(ta.value).toBe('third');
+    fireEvent.keyDown(ta, { key: 'ArrowUp' });
+    expect(ta.value).toBe('second');
+    fireEvent.keyDown(ta, { key: 'ArrowUp' });
+    expect(ta.value).toBe('first');
+  });
+
+  it('↑ at the oldest prompt is a no-op (stays put)', () => {
+    freshStoreWithSession(SID, ['only one'], { started: true });
+    stubCCSM();
+    render(<InputBar sessionId={SID} />);
+    const ta = getTextarea();
+    fireEvent.keyDown(ta, { key: 'ArrowUp' });
+    expect(ta.value).toBe('only one');
+    // Already at the top — another ↑ is swallowed but the value doesn't change.
+    fireEvent.keyDown(ta, { key: 'ArrowUp' });
+    expect(ta.value).toBe('only one');
+  });
+
+  it('↓ walks back toward the most recent prompt', () => {
+    freshStoreWithSession(SID, ['first', 'second', 'third'], { started: true });
+    stubCCSM();
+    render(<InputBar sessionId={SID} />);
+    const ta = getTextarea();
+    fireEvent.keyDown(ta, { key: 'ArrowUp' }); // third
+    fireEvent.keyDown(ta, { key: 'ArrowUp' }); // second
+    fireEvent.keyDown(ta, { key: 'ArrowUp' }); // first
+    fireEvent.keyDown(ta, { key: 'ArrowDown' }); // back to second
+    expect(ta.value).toBe('second');
+    fireEvent.keyDown(ta, { key: 'ArrowDown' }); // back to third
+    expect(ta.value).toBe('third');
+  });
+
+  it('↓ from the most recent prompt clears the composer back to idle', () => {
+    freshStoreWithSession(SID, ['first', 'second'], { started: true });
+    stubCCSM();
+    render(<InputBar sessionId={SID} />);
+    const ta = getTextarea();
+    fireEvent.keyDown(ta, { key: 'ArrowUp' });
+    expect(ta.value).toBe('second');
+    fireEvent.keyDown(ta, { key: 'ArrowDown' });
+    expect(ta.value).toBe('');
+    // Now in idle — another ↓ is a no-op (textarea handles it normally).
+    fireEvent.keyDown(ta, { key: 'ArrowDown' });
+    expect(ta.value).toBe('');
+  });
+
+  it('↑ on a non-empty composer (not in recall) does NOT trigger recall', () => {
+    freshStoreWithSession(SID, ['old prompt'], { started: true });
+    stubCCSM();
+    render(<InputBar sessionId={SID} />);
+    const ta = getTextarea();
+    // Simulate the user typing some draft.
+    fireEvent.change(ta, { target: { value: 'draft\nmulti\nline' } });
+    expect(ta.value).toBe('draft\nmulti\nline');
+    fireEvent.keyDown(ta, { key: 'ArrowUp' });
+    // Value unchanged — recall stayed dormant.
+    expect(ta.value).toBe('draft\nmulti\nline');
+  });
+
+  it('typing while in recall exits recall mode (next ↑ restarts at newest)', () => {
+    freshStoreWithSession(SID, ['first', 'second'], { started: true });
+    stubCCSM();
+    render(<InputBar sessionId={SID} />);
+    const ta = getTextarea();
+    fireEvent.keyDown(ta, { key: 'ArrowUp' }); // second
+    fireEvent.keyDown(ta, { key: 'ArrowUp' }); // first
+    expect(ta.value).toBe('first');
+    // User edits the recalled value — diverges from history[recallIndex-1].
+    fireEvent.change(ta, { target: { value: 'first edited' } });
+    expect(ta.value).toBe('first edited');
+    // ↑ on a non-empty composer in idle mode is a no-op — the user's edit
+    // dropped them out of recall, so this confirms the exit.
+    fireEvent.keyDown(ta, { key: 'ArrowUp' });
+    expect(ta.value).toBe('first edited');
+    // Clear back to empty and ↑ should now start fresh from the newest prompt.
+    fireEvent.change(ta, { target: { value: '' } });
+    fireEvent.keyDown(ta, { key: 'ArrowUp' });
+    expect(ta.value).toBe('second');
+  });
+
+  it('switching sessions resets the recall index', () => {
+    freshStoreWithSession(SID, ['a1', 'a2'], { started: true });
+    stubCCSM();
+    const { rerender } = render(<InputBar sessionId={SID} />);
+    const taA = getTextarea();
+    fireEvent.keyDown(taA, { key: 'ArrowUp' });
+    fireEvent.keyDown(taA, { key: 'ArrowUp' });
+    expect(taA.value).toBe('a1');
+
+    // Mount the store with a second session and switch to it.
+    act(() => {
+      useStore.setState((s) => ({
+        sessions: [
+          ...s.sessions,
+          {
+            id: 's-other',
+            name: 's-other',
+            state: 'idle',
+            cwd: '~',
+            model: 'claude',
+            groupId: 'g-default',
+            agentType: 'claude-code',
+          },
+        ],
+        messagesBySession: {
+          ...s.messagesBySession,
+          ['s-other']: [{ kind: 'user', id: 'u-o-0', text: 'b1' }],
+        },
+        startedSessions: { ...s.startedSessions, ['s-other']: true },
+        activeId: 's-other',
+      }));
+    });
+    rerender(<InputBar sessionId={'s-other'} />);
+    const taB = getTextarea();
+    expect(taB.value).toBe('');
+    // Recall index reset — first ↑ in the new session pulls the new session's
+    // newest prompt, not whatever index we were at in the previous session.
+    fireEvent.keyDown(taB, { key: 'ArrowUp' });
+    expect(taB.value).toBe('b1');
+  });
+
+  it('ignores empty / whitespace-only past prompts', () => {
+    freshStoreWithSession(SID, ['real prompt', '   ', ''], { started: true });
+    stubCCSM();
+    render(<InputBar sessionId={SID} />);
+    const ta = getTextarea();
+    fireEvent.keyDown(ta, { key: 'ArrowUp' });
+    expect(ta.value).toBe('real prompt');
+  });
+
+  it('does nothing when there is no user history at all', () => {
+    freshStoreWithSession(SID, [], { started: true });
+    stubCCSM();
+    render(<InputBar sessionId={SID} />);
+    const ta = getTextarea();
+    fireEvent.keyDown(ta, { key: 'ArrowUp' });
+    expect(ta.value).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
CLI-style ↑/↓ history recall for the ccsm composer.

- ↑ on an exactly-empty composer (or while already in recall mode) walks backwards through this session's user prompts.
- ↓ walks forward; ↓ from the most recent prompt clears the composer back to idle.
- Strict guard: ↑ on a non-empty composer that is NOT in recall mode is forwarded to the textarea — normal multi-line caret movement is preserved.
- Any user edit that diverges from the recalled text exits recall mode.
- Switching sessionId resets recallIndex.

## Layer 1 think — is this duplicating existing affordances?
Drafts (per-session text persistence in `stores/drafts.ts`) cover \"I'm in the middle of composing X\". Recall is a different semantic: \"I just sent X — let me re-send a slight variant\". CLI users get this for free from readline; ccsm composer didn't. Drafts persist the *uncommitted* text; recall walks the *committed* prompt history. They coexist cleanly:

- Idle composer with a saved draft → ↑ overwrites with the most recent committed prompt; ↓ down past the newest clears to `''` (the user can press Esc / refocus to get the draft back via `getDraft`, but a recalled value should not silently merge with a draft).
- In future we could restore the draft on ↓-past-newest instead of clearing — flagging for follow-up if users complain. Started conservative.

## Implementation notes
- New derived selector `userPromptHistory` (newest first) via `useShallow` — only re-renders when the user-prompt list itself changes, not on per-token assistant streaming chunks (consistent with the existing perf comment on the main store subscription).
- Filters whitespace-only past prompts (e.g. \"   \") and the existing slash-command-echo filter in `userFrameToBlock` already strips `<command-name>` wrappers.
- ↑/↓ handler runs after the slash-picker handler (which only activates for `/`-triggered values, so the recall guard `value === ''` already excludes that path).
- 10 unit tests cover every branch of the strict guard.

## Conflict expectation
PR-M is in flight refactoring InputBar's question/sticky regions. The diff here lives strictly in `onKeyDown`, the local `recallIndex` state, and the sessionId reset effect — small surface, ready to rebase if PR-M lands first.

## Test plan
- [x] `npx tsc --noEmit` (both renderer and electron tsconfigs) — clean
- [x] `npx vitest run tests/inputbar-recall.test.tsx` — 10/10 pass
- [x] `npx vitest run tests/inputbar*.test.tsx` — 18/18 pass (no regression in continue-after-interrupt or diff-comments)
- [ ] Manual smoke (deferred — local env can't build better-sqlite3 native): create a session, send 3 prompts, clear composer, ↑↑↑ should walk to oldest and stop, ↓↓↓ should walk forward and clear, then type a char in recall to confirm exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)