### PR TITLE
feat(statusbar): context usage pie + click-to-compact

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -421,6 +421,7 @@ export default function App() {
               <StatusBar
                 cwd={active.cwd}
                 cwdMissing={active.cwdMissing}
+                sessionId={active.id}
                 model={active.model || model}
                 permission={permission}
                 onChangeCwdToPath={(p) => {

--- a/src/agent/lifecycle.ts
+++ b/src/agent/lifecycle.ts
@@ -251,6 +251,15 @@ export function subscribeAgentEvents(): void {
           cache_creation_input_tokens?: number;
           cache_read_input_tokens?: number;
         };
+        // SDK surface name from claude-agent-sdk's `SDKResultSuccess`. We
+        // don't depend on the SDK at the renderer layer (raw stream-json
+        // is parsed by `electron/agent/stream-json-types.ts` and survives
+        // unknown fields via .passthrough()), so this is a structural cast
+        // rather than an import. Each entry's `contextWindow` is the
+        // model-aware token cap (e.g. 200_000 for sonnet/opus) — we use it
+        // to size the StatusBar context-pie chip without hardcoding a per-
+        // model map.
+        modelUsage?: Record<string, { inputTokens?: number; outputTokens?: number; cacheReadInputTokens?: number; cacheCreationInputTokens?: number; contextWindow?: number }>;
       };
       const usage = r.usage ?? {};
       store.addSessionStats(e.sessionId, {
@@ -261,6 +270,35 @@ export function subscribeAgentEvents(): void {
           (usage.cache_read_input_tokens ?? 0),
         outputTokens: usage.output_tokens ?? 0,
         costUsd: typeof r.total_cost_usd === 'number' ? r.total_cost_usd : 0
+      });
+      // Snapshot LATEST-turn context-window usage for the StatusBar pie chip.
+      // Note: SessionStats sums every turn's usage (cumulative API spend),
+      // which can exceed contextWindow once cache_read accumulates over a
+      // long conversation. The pie chip needs the absolute current prompt
+      // size — that's exactly what `result.usage` reports for the just-
+      // finished turn, so we snapshot rather than accumulate.
+      const turnTotalTokens =
+        (usage.input_tokens ?? 0) +
+        (usage.cache_creation_input_tokens ?? 0) +
+        (usage.cache_read_input_tokens ?? 0);
+      let contextWindow: number | null = null;
+      let modelId: string | null = null;
+      if (r.modelUsage && typeof r.modelUsage === 'object') {
+        // Pick whichever model entry actually carries a contextWindow. With
+        // a single primary model the map has one entry; sub-agents may add
+        // more, but the parent turn's window is what governs the chip.
+        for (const [m, mu] of Object.entries(r.modelUsage)) {
+          if (mu && typeof mu.contextWindow === 'number' && mu.contextWindow > 0) {
+            contextWindow = mu.contextWindow;
+            modelId = m;
+            break;
+          }
+        }
+      }
+      store.setSessionContextUsage(e.sessionId, {
+        totalTokens: turnTotalTokens,
+        contextWindow,
+        model: modelId
       });
       // PR-H: ccsm no longer persists message history. The CLI / Agent SDK
       // already writes every frame to ~/.claude/projects/<key>/<sid>.jsonl

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -147,9 +147,134 @@ function primaryOf<V extends string>(options: ChipOption<V>[], value: V): string
   return value;
 }
 
+// =====================================================================
+// ContextPieChip — StatusBar chip showing live context-window fill.
+//
+// Visibility rule mirrors the official VS Code Claude extension: hidden
+// below 50% to keep the bar quiet during normal turns, surfaces only when
+// /compact starts becoming a relevant action. Color buckets:
+//   50–79%  neutral (text-fg-tertiary)
+//   80–94%  amber  (text-state-warning)
+//   ≥95%    red    (text-state-error)
+// Click sends "/compact" through the same agentSend path the InputBar
+// slash-command flow uses (claude.exe handles /compact natively).
+//
+// SVG: a 12×12 ring drawn with `stroke-dasharray`. circumference = 2πr;
+// the visible-arc dash is `pct * circumference`, gap fills the rest. We
+// rotate −90° so the arc starts at 12-o'clock instead of 3-o'clock, which
+// matches every other "fuel gauge" pie users have seen.
+// =====================================================================
+
+const PIE_RADIUS = 4.5;
+const PIE_CIRCUMFERENCE = 2 * Math.PI * PIE_RADIUS;
+
+function pieToneClass(percent: number): string {
+  if (percent >= 95) return 'text-state-error';
+  if (percent >= 80) return 'text-state-warning';
+  return 'text-fg-tertiary';
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
+function ContextPieChip({ sessionId }: { sessionId: string }) {
+  const { t } = useTranslation();
+  const usage = useStore((s) => s.contextUsageBySession[sessionId]);
+
+  // Need both a snapshot and a model-reported window. Without the window
+  // we can't compute a meaningful percentage and would have to either
+  // hardcode 200_000 (forbidden) or guess — better to stay hidden.
+  if (!usage || !usage.contextWindow || usage.contextWindow <= 0) return null;
+
+  const rawPct = (usage.totalTokens / usage.contextWindow) * 100;
+  // Visibility threshold matches the upstream extension's auto-compact
+  // chip: under 50% the bar stays clean.
+  if (rawPct < 50) return null;
+
+  // Clamp display to [0, 100] so a 110%-overflow turn (rare but possible
+  // when the CLI reports a stale contextWindow) doesn't break the SVG.
+  const percent = Math.min(100, Math.max(0, rawPct));
+  const rounded = Math.round(percent);
+  const dash = (percent / 100) * PIE_CIRCUMFERENCE;
+  const tone = pieToneClass(percent);
+
+  const tokenLabel = `${formatTokens(usage.totalTokens)} / ${formatTokens(usage.contextWindow)}`;
+  const tooltip = t('statusBar.contextTooltip', {
+    percent: rounded,
+    used: formatTokens(usage.totalTokens),
+    limit: formatTokens(usage.contextWindow)
+  });
+  const aria = t('statusBar.contextAriaLabel', { percent: rounded });
+
+  const onClick = () => {
+    const api = window.ccsm;
+    if (!api) return;
+    void api.agentSend(sessionId, '/compact');
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={tooltip}
+      aria-label={aria}
+      data-testid="context-pie-chip"
+      data-percent={rounded}
+      data-tone={percent >= 95 ? 'error' : percent >= 80 ? 'warning' : 'neutral'}
+      className={cn(
+        'inline-flex items-center gap-1 h-5 px-1.5 rounded-sm',
+        tone,
+        'hover:bg-bg-hover',
+        'outline-none focus-ring',
+        'transition-colors duration-120 ease-out'
+      )}
+    >
+      <svg
+        width={12}
+        height={12}
+        viewBox="0 0 12 12"
+        aria-hidden
+        // Rotate so the arc grows clockwise from 12-o'clock.
+        style={{ transform: 'rotate(-90deg)' }}
+      >
+        {/* Background ring — keeps the empty portion legible against any
+            StatusBar bg. Uses currentColor at low alpha. */}
+        <circle
+          cx={6}
+          cy={6}
+          r={PIE_RADIUS}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={1.5}
+          opacity={0.25}
+        />
+        {/* Foreground arc */}
+        <circle
+          cx={6}
+          cy={6}
+          r={PIE_RADIUS}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={1.5}
+          strokeDasharray={`${dash} ${PIE_CIRCUMFERENCE}`}
+          strokeLinecap="butt"
+        />
+      </svg>
+      <span className="font-mono tabular-nums">{rounded}%</span>
+      {/* Hidden token-count for tests + screen readers without overloading
+          the visible label. */}
+      <span className="sr-only">{tokenLabel}</span>
+    </button>
+  );
+}
+
 export type StatusBarProps = {
   cwd: string;
   cwdMissing?: boolean;
+  sessionId: string;
   model: string;
   permission: PermissionMode;
   onChangeCwdToPath: (cwd: string) => void;
@@ -161,6 +286,7 @@ export type StatusBarProps = {
 export function StatusBar({
   cwd,
   cwdMissing,
+  sessionId,
   model,
   permission,
   onChangeCwdToPath,
@@ -171,6 +297,12 @@ export function StatusBar({
   const { t } = useTranslation();
   const models = useStore((s) => s.models);
   const modelsLoaded = useStore((s) => s.modelsLoaded);
+  const contextUsage = useStore((s) => s.contextUsageBySession[sessionId]);
+  const contextChipVisible = (() => {
+    if (!contextUsage || !contextUsage.contextWindow) return false;
+    const pct = (contextUsage.totalTokens / contextUsage.contextWindow) * 100;
+    return pct >= 50;
+  })();
 
   // Labels describe what claude.exe actually does per mode. The underlying
   // VALUES (default / acceptEdits / plan / bypassPermissions) are CLI argv
@@ -236,6 +368,9 @@ export function StatusBar({
       onSelect={onChangePermission}
     />
   ];
+  if (contextChipVisible) {
+    chips.push(<ContextPieChip key="context" sessionId={sessionId} />);
+  }
 
   return (
     <div data-type-scale-role="status-bar" className="h-6 px-4 pt-0.5 flex items-center gap-1 font-mono text-meta">

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -565,7 +565,12 @@ const en = {
     modePlanTooltip: 'Plan mode \u2014 read-only analysis; no file edits or shell until you approve.',
     modeDefaultTooltip: 'Default \u2014 auto-approve reads; ask before edits and shell.',
     modeAcceptEditsTooltip: 'Accept Edits \u2014 auto-approve reads and file edits; ask before shell.',
-    modeBypassTooltip: 'Bypass Permissions \u2014 every tool call runs without asking. Use with care.'
+    modeBypassTooltip: 'Bypass Permissions \u2014 every tool call runs without asking. Use with care.',
+    contextLabel: 'Context',
+    // Mirrors the official VS Code Claude extension's auto-compact tooltip
+    // wording so users who switch between surfaces see the same prompt.
+    contextTooltip: '{{percent}}% used ({{used}} / {{limit}} tokens). Click to /compact.',
+    contextAriaLabel: '{{percent}}% of context window used. Click to compact.'
   },
   cwdPopover: {
     placeholder: 'Type to filter or paste a path…',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -541,7 +541,10 @@ const zh: EnCatalog = {
     modePlanTooltip: '规划模式 \u2014 只读分析；不编辑文件、不执行 shell，除非你批准。',
     modeDefaultTooltip: '默认 \u2014 自动批准读取；编辑和 shell 先询问。',
     modeAcceptEditsTooltip: '接受编辑 \u2014 自动批准读取与文件编辑；shell 先询问。',
-    modeBypassTooltip: '跳过校验 \u2014 所有工具调用直接放行。请谨慎使用。'
+    modeBypassTooltip: '跳过校验 \u2014 所有工具调用直接放行。请谨慎使用。',
+    contextLabel: '上下文',
+    contextTooltip: '已用 {{percent}}%（{{used}} / {{limit}} 个 token）。点击执行 /compact。',
+    contextAriaLabel: '上下文窗口已使用 {{percent}}%。点击触发压缩。'
   },
   cwdPopover: {
     placeholder: '输入筛选或粘贴路径…',

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -89,6 +89,23 @@ export const EMPTY_SESSION_STATS: SessionStats = {
   costUsd: 0
 };
 
+// Snapshot of the last completed turn's context-window usage. Updated from
+// the latest `result` frame's `usage` (current prompt size, NOT the
+// cumulative API tokens that `SessionStats` tracks) and the model-aware
+// `contextWindow` reported in `modelUsage[model].contextWindow`. Drives the
+// StatusBar context-usage pie chip. Ephemeral — not persisted; the chip just
+// stays hidden until the first turn after reload.
+export interface SessionContextUsage {
+  /** Latest turn's prompt size: input + cache_creation + cache_read tokens.
+   *  This is the live "how full is the context window" number. */
+  totalTokens: number;
+  /** Model-reported context window for that turn (e.g. 200_000 for sonnet/opus).
+   *  Null when claude.exe didn't report `modelUsage` (older CLI / error frame). */
+  contextWindow: number | null;
+  /** Model id from the same `modelUsage` entry, kept for tooltip display. */
+  model: string | null;
+}
+
 export interface DiscoveredModel {
   id: string;
   source: ModelSource;
@@ -232,6 +249,10 @@ type State = {
   startedSessions: Record<string, true>;
   runningSessions: Record<string, true>;
   statsBySession: Record<string, SessionStats>;
+  /** Last-turn context-usage snapshot per session, updated from `result`
+   *  frames. Used by StatusBar's context-pie chip. Cleared on session
+   *  delete and on `/clear`-style transcript wipes. */
+  contextUsageBySession: Record<string, SessionContextUsage>;
   // Marks sessions where the user clicked Stop. Consumed when the next
   // `result { error_during_execution }` frame arrives so we can render a
   // neutral "Interrupted" banner instead of an error block.
@@ -522,6 +543,10 @@ type Actions = {
    *  via `resolvePermission`. */
   bumpComposerFocus: () => void;
   addSessionStats: (sessionId: string, delta: Partial<SessionStats>) => void;
+  /** Replace the last-turn context-usage snapshot for `sessionId`. Pass a
+   *  fresh object — we do NOT merge with prior state because each `result`
+   *  frame already carries the absolute current-prompt size. */
+  setSessionContextUsage: (sessionId: string, usage: SessionContextUsage) => void;
 
   loadModels: () => Promise<void>;
   loadConnection: () => Promise<void>;
@@ -916,6 +941,7 @@ export const useStore = create<State & Actions>((set, get) => ({
   startedSessions: {},
   runningSessions: {},
   statsBySession: {},
+  contextUsageBySession: {},
   interruptedSessions: {},
   messageQueues: {},
   models: [],
@@ -1708,6 +1734,8 @@ export const useStore = create<State & Actions>((set, get) => ({
       delete nextQueues[sessionId];
       const nextStats = { ...s.statsBySession };
       delete nextStats[sessionId];
+      const nextContextUsage = { ...s.contextUsageBySession };
+      delete nextContextUsage[sessionId];
       // Drop resumeSessionId so the next agentStart spawns a fresh
       // claude.exe conversation rather than continuing the old one. Also
       // reset state to 'idle' — clearing the context while the row is
@@ -1728,7 +1756,8 @@ export const useStore = create<State & Actions>((set, get) => ({
         runningSessions: nextRunning,
         interruptedSessions: nextInterrupted,
         messageQueues: nextQueues,
-        statsBySession: nextStats
+        statsBySession: nextStats,
+        contextUsageBySession: nextContextUsage
       };
     });
     // PR-H: ccsm no longer persists message history. The CLI's JSONL stays
@@ -1758,6 +1787,15 @@ export const useStore = create<State & Actions>((set, get) => ({
       };
       return { statsBySession: { ...s.statsBySession, [sessionId]: next } };
     });
+  },
+
+  setSessionContextUsage: (sessionId, usage) => {
+    set((s) => ({
+      contextUsageBySession: {
+        ...s.contextUsageBySession,
+        [sessionId]: usage
+      }
+    }));
   },
 
   loadMessages: async (sessionId) => {

--- a/tests/statusbar-context-pie.test.tsx
+++ b/tests/statusbar-context-pie.test.tsx
@@ -1,0 +1,144 @@
+// Component tests for the StatusBar context-usage pie chip (PR-R, Task #42).
+//
+// Behavior under test:
+//  1. Below 50% the chip stays hidden — keeps the StatusBar quiet on
+//     every-day turns where /compact isn't relevant.
+//  2. At 50–79% the chip surfaces with a neutral tone.
+//  3. At 80–94% the tone bumps to amber (state-warning).
+//  4. At ≥95% the tone bumps to red (state-error).
+//  5. Clicking the chip dispatches "/compact" through agentSend, matching the
+//     official VS Code Claude extension's auto-compact CTA. We assert the
+//     *raw* slash command — claude.exe handles /compact natively, ccsm does
+//     not need its own client-side handler.
+//
+// We render <StatusBar /> against the real Zustand store and stub
+// `window.ccsm.agentSend`. The store path that lifecycle.ts uses to push
+// usage snapshots is `setSessionContextUsage` — calling it here keeps the
+// test focused on the chip rather than re-exercising stream parsing.
+
+import React from 'react';
+import { describe, it, expect, beforeEach, vi, cleanup as _unused } from 'vitest';
+import { render, screen, fireEvent, act, cleanup } from '@testing-library/react';
+import { StatusBar } from '../src/components/StatusBar';
+import { useStore } from '../src/stores/store';
+
+const initial = useStore.getState();
+
+const SESSION_ID = 's-pie';
+
+function setupStore(usage?: { totalTokens: number; contextWindow: number; model: string }) {
+  useStore.setState(
+    {
+      ...initial,
+      sessions: [
+        {
+          id: SESSION_ID,
+          name: SESSION_ID,
+          state: 'idle',
+          cwd: '/tmp',
+          model: 'claude-sonnet-4-5',
+          groupId: 'g-default',
+          agentType: 'claude-code'
+        }
+      ],
+      groups: [{ id: 'g-default', name: 'Sessions', collapsed: false, kind: 'normal' }],
+      activeId: SESSION_ID,
+      contextUsageBySession: usage ? { [SESSION_ID]: usage } : {},
+      // ChipMenu binds to this; without a clean reset a leftover popoverId
+      // from a sibling test could leave a menu inadvertently open.
+      openPopoverId: null
+    },
+    true
+  );
+}
+
+function stubCCSM() {
+  const api = {
+    agentSend: vi.fn().mockResolvedValue(true),
+    agentInterrupt: vi.fn().mockResolvedValue(undefined),
+    agentSendContent: vi.fn().mockResolvedValue(true),
+    agentStart: vi.fn().mockResolvedValue({ ok: true })
+  };
+  (globalThis as unknown as { window: Window & { ccsm?: unknown } }).window.ccsm = api;
+  return api;
+}
+
+function renderBar() {
+  return render(
+    <StatusBar
+      cwd="/tmp"
+      sessionId={SESSION_ID}
+      model="claude-sonnet-4-5"
+      permission="default"
+      onChangeCwdToPath={() => {}}
+      onBrowseForCwd={() => {}}
+      onChangeModel={() => {}}
+      onChangePermission={() => {}}
+    />
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+  (globalThis as unknown as { window: Window & { ccsm?: unknown } }).window.ccsm = undefined;
+});
+
+describe('<StatusBar /> context-pie chip', () => {
+  it('stays hidden below the 50% display threshold', () => {
+    setupStore({ totalTokens: 60_000, contextWindow: 200_000, model: 'claude-sonnet-4-5' });
+    stubCCSM();
+    renderBar();
+    expect(screen.queryByTestId('context-pie-chip')).toBeNull();
+  });
+
+  it('stays hidden when the model has not reported a context window yet', () => {
+    // First-turn-before-result race: usage snapshot exists with totalTokens
+    // but contextWindow is null (older CLI / error frame). We refuse to
+    // hardcode 200_000 as a fallback — the chip just stays hidden.
+    setupStore({ totalTokens: 180_000, contextWindow: 0, model: 'claude-sonnet-4-5' });
+    stubCCSM();
+    renderBar();
+    expect(screen.queryByTestId('context-pie-chip')).toBeNull();
+  });
+
+  it('shows with a neutral tone at 70%', () => {
+    setupStore({ totalTokens: 140_000, contextWindow: 200_000, model: 'claude-sonnet-4-5' });
+    stubCCSM();
+    renderBar();
+    const chip = screen.getByTestId('context-pie-chip');
+    expect(chip).toBeInTheDocument();
+    expect(chip).toHaveAttribute('data-percent', '70');
+    expect(chip).toHaveAttribute('data-tone', 'neutral');
+    expect(chip.textContent).toContain('70%');
+  });
+
+  it('upgrades to the amber warning tone at 90%', () => {
+    setupStore({ totalTokens: 180_000, contextWindow: 200_000, model: 'claude-sonnet-4-5' });
+    stubCCSM();
+    renderBar();
+    const chip = screen.getByTestId('context-pie-chip');
+    expect(chip).toHaveAttribute('data-tone', 'warning');
+    expect(chip).toHaveAttribute('data-percent', '90');
+  });
+
+  it('upgrades to the red error tone at 95%+', () => {
+    setupStore({ totalTokens: 192_000, contextWindow: 200_000, model: 'claude-sonnet-4-5' });
+    stubCCSM();
+    renderBar();
+    const chip = screen.getByTestId('context-pie-chip');
+    expect(chip).toHaveAttribute('data-tone', 'error');
+    expect(chip).toHaveAttribute('data-percent', '96');
+  });
+
+  it('dispatches "/compact" via agentSend on click', () => {
+    setupStore({ totalTokens: 180_000, contextWindow: 200_000, model: 'claude-sonnet-4-5' });
+    const api = stubCCSM();
+    renderBar();
+    const chip = screen.getByTestId('context-pie-chip');
+    act(() => {
+      fireEvent.click(chip);
+    });
+    expect(api.agentSend).toHaveBeenCalledTimes(1);
+    expect(api.agentSend).toHaveBeenCalledWith(SESSION_ID, '/compact');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a live context-window usage chip to the StatusBar that mirrors the official VS Code Claude extension's auto-compact widget.

- **Pie + percentage** rendered with inline SVG (12x12 ring via `stroke-dasharray`); zero new deps.
- **Visibility ≥50%** keeps the StatusBar quiet during normal turns.
- **Color buckets**: 50–79% neutral (`text-fg-tertiary`), 80–94% amber (`text-state-warning`), ≥95% red (`text-state-error`).
- **Click → `/compact`** via `agentSend` — claude.exe handles the slash command natively, no new client-side handler.
- Tooltip wording matches upstream: \`{percent}% used ({used} / {limit} tokens). Click to /compact.\` with i18n parity for `en` / `zh`.

## Layer 1 conclusions

- **SDK token usage**: `result` SDKMessage carries `usage: NonNullableUsage` (the latest turn's prompt size, NOT a cumulative counter — important; ccsm's existing `addSessionStats` aggregates across turns and would over-count once `cache_read_input_tokens` repeats).
- **Context window limit**: SDK ships `ModelUsage.contextWindow` inside `result.modelUsage[modelName]`. ccsm parses raw stream-json with `.passthrough()`, so unknown fields survive — read structurally rather than hardcoding a per-model map. Chip stays hidden if claude.exe doesn't surface a `contextWindow` (no fallback guess).
- **`getContextUsage()` SDK method**: exists on `Query`, but ccsm doesn't hold a query handle (it spawns claude.exe directly), so this richer breakdown isn't reachable today. The `result.modelUsage` path is the lightest-weight signal that requires zero protocol changes.
- **`/compact` trigger**: pure pass-through string sent through the existing `agentSend` IPC. No new SDK calls.
- **≥50% threshold**: matches upstream — under 50% the chip would be visual noise.

## Changes

- `src/stores/store.ts`: new `contextUsageBySession: Record<sessionId, {totalTokens, contextWindow, model}>` slice + `setSessionContextUsage` action; cleared on `resetSessionContext`.
- `src/agent/lifecycle.ts`: snapshots latest-turn `usage` + `modelUsage[*].contextWindow` from each `result` frame (ALONGSIDE the existing cumulative `addSessionStats` call, which keeps its semantics).
- `src/components/StatusBar.tsx`: new `ContextPieChip` subcomponent + `sessionId` prop; chip slot only pushed when ≥50% to avoid orphan separator dots.
- `src/App.tsx`: passes `sessionId={active.id}`.
- `src/i18n/locales/{en,zh}.ts`: `contextLabel` / `contextTooltip` / `contextAriaLabel` keys, sentence case, upstream-aligned wording.
- `tests/statusbar-context-pie.test.tsx`: 6 cases (hidden < 50%, hidden when no contextWindow, neutral at 70%, amber at 90%, red at 96%, click → `/compact`).

## Test plan

- [x] `npx tsc --noEmit` (renderer + electron) — green.
- [x] `npx vitest run tests/statusbar-context-pie.test.tsx` — 6/6 pass.
- [x] `npx vitest run tests/store.test.ts tests/lifecycle.test.ts tests/i18n-key-parity.test.ts tests/cwd-popover.test.tsx` — 119/119 pass (no regressions in adjacent suites).
- [ ] Live dogfood smoke (long agent conversation → chip surfaces at 50% → tone bumps at 80% → click triggers compact). Skipped in worker context due to better-sqlite3 native rebuild gap; reviewer to verify in a built install with screenshots per `feedback_visual_fix_screenshots.md`.