### PR TITLE
fix(commands): project commands win over user (matches CLI)

### DIFF
--- a/electron/commands-loader.ts
+++ b/electron/commands-loader.ts
@@ -5,16 +5,19 @@
 // only DISCOVERS — execution is always pass-through to claude.exe (the
 // renderer types `/<name> <args>` and the CLI handles it).
 //
-// Scan order (lower index = higher priority for conflict resolution):
+// Conflict resolution order (lower priority number = wins):
+//   0. <cwd>/.claude/commands/*.md                      (source: 'project')
 //   1. ~/.claude/commands/*.md                          (source: 'user')
-//   2. <cwd>/.claude/commands/*.md                      (source: 'project')
-//   3. ~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/commands/*.md
+//   2. ~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/commands/*.md
 //      (source: 'plugin', name namespaced as `<plugin>:<basename>`)
-//   4. ~/.claude/skills/*.md                            (source: 'skill', tolerated if absent)
-//   5. ~/.claude/agents/*.md, <cwd>/.claude/agents/*.md (source: 'agent', tolerated if absent)
+//   3. ~/.claude/skills/*.md                            (source: 'skill', tolerated if absent)
+//   4. <cwd>/.claude/agents/*.md                        (source: 'agent', project-level, tolerated if absent)
+//   5. ~/.claude/agents/*.md                            (source: 'agent', user-level, tolerated if absent)
 //
-// Same name wins by priority; lower-priority duplicates are dropped with a
-// console.warn so the user can debug.
+// Project-level entries shadow user-level entries of the same name — this
+// matches the upstream Claude CLI's behavior where a per-project override
+// takes precedence over the user's global config. Lower-priority duplicates
+// are dropped with a console.warn so the user can debug.
 
 import * as fs from 'fs';
 import * as path from 'path';
@@ -224,15 +227,15 @@ export function loadCommands(opts: LoadOpts = {}): LoadedCommand[] {
   const claudeRoot = path.join(home, '.claude');
   const all: RawEntry[] = [];
 
-  // 1. user
+  // 1. user (priority 1 — shadowed by project)
   for (const file of listMdFiles(path.join(claudeRoot, 'commands'))) {
-    const e = readEntry(file, 'user', 0);
+    const e = readEntry(file, 'user', 1);
     if (e) all.push(e);
   }
-  // 2. project
+  // 2. project (priority 0 — wins over user, matching upstream CLI)
   if (cwd && path.isAbsolute(cwd)) {
     for (const file of listMdFiles(path.join(cwd, '.claude', 'commands'))) {
-      const e = readEntry(file, 'project', 1);
+      const e = readEntry(file, 'project', 0);
       if (e) all.push(e);
     }
   }
@@ -243,10 +246,10 @@ export function loadCommands(opts: LoadOpts = {}): LoadedCommand[] {
     const e = readEntry(file, 'skill', 3);
     if (e) all.push(e);
   }
-  // 5. agents (user-level, then project-level — same priority bucket so a
-  //    project agent shadows a user agent of the same name).
+  // 5. agents — user (priority 5) then project (priority 4) so the project
+  //    agent shadows the user agent of the same name.
   for (const file of listMdFiles(path.join(claudeRoot, 'agents'))) {
-    const e = readEntry(file, 'agent', 4);
+    const e = readEntry(file, 'agent', 5);
     if (e) all.push(e);
   }
   if (cwd && path.isAbsolute(cwd)) {

--- a/tests/commands-loader.test.ts
+++ b/tests/commands-loader.test.ts
@@ -102,6 +102,25 @@ describe('loadCommands', () => {
     expect(sources).toEqual({ usercmd: 'user', projcmd: 'project' });
   });
 
+  it('project commands shadow user commands of the same name', () => {
+    // Same bare name in ~/.claude/commands and <cwd>/.claude/commands.
+    // Per-project config overrides user-global config (matches upstream
+    // Claude CLI). The single surviving entry is the project one.
+    write(
+      path.join(tmpHome, '.claude', 'commands', 'shared.md'),
+      `---\ndescription: from-user\n---\n`
+    );
+    write(
+      path.join(tmpCwd, '.claude', 'commands', 'shared.md'),
+      `---\ndescription: from-project\n---\n`
+    );
+    const cmds = loadCommands({ homeDir: tmpHome, cwd: tmpCwd });
+    const shared = cmds.filter((c) => c.name === 'shared');
+    expect(shared).toHaveLength(1);
+    expect(shared[0].source).toBe('project');
+    expect(shared[0].description).toBe('from-project');
+  });
+
   it('namespaces plugin commands and resolves conflicts by priority', () => {
     // Same basename in user-level and plugin: user wins.
     write(
@@ -256,18 +275,9 @@ describe('loadCommands', () => {
   it('dedupes user vs project agents of the same name to a single entry', () => {
     // Both ~/.claude/agents/qux.md and <cwd>/.claude/agents/qux.md exist.
     // The conflict resolver collapses them to ONE entry — there must never
-    // be two `qux` rows in the picker.
-    //
-    // NOTE on shadow direction: the source comment at the top of
-    // commands-loader.ts claims "a project agent shadows a user agent of
-    // the same name", but the conflict resolver uses `entry.priority <
-    // existing.priority` (strict less-than), so on a priority TIE (both
-    // agents are bucket 4) the FIRST-pushed entry wins — and the loader
-    // pushes the user-level scan before the project-level scan. Net effect:
-    // the user-level agent currently wins on ties. This test pins the
-    // CURRENT behaviour so a refactor doesn't accidentally change it; if
-    // the comment-stated intent ("project wins") is the desired contract,
-    // that is a separate fix to the loader (PR-L is test-only).
+    // be two `qux` rows in the picker. The PROJECT-level agent wins,
+    // matching the upstream Claude CLI behavior where per-project config
+    // overrides user-global config.
     write(
       path.join(tmpHome, '.claude', 'agents', 'qux.md'),
       `---\ndescription: from-user\n---\n`
@@ -280,7 +290,7 @@ describe('loadCommands', () => {
     const qux = cmds.filter((c) => c.name === 'qux');
     expect(qux).toHaveLength(1);
     expect(qux[0].source).toBe('agent');
-    expect(qux[0].description).toBe('from-user');
+    expect(qux[0].description).toBe('from-project');
   });
 
   it('tolerates missing agents directories on both sides', () => {


### PR DESCRIPTION
## Summary
- Fixes task #38: slash-command loader had user-level entries shadowing project-level entries, opposite to upstream Claude CLI behavior.
- Flipped priority constants in `electron/commands-loader.ts`: project commands now priority 0 (was 1), user commands priority 1 (was 0); project agents priority 4 (was tied 4), user agents priority 5 (was tied 4 with first-pushed winning).
- Updated the agent-dedupe test to expect the project description, and added a new explicit test (`project commands shadow user commands of the same name`) documenting the new contract.

## Old vs new
- Old: user > project (user wins on collision); agents tied, user-pushed-first → user wins
- New: project > user > plugin > skill > agent(project) > agent(user)

## Test plan
- [x] `npx vitest run tests/commands-loader.test.ts` (19 tests pass, including new shadowing test)
- [x] `npm run typecheck` clean
- [x] `npm run lint` baseline-equivalent (no new errors introduced)

Generated with Claude Code.