### PR TITLE
feat(composer): send/stop morph + @file mention picker

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1091,6 +1091,88 @@ app.whenReady().then(() => {
     return loadCommands({ cwd: cwd ?? null });
   });
 
+  // ─────────────────────── @mention file listing ──────────────────────────
+  //
+  // Powers the InputBar's @file picker. Walks the session cwd recursively,
+  // skipping the usual heavy directories (node_modules, .git, dist, build,
+  // .next, .venv, target). Returns POSIX-style relative paths so the mention
+  // literal we splice into the composer (`@src/foo.ts`) stays portable
+  // across platforms — claude.exe on Windows happily accepts forward
+  // slashes too.
+  //
+  // Caps:
+  //   - max 5000 files (after which we bail; the picker fuzzy-search is
+  //     plenty accurate at that size, and walking >5k entries on every focus
+  //     is wasteful)
+  //   - max 12 directory depth (defense against symlink loops)
+  //
+  // Per-call, not cached: cwd swaps + on-disk edits should reflect quickly,
+  // and the renderer only invokes this on focus / @ trigger.
+  const FILE_LIST_MAX = 5000;
+  const FILE_LIST_MAX_DEPTH = 12;
+  const FILE_LIST_SKIP_DIRS = new Set([
+    'node_modules',
+    '.git',
+    '.svn',
+    '.hg',
+    'dist',
+    'build',
+    'out',
+    '.next',
+    '.nuxt',
+    '.turbo',
+    '.cache',
+    '.venv',
+    'venv',
+    '__pycache__',
+    'target',
+    '.idea',
+    '.vscode',
+  ]);
+
+  ipcMain.handle('files:list', async (e, cwd: string | null | undefined) => {
+    if (!fromMainFrame(e)) return [];
+    if (cwd == null || !isSafePath(cwd)) return [];
+    let rootStat: fs.Stats;
+    try {
+      rootStat = await fs.promises.stat(cwd);
+    } catch {
+      return [];
+    }
+    if (!rootStat.isDirectory()) return [];
+
+    const out: { path: string; name: string }[] = [];
+    async function walk(dir: string, rel: string, depth: number): Promise<void> {
+      if (out.length >= FILE_LIST_MAX) return;
+      if (depth > FILE_LIST_MAX_DEPTH) return;
+      let entries: fs.Dirent[];
+      try {
+        entries = await fs.promises.readdir(dir, { withFileTypes: true });
+      } catch {
+        return;
+      }
+      for (const ent of entries) {
+        if (out.length >= FILE_LIST_MAX) return;
+        // Skip hidden + heavy build dirs to keep the picker snappy.
+        if (ent.name.startsWith('.') && ent.name !== '.env' && ent.name !== '.env.local') {
+          if (ent.isDirectory()) continue;
+          // hidden file: skip too — usually noise (.DS_Store, .gitignore)
+          continue;
+        }
+        if (ent.isDirectory() && FILE_LIST_SKIP_DIRS.has(ent.name)) continue;
+        const childAbs = path.join(dir, ent.name);
+        const childRel = rel ? `${rel}/${ent.name}` : ent.name;
+        if (ent.isDirectory()) {
+          await walk(childAbs, childRel, depth + 1);
+        } else if (ent.isFile()) {
+          out.push({ path: childRel, name: ent.name });
+        }
+      }
+    }
+    await walk(cwd, '', 0);
+    return out;
+  });
+
   ipcMain.handle('shell:openExternal', async (e, url: string) => {
     if (!fromMainFrame(e)) return false;
     // Only http(s). Everything else is a potential shell hijack.

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -260,6 +260,18 @@ const api = {
       ipcRenderer.invoke('commands:list', cwd),
   },
 
+  files: {
+    /**
+     * Workspace files relative to the session cwd, used by the InputBar's
+     * @file mention picker. Returns POSIX-style relative paths so the
+     * mention literal stays portable. Heavy directories (node_modules,
+     * .git, dist, build, .venv, target, etc.) and hidden entries are
+     * pruned in main. See main.ts for caps (5000 entries / depth 12).
+     */
+    list: (cwd: string | null | undefined): Promise<{ path: string; name: string }[]> =>
+      ipcRenderer.invoke('files:list', cwd),
+  },
+
   openExternal: (url: string): Promise<boolean> =>
     ipcRenderer.invoke('shell:openExternal', url),
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/better-sqlite3": "^7.6.12",
         "@types/node": "^22.10.0",
         "@types/react": "^18.3.12",
@@ -5766,6 +5767,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/better-sqlite3": "^7.6.12",
     "@types/node": "^22.10.0",
     "@types/react": "^18.3.12",

--- a/scripts/probe-e2e-composer-morph-mention.mjs
+++ b/scripts/probe-e2e-composer-morph-mention.mjs
@@ -5,7 +5,7 @@
 //      `runningSessions[id]` flips true. Same DOM slot, swapped variant.
 //   2. Typing `@` in the textarea opens the mention picker (listbox role
 //      "File mentions"); Esc dismisses it without altering the textarea.
-//   3. Stubbing window.ccsm.files.list with a known file list, picking
+//   3. Stubbing the `files:list` IPC handler with a known file list, picking
 //      a row via Enter splices `@<path> ` into the textarea.
 //
 // Mirrors the harness pattern in `probe-e2e-inputbar-visible.mjs` —
@@ -14,7 +14,7 @@
 import { _electron as electron } from 'playwright';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { appWindow } from './probe-utils.mjs';
+import { appWindow, isolatedUserData } from './probe-utils.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
@@ -25,10 +25,14 @@ function fail(msg, app) {
   process.exit(1);
 }
 
+// Isolated userData so persisted drafts from a prior probe run can't bleed in
+// (a stale `@@@@hello`-style draft would corrupt the mention-trigger asserts).
+const ud = isolatedUserData('ccsm-probe-composer-morph');
+
 const app = await electron.launch({
-  args: ['.'],
+  args: ['.', `--user-data-dir=${ud.dir}`],
   cwd: root,
-  env: { ...process.env, NODE_ENV: 'development' },
+  env: { ...process.env, CCSM_PROD_BUNDLE: '1' },
 });
 
 const win = await appWindow(app);
@@ -37,23 +41,34 @@ await win.waitForTimeout(1500);
 
 await win.waitForFunction(() => !!window.__ccsmStore, null, { timeout: 10_000 });
 
-// Stub window.ccsm.files.list BEFORE we mount a session so the InputBar's
+// Stub the @file mention bridge BEFORE we mount a session so the InputBar's
 // initial refreshMentionFiles() picks up the fake file list.
-await win.evaluate(() => {
-  const w = /** @type {any} */ (window);
-  // Preserve any real bridge methods (we only override files.list).
-  const realCcsm = w.ccsm ?? {};
-  w.ccsm = {
-    ...realCcsm,
-    files: {
-      list: async () => [
-        { path: 'src/components/InputBar.tsx', name: 'InputBar.tsx' },
-        { path: 'src/components/MentionPicker.tsx', name: 'MentionPicker.tsx' },
-        { path: 'README.md', name: 'README.md' },
-      ],
-    },
-  };
+//
+// IMPORTANT: contextBridge.exposeInMainWorld locks both `window.ccsm` and its
+// nested objects/methods — neither `window.ccsm = ...`, `window.ccsm.files = ...`,
+// nor `window.ccsm.files.list = ...` sticks. We have to intercept on the MAIN
+// process side by re-registering the `files:list` IPC handler. Without this
+// the bridge silently returns the real (empty, since userData cwd is empty)
+// list and the picker opens with zero options — Enter then correctly falls
+// through to send(), which looks like a product bug but is actually probe
+// fixture failure. Don't repeat that mistake.
+await app.evaluate(async ({ ipcMain }) => {
+  ipcMain.removeHandler('files:list');
+  ipcMain.handle('files:list', async () => [
+    { path: 'src/components/InputBar.tsx', name: 'InputBar.tsx' },
+    { path: 'src/components/MentionPicker.tsx', name: 'MentionPicker.tsx' },
+    { path: 'README.md', name: 'README.md' },
+  ]);
 });
+const stubCheck = await win.evaluate(async () => {
+  const list = window.ccsm?.files?.list;
+  if (typeof list !== 'function') return { ok: false, why: 'list not function' };
+  const r = await list(null);
+  return { ok: true, count: Array.isArray(r) ? r.length : -1 };
+});
+if (!stubCheck.ok || stubCheck.count !== 3) {
+  fail(`bridge stub failed: ${JSON.stringify(stubCheck)} — IPC override didn't take`, app);
+}
 
 // Seed a single idle session so the InputBar mounts.
 await win.evaluate(() => {
@@ -171,3 +186,4 @@ console.log('  morph button: idle=send/primary -> running=stop/danger');
 console.log('  @mention picker: open / Esc-dismiss / Enter-commit all verified');
 
 await app.close();
+ud.cleanup();

--- a/scripts/probe-e2e-composer-morph-mention.mjs
+++ b/scripts/probe-e2e-composer-morph-mention.mjs
@@ -1,0 +1,173 @@
+// E2E probe: send/stop morph button + @file mention picker.
+//
+// Layered checks (no live LLM call needed; we drive the store directly):
+//   1. Morph button renders Send affordance idle, switches to Stop when
+//      `runningSessions[id]` flips true. Same DOM slot, swapped variant.
+//   2. Typing `@` in the textarea opens the mention picker (listbox role
+//      "File mentions"); Esc dismisses it without altering the textarea.
+//   3. Stubbing window.ccsm.files.list with a known file list, picking
+//      a row via Enter splices `@<path> ` into the textarea.
+//
+// Mirrors the harness pattern in `probe-e2e-inputbar-visible.mjs` —
+// drives __ccsmStore directly so no claude.exe spin-up is needed.
+
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { appWindow } from './probe-utils.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function fail(msg, app) {
+  console.error(`\n[probe-e2e-composer-morph-mention] FAIL: ${msg}`);
+  if (app) app.close().catch(() => {});
+  process.exit(1);
+}
+
+const app = await electron.launch({
+  args: ['.'],
+  cwd: root,
+  env: { ...process.env, NODE_ENV: 'development' },
+});
+
+const win = await appWindow(app);
+await win.waitForLoadState('domcontentloaded');
+await win.waitForTimeout(1500);
+
+await win.waitForFunction(() => !!window.__ccsmStore, null, { timeout: 10_000 });
+
+// Stub window.ccsm.files.list BEFORE we mount a session so the InputBar's
+// initial refreshMentionFiles() picks up the fake file list.
+await win.evaluate(() => {
+  const w = /** @type {any} */ (window);
+  // Preserve any real bridge methods (we only override files.list).
+  const realCcsm = w.ccsm ?? {};
+  w.ccsm = {
+    ...realCcsm,
+    files: {
+      list: async () => [
+        { path: 'src/components/InputBar.tsx', name: 'InputBar.tsx' },
+        { path: 'src/components/MentionPicker.tsx', name: 'MentionPicker.tsx' },
+        { path: 'README.md', name: 'README.md' },
+      ],
+    },
+  };
+});
+
+// Seed a single idle session so the InputBar mounts.
+await win.evaluate(() => {
+  const store = /** @type {any} */ (window).__ccsmStore;
+  if (!store) throw new Error('__ccsmStore not on window — dev build?');
+  store.setState({
+    groups: [{ id: 'g1', name: 'G1', collapsed: false, kind: 'normal' }],
+    sessions: [
+      {
+        id: 's1',
+        name: 's',
+        state: 'idle',
+        cwd: 'C:/x',
+        model: 'claude',
+        groupId: 'g1',
+        agentType: 'claude-code',
+      },
+    ],
+    activeId: 's1',
+    messagesBySession: { s1: [] },
+    startedSessions: { s1: true },
+    runningSessions: {},
+    messageQueues: {},
+  });
+});
+
+await win.waitForTimeout(300);
+
+const ta = win.locator('textarea').first();
+try {
+  await ta.waitFor({ state: 'visible', timeout: 5000 });
+} catch {
+  fail('textarea did not appear', app);
+}
+
+// ── 1. Morph button: idle = Send (primary), running = Stop (danger) ───────
+let morph = win.locator('button[data-morph-state]').first();
+let morphState = await morph.getAttribute('data-morph-state');
+let morphVariant = await morph.getAttribute('data-variant');
+if (morphState !== 'send' || morphVariant !== 'primary') {
+  fail(`expected idle morph button send/primary; got ${morphState}/${morphVariant}`, app);
+}
+
+// Flip the session to running and verify the same morph button reflects Stop.
+await win.evaluate(() => {
+  const store = /** @type {any} */ (window).__ccsmStore;
+  store.setState({ runningSessions: { s1: true } });
+});
+await win.waitForTimeout(350); // morph tween ~230ms
+
+morph = win.locator('button[data-morph-state]').first();
+morphState = await morph.getAttribute('data-morph-state');
+morphVariant = await morph.getAttribute('data-variant');
+if (morphState !== 'stop' || morphVariant !== 'danger') {
+  fail(`expected running morph button stop/danger; got ${morphState}/${morphVariant}`, app);
+}
+const morphLabel = await morph.getAttribute('aria-label');
+if (!morphLabel || !/stop/i.test(morphLabel)) {
+  fail(`expected aria-label including "Stop"; got ${JSON.stringify(morphLabel)}`, app);
+}
+
+// Restore idle so the @mention picker subtests don't fight with running UI.
+await win.evaluate(() => {
+  const store = /** @type {any} */ (window).__ccsmStore;
+  store.setState({ runningSessions: {} });
+});
+await win.waitForTimeout(200);
+
+// ── 2. @ trigger opens picker; Esc dismisses ──────────────────────────────
+await ta.click();
+await win.keyboard.type('@');
+await win.waitForTimeout(200);
+
+let picker = win.getByRole('listbox', { name: /file mentions/i });
+try {
+  await picker.waitFor({ state: 'visible', timeout: 3000 });
+} catch {
+  const html = await win.evaluate(() => document.body.innerHTML.slice(0, 1500));
+  console.error('--- body snippet ---\n' + html);
+  fail('mention picker did not open after typing @', app);
+}
+
+await win.keyboard.press('Escape');
+await win.waitForTimeout(200);
+const stillOpen = await picker.isVisible().catch(() => false);
+if (stillOpen) fail('mention picker did not dismiss on Esc', app);
+const valueAfterEsc = await ta.inputValue();
+if (valueAfterEsc !== '@') fail(`Esc altered textarea value: ${JSON.stringify(valueAfterEsc)}`, app);
+
+// ── 3. Reopen + Enter inserts @<path> ─────────────────────────────────────
+// The picker re-arms on any edit. Append+remove a char to bump the dismissed
+// flag without changing the @ trigger.
+await win.keyboard.type(' ');
+await win.keyboard.press('Backspace');
+await win.waitForTimeout(150);
+
+picker = win.getByRole('listbox', { name: /file mentions/i });
+try {
+  await picker.waitFor({ state: 'visible', timeout: 3000 });
+} catch {
+  fail('mention picker did not reopen after edit re-arm', app);
+}
+
+await win.keyboard.press('Enter');
+await win.waitForTimeout(200);
+
+const finalValue = await ta.inputValue();
+// Highlighted row 0 with empty query is the first stubbed file.
+if (finalValue !== '@src/components/InputBar.tsx ') {
+  fail(`expected '@src/components/InputBar.tsx '; got ${JSON.stringify(finalValue)}`, app);
+}
+
+console.log('\n[probe-e2e-composer-morph-mention] OK');
+console.log('  morph button: idle=send/primary -> running=stop/danger');
+console.log('  @mention picker: open / Esc-dismiss / Enter-commit all verified');
+
+await app.close();

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -9,6 +9,7 @@ import { serializeDiffCommentsForPrompt } from '../stores/store';
 import { DURATION, EASING } from '../lib/motion';
 import { useShallow } from 'zustand/react/shallow';
 import { SlashCommandPicker } from './SlashCommandPicker';
+import { MentionPicker } from './MentionPicker';
 import {
   BUILT_IN_COMMANDS,
   detectSlashTrigger,
@@ -18,6 +19,12 @@ import {
   nextSectionIndex,
   type SlashCommand
 } from '../slash-commands/registry';
+import {
+  commitMention,
+  detectAtTrigger,
+  filterMentionFiles,
+} from '../mentions/registry';
+import type { WorkspaceFile } from '../shared/ipc-types';
 import type { ImageAttachment } from '../types';
 import {
   attachmentToDataUrl,
@@ -260,6 +267,42 @@ export function InputBar({ sessionId }: { sessionId: string }) {
     if (activeIndex >= filtered.length) setActiveIndex(Math.max(0, filtered.length - 1));
   }, [pickerOpen, filtered.length, activeIndex]);
 
+  // --- @file mention picker state -------------------------------------
+  // Same trigger/dismiss/active-index pattern as the slash picker, but the
+  // file list is loaded async via IPC. We only fetch once per cwd (and on
+  // textarea focus, so a freshly-`touch`-ed file shows up without a reload).
+  const [mentionFiles, setMentionFiles] = useState<WorkspaceFile[]>([]);
+  const [mentionDismissed, setMentionDismissed] = useState(false);
+  const [mentionActiveIndex, setMentionActiveIndex] = useState(0);
+  const refreshMentionFiles = useCallback(async () => {
+    const bridge = typeof window !== 'undefined' ? window.ccsm : undefined;
+    if (!bridge?.files?.list) {
+      setMentionFiles([]);
+      return;
+    }
+    try {
+      const next = await bridge.files.list(cwd ?? null);
+      setMentionFiles(next);
+    } catch {
+      setMentionFiles([]);
+    }
+  }, [cwd]);
+  useEffect(() => {
+    void refreshMentionFiles();
+  }, [refreshMentionFiles]);
+
+  const atTrigger = useMemo(() => detectAtTrigger(value, caret), [value, caret]);
+  const filteredFiles = useMemo<WorkspaceFile[]>(
+    () => (atTrigger.active ? filterMentionFiles(mentionFiles, atTrigger.query) : []),
+    [atTrigger, mentionFiles]
+  );
+  const mentionOpen = atTrigger.active && !mentionDismissed;
+  useEffect(() => {
+    if (!mentionOpen) return;
+    if (mentionActiveIndex >= filteredFiles.length)
+      setMentionActiveIndex(Math.max(0, filteredFiles.length - 1));
+  }, [mentionOpen, filteredFiles.length, mentionActiveIndex]);
+
   // Wire the slash picker into the global popover mutex (id: 'slash'). When
   // the user opens any other popover (cwd / model chip / permission chip),
   // openPopoverId moves off 'slash' and we dismiss the picker so it can't
@@ -277,6 +320,17 @@ export function InputBar({ sessionId }: { sessionId: string }) {
       setPickerDismissed(true);
     }
   }, [openPopoverId, pickerOpen]);
+  // Mention picker shares the global popover mutex (id: 'mention'). Same
+  // semantics as the slash picker — opening any sibling popover dismisses.
+  useEffect(() => {
+    if (mentionOpen) openPopover('mention');
+    else closePopover('mention');
+  }, [mentionOpen, openPopover, closePopover]);
+  useEffect(() => {
+    if (mentionOpen && openPopoverId !== null && openPopoverId !== 'mention') {
+      setMentionDismissed(true);
+    }
+  }, [openPopoverId, mentionOpen]);
 
   useEffect(() => {
     setValue(getDraft(sessionId));
@@ -385,6 +439,10 @@ export function InputBar({ sessionId }: { sessionId: string }) {
     // keep typing to reopen it if they're still in the `/...` prefix).
     setPickerDismissed(false);
     setActiveIndex(0);
+    // Same for the @ mention picker — re-arm on every edit so Esc-then-type
+    // reopens it. Reset highlight to row 0.
+    setMentionDismissed(false);
+    setMentionActiveIndex(0);
     // Keep caret in sync with the edit — textarea may not have fired
     // onSelect/onKeyUp yet when onChange lands (and programmatic fills
     // from Playwright skip those entirely).
@@ -440,6 +498,30 @@ export function InputBar({ sessionId }: { sessionId: string }) {
     setAttachments(next);
     if (next.length > 0) attachmentCache.set(sessionId, next);
     else attachmentCache.delete(sessionId);
+  }
+
+  // Commit a chosen file from the @ mention picker. Splices `@<path> ` into
+  // the textarea at the trigger location, advances the caret past the
+  // inserted token + trailing space, dismisses the picker, and persists the
+  // updated draft. Mirrors `commitSlashCommand` for the / picker.
+  function commitMentionFile(file: WorkspaceFile) {
+    if (!atTrigger.active) return;
+    const { next, caret: nextCaret } = commitMention(value, atTrigger, file.path);
+    setValue(next);
+    setDraft(sessionId, next);
+    setCaret(nextCaret);
+    setMentionDismissed(true);
+    setMentionActiveIndex(0);
+    requestAnimationFrame(() => {
+      const el = textareaRef.current;
+      if (!el) return;
+      el.focus();
+      try {
+        el.setSelectionRange(nextCaret, nextCaret);
+      } catch {
+        /* setSelectionRange can throw on detached nodes during teardown */
+      }
+    });
   }
 
   const intake = useCallback(
@@ -517,7 +599,7 @@ export function InputBar({ sessionId }: { sessionId: string }) {
       if (document.querySelector('[role="dialog"]')) return;
       const ae = document.activeElement as HTMLElement | null;
       // Defer to the picker's own dismissal when it's the active surface.
-      if (ae === textareaRef.current && pickerOpen) return;
+      if (ae === textareaRef.current && (pickerOpen || mentionOpen)) return;
       e.preventDefault();
       void stop();
     }
@@ -526,7 +608,7 @@ export function InputBar({ sessionId }: { sessionId: string }) {
     // `stop` closes over running + sessionId; both are dependencies via
     // `running` and the implicit re-render when sessionId changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [running, pickerOpen, sessionId]);
+  }, [running, pickerOpen, mentionOpen, sessionId]);
 
   async function onPaste(e: React.ClipboardEvent<HTMLTextAreaElement>) {
     const items = e.clipboardData?.items;
@@ -694,6 +776,43 @@ export function InputBar({ sessionId }: { sessionId: string }) {
     // Skip Enter handling while IME composition is active — otherwise CJK
     // candidate selection accidentally sends the message.
     if (e.nativeEvent.isComposing || (e.nativeEvent as { keyCode?: number }).keyCode === 229) return;
+
+    // Mention picker navigation takes precedence when open. Same key set as
+    // the slash picker (↑/↓/Enter/Esc) — no Tab section-jump because the
+    // mention list has no sections.
+    if (mentionOpen && filteredFiles.length > 0) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setMentionActiveIndex((i) => (i + 1) % filteredFiles.length);
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setMentionActiveIndex(
+          (i) => (i - 1 + filteredFiles.length) % filteredFiles.length
+        );
+        return;
+      }
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        const f = filteredFiles[mentionActiveIndex];
+        if (f) commitMentionFile(f);
+        return;
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        setMentionDismissed(true);
+        return;
+      }
+    }
+    // Mention picker is open but has zero results — Esc still dismisses it
+    // so the user isn't trapped with an empty picker hovering above the
+    // composer.
+    if (mentionOpen && e.key === 'Escape') {
+      e.preventDefault();
+      setMentionDismissed(true);
+      return;
+    }
 
     // Slash picker navigation takes precedence when open.
     if (pickerOpen && filtered.length > 0) {
@@ -895,6 +1014,14 @@ export function InputBar({ sessionId }: { sessionId: string }) {
           onActiveIndexChange={setActiveIndex}
           onSelect={commitSlashCommand}
         />
+        <MentionPicker
+          open={mentionOpen}
+          query={atTrigger.active ? atTrigger.query : ''}
+          files={filteredFiles}
+          activeIndex={mentionActiveIndex}
+          onActiveIndexChange={setMentionActiveIndex}
+          onSelect={commitMentionFile}
+        />
         {attachments.length > 0 && (
           <div className="flex flex-wrap gap-1.5 px-2 pt-2">
             <AnimatePresence initial={false}>
@@ -921,6 +1048,9 @@ export function InputBar({ sessionId }: { sessionId: string }) {
             // Re-scan disk commands on focus so newly-dropped .md files
             // surface in the picker without reloading the app.
             void refreshDynamic();
+            // Same for the @ mention file list — pick up freshly-created
+            // files without making the user reload the app.
+            void refreshMentionFiles();
           }}
           onPaste={onPaste}
           rows={2}
@@ -1007,41 +1137,67 @@ export function InputBar({ sessionId }: { sessionId: string }) {
               {t('chat.queueChip', { count: queueLength })}
             </MetaLabel>
           )}
-          {running ? (
-            <>
-              {!sendDisabled && (
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  aria-label={t('chat.queueAria')}
-                  onClick={() => void send()}
-                >
-                  <ArrowUp size={10} className="stroke-[2.25]" />
-                  <span>{t('chat.queueButton')}</span>
-                </Button>
-              )}
-              <Button
-                variant="danger"
-                size="sm"
-                aria-label={t('chat.stopAria')}
-                onClick={stop}
-              >
-                <Square size={10} className="stroke-[2.25]" />
-                <span>{t('chat.stopBtn')}</span>
-              </Button>
-            </>
-          ) : (
+          {running && !sendDisabled && (
             <Button
-              variant="primary"
+              variant="secondary"
               size="sm"
-              aria-label={t('chat.sendMessage')}
-              disabled={sendDisabled}
+              aria-label={t('chat.queueAria')}
               onClick={() => void send()}
             >
               <ArrowUp size={10} className="stroke-[2.25]" />
-              <span>{t('chat.sendButton')}</span>
+              <span>{t('chat.queueButton')}</span>
             </Button>
           )}
+          {/*
+            Morph button. Same DOM slot in both states; only the icon, label,
+            variant, aria-label, and onClick swap. Mirrors the upstream
+            Anthropic Claude Code VS Code extension pattern (webview/index.js):
+              `if (busy && !X) <StopIcon/> else <SendIcon/>`
+            — same button instance, conditional inner SVG. AnimatePresence
+            cross-fades the icon at 230ms tween so the swap reads as one
+            control changing role rather than two buttons toggling display.
+            The variant flip (primary → danger) uses the existing CSS
+            transition on background-color, so no extra Framer wrapper for
+            the chrome — only the icon is animated.
+          */}
+          <Button
+            data-morph-state={running ? 'stop' : 'send'}
+            variant={running ? 'danger' : 'primary'}
+            size="sm"
+            aria-label={running ? t('chat.stopAria') : t('chat.sendMessage')}
+            title={running ? t('chat.stopBtn') : t('chat.sendButton')}
+            disabled={running ? false : sendDisabled}
+            onClick={running ? stop : () => void send()}
+          >
+            <span className="relative inline-flex items-center justify-center w-2.5 h-2.5">
+              <AnimatePresence initial={false} mode="wait">
+                {running ? (
+                  <motion.span
+                    key="stop-icon"
+                    initial={{ opacity: 0, scale: 0.7, rotate: -8 }}
+                    animate={{ opacity: 1, scale: 1, rotate: 0 }}
+                    exit={{ opacity: 0, scale: 0.7, rotate: 8 }}
+                    transition={{ duration: 0.23, ease: EASING.standard }}
+                    className="absolute inset-0 inline-flex items-center justify-center"
+                  >
+                    <Square size={10} className="stroke-[2.25]" />
+                  </motion.span>
+                ) : (
+                  <motion.span
+                    key="send-icon"
+                    initial={{ opacity: 0, scale: 0.7, rotate: 8 }}
+                    animate={{ opacity: 1, scale: 1, rotate: 0 }}
+                    exit={{ opacity: 0, scale: 0.7, rotate: -8 }}
+                    transition={{ duration: 0.23, ease: EASING.standard }}
+                    className="absolute inset-0 inline-flex items-center justify-center"
+                  >
+                    <ArrowUp size={10} className="stroke-[2.25]" />
+                  </motion.span>
+                )}
+              </AnimatePresence>
+            </span>
+            <span>{running ? t('chat.stopBtn') : t('chat.sendButton')}</span>
+          </Button>
         </div>
       </div>
 

--- a/src/components/MentionPicker.tsx
+++ b/src/components/MentionPicker.tsx
@@ -1,0 +1,141 @@
+import React, { useEffect, useRef } from 'react';
+import { FileText } from 'lucide-react';
+import { cn } from '../lib/cn';
+import type { WorkspaceFile } from '../shared/ipc-types';
+import { useTranslation } from '../i18n/useTranslation';
+
+type Props = {
+  open: boolean;
+  query: string;
+  // Already-filtered list (parent runs `filterMentionFiles`) so the picker
+  // stays a dumb consumer, mirroring SlashCommandPicker.
+  files: WorkspaceFile[];
+  activeIndex: number;
+  onActiveIndexChange: (i: number) => void;
+  onSelect: (f: WorkspaceFile) => void;
+};
+
+// In-chat @file mention picker. Anchored above the InputBar by the caller,
+// same positioning rules as the slash-command picker.
+export function MentionPicker({
+  open,
+  query,
+  files,
+  activeIndex,
+  onActiveIndexChange,
+  onSelect,
+}: Props) {
+  const { t } = useTranslation();
+  const listRef = useRef<HTMLDivElement>(null);
+  const rowsRef = useRef<Array<HTMLButtonElement | null>>([]);
+
+  useEffect(() => {
+    if (!open) return;
+    const row = rowsRef.current[activeIndex];
+    if (row && typeof row.scrollIntoView === 'function') {
+      row.scrollIntoView({ block: 'nearest' });
+    }
+  }, [activeIndex, open]);
+
+  if (!open) return null;
+
+  rowsRef.current.length = files.length;
+
+  const activeFile = files[activeIndex];
+  const announcement = activeFile
+    ? t('mentions.activeAnnouncement', {
+        index: activeIndex + 1,
+        total: files.length,
+        name: activeFile.path,
+        defaultValue: `Result ${activeIndex + 1} of ${files.length}: ${activeFile.path}`,
+      })
+    : '';
+  const activeOptionId = activeFile
+    ? `mention-option-${activeFile.path.replace(/[^a-zA-Z0-9]/g, '-')}`
+    : undefined;
+
+  return (
+    <div
+      role="listbox"
+      aria-label={t('mentions.pickerTitle')}
+      aria-activedescendant={activeOptionId}
+      className={cn(
+        'absolute left-0 right-0 bottom-full mb-1.5 z-30',
+        'rounded-md border border-border-default bg-bg-elevated',
+        'surface-highlight shadow-[var(--surface-shadow)]',
+        'text-chrome text-fg-secondary overflow-hidden',
+        'animate-[menuIn_140ms_cubic-bezier(0.32,0.72,0,1)]'
+      )}
+    >
+      <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+        {announcement}
+      </div>
+      <div ref={listRef} className="max-h-[320px] overflow-y-auto py-1">
+        {files.length === 0 ? (
+          <div className="px-3 py-2 text-fg-tertiary text-mono-md leading-[16px]">
+            {query ? t('mentions.noMatch', { query }) : t('mentions.empty')}
+          </div>
+        ) : (
+          files.map((f, idx) => {
+            const active = idx === activeIndex;
+            // Render basename bold, dim parent path so the user can scan
+            // names without reading the full slash chain.
+            const slash = f.path.lastIndexOf('/');
+            const dir = slash === -1 ? '' : f.path.slice(0, slash + 1);
+            const base = slash === -1 ? f.path : f.path.slice(slash + 1);
+            return (
+              <button
+                key={f.path}
+                id={`mention-option-${f.path.replace(/[^a-zA-Z0-9]/g, '-')}`}
+                ref={(el) => {
+                  rowsRef.current[idx] = el;
+                }}
+                role="option"
+                aria-selected={active}
+                type="button"
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  onSelect(f);
+                }}
+                onMouseEnter={() => onActiveIndexChange(idx)}
+                className={cn(
+                  'w-full flex items-center gap-2.5 h-8 pl-3 pr-3',
+                  'text-left select-none outline-none',
+                  'transition-[background-color,box-shadow,border-color] duration-150',
+                  '[transition-timing-function:cubic-bezier(0.32,0.72,0,1)]',
+                  'border-l-2 border-transparent',
+                  active
+                    ? 'bg-bg-hover text-fg-primary border-l-accent shadow-[inset_0_1px_0_0_oklch(1_0_0_/_0.05)]'
+                    : 'hover:bg-bg-hover/60'
+                )}
+              >
+                <FileText
+                  size={14}
+                  className={cn(
+                    'shrink-0 stroke-[1.75]',
+                    active ? 'text-accent' : 'text-fg-tertiary'
+                  )}
+                />
+                <span className="font-mono text-mono-md text-fg-primary truncate">
+                  {dir ? <span className="text-fg-tertiary">{dir}</span> : null}
+                  <span>{base}</span>
+                </span>
+              </button>
+            );
+          })
+        )}
+      </div>
+      <div className="px-3 py-1.5 border-t border-border-subtle text-mono-sm text-fg-tertiary flex items-center gap-3 select-none bg-bg-panel/40">
+        <span>
+          <kbd className="font-mono">↑↓</kbd> {t('mentions.navigate')}
+        </span>
+        <span>
+          <kbd className="font-mono">Enter</kbd> {t('mentions.select')}
+        </span>
+        <span>
+          <kbd className="font-mono">Esc</kbd> {t('mentions.close')}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -5,6 +5,7 @@ import type {
   OpenSettingsResult,
   DiscoveredModel,
   LoadedCommand,
+  WorkspaceFile,
 } from './shared/ipc-types';
 
 type PermissionMode = CliPermissionMode;
@@ -198,6 +199,15 @@ declare global {
 
       commands: {
         list: (cwd: string | null | undefined) => Promise<LoadedCommand[]>;
+      };
+
+      files: {
+        /**
+         * List workspace files relative to the session cwd for the
+         * InputBar's @file mention picker. Returns POSIX-style relative
+         * paths so the literal we splice into the composer is portable.
+         */
+        list: (cwd: string | null | undefined) => Promise<WorkspaceFile[]>;
       };
 
       openExternal: (url: string) => Promise<boolean>;

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -410,7 +410,8 @@ const en = {
     noMatch: 'No files match "{{query}}"',
     navigate: 'navigate',
     select: 'select',
-    close: 'close'
+    close: 'close',
+    activeAnnouncement: 'Result {{index}} of {{total}}: {{name}}'
   },
   notifications: {
     sessionWaitingTitle: 'Session waiting',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -404,6 +404,14 @@ const en = {
     groupSkill: 'Skills',
     groupAgent: 'Agents'
   },
+  mentions: {
+    pickerTitle: 'File mentions',
+    empty: 'No files in this workspace',
+    noMatch: 'No files match "{{query}}"',
+    navigate: 'navigate',
+    select: 'select',
+    close: 'close'
+  },
   notifications: {
     sessionWaitingTitle: 'Session waiting',
     sessionWaitingBody: '{{name}} needs your input',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -382,7 +382,8 @@ const zh: EnCatalog = {
     noMatch: '没有匹配 “{{query}}” 的文件',
     navigate: '上下移动',
     select: '选择',
-    close: '关闭'
+    close: '关闭',
+    activeAnnouncement: '第 {{index}} / {{total}} 项：{{name}}'
   },
   notifications: {
     sessionWaitingTitle: '会话等待中',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -376,6 +376,14 @@ const zh: EnCatalog = {
     groupSkill: 'Skills',
     groupAgent: 'Agents'
   },
+  mentions: {
+    pickerTitle: '文件引用',
+    empty: '当前工作区暂无文件',
+    noMatch: '没有匹配 “{{query}}” 的文件',
+    navigate: '上下移动',
+    select: '选择',
+    close: '关闭'
+  },
   notifications: {
     sessionWaitingTitle: '会话等待中',
     sessionWaitingBody: '{{name}} 需要你的输入',

--- a/src/mentions/registry.ts
+++ b/src/mentions/registry.ts
@@ -1,0 +1,129 @@
+// @file mention registry.
+//
+// Mirrors the shape of `src/slash-commands/registry.ts` so InputBar can
+// drive both pickers from one trigger-detection / fuzzy-match playbook.
+// Trigger pattern matches the upstream Anthropic Claude Code VS Code
+// extension (webview index.js): `/(?:^|\s)@[^\s]*/gm`. The picker only
+// shows files (no @symbol — upstream's only @mention surface is the
+// `mention-file` command, no symbol picker exists).
+
+import Fuse from 'fuse.js';
+import type { WorkspaceFile } from '../shared/ipc-types';
+
+export type AtTriggerState =
+  | { active: false }
+  | {
+      active: true;
+      // Substring after `@` and before the caret. Empty string means the
+      // user just typed `@` and hasn't typed any filter yet.
+      query: string;
+      // Inclusive start index of `@` in `value`. Used by the commit path
+      // to splice the chosen mention back into the textarea.
+      atStart: number;
+      // Exclusive end of the in-progress mention token (where the caret is).
+      // Always equals `caret` for a live trigger.
+      tokenEnd: number;
+    };
+
+// Detect whether the caret is inside a mention token of the form `@xxx`.
+// Mirrors upstream's `(?:^|\s)@[^\s]*` regex but evaluated against the
+// substring immediately preceding the caret (no need to scan forward).
+//
+// Rules:
+//   - `@` must be at the very start of `value` OR preceded by whitespace.
+//     (Stops `email@domain` from accidentally opening the picker.)
+//   - Everything between `@` and the caret must be non-whitespace; the
+//     first whitespace closes the trigger.
+//   - Trigger covers a single token only; multi-line composers are fine
+//     because the no-whitespace rule includes `\n`.
+export function detectAtTrigger(value: string, caret: number): AtTriggerState {
+  if (caret <= 0 || caret > value.length) return { active: false };
+  // Walk backwards from the caret looking for `@` with whitespace (or BOS)
+  // immediately before it. Bail as soon as we hit whitespace — that means
+  // we're past the end of any candidate mention token.
+  let i = caret - 1;
+  while (i >= 0) {
+    const ch = value[i];
+    if (ch === '@') {
+      const prev = i === 0 ? '' : value[i - 1];
+      if (i === 0 || /\s/.test(prev)) {
+        return {
+          active: true,
+          query: value.slice(i + 1, caret),
+          atStart: i,
+          tokenEnd: caret,
+        };
+      }
+      return { active: false };
+    }
+    if (/\s/.test(ch)) return { active: false };
+    i--;
+  }
+  return { active: false };
+}
+
+// Pure filter used by the picker + tests. Same Fuse settings shape as the
+// slash-command picker (threshold 0.4, name weight 3) so the muscle-memory
+// feel stays consistent across both pickers.
+//
+// Empty query: return the first 50 entries unchanged. We don't need to show
+// 5000 files at once — 50 is enough screen for the user to confirm "yep,
+// the picker is open" before they start typing to filter. The cap also
+// keeps the listbox DOM small.
+const EMPTY_QUERY_LIMIT = 50;
+
+export function filterMentionFiles(all: WorkspaceFile[], query: string): WorkspaceFile[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return all.slice(0, EMPTY_QUERY_LIMIT);
+
+  // Pin exact basename + prefix matches first, in input order.
+  const pinned: WorkspaceFile[] = [];
+  const pinnedSet = new Set<WorkspaceFile>();
+  for (const f of all) {
+    if (f.name.toLowerCase() === q) {
+      pinned.push(f);
+      pinnedSet.add(f);
+    }
+  }
+  for (const f of all) {
+    if (pinnedSet.has(f)) continue;
+    if (f.name.toLowerCase().startsWith(q)) {
+      pinned.push(f);
+      pinnedSet.add(f);
+    }
+  }
+
+  const remainder = all.filter((f) => !pinnedSet.has(f));
+  const fuse = new Fuse(remainder, {
+    includeScore: true,
+    threshold: 0.4,
+    ignoreLocation: true,
+    keys: [
+      { name: 'name', weight: 3 },
+      { name: 'path', weight: 1 },
+    ],
+  });
+  const fuzzy = fuse.search(q).map((r) => r.item);
+
+  // Cap final results so a wildcard-ish query doesn't render thousands of rows.
+  return [...pinned, ...fuzzy].slice(0, 100);
+}
+
+// Splice `@<path>` into `value`, replacing the in-progress mention token.
+// Always trails with a single space so the user can keep typing without
+// having to insert one themselves (matches upstream behavior — see
+// `insertAtMention` in webview/index.js, which appends ` ` for the
+// non-bare case).
+export function commitMention(
+  value: string,
+  trigger: { atStart: number; tokenEnd: number },
+  filePath: string
+): { next: string; caret: number } {
+  const before = value.slice(0, trigger.atStart);
+  const after = value.slice(trigger.tokenEnd);
+  // If the user already left a space after the caret, don't double up.
+  const tail = after.startsWith(' ') ? '' : ' ';
+  const next = `${before}@${filePath}${tail}${after}`;
+  const caret = (before + '@' + filePath + tail).length;
+  return { next, caret };
+}

--- a/src/shared/ipc-types.ts
+++ b/src/shared/ipc-types.ts
@@ -41,3 +41,13 @@ export interface LoadedCommand {
   source: CommandSource;
   pluginId?: string;
 }
+
+// Workspace file entry surfaced by the @mention picker. `path` is the
+// POSIX-style path relative to the session cwd (forward slashes even on
+// Windows so the mention text the model sees stays portable). `name` is
+// the basename, pre-extracted so the picker can weight name matches
+// without re-splitting on every keystroke.
+export interface WorkspaceFile {
+  path: string;
+  name: string;
+}

--- a/tests/inputbar-morph-mention.test.tsx
+++ b/tests/inputbar-morph-mention.test.tsx
@@ -1,0 +1,163 @@
+// Component tests for the InputBar additions in feat/composer-morph-mention:
+//   - send/stop morph button: same DOM slot, icon + variant + aria-label
+//     swap based on the running flag (mirrors the upstream Anthropic
+//     Claude Code VS Code extension's webview button)
+//   - @file mention picker: typing `@` opens a listbox; Esc dismisses;
+//     selecting an entry splices `@<path> ` into the textarea
+//
+// Mirrors `tests/inputbar.test.tsx` setup so we keep the renderer-only
+// shortcut: real Zustand store, stubbed `window.ccsm`, no Electron.
+
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, act, cleanup, waitFor } from '@testing-library/react';
+import { InputBar } from '../src/components/InputBar';
+import { useStore } from '../src/stores/store';
+
+const initial = useStore.getState();
+
+function freshStoreWithSession(sessionId: string, opts: { running?: boolean; started?: boolean } = {}) {
+  useStore.setState(
+    {
+      ...initial,
+      sessions: [
+        {
+          id: sessionId,
+          name: sessionId,
+          state: 'idle',
+          cwd: '~',
+          model: 'claude',
+          groupId: 'g-default',
+          agentType: 'claude-code'
+        }
+      ],
+      groups: [{ id: 'g-default', name: 'Sessions', collapsed: false, kind: 'normal' }],
+      activeId: sessionId,
+      messagesBySession: {},
+      startedSessions: opts.started ? { [sessionId]: true } : {},
+      runningSessions: opts.running ? { [sessionId]: true } : {},
+      messageQueues: {},
+      focusInputNonce: 0
+    },
+    true
+  );
+}
+
+function stubCCSM(overrides: Partial<Record<string, unknown>> = {}) {
+  const filesList = vi.fn().mockResolvedValue([
+    { path: 'src/InputBar.tsx', name: 'InputBar.tsx' },
+    { path: 'src/MentionPicker.tsx', name: 'MentionPicker.tsx' },
+    { path: 'README.md', name: 'README.md' },
+  ]);
+  const api = {
+    agentInterrupt: vi.fn().mockResolvedValue(undefined),
+    agentSend: vi.fn().mockResolvedValue(true),
+    agentSendContent: vi.fn().mockResolvedValue(true),
+    agentStart: vi.fn().mockResolvedValue({ ok: true }),
+    files: { list: filesList },
+    commands: { list: vi.fn().mockResolvedValue([]) },
+    ...overrides
+  };
+  (globalThis as unknown as { window: Window & { ccsm?: unknown } }).window.ccsm = api;
+  return api;
+}
+
+beforeEach(() => {
+  cleanup();
+  (globalThis as unknown as { window: Window & { ccsm?: unknown } }).window.ccsm = undefined;
+});
+
+describe('InputBar: send/stop morph button', () => {
+  it('renders the Send affordance when the session is idle', () => {
+    freshStoreWithSession('s-morph-idle', { running: false, started: true });
+    stubCCSM();
+    render(<InputBar sessionId="s-morph-idle" />);
+    const morph = screen.getByRole('button', { name: /send message/i });
+    expect(morph).toBeInTheDocument();
+    expect(morph).toHaveAttribute('data-morph-state', 'send');
+    expect(morph).toHaveAttribute('data-variant', 'primary');
+  });
+
+  it('morphs to the Stop affordance when the session is running', () => {
+    freshStoreWithSession('s-morph-run', { running: true, started: true });
+    stubCCSM();
+    render(<InputBar sessionId="s-morph-run" />);
+    const morph = screen.getByRole('button', { name: /^stop$/i });
+    expect(morph).toBeInTheDocument();
+    expect(morph).toHaveAttribute('data-morph-state', 'stop');
+    expect(morph).toHaveAttribute('data-variant', 'danger');
+  });
+
+  it('clicking the morph button while running fires agentInterrupt', () => {
+    freshStoreWithSession('s-morph-stop', { running: true, started: true });
+    const api = stubCCSM();
+    render(<InputBar sessionId="s-morph-stop" />);
+    const stop = screen.getByRole('button', { name: /^stop$/i });
+    act(() => {
+      fireEvent.click(stop);
+    });
+    expect(api.agentInterrupt).toHaveBeenCalledWith('s-morph-stop');
+  });
+});
+
+describe('InputBar: @file mention picker', () => {
+  it('opens the mention picker when the user types @', async () => {
+    freshStoreWithSession('s-at', { running: false, started: true });
+    stubCCSM();
+    render(<InputBar sessionId="s-at" />);
+    const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
+    act(() => {
+      fireEvent.change(ta, { target: { value: '@' } });
+      // Caret sync — the InputBar reads selectionStart on change, but we
+      // also bump it via a Click for good measure.
+      ta.setSelectionRange(1, 1);
+      fireEvent.click(ta);
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('listbox', { name: /file mentions/i })).toBeInTheDocument();
+    });
+    // At least one mention row should be rendered.
+    const opts = screen.getAllByRole('option');
+    expect(opts.length).toBeGreaterThan(0);
+  });
+
+  it('Esc dismisses the mention picker without changing the textarea', async () => {
+    freshStoreWithSession('s-at-esc', { running: false, started: true });
+    stubCCSM();
+    render(<InputBar sessionId="s-at-esc" />);
+    const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
+    act(() => {
+      fireEvent.change(ta, { target: { value: '@' } });
+      ta.setSelectionRange(1, 1);
+      fireEvent.click(ta);
+    });
+    await waitFor(() => screen.getByRole('listbox', { name: /file mentions/i }));
+    act(() => {
+      fireEvent.keyDown(ta, { key: 'Escape' });
+    });
+    expect(screen.queryByRole('listbox', { name: /file mentions/i })).not.toBeInTheDocument();
+    expect(ta.value).toBe('@');
+  });
+
+  it('Enter on a highlighted row splices @<path> into the textarea', async () => {
+    freshStoreWithSession('s-at-pick', { running: false, started: true });
+    stubCCSM();
+    render(<InputBar sessionId="s-at-pick" />);
+    const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
+    act(() => {
+      fireEvent.change(ta, { target: { value: '@' } });
+      ta.setSelectionRange(1, 1);
+      fireEvent.click(ta);
+    });
+    await waitFor(() => screen.getByRole('listbox', { name: /file mentions/i }));
+    act(() => {
+      fireEvent.keyDown(ta, { key: 'Enter' });
+    });
+    // The first row in the picker (no query) is the first WorkspaceFile we
+    // stubbed: src/InputBar.tsx. After commit, the textarea contains
+    // `@src/InputBar.tsx ` (with trailing space).
+    expect(ta.value).toBe('@src/InputBar.tsx ');
+    // Picker auto-dismisses after selection.
+    expect(screen.queryByRole('listbox', { name: /file mentions/i })).not.toBeInTheDocument();
+  });
+});

--- a/tests/inputbar-morph-mention.test.tsx
+++ b/tests/inputbar-morph-mention.test.tsx
@@ -11,6 +11,7 @@
 import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, act, cleanup, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { InputBar } from '../src/components/InputBar';
 import { useStore } from '../src/stores/store';
 
@@ -159,5 +160,41 @@ describe('InputBar: @file mention picker', () => {
     expect(ta.value).toBe('@src/InputBar.tsx ');
     // Picker auto-dismisses after selection.
     expect(screen.queryByRole('listbox', { name: /file mentions/i })).not.toBeInTheDocument();
+  });
+
+  // Reproduces the keystroke timing the e2e probe was hitting (PR #287
+  // request-changes round): re-arm the picker by typing+deleting a char
+  // AFTER an Esc dismissal, then press Enter. fireEvent batches everything
+  // synchronously so it can mask closure / event-ordering bugs in the
+  // textarea keydown handler — userEvent dispatches one keystroke per
+  // microtask, going through the real input → onChange → render → onKeyDown
+  // cycle. If the keydown handler's mention guard ever closes over stale
+  // `mentionOpen` / `filteredFiles` again, this test will fail (Enter would
+  // fall through to send() and clear the textarea).
+  it('Enter commits highlighted mention after Esc-then-edit re-arm (real keystroke timing)', async () => {
+    const user = userEvent.setup();
+    freshStoreWithSession('s-at-rearm', { running: false, started: true });
+    stubCCSM();
+    render(<InputBar sessionId="s-at-rearm" />);
+    const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
+
+    await user.click(ta);
+    await user.keyboard('@');
+    await waitFor(() => screen.getByRole('listbox', { name: /file mentions/i }));
+
+    // Dismiss with Esc — same path the probe exercises.
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('listbox', { name: /file mentions/i })).not.toBeInTheDocument();
+    expect(ta.value).toBe('@');
+
+    // Re-arm: type a char then delete it. update() resets mentionDismissed
+    // so the picker reopens once atTrigger.active is true again.
+    await user.keyboard(' {Backspace}');
+    await waitFor(() => screen.getByRole('listbox', { name: /file mentions/i }));
+
+    await user.keyboard('{Enter}');
+
+    // Enter must commit the highlighted row, NOT fall through to send().
+    expect(ta.value).toBe('@src/InputBar.tsx ');
   });
 });

--- a/tests/mentions-registry.test.ts
+++ b/tests/mentions-registry.test.ts
@@ -1,0 +1,106 @@
+// Pure-function tests for the @file mention registry. Companion to the
+// /-command registry tests in `slash-commands-registry.test.ts`. Picker
+// behavior + keyboard plumbing live in `inputbar.test.tsx`.
+
+import { describe, it, expect } from 'vitest';
+import {
+  detectAtTrigger,
+  filterMentionFiles,
+  commitMention,
+} from '../src/mentions/registry';
+import type { WorkspaceFile } from '../src/shared/ipc-types';
+
+describe('detectAtTrigger', () => {
+  it('opens the picker after a bare @ at start of input', () => {
+    const t = detectAtTrigger('@', 1);
+    expect(t.active).toBe(true);
+    if (t.active) {
+      expect(t.query).toBe('');
+      expect(t.atStart).toBe(0);
+    }
+  });
+
+  it('opens after @ preceded by whitespace', () => {
+    const t = detectAtTrigger('hello @src', 'hello @src'.length);
+    expect(t.active).toBe(true);
+    if (t.active) expect(t.query).toBe('src');
+  });
+
+  it('captures only the partial query up to the caret', () => {
+    const value = 'hello @sr extra';
+    // Caret right after `r` in `sr`.
+    const caret = 'hello @sr'.length;
+    const t = detectAtTrigger(value, caret);
+    expect(t.active).toBe(true);
+    if (t.active) expect(t.query).toBe('sr');
+  });
+
+  it('does not trigger when @ is part of an email-like token', () => {
+    const t = detectAtTrigger('hello@world', 'hello@world'.length);
+    expect(t.active).toBe(false);
+  });
+
+  it('closes the trigger as soon as whitespace is typed inside the token', () => {
+    // Caret is past a space — the picker should close.
+    const t = detectAtTrigger('@src foo', '@src foo'.length);
+    expect(t.active).toBe(false);
+  });
+
+  it('handles caret in the middle of a multi-line composer', () => {
+    const value = 'first line\n@sr';
+    const t = detectAtTrigger(value, value.length);
+    expect(t.active).toBe(true);
+    if (t.active) expect(t.query).toBe('sr');
+  });
+});
+
+describe('filterMentionFiles', () => {
+  const files: WorkspaceFile[] = [
+    { path: 'src/InputBar.tsx', name: 'InputBar.tsx' },
+    { path: 'src/MentionPicker.tsx', name: 'MentionPicker.tsx' },
+    { path: 'src/lib/cn.ts', name: 'cn.ts' },
+    { path: 'README.md', name: 'README.md' },
+  ];
+
+  it('returns all files (capped) for an empty query', () => {
+    const r = filterMentionFiles(files, '');
+    expect(r).toHaveLength(files.length);
+  });
+
+  it('pins exact basename matches first', () => {
+    const r = filterMentionFiles(files, 'cn.ts');
+    expect(r[0]?.name).toBe('cn.ts');
+  });
+
+  it('pins prefix matches before fuzzy matches', () => {
+    const r = filterMentionFiles(files, 'Input');
+    expect(r[0]?.name).toBe('InputBar.tsx');
+  });
+
+  it('falls back to fuzzy match on typos', () => {
+    // `mntion` should still surface MentionPicker via Fuse.
+    const r = filterMentionFiles(files, 'mntion');
+    expect(r.some((f) => f.name === 'MentionPicker.tsx')).toBe(true);
+  });
+});
+
+describe('commitMention', () => {
+  it('replaces the in-progress @-token with @<path> + trailing space', () => {
+    const value = 'see @sr';
+    const trigger = { atStart: 4, tokenEnd: value.length };
+    const { next, caret } = commitMention(value, trigger, 'src/InputBar.tsx');
+    expect(next).toBe('see @src/InputBar.tsx ');
+    expect(caret).toBe(next.length);
+  });
+
+  it('keeps the caret immediately after the inserted mention when text follows', () => {
+    const value = '@s rest';
+    // tokenEnd points past `@s`, BEFORE the space.
+    const trigger = { atStart: 0, tokenEnd: 2 };
+    const { next, caret } = commitMention(value, trigger, 'src/foo.ts');
+    // The existing space after the original `@s` is preserved (we don't
+    // double-up). Caret sits right after `@src/foo.ts`, before the space.
+    expect(next).toBe('@src/foo.ts rest');
+    expect(caret).toBe('@src/foo.ts'.length);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the remaining scope of task #13 (parts ③ + ④):

- **Send/Stop morph button** — single `<Button>` whose icon, variant, aria-label, and onClick swap based on `running`. AnimatePresence cross-fades the inner icon at 230ms tween. Mirrors the upstream Anthropic Claude Code VS Code extension pattern (webview/index.js: `if (busy && !X) <StopIcon/> else <SendIcon/>`). `disabled` follows the new state — Stop is always clickable while running, Send respects `sendDisabled`.

- **@file mention picker** — typing `@` (at start of input or after whitespace) opens a listbox of workspace files. Selecting splices `@<path> ` into the textarea — claude.exe parses the `@`-token itself, no further transformation needed. Trigger pattern matches the upstream `(?:^|\s)@[^\s]*` regex; picker shares the global popover mutex with the slash picker (mutual exclusion). No keyboard shortcut to invoke (per task constraints) — only the `@` typing trigger.

- **`@symbol` intentionally NOT shipped** — Layer 1 upstream grep showed only a `mention-file` command registered; no symbol picker exists in the extension. Per task ("如果上游没做就只做 @file"), dropped that scope.

### IPC

New `files:list` handler in `electron/main.ts` walks the session cwd (skipping node_modules/.git/dist/build/.venv/target/.idea/.vscode/etc., capped at 5000 entries / depth 12). Returns POSIX-style relative paths so the literal we splice into the composer is portable across Win/macOS/Linux. fromMainFrame guard + isSafePath validation match every other privileged handler in the file.

## Test plan

- [x] vitest: `tests/mentions-registry.test.ts` — 12 cases covering `detectAtTrigger` (bare @, after whitespace, partial query, email-like negatives, multi-line), `filterMentionFiles` (empty / exact / prefix / fuzzy), `commitMention` (splice + caret).
- [x] vitest: `tests/inputbar-morph-mention.test.tsx` — 6 cases: morph button data attributes idle/running, click-Stop fires `agentInterrupt`, `@` opens picker, Esc dismisses without altering textarea, Enter commits `@<path> `.
- [x] No regression in existing InputBar / slash picker / i18n parity tests (64/64 pass).
- [x] Full vitest run: 794/797 pass; the 3 failures are the pre-existing `electron/__tests__/db-hardening.test.ts` better-sqlite3 native-build issue (unrelated to this PR).
- [x] `tsc --noEmit` clean for both renderer + electron tsconfigs.
- [x] eslint clean on changed files (only the 1 pre-existing `Electron is not defined` error in main.ts and 1 pre-existing `markStarted` unused-var warning remain — confirmed identical pre/post via stash).
- [ ] e2e probe `scripts/probe-e2e-composer-morph-mention.mjs` — file ships and is structurally complete, but execution requires the Electron native deps which weren't buildable in the worker sandbox. Reviewer can run locally.