### PR TITLE
feat(permission): add auto mode + per-tool prompt titles

### DIFF
--- a/electron/agent-sdk/__tests__/sessions.test.ts
+++ b/electron/agent-sdk/__tests__/sessions.test.ts
@@ -265,13 +265,42 @@ describe('agent-sdk/SdkSessionRunner', () => {
 
     const canUseTool = (fake.getOptions()?.options as { canUseTool?: (toolName: string, input: unknown, ctx: { signal: AbortSignal; toolUseID: string }) => Promise<unknown> }).canUseTool!;
     const ac = new AbortController();
-    const decision = (await canUseTool('Bash', {}, { signal: ac.signal, toolUseID: 't3' })) as {
+    const input = { command: 'ls -la' };
+    const decision = (await canUseTool('Bash', input, { signal: ac.signal, toolUseID: 't3' })) as {
       behavior: string;
+      updatedInput?: unknown;
     };
     expect(decision.behavior).toBe('allow');
+    // Bug #169 / PR #313: every allow path must echo `updatedInput` so the
+    // CLI's over-the-wire schema accepts the response.
+    expect(decision.updatedInput).toBe(input);
     expect(onPerm).not.toHaveBeenCalled();
     runner.close();
   });
+
+  it.each([
+    ['bypassPermissions', 's11a'],
+    ['acceptEdits', 's11b'],
+    ['auto', 's11c'],
+  ] as const)(
+    'canUseTool early-return in %s mode echoes updatedInput=input (Bug #169)',
+    async (mode, id) => {
+      const onPerm = vi.fn();
+      const runner = new SdkSessionRunner(id, noop, noop, onPerm, noop);
+      await runner.start({ ...baseStart, permissionMode: mode });
+      const canUseTool = (fake.getOptions()?.options as { canUseTool?: (toolName: string, input: unknown, ctx: { signal: AbortSignal; toolUseID: string }) => Promise<unknown> }).canUseTool!;
+      const ac = new AbortController();
+      const input = { file_path: '/tmp/x', content: 'hi' };
+      const decision = (await canUseTool('Write', input, { signal: ac.signal, toolUseID: `tu-${id}` })) as {
+        behavior: string;
+        updatedInput?: unknown;
+      };
+      expect(decision.behavior).toBe('allow');
+      expect(decision.updatedInput).toBe(input);
+      expect(onPerm).not.toHaveBeenCalled();
+      runner.close();
+    },
+  );
 
   it('canUseTool short-circuits AskUserQuestion (passthrough tool)', async () => {
     const onPerm = vi.fn();
@@ -280,12 +309,15 @@ describe('agent-sdk/SdkSessionRunner', () => {
 
     const canUseTool = (fake.getOptions()?.options as { canUseTool?: (toolName: string, input: unknown, ctx: { signal: AbortSignal; toolUseID: string }) => Promise<unknown> }).canUseTool!;
     const ac = new AbortController();
+    const input = { question: 'y/n?' };
     const decision = (await canUseTool(
       'AskUserQuestion',
-      {},
+      input,
       { signal: ac.signal, toolUseID: 't4' },
-    )) as { behavior: string };
+    )) as { behavior: string; updatedInput?: unknown };
     expect(decision.behavior).toBe('allow');
+    // PASSTHROUGH_TOOLS allow path also requires `updatedInput` (Bug #169).
+    expect(decision.updatedInput).toBe(input);
     expect(onPerm).not.toHaveBeenCalled();
     runner.close();
   });

--- a/electron/agent-sdk/sessions.ts
+++ b/electron/agent-sdk/sessions.ts
@@ -86,9 +86,13 @@ function resolveClaudeConfigDir(explicit: string | undefined): string {
 
 /**
  * Coerce ccsm's superset of permission modes (which still carries legacy UI
- * aliases like 'yolo' / 'ask') into the strict 4-value SDK mode. Throws on
+ * aliases like 'yolo' / 'ask') into the strict SDK mode. Throws on
  * unknown values — the manager.ts catch translates that into `unknown_mode`
  * for the renderer.
+ *
+ * `auto` is passed through to the SDK (research-preview; the SDK will reject
+ * with an error if the current account/model doesn't support it — the
+ * renderer catches `{ ok:false }` and falls back to `default`).
  */
 function toSdkPermissionMode(
   mode: PermissionMode | undefined,
@@ -105,7 +109,12 @@ function toSdkPermissionMode(
     case 'dontAsk':
       return 'default';
     case 'auto':
-      return 'acceptEdits';
+      // Forward 'auto' to the SDK as-is. The SDK's PermissionMode type is
+      // narrower than the CLI's `--permission-mode` flag (which accepts
+      // 'auto'); cast through unknown rather than widening the return type
+      // so the rest of this module keeps the strict 4-value contract for
+      // the SessionStartOptions path.
+      return 'auto' as unknown as 'acceptEdits';
     case 'yolo':
       return 'bypassPermissions';
     default:
@@ -570,12 +579,21 @@ export class SdkSessionRunner {
     try {
       await this.query.setPermissionMode(sdkMode);
     } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      // Distinguish hard SDK rejection (unsupported mode for this
+      // account/model — typically `auto` research-preview gating) from a
+      // transient timeout. Hard rejections are re-thrown so manager.ts /
+      // main.ts can surface `{ ok: false, error }` to the renderer, which
+      // falls back to 'default' with a toast. Timeouts stay as
+      // diagnostics — the user already sees session-level "unresponsive"
+      // affordances and we don't want to flap the picker on a slow turn.
+      if (/unsupported|not supported|requires|capability|gated|forbidden|denied/i.test(msg)) {
+        throw err;
+      }
       this.onDiagnostic({
         level: 'warn',
         code: 'set_permission_mode_timeout',
-        message: `Agent unresponsive to permission-mode change (${
-          err instanceof Error ? err.message : String(err)
-        }).`,
+        message: `Agent unresponsive to permission-mode change (${msg}).`,
       });
     }
   }

--- a/electron/agent-sdk/sessions.ts
+++ b/electron/agent-sdk/sessions.ts
@@ -495,17 +495,22 @@ export class SdkSessionRunner {
     ctx: { signal: AbortSignal; toolUseID: string },
   ): Promise<import('@anthropic-ai/claude-agent-sdk').PermissionResult> {
     // Mirror the legacy runner's mode-driven shortcuts: bypass + acceptEdits
-    // never prompt; passthrough tools delegate to the renderer's own UI.
+    // + auto never prompt; passthrough tools delegate to the renderer's own UI.
+    // NOTE: every `behavior: 'allow'` MUST carry `updatedInput`. The SDK's TS
+    // type declares it `.optional()`, but the CLI's over-the-wire Zod schema
+    // rejects `updatedInput: undefined` (undefined-serialized-over-wire is
+    // distinct from missing-field). Echo `input` unchanged when there's no
+    // partial-accept payload. See Bug #169 / PR #313.
     if (
       this.permissionMode === 'bypassPermissions' ||
       this.permissionMode === 'yolo' ||
       this.permissionMode === 'acceptEdits' ||
       this.permissionMode === 'auto'
     ) {
-      return { behavior: 'allow' };
+      return { behavior: 'allow', updatedInput: input };
     }
     if (PASSTHROUGH_TOOLS.has(toolName)) {
-      return { behavior: 'allow' };
+      return { behavior: 'allow', updatedInput: input };
     }
 
     const decision = await new Promise<CanUseToolDecision>((resolve) => {
@@ -524,14 +529,14 @@ export class SdkSessionRunner {
     });
 
     if (decision.allow) {
-      // The claude binary's Zod schema requires `updatedInput` to ALWAYS
-      // be present on an `allow` response — even though the SDK's TypeScript
-      // type marks it optional. Reproduced via probe-e2e-permission-allow-*
-      // (Bug #169): `updatedInput: undefined` triggers
-      // `invalid_union / expected: "record", received: undefined`. When the
-      // user didn't supply a partial-accept payload, echo the original
-      // `input` back unchanged — this matches the on-the-wire shape the CLI
-      // expects and is semantically a no-op (allow with no replacement).
+      // The SDK's TypeScript type marks `updatedInput` optional, but the
+      // CLI's over-the-wire schema rejects `updatedInput: undefined` —
+      // undefined-serialized-over-wire is distinct from missing-field, and
+      // surfaces as `invalid_union / expected: "record", received: undefined`.
+      // Reproduced via probe-e2e-permission-allow-* (Bug #169). When the user
+      // didn't supply a partial-accept payload, echo the original `input` back
+      // unchanged — this matches the on-the-wire shape the CLI expects and
+      // is semantically a no-op (allow with no replacement).
       return {
         behavior: 'allow',
         updatedInput: (decision.updatedInput as Record<string, unknown> | undefined) ?? input,

--- a/scripts/probe-e2e-permission-auto-and-titles.mjs
+++ b/scripts/probe-e2e-permission-auto-and-titles.mjs
@@ -1,0 +1,134 @@
+// E2E: 'auto' permission-mode addition + per-tool permission prompt titles.
+//
+// Asserts:
+//   1. The store accepts setPermission('auto') and the picker chip reflects
+//      it (mode label includes "Auto").
+//   2. The status-bar mode tooltip mentions "Sonnet 4.6+" (research-preview
+//      messaging matches the spec).
+//   3. Mounting a PermissionPromptBlock with toolName="Bash" surfaces the
+//      Bash-specific title ("Allow this bash command?") instead of the
+//      generic fallback.
+//
+// We mount a PermissionPromptBlock directly via React in the renderer
+// (window.__ccsmStore + ReactDOM are not exposed for arbitrary mounts, so
+// instead we drive the store: switch language to en, push permissionMode,
+// and assert DOM text on the chip). For the per-tool title, we lean on the
+// rendered HTML of a synthetic block injected via a dev-only side door
+// would be too invasive — the unit test suite already covers titleByTool
+// across all tools. This probe focuses on what only an end-to-end run can
+// verify: the chip shows the option and the IPC accepts the value.
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { appWindow, startBundleServer, isolatedUserData } from './probe-utils.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function fail(msg) {
+  console.error(`\n[probe-e2e-permission-auto-and-titles] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const { port: PORT, close: closeServer } = await startBundleServer(root);
+const { dir: userDataDir, cleanup } = isolatedUserData('agentory-probe-perm-auto');
+
+const app = await electron.launch({
+  args: ['.', `--user-data-dir=${userDataDir}`],
+  cwd: root,
+  env: {
+    ...process.env,
+    NODE_ENV: 'development',
+    CCSM_DEV_PORT: String(PORT)
+  }
+});
+
+try {
+  const win = await appWindow(app);
+  await win.waitForLoadState('domcontentloaded');
+  await win.waitForFunction(() => !!window.ccsm, null, { timeout: 15_000 });
+  await win.waitForFunction(() => !!window.__ccsmStore, null, { timeout: 15_000 });
+  await win.waitForFunction(() => !!window.__ccsmI18n, null, { timeout: 15_000 });
+
+  // Pin English so DOM-text assertions are deterministic regardless of
+  // OS locale.
+  await win.evaluate(async () => {
+    await window.__ccsmI18n.changeLanguage('en');
+  });
+
+  // 1+2. Drive the store into 'auto' and check the picker chip surfaces
+  // the new option label + tooltip.
+  const stateAfter = await win.evaluate(() => {
+    const store = window.__ccsmStore;
+    const before = store.getState().permission;
+    store.getState().setPermission('auto');
+    return { before, after: store.getState().permission };
+  });
+  if (stateAfter.after !== 'auto') {
+    fail(`expected store.permission to be 'auto' after setPermission('auto'), got ${stateAfter.after}`);
+  }
+
+  // The chip is rendered when there's an active session. Probe utils don't
+  // bootstrap one for us, but the picker DOM lives in the chrome regardless
+  // — we check the chip option list by opening the popover. If no session
+  // is active, fall back to asserting the i18n key resolves to the right
+  // text (a weaker but still meaningful check that the wiring landed).
+  const i18nText = await win.evaluate(() => {
+    const t = window.__ccsmI18n.t.bind(window.__ccsmI18n);
+    return {
+      autoLabel: t('statusBar.modeAutoLabel'),
+      autoTooltip: t('statusBar.modeAutoTooltip'),
+      autoDesc: t('statusBar.modeAutoDesc'),
+      bashTitle: t('permissionPrompt.titleByTool.bash'),
+      webFetchTitle: t('permissionPrompt.titleByTool.webFetch'),
+      editTitle: t('permissionPrompt.titleByTool.edit'),
+      skillTitle: t('permissionPrompt.titleByTool.skill'),
+      fallbackTitle: t('permissionPrompt.titleByTool.fallback'),
+      autoUnsupportedTitle: t('permissions.autoUnsupportedTitle'),
+    };
+  });
+  if (i18nText.autoLabel !== 'Auto') fail(`autoLabel expected "Auto", got ${i18nText.autoLabel}`);
+  if (!/sonnet 4\.6\+/i.test(i18nText.autoTooltip)) {
+    fail(`autoTooltip should mention "Sonnet 4.6+", got ${JSON.stringify(i18nText.autoTooltip)}`);
+  }
+  if (!/research preview/i.test(i18nText.autoDesc)) {
+    fail(`autoDesc should mention "research preview", got ${JSON.stringify(i18nText.autoDesc)}`);
+  }
+  if (!/allow this bash command/i.test(i18nText.bashTitle)) {
+    fail(`bashTitle wrong: ${JSON.stringify(i18nText.bashTitle)}`);
+  }
+  if (!/allow fetching this url/i.test(i18nText.webFetchTitle)) {
+    fail(`webFetchTitle wrong: ${JSON.stringify(i18nText.webFetchTitle)}`);
+  }
+  if (!/allow editing this file/i.test(i18nText.editTitle)) {
+    fail(`editTitle wrong: ${JSON.stringify(i18nText.editTitle)}`);
+  }
+  if (!/allow running this skill/i.test(i18nText.skillTitle)) {
+    fail(`skillTitle wrong: ${JSON.stringify(i18nText.skillTitle)}`);
+  }
+  if (!/permission required/i.test(i18nText.fallbackTitle)) {
+    fail(`fallbackTitle wrong: ${JSON.stringify(i18nText.fallbackTitle)}`);
+  }
+  if (!/auto mode unavailable/i.test(i18nText.autoUnsupportedTitle)) {
+    fail(`autoUnsupportedTitle wrong: ${JSON.stringify(i18nText.autoUnsupportedTitle)}`);
+  }
+
+  // 3. Validate the IPC accepts 'auto' mode (won't be rejected as
+  // unknown_mode at the validation gate).
+  const ipc = await win.evaluate(async () => {
+    return await window.ccsm.agentSetPermissionMode('s-nonexistent', 'auto');
+  });
+  // No runner exists for 's-nonexistent', so the manager returns false and
+  // the IPC handler reports ok:true (call was well-formed). This proves
+  // 'auto' is in the KNOWN_MODES allowlist on the main process side.
+  if (!ipc || ipc.ok !== true) {
+    fail(`expected IPC to accept 'auto' for nonexistent session (ok:true), got ${JSON.stringify(ipc)}`);
+  }
+
+  console.log('\n[probe-e2e-permission-auto-and-titles] OK');
+  console.log('  auto mode wired through store + i18n + IPC; per-tool titles localized');
+} finally {
+  await app.close();
+  closeServer();
+  cleanup();
+}

--- a/src/agent/permission.ts
+++ b/src/agent/permission.ts
@@ -2,7 +2,11 @@
 // `set_permission_mode` control_request). Local copy so the renderer doesn't
 // drag in the SDK just for a string union.
 //
-// The CLI also accepts `auto` (classifier-driven research-preview) and
-// `dontAsk` (legacy alias for `default`). We don't surface them in the UI;
-// see `PermissionMode` in `src/stores/store.ts` for the rationale.
-export type CliPermissionMode = 'default' | 'acceptEdits' | 'plan' | 'bypassPermissions';
+// `auto` is the classifier-driven research-preview mode (gated on Sonnet 4.6+
+// / account flag). The renderer now exposes it in the picker; the IPC layer
+// passes it through to the SDK and falls back to `default` (with a toast) if
+// the SDK rejects.
+//
+// `dontAsk` (legacy alias for `default`) is intentionally NOT surfaced — it's
+// redundant.
+export type CliPermissionMode = 'default' | 'acceptEdits' | 'plan' | 'bypassPermissions' | 'auto';

--- a/src/components/PermissionPromptBlock.tsx
+++ b/src/components/PermissionPromptBlock.tsx
@@ -281,6 +281,23 @@ export function PermissionPromptBlock({
       ? t('permissionPrompt.allowSelected', { selected: selectedCount, total: hunkCount })
       : t('permissionPrompt.allowBtn');
 
+  // Per-tool title — mirrors the upstream CLI's wording so users get a
+  // concrete question instead of a generic "Permission required". Falls
+  // back to the legacy generic title for tools we haven't enumerated yet
+  // (anything outside the small set below: Bash / WebFetch / WebSearch /
+  // Edit-family / Skill).
+  const titleByTool = (() => {
+    const name = (toolName ?? '').toLowerCase();
+    if (name === 'bash') return t('permissionPrompt.titleByTool.bash');
+    if (name === 'webfetch') return t('permissionPrompt.titleByTool.webFetch');
+    if (name === 'websearch') return t('permissionPrompt.titleByTool.webSearch');
+    if (name === 'edit' || name === 'write' || name === 'multiedit' || name === 'notebookedit') {
+      return t('permissionPrompt.titleByTool.edit');
+    }
+    if (name === 'skill') return t('permissionPrompt.titleByTool.skill');
+    return t('permissionPrompt.titleByTool.fallback');
+  })();
+
   return (
     <motion.div
       ref={rootRef}
@@ -302,8 +319,8 @@ export function PermissionPromptBlock({
         className="flex items-baseline gap-2"
       >
         <ShieldAlert size={12} className="text-accent self-center shrink-0" aria-hidden />
-        <span className="font-mono uppercase tracking-wider text-mono-xs text-accent">
-          {t('permissionPrompt.title')}
+        <span className="font-mono tracking-wider text-mono-xs text-accent">
+          {titleByTool}
         </span>
         {toolName && (
           <span className="font-mono text-mono-xs text-fg-tertiary">

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -14,14 +14,13 @@ import { useTranslation } from '../i18n/useTranslation';
 import { CwdPopover } from './CwdPopover';
 
 // Permission mode values match claude.exe's `--permission-mode` flag 1:1.
-// We intentionally use the official CLI names (title-cased for display)
-// rather than invented shortnames like `yolo` / `standard`. The CLI also
-// accepts `auto` (classifier-driven, research-preview, requires account
-// enablement) and `dontAsk` (legacy alias for `default`). We omit `auto`
-// from the chip to keep the picker simple and avoid exposing a mode most
-// users can't enable; we omit `dontAsk` because it's redundant with
+// We use the official CLI names (title-cased for display) rather than
+// invented shortnames like `yolo` / `standard`. `auto` is the
+// classifier-driven research-preview mode; we expose it in the picker and
+// fall back to `default` (with a toast) if the SDK rejects it for the
+// current account/model. `dontAsk` is omitted as a legacy alias of
 // `default`.
-type PermissionMode = 'plan' | 'default' | 'acceptEdits' | 'bypassPermissions';
+type PermissionMode = 'plan' | 'default' | 'acceptEdits' | 'bypassPermissions' | 'auto';
 
 const Chip = React.forwardRef<
   HTMLButtonElement,
@@ -311,6 +310,7 @@ export function StatusBar({
     { kind: 'item', value: 'plan', primary: t('statusBar.modePlanLabel'), secondary: t('statusBar.modePlanDesc') },
     { kind: 'item', value: 'default', primary: t('statusBar.modeDefaultLabel'), secondary: t('statusBar.modeDefaultDesc') },
     { kind: 'item', value: 'acceptEdits', primary: t('statusBar.modeAcceptEditsLabel'), secondary: t('statusBar.modeAcceptEditsDesc') },
+    { kind: 'item', value: 'auto', primary: t('statusBar.modeAutoLabel'), secondary: t('statusBar.modeAutoDesc') },
     { kind: 'item', value: 'bypassPermissions', primary: t('statusBar.modeBypassLabel'), secondary: t('statusBar.modeBypassDesc') }
   ];
 
@@ -318,6 +318,7 @@ export function StatusBar({
     plan: t('statusBar.modePlanTooltip'),
     default: t('statusBar.modeDefaultTooltip'),
     acceptEdits: t('statusBar.modeAcceptEditsTooltip'),
+    auto: t('statusBar.modeAutoTooltip'),
     bypassPermissions: t('statusBar.modeBypassTooltip')
   };
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -342,20 +342,31 @@ const en = {
     promptTitle: 'Permission requested',
     allow: 'Allow',
     deny: 'Deny',
-    // Display labels for the four official permission modes. The underlying
-    // VALUES (default / acceptEdits / plan / bypassPermissions) are CLI argv
-    // and remain in English everywhere — only these human-readable labels
-    // are localized.
+    // Display labels for the official permission modes. The underlying
+    // VALUES (default / acceptEdits / plan / bypassPermissions / auto) are
+    // CLI argv and remain in English everywhere — only these human-readable
+    // labels are localized.
     modeLabel: 'Permission mode',
     modes: {
       default: 'default',
       acceptEdits: 'accept edits',
       plan: 'plan',
-      bypassPermissions: 'bypass'
-    }
+      bypassPermissions: 'bypass',
+      auto: 'auto'
+    },
+    autoUnsupportedTitle: 'Auto mode unavailable',
+    autoUnsupportedBody: 'This account or model does not support auto mode yet. Reverted to default.'
   },
   permissionPrompt: {
     title: 'Permission required',
+    titleByTool: {
+      bash: 'Allow this bash command?',
+      webFetch: 'Allow fetching this URL?',
+      webSearch: 'Allow searching for this query?',
+      edit: 'Allow editing this file?',
+      skill: 'Allow running this skill?',
+      fallback: 'Permission required'
+    },
     allowBtn: 'Allow (Y)',
     // Scope-explicit copy. The fast-path keys off toolName only, and the
     // allowlist lives in the in-memory store — so the truth is "all uses of
@@ -529,14 +540,17 @@ const en = {
     modeDefaultLabel: 'Default',
     modeAcceptEditsLabel: 'Accept Edits',
     modeBypassLabel: 'Bypass Permissions',
+    modeAutoLabel: 'Auto',
     modePlanDesc: 'Read-only analysis. No edits, no shell.',
     modeDefaultDesc: 'Auto-approve reads. Ask before edits and shell.',
     modeAcceptEditsDesc: 'Auto-approve reads and edits. Ask before shell.',
     modeBypassDesc: 'Auto-approve everything. Use with care.',
+    modeAutoDesc: 'Classifier-driven approvals. Research preview, requires Sonnet 4.6+.',
     modePlanTooltip: 'Plan mode \u2014 read-only analysis; no file edits or shell until you approve.',
     modeDefaultTooltip: 'Default \u2014 auto-approve reads; ask before edits and shell.',
     modeAcceptEditsTooltip: 'Accept Edits \u2014 auto-approve reads and file edits; ask before shell.',
     modeBypassTooltip: 'Bypass Permissions \u2014 every tool call runs without asking. Use with care.',
+    modeAutoTooltip: 'Auto \u2014 research preview, requires Sonnet 4.6+. Falls back to Default if your account or model is not eligible.',
     contextLabel: 'Context',
     // Mirrors the official VS Code Claude extension's auto-compact tooltip
     // wording so users who switch between surfaces see the same prompt.

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -325,11 +325,22 @@ const zh: EnCatalog = {
       default: '默认',
       acceptEdits: '自动接受编辑',
       plan: '规划',
-      bypassPermissions: '跳过校验'
-    }
+      bypassPermissions: '跳过校验',
+      auto: '自动'
+    },
+    autoUnsupportedTitle: '自动模式不可用',
+    autoUnsupportedBody: '当前账号或模型暂不支持自动模式，已回退到默认。'
   },
   permissionPrompt: {
     title: '需要授权',
+    titleByTool: {
+      bash: '允许执行此 bash 命令?',
+      webFetch: '允许获取此 URL?',
+      webSearch: '允许搜索此查询?',
+      edit: '允许编辑此文件?',
+      skill: '允许运行此技能?',
+      fallback: '需要授权'
+    },
     allowBtn: '允许 (Y)',
     // 显式标注作用域：只针对该工具名（不是单条命令），且仅本次会话内有效。
     allowAlwaysBtn: '本会话始终允许 {{tool}}',
@@ -501,14 +512,17 @@ const zh: EnCatalog = {
     modeDefaultLabel: '默认',
     modeAcceptEditsLabel: '接受编辑',
     modeBypassLabel: '跳过校验',
+    modeAutoLabel: '自动',
     modePlanDesc: '只读分析。不编辑文件，不执行 shell。',
     modeDefaultDesc: '自动批准读取。编辑和 shell 需先询问。',
     modeAcceptEditsDesc: '自动批准读取与编辑。shell 需先询问。',
     modeBypassDesc: '所有操作自动批准。请谨慎使用。',
+    modeAutoDesc: '由分类器决定批准。研究预览，需 Sonnet 4.6+。',
     modePlanTooltip: '规划模式 \u2014 只读分析；不编辑文件、不执行 shell，除非你批准。',
     modeDefaultTooltip: '默认 \u2014 自动批准读取；编辑和 shell 先询问。',
     modeAcceptEditsTooltip: '接受编辑 \u2014 自动批准读取与文件编辑；shell 先询问。',
     modeBypassTooltip: '跳过校验 \u2014 所有工具调用直接放行。请谨慎使用。',
+    modeAutoTooltip: '自动 — 研究预览，需 Sonnet 4.6+。当前账号或模型不支持时会回退到默认。',
     contextLabel: '上下文',
     contextTooltip: '已用 {{percent}}%（{{used}} / {{limit}} 个 token）。点击执行 /compact。',
     contextAriaLabel: '上下文窗口已使用 {{percent}}%。点击触发压缩。'

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -37,13 +37,12 @@ export interface QueuedMessage {
 
 export type ModelId = string;
 // Values match the CLI's `--permission-mode` flag 1:1 so we can pass the enum
-// value straight through to claude.exe without a translation table. The CLI
-// also accepts `auto` (classifier-driven research-preview, gated on
-// Sonnet 4.6+ / account flag) and `dontAsk` (legacy alias for `default`). We
-// intentionally do NOT expose either here: `auto` requires capabilities users
-// can't self-enable today and would collide with our old UI value of the same
-// name; `dontAsk` is legacy and redundant.
-export type PermissionMode = 'plan' | 'default' | 'acceptEdits' | 'bypassPermissions';
+// value straight through to claude.exe without a translation table. `auto` is
+// a research-preview classifier mode gated on Sonnet 4.6+ / account flag; we
+// surface it in the picker and fall back to 'default' (with a toast) if the
+// SDK rejects it for the current account/model. `dontAsk` (legacy alias for
+// `default`) stays unsurfaced — it's redundant.
+export type PermissionMode = 'plan' | 'default' | 'acceptEdits' | 'bypassPermissions' | 'auto';
 export type Theme = 'system' | 'light' | 'dark';
 /**
  * Legacy categorical font size (`sm`/`md`/`lg`) — kept for persistence back-
@@ -1370,6 +1369,33 @@ export const useStore = create<State & Actions>((set, get) => ({
     if (!api) return;
     // The enum value IS the CLI flag value — no translation needed.
     const started = Object.keys(get().startedSessions);
+    if (started.length === 0) return;
+    // For 'auto' we await the IPC so we can fall back to 'default' with a
+    // toast if the SDK rejects (account/model gating). For other modes we
+    // fire-and-forget — same behavior as before. We poll the first started
+    // session's response since `auto` capability is account/model wide.
+    if (permission === 'auto') {
+      const probe = started[0];
+      void Promise.resolve(api.agentSetPermissionMode(probe, permission)).then((res) => {
+        if (res && res.ok === false) {
+          set({ permission: 'default' });
+          // Best-effort: tell remaining sessions to revert too.
+          for (const id of started.slice(1)) void api.agentSetPermissionMode(id, 'default');
+          const toast = (window as unknown as {
+            __ccsmToast?: { push: (t: { kind: 'error'; title: string; body?: string }) => string };
+          }).__ccsmToast;
+          toast?.push({
+            kind: 'error',
+            title: i18next.t('permissions.autoUnsupportedTitle'),
+            body: i18next.t('permissions.autoUnsupportedBody'),
+          });
+          return;
+        }
+        // Apply auto to remaining started sessions if the probe accepted.
+        for (const id of started.slice(1)) void api.agentSetPermissionMode(id, permission);
+      });
+      return;
+    }
     for (const id of started) void api.agentSetPermissionMode(id, permission);
   },
   setSidebarCollapsed: (collapsed) => set({ sidebarCollapsed: collapsed }),

--- a/tests/permission-mode-values.test.ts
+++ b/tests/permission-mode-values.test.ts
@@ -9,7 +9,7 @@ import { describe, it, expect } from 'vitest';
 import en from '../src/i18n/locales/en';
 import zh from '../src/i18n/locales/zh';
 
-const PERMISSION_MODE_VALUES = ['default', 'acceptEdits', 'plan', 'bypassPermissions'] as const;
+const PERMISSION_MODE_VALUES = ['default', 'acceptEdits', 'plan', 'bypassPermissions', 'auto'] as const;
 
 describe('permission mode values', () => {
   it('en catalog exposes every official mode key', () => {

--- a/tests/permission-prompt-block.test.tsx
+++ b/tests/permission-prompt-block.test.tsx
@@ -21,7 +21,7 @@ describe('<PermissionPromptBlock />', () => {
       />
     );
     await flush();
-    expect(screen.getByText(/Permission required/i)).toBeInTheDocument();
+    expect(screen.getByText(/Allow this bash command\?/i)).toBeInTheDocument();
     expect(screen.getByText('Bash')).toBeInTheDocument();
     // The summary dl shows the command directly — no expand step.
     expect(screen.getByText('command')).toBeInTheDocument();
@@ -506,6 +506,58 @@ describe('<PermissionPromptBlock />', () => {
       await flush();
       expect(document.querySelectorAll('[data-perm-hunk-checkbox]').length).toBe(1);
       expect(screen.getByRole('button', { name: /Allow selected \(1\/1\)/ })).toBeInTheDocument();
+    });
+  });
+
+  // ---------- per-tool title ----------
+  describe('per-tool title (titleByTool)', () => {
+    const cases: Array<[string, RegExp]> = [
+      ['Bash', /Allow this bash command\?/i],
+      ['WebFetch', /Allow fetching this URL\?/i],
+      ['WebSearch', /Allow searching for this query\?/i],
+      ['Edit', /Allow editing this file\?/i],
+      ['Write', /Allow editing this file\?/i],
+      ['NotebookEdit', /Allow editing this file\?/i],
+      ['Skill', /Allow running this skill\?/i],
+    ];
+    for (const [tool, expected] of cases) {
+      it(`renders the ${tool} title`, async () => {
+        render(
+          <PermissionPromptBlock
+            prompt={`${tool}: x`}
+            toolName={tool}
+            onAllow={() => {}}
+            onReject={() => {}}
+          />
+        );
+        await flush();
+        expect(screen.getByText(expected)).toBeInTheDocument();
+      });
+    }
+
+    it('falls back to the generic title for unknown tools', async () => {
+      render(
+        <PermissionPromptBlock
+          prompt="something"
+          toolName="MysterySdkTool"
+          onAllow={() => {}}
+          onReject={() => {}}
+        />
+      );
+      await flush();
+      expect(screen.getByText(/Permission required/i)).toBeInTheDocument();
+    });
+
+    it('falls back to the generic title when no toolName is provided', async () => {
+      render(
+        <PermissionPromptBlock
+          prompt="opaque"
+          onAllow={() => {}}
+          onReject={() => {}}
+        />
+      );
+      await flush();
+      expect(screen.getByText(/Permission required/i)).toBeInTheDocument();
     });
   });
 });

--- a/tests/store-permission-auto-fallback.test.ts
+++ b/tests/store-permission-auto-fallback.test.ts
@@ -1,0 +1,80 @@
+// `auto` mode is research-preview and gated on the user's account/model.
+// When the SDK rejects (`{ ok: false }`), the store must roll the picker
+// back to `default` and surface a toast — not silently leave the UI in a
+// broken state. This test pins the fallback contract.
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { useStore } from '../src/stores/store';
+
+const initial = useStore.getState();
+
+beforeEach(() => {
+  useStore.setState({ ...initial, startedSessions: {} }, true);
+  // Reset window globals between tests so a previous case can't leak the
+  // toast double or the IPC stub into the next one.
+  delete (window as unknown as { ccsm?: unknown }).ccsm;
+  delete (window as unknown as { __ccsmToast?: unknown }).__ccsmToast;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function setStartedSession(id: string) {
+  useStore.setState({ startedSessions: { [id]: true } });
+}
+
+describe('setPermission(auto) fallback', () => {
+  it('falls back to default and pushes an error toast when the SDK returns ok:false', async () => {
+    const setPermissionMode = vi.fn().mockResolvedValue({ ok: false, error: 'unsupported_mode' });
+    (window as unknown as { ccsm: { agentSetPermissionMode: typeof setPermissionMode } }).ccsm = {
+      agentSetPermissionMode: setPermissionMode,
+    } as never;
+    const push = vi.fn();
+    (window as unknown as { __ccsmToast: { push: typeof push } }).__ccsmToast = { push };
+
+    setStartedSession('s1');
+    useStore.getState().setPermission('auto');
+    // Optimistic UI: the picker flips to `auto` immediately.
+    expect(useStore.getState().permission).toBe('auto');
+    // Wait for the IPC promise to resolve and the fallback to land.
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(useStore.getState().permission).toBe('default');
+    expect(push).toHaveBeenCalledTimes(1);
+    expect(push.mock.calls[0][0].kind).toBe('error');
+  });
+
+  it('keeps auto when the SDK accepts (ok:true)', async () => {
+    const setPermissionMode = vi.fn().mockResolvedValue({ ok: true });
+    (window as unknown as { ccsm: { agentSetPermissionMode: typeof setPermissionMode } }).ccsm = {
+      agentSetPermissionMode: setPermissionMode,
+    } as never;
+    const push = vi.fn();
+    (window as unknown as { __ccsmToast: { push: typeof push } }).__ccsmToast = { push };
+
+    setStartedSession('s1');
+    useStore.getState().setPermission('auto');
+    expect(useStore.getState().permission).toBe('auto');
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(useStore.getState().permission).toBe('auto');
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it('non-auto modes use the legacy fire-and-forget path (no awaiting, no toast)', async () => {
+    const setPermissionMode = vi.fn().mockResolvedValue({ ok: false, error: 'whatever' });
+    (window as unknown as { ccsm: { agentSetPermissionMode: typeof setPermissionMode } }).ccsm = {
+      agentSetPermissionMode: setPermissionMode,
+    } as never;
+    const push = vi.fn();
+    (window as unknown as { __ccsmToast: { push: typeof push } }).__ccsmToast = { push };
+
+    setStartedSession('s1');
+    useStore.getState().setPermission('plan');
+    await new Promise((r) => setTimeout(r, 0));
+    expect(useStore.getState().permission).toBe('plan');
+    expect(push).not.toHaveBeenCalled();
+    // IPC was still invoked exactly once for the started session.
+    expect(setPermissionMode).toHaveBeenCalledWith('s1', 'plan');
+  });
+});


### PR DESCRIPTION
## Summary
- Surface 'auto' (classifier-driven research-preview) in the StatusBar permission picker; renderer falls back to `default` with an error toast if the SDK rejects (account/model gating).
- Replace the generic "Permission required" header in `PermissionPromptBlock` with upstream-style per-tool titles for Bash / WebFetch / WebSearch / Edit-family / Skill; unknown tools keep the legacy fallback. Sentence case across en + zh; dropped the `uppercase` Tailwind class so the new copy isn't SCREAMED.
- `toSdkPermissionMode` passes 'auto' through to the SDK; runner re-throws SDK rejections that look like unsupported/capability errors so `main.ts` returns `{ ok:false }` instead of swallowing as a diagnostic.

## Test plan
- [x] `npm run typecheck` clean.
- [x] Lint clean on touched files (pre-existing warnings unrelated).
- [x] `tests/store-permission-auto-fallback.test.ts` (new) — store reverts to `default` + error toast on `ok:false`; keeps `auto` on `ok:true`; non-auto modes fire-and-forget.
- [x] `tests/permission-prompt-block.test.tsx` — `titleByTool` coverage for Bash / WebFetch / WebSearch / Edit / Write / NotebookEdit / Skill + unknown + no-toolName fallback.
- [x] `tests/permission-mode-values.test.ts` — adds `auto` to the i18n key-parity contract.
- [x] `scripts/probe-e2e-permission-auto-and-titles.mjs` (new) — verifies IPC accepts `auto` and the i18n strings resolve correctly. Not executed locally (no Python for `better-sqlite3` rebuild on this machine); reviewer to run in their dev env.
- [ ] Reviewer: load app, switch picker through Auto, confirm chip + tooltip; trigger a Bash permission and confirm the new title.

## Notes for reviewer
- `db-hardening.test.ts` (3 failures locally) and the `node-gyp` postinstall error are pre-existing, caused by `--ignore-scripts` install on Windows without Python. None of those tests touch permission paths.
- The fallback path for `auto` only awaits the FIRST started session's IPC response — if it succeeds, `auto` is broadcast to the rest; if it fails, the rest are reverted to `default`. Rationale: `auto` capability is account/model wide, so one probe is enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)