### PR TITLE
build: pin clang=0 in .npmrc for Node 22+ better-sqlite3 build

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,6 @@
+# Node 22+ defaults process.config.variables.clang=1 on Windows, which
+# @electron/node-gyp's common.gypi translates to msbuild_toolset=ClangCL.
+# ClangCL is not installed in standard VS 2022 BuildTools, so better-sqlite3's
+# native build fails with MSB8020 on fresh checkouts. Pin to 0 to use the
+# default MSVC toolset.
+clang=0


### PR DESCRIPTION
## Why

Node 22+ on Windows defaults `process.config.variables.clang=1`, which @electron/node-gyp's `common.gypi` translates to `msbuild_toolset=ClangCL`. ClangCL is not installed in standard VS 2022 BuildTools, so `better-sqlite3`'s native build fails with `MSB8020: ClangCL toolset not found` on every fresh checkout.

Yesterday's dogfood worker confirmed `npm_config_clang=0` makes install succeed cleanly; pinning it in `.npmrc` makes that fix automatic so new contributors don't have to diagnose the MSB8020 error.