### PR TITLE
test(e2e): use stable [data-cwd-chip] selector in input-queue probe

### DIFF
--- a/scripts/probe-e2e-input-queue.mjs
+++ b/scripts/probe-e2e-input-queue.mjs
@@ -62,7 +62,7 @@ const textarea = win.locator('textarea');
 await textarea.waitFor({ state: 'visible', timeout: 5000 }).catch(() => fail('textarea did not appear'));
 
 // Pick a cwd so agent:start has a valid working dir.
-const cwdChip = win.locator('[title="~"]').first();
+const cwdChip = win.locator('[data-cwd-chip]').first();
 await cwdChip.waitFor({ state: 'visible', timeout: 5000 }).catch(() => fail('cwd chip not found'));
 await cwdChip.click();
 const browseItem = win.getByText('Browse folder…').first();


### PR DESCRIPTION
## Summary
- `scripts/probe-e2e-input-queue.mjs` failed with \"cwd chip not found\" because PR #270 (per-group default cwd) populates new sessions with a real path instead of `~`, so `[title=\"~\"]` no longer matches.
- Switch to the stable `[data-cwd-chip]` hook already exposed at `src/components/CwdPopover.tsx:222`.

## Test plan
- [x] Forward verify: `node scripts/probe-e2e-input-queue.mjs` -> OK
- [x] Reverse verify: revert to `[title=\"~\"]` -> fails with \"cwd chip not found\"; restore -> OK