### PR TITLE
test(e2e): replace pid-polling with activeSessionCount in liveness probes

### DIFF
--- a/scripts/probe-e2e-close-window-aborts-sessions.mjs
+++ b/scripts/probe-e2e-close-window-aborts-sessions.mjs
@@ -1,20 +1,29 @@
 // Regression probe for Worker D finding #3 (subprocess lifecycle):
 // closing the app window (the real-quit path, not minimize-to-tray) must
-// tear down every live claude.exe child before the Electron process exits.
+// tear down every live agent session before the Electron process exits.
 // Before the fix, `app.before-quit` only flipped `isQuitting=true`; cleanup
 // happened inside `window-all-closed`, which could miss the tray→Quit path
 // (windows hidden, not closed). The fix pulls `sessions.closeAll()` forward
 // into `before-quit` as a belt-and-suspenders guarantee.
 //
+// Liveness signal:
+//   The legacy probe polled the OS pid via `process.kill(pid, 0)`. After
+//   PR #271/#273 the agent runs through the SDK transport and the main
+//   process no longer holds a child pid (`getPid()` returns undefined by
+//   design). Instead we use `sessions.activeSessionCount()` exposed via the
+//   `globalThis.__ccsmDebug` backdoor in main.ts as the liveness signal:
+//   before triggering shutdown the count must be > 0; after the
+//   `before-quit` handler runs it must be 0.
+//
 // Strategy:
 //   - Launch Electron with an isolated userData dir.
-//   - Spawn a real claude.exe via agentStart; capture pid through the
-//     `globalThis.__ccsmDebug` backdoor.
-//   - Set `isQuitting=true` equivalent by calling `app.quit()` on the main
-//     process — this bypasses the minimize-to-tray window.close hook and
-//     drives the real shutdown path.
-//   - After `app.close()` resolves, the probe's own node runtime polls
-//     `process.kill(pid, 0)` until the child is gone or we time out.
+//   - Spawn a real agent session via agentStart; assert active count > 0
+//     through the debug backdoor.
+//   - Drive the real-quit cleanup path by emitting `before-quit` on the
+//     main-process app object (the same hook that fires on tray→Quit /
+//     Cmd-Q). We don't call `app.quit()` because that would tear down the
+//     Electron process and leave the probe with no surface to assert on.
+//   - Poll `activeSessionCount()` until it goes to 0 or we time out.
 //
 // Falls back to SKIP if claude isn't resolvable on this host (same policy as
 // the companion delete-session probe).
@@ -37,16 +46,6 @@ function fail(msg, app) {
 function skip(msg) {
   console.log(`\n[probe-e2e-close-window-aborts-sessions] SKIP: ${msg}`);
   process.exit(0);
-}
-
-function isPidAlive(pid) {
-  if (!pid || pid <= 0) return false;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agentory-probe-close-'));
@@ -108,63 +107,62 @@ try {
     fail(`agentStart failed: ${JSON.stringify(startRes)}`, app);
   }
 
-  // Wait for a real pid to appear in the main-process map.
-  let pid = null;
+  // Confirm the runner registered in the main-process map. agentStart only
+  // resolves ok:true after start() pushes the runner into `sessions.runners`,
+  // but a tiny micro-task tail can still leave the count at 0 for a tick.
+  let countBefore = 0;
   for (let i = 0; i < 30; i++) {
-    const pids = await app.evaluate(() => {
+    countBefore = await app.evaluate(() => {
       const dbg = globalThis.__ccsmDebug;
-      return dbg ? dbg.activeSessionPids() : null;
+      return dbg ? dbg.activeSessionCount() : -1;
     });
-    if (!pids) fail('globalThis.__ccsmDebug missing in main process', app);
-    const row = pids.find((r) => r.sessionId === sessionId);
-    if (row && typeof row.pid === 'number') {
-      pid = row.pid;
-      break;
-    }
+    if (countBefore === -1) fail('globalThis.__ccsmDebug missing in main process', app);
+    if (countBefore > 0) break;
     await new Promise((r) => setTimeout(r, 100));
   }
-  if (!pid) fail('never observed a pid for the spawned session', app);
-  console.log(`[probe-e2e-close-window-aborts-sessions] live pid = ${pid}`);
-  if (!isPidAlive(pid)) {
-    fail(`reported pid ${pid} was already dead before quit — spawner smoke failed`, app);
+  if (countBefore <= 0) {
+    fail(`activeSessionCount=${countBefore} after agentStart; expected > 0`, app);
   }
+  console.log(
+    `[probe-e2e-close-window-aborts-sessions] activeSessionCount before quit = ${countBefore}`
+  );
 
-  // Drive the real-quit path. app.quit() emits `before-quit` → our hook
-  // fires `sessions.closeAll()`, then window-all-closed + closeDb + actual
-  // process exit. This mirrors the tray menu's Quit item, not a plain
-  // window close (which minimize-to-tray would intercept).
+  // Drive the real-quit cleanup path. Emitting `before-quit` synchronously
+  // runs the same handler the tray menu's Quit item triggers:
+  //   isQuitting = true; sessions.closeAll();
+  // We deliberately do NOT call app.quit() here — that would tear down the
+  // Electron process and leave us with no surface to verify against. The
+  // cleanup itself is what we're testing; the actual exit is exercised by
+  // every other e2e probe that calls `app.close()`.
   await app.evaluate(({ app: a }) => {
-    a.quit();
+    a.emit('before-quit', { preventDefault() {}, defaultPrevented: false });
   });
 
-  // Let playwright's wrapper observe the electron process exit.
-  await app.close().catch(() => {});
-
-  // Poll from the probe's own runtime — claude.exe is a grandchild of this
-  // process, so it outlives app.close() only if the parent leaked it. Give
-  // the kernel up to 8s to reap on Windows (WMI reaping can be slow).
-  const deadline = Date.now() + 8_000;
-  let dead = false;
+  // Poll for activeSessionCount to drop to 0. closeAll() is synchronous in
+  // the manager (it calls runner.close() and clears the map), so this
+  // usually lands on the first read; allow up to 5s for the SDK transport's
+  // own teardown to settle the runner-side abort.
+  const deadline = Date.now() + 5_000;
+  let countAfter = countBefore;
   while (Date.now() < deadline) {
-    if (!isPidAlive(pid)) {
-      dead = true;
-      break;
-    }
-    await new Promise((r) => setTimeout(r, 200));
+    countAfter = await app.evaluate(() => {
+      const dbg = globalThis.__ccsmDebug;
+      return dbg ? dbg.activeSessionCount() : -1;
+    });
+    if (countAfter === 0) break;
+    await new Promise((r) => setTimeout(r, 100));
   }
-  if (!dead) {
-    // Best-effort cleanup before failing so we don't leave a token-burning
-    // zombie behind after a regression.
-    try {
-      process.kill(pid, 'SIGKILL');
-    } catch {
-      /* ignore */
-    }
-    fail(`pid ${pid} still alive 8s after app.quit() — orphan claude.exe regression`);
+  if (countAfter !== 0) {
+    fail(
+      `activeSessionCount=${countAfter} 5s after before-quit; expected 0 — closeAll regression`,
+      app
+    );
   }
 
   console.log('\n[probe-e2e-close-window-aborts-sessions] OK');
-  console.log(`  spawned claude pid=${pid} died within 8s of app.quit()`);
+  console.log(`  activeSessionCount went ${countBefore} -> 0 within 5s of before-quit`);
+
+  await app.close();
 } catch (err) {
   console.error('[probe-e2e-close-window-aborts-sessions] threw:', err);
   await app.close().catch(() => {});

--- a/scripts/probe-e2e-delete-session-kills-process.mjs
+++ b/scripts/probe-e2e-delete-session-kills-process.mjs
@@ -1,21 +1,26 @@
 // Regression probe for Worker D finding #1 (subprocess lifecycle):
-// deleting a session while its claude.exe child is live must kill the child.
+// deleting a session while its agent is live must tear down the runner.
 // Before the fix, `deleteSession()` in the store cleared renderer state but
 // never dispatched `agent:close`, so the spawned process kept running (and
 // burning tokens) as a zombie until the app quit.
+//
+// Liveness signal:
+//   The legacy probe polled the OS pid via `process.kill(pid, 0)`. After
+//   PR #271/#273 the agent runs through the SDK transport and the main
+//   process no longer holds a child pid (`getPid()` returns undefined by
+//   design). Instead we use `sessions.activeSessionCount()` exposed via the
+//   `globalThis.__ccsmDebug` backdoor in main.ts as the liveness signal:
+//   before delete the count must be > 0; after delete it must drop to 0.
 //
 // Strategy:
 //   - Launch Electron with an isolated userData dir + a real CLI present on
 //     the machine (resolved through CCSM_CLAUDE_BIN / PATH by main).
 //   - Seed a session and trigger agentStart through the live IPC bridge.
-//     claude.exe sits at the stdio prompt waiting for a `user` frame — it
-//     doesn't need a real prompt or network to exist as a process.
-//   - Snapshot the pid via the dev-only `globalThis.__ccsmDebug` backdoor
-//     installed in electron/main.ts (guarded by !app.isPackaged).
-//   - Call the store's deleteSession action and then poll
-//     `process.kill(pid, 0)` from the probe's node runtime — on Windows this
-//     uses OpenProcess under the hood, and throws ESRCH once the child is
-//     gone. If it still responds after 3 seconds we fail.
+//     The SDK runner sits at the stdio prompt waiting for a `user` frame —
+//     it doesn't need a real prompt or network to exist.
+//   - Assert `activeSessionCount() > 0` via the debug backdoor.
+//   - Call the store's deleteSession action and poll the backdoor until
+//     the count drops to 0 (or we time out).
 //
 // If claude.exe is not installed/resolvable in this environment we exit 0
 // with a SKIP banner — running this probe in CI without the binary should
@@ -39,18 +44,6 @@ function fail(msg, app) {
 function skip(msg) {
   console.log(`\n[probe-e2e-delete-session-kills-process] SKIP: ${msg}`);
   process.exit(0);
-}
-
-function isPidAlive(pid) {
-  if (!pid || pid <= 0) return false;
-  try {
-    // Signal 0 is a liveness check on POSIX; on Windows Node maps it to
-    // OpenProcess + check status. Throws on dead / missing process.
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agentory-probe-delete-'));
@@ -126,64 +119,55 @@ try {
     st.setRunning(sid, true);
   }, sessionId);
 
-  // Grab the child pid via the main-process debug backdoor. Poll briefly
-  // because claude.exe's spawn-through-cmd-shim path on Windows has a tiny
-  // lag between agentStart resolving and the pid becoming readable.
-  let pid = null;
+  // Confirm the runner registered in the main-process map. agentStart only
+  // resolves ok:true after start() pushes the runner into the map, but a
+  // tiny micro-task tail can still leave the count at 0 for a tick.
+  let countBefore = 0;
   for (let i = 0; i < 30; i++) {
-    const pids = await app.evaluate(() => {
+    countBefore = await app.evaluate(() => {
       const dbg = globalThis.__ccsmDebug;
-      return dbg ? dbg.activeSessionPids() : null;
+      return dbg ? dbg.activeSessionCount() : -1;
     });
-    if (!pids) fail('globalThis.__ccsmDebug missing in main process', app);
-    const row = pids.find((r) => r.sessionId === sessionId);
-    if (row && typeof row.pid === 'number') {
-      pid = row.pid;
-      break;
-    }
+    if (countBefore === -1) fail('globalThis.__ccsmDebug missing in main process', app);
+    if (countBefore > 0) break;
     await new Promise((r) => setTimeout(r, 100));
   }
-  if (!pid) fail('never observed a pid for the spawned session', app);
-  console.log(`[probe-e2e-delete-session-kills-process] live pid = ${pid}`);
-
-  if (!isPidAlive(pid)) {
-    fail(`reported pid ${pid} was already dead before delete — spawner smoke failed`, app);
+  if (countBefore <= 0) {
+    fail(`activeSessionCount=${countBefore} after agentStart; expected > 0`, app);
   }
+  console.log(
+    `[probe-e2e-delete-session-kills-process] activeSessionCount before delete = ${countBefore}`
+  );
 
   // Trigger the store's deleteSession — the path under test. This should
-  // dispatch window.ccsm.agentClose(sid) as a side effect.
+  // dispatch window.ccsm.agentClose(sid) as a side effect, which calls
+  // sessions.close(sid) in the manager and removes the runner from the map.
   await win.evaluate((sid) => {
     window.__ccsmStore.getState().deleteSession(sid);
   }, sessionId);
 
-  // Poll for the pid to go away. The spawner escalates SIGTERM → SIGKILL
-  // after killGracePeriodMs (default 5s), but a soft interrupt usually lands
-  // within a second.
-  const deadline = Date.now() + 8_000;
-  let dead = false;
+  // Poll for activeSessionCount to drop to 0. The IPC round-trip + SDK
+  // transport teardown usually lands within a few hundred ms; 5s is a
+  // generous ceiling.
+  const deadline = Date.now() + 5_000;
+  let countAfter = countBefore;
   while (Date.now() < deadline) {
-    if (!isPidAlive(pid)) {
-      dead = true;
-      break;
-    }
-    await new Promise((r) => setTimeout(r, 150));
+    countAfter = await app.evaluate(() => {
+      const dbg = globalThis.__ccsmDebug;
+      return dbg ? dbg.activeSessionCount() : -1;
+    });
+    if (countAfter === 0) break;
+    await new Promise((r) => setTimeout(r, 100));
   }
-  if (!dead) {
-    fail(`pid ${pid} still alive 8s after deleteSession — zombie regression`, app);
-  }
-
-  // Double-check the main-process map also forgot the runner.
-  const remaining = await app.evaluate(() => {
-    const dbg = globalThis.__ccsmDebug;
-    return dbg ? dbg.activeSessionCount() : -1;
-  });
-  if (remaining !== 0) {
-    fail(`activeSessionCount=${remaining} after deleteSession; expected 0`, app);
+  if (countAfter !== 0) {
+    fail(
+      `activeSessionCount=${countAfter} 5s after deleteSession; expected 0 — zombie regression`,
+      app
+    );
   }
 
   console.log('\n[probe-e2e-delete-session-kills-process] OK');
-  console.log(`  spawned claude pid=${pid} killed within 8s of deleteSession`);
-  console.log('  activeSessionCount went to 0');
+  console.log(`  activeSessionCount went ${countBefore} -> 0 within 5s of deleteSession`);
 
   await app.close();
 } catch (err) {


### PR DESCRIPTION
## Summary
- The `close-window-aborts-sessions` and `delete-session-kills-process` probes failed with "never observed a pid" because `SdkSessionRunner.getPid()` returns `undefined` — after PR #271/#273 the SDK transport owns the child process and the main side intentionally has no pid.
- Both probes now use `sessions.activeSessionCount()` (already exposed via `globalThis.__ccsmDebug` in `electron/main.ts`) as the liveness signal: assert > 0 before the action, poll for == 0 after.
- Close-window probe drives cleanup by emitting `before-quit` directly on the main-process `app` (instead of `app.quit()`) so the probe still has a surface to query after the handler runs. The actual exit path is already exercised by every other probe via `app.close()`.
- No changes to production code. No new IPC. No widening of preload.ts. The `__ccsmDebug` backdoor already exposed `activeSessionCount`, so the probe rewrites are file-local.

## Reverse-verify evidence
- Close-window probe: stashed `sessions.closeAll()` inside `before-quit` in `electron/main.ts` → probe FAIL: `activeSessionCount=1 5s after before-quit; expected 0 — closeAll regression`. Restored → probe PASS.
- Delete-session probe: stashed `return sessions.close(sessionId)` inside the `agent:close` IPC handler in `electron/main.ts` → probe FAIL: `activeSessionCount=1 5s after deleteSession; expected 0 — zombie regression`. Restored → probe PASS.

## Test plan
- [x] `node scripts/probe-e2e-delete-session-kills-process.mjs` → OK (`activeSessionCount went 1 -> 0 within 5s of deleteSession`)
- [x] `node scripts/probe-e2e-close-window-aborts-sessions.mjs` → OK (`activeSessionCount went 1 -> 0 within 5s of before-quit`)
- [x] Reverse-verify both probes (see evidence above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)