### PR TITLE
test(e2e): use getByRole('tab') for SettingsDialog tabs

### DIFF
--- a/scripts/probe-e2e-i18n-settings-zh.mjs
+++ b/scripts/probe-e2e-i18n-settings-zh.mjs
@@ -69,7 +69,7 @@ try {
 
   // Helper: switch to a tab by its (now Chinese) label.
   async function switchTab(name) {
-    const tab = dialog.getByRole('button', { name });
+    const tab = dialog.getByRole('tab', { name });
     await tab.waitFor({ state: 'visible', timeout: 2000 });
     await tab.click();
     await win.waitForTimeout(150);

--- a/scripts/probe-e2e-settings-open.mjs
+++ b/scripts/probe-e2e-settings-open.mjs
@@ -59,7 +59,7 @@ try {
     });
     // Confirm it's the Settings dialog by checking for the tab nav. We use
     // the i18n-stable 'Connection' tab name (English locale boots first).
-    const conn = dialog.getByRole('button', { name: /^connection$/i });
+    const conn = dialog.getByRole('tab', { name: /^connection$/i });
     await conn.waitFor({ state: 'visible', timeout: 1500 }).catch(() => {
       fail(`${label}: Settings tabs not visible — wrong dialog opened?`);
     });


### PR DESCRIPTION
## Summary
SettingsDialog tabs render as `<button role="tab">` (per ARIA). Playwright's `getByRole('button', ...)` does not match elements whose explicit `role` overrides their implicit role, so both probes were finding zero tab elements. Swap the tab-targeting selectors only — Save/Cancel/sidebar/new-session button selectors untouched.

## Reverse-verify
- `git stash` (revert fix) → `probe-e2e-settings-open` fails at step 1: `"sidebar button: Settings tabs not visible — wrong dialog opened?"` (the original bug).
- `git stash pop` (re-apply fix) → step 1 passes.
- `probe-e2e-i18n-settings-zh` is fully green end-to-end (Appearance / Notifications / Updates / Connection panes all switch correctly).

## Partial — separate follow-up
`probe-e2e-settings-open` step 2 (the `/config` slash command entry point) still fails reproducibly with `"/config: dialog never became visible"`. This is a different bug — the `dialog.waitFor({state:'visible'})` on line 57 times out BEFORE my tab assertion ever runs, so it is independent of the tab selector. Manager will dispatch a separate worker. Tab-selector fix lands on its own merits since it is correct and unblocks the i18n probe entirely.

## Test plan
- [x] `node scripts/probe-e2e-i18n-settings-zh.mjs` passes
- [x] Reverse-verify confirms pre-fix failure was the tab-selector bug
- [ ] `node scripts/probe-e2e-settings-open.mjs` step 2 (`/config`) — separately tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)