### PR TITLE
test(e2e): drop python dependency in permission-allow-bash probe

### DIFF
--- a/scripts/probe-e2e-permission-allow-bash.mjs
+++ b/scripts/probe-e2e-permission-allow-bash.mjs
@@ -23,10 +23,13 @@ fs.mkdirSync(UDD, { recursive: true });
 fs.mkdirSync(PROJ, { recursive: true });
 
 // Use a bash command unlikely to be in any default allowlist so the host
-// permission prompt definitely fires. `python --version` is harmless but
-// prompts unless `Bash(python:*)` is explicitly allowed in user settings.
+// permission prompt definitely fires. `node --version` is harmless and
+// universally available (this IS a Node project — node is required to
+// build/run ccsm), while `Bash(node:*)` is NOT in the upstream CLI's
+// default-allow list, so the permission prompt still fires. Avoids the
+// silent system-Python dependency the previous fixture had.
 const PROMPT =
-  "Run the bash command `python --version` (or `python3 --version` if python is not found) and tell me the version number.";
+  'Run the bash command `node --version` and tell me the version number.';
 
 function log(m) {
   process.stderr.write(`[probe-bugl-bash ${new Date().toISOString()}] ${m}\n`);


### PR DESCRIPTION
## Why

`scripts/probe-e2e-permission-allow-bash.mjs` was prompting the agent to run `python --version`, which silently made the e2e suite depend on system Python being installed. Swap the fixture to `node --version` — Node is guaranteed present (the repo IS a Node project) and `Bash(node:*)` is still not in the upstream default-allow list, so the permission prompt the probe exists to exercise still fires.

## Upstream verification

Probed `claude --print --output-format json` from a fresh dir with no prior allow:
- `python --version` → ran, `permission_denials: []` (— `--print` mode bypasses interactive callbacks, so this only confirms the CLI doesn't reject; it does NOT confirm the host SDK callback fires).
- `node --version` → same (`v24.14.1`, no denial).
- `whoami` → same (no denial).

The `--print` flow is not the surface this probe tests. The probe drives the Electron host's `canUseTool` callback via the SDK; in CI's clean environment, neither `python` nor `node` are in the default-allow list, so both trigger the host's permission prompt. By symmetry the swap preserves probe semantics.

## Reverse verification (local — incomplete, see caveat)

Ran the probe locally against the new `node --version` fixture in an isolated worktree. Probe FAILED to observe an Allow button — but ALSO fails to observe one with the original `python --version` fixture on this same machine (verified). Root cause: this dev box's `~/.claude/settings.json` has `Bash(*)` in the allow list, so EVERY bash command is auto-allowed before the host callback ever runs, regardless of fixture. This is a pre-existing local-env limitation, not a regression introduced by this PR.

In CI (clean HOME, no user-level allowlist) the probe should fire the prompt for `node --version` exactly as it did for `python --version`.

## Caveat / follow-up

Separate observation worth flagging: the probe doesn't sandbox HOME / USERPROFILE / CLAUDE_HOME like several other probes do (per `project_probe_skill_injection.md`). That's why developer-machine `Bash(*)` allowlists leak in. Not in scope for this 1-line fixture swap, but worth a follow-up to make the probe robust to dev `~/.claude/settings.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)