### PR TITLE
test(e2e): switch send/switch/default-cwd probes to data-type-scale-role

### DIFF
--- a/scripts/probe-e2e-default-cwd.mjs
+++ b/scripts/probe-e2e-default-cwd.mjs
@@ -49,7 +49,9 @@ await textarea.click();
 await textarea.fill('hi');
 await win.keyboard.press('Enter');
 
-const assistant = win.locator('div.flex.gap-3.text-base').filter({
+// Use the stable `data-type-scale-role` data-attr (assistant-body) — class-
+// based selectors break on every Tailwind/type-token refactor.
+const assistant = win.locator('[data-type-scale-role="assistant-body"]').filter({
   has: win.locator('span:has-text("●")')
 });
 

--- a/scripts/probe-e2e-send.mjs
+++ b/scripts/probe-e2e-send.mjs
@@ -90,7 +90,10 @@ await win.waitForTimeout(400);
 // at least one *new* assistant block are visible. We keep a running count of
 // assistant blocks so subsequent phases don't false-positive on phase 1's
 // reply still being on screen.
-const assistantSelector = 'div.flex.gap-3.text-base';
+// Use the stable `data-type-scale-role` data-attr exposed by AssistantBlock.tsx.
+// Class-based selectors (e.g. `div.flex.gap-3.text-base`) break on every
+// type-token / Tailwind refactor — the data-attr is the contract.
+const assistantSelector = '[data-type-scale-role="assistant-body"]';
 async function countAssistantBlocks() {
   return await win.evaluate((sel) => {
     return document.querySelectorAll(sel).length;

--- a/scripts/probe-e2e-switch.mjs
+++ b/scripts/probe-e2e-switch.mjs
@@ -77,7 +77,9 @@ async function sendPrompt(text) {
   await textarea.fill(text);
   await win.keyboard.press('Enter');
   // Wait for SOME assistant block to render visible body text.
-  const assistant = win.locator('div.flex.gap-3.text-base').filter({
+  // Use the stable `data-type-scale-role` data-attr (assistant-body) — class-
+  // based selectors break on every Tailwind/type-token refactor.
+  const assistant = win.locator('[data-type-scale-role="assistant-body"]').filter({
     has: win.locator('span:has-text("●")')
   });
   await assistant.first().waitFor({ state: 'visible', timeout: 30_000 });
@@ -126,6 +128,11 @@ if (draftBefore !== DRAFT_A) {
 // === Session B (this also forces sidebar to have ≥2 sessions to click
 //     between, AND triggers another temp→real id swap once B starts) ===
 await clickNewSession();
+// ChatStream wraps content in AnimatePresence(mode="wait") — old session's
+// blocks animate OUT before new session's empty state animates IN. The
+// transition is ~180ms. Wait past it so the assertion sees a quiesced DOM
+// instead of a mid-flight exit.
+await win.waitForTimeout(500);
 // session B is now active; A's chat should be off-screen
 const aGoneFromMain = !(await win.getByText(PROMPT_A).first().isVisible().catch(() => false));
 if (!aGoneFromMain) {
@@ -163,7 +170,7 @@ if (!snapshotA_after.includes(PROMPT_A)) {
 }
 // Also check assistant body still rendered (not just user echo).
 const assistantStillThere = await win
-  .locator('div.flex.gap-3.text-base')
+  .locator('[data-type-scale-role="assistant-body"]')
   .filter({ has: win.locator('span:has-text("●")') })
   .first()
   .isVisible()


### PR DESCRIPTION
## Root cause

NOT a renderer crash, NOT PR #282. The 'Target crashed' diagnosis was a
red herring — current run shows clean failure with assistant text visible
in `<main>`.

PR #205 (`feat/type-scale-225`, merged 2026-04-24) renamed `text-base` to
`text-body` in `AssistantBlock.tsx` and `UserBlock.tsx`. Three probes
hard-coded the Tailwind class chain `div.flex.gap-3.text-base` and have
been silently failing since:

- `probe-e2e-send.mjs`     — assistant baseline counter never advances
- `probe-e2e-switch.mjs`   — same selector + `aGoneFromMain` race
- `probe-e2e-default-cwd.mjs` — same selector

The other 7 in the manager's list were misattributed:
- `probe-e2e-env-passthrough.mjs` — actually PASSES on HEAD
- `probe-e2e-permission-allow-bash.mjs` — owned by another worker (python→node swap)
- `probe-e2e-connection-pane.mjs`, `harness-*` — already fixed by #294 / no longer exist
- `permission-allow-write/parallel-batch/prompt-default-mode` — separate model-behavior / Bash-allowlist issue, NOT this PR

## Fix shape

Switch to the stable `[data-type-scale-role="assistant-body"]` data-attr
the type-scale migration left specifically for this purpose. Also widen
`probe-e2e-switch.mjs`'s post-clickNewSession wait past ChatStream's
180ms `AnimatePresence(mode="wait")` cross-fade — the assertion was
firing mid-exit and seeing stale content.

3 files, 16 insertions / 4 deletions.

## Before / after

```
                       before    after
probe-e2e-send         FAIL      OK (3/3 phases)
probe-e2e-default-cwd  FAIL      OK
probe-e2e-switch       FAIL      OK (all 3 phases)
```

## Test plan

- [x] `node scripts/probe-e2e-send.mjs` → OK
- [x] `node scripts/probe-e2e-default-cwd.mjs` → OK
- [x] `node scripts/probe-e2e-switch.mjs` → OK (all 3 phases incl. draft / focus / scroll restoration)
- [ ] CI re-run on the rest of the suite to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)