### PR TITLE
docs: document Windows python.exe gotcha for better-sqlite3 rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,21 @@ npm run make:linux   # build AppImage / .deb / .rpm
 
 The architecture has a hard rule: **frontend code under `src/` may not import from `electron`**. The only backend entry point is `window.ccsm` (declared in `src/global.d.ts`), exposed via `electron/preload.ts`. This keeps the door open for a future remote daemon. See `docs/mvp-design.md` §15.
 
+### Windows: `gyp ERR! find Python` on `npm install`
+
+`better-sqlite3`'s native rebuild uses `node-gyp`, which on Windows often
+picks up the `WindowsApps\python.exe` Microsoft Store launcher stub instead
+of a real interpreter and fails. If you see `gyp ERR! find Python`, point
+node-gyp at a real Python 3.x in your **user-level** `~/.npmrc` (not the
+repo's `.npmrc` — the path is machine-specific):
+
+```ini
+python=C:/Users/<you>/AppData/Local/Programs/Python/Python312/python.exe
+```
+
+Any installed Python 3.8+ works. Re-run `npm install` and the rebuild
+will pick up the override automatically.
+
 ## Notifications
 
 CCSM raises desktop notifications when a background session needs your


### PR DESCRIPTION
## Summary

- Fresh Windows checkouts hit ~3 min wasted on the first `npm install` because node-gyp picks `C:/Users/<you>/AppData/Local/Microsoft/WindowsApps/python.exe` (the Microsoft Store launcher stub, not a real Python) and `better-sqlite3`'s native rebuild fails with `gyp ERR! find Python`.
- Setting `python=<absolute path to a real Python 3.x>` in user-level `~/.npmrc` makes the override automatic for every npm call, with no repo or CI pollution. Verified locally: `rm -rf node_modules/better-sqlite3/build && npx electron-rebuild --only better-sqlite3` succeeds without any `npm_config_python` env var dance.
- Repo `.npmrc` deliberately untouched (the path is per-machine and would leak to other devs / CI). Fix is documentation only — points new contributors at the user-level workaround.

## Test plan

- [x] Verified locally: rebuild succeeds without `npm_config_python` env var after writing the line into `~/.npmrc`.
- [x] `node_modules/better-sqlite3/build/Release/better_sqlite3.node` produced.
- [ ] vitest (doc-only PR; e2e probe N/A per `feedback_e2e_before_merge.md` doc-only carve-out).

Generated with Claude Code.