### PR TITLE
fix: /config slash command opens Settings dialog

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -267,6 +267,15 @@ export default function App() {
     return () => window.removeEventListener('keydown', onKey);
   }, [createGroup, focusGroup, toggleSidebar, newSession]);
 
+  // `/config` slash command opens the Settings dialog. The slash dispatcher
+  // lives in src/slash-commands/handlers.ts and can't reach App-level React
+  // state, so it fires a window CustomEvent that we listen for here.
+  useEffect(() => {
+    const onOpenSettings = () => setSettingsOpen(true);
+    window.addEventListener('ccsm:open-settings', onOpenSettings);
+    return () => window.removeEventListener('ccsm:open-settings', onOpenSettings);
+  }, []);
+
   if (!active) {
     return (
       <TooltipProvider delayDuration={400} skipDelayDuration={100}>

--- a/src/slash-commands/handlers.ts
+++ b/src/slash-commands/handlers.ts
@@ -78,6 +78,17 @@ export function blocksToTranscript(blocks: MessageBlock[]): string {
   return lines.join('\n');
 }
 
+// ---------- /config ----------
+// Open the Settings dialog. We can't import App-level React state here, so
+// we dispatch a window CustomEvent that App.tsx listens for. This mirrors
+// the upstream CLI's `/config` (which pops its inline config view) — in our
+// Electron UI the analogous surface is the Radix Settings dialog. Defaults
+// to the first tab; users can navigate from there.
+export function handleConfig(_ctx: SlashCommandContext): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent('ccsm:open-settings'));
+}
+
 // Attach the local handler as a module side-effect, same as before.
 function attach(name: string, handler: (ctx: SlashCommandContext) => void | Promise<void>): void {
   const entry = BUILT_IN_COMMANDS.find((c) => c.name === name);
@@ -85,3 +96,4 @@ function attach(name: string, handler: (ctx: SlashCommandContext) => void | Prom
 }
 
 attach('clear', handleClear);
+attach('config', handleConfig);

--- a/src/slash-commands/registry.ts
+++ b/src/slash-commands/registry.ts
@@ -18,7 +18,7 @@
 // raw `/foo` line, which is intentional: forward-compat with new commands
 // the CLI ships before we sync.
 
-import { Eraser, Minimize2, type LucideIcon } from 'lucide-react';
+import { Eraser, Minimize2, Settings, type LucideIcon } from 'lucide-react';
 import Fuse from 'fuse.js';
 
 // Six logical sources surfaced by the slash-command palette. Mirrors the
@@ -73,6 +73,13 @@ export const BUILT_IN_COMMANDS: SlashCommand[] = [
     icon: Minimize2,
     source: 'built-in',
     passThrough: true,
+  },
+  {
+    name: 'config',
+    description: 'Open the Settings dialog',
+    icon: Settings,
+    source: 'built-in',
+    passThrough: false,
   },
 ];
 

--- a/tests/slash-commands-handlers.test.ts
+++ b/tests/slash-commands-handlers.test.ts
@@ -6,7 +6,7 @@ import {
   parseSlashInvocation,
   findSlashCommand,
 } from '../src/slash-commands/registry';
-import { handleClear, blocksToTranscript } from '../src/slash-commands/handlers';
+import { handleClear, handleConfig, blocksToTranscript } from '../src/slash-commands/handlers';
 
 const initial = useStore.getState();
 
@@ -106,16 +106,19 @@ describe('dispatchSlashCommand', () => {
 });
 
 describe('registry shape', () => {
-  it('exposes exactly /clear and /compact as built-ins', () => {
-    expect(BUILT_IN_COMMANDS.map((c) => c.name)).toEqual(['clear', 'compact']);
+  it('exposes /clear, /compact, /config as built-ins', () => {
+    expect(BUILT_IN_COMMANDS.map((c) => c.name)).toEqual(['clear', 'compact', 'config']);
   });
-  it('/clear has a client handler, /compact does not', () => {
+  it('/clear has a client handler, /compact does not, /config does', () => {
     const clear = findSlashCommand(BUILT_IN_COMMANDS, 'clear');
     const compact = findSlashCommand(BUILT_IN_COMMANDS, 'compact');
+    const config = findSlashCommand(BUILT_IN_COMMANDS, 'config');
     expect(clear?.passThrough).toBe(false);
     expect(typeof clear?.clientHandler).toBe('function');
     expect(compact?.passThrough).toBe(true);
     expect(compact?.clientHandler).toBeUndefined();
+    expect(config?.passThrough).toBe(false);
+    expect(typeof config?.clientHandler).toBe('function');
   });
 });
 
@@ -150,6 +153,22 @@ describe('/clear', () => {
     expect(blocks[0].kind).toBe('status');
     if (blocks[0].kind === 'status') {
       expect(blocks[0].title).toBe('Context cleared');
+    }
+  });
+});
+
+describe('/config', () => {
+  it('dispatches the ccsm:open-settings window event', () => {
+    let fired = 0;
+    const listener = () => {
+      fired += 1;
+    };
+    window.addEventListener('ccsm:open-settings', listener);
+    try {
+      handleConfig({ sessionId: 's1', args: '' });
+      expect(fired).toBe(1);
+    } finally {
+      window.removeEventListener('ccsm:open-settings', listener);
     }
   });
 });

--- a/tests/slash-commands-registry.test.ts
+++ b/tests/slash-commands-registry.test.ts
@@ -129,7 +129,7 @@ describe('groupSlashCommands', () => {
       'skill',
       'agent',
     ]);
-    expect(groups[0].commands.map((c) => c.name)).toEqual(['clear', 'compact']);
+    expect(groups[0].commands.map((c) => c.name)).toEqual(['clear', 'compact', 'config']);
     expect(groups[1].commands.map((c) => c.name)).toEqual(['user-cmd']);
     expect(groups[2].commands.map((c) => c.name)).toEqual(['proj-cmd']);
     expect(groups[3].commands.map((c) => c.name)).toEqual(['plug-cmd']);
@@ -168,15 +168,16 @@ describe('filterSlashCommands fuzzy matching', () => {
 });
 
 describe('nextSectionIndex', () => {
-  // Two built-ins (clear, compact), then user, project, plugin sections.
+  // Three built-ins (clear, compact, config), then user, project, plugin sections.
   // Flat layout:
   //   [0] clear           built-in
   //   [1] compact         built-in
-  //   [2] u1              user
-  //   [3] u2              user
-  //   [4] p1              project
-  //   [5] pl1             plugin
-  //   [6] pl2             plugin
+  //   [2] config          built-in
+  //   [3] u1              user
+  //   [4] u2              user
+  //   [5] p1              project
+  //   [6] pl1             plugin
+  //   [7] pl2             plugin
   const fixture: SlashCommand[] = [
     ...BUILT_IN_COMMANDS,
     mkDynamic('u1', 'user'),
@@ -187,33 +188,35 @@ describe('nextSectionIndex', () => {
   ];
 
   it('Tab from inside built-in jumps to first row of next section (user)', () => {
-    expect(nextSectionIndex(fixture, 0, 1)).toBe(2);
-    expect(nextSectionIndex(fixture, 1, 1)).toBe(2);
+    expect(nextSectionIndex(fixture, 0, 1)).toBe(3);
+    expect(nextSectionIndex(fixture, 1, 1)).toBe(3);
+    expect(nextSectionIndex(fixture, 2, 1)).toBe(3);
   });
 
   it('Tab from inside user jumps to first row of project', () => {
-    expect(nextSectionIndex(fixture, 2, 1)).toBe(4);
-    expect(nextSectionIndex(fixture, 3, 1)).toBe(4);
+    expect(nextSectionIndex(fixture, 3, 1)).toBe(5);
+    expect(nextSectionIndex(fixture, 4, 1)).toBe(5);
   });
 
   it('Tab from the last section wraps to the first section', () => {
     // Plugin is the last group in fixture; wrap → built-in (idx 0).
-    expect(nextSectionIndex(fixture, 5, 1)).toBe(0);
     expect(nextSectionIndex(fixture, 6, 1)).toBe(0);
+    expect(nextSectionIndex(fixture, 7, 1)).toBe(0);
   });
 
   it('Shift+Tab from inside a section jumps to the start of the previous section', () => {
     // From plugin → project.
-    expect(nextSectionIndex(fixture, 6, -1)).toBe(4);
+    expect(nextSectionIndex(fixture, 7, -1)).toBe(5);
     // From project → user.
-    expect(nextSectionIndex(fixture, 4, -1)).toBe(2);
+    expect(nextSectionIndex(fixture, 5, -1)).toBe(3);
     // From user → built-in.
-    expect(nextSectionIndex(fixture, 2, -1)).toBe(0);
+    expect(nextSectionIndex(fixture, 3, -1)).toBe(0);
   });
 
   it('Shift+Tab from the first section wraps to the last section', () => {
-    expect(nextSectionIndex(fixture, 0, -1)).toBe(5);
-    expect(nextSectionIndex(fixture, 1, -1)).toBe(5);
+    expect(nextSectionIndex(fixture, 0, -1)).toBe(6);
+    expect(nextSectionIndex(fixture, 1, -1)).toBe(6);
+    expect(nextSectionIndex(fixture, 2, -1)).toBe(6);
   });
 
   it('skips groups that are empty after filtering', () => {


### PR DESCRIPTION
## Root cause
`/config` was never registered in `BUILT_IN_COMMANDS`, so typing `/config` in the composer fell through to `claude.exe` (which has its own inline TUI config view) instead of opening the Electron Settings dialog. The `InputBar.tsx` source comment (line ~581) even documents the intended behavior (`/config opens settings`), but no handler existed.

## Fix
Register `/config` as a built-in command with a client handler that dispatches a `window` CustomEvent (`ccsm:open-settings`). `App.tsx` listens for this event and toggles the existing `settingsOpen` state. Same Radix Settings dialog as the sidebar button and `Cmd/Ctrl+,` shortcut — defaults to the first tab (Connection), users can navigate from there.

Files changed:
- `src/slash-commands/registry.ts` — add `config` entry to `BUILT_IN_COMMANDS`
- `src/slash-commands/handlers.ts` — add `handleConfig` (3 lines) + attach
- `src/App.tsx` — add window event listener (5 lines)
- `tests/slash-commands-{handlers,registry}.test.ts` — update fixtures (3 → 3 built-ins) + new `/config` handler test

## Probe verification (per `feedback_e2e_before_merge.md` + `feedback_e2e_discipline.md`)

**With fix applied** (`node scripts/probe-e2e-settings-open.mjs`):
```
[probe-e2e-settings-open] OK
  sidebar button, /config slash, and Cmd+, all open the same Settings dialog
  Esc closes it from each entry point
EXIT=0
```

**Reverse-verify (fix stashed, rebuilt, re-run probe)**:
```
[probe-e2e-settings-open] FAIL: /config: dialog never became visible
EXIT=1
```
Confirms the probe's step 2 was the assertion that surfaced the bug, and the fix is what makes it pass.

## Vitest
`npm run test`: 777/780 passing. The 3 failures are in `electron/__tests__/db-hardening.test.ts` (better-sqlite3 NODE_MODULE_VERSION 130 vs 137 native binding mismatch). Confirmed pre-existing on stashed working tree — unrelated to this change.

## Electron leak count after probe
0 stray `electron.exe` processes after probe completes (verified via `tasklist`, after manual cleanup of leaked procs from earlier reverse-verify run that exited via `process.exit(1)` before `app.close()` ran).

🤖 Generated with [Claude Code](https://claude.com/claude-code)