### PR TITLE
fix: silence tool_cancel_fallback banner (demote to console.warn)

### DIFF
--- a/electron/agent-sdk/__tests__/sessions.test.ts
+++ b/electron/agent-sdk/__tests__/sessions.test.ts
@@ -190,7 +190,7 @@ describe('agent-sdk/SdkSessionRunner', () => {
     runner.close();
   });
 
-  it('cancelToolUse() emits diagnostic and falls back to interrupt', async () => {
+  it('cancelToolUse() silently falls back to turn-level interrupt without diagnostic', async () => {
     const diags: Array<{ code: string }> = [];
     const runner = new SdkSessionRunner(
       's8',
@@ -201,7 +201,7 @@ describe('agent-sdk/SdkSessionRunner', () => {
     );
     await runner.start(baseStart);
     await runner.cancelToolUse('toolUse-42');
-    expect(diags.some((d) => d.code === 'tool_cancel_fallback')).toBe(true);
+    expect(diags.some((d) => d.code === 'tool_cancel_fallback')).toBe(false);
     expect(fake.interrupt).toHaveBeenCalled();
     runner.close();
   });

--- a/electron/agent-sdk/sessions.ts
+++ b/electron/agent-sdk/sessions.ts
@@ -546,13 +546,12 @@ export class SdkSessionRunner {
   async cancelToolUse(toolUseId: string): Promise<void> {
     if (!this.query) return;
     // Same fallback as the legacy runner: SDK has no per-tool cancel today,
-    // so a per-tool Cancel falls back to a turn-level interrupt. The
-    // diagnostic is emitted so the per-tool fallback shows in dogfood logs.
-    this.onDiagnostic({
-      level: 'warn',
-      code: 'tool_cancel_fallback',
-      message: `Per-tool cancel for ${toolUseId} fell back to turn interrupt (SDK lacks scoped cancel).`,
-    });
+    // so a per-tool Cancel falls back to a turn-level interrupt. Per-tool
+    // Cancel is a normal user action, so we log to stdout (for ccsm-side
+    // debugging) instead of emitting a user-facing diagnostic banner.
+    console.warn(
+      `[ccsm] tool cancel falling back to turn-level interrupt: SDK lacks scoped cancel API (toolUseId=${toolUseId})`,
+    );
     await this.interrupt();
   }
 


### PR DESCRIPTION
## Why
The `tool_cancel_fallback` AgentDiagnostic banner was a false positive — it fired on every per-tool Cancel click, which is a normal user action, not an error. Per-tool Cancel already works correctly (it falls back to the turn-level interrupt because the SDK has no scoped cancel API today); the banner just surfaced implementation trivia to the user.

## What
- `electron/agent-sdk/sessions.ts` — replaced the `this.onDiagnostic({ code: 'tool_cancel_fallback', ... })` emit in `cancelToolUse()` with a `console.warn(...)` so the information stays in main-process stdout for ccsm-side debugging without rendering a user-facing banner.
- The fallback logic itself (calling `this.interrupt()`) is unchanged — only the diagnostic emit was removed.
- `electron/agent-sdk/__tests__/sessions.test.ts` — updated the corresponding unit test to assert the diagnostic is NOT emitted (silent fallback) while the turn-level `interrupt()` still runs.

## Verify
- `npm run test` — sessions.test.ts passes (`cancelToolUse() silently falls back...`). 3 unrelated pre-existing failures in `db-hardening.test.ts` due to better-sqlite3 NODE_MODULE_VERSION mismatch in this worktree's node_modules; not touched by this PR.
- `node scripts/probe-e2e-esc-interrupt.mjs` — passes (turn-level interrupt path still works, no regression).
- Audited `scripts/` and `src/` for `tool_cancel_fallback` references — none found beyond the unit test (no other probe asserted this code).
- Diagnostics catalog: `tool_cancel_fallback` no longer emitted anywhere in the codebase post-fix (grep confirms only the negated test assertion remains).

## Reverse-verify
N/A — this is a pure noise-silencing change with no behavior to flip. The fallback path is exercised by the unit test (interrupt still called) and the esc-interrupt probe (turn-level interrupt path).