### PR TITLE
fix(e2e): permission probes sandbox CLAUDE_CONFIG_DIR

### DIFF
--- a/scripts/probe-e2e-permission-allow-bash.mjs
+++ b/scripts/probe-e2e-permission-allow-bash.mjs
@@ -13,6 +13,7 @@ import path from 'node:path';
 import fs from 'node:fs';
 import os from 'node:os';
 import { fileURLToPath } from 'node:url';
+import { isolatedClaudeConfigDir } from './probe-utils.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -21,6 +22,12 @@ const UDD = path.join(os.tmpdir(), `agentory-bugl-bash-${TS}`);
 const PROJ = path.join(os.tmpdir(), `agentory-bugl-bash-proj-${TS}`);
 fs.mkdirSync(UDD, { recursive: true });
 fs.mkdirSync(PROJ, { recursive: true });
+
+// Sandbox CLAUDE_CONFIG_DIR so the dev's real `~/.claude/settings.json`
+// (which may have `Bash(*)` allowlisted) cannot auto-allow the bash command
+// before the permission prompt fires. Without this, a permissive dev config
+// turns this probe into a silent no-op false-green.
+const cfg = isolatedClaudeConfigDir('agentory-bugl-bash');
 
 // Use a bash command unlikely to be in any default allowlist so the host
 // permission prompt definitely fires. `node --version` is harmless and
@@ -37,6 +44,7 @@ function log(m) {
 function fail(msg, app) {
   console.error(`[probe-bugl-bash] FAIL: ${msg}`);
   if (app) app.close().catch(() => {});
+  cfg.cleanup();
   process.exit(1);
 }
 
@@ -45,7 +53,12 @@ log(`START PROJ=${PROJ} UDD=${UDD}`);
 const app = await electron.launch({
   args: ['.', `--user-data-dir=${UDD}`],
   cwd: ROOT,
-  env: { ...process.env, NODE_ENV: 'production', CCSM_PROD_BUNDLE: '1' },
+  env: {
+    ...process.env,
+    NODE_ENV: 'production',
+    CCSM_PROD_BUNDLE: '1',
+    CCSM_CLAUDE_CONFIG_DIR: cfg.dir,
+  },
 });
 
 try { // ccsm-probe-cleanup-wrap
@@ -142,5 +155,6 @@ if (storeHit.isError)
 
 console.log('[probe-bugl-bash] OK: bash executed, tool_result delivered');
 await app.close();
+cfg.cleanup();
 process.exit(0);
 } finally { try { await app.close(); } catch {} } // ccsm-probe-cleanup-wrap

--- a/scripts/probe-e2e-permission-allow-parallel-batch.mjs
+++ b/scripts/probe-e2e-permission-allow-parallel-batch.mjs
@@ -29,6 +29,7 @@ import path from 'node:path';
 import fs from 'node:fs';
 import os from 'node:os';
 import { fileURLToPath } from 'node:url';
+import { isolatedClaudeConfigDir } from './probe-utils.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -36,12 +37,18 @@ const TS = new Date().toISOString().replace(/[:.]/g, '-');
 const UDD = path.join(os.tmpdir(), `agentory-bugl-par-${TS}`);
 fs.mkdirSync(UDD, { recursive: true });
 
+// Sandbox CLAUDE_CONFIG_DIR so the dev's real `~/.claude/settings.json`
+// can't auto-allow Bash/Read calls before the prompts fire — see
+// probe-e2e-permission-allow-bash.mjs for rationale.
+const cfg = isolatedClaudeConfigDir('agentory-bugl-par');
+
 function log(m) {
   process.stderr.write(`[probe-bugl-parallel ${new Date().toISOString()}] ${m}\n`);
 }
 function fail(msg, app) {
   console.error(`[probe-bugl-parallel] FAIL: ${msg}`);
   if (app) app.close().catch(() => {});
+  cfg.cleanup();
   process.exit(1);
 }
 
@@ -50,7 +57,12 @@ log(`START UDD=${UDD}`);
 const app = await electron.launch({
   args: ['.', `--user-data-dir=${UDD}`],
   cwd: ROOT,
-  env: { ...process.env, NODE_ENV: 'production', CCSM_PROD_BUNDLE: '1' },
+  env: {
+    ...process.env,
+    NODE_ENV: 'production',
+    CCSM_PROD_BUNDLE: '1',
+    CCSM_CLAUDE_CONFIG_DIR: cfg.dir,
+  },
 });
 
 try { // ccsm-probe-cleanup-wrap
@@ -379,5 +391,6 @@ console.log(
   `[probe-bugl-parallel] OK: parallel-bash-N4 + parallel-read-N5 both pass with strict equality (clicks === results).`,
 );
 await app.close();
+cfg.cleanup();
 process.exit(0);
 } finally { try { await app.close(); } catch {} } // ccsm-probe-cleanup-wrap

--- a/scripts/probe-e2e-permission-allow-write.mjs
+++ b/scripts/probe-e2e-permission-allow-write.mjs
@@ -25,6 +25,7 @@ import path from 'node:path';
 import fs from 'node:fs';
 import os from 'node:os';
 import { fileURLToPath } from 'node:url';
+import { isolatedClaudeConfigDir } from './probe-utils.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -33,6 +34,12 @@ const UDD = path.join(os.tmpdir(), `agentory-bugl-write-${TS}`);
 const PROJ = path.join(os.tmpdir(), `agentory-bugl-write-proj-${TS}`);
 fs.mkdirSync(UDD, { recursive: true });
 fs.mkdirSync(PROJ, { recursive: true });
+
+// Sandbox CLAUDE_CONFIG_DIR so the dev's real `~/.claude/settings.json`
+// (which may have `Write(*)` allowlisted) cannot auto-allow the Write call
+// before the permission prompt fires. See probe-e2e-permission-allow-bash.mjs
+// for the same rationale.
+const cfg = isolatedClaudeConfigDir('agentory-bugl-write');
 
 // Anchor the model on the Write tool explicitly. Earlier wording
 // ("Write a file called ...") let the model occasionally pick Edit /
@@ -49,6 +56,7 @@ function log(m) {
 function fail(msg, app) {
   console.error(`[probe-bugl-write] FAIL: ${msg}`);
   if (app) app.close().catch(() => {});
+  cfg.cleanup();
   process.exit(1);
 }
 
@@ -57,7 +65,12 @@ log(`START PROJ=${PROJ} UDD=${UDD}`);
 const app = await electron.launch({
   args: ['.', `--user-data-dir=${UDD}`],
   cwd: ROOT,
-  env: { ...process.env, NODE_ENV: 'production', CCSM_PROD_BUNDLE: '1' },
+  env: {
+    ...process.env,
+    NODE_ENV: 'production',
+    CCSM_PROD_BUNDLE: '1',
+    CCSM_CLAUDE_CONFIG_DIR: cfg.dir,
+  },
 });
 
 try { // ccsm-probe-cleanup-wrap
@@ -368,5 +381,6 @@ if (!domHit) log('WARN: DOM signal missed (non-fatal — fs+store assertion is a
 
 console.log('[probe-bugl-write] OK: file written, tool_result delivered, store updated');
 await app.close();
+cfg.cleanup();
 process.exit(0);
 } finally { try { await app.close(); } catch {} } // ccsm-probe-cleanup-wrap

--- a/scripts/probe-e2e-permission-prompt-default-mode.mjs
+++ b/scripts/probe-e2e-permission-prompt-default-mode.mjs
@@ -29,7 +29,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import { randomUUID } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
-import { appWindow } from './probe-utils.mjs';
+import { appWindow, isolatedClaudeConfigDir } from './probe-utils.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
@@ -45,11 +45,25 @@ const GROUP_ID = 'g-default';
 const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agentory-perm-default-'));
 console.log(`[${NAME}] userData = ${userDataDir}`);
 
+// Sandbox CLAUDE_CONFIG_DIR. THIS PROBE IS THE WHOLE POINT of the sandbox
+// fix: it asserts "permission prompt UI appears for `echo MARKER`". If the
+// dev's real `~/.claude/settings.json` has `Bash(*)` or even `Bash(echo:*)`
+// allowlisted, the upstream CLI auto-allows the call, no `can_use_tool` /
+// hook_callback fires, no prompt UI renders, and this probe times out OR
+// false-greens on a stale assertion. Empty-allowlist config dir restores
+// the prompt path.
+const cfg = isolatedClaudeConfigDir(`${NAME}`);
+console.log(`[${NAME}] sandboxed CLAUDE_CONFIG_DIR = ${cfg.dir}`);
+
 const commonArgs = ['.', `--user-data-dir=${userDataDir}`];
 // Strip CLAUDECODE so the spawned claude.exe doesn't refuse-to-launch with
 // "cannot run inside another Claude Code session". Probes that drive a real
 // CLI must do this — the dogfood guide called it out repeatedly.
-const env = { ...process.env, CCSM_PROD_BUNDLE: '1' };
+const env = {
+  ...process.env,
+  CCSM_PROD_BUNDLE: '1',
+  CCSM_CLAUDE_CONFIG_DIR: cfg.dir,
+};
 delete env.CLAUDECODE;
 delete env.CLAUDE_CODE_ENTRYPOINT;
 
@@ -58,6 +72,7 @@ function fail(msg, extra) {
   console.error(`\n[${NAME}] FAIL: ${msg}`);
   if (extra) console.error(extra);
   if (appRef) appRef.close().catch(() => {});
+  cfg.cleanup();
   process.exit(1);
 }
 
@@ -239,4 +254,5 @@ console.log(`\n[${NAME}] OK`);
 console.log(`  - permission prompt rendered, allow clicked, marker "${MARKER}" appeared in chat`);
 
 await app2.close();
+cfg.cleanup();
 } finally { try { await appRef?.close(); } catch {} } // ccsm-probe-cleanup-wrap

--- a/scripts/probe-utils.mjs
+++ b/scripts/probe-utils.mjs
@@ -146,6 +146,68 @@ export function isolatedUserData(prefix) {
   };
 }
 
+// Allocate an isolated `CLAUDE_CONFIG_DIR` for a probe that asserts on
+// permission-prompt behavior.
+//
+// Why this exists: the dev's real `~/.claude/settings.json` may contain
+// `Bash(*)`, `Write(*)`, etc. in `permissions.allow`. With those rules the
+// upstream CLI silently auto-allows the tool calls these probes use as
+// triggers, the renderer never receives a `can_use_tool`/`hook_callback`
+// request, no Allow button ever appears, and the probe's `waitFor(allowSel)`
+// times out — OR worse, the probe asserts the wrong thing and false-greens.
+// Probes that EXIST to verify "the permission prompt fires" must spawn the
+// CLI against a config dir whose allowlist is empty.
+//
+// Returned shape mirrors `isolatedUserData`. The settings.json seeded inside
+// is the minimum the CLI needs to boot with no allowlist. Pass the resulting
+// `dir` as `CCSM_CLAUDE_CONFIG_DIR` in the electron launch env — ccsm's
+// `resolveClaudeConfigDir` (electron/agent-sdk/sessions.ts) will pick it up
+// and the spawned CLI will see it as `CLAUDE_CONFIG_DIR`.
+//
+// CRITICAL: the user's real `~/.claude/.credentials.json` is NOT copied —
+// these probes rely on the user being logged in to talk to the model. We
+// symlink (or copy if symlinks aren't allowed) just `.credentials.json`
+// from the real config dir so login persists, while leaving every other
+// file (settings.json, projects/, agents/, etc.) absent.
+export function isolatedClaudeConfigDir(prefix) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix + '-cfg-'));
+  // Inherit only the `env` block from the user's real settings.json — that's
+  // where ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN / model overrides live
+  // and the CLI needs them to actually talk to a backend. Drop `permissions`
+  // (and everything else) so no auto-allow rules carry over and every tool
+  // call must hit the permission-prompt path.
+  const sandboxSettings = { permissions: { allow: [], deny: [] } };
+  try {
+    const realSettings = path.join(os.homedir(), '.claude', 'settings.json');
+    if (fs.existsSync(realSettings)) {
+      const raw = JSON.parse(fs.readFileSync(realSettings, 'utf8'));
+      if (raw && typeof raw === 'object' && raw.env && typeof raw.env === 'object') {
+        sandboxSettings.env = raw.env;
+      }
+    }
+  } catch {}
+  fs.writeFileSync(
+    path.join(dir, 'settings.json'),
+    JSON.stringify(sandboxSettings, null, 2),
+    'utf8'
+  );
+  // Inherit credentials so the spawned CLI can authenticate.
+  const realCreds = path.join(os.homedir(), '.claude', '.credentials.json');
+  if (fs.existsSync(realCreds)) {
+    try {
+      fs.copyFileSync(realCreds, path.join(dir, '.credentials.json'));
+    } catch {}
+  }
+  return {
+    dir,
+    cleanup() {
+      try {
+        fs.rmSync(dir, { recursive: true, force: true });
+      } catch {}
+    }
+  };
+}
+
 // Switch the renderer's theme deterministically and wait for the swap to
 // take visual effect.
 //


### PR DESCRIPTION
## Why

Dev's real `~/.claude/settings.json` may have `Bash(*)`, `Write(*)`, `Read(*)`, `Edit(*)` etc in `permissions.allow`. The upstream CLI honors these and auto-allows the corresponding tool calls before any permission prompt fires. The 4 permission probes that drive a real Electron + claude.exe spawn use exactly those tools as their triggers, so on a dev machine with a permissive settings.json they either:

- hard-fail (`never saw Allow button within 90s`) when the assertion that runs first is the Allow-button wait, OR
- false-green when the assertion that runs first is the downstream side-effect (file written, tool_result populated).

Either way the probes do NOT actually exercise the permission-prompt code path on a developer's machine. Per `feedback_e2e_before_merge.md` this kind of silent-no-op is exactly what we should be catching.

## What this PR does

- Adds `isolatedClaudeConfigDir(prefix)` in `scripts/probe-utils.mjs`. Mints a fresh tmpdir, seeds `settings.json` with empty `allow` / `deny` lists. Inherits ONLY the `env` block from the user's real `settings.json` (so `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` / model overrides survive) and copies `.credentials.json` (so the CLI can authenticate). Returns `{ dir, cleanup }`.
- Threads `CCSM_CLAUDE_CONFIG_DIR=<tmpdir>` into the `electron.launch({ env })` of 4 permission probes:
  - `scripts/probe-e2e-permission-allow-bash.mjs`
  - `scripts/probe-e2e-permission-allow-write.mjs`
  - `scripts/probe-e2e-permission-allow-parallel-batch.mjs`
  - `scripts/probe-e2e-permission-prompt-default-mode.mjs`
- ccsm's `resolveClaudeConfigDir` (`electron/agent-sdk/sessions.ts:80-85`) already reads `CCSM_CLAUDE_CONFIG_DIR` and forwards it as `CLAUDE_CONFIG_DIR` to the spawned CLI subprocess — no electron/ code change needed.
- `cfg.cleanup()` called in both `fail()` and the success-exit paths.
- `probe-e2e-permission-reject-stops-agent.mjs` was audited and intentionally NOT changed — it's renderer-only (uses `appendBlocks` to inject a synthetic waiting block, never spawns a real CLI), so the dev's allowlist cannot affect it.

## What this PR does NOT do

Even with the sandbox in place, the SDK / upstream CLI auto-allows safe commands like `node --version`, `echo`, etc. through a built-in heuristic that runs BEFORE `canUseTool` is invoked. The probes still cannot observe a real permission prompt for those commands.

The original mechanism that forced every tool through the permission UI was a `PreToolUse` hook with matcher `.*` registered at `initialize` time (PR #167). Grepping the worktree:

```
$ grep -rn PreToolUse electron/ src/
(no matches outside the probe's own outdated docstring)
```

The hook was lost during the SDK migration. Fixing that is a separate, deeper change; the manager has tracked it as a follow-up task. This PR ships the sandbox infrastructure so when the hook is revived the probes will already be isolated from dev config.

## Verification

- `npm run test`: 776 pass, 3 fail (pre-existing — `better-sqlite3` `NODE_MODULE_VERSION` mismatch in `electron/__tests__/db-hardening.test.ts`, unrelated to this PR).
- Probes still RUN — no crash on the env injection or the helper. Sandbox dir is created, settings.json seeded, credentials copied; the probe proceeds through the existing UI flow exactly as before.
- The probes still fail their downstream assertions when run locally, BUT the failure mode is the pre-existing `PreToolUse`-hook-missing bug described above, not a regression introduced by this PR. Baseline run on `origin/working` (no sandbox) and run on this branch both fail at `never saw Allow button within 90s`.

```
[probe-bugl-bash 2026-04-25T15:54:11.067Z] prompt sent
[probe-bugl-bash] FAIL: never saw Allow button within 90s
```

## User config untouched

```
$ stat -c %y ~/.claude/settings.json   # before any probe run
2026-04-25 14:52:35.044570700 +0800
$ stat -c %y ~/.claude/settings.json   # after all probe runs
2026-04-25 14:52:35.044570700 +0800
```

mtime unchanged — sandbox isolates writes to tmpdir as designed.

## Conflict note

May need rebase after the `CCSM_E2E_HIDDEN` env PR (pool-1) lands; both PRs touch the `env: { ...process.env, NODE_ENV: 'production', CCSM_PROD_BUNDLE: '1' }` block in the 4 permission probes. Reviewer can ignore if no conflict at review time.

## Files changed

- `scripts/probe-utils.mjs` (helper)
- `scripts/probe-e2e-permission-allow-bash.mjs`
- `scripts/probe-e2e-permission-allow-write.mjs`
- `scripts/probe-e2e-permission-allow-parallel-batch.mjs`
- `scripts/probe-e2e-permission-prompt-default-mode.mjs`