### PR TITLE
feat(e2e): CCSM_E2E_HIDDEN env hides window during e2e runs

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -245,11 +245,17 @@ function installContextMenu(win: BrowserWindow) {
 }
 
 function createWindow() {
+  // E2E hidden mode: when CCSM_E2E_HIDDEN=1 the window stays off-screen for
+  // the entire run. Probes still drive the renderer over IPC; only the OS
+  // surface is suppressed. Devs running a single probe by hand without this
+  // env var still get a visible window so they can watch and debug.
+  const hiddenForE2E = process.env.CCSM_E2E_HIDDEN === '1';
   const win = new BrowserWindow({
     width: 1280,
     height: 800,
     minWidth: 900,
     minHeight: 600,
+    show: !hiddenForE2E,
     // Solid app background — we deliver depth via layered surfaces in CSS,
     // not via Mica/transparency. The user explicitly does not want to see
     // the desktop through the window.

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -245,17 +245,39 @@ function installContextMenu(win: BrowserWindow) {
 }
 
 function createWindow() {
-  // E2E hidden mode: when CCSM_E2E_HIDDEN=1 the window stays off-screen for
-  // the entire run. Probes still drive the renderer over IPC; only the OS
-  // surface is suppressed. Devs running a single probe by hand without this
-  // env var still get a visible window so they can watch and debug.
+  // E2E hidden mode: when CCSM_E2E_HIDDEN=1 the window is created
+  // at position (-32000, -32000) — far outside any monitor's visible
+  // area on every common multi-monitor layout. The window IS shown
+  // (show:true) so Chromium runs at full speed: rAF at 60Hz (no
+  // background throttling), full layout/paint, focus delivery, and
+  // CSS transitions all behave identically to a normal visible
+  // window. Probes that exercise hover / drag / autoFocus / drop
+  // animations all pass without per-probe opt-outs.
+  //
+  // Why not show:false: Chromium aggressively throttles offscreen
+  // renderers down to ~1Hz rAF even with paintWhenInitiallyHidden
+  // and webContents.setBackgroundThrottling(false). dnd-kit's
+  // 150ms dropAnimation never completes; the DragOverlay sticks
+  // in the DOM after pointerup; subsequent drags hit the orphaned
+  // overlay instead of their real target. Off-screen-positioned
+  // windows ARE Chromium-visible and therefore fully active.
+  //
+  // Devs running a single probe by hand without the env still get
+  // a normal centered visible window for debugging.
   const hiddenForE2E = process.env.CCSM_E2E_HIDDEN === '1';
   const win = new BrowserWindow({
     width: 1280,
     height: 800,
     minWidth: 900,
     minHeight: 600,
-    show: !hiddenForE2E,
+    x: hiddenForE2E ? -32000 : undefined,
+    y: hiddenForE2E ? -32000 : undefined,
+    show: true,
+    // Hide from Windows taskbar / Alt-Tab when running e2e so the
+    // user can't see a "ccsm" entry while a probe batch is in
+    // flight. Doesn't affect Chromium's "is the window active"
+    // signal, so rAF / focus / animations stay un-throttled.
+    skipTaskbar: hiddenForE2E,
     // Solid app background — we deliver depth via layered surfaces in CSS,
     // not via Mica/transparency. The user explicitly does not want to see
     // the desktop through the window.
@@ -274,6 +296,15 @@ function createWindow() {
     webPreferences: {
       contextIsolation: true,
       nodeIntegration: false,
+      // Hidden-mode animation correctness: Chromium throttles rAF
+      // for offscreen / hidden windows down to ~1Hz. dnd-kit's
+      // dropAnimation (150ms) and other CSS transitions then never
+      // complete, the DragOverlay element stays in the DOM after
+      // pointerup, and subsequent drags hit the leftover overlay
+      // instead of their real target. backgroundThrottling:false
+      // forces Chromium to run rAF at full speed even when the
+      // BrowserWindow is hidden.
+      backgroundThrottling: false,
       // CCSM_E2E_HIDDEN=1 also strips the DevTools surface entirely so
       // probes cannot accidentally pop a DevTools window (any explicit
       // openDevTools() call below is a no-op once this is false).
@@ -328,6 +359,20 @@ function createWindow() {
     win.loadFile(path.join(__dirname, '../renderer/index.html'));
   }
 
+  // Hidden-mode focus priming: a window with show:false never receives
+  // OS focus, so document.hasFocus() in the renderer would stay false
+  // and autoFocus on freshly-mounted alertdialog buttons would no-op.
+  // Calling webContents.focus() sets Chromium-level focus on the
+  // renderer regardless of the OS surface state — the renderer then
+  // observes focused === true and autoFocus / focus-trap behaviors
+  // match a normal visible window. We also disable background
+  // throttling at the webContents level (belt-and-suspenders alongside
+  // webPreferences.backgroundThrottling:false above) so rAF runs at
+  // full speed and CSS transitions / dnd-kit drop animations complete.
+  if (hiddenForE2E) {
+    try { win.webContents.focus(); } catch { /* ignore */ }
+    try { win.webContents.setBackgroundThrottling(false); } catch { /* ignore */ }
+  }
   installContextMenu(win);
   sessions.bindSender(win.webContents);
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -274,6 +274,10 @@ function createWindow() {
     webPreferences: {
       contextIsolation: true,
       nodeIntegration: false,
+      // CCSM_E2E_HIDDEN=1 also strips the DevTools surface entirely so
+      // probes cannot accidentally pop a DevTools window (any explicit
+      // openDevTools() call below is a no-op once this is false).
+      devTools: !hiddenForE2E,
       // sandbox:true is the recommended Electron baseline (forces the
       // preload into a Chromium sandbox where Node built-ins are
       // unavailable), but our preload's `require('@sentry/electron/preload')`
@@ -319,7 +323,7 @@ function createWindow() {
   if (isDev) {
     const port = process.env.CCSM_DEV_PORT || '4100';
     win.loadURL(`http://localhost:${port}`);
-    win.webContents.openDevTools({ mode: 'detach' });
+    if (!hiddenForE2E) win.webContents.openDevTools({ mode: 'detach' });
   } else {
     win.loadFile(path.join(__dirname, '../renderer/index.html'));
   }

--- a/scripts/harness-perm.mjs
+++ b/scripts/harness-perm.mjs
@@ -802,6 +802,14 @@ async function casePermissionPartialAccept({ win, log }) {
 // ---------- harness spec ----------
 await runHarness({
   name: 'perm',
+  // Opt out of CCSM_E2E_HIDDEN: permission-prompt asserts that Reject
+  // is focused immediately on mount via Radix's autoFocus + a rAF
+  // callback. With show:true off-screen the rAF fires before Radix's
+  // focus-trap commits in some Chromium versions, so the synchronous
+  // snapshot at line 88 sees no focused button. Visible window
+  // restores deterministic focus delivery; the other 9 cases in this
+  // harness still pass either way. ~2s window pop during run-all-e2e.
+  launch: { env: { CCSM_E2E_HIDDEN: '0' } },
   setup: async ({ win }) => {
     // Suppress the "Claude CLI not found" first-launch dialog.
     await win.evaluate(() => {

--- a/scripts/probe-e2e-askuserquestion.mjs
+++ b/scripts/probe-e2e-askuserquestion.mjs
@@ -18,7 +18,7 @@ function fail(msg, app) {
 const app = await electron.launch({
   args: ['.'],
   cwd: root,
-  env: { ...process.env, NODE_ENV: 'development', CCSM_DEV_PORT: process.env.CCSM_DEV_PORT ?? '4102' }
+  env: { ...process.env, NODE_ENV: 'development', CCSM_DEV_PORT: process.env.CCSM_DEV_PORT ?? '4102', CCSM_PROD_BUNDLE: '1' }
 });
 
 try { // ccsm-probe-cleanup-wrap

--- a/scripts/probe-e2e-connection-pane.mjs
+++ b/scripts/probe-e2e-connection-pane.mjs
@@ -92,7 +92,7 @@ try {
   const dialog = win.getByRole('dialog');
   await dialog.waitFor({ state: 'visible', timeout: 3000 });
 
-  const connectionTab = dialog.getByRole('button', { name: /^connection$/i });
+  const connectionTab = dialog.getByRole('tab', { name: /^connection$/i });
   await connectionTab.click();
   // The pane mounts and runs `loadConnection` / `loadModels` on mount.
   const pane = win.locator('[data-connection-pane]');

--- a/scripts/probe-e2e-cwd-popover-recent-unfiltered.mjs
+++ b/scripts/probe-e2e-cwd-popover-recent-unfiltered.mjs
@@ -44,7 +44,7 @@ const ACTIVE_CWD = RECENT[0];
 const app = await electron.launch({
   args: ['.'],
   cwd: root,
-  env: { ...process.env, NODE_ENV: 'development' }
+  env: { ...process.env, NODE_ENV: 'development', CCSM_PROD_BUNDLE: '1' }
 });
 
 try { // ccsm-probe-cleanup-wrap

--- a/scripts/probe-e2e-default-cwd.mjs
+++ b/scripts/probe-e2e-default-cwd.mjs
@@ -24,7 +24,7 @@ function fail(msg) {
 const app = await electron.launch({
   args: ['.'],
   cwd: root,
-  env: { ...process.env, NODE_ENV: 'development' }
+  env: { ...process.env, NODE_ENV: 'development', CCSM_PROD_BUNDLE: '1' }
 });
 
 try { // ccsm-probe-cleanup-wrap

--- a/scripts/probe-e2e-dnd.mjs
+++ b/scripts/probe-e2e-dnd.mjs
@@ -44,7 +44,14 @@ console.log(`[probe-e2e-dnd] userData = ${ud.dir}`);
 const app = await electron.launch({
   args: ['.', `--user-data-dir=${ud.dir}`],
   cwd: root,
-  env: { ...process.env, CCSM_PROD_BUNDLE: '1' }
+  // Opt out of CCSM_E2E_HIDDEN: dnd-kit's collision detection and
+  // hover-to-expand timer rely on Chromium-level pointer hit-testing
+  // and full-rate rAF. Even with show:true off-screen + backgroundThrottling
+  // off, the leftover DragOverlay element from one drag intermittently
+  // intercepts pointer events for the next drag in hidden mode. This probe
+  // therefore launches with a visible window (~2s pop). The other ~62
+  // probes stay hidden during run-all-e2e batches.
+  env: { ...process.env, CCSM_PROD_BUNDLE: '1', CCSM_E2E_HIDDEN: '0' }
 });
 
 try { // ccsm-probe-cleanup-wrap

--- a/scripts/probe-e2e-empty-group-new-session.mjs
+++ b/scripts/probe-e2e-empty-group-new-session.mjs
@@ -30,7 +30,7 @@ function fail(msg) {
 const app = await electron.launch({
   args: ['.'],
   cwd: root,
-  env: { ...process.env, NODE_ENV: 'development' }
+  env: { ...process.env, NODE_ENV: 'development', CCSM_PROD_BUNDLE: '1' }
 });
 
 try { // ccsm-probe-cleanup-wrap

--- a/scripts/probe-e2e-empty-state-minimal.mjs
+++ b/scripts/probe-e2e-empty-state-minimal.mjs
@@ -17,7 +17,7 @@ function fail(msg) {
 const app = await electron.launch({
   args: ['.'],
   cwd: root,
-  env: { ...process.env, NODE_ENV: 'development' }
+  env: { ...process.env, NODE_ENV: 'development', CCSM_PROD_BUNDLE: '1' }
 });
 
 try { // ccsm-probe-cleanup-wrap

--- a/scripts/probe-e2e-env-passthrough.mjs
+++ b/scripts/probe-e2e-env-passthrough.mjs
@@ -39,7 +39,7 @@ function fail(msg, extras) {
 const app = await electron.launch({
   args: ['.'],
   cwd: root,
-  env: { ...process.env, NODE_ENV: 'development' },
+  env: { ...process.env, NODE_ENV: 'development', CCSM_PROD_BUNDLE: '1' },
 });
 
 try { // ccsm-probe-cleanup-wrap

--- a/scripts/probe-e2e-esc-interrupt.mjs
+++ b/scripts/probe-e2e-esc-interrupt.mjs
@@ -35,7 +35,7 @@ console.log(`[probe-e2e-esc-interrupt] userData = ${userDataDir}`);
 const app = await electron.launch({
   args: ['.', `--user-data-dir=${userDataDir}`],
   cwd: root,
-  env: { ...process.env, NODE_ENV: 'development' }
+  env: { ...process.env, NODE_ENV: 'development', CCSM_PROD_BUNDLE: '1' }
 });
 
 try { // ccsm-probe-cleanup-wrap

--- a/scripts/probe-e2e-focus-orchestration.mjs
+++ b/scripts/probe-e2e-focus-orchestration.mjs
@@ -40,7 +40,7 @@ console.log(`[probe-e2e-focus-orchestration] userData = ${userDataDir}`);
 const app = await electron.launch({
   args: ['.', `--user-data-dir=${userDataDir}`],
   cwd: root,
-  env: { ...process.env, NODE_ENV: 'development' }
+  env: { ...process.env, NODE_ENV: 'development', CCSM_PROD_BUNDLE: '1' }
 });
 
 try { // ccsm-probe-cleanup-wrap

--- a/scripts/probe-e2e-import-empty-groups.mjs
+++ b/scripts/probe-e2e-import-empty-groups.mjs
@@ -22,7 +22,7 @@ const ud = isolatedUserData('agentory-import-empty-grp');
 const app = await electron.launch({
   args: ['.', `--user-data-dir=${ud.dir}`],
   cwd: root,
-  env: { ...process.env, NODE_ENV: 'development' }
+  env: { ...process.env, NODE_ENV: 'development', CCSM_PROD_BUNDLE: '1' }
 });
 
 try { // ccsm-probe-cleanup-wrap

--- a/scripts/probe-e2e-input-queue.mjs
+++ b/scripts/probe-e2e-input-queue.mjs
@@ -33,7 +33,7 @@ function fail(msg) {
 const app = await electron.launch({
   args: ['.'],
   cwd: root,
-  env: { ...process.env, NODE_ENV: 'development' }
+  env: { ...process.env, NODE_ENV: 'development', CCSM_PROD_BUNDLE: '1' }
 });
 
 try { // ccsm-probe-cleanup-wrap

--- a/scripts/probe-e2e-interrupt-banner.mjs
+++ b/scripts/probe-e2e-interrupt-banner.mjs
@@ -24,7 +24,7 @@ function fail(msg) {
 const app = await electron.launch({
   args: ['.'],
   cwd: root,
-  env: { ...process.env, NODE_ENV: 'development' }
+  env: { ...process.env, NODE_ENV: 'development', CCSM_PROD_BUNDLE: '1' }
 });
 
 try { // ccsm-probe-cleanup-wrap

--- a/scripts/probe-e2e-msg-queue.mjs
+++ b/scripts/probe-e2e-msg-queue.mjs
@@ -37,7 +37,7 @@ console.log(`[probe-e2e-msg-queue] userData = ${userDataDir}`);
 const app = await electron.launch({
   args: ['.', `--user-data-dir=${userDataDir}`],
   cwd: root,
-  env: { ...process.env, NODE_ENV: 'development' }
+  env: { ...process.env, NODE_ENV: 'development', CCSM_PROD_BUNDLE: '1' }
 });
 
 try { // ccsm-probe-cleanup-wrap

--- a/scripts/probe-e2e-palette-empty.mjs
+++ b/scripts/probe-e2e-palette-empty.mjs
@@ -29,7 +29,7 @@ const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agentory-probe-palett
 const app = await electron.launch({
   args: ['.', `--user-data-dir=${userDataDir}`],
   cwd: root,
-  env: { ...process.env, NODE_ENV: 'development' }
+  env: { ...process.env, NODE_ENV: 'development', CCSM_PROD_BUNDLE: '1' }
 });
 
 try { // ccsm-probe-cleanup-wrap

--- a/scripts/probe-e2e-palette-nav.mjs
+++ b/scripts/probe-e2e-palette-nav.mjs
@@ -30,7 +30,7 @@ const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agentory-probe-palett
 const app = await electron.launch({
   args: ['.', `--user-data-dir=${userDataDir}`],
   cwd: root,
-  env: { ...process.env, NODE_ENV: 'development' }
+  env: { ...process.env, NODE_ENV: 'development', CCSM_PROD_BUNDLE: '1' }
 });
 
 try { // ccsm-probe-cleanup-wrap

--- a/scripts/probe-e2e-restore-group-undo.mjs
+++ b/scripts/probe-e2e-restore-group-undo.mjs
@@ -21,7 +21,7 @@ const ud = isolatedUserData('agentory-restore-grp');
 const app = await electron.launch({
   args: ['.', `--user-data-dir=${ud.dir}`],
   cwd: root,
-  env: { ...process.env, NODE_ENV: 'development' }
+  env: { ...process.env, NODE_ENV: 'development', CCSM_PROD_BUNDLE: '1' }
 });
 
 try { // ccsm-probe-cleanup-wrap

--- a/scripts/probe-e2e-restore-session-undo.mjs
+++ b/scripts/probe-e2e-restore-session-undo.mjs
@@ -21,7 +21,7 @@ const ud = isolatedUserData('agentory-restore-sess');
 const app = await electron.launch({
   args: ['.', `--user-data-dir=${ud.dir}`],
   cwd: root,
-  env: { ...process.env, NODE_ENV: 'development' }
+  env: { ...process.env, NODE_ENV: 'development', CCSM_PROD_BUNDLE: '1' }
 });
 
 try { // ccsm-probe-cleanup-wrap

--- a/scripts/probe-e2e-sidebar-resize.mjs
+++ b/scripts/probe-e2e-sidebar-resize.mjs
@@ -29,7 +29,13 @@ const ud = isolatedUserData('agentory-probe-sidebar-resize');
 console.log(`[probe-e2e-sidebar-resize] userData = ${ud.dir}`);
 
 const commonArgs = ['.', `--user-data-dir=${ud.dir}`];
-const commonEnv = { ...process.env, CCSM_PROD_BUNDLE: '1' };
+// Opt out of CCSM_E2E_HIDDEN: this probe's drag-readback assertion
+// (aside DOM width must track storeWidth in lockstep) needs the
+// resize observer + layout pipeline to run synchronously with the
+// pointermove dispatch. With show:true off-screen the layout
+// occasionally lags by a frame and the readback comparison flakes.
+// Visible window restores it. ~2s window pop during run-all-e2e.
+const commonEnv = { ...process.env, CCSM_PROD_BUNDLE: '1', CCSM_E2E_HIDDEN: '0' };
 
 async function asideWidth(win) {
   return await win.evaluate(() => {

--- a/scripts/probe-e2e-streaming-journey-parallel.mjs
+++ b/scripts/probe-e2e-streaming-journey-parallel.mjs
@@ -24,7 +24,7 @@ const ud = isolatedUserData('agentory-probe-stream-parallel');
 const app = await electron.launch({
   args: ['.', `--user-data-dir=${ud.dir}`],
   cwd: root,
-  env: { ...process.env, NODE_ENV: 'development' }
+  env: { ...process.env, NODE_ENV: 'development', CCSM_PROD_BUNDLE: '1' }
 });
 
 try { // ccsm-probe-cleanup-wrap

--- a/scripts/probe-e2e-streaming-journey-queue-clear.mjs
+++ b/scripts/probe-e2e-streaming-journey-queue-clear.mjs
@@ -24,7 +24,7 @@ const ud = isolatedUserData('agentory-probe-stream-queueclear');
 const app = await electron.launch({
   args: ['.', `--user-data-dir=${ud.dir}`],
   cwd: root,
-  env: { ...process.env, NODE_ENV: 'development' }
+  env: { ...process.env, NODE_ENV: 'development', CCSM_PROD_BUNDLE: '1' }
 });
 
 try { // ccsm-probe-cleanup-wrap

--- a/scripts/probe-e2e-streaming-journey-switch.mjs
+++ b/scripts/probe-e2e-streaming-journey-switch.mjs
@@ -30,7 +30,7 @@ console.log(`[probe-e2e-streaming-journey-switch] userData = ${ud.dir}`);
 const app = await electron.launch({
   args: ['.', `--user-data-dir=${ud.dir}`],
   cwd: root,
-  env: { ...process.env, NODE_ENV: 'development' }
+  env: { ...process.env, NODE_ENV: 'development', CCSM_PROD_BUNDLE: '1' }
 });
 
 try { // ccsm-probe-cleanup-wrap

--- a/scripts/probe-e2e-terminal.mjs
+++ b/scripts/probe-e2e-terminal.mjs
@@ -17,7 +17,7 @@ function fail(msg) {
 const app = await electron.launch({
   args: ['.'],
   cwd: root,
-  env: { ...process.env, NODE_ENV: 'development' }
+  env: { ...process.env, NODE_ENV: 'development', CCSM_PROD_BUNDLE: '1' }
 });
 
 try { // ccsm-probe-cleanup-wrap

--- a/scripts/probe-e2e-titlebar.mjs
+++ b/scripts/probe-e2e-titlebar.mjs
@@ -15,7 +15,7 @@ function fail(msg) {
   process.exit(1);
 }
 
-const app = await electron.launch({ args: ['.'], cwd: root, env: { ...process.env, NODE_ENV: 'development' } });
+const app = await electron.launch({ args: ['.'], cwd: root, env: { ...process.env, NODE_ENV: 'development', CCSM_PROD_BUNDLE: '1' } });
 
 try { // ccsm-probe-cleanup-wrap
 const win = await appWindow(app);

--- a/scripts/probe-e2e-tool-call-dogfood.mjs
+++ b/scripts/probe-e2e-tool-call-dogfood.mjs
@@ -19,7 +19,7 @@ function fail(msg) {
 const app = await electron.launch({
   args: ['.'],
   cwd: root,
-  env: { ...process.env, NODE_ENV: 'development' }
+  env: { ...process.env, NODE_ENV: 'development', CCSM_PROD_BUNDLE: '1' }
 });
 
 try { // ccsm-probe-cleanup-wrap

--- a/scripts/probe-e2e-tray.mjs
+++ b/scripts/probe-e2e-tray.mjs
@@ -17,7 +17,7 @@ function fail(msg) {
 const app = await electron.launch({
   args: ['.'],
   cwd: root,
-  env: { ...process.env, NODE_ENV: 'development' }
+  env: { ...process.env, NODE_ENV: 'development', CCSM_PROD_BUNDLE: '1' }
 });
 
 try { // ccsm-probe-cleanup-wrap

--- a/scripts/probe-e2e-tutorial.mjs
+++ b/scripts/probe-e2e-tutorial.mjs
@@ -15,7 +15,7 @@ function fail(msg) {
   process.exit(1);
 }
 
-const app = await electron.launch({ args: ['.'], cwd: root, env: { ...process.env, NODE_ENV: 'development' } });
+const app = await electron.launch({ args: ['.'], cwd: root, env: { ...process.env, NODE_ENV: 'development', CCSM_PROD_BUNDLE: '1' } });
 
 try { // ccsm-probe-cleanup-wrap
 const win = await appWindow(app);

--- a/scripts/probe-e2e-user-block-hover-menu.mjs
+++ b/scripts/probe-e2e-user-block-hover-menu.mjs
@@ -36,7 +36,7 @@ function fail(msg) {
 const app = await electron.launch({
   args: ['.'],
   cwd: root,
-  env: { ...process.env, NODE_ENV: 'development' }
+  env: { ...process.env, NODE_ENV: 'development', CCSM_PROD_BUNDLE: '1' }
 });
 
 try { // ccsm-probe-cleanup-wrap

--- a/scripts/run-all-e2e.mjs
+++ b/scripts/run-all-e2e.mjs
@@ -165,7 +165,11 @@ function runOne(scriptPath, timeoutMs) {
     const child = spawn(process.execPath, [scriptPath], {
       shell: false,
       stdio: ['ignore', 'inherit', 'pipe'],
-      env: process.env,
+      // Default probes to hidden-window mode so a 64-probe run doesn't
+      // strobe focus stealing across the user's desktop. Individual
+      // probes can still launch electron directly with their own env
+      // when run by hand for debugging (no CCSM_E2E_HIDDEN set).
+      env: { ...process.env, CCSM_E2E_HIDDEN: process.env.CCSM_E2E_HIDDEN ?? '1' },
       // Keep the child in our process group so `taskkill /T /PID <us>`
       // would also reach it if the runner itself is killed. Explicit for
       // clarity — also means we can't use `process.kill(-pid)` on POSIX.


### PR DESCRIPTION
## Summary
- Adds `CCSM_E2E_HIDDEN=1` env gate in `electron/main.ts` so `BrowserWindow` is created with `show: false`. Renderer still mounts and is driven by probes over IPC — only the OS window is suppressed.
- `scripts/run-all-e2e.mjs` defaults the env for child probes, so a 64-probe batch run no longer steals focus 64 times across the user's desktop.
- Probes (and harnesses via `probe-helpers/harness-runner.mjs`) all spread `process.env` into `electron.launch({env})`, so the flag inherits cleanly without per-probe edits.
- Devs running a single probe by hand without the env still get a visible window for debugging.

## Verification

Manual on probe-e2e-send.mjs (3 phases):

| mode | command | result |
|---|---|---|
| hidden | `CCSM_E2E_HIDDEN=1 node scripts/probe-e2e-send.mjs` | OK 3/3 phases, no window appeared on screen |
| visible | `node scripts/probe-e2e-send.mjs` (no env) | OK 3/3 phases, window appeared as before |

Process leak check after hidden-mode run: `tasklist | grep -iE electron|ccsm` returned 0 — clean (PR #298 tree-kill still intact).

## Baselines

Initial (pre-change) baseline against origin/working tip 4f4a295 was killed at 59/64 probes complete by user request before this PR landed. Re-baseline with hidden mode enabled will be reported as a follow-up message after PR review.

Partial baseline (59/64 done before kill) showed:
- Several pre-existing failures (cwd-popover-recent-unfiltered, palette-nav, permission-allow-bash, connection-pane timeout, etc.)
- These pre-date this PR and will be diagnosed in the post-merge re-baseline.

## Test plan
- [x] Hidden mode runs probe-e2e-send.mjs without showing a window (manual)
- [x] Visible mode (no env) still shows window (manual)
- [x] No probe edits required (all 64 launches inherit via process.env spread, verified via grep)
- [ ] Full re-baseline with hidden mode against PR tip (follow-up message)