### PR TITLE
fix(auq): sticky widget renders above chips, no focus theft

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -420,6 +420,7 @@ export default function App() {
                 <AgentDiagnosticBanner />
               </TopBannerStack>
               <ChatStream />
+              <QuestionStickyHost sessionId={active.id} />
               <StatusBar
                 cwd={active.cwd}
                 cwdMissing={active.cwdMissing}
@@ -440,7 +441,6 @@ export default function App() {
                 onChangeModel={(m) => setSessionModel(active.id, m)}
                 onChangePermission={setPermission}
               />
-              <QuestionStickyHost sessionId={active.id} />
               <InputBar sessionId={active.id} />
             </main>
           }

--- a/src/components/QuestionBlock.tsx
+++ b/src/components/QuestionBlock.tsx
@@ -246,7 +246,6 @@ export function QuestionBlock({ questions, onSubmit, onReject, autoFocus = true 
   return (
     <motion.div
       ref={rootRef}
-      data-question-sticky
       role="dialog"
       aria-label={t('questionBlock.title')}
       initial={{ opacity: 0, y: 8 }}

--- a/src/components/QuestionStickyHost.tsx
+++ b/src/components/QuestionStickyHost.tsx
@@ -40,71 +40,74 @@ export function QuestionStickyHost({ sessionId }: { sessionId: string }) {
   const block = pending as Extract<MessageBlock, { kind: 'question' }>;
 
   return (
-    <QuestionBlock
-      key={block.id}
-      questions={block.questions}
-      onSubmit={(answersByQuestion) => {
-        const api = window.ccsm;
-        if (!api) return;
-        // Two flows land here:
-        //  1. can_use_tool path (current claude.exe spawn): the question
-        //     block carries `requestId`. We deny the pending permission
-        //     promise on the main side so claude.exe stops blocking on
-        //     it, then send the answers as a fresh user turn so the
-        //     model receives them. This is intentionally lossy in the
-        //     CLI sense (we don't write back to the AskUserQuestion
-        //     tool_result), but it matches what the user actually wants
-        //     and unblocks the turn cleanly. Mirrors upstream's submit
-        //     path semantics — see PermissionPromptBlock for the
-        //     analogous wiring.
-        //  2. tool_use-only path (no requestId): the bogus tool_result
-        //     has already landed via the dedicated AskUserQuestion
-        //     handler; just send the user's answers as the next turn.
-        if (block.requestId) {
-          void api.agentResolvePermission(sessionId, block.requestId, 'deny');
-        }
-        // Serialize the per-question Q→A map into a single user-message
-        // body. Keeps the wire format simple (one agentSend call) and
-        // produces a chat history that reads naturally if the user
-        // scrolls back. We use upstream's "\n " separator to split
-        // multi-select answers inside a single question's value; here
-        // we pre-split each value back to per-line answers under the Q
-        // for the prompt body.
-        const lines: string[] = [];
-        for (const q of block.questions) {
-          const a = answersByQuestion[q.question];
-          if (!a) continue;
-          lines.push(`Q: ${q.question}`);
-          // Each "\n " in `a` already implies a separate line in the
-          // outgoing prompt — emit them as `A: <first>` then bare lines.
-          const parts = a.split(/\n\s*/);
-          lines.push(`A: ${parts[0]}`);
-          for (let i = 1; i < parts.length; i++) lines.push(`   ${parts[i]}`);
-        }
-        const text = lines.join('\n');
-        void api.agentSend(sessionId, text);
-        markQuestionAnswered(sessionId, block.id, {
-          answers: answersByQuestion,
-          rejected: false
-        });
-        bumpComposerFocus();
-      }}
-      onReject={() => {
-        const api = window.ccsm;
-        // Reject path: only the can_use_tool flow has a requestId we can
-        // settle. For the tool_use-only path there's nothing on the main
-        // side to deny — we just drop the card from the sticky and leave
-        // the bogus tool_result already in the timeline. Either way the
-        // timeline keeps a "rejected" trace row.
-        if (api && block.requestId) {
-          void api.agentResolvePermission(sessionId, block.requestId, 'deny');
-        }
-        markQuestionAnswered(sessionId, block.id, {
-          answers: {},
-          rejected: true
-        });
-        bumpComposerFocus();
-      }}
-    />
+    <div data-question-sticky>
+      <QuestionBlock
+        key={block.id}
+        questions={block.questions}
+        autoFocus={false}
+        onSubmit={(answersByQuestion) => {
+          const api = window.ccsm;
+          if (!api) return;
+          // Two flows land here:
+          //  1. can_use_tool path (current claude.exe spawn): the question
+          //     block carries `requestId`. We deny the pending permission
+          //     promise on the main side so claude.exe stops blocking on
+          //     it, then send the answers as a fresh user turn so the
+          //     model receives them. This is intentionally lossy in the
+          //     CLI sense (we don't write back to the AskUserQuestion
+          //     tool_result), but it matches what the user actually wants
+          //     and unblocks the turn cleanly. Mirrors upstream's submit
+          //     path semantics — see PermissionPromptBlock for the
+          //     analogous wiring.
+          //  2. tool_use-only path (no requestId): the bogus tool_result
+          //     has already landed via the dedicated AskUserQuestion
+          //     handler; just send the user's answers as the next turn.
+          if (block.requestId) {
+            void api.agentResolvePermission(sessionId, block.requestId, 'deny');
+          }
+          // Serialize the per-question Q→A map into a single user-message
+          // body. Keeps the wire format simple (one agentSend call) and
+          // produces a chat history that reads naturally if the user
+          // scrolls back. We use upstream's "\n " separator to split
+          // multi-select answers inside a single question's value; here
+          // we pre-split each value back to per-line answers under the Q
+          // for the prompt body.
+          const lines: string[] = [];
+          for (const q of block.questions) {
+            const a = answersByQuestion[q.question];
+            if (!a) continue;
+            lines.push(`Q: ${q.question}`);
+            // Each "\n " in `a` already implies a separate line in the
+            // outgoing prompt — emit them as `A: <first>` then bare lines.
+            const parts = a.split(/\n\s*/);
+            lines.push(`A: ${parts[0]}`);
+            for (let i = 1; i < parts.length; i++) lines.push(`   ${parts[i]}`);
+          }
+          const text = lines.join('\n');
+          void api.agentSend(sessionId, text);
+          markQuestionAnswered(sessionId, block.id, {
+            answers: answersByQuestion,
+            rejected: false
+          });
+          bumpComposerFocus();
+        }}
+        onReject={() => {
+          const api = window.ccsm;
+          // Reject path: only the can_use_tool flow has a requestId we can
+          // settle. For the tool_use-only path there's nothing on the main
+          // side to deny — we just drop the card from the sticky and leave
+          // the bogus tool_result already in the timeline. Either way the
+          // timeline keeps a "rejected" trace row.
+          if (api && block.requestId) {
+            void api.agentResolvePermission(sessionId, block.requestId, 'deny');
+          }
+          markQuestionAnswered(sessionId, block.id, {
+            answers: {},
+            rejected: true
+          });
+          bumpComposerFocus();
+        }}
+      />
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

Fixes AskUserQuestion sticky-widget regressions tracked as tasks #75 / #81 / #85. Three small UI changes (~5 LoC net):

- **`src/App.tsx`** — render `<QuestionStickyHost />` BEFORE `<StatusBar />` so the AUQ widget floats above the chip row instead of being hidden below it (covers #85, #81).
- **`src/components/QuestionStickyHost.tsx`** — pass `autoFocus={false}` to `QuestionBlock` and wrap it in a `<div data-question-sticky>` selector hook. Composer focus is sacred per ccsm design (`feedback_dispatch_avoid_collisions.md` lists InputBar as a hot file precisely because focus theft is a recurring complaint). User must Tab from the composer or click the AUQ widget explicitly to interact. **Intentionally divergent from upstream VS Code extension**, which auto-focuses on mount — we lock this behavior because the half-typed-draft case (block injected mid-typing) is the dominant ccsm use pattern. Covers #75.
- **`src/components/QuestionBlock.tsx`** — drop the redundant `data-question-sticky` attribute from the component root; the selector now lives on the QuestionStickyHost wrapper, keeping QuestionBlock reusable in non-sticky contexts. The `autoFocus` prop already existed and is already correctly respected by the focus `useEffect` (it short-circuits when `autoFocus === false`).

## Verification

- `npm run test`: **780/780 pass**
- `npm run build`: **pass** (only pre-existing bundle-size warnings)

## Probe deferral

Probe rewrite (J1 / J3 / J4 / J6) and the new positioning assertion (J7) are **deferred** — probe modifications are blocked until baseline e2e is green per current manager rule. Once that lifts, follow-up PR will:
- Update J1 to use `data-question-label` instead of the (non-existent) `value` attribute, then assert composer focus is preserved.
- Rewrite J3/J6 for the chip-tab UX (no default pre-select; click `[data-testid="question-tab-N"]` then click the option).
- Switch J4 wrap-around assertions to `data-question-label`.
- Add J7 boundingBox assertion that `[data-question-sticky]`'s bottom is above `[data-type-scale-role="status-bar"]`'s top, locking the "above chips" invariant against silent regressions.

## Test plan

- [x] vitest passes
- [x] webpack build passes
- [ ] Manual sanity (defer to reviewer): `npm start`, trigger an AskUserQuestion, observe widget rendering above the chip/status-bar row instead of below it; observe composer focus preserved when AUQ injected mid-typing

🤖 Generated with [Claude Code](https://claude.com/claude-code)