### PR TITLE
fix(e2e): bucket-7 chrome/shell all green

### DIFF
--- a/scripts/probe-e2e-terminal.mjs
+++ b/scripts/probe-e2e-terminal.mjs
@@ -75,15 +75,15 @@ const chatRendered = await win.evaluate(() => {
   // or a list of blocks inside a max-w-[1100px] container.
   const ready = !!document.body.innerText?.includes('Ready when you are.');
   const hasList = !!document.querySelector('.max-w-\\[1100px\\]');
-  const toolButtons = document.querySelectorAll('.font-mono.text-sm button[aria-expanded]').length;
+  const toolButtons = document.querySelectorAll('[data-testid="tool-block-root"] button[aria-expanded]').length;
   return { ready, hasList, toolButtons };
 });
 console.log('[probe-terminal] chat render state:', JSON.stringify(chatRendered));
 
-// Expand the Bash tool row — target the chat-stream ToolBlock specifically.
-// ChatStream ToolBlock is wrapped in `.font-mono.text-sm` so that class
-// combo uniquely disambiguates from sidebar group-header expand buttons.
-const candidates = win.locator('.font-mono.text-sm button[aria-expanded]');
+// Expand the Bash tool row — target the chat-stream ToolBlock specifically
+// via its data-testid (durable across the type-token rename that turned
+// `font-mono text-sm` into `font-mono text-chrome`).
+const candidates = win.locator('[data-testid="tool-block-root"] button[aria-expanded]');
 const btnCount = await candidates.count();
 console.log(`[probe-terminal] chat tool expand buttons: ${btnCount}`);
 if (btnCount === 0) fail('no ChatStream ToolBlock button found');
@@ -94,7 +94,7 @@ await new Promise((r) => setTimeout(r, 500));
 const hostCount = await win.locator('[data-testid="terminal-host"]').count();
 if (hostCount !== 1) {
   const summary = await win.evaluate(() => {
-    const toolButtons = Array.from(document.querySelectorAll('.font-mono.text-sm button[aria-expanded]'));
+    const toolButtons = Array.from(document.querySelectorAll('[data-testid="tool-block-root"] button[aria-expanded]'));
     return toolButtons.map((b) => ({
       aria: b.getAttribute('aria-expanded'),
       outer: b.outerHTML.slice(0, 300),


### PR DESCRIPTION
## Summary

Bucket #172 — 12 chrome/shell probes all green:

- probe-e2e-app-icon-present — already green
- probe-e2e-connection-pane — already green
- probe-e2e-i18n-settings-zh — already green
- probe-e2e-language-toggle — already green
- probe-e2e-palette-empty — already green
- probe-e2e-palette-nav — already green
- probe-e2e-settings-open — already green
- probe-e2e-terminal — **fixed** (stale Tailwind selector after type-token migration)
- probe-e2e-theme-toggle — already green
- probe-e2e-titlebar — already green
- probe-e2e-tray — already green
- probe-e2e-tutorial — already green

## Root cause (terminal)

`ChatStream`'s `ToolBlock` root used to carry `font-mono text-sm`. PR #225 / #205 (4-step semantic type-token migration) renamed `text-sm` to `text-chrome` across the codebase, including `ToolBlock.tsx`. The probe's `.font-mono.text-sm button[aria-expanded]` Playwright selector silently matched zero buttons after that rename and the probe failed with "no ChatStream ToolBlock button found" — even though the block was rendering correctly.

## Fix

Swap the brittle Tailwind-class selector for the durable `data-testid="tool-block-root"` hook the component already exposes. Same disambiguation goal (don't match sidebar group-header expand buttons) without coupling to class names. Two call sites updated (the candidate locator and the diagnostic dump).

No product code changed.

## Test plan

- [x] 3 rounds x 12 probes with `CCSM_E2E_HIDDEN=1` — 36/36 PASS.
- [x] Confirmed `probe-e2e-terminal` previously failed on `origin/working` with the same env.