### PR TITLE
fix(e2e): bucket-6 sidebar/dnd all green

### DIFF
--- a/scripts/probe-e2e-sidebar-journey-create-delete.mjs
+++ b/scripts/probe-e2e-sidebar-journey-create-delete.mjs
@@ -405,6 +405,18 @@ await seedStore(win, {
     activeId: 'a1',
     focusedGroupId: null
   });
+  // Dismiss any lingering toasts from earlier journeys (J4's session-undo
+  // toast can still be in DOM if its 3s TTL hasn't elapsed) so the locator
+  // below resolves to J7's group-undo toast unambiguously.
+  await win.evaluate(() => {
+    const t = window.__ccsmToast;
+    if (!t) return;
+    document.querySelectorAll('[data-toast-id]').forEach((el) => {
+      const id = el.getAttribute('data-toast-id');
+      if (id) t.dismiss(id);
+    });
+  });
+  await win.waitForTimeout(150);
   const header = win.locator('[data-group-header-id="gA"]').first();
   await header.click({ button: 'right' });
   const delMenu = win.getByRole('menuitem').filter({ hasText: /Delete group/ }).first();


### PR DESCRIPTION
## Summary
Bucket-6 e2e bucket — all 4 sidebar/dnd probes now green.

## Per-probe state

| Probe | Baseline | Action |
| --- | --- | --- |
| `probe-e2e-sidebar-journey-create-delete` | FAIL (J7) | fixed in this PR |
| `probe-e2e-sidebar-journey-rename-dnd-state` | OK | none |
| `probe-e2e-sidebar-resize` | OK | none |
| `probe-e2e-dnd` | OK | none |

## Root cause: J7 was racing J4's stale undo toast

`probe-e2e-sidebar-journey-create-delete` J7 deletes a non-empty group via UI, then asserts that clicking the resulting "Undo" toast restores the group + its members. Failure was `J7.undoMembersOrder ... observed: [k2]` — `k2` is from J4's seed, never present in J7's seed.

Trace:
1. J4 right-click-deletes session `k2` → `Sidebar.tsx` calls `toast.push({...action: { onClick: () => restoreSession(snapshot of k2) }})`. TTL is 3s (`src/components/ui/Toast.tsx`).
2. J5 + J6 + J7-seed take less than 3s on a fast machine → J4's toast is still mounted in the DOM.
3. J7 looks up `win.locator('button').filter({hasText: /^Undo$/}).first()`. AnimatePresence renders toasts oldest-first, so `.first()` picks J4's stale Undo. Clicking it runs `restoreSession(k2)` instead of `restoreGroup(gA)`. Sessions ends up containing `k2` (with stale `groupId='gA'` from the J4 fixture) and gA stays missing.

Probe-only bug — the product is fine. Toast TTL is intentional UX. The probe must not depend on no-other-toasts-being-live.

## Fix
Probe dismisses every mounted toast via the `window.__ccsmToast` debug handle (the same one already used by `harness-ui.mjs` for the toast-a11y case) right before J7's flow. Clean slate, single Undo button in DOM, no ambiguity.

```js
await win.evaluate(() => {
  const t = window.__ccsmToast;
  if (!t) return;
  document.querySelectorAll('[data-toast-id]').forEach((el) => {
    const id = el.getAttribute('data-toast-id');
    if (id) t.dismiss(id);
  });
});
```

12 lines added in `scripts/probe-e2e-sidebar-journey-create-delete.mjs`. Zero product changes.

## Final stdout (3rd consecutive run, all 4 probes)
```
=== ROUND 3 ===
sidebar-journey-create-delete exit=0
sidebar-journey-rename-dnd-state exit=0
sidebar-resize exit=0
dnd exit=0
```
3/3 stable rounds (12/12 individual passes).

## Test plan
- [x] `node scripts/probe-e2e-sidebar-journey-create-delete.mjs` — green 3x
- [x] `node scripts/probe-e2e-sidebar-journey-rename-dnd-state.mjs` — green 3x
- [x] `node scripts/probe-e2e-sidebar-resize.mjs` — green 3x
- [x] `node scripts/probe-e2e-dnd.mjs` — green 3x
- [ ] Reviewer: confirm using `window.__ccsmToast.dismiss` from a probe is consistent with how other probes reach into renderer-only debug handles (see `__ccsmStore`, `__ccsmI18n`, the existing `__ccsmToast` use in `harness-ui.mjs`).