### PR TITLE
fix(e2e): bucket-9 session lifecycle all green

### DIFF
--- a/scripts/probe-e2e-default-cwd.mjs
+++ b/scripts/probe-e2e-default-cwd.mjs
@@ -11,7 +11,7 @@
 import { _electron as electron } from 'playwright';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { appWindow } from './probe-utils.mjs';
+import { appWindow, isolatedUserData } from './probe-utils.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
@@ -21,13 +21,16 @@ function fail(msg) {
   process.exit(1);
 }
 
+const ud = isolatedUserData('agentory-probe-default-cwd');
 const app = await electron.launch({
-  args: ['.'],
+  args: ['.', `--user-data-dir=${ud.dir}`],
   cwd: root,
   env: { ...process.env, NODE_ENV: 'development', CCSM_PROD_BUNDLE: '1' }
 });
 
 try { // ccsm-probe-cleanup-wrap
+
+try {
 
 const win = await appWindow(app);
 const errors = [];
@@ -81,4 +84,7 @@ console.log('\n[probe-e2e-default-cwd] OK');
 console.log('  sending with default cwd "~" produced an assistant reply');
 
 await app.close();
+} finally {
+  ud.cleanup();
+}
 } finally { try { await app.close(); } catch {} } // ccsm-probe-cleanup-wrap

--- a/scripts/probe-e2e-env-passthrough.mjs
+++ b/scripts/probe-e2e-env-passthrough.mjs
@@ -13,7 +13,7 @@
 import { _electron as electron } from 'playwright';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { appWindow } from './probe-utils.mjs';
+import { appWindow, isolatedUserData } from './probe-utils.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
@@ -36,14 +36,16 @@ function fail(msg, extras) {
   process.exit(1);
 }
 
+const ud = isolatedUserData('agentory-probe-env-passthrough');
 const app = await electron.launch({
-  args: ['.'],
+  args: ['.', `--user-data-dir=${ud.dir}`],
   cwd: root,
   env: { ...process.env, NODE_ENV: 'development', CCSM_PROD_BUNDLE: '1' },
 });
 
 try { // ccsm-probe-cleanup-wrap
 
+try {
 const win = await appWindow(app);
 const errors = [];
 win.on('pageerror', (e) => errors.push(`[pageerror] ${e.message}`));
@@ -111,4 +113,7 @@ console.log(finalDump.slice(0, 2000));
 console.log('  ---- end ----');
 
 await app.close();
+} finally {
+  ud.cleanup();
+}
 } finally { try { await app.close(); } catch {} } // ccsm-probe-cleanup-wrap


### PR DESCRIPTION
## Summary

Bucket #176 — session-lifecycle probes all green.

The bucket spec lists 11 probes. One (`probe-e2e-savemessages-size-cap.mjs`) was retired in PR #296 alongside the `db:saveMessages` IPC removal (PR #278 / PR-H "load session history from CLI JSONL"); the file no longer exists on `working` and is correctly absent. The remaining 10 are all green.

Per-probe baseline on `origin/working`:

- probe-e2e-switch — already green
- probe-e2e-rename — already green
- probe-e2e-close-window-aborts-sessions — already green
- probe-e2e-delete-session-kills-process — already green
- probe-e2e-jsonl-filename-matches-session — already green
- probe-e2e-savemessages-size-cap — **retired** (file deleted in #296; not in repo)
- probe-e2e-db-corruption-recovery — already green
- probe-e2e-ipc-unc-rejection — already green
- probe-e2e-env-passthrough — **fixed** (userData contamination → isolated)
- probe-e2e-default-cwd — **fixed** (userData contamination → isolated)
- probe-e2e-cwd-popover-recent-unfiltered — already green

## Root cause (env-passthrough + default-cwd)

Both probes launched without `--user-data-dir`, sharing the developer's real `AppData/Roaming/CCSM/ccsm.db`. Earlier probes (and historical dev runs) had populated that DB with sessions whose `cwd` was a stub path like `C:/x` — confirmed by grepping the on-disk DB. `createSession`'s default-cwd resolver (store.ts:1040-1044) picks the most-recent session's cwd in the target group; the new probe-spawned session inherited `C:/x`, a path that does not exist, so the renderer's pre-flight cwd-validation banner appeared and the prompt never reached claude.exe.

## Fix

Both probes test fresh-launch behavior — they don't need persistent userData. Switching them to `isolatedUserData('...')` (already used by every other probe in this bucket) gives them an empty DB; default-cwd then falls back to `''`, the spawn proceeds, and the assistant reply lands. Pure probe hygiene; no product code touched.

Note on retired probe: bucket spec was generated from an older snapshot. `probe-e2e-savemessages-size-cap.mjs` targeted the `db:saveMessages` IPC's payload-size cap (commit b3da118). PR #278 deleted that IPC entirely (CLI JSONL is now the source of truth for history); PR #296 retired the seven probes that depended on it, including this one. No follow-up needed.

## Test plan

- [x] 3 rounds x 10 probes with `CCSM_E2E_HIDDEN=1` — 30/30 PASS.
- [x] Confirmed both target probes previously failed on `origin/working` with `Working directory no longer exists: C:/x`.
- [x] Confirmed `probe-e2e-savemessages-size-cap.mjs` not present on `working` (retired in #296).