### PR TITLE
fix(e2e): bucket-3 permission all green

### DIFF
--- a/electron/agent-sdk/sessions.ts
+++ b/electron/agent-sdk/sessions.ts
@@ -515,9 +515,17 @@ export class SdkSessionRunner {
     });
 
     if (decision.allow) {
+      // The claude binary's Zod schema requires `updatedInput` to ALWAYS
+      // be present on an `allow` response — even though the SDK's TypeScript
+      // type marks it optional. Reproduced via probe-e2e-permission-allow-*
+      // (Bug #169): `updatedInput: undefined` triggers
+      // `invalid_union / expected: "record", received: undefined`. When the
+      // user didn't supply a partial-accept payload, echo the original
+      // `input` back unchanged — this matches the on-the-wire shape the CLI
+      // expects and is semantically a no-op (allow with no replacement).
       return {
         behavior: 'allow',
-        updatedInput: decision.updatedInput as Record<string, unknown> | undefined,
+        updatedInput: (decision.updatedInput as Record<string, unknown> | undefined) ?? input,
       };
     }
     return {

--- a/scripts/probe-e2e-permission-allow-bash.mjs
+++ b/scripts/probe-e2e-permission-allow-bash.mjs
@@ -8,6 +8,25 @@
 // Pre-fix: clicking Allow on the Bash prompt resolved the renderer state
 // but the bash never executed and no tool_result arrived. Post-fix the
 // nested control_response envelope reaches claude.exe and the bash runs.
+//
+// known-incomplete: PreToolUse missing (#94)
+// ─────────────────────────────────────────
+// The Claude Code CLI's local rule engine handles built-in `Bash` tool
+// invocations entirely client-side and does NOT route them through
+// `canUseTool` (the SDK callback ccsm hooks into). Pre-#94 the legacy
+// runner registered a `PreToolUse` hook with matcher `.*` to bridge every
+// tool invocation through the permission flow regardless of CLI internal
+// rules. The SDK migration dropped that hook; the SDK has no equivalent
+// API surface yet (verified against
+// node_modules/@anthropic-ai/claude-agent-sdk/sdk.d.ts).
+//
+// Net effect: in default permission mode no Allow button ever appears for
+// Bash. Per ccsm e2e policy ("never skip — degrade with a labeled
+// assertion") this probe degrades to: tool block lands with a tool_result
+// regardless of whether the prompt rendered. The original strict
+// "Allow-clicked → result lands" assertion is preserved as a soft check
+// that LOGS rather than fails when the prompt doesn't fire. Once #94
+// lands the soft check should be promoted back to a hard assert.
 import { _electron as electron } from 'playwright';
 import path from 'node:path';
 import fs from 'node:fs';
@@ -98,31 +117,30 @@ await ta.fill(PROMPT);
 await win.keyboard.press('Enter');
 log('prompt sent');
 
+// Race: either an Allow button appears (strict path — assert on it) OR the
+// Bash tool block lands a tool_result without ever prompting (degraded
+// path — log and continue, mark known-incomplete (#94)).
 const allowSel = '[data-perm-action="allow"]';
 const waitDl = Date.now() + 90_000;
 let allowClicked = false;
+let storeHit = null;
+let knownIncomplete = false;
 while (Date.now() < waitDl) {
   await win.waitForTimeout(1000);
-  const visible = await win
-    .locator(allowSel)
-    .first()
-    .isVisible({ timeout: 200 })
-    .catch(() => false);
-  if (visible) {
-    await win.locator(allowSel).first().click();
-    allowClicked = true;
-    log('clicked Allow (Y)');
-    break;
+  // Strict path — click Allow if rendered.
+  if (!allowClicked) {
+    const visible = await win
+      .locator(allowSel)
+      .first()
+      .isVisible({ timeout: 200 })
+      .catch(() => false);
+    if (visible) {
+      await win.locator(allowSel).first().click();
+      allowClicked = true;
+      log('clicked Allow (Y)');
+    }
   }
-}
-if (!allowClicked) fail('never saw Allow button within 90s', app);
-
-// 30s observation window. For Bash there is no fs side effect to assert on,
-// so we rely on the Bash tool block in the renderer store gaining a result.
-const obsStart = Date.now();
-let storeHit = null;
-while (Date.now() - obsStart < 30_000) {
-  await win.waitForTimeout(1500);
+  // Always poll for the result regardless of prompt.
   const snap = await win
     .evaluate(() => {
       const st = window.__ccsmStore?.getState?.();
@@ -141,19 +159,29 @@ while (Date.now() - obsStart < 30_000) {
         : null;
     })
     .catch(() => null);
-  if (!storeHit && snap?.hasResult) {
+  if (snap?.hasResult) {
     storeHit = snap;
     log(`STORE HIT: ${JSON.stringify(snap)}`);
     break;
   }
 }
 
-if (!storeHit)
-  fail('Bash tool block never received a tool_result after Allow (Bug L regression)', app);
+if (!storeHit) {
+  fail('Bash tool block never received a tool_result (Bug L regression OR CLI did not run the tool at all)', app);
+}
 if (storeHit.isError)
   fail(`Bash tool block received an ERROR result: ${storeHit.head}`, app);
 
-console.log('[probe-bugl-bash] OK: bash executed, tool_result delivered');
+if (!allowClicked) {
+  knownIncomplete = true;
+  log('known-incomplete: PreToolUse missing (#94) — Bash auto-allowed by CLI without firing canUseTool; tool result still landed, so degraded assertion passes.');
+}
+
+console.log(
+  knownIncomplete
+    ? '[probe-bugl-bash] OK (known-incomplete: PreToolUse missing #94): bash executed, tool_result delivered; permission prompt never fired (CLI client-side auto-allow)'
+    : '[probe-bugl-bash] OK: bash executed, tool_result delivered'
+);
 await app.close();
 cfg.cleanup();
 process.exit(0);

--- a/scripts/probe-e2e-permission-allow-parallel-batch.mjs
+++ b/scripts/probe-e2e-permission-allow-parallel-batch.mjs
@@ -19,11 +19,18 @@
 //      unique `tool_use.id`. See `assistantBlocks` in
 //      `src/agent/stream-to-blocks.ts`.
 //
-// Two cases below cover both the Bash and Read parallel-batch shapes seen
-// in the wild (Bash from the original probe; Read from Dogfood G's
-// REPORT-RERUN.md §A2-NEW-3-PARALLEL-V2). Tightened assertion:
-// `succeeded.length === clicks` — every Allow click must produce a
-// resolved tool_result, not just one.
+// known-incomplete: PreToolUse missing (#94)
+// ─────────────────────────────────────────
+// In default mode the CLI auto-allows built-in `Bash` (and often `Read`)
+// invocations client-side, so no permission prompt fires and `clicks`
+// will be 0. The actual Bug L invariant (`N tool_use blocks → N tool
+// blocks in store → N tool_results`) is independent of whether a prompt
+// rendered — IPC envelope correctness applies equally to the auto-allow
+// path. So this probe degrades to: assert N parallel tool blocks exist
+// AND each carries a tool_result. The strict-equality `clicks === N`
+// assertion is preserved as a soft check that LOGS "known-incomplete:
+// PreToolUse missing (#94)" rather than failing when the prompt doesn't
+// fire. Once #94 lands the strict path should be re-enabled.
 import { _electron as electron } from 'playwright';
 import path from 'node:path';
 import fs from 'node:fs';
@@ -124,9 +131,15 @@ async function runCase({ caseName, files, prompt, toolName, expectedClicks }) {
   log(`[${caseName}] prompt sent`);
 
   const allowSel = '[data-perm-action="allow"]';
-  const totalDl = Date.now() + 120_000;
-  let lastClickAt = 0;
+  // Click loop AND result-poll happen concurrently. With PreToolUse
+  // missing (#94) the CLI may auto-allow Bash/Read with no prompt, so we
+  // can't gate on `clicks > 0`. Exit when N tool blocks all have results
+  // OR when 120s elapses with zero progress.
+  const totalDl = Date.now() + 180_000;
   let clicks = 0;
+  let snap = null;
+  let lastProgressAt = Date.now();
+  const N = expectedClicks ?? 0;
   while (Date.now() < totalDl) {
     await win.waitForTimeout(750);
     const visible = await win
@@ -137,19 +150,10 @@ async function runCase({ caseName, files, prompt, toolName, expectedClicks }) {
     if (visible) {
       await win.locator(allowSel).first().click();
       clicks += 1;
-      lastClickAt = Date.now();
+      lastProgressAt = Date.now();
       log(`[${caseName}] clicked Allow #${clicks}`);
       continue;
     }
-    if (clicks > 0 && Date.now() - lastClickAt > 8_000) break;
-  }
-  if (clicks === 0) fail(`[${caseName}] never saw any Allow button within 120s`, app);
-  log(`[${caseName}] total Allow clicks: ${clicks}`);
-
-  const obsStart = Date.now();
-  let snap;
-  while (Date.now() - obsStart < 60_000) {
-    await win.waitForTimeout(2000);
     snap = await win
       .evaluate((tn) => {
         const st = window.__ccsmStore?.getState?.();
@@ -166,6 +170,7 @@ async function runCase({ caseName, files, prompt, toolName, expectedClicks }) {
             hasResult: typeof b.result === 'string' && b.result.length > 0,
             isError: b.isError === true,
             resultLen: typeof b.result === 'string' ? b.result.length : 0,
+            resultHead: typeof b.result === 'string' ? b.result.slice(0, 300) : null,
           }));
         const resolvedTraces = blocks.filter(
           (b) =>
@@ -179,42 +184,56 @@ async function runCase({ caseName, files, prompt, toolName, expectedClicks }) {
         return { tools, resolvedTraces, totalBlocks: blocks.length, allBlockKinds };
       }, toolName)
       .catch(() => null);
-    if (
-      snap &&
-      snap.resolvedTraces >= clicks &&
-      snap.tools.length >= clicks &&
-      snap.tools.filter((t) => t.hasResult).length >= clicks
-    )
-      break;
+    const succeeded = snap?.tools.filter((t) => t.hasResult).length ?? 0;
+    if (N > 0 && snap && snap.tools.length >= N && succeeded >= N) break;
+    // Generic exit: had at least one tool with result and 8s of stillness.
+    if (succeeded > 0 && Date.now() - lastProgressAt > 12_000) break;
+    if (succeeded > 0) lastProgressAt = Date.now();
   }
+  log(`[${caseName}] total Allow clicks: ${clicks}`);
 
   if (!snap) fail(`[${caseName}] could not snapshot store`, app);
   log(`[${caseName}] final snapshot: tools=${JSON.stringify(snap.tools)} resolvedTraces=${snap.resolvedTraces}`);
   log(`[${caseName}] final allBlocks=${JSON.stringify(snap.allBlockKinds)}`);
 
-  if (expectedClicks && clicks !== expectedClicks)
-    fail(
-      `[${caseName}] expected ${expectedClicks} Allow clicks but observed ${clicks}. Did the model serialize the calls instead of issuing them in parallel?`,
-      app,
-    );
+  // Strict equality `clicks === expectedClicks` is degraded to a SOFT check
+  // when the CLI auto-allowed (clicks === 0). See "known-incomplete: #94".
+  let knownIncomplete = false;
+  if (expectedClicks && clicks !== expectedClicks) {
+    if (clicks === 0) {
+      knownIncomplete = true;
+      console.warn(
+        `[${caseName}] known-incomplete: PreToolUse missing (#94) — expected ${expectedClicks} Allow clicks, observed 0. CLI auto-allowed all ${expectedClicks} ${toolName} calls client-side without firing canUseTool. Falling through to the N-tool-block invariant assertion (the actual Bug L target).`
+      );
+    } else {
+      fail(
+        `[${caseName}] expected ${expectedClicks} Allow clicks but observed ${clicks} (partial — neither the strict path nor the auto-allow path). ` +
+          `Did the model serialize the calls instead of issuing them in parallel?`,
+        app,
+      );
+    }
+  }
 
-  if (snap.resolvedTraces < clicks)
+  if (!knownIncomplete && snap.resolvedTraces < clicks)
     fail(
       `[${caseName}] Bug L renderer regression: clicked Allow ${clicks}x but only ${snap.resolvedTraces} permission-resolved traces appeared in store.`,
       app,
     );
 
-  if (snap.tools.length < clicks)
+  // The N-tool-block invariant is THE Bug L assertion — applies regardless
+  // of whether prompts rendered.
+  const targetN = expectedClicks ?? clicks;
+  if (snap.tools.length < targetN)
     fail(
-      `[${caseName}] Bug L parallel-batch RENDERER regression: ${clicks} Allow clicks but only ${snap.tools.length} \`tool:${toolName}\` blocks exist in store. ` +
+      `[${caseName}] Bug L parallel-batch RENDERER regression: expected ≥${targetN} \`tool:${toolName}\` blocks in store, got ${snap.tools.length}. ` +
         `Parallel tool_use blocks are being coalesced by id (see assistantBlocks). allBlocks=${JSON.stringify(snap.allBlockKinds)}`,
       app,
     );
 
   const succeeded = snap.tools.filter((t) => t.hasResult);
-  if (succeeded.length !== clicks)
+  if (succeeded.length < targetN)
     fail(
-      `[${caseName}] Bug L parallel-batch IPC/RENDERER regression: ${clicks} Allow clicks but only ${succeeded.length}/${clicks} \`tool:${toolName}\` blocks received a tool_result. ` +
+      `[${caseName}] Bug L parallel-batch IPC/RENDERER regression: expected ≥${targetN} \`tool:${toolName}\` blocks with tool_result, got ${succeeded.length}. ` +
         `tools=${JSON.stringify(snap.tools)} allBlocks=${JSON.stringify(snap.allBlockKinds)}`,
       app,
     );
@@ -224,9 +243,9 @@ async function runCase({ caseName, files, prompt, toolName, expectedClicks }) {
     fail(`[${caseName}] one or more ${toolName} tool blocks errored: ${JSON.stringify(errored)}`, app);
 
   log(
-    `[${caseName}] OK: ${clicks} Allow clicks → ${snap.resolvedTraces} resolved traces, ${succeeded.length}/${clicks} ${toolName} blocks have tool_result.`,
+    `[${caseName}] OK${knownIncomplete ? ' (known-incomplete: PreToolUse missing #94)' : ''}: ${clicks} Allow clicks → ${snap.resolvedTraces} resolved traces, ${succeeded.length}/${targetN} ${toolName} blocks have tool_result.`,
   );
-  return { clicks, snap };
+  return { clicks, snap, knownIncomplete };
 }
 
 // === case: parallel-bash-N4 ===
@@ -254,7 +273,14 @@ const READ_FILES = ['README.md', 'package.json', 'src/strings.js', 'src/math.js'
 // runCase seeds files at the top level only; for nested paths we just write
 // them in the seeded dir, the case handler creates the directory tree below.
 const READ_PROMPT =
-  `Use the Read tool to read README.md, package.json, src/strings.js, src/math.js, src/cart.js IN PARALLEL — emit FIVE Read tool_use blocks in a SINGLE assistant message. Do NOT serialize. After all five reads come back, give a 5-line summary, one bullet per file.`;
+  `Use the Read tool to read the following files IN PARALLEL — emit FIVE Read tool_use blocks in a SINGLE assistant message. Do NOT serialize.\n\n` +
+  `IMPORTANT: the Read tool requires ABSOLUTE file paths. Use these exact absolute paths (already on disk):\n` +
+  `- {{ABSPATH:README.md}}\n` +
+  `- {{ABSPATH:package.json}}\n` +
+  `- {{ABSPATH:src/strings.js}}\n` +
+  `- {{ABSPATH:src/math.js}}\n` +
+  `- {{ABSPATH:src/cart.js}}\n\n` +
+  `After all five reads come back, give a 5-line summary, one bullet per file.`;
 
 // runCase only handles flat files; do a tiny inline variant that supports
 // nested paths so we can hit the exact dogfood shape.
@@ -278,14 +304,24 @@ const READ_PROMPT =
   const ta = win.locator('textarea').first();
   await ta.waitFor({ state: 'visible', timeout: 8000 });
   await ta.click();
-  await ta.fill(READ_PROMPT);
+  // Substitute {{ABSPATH:relpath}} placeholders with concrete absolute
+  // paths under proj. The Read tool requires absolute paths and will
+  // emit "File does not exist" errors otherwise.
+  const filledPrompt = READ_PROMPT.replace(/\{\{ABSPATH:([^}]+)\}\}/g, (_, rel) =>
+    path.resolve(proj, rel)
+  );
+  await ta.fill(filledPrompt);
   await win.keyboard.press('Enter');
   log(`[${caseName}] prompt sent`);
 
   const allowSel = '[data-perm-action="allow"]';
-  const totalDl = Date.now() + 120_000;
-  let lastClickAt = 0;
+  // Same combined click+poll loop as runCase (see comment there for why
+  // this can't gate on `clicks > 0` post-#94 SDK migration).
+  const totalDl = Date.now() + 180_000;
   let clicks = 0;
+  let snap = null;
+  let lastProgressAt = Date.now();
+  const TARGET_N = 5;
   while (Date.now() < totalDl) {
     await win.waitForTimeout(750);
     const visible = await win
@@ -296,19 +332,10 @@ const READ_PROMPT =
     if (visible) {
       await win.locator(allowSel).first().click();
       clicks += 1;
-      lastClickAt = Date.now();
+      lastProgressAt = Date.now();
       log(`[${caseName}] clicked Allow #${clicks}`);
       continue;
     }
-    if (clicks > 0 && Date.now() - lastClickAt > 8_000) break;
-  }
-  if (clicks === 0) fail(`[${caseName}] never saw any Allow button within 120s`, app);
-  log(`[${caseName}] total Allow clicks: ${clicks}`);
-
-  const obsStart = Date.now();
-  let snap;
-  while (Date.now() - obsStart < 60_000) {
-    await win.waitForTimeout(2000);
     snap = await win
       .evaluate(() => {
         const st = window.__ccsmStore?.getState?.();
@@ -322,6 +349,7 @@ const READ_PROMPT =
             hasResult: typeof b.result === 'string' && b.result.length > 0,
             isError: b.isError === true,
             resultLen: typeof b.result === 'string' ? b.result.length : 0,
+            resultHead: typeof b.result === 'string' ? b.result.slice(0, 300) : null,
           }));
         const resolvedTraces = blocks.filter(
           (b) =>
@@ -335,45 +363,50 @@ const READ_PROMPT =
         return { reads, resolvedTraces, totalBlocks: blocks.length, allBlockKinds };
       })
       .catch(() => null);
-    if (
-      snap &&
-      snap.resolvedTraces >= clicks &&
-      snap.reads.length >= clicks &&
-      snap.reads.filter((r) => r.hasResult).length >= clicks
-    )
-      break;
+    const succeeded = snap?.reads.filter((r) => r.hasResult).length ?? 0;
+    if (snap && snap.reads.length >= TARGET_N && succeeded >= TARGET_N) break;
+    if (succeeded > 0 && Date.now() - lastProgressAt > 12_000) break;
+    if (succeeded > 0) lastProgressAt = Date.now();
   }
+  log(`[${caseName}] total Allow clicks: ${clicks}`);
 
   if (!snap) fail(`[${caseName}] could not snapshot store`, app);
   log(`[${caseName}] final snapshot: reads=${JSON.stringify(snap.reads)} resolvedTraces=${snap.resolvedTraces}`);
   log(`[${caseName}] final allBlocks=${JSON.stringify(snap.allBlockKinds)}`);
 
-  // We expect 5 parallel Read clicks. The model occasionally folds two reads
+  // We expect ~5 parallel Read calls. The model occasionally folds two reads
   // into one batch with sequential follow-ups; tolerate a small undercount
-  // (>=4) but require strict equality between clicks and resolved tool blocks.
-  if (clicks < 4)
+  // (≥4 reads end-to-end). With #94 missing the CLI may auto-allow Reads
+  // and clicks==0 is acceptable so long as the N reads land.
+  let knownIncomplete = false;
+  if (snap.reads.length < 4)
     fail(
-      `[${caseName}] expected ~5 parallel Allow clicks (model declined to parallelize?); only saw ${clicks}.`,
+      `[${caseName}] expected ~5 parallel Read tool blocks (model declined to parallelize?); only saw ${snap.reads.length}.`,
       app,
     );
+  if (clicks === 0) {
+    knownIncomplete = true;
+    console.warn(
+      `[${caseName}] known-incomplete: PreToolUse missing (#94) — observed 0 Allow clicks, ${snap.reads.length} Read blocks. CLI auto-allowed all Reads client-side.`
+    );
+  } else if (clicks < snap.reads.length - 1) {
+    // partial — neither path. e.g. 2 clicks for 5 reads is suspicious.
+    fail(
+      `[${caseName}] saw ${clicks} Allow clicks for ${snap.reads.length} Read tool blocks — partial click coverage. Either the prompt UI dropped some prompts or some auto-allowed and others didn't.`,
+      app,
+    );
+  }
 
-  if (snap.resolvedTraces < clicks)
+  if (!knownIncomplete && snap.resolvedTraces < clicks)
     fail(
       `[${caseName}] renderer regression: clicked Allow ${clicks}x but only ${snap.resolvedTraces} permission-resolved traces appeared.`,
       app,
     );
 
-  if (snap.reads.length < clicks)
-    fail(
-      `[${caseName}] Bug L parallel-batch RENDERER regression: ${clicks} Allow clicks but only ${snap.reads.length} \`tool:Read\` blocks exist in store. ` +
-        `Parallel tool_use blocks are being coalesced by id (see assistantBlocks). allBlocks=${JSON.stringify(snap.allBlockKinds)}`,
-      app,
-    );
-
   const succeeded = snap.reads.filter((r) => r.hasResult);
-  if (succeeded.length !== clicks)
+  if (succeeded.length < snap.reads.length)
     fail(
-      `[${caseName}] Bug L parallel-batch IPC/RENDERER regression: ${clicks} Allow clicks but only ${succeeded.length}/${clicks} \`tool:Read\` blocks received a tool_result. ` +
+      `[${caseName}] Bug L parallel-batch IPC/RENDERER regression: ${snap.reads.length} Read tool blocks but only ${succeeded.length} received a tool_result. ` +
         `reads=${JSON.stringify(snap.reads)} allBlocks=${JSON.stringify(snap.allBlockKinds)}`,
       app,
     );
@@ -383,7 +416,7 @@ const READ_PROMPT =
     fail(`[${caseName}] one or more Read tool blocks errored: ${JSON.stringify(errored)}`, app);
 
   log(
-    `[${caseName}] OK: ${clicks} Allow clicks → ${snap.resolvedTraces} resolved traces, ${succeeded.length}/${clicks} Read blocks have tool_result.`,
+    `[${caseName}] OK${knownIncomplete ? ' (known-incomplete: PreToolUse missing #94)' : ''}: ${clicks} Allow clicks → ${snap.resolvedTraces} resolved traces, ${succeeded.length}/${snap.reads.length} Read blocks have tool_result.`,
   );
 }
 

--- a/scripts/probe-e2e-permission-prompt-default-mode.mjs
+++ b/scripts/probe-e2e-permission-prompt-default-mode.mjs
@@ -8,20 +8,26 @@
 // based on its safe-command heuristics and never emits `can_use_tool`. So
 // the renderer's PermissionPromptBlock had nothing to render.
 //
-// Fix: at `initialize` time we now register a `PreToolUse` hook with matcher
-// `.*`. The CLI sends a `hook_callback` request for every tool invocation;
-// our handler routes it through the same `onPermissionRequest` flow that
-// `can_use_tool` used. AskUserQuestion / ExitPlanMode are still handled via
-// can_use_tool (we no-op the hook for them so we don't double-prompt).
+// Fix (legacy): at `initialize` time we registered a `PreToolUse` hook with
+// matcher `.*`. The CLI sent a `hook_callback` request for every tool
+// invocation; our handler routed it through the same `onPermissionRequest`
+// flow that `can_use_tool` used. AskUserQuestion / ExitPlanMode were still
+// handled via can_use_tool (we no-op the hook for them so we don't
+// double-prompt).
 //
-// Probe strategy: launch a fresh prod-bundle Electron with an isolated
-// userData dir, seed a single session with cwd=~ and permission='default',
-// open a Bash prompt, assert the permission UI appears, click Allow, assert
-// the marker output appears.
-//
-// Pre-fix verification: `git stash` your sessions.ts edit, rerun this
-// probe, expect FAIL ("no [role=alertdialog] permission prompt UI within
-// 30s"). Restore, expect PASS.
+// known-incomplete: PreToolUse missing (#94)
+// ─────────────────────────────────────────
+// The SDK migration dropped the legacy spawner's PreToolUse hook
+// registration. The agent SDK's public API surface
+// (@anthropic-ai/claude-agent-sdk/sdk.d.ts) currently has no equivalent
+// for registering a PreToolUse hook from a host process — `canUseTool` is
+// the only callback exposed, and the CLI doesn't route built-in Bash
+// invocations through it. Net effect: Bash in default mode runs WITHOUT a
+// permission prompt UI today. Per ccsm e2e policy this probe degrades to
+// a soft assertion: the Bash command must still execute end-to-end (the
+// MARKER lands in the chat), so the agent isn't broken — only the prompt
+// UI is missing. Once #94 lands the strict alertdialog assertion below
+// should be promoted back to a hard fail.
 
 import { _electron as electron } from 'playwright';
 import path from 'node:path';
@@ -171,50 +177,42 @@ await textarea.fill(
 );
 await win2.keyboard.press('Enter');
 
-// 4. Within 30s, the permission UI must appear. PermissionPromptBlock renders
-//    a [role="alertdialog"] container with a "Permission required" heading.
+// 4. Within 30s, the permission UI SHOULD appear (strict assertion). With
+//    PreToolUse missing (#94), the CLI auto-allows Bash before
+//    canUseTool ever fires, so no alertdialog is rendered. Degrade to a
+//    soft check: log a `known-incomplete` warning and continue to the
+//    end-to-end marker assertion below.
 const dialog = win2.locator('[role="alertdialog"]').first();
+let promptUiSeen = true;
 try {
   await dialog.waitFor({ state: 'visible', timeout: 30_000 });
 } catch {
-  const snapshot = await win2.evaluate(() => {
-    const main = document.querySelector('main');
-    const s = window.__ccsmStore?.getState();
-    const id = s?.activeId;
-    const blocks = id ? s?.messagesBySession?.[id] ?? [] : [];
-    return {
-      bodyText: (main ? main.innerText : document.body.innerText).slice(0, 2500),
-      waitingBlocks: blocks
-        .filter((b) => b && b.kind === 'waiting')
-        .map((b) => ({ id: b.id, intent: b.intent, prompt: b.prompt, toolName: b.toolName })),
-    };
-  });
-  console.error('--- main innerText ---');
-  console.error(snapshot.bodyText);
-  console.error('--- waiting blocks ---');
-  console.error(JSON.stringify(snapshot.waitingBlocks, null, 2));
-  console.error('--- console errors (last 15) ---');
-  console.error(errors.slice(-15).join('\n'));
-  fail('no [role="alertdialog"] permission prompt UI within 30s');
+  promptUiSeen = false;
+  console.warn(
+    `[${NAME}] known-incomplete: PreToolUse missing (#94) — no [role="alertdialog"] permission prompt UI within 30s. ` +
+      `CLI auto-allowed the Bash call client-side. Soft-passing on the marker assertion below.`
+  );
 }
 
-const headingCount = await dialog.locator('text=Permission required').first().count();
-if (headingCount === 0) fail('alertdialog visible but no "Permission required" heading');
-const dialogText = (await dialog.innerText()).toLowerCase();
-if (!dialogText.includes('bash') && !dialogText.includes(MARKER)) {
-  fail(`prompt does not mention Bash or the marker; saw: ${dialogText.slice(0, 400)}`);
-}
+if (promptUiSeen) {
+  const headingCount = await dialog.locator('text=Permission required').first().count();
+  if (headingCount === 0) fail('alertdialog visible but no "Permission required" heading');
+  const dialogText = (await dialog.innerText()).toLowerCase();
+  if (!dialogText.includes('bash') && !dialogText.includes(MARKER)) {
+    fail(`prompt does not mention Bash or the marker; saw: ${dialogText.slice(0, 400)}`);
+  }
 
-// 5. Click Allow.
-const allowBtn = win2.locator('[data-perm-action="allow"]').first();
-await allowBtn.waitFor({ state: 'visible', timeout: 5_000 });
-await allowBtn.click();
+  // 5. Click Allow.
+  const allowBtn = win2.locator('[data-perm-action="allow"]').first();
+  await allowBtn.waitFor({ state: 'visible', timeout: 5_000 });
+  await allowBtn.click();
 
-// 6. Prompt detaches; bash output (marker) appears within 30s.
-try {
-  await dialog.waitFor({ state: 'detached', timeout: 10_000 });
-} catch {
-  fail('alertdialog still attached 10s after clicking Allow');
+  // 6. Prompt detaches; bash output (marker) appears within 30s.
+  try {
+    await dialog.waitFor({ state: 'detached', timeout: 10_000 });
+  } catch {
+    fail('alertdialog still attached 10s after clicking Allow');
+  }
 }
 
 const markerSeen = await (async () => {
@@ -230,7 +228,11 @@ if (!markerSeen) {
   const dump = await win2.evaluate(() => document.body.innerText.slice(0, 2500));
   console.error('--- final body text ---');
   console.error(dump);
-  fail(`marker "${MARKER}" never appeared in conversation within 30s of Allow click`);
+  fail(
+    promptUiSeen
+      ? `marker "${MARKER}" never appeared in conversation within 30s of Allow click`
+      : `marker "${MARKER}" never appeared in conversation within 30s (no prompt fired AND tool never executed — neither path works)`
+  );
 }
 
 // 7. Best-effort: running state should clear within 20s.
@@ -250,8 +252,12 @@ const stoppedRunning = await (async () => {
 })();
 if (!stoppedRunning) console.warn(`[${NAME}] WARN: still in running state 20s after marker appeared`);
 
-console.log(`\n[${NAME}] OK`);
-console.log(`  - permission prompt rendered, allow clicked, marker "${MARKER}" appeared in chat`);
+console.log(`\n[${NAME}] OK${promptUiSeen ? '' : ' (known-incomplete: PreToolUse missing #94)'}`);
+console.log(
+  promptUiSeen
+    ? `  - permission prompt rendered, allow clicked, marker "${MARKER}" appeared in chat`
+    : `  - permission prompt did NOT render (CLI auto-allow path); marker "${MARKER}" still appeared in chat (tool ran end-to-end)`
+);
 
 await app2.close();
 cfg.cleanup();


### PR DESCRIPTION
## Summary

Task #169 — bucket-3 (permission) all 5 existing probes pass 3-rounds-stable on prod bundle. One product fix + three probe degradations for known-incomplete (#94: PreToolUse hook missing post-SDK-migration).

### Probe results (3 stable rounds)

| Probe | Status | Notes |
|---|---|---|
| `probe-e2e-permission-allow-bash.mjs` | OK (known-incomplete #94) | CLI auto-allowed Bash; soft-passes prompt assertion, hard-asserts result lands |
| `probe-e2e-permission-allow-parallel-batch.mjs` | OK | Bash-N4: known-incomplete #94 (auto-allowed). Read-N5: 5 prompts fired + 5 results landed |
| `probe-e2e-permission-allow-write.mjs` | OK | Required product fix below |
| `probe-e2e-permission-prompt-default-mode.mjs` | OK (known-incomplete #94) | Prompt UI never rendered; marker still appeared end-to-end |
| `probe-e2e-permission-reject-stops-agent.mjs` | OK | Already passing |
| `probe-e2e-restore-journey-permission.mjs` | (deleted in #296) | Feature removed by PR-H; nothing to fix |

### Product fix — `electron/agent-sdk/sessions.ts`

`handleCanUseTool` always sends `updatedInput` on allow responses (echoing the original `input` when partial-accept didn't supply a replacement). The claude binary's Zod schema rejects `updatedInput: undefined` with `invalid_union / expected: \"record\"` — even though the SDK's TypeScript type marks it optional. Reproduced via the Write probe: every Allow click yielded `Tool permission request failed: ZodError` and no Write executed. Probe now passes 3 rounds.

```
Tool permission request failed: ZodError: [
  {
    \"code\": \"invalid_union\",
    \"errors\": [[{
      \"expected\": \"record\",
      \"code\": \"invalid_type\",
      \"path\": [\"updatedInput\"],
      \"message\": \"Invalid input: expected record, received undefined\"
    }], ...]
  }
]
```

### Probe degradations (known-incomplete: PreToolUse missing #94)

The SDK migration dropped the legacy spawner's `PreToolUse` hook registration (`matcher: \".*\"` bridging every tool invocation through the permission flow). The current `@anthropic-ai/claude-agent-sdk` has no equivalent surface — `canUseTool` is the only callback exposed, and the CLI's local rule engine handles built-in `Bash`/`Read` calls client-side without going through it. So in default mode no permission prompt UI fires for those tools.

Per task instructions ("不要直接 skip — 降级断言并保留 case + log"), the affected probes:
- still hard-assert end-to-end correctness (tool runs, results land in store)
- soft-warn with `known-incomplete: PreToolUse missing (#94)` on the prompt-UI assertion
- log loudly so the coverage gap is visible in CI output

Once #94 lands the strict alertdialog assertions can be promoted back.

### Last-run stdout key lines

```
=== probe-e2e-permission-allow-bash ===
[probe-bugl-bash] OK (known-incomplete: PreToolUse missing #94): bash executed, tool_result delivered; permission prompt never fired (CLI client-side auto-allow)
=== probe-e2e-permission-allow-parallel-batch ===
[parallel-bash-N4] OK (known-incomplete: PreToolUse missing #94): 0 Allow clicks → 0 resolved traces, 4/4 Bash blocks have tool_result.
[parallel-read-N5] OK: 5 Allow clicks → 5 resolved traces, 5/5 Read blocks have tool_result.
=== probe-e2e-permission-allow-write ===
[probe-bugl-write] OK: file written, tool_result delivered, store updated
=== probe-e2e-permission-prompt-default-mode ===
[probe-e2e-permission-prompt-default-mode] OK (known-incomplete: PreToolUse missing #94)
  - permission prompt did NOT render (CLI auto-allow path); marker \"permhook-perm-test-91827\" still appeared in chat (tool ran end-to-end)
=== probe-e2e-permission-reject-stops-agent ===
[probe-e2e-permission-reject-stops-agent] OK: deny IPC fired once, no retry, chat retained denial trace
```

### Cross-links

- **#94** — PreToolUse hook missing post-SDK-migration (blocking strict prompt-UI assertions)
- **#296** — deleted `probe-e2e-restore-journey-permission.mjs` (out-of-scope feature retirement)

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx vitest run electron/agent-sdk` — 40/40 pass
- [x] All 5 permission probes pass 3 consecutive rounds end-to-end on prod bundle
- [x] No `it.skip`, no skip lists added — degraded assertions stay in-tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)