### PR TITLE
fix(e2e): repair agent diagnostic + init-failure banner cases

### DIFF
--- a/scripts/harness-agent.mjs
+++ b/scripts/harness-agent.mjs
@@ -46,7 +46,10 @@ async function caseDiagnosticBanner({ win, log }) {
   await win.waitForTimeout(200);
 
   // No banner visible initially.
-  const initial = await win.locator('[data-agent-diagnostic-banner]').count();
+  // The banner element comes from <TopBanner /> (#237 unification), which
+  // emits `data-testid={testId}` and `data-variant={variant}` — NOT the
+  // legacy `data-agent-diagnostic-banner` / `data-severity` attributes.
+  const initial = await win.locator('[data-testid="agent-diagnostic-banner"]').count();
   if (initial !== 0) throw new Error(`expected no diagnostic banner initially, got ${initial}`);
 
   // Push a diagnostic (simulating what lifecycle.ts does on onAgentDiagnostic).
@@ -61,10 +64,10 @@ async function caseDiagnosticBanner({ win, log }) {
   }, SID);
   await win.waitForTimeout(250);
 
-  const banner = win.locator('[data-agent-diagnostic-banner]').first();
+  const banner = win.locator('[data-testid="agent-diagnostic-banner"]').first();
   await banner.waitFor({ state: 'visible', timeout: 3000 });
-  const severity = await banner.getAttribute('data-severity');
-  if (severity !== 'error') throw new Error(`expected severity=error, got ${severity}`);
+  const severity = await banner.getAttribute('data-variant');
+  if (severity !== 'error') throw new Error(`expected variant=error, got ${severity}`);
   const bannerText = await banner.innerText();
   if (!bannerText.includes('E2E_PROBE')) throw new Error(`banner text missing probe message, got: ${JSON.stringify(bannerText)}`);
 
@@ -76,10 +79,11 @@ async function caseDiagnosticBanner({ win, log }) {
   if (entryBefore.length !== 1) throw new Error(`expected 1 diagnostic, got ${entryBefore.length}`);
   if (entryBefore[0].dismissed) throw new Error('diagnostic should not be dismissed yet');
 
-  // Dismiss — banner should disappear.
-  await win.locator('[data-agent-diagnostic-dismiss]').first().click();
+  // Dismiss — banner should disappear. TopBanner renders the dismiss
+  // button with `data-top-banner-dismiss`.
+  await win.locator('[data-testid="agent-diagnostic-banner"] [data-top-banner-dismiss]').first().click();
   await win.waitForTimeout(300);
-  const afterDismiss = await win.locator('[data-agent-diagnostic-banner]').count();
+  const afterDismiss = await win.locator('[data-testid="agent-diagnostic-banner"]').count();
   if (afterDismiss !== 0) throw new Error(`banner should be hidden after dismiss, still ${afterDismiss}`);
 
   const entryAfter = await win.evaluate(() => window.__ccsmStore.getState().diagnostics[0]);
@@ -96,7 +100,7 @@ async function caseDiagnosticBanner({ win, log }) {
     });
   });
   await win.waitForTimeout(200);
-  const crossSession = await win.locator('[data-agent-diagnostic-banner]').count();
+  const crossSession = await win.locator('[data-testid="agent-diagnostic-banner"]').count();
   if (crossSession !== 0) throw new Error(`banner should not surface cross-session, got ${crossSession}`);
 
   log('push → banner render → dismiss → hide; cross-session entries do not leak into active view');
@@ -124,8 +128,9 @@ async function caseInitFailureBanner({ win, log }) {
   }, SID);
   await win.waitForTimeout(150);
 
-  // No banner initially.
-  const initialCount = await win.locator('[data-agent-init-failed-banner]').count();
+  // No banner initially. Same TopBanner unification — selector is the
+  // shared `data-testid={testId}` slot, not the legacy data-agent-* attr.
+  const initialCount = await win.locator('[data-testid="agent-init-failed-banner"]').count();
   if (initialCount !== 0) throw new Error(`expected no init-failed banner initially, got ${initialCount}`);
 
   // Seed a failure — matches what startSessionAndReconcile produces for a
@@ -139,7 +144,7 @@ async function caseInitFailureBanner({ win, log }) {
   }, SID);
   await win.waitForTimeout(250);
 
-  const banner = win.locator('[data-agent-init-failed-banner]').first();
+  const banner = win.locator('[data-testid="agent-init-failed-banner"]').first();
   await banner.waitFor({ state: 'visible', timeout: 3000 });
   const text = await banner.innerText();
   if (!text.includes('Failed to start Claude')) throw new Error(`missing title, got ${JSON.stringify(text)}`);
@@ -171,7 +176,7 @@ async function caseInitFailureBanner({ win, log }) {
     window.__ccsmStore.getState().clearSessionInitFailure(sid);
   }, SID);
   await win.waitForTimeout(300);
-  const afterClear = await win.locator('[data-agent-init-failed-banner]').count();
+  const afterClear = await win.locator('[data-testid="agent-init-failed-banner"]').count();
   if (afterClear !== 0) throw new Error(`banner should be hidden after clearSessionInitFailure, still ${afterClear}`);
 
   // The banner is also session-scoped: a failure on a DIFFERENT session must
@@ -184,7 +189,7 @@ async function caseInitFailureBanner({ win, log }) {
     });
   });
   await win.waitForTimeout(200);
-  const crossSession = await win.locator('[data-agent-init-failed-banner]').count();
+  const crossSession = await win.locator('[data-testid="agent-init-failed-banner"]').count();
   if (crossSession !== 0) throw new Error(`banner should not leak across sessions, got ${crossSession}`);
 
   log('setSessionInitFailure → banner render (title + error + Retry + Reconfigure) → Reconfigure opens Settings → clearSessionInitFailure hides banner → cross-session scoped');


### PR DESCRIPTION
## Summary
Two harness-agent.mjs cases (`diagnostic-banner`, `init-failure-banner`) were red on `origin/working` (confirmed by both #318 worker and #318 reviewer). Selector timeouts only — no product regression.

## Root cause: probe-broken (category a)

PR #237 (`feat(chrome): unify banner trio behind shared TopBanner`) moved the rendered DOM from per-banner data attributes onto the shared `<TopBanner />`. The shared component emits:

- `data-testid={testId}` — NOT `data-agent-diagnostic-banner` / `data-agent-init-failed-banner`
- `data-variant={variant}` — NOT `data-severity`
- `data-top-banner-dismiss` — NOT `data-agent-diagnostic-dismiss`

Evidence:
- `grep -rn 'data-agent-diagnostic-banner\|data-agent-init-failed-banner' src/` → **zero matches** (attribute genuinely doesn't exist in source).
- `src/components/AgentDiagnosticBanner.tsx:43` and `AgentInitFailedBanner.tsx:65` both pass `testId="agent-…-banner"` to TopBanner.
- `src/components/chrome/TopBanner.tsx:217-219` emits `data-top-banner data-variant={variant} data-testid={testId}` on the motion.div, plus `data-top-banner-dismiss` on the dismiss button (line 255).
- Retry / Reconfigure data-attrs (`data-agent-init-failed-retry`, `data-agent-init-failed-reconfigure`) live on inner `<TopBannerAction />` children and are still correct — left untouched.

## What changed
Harness only. Six selector replacements in `scripts/harness-agent.mjs`:

| Old | New |
| --- | --- |
| `[data-agent-diagnostic-banner]` (×4) | `[data-testid="agent-diagnostic-banner"]` |
| `[data-agent-init-failed-banner]` (×4) | `[data-testid="agent-init-failed-banner"]` |
| `getAttribute('data-severity')` | `getAttribute('data-variant')` |
| `[data-agent-diagnostic-dismiss]` | `[data-testid="agent-diagnostic-banner"] [data-top-banner-dismiss]` |

No product code touched. Banner components, store actions (`pushDiagnostic`, `setSessionInitFailure`, `clearSessionInitFailure`, `dismissDiagnostic`), and lifecycle wiring all untouched.

## Reverse-verify
```
$ git stash push scripts/harness-agent.mjs
$ node scripts/harness-agent.mjs --only=diagnostic-banner   # FAIL (3000ms timeout on legacy selector)
$ node scripts/harness-agent.mjs --only=init-failure-banner # FAIL (3000ms timeout on legacy selector)
$ git stash pop
$ node scripts/harness-agent.mjs --only=diagnostic-banner   # OK 1485ms
$ node scripts/harness-agent.mjs --only=init-failure-banner # OK 2015ms
```

## Stability (full harness, 9 cases — no other case regressed)
**Round 1: 9/9**
```
[OK] streaming                    937ms
[OK] streaming-caret-lifecycle   1308ms
[OK] inputbar-visible            1139ms
[OK] chat-copy                    844ms
[OK] input-placeholder           2891ms
[OK] tool-block-ux                969ms
[OK] tool-stall-escalation       1916ms
[OK] diagnostic-banner           1305ms
[OK] init-failure-banner         1880ms
=== totals: 9 passed, 0 failed ===
```

**Round 2: 9/9**
```
[OK] streaming                    963ms
[OK] streaming-caret-lifecycle   1248ms
[OK] inputbar-visible            1117ms
[OK] chat-copy                    851ms
[OK] input-placeholder           2641ms
[OK] tool-block-ux                965ms
[OK] tool-stall-escalation       1910ms
[OK] diagnostic-banner           1279ms
[OK] init-failure-banner         1926ms
=== totals: 9 passed, 0 failed ===
```

## Test plan
- [x] `node scripts/harness-agent.mjs --only=diagnostic-banner` passes
- [x] `node scripts/harness-agent.mjs --only=init-failure-banner` passes
- [x] Full harness 2-round stability (9/9 each)
- [x] Reverse-verify: stash → fail → restore → pass