### PR TITLE
fix(e2e): scrub harness-perm drafts via saveState IPC

### DIFF
--- a/scripts/harness-perm.mjs
+++ b/scripts/harness-perm.mjs
@@ -31,6 +31,36 @@ import { runHarness } from './probe-helpers/harness-runner.mjs';
 // Shared helper: ensure a session exists with a usable cwd so InputBar enables
 // the textarea. Mirrors the seed pattern used across the source probes.
 async function seedSession(win, { sid = 's-perm', cwd = 'C:/x' } = {}) {
+  // Scrub the composer-draft cache BEFORE touching the store. The drafts
+  // module (src/stores/drafts.ts) keeps a module-scope `cache` Map that
+  // outlives `resetBetweenCases` — once a prior case typed into the
+  // composer (e.g. the `keyboard.press('n')` in casePermissionPrompt that
+  // landed inside the textarea before autoFocus committed), the cached
+  // entry hydrates back into InputBar's initial `value` on the next case's
+  // mount, focuses the composer, and PermissionPromptBlock's auto-focus
+  // exception clause (composer focused + non-empty → don't steal) keeps
+  // Reject from getting focus. That's the root cause #320 chased.
+  //
+  // Two-pronged scrub (no DOM input — PR #320 used composer.fill('') + blur
+  // and that introduced a NEW focus race against the permission-prompt
+  // autoFocus path, ~50% flake on the previously-stable case):
+  //   1. `__ccsmDrafts._resetForTests()` clears the in-memory Map. Exposed
+  //      from drafts.ts purely for harness use, mirroring `__ccsmStore` /
+  //      `__ccsmI18n`.
+  //   2. `saveState('drafts', empty)` zeroes the persisted blob so a
+  //      future renderer reload (or next launch) doesn't re-hydrate the
+  //      stale entry.
+  await win.evaluate(async () => {
+    window.__ccsmDrafts?._resetForTests?.();
+    try {
+      await window.ccsm?.saveState?.('drafts', JSON.stringify({ version: 1, drafts: {} }));
+    } catch {
+      /* persist failure here is non-fatal — in-memory wipe is what matters
+       * for the in-process focus race; persisted-blob wipe is defense in
+       * depth for next-launch hydration. */
+    }
+  });
+
   await win.evaluate(({ sid, cwd }) => {
     window.__ccsmStore.setState({
       groups: [{ id: 'g1', name: 'G1', collapsed: false, kind: 'normal' }],
@@ -367,18 +397,13 @@ async function casePermissionTruncateWidth({ win, log }) {
 async function casePermissionSequentialFocus({ win, log }) {
   await seedSession(win);
 
-  // Reset draft-cache + blur textarea so a prior case's leftover text
-  // (e.g. shortcut-scope leaves "helloY") doesn't steal focus during
-  // subsequent autoFocus assertions. The drafts cache is module-scope and
-  // DB cleanup alone can't reach it.
-  const ta = win.locator('textarea').first();
-  await ta.waitFor({ state: 'visible', timeout: 5000 });
-  await ta.fill('');
-  await win.evaluate(() => {
-    if (document.activeElement instanceof HTMLElement) document.activeElement.blur();
-    document.body.focus?.();
-  });
-  await win.waitForTimeout(100);
+  // Note: previously this case did `ta.fill('') + blur` here to defend
+  // against a stale draft (e.g. shortcut-scope leaves "helloY") stealing
+  // focus during subsequent autoFocus assertions. seedSession now scrubs
+  // the drafts cache directly via `__ccsmDrafts._resetForTests()`, so the
+  // DOM-level workaround is unnecessary — and the blur half of it
+  // introduced a focus race against permission-prompt's autoFocus on
+  // some Chromium builds.
 
   // Inject first permission.
   await injectWaiting(win, {

--- a/src/stores/drafts.ts
+++ b/src/stores/drafts.ts
@@ -96,3 +96,17 @@ export function _resetForTests(): void {
   if (writeTimer) clearTimeout(writeTimer);
   writeTimer = null;
 }
+
+// E2E debug affordance — mirrors `window.__ccsmStore` / `window.__ccsmI18n`.
+// Themed harnesses run multiple cases inside one Electron process; the
+// module-scope `cache` survives the per-case store reset, so a draft typed
+// during case N (e.g. the "n" keypress in casePermissionPrompt) leaks into
+// the InputBar's initial value for case N+1, focuses the composer, and steals
+// focus from the next permission prompt (see PR #320 root-cause writeup).
+// Exposing `_resetForTests` on the window lets the harness scrub the cache
+// without going through DOM input events that introduce focus races.
+if (typeof window !== 'undefined') {
+  (window as unknown as { __ccsmDrafts?: { _resetForTests: () => void } }).__ccsmDrafts = {
+    _resetForTests
+  };
+}


### PR DESCRIPTION
## Summary

Fixes the 2 known-red cases in `scripts/harness-perm.mjs` (`permission-a11y`, `permission-partial-accept`) without re-introducing the focus-race flake that got #320 closed.

Replaces #320's `composer.fill('') + blur` approach with a direct in-memory drafts cache reset, no DOM input.

Closes follow-up of #320.

## Why a different approach from #320

#320 was REJECTED by reviewer because `composer.fill('') + blur` introduced ~50% flake on the previously-stable `permission-prompt` case. The blur half raced against PermissionPromptBlock's autoFocus on some Chromium builds.

Root cause analysis from #320 still holds: drafts.ts keeps a module-scope `cache` Map that survives `resetBetweenCases`. A draft typed in case N (e.g. the `'n'` keypress in `casePermissionPrompt` that landed in the textarea before autoFocus committed) hydrates back into InputBar's initial value for case N+1, focuses the composer, and PermissionPromptBlock's auto-focus exception clause (composer focused + non-empty -> don't steal) keeps Reject from getting focus.

This PR sidesteps DOM entirely:

1. **`src/stores/drafts.ts`**: expose a `__ccsmDrafts` debug handle (mirrors existing `__ccsmStore` / `__ccsmI18n` patterns) with `_resetForTests`. Pure testability surface; no production behavior change.
2. **`scripts/harness-perm.mjs`**: `seedSession()` now calls `__ccsmDrafts._resetForTests()` (clears the in-memory cache) AND `saveState('drafts', empty)` (zeros the persisted blob for next-launch hydration) BEFORE the store `setState`. No textarea.fill, no blur. The reviewer's recommended approach used `saveState` alone, but that's insufficient on its own because the in-memory cache is what `getDraft()` reads inside the same process — wiping the persisted blob only protects the next launch.
3. Drop the now-redundant `fill('') + blur` scrub at the top of `casePermissionSequentialFocus` (same workaround, same flake risk).

## 2-round green proof

Both rounds run from a clean pool, full `node scripts/harness-perm.mjs`:

```
=== ROUND 1 ===
=== harness=perm summary (24357ms wall) ===
  [OK] permission-prompt                          1272ms
  [OK] permission-mode-strict                      112ms
  [OK] permission-focus-not-stolen                1218ms
  [OK] permission-shortcut-scope                  1290ms
  [OK] permission-nested-input                     907ms
  [OK] permission-truncate-width                   920ms
  [OK] permission-sequential-focus                1419ms
  [OK] permission-allow-always                    1483ms
  [OK] permission-a11y                             854ms
  [OK] permission-partial-accept                   972ms
  [OK] permission-auto-and-titles                  439ms
  [OK] permission-reject-stops-agent              1975ms
=== totals: 12 passed, 0 failed, 12 total ===
EXIT=0

=== ROUND 2 ===
=== harness=perm summary (16153ms wall) ===
  [OK] permission-prompt                          1307ms
  [OK] permission-mode-strict                      107ms
  [OK] permission-focus-not-stolen                1258ms
  [OK] permission-shortcut-scope                  1344ms
  [OK] permission-nested-input                     933ms
  [OK] permission-truncate-width                   932ms
  [OK] permission-sequential-focus                1394ms
  [OK] permission-allow-always                    1414ms
  [OK] permission-a11y                             822ms
  [OK] permission-partial-accept                   947ms
  [OK] permission-auto-and-titles                  443ms
  [OK] permission-reject-stops-agent              1953ms
=== totals: 12 passed, 0 failed, 12 total ===
EXIT=0
```

`permission-prompt` (the case #320 broke), `permission-a11y`, and `permission-partial-accept` are all green in both rounds.

## No skips

Confirmed: no `.skip`, no `E2E_SKIP` env-var entry, no test removal. All 12 cases run on every invocation. Per `feedback_no_skipped_e2e.md`.

## Test plan

- [x] `node scripts/harness-perm.mjs` round 1: 12/12 green
- [x] `node scripts/harness-perm.mjs` round 2: 12/12 green
- [x] `permission-prompt` not regressed (the case #320 broke)
- [x] No skips added
- [x] No production focus logic touched (`PermissionPromptBlock.tsx` unchanged)

Generated with [Claude Code](https://claude.com/claude-code)