### PR TITLE
fix(e2e): stabilize notify-integration case in harness-agent

### DIFF
--- a/scripts/probe-e2e-notify-integration.mjs
+++ b/scripts/probe-e2e-notify-integration.mjs
@@ -50,6 +50,40 @@ function fail(msg) {
   process.exit(1);
 }
 
+// FLAKE FIX: `BrowserWindow.blur()` is asynchronous from the OS's perspective
+// (especially on Windows). If the probe drives `window.ccsm.notify(...)`
+// immediately after `w.blur()`, the IPC handler in `electron/notifications.ts`
+// can still see `shouldSuppressForFocus() === true` (line 103) and silently
+// drop the call — manifesting as "timeout waiting for notify* call". We blur
+// every window then poll until focus is actually gone, with a hide() fallback
+// for the stubborn launch-time case.
+async function blurAndWaitUnfocused(app, { allowHideFallback = true } = {}) {
+  await app.evaluate(async ({ BrowserWindow }, allowHide) => {
+    const stillFocused = () => BrowserWindow.getAllWindows()
+      .some((w) => !w.isDestroyed() && w.isFocused() && w.isVisible());
+    for (const w of BrowserWindow.getAllWindows()) {
+      try { w.blur(); } catch {}
+    }
+    const deadline = Date.now() + 3000;
+    while (Date.now() < deadline && stillFocused()) {
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    if (stillFocused() && allowHide) {
+      // Last resort for runners that hold focus on the launched Electron
+      // window (some headless / playwright environments). hide() reliably
+      // clears `isFocused()`; subsequent steps that need focus call
+      // `w.show()` + `w.focus()` explicitly anyway.
+      for (const w of BrowserWindow.getAllWindows()) {
+        try { w.hide(); } catch {}
+      }
+      const deadline2 = Date.now() + 1000;
+      while (Date.now() < deadline2 && stillFocused()) {
+        await new Promise((r) => setTimeout(r, 50));
+      }
+    }
+  }, allowHideFallback);
+}
+
 const { port: PORT, close: closeServer } = await startBundleServer(root);
 
 // HOME / USERPROFILE sanitization per project rule — the probe must not
@@ -141,15 +175,11 @@ try {
   console.log(`[probe-e2e-notify-integration] seeded sessionId=${sessionId}`);
 
   // ── 3. Blur the window so focus suppression doesn't gate the probe ──────
-  // The legacy electron Notification path is still gated by
-  // `BrowserWindow.isFocused()` in main; we explicitly drop focus so emits
-  // fan out to the @ccsm/notify wrapper. (We re-test focus suppression at
-  // step 7 below by re-focusing.)
-  await app.evaluate(({ BrowserWindow }) => {
-    for (const w of BrowserWindow.getAllWindows()) {
-      try { w.blur(); } catch {}
-    }
-  });
+  // The legacy electron Notification path is gated by `BrowserWindow.isFocused()`
+  // in main; we explicitly drop focus so emits fan out to the @ccsm/notify
+  // wrapper. (We re-test focus suppression at step 7 by re-focusing.)
+  // See `blurAndWaitUnfocused` for the rationale on polling.
+  await blurAndWaitUnfocused(app);
 
   const REQUEST_ID = 'probe-req-1';
 
@@ -346,11 +376,7 @@ try {
   // retry). Then verify cancellation: schedule a fresh retry and call the
   // resolvePermission IPC — the timer must have been removed without
   // firing.
-  await app.evaluate(({ BrowserWindow }) => {
-    for (const w of BrowserWindow.getAllWindows()) {
-      try { w.blur(); } catch {}
-    }
-  });
+  await blurAndWaitUnfocused(app);
 
   const installedRetry = await app.evaluate(() => {
     const g = globalThis;
@@ -619,11 +645,7 @@ try {
   const REJECT_REQ = 'probe-q-reject-1';
   // Ensure the window is blurred so focus suppression doesn't gate the
   // initial emit (case 8 above re-focused it).
-  await app.evaluate(({ BrowserWindow }) => {
-    for (const w of BrowserWindow.getAllWindows()) {
-      try { w.blur(); } catch {}
-    }
-  });
+  await blurAndWaitUnfocused(app);
 
   // Install a spy on `cancelQuestionRetry` that flags calls coming from
   // the router by wrapping the deps-injected reference, not the module
@@ -730,11 +752,7 @@ try {
   // The toast-action reject path (case 10c) routes through the default
   // router which focuses the main window. Blur again before firing the
   // next emit so focus suppression doesn't gate it.
-  await app.evaluate(({ BrowserWindow }) => {
-    for (const w of BrowserWindow.getAllWindows()) {
-      try { w.blur(); } catch {}
-    }
-  });
+  await blurAndWaitUnfocused(app);
   await win.evaluate((args) => {
     return window.ccsm.notify({
       sessionId: args.sessionId,


### PR DESCRIPTION
## Summary
Fixes a ~1-in-3 flake in the `notify-integration` e2e case. The case lives in `scripts/probe-e2e-notify-integration.mjs` (standalone probe), NOT in `scripts/harness-agent.mjs` — the harness has zero "notify" references. (Title kept per task brief; scope clarified here.)

## Root cause
`BrowserWindow.blur()` is asynchronous from the OS's perspective (notably Windows). The probe drove `window.ccsm.notify(...)` immediately after `w.blur()`, but `electron/notifications.ts:103` checks `shouldSuppressForFocus()` and silently drops the call when any window is still focused. Race manifested as `timeout waiting for notifyPermission call` in step 4.

## Fix
Extract a `blurAndWaitUnfocused(app)` helper that:
1. Calls `w.blur()` on every BrowserWindow.
2. Polls `BrowserWindow.isFocused()` for up to 3s until focus drops.
3. Falls back to `w.hide()` for the stubborn launch-time case (some headless / playwright environments hold focus even after explicit blur). Step 7 (focus-suppression assertion) explicitly calls `w.show(); w.focus();` before reading `shouldSuppressForFocus()`, so the hide fallback is recoverable.

Applied at all 4 blur sites (steps 3, 9, 10c, 11). No product code touched.

## Reverse-verify
Reproduced flake on `origin/working` HEAD (before this fix): run 1 OK, run 2 OK, run 3 FAIL with `timeout waiting for notifyPermission call`.

## 3-round green proof (post-rebase onto origin/working including #319)
```
=== RUN 1 ===
[probe-e2e-notify-integration] toast-action reject cancellation OK
[probe-e2e-notify-integration] rich done payload OK
[probe-e2e-notify-integration] OK
=== RUN 2 ===
[probe-e2e-notify-integration] toast-action reject cancellation OK
[probe-e2e-notify-integration] rich done payload OK
[probe-e2e-notify-integration] OK
=== RUN 3 ===
[probe-e2e-notify-integration] toast-action reject cancellation OK
[probe-e2e-notify-integration] rich done payload OK
[probe-e2e-notify-integration] OK
```
Plus 5 back-to-back green pre-rebase. Cumulative: 8/8 green, zero flakes after fix.

## Test plan
- [x] Reproduce flake on unmodified `origin/working`
- [x] Apply fix
- [x] 3 back-to-back full-probe runs all green
- [x] Rebase onto latest `origin/working` (PR #319 merged) — fast-forward, no conflicts
- [x] 3 more back-to-back runs post-rebase all green