### PR TITLE
chore: inline @ccsm/notify into main repo (drop private dep)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,9 @@ attention or a long-running turn finishes:
 - `turn_done` — a turn finished, and either took longer than 15 seconds,
   errored, or completed in a session that wasn't focused.
 
-On Windows, when the optional `@ccsm/notify` package is installed (it ships
-as an `optionalDependency`; see Wave 1B), CCSM uses Adaptive Toasts with
+On Windows, when the optional `electron-windows-notifications` native module
+is installed (it ships as an `optionalDependency` and may fail to build on
+machines without MSBuild — that's tolerated), CCSM uses Adaptive Toasts with
 inline buttons — clicking **Allow** / **Allow always** / **Reject** on the
 toast resolves the in-app permission prompt without bringing the window
 forward. On other platforms, or when the optional native module fails to
@@ -137,7 +138,7 @@ CCSM register both automatically. For `npm run dev` (no installer is run),
 register them once per machine:
 
 ```powershell
-pwsh node_modules/@ccsm/notify/scripts/setup-aumid.ps1
+pwsh scripts/setup-aumid.ps1
 ```
 
 Without this, the Adaptive Toast pipeline silently no-ops in dev mode and

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -508,7 +508,7 @@ app.whenReady().then(() => {
   }
   initDb();
 
-  // Wave 1D: bootstrap the optional `@ccsm/notify` Adaptive Toast pipeline.
+  // Wave 1D: bootstrap the optional the inlined notify module Adaptive Toast pipeline.
   // Wrapped in try/catch by the bootstrap helper itself; failure (missing
   // native deps, unregistered AUMID, non-win32) leaves the app running with
   // the legacy Electron Notification path. The router below routes toast
@@ -1305,7 +1305,7 @@ app.whenReady().then(() => {
       // count-dropped-to-0-because-CLI-self-crashed.
       selfExitCount: () => sessions.selfExitsSinceStart(),
       // Wave 1D: probe seam — exposed so `scripts/probe-e2e-notify-integration.mjs`
-      // can swap the @ccsm/notify importer for a fake without resorting to
+      // can swap the the inlined notify module importer for a fake without resorting to
       // `require` from inside `app.evaluate` (where it's not in scope).
       notify: notifyMod,
       notifyBootstrap: bootstrapMod,

--- a/electron/notifications.ts
+++ b/electron/notifications.ts
@@ -11,7 +11,7 @@ import { shouldSuppressForFocus, registerToastTarget } from './notify-bootstrap'
 import { scheduleQuestionRetry } from './notify-retry';
 
 // Wave 3 polish (#252): cap the assistant-message preview that the legacy
-// Electron Notification body renders. The @ccsm/notify Adaptive Toast
+// Electron Notification body renders. The the inlined notify module Adaptive Toast
 // re-truncates inside the SDK (xml/done.ts ASSISTANT_LINE_MAX = 80), so we
 // match the same budget here for consistency. Anything longer just waste
 // pixels in the OS banner.
@@ -26,12 +26,12 @@ export type NotificationEventType = 'permission' | 'question' | 'turn_done' | 't
 
 /**
  * Optional rich metadata callers (the renderer's `dispatchNotification`)
- * provide so we can fire a `@ccsm/notify` Adaptive Toast in parallel with
+ * provide so we can fire a the inlined notify module Adaptive Toast in parallel with
  * the basic `electron.Notification`. None of these fields are required — when
  * absent, only the legacy toast fires.
  */
 export interface NotifyExtras {
-  /** Stable id used by @ccsm/notify to dedupe + route activations. */
+  /** Stable id used by the inlined notify module to dedupe + route activations. */
   toastId?: string;
   sessionName?: string;
   groupName?: string;
@@ -63,7 +63,7 @@ export interface ShowNotificationPayload {
   body?: string;
   eventType?: NotificationEventType;
   silent?: boolean;
-  /** Optional rich metadata for the @ccsm/notify Adaptive Toast pipeline. */
+  /** Optional rich metadata for the the inlined notify module Adaptive Toast pipeline. */
   extras?: NotifyExtras;
 }
 
@@ -82,7 +82,7 @@ function cwdBasename(cwd: string | undefined): string {
 // suppressed because the window is already focused).
 //
 // Wave 1D: in addition to the legacy Electron Notification, fan out to the
-// optional `@ccsm/notify` Adaptive Toast pipeline when extras are supplied
+// optional the inlined notify module Adaptive Toast pipeline when extras are supplied
 // and the wrapper has loaded. Both fire in parallel with the in-app render —
 // failure of either path never blocks the other.
 export function showNotification(
@@ -109,7 +109,7 @@ export function showNotification(
   // chars as the legacy toast body so the OS banner conveys real context
   // instead of just "{name} is done". The Adaptive Toast pipeline already
   // does this via `xml/done.ts`; we mirror it here for parity on machines
-  // where @ccsm/notify is unavailable (non-win32, missing native deps).
+  // where the inlined notify module is unavailable (non-win32, missing native deps).
   let body = payload.body ?? '';
   if (
     payload.eventType === 'turn_done' &&
@@ -134,7 +134,7 @@ export function showNotification(
   });
   n.show();
 
-  // Fan out to @ccsm/notify if available + we have enough metadata. All four
+  // Fan out to the inlined notify module if available + we have enough metadata. All four
   // wrapper functions are async-no-throw; we fire-and-forget so the legacy
   // toast (already shown) isn't blocked by a slow native call.
   void emitAdaptiveToast(payload).catch(() => {

--- a/electron/notify-bootstrap.ts
+++ b/electron/notify-bootstrap.ts
@@ -1,4 +1,4 @@
-// Wave 1D — bootstrap integration for the optional `@ccsm/notify` package.
+// Wave 1D — bootstrap integration for the optional the inlined notify module package.
 //
 // The thin wrapper in `electron/notify.ts` (#267) exposes typed no-op
 // fallbacks so the rest of the app can call notify functions without caring
@@ -12,7 +12,7 @@
 //   3. Wraps everything in try/catch so a bad install (missing native deps,
 //      AUMID not registered, etc.) cannot block app startup.
 //
-// All entry points are no-ops on non-win32 platforms — phase 1 of @ccsm/notify
+// All entry points are no-ops on non-win32 platforms — phase 1 of the inlined notify module
 // only ships a Windows adapter.
 
 import { BrowserWindow } from 'electron';
@@ -27,12 +27,12 @@ import {
 // route adaptive toast activations unless the host process AUMID matches the
 // AUMID stamped on the Start Menu shortcut. In packaged builds NSIS sets the
 // shortcut up; for ad-hoc dev runs, see `scripts/setup-aumid.ps1` in the
-// `@ccsm/notify` package.
+// the inlined notify module package.
 const APP_ID = 'com.ccsm.app';
 const APP_NAME = 'CCSM';
 
 /**
- * Callback the bootstrap hands to `@ccsm/notify` so toast-button activations
+ * Callback the bootstrap hands to the inlined notify module so toast-button activations
  * can be routed back into the host. Wired by main.ts at app `ready`.
  *
  *  - `permission` toasts use `toastId === requestId` for the underlying
@@ -47,7 +47,7 @@ export type NotifyActionRouter = (event: ActionEvent) => void;
 let bootstrapped = false;
 
 /**
- * Configure the @ccsm/notify wrapper. Safe to call multiple times — only the
+ * Configure the the inlined notify module wrapper. Safe to call multiple times — only the
  * first invocation actually configures; subsequent calls are no-ops so the
  * onAction callback isn't replaced mid-flight (which would orphan in-flight
  * toasts).

--- a/electron/notify-impl/index.ts
+++ b/electron/notify-impl/index.ts
@@ -1,0 +1,32 @@
+// Public API surface for the inlined notify module.
+//
+// Originally vendored from the standalone `@ccsm/notify` package (v0.1.1).
+// Kept as a self-contained module under `electron/notify-impl/` so it can be
+// extracted again later if it ever needs to ship as a separate package.
+
+export { Notifier } from './notifier';
+export { ToastRegistry } from './registry';
+export { truncate, codePointLength } from './util/truncate';
+export { buildPermissionXml } from './xml/permission';
+export { buildQuestionXml } from './xml/question';
+export { buildDoneXml, formatElapsed } from './xml/done';
+export {
+  buildActionArgs,
+  parseActionArgs,
+  xmlEscape,
+} from './xml/common';
+
+export type {
+  ActionArgs,
+  ActionEvent,
+  ActionId,
+  DonePayload,
+  NotifierOptions,
+  PermissionPayload,
+  QuestionPayload,
+} from './types';
+
+export type { TruncateResult } from './util/truncate';
+export type { PlatformAdapter } from './platform/windows';
+export type { ToastCallback } from './registry';
+export type { XmlBuildOptions } from './xml/common';

--- a/electron/notify-impl/notifier.ts
+++ b/electron/notify-impl/notifier.ts
@@ -1,0 +1,117 @@
+// Platform-agnostic notification dispatcher. Detects `process.platform` and
+// delegates to a registered adapter. Currently only the Windows adapter is
+// implemented; macOS / Linux fall through to the host's in-app banners.
+
+import { ToastRegistry } from './registry';
+import type {
+  ActionEvent,
+  ActionId,
+  DonePayload,
+  NotifierOptions,
+  PermissionPayload,
+  QuestionPayload,
+} from './types';
+import { type PlatformAdapter, WindowsAdapter } from './platform/windows';
+
+const UNSUPPORTED_PLATFORM = (p: string): string =>
+  `ccsm/notify: platform "${p}" is not supported (Windows only).`;
+
+export class Notifier {
+  private readonly adapter: PlatformAdapter;
+  private readonly registry: ToastRegistry;
+  private readonly options: NotifierOptions;
+
+  private constructor(adapter: PlatformAdapter, options: NotifierOptions) {
+    this.adapter = adapter;
+    this.options = options;
+    this.registry = new ToastRegistry();
+    // Real adapters expose an activation hook so we can route OS-side toast
+    // clicks through the registry. The stub adapter (and future macOS/Linux
+    // adapters before they're implemented) may not — feature-detect.
+    const maybeHookable = adapter as PlatformAdapter & {
+      setActivationCallback?: (
+        cb: (toastId: string, action: ActionId, args: Record<string, string>) => void,
+      ) => void;
+    };
+    if (typeof maybeHookable.setActivationCallback === 'function') {
+      maybeHookable.setActivationCallback((toastId, action, args) => {
+        this.dispatchActivation({ toastId, action, args });
+      });
+    }
+  }
+
+  /**
+   * Async factory — async because real adapters may need to verify
+   * AUMID registration or wire native event subscriptions before returning.
+   */
+  static async create(options: NotifierOptions): Promise<Notifier> {
+    const platform = process.platform;
+    if (platform !== 'win32') {
+      throw new Error(UNSUPPORTED_PLATFORM(platform));
+    }
+    const adapter = new WindowsAdapter(options);
+    return new Notifier(adapter, options);
+  }
+
+  /** Internal: register the active onAction handler under a toastId. */
+  private track(toastId: string): void {
+    this.registry.register(toastId, (event) => {
+      // Forward to the host app. The adapter is responsible for tearing the
+      // OS-side toast down (it already calls `dismiss` after firing the
+      // activation callback). We swallow handler errors so a buggy host
+      // can't strand the registry entry — but we re-throw nothing.
+      try {
+        this.options.onAction(event);
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        console.error(
+          `[ccsm/notify] onAction handler threw for toast ${event.toastId}: ${detail}`,
+        );
+      }
+    });
+  }
+
+  /** Routed from the platform adapter when a toast is clicked. */
+  private dispatchActivation(event: ActionEvent): void {
+    // `fire` is idempotent — duplicate OS activations are silently ignored.
+    this.registry.fire(event);
+  }
+
+  permission(payload: PermissionPayload): void {
+    this.track(payload.toastId);
+    this.adapter.permission(payload);
+  }
+
+  question(payload: QuestionPayload): void {
+    this.track(payload.toastId);
+    this.adapter.question(payload);
+  }
+
+  done(payload: DonePayload): void {
+    this.track(payload.toastId);
+    this.adapter.done(payload);
+  }
+
+  /**
+   * Caller-initiated dismiss. Removes the registry entry and asks the
+   * adapter to tear the toast down. No callback fires.
+   */
+  dismiss(toastId: string): void {
+    this.registry.dismiss(toastId);
+    try {
+      this.adapter.dismiss(toastId);
+    } catch {
+      // Adapter may already be gone — swallow.
+    }
+  }
+
+  /** Diagnostic — number of pending toast callbacks. */
+  pendingCount(): number {
+    return this.registry.size();
+  }
+
+  /** Release native handles. Safe to call multiple times. */
+  dispose(): void {
+    this.adapter.dispose?.();
+  }
+}

--- a/electron/notify-impl/platform/windows.ts
+++ b/electron/notify-impl/platform/windows.ts
@@ -1,0 +1,249 @@
+// Windows platform adapter.
+//
+// Wraps `electron-windows-notifications` so the dispatcher can stay
+// platform-agnostic. Each emit method:
+//   1. Builds Adaptive Toast XML for the requested type.
+//   2. Constructs a ToastNotification tagged by toastId so it can be
+//      hidden/removed from the Action Center later.
+//   3. Subscribes to the `activated` event, parses the arguments string,
+//      forwards to `Notifier.onAction`, then auto-dismisses the toast.
+//
+// AUMID validation: the adapter requires a non-empty `appId`. Toasts emitted
+// without a registered AUMID + Start Menu shortcut on Windows silently
+// vanish, which is impossible to debug. We surface the requirement at
+// construction with a pointer to `setup-aumid.ps1`.
+
+import type {
+  ActionId,
+  DonePayload,
+  NotifierOptions,
+  PermissionPayload,
+  QuestionPayload,
+} from '../types';
+import { parseActionArgs } from '../xml/common';
+import { buildDoneXml } from '../xml/done';
+import { buildPermissionXml } from '../xml/permission';
+import { buildQuestionXml } from '../xml/question';
+
+/**
+ * Cross-platform shape the dispatcher targets. macOS / Linux adapters in
+ * later phases must satisfy the same interface.
+ */
+export interface PlatformAdapter {
+  permission(payload: PermissionPayload): void;
+  question(payload: QuestionPayload): void;
+  done(payload: DonePayload): void;
+  /** Force-dismiss a toast by id without firing its callback. */
+  dismiss(toastId: string): void;
+  /** Optional shutdown hook — release any native handles. */
+  dispose?(): void;
+}
+
+/** Subset of the electron-windows-notifications surface we depend on. */
+interface ToastNotificationCtor {
+  new (options: {
+    appId?: string;
+    template: string;
+    strings?: string[];
+    tag?: string;
+    group?: string;
+  }): ToastNotificationInstance;
+}
+
+interface ToastNotificationInstance {
+  on(
+    event: 'activated',
+    listener: (toast: unknown, args: string | undefined) => void,
+  ): void;
+  on(event: 'dismissed', listener: (...args: unknown[]) => void): void;
+  on(event: 'failed', listener: (err: unknown) => void): void;
+  show(): void;
+  hide(): void;
+}
+
+interface HistoryApi {
+  remove(options: { tag: string; group?: string; appId?: string }): void;
+}
+
+interface ElectronWindowsNotifications {
+  ToastNotification: ToastNotificationCtor;
+  history: HistoryApi;
+}
+
+/**
+ * Internal callback the adapter invokes after parsing an activation event.
+ * The dispatcher (`Notifier`) wires this to the registry → onAction chain.
+ */
+export type ActivationCallback = (
+  toastId: string,
+  action: ActionId,
+  args: Record<string, string>,
+) => void;
+
+const TOAST_GROUP = 'ccsm-notify';
+
+const AUMID_HELP =
+  'Set NotifierOptions.appId to the AUMID registered for this process. ' +
+  'For ad-hoc dev runs, use scripts/setup-aumid.ps1.';
+
+function loadNativeModule(): ElectronWindowsNotifications {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const mod = require('electron-windows-notifications') as ElectronWindowsNotifications;
+  return mod;
+}
+
+/**
+ * Allow tests to inject a fake native module without a real electron host.
+ * Production code never calls this.
+ */
+let nativeOverride: ElectronWindowsNotifications | undefined;
+export function __setNativeForTests(
+  mod: ElectronWindowsNotifications | undefined,
+): void {
+  nativeOverride = mod;
+}
+
+const KNOWN_ACTIONS: readonly ActionId[] = [
+  'allow',
+  'allow-always',
+  'reject',
+  'focus',
+];
+
+function isKnownAction(value: string): value is ActionId {
+  return (KNOWN_ACTIONS as readonly string[]).includes(value);
+}
+
+export class WindowsAdapter implements PlatformAdapter {
+  private readonly options: NotifierOptions;
+  private readonly native: ElectronWindowsNotifications;
+  /** Live toast handles, keyed by toastId, so `hide()` can be invoked. */
+  private readonly liveToasts = new Map<string, ToastNotificationInstance>();
+  /** Hook the dispatcher installs to route activations. */
+  private activationCallback: ActivationCallback | undefined;
+
+  constructor(options: NotifierOptions) {
+    if (!options.appId || options.appId.trim().length === 0) {
+      throw new Error(`ccsm/notify: AUMID not registered. ${AUMID_HELP}`);
+    }
+    this.options = options;
+    try {
+      this.native = nativeOverride ?? loadNativeModule();
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `ccsm/notify: failed to load electron-windows-notifications (${detail}). ` +
+          'Ensure the host process is electron and the package is installed.',
+      );
+    }
+  }
+
+  /**
+   * Register the dispatcher's activation callback. Called by `Notifier`
+   * once during construction. Kept separate from the constructor to keep
+   * the public `NotifierOptions` shape uncluttered.
+   */
+  setActivationCallback(cb: ActivationCallback): void {
+    this.activationCallback = cb;
+  }
+
+  permission(payload: PermissionPayload): void {
+    const xml = buildPermissionXml(payload, {
+      iconPath: this.options.iconPath,
+      silent: this.options.silent,
+    });
+    this.showToast(payload.toastId, xml);
+  }
+
+  question(payload: QuestionPayload): void {
+    const xml = buildQuestionXml(payload, {
+      iconPath: this.options.iconPath,
+      silent: this.options.silent,
+    });
+    this.showToast(payload.toastId, xml);
+  }
+
+  done(payload: DonePayload): void {
+    const xml = buildDoneXml(payload, {
+      iconPath: this.options.iconPath,
+      silent: this.options.silent,
+    });
+    this.showToast(payload.toastId, xml);
+  }
+
+  dismiss(toastId: string): void {
+    const handle = this.liveToasts.get(toastId);
+    this.liveToasts.delete(toastId);
+    if (handle) {
+      try {
+        handle.hide();
+      } catch {
+        // Toast may already have been dismissed by the OS.
+      }
+    }
+    // Also clear the entry from Action Center so the user doesn't see a
+    // stale notification after the in-app UI resolved the prompt.
+    try {
+      this.native.history.remove({
+        tag: toastId,
+        group: TOAST_GROUP,
+        appId: this.options.appId,
+      });
+    } catch {
+      // Older Windows builds occasionally throw if the entry is gone.
+    }
+  }
+
+  private showToast(toastId: string, template: string): void {
+    const toast = new this.native.ToastNotification({
+      appId: this.options.appId,
+      template,
+      tag: toastId,
+      group: TOAST_GROUP,
+    });
+    this.liveToasts.set(toastId, toast);
+    toast.on('activated', (_t, args) => {
+      this.handleActivation(toastId, args ?? '');
+    });
+    toast.on('dismissed', () => {
+      // OS-level dismiss (timeout, user swipe, action-center clear): drop the
+      // handle so the map doesn't leak. We intentionally do NOT fire the
+      // action callback here — only explicit user actions resolve the prompt.
+      this.liveToasts.delete(toastId);
+    });
+    toast.on('failed', (err) => {
+      // Log to stderr so the operator sees AUMID / shortcut issues. The
+      // dispatcher's registry stays alive — caller can fall back to in-app UI.
+      const detail = err instanceof Error ? err.message : String(err);
+      console.error(`[ccsm/notify] toast ${toastId} failed: ${detail}`);
+    });
+    toast.show();
+  }
+
+  private handleActivation(toastId: string, rawArgs: string): void {
+    const parsed = parseActionArgs(rawArgs);
+    const actionRaw = parsed['action'] ?? 'focus';
+    const action: ActionId = isKnownAction(actionRaw) ? actionRaw : 'focus';
+    // Strip the action key from the args bag before forwarding — callers
+    // already receive `action` as a top-level field.
+    const argsForCallback: Record<string, string> = { ...parsed };
+    delete argsForCallback['action'];
+    try {
+      this.activationCallback?.(toastId, action, argsForCallback);
+    } finally {
+      // Per spec: auto-dismiss after firing the callback.
+      this.dismiss(toastId);
+    }
+  }
+
+  dispose(): void {
+    for (const [id] of this.liveToasts) {
+      try {
+        this.dismiss(id);
+      } catch {
+        // best-effort
+      }
+    }
+    this.liveToasts.clear();
+  }
+}

--- a/electron/notify-impl/registry.ts
+++ b/electron/notify-impl/registry.ts
@@ -1,0 +1,54 @@
+// Map toastId -> action callback. The notifier registers a callback when a
+// toast is emitted and removes it when the toast is dismissed (either by an
+// action firing, by an explicit dismiss call, or by the OS timing out).
+//
+// `fire` is idempotent: a second fire for the same toastId is a no-op. This
+// guards against the OS delivering duplicate activations (it has happened on
+// Windows when a toast is clicked while already dismissing).
+
+import type { ActionEvent } from './types';
+
+export type ToastCallback = (event: ActionEvent) => void;
+
+export class ToastRegistry {
+  private readonly callbacks = new Map<string, ToastCallback>();
+
+  /** Register a callback for a toastId. Overwrites any previous entry. */
+  register(toastId: string, callback: ToastCallback): void {
+    this.callbacks.set(toastId, callback);
+  }
+
+  /** True iff a callback is currently registered for this toastId. */
+  has(toastId: string): boolean {
+    return this.callbacks.has(toastId);
+  }
+
+  /**
+   * Invoke the callback for a toastId, then remove the entry. Returns true if
+   * a callback was fired. Returns false if no entry exists (already fired,
+   * dismissed, or never registered) — the second-fire-after-fire case.
+   */
+  fire(event: ActionEvent): boolean {
+    const cb = this.callbacks.get(event.toastId);
+    if (!cb) return false;
+    // Remove BEFORE invoking so a re-entrant fire (callback that triggers
+    // another action) cannot loop.
+    this.callbacks.delete(event.toastId);
+    cb(event);
+    return true;
+  }
+
+  /**
+   * Drop the callback without firing. Used when the host resolves a pending
+   * permission via in-app UI before the user touches the toast.
+   * Returns true if an entry was removed.
+   */
+  dismiss(toastId: string): boolean {
+    return this.callbacks.delete(toastId);
+  }
+
+  /** Test/diagnostic helper. */
+  size(): number {
+    return this.callbacks.size;
+  }
+}

--- a/electron/notify-impl/types.ts
+++ b/electron/notify-impl/types.ts
@@ -1,0 +1,86 @@
+// Public payload + event types for the inlined notify module.
+//
+// Originally vendored from the standalone `@ccsm/notify` package (v0.1.1).
+// All emit methods are unconditional — caller is responsible for suppression
+// (focused-active session, user-disabled toggles). The toastId is owned by
+// the caller and must be unique across pending notifications.
+
+/** Payload for `Notifier.permission`. */
+export interface PermissionPayload {
+  /** Unique id used to correlate the action callback. Caller-owned. */
+  toastId: string;
+  /** Display name of the session asking for permission. */
+  sessionName: string;
+  /** Tool name, e.g. "Bash", "Write". */
+  toolName: string;
+  /** Short summary of what the tool wants to do (truncated for display). */
+  toolBrief: string;
+  /** Basename of the cwd, shown as attribution. */
+  cwdBasename: string;
+}
+
+/** Payload for `Notifier.question` — passive notification, no in-toast actions. */
+export interface QuestionPayload {
+  toastId: string;
+  sessionName: string;
+  /** The question text (truncated for display). */
+  question: string;
+  /** Whether the user must pick one or many options in-app. */
+  selectionKind: 'single' | 'multi';
+  /** Number of options the user will see in-app. */
+  optionCount: number;
+  cwdBasename: string;
+}
+
+/** Payload for `Notifier.done` — passive completion notification. */
+export interface DonePayload {
+  toastId: string;
+  /** Group / task name (top-level user concept). */
+  groupName: string;
+  /** Session name (sub-task). */
+  sessionName: string;
+  /** Last user message in the conversation, prefixed with "> " on display. */
+  lastUserMsg: string;
+  /** Last assistant message in the conversation. */
+  lastAssistantMsg: string;
+  /** Wall-clock duration of the completed run in milliseconds. */
+  elapsedMs: number;
+  /** Number of tool calls executed during the run. */
+  toolCount: number;
+  cwdBasename: string;
+}
+
+/**
+ * Action ids dispatched from a toast back to the host app.
+ *
+ * - `allow` / `allow-always` / `reject` — permission toast buttons
+ * - `focus` — body click on any toast (also dismiss-then-focus)
+ */
+export type ActionId = 'allow' | 'allow-always' | 'reject' | 'focus';
+
+/** Args bag carried in the toast `launch=` URL, parsed into a flat record. */
+export type ActionArgs = Record<string, string>;
+
+/** Event delivered to `NotifierOptions.onAction`. */
+export interface ActionEvent {
+  toastId: string;
+  action: ActionId;
+  args: ActionArgs;
+}
+
+/** Constructor options for `Notifier.create`. */
+export interface NotifierOptions {
+  /** Application User Model ID. Required on Windows for toast routing. */
+  appId: string;
+  /** Display name of the host app, shown in toast attribution chrome. */
+  appName: string;
+  /** Absolute path to a square PNG icon shown on the toast. */
+  iconPath?: string;
+  /** Mute the Windows default notification sound. */
+  silent?: boolean;
+  /**
+   * Single dispatch point for all toast interactions. The notifier auto-
+   * dismisses the toast after this callback returns.
+   */
+  onAction: (event: ActionEvent) => void;
+}

--- a/electron/notify-impl/util/truncate.ts
+++ b/electron/notify-impl/util/truncate.ts
@@ -1,0 +1,100 @@
+// Sentence-aware truncation for toast body lines.
+//
+// Order of operations:
+//   1. Strip markdown chrome (backticks, square brackets around link text,
+//      leading blockquote markers).
+//   2. Collapse all whitespace runs (newlines included) to a single space.
+//   3. If the cleaned text fits in maxChars, return as-is.
+//   4. Otherwise prefer a sentence boundary inside the budget. Fall back to
+//      hard char count + ellipsis.
+//
+// Char counts use code-point length (`[...str].length`) so a single emoji
+// counts as 1, matching what the user perceives in the toast UI.
+
+export interface TruncateResult {
+  text: string;
+  wasTruncated: boolean;
+}
+
+const SENTENCE_BOUNDARIES = ['. ', '。', '! ', '? ', '！', '？'];
+const ELLIPSIS = '…';
+
+/** Public char-count helper — code points, not UTF-16 units. */
+export function codePointLength(s: string): number {
+  return [...s].length;
+}
+
+function stripMarkdownChrome(input: string): string {
+  let s = input;
+  // Drop leading blockquote markers and surrounding whitespace per line.
+  s = s.replace(/^[ \t]*>+[ \t]?/gm, '');
+  // Strip backticks (inline code or code fences) — keep the inner text.
+  s = s.replace(/`+/g, '');
+  // Markdown links: [label](url) -> label
+  s = s.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '$1');
+  // Bare bracket pairs around plain text: [foo] -> foo
+  s = s.replace(/\[([^\]]+)\]/g, '$1');
+  return s;
+}
+
+function collapseWhitespace(s: string): string {
+  // Includes newlines, tabs, and runs of regular spaces.
+  return s.replace(/\s+/g, ' ').trim();
+}
+
+/** Slice a string by code-point count (not UTF-16 units). */
+function sliceCodePoints(s: string, maxChars: number): string {
+  const points = [...s];
+  if (points.length <= maxChars) return s;
+  return points.slice(0, maxChars).join('');
+}
+
+/**
+ * Truncate `text` to fit within `maxChars` code points. Prefers sentence
+ * boundaries; falls back to char count + ellipsis. The returned text is
+ * guaranteed to be at most `maxChars` code points.
+ */
+export function truncate(text: string, maxChars: number): TruncateResult {
+  if (maxChars <= 0) {
+    return { text: '', wasTruncated: text.length > 0 };
+  }
+  const cleaned = collapseWhitespace(stripMarkdownChrome(text));
+  const cleanedLen = codePointLength(cleaned);
+
+  if (cleanedLen <= maxChars) {
+    return { text: cleaned, wasTruncated: false };
+  }
+
+  // Find the latest sentence boundary that ends within the budget. Reserve
+  // no extra room for an ellipsis when ending at a real sentence — the
+  // boundary itself is a clean stopping point.
+  let bestEnd = -1;
+  for (const sep of SENTENCE_BOUNDARIES) {
+    // Search for boundaries whose punctuation char fits inside maxChars.
+    // We walk through every occurrence to find the latest valid one.
+    let from = 0;
+    while (from < cleaned.length) {
+      const idx = cleaned.indexOf(sep, from);
+      if (idx === -1) break;
+      // The boundary includes the punctuation char; cut after it.
+      const cutEnd = idx + sep.trimEnd().length;
+      const slice = cleaned.slice(0, cutEnd);
+      if (codePointLength(slice) <= maxChars) {
+        if (cutEnd > bestEnd) bestEnd = cutEnd;
+      } else {
+        break;
+      }
+      from = idx + sep.length;
+    }
+  }
+
+  if (bestEnd > 0) {
+    return { text: cleaned.slice(0, bestEnd), wasTruncated: true };
+  }
+
+  // Hard fallback: code-point slice with ellipsis. Reserve 1 code point for
+  // the ellipsis itself.
+  const budget = Math.max(0, maxChars - 1);
+  const head = sliceCodePoints(cleaned, budget);
+  return { text: head + ELLIPSIS, wasTruncated: true };
+}

--- a/electron/notify-impl/xml/common.ts
+++ b/electron/notify-impl/xml/common.ts
@@ -1,0 +1,73 @@
+// Shared helpers for building Windows Adaptive Toast XML.
+//
+// We hand-roll the XML rather than pulling in a templating dep — the schema
+// is small, fully documented by Microsoft, and golden-file tests catch any
+// regression. Output is a single line with no leading/trailing whitespace so
+// fixture diffs stay readable.
+
+const XML_ESCAPES: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&apos;',
+};
+
+/** Escape a string for safe inclusion in an XML attribute or text node. */
+export function xmlEscape(value: string): string {
+  return value.replace(/[&<>"']/g, (ch) => XML_ESCAPES[ch] ?? ch);
+}
+
+/**
+ * Build a `key=value&key=value` query string for the toast `arguments=`
+ * attribute. Values are URI-encoded so they survive the round-trip through
+ * Windows Notification Platform → activation event → our parser.
+ *
+ * Order is preserved — golden-file tests rely on stable output.
+ */
+export function buildActionArgs(params: Record<string, string>): string {
+  return Object.entries(params)
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join('&');
+}
+
+/**
+ * Inverse of `buildActionArgs`. Tolerates missing values and `?`-prefixed
+ * strings (defensive — the OS occasionally hands back the raw launch URL).
+ */
+export function parseActionArgs(raw: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  const trimmed = raw.startsWith('?') ? raw.slice(1) : raw;
+  if (trimmed.length === 0) return out;
+  for (const part of trimmed.split('&')) {
+    if (part.length === 0) continue;
+    const eq = part.indexOf('=');
+    const key = eq === -1 ? part : part.slice(0, eq);
+    const value = eq === -1 ? '' : part.slice(eq + 1);
+    out[decodeURIComponent(key)] = decodeURIComponent(value);
+  }
+  return out;
+}
+
+/** Common per-build options injected by the WindowsAdapter. */
+export interface XmlBuildOptions {
+  /** Absolute path to a square PNG icon (rendered as appLogoOverride). */
+  iconPath?: string;
+  /** When true, emits `<audio silent="true"/>`. */
+  silent?: boolean;
+}
+
+/** Render the optional <audio> element. */
+export function audioElement(silent: boolean | undefined): string {
+  return silent === true ? '<audio silent="true"/>' : '';
+}
+
+/** Render the optional appLogoOverride image inside a binding. */
+export function appLogoElement(iconPath: string | undefined): string {
+  if (!iconPath) return '';
+  // hint-crop="circle" matches the chat avatar treatment used elsewhere in
+  // CCSM and keeps the toast visually anchored.
+  return `<image placement="appLogoOverride" hint-crop="circle" src="${xmlEscape(
+    iconPath,
+  )}"/>`;
+}

--- a/electron/notify-impl/xml/done.ts
+++ b/electron/notify-impl/xml/done.ts
@@ -1,0 +1,74 @@
+// Adaptive Toast XML for the Done (run completed) notification type.
+//
+// Layout:
+//   title:        "{groupName} · {sessionName}"
+//   text 1:       "> {lastUserMsg}"             (truncated ~50 chars)
+//   text 2:       "{lastAssistantMsg}"          (truncated ~80 chars)
+//   attribution:  "{elapsed} · {toolCount} tools · {cwdBasename}"
+//   actions:      none — body click focuses the app
+
+import type { DonePayload } from '../types';
+import { truncate } from '../util/truncate';
+import {
+  appLogoElement,
+  audioElement,
+  buildActionArgs,
+  xmlEscape,
+  type XmlBuildOptions,
+} from './common';
+
+const TITLE_MAX = 80;
+const USER_LINE_MAX = 50;
+const ASSISTANT_LINE_MAX = 80;
+
+/** Format ms as a compact duration: 850ms / 42s / 7m 5s / 1h 3m. */
+export function formatElapsed(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return '0s';
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  const totalSec = Math.round(ms / 1000);
+  if (totalSec < 60) return `${totalSec}s`;
+  const totalMin = Math.floor(totalSec / 60);
+  const remSec = totalSec % 60;
+  if (totalMin < 60) {
+    return remSec === 0 ? `${totalMin}m` : `${totalMin}m ${remSec}s`;
+  }
+  const hours = Math.floor(totalMin / 60);
+  const remMin = totalMin % 60;
+  return remMin === 0 ? `${hours}h` : `${hours}h ${remMin}m`;
+}
+
+export function buildDoneXml(
+  payload: DonePayload,
+  opts: XmlBuildOptions = {},
+): string {
+  const title = truncate(
+    `${payload.groupName} · ${payload.sessionName}`,
+    TITLE_MAX,
+  ).text;
+  const userLine = truncate(payload.lastUserMsg, USER_LINE_MAX);
+  // The "> " prefix is part of the visual contract; it sits outside the
+  // truncation budget so the marker is never lost to the ellipsis.
+  const userText = `> ${userLine.text}`;
+  const assistantLine = truncate(payload.lastAssistantMsg, ASSISTANT_LINE_MAX).text;
+  const attribution = `${formatElapsed(payload.elapsedMs)} · ${payload.toolCount} tools · ${payload.cwdBasename}`;
+
+  const launchArgs = buildActionArgs({
+    action: 'focus',
+    toastId: payload.toastId,
+  });
+
+  return [
+    `<toast launch="${xmlEscape(launchArgs)}" activationType="foreground">`,
+    '<visual>',
+    '<binding template="ToastGeneric">',
+    `<text>${xmlEscape(title)}</text>`,
+    `<text>${xmlEscape(userText)}</text>`,
+    `<text>${xmlEscape(assistantLine)}</text>`,
+    `<text placement="attribution">${xmlEscape(attribution)}</text>`,
+    appLogoElement(opts.iconPath),
+    '</binding>',
+    '</visual>',
+    audioElement(opts.silent),
+    '</toast>',
+  ].join('');
+}

--- a/electron/notify-impl/xml/permission.ts
+++ b/electron/notify-impl/xml/permission.ts
@@ -1,0 +1,72 @@
+// Adaptive Toast XML for the Permission notification type.
+//
+// Layout:
+//   title:        "Permission needed · {sessionName}"
+//   text 1:       "{toolName} · {toolBrief}"   (truncated ~60 chars)
+//   attribution:  "cwd: {cwdBasename}"
+//   actions:      Allow / Allow always / Reject
+
+import type { PermissionPayload } from '../types';
+import { truncate } from '../util/truncate';
+import {
+  appLogoElement,
+  audioElement,
+  buildActionArgs,
+  xmlEscape,
+  type XmlBuildOptions,
+} from './common';
+
+const TITLE_MAX = 80;
+const BODY_MAX = 60;
+
+export function buildPermissionXml(
+  payload: PermissionPayload,
+  opts: XmlBuildOptions = {},
+): string {
+  const title = truncate(
+    `Permission needed · ${payload.sessionName}`,
+    TITLE_MAX,
+  ).text;
+  const body = truncate(
+    `${payload.toolName} · ${payload.toolBrief}`,
+    BODY_MAX,
+  ).text;
+  const attribution = `cwd: ${payload.cwdBasename}`;
+
+  const launchArgs = buildActionArgs({
+    action: 'focus',
+    toastId: payload.toastId,
+  });
+  const allowArgs = buildActionArgs({
+    action: 'allow',
+    toastId: payload.toastId,
+  });
+  const allowAlwaysArgs = buildActionArgs({
+    action: 'allow-always',
+    toastId: payload.toastId,
+    tool: payload.toolName,
+  });
+  const rejectArgs = buildActionArgs({
+    action: 'reject',
+    toastId: payload.toastId,
+  });
+
+  return [
+    `<toast launch="${xmlEscape(launchArgs)}" activationType="foreground">`,
+    '<visual>',
+    '<binding template="ToastGeneric">',
+    `<text>${xmlEscape(title)}</text>`,
+    `<text>${xmlEscape(body)}</text>`,
+    `<text placement="attribution">${xmlEscape(attribution)}</text>`,
+    appLogoElement(opts.iconPath),
+    '</binding>',
+    '</visual>',
+    '<actions>',
+    `<action content="Allow" arguments="${xmlEscape(allowArgs)}" activationType="background"/>`,
+    `<action content="Allow always" arguments="${xmlEscape(allowAlwaysArgs)}" activationType="background"/>`,
+    `<action content="Reject" arguments="${xmlEscape(rejectArgs)}" activationType="foreground"/>`,
+    '</actions>',
+    audioElement(opts.silent),
+    '</toast>',
+  ].join('');
+}

--- a/electron/notify-impl/xml/question.ts
+++ b/electron/notify-impl/xml/question.ts
@@ -1,0 +1,55 @@
+// Adaptive Toast XML for the Question notification type.
+//
+// Layout:
+//   title:        "Question · {sessionName}"
+//   text 1:       "{question}"                  (truncated ~50 chars)
+//   text 2:       "{Single|Multi}-select · {n} options"
+//   attribution:  "cwd: {cwdBasename}"
+//   actions:      none — body click focuses the app
+
+import type { QuestionPayload } from '../types';
+import { truncate } from '../util/truncate';
+import {
+  appLogoElement,
+  audioElement,
+  buildActionArgs,
+  xmlEscape,
+  type XmlBuildOptions,
+} from './common';
+
+const TITLE_MAX = 80;
+const QUESTION_MAX = 50;
+
+export function buildQuestionXml(
+  payload: QuestionPayload,
+  opts: XmlBuildOptions = {},
+): string {
+  const title = truncate(
+    `Question · ${payload.sessionName}`,
+    TITLE_MAX,
+  ).text;
+  const question = truncate(payload.question, QUESTION_MAX).text;
+  const kindLabel = payload.selectionKind === 'single' ? 'Single' : 'Multi';
+  const subline = `${kindLabel}-select · ${payload.optionCount} options`;
+  const attribution = `cwd: ${payload.cwdBasename}`;
+
+  const launchArgs = buildActionArgs({
+    action: 'focus',
+    toastId: payload.toastId,
+  });
+
+  return [
+    `<toast launch="${xmlEscape(launchArgs)}" activationType="foreground">`,
+    '<visual>',
+    '<binding template="ToastGeneric">',
+    `<text>${xmlEscape(title)}</text>`,
+    `<text>${xmlEscape(question)}</text>`,
+    `<text>${xmlEscape(subline)}</text>`,
+    `<text placement="attribution">${xmlEscape(attribution)}</text>`,
+    appLogoElement(opts.iconPath),
+    '</binding>',
+    '</visual>',
+    audioElement(opts.silent),
+    '</toast>',
+  ].join('');
+}

--- a/electron/notify-retry.ts
+++ b/electron/notify-retry.ts
@@ -17,7 +17,7 @@
 //     in-app QuestionBlock onSubmit and the toast focus action follow-up),
 //     which is the only path that ends a question's pending state.
 //   * Timer state lives in the main process — same lifetime as the
-//     `@ccsm/notify` notifier — so a renderer reload doesn't orphan it.
+//     the inlined notify module notifier — so a renderer reload doesn't orphan it.
 //   * Re-emission re-runs `notifyQuestion` with the SAME toastId so the
 //     SDK's dedupe / activation routing stays coherent (the action router
 //     in main.ts looks up by toastId).

--- a/electron/notify.ts
+++ b/electron/notify.ts
@@ -1,24 +1,30 @@
-// Defensive wrapper around the optional `@ccsm/notify` dependency.
+// Defensive wrapper around the inlined notify implementation.
 //
-// `@ccsm/notify` pulls in `electron-windows-notifications`, which transitively
-// depends on a chain of nan-based `@nodert-win10-au/*` native addons that have
-// no prebuilds. On environments without a working node-gyp / MSBuild toolchain
-// the install of those native deps fails, so we declare `@ccsm/notify` in
-// `optionalDependencies` (npm tolerates failed optional installs) and load it
-// lazily here. If loading fails — for any reason: optional install skipped,
-// platform unsupported, runtime adapter init throws — every wrapper function
-// becomes a graceful no-op so the rest of the app keeps working with the
-// existing in-app banners / Electron `Notification` toasts.
+// The notify implementation lives at `./notify-impl/` (originally vendored
+// from the standalone `@ccsm/notify` package — inlined to drop the private
+// GitHub dep and unblock public release; see #199). It pulls in
+// `electron-windows-notifications`, which transitively depends on a chain of
+// nan-based `@nodert-win10-au/*` native addons that have no prebuilds. On
+// environments without a working node-gyp / MSBuild toolchain the install of
+// those native deps fails, so we declare `electron-windows-notifications` in
+// `optionalDependencies` (npm tolerates failed optional installs) and load
+// the implementation lazily here. If loading fails — for any reason:
+// optional native dep missing, platform unsupported, runtime adapter init
+// throws — every wrapper function becomes a graceful no-op so the rest of
+// the app keeps working with the existing in-app banners / Electron
+// `Notification` toasts.
 //
 // Same design as `fsevents` on macOS: optional install + lazy require + soft
 // fallback. See task #267 for context.
 //
-// We intentionally do NOT `import type` from '@ccsm/notify' so that this file
-// type-checks even when the optional dep is missing on disk. The payload
-// shapes below are duplicated from the upstream public API (kept narrow on
-// purpose — only the fields callers actually pass through).
+// The payload shapes below are duplicated from the implementation's public
+// API (kept narrow on purpose — only the fields callers actually pass
+// through). We do NOT `import type` from `./notify-impl` directly so this
+// file's behavior under the lazy loader matches the prior @ccsm/notify
+// dynamic-import flow exactly; the test seam still routes through a single
+// `importer` indirection.
 
-// ---------- Local payload types (kept in lockstep with @ccsm/notify) ----------
+// ---------- Local payload types (kept in lockstep with notify-impl) ----------
 
 export interface PermissionPayload {
   toastId: string;
@@ -79,26 +85,31 @@ interface NotifierLike {
   dispose?: () => void;
 }
 
-// `@ccsm/notify` is published as ESM (`"type": "module"`). The electron main
-// process compiles to CommonJS, which can't `require()` ESM, so we use a
-// one-shot dynamic `import()` whose resolution is cached. Failure is sticky:
-// once we've decided the module is unavailable, every subsequent call is a
-// fast no-op without retrying the import.
+// `./notify-impl` is plain CommonJS (compiled from TS by tsconfig.electron),
+// so we can `require()` it synchronously. We still expose the load through a
+// promise-returning `importer` indirection so unit tests can swap the
+// resolution for an async fake without touching real module state. Failure
+// is sticky: once we've decided the module is unavailable, every subsequent
+// call is a fast no-op without retrying the import.
 let loadPromise: Promise<NotifyModuleLike | null> | null = null;
 let loadError: string | null = null;
 let resolvedAvailability: boolean | null = null;
 
-// Indirection so unit tests can swap the loader without touching the real
-// import resolution. Production code never overrides this.
-let importer: () => Promise<unknown> = () =>
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (Function('m', 'return import(m)') as (m: string) => Promise<any>)('@ccsm/notify');
+// Default importer: synchronously require the inlined implementation. Wrapped
+// in `Promise.resolve(...)` so the `importer` signature stays uniform across
+// the test seam. The require happens inside the function (not at module load)
+// so a `__setNotifyImporter` call before the first `loadModule()` invocation
+// can override the import without paying for the synchronous load.
+function defaultImporter(): Promise<unknown> {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  return Promise.resolve(require('./notify-impl'));
+}
+
+let importer: () => Promise<unknown> = defaultImporter;
 
 /** Test-only seam. Pass `null` to reset back to the real importer. */
 export function __setNotifyImporter(fn: (() => Promise<unknown>) | null): void {
-  importer = fn ?? (() =>
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (Function('m', 'return import(m)') as (m: string) => Promise<any>)('@ccsm/notify'));
+  importer = fn ?? defaultImporter;
   loadPromise = null;
   loadError = null;
   resolvedAvailability = null;
@@ -121,7 +132,7 @@ function loadModule(): Promise<NotifyModuleLike | null> {
       // is logged so callers don't spam the console.
       // eslint-disable-next-line no-console
       console.warn(
-        `[notify] @ccsm/notify unavailable, falling back to in-app only: ${loadError}`,
+        `[notify] native notification module unavailable, falling back to in-app only: ${loadError}`,
       );
       resolvedAvailability = false;
       return null;
@@ -182,13 +193,28 @@ export function isNotifyAvailable(): boolean {
 }
 
 /**
- * Async variant — forces the dynamic import to run if it hasn't yet, so
+ * Async variant — forces the JS module to load AND (when options have
+ * already been configured) the underlying Notifier to be constructed, so
  * callers (e.g. the Settings dialog) can render an accurate availability
  * indicator on mount.
+ *
+ * Constructing the Notifier is what surfaces native-dep failures: the
+ * `electron-windows-notifications` `require()` happens inside the
+ * `WindowsAdapter` constructor, not at JS module load time. Without this
+ * extra step, `probeNotifyAvailability()` would report "available" on
+ * machines where the native chain failed to build, only for the first emit
+ * to silently fall back later.
  */
 export async function probeNotifyAvailability(): Promise<boolean> {
   const mod = await loadModule();
-  return mod !== null;
+  if (!mod) return false;
+  // If options aren't configured yet, the JS module loaded successfully —
+  // that's the best we can report. The first real emit (after configure)
+  // will trip the native-dep require if it's missing and flip availability
+  // to false at that point.
+  if (!notifierOptions) return true;
+  const n = await getNotifier();
+  return n !== null;
 }
 
 /** Last load/init error message, or null when the module is healthy. */

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
         "webpack-dev-server": "^5.2.0"
       },
       "optionalDependencies": {
-        "@ccsm/notify": "github:Jiahui-Gu/ccsm-notify#v0.1.1"
+        "electron-windows-notifications": "^3.0.8"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -644,18 +644,6 @@
       },
       "bin": {
         "specificity": "bin/cli.js"
-      }
-    },
-    "node_modules/@ccsm/notify": {
-      "version": "0.1.1",
-      "resolved": "git+ssh://git@github.com/Jiahui-Gu/ccsm-notify.git#06f2f74fd2af7a32181c78253d29b73a844d8bef",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "electron-windows-notifications": "^3.0.8"
-      },
-      "engines": {
-        "node": ">=18.17"
       }
     },
     "node_modules/@csstools/color-helpers": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "webpack-dev-server": "^5.2.0"
   },
   "optionalDependencies": {
-    "@ccsm/notify": "github:Jiahui-Gu/ccsm-notify#v0.1.1"
+    "electron-windows-notifications": "^3.0.8"
   },
   "build": {
     "appId": "com.ccsm.app",

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -10,10 +10,11 @@
 //
 // Now we fail loudly for REQUIRED native deps (better-sqlite3) and tolerate
 // failures for OPTIONAL native deps (the @nodert-win10-au/* chain pulled in
-// by @ccsm/notify, which has no prebuilds and needs a working MSBuild
-// toolchain to compile). The optional chain is exposed through
-// `electron/notify.ts`, which lazy-loads @ccsm/notify and falls back to
-// in-app banners if the import throws — so a failed rebuild is recoverable.
+// by `electron-windows-notifications`, which has no prebuilds and needs a
+// working MSBuild toolchain to compile). The optional chain is exposed
+// through `electron/notify.ts`, which lazy-loads the inlined notify module
+// (`electron/notify-impl/`) and falls back to in-app banners if the native
+// require throws — so a failed rebuild is recoverable.
 
 import { spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
@@ -57,11 +58,11 @@ if (fullRebuild.signal) {
 
 if (typeof fullRebuild.status === 'number' && fullRebuild.status !== 0) {
   // The full rebuild failed. The most common cause is the @nodert-win10-au
-  // native chain pulled in by the optional @ccsm/notify dep (no prebuilds,
-  // requires MSBuild). Try rebuilding just better-sqlite3 — that's the only
-  // REQUIRED native module the app needs at runtime. If that succeeds,
-  // demote the original failure to a warning and let install proceed; the
-  // app's notify wrapper will fall back to in-app banners.
+  // native chain pulled in by the optional `electron-windows-notifications`
+  // dep (no prebuilds, requires MSBuild). Try rebuilding just better-sqlite3
+  // — that's the only REQUIRED native module the app needs at runtime. If
+  // that succeeds, demote the original failure to a warning and let install
+  // proceed; the app's notify wrapper will fall back to in-app banners.
   console.warn(
     `\n[postinstall] electron-builder install-app-deps exited with code ${fullRebuild.status}. ` +
       `Retrying with the required-only set (better-sqlite3) — see task #267.`,
@@ -93,9 +94,9 @@ if (typeof fullRebuild.status === 'number' && fullRebuild.status !== 0) {
 
   console.warn(
     '\n[postinstall] better-sqlite3 rebuilt OK. Optional native deps (e.g. ' +
-      '@ccsm/notify -> @nodert-win10-au/*) failed to build; CCSM will fall ' +
-      'back to in-app banners and standard system notifications. See ' +
-      'electron/notify.ts.',
+      'electron-windows-notifications -> @nodert-win10-au/*) failed to ' +
+      'build; CCSM will fall back to in-app banners and standard system ' +
+      'notifications. See electron/notify.ts.',
   );
   process.exit(0);
 }

--- a/scripts/probe-e2e-notify-fallback.mjs
+++ b/scripts/probe-e2e-notify-fallback.mjs
@@ -1,19 +1,22 @@
-// E2E: When the optional `@ccsm/notify` native module is unavailable
-// (npm install skipped it because the @nodert-win10-au native deps wouldn't
-// build on this machine), CCSM must:
+// E2E: When the optional `electron-windows-notifications` native module is
+// unavailable (npm install skipped it because the @nodert-win10-au native
+// deps wouldn't build on this machine), CCSM must:
 //
 //   1. Start cleanly — no startup crash, no unhandled promise rejection.
 //   2. Surface the fallback state in Settings → Notifications via the
 //      `data-testid=notifications-module-status` indicator
 //      (`data-available="false"` plus the sentence-case English string).
 //   3. The IPC `notify:availability` returns `{ available: false, error: ... }`
-//      with an error message that proves the dynamic import was attempted
+//      with an error message that proves the native require was attempted
 //      and failed.
 //
-// We simulate "optional install failed" by renaming `node_modules/@ccsm/notify`
-// to a sibling path before launching electron, then restoring it on exit.
-// The wrapper's dynamic import then throws ERR_MODULE_NOT_FOUND just as it
-// would on a user machine where the native deps couldn't compile.
+// We simulate "optional install failed" by renaming
+// `node_modules/electron-windows-notifications` to a sibling path before
+// launching electron, then restoring it on exit. The `WindowsAdapter`
+// constructor's `require('electron-windows-notifications')` then throws
+// MODULE_NOT_FOUND just as it would on a user machine where the native deps
+// couldn't compile, and that bubbles up to `Notifier.create` rejection in
+// the wrapper.
 //
 // Reverse-verify: stash the try/catch in `electron/notify.ts` (and rebuild)
 // and re-run this probe; it must FAIL with an unhandled rejection logged or
@@ -34,8 +37,12 @@ function fail(msg) {
   process.exit(1);
 }
 
-const notifyDir = path.join(root, 'node_modules', '@ccsm', 'notify');
-const stashedDir = path.join(root, 'node_modules', '@ccsm', 'notify.__probe_stash__');
+const notifyDir = path.join(root, 'node_modules', 'electron-windows-notifications');
+const stashedDir = path.join(
+  root,
+  'node_modules',
+  'electron-windows-notifications.__probe_stash__',
+);
 
 let stashed = false;
 function stashNotify() {
@@ -72,7 +79,7 @@ process.on('SIGINT', () => {
 // --- 1. Hide the optional dep -------------------------------------------
 stashNotify();
 if (fs.existsSync(notifyDir)) {
-  fail(`failed to stash node_modules/@ccsm/notify at ${notifyDir}`);
+  fail(`failed to stash node_modules/electron-windows-notifications at ${notifyDir}`);
 }
 
 const { port: PORT, close: closeServer } = await startBundleServer(root);
@@ -173,10 +180,12 @@ try {
   const text = (await status.textContent())?.trim() ?? '';
   if (!text) fail('notifications-module-status indicator was empty');
   // The English fallback message MUST be sentence case (no SCREAMING),
-  // mention @ccsm/notify, and explicitly call out "in-app banners" so the
-  // user knows what to expect instead.
+  // mention the native notification module, and explicitly call out
+  // "in-app banners" so the user knows what to expect instead.
   const lower = text.toLowerCase();
-  if (!lower.includes('@ccsm/notify')) fail(`fallback message missing @ccsm/notify: "${text}"`);
+  if (!lower.includes('native notification module')) {
+    fail(`fallback message missing "native notification module": "${text}"`);
+  }
   if (!lower.includes('in-app banners')) fail(`fallback message missing "in-app banners": "${text}"`);
   // Reject all-caps words (>3 letters) — project's "no SCREAMING UI strings".
   for (const word of text.split(/\s+/)) {

--- a/scripts/probe-e2e-notify-integration.mjs
+++ b/scripts/probe-e2e-notify-integration.mjs
@@ -1,4 +1,4 @@
-// E2E: Wave 1D notify integration. The `@ccsm/notify` Adaptive Toast
+// E2E: Wave 1D notify integration. The the inlined notify module Adaptive Toast
 // pipeline can't fire real Windows toasts under playwright (no AUMID
 // shortcut, no winrt under headless), so we mock the wrapper's underlying
 // dynamic import via the `__setNotifyImporter` test seam exposed in
@@ -113,7 +113,7 @@ try {
   // ── 1. Install mock importer in main and re-bootstrap notify ────────────
   //
   // The `notify.ts` wrapper exposes `__setNotifyImporter` so tests can swap
-  // the dynamic `import('@ccsm/notify')` resolution for a fake. The fake
+  // the dynamic `import('the inlined notify module')` resolution for a fake. The fake
   // returns a Notifier whose methods record into a global array we can
   // observe from the probe via `app.evaluate`.
   const installed = await app.evaluate(async ({ BrowserWindow }) => {
@@ -176,8 +176,8 @@ try {
 
   // ── 3. Blur the window so focus suppression doesn't gate the probe ──────
   // The legacy electron Notification path is gated by `BrowserWindow.isFocused()`
-  // in main; we explicitly drop focus so emits fan out to the @ccsm/notify
-  // wrapper. (We re-test focus suppression at step 7 by re-focusing.)
+  // in main; we explicitly drop focus so emits fan out to the inlined notify
+  // module wrapper. (We re-test focus suppression at step 7 by re-focusing.)
   // See `blurAndWaitUnfocused` for the rationale on polling.
   await blurAndWaitUnfocused(app);
 
@@ -301,7 +301,7 @@ try {
     ]);
   }, { sessionId, requestId: REQUEST_ID });
 
-  // Synthesize the host-side onAction call (what @ccsm/notify would do when
+  // Synthesize the host-side onAction call (what the inlined notify module would do when
   // the user clicks "Allow always" in the toast).
   await app.evaluate(({ ipcMain }, args) => {
     const cb = globalThis.__notifyOnAction;

--- a/scripts/setup-aumid.ps1
+++ b/scripts/setup-aumid.ps1
@@ -1,0 +1,166 @@
+<#
+.SYNOPSIS
+  Register an AUMID and Start Menu shortcut so Windows Adaptive Toasts route
+  to a dev build of CCSM.
+
+.DESCRIPTION
+  Windows requires an Application User Model ID (AUMID) registered on a
+  Start Menu shortcut before it will route Adaptive Toast notifications.
+  In a packaged installer (NSIS) this happens automatically. For ad-hoc
+  `npm run dev` runs of CCSM, run this script once per machine so toast
+  buttons (Allow / Allow always / Reject) actually appear.
+
+  Idempotent: re-running overwrites the shortcut in place.
+
+.PARAMETER AppId
+  The AUMID string to register. Must match the `appId` passed to
+  `Notifier.create` from `electron/main.ts` (currently `com.ccsm.app`).
+
+.PARAMETER ShortcutName
+  Display name of the Start Menu shortcut. Defaults to "CCSM Dev".
+
+.PARAMETER TargetExe
+  Absolute path to the .exe Windows should launch when the toast body is
+  clicked. Defaults to the bundled Electron executable resolved from
+  `node_modules/electron/dist/electron.exe`.
+
+.PARAMETER Arguments
+  Extra arguments appended to the shortcut's target. Defaults to the repo
+  root so `electron .` picks up the dev entry point.
+
+.NOTES
+  Requires Windows PowerShell 5.1+ or PowerShell 7+. Does NOT need to run
+  elevated — shortcuts go under the current user's Start Menu.
+
+  Originally vendored from the standalone `@ccsm/notify` package's
+  `scripts/setup-aumid.ps1` (v0.1.1).
+#>
+
+[CmdletBinding()]
+param(
+  [string]$AppId = 'com.ccsm.app',
+  [string]$ShortcutName = 'CCSM Dev',
+  [string]$TargetExe = $null,
+  [string]$Arguments = $null
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Resolve the repo root (parent of /scripts).
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot = Resolve-Path (Join-Path $ScriptDir '..')
+
+if (-not $TargetExe) {
+  $local = Join-Path $RepoRoot 'node_modules\electron\dist\electron.exe'
+  if (Test-Path $local) {
+    $TargetExe = $local
+  }
+  else {
+    $electron = Get-Command electron -ErrorAction SilentlyContinue
+    if ($electron) {
+      $TargetExe = $electron.Source
+    }
+    else {
+      throw "Could not find electron.exe. Pass -TargetExe explicitly or run 'npm install' first."
+    }
+  }
+}
+
+if (-not $Arguments) {
+  $Arguments = "`"$RepoRoot`""
+}
+
+$StartMenu = [Environment]::GetFolderPath('Programs')
+$ShortcutPath = Join-Path $StartMenu "$ShortcutName.lnk"
+
+# Idempotency: nuke any prior .lnk so the IPropertyStore writes against a
+# fresh shell link. Re-stamping an AUMID onto a shortcut that already has
+# one returns HRESULT 0x80070001 ("Incorrect function") from Commit() on
+# Windows 10/11 — easier to delete-and-recreate than to mutate in place.
+if (Test-Path $ShortcutPath) {
+  Remove-Item $ShortcutPath -Force
+}
+
+Write-Host "Creating Start Menu shortcut:"
+Write-Host "  Path:        $ShortcutPath"
+Write-Host "  TargetExe:   $TargetExe"
+Write-Host "  Arguments:   $Arguments"
+Write-Host "  AUMID:       $AppId"
+
+$WshShell = New-Object -ComObject WScript.Shell
+$Shortcut = $WshShell.CreateShortcut($ShortcutPath)
+$Shortcut.TargetPath = $TargetExe
+$Shortcut.Arguments = $Arguments
+$Shortcut.WorkingDirectory = $RepoRoot.Path
+$Shortcut.WindowStyle = 1
+$Shortcut.Save()
+
+# Stamp the AUMID onto the shortcut. Without this, Windows uses a derived id
+# and toasts will silently no-op even with a valid shortcut.
+# Reference: https://learn.microsoft.com/windows/win32/shell/appids
+$cs = @"
+using System;
+using System.Runtime.InteropServices;
+public static class AumidSetter {
+    [ComImport]
+    [Guid("886D8EEB-8CF2-4446-8D02-CDBA1DBDCF99")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IPropertyStore {
+        [PreserveSig] int GetCount(out uint propertyCount);
+        [PreserveSig] int GetAt(uint propertyIndex, out PROPERTYKEY key);
+        [PreserveSig] int GetValue([In] ref PROPERTYKEY key, IntPtr pv);
+        [PreserveSig] int SetValue([In] ref PROPERTYKEY key, IntPtr pv);
+        [PreserveSig] int Commit();
+    }
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    public struct PROPERTYKEY {
+        public Guid fmtid;
+        public uint pid;
+    }
+    [DllImport("shell32.dll", CharSet = CharSet.Unicode)]
+    public static extern int SHGetPropertyStoreFromParsingName(
+        [MarshalAs(UnmanagedType.LPWStr)] string pszPath,
+        IntPtr zeroWorks, uint flags,
+        [In] ref Guid riid, out IPropertyStore ppv);
+
+    private const ushort VT_LPWSTR = 31;
+    private const int PROPVARIANT_SIZE = 24;
+
+    public static void SetAumid(string shortcutPath, string aumid) {
+        Guid IID_IPropertyStore = new Guid("886D8EEB-8CF2-4446-8D02-CDBA1DBDCF99");
+        IPropertyStore store;
+        int hr = SHGetPropertyStoreFromParsingName(shortcutPath, IntPtr.Zero, 2 /* GPS_READWRITE */, ref IID_IPropertyStore, out store);
+        if (hr != 0) throw new System.ComponentModel.Win32Exception(hr);
+        PROPERTYKEY key = new PROPERTYKEY {
+            fmtid = new Guid("9F4C2855-9F79-4B39-A8D0-E1D42DE1D5F3"),
+            pid = 5
+        };
+        IntPtr pv = Marshal.AllocCoTaskMem(PROPVARIANT_SIZE);
+        IntPtr strPtr = IntPtr.Zero;
+        try {
+            for (int i = 0; i < PROPVARIANT_SIZE; i++) Marshal.WriteByte(pv, i, 0);
+            strPtr = Marshal.StringToCoTaskMemUni(aumid);
+            Marshal.WriteInt16(pv, 0, (short)VT_LPWSTR);
+            Marshal.WriteIntPtr(pv, 8, strPtr);
+            hr = store.SetValue(ref key, pv);
+            if (hr != 0) throw new System.ComponentModel.Win32Exception(hr);
+            hr = store.Commit();
+            if (hr != 0) throw new System.ComponentModel.Win32Exception(hr);
+        } finally {
+            if (strPtr != IntPtr.Zero) Marshal.FreeCoTaskMem(strPtr);
+            Marshal.FreeCoTaskMem(pv);
+            Marshal.ReleaseComObject(store);
+        }
+    }
+}
+"@
+
+if (-not ([System.Management.Automation.PSTypeName]'AumidSetter').Type) {
+  Add-Type -TypeDefinition $cs -Language CSharp
+}
+
+[AumidSetter]::SetAumid($ShortcutPath, $AppId) | Out-Null
+
+Write-Host ""
+Write-Host "Done. AUMID '$AppId' is now stamped on '$ShortcutPath'."
+Write-Host "Toasts emitted by a process that calls app.setAppUserModelId('$AppId') will now route correctly."

--- a/src/agent/lifecycle.ts
+++ b/src/agent/lifecycle.ts
@@ -333,7 +333,7 @@ export function subscribeAgentEvents(): void {
           ? i18next.t('notifications.turnErrorTitle', { name: sessionName })
           : i18next.t('notifications.turnDoneTitle', { name: sessionName });
         const body = errored ? i18next.t('notifications.turnErrorBody') : undefined;
-        // Wave 1D: build extras for the @ccsm/notify Adaptive Toast pipeline.
+        // Wave 1D: build extras for the the inlined notify module Adaptive Toast pipeline.
         // Last user / assistant message previews come from the in-store block
         // history; we cap them to 200 chars to keep the toast body readable.
         const blocks = useStore.getState().messagesBySession[e.sessionId] ?? [];
@@ -443,7 +443,7 @@ export function subscribeAgentEvents(): void {
       eventType,
       title,
       body,
-      // Wave 1D: rich extras for the @ccsm/notify Adaptive Toast. The toastId
+      // Wave 1D: rich extras for the the inlined notify module Adaptive Toast. The toastId
       // for permission events is the requestId itself so the main-process
       // action router can resolve back into the same agent permission gate.
       // For question events we prefix with `q-` to mirror the in-app block id.

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -290,7 +290,7 @@ const en = {
       testFailed: 'Failed - OS notifications unavailable.',
       moduleAvailable: 'Rich Windows toasts are available.',
       moduleUnavailable:
-        'Rich Windows toasts are unavailable on this machine — the optional @ccsm/notify native module did not install. CCSM will fall back to in-app banners and standard system notifications.',
+        'Rich Windows toasts are unavailable on this machine — the optional native notification module did not install. CCSM will fall back to in-app banners and standard system notifications.',
       moduleChecking: 'Checking notification module…'
     },
     connection: {

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -269,7 +269,7 @@ const zh: EnCatalog = {
       testFailed: '失败 — 系统通知不可用。',
       moduleAvailable: '富文本 Windows 通知可用。',
       moduleUnavailable:
-        '当前环境无法使用富文本 Windows 通知 — 可选的 @ccsm/notify 原生模块未安装。CCSM 会降级到应用内横幅和标准系统通知。',
+        '当前环境无法使用富文本 Windows 通知 — 可选的原生通知模块未安装。CCSM 会降级到应用内横幅和标准系统通知。',
       moduleChecking: '正在检查通知模块…'
     },
     connection: {

--- a/src/notifications/dispatch.ts
+++ b/src/notifications/dispatch.ts
@@ -8,7 +8,7 @@ export interface DispatchInput {
   title: string;
   body?: string;
   /**
-   * Optional rich metadata forwarded to `@ccsm/notify` Adaptive Toasts in
+   * Optional rich metadata forwarded to the inlined notify module Adaptive Toasts in
    * the main process (Wave 1D). Plain Electron Notification toasts ignore
    * this — they only need `title` + `body`. Routing the action callback
    * (Allow / Allow always / Reject) back to the renderer relies on

--- a/tests/notify-fallback.test.ts
+++ b/tests/notify-fallback.test.ts
@@ -1,8 +1,8 @@
-// Unit tests for the @ccsm/notify lazy-load wrapper. Tests cover both branches:
-//   1. Optional native module fails to load (e.g. install was skipped because
-//      its electron-windows-notifications native deps couldn't build) — every
-//      wrapper function must resolve to undefined without throwing, and
-//      isNotifyAvailable() must report false.
+// Unit tests for the notify lazy-load wrapper. Tests cover both branches:
+//   1. The inlined notify implementation fails to load (e.g. install was
+//      skipped because the electron-windows-notifications native deps
+//      couldn't build) — every wrapper function must resolve to undefined
+//      without throwing, and isNotifyAvailable() must report false.
 //   2. Module loads and exposes a Notifier — wrappers must delegate to the
 //      created notifier.
 //
@@ -23,14 +23,14 @@ describe('electron/notify wrapper', () => {
     vi.restoreAllMocks();
   });
 
-  describe('when @ccsm/notify is unavailable (optional install skipped)', () => {
+  describe('when the notify implementation is unavailable (optional native dep missing)', () => {
     it('does not throw, returns resolved promises, isNotifyAvailable=false', async () => {
       const wrapper = await freshWrapper();
       // Simulate dynamic import failure (e.g. ERR_MODULE_NOT_FOUND).
-      const importErr = new Error("Cannot find package '@ccsm/notify'");
+      const importErr = new Error("Cannot find module 'electron-windows-notifications'");
       wrapper.__setNotifyImporter(() => Promise.reject(importErr));
 
-      // Suppress the "@ccsm/notify unavailable" warning the wrapper logs.
+      // Suppress the "native notification module unavailable" warning the wrapper logs.
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
       // Even without a configured notifier, all emits must complete cleanly.
@@ -79,10 +79,10 @@ describe('electron/notify wrapper', () => {
 
       expect(wrapper.isNotifyAvailable()).toBe(false);
       expect(await wrapper.probeNotifyAvailability()).toBe(false);
-      expect(wrapper.notifyLastError()).toContain("Cannot find package '@ccsm/notify'");
+      expect(wrapper.notifyLastError()).toContain("Cannot find module 'electron-windows-notifications'");
       expect(warnSpy).toHaveBeenCalled();
       const warnText = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
-      expect(warnText).toContain('@ccsm/notify unavailable, falling back to in-app only');
+      expect(warnText).toContain('native notification module unavailable, falling back to in-app only');
     });
 
     it('does not retry the import after the first failure', async () => {
@@ -108,7 +108,7 @@ describe('electron/notify wrapper', () => {
     });
   });
 
-  describe('when @ccsm/notify loads successfully', () => {
+  describe('when the notify implementation loads successfully', () => {
     it('delegates wrapper calls to the created notifier', async () => {
       const wrapper = await freshWrapper();
 


### PR DESCRIPTION
## Why

Unblock public release of ccsm (#199). The standalone `@ccsm/notify` package is a private GitHub dep (`github:Jiahui-Gu/ccsm-notify#v0.1.1` in `optionalDependencies`), which prevents the ccsm repo from being made public — anyone outside the repo can't `npm install`.

This PR vendors the upstream package source (v0.1.1) into the main repo and drops the GitHub dep. The upstream `Jiahui-Gu/ccsm-notify` repo is intentionally left alive as a historical artifact; archiving handled separately.

## What changed

**Inlined source under `electron/notify-impl/`** (mirrors upstream `src/` 1:1):

- `index.ts` — re-exports
- `notifier.ts` — platform-agnostic dispatcher
- `registry.ts` — toast callback map
- `types.ts` — payload / event types
- `util/truncate.ts` — sentence-aware truncation
- `xml/{common,done,permission,question}.ts` — Adaptive Toast XML builders
- `platform/windows.ts` — `electron-windows-notifications` adapter

**`electron/notify.ts` (the lazy-load wrapper):**
- Default importer now `require()`s `./notify-impl` synchronously instead of doing a dynamic `import('@ccsm/notify')`.
- Test seam (`__setNotifyImporter`) preserved unchanged — production code path differs but the seam shape is identical.
- `probeNotifyAvailability()` now also attempts to construct the Notifier when options are configured, so native-dep failures (which only surface inside `WindowsAdapter` constructor's `require('electron-windows-notifications')`) flip availability to `false` immediately rather than silently waiting until first emit. This is what makes the fallback-probe still meaningful after inlining.

**`package.json`:**
- Drop `"@ccsm/notify": "github:Jiahui-Gu/ccsm-notify#v0.1.1"` from `optionalDependencies`.
- Add `"electron-windows-notifications": "^3.0.8"` to `optionalDependencies` — same fail-tolerant install semantics (no prebuilds, MSBuild required, optional install per `fsevents`-style precedent).

**`scripts/setup-aumid.ps1`:** vendored from upstream `scripts/setup-aumid.ps1`, defaulted to CCSM's AUMID (`com.ccsm.app`) and dev-mode entry point. README's pwsh command updated from the old `node_modules/@ccsm/notify/scripts/...` path.

**`scripts/postinstall.mjs`:** warning text updated to reference `electron-windows-notifications` instead of `@ccsm/notify` (the optional native chain now hangs off that name directly).

**`scripts/probe-e2e-notify-fallback.mjs`:** stashes `node_modules/electron-windows-notifications` instead of `node_modules/@ccsm/notify` to simulate the failed-native-install scenario; assertion text updated to look for "native notification module" instead of "@ccsm/notify".

**i18n (`src/i18n/locales/{en,zh}.ts`):** user-facing fallback message no longer mentions `@ccsm/notify` by package name (says "the optional native notification module" / "可选的原生通知模块").

**`tests/notify-fallback.test.ts`:** assertion text updated to match the new warning string. 4 tests, all pass.

**Code-comment sweep:** stale `@ccsm/notify` references in `electron/{main,notifications,notify-bootstrap,notify-retry}.ts` and `src/{agent/lifecycle,notifications/dispatch}.ts` rewritten to "the inlined notify module".

## Verification

- `npm run build` — passes (3 pre-existing webpack bundle-size warnings, untouched by this PR).
- `npx vitest run tests/notify-fallback.test.ts` — 4 passed.
- `node scripts/probe-e2e-notify-fallback.mjs` — OK. Verified the Settings banner reads correctly and IPC `availability=false` with `electron-windows-notifications` stashed; restored on exit.
- `node scripts/probe-e2e-notify-integration.mjs` — OK end-to-end, all 12 steps pass on top of #323's blur-stabilization fix (rebased onto `4db479a`).
- Pre-existing baseline failures (3 `db-hardening` vitest tests — better-sqlite3 ABI mismatch under plain Node) confirmed identical on `origin/working` baseline; unrelated to this PR.

## Test plan

- [x] Build green
- [x] Notify-fallback unit tests pass
- [x] Notify-fallback e2e probe pass
- [x] Notify-integration e2e probe pass (full 12-step run)
- [x] Confirm no remaining `@ccsm/notify` references except intentional historical comments in `notify-impl/`, `notify.ts`, `setup-aumid.ps1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)