### PR TITLE
fix(e2e): fail harness fast when dist/renderer/bundle.js is stale

### DIFF
--- a/scripts/probe-helpers/harness-runner.mjs
+++ b/scripts/probe-helpers/harness-runner.mjs
@@ -33,6 +33,68 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '../..');
 const ARTIFACTS_ROOT = path.join(REPO_ROOT, 'scripts/e2e-artifacts');
 
+const STALE_CHECK_EXTS = new Set(['.ts', '.tsx', '.js', '.jsx', '.css']);
+
+/**
+ * Walk `src/` and return the newest mtimeMs across files matching
+ * STALE_CHECK_EXTS. Dep-free (no glob). Returns 0 if `src/` is missing.
+ *
+ * @param {string} dir
+ * @returns {number}
+ */
+function newestSrcMtime(dir) {
+  let newest = 0;
+  let stack = [dir];
+  while (stack.length > 0) {
+    const cur = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(cur, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const ent of entries) {
+      const full = path.join(cur, ent.name);
+      if (ent.isDirectory()) {
+        stack.push(full);
+      } else if (ent.isFile()) {
+        const ext = path.extname(ent.name);
+        if (STALE_CHECK_EXTS.has(ext)) {
+          try {
+            const m = fs.statSync(full).mtimeMs;
+            if (m > newest) newest = m;
+          } catch {
+            // ignore stat errors
+          }
+        }
+      }
+    }
+  }
+  return newest;
+}
+
+/**
+ * Fail fast if `dist/renderer/bundle.js` is older than the newest file under
+ * `src/`. Harness runs use CCSM_PROD_BUNDLE=1 which loads the prebuilt bundle;
+ * a stale bundle silently masks src changes (PR #322 incident, 2026-04-26).
+ *
+ * Opt out via CCSM_HARNESS_SKIP_STALE_CHECK=1.
+ */
+function assertBundleFresh() {
+  if (process.env.CCSM_HARNESS_SKIP_STALE_CHECK === '1') return;
+  const bundlePath = path.join(REPO_ROOT, 'dist/renderer/bundle.js');
+  let bundleMtime;
+  try {
+    bundleMtime = fs.statSync(bundlePath).mtimeMs;
+  } catch {
+    throw new Error(`[harness] dist/renderer/bundle.js is missing — run \`npm run build\` first (harness loads the prebuilt bundle, not the dev server)`);
+  }
+  const srcMtime = newestSrcMtime(path.join(REPO_ROOT, 'src'));
+  if (srcMtime > bundleMtime) {
+    throw new Error(`[harness] dist/renderer/bundle.js is older than src/ — run \`npm run build\` first (current bundle would mask src changes)`);
+  }
+}
+
 /**
  * Parse `--only=a,b,c` from argv. Returns null when absent (= run all).
  *
@@ -80,6 +142,10 @@ function parseOnly(argv) {
  * @param {HarnessSpec} spec
  */
 export async function runHarness(spec) {
+  // Fail-fast BEFORE launching electron: a stale dist/renderer/bundle.js
+  // would silently run the harness against old src code (see PR #322 post-mortem).
+  assertBundleFresh();
+
   const only = parseOnly(process.argv.slice(2));
   const filtered = spec.cases.filter((c) => !only || only.has(c.id));
 


### PR DESCRIPTION
## Motivation

Harness runs set `CCSM_PROD_BUNDLE=1` so Electron loads the prebuilt `dist/renderer/bundle.js` (no dev server in CI). If you forget `npm run build` after editing `src/`, the harness happily runs against stale code.

**PR #322 incident (2026-04-26):** a reviewer issued `REQUEST_CHANGES` because their stale bundle didn't contain the new `src/stores/drafts.ts` side-effect. Diagnosis took ~5 minutes and only surfaced when they retroactively ran `npm run build`. Cost: wrong review + reviewer/author confusion.

## Change

Add `assertBundleFresh()` at the top of `runHarness` (before `electron.launch`). Walks `src/` for the newest `*.{ts,tsx,js,jsx,css}` mtime, stats `dist/renderer/bundle.js`, and throws if bundle is older. Dep-free walk, no glob lib.

- **Fail-fast**: ~1s (node startup) instead of ~30s (electron + first case).
- **Opt-out**: `CCSM_HARNESS_SKIP_STALE_CHECK=1` for CI flows that prep bundles out-of-band.
- **Missing-bundle case**: also caught with a clear "run npm run build first" message.

One helper + one call site. No refactor.

## Verification (4 steps from spec)

### Step 1: fresh build
```
$ npm run build
... webpack 5.106.2 compiled with 3 warnings in 27265 ms
```

### Step 2: harness-perm with fresh bundle (should pass)
```
$ node scripts/harness-perm.mjs
...
=== totals: 12 passed, 0 failed, 12 total ===
```

### Step 3: touch src/, expect FAIL FAST
```
$ touch src/App.tsx && time node scripts/harness-perm.mjs
Error: [harness] dist/renderer/bundle.js is older than src/ — run `npm run build` first (current bundle would mask src changes)
    at assertBundleFresh (.../harness-runner.mjs:94:11)
    at runHarness (.../harness-runner.mjs:147:3)
    ...
real  0m0.946s
```
Failure happens before any electron launch — well under the 30s electron-up cost.

### Step 4: env-var bypass
```
$ CCSM_HARNESS_SKIP_STALE_CHECK=1 node scripts/harness-perm.mjs
...
=== totals: 12 passed, 0 failed, 12 total ===
```

### Step 5: rebuild + run cleanly
```
$ npm run build && node scripts/harness-perm.mjs
... webpack 5.106.2 compiled with 3 warnings in 22787 ms
...
=== totals: 12 passed, 0 failed, 12 total ===
```

## Note on webpack 5 `compareBeforeEmit`

If a rebuild is a no-op (no src content actually changed), webpack 5 skips writing `bundle.js` and its mtime stays put. In that case the gate may still flag stale even after `npm run build`. Mitigation: any **real** src change always emits a fresh bundle, so the false-positive only happens when the rebuild is unnecessary anyway. If this becomes annoying, we can add a `touch dist/renderer/bundle.js` to the build script — out of scope here.

## Hot-file safety

Only touched `scripts/probe-helpers/harness-runner.mjs`. No collision with pool-1 (harness-agent.mjs) or pool-3 (ccsm-notify inlining).