### PR TITLE
chore: fix duplicated-article typo from PR #324 sed replacement

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1305,7 +1305,7 @@ app.whenReady().then(() => {
       // count-dropped-to-0-because-CLI-self-crashed.
       selfExitCount: () => sessions.selfExitsSinceStart(),
       // Wave 1D: probe seam — exposed so `scripts/probe-e2e-notify-integration.mjs`
-      // can swap the the inlined notify module importer for a fake without resorting to
+      // can swap the inlined notify module importer for a fake without resorting to
       // `require` from inside `app.evaluate` (where it's not in scope).
       notify: notifyMod,
       notifyBootstrap: bootstrapMod,

--- a/electron/notifications.ts
+++ b/electron/notifications.ts
@@ -63,7 +63,7 @@ export interface ShowNotificationPayload {
   body?: string;
   eventType?: NotificationEventType;
   silent?: boolean;
-  /** Optional rich metadata for the the inlined notify module Adaptive Toast pipeline. */
+  /** Optional rich metadata for the inlined notify module Adaptive Toast pipeline. */
   extras?: NotifyExtras;
 }
 

--- a/electron/notify-bootstrap.ts
+++ b/electron/notify-bootstrap.ts
@@ -47,7 +47,7 @@ export type NotifyActionRouter = (event: ActionEvent) => void;
 let bootstrapped = false;
 
 /**
- * Configure the the inlined notify module wrapper. Safe to call multiple times — only the
+ * Configure the inlined notify module wrapper. Safe to call multiple times — only the
  * first invocation actually configures; subsequent calls are no-ops so the
  * onAction callback isn't replaced mid-flight (which would orphan in-flight
  * toasts).

--- a/src/agent/lifecycle.ts
+++ b/src/agent/lifecycle.ts
@@ -333,7 +333,7 @@ export function subscribeAgentEvents(): void {
           ? i18next.t('notifications.turnErrorTitle', { name: sessionName })
           : i18next.t('notifications.turnDoneTitle', { name: sessionName });
         const body = errored ? i18next.t('notifications.turnErrorBody') : undefined;
-        // Wave 1D: build extras for the the inlined notify module Adaptive Toast pipeline.
+        // Wave 1D: build extras for the inlined notify module Adaptive Toast pipeline.
         // Last user / assistant message previews come from the in-store block
         // history; we cap them to 200 chars to keep the toast body readable.
         const blocks = useStore.getState().messagesBySession[e.sessionId] ?? [];
@@ -443,7 +443,7 @@ export function subscribeAgentEvents(): void {
       eventType,
       title,
       body,
-      // Wave 1D: rich extras for the the inlined notify module Adaptive Toast. The toastId
+      // Wave 1D: rich extras for the inlined notify module Adaptive Toast. The toastId
       // for permission events is the requestId itself so the main-process
       // action router can resolve back into the same agent permission gate.
       // For question events we prefix with `q-` to mirror the in-app block id.


### PR DESCRIPTION
## Summary

PR #324's mechanical replacement of "Adaptive Toast" -> "the inlined notify module Adaptive Toast" landed "the the inlined notify module" in 5 comments. Comment-only fix; no behavior change.

## Affected files

- `electron/main.ts:1308` - "swap the the inlined notify module importer" -> "swap the inlined notify module importer"
- `electron/notifications.ts:66` - "metadata for the the inlined notify module Adaptive Toast" -> "metadata for the inlined notify module Adaptive Toast"
- `electron/notify-bootstrap.ts:50` - "Configure the the inlined notify module wrapper" -> "Configure the inlined notify module wrapper"
- `src/agent/lifecycle.ts:336` - "build extras for the the inlined notify module Adaptive Toast" -> "build extras for the inlined notify module Adaptive Toast"
- `src/agent/lifecycle.ts:446` - "rich extras for the the inlined notify module Adaptive Toast" -> "rich extras for the inlined notify module Adaptive Toast"

Also grep-checked for other sed-style "a a" duplicates - none found.

## Test plan

- [x] `npm run build` passes
- [x] Diff verified comment-only (4 files, 5 +/5 -)
- [ ] No e2e needed - pure comment fix