### PR TITLE
fix(notify): log when notification is suppressed by focus

### DIFF
--- a/electron/notifications.ts
+++ b/electron/notifications.ts
@@ -101,6 +101,14 @@ export function showNotification(
   // here, since the user is already looking at the app and the sidebar pulse
   // is sufficient). Test-only `eventType === 'test'` skips this.
   if (payload.eventType !== 'test' && shouldSuppressForFocus()) {
+    // PR #323 + #324 incident: this gate was previously silent, so a flake
+    // where a notify was unexpectedly dropped looked indistinguishable from
+    // a wrapper failure. Log every focus-suppress with enough context
+    // (event type, session, title) to disambiguate during diagnosis.
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[notify] suppressed: a window is focused, dropping notification: eventType=${payload.eventType ?? 'unknown'} sessionId=${payload.sessionId} title=${JSON.stringify(payload.title)}`,
+    );
     return false;
   }
 


### PR DESCRIPTION
## Motivation

PR #323 + #324 reviewer noted that `electron/notifications.ts` silently drops a notify when `shouldSuppressForFocus()` returns true (window focused). Zero log, zero signal — a dropped notify was indistinguishable from a wrapper failure during the PR #323 flake hunt.

Closes #207.

## Change

Single `console.warn` on the focus-suppress branch in `showNotification()` with enough context (eventType, sessionId, title) to disambiguate during future diagnosis. Behaviour is otherwise unchanged: the function still returns `false` and bails before invoking the OS Notification or the adaptive-toast fan-out, so existing callers and the IPC contract are untouched.

Scope intentionally minimum (log, not richer return value):
- Only one IPC call site (`main.ts` `notification:show` handler) consumes the boolean directly, but the renderer-side dispatchers that consume the IPC return are many and treat `false` generically. Expanding the return shape would ripple into renderer code without solving anything the log doesn't.
- Companion suppress in `notify-retry`'s `shouldSuppressRetry` is a different code path (retry-fire) and out of scope for this issue.

## Verification

- `npm run build` — clean
- `npx vitest run electron/__tests__/notifications.test.ts` — 5/5 pass
- `npx vitest run tests/notify-fallback.test.ts` — 4/4 pass
- `node scripts/probe-e2e-notify-integration.mjs` — OK (the case PR #323 stabilized still passes)
- `node scripts/probe-e2e-notify-fallback.mjs` — OK
- Manual: invoked `showNotification` with a mocked focused `BrowserWindow`, captured the warn:
  ```
  [notify] suppressed: a window is focused, dropping notification: eventType=turn_done sessionId=sess-xyz title="hello world"
  ```
  and confirmed return value === `false`.

## Test plan

- [x] vitest notifications.test.ts passes
- [x] vitest notify-fallback.test.ts passes
- [x] notify-integration probe passes
- [x] notify-fallback probe passes
- [x] manual focus-suppress path emits the warn with full context