### PR TITLE
ci: enforce main only accepts PRs from working

### DIFF
--- a/.github/workflows/main-source-guard.yml
+++ b/.github/workflows/main-source-guard.yml
@@ -1,0 +1,17 @@
+name: main source guard
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-source:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject non-working source
+        run: |
+          if [ "${{ github.head_ref }}" != "working" ]; then
+            echo "::error::PRs to main must come from 'working'. Got '${{ github.head_ref }}'."
+            exit 1
+          fi
+          echo "OK: PR head ref is 'working'."


### PR DESCRIPTION
## Summary
GitHub branch protection cannot restrict PR source branch — only destination. To enforce that main only accepts merges from working (release-branch policy), this workflow fails any PR to main whose head ref is not `working`.

After this lands, the next step is to make the `check-source` job a required status check in main's branch protection rules.

## Test plan
- [x] Local YAML parses; mirrors existing workflow structure (release.yml, ci.yml, pr-no-silent-drops.yml)
- [ ] After merge: open a test PR from a non-working branch to main → expect this check to fail