### PR TITLE
fix(perm): restore PreToolUse hook in SDK runner (#94)

### DIFF
--- a/electron/agent-sdk/__tests__/sessions.test.ts
+++ b/electron/agent-sdk/__tests__/sessions.test.ts
@@ -335,6 +335,75 @@ describe('agent-sdk/SdkSessionRunner', () => {
     runner.close();
   });
 
+  // PreToolUse hook (#94): forces the CLI to defer built-in tools (Bash etc.)
+  // to canUseTool instead of auto-allowing via its safe-command heuristics.
+  // The CLI sees `permissionDecision: 'ask'` for non-passthrough tools and
+  // `'allow'` for passthrough/bypass paths.
+  type HookFn = (
+    input: { hook_event_name: 'PreToolUse'; tool_name: string },
+    toolUseID: string | undefined,
+    options: { signal: AbortSignal },
+  ) => Promise<{
+    hookSpecificOutput?: { hookEventName: string; permissionDecision?: string };
+  }>;
+  const getPreToolUseHook = (): HookFn => {
+    const opts = fake.getOptions()?.options as {
+      hooks?: { PreToolUse?: Array<{ matcher?: string; hooks: HookFn[] }> };
+    };
+    const matcher = opts.hooks?.PreToolUse?.[0];
+    if (!matcher) throw new Error('PreToolUse hook matcher not registered');
+    expect(matcher.matcher).toBe('.*');
+    return matcher.hooks[0];
+  };
+
+  it('PreToolUse hook returns ask for built-in tools in default mode (#94)', async () => {
+    const runner = new SdkSessionRunner('s12-pt-default', noop, noop, noop, noop);
+    await runner.start({ ...baseStart, permissionMode: 'default' });
+    const hook = getPreToolUseHook();
+    const ac = new AbortController();
+    const out = await hook(
+      { hook_event_name: 'PreToolUse', tool_name: 'Bash' },
+      'tu-bash',
+      { signal: ac.signal },
+    );
+    expect(out.hookSpecificOutput?.hookEventName).toBe('PreToolUse');
+    expect(out.hookSpecificOutput?.permissionDecision).toBe('ask');
+    runner.close();
+  });
+
+  it('PreToolUse hook returns allow for passthrough tools (#94)', async () => {
+    const runner = new SdkSessionRunner('s12-pt-pass', noop, noop, noop, noop);
+    await runner.start({ ...baseStart, permissionMode: 'default' });
+    const hook = getPreToolUseHook();
+    const ac = new AbortController();
+    for (const tool of ['AskUserQuestion', 'ExitPlanMode']) {
+      const out = await hook(
+        { hook_event_name: 'PreToolUse', tool_name: tool },
+        'tu-pass',
+        { signal: ac.signal },
+      );
+      expect(out.hookSpecificOutput?.permissionDecision).toBe('allow');
+    }
+    runner.close();
+  });
+
+  it.each(['bypassPermissions', 'acceptEdits', 'auto'] as const)(
+    'PreToolUse hook returns allow in %s mode (no host round-trip needed)',
+    async (mode) => {
+      const runner = new SdkSessionRunner(`s12-pt-${mode}`, noop, noop, noop, noop);
+      await runner.start({ ...baseStart, permissionMode: mode });
+      const hook = getPreToolUseHook();
+      const ac = new AbortController();
+      const out = await hook(
+        { hook_event_name: 'PreToolUse', tool_name: 'Bash' },
+        'tu-bypass',
+        { signal: ac.signal },
+      );
+      expect(out.hookSpecificOutput?.permissionDecision).toBe('allow');
+      runner.close();
+    },
+  );
+
   it('close() resolves outstanding permission requests as denied', async () => {
     let capturedReq: { requestId: string } | null = null;
     const runner = new SdkSessionRunner(

--- a/electron/agent-sdk/sessions.ts
+++ b/electron/agent-sdk/sessions.ts
@@ -378,6 +378,28 @@ export class SdkSessionRunner {
         sessionId: presetSessionId,
         pathToClaudeCodeExecutable: binaryPath,
         canUseTool: (toolName, input, ctx) => this.handleCanUseTool(toolName, input, ctx),
+        // PreToolUse hook (#94): the CLI's local rule engine handles built-in
+        // tools (Bash/Write/Edit/...) entirely client-side and only routes
+        // "ask" tools (AskUserQuestion / ExitPlanMode) through canUseTool.
+        // Without an external signal, Bash in `default` mode auto-allows
+        // based on the CLI's safe-command heuristics — so the renderer's
+        // PermissionPromptBlock never renders and probes can't assert the
+        // permission flow ran. The legacy wrapper used `--pretool-use-hook`
+        // to force every tool through our handler; the SDK exposes the same
+        // mechanism via `options.hooks`. Returning `permissionDecision:'ask'`
+        // makes the CLI defer to canUseTool. PASSTHROUGH_TOOLS get an
+        // explicit `allow` so we don't double-prompt over the renderer's
+        // own AskUserQuestion / ExitPlanMode UI (which uses canUseTool too;
+        // the canUseTool short-circuit at the top of handleCanUseTool stays
+        // as defence-in-depth).
+        hooks: {
+          PreToolUse: [
+            {
+              matcher: '.*',
+              hooks: [this.makePreToolUseHook()],
+            },
+          ],
+        },
         // Match the legacy spawner: we want partial-message streaming so
         // long replies don't appear frozen.
         includePartialMessages: true,
@@ -545,6 +567,42 @@ export class SdkSessionRunner {
     return {
       behavior: 'deny',
       message: decision.deny_reason ?? 'User denied tool use.',
+    };
+  }
+
+  /**
+   * Build the PreToolUse hook callback (#94). Fires for EVERY tool invocation
+   * (matcher `.*`) and forces the CLI to consult our canUseTool callback
+   * instead of auto-allowing built-in tools via its safe-command heuristics.
+   *
+   * Returned shape: `SyncHookJSONOutput` with a `PreToolUseHookSpecificOutput`
+   * payload. `permissionDecision: 'ask'` tells the CLI "delegate to the host's
+   * canUseTool"; `'allow'` tells it "skip canUseTool and run the tool". We use
+   * 'allow' for passthrough tools (AskUserQuestion / ExitPlanMode) so the
+   * renderer's bespoke UI stays the single source of truth for those — same
+   * rationale as the PASSTHROUGH_TOOLS short-circuit at the top of
+   * handleCanUseTool. Bypass-style modes are also fast-pathed to 'allow' so
+   * we don't pay a host round-trip per tool invocation when the user has
+   * explicitly opted out of prompting.
+   */
+  private makePreToolUseHook(): import('@anthropic-ai/claude-agent-sdk').HookCallback {
+    return async (input) => {
+      const toolName =
+        input.hook_event_name === 'PreToolUse' ? input.tool_name : '';
+      const decision: import('@anthropic-ai/claude-agent-sdk').HookPermissionDecision =
+        this.permissionMode === 'bypassPermissions' ||
+        this.permissionMode === 'yolo' ||
+        this.permissionMode === 'acceptEdits' ||
+        this.permissionMode === 'auto' ||
+        PASSTHROUGH_TOOLS.has(toolName)
+          ? 'allow'
+          : 'ask';
+      return {
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: decision,
+        },
+      };
     };
   }
 

--- a/scripts/probe-e2e-permission-allow-bash.mjs
+++ b/scripts/probe-e2e-permission-allow-bash.mjs
@@ -9,24 +9,18 @@
 // but the bash never executed and no tool_result arrived. Post-fix the
 // nested control_response envelope reaches claude.exe and the bash runs.
 //
-// known-incomplete: PreToolUse missing (#94)
-// ─────────────────────────────────────────
+// PreToolUse hook restored (#94 fix, post PR #271 SDK migration)
+// ──────────────────────────────────────────────────────────────
 // The Claude Code CLI's local rule engine handles built-in `Bash` tool
-// invocations entirely client-side and does NOT route them through
-// `canUseTool` (the SDK callback ccsm hooks into). Pre-#94 the legacy
-// runner registered a `PreToolUse` hook with matcher `.*` to bridge every
-// tool invocation through the permission flow regardless of CLI internal
-// rules. The SDK migration dropped that hook; the SDK has no equivalent
-// API surface yet (verified against
-// node_modules/@anthropic-ai/claude-agent-sdk/sdk.d.ts).
-//
-// Net effect: in default permission mode no Allow button ever appears for
-// Bash. Per ccsm e2e policy ("never skip — degrade with a labeled
-// assertion") this probe degrades to: tool block lands with a tool_result
-// regardless of whether the prompt rendered. The original strict
-// "Allow-clicked → result lands" assertion is preserved as a soft check
-// that LOGS rather than fails when the prompt doesn't fire. Once #94
-// lands the soft check should be promoted back to a hard assert.
+// invocations entirely client-side; in default mode it will auto-allow many
+// Bash calls based on its safe-command heuristics and never consult
+// `canUseTool` (the SDK callback ccsm hooks into). To force every tool
+// invocation through ccsm's permission flow, the runner registers a
+// `PreToolUse` SDK hook (`options.hooks.PreToolUse`, matcher `.*`,
+// `permissionDecision: 'ask'`) — see electron/agent-sdk/sessions.ts. With
+// that hook the CLI defers Bash to canUseTool deterministically, the
+// renderer alertdialog renders, and Allow → tool_result is the strict
+// assertion below.
 import { _electron as electron } from 'playwright';
 import path from 'node:path';
 import fs from 'node:fs';
@@ -117,14 +111,12 @@ await ta.fill(PROMPT);
 await win.keyboard.press('Enter');
 log('prompt sent');
 
-// Race: either an Allow button appears (strict path — assert on it) OR the
-// Bash tool block lands a tool_result without ever prompting (degraded
-// path — log and continue, mark known-incomplete (#94)).
+// With the PreToolUse hook (#94) installed in the SDK runner, the Allow
+// button MUST appear and a click MUST land before the tool_result arrives.
 const allowSel = '[data-perm-action="allow"]';
 const waitDl = Date.now() + 90_000;
 let allowClicked = false;
 let storeHit = null;
-let knownIncomplete = false;
 while (Date.now() < waitDl) {
   await win.waitForTimeout(1000);
   // Strict path — click Allow if rendered.
@@ -173,15 +165,10 @@ if (storeHit.isError)
   fail(`Bash tool block received an ERROR result: ${storeHit.head}`, app);
 
 if (!allowClicked) {
-  knownIncomplete = true;
-  log('known-incomplete: PreToolUse missing (#94) — Bash auto-allowed by CLI without firing canUseTool; tool result still landed, so degraded assertion passes.');
+  fail('Allow button never rendered — PreToolUse hook (#94) regression? CLI auto-allowed Bash without firing canUseTool.', app);
 }
 
-console.log(
-  knownIncomplete
-    ? '[probe-bugl-bash] OK (known-incomplete: PreToolUse missing #94): bash executed, tool_result delivered; permission prompt never fired (CLI client-side auto-allow)'
-    : '[probe-bugl-bash] OK: bash executed, tool_result delivered'
-);
+console.log('[probe-bugl-bash] OK: Allow clicked, bash executed, tool_result delivered');
 await app.close();
 cfg.cleanup();
 process.exit(0);

--- a/scripts/probe-e2e-permission-allow-parallel-batch.mjs
+++ b/scripts/probe-e2e-permission-allow-parallel-batch.mjs
@@ -19,18 +19,16 @@
 //      unique `tool_use.id`. See `assistantBlocks` in
 //      `src/agent/stream-to-blocks.ts`.
 //
-// known-incomplete: PreToolUse missing (#94)
-// ─────────────────────────────────────────
+// PreToolUse hook restored (#94 fix, post PR #271 SDK migration)
+// ──────────────────────────────────────────────────────────────
 // In default mode the CLI auto-allows built-in `Bash` (and often `Read`)
-// invocations client-side, so no permission prompt fires and `clicks`
-// will be 0. The actual Bug L invariant (`N tool_use blocks → N tool
-// blocks in store → N tool_results`) is independent of whether a prompt
-// rendered — IPC envelope correctness applies equally to the auto-allow
-// path. So this probe degrades to: assert N parallel tool blocks exist
-// AND each carries a tool_result. The strict-equality `clicks === N`
-// assertion is preserved as a soft check that LOGS "known-incomplete:
-// PreToolUse missing (#94)" rather than failing when the prompt doesn't
-// fire. Once #94 lands the strict path should be re-enabled.
+// invocations client-side via its safe-command heuristics. To force every
+// invocation through ccsm's permission flow, the runner registers a
+// `PreToolUse` SDK hook (`options.hooks.PreToolUse`, matcher `.*`,
+// `permissionDecision: 'ask'`) — see electron/agent-sdk/sessions.ts. With
+// that hook in place, this probe re-asserts strict equality
+// `clicks === expectedClicks` (every parallel tool_use → every Allow
+// click → every tool_result).
 import { _electron as electron } from 'playwright';
 import path from 'node:path';
 import fs from 'node:fs';
@@ -196,25 +194,17 @@ async function runCase({ caseName, files, prompt, toolName, expectedClicks }) {
   log(`[${caseName}] final snapshot: tools=${JSON.stringify(snap.tools)} resolvedTraces=${snap.resolvedTraces}`);
   log(`[${caseName}] final allBlocks=${JSON.stringify(snap.allBlockKinds)}`);
 
-  // Strict equality `clicks === expectedClicks` is degraded to a SOFT check
-  // when the CLI auto-allowed (clicks === 0). See "known-incomplete: #94".
-  let knownIncomplete = false;
+  // Strict equality `clicks === expectedClicks` — with the PreToolUse hook
+  // (#94) installed, every parallel tool_use must surface an Allow click.
   if (expectedClicks && clicks !== expectedClicks) {
-    if (clicks === 0) {
-      knownIncomplete = true;
-      console.warn(
-        `[${caseName}] known-incomplete: PreToolUse missing (#94) — expected ${expectedClicks} Allow clicks, observed 0. CLI auto-allowed all ${expectedClicks} ${toolName} calls client-side without firing canUseTool. Falling through to the N-tool-block invariant assertion (the actual Bug L target).`
-      );
-    } else {
-      fail(
-        `[${caseName}] expected ${expectedClicks} Allow clicks but observed ${clicks} (partial — neither the strict path nor the auto-allow path). ` +
-          `Did the model serialize the calls instead of issuing them in parallel?`,
-        app,
-      );
-    }
+    fail(
+      `[${caseName}] expected ${expectedClicks} Allow clicks but observed ${clicks}. ` +
+        `Either the model serialized the calls (didn't issue them in parallel) OR the PreToolUse hook (#94) regressed.`,
+      app,
+    );
   }
 
-  if (!knownIncomplete && snap.resolvedTraces < clicks)
+  if (snap.resolvedTraces < clicks)
     fail(
       `[${caseName}] Bug L renderer regression: clicked Allow ${clicks}x but only ${snap.resolvedTraces} permission-resolved traces appeared in store.`,
       app,
@@ -243,9 +233,9 @@ async function runCase({ caseName, files, prompt, toolName, expectedClicks }) {
     fail(`[${caseName}] one or more ${toolName} tool blocks errored: ${JSON.stringify(errored)}`, app);
 
   log(
-    `[${caseName}] OK${knownIncomplete ? ' (known-incomplete: PreToolUse missing #94)' : ''}: ${clicks} Allow clicks → ${snap.resolvedTraces} resolved traces, ${succeeded.length}/${targetN} ${toolName} blocks have tool_result.`,
+    `[${caseName}] OK: ${clicks} Allow clicks → ${snap.resolvedTraces} resolved traces, ${succeeded.length}/${targetN} ${toolName} blocks have tool_result.`,
   );
-  return { clicks, snap, knownIncomplete };
+  return { clicks, snap };
 }
 
 // === case: parallel-bash-N4 ===
@@ -315,8 +305,9 @@ const READ_PROMPT =
   log(`[${caseName}] prompt sent`);
 
   const allowSel = '[data-perm-action="allow"]';
-  // Same combined click+poll loop as runCase (see comment there for why
-  // this can't gate on `clicks > 0` post-#94 SDK migration).
+  // Same combined click+poll loop as runCase. With the PreToolUse hook
+  // (#94) wired into the SDK runner, the CLI defers every Read to
+  // canUseTool deterministically, so `clicks` should equal `snap.reads.length`.
   const totalDl = Date.now() + 180_000;
   let clicks = 0;
   let snap = null;
@@ -376,28 +367,21 @@ const READ_PROMPT =
 
   // We expect ~5 parallel Read calls. The model occasionally folds two reads
   // into one batch with sequential follow-ups; tolerate a small undercount
-  // (≥4 reads end-to-end). With #94 missing the CLI may auto-allow Reads
-  // and clicks==0 is acceptable so long as the N reads land.
-  let knownIncomplete = false;
+  // (≥4 reads end-to-end). With the PreToolUse hook (#94) installed,
+  // `clicks` should match `snap.reads.length`.
   if (snap.reads.length < 4)
     fail(
       `[${caseName}] expected ~5 parallel Read tool blocks (model declined to parallelize?); only saw ${snap.reads.length}.`,
       app,
     );
-  if (clicks === 0) {
-    knownIncomplete = true;
-    console.warn(
-      `[${caseName}] known-incomplete: PreToolUse missing (#94) — observed 0 Allow clicks, ${snap.reads.length} Read blocks. CLI auto-allowed all Reads client-side.`
-    );
-  } else if (clicks < snap.reads.length - 1) {
-    // partial — neither path. e.g. 2 clicks for 5 reads is suspicious.
+  if (clicks < snap.reads.length - 1) {
     fail(
-      `[${caseName}] saw ${clicks} Allow clicks for ${snap.reads.length} Read tool blocks — partial click coverage. Either the prompt UI dropped some prompts or some auto-allowed and others didn't.`,
+      `[${caseName}] saw ${clicks} Allow clicks for ${snap.reads.length} Read tool blocks — partial click coverage. PreToolUse hook (#94) regression?`,
       app,
     );
   }
 
-  if (!knownIncomplete && snap.resolvedTraces < clicks)
+  if (snap.resolvedTraces < clicks)
     fail(
       `[${caseName}] renderer regression: clicked Allow ${clicks}x but only ${snap.resolvedTraces} permission-resolved traces appeared.`,
       app,
@@ -416,7 +400,7 @@ const READ_PROMPT =
     fail(`[${caseName}] one or more Read tool blocks errored: ${JSON.stringify(errored)}`, app);
 
   log(
-    `[${caseName}] OK${knownIncomplete ? ' (known-incomplete: PreToolUse missing #94)' : ''}: ${clicks} Allow clicks → ${snap.resolvedTraces} resolved traces, ${succeeded.length}/${snap.reads.length} Read blocks have tool_result.`,
+    `[${caseName}] OK: ${clicks} Allow clicks → ${snap.resolvedTraces} resolved traces, ${succeeded.length}/${snap.reads.length} Read blocks have tool_result.`,
   );
 }
 

--- a/scripts/probe-e2e-permission-prompt-default-mode.mjs
+++ b/scripts/probe-e2e-permission-prompt-default-mode.mjs
@@ -8,26 +8,13 @@
 // based on its safe-command heuristics and never emits `can_use_tool`. So
 // the renderer's PermissionPromptBlock had nothing to render.
 //
-// Fix (legacy): at `initialize` time we registered a `PreToolUse` hook with
-// matcher `.*`. The CLI sent a `hook_callback` request for every tool
-// invocation; our handler routed it through the same `onPermissionRequest`
-// flow that `can_use_tool` used. AskUserQuestion / ExitPlanMode were still
-// handled via can_use_tool (we no-op the hook for them so we don't
-// double-prompt).
-//
-// known-incomplete: PreToolUse missing (#94)
-// ─────────────────────────────────────────
-// The SDK migration dropped the legacy spawner's PreToolUse hook
-// registration. The agent SDK's public API surface
-// (@anthropic-ai/claude-agent-sdk/sdk.d.ts) currently has no equivalent
-// for registering a PreToolUse hook from a host process — `canUseTool` is
-// the only callback exposed, and the CLI doesn't route built-in Bash
-// invocations through it. Net effect: Bash in default mode runs WITHOUT a
-// permission prompt UI today. Per ccsm e2e policy this probe degrades to
-// a soft assertion: the Bash command must still execute end-to-end (the
-// MARKER lands in the chat), so the agent isn't broken — only the prompt
-// UI is missing. Once #94 lands the strict alertdialog assertion below
-// should be promoted back to a hard fail.
+// Fix (current — restored after PR #271 SDK migration): we register a
+// `PreToolUse` SDK hook with matcher `.*` (electron/agent-sdk/sessions.ts).
+// The CLI sends a `hook_callback` request for every tool invocation; our
+// hook returns `permissionDecision: 'ask'` for non-passthrough tools, which
+// forces the CLI to delegate to canUseTool (and thus our renderer
+// prompt). AskUserQuestion / ExitPlanMode get `'allow'` from the hook so
+// the renderer's bespoke UI stays the single source of truth for them.
 
 import { _electron as electron } from 'playwright';
 import path from 'node:path';
@@ -177,42 +164,42 @@ await textarea.fill(
 );
 await win2.keyboard.press('Enter');
 
-// 4. Within 30s, the permission UI SHOULD appear (strict assertion). With
-//    PreToolUse missing (#94), the CLI auto-allows Bash before
-//    canUseTool ever fires, so no alertdialog is rendered. Degrade to a
-//    soft check: log a `known-incomplete` warning and continue to the
-//    end-to-end marker assertion below.
+// 4. Within 30s the permission UI MUST appear. With the PreToolUse hook
+//    wired (#94 fix), the CLI consults canUseTool for every Bash call and
+//    the renderer renders the alertdialog deterministically.
 const dialog = win2.locator('[role="alertdialog"]').first();
-let promptUiSeen = true;
 try {
   await dialog.waitFor({ state: 'visible', timeout: 30_000 });
 } catch {
-  promptUiSeen = false;
-  console.warn(
-    `[${NAME}] known-incomplete: PreToolUse missing (#94) — no [role="alertdialog"] permission prompt UI within 30s. ` +
-      `CLI auto-allowed the Bash call client-side. Soft-passing on the marker assertion below.`
+  fail(
+    'no [role="alertdialog"] permission prompt UI within 30s — PreToolUse hook (#94) regression?'
   );
 }
 
-if (promptUiSeen) {
-  const headingCount = await dialog.locator('text=Permission required').first().count();
-  if (headingCount === 0) fail('alertdialog visible but no "Permission required" heading');
-  const dialogText = (await dialog.innerText()).toLowerCase();
-  if (!dialogText.includes('bash') && !dialogText.includes(MARKER)) {
-    fail(`prompt does not mention Bash or the marker; saw: ${dialogText.slice(0, 400)}`);
-  }
+// PR #288 introduced per-tool titles ("Allow this bash command?") that
+// replace the generic "Permission required" for known tools. Accept either
+// — the assertion is "a recognisable permission heading is rendered", not
+// the literal English of the fallback.
+const headingHits = await dialog
+  .locator('text=/Permission required|Allow this bash command\\?/')
+  .first()
+  .count();
+if (headingHits === 0) fail('alertdialog visible but no recognisable permission heading');
+const dialogText = (await dialog.innerText()).toLowerCase();
+if (!dialogText.includes('bash') && !dialogText.includes(MARKER)) {
+  fail(`prompt does not mention Bash or the marker; saw: ${dialogText.slice(0, 400)}`);
+}
 
-  // 5. Click Allow.
-  const allowBtn = win2.locator('[data-perm-action="allow"]').first();
-  await allowBtn.waitFor({ state: 'visible', timeout: 5_000 });
-  await allowBtn.click();
+// 5. Click Allow.
+const allowBtn = win2.locator('[data-perm-action="allow"]').first();
+await allowBtn.waitFor({ state: 'visible', timeout: 5_000 });
+await allowBtn.click();
 
-  // 6. Prompt detaches; bash output (marker) appears within 30s.
-  try {
-    await dialog.waitFor({ state: 'detached', timeout: 10_000 });
-  } catch {
-    fail('alertdialog still attached 10s after clicking Allow');
-  }
+// 6. Prompt detaches; bash output (marker) appears within 30s.
+try {
+  await dialog.waitFor({ state: 'detached', timeout: 10_000 });
+} catch {
+  fail('alertdialog still attached 10s after clicking Allow');
 }
 
 const markerSeen = await (async () => {
@@ -228,11 +215,7 @@ if (!markerSeen) {
   const dump = await win2.evaluate(() => document.body.innerText.slice(0, 2500));
   console.error('--- final body text ---');
   console.error(dump);
-  fail(
-    promptUiSeen
-      ? `marker "${MARKER}" never appeared in conversation within 30s of Allow click`
-      : `marker "${MARKER}" never appeared in conversation within 30s (no prompt fired AND tool never executed — neither path works)`
-  );
+  fail(`marker "${MARKER}" never appeared in conversation within 30s of Allow click`);
 }
 
 // 7. Best-effort: running state should clear within 20s.
@@ -252,11 +235,9 @@ const stoppedRunning = await (async () => {
 })();
 if (!stoppedRunning) console.warn(`[${NAME}] WARN: still in running state 20s after marker appeared`);
 
-console.log(`\n[${NAME}] OK${promptUiSeen ? '' : ' (known-incomplete: PreToolUse missing #94)'}`);
+console.log(`\n[${NAME}] OK`);
 console.log(
-  promptUiSeen
-    ? `  - permission prompt rendered, allow clicked, marker "${MARKER}" appeared in chat`
-    : `  - permission prompt did NOT render (CLI auto-allow path); marker "${MARKER}" still appeared in chat (tool ran end-to-end)`
+  `  - permission prompt rendered, allow clicked, marker "${MARKER}" appeared in chat`
 );
 
 await app2.close();


### PR DESCRIPTION
## Summary
Restore the `PreToolUse` hook lost during the SDK migration (PR #271). Without it, the CLI auto-allows built-in tools (Bash/Write/Edit) via its safe-command heuristics and never consults `canUseTool`, so the renderer permission prompt didn't render in default mode and probes couldn't deterministically assert the permission flow.

## Approach choice (Layer 1)
Investigated three options:
- **(A) Re-wire via SDK hook** — chosen. The SDK exposes `options.hooks` with `HookCallbackMatcher` (verified in `node_modules/@anthropic-ai/claude-agent-sdk/sdk.d.ts`, lines 716–738, 3251). `PreToolUseHookSpecificOutput.permissionDecision` accepts `'ask' | 'allow' | 'deny' | 'defer'` — `'ask'` forces the CLI to delegate to `canUseTool`. This is a small, contained wiring change.
- (B) Renderer-side instrumentation event — would have left the CLI's auto-allow path intact (probes still couldn't drive the prompt UI for Bash). Rejected.
- (C) Won't-fix — the existing probe comments explicitly call out the gap and degrade soft-pass; without the fix probes could never assert the canonical `Allow click → tool runs` invariant for built-in tools. Rejected.

(A) is straightforward (~30 LOC + tests), so done.

## What I implemented
- `electron/agent-sdk/sessions.ts` — register a PreToolUse hook (matcher `.*`) in `start()`. The hook returns `permissionDecision: 'ask'` for non-passthrough tools (forces `canUseTool`), `'allow'` for `PASSTHROUGH_TOOLS` (AskUserQuestion / ExitPlanMode — the renderer's own UI handles these) and bypass-style modes (no host round-trip needed).
- `electron/agent-sdk/__tests__/sessions.test.ts` — 3 new tests covering ask path (Bash in default mode), allow path (passthrough tools), and bypass-mode short-circuit.
- 3 e2e probes — promoted soft `known-incomplete (#94)` assertions back to strict:
  - `probe-e2e-permission-prompt-default-mode.mjs` (heading match relaxed to accept PR #288's per-tool titles)
  - `probe-e2e-permission-allow-bash.mjs`
  - `probe-e2e-permission-allow-parallel-batch.mjs`

## Test plan
- [x] `npm run build` — clean
- [x] `vitest electron/agent-sdk/__tests__/sessions.test.ts` — 23/23 pass
- [x] `node scripts/harness-perm.mjs` — 12/12 cases green
- [x] `node scripts/probe-e2e-permission-prompt-default-mode.mjs` — OK (alertdialog renders, Allow clicked, marker delivered)
- [x] `node scripts/probe-e2e-permission-allow-bash.mjs` — OK (Allow clicked, `node --version` ran, `v24.14.1` returned)
- [x] `node scripts/probe-e2e-permission-allow-parallel-batch.mjs` — OK: parallel-bash-N4 (4 clicks → 4 results), parallel-read-N5 (5 clicks → 5 results)

🤖 Generated with [Claude Code](https://claude.com/claude-code)