### PR TITLE
test(e2e): assert AgentDiagnosticBanner is empty after happy-path streaming

### DIFF
--- a/scripts/harness-agent.mjs
+++ b/scripts/harness-agent.mjs
@@ -273,7 +273,28 @@ async function caseStreaming({ win, log }) {
   const finalCaretCount = await win.locator('span.animate-pulse').count();
   if (finalCaretCount !== 0) throw new Error(`caret should disappear after finalize; found ${finalCaretCount}`);
 
-  log('3 deltas coalesced into 1 block; caret shown then hidden on finalize');
+  // Baseline-diagnostics-empty contract (task #88): a happy-path streaming
+  // turn must NOT push any non-dismissed diagnostics for the active session.
+  // The store's lifecycle (setRunning, streamAssistantText, appendBlocks)
+  // does not auto-clear diagnostics, so any leak here would persist across
+  // turns. Dual check: DOM (banner not rendered) AND store (no active
+  // entries scoped to this session). Brief settle for any TopBanner
+  // <AnimatePresence> exit transition.
+  await win.waitForTimeout(250);
+  const baselineBannerCount = await win.locator('[data-testid="agent-diagnostic-banner"]').count();
+  if (baselineBannerCount !== 0) {
+    throw new Error(`baseline diagnostics should be empty after happy-path streaming; banner count=${baselineBannerCount}`);
+  }
+  const baselineStoreActive = await win.evaluate((sid) => {
+    const st = window.__ccsmStore.getState();
+    const all = st.diagnostics ?? [];
+    return all.filter((d) => d.sessionId === sid && !d.dismissed).map((d) => ({ code: d.code, level: d.level, message: d.message }));
+  }, sessionId);
+  if (baselineStoreActive.length !== 0) {
+    throw new Error(`baseline diagnostics should be empty in store for active session; found ${baselineStoreActive.length}: ${JSON.stringify(baselineStoreActive)}`);
+  }
+
+  log('3 deltas coalesced into 1 block; caret shown then hidden on finalize; baseline diagnostics empty (DOM + store)');
 }
 
 // ---------- streaming-caret-lifecycle ----------


### PR DESCRIPTION
## Summary
Extend the `streaming` case in `scripts/harness-agent.mjs` (task #88) with a baseline-diagnostics-empty dual assertion that locks in the contract: a happy-path agent run must not push any non-dismissed diagnostics.

- **DOM check**: `[data-testid="agent-diagnostic-banner"]` count === 0 after the streaming turn finalizes (caret cleared).
- **Store check**: `state.diagnostics.filter(d => d.sessionId === sid && !d.dismissed).length === 0`.

The store's `setRunning` / `streamAssistantText` / `appendBlocks` do not auto-clear diagnostics, so any stray push (info-level "turn complete" notice, leaked warning, etc.) would persist across turns. This catches such leaks at their source.

Closes #88. Plan: `docs/task-88-draft.md` (per worker brief).

## Verification

### Two-round green proof (`node scripts/harness-agent.mjs`)

Note: this branch is from before PR #326 lands, so the suite has 17 cases (not 20/23).

**Round 1**
```
=== totals: 17 passed, 0 failed, 17 total ===
  [OK] streaming                                  1285ms
  ... (all 17 OK)
```

**Round 2**
```
=== totals: 17 passed, 0 failed, 17 total ===
  [OK] streaming                                  2973ms
  ... (all 17 OK)
```

### Reverse-verify (the assertion is not a no-op)

Temporarily injected a fake diagnostic via `pushDiagnostic({ sessionId, level: 'warn', code: 'reverse_verify', ... })` immediately before the new assertion, then ran `--only=streaming`:

```
[case=streaming] FAIL: baseline diagnostics should be empty after happy-path streaming; banner count=1
=== totals: 0 passed, 1 failed, 1 total ===
```

The DOM check correctly fired (banner count went from 0 to 1). Injection was then removed and the case returned to green (Round 2 above).

### Production-bug findings
None. The happy-path codepath leaves diagnostics empty as expected. No bonus bug to file.

## Test plan
- [x] `npm run build` (passes #325 stale-bundle gate)
- [x] `node scripts/harness-agent.mjs` 2 rounds, all 17 cases green
- [x] Reverse-verify: injected fake diagnostic causes the assertion to fail with a clear message; removed cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)