### PR TITLE
fix(e2e): stale-bundle gate no longer trips after git checkout

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dev": "concurrently -k -n web,app -c blue,magenta \"npm:dev:web\" \"npm:dev:app\"",
     "dev:web": "webpack serve --config webpack.config.js --mode development",
     "dev:app": "wait-on http://localhost:4100 && tsc -p tsconfig.electron.json && electron .",
-    "build": "tsc -p tsconfig.electron.json && webpack --mode production",
+    "build": "tsc -p tsconfig.electron.json && webpack --mode production && node -e \"const fs=require('fs');const p='dist/renderer/bundle.js';const t=Date.now()/1000;fs.utimesSync(p,t,t)\"",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.electron.json",
     "lint": "eslint . --ext .ts,.tsx",
     "test": "vitest run",


### PR DESCRIPTION
## Problem

PR #325 added a fail-fast gate in `scripts/probe-helpers/harness-runner.mjs` that compares `mtime(dist/renderer/bundle.js)` vs newest mtime under `src/**`. Two workers (PR #325 reviewer + PR #331 worker) hit a false positive in the past hour:

```bash
git checkout -B branch origin/working   # bumps src/* mtimes on some FS/git combos
npm run build                            # webpack compareBeforeEmit:true skips
                                         # re-emit when bundle content unchanged
node scripts/harness-ui.mjs              # gate fires: "bundle older than src"
```

Both workers worked around it with a manual `touch dist/renderer/bundle.js` — the same operation this PR now does automatically.

## Fix (option B)

Append a one-line inline node step to the `build` script that touches `dist/renderer/bundle.js` after webpack finishes. Cross-platform, no new dep, no runtime gate change. Diff is +1 line in `package.json`.

```diff
- "build": "tsc -p tsconfig.electron.json && webpack --mode production",
+ "build": "tsc -p tsconfig.electron.json && webpack --mode production && node -e \"const fs=require('fs');const p='dist/renderer/bundle.js';const t=Date.now()/1000;fs.utimesSync(p,t,t)\"",
```

Other options considered:
- **A** (sha256 hash cache): more robust but ~30 lines + cache file management. Overkill when B fixes the symptom cheaply.
- **C** (disable webpack `compareBeforeEmit`): adds a needless disk write on every no-op rebuild.
- **D** (downgrade gate to warn): defeats the purpose of PR #325.

## Repro proof (verified locally)

1. **False-positive scenario** (artificially advance `src/App.tsx` mtime past current bundle, then `npm run build`):
   - Before fix: gate would fire (`stale? true`).
   - After fix: bundle mtime = post-build `now` > src mtime → `stale? false`. Gate PASSES.

2. **Real stale** (edit `src/App.tsx` AFTER build, do NOT rebuild):
   - Gate FIRES with the original PR #325 error message: ``[harness] dist/renderer/bundle.js is older than src/ — run `npm run build` first (current bundle would mask src changes)``.

3. **Normal `npm run build`** (no checkout shenanigans): gate PASSES clean.

## Test plan
- [x] False-positive scenario produces `stale? false` after `npm run build`
- [x] Real stale (edited src, no rebuild) still trips the gate
- [x] Plain `npm run build` followed by harness import → gate passes
- [ ] Reviewer: re-run the same three scenarios from a fresh checkout