### PR TITLE
harness-runner: per-case capability extension (#223)

### DIFF
--- a/scripts/harness-agent.mjs
+++ b/scripts/harness-agent.mjs
@@ -2130,6 +2130,62 @@ async function caseUserBlockHoverMenu({ win, log }) {
   log('hover reveals 4 actions; Copy -> clipboard; Truncate -> cut + clear resume');
 }
 
+// ---------- cap-pre-main-injects-global (capability demo) ----------
+// Demonstrates `preMain`: stage state in the electron MAIN process via
+// app.evaluate before the case body runs. The case body then reads it back
+// via a second app.evaluate. Mirrors the pattern probe-e2e-notify-integration
+// uses to install a fake `__setNotifyImporter`. Pure capability demo —
+// asserts only that the value round-trips.
+async function casePreMainInjectsGlobal({ app, log }) {
+  const observed = await app.evaluate(() => globalThis.__ccsmHarnessCapDemo);
+  if (observed !== 'preMain-was-here') {
+    throw new Error(`expected preMain to set globalThis.__ccsmHarnessCapDemo='preMain-was-here', got ${JSON.stringify(observed)}`);
+  }
+  log('preMain injected main-process global; case body read it back');
+}
+
+// ---------- cap-relaunch-cold-start (capability demo) ----------
+// Demonstrates `relaunch`: the runner closes the shared electron app and
+// brings up a fresh one before this case. The case asserts that the store
+// is at its post-boot baseline (no sessions from previous cases). Useful
+// for cases that need to verify cold-launch UX (probe-e2e-installer-corrupt
+// style) without paying for a fresh user-data dir.
+async function caseRelaunchColdStart({ win, log }) {
+  const sessionCount = await win.evaluate(() => {
+    return (window.__ccsmStore?.getState().sessions ?? []).length;
+  });
+  if (sessionCount !== 0) {
+    throw new Error(`expected 0 sessions after relaunch, got ${sessionCount}`);
+  }
+  log('relaunch produced fresh electron with empty store');
+}
+
+// ---------- cap-fresh-userdatadir (capability demo) ----------
+// Demonstrates `userDataDir: 'fresh'`: case launches into a brand-new
+// mktemp user-data directory. We assert that the userData path electron
+// reports lives under the OS tmpdir (so it's distinct from the dev's real
+// install). The dir is cleaned up after the case.
+async function caseFreshUserDataDir({ app, log }) {
+  const info = await app.evaluate(({ app: a }) => {
+    return { userData: a.getPath('userData'), tmp: a.getPath('temp') };
+  });
+  // On all 3 OSes os.tmpdir() and electron's `temp` resolve to the same root.
+  // The fresh dir name embeds 'ccsm-harness-' so check that explicitly.
+  if (!/ccsm-harness-/.test(info.userData)) {
+    throw new Error(`expected userData path to contain 'ccsm-harness-', got ${info.userData}`);
+  }
+  log(`userData=${info.userData} (fresh tmpdir-rooted)`);
+}
+
+// ---------- cap-requires-claude-bin-skip (capability demo) ----------
+// Demonstrates `requiresClaudeBin: true`. On dev machines without
+// `claude` on PATH (or CCSM_CLAUDE_BIN unset to a real path), the runner
+// will SKIP this case — body never executes. On a machine that has the
+// CLI we run a trivial assertion. Either outcome counts as harness-pass.
+async function caseRequiresClaudeBinSkip({ log }) {
+  log('claude binary detected; trivial pass (real probe would exec it here)');
+}
+
 // ---------- harness spec ----------
 await runHarness({
   name: 'agent',
@@ -2166,5 +2222,31 @@ await runHarness({
     { id: 'sdk-system-subtypes', run: caseSdkSystemSubtypes },
     { id: 'sdk-abort-on-disposed', run: caseSdkAbortOnDisposed },
     { id: 'user-block-hover-menu', run: caseUserBlockHoverMenu },
+    // ---- Per-case capability demos (task #223) ----
+    // Each demo exercises one new field on the runner contract; the assertion
+    // is intentionally trivial — the value here is locking the API shape, not
+    // re-testing app behavior the existing cases already cover.
+    {
+      id: 'cap-pre-main-injects-global',
+      preMain: async (app) => {
+        await app.evaluate(() => { globalThis.__ccsmHarnessCapDemo = 'preMain-was-here'; });
+      },
+      run: casePreMainInjectsGlobal
+    },
+    {
+      id: 'cap-relaunch-cold-start',
+      relaunch: true,
+      run: caseRelaunchColdStart
+    },
+    {
+      id: 'cap-fresh-userdatadir',
+      userDataDir: 'fresh',
+      run: caseFreshUserDataDir
+    },
+    {
+      id: 'cap-requires-claude-bin-skip',
+      requiresClaudeBin: true,
+      run: caseRequiresClaudeBinSkip
+    },
   ]
 });

--- a/scripts/harness-perm.mjs
+++ b/scripts/harness-perm.mjs
@@ -984,6 +984,25 @@ async function casePermissionRejectStopsAgent({ win, log }) {
   log('deny IPC fired exactly once, no retry, chat retained denial trace');
 }
 
+// ---------- cap-setup-before-i18n-pin (capability demo) ----------
+// Demonstrates `setupBefore`: per-case renderer-side hook. Pins i18n to
+// English BEFORE the case body so an English-anchored assertion is
+// deterministic regardless of OS locale or earlier-case mutations. Mirrors
+// the inline pattern at the top of casePermissionAutoAndTitles, but lifted
+// into a reusable hook.
+async function caseSetupBeforeI18nPin({ win, log }) {
+  const lang = await win.evaluate(() => window.__ccsmI18n?.language ?? null);
+  if (lang !== 'en') {
+    throw new Error(`expected setupBefore to pin i18n to 'en', got ${lang}`);
+  }
+  // Confirm a known en string resolves so we know i18n actually responded.
+  const sample = await win.evaluate(() => window.__ccsmI18n?.t?.('statusBar.modeAutoLabel'));
+  if (sample !== 'Auto') {
+    throw new Error(`expected i18n.t('statusBar.modeAutoLabel')='Auto' under en, got ${JSON.stringify(sample)}`);
+  }
+  log('setupBefore pinned i18n to en; English-anchored key resolves');
+}
+
 // ---------- harness spec ----------
 await runHarness({
   name: 'perm',
@@ -1014,6 +1033,16 @@ await runHarness({
     { id: 'permission-a11y', run: casePermissionA11y },
     { id: 'permission-partial-accept', run: casePermissionPartialAccept },
     { id: 'permission-auto-and-titles', run: casePermissionAutoAndTitles },
-    { id: 'permission-reject-stops-agent', run: casePermissionRejectStopsAgent }
+    { id: 'permission-reject-stops-agent', run: casePermissionRejectStopsAgent },
+    // ---- Per-case capability demo (task #223) ----
+    {
+      id: 'cap-setup-before-i18n-pin',
+      setupBefore: async ({ win }) => {
+        await win.evaluate(async () => {
+          if (window.__ccsmI18n?.changeLanguage) await window.__ccsmI18n.changeLanguage('en');
+        });
+      },
+      run: caseSetupBeforeI18nPin
+    }
   ]
 });

--- a/scripts/harness-ui.mjs
+++ b/scripts/harness-ui.mjs
@@ -36,6 +36,8 @@
 // Run one case: `node scripts/harness-ui.mjs --only=sidebar-align`
 
 import { runHarness } from './probe-helpers/harness-runner.mjs';
+import fs from 'node:fs';
+import path from 'node:path';
 
 // ---------- sidebar-align ----------
 async function caseSidebarAlign({ win, log }) {
@@ -1680,6 +1682,26 @@ async function caseI18nSettingsZh({ win, log, registerDispose }) {
   log('Appearance / Notifications / Updates / Connection panes all render Chinese labels');
 }
 
+// ---------- cap-skip-launch-bundle-shape (capability demo) ----------
+// Demonstrates `skipLaunch: true`: case runs as a pure Node script without
+// booting electron. Useful for fs / package.json / dist bundle checks that
+// don't need the renderer (saves ~1-2s of electron boot per case). Mirrors
+// the future probe-e2e-installer-bundle-shape migration target.
+async function caseSkipLaunchBundleShape({ harnessRoot, log }) {
+  const pkg = JSON.parse(fs.readFileSync(path.join(harnessRoot, 'package.json'), 'utf8'));
+  if (typeof pkg.main !== 'string' || pkg.main.length === 0) {
+    throw new Error('package.json "main" missing or non-string');
+  }
+  if (!pkg.main.includes('dist/')) {
+    throw new Error(`package.json "main" should point under dist/, got ${pkg.main}`);
+  }
+  const bundlePath = path.join(harnessRoot, 'dist/renderer/bundle.js');
+  if (!fs.existsSync(bundlePath)) {
+    throw new Error(`dist/renderer/bundle.js missing at ${bundlePath}`);
+  }
+  log(`pkg.main=${pkg.main} bundle=${path.relative(harnessRoot, bundlePath)}`);
+}
+
 // ---------- harness spec ----------
 await runHarness({
   name: 'ui',
@@ -1720,6 +1742,8 @@ await runHarness({
     { id: 'focus-orchestration', run: caseFocusOrchestration },
     { id: 'theme-toggle', run: caseThemeToggle },
     { id: 'language-toggle', run: caseLanguageToggle },
-    { id: 'i18n-settings-zh', run: caseI18nSettingsZh }
+    { id: 'i18n-settings-zh', run: caseI18nSettingsZh },
+    // ---- Per-case capability demo (task #223) ----
+    { id: 'cap-skip-launch-bundle-shape', skipLaunch: true, run: caseSkipLaunchBundleShape }
   ]
 });

--- a/scripts/probe-helpers/harness-runner.mjs
+++ b/scripts/probe-helpers/harness-runner.mjs
@@ -13,6 +13,11 @@
 //   4. caseScope — gives each case (a) a `log()` that adds the prefix,
 //      (b) a `dispose()` registry the runner drains in `resetBetweenCases`.
 //
+// Per-case capability extensions (task #223 — five-bucket migration prep):
+//   See "Per-case capabilities" section below for the documented contract.
+//   Each capability is opt-in; cases that omit the new fields run on the
+//   pre-existing single-launch shared-electron path with no behavior change.
+//
 // Each harness file imports `runHarness` and provides:
 //   - `name`: harness id used as artifact subdir + log tag.
 //   - `setup({ app, win })`: optional one-time prep after Electron launches
@@ -20,11 +25,15 @@
 //   - `cases`: array of `{ id, run({ app, win, log, registerDispose }) }`.
 //
 // The runner returns a non-zero exit if ANY case fails (after attempting to
-// run the rest, so one regression doesn't mask another).
+// run the rest, so one regression doesn't mask another). Skipped cases (via
+// `requiresClaudeBin` when no claude binary is on PATH) do NOT count as
+// failures — they're listed separately in the summary so coverage gaps stay
+// visible without breaking CI on dev machines that lack the CLI.
 
 import { _electron as electron } from 'playwright';
 import path from 'node:path';
 import fs from 'node:fs';
+import os from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { appWindow } from '../probe-utils.mjs';
 import { resetBetweenCases } from './reset-between-cases.mjs';
@@ -111,21 +120,184 @@ function parseOnly(argv) {
 }
 
 /**
- * @typedef {object} HarnessCase
- * @property {string} id  Unique within the harness; goes into log prefix +
- *                        artifact path.
- * @property {(ctx: HarnessCaseCtx) => Promise<void>} run
+ * Detect whether the upstream `claude` binary is reachable. Used to decide
+ * whether `requiresClaudeBin: true` cases run or skip.
+ *
+ * Resolution order (matches what cases that exec the binary actually do):
+ *   1. `CCSM_CLAUDE_BIN` env override — explicit absolute path.
+ *   2. Walk `PATH` looking for `claude` / `claude.exe` / `claude.cmd`.
+ *
+ * Returns the resolved path on hit, null on miss. Result is memoized for the
+ * lifetime of the harness process so we don't re-stat per case.
+ *
+ * @returns {string | null}
  */
+let _claudeBinCache;
+function resolveClaudeBin() {
+  if (_claudeBinCache !== undefined) return _claudeBinCache;
+  const override = process.env.CCSM_CLAUDE_BIN;
+  if (override && fs.existsSync(override)) {
+    _claudeBinCache = override;
+    return _claudeBinCache;
+  }
+  const exts = process.platform === 'win32' ? ['.exe', '.cmd', '.bat', ''] : [''];
+  const dirs = (process.env.PATH ?? '').split(path.delimiter).filter(Boolean);
+  for (const d of dirs) {
+    for (const ext of exts) {
+      const p = path.join(d, `claude${ext}`);
+      try {
+        if (fs.statSync(p).isFile()) {
+          _claudeBinCache = p;
+          return _claudeBinCache;
+        }
+      } catch { /* miss */ }
+    }
+  }
+  _claudeBinCache = null;
+  return _claudeBinCache;
+}
+
+/**
+ * Allocate a fresh electron user-data directory under tmpdir. Returns the
+ * path plus a cleanup hook the runner invokes after the case (or after the
+ * next relaunch consumes the dir, whichever comes first).
+ *
+ * @param {string} tag  Dir-name prefix for triage; usually `<harness>-<case>`.
+ * @returns {{ dir: string, cleanup: () => void }}
+ */
+function freshUserDataDir(tag) {
+  const safeTag = tag.replace(/[^a-zA-Z0-9._-]/g, '-');
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `ccsm-harness-${safeTag}-`));
+  return {
+    dir,
+    cleanup() {
+      try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* swallow */ }
+    }
+  };
+}
 
 /**
  * @typedef {object} HarnessCaseCtx
- * @property {import('playwright').ElectronApplication} app
- * @property {import('playwright').Page} win
+ * @property {import('playwright').ElectronApplication | null} app
+ *   Null only when the case set `skipLaunch: true`.
+ * @property {import('playwright').Page | null} win
+ *   Null only when the case set `skipLaunch: true`.
  * @property {(...args: unknown[]) => void} log  Emits `[case=<id>] ...` to
  *                                              stdout; use instead of console.log.
  * @property {(fn: () => void | Promise<void>) => void} registerDispose
  *           Push a cleanup; runner awaits all of these in reverse order
- *           inside resetBetweenCases.
+ *           inside resetBetweenCases (or directly for skipLaunch cases).
+ * @property {string} harnessRoot  Absolute path to the repo root. Convenient
+ *           for `skipLaunch` cases doing fs / json checks under `dist/`,
+ *           `package.json`, etc.
+ */
+
+/**
+ * Per-case capabilities (all optional; defaults preserve pre-existing
+ * single-launch shared-electron semantics):
+ *
+ * @typedef {object} HarnessCase
+ * @property {string} id
+ *   Unique within the harness; goes into log prefix + artifact path.
+ *
+ * @property {(ctx: HarnessCaseCtx) => Promise<void>} run
+ *   Throw to fail. Use `log()` not console.log.
+ *
+ * @property {'fresh' | 'shared'} [userDataDir]
+ *   - 'shared' (default): reuse the long-lived electron user-data directory
+ *     that the harness booted with. Cheap; no relaunch needed.
+ *   - 'fresh': allocate a brand-new mktemp directory for this case, force
+ *     a relaunch into it, and rm -rf the dir after the case finishes (or
+ *     after the next relaunch consumes it).
+ *   Setting `userDataDir: 'fresh'` implies `relaunch: true`.
+ *
+ *   Example (probe-e2e-installer-corrupt style — first-launch detection):
+ *     {
+ *       id: 'installer-corrupt-detection',
+ *       userDataDir: 'fresh',
+ *       run: async ({ win }) => { ... cold-launch assertions ... }
+ *     }
+ *
+ * @property {boolean} [relaunch]
+ *   Close the running electron app and launch a new one before the case.
+ *   The new launch reuses the harness's `launch.args`/`launch.env` plus any
+ *   per-case `userDataDir: 'fresh'`. Ignored when `skipLaunch: true`.
+ *
+ *   Example (window-close-aborts-sessions: needs a fresh process to assert
+ *   a fresh exit code):
+ *     { id: 'close-aborts-sessions', relaunch: true, run: async ({ app }) => { ... } }
+ *
+ * @property {boolean} [requiresClaudeBin]
+ *   Mark the case skippable when no upstream `claude` binary is reachable
+ *   (see `resolveClaudeBin` for resolution order). Skipped cases show up in
+ *   the summary as `[--]` and do NOT count toward the failure exit code.
+ *   Override via `CCSM_CLAUDE_BIN` env or by symlinking onto PATH.
+ *
+ *   Example (probe-e2e-permission-allow-bash style — needs real subprocess
+ *   to verify the IPC frame round-trips through claude.exe):
+ *     { id: 'permission-allow-bash', requiresClaudeBin: true, run: ... }
+ *
+ * @property {(app: import('playwright').ElectronApplication, ctx: HarnessCaseCtx) => Promise<void>} [preMain]
+ *   Run BEFORE the case body, in the electron MAIN process via `app.evaluate`.
+ *   Use for monkey-patching main-process modules (e.g. `notify.ts`'s
+ *   `__setNotifyImporter` test seam, dialog stubs, fake transports).
+ *
+ *   Caller is responsible for restoring via `registerDispose` if the patch
+ *   must not leak into subsequent cases. For `userDataDir: 'fresh'` cases
+ *   the relaunch makes restore a no-op, so dispose is optional there.
+ *
+ *   Example (probe-e2e-notify-integration style):
+ *     {
+ *       id: 'notify-importer-swap',
+ *       preMain: async (app) => {
+ *         await app.evaluate(async () => {
+ *           const mod = await import('./electron/notify.js');
+ *           globalThis.__notifyCalls = [];
+ *           mod.__setNotifyImporter(async () => ({ default: class { constructor(o) { globalThis.__notifyCalls.push(o); } show() {} } }));
+ *         });
+ *       },
+ *       run: async ({ app, win }) => { ... assert globalThis.__notifyCalls ... }
+ *     }
+ *
+ * @property {boolean} [skipLaunch]
+ *   Don't launch electron at all. The case receives `{ app: null, win: null,
+ *   harnessRoot, log, registerDispose }` and runs as a pure Node script.
+ *   Useful for fs / package.json / dist bundle / config-loader checks that
+ *   would otherwise pay 1-2s of electron boot for nothing.
+ *
+ *   Disposers registered by skipLaunch cases run inline AFTER the case body
+ *   (no resetBetweenCases — there is no renderer to reset).
+ *
+ *   Example (probe-e2e-installer-bundle-shape style):
+ *     {
+ *       id: 'bundle-has-required-files',
+ *       skipLaunch: true,
+ *       run: async ({ harnessRoot }) => {
+ *         const pkg = JSON.parse(fs.readFileSync(path.join(harnessRoot, 'package.json'), 'utf8'));
+ *         if (!pkg.main) throw new Error('package.json missing "main"');
+ *       }
+ *     }
+ *
+ * @property {(ctx: HarnessCaseCtx) => Promise<void>} [setupBefore]
+ *   Run BEFORE the case body, in the RENDERER context. Distinct from
+ *   `preMain` (main-process). Use to reset language, theme, or any
+ *   renderer-side global the case depends on but doesn't itself own.
+ *
+ *   Differs from harness-level `setup` in that `setupBefore` runs every
+ *   case, not just on first launch. Differs from inlining the same code at
+ *   the top of `run` in that it can't accidentally be skipped when a case
+ *   is rewritten — the runner promise-chains it before each `run()`.
+ *
+ *   Example (any case that asserts on English-anchored i18n strings):
+ *     {
+ *       id: 'english-only-assertions',
+ *       setupBefore: async ({ win }) => {
+ *         await win.evaluate(async () => {
+ *           if (window.__ccsmI18n?.changeLanguage) await window.__ccsmI18n.changeLanguage('en');
+ *         });
+ *       },
+ *       run: async ({ win }) => { ... }
+ *     }
  */
 
 /**
@@ -135,6 +307,29 @@ function parseOnly(argv) {
  * @property {HarnessCase[]} cases
  * @property {{ args?: string[], env?: Record<string, string> }} [launch]
  */
+
+/**
+ * Build the launch options used for both the initial boot and any per-case
+ * relaunch. Pulled out so `userDataDir` overrides can be applied uniformly.
+ *
+ * @param {HarnessSpec} spec
+ * @param {string | null} userDataDirOverride
+ */
+function buildLaunchOpts(spec, userDataDirOverride) {
+  const args = ['.', ...(spec.launch?.args ?? [])];
+  if (userDataDirOverride) {
+    // Electron honors `--user-data-dir=<path>` as a CLI flag; this is the
+    // same mechanism CCSM_USER_DATA_DIR-style overrides ultimately land on.
+    args.push(`--user-data-dir=${userDataDirOverride}`);
+  }
+  const env = {
+    ...process.env,
+    NODE_ENV: 'production',
+    CCSM_PROD_BUNDLE: '1',
+    ...(spec.launch?.env ?? {})
+  };
+  return { args, env };
+}
 
 /**
  * Drive a themed harness. See file comment.
@@ -157,49 +352,151 @@ export async function runHarness(spec) {
   const harnessArtifactDir = path.join(ARTIFACTS_ROOT, spec.name);
   fs.mkdirSync(harnessArtifactDir, { recursive: true });
 
-  console.log(`[harness=${spec.name}] launching electron — ${filtered.length}/${spec.cases.length} case(s)`);
+  // Note totals: if every case is skipLaunch we never boot electron.
+  const needsAnyLaunch = filtered.some((c) => !c.skipLaunch);
+  console.log(`[harness=${spec.name}] ${needsAnyLaunch ? 'launching electron — ' : 'no electron required — '}${filtered.length}/${spec.cases.length} case(s)`);
 
-  const launchArgs = ['.', ...(spec.launch?.args ?? [])];
-  // CCSM_PROD_BUNDLE=1 forces electron/main.ts to loadFile from
-  // dist/renderer instead of expecting a dev server on localhost:4100.
-  // Harness runs are CI-like by definition — no dev server is up.
-  const launchEnv = {
-    ...process.env,
-    NODE_ENV: 'production',
-    CCSM_PROD_BUNDLE: '1',
-    ...(spec.launch?.env ?? {})
-  };
+  /** @type {import('playwright').ElectronApplication | null} */
+  let app = null;
+  /** @type {import('playwright').Page | null} */
+  let win = null;
+  /** @type {{ dir: string, cleanup: () => void } | null} */
+  let activeUserDataDir = null;
 
-  const tStart = Date.now();
-  const app = await electron.launch({ args: launchArgs, cwd: REPO_ROOT, env: launchEnv });
-
-  /** @type {Array<{ id: string, status: 'passed'|'failed', ms: number, error?: string }>} */
-  const results = [];
-
-  let win;
-  try {
+  // Boot once up front IF any case needs the shared electron. Fresh-userData /
+  // relaunch cases will tear this down and rebuild as they're encountered.
+  if (needsAnyLaunch && filtered.some((c) => !c.skipLaunch && c.userDataDir !== 'fresh' && !c.relaunch)) {
+    const opts = buildLaunchOpts(spec, null);
+    app = await electron.launch({ args: opts.args, cwd: REPO_ROOT, env: opts.env });
     win = await appWindow(app);
     await win.waitForLoadState('domcontentloaded');
     await win.waitForFunction(() => !!window.__ccsmStore, null, { timeout: 20_000 });
-
     if (spec.setup) {
       await spec.setup({ app, win });
     }
+  }
 
+  /** @type {Array<{ id: string, status: 'passed'|'failed'|'skipped', ms: number, error?: string, reason?: string }>} */
+  const results = [];
+
+  const tStart = Date.now();
+  try {
     for (const c of filtered) {
+      const caseStart = Date.now();
+      const log = (...args) => console.log(`[case=${c.id}]`, ...args);
       /** @type {Array<() => void | Promise<void>>} */
       const disposers = [];
-      const log = (...args) => console.log(`[case=${c.id}]`, ...args);
       const registerDispose = (fn) => { disposers.push(fn); };
-
       const caseDir = path.join(harnessArtifactDir, c.id);
-      const caseStart = Date.now();
+
       console.log(`\n[harness=${spec.name}] >>> case ${c.id}`);
 
+      // ---- Capability: requiresClaudeBin ----
+      if (c.requiresClaudeBin && !resolveClaudeBin()) {
+        const reason = 'no `claude` binary on PATH (set CCSM_CLAUDE_BIN or install the upstream CLI)';
+        console.log(`[case=${c.id}] SKIPPED: ${reason}`);
+        results.push({ id: c.id, status: 'skipped', ms: Date.now() - caseStart, reason });
+        continue;
+      }
+
+      // ---- Capability: skipLaunch ----
+      if (c.skipLaunch) {
+        const ctx = { app: null, win: null, log, registerDispose, harnessRoot: REPO_ROOT };
+        let caseError = null;
+        try {
+          await c.run(ctx);
+          log('OK');
+        } catch (err) {
+          caseError = err instanceof Error ? err : new Error(String(err));
+          console.error(`[case=${c.id}] FAIL: ${caseError.message}`);
+        }
+        // Inline disposers — no renderer to drain through resetBetweenCases.
+        for (const fn of disposers.splice(0).reverse()) {
+          try { await fn(); } catch { /* swallow */ }
+        }
+        const ms = Date.now() - caseStart;
+        if (caseError) {
+          results.push({ id: c.id, status: 'failed', ms, error: caseError.stack ?? caseError.message });
+        } else {
+          results.push({ id: c.id, status: 'passed', ms });
+        }
+        continue;
+      }
+
+      // ---- Capabilities: userDataDir + relaunch ----
+      const wantsFreshDir = c.userDataDir === 'fresh';
+      const wantsRelaunch = wantsFreshDir || c.relaunch === true;
+
+      if (wantsRelaunch) {
+        // Tear down current app first so the next launch is genuinely fresh.
+        if (app) {
+          try { await app.close(); } catch { /* ignore */ }
+          app = null;
+          win = null;
+        }
+        // Drop the previous fresh dir if we owned one. Done AFTER close so
+        // electron has released the lock files.
+        if (activeUserDataDir) {
+          activeUserDataDir.cleanup();
+          activeUserDataDir = null;
+        }
+        if (wantsFreshDir) {
+          activeUserDataDir = freshUserDataDir(`${spec.name}-${c.id}`);
+        }
+        const opts = buildLaunchOpts(spec, activeUserDataDir?.dir ?? null);
+        app = await electron.launch({ args: opts.args, cwd: REPO_ROOT, env: opts.env });
+        win = await appWindow(app);
+        await win.waitForLoadState('domcontentloaded');
+        await win.waitForFunction(() => !!window.__ccsmStore, null, { timeout: 20_000 });
+        if (spec.setup) {
+          await spec.setup({ app, win });
+        }
+      }
+
+      // Defensive: if we got here and still don't have an app, the harness
+      // spec mixes shared+relaunch in a way the boot logic above missed.
+      // Lazy-launch once now so the case can run.
+      if (!app || !win) {
+        const opts = buildLaunchOpts(spec, activeUserDataDir?.dir ?? null);
+        app = await electron.launch({ args: opts.args, cwd: REPO_ROOT, env: opts.env });
+        win = await appWindow(app);
+        await win.waitForLoadState('domcontentloaded');
+        await win.waitForFunction(() => !!window.__ccsmStore, null, { timeout: 20_000 });
+        if (spec.setup) {
+          await spec.setup({ app, win });
+        }
+      }
+
+      const ctx = { app, win, log, registerDispose, harnessRoot: REPO_ROOT };
+
+      // ---- Capability: preMain (main-process setup) ----
+      if (c.preMain) {
+        try {
+          await c.preMain(app, ctx);
+        } catch (err) {
+          const e = err instanceof Error ? err : new Error(String(err));
+          console.error(`[case=${c.id}] preMain FAIL: ${e.message}`);
+          results.push({ id: c.id, status: 'failed', ms: Date.now() - caseStart, error: `preMain threw: ${e.stack ?? e.message}` });
+          continue;
+        }
+      }
+
+      // ---- Capability: setupBefore (renderer-side per-case setup) ----
+      if (c.setupBefore) {
+        try {
+          await c.setupBefore(ctx);
+        } catch (err) {
+          const e = err instanceof Error ? err : new Error(String(err));
+          console.error(`[case=${c.id}] setupBefore FAIL: ${e.message}`);
+          results.push({ id: c.id, status: 'failed', ms: Date.now() - caseStart, error: `setupBefore threw: ${e.stack ?? e.message}` });
+          continue;
+        }
+      }
+
       // Per-case Playwright trace. Only persisted on failure (see catch below).
-      const ctx = win.context();
+      const playwrightCtx = win.context();
       try {
-        await ctx.tracing.start({ screenshots: true, snapshots: true, sources: false, title: c.id });
+        await playwrightCtx.tracing.start({ screenshots: true, snapshots: true, sources: false, title: c.id });
       } catch {
         // Tracing may already be active if a previous case crashed mid-stop;
         // ignore and continue without trace.
@@ -207,7 +504,7 @@ export async function runHarness(spec) {
 
       let caseError = null;
       try {
-        await c.run({ app, win, log, registerDispose });
+        await c.run(ctx);
         log('OK');
       } catch (err) {
         caseError = err instanceof Error ? err : new Error(String(err));
@@ -218,11 +515,11 @@ export async function runHarness(spec) {
       try {
         if (caseError) {
           fs.mkdirSync(caseDir, { recursive: true });
-          await ctx.tracing.stop({ path: path.join(caseDir, 'trace.zip') });
+          await playwrightCtx.tracing.stop({ path: path.join(caseDir, 'trace.zip') });
           // Also dump page screenshot for fast triage without unzipping.
           try { await win.screenshot({ path: path.join(caseDir, 'failure.png'), fullPage: true }); } catch {}
         } else {
-          await ctx.tracing.stop();
+          await playwrightCtx.tracing.stop();
         }
       } catch {
         // Ignore tracing teardown errors — they shouldn't mask the case status.
@@ -245,17 +542,22 @@ export async function runHarness(spec) {
       }
     }
   } finally {
-    try { await app.close(); } catch {}
+    if (app) { try { await app.close(); } catch {} }
+    if (activeUserDataDir) activeUserDataDir.cleanup();
   }
 
   const wallMs = Date.now() - tStart;
   const passed = results.filter((r) => r.status === 'passed').length;
   const failed = results.filter((r) => r.status === 'failed');
+  const skipped = results.filter((r) => r.status === 'skipped');
 
   console.log(`\n=== harness=${spec.name} summary (${wallMs}ms wall) ===`);
   for (const r of results) {
-    const tag = r.status === 'passed' ? '[OK]' : '[XX]';
-    console.log(`  ${tag} ${r.id.padEnd(40)} ${String(r.ms).padStart(6)}ms`);
+    let tag;
+    if (r.status === 'passed') tag = '[OK]';
+    else if (r.status === 'failed') tag = '[XX]';
+    else tag = '[--]';
+    console.log(`  ${tag} ${r.id.padEnd(40)} ${String(r.ms).padStart(6)}ms${r.reason ? `  (${r.reason})` : ''}`);
   }
   if (failed.length > 0) {
     console.log(`\n=== failures (${failed.length}) ===`);
@@ -263,7 +565,7 @@ export async function runHarness(spec) {
       console.log(`\n--- ${r.id} ---\n${r.error}`);
     }
   }
-  console.log(`\n=== totals: ${passed} passed, ${failed.length} failed, ${results.length} total ===`);
+  console.log(`\n=== totals: ${passed} passed, ${failed.length} failed, ${skipped.length} skipped, ${results.length} total ===`);
 
   process.exit(failed.length === 0 ? 0 : 1);
 }


### PR DESCRIPTION
## Summary

Adds 6 opt-in per-case fields to `scripts/probe-helpers/harness-runner.mjs` so the upcoming five-bucket probe-migration workers can absorb probes that need cold-launch state, fresh user-data dirs, main-process mock injection, claude-bin gating, or pure fs/json checks — without each bucket re-implementing the same plumbing.

This PR contains **runner-only** changes plus minimal `cap-*` demo cases inside the existing 3 harnesses. **No probe migration.** Bucket workers will land probe migrations in follow-up PRs.

## Per-case capabilities

| Field | Default | Serves these case shapes |
|---|---|---|
| `userDataDir: 'fresh' \| 'shared'` | `'shared'` | First-launch / installer-corrupt / cold-boot probes that need an empty user-data dir. Implies `relaunch: true`. |
| `relaunch: boolean` | `false` | Cases that need a fresh electron process (e.g. `close-window-aborts-sessions`, `delete-session-kills-process`) but can reuse the shared user-data dir. |
| `requiresClaudeBin: boolean` | `false` | Probes that exec real `claude.exe` (e.g. `permission-allow-write`, `permission-allow-bash`, `permission-allow-parallel-batch`). Skipped (not failed) when no `claude` binary is on PATH; override via `CCSM_CLAUDE_BIN`. |
| `preMain(app, ctx)` | n/a | Main-process setup via `app.evaluate` — install `__setNotifyImporter`, dialog stubs, fake transports (`probe-e2e-notify-integration` pattern). |
| `skipLaunch: boolean` | `false` | Pure-node fs/json/bundle-shape checks that don't need electron. Saves ~1-2s of boot per case. |
| `setupBefore(ctx)` | n/a | Renderer-side per-case setup (e.g. pin i18n to `en` before English-anchored assertions). Runs every case, unlike harness-level `setup`. |

All fields are opt-in. Cases that omit them run unchanged on the pre-existing shared-electron path → full backwards compatibility (verified — all 62 pre-existing cases still pass).

## Demo coverage (where each capability is exercised)

| Capability | Demo case | Harness |
|---|---|---|
| `preMain` | `cap-pre-main-injects-global` | `harness-agent.mjs` |
| `relaunch` | `cap-relaunch-cold-start` | `harness-agent.mjs` |
| `userDataDir: 'fresh'` | `cap-fresh-userdatadir` | `harness-agent.mjs` |
| `requiresClaudeBin` | `cap-requires-claude-bin-skip` | `harness-agent.mjs` |
| `skipLaunch` | `cap-skip-launch-bundle-shape` | `harness-ui.mjs` |
| `setupBefore` | `cap-setup-before-i18n-pin` | `harness-perm.mjs` |

Each demo is intentionally a trivial assertion — the value is locking the API shape, not re-testing app behavior. Real exercising will come via the bucket migration PRs.

## Layer-1 verdict

All 6 capabilities were judged necessary; none skipped. Justifications:
- `userDataDir`/`relaunch` are tightly coupled (fresh dir requires relaunch) but both useful independently — relaunch alone is the cheaper option when only a fresh process is needed.
- `preMain` vs `setupBefore` distinction is which process. Both have demonstrated upstream needs (notify importer in main; i18n reset in renderer).
- `skipLaunch` saves measurable wall time for fs/json probes — `cap-skip-launch-bundle-shape` finishes in **2ms** vs ~1-2s for the same logic running in renderer.
- `requiresClaudeBin` correctly differentiates "skipped because env-incomplete" from "failed" — without it, bucket-3 probes would either fail on dev machines or require manual skip-list maintenance (per task #72 no-skipped-e2e rule).

## Verification

All 3 harnesses pass cleanly when run in isolation:

### `node scripts/harness-perm.mjs` (tail 5)
```
  [OK] permission-reject-stops-agent              1991ms
  [OK] cap-setup-before-i18n-pin                   127ms

=== totals: 13 passed, 0 failed, 0 skipped, 13 total ===
```

### `node scripts/harness-ui.mjs` (tail 5)
```
  [OK] language-toggle                            2258ms
  [OK] i18n-settings-zh                           1830ms
  [OK] cap-skip-launch-bundle-shape                  2ms

=== totals: 22 passed, 0 failed, 0 skipped, 22 total ===
```

### `node scripts/harness-agent.mjs` (tail 5)
```
  [OK] cap-pre-main-injects-global                  95ms
  [OK] cap-relaunch-cold-start                    3128ms
  [OK] cap-fresh-userdatadir                      2975ms
  [OK] cap-requires-claude-bin-skip                 95ms

=== totals: 27 passed, 0 failed, 0 skipped, 27 total ===
```

Note on flake observed during validation: when all 3 harnesses run **concurrently**, `user-block-hover-menu` flakes ~once due to OS clipboard contention between the three electron processes. Running each harness alone passes cleanly. This is orthogonal to this PR (pre-existing case, no relation to capability code).

## Dependent buckets

This PR must merge before:
- **Bucket 1** (cold-launch probes — needs `userDataDir: 'fresh'`)
- **Bucket 2** (process-lifecycle probes — needs `relaunch`)
- **Bucket 3** (real-CLI permission probes — needs `requiresClaudeBin`)
- **Bucket 4** (mock-injection probes — needs `preMain`)

**Bucket 5** (pure fs / json / config-loader probes — needs `skipLaunch`) is independent and can land in any order, but will share fewer test-runtime savings without this runner.

## Test plan

- [x] All pre-existing 62 cases pass (3 harnesses, isolated runs)
- [x] All 7 new `cap-*` demo cases pass
- [x] `requiresClaudeBin` skip-path verified (case shows `[OK]` with bin found; would show `[--]` skipped on a machine without `claude` on PATH)
- [x] `relaunch` actually closes + reopens (visible 3.1s relaunch latency in demo)
- [x] `userDataDir: 'fresh'` produces a tmpdir-rooted userData path (verified via `app.getPath('userData')`)
- [x] `skipLaunch` runs in 2ms (no electron boot)
- [x] `preMain` mutation visible from case body via shared `app.evaluate` global
- [x] `setupBefore` runs before each case body (i18n pin asserted in case body)

🤖 Generated with [Claude Code](https://claude.com/claude-code)