### PR TITLE
fix(perm): route AskUserQuestion through onPermissionRequest so UI mounts

### DIFF
--- a/electron/agent-sdk/__tests__/sessions.test.ts
+++ b/electron/agent-sdk/__tests__/sessions.test.ts
@@ -315,23 +315,41 @@ describe('agent-sdk/SdkSessionRunner', () => {
     },
   );
 
-  it('canUseTool short-circuits AskUserQuestion (passthrough tool)', async () => {
+  it('canUseTool emits onPermissionRequest for AskUserQuestion (passthrough tool routes to renderer UI)', async () => {
+    // Regression for "agent invoked AskUserQuestion but no question card showed
+    // up in the UI": the SDK runner originally short-circuited PASSTHROUGH_TOOLS
+    // to `behavior: 'allow'` here, never notifying the renderer — so no
+    // QuestionStickyHost card mounted, the SDK got an instant allow with empty
+    // input, and the model received an empty tool_result body. The contract is:
+    // PASSTHROUGH tools MUST surface through onPermissionRequest so the
+    // renderer's bespoke question / plan UI is the single source of truth.
     const onPerm = vi.fn();
     const runner = new SdkSessionRunner('s12', noop, noop, onPerm, noop);
     await runner.start({ ...baseStart, permissionMode: 'default' });
 
     const canUseTool = (fake.getOptions()?.options as { canUseTool?: (toolName: string, input: unknown, ctx: { signal: AbortSignal; toolUseID: string }) => Promise<unknown> }).canUseTool!;
     const ac = new AbortController();
-    const input = { question: 'y/n?' };
-    const decision = (await canUseTool(
-      'AskUserQuestion',
-      input,
-      { signal: ac.signal, toolUseID: 't4' },
-    )) as { behavior: string; updatedInput?: unknown };
-    expect(decision.behavior).toBe('allow');
-    // PASSTHROUGH_TOOLS allow path also requires `updatedInput` (Bug #169).
-    expect(decision.updatedInput).toBe(input);
-    expect(onPerm).not.toHaveBeenCalled();
+    const input = { questions: [{ question: 'y/n?', options: [{ label: 'y' }, { label: 'n' }] }] };
+    // Kick off the canUseTool call but don't await — it should suspend on the
+    // pending permission promise until we resolve it.
+    const decisionPromise = canUseTool('AskUserQuestion', input, {
+      signal: ac.signal,
+      toolUseID: 't4',
+    });
+    // Yield so the runner has a chance to call onPermissionRequest synchronously.
+    await new Promise((r) => setImmediate(r));
+    expect(onPerm).toHaveBeenCalledTimes(1);
+    const req = onPerm.mock.calls[0][0] as { requestId: string; toolName: string; input: unknown };
+    expect(req.toolName).toBe('AskUserQuestion');
+    expect(req.input).toBe(input);
+    expect(typeof req.requestId).toBe('string');
+
+    // Renderer settles the request via resolvePermission — the question UI's
+    // submit/reject path always denies the canUseTool gate (then sends the
+    // user's answers as the next user message). See QuestionStickyHost.
+    runner.resolvePermission(req.requestId, 'deny');
+    const decision = (await decisionPromise) as { behavior: string; message?: string };
+    expect(decision.behavior).toBe('deny');
     runner.close();
   });
 
@@ -371,7 +389,11 @@ describe('agent-sdk/SdkSessionRunner', () => {
     runner.close();
   });
 
-  it('PreToolUse hook returns allow for passthrough tools (#94)', async () => {
+  it('PreToolUse hook returns ask for passthrough tools so canUseTool fires (#94)', async () => {
+    // PASSTHROUGH tools must reach canUseTool so onPermissionRequest can mount
+    // the renderer's question / plan UI. Returning 'allow' here would let the
+    // CLI bypass canUseTool and synthesize an empty tool_result — exactly the
+    // bug "agent asked but nothing showed up in UI".
     const runner = new SdkSessionRunner('s12-pt-pass', noop, noop, noop, noop);
     await runner.start({ ...baseStart, permissionMode: 'default' });
     const hook = getPreToolUseHook();
@@ -382,9 +404,30 @@ describe('agent-sdk/SdkSessionRunner', () => {
         'tu-pass',
         { signal: ac.signal },
       );
-      expect(out.hookSpecificOutput?.permissionDecision).toBe('allow');
+      expect(out.hookSpecificOutput?.permissionDecision).toBe('ask');
     }
     runner.close();
+  });
+
+  it('PreToolUse hook returns ask for passthrough tools even in bypass modes', async () => {
+    // bypassPermissions / acceptEdits / auto skip the host round-trip for
+    // ordinary tools, but passthrough tools (AskUserQuestion / ExitPlanMode)
+    // must always reach canUseTool — the user explicitly opted into those
+    // interactions; bypass mode applies to "tools the agent uses without
+    // asking", not "questions the agent asks the user".
+    for (const mode of ['bypassPermissions', 'acceptEdits', 'auto'] as const) {
+      const runner = new SdkSessionRunner(`s12-pt-pass-${mode}`, noop, noop, noop, noop);
+      await runner.start({ ...baseStart, permissionMode: mode });
+      const hook = getPreToolUseHook();
+      const ac = new AbortController();
+      const out = await hook(
+        { hook_event_name: 'PreToolUse', tool_name: 'AskUserQuestion' },
+        'tu-aq',
+        { signal: ac.signal },
+      );
+      expect(out.hookSpecificOutput?.permissionDecision).toBe('ask');
+      runner.close();
+    }
   });
 
   it.each(['bypassPermissions', 'acceptEdits', 'auto'] as const)(

--- a/electron/agent-sdk/sessions.ts
+++ b/electron/agent-sdk/sessions.ts
@@ -517,7 +517,15 @@ export class SdkSessionRunner {
     ctx: { signal: AbortSignal; toolUseID: string },
   ): Promise<import('@anthropic-ai/claude-agent-sdk').PermissionResult> {
     // Mirror the legacy runner's mode-driven shortcuts: bypass + acceptEdits
-    // + auto never prompt; passthrough tools delegate to the renderer's own UI.
+    // + auto never prompt. Passthrough tools (AskUserQuestion / ExitPlanMode)
+    // are NOT short-circuited here — they MUST flow through onPermissionRequest
+    // so the renderer can mount its bespoke question / plan UI. The legacy
+    // spawner's `HOOK_PASSTHROUGH_TOOLS` check lived in the PreToolUse-hook
+    // path and meant "let the CLI fall through to can_use_tool"; on the SDK
+    // runner there's only one path, so a short-circuit here drops the request
+    // on the floor — the renderer never sees it, no question card mounts, the
+    // SDK gets a synthetic allow, and the agent receives an empty tool_result
+    // body. The user observes "agent asked but nothing showed up".
     // NOTE: every `behavior: 'allow'` MUST carry `updatedInput`. The SDK's TS
     // type declares it `.optional()`, but the CLI's over-the-wire Zod schema
     // rejects `updatedInput: undefined` (undefined-serialized-over-wire is
@@ -529,10 +537,13 @@ export class SdkSessionRunner {
       this.permissionMode === 'acceptEdits' ||
       this.permissionMode === 'auto'
     ) {
-      return { behavior: 'allow', updatedInput: input };
-    }
-    if (PASSTHROUGH_TOOLS.has(toolName)) {
-      return { behavior: 'allow', updatedInput: input };
+      // For passthrough tools we still need to surface the question UI to
+      // the user even in bypass-style modes — bypass means "skip permission
+      // prompts for tools the agent calls", not "skip the user-asked-me-a-
+      // question UI". Fall through to the onPermissionRequest path.
+      if (!PASSTHROUGH_TOOLS.has(toolName)) {
+        return { behavior: 'allow', updatedInput: input };
+      }
     }
 
     const decision = await new Promise<CanUseToolDecision>((resolve) => {
@@ -577,26 +588,30 @@ export class SdkSessionRunner {
    *
    * Returned shape: `SyncHookJSONOutput` with a `PreToolUseHookSpecificOutput`
    * payload. `permissionDecision: 'ask'` tells the CLI "delegate to the host's
-   * canUseTool"; `'allow'` tells it "skip canUseTool and run the tool". We use
-   * 'allow' for passthrough tools (AskUserQuestion / ExitPlanMode) so the
-   * renderer's bespoke UI stays the single source of truth for those — same
-   * rationale as the PASSTHROUGH_TOOLS short-circuit at the top of
-   * handleCanUseTool. Bypass-style modes are also fast-pathed to 'allow' so
-   * we don't pay a host round-trip per tool invocation when the user has
-   * explicitly opted out of prompting.
+   * canUseTool"; `'allow'` tells it "skip canUseTool and run the tool".
+   * Passthrough tools (AskUserQuestion / ExitPlanMode) MUST resolve to 'ask'
+   * — returning 'allow' here causes the CLI to bypass canUseTool entirely
+   * and synthesize a successful tool_result with empty body, so the renderer
+   * never receives the permission-request frame and no question / plan card
+   * mounts. The user observes "the agent asked me a question but nothing
+   * showed up". Bypass-style modes are still fast-pathed to 'allow' for
+   * NON-passthrough tools so we don't pay a host round-trip per tool
+   * invocation when the user has explicitly opted out of prompting.
    */
   private makePreToolUseHook(): import('@anthropic-ai/claude-agent-sdk').HookCallback {
     return async (input) => {
       const toolName =
         input.hook_event_name === 'PreToolUse' ? input.tool_name : '';
-      const decision: import('@anthropic-ai/claude-agent-sdk').HookPermissionDecision =
+      const isPassthrough = PASSTHROUGH_TOOLS.has(toolName);
+      const isBypassMode =
         this.permissionMode === 'bypassPermissions' ||
         this.permissionMode === 'yolo' ||
         this.permissionMode === 'acceptEdits' ||
-        this.permissionMode === 'auto' ||
-        PASSTHROUGH_TOOLS.has(toolName)
-          ? 'allow'
-          : 'ask';
+        this.permissionMode === 'auto';
+      // Passthrough tools always 'ask' — see jsdoc above. Bypass-mode
+      // short-circuit only applies to non-passthrough tools.
+      const decision: import('@anthropic-ai/claude-agent-sdk').HookPermissionDecision =
+        !isPassthrough && isBypassMode ? 'allow' : 'ask';
       return {
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',

--- a/scripts/harness-perm.mjs
+++ b/scripts/harness-perm.mjs
@@ -1556,6 +1556,84 @@ async function caseAskUserQuestionNoDupAndResolves({ app, win, log }) {
   log('AskUserQuestion dedup + resolve routing locked down');
 }
 
+// ---------- askuserquestion-routes-via-permission-request ----------
+// Regression for: "agent invoked AskUserQuestion but no question card showed
+// up in the UI". The SDK runner used to short-circuit PASSTHROUGH_TOOLS in
+// canUseTool / PreToolUse to `behavior: 'allow'`, which skipped
+// onPermissionRequest entirely. Result: SDK got synthetic allow with empty
+// input, no `agent:permissionRequest` IPC frame ever fired, no question card
+// ever mounted, and the agent received an empty tool_result body.
+//
+// This case asserts the IPC frame the renderer relies on actually mounts a
+// question card. We send the frame directly from main's webContents to skip
+// the cost of spawning real claude and getting the model to call AskUser-
+// Question — but the renderer-side wiring (lifecycle.ts permissionRequest →
+// permissionRequestToWaitingBlock → store.appendBlocks → QuestionStickyHost)
+// is exercised end-to-end exactly as it would be from a real SDK call.
+//
+// If the SDK runner regresses to swallowing PASSTHROUGH_TOOLS, the unit
+// test in electron/agent-sdk/__tests__/sessions.test.ts catches the SDK side;
+// this case catches the renderer-IPC side.
+async function caseAskUserQuestionRoutesViaPermissionRequest({ app, win, log }) {
+  const sessionId = await win.evaluate(() => {
+    const s = window.__ccsmStore.getState();
+    if (s.activeId && s.sessions.some((x) => x.id === s.activeId)) return s.activeId;
+    s.createSession({ name: 'aq-route-probe' });
+    return window.__ccsmStore.getState().activeId;
+  });
+  // Simulate "agent is running" so the renderer doesn't reject the in-flight
+  // permission frame as orphaned.
+  await win.evaluate((sid) => window.__ccsmStore.getState().setRunning(sid, true), sessionId);
+
+  const REQUEST_ID = 'perm-aq-route-1';
+  const QUESTION = 'Pick a color';
+  // Emit the IPC frame the SDK runner's onPermissionRequest path produces.
+  // Mirrors manager.ts L146: `this.emit('agent:permissionRequest', { sessionId, ...req })`.
+  await app.evaluate(({ BrowserWindow }, payload) => {
+    const wcs = BrowserWindow.getAllWindows().map((w) => w.webContents);
+    for (const wc of wcs) {
+      if (!wc.isDestroyed()) wc.send('agent:permissionRequest', payload);
+    }
+  }, {
+    sessionId,
+    requestId: REQUEST_ID,
+    toolName: 'AskUserQuestion',
+    input: {
+      questions: [
+        { question: QUESTION, options: [{ label: 'red' }, { label: 'blue' }] },
+      ],
+    },
+  });
+
+  // Question card MUST mount. Before the fix nothing rendered — the
+  // PASSTHROUGH short-circuit skipped onPermissionRequest, so this IPC frame
+  // never fired in production and the bug went undetected by every existing
+  // probe (all of which inject blocks directly into the store).
+  await win.waitForSelector('[data-question-sticky] [data-question-option]', { timeout: 5000 });
+
+  const observed = await win.evaluate(({ sid, q }) => {
+    const blocks = window.__ccsmStore.getState().messagesBySession[sid] || [];
+    const qb = blocks.find((b) => b.kind === 'question');
+    return {
+      hasQuestionBlock: !!qb,
+      requestId: qb?.requestId,
+      firstQuestion: qb?.questions?.[0]?.question,
+      optionCount: qb?.questions?.[0]?.options?.length,
+      domQuestionText: document.querySelector('[data-question-sticky]')?.innerText?.includes(q) ?? false,
+      genericPermBlock: blocks.some((b) => b.kind === 'waiting' && b.toolName === 'AskUserQuestion'),
+    };
+  }, { sid: sessionId, q: QUESTION });
+
+  if (!observed.hasQuestionBlock) throw new Error('expected question block in store, got none');
+  if (observed.requestId !== REQUEST_ID) throw new Error(`requestId not threaded into block: got ${observed.requestId}`);
+  if (observed.firstQuestion !== QUESTION) throw new Error(`question text mismatch: ${observed.firstQuestion}`);
+  if (observed.optionCount !== 2) throw new Error(`expected 2 options, got ${observed.optionCount}`);
+  if (!observed.domQuestionText) throw new Error('question text not visible in QuestionStickyHost DOM');
+  if (observed.genericPermBlock) throw new Error('AskUserQuestion fell through to generic waiting/permission block — parseQuestions failed?');
+
+  log('AskUserQuestion permission-request frame mounts a question card');
+}
+
 // ---------- env-passthrough ----------
 // Was: probe-e2e-env-passthrough.mjs.
 // Auth env (ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN) flows through
@@ -1761,6 +1839,19 @@ await runHarness({
         });
       },
       run: caseAskUserQuestionNoDupAndResolves,
+    },
+    // askuserquestion-routes-via-permission-request: regression for
+    // "agent asked but no question card showed up". Fires the
+    // agent:permissionRequest IPC frame the SDK runner emits in production
+    // (after the PASSTHROUGH short-circuit was removed) and asserts a
+    // question card mounts in the renderer. Pure renderer-IPC contract — no
+    // real claude needed; pairs with the SDK-side unit test in
+    // electron/agent-sdk/__tests__/sessions.test.ts that asserts onPermission-
+    // Request is invoked for AskUserQuestion.
+    {
+      id: 'askuserquestion-routes-via-permission-request',
+      userDataDir: 'fresh',
+      run: caseAskUserQuestionRoutesViaPermissionRequest,
     },
     // permission-allow-bash: requires real claude.exe to round-trip the
     // nested control_response envelope (Bug L). Fresh udd so the renderer's


### PR DESCRIPTION
## Bug

P0 — user reported during dogfood:

> "我没有收到问题呢"
> 系统又返回空答案。看起来你当前的环境（Claude Code 版本或终端 UI）可能不支持 AskUserQuestion 的交互弹窗渲染——工具调用成功了，但 UI 层没有显示选项给你。

Agent invokes \`AskUserQuestion\`, the tool call "succeeds" (model receives a tool_result), but **no question card ever renders in the ccsm UI**. Every question silently returns an empty answer; agent assumes the user skipped.

## Link diagnosis

\`\`\`
SDK invokes tool
  → handleCanUseTool('AskUserQuestion', input)         electron/agent-sdk/sessions.ts:514
    → PASSTHROUGH_TOOLS short-circuit returns {behavior:'allow'}   ← BUG
    → onPermissionRequest NEVER called
  → manager.ts L146 'agent:permissionRequest' IPC frame NEVER emitted
  → preload onAgentPermissionRequest handler in renderer NEVER fires
  → lifecycle.ts permissionRequestToWaitingBlock NEVER appends question block
  → QuestionStickyHost has nothing to mount

Meanwhile assistant tool_use(AskUserQuestion):
  → stream-to-blocks.ts L401-412 SUPPRESSES it
    (assumes can_use_tool path already added a question block — wrong)
\`\`\`

Both paths drop the request silently. The model gets an instant successful tool_result with empty body and continues.

## Root cause

**PR #271** (SDK adapter) inverted the legacy spawner's PASSTHROUGH semantics:

| Layer | Legacy spawner | SDK runner (broken) | SDK runner (this PR) |
|---|---|---|---|
| PreToolUse hook for AskUserQuestion | \`{}\` (no-op continue → CLI uses \`--permission-prompt-tool stdio\`) | \`'allow'\` (skip canUseTool) | \`'ask'\` (defer to canUseTool) |
| can_use_tool / canUseTool for AskUserQuestion | normal \`onPermissionRequest\` path (no PASSTHROUGH bypass) | short-circuit to \`{behavior:'allow'}\` | normal \`onPermissionRequest\` path |

The legacy comment "passthrough = renderer's bespoke UI is single source of truth" was right; the SDK runner accidentally implemented "passthrough = silently allow with empty input". **PR #330**'s PreToolUse change preserved (and reinforced) the bug.

## Fix

\`electron/agent-sdk/sessions.ts\`:

1. \`handleCanUseTool\`: drop the \`PASSTHROUGH_TOOLS.has(toolName) → return {behavior:'allow', updatedInput:input}\` branch. Bypass-style modes (\`bypassPermissions\` / \`acceptEdits\` / \`auto\` / \`yolo\`) only fast-path **non-passthrough** tools — passthrough always reaches \`onPermissionRequest\`. "Bypass" means "agent's tool calls auto-allow", not "questions the agent asked the user auto-answer".
2. \`makePreToolUseHook\`: passthrough tools return \`'ask'\` (delegate to canUseTool) instead of \`'allow'\` (which makes the CLI bypass canUseTool).

Renderer side is unchanged — \`QuestionStickyHost\` already handles the resolve flow: \`agentResolvePermission(deny)\` to release the SDK gate, then \`agentSend(text)\` to deliver answers as the next user message (intentionally lossy in the tool_result sense; matches the existing comment).

## Reproduce

Before fix:
1. Open ccsm with any session in \`default\` mode.
2. Ask agent something that prompts it to call \`AskUserQuestion\` (e.g. "ask me 3 questions about my preferences before continuing").
3. Observe: agent's chat shows nothing; agent's next turn says "the tool returned no answer".

After fix: question card mounts in the sticky host; submit/reject route correctly.

## Tests

### vitest (SDK runner contract)

\`electron/agent-sdk/__tests__/sessions.test.ts\` — 24/24 pass.

- **Rewrote** \`canUseTool short-circuits AskUserQuestion (passthrough tool)\` → \`canUseTool emits onPermissionRequest for AskUserQuestion (passthrough tool routes to renderer UI)\`. The new test asserts the SDK runner DOES call \`onPermissionRequest\` for AskUserQuestion and waits for the renderer to settle the request.
- **Updated** \`PreToolUse hook returns allow for passthrough tools (#94)\` → \`PreToolUse hook returns ask for passthrough tools so canUseTool fires (#94)\`. Same flip, hook side.
- **Added** \`PreToolUse hook returns ask for passthrough tools even in bypass modes\` — bypass mode must NOT swallow user-question UI.

Reverse-verify (revert sessions.ts, keep tests): 3/24 fail with the expected diagnostics.

### harness-perm (renderer-IPC contract)

\`scripts/harness-perm.mjs\` — new case \`askuserquestion-routes-via-permission-request\`. Fires the \`agent:permissionRequest\` IPC frame the SDK runner emits in production and asserts:
- A \`kind:'question'\` block lands in the store with the right \`requestId\` / question text / option count.
- \`QuestionStickyHost\` renders it with \`[data-question-option]\` selectors.
- It does NOT fall through to a generic waiting/permission block.

Catches future renderer-side regressions (lifecycle.ts wiring breaks, store dedup logic etc.) that the SDK-side unit test wouldn't see.

Existing \`askuserquestion-no-dup-and-resolves\` and \`probe-e2e-askuserquestion-full.mjs\` both inject blocks **directly** into the zustand store, so they couldn't catch this — they bypass the entire SDK → onPermissionRequest → IPC chain that was broken.

## Verification

- \`npx tsc --noEmit\`: clean
- \`vitest electron/agent-sdk/__tests__/sessions.test.ts\`: 24/24 pass
- \`vitest run\` full: 829/832 pass; the 3 failures are pre-existing better-sqlite3 NODE_MODULE_VERSION mismatch in this worker env (unrelated to this change)
- \`node scripts/harness-perm.mjs --only=askuserquestion-routes-via-permission-request\`: OK
- \`node scripts/harness-perm.mjs --only=askuserquestion-no-dup-and-resolves\`: OK (existing case still green)
- \`npm run build\`: clean

## Hot files touched

- \`electron/agent-sdk/sessions.ts\` (single-owner; SDK adapter)
- No conflict with active branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)