### PR TITLE
feat: remove non-functional density setting

### DIFF
--- a/scripts/harness-ui.mjs
+++ b/scripts/harness-ui.mjs
@@ -1664,9 +1664,7 @@ async function caseI18nSettingsZh({ win, log, registerDispose }) {
   let txt = await paneText();
   assertHasText(txt, '主题', 'appearance');
   assertHasText(txt, '字号', 'appearance');
-  assertHasText(txt, '密度', 'appearance');
   assertNotHasText(txt, 'Theme', 'appearance');
-  assertNotHasText(txt, 'Density', 'appearance');
 
   // Notifications.
   await switchTab(/^通知$/);

--- a/scripts/probe-appearance-polish.mjs
+++ b/scripts/probe-appearance-polish.mjs
@@ -1,11 +1,10 @@
 // E2E: appearance polish probe.
 //
-// Exercises the four polish features without needing an API key:
+// Exercises the polish features without needing an API key:
 //   1. Theme toggle → verify <html> class flips (dark ⇄ theme-light)
 //   2. Font-size slider → verify --app-font-size CSS var updates
-//   3. Density segmented → verify html.density-* class updates
-//   4. Sidebar drag → verify sidebarWidthPct persists across reload
-//   5. Memory tab → create/edit CLAUDE.md in a temp cwd, verify file written
+//   3. Sidebar drag → verify sidebarWidthPct persists across reload
+//   4. Memory tab → create/edit CLAUDE.md in a temp cwd, verify file written
 //
 // Pure black-box where possible; uses store introspection only for the
 // persist-round-trip step (which otherwise needs a full app restart to see).
@@ -85,18 +84,7 @@ await win.keyboard.press('ArrowRight');
 await win.keyboard.press('ArrowRight');
 await win.waitForTimeout(150);
 
-// ── 3. Density ─────────────────────────────────────────────────────────────
-await win.getByRole('radio', { name: /^compact$/i }).click();
-await win.waitForTimeout(200);
-const isCompact = await win.evaluate(() =>
-  document.documentElement.classList.contains('density-compact')
-);
-if (!isCompact) fail('density-compact class not applied');
-ok('density → compact');
-await win.getByRole('radio', { name: /^normal$/i }).click();
-await win.waitForTimeout(150);
-
-// ── 4. Memory tab ──────────────────────────────────────────────────────────
+// ── 3. Memory tab ──────────────────────────────────────────────────────────
 // Close settings first; create a session pinned to tmpRepo so project memory is active.
 await win.keyboard.press('Escape');
 await win.waitForTimeout(200);
@@ -159,7 +147,7 @@ if (!content.includes('written by probe-appearance-polish')) {
 }
 ok(`CLAUDE.md written at ${memoryPath}`);
 
-// ── 5. Sidebar width persistence ───────────────────────────────────────────
+// ── 4. Sidebar width persistence ───────────────────────────────────────────
 // Close settings.
 await win.keyboard.press('Escape');
 await win.waitForTimeout(200);

--- a/scripts/probe-helpers/reset-between-cases.mjs
+++ b/scripts/probe-helpers/reset-between-cases.mjs
@@ -35,7 +35,7 @@
 // a future-proof spot in case persist.ts ever splits keys into rows.
 const APP_STATE_KEEP = new Set([
   // currently empty — see comment above. If/when persist.ts splits keys, list
-  // the survivors here (e.g. 'theme', 'fontSize', 'fontSizePx', 'density').
+  // the survivors here (e.g. 'theme', 'fontSize', 'fontSizePx').
 ]);
 
 /**

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -90,7 +90,6 @@ export default function App() {
   const toggleSidebar = useStore((s) => s.toggleSidebar);
   const theme = useStore((s) => s.theme);
   const fontSizePx = useStore((s) => s.fontSizePx);
-  const density = useStore((s) => s.density);
   const tutorialSeen = useStore((s) => s.tutorialSeen);
   const markTutorialSeen = useStore((s) => s.markTutorialSeen);
 
@@ -126,14 +125,6 @@ export default function App() {
   useEffect(() => {
     document.documentElement.style.setProperty('--app-font-size', `${fontSizePx}px`);
   }, [fontSizePx]);
-
-  // Density class on <html>. Components consume `--density-scale` via
-  // .density-row / inline calc() — see global.css.
-  useEffect(() => {
-    const root = document.documentElement;
-    root.classList.remove('density-compact', 'density-normal', 'density-comfortable');
-    root.classList.add(`density-${density}`);
-  }, [density]);
 
   // Locale: ask main for the OS locale, feed it into the preferences store
   // so a "system" preference resolves correctly. Falls back to navigator.

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -193,10 +193,8 @@ function Field({ label, hint, children }: { label: string; hint?: string; childr
 function AppearancePane() {
   const theme = useStore((s) => s.theme);
   const fontSizePx = useStore((s) => s.fontSizePx);
-  const density = useStore((s) => s.density);
   const setTheme = useStore((s) => s.setTheme);
   const setFontSizePx = useStore((s) => s.setFontSizePx);
-  const setDensity = useStore((s) => s.setDensity);
   const language = usePreferences((s) => s.language);
   const setLanguage = usePreferences((s) => s.setLanguage);
   const [windowTint, setWindowTint] = useWindowTint();
@@ -247,17 +245,6 @@ function AppearancePane() {
           />
           <span className="text-meta font-mono text-fg-secondary tabular-nums w-10">{fontSizePx}px</span>
         </div>
-      </Field>
-      <Field label={t('density')} hint={t('densityHint')}>
-        <Segmented
-          value={density}
-          onChange={setDensity}
-          options={[
-            { value: 'compact', label: t('densityOptions.compact') },
-            { value: 'normal', label: t('densityOptions.normal') },
-            { value: 'comfortable', label: t('densityOptions.comfortable') },
-          ]}
-        />
       </Field>
       <Field label={t('windowTint')} hint={t('windowTintHint')}>
         <WindowTintPicker value={windowTint} onChange={setWindowTint} t={t} />

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -237,13 +237,6 @@ const en = {
       md: 'Medium (13px, default)',
       lg: 'Large (14px)'
     },
-    density: 'Density',
-    densityHint: 'Tightens or loosens row padding and spacing across the app.',
-    densityOptions: {
-      compact: 'Compact',
-      normal: 'Normal',
-      comfortable: 'Comfortable'
-    },
     windowTint: 'Window tint',
     windowTintHint:
       'Faint accent on this window\u2019s title bar to tell parallel CCSM windows apart at a glance. Local to this window only.',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -218,13 +218,6 @@ const zh: EnCatalog = {
       md: '中 (13px，默认)',
       lg: '大 (14px)'
     },
-    density: '密度',
-    densityHint: '调整全局行间距与内边距的紧凑程度。',
-    densityOptions: {
-      compact: '紧凑',
-      normal: '常规',
-      comfortable: '宽松'
-    },
     windowTint: '窗口色调',
     windowTintHint: '为当前窗口的标题栏添加一抹淡色，便于在多开 CCSM 窗口时一眼区分。仅作用于当前窗口。',
     windowTintOptions: {

--- a/src/stores/persist.ts
+++ b/src/stores/persist.ts
@@ -4,7 +4,6 @@ import type {
   Theme,
   FontSize,
   FontSizePx,
-  Density,
   NotificationSettings,
   ThinkingLevel
 } from './store';
@@ -44,7 +43,6 @@ export const PERSISTED_KEYS = [
   'theme',
   'fontSize',
   'fontSizePx',
-  'density',
   'recentProjects',
   'tutorialSeen',
   'notificationSettings',
@@ -77,8 +75,6 @@ export interface PersistedState {
   fontSize?: FontSize;
   /** Preferred over legacy `fontSize` when present. 12–16 px scale. */
   fontSizePx?: FontSizePx;
-  /** UI density (compact/normal/comfortable). */
-  density?: Density;
   recentProjects?: RecentProject[];
   tutorialSeen?: boolean;
   notificationSettings?: NotificationSettings;

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -54,9 +54,6 @@ export type Theme = 'system' | 'light' | 'dark';
 export type FontSize = 'sm' | 'md' | 'lg';
 /** Root font-size in px. One of 12/13/14/15/16. */
 export type FontSizePx = 12 | 13 | 14 | 15 | 16;
-/** UI density — drives row padding / line height / block spacing via
- * `--density-scale` CSS variable. Compact = tighter, Comfortable = airier. */
-export type Density = 'compact' | 'normal' | 'comfortable';
 
 export type EndpointKind =
   | 'anthropic'
@@ -223,7 +220,6 @@ type State = {
   theme: Theme;
   fontSize: FontSize;
   fontSizePx: FontSizePx;
-  density: Density;
   tutorialSeen: boolean;
   notificationSettings: NotificationSettings;
   messagesBySession: Record<string, MessageBlock[]>;
@@ -485,7 +481,6 @@ type Actions = {
   setTheme: (theme: Theme) => void;
   setFontSize: (size: FontSize) => void;
   setFontSizePx: (px: FontSizePx) => void;
-  setDensity: (density: Density) => void;
   setSidebarWidth: (px: number) => void;
   resetSidebarWidth: () => void;
   markTutorialSeen: () => void;
@@ -799,11 +794,6 @@ export function sanitizeFontSizePx(raw: unknown): FontSizePx {
   return 14;
 }
 
-export function sanitizeDensity(raw: unknown): Density {
-  if (raw === 'compact' || raw === 'normal' || raw === 'comfortable') return raw;
-  return 'normal';
-}
-
 export const SIDEBAR_WIDTH_DEFAULT = 260;
 export const SIDEBAR_WIDTH_MIN = 200;
 export const SIDEBAR_WIDTH_MAX = 480;
@@ -988,7 +978,6 @@ export const useStore = create<State & Actions>((set, get) => ({
   theme: 'system',
   fontSize: 'md',
   fontSizePx: 14,
-  density: 'normal',
   tutorialSeen: false,
   notificationSettings: DEFAULT_NOTIFICATION_SETTINGS,
   messagesBySession: {},
@@ -1467,7 +1456,6 @@ export const useStore = create<State & Actions>((set, get) => ({
   setTheme: (theme) => set({ theme }),
   setFontSize: (fontSize) => set({ fontSize, fontSizePx: legacyFontSizeToPx(fontSize) }),
   setFontSizePx: (fontSizePx) => set({ fontSizePx, fontSize: pxToLegacyFontSize(fontSizePx) }),
-  setDensity: (density) => set({ density }),
   setSidebarWidth: (px) => set({ sidebarWidth: sanitizeSidebarWidth(px) }),
   resetSidebarWidth: () => set({ sidebarWidth: SIDEBAR_WIDTH_DEFAULT }),
   markTutorialSeen: () => set({ tutorialSeen: true }),
@@ -2553,7 +2541,6 @@ export async function hydrateStore(): Promise<void> {
       fontSizePx: persisted.fontSizePx !== undefined
         ? sanitizeFontSizePx(persisted.fontSizePx)
         : legacyFontSizeToPx(persisted.fontSize ?? 'md'),
-      density: sanitizeDensity(persisted.density),
       recentProjects: persisted.recentProjects ?? [],
       tutorialSeen: persisted.tutorialSeen ?? false,
       notificationSettings: {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -230,19 +230,6 @@ html, body, #root {
 }
 
 /*
-  Density scale. Multiplies padding / row heights in density-aware utilities
-  (see `.density-row` below). The three stops are intentionally narrow —
-  beyond ±15% the sidebar reads as broken, not "cozy". Applied to the
-  <html> element via JS based on user preference.
-*/
-html {
-  --density-scale: 1;
-}
-html.density-compact     { --density-scale: 0.88; }
-html.density-normal      { --density-scale: 1; }
-html.density-comfortable { --density-scale: 1.15; }
-
-/*
   Sidebar right-rail X axis. The 5 right-anchored affordances (search button,
   new-group +, in-group new-session +, selected-session blue dot, import
   button) all share a single vertical line so the eye reads them as one

--- a/tests/appearance.test.ts
+++ b/tests/appearance.test.ts
@@ -4,7 +4,6 @@ import {
   legacyFontSizeToPx,
   pxToLegacyFontSize,
   sanitizeFontSizePx,
-  sanitizeDensity,
   sanitizeSidebarWidth,
   resolvePersistedSidebarWidth,
   SIDEBAR_WIDTH_DEFAULT,
@@ -61,20 +60,6 @@ describe('font size migration', () => {
     expect(sanitizeFontSizePx(null)).toBe(14);
     expect(sanitizeFontSizePx(99)).toBe(14);
     expect(sanitizeFontSizePx(NaN)).toBe(14);
-  });
-});
-
-describe('density sanitize', () => {
-  it('passes through valid values', () => {
-    expect(sanitizeDensity('compact')).toBe('compact');
-    expect(sanitizeDensity('normal')).toBe('normal');
-    expect(sanitizeDensity('comfortable')).toBe('comfortable');
-  });
-
-  it('coerces invalid to normal (default)', () => {
-    expect(sanitizeDensity('weird')).toBe('normal');
-    expect(sanitizeDensity(undefined)).toBe('normal');
-    expect(sanitizeDensity(42)).toBe('normal');
   });
 });
 

--- a/tests/persist-shape.test.ts
+++ b/tests/persist-shape.test.ts
@@ -29,7 +29,6 @@ describe('persist: curated snapshot payload', () => {
         theme: 'system',
         fontSize: 'md',
         fontSizePx: 14,
-        density: 'normal',
         recentProjects: [],
         tutorialSeen: false,
         notificationSettings: {
@@ -61,7 +60,6 @@ describe('persist: curated snapshot payload', () => {
         'theme',
         'fontSize',
         'fontSizePx',
-        'density',
         'recentProjects',
         'tutorialSeen',
         'notificationSettings'

--- a/tests/persisted-keys-source-of-truth.test.ts
+++ b/tests/persisted-keys-source-of-truth.test.ts
@@ -67,7 +67,6 @@ describe('persist: PERSISTED_KEYS is the single source of truth', () => {
         "theme",
         "fontSize",
         "fontSizePx",
-        "density",
         "recentProjects",
         "tutorialSeen",
         "notificationSettings",
@@ -138,7 +137,6 @@ describe('persist: PERSISTED_KEYS is the single source of truth', () => {
       theme: 'dark',
       fontSize: 'lg',
       fontSizePx: 16,
-      density: 'compact',
       recentProjects: [{ id: 'p1', name: 'n', path: '/x' }],
       tutorialSeen: true,
       notificationSettings: {

--- a/tests/store-appearance.test.ts
+++ b/tests/store-appearance.test.ts
@@ -24,9 +24,7 @@ describe('appearance setters', () => {
     expect(useStore.getState().fontSizePx).toBe(16);
   });
 
-  it('setDensity writes and setTheme writes', () => {
-    useStore.getState().setDensity('compact');
-    expect(useStore.getState().density).toBe('compact');
+  it('setTheme writes', () => {
     useStore.getState().setTheme('light');
     expect(useStore.getState().theme).toBe('light');
   });


### PR DESCRIPTION
## User report
> Density 这个设置我调整了以后页面不见调整呀，要不先去掉

## Layer 1: grep audit
**Result: full deadcode.** The toggle wrote to `store.density`, App.tsx mirrored that to `html.density-{compact,normal,comfortable}`, global.css set `--density-scale` per class — but **no component / utility ever read `var(--density-scale)`**.

```
$ grep -rn 'var(--density-scale)\|\.density-row\|density-row' src/
src/styles/global.css:234:  (see `.density-row` below). The three stops are intentionally narrow —
src/App.tsx:131:  // .density-row / inline calc() — see global.css.
```

Both hits are stale **comments** referencing a `.density-row` class that was never defined and `var(--density-scale)` consumers that never landed. The whole pipeline (toggle → store → html class → CSS var) terminates in a dead variable. User's "页面不见调整" matches: the var changes, nothing observes it.

## Why delete instead of fix
- Per `feedback_design_density_polish.md`: ccsm intentionally targets one CLI-style density (block rendering + monospace + scannable). A density toggle is the wrong axis to expose.
- Implementing real density consumers across sidebar/chat/blocks would balloon the visual contract; that's a different design exercise, not a bug fix.
- User's instinct ("先去掉") matches the memory.

## Removed
| Layer        | File                                              | What                                                                 |
| ------------ | ------------------------------------------------- | -------------------------------------------------------------------- |
| UI           | `src/components/SettingsDialog.tsx`               | density `Field` + `Segmented`, store selector, setter                |
| State        | `src/stores/store.ts`                             | `Density` type, `density` state field, `setDensity`, `sanitizeDensity`, default, hydration line |
| Persist      | `src/stores/persist.ts`                           | `density` from `PERSISTED_KEYS` + `PersistedState`, `Density` import |
| Effect       | `src/App.tsx`                                     | density store selector + `useEffect` that toggled `html.density-*`   |
| CSS          | `src/styles/global.css`                           | `--density-scale` block + `html.density-{compact,normal,comfortable}` rules |
| i18n         | `src/i18n/locales/en.ts`, `src/i18n/locales/zh.ts`| `density`, `densityHint`, `densityOptions.*`                         |
| Tests        | `tests/appearance.test.ts`                        | `density sanitize` describe block + `sanitizeDensity` import         |
| Tests        | `tests/store-appearance.test.ts`                  | `setDensity` arm of combined test (kept theme arm)                   |
| Tests        | `tests/persist-shape.test.ts`                     | `density` from snapshot fixture + ALLOWED set                        |
| Tests        | `tests/persisted-keys-source-of-truth.test.ts`    | `density` from inline snapshot + fresh-value map                     |
| Harness      | `scripts/harness-ui.mjs`                          | `assertHasText '密度'` + `assertNotHasText 'Density'` in i18n-settings-zh |
| Probe        | `scripts/probe-appearance-polish.mjs`             | section 3 (Density) deleted; section numbers shifted                 |
| Comment      | `scripts/probe-helpers/reset-between-cases.mjs`   | example-list comment scrubbed                                        |

No backward-compat alias / deprecation comment (per task brief). Older persisted snapshots silently drop the key on hydrate.

## Verification
- [x] `npm run typecheck` — passes
- [x] vitest on touched tests (`tests/appearance.test.ts`, `tests/store-appearance.test.ts`, `tests/persist-shape.test.ts`, `tests/persisted-keys-source-of-truth.test.ts`) — 26/26 pass
- [x] `node scripts/harness-ui.mjs` — `i18n-settings-zh` passes (settings dialog no longer mentions 密度 / Density). 1 unrelated pre-existing flake (`terminal` ChatStream ToolBlock) not touched.

## Test plan
- [ ] Open settings → Appearance: confirm no Density field between Font Size and Window Tint
- [ ] Reload app: persisted state from older builds with `density: 'compact'` hydrates cleanly (key silently dropped)
- [ ] zh + en locale: settings dialog renders without missing-key warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)