### PR TITLE
fix(slash): hide plugin/skill/agent commands from picker (SDK can't run them)

### DIFF
--- a/electron/commands-loader.ts
+++ b/electron/commands-loader.ts
@@ -299,3 +299,39 @@ export function loadCommands(opts: LoadOpts = {}): LoadedCommand[] {
       ...(e.pluginId ? { pluginId: e.pluginId } : {}),
     }));
 }
+
+// ────────────────────── picker-visible filter ──────────────────────────────
+//
+// Subset of `loadCommands` surfaced to the slash-command picker. Three
+// sources are deliberately hidden:
+//
+//   - PLUGIN commands (`/<plugin>:<name>` from ~/.claude/plugins/cache/...).
+//     The CLI binary loads them in its own REPL but the
+//     @anthropic-ai/claude-agent-sdk transport ccsm uses requires plugins
+//     to be declared via `query({ options: { plugins: [...] } })`, which
+//     ccsm doesn't pass. Forwarding `/superpowers:brainstorm` to the SDK
+//     therefore arrives as plain user text and the model replies with the
+//     deprecated-skill stub instead of running the plugin command.
+//
+//   - SKILL entries (from ~/.claude/skills/) are loaded by the SDK as
+//     description-keyed system-prompt extensions ("when X happens, use this
+//     skill") — the agent invokes them on its own, the user cannot trigger
+//     them with `/skill-name`. Listing them in the picker created the same
+//     false affordance.
+//
+//   - AGENT entries are subagent definitions invoked by the main agent via
+//     the Task tool. There is no user-facing slash form, so they had no
+//     business in the picker either.
+//
+// `loadCommands` itself still returns every source — keeps the discovery
+// complete for future wiring (e.g. surfacing skills in a separate UI). Add
+// a source to PICKER_VISIBLE_SOURCES once the corresponding execution path
+// is actually wired through the SDK.
+export const PICKER_VISIBLE_SOURCES: ReadonlySet<CommandSource> = new Set([
+  'user',
+  'project',
+]);
+
+export function loadPickerCommands(opts: LoadOpts = {}): LoadedCommand[] {
+  return loadCommands(opts).filter((c) => PICKER_VISIBLE_SOURCES.has(c.source));
+}

--- a/electron/commands-loader.ts
+++ b/electron/commands-loader.ts
@@ -219,9 +219,16 @@ export type LoadOpts = {
 };
 
 export function loadCommands(opts: LoadOpts = {}): LoadedCommand[] {
-  const home = opts.homeDir ?? os.homedir();
   const cwd = opts.cwd ?? null;
-  const claudeRoot = path.join(home, '.claude');
+  // Resolve the Claude config root. Precedence:
+  //   1. opts.homeDir → `<homeDir>/.claude` (test override)
+  //   2. process.env.CLAUDE_CONFIG_DIR (used in production — ccsm sets this so
+  //      the binary and the GUI loader read the same tree; ignoring it would
+  //      desync the picker from what claude.exe actually executes)
+  //   3. `<os.homedir()>/.claude` (last-resort default)
+  const claudeRoot = opts.homeDir
+    ? path.join(opts.homeDir, '.claude')
+    : (process.env.CLAUDE_CONFIG_DIR ?? path.join(os.homedir(), '.claude'));
   const all: RawEntry[] = [];
 
   // 1. user

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -83,7 +83,7 @@ import { cancelQuestionRetry } from './notify-retry';
 import type { PermissionMode } from './agent/sessions';
 import { listModelsFromSettings } from './agent/list-models-from-settings';
 import { readMemoryFile, writeMemoryFile, memoryFileExists } from './memory';
-import { loadCommands } from './commands-loader';
+import { loadPickerCommands } from './commands-loader';
 
 // ─────────────────────── IPC security helpers ────────────────────────────
 //
@@ -1111,17 +1111,23 @@ app.whenReady().then(() => {
 
   // ─────────────────────── disk-based slash commands ──────────────────────
   //
-  // Picker discovery for user / project / plugin command markdown files.
-  // Renderer calls this on focus / cwd change. Execution stays pass-through:
+  // Picker discovery for user / project command markdown files. Renderer
+  // calls this on focus / cwd change. Execution stays pass-through:
   // selecting one inserts `/<name>` into the textarea, which the existing
   // send path forwards to claude.exe. We never parse the body.
+  //
+  // `loadPickerCommands` filters out plugin / skill / agent sources because
+  // the @anthropic-ai/claude-agent-sdk transport doesn't execute them
+  // without explicit configuration ccsm doesn't currently provide; listing
+  // them in the picker misled users into invocations that fell through to
+  // the model as plain text. See commands-loader.ts for the full rationale.
   ipcMain.handle('commands:list', (_e, cwd: string | null | undefined) => {
     // commands-loader does its own fs reads against the supplied cwd; UNC or
     // relative inputs get filtered out here so we don't leak NTLM (Windows)
     // or descend into wherever a confused renderer points us. Empty list is
     // the safe fallback for any unsafe input.
     if (cwd != null && !isSafePath(cwd)) return [];
-    return loadCommands({ cwd: cwd ?? null });
+    return loadPickerCommands({ cwd: cwd ?? null });
   });
 
   // ─────────────────────── @mention file listing ──────────────────────────

--- a/scripts/harness-ui.mjs
+++ b/scripts/harness-ui.mjs
@@ -20,6 +20,7 @@
 //   - cwd-popover-recent-unfiltered        (probe-e2e-cwd-popover-recent-unfiltered)
 //   - palette-empty                        (probe-e2e-palette-empty, #117 / #258)
 //   - palette-nav                          (probe-e2e-palette-nav)
+//   - slash-picker-claude-config-dir       (PR #346, env-scoped fake ~/.claude)
 //   - settings-open                        (probe-e2e-settings-open)
 //   - search-shortcut-f                    (probe-e2e-search-shortcut-f)
 //   - tutorial                             (probe-e2e-tutorial)
@@ -896,6 +897,81 @@ async function caseCwdPopoverRecentUnfiltered({ app, win, log, registerDispose }
   if (recentOffender) throw new Error(`"Recent" header is CSS-uppercased — forbidden`);
 
   log(`open with cwd "${ACTIVE_CWD}" → all ${RECENT.length} visible; "bar" filters to 1; clear restores`);
+}
+
+// ---------- slash-picker-claude-config-dir ----------
+// Loader honors `CLAUDE_CONFIG_DIR`. Seeds a fake `<tmp>/.claude`-shaped
+// tree via the env var (NOT $HOME) and asserts the in-chat slash picker:
+//   - surfaces the user-level command (`local-test`)
+//   - hides plugin-cache commands (`brainstorm`, `superpowers:brainstorm`)
+//
+// This pins both gates simultaneously:
+//   1. commands-loader.ts reads `process.env.CLAUDE_CONFIG_DIR` (fall-through
+//      to `os.homedir()` would scan the dev's real ~/.claude, populating
+//      the picker with whatever they have installed and breaking the
+//      assertions). The `superpowers:brainstorm` row is the canary —
+//      the dev's real ~/.claude has it, the fake tree must NOT surface it.
+//   2. PICKER_VISIBLE_SOURCES filter still excludes `plugin` (the seeded
+//      brainstorm.md sits under plugins/cache/...).
+//
+// preMain wires the env on the main process (where the IPC handler reads
+// `process.env.CLAUDE_CONFIG_DIR`). Disposers restore env and rm -rf the
+// fake tree.
+//
+// Reverse-verification: stash PICKER_VISIBLE_SOURCES filter (set it to
+// include all sources) → `superpowers:brainstorm` appears → case fails.
+async function caseSlashPickerClaudeConfigDir({ win, log }) {
+  await win.evaluate(() => {
+    window.__ccsmStore.setState({
+      groups: [{ id: 'g-slash', name: 'G', collapsed: false, kind: 'normal' }],
+      sessions: [{
+        id: 's-slash-1', name: 'slash-pick', state: 'idle', cwd: 'C:/x',
+        model: 'claude-opus-4', groupId: 'g-slash', agentType: 'claude-code'
+      }],
+      activeId: 's-slash-1',
+      tutorialSeen: true
+    });
+  });
+  await win.waitForTimeout(200);
+
+  const textarea = win.locator('textarea').first();
+  await textarea.waitFor({ state: 'visible', timeout: 5000 });
+  // Defocus then focus so the InputBar's onFocus refreshDynamic() fires
+  // AFTER preMain set CLAUDE_CONFIG_DIR (the harness boots before preMain).
+  await win.locator('body').click({ position: { x: 5, y: 5 } }).catch(() => {});
+  await textarea.click();
+  await win.waitForTimeout(150);
+  await textarea.fill('/');
+  await win.waitForTimeout(200);
+
+  const picker = win.locator('[role="listbox"][aria-label="Slash commands"]');
+  await picker.waitFor({ state: 'visible', timeout: 3000 });
+
+  const optionTexts = await picker.locator('[role="option"]').allInnerTexts();
+  const flat = optionTexts.join(' | ');
+
+  // Positive: the seeded user command must be there.
+  if (!flat.includes('/local-test')) {
+    throw new Error(`expected /local-test in picker; got: ${flat}`);
+  }
+
+  // Negative: plugin-source commands must be filtered out. The seeded
+  // plugin is "superpowers" with command "brainstorm" — the loader emits
+  // it as `superpowers:brainstorm`. Bare `brainstorm` is also forbidden.
+  for (const forbidden of ['superpowers:brainstorm', '/brainstorm ', '/brainstorm\n', '/brainstorm$']) {
+    if (forbidden.startsWith('/brainstorm')) {
+      // Match `/brainstorm` only as a whole token (not as a prefix of
+      // another name, though we don't seed any). Use a regex.
+      const re = new RegExp(`/brainstorm(?![a-zA-Z0-9._:-])`);
+      if (re.test(flat)) {
+        throw new Error(`forbidden plugin command surfaced: /brainstorm in ${flat}`);
+      }
+    } else if (flat.includes(forbidden)) {
+      throw new Error(`forbidden plugin command surfaced: ${forbidden} in ${flat}`);
+    }
+  }
+
+  log(`picker showed /local-test; suppressed superpowers:brainstorm (env-scoped fake ~/.claude)`);
 }
 
 // ---------- palette-empty ----------
@@ -2314,6 +2390,57 @@ await runHarness({
     { id: 'cwd-popover-recent-unfiltered', run: caseCwdPopoverRecentUnfiltered },
     { id: 'palette-empty', run: casePaletteEmpty },
     { id: 'palette-nav', run: casePaletteNav },
+    // slash-picker-claude-config-dir: pins (a) loader honoring CLAUDE_CONFIG_DIR
+    // and (b) picker filtering plugin-source commands. preMain seeds a fake
+    // `<tmp>/.claude` tree with one user command (`local-test`, must appear)
+    // and one plugin command (`brainstorm` under `superpowers`, must NOT
+    // appear), then sets process.env.CLAUDE_CONFIG_DIR on the main process so
+    // the loader's IPC handler resolves to the fixture instead of the dev's
+    // real ~/.claude. Disposers restore env + rm -rf tmp tree.
+    {
+      id: 'slash-picker-claude-config-dir',
+      preMain: async (app, ctx) => {
+        const fakeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ccsm-e2e-fake-claude-'));
+        // user command — should surface in the picker.
+        const userDir = path.join(fakeRoot, 'commands');
+        fs.mkdirSync(userDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(userDir, 'local-test.md'),
+          `---\ndescription: seeded user command\n---\nbody\n`,
+          'utf8'
+        );
+        // plugin command — should be hidden by PICKER_VISIBLE_SOURCES.
+        const pluginCmdDir = path.join(
+          fakeRoot, 'plugins', 'cache', 'mkt', 'superpowers', '1.0.0', 'commands'
+        );
+        fs.mkdirSync(pluginCmdDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(pluginCmdDir, 'brainstorm.md'),
+          `---\ndescription: deprecated plugin command\n---\nbody\n`,
+          'utf8'
+        );
+
+        // Set CLAUDE_CONFIG_DIR on the main process so the loader's IPC
+        // handler reads the fixture. Snapshot the prior value so the
+        // disposer can restore it (env may legitimately be set in dev).
+        const prior = await app.evaluate((_mod, args) => {
+          const before = process.env.CLAUDE_CONFIG_DIR;
+          process.env.CLAUDE_CONFIG_DIR = args.fakeRoot;
+          return before ?? null;
+        }, { fakeRoot });
+
+        ctx.registerDispose(async () => {
+          try {
+            await app.evaluate((_mod, args) => {
+              if (args.prior == null) delete process.env.CLAUDE_CONFIG_DIR;
+              else process.env.CLAUDE_CONFIG_DIR = args.prior;
+            }, { prior });
+          } catch { /* app may already be torn down */ }
+          try { fs.rmSync(fakeRoot, { recursive: true, force: true }); } catch {}
+        });
+      },
+      run: caseSlashPickerClaudeConfigDir,
+    },
     { id: 'settings-open', run: caseSettingsOpen },
     { id: 'search-shortcut-f', run: caseSearchShortcutF },
     { id: 'tutorial', run: caseTutorial },

--- a/tests/commands-loader.test.ts
+++ b/tests/commands-loader.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { loadCommands, parseFrontmatter } from '../electron/commands-loader';
+import { loadCommands, loadPickerCommands, parseFrontmatter } from '../electron/commands-loader';
 
 let tmpHome: string;
 let tmpCwd: string;
@@ -309,5 +309,90 @@ describe('loadCommands', () => {
     const agents = cmds.filter((c) => c.source === 'agent');
     expect(agents.map((c) => c.name)).toEqual(['empty']);
     expect(agents[0].description).toBeUndefined();
+  });
+});
+
+// ─── loadPickerCommands ────────────────────────────────────────────────────
+//
+// Picker-visible filter: hides plugin / skill / agent sources because the
+// agent SDK transport ccsm uses cannot execute them without configuration
+// ccsm doesn't supply. These tests pin that contract so a future
+// refactor doesn't silently re-surface broken slash entries to users.
+
+describe('loadPickerCommands', () => {
+  it('keeps user and project sources, drops plugin / skill / agent', () => {
+    // user
+    write(
+      path.join(tmpHome, '.claude', 'commands', 'user-cmd.md'),
+      `---\ndescription: u\n---\n`
+    );
+    // project
+    write(
+      path.join(tmpCwd, '.claude', 'commands', 'project-cmd.md'),
+      `---\ndescription: p\n---\n`
+    );
+    // plugin
+    write(
+      path.join(
+        tmpHome,
+        '.claude',
+        'plugins',
+        'cache',
+        'mkt',
+        'pluginA',
+        '1.0.0',
+        'commands',
+        'plugin-cmd.md'
+      ),
+      `---\ndescription: pl\n---\n`
+    );
+    // skill
+    write(
+      path.join(tmpHome, '.claude', 'skills', 'skill-cmd.md'),
+      `---\ndescription: sk\n---\n`
+    );
+    // agent
+    write(
+      path.join(tmpHome, '.claude', 'agents', 'agent-cmd.md'),
+      `---\ndescription: ag\n---\n`
+    );
+
+    const all = loadCommands({ homeDir: tmpHome, cwd: tmpCwd });
+    const picker = loadPickerCommands({ homeDir: tmpHome, cwd: tmpCwd });
+
+    // sanity: full loader still returns every source
+    const allSources = new Set(all.map((c) => c.source));
+    expect(allSources).toEqual(new Set(['user', 'project', 'plugin', 'skill', 'agent']));
+
+    // picker filter: only user + project survive
+    const pickerNames = picker.map((c) => `${c.source}/${c.name}`).sort();
+    expect(pickerNames).toEqual(['project/project-cmd', 'user/user-cmd']);
+  });
+
+  it('returns an empty list when only plugin / skill / agent entries exist', () => {
+    // Real-world scenario: a fresh user with the superpowers + pua plugins
+    // installed but no personal `~/.claude/commands` of their own. The
+    // picker must NOT show plugin entries — that's the whole bug.
+    write(
+      path.join(
+        tmpHome,
+        '.claude',
+        'plugins',
+        'cache',
+        'mkt',
+        'superpowers',
+        '1.0.0',
+        'commands',
+        'brainstorm.md'
+      ),
+      `---\ndescription: deprecated\n---\n`
+    );
+    write(
+      path.join(tmpHome, '.claude', 'skills', 'helpful.md'),
+      `---\ndescription: a skill\n---\n`
+    );
+
+    const picker = loadPickerCommands({ homeDir: tmpHome, cwd: tmpCwd });
+    expect(picker).toEqual([]);
   });
 });

--- a/tests/commands-loader.test.ts
+++ b/tests/commands-loader.test.ts
@@ -221,6 +221,64 @@ describe('loadCommands', () => {
     expect(cmds.map((c) => c.name)).toEqual(['a']);
   });
 
+  // ─── CLAUDE_CONFIG_DIR env fallback (PR #346 review) ────────────────────
+  //
+  // Production code path: ccsm sets `CLAUDE_CONFIG_DIR=~/.claude` so the
+  // claude.exe binary and the GUI loader read the same tree (see project
+  // memory `project_cli_config_reuse`). Before the env-fallback patch the
+  // loader hard-coded `os.homedir()/.claude`, silently desyncing the picker
+  // from what the binary actually executed. These tests pin the env path:
+  //   - explicit `homeDir` opt always wins (test override beats env)
+  //   - env var resolved when no opt provided
+  //   - falls back to os.homedir() when neither is set
+
+  it('honors process.env.CLAUDE_CONFIG_DIR when no homeDir opt is passed', () => {
+    write(
+      path.join(tmpHome, '.claude', 'commands', 'should-not-load.md'),
+      `---\n---\n`
+    );
+    // Build a separate fake root and point the env var at it. Because we
+    // omit `homeDir`, the env var should win and the loader should read
+    // from the fake root, NOT tmpHome.
+    const fakeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agentory-cmds-env-'));
+    write(
+      path.join(fakeRoot, 'commands', 'env-cmd.md'),
+      `---\ndescription: from-env\n---\n`
+    );
+    const prior = process.env.CLAUDE_CONFIG_DIR;
+    process.env.CLAUDE_CONFIG_DIR = fakeRoot;
+    try {
+      const cmds = loadCommands({ cwd: tmpCwd });
+      expect(cmds.map((c) => c.name)).toEqual(['env-cmd']);
+    } finally {
+      if (prior == null) delete process.env.CLAUDE_CONFIG_DIR;
+      else process.env.CLAUDE_CONFIG_DIR = prior;
+      fs.rmSync(fakeRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('opt.homeDir wins over CLAUDE_CONFIG_DIR when both are set', () => {
+    write(
+      path.join(tmpHome, '.claude', 'commands', 'from-opt.md'),
+      `---\n---\n`
+    );
+    const fakeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agentory-cmds-env2-'));
+    write(
+      path.join(fakeRoot, 'commands', 'from-env.md'),
+      `---\n---\n`
+    );
+    const prior = process.env.CLAUDE_CONFIG_DIR;
+    process.env.CLAUDE_CONFIG_DIR = fakeRoot;
+    try {
+      const cmds = loadCommands({ homeDir: tmpHome, cwd: tmpCwd });
+      expect(cmds.map((c) => c.name)).toEqual(['from-opt']);
+    } finally {
+      if (prior == null) delete process.env.CLAUDE_CONFIG_DIR;
+      else process.env.CLAUDE_CONFIG_DIR = prior;
+      fs.rmSync(fakeRoot, { recursive: true, force: true });
+    }
+  });
+
   // ─── agents loading (PR-E shipped this; PR-L adds the missing tests) ───
   //
   // The loader scans both ~/.claude/agents and <cwd>/.claude/agents and tags


### PR DESCRIPTION
## Summary

User report (dogfood): `/plugin`, `/superpowers:brainstorm`, `/superpowers:write-plan`, `/pua:kpi` all behave broken — selecting them in the slash picker (or typing them manually) yields a model-text reply like "already deprecated, use the skill instead" or "unknown command" instead of actually running anything.

## Root cause

`electron/commands-loader.ts` scans five sources off disk:

1. `~/.claude/commands/` — user-level (`source: 'user'`)
2. `<cwd>/.claude/commands/` — project-level (`source: 'project'`)
3. `~/.claude/plugins/cache/<market>/<plugin>/<ver>/commands/` (`source: 'plugin'`)
4. `~/.claude/skills/` (`source: 'skill'`)
5. `~/.claude/{,project/}agents/` (`source: 'agent'`)

But the actual slash dispatch is a pass-through: `InputBar.send()` → `dispatchSlashCommand` returns `'pass-through'` → the literal `/<name> <args>` text is forwarded as a plain SDKUserMessage (`electron/agent-sdk/sessions.ts:466-478`).

The `@anthropic-ai/claude-agent-sdk` transport does NOT auto-execute CLI plugins / skills / subagents the way the CLI's REPL does:

- **plugin** — SDK requires explicit `query({ options: { plugins: SdkPluginConfig[] } })` (see node_modules sdk.d.ts:1471–1485). ccsm doesn't pass that field, so plugin commands never get installed; the slash text falls through to the model, which (correctly!) knows `/superpowers:brainstorm` is the deprecated stub of the `brainstorming` skill and replies as such.
- **skill** — skills are description-keyed system-prompt extensions invoked by the agent itself, never via `/skill-name`. Listing them in the picker created a false affordance.
- **agent** — subagent definitions reached via the Task tool, not by the user. Same false-affordance issue.

So three of the five loader sources have been surfacing un-runnable entries, and the model's polite "deprecated, use the skill" replies are the symptom users were filing.

## Decision

**Hide plugin / skill / agent in the picker** rather than:

- (b) grey them out — still surfaces names the user can't act on
- (c) wire SDK plugin/skill execution — non-trivial (`SdkPluginConfig` is local-path only, would need to enumerate `~/.claude/plugins/cache` paths and validate each), out of dogfood scope. Re-enable in a follow-up that actually plumbs `plugins` / `skills` through to `query()`.

Loader-level filter (vs. picker-level) so the contract is unit-testable without standing up the renderer or Electron.

## Implementation

- New `loadPickerCommands(opts)` in `electron/commands-loader.ts` — thin wrapper around `loadCommands` that filters down to `PICKER_VISIBLE_SOURCES = {user, project}`.
- Loader honors `process.env.CLAUDE_CONFIG_DIR` (review fix). ccsm sets this for the `claude` binary so the picker and the binary read the same tree (project memory `project_cli_config_reuse`); the prior hard-coded `os.homedir()` silently desynced them. Resolution order: `opts.homeDir` (test override) > `process.env.CLAUDE_CONFIG_DIR` > `os.homedir()/.claude`.
- `commands:list` IPC in `electron/main.ts` switched from `loadCommands` to `loadPickerCommands`. `isSafePath` guard preserved.
- `loadCommands` itself is **kept** rather than inlined into `loadPickerCommands`. This is intentional, not speculative reuse: the full discovery is the public contract the existing `tests/commands-loader.test.ts` suite asserts against (plugin namespacing, conflict resolution, agent dedupe, etc.) and is the natural seam for a future UI that surfaces skills/agents in a separate panel once execution is wired. Removing it would force any such follow-up to re-implement the scan from scratch.

## Tests

vitest cases in `tests/commands-loader.test.ts`:

- `loadPickerCommands` describe block: filter keeps user + project, drops plugin / skill / agent (mixed-source fixture); empty-result case for the dogfood scenario (only plugin/skill installed, no personal commands).
- New env-fallback tests: `CLAUDE_CONFIG_DIR` resolved when no `homeDir` opt; `opts.homeDir` wins when both set.

E2E (review request): new harness-ui case `slash-picker-claude-config-dir`. `preMain` mints a fresh `<tmp>/ccsm-e2e-fake-claude-*` tree seeded with `commands/local-test.md` (must surface) + `plugins/cache/mkt/superpowers/1.0.0/commands/brainstorm.md` (must NOT surface), points `process.env.CLAUDE_CONFIG_DIR` at it on the main process, then opens the slash picker and asserts the visibility contract. Disposers restore the env var and `rm -rf` the fake root.

Reverse-verification (per project E2E discipline): stashed the env-fallback in `commands-loader.ts` (loader reverts to scanning the dev's real `~/.claude`) → case fails as expected (`/local-test` never appears, only built-ins). Stash restored, case passes again.

## Follow-ups

- Typing `/plugin` (or any namespaced unknown slash like `/foo:bar`) directly into the textarea still pass-throughs to the model instead of producing a local "unknown command" toast — the picker filter only hides them from suggestion, it doesn't reject manual entry. Tracked separately; out of scope for this PR.

## Coordination

Touched: `electron/commands-loader.ts`, `electron/main.ts`, `tests/commands-loader.test.ts`, `scripts/harness-ui.mjs`. No overlap with the `fix-think-dropdown` worker — that one operates on `registry.ts` / `SlashCommandPicker.tsx` / `handlers.ts` which this PR doesn't touch.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run tests/commands-loader.test.ts` — 22/22 pass
- [x] `node scripts/harness-ui.mjs --only=slash-picker-claude-config-dir` — pass
- [x] Reverse-verify: stash env-fallback → harness case fails → restore → passes
- [ ] Manual dogfood: open picker with superpowers + pua plugins installed → no `/superpowers:*` / `/pua:*` rows visible; `/clear`, `/compact`, `/config`, `/think` still visible