### PR TITLE
notif: strip dispatch + lifecycle 抑制逻辑 (W1)

### DIFF
--- a/src/agent/lifecycle.ts
+++ b/src/agent/lifecycle.ts
@@ -14,12 +14,10 @@ const streamers = new Map<string, PartialAssistantStreamer>();
 // so subsequent assistant text blocks in the same turn carry `viaSkill` for
 // the AssistantBlock badge (Task #318).
 const activeSkillBySession = new Map<string, SkillProvenance | null>();
-// Wall-clock timestamps for currently-running turns. We use elapsed time as
-// one of the signals for whether a `turn_done` is worth notifying about — a
-// fast turn that wraps in <15s is rarely worth surfacing, but a long-running
-// one almost always is.
+// Wall-clock timestamps for currently-running turns. Kept around so other
+// future signals (e.g. duration logging) have access; the turn_done
+// notification itself fires unconditionally now.
 const turnStartedAt = new Map<string, number>();
-const TURN_DONE_THRESHOLD_MS = 15_000;
 function streamerFor(sessionId: string): PartialAssistantStreamer {
   let s = streamers.get(sessionId);
   if (!s) {
@@ -305,48 +303,27 @@ export function subscribeAgentEvents(): void {
       // as it streams; we just read from there on load. The previous
       // `saveMessages` call here was a redundant secondary write that
       // mirrored the SDK's own transcript into ccsm's SQLite.
-      // `turn_done` notification policy: only ping when the turn meaningfully
-      // consumed the user's patience — long (>15s), or errored, or this
-      // session isn't the one being watched. Fast, successful, focused turns
-      // are noise; we skip them.
-      const startedAt = turnStartedAt.get(e.sessionId);
+      // turn_done notification: fires unconditionally on every result frame
+      // (subject only to the global enabled gate inside dispatchNotification).
+      // The user explicitly wants to be pinged whenever a turn ends — focus,
+      // duration, and per-event toggles all removed.
       turnStartedAt.delete(e.sessionId);
-      const durationMs = startedAt ? Date.now() - startedAt : 0;
-      const result = e.message as { subtype?: string; is_error?: boolean };
-      const errored =
-        !!result.is_error ||
-        result.subtype === 'error_max_turns' ||
-        result.subtype === 'error_during_execution';
       const isActive = store.activeId === e.sessionId;
       const windowFocused = typeof document !== 'undefined' && document.hasFocus();
       const sessionFocused = isActive && windowFocused;
       // Pulse the sidebar icon when the user isn't actively watching this
-      // session's chat. Cleared by selectSession on click. Same focus rule as
-      // the OS notification below — if the user has eyes on it, no pulse.
+      // session's chat. Cleared by selectSession on click.
       if (!sessionFocused) {
         store.setSessionState(e.sessionId, 'waiting');
       }
-      if (errored || durationMs >= TURN_DONE_THRESHOLD_MS || !sessionFocused) {
+      {
         const session = store.sessions.find((s) => s.id === e.sessionId);
         const sessionName = session?.name ?? 'Session';
-        const title = errored
-          ? i18next.t('notifications.turnErrorTitle', { name: sessionName })
-          : i18next.t('notifications.turnDoneTitle', { name: sessionName });
-        const body = errored ? i18next.t('notifications.turnErrorBody') : undefined;
-        // Wave 1D: build extras for the inlined notify module Adaptive Toast pipeline.
-        // Last user / assistant message previews come from the in-store block
-        // history; we cap them to 200 chars to keep the toast body readable.
-        const blocks = useStore.getState().messagesBySession[e.sessionId] ?? [];
-        const lastUser = [...blocks].reverse().find((b) => b.kind === 'user');
-        const lastAssistant = [...blocks]
-          .reverse()
-          .find((b) => b.kind === 'assistant');
-        const truncate = (s: string, n = 200): string =>
-          s.length > n ? `${s.slice(0, n - 1)}…` : s;
         const groupName = session
           ? store.groups.find((g) => g.id === session.groupId)?.name ?? ''
           : '';
-        const toolCount = blocks.filter((b) => b.kind === 'tool').length;
+        const title = groupName ? `${groupName} / ${sessionName}` : sessionName;
+        const body = i18next.t('notifications.turnDoneBody');
         void dispatchNotification({
           sessionId: e.sessionId,
           eventType: 'turn_done',
@@ -356,17 +333,7 @@ export function subscribeAgentEvents(): void {
             toastId: `done-${e.sessionId}-${Date.now().toString(36)}`,
             sessionName,
             groupName,
-            cwd: session?.cwd,
-            elapsedMs: durationMs,
-            toolCount,
-            lastUserMsg:
-              lastUser && 'text' in lastUser && typeof lastUser.text === 'string'
-                ? truncate(lastUser.text)
-                : '',
-            lastAssistantMsg:
-              lastAssistant && 'text' in lastAssistant && typeof lastAssistant.text === 'string'
-                ? truncate(lastAssistant.text)
-                : '',
+            eventType: 'turn_done',
           },
         });
       }
@@ -422,48 +389,30 @@ export function subscribeAgentEvents(): void {
       const sessionName = session?.name ?? i18next.t('notifications.backgroundSessionFallback');
       backgroundWaitingHandler({ sessionId: req.sessionId, sessionName, prompt });
     }
-    // OS-level notification dispatch is deduped/suppressed inside dispatch:
-    // mute, focus, debounce, and per-event-type toggles all live there. We
-    // just hand it the semantic event and let it decide whether to ping the OS.
+    // OS-level notification: the only suppression that remains is the global
+    // enabled toggle, applied inside dispatchNotification.
     const session = store.sessions.find((s) => s.id === req.sessionId);
     const sessionName = session?.name ?? i18next.t('notifications.backgroundSessionFallback');
+    const groupName = session
+      ? store.groups.find((g) => g.id === session.groupId)?.name ?? ''
+      : '';
     const eventType = block.kind === 'question' ? 'question' : 'permission';
-    const title =
-      block.kind === 'question'
-        ? i18next.t('notifications.questionTitle', { name: sessionName })
-        : i18next.t('notifications.inputNeededTitle', { name: sessionName });
-    let body: string | undefined;
-    if (block.kind === 'question') {
-      body = block.questions[0]?.question;
-    } else if (block.kind === 'waiting') {
-      body = block.intent === 'plan' ? i18next.t('chat.planTitle') : block.prompt;
-    }
+    const title = groupName ? `${groupName} / ${sessionName}` : sessionName;
+    const body =
+      eventType === 'question'
+        ? i18next.t('notifications.questionBody')
+        : i18next.t('notifications.permissionBody');
     void dispatchNotification({
       sessionId: req.sessionId,
       eventType,
       title,
       body,
-      // Wave 1D: rich extras for the inlined notify module Adaptive Toast. The toastId
-      // for permission events is the requestId itself so the main-process
-      // action router can resolve back into the same agent permission gate.
-      // For question events we prefix with `q-` to mirror the in-app block id.
-      extras:
-        block.kind === 'question'
-          ? {
-              toastId: `q-${req.requestId}`,
-              sessionName,
-              cwd: session?.cwd,
-              question: block.questions[0]?.question ?? '',
-              selectionKind: block.questions[0]?.multiSelect ? 'multi' : 'single',
-              optionCount: block.questions[0]?.options.length ?? 0,
-            }
-          : {
-              toastId: req.requestId,
-              sessionName,
-              cwd: session?.cwd,
-              toolName: req.toolName,
-              toolBrief: typeof body === 'string' ? body : '',
-            },
+      extras: {
+        toastId: block.kind === 'question' ? `q-${req.requestId}` : req.requestId,
+        sessionName,
+        groupName,
+        eventType,
+      },
     });
   });
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -425,10 +425,13 @@ const en = {
     permissionRequestTitle: 'Permission requested',
     permissionRequestBody: '{{name}} is asking to {{action}}',
     turnDoneTitle: '{{name}} is done',
+    turnDoneBody: 'Turn done',
     turnErrorTitle: '{{name}} finished with an error',
     turnErrorBody: 'Turn ended in error - check the chat.',
     questionTitle: '{{name}} has a question',
+    questionBody: 'Question',
     inputNeededTitle: '{{name}} needs your input',
+    permissionBody: 'Permission',
     backgroundSessionFallback: 'Background session',
     backgroundWaitingToastTitle: '{{name}} needs your input'
   },

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -397,10 +397,13 @@ const zh: EnCatalog = {
     permissionRequestTitle: '请求权限',
     permissionRequestBody: '{{name}} 想要 {{action}}',
     turnDoneTitle: '{{name}} 已完成',
+    turnDoneBody: '回合结束',
     turnErrorTitle: '{{name}} 执行出错',
     turnErrorBody: '本轮以错误结束，请查看聊天。',
     questionTitle: '{{name}} 提了一个问题',
+    questionBody: '提问',
     inputNeededTitle: '{{name}} 需要你的输入',
+    permissionBody: '权限请求',
     backgroundSessionFallback: '后台会话',
     backgroundWaitingToastTitle: '{{name}} 需要你的输入'
   },

--- a/src/notifications/dispatch.ts
+++ b/src/notifications/dispatch.ts
@@ -8,114 +8,35 @@ export interface DispatchInput {
   title: string;
   body?: string;
   /**
-   * Optional rich metadata forwarded to the inlined notify module Adaptive Toasts in
-   * the main process (Wave 1D). Plain Electron Notification toasts ignore
-   * this — they only need `title` + `body`. Routing the action callback
-   * (Allow / Allow always / Reject) back to the renderer relies on
-   * `extras.toastId` matching the `requestId` used by PermissionPromptBlock.
+   * Minimal metadata forwarded to the main process notification IPC. Plain
+   * Electron Notification toasts ignore this — they only need `title` + `body`.
+   * `toastId` matches the `requestId` used by PermissionPromptBlock so the
+   * action callback (Allow / Allow always / Reject) can route back.
    */
   extras?: {
     toastId?: string;
     sessionName?: string;
     groupName?: string;
-    toolName?: string;
-    toolBrief?: string;
-    question?: string;
-    selectionKind?: 'single' | 'multi';
-    optionCount?: number;
-    lastUserMsg?: string;
-    lastAssistantMsg?: string;
-    elapsedMs?: number;
-    toolCount?: number;
-    cwd?: string;
+    eventType?: NotificationEventType;
   };
 }
 
-export type DispatchSkipReason =
-  | 'no-api'
-  | 'global-disabled'
-  | 'event-disabled'
-  | 'session-muted'
-  | 'focused-active'
-  | 'debounced';
+export type DispatchSkipReason = 'no-api' | 'global-disabled';
 
 export interface DispatchResult {
   dispatched: boolean;
   reason?: DispatchSkipReason;
 }
 
-const DEBOUNCE_MS = 30_000;
-// Last-fired timestamp per (sessionId|eventType). Module-level on purpose:
-// the lifecycle module is a singleton in the renderer, so this map naturally
-// scopes to one window. A bounded LRU is overkill — a typical user has at
-// most a few dozen sessions × 3 event types.
-const lastFiredAt = new Map<string, number>();
-
-function cacheKey(sessionId: string, eventType: NotificationEventType): string {
-  return `${sessionId}|${eventType}`;
-}
-
-// Test seam: probe-notifications.mjs and unit tests can override these to
-// simulate window focus / active session without driving real DOM events.
-export interface DispatchEnv {
-  hasFocus: () => boolean;
-  now: () => number;
-}
-
-const defaultEnv: DispatchEnv = {
-  hasFocus: () => (typeof document !== 'undefined' ? document.hasFocus() : false),
-  now: () => Date.now()
-};
-
-let env: DispatchEnv = defaultEnv;
-
-export function setDispatchEnv(next: Partial<DispatchEnv>): void {
-  env = { ...defaultEnv, ...env, ...next };
-}
-
-export function resetDispatchState(): void {
-  env = defaultEnv;
-  lastFiredAt.clear();
-}
-
-// Apply suppression rules then call the main-process notification IPC. The
-// rules are intentionally conservative: a notification is a heavy, OS-level
-// interruption, so when in doubt we skip rather than spam. Returns a structured
-// result so callers (and tests) can see *why* something was suppressed.
+// Single gate: if notifications are enabled globally, fire. No focus gate, no
+// debounce, no per-event toggle, no per-session mute. The user wants to know
+// whenever a session needs them — that's the whole point of an OS toast.
 export async function dispatchNotification(input: DispatchInput): Promise<DispatchResult> {
   const api = window.ccsm;
   if (!api) return { dispatched: false, reason: 'no-api' };
 
-  const state = useStore.getState();
-  const settings = state.notificationSettings;
+  const settings = useStore.getState().notificationSettings;
   if (!settings.enabled) return { dispatched: false, reason: 'global-disabled' };
-
-  const eventEnabled =
-    (input.eventType === 'permission' && settings.permission) ||
-    (input.eventType === 'question' && settings.question) ||
-    (input.eventType === 'turn_done' && settings.turnDone);
-  if (!eventEnabled) return { dispatched: false, reason: 'event-disabled' };
-
-  const session = state.sessions.find((s) => s.id === input.sessionId);
-  if (session?.notificationsMuted) {
-    return { dispatched: false, reason: 'session-muted' };
-  }
-
-  // Suppress when the user is already looking at this exact session — they
-  // will see the in-app affordance, no need to ping the OS too.
-  const focused = env.hasFocus();
-  const isActive = state.activeId === input.sessionId;
-  if (focused && isActive) {
-    return { dispatched: false, reason: 'focused-active' };
-  }
-
-  const key = cacheKey(input.sessionId, input.eventType);
-  const last = lastFiredAt.get(key) ?? 0;
-  const now = env.now();
-  if (now - last < DEBOUNCE_MS) {
-    return { dispatched: false, reason: 'debounced' };
-  }
-  lastFiredAt.set(key, now);
 
   await api.notify({
     sessionId: input.sessionId,


### PR DESCRIPTION
## Summary
W1 of notification simplification.
- Strip debounce, focus gate, per-event toggle, per-session mute from dispatch
- turn_done fires unconditionally (no 15s threshold, no focus suppression)
- Reshape extras to `{toastId, sessionName, groupName, eventType}` for all 3 events
- Add groupName to permission/question (was only in turn_done)
- Title=`{group} / {session}`, body via i18n key (`permissionBody` / `questionBody` / `turnDoneBody`)
- Add the three new i18n keys in en + zh

## Notes
- Settings type narrowing to `{enabled, sound}` lands in W2; this PR only stops READING the removed fields (`permission`, `question`, `turnDone`) and the removed `notificationsMuted` per-session flag.
- `scheduleQuestionRetry` import was already absent in lifecycle.ts; the file itself is deleted by W4.
- Test failures from removed extras fields + removed `resetDispatchState`/`setDispatchEnv` are expected — W5 rewrites tests after all 4 PRs land. 9 cases in `tests/notifications-dispatch.test.ts` currently fail.

## Test plan
- [x] typecheck pass
- [x] lint pass on changed files (pre-existing 41 errors in dogfood-logs/verification/electron unchanged)
- [ ] W5 e2e suite (after merge of W1-W4)