### PR TITLE
notif: settings UI + store 砍到 2 toggle (W2)

### DIFF
--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -358,141 +358,28 @@ function Segmented<T extends string>({
 function NotificationsPane() {
   const settings = useStore((s) => s.notificationSettings);
   const setNotificationSettings = useStore((s) => s.setNotificationSettings);
-  const activeId = useStore((s) => s.activeId);
-  const [testStatus, setTestStatus] = useState<string | null>(null);
-  const [moduleStatus, setModuleStatus] = useState<
-    { available: boolean; error: string | null } | null
-  >(null);
   const { t } = useTranslation('settings');
-
-  useEffect(() => {
-    let cancelled = false;
-    const api = window.ccsm;
-    if (!api?.notifyAvailability) return;
-    api.notifyAvailability().then((res) => {
-      if (!cancelled) setModuleStatus(res);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const Toggle = ({
-    checked,
-    onChange,
-    disabled,
-    ariaLabel
-  }: {
-    checked: boolean;
-    onChange: (v: boolean) => void;
-    disabled?: boolean;
-    ariaLabel?: string;
-  }) => (
-    <Switch
-      checked={checked}
-      disabled={disabled}
-      aria-label={ariaLabel}
-      onCheckedChange={onChange}
-    />
-  );
-
-  const onTest = async () => {
-    const api = window.ccsm;
-    if (!api) {
-      setTestStatus(t('notifications.testIpcUnavailable'));
-      setTimeout(() => setTestStatus(null), 2000);
-      return;
-    }
-    const ok = await api.notify({
-      sessionId: activeId,
-      title: t('notifications.testTitle'),
-      body: t('notifications.testBody'),
-      eventType: 'test',
-      silent: !settings.sound
-    });
-    setTestStatus(ok ? t('notifications.testSent') : t('notifications.testFailed'));
-    setTimeout(() => setTestStatus(null), 2500);
-  };
-
-  const disableChildren = !settings.enabled;
 
   return (
     <>
       <div className="text-meta text-fg-tertiary mb-4">
         {t('notifications.intro')}
       </div>
-      <div
-        data-testid="notifications-module-status"
-        data-available={
-          moduleStatus === null ? 'unknown' : moduleStatus.available ? 'true' : 'false'
-        }
-        className={cn(
-          'text-meta mb-4 rounded-md border px-3 py-2',
-          moduleStatus === null && 'border-border-subtle text-fg-tertiary',
-          moduleStatus?.available && 'border-border-subtle text-fg-secondary',
-          moduleStatus && !moduleStatus.available &&
-            'border-amber-500/40 bg-amber-500/5 text-fg-secondary'
-        )}
-      >
-        {moduleStatus === null
-          ? t('notifications.moduleChecking')
-          : moduleStatus.available
-            ? t('notifications.moduleAvailable')
-            : t('notifications.moduleUnavailable')}
-      </div>
       <Field label={t('notifications.enable')}>
-        <Toggle
+        <Switch
           checked={settings.enabled}
-          onChange={(v) => setNotificationSettings({ enabled: v })}
-          ariaLabel={t('notifications.enable')}
-        />
-      </Field>
-      <Field label={t('notifications.permission')} hint={t('notifications.permissionHint')}>
-        <Toggle
-          checked={settings.permission}
-          disabled={disableChildren}
-          onChange={(v) => setNotificationSettings({ permission: v })}
-          ariaLabel={t('notifications.permission')}
-        />
-      </Field>
-      <Field label={t('notifications.question')} hint={t('notifications.questionHint')}>
-        <Toggle
-          checked={settings.question}
-          disabled={disableChildren}
-          onChange={(v) => setNotificationSettings({ question: v })}
-          ariaLabel={t('notifications.question')}
-        />
-      </Field>
-      <Field label={t('notifications.turnDone')} hint={t('notifications.turnDoneHint')}>
-        <Toggle
-          checked={settings.turnDone}
-          disabled={disableChildren}
-          onChange={(v) => setNotificationSettings({ turnDone: v })}
-          ariaLabel={t('notifications.turnDone')}
+          aria-label={t('notifications.enable')}
+          onCheckedChange={(v) => setNotificationSettings({ enabled: v })}
         />
       </Field>
       <Field label={t('notifications.sound')} hint={t('notifications.soundHint')}>
-        <Toggle
+        <Switch
           checked={settings.sound}
-          disabled={disableChildren}
-          onChange={(v) => setNotificationSettings({ sound: v })}
-          ariaLabel={t('notifications.sound')}
+          disabled={!settings.enabled}
+          aria-label={t('notifications.sound')}
+          onCheckedChange={(v) => setNotificationSettings({ sound: v })}
         />
       </Field>
-      <div className="flex items-center gap-3">
-        <Button variant="secondary" size="md" onClick={onTest} disabled={disableChildren}>
-          {t('notifications.testButton')}
-        </Button>
-        <span
-          role="status"
-          aria-live="polite"
-          aria-atomic="true"
-          data-testid="notifications-test-status"
-          className="text-meta text-fg-secondary"
-        >
-          {testStatus ?? ''}
-        </span>
-      </div>
       <div className="mt-6 pt-5 border-t border-border-subtle">
         <CrashReportingField />
       </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -5,8 +5,7 @@ import {
   Download,
   Plus,
   Search,
-  Settings,
-  BellOff
+  Settings
 } from 'lucide-react';
 import {
   DndContext,
@@ -319,7 +318,6 @@ function SessionRow({ session, active, selected, onSelect, normalGroups }: { ses
   const restoreSession = useStore((s) => s.restoreSession);
   const moveSession = useStore((s) => s.moveSession);
   const createGroup = useStore((s) => s.createGroup);
-  const setSessionNotificationsMuted = useStore((s) => s.setSessionNotificationsMuted);
   const toast = useToast();
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: session.id,
@@ -443,13 +441,6 @@ function SessionRow({ session, active, selected, onSelect, normalGroups }: { ses
               </>
             )}
           </span>
-          {session.notificationsMuted && (
-            <BellOff
-              size={12}
-              className="stroke-[1.5] text-fg-tertiary shrink-0"
-              aria-label={t('sidebar.notificationsMutedAria')}
-            />
-          )}
           {active && (
             <span className="sidebar-rail-cell sidebar-rail-cell--nested shrink-0">
               <span
@@ -462,13 +453,6 @@ function SessionRow({ session, active, selected, onSelect, normalGroups }: { ses
       </ContextMenuTrigger>
       <ContextMenuContent>
         <ContextMenuItem onSelect={() => setRenaming(true)}>{t('common.rename')}</ContextMenuItem>
-        <ContextMenuItem
-          onSelect={() =>
-            setSessionNotificationsMuted(session.id, !session.notificationsMuted)
-          }
-        >
-          {session.notificationsMuted ? t('sidebar.unmuteNotifications') : t('sidebar.muteNotifications')}
-        </ContextMenuItem>
         <ContextMenuSub>
           <ContextMenuSubTrigger>{t('sidebar.moveToGroup')}</ContextMenuSubTrigger>
           <ContextMenuSubContent>

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -204,11 +204,8 @@ const en = {
     importAriaShort: 'Import session',
     settingsTooltip: 'Settings  ⌘,',
     settingsAria: 'Settings',
-    notificationsMutedAria: 'Notifications muted',
     cwdMissingTooltip:
       'Working directory no longer exists: {{cwd}}. Open this session and repick the folder via the cwd button in the status bar.',
-    muteNotifications: 'Mute notifications',
-    unmuteNotifications: 'Unmute notifications',
     resizerAriaLabel: 'Resize sidebar',
     resizerTooltip: 'Drag to resize · double-click to reset ({{default}}px)'
   },
@@ -266,25 +263,8 @@ const en = {
       intro:
         'OS-level toasts when a session needs your attention. Suppressed when the window is focused on that same session, and debounced per session per event type so a chatty agent cannot spam you.',
       enable: 'Enable notifications',
-      permission: 'Permission prompts',
-      permissionHint: 'When a tool call is waiting on your approval.',
-      question: 'Questions',
-      questionHint: 'When the agent uses AskUserQuestion to ask you something.',
-      turnDone: 'Turn done',
-      turnDoneHint:
-        'Only fires for long (>15s), errored, or unfocused turns - routine fast turns are skipped.',
       sound: 'Sound',
-      soundHint: 'Play the OS default notification sound.',
-      testButton: 'Test notification',
-      testTitle: 'CCSM test notification',
-      testBody: 'If you can read this, OS notifications are working.',
-      testIpcUnavailable: 'IPC unavailable.',
-      testSent: 'Sent.',
-      testFailed: 'Failed - OS notifications unavailable.',
-      moduleAvailable: 'Rich Windows toasts are available.',
-      moduleUnavailable:
-        'Rich Windows toasts are unavailable on this machine — the optional native notification module did not install. CCSM will fall back to in-app banners and standard system notifications.',
-      moduleChecking: 'Checking notification module…'
+      soundHint: 'Play the OS default notification sound.'
     },
     connection: {
       intro:

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -186,10 +186,7 @@ const zh: EnCatalog = {
     importAriaShort: '导入会话',
     settingsTooltip: '设置  ⌘,',
     settingsAria: '设置',
-    notificationsMutedAria: '通知已静音',
     cwdMissingTooltip: '工作目录已不存在: {{cwd}}。打开此会话后，用状态栏的 cwd 按钮重新选择目录。',
-    muteNotifications: '静音通知',
-    unmuteNotifications: '取消静音',
     resizerAriaLabel: '调整侧边栏宽度',
     resizerTooltip: '拖动调整宽度 · 双击重置（{{default}}px）'
   },
@@ -246,24 +243,8 @@ const zh: EnCatalog = {
       intro:
         '当某个会话需要你处理时，弹出系统级通知。如果窗口正聚焦在该会话上会自动抑制；同一事件类型按会话做了去抖，避免话痨 agent 刷屏。',
       enable: '启用通知',
-      permission: '权限请求',
-      permissionHint: '当某个工具调用在等待你的批准时。',
-      question: '提问',
-      questionHint: 'agent 通过 AskUserQuestion 提问时。',
-      turnDone: '本轮完成',
-      turnDoneHint: '只在长时间（>15s）、出错或非聚焦的轮次触发，常规快速轮次会被跳过。',
       sound: '声音',
-      soundHint: '播放系统默认通知声。',
-      testButton: '发送测试通知',
-      testTitle: 'CCSM 测试通知',
-      testBody: '能看到这条消息说明系统通知正常工作。',
-      testIpcUnavailable: 'IPC 不可用。',
-      testSent: '已发送。',
-      testFailed: '失败 — 系统通知不可用。',
-      moduleAvailable: '富文本 Windows 通知可用。',
-      moduleUnavailable:
-        '当前环境无法使用富文本 Windows 通知 — 可选的原生通知模块未安装。CCSM 会降级到应用内横幅和标准系统通知。',
-      moduleChecking: '正在检查通知模块…'
+      soundHint: '播放系统默认通知声。'
     },
     connection: {
       intro:

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -118,17 +118,11 @@ export type { ConnectionInfo };
 // the rest of app state.
 export interface NotificationSettings {
   enabled: boolean;
-  permission: boolean;
-  question: boolean;
-  turnDone: boolean;
   sound: boolean;
 }
 
 export const DEFAULT_NOTIFICATION_SETTINGS: NotificationSettings = {
   enabled: true,
-  permission: true,
-  question: true,
-  turnDone: true,
   sound: true
 };
 
@@ -485,7 +479,6 @@ type Actions = {
   resetSidebarWidth: () => void;
   markTutorialSeen: () => void;
   setNotificationSettings: (patch: Partial<NotificationSettings>) => void;
-  setSessionNotificationsMuted: (sessionId: string, muted: boolean) => void;
 
   createGroup: (name?: string) => string;
   renameGroup: (id: string, name: string) => void;
@@ -708,6 +701,24 @@ export function migratePermission(raw: unknown): PermissionMode {
     default:
       return 'default';
   }
+}
+
+/**
+ * Coerce a persisted notification-settings blob into the current
+ * `{ enabled, sound }` shape. The pre-simplification shape carried per-event
+ * toggles (`permission` / `question` / `turnDone`) plus a global `enabled`
+ * and `sound`. Strip any unknown keys, fill missing fields with defaults
+ * (true) so a partial blob doesn't silently mute the user.
+ */
+export function migrateNotificationSettings(
+  raw: unknown
+): NotificationSettings {
+  if (!raw || typeof raw !== 'object') return { ...DEFAULT_NOTIFICATION_SETTINGS };
+  const r = raw as Record<string, unknown>;
+  return {
+    enabled: typeof r.enabled === 'boolean' ? r.enabled : true,
+    sound: typeof r.sound === 'boolean' ? r.sound : true
+  };
 }
 
 /**
@@ -1462,13 +1473,6 @@ export const useStore = create<State & Actions>((set, get) => ({
 
   setNotificationSettings: (patch) =>
     set((s) => ({ notificationSettings: { ...s.notificationSettings, ...patch } })),
-
-  setSessionNotificationsMuted: (sessionId, muted) =>
-    set((s) => ({
-      sessions: s.sessions.map((x) =>
-        x.id === sessionId ? { ...x, notificationsMuted: muted } : x
-      )
-    })),
 
   createGroup: (name) => {
     const id = nextId('g');
@@ -2543,10 +2547,7 @@ export async function hydrateStore(): Promise<void> {
         : legacyFontSizeToPx(persisted.fontSize ?? 'md'),
       recentProjects: persisted.recentProjects ?? [],
       tutorialSeen: persisted.tutorialSeen ?? false,
-      notificationSettings: {
-        ...DEFAULT_NOTIFICATION_SETTINGS,
-        ...(persisted.notificationSettings ?? {})
-      },
+      notificationSettings: migrateNotificationSettings(persisted.notificationSettings),
       globalThinkingDefault:
         persisted.globalThinkingDefault === 'default_on' ? 'default_on' : 'off',
       thinkingLevelBySession: sanitizeThinkingLevelMap(persisted.thinkingLevelBySession)

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,9 +15,6 @@ export interface Session {
   // Set when the session was imported from a Claude Code CLI transcript.
   // Passed to agentStart on first send so the SDK resumes the same thread.
   resumeSessionId?: string;
-  // Per-session OS notification mute. When true, dispatch suppresses all
-  // notification events for this session regardless of global settings.
-  notificationsMuted?: boolean;
   // Marks a session whose persisted `cwd` no longer exists on disk (e.g.
   // a directory that was deleted between app runs — common after the
   // worktree feature was reverted). Set by `hydrateStore` via a best-effort


### PR DESCRIPTION
## Summary
W2 of notification simplification.
- NotificationSettings reduced to `{enabled, sound}` with auto-migration of old persisted shape (`migrateNotificationSettings` in `src/stores/store.ts`)
- Per-session mute removed (`Session.notificationsMuted`, sidebar context menu, `BellOff` icon, `setSessionNotificationsMuted` action)
- SettingsDialog notifications section: 2 toggles only — dropped per-event toggles, test button, module-availability indicator
- i18n: removed `sidebar.muteNotifications/unmuteNotifications/notificationsMutedAria` and `settings.notifications.{permission,permissionHint,question,questionHint,turnDone,turnDoneHint,testButton,testTitle,testBody,testIpcUnavailable,testSent,testFailed,moduleAvailable,moduleUnavailable,moduleChecking}` in both en.ts and zh.ts

## Migration
Old persisted shape `{enabled, permission, question, turnDone, sound}` (or any partial blob) hydrates through `migrateNotificationSettings` → `{enabled, sound}`. Missing booleans default to `true` so a corrupted/partial blob doesn't silently mute the user. Persist schema version stays at 1 — extra keys on disk are simply ignored on next read; first write rewrites the snapshot in the new shape.

## Cross-worker dependency
Typecheck currently fails on `src/notifications/dispatch.ts` (W1's file) — it still references the removed `settings.permission/question/turnDone` and `session.notificationsMuted`. W1's PR removes those readers. Both PRs must merge together (or W1 first) for `working` to compile.

## Test plan
- [ ] typecheck pass (after W1 lands)
- [ ] lint pass — no new lint issues introduced by W2 (verified locally; pre-existing unused-disable warning at store.ts:1185 is not from this PR)
- [ ] W5 e2e suite (after W1-W4 land)