### PR TITLE
test(e2e): fix titlebar case after #347 sidebar 8px split

### DIFF
--- a/scripts/harness-ui.mjs
+++ b/scripts/harness-ui.mjs
@@ -1418,10 +1418,12 @@ async function caseTitlebar({ app, win, log }) {
   if (dragRegions.length < 2) {
     throw new Error(`expected >=2 top drag regions, got ${dragRegions.length}: ${JSON.stringify(dragRegions)}`);
   }
-  const EXPECTED_STRIP = 32;
+  // After PR #347: sidebar drag region is 8px (macOS traffic-lights spacer removed),
+  // right pane stays 32px to host WindowControls.
   for (const r of dragRegions) {
-    if (Math.abs(r.height - EXPECTED_STRIP) > 2) {
-      throw new Error(`drag region height expected ~${EXPECTED_STRIP}, got ${r.height}. all=${JSON.stringify(dragRegions)}`);
+    const expected = r.left === 0 ? 8 : 32;
+    if (Math.abs(r.height - expected) > 2) {
+      throw new Error(`drag region height expected ~${expected} (left=${r.left}), got ${r.height}. all=${JSON.stringify(dragRegions)}`);
     }
   }
 


### PR DESCRIPTION
## Summary
PR #347 reduced the sidebar DragRegion from 32px to 8px (Windows traffic-lights spacer removed), while the right pane stays 32px to host `WindowControls`. The `titlebar` harness case still asserted `EXPECTED_STRIP=32` for **all** top drag regions, so it regressed.

This patch makes the assertion per-region: `left === 0` (sidebar) expects 8px; otherwise (right pane) 32px.

## Changes
- `scripts/harness-ui.mjs` `caseTitlebar`: replace flat `EXPECTED_STRIP=32` loop with per-region expected height keyed off `r.left`.

## Verification
- Forward: `node scripts/harness-ui.mjs --only=titlebar` -> PASS (`platform=win32 dragRegions=2`, observed `[{height:8,left:0},{height:32,left:418}]`).
- Reverse: temporarily setting `expected=32` for all -> FAIL with `expected ~32 (left=0), got 8` -> restored. Confirms the case is real and not a tautology.
- `npx tsc --noEmit` clean.

## Test plan
- [x] Forward run passes
- [x] Reverse run fails (confirms assertion is meaningful)
- [x] Typecheck clean

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>