### PR TITLE
fix(perm): focus Reject in layout phase to win autoFocus race

### DIFF
--- a/src/components/PermissionPromptBlock.tsx
+++ b/src/components/PermissionPromptBlock.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
 import { Loader2, ShieldAlert } from 'lucide-react';
 import { Button } from './ui/Button';
@@ -136,9 +136,21 @@ export function PermissionPromptBlock({
   //    on it after they finish typing).
   // External text entries (rename input, dialog field, IME composition,
   // settings textarea) are always respected.
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!autoFocus) return;
-    const raf = requestAnimationFrame(() => {
+    // Focus synchronously in the layout phase (before paint) so the button
+    // is focused by the time anything observes activeElement on first frame.
+    // Original implementation used a single rAF, which created a race: the
+    // observer (test harness, screen-readers, anything querying focus on
+    // mount) could read activeElement BEFORE the rAF fired, seeing body.
+    // We still re-check on the next two frames to defend against any later
+    // focus-claim (e.g. InputBar's own mount-time textarea.focus()) winning
+    // a subsequent tick — capped so we never loop.
+    let raf = 0;
+    let cancelled = false;
+    const MAX_RETRIES = 2;
+    const tryFocus = () => {
+      if (cancelled) return false;
       const active = document.activeElement;
       if (active instanceof HTMLElement && active !== document.body && !rootRef.current?.contains(active)) {
         const isTextEntry =
@@ -149,18 +161,35 @@ export function PermissionPromptBlock({
           active.getAttribute('role') === 'textbox';
         if (isTextEntry) {
           const isComposer = active.hasAttribute('data-input-bar');
-          if (!isComposer) return;
+          if (!isComposer) return false;
           // Composer-specific: only steal when it's empty.
           const value =
             active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement
               ? active.value
               : active.textContent ?? '';
-          if (value.trim().length > 0) return;
+          if (value.trim().length > 0) return false;
         }
       }
       rejectRef.current?.focus({ preventScroll: true });
-    });
-    return () => cancelAnimationFrame(raf);
+      return document.activeElement === rejectRef.current;
+    };
+    const succeeded = tryFocus();
+    if (!succeeded) {
+      // Schedule retries across the next 2 frames in case rejectRef wasn't
+      // attachable yet, or a same-tick focus claim landed after us.
+      let attempt = 0;
+      const next = () => {
+        if (cancelled) return;
+        if (document.activeElement === rejectRef.current) return;
+        if (tryFocus()) return;
+        if (++attempt < MAX_RETRIES) raf = requestAnimationFrame(next);
+      };
+      raf = requestAnimationFrame(next);
+    }
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(raf);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
## Root cause

`PermissionPromptBlock.tsx:139-165` used `useEffect` + a single `requestAnimationFrame` to focus the Reject button on mount. Two failure modes against this:

1. **Observer pre-empts rAF.** Anything reading `document.activeElement` on the first frame after the prompt becomes visible (the harness probe, a screen reader, an early keystroke routed through React) sees `body` because the rAF callback hasn't fired yet.
2. **Same-tick focus claim races.** `InputBar.tsx:374-392` runs its own focus-claim `useEffect` (textareaRef.focus()) on session-mount/nonce-change. If that effect commits in the same tick as ours, whichever rAF lands second wins. With both using `requestAnimationFrame`, ordering is non-deterministic.

Diagnostic: the harness's `activeElement` snapshot reported `BODY` (not the textarea) on failures, confirming the observer-pre-empts-rAF path is the dominant one in this probe.

## Fix

- Move autoFocus from `useEffect` to `useLayoutEffect` and call `rejectRef.current?.focus()` **synchronously** in the layout phase (before paint), so the button is focused by the time anything observes activeElement on first frame.
- Keep two `requestAnimationFrame` retries as defence-in-depth against later same-tick focus claims (e.g. InputBar's effect landing after layout). Cap at 2 retries so we never loop.

The composer-empty / external-text-entry guards from the original implementation are preserved unchanged.

## Verification

- **Forward (with fix)**: `node scripts/harness-perm.mjs --only=permission-prompt` x10 → **10/10 PASS**.
- **Reverse (stash fix, rebuild)**: same probe x5 → **3/5 PASS** (60%) — confirms the flake reproduces at baseline and the fix is what closes it.
- `npx vitest run tests/permission-prompt-block.test.tsx` → 33/33 PASS.

## Flake history

`harness-perm:permission-prompt` has flaked since at least pre-#343 (regression diagnostic worker reported 1/3 at pre-#343, 2/5 at pre-#342 and origin/working). Local repro at origin/working before this fix: **3/15 PASS (~20%)**. Pre-existing, not regression-introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)