### PR TITLE
fix(perm): always pass allowDangerouslySkipPermissions for mid-session toggle

### DIFF
--- a/electron/agent-sdk/__tests__/sessions.test.ts
+++ b/electron/agent-sdk/__tests__/sessions.test.ts
@@ -202,6 +202,67 @@ describe('agent-sdk/SdkSessionRunner', () => {
     runner.close();
   });
 
+  it('always passes allowDangerouslySkipPermissions: true regardless of initial mode', async () => {
+    // Regression: SDK gate on switching INTO bypassPermissions mid-session
+    // requires the launch flag. ccsm previously only set the flag when the
+    // initial mode was bypass, so default→bypass toggles via the chip
+    // failed with a vague "Agent unresponsive" toast. The flag is harmless
+    // when the active mode isn't bypass (SDK only consults it on mode
+    // transitions into bypass), so we set it unconditionally.
+    for (const mode of ['default', 'plan', 'acceptEdits', 'bypassPermissions'] as const) {
+      const local = makeFakeSdk();
+      __setSdkModuleForTests(
+        local.sdk as unknown as typeof import('@anthropic-ai/claude-agent-sdk'),
+      );
+      const runner = new SdkSessionRunner('s6a-' + mode, noop, noop, noop, noop);
+      await runner.start({ ...baseStart, permissionMode: mode });
+      const opts = local.getOptions()?.options ?? {};
+      expect(opts.allowDangerouslySkipPermissions).toBe(true);
+      runner.close();
+    }
+  });
+
+  it('setPermissionMode() rethrows when SDK rejects with "was not launched" message', async () => {
+    // Hard SDK rejections (e.g. capability gates, "was not launched with
+    // --dangerously-skip-permissions") must propagate so main.ts can
+    // surface { ok:false, error } to the renderer toast. The launch-flag
+    // case is now defensive — improvement #1 prevents it from triggering
+    // in practice — but other SDK rejection wordings reuse this path.
+    const diags: Array<{ code: string; message: string }> = [];
+    const runner = new SdkSessionRunner(
+      's6b',
+      noop,
+      noop,
+      noop,
+      (d) => diags.push(d as { code: string; message: string }),
+    );
+    await runner.start(baseStart);
+    fake.setPermissionMode.mockRejectedValueOnce(
+      new Error('session was not launched with --dangerously-skip-permissions'),
+    );
+    await expect(runner.setPermissionMode('bypassPermissions')).rejects.toThrow(/was not launched/);
+    expect(diags).toHaveLength(0);
+    runner.close();
+  });
+
+  it('setPermissionMode() emits diagnostic (no throw) on transient timeouts', async () => {
+    const diags: Array<{ code: string; message: string }> = [];
+    const runner = new SdkSessionRunner(
+      's6c',
+      noop,
+      noop,
+      noop,
+      (d) => diags.push(d as { code: string; message: string }),
+    );
+    await runner.start(baseStart);
+    fake.setPermissionMode.mockRejectedValueOnce(new Error('timeout waiting for ack'));
+    await runner.setPermissionMode('plan');
+    expect(diags).toHaveLength(1);
+    expect(diags[0].code).toBe('set_permission_mode_timeout');
+    expect(diags[0].message).not.toMatch(/Agent unresponsive/);
+    runner.close();
+  });
+
   it('setModel() delegates only if model is provided', async () => {
     const runner = new SdkSessionRunner('s7', noop, noop, noop, noop);
     await runner.start(baseStart);

--- a/electron/agent-sdk/sessions.ts
+++ b/electron/agent-sdk/sessions.ts
@@ -388,7 +388,15 @@ export class SdkSessionRunner {
         }),
         model: opts.model,
         permissionMode: sdkPermissionMode,
-        allowDangerouslySkipPermissions: sdkPermissionMode === 'bypassPermissions' ? true : undefined,
+        // Always pass allowDangerouslySkipPermissions: true so users can
+        // switch to bypassPermissions mid-session via the chip without
+        // restarting. The SDK gate is one-way: the launch flag is only
+        // required to ENTER bypassPermissions; switching out of bypass
+        // needs no flag. Without this, sessions launched in `default`
+        // mode hit "was not launched with --dangerously-skip-permissions"
+        // when the user clicks the bypass chip, surfacing as a vague
+        // "Agent unresponsive" toast.
+        allowDangerouslySkipPermissions: true,
         resume: opts.resumeSessionId,
         sessionId: presetSessionId,
         pathToClaudeCodeExecutable: binaryPath,
@@ -674,19 +682,20 @@ export class SdkSessionRunner {
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       // Distinguish hard SDK rejection (unsupported mode for this
-      // account/model — typically `auto` research-preview gating) from a
+      // account/model — typically `auto` research-preview gating, or
+      // `bypassPermissions` when the launch flag was withheld) from a
       // transient timeout. Hard rejections are re-thrown so manager.ts /
       // main.ts can surface `{ ok: false, error }` to the renderer, which
       // falls back to 'default' with a toast. Timeouts stay as
       // diagnostics — the user already sees session-level "unresponsive"
       // affordances and we don't want to flap the picker on a slow turn.
-      if (/unsupported|not supported|requires|capability|gated|forbidden|denied/i.test(msg)) {
+      if (/unsupported|not supported|requires|capability|gated|forbidden|denied|was not launched|dangerously-skip-permissions/i.test(msg)) {
         throw err;
       }
       this.onDiagnostic({
         level: 'warn',
         code: 'set_permission_mode_timeout',
-        message: `Agent unresponsive to permission-mode change (${msg}).`,
+        message: `Permission mode change timed out (${msg}).`,
       });
     }
   }

--- a/scripts/harness-perm.mjs
+++ b/scripts/harness-perm.mjs
@@ -1474,6 +1474,77 @@ async function caseJsonlFilenameMatchesSession({ win, log }) {
   }
 }
 
+// ---------- bypass-mid-session-toggle ----------
+// Regression for the "Agent unresponsive" toast users hit when clicking the
+// bypassPermissions chip on a session launched in default mode. Root cause
+// (eval doc bypass-perm-eval-2026-04-26.md): the bundled CLI's
+// setPermissionMode handler refuses transitions INTO bypassPermissions
+// unless the session was started with --dangerously-skip-permissions. ccsm
+// previously only sent that flag when the INITIAL mode was bypass, so any
+// runtime upgrade was silently rejected and surfaced as a vague timeout
+// diagnostic. Fix: always pass allowDangerouslySkipPermissions:true at
+// launch (sessions.ts:391); the SDK gate is one-way so this is harmless
+// when the active mode isn't bypass.
+//
+// Forward verification: start a real SDK session in default mode, toggle
+// to bypass via IPC, assert ok:true. Toggle back to default to confirm
+// downgrade still works. Reverse-verified manually by reverting the
+// conditional flag — the case fails with `{ ok:false, error:'... was not
+// launched ...' }` from the rethrown SDK rejection.
+async function caseBypassMidSessionToggle({ win, log }) {
+  const TS = Date.now();
+  const SID = `b3c0d000-0000-4000-8000-${String(TS).padStart(12, '0').slice(-12)}`;
+  const PROBE_TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'ccsm-harness-bypass-mid-'));
+
+  try {
+    await win.evaluate(({ sid, cwd }) => {
+      window.__ccsmStore.setState({
+        groups: [{ id: 'g1', name: 'G1', collapsed: false, kind: 'normal' }],
+        sessions: [{ id: sid, name: 'bypass-mid', state: 'idle', cwd, model: 'claude-sonnet-4', groupId: 'g1', agentType: 'claude-code' }],
+        activeId: sid,
+        messagesBySession: { [sid]: [] },
+        startedSessions: {},
+        runningSessions: {},
+      });
+    }, { sid: SID, cwd: PROBE_TMP });
+
+    // 1. Start in default mode — the failure case before the fix.
+    const startRes = await win.evaluate(async ({ sid, cwd }) =>
+      await window.ccsm.agentStart(sid, { cwd, permissionMode: 'default', sessionId: sid }),
+      { sid: SID, cwd: PROBE_TMP });
+    if (!startRes || startRes.ok !== true) {
+      throw new Error(`agentStart(default) failed: ${JSON.stringify(startRes)}`);
+    }
+    log('session started in default mode');
+
+    // Brief settle so the SDK init handshake completes before the runtime
+    // mode change (matches what a real user toggling the chip looks like).
+    await win.waitForTimeout(500);
+
+    // 2. Toggle to bypassPermissions — pre-fix this rejected with
+    //    "session was not launched with --dangerously-skip-permissions".
+    const upRes = await win.evaluate(async (sid) =>
+      await window.ccsm.agentSetPermissionMode(sid, 'bypassPermissions'), SID);
+    if (!upRes || upRes.ok !== true) {
+      throw new Error(`agentSetPermissionMode(bypass) expected ok:true, got ${JSON.stringify(upRes)}`);
+    }
+    log('default → bypass accepted');
+
+    // 3. Toggle back to default — should always succeed (downgrade is
+    //    ungated by the SDK).
+    const downRes = await win.evaluate(async (sid) =>
+      await window.ccsm.agentSetPermissionMode(sid, 'default'), SID);
+    if (!downRes || downRes.ok !== true) {
+      throw new Error(`agentSetPermissionMode(default) expected ok:true, got ${JSON.stringify(downRes)}`);
+    }
+    log('bypass → default accepted');
+
+    await win.evaluate(async (sid) => await window.ccsm.agentClose(sid), SID);
+  } finally {
+    try { fs.rmSync(PROBE_TMP, { recursive: true, force: true }); } catch {}
+  }
+}
+
 // ---------- askuserquestion-no-dup-and-resolves ----------
 // Was: probe-e2e-askuserquestion-no-dup-and-resolves.mjs.
 // preMain installs ipcMain stubs to capture resolvePermission + send calls
@@ -1890,6 +1961,15 @@ await runHarness({
       userDataDir: 'fresh',
       requiresClaudeBin: true,
       run: caseJsonlFilenameMatchesSession,
+    },
+    // bypass-mid-session-toggle: regression for "Agent unresponsive" toast
+    // when toggling default→bypass via the chip. Real session, real SDK,
+    // both directions verified.
+    {
+      id: 'bypass-mid-session-toggle',
+      userDataDir: 'fresh',
+      requiresClaudeBin: true,
+      run: caseBypassMidSessionToggle,
     },
     // env-passthrough: ANTHROPIC_API_KEY/AUTH_TOKEN must flow through to
     // claude.exe so the CLI authenticates without an isolated CLAUDE_CONFIG_DIR


### PR DESCRIPTION
## Root cause

The bundled CLI's runtime `setPermissionMode` handler refuses transitions **into** `bypassPermissions` unless the session was started with `--dangerously-skip-permissions`. The SDK's `allowDangerouslySkipPermissions: true` option is what flips that flag.

ccsm only passed the option when the **initial** mode was `bypassPermissions`. A user starting in `default` and then clicking the bypass chip hit:
> Cannot set permission mode to bypassPermissions because the session was not launched with --dangerously-skip-permissions

…which our error path then swallowed into the misleading **"Agent unresponsive to permission-mode change"** toast (the regex didn't match this rejection, so it fell through to the timeout diagnostic).

The SDK gate is one-way: the launch flag is only required to **enter** bypass; switching **out** of bypass works regardless. So unconditionally setting the flag at launch is harmless.

Eval: `docs/bypass-perm-eval-2026-04-26.md` (kept on the `investigate-bypass-perm` branch in pool-2 worktree, not committed here per instructions). Implements **Path A + D**: always-on launch flag, no first-time modal, no restart flow.

## Changes

**`electron/agent-sdk/sessions.ts:391`** — `allowDangerouslySkipPermissions: true` unconditionally (was: only when `sdkPermissionMode === 'bypassPermissions'`). Inline comment explains why.

**`electron/agent-sdk/sessions.ts:683`** — extend hard-rejection regex with `was not launched|dangerously-skip-permissions` so the real SDK rejection wording propagates as `{ ok:false, error }` to the renderer toast (defensive: the unconditional flag prevents this from triggering in practice, but other future SDK rejection wordings reuse the same path).

**`electron/agent-sdk/sessions.ts:689`** — diagnostic message changed from `Agent unresponsive to permission-mode change (...)` to `Permission mode change timed out (...)` (only fires on real transient timeouts now).

## Tests

**Vitest** (`electron/agent-sdk/__tests__/sessions.test.ts`) — 3 new cases:
- `always passes allowDangerouslySkipPermissions: true regardless of initial mode` — iterates `default | plan | acceptEdits | bypassPermissions`, asserts the option is `true` in every `query()` call.
- `setPermissionMode() rethrows when SDK rejects with "was not launched" message` — asserts the new regex alternative routes through the throw path so main.ts can surface `{ ok:false, error }`.
- `setPermissionMode() emits diagnostic (no throw) on transient timeouts` — asserts the timeout diagnostic still fires (and that the misleading "Agent unresponsive" wording is gone).

All 28 cases in the file pass; full vitest run shows only pre-existing failures unrelated to this change (better-sqlite3 NODE_MODULE_VERSION mismatch, notification suite — confirmed identical on `origin/working` via `git stash`).

**E2E** (`scripts/harness-perm.mjs`) — new case `bypass-mid-session-toggle` (extends harness-perm rather than spawning a new probe per `feedback_e2e_prefer_harness`):
- Starts a real SDK session via `agentStart` in `permissionMode: 'default'` against the system claude binary.
- Calls `agentSetPermissionMode(sid, 'bypassPermissions')` — asserts `{ ok: true }`.
- Calls `agentSetPermissionMode(sid, 'default')` — asserts `{ ok: true }`.

**Forward**: `1 passed, 0 failed`.

**Reverse**: temporarily restored the conditional flag + rebuilt → case fails with the **exact** real SDK message:
> agentSetPermissionMode(bypass) expected ok:true, got {"ok":false,"error":"Cannot set permission mode to bypassPermissions because the session was not launched with --dangerously-skip-permissions"}

This also confirms the regex extension works: pre-fix, that error string was being thrown (not swallowed) only because the regex change is now in place; after restoring the fix, the case passes again.

## Dogfood

Skipped manual screenshot capture — the e2e case exercises real claude.exe + real IPC + real renderer fallback path and reproduces the exact production rejection wording in reverse mode, which is higher-fidelity evidence than a UI screenshot of the now-absent toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)