### PR TITLE
fix(slash): namespaced unknown slash → local toast

### DIFF
--- a/scripts/harness-ui.mjs
+++ b/scripts/harness-ui.mjs
@@ -1081,6 +1081,88 @@ async function caseSlashPickerClaudeConfigDir({ win, log }) {
   log(`picker showed /local-test; suppressed superpowers:brainstorm (env-scoped fake ~/.claude)`);
 }
 
+// ---------- slash-namespaced-unknown-toast ----------
+// Follow-up to PR #346: typing a namespaced-shape unknown slash command
+// (e.g. `/plugin`, `/superpowers:brainstorm`) and pressing Enter must
+// surface a local error toast and NOT append a user message to the
+// transcript (forwarding the raw text to the SDK ends up as plain prose
+// that the model misinterprets — the user-side bug PR #346 paired with
+// the picker filter).
+//
+// Reverse-verification: stash the 'unknown-namespaced' branch in
+// dispatchSlashCommand (or the toast handler in InputBar) → /plugin
+// falls through to the local-echo append path → no toast + a user
+// block appears → case fails.
+async function caseSlashNamespacedUnknownToast({ win, log }) {
+  await win.evaluate(() => {
+    window.__ccsmStore.setState({
+      groups: [{ id: 'g-slash-tn', name: 'G', collapsed: false, kind: 'normal' }],
+      sessions: [{
+        id: 's-slash-tn-1', name: 'slash-tn', state: 'idle', cwd: 'C:/x',
+        model: 'claude-opus-4', groupId: 'g-slash-tn', agentType: 'claude-code'
+      }],
+      activeId: 's-slash-tn-1',
+      messagesBySession: { 's-slash-tn-1': [] },
+      tutorialSeen: true
+    });
+  });
+  await win.waitForTimeout(150);
+
+  const textarea = win.locator('textarea').first();
+  await textarea.waitFor({ state: 'visible', timeout: 5000 });
+  await textarea.click();
+
+  // Two namespaced shapes the dispatcher should bounce locally:
+  //   - `/plugin`              (CLI plugin manager — SDK can't run it)
+  //   - `/superpowers:foo`     (colon-namespaced plugin/skill)
+  const cases = [
+    { input: '/plugin', expectedTitle: 'Unknown command: /plugin' },
+    { input: '/superpowers:foo', expectedTitle: 'Unknown command: /superpowers:foo' }
+  ];
+
+  for (const { input, expectedTitle } of cases) {
+    await textarea.fill(input);
+    await win.waitForTimeout(80);
+    // Picker may be open showing "No matching command" — Esc dismisses it
+    // so the next Enter fires send() instead of committing a picker row.
+    await win.keyboard.press('Escape');
+    await win.waitForTimeout(60);
+    await win.keyboard.press('Enter');
+    await win.waitForTimeout(200);
+
+    // Assert error toast surfaced with the exact title.
+    const toast = win.locator('[data-testid="toast-error"]', { hasText: expectedTitle });
+    await toast.waitFor({ state: 'visible', timeout: 2000 }).catch(() => {
+      throw new Error(`expected error toast titled "${expectedTitle}" for ${input}; not visible`);
+    });
+
+    // Assert NO user message was appended (would mean the slash text fell
+    // through to the regular send path).
+    const userBlockCount = await win.evaluate((sid) => {
+      const blocks = window.__ccsmStore.getState().messagesBySession[sid] ?? [];
+      return blocks.filter((b) => b.kind === 'user').length;
+    }, 's-slash-tn-1');
+    if (userBlockCount !== 0) {
+      throw new Error(
+        `expected 0 user blocks after typing ${input} (toast path); found ${userBlockCount}`
+      );
+    }
+
+    // Composer must be cleared so the user can keep typing.
+    const value = await textarea.inputValue();
+    if (value !== '') {
+      throw new Error(`expected textarea cleared after ${input}; still has "${value}"`);
+    }
+
+    // Dismiss the toast so the next iteration's wait isn't satisfied by a
+    // stale one. Esc dismisses the most recent toast.
+    await win.keyboard.press('Escape');
+    await win.waitForTimeout(60);
+  }
+
+  log(`namespaced unknown slashes (${cases.map((c) => c.input).join(', ')}) bounced locally with toast; no user messages forwarded`);
+}
+
 // ---------- palette-empty ----------
 // CommandPalette empty state (#117): on open, NO results shown until user
 // types. Plus #258 CP3 (no-matches block) and CP4 (kbd hint footer).
@@ -2727,6 +2809,7 @@ await runHarness({
       },
       run: caseSlashPickerClaudeConfigDir,
     },
+    { id: 'slash-namespaced-unknown-toast', run: caseSlashNamespacedUnknownToast },
     { id: 'settings-open', run: caseSettingsOpen },
     { id: 'search-shortcut-f', run: caseSearchShortcutF },
     { id: 'tutorial', run: caseTutorial },

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -17,6 +17,7 @@ import {
   filterSlashCommands,
   loadDynamicCommands,
   nextSectionIndex,
+  parseSlashInvocation,
   type SlashCommand
 } from '../slash-commands/registry';
 import {
@@ -38,6 +39,7 @@ import {
 } from '../lib/attachments';
 import { useTranslation } from '../i18n/useTranslation';
 import { runningPlaceholderForMode } from '../lib/runningPlaceholder';
+import { useToast } from './ui/Toast';
 
 // Per-session text drafts persist across session switches AND across app
 // restarts (see ../stores/drafts). Cleared on send. Image attachments stay
@@ -137,6 +139,7 @@ function hasDraggedFiles(e: DragEvent): boolean {
 
 export function InputBar({ sessionId }: { sessionId: string }) {
   const { t } = useTranslation();
+  const { push: pushToast } = useToast();
   const [value, setValue] = useState(() => getDraft(sessionId));
   const [attachments, setAttachments] = useState<ImageAttachment[]>(
     () => attachmentCache.get(sessionId) ?? []
@@ -667,6 +670,21 @@ export function InputBar({ sessionId }: { sessionId: string }) {
     if (text.startsWith('/') && imgs.length === 0) {
       const outcome = await dispatchSlashCommand(text, allCommands, { sessionId, args: '' });
       if (outcome === 'handled') {
+        update('');
+        return;
+      }
+      if (outcome === 'unknown-namespaced') {
+        // `/x:y` or `/plugin` — looks like a CLI / plugin command but the
+        // SDK transport can't run it. Forwarding would deliver the raw
+        // `/foo` text as a user message, which the model then either
+        // misinterprets or replies "deprecated, use the skill instead"
+        // (the bug PR #346 surfaced from the picker side). Bounce locally.
+        const parsed = parseSlashInvocation(text);
+        const name = parsed?.name ?? text.slice(1).split(/\s/)[0] ?? '';
+        pushToast({
+          kind: 'error',
+          title: t('slashCommands.unknownToast', { name })
+        });
         update('');
         return;
       }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -371,7 +371,8 @@ const en = {
     groupProject: 'Project commands',
     groupPlugin: 'Plugin commands',
     groupSkill: 'Skills',
-    groupAgent: 'Agents'
+    groupAgent: 'Agents',
+    unknownToast: 'Unknown command: /{{name}}'
   },
   mentions: {
     pickerTitle: 'File mentions',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -345,7 +345,8 @@ const zh: EnCatalog = {
     groupProject: '项目 Commands',
     groupPlugin: 'Plugin Commands',
     groupSkill: 'Skills',
-    groupAgent: 'Agents'
+    groupAgent: 'Agents',
+    unknownToast: '未知命令：/{{name}}'
   },
   mentions: {
     pickerTitle: '文件引用',

--- a/src/slash-commands/registry.ts
+++ b/src/slash-commands/registry.ts
@@ -133,16 +133,46 @@ export function findSlashCommand(
   return all.find((c) => c.name === name);
 }
 
-export type DispatchOutcome = 'handled' | 'pass-through' | 'unknown';
+export type DispatchOutcome =
+  | 'handled'
+  | 'pass-through'
+  | 'unknown'
+  | 'unknown-namespaced';
+
+// Names whose shape advertises "this is a CLI / plugin command" but which
+// the SDK transport cannot execute. Two cases:
+//
+//   1. Colon-namespaced (`/superpowers:brainstorm`, `/pua:kpi`) — always a
+//      plugin / skill / agent command discovered on disk. PR #346 already
+//      hides these from the picker, but a user who types one by hand still
+//      needs a clear local rejection instead of having the raw text sent
+//      to the model (which then replies "deprecated, use the skill" or
+//      similar — the bug PR #346 surfaced from the user side).
+//   2. `/plugin` — the CLI's own plugin manager. The SDK doesn't load it;
+//      forwarding "/plugin" to claude.exe via the agent transport ends up
+//      as plain user prose, not a command invocation.
+//
+// Anything else (e.g. `/nope`, `/help`) is left as plain `'unknown'` so
+// the existing forward-compat path keeps working — those names might be
+// valid CLI commands ccsm hasn't catalogued yet.
+export function isUnsupportedSlashShape(name: string): boolean {
+  if (name.includes(':')) return true;
+  if (name === 'plugin') return true;
+  return false;
+}
 
 // Dispatch a parsed slash command. The caller passes the merged command
 // list (built-ins ⊕ disk-discovered).
 //
-// - 'handled'      — local clientHandler ran; do NOT forward.
-// - 'pass-through' — known dynamic / pass-through command; forward to claude.exe.
-// - 'unknown'      — name doesn't match anything we know; caller decides
-//                    (current InputBar still forwards so future CLI commands
-//                    keep working before our registry catches up).
+// - 'handled'            — local clientHandler ran; do NOT forward.
+// - 'pass-through'       — known dynamic / pass-through command; forward to claude.exe.
+// - 'unknown-namespaced' — unknown command whose shape (`/x:y` or `/plugin`)
+//                          marks it as plugin/skill/CLI-only. Caller should
+//                          show a local "Unknown command" toast and NOT
+//                          forward — the SDK can't run it.
+// - 'unknown'            — unrecognised plain name; caller decides
+//                          (current InputBar still forwards so future CLI
+//                          commands keep working before our registry catches up).
 export async function dispatchSlashCommand(
   raw: string,
   all: SlashCommand[],
@@ -151,7 +181,9 @@ export async function dispatchSlashCommand(
   const parsed = parseSlashInvocation(raw);
   if (!parsed) return 'unknown';
   const cmd = findSlashCommand(all, parsed.name);
-  if (!cmd) return 'unknown';
+  if (!cmd) {
+    return isUnsupportedSlashShape(parsed.name) ? 'unknown-namespaced' : 'unknown';
+  }
   if (cmd.clientHandler) {
     await cmd.clientHandler({ ...ctx, args: parsed.args });
     return 'handled';

--- a/tests/slash-commands-handlers.test.ts
+++ b/tests/slash-commands-handlers.test.ts
@@ -86,6 +86,38 @@ describe('dispatchSlashCommand', () => {
     );
     expect(outcome).toBe('unknown');
   });
+  it('returns unknown-namespaced for colon-namespaced unknowns', async () => {
+    const outcome = await dispatchSlashCommand(
+      '/superpowers:brainstorm idea',
+      BUILT_IN_COMMANDS,
+      { sessionId: 's1', args: '' }
+    );
+    expect(outcome).toBe('unknown-namespaced');
+  });
+  it('returns unknown-namespaced for /plugin (CLI-only manager)', async () => {
+    const outcome = await dispatchSlashCommand(
+      '/plugin',
+      BUILT_IN_COMMANDS,
+      { sessionId: 's1', args: '' }
+    );
+    expect(outcome).toBe('unknown-namespaced');
+  });
+  it('still returns pass-through when a colon-namespaced command IS in the merged list', async () => {
+    const merged = [
+      ...BUILT_IN_COMMANDS,
+      {
+        name: 'foo:bar',
+        source: 'plugin' as const,
+        passThrough: true,
+      },
+    ];
+    const outcome = await dispatchSlashCommand(
+      '/foo:bar',
+      merged,
+      { sessionId: 's1', args: '' }
+    );
+    expect(outcome).toBe('pass-through');
+  });
   it('respects a dynamic command in the merged list (pass-through)', async () => {
     const merged = [
       ...BUILT_IN_COMMANDS,


### PR DESCRIPTION
## Summary

Follow-up to #346. Picker now filters plugin / skill / agent / namespaced commands, but a user who types `/plugin` or `/superpowers:brainstorm` by hand still had the raw text forwarded as plain user prose to the SDK transport — model then either misinterprets it or replies "deprecated, use the skill instead" (the user-side symptom #346 paired with).

- `registry.ts`: `isUnsupportedSlashShape(name)` (`:` or `plugin`) + new `'unknown-namespaced'` outcome from `dispatchSlashCommand`. Plain-name unknowns (`/foo`) still return `'unknown'` to preserve forward-compat for CLI commands ccsm hasn't catalogued yet.
- `InputBar.tsx`: handle `'unknown-namespaced'` — push error toast ("Unknown command: /\<name\>"), clear composer, return early. No user message appended, no IPC send.
- en/zh i18n: new `slashCommands.unknownToast` key (sentence case, `{{name}}` interpolation).

## Verification

**Unit tests** (`tests/slash-commands-handlers.test.ts`): 3 new cases — colon-namespaced unknown, bare `/plugin`, registered colon-namespaced still pass-through. 18/18 pass.

**E2E (`scripts/harness-ui.mjs` → `slash-namespaced-unknown-toast`)**: types `/plugin` and `/superpowers:foo`, asserts error toast surfaces with the exact title, zero user blocks appended, composer cleared.

```
[case=slash-namespaced-unknown-toast] OK   1655ms (forward)
```

**Reverse-verified** by reverting the dispatcher branch to always return `'unknown'`:

```
[case=slash-namespaced-unknown-toast] FAIL: expected error toast titled "Unknown command: /plugin" for /plugin; not visible
```

After restoring the branch the case passes again.

## Test plan

- [x] vitest `slash-commands-handlers` — 18 pass
- [x] `node scripts/harness-ui.mjs --only=slash-namespaced-unknown-toast` — pass
- [x] reverse-verify — fails as expected when dispatcher branch is stubbed
- [x] tsc --noEmit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)