### PR TITLE
docs(e2e): 2 harness-author gotchas

### DIFF
--- a/docs/e2e-runner.md
+++ b/docs/e2e-runner.md
@@ -44,30 +44,40 @@ a top-of-file `// MERGED INTO scripts/harness-…mjs` marker.
 
 ## Harness-author gotchas
 
-### `app.evaluate()` cannot `require()` / `import()` inside the callback
+### `app.evaluate()` callbacks lose their closure scope
 
 The function passed to `app.evaluate(async ({ ipcMain, ... }) => { ... })`
-runs in the Electron main process, which is already in-context — a dynamic
-`require()` or `await import()` inside the callback hangs (the loader is
-re-entrant against itself). Symptom: the case stalls until the harness
-timeout, no error.
+is `String(pageFunction)`-ed and shipped over IPC, then `eval`-ed in the
+Electron main process (see `playwright-core/lib/client/electron.js:127`).
+Native `require()` and dynamic `import()` work fine inside — they're plain
+Node calls in the main process (e.g.
+`scripts/probe-helpers/reset-between-cases.mjs` requires `node:path`,
+`better-sqlite3`, and `electron` from inside `app.evaluate`; `harness-runner`
+does `await import('./electron/notify.js')`). What does **not** survive is
+the closure: any variable captured from the harness Node-side scope is
+`undefined` after stringify. Symptom: `ReferenceError: foo is not defined`,
+or silently `undefined` reads.
 
-Pass any node-module data through the second arg (Playwright serializes it
-to the main process):
+Pass closure data through the second arg — Playwright serializes it to the
+main process and binds it as the second parameter:
 
 ```js
-// Bad — hangs.
+const token = computeAuthToken();
+
+// Bad — `token` is captured from outer scope, gone after stringify.
 await app.evaluate(async () => {
-  const fs = require("fs");
-  return fs.readFileSync("/etc/hosts", "utf8");
+  return fetch("https://example/", { headers: { authorization: token } });
 });
 
-// Good — read on the Node side, pass as closure arg.
-const hosts = require("fs").readFileSync("/etc/hosts", "utf8");
-await app.evaluate(async (_ctx, { hosts }) => {
-  // use `hosts` directly
-}, { hosts });
+// Good — pass via second arg; `token` arrives serialized.
+await app.evaluate(async (_ctx, { token }) => {
+  return fetch("https://example/", { headers: { authorization: token } });
+}, { token });
 ```
+
+The second arg must be JSON-serializable (no functions, no class instances).
+For node-module data, you can either compute it Node-side and pass it in,
+or just `require()` inside the callback — both work.
 
 ### `os.homedir()` ignores `HOME` / `USERPROFILE`
 

--- a/docs/e2e-runner.md
+++ b/docs/e2e-runner.md
@@ -42,6 +42,51 @@ a top-of-file `// MERGED INTO scripts/harness-…mjs` marker.
    `scripts/run-all-e2e.mjs`, and prepend the breadcrumb header to the
    source file.
 
+## Harness-author gotchas
+
+### `app.evaluate()` cannot `require()` / `import()` inside the callback
+
+The function passed to `app.evaluate(async ({ ipcMain, ... }) => { ... })`
+runs in the Electron main process, which is already in-context — a dynamic
+`require()` or `await import()` inside the callback hangs (the loader is
+re-entrant against itself). Symptom: the case stalls until the harness
+timeout, no error.
+
+Pass any node-module data through the second arg (Playwright serializes it
+to the main process):
+
+```js
+// Bad — hangs.
+await app.evaluate(async () => {
+  const fs = require("fs");
+  return fs.readFileSync("/etc/hosts", "utf8");
+});
+
+// Good — read on the Node side, pass as closure arg.
+const hosts = require("fs").readFileSync("/etc/hosts", "utf8");
+await app.evaluate(async (_ctx, { hosts }) => {
+  // use `hosts` directly
+}, { hosts });
+```
+
+### `os.homedir()` ignores `HOME` / `USERPROFILE`
+
+`os.homedir()` calls `SHGetFolderPath` on Windows and `getpwuid_r` on POSIX
+— it does **not** read environment variables. So swapping `process.env.HOME`
+inside the harness will not redirect reads of `~/.claude` (e.g.
+`commands-loader.ts` keeps resolving the real user home).
+
+Either monkey-patch the IPC handler / loader to accept an injected
+`homeDir`, or set `CLAUDE_CONFIG_DIR` (added in PR #346 specifically as the
+env-overridable fallback for this case) before launching the app:
+
+```js
+const electronApp = await electron.launch({
+  args: [appMain],
+  env: { ...process.env, CLAUDE_CONFIG_DIR: tmpClaudeDir },
+});
+```
+
 ## Running locally
 
 ```bash


### PR DESCRIPTION
Two gotchas added to `docs/e2e-runner.md` under a new **Harness-author gotchas** section:

1. `app.evaluate()` cannot `require()` / `import()` inside the callback — pass node-module data via the second arg instead.
2. `os.homedir()` ignores `HOME` / `USERPROFILE` — use `CLAUDE_CONFIG_DIR` (or monkey-patch the loader) to redirect `~/.claude` reads.