### PR TITLE
feat(effort): use SDK-reported supportedEffortLevels (drop hardcoded)

### DIFF
--- a/electron/agent-sdk/sessions.ts
+++ b/electron/agent-sdk/sessions.ts
@@ -42,6 +42,7 @@ import type {
   ExitHandler,
   PermissionRequestHandler,
   DiagnosticHandler,
+  ModelInfoHandler,
   AgentMessage,
 } from '../agent/sessions';
 import { translateSdkMessage, type SdkMessageLike } from './sdk-message-translator';
@@ -287,6 +288,7 @@ export class SdkSessionRunner {
     private readonly onExit: ExitHandler,
     private readonly onPermissionRequest: PermissionRequestHandler,
     private readonly onDiagnostic: DiagnosticHandler = () => {},
+    private readonly onModelInfo: ModelInfoHandler = () => {},
   ) {}
 
   /**
@@ -418,8 +420,7 @@ export class SdkSessionRunner {
         // every other tier. `effort` carries the actual tier label and is
         // omitted when Off (the SDK's model-default is then irrelevant
         // because thinking is disabled). See src/agent/effort.ts for the
-        // mapping table and `docs/thinking-tier-vscode-eval-2026-04-26.md`
-        // for the upstream probe that confirms this is the wire shape.
+        // mapping table.
         thinking: wire.thinking,
         effort: wire.effort,
         canUseTool: (toolName, input, ctx) => this.handleCanUseTool(toolName, input, ctx),
@@ -455,6 +456,50 @@ export class SdkSessionRunner {
     // Drain the SDK's outbound stream into ccsm's renderer event channel.
     // Errors from the iterator are surfaced via onExit; see the catch below.
     const query = this.query;
+
+    // Pull per-model capability metadata (notably `supportedEffortLevels`)
+    // from the SDK's initialize control_response. The promise resolves once
+    // the CLI has acknowledged the initialize handshake — at that point the
+    // SDK has the full ModelInfo[] available. Fire-and-forget: a failure
+    // here just means the StatusBar effort chip falls back to its hardcoded
+    // model→tier table (src/agent/effort.ts).
+    void (async () => {
+      try {
+        type SdkModelInfo = {
+          value?: unknown;
+          supportedEffortLevels?: unknown;
+        };
+        const supportedModels = (
+          query as unknown as { supportedModels?: () => Promise<SdkModelInfo[]> }
+        ).supportedModels;
+        if (typeof supportedModels !== 'function') return;
+        const models = await supportedModels.call(query);
+        if (this.disposed || !Array.isArray(models)) return;
+        const allowed = new Set(['low', 'medium', 'high', 'xhigh', 'max']);
+        const out = models
+          .map((m) => {
+            const id = typeof m?.value === 'string' ? m.value : null;
+            if (!id) return null;
+            const raw = m?.supportedEffortLevels;
+            const tiers = Array.isArray(raw)
+              ? raw.filter(
+                  (t): t is 'low' | 'medium' | 'high' | 'xhigh' | 'max' =>
+                    typeof t === 'string' && allowed.has(t),
+                )
+              : undefined;
+            return { modelId: id, supportedEffortLevels: tiers };
+          })
+          .filter((x): x is { modelId: string; supportedEffortLevels: ('low'|'medium'|'high'|'xhigh'|'max')[] | undefined } => x !== null);
+        if (out.length > 0) this.onModelInfo({ models: out });
+      } catch (err) {
+        this.onDiagnostic({
+          level: 'warn',
+          code: 'supported_models_failed',
+          message: `query.supportedModels() failed: ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
+    })();
+
     this.consumer = (async () => {
       try {
         for await (const msg of query) {

--- a/electron/agent/manager.ts
+++ b/electron/agent/manager.ts
@@ -49,6 +49,20 @@ export type AgentDiagnostic = {
   message: string;
 };
 
+/**
+ * Per-model capability metadata reported by the SDK after session start.
+ * Drives the StatusBar effort chip's tier gating — see
+ * `src/agent/effort.ts::supportedEffortLevelsForModel` for the
+ * fallback table used when a model is absent from this report.
+ */
+export type AgentModelInfoEvent = {
+  sessionId: string;
+  models: Array<{
+    modelId: string;
+    supportedEffortLevels?: ReadonlyArray<'low' | 'medium' | 'high' | 'xhigh' | 'max'>;
+  }>;
+};
+
 class SessionsManager {
   private runners = new Map<string, Runner>();
   private sender: Sender | null = null;
@@ -156,7 +170,12 @@ class SessionsManager {
             level: diag.level,
             code: diag.code,
             message: diag.message,
-          } satisfies AgentDiagnostic)
+          } satisfies AgentDiagnostic),
+        (info) =>
+          this.emit('agent:modelInfo', {
+            sessionId,
+            models: info.models,
+          } satisfies AgentModelInfoEvent)
       );
       await runner.start(opts);
       await Promise.race([firstSignal, new Promise<void>((r) => setTimeout(r, 800))]);

--- a/electron/agent/sessions.ts
+++ b/electron/agent/sessions.ts
@@ -100,4 +100,18 @@ export type DiagnosticHandler = (d: {
   message: string;
 }) => void;
 
+/**
+ * Per-model capability metadata reported by the SDK's `query.supportedModels()`
+ * shortly after session start. Today ccsm only consumes
+ * `supportedEffortLevels` (powers the StatusBar effort chip's gating —
+ * see src/agent/effort.ts::supportedEffortLevelsForModel) and uses the
+ * hardcoded fallback for any model the SDK doesn't report.
+ */
+export type AgentModelInfo = {
+  modelId: string;
+  supportedEffortLevels?: ReadonlyArray<'low' | 'medium' | 'high' | 'xhigh' | 'max'>;
+};
+
+export type ModelInfoHandler = (info: { models: AgentModelInfo[] }) => void;
+
 export type { ClaudeStreamEvent };

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -33,6 +33,13 @@ type AgentDiagnostic = {
   code: string;
   message: string;
 };
+type AgentModelInfoEvent = {
+  sessionId: string;
+  models: Array<{
+    modelId: string;
+    supportedEffortLevels?: ReadonlyArray<'low' | 'medium' | 'high' | 'xhigh' | 'max'>;
+  }>;
+};
 type AgentPermissionRequest = {
   sessionId: string;
   requestId: string;
@@ -213,6 +220,11 @@ const api = {
     const wrap = (_e: IpcRendererEvent, payload: AgentDiagnostic) => handler(payload);
     ipcRenderer.on('agent:diagnostic', wrap);
     return () => ipcRenderer.removeListener('agent:diagnostic', wrap);
+  },
+  onAgentModelInfo: (handler: (e: AgentModelInfoEvent) => void): (() => void) => {
+    const wrap = (_e: IpcRendererEvent, payload: AgentModelInfoEvent) => handler(payload);
+    ipcRenderer.on('agent:modelInfo', wrap);
+    return () => ipcRenderer.removeListener('agent:modelInfo', wrap);
   },
   onAgentPermissionRequest: (handler: (e: AgentPermissionRequest) => void): (() => void) => {
     const wrap = (_e: IpcRendererEvent, payload: AgentPermissionRequest) => handler(payload);

--- a/src/agent/effort.ts
+++ b/src/agent/effort.ts
@@ -23,9 +23,14 @@
 //   - Persistence: settings.json effortLevel (CLI reads via CLAUDE_CONFIG_DIR;
 //                  ccsm does NOT parse settings.json — see project_cli_config_reuse memory).
 //
-// Model gating: hardcoded below until DiscoveredModel surfaces
-// `supportedEffortLevels` from the SDK's model metadata. Gated tiers render
-// `disabled` in the dropdown with a "not supported by current model" tooltip.
+// Model gating: we prefer the SDK's own `Model.supportedEffortLevels` (piped
+// in per-model via the `agent:modelInfo` IPC channel — see
+// `electron/agent-sdk/sessions.ts` and the renderer wiring in
+// `src/agent/lifecycle.ts`). When no SDK report is available yet — e.g.
+// before the first session starts in an app run — we fall back to a small
+// hardcoded model→tier table inside `supportedEffortLevelsForModel`. Gated
+// tiers render `disabled` in the dropdown with a "not supported by current
+// model" tooltip.
 
 export type EffortLevel = 'off' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 
@@ -91,25 +96,45 @@ export function thinkingTokensForLevel(level: EffortLevel): number | null {
 }
 
 /**
- * Hardcoded model -> supported tier list. Off is implicitly always
- * supported. Mirrors what the bundled SDK reports today via
- * `Model.supportedEffortLevels` (probed in
- * `docs/thinking-tier-vscode-eval-2026-04-26.md`).
- *
- *   Opus 4.7    → low, medium, high, xhigh, max
- *   Opus 4.6    → low, medium, high, max
- *   Sonnet 4.6+ → low, medium, high
- *   Older       → none (effort gating not yet supported); chip shows Off+High
- *                 fallback. We still expose the full picker so a model swap
- *                 picks up support without a relaunch.
- *
- * Returns the set of NON-'off' tiers a given model supports. 'off' is always
+ * Resolve the set of NON-'off' tiers a given model supports. 'off' is always
  * usable (it is purely a ccsm-side toggle: thinking=disabled).
+ *
+ * Resolution order:
+ *   1. `sdkReported` — the SDK's own `Model.supportedEffortLevels` for this
+ *      model id, populated on session start via `query.supportedModels()`
+ *      (see electron/agent-sdk/sessions.ts and the `agent:modelInfo` IPC
+ *      channel). This is the canonical answer when present, including
+ *      future model additions ccsm hasn't been recompiled for.
+ *   2. Hardcoded fallback below — used when no SDK report has arrived yet
+ *      (no session has started in this app run, or the running SDK build
+ *      doesn't list the chosen model). Mirrors what the bundled CLI
+ *      reported in dogfood at the time of writing:
+ *
+ *        Opus 4.7    → low, medium, high, xhigh, max
+ *        Opus 4.6    → low, medium, high, max
+ *        Sonnet 4.6+ → low, medium, high
+ *        Older       → low, medium, high  (always-safe trio; the chip still
+ *                      works so a model swap picks up support without a
+ *                      relaunch).
  */
 export function supportedEffortLevelsForModel(
   modelId: string | null | undefined,
+  sdkReported?: Readonly<
+    Record<string, ReadonlyArray<Exclude<EffortLevel, 'off'>>>
+  >
 ): ReadonlySet<Exclude<EffortLevel, 'off'>> {
   const id = (modelId ?? '').toLowerCase();
+  if (sdkReported && modelId) {
+    // Try the exact id the SDK reported with first; fall back to a
+    // case-insensitive lookup so callers don't have to care about how the
+    // CLI spells the canonical id (e.g. `claude-opus-4-7-...` vs the
+    // user-facing alias).
+    const exact = sdkReported[modelId];
+    if (exact && exact.length > 0) return new Set(exact);
+    for (const [k, v] of Object.entries(sdkReported)) {
+      if (k.toLowerCase() === id && v.length > 0) return new Set(v);
+    }
+  }
   // Order matters: opus-4-7 must be tested before opus-4 (substring match).
   if (/opus-4[-_]7|opus-4\.7/.test(id)) {
     return new Set(['low', 'medium', 'high', 'xhigh', 'max']);
@@ -120,17 +145,19 @@ export function supportedEffortLevelsForModel(
   if (/sonnet-4|sonnet/.test(id)) {
     return new Set(['low', 'medium', 'high']);
   }
-  // Unknown model: surface only the always-safe trio. The chip still works;
-  // a future SDK metadata exposure can replace this branch.
+  // Unknown model: surface the always-safe trio.
   return new Set(['low', 'medium', 'high']);
 }
 
 export function isEffortLevelSupported(
   modelId: string | null | undefined,
   level: EffortLevel,
+  sdkReported?: Readonly<
+    Record<string, ReadonlyArray<Exclude<EffortLevel, 'off'>>>
+  >
 ): boolean {
   if (level === 'off') return true;
-  return supportedEffortLevelsForModel(modelId).has(level);
+  return supportedEffortLevelsForModel(modelId, sdkReported).has(level);
 }
 
 /**

--- a/src/agent/lifecycle.ts
+++ b/src/agent/lifecycle.ts
@@ -365,6 +365,14 @@ export function subscribeAgentEvents(): void {
     });
   });
 
+  // Per-model effort-tier metadata reported by the SDK on session start
+  // (electron/agent-sdk/sessions.ts → `query.supportedModels()`). Drives
+  // StatusBar effort chip gating; the hardcoded fallback in
+  // src/agent/effort.ts handles models the SDK doesn't report.
+  api.onAgentModelInfo?.((e) => {
+    useStore.getState().applyModelInfo(e.models);
+  });
+
   api.onAgentPermissionRequest((req) => {
     // Session-scoped "Allow always" fast-path: if the user previously ticked
     // "Allow always" for this tool name, auto-resolve Allow and skip rendering

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -331,6 +331,11 @@ export function StatusBar({
   const { t } = useTranslation();
   const models = useStore((s) => s.models);
   const modelsLoaded = useStore((s) => s.modelsLoaded);
+  // SDK-reported per-model effort tiers (populated from the `agent:modelInfo`
+  // IPC channel in src/agent/lifecycle.ts). Empty until at least one session
+  // has started; supportedEffortLevelsForModel falls back to its hardcoded
+  // table for any model not yet reported.
+  const supportedEffortLevelsByModel = useStore((s) => s.supportedEffortLevelsByModel);
   const contextUsage = useStore((s) => s.contextUsageBySession[sessionId]);
   // 6-tier effort+thinking chip: per-session override falls back to the
   // global default so a fresh session starts at 'high' (the unified chip's
@@ -412,7 +417,7 @@ export function StatusBar({
   };
   const gatedTooltip = t('statusBar.effortGatedTooltip');
   const effortOptions: ChipOption<EffortLevel>[] = EFFORT_LEVELS.map((lvl) => {
-    const supported = isEffortLevelSupported(model, lvl);
+    const supported = isEffortLevelSupported(model, lvl, supportedEffortLevelsByModel);
     return {
       kind: 'item' as const,
       value: lvl,

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -49,6 +49,13 @@ type AgentDiagnostic = {
   code: string;
   message: string;
 };
+type AgentModelInfoEvent = {
+  sessionId: string;
+  models: Array<{
+    modelId: string;
+    supportedEffortLevels?: ReadonlyArray<'low' | 'medium' | 'high' | 'xhigh' | 'max'>;
+  }>;
+};
 type AgentPermissionRequest = {
   sessionId: string;
   requestId: string;
@@ -158,6 +165,7 @@ declare global {
       onAgentEvent: (handler: (e: AgentEvent) => void) => () => void;
       onAgentExit: (handler: (e: AgentExit) => void) => () => void;
       onAgentDiagnostic: (handler: (e: AgentDiagnostic) => void) => () => void;
+      onAgentModelInfo: (handler: (e: AgentModelInfoEvent) => void) => () => void;
       onAgentPermissionRequest: (handler: (e: AgentPermissionRequest) => void) => () => void;
 
       scanImportable: () => Promise<

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -250,6 +250,19 @@ type State = {
   messageQueues: Record<string, QueuedMessage[]>;
   models: DiscoveredModel[];
   modelsLoaded: boolean;
+  /**
+   * Per-model `supportedEffortLevels` reported by the SDK on session start
+   * via `query.supportedModels()` (forwarded to the renderer over the
+   * `agent:modelInfo` IPC channel — see `electron/agent-sdk/sessions.ts`).
+   * Source of truth for the StatusBar effort chip's tier gating; falls
+   * back to the hardcoded model→tier table in `src/agent/effort.ts` for
+   * any model not yet reported (e.g. before any session has started, or
+   * for a model the bundled SDK doesn't list).
+   *
+   * Keyed by raw model id (`ModelInfo.value`), shared across sessions —
+   * the SDK reports the SAME catalogue regardless of which session asked.
+   */
+  supportedEffortLevelsByModel: Record<string, ReadonlyArray<Exclude<EffortLevel, 'off'>>>;
   connection: ConnectionInfo | null;
   // Monotonic counter bumped whenever a user-driven action requests that the
   // InputBar textarea take focus (e.g. clicking a session in the sidebar,
@@ -580,6 +593,19 @@ type Actions = {
   setSessionContextUsage: (sessionId: string, usage: SessionContextUsage) => void;
 
   loadModels: () => Promise<void>;
+  /**
+   * Merge per-model effort-tier metadata reported by the SDK
+   * (`agent:modelInfo` IPC) into `supportedEffortLevelsByModel`. New entries
+   * overwrite previous ones — the SDK's report is canonical for whatever
+   * model id it includes. Models absent from the report keep their prior
+   * entries (or fall back to the hardcoded table at lookup time).
+   */
+  applyModelInfo: (
+    models: ReadonlyArray<{
+      modelId: string;
+      supportedEffortLevels?: ReadonlyArray<'low' | 'medium' | 'high' | 'xhigh' | 'max'>;
+    }>
+  ) => void;
   loadConnection: () => Promise<void>;
 
   /** Flip the `installerCorrupt` banner on (true) or off (false). Called
@@ -1015,6 +1041,7 @@ export const useStore = create<State & Actions>((set, get) => ({
   messageQueues: {},
   models: [],
   modelsLoaded: false,
+  supportedEffortLevelsByModel: {},
   connection: null,
   focusInputNonce: 0,
   installerCorrupt: false,
@@ -2452,6 +2479,40 @@ export const useStore = create<State & Actions>((set, get) => ({
     } catch {
       set({ modelsLoaded: true });
     }
+  },
+
+  applyModelInfo: (models) => {
+    if (!Array.isArray(models) || models.length === 0) return;
+    set((s) => {
+      const next = { ...s.supportedEffortLevelsByModel };
+      let changed = false;
+      for (const m of models) {
+        if (!m || typeof m.modelId !== 'string' || !m.modelId) continue;
+        const tiers = m.supportedEffortLevels;
+        if (!Array.isArray(tiers)) continue;
+        // Defence-in-depth: filter to known union members. The IPC payload
+        // is already validated in preload but the store is the boundary
+        // both production and harness probes hit, so keep the guard local.
+        const allowed = (['low', 'medium', 'high', 'xhigh', 'max'] as const).filter((t) =>
+          tiers.includes(t)
+        );
+        // Empty filter result == no usable info → skip rather than write an
+        // empty array (effort.ts treats empty as "no SDK report" and falls
+        // back to the hardcoded table; storing [] would just waste a slot).
+        if (allowed.length === 0) continue;
+        const prev = next[m.modelId];
+        if (
+          prev &&
+          prev.length === allowed.length &&
+          prev.every((v, i) => v === allowed[i])
+        ) {
+          continue;
+        }
+        next[m.modelId] = allowed;
+        changed = true;
+      }
+      return changed ? { supportedEffortLevelsByModel: next } : s;
+    });
   },
 
   loadConnection: async () => {

--- a/tests/effort.test.ts
+++ b/tests/effort.test.ts
@@ -67,6 +67,39 @@ describe('effort: model gating', () => {
     expect(isEffortLevelSupported(undefined, 'off')).toBe(true);
     expect(isEffortLevelSupported(null, 'off')).toBe(true);
   });
+
+  it('SDK-reported tiers OVERRIDE the hardcoded fallback', () => {
+    // Sonnet hardcoded -> [low,medium,high]. SDK report grants xhigh too.
+    const sdk = { 'claude-sonnet-4-99': ['low', 'medium', 'high', 'xhigh'] as const };
+    const set = supportedEffortLevelsForModel('claude-sonnet-4-99', sdk);
+    expect(set.has('xhigh')).toBe(true);
+    expect(set.has('max')).toBe(false);
+    // isEffortLevelSupported respects the override too.
+    expect(isEffortLevelSupported('claude-sonnet-4-99', 'xhigh', sdk)).toBe(true);
+    expect(isEffortLevelSupported('claude-sonnet-4-99', 'max', sdk)).toBe(false);
+  });
+
+  it('Falls back to hardcoded table when SDK has no entry for the model', () => {
+    const sdk = { 'some-other-model': ['low'] as const };
+    const set = supportedEffortLevelsForModel('claude-opus-4-7', sdk);
+    expect(set.has('xhigh')).toBe(true);
+    expect(set.has('max')).toBe(true);
+  });
+
+  it('SDK lookup is case-insensitive on the model id', () => {
+    const sdk = { 'Custom-Model-X': ['low', 'medium'] as const };
+    const set = supportedEffortLevelsForModel('custom-model-x', sdk);
+    expect(set.has('low')).toBe(true);
+    expect(set.has('medium')).toBe(true);
+    expect(set.has('high')).toBe(false);
+  });
+
+  it('Empty SDK report falls through to hardcoded fallback (no spurious empty set)', () => {
+    const sdk = { 'claude-opus-4-7': [] as const };
+    const set = supportedEffortLevelsForModel('claude-opus-4-7', sdk);
+    // Empty array shouldn't lock the chip out; treat as "no info" and fall back.
+    expect(set.has('high')).toBe(true);
+  });
 });
 
 describe('effort: coerceEffortLevel migration', () => {
@@ -216,5 +249,40 @@ describe('store: effort-level actions', () => {
     await hydrateStore();
     expect(useStore.getState().globalEffortLevel).toBe('high');
     expect(useStore.getState().effortLevelBySession).toEqual({});
+  });
+});
+
+describe('store: applyModelInfo (SDK-reported supportedEffortLevels)', () => {
+  it('populates supportedEffortLevelsByModel from agent:modelInfo payload', async () => {
+    const { useStore } = await freshStore({});
+    expect(useStore.getState().supportedEffortLevelsByModel).toEqual({});
+    useStore.getState().applyModelInfo([
+      { modelId: 'claude-opus-4-7', supportedEffortLevels: ['low', 'medium', 'high', 'xhigh', 'max'] },
+      { modelId: 'claude-sonnet-4-6', supportedEffortLevels: ['low', 'medium', 'high'] },
+    ]);
+    const m = useStore.getState().supportedEffortLevelsByModel;
+    expect(m['claude-opus-4-7']).toEqual(['low', 'medium', 'high', 'xhigh', 'max']);
+    expect(m['claude-sonnet-4-6']).toEqual(['low', 'medium', 'high']);
+  });
+
+  it('ignores empty / malformed payloads without clobbering existing entries', async () => {
+    const { useStore } = await freshStore({});
+    useStore.getState().applyModelInfo([
+      { modelId: 'claude-opus-4-7', supportedEffortLevels: ['low', 'medium', 'high', 'xhigh', 'max'] },
+    ]);
+    // Empty list — no-op.
+    useStore.getState().applyModelInfo([]);
+    // Malformed entries — skipped.
+    useStore
+      .getState()
+      .applyModelInfo([
+        { modelId: '', supportedEffortLevels: ['low'] } as never,
+        // unknown tier strings are filtered out by the reducer's allow-list.
+        { modelId: 'claude-bad', supportedEffortLevels: ['bogus' as never, 'high'] },
+      ]);
+    const m = useStore.getState().supportedEffortLevelsByModel;
+    expect(m['claude-opus-4-7']).toEqual(['low', 'medium', 'high', 'xhigh', 'max']);
+    expect(m['claude-bad']).toEqual(['high']);
+    expect(m['']).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
Replace the hardcoded model→effort-tiers table with the SDK's own per-model
report (`Model.supportedEffortLevels`), keeping the table as a fallback for
models the SDK doesn't list yet. Also drops two stale references to a doc
that never landed.

## Layer 1 — upstream verification (SDK exposes the field?)

Yes — confirmed via three sources before touching code:

1. SDK type: `node_modules/@anthropic-ai/claude-agent-sdk/sdk.d.ts:1064`
   ```ts
   supportedEffortLevels?: ('low' | 'medium' | 'high' | 'xhigh' | 'max')[];
   ```
   on `ModelInfo`, which appears as `models: coreTypes.ModelInfo[]` in
   `SDKControlInitializeResponse` (sdk.d.ts:2568).

2. Bundled CLI emits it. `grep -aoE ".{60}supportedEffortLevels.{120}"` on
   `C:/ProgramData/global-npm/node_modules/@anthropic-ai/claude-code/bin/claude.exe`:
   ```
   ...supportsEffort:!0,supportedEffortLevels:sm.filter((P8)=>{
     if(P8==="max"&&!oK8(kH))return!1;
     if(P8==="xhigh"&&!aK8(kH))return!1;
     return!0
   })...
   ```
   So the CLI populates the field per-model, filtered by capability.

3. VS Code extension consumes it. `webview/index.js`:
   ```
   M=A?.find((w)=>w.value===_); if(M?.supportsEffort)...
   j=M.supportedEffortLevels??["low","medium","high"]
   ```
   The exact path we mirror.

Public SDK access: `query.supportedModels()` returns the `ModelInfo[]` once
the initialize control_response settles
(`sdk.mjs: supportedModels(){return(await this.initialization).models}`).

## Wire path
1. `SdkSessionRunner.start()` fires `query.supportedModels()` after launch
   (fire-and-forget; new `onModelInfo` callback sibling of `onDiagnostic`).
   Failure surfaces a `supported_models_failed` warn diagnostic; the chip
   stays usable via the hardcoded fallback.
2. `SessionsManager` emits `agent:modelInfo` IPC.
3. `preload.ts` exposes `onAgentModelInfo`; renderer subscribes in
   `lifecycle.ts` → store action `applyModelInfo` populates
   `supportedEffortLevelsByModel: Record<modelId, EffortLevel[]>` (per-model,
   not per-session — the SDK reports the same catalogue for every session).
4. `effort.ts::supportedEffortLevelsForModel(modelId, sdkReported?)` prefers
   the SDK report (exact + case-insensitive lookup, empty arrays fall through),
   falls back to the hardcoded table.
5. `StatusBar` passes the store map.

## Drive-by
Two stale references to `docs/thinking-tier-vscode-eval-2026-04-26.md` (a
file that was never created) are removed:
- `src/agent/effort.ts` top comment
- `electron/agent-sdk/sessions.ts` thinking/effort wire comment

The upstream probe rationale those comments pointed to is now self-contained
in `effort.ts`'s top comment + this PR body.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run tests/effort.test.ts` — **26/26 pass**, including 5
      new cases:
      - SDK report overrides hardcoded fallback
      - Falls back to hardcoded when SDK has no entry
      - Lookup is case-insensitive on model id
      - Empty SDK array falls through to hardcoded
      - `applyModelInfo` populates store / rejects empty + malformed
- [x] `npx vitest run electron/agent-sdk/__tests__/sessions.test.ts` —
      **31/31 pass** (new constructor param has a default; no test-call
      signatures changed)
- [x] e2e `node scripts/harness-ui.mjs --only=effort-chip-toggle` —
      **pass**, exercises the fallback path with default Opus 4.7 (still 5
      tiers; chip render unchanged). The SDK-reported branch is fully
      unit-covered, so no new e2e case was added per
      `feedback_e2e_prefer_harness` (avoid +30s test time when unit covers it).
- [x] eslint on touched files — clean (only one pre-existing unrelated
      warning in `store.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)