### PR TITLE
fix(ux): batch — Esc/question/auto-advance/sidebar UX bugs

### DIFF
--- a/scripts/harness-agent.mjs
+++ b/scripts/harness-agent.mjs
@@ -1490,6 +1490,98 @@ async function caseEscInterrupt({ win, log }) {
   }
 
   log('Esc -> stop() ran (interrupted+queue cleared); Interrupted status block; textarea usable');
+
+  // ── J2 ────────────────────────────────────────────────────────────────
+  // Regression for #286 (PR #365): Esc must interrupt while textarea has
+  // focus AND when an inline `role="dialog"` widget (AskUserQuestion sticky,
+  // CwdPopover) is mounted. Before the fix, the doc-level handler returned
+  // early on `[role="dialog"]` — any inline a11y dialog silently disabled
+  // Esc-to-stop, including from the composer.
+  //
+  // Sub-case A: textarea-focus + inline role="dialog" (no data-modal-dialog).
+  // Asserts interrupt still fires.
+  // Sub-case B: textarea-focus + role="dialog" + data-modal-dialog.
+  // Asserts interrupt is suppressed (real Radix modals own Esc).
+  const SID2 = 's-esc-int-j2';
+  await win.evaluate((sid) => {
+    const store = window.__ccsmStore;
+    store.setState({
+      groups: [{ id: 'g1', name: 'G1', collapsed: false, kind: 'normal' }],
+      sessions: [{
+        id: sid, name: 'esc-textarea', state: 'idle', cwd: 'C:/x',
+        model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code'
+      }],
+      activeId: sid,
+      messagesBySession: { [sid]: [] },
+      startedSessions: { [sid]: true },
+      runningSessions: { [sid]: true },
+      interruptedSessions: {},
+    });
+  }, SID2);
+  await win.waitForTimeout(150);
+
+  // Sub-case A: inline role="dialog" must NOT block doc-level Esc handler.
+  await win.evaluate(() => {
+    // Remove any leftover from sub-case set up below on retries.
+    document.querySelectorAll('[data-harness-injected-dialog]').forEach((n) => n.remove());
+    const inline = document.createElement('div');
+    inline.setAttribute('role', 'dialog');
+    inline.setAttribute('aria-label', 'inline a11y widget (no aria-modal)');
+    inline.setAttribute('data-harness-injected-dialog', 'inline');
+    // No data-modal-dialog marker — this is the inline-widget shape that
+    // QuestionBlock + CwdPopover use.
+    document.body.appendChild(inline);
+  });
+  // Real textarea focus — that's the regression scenario.
+  const ta2A = win.locator('textarea').first();
+  await ta2A.waitFor({ state: 'visible', timeout: 5000 });
+  await ta2A.click();
+  const focusedA = await win.evaluate(() => document.activeElement?.tagName);
+  if (focusedA !== 'TEXTAREA') throw new Error(`J2-A: expected textarea focus, got activeElement=${focusedA}`);
+  await win.evaluate(() => {
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+  });
+  await win.waitForTimeout(200);
+  const interruptedA = await win.evaluate((sid) => !!window.__ccsmStore.getState().interruptedSessions[sid], SID2);
+  if (!interruptedA) {
+    throw new Error('J2-A regression: textarea-focus Esc did NOT interrupt while inline role="dialog" was mounted — the global selector is over-matching');
+  }
+  // Reset for sub-case B.
+  await win.evaluate((sid) => {
+    document.querySelectorAll('[data-harness-injected-dialog]').forEach((n) => n.remove());
+    const st = window.__ccsmStore.getState();
+    st.consumeInterrupted(sid);
+    st.setRunning(sid, true);
+  }, SID2);
+  await win.waitForTimeout(120);
+
+  // Sub-case B: data-modal-dialog (real Radix modal shape) MUST suppress.
+  await win.evaluate(() => {
+    const modal = document.createElement('div');
+    modal.setAttribute('role', 'dialog');
+    modal.setAttribute('aria-modal', 'true');
+    modal.setAttribute('data-modal-dialog', '');
+    modal.setAttribute('data-harness-injected-dialog', 'modal');
+    document.body.appendChild(modal);
+  });
+  const ta2B = win.locator('textarea').first();
+  await ta2B.click();
+  const focusedB = await win.evaluate(() => document.activeElement?.tagName);
+  if (focusedB !== 'TEXTAREA') throw new Error(`J2-B: expected textarea focus, got activeElement=${focusedB}`);
+  await win.evaluate(() => {
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+  });
+  await win.waitForTimeout(200);
+  const interruptedB = await win.evaluate((sid) => !!window.__ccsmStore.getState().interruptedSessions[sid], SID2);
+  if (interruptedB) {
+    throw new Error('J2-B contract broken: data-modal-dialog should suppress global Esc-to-stop (real Radix modals own Esc), but interrupt fired anyway');
+  }
+  // Cleanup so later cases see a clean DOM.
+  await win.evaluate(() => {
+    document.querySelectorAll('[data-harness-injected-dialog]').forEach((n) => n.remove());
+  });
+
+  log('J2 — textarea-focus Esc passes through inline role="dialog" (#286), suppressed by data-modal-dialog');
 }
 
 // ---------- composer-morph-mention ----------

--- a/scripts/harness-perm.mjs
+++ b/scripts/harness-perm.mjs
@@ -1705,6 +1705,272 @@ async function caseAskUserQuestionRoutesViaPermissionRequest({ app, win, log }) 
   log('AskUserQuestion permission-request frame mounts a question card');
 }
 
+// ---------- auq-single-select-auto-advance ----------
+// Regression for #287 (PR #365 review feedback): single-choice auto-advance
+// on AskUserQuestion silently broke in production builds because togglePick
+// read a `let didSelectFresh` flag set INSIDE the setPicks state-updater
+// callback. React state updaters run during the next render commit, not
+// synchronously when set is called — so the immediate `if (didSelectFresh)`
+// check below the setPicks call always observed `false` and the auto-
+// advance never fired. Vitest masked this because RTL's fireEvent flushes
+// updaters synchronously inside `act`; harness uses real Playwright clicks
+// dispatched into a real Electron renderer (no act-wrapping), so it
+// reproduces the bug exactly as the user sees it.
+async function caseAuqSingleSelectAutoAdvance({ win, log }) {
+  const sessionId = await win.evaluate(() => {
+    const s = window.__ccsmStore.getState();
+    if (s.activeId && s.sessions.some((x) => x.id === s.activeId)) return s.activeId;
+    s.createSession({ name: 'auq-advance-probe' });
+    return window.__ccsmStore.getState().activeId;
+  });
+  await win.evaluate((sid) => window.__ccsmStore.getState().setRunning(sid, true), sessionId);
+  await win.evaluate((sid) => window.__ccsmStore.getState().clearMessages(sid), sessionId);
+
+  // Three single-select questions — exercises the auto-advance path twice
+  // (Q1 → Q2 → Q3, then no advance from Q3 since it's the last).
+  const QUESTIONS = [
+    { question: 'Which language?', options: [{ label: 'Python' }, { label: 'TypeScript' }, { label: 'Rust' }] },
+    { question: 'Which build tool?', options: [{ label: 'esbuild' }, { label: 'rollup' }, { label: 'webpack' }] },
+    { question: 'Which DB?', options: [{ label: 'sqlite' }, { label: 'postgres' }] },
+  ];
+  await win.evaluate(({ sid, q }) => {
+    window.__ccsmStore.getState().appendBlocks(sid, [
+      { kind: 'question', id: 'q-auto-advance', questions: q },
+    ]);
+  }, { sid: sessionId, q: QUESTIONS });
+  await win.waitForSelector('[data-question-option]', { timeout: 5000 });
+  await win.waitForTimeout(150);
+
+  // Initial state: Q1 active, no answers yet.
+  let activeTab = await win.evaluate(() => {
+    const tabs = document.querySelectorAll('[data-testid^="question-tab-"]');
+    for (let i = 0; i < tabs.length; i++) {
+      if (tabs[i].dataset.active === 'true') return i;
+    }
+    return -1;
+  });
+  if (activeTab !== 0) throw new Error(`expected Q1 active before any pick, got tab index ${activeTab}`);
+
+  // Click first option of Q1. Pre-fix: stays on Q1 forever. Post-fix:
+  // 300ms confirm flash, then auto-advance to Q2.
+  await win.locator('[data-question-option][data-question-label="Python"]').first().click();
+  // The advance is scheduled with setTimeout(300). Wait > 300ms with
+  // generous slack for renderer scheduling under Electron load.
+  await win.waitForTimeout(600);
+
+  activeTab = await win.evaluate(() => {
+    const tabs = document.querySelectorAll('[data-testid^="question-tab-"]');
+    for (let i = 0; i < tabs.length; i++) {
+      if (tabs[i].dataset.active === 'true') return i;
+    }
+    return -1;
+  });
+  if (activeTab !== 1) {
+    throw new Error(`#287 regression: after clicking Python (Q1 single-select), expected auto-advance to Q2 (tab index 1), got ${activeTab} — togglePick's didSelectFresh closure read the stale value`);
+  }
+
+  // Verify Q1's pick persisted across the page change (not blown away by
+  // setPicks updater running after the auto-advance setTimeout).
+  const q1State = await win.evaluate((sid) => {
+    const blocks = window.__ccsmStore.getState().messagesBySession[sid] || [];
+    const qb = blocks.find((b) => b.id === 'q-auto-advance');
+    return { hasBlock: !!qb, answered: qb?.answered ?? false };
+  }, sessionId);
+  if (!q1State.hasBlock) throw new Error('question block disappeared from store');
+  if (q1State.answered) throw new Error('question block flipped to answered after one pick — should still be open until Submit');
+
+  // Click Q2's first option — auto-advance to Q3.
+  await win.locator('[data-question-option][data-question-label="esbuild"]').first().click();
+  await win.waitForTimeout(600);
+  activeTab = await win.evaluate(() => {
+    const tabs = document.querySelectorAll('[data-testid^="question-tab-"]');
+    for (let i = 0; i < tabs.length; i++) {
+      if (tabs[i].dataset.active === 'true') return i;
+    }
+    return -1;
+  });
+  if (activeTab !== 2) {
+    throw new Error(`after clicking esbuild (Q2 single-select), expected auto-advance to Q3 (tab index 2), got ${activeTab}`);
+  }
+
+  // Click Q3's first option. Q3 is the last question — no advance.
+  await win.locator('[data-question-option][data-question-label="sqlite"]').first().click();
+  await win.waitForTimeout(600);
+  activeTab = await win.evaluate(() => {
+    const tabs = document.querySelectorAll('[data-testid^="question-tab-"]');
+    for (let i = 0; i < tabs.length; i++) {
+      if (tabs[i].dataset.active === 'true') return i;
+    }
+    return -1;
+  });
+  if (activeTab !== 2) {
+    throw new Error(`Q3 is the last question, expected to stay on tab 2, got ${activeTab}`);
+  }
+
+  // Submit must be enabled now (all 3 answered) — sanity check that the
+  // visible state reached the same place as upstream's tab-click flow.
+  const submit = win.locator('[data-testid="question-submit"]');
+  if (await submit.isDisabled()) {
+    throw new Error('Submit disabled after all 3 questions answered via auto-advance — picks state lost across advances');
+  }
+
+  log('#287 — single-choice auto-advance fires from Q1→Q2→Q3, last question stays put');
+}
+
+// ---------- auq-stop-dismisses-question ----------
+// Regression for PR #365 bug 2: when the agent is interrupted via Esc / Stop
+// while waiting on an AskUserQuestion, the sticky question card must be
+// auto-dismissed (no one will answer it now). Pre-fix the card stayed sticky
+// forever with no way to close it. The fix iterates session blocks in stop()
+// and marks every unanswered question as rejected.
+async function caseAuqStopDismissesQuestion({ win, log }) {
+  const sessionId = await win.evaluate(() => {
+    const s = window.__ccsmStore.getState();
+    if (s.activeId && s.sessions.some((x) => x.id === s.activeId)) return s.activeId;
+    s.createSession({ name: 'auq-stop-probe' });
+    return window.__ccsmStore.getState().activeId;
+  });
+
+  // Seed unanswered question + running session.
+  await win.evaluate((sid) => {
+    const st = window.__ccsmStore.getState();
+    st.clearMessages(sid);
+    st.setRunning(sid, true);
+    st.appendBlocks(sid, [
+      {
+        kind: 'question',
+        id: 'q-stop-dismiss',
+        questions: [{ question: 'Pick one', options: [{ label: 'A' }, { label: 'B' }] }],
+      },
+    ]);
+  }, sessionId);
+  await win.waitForSelector('[data-question-sticky] [data-question-option]', { timeout: 5000 });
+
+  // Sanity: question is unanswered and visible.
+  const before = await win.evaluate((sid) => {
+    const blocks = window.__ccsmStore.getState().messagesBySession[sid] || [];
+    const qb = blocks.find((b) => b.id === 'q-stop-dismiss');
+    return {
+      answered: qb?.answered ?? null,
+      stickyVisible: !!document.querySelector('[data-question-sticky]'),
+    };
+  }, sessionId);
+  if (before.answered) {
+    throw new Error(`pre-stop: expected unanswered question, got answered=${before.answered}`);
+  }
+  if (!before.stickyVisible) throw new Error('pre-stop: sticky question card not visible');
+
+  // Press Esc with focus on the textarea (real-world flow). The doc-level
+  // Esc handler must fire stop() because the question is an inline
+  // role="dialog" (no data-modal-dialog) and must not block the shortcut.
+  const textarea = win.locator('textarea').first();
+  await textarea.waitFor({ state: 'visible', timeout: 5000 });
+  await textarea.click();
+  await win.evaluate(() => {
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+  });
+  await win.waitForTimeout(300);
+
+  const after = await win.evaluate((sid) => {
+    const blocks = window.__ccsmStore.getState().messagesBySession[sid] || [];
+    const qb = blocks.find((b) => b.id === 'q-stop-dismiss');
+    return {
+      interrupted: !!window.__ccsmStore.getState().interruptedSessions[sid],
+      answered: qb?.answered ?? false,
+      rejected: qb?.rejected ?? false,
+      stickyVisible: !!document.querySelector('[data-question-sticky]'),
+    };
+  }, sessionId);
+
+  if (!after.interrupted) throw new Error('post-stop: interruptedSessions flag not set — stop() did not run');
+  if (!after.answered) {
+    throw new Error('regression: unanswered question still answered=false after Esc/stop — sticky card would persist forever');
+  }
+  if (!after.rejected) {
+    throw new Error('regression: question marked answered but not rejected — should be rejected (no answer was sent)');
+  }
+  // Sticky host renders on `unanswered` predicate; once flipped to answered
+  // it should unmount on the next render.
+  if (after.stickyVisible) {
+    throw new Error('post-stop: question sticky card still in DOM after answered=true — QuestionStickyHost did not re-render');
+  }
+
+  log('PR#365 bug 2 — Esc/stop dismisses unanswered AskUserQuestion sticky');
+}
+
+// ---------- question-dismisses-on-stop-button ----------
+// Sibling to caseAuqStopDismissesQuestion: same contract, but driven by a
+// real click on the visible Stop button instead of a synthesised Esc
+// keydown. The Stop button's onClick at InputBar.tsx:1210 wires to the
+// same `stop()` function as Esc, so the markQuestionAnswered fix should
+// cover both paths — but the user reported this bug separately, so we
+// pin the contract with an explicit case to prevent any future divergence
+// (e.g. someone introducing a parallel button-only handler that bypasses
+// the question-dismiss block).
+async function caseQuestionDismissesOnStopButton({ win, log }) {
+  const sessionId = await win.evaluate(() => {
+    const s = window.__ccsmStore.getState();
+    if (s.activeId && s.sessions.some((x) => x.id === s.activeId)) return s.activeId;
+    s.createSession({ name: 'auq-stop-btn-probe' });
+    return window.__ccsmStore.getState().activeId;
+  });
+
+  // Pin English so the Stop button name resolves.
+  await win.evaluate(async () => {
+    try { if (window.__ccsmI18n && window.__ccsmI18n.language !== 'en') await window.__ccsmI18n.changeLanguage('en'); } catch {}
+  });
+
+  await win.evaluate((sid) => {
+    const st = window.__ccsmStore.getState();
+    st.clearMessages(sid);
+    st.setRunning(sid, true);
+    st.appendBlocks(sid, [
+      {
+        kind: 'question',
+        id: 'q-stop-btn',
+        questions: [{ question: 'Pick one', options: [{ label: 'A' }, { label: 'B' }] }],
+      },
+    ]);
+  }, sessionId);
+  await win.waitForSelector('[data-question-sticky] [data-question-option]', { timeout: 5000 });
+
+  // The morph button reads "Stop" while running. Same button as InputBar
+  // covers via Esc — verify the click path lands on the same stop() flow
+  // and dismisses the unanswered question.
+  const stopBtn = win.getByRole('button', { name: /^stop$/i });
+  await stopBtn.waitFor({ state: 'visible', timeout: 5000 }).catch(() => {
+    throw new Error('Stop button not visible — running state did not flip the morph button');
+  });
+  await stopBtn.click();
+  await win.waitForTimeout(300);
+
+  const after = await win.evaluate((sid) => {
+    const blocks = window.__ccsmStore.getState().messagesBySession[sid] || [];
+    const qb = blocks.find((b) => b.id === 'q-stop-btn');
+    return {
+      interrupted: !!window.__ccsmStore.getState().interruptedSessions[sid],
+      answered: qb?.answered ?? false,
+      rejected: qb?.rejected ?? false,
+      stickyVisible: !!document.querySelector('[data-question-sticky]'),
+    };
+  }, sessionId);
+
+  if (!after.interrupted) {
+    throw new Error('Stop-button click did not run stop() — interruptedSessions flag not set');
+  }
+  if (!after.answered) {
+    throw new Error('regression: clicking Stop did not dismiss the unanswered question — Stop-button onClick path bypasses markQuestionAnswered');
+  }
+  if (!after.rejected) {
+    throw new Error('Stop-button dismiss: question marked answered but not rejected — should be rejected (no answer was sent)');
+  }
+  if (after.stickyVisible) {
+    throw new Error('Stop-button click: question sticky still in DOM after answered=true — QuestionStickyHost did not re-render');
+  }
+
+  log('PR#365 — Stop button click also dismisses unanswered AskUserQuestion sticky (same path as Esc)');
+}
+
 // ---------- env-passthrough ----------
 // Was: probe-e2e-env-passthrough.mjs.
 // Auth env (ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN) flows through
@@ -1924,6 +2190,24 @@ await runHarness({
       userDataDir: 'fresh',
       run: caseAskUserQuestionRoutesViaPermissionRequest,
     },
+    // auq-single-select-auto-advance: regression for #287 (PR #365). Vitest
+    // can't catch this — RTL fireEvent flushes state updaters synchronously
+    // inside `act`, but real Playwright clicks dispatch into the Electron
+    // renderer without that wrapper, exposing the closure-vs-updater race.
+    // Pure-renderer case: no claude.exe needed.
+    { id: 'auq-single-select-auto-advance', run: caseAuqSingleSelectAutoAdvance },
+    // auq-stop-dismisses-question: regression for PR #365 bug 2. Tests the
+    // stop()-path question dismissal end-to-end — keypress dispatches at
+    // the document level, hits InputBar's doc handler, runs through the
+    // real markQuestionAnswered store action, and QuestionStickyHost must
+    // unmount the card on the resulting re-render.
+    { id: 'auq-stop-dismisses-question', run: caseAuqStopDismissesQuestion },
+    // question-dismisses-on-stop-button: sibling case driven by clicking
+    // the visible Stop morph button (same stop() path, but a different
+    // entry edge from the user's perspective). User reported this as a
+    // separate bug; pin the contract explicitly so a future patch
+    // splitting the onClick wiring can't silently break it.
+    { id: 'question-dismisses-on-stop-button', run: caseQuestionDismissesOnStopButton },
     // permission-allow-bash: requires real claude.exe to round-trip the
     // nested control_response envelope (Bug L). Fresh udd so the renderer's
     // allowAlwaysTools allow-list state from earlier cases can't auto-allow

--- a/scripts/harness-ui.mjs
+++ b/scripts/harness-ui.mjs
@@ -2064,6 +2064,110 @@ async function caseI18nSettingsZh({ win, log, registerDispose }) {
 // `window.ccsm.notify` IPC is NEVER fired. Drives `__ccsmDispatchNotification`
 // (debug seam in App.tsx) directly so the test doesn't need a real agent
 // permission request — pure renderer flow.
+// ---------- sidebar-active-row-no-pulse ----------
+// Regression for #289 (PR #365): when the agent finishes a turn for the
+// CURRENTLY ACTIVE session, the sidebar row must NOT flip to state='waiting'
+// (which drives the pulse glyph) — even when the OS-level window focus has
+// been lost (alt-tab away). Pre-fix lifecycle.ts gated the pulse on
+// `isActive && document.hasFocus()`, so alt-tabbing away while a turn was
+// in flight made the active row pulse on result, which is visual noise for
+// the row the user is already looking at. Post-fix: active session = no
+// pulse, period; background sessions still pulse.
+//
+// We exercise the production lifecycle.ts onAgentEvent handler by sending
+// the same `agent:event` IPC frame that the SDK runner emits in production
+// (electron/agent-sdk routing -> webContents.send('agent:event', ...)).
+// Pure renderer-IPC contract — no real claude.exe needed.
+async function caseSidebarActiveRowNoPulse({ app, win, log }) {
+  // Two sessions: 'sA' (active), 'sB' (background). Both started+running
+  // so the result frame's setRunning(false) actually flips state.
+  await win.evaluate(() => {
+    const store = window.__ccsmStore;
+    store.setState({
+      groups: [{ id: 'g1', name: 'G1', collapsed: false, kind: 'normal' }],
+      sessions: [
+        { id: 'sA', name: 'active-session', state: 'idle', cwd: 'C:/x', model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code' },
+        { id: 'sB', name: 'background-session', state: 'idle', cwd: 'C:/y', model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code' },
+      ],
+      activeId: 'sA',
+      messagesBySession: { sA: [], sB: [] },
+      startedSessions: { sA: true, sB: true },
+      runningSessions: { sA: true, sB: true },
+    });
+  });
+  await win.waitForTimeout(120);
+
+  // Force document.hasFocus() to return false so we exercise exactly the
+  // alt-tabbed-away scenario. This is the path that pre-fix would have
+  // pulsed the active row.
+  await win.evaluate(() => {
+    Object.defineProperty(document, 'hasFocus', {
+      configurable: true,
+      value: () => false,
+    });
+  });
+
+  // Sanity: pre-event state must NOT already be 'waiting' (otherwise we
+  // can't tell whether the no-pulse contract held).
+  const before = await win.evaluate(() => {
+    const sA = window.__ccsmStore.getState().sessions.find((s) => s.id === 'sA');
+    const sB = window.__ccsmStore.getState().sessions.find((s) => s.id === 'sB');
+    return { sA: sA?.state, sB: sB?.state };
+  });
+  if (before.sA === 'waiting' || before.sB === 'waiting') {
+    throw new Error(`pre-event: expected both sessions !waiting, got sA=${before.sA} sB=${before.sB}`);
+  }
+
+  // Dispatch a result frame for the ACTIVE session (sA). Lifecycle's
+  // onAgentEvent handler runs in the renderer; with !isActive guard the
+  // active row must NOT flip to 'waiting'. All result-frame fields beyond
+  // `type` are optional (lifecycle.ts:243-260 reads them with `?`).
+  await app.evaluate(({ BrowserWindow }, payload) => {
+    for (const w of BrowserWindow.getAllWindows()) {
+      if (!w.webContents.isDestroyed()) w.webContents.send('agent:event', payload);
+    }
+  }, {
+    sessionId: 'sA',
+    message: { type: 'result', subtype: 'success', usage: {}, modelUsage: {} },
+  });
+  await win.waitForTimeout(250);
+
+  const afterActive = await win.evaluate(() => {
+    const sA = window.__ccsmStore.getState().sessions.find((s) => s.id === 'sA');
+    return { state: sA?.state, running: !!window.__ccsmStore.getState().runningSessions['sA'] };
+  });
+  // Lifecycle's setRunning(false) must have run (proves the event reached
+  // the renderer); state must NOT be 'waiting' for the active session.
+  if (afterActive.running) {
+    throw new Error('result frame did not reach renderer — runningSessions[sA] still true');
+  }
+  if (afterActive.state === 'waiting') {
+    throw new Error(`#289 regression: active session pulsed on turn_done (state='waiting') even though it's the focused row — alt-tab unfocus path leaked back in`);
+  }
+
+  // Counter-positive: background session SHOULD still pulse. This guards
+  // the fix from over-correcting (e.g. dropping the pulse for everyone).
+  await app.evaluate(({ BrowserWindow }, payload) => {
+    for (const w of BrowserWindow.getAllWindows()) {
+      if (!w.webContents.isDestroyed()) w.webContents.send('agent:event', payload);
+    }
+  }, {
+    sessionId: 'sB',
+    message: { type: 'result', subtype: 'success', usage: {}, modelUsage: {} },
+  });
+  await win.waitForTimeout(250);
+
+  const afterBackground = await win.evaluate(() => {
+    const sB = window.__ccsmStore.getState().sessions.find((s) => s.id === 'sB');
+    return { state: sB?.state };
+  });
+  if (afterBackground.state !== 'waiting') {
+    throw new Error(`background session expected state='waiting' (pulse signal preserved), got '${afterBackground.state}' — fix over-corrected`);
+  }
+
+  log('#289 — active row stays !waiting on turn_done; background row still pulses');
+}
+
 async function caseNotifDisabledSuppress({ app, win, log }) {
   // Replace the main-process `notification:show` handler with a recorder so a
   // regression that DOES dispatch lands somewhere we can observe.
@@ -2932,6 +3036,11 @@ await runHarness({
     // spy on agent:setEffort. Pure UI, single launch, fits harness-ui.
     { id: 'effort-chip-toggle', run: caseEffortChipToggle },
     { id: 'dead-ui-cleanup', run: caseDeadUiCleanup },
+    // sidebar-active-row-no-pulse: regression for #289 (PR #365). Active
+    // session must NOT pulse on turn_done even when window focus is lost
+    // (alt-tabbed away). Pure renderer-IPC: dispatches `agent:event` from
+    // main into the renderer's lifecycle handler, no claude.exe needed.
+    { id: 'sidebar-active-row-no-pulse', run: caseSidebarActiveRowNoPulse },
     // notif-disabled-suppress: W5. Verifies the post-W1 single-gate dispatch
     // contract — enabled=false → dispatched:false, reason:'global-disabled',
     // zero notification:show IPC. Re-enabling proves recorder is wired.

--- a/src/agent/lifecycle.ts
+++ b/src/agent/lifecycle.ts
@@ -309,11 +309,13 @@ export function subscribeAgentEvents(): void {
       // duration, and per-event toggles all removed.
       turnStartedAt.delete(e.sessionId);
       const isActive = store.activeId === e.sessionId;
-      const windowFocused = typeof document !== 'undefined' && document.hasFocus();
-      const sessionFocused = isActive && windowFocused;
-      // Pulse the sidebar icon when the user isn't actively watching this
-      // session's chat. Cleared by selectSession on click.
-      if (!sessionFocused) {
+      // Pulse the sidebar icon ONLY when the user isn't actively viewing this
+      // session's chat. We previously also required `document.hasFocus()` to
+      // skip the pulse, which meant alt-tabbing away (window unfocused) and
+      // back would briefly pulse the active row — visual noise for the row
+      // the user is already looking at. Active session = no pulse, period.
+      // Cleared by selectSession on click for non-active sessions.
+      if (!isActive) {
         store.setSessionState(e.sessionId, 'waiting');
       }
       {

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -209,6 +209,9 @@ export function CommandPalette({
       <DialogPortal>
         <DialogOverlay />
         <RD.Content
+          // Marker for InputBar's global Esc handler — modal dialogs own Esc.
+          data-modal-dialog=""
+          aria-modal="true"
           onKeyDown={onKeyDown}
           onOpenAutoFocus={(e) => {
             // Let Radix's FocusScope own the focus handoff (so it knows

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -218,7 +218,7 @@ export function InputBar({ sessionId }: { sessionId: string }) {
   );
   // Action references are stable across renders in Zustand v5, so reading them
   // via getState() avoids registering listeners that would never fire anyway.
-  const { appendBlocks, markStarted, setRunning, markInterrupted, enqueueMessage, clearQueue, bumpComposerFocus, clearDiffComments, clearLastTurnEnd } =
+  const { appendBlocks, markStarted, setRunning, markInterrupted, enqueueMessage, clearQueue, bumpComposerFocus, clearDiffComments, clearLastTurnEnd, markQuestionAnswered } =
     useStore.getState();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -590,16 +590,19 @@ export function InputBar({ sessionId }: { sessionId: string }) {
   // Global Esc → stop running turn. Intentionally listens at the document
   // level so the shortcut works regardless of which surface has focus
   // (composer, chat scroll area, sidebar). Yields to:
-  //   - Open Radix dialogs (settings, command palette, CLI-missing) — they
-  //     manage their own Esc-to-close inside `[role="dialog"]`.
+  //   - Open Radix modal dialogs (settings, command palette, CLI-missing) —
+  //     they manage their own Esc-to-close. We discriminate true modals via
+  //     `[data-modal-dialog]` (set by our DialogContent + CommandPalette
+  //     wrappers) so inline widgets that also use `role="dialog"` for a11y
+  //     (AskUserQuestion sticky, CwdPopover) do NOT block Esc-to-stop.
   //   - The slash-command picker when it's open and the textarea has focus —
   //     the inline Esc handler in `onKeyDown` dismisses the picker first.
   useEffect(() => {
     function onDocKeyDown(e: KeyboardEvent) {
       if (e.key !== 'Escape') return;
       if (!running) return;
-      // Some other modal owns Escape right now.
-      if (document.querySelector('[role="dialog"]')) return;
+      // Only true modal dialogs (Radix-portaled, focus-trapped) own Esc.
+      if (document.querySelector('[data-modal-dialog]')) return;
       const ae = document.activeElement as HTMLElement | null;
       // Defer to the picker's own dismissal when it's the active surface.
       if (ae === textareaRef.current && (pickerOpen || mentionOpen)) return;
@@ -781,6 +784,25 @@ export function InputBar({ sessionId }: { sessionId: string }) {
     // queued during this turn. Otherwise the next turn would auto-send work
     // the user just decided to abandon.
     clearQueue(sessionId);
+    // Dismiss any unanswered AskUserQuestion sticky for this session — the
+    // agent is being stopped, so there's no one to receive an answer. Without
+    // this the question card would stay sticky after interrupt with no path
+    // to close it (Bug: AskUserQuestion sticky doesn't disappear on stop).
+    // We mark every unanswered question block as rejected; the per-block
+    // permission deny (if any requestId) is best-effort via the same path
+    // QuestionBlock takes when the user clicks the Cancel chip.
+    {
+      const state = useStore.getState();
+      const blocks = state.messagesBySession[sessionId] ?? [];
+      for (const b of blocks) {
+        if (b.kind === 'question' && !b.answered) {
+          if (b.requestId) {
+            void api.agentResolvePermission(sessionId, b.requestId, 'deny');
+          }
+          markQuestionAnswered(sessionId, b.id, { answers: {}, rejected: true });
+        }
+      }
+    }
     await api.agentInterrupt(sessionId);
     // Return focus to the composer so the user can type immediately
     // (matches CLI Ctrl+C behavior). The InputBar focus useEffect picks

--- a/src/components/QuestionBlock.tsx
+++ b/src/components/QuestionBlock.tsx
@@ -157,7 +157,15 @@ export function QuestionBlock({ questions, onSubmit, onReject, autoFocus = true 
   const togglePick = useCallback(
     (q: QuestionSpec, label: string) => {
       if (submitted) return;
-      let didSelectFresh = false;
+      // Compute the "fresh selection" signal BEFORE the setPicks call. The
+      // updater fn passed to setState runs during the next render commit,
+      // not synchronously when set is called — reading a `let` flag set
+      // INSIDE the updater on the line below would always observe the
+      // initial `false` value (the auto-advance condition would silently
+      // never fire in production). Tests masked this because RTL's
+      // fireEvent flushes updaters synchronously inside `act`, but real
+      // browser dispatch defers them. Read from current picks instead.
+      const didSelectFresh = !q.multiSelect && !(picks[q.question]?.has(label) ?? false);
       setPicks((prev) => {
         const next = { ...prev };
         const set = new Set(next[q.question] ?? []);
@@ -165,7 +173,6 @@ export function QuestionBlock({ questions, onSubmit, onReject, autoFocus = true 
           if (set.has(label)) set.delete(label);
           else set.add(label);
         } else {
-          if (!set.has(label)) didSelectFresh = true;
           set.clear();
           set.add(label);
         }
@@ -189,7 +196,7 @@ export function QuestionBlock({ questions, onSubmit, onReject, autoFocus = true 
         }, AUTO_ADVANCE_MS);
       }
     },
-    [active, confirming, questions.length, submitted]
+    [active, confirming, picks, questions.length, submitted]
   );
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {

--- a/src/components/ui/Dialog.tsx
+++ b/src/components/ui/Dialog.tsx
@@ -48,6 +48,11 @@ export const DialogContent = forwardRef<
       <DialogOverlay />
       <RD.Content
         ref={ref}
+        // Marker used by InputBar's global Esc handler to back off. Inline
+        // sticky widgets (AskUserQuestion, CwdPopover) also use role="dialog"
+        // for a11y but are NOT modal — they should not consume Esc-to-stop.
+        data-modal-dialog=""
+        aria-modal="true"
         className={cn(
           'fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2',
           'rounded-lg border border-border-default bg-bg-panel',

--- a/tests/inputbar-continue-after-interrupt.test.tsx
+++ b/tests/inputbar-continue-after-interrupt.test.tsx
@@ -17,8 +17,18 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, act, cleanup } from '@testing-library/react';
 import { InputBar } from '../src/components/InputBar';
 import { useStore } from '../src/stores/store';
+import { ToastProvider } from '../src/components/ui/Toast';
 
 const initial = useStore.getState();
+
+// PR #359 added a `useToast()` call in InputBar; renders need ToastProvider.
+function renderInputBar(sessionId: string) {
+  return render(
+    <ToastProvider>
+      <InputBar sessionId={sessionId} />
+    </ToastProvider>
+  );
+}
 
 function freshStoreWithSession(
   sessionId: string,
@@ -78,14 +88,14 @@ describe('InputBar: continue-after-interrupt hint (#322)', () => {
   it('does not show the hint when the last turn has not been interrupted', () => {
     freshStoreWithSession(SID, { started: true });
     stubCCSM();
-    render(<InputBar sessionId={SID} />);
+    renderInputBar(SID);
     expect(screen.queryByTestId(HINT_TID)).toBeNull();
   });
 
   it('shows the hint after markInterrupted while composer is empty + agent idle', () => {
     freshStoreWithSession(SID, { started: true });
     stubCCSM();
-    render(<InputBar sessionId={SID} />);
+    renderInputBar(SID);
     act(() => {
       useStore.getState().markInterrupted(SID);
     });
@@ -97,7 +107,7 @@ describe('InputBar: continue-after-interrupt hint (#322)', () => {
   it('hides the hint as soon as the user types a character', () => {
     freshStoreWithSession(SID, { started: true });
     stubCCSM();
-    render(<InputBar sessionId={SID} />);
+    renderInputBar(SID);
     act(() => {
       useStore.getState().markInterrupted(SID);
     });
@@ -114,7 +124,7 @@ describe('InputBar: continue-after-interrupt hint (#322)', () => {
   it('sends the literal `continue` when the hint is visible and Enter is pressed on empty composer', async () => {
     freshStoreWithSession(SID, { started: true });
     const api = stubCCSM();
-    render(<InputBar sessionId={SID} />);
+    renderInputBar(SID);
     act(() => {
       useStore.getState().markInterrupted(SID);
     });
@@ -134,7 +144,7 @@ describe('InputBar: continue-after-interrupt hint (#322)', () => {
   it('does not show the hint when the agent is currently running', () => {
     freshStoreWithSession(SID, { started: true, running: true });
     stubCCSM();
-    render(<InputBar sessionId={SID} />);
+    renderInputBar(SID);
     // Even if some prior turn was marked interrupted, a running session is
     // not an "interrupted, awaiting continue" state.
     act(() => {
@@ -146,7 +156,7 @@ describe('InputBar: continue-after-interrupt hint (#322)', () => {
   it('re-arms after a fresh interrupt following a normal send', async () => {
     freshStoreWithSession(SID, { started: true });
     const api = stubCCSM();
-    render(<InputBar sessionId={SID} />);
+    renderInputBar(SID);
     act(() => {
       useStore.getState().markInterrupted(SID);
     });

--- a/tests/inputbar-diff-comments.test.tsx
+++ b/tests/inputbar-diff-comments.test.tsx
@@ -18,6 +18,7 @@ import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, act, cleanup } from '@testing-library/react';
 import { InputBar } from '../src/components/InputBar';
+import { ToastProvider } from '../src/components/ui/Toast';
 import { useStore } from '../src/stores/store';
 
 const initial = useStore.getState();
@@ -76,7 +77,7 @@ describe('InputBar: diff-comment prepend on send', () => {
   it('forwards the raw text unchanged when there are no pending comments', async () => {
     freshStoreWithSession(SID, { started: true });
     const api = stubCCSM();
-    render(<InputBar sessionId={SID} />);
+    render(<ToastProvider><InputBar sessionId={SID} /></ToastProvider>);
     const ta = screen.getByRole('textbox');
     fireEvent.change(ta, { target: { value: 'hello' } });
     await act(async () => {
@@ -95,7 +96,7 @@ describe('InputBar: diff-comment prepend on send', () => {
       useStore.getState().addDiffComment(SID, { file: '/a/x.ts', line: 3, text: 'rename Y' });
     });
     const api = stubCCSM();
-    render(<InputBar sessionId={SID} />);
+    render(<ToastProvider><InputBar sessionId={SID} /></ToastProvider>);
     const ta = screen.getByRole('textbox');
     fireEvent.change(ta, { target: { value: 'fix it' } });
     await act(async () => {
@@ -122,7 +123,7 @@ describe('InputBar: diff-comment prepend on send', () => {
       useStore.getState().addDiffComment(SID, { file: '/q.ts', line: 1, text: 'less code' });
     });
     const api = stubCCSM();
-    render(<InputBar sessionId={SID} />);
+    render(<ToastProvider><InputBar sessionId={SID} /></ToastProvider>);
     const ta = screen.getByRole('textbox');
     fireEvent.change(ta, { target: { value: 'follow-up' } });
     act(() => {
@@ -149,7 +150,7 @@ describe('InputBar: diff-comment prepend on send', () => {
       useStore.getState().addDiffComment(SID, { file: '/a.ts', line: 2, text: 'c' });
     });
     stubCCSM();
-    render(<InputBar sessionId={SID} />);
+    render(<ToastProvider><InputBar sessionId={SID} /></ToastProvider>);
     expect(screen.getByText(/3 diff comments will be sent/i)).toBeInTheDocument();
     const ta = screen.getByRole('textbox');
     fireEvent.change(ta, { target: { value: 'go' } });
@@ -196,7 +197,7 @@ describe('InputBar: diff-comment prepend on send', () => {
     firstEl.scrollIntoView = scrollSpy as unknown as Element['scrollIntoView'];
 
     stubCCSM();
-    render(<InputBar sessionId={SID} />);
+    render(<ToastProvider><InputBar sessionId={SID} /></ToastProvider>);
     const indicator = screen.getByText(/3 diff comments will be sent/i);
     fireEvent.click(indicator);
     expect(scrollSpy).toHaveBeenCalledTimes(1);

--- a/tests/inputbar-morph-mention.test.tsx
+++ b/tests/inputbar-morph-mention.test.tsx
@@ -13,6 +13,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, act, cleanup, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { InputBar } from '../src/components/InputBar';
+import { ToastProvider } from '../src/components/ui/Toast';
 import { useStore } from '../src/stores/store';
 
 const initial = useStore.getState();
@@ -72,7 +73,7 @@ describe('InputBar: send/stop morph button', () => {
   it('renders the Send affordance when the session is idle', () => {
     freshStoreWithSession('s-morph-idle', { running: false, started: true });
     stubCCSM();
-    render(<InputBar sessionId="s-morph-idle" />);
+    render(<ToastProvider><InputBar sessionId="s-morph-idle" /></ToastProvider>);
     const morph = screen.getByRole('button', { name: /send message/i });
     expect(morph).toBeInTheDocument();
     expect(morph).toHaveAttribute('data-morph-state', 'send');
@@ -82,7 +83,7 @@ describe('InputBar: send/stop morph button', () => {
   it('morphs to the Stop affordance when the session is running', () => {
     freshStoreWithSession('s-morph-run', { running: true, started: true });
     stubCCSM();
-    render(<InputBar sessionId="s-morph-run" />);
+    render(<ToastProvider><InputBar sessionId="s-morph-run" /></ToastProvider>);
     const morph = screen.getByRole('button', { name: /^stop$/i });
     expect(morph).toBeInTheDocument();
     expect(morph).toHaveAttribute('data-morph-state', 'stop');
@@ -92,7 +93,7 @@ describe('InputBar: send/stop morph button', () => {
   it('clicking the morph button while running fires agentInterrupt', () => {
     freshStoreWithSession('s-morph-stop', { running: true, started: true });
     const api = stubCCSM();
-    render(<InputBar sessionId="s-morph-stop" />);
+    render(<ToastProvider><InputBar sessionId="s-morph-stop" /></ToastProvider>);
     const stop = screen.getByRole('button', { name: /^stop$/i });
     act(() => {
       fireEvent.click(stop);
@@ -105,7 +106,7 @@ describe('InputBar: @file mention picker', () => {
   it('opens the mention picker when the user types @', async () => {
     freshStoreWithSession('s-at', { running: false, started: true });
     stubCCSM();
-    render(<InputBar sessionId="s-at" />);
+    render(<ToastProvider><InputBar sessionId="s-at" /></ToastProvider>);
     const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
     act(() => {
       fireEvent.change(ta, { target: { value: '@' } });
@@ -125,7 +126,7 @@ describe('InputBar: @file mention picker', () => {
   it('Esc dismisses the mention picker without changing the textarea', async () => {
     freshStoreWithSession('s-at-esc', { running: false, started: true });
     stubCCSM();
-    render(<InputBar sessionId="s-at-esc" />);
+    render(<ToastProvider><InputBar sessionId="s-at-esc" /></ToastProvider>);
     const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
     act(() => {
       fireEvent.change(ta, { target: { value: '@' } });
@@ -143,7 +144,7 @@ describe('InputBar: @file mention picker', () => {
   it('Enter on a highlighted row splices @<path> into the textarea', async () => {
     freshStoreWithSession('s-at-pick', { running: false, started: true });
     stubCCSM();
-    render(<InputBar sessionId="s-at-pick" />);
+    render(<ToastProvider><InputBar sessionId="s-at-pick" /></ToastProvider>);
     const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
     act(() => {
       fireEvent.change(ta, { target: { value: '@' } });
@@ -175,7 +176,7 @@ describe('InputBar: @file mention picker', () => {
     const user = userEvent.setup();
     freshStoreWithSession('s-at-rearm', { running: false, started: true });
     stubCCSM();
-    render(<InputBar sessionId="s-at-rearm" />);
+    render(<ToastProvider><InputBar sessionId="s-at-rearm" /></ToastProvider>);
     const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
 
     await user.click(ta);

--- a/tests/inputbar-recall.test.tsx
+++ b/tests/inputbar-recall.test.tsx
@@ -15,6 +15,7 @@ import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, act, cleanup } from '@testing-library/react';
 import { InputBar } from '../src/components/InputBar';
+import { ToastProvider } from '../src/components/ui/Toast';
 import { useStore } from '../src/stores/store';
 import { clearDraft } from '../src/stores/drafts';
 import type { MessageBlock } from '../src/types';
@@ -92,7 +93,7 @@ describe('InputBar: ↑/↓ history recall (PR-N)', () => {
   it('↑ on empty composer fills the most recent user prompt', () => {
     freshStoreWithSession(SID, ['first prompt', 'second prompt', 'third prompt'], { started: true });
     stubCCSM();
-    render(<InputBar sessionId={SID} />);
+    render(<ToastProvider><InputBar sessionId={SID} /></ToastProvider>);
     const ta = getTextarea();
     expect(ta.value).toBe('');
     fireEvent.keyDown(ta, { key: 'ArrowUp' });
@@ -102,7 +103,7 @@ describe('InputBar: ↑/↓ history recall (PR-N)', () => {
   it('repeated ↑ walks backwards through history', () => {
     freshStoreWithSession(SID, ['first', 'second', 'third'], { started: true });
     stubCCSM();
-    render(<InputBar sessionId={SID} />);
+    render(<ToastProvider><InputBar sessionId={SID} /></ToastProvider>);
     const ta = getTextarea();
     fireEvent.keyDown(ta, { key: 'ArrowUp' });
     expect(ta.value).toBe('third');
@@ -115,7 +116,7 @@ describe('InputBar: ↑/↓ history recall (PR-N)', () => {
   it('↑ at the oldest prompt is a no-op (stays put)', () => {
     freshStoreWithSession(SID, ['only one'], { started: true });
     stubCCSM();
-    render(<InputBar sessionId={SID} />);
+    render(<ToastProvider><InputBar sessionId={SID} /></ToastProvider>);
     const ta = getTextarea();
     fireEvent.keyDown(ta, { key: 'ArrowUp' });
     expect(ta.value).toBe('only one');
@@ -127,7 +128,7 @@ describe('InputBar: ↑/↓ history recall (PR-N)', () => {
   it('↓ walks back toward the most recent prompt', () => {
     freshStoreWithSession(SID, ['first', 'second', 'third'], { started: true });
     stubCCSM();
-    render(<InputBar sessionId={SID} />);
+    render(<ToastProvider><InputBar sessionId={SID} /></ToastProvider>);
     const ta = getTextarea();
     fireEvent.keyDown(ta, { key: 'ArrowUp' }); // third
     fireEvent.keyDown(ta, { key: 'ArrowUp' }); // second
@@ -141,7 +142,7 @@ describe('InputBar: ↑/↓ history recall (PR-N)', () => {
   it('↓ from the most recent prompt clears the composer back to idle', () => {
     freshStoreWithSession(SID, ['first', 'second'], { started: true });
     stubCCSM();
-    render(<InputBar sessionId={SID} />);
+    render(<ToastProvider><InputBar sessionId={SID} /></ToastProvider>);
     const ta = getTextarea();
     fireEvent.keyDown(ta, { key: 'ArrowUp' });
     expect(ta.value).toBe('second');
@@ -155,7 +156,7 @@ describe('InputBar: ↑/↓ history recall (PR-N)', () => {
   it('↑ on a non-empty composer (not in recall) does NOT trigger recall', () => {
     freshStoreWithSession(SID, ['old prompt'], { started: true });
     stubCCSM();
-    render(<InputBar sessionId={SID} />);
+    render(<ToastProvider><InputBar sessionId={SID} /></ToastProvider>);
     const ta = getTextarea();
     // Simulate the user typing some draft.
     fireEvent.change(ta, { target: { value: 'draft\nmulti\nline' } });
@@ -168,7 +169,7 @@ describe('InputBar: ↑/↓ history recall (PR-N)', () => {
   it('typing while in recall exits recall mode (next ↑ restarts at newest)', () => {
     freshStoreWithSession(SID, ['first', 'second'], { started: true });
     stubCCSM();
-    render(<InputBar sessionId={SID} />);
+    render(<ToastProvider><InputBar sessionId={SID} /></ToastProvider>);
     const ta = getTextarea();
     fireEvent.keyDown(ta, { key: 'ArrowUp' }); // second
     fireEvent.keyDown(ta, { key: 'ArrowUp' }); // first
@@ -189,7 +190,7 @@ describe('InputBar: ↑/↓ history recall (PR-N)', () => {
   it('switching sessions resets the recall index', () => {
     freshStoreWithSession(SID, ['a1', 'a2'], { started: true });
     stubCCSM();
-    const { rerender } = render(<InputBar sessionId={SID} />);
+    const { rerender } = render(<ToastProvider><InputBar sessionId={SID} /></ToastProvider>);
     const taA = getTextarea();
     fireEvent.keyDown(taA, { key: 'ArrowUp' });
     fireEvent.keyDown(taA, { key: 'ArrowUp' });
@@ -218,7 +219,7 @@ describe('InputBar: ↑/↓ history recall (PR-N)', () => {
         activeId: 's-other',
       }));
     });
-    rerender(<InputBar sessionId={'s-other'} />);
+    rerender(<ToastProvider><InputBar sessionId={'s-other'} /></ToastProvider>);
     const taB = getTextarea();
     expect(taB.value).toBe('');
     // Recall index reset — first ↑ in the new session pulls the new session's
@@ -230,7 +231,7 @@ describe('InputBar: ↑/↓ history recall (PR-N)', () => {
   it('ignores empty / whitespace-only past prompts', () => {
     freshStoreWithSession(SID, ['real prompt', '   ', ''], { started: true });
     stubCCSM();
-    render(<InputBar sessionId={SID} />);
+    render(<ToastProvider><InputBar sessionId={SID} /></ToastProvider>);
     const ta = getTextarea();
     fireEvent.keyDown(ta, { key: 'ArrowUp' });
     expect(ta.value).toBe('real prompt');
@@ -239,7 +240,7 @@ describe('InputBar: ↑/↓ history recall (PR-N)', () => {
   it('does nothing when there is no user history at all', () => {
     freshStoreWithSession(SID, [], { started: true });
     stubCCSM();
-    render(<InputBar sessionId={SID} />);
+    render(<ToastProvider><InputBar sessionId={SID} /></ToastProvider>);
     const ta = getTextarea();
     fireEvent.keyDown(ta, { key: 'ArrowUp' });
     expect(ta.value).toBe('');

--- a/tests/inputbar.test.tsx
+++ b/tests/inputbar.test.tsx
@@ -12,8 +12,20 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, act, cleanup } from '@testing-library/react';
 import { InputBar } from '../src/components/InputBar';
 import { useStore } from '../src/stores/store';
+import { ToastProvider } from '../src/components/ui/Toast';
 
 const initial = useStore.getState();
+
+// PR #359 added a `useToast()` call in InputBar; component renders now
+// require a ToastProvider in the tree. Wrap once here so individual cases
+// can keep using bare <InputBar /> JSX.
+function renderWithProviders(sessionId: string) {
+  return render(
+    <ToastProvider>
+      <InputBar sessionId={sessionId} />
+    </ToastProvider>
+  );
+}
 
 function freshStoreWithSession(sessionId: string, opts: { running?: boolean; started?: boolean } = {}) {
   useStore.setState(
@@ -63,7 +75,7 @@ describe('InputBar: Esc to interrupt running turn', () => {
   it('Esc fires agentInterrupt when the session is running', () => {
     freshStoreWithSession('s-esc', { running: true, started: true });
     const api = stubCCSM();
-    render(<InputBar sessionId="s-esc" />);
+    renderWithProviders("s-esc");
     act(() => {
       fireEvent.keyDown(document, { key: 'Escape' });
     });
@@ -75,21 +87,25 @@ describe('InputBar: Esc to interrupt running turn', () => {
   it('Esc is a no-op when the session is NOT running', () => {
     freshStoreWithSession('s-idle', { running: false, started: true });
     const api = stubCCSM();
-    render(<InputBar sessionId="s-idle" />);
+    renderWithProviders("s-idle");
     act(() => {
       fireEvent.keyDown(document, { key: 'Escape' });
     });
     expect(api.agentInterrupt).not.toHaveBeenCalled();
   });
 
-  it('Esc yields to an open Radix dialog (lets the dialog close itself)', () => {
+  it('Esc yields to an open modal dialog (lets the dialog close itself)', () => {
     freshStoreWithSession('s-modal', { running: true, started: true });
     const api = stubCCSM();
-    render(<InputBar sessionId="s-modal" />);
-    // Inject a fake dialog element — the global handler must back off when one
-    // is present so settings/command-palette Esc-to-close still works.
+    renderWithProviders("s-modal");
+    // Inject a fake modal dialog — the global handler must back off when one
+    // is present so settings/command-palette Esc-to-close still works. Inline
+    // widgets that use `role="dialog"` for a11y (AskUserQuestion sticky,
+    // CwdPopover) are explicitly NOT modal — they lack `data-modal-dialog`
+    // and must not block the global Esc-to-stop shortcut.
     const fakeDialog = document.createElement('div');
     fakeDialog.setAttribute('role', 'dialog');
+    fakeDialog.setAttribute('data-modal-dialog', '');
     document.body.appendChild(fakeDialog);
     try {
       act(() => {
@@ -100,13 +116,80 @@ describe('InputBar: Esc to interrupt running turn', () => {
       fakeDialog.remove();
     }
   });
+
+  it('Esc still interrupts when an inline role="dialog" widget is present (e.g. AskUserQuestion sticky)', () => {
+    // Regression: before this fix, ANY [role="dialog"] in the DOM blocked
+    // the global Esc-to-stop. AskUserQuestion sticky and CwdPopover both
+    // legitimately use role="dialog" for a11y but are NOT modal — Esc must
+    // still interrupt the running turn even when one is mounted.
+    freshStoreWithSession('s-inline', { running: true, started: true });
+    const api = stubCCSM();
+    renderWithProviders("s-inline");
+    const fakeInlineDialog = document.createElement('div');
+    fakeInlineDialog.setAttribute('role', 'dialog');
+    // No data-modal-dialog marker — this is the inline-widget shape.
+    document.body.appendChild(fakeInlineDialog);
+    try {
+      act(() => {
+        fireEvent.keyDown(document, { key: 'Escape' });
+      });
+      expect(api.agentInterrupt).toHaveBeenCalledWith('s-inline');
+    } finally {
+      fakeInlineDialog.remove();
+    }
+  });
+
+  it('Esc fires interrupt when textarea has focus (no picker, no modal)', () => {
+    // Regression for the report "焦点在 textarea 时按 Esc 无法 interrupt".
+    // Doc-level handler must still fire because the textarea's own onKeyDown
+    // does not consume Esc when no picker / mention / modal is open.
+    freshStoreWithSession('s-ta', { running: true, started: true });
+    const api = stubCCSM();
+    renderWithProviders("s-ta");
+    const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
+    ta.focus();
+    expect(document.activeElement).toBe(ta);
+    act(() => {
+      fireEvent.keyDown(document, { key: 'Escape' });
+    });
+    expect(api.agentInterrupt).toHaveBeenCalledWith('s-ta');
+  });
+
+  it('interrupt clears unanswered AskUserQuestion sticky for the session', () => {
+    // Regression: before this fix, the sticky AskUserQuestion card would
+    // persist after Esc / Stop because the question block stayed unanswered
+    // in the store, even though the agent had been interrupted.
+    const sessionId = 's-q-clear';
+    freshStoreWithSession(sessionId, { running: true, started: true });
+    useStore.setState({
+      messagesBySession: {
+        [sessionId]: [
+          {
+            kind: 'question',
+            id: 'q-1',
+            questions: [{ question: 'Pick one', options: [{ label: 'A' }] }]
+          }
+        ]
+      }
+    });
+    const api = stubCCSM();
+    renderWithProviders(sessionId);
+    act(() => {
+      fireEvent.keyDown(document, { key: 'Escape' });
+    });
+    expect(api.agentInterrupt).toHaveBeenCalledWith(sessionId);
+    const blocks = useStore.getState().messagesBySession[sessionId] ?? [];
+    const q = blocks.find((b) => b.id === 'q-1');
+    expect(q && q.kind === 'question' && q.answered).toBe(true);
+    expect(q && q.kind === 'question' && q.rejected).toBe(true);
+  });
 });
 
 describe('InputBar: send-while-running enqueues into FIFO', () => {
   it('typing + Send while running enqueues instead of calling agentSend', () => {
     freshStoreWithSession('s-q', { running: true, started: true });
     const api = stubCCSM();
-    render(<InputBar sessionId="s-q" />);
+    renderWithProviders("s-q");
     const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
     fireEvent.change(ta, { target: { value: 'queued thought' } });
     // Press Enter to submit (existing send keybind).
@@ -126,14 +209,14 @@ describe('InputBar: send-while-running enqueues into FIFO', () => {
       useStore.getState().enqueueMessage('s-chip', { text: 'first', attachments: [] });
       useStore.getState().enqueueMessage('s-chip', { text: 'second', attachments: [] });
     });
-    render(<InputBar sessionId="s-chip" />);
+    renderWithProviders("s-chip");
     expect(screen.getByText('+2 queued')).toBeInTheDocument();
   });
 
   it('Stop clears the queue (CLI Ctrl+C behavior)', async () => {
     freshStoreWithSession('s-stop', { running: true, started: true });
     const api = stubCCSM();
-    render(<InputBar sessionId="s-stop" />);
+    renderWithProviders("s-stop");
     act(() => {
       useStore.getState().enqueueMessage('s-stop', { text: 'pending', attachments: [] });
     });
@@ -152,7 +235,7 @@ describe('InputBar: textarea remains editable while running', () => {
   it('does not set the disabled attribute on the textarea during a running turn', () => {
     freshStoreWithSession('s-edit', { running: true, started: true });
     stubCCSM();
-    render(<InputBar sessionId="s-edit" />);
+    renderWithProviders("s-edit");
     const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
     expect(ta.disabled).toBe(false);
     fireEvent.change(ta, { target: { value: 'still typing' } });


### PR DESCRIPTION
## Summary

Four small but visible UX bugs reported via dogfood, batched together because they sit in adjacent surfaces (InputBar + QuestionBlock + lifecycle pulse).

### Bug 1 — Esc doesn't interrupt running turn from textarea focus

**Root cause:** doc-level Esc handler in `InputBar.tsx` returns early on `document.querySelector('[role="dialog"]')`. Both `QuestionBlock` and `CwdPopover` set `role="dialog"` for a11y but are NOT modal — their mere presence silently disabled Esc-to-stop everywhere, including from the composer.

**Fix:** discriminate true modals via a new `data-modal-dialog` marker, set by our `DialogContent` wrapper (`src/components/ui/Dialog.tsx`) + `CommandPalette` (which uses `RD.Content` directly). Doc handler now ignores inline a11y dialogs.

### Bug 2 — AskUserQuestion sticky doesn't disappear on interrupt

**Root cause:** `stop()` only flipped store flags + IPC-interrupted; the unanswered question block stayed in `messagesBySession`, so `QuestionStickyHost` kept rendering it. User saw a permanently sticky card with no way to dismiss.

**Fix:** in `stop()`, iterate session blocks, mark every unanswered `kind: 'question'` as rejected, and best-effort deny any pending `requestId` permission. Mirrors what `QuestionBlock`'s Cancel chip does, but driven by the interrupt path.

### Bug 3 — Single-choice auto-advance never fires in production

**Root cause:** classic React state-updater closure trap.

```ts
let didSelectFresh = false;
setPicks((prev) => { ...; if (!set.has(label)) didSelectFresh = true; ... });
if (!q.multiSelect && didSelectFresh && active < questions.length - 1 && ...) {
  // schedule advance
}
```

The setPicks updater runs during the next render commit, not synchronously. By the time the `if` check executes, `didSelectFresh` is still `false`. Tests passed because `fireEvent` inside `act` flushes updaters synchronously — real browser dispatch defers them.

**Fix:** compute `didSelectFresh` from the current `picks` state BEFORE calling `setPicks`. Add `picks` to the useCallback deps.

### Bug 4 — Active session row pulses on agent reply

**Root cause:** `lifecycle.ts` turn_done path triggered sidebar pulse whenever `document.hasFocus()` was false, even when the session was active. Alt-tab away and back, and the row the user is already looking at pulses briefly.

**Fix:** check active-ness only. `if (!isActive) setSessionState(id, 'waiting')`. Background sessions still pulse; the active row never does.

## Files

- `src/components/InputBar.tsx` — `data-modal-dialog` selector + question-dismiss in `stop()`
- `src/components/ui/Dialog.tsx` — set `data-modal-dialog` + `aria-modal="true"` on `RD.Content`
- `src/components/CommandPalette.tsx` — same markers on its inline `RD.Content`
- `src/components/QuestionBlock.tsx` — fix updater-closure bug, recompute `didSelectFresh` upfront
- `src/agent/lifecycle.ts` — drop `windowFocused` check from turn_done pulse gate
- 5 `tests/inputbar-*.tsx` files — wrap renders in `ToastProvider` (PR #359 broke these on `working`; not introduced here)

## Test plan

- [x] `npx vitest run tests/inputbar.test.tsx` — 10/10 PASS (3 new cases: textarea-focus Esc, inline-dialog passthrough, interrupt-clears-question)
- [x] `npx vitest run tests/question-block.test.tsx` — 13/13 PASS (existing auto-advance tests still pass; production fix doesn't change RTL behavior)
- [x] `npx vitest run tests/inputbar-continue-after-interrupt.test.tsx tests/inputbar-recall.test.tsx tests/inputbar-diff-comments.test.tsx` — PASS after ToastProvider wrap
- [x] Full vitest: 845/848 PASS. 3 failures all unrelated (better-sqlite3 native binding NODE_MODULE_VERSION mismatch + missing `@testing-library/user-event` dep on `tests/inputbar-morph-mention`); same 3 fail on origin/working — went from 31 failures → 3.
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean (3 pre-existing webpack size warnings)
- [ ] Dogfood self-verify: Esc-from-textarea-focus, question-dismiss-on-stop, single-choice auto-advance in 2-question tool_use, active-session pulse suppressed (user to verify in dev app at port 4100)

## Commits

1. `fix(input): Esc interrupts from textarea focus + dismisses unanswered question on stop` (bugs 1+2 + test infra)
2. `fix(question): single-choice auto-advance fires in production builds` (bug 3)
3. `fix(sidebar): never pulse the active session row` (bug 4)

Bugs 5 (focus coordination across question/permission/textarea) and 6 (slash picker shows skill/plugin commands) are split into a follow-up PR — different file scopes, plus bug 5 needs cross-component focus orchestration that warrants its own design pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)