### PR TITLE
fix(import): reuse JSONL UUID as ccsm runner id

### DIFF
--- a/scripts/harness-restore.mjs
+++ b/scripts/harness-restore.mjs
@@ -1101,7 +1101,23 @@ async function caseImportSession({ log, registerDispose }) {
     if (!hasUser || !hasAssistant) {
       throw new Error(`Bug A: hydrated blocks missing expected text (user=${hasUser}, assistant=${hasAssistant}); blocks=${JSON.stringify(hydrated.blocks)}`);
     }
-    log(`imported clean session; sub-agent + sidechain + ccsm-temp correctly filtered; ${hydrated.blocks.length} blocks hydrated`);
+
+    // Task #292: ccsm session.id must equal the JSONL filename UUID. Without
+    // this, the SDK's first init frame fires a `session_id_mismatch`
+    // diagnostic on resume and the in-app id forever drifts from the
+    // on-disk transcript path. Assert both: the id matches the planted
+    // sid, and no mismatch diagnostic was pushed during import.
+    if (hydrated.sid !== CLEAN_SID) {
+      throw new Error(`Task #292 regression: ccsm session.id (${hydrated.sid}) != JSONL filename UUID (${CLEAN_SID})`);
+    }
+    const mismatchDiagnostics = await win.evaluate(() => {
+      const s = window.__ccsmStore.getState();
+      return (s.diagnostics ?? []).filter((d) => d.code === 'session_id_mismatch');
+    });
+    if (mismatchDiagnostics.length > 0) {
+      throw new Error(`Task #292 regression: session_id_mismatch diagnostic fired during import: ${JSON.stringify(mismatchDiagnostics)}`);
+    }
+    log(`imported clean session; sub-agent + sidechain + ccsm-temp correctly filtered; ${hydrated.blocks.length} blocks hydrated; ccsm.id == JSONL UUID; no session_id_mismatch`);
   } finally {
     closed = true;
     try { await app.close(); } catch {}

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -1168,13 +1168,22 @@ export const useStore = create<State & Actions>((set, get) => ({
 
   importSession: ({ name, cwd, groupId, resumeSessionId, projectDir }) => {
     const { sessions, groups, model, models, connection } = get();
-    // Imported sessions get a fresh local UUID (not the JSONL filename UUID)
-    // so importing the same transcript twice doesn't collide. The original
-    // CLI sid lives on as `resumeSessionId` and is forwarded to the SDK on
-    // first send; the SDK is free to allocate a fresh sid for the resumed
-    // conversation, which we then capture and pass back as our session id
-    // on subsequent spawns (see startSession.ts).
-    const id = newSessionId();
+    // Re-importing the same transcript: just re-select the existing row.
+    // The JSONL UUID uniquely identifies the conversation, and our session
+    // record already holds it as `id` (see below), so a duplicate import
+    // becomes a no-op that focuses the session the user already has.
+    const existing = sessions.find((s) => s.id === resumeSessionId);
+    if (existing) {
+      set({ activeId: existing.id, focusedGroupId: null });
+      return existing.id;
+    }
+    // Imported sessions adopt the JSONL filename UUID as the ccsm runner id
+    // (same invariant fresh sessions follow: ccsm id == CLI session UUID ==
+    // JSONL filename UUID). This keeps the SDK's reported session_id, the
+    // on-disk transcript path, and our in-app id in lockstep — without it
+    // `electron/agent-sdk/sessions.ts` fires a `session_id_mismatch`
+    // diagnostic on the first SDK init frame after resume.
+    const id = resumeSessionId;
     let initialModel = model;
     if (!initialModel) initialModel = connection?.model ?? '';
     if (!initialModel) initialModel = models[0]?.id ?? '';

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -1033,6 +1033,90 @@ describe('store: importSession synthesis path', () => {
   });
 });
 
+describe('store: importSession reuses JSONL UUID', () => {
+  // Task #292: imported sessions must adopt the JSONL filename UUID as their
+  // ccsm runner id, otherwise the SDK's first init frame triggers a
+  // `session_id_mismatch` diagnostic and the in-app id diverges from the
+  // on-disk transcript filename (breaking the task #22 invariant that
+  // ccsm id == CLI sid == JSONL filename UUID).
+  it('uses resumeSessionId as the ccsm session id', () => {
+    useStore.setState({
+      groups: [{ id: 'g1', name: 'G', collapsed: false, kind: 'normal' }],
+      sessions: [],
+      activeId: ''
+    });
+    const id = useStore.getState().importSession({
+      name: 'Imported',
+      cwd: '/tmp/imp',
+      groupId: 'g1',
+      resumeSessionId: 'jsonl-uuid-aaaa'
+    });
+    expect(id).toBe('jsonl-uuid-aaaa');
+    const s = useStore.getState();
+    const session = s.sessions.find((x) => x.id === 'jsonl-uuid-aaaa');
+    expect(session).toBeDefined();
+    expect(session!.id).toBe('jsonl-uuid-aaaa');
+    expect(session!.resumeSessionId).toBe('jsonl-uuid-aaaa');
+    expect(s.activeId).toBe('jsonl-uuid-aaaa');
+  });
+
+  it('importing the same transcript twice de-dupes onto the existing session', () => {
+    useStore.setState({
+      groups: [{ id: 'g1', name: 'G', collapsed: false, kind: 'normal' }],
+      sessions: [],
+      activeId: 'something-else'
+    });
+    const first = useStore.getState().importSession({
+      name: 'Imported',
+      cwd: '/tmp/imp',
+      groupId: 'g1',
+      resumeSessionId: 'dup-uuid'
+    });
+    expect(useStore.getState().sessions).toHaveLength(1);
+
+    // Switch active off so we can verify importSession re-selects.
+    useStore.setState({ activeId: 'something-else' });
+
+    const second = useStore.getState().importSession({
+      name: 'Imported again',
+      cwd: '/tmp/imp-other',
+      groupId: 'g1',
+      resumeSessionId: 'dup-uuid'
+    });
+    expect(second).toBe(first);
+    const s = useStore.getState();
+    expect(s.sessions).toHaveLength(1);
+    expect(s.activeId).toBe('dup-uuid');
+    // Original session record untouched (name, cwd not overwritten).
+    expect(s.sessions[0].name).toBe('Imported');
+    expect(s.sessions[0].cwd).toBe('/tmp/imp');
+  });
+
+  it('importing a different resumeSessionId adds a new session', () => {
+    useStore.setState({
+      groups: [{ id: 'g1', name: 'G', collapsed: false, kind: 'normal' }],
+      sessions: [],
+      activeId: ''
+    });
+    useStore.getState().importSession({
+      name: 'A',
+      cwd: '/tmp/a',
+      groupId: 'g1',
+      resumeSessionId: 'uuid-A'
+    });
+    useStore.getState().importSession({
+      name: 'B',
+      cwd: '/tmp/b',
+      groupId: 'g1',
+      resumeSessionId: 'uuid-B'
+    });
+    const s = useStore.getState();
+    expect(s.sessions).toHaveLength(2);
+    expect(s.activeId).toBe('uuid-B');
+    expect(s.sessions.map((x) => x.id).sort()).toEqual(['uuid-A', 'uuid-B']);
+  });
+});
+
 describe('framesToBlocks', () => {
   it('returns [] for empty input', () => {
     expect(framesToBlocks([])).toEqual([]);


### PR DESCRIPTION
## Root cause (task #292)

User report: after importing a session, the agent's first reply triggers
`SDK assigned session_id X but ccsm runner id is Y. JSONL transcript will not match in-app id.`

`src/stores/store.ts` `importSession` was minting a **fresh random UUID** for the ccsm runner id (`const id = newSessionId()`) while the JSONL filename UUID lived only on `resumeSessionId`. On the first SDK init frame after resume the SDK reports its session_id (= JSONL UUID), which never matches our random runner id, so `electron/agent-sdk/sessions.ts:514-526` fires the `session_id_mismatch` diagnostic — and nobody writes the SDK sid back, so every subsequent spawn re-fires it.

This directly violates the invariant task #22 established: **ccsm session id == CLI sid == JSONL filename UUID**. Task #22 unified the fresh-session path; the import path was missed.

## Fix

### Part 1 — adopt the JSONL UUID as the ccsm runner id
`importSession` uses `resumeSessionId` as the new session's `id`. The SDK's reported sid now matches our runner id by construction; the diagnostic stops firing on the import path.

### Part 2 — dedupe re-import (user decision: option c, reuse existing)
Re-importing the same transcript was previously creating a second row. Now it no-ops: we look up the existing session by `id === resumeSessionId`, switch `activeId` to it, and return its id. Original record (name, cwd, etc.) is left untouched. New `resumeSessionId`s still create new sessions normally.

### Part 3 — diagnostic kept
`session_id_mismatch` in `electron/agent-sdk/sessions.ts` is preserved as-is — it's still a valid drift detector for other scenarios. The fix removes the *cause* on the import path, not the detector.

## Test coverage

**vitest** (`tests/store.test.ts`, 3 new cases):
- `importSession` returns `resumeSessionId` and stores it as `session.id`
- Re-importing the same transcript doesn't grow `sessions[]`; it switches `activeId`; original record fields aren't overwritten
- Distinct `resumeSessionId`s still create separate sessions

**e2e** (`scripts/harness-restore.mjs --only=import-session`, extended in place per harness-prefer-harness rule — no new probe):
- Asserts `ccsm session.id === CLEAN_SID` (JSONL filename UUID)
- Asserts no `session_id_mismatch` diagnostic in `store.diagnostics` after import

Both pass locally.

## Links
- Closes task #292
- Restores invariant established in task #22 (fresh-session path UUID unification)