### PR TITLE
refactor(effort): optimistic 6-tier + auto-fallback on CLI reject

### DIFF
--- a/electron/agent-sdk/sessions.ts
+++ b/electron/agent-sdk/sessions.ts
@@ -42,7 +42,6 @@ import type {
   ExitHandler,
   PermissionRequestHandler,
   DiagnosticHandler,
-  ModelInfoHandler,
   AgentMessage,
 } from '../agent/sessions';
 import { translateSdkMessage, type SdkMessageLike } from './sdk-message-translator';
@@ -64,7 +63,12 @@ type CanUseToolDecision =
   | { allow: false; deny_reason?: string };
 
 import { filterToolInputByAcceptedHunks } from '../agent/partial-write';
-import { projectEffortToWire, thinkingTokensForLevel } from '../../src/agent/effort';
+import {
+  projectEffortToWire,
+  thinkingTokensForLevel,
+  nextLowerEffort,
+  isEffortRejectionError,
+} from '../../src/agent/effort';
 
 type EffortLevel = 'off' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 
@@ -288,7 +292,6 @@ export class SdkSessionRunner {
     private readonly onExit: ExitHandler,
     private readonly onPermissionRequest: PermissionRequestHandler,
     private readonly onDiagnostic: DiagnosticHandler = () => {},
-    private readonly onModelInfo: ModelInfoHandler = () => {},
   ) {}
 
   /**
@@ -389,160 +392,283 @@ export class SdkSessionRunner {
     // value is the single source of truth — the bundled CLI's
     // settings.json default doesn't get to second-guess us. Mirrors the
     // VS Code extension's wire path.
-    const effortLevel: EffortLevel = opts.effortLevel ?? 'high';
-    const wire = projectEffortToWire(effortLevel);
-    this.effortLevel = effortLevel;
+    //
+    // Optimistic gating: ccsm UI never disables effort tiers. If the CLI
+    // rejects the user-selected tier as unsupported for the current model
+    // (typical alias surface: `opus[1m]` -> Opus 4.7 1M which has different
+    // tier ceilings than the alias regex would suggest), we auto-downgrade
+    // one tier at a time (max -> xhigh -> ... -> off) and retry. The
+    // chip's visible label in StatusBar stays at the user-selected tier;
+    // each downgrade emits a diagnostic.
+    const userEffort: EffortLevel = opts.effortLevel ?? 'high';
+    this.effortLevel = userEffort;
 
-    this.query = sdk.query({
-      prompt: this.makeInputIterable(),
-      options: {
-        cwd: resolveCwd(opts.cwd),
-        env: buildSdkEnv({
-          configDir: resolveClaudeConfigDir(opts.configDir),
-          envOverrides: opts.envOverrides,
-        }),
-        model: opts.model,
-        permissionMode: sdkPermissionMode,
-        // Always pass allowDangerouslySkipPermissions: true so users can
-        // switch to bypassPermissions mid-session via the chip without
-        // restarting. The SDK gate is one-way: the launch flag is only
-        // required to ENTER bypassPermissions; switching out of bypass
-        // needs no flag. Without this, sessions launched in `default`
-        // mode hit "was not launched with --dangerously-skip-permissions"
-        // when the user clicks the bypass chip, surfacing as a vague
-        // "Agent unresponsive" toast.
-        allowDangerouslySkipPermissions: true,
-        resume: opts.resumeSessionId,
-        sessionId: presetSessionId,
-        pathToClaudeCodeExecutable: binaryPath,
-        // 6-tier effort+thinking chip → SDK options. `thinking: 'disabled'`
-        // when the chip is Off, `'adaptive'` (Claude decides budget) for
-        // every other tier. `effort` carries the actual tier label and is
-        // omitted when Off (the SDK's model-default is then irrelevant
-        // because thinking is disabled). See src/agent/effort.ts for the
-        // mapping table.
-        thinking: wire.thinking,
-        effort: wire.effort,
-        canUseTool: (toolName, input, ctx) => this.handleCanUseTool(toolName, input, ctx),
-        // PreToolUse hook (#94): the CLI's local rule engine handles built-in
-        // tools (Bash/Write/Edit/...) entirely client-side and only routes
-        // "ask" tools (AskUserQuestion / ExitPlanMode) through canUseTool.
-        // Without an external signal, Bash in `default` mode auto-allows
-        // based on the CLI's safe-command heuristics — so the renderer's
-        // PermissionPromptBlock never renders and probes can't assert the
-        // permission flow ran. The legacy wrapper used `--pretool-use-hook`
-        // to force every tool through our handler; the SDK exposes the same
-        // mechanism via `options.hooks`. Returning `permissionDecision:'ask'`
-        // makes the CLI defer to canUseTool. PASSTHROUGH_TOOLS get an
-        // explicit `allow` so we don't double-prompt over the renderer's
-        // own AskUserQuestion / ExitPlanMode UI (which uses canUseTool too;
-        // the canUseTool short-circuit at the top of handleCanUseTool stays
-        // as defence-in-depth).
-        hooks: {
-          PreToolUse: [
-            {
-              matcher: '.*',
-              hooks: [this.makePreToolUseHook()],
-            },
-          ],
-        },
-        // Match the legacy spawner: we want partial-message streaming so
-        // long replies don't appear frozen.
-        includePartialMessages: true,
-        abortController: this.abort,
-      },
+    // Spawn the first attempt synchronously so `start()` returns immediately
+    // (matching the legacy contract: manager.ts races its first-event signal
+    // against an 800ms timeout AFTER start() resolves). The retry loop lives
+    // entirely inside the spawned consumer chain — see `attemptRun` below.
+    this.consumer = this.attemptRun(sdk, {
+      sdkPermissionMode,
+      presetSessionId,
+      binaryPath,
+      cwd: opts.cwd,
+      configDir: resolveClaudeConfigDir(opts.configDir),
+      envOverrides: opts.envOverrides,
+      model: opts.model,
+      resumeSessionId: opts.resumeSessionId,
+      userEffort,
+      currentEffort: userEffort,
     });
+  }
 
-    // Drain the SDK's outbound stream into ccsm's renderer event channel.
-    // Errors from the iterator are surfaced via onExit; see the catch below.
-    const query = this.query;
+  private async attemptRun(
+    sdk: typeof import('@anthropic-ai/claude-agent-sdk'),
+    ctx: {
+      sdkPermissionMode: ReturnType<typeof toSdkPermissionMode>;
+      presetSessionId: string | undefined;
+      binaryPath: string | undefined;
+      cwd: string;
+      configDir: string;
+      envOverrides: Record<string, string> | undefined;
+      model: string | undefined;
+      resumeSessionId: string | undefined;
+      userEffort: EffortLevel;
+      currentEffort: EffortLevel;
+    },
+  ): Promise<void> {
+    let attemptedDowngrade = false;
+    // Attempt loop: tries up to 6 tiers (max -> off). Each iteration sets
+    // up the consumer; on effort-rejection at the initial handshake we
+    // tear down and retry. Any non-effort error or stream-mid error is
+    // surfaced normally via onExit.
+    while (true) {
+      if (this.disposed) return;
+      // Refresh abort controller each retry — the previous one is wired to
+      // the torn-down query.
+      if (!this.abort) this.abort = new AbortController();
+      const wire = projectEffortToWire(ctx.currentEffort);
 
-    // Pull per-model capability metadata (notably `supportedEffortLevels`)
-    // from the SDK's initialize control_response. The promise resolves once
-    // the CLI has acknowledged the initialize handshake — at that point the
-    // SDK has the full ModelInfo[] available. Fire-and-forget: a failure
-    // here just means the StatusBar effort chip falls back to its hardcoded
-    // model→tier table (src/agent/effort.ts).
-    void (async () => {
-      try {
-        type SdkModelInfo = {
-          value?: unknown;
-          supportedEffortLevels?: unknown;
-        };
-        const supportedModels = (
-          query as unknown as { supportedModels?: () => Promise<SdkModelInfo[]> }
-        ).supportedModels;
-        if (typeof supportedModels !== 'function') return;
-        const models = await supportedModels.call(query);
-        if (this.disposed || !Array.isArray(models)) return;
-        const allowed = new Set(['low', 'medium', 'high', 'xhigh', 'max']);
-        const out = models
-          .map((m) => {
-            const id = typeof m?.value === 'string' ? m.value : null;
-            if (!id) return null;
-            const raw = m?.supportedEffortLevels;
-            const tiers = Array.isArray(raw)
-              ? raw.filter(
-                  (t): t is 'low' | 'medium' | 'high' | 'xhigh' | 'max' =>
-                    typeof t === 'string' && allowed.has(t),
-                )
-              : undefined;
-            return { modelId: id, supportedEffortLevels: tiers };
-          })
-          .filter((x): x is { modelId: string; supportedEffortLevels: ('low'|'medium'|'high'|'xhigh'|'max')[] | undefined } => x !== null);
-        if (out.length > 0) this.onModelInfo({ models: out });
-      } catch (err) {
+      const query = sdk.query({
+        prompt: this.makeInputIterable(),
+        options: {
+          cwd: resolveCwd(ctx.cwd),
+          env: buildSdkEnv({
+            configDir: ctx.configDir,
+            envOverrides: ctx.envOverrides,
+          }),
+          model: ctx.model,
+          permissionMode: ctx.sdkPermissionMode,
+          // Always pass allowDangerouslySkipPermissions: true so users can
+          // switch to bypassPermissions mid-session via the chip without
+          // restarting. The SDK gate is one-way: the launch flag is only
+          // required to ENTER bypassPermissions; switching out of bypass
+          // needs no flag. Without this, sessions launched in `default`
+          // mode hit "was not launched with --dangerously-skip-permissions"
+          // when the user clicks the bypass chip, surfacing as a vague
+          // "Agent unresponsive" toast.
+          allowDangerouslySkipPermissions: true,
+          resume: ctx.resumeSessionId,
+          sessionId: ctx.presetSessionId,
+          pathToClaudeCodeExecutable: ctx.binaryPath,
+          // 6-tier effort+thinking chip → SDK options. `thinking: 'disabled'`
+          // when the chip is Off, `'adaptive'` (Claude decides budget) for
+          // every other tier. `effort` carries the actual tier label and is
+          // omitted when Off (the SDK's model-default is then irrelevant
+          // because thinking is disabled). See src/agent/effort.ts for the
+          // mapping table.
+          thinking: wire.thinking,
+          effort: wire.effort,
+          canUseTool: (toolName, input, c) => this.handleCanUseTool(toolName, input, c),
+          // PreToolUse hook (#94): the CLI's local rule engine handles built-in
+          // tools (Bash/Write/Edit/...) entirely client-side and only routes
+          // "ask" tools (AskUserQuestion / ExitPlanMode) through canUseTool.
+          // Without an external signal, Bash in `default` mode auto-allows
+          // based on the CLI's safe-command heuristics — so the renderer's
+          // PermissionPromptBlock never renders and probes can't assert the
+          // permission flow ran. The legacy wrapper used `--pretool-use-hook`
+          // to force every tool through our handler; the SDK exposes the same
+          // mechanism via `options.hooks`. Returning `permissionDecision:'ask'`
+          // makes the CLI defer to canUseTool. PASSTHROUGH_TOOLS get an
+          // explicit `allow` so we don't double-prompt over the renderer's
+          // own AskUserQuestion / ExitPlanMode UI (which uses canUseTool too;
+          // the canUseTool short-circuit at the top of handleCanUseTool stays
+          // as defence-in-depth).
+          hooks: {
+            PreToolUse: [
+              {
+                matcher: '.*',
+                hooks: [this.makePreToolUseHook()],
+              },
+            ],
+          },
+          // Match the legacy spawner: we want partial-message streaming so
+          // long replies don't appear frozen.
+          includePartialMessages: true,
+          abortController: this.abort,
+        },
+      });
+      this.query = query;
+
+      // Probe the initialize handshake before committing to the consumer
+      // loop. Effort rejections from the CLI surface here (control_response
+      // with subtype:"error") as a rejection from .next(); we tear down and
+      // retry one tier lower. Any other error or success falls through to
+      // the production consumer path.
+      const probe = await this.probeFirstMessage(query);
+
+      if (probe.kind === 'effort-rejected') {
+        const downgrade = nextLowerEffort(ctx.currentEffort);
+        try { query.close(); } catch { /* ignore */ }
+        this.query = null;
+        this.abort = null;
+        if (downgrade === null) {
+          // Already at 'off'; surface the original error via onExit.
+          this.onExit({ error: probe.error });
+          this.cleanupAfterExit();
+          return;
+        }
         this.onDiagnostic({
           level: 'warn',
-          code: 'supported_models_failed',
-          message: `query.supportedModels() failed: ${err instanceof Error ? err.message : String(err)}`,
+          code: 'effort_downgrade_on_launch',
+          message: `Model rejected effort=${ctx.currentEffort} at launch (${probe.error}); retrying with ${downgrade}.`,
+        });
+        attemptedDowngrade = true;
+        ctx.currentEffort = downgrade;
+        // Note: we keep `this.effortLevel = userEffort` unchanged — the chip
+        // continues to render the user-selected tier even though the runner
+        // is now at the downgraded one.
+        continue;
+      }
+
+      if (probe.kind === 'other-error') {
+        this.query = null;
+        this.abort = null;
+        this.onExit({ error: probe.error });
+        this.cleanupAfterExit();
+        return;
+      }
+
+      // Success path.
+      if (attemptedDowngrade) {
+        this.onDiagnostic({
+          level: 'warn',
+          code: 'effort_downgraded_active',
+          message: `Effort level downgraded to ${ctx.currentEffort} (user selected ${ctx.userEffort}); chip label unchanged.`,
         });
       }
-    })();
+      await this.runConsumer(probe.iterator, probe.first);
+      return;
+    }
+  }
 
-    this.consumer = (async () => {
-      try {
-        for await (const msg of query) {
-          if (this.disposed) break;
-          // Capture cliSessionId from the first system init frame and
-          // diagnose when it differs from ccsm's runner id. With PR-D's
-          // pre-allocated sessionId option the two should always match
-          // for fresh spawns; a mismatch is informative — either the SDK
-          // ignored our sessionId, or this is a resume path where the
-          // SDK allocated a fresh sid for the resumed branch.
-          const m = msg as SdkMessageLike;
-          if (m.type === 'system' && m.subtype === 'init' && !this.cliSessionId) {
-            const sid = (m as { session_id?: unknown }).session_id;
-            if (typeof sid === 'string') {
-              this.cliSessionId = sid;
-              if (sid !== this.id) {
-                this.onDiagnostic({
-                  level: 'warn',
-                  code: 'session_id_mismatch',
-                  message: `SDK assigned session_id ${sid} but ccsm runner id is ${this.id}. JSONL transcript will not match in-app id.`,
-                });
-              }
-            }
-          }
-          const translated = translateSdkMessage(m);
-          if (translated) this.onEvent(translated);
-        }
-        this.onExit({ error: undefined });
-      } catch (err) {
-        // The SDK throws AbortError on intentional close — don't surface that
-        // as a user-visible error. Anything else propagates with its message.
-        const isAbort =
-          err instanceof Error &&
-          (err.name === 'AbortError' || /aborted/i.test(err.message));
-        if (isAbort && this.disposed) {
-          this.onExit({ error: undefined });
-        } else {
-          this.onExit({ error: err instanceof Error ? err.message : String(err) });
-        }
-      } finally {
-        this.cleanupAfterExit();
+  /**
+   * Pull the first SDK message off a freshly-created query handle so we can
+   * detect a CLI-side rejection of the launch options (notably an unsupported
+   * `effort` tier) before committing to the production consumer loop. Returns
+   * either the buffered first message (`success`) or a classified error.
+   *
+   * The real SDK Query exposes `next()` directly on the handle; tests
+   * sometimes only expose the iterator protocol. We grab `Symbol.asyncIterator`
+   * once and reuse it for both the probe and the production consumer (passed
+   * through via `runConsumer`'s `iterator` arg) so the consumer sees no gap
+   * between the buffered first message and subsequent frames.
+   */
+  private async probeFirstMessage(
+    query: import('@anthropic-ai/claude-agent-sdk').Query,
+  ): Promise<
+    | {
+        kind: 'success';
+        first: SdkMessageLike | undefined;
+        iterator: AsyncIterator<unknown>;
       }
-    })();
+    | { kind: 'effort-rejected'; error: string }
+    | { kind: 'other-error'; error: string }
+  > {
+    const iterable = query as unknown as AsyncIterable<unknown>;
+    const iterator = iterable[Symbol.asyncIterator]();
+    try {
+      const result = await iterator.next();
+      if (result.done) {
+        return { kind: 'success', first: undefined, iterator };
+      }
+      return {
+        kind: 'success',
+        first: result.value as SdkMessageLike,
+        iterator,
+      };
+    } catch (err) {
+      const isAbort =
+        err instanceof Error &&
+        (err.name === 'AbortError' || /aborted/i.test(err.message));
+      if (isAbort && this.disposed) {
+        return { kind: 'other-error', error: '' };
+      }
+      const msg = err instanceof Error ? err.message : String(err);
+      if (isEffortRejectionError(err)) {
+        return { kind: 'effort-rejected', error: msg };
+      }
+      return { kind: 'other-error', error: msg };
+    }
+  }
+
+  /**
+   * Drain the SDK's outbound stream into ccsm's renderer event channel.
+   * Errors from the iterator are surfaced via onExit. Takes the iterator
+   * already drawn by `probeFirstMessage` plus its buffered first message
+   * so no frame is dropped between probe and consumer handoff.
+   */
+  private async runConsumer(
+    iterator: AsyncIterator<unknown>,
+    bufferedFirst: SdkMessageLike | undefined,
+  ): Promise<void> {
+    try {
+      if (bufferedFirst !== undefined) {
+        this.handleSdkMessage(bufferedFirst);
+      }
+      while (!this.disposed) {
+        const r = await iterator.next();
+        if (r.done) break;
+        this.handleSdkMessage(r.value as SdkMessageLike);
+      }
+      this.onExit({ error: undefined });
+    } catch (err) {
+      // The SDK throws AbortError on intentional close — don't surface that
+      // as a user-visible error. Anything else propagates with its message.
+      const isAbort =
+        err instanceof Error &&
+        (err.name === 'AbortError' || /aborted/i.test(err.message));
+      if (isAbort && this.disposed) {
+        this.onExit({ error: undefined });
+      } else {
+        this.onExit({ error: err instanceof Error ? err.message : String(err) });
+      }
+    } finally {
+      this.cleanupAfterExit();
+    }
+  }
+
+  private handleSdkMessage(m: SdkMessageLike): void {
+    // Capture cliSessionId from the first system init frame and
+    // diagnose when it differs from ccsm's runner id. With PR-D's
+    // pre-allocated sessionId option the two should always match
+    // for fresh spawns; a mismatch is informative — either the SDK
+    // ignored our sessionId, or this is a resume path where the
+    // SDK allocated a fresh sid for the resumed branch.
+    if (m.type === 'system' && m.subtype === 'init' && !this.cliSessionId) {
+      const sid = (m as { session_id?: unknown }).session_id;
+      if (typeof sid === 'string') {
+        this.cliSessionId = sid;
+        if (sid !== this.id) {
+          this.onDiagnostic({
+            level: 'warn',
+            code: 'session_id_mismatch',
+            message: `SDK assigned session_id ${sid} but ccsm runner id is ${this.id}. JSONL transcript will not match in-app id.`,
+          });
+        }
+      }
+    }
+    const translated = translateSdkMessage(m);
+    if (translated) this.onEvent(translated);
   }
 
   /**
@@ -821,13 +947,19 @@ export class SdkSessionRunner {
    * For the 'off' chip: only RPC #1 is meaningful (thinking off; tier is
    * irrelevant). We still send #2 as 'low' so a flip back ON re-syncs
    * cleanly without leaving stale higher-tier state on the SDK side.
+   *
+   * Optimistic gating: ccsm UI never disables effort tiers. If the CLI
+   * rejects `applyFlagSettings({ effortLevel })` as unsupported for the
+   * current model, we auto-downgrade one tier at a time (max -> xhigh ->
+   * ... -> off) and retry until accepted. The chip's visible label keeps
+   * showing the user-selected tier; the runner's `this.effortLevel` is
+   * what the chip reads, so it must stay at `level` even when the wire
+   * value drops below it.
    */
   async setEffort(level: EffortLevel): Promise<void> {
     this.effortLevel = level;
     if (!this.query) return;
     const tokens = thinkingTokensForLevel(level);
-    const settingsEffort: 'low' | 'medium' | 'high' | 'xhigh' | 'max' =
-      level === 'off' ? 'low' : level;
 
     const q = this.query as unknown as {
       setMaxThinkingTokens?: (n: number | null) => Promise<void>;
@@ -855,19 +987,7 @@ export class SdkSessionRunner {
       });
     }
     if (typeof q.applyFlagSettings === 'function') {
-      tasks.push(
-        q
-          .applyFlagSettings({ effortLevel: settingsEffort })
-          .catch((err) => {
-            this.onDiagnostic({
-              level: 'warn',
-              code: 'apply_flag_settings_failed',
-              message: `Agent unresponsive to effort change (${
-                err instanceof Error ? err.message : String(err)
-              }).`,
-            });
-          }),
-      );
+      tasks.push(this.applyEffortWithFallback(q.applyFlagSettings.bind(q), level));
     } else {
       this.onDiagnostic({
         level: 'warn',
@@ -876,6 +996,61 @@ export class SdkSessionRunner {
       });
     }
     await Promise.all(tasks);
+  }
+
+  /**
+   * Send `applyFlagSettings({ effortLevel })` with auto-downgrade on CLI
+   * rejection. See `setEffort` jsdoc for the gating rationale. Stops at
+   * the first wire value that succeeds; gives up at 'off' (which would
+   * have nothing to send and is treated as success). Each downgrade
+   * emits an `effort_downgrade_on_apply` diagnostic.
+   */
+  private async applyEffortWithFallback(
+    applyFlagSettings: (settings: Record<string, unknown>) => Promise<void>,
+    requested: EffortLevel,
+  ): Promise<void> {
+    let current: EffortLevel = requested;
+    while (true) {
+      // 'off' is meaningless on the wire (thinking already disabled via
+      // setMaxThinkingTokens); we send `low` as a stable resync-anchor
+      // matching the pre-fallback behaviour. Treat as terminal success.
+      const wire: 'low' | 'medium' | 'high' | 'xhigh' | 'max' =
+        current === 'off' ? 'low' : current;
+      try {
+        await applyFlagSettings({ effortLevel: wire });
+        return;
+      } catch (err) {
+        if (!isEffortRejectionError(err)) {
+          this.onDiagnostic({
+            level: 'warn',
+            code: 'apply_flag_settings_failed',
+            message: `Agent unresponsive to effort change (${
+              err instanceof Error ? err.message : String(err)
+            }).`,
+          });
+          return;
+        }
+        const downgrade = nextLowerEffort(current);
+        if (downgrade === null) {
+          this.onDiagnostic({
+            level: 'warn',
+            code: 'apply_flag_settings_failed',
+            message: `Effort change rejected at every tier; giving up (${
+              err instanceof Error ? err.message : String(err)
+            }).`,
+          });
+          return;
+        }
+        this.onDiagnostic({
+          level: 'warn',
+          code: 'effort_downgrade_on_apply',
+          message: `Model rejected effort=${current} mid-session (${
+            err instanceof Error ? err.message : String(err)
+          }); retrying with ${downgrade}.`,
+        });
+        current = downgrade;
+      }
+    }
   }
 
   async setModel(model?: string): Promise<void> {

--- a/electron/agent/manager.ts
+++ b/electron/agent/manager.ts
@@ -49,20 +49,6 @@ export type AgentDiagnostic = {
   message: string;
 };
 
-/**
- * Per-model capability metadata reported by the SDK after session start.
- * Drives the StatusBar effort chip's tier gating — see
- * `src/agent/effort.ts::supportedEffortLevelsForModel` for the
- * fallback table used when a model is absent from this report.
- */
-export type AgentModelInfoEvent = {
-  sessionId: string;
-  models: Array<{
-    modelId: string;
-    supportedEffortLevels?: ReadonlyArray<'low' | 'medium' | 'high' | 'xhigh' | 'max'>;
-  }>;
-};
-
 class SessionsManager {
   private runners = new Map<string, Runner>();
   private sender: Sender | null = null;
@@ -163,19 +149,14 @@ class SessionsManager {
           if (this.runners.has(sessionId)) this.selfExitCount += 1;
           this.runners.delete(sessionId);
         },
-        (req) => this.emit('agent:permissionRequest', { sessionId, ...req }),
-        (diag) =>
-          this.emit('agent:diagnostic', {
-            sessionId,
-            level: diag.level,
-            code: diag.code,
-            message: diag.message,
-          } satisfies AgentDiagnostic),
-        (info) =>
-          this.emit('agent:modelInfo', {
-            sessionId,
-            models: info.models,
-          } satisfies AgentModelInfoEvent)
+          (req) => this.emit('agent:permissionRequest', { sessionId, ...req }),
+          (diag) =>
+            this.emit('agent:diagnostic', {
+              sessionId,
+              level: diag.level,
+              code: diag.code,
+              message: diag.message,
+            } satisfies AgentDiagnostic)
       );
       await runner.start(opts);
       await Promise.race([firstSignal, new Promise<void>((r) => setTimeout(r, 800))]);

--- a/electron/agent/sessions.ts
+++ b/electron/agent/sessions.ts
@@ -100,18 +100,4 @@ export type DiagnosticHandler = (d: {
   message: string;
 }) => void;
 
-/**
- * Per-model capability metadata reported by the SDK's `query.supportedModels()`
- * shortly after session start. Today ccsm only consumes
- * `supportedEffortLevels` (powers the StatusBar effort chip's gating —
- * see src/agent/effort.ts::supportedEffortLevelsForModel) and uses the
- * hardcoded fallback for any model the SDK doesn't report.
- */
-export type AgentModelInfo = {
-  modelId: string;
-  supportedEffortLevels?: ReadonlyArray<'low' | 'medium' | 'high' | 'xhigh' | 'max'>;
-};
-
-export type ModelInfoHandler = (info: { models: AgentModelInfo[] }) => void;
-
 export type { ClaudeStreamEvent };

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -33,13 +33,6 @@ type AgentDiagnostic = {
   code: string;
   message: string;
 };
-type AgentModelInfoEvent = {
-  sessionId: string;
-  models: Array<{
-    modelId: string;
-    supportedEffortLevels?: ReadonlyArray<'low' | 'medium' | 'high' | 'xhigh' | 'max'>;
-  }>;
-};
 type AgentPermissionRequest = {
   sessionId: string;
   requestId: string;
@@ -220,11 +213,6 @@ const api = {
     const wrap = (_e: IpcRendererEvent, payload: AgentDiagnostic) => handler(payload);
     ipcRenderer.on('agent:diagnostic', wrap);
     return () => ipcRenderer.removeListener('agent:diagnostic', wrap);
-  },
-  onAgentModelInfo: (handler: (e: AgentModelInfoEvent) => void): (() => void) => {
-    const wrap = (_e: IpcRendererEvent, payload: AgentModelInfoEvent) => handler(payload);
-    ipcRenderer.on('agent:modelInfo', wrap);
-    return () => ipcRenderer.removeListener('agent:modelInfo', wrap);
   },
   onAgentPermissionRequest: (handler: (e: AgentPermissionRequest) => void): (() => void) => {
     const wrap = (_e: IpcRendererEvent, payload: AgentPermissionRequest) => handler(payload);

--- a/src/agent/effort.ts
+++ b/src/agent/effort.ts
@@ -14,8 +14,8 @@
 //   Low           thinking=adaptive   effort=low
 //   Medium        thinking=adaptive   effort=medium
 //   High          thinking=adaptive   effort=high       <- default
-//   Extra high    thinking=adaptive   effort=xhigh      (model-gated)
-//   Max           thinking=adaptive   effort=max        (model-gated)
+//   Extra high    thinking=adaptive   effort=xhigh
+//   Max           thinking=adaptive   effort=max
 //
 // Wire path (mirrors SDK schema):
 //   - Launch:      query({ thinking, effort })
@@ -23,14 +23,22 @@
 //   - Persistence: settings.json effortLevel (CLI reads via CLAUDE_CONFIG_DIR;
 //                  ccsm does NOT parse settings.json — see project_cli_config_reuse memory).
 //
-// Model gating: we prefer the SDK's own `Model.supportedEffortLevels` (piped
-// in per-model via the `agent:modelInfo` IPC channel — see
-// `electron/agent-sdk/sessions.ts` and the renderer wiring in
-// `src/agent/lifecycle.ts`). When no SDK report is available yet — e.g.
-// before the first session starts in an app run — we fall back to a small
-// hardcoded model→tier table inside `supportedEffortLevelsForModel`. Gated
-// tiers render `disabled` in the dropdown with a "not supported by current
-// model" tooltip.
+// Model gating: ccsm is OPTIMISTIC. Every chip tier is enabled in the UI
+// regardless of which model the user picked — the chip never disables itself
+// or shows a "not supported" tooltip. If the CLI rejects the chosen tier (for
+// either a launch or mid-session apply), the runner auto-downgrades one tier
+// at a time (max → xhigh → high → medium → low → off) and retries until the
+// CLI accepts. The chip's visible label keeps showing the user-selected tier
+// — the downgrade is invisible at the UI layer, only logged via diagnostic.
+//
+// Why optimistic instead of a hardcoded model→tiers table or piping the SDK's
+// `Model.supportedEffortLevels` into a `disabled+tooltip` UI: alias model ids
+// (e.g. CLI picker `opus[1m]` → real id `claude-opus-4-7-1m`) defeat regex-
+// based gating, and the SDK report only arrives once a session has started
+// — so a fresh chip on app launch had no usable info anyway. The downgrade
+// loop is a single source of truth that works for every model the CLI knows
+// about, including aliases and future additions ccsm hasn't been recompiled
+// for.
 
 export type EffortLevel = 'off' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 
@@ -96,68 +104,59 @@ export function thinkingTokensForLevel(level: EffortLevel): number | null {
 }
 
 /**
- * Resolve the set of NON-'off' tiers a given model supports. 'off' is always
- * usable (it is purely a ccsm-side toggle: thinking=disabled).
+ * Optimistic-fallback ladder. Returns the next-lower tier to try after the
+ * CLI rejected the current one, or `null` once we've reached the bottom
+ * ('off' is always accepted because it's purely a ccsm-side toggle: thinking=disabled,
+ * no effort sent).
  *
- * Resolution order:
- *   1. `sdkReported` — the SDK's own `Model.supportedEffortLevels` for this
- *      model id, populated on session start via `query.supportedModels()`
- *      (see electron/agent-sdk/sessions.ts and the `agent:modelInfo` IPC
- *      channel). This is the canonical answer when present, including
- *      future model additions ccsm hasn't been recompiled for.
- *   2. Hardcoded fallback below — used when no SDK report has arrived yet
- *      (no session has started in this app run, or the running SDK build
- *      doesn't list the chosen model). Mirrors what the bundled CLI
- *      reported in dogfood at the time of writing:
+ * Order: max → xhigh → high → medium → low → off → null.
  *
- *        Opus 4.7    → low, medium, high, xhigh, max
- *        Opus 4.6    → low, medium, high, max
- *        Sonnet 4.6+ → low, medium, high
- *        Older       → low, medium, high  (always-safe trio; the chip still
- *                      works so a model swap picks up support without a
- *                      relaunch).
+ * Used by `electron/agent-sdk/sessions.ts` on both launch (query() rejected
+ * for unsupported `effort`) and mid-session (`apply_flag_settings` rejected).
  */
-export function supportedEffortLevelsForModel(
-  modelId: string | null | undefined,
-  sdkReported?: Readonly<
-    Record<string, ReadonlyArray<Exclude<EffortLevel, 'off'>>>
-  >
-): ReadonlySet<Exclude<EffortLevel, 'off'>> {
-  const id = (modelId ?? '').toLowerCase();
-  if (sdkReported && modelId) {
-    // Try the exact id the SDK reported with first; fall back to a
-    // case-insensitive lookup so callers don't have to care about how the
-    // CLI spells the canonical id (e.g. `claude-opus-4-7-...` vs the
-    // user-facing alias).
-    const exact = sdkReported[modelId];
-    if (exact && exact.length > 0) return new Set(exact);
-    for (const [k, v] of Object.entries(sdkReported)) {
-      if (k.toLowerCase() === id && v.length > 0) return new Set(v);
-    }
+export function nextLowerEffort(level: EffortLevel): EffortLevel | null {
+  switch (level) {
+    case 'max':
+      return 'xhigh';
+    case 'xhigh':
+      return 'high';
+    case 'high':
+      return 'medium';
+    case 'medium':
+      return 'low';
+    case 'low':
+      return 'off';
+    case 'off':
+      return null;
   }
-  // Order matters: opus-4-7 must be tested before opus-4 (substring match).
-  if (/opus-4[-_]7|opus-4\.7/.test(id)) {
-    return new Set(['low', 'medium', 'high', 'xhigh', 'max']);
-  }
-  if (/opus-4[-_]6|opus-4\.6|opus-4(?![-_.\d])/.test(id)) {
-    return new Set(['low', 'medium', 'high', 'max']);
-  }
-  if (/sonnet-4|sonnet/.test(id)) {
-    return new Set(['low', 'medium', 'high']);
-  }
-  // Unknown model: surface the always-safe trio.
-  return new Set(['low', 'medium', 'high']);
 }
 
-export function isEffortLevelSupported(
-  modelId: string | null | undefined,
-  level: EffortLevel,
-  sdkReported?: Readonly<
-    Record<string, ReadonlyArray<Exclude<EffortLevel, 'off'>>>
-  >
-): boolean {
-  if (level === 'off') return true;
-  return supportedEffortLevelsForModel(modelId, sdkReported).has(level);
+/**
+ * Heuristic to decide whether an SDK / CLI error message indicates the
+ * `effort` (or its underlying `thinking` dimension) was rejected and the
+ * runner should auto-downgrade. Bundled CLI rejections come back as plain
+ * `Error(W.error)` (see `node_modules/@anthropic-ai/claude-agent-sdk/sdk.mjs`
+ * `pendingControlResponses` handler) — the only signal is the message text,
+ * and the CLI's exact wording varies across versions. The regex matches the
+ * intersection of words seen in dogfood and is intentionally permissive —
+ * a false positive just means a one-tier downgrade on a different class of
+ * error (still ends up at `off` and surfaces the original error if even
+ * `off` fails).
+ */
+export function isEffortRejectionError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err ?? '');
+  if (!msg) return false;
+  // Match any of:
+  //   - phrases mentioning "effort" with unsupported/invalid/not-supported
+  //   - phrases mentioning "thinking" with unsupported/invalid/not-supported
+  //   - flag_settings rejections that name effortLevel
+  return (
+    /\beffort\b[^.]{0,60}\b(unsupported|not\s+supported|invalid|unknown|disallow|not\s+allowed)\b/i.test(msg) ||
+    /\b(unsupported|not\s+supported|invalid|unknown|disallow|not\s+allowed)\b[^.]{0,60}\beffort\b/i.test(msg) ||
+    /\bthinking\b[^.]{0,60}\b(unsupported|not\s+supported|invalid|unknown|disallow|not\s+allowed)\b/i.test(msg) ||
+    /\b(unsupported|not\s+supported|invalid|unknown|disallow|not\s+allowed)\b[^.]{0,60}\bthinking\b/i.test(msg) ||
+    /\beffortLevel\b/i.test(msg)
+  );
 }
 
 /**

--- a/src/agent/lifecycle.ts
+++ b/src/agent/lifecycle.ts
@@ -365,14 +365,6 @@ export function subscribeAgentEvents(): void {
     });
   });
 
-  // Per-model effort-tier metadata reported by the SDK on session start
-  // (electron/agent-sdk/sessions.ts → `query.supportedModels()`). Drives
-  // StatusBar effort chip gating; the hardcoded fallback in
-  // src/agent/effort.ts handles models the SDK doesn't report.
-  api.onAgentModelInfo?.((e) => {
-    useStore.getState().applyModelInfo(e.models);
-  });
-
   api.onAgentPermissionRequest((req) => {
     // Session-scoped "Allow always" fast-path: if the user previously ticked
     // "Allow always" for this tool name, auto-resolve Allow and skip rendering

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -14,7 +14,6 @@ import { useTranslation } from '../i18n/useTranslation';
 import { CwdPopover } from './CwdPopover';
 import {
   EFFORT_LEVELS,
-  isEffortLevelSupported,
   type EffortLevel,
 } from '../agent/effort';
 
@@ -59,15 +58,6 @@ type ChipOption<V extends string> =
       primary: string;
       secondary?: string;
       icon?: React.ReactNode;
-      /**
-       * Render the row greyed-out and non-selectable. Used by the Effort
-       * chip to flag tiers the current model doesn't support — surfacing
-       * them visibly (rather than hiding) so users can see why a tier
-       * isn't selectable and understand model gating exists.
-       */
-      disabled?: boolean;
-      /** Tooltip surfaced on hover; primary use is explaining `disabled`. */
-      titleAttr?: string;
     }
   | { kind: 'separator' }
   | { kind: 'label'; primary: string };
@@ -133,15 +123,7 @@ function ChipMenu<V extends string>({
             return (
               <DropdownMenuItem
                 key={o.value}
-                disabled={o.disabled}
-                title={o.titleAttr}
-                onSelect={(e) => {
-                  if (o.disabled) {
-                    e.preventDefault();
-                    return;
-                  }
-                  onSelect(o.value);
-                }}
+                onSelect={() => onSelect(o.value)}
                 className="flex-col items-start gap-0 h-auto py-1.5"
               >
                 <span className="truncate w-full text-fg-primary">{o.primary}</span>
@@ -154,15 +136,7 @@ function ChipMenu<V extends string>({
           return (
             <DropdownMenuItem
               key={o.value}
-              disabled={o.disabled}
-              title={o.titleAttr}
-              onSelect={(e) => {
-                if (o.disabled) {
-                  e.preventDefault();
-                  return;
-                }
-                onSelect(o.value);
-              }}
+              onSelect={() => onSelect(o.value)}
             >
               {o.icon}
               <span>{o.primary}</span>
@@ -331,11 +305,6 @@ export function StatusBar({
   const { t } = useTranslation();
   const models = useStore((s) => s.models);
   const modelsLoaded = useStore((s) => s.modelsLoaded);
-  // SDK-reported per-model effort tiers (populated from the `agent:modelInfo`
-  // IPC channel in src/agent/lifecycle.ts). Empty until at least one session
-  // has started; supportedEffortLevelsForModel falls back to its hardcoded
-  // table for any model not yet reported.
-  const supportedEffortLevelsByModel = useStore((s) => s.supportedEffortLevelsByModel);
   const contextUsage = useStore((s) => s.contextUsageBySession[sessionId]);
   // 6-tier effort+thinking chip: per-session override falls back to the
   // global default so a fresh session starts at 'high' (the unified chip's
@@ -396,9 +365,13 @@ export function StatusBar({
   const modelTriggerLabel = model || t('statusBar.pickModel');
 
   // 6-tier effort+thinking chip. Labels are localized; the underlying VALUES
-  // are the SDK's union literals and stay in English. Tiers the current
-  // model doesn't support are rendered disabled+tooltipped (rather than
-  // hidden) so users see model gating exists. Off is always selectable.
+  // are the SDK's union literals and stay in English. Every tier is enabled
+  // unconditionally — ccsm is OPTIMISTIC about model support and lets the
+  // CLI reject unsupported tiers, at which point the runner auto-downgrades
+  // (see `electron/agent-sdk/sessions.ts` setEffort + start fallback paths
+  // and `src/agent/effort.ts::nextLowerEffort`). The chip's visible label
+  // keeps showing the user-selected tier even if the runner had to downgrade
+  // under the hood.
   const effortLabels: Record<EffortLevel, string> = {
     off: t('statusBar.effortOffLabel'),
     low: t('statusBar.effortLowLabel'),
@@ -415,18 +388,12 @@ export function StatusBar({
     xhigh: t('statusBar.effortXhighDesc'),
     max: t('statusBar.effortMaxDesc'),
   };
-  const gatedTooltip = t('statusBar.effortGatedTooltip');
-  const effortOptions: ChipOption<EffortLevel>[] = EFFORT_LEVELS.map((lvl) => {
-    const supported = isEffortLevelSupported(model, lvl, supportedEffortLevelsByModel);
-    return {
-      kind: 'item' as const,
-      value: lvl,
-      primary: effortLabels[lvl],
-      secondary: effortDescs[lvl],
-      disabled: !supported,
-      titleAttr: supported ? undefined : gatedTooltip,
-    };
-  });
+  const effortOptions: ChipOption<EffortLevel>[] = EFFORT_LEVELS.map((lvl) => ({
+    kind: 'item' as const,
+    value: lvl,
+    primary: effortLabels[lvl],
+    secondary: effortDescs[lvl],
+  }));
 
   const chips: React.ReactNode[] = [
     cwdChip,

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -49,13 +49,6 @@ type AgentDiagnostic = {
   code: string;
   message: string;
 };
-type AgentModelInfoEvent = {
-  sessionId: string;
-  models: Array<{
-    modelId: string;
-    supportedEffortLevels?: ReadonlyArray<'low' | 'medium' | 'high' | 'xhigh' | 'max'>;
-  }>;
-};
 type AgentPermissionRequest = {
   sessionId: string;
   requestId: string;
@@ -165,7 +158,6 @@ declare global {
       onAgentEvent: (handler: (e: AgentEvent) => void) => () => void;
       onAgentExit: (handler: (e: AgentExit) => void) => () => void;
       onAgentDiagnostic: (handler: (e: AgentDiagnostic) => void) => () => void;
-      onAgentModelInfo: (handler: (e: AgentModelInfoEvent) => void) => () => void;
       onAgentPermissionRequest: (handler: (e: AgentPermissionRequest) => void) => () => void;
 
       scanImportable: () => Promise<

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -543,8 +543,7 @@ const en = {
     effortMediumDesc: 'Balanced reasoning.',
     effortHighDesc: 'Deeper thinking (default).',
     effortXhighDesc: 'Extended deliberation. Opus 4.7.',
-    effortMaxDesc: 'Maximum effort. Opus 4.6/4.7.',
-    effortGatedTooltip: 'Not supported by current model.'
+    effortMaxDesc: 'Maximum effort. Opus 4.6/4.7.'
   },
   cwdPopover: {
     placeholder: 'Type to filter or paste a path…',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -511,8 +511,7 @@ const zh: EnCatalog = {
     effortMediumDesc: '兼顾速度与深度。',
     effortHighDesc: '更深入思考（默认）。',
     effortXhighDesc: '更长时间的推理。Opus 4.7。',
-    effortMaxDesc: '最大推理强度。Opus 4.6/4.7。',
-    effortGatedTooltip: '当前模型不支持此档位。'
+    effortMaxDesc: '最大推理强度。Opus 4.6/4.7。'
   },
   cwdPopover: {
     placeholder: '输入筛选或粘贴路径…',

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -250,19 +250,6 @@ type State = {
   messageQueues: Record<string, QueuedMessage[]>;
   models: DiscoveredModel[];
   modelsLoaded: boolean;
-  /**
-   * Per-model `supportedEffortLevels` reported by the SDK on session start
-   * via `query.supportedModels()` (forwarded to the renderer over the
-   * `agent:modelInfo` IPC channel — see `electron/agent-sdk/sessions.ts`).
-   * Source of truth for the StatusBar effort chip's tier gating; falls
-   * back to the hardcoded model→tier table in `src/agent/effort.ts` for
-   * any model not yet reported (e.g. before any session has started, or
-   * for a model the bundled SDK doesn't list).
-   *
-   * Keyed by raw model id (`ModelInfo.value`), shared across sessions —
-   * the SDK reports the SAME catalogue regardless of which session asked.
-   */
-  supportedEffortLevelsByModel: Record<string, ReadonlyArray<Exclude<EffortLevel, 'off'>>>;
   connection: ConnectionInfo | null;
   // Monotonic counter bumped whenever a user-driven action requests that the
   // InputBar textarea take focus (e.g. clicking a session in the sidebar,
@@ -593,19 +580,6 @@ type Actions = {
   setSessionContextUsage: (sessionId: string, usage: SessionContextUsage) => void;
 
   loadModels: () => Promise<void>;
-  /**
-   * Merge per-model effort-tier metadata reported by the SDK
-   * (`agent:modelInfo` IPC) into `supportedEffortLevelsByModel`. New entries
-   * overwrite previous ones — the SDK's report is canonical for whatever
-   * model id it includes. Models absent from the report keep their prior
-   * entries (or fall back to the hardcoded table at lookup time).
-   */
-  applyModelInfo: (
-    models: ReadonlyArray<{
-      modelId: string;
-      supportedEffortLevels?: ReadonlyArray<'low' | 'medium' | 'high' | 'xhigh' | 'max'>;
-    }>
-  ) => void;
   loadConnection: () => Promise<void>;
 
   /** Flip the `installerCorrupt` banner on (true) or off (false). Called
@@ -1041,7 +1015,6 @@ export const useStore = create<State & Actions>((set, get) => ({
   messageQueues: {},
   models: [],
   modelsLoaded: false,
-  supportedEffortLevelsByModel: {},
   connection: null,
   focusInputNonce: 0,
   installerCorrupt: false,
@@ -2479,40 +2452,6 @@ export const useStore = create<State & Actions>((set, get) => ({
     } catch {
       set({ modelsLoaded: true });
     }
-  },
-
-  applyModelInfo: (models) => {
-    if (!Array.isArray(models) || models.length === 0) return;
-    set((s) => {
-      const next = { ...s.supportedEffortLevelsByModel };
-      let changed = false;
-      for (const m of models) {
-        if (!m || typeof m.modelId !== 'string' || !m.modelId) continue;
-        const tiers = m.supportedEffortLevels;
-        if (!Array.isArray(tiers)) continue;
-        // Defence-in-depth: filter to known union members. The IPC payload
-        // is already validated in preload but the store is the boundary
-        // both production and harness probes hit, so keep the guard local.
-        const allowed = (['low', 'medium', 'high', 'xhigh', 'max'] as const).filter((t) =>
-          tiers.includes(t)
-        );
-        // Empty filter result == no usable info → skip rather than write an
-        // empty array (effort.ts treats empty as "no SDK report" and falls
-        // back to the hardcoded table; storing [] would just waste a slot).
-        if (allowed.length === 0) continue;
-        const prev = next[m.modelId];
-        if (
-          prev &&
-          prev.length === allowed.length &&
-          prev.every((v, i) => v === allowed[i])
-        ) {
-          continue;
-        }
-        next[m.modelId] = allowed;
-        changed = true;
-      }
-      return changed ? { supportedEffortLevelsByModel: next } : s;
-    });
   },
 
   loadConnection: async () => {

--- a/tests/effort.test.ts
+++ b/tests/effort.test.ts
@@ -2,10 +2,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   coerceEffortLevel,
   DEFAULT_EFFORT_LEVEL,
-  isEffortLevelSupported,
+  isEffortRejectionError,
+  nextLowerEffort,
   projectEffortToWire,
-  supportedEffortLevelsForModel,
   thinkingTokensForLevel,
+  type EffortLevel,
 } from '../src/agent/effort';
 
 describe('effort: projectEffortToWire', () => {
@@ -35,70 +36,54 @@ describe('effort: thinkingTokensForLevel', () => {
   });
 });
 
-describe('effort: model gating', () => {
-  it('Opus 4.7 supports all 5 non-Off tiers', () => {
-    const ids = ['claude-opus-4-7', 'claude-opus-4.7', 'opus-4-7-20251111'];
-    for (const id of ids) {
-      const set = supportedEffortLevelsForModel(id);
-      expect(set.has('low')).toBe(true);
-      expect(set.has('medium')).toBe(true);
-      expect(set.has('high')).toBe(true);
-      expect(set.has('xhigh')).toBe(true);
-      expect(set.has('max')).toBe(true);
+describe('effort: nextLowerEffort fallback ladder', () => {
+  it('walks max -> xhigh -> high -> medium -> low -> off -> null', () => {
+    const ladder: Array<EffortLevel | null> = [
+      'max',
+      'xhigh',
+      'high',
+      'medium',
+      'low',
+      'off',
+      null,
+    ];
+    for (let i = 0; i < ladder.length - 1; i++) {
+      expect(nextLowerEffort(ladder[i] as EffortLevel)).toBe(ladder[i + 1]);
     }
   });
 
-  it('Opus 4.6 supports low/medium/high/max but NOT xhigh', () => {
-    const set = supportedEffortLevelsForModel('claude-opus-4-6');
-    expect(set.has('xhigh')).toBe(false);
-    expect(set.has('max')).toBe(true);
-    expect(set.has('high')).toBe(true);
+  it('off is the bottom of the ladder', () => {
+    expect(nextLowerEffort('off')).toBeNull();
+  });
+});
+
+describe('effort: isEffortRejectionError', () => {
+  it.each([
+    'effort level "max" is not supported by this model',
+    'Invalid effort tier',
+    'effortLevel: unknown value',
+    'unsupported effort',
+    'thinking is not supported',
+    'invalid thinking config',
+  ])('classifies CLI effort rejection: %s', (msg) => {
+    expect(isEffortRejectionError(new Error(msg))).toBe(true);
   });
 
-  it('Sonnet supports low/medium/high but NOT xhigh or max', () => {
-    const set = supportedEffortLevelsForModel('claude-sonnet-4-6');
-    expect(set.has('xhigh')).toBe(false);
-    expect(set.has('max')).toBe(false);
-    expect(set.has('high')).toBe(true);
+  it.each([
+    'connection refused',
+    'session aborted',
+    'permission denied for tool Bash',
+    '',
+    'something else entirely',
+  ])('does NOT classify unrelated error: %s', (msg) => {
+    expect(isEffortRejectionError(new Error(msg))).toBe(false);
   });
 
-  it('Off is always selectable regardless of model', () => {
-    expect(isEffortLevelSupported('claude-haiku-4-5', 'off')).toBe(true);
-    expect(isEffortLevelSupported(undefined, 'off')).toBe(true);
-    expect(isEffortLevelSupported(null, 'off')).toBe(true);
-  });
-
-  it('SDK-reported tiers OVERRIDE the hardcoded fallback', () => {
-    // Sonnet hardcoded -> [low,medium,high]. SDK report grants xhigh too.
-    const sdk = { 'claude-sonnet-4-99': ['low', 'medium', 'high', 'xhigh'] as const };
-    const set = supportedEffortLevelsForModel('claude-sonnet-4-99', sdk);
-    expect(set.has('xhigh')).toBe(true);
-    expect(set.has('max')).toBe(false);
-    // isEffortLevelSupported respects the override too.
-    expect(isEffortLevelSupported('claude-sonnet-4-99', 'xhigh', sdk)).toBe(true);
-    expect(isEffortLevelSupported('claude-sonnet-4-99', 'max', sdk)).toBe(false);
-  });
-
-  it('Falls back to hardcoded table when SDK has no entry for the model', () => {
-    const sdk = { 'some-other-model': ['low'] as const };
-    const set = supportedEffortLevelsForModel('claude-opus-4-7', sdk);
-    expect(set.has('xhigh')).toBe(true);
-    expect(set.has('max')).toBe(true);
-  });
-
-  it('SDK lookup is case-insensitive on the model id', () => {
-    const sdk = { 'Custom-Model-X': ['low', 'medium'] as const };
-    const set = supportedEffortLevelsForModel('custom-model-x', sdk);
-    expect(set.has('low')).toBe(true);
-    expect(set.has('medium')).toBe(true);
-    expect(set.has('high')).toBe(false);
-  });
-
-  it('Empty SDK report falls through to hardcoded fallback (no spurious empty set)', () => {
-    const sdk = { 'claude-opus-4-7': [] as const };
-    const set = supportedEffortLevelsForModel('claude-opus-4-7', sdk);
-    // Empty array shouldn't lock the chip out; treat as "no info" and fall back.
-    expect(set.has('high')).toBe(true);
+  it('handles non-Error inputs without throwing', () => {
+    expect(isEffortRejectionError(null)).toBe(false);
+    expect(isEffortRejectionError(undefined)).toBe(false);
+    expect(isEffortRejectionError('effort unsupported')).toBe(true);
+    expect(isEffortRejectionError(42)).toBe(false);
   });
 });
 
@@ -252,37 +237,3 @@ describe('store: effort-level actions', () => {
   });
 });
 
-describe('store: applyModelInfo (SDK-reported supportedEffortLevels)', () => {
-  it('populates supportedEffortLevelsByModel from agent:modelInfo payload', async () => {
-    const { useStore } = await freshStore({});
-    expect(useStore.getState().supportedEffortLevelsByModel).toEqual({});
-    useStore.getState().applyModelInfo([
-      { modelId: 'claude-opus-4-7', supportedEffortLevels: ['low', 'medium', 'high', 'xhigh', 'max'] },
-      { modelId: 'claude-sonnet-4-6', supportedEffortLevels: ['low', 'medium', 'high'] },
-    ]);
-    const m = useStore.getState().supportedEffortLevelsByModel;
-    expect(m['claude-opus-4-7']).toEqual(['low', 'medium', 'high', 'xhigh', 'max']);
-    expect(m['claude-sonnet-4-6']).toEqual(['low', 'medium', 'high']);
-  });
-
-  it('ignores empty / malformed payloads without clobbering existing entries', async () => {
-    const { useStore } = await freshStore({});
-    useStore.getState().applyModelInfo([
-      { modelId: 'claude-opus-4-7', supportedEffortLevels: ['low', 'medium', 'high', 'xhigh', 'max'] },
-    ]);
-    // Empty list — no-op.
-    useStore.getState().applyModelInfo([]);
-    // Malformed entries — skipped.
-    useStore
-      .getState()
-      .applyModelInfo([
-        { modelId: '', supportedEffortLevels: ['low'] } as never,
-        // unknown tier strings are filtered out by the reducer's allow-list.
-        { modelId: 'claude-bad', supportedEffortLevels: ['bogus' as never, 'high'] },
-      ]);
-    const m = useStore.getState().supportedEffortLevelsByModel;
-    expect(m['claude-opus-4-7']).toEqual(['low', 'medium', 'high', 'xhigh', 'max']);
-    expect(m['claude-bad']).toEqual(['high']);
-    expect(m['']).toBeUndefined();
-  });
-});

--- a/tests/sdk-session-effort-fallback.test.ts
+++ b/tests/sdk-session-effort-fallback.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  SdkSessionRunner,
+  __setSdkModuleForTests,
+} from '../electron/agent-sdk/sessions';
+import type { StartOptions } from '../electron/agent/sessions';
+
+// Minimal SDK shape the runner touches: query() returning an AsyncIterator
+// + close()/interrupt()/setMaxThinkingTokens()/applyFlagSettings(). We
+// fake it per-test so we can assert downgrade behaviour without a real
+// CLI subprocess.
+
+type FakeQueryOpts = {
+  // First-call behaviour: 'success' yields one system init frame; 'error'
+  // throws the supplied Error from .next().
+  firstCall: 'success' | 'error';
+  firstCallError?: Error;
+  applyFlagSettingsBehaviour?: (settings: Record<string, unknown>) => Promise<void>;
+};
+
+function makeFakeSdk(
+  queries: FakeQueryOpts[],
+  observed: { effortAttempts: (string | undefined)[]; applyAttempts: unknown[] },
+) {
+  let queryIndex = 0;
+  const fakeQuery = (call: { options: { effort?: string } }) => {
+    const i = queryIndex++;
+    const cfg = queries[i];
+    if (!cfg) throw new Error(`unexpected query() call #${i}`);
+    observed.effortAttempts.push(call.options.effort);
+    let yielded = false;
+    let endResolve: (() => void) | null = null;
+    const endPromise = new Promise<void>((r) => { endResolve = r; });
+    const iter: AsyncIterator<unknown> & {
+      [Symbol.asyncIterator](): AsyncIterator<unknown>;
+      close(): void;
+      interrupt(): Promise<void>;
+      setMaxThinkingTokens(n: number | null): Promise<void>;
+      applyFlagSettings(s: Record<string, unknown>): Promise<void>;
+    } = {
+      async next() {
+        if (cfg.firstCall === 'error') {
+          throw cfg.firstCallError ?? new Error('unspecified error');
+        }
+        if (yielded) {
+          // Block until close() so consumer stays alive — mirrors a real
+          // SDK session waiting for further frames.
+          await endPromise;
+          return { done: true, value: undefined };
+        }
+        yielded = true;
+        return {
+          done: false,
+          value: {
+            type: 'system',
+            subtype: 'init',
+            session_id: 'sid-fake',
+          },
+        };
+      },
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+      close() {
+        if (endResolve) endResolve();
+      },
+      interrupt: async () => {},
+      setMaxThinkingTokens: async (_n: number | null) => {},
+      applyFlagSettings: async (settings: Record<string, unknown>) => {
+        observed.applyAttempts.push(settings.effortLevel);
+        if (cfg.applyFlagSettingsBehaviour) {
+          return cfg.applyFlagSettingsBehaviour(settings);
+        }
+      },
+    };
+    return iter;
+  };
+  return {
+    query: fakeQuery,
+  } as unknown as typeof import('@anthropic-ai/claude-agent-sdk');
+}
+
+// SdkSessionRunner.start() resolves the user binary via binary-resolver.
+// Skip that path by supplying an explicit binaryPath on the StartOptions —
+// the runner short-circuits resolveClaudeInvocation when binaryPath is set.
+function baseOpts(over: Partial<StartOptions> = {}): StartOptions {
+  return {
+    cwd: '/tmp',
+    binaryPath: '/fake/claude',
+    permissionMode: 'default',
+    ...over,
+  };
+}
+
+afterEach(() => {
+  __setSdkModuleForTests(null);
+  vi.useRealTimers();
+});
+
+describe('SdkSessionRunner: launch effort fallback', () => {
+  it('downgrades from max -> high when CLI rejects "effort unsupported"', async () => {
+    const observed = { effortAttempts: [] as (string | undefined)[], applyAttempts: [] as unknown[] };
+    __setSdkModuleForTests(
+      makeFakeSdk(
+        [
+          { firstCall: 'error', firstCallError: new Error('effort level "max" is not supported') },
+          { firstCall: 'error', firstCallError: new Error('effort xhigh is unsupported by this model') },
+          { firstCall: 'success' }, // high accepted
+        ],
+        observed,
+      ),
+    );
+    const events: unknown[] = [];
+    const exits: unknown[] = [];
+    const diags: { code: string; message: string }[] = [];
+    const runner = new SdkSessionRunner(
+      'sid-1',
+      (m) => events.push(m),
+      (e) => exits.push(e),
+      () => {},
+      (d) => diags.push({ code: d.code, message: d.message }),
+    );
+    await runner.start(baseOpts({ effortLevel: 'max' }));
+    // Spin the event loop so the spawned attemptRun + probe + downgrades run.
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(observed.effortAttempts).toEqual(['max', 'xhigh', 'high']);
+    // Two downgrade diagnostics + one success-after-downgrade diagnostic.
+    expect(diags.filter((d) => d.code === 'effort_downgrade_on_launch').length).toBe(2);
+    expect(diags.filter((d) => d.code === 'effort_downgraded_active').length).toBe(1);
+    // No exit (consumer still alive).
+    expect(exits.length).toBe(0);
+    runner.close();
+  });
+
+  it('non-effort errors do NOT trigger downgrade — surfaces via onExit', async () => {
+    const observed = { effortAttempts: [] as (string | undefined)[], applyAttempts: [] as unknown[] };
+    __setSdkModuleForTests(
+      makeFakeSdk(
+        [{ firstCall: 'error', firstCallError: new Error('connection refused') }],
+        observed,
+      ),
+    );
+    const exits: { error?: string }[] = [];
+    const runner = new SdkSessionRunner(
+      'sid-2',
+      () => {},
+      (e) => exits.push(e),
+      () => {},
+    );
+    await runner.start(baseOpts({ effortLevel: 'max' }));
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(observed.effortAttempts).toEqual(['max']);
+    expect(exits.length).toBe(1);
+    expect(exits[0].error).toMatch(/connection refused/);
+  });
+
+  it('gives up at off, surfaces last error', async () => {
+    const observed = { effortAttempts: [] as (string | undefined)[], applyAttempts: [] as unknown[] };
+    __setSdkModuleForTests(
+      makeFakeSdk(
+        [
+          { firstCall: 'error', firstCallError: new Error('effort max unsupported') },
+          { firstCall: 'error', firstCallError: new Error('effort xhigh unsupported') },
+          { firstCall: 'error', firstCallError: new Error('effort high unsupported') },
+          { firstCall: 'error', firstCallError: new Error('effort medium unsupported') },
+          { firstCall: 'error', firstCallError: new Error('effort low unsupported') },
+          { firstCall: 'error', firstCallError: new Error('effort off unsupported') },
+        ],
+        observed,
+      ),
+    );
+    const exits: { error?: string }[] = [];
+    const runner = new SdkSessionRunner(
+      'sid-3',
+      () => {},
+      (e) => exits.push(e),
+      () => {},
+    );
+    await runner.start(baseOpts({ effortLevel: 'max' }));
+    for (let i = 0; i < 12; i++) await new Promise((r) => setTimeout(r, 0));
+    expect(observed.effortAttempts).toEqual(['max', 'xhigh', 'high', 'medium', 'low', undefined]);
+    expect(exits.length).toBe(1);
+    expect(exits[0].error).toMatch(/effort off unsupported/);
+  });
+});
+
+describe('SdkSessionRunner: mid-session effort fallback', () => {
+  it('applyFlagSettings rejection downgrades and retries until accepted', async () => {
+    const observed = { effortAttempts: [] as (string | undefined)[], applyAttempts: [] as unknown[] };
+    __setSdkModuleForTests(
+      makeFakeSdk(
+        [
+          {
+            firstCall: 'success',
+            applyFlagSettingsBehaviour: async (s) => {
+              if (s.effortLevel === 'max' || s.effortLevel === 'xhigh') {
+                throw new Error(`effort ${s.effortLevel} is not supported`);
+              }
+            },
+          },
+        ],
+        observed,
+      ),
+    );
+    const diags: { code: string }[] = [];
+    const runner = new SdkSessionRunner(
+      'sid-4',
+      () => {},
+      () => {},
+      () => {},
+      (d) => diags.push({ code: d.code }),
+    );
+    await runner.start(baseOpts({ effortLevel: 'high' }));
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    // Mid-session: user picks max.
+    await runner.setEffort('max');
+    expect(observed.applyAttempts).toEqual(['max', 'xhigh', 'high']);
+    expect(diags.filter((d) => d.code === 'effort_downgrade_on_apply').length).toBe(2);
+    runner.close();
+  });
+
+  it('non-effort applyFlagSettings rejection does NOT loop — single warn', async () => {
+    const observed = { effortAttempts: [] as (string | undefined)[], applyAttempts: [] as unknown[] };
+    __setSdkModuleForTests(
+      makeFakeSdk(
+        [
+          {
+            firstCall: 'success',
+            applyFlagSettingsBehaviour: async (s) => {
+              if (s.effortLevel === 'max') throw new Error('something else broke');
+            },
+          },
+        ],
+        observed,
+      ),
+    );
+    const diags: { code: string }[] = [];
+    const runner = new SdkSessionRunner(
+      'sid-5',
+      () => {},
+      () => {},
+      () => {},
+      (d) => diags.push({ code: d.code }),
+    );
+    await runner.start(baseOpts({ effortLevel: 'high' }));
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    await runner.setEffort('max');
+    // No downgrade diagnostics; just one apply_flag_settings_failed.
+    expect(diags.filter((d) => d.code === 'effort_downgrade_on_apply').length).toBe(0);
+    expect(diags.filter((d) => d.code === 'apply_flag_settings_failed').length).toBe(1);
+    runner.close();
+  });
+});


### PR DESCRIPTION
## Why

User feedback (verbatim): 「所有模型都默认开所有 effort, 然后如果高的不行就自动一档一档 fallback」

Hardcoded model→tier gating (#360) and SDK-reported `supportedEffortLevels` gating (#364) both fail on alias model ids — e.g. CLI picker `opus[1m]` (real id `claude-opus-4-7-1m`) is shown as Opus-4.7-with-no-Extra-high-or-Max because alias regex doesn't match. Chip locks tiers the model actually supports.

## Approach

Optimistic UI + automatic runtime fallback:

1. Every chip tier is enabled. No `disabled+tooltip` row. No model→tiers table. No piping `supportedEffortLevels` from the SDK.
2. If the CLI rejects the user-selected tier, the runner auto-downgrades **one tier at a time** (`max → xhigh → high → medium → low → off`) until accepted. `off` always succeeds (it sets `thinking=disabled` + omits `effort`).
3. The chip's visible label always shows the user-selected tier. Downgrade is invisible at UI; surfaced via `warn`-level diagnostic only.

Two fallback sites:
- **Launch** (`query()` in `electron/agent-sdk/sessions.ts`): probe the first SDK frame; on effort-rejection error, tear down + retry one tier lower.
- **Mid-session** (`applyFlagSettings({effortLevel})`): on rejection, downgrade + retry inline.

Detection: SDK rejects from CLI `control_response` via plain `Error(W.error)` (verified at `node_modules/@anthropic-ai/claude-agent-sdk/sdk.mjs:61`). `isEffortRejectionError(err)` is a permissive regex on `Error.message`: `{effort|thinking|effortLevel} ∩ {unsupported|not supported|invalid|unknown|disallow|not allowed}`.

## Removed

- `src/agent/effort.ts`: `supportedEffortLevelsForModel`, `isEffortLevelSupported`
- `src/stores/store.ts`: `supportedEffortLevelsByModel` field, `applyModelInfo` action
- `electron/agent/manager.ts`: `agent:modelInfo` IPC fan-out, `AgentModelInfoEvent` type
- `electron/agent/sessions.ts`: `AgentModelInfo` + `ModelInfoHandler` types
- `electron/agent-sdk/sessions.ts`: `query.supportedModels()` + `onModelInfo` plumbing
- `electron/preload.ts`: `onAgentModelInfo` bridge
- `src/global.d.ts`: matching `window.ccsm` types
- `src/agent/lifecycle.ts`: `api.onAgentModelInfo` handler
- `src/components/StatusBar.tsx`: `isEffortLevelSupported()` call, `ChipOption.disabled` + `ChipOption.titleAttr`
- i18n: `statusBar.effortGatedTooltip` (en + zh)

## Added

- `src/agent/effort.ts`: `nextLowerEffort(level)`, `isEffortRejectionError(err)`
- `electron/agent-sdk/sessions.ts`: `attemptRun(ctx)`, `probeFirstMessage(query)`, `runConsumer(iterator, bufferedFirst)`, `applyEffortWithFallback(applyFlagSettings, level)`
- Diagnostics: `effort_downgrade_on_launch`, `effort_downgraded_active`, `effort_downgrade_on_apply`

## Tests

- `tests/effort.test.ts` rewritten: deleted gating + applyModelInfo cases; added `nextLowerEffort` ladder + `isEffortRejectionError` classification coverage
- `tests/sdk-session-effort-fallback.test.ts` (new, 5 cases):
  - launch fallback `max → xhigh → high` success path
  - non-effort error does NOT trigger downgrade (surfaces via `onExit`)
  - gives up at `off`, surfaces last error
  - mid-session `applyFlagSettings` rejection downgrades + retries
  - non-effort `applyFlagSettings` rejection does NOT loop (single warn)

## Verification

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on all changed files
- [x] vitest 204/204 pass on changed-area test files (effort, sdk-session-effort-fallback, electron/agent-sdk/__tests__, store, lifecycle, persist, persisted-keys-source-of-truth)
- [x] e2e `node scripts/harness-ui.mjs --only=effort-chip-toggle` PASS — chip still renders 6 enabled tiers, store action still IPC-fans-out

## Test plan

- [ ] Reviewer reverse-verify: stash `applyEffortWithFallback`, run sdk-session-effort-fallback test → mid-session fallback test should fail
- [ ] Reviewer reverse-verify: stash `attemptRun` retry loop, run sdk-session-effort-fallback test → launch fallback test should fail
- [ ] e2e effort-chip-toggle PASS on reviewer's box

🤖 Generated with [Claude Code](https://claude.com/claude-code)