### PR TITLE
fix(question/permission): focus transfer to block on mount, back to textarea on submit (#291)

### DIFF
--- a/scripts/harness-agent.mjs
+++ b/scripts/harness-agent.mjs
@@ -3839,15 +3839,34 @@ async function caseAskUserQuestionFull({ app, win, log }) {
       { question: 'Which language?', options: [{ label: 'Python' }, { label: 'TypeScript' }, { label: 'Rust' }] },
     ]);
     await win.waitForSelector('[data-question-option]', { timeout: 5000 });
-    await win.waitForTimeout(150);
+    // Task #291: question card now grabs focus on mount (reverses PR #305's
+    // "no focus theft" choice). First option (Python) should be the active
+    // element; the textarea draft is preserved as a controlled value but
+    // no longer holds focus.
+    await win.waitForFunction(() => {
+      const el = document.activeElement;
+      return el instanceof HTMLElement && el.getAttribute('data-question-label') === 'Python';
+    }, null, { timeout: 2000 }).catch(() => {});
     const afterActive = await win.evaluate(() => {
       const el = document.activeElement;
-      return { tag: el?.tagName, textareaValue: document.querySelector('textarea')?.value?.slice(0, 32) };
+      return {
+        tag: el?.tagName,
+        role: el?.getAttribute('role'),
+        label: el?.getAttribute('data-question-label'),
+        textareaValue: document.querySelector('textarea')?.value?.slice(0, 32),
+      };
     });
-    if (afterActive.tag !== 'TEXTAREA') return record('J1', false, `auto-focus stole focus: tag=${afterActive.tag}`);
-    const firstOpt = win.locator('[data-question-option]').first();
-    await firstOpt.click();
-    await win.waitForTimeout(80);
+    if (afterActive.tag === 'TEXTAREA') return record('J1', false, `auto-focus left focus on textarea (#291 contract: question takes over): ${JSON.stringify(afterActive)}`);
+    if (afterActive.role !== 'radio' || afterActive.label !== 'Python') {
+      return record('J1', false, `expected first option (Python) focused on mount, got ${JSON.stringify(afterActive)}`);
+    }
+    if (afterActive.textareaValue !== 'half-typed draft') {
+      return record('J1', false, `textarea draft lost when question mounted: ${JSON.stringify(afterActive.textareaValue)}`);
+    }
+    // Starting from Python (focused via mount auto-focus, NOT yet selected).
+    // ↓↓↑ → TypeScript (Python → TypeScript → Rust → TypeScript). Same end
+    // state as the pre-#291 flow — only the starting focus changed (used to
+    // require an explicit click on the first option to seed focus).
     await win.keyboard.press('ArrowDown'); await win.waitForTimeout(40);
     await win.keyboard.press('ArrowDown'); await win.waitForTimeout(40);
     await win.keyboard.press('ArrowUp'); await win.waitForTimeout(40);
@@ -3873,7 +3892,7 @@ async function caseAskUserQuestionFull({ app, win, log }) {
     if (postSubmitFocus !== 'TEXTAREA') return record('J1', false, `after submit focus=${postSubmitFocus}, expected TEXTAREA`);
     await win.evaluate((sid) => window.__ccsmStore.getState().clearMessages(sid), sessionId);
     await clearCaptured();
-    record('J1', true, 'auto-focus did not steal textarea; ↓↓↑Enter routed TypeScript; focus returned');
+    record('J1', true, 'mount auto-focused Python (textarea draft preserved); ↓↓↑Enter routed TypeScript; focus returned');
   }
 
   // ── J2 ────────────────────────────────────────────────────────────────

--- a/scripts/harness-perm.mjs
+++ b/scripts/harness-perm.mjs
@@ -1826,6 +1826,251 @@ async function caseConnectionPane({ win, log, registerDispose }) {
   log('OK: settings.json read, no token leak, Open IPC fired');
 }
 
+// ---------- permission-focus-returns-to-textarea ----------
+// Task #291 part B: after the user resolves a permission prompt (allow / reject),
+// keyboard focus should return to the composer textarea so the next keystroke
+// types into the chat. PR #357 fixed the *mount* race (Reject focused on
+// arrival); this case covers the *response* → textarea contract.
+//
+// Reproduces the user-reported bug: "permission appears, I press n, focus
+// stays on the (now-unmounted) Reject button → next keystroke goes nowhere".
+async function casePermissionFocusReturnsToTextarea({ win, log }) {
+  await seedSession(win);
+
+  const textarea = win.locator('[data-input-bar]').first();
+  await textarea.waitFor({ state: 'visible', timeout: 5_000 });
+  // Empty composer — within the existing PermissionPromptBlock contract this
+  // means the prompt MAY steal focus on mount (composer-empty exception).
+  await textarea.click();
+  await textarea.fill('');
+
+  await injectWaiting(win, {
+    id: 'wait-FOCUS-RETURN',
+    requestId: 'FOCUS-RETURN',
+    toolInput: { command: 'echo hi' },
+    prompt: 'Bash: echo hi'
+  });
+
+  const heading = win.locator('[role="alertdialog"]').first();
+  await heading.waitFor({ state: 'visible', timeout: 5_000 });
+  // Wait for the autoFocus effect to land on Reject so 'n' is consumed by the
+  // global hotkey handler (not by the textarea) — same defensive wait used in
+  // casePermissionPrompt.
+  await win.waitForFunction(() => {
+    const el = document.activeElement;
+    return el?.getAttribute?.('data-perm-action') === 'reject';
+  }, null, { timeout: 2000 });
+
+  await win.keyboard.press('n');
+
+  try {
+    await heading.waitFor({ state: 'detached', timeout: 3_000 });
+  } catch {
+    throw new Error('permission prompt still visible after pressing N');
+  }
+
+  // Wait briefly for the focusInputNonce → InputBar effect to commit.
+  await win.waitForFunction(() => {
+    const el = document.activeElement;
+    return el instanceof HTMLTextAreaElement && el.hasAttribute('data-input-bar');
+  }, null, { timeout: 2_000 }).catch(() => {});
+
+  const after = await win.evaluate(() => {
+    const el = document.activeElement;
+    return {
+      tag: el?.tagName?.toLowerCase() ?? null,
+      isInputBarTextarea: el instanceof HTMLTextAreaElement && el.hasAttribute('data-input-bar')
+    };
+  });
+  if (!after.isInputBarTextarea) {
+    throw new Error(`expected focus to return to composer textarea after Reject (empty composer); got ${JSON.stringify(after)}`);
+  }
+
+  // Smoke test: typing now lands in the textarea.
+  await win.keyboard.type('after-reject');
+  await win.waitForTimeout(80);
+  const value = await textarea.inputValue();
+  if (!value.endsWith('after-reject')) {
+    throw new Error(`expected textarea to receive keystrokes after reject; got value=${JSON.stringify(value)}`);
+  }
+
+  // ----- Round 2: composer was non-empty when the prompt arrived. The
+  // existing "composer focused + non-empty → don't steal" exception in
+  // PermissionPromptBlock means Reject is NOT focused on mount — focus stays
+  // on the textarea. The user clicks Reject (or Allow) instead of the 'n'
+  // hotkey path. After the prompt resolves the focus contract is the same:
+  // composer textarea is the resting focus surface for the next keystroke.
+  await textarea.click();
+  await textarea.fill('mid-typed message');
+
+  await injectWaiting(win, {
+    id: 'wait-FOCUS-RETURN-2',
+    requestId: 'FOCUS-RETURN-2',
+    toolInput: { command: 'echo hi2' },
+    prompt: 'Bash: echo hi2'
+  });
+  await heading.waitFor({ state: 'visible', timeout: 5_000 });
+  // Pre-click sanity: focus retained on textarea (composer-empty exception
+  // does NOT apply when composer has content).
+  const preClick = await win.evaluate(() => {
+    const el = document.activeElement;
+    return {
+      isInputBarTextarea: el instanceof HTMLTextAreaElement && el.hasAttribute('data-input-bar'),
+      val: el instanceof HTMLTextAreaElement ? el.value : null
+    };
+  });
+  if (!preClick.isInputBarTextarea || preClick.val !== 'mid-typed message') {
+    throw new Error(`round2: expected focus retained on typed textarea pre-click; got ${JSON.stringify(preClick)}`);
+  }
+
+  // Click Reject explicitly — focus moves into the alertdialog button.
+  await win.locator('[data-perm-action="reject"]').click();
+
+  try {
+    await heading.waitFor({ state: 'detached', timeout: 3_000 });
+  } catch {
+    throw new Error('round2: permission prompt still visible after clicking Reject');
+  }
+
+  await win.waitForFunction(() => {
+    const el = document.activeElement;
+    return el instanceof HTMLTextAreaElement && el.hasAttribute('data-input-bar');
+  }, null, { timeout: 2_000 }).catch(() => {});
+
+  const after2 = await win.evaluate(() => {
+    const el = document.activeElement;
+    return {
+      tag: el?.tagName?.toLowerCase() ?? null,
+      isInputBarTextarea: el instanceof HTMLTextAreaElement && el.hasAttribute('data-input-bar'),
+      val: el instanceof HTMLTextAreaElement ? el.value : null
+    };
+  });
+  if (!after2.isInputBarTextarea) {
+    throw new Error(`round2: expected focus to return to composer textarea after click-Reject; got ${JSON.stringify(after2)}`);
+  }
+  if (after2.val !== 'mid-typed message') {
+    throw new Error(`round2: textarea draft changed; got ${JSON.stringify(after2.val)}`);
+  }
+
+  log('focus returned to textarea after permission reject in both empty + typed composer cases');
+}
+
+// ---------- question-focus-on-mount ----------
+// Task #291 part A: when an AskUserQuestion card mounts, keyboard focus should
+// move to the first option even if the user was typing in the composer at the
+// moment the question arrived. The composer draft is a controlled value and
+// won't be lost; the user's expectation (per real-use feedback) is that ↑/↓
+// + Enter just work without an extra Tab.
+//
+// PR #305 deliberately set autoFocus={false} on the QuestionStickyHost ("no
+// focus theft") — this case codifies the reversal: question takes focus on
+// mount unconditionally.
+async function caseQuestionFocusOnMount({ win, log }) {
+  await seedSession(win);
+
+  const textarea = win.locator('[data-input-bar]').first();
+  await textarea.waitFor({ state: 'visible', timeout: 5_000 });
+  await textarea.click();
+  await textarea.fill('half-typed message');
+
+  // Sanity: textarea actually focused with content before the question lands.
+  const before = await win.evaluate(() => {
+    const el = document.activeElement;
+    return {
+      tag: el?.tagName?.toLowerCase() ?? null,
+      isTextarea: el instanceof HTMLTextAreaElement,
+      value: el instanceof HTMLTextAreaElement ? el.value : null
+    };
+  });
+  if (!before.isTextarea || before.value !== 'half-typed message') {
+    throw new Error(`pre-mount focus expected typed textarea; got ${JSON.stringify(before)}`);
+  }
+
+  // Inject a question block.
+  await win.evaluate(() => {
+    const s = window.__ccsmStore.getState();
+    s.appendBlocks(s.activeId, [{
+      kind: 'question',
+      id: 'q-FOCUS-MOUNT',
+      requestId: 'q-FOCUS-MOUNT',
+      questions: [{
+        question: 'Pick a stack',
+        options: [{ label: 'TypeScript' }, { label: 'Rust' }, { label: 'Go' }]
+      }]
+    }]);
+  });
+
+  await win.waitForSelector('[data-question-option]', { timeout: 5_000 });
+
+  // The mount-focus effect runs on rAF; wait until activeElement is a question
+  // option (or until the timeout — we then snapshot to produce a clear failure).
+  await win.waitForFunction(() => {
+    const el = document.activeElement;
+    return el instanceof HTMLElement && el.hasAttribute('data-question-option');
+  }, null, { timeout: 2_000 }).catch(() => {});
+
+  const onMount = await win.evaluate(() => {
+    const el = document.activeElement;
+    return {
+      tag: el?.tagName?.toLowerCase() ?? null,
+      isOption: el instanceof HTMLElement && el.hasAttribute('data-question-option'),
+      label: el instanceof HTMLElement ? el.getAttribute('data-question-label') : null,
+      isTextarea: el instanceof HTMLTextAreaElement
+    };
+  });
+  if (onMount.isTextarea) {
+    throw new Error(`question mount did not move focus off textarea: ${JSON.stringify(onMount)}`);
+  }
+  if (!onMount.isOption) {
+    throw new Error(`expected first question option focused on mount; got ${JSON.stringify(onMount)}`);
+  }
+  if (onMount.label !== 'TypeScript') {
+    throw new Error(`expected first option (TypeScript) focused, got label=${onMount.label}`);
+  }
+
+  // ↓ moves to the next option.
+  await win.keyboard.press('ArrowDown');
+  await win.waitForTimeout(80);
+  const afterDown = await win.evaluate(() =>
+    document.activeElement instanceof HTMLElement
+      ? document.activeElement.getAttribute('data-question-label')
+      : null
+  );
+  if (afterDown !== 'Rust') {
+    throw new Error(`expected ArrowDown to move focus to Rust, got ${afterDown}`);
+  }
+
+  // Space to toggle the radio (Enter on a single-select w/ auto-advance is
+  // tricky; Space is the deterministic pick path inside QuestionBlock).
+  await win.keyboard.press(' ');
+  await win.waitForTimeout(80);
+
+  // Submit via the Submit button — clicking is more deterministic than
+  // synthesising Enter while focus is on the option (single-question form
+  // doesn't auto-submit on Enter).
+  await win.locator('[data-testid="question-submit"]').click();
+
+  // After submit, QuestionStickyHost calls bumpComposerFocus → focus should
+  // return to the textarea.
+  await win.waitForFunction(() => {
+    const el = document.activeElement;
+    return el instanceof HTMLTextAreaElement && el.hasAttribute('data-input-bar');
+  }, null, { timeout: 2_000 }).catch(() => {});
+
+  const afterSubmit = await win.evaluate(() => {
+    const el = document.activeElement;
+    return {
+      tag: el?.tagName?.toLowerCase() ?? null,
+      isInputBarTextarea: el instanceof HTMLTextAreaElement && el.hasAttribute('data-input-bar')
+    };
+  });
+  if (!afterSubmit.isInputBarTextarea) {
+    throw new Error(`expected focus back on composer textarea after submit; got ${JSON.stringify(afterSubmit)}`);
+  }
+
+  log('question stole focus from typed textarea on mount; ↑/↓ navigated; submit returned focus to textarea');
+}
+
 // ---------- harness spec ----------
 await runHarness({
   name: 'perm',
@@ -1856,6 +2101,8 @@ await runHarness({
     { id: 'permission-prompt', run: casePermissionPrompt },
     { id: 'permission-mode-strict', run: casePermissionModeStrict },
     { id: 'permission-focus-not-stolen', run: casePermissionFocusNotStolen },
+    { id: 'permission-focus-returns-to-textarea', run: casePermissionFocusReturnsToTextarea },
+    { id: 'question-focus-on-mount', run: caseQuestionFocusOnMount },
     { id: 'permission-shortcut-scope', run: casePermissionShortcutScope },
     { id: 'permission-nested-input', run: casePermissionNestedInput },
     { id: 'permission-truncate-width', run: casePermissionTruncateWidth },

--- a/src/components/QuestionBlock.tsx
+++ b/src/components/QuestionBlock.tsx
@@ -134,6 +134,14 @@ export function QuestionBlock({ questions, onSubmit, onReject, autoFocus = true 
 
   // Auto-focus first option of the active question on mount + on every page
   // change. Mirrors upstream's "切题自动 focus 第一个" behavior.
+  //
+  // Task #291 — we DO steal focus from the composer textarea on mount. The
+  // question card is the dominant interaction surface once it appears; the
+  // composer draft is a controlled value, so taking focus doesn't lose what
+  // the user typed. The only thing we still respect is focus already living
+  // INSIDE the question (e.g. a freshly-mounted "Other" contenteditable)
+  // because re-running on `active` change shouldn't yank focus off something
+  // the user is currently typing into.
   useEffect(() => {
     if (!autoFocus || submitted) return;
     const root = optionsRef.current;
@@ -142,12 +150,11 @@ export function QuestionBlock({ questions, onSubmit, onReject, autoFocus = true 
       const target = root.querySelector<HTMLElement>('[data-question-option]');
       if (!target) return;
       const ae = document.activeElement as HTMLElement | null;
-      // Don't steal focus from a text-entry surface the user is actively
-      // typing in. The composer (TEXTAREA) and any INPUT/contenteditable
-      // are excluded — sticky widget appears alongside the composer, not
-      // on top of it.
-      if (ae && ae !== document.body && (ae.tagName === 'INPUT' || ae.tagName === 'TEXTAREA')) return;
-      if (ae && ae.isContentEditable && ae !== target) return;
+      // Don't steal focus from an element already inside the options group —
+      // covers the inline "Other" contenteditable that a previous interaction
+      // moved focus to. Composer textarea / external inputs are NOT exempt:
+      // when the question mounts, it takes over.
+      if (ae && root.contains(ae) && ae !== target) return;
       target.focus({ preventScroll: true });
     });
     return () => cancelAnimationFrame(id);

--- a/src/components/QuestionStickyHost.tsx
+++ b/src/components/QuestionStickyHost.tsx
@@ -44,7 +44,14 @@ export function QuestionStickyHost({ sessionId }: { sessionId: string }) {
       <QuestionBlock
         key={block.id}
         questions={block.questions}
-        autoFocus={false}
+        // autoFocus defaults to true: when the agent asks a question the
+        // sticky widget takes focus even if the user was mid-typing in the
+        // composer. The composer draft is a controlled state and isn't lost.
+        // Reverses PR #305's "no focus theft" choice — task #291 user testing
+        // showed leaving focus on the textarea breaks the ↑/↓ + Enter flow
+        // (the keystrokes go into the composer instead of navigating
+        // options) which is the dominant interaction the question card is
+        // designed for.
         onSubmit={(answersByQuestion) => {
           const api = window.ccsm;
           if (!api) return;


### PR DESCRIPTION
Closes task #291. Builds on PR #357 (permission mount-focus race fix).

## User report
> "我的焦点在输入框，输了东西，然后它问我问题，焦点还在输入框，而不在问题的选项上"

When an AskUserQuestion arrives while the composer textarea is focused, focus stays on the textarea, so ↑/↓ + Enter type into the composer instead of navigating + selecting options. The contract should be: question/permission appears → it takes focus → user navigates → submit returns focus to textarea.

## Scope (one fix, not two)

The task spec assumed both AUQ and Permission needed fixes. After writing the e2e baseline:
- AUQ mount focus: **broken** — fix needed.
- Permission post-resolve focus: **already works** — `store.resolvePermission` bumps `focusInputNonce` and InputBar's effect picks it up. The new e2e covers it as a regression guard but no code change required.

So this PR is one fix + two e2e cases.

## Root cause (AUQ)
- `QuestionStickyHost.tsx:47` passed `autoFocus={false}` (PR #305).
- `QuestionBlock.tsx`'s mount-focus useEffect additionally bailed when `activeElement` was a TEXTAREA/INPUT/contenteditable.

Combined, the question card never grabbed focus when the composer was the active element — exactly the user's path (type, send, agent asks question, focus stays in textarea).

## Fix
- `QuestionStickyHost.tsx`: drop `autoFocus={false}` (default `true` now applies).
- `QuestionBlock.tsx`: remove the TEXTAREA/INPUT guard from the mount-focus effect. Narrower guard remains: don't steal from elements already inside the options group (protects the inline "Other" contenteditable on page change).

The composer draft is a controlled value, so taking focus doesn't lose typed content. PR #305's "composer focus is sacred" choice is intentionally reversed here for AUQ — the question card is the dominant interaction surface once it appears. PermissionPromptBlock's "composer focused + non-empty → don't steal" exception is unchanged (different contract — see `permission-focus-not-stolen` case which still passes).

## E2E

Two new cases in `scripts/harness-perm.mjs`:

1. `question-focus-on-mount` — typed-composer + question arrival → first option focused → ↑/↓ navigates → submit returns focus to textarea.
2. `permission-focus-returns-to-textarea` — covers both rounds (empty composer + typed composer) of post-resolve focus return. Regression guard for already-working behavior.

### Before (failing baseline, after the test commit, before the fix commit)

```
[harness=perm] >>> case question-focus-on-mount
[case=question-focus-on-mount] FAIL: question mount did not move focus off textarea: {"tag":"textarea","isOption":false,"label":null,"isTextarea":true}

=== harness=perm summary (5185ms wall) ===
  [XX] question-focus-on-mount                    2939ms
=== totals: 0 passed, 1 failed, 0 skipped, 1 total ===
```

(`permission-focus-returns-to-textarea` already PASSED at baseline.)

### After (current HEAD)

```
[harness=perm] >>> case permission-prompt
[case=permission-prompt] expanded=yes rejectFocused=yes keyboard Y/N works
[case=permission-prompt] OK
[harness=perm] >>> case permission-focus-not-stolen
[case=permission-focus-not-stolen] focus retained on textarea, typing not intercepted by permission block
[case=permission-focus-not-stolen] OK
[harness=perm] >>> case permission-focus-returns-to-textarea
[case=permission-focus-returns-to-textarea] focus returned to textarea after permission reject in both empty + typed composer cases
[case=permission-focus-returns-to-textarea] OK
[harness=perm] >>> case question-focus-on-mount
[case=question-focus-on-mount] question stole focus from typed textarea on mount; ↑/↓ navigated; submit returned focus to textarea
[case=question-focus-on-mount] OK
[harness=perm] >>> case permission-sequential-focus
[case=permission-sequential-focus] focus correctly transfers to second block's Reject
[case=permission-sequential-focus] OK
[harness=perm] >>> case askuserquestion-no-dup-and-resolves
[case=askuserquestion-no-dup-and-resolves] AskUserQuestion dedup + resolve routing locked down
[case=askuserquestion-no-dup-and-resolves] OK
=== totals: 6 passed, 0 failed, 0 skipped, 6 total ===
```

## Also verified
- `npm test -- question-block question-sticky permission-prompt` → 50/50 passed.
- `npm run typecheck` → clean.
- `npm run build` → clean (1 unrelated webpack-size warning, pre-existing).
- `tests/inputbar.test.tsx` had 35 pre-existing failures (`useToast must be used inside <ToastProvider>`) on origin/working too — out of scope.

## Test plan
- [ ] Open ccsm, send a message that triggers AskUserQuestion (e.g. "I want to start a project, but ask me 3 questions first via AskUserQuestion").
- [ ] Type some characters in the composer mid-stream (before the question card mounts).
- [ ] When the question card appears, verify ↑/↓ navigates options, Space/Enter selects, Submit returns focus to the composer.
- [ ] Verify a permission prompt (Bash) with empty composer still autofocuses Reject (no regression).
- [ ] Verify a permission prompt with a typed composer leaves focus on textarea (no regression — `permission-focus-not-stolen` passes).