### PR TITLE
feat(history): default cwd/model from frequency of last 10 sessions

### DIFF
--- a/electron/import-scanner.ts
+++ b/electron/import-scanner.ts
@@ -220,28 +220,45 @@ function truncate(s: string, n: number): string {
 }
 
 /**
- * Derive a deduped list of recently-used cwds from a (presumably mtime-sorted)
- * scan result. Most-recent first, dropping the placeholder `~` entries the
- * scanner emits when no `cwd` field was found in the transcript head — those
- * would default the picker to the user's home dir, which is rarely useful.
- * Caps at `max` entries so the dropdown stays a reasonable length.
+ * Derive a frequency-ranked list of recently-used cwds from a scan result.
+ *
+ * Algorithm (task #293 — dogfood-driven default-cwd correctness):
+ *   1. Take the last `windowSize=10` sessions by mtime (most-recent first).
+ *   2. Count how often each cwd appears in that window.
+ *   3. Return the top `max=10` cwds sorted by frequency desc, ties broken by
+ *      most-recent occurrence so a directory the user just opened wins over
+ *      an equally-frequent but stale one.
+ *
+ * Why frequency over pure recency: a one-off `cd` into a side project
+ * shouldn't override the directory the user actually works in 9 days out
+ * of 10. The CLI transcript history is exactly the right signal for "where
+ * does this user usually work" — we just had to read it correctly.
+ *
+ * Drops placeholder `~` entries the scanner emits when no `cwd` field was
+ * found in the transcript head; those would default the picker to the
+ * user's home dir, which is rarely useful.
  */
 export function deriveRecentCwds(
   sessions: ReadonlyArray<Pick<ScannableSession, 'cwd' | 'mtime'>>,
-  max = 10
+  max = 10,
+  windowSize = 10
 ): string[] {
-  const ordered = [...sessions].sort((a, b) => b.mtime - a.mtime);
-  const seen = new Set<string>();
-  const out: string[] = [];
+  if (sessions.length === 0) return [];
+  const ordered = [...sessions].sort((a, b) => b.mtime - a.mtime).slice(0, windowSize);
+  const counts = new Map<string, number>();
+  const lastSeen = new Map<string, number>();
   for (const s of ordered) {
     const cwd = s.cwd;
     if (!cwd || cwd === '~') continue;
-    if (seen.has(cwd)) continue;
-    seen.add(cwd);
-    out.push(cwd);
-    if (out.length >= max) break;
+    counts.set(cwd, (counts.get(cwd) ?? 0) + 1);
+    if (!lastSeen.has(cwd)) lastSeen.set(cwd, s.mtime);
   }
-  return out;
+  if (counts.size === 0) return [];
+  const ranked = Array.from(counts.entries()).sort((a, b) => {
+    if (b[1] !== a[1]) return b[1] - a[1];
+    return (lastSeen.get(b[0]) ?? 0) - (lastSeen.get(a[0]) ?? 0);
+  });
+  return ranked.slice(0, max).map(([cwd]) => cwd);
 }
 
 // A frame written by the CLI for a sub-agent (Task tool spawn) carries either
@@ -304,14 +321,18 @@ function extractModel(d: any): string | null {
 }
 
 /**
- * Most-frequently-observed model across the (presumably mtime-sorted) recent
- * `max` sessions. Ties broken by most-recent occurrence so a model the user
+ * Most-frequently-observed model across the most recent `max=10` sessions
+ * (by mtime). Ties broken by most-recent occurrence so a model the user
  * just switched to wins over a stale historical favourite. Returns null on
  * empty input or when no session carries a model.
+ *
+ * The 10-session window matches `deriveRecentCwds` (task #293) — the
+ * default-cwd and default-model both derive from the same "last 10 things
+ * the user actually did" signal so they tell a consistent story.
  */
 export function deriveTopModel(
   sessions: ReadonlyArray<Pick<ScannableSession, 'model' | 'mtime'>>,
-  max = 50
+  max = 10
 ): string | null {
   if (sessions.length === 0) return null;
   const ordered = [...sessions].sort((a, b) => b.mtime - a.mtime).slice(0, max);

--- a/scripts/harness-restore.mjs
+++ b/scripts/harness-restore.mjs
@@ -1638,8 +1638,195 @@ async function casePermissionPromptDefaultMode({ log, registerDispose }) {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// Harness spec.
+// CASE: default-cwd-model-from-recent-history
+// Pre-launch fixture: plant 10 JSONL transcripts under a sandboxed HOME with
+// controlled cwd/model frequency distributions. Boot the app, call
+// `createSession()`, assert the new session's `cwd` and `model` come from the
+// MOST-FREQUENT cwd/model in the last 10 CLI sessions — not the most recent.
+//
+// Task #293: dogfood found that default cwd/model on a fresh session were
+// pulling from "most recently mtime'd" CLI session, which means a one-off
+// `cd` into a side project hijacks the default. Fix: derive defaults from
+// frequency over the last 10 sessions.
 // ──────────────────────────────────────────────────────────────────────────
+async function caseDefaultCwdModelFromRecentHistory({ log, registerDispose }) {
+  const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ccsm-harness-default-cwd-home-'));
+  registerDispose(() => { try { fs.rmSync(fakeHome, { recursive: true, force: true }); } catch {} });
+  const projectsRoot = path.join(fakeHome, '.claude', 'projects');
+  fs.mkdirSync(projectsRoot, { recursive: true });
+
+  // The frequency-ranked default sources from the last 10 jsonl files by mtime.
+  // We design the 10 fixtures so:
+  //   cwd  /path/A appears 6x, /path/B appears 4x  → expect default = /path/A
+  //   model claude-opus-4-7[1m] appears 7x,
+  //         claude-sonnet-4-6   appears 3x         → expect default = opus[1m]
+  //
+  // To prove this is FREQUENCY (not "most-recent mtime"), we make the SINGLE
+  // most-recent fixture be the (B, sonnet) pair — pure-recency code would
+  // pick those, frequency code picks (A, opus[1m]). That's the key bug
+  // signal from dogfood.
+  //
+  // mtime layout (newest → oldest):
+  //   t=10  → cwd /path/B, model sonnet  ← most recent (would win in old code)
+  //   t=9   → cwd /path/B, model opus[1m]
+  //   t=8   → cwd /path/A, model opus[1m]
+  //   t=7   → cwd /path/A, model opus[1m]
+  //   t=6   → cwd /path/B, model opus[1m]
+  //   t=5   → cwd /path/A, model opus[1m]
+  //   t=4   → cwd /path/A, model opus[1m]
+  //   t=3   → cwd /path/A, model opus[1m]
+  //   t=2   → cwd /path/B, model sonnet
+  //   t=1   → cwd /path/A, model sonnet
+  //   ─────────────────────────────────────
+  //   /path/A: 6, /path/B: 4
+  //   opus[1m]: 7, sonnet: 3
+  const fixtures = [
+    { mtime: 10, cwd: '/path/B', model: 'claude-sonnet-4-6' },
+    { mtime: 9,  cwd: '/path/B', model: 'claude-opus-4-7[1m]' },
+    { mtime: 8,  cwd: '/path/A', model: 'claude-opus-4-7[1m]' },
+    { mtime: 7,  cwd: '/path/A', model: 'claude-opus-4-7[1m]' },
+    { mtime: 6,  cwd: '/path/B', model: 'claude-opus-4-7[1m]' },
+    { mtime: 5,  cwd: '/path/A', model: 'claude-opus-4-7[1m]' },
+    { mtime: 4,  cwd: '/path/A', model: 'claude-opus-4-7[1m]' },
+    { mtime: 3,  cwd: '/path/A', model: 'claude-opus-4-7[1m]' },
+    { mtime: 2,  cwd: '/path/B', model: 'claude-sonnet-4-6' },
+    { mtime: 1,  cwd: '/path/A', model: 'claude-sonnet-4-6' },
+  ];
+
+  // Plant each fixture as a separate jsonl, under the projectKey-from-cwd
+  // directory the scanner reads from. Each session needs the cwd field on
+  // the first user frame (so parseHead picks it up) and the model field on
+  // an assistant frame.
+  const baseTime = Date.now() - 10 * 60_000; // 10 min ago, drift-safe
+  for (let i = 0; i < fixtures.length; i++) {
+    const f = fixtures[i];
+    const sid = `00000000-0000-4000-8000-00000000000${(i + 1).toString(16)}`;
+    const projDir = path.join(projectsRoot, projectKeyFromCwd(f.cwd));
+    fs.mkdirSync(projDir, { recursive: true });
+    const filePath = path.join(projDir, `${sid}.jsonl`);
+    const ts = new Date(baseTime + f.mtime * 1000).toISOString();
+    const frames = [
+      {
+        type: 'user', parentUuid: null, isSidechain: false, uuid: `u-${i}`,
+        cwd: f.cwd, sessionId: sid, timestamp: ts,
+        message: { role: 'user', content: [{ type: 'text', text: `probe ${i}` }] }
+      },
+      {
+        type: 'assistant', session_id: sid, parentUuid: `u-${i}`, isSidechain: false,
+        uuid: `a-${i}`, cwd: f.cwd, timestamp: ts,
+        message: {
+          id: `msg-${i}`, role: 'assistant', model: f.model,
+          content: [{ type: 'text', text: `reply ${i}` }]
+        }
+      }
+    ];
+    fs.writeFileSync(filePath, frames.map((fr) => JSON.stringify(fr)).join('\n') + '\n');
+    // Force the file mtime to match the intended ordering — fs.writeFileSync
+    // uses wallclock and a 10-fixture loop can complete inside one ms tick,
+    // collapsing the ordering. Explicit utimes nails it down.
+    const wantMs = baseTime + f.mtime * 1000;
+    fs.utimesSync(filePath, wantMs / 1000, wantMs / 1000);
+  }
+  log(`planted 10 fixtures under ${projectsRoot} (cwd /path/A:6 /path/B:4; model opus[1m]:7 sonnet:3)`);
+
+  const ud = isolatedUserData('ccsm-harness-default-cwd-userdata');
+  registerDispose(ud.cleanup);
+
+  const app = await electron.launch({
+    args: ['.', `--user-data-dir=${ud.dir}`],
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      NODE_ENV: 'production',
+      CCSM_PROD_BUNDLE: '1',
+      HOME: fakeHome,
+      USERPROFILE: fakeHome,
+      CLAUDE_HOME: fakeHome
+    }
+  });
+  let closed = false;
+  registerDispose(async () => { if (!closed) try { await app.close(); } catch {} });
+
+  try {
+    const win = await waitReady(app);
+
+    // Wait for the boot-time history scan IPC to populate the renderer
+    // store. The store seeds `historyRecentCwds` + `historyTopModel` from
+    // `window.ccsm.recentCwds()` + `topModel()` — both are async and not
+    // awaited by hydration, so we poll until the values land.
+    await win.waitForFunction(
+      () => {
+        const s = window.__ccsmStore?.getState?.();
+        return !!s && Array.isArray(s.historyRecentCwds) && s.historyRecentCwds.length > 0 && typeof s.historyTopModel === 'string';
+      },
+      null,
+      { timeout: 15_000 }
+    );
+
+    // Snapshot what the renderer thinks the history defaults are, before
+    // we exercise createSession. If THIS is wrong, the createSession
+    // assertion below will fail too, but the snapshot lets us pinpoint
+    // whether the regression is in the IPC scan or in the store fallback.
+    const seeded = await win.evaluate(() => {
+      const s = window.__ccsmStore.getState();
+      return {
+        historyRecentCwds: s.historyRecentCwds,
+        historyTopModel: s.historyTopModel,
+        // Also snapshot the in-memory store's `model` and `recentProjects`
+        // — both should be empty on this fresh user-data dir, which is
+        // what makes the history-derived defaults the actual source.
+        globalModel: s.model,
+        recentProjectsCount: (s.recentProjects ?? []).length,
+      };
+    });
+    log(`seeded defaults: historyRecentCwds[0]=${seeded.historyRecentCwds[0]} historyTopModel=${seeded.historyTopModel} (globalModel="${seeded.globalModel}", recentProjects=${seeded.recentProjectsCount})`);
+
+    if (seeded.historyRecentCwds[0] !== '/path/A') {
+      throw new Error(`task#293: historyRecentCwds[0] should be the FREQUENCY-TOP cwd (/path/A appears 6x); got ${JSON.stringify(seeded.historyRecentCwds)}`);
+    }
+    if (seeded.historyTopModel !== 'claude-opus-4-7[1m]') {
+      throw new Error(`task#293: historyTopModel should be the FREQUENCY-TOP model (claude-opus-4-7[1m] appears 7x); got ${seeded.historyTopModel}`);
+    }
+
+    // Now drive createSession() and verify the new session inherits the
+    // frequency-top cwd + model. We zero out `sessions` first so the
+    // task328 group-recent-cwd path doesn't shadow the history default
+    // (no sessions in any group → falls through to historyRecentCwds[0]).
+    const created = await win.evaluate(() => {
+      const st = window.__ccsmStore;
+      st.setState({
+        sessions: [],
+        groups: [{ id: 'g-default', name: 'Sessions', collapsed: false, kind: 'normal' }],
+        activeId: '',
+        focusedGroupId: 'g-default',
+        // Defensive: belt-and-suspenders zero-out for a possibly-persisted
+        // global model from a prior install. With the user-data dir freshly
+        // created this is already '', but stating it makes the assertion
+        // about "frequency-default wins" unambiguous.
+        model: '',
+        recentProjects: [],
+      });
+      st.getState().createSession();
+      const s = st.getState();
+      const newSession = s.sessions[0];
+      return { cwd: newSession?.cwd, model: newSession?.model };
+    });
+    log(`createSession() produced cwd=${created.cwd} model=${created.model}`);
+
+    if (created.cwd !== '/path/A') {
+      throw new Error(`task#293: new session cwd should be /path/A (most-frequent in last 10 sessions); got ${created.cwd}`);
+    }
+    if (created.model !== 'claude-opus-4-7[1m]') {
+      throw new Error(`task#293: new session model should be claude-opus-4-7[1m] (most-frequent in last 10 sessions); got ${created.model}`);
+    }
+    log(`task#293 PASS — default cwd/model derive from last-10 frequency`);
+  } finally {
+    closed = true;
+    try { await app.close(); } catch {}
+  }
+}
+
+
 await runHarness({
   name: 'restore',
   // Every case is skipLaunch — they all manage their own electron lifecycle
@@ -1659,6 +1846,10 @@ await runHarness({
     // permission-prompt-default-mode: 2-launch (seed → close → relaunch)
     // with sandboxed CLAUDE_CONFIG_DIR + real claude.exe Bash invocation.
     // 桶 3 worker classified as restore-fits-the-multi-launch pattern.
-    { id: 'permission-prompt-default-mode', skipLaunch: true, requiresClaudeBin: true, run: casePermissionPromptDefaultMode }
+    { id: 'permission-prompt-default-mode', skipLaunch: true, requiresClaudeBin: true, run: casePermissionPromptDefaultMode },
+    // task#293: default cwd/model on a fresh session derive from frequency
+    // over the last 10 CLI sessions. Pre-launch HOME sandbox + 10 jsonl
+    // fixtures with controlled cwd/model distribution.
+    { id: 'default-cwd-model-from-recent-history', skipLaunch: true, run: caseDefaultCwdModelFromRecentHistory }
   ]
 });

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -1121,14 +1121,20 @@ export const useStore = create<State & Actions>((set, get) => ({
     // prefer the most-recent session in the target group that has a usable
     // cwd. `sessions` is ordered newest-first (createSession prepends), so
     // the first match is the most recent. Falls through to the global
-    // recentProjects/historyRecentCwds defaults when the group is empty or
+    // historyRecentCwds/recentProjects defaults when the group is empty or
     // none of its sessions have a cwd. `(none)` chip placeholder appears
     // only when ALL of these resolve to empty.
+    //
+    // task#293: `historyRecentCwds[0]` (now frequency-ranked from the last
+    // 10 CLI sessions) takes precedence over `recentProjects[0]?.path` (a
+    // pure recency list of in-app picks). If the user works in a directory
+    // 9 out of 10 sessions, that's their default — a one-off chip pick
+    // shouldn't override it.
     const groupRecentCwd = sessions.find(
       (x) => x.groupId === targetGroupId && !!x.cwd
     )?.cwd;
     const defaultCwd =
-      groupRecentCwd ?? recentProjects[0]?.path ?? historyRecentCwds[0] ?? '';
+      groupRecentCwd ?? historyRecentCwds[0] ?? recentProjects[0]?.path ?? '';
     let initialModel = model;
     if (!initialModel) initialModel = historyTopModel ?? '';
     if (!initialModel) initialModel = connection?.model ?? '';

--- a/tests/import-scanner.test.ts
+++ b/tests/import-scanner.test.ts
@@ -186,22 +186,28 @@ describe('deriveRecentCwds', () => {
     expect(deriveRecentCwds([])).toEqual([]);
   });
 
-  it('orders by mtime descending', () => {
+  it('ranks by frequency in the recent window, ties broken by recency', () => {
+    // /a appears 3x, /b 2x, /c 1x → frequency order /a, /b, /c.
     expect(
       deriveRecentCwds([
         { cwd: '/a', mtime: 100 },
-        { cwd: '/b', mtime: 300 },
-        { cwd: '/c', mtime: 200 },
+        { cwd: '/b', mtime: 90 },
+        { cwd: '/a', mtime: 80 },
+        { cwd: '/b', mtime: 70 },
+        { cwd: '/a', mtime: 60 },
+        { cwd: '/c', mtime: 50 },
       ])
-    ).toEqual(['/b', '/c', '/a']);
+    ).toEqual(['/a', '/b', '/c']);
   });
 
-  it('dedupes repeated cwds, keeping the most-recent occurrence', () => {
+  it('breaks frequency ties by most-recent occurrence', () => {
+    // /a + /b each 2x; /a's most recent mtime is 100, /b's is 90 → /a wins.
     expect(
       deriveRecentCwds([
         { cwd: '/a', mtime: 100 },
-        { cwd: '/a', mtime: 500 },
-        { cwd: '/b', mtime: 300 },
+        { cwd: '/b', mtime: 90 },
+        { cwd: '/a', mtime: 50 },
+        { cwd: '/b', mtime: 40 },
       ])
     ).toEqual(['/a', '/b']);
   });
@@ -224,24 +230,36 @@ describe('deriveRecentCwds', () => {
     ).toEqual(['/real']);
   });
 
-  it('caps at the requested max', () => {
-    const sessions = Array.from({ length: 25 }, (_, i) => ({
-      cwd: `/p${i}`,
-      mtime: 1000 - i,
-    }));
-    const cwds = deriveRecentCwds(sessions, 10);
-    expect(cwds).toHaveLength(10);
-    // mtime descending → /p0 is newest
-    expect(cwds[0]).toBe('/p0');
-    expect(cwds[9]).toBe('/p9');
+  it('only counts the most-recent windowSize sessions (default 10)', () => {
+    // Older /b appears 100x, but only the 10 most-recent enter the window
+    // and those 10 are all /a. Frequency in window: /a=10, /b=0.
+    const sessions = [
+      ...Array.from({ length: 10 }, (_, i) => ({ cwd: '/a', mtime: 1000 - i })),
+      ...Array.from({ length: 100 }, (_, i) => ({ cwd: '/b', mtime: 100 - i })),
+    ];
+    expect(deriveRecentCwds(sessions)).toEqual(['/a']);
   });
 
-  it('defaults max to 10', () => {
-    const sessions = Array.from({ length: 15 }, (_, i) => ({
+  it('honours a custom windowSize', () => {
+    // windowSize=3 → only the 3 newest sessions count: /b, /b, /a → /b wins.
+    const sessions = [
+      { cwd: '/b', mtime: 300 },
+      { cwd: '/b', mtime: 200 },
+      { cwd: '/a', mtime: 100 },
+      { cwd: '/a', mtime: 50 },
+      { cwd: '/a', mtime: 10 },
+    ];
+    expect(deriveRecentCwds(sessions, 10, 3)).toEqual(['/b', '/a']);
+  });
+
+  it('caps the output at max entries', () => {
+    // 12 distinct cwds, each appears once in the window. Default windowSize=10
+    // takes the 10 most-recent, max=5 returns top 5.
+    const sessions = Array.from({ length: 12 }, (_, i) => ({
       cwd: `/p${i}`,
       mtime: 1000 - i,
     }));
-    expect(deriveRecentCwds(sessions)).toHaveLength(10);
+    expect(deriveRecentCwds(sessions, 5)).toHaveLength(5);
   });
 });
 
@@ -308,6 +326,8 @@ describe('deriveTopModel', () => {
   });
 
   it('honours the max window — older entries past the cap are ignored', () => {
+    // Default cap is 10 (matches deriveRecentCwds for consistent default-
+    // sourcing). With a tiny cap of 1, only the single newest entry counts.
     const sessions = [
       { model: 'recent-model', mtime: 500 },
       ...Array.from({ length: 60 }, (_, i) => ({
@@ -316,5 +336,23 @@ describe('deriveTopModel', () => {
       })),
     ];
     expect(deriveTopModel(sessions, 1)).toBe('recent-model');
+  });
+
+  it('default max=10 means older sessions past the 10th are ignored', () => {
+    // 9 newest sessions are all 'opus[1m]', the 10th newest is 'sonnet',
+    // and there are 100 ancient 'haiku' sessions. Within the last-10 window
+    // opus has 9 hits, sonnet has 1, haiku has 0 → opus wins.
+    const sessions = [
+      ...Array.from({ length: 9 }, (_, i) => ({
+        model: 'claude-opus-4-7[1m]',
+        mtime: 1000 - i,
+      })),
+      { model: 'claude-sonnet-4-6', mtime: 990 },
+      ...Array.from({ length: 100 }, (_, i) => ({
+        model: 'claude-haiku-4-5',
+        mtime: 100 - i,
+      })),
+    ];
+    expect(deriveTopModel(sessions)).toBe('claude-opus-4-7[1m]');
   });
 });


### PR DESCRIPTION
## Summary

Dogfood (task #293): a fresh session's default cwd + model were getting hijacked by single one-off `cd`s into side projects — both defaults derived from "most-recently-mtime'd CLI session", so any stray run shifted the picker away from where the user actually works.

Fix per user direction (locked):
> 软件启动的时候看最近10次的cwd和model，里面最频繁的为默认值。我们启动的时候本来就要看历史session，结合一下

i.e. on app cold-start, scan the last 10 history sessions; the most-frequent cwd / model in that window become the global defaults. Reuses the existing import-scanner (already runs at boot) — no new IPC.

## Algorithm

`deriveRecentCwds(sessions, max=10, windowSize=10)`:
1. take the `windowSize` most-recent sessions by mtime
2. count occurrences of each cwd
3. sort desc by count, ties broken by most-recent occurrence
4. return top `max`

`deriveTopModel(sessions, max=10)`: same shape; `max` window dropped from 50 → 10 so cwd + model defaults derive from the same conversation window and tell a consistent story.

`createSession()` cwd fallback chain reordered:
- before: `groupRecent ?? recentProjects[0] ?? historyRecentCwds[0] ?? ''`
- after:  `groupRecent ?? historyRecentCwds[0] ?? recentProjects[0] ?? ''`

The CLI history is a stronger "where do you work" signal than a one-off chip pick. Model fallback chain unchanged — `historyTopModel` was already consulted after the persisted global `model`; with the new last-10 window it now correctly answers "which model are you on right now" instead of "which model dominated 50 sessions ago".

## Test plan

- [x] vitest `tests/import-scanner.test.ts` — rewrote `deriveRecentCwds` suite for frequency semantics, added `deriveTopModel` last-10 window assertion (42 tests pass)
- [x] vitest related stores: `effort`, `first-run-empty-state`, `persisted-keys-source-of-truth` (all pass)
- [x] typecheck (`tsc --noEmit`) clean
- [x] webpack production build clean
- [x] e2e `scripts/harness-restore.mjs --only=default-cwd-model-from-recent-history`:
  - plants 10 jsonl fixtures under sandboxed HOME with cwd /path/A:6 /path/B:4 (B is mtime-newest), model opus[1m]:7 sonnet:3 (sonnet is mtime-newest)
  - boots app, asserts `historyRecentCwds[0] === /path/A`, `historyTopModel === claude-opus-4-7[1m]`
  - calls `createSession()`, asserts new session inherits `(/path/A, opus[1m])`
- [x] **reverse-verified**: stashing the fix on top of the test-only commit makes the e2e fail with `historyRecentCwds[0]=/path/B` (mtime-newest leaks through) — confirms the test would catch a regression

### Before (mtime-newest leaks)

```
seeded defaults: historyRecentCwds[0]=/path/B historyTopModel=claude-opus-4-7[1m]
FAIL: historyRecentCwds[0] should be the FREQUENCY-TOP cwd (/path/A appears 6x); got ["/path/B","/path/A"]
```

### After (frequency-top wins)

```
seeded defaults: historyRecentCwds[0]=/path/A historyTopModel=claude-opus-4-7[1m]
createSession() produced cwd=/path/A model=claude-opus-4-7[1m]
task#293 PASS — default cwd/model derive from last-10 frequency
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)