### PR TITLE
feat(question): UX parity with PermissionPromptBlock + 8 fixes

### DIFF
--- a/scripts/harness-perm.mjs
+++ b/scripts/harness-perm.mjs
@@ -2337,6 +2337,493 @@ async function caseQuestionFocusOnMount({ win, log }) {
   log('question stole focus from typed textarea on mount; ↑/↓ navigated; submit returned focus to textarea');
 }
 
+// ---------- question-tab-trap-cycles ----------
+// Task #307 bug 1: Tab key inside the question card must cycle through
+// option buttons + Submit instead of escaping to the composer textarea.
+// Mirrors the focus-trap on PermissionPromptBlock (lines 249-263).
+async function caseQuestionTabTrapCycles({ win, log }) {
+  await seedSession(win);
+  await win.evaluate(() => {
+    const s = window.__ccsmStore.getState();
+    s.appendBlocks(s.activeId, [{
+      kind: 'question',
+      id: 'q-TAB-TRAP',
+      requestId: 'q-TAB-TRAP',
+      questions: [{
+        question: 'Pick a stack',
+        options: [{ label: 'TypeScript' }, { label: 'Rust' }, { label: 'Go' }]
+      }]
+    }]);
+  });
+
+  await win.waitForSelector('[data-question-option]', { timeout: 5_000 });
+  // Wait for autoFocus to land on first option.
+  await win.waitForFunction(() => {
+    const el = document.activeElement;
+    return el instanceof HTMLElement && el.hasAttribute('data-question-option');
+  }, null, { timeout: 2_000 });
+
+  // 4 options (TS, Rust, Go, Other) + 1 submit button = 5 stops.
+  // Tab 5 times: should wrap back to first option.
+  // Also verify focus never leaves card.
+  const stops = [];
+  for (let i = 0; i < 6; i++) {
+    const here = await win.evaluate(() => {
+      const el = document.activeElement;
+      const inCard = !!el?.closest?.('[data-question-sticky]');
+      return {
+        inCard,
+        label: el instanceof HTMLElement ? el.getAttribute('data-question-label') : null,
+        testid: el instanceof HTMLElement ? el.getAttribute('data-testid') : null,
+        tag: el?.tagName?.toLowerCase() ?? null
+      };
+    });
+    stops.push(here);
+    if (!here.inCard) {
+      throw new Error(`Tab #${i} escaped the question card; focus=${JSON.stringify(here)}; trail=${JSON.stringify(stops)}`);
+    }
+    await win.keyboard.press('Tab');
+    await win.waitForTimeout(50);
+  }
+
+  // Final stop after 6 Tabs should be back on first option (cycled).
+  const final = await win.evaluate(() => {
+    const el = document.activeElement;
+    return {
+      label: el instanceof HTMLElement ? el.getAttribute('data-question-label') : null,
+      inCard: !!el?.closest?.('[data-question-sticky]')
+    };
+  });
+  if (!final.inCard) {
+    throw new Error(`final Tab escaped card: ${JSON.stringify(final)}`);
+  }
+
+  log(`tab cycled 6 times within question card; trail=${stops.map(s => s.label ?? s.testid ?? s.tag).join(' -> ')}`);
+}
+
+// ---------- question-yn-hotkey ----------
+// Task #307 bug 2: Y/N hotkeys should pick first/last option for a binary
+// Yes/No single-select. Only enabled when single-select + 2 options +
+// labels start with Y / N (case-insensitive) — otherwise we don't hijack.
+async function caseQuestionYNHotkey({ win, log }) {
+  await seedSession(win);
+
+  // Stub agent:send + agent:resolvePermission so submit doesn't fan out.
+  const submitsCaptured = await win.evaluate(() => {
+    const captured = { sends: [], resolves: [] };
+    window.__ccsmTestCapture = captured;
+    const orig = window.ccsm;
+    window.ccsm = new Proxy(orig, {
+      get(t, k) {
+        if (k === 'agentSend') return async (...a) => { captured.sends.push(a); };
+        if (k === 'agentResolvePermission') return async (...a) => { captured.resolves.push(a); };
+        return Reflect.get(t, k);
+      }
+    });
+    return true;
+  });
+
+  await win.evaluate(() => {
+    const s = window.__ccsmStore.getState();
+    s.appendBlocks(s.activeId, [{
+      kind: 'question',
+      id: 'q-YN',
+      requestId: 'q-YN',
+      questions: [{
+        question: 'Confirm action?',
+        options: [{ label: 'Yes' }, { label: 'No' }]
+      }]
+    }]);
+  });
+
+  await win.waitForSelector('[data-question-option]', { timeout: 5_000 });
+  await win.waitForFunction(() => {
+    const el = document.activeElement;
+    return el instanceof HTMLElement && el.hasAttribute('data-question-option');
+  }, null, { timeout: 2_000 });
+
+  // Press Y → should pick "Yes". Single-question form does NOT auto-submit
+  // (auto-advance only triggers between questions); but selection should land.
+  await win.keyboard.press('y');
+  await win.waitForTimeout(120);
+  const afterY = await win.evaluate(() => {
+    const el = document.querySelector('[data-question-option][data-question-label="Yes"]');
+    return el?.getAttribute('aria-checked');
+  });
+  if (afterY !== 'true') {
+    throw new Error(`expected Yes selected after pressing Y; got aria-checked=${afterY}`);
+  }
+
+  // Press N → should switch selection to "No".
+  await win.keyboard.press('n');
+  await win.waitForTimeout(120);
+  const afterN = await win.evaluate(() => {
+    const yes = document.querySelector('[data-question-option][data-question-label="Yes"]')?.getAttribute('aria-checked');
+    const no = document.querySelector('[data-question-option][data-question-label="No"]')?.getAttribute('aria-checked');
+    return { yes, no };
+  });
+  if (afterN.no !== 'true' || afterN.yes !== 'false') {
+    throw new Error(`expected No selected, Yes deselected after N; got ${JSON.stringify(afterN)}`);
+  }
+
+  log('Y picked Yes, N switched to No on a binary single-select question');
+}
+
+// ---------- question-enter-on-submit-button ----------
+// Task #305: Tab to Submit button, press Enter, onSubmit should fire.
+async function caseQuestionEnterOnSubmitButton({ win, log }) {
+  await seedSession(win);
+
+  // Stub agentSend so we can detect submit.
+  await win.evaluate(() => {
+    const captured = { sends: [], resolves: [] };
+    window.__ccsmTestCapture = captured;
+    const orig = window.ccsm;
+    window.ccsm = new Proxy(orig, {
+      get(t, k) {
+        if (k === 'agentSend') return async (...a) => { captured.sends.push(a); };
+        if (k === 'agentResolvePermission') return async (...a) => { captured.resolves.push(a); };
+        return Reflect.get(t, k);
+      }
+    });
+  });
+
+  await win.evaluate(() => {
+    const s = window.__ccsmStore.getState();
+    s.appendBlocks(s.activeId, [{
+      kind: 'question',
+      id: 'q-ENTER-SUBMIT',
+      requestId: 'q-ENTER-SUBMIT',
+      questions: [{
+        question: 'Pick one',
+        options: [{ label: 'A' }, { label: 'B' }]
+      }]
+    }]);
+  });
+
+  await win.waitForSelector('[data-question-option]', { timeout: 5_000 });
+  await win.waitForFunction(() => {
+    const el = document.activeElement;
+    return el instanceof HTMLElement && el.hasAttribute('data-question-option');
+  }, null, { timeout: 2_000 });
+
+  // Pick first option via Space; single-question doesn't auto-advance.
+  await win.keyboard.press(' ');
+  await win.waitForTimeout(80);
+
+  // Move focus directly to Submit button and press Enter.
+  await win.locator('[data-testid="question-submit"]').focus();
+  await win.waitForTimeout(80);
+  await win.keyboard.press('Enter');
+
+  await win.waitForFunction(() => (window.__ccsmTestCapture?.sends?.length ?? 0) > 0, null, { timeout: 2_000 }).catch(() => {});
+
+  const cap = await win.evaluate(() => window.__ccsmTestCapture);
+  if (!cap.sends.length) {
+    throw new Error(`expected agentSend after Enter on Submit button; sends=${cap.sends.length} resolves=${cap.resolves.length}`);
+  }
+
+  log(`Enter on Submit button fired onSubmit (${cap.sends.length} send call captured)`);
+}
+
+// ---------- question-focus-ring-visible ----------
+// Task #307 bug 4: focus ring on options must be visible on the
+// state-waiting/[0.06] tinted bg. Check that focused option has a non-none
+// outline whose color has decent contrast against the row bg.
+async function caseQuestionFocusRingVisible({ win, log }) {
+  await seedSession(win);
+  await win.evaluate(() => {
+    const s = window.__ccsmStore.getState();
+    s.appendBlocks(s.activeId, [{
+      kind: 'question',
+      id: 'q-RING',
+      requestId: 'q-RING',
+      questions: [{
+        question: 'Pick',
+        options: [{ label: 'A' }, { label: 'B' }]
+      }]
+    }]);
+  });
+
+  await win.waitForSelector('[data-question-option]', { timeout: 5_000 });
+  await win.waitForFunction(() => {
+    const el = document.activeElement;
+    return el instanceof HTMLElement && el.hasAttribute('data-question-option');
+  }, null, { timeout: 2_000 });
+
+  // Move focus to second option to ensure :focus-visible applies (keyboard nav).
+  await win.keyboard.press('ArrowDown');
+  await win.waitForTimeout(80);
+
+  const ring = await win.evaluate(() => {
+    const el = document.activeElement;
+    if (!(el instanceof HTMLElement)) return { ok: false, why: 'no active' };
+    const cs = getComputedStyle(el);
+    const outline = cs.outlineStyle;
+    const w = parseFloat(cs.outlineWidth);
+    const color = cs.outlineColor;
+    return { outline, w, color, label: el.getAttribute('data-question-label') };
+  });
+
+  if (!ring) throw new Error('no ring snapshot');
+  if (ring.outline === 'none' || !(ring.w > 0)) {
+    throw new Error(`focus ring not visible: outline=${ring.outline} width=${ring.w} color=${ring.color}`);
+  }
+  // Width should be at least 1.5px or color should be near-opaque (alpha-ish).
+  // Crude visibility check: outlineWidth must be >= 1.5 OR alpha approx 1.
+  // We can't easily luminance-compare against the bg; assert width >= 1.5px
+  // (the fix bumps it from 1px to 1.5px / 2px) OR use a non-translucent color.
+  // The audit says alpha 0.6 is too low; require >= 0.8 OR width >= 2.
+  let alpha = 1;
+  // Match rgba(r,g,b,a) or oklab(L a b / alpha) or oklch(L c h / alpha).
+  let m = /rgba?\(([^)]+)\)/.exec(ring.color);
+  if (m) {
+    const parts = m[1].split(',').map((s) => s.trim());
+    if (parts.length === 4) alpha = parseFloat(parts[3]);
+  } else {
+    m = /(?:oklab|oklch|lab|lch|hsl|hsla)\([^)]*\/\s*([0-9.]+)\)/.exec(ring.color);
+    if (m) alpha = parseFloat(m[1]);
+  }
+  // The audit says alpha 0.6 is too low on the waiting tint bg. Require
+  // alpha >= 0.9 OR outline-width >= 2px (the fix doubles outline density).
+  if (alpha < 0.9 && ring.w < 2) {
+    throw new Error(`focus ring contrast too low on tinted bg: alpha=${alpha} width=${ring.w} color=${ring.color}`);
+  }
+  log(`focus ring on option "${ring.label}": outline=${ring.outline} width=${ring.w} color=${ring.color} alpha=${alpha}`);
+}
+
+// ---------- question-other-page-flip-preserves-focus ----------
+// Task #307 bug 5: switching question and switching back should NOT steal
+// focus from the Other input if it has been selected + has typed content.
+async function caseQuestionOtherPageFlipPreservesFocus({ win, log }) {
+  await seedSession(win);
+  await win.evaluate(() => {
+    const s = window.__ccsmStore.getState();
+    s.appendBlocks(s.activeId, [{
+      kind: 'question',
+      id: 'q-PAGE-FLIP',
+      requestId: 'q-PAGE-FLIP',
+      questions: [
+        { question: 'Q1', options: [{ label: 'Python' }, { label: 'Ruby' }] },
+        { question: 'Q2', options: [{ label: 'X' }, { label: 'Y' }] }
+      ]
+    }]);
+  });
+
+  await win.waitForSelector('[data-question-option]', { timeout: 5_000 });
+  await win.waitForFunction(() => {
+    const el = document.activeElement;
+    return el instanceof HTMLElement && el.hasAttribute('data-question-option');
+  }, null, { timeout: 2_000 });
+
+  // Click Other (3rd, last option) on Q1.
+  const other = win.locator('[data-question-option][data-question-label="Other"]').first();
+  await other.click();
+  await win.waitForTimeout(150);
+
+  // Type into the Other input.
+  const otherInput = win.locator('[data-testid="question-other-input"]').first();
+  await otherInput.click();
+  await win.waitForTimeout(50);
+  await win.keyboard.type('abc');
+  await win.waitForTimeout(80);
+
+  // Confirm Other input has 'abc'.
+  const before = await win.evaluate(() => {
+    const inp = document.querySelector('[data-testid="question-other-input"]');
+    return { txt: inp?.textContent, isFocused: document.activeElement === inp };
+  });
+  if (before.txt !== 'abc' || !before.isFocused) {
+    throw new Error(`pre-flip: Other input expected 'abc' + focused, got ${JSON.stringify(before)}`);
+  }
+
+  // Click tab Q2 (page right).
+  await win.locator('[data-testid="question-tab-1"]').click();
+  await win.waitForTimeout(200);
+
+  // Click tab Q1 (page back).
+  await win.locator('[data-testid="question-tab-0"]').click();
+  await win.waitForTimeout(300);
+
+  // Active element should be the Other input again, not "Python".
+  const after = await win.evaluate(() => {
+    const el = document.activeElement;
+    return {
+      tag: el?.tagName?.toLowerCase() ?? null,
+      isOtherInput: el?.getAttribute?.('data-testid') === 'question-other-input',
+      label: el instanceof HTMLElement ? el.getAttribute('data-question-label') : null,
+      otherTxt: document.querySelector('[data-testid="question-other-input"]')?.textContent
+    };
+  });
+
+  if (after.otherTxt !== 'abc') {
+    throw new Error(`Other text lost on page flip; got '${after.otherTxt}'`);
+  }
+  if (!after.isOtherInput) {
+    throw new Error(`page flip stole focus from Other input; got ${JSON.stringify(after)}`);
+  }
+  log('page flip preserved Other-input focus + typed text');
+}
+
+// ---------- question-other-esc-dismisses ----------
+// Task #302: Esc inside the Other contenteditable must dismiss the question
+// (currently stopPropagation in onKeyDown swallows Escape).
+async function caseQuestionOtherEscDismisses({ win, log }) {
+  await seedSession(win);
+  await win.evaluate(() => {
+    const s = window.__ccsmStore.getState();
+    s.appendBlocks(s.activeId, [{
+      kind: 'question',
+      id: 'q-OTHER-ESC',
+      requestId: 'q-OTHER-ESC',
+      questions: [{
+        question: 'Q',
+        options: [{ label: 'A' }]
+      }]
+    }]);
+  });
+
+  await win.waitForSelector('[data-question-option]', { timeout: 5_000 });
+  // Click Other to expand input + focus it.
+  await win.locator('[data-question-option][data-question-label="Other"]').first().click();
+  await win.waitForTimeout(150);
+  await win.locator('[data-testid="question-other-input"]').first().click();
+  await win.waitForTimeout(80);
+  await win.keyboard.type('hi');
+  await win.waitForTimeout(50);
+
+  // Press Esc — should close the question.
+  await win.keyboard.press('Escape');
+  await win.waitForTimeout(300);
+
+  const dismissed = await win.evaluate(() => {
+    const card = document.querySelector('[data-question-sticky]');
+    const block = window.__ccsmStore?.getState()?.messagesBySession?.['s-perm']?.find?.(b => b.id === 'q-OTHER-ESC');
+    return {
+      cardGone: !card,
+      answered: block?.answered,
+      rejected: block?.rejected
+    };
+  });
+
+  if (!dismissed.cardGone || !dismissed.answered) {
+    throw new Error(`Esc in Other input did not dismiss; ${JSON.stringify(dismissed)}`);
+  }
+  log(`Esc inside Other input dismissed the question (rejected=${dismissed.rejected})`);
+}
+
+// ---------- question-last-question-other-enter-submits ----------
+// Task #307 bug 7: pressing Enter inside Other input on the LAST question
+// should submit (not no-op via active+1 clamp).
+async function caseQuestionLastQuestionOtherEnterSubmits({ win, log }) {
+  await seedSession(win);
+
+  await win.evaluate(() => {
+    const captured = { sends: [], resolves: [] };
+    window.__ccsmTestCapture = captured;
+    const orig = window.ccsm;
+    window.ccsm = new Proxy(orig, {
+      get(t, k) {
+        if (k === 'agentSend') return async (...a) => { captured.sends.push(a); };
+        if (k === 'agentResolvePermission') return async (...a) => { captured.resolves.push(a); };
+        return Reflect.get(t, k);
+      }
+    });
+  });
+
+  await win.evaluate(() => {
+    const s = window.__ccsmStore.getState();
+    s.appendBlocks(s.activeId, [{
+      kind: 'question',
+      id: 'q-LAST-OTHER-ENTER',
+      requestId: 'q-LAST-OTHER-ENTER',
+      questions: [
+        { question: 'Q1', options: [{ label: 'A' }] },
+        { question: 'Q2', options: [{ label: 'B' }] },
+        { question: 'Q3', options: [{ label: 'C' }] }
+      ]
+    }]);
+  });
+
+  await win.waitForSelector('[data-question-option]', { timeout: 5_000 });
+  // Pick Q1.A.
+  await win.locator('[data-question-option][data-question-label="A"]').first().click();
+  await win.waitForTimeout(400); // auto-advance
+  // Pick Q2.B.
+  await win.locator('[data-question-option][data-question-label="B"]').first().click();
+  await win.waitForTimeout(400);
+  // On Q3: click Other.
+  await win.locator('[data-testid="question-tab-2"]').click();
+  await win.waitForTimeout(150);
+  await win.locator('[data-question-option][data-question-label="Other"]').first().click();
+  await win.waitForTimeout(150);
+  await win.locator('[data-testid="question-other-input"]').first().click();
+  await win.waitForTimeout(80);
+  await win.keyboard.type('xyz');
+  await win.waitForTimeout(80);
+
+  // Press Enter inside Other on the last question — should fire submit.
+  await win.keyboard.press('Enter');
+  await win.waitForFunction(() => (window.__ccsmTestCapture?.sends?.length ?? 0) > 0, null, { timeout: 2_000 }).catch(() => {});
+
+  const cap = await win.evaluate(() => window.__ccsmTestCapture);
+  if (!cap.sends.length) {
+    throw new Error(`expected agentSend on last-question Other Enter; sends=${cap.sends.length}`);
+  }
+  // Confirm payload contains 'xyz' under Q3.
+  const text = cap.sends[0]?.[1] ?? '';
+  if (!text.includes('xyz')) {
+    throw new Error(`expected 'xyz' in submitted text; got "${text}"`);
+  }
+  log(`Enter on Other input of last question submitted with payload containing 'xyz'`);
+}
+
+// ---------- question-many-options-scrolls ----------
+// Task #307 bug 8: a question with many options should make the options
+// container scroll, not blow out the page height.
+async function caseQuestionManyOptionsScrolls({ win, log }) {
+  await seedSession(win);
+  await win.evaluate(() => {
+    const s = window.__ccsmStore.getState();
+    const opts = Array.from({ length: 25 }, (_, i) => ({ label: `option-${i + 1}` }));
+    s.appendBlocks(s.activeId, [{
+      kind: 'question',
+      id: 'q-MANY',
+      requestId: 'q-MANY',
+      questions: [{ question: 'Pick', options: opts }]
+    }]);
+  });
+
+  await win.waitForSelector('[data-question-option]', { timeout: 5_000 });
+  await win.waitForTimeout(200);
+
+  const scrollInfo = await win.evaluate(() => {
+    const card = document.querySelector('[data-question-sticky]');
+    if (!card) return null;
+    // The options container has role=radiogroup or =group inside the card.
+    const grp = card.querySelector('[role="radiogroup"], [role="group"]');
+    if (!grp) return { reason: 'no group' };
+    const cs = getComputedStyle(grp);
+    return {
+      scrollHeight: grp.scrollHeight,
+      clientHeight: grp.clientHeight,
+      overflowY: cs.overflowY,
+      overflow: cs.overflow,
+      maxHeight: cs.maxHeight
+    };
+  });
+  if (!scrollInfo || scrollInfo.reason) {
+    throw new Error(`couldn't find options group: ${JSON.stringify(scrollInfo)}`);
+  }
+  if (scrollInfo.overflowY !== 'auto' && scrollInfo.overflowY !== 'scroll') {
+    throw new Error(`options group overflowY should be auto/scroll; got '${scrollInfo.overflowY}' max-height='${scrollInfo.maxHeight}'`);
+  }
+  if (!(scrollInfo.scrollHeight > scrollInfo.clientHeight)) {
+    throw new Error(`expected scrollable overflow; scrollHeight=${scrollInfo.scrollHeight} clientHeight=${scrollInfo.clientHeight}`);
+  }
+  log(`many-options scrollable: ${scrollInfo.scrollHeight}px content / ${scrollInfo.clientHeight}px visible, overflow-y=${scrollInfo.overflowY}`);
+}
+
 // ---------- harness spec ----------
 await runHarness({
   name: 'perm',
@@ -2369,6 +2856,15 @@ await runHarness({
     { id: 'permission-focus-not-stolen', run: casePermissionFocusNotStolen },
     { id: 'permission-focus-returns-to-textarea', run: casePermissionFocusReturnsToTextarea },
     { id: 'question-focus-on-mount', run: caseQuestionFocusOnMount },
+    // Task #307 batch — QuestionBlock UX parity with PermissionPromptBlock.
+    { id: 'question-tab-trap-cycles', run: caseQuestionTabTrapCycles },
+    { id: 'question-yn-hotkey', run: caseQuestionYNHotkey },
+    { id: 'question-enter-on-submit-button', run: caseQuestionEnterOnSubmitButton },
+    { id: 'question-focus-ring-visible', run: caseQuestionFocusRingVisible },
+    { id: 'question-other-page-flip-preserves-focus', run: caseQuestionOtherPageFlipPreservesFocus },
+    { id: 'question-other-esc-dismisses', run: caseQuestionOtherEscDismisses },
+    { id: 'question-last-question-other-enter-submits', run: caseQuestionLastQuestionOtherEnterSubmits },
+    { id: 'question-many-options-scrolls', run: caseQuestionManyOptionsScrolls },
     { id: 'permission-shortcut-scope', run: casePermissionShortcutScope },
     { id: 'permission-nested-input', run: casePermissionNestedInput },
     { id: 'permission-truncate-width', run: casePermissionTruncateWidth },

--- a/scripts/harness-perm.mjs
+++ b/scripts/harness-perm.mjs
@@ -2408,21 +2408,6 @@ async function caseQuestionTabTrapCycles({ win, log }) {
 async function caseQuestionYNHotkey({ win, log }) {
   await seedSession(win);
 
-  // Stub agent:send + agent:resolvePermission so submit doesn't fan out.
-  const submitsCaptured = await win.evaluate(() => {
-    const captured = { sends: [], resolves: [] };
-    window.__ccsmTestCapture = captured;
-    const orig = window.ccsm;
-    window.ccsm = new Proxy(orig, {
-      get(t, k) {
-        if (k === 'agentSend') return async (...a) => { captured.sends.push(a); };
-        if (k === 'agentResolvePermission') return async (...a) => { captured.resolves.push(a); };
-        return Reflect.get(t, k);
-      }
-    });
-    return true;
-  });
-
   await win.evaluate(() => {
     const s = window.__ccsmStore.getState();
     s.appendBlocks(s.activeId, [{
@@ -2474,20 +2459,6 @@ async function caseQuestionYNHotkey({ win, log }) {
 async function caseQuestionEnterOnSubmitButton({ win, log }) {
   await seedSession(win);
 
-  // Stub agentSend so we can detect submit.
-  await win.evaluate(() => {
-    const captured = { sends: [], resolves: [] };
-    window.__ccsmTestCapture = captured;
-    const orig = window.ccsm;
-    window.ccsm = new Proxy(orig, {
-      get(t, k) {
-        if (k === 'agentSend') return async (...a) => { captured.sends.push(a); };
-        if (k === 'agentResolvePermission') return async (...a) => { captured.resolves.push(a); };
-        return Reflect.get(t, k);
-      }
-    });
-  });
-
   await win.evaluate(() => {
     const s = window.__ccsmStore.getState();
     s.appendBlocks(s.activeId, [{
@@ -2509,21 +2480,58 @@ async function caseQuestionEnterOnSubmitButton({ win, log }) {
 
   // Pick first option via Space; single-question doesn't auto-advance.
   await win.keyboard.press(' ');
-  await win.waitForTimeout(80);
+  await win.waitForTimeout(150);
+
+  // Sanity check: option got selected and submit became enabled.
+  const stateAfterPick = await win.evaluate(() => {
+    const a = document.querySelector('[data-question-option][data-question-label="A"]');
+    const submit = document.querySelector('[data-testid="question-submit"]');
+    return {
+      aChecked: a?.getAttribute('aria-checked'),
+      submitDisabled: submit?.hasAttribute('disabled'),
+    };
+  });
+  if (stateAfterPick.aChecked !== 'true' || stateAfterPick.submitDisabled) {
+    throw new Error(`pre-Enter sanity failed: ${JSON.stringify(stateAfterPick)}`);
+  }
 
   // Move focus directly to Submit button and press Enter.
   await win.locator('[data-testid="question-submit"]').focus();
   await win.waitForTimeout(80);
+  const focusSnap = await win.evaluate(() => ({
+    isSubmit: document.activeElement?.getAttribute?.('data-testid') === 'question-submit',
+  }));
+  if (!focusSnap.isSubmit) {
+    throw new Error(`could not focus submit button; ${JSON.stringify(focusSnap)}`);
+  }
   await win.keyboard.press('Enter');
 
-  await win.waitForFunction(() => (window.__ccsmTestCapture?.sends?.length ?? 0) > 0, null, { timeout: 2_000 }).catch(() => {});
+  // Detect submit via the store: QuestionStickyHost calls
+  // markQuestionAnswered → block.answered=true. This bypasses the
+  // contextBridge stubbing trickery (window.ccsm methods are read-only via
+  // contextBridge in production builds) and asserts the user-visible effect.
+  await win.waitForFunction(() => {
+    const s = window.__ccsmStore.getState();
+    for (const b of s.messagesBySession[s.activeId] ?? []) {
+      if (b.id === 'q-ENTER-SUBMIT' && b.answered) return true;
+    }
+    return false;
+  }, null, { timeout: 2_000 }).catch(() => {});
 
-  const cap = await win.evaluate(() => window.__ccsmTestCapture);
-  if (!cap.sends.length) {
-    throw new Error(`expected agentSend after Enter on Submit button; sends=${cap.sends.length} resolves=${cap.resolves.length}`);
+  const after = await win.evaluate(() => {
+    const s = window.__ccsmStore.getState();
+    const b = (s.messagesBySession[s.activeId] ?? []).find((x) => x.id === 'q-ENTER-SUBMIT');
+    return {
+      answered: b?.answered,
+      rejected: b?.rejected,
+      cardGone: !document.querySelector('[data-testid="question-submit"]'),
+    };
+  });
+  if (!after.answered || after.rejected) {
+    throw new Error(`expected submit fired (answered=true, rejected=false) on Enter; got ${JSON.stringify(after)}`);
   }
 
-  log(`Enter on Submit button fired onSubmit (${cap.sends.length} send call captured)`);
+  log(`Enter on Submit button fired onSubmit (answered=${after.answered}, cardGone=${after.cardGone})`);
 }
 
 // ---------- question-focus-ring-visible ----------
@@ -2719,19 +2727,6 @@ async function caseQuestionLastQuestionOtherEnterSubmits({ win, log }) {
   await seedSession(win);
 
   await win.evaluate(() => {
-    const captured = { sends: [], resolves: [] };
-    window.__ccsmTestCapture = captured;
-    const orig = window.ccsm;
-    window.ccsm = new Proxy(orig, {
-      get(t, k) {
-        if (k === 'agentSend') return async (...a) => { captured.sends.push(a); };
-        if (k === 'agentResolvePermission') return async (...a) => { captured.resolves.push(a); };
-        return Reflect.get(t, k);
-      }
-    });
-  });
-
-  await win.evaluate(() => {
     const s = window.__ccsmStore.getState();
     s.appendBlocks(s.activeId, [{
       kind: 'question',
@@ -2748,10 +2743,10 @@ async function caseQuestionLastQuestionOtherEnterSubmits({ win, log }) {
   await win.waitForSelector('[data-question-option]', { timeout: 5_000 });
   // Pick Q1.A.
   await win.locator('[data-question-option][data-question-label="A"]').first().click();
-  await win.waitForTimeout(400); // auto-advance
+  await win.waitForTimeout(450); // auto-advance
   // Pick Q2.B.
   await win.locator('[data-question-option][data-question-label="B"]').first().click();
-  await win.waitForTimeout(400);
+  await win.waitForTimeout(450);
   // On Q3: click Other.
   await win.locator('[data-testid="question-tab-2"]').click();
   await win.waitForTimeout(150);
@@ -2764,18 +2759,33 @@ async function caseQuestionLastQuestionOtherEnterSubmits({ win, log }) {
 
   // Press Enter inside Other on the last question — should fire submit.
   await win.keyboard.press('Enter');
-  await win.waitForFunction(() => (window.__ccsmTestCapture?.sends?.length ?? 0) > 0, null, { timeout: 2_000 }).catch(() => {});
+  // Assert via store: markQuestionAnswered records `answers` keyed by
+  // question text. Bypasses contextBridge stubbing limitations.
+  await win.waitForFunction(() => {
+    const s = window.__ccsmStore.getState();
+    for (const b of s.messagesBySession[s.activeId] ?? []) {
+      if (b.id === 'q-LAST-OTHER-ENTER' && b.answered) return true;
+    }
+    return false;
+  }, null, { timeout: 2_000 }).catch(() => {});
 
-  const cap = await win.evaluate(() => window.__ccsmTestCapture);
-  if (!cap.sends.length) {
-    throw new Error(`expected agentSend on last-question Other Enter; sends=${cap.sends.length}`);
+  const after = await win.evaluate(() => {
+    const s = window.__ccsmStore.getState();
+    const b = (s.messagesBySession[s.activeId] ?? []).find((x) => x.id === 'q-LAST-OTHER-ENTER');
+    return {
+      answered: b?.answered,
+      rejected: b?.rejected,
+      answers: b?.answers,
+    };
+  });
+  if (!after.answered || after.rejected) {
+    throw new Error(`expected submit fired on last-question Other Enter; got ${JSON.stringify(after)}`);
   }
-  // Confirm payload contains 'xyz' under Q3.
-  const text = cap.sends[0]?.[1] ?? '';
-  if (!text.includes('xyz')) {
-    throw new Error(`expected 'xyz' in submitted text; got "${text}"`);
+  // Q3 answer should be 'xyz' (Other replaced with typed text).
+  if (after.answers?.['Q3'] !== 'xyz') {
+    throw new Error(`expected Q3 answer 'xyz'; got '${after.answers?.['Q3']}' (full=${JSON.stringify(after.answers)})`);
   }
-  log(`Enter on Other input of last question submitted with payload containing 'xyz'`);
+  log(`Enter on Other input of last question submitted; Q3='${after.answers['Q3']}'`);
 }
 
 // ---------- question-many-options-scrolls ----------

--- a/src/components/QuestionBlock.tsx
+++ b/src/components/QuestionBlock.tsx
@@ -67,6 +67,10 @@ export function QuestionBlock({ questions, onSubmit, onReject, autoFocus = true 
 
   // Page index (active question).
   const [active, setActive] = useState(0);
+  // Track previous active so the page-change focus effect can detect "we came
+  // back to a question whose Other input the user already filled in" — in
+  // which case we focus the Other input, not the first option (#307 bug 5).
+  const prevActiveRef = useRef(0);
   // Per-question selection set. Key = question.question, value = Set of
   // labels (NOT indices — matches upstream's `selectedAnswers` shape; lets
   // "Other" coexist with named options without index tricks).
@@ -87,6 +91,7 @@ export function QuestionBlock({ questions, onSubmit, onReject, autoFocus = true 
   const rootRef = useRef<HTMLDivElement>(null);
   const optionsRef = useRef<HTMLDivElement>(null);
   const otherInputRef = useRef<HTMLDivElement>(null);
+  const submitBtnRef = useRef<HTMLButtonElement>(null);
 
   const current = questions[active];
 
@@ -142,11 +147,37 @@ export function QuestionBlock({ questions, onSubmit, onReject, autoFocus = true 
   // INSIDE the question (e.g. a freshly-mounted "Other" contenteditable)
   // because re-running on `active` change shouldn't yank focus off something
   // the user is currently typing into.
+  //
+  // Task #307 bug 5: when the user pages back to a question they already
+  // engaged with via Other (Other selected + non-empty typed text), focus the
+  // Other contenteditable instead of the first option. Without this guard,
+  // every page flip yanks focus to "Python" / "TypeScript" / etc. and erodes
+  // the trust that paging is non-destructive.
   useEffect(() => {
-    if (!autoFocus || submitted) return;
+    if (!autoFocus || submitted) {
+      prevActiveRef.current = active;
+      return;
+    }
     const root = optionsRef.current;
-    if (!root) return;
+    if (!root) {
+      prevActiveRef.current = active;
+      return;
+    }
     const id = requestAnimationFrame(() => {
+      // If THIS question already has Other selected + non-empty text, send
+      // focus to the Other input instead of stealing to the first option.
+      const q = questions[active];
+      const hasOther =
+        q && (picks[q.question]?.has(OTHER_LABEL) ?? false) && (otherText[q.question]?.trim().length ?? 0) > 0;
+      if (hasOther && otherInputRef.current) {
+        const ae = document.activeElement as HTMLElement | null;
+        // If focus is already inside this question's options group, don't
+        // disturb it (covers the freshly-clicked Other case where the click
+        // handler will move focus naturally).
+        if (ae && root.contains(ae)) return;
+        otherInputRef.current.focus({ preventScroll: true });
+        return;
+      }
       const target = root.querySelector<HTMLElement>('[data-question-option]');
       if (!target) return;
       const ae = document.activeElement as HTMLElement | null;
@@ -157,8 +188,9 @@ export function QuestionBlock({ questions, onSubmit, onReject, autoFocus = true 
       if (ae && root.contains(ae) && ae !== target) return;
       target.focus({ preventScroll: true });
     });
+    prevActiveRef.current = active;
     return () => cancelAnimationFrame(id);
-  }, [active, autoFocus, submitted]);
+  }, [active, autoFocus, submitted, questions, picks, otherText]);
 
   // ---- Selection + auto-advance -------------------------------------------
   const togglePick = useCallback(
@@ -214,6 +246,37 @@ export function QuestionBlock({ questions, onSubmit, onReject, autoFocus = true 
       onReject?.();
       return;
     }
+    // Task #307 bug 1: Tab focus trap. Cycle between every option in the
+    // active question (data-question-option) + the Submit button. Mirrors
+    // PermissionPromptBlock:249-263. Only engages while focus is already
+    // inside the card — Tab from outside lands on the first focusable as
+    // usual.
+    if (e.key === 'Tab' && !e.ctrlKey && !e.altKey) {
+      const root = rootRef.current;
+      if (!root) return;
+      const ae = document.activeElement as HTMLElement | null;
+      if (!ae || !root.contains(ae)) return;
+      const opts = optionsRef.current
+        ? Array.from(optionsRef.current.querySelectorAll<HTMLElement>('[data-question-option]'))
+        : [];
+      const submit = submitBtnRef.current;
+      const trap: HTMLElement[] = submit ? [...opts, submit] : opts;
+      if (trap.length === 0) return;
+      const idx = trap.indexOf(ae);
+      // Special case: focus is on the Other contenteditable — treat as if
+      // we're on the Other option (parent container) for trap purposes.
+      const fallbackIdx = idx === -1 && otherInputRef.current?.contains(ae)
+        ? trap.findIndex((el) => el.dataset.questionLabel === OTHER_LABEL)
+        : idx;
+      if (fallbackIdx === -1) return;
+      e.preventDefault();
+      e.stopPropagation();
+      const nextIdx = e.shiftKey
+        ? (fallbackIdx - 1 + trap.length) % trap.length
+        : (fallbackIdx + 1) % trap.length;
+      trap[nextIdx]?.focus({ preventScroll: true });
+      return;
+    }
     if (otherFocused) return;
     if (e.key === 'ArrowLeft' && active > 0) {
       e.preventDefault();
@@ -253,6 +316,71 @@ export function QuestionBlock({ questions, onSubmit, onReject, autoFocus = true 
       }
     }
   };
+
+  // Task #307 bug 2: Y/N hotkey for binary single-select questions.
+  // Mirrors PermissionPromptBlock:284-293. We only hijack Y/N when:
+  //   - current question is single-select
+  //   - it has exactly 2 user options (Other doesn't count)
+  //   - first option's label starts with 'y' (case-insensitive) and second's
+  //     starts with 'n' — i.e. the model framed an actual yes/no question.
+  // Also skip if the user is typing into a text-entry surface anywhere.
+  useEffect(() => {
+    if (submitted) return;
+    if (!current || current.multiSelect) return;
+    if (current.options.length !== 2) return;
+    const first = current.options[0]?.label ?? '';
+    const second = current.options[1]?.label ?? '';
+    if (!/^y/i.test(first) || !/^n/i.test(second)) return;
+
+    const handler = (e: KeyboardEvent) => {
+      if (e.defaultPrevented) return;
+      if (e.ctrlKey || e.altKey || e.metaKey) return;
+      const root = rootRef.current;
+      if (!root) return;
+      const ae = document.activeElement;
+      const focusInside = ae instanceof HTMLElement && root.contains(ae);
+      const typing =
+        ae instanceof HTMLElement &&
+        (ae.tagName === 'INPUT' || ae.tagName === 'TEXTAREA' || ae.isContentEditable);
+      // Don't hijack while focus is in any text-entry surface (composer,
+      // Other contenteditable, external rename input, …).
+      if (typing) return;
+      // And only act when the question card is mounted + visible (focus
+      // anywhere doesn't matter as long as we're not eating someone else's
+      // typing — already gated above).
+      if (!focusInside && document.activeElement !== document.body) {
+        // Allow body-focus (no-one is typing) — common case after autoFocus
+        // hands focus to a div option but a stray re-render reset it.
+      }
+      const key = e.key.toLowerCase();
+      if (key !== 'y' && key !== 'n') return;
+      e.preventDefault();
+      togglePick(current, key === 'y' ? first : second);
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [current, submitted, togglePick]);
+
+  // Sync persisted Other-input text back into the contenteditable when the
+  // question is re-rendered (e.g. after paging away and back). The Other
+  // input is uncontrolled — React doesn't manage textContent for
+  // contenteditable — so without this effect the typed text disappears
+  // visually on page flip even though `otherText[q.question]` still holds
+  // the value (#307 bug 5 part 2).
+  useEffect(() => {
+    if (!current) return;
+    const inp = otherInputRef.current;
+    if (!inp) return;
+    const stored = otherText[current.question] ?? '';
+    if ((inp.textContent ?? '') !== stored) {
+      inp.textContent = stored;
+    }
+    // We intentionally only run this when the active question changes or when
+    // Other is freshly selected (the input element exists or doesn't); during
+    // typing the user's keystrokes drive the DOM and `otherText` state, so we
+    // don't want to clobber the caret on every keystroke.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active, current?.question, picks[current?.question ?? '']?.has(OTHER_LABEL)]);
 
   if (!current) return null;
 
@@ -325,7 +453,7 @@ export function QuestionBlock({ questions, onSubmit, onReject, autoFocus = true 
         <div className="text-body text-fg-primary mb-3">{current.question}</div>
         <div
           ref={optionsRef}
-          className="space-y-1"
+          className="space-y-1 max-h-[clamp(40vh,calc(100vh-300px),60vh)] overflow-y-auto"
           role={current.multiSelect ? 'group' : 'radiogroup'}
           aria-label={current.question}
         >
@@ -399,10 +527,23 @@ export function QuestionBlock({ questions, onSubmit, onReject, autoFocus = true 
                       }}
                       onKeyDown={(e) => {
                         if (e.nativeEvent.isComposing) return;
+                        // Esc must dismiss (#302). Don't stopPropagation —
+                        // let the root onKeyDown handle the reject path.
+                        if (e.key === 'Escape') {
+                          // Fall through to root handler.
+                          return;
+                        }
                         e.stopPropagation();
                         if (e.key === 'Enter' && !e.shiftKey) {
                           e.preventDefault();
-                          if (active < questions.length - 1) setActive(active + 1);
+                          // Last question: Enter inside Other = submit
+                          // (matches the Submit button). Earlier questions
+                          // page forward.
+                          if (active < questions.length - 1) {
+                            setActive(active + 1);
+                          } else {
+                            submit();
+                          }
                         }
                       }}
                       className="mt-2 min-h-[28px] px-2 py-1 rounded-sm border border-border-default bg-bg-app text-body text-fg-primary outline-none focus-ring-waiting empty:before:content-[attr(data-placeholder)] empty:before:text-fg-tertiary"
@@ -423,10 +564,22 @@ export function QuestionBlock({ questions, onSubmit, onReject, autoFocus = true 
             : t('questionBlock.singleHint')}
         </span>
         <button
+          ref={submitBtnRef}
           type="button"
           data-testid="question-submit"
           disabled={!allAnswered || submitted}
           onClick={submit}
+          onKeyDown={(e) => {
+            // #305: Enter on the submit button must trigger submit. Native
+            // <button> usually fires onClick on Enter, but the root's
+            // onKeyDown sees Enter first; we handle it here explicitly so
+            // it works whether the root handler claims the event or not.
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              e.stopPropagation();
+              submit();
+            }
+          }}
           className={
             'inline-flex items-center px-3 py-1.5 rounded-sm text-body font-medium outline-none focus-ring-waiting transition-colors duration-150 ease-out ' +
             (allAnswered && !submitted

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -546,8 +546,9 @@ html.theme-light ::-webkit-scrollbar-thumb:hover {
       - .focus-ring           : inset 1px accent (default selectable / chrome)
       - .focus-ring-destructive: outset 1px state-error at 0.6 alpha
         (destructive chips — Reject / Delete / Interrupt)
-      - .focus-ring-waiting   : outset 1px state-waiting at 0.6 alpha
-        (selectable options blocking on user input — QuestionBlock rows)
+      - .focus-ring-waiting   : outset 2px state-waiting at 0.95 alpha
+        (selectable options blocking on user input — QuestionBlock rows.
+         Denser than the others to remain visible on the waiting tint bg.)
       - .focus-ring-success   : outset 1px state-success at 0.6 alpha
         (affirmative actions paired with destructive chips — DiffView Accept,
         QuestionBlock once submitted)
@@ -561,11 +562,13 @@ html.theme-light ::-webkit-scrollbar-thumb:hover {
     outline-offset: 0;
   }
   /*
-    `focus-ring-waiting` is geometrically identical to `focus-ring-destructive`
-    (1px outset at 0.6 alpha) but tinted with the waiting amber. We use it
-    on QuestionBlock options where the surface itself is already tinted with
-    `state-waiting/[0.06]` — the matched-hue ring reads as "this row belongs
-    to the waiting prompt" rather than a generic accent.
+    `focus-ring-waiting` is geometrically denser than `focus-ring-destructive`
+    (2px outset at 0.95 alpha) and tinted with the waiting amber. The denser
+    ring is necessary because QuestionBlock options sit on a `state-waiting/
+    [0.06]` tinted bg — at 1px / 0.6 alpha the ring blended into the tint and
+    failed visibility audits (#307 bug 4). 2px width + near-opaque alpha
+    matches Apple-tier focus indicators while still reading as the waiting
+    hue (matched-tone reinforces "this row belongs to the waiting prompt").
 
     Both `:focus-visible` and `:focus-within` selectors are exposed because
     QuestionBlock wraps the radio inside a `<label>`, so the wrapper needs
@@ -574,7 +577,7 @@ html.theme-light ::-webkit-scrollbar-thumb:hover {
   */
   .focus-ring-waiting:focus-visible,
   .focus-ring-waiting:focus-within {
-    outline: 1px solid oklch(from var(--color-state-waiting) l c h / 0.6);
+    outline: 2px solid oklch(from var(--color-state-waiting) l c h / 0.95);
     outline-offset: 0;
   }
   .focus-ring-success:focus-visible,


### PR DESCRIPTION
## Why

User feedback: **"question 这块问题比较大"** — the AskUserQuestion sticky widget lagged PermissionPromptBlock on every interaction polish dimension. UX audit + #302 + #305 surfaced 8 concrete bugs; this PR collects them all into one batch so QuestionBlock and PermissionPromptBlock now have parity for keyboard discipline, focus management, and visual focus indicators.

Closes #302, #305, #306, #307.

## Bugs absorbed

| # | Severity | Bug | Fix | File:Line | E2E case |
|---|----------|-----|-----|-----------|----------|
| 1 | HIGH | Tab escapes the question card | Focus trap that cycles options + Submit (mirrors PermissionPromptBlock:249-263) | `src/components/QuestionBlock.tsx` (Tab branch in `onKeyDown`) | `question-tab-trap-cycles` |
| 2 | HIGH | No Y/N hotkey for binary single-select | Window keydown listener; only engages when single-select + 2 opts + first /^y/i + second /^n/i | `src/components/QuestionBlock.tsx` (Y/N `useEffect`) | `question-yn-hotkey` |
| 3 (#305) | HIGH | Enter on Submit button no-ops | Explicit `onKeyDown` on Submit button | `src/components/QuestionBlock.tsx` (Submit button) | `question-enter-on-submit-button` |
| 4 | MED | focus-ring on `bg-state-waiting/[0.06]` invisible | Boost ring to 2px / 0.95 alpha (was 1px / 0.6) | `src/styles/global.css` `.focus-ring-waiting` | `question-focus-ring-visible` |
| 5 | MED | Page flip steals focus from Other input | Auto-focus effect re-targets Other input + layout effect syncs persisted text into the contenteditable on remount | `src/components/QuestionBlock.tsx` (auto-focus + sync effects) | `question-other-page-flip-preserves-focus` |
| 6 (#302) | MED | Esc inside Other input swallowed by stopPropagation | Esc falls through to root reject path | `src/components/QuestionBlock.tsx` (Other `onKeyDown`) | `question-other-esc-dismisses` |
| 7 | MED | Enter inside Other on LAST question is a no-op | Last-question Other Enter calls `submit()` | `src/components/QuestionBlock.tsx` (Other `onKeyDown`) | `question-last-question-other-enter-submits` |
| 8 | LOW | Pathological options (>20) blow out page height | `max-h-[clamp(40vh,calc(100vh-300px),60vh)] overflow-y-auto` on options group | `src/components/QuestionBlock.tsx` (options container) | `question-many-options-scrolls` |

## E2E phase 1 → phase 3 evidence

**Phase 1** (failing baseline against current bundle, before any fix):

```
=== harness=perm summary ===
  [XX] question-tab-trap-cycles                   1125ms
  [XX] question-yn-hotkey                          787ms
  [XX] question-enter-on-submit-button            2930ms
  [OK] question-focus-ring-visible                 487ms   (lax assertion — tightened in same commit)
  [XX] question-other-page-flip-preserves-focus   2141ms
  [XX] question-other-esc-dismisses               1787ms
  [XX] question-last-question-other-enter-submits 4655ms
  [XX] question-many-options-scrolls               819ms
=== totals: 1 passed, 7 failed ===
```

**Phase 3** (full harness-perm after the fixes — 36/36 incl. previously-passing 25):

```
=== harness=perm summary (136285ms wall) ===
  [OK] permission-prompt                          1217ms
  [OK] permission-mode-strict                      108ms
  [OK] permission-focus-not-stolen                1201ms
  [OK] permission-focus-returns-to-textarea       1450ms
  [OK] question-focus-on-mount                     857ms
  [OK] question-tab-trap-cycles                    821ms
  [OK] question-yn-hotkey                          678ms
  [OK] question-enter-on-submit-button             713ms
  [OK] question-focus-ring-visible                 474ms
  [OK] question-other-page-flip-preserves-focus   1774ms
  [OK] question-other-esc-dismisses               1516ms
  [OK] question-last-question-other-enter-submits 2573ms
  [OK] question-many-options-scrolls               601ms
  [OK] permission-shortcut-scope                  1267ms
  [OK] permission-nested-input                     995ms
  ... (20 more, all OK) ...
=== totals: 36 passed, 0 failed, 0 skipped ===
```

Vitest `tests/question-block.test.tsx` + `tests/question-sticky-host.test.tsx` — **17/17** pass.
Full vitest — 866/869 pass; the 3 failures are `electron/__tests__/db-hardening.test.ts` (better-sqlite3 NODE_MODULE_VERSION mismatch — env, unrelated to this PR).
Typecheck clean. Build clean (3 pre-existing webpack size warnings unchanged).

## Notes / decisions

- **Y/N semantics**: only engages when the model framed an actual yes/no question (single-select + 2 options + first label /^y/i + second /^n/i). Anything else (3+ options, multi-select, arbitrary labels) leaves Y/N alone so we don't hijack future generative cases.
- **Submit button Enter**: kept the explicit `onKeyDown` instead of relying on native Enter→click — the root `onKeyDown` handler can claim the event in some focus configurations, and the explicit handler makes the contract testable.
- **Other input text persistence on page flip**: required a layout effect to push `otherText[q.question]` back into the contenteditable's textContent on remount. React doesn't manage textContent for contenteditable, so without this the typed value disappears visually even though state is preserved.
- **Two harness cases assert via `__ccsmStore` instead of stubbing `window.ccsm`**: contextBridge in the production preload makes `agentSend` / `agentResolvePermission` non-writable. Both Proxy-wrap and direct property assignment failed silently. Reading `block.answered` after submit gives the same signal without fighting the bridge.

## Test plan

- [x] Phase 1: 8 failing harness cases land on a separate commit before any fix
- [x] Phase 2: implementation lands; failing harness cases turn green
- [x] Phase 3: full `node scripts/harness-perm.mjs` — 36/36 OK
- [x] Vitest unit suite (question-block, question-sticky-host) — 17/17
- [x] Typecheck + build clean
- [ ] Reviewer: dogfood the binary, focus on Tab discipline + page-flip Other behaviour + Y/N hotkey on a real yes/no question + visual focus ring on the waiting tint