### PR TITLE
feat(slash): wire SDK plugins+skills, restore namespaced commands in picker (#290)

### DIFF
--- a/electron/commands-loader.ts
+++ b/electron/commands-loader.ts
@@ -309,34 +309,44 @@ export function loadCommands(opts: LoadOpts = {}): LoadedCommand[] {
 
 // ────────────────────── picker-visible filter ──────────────────────────────
 //
-// Subset of `loadCommands` surfaced to the slash-command picker. Three
-// sources are deliberately hidden:
+// Subset of `loadCommands` surfaced to the slash-command picker. All five
+// disk-discovered sources are visible.
 //
-//   - PLUGIN commands (`/<plugin>:<name>` from ~/.claude/plugins/cache/...).
-//     The CLI binary loads them in its own REPL but the
-//     @anthropic-ai/claude-agent-sdk transport ccsm uses requires plugins
-//     to be declared via `query({ options: { plugins: [...] } })`, which
-//     ccsm doesn't pass. Forwarding `/superpowers:brainstorm` to the SDK
-//     therefore arrives as plain user text and the model replies with the
-//     deprecated-skill stub instead of running the plugin command.
+// Why every source is included (reversal of PR #346, see #290):
 //
-//   - SKILL entries (from ~/.claude/skills/) are loaded by the SDK as
-//     description-keyed system-prompt extensions ("when X happens, use this
-//     skill") — the agent invokes them on its own, the user cannot trigger
-//     them with `/skill-name`. Listing them in the picker created the same
-//     false affordance.
+//   - PLUGIN commands (`/<plugin>:<name>` from ~/.claude/plugins/cache/...)
+//     are loaded automatically by the bundled CLI from the user's
+//     `enabledPlugins` setting in ~/.claude/settings.json. The SDK
+//     `query()` defaults to `settingSources: ['user','project','local']`
+//     when the option is omitted (which ccsm intentionally does), so the
+//     CLI subprocess discovers and registers every enabled plugin command.
+//     Empirically verified: spawning the SDK-bundled claude.exe with
+//     stream-json and sending `/superpowers:brainstorming <q>` runs the
+//     plugin and produces real output. The "deprecated, use the skill"
+//     reply that PR #346 attributed to a transport gap is in fact the
+//     CONTENT of the deprecated `/superpowers:brainstorm` plugin command
+//     itself — the plugin authors deprecated that name in favour of the
+//     `superpowers:brainstorming` skill. PR #346 misdiagnosed user-visible
+//     plugin output as a missing feature.
 //
-//   - AGENT entries are subagent definitions invoked by the main agent via
-//     the Task tool. There is no user-facing slash form, so they had no
-//     business in the picker either.
+//   - SKILL entries (from ~/.claude/skills/) are also loaded by the
+//     bundled CLI; invoking `/<skill-name>` in the composer triggers the
+//     skill (the CLI's own command resolution recognises these).
 //
-// `loadCommands` itself still returns every source — keeps the discovery
-// complete for future wiring (e.g. surfacing skills in a separate UI). Add
-// a source to PICKER_VISIBLE_SOURCES once the corresponding execution path
-// is actually wired through the SDK.
+//   - AGENT entries (subagent definitions) are invocable as
+//     `/<agent-name>` — the CLI exposes them as commands too.
+//
+// All disk-discovered commands are forwarded to claude.exe via the existing
+// pass-through path (`passThrough: true` in registry.ts loadDynamicCommands).
+// The unknown-namespaced toast (PR #359, src/components/InputBar.tsx) still
+// catches genuinely-missing namespaced commands because it only fires when
+// the name is NOT found in the merged command list.
 export const PICKER_VISIBLE_SOURCES: ReadonlySet<CommandSource> = new Set([
   'user',
   'project',
+  'plugin',
+  'skill',
+  'agent',
 ]);
 
 export function loadPickerCommands(opts: LoadOpts = {}): LoadedCommand[] {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1135,11 +1135,10 @@ app.whenReady().then(() => {
   // selecting one inserts `/<name>` into the textarea, which the existing
   // send path forwards to claude.exe. We never parse the body.
   //
-  // `loadPickerCommands` filters out plugin / skill / agent sources because
-  // the @anthropic-ai/claude-agent-sdk transport doesn't execute them
-  // without explicit configuration ccsm doesn't currently provide; listing
-  // them in the picker misled users into invocations that fell through to
-  // the model as plain text. See commands-loader.ts for the full rationale.
+  // `loadPickerCommands` returns every disk-discovered source (user /
+  // project / plugin / skill / agent). Plugin and skill commands are
+  // executed by the bundled CLI itself — see commands-loader.ts
+  // PICKER_VISIBLE_SOURCES for the empirical rationale.
   ipcMain.handle('commands:list', (_e, cwd: string | null | undefined) => {
     // commands-loader does its own fs reads against the supplied cwd; UNC or
     // relative inputs get filtered out here so we don't leak NTLM (Windows)

--- a/scripts/harness-real-cli.mjs
+++ b/scripts/harness-real-cli.mjs
@@ -295,10 +295,257 @@ async function caseIdeAutoConnectKillSwitchPresent({ log }) {
   log(`bundled CLI references "${needle}" at offset ${at} (${(buf.length / 1e6).toFixed(0)} MB scanned) — kill-switch still recognised`);
 }
 
+/**
+ * Task #312 / closes #290 / reopens what PR #346 hid.
+ *
+ * Regression guard: when the SDK-bundled CLI is launched with default
+ * settingSources (i.e. ccsm omits the option, which loads user + project +
+ * local settings — see node_modules/@anthropic-ai/claude-agent-sdk/sdk.d.ts
+ * `Options.settingSources`), namespaced plugin commands declared via the
+ * user's `~/.claude/settings.json` `enabledPlugins` map MUST execute via
+ * the standard pass-through path. The CLI itself owns plugin discovery
+ * and registration; the SDK's `plugins` option is only for SDK consumers
+ * to inject EXTRA plugin paths.
+ *
+ * If a future SDK change moves plugin loading behind an opt-in flag, this
+ * case fails — and ccsm has to wire `query({ options: { plugins: [...] }})`
+ * to feed the user's installed plugin paths from commands-loader.ts.
+ *
+ * Why this case probes via stream-json instead of `--print`:
+ *   - It mirrors what `electron/agent-sdk/sessions.ts` actually does (the
+ *     SDK's own transport is stream-json over stdio).
+ *   - `--print` shells out through the OS command line, which on Windows
+ *     mangles `/superpowers:brainstorming` into a path. stream-json sends
+ *     the literal string in a JSON-quoted `user` message — same as ccsm.
+ *
+ * Choice of test command: `/superpowers:brainstorming` (a SKILL command,
+ * exposed as a slash because the user's `~/.claude/skills/` and the
+ * superpowers plugin's bundled skills are loaded by the CLI). The
+ * deprecated `/superpowers:brainstorm` (plugin command) returns a
+ * deprecation banner that LOOKS like a "transport gap" — the canary phrase
+ * in this case is therefore the absence of "deprecated and will be
+ * removed", which is the literal banner the deprecated command emits.
+ *
+ * Pre-fix (PR #346 era): namespaced commands never reached the user
+ * because the picker hid them and the InputBar bounced them locally with
+ * an "Unknown command" toast. So the regression case here covers the
+ * EXECUTION layer, not the UI layer (which the harness-ui case covers).
+ *
+ * Skips when no plugins/skills are installed in the test env's
+ * CLAUDE_CONFIG_DIR — ccsm dev machines have them, CI may not.
+ */
+async function caseNamespacedCommandActuallyRuns({ log }) {
+  // Pre-flight: confirm the user has the plugin installed. If not, skip
+  // (don't fail) — we cover the contract on dev machines where it's set
+  // up, and we'd rather know about a real regression than chase missing
+  // test fixtures in CI.
+  const installedManifest = path.join(CONFIG_DIR, 'plugins', 'installed_plugins.json');
+  if (!fs.existsSync(installedManifest)) {
+    log(`SKIP: ${installedManifest} not present — no plugins installed in test env`);
+    return;
+  }
+  const manifest = JSON.parse(fs.readFileSync(installedManifest, 'utf8'));
+  const hasSuperpowers = Object.keys(manifest.plugins ?? {}).some((k) =>
+    k.startsWith('superpowers@')
+  );
+  if (!hasSuperpowers) {
+    log(`SKIP: superpowers plugin not in ${installedManifest}`);
+    return;
+  }
+
+  // Use the SDK-bundled binary (matches electron/agent-sdk/sessions.ts'
+  // resolveClaudeInvocation when no system claude is present).
+  const platformPkg = `@anthropic-ai/claude-agent-sdk-${process.platform}-${process.arch}`;
+  const { createRequire } = await import('node:module');
+  const require_ = createRequire(import.meta.url);
+  let exe;
+  try {
+    const pkgRoot = path.dirname(require_.resolve(`${platformPkg}/package.json`));
+    exe = path.join(pkgRoot, process.platform === 'win32' ? 'claude.exe' : 'claude');
+  } catch {
+    log(`SKIP: ${platformPkg} not installed`);
+    return;
+  }
+  if (!fs.existsSync(exe)) {
+    log(`SKIP: ${exe} not found`);
+    return;
+  }
+
+  const HARD_TIMEOUT_MS = 90_000;
+
+  const args = [
+    '--output-format', 'stream-json',
+    '--verbose',
+    '--input-format', 'stream-json',
+    '--permission-mode', 'bypassPermissions',
+    '--allow-dangerously-skip-permissions',
+  ];
+
+  log(`spawning ${path.basename(exe)} ${args.join(' ')}`);
+  const child = spawn(exe, args, {
+    cwd: process.cwd(),
+    env: claudeEnv(),
+    shell: false,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  return await new Promise((resolve, reject) => {
+    let finished = false;
+    let assistantText = '';
+    let resultPayload = null;
+    let initSeen = false;
+    let userSent = false;
+
+    function done(err) {
+      if (finished) return;
+      finished = true;
+      clearTimeout(hardTimer);
+      try { child.kill(); } catch { /* ignore */ }
+      if (err) reject(err);
+      else resolve();
+    }
+
+    const hardTimer = setTimeout(() => {
+      done(new Error(
+        `hard timeout (${HARD_TIMEOUT_MS}ms) — CLI never produced a result frame. ` +
+        `initSeen=${initSeen} userSent=${userSent} assistantText so far: ${assistantText.slice(0, 200)} ` +
+        `stderr tail: ${stderrBuf.slice(-300)}`,
+      ));
+    }, HARD_TIMEOUT_MS);
+
+    let stderrBuf = '';
+    child.stderr.on('data', (d) => { stderrBuf += d.toString('utf8'); });
+
+    // Handshake: send a control_request initialize (matches what
+    // electron/agent-sdk/sessions.ts does via the SDK transport). Without
+    // it the CLI sits in input-format=stream-json mode waiting for the
+    // initialize frame and never emits the `system/init` message.
+    const initId = `req_${randomUUID()}`;
+    try {
+      child.stdin.write(JSON.stringify({
+        type: 'control_request',
+        request_id: initId,
+        request: { subtype: 'initialize', hooks: {} },
+      }) + '\n');
+    } catch (e) {
+      return done(new Error(`failed to write initialize: ${e.message}`));
+    }
+
+    // Send the user message immediately after init — the CLI buffers it
+    // until handshake completes.
+    function sendUser() {
+      if (userSent) return;
+      userSent = true;
+      const userMsg = {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: '/superpowers:brainstorming I want to build a small CLI tool',
+        },
+        parent_tool_use_id: null,
+        session_id: '00000000-0000-0000-0000-000000000000',
+      };
+      try { child.stdin.write(JSON.stringify(userMsg) + '\n'); } catch (e) {
+        return done(new Error(`failed to write user message: ${e.message}`));
+      }
+    }
+
+    let buf = '';
+    child.stdout.on('data', (chunk) => {
+      buf += chunk.toString('utf8');
+      let idx;
+      while ((idx = buf.indexOf('\n')) !== -1) {
+        const line = buf.slice(0, idx).trim();
+        buf = buf.slice(idx + 1);
+        if (!line) continue;
+        let parsed;
+        try { parsed = JSON.parse(line); } catch { continue; }
+
+        if (parsed.type === 'control_response') {
+          // Handshake complete — fire the user message.
+          sendUser();
+          continue;
+        }
+
+        if (parsed.type === 'system' && parsed.subtype === 'init') {
+          initSeen = true;
+          // Some CLI versions emit init unsolicited; send if we haven't yet.
+          sendUser();
+          continue;
+        }
+
+        if (parsed.type === 'assistant' && parsed.message?.content) {
+          for (const c of parsed.message.content) {
+            if (c.type === 'text' && typeof c.text === 'string') {
+              assistantText += c.text;
+            }
+          }
+        }
+
+        if (parsed.type === 'result') {
+          resultPayload = parsed;
+          // The deprecated /superpowers:brainstorm plugin command's
+          // canonical reply is "deprecated and will be removed" — this is
+          // the SAME phrase PR #346 misread as a transport failure. The
+          // brainstorming SKILL invocation should NOT contain it.
+          const lc = (assistantText + ' ' + (parsed.result ?? '')).toLowerCase();
+          const sawDeprecationStub = lc.includes('deprecated and will be removed');
+          // We also want a sign the slash command was UNDERSTOOD (not
+          // bounced as plain text). Skill output varies wildly; threshold
+          // is "any successful non-error result with non-empty text" —
+          // pre-fix the model would have replied "I don't understand
+          // /superpowers:..." or echoed back the prompt. The deprecation
+          // canary above is the harder test.
+          const isError = parsed.is_error === true || parsed.subtype === 'error';
+          const hasContent = assistantText.trim().length > 0 ||
+            (typeof parsed.result === 'string' && parsed.result.trim().length > 0);
+
+          if (!userSent) {
+            return done(new Error('result arrived before we sent the slash command'));
+          }
+          if (isError) {
+            return done(new Error(
+              `CLI returned error result: ${JSON.stringify(parsed).slice(0, 400)}`,
+            ));
+          }
+          if (sawDeprecationStub) {
+            return done(new Error(
+              `assistant reply contained the "deprecated and will be removed" canary — ` +
+              `either the wrong command was invoked, or the plugin/skill loading regressed. ` +
+              `text: ${assistantText.slice(0, 300)}`,
+            ));
+          }
+          if (!hasContent) {
+            return done(new Error(
+              `assistant produced no real content — likely the slash command was treated ` +
+              `as plain prose. text: ${assistantText.slice(0, 300)} / result: ${String(parsed.result).slice(0, 200)}`,
+            ));
+          }
+          log(`namespaced command produced ${assistantText.length}-char reply, no deprecation canary`);
+          return done();
+        }
+      }
+    });
+
+    child.on('exit', (code, signal) => {
+      if (finished) return;
+      done(new Error(
+        `CLI exited unexpectedly (code=${code}, signal=${signal}) before result. ` +
+        `stderr tail: ${stderrBuf.slice(-400)}`,
+      ));
+    });
+
+    child.on('error', (err) => {
+      done(new Error(`spawn error: ${err.message}`));
+    });
+  });
+}
+
 // ---------- runner ----------
 const cases = [
   { id: 'control-response-no-timeout', run: caseControlResponseNoTimeout },
   { id: 'ide-auto-connect-kill-switch-present', run: caseIdeAutoConnectKillSwitchPresent },
+  { id: 'namespaced-command-actually-runs', run: caseNamespacedCommandActuallyRuns },
 ];
 
 const selected = onlyId ? cases.filter((c) => c.id === onlyId) : cases;

--- a/scripts/harness-ui.mjs
+++ b/scripts/harness-ui.mjs
@@ -1010,23 +1010,25 @@ async function caseCwdPopoverRecentUnfiltered({ app, win, log, registerDispose }
 // Loader honors `CLAUDE_CONFIG_DIR`. Seeds a fake `<tmp>/.claude`-shaped
 // tree via the env var (NOT $HOME) and asserts the in-chat slash picker:
 //   - surfaces the user-level command (`local-test`)
-//   - hides plugin-cache commands (`brainstorm`, `superpowers:brainstorm`)
+//   - surfaces plugin-cache commands (`superpowers:brainstorm`) — these
+//     are loaded by the bundled CLI itself via the user's settings.json
+//     `enabledPlugins` map; ccsm just has to NOT hide them from the picker.
 //
 // This pins both gates simultaneously:
 //   1. commands-loader.ts reads `process.env.CLAUDE_CONFIG_DIR` (fall-through
-//      to `os.homedir()` would scan the dev's real ~/.claude, populating
-//      the picker with whatever they have installed and breaking the
-//      assertions). The `superpowers:brainstorm` row is the canary —
-//      the dev's real ~/.claude has it, the fake tree must NOT surface it.
-//   2. PICKER_VISIBLE_SOURCES filter still excludes `plugin` (the seeded
-//      brainstorm.md sits under plugins/cache/...).
+//      to `os.homedir()` would scan the dev's real ~/.claude, polluting
+//      the assertions with whatever the dev has installed locally).
+//   2. PICKER_VISIBLE_SOURCES INCLUDES `plugin` (post-#290 — see
+//      commands-loader.ts for the rationale and the empirical SDK probe
+//      that confirmed plugins run end-to-end via stream-json).
 //
 // preMain wires the env on the main process (where the IPC handler reads
 // `process.env.CLAUDE_CONFIG_DIR`). Disposers restore env and rm -rf the
 // fake tree.
 //
-// Reverse-verification: stash PICKER_VISIBLE_SOURCES filter (set it to
-// include all sources) → `superpowers:brainstorm` appears → case fails.
+// Reverse-verification: shrink PICKER_VISIBLE_SOURCES back to ['user',
+// 'project'] → `superpowers:brainstorm` disappears from the picker → case
+// fails on the positive assertion.
 async function caseSlashPickerClaudeConfigDir({ win, log }) {
   await win.evaluate(() => {
     window.__ccsmStore.setState({
@@ -1062,23 +1064,16 @@ async function caseSlashPickerClaudeConfigDir({ win, log }) {
     throw new Error(`expected /local-test in picker; got: ${flat}`);
   }
 
-  // Negative: plugin-source commands must be filtered out. The seeded
-  // plugin is "superpowers" with command "brainstorm" — the loader emits
-  // it as `superpowers:brainstorm`. Bare `brainstorm` is also forbidden.
-  for (const forbidden of ['superpowers:brainstorm', '/brainstorm ', '/brainstorm\n', '/brainstorm$']) {
-    if (forbidden.startsWith('/brainstorm')) {
-      // Match `/brainstorm` only as a whole token (not as a prefix of
-      // another name, though we don't seed any). Use a regex.
-      const re = new RegExp(`/brainstorm(?![a-zA-Z0-9._:-])`);
-      if (re.test(flat)) {
-        throw new Error(`forbidden plugin command surfaced: /brainstorm in ${flat}`);
-      }
-    } else if (flat.includes(forbidden)) {
-      throw new Error(`forbidden plugin command surfaced: ${forbidden} in ${flat}`);
-    }
+  // Positive (post-#290): the seeded plugin-cache command MUST surface.
+  // The seeded plugin is "superpowers" with command "brainstorm" — the
+  // loader emits it as `superpowers:brainstorm`.
+  if (!flat.includes('superpowers:brainstorm')) {
+    throw new Error(
+      `expected /superpowers:brainstorm in picker (plugin source must be visible post-#290); got: ${flat}`
+    );
   }
 
-  log(`picker showed /local-test; suppressed superpowers:brainstorm (env-scoped fake ~/.claude)`);
+  log(`picker showed /local-test and /superpowers:brainstorm (plugin source restored, env-scoped fake ~/.claude)`);
 }
 
 // ---------- slash-namespaced-unknown-toast ----------

--- a/src/slash-commands/registry.ts
+++ b/src/slash-commands/registry.ts
@@ -136,17 +136,21 @@ export type DispatchOutcome =
   | 'unknown-namespaced';
 
 // Names whose shape advertises "this is a CLI / plugin command" but which
-// the SDK transport cannot execute. Two cases:
+// are NOT in the merged command list. Two cases:
 //
-//   1. Colon-namespaced (`/superpowers:brainstorm`, `/pua:kpi`) — always a
-//      plugin / skill / agent command discovered on disk. PR #346 already
-//      hides these from the picker, but a user who types one by hand still
-//      needs a clear local rejection instead of having the raw text sent
-//      to the model (which then replies "deprecated, use the skill" or
-//      similar — the bug PR #346 surfaced from the user side).
-//   2. `/plugin` — the CLI's own plugin manager. The SDK doesn't load it;
-//      forwarding "/plugin" to claude.exe via the agent transport ends up
-//      as plain user prose, not a command invocation.
+//   1. Colon-namespaced (`/superpowers:brainstrom` typo, `/pua:kpi` for an
+//      uninstalled plugin) — colon-shape strongly implies plugin / skill /
+//      agent, none of which would ever be defined as a built-in. If the
+//      name isn't in the disk-discovered list, it doesn't exist anywhere
+//      we can route it. Bouncing locally is better than forwarding the
+//      raw text and getting a confused model reply. KNOWN namespaced
+//      commands (those returned by loadPickerCommands as plugin/skill/
+//      agent — see PICKER_VISIBLE_SOURCES, restored in #290) are matched
+//      by `findSlashCommand` before this function is consulted, so they
+//      route through the normal pass-through path.
+//   2. `/plugin` — the CLI's own plugin manager. The SDK transport
+//      doesn't surface it; forwarding "/plugin" via the agent stream
+//      ends up as plain user prose, not a command invocation.
 //
 // Anything else (e.g. `/nope`, `/help`) is left as plain `'unknown'` so
 // the existing forward-compat path keeps working — those names might be

--- a/tests/commands-loader.test.ts
+++ b/tests/commands-loader.test.ts
@@ -372,13 +372,13 @@ describe('loadCommands', () => {
 
 // ─── loadPickerCommands ────────────────────────────────────────────────────
 //
-// Picker-visible filter: hides plugin / skill / agent sources because the
-// agent SDK transport ccsm uses cannot execute them without configuration
-// ccsm doesn't supply. These tests pin that contract so a future
-// refactor doesn't silently re-surface broken slash entries to users.
-
+// Picker-visible filter: surfaces every disk-discovered source (user,
+// project, plugin, skill, agent). Reversal of PR #346 — see #290 and the
+// `PICKER_VISIBLE_SOURCES` block in commands-loader.ts for the empirical
+// rationale (the SDK-bundled CLI loads plugins/skills automatically via
+// the user's ~/.claude/settings.json `enabledPlugins` map).
 describe('loadPickerCommands', () => {
-  it('keeps user and project sources, drops plugin / skill / agent', () => {
+  it('surfaces user, project, plugin, skill, and agent sources', () => {
     // user
     write(
       path.join(tmpHome, '.claude', 'commands', 'user-cmd.md'),
@@ -422,15 +422,23 @@ describe('loadPickerCommands', () => {
     const allSources = new Set(all.map((c) => c.source));
     expect(allSources).toEqual(new Set(['user', 'project', 'plugin', 'skill', 'agent']));
 
-    // picker filter: only user + project survive
+    // picker filter: every disk source survives (no built-ins; those are
+    // merged in by the renderer separately).
     const pickerNames = picker.map((c) => `${c.source}/${c.name}`).sort();
-    expect(pickerNames).toEqual(['project/project-cmd', 'user/user-cmd']);
+    expect(pickerNames).toEqual([
+      'agent/agent-cmd',
+      'plugin/pluginA:plugin-cmd',
+      'project/project-cmd',
+      'skill/skill-cmd',
+      'user/user-cmd',
+    ]);
   });
 
-  it('returns an empty list when only plugin / skill / agent entries exist', () => {
+  it('returns plugin / skill entries even when no user commands exist', () => {
     // Real-world scenario: a fresh user with the superpowers + pua plugins
     // installed but no personal `~/.claude/commands` of their own. The
-    // picker must NOT show plugin entries — that's the whole bug.
+    // picker MUST show plugin entries — the bundled CLI loads them via
+    // settings.json `enabledPlugins`, so they're real, runnable commands.
     write(
       path.join(
         tmpHome,
@@ -451,6 +459,10 @@ describe('loadPickerCommands', () => {
     );
 
     const picker = loadPickerCommands({ homeDir: tmpHome, cwd: tmpCwd });
-    expect(picker).toEqual([]);
+    const names = picker.map((c) => `${c.source}/${c.name}`).sort();
+    expect(names).toEqual([
+      'plugin/superpowers:brainstorm',
+      'skill/helpful',
+    ]);
   });
 });


### PR DESCRIPTION
Closes #290. Reopens what PR #346 hid.

## Phase 0 finding (overturns PR #346 premise)

Empirically verified that the SDK-bundled CLI **already** loads plugins and skills automatically from the user's `~/.claude/settings.json` `enabledPlugins` map when the SDK's `settingSources` option is omitted (its default — and ccsm has never set it). No `query({ options: { plugins: [...] } })` wiring is needed.

Probe (raw bundled `claude.exe` + stream-json, exactly the SDK transport ccsm uses):

| Command | Result |
|---|---|
| `/superpowers:brainstorming I want to build a CLI tool` | Real skill output, multiple turns, no deprecation banner |
| `/superpowers:brainstorm <prompt>` | Deprecation banner ("This command is deprecated…") followed by real skill output |

The "deprecated, use the skill" reply that PR #346 attributed to a transport gap is the **actual content** of the deprecated `/superpowers:brainstorm` plugin command — the plugin's authors deprecated that name in favour of the `superpowers:brainstorming` skill. PR #346 misdiagnosed user-visible plugin output as a missing feature.

## SDK option used

None. The SDK's `plugins: SdkPluginConfig[]` option is for SDK consumers to inject EXTRA local plugin paths via `--plugin-dir`. User-installed plugins (under `~/.claude/plugins/cache/...`) are loaded by the bundled CLI itself based on `enabledPlugins` in user settings, which the SDK forwards by virtue of leaving `settingSources` at its default.

## Changes

- `electron/commands-loader.ts` — `PICKER_VISIBLE_SOURCES` now includes `plugin`, `skill`, `agent` (5 disk sources visible). Long comment block explains the empirical rationale.
- `electron/main.ts` — comment refresh.
- `src/slash-commands/registry.ts` — `isUnsupportedSlashShape` comment refreshed. KNOWN namespaced commands match in `findSlashCommand` (pass-through path); only UNKNOWN ones bounce locally via PR #359's toast — that path still applies for genuinely missing commands.
- `tests/commands-loader.test.ts` — flipped `loadPickerCommands` assertions to expect plugin/skill/agent visible.
- `scripts/harness-ui.mjs` `slash-picker-claude-config-dir` — asserts `/superpowers:brainstorm` NOW APPEARS in the picker. Reverse-verified: stashing the loader change makes the case fail with the expected error.
- `scripts/harness-real-cli.mjs` new case `namespaced-command-actually-runs` — spawns the bundled CLI via stream-json, completes the control_request handshake, sends `/superpowers:brainstorming I want to build a small CLI tool`, asserts non-deprecation reply with non-empty content. Regression guard against any future SDK change that would move plugin loading behind an opt-in flag.

## E2E evidence

```
[harness-real-cli] PASS  control-response-no-timeout (1494ms)
[harness-real-cli] PASS  ide-auto-connect-kill-switch-present (245ms)
[harness-real-cli] PASS  namespaced-command-actually-runs (14618ms)
[harness-real-cli] all 3 case(s) passed
```

```
[harness=ui] >>> case slash-picker-claude-config-dir
[case] picker showed /local-test and /superpowers:brainstorm (plugin source restored, env-scoped fake ~/.claude)
[case] OK
```

```
[harness=ui] >>> case slash-namespaced-unknown-toast
[case] namespaced unknown slashes (/plugin, /superpowers:foo) bounced locally with toast; no user messages forwarded
[case] OK
```

Reverse-verify (harness-ui, plugin source removed from PICKER_VISIBLE_SOURCES):
```
Error: expected /superpowers:brainstorm in picker (plugin source must be visible post-#290); got: /clear ... /local-test ...
=== totals: 0 passed, 1 failed ===
```

vitest: 866/869 pass. The 3 failures are pre-existing in `electron/__tests__/db-hardening.test.ts` (better-sqlite3 native module issue on `working`), unrelated to this PR.

## Note on PR #359 unknown-namespaced toast

Still applies for genuinely missing commands: typing `/superpowers:foo` (where `foo` doesn't exist) still bounces locally via the toast, because `findSlashCommand` returns nothing and `isUnsupportedSlashShape` fires. Verified with the existing `slash-namespaced-unknown-toast` harness case (passes unchanged).

## Test plan

- [x] `npx vitest run tests/commands-loader.test.ts tests/slash-commands-handlers.test.ts` — 40/40 pass
- [x] `node scripts/harness-real-cli.mjs` — 3/3 pass
- [x] `node scripts/harness-ui.mjs --only=slash-picker-claude-config-dir` — pass + reverse-verify fails as expected
- [x] `node scripts/harness-ui.mjs --only=slash-namespaced-unknown-toast` — pass (PR #359 still works)
- [x] `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)