### PR TITLE
fix(e2e): tighten i18n-settings-zh assertion against body-text false positive

### DIFF
--- a/scripts/harness-ui.mjs
+++ b/scripts/harness-ui.mjs
@@ -2019,15 +2019,38 @@ async function caseI18nSettingsZh({ win, log, registerDispose }) {
   // Per-event toggle ('权限请求') and the test-notification button
   // ('发送测试通知') were removed; assert they're gone so a regression that
   // re-introduces either is caught here.
+  //
+  // NOTE: the per-event-toggle / test-notification absence checks are scoped
+  // to actual interactive controls (role=switch / role=button) instead of a
+  // raw page-text scan — the zh `notifications.intro` prose mentions
+  // "权限请求" as part of an explanatory sentence, which would false-positive
+  // a substring blacklist. The regression we actually care about is a
+  // re-introduced Field/Switch or button, not the word appearing in copy.
   await switchTab(/^通知$/);
   txt = await paneText();
   assertHasText(txt, '启用通知', 'notifications');
   assertHasText(txt, '声音', 'notifications');
   assertNotHasText(txt, 'Enable notifications', 'notifications');
   assertNotHasText(txt, 'Sound', 'notifications');
-  assertNotHasText(txt, '权限请求', 'notifications');
-  assertNotHasText(txt, '发送测试通知', 'notifications');
-  assertNotHasText(txt, 'Test notification', 'notifications');
+
+  const notifSwitchCount = await dialog
+    .getByRole('switch', { name: /权限请求/ })
+    .count();
+  if (notifSwitchCount > 0) {
+    throw new Error(
+      `notifications: per-event toggle (role=switch name="权限请求") regressed — should not exist post-W2`,
+    );
+  }
+  for (const buttonName of [/发送测试通知/, /Test notification/i]) {
+    const btnCount = await dialog
+      .getByRole('button', { name: buttonName })
+      .count();
+    if (btnCount > 0) {
+      throw new Error(
+        `notifications: test-notification button (name=${buttonName}) regressed — should not exist post-W2`,
+      );
+    }
+  }
 
   // Updates.
   await switchTab(/^更新$/);


### PR DESCRIPTION
## Root cause

`i18n-settings-zh` is **red on `working`** (caught by PR #373 reviewer).

PR #363 added prose to the zh Notifications pane:

> 当某个会话需要你处理时弹出系统通知 —— **权限请求**、agent 提问和回合完成都会立即触发。通知标题显示分组与会话名，正文显示事件类型。

The case was using a whole-pane `textContent.includes('权限请求')` blacklist as a sentinel for the post-W2 per-event toggle having been re-introduced. The new prose contains that exact substring, so the assertion now fires against legitimate intro copy — not against any regressed UI element.

## Fix chosen — (a) tighten the assertion

Scope the regression check to actual interactive controls:

- `role=switch` named `/权限请求/` → would only match a re-introduced `<Switch aria-label="权限请求" />` in the per-event toggle Field.
- `role=button` named `/发送测试通知/` and `/Test notification/i` → would only match a re-introduced test-notification button.

Prose strings should not be blacklisted in a body-text scan — they will keep mutating as we add helpful copy. Element-scoped checks express the actual invariant ("this control does not exist post-W2") much more directly. The positive checks (`'启用通知'`, `'声音'`) and the English-leak checks (`'Enable notifications'`, `'Sound'`) stay as body-text scans because none of them appear in any zh prose.

(b) — change the zh prose to avoid '权限请求' — was rejected because it would (1) remove the most natural zh phrasing for that user-facing concept and (2) leave the same trap for the next prose update touching any other sentinel substring.

## Reproduce / verify

Before:
```
node scripts/harness-ui.mjs --only=i18n-settings-zh
# FAIL: notifications: unexpected English string "权限请求" leaked into zh pane.
```

After:
```
node scripts/harness-ui.mjs --only=i18n-settings-zh
# [OK] i18n-settings-zh
```

Full `node scripts/harness-ui.mjs` run: 34 passed, 1 unrelated flake (`terminal` — passes in isolation, fails when run alongside `tool-render-open-in-editor`; pre-existing on `working`, not introduced here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)