### PR TITLE
style(icons): unify lucide icon size to 14px in Sidebar + StatusBar (UX audit Group D)

### DIFF
--- a/scripts/harness-ui.mjs
+++ b/scripts/harness-ui.mjs
@@ -3056,6 +3056,126 @@ async function caseSidebarVerticalSymmetry({ win, log }) {
   );
 }
 
+// ---------- icon-size-canon ----------
+// UX audit Group D — pin lucide icon sizes in Sidebar (collapsed rail +
+// expanded top/bottom action buttons) and StatusBar chip chevron to the
+// canonical 14px. Catches regressions where size={13} or size={10} sneak
+// back into the rail, which previously created a visible icon-size jitter
+// across otherwise identical h-8 buttons.
+async function caseIconSizeCanon({ win, log }) {
+  // Need an active session so the StatusBar (and thus the effort-chip)
+  // renders. Use the same minimal seed pattern as caseEffortChipToggle.
+  await win.evaluate(() => {
+    const store = window.__ccsmStore;
+    const s = store.getState();
+    if (s.sessions.length === 0) s.createSession('~');
+    const sid = store.getState().activeId;
+    store.setState((prev) => ({
+      startedSessions: { ...prev.startedSessions, [sid]: true },
+    }));
+  });
+  await win.waitForTimeout(200);
+
+  // --- Expanded sidebar measurements (default state) ---
+  const expanded = await win.evaluate(() => {
+    const aside = document.querySelector('aside');
+    if (!aside) return null;
+    const buttons = Array.from(aside.querySelectorAll('button'));
+    function svgWidthIn(btn) {
+      if (!btn) return null;
+      const svg = btn.querySelector('svg');
+      if (!svg) return null;
+      const w = svg.getAttribute('width');
+      return w == null ? null : Number(w);
+    }
+    const newSession = buttons.find((b) => /^New Session$/i.test(b.textContent?.trim() ?? ''));
+    const settings = buttons.find((b) => /^Settings$/i.test(b.textContent?.trim() ?? ''));
+    // Search and Import (Download) are icon-only; identify by aria-label.
+    const search = buttons.find((b) => /search/i.test(b.getAttribute('aria-label') ?? ''));
+    const importBtn = buttons.find((b) => /import/i.test(b.getAttribute('aria-label') ?? ''));
+    return {
+      newSession: svgWidthIn(newSession),
+      settings: svgWidthIn(settings),
+      search: svgWidthIn(search),
+      importBtn: svgWidthIn(importBtn),
+    };
+  });
+  if (!expanded) throw new Error('expanded sidebar not found');
+
+  // --- StatusBar effort-chip chevron measurement ---
+  const chipChevron = await win.evaluate(() => {
+    const chip = document.querySelector('[data-testid="effort-chip"]');
+    if (!chip) return null;
+    const svg = chip.querySelector('svg');
+    if (!svg) return null;
+    const w = svg.getAttribute('width');
+    return w == null ? null : Number(w);
+  });
+  if (chipChevron == null) throw new Error('StatusBar effort-chip chevron not found');
+
+  // --- Collapse the sidebar and measure the rail icons ---
+  await win.evaluate(() => {
+    window.__ccsmStore.setState({ sidebarCollapsed: true });
+  });
+  await win.waitForTimeout(300);
+
+  const rail = await win.evaluate(() => {
+    const aside = document.querySelector('aside');
+    if (!aside) return null;
+    const buttons = Array.from(aside.querySelectorAll('button'));
+    function svgWidthInBtn(matcher) {
+      const btn = buttons.find((b) => matcher(b.getAttribute('aria-label') ?? ''));
+      if (!btn) return null;
+      const svg = btn.querySelector('svg');
+      if (!svg) return null;
+      const w = svg.getAttribute('width');
+      return w == null ? null : Number(w);
+    }
+    return {
+      expand: svgWidthInBtn((l) => /expand/i.test(l)),
+      newSession: svgWidthInBtn((l) => /new session/i.test(l)),
+      search: svgWidthInBtn((l) => /search/i.test(l)),
+      importBtn: svgWidthInBtn((l) => /import/i.test(l)),
+      settings: svgWidthInBtn((l) => /settings/i.test(l)),
+    };
+  });
+  if (!rail) throw new Error('collapsed rail not found');
+
+  // Restore for subsequent cases.
+  await win.evaluate(() => {
+    window.__ccsmStore.setState({ sidebarCollapsed: false });
+  });
+
+  const CANON = 14;
+  const measurements = {
+    'expanded.newSession': expanded.newSession,
+    'expanded.search': expanded.search,
+    'expanded.settings': expanded.settings,
+    'expanded.import': expanded.importBtn,
+    'rail.expand': rail.expand,
+    'rail.newSession': rail.newSession,
+    'rail.search': rail.search,
+    'rail.import': rail.importBtn,
+    'rail.settings': rail.settings,
+    'statusbar.chipChevron': chipChevron,
+  };
+
+  const offenders = Object.entries(measurements)
+    .filter(([, v]) => v !== CANON)
+    .map(([k, v]) => `${k}=${v}`);
+  if (offenders.length) {
+    throw new Error(
+      `icon size drift (canon=${CANON}px): ${offenders.join(', ')}`
+    );
+  }
+
+  log(
+    Object.entries(measurements)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(' ')
+  );
+}
+
 // ---------- harness spec ----------
 await runHarness({
   name: 'ui',
@@ -3082,6 +3202,10 @@ await runHarness({
     // (2) Sidebar internal top/bottom symmetry.
     { id: 'sidebar-inputbar-bottom-align', run: caseSidebarInputbarBottomAlign },
     { id: 'sidebar-vertical-symmetry', run: caseSidebarVerticalSymmetry },
+    // UX audit Group D — task #310. Pin lucide icon sizes (Sidebar collapsed
+    // rail + expanded action buttons + StatusBar chip chevron) to canonical
+    // 14px so 13/10 mismatches don't sneak back in.
+    { id: 'icon-size-canon', run: caseIconSizeCanon },
     { id: 'no-sessions-landing', run: caseNoSessionsLanding },
     { id: 'empty-state-minimal', run: caseEmptyStateMinimal },
     { id: 'a11y-focus-restore', run: caseA11yFocusRestore },

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -661,7 +661,7 @@ export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, onOpen
             aria-label={t('sidebar.importAriaShort')}
             className="h-8 w-8"
           >
-            <Download size={13} className="stroke-[1.5]" />
+            <Download size={14} className="stroke-[1.5]" />
           </IconButton>
           <IconButton
             variant="raised"
@@ -672,7 +672,7 @@ export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, onOpen
             aria-label={t('sidebar.settingsAria')}
             className="h-8 w-8"
           >
-            <Settings size={13} className="stroke-[1.5]" />
+            <Settings size={14} className="stroke-[1.5]" />
           </IconButton>
         </div>
       ) : (
@@ -800,7 +800,7 @@ export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, onOpen
               onClick={onOpenSettings}
               className="flex-1 h-8 text-chrome gap-1.5"
             >
-              <Settings size={13} className="stroke-[1.5]" />
+              <Settings size={14} className="stroke-[1.5]" />
               <span>{t('common.settings')}</span>
             </Button>
             <IconButton
@@ -812,7 +812,7 @@ export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, onOpen
               aria-label={t('sidebar.importAriaShort')}
               className="h-8 w-8 shrink-0"
             >
-              <Download size={13} className="stroke-[1.5]" />
+              <Download size={14} className="stroke-[1.5]" />
             </IconButton>
           </div>
         </div>

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -46,7 +46,7 @@ const Chip = React.forwardRef<
       )}
     >
       {children}
-      <ChevronDown size={10} className="stroke-[1.75] opacity-70" />
+      <ChevronDown size={14} className="stroke-[1.75] opacity-70" />
     </button>
   );
 });


### PR DESCRIPTION
## Summary

UX audit Group D — eliminate the 13px / 10px lucide-icon outliers that made otherwise-identical h-8 buttons render with subtly different glyph weights across the sidebar rail, expanded action zones, and the StatusBar chip chevron. All in-scope icons now share the canonical **14px** size.

## Changes

### `src/components/Sidebar.tsx`
| Line | Icon | Before | After |
|------|------|--------|-------|
| 664 | collapsed rail Download (Import) | 13 | **14** |
| 675 | collapsed rail Settings | 13 | **14** |
| 803 | expanded Settings button | 13 | **14** |
| 815 | expanded Import (Download) | 13 | **14** |

Already 14 — left as-is: L514 (NewSession Plus), L630 (collapsed Expand chevron), L641 (collapsed Plus), L652 (collapsed Search), L696 (expanded Search).

Out of scope per the audit (group / archive rows, untouched): L180, L221, L717, L762.

### `src/components/StatusBar.tsx`
| Line | Icon | Before | After |
|------|------|--------|-------|
| 49 | chip chevron (ChevronDown) | 10 | **14** |

## Regression test

`scripts/harness-ui.mjs` — new case `icon-size-canon`:

- Seeds an active session so the StatusBar renders.
- Measures the SVG `width` attribute on every in-scope icon: expanded NewSession / Search / Settings / Import, collapsed rail Expand / NewSession / Search / Import / Settings, and the StatusBar `effort-chip` chevron.
- Asserts each equals 14. Reports the offending key=value list when any drift.

Pre-fix run (confirmed failing on exactly these five):
```
FAIL: icon size drift (canon=14px): expanded.settings=13, expanded.import=13, rail.import=13, rail.settings=13, statusbar.chipChevron=10
```

Post-fix run:
```
expanded.newSession=14 expanded.search=14 expanded.settings=14 expanded.import=14 rail.expand=14 rail.newSession=14 rail.search=14 rail.import=14 rail.settings=14 statusbar.chipChevron=14
[case=icon-size-canon] OK
```

## Verification

- `node scripts/harness-ui.mjs --only=icon-size-canon` → passes after fix, fails before fix (recorded above).
- `node scripts/harness-ui.mjs` (full sweep) → 37/38 pass; only the pre-existing `terminal` flake fails (unrelated, known).
- `npx tsc --noEmit` → clean.

## Test plan

- [x] icon-size-canon green
- [x] Full harness-ui no new red
- [x] tsc clean
- [ ] Reviewer reverse-verify: stash this PR's component edits, re-run `--only=icon-size-canon`, confirm the same 5-offender FAIL.

Part of #310.