### PR TITLE
fix(e2e): default CCSM_E2E_HIDDEN=1 in harness scripts so worker runs don't pop windows

### DIFF
--- a/scripts/probe-helpers/harness-runner.mjs
+++ b/scripts/probe-helpers/harness-runner.mjs
@@ -322,7 +322,17 @@ function buildLaunchOpts(spec, userDataDirOverride) {
     // same mechanism CCSM_USER_DATA_DIR-style overrides ultimately land on.
     args.push(`--user-data-dir=${userDataDirOverride}`);
   }
+  // Default CCSM_E2E_HIDDEN=1 so direct `node scripts/harness-*.mjs` runs
+  // (e.g. background workers, or a single-case iteration) don't pop a window
+  // onto the user's desktop and steal focus. run-all-e2e.mjs already sets
+  // this; this default makes the same behavior apply when a harness is
+  // invoked standalone. Visible-mode harnesses (dnd, perm, restore's
+  // sidebar-resize) explicitly opt out via `spec.launch.env.CCSM_E2E_HIDDEN
+  // = '0'`, which still wins because `spec.launch.env` is spread last. Users
+  // debugging can also opt out by exporting `CCSM_E2E_HIDDEN=0` before the
+  // run — `process.env` is spread after the default, so an explicit env wins.
   const env = {
+    CCSM_E2E_HIDDEN: '1',
     ...process.env,
     NODE_ENV: 'production',
     CCSM_PROD_BUNDLE: '1',


### PR DESCRIPTION
## Pain point
Background workers running e2e (`node scripts/harness-*.mjs --only=<case>`) popped Electron windows onto the user's desktop and stole focus. PR #304 added `CCSM_E2E_HIDDEN` but only `scripts/run-all-e2e.mjs:172` defaulted it to `'1'`. Standalone harness invocations inherited an empty value, so `electron/main.ts:263` (`hiddenForE2E = process.env.CCSM_E2E_HIDDEN === '1'`) read `false` and showed the window normally.

## Phase 1 — diagnosis
- All 6 harnesses (`harness-agent`, `harness-dnd`, `harness-perm`, `harness-real-cli`, `harness-restore`, `harness-ui`) launch Electron via `runHarness` -> `buildLaunchOpts` in `scripts/probe-helpers/harness-runner.mjs:318`. That's the single chokepoint for both initial boot and per-case relaunch.
- `buildLaunchOpts` already spread `process.env` correctly (`{ ...process.env, NODE_ENV, CCSM_PROD_BUNDLE, ...spec.launch?.env }`), so env passthrough was fine — the problem was simply that no default for `CCSM_E2E_HIDDEN` was injected.
- `run-all-e2e.mjs:172` correctly sets `CCSM_E2E_HIDDEN: process.env.CCSM_E2E_HIDDEN ?? '1'` before spawning each child harness, which is why the full batch suite never popped — but direct `node scripts/harness-*.mjs` runs (the worker pattern) did.
- Visible-mode opt-outs (`harness-dnd.mjs:146`, `harness-perm.mjs:2849`, `harness-restore.mjs:599`) all work via `spec.launch.env.CCSM_E2E_HIDDEN: '0'`, which is spread last in `buildLaunchOpts` — i.e. they win over any default we inject.

## Fix (modification A in the proposed list)
Inject `CCSM_E2E_HIDDEN: '1'` as the very first key in the env merge inside `buildLaunchOpts`. Precedence chain (left = lowest priority, last spread wins):

```
default '1'  <  process.env  <  spec.launch.env
```

Outcome:
- Direct `node scripts/harness-ui.mjs` -> hidden (fixes the bug)
- `CCSM_E2E_HIDDEN=0 node scripts/harness-ui.mjs` -> visible (debug mode preserved; explicit env wins)
- `harness-dnd` / `harness-perm` / `harness-restore` sidebar-resize -> still visible (spec.launch.env wins)
- `run-all-e2e.mjs` -> hidden (unchanged behavior)

Modification B (touching individual `_electron.launch` env spreads) was not needed — the harness-runner chokepoint already spreads `process.env` correctly. Modification C was not needed — `run-all-e2e.mjs` is already correct.

## Phase 4 — verification
Ran from `~/ccsm-worktrees/pool-9` on the patched branch (used a temporary diagnostic probe that called `app.evaluate(() => process.env.CCSM_E2E_HIDDEN)` and `BrowserWindow.getPosition()` — deleted before commit):

| scenario | env in main process | window position | result |
| --- | --- | --- | --- |
| `node scripts/harness-ui.mjs --only=sidebar-align` | `CCSM_E2E_HIDDEN=1` | `[-16384, -16384]` | hidden, no focus steal |
| `node scripts/harness-ui.mjs --only=settings-open` | `CCSM_E2E_HIDDEN=1` | offscreen | hidden, passes |
| `CCSM_E2E_HIDDEN=0 node scripts/probe-...` (debug) | `CCSM_E2E_HIDDEN=0` | `[80, 26]` | visible (reverse-verified) |
| `harness-perm --only=permission-focus-not-stolen` (visible by design via `spec.launch.env`) | `CCSM_E2E_HIDDEN=0` | on-screen | visible (intended), passes |

All four scenarios behave as expected. Visible-mode debugging (`CCSM_E2E_HIDDEN=0`) is unaffected.

## Files
- `scripts/probe-helpers/harness-runner.mjs` — 10-line addition inside `buildLaunchOpts`.