### PR TITLE
fix(e2e): terminal case state pollution from tool-render-open-in-editor

### DIFF
--- a/scripts/harness-ui.mjs
+++ b/scripts/harness-ui.mjs
@@ -2623,9 +2623,22 @@ async function caseTerminal({ win, log }) {
     ]);
   }, sessionId);
 
-  await win.waitForTimeout(200);
-
+  // Wait for ChatStream to commit a render that includes the tool block we
+  // just appended, instead of relying on a fixed sleep. A bare 200ms is enough
+  // when this case runs first (cold renderer, immediate React commit), but
+  // becomes flaky when prior cases (language-toggle / i18n-settings-zh /
+  // settings-open / etc.) have churned i18n + framer-motion AnimatePresence
+  // transitions. In that scenario, the createSession+selectSession bump
+  // triggers a session-switch crossfade keyed on activeId; the EmptyState
+  // branch is mid-exit when appendBlocks fires, and the blocks branch hasn't
+  // mounted yet by the 200ms mark. Using locator.waitFor with the actual
+  // selector turns the wait into "wait until React commits", not "guess".
   const candidates = win.locator('[data-testid="tool-block-root"] button[aria-expanded]');
+  try {
+    await candidates.first().waitFor({ state: 'visible', timeout: 5000 });
+  } catch {
+    throw new Error('no ChatStream ToolBlock button found within 5s after appendBlocks');
+  }
   const btnCount = await candidates.count();
   if (btnCount === 0) throw new Error('no ChatStream ToolBlock button found');
   await candidates.first().click();


### PR DESCRIPTION
## Summary

Replace the 200ms hard sleep in harness-ui's `terminal` case with a `locator.waitFor` on the actual `tool-block-root` selector. The fixed sleep was racing the AnimatePresence session-switch crossfade left running by upstream cases that churn i18n / settings dialogs.

## Phase 1 — repro (failure output)

Full `node scripts/harness-ui.mjs` on `working`:

```
[case=terminal] FAIL: no ChatStream ToolBlock button found
...
  [XX] terminal                                    872ms
```

`--only=terminal` alone: PASS.
`--only=tool-render-open-in-editor,terminal`: PASS (runner respects spec order, runs `terminal` first).
`--only=language-toggle,terminal`: FAIL — first reproducer pair.
`--only=i18n-settings-zh,terminal`: FAIL — second reproducer.

So the polluter is not specifically `tool-render-open-in-editor`; it's any predecessor that exercises the Settings dialog / i18n flip. Adding 2s to the existing sleep made it pass, confirming a timing issue rather than store-state contamination.

## Phase 2 — root cause

Instrumentation at the failure point dumped:

```
sid == activeId, sessionsCount: 1, msgsForSid: 1, msgsForSidKinds: ["tool:tu-probe"],
toolBlockRootCount: 0, language: "en", chatStreamRendered: true,
mainHTMLSnippet: "Type a message and press\nEnter\nterminal-probe..."
```

Store has the tool block under the right session id, language is back to `en` (dispose worked), `[data-chat-stream]` exists — but the EmptyState branch is what's mounted, not the blocks branch. React simply hadn't committed the post-`appendBlocks` re-render yet.

`src/components/ChatStream.tsx:130-148` wraps the empty/blocks branches in `<AnimatePresence mode="wait">` keyed on `empty:${activeId}` / `blocks:${activeId}`. With `mode="wait"`, the new branch can't mount until the old one's exit animation completes (`MOTION_SESSION_SWITCH_DURATION`). When `terminal` runs first, the renderer is cold and exit is instant; when prior cases have left framer-motion transitions warm and i18n re-bound a Suspense boundary, the exit takes longer than the 200ms `waitForTimeout`. The case's `[data-testid=...]` query then runs against the still-mounted EmptyState.

## Fix — option (a) (chose) vs (b) vs (c)

- **(a) cleanup in `tool-render-open-in-editor` / harness teardown:** rejected. The polluter isn't that case — it's `language-toggle`, `i18n-settings-zh`, and any Settings-dialog case. There's nothing specific to clean up; the problem is timing, not residue. Patching cleanup on every potential polluter would scale poorly and miss future cases that do the same.
- **(b) defensive in `terminal` setup:** chose. The bug is specifically that the case asserts via a fixed sleep instead of a state-driven wait. Replacing the sleep with `locator.waitFor` on the real selector turns the wait into "wait until React commits the re-render with the tool block visible," which is correct regardless of how warm/cold the predecessor cases left framer-motion or i18n. This is the canonical Playwright fix for this category of flake.
- **(c) reorder cases:** rejected per task brief — escapism, doesn't survive new cases.

## Phase 4 — verify

| invocation | terminal status |
|---|---|
| `--only=terminal` | PASS |
| `--only=language-toggle,terminal` | PASS (was: FAIL) |
| `--only=tool-render-open-in-editor,terminal` | PASS |
| full `harness-ui.mjs` | PASS |

Full-suite summary after fix:
```
=== totals: 36 passed, 1 failed, 0 skipped, 37 total ===
```

The single remaining failure is `i18n-settings-zh` (translation-parity assertion catching a stale "权限请求" English-vs-zh leak) — pre-existing, completely unrelated to this PR, present on `working` before this change. Out of scope.

## Test plan

- [x] `node scripts/harness-ui.mjs --only=terminal`
- [x] `node scripts/harness-ui.mjs --only=language-toggle,terminal` (was the deterministic reproducer)
- [x] `node scripts/harness-ui.mjs --only=tool-render-open-in-editor,terminal`
- [x] `node scripts/harness-ui.mjs` full suite — terminal green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>