### PR TITLE
fix(rewind): keep clicked user message in rewind-from-here (#309)

### DIFF
--- a/scripts/harness-agent.mjs
+++ b/scripts/harness-agent.mjs
@@ -2226,17 +2226,27 @@ async function caseUserBlockHoverMenu({ win, log }) {
       started: !!s.startedSessions[sid]
     };
   }, SID);
-  if (after.blockIds.length !== 1 || after.blockIds[0] !== 'a0') {
-    throw new Error(`expected blocks=[a0] after Truncate, got ${JSON.stringify(after.blockIds)}`);
+  // Bug #309 ("Rewind from here keeps clicked user message"): the clicked
+  // user block (`u-rewind`) MUST remain after the cut — the rewind
+  // semantics are "go back to right after this message was sent, before
+  // the agent replied", not "delete this message too". Pre-fix
+  // `prev.slice(0, idx)` (exclusive) wrongly dropped `u-rewind` and left
+  // only `[a0]`; post-fix `prev.slice(0, idx + 1)` (inclusive) keeps it.
+  if (after.blockIds.length !== 2 || after.blockIds[0] !== 'a0' || after.blockIds[1] !== 'u-rewind') {
+    throw new Error(`expected blocks=[a0, u-rewind] after Truncate (#309: clicked user msg preserved), got ${JSON.stringify(after.blockIds)}`);
   }
-  if (after.resume !== null) {
-    throw new Error(`expected resumeSessionId=null after Truncate, got ${JSON.stringify(after.resume)}`);
+  // Bug #288 fix (preserved): `resumeSessionId` is pinned to the on-disk
+  // session id (= existing resumeSessionId, here 'old-uuid') so the next
+  // `agentStart` resumes via `--resume` instead of colliding on
+  // `--session-id`. Do NOT regress to `null`.
+  if (after.resume !== 'old-uuid') {
+    throw new Error(`expected resumeSessionId='old-uuid' (pinned per #288 fix) after Truncate, got ${JSON.stringify(after.resume)}`);
   }
   if (after.started) {
     throw new Error(`expected startedSessions cleared after Truncate, got true`);
   }
 
-  log('hover reveals 4 actions; Copy -> clipboard; Truncate -> cut + clear resume');
+  log('hover reveals 4 actions; Copy -> clipboard; Truncate -> cut keeps clicked user msg + pinned resume');
 }
 
 // ---------- cap-pre-main-injects-global (capability demo) ----------

--- a/scripts/harness-real-cli.mjs
+++ b/scripts/harness-real-cli.mjs
@@ -587,12 +587,11 @@ async function caseNamespacedCommandActuallyRuns({ log }) {
  * Failure mode C is the #288 reproduction.
  *
  * Note on bug #309 (off-by-one): the off-by-one is purely a renderer-side
- * `Array.slice` boundary in `rewindToBlock` (`prev.slice(0, idx)` keeps
- * blocks BEFORE idx, dropping the clicked block itself). It cannot be
- * exercised from a CLI-only harness because the renderer is the one
- * computing the cut. It IS covered by a unit test added in this PR
- * (`tests/store-rewind-to-block.test.ts`), and reverse-verified by reverting
- * the slice to the pre-fix expression. The harness-real-cli case is the
+ * `Array.slice` boundary in `rewindToBlock`. It cannot be exercised from a
+ * CLI-only harness because the renderer is the one computing the cut. It is
+ * covered by `scripts/harness-agent.mjs` case `user-block-hover-menu` (real
+ * Playwright-driven store + UI) and the unit tests in
+ * `tests/user-block-hover-menu.test.tsx`. The harness-real-cli case is the
  * #288-side reproduction (CLI-side state interaction).
  *
  * Hard timeout: 60s for the whole case (4 spawns × ~1.5s warmup +

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -1898,7 +1898,11 @@ export const useStore = create<State & Actions>((set, get) => ({
       if (!prev) return s;
       const idx = prev.findIndex((b) => b.id === blockId);
       if (idx < 0) return s;
-      const truncated = prev.slice(0, idx);
+      // Bug #309: keep the clicked user message itself — "rewind from here"
+      // means "go back to right after this message was sent, before the
+      // agent replied", NOT "delete this message too". Slice is inclusive of
+      // `idx` (`idx + 1`); blocks AFTER the clicked one are dropped.
+      const truncated = prev.slice(0, idx + 1);
       // Drop every flag that pins this session to the now-orphaned claude.exe
       // conversation: started, running, interrupted, queue. Stats are
       // intentionally preserved — they're the user's lifetime spend for this
@@ -2087,7 +2091,9 @@ export const useStore = create<State & Actions>((set, get) => ({
         const marker = await window.ccsm?.truncationGet?.(sessionId);
         if (marker && marker.blockId) {
           const cut = sanitized.findIndex((b) => b.id === marker.blockId);
-          if (cut >= 0) sanitized = sanitized.slice(0, cut);
+          // Bug #309: inclusive cut — keep the marker block itself. Mirrors
+          // `rewindToBlock`'s `prev.slice(0, idx + 1)`.
+          if (cut >= 0) sanitized = sanitized.slice(0, cut + 1);
         }
       } catch (err) {
         // truncationGet is best-effort; a failure leaves history intact.

--- a/tests/user-block-hover-menu.test.tsx
+++ b/tests/user-block-hover-menu.test.tsx
@@ -134,7 +134,7 @@ describe('<UserBlock /> hover menu', () => {
     expect(useStore.getState().runningSessions['s1']).toBe(true);
   });
 
-  it('Truncate from here: truncates the conversation to before this block, pins resumeSessionId to the on-disk session id, calls agentClose', () => {
+  it('Truncate from here: keeps clicked user msg, drops everything after, pins resumeSessionId, calls agentClose', () => {
     const blocks = [
       { kind: 'assistant' as const, id: 'a0', text: 'previous reply' },
       { kind: 'user' as const, id: 'u1', text: 'this one' },
@@ -161,8 +161,12 @@ describe('<UserBlock /> hover menu', () => {
       fireEvent.click(screen.getByRole('button', { name: /truncate from here/i }));
     });
     const after = useStore.getState();
-    expect(after.messagesBySession['s1']).toHaveLength(1);
+    // Bug #309: clicked user message is PRESERVED ([a0, u1]); only blocks
+    // AFTER it (a1, t1) are dropped. "Rewind from here" = "go back to right
+    // after this message was sent, before the agent replied".
+    expect(after.messagesBySession['s1']).toHaveLength(2);
     expect(after.messagesBySession['s1'][0].id).toBe('a0');
+    expect(after.messagesBySession['s1'][1].id).toBe('u1');
     const sess = after.sessions.find((x) => x.id === 's1');
     // resumeSessionId stays pinned to whatever was already on disk so the
     // next agentStart re-uses it via `--resume` instead of fighting the CLI
@@ -235,8 +239,9 @@ describe('<UserBlock /> hover menu', () => {
     ];
     const api = stubCCSM({
       loadHistory: vi.fn().mockResolvedValue({ ok: true, frames }),
-      // Marker says: cut at the SECOND user message, so only the first
-      // should remain.
+      // Marker says: cut at the SECOND user message — inclusive cut keeps
+      // the marker block itself (#309), so 'first' AND 'second' should
+      // remain; only 'third' is dropped.
       truncationGet: vi.fn().mockResolvedValue({ blockId: 'u-two', truncatedAt: 1 }),
       truncationSet: vi.fn().mockResolvedValue({ ok: true })
     });
@@ -247,7 +252,8 @@ describe('<UserBlock /> hover menu', () => {
     const userBlocks = blocks.filter((b) => b.kind === 'user');
     expect(api.loadHistory).toHaveBeenCalled();
     expect(api.truncationGet).toHaveBeenCalledWith(sessionId);
-    // Only the first user message survives. The second/third are cut.
-    expect(userBlocks.map((b) => b.text)).toEqual(['first']);
+    // Inclusive cut: the second user message (the marker) stays, the third
+    // is dropped.
+    expect(userBlocks.map((b) => b.text)).toEqual(['first', 'second']);
   });
 });


### PR DESCRIPTION
## Bug

Hover menu's "Rewind from here" / "Truncate from here" on a user message was DELETING that clicked message itself. `prev.slice(0, idx)` is exclusive of `idx`, so the clicked block fell out of the truncated view along with everything after it.

User-confirmed semantics: "rewind from here" = "go back to right after this message was sent, before the agent replied". The clicked user message MUST stay; the next agent run re-answers it.

#378 fixed bug #288 (the exit-1 on resend) but explicitly chose NOT to fix #309, on the (incorrect) read that "the user's spec for expected and actual both reduce to the same outcome." Re-confirmed with user that the clicked message is in fact lost and that's the bug.

## Fix

`src/stores/store.ts` `rewindToBlock`: `prev.slice(0, idx)` -> `prev.slice(0, idx + 1)` (inclusive of the clicked block).

`src/stores/store.ts` `loadMessages` truncation-marker re-apply: same `cut + 1` so reload after a ccsm restart matches the in-memory cut semantics.

That's it for source. Tests + harness updated to match.

## #288 fix preserved

The `resumeSessionId` pin from #378 (so the next `agentStart` resumes via `--resume` instead of colliding on `--session-id`) is unchanged. Harness assertion explicitly pins it: `expected resumeSessionId='old-uuid' (pinned per #288 fix)`.

## Phase 1: failing e2e first (pre-fix)

Updated harness-agent `user-block-hover-menu` to assert the correct post-fix shape, then ran it BEFORE touching `store.ts`:

```
[case=user-block-hover-menu] FAIL: expected blocks=[a0, u-rewind] after Truncate (#309: clicked user msg preserved), got ["a0"]
```

Confirms the bug: clicked `u-rewind` is gone.

## Phase 4: post-fix passing + reverse-verify

```
[case=user-block-hover-menu] hover reveals 4 actions; Copy -> clipboard; Truncate -> cut keeps clicked user msg + pinned resume
[case=user-block-hover-menu] OK
=== totals: 1 passed, 0 failed, 0 skipped, 1 total ===
```

Reverse-verify (`git stash` the store.ts change, rebuild, re-run):

```
Error: expected blocks=[a0, u-rewind] after Truncate (#309: clicked user msg preserved), got ["a0"]
=== totals: 0 passed, 1 failed, 0 skipped, 1 total ===
```

Stash popped, rebuilt, harness green again. Fix is the cause.

## Other checks

- `npm test -- user-block-hover-menu`: 7/7 passed (truncate case + loadMessages re-apply case both flipped to inclusive).
- `npx tsc --noEmit`: clean.
- harness-real-cli docstring de-references the never-created `tests/store-rewind-to-block.test.ts` (reviewer note from #378) and points at the real coverage.

## Bonus latent bug fixed

The pre-existing harness-agent assertion `expected resumeSessionId=null after Truncate` was stale — #378 changed the store to PIN resumeSessionId but didn't update this case. It would have failed the moment anyone ran the case post-#378. Updated to assert the pinned value (`'old-uuid'`).

## Test plan

- [x] harness-agent `user-block-hover-menu` passes
- [x] `tests/user-block-hover-menu.test.tsx` 7/7 passing
- [x] `npx tsc --noEmit` clean
- [x] reverse-verify: stash fix -> harness fails; unstash -> harness passes