### PR TITLE
fix(session): new-session default cwd falls back to c:/x instead of frequency vote

### DIFF
--- a/scripts/harness-restore.mjs
+++ b/scripts/harness-restore.mjs
@@ -1842,6 +1842,175 @@ async function caseDefaultCwdModelFromRecentHistory({ log, registerDispose }) {
   }
 }
 
+// ──────────────────────────────────────────────────────────────────────────
+// CASE: new-session-default-cwd-from-frequency
+//
+// Bug repro (post-#369): in the wild, "新建 session" still produces a default
+// cwd that has nothing to do with the user's frequency-top CLI directory.
+// The user reported the picker landing on `c:/x` — a stale value that lives
+// only inside their already-open ccsm session.
+//
+// Root cause: the `createSession` cwd fallback chain still prefers
+// `groupRecentCwd` (the cwd of the most-recent existing session in the
+// target group) BEFORE `historyRecentCwds[0]` (frequency vote over the last
+// 10 CLI sessions). So if the user has any prior session in the focused
+// group whose cwd happens to be a stray throwaway dir, every "New session"
+// click in that group inherits that stray cwd — completely shadowing #369's
+// frequency-vote default the user explicitly asked for.
+//
+// Expected per user direction: frequency vote wins over both
+// `groupRecentCwd` and `recentProjects`. The CLI transcript history is the
+// ONLY "where do you actually work" signal — neither a one-off chip pick
+// nor a stray cwd inherited from a prior in-app session should override it.
+//
+// This probe plants:
+//   - 10 jsonl history fixtures with frequency-top cwd `D:/work/repo-a` (×7)
+//     and `D:/work/repo-b` (×3) — same pattern as the #369 case but using
+//     Windows-style paths to match what the user actually hit.
+//   - An existing in-app session in the focused group with a stale cwd
+//     `c:/x` (the literal value the user reported).
+//   - A persisted `recentProjects` entry of `c:/x` so even if the
+//     groupRecentCwd path didn't fire, the second-best wrong-source would.
+//
+// Then triggers `createSession()` and asserts the new session's cwd ===
+// `D:/work/repo-a` (frequency winner).
+// ──────────────────────────────────────────────────────────────────────────
+async function caseNewSessionDefaultCwdFromFrequency({ log, registerDispose }) {
+  const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ccsm-harness-new-session-cwd-home-'));
+  registerDispose(() => { try { fs.rmSync(fakeHome, { recursive: true, force: true }); } catch {} });
+  const projectsRoot = path.join(fakeHome, '.claude', 'projects');
+  fs.mkdirSync(projectsRoot, { recursive: true });
+
+  // Frequency layout: D:/work/repo-a 7x, D:/work/repo-b 3x in last 10.
+  const fixtures = [
+    { mtime: 10, cwd: 'D:/work/repo-b' },
+    { mtime: 9,  cwd: 'D:/work/repo-a' },
+    { mtime: 8,  cwd: 'D:/work/repo-a' },
+    { mtime: 7,  cwd: 'D:/work/repo-a' },
+    { mtime: 6,  cwd: 'D:/work/repo-b' },
+    { mtime: 5,  cwd: 'D:/work/repo-a' },
+    { mtime: 4,  cwd: 'D:/work/repo-a' },
+    { mtime: 3,  cwd: 'D:/work/repo-a' },
+    { mtime: 2,  cwd: 'D:/work/repo-b' },
+    { mtime: 1,  cwd: 'D:/work/repo-a' },
+  ];
+  const baseTime = Date.now() - 10 * 60_000;
+  for (let i = 0; i < fixtures.length; i++) {
+    const f = fixtures[i];
+    const sid = `00000000-0000-4000-8000-00000000010${(i + 1).toString(16)}`;
+    const projDir = path.join(projectsRoot, projectKeyFromCwd(f.cwd));
+    fs.mkdirSync(projDir, { recursive: true });
+    const filePath = path.join(projDir, `${sid}.jsonl`);
+    const ts = new Date(baseTime + f.mtime * 1000).toISOString();
+    const frames = [
+      {
+        type: 'user', parentUuid: null, isSidechain: false, uuid: `nu-${i}`,
+        cwd: f.cwd, sessionId: sid, timestamp: ts,
+        message: { role: 'user', content: [{ type: 'text', text: `probe ${i}` }] }
+      },
+      {
+        type: 'assistant', session_id: sid, parentUuid: `nu-${i}`, isSidechain: false,
+        uuid: `na-${i}`, cwd: f.cwd, timestamp: ts,
+        message: {
+          id: `nmsg-${i}`, role: 'assistant', model: 'claude-opus-4-7[1m]',
+          content: [{ type: 'text', text: `reply ${i}` }]
+        }
+      }
+    ];
+    fs.writeFileSync(filePath, frames.map((fr) => JSON.stringify(fr)).join('\n') + '\n');
+    const wantMs = baseTime + f.mtime * 1000;
+    fs.utimesSync(filePath, wantMs / 1000, wantMs / 1000);
+  }
+  log(`planted 10 fixtures: D:/work/repo-a:7 D:/work/repo-b:3 under ${projectsRoot}`);
+
+  const ud = isolatedUserData('ccsm-harness-new-session-cwd-userdata');
+  registerDispose(ud.cleanup);
+
+  const app = await electron.launch({
+    args: ['.', `--user-data-dir=${ud.dir}`],
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      NODE_ENV: 'production',
+      CCSM_PROD_BUNDLE: '1',
+      HOME: fakeHome,
+      USERPROFILE: fakeHome,
+      CLAUDE_HOME: fakeHome
+    }
+  });
+  let closed = false;
+  registerDispose(async () => { if (!closed) try { await app.close(); } catch {} });
+
+  try {
+    const win = await waitReady(app);
+
+    // Wait for the boot-time history scan IPC to populate the renderer store.
+    await win.waitForFunction(
+      () => {
+        const s = window.__ccsmStore?.getState?.();
+        return !!s && Array.isArray(s.historyRecentCwds) && s.historyRecentCwds.length > 0;
+      },
+      null,
+      { timeout: 15_000 }
+    );
+
+    // Sanity-check that the IPC ranked frequency-top correctly. If THIS
+    // fails, the bug is in the scanner / deriveRecentCwds, not in the
+    // store fallback chain.
+    const seeded = await win.evaluate(() => {
+      const s = window.__ccsmStore.getState();
+      return { historyRecentCwds: s.historyRecentCwds };
+    });
+    log(`seeded historyRecentCwds[0]=${seeded.historyRecentCwds[0]}`);
+    if (seeded.historyRecentCwds[0] !== 'D:/work/repo-a') {
+      throw new Error(`scanner regression: historyRecentCwds[0] should be D:/work/repo-a; got ${JSON.stringify(seeded.historyRecentCwds)}`);
+    }
+
+    // Now plant the bug-repro state in the store:
+    //  1. an existing session in the focused group with cwd 'c:/x'
+    //     (mimics user's stale prior session that's leaking via groupRecentCwd)
+    //  2. recentProjects[0].path === 'c:/x' (mimics a stale chip pick)
+    //  3. focusedGroupId points to that group so createSession targets it
+    //
+    // The freq-vote winner is `D:/work/repo-a`; assertion below requires the
+    // new session to land on that, NOT on `c:/x`.
+    const created = await win.evaluate(() => {
+      const st = window.__ccsmStore;
+      st.setState({
+        sessions: [{
+          id: 's-stale',
+          name: 'stale prior',
+          state: 'idle',
+          cwd: 'c:/x',
+          model: 'claude-opus-4-7[1m]',
+          groupId: 'g-default',
+          agentType: 'claude-code',
+        }],
+        groups: [{ id: 'g-default', name: 'Sessions', collapsed: false, kind: 'normal' }],
+        activeId: 's-stale',
+        focusedGroupId: 'g-default',
+        model: '',
+        recentProjects: [{ id: 'p-stale', name: 'x', path: 'c:/x' }],
+      });
+      st.getState().createSession();
+      const s = st.getState();
+      // createSession prepends, so the new session is index 0; the stale
+      // one is index 1.
+      const newSession = s.sessions[0];
+      return { cwd: newSession?.cwd, allCwds: s.sessions.map(x => x.cwd) };
+    });
+    log(`createSession() produced cwd=${created.cwd} (all session cwds: ${JSON.stringify(created.allCwds)})`);
+
+    if (created.cwd !== 'D:/work/repo-a') {
+      throw new Error(`new-session-default-cwd-from-frequency: new session cwd should be the frequency-top D:/work/repo-a; got ${created.cwd}. The stale 'c:/x' from groupRecentCwd / recentProjects shadowed the frequency vote — fix createSession's fallback chain so historyRecentCwds wins.`);
+    }
+    log(`PASS — new session cwd derived from frequency vote, not from stale groupRecentCwd/recentProjects`);
+  } finally {
+    closed = true;
+    try { await app.close(); } catch {}
+  }
+}
+
 
 await runHarness({
   name: 'restore',
@@ -1866,6 +2035,12 @@ await runHarness({
     // task#293: default cwd/model on a fresh session derive from frequency
     // over the last 10 CLI sessions. Pre-launch HOME sandbox + 10 jsonl
     // fixtures with controlled cwd/model distribution.
-    { id: 'default-cwd-model-from-recent-history', skipLaunch: true, run: caseDefaultCwdModelFromRecentHistory }
+    { id: 'default-cwd-model-from-recent-history', skipLaunch: true, run: caseDefaultCwdModelFromRecentHistory },
+    // dogfood-reported: post-#369, stale `groupRecentCwd` / `recentProjects`
+    // were still shadowing the frequency-vote default (user hit `c:/x` on
+    // every "New session"). This case proves the new-session cwd resolves
+    // to the frequency-top history cwd even when both stale sources are
+    // present in the store.
+    { id: 'new-session-default-cwd-from-frequency', skipLaunch: true, run: caseNewSessionDefaultCwdFromFrequency }
   ]
 });

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -1090,24 +1090,23 @@ export const useStore = create<State & Actions>((set, get) => ({
     const targetGroupId = ensured.groupId;
     const baseGroups = ensured.groups;
     const id = newSessionId();
-    // task328: per-group cwd default — when the caller doesn't pin a cwd,
-    // prefer the most-recent session in the target group that has a usable
-    // cwd. `sessions` is ordered newest-first (createSession prepends), so
-    // the first match is the most recent. Falls through to the global
-    // historyRecentCwds/recentProjects defaults when the group is empty or
-    // none of its sessions have a cwd. `(none)` chip placeholder appears
-    // only when ALL of these resolve to empty.
+    // task#293 (post-#369 dogfood follow-up): the frequency vote over the
+    // last 10 CLI sessions IS the answer to "where does this user actually
+    // work" — it must win over `groupRecentCwd` (a single stale prior
+    // session in the focused group can otherwise shadow the user's actual
+    // working directory; dogfood hit `c:/x` on every "New session" because
+    // a long-forgotten session in the focused group held that cwd) AND
+    // over `recentProjects[0]?.path` (a one-off chip pick).
     //
-    // task#293: `historyRecentCwds[0]` (now frequency-ranked from the last
-    // 10 CLI sessions) takes precedence over `recentProjects[0]?.path` (a
-    // pure recency list of in-app picks). If the user works in a directory
-    // 9 out of 10 sessions, that's their default — a one-off chip pick
-    // shouldn't override it.
+    // `groupRecentCwd` stays in the chain as a tertiary fallback for the
+    // case where `historyRecentCwds` is empty (fresh-install with no CLI
+    // history) AND `recentProjects` is empty — better to inherit the
+    // group's own recent cwd than fall to ''.
     const groupRecentCwd = sessions.find(
       (x) => x.groupId === targetGroupId && !!x.cwd
     )?.cwd;
     const defaultCwd =
-      groupRecentCwd ?? historyRecentCwds[0] ?? recentProjects[0]?.path ?? '';
+      historyRecentCwds[0] ?? recentProjects[0]?.path ?? groupRecentCwd ?? '';
     let initialModel = model;
     if (!initialModel) initialModel = historyTopModel ?? '';
     if (!initialModel) initialModel = connection?.model ?? '';

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -1462,7 +1462,13 @@ describe('store: createSession — per-group cwd default (task328)', () => {
     expect(useStore.getState().sessions[0].cwd).toBe('/explicit/path');
   });
 
-  it('per-group default loses to recentProjects only when group is empty', () => {
+  it('recentProjects wins over per-group default (frequency-vote priority)', () => {
+    // task#293 follow-up: stale `groupRecentCwd` shadowing the
+    // user's actual working directory was a real dogfood bug — a single
+    // forgotten session in the focused group with cwd 'c:/x' was enough
+    // to make every "New session" land on 'c:/x'. The new priority puts
+    // `historyRecentCwds[0]` (frequency vote) and `recentProjects[0]?.path`
+    // BEFORE `groupRecentCwd` for exactly this reason.
     useStore.getState().pushRecentProject('/recent/proj');
     const gid = useStore.getState().createGroup('Fresh');
     useStore.getState().focusGroup(gid);
@@ -1470,12 +1476,13 @@ describe('store: createSession — per-group cwd default (task328)', () => {
     // No prior sessions in 'Fresh' → recentProjects[0] wins.
     expect(useStore.getState().sessions[0].cwd).toBe('/recent/proj');
     // Now create a second session in the same group; per-group default
-    // should now win over recentProjects.
+    // STILL loses to recentProjects (priority is recentProjects ahead of
+    // groupRecentCwd, since groupRecentCwd is the weakest of the three).
     useStore.getState().focusGroup(gid);
     useStore.getState().createSession('/repo/inside-group');
     useStore.getState().focusGroup(gid);
     useStore.getState().createSession(null);
-    expect(useStore.getState().sessions[0].cwd).toBe('/repo/inside-group');
+    expect(useStore.getState().sessions[0].cwd).toBe('/recent/proj');
   });
 
   it('skips sessions with empty cwd when scanning the group', () => {


### PR DESCRIPTION
## Summary

Dogfood follow-up to [PR #369](https://github.com/Jiahui-Gu/ccsm/pull/369): clicking "New session" still produced a default cwd that had nothing to do with the user's frequency-top CLI directory. User reported the picker landing on `c:/x` — a stale value from a long-forgotten in-app session in the focused group. User confirmed the expected behavior (frequency vote of last-10 CLI sessions wins) "应该是这样但坏了 — so the frequency logic is broken."

## Root cause

`createSession`'s cwd fallback chain still preferred `groupRecentCwd` (most-recent prior session in target group) BEFORE `historyRecentCwds[0]` (frequency vote over last 10 CLI sessions). One stale prior session in the focused group was enough to permanently shadow #369's frequency-vote default.

```ts
// before
const defaultCwd =
  groupRecentCwd ?? historyRecentCwds[0] ?? recentProjects[0]?.path ?? '';
```

## Fix

```ts
// after
const defaultCwd =
  historyRecentCwds[0] ?? recentProjects[0]?.path ?? groupRecentCwd ?? '';
```

Frequency vote wins; `groupRecentCwd` retained only as a tertiary fallback for the case where both global signals are empty (fresh install with no CLI history).

## E2E reproduction (Phase 1 — failing probe before fix)

New harness case `new-session-default-cwd-from-frequency` in `scripts/harness-restore.mjs` plants:
- 10 jsonl history fixtures: `D:/work/repo-a` ×7, `D:/work/repo-b` ×3 (freq-top = `D:/work/repo-a`)
- An existing in-app session in focused group with `cwd: 'c:/x'` (mimics user's stale prior)
- `recentProjects: [{path: 'c:/x'}]` (mimics a stale chip pick)

Asserts `createSession()` → `cwd === 'D:/work/repo-a'`.

**Before fix**:
```
[case=new-session-default-cwd-from-frequency] seeded historyRecentCwds[0]=D:/work/repo-a
[case=new-session-default-cwd-from-frequency] createSession() produced cwd=c:/x (all session cwds: ["c:/x","c:/x"])
[case=new-session-default-cwd-from-frequency] FAIL: new session cwd should be the frequency-top D:/work/repo-a; got c:/x. The stale 'c:/x' from groupRecentCwd / recentProjects shadowed the frequency vote
```
Note: `historyRecentCwds[0]` was correctly `D:/work/repo-a` (so the IPC scan + freq derivation work). The bug was purely in the fallback-chain ordering inside `createSession`.

## E2E green (Phase 4 — after fix)

```
[case=new-session-default-cwd-from-frequency] seeded historyRecentCwds[0]=D:/work/repo-a
[case=new-session-default-cwd-from-frequency] createSession() produced cwd=D:/work/repo-a (all session cwds: ["D:/work/repo-a","c:/x"])
[case=new-session-default-cwd-from-frequency] PASS — new session cwd derived from frequency vote, not from stale groupRecentCwd/recentProjects
=== totals: 1 passed, 0 failed, 0 skipped, 1 total ===
```

## Reverse-verify

`git stash push src/stores/store.ts` → rebuild → re-run probe:
```
[case=new-session-default-cwd-from-frequency] createSession() produced cwd=c:/x (all session cwds: ["c:/x","c:/x"])
[case=new-session-default-cwd-from-frequency] FAIL: ...
=== totals: 0 passed, 1 failed ===
```
`git stash pop` → rebuild → re-run probe → PASS. Confirms the probe meaningfully gates the fix.

## Test plan

- [x] new e2e: `harness-restore --only=new-session-default-cwd-from-frequency` PASS (3.0s)
- [x] reverse-verify: stashing src fix makes the probe FAIL with `c:/x`; pop → PASS
- [x] existing #369 e2e: `harness-restore --only=default-cwd-model-from-recent-history` PASS (3.0s, no regression)
- [x] vitest `tests/store.test.ts` — 95/95 pass after updating the one task328 case whose expectation was tied to the OLD priority ("per-group default loses to recentProjects only when group is empty" → renamed and rewritten to assert the new priority: recentProjects wins over groupRecentCwd unconditionally)
- [x] vitest `tests/import-scanner.test.ts` — 42/42 pass (no scanner changes)
- [x] full vitest run — only failures are 3 pre-existing `electron/__tests__/db-hardening.test.ts` failures unrelated to this change (verified by stashing — they fail on `origin/working` HEAD too)
- [x] `npx tsc --noEmit` clean (both src + electron tsconfigs)

## Hot file note

`src/stores/store.ts` overlaps with #380 (`rewindToBlock` area, lines 1895-1949). This change is in the unrelated `createSession` function (lines 1106-1118) — no collision. Branch rebased onto current `origin/working` (now includes #380's merge commit `723c201`).