### PR TITLE
fix(question): submit on Enter when all questions answered

### DIFF
--- a/scripts/harness-agent.mjs
+++ b/scripts/harness-agent.mjs
@@ -4244,17 +4244,69 @@ async function caseAskUserQuestionFull({ app, win, log }) {
       } catch {}
     }
   }
+  // ── J7 ────────────────────────────────────────────────────────────────
+  // Repro for "AskUserQuestion: Enter doesn't submit when all answered".
+  // Two questions (single-select + multi-select). After answering both, the
+  // last interaction leaves focus on a freshly-clicked option chip; pressing
+  // Enter (no modifier) on the QuestionBlock root must fire submit, matching
+  // the Submit button's onClick. Before the fix, Enter on the focused chip
+  // re-routed through togglePick — single-select with the same label is a
+  // no-op, multi-select toggles the selection OFF — so submit never fired.
+  async function j7() {
+    const sessionId = await ensureSession('J7');
+    await installAgentSendCapture();
+    await win.evaluate((sid) => window.__ccsmStore.getState().clearMessages(sid), sessionId);
+    await injectQuestion(sessionId, 'q-J7', [
+      { question: 'Q1 lang', options: [{ label: 'Python' }, { label: 'TypeScript' }] },
+      { question: 'Q2 features', multiSelect: true, options: [{ label: 'Auth' }, { label: 'Billing' }, { label: 'Search' }] },
+    ]);
+    await win.waitForSelector('[data-question-option]', { timeout: 5000 });
+    await win.waitForTimeout(150);
+    // Q1 single-select: clicking Python auto-advances to Q2 after 300ms.
+    await win.locator('[data-question-option][data-question-label="Python"]').first().click();
+    await win.waitForTimeout(450);
+    const onQ2 = await win.evaluate(() =>
+      document.querySelector('[data-testid="question-tab-1"]')?.getAttribute('data-active') === 'true'
+    );
+    if (!onQ2) return record('J7', false, 'after picking Q1.Python, expected auto-advance to Q2 tab');
+    // Q2 multi-select: click two options. No auto-advance for multi-select.
+    await win.locator('[data-question-option][data-question-label="Auth"]').first().click();
+    await win.waitForTimeout(80);
+    await win.locator('[data-question-option][data-question-label="Billing"]').first().click();
+    await win.waitForTimeout(120);
+    // All answered → Submit button enabled.
+    const submit = questionSubmitButton();
+    if (await submit.isDisabled()) return record('J7', false, 'Submit disabled after picking Q1+Q2 options');
+    // Simulate the user's flow: focus is on the last clicked option chip.
+    // Press Enter on the QuestionBlock root — must fire submit.
+    await win.locator('[data-question-option][data-question-label="Billing"]').first().focus();
+    await win.waitForTimeout(40);
+    await win.keyboard.press('Enter');
+    await win.waitForTimeout(350);
+    const sent = await getCapturedSends();
+    if (sent.length !== 1) return record('J7', false, `expected 1 send after Enter-on-all-answered, got ${sent.length}`);
+    if (!/Python/.test(sent[0].text || '')) return record('J7', false, `payload missing Python: ${JSON.stringify(sent[0])}`);
+    if (!/Auth/.test(sent[0].text || '') || !/Billing/.test(sent[0].text || '')) {
+      return record('J7', false, `payload missing Auth/Billing: ${JSON.stringify(sent[0])}`);
+    }
+    if (sent[0].sessionId !== sessionId) return record('J7', false, `wrong sessionId: ${sent[0].sessionId}`);
+    await win.evaluate((sid) => window.__ccsmStore.getState().clearMessages(sid), sessionId);
+    await clearCaptured();
+    record('J7', true, 'Enter on focused option submitted when all questions answered (single+multi)');
+  }
+
   await safeRun('J1', j1);
   await safeRun('J2', j2);
   await safeRun('J3', j3);
   await safeRun('J4', j4);
   await safeRun('J5', j5);
   await safeRun('J6', j6);
+  await safeRun('J7', j7);
 
   if (failures.length > 0) {
     throw new Error(`${failures.length} journey failure(s):\n  - ${failures.join('\n  - ')}`);
   }
-  log('all 6 journeys matched expected behavior');
+  log('all 7 journeys matched expected behavior');
 }
 
 // ---------- sidebar-journey-create-delete (was probe-e2e-sidebar-journey-create-delete) ----------

--- a/src/components/QuestionBlock.tsx
+++ b/src/components/QuestionBlock.tsx
@@ -305,6 +305,24 @@ export function QuestionBlock({ questions, onSubmit, onReject, autoFocus = true 
       return;
     }
     if (e.key === 'Enter') {
+      // When every question is answered, plain Enter (no modifier) submits
+      // from anywhere inside the card — even if focus still sits on the
+      // last clicked option chip. Without this, Enter on a focused chip
+      // routes through togglePick (single-select repick = no-op,
+      // multi-select = toggles the selection OFF), so the user's "I'm
+      // done" Enter silently does nothing.
+      if (allAnswered && !e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey) {
+        const ae = document.activeElement as HTMLElement | null;
+        // Don't hijack Enter inside the Other contenteditable — it has its
+        // own handler (paginates / submits depending on which question).
+        const inOther = ae && otherInputRef.current?.contains(ae);
+        if (!inOther) {
+          e.preventDefault();
+          e.stopPropagation();
+          submit();
+          return;
+        }
+      }
       const ae = document.activeElement as HTMLElement | null;
       if (ae && ae.closest('[data-question-option]')) {
         const label = (ae as HTMLElement).dataset.questionLabel;


### PR DESCRIPTION
## Bug (dogfood)
> AskUserQuestion: when all questions are answered, pressing Enter should submit. Currently nothing happens.

## Root cause
In `QuestionBlock.onKeyDown`, the only Enter branch is "if focus is on an option chip, toggle that option's selection." After the user finishes answering, focus typically still sits on the last clicked option chip, so Enter routes through `togglePick`:
- single-select repick of an already-selected option = no-op
- multi-select = toggles the selection OFF

The Submit button's own onClick / onKeyDown only fires when focus is *on* the button, which it isn't post-click. Result: Enter visibly does nothing once everything is answered.

## Fix (src/components/QuestionBlock.tsx)
Add an early branch in the root `onKeyDown` Enter path: when `allAnswered` and Enter has no modifier and focus is not in the Other contenteditable, call `submit()` directly. The existing focused-chip toggle path is preserved for the not-yet-all-answered states (#J1, #J2, #J4 still pass). Other's own Enter handler (paginate / submit) is untouched.

```ts
if (e.key === 'Enter') {
  if (allAnswered && !e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey) {
    const ae = document.activeElement as HTMLElement | null;
    const inOther = ae && otherInputRef.current?.contains(ae);
    if (!inOther) {
      e.preventDefault();
      e.stopPropagation();
      submit();
      return;
    }
  }
  // …existing focused-chip toggle path…
}
```

## E2E (scripts/harness-agent.mjs `askuserquestion-full` J7)
New journey: 2 questions (single-select Q1 + multi-select Q2). Click Q1.Python (auto-advances to Q2). Click Auth + Billing. Focus is on the Billing chip. Press Enter on the QuestionBlock root. Assert one `agent:send` fired with both Python and Auth+Billing in the payload.

### Pre-fix (failing)
```
[case=askuserquestion-full] OK    J1..J6
[case=askuserquestion-full] FAIL  J7  — expected 1 send after Enter-on-all-answered, got 0
=== totals: 0 passed, 1 failed ===
```

### Post-fix (passing)
```
[case=askuserquestion-full] OK    J1  — mount auto-focused Python (textarea draft preserved); ↓↓↑Enter routed TypeScript; focus returned
[case=askuserquestion-full] OK    J2  — gating tracks pick count (0→1→0→2); both labels submitted
[case=askuserquestion-full] OK    J3  — revised picks captured (A3+B1+C0), no stale A2
[case=askuserquestion-full] OK    J4  — down/up wraps through 12+Other; last model option submits
[case=askuserquestion-full] OK    J5  — no horizontal overflow (0 labels)
[case=askuserquestion-full] OK    J6  — answers routed to correct sessions; no question leakage on switch
[case=askuserquestion-full] OK    J7  — Enter on focused option submitted when all questions answered (single+multi)
[case=askuserquestion-full] all 7 journeys matched expected behavior
=== totals: 1 passed, 0 failed ===
```

### Reverse-verify
Stashed `src/components/QuestionBlock.tsx`, rebuilt, re-ran — J7 fails (`expected 1 send after Enter-on-all-answered, got 0`). Restored — J7 passes again. Confirms J7 actually exercises the fix path.

## Other checks
- `npx tsc --noEmit` clean.
- All existing journeys (J1..J6) still pass — focused-chip Enter (J1: ↓↓↑ then Enter to pick TypeScript) still goes through `togglePick` because `allAnswered` is false until the only single-select question gets a pick.
- No collision with #381 (footer padding line 560); my edit is in the keydown handler around line 307.