### PR TITLE
fix(chat): hide raw JSON dump on tool input validation error

### DIFF
--- a/scripts/harness-agent.mjs
+++ b/scripts/harness-agent.mjs
@@ -2015,6 +2015,297 @@ async function caseSdkToolUseRoundtrip({ app, win, log }) {
   log('SDK assistant(tool_use)+user(tool_result) via real agent:event IPC -> tool block coalesced with result');
 }
 
+// ---------- tool-failure-input-validation-collapsed ----------
+// Bug: AskUserQuestion (and any tool) whose `input` fails CLI-side Zod
+// validation streams a normal assistant `tool_use` block followed by a
+// synthetic user `tool_result` carrying
+// `<tool_use_error>InputValidationError: …</tool_use_error>` with
+// is_error=true. ccsm previously rendered the failed tool_use as a tool
+// block whose auto-expand-on-error path called PrettyInput on the
+// malformed payload — printing the rejected JSON ("questions", "options",
+// "header" keys) at the user. The retry's correct card landed too, so the
+// chat ended up with a useless raw-JSON dump above the real question.
+//
+// Fix A (scoped): drop the AskUserQuestion fallback tool block entirely
+// when parseQuestions returns []. Fix B (generic): in ToolBlock, render a
+// collapsed pill (no PrettyInput, no auto-expand) when isError && result
+// matches `<tool_use_error>` / contains `InputValidationError`. Existing
+// behavior for OTHER tool errors (non-validation) must remain unchanged
+// (auto-expand + PrettyInput).
+async function caseToolFailureInputValidationCollapsed({ app, win, log }) {
+  const SID = 's-tool-fail-iv';
+  const ASKQ_TUID = 'toolu_iv_askq_failed';
+  const ASKQ_RETRY_TUID = 'toolu_iv_askq_retry';
+  const BASH_TUID = 'toolu_iv_bash_failed';
+  const GENUINE_TUID = 'toolu_iv_bash_genuine_failed';
+
+  await win.evaluate((sid) => {
+    window.__ccsmStore.setState({
+      groups: [{ id: 'g1', name: 'G1', collapsed: false, kind: 'normal' }],
+      sessions: [{ id: sid, name: 'tool-fail-iv', state: 'idle', cwd: 'C:/x', model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code' }],
+      activeId: sid,
+      messagesBySession: { [sid]: [{ kind: 'user', id: 'u-1', text: 'ask me something' }] },
+      startedSessions: { [sid]: true },
+      runningSessions: { [sid]: true },
+    });
+  }, SID);
+  await win.waitForTimeout(150);
+
+  // Inject the failure pair via real agent:event IPC, mirroring what the
+  // CLI streams on InputValidationError. The malformed input is
+  // exactly the dogfood-observed shape: questions[].header + options
+  // present, questions[].question MISSING.
+  await app.evaluate(({ BrowserWindow }, [sid, askqTuid, askqRetryTuid, bashTuid, genuineTuid]) => {
+    const wc = BrowserWindow.getAllWindows()[0]?.webContents;
+    if (!wc) throw new Error('no BrowserWindow available');
+    // 1) failed AskUserQuestion tool_use (malformed payload — missing
+    // `question` field on every entry; has the diagnostic keys we'll
+    // assert NOT visible: "options", "header").
+    wc.send('agent:event', {
+      sessionId: sid,
+      message: {
+        type: 'assistant',
+        session_id: sid,
+        message: {
+          id: 'msg-iv-1',
+          role: 'assistant',
+          model: 'claude-opus-4',
+          content: [
+            {
+              type: 'tool_use',
+              id: askqTuid,
+              name: 'AskUserQuestion',
+              input: {
+                questions: [
+                  { header: 'iv-h1', options: [{ label: 'iv-opt-A' }, { label: 'iv-opt-B' }] }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    });
+    // 2) the synthetic user tool_result with InputValidationError envelope.
+    wc.send('agent:event', {
+      sessionId: sid,
+      message: {
+        type: 'user',
+        session_id: sid,
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: askqTuid,
+              is_error: true,
+              content: '<tool_use_error>InputValidationError: questions[0].question is missing</tool_use_error>'
+            }
+          ]
+        }
+      }
+    });
+    // 3) generic non-AskUserQuestion validation failure (Bash with bogus
+    // args, simulating CLI Zod rejection). Used to verify Fix B applies
+    // generically — collapsed pill, no PrettyInput.
+    wc.send('agent:event', {
+      sessionId: sid,
+      message: {
+        type: 'assistant',
+        session_id: sid,
+        message: {
+          id: 'msg-iv-2',
+          role: 'assistant',
+          model: 'claude-opus-4',
+          content: [
+            {
+              type: 'tool_use',
+              id: bashTuid,
+              name: 'Bash',
+              input: { iv_bash_marker_key: 'iv_bash_marker_value' }
+            }
+          ]
+        }
+      }
+    });
+    wc.send('agent:event', {
+      sessionId: sid,
+      message: {
+        type: 'user',
+        session_id: sid,
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: bashTuid,
+              is_error: true,
+              content: '<tool_use_error>InputValidationError: command is required</tool_use_error>'
+            }
+          ]
+        }
+      }
+    });
+    // 4) genuinely-failing Bash (non-validation error — e.g. command not
+    // found). Must keep existing auto-expand + PrettyInput behavior so we
+    // don't regress visibility of real failures.
+    wc.send('agent:event', {
+      sessionId: sid,
+      message: {
+        type: 'assistant',
+        session_id: sid,
+        message: {
+          id: 'msg-iv-3',
+          role: 'assistant',
+          model: 'claude-opus-4',
+          content: [
+            {
+              type: 'tool_use',
+              id: genuineTuid,
+              name: 'Bash',
+              input: { command: 'iv_genuine_marker_command' }
+            }
+          ]
+        }
+      }
+    });
+    wc.send('agent:event', {
+      sessionId: sid,
+      message: {
+        type: 'user',
+        session_id: sid,
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: genuineTuid,
+              is_error: true,
+              content: 'iv_genuine_marker_stderr: command not found'
+            }
+          ]
+        }
+      }
+    });
+    // The AskUserQuestion retry's question card is mounted via the
+    // can_use_tool permission path (lifecycle.ts →
+    // permissionRequestToWaitingBlock), NOT via assistantBlocks (which
+    // deliberately drops AskUserQuestion tool_use — see comment in
+    // stream-to-blocks.ts). We don't simulate the full permission RPC
+    // handshake here; the test appends the retry's `question` block
+    // directly to the store after this app.evaluate returns.
+  }, [SID, ASKQ_TUID, ASKQ_RETRY_TUID, BASH_TUID, GENUINE_TUID]);
+  await win.waitForTimeout(300);
+
+  // Append the retry's question card directly (see comment above —
+  // lifecycle's permission path is what mounts this in production; we
+  // shortcut it for the harness).
+  await win.evaluate(({ sid, blockId }) => {
+    window.__ccsmStore.getState().appendBlocks(sid, [
+      {
+        kind: 'question',
+        id: blockId,
+        questions: [
+          {
+            question: 'iv-retry-question-prompt',
+            header: 'iv-h2',
+            options: [{ label: 'iv-retry-opt-A' }, { label: 'iv-retry-opt-B' }]
+          }
+        ]
+      }
+    ]);
+  }, { sid: SID, blockId: 'q-iv-retry' });
+  await win.waitForTimeout(300);
+
+  const blockSummary = await win.evaluate((sid) => {
+    const blocks = window.__ccsmStore.getState().messagesBySession[sid] ?? [];
+    return blocks.map((b) => ({
+      kind: b.kind,
+      id: b.id,
+      name: b.name,
+      toolUseId: b.toolUseId,
+      isError: b.isError,
+      resultPreview: typeof b.result === 'string' ? b.result.slice(0, 80) : undefined,
+    }));
+  }, SID);
+
+  // Fix A: the AskUserQuestion failed tool_use must NOT have produced a
+  // tool block in the store at all. parseQuestions returned [] → drop.
+  const failedAskQBlock = blockSummary.find(
+    (b) => b.kind === 'tool' && b.toolUseId === ASKQ_TUID
+  );
+  if (failedAskQBlock) {
+    throw new Error(
+      `Fix A: expected NO tool block for failed AskUserQuestion (parseQuestions=[]); got: ${JSON.stringify(failedAskQBlock)}`
+    );
+  }
+
+  // Generic validation-error Bash: tool block must exist (so we can show
+  // a pill), but it MUST NOT render PrettyInput payload in the DOM.
+  const failedBashBlock = blockSummary.find(
+    (b) => b.kind === 'tool' && b.toolUseId === BASH_TUID
+  );
+  if (!failedBashBlock) {
+    throw new Error(`expected tool block for validation-failed Bash; got blocks=${JSON.stringify(blockSummary)}`);
+  }
+  if (!failedBashBlock.isError) {
+    throw new Error(`validation-failed Bash block expected isError=true; got ${JSON.stringify(failedBashBlock)}`);
+  }
+
+  // Genuinely-failing Bash block must exist + isError=true (regression
+  // guard for Fix B's overreach).
+  const genuineBashBlock = blockSummary.find(
+    (b) => b.kind === 'tool' && b.toolUseId === GENUINE_TUID
+  );
+  if (!genuineBashBlock) {
+    throw new Error(`expected tool block for genuinely-failing Bash; got blocks=${JSON.stringify(blockSummary)}`);
+  }
+
+  // DOM assertions.
+  const chatText = await win.evaluate(() => document.body.innerText);
+
+  // Fix A consequence: the malformed AskUserQuestion payload's diagnostic
+  // keys ("options" / "header") must NOT appear anywhere — neither
+  // because of an AskUserQuestion fallback tool block (Fix A) nor because
+  // a generic tool block expanded its PrettyInput (Fix B).
+  if (chatText.includes('iv-opt-A') || chatText.includes('iv-opt-B')) {
+    throw new Error('Fix A: malformed AskUserQuestion option labels leaked into chat (PrettyInput dumped them)');
+  }
+  if (chatText.includes('iv-h1')) {
+    throw new Error('Fix A: malformed AskUserQuestion header value leaked into chat');
+  }
+
+  // Fix B: validation-failed Bash must NOT show its raw input payload.
+  if (chatText.includes('iv_bash_marker_key') || chatText.includes('iv_bash_marker_value')) {
+    throw new Error('Fix B: validation-error tool block expanded PrettyInput; raw input leaked');
+  }
+  if (chatText.includes('InputValidationError')) {
+    throw new Error('Fix B: raw <tool_use_error> envelope leaked into chat (collapsed pill should suppress LongOutputView too)');
+  }
+
+  // Fix B regression guard: genuinely-failing Bash MUST still surface its
+  // input + result text. Otherwise we've over-collapsed real failures.
+  if (!chatText.includes('iv_genuine_marker_command')) {
+    throw new Error('Fix B regression: genuinely-failing Bash no longer shows its command (auto-expand on real errors broke)');
+  }
+  if (!chatText.includes('iv_genuine_marker_stderr')) {
+    throw new Error('Fix B regression: genuinely-failing Bash no longer shows its stderr');
+  }
+
+  // The retry's question card must have rendered.
+  await win.waitForSelector('[data-question-option]', { timeout: 5000 });
+  const retryQuestionVisible = await win.evaluate(() => document.body.innerText.includes('iv-retry-question-prompt'));
+  if (!retryQuestionVisible) {
+    throw new Error('expected the AskUserQuestion retry card to render with its corrected question text');
+  }
+  // And the retry's options should be reachable.
+  const retryOptCount = await win.locator('[data-question-option][data-question-label="iv-retry-opt-A"]').count();
+  if (retryOptCount === 0) {
+    throw new Error('expected retry option A to be rendered');
+  }
+
+  log('AskUserQuestion validation failure: no fallback tool block; generic validation pill suppresses PrettyInput; non-validation Bash error still expands; retry card renders');
+}
+
 // ---------- sdk-system-subtypes ----------
 // Follow-up to PR #326. translateSdkMessage allow-lists three system
 // subtypes (init, compact_boundary, api_retry) and drops the rest. The 3
@@ -4610,6 +4901,7 @@ await runHarness({
     { id: 'sdk-stream-event-partial', run: caseSdkStreamEventPartial },
     { id: 'sdk-exit-error-surfaces', run: caseSdkExitErrorSurfaces },
     { id: 'sdk-tool-use-roundtrip', run: caseSdkToolUseRoundtrip },
+    { id: 'tool-failure-input-validation-collapsed', run: caseToolFailureInputValidationCollapsed },
     { id: 'sdk-system-subtypes', run: caseSdkSystemSubtypes },
     { id: 'sdk-abort-on-disposed', run: caseSdkAbortOnDisposed },
     { id: 'user-block-hover-menu', run: caseUserBlockHoverMenu },

--- a/src/agent/stream-to-blocks.ts
+++ b/src/agent/stream-to-blocks.ts
@@ -9,7 +9,12 @@ import type {
   UserEvent
 } from '../../electron/agent/stream-json-types';
 import type { MessageBlock, SkillProvenance, TodoItem } from '../types';
-import { parseQuestions } from './ask-user-question';
+// `parseQuestions` previously sat here for the AskUserQuestion
+// malformed-input fallback (which dumped the rejected payload via
+// PrettyInput on top of the SDK retry's correct card — see
+// docs/tool-failure-render-research.md). That fallback was removed
+// 2026-04-26; lifecycle.ts imports parseQuestions directly from
+// ./ask-user-question for the can_use_tool permission path.
 
 export type ToolResultPatch = {
   toolUseId: string;
@@ -417,25 +422,24 @@ function assistantBlocks(msg: AssistantEvent, activeSkill?: SkillProvenance): Me
         // forever waiting for a `result` frame that never arrives.
         // (See feedback_bugfix_requires_e2e — Bugs A+B reported 2026-04-23.)
         //
-        // We only fall back to a generic tool block when the input is so
-        // malformed that `parseQuestions` returns nothing AND the
-        // permission path also wouldn't have rendered a usable card —
-        // gives the user at least SOMETHING to inspect rather than a
-        // silent skip. The permission-path block in this case is a
-        // generic Allow/Reject prompt, which we keep too; the tool block
-        // here is purely diagnostic.
-        const questions = parseQuestions(tu.input);
-        if (questions.length === 0) {
-          out.push({
-            kind: 'tool',
-            id: blockId,
-            toolUseId: tu.id,
-            name: tu.name,
-            brief: briefForTool(tu.name, tu.input),
-            expanded: false,
-            input: tu.input
-          });
-        }
+        // Malformed-input fallback REMOVED (tool-failure render dogfood,
+        // 2026-04-26): when `parseQuestions` returned [] (the model
+        // emitted `{header, options}` only, missing `question`), we used
+        // to push a generic tool block here so the user "had something
+        // to inspect". In practice that block paired with the CLI's
+        // synthetic `<tool_use_error>InputValidationError…` tool_result
+        // and auto-expanded into a 50-line PrettyInput dump of the
+        // rejected payload — directly above the SDK's correct retry
+        // card. Zero user value, lots of noise. The retry path
+        // guarantees the real question card lands; we drop the failed
+        // attempt entirely. Generic non-AskUserQuestion validation
+        // failures are still rendered (collapsed pill in ToolBlock,
+        // see Fix B for that branch).
+        //
+        // `parseQuestions` is intentionally NOT called here anymore —
+        // even when it returns a non-empty array, the can_use_tool
+        // permission path has already mounted the question card, so
+        // there is nothing for us to add.
       } else {
         out.push({
           kind: 'tool',

--- a/src/components/chat/blocks/ToolBlock.tsx
+++ b/src/components/chat/blocks/ToolBlock.tsx
@@ -68,7 +68,28 @@ export function ToolBlock({
   streamingInput?: boolean;
 }) {
   const { t } = useTranslation();
-  const [open, setOpen] = useState<boolean>(!!isError);
+  // Validation-error pill (#tool-failure-render dogfood, 2026-04-26).
+  // The bundled CLI emits a synthetic user `tool_result` carrying
+  //   "<tool_use_error>InputValidationError: …</tool_use_error>"
+  // with `is_error: true` whenever a tool_use's input fails the CLI-side
+  // Zod schema. The model retries on the next assistant turn and
+  // produces a correct invocation; the failed attempt has zero user
+  // value but its raw payload would otherwise be dumped via PrettyInput
+  // on the auto-expand-on-error path. We detect that envelope here and
+  // short-circuit to a tiny collapsed pill: tool name + a muted
+  // "input rejected, retried" subtitle, no body. Genuine tool failures
+  // (bash exit ≠ 0, file-not-found, etc.) do NOT match this pattern and
+  // keep their existing auto-expand behavior so users can see what
+  // actually went wrong. Match is intentionally narrow — both the
+  // envelope tag and the InputValidationError sentinel must appear, so
+  // a real shell error that happens to mention either substring won't
+  // accidentally collapse.
+  const isValidationError =
+    !!isError &&
+    typeof result === 'string' &&
+    result.includes('<tool_use_error>') &&
+    result.includes('InputValidationError');
+  const [open, setOpen] = useState<boolean>(!!isError && !isValidationError);
   const [cancelling, setCancelling] = useState(false);
   // Auto-expand precedence (#304): on transition into error or stall-escalation
   // we open the block automatically so the user doesn't have to hunt for the
@@ -131,6 +152,9 @@ export function ToolBlock({
   // without fighting users who deliberately collapse the block.
   useEffect(() => {
     if (userToggledRef.current) return;
+    // Validation-error pill never auto-expands — there is nothing useful
+    // inside (we suppress PrettyInput + the body branch entirely below).
+    if (isValidationError) return;
     // Error transition (false -> true). Initial-mount-with-error is handled
     // by useState's initializer; this branch only fires when a previously
     // healthy tool block flips to error mid-stream.
@@ -139,7 +163,7 @@ export function ToolBlock({
       setOpen(true);
     }
     prevIsErrorRef.current = !!isError;
-  }, [isError]);
+  }, [isError, isValidationError]);
   useEffect(() => {
     if (userToggledRef.current) return;
     if (escalated && !autoExpandedForEscalatedRef.current) {
@@ -174,6 +198,34 @@ export function ToolBlock({
   const diff = diffFromToolInput(name, input);
   const isFileTree = FILE_TREE_TOOLS.has(name) && hasResult && !isError;
   const isShellTool = SHELL_OUTPUT_TOOLS.has(name);
+  if (isValidationError) {
+    // Single-line collapsed pill. Reuses the same data-testid as the
+    // generic tool block so existing chat-stream queries still find it,
+    // but exposes data-validation-error for tests / styling that need
+    // to single it out. No <button>: this row is intentionally inert —
+    // expanding wouldn't reveal anything meaningful (the rejected
+    // payload is the bug, not the signal). The visual treatment is
+    // muted-tertiary, NOT the red error frame the auto-expanded error
+    // path uses, because the retry has already (or will shortly)
+    // surface the real artifact and we don't want to draw the eye.
+    return (
+      <div
+        data-testid="tool-block-root"
+        data-validation-error="true"
+        className="font-mono text-chrome flex items-baseline gap-2 text-fg-tertiary"
+      >
+        <span
+          data-type-scale-role="tool-name"
+          className="text-fg-tertiary text-meta"
+        >
+          {name}
+        </span>
+        <span className="text-fg-tertiary/80 text-meta italic">
+          {t('chat.toolInputRejectedRetried')}
+        </span>
+      </div>
+    );
+  }
   return (
     <div
       data-testid="tool-block-root"

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -65,6 +65,7 @@ const en = {
     toolFailedTag: 'failed',
     runningEllipsis: '(running…)',
     toolNoResult: '(no result)',
+    toolInputRejectedRetried: 'input rejected, retried',
     toolTakingLonger: '(taking longer than usual…)',
     toolStallEscalated: 'Tool has been running 90s+ — still no result.',
     toolStallCancel: 'Cancel',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -65,6 +65,7 @@ const zh: EnCatalog = {
     toolFailedTag: '失败',
     runningEllipsis: '（执行中…）',
     toolNoResult: '（无结果）',
+    toolInputRejectedRetried: '入参不合法，已自动重试',
     toolTakingLonger: '（耗时较长…）',
     toolStallEscalated: '工具已运行 90 秒以上，仍无结果。',
     toolStallCancel: '取消',

--- a/tests/stream-to-blocks.test.ts
+++ b/tests/stream-to-blocks.test.ts
@@ -176,7 +176,15 @@ describe('streamEventToTranslation', () => {
     expect(out.append).toHaveLength(0);
   });
 
-  it('AskUserQuestion with malformed input falls back to a generic tool block', () => {
+  it('AskUserQuestion with malformed input is dropped entirely (no diagnostic tool block)', () => {
+    // Pre-2026-04-26 we used to push a fallback `tool` block here so the
+    // user "had something to inspect". In practice that block paired
+    // with the CLI's synthetic `<tool_use_error>InputValidationError…`
+    // tool_result and auto-expanded into a raw-JSON dump of the
+    // rejected payload — directly above the SDK's correct retry card.
+    // Fix A drops the fallback; the retry card is sufficient. See
+    // docs/tool-failure-render-research.md and the
+    // `tool-failure-input-validation-collapsed` harness probe.
     const out = streamEventToTranslation(
       asEvent({
         type: 'assistant',
@@ -196,10 +204,7 @@ describe('streamEventToTranslation', () => {
         }
       })
     );
-    expect(out.append).toHaveLength(1);
-    const b = out.append[0] as { kind: string; name?: string };
-    expect(b.kind).toBe('tool');
-    expect(b.name).toBe('AskUserQuestion');
+    expect(out.append).toHaveLength(0);
   });
 
   it('TodoWrite tool_use becomes a todo block (not generic tool)', () => {


### PR DESCRIPTION
## Summary

When a tool_use's input fails the CLI-side Zod schema, the bundled CLI streams a synthetic user `tool_result` carrying `<tool_use_error>InputValidationError: …</tool_use_error>` with `is_error: true`. Two ccsm-side rendering paths then dumped the rejected JSON at the user (above the SDK retry's correct artifact). Two narrow fixes here, plus an e2e probe and dual unit-test update.

- **Fix A (scoped, AskUserQuestion only)** — `src/agent/stream-to-blocks.ts`: drop the malformed-input fallback that pushed a generic `tool` block whenever `parseQuestions(tu.input)` returned `[]`. The retry's question card mounted via the `can_use_tool` permission path is sufficient.
- **Fix B (generic)** — `src/components/chat/blocks/ToolBlock.tsx`: when `isError && result` contains both `<tool_use_error>` and `InputValidationError`, short-circuit to a one-line collapsed pill (tool name + "input rejected, retried" subtitle), suppressing `PrettyInput` / `LongOutputView` entirely and overriding the auto-expand-on-error path. Existing behavior for OTHER tool errors (genuine bash failures, file-not-found, etc.) is unchanged.
- New i18n key `chat.toolInputRejectedRetried` (en + zh).
- New e2e probe `tool-failure-input-validation-collapsed` in `scripts/harness-agent.mjs` exercising both fixes plus a regression guard for genuine non-validation errors.
- Updated `tests/stream-to-blocks.test.ts > AskUserQuestion with malformed input is dropped entirely (no diagnostic tool block)` to match the new contract.

Background research: `docs/tool-failure-render-research.md` (in the research repo).

## Phase 1 — failing e2e (before fixes)

```
[harness=agent] >>> case tool-failure-input-validation-collapsed
[case=tool-failure-input-validation-collapsed] FAIL: Fix A: expected NO tool block for failed AskUserQuestion (parseQuestions=[]); got: {"kind":"tool","id":"msg-iv-1:toolu_iv_askq_failed","name":"AskUserQuestion","toolUseId":"toolu_iv_askq_failed","isError":true,"resultPreview":"<tool_use_error>InputValidationError: questions[0].question is missing</tool_use"}
=== totals: 0 passed, 1 failed, 0 skipped, 1 total ===
```

## Phase 4 — green (with both fixes)

```
[harness=agent] >>> case tool-failure-input-validation-collapsed
[case=tool-failure-input-validation-collapsed] AskUserQuestion validation failure: no fallback tool block; generic validation pill suppresses PrettyInput; non-validation Bash error still expands; retry card renders
[case=tool-failure-input-validation-collapsed] OK
=== harness=agent summary (3455ms wall) ===
  [OK] tool-failure-input-validation-collapsed    1143ms
=== totals: 1 passed, 0 failed, 0 skipped, 1 total ===
```

## Phase 5 — reverse-verify

**Fix A reverted (Fix B kept)** — the AskUserQuestion fallback tool block reappears and the assertion fails on the leaked diagnostic block (its result string is the InputValidationError envelope; PrettyInput would render the JSON):

```
[case=tool-failure-input-validation-collapsed] FAIL: Fix A: expected NO tool block for failed AskUserQuestion (parseQuestions=[]); got: {"kind":"tool","id":"msg-iv-1:toolu_iv_askq_failed","name":"AskUserQuestion","toolUseId":"toolu_iv_askq_failed","isError":true,"resultPreview":"<tool_use_error>InputValidationError: questions[0].question is missing</tool_use"}
```

**Fix B reverted (Fix A kept)** — the generic validation-error Bash block expands `PrettyInput`, leaking its raw input:

```
[case=tool-failure-input-validation-collapsed] FAIL: Fix B: validation-error tool block expanded PrettyInput; raw input leaked
```

Each revert isolates the assertion that fails specifically; restoring both yields green again (Phase 4 output above).

## Test plan

- [x] `node scripts/harness-agent.mjs --only=tool-failure-input-validation-collapsed` — green (1.1s).
- [x] `npx vitest run tests/stream-to-blocks.test.ts` — 40/40 green (updated malformed-input test).
- [x] `npx vitest run tests/chatstream-tool-block-ux.test.tsx tests/tool-block-bash-streaming.test.tsx` — 14/14 green (no regression in existing ToolBlock behavior).
- [x] `npm run typecheck` — clean.
- [x] `npx eslint` on the changed source files — clean (0 errors).
- [x] Reverse-verify deltas captured above (Phase 5).
- [x] Pre-existing test failures (`electron/__tests__/db-hardening.test.ts` × 3 due to better-sqlite3 NODE_MODULE_VERSION 130 vs 137 mismatch) are env-only and unrelated to this PR — they reproduce on `working` HEAD.

## Notes

- Pill is intentionally inert (no `<button>` toggle) — expanding wouldn't reveal anything meaningful since the rejected payload is the bug, not the signal. Visual treatment is muted-tertiary (not the red error frame), so it doesn't compete for attention with the retry's real artifact.
- Validation-error detection is narrow on purpose: BOTH `<tool_use_error>` and `InputValidationError` must appear in the result string. A real shell error mentioning either substring alone won't accidentally collapse.
- Retained `parseQuestions` import was removed from `stream-to-blocks.ts` (only `lifecycle.ts` uses it now, importing directly from `./ask-user-question`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)