### PR TITLE
fix(e2e): harness-restore direct-launch sites default CCSM_E2E_HIDDEN=1

### DIFF
--- a/scripts/harness-restore.mjs
+++ b/scripts/harness-restore.mjs
@@ -109,7 +109,12 @@ async function launch({ userDataDir, env = {}, extraArgs = [] }) {
   const app = await electron.launch({
     args: ['.', `--user-data-dir=${userDataDir}`, ...extraArgs],
     cwd: ROOT,
-    env: { ...process.env, CCSM_PROD_BUNDLE: '1', ...env }
+    // Mirror harness-runner.mjs:334 — default CCSM_E2E_HIDDEN=1 so standalone
+    // `node scripts/harness-restore.mjs --only=<case>` runs don't pop a window
+    // and steal focus. Order matters: default first, then process.env (user
+    // can opt out with CCSM_E2E_HIDDEN=0 in shell), then per-case env wins
+    // last (caseSidebarResize sets '0' to force visible).
+    env: { CCSM_E2E_HIDDEN: '1', ...process.env, CCSM_PROD_BUNDLE: '1', ...env }
   });
   return app;
 }
@@ -825,6 +830,7 @@ async function caseNotifyFallback({ log, registerDispose }) {
     args: ['.', `--user-data-dir=${userDataDir}`],
     cwd: ROOT,
     env: {
+      CCSM_E2E_HIDDEN: process.env.CCSM_E2E_HIDDEN ?? '1',
       ...process.env,
       NODE_ENV: 'development',
       CCSM_DEV_PORT: String(server.port),
@@ -997,6 +1003,7 @@ async function caseImportSession({ log, registerDispose }) {
     args: ['.', `--user-data-dir=${ud.dir}`],
     cwd: ROOT,
     env: {
+      CCSM_E2E_HIDDEN: process.env.CCSM_E2E_HIDDEN ?? '1',
       ...process.env,
       NODE_ENV: 'production',
       CCSM_PROD_BUNDLE: '1',
@@ -1513,6 +1520,7 @@ async function casePermissionPromptDefaultMode({ log, registerDispose }) {
   // Strip CLAUDECODE so the spawned claude.exe doesn't refuse-to-launch
   // with "cannot run inside another Claude Code session".
   const env = {
+    CCSM_E2E_HIDDEN: process.env.CCSM_E2E_HIDDEN ?? '1',
     ...process.env,
     CCSM_PROD_BUNDLE: '1',
     CCSM_CLAUDE_CONFIG_DIR: cfg.dir,
@@ -1755,6 +1763,7 @@ async function caseDefaultCwdModelFromRecentHistory({ log, registerDispose }) {
     args: ['.', `--user-data-dir=${ud.dir}`],
     cwd: ROOT,
     env: {
+      CCSM_E2E_HIDDEN: process.env.CCSM_E2E_HIDDEN ?? '1',
       ...process.env,
       NODE_ENV: 'production',
       CCSM_PROD_BUNDLE: '1',
@@ -1870,6 +1879,7 @@ async function caseNewSessionDefaultModelFromClaudeSettings({ log, registerDispo
     args: ['.', `--user-data-dir=${ud.dir}`],
     cwd: ROOT,
     env: {
+      CCSM_E2E_HIDDEN: process.env.CCSM_E2E_HIDDEN ?? '1',
       ...process.env,
       NODE_ENV: 'production',
       CCSM_PROD_BUNDLE: '1',
@@ -2031,6 +2041,7 @@ async function caseNewSessionDefaultCwdFromFrequency({ log, registerDispose }) {
     args: ['.', `--user-data-dir=${ud.dir}`],
     cwd: ROOT,
     env: {
+      CCSM_E2E_HIDDEN: process.env.CCSM_E2E_HIDDEN ?? '1',
       ...process.env,
       NODE_ENV: 'production',
       CCSM_PROD_BUNDLE: '1',


### PR DESCRIPTION
## Bug
Standalone `node scripts/harness-restore.mjs --only=<case>` runs (worker context, single-case iteration) flashed an Electron window onto the desktop and stole focus. The `launch()` helper and seven inline `electron.launch()` sites in `harness-restore.mjs` built their env without defaulting `CCSM_E2E_HIDDEN=1`, so unless the orchestrator (`run-all-e2e.mjs`) exported it first, the window was visible. Other harnesses route through `harness-runner.mjs:334` which already defaults the env, so they were unaffected.

## Phase 1 — repro (window flashed onto desktop)
Pre-fix run of `node scripts/harness-restore.mjs --only=notify-fallback`: window visible during the case. Console output (failure is pre-existing on baseline, unrelated to this bug):
```
[harness=restore] >>> case notify-fallback
[case=notify-fallback] FAIL: locator.waitFor: Timeout 3000ms exceeded.
=== totals: 0 passed, 1 failed, 0 skipped, 1 total ===
```

## Fix
Mirror the `harness-runner.mjs:334` idiom — leftmost default `CCSM_E2E_HIDDEN: '1'`, then `process.env` (shell `CCSM_E2E_HIDDEN=0` still opts out for debugging), then per-case env wins last so `caseSidebarResize`'s `'0'` override still produces a visible window.

5 edits:
- `scripts/harness-restore.mjs:108` — `launch()` helper env merge order
- `scripts/harness-restore.mjs:829` — `caseNotifyFallback` inline launch env
- `scripts/harness-restore.mjs:1002` — `caseImportSession` inline launch env
- `scripts/harness-restore.mjs:1515` — `casePermissionPromptDefaultMode` shared `env` literal (used by both launches at 1533 + 1578)
- `scripts/harness-restore.mjs:1762` / `1878` / `2040` — `caseDefaultCwdModelFromRecentHistory` / `caseNewSessionDefaultModelFromClaudeSettings` / `caseNewSessionDefaultCwdFromFrequency` inline launch env (identical `NODE_ENV: 'production', CCSM_PROD_BUNDLE: '1', HOME: fakeHome` prefix — single `replace_all`)

For the 7 inline-env sites the patch is `CCSM_E2E_HIDDEN: process.env.CCSM_E2E_HIDDEN ?? '1'` as the first key (shell opt-out still wins). For the helper, the spread order matches `harness-runner.mjs:334`.

## Phase 3 — verification
- `--only=notify-fallback` post-fix: **no window appeared** (was visible pre-fix). Same pre-existing locator-timeout failure as baseline (verified via `git stash` round-trip on `origin/working`).
- `--only=sidebar-resize` (opt-out regression guard): window **VISIBLE**, case **PASSED**.
  ```
  [case=sidebar-resize] launch #1: drag/clamp/reset OK, chose width=333
  [case=sidebar-resize] launch #2: restored width=333 (DOM=333)
  [case=sidebar-resize] OK
  === totals: 1 passed, 0 failed, 0 skipped, 1 total ===
  ```
- `--only=restore` (helper-path): hidden, OK.
- `--only=db-corruption-recovery` (direct-launch path): hidden, OK.
- Full `node scripts/harness-restore.mjs`: **11/12 OK** — only failure is the pre-existing `notify-fallback` flake (already failing on `origin/working`, see stash round-trip in repro section above; unrelated to this fix).
  ```
  === totals: 11 passed, 1 failed, 0 skipped, 12 total ===
  ```

## Test plan
- [x] Standalone `--only=<case>` no longer pops window for hidden cases
- [x] `sidebar-resize` opt-out still produces visible window (per-case env wins)
- [x] Shell `CCSM_E2E_HIDDEN=0` still wins (process.env spread after default)
- [x] Full harness-restore: 11/12 OK, no new regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)