### PR TITLE
fix(models): listModelsFromSettings honors CLAUDE_CONFIG_DIR

### DIFF
--- a/electron/agent/list-models-from-settings.ts
+++ b/electron/agent/list-models-from-settings.ts
@@ -152,7 +152,8 @@ export async function readDefaultModelFromSettings(
 export async function listModelsFromSettings(
   opts: ListModelsFromSettingsOpts = {},
 ): Promise<ListModelsResult> {
-  const configDir = opts.configDir ?? path.join(os.homedir(), '.claude');
+  const configDir =
+    opts.configDir ?? process.env.CLAUDE_CONFIG_DIR ?? path.join(os.homedir(), '.claude');
   const env = opts.env ?? process.env;
 
   const settings = await readSettings(configDir);

--- a/scripts/harness-restore.mjs
+++ b/scripts/harness-restore.mjs
@@ -2045,6 +2045,94 @@ async function caseNewSessionDefaultModelHonorsClaudeConfigDir({ log, registerDi
 }
 
 // ──────────────────────────────────────────────────────────────────────────
+// CASE: model-picker-list-honors-claude-config-dir
+// Bug #328 follow-up to PR #386. `listModelsFromSettings()` (the source for
+// the model picker list, exposed via IPC `models:list` →
+// `window.ccsm.models.list()`) had the same `os.homedir() + '.claude'`
+// hard-code that `readDefaultModelFromSettings()` had pre-#386. So under a
+// custom `CLAUDE_CONFIG_DIR`, any sentinel model id placed in the real
+// settings.json was silently dropped from the picker — the picker only
+// surfaced the static fallback / cli-picker entries instead.
+//
+// Setup mirrors `new-session-default-model-honors-claude-config-dir`:
+// HOME → decoy `~/.claude/settings.json` (no model fields);
+// CLAUDE_CONFIG_DIR → sandbox B with a sentinel model id.
+//
+// Without the fix: `models:list` returns the fallback list with NO sentinel.
+// With the fix: the sentinel id is present, tagged source 'settings'.
+// ──────────────────────────────────────────────────────────────────────────
+async function caseModelPickerListHonorsClaudeConfigDir({ log, registerDispose }) {
+  const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ccsm-harness-models-cfgdir-home-'));
+  registerDispose(() => { try { fs.rmSync(fakeHome, { recursive: true, force: true }); } catch {} });
+  // Decoy `~/.claude/settings.json` in HOME with NO model field. If the
+  // picker list reader fell back to homedir, it would see only the static
+  // fallback + cli-picker entries — never the sentinel below.
+  const decoyClaudeDir = path.join(fakeHome, '.claude');
+  fs.mkdirSync(decoyClaudeDir, { recursive: true });
+  fs.writeFileSync(path.join(decoyClaudeDir, 'settings.json'), JSON.stringify({}, null, 2));
+
+  const cfgDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccsm-harness-models-cfgdir-real-'));
+  registerDispose(() => { try { fs.rmSync(cfgDir, { recursive: true, force: true }); } catch {} });
+  // Sentinel id is intentionally a string that cannot collide with any
+  // CLI_PICKER_MODELS / FALLBACK_MODELS / env-derived id, so its presence
+  // proves the read consulted CLAUDE_CONFIG_DIR.
+  const SENTINEL = 'sentinel-cfgdir-model-9zq';
+  fs.writeFileSync(
+    path.join(cfgDir, 'settings.json'),
+    JSON.stringify({ model: SENTINEL }, null, 2)
+  );
+  log(`HOME=${fakeHome} (decoy empty settings) | CLAUDE_CONFIG_DIR=${cfgDir} (model="${SENTINEL}")`);
+
+  const ud = isolatedUserData('ccsm-harness-models-cfgdir-userdata');
+  registerDispose(ud.cleanup);
+
+  const app = await electron.launch({
+    args: ['.', `--user-data-dir=${ud.dir}`],
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      NODE_ENV: 'production',
+      CCSM_PROD_BUNDLE: '1',
+      HOME: fakeHome,
+      USERPROFILE: fakeHome,
+      CLAUDE_HOME: fakeHome,
+      CLAUDE_CONFIG_DIR: cfgDir
+    }
+  });
+  let closed = false;
+  registerDispose(async () => { if (!closed) try { await app.close(); } catch {} });
+
+  try {
+    const win = await waitReady(app);
+
+    // Invoke the same IPC that the model picker UI uses.
+    const models = await win.evaluate(async () => {
+      // @ts-expect-error renderer global injected by preload
+      return await window.ccsm.models.list();
+    });
+    log(`models:list returned ${models.length} entries (first 3: ${JSON.stringify(models.slice(0, 3))})`);
+
+    const sentinelEntry = models.find((m) => m.id === SENTINEL);
+    if (!sentinelEntry) {
+      throw new Error(
+        `expected models:list to contain sentinel id "${SENTINEL}" sourced from CLAUDE_CONFIG_DIR/settings.json; ` +
+        `got ids=${JSON.stringify(models.map((m) => m.id))}. ` +
+        `listModelsFromSettings() should consult process.env.CLAUDE_CONFIG_DIR like readDefaultModelFromSettings() and commands-loader.ts do.`
+      );
+    }
+    if (sentinelEntry.source !== 'settings') {
+      throw new Error(
+        `sentinel "${SENTINEL}" found but source=${sentinelEntry.source}; expected 'settings' (top-level model field).`
+      );
+    }
+    log(`PASS — listModelsFromSettings honors CLAUDE_CONFIG_DIR (sentinel present, source='settings')`);
+  } finally {
+    closed = true;
+    try { await app.close(); } catch {}
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
 // CASE: new-session-default-cwd-from-frequency
 //
 // Bug repro (post-#369): in the wild, "新建 session" still produces a default
@@ -2251,6 +2339,14 @@ await runHarness({
     // The same read must honor `CLAUDE_CONFIG_DIR` (commands-loader.ts:231
     // already does). ccsm pins this env var in production; this case
     // guards against future drift between the two readers.
-    { id: 'new-session-default-model-honors-claude-config-dir', skipLaunch: true, run: caseNewSessionDefaultModelHonorsClaudeConfigDir }
+    { id: 'new-session-default-model-honors-claude-config-dir', skipLaunch: true, run: caseNewSessionDefaultModelHonorsClaudeConfigDir },
+    // Bug #328 follow-up: `listModelsFromSettings()` in list-models-from-settings.ts
+    // is the second consumer of `<configDir>/settings.json` in this module and
+    // had the SAME hard-coded `os.homedir() + '.claude'` fallback that
+    // `readDefaultModelFromSettings()` had pre-#386. The model picker list
+    // therefore silently ignores settings.json under a custom CLAUDE_CONFIG_DIR.
+    // This case mirrors the case above but asserts the IPC `models:list`
+    // result (what populates the picker UI) reflects the sandbox-B settings.
+    { id: 'model-picker-list-honors-claude-config-dir', skipLaunch: true, run: caseModelPickerListHonorsClaudeConfigDir }
   ]
 });


### PR DESCRIPTION
## Summary

Bug #328 follow-up to PR #386. `readDefaultModelFromSettings()` was fixed in #386 but the *parallel* function in the same file, `listModelsFromSettings()` (line 155, source for the model picker list via IPC `models:list`), had the same hard-coded `os.homedir() + '.claude'` fallback. Under a custom `CLAUDE_CONFIG_DIR`, the model declared in that dir's settings.json was silently dropped from the picker — only static fallback + cli-picker entries surfaced.

One-line fix mirrors #386:

```ts
const configDir =
  opts.configDir ?? process.env.CLAUDE_CONFIG_DIR ?? path.join(os.homedir(), '.claude');
```

Explicit `opts.configDir` still wins (existing vitest fixtures keep working).

## E2e — `model-picker-list-honors-claude-config-dir`

New harness-restore case sandboxes HOME (decoy empty `~/.claude/settings.json`) + `CLAUDE_CONFIG_DIR` (sandbox-B with `{ model: "sentinel-cfgdir-model-9zq" }`), launches electron, calls `window.ccsm.models.list()` via IPC, asserts the sentinel id is present with `source: 'settings'`.

**Phase 1 (pre-fix on this branch, fix stashed):** FAIL —
> expected models:list to contain sentinel id "sentinel-cfgdir-model-9zq"...; got ids=["claude-haiku-4-5-20251001","sonnet","opus","haiku","sonnet[1m]","opus[1m]","claude-opus-4-6[1m]","claude-opus-4-1","claude-opus-4-7","claude-sonnet-4-6","claude-haiku-4-5"]

**Phase 4 (post-fix):** PASS —
> models:list returned 12 entries (first 3: [{"id":"sentinel-cfgdir-model-9zq","source":"settings"}, ...])
> PASS — listModelsFromSettings honors CLAUDE_CONFIG_DIR (sentinel present, source='settings')

## Test plan

- [x] `node scripts/harness-restore.mjs --only=model-picker-list-honors-claude-config-dir` — PASS
- [x] `node scripts/harness-restore.mjs --only=new-session-default-model-honors-claude-config-dir` — PASS (no regression in PR #386's case)
- [x] `npx vitest run electron/agent/__tests__/list-models-from-settings.test.ts` — 14/14 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)