### PR TITLE
fix(question): other input forwards arrow/enter to question controller

### DIFF
--- a/docs/screenshots/fix-330/phase1-fail.txt
+++ b/docs/screenshots/fix-330/phase1-fail.txt
@@ -1,0 +1,1 @@
+[case=askuserquestion-full] FAIL  J8  --  (1) after ArrowUp from Other input expected TypeScript option focused, got {tag:DIV,label:null,role:textbox}

--- a/docs/screenshots/fix-330/phase4-pass.txt
+++ b/docs/screenshots/fix-330/phase4-pass.txt
@@ -1,0 +1,18 @@
+[harness=agent] launching electron — 1/45 case(s)
+
+[harness=agent] >>> case askuserquestion-full
+[case=askuserquestion-full] OK    J1  — mount auto-focused Python (textarea draft preserved); ↓↓↑Enter routed TypeScript; focus returned
+[case=askuserquestion-full] OK    J2  — gating tracks pick count (0→1→0→2); both labels submitted
+[case=askuserquestion-full] OK    J3  — revised picks captured (A3+B1+C0), no stale A2
+[case=askuserquestion-full] OK    J4  — down/up wraps through 12+Other; last model option submits
+[case=askuserquestion-full] OK    J5  — no horizontal overflow (0 labels)
+[case=askuserquestion-full] OK    J6  — answers routed to correct sessions; no question leakage on switch
+[case=askuserquestion-full] OK    J7  — Enter on focused option submitted when all questions answered (single+multi)
+[case=askuserquestion-full] OK    J8  — ① ↑↓ from Other input cycles options + preserves text; ② ←/→ at edges pages question; ③ Enter on last question submits
+[case=askuserquestion-full] all 8 journeys matched expected behavior
+[case=askuserquestion-full] OK
+
+=== harness=agent summary (19020ms wall) ===
+  [OK] askuserquestion-full                      16785ms
+
+=== totals: 1 passed, 0 failed, 0 skipped, 1 total ===

--- a/scripts/harness-agent.mjs
+++ b/scripts/harness-agent.mjs
@@ -4586,6 +4586,193 @@ async function caseAskUserQuestionFull({ app, win, log }) {
     record('J7', true, 'Enter on focused option submitted when all questions answered (single+multi)');
   }
 
+  // ── J8 ────────────────────────────────────────────────────────────────
+  // Bug #330: AskUserQuestion 选 Other 后输入态键盘全废. While the Other
+  // contenteditable input has focus and the user is typing, three keyboard
+  // behaviors must work:
+  //   ① ↑/↓ cycles options (incl. Other itself + above predefined options).
+  //      Input text and Other-selected state preserved across the cycle.
+  //   ② ←/→ moves caret inside the text by default; at the EDGE
+  //      (caret at 0 with no selection → previous question; caret at end with
+  //      no selection → next question).
+  //   ③ Enter on the LAST question with all answered → submits the whole set.
+  async function j8() {
+    const sessionId = await ensureSession('J8');
+    await installAgentSendCapture();
+    await win.evaluate((sid) => window.__ccsmStore.getState().clearMessages(sid), sessionId);
+    await injectQuestion(sessionId, 'q-J8', [
+      { question: 'Q1 lang', options: [{ label: 'Python' }, { label: 'TypeScript' }] },
+      { question: 'Q2 db', options: [{ label: 'Postgres' }, { label: 'SQLite' }] },
+    ]);
+    await win.waitForSelector('[data-question-option]', { timeout: 5000 });
+    await win.waitForTimeout(150);
+
+    // Activate Other on Q1 by clicking its chip (auto-focuses the input).
+    await win.locator('[data-question-option][data-question-label="Other"]').first().click();
+    await win.waitForTimeout(150);
+    const otherInput = win.locator('[data-testid="question-other-input"]').first();
+    await otherInput.waitFor({ state: 'visible', timeout: 2000 });
+
+    // Type "abc" into the Other input. Use keyboard.type so the input takes
+    // focus through real key events (matches the user flow that triggered
+    // the bug — keyboard becomes unresponsive once focus enters the input).
+    await otherInput.click();
+    await win.waitForTimeout(40);
+    await win.keyboard.type('abc', { delay: 10 });
+    await win.waitForTimeout(60);
+    let txt = await otherInput.evaluate((el) => el.textContent || '');
+    if (txt !== 'abc') return record('J8', false, `expected 'abc' typed into Other input, got '${txt}'`);
+
+    // ── Assertion ① ↑/↓ cycles options even with focus inside Other input.
+    // Other is the LAST option (Python, TypeScript, Other). ↑ → TypeScript.
+    await win.keyboard.press('ArrowUp');
+    await win.waitForTimeout(80);
+    let focused = await win.evaluate(() => {
+      const el = document.activeElement;
+      return el ? { tag: el.tagName, label: el.getAttribute('data-question-label'), role: el.getAttribute('role') } : null;
+    });
+    if (focused?.label !== 'TypeScript') {
+      return record('J8', false, `① after ArrowUp from Other input expected TypeScript option focused, got ${JSON.stringify(focused)}`);
+    }
+    // ↓ → Other again. The Other option chip is what gets focus; the inline
+    // input remains rendered with our typed text intact.
+    await win.keyboard.press('ArrowDown');
+    await win.waitForTimeout(80);
+    focused = await win.evaluate(() => {
+      const el = document.activeElement;
+      return el ? { tag: el.tagName, label: el.getAttribute('data-question-label'), role: el.getAttribute('role') } : null;
+    });
+    if (focused?.label !== 'Other') {
+      return record('J8', false, `① after ArrowDown back expected Other focused, got ${JSON.stringify(focused)}`);
+    }
+    txt = await otherInput.evaluate((el) => el.textContent || '');
+    if (txt !== 'abc') {
+      return record('J8', false, `① Other input text mutated by arrow cycling, expected 'abc' got '${txt}'`);
+    }
+    // Other is still selected (input still rendered).
+    const stillRendered = await win.locator('[data-testid="question-other-input"]').count();
+    if (stillRendered !== 1) return record('J8', false, `① Other input no longer rendered after ↑↓ cycle (count=${stillRendered})`);
+
+    // Re-focus the input and place caret at offset 0 (start). Pressing →
+    // three times should walk through 'a','b','c' to end, with NO page change.
+    // The fourth → at end-with-no-selection should page to Q1. (Spec: edge-
+    // overflow pages; mid-text caret movement stays put.)
+    await otherInput.click();
+    await otherInput.evaluate((el) => {
+      const range = document.createRange();
+      range.setStart(el.firstChild ?? el, 0);
+      range.collapse(true);
+      const sel = window.getSelection();
+      sel?.removeAllRanges();
+      sel?.addRange(range);
+    });
+    await win.waitForTimeout(40);
+
+    // ── Assertion ② right arrow moves caret while inside text, pages at edge.
+    await win.keyboard.press('ArrowRight');
+    await win.waitForTimeout(40);
+    await win.keyboard.press('ArrowRight');
+    await win.waitForTimeout(40);
+    await win.keyboard.press('ArrowRight');
+    await win.waitForTimeout(40);
+    let activeTab = await win.evaluate(() =>
+      document.querySelector('[data-testid="question-tab-1"]')?.getAttribute('data-active') === 'true' ? 1
+        : document.querySelector('[data-testid="question-tab-0"]')?.getAttribute('data-active') === 'true' ? 0 : -1
+    );
+    if (activeTab !== 0) {
+      return record('J8', false, `② non-edge ArrowRights should NOT page; expected still on Q0 got tab=${activeTab}`);
+    }
+    await win.keyboard.press('ArrowRight');
+    await win.waitForTimeout(120);
+    activeTab = await win.evaluate(() =>
+      document.querySelector('[data-testid="question-tab-1"]')?.getAttribute('data-active') === 'true' ? 1 : 0
+    );
+    if (activeTab !== 1) {
+      return record('J8', false, `② ArrowRight at end-of-input should page to Q1, got tab=${activeTab}`);
+    }
+    // Pick a normal option on Q2 to satisfy allAnswered.
+    await win.locator('[data-question-option][data-question-label="Postgres"]').first().click();
+    await win.waitForTimeout(150);
+    // Page back to Q1 to test left-edge → previous question. Click tab 0.
+    await win.locator('[data-testid="question-tab-0"]').click();
+    await win.waitForTimeout(200);
+    // Other input is auto-focused on return (see useEffect at line 156). Place
+    // caret at offset 0.
+    const otherInput2 = win.locator('[data-testid="question-other-input"]').first();
+    await otherInput2.waitFor({ state: 'visible', timeout: 2000 });
+    await otherInput2.click();
+    await otherInput2.evaluate((el) => {
+      const range = document.createRange();
+      range.setStart(el.firstChild ?? el, 0);
+      range.collapse(true);
+      const sel = window.getSelection();
+      sel?.removeAllRanges();
+      sel?.addRange(range);
+    });
+    await win.waitForTimeout(40);
+    // Q1 is the FIRST question (index 0); ArrowLeft at caret 0 has no prev
+    // question so it's a no-op. We can't assert "page prev" here (no prev
+    // question exists). Instead, advance to Q2 first, focus Q2 Other? Q2 is
+    // currently a Postgres pick — no Other. Test left-edge from Q2 by
+    // re-picking Other on Q2.
+    await win.locator('[data-testid="question-tab-1"]').click();
+    await win.waitForTimeout(150);
+    await win.locator('[data-question-option][data-question-label="Other"]').first().click();
+    await win.waitForTimeout(150);
+    const otherInputQ2 = win.locator('[data-testid="question-other-input"]').first();
+    await otherInputQ2.waitFor({ state: 'visible', timeout: 2000 });
+    await otherInputQ2.click();
+    await win.waitForTimeout(40);
+    await win.keyboard.type('xy', { delay: 10 });
+    await win.waitForTimeout(60);
+    // Caret at end (offset 2). Press ← twice — caret moves through chars,
+    // not pages. Then a 3rd press lands at offset 0 (still in text) — also
+    // no page. 4th press at offset 0 → page back to Q1.
+    await otherInputQ2.evaluate((el) => {
+      const range = document.createRange();
+      range.setStart(el.firstChild ?? el, 0);
+      range.collapse(true);
+      const sel = window.getSelection();
+      sel?.removeAllRanges();
+      sel?.addRange(range);
+    });
+    await win.waitForTimeout(40);
+    await win.keyboard.press('ArrowLeft');
+    await win.waitForTimeout(120);
+    activeTab = await win.evaluate(() =>
+      document.querySelector('[data-testid="question-tab-0"]')?.getAttribute('data-active') === 'true' ? 0 : 1
+    );
+    if (activeTab !== 0) {
+      return record('J8', false, `② ArrowLeft at start-of-input should page back to Q0, got tab=${activeTab}`);
+    }
+
+    // ── Assertion ③ Enter when all answered submits.
+    // Currently on Q0 with Other='abc'. Q1 had Other='xy' — both questions
+    // answered. Move to last question (Q1) and press Enter inside Other input.
+    await win.locator('[data-testid="question-tab-1"]').click();
+    await win.waitForTimeout(200);
+    const otherInputQ2b = win.locator('[data-testid="question-other-input"]').first();
+    await otherInputQ2b.waitFor({ state: 'visible', timeout: 2000 });
+    await otherInputQ2b.click();
+    await win.waitForTimeout(40);
+    await win.keyboard.press('Enter');
+    await win.waitForTimeout(350);
+    const sent = await getCapturedSends();
+    if (sent.length !== 1) {
+      return record('J8', false, `③ expected 1 send after Enter on last question's Other input, got ${sent.length}`);
+    }
+    if (!/abc/.test(sent[0].text || '') || !/xy/.test(sent[0].text || '')) {
+      return record('J8', false, `③ payload missing 'abc' and/or 'xy': ${JSON.stringify(sent[0])}`);
+    }
+    if (sent[0].sessionId !== sessionId) {
+      return record('J8', false, `③ wrong sessionId: expected ${sessionId}, got ${sent[0].sessionId}`);
+    }
+
+    await win.evaluate((sid) => window.__ccsmStore.getState().clearMessages(sid), sessionId);
+    await clearCaptured();
+    record('J8', true, '① ↑↓ from Other input cycles options + preserves text; ② ←/→ at edges pages question; ③ Enter on last question submits');
+  }
+
   await safeRun('J1', j1);
   await safeRun('J2', j2);
   await safeRun('J3', j3);
@@ -4593,11 +4780,12 @@ async function caseAskUserQuestionFull({ app, win, log }) {
   await safeRun('J5', j5);
   await safeRun('J6', j6);
   await safeRun('J7', j7);
+  await safeRun('J8', j8);
 
   if (failures.length > 0) {
     throw new Error(`${failures.length} journey failure(s):\n  - ${failures.join('\n  - ')}`);
   }
-  log('all 7 journeys matched expected behavior');
+  log('all 8 journeys matched expected behavior');
 }
 
 // ---------- sidebar-journey-create-delete (was probe-e2e-sidebar-journey-create-delete) ----------

--- a/src/components/QuestionBlock.tsx
+++ b/src/components/QuestionBlock.tsx
@@ -551,15 +551,112 @@ export function QuestionBlock({ questions, onSubmit, onReject, autoFocus = true 
                           // Fall through to root handler.
                           return;
                         }
+                        // #330: keyboard inside the Other input was fully
+                        // dead. Three behaviors must work even with focus in
+                        // the contenteditable:
+                        //   ↑/↓  → cycle options (input is single-line; up/
+                        //          down has no caret meaning, route to the
+                        //          question controller).
+                        //   ←/→  → default caret movement; at the EDGE
+                        //          (caret=0 / caret=end with no selection)
+                        //          → page question.
+                        //   Enter → submit when all answered, else page
+                        //           forward on non-last questions.
+                        // We stopPropagation AFTER our own handling so the
+                        // root onKeyDown doesn't double-fire.
+                        if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          const root = optionsRef.current;
+                          if (!root) return;
+                          const opts = Array.from(
+                            root.querySelectorAll<HTMLElement>('[data-question-option]')
+                          );
+                          if (opts.length === 0) return;
+                          // Caret lives in the Other input; logical "current"
+                          // option is the Other chip (parent of this input).
+                          const otherChipIdx = opts.findIndex(
+                            (el) => el.dataset.questionLabel === OTHER_LABEL
+                          );
+                          if (otherChipIdx === -1) return;
+                          const nextIdx =
+                            e.key === 'ArrowUp'
+                              ? otherChipIdx <= 0
+                                ? opts.length - 1
+                                : otherChipIdx - 1
+                              : otherChipIdx >= opts.length - 1
+                                ? 0
+                                : otherChipIdx + 1;
+                          opts[nextIdx]?.focus({ preventScroll: true });
+                          return;
+                        }
+                        if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+                          // Detect edge + no selection. If neither, fall
+                          // through to default caret behavior (and DON'T
+                          // stopPropagation — the root handler also wants
+                          // to ignore it because we're typing).
+                          const sel = window.getSelection();
+                          const node = e.currentTarget;
+                          const text = node.textContent ?? '';
+                          let atStart = false;
+                          let atEnd = false;
+                          let collapsed = true;
+                          if (sel && sel.rangeCount > 0) {
+                            const range = sel.getRangeAt(0);
+                            collapsed = range.collapsed;
+                            // Compute caret offset relative to the input's
+                            // text by measuring a range from start-of-node
+                            // to caret.
+                            const probe = document.createRange();
+                            probe.selectNodeContents(node);
+                            try {
+                              probe.setEnd(range.endContainer, range.endOffset);
+                            } catch {
+                              // endContainer outside the node — bail.
+                              e.stopPropagation();
+                              return;
+                            }
+                            const caret = probe.toString().length;
+                            atStart = caret === 0;
+                            atEnd = caret === text.length;
+                          }
+                          if (!collapsed) {
+                            // Selection active → default behavior (collapse
+                            // selection); don't page.
+                            e.stopPropagation();
+                            return;
+                          }
+                          if (e.key === 'ArrowLeft' && atStart && active > 0) {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            setActive(active - 1);
+                            return;
+                          }
+                          if (
+                            e.key === 'ArrowRight' &&
+                            atEnd &&
+                            active < questions.length - 1
+                          ) {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            setActive(active + 1);
+                            return;
+                          }
+                          // Mid-text or at-edge-but-no-more-questions →
+                          // default caret movement; stop bubbling so the
+                          // root doesn't try to interpret it.
+                          e.stopPropagation();
+                          return;
+                        }
                         e.stopPropagation();
                         if (e.key === 'Enter' && !e.shiftKey) {
                           e.preventDefault();
-                          // Last question: Enter inside Other = submit
-                          // (matches the Submit button). Earlier questions
-                          // page forward.
+                          // Last question + all answered → submit. Earlier
+                          // questions OR last-but-not-yet-answered → page
+                          // forward (legacy behavior).
                           if (active < questions.length - 1) {
                             setActive(active + 1);
-                          } else {
+                          } else if (allAnswered) {
                             submit();
                           }
                         }


### PR DESCRIPTION
## Bug
#330 — Typing into the AskUserQuestion Other contenteditable killed every keyboard shortcut. Root onKeyDown bailed on `otherFocused`; the input's own handler stopPropagation'd everything except Esc/Enter. ↑/↓ did nothing, ←/→ never paged at edges, and Enter submitted only via a special-case (worked) but the broader nav was dead.

## Behavior table

| Key | When focus is in Other input | Result |
|---|---|---|
| ① ↑ / ↓ | always | Cycle options (incl. above predefined options + Other itself). Input text + Other-selected state preserved. |
| ② ← | caret offset 0, no selection | Page to previous question. |
| ② ← | mid-text or with selection | Default caret movement; no paging. |
| ② → | caret at end, no selection | Page to next question. |
| ② → | mid-text or with selection | Default caret movement; no paging. |
| ③ Enter (last question, all answered) | always | Submit whole answer set. |
| ③ Enter (earlier question) | always | Page forward (legacy). |

## Phase 1 — failing harness on unfixed working

```
[case=askuserquestion-full] FAIL  J8  — ① after ArrowUp from Other input expected TypeScript option focused, got {"tag":"DIV","label":null,"role":"textbox"}
```
(focus stuck in input — root `onKeyDown` short-circuits on `otherFocused` so ↑/↓ never reach the cycler.)

## Phase 4 — green with fix

```
[case=askuserquestion-full] OK    J1  — mount auto-focused Python (textarea draft preserved); ↓↓↑Enter routed TypeScript; focus returned
[case=askuserquestion-full] OK    J2  — gating tracks pick count (0→1→0→2); both labels submitted
[case=askuserquestion-full] OK    J3  — revised picks captured (A3+B1+C0), no stale A2
[case=askuserquestion-full] OK    J4  — down/up wraps through 12+Other; last model option submits
[case=askuserquestion-full] OK    J5  — no horizontal overflow (0 labels)
[case=askuserquestion-full] OK    J6  — answers routed to correct sessions; no question leakage on switch
[case=askuserquestion-full] OK    J7  — Enter on focused option submitted when all questions answered (single+multi)
[case=askuserquestion-full] OK    J8  — ① ↑↓ from Other input cycles options + preserves text; ② ←/→ at edges pages question; ③ Enter on last question submits
[case=askuserquestion-full] all 8 journeys matched expected behavior

=== totals: 1 passed, 0 failed, 0 skipped, 1 total ===
```

## Implementation
Single touch in `src/components/QuestionBlock.tsx` — replaced the Other input's `onKeyDown` to handle arrows + Enter inline (uses `window.getSelection()` to detect caret edge / collapsed state for the ←/→ overflow logic). Root onKeyDown's `otherFocused` short-circuit is left intact since the input now consumes (stopPropagation) the keys it owns.

## Test plan
- [x] Phase 1 reproduced: J8 ① fails on unfixed working
- [x] Phase 4 green: 8/8 askuserquestion-full journeys pass
- [x] No regression on J1–J7 (existing AskUserQuestion behavior)