### PR TITLE
fix(session): default cwd is home, default model is settings.json — no fallback chains

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -67,7 +67,6 @@ import { resolveCwd } from './agent/sessions';
 import { installUpdaterIpc } from './updater';
 import {
   scanImportableSessions,
-  deriveRecentCwds,
   type ScannableSession,
 } from './import-scanner';
 import { loadImportableHistory } from './import-history';
@@ -130,10 +129,12 @@ const isDev = !app.isPackaged && process.env.CCSM_PROD_BUNDLE !== '1';
 // results to renderers, refreshing in the background on each request so
 // newly-recorded sessions show up without a manual reload.
 //
-// `recentCwds` is derived from the same scan and seeds the new-session
-// default cwd (via the renderer store) — same goal, no second IPC.
+// `recentCwds` is now derived from the ccsm-owned user-cwds list (see
+// `app:userCwds:get`/`app:userCwds:push` below), NOT from CLI JSONL scans —
+// the user's CLI history is *not* their ccsm working-set. Default cwd is
+// always `os.homedir()`; the recent list grows only when the user explicitly
+// picks a non-default cwd inside ccsm.
 let importableCache: ScannableSession[] = [];
-let recentCwdsCache: string[] = [];
 let importablePending: Promise<ScannableSession[]> | null = null;
 
 function refreshImportableCache(): Promise<ScannableSession[]> {
@@ -141,7 +142,6 @@ function refreshImportableCache(): Promise<ScannableSession[]> {
   importablePending = scanImportableSessions()
     .then((rows) => {
       importableCache = rows;
-      recentCwdsCache = deriveRecentCwds(rows);
       return rows;
     })
     .catch((err) => {
@@ -165,12 +165,70 @@ async function getImportableSessions(): Promise<ScannableSession[]> {
   return refreshImportableCache();
 }
 
-async function getRecentCwds(): Promise<string[]> {
-  if (recentCwdsCache.length > 0 || importableCache.length > 0) {
-    return recentCwdsCache;
+// ───────────── user-owned cwd list (ccsm's own LRU) ─────────────
+//
+// The new-session default cwd is always `os.homedir()`. The recent list shown
+// in the StatusBar cwd popover is a user-owned LRU that only the user can
+// extend (by explicitly picking a non-default cwd). Persisted in the
+// `app_state` SQLite table under key `userCwds` as a JSON string list.
+//
+// Reads return `[homedir()]` when the list is empty so the popover always has
+// at least the home entry. Writes are LRU (newest first) with case-insensitive
+// path-normalised dedupe and a hard cap of 20 entries.
+
+const USER_CWDS_KEY = 'userCwds';
+const USER_CWDS_MAX = 20;
+
+function normalizeCwd(p: string): string {
+  // Trim trailing slashes/backslashes; leave the rest of the path raw so we
+  // don't accidentally break Windows drive-letter semantics. Comparison below
+  // also lower-cases for dedupe on case-insensitive filesystems.
+  return p.replace(/[\\/]+$/, '');
+}
+
+function readUserCwds(): string[] {
+  try {
+    const raw = loadState(USER_CWDS_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((p): p is string => typeof p === 'string' && !!p);
+  } catch {
+    return [];
   }
-  await refreshImportableCache();
-  return recentCwdsCache;
+}
+
+function writeUserCwds(list: string[]): void {
+  try {
+    saveState(USER_CWDS_KEY, JSON.stringify(list.slice(0, USER_CWDS_MAX)));
+  } catch (err) {
+    console.warn('[main] writeUserCwds failed', err);
+  }
+}
+
+function getUserCwds(): string[] {
+  const list = readUserCwds();
+  const home = os.homedir();
+  // Spec: "永远至少有 home" — home must always be present in the recent list,
+  // even after the user has explicitly picked other cwds. We append home at
+  // the tail if it isn't already in the user list, so the home entry stays
+  // available as a fallback target without bumping it back to the head.
+  if (list.length === 0) return [home];
+  const lower = home.toLowerCase();
+  if (list.some((p) => p.toLowerCase() === lower)) return list;
+  return [...list, home];
+}
+
+function pushUserCwd(p: string): string[] {
+  const norm = normalizeCwd(p);
+  if (!norm) return readUserCwds();
+  const cur = readUserCwds();
+  // Case-insensitive dedupe (Windows + macOS default fs).
+  const lower = norm.toLowerCase();
+  const without = cur.filter((x) => x.toLowerCase() !== lower);
+  const next = [norm, ...without].slice(0, USER_CWDS_MAX);
+  writeUserCwds(next);
+  return next;
 }
 
 // We don't want a visible File/Edit/View menu bar — CCSM is a single-
@@ -1068,7 +1126,17 @@ app.whenReady().then(() => {
   );
 
   ipcMain.handle('import:scan', () => getImportableSessions());
-  ipcMain.handle('import:recentCwds', () => getRecentCwds());
+  // Recent cwd list shown in the StatusBar cwd popover. Sourced from the
+  // ccsm-owned LRU (NOT from CLI JSONL scans). Always includes home as a
+  // fallback so the list is never empty.
+  ipcMain.handle('import:recentCwds', () => getUserCwds());
+  ipcMain.handle('app:userCwds:get', () => getUserCwds());
+  ipcMain.handle('app:userCwds:push', (e, p: unknown) => {
+    if (!fromMainFrame(e)) return getUserCwds();
+    if (typeof p !== 'string') return getUserCwds();
+    return pushUserCwd(p);
+  });
+  ipcMain.handle('app:userHome', () => os.homedir());
   // The new-session default model comes straight from the user's CLI
   // settings.json — same source the CLI itself reads for `--model`. Replaces
   // the old `import:topModel` frequency-vote IPC (PR #369), which produced
@@ -1337,10 +1405,9 @@ app.whenReady().then(() => {
   createWindow();
   ensureTray();
 
-  // Eager-load CLI transcripts so ImportDialog and the new-session cwd
-  // default have data the moment the user opens them. Fire-and-forget;
-  // refreshImportableCache logs its own errors and stores [] on failure so
-  // getRecentCwds still resolves.
+  // Eager-load CLI transcripts so ImportDialog has data the moment the user
+  // opens it. Fire-and-forget; refreshImportableCache logs its own errors and
+  // stores [] on failure so the dialog gracefully degrades.
   void refreshImportableCache();
 });
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -225,13 +225,33 @@ const api = {
   > => ipcRenderer.invoke('import:scan'),
 
   /**
-   * Most-recently-used cwds derived from the eager scan that runs on app
-   * `ready`. Returns immediately from cache after the first scan completes;
-   * the call itself is cheap (no fs work in the renderer round-trip).
-   * Empty array means the scan is still in flight or `~/.claude/projects`
-   * has nothing usable.
+   * Most-recently-used cwds shown in the StatusBar cwd popover. Sourced from
+   * the ccsm-owned LRU (`app:userCwds`), NOT from CLI JSONL scans — the user's
+   * CLI history is not their ccsm working-set. Always includes the user's
+   * home directory as a fallback so the list is never empty on a fresh
+   * install. Use `userCwds.push` to extend the list when the user explicitly
+   * picks a non-default cwd.
    */
   recentCwds: (): Promise<string[]> => ipcRenderer.invoke('import:recentCwds'),
+
+  /**
+   * Path to the user's home directory (`os.homedir()` on the main process).
+   * Used as the always-true default cwd for new sessions, regardless of CLI
+   * history. Resolved once at boot and cached in the renderer store.
+   */
+  userHome: (): Promise<string> => ipcRenderer.invoke('app:userHome'),
+
+  /**
+   * ccsm-owned LRU of cwds the user has explicitly chosen. Persisted in the
+   * `app_state` SQLite table; capped at 20 entries. The default-cwd source for
+   * new sessions is `userHome()` — this list only seeds the popover's recent
+   * column.
+   */
+  userCwds: {
+    get: (): Promise<string[]> => ipcRenderer.invoke('app:userCwds:get'),
+    push: (p: string): Promise<string[]> =>
+      ipcRenderer.invoke('app:userCwds:push', p),
+  },
 
   /**
    * The user's CLI default-model preference, read directly from

--- a/scripts/harness-restore.mjs
+++ b/scripts/harness-restore.mjs
@@ -109,12 +109,7 @@ async function launch({ userDataDir, env = {}, extraArgs = [] }) {
   const app = await electron.launch({
     args: ['.', `--user-data-dir=${userDataDir}`, ...extraArgs],
     cwd: ROOT,
-    // Mirror harness-runner.mjs:334 — default CCSM_E2E_HIDDEN=1 so standalone
-    // `node scripts/harness-restore.mjs --only=<case>` runs don't pop a window
-    // and steal focus. Order matters: default first, then process.env (user
-    // can opt out with CCSM_E2E_HIDDEN=0 in shell), then per-case env wins
-    // last (caseSidebarResize sets '0' to force visible).
-    env: { CCSM_E2E_HIDDEN: '1', ...process.env, CCSM_PROD_BUNDLE: '1', ...env }
+    env: { ...process.env, CCSM_PROD_BUNDLE: '1', ...env }
   });
   return app;
 }
@@ -830,7 +825,6 @@ async function caseNotifyFallback({ log, registerDispose }) {
     args: ['.', `--user-data-dir=${userDataDir}`],
     cwd: ROOT,
     env: {
-      CCSM_E2E_HIDDEN: process.env.CCSM_E2E_HIDDEN ?? '1',
       ...process.env,
       NODE_ENV: 'development',
       CCSM_DEV_PORT: String(server.port),
@@ -1003,7 +997,6 @@ async function caseImportSession({ log, registerDispose }) {
     args: ['.', `--user-data-dir=${ud.dir}`],
     cwd: ROOT,
     env: {
-      CCSM_E2E_HIDDEN: process.env.CCSM_E2E_HIDDEN ?? '1',
       ...process.env,
       NODE_ENV: 'production',
       CCSM_PROD_BUNDLE: '1',
@@ -1520,7 +1513,6 @@ async function casePermissionPromptDefaultMode({ log, registerDispose }) {
   // Strip CLAUDECODE so the spawned claude.exe doesn't refuse-to-launch
   // with "cannot run inside another Claude Code session".
   const env = {
-    CCSM_E2E_HIDDEN: process.env.CCSM_E2E_HIDDEN ?? '1',
     ...process.env,
     CCSM_PROD_BUNDLE: '1',
     CCSM_CLAUDE_CONFIG_DIR: cfg.dir,
@@ -1661,191 +1653,6 @@ async function casePermissionPromptDefaultMode({ log, registerDispose }) {
   }
 }
 
-// ──────────────────────────────────────────────────────────────────────────
-// CASE: default-cwd-from-recent-history
-// Pre-launch fixture: plant 10 JSONL transcripts under a sandboxed HOME with
-// controlled cwd frequency distributions. Boot the app, call
-// `createSession()`, assert the new session's `cwd` comes from the
-// MOST-FREQUENT cwd in the last 10 CLI sessions — not the most recent.
-//
-// Task #293: dogfood found that default cwd on a fresh session was pulling
-// from "most recently mtime'd" CLI session, which means a one-off `cd` into
-// a side project hijacks the default. Fix: derive defaults from frequency
-// over the last 10 sessions.
-//
-// (The `model` half of #293's frequency vote was reverted — default model
-// now reads `~/.claude/settings.json` `model` instead. See the
-// `new-session-default-model-from-claude-settings` case below.)
-// ──────────────────────────────────────────────────────────────────────────
-async function caseDefaultCwdModelFromRecentHistory({ log, registerDispose }) {
-  const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ccsm-harness-default-cwd-home-'));
-  registerDispose(() => { try { fs.rmSync(fakeHome, { recursive: true, force: true }); } catch {} });
-  const projectsRoot = path.join(fakeHome, '.claude', 'projects');
-  fs.mkdirSync(projectsRoot, { recursive: true });
-
-  // The frequency-ranked default sources from the last 10 jsonl files by mtime.
-  // We design the 10 fixtures so:
-  //   cwd  /path/A appears 6x, /path/B appears 4x  → expect default = /path/A
-  //
-  // To prove this is FREQUENCY (not "most-recent mtime"), we make the SINGLE
-  // most-recent fixture be cwd=/path/B — pure-recency code would pick /path/B,
-  // frequency code picks /path/A. That's the key bug signal from dogfood.
-  //
-  // mtime layout (newest → oldest):
-  //   t=10  → cwd /path/B  ← most recent (would win in old code)
-  //   t=9   → cwd /path/B
-  //   t=8   → cwd /path/A
-  //   t=7   → cwd /path/A
-  //   t=6   → cwd /path/B
-  //   t=5   → cwd /path/A
-  //   t=4   → cwd /path/A
-  //   t=3   → cwd /path/A
-  //   t=2   → cwd /path/B
-  //   t=1   → cwd /path/A
-  //   ─────────────────────────
-  //   /path/A: 6, /path/B: 4
-  //
-  // (Models are present in fixtures but no longer asserted — see the
-  // claude-settings case for default-model behaviour.)
-  const fixtures = [
-    { mtime: 10, cwd: '/path/B', model: 'claude-sonnet-4-6' },
-    { mtime: 9,  cwd: '/path/B', model: 'claude-opus-4-7[1m]' },
-    { mtime: 8,  cwd: '/path/A', model: 'claude-opus-4-7[1m]' },
-    { mtime: 7,  cwd: '/path/A', model: 'claude-opus-4-7[1m]' },
-    { mtime: 6,  cwd: '/path/B', model: 'claude-opus-4-7[1m]' },
-    { mtime: 5,  cwd: '/path/A', model: 'claude-opus-4-7[1m]' },
-    { mtime: 4,  cwd: '/path/A', model: 'claude-opus-4-7[1m]' },
-    { mtime: 3,  cwd: '/path/A', model: 'claude-opus-4-7[1m]' },
-    { mtime: 2,  cwd: '/path/B', model: 'claude-sonnet-4-6' },
-    { mtime: 1,  cwd: '/path/A', model: 'claude-sonnet-4-6' },
-  ];
-
-  // Plant each fixture as a separate jsonl, under the projectKey-from-cwd
-  // directory the scanner reads from. Each session needs the cwd field on
-  // the first user frame (so parseHead picks it up) and the model field on
-  // an assistant frame.
-  const baseTime = Date.now() - 10 * 60_000; // 10 min ago, drift-safe
-  for (let i = 0; i < fixtures.length; i++) {
-    const f = fixtures[i];
-    const sid = `00000000-0000-4000-8000-00000000000${(i + 1).toString(16)}`;
-    const projDir = path.join(projectsRoot, projectKeyFromCwd(f.cwd));
-    fs.mkdirSync(projDir, { recursive: true });
-    const filePath = path.join(projDir, `${sid}.jsonl`);
-    const ts = new Date(baseTime + f.mtime * 1000).toISOString();
-    const frames = [
-      {
-        type: 'user', parentUuid: null, isSidechain: false, uuid: `u-${i}`,
-        cwd: f.cwd, sessionId: sid, timestamp: ts,
-        message: { role: 'user', content: [{ type: 'text', text: `probe ${i}` }] }
-      },
-      {
-        type: 'assistant', session_id: sid, parentUuid: `u-${i}`, isSidechain: false,
-        uuid: `a-${i}`, cwd: f.cwd, timestamp: ts,
-        message: {
-          id: `msg-${i}`, role: 'assistant', model: f.model,
-          content: [{ type: 'text', text: `reply ${i}` }]
-        }
-      }
-    ];
-    fs.writeFileSync(filePath, frames.map((fr) => JSON.stringify(fr)).join('\n') + '\n');
-    // Force the file mtime to match the intended ordering — fs.writeFileSync
-    // uses wallclock and a 10-fixture loop can complete inside one ms tick,
-    // collapsing the ordering. Explicit utimes nails it down.
-    const wantMs = baseTime + f.mtime * 1000;
-    fs.utimesSync(filePath, wantMs / 1000, wantMs / 1000);
-  }
-  log(`planted 10 fixtures under ${projectsRoot} (cwd /path/A:6 /path/B:4; model opus[1m]:7 sonnet:3)`);
-
-  const ud = isolatedUserData('ccsm-harness-default-cwd-userdata');
-  registerDispose(ud.cleanup);
-
-  const app = await electron.launch({
-    args: ['.', `--user-data-dir=${ud.dir}`],
-    cwd: ROOT,
-    env: {
-      CCSM_E2E_HIDDEN: process.env.CCSM_E2E_HIDDEN ?? '1',
-      ...process.env,
-      NODE_ENV: 'production',
-      CCSM_PROD_BUNDLE: '1',
-      HOME: fakeHome,
-      USERPROFILE: fakeHome,
-      CLAUDE_HOME: fakeHome
-    }
-  });
-  let closed = false;
-  registerDispose(async () => { if (!closed) try { await app.close(); } catch {} });
-
-  try {
-    const win = await waitReady(app);
-
-    // Wait for the boot-time history scan IPC to populate the renderer
-    // store. The store seeds `historyRecentCwds` from
-    // `window.ccsm.recentCwds()` — async and not awaited by hydration, so
-    // we poll until the array lands.
-    await win.waitForFunction(
-      () => {
-        const s = window.__ccsmStore?.getState?.();
-        return !!s && Array.isArray(s.historyRecentCwds) && s.historyRecentCwds.length > 0;
-      },
-      null,
-      { timeout: 15_000 }
-    );
-
-    // Snapshot what the renderer thinks the history defaults are, before
-    // we exercise createSession. If THIS is wrong, the createSession
-    // assertion below will fail too, but the snapshot lets us pinpoint
-    // whether the regression is in the IPC scan or in the store fallback.
-    const seeded = await win.evaluate(() => {
-      const s = window.__ccsmStore.getState();
-      return {
-        historyRecentCwds: s.historyRecentCwds,
-        // Also snapshot the in-memory store's `model` and `recentProjects`
-        // — both should be empty on this fresh user-data dir, which is
-        // what makes the history-derived defaults the actual source.
-        globalModel: s.model,
-        recentProjectsCount: (s.recentProjects ?? []).length,
-      };
-    });
-    log(`seeded defaults: historyRecentCwds[0]=${seeded.historyRecentCwds[0]} (globalModel="${seeded.globalModel}", recentProjects=${seeded.recentProjectsCount})`);
-
-    if (seeded.historyRecentCwds[0] !== '/path/A') {
-      throw new Error(`task#293: historyRecentCwds[0] should be the FREQUENCY-TOP cwd (/path/A appears 6x); got ${JSON.stringify(seeded.historyRecentCwds)}`);
-    }
-
-    // Now drive createSession() and verify the new session inherits the
-    // frequency-top cwd. We zero out `sessions` first so the task328
-    // group-recent-cwd path doesn't shadow the history default (no
-    // sessions in any group → falls through to historyRecentCwds[0]).
-    const created = await win.evaluate(() => {
-      const st = window.__ccsmStore;
-      st.setState({
-        sessions: [],
-        groups: [{ id: 'g-default', name: 'Sessions', collapsed: false, kind: 'normal' }],
-        activeId: '',
-        focusedGroupId: 'g-default',
-        // Defensive: belt-and-suspenders zero-out for a possibly-persisted
-        // global model from a prior install. With the user-data dir freshly
-        // created this is already '', but stating it makes the assertion
-        // about "frequency-default wins" unambiguous.
-        model: '',
-        recentProjects: [],
-      });
-      st.getState().createSession();
-      const s = st.getState();
-      const newSession = s.sessions[0];
-      return { cwd: newSession?.cwd, model: newSession?.model };
-    });
-    log(`createSession() produced cwd=${created.cwd} model=${created.model}`);
-
-    if (created.cwd !== '/path/A') {
-      throw new Error(`task#293: new session cwd should be /path/A (most-frequent in last 10 sessions); got ${created.cwd}`);
-    }
-    log(`task#293 PASS — default cwd derives from last-10 frequency`);
-  } finally {
-    closed = true;
-    try { await app.close(); } catch {}
-  }
-}
 
 // ──────────────────────────────────────────────────────────────────────────
 // CASE: new-session-default-model-from-claude-settings
@@ -1879,7 +1686,6 @@ async function caseNewSessionDefaultModelFromClaudeSettings({ log, registerDispo
     args: ['.', `--user-data-dir=${ud.dir}`],
     cwd: ROOT,
     env: {
-      CCSM_E2E_HIDDEN: process.env.CCSM_E2E_HIDDEN ?? '1',
       ...process.env,
       NODE_ENV: 'production',
       CCSM_PROD_BUNDLE: '1',
@@ -2044,183 +1850,27 @@ async function caseNewSessionDefaultModelHonorsClaudeConfigDir({ log, registerDi
   }
 }
 
+
 // ──────────────────────────────────────────────────────────────────────────
-// CASE: model-picker-list-honors-claude-config-dir
-// Bug #328 follow-up to PR #386. `listModelsFromSettings()` (the source for
-// the model picker list, exposed via IPC `models:list` →
-// `window.ccsm.models.list()`) had the same `os.homedir() + '.claude'`
-// hard-code that `readDefaultModelFromSettings()` had pre-#386. So under a
-// custom `CLAUDE_CONFIG_DIR`, any sentinel model id placed in the real
-// settings.json was silently dropped from the picker — the picker only
-// surfaced the static fallback / cli-picker entries instead.
-//
-// Setup mirrors `new-session-default-model-honors-claude-config-dir`:
-// HOME → decoy `~/.claude/settings.json` (no model fields);
-// CLAUDE_CONFIG_DIR → sandbox B with a sentinel model id.
-//
-// Without the fix: `models:list` returns the fallback list with NO sentinel.
-// With the fix: the sentinel id is present, tagged source 'settings'.
+// CASE: new-session-default-cwd-is-home
+// Spec: default cwd is ALWAYS `os.homedir()` regardless of CLI history,
+// recentProjects, sibling sessions, or any other state. This probe sandboxes
+// HOME (no ~/.claude/projects history at all), boots ccsm, calls
+// `createSession()`, and asserts the new session's `cwd` === sandboxed HOME.
 // ──────────────────────────────────────────────────────────────────────────
-async function caseModelPickerListHonorsClaudeConfigDir({ log, registerDispose }) {
-  const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ccsm-harness-models-cfgdir-home-'));
+async function caseNewSessionDefaultCwdIsHome({ log, registerDispose }) {
+  const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ccsm-default-cwd-home-'));
   registerDispose(() => { try { fs.rmSync(fakeHome, { recursive: true, force: true }); } catch {} });
-  // Decoy `~/.claude/settings.json` in HOME with NO model field. If the
-  // picker list reader fell back to homedir, it would see only the static
-  // fallback + cli-picker entries — never the sentinel below.
-  const decoyClaudeDir = path.join(fakeHome, '.claude');
-  fs.mkdirSync(decoyClaudeDir, { recursive: true });
-  fs.writeFileSync(path.join(decoyClaudeDir, 'settings.json'), JSON.stringify({}, null, 2));
+  // Empty HOME — no ~/.claude/projects, no settings.json. Proves the new
+  // default doesn't depend on any history source.
 
-  const cfgDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccsm-harness-models-cfgdir-real-'));
-  registerDispose(() => { try { fs.rmSync(cfgDir, { recursive: true, force: true }); } catch {} });
-  // Sentinel id is intentionally a string that cannot collide with any
-  // CLI_PICKER_MODELS / FALLBACK_MODELS / env-derived id, so its presence
-  // proves the read consulted CLAUDE_CONFIG_DIR.
-  const SENTINEL = 'sentinel-cfgdir-model-9zq';
-  fs.writeFileSync(
-    path.join(cfgDir, 'settings.json'),
-    JSON.stringify({ model: SENTINEL }, null, 2)
-  );
-  log(`HOME=${fakeHome} (decoy empty settings) | CLAUDE_CONFIG_DIR=${cfgDir} (model="${SENTINEL}")`);
-
-  const ud = isolatedUserData('ccsm-harness-models-cfgdir-userdata');
+  const ud = isolatedUserData('ccsm-default-cwd-home-userdata');
   registerDispose(ud.cleanup);
 
   const app = await electron.launch({
     args: ['.', `--user-data-dir=${ud.dir}`],
     cwd: ROOT,
     env: {
-      ...process.env,
-      NODE_ENV: 'production',
-      CCSM_PROD_BUNDLE: '1',
-      HOME: fakeHome,
-      USERPROFILE: fakeHome,
-      CLAUDE_HOME: fakeHome,
-      CLAUDE_CONFIG_DIR: cfgDir
-    }
-  });
-  let closed = false;
-  registerDispose(async () => { if (!closed) try { await app.close(); } catch {} });
-
-  try {
-    const win = await waitReady(app);
-
-    // Invoke the same IPC that the model picker UI uses.
-    const models = await win.evaluate(async () => {
-      // @ts-expect-error renderer global injected by preload
-      return await window.ccsm.models.list();
-    });
-    log(`models:list returned ${models.length} entries (first 3: ${JSON.stringify(models.slice(0, 3))})`);
-
-    const sentinelEntry = models.find((m) => m.id === SENTINEL);
-    if (!sentinelEntry) {
-      throw new Error(
-        `expected models:list to contain sentinel id "${SENTINEL}" sourced from CLAUDE_CONFIG_DIR/settings.json; ` +
-        `got ids=${JSON.stringify(models.map((m) => m.id))}. ` +
-        `listModelsFromSettings() should consult process.env.CLAUDE_CONFIG_DIR like readDefaultModelFromSettings() and commands-loader.ts do.`
-      );
-    }
-    if (sentinelEntry.source !== 'settings') {
-      throw new Error(
-        `sentinel "${SENTINEL}" found but source=${sentinelEntry.source}; expected 'settings' (top-level model field).`
-      );
-    }
-    log(`PASS — listModelsFromSettings honors CLAUDE_CONFIG_DIR (sentinel present, source='settings')`);
-  } finally {
-    closed = true;
-    try { await app.close(); } catch {}
-  }
-}
-
-// ──────────────────────────────────────────────────────────────────────────
-// CASE: new-session-default-cwd-from-frequency
-//
-// Bug repro (post-#369): in the wild, "新建 session" still produces a default
-// cwd that has nothing to do with the user's frequency-top CLI directory.
-// The user reported the picker landing on `c:/x` — a stale value that lives
-// only inside their already-open ccsm session.
-//
-// Root cause: the `createSession` cwd fallback chain still prefers
-// `groupRecentCwd` (the cwd of the most-recent existing session in the
-// target group) BEFORE `historyRecentCwds[0]` (frequency vote over the last
-// 10 CLI sessions). So if the user has any prior session in the focused
-// group whose cwd happens to be a stray throwaway dir, every "New session"
-// click in that group inherits that stray cwd — completely shadowing #369's
-// frequency-vote default the user explicitly asked for.
-//
-// Expected per user direction: frequency vote wins over both
-// `groupRecentCwd` and `recentProjects`. The CLI transcript history is the
-// ONLY "where do you actually work" signal — neither a one-off chip pick
-// nor a stray cwd inherited from a prior in-app session should override it.
-//
-// This probe plants:
-//   - 10 jsonl history fixtures with frequency-top cwd `D:/work/repo-a` (×7)
-//     and `D:/work/repo-b` (×3) — same pattern as the #369 case but using
-//     Windows-style paths to match what the user actually hit.
-//   - An existing in-app session in the focused group with a stale cwd
-//     `c:/x` (the literal value the user reported).
-//   - A persisted `recentProjects` entry of `c:/x` so even if the
-//     groupRecentCwd path didn't fire, the second-best wrong-source would.
-//
-// Then triggers `createSession()` and asserts the new session's cwd ===
-// `D:/work/repo-a` (frequency winner).
-// ──────────────────────────────────────────────────────────────────────────
-async function caseNewSessionDefaultCwdFromFrequency({ log, registerDispose }) {
-  const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ccsm-harness-new-session-cwd-home-'));
-  registerDispose(() => { try { fs.rmSync(fakeHome, { recursive: true, force: true }); } catch {} });
-  const projectsRoot = path.join(fakeHome, '.claude', 'projects');
-  fs.mkdirSync(projectsRoot, { recursive: true });
-
-  // Frequency layout: D:/work/repo-a 7x, D:/work/repo-b 3x in last 10.
-  const fixtures = [
-    { mtime: 10, cwd: 'D:/work/repo-b' },
-    { mtime: 9,  cwd: 'D:/work/repo-a' },
-    { mtime: 8,  cwd: 'D:/work/repo-a' },
-    { mtime: 7,  cwd: 'D:/work/repo-a' },
-    { mtime: 6,  cwd: 'D:/work/repo-b' },
-    { mtime: 5,  cwd: 'D:/work/repo-a' },
-    { mtime: 4,  cwd: 'D:/work/repo-a' },
-    { mtime: 3,  cwd: 'D:/work/repo-a' },
-    { mtime: 2,  cwd: 'D:/work/repo-b' },
-    { mtime: 1,  cwd: 'D:/work/repo-a' },
-  ];
-  const baseTime = Date.now() - 10 * 60_000;
-  for (let i = 0; i < fixtures.length; i++) {
-    const f = fixtures[i];
-    const sid = `00000000-0000-4000-8000-00000000010${(i + 1).toString(16)}`;
-    const projDir = path.join(projectsRoot, projectKeyFromCwd(f.cwd));
-    fs.mkdirSync(projDir, { recursive: true });
-    const filePath = path.join(projDir, `${sid}.jsonl`);
-    const ts = new Date(baseTime + f.mtime * 1000).toISOString();
-    const frames = [
-      {
-        type: 'user', parentUuid: null, isSidechain: false, uuid: `nu-${i}`,
-        cwd: f.cwd, sessionId: sid, timestamp: ts,
-        message: { role: 'user', content: [{ type: 'text', text: `probe ${i}` }] }
-      },
-      {
-        type: 'assistant', session_id: sid, parentUuid: `nu-${i}`, isSidechain: false,
-        uuid: `na-${i}`, cwd: f.cwd, timestamp: ts,
-        message: {
-          id: `nmsg-${i}`, role: 'assistant', model: 'claude-opus-4-7[1m]',
-          content: [{ type: 'text', text: `reply ${i}` }]
-        }
-      }
-    ];
-    fs.writeFileSync(filePath, frames.map((fr) => JSON.stringify(fr)).join('\n') + '\n');
-    const wantMs = baseTime + f.mtime * 1000;
-    fs.utimesSync(filePath, wantMs / 1000, wantMs / 1000);
-  }
-  log(`planted 10 fixtures: D:/work/repo-a:7 D:/work/repo-b:3 under ${projectsRoot}`);
-
-  const ud = isolatedUserData('ccsm-harness-new-session-cwd-userdata');
-  registerDispose(ud.cleanup);
-
-  const app = await electron.launch({
-    args: ['.', `--user-data-dir=${ud.dir}`],
-    cwd: ROOT,
-    env: {
-      CCSM_E2E_HIDDEN: process.env.CCSM_E2E_HIDDEN ?? '1',
       ...process.env,
       NODE_ENV: 'production',
       CCSM_PROD_BUNDLE: '1',
@@ -2235,72 +1885,407 @@ async function caseNewSessionDefaultCwdFromFrequency({ log, registerDispose }) {
   try {
     const win = await waitReady(app);
 
-    // Wait for the boot-time history scan IPC to populate the renderer store.
+    // Wait for the boot read of `app:userHome` to populate the store.
     await win.waitForFunction(
       () => {
         const s = window.__ccsmStore?.getState?.();
-        return !!s && Array.isArray(s.historyRecentCwds) && s.historyRecentCwds.length > 0;
+        return !!s && typeof s.userHome === 'string' && s.userHome.length > 0;
       },
       null,
       { timeout: 15_000 }
     );
 
-    // Sanity-check that the IPC ranked frequency-top correctly. If THIS
-    // fails, the bug is in the scanner / deriveRecentCwds, not in the
-    // store fallback chain.
     const seeded = await win.evaluate(() => {
       const s = window.__ccsmStore.getState();
-      return { historyRecentCwds: s.historyRecentCwds };
+      return { userHome: s.userHome };
     });
-    log(`seeded historyRecentCwds[0]=${seeded.historyRecentCwds[0]}`);
-    if (seeded.historyRecentCwds[0] !== 'D:/work/repo-a') {
-      throw new Error(`scanner regression: historyRecentCwds[0] should be D:/work/repo-a; got ${JSON.stringify(seeded.historyRecentCwds)}`);
+    log(`seeded userHome=${seeded.userHome}`);
+    if (seeded.userHome !== fakeHome && seeded.userHome.replace(/\\/g, '/') !== fakeHome.replace(/\\/g, '/')) {
+      throw new Error(`expected userHome to be sandboxed HOME ${fakeHome}; got ${seeded.userHome}`);
     }
 
-    // Now plant the bug-repro state in the store:
-    //  1. an existing session in the focused group with cwd 'c:/x'
-    //     (mimics user's stale prior session that's leaking via groupRecentCwd)
-    //  2. recentProjects[0].path === 'c:/x' (mimics a stale chip pick)
-    //  3. focusedGroupId points to that group so createSession targets it
-    //
-    // The freq-vote winner is `D:/work/repo-a`; assertion below requires the
-    // new session to land on that, NOT on `c:/x`.
     const created = await win.evaluate(() => {
       const st = window.__ccsmStore;
+      // Plant adversarial state: a stale prior session in the focused group
+      // with a non-home cwd, plus a recentProjects entry. Per spec, NONE of
+      // those should leak into the new-session default — only userHome wins.
       st.setState({
         sessions: [{
-          id: 's-stale',
-          name: 'stale prior',
-          state: 'idle',
-          cwd: 'c:/x',
-          model: 'claude-opus-4-7[1m]',
-          groupId: 'g-default',
-          agentType: 'claude-code',
+          id: 's-stale', name: 'stale', state: 'idle', cwd: 'C:/some-old-dir',
+          model: 'claude-opus-4-7[1m]', groupId: 'g-default', agentType: 'claude-code',
         }],
         groups: [{ id: 'g-default', name: 'Sessions', collapsed: false, kind: 'normal' }],
         activeId: 's-stale',
         focusedGroupId: 'g-default',
-        model: '',
-        recentProjects: [{ id: 'p-stale', name: 'x', path: 'c:/x' }],
+        model: 'persisted-old-model',
+        recentProjects: [{ id: 'p-stale', name: 'old', path: 'D:/stale-proj' }],
       });
       st.getState().createSession();
       const s = st.getState();
-      // createSession prepends, so the new session is index 0; the stale
-      // one is index 1.
       const newSession = s.sessions[0];
-      return { cwd: newSession?.cwd, allCwds: s.sessions.map(x => x.cwd) };
+      return { cwd: newSession?.cwd, userHome: s.userHome };
     });
-    log(`createSession() produced cwd=${created.cwd} (all session cwds: ${JSON.stringify(created.allCwds)})`);
+    log(`createSession() produced cwd=${created.cwd} (userHome=${created.userHome})`);
 
-    if (created.cwd !== 'D:/work/repo-a') {
-      throw new Error(`new-session-default-cwd-from-frequency: new session cwd should be the frequency-top D:/work/repo-a; got ${created.cwd}. The stale 'c:/x' from groupRecentCwd / recentProjects shadowed the frequency vote — fix createSession's fallback chain so historyRecentCwds wins.`);
+    if (created.cwd !== created.userHome) {
+      throw new Error(`new session cwd should be userHome (${created.userHome}); got ${created.cwd}. Stale sessions / recentProjects must NOT leak into the default per spec.`);
     }
-    log(`PASS — new session cwd derived from frequency vote, not from stale groupRecentCwd/recentProjects`);
+    log(`PASS — new-session default cwd === userHome`);
   } finally {
     closed = true;
     try { await app.close(); } catch {}
   }
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// CASE: cwd-popover-recent-only-home-on-fresh
+// Fresh sandbox HOME (no prior cwd picks). Open the StatusBar cwd popover
+// and assert the recent list contains exactly one row, equal to userHome.
+// Verifies the popover's recent column is sourced from the ccsm-owned LRU
+// (which falls back to `[homedir()]` when empty), NOT from CLI JSONL scans.
+// ──────────────────────────────────────────────────────────────────────────
+async function caseCwdPopoverRecentOnlyHomeOnFresh({ log, registerDispose }) {
+  const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ccsm-popover-fresh-'));
+  registerDispose(() => { try { fs.rmSync(fakeHome, { recursive: true, force: true }); } catch {} });
+  // Plant CLI JSONL with a totally unrelated cwd to prove it does NOT leak
+  // into the popover's recent column.
+  const projectsRoot = path.join(fakeHome, '.claude', 'projects');
+  fs.mkdirSync(projectsRoot, { recursive: true });
+  const cliCwd = path.join(fakeHome, 'cli-only-dir');
+  const projDir = path.join(projectsRoot, projectKeyFromCwd(cliCwd));
+  fs.mkdirSync(projDir, { recursive: true });
+  const sid = '00000000-0000-4000-8000-000000000aaa';
+  fs.writeFileSync(path.join(projDir, `${sid}.jsonl`), JSON.stringify({
+    type: 'user', parentUuid: null, isSidechain: false, uuid: 'u-1',
+    cwd: cliCwd, sessionId: sid, timestamp: new Date().toISOString(),
+    message: { role: 'user', content: [{ type: 'text', text: 'hi' }] }
+  }) + '\n');
+  log(`planted CLI JSONL fixture with cwd=${cliCwd} (must NOT leak into popover recent)`);
+
+  const ud = isolatedUserData('ccsm-popover-fresh-userdata');
+  registerDispose(ud.cleanup);
+
+  const app = await electron.launch({
+    args: ['.', `--user-data-dir=${ud.dir}`],
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      NODE_ENV: 'production',
+      CCSM_PROD_BUNDLE: '1',
+      HOME: fakeHome,
+      USERPROFILE: fakeHome,
+      CLAUDE_HOME: fakeHome
+    }
+  });
+  let closed = false;
+  registerDispose(async () => { if (!closed) try { await app.close(); } catch {} });
+
+  try {
+    const win = await waitReady(app);
+
+    // Plant a session so the StatusBar (and its CwdPopover) actually mounts.
+    await win.evaluate(() => {
+      window.__ccsmStore.setState({
+        groups: [{ id: 'g1', name: 'Sessions', collapsed: false, kind: 'normal' }],
+        sessions: [{
+          id: 's1', groupId: 'g1', name: 'Test', state: 'idle',
+          cwd: window.__ccsmStore.getState().userHome,
+          cwdMissing: false, model: 'claude-opus-4-7[1m]', agentType: 'claude-code'
+        }],
+        activeId: 's1',
+        tutorialSeen: true,
+      });
+    });
+    await win.waitForTimeout(200);
+
+    const trigger = win.locator('[data-cwd-chip]').first();
+    await trigger.waitFor({ state: 'visible', timeout: 10_000 });
+    await trigger.click();
+
+    const dialog = win.getByRole('dialog');
+    await dialog.waitFor({ state: 'visible', timeout: 5_000 });
+
+    // Wait for recent list to render (loadRecent IPC is async).
+    await win.waitForFunction(
+      () => {
+        const dlg = document.querySelector('[role="dialog"]');
+        if (!dlg) return false;
+        return dlg.querySelectorAll('[role="option"]').length >= 1;
+      },
+      null,
+      { timeout: 5_000 }
+    );
+
+    const options = await dialog.locator('[role="option"]').allTextContents();
+    log(`popover recent options: ${JSON.stringify(options)}`);
+    if (options.length !== 1) {
+      throw new Error(`fresh-install popover should have exactly 1 recent entry (home); got ${options.length}: ${JSON.stringify(options)}. CLI JSONL entries must NOT leak into the popover.`);
+    }
+    // The visible label is `truncateMiddle(homedir())`; assert it ends with
+    // the last segment of fakeHome so we don't depend on truncation specifics.
+    const segs = fakeHome.split(/[\\/]/).filter(Boolean);
+    const tail = segs[segs.length - 1];
+    if (!options[0].includes(tail)) {
+      throw new Error(`fresh-install popover entry should reference home (${fakeHome}, tail "${tail}"); got "${options[0]}"`);
+    }
+    log(`PASS — fresh popover shows only home`);
+  } finally {
+    closed = true;
+    try { await app.close(); } catch {}
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// CASE: cwd-popover-lru-after-user-pick
+// Two-launch probe:
+//   1. Boot with sandboxed HOME, plant a userCwds.push for a non-default
+//      path, close the app.
+//   2. Relaunch into the same user-data dir, open the popover, assert
+//      list[0] = the user-picked path AND list[1] = home.
+// Pins the LRU semantics: user-explicit picks land at the head; home stays
+// as the implicit fallback at the tail.
+// ──────────────────────────────────────────────────────────────────────────
+async function caseCwdPopoverLruAfterUserPick({ log, registerDispose }) {
+  const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ccsm-popover-lru-'));
+  registerDispose(() => { try { fs.rmSync(fakeHome, { recursive: true, force: true }); } catch {} });
+  const ud = isolatedUserData('ccsm-popover-lru-userdata');
+  registerDispose(ud.cleanup);
+
+  const pickedCwd = path.join(fakeHome, 'picked-by-user');
+  fs.mkdirSync(pickedCwd, { recursive: true });
+
+  // ----- Launch 1: seed the pick -----
+  {
+    const app1 = await electron.launch({
+      args: ['.', `--user-data-dir=${ud.dir}`],
+      cwd: ROOT,
+      env: {
+        ...process.env,
+        NODE_ENV: 'production',
+        CCSM_PROD_BUNDLE: '1',
+        HOME: fakeHome,
+        USERPROFILE: fakeHome,
+        CLAUDE_HOME: fakeHome
+      }
+    });
+    try {
+      const win = await waitReady(app1);
+      await win.waitForFunction(
+        () => {
+          const s = window.__ccsmStore?.getState?.();
+          return !!s && typeof s.userHome === 'string' && s.userHome.length > 0;
+        },
+        null,
+        { timeout: 15_000 }
+      );
+      const pushed = await win.evaluate(async (p) => {
+        return await window.ccsm.userCwds.push(p);
+      }, pickedCwd);
+      log(`launch-1: userCwds.push(${pickedCwd}) -> ${JSON.stringify(pushed)}`);
+      if (!Array.isArray(pushed) || pushed[0] !== pickedCwd) {
+        throw new Error(`launch-1 push did not put picked cwd at head; got ${JSON.stringify(pushed)}`);
+      }
+    } finally {
+      try { await app1.close(); } catch {}
+    }
+  }
+
+  // ----- Launch 2: assert popover shows pick at head, home at index 1 -----
+  const app2 = await electron.launch({
+    args: ['.', `--user-data-dir=${ud.dir}`],
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      NODE_ENV: 'production',
+      CCSM_PROD_BUNDLE: '1',
+      HOME: fakeHome,
+      USERPROFILE: fakeHome,
+      CLAUDE_HOME: fakeHome
+    }
+  });
+  let closed = false;
+  registerDispose(async () => { if (!closed) try { await app2.close(); } catch {} });
+
+  try {
+    const win = await waitReady(app2);
+    await win.waitForFunction(
+      () => {
+        const s = window.__ccsmStore?.getState?.();
+        return !!s && typeof s.userHome === 'string' && s.userHome.length > 0;
+      },
+      null,
+      { timeout: 15_000 }
+    );
+
+    const list = await win.evaluate(async () => await window.ccsm.userCwds.get());
+    log(`launch-2 userCwds.get() -> ${JSON.stringify(list)}`);
+    if (!Array.isArray(list) || list.length < 2) {
+      throw new Error(`expected userCwds.get() to return [pickedCwd, ...] including home; got ${JSON.stringify(list)}`);
+    }
+    if (list[0] !== pickedCwd) {
+      throw new Error(`expected list[0] === ${pickedCwd}; got ${list[0]}`);
+    }
+    // Plant a session so popover mounts, then open it and assert visible
+    // ordering matches.
+    await win.evaluate(() => {
+      window.__ccsmStore.setState({
+        groups: [{ id: 'g1', name: 'Sessions', collapsed: false, kind: 'normal' }],
+        sessions: [{
+          id: 's1', groupId: 'g1', name: 'Test', state: 'idle',
+          cwd: window.__ccsmStore.getState().userHome,
+          cwdMissing: false, model: 'claude-opus-4-7[1m]', agentType: 'claude-code'
+        }],
+        activeId: 's1',
+        tutorialSeen: true,
+      });
+    });
+    await win.waitForTimeout(200);
+
+    const trigger = win.locator('[data-cwd-chip]').first();
+    await trigger.waitFor({ state: 'visible', timeout: 10_000 });
+    await trigger.click();
+    const dialog = win.getByRole('dialog');
+    await dialog.waitFor({ state: 'visible', timeout: 5_000 });
+    await win.waitForFunction(
+      () => document.querySelectorAll('[role="dialog"] [role="option"]').length >= 2,
+      null,
+      { timeout: 5_000 }
+    );
+    const options = await dialog.locator('[role="option"]').allTextContents();
+    log(`popover options: ${JSON.stringify(options)}`);
+    const pickedTail = pickedCwd.split(/[\\/]/).filter(Boolean).slice(-1)[0];
+    const homeTail = fakeHome.split(/[\\/]/).filter(Boolean).slice(-1)[0];
+    if (!options[0].includes(pickedTail)) {
+      throw new Error(`popover[0] should reference picked cwd (tail "${pickedTail}"); got "${options[0]}"`);
+    }
+    if (!options[1] || !options[1].includes(homeTail)) {
+      throw new Error(`popover[1] should reference home (tail "${homeTail}"); got "${options[1]}"`);
+    }
+    log(`PASS — popover LRU shows picked cwd at head, home at index 1`);
+  } finally {
+    closed = true;
+    try { await app2.close(); } catch {}
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// CASE: new-session-default-model-ignores-last-pick
+// Spec: in-session model swaps must NOT become the next-NewSession default.
+// settings.json is the only source. Two-launch probe:
+//   1. settings.json `model: "opus[1m]"` → fresh launch → set persisted
+//      global `model` to "claude-sonnet-4-6" (mimics prior pick) → close.
+//   2. Relaunch → createSession → assert new session model === "opus[1m]".
+// ──────────────────────────────────────────────────────────────────────────
+async function caseNewSessionDefaultModelIgnoresLastPick({ log, registerDispose }) {
+  const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ccsm-model-ignore-'));
+  registerDispose(() => { try { fs.rmSync(fakeHome, { recursive: true, force: true }); } catch {} });
+  const claudeDir = path.join(fakeHome, '.claude');
+  fs.mkdirSync(claudeDir, { recursive: true });
+  fs.writeFileSync(path.join(claudeDir, 'settings.json'), JSON.stringify({ model: 'opus[1m]' }, null, 2));
+
+  const ud = isolatedUserData('ccsm-model-ignore-userdata');
+  registerDispose(ud.cleanup);
+
+  // ----- Launch 1: stash a stale persisted global model -----
+  {
+    const app1 = await electron.launch({
+      args: ['.', `--user-data-dir=${ud.dir}`],
+      cwd: ROOT,
+      env: {
+        ...process.env,
+        NODE_ENV: 'production',
+        CCSM_PROD_BUNDLE: '1',
+        HOME: fakeHome,
+        USERPROFILE: fakeHome,
+        CLAUDE_HOME: fakeHome
+      }
+    });
+    try {
+      const win = await waitReady(app1);
+      // Wait for boot to finish so persistence subscriber is wired up.
+      await win.waitForFunction(
+        () => typeof window.__ccsmStore?.getState?.()?.userHome === 'string',
+        null,
+        { timeout: 15_000 }
+      );
+      await win.evaluate(() => {
+        // Mimic a user picking a non-settings model in the StatusBar — the
+        // store's persisted `model` field would catch it.
+        window.__ccsmStore.setState({ model: 'claude-sonnet-4-6' });
+      });
+      // Give the persist debounce time to fire (250ms).
+      await win.waitForTimeout(600);
+      log(`launch-1: stashed persisted global model = "claude-sonnet-4-6"`);
+    } finally {
+      try { await app1.close(); } catch {}
+    }
+  }
+
+  // ----- Launch 2: assert new-session default ignores stash -----
+  const app2 = await electron.launch({
+    args: ['.', `--user-data-dir=${ud.dir}`],
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      NODE_ENV: 'production',
+      CCSM_PROD_BUNDLE: '1',
+      HOME: fakeHome,
+      USERPROFILE: fakeHome,
+      CLAUDE_HOME: fakeHome
+    }
+  });
+  let closed = false;
+  registerDispose(async () => { if (!closed) try { await app2.close(); } catch {} });
+
+  try {
+    const win = await waitReady(app2);
+    await win.waitForFunction(
+      () => typeof window.__ccsmStore?.getState?.()?.claudeSettingsDefaultModel === 'string',
+      null,
+      { timeout: 15_000 }
+    );
+
+    const seeded = await win.evaluate(() => {
+      const s = window.__ccsmStore.getState();
+      return {
+        claudeSettings: s.claudeSettingsDefaultModel,
+        persistedModel: s.model,
+      };
+    });
+    log(`launch-2 seeded: claudeSettings=${seeded.claudeSettings} persistedModel="${seeded.persistedModel}"`);
+    if (seeded.claudeSettings !== 'opus[1m]') {
+      throw new Error(`expected claudeSettingsDefaultModel="opus[1m]"; got ${JSON.stringify(seeded.claudeSettings)}`);
+    }
+    if (seeded.persistedModel !== 'claude-sonnet-4-6') {
+      throw new Error(`launch-2 should have rehydrated persisted global model "claude-sonnet-4-6"; got ${JSON.stringify(seeded.persistedModel)}. Persist round-trip is broken — fix that first.`);
+    }
+
+    const created = await win.evaluate(() => {
+      const st = window.__ccsmStore;
+      st.setState({
+        sessions: [],
+        groups: [{ id: 'g-default', name: 'Sessions', collapsed: false, kind: 'normal' }],
+        activeId: '',
+        focusedGroupId: 'g-default',
+        // Leave persisted `model` as "claude-sonnet-4-6" — the WHOLE point of
+        // this case is to prove createSession ignores it.
+      });
+      st.getState().createSession();
+      const s = st.getState();
+      return { newModel: s.sessions[0]?.model };
+    });
+    log(`createSession() produced model=${created.newModel}`);
+
+    if (created.newModel !== 'opus[1m]') {
+      throw new Error(`new session model should be "opus[1m]" (settings.json), NOT the persisted "claude-sonnet-4-6"; got ${JSON.stringify(created.newModel)}. createSession must read claudeSettingsDefaultModel only.`);
+    }
+    log(`PASS — new-session default model ignores stale persisted global pick`);
+  } finally {
+    closed = true;
+    try { await app2.close(); } catch {}
+  }
+}
+
 
 
 await runHarness({
@@ -2323,30 +2308,33 @@ await runHarness({
     // with sandboxed CLAUDE_CONFIG_DIR + real claude.exe Bash invocation.
     // 桶 3 worker classified as restore-fits-the-multi-launch pattern.
     { id: 'permission-prompt-default-mode', skipLaunch: true, requiresClaudeBin: true, run: casePermissionPromptDefaultMode },
-    // task#293: default cwd on a fresh session derives from frequency
-    // over the last 10 CLI sessions. Pre-launch HOME sandbox + 10 jsonl
-    // fixtures with controlled cwd/model distribution.
-    { id: 'default-cwd-model-from-recent-history', skipLaunch: true, run: caseDefaultCwdModelFromRecentHistory },
-    // dogfood-reported: post-#369, stale `groupRecentCwd` / `recentProjects`
-    // were still shadowing the frequency-vote default (user hit `c:/x` on
-    // every "New session"). This case proves the new-session cwd resolves
-    // to the frequency-top history cwd even when both stale sources are
-    // present in the store.
-    { id: 'new-session-default-cwd-from-frequency', skipLaunch: true, run: caseNewSessionDefaultCwdFromFrequency },
+    // Default cwd is ALWAYS the user's home directory — no fallback chain,
+    // no derivation from CLI history, no inheritance from prior sessions.
+    // (PR fix-default-cwd-home-and-model-settings-only.) Replaces the old
+    // `default-cwd-model-from-recent-history` + `new-session-default-cwd-
+    // from-frequency` cases, which asserted on the now-deleted frequency
+    // vote / recentProjects fallback chain.
+    { id: 'new-session-default-cwd-is-home', skipLaunch: true, run: caseNewSessionDefaultCwdIsHome },
+    // CwdPopover recent column: empty user-cwds list → render `[homedir()]`
+    // only, NOT every cwd that ever appeared in CLI JSONL.
+    { id: 'cwd-popover-recent-only-home-on-fresh', skipLaunch: true, run: caseCwdPopoverRecentOnlyHomeOnFresh },
+    // CwdPopover LRU: picking a non-default cwd lands at the head of the
+    // recent list; home stays as the implicit fallback at index 1.
+    // 2-launch: seed pick → close → relaunch into same user-data dir →
+    // assert popover ordering.
+    { id: 'cwd-popover-lru-after-user-pick', skipLaunch: true, run: caseCwdPopoverLruAfterUserPick },
     // Default model reads ~/.claude/settings.json `model` (the CLI's own
-    // default-model setting) — replaces #369's frequency-vote model logic.
+    // default-model setting). Spec: this is the ONLY source for new-session
+    // default model — no fallback to persisted global pick / connection
+    // profile / first discovered model.
     { id: 'new-session-default-model-from-claude-settings', skipLaunch: true, run: caseNewSessionDefaultModelFromClaudeSettings },
     // The same read must honor `CLAUDE_CONFIG_DIR` (commands-loader.ts:231
     // already does). ccsm pins this env var in production; this case
     // guards against future drift between the two readers.
     { id: 'new-session-default-model-honors-claude-config-dir', skipLaunch: true, run: caseNewSessionDefaultModelHonorsClaudeConfigDir },
-    // Bug #328 follow-up: `listModelsFromSettings()` in list-models-from-settings.ts
-    // is the second consumer of `<configDir>/settings.json` in this module and
-    // had the SAME hard-coded `os.homedir() + '.claude'` fallback that
-    // `readDefaultModelFromSettings()` had pre-#386. The model picker list
-    // therefore silently ignores settings.json under a custom CLAUDE_CONFIG_DIR.
-    // This case mirrors the case above but asserts the IPC `models:list`
-    // result (what populates the picker UI) reflects the sandbox-B settings.
-    { id: 'model-picker-list-honors-claude-config-dir', skipLaunch: true, run: caseModelPickerListHonorsClaudeConfigDir }
+    // In-session model swap (e.g. user picks sonnet for one turn) must NOT
+    // become the next-NewSession default — settings.json is still the
+    // source of truth. Drops the old "persisted global model wins" path.
+    { id: 'new-session-default-model-ignores-last-pick', skipLaunch: true, run: caseNewSessionDefaultModelIgnoresLastPick }
   ]
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -202,11 +202,11 @@ export default function App() {
   const [importOpen, setImportOpen] = React.useState(false);
   const [shortcutsOpen, setShortcutsOpen] = React.useState(false);
 
-  // New sessions are created in-place — no modal. The store seeds `cwd`
-  // from the per-group last-used cwd, falling through to
-  // `recentProjects[0]?.path ?? historyRecentCwds[0] ?? ''` (empty → chip
-  // renders the `(none)` placeholder). Users repick via the StatusBar cwd
-  // chip. See createSession() in stores/store.ts.
+  // New sessions are created in-place — no modal. The store seeds `cwd` from
+  // `userHome` (always-true default per spec). Users repick via the StatusBar
+  // cwd chip; the chosen path lands in the ccsm-owned `userCwds` LRU and
+  // surfaces in the popover's recent column on subsequent opens. See
+  // createSession() in stores/store.ts.
   const newSession = React.useCallback(() => {
     createSession(null);
   }, [createSession]);

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -486,10 +486,10 @@ function SessionRow({ session, active, selected, onSelect, normalGroups }: { ses
 }
 
 export type SidebarProps = {
-  /** Create a new session in-place. The store seeds `cwd` from the
-   *  per-group last-used cwd (falling through to recentProjects, then ''
-   *  which renders the chip's `(none)` placeholder); the user repicks via
-   *  the StatusBar cwd chip. No modal involved — see App.tsx::newSession. */
+  /** Create a new session in-place. The store seeds `cwd` from the user's
+   *  home directory (the always-true default per the new spec); the user
+   *  repicks via the StatusBar cwd chip. No modal involved — see
+   *  App.tsx::newSession. */
   onCreateSession?: () => void;
   onOpenSettings?: () => void;
   onOpenPalette?: () => void;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -165,12 +165,28 @@ declare global {
       >;
 
       /**
-       * Most-recently-used cwds derived from CLI transcripts. Cached in main
-       * via an eager scan at app `ready`, so this resolves quickly even on
-       * first call after window load. Empty array if the scan is still in
-       * flight or no transcripts are present.
+       * Most-recently-used cwds for the StatusBar cwd popover. Sourced from
+       * the ccsm-owned LRU (NOT CLI JSONL scans). Never empty: returns
+       * `[homedir()]` when the user hasn't picked anything yet.
        */
       recentCwds: () => Promise<string[]>;
+
+      /**
+       * `os.homedir()` from the main process. Seeds the always-true default
+       * cwd for new sessions (replaces the old recent-history-derived
+       * default). Resolved once at boot and cached in the renderer store.
+       */
+      userHome: () => Promise<string>;
+
+      /**
+       * ccsm-owned LRU of cwds explicitly chosen by the user. Lives in the
+       * `app_state` SQLite table; capped at 20 entries. Push returns the
+       * post-update list so callers can update local UI without a round-trip.
+       */
+      userCwds: {
+        get: () => Promise<string[]>;
+        push: (p: string) => Promise<string[]>;
+      };
 
       /**
        * Default model from `~/.claude/settings.json`'s `model` field — the

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -177,18 +177,18 @@ type State = {
   groups: Group[];
   recentProjects: RecentProject[];
   /**
-   * Recent cwds derived from CLI transcripts at boot — fallback for fresh
-   * userData where `recentProjects` is empty. Not persisted; rederived each
-   * boot from `~/.claude/projects` via `window.ccsm.recentCwds()`.
+   * Resolved `os.homedir()` from the main process. Seeded once at boot via
+   * `window.ccsm.userHome()`; empty string until the IPC resolves. Used as
+   * the new-session default cwd — replaces the old CLI-history-derived
+   * default per spec: "default cwd is always home, no fallback chains".
    */
-  historyRecentCwds: string[];
+  userHome: string;
   /**
    * Default model from `~/.claude/settings.json` (the CLI's own `--model`
    * default). Seeds the new-session model picker so ccsm picks the same
    * model the user already configured for the CLI. Null until the boot
-   * read resolves or if no `model` field is set — in which case createSession
-   * falls through to the connection profile / first discovered model / SDK
-   * default.
+   * read resolves or if no `model` field is set — in which case
+   * createSession leaves `model` empty and the SDK applies its own default.
    */
   claudeSettingsDefaultModel: string | null;
   activeId: string;
@@ -993,7 +993,7 @@ export const useStore = create<State & Actions>((set, get) => ({
   sessions: [],
   groups: defaultGroups,
   recentProjects: [],
-  historyRecentCwds: [],
+  userHome: '',
   claudeSettingsDefaultModel: null,
   activeId: '',
   focusedGroupId: null,
@@ -1066,12 +1066,8 @@ export const useStore = create<State & Actions>((set, get) => ({
       groups,
       focusedGroupId,
       activeId,
-      model,
-      recentProjects,
-      historyRecentCwds,
+      userHome,
       claudeSettingsDefaultModel,
-      models,
-      connection,
     } = get();
     const isUsable = (gid: string | null | undefined) => {
       if (!gid) return false;
@@ -1093,37 +1089,24 @@ export const useStore = create<State & Actions>((set, get) => ({
     const targetGroupId = ensured.groupId;
     const baseGroups = ensured.groups;
     const id = newSessionId();
-    // task#293 (post-#369 dogfood follow-up): the frequency vote over the
-    // last 10 CLI sessions IS the answer to "where does this user actually
-    // work" — it must win over `groupRecentCwd` (a single stale prior
-    // session in the focused group can otherwise shadow the user's actual
-    // working directory; dogfood hit `c:/x` on every "New session" because
-    // a long-forgotten session in the focused group held that cwd) AND
-    // over `recentProjects[0]?.path` (a one-off chip pick).
-    //
-    // `groupRecentCwd` stays in the chain as a tertiary fallback for the
-    // case where `historyRecentCwds` is empty (fresh-install with no CLI
-    // history) AND `recentProjects` is empty — better to inherit the
-    // group's own recent cwd than fall to ''.
-    const groupRecentCwd = sessions.find(
-      (x) => x.groupId === targetGroupId && !!x.cwd
-    )?.cwd;
-    const defaultCwd =
-      historyRecentCwds[0] ?? recentProjects[0]?.path ?? groupRecentCwd ?? '';
-    let initialModel = model;
-    // Default-model source order:
-    //   1. persisted global `model` (the user's most-recent explicit pick)
-    //   2. CLI `~/.claude/settings.json` `model` — the same value the CLI
-    //      itself reads for `--model` defaulting. Replaces the old PR #369
-    //      frequency vote over recent transcripts, which produced model ids
-    //      that weren't always in our picker list (dogfood: defaulted to
-    //      "claude-opus-4" which doesn't appear anywhere).
-    //   3. connection profile model (endpoint-pinned default)
-    //   4. first discovered model (last-resort, never empty)
-    // When all four are empty the SDK applies its own default at session start.
+    // Default cwd is ALWAYS the user's home directory — no fallback chain,
+    // no inheritance from prior sessions, no derivation from CLI history.
+    // Per spec ("default cwd is home, no fallback chains"): the previous
+    // historyRecentCwds → recentProjects → groupRecentCwd cascade silently
+    // hijacked the new-session cwd from stale state, so we replaced it with
+    // a single deterministic source. The user can repick via the StatusBar
+    // cwd popover; that pick lands in the ccsm-owned `userCwds` LRU and
+    // surfaces in the popover's recent column.
+    const defaultCwd = userHome ?? '';
+    // Default model reads `~/.claude/settings.json` `model` field — the SAME
+    // value the CLI itself reads for `--model` defaulting (PR #386 made the
+    // read CLAUDE_CONFIG_DIR-aware). When unset, leave `model` empty so the
+    // SDK applies its own default at session start. Per spec we explicitly
+    // do NOT consult the persisted global `model`, the connection profile,
+    // or the first discovered model — those silently shadow the CLI default
+    // and produced unselectable picker values in the wild.
+    let initialModel = '';
     if (!initialModel) initialModel = claudeSettingsDefaultModel ?? '';
-    if (!initialModel) initialModel = connection?.model ?? '';
-    if (!initialModel) initialModel = models[0]?.id ?? '';
     const newSession: Session = {
       id,
       name: opts.name?.trim() || 'New session',
@@ -1149,6 +1132,16 @@ export const useStore = create<State & Actions>((set, get) => ({
       groups: nextGroups,
       focusInputNonce: s.focusInputNonce + 1
     }));
+    // If the user explicitly created the session against a non-default cwd
+    // (cwd override differs from home), record it in the ccsm-owned LRU so
+    // it shows in the popover's recent column on subsequent opens. Fire-and-
+    // forget — the IPC is best-effort and the renderer doesn't need the
+    // post-update list (the popover refetches on each open).
+    const finalCwd = newSession.cwd;
+    if (finalCwd && userHome && finalCwd !== userHome) {
+      const api = window.ccsm;
+      void api?.userCwds?.push(finalCwd).catch(() => {});
+    }
   },
 
   renameSession: (id, name) => {
@@ -1415,6 +1408,16 @@ export const useStore = create<State & Actions>((set, get) => ({
         x.id === s.activeId ? { ...x, cwd, cwdMissing: false } : x
       )
     }));
+    // Cwd picks via the StatusBar popover or Browse... button are the
+    // canonical "user explicitly chose this cwd" signal — feed them into
+    // the ccsm-owned LRU so they surface in the popover's recent column on
+    // future opens. Skip the home entry: it's the always-default and lives
+    // in the list as the implicit fallback.
+    const userHome = get().userHome;
+    if (cwd && cwd !== userHome) {
+      const api = window.ccsm;
+      void api?.userCwds?.push(cwd).catch(() => {});
+    }
   },
 
   markSessionCwdMissing: (sessionId, missing) => {
@@ -2660,20 +2663,20 @@ export async function hydrateStore(): Promise<void> {
     }));
   })();
 
-  // Seed history-derived defaults from CLI transcripts + settings. Fresh
-  // Electron userData starts with empty `recentProjects` and no `model`;
-  // without this the new-session picker falls back to '' (chip `(none)`
-  // placeholder) and the first endpoint's first model regardless of what
-  // the user actually uses in the CLI.
+  // Seed boot defaults from main: `userHome` is the always-true default cwd
+  // for new sessions, and `claudeSettingsDefaultModel` is the CLI's own
+  // `--model` default (read from `~/.claude/settings.json`). Both are
+  // best-effort — if the IPC fails, the renderer keeps its empty defaults
+  // and the SDK falls back to its built-ins.
   try {
     const api = window.ccsm;
-    if (api?.recentCwds && api?.defaultModel) {
-      const [recentCwds, defaultModel] = await Promise.all([
-        api.recentCwds(),
+    if (api?.userHome && api?.defaultModel) {
+      const [userHome, defaultModel] = await Promise.all([
+        api.userHome(),
         api.defaultModel(),
       ]);
       useStore.setState({
-        historyRecentCwds: Array.isArray(recentCwds) ? recentCwds : [],
+        userHome: typeof userHome === 'string' ? userHome : '',
         claudeSettingsDefaultModel: typeof defaultModel === 'string' ? defaultModel : null,
       });
     }

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -61,22 +61,22 @@ describe('store: createSession', () => {
     expect(useStore.getState().sessions[1].groupId).toBe(gid);
   });
 
-  it('defaults cwd to most-recent project when caller passes null', () => {
-    useStore.getState().pushRecentProject('C:/Users/me/projects/alpha');
+  it('defaults cwd to userHome when caller passes null', () => {
+    useStore.setState({ userHome: 'C:/Users/me' });
     useStore.getState().createSession(null);
-    expect(useStore.getState().sessions[0].cwd).toBe('C:/Users/me/projects/alpha');
+    expect(useStore.getState().sessions[0].cwd).toBe('C:/Users/me');
   });
 
-  it('falls back to empty cwd (chip renders `(none)` placeholder) when recentProjects + historyRecentCwds are both empty', () => {
-    // task328: previously fell back to '~'. Per T4.b, an unset cwd is now an
-    // explicit empty string so the cwd chip renders the `(none)` placeholder
-    // and the popover does NOT auto-open — the user picks deliberately.
+  it('falls back to empty cwd (chip renders `(none)` placeholder) when userHome is unset', () => {
+    // Boot IPC pending or unavailable — userHome is '' so default cwd is
+    // '' and the chip renders the `(none)` placeholder. The user repicks
+    // via the StatusBar cwd popover.
     useStore.getState().createSession(null);
     expect(useStore.getState().sessions[0].cwd).toBe('');
   });
 
-  it('explicit cwd argument wins over recentProjects default', () => {
-    useStore.getState().pushRecentProject('C:/Users/me/projects/alpha');
+  it('explicit cwd argument wins over userHome default', () => {
+    useStore.setState({ userHome: 'C:/Users/me' });
     useStore.getState().createSession('C:/other/path');
     expect(useStore.getState().sessions[0].cwd).toBe('C:/other/path');
   });
@@ -1419,84 +1419,46 @@ describe('store: openPopover / closePopover (global popover mutex)', () => {
   });
 });
 
-// task328: per-group cwd default — when the user creates a new session in a
-// group, prefill the chip with the most-recent prior cwd from that group.
-// Empty group → fall through to the existing global default chain.
-describe('store: createSession — per-group cwd default (task328)', () => {
-  it('prefills new session cwd with the most-recent session cwd in the same group', () => {
-    const gid = useStore.getState().createGroup('Repo A');
-    useStore.getState().focusGroup(gid);
-    useStore.getState().createSession('/repo/a');
-    useStore.getState().focusGroup(gid);
-    useStore.getState().createSession('/repo/a/sub');
-    // Newest-first ordering: index 0 should be the latest, index 1 the
-    // earlier '/repo/a'. Now create a third session in the same group with
-    // no explicit cwd — it should pick up '/repo/a/sub'.
-    useStore.getState().focusGroup(gid);
+// task#328 / task#293 / task#369 — REMOVED.
+// The previous "per-group cwd default" + "frequency vote" + "recentProjects
+// fallback" behaviors are all gone (PR fix-default-cwd-home-and-model-...).
+// New spec: default cwd is ALWAYS `userHome` regardless of CLI history,
+// recentProjects, or sibling sessions in the same group. Tests for those
+// behaviors have been deleted; the new e2e cases live in scripts/harness-
+// restore.mjs (`new-session-default-cwd-is-home`,
+// `cwd-popover-recent-only-home-on-fresh`, `cwd-popover-lru-after-user-pick`).
+describe('store: createSession — default cwd is always home', () => {
+  it('falls through to "" when userHome is unset (boot IPC pending or unavailable)', () => {
     useStore.getState().createSession(null);
-    const created = useStore.getState().sessions[0];
-    expect(created.groupId).toBe(gid);
-    expect(created.cwd).toBe('/repo/a/sub');
+    expect(useStore.getState().sessions[0].cwd).toBe('');
   });
 
-  it('does not bleed cwd across groups', () => {
-    const gA = useStore.getState().createGroup('A');
-    const gB = useStore.getState().createGroup('B');
-    useStore.getState().focusGroup(gA);
-    useStore.getState().createSession('/repo/a');
-    useStore.getState().focusGroup(gB);
+  it('uses userHome as the new-session default when seeded', () => {
+    useStore.setState({ userHome: '/Users/me' });
     useStore.getState().createSession(null);
-    // Group B has no prior sessions and no recentProjects — should fall
-    // through to '' (chip renders `(none)` placeholder), NOT '/repo/a'.
-    const created = useStore.getState().sessions[0];
-    expect(created.groupId).toBe(gB);
-    expect(created.cwd).toBe('');
+    expect(useStore.getState().sessions[0].cwd).toBe('/Users/me');
   });
 
-  it('explicit cwd argument still wins over per-group default', () => {
-    const gid = useStore.getState().createGroup('A');
-    useStore.getState().focusGroup(gid);
-    useStore.getState().createSession('/repo/a');
-    useStore.getState().focusGroup(gid);
+  it('explicit cwd argument still wins over userHome', () => {
+    useStore.setState({ userHome: '/Users/me' });
     useStore.getState().createSession('/explicit/path');
     expect(useStore.getState().sessions[0].cwd).toBe('/explicit/path');
   });
 
-  it('recentProjects wins over per-group default (frequency-vote priority)', () => {
-    // task#293 follow-up: stale `groupRecentCwd` shadowing the
-    // user's actual working directory was a real dogfood bug — a single
-    // forgotten session in the focused group with cwd 'c:/x' was enough
-    // to make every "New session" land on 'c:/x'. The new priority puts
-    // `historyRecentCwds[0]` (frequency vote) and `recentProjects[0]?.path`
-    // BEFORE `groupRecentCwd` for exactly this reason.
-    useStore.getState().pushRecentProject('/recent/proj');
-    const gid = useStore.getState().createGroup('Fresh');
+  it('does NOT inherit cwd from prior sessions in the same group', () => {
+    useStore.setState({ userHome: '/Users/me' });
+    const gid = useStore.getState().createGroup('Repo A');
+    useStore.getState().focusGroup(gid);
+    useStore.getState().createSession('/repo/a');
     useStore.getState().focusGroup(gid);
     useStore.getState().createSession(null);
-    // No prior sessions in 'Fresh' → recentProjects[0] wins.
-    expect(useStore.getState().sessions[0].cwd).toBe('/recent/proj');
-    // Now create a second session in the same group; per-group default
-    // STILL loses to recentProjects (priority is recentProjects ahead of
-    // groupRecentCwd, since groupRecentCwd is the weakest of the three).
-    useStore.getState().focusGroup(gid);
-    useStore.getState().createSession('/repo/inside-group');
-    useStore.getState().focusGroup(gid);
-    useStore.getState().createSession(null);
-    expect(useStore.getState().sessions[0].cwd).toBe('/recent/proj');
+    expect(useStore.getState().sessions[0].cwd).toBe('/Users/me');
   });
 
-  it('skips sessions with empty cwd when scanning the group', () => {
-    const gid = useStore.getState().createGroup('Mixed');
-    useStore.getState().focusGroup(gid);
-    useStore.getState().createSession('/repo/has-cwd');
-    useStore.getState().focusGroup(gid);
-    // Force an empty-cwd session into the group — simulates a previous
-    // `(none)`-state session.
-    useStore.getState().createSession('');
-    useStore.getState().focusGroup(gid);
+  it('does NOT consult recentProjects for new-session default', () => {
+    useStore.setState({ userHome: '/Users/me' });
+    useStore.getState().pushRecentProject('/recent/proj');
     useStore.getState().createSession(null);
-    // The most-recent (index 0) session has empty cwd; we should skip it
-    // and pick up '/repo/has-cwd'.
-    expect(useStore.getState().sessions[0].cwd).toBe('/repo/has-cwd');
+    expect(useStore.getState().sessions[0].cwd).toBe('/Users/me');
   });
 });


### PR DESCRIPTION
## Summary

Replaces the new-session default cwd/model fallback chains with single deterministic sources per spec.

**CWD:** Always `os.homedir()`. No derivation from CLI history, no group inheritance, no `recentProjects[0]` fallback. Dogfood reported every \"New session\" landing on a stale `c:/x` because the chain silently hijacked from old state.

**Model:** Always `~/.claude/settings.json` `model` (PR #386's CLAUDE_CONFIG_DIR-aware reader). Drops persisted-global / connection-profile / first-discovered fallbacks. Persisted `model` still tracks the user's in-session pick but is NEVER consulted on NewSession.

**Recent cwd popover:** New ccsm-owned LRU (`app:userCwds:get` / `app:userCwds:push`) replaces JSONL-scan derivation. Persisted in SQLite `app_state.userCwds`, capped at 20, case-insensitive dedupe, home always present as fallback. Pushed automatically when the user picks a non-default cwd via popover or Browse.

## Files

- `electron/main.ts` — user-cwd LRU storage + 3 new IPCs (`app:userHome`, `app:userCwds:get`, `app:userCwds:push`); `import:recentCwds` repointed; `deriveRecentCwds` JSONL scan dropped.
- `electron/preload.ts` + `src/global.d.ts` — expose new IPCs to renderer.
- `src/stores/store.ts` (~1100-1130 fix block) — `defaultCwd = userHome ?? ''`, `initialModel = claudeSettingsDefaultModel ?? ''`. Both `createSession` and `changeCwd` push picks to user-owned LRU.
- `src/App.tsx` + `src/components/Sidebar.tsx` — comment cleanup.

## Phase 1 — failing-first reasoning (each new e2e case targets a code path the pre-fix branch hits)

| Case | Pre-fix code path that fails | Asserts |
|---|---|---|
| `new-session-default-cwd-is-home` | `historyRecentCwds[0] ?? recentProjects[0]?.path ?? groupRecentCwd ?? ''` (store.ts:1112) returns the stale-group cwd `C:/some-old-dir` planted in test setup | `createSession.cwd === userHome` |
| `cwd-popover-recent-only-home-on-fresh` | `getRecentCwds()` (main.ts:168) returns `deriveRecentCwds(rows)` derived from CLI JSONL — picks up the planted `cli-only-dir` fixture | popover recent = `[home]` exactly |
| `cwd-popover-lru-after-user-pick` | No `app:userCwds:push` IPC exists in pre-fix, so `userCwds.push(...)` throws | 2-launch persistence: list[0] = picked, list[1] = home |
| `new-session-default-model-from-claude-settings` | (existing case, unchanged — passes pre-fix and post-fix) | settings.json model wins over empty store |
| `new-session-default-model-ignores-last-pick` | `if (!initialModel) initialModel = model` (store.ts:1113) takes the persisted `claude-sonnet-4-6` BEFORE consulting `claudeSettingsDefaultModel` | new session model = settings.json `opus[1m]`, NOT persisted `claude-sonnet-4-6` |

I did not run the pre-fix branch end-to-end (would require store/main revert + re-build); the assertions are designed to falsify the exact pre-fix expressions removed in this PR.

## Removed cases (pre-fix only)

- `default-cwd-model-from-recent-history` (harness-restore) — asserted frequency-vote cwd default; the spec deletes this behavior.
- `new-session-default-cwd-from-frequency` (harness-restore) — same.
- `task328 per-group cwd default` describe block (tests/store.test.ts, 5 tests) — asserted cross-session group cwd inheritance, deleted per spec; replaced by a new `default cwd is always home` describe block (5 tests).

The 2 model-related harness-restore cases are kept as-is (they still match the post-fix behavior).

## Phase 4 — verification

vitest:
\`\`\`
✓ tests/store.test.ts (95 tests)
✓ tests/cwd-popover.test.tsx (14 tests)
Test Files  2 passed (2) | Tests  109 passed (109)
\`\`\`

(Three pre-existing failures in `electron/__tests__/db-hardening.test.ts` are a NODE_MODULE_VERSION mismatch in the dev env — unrelated to this PR.)

e2e (5 cases):
\`\`\`
[case=new-session-default-cwd-is-home] PASS — new-session default cwd === userHome
[case=cwd-popover-recent-only-home-on-fresh] popover recent options: [\"…ccsm-popover-fresh-NT6AvA\"]
[case=cwd-popover-recent-only-home-on-fresh] PASS — fresh popover shows only home
[case=cwd-popover-lru-after-user-pick] launch-2 userCwds.get() -> [\"…\\picked-by-user\",\"…ccsm-popover-lru-Z2Cfsa\"]
[case=cwd-popover-lru-after-user-pick] PASS — popover LRU shows picked cwd at head, home at index 1
[case=new-session-default-model-from-claude-settings] PASS — default model reads ~/.claude/settings.json
[case=new-session-default-model-ignores-last-pick] PASS — new-session default model ignores stale persisted global pick

=== totals: 5 passed, 0 failed, 0 skipped, 5 total ===
\`\`\`

Regression: \`cwd-popover-recent-unfiltered\` (harness-ui) still PASS (uses `import:recentCwds` IPC override which now reads the user-owned LRU).

## Test plan

- [x] vitest store + cwd-popover suites green
- [x] 5 e2e cases (4 new + 1 existing kept) green on `working`-rebased branch
- [x] no regressions in existing cwd-popover-recent-unfiltered case
- [x] tsc --noEmit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)