### PR TITLE
fix(sidebar): add archive option to session context menu (#bug-2)

### DIFF
--- a/scripts/harness-ui.mjs
+++ b/scripts/harness-ui.mjs
@@ -2610,6 +2610,73 @@ async function caseRename({ win, log }) {
   log('session: Enter / Escape / whitespace / click-outside / IME guard; group: Enter / Escape');
 }
 
+// ---------- session-archive ----------
+// BUG-2: session right-click context menu must offer Archive (and Unarchive
+// for sessions already in an archive group). Archiving moves the session
+// into an archive group (auto-creating one if no archive group exists);
+// unarchive moves it back to a normal group.
+async function caseSessionArchive({ win, log }) {
+  await seedStore(win, {
+    groups: [
+      { id: 'g1', name: 'Alpha', collapsed: false, kind: 'normal' }
+    ],
+    sessions: [
+      { id: 's1', name: 'first', state: 'idle', cwd: '~', model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code' }
+    ],
+    activeId: 's1'
+  });
+
+  // Step 1: right-click the session row, assert the menu surfaces an
+  // Archive item (en: "Archive", zh: "归档").
+  const row = win.locator('li[data-session-id="s1"]').first();
+  await row.click({ button: 'right' });
+  const archiveItem = win.getByRole('menuitem', { name: /^(Archive|归档)$/ }).first();
+  await archiveItem.waitFor({ state: 'visible', timeout: 3000 });
+
+  // Step 2: click Archive — session should land in an archive-kind group.
+  await archiveItem.click();
+  await win.waitForTimeout(200);
+
+  const afterArchive = await win.evaluate(() => {
+    const st = window.__ccsmStore.getState();
+    const s = st.sessions.find((x) => x.id === 's1');
+    if (!s) return { found: false };
+    const g = st.groups.find((gr) => gr.id === s.groupId);
+    return { found: true, groupId: s.groupId, groupKind: g?.kind ?? null };
+  });
+  if (!afterArchive.found) throw new Error('session s1 vanished after archive');
+  if (afterArchive.groupKind !== 'archive') {
+    throw new Error(`expected session in archive-kind group, got kind=${afterArchive.groupKind} (groupId=${afterArchive.groupId})`);
+  }
+
+  // Step 3: open the Archived Groups panel so the row becomes interactable,
+  // then right-click and assert the same menu now offers Unarchive.
+  const archivedToggle = win.locator('button[aria-expanded]').filter({ hasText: /Archived Groups|已归档分组/ }).first();
+  await archivedToggle.click();
+  await win.waitForTimeout(150);
+
+  const archivedRow = win.locator('li[data-session-id="s1"]').first();
+  await archivedRow.click({ button: 'right' });
+  const unarchiveItem = win.getByRole('menuitem', { name: /^(Unarchive|取消归档)$/ }).first();
+  await unarchiveItem.waitFor({ state: 'visible', timeout: 3000 });
+  await unarchiveItem.click();
+  await win.waitForTimeout(200);
+
+  const afterRestore = await win.evaluate(() => {
+    const st = window.__ccsmStore.getState();
+    const s = st.sessions.find((x) => x.id === 's1');
+    if (!s) return { found: false };
+    const g = st.groups.find((gr) => gr.id === s.groupId);
+    return { found: true, groupId: s.groupId, groupKind: g?.kind ?? null };
+  });
+  if (!afterRestore.found) throw new Error('session s1 vanished after unarchive');
+  if (afterRestore.groupKind !== 'normal') {
+    throw new Error(`expected session restored to a normal group, got kind=${afterRestore.groupKind} (groupId=${afterRestore.groupId})`);
+  }
+
+  log('archive moves session into archive group; unarchive moves it back to a normal group');
+}
+
 // ---------- terminal ----------
 // Seed a Bash tool block with ANSI-colored output, expand it, and verify the
 // xterm host renders with the payload visible.
@@ -3550,6 +3617,7 @@ await runHarness({
     { id: 'group-add', run: caseGroupAdd },
     { id: 'import-empty-groups', run: caseImportEmptyGroups },
     { id: 'rename', run: caseRename },
+    { id: 'session-archive', run: caseSessionArchive },
     { id: 'terminal', run: caseTerminal },
     { id: 'tool-render-open-in-editor', run: caseToolRenderOpenInEditor },
     // ---- Bucket-7 absorption (final cleanup pass) ----

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -318,6 +318,15 @@ function SessionRow({ session, active, selected, onSelect, normalGroups }: { ses
   const restoreSession = useStore((s) => s.restoreSession);
   const moveSession = useStore((s) => s.moveSession);
   const createGroup = useStore((s) => s.createGroup);
+  const archiveSession = useStore((s) => s.archiveSession);
+  const unarchiveSession = useStore((s) => s.unarchiveSession);
+  // BUG-2: the menu's archive entry flips to Unarchive when this session
+  // already lives under an archive-kind group. Read group kind from the
+  // store so the label stays in sync without threading a prop down.
+  const isArchived = useStore((s) => {
+    const g = s.groups.find((x) => x.id === session.groupId);
+    return g?.kind === 'archive';
+  });
   const toast = useToast();
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: session.id,
@@ -476,6 +485,14 @@ function SessionRow({ session, active, selected, onSelect, normalGroups }: { ses
             </ContextMenuItem>
           </ContextMenuSubContent>
         </ContextMenuSub>
+        <ContextMenuSeparator />
+        <ContextMenuItem
+          onSelect={() =>
+            isArchived ? unarchiveSession(session.id) : archiveSession(session.id)
+          }
+        >
+          {isArchived ? t('common.unarchive') : t('common.archive')}
+        </ContextMenuItem>
         <ContextMenuSeparator />
         <ContextMenuItem danger onSelect={performDelete}>
           {t('common.delete')}

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -495,6 +495,14 @@ type Actions = {
   restoreGroup: (snapshot: GroupSnapshot) => void;
   archiveGroup: (id: string) => void;
   unarchiveGroup: (id: string) => void;
+  /** Move a session into an archive-kind group. Auto-creates an "Archive"
+   *  group on first use if no archive group exists. Inverse of
+   *  `unarchiveSession`. The bottom Archived Groups panel renders the
+   *  resulting group; the user finds the session there. */
+  archiveSession: (id: string) => void;
+  /** Move an archived session back into a normal-kind group (the first
+   *  available, or a freshly created one). Inverse of `archiveSession`. */
+  unarchiveSession: (id: string) => void;
   setGroupCollapsed: (id: string, collapsed: boolean) => void;
 
   appendBlocks: (sessionId: string, blocks: MessageBlock[]) => void;
@@ -1667,6 +1675,67 @@ export const useStore = create<State & Actions>((set, get) => ({
     set((s) => ({
       groups: s.groups.map((g) => (g.id === id ? { ...g, kind: 'normal' } : g))
     }));
+  },
+
+  // BUG-2: session-level archive. Moves the session into an archive-kind
+  // group so it lands in the sidebar's bottom "Archived Groups" panel
+  // (read-only viewer). If no archive group exists, lazily create one named
+  // "Archive" — keeps the data shape uniform (sessions always live under a
+  // group) and avoids introducing a separate per-session `archived` flag.
+  archiveSession: (id) => {
+    set((s) => {
+      const session = s.sessions.find((x) => x.id === id);
+      if (!session) return s;
+      const currentGroup = s.groups.find((g) => g.id === session.groupId);
+      if (currentGroup?.kind === 'archive') return s; // already archived
+      let archiveGroup = s.groups.find((g) => g.kind === 'archive');
+      let groups = s.groups;
+      if (!archiveGroup) {
+        archiveGroup = {
+          id: nextId('g'),
+          name: 'Archive',
+          collapsed: false,
+          kind: 'archive'
+        };
+        groups = [...s.groups, archiveGroup];
+      }
+      const without = s.sessions.filter((x) => x.id !== id);
+      const updated: Session = { ...session, groupId: archiveGroup.id };
+      return { groups, sessions: [...without, updated] };
+    });
+  },
+
+  unarchiveSession: (id) => {
+    set((s) => {
+      const session = s.sessions.find((x) => x.id === id);
+      if (!session) return s;
+      const currentGroup = s.groups.find((g) => g.id === session.groupId);
+      if (currentGroup?.kind !== 'archive') return s; // not archived
+      let target = s.groups.find((g) => g.kind === 'normal');
+      let groups = s.groups;
+      if (!target) {
+        target = {
+          id: nextId('g'),
+          name: 'New group',
+          collapsed: false,
+          kind: 'normal'
+        };
+        groups = [target, ...s.groups];
+      }
+      const without = s.sessions.filter((x) => x.id !== id);
+      const updated: Session = { ...session, groupId: target.id };
+      // Append at the end of the target group so the restored row is visible
+      // at the bottom rather than inserted at index 0 of the global array.
+      let lastIdx = -1;
+      without.forEach((x, i) => {
+        if (x.groupId === target!.id) lastIdx = i;
+      });
+      const insertAt = lastIdx === -1 ? without.length : lastIdx + 1;
+      return {
+        groups,
+        sessions: [...without.slice(0, insertAt), updated, ...without.slice(insertAt)]
+      };
+    });
   },
 
   setGroupCollapsed: (id, collapsed) => {


### PR DESCRIPTION
## Bug

BUG-2 from `docs/dogfood-r1-bugs.md`. Right-clicking a session in the sidebar showed only `Rename | Move to group | Delete` — no Archive option. The dogfood checklist expects users to archive a session and restore it from the Archived Groups panel at the bottom of the sidebar.

## Fix

- **Store**: new `archiveSession(id)` / `unarchiveSession(id)` actions in `src/stores/store.ts`.
  - `archiveSession` moves the session into an archive-kind group; lazily creates a group named `Archive` on first use if none exists. Avoids introducing a separate per-session `archived` flag — sessions stay uniformly parented under a group, and the existing Archived Groups panel renders them for free.
  - `unarchiveSession` moves the session back into the first normal-kind group (creates one named `New group` if none exists).
- **Menu**: new entry between Move-to-group and Delete in the session context menu (`src/components/Sidebar.tsx`). Label flips between `Archive` / `Unarchive` based on the session's current group kind. Reuses the existing `common.archive` / `common.unarchive` i18n keys (en + zh) — no new strings.
- **i18n**: zero new keys. en `Archive` / `Unarchive`, zh `归档` / `取消归档`.

## E2E

New case in the existing `harness-ui.mjs` (per `feedback_e2e_prefer_harness.md` — no new probe file). Seeds a single normal group + session, right-clicks → asserts Archive menu item exists, clicks it, asserts session lands in an archive-kind group, opens the Archived Groups panel, right-clicks again → asserts Unarchive item exists, clicks it, asserts session lands back in a normal group.

```
node scripts/harness-ui.mjs --only=session-archive
```

Reverse-verified by stashing the fix: case fails at `waiting for getByRole('menuitem', { name: /^(Archive|归档)$/ })` (the original bug surface).

## Verification

- `npm run typecheck` — pass
- `npx vitest run tests/store` — 107/107 pass (no store regressions)
- `node scripts/harness-ui.mjs --only=session-archive` — pass

## Before / after (text)

Before — session right-click menu:
```
Rename
Move to group >
---
Delete
```

After — session right-click menu (normal group):
```
Rename
Move to group >
---
Archive
---
Delete
```

After — session right-click menu (archive group):
```
Rename
Move to group >
---
Unarchive
---
Delete
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)