### PR TITLE
revert: 'fix(session): distinct default names from cwd basename (#bug-3)' (#394)

### DIFF
--- a/scripts/harness-ui.mjs
+++ b/scripts/harness-ui.mjs
@@ -2457,82 +2457,6 @@ async function caseImportEmptyGroups({ win, log }) {
   log(`empty groups[] + stale groupId → synthesized group ${synth.id} (nameKey='${synth.nameKey}'); imported session parented + sidebar renders both`);
 }
 
-// ---------- session-default-name-distinct (bug-3) ----------
-// Brand-new sessions used to all show as "New session" in the sidebar — three
-// rows = three identical labels, no way to tell them apart. We now derive the
-// default name from the cwd basename and append `(2)`, `(3)` for collisions.
-// This case drives `createSession` through the store (the same entry point the
-// "New Session" button uses) and asserts the rendered <span> text the user
-// actually sees in the sidebar is unique per row.
-async function caseSessionDefaultNameDistinct({ win, log }) {
-  // Reset to a clean group + no sessions, with a deterministic userHome so
-  // basename is reproducible regardless of dev box.
-  await seedStore(win, {
-    groups: [{ id: 'g-default', name: 'Sessions', collapsed: false, kind: 'normal' }],
-    sessions: [],
-    activeId: '',
-    focusedGroupId: null,
-    userHome: 'C:/Users/jiahuigu',
-  });
-
-  // Helper: read the rendered name span for a given session id.
-  async function rowNameText(sessionId) {
-    return await win.evaluate((sid) => {
-      const li = document.querySelector(`li[data-session-id="${sid}"]`);
-      // First inner span is the name (see SessionRow render). Tolerate the
-      // inline-rename input by falling back to li.textContent.
-      const span = li?.querySelector('span.truncate');
-      return (span?.textContent ?? li?.textContent ?? '').trim();
-    }, sessionId);
-  }
-
-  // Step 1: two new sessions in the home cwd → distinct labels.
-  await win.evaluate(() => {
-    window.__ccsmStore.getState().createSession(null);
-    window.__ccsmStore.getState().createSession(null);
-  });
-  await win.waitForTimeout(150);
-
-  const ids2 = await win.evaluate(() => window.__ccsmStore.getState().sessions.map((s) => s.id));
-  if (ids2.length !== 2) throw new Error(`expected 2 sessions, got ${ids2.length}`);
-  const names2 = await Promise.all(ids2.map(rowNameText));
-  const set2 = new Set(names2);
-  if (set2.size !== 2) {
-    throw new Error(`sidebar names not distinct after 2 home sessions: ${JSON.stringify(names2)}`);
-  }
-  if (!names2.includes('jiahuigu') || !names2.includes('jiahuigu (2)')) {
-    throw new Error(`expected names ['jiahuigu', 'jiahuigu (2)'], got ${JSON.stringify(names2)}`);
-  }
-  // Neither row may show the legacy literal.
-  for (const n of names2) {
-    if (n === 'New session') throw new Error(`row still shows literal 'New session': ${JSON.stringify(names2)}`);
-  }
-
-  // Step 2: third session at a different cwd → its own basename.
-  await win.evaluate(() => {
-    window.__ccsmStore.getState().createSession('C:/temp');
-  });
-  await win.waitForTimeout(150);
-  const ids3 = await win.evaluate(() => window.__ccsmStore.getState().sessions.map((s) => s.id));
-  const names3 = await Promise.all(ids3.map(rowNameText));
-  if (!names3.includes('temp')) {
-    throw new Error(`expected a row named 'temp' from cwd=C:/temp, got ${JSON.stringify(names3)}`);
-  }
-  if (new Set(names3).size !== names3.length) {
-    throw new Error(`sidebar names not distinct after 3 sessions: ${JSON.stringify(names3)}`);
-  }
-
-  // Step 3: cleanup so subsequent cases start with a clean slate.
-  await seedStore(win, {
-    groups: [{ id: 'g-default', name: 'Sessions', collapsed: false, kind: 'normal' }],
-    sessions: [],
-    activeId: '',
-    focusedGroupId: null,
-  });
-
-  log(`distinct names ok: ${JSON.stringify(names2)} → ${JSON.stringify(names3)}`);
-}
-
 // ---------- rename ----------
 // Inline rename for sessions and groups via context menu. Covers the four
 // exit paths InlineRename supports plus IME composition guard.
@@ -3626,7 +3550,6 @@ await runHarness({
     { id: 'group-add', run: caseGroupAdd },
     { id: 'import-empty-groups', run: caseImportEmptyGroups },
     { id: 'rename', run: caseRename },
-    { id: 'session-default-name-distinct', run: caseSessionDefaultNameDistinct },
     { id: 'terminal', run: caseTerminal },
     { id: 'tool-render-open-in-editor', run: caseToolRenderOpenInEditor },
     // ---- Bucket-7 absorption (final cleanup pass) ----

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -1061,29 +1061,6 @@ export const useStore = create<State & Actions>((set, get) => ({
       cwdOrOpts == null || typeof cwdOrOpts === 'string'
         ? { cwd: cwdOrOpts ?? null }
         : cwdOrOpts;
-    // Bug-3: distinct default session names. Without this, every brand-new
-    // session shows "New session" in the sidebar and the user can't tell rows
-    // apart. We derive the default from the cwd basename (matches the cwd chip
-    // label produced by `lastSegment` in CwdPopover) and append `(2)`, `(3)`
-    // ... when a peer session in the store already uses that same label.
-    // Imported sessions and explicit-name callers bypass this entirely.
-    const deriveDefaultName = (cwd: string, takenNames: ReadonlyArray<string>): string => {
-      // Strip `~/` shorthand and trailing slashes, then pick the trailing path
-      // segment. `~` alone or empty cwd → 'New session' literal fallback.
-      const stripped = cwd.replace(/^~[\\/]?/, '').replace(/[\\/]+$/, '');
-      const segs = stripped.split(/[\\/]/).filter(Boolean);
-      const base = segs[segs.length - 1] ?? '';
-      const seed = base || 'New session';
-      const taken = new Set(takenNames);
-      if (!taken.has(seed)) return seed;
-      // Bump `(N)` suffix until unique. We scan against ALL session names (not
-      // just defaults) so a user-renamed session also blocks collisions.
-      for (let n = 2; n < 1000; n++) {
-        const candidate = `${seed} (${n})`;
-        if (!taken.has(candidate)) return candidate;
-      }
-      return seed;
-    };
     const {
       sessions,
       groups,
@@ -1132,12 +1109,7 @@ export const useStore = create<State & Actions>((set, get) => ({
     if (!initialModel) initialModel = claudeSettingsDefaultModel ?? '';
     const newSession: Session = {
       id,
-      name:
-        opts.name?.trim() ||
-        deriveDefaultName(
-          opts.cwd ?? defaultCwd,
-          sessions.map((s) => s.name),
-        ),
+      name: opts.name?.trim() || 'New session',
       state: 'idle',
       cwd: opts.cwd ?? defaultCwd,
       model: initialModel,

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -105,65 +105,6 @@ describe('store: createSession', () => {
     useStore.getState().createSession('~/a');
     expect(useStore.getState().focusInputNonce).toBe(before + 1);
   });
-
-  // Bug-3: distinct default session names. Brand-new sessions inherit the cwd
-  // basename so the sidebar can tell rows apart at a glance, with `(N)` dedupe
-  // when the same cwd produces a collision.
-  describe('default name derivation (bug-3)', () => {
-    it('derives default name from cwd basename', () => {
-      useStore.getState().createSession('C:/projects/foo');
-      expect(useStore.getState().sessions[0].name).toBe('foo');
-    });
-
-    it('strips ~/ shorthand and uses trailing segment', () => {
-      useStore.getState().createSession('~/work/bar');
-      expect(useStore.getState().sessions[0].name).toBe('bar');
-    });
-
-    it('uses userHome basename when cwd defaults to home', () => {
-      useStore.setState({ userHome: 'C:/Users/jiahuigu' });
-      useStore.getState().createSession(null);
-      expect(useStore.getState().sessions[0].name).toBe('jiahuigu');
-    });
-
-    it('appends (N) suffix when basename collides with an existing session', () => {
-      useStore.setState({ userHome: 'C:/Users/jiahuigu' });
-      useStore.getState().createSession(null);
-      useStore.getState().createSession(null);
-      useStore.getState().createSession(null);
-      const names = useStore.getState().sessions.map((s) => s.name).sort();
-      expect(names).toEqual(['jiahuigu', 'jiahuigu (2)', 'jiahuigu (3)']);
-    });
-
-    it('falls back to literal "New session" when cwd is empty', () => {
-      // userHome unset → defaultCwd is '', no basename available.
-      useStore.getState().createSession(null);
-      expect(useStore.getState().sessions[0].name).toBe('New session');
-    });
-
-    it('explicit name wins over cwd-derived default', () => {
-      useStore.getState().createSession({ cwd: 'C:/projects/foo', name: 'Spike' });
-      expect(useStore.getState().sessions[0].name).toBe('Spike');
-    });
-
-    it('dedupes against user-renamed sessions too', () => {
-      useStore.setState({ userHome: 'C:/Users/jiahuigu' });
-      useStore.getState().createSession(null); // 'jiahuigu'
-      useStore.getState().createSession(null); // 'jiahuigu (2)'
-      const id = useStore.getState().sessions[0].id; // most recent (created last)
-      useStore.getState().renameSession(id, 'jiahuigu (5)');
-      useStore.getState().createSession(null);
-      // Existing names: 'jiahuigu', 'jiahuigu (5)'. Next default must skip
-      // both occupied slots. Naive numbering would land on (2); we expect (2)
-      // to be free since the rename freed it, but the new session must NOT
-      // collide with 'jiahuigu (5)'.
-      const names = useStore.getState().sessions.map((s) => s.name).sort();
-      expect(names).toContain('jiahuigu (5)');
-      expect(names).toContain('jiahuigu');
-      // The third (newest) must not duplicate any existing name.
-      expect(new Set(names).size).toBe(names.length);
-    });
-  });
 });
 
 describe('store: deleteSession', () => {


### PR DESCRIPTION
## Why
User confirmed during dogfood r2: BUG-3 ("multiple sessions all named 'New session', cannot distinguish in sidebar") is **by-design**. Auto-deriving name from cwd basename was a wrong fix. Reverting.

Per `feedback_reviewer_flags_ambiguous_requirements.md`: original BUG-3 report was a wrong requirement, caught after merge during dogfood.

## What
- Reverts commit 0977786 (PR #394)
- Drops `deriveDefaultName` helper from `createSession`
- Restores original default name (`'New session'`)
- Drops `session-default-name-distinct` e2e case
- Drops 7 unit tests added by #394

## Verify
- typecheck pass
- store unit tests still green (95 passed, without the 7 deleted)

## Note
Independent of revert-PR-393 (also in flight). Either merge order works.