### PR TITLE
fix(chat): assistant block copy button (#bug5)

### DIFF
--- a/scripts/harness-agent.mjs
+++ b/scripts/harness-agent.mjs
@@ -2540,6 +2540,74 @@ async function caseUserBlockHoverMenu({ win, log }) {
   log('hover reveals 4 actions; Copy -> clipboard; Truncate -> cut keeps clicked user msg + pinned resume');
 }
 
+// ---------- assistant-copy-button ----------
+// Dogfood r2 fp2 bug #5: AssistantBlock had no copy-message button while
+// UserBlock did (parity gap). Mirrors the UserBlock hover-reveal Copy pattern
+// on assistant rows. We seed BOTH a user prompt and an assistant reply, then
+// click the Copy button on the assistant row and assert the clipboard
+// contains the assistant text — NOT the user prompt (regression guard: the
+// bug we're fixing was "no button at all", but the next-most-likely
+// regression is wiring it to the wrong block's text).
+async function caseAssistantCopyButton({ win, log }) {
+  // i18n is global; pin English so aria-label assertions are stable.
+  await win.evaluate(async () => {
+    try { if (window.__ccsmI18n && window.__ccsmI18n.language !== 'en') await window.__ccsmI18n.changeLanguage('en'); } catch {}
+  });
+  const USER_TEXT = 'PROBE_USER_PROMPT please say copy me';
+  const ASSISTANT_TEXT = 'PROBE_ASSISTANT_REPLY copy me';
+  const SID = 's-acopy';
+  const BID = 'a-copy';
+  await win.evaluate(([sid, bid, userText, assistantText]) => {
+    window.__ccsmStore.setState({
+      groups: [{ id: 'g1', name: 'G1', collapsed: false, kind: 'normal' }],
+      sessions: [{ id: sid, name: 's', state: 'idle', cwd: 'C:/x', model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code' }],
+      activeId: sid,
+      messagesBySession: {
+        [sid]: [
+          { kind: 'user', id: 'u-copy', text: userText },
+          { kind: 'assistant', id: bid, text: assistantText }
+        ]
+      }
+    });
+  }, [SID, BID, USER_TEXT, ASSISTANT_TEXT]);
+  await win.waitForTimeout(300);
+
+  const assistantRow = win.locator(`[data-assistant-block-id="${BID}"]`);
+  await assistantRow.waitFor({ state: 'visible', timeout: 5000 });
+
+  await assistantRow.hover();
+  await win.waitForTimeout(250);
+
+  const actions = assistantRow.locator('[data-testid="assistant-block-actions"]');
+  if ((await actions.count()) !== 1) {
+    throw new Error('expected assistant-block-actions row to render (bug #5: no copy button on assistant blocks)');
+  }
+  const opacity = await actions.evaluate((el) => getComputedStyle(el).opacity);
+  if (opacity !== '1') {
+    throw new Error(`expected assistant actions opacity=1 on hover, got ${opacity}`);
+  }
+
+  const copyBtn = actions.locator('button[aria-label="Copy message"]');
+  if ((await copyBtn.count()) !== 1) {
+    throw new Error('expected exactly 1 Copy message button on assistant block');
+  }
+  await copyBtn.click();
+  await win.waitForTimeout(200);
+
+  const clip = await win.evaluate(() =>
+    navigator.clipboard.readText().catch((e) => `ERR:${e.message}`)
+  );
+  if (!clip.includes('PROBE_ASSISTANT_REPLY')) {
+    throw new Error(`clipboard missing assistant text after Copy click (clip=${JSON.stringify(clip.slice(0, 120))})`);
+  }
+  // Regression guard: must NOT have grabbed the user prompt instead.
+  if (clip.includes('PROBE_USER_PROMPT')) {
+    throw new Error(`clipboard wrongly contains user prompt — copy button wired to wrong block (clip=${JSON.stringify(clip.slice(0, 120))})`);
+  }
+
+  log('hover reveals Copy on assistant block; click -> clipboard has assistant text (not user prompt)');
+}
+
 // ---------- cap-pre-main-injects-global (capability demo) ----------
 // Demonstrates `preMain`: stage state in the electron MAIN process via
 // app.evaluate before the case body runs. The case body then reads it back
@@ -5093,6 +5161,7 @@ await runHarness({
     { id: 'sdk-system-subtypes', run: caseSdkSystemSubtypes },
     { id: 'sdk-abort-on-disposed', run: caseSdkAbortOnDisposed },
     { id: 'user-block-hover-menu', run: caseUserBlockHoverMenu },
+    { id: 'assistant-copy-button', run: caseAssistantCopyButton },
     // ---- Per-case capability demos (task #223) ----
     // Each demo exercises one new field on the runner contract; the assertion
     // is intentionally trivial — the value here is locking the API shape, not

--- a/src/components/chat/blocks/AssistantBlock.tsx
+++ b/src/components/chat/blocks/AssistantBlock.tsx
@@ -1,23 +1,46 @@
-import React from 'react';
+import React, { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { Copy, Check } from 'lucide-react';
 import { CodeBlock } from '../../CodeBlock';
 import { Tooltip } from '../../ui/Tooltip';
 import { useTranslation } from '../../../i18n/useTranslation';
 import type { SkillProvenance } from '../../../types';
 
 export function AssistantBlock({
+  id,
   text,
   streaming,
   viaSkill
 }: {
+  id?: string;
   text: string;
   streaming?: boolean;
   viaSkill?: SkillProvenance;
 }) {
   const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+
+  // Mirror UserBlock.handleCopy: writeText with the assistant's plain text
+  // (the same string the user sees rendered as markdown). Silently no-op on
+  // clipboard-blocked environments rather than spamming a toast.
+  async function handleCopy() {
+    if (!text) return;
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard blocked — silently no-op */
+    }
+  }
+
   return (
-    <div className="flex gap-3 text-body" data-type-scale-role="assistant-body">
+    <div
+      className="group relative flex gap-3 text-body"
+      data-type-scale-role="assistant-body"
+      data-assistant-block-id={id}
+    >
       <span className="text-fg-secondary select-none w-3 shrink-0 font-mono font-semibold leading-[22px]">●</span>
       <div className="text-fg-primary min-w-0 leading-[22px]">
         {viaSkill && (
@@ -96,6 +119,27 @@ export function AssistantBlock({
           />
         )}
       </div>
+      {/* Hover-only action row mirroring UserBlock's pattern. Hidden while the
+          assistant is streaming — copying a half-streamed reply would be
+          surprising. focus-within keeps it visible during keyboard tab-through. */}
+      {!streaming && text && (
+        <div
+          data-testid="assistant-block-actions"
+          className="absolute top-0 right-0 flex items-center gap-0.5 opacity-0 transition-opacity duration-150 group-hover:opacity-100 focus-within:opacity-100"
+        >
+          <Tooltip content={copied ? t('chat.userMsgCopied') : t('chat.userMsgCopy')} side="top">
+            <button
+              type="button"
+              aria-label={copied ? t('chat.userMsgCopied') : t('chat.userMsgCopy')}
+              data-copied={copied ? 'true' : 'false'}
+              onClick={handleCopy}
+              className="inline-grid place-items-center h-6 w-6 rounded-md text-fg-tertiary hover:bg-bg-hover hover:text-fg-primary focus-visible:bg-bg-hover focus-visible:outline-none transition-colors"
+            >
+              {copied ? <Check size={13} /> : <Copy size={13} />}
+            </button>
+          </Tooltip>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/chat/renderBlock.tsx
+++ b/src/components/chat/renderBlock.tsx
@@ -27,7 +27,7 @@ export function renderBlock(
     case 'user':
       return <UserBlock id={b.id} text={b.text} images={b.images} sessionId={activeId} />;
     case 'assistant':
-      return <AssistantBlock text={b.text} streaming={b.streaming} viaSkill={b.viaSkill} />;
+      return <AssistantBlock id={b.id} text={b.text} streaming={b.streaming} viaSkill={b.viaSkill} />;
     case 'tool':
       return <ToolBlock name={b.name} brief={b.brief} result={b.result} isError={b.isError} input={b.input} now={opts.now} sessionId={activeId} toolUseId={b.toolUseId} permissionPending={!!(b.toolUseId && opts.permissionPendingToolIds?.has(b.toolUseId))} bashPartialCommand={b.bashPartialCommand} streamingInput={b.streamingInput} />;
     case 'todo':


### PR DESCRIPTION
## Summary
- Dogfood r2 fp2 found assistant message blocks have no copy-to-clipboard button while user blocks have one (UserBlock.tsx:213-220).
- Mirror the UserBlock pattern in AssistantBlock — same i18n keys (`chat.userMsgCopy`/`chat.userMsgCopied`), same hover-reveal placement, same `navigator.clipboard.writeText(text)` handler shape, same a11y attrs.
- Hidden while streaming (copying half-streamed text would surprise) and only shown when text is non-empty.

## Test plan
- [x] New `assistant-copy-button` harness-agent case clicks copy on a real assistant block and asserts clipboard matches the assistant text (with regression guard that user prompt text is NOT in clipboard).
- [x] Case fails on working HEAD without the fix (reverse-verified via stash + rebuild — `data-assistant-block-id` attribute missing, locator timeout 5s).
- [x] Case passes with fix applied (1.2s).
- [ ] Manual screenshot at docs/screenshots/dogfood-r2/fp2-basic-dialog/bug5-fixed.png — skipped due to time; e2e exercises the real Electron + clipboard path which is the same surface the manual would test.

Bundled into harness-agent (per E2E discipline rule: prefer harness over standalone probe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)