### PR TITLE
fix(e2e): harness-restore notify-fallback green

### DIFF
--- a/scripts/harness-restore.mjs
+++ b/scripts/harness-restore.mjs
@@ -782,6 +782,14 @@ async function caseDbCorruptionRecovery({ log, registerDispose }) {
 // Pre-launch fixture: rename `node_modules/electron-windows-notifications` so
 // the WindowsAdapter's require() throws MODULE_NOT_FOUND. Sandboxes HOME so
 // the dev's real ~/.claude isn't touched. From probe-e2e-notify-fallback.mjs.
+//
+// What this guards: the `notify:availability` IPC handler must report
+// available=false + a non-empty error string when the native module can't
+// load, so in-app banner fallback can take over silently. PR #354
+// deliberately removed the Settings → Notifications "module status" banner
+// (settings simplified to enabled+sound only — silent fallback is the design
+// intent). We no longer assert any user-facing UI for this case; the IPC
+// contract is the only contract.
 // ──────────────────────────────────────────────────────────────────────────
 async function caseNotifyFallback({ log, registerDispose }) {
   const notifyDir = path.join(ROOT, 'node_modules', 'electron-windows-notifications');
@@ -869,46 +877,9 @@ async function caseNotifyFallback({ log, registerDispose }) {
       throw new Error(`expected error to be non-empty string — got ${JSON.stringify(ipcResult)}`);
     }
 
-    const sidebarBtn = win.getByRole('button', { name: /^settings$/i }).first();
-    await sidebarBtn.waitFor({ state: 'visible', timeout: 5000 });
-    await sidebarBtn.click();
-
-    const dialog = win.getByRole('dialog');
-    await dialog.waitFor({ state: 'visible', timeout: 3000 });
-
-    const notifTab = dialog.getByRole('tab', { name: /^notifications$/i });
-    await notifTab.waitFor({ state: 'visible', timeout: 2000 });
-    await notifTab.click();
-
-    const status = win.locator('[data-testid="notifications-module-status"]');
-    await status.waitFor({ state: 'visible', timeout: 3000 });
-    await win.waitForFunction(
-      () => {
-        const el = document.querySelector('[data-testid="notifications-module-status"]');
-        return el && el.getAttribute('data-available') === 'false';
-      },
-      null,
-      { timeout: 5000 }
-    );
-
-    const text = (await status.textContent())?.trim() ?? '';
-    if (!text) throw new Error('notifications-module-status indicator was empty');
-    const lower = text.toLowerCase();
-    if (!lower.includes('native notification module')) {
-      throw new Error(`fallback message missing "native notification module": "${text}"`);
-    }
-    if (!lower.includes('in-app banners')) {
-      throw new Error(`fallback message missing "in-app banners": "${text}"`);
-    }
-    for (const word of text.split(/\s+/)) {
-      if (word.length > 3 && /^[A-Z]+$/.test(word) && word !== 'CCSM') {
-        throw new Error(`fallback message contains uppercase word "${word}" (no SCREAMING UI): "${text}"`);
-      }
-    }
-
     if (rendererErrors.length > 0) throw new Error(`renderer logged errors:\n  ${rendererErrors.join('\n  ')}`);
     if (mainErrors.length > 0) throw new Error(`main process errors:\n  ${mainErrors.join('\n  ')}`);
-    log(`Settings banner reads: "${text}"`);
+    log(`notify:availability reports available=false with error: "${ipcResult.error}"`);
   } finally {
     closed = true;
     try { await app.close(); } catch {}


### PR DESCRIPTION
## Summary
- `harness-restore::notify-fallback` was timing out on `[data-testid=\"notifications-module-status\"]`.
- PR #354 (notif settings simplified to enabled + sound only) deliberately removed that banner — silent fallback to in-app banners is the design intent.
- Drop the dead UI assertion; keep the `notify:availability` IPC contract assertion (available=false + non-empty error string) as the real contract. Documented rationale inline so the next Settings refactor isn't blamed.

## Root cause
`scripts/harness-restore.mjs:884` waited on `locator('[data-testid=\"notifications-module-status\"]')`. After PR #354 (merged 2026-04-26) the Settings → Notifications panel no longer renders that element, so the locator could never become visible — 3s timeout.

## Fix
`scripts/harness-restore.mjs` (`caseNotifyFallback`):
- Removed the Settings sidebar → notifications-tab → module-status assertion block (38 lines).
- Kept the existing IPC assertion (`available === false`, `error` is non-empty string), the renderer/main error-log assertions, and updated the success log to print the IPC error string instead of the now-gone banner text.
- Added a header comment pinning the rationale to PR #354 so future refactors know the IPC contract is the only contract.

Net diff: -38 / +9 in one file. No src/ changes.

## Test plan
- [x] Phase 0: confirmed branch + dirty file match killed-worker state.
- [x] Phase 1 (sanity, with fix): `node scripts/harness-restore.mjs --only=notify-fallback` → **OK** in 3.7s.
- [x] Phase 2 (neighbor regression): full `node scripts/harness-restore.mjs` → **15 passed, 0 failed, 0 skipped** (100.5s wall).
- [x] Phase 3: `npm run typecheck` → clean.
- [x] Reverse-verify: `git stash push scripts/harness-restore.mjs` → re-run only=notify-fallback → **FAIL** with the original `locator(...notifications-module-status...) Timeout 3000ms exceeded` at line 884. Stash popped, fix back in place.

Pre-fix failure log (reverse-verify):
```
[case=notify-fallback] FAIL: locator.waitFor: Timeout 3000ms exceeded.
Call log:
  - waiting for locator('[data-testid=\"notifications-module-status\"]') to be visible
=== totals: 0 passed, 1 failed, 0 skipped, 1 total ===
```

Post-fix pass log:
```
[case=notify-fallback] notify:availability reports available=false with error: \"ccsm/notify: failed to load electron-windows-notifications (Cannot find module 'electron-windows-notifications'...)\"
[case=notify-fallback] OK
=== totals: 1 passed, 0 failed, 0 skipped, 1 total ===
```