### PR TITLE
fix(chat): wrap unbreakable long lines in assistant prose (#fp11-F)

### DIFF
--- a/scripts/harness-ui.mjs
+++ b/scripts/harness-ui.mjs
@@ -15,6 +15,7 @@
 //   - popover-cross-dismiss                (popover-mutex / #221)
 //   - type-scale-snapshot                  (#225, 4-step type token system)
 //   - chat-user-assistant-contrast         (#345, dogfood: user vs assistant rail)
+//   - assistant-long-line-wraps            (fp11 Check F, long unbreakable run wraps)
 //   - banner-i18n-toggle                   (banner i18n)
 //   - toast-a11y                           (#298 follow-up)
 //   - cwd-popover-recent-unfiltered        (probe-e2e-cwd-popover-recent-unfiltered)
@@ -700,6 +701,76 @@ async function caseChatUserAssistantContrast({ win, log }) {
   }
 
   log(`user.border=${probe.user.borderLeftWidth}@${probe.user.borderLeftColor} user.prefix=${probe.user.prefixColor}/${probe.user.prefixWeight} assistant.prefix=${probe.assistant.prefixColor}`);
+}
+
+// ---------- assistant-long-line-wraps ----------
+// fp11 dogfood Check F: when the assistant emits a single 500-char run with
+// no whitespace (URL, hash, "aaaa..."), the `<p>` must wrap inside the chat
+// column instead of pushing the whole row into horizontal scroll. Without
+// `overflow-wrap: anywhere` on the prose `<p>`, the default `word-break:
+// normal` + `overflow-wrap: normal` leaves unbreakable runs intact and the
+// assistant block's scrollWidth balloons to ~4× clientWidth (4297 vs 1006
+// in the original repro).
+//
+// Reverse-verify: drop `[overflow-wrap:anywhere]` from the `<p>` className
+// in src/components/chat/blocks/AssistantBlock.tsx; this case must FAIL on
+// the scrollWidth-overflow check.
+async function caseAssistantLongLineWraps({ win, log }) {
+  const longRun = 'a'.repeat(500);
+  await win.evaluate((text) => {
+    window.__ccsmStore.setState({
+      groups: [{ id: 'g1', name: 'G1', collapsed: false, kind: 'normal' }],
+      sessions: [{ id: 's1', name: 'session-one', state: 'idle', cwd: 'C:/x', model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code' }],
+      activeId: 's1',
+      messagesBySession: {
+        s1: [
+          { kind: 'assistant', id: 'm-asst-long', text }
+        ]
+      }
+    });
+  }, longRun);
+  await win.waitForTimeout(300);
+
+  const probe = await win.evaluate(() => {
+    const block = document.querySelector('[data-type-scale-role="assistant-body"]');
+    if (!block) return null;
+    // Walk to the `<p>` ReactMarkdown rendered inside the prose container.
+    const p = block.querySelector('p');
+    return {
+      blockScrollWidth: block.scrollWidth,
+      blockClientWidth: block.clientWidth,
+      pScrollWidth: p ? p.scrollWidth : null,
+      pClientWidth: p ? p.clientWidth : null,
+      pOverflowWrap: p ? getComputedStyle(p).overflowWrap : null
+    };
+  });
+
+  if (!probe) throw new Error('assistant-body block not found in DOM');
+
+  const failures = [];
+  // Allow 2px slack for sub-pixel rounding.
+  if (probe.blockScrollWidth > probe.blockClientWidth + 2) {
+    failures.push(
+      `assistant block horizontal overflow: scrollWidth=${probe.blockScrollWidth} > clientWidth=${probe.blockClientWidth} (expected wrap)`
+    );
+  }
+  if (probe.pScrollWidth != null && probe.pScrollWidth > probe.pClientWidth + 2) {
+    failures.push(
+      `assistant <p> horizontal overflow: scrollWidth=${probe.pScrollWidth} > clientWidth=${probe.pClientWidth}`
+    );
+  }
+  if (probe.pOverflowWrap !== 'anywhere') {
+    failures.push(`assistant <p> overflow-wrap should be 'anywhere', got '${probe.pOverflowWrap}'`);
+  }
+
+  if (failures.length > 0) {
+    throw new Error(
+      'assistant long-line wrap regression:\n  - ' + failures.join('\n  - ') +
+      '\n  probe=' + JSON.stringify(probe)
+    );
+  }
+
+  log(`block ${probe.blockScrollWidth}/${probe.blockClientWidth} p ${probe.pScrollWidth}/${probe.pClientWidth} overflow-wrap=${probe.pOverflowWrap}`);
 }
 
 // ---------- banner-i18n-toggle ----------
@@ -3477,6 +3548,7 @@ await runHarness({
     { id: 'popover-cross-dismiss', run: casePopoverCrossDismiss },
     { id: 'type-scale-snapshot', run: caseTypeScaleSnapshot },
     { id: 'chat-user-assistant-contrast', run: caseChatUserAssistantContrast },
+    { id: 'assistant-long-line-wraps', run: caseAssistantLongLineWraps },
     { id: 'banner-i18n-toggle', run: caseBannerI18nToggle },
     { id: 'toast-a11y', run: caseToastA11y },
     { id: 'cwd-popover-recent-unfiltered', run: caseCwdPopoverRecentUnfiltered },

--- a/src/components/chat/blocks/AssistantBlock.tsx
+++ b/src/components/chat/blocks/AssistantBlock.tsx
@@ -56,7 +56,16 @@ export function AssistantBlock({
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}
           components={{
-            p: ({ children }) => <p className="whitespace-pre-wrap mb-2 last:mb-0">{children}</p>,
+            // `[overflow-wrap:anywhere]` — long unbreakable runs (URLs, hashes,
+            // a 500-char glob of one letter) must wrap inside the chat column,
+            // otherwise the assistant prose forces horizontal scroll on the
+            // whole row (fp11 dogfood Check F: scrollWidth=4297 vs
+            // clientWidth=1006). `anywhere` is preferred over `break-word`
+            // because it contributes to min-content sizing — necessary inside
+            // the parent `flex` + `min-w-0` container so the inner div
+            // actually shrinks. <pre> code blocks keep their own
+            // `overflow-x-auto` and are not affected by this rule.
+            p: ({ children }) => <p className="whitespace-pre-wrap [overflow-wrap:anywhere] mb-2 last:mb-0">{children}</p>,
             code: ({ className, children, ...props }: React.HTMLAttributes<HTMLElement> & { node?: unknown; children?: React.ReactNode }) => {
               const isInline = !className?.startsWith('language-');
               const { node: _node, ...rest } = props as { node?: unknown } & Record<string, unknown>;


### PR DESCRIPTION
## Bug

fp11 dogfood Check F (PR #404 findings.json): user prompt `output a single line of 500 'a' characters` produces an assistant block whose `scrollWidth=4297` vs `clientWidth=1006` — ~4x horizontal overflow that pushes the entire chat row sideways and breaks the no-bubble density philosophy.

## Repro

1. Send any single-line response with no whitespace (500 'a' chars, a long URL, a long hash, a base64 blob).
2. Observe the chat row gains a horizontal scrollbar; the run does not wrap.

## Root cause

`AssistantBlock.tsx` rendered the markdown `<p>` with `whitespace-pre-wrap` only. That preserves newlines but the default `word-break: normal` + `overflow-wrap: normal` will not break a run that contains no break opportunity. The flex parent (`flex gap-3` + inner `min-w-0`) then stretches to fit the unbreakable child.

## Fix

Add `[overflow-wrap:anywhere]` to the prose `<p>` className.

**Why `anywhere` over `break-word`:** `anywhere` contributes to min-content sizing, so the inner flex child with `min-w-0` actually shrinks below the long word's width. `break-word` only breaks once the line genuinely overflows AND does not help min-content — leaves flex parents stretched in some configurations. Both are equivalent visually on prose; `anywhere` is the safer choice in this layout.

**Why only `<p>`:** `<pre>` blocks keep `overflow-x-auto whitespace-pre` — code should scroll, not break mid-token. Inline `<code>` is unchanged. Tables already wrap their own `overflow-x-auto`. Long URLs in `<a>` inside `<p>` inherit the rule, which is what we want.

## E2E

New `harness-ui` case: `assistant-long-line-wraps`.

- Seeds one assistant message with `'a'.repeat(500)`.
- Asserts `assistant-body` block + inner `<p>`: `scrollWidth <= clientWidth + 2`.
- Asserts computed `overflow-wrap === 'anywhere'` (catches anyone replacing the rule with a no-op or removing it).

**Reverse-verified:** stashed the AssistantBlock change, rebuilt, ran the case — FAIL with `scrollWidth=4235 / clientWidth=1044 / overflow-wrap=normal` (same signature as the dogfood probe). Restored the fix — PASS with `block 1044/1044 p 1020/1020 overflow-wrap=anywhere`.

Also re-ran nearby cases `chat-user-assistant-contrast` + `type-scale-snapshot` — both green, no regression.

## Test plan

- [x] `node scripts/harness-ui.mjs --only=assistant-long-line-wraps` passes
- [x] Reverse-verify: case fails on origin/working HEAD with the dogfood overflow signature
- [x] `chat-user-assistant-contrast` + `type-scale-snapshot` still green
- [ ] Manual: Chinese / Japanese / mixed-script prose still wraps cleanly (fp11 Check A + E remain PASS — `overflow-wrap: anywhere` does not change CJK wrapping which already had break opportunities)