### PR TITLE
docs(dogfood): translate fp11/fp13 report narrative to English

### DIFF
--- a/docs/dogfood-r2-fp13-report.md
+++ b/docs/dogfood-r2-fp13-report.md
@@ -1,4 +1,4 @@
-# Dogfood r2 fp13 — 细节抠 (truncate / cwd / token / cost / pill / effort)
+# Dogfood r2 fp13 — detail audit (truncate / cwd / token / cost / pill / effort)
 
 Branch: `dogfood-r2-fp13` off `origin/working` (HEAD c5d7209 — post #406)
 Binary: installed `C:/Users/jiahuigu/AppData/Local/Programs/CCSM/CCSM.exe` (older bundle, predates #397/#403/#405/#406)


### PR DESCRIPTION
## Summary

Translate Chinese narrative in dogfood reports to English, per project rule that GitHub-committed content must be English (i18n bundle target strings excepted).

## Changes

- `docs/dogfood-r2-fp13-report.md` line 1: `细节抠` → `detail audit` (section title, narrative)

## What was preserved (test evidence, not narrative)

`docs/dogfood-r2-fp11-report.md` contains Chinese strings that are **probe inputs** and **model output excerpts** being verified by the report:

- Line 27: probe prompt `用三句话介绍一下今天天气怎么测，很感谢` — test fixture
- Lines 30-33: model reply excerpt — evidence the Chinese round-trip works
- Line 99: mixed-script probe `summarize 这段内容: hello 世界 こんにちは` — test fixture
- Lines 104-105: model reply excerpt — evidence mixed CJK + Latin renders cleanly

Touching these would destroy the authenticity of the i18n verification report.

## Test plan

- [x] Verified no narrative CJK remains outside test-evidence contexts (grep `[\p{Han}\p{Hiragana}\p{Katakana}]`)
- [x] Markdown structure / table formatting preserved