### PR TITLE
chore(ci): scope CI to PRs targeting main; release windows-only + manual-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,7 @@ name: CI
 on:
   workflow_dispatch:
   pull_request:
-    branches: [working, main]
-  push:
-    branches: [working, main]
+    branches: [main]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 
+# CI minutes are scarce — release artifacts are produced locally and
+# uploaded via `gh release create`. Re-enable the tag trigger once we
+# have CI budget back; until then, manual workflow_dispatch only.
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
     inputs:
       tag:
@@ -48,10 +48,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
-            platform: linux
-          - os: macos-latest
-            platform: mac
           - os: windows-latest
             platform: win
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary

Scope CI tighter to save GitHub Actions minutes; prepare for v0.1.0 windows-only release that produces artifacts locally.

## Changes

**ci.yml**
- pull_request: only on PRs targeting main (was [working, main])
- push trigger removed

**release.yml**
- build matrix reduced to windows-latest only (was linux + mac + win)
- on-tag push trigger removed; workflow_dispatch only

## Rationale

CI minutes are scarce this cycle. Feature -> working PRs no longer burn minutes; the working -> main PR is the single full-suite gate. v0.1.0 ships windows-only and the .exe is built locally + pushed via `gh release create`. Re-enable broader CI + on-tag release once budget recovers.

## Test plan

- [x] ci.yml syntax valid (yaml)
- [x] release.yml still has workflow_dispatch path for manual builds
- [x] Linux/mac steps left in release.yml so future restore is matrix-only