### PR TITLE
fix(chatstream): hoist Footer so streaming ticks don't reset thinking-dots animation

### DIFF
--- a/scripts/harness-ui.mjs
+++ b/scripts/harness-ui.mjs
@@ -3794,6 +3794,95 @@ async function caseStartupPaintsBeforeHydrate({ win, log }) {
   );
 }
 
+// ---------- chatstream-footer-stable ----------
+// Regression for task #407 (ChatStream perf-1 follow-up). Pre-fix: `Footer`
+// was defined inside the `ChatStream` function body, so every render produced
+// a fresh component identity for `<Virtuoso components={{ Footer }} />`,
+// which remounted the Footer subtree on every store tick (~10 Hz while
+// streaming). The thinking-dots `motion.div` therefore restarted its
+// opacity-pulse cycle on every tick, looking like a stuck/broken animation.
+// Fix: hoist `Footer` to module scope and pass dynamic state via Virtuoso's
+// `context` prop. This case pins the contract: the thinking-dots DOM node
+// MUST persist across multiple store ticks while the streaming/thinking
+// condition is unchanged.
+async function caseChatStreamFooterStable({ win, log }) {
+  // Seed an active session in the "thinking" state (running, last block is
+  // user, no permission gate) so showThinkingDots resolves to true.
+  await win.evaluate(() => {
+    const store = window.__ccsmStore;
+    store.setState({
+      groups: [{ id: 'g1', name: 'G1', collapsed: false, kind: 'normal' }],
+      sessions: [
+        { id: 's1', name: 'thinking-session', state: 'idle', cwd: 'C:/x', model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code' },
+      ],
+      activeId: 's1',
+      messagesBySession: { s1: [{ kind: 'user', id: 'u1', text: 'hello' }] },
+      runningSessions: { s1: true },
+      startedSessions: { s1: true },
+    });
+  });
+
+  // Wait for the dots to appear.
+  await win.waitForFunction(
+    () => !!document.querySelector('[data-testid="chat-thinking-dots"]'),
+    null,
+    { timeout: 5_000 }
+  );
+
+  // Tag the initial dots node so we can detect remounts: if Footer remounts,
+  // React replaces the DOM element entirely and our marker disappears with
+  // the old node.
+  await win.evaluate(() => {
+    const el = document.querySelector('[data-testid="chat-thinking-dots"]');
+    el.setAttribute('data-footer-stability-marker', '1');
+  });
+
+  // Trigger several store ticks that should NOT cause the thinking-dots to
+  // unmount: append more user-only blocks (lastBlock stays kind='user', so
+  // showThinkingDots stays true), and bump unrelated state. Pre-fix each
+  // setState() rerenders ChatStream → fresh Footer identity → remount.
+  await win.evaluate(async () => {
+    const store = window.__ccsmStore;
+    for (let i = 0; i < 5; i++) {
+      store.setState((s) => ({
+        messagesBySession: {
+          ...s.messagesBySession,
+          s1: [
+            ...s.messagesBySession.s1,
+            { kind: 'user', id: `u-tick-${i}`, text: `tick ${i}` },
+          ],
+        },
+      }));
+      await new Promise((r) => setTimeout(r, 60));
+    }
+  });
+
+  // After the ticks, the marker must still be on the (still-present) dots
+  // node — proving the same DOM element survived all updates.
+  const stable = await win.evaluate(() => {
+    const el = document.querySelector('[data-testid="chat-thinking-dots"]');
+    if (!el) return { present: false, marked: false };
+    return { present: true, marked: el.getAttribute('data-footer-stability-marker') === '1' };
+  });
+
+  if (!stable.present) {
+    throw new Error(
+      '#407 regression: [data-testid="chat-thinking-dots"] vanished after store ticks — ' +
+        'Footer condition flipped unexpectedly during the test or DOM was torn down.'
+    );
+  }
+  if (!stable.marked) {
+    throw new Error(
+      '#407 regression: thinking-dots DOM node was replaced across store ticks — ' +
+        'Footer is remounting on every render (likely defined inside ChatStream() ' +
+        'function body), which restarts the opacity-pulse animation cycle. ' +
+        'Hoist Footer to module scope and pass dynamic state via Virtuoso context.'
+    );
+  }
+
+  log('#407 — thinking-dots DOM node identity stable across 5 store ticks');
+}
+
 // ---------- harness spec ----------
 await runHarness({
   name: 'ui',
@@ -3936,7 +4025,11 @@ await runHarness({
     // Placed last because it calls win.reload() with a 500ms init-script
     // delay on models.list, and the reload + delay perturb the page state
     // for any case that follows.
-    { id: 'startup-paints-before-hydrate', run: caseStartupPaintsBeforeHydrate }
+    { id: 'startup-paints-before-hydrate', run: caseStartupPaintsBeforeHydrate },
+    // chatstream-footer-stable: regression for #407. Pins the contract that
+    // ChatStream's Footer (thinking-dots host) doesn't remount on every
+    // store tick — see caseChatStreamFooterStable for full context.
+    { id: 'chatstream-footer-stable', run: caseChatStreamFooterStable }
   ],
   launch: {
     // CCSM_OPEN_IN_EDITOR_NOOP=1: tells the tool:open-in-editor IPC handler

--- a/src/components/ChatStream.tsx
+++ b/src/components/ChatStream.tsx
@@ -56,6 +56,43 @@ const VirtuosoList = forwardRef<HTMLDivElement, React.HTMLProps<HTMLDivElement>>
   }
 );
 
+// Footer context shape passed through Virtuoso's `context` prop. Hoisting
+// Footer to module scope (rather than defining it inside ChatStream) keeps
+// its component identity stable across renders so Virtuoso doesn't remount
+// the subtree on every store tick — that remount restarts the thinking-dots
+// motion.div animation cycle and makes streaming look broken (#407).
+type FooterContext = {
+  loadError: string | undefined;
+  showThinkingDots: boolean;
+  activeId: string;
+  onRetryLoad: () => void;
+  thinkingLabel: string;
+};
+
+function Footer({ context }: { context?: FooterContext }) {
+  if (!context) return null;
+  const { loadError, showThinkingDots, onRetryLoad, thinkingLabel } = context;
+  return (
+    <>
+      {loadError && (
+        <LoadHistoryErrorBlock message={loadError} onRetry={onRetryLoad} />
+      )}
+      {showThinkingDots && (
+        <motion.div
+          key="thinking-dots"
+          data-testid="chat-thinking-dots"
+          aria-label={thinkingLabel}
+          className="font-mono text-mono-sm text-state-running select-none tracking-[0.2em] leading-none px-4 pb-3"
+          animate={{ opacity: [0.3, 1, 0.3] }}
+          transition={{ duration: 1.2, repeat: Infinity, ease: 'easeInOut' }}
+        >
+          {'· · ·'}
+        </motion.div>
+      )}
+    </>
+  );
+}
+
 export function ChatStream() {
   const { t } = useTranslation();
   const activeId = useStore((s) => s.activeId);
@@ -175,40 +212,28 @@ export function ChatStream() {
 
   // Footer: load-error banner (rare) + thinking dots (frequent). Rendered
   // as Virtuoso's footer so they live inside the scroll container at the
-  // tail and don't get virtualized away.
-  function Footer() {
-    return (
-      <>
-        {loadError && (
-          <LoadHistoryErrorBlock
-            message={loadError}
-            onRetry={() => {
-              useStore.setState((s) => {
-                const nextMsgs = { ...s.messagesBySession };
-                delete nextMsgs[activeId];
-                const nextErrs = { ...s.loadMessageErrors };
-                delete nextErrs[activeId];
-                return { messagesBySession: nextMsgs, loadMessageErrors: nextErrs };
-              });
-              void loadMessages(activeId);
-            }}
-          />
-        )}
-        {showThinkingDots && (
-          <motion.div
-            key="thinking-dots"
-            data-testid="chat-thinking-dots"
-            aria-label={t('chat.thinking', { defaultValue: 'Agent is thinking' })}
-            className="font-mono text-mono-sm text-state-running select-none tracking-[0.2em] leading-none px-4 pb-3"
-            animate={{ opacity: [0.3, 1, 0.3] }}
-            transition={{ duration: 1.2, repeat: Infinity, ease: 'easeInOut' }}
-          >
-            {'· · ·'}
-          </motion.div>
-        )}
-      </>
-    );
-  }
+  // tail and don't get virtualized away. The Footer component itself is
+  // hoisted to module scope (see top of file); dynamic state flows through
+  // Virtuoso's `context` prop so the Footer subtree never remounts on store
+  // ticks — preserving the thinking-dots animation cycle (#407).
+  const onRetryLoad = useMemo(
+    () => () => {
+      useStore.setState((s) => {
+        const nextMsgs = { ...s.messagesBySession };
+        delete nextMsgs[activeId];
+        const nextErrs = { ...s.loadMessageErrors };
+        delete nextErrs[activeId];
+        return { messagesBySession: nextMsgs, loadMessageErrors: nextErrs };
+      });
+      void loadMessages(activeId);
+    },
+    [activeId, loadMessages]
+  );
+  const thinkingLabel = t('chat.thinking', { defaultValue: 'Agent is thinking' });
+  const footerContext = useMemo<FooterContext>(
+    () => ({ loadError, showThinkingDots, activeId, onRetryLoad, thinkingLabel }),
+    [loadError, showThinkingDots, activeId, onRetryLoad, thinkingLabel]
+  );
 
   function itemContent(index: number, m: MessageBlock) {
     return (
@@ -277,6 +302,7 @@ export function ChatStream() {
           // recent block, matching pre-virtualization behavior.
           initialTopMostItemIndex={Math.max(blocks.length - 1, 0)}
           components={{ Scroller: VirtuosoScroller, List: VirtuosoList, Footer }}
+          context={footerContext}
           className="flex-1 min-w-0"
           style={{ height: '100%' }}
           increaseViewportBy={{ top: 600, bottom: 600 }}

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -34,20 +34,21 @@ import { vi } from 'vitest';
 import * as React from 'react';
 vi.mock('react-virtuoso', () => {
   type ItemContent<T> = (index: number, item: T) => React.ReactNode;
-  type Components = {
+  type Components<C> = {
     Scroller?: React.ComponentType<React.HTMLProps<HTMLDivElement>>;
     List?: React.ComponentType<React.HTMLProps<HTMLDivElement>>;
-    Footer?: React.ComponentType;
+    Footer?: React.ComponentType<{ context?: C }>;
   };
-  type Props<T> = {
+  type Props<T, C> = {
     data?: T[];
     itemContent?: ItemContent<T>;
-    components?: Components;
+    components?: Components<C>;
+    context?: C;
     className?: string;
     style?: React.CSSProperties;
   };
-  const Virtuoso = React.forwardRef(function Virtuoso<T>(
-    props: Props<T>,
+  const Virtuoso = React.forwardRef(function Virtuoso<T, C>(
+    props: Props<T, C>,
     _ref: React.ForwardedRef<unknown>
   ) {
     const data = props.data ?? [];
@@ -72,7 +73,7 @@ vi.mock('react-virtuoso', () => {
           )
         )
       ),
-      Footer ? React.createElement(Footer) : null
+      Footer ? React.createElement(Footer, { context: props.context }) : null
     );
   });
   return { Virtuoso };


### PR DESCRIPTION
## Summary

Fixes #407.

PR #413 (perf-1, ChatStream virtualization with react-virtuoso) defined `Footer` inside the `ChatStream()` function body. Every render produced a fresh component identity for `<Virtuoso components={{ Footer }} />`, which caused Virtuoso to remount the Footer subtree on every store tick. During streaming the store updates ~10 times per second, so the `thinking-dots` framer-motion `motion.div` restarted its opacity-pulse cycle on each tick, looking like a broken/jittery indicator.

## Repro (pre-fix)

`node scripts/harness-ui.mjs --only=chatstream-footer-stable` on `working` HEAD:

```
[case=chatstream-footer-stable] FAIL: #407 regression: thinking-dots DOM node was replaced
across store ticks — Footer is remounting on every render (likely defined inside
ChatStream() function body), which restarts the opacity-pulse animation cycle.
```

## Fix

- Hoist `Footer` to module scope in `src/components/ChatStream.tsx` so its component identity is stable across renders.
- Pass dynamic state (`loadError`, `showThinkingDots`, `activeId`, `onRetryLoad`, `thinkingLabel`) through Virtuoso's `context` prop. Per `react-virtuoso` types (`Footer?: ComponentType<ContextProp<Context>>`), Virtuoso forwards `context` into Footer as a prop, so dynamic state still flows in without remounting the subtree.
- Memoize `onRetryLoad` and `footerContext` so context identity only changes when its inputs do.
- Extend the jsdom react-virtuoso shim (`tests/setup.ts`) to forward `context` into the Footer mock so existing component tests keep passing.

## Verification

- `node scripts/harness-ui.mjs --only=chatstream-footer-stable` — passes (case asserts the dots DOM node stays the same across 5 sequential store ticks).
- `npm run typecheck` — clean.
- `npm test` — chatstream-thinking-dots suite (5/5) green; full suite green except 3 pre-existing `electron/__tests__/db-hardening.test.ts` failures caused by `better-sqlite3` native binding mismatch in this dev env (`--ignore-scripts` install workaround for unrelated `@nodert-win10-au` build failure). Same 3 failures reproduce on `origin/working` with no diff applied.
- Manually launched the app and confirmed the thinking dots now pulse smoothly while the agent is streaming, with no visible reset on each token-tick (pre-fix the dots flashed on/off rapidly during streaming because the animation kept restarting from opacity 0.3).

## Test plan

- [x] new harness case `chatstream-footer-stable` fails on pre-fix code, passes after fix
- [x] existing `tests/chatstream-thinking-dots.test.tsx` still passes
- [x] manual: dots animate smoothly during real streaming session