### PR TITLE
chore(install): warn on Node version mismatch with build-friendly hint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,6 @@
+# Contributing to ccsm
+
+## Local development
+
+- Use Node 20.x for local builds. CI runs on 20.x.
+- On Windows, native modules require VS Build Tools with C++/CX SDK (full VS 2022, not just BuildTools).

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -23,6 +23,20 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import process from 'node:process';
 
+// Preflight: warn (don't block) when running on a Node major other than 20.
+// Native deps (better-sqlite3, electron-windows-notifications, @nodert-win10-au)
+// build cleanly on Node 20.x. node-gyp 10.x + Node >= 22 trips a `/std:c++20`
+// vs WinRT `/ZW` clash that surfaces as `error C1107: could not find assembly
+// 'platform.winmd'`, even with the full VS 2022 C++/CX SDK installed. We don't
+// pin engines.node so contributors who only touch UI/tests can still
+// `npm install` on newer Node; this warning gives them the clue if it breaks.
+const nodeMajor = Number.parseInt(process.versions.node.split('.')[0], 10);
+if (nodeMajor !== 20) {
+  console.warn(
+    `[postinstall] WARNING: ccsm native deps (better-sqlite3, electron-windows-notifications, @nodert-win10-au) build cleanly on Node 20.x. You're on Node ${process.version}. If you only touch UI/tests, this is fine; if you hit \`node-gyp\` C1107 or \`/std:c++20 /ZW\` errors during install, switch with \`nvm use 20\` and re-run \`npm ci --legacy-peer-deps\`. CI uses Node 20.`,
+  );
+}
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..');
 const isWindows = process.platform === 'win32';


### PR DESCRIPTION
## Summary

Add a non-fatal Node-version preflight to `scripts/postinstall.mjs`. If a contributor runs `npm install` on a Node major other than 20, they now see:

```
[postinstall] WARNING: ccsm native deps (better-sqlite3, electron-windows-notifications, @nodert-win10-au) build cleanly on Node 20.x. You're on Node v24.14.1. If you only touch UI/tests, this is fine; if you hit `node-gyp` C1107 or `/std:c++20 /ZW` errors during install, switch with `nvm use 20` and re-run `npm ci --legacy-peer-deps`. CI uses Node 20.
```

The warning prints before `electron-builder install-app-deps` runs, so any subsequent C1107 has a clear lead-in.

## Why warning, not `engines.node` pin

node-gyp 10.x + Node >= 22 hits a `/std:c++20` vs WinRT `/ZW` clash that surfaces as `error C1107: could not find assembly 'platform.winmd'` — even with the full VS 2022 C++/CX SDK installed. The trap looks like missing tooling but is actually a compiler-flag conflict.

Pinning `engines.node` would block contributors who only touch UI / tests / docs on Node 22/24 from running `npm install` at all. Friendly warning preserves their workflow while giving anyone hitting the native build a clean diagnostic.

CI (`.github/workflows/ci.yml`, `release.yml`) already pins Node 20, so production builds are unaffected.

## Also

Adds a minimal `CONTRIBUTING.md` with a Local development section calling out Node 20.x and the Windows VS 2022 (full, not just BuildTools) C++/CX SDK requirement.

## Test plan

- [x] `node scripts/postinstall.mjs` on Node 24.x prints the warning then continues to normal flow
- [x] No `engines.node` change in `package.json`
- [x] Diff is +20 lines across 2 files

Closes ccsm task #410.