### PR TITLE
perf(chat): memoize AssistantBlock to skip markdown re-parse on store ticks

### DIFF
--- a/src/components/chat/blocks/AssistantBlock.tsx
+++ b/src/components/chat/blocks/AssistantBlock.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import ReactMarkdown from 'react-markdown';
+import ReactMarkdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Copy, Check } from 'lucide-react';
 import { CodeBlock } from '../../CodeBlock';
@@ -7,17 +7,90 @@ import { Tooltip } from '../../ui/Tooltip';
 import { useTranslation } from '../../../i18n/useTranslation';
 import type { SkillProvenance } from '../../../types';
 
-export function AssistantBlock({
-  id,
-  text,
-  streaming,
-  viaSkill
-}: {
+// Hoisted to module scope so React.memo's referential equality on
+// `<ReactMarkdown components={...}>` holds across re-renders. When this object
+// was inline the ChatStream parent would re-create it every store tick, which
+// forced react-markdown to re-parse + re-highlight every visible historical
+// assistant block on every streamed token (5–30ms × N visible blocks).
+const MD_COMPONENTS: Components = {
+  // `[overflow-wrap:anywhere]` — long unbreakable runs (URLs, hashes,
+  // a 500-char glob of one letter) must wrap inside the chat column,
+  // otherwise the assistant prose forces horizontal scroll on the
+  // whole row (fp11 dogfood Check F: scrollWidth=4297 vs
+  // clientWidth=1006). `anywhere` is preferred over `break-word`
+  // because it contributes to min-content sizing — necessary inside
+  // the parent `flex` + `min-w-0` container so the inner div
+  // actually shrinks. <pre> code blocks keep their own
+  // `overflow-x-auto` and are not affected by this rule.
+  p: ({ children }) => <p className="whitespace-pre-wrap [overflow-wrap:anywhere] mb-2 last:mb-0">{children}</p>,
+  code: ({ className, children, ...props }: React.HTMLAttributes<HTMLElement> & { node?: unknown; children?: React.ReactNode }) => {
+    const isInline = !className?.startsWith('language-');
+    const { node: _node, ...rest } = props as { node?: unknown } & Record<string, unknown>;
+    if (isInline) {
+      return (
+        <code
+          className="font-mono text-[0.9em] px-1 py-0.5 rounded bg-bg-elevated text-fg-primary"
+          {...rest}
+        >
+          {children}
+        </code>
+      );
+    }
+    const lang = className?.replace(/^language-/, '') ?? '';
+    const code = Array.isArray(children)
+      ? children.filter((c): c is string => typeof c === 'string').join('')
+      : typeof children === 'string'
+      ? children
+      : '';
+    return <CodeBlock code={code} language={lang} />;
+  },
+  pre: ({ children }) => (
+    <pre className="my-2 p-3 rounded-md bg-bg-elevated border border-border-subtle overflow-x-auto font-mono text-chrome whitespace-pre">
+      {children}
+    </pre>
+  ),
+  ul: ({ children }) => <ul className="list-disc pl-5 my-2 space-y-1">{children}</ul>,
+  ol: ({ children }) => <ol className="list-decimal pl-5 my-2 space-y-1">{children}</ol>,
+  li: ({ children }) => <li className="leading-[22px]">{children}</li>,
+  a: ({ children, href }) => (
+    <a href={href} target="_blank" rel="noreferrer" className="text-accent underline underline-offset-2">
+      {children}
+    </a>
+  ),
+  h1: ({ children }) => <h1 className="text-display font-semibold mt-3 mb-2">{children}</h1>,
+  h2: ({ children }) => <h2 className="text-heading font-semibold mt-3 mb-1.5">{children}</h2>,
+  h3: ({ children }) => <h3 className="text-heading font-medium mt-2 mb-1">{children}</h3>,
+  blockquote: ({ children }) => (
+    <blockquote className="border-l-2 border-border-subtle pl-3 my-2 text-fg-secondary">
+      {children}
+    </blockquote>
+  ),
+  table: ({ children }) => (
+    <div className="my-2 overflow-x-auto">
+      <table className="border-collapse text-chrome">{children}</table>
+    </div>
+  ),
+  th: ({ children }) => (
+    <th className="border border-border-subtle px-2 py-1 text-left font-semibold">{children}</th>
+  ),
+  td: ({ children }) => <td className="border border-border-subtle px-2 py-1 align-top">{children}</td>
+};
+
+const REMARK_PLUGINS = [remarkGfm];
+
+interface AssistantBlockProps {
   id?: string;
   text: string;
   streaming?: boolean;
   viaSkill?: SkillProvenance;
-}) {
+}
+
+function AssistantBlockImpl({
+  id,
+  text,
+  streaming,
+  viaSkill
+}: AssistantBlockProps) {
   const { t } = useTranslation();
   const [copied, setCopied] = useState(false);
 
@@ -53,72 +126,7 @@ export function AssistantBlock({
             </span>
           </Tooltip>
         )}
-        <ReactMarkdown
-          remarkPlugins={[remarkGfm]}
-          components={{
-            // `[overflow-wrap:anywhere]` — long unbreakable runs (URLs, hashes,
-            // a 500-char glob of one letter) must wrap inside the chat column,
-            // otherwise the assistant prose forces horizontal scroll on the
-            // whole row (fp11 dogfood Check F: scrollWidth=4297 vs
-            // clientWidth=1006). `anywhere` is preferred over `break-word`
-            // because it contributes to min-content sizing — necessary inside
-            // the parent `flex` + `min-w-0` container so the inner div
-            // actually shrinks. <pre> code blocks keep their own
-            // `overflow-x-auto` and are not affected by this rule.
-            p: ({ children }) => <p className="whitespace-pre-wrap [overflow-wrap:anywhere] mb-2 last:mb-0">{children}</p>,
-            code: ({ className, children, ...props }: React.HTMLAttributes<HTMLElement> & { node?: unknown; children?: React.ReactNode }) => {
-              const isInline = !className?.startsWith('language-');
-              const { node: _node, ...rest } = props as { node?: unknown } & Record<string, unknown>;
-              if (isInline) {
-                return (
-                  <code
-                    className="font-mono text-[0.9em] px-1 py-0.5 rounded bg-bg-elevated text-fg-primary"
-                    {...rest}
-                  >
-                    {children}
-                  </code>
-                );
-              }
-              const lang = className?.replace(/^language-/, '') ?? '';
-              const code = Array.isArray(children)
-                ? children.filter((c): c is string => typeof c === 'string').join('')
-                : typeof children === 'string'
-                ? children
-                : '';
-              return <CodeBlock code={code} language={lang} />;
-            },
-            pre: ({ children }) => (
-              <pre className="my-2 p-3 rounded-md bg-bg-elevated border border-border-subtle overflow-x-auto font-mono text-chrome whitespace-pre">
-                {children}
-              </pre>
-            ),
-            ul: ({ children }) => <ul className="list-disc pl-5 my-2 space-y-1">{children}</ul>,
-            ol: ({ children }) => <ol className="list-decimal pl-5 my-2 space-y-1">{children}</ol>,
-            li: ({ children }) => <li className="leading-[22px]">{children}</li>,
-            a: ({ children, href }) => (
-              <a href={href} target="_blank" rel="noreferrer" className="text-accent underline underline-offset-2">
-                {children}
-              </a>
-            ),
-            h1: ({ children }) => <h1 className="text-display font-semibold mt-3 mb-2">{children}</h1>,
-            h2: ({ children }) => <h2 className="text-heading font-semibold mt-3 mb-1.5">{children}</h2>,
-            h3: ({ children }) => <h3 className="text-heading font-medium mt-2 mb-1">{children}</h3>,
-            blockquote: ({ children }) => (
-              <blockquote className="border-l-2 border-border-subtle pl-3 my-2 text-fg-secondary">
-                {children}
-              </blockquote>
-            ),
-            table: ({ children }) => (
-              <div className="my-2 overflow-x-auto">
-                <table className="border-collapse text-chrome">{children}</table>
-              </div>
-            ),
-            th: ({ children }) => (
-              <th className="border border-border-subtle px-2 py-1 text-left font-semibold">{children}</th>
-            ),
-            td: ({ children }) => <td className="border border-border-subtle px-2 py-1 align-top">{children}</td>
-          }}
-        >
+        <ReactMarkdown remarkPlugins={REMARK_PLUGINS} components={MD_COMPONENTS}>
           {text}
         </ReactMarkdown>
         {streaming && (
@@ -152,3 +160,23 @@ export function AssistantBlock({
     </div>
   );
 }
+
+// Memoize so historical assistant blocks skip re-rendering (and re-parsing
+// markdown) on every ChatStream store tick. Equality compares the only props
+// that actually change render output: text, streaming flag, id, and a stable
+// scalar key derived from the viaSkill object (its identity churns even when
+// content is unchanged).
+function viaSkillKey(v: SkillProvenance | undefined): string | null {
+  if (!v) return null;
+  return v.path ?? v.name ?? null;
+}
+
+export const AssistantBlock = React.memo(AssistantBlockImpl, (prev, next) => {
+  return (
+    prev.text === next.text &&
+    prev.streaming === next.streaming &&
+    prev.id === next.id &&
+    viaSkillKey(prev.viaSkill) === viaSkillKey(next.viaSkill)
+  );
+});
+AssistantBlock.displayName = 'AssistantBlock';


### PR DESCRIPTION
## Symptom
During assistant streaming, every store tick (new token, tool block update, permission popup) triggers a `ChatStream` re-render. Each re-render forced every visible historical `AssistantBlock` to re-parse + re-highlight its markdown:

- `<ReactMarkdown text={text}>` with an inline `components={{...}}` literal -> reference changed every render -> react-markdown re-walks AST and re-renders all custom renderers (including `<CodeBlock>` with prism highlighting).
- `AssistantBlock` itself had no `React.memo`, so the parent's re-render propagated unconditionally.

Measured cost (scout): 5-30ms per visible block per tick. With 5-10 visible blocks during streaming this is 50-300ms of cumulative work per streamed token, perceptible as choppy streaming and laggy scroll-back.

## Fix
1. Hoist the `components` map (previously inline at lines 58-120) to a module-scope `MD_COMPONENTS: Components` constant. Same for `remarkPlugins` (now `REMARK_PLUGINS`). Stable references mean react-markdown can short-circuit its internal work.
2. Wrap the export with `React.memo`. Equality compares the only props that affect output:
   - `text`, `streaming`, `id` (primitives)
   - `viaSkill` reduced to a stable scalar via `viaSkill?.path ?? viaSkill?.name ?? null` (the object identity churns even when content is unchanged).
3. `CodeBlock` is already a stable module-level component, no change needed there.

No behaviour change; only re-render frequency drops. Same JSX, same DOM output.

## Verification
- `npm run typecheck` clean.
- `npm run lint` no new errors attributable to this file (pre-existing baseline noise in probe scripts unchanged).
- `npx vitest run tests/assistant-block-skill-badge.test.tsx` -> 3/3 pass (text + via-skill badge + plugin-namespaced badge).
- `npx vitest run tests/chatstream-tool-block-ux.test.tsx tests/chatstream-thinking-dots.test.tsx tests/chatstream-terminal.test.tsx` -> 18/18 pass (covers ChatStream interaction with assistant blocks).

E2E visual probe was not added: this is a pure memoization refactor with no rendered-output diff and the existing unit tests already exercise text rendering, the via-skill badge with both name shapes, and ChatStream's interaction with assistant blocks.

## Files changed
- `src/components/chat/blocks/AssistantBlock.tsx` — hoist components/plugins to module scope, rename inner fn to `AssistantBlockImpl`, export `React.memo(AssistantBlockImpl, ...)` as `AssistantBlock`.