### PR TITLE
chore(updater): polish + i18n the existing auto-update flow

### DIFF
--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -39,6 +39,16 @@ Known caveats:
   installs; until then this is expected.
 - **Unsigned builds**: if `CSC_LINK` is absent, SmartScreen prompts on every
   launch. This is the path used for dry-run builds.
+- **`build.win.publisherName` is intentionally unset** in `package.json`. With
+  no publisherName, electron-updater's `verifySignature` step returns `null`
+  rather than failing — letting unsigned local / CI dry-run builds still
+  exercise the auto-update flow without a code-signing certificate. Once we
+  ship a signed release with a real CN, set `publisherName` to the cert's
+  Common Name so signature verification becomes mandatory in production.
+- **`build.nsis.disableWebInstaller: true`** silences the runtime warning
+  electron-updater emits when an NSIS web installer is detected. We ship a
+  full installer (single `.exe` carrying the app payload), so the web-installer
+  path is unreachable; the flag just removes the noise.
 
 ### macOS
 

--- a/electron/__tests__/updater.test.ts
+++ b/electron/__tests__/updater.test.ts
@@ -177,12 +177,25 @@ describe('updater: IPC wiring', () => {
   });
 
   it('updates:install calls quitAndInstall with visible installer + relaunch', async () => {
+    // Defense-in-depth gate (#TBD): updates:install refuses unless
+    // lastStatus is `downloaded`. Drive the broadcast first so the
+    // handler can proceed.
+    autoUpdaterEmitter.emit('update-downloaded', { version: '0.1.3' });
     const handler = ipcHandlers.get('updates:install')!;
     const res = handler({});
     expect(res).toEqual({ ok: true });
     // quitAndInstall is scheduled via setImmediate — flush it.
     await new Promise((r) => setImmediate(r));
     expect(quitAndInstallCalls).toEqual([{ isSilent: false, isForceRunAfter: true }]);
+  });
+
+  it('updates:install refuses when no download has completed', () => {
+    // No `update-downloaded` event broadcast → lastStatus stays `idle`.
+    // The defense-in-depth gate must short-circuit before quitAndInstall.
+    const handler = ipcHandlers.get('updates:install')!;
+    const res = handler({});
+    expect(res).toEqual({ ok: false, reason: 'not-ready' });
+    expect(quitAndInstallCalls).toEqual([]);
   });
 
   it('updates:install refuses when not packaged', async () => {

--- a/electron/updater.ts
+++ b/electron/updater.ts
@@ -155,6 +155,17 @@ export function installUpdaterIpc(): void {
 
   ipcMain.handle('updates:install', () => {
     if (!app.isPackaged) return { ok: false as const, reason: 'not-packaged' as const };
+    // Defense-in-depth: refuse to call quitAndInstall unless we've
+    // actually broadcast a `downloaded` event. Without this guard a
+    // misbehaving renderer (e.g. the user clicking the persistent toast
+    // after a stale state, or a future bug that wires the install button
+    // to a non-downloaded state) can trigger autoUpdater.quitAndInstall()
+    // mid-download — electron-updater handles that by force-killing the
+    // app, which the user reads as a crash. Returning `not-ready` lets
+    // the renderer surface a sane "still downloading" message instead.
+    if (lastStatus.kind !== 'downloaded') {
+      return { ok: false as const, reason: 'not-ready' as const };
+    }
     // quitAndInstall: (isSilent, isForceRunAfter). We want a visible installer
     // on Windows (isSilent=false) and to relaunch after install on all OSes.
     setImmediate(() => autoUpdater.quitAndInstall(false, true));

--- a/package.json
+++ b/package.json
@@ -157,7 +157,8 @@
       "deleteAppDataOnUninstall": false,
       "createDesktopShortcut": true,
       "createStartMenuShortcut": true,
-      "shortcutName": "CCSM"
+      "shortcutName": "CCSM",
+      "disableWebInstaller": true
     },
     "mac": {
       "target": [

--- a/scripts/harness-ui.mjs
+++ b/scripts/harness-ui.mjs
@@ -25,6 +25,7 @@
 //   - palette-nav                          (probe-e2e-palette-nav)
 //   - slash-picker-claude-config-dir       (PR #346, env-scoped fake ~/.claude)
 //   - settings-open                        (probe-e2e-settings-open)
+//   - settings-updates-pane                (Settings → Updates pane render contract)
 //   - search-shortcut-f                    (probe-e2e-search-shortcut-f)
 //   - tutorial                             (probe-e2e-tutorial)
 //   - titlebar                             (probe-e2e-titlebar)
@@ -1575,6 +1576,85 @@ async function caseSettingsOpen({ win, log }) {
   await pressEscAndExpectClosed('keyboard shortcut');
 
   log('sidebar / /config / Cmd+, all open Settings; Esc closes');
+}
+
+// ---------- settings-updates-pane ----------
+// Settings → Updates tab renders the current version + status line driven
+// by `electron/updater.ts` over the `updates:status` IPC channel. Today
+// `updates:status` returns `{ kind: 'idle' }` in dev (autoUpdater short-
+// circuits when !app.isPackaged) so the displayed status line should
+// match the i18n `updates.statusIdle` copy. This case guards the contract
+// the UpdateBanner / dogfood toast both depend on: that the pane mounts,
+// reads the IPC bridge, and surfaces a sane status string instead of an
+// empty placeholder.
+//
+// We DO NOT exercise the install button here — quitAndInstall would tear
+// down the app mid-test. The download path is also gated behind
+// `app.isPackaged`, so there's no value in clicking those CTAs.
+async function caseSettingsUpdatesPane({ win, log }) {
+  await win.evaluate(() => {
+    window.__ccsmStore.setState({
+      groups: [{ id: 'g1', name: 'G1', collapsed: false, kind: 'normal' }],
+      sessions: [{ id: 's1', name: 's', state: 'idle', cwd: 'C:/x', model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code' }],
+      activeId: 's1',
+      messagesBySession: { s1: [] },
+      tutorialSeen: true,
+    });
+  });
+  await win.waitForTimeout(150);
+
+  // Open Settings via the sidebar button so this case doesn't depend on
+  // keyboard-shortcut wiring already covered by `settings-open`.
+  await win.evaluate(() => window.dispatchEvent(new Event('ccsm:open-settings')));
+  const dialog = win.getByRole('dialog');
+  await dialog.waitFor({ state: 'visible', timeout: 3000 });
+
+  // Switch to the Updates tab. Tab labels are i18n strings; the case
+  // runs in default English so the regex is fine. Multilingual variants
+  // are covered by `i18n-settings-zh`.
+  const updatesTab = dialog.getByRole('tab', { name: /^updates$/i });
+  await updatesTab.waitFor({ state: 'visible', timeout: 1500 });
+  await updatesTab.click();
+
+  // The pane's tabpanel is `settings-panel-updates`.
+  const panel = dialog.locator('#settings-panel-updates');
+  await panel.waitFor({ state: 'visible', timeout: 1500 });
+
+  // Version + Status field labels are sentence-case ("Version", "Status")
+  // — assert they're visible inside the panel.
+  const text = (await panel.textContent()) || '';
+  if (!/Version/i.test(text)) {
+    throw new Error('updates pane missing "Version" label');
+  }
+  if (!/Status/i.test(text)) {
+    throw new Error('updates pane missing "Status" label');
+  }
+  // Dev runs hit the `not-packaged` short-circuit so `safeCheck` broadcasts
+  // `{ kind: 'not-available' }` on boot — the i18n `statusNotAvailable`
+  // copy ("You are on the latest version.") should render. We accept
+  // either the not-available or the idle line so this case stays resilient
+  // to future startup-broadcast changes (e.g. delaying the boot check).
+  const statusOk = await Promise.race([
+    panel.getByText('You are on the latest version.').waitFor({ state: 'visible', timeout: 2500 }).then(() => true).catch(() => false),
+    panel.getByText('No update check performed yet.').waitFor({ state: 'visible', timeout: 2500 }).then(() => true).catch(() => false),
+  ]);
+  if (!statusOk) {
+    const dump = (await panel.textContent()) || '';
+    throw new Error(`updates pane never rendered a recognisable status line; panel text: ${dump.slice(0, 200)}`);
+  }
+
+  // The "Check for updates" button must be visible + enabled (the dev
+  // short-circuit returns idle so canCheck === true).
+  const checkBtn = panel.getByRole('button', { name: /^check for updates$/i });
+  await checkBtn.waitFor({ state: 'visible', timeout: 1500 });
+  if (await checkBtn.isDisabled()) {
+    throw new Error('Check for updates button unexpectedly disabled in idle state');
+  }
+
+  await win.keyboard.press('Escape');
+  await dialog.waitFor({ state: 'hidden', timeout: 1500 }).catch(() => {});
+
+  log('updates pane: version + status labels render, idle status line + check button visible');
 }
 
 // ---------- search-shortcut-f ----------
@@ -4108,6 +4188,7 @@ await runHarness({
     },
     { id: 'slash-namespaced-unknown-toast', run: caseSlashNamespacedUnknownToast },
     { id: 'settings-open', run: caseSettingsOpen },
+    { id: 'settings-updates-pane', run: caseSettingsUpdatesPane },
     { id: 'search-shortcut-f', run: caseSearchShortcutF },
     { id: 'tutorial', run: caseTutorial },
     { id: 'titlebar', run: caseTitlebar },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -546,13 +546,17 @@ function UpdateDownloadedBridge() {
     const off = window.ccsm?.onUpdateDownloaded((info) => {
       if (shown) return;
       shown = true;
+      // Strings live in `settings:updates.downloadedToast*` so the toast
+      // localizes alongside the Settings → Updates pane copy. Using
+      // `i18next.t` (not the React hook) keeps this callback pure — it
+      // fires from an IPC subscription, not a render.
       push({
         kind: 'info',
-        title: 'Update downloaded — restart to apply',
-        body: `Version ${info.version} is ready.`,
+        title: i18next.t('settings:updates.downloadedToastTitle'),
+        body: i18next.t('settings:updates.downloadedToastBody', { version: info.version }),
         persistent: true,
         action: {
-          label: 'Restart',
+          label: i18next.t('settings:updates.downloadedToastAction'),
           onClick: () => {
             void window.ccsm?.updatesInstall();
           }

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -13,15 +13,7 @@ import { useTranslation } from '../i18n/useTranslation';
 import { usePreferences } from '../store/preferences';
 import { useFocusRestore } from '../lib/useFocusRestore';
 import { DURATION_RAW, EASING } from '../lib/motion';
-
-type LocalUpdateStatus =
-  | { kind: 'idle' }
-  | { kind: 'checking' }
-  | { kind: 'available'; version: string; releaseDate?: string }
-  | { kind: 'not-available'; version: string }
-  | { kind: 'downloading'; percent: number; transferred: number; total: number }
-  | { kind: 'downloaded'; version: string }
-  | { kind: 'error'; message: string };
+import type { UpdateStatus } from '../global';
 
 type Tab = 'appearance' | 'notifications' | 'connection' | 'updates';
 
@@ -393,7 +385,7 @@ function CrashReportingField() {
 
 function UpdatesPane() {
   const [version, setVersion] = useState<string>('…');
-  const [status, setStatus] = useState<LocalUpdateStatus>({ kind: 'idle' });
+  const [status, setStatus] = useState<UpdateStatus>({ kind: 'idle' });
   const [autoCheck, setAutoCheck] = useState<boolean>(true);
   const { t } = useTranslation('settings');
 
@@ -469,7 +461,7 @@ function UpdatesPane() {
   );
 }
 
-function describeStatus(s: LocalUpdateStatus, t: (key: string, vars?: Record<string, unknown>) => string): string {
+function describeStatus(s: UpdateStatus, t: (key: string, vars?: Record<string, unknown>) => string): string {
   switch (s.kind) {
     case 'idle':
       return t('updates.statusIdle');

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -56,7 +56,11 @@ type AgentPermissionRequest = {
   input: Record<string, unknown>;
 };
 
-type UpdateStatus =
+// Updater status — exported so the renderer's `UpdatesPane` (and any
+// future banners/toasts) can import a single source of truth instead of
+// redeclaring the union locally. Mirrors the shape broadcast by
+// `electron/updater.ts` over the `updates:status` IPC channel.
+export type UpdateStatus =
   | { kind: 'idle' }
   | { kind: 'checking' }
   | { kind: 'available'; version: string; releaseDate?: string }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -294,7 +294,15 @@ const en = {
       statusNotAvailable: 'You are on the latest version.',
       statusDownloading: 'Downloading… {{percent}}% ({{transferred}} / {{total}})',
       statusDownloaded: 'Update {{version}} ready — restart to install.',
-      statusError: 'Update check failed: {{message}}'
+      statusError: 'Update check failed: {{message}}',
+      // Strings for the persistent renderer toast surfaced by
+      // App.tsx's UpdateDownloadedBridge when main pushes
+      // `update:downloaded`. Lives under `settings:updates.*` for parity
+      // with the rest of the updater copy even though the toast itself
+      // is rendered outside the Settings dialog.
+      downloadedToastTitle: 'Update downloaded — restart to apply',
+      downloadedToastBody: 'Version {{version}} is ready.',
+      downloadedToastAction: 'Restart'
     }
   },
   permissions: {

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -274,7 +274,10 @@ const zh: EnCatalog = {
       statusNotAvailable: '已经是最新版本。',
       statusDownloading: '下载中… {{percent}}%（{{transferred}} / {{total}}）',
       statusDownloaded: '更新 {{version}} 已就绪 — 重启即可安装。',
-      statusError: '检查更新失败：{{message}}'
+      statusError: '检查更新失败：{{message}}',
+      downloadedToastTitle: '更新已下载 — 重启以应用',
+      downloadedToastBody: '版本 {{version}} 已就绪。',
+      downloadedToastAction: '重启'
     }
   },
   permissions: {


### PR DESCRIPTION
## Summary

Delta polish on top of the already-shipped electron-updater wiring. Six small improvements; **no new banner / store / IPC channel** — the existing `UpdateDownloadedBridge` toast in `src/App.tsx` and the `UpdatesPane` in `SettingsDialog.tsx` already cover the surface. Scope re-derived after the parallel auto-update eval discovered the wiring already exists.

### Changes

1. **i18n the toast strings** (`src/App.tsx` + `src/i18n/locales/{en,zh}.ts`)
   `UpdateDownloadedBridge` toast title/body/action moved from hardcoded English to `i18next.t('settings:updates.downloadedToast*')` — three new keys added in both locales (parity test passes).

2. **Silence the NSIS web-installer warning** (`package.json`)
   `build.nsis.disableWebInstaller: true`. We ship a full installer; the web-installer path is unreachable and electron-updater's runtime warning was just noise.

3. **Document `publisherName` rationale** (`docs/packaging.md`)
   Plain-English explanation of why `build.win.publisherName` is intentionally unset (verifySignature returns null for unsigned builds → local/CI dry-run path still works without a code-signing cert). Also documents the `disableWebInstaller` flip.

4. **Defense-in-depth `updates:install` gate** (`electron/updater.ts`)
   Refuses with `{ ok: false, reason: 'not-ready' }` unless `lastStatus.kind === 'downloaded'`. Prevents a stale-state renderer click from triggering `quitAndInstall()` mid-download (which the user reads as a crash). Existing test updated + new not-ready case added.

5. **Drop `LocalUpdateStatus` redeclaration** (`src/components/SettingsDialog.tsx` + `src/global.d.ts`)
   `UpdateStatus` exported from `src/global.d.ts`; `UpdatesPane` imports it instead of inlining a copy.

6. **E2E coverage** (`scripts/harness-ui.mjs`)
   New `settings-updates-pane` case (per `feedback_e2e_prefer_harness` — extends harness-ui, not a new probe). Asserts the Updates tab mounts, renders Version + Status labels, surfaces a recognisable status line, and shows an enabled "Check for updates" button.

## Context

- Parallel task #431 (auto-update eval) discovered the wiring already exists. This PR is the "delta polish" arm of that finding — the original "build banner UI from scratch" plan was scrapped.
- No follow-up wiring PR needed; the existing setup covers the auto-update surface.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` no new errors vs baseline (existing `EventTarget`/`document` undefined pre-existed)
- [x] `npm test` — 855/858 pass; 3 failures pre-existing in `db-hardening.test.ts` (better-sqlite3 native binding NODE_MODULE_VERSION mismatch, unrelated)
  - Touched suites: `electron/__tests__/updater.test.ts` (13 pass, +1 not-ready case), `tests/i18n-key-parity.test.ts` (2 pass)
- [x] `node scripts/harness-ui.mjs --only=settings-updates-pane` — passes (1635ms)
- [x] `node scripts/harness-ui.mjs --only=settings-open` — passes (no regression, 2306ms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)