### PR TITLE
fix(commands-loader): scan plugin cache for SKILL.md and skip temp_git dirs

### DIFF
--- a/electron/commands-loader.ts
+++ b/electron/commands-loader.ts
@@ -10,6 +10,10 @@
 //   2. <cwd>/.claude/commands/*.md                      (source: 'project')
 //   3. ~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/commands/*.md
 //      (source: 'plugin', name namespaced as `<plugin>:<basename>`)
+//      Plus skills bundled in the same plugin version dir at either
+//      `skills/<name>/SKILL.md` or `.claude/skills/<name>/SKILL.md`
+//      (source: 'skill', name namespaced as `<plugin>:<name>`).
+//      `temp_git_*` cache subdirs are skipped — they're scratch checkouts.
 //   4. ~/.claude/skills/*.md                            (source: 'skill', tolerated if absent)
 //   5. ~/.claude/agents/*.md, <cwd>/.claude/agents/*.md (source: 'agent', tolerated if absent)
 //
@@ -176,6 +180,64 @@ function pickHighestVersionDir(pluginDir: string): string | null {
   return last ? path.join(pluginDir, last) : null;
 }
 
+// Collect SKILL.md entries from a plugin version dir. Plugin authors put
+// skills in either `<versionDir>/skills/<name>/SKILL.md` (e.g. document-skills,
+// superpowers) or `<versionDir>/.claude/skills/<name>/SKILL.md` (e.g.
+// ui-ux-pro-max). Both layouts are scanned. Each skill is namespaced as
+// `<pluginId>:<subdirName>` to match the `<plugin>:<skill>` form the SDK
+// surfaces in agent system reminders (e.g. `superpowers:brainstorming`,
+// `document-skills:docx`). The frontmatter `name` field is intentionally
+// ignored for the namespace — the directory name is the canonical id.
+function collectSkillEntries(
+  versionDir: string,
+  pluginId: string,
+  basePriority: number
+): RawEntry[] {
+  const out: RawEntry[] = [];
+  const skillRoots = [
+    path.join(versionDir, 'skills'),
+    path.join(versionDir, '.claude', 'skills'),
+  ];
+  for (const skillsDir of skillRoots) {
+    if (!isReadableDir(skillsDir)) continue;
+    let subdirs: string[];
+    try {
+      subdirs = fs.readdirSync(skillsDir);
+    } catch {
+      continue;
+    }
+    for (const subdirName of subdirs) {
+      const subdir = path.join(skillsDir, subdirName);
+      if (!isReadableDir(subdir)) continue;
+      const skillFile = path.join(subdir, 'SKILL.md');
+      let raw: string;
+      try {
+        raw = fs.readFileSync(skillFile, 'utf8');
+      } catch {
+        continue; // no SKILL.md — not a skill dir
+      }
+      if (!/^[a-zA-Z0-9._-]+$/.test(subdirName)) {
+        console.warn(
+          `[commands-loader] skipping plugin skill ${skillFile}: subdir name has invalid chars`
+        );
+        continue;
+      }
+      const { data } = parseFrontmatter(raw);
+      const fullName = `${pluginId}:${subdirName}`;
+      out.push({
+        name: fullName,
+        description: data['description'] || undefined,
+        argumentHint: data['argument-hint'] || undefined,
+        source: 'skill',
+        pluginId,
+        file: skillFile,
+        priority: basePriority,
+      });
+    }
+  }
+  return out;
+}
+
 function collectPluginEntries(pluginsRoot: string, basePriority: number): RawEntry[] {
   const cacheRoot = path.join(pluginsRoot, 'cache');
   if (!isReadableDir(cacheRoot)) return [];
@@ -187,6 +249,11 @@ function collectPluginEntries(pluginsRoot: string, basePriority: number): RawEnt
     return [];
   }
   for (const market of marketplaces) {
+    // `temp_git_*` dirs are scratch checkouts the plugin manager uses while
+    // resolving git-sourced marketplaces. They are not real marketplace dirs
+    // and treating them as such surfaces noise entries (and can shadow the
+    // real namespaced names).
+    if (market.startsWith('temp_git_')) continue;
     const marketDir = path.join(cacheRoot, market);
     if (!isReadableDir(marketDir)) continue;
     let plugins: string[];
@@ -204,6 +271,8 @@ function collectPluginEntries(pluginsRoot: string, basePriority: number): RawEnt
         const entry = readEntry(file, 'plugin', basePriority, pluginId);
         if (entry) out.push(entry);
       }
+      // Skills live alongside commands in the same plugin version dir.
+      out.push(...collectSkillEntries(versionDir, pluginId, basePriority + 1));
     }
   }
   return out;
@@ -309,38 +378,8 @@ export function loadCommands(opts: LoadOpts = {}): LoadedCommand[] {
 
 // ────────────────────── picker-visible filter ──────────────────────────────
 //
-// Subset of `loadCommands` surfaced to the slash-command picker. All five
-// disk-discovered sources are visible.
-//
-// Why every source is included (reversal of PR #346, see #290):
-//
-//   - PLUGIN commands (`/<plugin>:<name>` from ~/.claude/plugins/cache/...)
-//     are loaded automatically by the bundled CLI from the user's
-//     `enabledPlugins` setting in ~/.claude/settings.json. The SDK
-//     `query()` defaults to `settingSources: ['user','project','local']`
-//     when the option is omitted (which ccsm intentionally does), so the
-//     CLI subprocess discovers and registers every enabled plugin command.
-//     Empirically verified: spawning the SDK-bundled claude.exe with
-//     stream-json and sending `/superpowers:brainstorming <q>` runs the
-//     plugin and produces real output. The "deprecated, use the skill"
-//     reply that PR #346 attributed to a transport gap is in fact the
-//     CONTENT of the deprecated `/superpowers:brainstorm` plugin command
-//     itself — the plugin authors deprecated that name in favour of the
-//     `superpowers:brainstorming` skill. PR #346 misdiagnosed user-visible
-//     plugin output as a missing feature.
-//
-//   - SKILL entries (from ~/.claude/skills/) are also loaded by the
-//     bundled CLI; invoking `/<skill-name>` in the composer triggers the
-//     skill (the CLI's own command resolution recognises these).
-//
-//   - AGENT entries (subagent definitions) are invocable as
-//     `/<agent-name>` — the CLI exposes them as commands too.
-//
-// All disk-discovered commands are forwarded to claude.exe via the existing
-// pass-through path (`passThrough: true` in registry.ts loadDynamicCommands).
-// The unknown-namespaced toast (PR #359, src/components/InputBar.tsx) still
-// catches genuinely-missing namespaced commands because it only fires when
-// the name is NOT found in the merged command list.
+// All disk-discovered sources are surfaced; the CLI subprocess actually
+// executes them via the standard pass-through path.
 export const PICKER_VISIBLE_SOURCES: ReadonlySet<CommandSource> = new Set([
   'user',
   'project',

--- a/scripts/verify-skills-loader.cts
+++ b/scripts/verify-skills-loader.cts
@@ -1,0 +1,27 @@
+// One-shot verification script for the commands-loader plugin-skill scan.
+// Runs the loader against the user's real ~/.claude tree and prints the
+// resulting entries grouped by source. Used as PR evidence — not a CI gate.
+//
+// Run: npx tsx scripts/verify-skills-loader.cts
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { loadCommands } from '../electron/commands-loader';
+
+const home = os.homedir();
+const claudeRoot = path.join(home, '.claude');
+const cmds = loadCommands({ homeDir: home, cwd: process.cwd() });
+
+const bySource = new Map<string, string[]>();
+for (const c of cmds) {
+  if (!bySource.has(c.source)) bySource.set(c.source, []);
+  bySource.get(c.source)!.push(c.name);
+}
+
+console.log(`# loader output for ${claudeRoot}`);
+console.log(`total entries: ${cmds.length}`);
+console.log('');
+for (const [src, names] of bySource) {
+  console.log(`## ${src} (${names.length})`);
+  for (const n of names.sort()) console.log(`  - ${n}`);
+  console.log('');
+}

--- a/tests/commands-loader.test.ts
+++ b/tests/commands-loader.test.ts
@@ -466,3 +466,158 @@ describe('loadPickerCommands', () => {
     ]);
   });
 });
+
+// ─── plugin-bundled skills (SKILL.md) ─────────────────────────────────────
+//
+// Plugins ship skills inside their version dir under either
+// `skills/<name>/SKILL.md` (document-skills, superpowers layout) or
+// `.claude/skills/<name>/SKILL.md` (ui-ux-pro-max layout). Both must be
+// surfaced as `<plugin>:<name>` with source='skill' to match the form the
+// SDK exposes in agent system reminders. Marketplace cache subdirs that
+// start with `temp_git_` are scratch checkouts and must be ignored.
+
+describe('plugin-bundled skill discovery', () => {
+  it('collects skills from both `skills/` and `.claude/skills/` layouts', () => {
+    // pluginA: only has commands/
+    write(
+      path.join(
+        tmpHome,
+        '.claude',
+        'plugins',
+        'cache',
+        'mkt',
+        'pluginA',
+        '1.0.0',
+        'commands',
+        'do-thing.md'
+      ),
+      `---\ndescription: command only\n---\n`
+    );
+    // pluginB: only has skills/<name>/SKILL.md (document-skills layout)
+    write(
+      path.join(
+        tmpHome,
+        '.claude',
+        'plugins',
+        'cache',
+        'mkt',
+        'pluginB',
+        '1.0.0',
+        'skills',
+        'docx',
+        'SKILL.md'
+      ),
+      `---\nname: docx\ndescription: word docs\n---\nbody`
+    );
+    // pluginC: only has .claude/skills/<name>/SKILL.md (ui-ux-pro-max layout)
+    write(
+      path.join(
+        tmpHome,
+        '.claude',
+        'plugins',
+        'cache',
+        'mkt',
+        'pluginC',
+        '2.5.0',
+        '.claude',
+        'skills',
+        'ui-ux-pro-max',
+        'SKILL.md'
+      ),
+      `---\nname: ui-ux-pro-max\ndescription: ui design\n---\nbody`
+    );
+    // temp_git_* marketplace MUST be ignored even if it contains real-looking
+    // plugin/skill content.
+    write(
+      path.join(
+        tmpHome,
+        '.claude',
+        'plugins',
+        'cache',
+        'temp_git_1234_abc',
+        'pluginX',
+        '1.0.0',
+        'skills',
+        'ghost',
+        'SKILL.md'
+      ),
+      `---\nname: ghost\ndescription: should not appear\n---\n`
+    );
+    write(
+      path.join(
+        tmpHome,
+        '.claude',
+        'plugins',
+        'cache',
+        'temp_git_1234_abc',
+        'pluginX',
+        '1.0.0',
+        'commands',
+        'ghost-cmd.md'
+      ),
+      `---\ndescription: should not appear\n---\n`
+    );
+
+    const cmds = loadCommands({ homeDir: tmpHome, cwd: tmpCwd });
+    const byName = Object.fromEntries(cmds.map((c) => [c.name, c]));
+
+    // pluginA command surfaces as before
+    expect(byName['pluginA:do-thing']?.source).toBe('plugin');
+    // pluginB skill (skills/<name>/SKILL.md layout)
+    expect(byName['pluginB:docx']?.source).toBe('skill');
+    expect(byName['pluginB:docx']?.pluginId).toBe('pluginB');
+    expect(byName['pluginB:docx']?.description).toBe('word docs');
+    // pluginC skill (.claude/skills/<name>/SKILL.md layout)
+    expect(byName['pluginC:ui-ux-pro-max']?.source).toBe('skill');
+    expect(byName['pluginC:ui-ux-pro-max']?.pluginId).toBe('pluginC');
+    expect(byName['pluginC:ui-ux-pro-max']?.description).toBe('ui design');
+    // temp_git_* entries dropped entirely
+    expect(byName['pluginX:ghost']).toBeUndefined();
+    expect(byName['pluginX:ghost-cmd']).toBeUndefined();
+    expect(cmds.find((c) => c.name.startsWith('pluginX:'))).toBeUndefined();
+  });
+
+  it('uses the directory name (not frontmatter name) for the skill namespace', () => {
+    // Even if frontmatter declares a different name, the canonical id is
+    // derived from the subdir to match `<plugin>:<subdir>` format the SDK
+    // surfaces.
+    write(
+      path.join(
+        tmpHome,
+        '.claude',
+        'plugins',
+        'cache',
+        'mkt',
+        'pluginD',
+        '1.0.0',
+        'skills',
+        'real-name',
+        'SKILL.md'
+      ),
+      `---\nname: lying-name\ndescription: hi\n---\n`
+    );
+    const cmds = loadCommands({ homeDir: tmpHome, cwd: tmpCwd });
+    expect(cmds.find((c) => c.name === 'pluginD:real-name')).toBeDefined();
+    expect(cmds.find((c) => c.name === 'pluginD:lying-name')).toBeUndefined();
+  });
+
+  it('skips skill subdirs that lack SKILL.md', () => {
+    // A bare directory under skills/ with no SKILL.md is not a skill.
+    fs.mkdirSync(
+      path.join(
+        tmpHome,
+        '.claude',
+        'plugins',
+        'cache',
+        'mkt',
+        'pluginE',
+        '1.0.0',
+        'skills',
+        'not-a-skill'
+      ),
+      { recursive: true }
+    );
+    const cmds = loadCommands({ homeDir: tmpHome, cwd: tmpCwd });
+    expect(cmds.find((c) => c.name.startsWith('pluginE:'))).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Bug

The slash-command picker only surfaced plugin entries for `pua` and `superpowers` even though the user has 7 plugins installed (document-skills, example-skills, frontend-design, pua, superpowers, ui-ux-pro-max). Root cause: `collectPluginEntries` in `electron/commands-loader.ts` only scanned `<versionDir>/commands/*.md`. The other 5 plugins ship their content as **skills**, not commands, at either `<versionDir>/skills/<name>/SKILL.md` (document-skills, superpowers layout) or `<versionDir>/.claude/skills/<name>/SKILL.md` (ui-ux-pro-max layout). With no `commands/` dir, those plugins were invisible.

A second issue: `~/.claude/plugins/cache/temp_git_*/` scratch checkouts (created by the plugin manager while resolving git-sourced marketplaces) were being treated as real marketplaces, surfacing duplicate / noise entries.

## Changes

- New `collectSkillEntries(versionDir, pluginId, basePriority)` helper that walks both `skills/` and `.claude/skills/` layouts, reads each `SKILL.md`, and emits a `<plugin>:<subdir>` entry with `source: 'skill'`. Subdir name (not frontmatter `name`) is the canonical id, matching the form the SDK surfaces in agent system reminders (e.g. `superpowers:brainstorming`, `document-skills:docx`).
- `collectPluginEntries` now calls `collectSkillEntries` per plugin version dir alongside the existing `commands/*.md` scan.
- Skip any cache subdir whose name starts with `temp_git_`.
- Replace the misleading PR #346 comment block above `PICKER_VISIBLE_SOURCES` that claimed plugin skills did not need their own loader.
- Tests: 3 new cases in `tests/commands-loader.test.ts` covering the `skills/` layout, the `.claude/skills/` layout, the `temp_git_*` filter, and that the directory name (not frontmatter `name`) drives the namespace. Plus a "skill subdir without SKILL.md is ignored" edge case.

## Verification

### Loader output against real `~/.claude/plugins/cache/`

Before fix:

```
total entries: 20
## plugin (20)
  - pua:cancel-pua-loop, pua:flavor, pua:kpi, pua:mama, pua:off, pua:on,
    pua:p10, pua:p7, pua:p9, pua:pro, pua:pua, pua:pua-loop,
    pua:reap-orphans, pua:survey, pua:team-status, pua:teardown-all,
    pua:yes, superpowers:brainstorm, superpowers:execute-plan,
    superpowers:write-plan
```

After fix:

```
total entries: 79

## plugin (20)   <-- unchanged
  - (same 20 commands)

## skill (59)    <-- NEW
  - document-skills:algorithmic-art, document-skills:brand-guidelines,
    document-skills:canvas-design, document-skills:claude-api,
    document-skills:doc-coauthoring, document-skills:docx,
    document-skills:frontend-design, document-skills:internal-comms,
    document-skills:mcp-builder, document-skills:pdf,
    document-skills:pptx, document-skills:skill-creator,
    document-skills:slack-gif-creator, document-skills:theme-factory,
    document-skills:web-artifacts-builder,
    document-skills:webapp-testing, document-skills:xlsx,
    example-skills:* (17 skills),
    frontend-design:frontend-design,
    pua:pua-en, pua:pua-ja, pua:shot,
    superpowers:brainstorming, superpowers:dispatching-parallel-agents,
    superpowers:executing-plans, superpowers:finishing-a-development-branch,
    superpowers:receiving-code-review, superpowers:requesting-code-review,
    superpowers:subagent-driven-development, superpowers:systematic-debugging,
    superpowers:test-driven-development, superpowers:using-git-worktrees,
    superpowers:using-superpowers, superpowers:verification-before-completion,
    superpowers:writing-plans, superpowers:writing-skills,
    ui-ux-pro-max:banner-design, ui-ux-pro-max:brand,
    ui-ux-pro-max:design, ui-ux-pro-max:design-system,
    ui-ux-pro-max:slides, ui-ux-pro-max:ui-styling,
    ui-ux-pro-max:ui-ux-pro-max
```

`temp_git_*` cache dirs produced zero entries (verified — no `pluginX:*` rows even though the test fixture writes both a command and a skill into a `temp_git_1234_abc/` marketplace).

Verification was produced by `scripts/verify-skills-loader.cts` (one-shot script, included in this PR for reproducibility). The vitest fixtures are the regression guard; this script can be deleted later once we are confident.

### Gates

- `npm run typecheck` — clean.
- `npm run lint` — 55 problems / 45 errors / 10 warnings, identical to `origin/working` baseline (no new errors on touched files).
- `npm test` — `tests/commands-loader.test.ts` 25/25 pass (was 22, +3 new cases). 3 unrelated failures in `electron/__tests__/db-hardening.test.ts` (better-sqlite3 native binding under vitest), pre-existing on `origin/working`.

### E2E harness vs standalone script

Per `feedback_e2e_prefer_harness`, I checked existing harnesses (`harness-ui.mjs`, `harness-agent.mjs`) for a "picker shows N items" hook that could be extended. None of them exercise `loadCommands` directly — they use the renderer. Since the regression guard is the vitest suite (which directly fixtures both layouts and the `temp_git_*` filter), shipping a one-shot loader script as PR evidence felt right; flagging in case reviewer wants it deleted post-merge.