### PR TITLE
feat(ui): add TtydPane component

### DIFF
--- a/src/cliBridge.d.ts
+++ b/src/cliBridge.d.ts
@@ -1,0 +1,40 @@
+// Renderer-side type augmentation for `window.ccsmCliBridge`. The
+// authoritative surface is defined in `electron/preload.ts` (exported as
+// `CCSMCliBridgeAPI`) but the renderer's Vite build cannot import from
+// the electron tree, so the shape is mirrored here. Keep both in sync.
+//
+// Per preload.ts: `ccsmCliBridge` is intentionally a separate namespace
+// from `window.ccsm` while the in-process SDK runner is being torn out.
+// It will fold into the main `ccsm` namespace once that work lands.
+
+type CliBridgeOpenResult =
+  | { ok: true; port: number; sid: string }
+  | { ok: false; error: string };
+
+type CliBridgeKillResult =
+  | { ok: true; killed: boolean }
+  | { ok: false; error: string };
+
+type CliBridgeAvailability =
+  | { available: true; path: string }
+  | { available: false };
+
+type TtydExitEvent = {
+  sessionId: string;
+  code: number | null;
+  signal: NodeJS.Signals | null;
+};
+
+declare global {
+  interface Window {
+    ccsmCliBridge?: {
+      openTtydForSession: (sessionId: string) => Promise<CliBridgeOpenResult>;
+      resumeSession: (sessionId: string, sid: string) => Promise<CliBridgeOpenResult>;
+      killTtydForSession: (sessionId: string) => Promise<CliBridgeKillResult>;
+      checkClaudeAvailable: () => Promise<CliBridgeAvailability>;
+      onTtydExit: (handler: (e: TtydExitEvent) => void) => () => void;
+    };
+  }
+}
+
+export {};

--- a/src/components/TtydPane.tsx
+++ b/src/components/TtydPane.tsx
@@ -1,0 +1,119 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+// TtydPane mounts a per-session iframe that points at the ttyd HTTP
+// server spawned by the main-process cliBridge. Each session owns its
+// own ttyd instance on a dedicated 127.0.0.1 port; this component is the
+// renderer-side lifecycle owner for that pairing.
+//
+// Lifecycle (per sessionId):
+//   1. mount / sessionId change → openTtydForSession(sid)
+//   2. on ok → render <iframe src="http://127.0.0.1:<port>/">
+//   3. on error or ttyd-exit for this sid → flip to error state w/ Retry
+//   4. unmount / sessionId change → killTtydForSession(prevSid)
+//
+// Strings are intentionally hardcoded English placeholders for now; W2c
+// will swap them for i18n keys when wiring this into App.
+
+type Props = { sessionId: string };
+
+type State =
+  | { kind: 'loading' }
+  | { kind: 'ready'; port: number }
+  | { kind: 'error'; message: string };
+
+export function TtydPane({ sessionId }: Props) {
+  const [state, setState] = useState<State>({ kind: 'loading' });
+  // Track the sessionId we requested for so a stale resolve from a
+  // previous session can't clobber the current one when the user
+  // switches quickly.
+  const activeSidRef = useRef<string>(sessionId);
+
+  const open = useCallback(async (sid: string) => {
+    const bridge = window.ccsmCliBridge;
+    if (!bridge) {
+      setState({ kind: 'error', message: 'cliBridge unavailable' });
+      return;
+    }
+    setState({ kind: 'loading' });
+    try {
+      const res = await bridge.openTtydForSession(sid);
+      if (activeSidRef.current !== sid) return; // session switched mid-flight
+      if (res.ok) {
+        setState({ kind: 'ready', port: res.port });
+      } else {
+        setState({ kind: 'error', message: res.error });
+      }
+    } catch (err) {
+      if (activeSidRef.current !== sid) return;
+      const message = err instanceof Error ? err.message : String(err);
+      setState({ kind: 'error', message });
+    }
+  }, []);
+
+  // Mount / sessionId change: open the new session, kill the previous on
+  // cleanup. Effect cleanup runs before the next effect for the new sid,
+  // so prevSid is always the one we opened.
+  useEffect(() => {
+    activeSidRef.current = sessionId;
+    void open(sessionId);
+    const prevSid = sessionId;
+    return () => {
+      window.ccsmCliBridge?.killTtydForSession(prevSid).catch(() => {
+        // best-effort cleanup; main process will reap on quit anyway
+      });
+    };
+  }, [sessionId, open]);
+
+  // Subscribe to ttyd-exit broadcasts so an unexpected backend death
+  // flips us into the error state with a Retry affordance.
+  useEffect(() => {
+    const bridge = window.ccsmCliBridge;
+    if (!bridge?.onTtydExit) return;
+    const unsubscribe = bridge.onTtydExit((evt) => {
+      if (evt.sessionId !== activeSidRef.current) return;
+      const detail =
+        evt.signal != null
+          ? `signal ${evt.signal}`
+          : evt.code != null
+            ? `exit code ${evt.code}`
+            : 'unknown reason';
+      setState({ kind: 'error', message: `ttyd exited (${detail})` });
+    });
+    return unsubscribe;
+  }, []);
+
+  if (state.kind === 'loading') {
+    return (
+      <div className="flex items-center justify-center h-full text-neutral-400 text-sm">
+        Starting...
+      </div>
+    );
+  }
+
+  if (state.kind === 'error') {
+    return (
+      <div className="flex flex-col items-center justify-center h-full gap-3 text-sm">
+        <div className="text-red-400 max-w-md text-center break-words px-4">
+          {state.message}
+        </div>
+        <button
+          type="button"
+          onClick={() => void open(sessionId)}
+          className="px-3 py-1 rounded border border-neutral-700 text-neutral-200 hover:bg-neutral-800 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-neutral-400"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <iframe
+      src={`http://127.0.0.1:${state.port}/`}
+      className="flex-1 w-full h-full border-0 bg-black"
+      title={`ttyd session ${sessionId}`}
+    />
+  );
+}
+
+export default TtydPane;


### PR DESCRIPTION
## Summary
- New `src/components/TtydPane.tsx` mounts a ttyd iframe per session via `window.ccsmCliBridge`.
- Adds `src/cliBridge.d.ts` mirroring the preload `CCSMCliBridgeAPI` surface (renderer can't import from electron tree).
- No App.tsx wiring yet (W2c).

## Coordination
- Depends on: PR #428 (W1, MERGED) — uses cliBridge IPC.
- Sibling: W2b (ClaudeMissingGuide + i18n).
- Blocks: W2c (App wiring + e2e harness).

## Test plan
- [x] typecheck green (`tsc --noEmit`)
- [ ] component renders in W2c integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>