### PR TITLE
feat(ui): ClaudeMissingGuide + i18n keys

### DIFF
--- a/src/components/ClaudeMissingGuide.tsx
+++ b/src/components/ClaudeMissingGuide.tsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react';
+import { useTranslation } from '../i18n/useTranslation';
+
+/**
+ * Full-screen page rendered at boot when the `claude` CLI is not on PATH.
+ *
+ * Background: ccsm shells out to the user's locally-installed Claude CLI
+ * (no bundled binary in this code path — see W1/W3). When PATH lookup
+ * fails, the rest of the app cannot function, so we replace the entire UI
+ * with this guide rather than letting users dig through broken sessions.
+ *
+ * The re-check button calls `cliBridge.checkClaudeAvailable` so the user
+ * can install via npm in a separate terminal and resolve in-place without
+ * restarting the app. App wiring (deciding when to mount this vs. the
+ * normal shell) lands in W2c.
+ */
+type Props = { onResolved: () => void };
+
+export function ClaudeMissingGuide({ onResolved }: Props) {
+  const { t } = useTranslation();
+  const [checking, setChecking] = useState(false);
+  const installCommand = 'npm install -g @anthropic-ai/claude-code';
+
+  const onRecheck = async () => {
+    if (checking) return;
+    setChecking(true);
+    try {
+      // `window.ccsmCliBridge` is exposed by `electron/preload.ts` but the
+      // global type isn't published in `src/global.d.ts` yet (App-level
+      // wiring lands in W2c, which will own that declaration). Local cast
+      // keeps this PR scoped to the 3 files in the W2b spec.
+      const bridge = (window as unknown as {
+        ccsmCliBridge: {
+          checkClaudeAvailable: () => Promise<{ available: boolean }>;
+        };
+      }).ccsmCliBridge;
+      const result = await bridge.checkClaudeAvailable();
+      if (result.available) {
+        onResolved();
+        return;
+      }
+    } finally {
+      setChecking(false);
+    }
+  };
+
+  return (
+    <div
+      className="flex h-screen w-screen items-center justify-center bg-neutral-950 px-6 text-neutral-100"
+      data-testid="claude-missing-guide"
+    >
+      <div className="w-full max-w-lg rounded-lg border border-neutral-800 bg-neutral-900 p-8 shadow-xl">
+        <h1 className="text-lg font-semibold text-neutral-50">
+          {t('claudeMissing.title')}
+        </h1>
+        <p className="mt-3 text-sm leading-relaxed text-neutral-300">
+          {t('claudeMissing.body')}
+        </p>
+        <div className="mt-5">
+          <div className="text-xs uppercase tracking-wide text-neutral-500">
+            {t('claudeMissing.installCommandLabel')}
+          </div>
+          <code
+            className="mt-2 block select-all rounded border border-neutral-800 bg-neutral-950 px-3 py-2 font-mono text-sm text-neutral-100"
+            data-testid="claude-missing-install-command"
+          >
+            {installCommand}
+          </code>
+        </div>
+        <div className="mt-6 flex justify-end">
+          <button
+            type="button"
+            onClick={onRecheck}
+            disabled={checking}
+            className="rounded border border-neutral-700 bg-neutral-800 px-4 py-1.5 text-sm font-medium text-neutral-100 transition-colors hover:bg-neutral-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-400 disabled:cursor-not-allowed disabled:opacity-60"
+            data-testid="claude-missing-recheck"
+          >
+            {checking ? t('common.loading') : t('claudeMissing.recheckButton')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ClaudeMissingGuide;

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -505,7 +505,10 @@ const en = {
   },
   terminal: {
     waitingOutput: 'waiting for output…',
-    noOutput: '(no output)'
+    noOutput: '(no output)',
+    starting: 'Starting…',
+    spawnFailed: 'Failed to start terminal',
+    retryButton: 'Retry'
   },
   statusBar: {
     workingDirectory: 'Working directory',
@@ -622,6 +625,16 @@ const en = {
   firstRun: {
     newSession: 'New session',
     importSession: 'Import a CLI session'
+  },
+  // Shown full-screen at boot when the `claude` CLI is not on PATH.
+  // ccsm requires the user to install the Claude CLI separately; this
+  // page links them to the install command and lets them re-check
+  // without restarting the app.
+  claudeMissing: {
+    title: 'Claude CLI not found',
+    body: 'ccsm requires the Claude CLI to be installed separately. Install it via npm and re-check.',
+    installCommandLabel: 'Install command',
+    recheckButton: 'Re-check'
   }
 } as const;
 

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -474,7 +474,10 @@ const zh: EnCatalog = {
   },
   terminal: {
     waitingOutput: '等待输出…',
-    noOutput: '（无输出）'
+    noOutput: '（无输出）',
+    starting: '启动中…',
+    spawnFailed: '终端启动失败',
+    retryButton: '重试'
   },
   statusBar: {
     workingDirectory: '工作目录',
@@ -578,6 +581,13 @@ const zh: EnCatalog = {
   firstRun: {
     newSession: '新建会话',
     importSession: '从 CLI 导入会话'
+  },
+  // Boot-time full-screen page shown when `claude` CLI not on PATH.
+  claudeMissing: {
+    title: 'Claude CLI 未找到',
+    body: 'ccsm 需要单独安装 Claude CLI。请通过 npm 安装后重新检查。',
+    installCommandLabel: '安装命令',
+    recheckButton: '重新检查'
   }
 };
 


### PR DESCRIPTION
## Summary
- New `src/components/ClaudeMissingGuide.tsx` full-screen page.
- New i18n keys: `claudeMissing.*`, `terminal.*` (en + zh).
- Parity test green.

## Coordination
- Depends on: PR #428 (W1, MERGED) — calls `cliBridge.checkClaudeAvailable`.
- Sibling: W2a (TtydPane component).
- Blocks: W2c (App wiring), W3 (full SDK delete).

## Test plan
- [ ] i18n-key-parity test green
- [ ] typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>