### PR TITLE
feat(ui): wire App to TtydPane + ClaudeMissingGuide + harness e2e

### DIFF
--- a/scripts/harness-ui.mjs
+++ b/scripts/harness-ui.mjs
@@ -3997,6 +3997,79 @@ async function caseStartupPaintsBeforeHydrate({ win, log }) {
   );
 }
 
+// ---------- ttyd-pane-iframe-mounted ----------
+// W2c (ttyd-iframe refactor): pin the App→{TtydPane | ClaudeMissingGuide}
+// wiring contract. Two branches, both real verifications (no skips):
+//   - claudeAvailable=true  → right pane mounts an `<iframe>` whose src
+//     matches `http://127.0.0.1:<port>/` (the per-session ttyd HTTP
+//     server from electron/cliBridge).
+//   - claudeAvailable=false → right pane mounts ClaudeMissingGuide
+//     (data-testid="claude-missing-guide"), proving the selector
+//     correctly chose the fallback path.
+// Backend ttyd spawn/teardown coverage lives in
+// `harness-real-cli.mjs::cli-bridge-ttyd-spawn-and-kill`; this case is
+// strictly the renderer-side wiring contract.
+async function caseTtydPaneIframeMounted({ win, log }) {
+  // Seed a real session so App's `active` resolves and the right-pane
+  // branch runs. tutorialSeen=true skips the tutorial overlay.
+  await win.evaluate(() => {
+    window.__ccsmStore.setState({
+      groups: [{ id: 'g1', name: 'G1', collapsed: false, kind: 'normal' }],
+      sessions: [
+        { id: 's-ttyd', name: 'ttyd-probe', state: 'idle', cwd: 'C:/x', model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code' },
+      ],
+      activeId: 's-ttyd',
+      messagesBySession: { 's-ttyd': [] },
+      tutorialSeen: true,
+    });
+  });
+
+  // Wait for App to resolve the boot-time claudeAvailable check —
+  // either the guide or the iframe (or its loading shell) shows up.
+  await win.waitForFunction(
+    () =>
+      !!document.querySelector('[data-testid="claude-missing-guide"]') ||
+      !!document.querySelector('iframe[title^="ttyd session"]') ||
+      !!document.querySelector('[data-testid="claude-availability-probing"]') === false,
+    null,
+    { timeout: 8000 }
+  );
+
+  const guideCount = await win.locator('[data-testid="claude-missing-guide"]').count();
+  if (guideCount > 0) {
+    // claude not on PATH → fallback selector branch. Verify the guide
+    // is the only right-pane content (no leaked iframe).
+    const iframeCount = await win.locator('iframe[title^="ttyd session"]').count();
+    if (iframeCount > 0) {
+      throw new Error('both ClaudeMissingGuide and TtydPane rendered — selector logic broken');
+    }
+    log('claudeAvailable=false branch: ClaudeMissingGuide rendered, no leaked iframe');
+    return;
+  }
+
+  // claude available → iframe must mount. TtydPane goes through a
+  // brief `loading` state while it awaits openTtydForSession, then
+  // flips to `ready` and renders the iframe. 8s timeout absorbs ttyd
+  // spawn cost on cold harness boot.
+  const iframe = win.locator('iframe[title^="ttyd session"]');
+  try {
+    await iframe.first().waitFor({ state: 'attached', timeout: 8000 });
+  } catch {
+    throw new Error('TtydPane iframe did not mount within 8s — App→TtydPane wiring broken or ttyd spawn failed');
+  }
+
+  const src = await iframe.first().getAttribute('src');
+  if (!src) throw new Error('iframe missing src attribute');
+  // Wiring contract: src must be a localhost HTTP URL on a non-zero
+  // port. The exact port is allocated dynamically per session.
+  const expected = /^http:\/\/127\.0\.0\.1:\d+\/?$/;
+  if (!expected.test(src)) {
+    throw new Error(`iframe src does not match wiring contract: got "${src}", expected ${expected}`);
+  }
+
+  log(`claudeAvailable=true branch: iframe mounted with src=${src}`);
+}
+
 // ---------- chatstream-footer-stable ----------
 // Regression for task #407 (ChatStream perf-1 follow-up). Pre-fix: `Footer`
 // was defined inside the `ChatStream` function body, so every render produced
@@ -4238,7 +4311,13 @@ await runHarness({
     // chatstream-footer-stable: regression for #407. Pins the contract that
     // ChatStream's Footer (thinking-dots host) doesn't remount on every
     // store tick — see caseChatStreamFooterStable for full context.
-    { id: 'chatstream-footer-stable', run: caseChatStreamFooterStable }
+    { id: 'chatstream-footer-stable', run: caseChatStreamFooterStable },
+    // ttyd-pane-iframe-mounted: W2c (ttyd-iframe refactor). Pins the
+    // App→TtydPane wiring contract — when claude is available and a
+    // session is active, the right pane mounts an `<iframe>` whose src
+    // points at the per-session ttyd HTTP server. cliBridge is stubbed
+    // in-renderer; backend spawn coverage lives in harness-real-cli.
+    { id: 'ttyd-pane-iframe-mounted', run: caseTtydPaneIframeMounted }
   ],
   launch: {
     // CCSM_OPEN_IN_EDITOR_NOOP=1: tells the tool:open-in-editor IPC handler

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,10 +5,8 @@ import { ToastProvider, useToast } from './components/ui/Toast';
 import { Button } from './components/ui/Button';
 import { Sidebar } from './components/Sidebar';
 import { AppShell } from './components/AppShell';
-import { ChatStream } from './components/ChatStream';
-import { InputBar } from './components/InputBar';
-import { QuestionStickyHost } from './components/QuestionStickyHost';
-import { StatusBar } from './components/StatusBar';
+import { TtydPane } from './components/TtydPane';
+import { ClaudeMissingGuide } from './components/ClaudeMissingGuide';
 import { SettingsDialog } from './components/SettingsDialog';
 import { CommandPalette } from './components/CommandPalette';
 import { ImportDialog } from './components/ImportDialog';
@@ -83,8 +81,6 @@ export default function App() {
   const sessions = useStore((s) => s.sessions);
   const activeId = useStore((s) => s.activeId);
   const focusedGroupId = useStore((s) => s.focusedGroupId);
-  const model = useStore((s) => s.model);
-  const permission = useStore((s) => s.permission);
   // perf/startup-render-gate: App now mounts BEFORE `hydrateStore()`
   // resolves (index.tsx no longer awaits hydration). For the sub-frame
   // window where `hydrated` is still false, sessions/groups are at their
@@ -100,10 +96,6 @@ export default function App() {
   const moveSession = useStore((s) => s.moveSession);
   const createGroup = useStore((s) => s.createGroup);
   const createSession = useStore((s) => s.createSession);
-  const changeCwd = useStore((s) => s.changeCwd);
-  const pushRecentProject = useStore((s) => s.pushRecentProject);
-  const setSessionModel = useStore((s) => s.setSessionModel);
-  const setPermission = useStore((s) => s.setPermission);
   const toggleSidebar = useStore((s) => s.toggleSidebar);
   const theme = useStore((s) => s.theme);
   const fontSizePx = useStore((s) => s.fontSizePx);
@@ -210,6 +202,38 @@ export default function App() {
   const [paletteOpen, setPaletteOpen] = React.useState(false);
   const [importOpen, setImportOpen] = React.useState(false);
   const [shortcutsOpen, setShortcutsOpen] = React.useState(false);
+
+  // Boot-time check: is the `claude` CLI on PATH? Cached in App-level
+  // state because the install state doesn't change mid-session — only
+  // when the user runs `npm install -g …` in another terminal and hits
+  // "Re-check" inside ClaudeMissingGuide, which calls
+  // `cliBridge.checkClaudeAvailable` itself and signals success via
+  // its `onResolved` prop.
+  //
+  // `undefined` = still probing (render nothing claude-gated yet);
+  // `true`/`false` = resolved.
+  const [claudeAvailable, setClaudeAvailable] = React.useState<boolean | undefined>(undefined);
+  useEffect(() => {
+    let cancelled = false;
+    const bridge = window.ccsmCliBridge;
+    if (!bridge) {
+      // Preload missing — treat as unavailable so the guide surfaces
+      // rather than silently rendering an empty TtydPane.
+      setClaudeAvailable(false);
+      return;
+    }
+    void (async () => {
+      try {
+        const result = await bridge.checkClaudeAvailable();
+        if (!cancelled) setClaudeAvailable(result.available);
+      } catch {
+        if (!cancelled) setClaudeAvailable(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // New sessions are created in-place — no modal. The store seeds `cwd` from
   // `userHome` (always-true default per spec). Users repick via the StatusBar
@@ -441,29 +465,15 @@ export default function App() {
                 <AgentInitFailedBanner onRequestReconfigure={() => setSettingsOpen(true)} />
                 <AgentDiagnosticBanner />
               </TopBannerStack>
-              <ChatStream />
-              <QuestionStickyHost sessionId={active.id} />
-              <StatusBar
-                cwd={active.cwd}
-                cwdMissing={active.cwdMissing}
-                sessionId={active.id}
-                model={active.model || model}
-                permission={permission}
-                onChangeCwdToPath={(p) => {
-                  if (!p) return;
-                  changeCwd(p);
-                  pushRecentProject(p);
-                }}
-                onBrowseForCwd={async () => {
-                  const next = (await window.ccsm?.pickDirectory()) ?? null;
-                  if (!next) return;
-                  changeCwd(next);
-                  pushRecentProject(next);
-                }}
-                onChangeModel={(m) => setSessionModel(active.id, m)}
-                onChangePermission={setPermission}
-              />
-              <InputBar sessionId={active.id} />
+              {claudeAvailable === false ? (
+                <ClaudeMissingGuide onResolved={() => setClaudeAvailable(true)} />
+              ) : claudeAvailable === true ? (
+                <TtydPane sessionId={active.id} />
+              ) : (
+                // Probing claude availability — render an empty flex spacer
+                // so the layout doesn't jump once the boot check resolves.
+                <div className="flex-1 min-h-0" data-testid="claude-availability-probing" />
+              )}
             </main>
           }
         />

--- a/src/components/ClaudeMissingGuide.tsx
+++ b/src/components/ClaudeMissingGuide.tsx
@@ -25,15 +25,10 @@ export function ClaudeMissingGuide({ onResolved }: Props) {
     if (checking) return;
     setChecking(true);
     try {
-      // `window.ccsmCliBridge` is exposed by `electron/preload.ts` but the
-      // global type isn't published in `src/global.d.ts` yet (App-level
-      // wiring lands in W2c, which will own that declaration). Local cast
-      // keeps this PR scoped to the 3 files in the W2b spec.
-      const bridge = (window as unknown as {
-        ccsmCliBridge: {
-          checkClaudeAvailable: () => Promise<{ available: boolean }>;
-        };
-      }).ccsmCliBridge;
+      // `window.ccsmCliBridge` is typed via `src/cliBridge.d.ts` (added
+      // in W2a alongside the TtydPane wiring).
+      const bridge = window.ccsmCliBridge;
+      if (!bridge) return;
       const result = await bridge.checkClaudeAvailable();
       if (result.available) {
         onResolved();


### PR DESCRIPTION
## Summary

Closes the W2c task (final worker in the ttyd-iframe refactor sequence). Wires `App.tsx` to render either `<TtydPane>` or `<ClaudeMissingGuide>` based on a boot-time `cliBridge.checkClaudeAvailable()` probe.

Unblocked by:
- #430 (W2a — TtydPane component + `src/cliBridge.d.ts` global type augmentation)
- #431 (W2b — ClaudeMissingGuide component + `claudeMissing.*` i18n keys)

## Changes

### `src/App.tsx`
- New `claudeAvailable` state (undefined → true | false), resolved once at boot via `window.ccsmCliBridge.checkClaudeAvailable()`. App-level cache because install state doesn't change mid-session; the `Re-check` button inside `ClaudeMissingGuide` calls the bridge itself and signals success via its `onResolved` prop.
- Right-pane selector in the active-session branch:
  - `claudeAvailable === false` → `<ClaudeMissingGuide onResolved={...} />`
  - `claudeAvailable === true`  → `<TtydPane sessionId={active.id} />`
  - `undefined` (still probing) → empty flex spacer (no layout jump on resolve)
- Removed JSX references to the old SDK chat pane (`<ChatStream>`, `<QuestionStickyHost>`, `<StatusBar>`, `<InputBar>`) and the imports plus now-unused store hooks (`model`, `permission`, `setSessionModel`, `setPermission`, `changeCwd`, `pushRecentProject`). Those component files stay in tree pending W3's SDK teardown.
- Banners (`TopBannerStack`, `InstallerCorruptBanner`, `AgentInitFailedBanner`, `AgentDiagnosticBanner`) preserved — W4 cleanup will revisit.
- No-active-session / pre-hydrate branches untouched.

### `src/components/ClaudeMissingGuide.tsx`
- Removed W2b's local `(window as unknown as { ccsmCliBridge?: ... }).ccsmCliBridge` cast. The typed global is now provided by `src/cliBridge.d.ts` (W2a), so plain `window.ccsmCliBridge` resolves with the correct type.

### `scripts/harness-ui.mjs`
- New case `ttyd-pane-iframe-mounted` pinning the selector contract:
  - **`claudeAvailable=true` branch**: an `<iframe title^="ttyd session">` mounts within 8s, with `src` matching `^http://127\.0\.0\.1:\d+/?$` (the per-session ttyd HTTP server, dynamically allocated port).
  - **`claudeAvailable=false` branch**: `[data-testid="claude-missing-guide"]` is present AND no `<iframe>` leaks through (selector mutual exclusion).
- Both branches assert real renderer state — no hardcoded skips. Backend ttyd spawn/teardown coverage continues to live in `harness-real-cli.mjs::cli-bridge-ttyd-spawn-and-kill`.

## Test plan

- [x] `npm run typecheck` — clean (no new errors).
- [x] `node scripts/harness-ui.mjs --only=ttyd-pane-iframe-mounted` — passes locally; iframe mounted with `src=http://127.0.0.1:59991/`.
- [ ] Reviewer reverse-verify: stash this PR's `App.tsx` change → harness case fails (no iframe mounts because right pane still shows old ChatStream).