### PR TITLE
chore(ci): trigger CI workflow on PRs to working branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main]
+    branches: [main, working]
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
## Summary
- ci.yml previously had `pull_request: branches: [main]`, so PRs targeting working never auto-triggered the lint+typecheck+test matrix.
- Reviewers were manually `gh workflow run ci.yml --ref <branch>` per PR (easy to forget; first batch of cleanup PRs all needed manual kicks).
- Add `working` so CI fires automatically.

## Test plan
- [ ] This PR itself triggers CI on push (proves the fix).
- [ ] Future PRs to working show CI status without manual intervention.