### PR TITLE
fix(ttyd): propagate session cwd to claude (P0 dogfood blocker)

### DIFF
--- a/electron/cliBridge/index.ts
+++ b/electron/cliBridge/index.ts
@@ -7,11 +7,11 @@
 // is unused by the renderer until Worker 2 wires it).
 //
 // IPC contract (mirrored in preload.ts):
-//   cliBridge:openTtydForSession(sessionId)      → {ok,port,sid} | {ok:false,error}
-//   cliBridge:resumeSession(sessionId, sid)      → {ok,port,sid} | {ok:false,error}
-//   cliBridge:killTtydForSession(sessionId)      → {ok,killed}
-//   cliBridge:checkClaudeAvailable()             → {available, path?}
-//   event cliBridge:ttyd-exit                    → {sessionId, code, signal}
+//   cliBridge:openTtydForSession(sessionId, cwd)      → {ok,port,sid} | {ok:false,error}
+//   cliBridge:resumeSession(sessionId, cwd, sid)      → {ok,port,sid} | {ok:false,error}
+//   cliBridge:killTtydForSession(sessionId)           → {ok,killed}
+//   cliBridge:checkClaudeAvailable()                  → {available, path?}
+//   event cliBridge:ttyd-exit                         → {sessionId, code, signal}
 //
 // Security: every handler that takes an action gates on `fromMainFrame(e)`
 // — a compromised iframe (the ttyd one we host, future webviews, etc.)
@@ -35,18 +35,19 @@ function fromMainFrame(e: IpcMainInvokeEvent): boolean {
 export function registerCliBridgeIpc(): void {
   ipcMain.handle(
     'cliBridge:openTtydForSession',
-    async (e, sessionId: unknown) => {
+    async (e, sessionId: unknown, cwd: unknown) => {
       if (!fromMainFrame(e)) return { ok: false, error: 'rejected' };
       if (typeof sessionId !== 'string' || !sessionId) {
         return { ok: false, error: 'bad_session_id' };
       }
-      return openTtydForSession(sessionId);
+      const cwdStr = typeof cwd === 'string' ? cwd : '';
+      return openTtydForSession(sessionId, cwdStr);
     },
   );
 
   ipcMain.handle(
     'cliBridge:resumeSession',
-    async (e, sessionId: unknown, sid: unknown) => {
+    async (e, sessionId: unknown, cwd: unknown, sid: unknown) => {
       if (!fromMainFrame(e)) return { ok: false, error: 'rejected' };
       if (typeof sessionId !== 'string' || !sessionId) {
         return { ok: false, error: 'bad_session_id' };
@@ -54,7 +55,8 @@ export function registerCliBridgeIpc(): void {
       if (typeof sid !== 'string' || !sid) {
         return { ok: false, error: 'bad_sid' };
       }
-      return resumeTtydForSession(sessionId, sid);
+      const cwdStr = typeof cwd === 'string' ? cwd : '';
+      return resumeTtydForSession(sessionId, cwdStr, sid);
     },
   );
 

--- a/electron/cliBridge/processManager.ts
+++ b/electron/cliBridge/processManager.ts
@@ -75,8 +75,15 @@ function emitExit(sessionId: string, code: number | null, signal: NodeJS.Signals
 // Shared spawn helper. `claudeArgs` is the list AFTER the ttyd-owned
 // flags (`-p <port> -W -t fontSize=14 <claudePath>`); for new sessions
 // it's `['--session-id', sid]`, for resumes `['--resume', sid]`.
+//
+// `cwd` is the directory `claude` should be launched in. Without it,
+// claude inherits Electron's cwd and writes its JSONL transcripts to
+// `~/.claude/projects/<electron-cwd>/...` instead of the user's chosen
+// project — also picking up settings/agents/skills from the wrong
+// project context (P0 dogfood blocker).
 async function spawnTtyd(
   sessionId: string,
+  cwd: string,
   claudeArgs: string[],
 ): Promise<OpenResult | OpenError> {
   // Refuse to start a second ttyd for the same ccsm session — the prior
@@ -140,6 +147,11 @@ async function spawnTtyd(
     proc = spawn(ttyd, args, {
       stdio: ['ignore', 'pipe', 'pipe'],
       windowsHide: true,
+      // Run claude inside the user's chosen project dir so JSONLs land
+      // under `~/.claude/projects/<this-dir>/<sid>.jsonl` and the CLI
+      // picks up settings/agents/skills from the right project root.
+      // Falsy cwd → fall back to Electron's cwd (early-boot only).
+      cwd: cwd && cwd.length > 0 ? cwd : undefined,
     });
   } catch (err) {
     return {
@@ -195,19 +207,21 @@ async function spawnTtyd(
 
 export async function openTtydForSession(
   sessionId: string,
+  cwd: string,
 ): Promise<OpenResult | OpenError> {
   const sid = randomUUID();
-  return spawnTtyd(sessionId, ['--session-id', sid]);
+  return spawnTtyd(sessionId, cwd, ['--session-id', sid]);
 }
 
 export async function resumeTtydForSession(
   sessionId: string,
+  cwd: string,
   sid: string,
 ): Promise<OpenResult | OpenError> {
   if (typeof sid !== 'string' || !sid) {
     return { ok: false, error: 'bad_sid' };
   }
-  return spawnTtyd(sessionId, ['--resume', sid]);
+  return spawnTtyd(sessionId, cwd, ['--resume', sid]);
 }
 
 // Kill the ttyd process tree for `sessionId`. On Windows we MUST use

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -206,10 +206,10 @@ type TtydExitEvent = {
 };
 
 const cliBridge = {
-  openTtydForSession: (sessionId: string): Promise<CliBridgeOpenResult> =>
-    ipcRenderer.invoke('cliBridge:openTtydForSession', sessionId),
-  resumeSession: (sessionId: string, sid: string): Promise<CliBridgeOpenResult> =>
-    ipcRenderer.invoke('cliBridge:resumeSession', sessionId, sid),
+  openTtydForSession: (sessionId: string, cwd: string): Promise<CliBridgeOpenResult> =>
+    ipcRenderer.invoke('cliBridge:openTtydForSession', sessionId, cwd),
+  resumeSession: (sessionId: string, cwd: string, sid: string): Promise<CliBridgeOpenResult> =>
+    ipcRenderer.invoke('cliBridge:resumeSession', sessionId, cwd, sid),
   killTtydForSession: (sessionId: string): Promise<CliBridgeKillResult> =>
     ipcRenderer.invoke('cliBridge:killTtydForSession', sessionId),
   checkClaudeAvailable: (): Promise<CliBridgeAvailability> =>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -439,7 +439,7 @@ export default function App() {
               {claudeAvailable === false ? (
                 <ClaudeMissingGuide onResolved={() => setClaudeAvailable(true)} />
               ) : claudeAvailable === true ? (
-                <TtydPane sessionId={active.id} />
+                <TtydPane sessionId={active.id} cwd={active.cwd ?? ''} />
               ) : (
                 // Probing claude availability — render an empty flex spacer
                 // so the layout doesn't jump once the boot check resolves.

--- a/src/cliBridge.d.ts
+++ b/src/cliBridge.d.ts
@@ -28,8 +28,8 @@ type TtydExitEvent = {
 declare global {
   interface Window {
     ccsmCliBridge?: {
-      openTtydForSession: (sessionId: string) => Promise<CliBridgeOpenResult>;
-      resumeSession: (sessionId: string, sid: string) => Promise<CliBridgeOpenResult>;
+      openTtydForSession: (sessionId: string, cwd: string) => Promise<CliBridgeOpenResult>;
+      resumeSession: (sessionId: string, cwd: string, sid: string) => Promise<CliBridgeOpenResult>;
       killTtydForSession: (sessionId: string) => Promise<CliBridgeKillResult>;
       checkClaudeAvailable: () => Promise<CliBridgeAvailability>;
       onTtydExit: (handler: (e: TtydExitEvent) => void) => () => void;

--- a/src/components/TtydPane.tsx
+++ b/src/components/TtydPane.tsx
@@ -14,21 +14,21 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 // Strings are intentionally hardcoded English placeholders for now; W2c
 // will swap them for i18n keys when wiring this into App.
 
-type Props = { sessionId: string };
+type Props = { sessionId: string; cwd: string };
 
 type State =
   | { kind: 'loading' }
   | { kind: 'ready'; port: number }
   | { kind: 'error'; message: string };
 
-export function TtydPane({ sessionId }: Props) {
+export function TtydPane({ sessionId, cwd }: Props) {
   const [state, setState] = useState<State>({ kind: 'loading' });
   // Track the sessionId we requested for so a stale resolve from a
   // previous session can't clobber the current one when the user
   // switches quickly.
   const activeSidRef = useRef<string>(sessionId);
 
-  const open = useCallback(async (sid: string) => {
+  const open = useCallback(async (sid: string, sessionCwd: string) => {
     const bridge = window.ccsmCliBridge;
     if (!bridge) {
       setState({ kind: 'error', message: 'cliBridge unavailable' });
@@ -36,7 +36,7 @@ export function TtydPane({ sessionId }: Props) {
     }
     setState({ kind: 'loading' });
     try {
-      const res = await bridge.openTtydForSession(sid);
+      const res = await bridge.openTtydForSession(sid, sessionCwd);
       if (activeSidRef.current !== sid) return; // session switched mid-flight
       if (res.ok) {
         setState({ kind: 'ready', port: res.port });
@@ -55,14 +55,14 @@ export function TtydPane({ sessionId }: Props) {
   // so prevSid is always the one we opened.
   useEffect(() => {
     activeSidRef.current = sessionId;
-    void open(sessionId);
+    void open(sessionId, cwd);
     const prevSid = sessionId;
     return () => {
       window.ccsmCliBridge?.killTtydForSession(prevSid).catch(() => {
         // best-effort cleanup; main process will reap on quit anyway
       });
     };
-  }, [sessionId, open]);
+  }, [sessionId, cwd, open]);
 
   // Subscribe to ttyd-exit broadcasts so an unexpected backend death
   // flips us into the error state with a Retry affordance.
@@ -98,7 +98,7 @@ export function TtydPane({ sessionId }: Props) {
         </div>
         <button
           type="button"
-          onClick={() => void open(sessionId)}
+          onClick={() => void open(sessionId, cwd)}
           className="px-3 py-1 rounded border border-neutral-700 text-neutral-200 hover:bg-neutral-800 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-neutral-400"
         >
           Retry


### PR DESCRIPTION
## Summary

`spawnTtyd` had no `cwd` option, so ttyd inherited Electron's working directory and started `claude` there. Result: every session's JSONL transcripts landed in `~/.claude/projects/<electron-cwd>/` instead of the user's chosen project, and the CLI loaded settings/agents/skills from the wrong project root — making dogfood unusable.

This PR threads `cwd` from the ccsm session row through the renderer (`TtydPane`), the preload bridge, the IPC handler, and into the `spawn` options. Falsy `cwd` falls back to Electron's cwd to keep early-boot working.

## Scope

Minimal cwd-only fix to unblock dogfood in parallel. The other four ttyd lifecycle bugs are deferred to a follow-up PR:

- #488 — `openTtydForSession` mints a random UUID instead of using the ccsm session.id
- #490 — switching session kills the ttyd → conversation lost
- #492 — `claudeResolver` cache never expires (Re-check button no-ops)
- #489 — `deleteSession` doesn't kill ttyd → process leak

## Files changed

- `electron/cliBridge/processManager.ts` — `spawnTtyd` accepts `cwd`, passes it to `spawn` options; `openTtydForSession` / `resumeTtydForSession` accept `cwd`.
- `electron/cliBridge/index.ts` — IPC handlers forward `cwd`.
- `electron/preload.ts` — bridge methods accept `cwd`.
- `src/cliBridge.d.ts` — type signatures.
- `src/components/TtydPane.tsx` — Props add `cwd`, passed through to bridge.
- `src/App.tsx` — `<TtydPane cwd={active.cwd ?? ''} />`.

41 insertions, 25 deletions across 6 files.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint <changed files>` clean
- [x] `npm test` — 32 files / 292 tests all pass
- [ ] Reviewer to verify with the dogfood probe (separate worker is wiring `dogfood-probe-current-ui.mjs` to grep `~/.claude/projects/<encoded-cwd>/<sid>.jsonl`)

## Why no e2e in this PR

A separate worker (pool-2) is extending `scripts/dogfood-probe-current-ui.mjs` with the JSONL-on-disk verification. Per coordinator direction, this PR ships the minimum production fix so the probe (which currently fails because of the wrong cwd) can be re-run against `working` immediately after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)