### PR TITLE
ci: pin Python to 3.11 to unblock Windows runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,12 @@ jobs:
       # GitHub-hosted ubuntu image already has them, but setup-python makes
       # it explicit and pins the version so upstream image changes don't
       # surprise us.
+      # Pinned to 3.11 because 3.12+ removed the distutils stdlib (PEP 632)
+      # which the older node-gyp invoked by better-sqlite3's postinstall
+      # still imports. Bump back when better-sqlite3 ships node-gyp >= 10.
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.11'
 
       - name: Install deps
         run: npm ci --legacy-peer-deps


### PR DESCRIPTION
## Summary
- Python 3.12 removed `distutils` from stdlib (PEP 632)
- better-sqlite3 postinstall calls older node-gyp that still imports it
- Result: Windows CI npm ci fails with ModuleNotFoundError
- Fix: pin actions/setup-python to 3.11 (last version with distutils)

## Evidence
- GHA run 25019887683 (working HEAD) shows the failure pre-existed before this PR
- PR #455 review caught it; #455 merged with admin override

## Test plan
- [ ] Windows CI on this PR passes (will reveal in CI run)
- [ ] Ubuntu + macOS still pass (3.11 supports both unchanged)