### PR TITLE
fix(probe-utils): helper gaps from 5 sister probes

### DIFF
--- a/scripts/probe-utils-real-cli.mjs
+++ b/scripts/probe-utils-real-cli.mjs
@@ -37,7 +37,11 @@
 //      CLAUDE_CONFIG_DIR.
 //
 //   6. Cleanup must run on Ctrl+C too — registered via process.on('exit')
-//      AND process.on('SIGINT') / SIGTERM.
+//      AND process.on('SIGINT') / SIGTERM / uncaughtException /
+//      unhandledRejection. Cleanups run LIFO so process force-kill
+//      (electron + ttyd + claude subtree, registered in launchCcsmIsolated)
+//      runs BEFORE tempdir rmSync — Windows can't remove a directory whose
+//      files are still locked by live processes.
 
 import { _electron as electron } from 'playwright';
 import {
@@ -52,6 +56,7 @@ import {
 import { homedir, tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { randomUUID } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
 
 // ============================================================================
 // OOPIF helpers
@@ -251,7 +256,12 @@ function installCleanupHooks() {
   if (cleanupHooksInstalled) return;
   cleanupHooksInstalled = true;
   const runAll = () => {
-    for (const fn of cleanupRegistry) {
+    // Iterate in reverse insertion order (LIFO) so process-kill cleanups
+    // registered after tempdir cleanups run FIRST. Order matters on
+    // Windows: rmSync on a tempdir fails if electron / ttyd / claude still
+    // hold file locks inside it.
+    const fns = Array.from(cleanupRegistry).reverse();
+    for (const fn of fns) {
       try { fn(); } catch (_) { /* ignore */ }
     }
     cleanupRegistry.clear();
@@ -382,6 +392,37 @@ export async function launchCcsmIsolated({ tempDir, userDataDir, env = {} } = {}
     },
     timeout: 60000,
   });
+
+  // Force-kill cleanup. Registered AFTER tempdir/userdata cleanups so that
+  // LIFO iteration in `runAll` runs this FIRST — electron + ttyd + claude
+  // die before rmSync touches the dirs (Windows fails to remove locked
+  // files otherwise). User reported leaked processes (2 electron / 5 ttyd
+  // / 2 claude) after probe runs because the previous cleanup only rm-ed
+  // tempdirs and never killed the process tree.
+  const electronPid = electronApp.process()?.pid ?? null;
+  const killCleanup = () => {
+    cleanupRegistry.delete(killCleanup);
+    // Best-effort async close so playwright tears down its IPC pipes.
+    // Fire-and-forget — the synchronous taskkill below is what guarantees
+    // death even from inside a sync `exit` handler.
+    try { electronApp.close(); } catch (_) { /* ignore */ }
+    if (electronPid) {
+      try {
+        if (process.platform === 'win32') {
+          spawnSync('taskkill', ['/T', '/F', '/PID', String(electronPid)]);
+        } else {
+          // SIGKILL the whole process group; falls back to plain pid kill
+          // if the process wasn't started as group leader.
+          try { process.kill(-electronPid, 'SIGKILL'); } catch (_) {
+            try { process.kill(electronPid, 'SIGKILL'); } catch (_) { /* ignore */ }
+          }
+        }
+      } catch (_) { /* ignore */ }
+    }
+  };
+  installCleanupHooks();
+  cleanupRegistry.add(killCleanup);
+
   const win = await electronApp.firstWindow();
   await win.waitForLoadState('domcontentloaded');
   // Renderer needs a beat to mount App + populate window.__ccsmStore.
@@ -464,7 +505,7 @@ export async function waitForWebviewMounted(win, electronApp, sessionId, { timeo
   // multiple ttyd webviews are alive simultaneously.
   const port = await win
     .evaluate(
-      (sid) => window.ccsmCliBridge?.getTtydForSession?.(sid).catch(() => null),
+      (sid) => Promise.resolve(window.ccsmCliBridge?.getTtydForSession?.(sid)).catch(() => null),
       sessionId,
     )
     .then((res) => (res && typeof res.port === 'number' ? res.port : null))

--- a/scripts/probe-utils-real-cli.mjs
+++ b/scripts/probe-utils-real-cli.mjs
@@ -65,25 +65,37 @@ import { randomUUID } from 'node:crypto';
  *
  * Throws if no matching webview is found within `timeout` ms.
  */
-export async function getTtydWebContentsId(electronApp, { timeout = 5000 } = {}) {
+export async function getTtydWebContentsId(electronApp, { timeout = 5000, port = null } = {}) {
   const deadline = Date.now() + timeout;
   let lastSeen = null;
+  // Build a port-specific URL prefix when caller supplies one. This lets
+  // multi-ttyd probes (switch-session) target the right webview instead of
+  // racing on highest-id heuristics.
+  const portRe = port != null
+    ? new RegExp(`^http:\\/\\/127\\.0\\.0\\.1:${port}(?:\\/|$)`)
+    : /^http:\/\/127\.0\.0\.1:\d+/;
   while (Date.now() < deadline) {
-    const found = await electronApp.evaluate(({ webContents }) => {
-      const all = webContents.getAllWebContents();
-      const matches = [];
-      for (const wc of all) {
-        const type = wc.getType();
-        const url = wc.getURL();
-        if (type === 'webview' && /^http:\/\/127\.0\.0\.1:\d+/.test(url)) {
-          matches.push({ id: wc.id, url });
+    const found = await electronApp.evaluate(
+      ({ webContents }, { reSrc }) => {
+        const re = new RegExp(reSrc);
+        const all = webContents.getAllWebContents();
+        const matches = [];
+        for (const wc of all) {
+          const type = wc.getType();
+          const url = wc.getURL();
+          if (type === 'webview' && re.test(url)) {
+            matches.push({ id: wc.id, url });
+          }
         }
-      }
-      return matches;
-    });
+        return matches;
+      },
+      { reSrc: portRe.source },
+    );
     if (found && found.length > 0) {
       // Prefer the most recently created (highest id) — matches the
       // "current session's ttyd" intent when multiple have been opened.
+      // When `port` was supplied this is already filtered to that ttyd,
+      // so the highest-id pick is just a tie-break.
       found.sort((a, b) => b.id - a.id);
       return found[0].id;
     }
@@ -91,7 +103,7 @@ export async function getTtydWebContentsId(electronApp, { timeout = 5000 } = {})
     await sleep(200);
   }
   throw new Error(
-    `getTtydWebContentsId: no <webview> with http://127.0.0.1:* URL found within ${timeout}ms (last seen: ${JSON.stringify(lastSeen)})`,
+    `getTtydWebContentsId: no <webview> with URL matching ${portRe} found within ${timeout}ms (last seen: ${JSON.stringify(lastSeen)})`,
   );
 }
 
@@ -252,6 +264,12 @@ function installCleanupHooks() {
     // Re-throw so the original error still surfaces.
     throw err;
   });
+  process.on('unhandledRejection', (err) => {
+    // Async electron crashes surface here; without this the tempdir leaks.
+    runAll();
+    // Surface the rejection — let Node's default handler exit non-zero.
+    throw err;
+  });
 }
 
 /**
@@ -304,13 +322,19 @@ export async function createIsolatedClaudeDir({ keep = false } = {}) {
  * Sets CCSM_PROD_BUNDLE=1 + the full quartet of config-dir env vars (HOME,
  * USERPROFILE, CLAUDE_CONFIG_DIR, CCSM_CLAUDE_CONFIG_DIR).
  *
- * Returns { electronApp, win, userDataDir } from playwright. `userDataDir`
- * is registered for cleanup alongside the tempDir.
+ * Returns { electronApp, win, userDataDir } from playwright.
+ *
+ * `userDataDir` behaviour:
+ *   - If caller passes `userDataDir`: helper uses it verbatim and does NOT
+ *     register it for cleanup (caller owns it). This is the cross-restart
+ *     pattern used by reopen/import probes that need ccsm.db to persist
+ *     between two `launchCcsmIsolated` calls on the same dir.
+ *   - If omitted: helper mints a fresh tempdir and registers it for cleanup.
  *
  * Throws a clear error if `dist/renderer/index.html` doesn't exist (caller
  * forgot to run `npm run build`).
  */
-export async function launchCcsmIsolated({ tempDir, env = {} } = {}) {
+export async function launchCcsmIsolated({ tempDir, userDataDir, env = {} } = {}) {
   if (!tempDir) throw new Error('launchCcsmIsolated: tempDir is required');
   const cwd = process.cwd();
   const distIndex = path.join(cwd, 'dist', 'renderer', 'index.html');
@@ -321,19 +345,26 @@ export async function launchCcsmIsolated({ tempDir, env = {} } = {}) {
   }
 
   // Per-launch electron user-data-dir, isolated from the user's real one.
-  const userDataDir = mkdtempSync(path.join(tmpdir(), 'ccsm-probe-userdata-'));
+  // If caller supplied one, they own its lifecycle (cross-restart pattern).
+  const callerOwnsUserData = typeof userDataDir === 'string' && userDataDir.length > 0;
+  const effectiveUserDataDir = callerOwnsUserData
+    ? userDataDir
+    : mkdtempSync(path.join(tmpdir(), 'ccsm-probe-userdata-'));
+
   let cleaned = false;
   const cleanupUd = () => {
     if (cleaned) return;
     cleaned = true;
     cleanupRegistry.delete(cleanupUd);
-    try { rmSync(userDataDir, { recursive: true, force: true }); } catch (_) { /* ignore */ }
+    try { rmSync(effectiveUserDataDir, { recursive: true, force: true }); } catch (_) { /* ignore */ }
   };
-  installCleanupHooks();
-  cleanupRegistry.add(cleanupUd);
+  if (!callerOwnsUserData) {
+    installCleanupHooks();
+    cleanupRegistry.add(cleanupUd);
+  }
 
   const electronApp = await electron.launch({
-    args: ['.', `--user-data-dir=${userDataDir}`],
+    args: ['.', `--user-data-dir=${effectiveUserDataDir}`],
     cwd,
     env: {
       ...process.env,
@@ -355,7 +386,12 @@ export async function launchCcsmIsolated({ tempDir, env = {} } = {}) {
   await win.waitForLoadState('domcontentloaded');
   // Renderer needs a beat to mount App + populate window.__ccsmStore.
   await sleep(2500);
-  return { electronApp, win, userDataDir, cleanup: cleanupUd };
+  return {
+    electronApp,
+    win,
+    userDataDir: effectiveUserDataDir,
+    cleanup: callerOwnsUserData ? () => {} : cleanupUd,
+  };
 }
 
 // ============================================================================
@@ -409,15 +445,36 @@ export async function seedSession(win, { sid, name = 'probe-session', cwd, group
  */
 export async function waitForWebviewMounted(win, electronApp, sessionId, { timeout = 10000 } = {}) {
   // Step 1: wait for the host-page <webview> tag for THIS session.
+  //
+  // Use `state: 'attached'` rather than the Playwright default `visible`.
+  // Electron `<webview>` elements report visibility inconsistently to
+  // Playwright on Windows — PR #462's failure showed the webview fully
+  // wired (ttyd up, websocket connected, claude PID running) yet the
+  // default visibility check timed out. `attached` is the right semantic
+  // for OOPIF probes: presence in DOM is sufficient because the xterm
+  // readiness check in step 3 already validates the inner page is live.
   const selector = `webview[title="ttyd session ${sessionId}"]`;
-  await win.waitForSelector(selector, { timeout });
+  await win.waitForSelector(selector, { timeout, state: 'attached' });
 
   // Step 2: poll for the matching WebContents in main process.
+  //
+  // Look up THIS session's ttyd port via the cliBridge IPC so we can
+  // filter webContents by URL — picking the highest-id webContents
+  // (the previous default) misfires on switch-session probes where
+  // multiple ttyd webviews are alive simultaneously.
+  const port = await win
+    .evaluate(
+      (sid) => window.ccsmCliBridge?.getTtydForSession?.(sid).catch(() => null),
+      sessionId,
+    )
+    .then((res) => (res && typeof res.port === 'number' ? res.port : null))
+    .catch(() => null);
+
   const deadline = Date.now() + timeout;
   let wcId = null;
   while (Date.now() < deadline) {
     try {
-      wcId = await getTtydWebContentsId(electronApp, { timeout: 1000 });
+      wcId = await getTtydWebContentsId(electronApp, { timeout: 1000, port });
       if (wcId != null) break;
     } catch (_) {
       // Keep polling.
@@ -425,7 +482,9 @@ export async function waitForWebviewMounted(win, electronApp, sessionId, { timeo
     await sleep(200);
   }
   if (wcId == null) {
-    throw new Error(`waitForWebviewMounted: no ttyd webContents found for session ${sessionId} within ${timeout}ms`);
+    throw new Error(
+      `waitForWebviewMounted: no ttyd webContents found for session ${sessionId} (port=${port ?? 'unknown'}) within ${timeout}ms`,
+    );
   }
 
   // Step 3: wait for xterm + window.term inside the OOPIF.
@@ -447,6 +506,75 @@ export async function waitForWebviewMounted(win, electronApp, sessionId, { timeo
   throw new Error(
     `waitForWebviewMounted: webview mounted (wcId=${wcId}) but xterm/window.term not ready within ${timeout}ms`,
   );
+}
+
+/**
+ * Dismiss claude's "Welcome back!" / "Try /help" splash card that intercepts
+ * the first keystrokes after a cold start. Sends Enter (via triggerDataEvent,
+ * NOT bracketed-paste) up to `maxAttempts` times until either:
+ *   - the splash text disappears from the visible buffer, OR
+ *   - the input prompt indicator (`│ >`) becomes visible (indicates input
+ *     box is interactive)
+ *
+ * Returns { dismissed: boolean, attempts: number, finalScreen: string }.
+ * Never throws — splash absence is the happy path. Callers can inspect the
+ * result if they want to assert the splash was actually present.
+ *
+ * Probes #505 (new-session-chat) and #506 (switch-session-keeps-chat)
+ * regressed because their first prompt keystrokes hit the splash card,
+ * not the input field — claude never received the user message.
+ */
+export async function dismissWelcomeSplash(
+  electronApp,
+  wcId,
+  { maxAttempts = 3, settleMs = 500 } = {},
+) {
+  // Heuristics for "splash is present":
+  //   - "Welcome back" greeting line
+  //   - "Try /" or "/help" hint card
+  //   - "press Enter" / "Press Enter" prompt to dismiss
+  // Heuristics for "input ready" (definitely past splash):
+  //   - "│ >" or "> " followed by cursor (claude TUI input row)
+  const splashRe = /Welcome back|Try \/|press Enter|Press Enter/;
+  const readyRe = /│\s*>|^\s*>\s*$/m;
+
+  let attempts = 0;
+  let finalScreen = '';
+  for (let i = 0; i < maxAttempts; i++) {
+    const buf = await readXtermBufferSafe(electronApp, wcId);
+    finalScreen = buf.screen;
+    const hasSplash = splashRe.test(buf.screen);
+    const hasReady = readyRe.test(buf.screen);
+    if (!hasSplash && hasReady) {
+      return { dismissed: i > 0, attempts, finalScreen };
+    }
+    if (!hasSplash && i > 0) {
+      // Splash gone, no explicit ready marker — accept.
+      return { dismissed: true, attempts, finalScreen };
+    }
+    // Send a bare Enter via triggerDataEvent (no bracketed-paste).
+    try {
+      await sendToClaudeTui(electronApp, wcId, '\r');
+      attempts++;
+    } catch (_) {
+      // term not reachable — bail without throwing.
+      return { dismissed: false, attempts, finalScreen };
+    }
+    await sleep(settleMs);
+  }
+  // Final read so caller sees the post-attempt state.
+  const buf = await readXtermBufferSafe(electronApp, wcId);
+  finalScreen = buf.screen;
+  const stillSplash = splashRe.test(buf.screen);
+  return { dismissed: !stillSplash, attempts, finalScreen };
+}
+
+async function readXtermBufferSafe(electronApp, wcId) {
+  try {
+    return await readXtermBuffer(electronApp, wcId);
+  } catch (_) {
+    return { full: '', screen: '' };
+  }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Patches `scripts/probe-utils-real-cli.mjs` (the shared real-claude probe helper merged via #457) to address gaps surfaced by the 5 sister probes (#458 / #459 / #460 / #461 / #462).

Touches ONLY the helper. No probe files modified. No product code touched.

## Helper changes

| # | Change | Surfaced by |
|---|---|---|
| 1 | `dismissWelcomeSplash(electronApp, wcId, opts?)` — new helper. Detects claude's "Welcome back!" / "Try /help" / "press Enter" splash card via xterm buffer text and sends Enter via `triggerDataEvent` (NOT bracketed-paste) up to N times until the splash disappears or the input prompt indicator (`│ >`) is visible. Returns `{ dismissed, attempts, finalScreen }`; never throws. | #461 (#506) — the `A-first-reply` PASS was a false positive: ALPHA never reached claude because the first keystrokes hit the splash. Same hazard called out by #458 (#504, UX E) which had to inline `Enter` mashing. |
| 2 | `waitForWebviewMounted` — selector now uses `state: 'attached'` instead of Playwright's default `state: 'visible'`. Electron `<webview>` reports visibility inconsistently to Playwright on Windows; presence in DOM is the correct semantic for an OOPIF probe (the xterm-readiness check that follows already validates the inner page). | #462 (#505) — main-process logs showed ttyd fully wired (port listening, websocket connected, claude PID started) yet `waitForSelector` (visible) timed out at 60s. |
| 3 | `launchCcsmIsolated({ tempDir, userDataDir?, env? })` — accepts caller-supplied `userDataDir`. When supplied, helper uses it verbatim and does NOT register it for cleanup (caller owns lifecycle). Without it, behaviour is unchanged (mint fresh + auto-cleanup). | #459 (#507, UX G) — reopen-resume probe needs ccsm.db to persist across two `launchCcsmIsolated` calls on the same Electron user-data-dir. The previous mkdtempSync-always behaviour blocked cross-restart probes. |
| 4 | `process.on('unhandledRejection', cleanup)` hook installed alongside existing `exit` / `SIGINT` / `SIGTERM` / `uncaughtException` hooks. Async electron crashes now run the tempdir cleanup instead of leaking. | #457 review feedback (reviewer noted async crash leaks). |
| 5 | `waitForWebviewMounted` URL filter — looks up the session's ttyd port via `bridge.getTtydForSession(sid)` IPC and passes it to `getTtydWebContentsId({ port })`, which filters webContents by URL prefix `http://127.0.0.1:<port>/`. Eliminates the highest-id race when multiple ttyd webviews are alive simultaneously (switch-session). | #461 (#506) reviewer note — the round-trip A→B→A path keeps multiple ttyds alive, so highest-id heuristic could misfire; explicit port match is deterministic. |

Backward compatible: every existing call site keeps working without changes (port option is optional, userDataDir is optional, dismissWelcomeSplash is opt-in).

## Re-run results (after helper fix, against the cherry-picked probe files)

| Probe | Branch | Before | After helper fix | Outcome |
|---|---|---|---|---|
| #505 (UX C, new-session-chat) | `feat/probe-real-new-session` (#462) | FAIL — `waitForSelector(webview[title=...])` timeout 60s | **PASS** (all 10 steps green; claude replied in 2008ms) | helper bug — fixed by change #2 (`state: 'attached'`) |
| #506 (UX F, switch-keeps-chat) | `feat/probe-real-switch-session` (#461) | FAIL — empty xterm scrollback after switch-back | FAIL — same step (10/11 green; A's scrollback empty after switch-back). Mount/port-reuse logic all PASS (ports preserved across A→B→A round-trip, webview correctly attaches to original port 56475). | mixed — helper fix unblocks the mount path but the probe itself doesn't yet call `dismissWelcomeSplash`, so `A-first-reply` is still a false positive (claude shows only `❯` and `? for shortcuts` in the tail, no ALPHA echo — first keystrokes ate by splash) |

### Outcome case: **2** (split)

- **#505 was a probe/helper bug.** The new helper unblocks it cleanly — 10/10 PASS. Recommend the manager re-review #462 against this helper PR (no probe-side changes needed) and merge.
- **#506 is partially helper, partially probe-side.** The cliBridge port-reuse path is verified correct (4 PASS steps explicitly proving A's port is preserved and re-attached). The remaining FAIL is the scrollback assertion, which can't be evaluated yet because the splash-card hypothesis can't be ruled out from this run (probe doesn't call `dismissWelcomeSplash` because it predates this helper). 
  - Recommended next step: a tiny follow-up worker on #461's branch to insert `await dismissWelcomeSplash(electronApp, wcA)` between `select-A-mounted` and the first ALPHA send. After that change, the run will be definitive: 
    - If ALPHA echoes back AND scrollback persists → all green, full PASS.
    - If ALPHA echoes back AND scrollback empty after switch → genuine ttyd-scrollback product bug (task #511 / new bug-fix worker scope).

### Recommended manager next step

1. Review + merge this helper PR.
2. Re-trigger #462's reviewer (probe should now PASS unchanged against the merged helper).
3. Dispatch a 15-minute follow-up worker on #461 to wire `dismissWelcomeSplash` into the probe; that worker will produce the definitive Case 2-or-Case 4 verdict for #506.

## Local verification commands

```bash
# Helper syntax
node --check scripts/probe-utils-real-cli.mjs

# Build prod bundle (TtydPane.tsx newer than dist/renderer/index.html)
npm run build

# Cherry-pick + run sister probes against the new helper
git checkout origin/feat/probe-real-new-session -- scripts/probe-real-new-session-chat.mjs
git checkout origin/feat/probe-real-switch-session -- scripts/probe-real-switch-session-keeps-chat.mjs
node scripts/probe-real-new-session-chat.mjs   # PASS
node scripts/probe-real-switch-session-keeps-chat.mjs   # FAIL at scrollback (probe-side splash-dismiss missing)
```

## Test plan

- [x] `node --check scripts/probe-utils-real-cli.mjs` — clean
- [x] Re-ran #505's probe against the helper — PASS exit 0
- [x] Re-ran #506's probe against the helper — same step still FAIL but for diagnosable reason (probe doesn't yet call new `dismissWelcomeSplash`)
- [x] No probe files modified in this PR
- [x] No product code touched