### PR TITLE
fix(ttyd): use --resume when JSONL exists on disk (closes #507, #508)

### DIFF
--- a/electron/cliBridge/processManager.ts
+++ b/electron/cliBridge/processManager.ts
@@ -6,9 +6,16 @@
 //
 // Lifecycle:
 //   - openTtydForSession  → spawn ttyd with `claude --session-id <uuid>`
-//                           (new chat). Returns {port, sid}. Caller keys
-//                           ccsm's session row by `sid` so the JSONL
-//                           transcript on disk and ccsm's session id
+//                           when no on-disk JSONL exists for the projected
+//                           sid (fresh session), OR `claude --resume <uuid>`
+//                           when one does (app restart, imported transcript,
+//                           prior in-app spawn that exited). The on-disk
+//                           JSONL is the only ground truth — fixes #507/#508
+//                           where always passing `--session-id` made claude
+//                           reject with "Session ID is already in use." on
+//                           any rehydrated session. Returns {port, sid}.
+//                           Caller keys ccsm's session row by `sid` so the
+//                           JSONL transcript on disk and ccsm's session id
 //                           agree (matches the existing agent:start
 //                           pre-allocated-uuid pattern).
 //   - resumeTtydForSession → spawn ttyd with `claude --resume <sid>`
@@ -32,6 +39,9 @@
 
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
 import { createHash } from 'node:crypto';
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join as pathJoin } from 'node:path';
 import type { WebContents } from 'electron';
 import { pickFreePort } from './portAllocator';
 import { resolveClaude } from './claudeResolver';
@@ -254,7 +264,77 @@ export async function openTtydForSession(
   // → ccsm sidebar ↔ on-disk transcript stay aligned (the previous
   // randomUUID() per spawn caused divergence + orphaned JSONLs).
   const sid = toClaudeSid(sessionId);
+  // If the JSONL transcript already exists on disk for this sid (app
+  // restart, imported session, prior in-app spawn that exited), claude
+  // refuses `--session-id <sid>` with "Session ID is already in use." We
+  // must `--resume <sid>` instead so the prior conversation reattaches.
+  // Fixes #507 (UX G reopen-resume) and #508 (UX H import-resume).
+  //
+  // Backend-decides over renderer-decides: the on-disk JSONL is the only
+  // source of truth — the renderer cannot distinguish a fresh-this-session
+  // sid from a rehydrated-from-persistence sid without a roundtrip anyway.
+  // Keeping the decision here means a single codepath for both new and
+  // rehydrated sessions, and no new IPC surface.
+  if (jsonlExistsForSid(sid)) {
+    return spawnTtyd(sessionId, cwd, ['--resume', sid]);
+  }
   return spawnTtyd(sessionId, cwd, ['--session-id', sid]);
+}
+
+// Synchronously locate a `<sid>.jsonl` transcript anywhere under the
+// claude projects root(s). claude encodes each cwd as a flattened
+// directory name (e.g. `C:\foo\bar` → `C--foo-bar`); rather than
+// reproducing that encoding (which we don't fully own — it's a CLI
+// implementation detail), scan all project subdirs and return true on
+// first match. ~tens of dirs in steady state, single readdir + a per-dir
+// existsSync — well below the spawnTtyd 200ms warmup budget.
+//
+// Two roots to scan, mirroring two codepaths:
+//   1. `${CLAUDE_CONFIG_DIR}/projects/` when env is set — matches where
+//      ccsm-spawned claude writes transcripts (commands-loader.ts uses
+//      CLAUDE_CONFIG_DIR as a full replacement for ~/.claude).
+//   2. `${HOME}/.claude/projects/` — matches where the import scanner
+//      reads imported transcripts from (import-scanner.ts uses
+//      `os.homedir() + .claude` directly), and where production claude
+//      writes when CLAUDE_CONFIG_DIR is unset.
+// Production: both resolve to the same path so we deduplicate. The
+// probes set HOME and CLAUDE_CONFIG_DIR to the same tempDir but the
+// scanner places imports under `${tempDir}/.claude/projects/` while
+// spawned claude writes to `${tempDir}/projects/` — so we need both.
+//
+// Best-effort: any fs error → treat as "no transcript", which falls
+// back to `--session-id` (the prior behavior).
+function jsonlExistsForSid(sid: string): boolean {
+  const roots = new Set<string>();
+  if (process.env.CLAUDE_CONFIG_DIR) {
+    roots.add(pathJoin(process.env.CLAUDE_CONFIG_DIR, 'projects'));
+  }
+  roots.add(pathJoin(homedir(), '.claude', 'projects'));
+  const filename = `${sid}.jsonl`;
+  for (const root of roots) {
+    let dirs: string[];
+    try {
+      dirs = readdirSync(root);
+    } catch {
+      continue;
+    }
+    for (const d of dirs) {
+      const candidate = pathJoin(root, d, filename);
+      try {
+        if (existsSync(candidate)) {
+          // Guard against accidentally matching a 0-byte placeholder; only
+          // treat the file as a real transcript when there's content to
+          // resume. A truly fresh `--session-id` spawn has no JSONL yet,
+          // so a stat here can't false-positive on what we just spawned.
+          const st = statSync(candidate);
+          if (st.isFile() && st.size > 0) return true;
+        }
+      } catch {
+        /* skip unreadable entries */
+      }
+    }
+  }
+  return false;
 }
 
 export async function resumeTtydForSession(


### PR DESCRIPTION
## Approach

**Approach A (backend-decides)**: `openTtydForSession` stats the on-disk JSONL for the projected sid before spawning. If found + non-empty -> `--resume <sid>`. Otherwise `--session-id <sid>` (fresh, prior behavior).

**Why A over B (renderer-decides via `resumeTtydForSession`):** the on-disk JSONL is the only source of truth. The renderer cannot reliably distinguish a fresh-this-session sid from a rehydrated-from-persistence sid without a roundtrip — there is no `session.persistedFromDisk` flag, and `resumeSessionId` is only set on import (not on app-restart-rehydrate). Backend-decides keeps a single codepath for both new and rehydrated sessions, no new IPC surface, no churn in TtydPane. The existing `resumeTtydForSession` IPC and preload entry are left untouched (still callable for explicit-resume paths if needed later).

## Files changed

- **`electron/cliBridge/processManager.ts`** — `openTtydForSession` now calls a new helper `jsonlExistsForSid(sid)` that stat's `<sid>.jsonl` under `${CLAUDE_CONFIG_DIR}/projects/` and `${HOME}/.claude/projects/` (dual-scan to align with `commands-loader.ts` and `import-scanner.ts` respectively — both paths coincide in production but diverge under probe overrides). If found, swap `--session-id` for `--resume`. ~80 LOC of additions, all guarded by the existing `existing.status === 'running'` reuse path so no perf hit on hot reuses.

No `src/` changes — the renderer side (`TtydPane.tsx`) keeps calling `openTtydForSession` unconditionally and the fix is transparent.

## Re-run results

| Probe | Before | After |
|-------|--------|-------|
| #459 (`probe-real-reopen-resume`) | FAIL: 'Session ID is already in use' | **Fix verified** — `--resume` is invoked (no ttyd-exit, no 'already in use'). Probe still surfaces FAIL but for an unrelated trust-modal-dismissal gap (see below). |
| #460 (`probe-real-import-resume`) | FAIL: same | **Fix verified** — `--resume` is invoked, no ttyd-exit. Probe FAIL is now a probe-setup mismatch (see below). |
| #455 (`probe-real-cwd-projects-claude`) | PASS | **PASS** (verified) |
| #506 (switch) | ambiguous | not addressed here — task #512's territory. |

### Why the two target probes still report FAIL despite a working fix

I verified the fix end-to-end by **temporarily** patching each probe locally (NOT committed). Both probes pass when patched:

1. **#459 reopen-resume**: probe's run2 polls for the OMEGA token immediately after the webview mounts, but claude shows the trust-folder modal again on `--resume` (because run1's modal-dismissal loop pressed Enter rather than '1\r' and `hasTrustDialogAccepted: false` persisted). When I added a 6-iteration '1\r' dismissal loop in run2 mirroring the one already in run1, the probe **PASSES** — OMEGA appears in the resumed buffer and the follow-up reply lands. So the fix works; the probe just needs a run2 trust-dismissal loop. Filing this as a probe follow-up.

2. **#460 import-resume**: probe seeds the JSONL at `${tempDir}/.claude/projects/...` (matching `import-scanner.ts`'s `os.homedir()` lookup), but claude with `CLAUDE_CONFIG_DIR=tempDir` writes/reads transcripts at `${tempDir}/projects/...`. So `--resume <sid>` fails with `No conversation found with session ID: ...` — claude itself can't find the seeded JSONL because the probe's seed-path doesn't match where claude looks under its own env. My code's dual-root scan finds it (correctly!), but `--resume` fails downstream because claude only checks one location. **In production this works** (no `CLAUDE_CONFIG_DIR` override → both paths collapse to `~/.claude/projects/`). Probe needs to seed at `${tempDir}/projects/...` instead of `${tempDir}/.claude/projects/...`. Filing this as a probe follow-up too.

### #496 stash usefulness

Inspected `stash@{0}` in pool-4 read-only — it was only `package-lock.json` churn (no electron/src changes). Not useful.

## Test plan

- [x] `node scripts/probe-real-cwd-projects-claude.mjs` PASS (no regression)
- [x] `node scripts/probe-real-reopen-resume.mjs` — fix path verified locally with patched probe (run2 trust dismissal); raw probe still hits the run2 modal gap
- [x] `node scripts/probe-real-import-resume.mjs` — fix path verified locally with patched probe; raw probe hits a seed-path mismatch in CLAUDE_CONFIG_DIR override
- [ ] In-app dogfood: open ccsm with persisted session, restart, click session, confirm chat resumes (manual smoke)

## Risks

- Adds a `readdirSync` + per-dir `existsSync` + `statSync` on every `openTtydForSession` cache-miss. Tens of dirs at most in steady state, dwarfed by the existing 200ms ttyd warmup sleep. Already wrapped in try/catch; any fs error → falls back to `--session-id` (current behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)