### PR TITLE
fix(ttyd): keep claude alive across ws-client reconnect (UX F)

### DIFF
--- a/electron/cliBridge/processManager.ts
+++ b/electron/cliBridge/processManager.ts
@@ -5,19 +5,27 @@
 // `<iframe src="http://127.0.0.1:<port>">`.
 //
 // Lifecycle:
-//   - openTtydForSession  → spawn ttyd with `claude --session-id <uuid>`
-//                           when no on-disk JSONL exists for the projected
-//                           sid (fresh session), OR `claude --resume <uuid>`
-//                           when one does (app restart, imported transcript,
-//                           prior in-app spawn that exited). The on-disk
-//                           JSONL is the only ground truth — fixes #507/#508
-//                           where always passing `--session-id` made claude
-//                           reject with "Session ID is already in use." on
-//                           any rehydrated session. Returns {port, sid}.
-//                           Caller keys ccsm's session row by `sid` so the
-//                           JSONL transcript on disk and ccsm's session id
-//                           agree (matches the existing agent:start
-//                           pre-allocated-uuid pattern).
+//   - openTtydForSession  → spawn ttyd with a tiny Node wrapper that
+//                           re-evaluates JSONL existence on every
+//                           ttyd-internal PTY spawn and chooses
+//                           `claude --session-id <uuid>` (no JSONL,
+//                           fresh) vs `claude --resume <uuid>` (JSONL
+//                           present, rehydrate). The wrapper — not
+//                           claude directly — is ttyd's command, so
+//                           the decision is re-made every time ttyd
+//                           respawns claude on a new ws-client (fixes
+//                           UX F switch-back: A→B→A would otherwise
+//                           reuse stale `--session-id` args and hit
+//                           "Session ID is already in use." once the
+//                           first turn had written the JSONL). Also
+//                           fixes #507/#508 (rehydrate on app
+//                           restart / imported transcripts) by the
+//                           same mechanism. Returns {port, sid}.
+//                           Caller keys ccsm's session row by `sid`
+//                           so the JSONL transcript on disk and
+//                           ccsm's session id agree (matches the
+//                           existing agent:start pre-allocated-uuid
+//                           pattern).
 //   - resumeTtydForSession → spawn ttyd with `claude --resume <sid>`
 //                            (re-attach to an existing CLI session).
 //   - killTtydForSession  → tree-kill the ttyd PID (Windows: taskkill
@@ -39,8 +47,8 @@
 
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { existsSync, readdirSync, statSync } from 'node:fs';
-import { homedir } from 'node:os';
+import { mkdirSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join as pathJoin } from 'node:path';
 import type { WebContents } from 'electron';
 import { pickFreePort } from './portAllocator';
@@ -104,9 +112,86 @@ function emitExit(sessionId: string, code: number | null, signal: NodeJS.Signals
   }
 }
 
-// Shared spawn helper. `claudeArgs` is the list AFTER the ttyd-owned
-// flags (`-p <port> -W -t fontSize=14 <claudePath>`); for new sessions
-// it's `['--session-id', sid]`, for resumes `['--resume', sid]`.
+// Tiny .cmd wrapper that ttyd execs in place of `claude` directly.
+// Re-evaluates JSONL existence on EVERY invocation and chooses
+// `--session-id <sid>` (fresh) vs `--resume <sid>` (rehydrate)
+// accordingly.
+//
+// Why a wrapper at all: ttyd spawns a NEW PTY child per websocket
+// client (see protocol.c LWS_CALLBACK_CLOSED → pty_kill). When the
+// user switches session A → B → A, A's webview unmounts → ws-client
+// disconnects → ttyd kills claude-A. On switch back, ttyd respawns
+// claude with the SAME baked-in args. If we baked `--session-id sid`
+// at first launch (no JSONL yet) and JSONL now exists from the prior
+// turn, claude rejects the second spawn with "Session ID is already
+// in use." (UX F bug.) #464's `openTtydForSession` picker only fires
+// on the FIRST spawn — it can't influence ttyd's internal respawn.
+//
+// Solution: ttyd's command is the wrapper, not claude. The wrapper
+// re-runs the JSONL scan on every spawn, so the second (and Nth) PTY
+// launch always picks the right flag for current disk state.
+//
+// Why .cmd and not Node-as-script: launching `electron.exe`
+// (process.execPath) with ELECTRON_RUN_AS_NODE=1 inside ttyd's
+// conpty-driven PTY access-violates on Windows (ttyd exits with
+// 0xC0000409 STATUS_STACK_BUFFER_OVERRUN before it can serve the
+// HTTP listener). cmd.exe is the native PTY shell on Windows, so a
+// .cmd shim has zero binding overhead and zero risk of conpty
+// regression. Two-root scan mirrors the (now-removed) JS-side
+// jsonlExistsForSid: CLAUDE_CONFIG_DIR/projects/* (set in dev/probe)
+// and %USERPROFILE%/.claude/projects/* (production default).
+const TTYD_WRAPPER_CMD = `@echo off
+setlocal EnableDelayedExpansion
+set "SID=%~1"
+set "CLAUDE=%~2"
+set "FILENAME=!SID!.jsonl"
+set RESUME=0
+if defined CLAUDE_CONFIG_DIR if exist "%CLAUDE_CONFIG_DIR%\\projects" (
+  for /d %%D in ("%CLAUDE_CONFIG_DIR%\\projects\\*") do (
+    if exist "%%~D\\!FILENAME!" for %%S in ("%%~D\\!FILENAME!") do if not %%~zS==0 set RESUME=1
+  )
+)
+if exist "%USERPROFILE%\\.claude\\projects" (
+  for /d %%D in ("%USERPROFILE%\\.claude\\projects\\*") do (
+    if exist "%%~D\\!FILENAME!" for %%S in ("%%~D\\!FILENAME!") do if not %%~zS==0 set RESUME=1
+  )
+)
+if "!RESUME!"=="1" (
+  call "!CLAUDE!" --resume "!SID!"
+) else (
+  call "!CLAUDE!" --session-id "!SID!"
+)
+exit /b %ERRORLEVEL%
+`;
+
+let cachedWrapperPath: string | null = null;
+
+// Write the wrapper .cmd to a stable per-user temp path so ttyd can
+// invoke it as a normal file. Cached across the process lifetime — the
+// wrapper contents never change at runtime, and overwriting on every
+// spawn would race ttyd's PTY child startup. Returns null if the temp
+// dir is unwritable (caller falls back to direct mode).
+function ensureWrapperCmd(): string | null {
+  if (cachedWrapperPath && existsSync(cachedWrapperPath)) return cachedWrapperPath;
+  try {
+    const dir = pathJoin(tmpdir(), 'ccsm-ttyd-wrapper');
+    mkdirSync(dir, { recursive: true });
+    const filePath = pathJoin(dir, 'claude-auto.cmd');
+    writeFileSync(filePath, TTYD_WRAPPER_CMD);
+    cachedWrapperPath = filePath;
+    return filePath;
+  } catch {
+    return null;
+  }
+}
+
+// Shared spawn helper. `claudeArgs` is the list of args appended to
+// the ttyd command line.
+//   - mode='direct' (default): `claudeArgs` is the args list claude
+//     receives directly, e.g. `['--resume', sid]` for explicit resumes.
+//   - mode='auto': `claudeArgs` is `[sid]` only — the wrapper script
+//     prepended by spawnTtyd picks --session-id vs --resume itself
+//     based on current JSONL state, on every ttyd-internal respawn.
 //
 // `cwd` is the directory `claude` should be launched in. Without it,
 // claude inherits Electron's cwd and writes its JSONL transcripts to
@@ -117,6 +202,7 @@ async function spawnTtyd(
   sessionId: string,
   cwd: string,
   claudeArgs: string[],
+  mode: 'auto' | 'direct' = 'direct',
 ): Promise<OpenResult | OpenError> {
   // Refuse to start a second ttyd for the same ccsm session — the prior
   // one would leak. Caller should explicitly kill first if they want a
@@ -166,8 +252,27 @@ async function spawnTtyd(
   //                       wasted-effort rounds (#499).
   //
   // Trailing positional args: the program ttyd should exec inside the
-  // pty — the absolute claude path + the per-mode args (--session-id
-  // for new, --resume for continue).
+  // pty.
+  //   - mode='direct': absolute claude path + per-mode args (e.g.
+  //     `<claudePath> --resume <sid>` for explicit resumes).
+  //   - mode='auto': the .cmd wrapper (see TTYD_WRAPPER_CMD comment)
+  //     called with `<sid> <claudePath>` so it picks --session-id vs
+  //     --resume on EVERY spawn — fixes UX F switch-back, where ttyd
+  //     respawns claude on each ws-client reconnect and the second
+  //     spawn must use --resume because the first turn already wrote
+  //     the JSONL. Falls back to direct --session-id if the wrapper
+  //     can't be written (e.g. unwritable temp).
+  let trailingArgs: string[];
+  if (mode === 'auto') {
+    const wrapper = ensureWrapperCmd();
+    if (wrapper) {
+      trailingArgs = [wrapper, ...claudeArgs, claudePath];
+    } else {
+      trailingArgs = [claudePath, '--session-id', ...claudeArgs];
+    }
+  } else {
+    trailingArgs = [claudePath, ...claudeArgs];
+  }
   const args = [
     '-p',
     String(port),
@@ -178,8 +283,7 @@ async function spawnTtyd(
     'fontSize=14',
     '-t',
     'theme={"background":"#0B0B0C"}',
-    claudePath,
-    ...claudeArgs,
+    ...trailingArgs,
   ];
 
   let proc: ChildProcess;
@@ -200,10 +304,10 @@ async function spawnTtyd(
     };
   }
 
-  // Determine sid: if --session-id was passed, the caller already chose
-  // it; if --resume was passed, the second arg is the existing sid.
-  // Either way, claudeArgs[1] is the sid we want to surface back.
-  const sid = claudeArgs[1] ?? '';
+  // Determine sid for the entry record. In auto mode `claudeArgs` is
+  // `[sid]`; in direct mode it's `['--resume', sid]` or
+  // `['--session-id', sid]`. The sid is the LAST element either way.
+  const sid = claudeArgs[claudeArgs.length - 1] ?? '';
 
   const entry: TtydEntry = { proc, port, sid, status: 'starting' };
   sessions.set(sessionId, entry);
@@ -264,78 +368,26 @@ export async function openTtydForSession(
   // → ccsm sidebar ↔ on-disk transcript stay aligned (the previous
   // randomUUID() per spawn caused divergence + orphaned JSONLs).
   const sid = toClaudeSid(sessionId);
-  // If the JSONL transcript already exists on disk for this sid (app
-  // restart, imported session, prior in-app spawn that exited), claude
-  // refuses `--session-id <sid>` with "Session ID is already in use." We
-  // must `--resume <sid>` instead so the prior conversation reattaches.
-  // Fixes #507 (UX G reopen-resume) and #508 (UX H import-resume).
+  // Use the wrapper-mode spawn so EVERY ttyd-internal claude respawn
+  // (one per ws-client connection — see TTYD_WRAPPER_SCRIPT comment)
+  // re-evaluates JSONL existence and picks --session-id vs --resume
+  // accordingly. Without this, the first spawn (no JSONL → uses
+  // --session-id) bakes args that the second spawn (JSONL now exists
+  // because the first turn wrote it) cannot reuse — claude rejects
+  // with "Session ID is already in use." (UX F switch-back bug).
   //
-  // Backend-decides over renderer-decides: the on-disk JSONL is the only
-  // source of truth — the renderer cannot distinguish a fresh-this-session
-  // sid from a rehydrated-from-persistence sid without a roundtrip anyway.
-  // Keeping the decision here means a single codepath for both new and
-  // rehydrated sessions, and no new IPC surface.
-  if (jsonlExistsForSid(sid)) {
-    return spawnTtyd(sessionId, cwd, ['--resume', sid]);
-  }
-  return spawnTtyd(sessionId, cwd, ['--session-id', sid]);
+  // Backend-decides over renderer-decides: the on-disk JSONL is the
+  // only source of truth — and the decision needs to be re-made on
+  // each spawn, not just the first. Keeping it inside the wrapper
+  // means a single codepath for new, rehydrated, and reconnected
+  // sessions, with no new IPC surface.
+  return spawnTtyd(sessionId, cwd, [sid], 'auto');
 }
 
-// Synchronously locate a `<sid>.jsonl` transcript anywhere under the
-// claude projects root(s). claude encodes each cwd as a flattened
-// directory name (e.g. `C:\foo\bar` → `C--foo-bar`); rather than
-// reproducing that encoding (which we don't fully own — it's a CLI
-// implementation detail), scan all project subdirs and return true on
-// first match. ~tens of dirs in steady state, single readdir + a per-dir
-// existsSync — well below the spawnTtyd 200ms warmup budget.
-//
-// Two roots to scan, mirroring two codepaths:
-//   1. `${CLAUDE_CONFIG_DIR}/projects/` when env is set — matches where
-//      ccsm-spawned claude writes transcripts (commands-loader.ts uses
-//      CLAUDE_CONFIG_DIR as a full replacement for ~/.claude).
-//   2. `${HOME}/.claude/projects/` — matches where the import scanner
-//      reads imported transcripts from (import-scanner.ts uses
-//      `os.homedir() + .claude` directly), and where production claude
-//      writes when CLAUDE_CONFIG_DIR is unset.
-// Production: both resolve to the same path so we deduplicate. The
-// probes set HOME and CLAUDE_CONFIG_DIR to the same tempDir but the
-// scanner places imports under `${tempDir}/.claude/projects/` while
-// spawned claude writes to `${tempDir}/projects/` — so we need both.
-//
-// Best-effort: any fs error → treat as "no transcript", which falls
-// back to `--session-id` (the prior behavior).
-function jsonlExistsForSid(sid: string): boolean {
-  const roots = new Set<string>();
-  if (process.env.CLAUDE_CONFIG_DIR) {
-    roots.add(pathJoin(process.env.CLAUDE_CONFIG_DIR, 'projects'));
-  }
-  roots.add(pathJoin(homedir(), '.claude', 'projects'));
-  const filename = `${sid}.jsonl`;
-  for (const root of roots) {
-    let dirs: string[];
-    try {
-      dirs = readdirSync(root);
-    } catch {
-      continue;
-    }
-    for (const d of dirs) {
-      const candidate = pathJoin(root, d, filename);
-      try {
-        if (existsSync(candidate)) {
-          // Guard against accidentally matching a 0-byte placeholder; only
-          // treat the file as a real transcript when there's content to
-          // resume. A truly fresh `--session-id` spawn has no JSONL yet,
-          // so a stat here can't false-positive on what we just spawned.
-          const st = statSync(candidate);
-          if (st.isFile() && st.size > 0) return true;
-        }
-      } catch {
-        /* skip unreadable entries */
-      }
-    }
-  }
-  return false;
-}
+// Note: the previous JS-side `jsonlExistsForSid` helper is gone — the
+// equivalent scan now lives inside TTYD_WRAPPER_SCRIPT and runs on
+// every ttyd PTY spawn (not just the first), which is what UX F
+// switch-back requires. See the wrapper script comment for details.
 
 export async function resumeTtydForSession(
   sessionId: string,

--- a/scripts/probe-real-switch-session-keeps-chat.mjs
+++ b/scripts/probe-real-switch-session-keeps-chat.mjs
@@ -1,0 +1,476 @@
+// probe-real-switch-session-keeps-chat — UX scenario F.
+//
+// User scenario (verbatim from product owner):
+//   "2 是在 session 之间切换，右边窗口随之切换，并且可以聊天，这个现在有问题，
+//    切换的时候当成是 resume 了，报错 session is already in use"
+//
+// Translation: when the user clicks between sessions in the sidebar, the right
+// pane should follow and remain chattable. The bug being locked down: switching
+// back to a session that already has a running ttyd was being treated as a
+// fresh resume — which collided with the existing claude PTY and surfaced a
+// "session already in use" error in the renderer.
+//
+// The fix lives in two places:
+//   * `electron/cliBridge/processManager.ts::getTtydForSession` returns the
+//     existing {port, sid} when the session's ttyd is still alive.
+//   * `src/components/TtydPane.tsx` calls `getTtydForSession` BEFORE
+//     `openTtydForSession`, attaching to the existing port instead of
+//     respawning.
+//
+// This probe verifies the round-trip A → B → A:
+//   1. Session A's ttyd webContents id is captured on the first mount.
+//   2. After switching to B and back to A, the renderer's TtydPane MUST
+//      reuse the same webContents (port reuse path).
+//   3. A's xterm scrollback still contains the ALPHA prompt/reply from
+//      step 1 (i.e. the conversation was preserved, not restarted).
+//   4. A second prompt sent in A also gets a reply.
+//   5. No console error toast about "already in use" appears, and no
+//      ttyd-exit event for A's sid was broadcast during the round-trip.
+//
+// Reviewer-flagged helper limitation (do NOT patch helper):
+//   `waitForWebviewMounted` picks the highest-id webContents — when both A's
+//   and B's ttyds are alive on switch-back, that helper might return B's id.
+//   We work around it here by remembering A's wcId from the first mount and
+//   asserting the live webview-set still contains it after switch-back.
+
+import { mkdirSync, writeFileSync, existsSync } from 'node:fs';
+import * as path from 'node:path';
+import {
+  createIsolatedClaudeDir,
+  launchCcsmIsolated,
+  seedSession,
+  waitForWebviewMounted,
+  waitForXtermBuffer,
+  sendToClaudeTui,
+  readXtermLines,
+  executeJavaScriptOnWebview,
+  dismissWelcomeSplash,
+} from './probe-utils-real-cli.mjs';
+
+const screenshotDir = path.resolve('docs/screenshots/probe-real-switch-session-keeps-chat');
+mkdirSync(screenshotDir, { recursive: true });
+
+const steps = [];
+const log = (step, ok, detail) => {
+  const entry = { step, ok, detail: detail ?? null };
+  steps.push(entry);
+  const tag = ok ? 'PASS' : 'FAIL';
+  const tail = detail ? ': ' + JSON.stringify(detail).slice(0, 240) : '';
+  console.log(`[STEP] ${step}: ${tag}${tail}`);
+};
+
+const ttydExits = [];
+const consoleErrors = [];
+
+let electronApp = null;
+let win = null;
+let ranCleanup = false;
+let exitCode = 1;
+let cleanupClaude = null;
+
+const finish = async () => {
+  if (ranCleanup) return;
+  ranCleanup = true;
+  const report = {
+    generatedAt: new Date().toISOString(),
+    steps,
+    ttydExits,
+    consoleErrors: consoleErrors.slice(0, 50),
+  };
+  try {
+    writeFileSync(path.join(screenshotDir, 'probe.json'), JSON.stringify(report, null, 2));
+  } catch { /* ignore */ }
+  if (electronApp) {
+    try { await electronApp.close(); } catch { /* ignore */ }
+  }
+  try { cleanupClaude?.(); } catch { /* ignore */ }
+  console.log(`\n===== ${exitCode === 0 ? '[PASS]' : '[FAIL]'} probe-real-switch-session-keeps-chat =====`);
+  if (exitCode !== 0) {
+    console.log(JSON.stringify(report, null, 2));
+  }
+  process.exit(exitCode);
+};
+
+const fail = async (reason) => {
+  console.error(`[FAIL] ${reason}`);
+  let screenshotPath = null;
+  let xtermTail = null;
+  if (win) {
+    const ts = Date.now();
+    screenshotPath = path.join(screenshotDir, `fail-${ts}.png`);
+    try {
+      await win.screenshot({ path: screenshotPath, fullPage: true });
+    } catch { /* ignore */ }
+  }
+  // Best-effort xterm buffer dump for the LAST captured webContents id, so
+  // failures involving xterm (scrollback / reply detection) show what was
+  // actually on screen. We capture lastWcId opportunistically as the probe
+  // advances; if it's null we just skip.
+  if (lastWcId != null && electronApp) {
+    try {
+      const lines = await readXtermLines(electronApp, lastWcId, { lines: 40 });
+      xtermTail = lines.join('\n');
+      console.error(`[xterm-tail wcId=${lastWcId}]\n${xtermTail}`);
+    } catch (err) {
+      console.error('[xterm-tail] read failed:', err?.message || err);
+    }
+  }
+  if (win) {
+    try {
+      const dump = await win.evaluate(() => {
+        const st = window.__ccsmStore?.getState?.() || null;
+        const probing = !!document.querySelector('[data-testid="claude-availability-probing"]');
+        const guide = !!document.querySelector('[data-testid="claude-missing-guide"]');
+        const skel = !!document.querySelector('[data-testid="main-skeleton"]');
+        const firstRun = !!document.querySelector('[data-testid="first-run-empty"]');
+        const wvCount = document.querySelectorAll('webview').length;
+        const wvTitles = Array.from(document.querySelectorAll('webview')).map((w) => w.getAttribute('title'));
+        return {
+          activeId: st?.activeId,
+          sessionIds: (st?.sessions || []).map((s) => ({ id: s.id, name: s.name, state: s.state, cwd: s.cwd })),
+          probing,
+          guide,
+          skel,
+          firstRun,
+          wvCount,
+          wvTitles,
+        };
+      });
+      console.error('[render-state]', JSON.stringify(dump, null, 2));
+    } catch { /* ignore */ }
+  }
+  if (screenshotPath) console.error(`[screenshot] ${screenshotPath}`);
+  exitCode = 1;
+  await finish();
+};
+
+// Tracked by the steps below so a FAIL can dump the most recent webview's
+// xterm buffer without having to plumb wcId into `fail()` each time.
+let lastWcId = null;
+
+process.on('uncaughtException', async (err) => {
+  console.error('[uncaughtException]', err);
+  await fail(`uncaughtException: ${err?.stack || err}`);
+});
+process.on('unhandledRejection', async (err) => {
+  console.error('[unhandledRejection]', err);
+  await fail(`unhandledRejection: ${err?.stack || err}`);
+});
+
+// ---- helpers local to this probe ----
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Send `text` to claude and wait for a non-echo reply containing `replyToken`.
+ * Strips the echoed prompt (which appears in claude's input box) before
+ * checking, mirroring dogfood-probe-happy-path.
+ */
+async function sendAndAwaitReply(electronApp, wcId, prompt, replyToken, { timeout = 90000 } = {}) {
+  // Make sure claude has focus before typing.
+  await executeJavaScriptOnWebview(electronApp, wcId, `(function(){
+    const ta = document.querySelector('.xterm-helper-textarea');
+    if (ta) ta.focus();
+    if (window.term && typeof window.term.focus === 'function') window.term.focus();
+    return true;
+  })()`);
+  await sleep(300);
+  await sendToClaudeTui(electronApp, wcId, prompt);
+  await sleep(400);
+  await sendToClaudeTui(electronApp, wcId, '\r');
+
+  const deadline = Date.now() + timeout;
+  let lastTail = '';
+  while (Date.now() < deadline) {
+    await sleep(2000);
+    const lines = await readXtermLines(electronApp, wcId, { lines: 200 }).catch(() => []);
+    const full = lines.join('\n');
+    lastTail = full.slice(-800);
+    // Drop the first occurrence of the echoed prompt before searching for the
+    // reply token so we don't false-positive on the user's own typing.
+    const after = full.split(prompt).slice(1).join(prompt);
+    if (after && new RegExp(replyToken).test(after)) {
+      return { ok: true, tail: lastTail };
+    }
+  }
+  return { ok: false, tail: lastTail };
+}
+
+/**
+ * Return all live ttyd webview ids known to the main process.
+ */
+async function listTtydWebviewIds(electronApp) {
+  return await electronApp.evaluate(({ webContents }) => {
+    const out = [];
+    for (const wc of webContents.getAllWebContents()) {
+      try {
+        if (wc.getType() === 'webview' && /^http:\/\/127\.0\.0\.1:\d+/.test(wc.getURL())) {
+          out.push({ id: wc.id, url: wc.getURL() });
+        }
+      } catch { /* ignore */ }
+    }
+    return out;
+  });
+}
+
+/**
+ * Ask main process for the running ttyd port for `sid` (mirrors the
+ * renderer's reuse-first call). Returns null if not running.
+ */
+async function getTtydPortForSid(win, sid) {
+  return await win.evaluate(async (sessionId) => {
+    const bridge = window.ccsmCliBridge;
+    if (!bridge?.getTtydForSession) return null;
+    try {
+      return await bridge.getTtydForSession(sessionId);
+    } catch (err) {
+      return { __error: String(err) };
+    }
+  }, sid);
+}
+
+// ---- run ----
+
+(async () => {
+  // Sanity: dist must be built.
+  if (!existsSync(path.resolve('dist/renderer/index.html'))) {
+    return fail('dist/renderer/index.html missing — run `npm run build` first');
+  }
+
+  // 1) isolated ~/.claude clone
+  const claude = await createIsolatedClaudeDir();
+  cleanupClaude = claude.cleanup;
+  const tempDir = claude.tempDir;
+  log('isolated-claude-dir', true, { tempDir });
+
+  // 2) launch ccsm
+  let launch;
+  try {
+    launch = await launchCcsmIsolated({ tempDir });
+  } catch (err) {
+    return fail(`launchCcsmIsolated: ${err?.message || err}`);
+  }
+  electronApp = launch.electronApp;
+  win = launch.win;
+
+  win.on('console', (msg) => {
+    if (msg.type() === 'error') consoleErrors.push({ type: 'error', text: msg.text() });
+  });
+  win.on('pageerror', (err) => consoleErrors.push({ type: 'pageerror', text: String(err) }));
+
+  // Subscribe to ttyd-exit broadcasts from the renderer side so we can later
+  // assert no exit fired for A during the round-trip.
+  await win.evaluate(() => {
+    window.__probeTtydExits = [];
+    const bridge = window.ccsmCliBridge;
+    if (bridge?.onTtydExit) {
+      bridge.onTtydExit((evt) => {
+        window.__probeTtydExits.push(evt);
+      });
+    }
+  });
+  log('boot', true, { tempDir });
+
+  // 3) seed two sessions (probe author chooses fixed ids so logs are readable)
+  let sidA, sidB;
+  try {
+    sidA = (await seedSession(win, { name: 'session-A', cwd: tempDir })).sid;
+    sidB = (await seedSession(win, { name: 'session-B', cwd: tempDir })).sid;
+    if (!sidA || !sidB || sidA === sidB) {
+      return fail(`seedSession returned bad ids A=${sidA} B=${sidB}`);
+    }
+    log('seed-sessions', true, { sidA, sidB });
+  } catch (err) {
+    return fail(`seedSession: ${err?.message || err}`);
+  }
+
+  // 4) select A; wait for webview + claude TUI; capture A's wcId.
+  //    First wait for the claude-availability probe to resolve — TtydPane
+  //    only mounts after `claudeAvailable===true`.
+  try {
+    await win.waitForFunction(
+      () => !document.querySelector('[data-testid="claude-availability-probing"]'),
+      null,
+      { timeout: 30000 },
+    );
+  } catch (err) {
+    return fail(`claude-availability never resolved: ${err?.message || err}`);
+  }
+  let wcA;
+  try {
+    await win.evaluate((id) => {
+      window.__ccsmStore.getState().selectSession(id);
+    }, sidA);
+    wcA = await waitForWebviewMounted(win, electronApp, sidA, { timeout: 45000 });
+    lastWcId = wcA;
+    // Wait until claude's banner / input box is visible so the conversation
+    // is actually live (otherwise the "send first prompt" step races claude's
+    // first-run setup screens).
+    await waitForXtermBuffer(electronApp, wcA, /claude|welcome|│|╭|\?\sfor\sshortcuts/i, {
+      timeout: 30000,
+    });
+    log('select-A-mounted', true, { wcA });
+  } catch (err) {
+    return fail(`select A / mount: ${err?.message || err}`);
+  }
+
+  // Snapshot A's port from main so we can compare on switch-back.
+  const portA1 = await getTtydPortForSid(win, sidA);
+  if (!portA1 || portA1.__error || typeof portA1.port !== 'number') {
+    return fail(`A's ttyd port not reported: ${JSON.stringify(portA1)}`);
+  }
+  log('A-port-captured', true, { port: portA1.port });
+
+  // Try to advance any first-run prompts so the input box accepts text.
+  for (let i = 0; i < 6; i++) {
+    const lines = await readXtermLines(electronApp, wcA, { lines: 30 }).catch(() => []);
+    const tail = lines.join('\n');
+    if (/│\s*>/m.test(tail) || /^\s*>\s/m.test(tail)) break;
+    await sendToClaudeTui(electronApp, wcA, '\r');
+    await sleep(1500);
+  }
+
+  // 5) send ALPHA prompt to A and wait for reply
+  const ALPHA_PROMPT = 'Please reply with the single word ALPHA';
+  await dismissWelcomeSplash(electronApp, wcA);
+  const reply1 = await sendAndAwaitReply(electronApp, wcA, ALPHA_PROMPT, 'ALPHA');
+  if (!reply1.ok) {
+    return fail(`A first reply (ALPHA) timed out. Tail:\n${reply1.tail}`);
+  }
+  log('A-first-reply', true, { tail: reply1.tail.slice(-200) });
+
+  // 6) switch to B; wait for B's webview + TUI
+  let wcB;
+  try {
+    await win.evaluate((id) => {
+      window.__ccsmStore.getState().selectSession(id);
+    }, sidB);
+    // Helper picks highest wcId — on first appearance of B that is B (B is
+    // newer than A). Capture it now for sanity.
+    wcB = await waitForWebviewMounted(win, electronApp, sidB, { timeout: 30000 });
+    lastWcId = wcB;
+    if (wcB === wcA) {
+      return fail(`switch to B: helper returned A's wcId (${wcA}); switch did not actually mount B`);
+    }
+    await waitForXtermBuffer(electronApp, wcB, /claude|welcome|│|╭|\?\sfor\sshortcuts/i, {
+      timeout: 30000,
+    });
+    await dismissWelcomeSplash(electronApp, wcB);
+    log('select-B-mounted', true, { wcB });
+  } catch (err) {
+    return fail(`select B / mount: ${err?.message || err}`);
+  }
+
+  // Confirm A's ttyd is still tracked on the main side (no kill on hide).
+  const portA2 = await getTtydPortForSid(win, sidA);
+  if (!portA2 || portA2.__error || portA2.port !== portA1.port) {
+    return fail(`A's ttyd dropped after switching to B: was ${portA1.port}, now ${JSON.stringify(portA2)}`);
+  }
+  log('A-port-still-alive-while-B-active', true, { port: portA2.port });
+
+  // 7) switch BACK to A; assert reuse
+  try {
+    await win.evaluate((id) => {
+      window.__ccsmStore.getState().selectSession(id);
+    }, sidA);
+  } catch (err) {
+    return fail(`selectSession back to A: ${err?.message || err}`);
+  }
+
+  // Wait for the host-page <webview> for A to be visible again. (B's webview
+  // tag is unmounted when activeId flips because TtydPane is keyed/conditional
+  // by sessionId via the parent; the live webContents for B is detached.)
+  try {
+    await win.waitForSelector(`webview[title="ttyd session ${sidA}"]`, { timeout: 15000 });
+  } catch (err) {
+    return fail(`A's <webview> did not re-appear after switch-back: ${err?.message || err}`);
+  }
+
+  // Confirm A's port is unchanged (reuse path, NOT respawn).
+  const portA3 = await getTtydPortForSid(win, sidA);
+  if (!portA3 || portA3.__error || portA3.port !== portA1.port) {
+    return fail(`A's ttyd port changed on switch-back (was ${portA1.port}, now ${JSON.stringify(portA3)}) — switch was treated as resume`);
+  }
+  log('A-port-reused-on-switch-back', true, { port: portA3.port });
+
+  // The original wcA was destroyed when A's TtydPane unmounted on switch-to-B
+  // (Electron <webview> tags own their webContents; removing the tag tears
+  // down the inner renderer). On switch-back, a NEW webview is mounted that
+  // attaches to the SAME ttyd port — that's the reuse path the bug fix
+  // exercised. ttyd replays its scrollback to the fresh client, so the live
+  // claude PTY is preserved.
+  //
+  // Capture the new wcId and confirm its URL points at A's original port.
+  let wcA2;
+  try {
+    wcA2 = await waitForWebviewMounted(win, electronApp, sidA, { timeout: 30000 });
+    lastWcId = wcA2;
+  } catch (err) {
+    return fail(`A's webview did not re-mount with xterm after switch-back: ${err?.message || err}`);
+  }
+  const liveAfter = await listTtydWebviewIds(electronApp);
+  const wcA2Entry = liveAfter.find((x) => x.id === wcA2);
+  if (!wcA2Entry || !wcA2Entry.url.includes(`:${portA1.port}`)) {
+    return fail(
+      `A's new webview wcId=${wcA2} url=${wcA2Entry?.url} does not point at original port ${portA1.port}; live=${JSON.stringify(liveAfter)}`,
+    );
+  }
+  log('A-webview-attached-to-original-port', true, { wcA2, url: wcA2Entry.url, originalPort: portA1.port });
+  // The reconnect respawns claude (ttyd's per-client PTY model — see
+  // processManager TTYD_WRAPPER_CMD) with `--resume <sid>`. Claude's
+  // first-run trust prompt re-appears whenever it sees a workspace
+  // its (isolated) config doesn't yet trust, so dismiss it again
+  // before checking scrollback. In production, settings persistence
+  // across spawns suppresses this; in the probe's isolated
+  // CLAUDE_CONFIG_DIR + repeated spawns it still fires.
+  for (let i = 0; i < 6; i++) {
+    const lines = await readXtermLines(electronApp, wcA2, { lines: 30 }).catch(() => []);
+    const tail = lines.join('\n');
+    if (/│\s*>/m.test(tail) || /^\s*>\s/m.test(tail)) break;
+    await sendToClaudeTui(electronApp, wcA2, '\r');
+    await sleep(1500);
+  }
+  // 8) confirm A's xterm buffer still has ALPHA history (replayed by ttyd to
+  //    the freshly-attached client).
+  //
+  //    The freshly-mounted webview attaches to the existing ttyd port, but
+  //    ttyd needs a brief moment to replay its scrollback over the new
+  //    websocket connection. Wait for ALPHA to actually surface in the
+  //    buffer (with a generous timeout) before failing.
+  try {
+    await waitForXtermBuffer(electronApp, wcA2, /ALPHA/, { timeout: 15000 });
+  } catch (_) { /* fall through to read + assert below for a useful tail */ }
+  const aLines = await readXtermLines(electronApp, wcA2, { lines: 200 }).catch(() => []);
+  const aFull = aLines.join('\n');
+  if (!/ALPHA/.test(aFull)) {
+    return fail(`A's scrollback lost ALPHA history after switch-back. lines=${aLines.length} fullLen=${aFull.length} json=${JSON.stringify(aLines.slice(-30))}`);
+  }
+  log('A-scrollback-preserved', true, { tail: aFull.slice(-300) });
+
+  // 9) send another prompt in A — confirm reply lands on the SAME conversation
+  const BETA_PROMPT = 'Please reply with the single word BETA';
+  await dismissWelcomeSplash(electronApp, wcA2);
+  const reply2 = await sendAndAwaitReply(electronApp, wcA2, BETA_PROMPT, 'BETA');
+  if (!reply2.ok) {
+    return fail(`A second reply (BETA) timed out after switch-back. Tail:\n${reply2.tail}`);
+  }
+  log('A-post-switch-reply', true, { tail: reply2.tail.slice(-200) });
+
+  // 10) assert no "already in use" error toast / console error AND no ttyd-exit for A
+  const exitsForA = await win.evaluate((sid) => {
+    const arr = window.__probeTtydExits || [];
+    return arr.filter((e) => e.sessionId === sid);
+  }, sidA);
+  if (exitsForA.length > 0) {
+    ttydExits.push(...exitsForA);
+    return fail(`ttyd-exit fired for A during round-trip: ${JSON.stringify(exitsForA)}`);
+  }
+  const inUseError = consoleErrors.find((e) => /already in use|session is already/i.test(e.text || ''));
+  if (inUseError) {
+    return fail(`renderer console contains "already in use" error: ${inUseError.text}`);
+  }
+  log('no-exit-no-in-use-error', true, { consoleErrorCount: consoleErrors.length });
+
+  exitCode = 0;
+  await finish();
+})();


### PR DESCRIPTION
## Summary
- Fixes UX F: switching A->B->A throws "Session ID is already in use" because ttyd respawns claude with stale --session-id on every ws-client reconnect (one PTY per client; see ttyd `protocol.c` `LWS_CALLBACK_CLOSED` -> `pty_kill`).
- Root cause: #464's `--session-id` vs `--resume` picker only fires inside `openTtydForSession`. When ttyd respawns claude internally on a new client connection, the args are baked-in from the original spawn -- so the second spawn passes `--session-id` even though the JSONL now exists from the first turn, and claude rejects with "Session ID is already in use."
- Fix: ttyd's command is now a tiny `.cmd` wrapper (not `claude` directly). The wrapper re-scans `CLAUDE_CONFIG_DIR/projects/*` and `%USERPROFILE%/.claude/projects/*` on EVERY invocation and picks `--session-id` (no JSONL) vs `--resume` (JSONL present) accordingly, so each ttyd-internal respawn gets fresh-disk-state args.

## Implementation notes
- Wrapper is generated to `%TEMP%/ccsm-ttyd-wrapper/claude-auto.cmd` on first spawn and reused across the process lifetime.
- First attempt used Electron-as-node (`process.execPath` + `ELECTRON_RUN_AS_NODE=1`) but ttyd's conpty PTY child access-violated (`0xC0000409 STATUS_STACK_BUFFER_OVERRUN`). The `.cmd` wrapper has zero conpty risk and zero binding overhead.
- `resumeTtydForSession` keeps direct mode (caller has already decided to resume).
- The previous JS-side `jsonlExistsForSid` is removed; the equivalent scan now lives inside the wrapper and runs every spawn -- which is what UX F requires.
- `openTtydForSession`'s same-session-running reuse is unchanged; the wrapper only matters for ttyd's INTERNAL respawn-on-new-ws-client.

## Test plan
- [x] `node scripts/probe-real-switch-session-keeps-chat.mjs` PASS locally (added the probe; previously failed on origin with "Session ID is already in use" after switch-back)
- [x] `node scripts/probe-real-new-session-chat.mjs` PASS locally -- no regression on the simplest case
- [x] `npm run typecheck` clean
- [x] `npm run build` clean

The probe also dismisses the trust-folder prompt on switch-back, since claude `--resume` re-prompts when the workspace trust isn't yet persisted in the probe's isolated `CLAUDE_CONFIG_DIR` (production settings persistence suppresses this in normal use).

Closes the UX F bug surfaced in #461 disambiguation.