### PR TITLE
fix(ux): blur trigger before focusing CLI on new session (closes #467 regression)

### DIFF
--- a/scripts/harness-real-cli.mjs
+++ b/scripts/harness-real-cli.mjs
@@ -567,6 +567,92 @@ async function caseImportResume({ electronApp, win, tempDir }) {
 }
 
 // ============================================================================
+// Case: new-session-focus-cli — clicking "New Session" must transfer focus
+// AWAY from the trigger button so a subsequent Enter goes to the CLI, not
+// to the still-focused button (which would re-fire and spawn yet another
+// session). Reproduces the user-reported bug behind the partial fix in
+// PR #467 (cliFocusNonce alone is insufficient — DOM focus stays on the
+// button).
+// ============================================================================
+
+async function caseNewSessionFocusCli({ electronApp, win, tempDir }) {
+  // Wait for boot probe so the main shell renders TtydPane/empty state
+  // rather than the availability spinner (which has no sidebar).
+  await win.waitForFunction(
+    () => !document.querySelector('[data-testid="claude-availability-probing"]'),
+    null,
+    { timeout: 30000 },
+  );
+
+  // Reproduce the user-reported flow. Bug repro requires the sidebar
+  // "New Session" button to retain DOM focus after activation. PR #467's
+  // cliFocusNonce path moves focus to the embedded webview ONLY when
+  // (a) a webview already exists AND (b) its dom-ready has fired. If the
+  // CURRENT session's TtydPane is still in 'loading' state at the moment
+  // of click — e.g., the user just created a session and immediately
+  // creates another, or ttyd port allocation is slow — flushFocus is a
+  // no-op, the button keeps focus, and the next Enter re-fires it.
+  //
+  // The harness's shared launch may already have sessions from earlier
+  // cases; that's fine. We seed a fresh session so TtydPane is in
+  // 'loading' state, then immediately activate sidebar New Session.
+  await win.evaluate(() => {
+    const useStore = window.__ccsmStore;
+    useStore.setState({ tutorialSeen: true });
+  });
+  // Seed a session and don't wait for its webview to finish loading —
+  // the bug surfaces precisely when state.kind === 'loading' and there
+  // is no webview to receive focus.
+  const { sid: seedSid } = await seedSession(win, { name: 'focus-loading', cwd: tempDir });
+  if (!seedSid) throw new Error('seedSession returned empty sid');
+  // Tiny wait so the sidebar+TtydPane mount, but NOT enough for ttyd to
+  // resolve and dom-ready to fire (typically 1500ms+).
+  await sleep(150);
+
+  await win.waitForSelector('[data-testid="sidebar-newsession-row"]', { timeout: 10000 });
+
+  const before = await win.evaluate(() => window.__ccsmStore.getState().sessions.length);
+
+  // Focus the sidebar "New Session" button via JS (mirrors keyboard-walk
+  // or post-mousedown DOM state) and activate via Enter, then immediately
+  // press Enter again.
+  await win.evaluate(() => {
+    const el = document.querySelector('[data-testid="sidebar-newsession-row"] button');
+    if (!el) throw new Error('sidebar new-session button not found');
+    el.focus();
+  });
+  await win.keyboard.press('Enter');
+  // Tight gap: enough for React to commit the cliFocusNonce bump (and
+  // for flushFocus to run) but NOT enough for a fresh webview's
+  // dom-ready to fire.
+  await sleep(50);
+  await win.keyboard.press('Enter');
+
+  // Wait long enough for any second createSession to land in the store.
+  await sleep(2500);
+
+  const after = await win.evaluate(() => window.__ccsmStore.getState().sessions.length);
+  const delta = after - before;
+  if (delta !== 1) {
+    const focusAfter = await win.evaluate(() => {
+      const el = document.activeElement;
+      if (!el) return { tag: null };
+      return {
+        tag: el.tagName,
+        text: (el.textContent || '').trim().slice(0, 80),
+        testid: el.getAttribute('data-testid'),
+        ariaLabel: el.getAttribute('aria-label'),
+      };
+    });
+    throw new Error(
+      `expected exactly 1 new session after focus+Enter+Enter, got ${delta} ` +
+        `(before=${before}, after=${after}). ` +
+        `Active element after: ${JSON.stringify(focusAfter)}`,
+    );
+  }
+}
+
+// ============================================================================
 // Case 5: reopen-resume (UX G) — owns its launches
 // ============================================================================
 
@@ -695,6 +781,7 @@ const CASE_REGISTRY = [
   { name: 'switch-session-keeps-chat', group: 'shared', run: caseSwitchSessionKeepsChat },
   { name: 'cwd-projects-claude',       group: 'shared', run: caseCwdProjectsClaude },
   { name: 'import-resume',             group: 'shared', run: caseImportResume },
+  { name: 'new-session-focus-cli',     group: 'shared', run: caseNewSessionFocusCli },
   { name: 'reopen-resume',             group: 'standalone', run: caseReopenResume },
 ];
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -230,8 +230,23 @@ export default function App() {
   // every session switch — only on this explicit new-session intent — so
   // navigating between existing sessions (arrow keys in sidebar, palette
   // selection, etc.) keeps the user's prior focus context.
+  //
+  // We ALSO blur the trigger element synchronously here. PR #467 only
+  // moved focus *into* the webview when its dom-ready had already fired
+  // — but a fresh TtydPane is in 'loading' state at click time, so
+  // flushFocus is a no-op and the trigger button retains DOM focus.
+  // Pressing Enter again then re-activates the button → spawns yet
+  // another session. Blurring the active element synchronously breaks
+  // that loop regardless of webview readiness; the subsequent dom-ready
+  // → flushFocus path then moves focus into the CLI as intended.
   const [cliFocusNonce, setCliFocusNonce] = React.useState(0);
   const newSession = React.useCallback(() => {
+    if (typeof document !== 'undefined') {
+      const active = document.activeElement;
+      if (active instanceof HTMLElement && active !== document.body) {
+        try { active.blur(); } catch { /* noop */ }
+      }
+    }
     createSession(null);
     setCliFocusNonce((n) => n + 1);
   }, [createSession]);

--- a/src/components/TtydPane.tsx
+++ b/src/components/TtydPane.tsx
@@ -145,6 +145,14 @@ export function TtydPane({ sessionId, cwd, focusRequestNonce }: Props) {
   // — xterm.js routes keyboard input through that hidden textarea, so
   // focusing the webview alone leaves the cursor un-blinking and the
   // first keystroke gets dropped.
+  //
+  // The xterm helper textarea is constructed AFTER dom-ready (the page
+  // has to download xterm.js, mount Terminal, then xterm injects the
+  // textarea). A single executeJavaScript right at dom-ready often hits
+  // a null selector. We retry on a short backoff so the focus actually
+  // lands inside xterm rather than only on the host webview tag (which
+  // forwards key events but leaves the cursor non-blinking and the
+  // first keystroke discarded by xterm's own focus gate).
   const flushFocus = useCallback(() => {
     const wv = webviewRef.current;
     if (!wv || !domReadyRef.current) return;
@@ -155,14 +163,21 @@ export function TtydPane({ sessionId, cwd, focusRequestNonce }: Props) {
       // focus() can throw if the webview was just detached; ignore
       // — the next nonce bump will retry.
     }
-    // Best-effort: if the embedded page hasn't loaded xterm yet
-    // (very fast new-session race) the selector returns null and the
-    // call is a no-op. The user's first keystroke after the webview
-    // itself has focus will still register inside xterm because
-    // <webview> forwards key events to its hosted page.
+    // Retry the helper-textarea focus a few times — xterm constructs
+    // the textarea asynchronously after the embedded page loads, so
+    // the first call (right at dom-ready) usually misses.
     void wv
       .executeJavaScript(
-        "(() => { const el = document.querySelector('.xterm-helper-textarea'); if (el) el.focus(); })();"
+        `(function(){
+          const tryFocus = (attemptsLeft) => {
+            const el = document.querySelector('.xterm-helper-textarea');
+            if (el) { el.focus(); return true; }
+            if (attemptsLeft <= 0) return false;
+            setTimeout(() => tryFocus(attemptsLeft - 1), 100);
+            return false;
+          };
+          return tryFocus(20);
+        })();`,
       )
       .catch(() => {});
   }, []);


### PR DESCRIPTION
## Summary
- PR #467 added `cliFocusNonce` -> `webview.focus()` to land focus in the CLI after creating a new session, but the trigger button kept DOM focus whenever `TtydPane` was still in `loading` state at click time -- which is exactly the case right after `createSession`. `flushFocus` is a no-op (no webview yet), the button stays focused, and the user's next Enter re-fires the button -> spawns another session. Repeats N times -> N extra sessions.
- Fix has two parts:
  1. `App.newSession` blurs `document.activeElement` synchronously before calling `createSession` + bumping the nonce -- breaks the re-fire loop regardless of webview readiness.
  2. `TtydPane.flushFocus` retries the `.xterm-helper-textarea` focus on a 100ms backoff (up to 2s) since xterm constructs the helper textarea AFTER `dom-ready` (previous single-shot call usually missed -> first keystroke dropped, cursor non-blinking).

## Repro / e2e
New harness case `new-session-focus-cli`:
- Seeds a session (so `TtydPane` is in `loading` state -- the bug window).
- Focuses the sidebar New Session button, presses Enter twice with a 50ms gap.
- Asserts session count grew by exactly 1 (not 2).

Reproduces on `b80d8ca` (delta=2 -> FAIL), PASSes after this fix.

## Test plan
- [x] `node scripts/harness-real-cli.mjs --only=new-session-focus-cli` -- PASS
- [x] Reverse-verified: stash this PR's src/ changes -> e2e FAILs with `expected exactly 1 new session, got 2`
- [x] Full harness `node scripts/harness-real-cli.mjs` -- 6/6 PASS