### PR TITLE
feat(preload): expose window.ccsmPty + ccsmPty.clipboard

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,5 +1,5 @@
 import '@sentry/electron/preload';
-import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron';
+import { contextBridge, ipcRenderer, clipboard, type IpcRendererEvent } from 'electron';
 import type {
   ConnectionInfo,
   OpenSettingsResult,
@@ -203,3 +203,80 @@ const cliBridge = {
 contextBridge.exposeInMainWorld('ccsmCliBridge', cliBridge);
 
 export type CCSMCliBridgeAPI = typeof cliBridge;
+
+// ─────────────────────────── ccsmPty ─────────────────────────────────────
+//
+// In-process node-pty bridge that replaces the ttyd HTTP/WebSocket detour.
+// Exposed under `window.ccsmPty` in parallel with `window.ccsmCliBridge`
+// during the migration; PR-8 deletes the old ttyd surface once every
+// renderer call site has moved over.
+//
+// `onData` / `onExit` use a listener-set fan-out pattern (see spike
+// `xterm-attach/src/preload.cjs`) so multiple subscribers can attach
+// without each registering its own ipcRenderer listener — important
+// because every TerminalPane mount would otherwise leak a handler on
+// the single shared 'pty:data' channel.
+
+type PtyDataPayload = { sid: string; chunk: string };
+type PtyExitPayload = {
+  sessionId: string;
+  code: number | null;
+  signal: number | null;
+};
+
+const ptyDataListeners = new Set<(e: PtyDataPayload) => void>();
+const ptyExitListeners = new Set<(e: PtyExitPayload) => void>();
+
+ipcRenderer.on('pty:data', (_e: IpcRendererEvent, payload: PtyDataPayload) => {
+  for (const cb of ptyDataListeners) {
+    try {
+      cb(payload);
+    } catch (err) {
+      console.error('[ccsmPty] onData listener threw', err);
+    }
+  }
+});
+
+ipcRenderer.on('pty:exit', (_e: IpcRendererEvent, payload: PtyExitPayload) => {
+  for (const cb of ptyExitListeners) {
+    try {
+      cb(payload);
+    } catch (err) {
+      console.error('[ccsmPty] onExit listener threw', err);
+    }
+  }
+});
+
+const ccsmPty = {
+  list: (): Promise<unknown> => ipcRenderer.invoke('pty:list'),
+  spawn: (sid: string, cwd: string): Promise<unknown> =>
+    ipcRenderer.invoke('pty:spawn', sid, cwd),
+  attach: (sid: string): Promise<unknown> => ipcRenderer.invoke('pty:attach', sid),
+  detach: (sid: string): Promise<void> => ipcRenderer.invoke('pty:detach', sid),
+  input: (sid: string, data: string): Promise<void> =>
+    ipcRenderer.invoke('pty:input', sid, data),
+  resize: (sid: string, cols: number, rows: number): Promise<void> =>
+    ipcRenderer.invoke('pty:resize', sid, cols, rows),
+  kill: (sid: string): Promise<unknown> => ipcRenderer.invoke('pty:kill', sid),
+  get: (sid: string): Promise<unknown> => ipcRenderer.invoke('pty:get', sid),
+  onData: (cb: (e: PtyDataPayload) => void): (() => void) => {
+    ptyDataListeners.add(cb);
+    return () => {
+      ptyDataListeners.delete(cb);
+    };
+  },
+  onExit: (cb: (e: PtyExitPayload) => void): (() => void) => {
+    ptyExitListeners.add(cb);
+    return () => {
+      ptyExitListeners.delete(cb);
+    };
+  },
+  clipboard: {
+    readText: (): string => clipboard.readText(),
+    writeText: (text: string): void => clipboard.writeText(text),
+  },
+};
+
+contextBridge.exposeInMainWorld('ccsmPty', ccsmPty);
+
+export type CCSMPtyAPI = typeof ccsmPty;

--- a/src/pty.d.ts
+++ b/src/pty.d.ts
@@ -1,0 +1,65 @@
+// Type surface for the `window.ccsmPty` preload bridge defined in
+// `electron/preload.ts`. Consumed by TerminalPane (PR-4) and the
+// session lifecycle wiring in App / store (PR-6, PR-7).
+//
+// Kept in `src/` (not `electron/`) because this is the renderer-side
+// view of the IPC contract — the main-process handlers in
+// `electron/ptyHost/*` own the runtime implementation.
+
+export interface PtySessionInfo {
+  sid: string;
+  pid: number;
+  cols: number;
+  rows: number;
+}
+
+export interface AttachResult {
+  snapshot: string;
+  cols: number;
+  rows: number;
+  pid: number;
+}
+
+export interface SpawnResult {
+  ok: boolean;
+  sid: string;
+  pid?: number;
+  error?: string;
+}
+
+export interface PtyExitEvent {
+  sessionId: string;
+  code: number | null;
+  signal: number | null;
+}
+
+export interface PtyDataEvent {
+  sid: string;
+  chunk: string;
+}
+
+export interface CcsmPtyApi {
+  list(): Promise<PtySessionInfo[]>;
+  spawn(sid: string, cwd: string): Promise<SpawnResult>;
+  attach(sid: string): Promise<AttachResult | null>;
+  detach(sid: string): Promise<void>;
+  input(sid: string, data: string): Promise<void>;
+  resize(sid: string, cols: number, rows: number): Promise<void>;
+  kill(sid: string): Promise<{ ok: boolean; killed?: boolean }>;
+  get(sid: string): Promise<PtySessionInfo | null>;
+  onData(cb: (e: PtyDataEvent) => void): () => void;
+  onExit(cb: (e: PtyExitEvent) => void): () => void;
+  clipboard: {
+    readText(): string;
+    writeText(text: string): void;
+  };
+}
+
+declare global {
+  interface Window {
+    ccsmPty: CcsmPtyApi;
+    __ccsmTerm?: unknown;
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- Add window.ccsmPty bridge to electron/preload.ts: list/spawn/attach/detach/input/resize/kill/get + onData/onExit fan-out + clipboard.{readText,writeText}
- Add src/pty.d.ts with full type surface (consumed by TerminalPane in PR-4 / App in PR-6)
- window.ccsmCliBridge kept intact — PR-8 will remove the ttyd-only methods

Compiles once PR-1 (deps) + PR-2 (ptyHost IPC handlers) land.

## Test plan
- [ ] type-check passes after PR-1 + PR-2
- [ ] runtime validation in PR-6 + PR-7