### PR TITLE
fix(build): drop deprecated nsis.disableWebInstaller

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,8 +158,7 @@
       "deleteAppDataOnUninstall": false,
       "createDesktopShortcut": true,
       "createStartMenuShortcut": true,
-      "shortcutName": "CCSM",
-      "disableWebInstaller": true
+      "shortcutName": "CCSM"
     },
     "mac": {
       "target": [


### PR DESCRIPTION
## Summary
electron-builder 25.x removed nsis.disableWebInstaller. Blocking make:win since the upgrade. One-line removal.

Discovered while building post-ttyd-rewrite installer — pre-existing config rot, not a rewrite regression.

## Test plan
- [x] make:win progresses past the validation step (deps install + webpack build already verified)