### PR TITLE
fix(session): default new-session cwd to last-used (userCwds LRU head) (#551)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -162,9 +162,11 @@ async function getImportableSessions(): Promise<ScannableSession[]> {
 
 // ───────────── user-owned cwd list (ccsm's own LRU) ─────────────
 //
-// The new-session default cwd is always `os.homedir()`. The recent list shown
-// in the StatusBar cwd popover is a user-owned LRU that only the user can
-// extend (by explicitly picking a non-default cwd). Persisted in the
+// The new-session default cwd is the LRU head (the user's most-recently
+// picked cwd) when present, falling back to `os.homedir()` when the LRU
+// is empty (fresh install). The recent list shown in the StatusBar cwd
+// popover is a user-owned LRU that only the user can extend (by
+// explicitly picking a non-default cwd). Persisted in the
 // `app_state` SQLite table under key `userCwds` as a JSON string list.
 //
 // Reads return `[homedir()]` when the list is empty so the popover always has

--- a/scripts/harness-real-cli.mjs
+++ b/scripts/harness-real-cli.mjs
@@ -6,9 +6,10 @@
 //   2. switch-session-keeps-chat     — UX F: session A↔B switch reuses pty, scrollback intact
 //   3. cwd-projects-claude           — UX E: real cwd flows into claude's JSONL hash
 //   4. import-resume                 — UX H: import existing JSONL, claude --resume restores
-//   5. new-session-focus-cli         — UX C': button focus does not double-fire
-//   6. pty-pid-stable-across-switch  — direct-xterm: pty pid stable across A→B→A switch
-//   7. reopen-resume                 — UX G: close ccsm, reopen, click session, --resume restores
+//   5. default-cwd-from-userCwds-lru — task #551: new-session cwd defaults to LRU head
+//   6. new-session-focus-cli         — UX C': button focus does not double-fire
+//   7. pty-pid-stable-across-switch  — direct-xterm: pty pid stable across A→B→A switch
+//   8. reopen-resume                 — UX G: close ccsm, reopen, click session, --resume restores
 //
 // Sharing strategy:
 //   * Cases 1–6 share ONE Electron launch + ONE isolated tempDir. Each case
@@ -625,6 +626,119 @@ async function caseImportResume({ electronApp, win, tempDir }) {
 }
 
 // ============================================================================
+// Case: default-cwd-from-userCwds-lru (task #551)
+//
+// New session creation must default the cwd to the user's most-recently
+// used cwd from the ccsm-owned `userCwds` LRU (head of the list), with
+// a fallback to `userHome` only when the LRU is empty.
+//
+// Reproduces the bug from PR #392's "default cwd is always home" policy:
+// the user re-picks the same project on every new session because the
+// LRU is consulted only by the picker, never by the default.
+//
+// Steps:
+//   1. Read userHome from the renderer.
+//   2. Push a synthetic non-home cwd into the LRU via `window.ccsm.userCwds.push`.
+//   3. Wait for `lastUsedCwd` to reflect the new head in the store.
+//   4. Call `createSession()` with NO opts.cwd — the new session's cwd
+//      MUST equal the pushed path, NOT userHome.
+//   5. Soft-cleanup: delete the new session so subsequent cases see a
+//      clean shared launch.
+// ============================================================================
+
+async function caseDefaultCwdFromUserCwdsLru({ electronApp: _e, win, tempDir }) {
+  // Boot probe must have resolved (renderer needs userCwds IPC + store).
+  await win.waitForFunction(
+    () => !document.querySelector('[data-testid="claude-availability-probing"]'),
+    null,
+    { timeout: 30000 },
+  );
+
+  // Synthetic project dir distinct from tempDir so we don't collide with
+  // earlier cases that may have pushed tempDir already.
+  const projectDir = path.join(tempDir, 'lru-project-' + Math.random().toString(36).slice(2, 8));
+  mkdirSync(projectDir, { recursive: true });
+  const normalizedExpected = projectDir.replace(/[\\/]+$/, '');
+
+  // Push the cwd through the real IPC. The renderer-side `lastUsedCwd`
+  // cache is normally updated by store mutators (createSession /
+  // setSessionCwd / importSession) that wrap the push call; pushing the
+  // raw IPC bypasses those wrappers, so we mirror what `hydrateStore`
+  // does at boot — read the LRU back via `userCwds.get` and seed
+  // `lastUsedCwd` from the head. This matches the real path for the
+  // first `+` click of every fresh launch.
+  const pushed = await win.evaluate(async (p) => {
+    const api = window.ccsm;
+    if (!api?.userCwds?.push || !api?.userCwds?.get) {
+      return { ok: false, reason: 'userCwds IPC unavailable' };
+    }
+    await api.userCwds.push(p);
+    const list = await api.userCwds.get();
+    const head = Array.isArray(list) && list.length > 0 ? list[0] : null;
+    if (head) {
+      window.__ccsmStore.setState({ lastUsedCwd: head });
+    }
+    return { ok: true, head };
+  }, projectDir);
+  if (!pushed.ok) throw new Error(`userCwds.push failed: ${pushed.reason}`);
+
+  // Wait briefly for the setState to flush. The check polls instead of
+  // relying on react-batching timing.
+  await win.waitForFunction(
+    (expected) => {
+      const st = window.__ccsmStore?.getState?.();
+      return !!st && (st.lastUsedCwd || '').replace(/[\\/]+$/, '') === expected;
+    },
+    normalizedExpected,
+    { timeout: 5000 },
+  );
+
+  // Snapshot pre-create state for the failure message.
+  const before = await win.evaluate(() => {
+    const st = window.__ccsmStore.getState();
+    return {
+      lastUsedCwd: st.lastUsedCwd,
+      userHome: st.userHome,
+      sessionCount: st.sessions.length,
+    };
+  });
+
+  // Create the new session WITHOUT specifying cwd — this is the defaulted
+  // path the bug is about. Read back the active session's cwd.
+  const result = await win.evaluate(() => {
+    const useStore = window.__ccsmStore;
+    const { createSession } = useStore.getState();
+    createSession({ name: 'lru-default-probe' });
+    const st = useStore.getState();
+    const active = st.sessions.find((s) => s.id === st.activeId);
+    return { sid: st.activeId, cwd: active?.cwd ?? null };
+  });
+
+  const actual = (result.cwd || '').replace(/[\\/]+$/, '');
+  if (actual !== normalizedExpected) {
+    throw new Error(
+      `default cwd did not honor userCwds LRU.\n` +
+        `  expected (LRU head): ${normalizedExpected}\n` +
+        `  actual (session.cwd): ${result.cwd}\n` +
+        `  store.lastUsedCwd:   ${before.lastUsedCwd}\n` +
+        `  store.userHome:      ${before.userHome}`,
+    );
+  }
+
+  // Negative: actual MUST NOT equal userHome (the regressed default).
+  if (before.userHome && actual === before.userHome.replace(/[\\/]+$/, '')) {
+    throw new Error(`default cwd fell back to userHome (${before.userHome}) despite non-empty LRU`);
+  }
+
+  // Cleanup so subsequent cases see no extra session row.
+  await win.evaluate((sid) => {
+    const useStore = window.__ccsmStore;
+    const { deleteSession } = useStore.getState();
+    deleteSession?.(sid);
+  }, result.sid);
+}
+
+// ============================================================================
 // Case: new-session-focus-cli — clicking "New Session" must transfer focus
 // AWAY from the trigger button so a subsequent Enter goes to the CLI, not
 // to the still-focused button (which would re-fire and spawn yet another
@@ -917,6 +1031,7 @@ const CASE_REGISTRY = [
   { name: 'switch-session-keeps-chat',   group: 'shared', run: caseSwitchSessionKeepsChat },
   { name: 'cwd-projects-claude',         group: 'shared', run: caseCwdProjectsClaude },
   { name: 'import-resume',               group: 'shared', run: caseImportResume },
+  { name: 'default-cwd-from-userCwds-lru', group: 'shared', run: caseDefaultCwdFromUserCwdsLru },
   { name: 'new-session-focus-cli',       group: 'shared', run: caseNewSessionFocusCli },
   { name: 'pty-pid-stable-across-switch',group: 'shared', run: casePtyPidStableAcrossSwitch },
   { name: 'reopen-resume',               group: 'standalone', run: caseReopenResume },

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -143,6 +143,20 @@ type State = {
    * the user on a randomly-open menu after restart).
    */
   openPopoverId: string | null;
+  /**
+   * Most-recent cwd from the ccsm-owned `userCwds` LRU (head of the list),
+   * cached in renderer state so `createSession` can read it synchronously
+   * to default a new session's cwd. Seeded at boot from
+   * `window.ccsm.userCwds.get()` and refreshed every time `userCwds.push`
+   * resolves. `null` when the LRU is empty (fresh install / user has never
+   * picked) — `createSession` falls back to `userHome` in that case.
+   *
+   * NOT persisted — derived from main-process state on every boot. Out of
+   * scope: cwd-missing degradation. If the head path no longer exists on
+   * disk we still hand it to the new session; the existing
+   * `cwd-missing` flag on Session continues to flag it after creation.
+   */
+  lastUsedCwd: string | null;
 };
 
 export interface CreateSessionOptions {
@@ -420,6 +434,7 @@ export const useStore = create<State & Actions>((set, get) => ({
   hydrated: false,
   installerCorrupt: false,
   openPopoverId: null,
+  lastUsedCwd: null,
 
   selectSession: (id) => {
     set((s) => ({
@@ -445,6 +460,7 @@ export const useStore = create<State & Actions>((set, get) => ({
       activeId,
       userHome,
       claudeSettingsDefaultModel,
+      lastUsedCwd,
     } = get();
     const isUsable = (gid: string | null | undefined) => {
       if (!gid) return false;
@@ -466,15 +482,20 @@ export const useStore = create<State & Actions>((set, get) => ({
     const targetGroupId = ensured.groupId;
     const baseGroups = ensured.groups;
     const id = newSessionId();
-    // Default cwd is ALWAYS the user's home directory — no fallback chain,
-    // no inheritance from prior sessions, no derivation from CLI history.
-    // Per spec ("default cwd is home, no fallback chains"): the previous
-    // historyRecentCwds → recentProjects → groupRecentCwd cascade silently
-    // hijacked the new-session cwd from stale state, so we replaced it with
-    // a single deterministic source. The user can repick via the StatusBar
-    // cwd popover; that pick lands in the ccsm-owned `userCwds` LRU and
-    // surfaces in the popover's recent column.
-    const defaultCwd = userHome ?? '';
+    // Default cwd is the most recently used cwd from the ccsm-owned
+    // `userCwds` LRU (the head of the list), falling back to the user's
+    // home directory when the LRU is empty (fresh install / user has
+    // never explicitly picked a cwd). Per task #551 ("default new-session
+    // cwd to last-used"): repeat use of the same project should not
+    // require re-picking the cwd every time. Caller-provided `opts.cwd`
+    // always wins. The LRU itself is fed from three signals:
+    //   - explicit picks via the StatusBar cwd popover (`setSessionCwd`)
+    //   - new-session creation against an explicit cwd (below)
+    //   - importing an existing transcript (`importSession` below)
+    // Out of scope: cwd-missing degradation. If the LRU head no longer
+    // exists on disk we still hand it to the new session; the existing
+    // `cwd-missing` post-create flag continues to surface that case.
+    const defaultCwd = lastUsedCwd ?? userHome ?? '';
     // Default model reads `~/.claude/settings.json` `model` field — the SAME
     // value the CLI itself reads for `--model` defaulting (PR #386 made the
     // read CLAUDE_CONFIG_DIR-aware). When unset, leave `model` empty so the
@@ -514,7 +535,17 @@ export const useStore = create<State & Actions>((set, get) => ({
     const finalCwd = newSession.cwd;
     if (finalCwd && userHome && finalCwd !== userHome) {
       const api = window.ccsm;
-      void api?.userCwds?.push(finalCwd).catch(() => {});
+      void api?.userCwds?.push(finalCwd)
+        .then((list) => {
+          if (Array.isArray(list) && list.length > 0) {
+            set({ lastUsedCwd: list[0] ?? null });
+          }
+        })
+        .catch(() => {});
+      // Optimistic local update so an immediately-following createSession
+      // (before the IPC resolves) sees the new head. Skipped when the
+      // value is already the head — avoids a redundant set + re-render.
+      if (finalCwd !== lastUsedCwd) set({ lastUsedCwd: finalCwd });
     }
   },
 
@@ -569,6 +600,21 @@ export const useStore = create<State & Actions>((set, get) => ({
       focusedGroupId: null,
       groups: ensured.groups
     });
+    // Importing an existing transcript is a strong "user is working in
+    // this cwd" signal — feed it into the same `userCwds` LRU that fresh
+    // sessions populate so the next `+` click defaults to it.
+    const userHome = get().userHome;
+    if (cwd && userHome && cwd !== userHome) {
+      const api = window.ccsm;
+      void api?.userCwds?.push(cwd)
+        .then((list) => {
+          if (Array.isArray(list) && list.length > 0) {
+            set({ lastUsedCwd: list[0] ?? null });
+          }
+        })
+        .catch(() => {});
+      if (cwd !== get().lastUsedCwd) set({ lastUsedCwd: cwd });
+    }
     return id;
   },
 
@@ -703,7 +749,14 @@ export const useStore = create<State & Actions>((set, get) => ({
     const userHome = get().userHome;
     if (cwd && cwd !== userHome) {
       const api = window.ccsm;
-      void api?.userCwds?.push(cwd).catch(() => {});
+      void api?.userCwds?.push(cwd)
+        .then((list) => {
+          if (Array.isArray(list) && list.length > 0) {
+            set({ lastUsedCwd: list[0] ?? null });
+          }
+        })
+        .catch(() => {});
+      if (cwd !== get().lastUsedCwd) set({ lastUsedCwd: cwd });
     }
   },
 
@@ -999,6 +1052,22 @@ export async function hydrateStore(): Promise<void> {
           userHome: typeof userHome === 'string' ? userHome : '',
           claudeSettingsDefaultModel: typeof defaultModel === 'string' ? defaultModel : null,
         });
+      }
+      // Seed `lastUsedCwd` from the ccsm-owned `userCwds` LRU so the very
+      // first `+` click after launch already lands in the user's most
+      // recent project. Without this, the first session of every boot
+      // would silently fall back to home and re-train the picker. Skip
+      // when the only entry is `userHome` — that's the empty-LRU sentinel
+      // (`getUserCwds()` always appends home), which means "no real
+      // pick", so we leave `lastUsedCwd` null and let createSession use
+      // userHome via the explicit fallback.
+      if (api?.userCwds?.get) {
+        const list = await api.userCwds.get().catch(() => [] as string[]);
+        const head = Array.isArray(list) && list.length > 0 ? list[0] : null;
+        const home = useStore.getState().userHome;
+        if (head && head !== home) {
+          useStore.setState({ lastUsedCwd: head });
+        }
       }
     } catch {
       /* IPC unavailable — boot continues with empty defaults */


### PR DESCRIPTION
## Summary

Reverses PR #392's "default cwd is always home" policy. The user re-picked the same project on every new session because the LRU was consulted only by the StatusBar picker, never by the new-session default. Per task #551: repeat use of the same project should not require re-picking.

- `createSession` now defaults to `lastUsedCwd ?? userHome`. Caller-provided `opts.cwd` still wins.
- `lastUsedCwd` is a renderer-side cache of the ccsm-owned `userCwds` LRU head, seeded at hydrate from `window.ccsm.userCwds.get()` and refreshed (optimistic + IPC-resolved) on every `userCwds.push` triggered by `createSession`, `setSessionCwd`, `importSession`.
- `importSession` now feeds its cwd into the LRU too — importing an existing transcript is a strong "user works in this cwd" signal.

## Out of scope

- **cwd-missing degradation.** The existing `cwd-missing` flag on Session continues to surface paths that no longer exist on disk; no new UI is added for that case (per task brief).

## Visual change

None. Picker layout, popover styling, and all rendered chrome are byte-identical. Only the data path that defaults a new session's cwd changed. Screenshots are not applicable.

## Test plan

- [x] `node scripts/harness-real-cli.mjs --only=default-cwd-from-userCwds-lru` — PASS (216ms) on this branch.
- [x] Reverse-verify: `git stash push src/stores/store.ts` + rebuild + rerun probe — FAILS with `actual=userHome, expected=lru-head`. Restoring the fix returns to PASS.
- [x] `npm run build` clean (3 webpack size warnings unchanged from `working`).
- [ ] Reviewer: confirm caller-passed `opts.cwd` still beats the LRU head (createSession line ~501: `cwd: opts.cwd ?? defaultCwd`).
- [ ] Reviewer: confirm hydrate seed skips the empty-LRU sentinel (`getUserCwds()` always appends home; renderer must not treat that as a real LRU entry).