### PR TITLE
refactor(e2e): hoist dismissFirstRunModals helper (#519)

### DIFF
--- a/scripts/harness-real-cli.mjs
+++ b/scripts/harness-real-cli.mjs
@@ -52,6 +52,7 @@ import * as path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import {
   createIsolatedClaudeDir,
+  dismissFirstRunModals,
   dismissWelcomeSplash,
   launchCcsmIsolated,
   readXtermLines,
@@ -186,17 +187,7 @@ async function caseNewSessionChat({ electronApp, win, tempDir }) {
   await waitForXtermBuffer(win, /trust|claude|welcome|│|╭|>/i, { timeout: 30000 });
 
   // Dismiss trust / welcome / theme splashes.
-  for (let i = 0; i < 12; i++) {
-    const lines = await readXtermLines(win, { lines: 30 }).catch(() => []);
-    const screen = lines.join('\n');
-    if (/│\s*>/.test(screen) || /^\s*>\s/m.test(screen)) break;
-    if (/trust|do you trust/i.test(screen)) {
-      await sendToClaudeTui(win, '1\r').catch(() => {});
-    } else {
-      await sendToClaudeTui(win, '\r').catch(() => {});
-    }
-    await sleep(1500);
-  }
+  await dismissFirstRunModals(win);
 
   await sendToClaudeTui(win, CHAT_PROMPT);
   await sleep(500);
@@ -852,17 +843,7 @@ async function casePtyPidStableAcrossSwitch({ electronApp, win, tempDir }) {
   // the first keystrokes after a cold start. Without this, the
   // `echo MARKER` below would be eaten by the trust modal and the
   // marker would never reach the shell.
-  for (let i = 0; i < 12; i++) {
-    const lines = await readXtermLines(win, { lines: 30 }).catch(() => []);
-    const screen = lines.join('\n');
-    if (/│\s*>/.test(screen) || /^\s*>\s/m.test(screen)) break;
-    if (/trust|do you trust/i.test(screen)) {
-      await sendToClaudeTui(win, '1\r').catch(() => {});
-    } else {
-      await sendToClaudeTui(win, '\r').catch(() => {});
-    }
-    await sleep(1500);
-  }
+  await dismissFirstRunModals(win);
 
   // Snapshot pidA1 from window.ccsmPty.list().
   const pidA1 = await getPtyPidForSid(win, sidA);
@@ -994,31 +975,6 @@ async function caseReopenResume() {
     if (app2) try { await app2.close(); } catch (_) { /* ignore */ }
     try { rmSync(userDataDir, { recursive: true, force: true }); } catch (_) { /* ignore */ }
     isolated.cleanup?.();
-  }
-}
-
-async function dismissFirstRunModals(win) {
-  const trustRe = /trust the files|trust this folder|Do you trust|1\.\s*Yes|Yes, proceed/i;
-  const promptRe = /│\s*>|^\s*>\s/m;
-
-  for (let i = 0; i < 8; i++) {
-    const lines = await readXtermLines(win, { lines: 20 }).catch(() => []);
-    const screen = lines.join('\n');
-    if (promptRe.test(screen)) break;
-    if (trustRe.test(screen)) {
-      await sendToClaudeTui(win, '1\r').catch(() => {});
-      await sleep(800);
-      continue;
-    }
-    await sleep(600);
-  }
-  await dismissWelcomeSplash(win, { maxAttempts: 5, settleMs: 600 });
-  for (let i = 0; i < 4; i++) {
-    const lines = await readXtermLines(win, { lines: 12 }).catch(() => []);
-    const screen = lines.join('\n');
-    if (/│\s*>|^\s*>\s/m.test(screen)) return;
-    await sendToClaudeTui(win, '\r').catch(() => {});
-    await sleep(900);
   }
 }
 

--- a/scripts/probe-utils-real-cli.mjs
+++ b/scripts/probe-utils-real-cli.mjs
@@ -532,6 +532,64 @@ export async function dismissWelcomeSplash(
   return { dismissed: !stillSplash, attempts, finalScreen };
 }
 
+/**
+ * Dismiss claude's first-run modals (trust dialog + welcome / theme splashes)
+ * that intercept keystrokes after a cold start. Without this, the probe's
+ * first `\r` / prompt would be eaten by the trust modal and never reach
+ * the shell.
+ *
+ * Behavior is the union of the patterns the harness probes evolved
+ * independently:
+ *   - Phase 1 (trust loop): up to `maxIters` iterations. Read the buffer;
+ *     if the input prompt (`│ >` or leading `> `) is visible, we're done.
+ *     If a trust prompt is visible, send `1\r` to accept. Otherwise send
+ *     a bare `\r` to advance any other intermediate splash.
+ *   - Phase 2 (welcome splash): delegate to `dismissWelcomeSplash` for
+ *     the "Welcome back" / "Try /" hint card that some claude versions
+ *     show after trust.
+ *   - Phase 3 (final settle): a few more bare-Enter retries in case a
+ *     theme picker or version hint is still visible after the welcome
+ *     card was dismissed.
+ *
+ * Returns once the input prompt regex matches, or after the iteration
+ * budget is exhausted. Never throws — caller can verify ready state via
+ * the next `readXtermLines` / `waitForXtermBuffer` call.
+ */
+export async function dismissFirstRunModals(win, opts = {}) {
+  const {
+    maxIters = 12,
+    intervalMs = 250,
+  } = opts;
+
+  const trustRe = /trust the files|trust this folder|Do you trust|trust|do you trust|1\.\s*Yes|Yes, proceed/i;
+  const promptRe = /│\s*>|^\s*>\s/m;
+
+  // Phase 1: trust + generic splash advance.
+  for (let i = 0; i < maxIters; i++) {
+    const lines = await readXtermLines(win, { lines: 30 }).catch(() => []);
+    const screen = lines.join('\n');
+    if (promptRe.test(screen)) return;
+    if (trustRe.test(screen)) {
+      await sendToClaudeTui(win, '1\r').catch(() => {});
+    } else {
+      await sendToClaudeTui(win, '\r').catch(() => {});
+    }
+    await sleep(Math.max(intervalMs, 600));
+  }
+
+  // Phase 2: welcome / hint card.
+  await dismissWelcomeSplash(win, { maxAttempts: 5, settleMs: 600 }).catch(() => {});
+
+  // Phase 3: final settle.
+  for (let i = 0; i < 4; i++) {
+    const lines = await readXtermLines(win, { lines: 12 }).catch(() => []);
+    const screen = lines.join('\n');
+    if (promptRe.test(screen)) return;
+    await sendToClaudeTui(win, '\r').catch(() => {});
+    await sleep(Math.max(intervalMs, 600));
+  }
+}
+
 async function readXtermBufferSafe(win) {
   try {
     return await readXtermBuffer(win);


### PR DESCRIPTION
## Summary

- Hoist three drifting copies of trust/welcome-modal dismissal in `scripts/harness-real-cli.mjs` into a single exported helper `dismissFirstRunModals(win, opts)` in `scripts/probe-utils-real-cli.mjs`.
- Replace two inline 12-iter loops (in `caseNewSessionChat` around L189 and `casePtyPidStableAcrossSwitch` around L855) and one module-local `dismissFirstRunModals` (around L1000) with `await dismissFirstRunModals(win)`.
- Default opts `{ maxIters: 12, intervalMs: 250 }`. Behavior is the union of the previous three: phase 1 trust-or-bare-Enter loop, phase 2 `dismissWelcomeSplash` for the hint card, phase 3 a few bare-Enter retries.

Diff is scoped strictly to the two files; no behavioral change beyond the union merge.

## Test plan

- [x] `node --check` both .mjs files: OK.
- [x] `node scripts/harness-real-cli.mjs --only=new-session-chat`: PASS (19535ms).
  ```
  [HARNESS] >>> case: new-session-chat
  [HARNESS] <<< PASS new-session-chat (19535ms)
    total: 1/1 passed, 48.0s wall
  ```
- [x] `node scripts/harness-real-cli.mjs --only=pty-pid-stable-across-switch`: PASS (13623ms).
  ```
  [HARNESS] >>> case: pty-pid-stable-across-switch
  [HARNESS] <<< PASS pty-pid-stable-across-switch (13623ms)
    total: 1/1 passed, 20.2s wall
  ```
- Lint/typecheck scripts only target `.ts/.tsx`, so the `.mjs` edits do not affect them.

## Unrelated cleanup opportunities (not in this diff)

- `dismissWelcomeSplash` is still called inline in three other case bodies (around L281, L291, L326 in `harness-real-cli.mjs`). They could be migrated to `dismissFirstRunModals` if the union behavior is desired in those cases too.
- `scripts/harness-real-cli.mjs` defines a local `sleep` (L64) duplicated by the internal `sleep` in `probe-utils-real-cli.mjs`; could be unified later.