### PR TITLE
feat(close): ask/tray/quit + Settings + single-instance lock (#561)

### DIFF
--- a/electron/i18n.ts
+++ b/electron/i18n.ts
@@ -36,10 +36,19 @@ type DialogCatalog = {
   chooseCwd: string;
 };
 
+type CloseDialogCatalog = {
+  message: string;
+  detail: string;
+  tray: string;
+  quit: string;
+  dontAskAgain: string;
+};
+
 type NotificationKey = keyof NotificationCatalog;
 type TrayKey = keyof TrayCatalog;
 type MenuKey = keyof MenuCatalog;
 type DialogKey = keyof DialogCatalog;
+type CloseDialogKey = keyof CloseDialogCatalog;
 
 // IMPORTANT: keep these strings byte-identical to the renderer catalog
 // `notifications` namespace. The renderer catalog is the source of truth.
@@ -102,6 +111,29 @@ const dialogCatalogs: Record<SupportedLanguage, DialogCatalog> = {
   }
 };
 
+// Native "close to tray or quit?" prompt shown the first time the user
+// clicks the window X (when their preference is still 'ask'). Keep parity
+// with the renderer catalog `closeDialog` namespace — the same strings are
+// surfaced in the Settings explainer hint so wording stays consistent.
+const closeDialogCatalogs: Record<SupportedLanguage, CloseDialogCatalog> = {
+  en: {
+    message: 'Close ccsm?',
+    detail:
+      'Minimize to tray keeps ccsm running so notifications and background sessions stay active.',
+    tray: 'Minimize to tray',
+    quit: 'Quit',
+    dontAskAgain: "Don't ask again"
+  },
+  zh: {
+    message: '关闭 ccsm？',
+    detail:
+      '最小化到托盘会让 ccsm 继续运行，通知和后台会话保持活跃。',
+    tray: '最小化到托盘',
+    quit: '退出',
+    dontAskAgain: '不再询问'
+  }
+};
+
 let activeLanguage: SupportedLanguage = 'en';
 
 export function setMainLanguage(lang: SupportedLanguage): void {
@@ -143,6 +175,11 @@ export function tMenu(key: MenuKey): string {
 export function tDialog(key: DialogKey): string {
   const catalog = dialogCatalogs[activeLanguage] ?? dialogCatalogs.en;
   return catalog[key] ?? dialogCatalogs.en[key] ?? key;
+}
+
+export function tCloseDialog(key: CloseDialogKey): string {
+  const catalog = closeDialogCatalogs[activeLanguage] ?? closeDialogCatalogs.en;
+  return catalog[key] ?? closeDialogCatalogs.en[key] ?? key;
 }
 
 // Resolve a system locale tag into one of the two supported languages.

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/electron/main';
-import { app, BrowserWindow, Menu, Tray, nativeImage, ipcMain, shell, type MenuItemConstructorOptions } from 'electron';
+import { app, BrowserWindow, Menu, Tray, dialog, nativeImage, ipcMain, shell, type MenuItemConstructorOptions } from 'electron';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
@@ -114,6 +114,60 @@ function fromMainFrame(e: Electron.IpcMainInvokeEvent): boolean {
 // bundle from `dist/renderer/index.html` even though we're invoked via
 // `electron .`, so they don't require a running webpack-dev-server.
 const isDev = !app.isPackaged && process.env.CCSM_PROD_BUNDLE !== '1';
+
+// Single-instance lock — the actual zombie-source plug. The custom title-bar
+// "X" button hides the window into the tray (intentional, see win.on('close')
+// below); subsequent double-clicks of the desktop icon would otherwise spawn
+// a brand-new main process every time, leaving the prior one alive and
+// hidden. Calling this at module load (before app.whenReady) ensures the
+// second instance bails out before it can build any window.
+//
+// Skipped under E2E so probe runs that spawn the app multiple times in
+// parallel (each with their own CCSM_TMP_HOME / CLAUDE_CONFIG_DIR) don't
+// collide on the global lock and exit unexpectedly.
+const skipSingleInstanceLock =
+  process.env.CCSM_E2E_HIDDEN === '1' || process.env.CCSM_E2E_NO_SINGLE_INSTANCE === '1';
+if (!skipSingleInstanceLock) {
+  const gotLock = app.requestSingleInstanceLock();
+  if (!gotLock) {
+    app.quit();
+    process.exit(0);
+  }
+  app.on('second-instance', () => {
+    const w = BrowserWindow.getAllWindows()[0];
+    if (w) {
+      if (w.isMinimized()) w.restore();
+      if (!w.isVisible()) w.show();
+      w.focus();
+    }
+  });
+}
+
+// Close-button preference: 'ask' shows a one-time dialog the first time the
+// user clicks the X (defaulting on Windows/Linux), 'tray' silently minimizes
+// to the tray (mac default — matches OS red-light convention), 'quit' really
+// quits. Persisted in app_state under key `closeAction` so the choice
+// survives restart. Read synchronously inside win.on('close') because the
+// close event itself is sync; the SQLite read is a single point lookup
+// (sub-millisecond) so the cost is negligible vs. the visible click latency.
+type CloseAction = 'ask' | 'tray' | 'quit';
+const CLOSE_ACTION_KEY = 'closeAction';
+function getCloseAction(): CloseAction {
+  try {
+    const raw = loadState(CLOSE_ACTION_KEY);
+    if (raw === 'ask' || raw === 'tray' || raw === 'quit') return raw;
+  } catch {
+    /* fall through to default */
+  }
+  return process.platform === 'darwin' ? 'tray' : 'ask';
+}
+function setCloseAction(value: CloseAction): void {
+  try {
+    saveState(CLOSE_ACTION_KEY, value);
+  } catch (err) {
+    console.warn('[main] setCloseAction failed', err);
+  }
+}
 
 // ───────────────────── importable-sessions cache ─────────────────────────
 //
@@ -432,23 +486,25 @@ function createWindow() {
   win.on('maximize', emitMax);
   win.on('unmaximize', emitMax);
 
-  // Minimize-to-tray: clicking close (or the OS X red dot, our own custom
-  // close button via window:close IPC) hides the window instead of quitting.
-  // The user can still really quit via the tray menu's Quit item, the
-  // app menu's Quit, or Ctrl-Q.
+  // Close-button behaviour. Three modes — see getCloseAction() above:
+  //   'quit' → don't preventDefault; let the window close, fall through to
+  //            window-all-closed → before-quit → app exit.
+  //   'tray' → preventDefault + fade-to-hide (the original behaviour).
+  //   'ask'  → preventDefault + native dialog with a "Don't ask again"
+  //            checkbox; on confirm we persist the choice via setCloseAction
+  //            so the next click goes straight to that branch.
+  // The `isQuitting` short-circuit at the top stays so explicit quit paths
+  // (tray menu Quit, app.before-quit safety net, electron-builder updater)
+  // bypass everything.
   //
   // Fade-to-hide: before actually calling `win.hide()` we send a
   // `window:beforeHide` event so the renderer can run a short opacity
   // fade-out. `HIDE_FADE_MS` matches `DURATION.standard` (180ms) from the
   // shared motion tokens — kept short so closing still feels responsive.
-  // Guarded by `fadePending` so repeated Ctrl+W presses don't stack
-  // timers. On real quit (`isQuitting === true`) we skip the fade entirely
-  // so shutdown stays fast.
+  // Guarded by `fadePending` so repeated Ctrl+W presses don't stack timers.
   const HIDE_FADE_MS = 180;
   let fadePending = false;
-  win.on('close', (e) => {
-    if (isQuitting) return;
-    e.preventDefault();
+  const fadeThenHide = () => {
     if (fadePending) return;
     fadePending = true;
     try {
@@ -463,6 +519,51 @@ function createWindow() {
       if (win.isDestroyed()) return;
       win.hide();
     }, HIDE_FADE_MS);
+  };
+  win.on('close', (e) => {
+    if (isQuitting) return;
+    const pref = getCloseAction();
+    if (pref === 'quit') {
+      isQuitting = true;
+      return;
+    }
+    e.preventDefault();
+    if (pref === 'tray') {
+      fadeThenHide();
+      return;
+    }
+    // pref === 'ask': prompt once. Showing the dialog is async, but
+    // preventDefault has already kept the window alive; we run the dialog
+    // and act on the user's choice in the resolved promise.
+    void (async () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const i18n = require('./i18n') as typeof import('./i18n');
+      let result: { response: number; checkboxChecked: boolean };
+      try {
+        result = await dialog.showMessageBox(win, {
+          type: 'question',
+          buttons: [i18n.tCloseDialog('tray'), i18n.tCloseDialog('quit')],
+          defaultId: 0,
+          cancelId: 0,
+          message: i18n.tCloseDialog('message'),
+          detail: i18n.tCloseDialog('detail'),
+          checkboxLabel: i18n.tCloseDialog('dontAskAgain'),
+          checkboxChecked: false,
+        });
+      } catch (err) {
+        console.warn('[main] close-action dialog failed; falling back to tray', err);
+        fadeThenHide();
+        return;
+      }
+      const choice: CloseAction = result.response === 0 ? 'tray' : 'quit';
+      if (result.checkboxChecked) setCloseAction(choice);
+      if (choice === 'tray') {
+        fadeThenHide();
+      } else {
+        isQuitting = true;
+        app.quit();
+      }
+    })();
   });
 
   // After the window is shown again (tray click, dock click on macOS) the

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -231,7 +231,60 @@ function AppearancePane() {
           <span className="text-meta font-mono text-fg-secondary tabular-nums w-10">{fontSizePx}px</span>
         </div>
       </Field>
+      <CloseBehaviorField />
     </>
+  );
+}
+
+// Close-button behaviour preference. Persisted via the existing `db:save` /
+// `db:load` IPC under the `closeAction` app_state key — main reads the same
+// key on every win.on('close') so the choice takes effect without a restart.
+// Default is platform-derived inside main (win/linux=ask, mac=tray); the
+// renderer mirrors that fallback so the segmented control reflects the
+// current effective value before the user ever picks a row.
+type CloseBehavior = 'ask' | 'tray' | 'quit';
+function CloseBehaviorField() {
+  const { t } = useTranslation('settings');
+  const platformDefault: CloseBehavior =
+    typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform) ? 'tray' : 'ask';
+  const [value, setValue] = useState<CloseBehavior>(platformDefault);
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const raw = await window.ccsm?.loadState('closeAction');
+        if (cancelled) return;
+        if (raw === 'ask' || raw === 'tray' || raw === 'quit') setValue(raw);
+      } finally {
+        if (!cancelled) setHydrated(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const onChange = (next: CloseBehavior) => {
+    setValue(next);
+    void window.ccsm?.saveState('closeAction', next);
+  };
+
+  return (
+    <Field label={t('closeBehavior')} hint={t('closeBehaviorHint')}>
+      <div className={cn(!hydrated && 'opacity-60')} data-close-behavior>
+        <Segmented
+          value={value}
+          onChange={onChange}
+          options={[
+            { value: 'ask', label: t('closeBehaviorOptions.ask') },
+            { value: 'tray', label: t('closeBehaviorOptions.tray') },
+            { value: 'quit', label: t('closeBehaviorOptions.quit') }
+          ]}
+        />
+      </div>
+    </Field>
   );
 }
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -118,6 +118,14 @@ const en = {
       en: 'English',
       zh: '中文'
     },
+    closeBehavior: 'Close button behavior',
+    closeBehaviorHint:
+      'What clicking the window X (or pressing Ctrl+W) should do. Minimizing to tray keeps notifications and background sessions running.',
+    closeBehaviorOptions: {
+      ask: 'Ask every time',
+      tray: 'Minimize to tray',
+      quit: 'Quit'
+    },
     version: 'Version',
     checkForUpdates: 'Check for updates',
     crashReporting: {

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -113,6 +113,14 @@ const zh: EnCatalog = {
       en: 'English',
       zh: '中文'
     },
+    closeBehavior: '关闭按钮行为',
+    closeBehaviorHint:
+      '点击窗口右上角 X（或按 Ctrl+W）时执行的操作。最小化到托盘可让通知和后台会话保持运行。',
+    closeBehaviorOptions: {
+      ask: '每次询问',
+      tray: '最小化到托盘',
+      quit: '退出'
+    },
     version: '版本',
     checkForUpdates: '检查更新',
     crashReporting: {


### PR DESCRIPTION
## Summary
Plug the zombie-main-process leak (3 explorer-parented CCSM PIDs found alive in the wild on 2026-04-28) by adding three correlated fixes:

- **Single-instance lock** (cross-platform). Custom title-bar X used to silently `win.hide()` and there was no `requestSingleInstanceLock`, so each subsequent launch spawned a fresh main process while the prior stayed alive in the tray. Now a `second-instance` handler restores+focuses the existing window instead.
- **Configurable close behavior**. `win.on('close')` now consults a persisted `closeAction` preference: `ask` | `tray` | `quit`. Default is `'ask'` on Windows/Linux and `'tray'` on macOS — mac users expect the red traffic-light to hide because that's the system convention; Windows users do not have an established expectation, so we ask once and remember the choice.
- **Settings UI**. New "Close button behavior" segmented control in Settings > Appearance, persisted via the existing `db:save`/`db:load` IPC under key `closeAction` (same KV the crash-reporting toggle uses, no new persistence infra). Main re-reads on every close so a mid-session change takes effect immediately without restart.

The native dialog ("Close ccsm? Minimize to tray | Quit, with a 'Don't ask again' checkbox") is fully localized — added a new `closeDialogCatalogs` block to `electron/i18n.ts` with en+zh, and a matching `settings.closeBehavior*` block to the renderer catalog. Parity test passes.

`isQuitting` already covered tray-menu Quit and the `before-quit` safety net, so all real quit paths bypass the new dialog correctly.

## Platform default rationale
- **macOS = 'tray'**: red traffic-light hiding is the OS convention; users expect Cmd+Q to be the only true quit. Showing a dialog every time would feel un-native.
- **Windows/Linux = 'ask'**: there is no established convention. Older Windows apps quit on X; Slack/Discord/Teams hide. We explicitly ask on first encounter and let the user lock in their preference.

## Test plan
- [x] `npm run typecheck` — pass
- [x] `npm run lint` — pass (173 errors are pre-existing, identical to baseline; zero added by this PR)
- [x] `npm test` — 270 pass / 3 fail (the 3 failures are pre-existing `better-sqlite3` ABI mismatch on the dev box, identical to baseline)
- [x] `node scripts/harness-real-cli.mjs --only=new-session-chat` — PASS (19s)
- [x] `node scripts/harness-real-cli.mjs --only=reopen-resume` — PASS (50s) — this case exercises the full app lifecycle (launch → seed session → close app → relaunch with same userDataDir → resume), which is exactly what would break if the new single-instance lock or close interceptor regressed restart flow
- [ ] Manual smoke not captured (no GUI session available in worker env). Reviewer or follow-up should:
  1. `npm start`, click X, confirm "Close ccsm?" dialog appears with two buttons + "Don't ask again" checkbox.
  2. Pick "Quit" → confirm process exits (no zombie in Task Manager).
  3. Restart, click X, pick "Minimize to tray" + check "Don't ask again" → window hides.
  4. Restart with same user-data-dir, click X again → no dialog, immediate hide.
  5. Double-click desktop icon while app is hidden → first window restores, no second main process appears.
  6. Open Settings > Appearance → "Close button behavior" segmented control reflects current value; changing it takes effect on the next X-click.

## Verification of root cause
Re-read of `electron/main.ts` matches the Layer 1 grep:
- L326-330: mac uses `titleBarStyle: 'hiddenInset'` + traffic lights; win/linux uses `frame: false`.
- L447-466 (pre-change): `win.on('close')` always preventDefault + fade-to-hide.
- L808-816: `app.on('window-all-closed')` only quits when `isQuitting`.
- L505-508: tray Quit sets `isQuitting = true` before `app.quit()`.
- L796-806: `app.on('before-quit')` sets `isQuitting = true` (safety net for any other quit path).
- No existing `requestSingleInstanceLock` — confirmed via grep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)