### PR TITLE
fix(pty): recursively kill PTY subtree on session kill + app quit (#554)

### DIFF
--- a/electron/ptyHost/index.ts
+++ b/electron/ptyHost/index.ts
@@ -28,6 +28,7 @@
 // is PR-3. This file ships standalone and only typechecks once PR-1 has added
 // the node-pty / @xterm/headless / @xterm/addon-serialize deps.
 
+import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { existsSync, readdirSync, statSync } from 'node:fs';
 import { join as pathJoin } from 'node:path';
@@ -286,15 +287,55 @@ export function resizePtySession(sid: string, cols: number, rows: number): void 
 export function killPtySession(sid: string): boolean {
   const entry = sessions.get(sid);
   if (!entry) return false;
+  // Capture pid BEFORE pty.kill() — the binding may zero it after kill.
+  const pid = entry.pty.pid;
   try {
     entry.pty.kill();
   } catch {
     /* already dead */
   }
+  // ConPTY's kill only terminates the cmd.exe / OpenConsole wrapper; on Windows
+  // the claude.exe child (and its grandchildren) survive as orphans. On
+  // mac/linux the pgid may also have stragglers. Walk the tree via a
+  // platform-native call to guarantee a clean shutdown.
+  killProcessSubtree(pid);
   // headless dispose + map delete happen in the onExit handler so we don't
   // double-clean. Belt-and-braces drop here in case onExit doesn't fire (rare:
   // the binding has fired reliably on Windows conpty in spike testing).
   return true;
+}
+
+// Recursively terminate the entire subtree rooted at `pid`. Best-effort: any
+// already-dead pid is swallowed silently. Called from killPtySession after
+// pty.kill() so the IPC `pty:kill` path and `before-quit` both get cleanup.
+function killProcessSubtree(pid: number | undefined): void {
+  if (!pid || pid <= 0) return;
+  if (process.platform === 'win32') {
+    try {
+      // /T walks the entire tree, /F forces termination.
+      spawnSync('taskkill', ['/F', '/T', '/PID', String(pid)], {
+        windowsHide: true,
+        stdio: 'ignore',
+      });
+    } catch {
+      /* already dead or taskkill unavailable */
+    }
+    return;
+  }
+  // POSIX: signal the process group (negative pid). SIGTERM first; SIGKILL
+  // after a short grace period if anything refuses to exit.
+  try {
+    process.kill(-pid, 'SIGTERM');
+  } catch {
+    /* group already gone */
+  }
+  setTimeout(() => {
+    try {
+      process.kill(-pid, 'SIGKILL');
+    } catch {
+      /* already dead */
+    }
+  }, 500).unref();
 }
 
 export function getPtySession(sid: string): PtySessionInfo | null {

--- a/scripts/harness-real-cli.mjs
+++ b/scripts/harness-real-cli.mjs
@@ -50,6 +50,7 @@ import {
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { randomUUID } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
 import {
   createIsolatedClaudeDir,
   dismissFirstRunModals,
@@ -979,6 +980,218 @@ async function caseReopenResume() {
 }
 
 // ============================================================================
+// Case: pty-subtree-killed-on-quit (#554) — owns its own launch
+// ============================================================================
+//
+// Verifies that quitting ccsm tears down the ENTIRE PTY subtree, not just the
+// ConPTY wrapper. On Windows, node-pty.kill() only terminates the
+// cmd.exe / OpenConsole wrapper; without an explicit `taskkill /F /T` the
+// claude.exe grandchild (and anything it spawned) survives as an orphan.
+//
+// Flow: launch ccsm -> create 2 sessions -> walk pty pid + descendants ->
+// quit app -> confirm none of those pids are alive after a 2s settle.
+
+function listChildPids(parentPid) {
+  if (!parentPid || parentPid <= 0) return [];
+  if (process.platform === 'win32') {
+    // wmic is deprecated on newer Windows but still installed; fall back to
+    // PowerShell Get-CimInstance if it's missing.
+    const wmic = spawnSync(
+      'wmic',
+      ['process', 'where', `ParentProcessId=${parentPid}`, 'get', 'ProcessId'],
+      { encoding: 'utf8', windowsHide: true },
+    );
+    if (wmic.status === 0 && wmic.stdout) {
+      return wmic.stdout
+        .split(/\r?\n/)
+        .map((l) => l.trim())
+        .filter((l) => /^\d+$/.test(l))
+        .map((l) => Number(l))
+        .filter((n) => n !== parentPid);
+    }
+    const ps = spawnSync(
+      'powershell',
+      [
+        '-NoProfile',
+        '-Command',
+        `Get-CimInstance Win32_Process -Filter "ParentProcessId=${parentPid}" | Select-Object -ExpandProperty ProcessId`,
+      ],
+      { encoding: 'utf8', windowsHide: true },
+    );
+    if (ps.status === 0 && ps.stdout) {
+      return ps.stdout
+        .split(/\r?\n/)
+        .map((l) => l.trim())
+        .filter((l) => /^\d+$/.test(l))
+        .map((l) => Number(l));
+    }
+    return [];
+  }
+  const r = spawnSync('pgrep', ['-P', String(parentPid)], { encoding: 'utf8' });
+  if (r.status !== 0 || !r.stdout) return [];
+  return r.stdout
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => /^\d+$/.test(l))
+    .map((l) => Number(l));
+}
+
+function walkSubtree(rootPid) {
+  const all = new Set();
+  const queue = [rootPid];
+  while (queue.length) {
+    const pid = queue.shift();
+    if (!pid || all.has(pid)) continue;
+    all.add(pid);
+    for (const child of listChildPids(pid)) {
+      if (!all.has(child)) queue.push(child);
+    }
+  }
+  return [...all];
+}
+
+function pidAlive(pid) {
+  if (!pid || pid <= 0) return false;
+  if (process.platform === 'win32') {
+    const r = spawnSync('tasklist', ['/FI', `PID eq ${pid}`, '/NH', '/FO', 'CSV'], {
+      encoding: 'utf8',
+      windowsHide: true,
+    });
+    if (r.status !== 0 || !r.stdout) return false;
+    // tasklist prints "INFO: No tasks are running ..." when no match, otherwise
+    // a CSV row containing the pid.
+    return new RegExp(`"${pid}"`).test(r.stdout);
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return e && e.code === 'EPERM';
+  }
+}
+
+function processName(pid) {
+  if (process.platform === 'win32') {
+    const r = spawnSync('tasklist', ['/FI', `PID eq ${pid}`, '/NH', '/FO', 'CSV'], {
+      encoding: 'utf8',
+      windowsHide: true,
+    });
+    if (r.status === 0 && r.stdout) {
+      const m = r.stdout.match(/"([^"]+)"/);
+      if (m) return m[1];
+    }
+    return '?';
+  }
+  const r = spawnSync('ps', ['-p', String(pid), '-o', 'comm='], { encoding: 'utf8' });
+  return r.status === 0 && r.stdout ? r.stdout.trim() : '?';
+}
+
+async function casePtySubtreeKilledOnQuit() {
+  const isolated = await createIsolatedClaudeDir();
+  const tempDir = isolated.tempDir;
+
+  let app = null;
+  try {
+    const launched = await launchCcsmIsolated({ tempDir });
+    app = launched.electronApp;
+    const win = launched.win;
+    await sleep(1500);
+
+    await win.waitForFunction(
+      () => !document.querySelector('[data-testid="claude-availability-probing"]'),
+      null,
+      { timeout: 30000 },
+    );
+
+    // Spawn 2 sessions so we exercise the kill loop, not just one entry.
+    const sessions = [];
+    for (const name of ['subtree-A', 'subtree-B']) {
+      const { sid } = await seedSession(win, { name, cwd: tempDir });
+      if (!sid) throw new Error(`seedSession (${name}) returned no sid`);
+      await waitForTerminalReady(win, sid, { timeout: 60000 });
+      await waitForXtermBuffer(win, /claude|welcome|│|╭|trust|\?\sfor\sshortcuts/i, {
+        timeout: 30000,
+      });
+      const pid = await getPtyPidForSid(win, sid);
+      if (typeof pid !== 'number') throw new Error(`no pty pid for ${name} (${sid})`);
+      sessions.push({ name, sid, pid });
+    }
+
+    // Walk the full subtree for each pty root. Capture BEFORE quit so we have
+    // ground truth — after the quit the kernel will recycle pid table entries
+    // and we'd miss children.
+    const allPids = new Map(); // pid -> { ownerName, name }
+    for (const s of sessions) {
+      const tree = walkSubtree(s.pid);
+      for (const p of tree) {
+        if (!allPids.has(p)) allPids.set(p, { ownerName: s.name, name: processName(p) });
+      }
+    }
+
+    if (allPids.size < sessions.length) {
+      throw new Error(
+        `expected at least ${sessions.length} pids in tree, got ${allPids.size}: ` +
+          JSON.stringify([...allPids]),
+      );
+    }
+    console.log(
+      `[pty-subtree] captured ${allPids.size} pids across ${sessions.length} sessions: ` +
+        [...allPids.entries()]
+          .map(([pid, m]) => `${pid}(${m.name})`)
+          .join(', '),
+    );
+
+    // Trigger graceful quit (drives the before-quit handler that calls
+    // killAllPtySessions). Tolerate the close raising — Electron is going down.
+    try {
+      await app.evaluate(({ app: a }) => a.quit());
+    } catch (_) {
+      /* expected if context tears down mid-evaluate */
+    }
+    try {
+      await app.close();
+    } catch (_) {
+      /* already closing */
+    }
+    app = null;
+
+    // 2s settle so taskkill /T can finish walking the tree and the OS reaps
+    // the children.
+    await sleep(2000);
+
+    const survivors = [];
+    for (const [pid, meta] of allPids.entries()) {
+      if (pidAlive(pid)) survivors.push({ pid, ...meta, currentName: processName(pid) });
+    }
+
+    if (survivors.length > 0) {
+      // Best-effort cleanup so a failed run doesn't leak claude.exe forever.
+      for (const s of survivors) {
+        if (process.platform === 'win32') {
+          spawnSync('taskkill', ['/F', '/T', '/PID', String(s.pid)], {
+            windowsHide: true,
+            stdio: 'ignore',
+          });
+        } else {
+          try { process.kill(s.pid, 'SIGKILL'); } catch (_) { /* ignore */ }
+        }
+      }
+      throw new Error(
+        `pty subtree leaked after app quit: ` +
+          survivors
+            .map((s) => `pid=${s.pid} name=${s.currentName} owner=${s.ownerName}`)
+            .join('; '),
+      );
+    }
+  } finally {
+    if (app) {
+      try { await app.close(); } catch (_) { /* ignore */ }
+    }
+    isolated.cleanup?.();
+  }
+}
+
+// ============================================================================
 // Registry
 // ============================================================================
 
@@ -991,6 +1204,7 @@ const CASE_REGISTRY = [
   { name: 'new-session-focus-cli',       group: 'shared', run: caseNewSessionFocusCli },
   { name: 'pty-pid-stable-across-switch',group: 'shared', run: casePtyPidStableAcrossSwitch },
   { name: 'reopen-resume',               group: 'standalone', run: caseReopenResume },
+  { name: 'pty-subtree-killed-on-quit',  group: 'standalone', run: casePtySubtreeKilledOnQuit },
 ];
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Closes the GAP in #554: `before-quit` already calls `killAllPtySessions()` (electron/main.ts:796), but `killPtySession` only calls `entry.pty.kill()`. On Windows ConPTY's modern `_useConptyDll` path that just releases the conpty handle — the cmd.exe wrapper exits but the `claude.exe` grandchild can survive as an orphan. On POSIX the pgid may also keep stragglers.

This change wraps `pty.kill()` with a platform-native subtree kill so both the `before-quit` path AND the renderer-initiated `pty:kill` IPC (used on session delete) get a clean teardown.

## Grep-proof of the gap

`electron/ptyHost/index.ts:286` BEFORE this PR:
```ts
export function killPtySession(sid: string): boolean {
  const entry = sessions.get(sid);
  if (!entry) return false;
  try {
    entry.pty.kill();          // <-- only releases conpty handle
  } catch {}
  return true;                 // <-- no subtree walk
}
```

node-pty `windowsPtyAgent.js:153-160` confirms the leak path — when `_useConptyDll` is true, `kill()` just calls the native handle release; the legacy `consoleProcessList` walk (lines 137-152) is skipped entirely.

## Fix

Inside `killPtySession`:
1. Capture `pid = entry.pty.pid` BEFORE `pty.kill()` (the binding may zero it).
2. Call `pty.kill()` first (graceful conpty-level kill).
3. Call `killProcessSubtree(pid)`:
   - **Windows**: `spawnSync('taskkill', ['/F', '/T', '/PID', pid])` — `/T` walks the tree, `/F` forces termination.
   - **POSIX**: `process.kill(-pid, 'SIGTERM')` then `SIGKILL` after 500 ms via an unrefed timer.
4. All wrapped in try/catch — already-dead pids do not throw.

`killAllPtySessions` is unchanged; the recursive kill lives inside `killPtySession` so the IPC `pty:kill` path (renderer-driven session delete) gets the upgrade for free.

## E2E probe

New standalone case `pty-subtree-killed-on-quit` in `scripts/harness-real-cli.mjs`:
1. Launch isolated ccsm.
2. Spawn 2 sessions, wait for terminal-ready in each.
3. Walk each pty pid's descendants via `wmic ProcessId=...` (Win) or `pgrep -P` (Unix). Build the full set of "child pids" (4 on Windows: 2x cmd.exe wrapper + 2x claude.exe).
4. Trigger graceful quit via `app.evaluate(({app}) => app.quit())`.
5. Wait 2 s, then assert via `tasklist /FI "PID eq <pid>"` (Win) or `process.kill(pid, 0)` (POSIX) that NONE of the captured pids are alive.
6. On failure: print `pid=N name=X owner=session-A/B` for every survivor, plus best-effort cleanup so the test environment doesn't leak claude.exe forever.

## Verification

- `npm run typecheck` — PASS
- `npm run lint` — PASS for changed files (the 11 pre-existing errors in `src/components/TerminalPane.tsx` already exist on `origin/working`; not introduced here)
- `npm test` — 273/273 PASS (after a stray `npm rebuild better-sqlite3` for the local Node 24 toolchain)
- `node scripts/harness-real-cli.mjs --only=pty-subtree-killed-on-quit` — **PASS** (14.6 s). Captured 4 pids: `cmd.exe + claude.exe` per session; all dead after quit.
- `node scripts/harness-real-cli.mjs --only=reopen-resume` — **PASS** (48.5 s). Resume path intact, subtree kill on app shutdown does not interfere with `--resume`.
- `node scripts/harness-real-cli.mjs --only=switch-session-keeps-chat` — **PASS** (33.5 s). Per-session pty lifecycle preserved across A↔B switch.

## Out of scope

- Cross-process leaks beyond the PTY tree (e.g. orphan native handles).
- Rate-limiting subtree kill (taskkill is fast).