### PR TITLE
scripts: add sync-pool.sh for worktree bit-rot recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ docs/screenshots/dogfood-happy-path/
 *.deb
 *.rpm
 *.blockmap
+.pool-synced-at-*

--- a/scripts/sync-pool.sh
+++ b/scripts/sync-pool.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Usage: scripts/sync-pool.sh [branch] [--force]
+#   branch: defaults to "working"
+#   --force: skip uncommitted-changes guard (for cron / unattended use)
+set -euo pipefail
+
+BRANCH="working"
+FORCE=0
+for arg in "$@"; do
+  case "$arg" in
+    --force) FORCE=1 ;;
+    *) BRANCH="$arg" ;;
+  esac
+done
+
+git fetch origin --quiet
+TARGET_SHA="$(git rev-parse "origin/$BRANCH")"
+MARKER=".pool-synced-at-$TARGET_SHA"
+
+# Idempotent no-op if already synced AND build artifact present
+if [ -f "$MARKER" ] && [ -f "dist/renderer/bundle.js" ]; then
+  echo "sync-pool: already at $TARGET_SHA with built dist, skipping"
+  exit 0
+fi
+
+# Guard: refuse to nuke uncommitted work unless --force
+if [ "$FORCE" -eq 0 ]; then
+  if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo "sync-pool: uncommitted changes present, refusing to reset (use --force to override)" >&2
+    exit 1
+  fi
+fi
+
+git reset --hard "origin/$BRANCH"
+git clean -fd
+npm install --no-audit --no-fund
+npm run build
+
+rm -f .pool-synced-at-* 2>/dev/null || true
+touch "$MARKER"
+echo "sync-pool: synced to $TARGET_SHA, deps installed, build complete"


### PR DESCRIPTION
## Summary

Pool worktrees (`~/ccsm-worktrees/pool-{1..5}`) accumulate bit-rot when reviewers/workers reuse them across PRs:
- missing native deps (e.g. `@xterm/*`) after a dependency change merged on `working`
- stale `dist/renderer/bundle.js` after a renderer change merged on `working`
- worktree still checked out on some prior feature branch

3 reviewer subagents in 2 days have hit one of these. #562 diagnosed the pattern and recommended a single sync entry point invoked at the top of every worker/reviewer prompt.

## What's in this PR

`scripts/sync-pool.sh`:
- `git fetch origin --quiet`
- If `.pool-synced-at-<SHA>` marker matches `origin/<branch>` SHA **and** `dist/renderer/bundle.js` exists → no-op skip (cheap, idempotent)
- Otherwise:
  - Guard: refuse if uncommitted/staged changes exist (unless `--force` for cron)
  - `git reset --hard origin/<branch>` + `git clean -fd`
  - `npm install --no-audit --no-fund`
  - `npm run build`
  - Drop a fresh marker, remove old ones

`.gitignore`: ignore `.pool-synced-at-*` markers.

## Tested in this worktree

- Idempotent path: marker present + `dist/renderer/bundle.js` present → prints "already at <SHA> with built dist, skipping" and exits 0.
- Guard path: with staged changes and no marker → prints "uncommitted changes present, refusing to reset" and exits 1.
- Full-run path: implicitly tested during worktree prep (manual `git fetch && git reset --hard origin/working && npm install && npm run build` — exactly what the script automates) — `dist/renderer/bundle.js` rebuilt cleanly, no errors.

## Follow-up (separate work)

Update worker/reviewer prompt templates to start with `bash scripts/sync-pool.sh` so every dispatched subagent self-heals before doing anything.

Refs #562.