### PR TITLE
scripts(sync-pool): also guard against untracked files (#568)

### DIFF
--- a/scripts/sync-pool.sh
+++ b/scripts/sync-pool.sh
@@ -29,6 +29,10 @@ if [ "$FORCE" -eq 0 ]; then
     echo "sync-pool: uncommitted changes present, refusing to reset (use --force to override)" >&2
     exit 1
   fi
+  if [ -n "$(git ls-files --others --exclude-standard)" ]; then
+    echo "sync-pool: untracked files present, refusing to wipe (use --force to override)" >&2
+    exit 1
+  fi
 fi
 
 git reset --hard "origin/$BRANCH"


### PR DESCRIPTION
## Summary

Follow-up to PR #487 (sync-pool.sh). Reviewer flagged that the uncommitted-changes guard only inspects staged + unstaged tracked changes via `git diff` / `git diff --cached`. Because the script later runs `git clean -fd` (line 35), any untracked files in the worktree were silently wiped on every sync.

This PR extends the guard inside the existing `if [ "$FORCE" -eq 0 ]` block to also abort when untracked files are present:

```bash
if [ -n "$(git ls-files --others --exclude-standard)" ]; then
  echo "sync-pool: untracked files present, refusing to wipe (use --force to override)" >&2
  exit 1
fi
```

`--force` semantics are preserved: it still skips ALL guards (diff, diff --cached, untracked) — the new check is purely additive inside the same block.

## Test plan

- [x] Syntax check: `bash -n scripts/sync-pool.sh`
- [x] With clean tree + untracked file: `touch test-untracked.txt && bash scripts/sync-pool.sh` aborts with the new message and leaves the file in place
- [x] Existing diff guard still fires first when there are tracked modifications (verified during dev)
- [x] `--force` bypasses the new check by construction (additive inside `if [ "$FORCE" -eq 0 ]`)