### PR TITLE
fix(ui): keep app title as CCSM, don't follow session title (#573)

### DIFF
--- a/scripts/harness-real-cli.mjs
+++ b/scripts/harness-real-cli.mjs
@@ -233,6 +233,17 @@ async function caseNewSessionChat({ electronApp, win, tempDir }) {
   });
   if (healthy.errorToast) throw new Error(`error toast surfaced: ${healthy.errorToast}`);
   if (healthy.terminalErrorVisible) throw new Error('terminal pane flipped to error state (Retry button visible)');
+
+  // Task #573 — the window title must stay "CCSM" even after claude has
+  // emitted ESC ]0;TITLE BEL sequences during the session. Previously
+  // TerminalPane forwarded those into document.title, hijacking the app
+  // window title. After 2s settle to give any pending ANSI title sequence
+  // time to land in the renderer.
+  await sleep(2000);
+  const docTitle = await win.title();
+  if (docTitle !== 'CCSM') {
+    throw new Error(`window title hijacked by CLI: expected "CCSM", got ${JSON.stringify(docTitle)}`);
+  }
 }
 
 // ============================================================================

--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -132,12 +132,6 @@ function ensureTerminal(host: HTMLDivElement): Terminal {
     }
   });
 
-  // Window title follows xterm escape sequences (ESC ]0;TITLE BEL),
-  // matching ttyd's onTitleChange behaviour.
-  term.onTitleChange((t) => {
-    if (t) document.title = t;
-  });
-
   // Copy/paste keyboard shortcuts (Windows Terminal style):
   //   Ctrl+C  → if selection, copy; else fall through to SIGINT
   //   Ctrl+V  → paste


### PR DESCRIPTION
## Bug
Opening a session changed the ccsm window title (and Windows taskbar entry) to whatever the embedded CLI emitted via ANSI ESC ]0;TITLE BEL — typically \`✳ Claude Code\`. The app title should stay \`CCSM\` (the value baked into \`src/index.html\`).

## Root cause
\`src/components/TerminalPane.tsx\` wired \`xterm.onTitleChange\` straight into \`document.title\`, mirroring ttyd's behaviour:

\`\`\`ts
term.onTitleChange((t) => {
  if (t) document.title = t;
});
\`\`\`

ttyd is a single-tab terminal-first app, so reflecting the CLI title makes sense. ccsm is an app shell that happens to embed a CLI; the window title is product chrome and must not be hijacked.

## Fix
Drop the entire \`onTitleChange\` handler (5 lines incl. comment). \`<title>CCSM</title>\` in \`src/index.html\` is now the only writer. No replacement needed — Electron picks the title up from the renderer document.

## Behavior
- Before: window title flips to \`✳ Claude Code\` ~1-2s after opening a session.
- After: window title stays \`CCSM\` for the lifetime of the app.

## Probe
Extended the existing \`new-session-chat\` case in \`scripts/harness-real-cli.mjs\` rather than adding a standalone case (per \`feedback_e2e_prefer_harness.md\` — that case already opens a session, sends a prompt, and waits for a real claude reply, which is exactly when the CLI emits the title sequence; tacking on a \`win.title()\` assertion costs ~2s vs. ~30s for a new launch).

## Reverse-verify
\`git stash\` of \`TerminalPane.tsx\` → rebuild → run probe → FAIL with:
\`\`\`
window title hijacked by CLI: expected \"CCSM\", got \"✳ Claude Code\"
\`\`\`
\`git stash pop\` → rebuild → run probe → PASS.

## Probe run
\`\`\`
node scripts/harness-real-cli.mjs --only=new-session-chat
[HARNESS] <<< PASS new-session-chat (21567ms)
\`\`\`

Closes #573.