### PR TITLE
fix(notify): handle install-day case for fresh projects (#576)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -949,40 +949,6 @@ app.whenReady().then(() => {
     (globalThis as unknown as Record<string, unknown>).__ccsmTestDebug = {
       getLastEmittedForSid: (sid: string) =>
         sessionWatcher.getLastEmittedForTest(sid),
-      // Force the watcher to re-attach for `sid`. Used by the e2e to work
-      // around a PR-A (#553) startWatching limitation: when the parent
-      // projects/<projectKey>/ dir does not exist at startWatching time
-      // (claude has never run in this cwd before — fresh isolated config),
-      // sessionWatcher silently bails on the dir watcher and never re-scans.
-      // The harness pokes this seam after seedSession + first prompt so the
-      // re-attach picks up the now-existing JSONL. Tracked for upstream fix.
-      reAttachWatcher: (sid: string) => {
-        try {
-          // eslint-disable-next-line @typescript-eslint/no-require-imports
-          const fs = require('node:fs');
-          // eslint-disable-next-line @typescript-eslint/no-require-imports
-          const path = require('node:path');
-          const root =
-            process.env.CCSM_CLAUDE_CONFIG_DIR ||
-            process.env.CLAUDE_CONFIG_DIR;
-          if (!root) return { ok: false, reason: 'no-config-root' };
-          const projDir = path.join(root, 'projects');
-          if (!fs.existsSync(projDir))
-            return { ok: false, reason: 'no-projects-dir' };
-          const projects = fs.readdirSync(projDir);
-          for (const p of projects) {
-            const fp = path.join(projDir, p, `${sid}.jsonl`);
-            if (fs.existsSync(fp)) {
-              sessionWatcher.stopWatching(sid);
-              sessionWatcher.startWatching(sid, fp);
-              return { ok: true, fp };
-            }
-          }
-          return { ok: false, reason: 'no-jsonl-found' };
-        } catch (e) {
-          return { ok: false, err: String(e) };
-        }
-      },
       env: () => ({
         CCSM_CLAUDE_CONFIG_DIR: process.env.CCSM_CLAUDE_CONFIG_DIR ?? null,
         CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR ?? null,

--- a/electron/sessionWatcher/index.ts
+++ b/electron/sessionWatcher/index.ts
@@ -44,6 +44,12 @@ interface Entry {
   // creation even if claude hasn't written it at startWatching time).
   fileWatcher: fs.FSWatcher | null;
   dirWatcher: fs.FSWatcher | null;
+  // Install-day fallback: when the parent `projects/<projectKey>/` doesn't
+  // exist yet (claude has never run for this cwd), we watch the nearest
+  // existing ancestor and retry installDirWatcher when something is created
+  // there. Cleaned up the moment the real dirWatcher is in place.
+  ancestorWatcher: fs.FSWatcher | null;
+  ancestorPath: string | null;
   lastEmitted: WatcherState | null;
   // Coalesce bursts of fs events. fs.watch on Windows can fire 3-5 times
   // for a single append; we don't want to re-read + reclassify each time.
@@ -80,6 +86,8 @@ class SessionWatcher extends EventEmitter {
       jsonlPath,
       fileWatcher: null,
       dirWatcher: null,
+      ancestorWatcher: null,
+      ancestorPath: null,
       lastEmitted: null,
       pendingTimer: null,
       closed: false,
@@ -109,6 +117,10 @@ class SessionWatcher extends EventEmitter {
     if (entry.dirWatcher) {
       try { entry.dirWatcher.close(); } catch { /* already closed */ }
       entry.dirWatcher = null;
+    }
+    if (entry.ancestorWatcher) {
+      try { entry.ancestorWatcher.close(); } catch { /* already closed */ }
+      entry.ancestorWatcher = null;
     }
     this.entries.delete(sid);
   }
@@ -148,13 +160,23 @@ class SessionWatcher extends EventEmitter {
 
   private installDirWatcher(entry: Entry): void {
     if (entry.closed) return;
+    if (entry.dirWatcher) return;
     const dir = path.dirname(entry.jsonlPath);
     const baseName = path.basename(entry.jsonlPath);
     if (!fs.existsSync(dir)) {
-      // Parent doesn't exist yet — claude hasn't ever run for this cwd.
-      // We can't watch a non-existent directory portably; bail. The first
-      // re-attach (e.g. on session-switch) will re-run startWatching.
+      // Install-day case: parent `projects/<projectKey>/` doesn't exist yet
+      // (claude has never run for this cwd). We can't fs.watch a missing
+      // dir portably, so watch the nearest existing ancestor instead and
+      // retry once any descendant is created. Promotes itself to a real
+      // dirWatcher the moment `dir` appears.
+      this.installAncestorWatcher(entry, dir);
       return;
+    }
+    // dir exists — drop any ancestor fallback we had.
+    if (entry.ancestorWatcher) {
+      try { entry.ancestorWatcher.close(); } catch { /* */ }
+      entry.ancestorWatcher = null;
+      entry.ancestorPath = null;
     }
     try {
       entry.dirWatcher = fs.watch(dir, (_evt, filename) => {
@@ -174,6 +196,55 @@ class SessionWatcher extends EventEmitter {
       });
     } catch {
       entry.dirWatcher = null;
+    }
+  }
+
+  private installAncestorWatcher(entry: Entry, missingDir: string): void {
+    if (entry.closed) return;
+    // Walk up until we find an existing ancestor. fs.watch won't accept a
+    // missing path; the nearest existing ancestor is guaranteed to exist
+    // (worst case: the filesystem root).
+    let ancestor = path.dirname(missingDir);
+    let prev = missingDir;
+    while (!fs.existsSync(ancestor) && ancestor !== prev) {
+      prev = ancestor;
+      ancestor = path.dirname(ancestor);
+    }
+    // Already watching this same ancestor — nothing to do.
+    if (entry.ancestorWatcher && entry.ancestorPath === ancestor) return;
+    if (entry.ancestorWatcher) {
+      try { entry.ancestorWatcher.close(); } catch { /* */ }
+      entry.ancestorWatcher = null;
+      entry.ancestorPath = null;
+    }
+    try {
+      entry.ancestorWatcher = fs.watch(ancestor, () => {
+        if (entry.closed) return;
+        // Any change in the ancestor — retry the dir-watcher chain. If the
+        // immediate parent now exists, installDirWatcher will close this
+        // ancestor watcher and install the real one. Otherwise it'll just
+        // re-check (or re-anchor to a deeper ancestor that just appeared).
+        if (entry.dirWatcher) return;
+        this.installDirWatcher(entry);
+        // If we successfully promoted to a real dir watcher, also try to
+        // install the file watcher and re-classify in case the JSONL has
+        // already landed.
+        if (entry.dirWatcher) {
+          if (!entry.fileWatcher) this.installFileWatcher(entry);
+          this.scheduleRead(entry);
+        }
+      });
+      entry.ancestorPath = ancestor;
+      entry.ancestorWatcher.on('error', () => {
+        if (entry.ancestorWatcher) {
+          try { entry.ancestorWatcher.close(); } catch { /* */ }
+          entry.ancestorWatcher = null;
+          entry.ancestorPath = null;
+        }
+      });
+    } catch {
+      entry.ancestorWatcher = null;
+      entry.ancestorPath = null;
     }
   }
 

--- a/scripts/harness-real-cli.mjs
+++ b/scripts/harness-real-cli.mjs
@@ -422,24 +422,8 @@ async function caseNotifyFiresOnIdle({ electronApp, win, tempDir }) {
   // Wait up to 180s for a notification entry whose sid matches.
   const start = Date.now();
   let entry = null;
-  let pokeAttempted = false;
   while (Date.now() - start < 180_000) {
     await sleep(2000);
-    // After ~6s, poke the sessionWatcher to re-attach for this sid. This
-    // works around a PR-A (#553) startWatching limitation: when the parent
-    // projects/<projectKey>/ dir does not exist at startWatching time,
-    // sessionWatcher silently skips installing the dir watcher and never
-    // re-scans. By re-attaching after the JSONL has been written, the
-    // watcher picks up the file and emits idle. Production code paths hit
-    // this less often because parent dirs typically exist from prior runs.
-    if (!pokeAttempted && Date.now() - start > 6000) {
-      pokeAttempted = true;
-      const pokeResult = await electronApp.evaluate((electron, s) => {
-        const dbg = globalThis.__ccsmTestDebug;
-        return dbg?.reAttachWatcher ? dbg.reAttachWatcher(s) : 'no-debug-seam';
-      }, sid);
-      console.log(`[HARNESS]   reAttachWatcher: ${JSON.stringify(pokeResult)}`);
-    }
     const nextEntries = await electronApp.evaluate(
       (_electron, [s, base]) => (globalThis.__ccsmNotifyLog || []).slice(base).filter((e) => e.sid === s),
       [sid, baseline],


### PR DESCRIPTION
## Bug
`electron/sessionWatcher/index.ts` `installDirWatcher` silently bailed when the parent `projects/<projectKey>/` didn't exist at `startWatching` time (claude had never run for the cwd). Install-day notify path (first-ever session in a fresh project) missed every notification until something else re-triggered `startWatching`.

Surfaced by PR #486 reviewer; that PR shipped with a `__ccsmTestDebug.reAttachWatcher` workaround in `electron/main.ts` + a poke in `scripts/harness-real-cli.mjs` to keep the probe green.

## Fix
Per-entry **ancestor watcher**: when the immediate parent dir is missing, walk up to the nearest existing ancestor and `fs.watch` that. On any descendant creation, retry `installDirWatcher`; if the real parent now exists, close the ancestor watcher, install the real dir watcher, install the file watcher, and re-classify.

- No polling, no extra deps, no shared state
- Per-Entry — `stopWatching` cleans up the ancestor watcher alongside file/dir watchers
- Re-entrancy guard in `installDirWatcher` (`if (entry.dirWatcher) return`) prevents double-install if both ancestor-fired retry and a delayed direct call race
- Inline comment explains the install-day rationale

Considered alternatives:
1. Polling fallback — simple but per-entry interval timers, ugly
2. Single grandparent watch on `~/.claude/projects/` — needs extra plumbing for the per-projectKey nesting; ancestor-walk per-entry is simpler and naturally handles arbitrary missing-ancestor depth (e.g. fresh `CCSM_CLAUDE_CONFIG_DIR`)

## Seam removal
Removed `__ccsmTestDebug.reAttachWatcher` from `electron/main.ts` and the corresponding poke in `scripts/harness-real-cli.mjs`. Diagnostic helpers (`getLastEmittedForSid`, `env`, `jsonl`) kept — they remain useful for probe diagnostics.

## E2E
- `notify-fires-on-idle` (without seam) — **PASS** in 18.6s (`state=requires_action`)
- Reverse-verify (stash watcher fix, keep seam removal, rebuild) — **FAIL** with `lastEmitted: 'running'` and empty notify log → confirms the install-day path actually needed the fix

## Diff stat
```
electron/main.ts                 | 34 ------------------
electron/sessionWatcher/index.ts | 77 ++++++++++++++++++++++++++++++++++++++--
scripts/harness-real-cli.mjs     | 16 ---------
3 files changed, 74 insertions(+), 53 deletions(-)
```