### PR TITLE
test(e2e): replace silent .catch swallows on readXtermLines (#577)

### DIFF
--- a/scripts/harness-real-cli.mjs
+++ b/scripts/harness-real-cli.mjs
@@ -601,7 +601,12 @@ async function caseSwitchSessionKeepsChat({ electronApp, win, tempDir }) {
     try {
       await waitForXtermBuffer(win, /ALPHA/, { timeout: 15000 });
     } catch (_) { /* fall through */ }
-    const aLines = await readXtermLines(win, { lines: 200 }).catch(() => []);
+    // Surface real errors instead of swallowing to []: a swallowed evaluate
+    // failure here would fire the generic "scrollback lost ALPHA" assertion
+    // and hide the actual buffer state (see #490 / #574 flake repro).
+    const aLines = await readXtermLines(win, { lines: 200 }).catch((err) => {
+      throw new Error(`readXtermLines failed after switch-back to sid=${sidA}: ${err && err.stack || err}`);
+    });
     if (!/ALPHA/.test(aLines.join('\n'))) {
       throw new Error(`A's scrollback lost ALPHA after switch-back. lines=${aLines.length}`);
     }


### PR DESCRIPTION
## Summary

Follow-up to PR #490 reviewer flag. The reviewer listed 7 `.catch(() => [])` sites on `readXtermLines` calls as potentially swallowing real `win.evaluate` errors behind generic assertion failures (the same root cause as the #574 flake).

After per-site analysis, **only 1 of the 7 sites fits PR #490's pattern** (one-shot read immediately followed by an assertion). The other 6 are intentional graceful fallbacks where empty array IS the semantic. Each is documented below.

## Changed (1 line)

| Line | Before | After |
| --- | --- | --- |
| `scripts/harness-real-cli.mjs:604` | `await readXtermLines(win, { lines: 200 }).catch(() => [])` | `await readXtermLines(win, { lines: 200 }).catch((err) => { throw new Error(\`readXtermLines failed after switch-back to sid=${'$'}{sidA}: ${'$'}{err && err.stack || err}\`); })` |

Context: `caseSwitchSessionKeepsChat`, post-switch-back ALPHA scrollback assertion. Same shape as the #490 fix at line 1268 (post-`waitFor*`, then `if (!regex.test(...)) throw`). A swallowed evaluate failure here would surface as the generic `"A's scrollback lost ALPHA after switch-back"` and hide the actual buffer state.

## Skipped (6 sites) — empty fallback is intended graceful behavior

All of these meet the task's stated exception: `\"something where empty fallback IS the intended graceful behavior, not error swallow\"`.

| Line | Context | Why skipped |
| --- | --- | --- |
| 246 | `caseNewSessionChat` 90s reply-wait loop | Polling loop with `await sleep(2000)`; empty array = \"keep waiting\". Rethrowing would kill the whole 90s wait. |
| 558 | `caseSwitchSessionKeepsChat` first-run-prompt drain (`for i in 6`) | Polling loop; empty = retry `\r`. |
| 592 | `caseSwitchSessionKeepsChat` post-switch splash drain (`for i in 6`) | Polling loop; empty = retry `\r`. |
| 677 | `sendAndAwaitReply` reply-wait loop | Polling loop with `await sleep(2000)`; empty = continue polling. |
| 717 | `caseCwdProjectsClaude` prompt-echo check | Probe-decision read: empty triggers a retry-send. |
| 1379 | `caseDualLaunchExclusive` run2 follow-up reply wait | Polling loop with `await sleep(2000)`; empty = continue polling. |

Note: `readXtermLines` itself already swallows internal `win.evaluate` errors with `.catch(() => [])` at `scripts/probe-utils-real-cli.mjs:141` (and its docstring documents `\"returns an empty array (safe for polling loops)\"`). So in practice the outer `.catch(() => [])` is dead defensive code — the inner swallow happens first. The fix here matches PR #490's pattern at the only assertion-shaped call site for consistency; deeper hardening (removing the inner swallow) is out of scope for this PR and would need its own task.

## Sanity probes (post-fix)

- `--only=new-session-chat`: PASS (21527ms)
- `--only=notify-fires-on-idle`: PASS (24607ms)

## Diff stat

```
 scripts/harness-real-cli.mjs |   7 +-
 1 file changed, 6 insertions(+), 1 deletion(-)
```

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>