### PR TITLE
feat(notify): tray + taskbar badge with unread count (#572)

### DIFF
--- a/electron/i18n.ts
+++ b/electron/i18n.ts
@@ -44,11 +44,16 @@ type CloseDialogCatalog = {
   dontAskAgain: string;
 };
 
+type BadgeCatalog = {
+  unreadOverlay: string;
+};
+
 type NotificationKey = keyof NotificationCatalog;
 type TrayKey = keyof TrayCatalog;
 type MenuKey = keyof MenuCatalog;
 type DialogKey = keyof DialogCatalog;
 type CloseDialogKey = keyof CloseDialogCatalog;
+type BadgeKey = keyof BadgeCatalog;
 
 // IMPORTANT: keep these strings byte-identical to the renderer catalog
 // `notifications` namespace. The renderer catalog is the source of truth.
@@ -134,6 +139,18 @@ const closeDialogCatalogs: Record<SupportedLanguage, CloseDialogCatalog> = {
   }
 };
 
+// Accessibility alt text for the Windows taskbar overlay icon. The visible
+// badge is just a digit ("1" / "9+"); screen readers announce this string.
+// Not surfaced in the renderer so no parity concern.
+const badgeCatalogs: Record<SupportedLanguage, BadgeCatalog> = {
+  en: {
+    unreadOverlay: '{{n}} unread'
+  },
+  zh: {
+    unreadOverlay: '{{n}} 条未读'
+  }
+};
+
 let activeLanguage: SupportedLanguage = 'en';
 
 export function setMainLanguage(lang: SupportedLanguage): void {
@@ -180,6 +197,15 @@ export function tDialog(key: DialogKey): string {
 export function tCloseDialog(key: CloseDialogKey): string {
   const catalog = closeDialogCatalogs[activeLanguage] ?? closeDialogCatalogs.en;
   return catalog[key] ?? closeDialogCatalogs.en[key] ?? key;
+}
+
+export function tBadge(
+  key: BadgeKey,
+  vars: Record<string, string | number> = {}
+): string {
+  const catalog = badgeCatalogs[activeLanguage] ?? badgeCatalogs.en;
+  const template = catalog[key] ?? badgeCatalogs.en[key] ?? key;
+  return interpolate(template, vars);
 }
 
 // Resolve a system locale tag into one of the two supported languages.

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -69,6 +69,7 @@ import { listModelsFromSettings, readDefaultModelFromSettings } from './agent/li
 import { registerPtyHostIpc, killAllPtySessions } from './ptyHost';
 import { sessionWatcher } from './sessionWatcher';
 import { installNotifyBridge } from './notify';
+import { BadgeManager } from './notify/badge';
 
 // ─────────────────────── IPC security helpers ────────────────────────────
 //
@@ -511,6 +512,10 @@ function createWindow() {
     }
   });
 
+  win.on('focus', () => {
+    clearBadgeForActiveIfFocused();
+  });
+
   const emitMax = () => win.webContents.send('window:maximizedChanged', win.isMaximized());
   win.on('maximize', emitMax);
   win.on('unmaximize', emitMax);
@@ -603,6 +608,20 @@ function createWindow() {
 
 let tray: Tray | null = null;
 let isQuitting = false;
+let badgeManager: BadgeManager | null = null;
+
+function getTrayBaseImage() {
+  return buildTrayIcon();
+}
+
+function clearBadgeForActiveIfFocused() {
+  if (!badgeManager) return;
+  const w = BrowserWindow.getAllWindows()[0];
+  const focused = !!(w && !w.isDestroyed() && w.isFocused());
+  if (!focused) return;
+  if (!activeSidFromRenderer) return;
+  badgeManager.clearSid(activeSidFromRenderer);
+}
 
 function buildTrayIcon() {
   // Tiny 16×16 placeholder (white square on transparent). Windows
@@ -920,11 +939,17 @@ app.whenReady().then(() => {
   ipcMain.on('session:setActive', (e, sid: unknown) => {
     if (!fromMainFrame(e)) return;
     activeSidFromRenderer = typeof sid === 'string' && sid.length > 0 ? sid : null;
+    clearBadgeForActiveIfFocused();
   });
 
   // Desktop notification bridge — fires OS toasts on session 'idle' /
   // 'requires_action' transitions, with global-mute + active-window +
   // active-sid suppression and per-sid 5s dedupe. See electron/notify.
+  badgeManager = new BadgeManager({
+    getTray: () => tray,
+    getBaseTrayImage: getTrayBaseImage,
+    getWindows: () => BrowserWindow.getAllWindows(),
+  });
   installNotifyBridge({
     sessionWatcher,
     getMainWindow: () => BrowserWindow.getAllWindows()[0] ?? null,
@@ -934,7 +959,17 @@ app.whenReady().then(() => {
       const w = BrowserWindow.getAllWindows()[0];
       return !!(w && !w.isDestroyed() && w.isFocused());
     },
+    onNotified: (sid) => {
+      badgeManager?.incrementSid(sid);
+    },
   });
+
+  if (process.env.CCSM_NOTIFY_TEST_HOOK) {
+    (globalThis as unknown as Record<string, unknown>).__ccsmBadgeDebug = {
+      getTotal: () => badgeManager?.getTotal() ?? 0,
+      clearAll: () => badgeManager?.clearAll(),
+    };
+  }
 
   // Dev-only `globalThis.__ccsmDebug` backdoor was removed alongside the
   // notify subsystem cleanup — its only members exposed the dead notify /

--- a/electron/notify/badge.ts
+++ b/electron/notify/badge.ts
@@ -1,0 +1,367 @@
+// Tray + taskbar unread badge.
+//
+// Maintains a per-sid unread map. On every change recomputes the total and
+// pushes it to the OS:
+//   * macOS / Linux: app.setBadgeCount(n)
+//   * Windows: BrowserWindow.setOverlayIcon for every visible window AND
+//     tray.setImage with the base tray icon composited with the badge.
+//
+// Display rule: 1-9 shows the digit; >=10 shows "9+". 0 clears.
+//
+// Renders nativeImages at runtime (no PNG asset files). The total badge
+// images we ever build is 11 (1..9, 9+, plus the bare base for tray-clear),
+// per scale, so caching is trivial and there's no perf concern.
+
+import { app, BrowserWindow, nativeImage, type NativeImage, type Tray } from 'electron';
+import { tBadge } from '../i18n';
+
+export interface BadgeManagerDeps {
+  getTray: () => Tray | null;
+  getBaseTrayImage: () => NativeImage;
+  getWindows: () => BrowserWindow[];
+}
+
+const TRAY_SIZE = 16;
+const OVERLAY_SIZE = 16;
+
+export class BadgeManager {
+  private unread = new Map<string, number>();
+  private deps: BadgeManagerDeps;
+  private trayCache = new Map<string, NativeImage>();
+  private overlayCache = new Map<string, NativeImage>();
+
+  constructor(deps: BadgeManagerDeps) {
+    this.deps = deps;
+  }
+
+  incrementSid(sid: string): void {
+    if (!sid) return;
+    this.unread.set(sid, (this.unread.get(sid) ?? 0) + 1);
+    this.apply();
+  }
+
+  clearSid(sid: string): void {
+    if (!sid) return;
+    if (!this.unread.has(sid)) return;
+    this.unread.delete(sid);
+    this.apply();
+  }
+
+  clearAll(): void {
+    if (this.unread.size === 0) return;
+    this.unread.clear();
+    this.apply();
+  }
+
+  getTotal(): number {
+    let n = 0;
+    for (const v of this.unread.values()) n += v;
+    return n;
+  }
+
+  reapply(): void {
+    this.apply();
+  }
+
+  private apply(): void {
+    const total = this.getTotal();
+
+    if (process.platform !== 'win32') {
+      try {
+        app.setBadgeCount(total);
+      } catch (err) {
+        console.warn('[badge] setBadgeCount failed', err);
+      }
+      return;
+    }
+
+    // Windows: taskbar overlay + tray composite.
+    const label = badgeLabel(total);
+    const overlay = total > 0 ? this.getOverlay(label) : null;
+    const altText = total > 0 ? tBadge('unreadOverlay', { n: label }) : '';
+    for (const w of this.deps.getWindows()) {
+      if (!w || w.isDestroyed()) continue;
+      try {
+        w.setOverlayIcon(overlay, altText);
+      } catch (err) {
+        console.warn('[badge] setOverlayIcon failed', err);
+      }
+    }
+
+    const tray = this.deps.getTray();
+    if (tray) {
+      try {
+        const trayImg =
+          total > 0 ? this.getTrayComposite(label) : this.deps.getBaseTrayImage();
+        tray.setImage(trayImg);
+      } catch (err) {
+        console.warn('[badge] tray.setImage failed', err);
+      }
+    }
+  }
+
+  private getOverlay(label: string): NativeImage {
+    const cached = this.overlayCache.get(label);
+    if (cached) return cached;
+    const img = renderBadgeImage(label, OVERLAY_SIZE);
+    this.overlayCache.set(label, img);
+    return img;
+  }
+
+  private getTrayComposite(label: string): NativeImage {
+    const cached = this.trayCache.get(label);
+    if (cached) return cached;
+    const base = this.deps.getBaseTrayImage();
+    const img = compositeTrayImage(base, label, TRAY_SIZE);
+    this.trayCache.set(label, img);
+    return img;
+  }
+}
+
+export function badgeLabel(n: number): string {
+  if (n <= 0) return '';
+  if (n >= 10) return '9+';
+  return String(n);
+}
+
+// ---------- Pixel rendering ----------------------------------------------
+
+// 3x5 bitmap font for digits + '+'. Each glyph is 5 rows of 3 columns.
+// 1 = ink, 0 = transparent. '+' is rendered into the same 3x5 cell.
+const GLYPHS: Record<string, number[][]> = {
+  '0': [
+    [1, 1, 1],
+    [1, 0, 1],
+    [1, 0, 1],
+    [1, 0, 1],
+    [1, 1, 1],
+  ],
+  '1': [
+    [0, 1, 0],
+    [1, 1, 0],
+    [0, 1, 0],
+    [0, 1, 0],
+    [1, 1, 1],
+  ],
+  '2': [
+    [1, 1, 1],
+    [0, 0, 1],
+    [1, 1, 1],
+    [1, 0, 0],
+    [1, 1, 1],
+  ],
+  '3': [
+    [1, 1, 1],
+    [0, 0, 1],
+    [0, 1, 1],
+    [0, 0, 1],
+    [1, 1, 1],
+  ],
+  '4': [
+    [1, 0, 1],
+    [1, 0, 1],
+    [1, 1, 1],
+    [0, 0, 1],
+    [0, 0, 1],
+  ],
+  '5': [
+    [1, 1, 1],
+    [1, 0, 0],
+    [1, 1, 1],
+    [0, 0, 1],
+    [1, 1, 1],
+  ],
+  '6': [
+    [1, 1, 1],
+    [1, 0, 0],
+    [1, 1, 1],
+    [1, 0, 1],
+    [1, 1, 1],
+  ],
+  '7': [
+    [1, 1, 1],
+    [0, 0, 1],
+    [0, 1, 0],
+    [0, 1, 0],
+    [0, 1, 0],
+  ],
+  '8': [
+    [1, 1, 1],
+    [1, 0, 1],
+    [1, 1, 1],
+    [1, 0, 1],
+    [1, 1, 1],
+  ],
+  '9': [
+    [1, 1, 1],
+    [1, 0, 1],
+    [1, 1, 1],
+    [0, 0, 1],
+    [1, 1, 1],
+  ],
+  '+': [
+    [0, 0, 0],
+    [0, 1, 0],
+    [1, 1, 1],
+    [0, 1, 0],
+    [0, 0, 0],
+  ],
+};
+
+const GLYPH_W = 3;
+const GLYPH_H = 5;
+
+interface Rgba {
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+}
+
+const RED: Rgba = { r: 0xdc, g: 0x26, b: 0x26, a: 0xff };
+const WHITE: Rgba = { r: 0xff, g: 0xff, b: 0xff, a: 0xff };
+const TRANSPARENT: Rgba = { r: 0, g: 0, b: 0, a: 0 };
+
+// Renders an unread-badge nativeImage at the requested square size.
+// Red filled circle background; white digit(s) centered on top.
+function renderBadgeImage(label: string, size: number): NativeImage {
+  const buf = Buffer.alloc(size * size * 4);
+  fillCircle(buf, size, RED);
+  drawLabel(buf, size, label, WHITE);
+  return nativeImage.createFromBuffer(buf, { width: size, height: size });
+}
+
+// Composites the badge onto the bottom-right corner of the tray base icon.
+function compositeTrayImage(
+  base: NativeImage,
+  label: string,
+  size: number,
+): NativeImage {
+  const baseBuf = base.toBitmap();
+  const baseSize = base.getSize();
+  const buf = Buffer.alloc(size * size * 4);
+
+  // Copy base (resize-fit if base isn't already the target size — simple
+  // nearest-neighbour, since the placeholder base is 16x16 too).
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const sx = Math.floor((x * baseSize.width) / size);
+      const sy = Math.floor((y * baseSize.height) / size);
+      const si = (sy * baseSize.width + sx) * 4;
+      const di = (y * size + x) * 4;
+      // Electron's toBitmap is BGRA on every platform we care about.
+      buf[di + 0] = baseBuf[si + 2];
+      buf[di + 1] = baseBuf[si + 1];
+      buf[di + 2] = baseBuf[si + 0];
+      buf[di + 3] = baseBuf[si + 3];
+    }
+  }
+
+  // Badge takes the bottom-right ~60% of the icon so digits stay readable.
+  const badgeSize = Math.round(size * 0.62);
+  const ox = size - badgeSize;
+  const oy = size - badgeSize;
+  const badge = Buffer.alloc(badgeSize * badgeSize * 4);
+  fillCircle(badge, badgeSize, RED);
+  drawLabel(badge, badgeSize, label, WHITE);
+  blit(buf, size, badge, badgeSize, ox, oy);
+
+  return nativeImage.createFromBuffer(buf, { width: size, height: size });
+}
+
+function fillCircle(buf: Buffer, size: number, color: Rgba): void {
+  const cx = (size - 1) / 2;
+  const cy = (size - 1) / 2;
+  const r = size / 2;
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const dx = x - cx;
+      const dy = y - cy;
+      const d = Math.sqrt(dx * dx + dy * dy);
+      const i = (y * size + x) * 4;
+      if (d <= r - 0.5) {
+        buf[i + 0] = color.r;
+        buf[i + 1] = color.g;
+        buf[i + 2] = color.b;
+        buf[i + 3] = color.a;
+      } else if (d <= r + 0.5) {
+        // Soft 1px edge for anti-alias.
+        const t = Math.max(0, Math.min(1, r + 0.5 - d));
+        buf[i + 0] = color.r;
+        buf[i + 1] = color.g;
+        buf[i + 2] = color.b;
+        buf[i + 3] = Math.round(color.a * t);
+      } else {
+        buf[i + 0] = TRANSPARENT.r;
+        buf[i + 1] = TRANSPARENT.g;
+        buf[i + 2] = TRANSPARENT.b;
+        buf[i + 3] = TRANSPARENT.a;
+      }
+    }
+  }
+}
+
+// Lays out `label` characters horizontally, centered, scaled to fit ~70% of
+// the canvas height. White ink only.
+function drawLabel(buf: Buffer, size: number, label: string, ink: Rgba): void {
+  if (!label) return;
+  const targetH = Math.max(5, Math.floor(size * 0.62));
+  const scale = Math.max(1, Math.floor(targetH / GLYPH_H));
+  const glyphW = GLYPH_W * scale;
+  const glyphH = GLYPH_H * scale;
+  const gap = scale; // 1 scaled pixel between glyphs
+  const totalW = label.length * glyphW + (label.length - 1) * gap;
+  const startX = Math.round((size - totalW) / 2);
+  const startY = Math.round((size - glyphH) / 2);
+  for (let ci = 0; ci < label.length; ci++) {
+    const ch = label[ci];
+    const glyph = GLYPHS[ch];
+    if (!glyph) continue;
+    const gx0 = startX + ci * (glyphW + gap);
+    for (let gy = 0; gy < GLYPH_H; gy++) {
+      for (let gx = 0; gx < GLYPH_W; gx++) {
+        if (!glyph[gy][gx]) continue;
+        for (let sy = 0; sy < scale; sy++) {
+          for (let sx = 0; sx < scale; sx++) {
+            const px = gx0 + gx * scale + sx;
+            const py = startY + gy * scale + sy;
+            if (px < 0 || px >= size || py < 0 || py >= size) continue;
+            const i = (py * size + px) * 4;
+            buf[i + 0] = ink.r;
+            buf[i + 1] = ink.g;
+            buf[i + 2] = ink.b;
+            buf[i + 3] = ink.a;
+          }
+        }
+      }
+    }
+  }
+}
+
+function blit(
+  dst: Buffer,
+  dstSize: number,
+  src: Buffer,
+  srcSize: number,
+  ox: number,
+  oy: number,
+): void {
+  for (let y = 0; y < srcSize; y++) {
+    for (let x = 0; x < srcSize; x++) {
+      const si = (y * srcSize + x) * 4;
+      const sa = src[si + 3];
+      if (sa === 0) continue;
+      const dx = ox + x;
+      const dy = oy + y;
+      if (dx < 0 || dx >= dstSize || dy < 0 || dy >= dstSize) continue;
+      const di = (dy * dstSize + dx) * 4;
+      // Source-over alpha blend.
+      const a = sa / 255;
+      const inv = 1 - a;
+      dst[di + 0] = Math.round(src[si + 0] * a + dst[di + 0] * inv);
+      dst[di + 1] = Math.round(src[si + 1] * a + dst[di + 1] * inv);
+      dst[di + 2] = Math.round(src[si + 2] * a + dst[di + 2] * inv);
+      dst[di + 3] = Math.max(dst[di + 3], sa);
+    }
+  }
+}

--- a/electron/notify/index.ts
+++ b/electron/notify/index.ts
@@ -63,6 +63,11 @@ export interface InstallNotifyBridgeOptions {
   /** Optional injected Notification impl — defaults to Electron's. The
    *  e2e test seam swaps this for an in-memory log. */
   notifyImpl?: NotifyImpl;
+  /** Optional unread-badge sink. When the bridge actually fires a
+   *  notification (i.e. it survived mute / focus / dedupe), the bridge
+   *  bumps unread for that sid. The badge sink owns its own clearing
+   *  via focus / active-sid listeners installed in main. */
+  onNotified?: (sid: string) => void;
 }
 
 const DEDUPE_WINDOW_MS = 5_000;
@@ -170,6 +175,14 @@ export function installNotifyBridge(opts: InstallNotifyBridgeOptions): () => voi
       { sid: evt.sid, state: evt.state, ts: now, title: copy.title, body: copy.body },
       () => focusAndActivate(getMainWindow(), evt.sid),
     );
+
+    if (opts.onNotified) {
+      try {
+        opts.onNotified(evt.sid);
+      } catch (err) {
+        console.warn('[notify] onNotified threw', err);
+      }
+    }
   };
 
   sessionWatcher.on('state-changed', onStateChanged);

--- a/scripts/harness-real-cli.mjs
+++ b/scripts/harness-real-cli.mjs
@@ -499,6 +499,54 @@ async function caseNotifyFiresOnIdle({ electronApp, win, tempDir }) {
     throw new Error(`unexpected notify state=${entry.state}`);
   }
   console.log(`[HARNESS]   notify fired: state=${entry.state} title="${entry.title}" body="${entry.body}"`);
+
+  // -- Tray + taskbar badge unread count (#572) ------------------------
+  // The notify bridge bumps BadgeManager.incrementSid(sid) ONLY when the
+  // notification actually fired (mute/focus/dedupe survived). We just
+  // observed the fire above, so total must be >= 1 and include our sid.
+  // On mac/linux app.getBadgeCount() is the source of truth; on win32 we
+  // assert via the BadgeManager debug seam since setOverlayIcon state
+  // can't be probed back out.
+  const totalAfterFire = await electronApp.evaluate(({ app }) => {
+    const dbg = globalThis.__ccsmBadgeDebug;
+    return {
+      app: app.getBadgeCount?.() ?? 0,
+      mgr: dbg?.getTotal ? dbg.getTotal() : null,
+    };
+  });
+  const observed = process.platform === 'win32' ? totalAfterFire.mgr : totalAfterFire.app;
+  if (observed === null || observed === undefined) {
+    throw new Error(`badge total unreadable. Diag: ${JSON.stringify(totalAfterFire)}`);
+  }
+  if (observed < 1) {
+    throw new Error(
+      `badge total expected >=1 after notify fire, got ${observed}. Diag: ${JSON.stringify(totalAfterFire)}`,
+    );
+  }
+  console.log(`[HARNESS]   badge total after fire: ${observed} (platform=${process.platform})`);
+
+  // Re-focus + re-set active sid → BadgeManager.clearSid(sid) → total back to 0.
+  await win.evaluate((s) => {
+    const bridge = window.ccsmSession;
+    if (bridge && typeof bridge.setActive === 'function') bridge.setActive(s);
+  }, sid);
+  // The window already has focus (Playwright keeps it focused); the
+  // session:setActive IPC arriving in main triggers clearBadgeForActiveIfFocused.
+  await sleep(300);
+  const totalAfterClear = await electronApp.evaluate(({ app }) => {
+    const dbg = globalThis.__ccsmBadgeDebug;
+    return {
+      app: app.getBadgeCount?.() ?? 0,
+      mgr: dbg?.getTotal ? dbg.getTotal() : null,
+    };
+  });
+  const cleared = process.platform === 'win32' ? totalAfterClear.mgr : totalAfterClear.app;
+  if (cleared !== 0) {
+    throw new Error(
+      `badge total expected 0 after re-focus, got ${cleared}. Diag: ${JSON.stringify(totalAfterClear)}`,
+    );
+  }
+  console.log(`[HARNESS]   badge total after clear: ${cleared}`);
 }
 
 // ============================================================================


### PR DESCRIPTION
Closes #572.

## Plan (locked)

Hook the existing notify bridge (PR-B #486). Maintain a per-sid unread map; bump on each fire that survives mute / focus / dedupe; clear when window is focused AND the active sid matches that sid (symmetric with the bridge's own focus-suppression).

- Display: 1-9 shows the digit, >=10 shows `9+`, 0 clears.
- macOS / Linux: `app.setBadgeCount(total)`.
- Windows: `BrowserWindow.setOverlayIcon(img, alt)` on every window + `tray.setImage` composited onto the existing tray base icon.
- Tray menu unchanged. Tray single-click unchanged.

## Implementation notes

- New `electron/notify/badge.ts` exports `BadgeManager` with `incrementSid` / `clearSid` / `clearAll` / `getTotal` / `reapply`.
- Badge images are rendered at runtime: a red (#dc2626) anti-aliased disc with white digits drawn from a 3x5 bitmap font, scaled to fit. Cached per label+scale, so the entire image set the app ever produces is ~11 nativeImages per surface.
- Skipped pre-shipped PNG assets to avoid pulling in `sharp` / `node-canvas` for one icon set. Functionally identical to a precomputed PNG (same `NativeImage` flowing into `setOverlayIcon` / `tray.setImage`); deviates from the original "PNGs in `assets/badge/`" plan but keeps the dep graph clean and avoids a build step.
- Windows tray image composites the badge into the bottom-right ~62% of the existing tray base icon.
- `onNotified` hook on `installNotifyBridge` is the single bump site. Wired in `electron/main.ts` after `notifyImpl.show()`. Cleared via `win.on('focus')` and the existing `session:setActive` IPC handler.
- New i18n key `tBadge('unreadOverlay', { n })` for the Windows overlay-icon alt text (en + zh).

## E2E

Extended `notify-fires-on-idle` in `scripts/harness-real-cli.mjs`: after the notify fire is observed, asserts `getBadgeCount` (mac/linux) or `__ccsmBadgeDebug.getTotal()` (win32) is >= 1; then re-sets the active sid via `window.ccsmSession.setActive(sid)` and asserts the total drops to 0.

Existing `harness-real-cli` notify case is shared, so this extension absorbs the new coverage instead of adding a new probe (per `feedback_e2e_prefer_harness`).

```
[OK] harness-real-cli  passed  225763ms  exit=0
```

## Reverse-verify

Replaced `onNotified: (sid) => badgeManager?.incrementSid(sid)` with a no-op stub, rebuilt, re-ran the probe:

```
[HARNESS] <<< FAIL notify-fires-on-idle (18515ms): badge total expected >=1 after notify fire, got 0. Diag: {"app":0,"mgr":0}
```

Restored the wire-up; probe green again.

## Out of scope (per locked plan)

- Tray right-click menu unread session list.
- Tray click auto-switching to an unread session.
- Pre-shipped PNG assets / `assets/badge/` directory.

Refs task #572.