### PR TITLE
test(e2e): consolidate readXtermLines error handling at inner site (#579)

### DIFF
--- a/scripts/harness-real-cli.mjs
+++ b/scripts/harness-real-cli.mjs
@@ -585,12 +585,10 @@ async function caseSwitchSessionKeepsChat({ electronApp, win, tempDir }) {
     try {
       await waitForXtermBuffer(win, /ALPHA/, { timeout: 15000 });
     } catch (_) { /* fall through */ }
-    // Surface real errors instead of swallowing to []: a swallowed evaluate
-    // failure here would fire the generic "scrollback lost ALPHA" assertion
-    // and hide the actual buffer state (see #490 / #574 flake repro).
-    const aLines = await readXtermLines(win, { lines: 200 }).catch((err) => {
-      throw new Error(`readXtermLines failed after switch-back to sid=${sidA}: ${err && err.stack || err}`);
-    });
+    // readXtermLines (since #579) re-throws unexpected evaluate failures
+    // with context at the inner site, so a generic "scrollback lost ALPHA"
+    // assertion no longer hides the real buffer state (see #490 / #574).
+    const aLines = await readXtermLines(win, { lines: 200 });
     if (!/ALPHA/.test(aLines.join('\n'))) {
       throw new Error(`A's scrollback lost ALPHA after switch-back. lines=${aLines.length}`);
     }
@@ -1263,11 +1261,10 @@ async function casePtyPidStableAcrossSwitch({ electronApp, win, tempDir }) {
   await waitForActiveXtermBuffer(win, sidA, { minLines: 1, timeout: 5000 });
 
   // Assert MARKER is STILL in the active buffer — no replay = same pty.
-  // Surface real errors instead of swallowing to []: the prior flake hid
-  // the actual buffer state behind a generic "MARKER not found".
-  const lines = await readXtermLines(win, { lines: 200 }).catch((err) => {
-    throw new Error(`readXtermLines failed after switch-back to sid=${sidA}: ${err && err.stack || err}`);
-  });
+  // readXtermLines (since #579) re-throws unexpected evaluate failures
+  // with context at the inner site, so the prior "MARKER not found" flake
+  // can no longer hide a real driver error.
+  const lines = await readXtermLines(win, { lines: 200 });
   const joined = lines.join('\n');
   if (!new RegExp(MARKER).test(joined)) {
     throw new Error(

--- a/scripts/probe-utils-real-cli.mjs
+++ b/scripts/probe-utils-real-cli.mjs
@@ -117,8 +117,18 @@ export async function waitForTerminalReady(win, sid, { timeout = 10000 } = {}) {
  * cursor row. Returns an array of strings (one per row, top-to-bottom).
  * Empty rows are preserved so callers can see the cursor row context.
  *
- * If `window.__ccsmTerm` is unavailable, returns an empty array (safe for
- * polling loops).
+ * If `window.__ccsmTerm` is unavailable, the inner evaluate resolves to []
+ * (safe for polling loops).
+ *
+ * Error semantics (single source of truth — see #579):
+ * - Transient evaluate failures (page closed / context destroyed / target
+ *   closed mid-navigation) are absorbed and resolve to []. Polling loops
+ *   can keep polling.
+ * - Anything else (real driver / bridge / unexpected exception) is
+ *   re-thrown with a wrapped message + original stack so callers see the
+ *   actual root cause instead of a generic "buffer empty" assertion.
+ *   This was the #569 / #574 flake's actual root cause: the inner site
+ *   silently returned [] and the assertion blamed the wrong layer.
  */
 export async function readXtermLines(win, { lines = 30 } = {}) {
   const out = await win
@@ -138,7 +148,13 @@ export async function readXtermLines(win, { lines = 30 } = {}) {
       },
       { n: lines },
     )
-    .catch(() => []);
+    .catch((err) => {
+      // Page closed / context destroyed / evaluate timeout = transient,
+      // polling-friendly. Match Playwright/Electron driver phrasings.
+      if (/Target closed|Execution context|page has been closed|context.*was destroyed/i.test(String(err))) return [];
+      // Anything else is unexpected — surface real error with context.
+      throw new Error(`readXtermLines.evaluate failed: ${err?.stack || err?.message || err}`);
+    });
   return out;
 }
 


### PR DESCRIPTION
## Architectural finding (from PR #492 reviewer)

`scripts/probe-utils-real-cli.mjs:141` swallowed ALL evaluate errors with `.catch(() => [])`. Consequences:

1. The 7 outer `.catch(() => [])` defensive sites in `scripts/harness-real-cli.mjs` were dead code on the happy path -- inner already absorbed everything.
2. The 2 outer rethrows added in PR #490 (`harness-real-cli.mjs:1268`) and PR #492 (`harness-real-cli.mjs:591`) provably never fired on normal runs -- reverse-verify in #577 review confirmed: stash the rethrow then run -> still PASS.
3. The original #569 / #574 flake's actual root cause was the inner `evaluate` returning `[]` when `__ccsmTerm` was momentarily unattached. The outer rethrows could not catch this because `readXtermLines` resolved to `[]`, it did not reject.

This PR moves the discrimination to the single canonical site (the inner catch) so the assertion failure mode reflects the real layer.

## Inner-site change (`scripts/probe-utils-real-cli.mjs`)

Replace the blanket `.catch(() => [])` with a discriminating handler:

```js
.catch((err) => {
  // Page closed / context destroyed / evaluate timeout = transient,
  // polling-friendly. Match Playwright/Electron driver phrasings.
  if (/Target closed|Execution context|page has been closed|context.*was destroyed/i.test(String(err))) return [];
  // Anything else is unexpected -- surface real error with context.
  throw new Error(`readXtermLines.evaluate failed: ${err?.stack || err?.message || err}`);
});
```

Regex rationale: these four phrasings cover the real transient cases observed when Electron tears down a webContents / Playwright closes the target while a long evaluate is in flight. Every other `Error` instance the renderer can produce (TypeError from xterm internals, RangeError, custom thrown strings) is genuinely unexpected and the test should see it. Docstring updated to spell out the new contract as the single source of truth.

## Outer-site decision

**REMOVE** the 2 redundant outer rethrows (`harness-real-cli.mjs` lines 591, 1268). Inner site is now the source of truth; outer rethrows just duplicate the message with strictly less context.

**KEEP** the 6 polling-loop `.catch(() => [])` sites (lines 246, 542, 576, 664, 704, 1365). Reasoning:
- Polling loops want `[]` as "not ready, retry" regardless of which layer produces it.
- Inner site already produces `[]` for the documented transient cases, so behavior is unchanged today.
- The outer catch is a belt: if a future inner change ever throws a new non-transient error class, polling-loop callers (which can't act on it anyway) keep retrying instead of cascading a useless rejection.

This is a clean architectural separation: assertion-style callers get loud failures via the inner rethrow; polling-style callers stay quiet via the outer absorb.

## Reverse-verify (synthetic evaluate error)

Injected `if (n === 200) throw new Error('synthetic-579-evaluate-error')` into the inner evaluate body (only fires on the `lines: 200` reads, so polling at `lines: 12 / 30 / 60` still settles).

| State | Result |
| --- | --- |
| With fix | `readXtermLines.evaluate failed: page.evaluate: Error: synthetic-579-evaluate-error` + full stack at `harness-real-cli.mjs:1267:23` -- root cause visible. |
| Without fix (revert inner catch to `() => []`) | `MARKER MARKER_... not found in A's scrollback after switch-back. Tail:` -- generic, blames wrong layer. Exact pattern of the original #569 / #574 flake. |

Synthetic reverted; commit contains only the production fix.

## Full harness pass log

`node scripts/harness-real-cli.mjs` (no `--only`, full suite):

```
PASS  new-session-chat                   21576ms
PASS  session-state-becomes-idle         19504ms
PASS  notify-fires-on-idle               18458ms
PASS  switch-session-keeps-chat          29503ms
PASS  cwd-projects-claude                17523ms
PASS  import-resume                      4048ms
PASS  default-cwd-from-userCwds-lru      71ms
PASS  new-session-focus-cli              16331ms
PASS  pty-pid-stable-across-switch       13673ms
PASS  cwd-picker-top-default             784ms
PASS  cwd-picker-top-chevron             1026ms
PASS  cwd-picker-group                   828ms
PASS  cwd-picker-no-shortcut             493ms
PASS  cwd-picker-only-one-open           520ms
PASS  reopen-resume                      58547ms
PASS  pty-subtree-killed-on-quit         15173ms
total: 16/16 passed, 232.1s wall
```

Both rethrow-removal sites (`switch-session-keeps-chat`, `pty-pid-stable-across-switch`) green.

## Files

- `scripts/probe-utils-real-cli.mjs` (+18 -4): inner-site discriminating catch + docstring.
- `scripts/harness-real-cli.mjs` (+9 -10): drop 2 redundant outer rethrows; comments updated to point to #579.