### PR TITLE
fix(test): repair pre-existing test failures gating dogfood baseline (#578)

### DIFF
--- a/scripts/harness-ui.mjs
+++ b/scripts/harness-ui.mjs
@@ -892,7 +892,21 @@ async function caseTitlebar({ app, win, log }) {
 
 // ---------- tray ----------
 // Closing the window hides it (does NOT quit) on win32/linux; show() restores.
+//
+// Post-#561 (close-to-tray ask/tray/quit dialog): the win32 default for
+// `closeAction` is `'ask'`, which surfaces a modal dialog instead of
+// hiding. The probe asserts the hide-on-close branch specifically, so we
+// pin `closeAction='tray'` via the same `db:save` IPC the Settings dialog
+// uses before triggering close. We restore the prior value in dispose so
+// later cases (and the persisted user preference, if running outside the
+// harness) aren't perturbed.
 async function caseTray({ app, win, log, registerDispose }) {
+  const prevCloseAction = await win.evaluate(async () => {
+    return await window.ccsm.loadState('closeAction');
+  });
+  await win.evaluate(async () => {
+    await window.ccsm.saveState('closeAction', 'tray');
+  });
   // Belt-and-suspenders: ensure the window is visible after we're done so
   // subsequent cases can interact with it (the harness window is shared).
   registerDispose(async () => {
@@ -900,6 +914,16 @@ async function caseTray({ app, win, log, registerDispose }) {
       const w = BrowserWindow.getAllWindows().find((x) => !x.webContents.getURL().startsWith('devtools://'));
       try { w?.show(); } catch {}
     });
+    try {
+      await win.evaluate(async (prev) => {
+        if (prev == null) {
+          // No way to delete via the IPC; leave 'tray' (matches mac default
+          // and was the pre-#561 implicit behaviour).
+          return;
+        }
+        await window.ccsm.saveState('closeAction', prev);
+      }, prevCloseAction);
+    } catch {}
   });
 
   await app.evaluate(({ BrowserWindow }) => {
@@ -1903,17 +1927,26 @@ async function caseStartupPaintsBeforeHydrate({ win, log }) {
 async function caseTerminalPaneMounted({ win, log }) {
   // Seed a real session so App's `active` resolves and the right-pane
   // branch runs. tutorialSeen=true skips the tutorial overlay.
-  await win.evaluate(() => {
+  //
+  // The cwd MUST be a real existing directory: TerminalPane's attach
+  // effect calls `pty.spawn(sid, cwd)` which routes to node-pty, which
+  // throws synchronously if cwd doesn't exist. Without a valid cwd the
+  // pty bridge wires up (`window.ccsmPty.list` is callable) but no pty
+  // entry ever lands, which is exactly the failure mode the assertion
+  // below was reporting. Use the harness process cwd (the repo root) —
+  // always present, no privilege issues.
+  const probeCwd = process.cwd().replace(/\\/g, '/');
+  await win.evaluate((cwd) => {
     window.__ccsmStore.setState({
       groups: [{ id: 'g1', name: 'G1', collapsed: false, kind: 'normal' }],
       sessions: [
-        { id: 's-term', name: 'terminal-probe', state: 'idle', cwd: 'C:/x', model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code' },
+        { id: 's-term', name: 'terminal-probe', state: 'idle', cwd, model: 'claude-opus-4', groupId: 'g1', agentType: 'claude-code' },
       ],
       activeId: 's-term',
       messagesBySession: { 's-term': [] },
       tutorialSeen: true,
     });
-  });
+  }, probeCwd);
 
   // Wait for App to resolve the boot-time claudeAvailable check —
   // either the guide or the terminal host (or its loading shell) shows up.


### PR DESCRIPTION
## Summary

Investigated the 3 "pre-existing failures" reported by the #493 reviewer that block the #575 e2e baseline. Result: only **1 real test bug**; the other 2 are non-issues. Net change: 39 LOC, test-only.

## Per-bug findings

### Bug 1: harness-ui `tray` (TEST hardening, not a real failure)

- **Root cause**: post-#561 the win32 default `closeAction` is `'ask'`, which surfaces a modal dialog instead of hide-on-close. The probe asserts the hide branch unconditionally.
- **Investigation**: ran the case 5x in isolation against HEAD with no fix - **all 5 PASSED**. Cannot reproduce the reported failure. Likely a one-off cold-launch flake (dialog vs 600ms wait race).
- **Fix anyway**: pin `closeAction='tray'` via the existing `db:save` IPC before triggering close, restore prior value in dispose. ~16 LOC, eliminates the latent flake mode.
- **Layer**: TEST.

### Bug 2: harness-ui `terminal-pane-mounted` (TEST fix, real bug)

- **Root cause**: probe seeded session with `cwd: 'C:/x'` (non-existent). `TerminalPane`'s attach effect calls `pty.spawn(sid, cwd)` -> node-pty throws synchronously when cwd doesn't exist. Bridge wires up but no pty entry lands.
- **Fix**: use `process.cwd()` (harness process - repo root, always exists). ~3 LOC.
- **Reverse-verify**: 3/3 FAIL stashed, 1/1 PASS with fix.
- **Layer**: TEST.

### "Bug 3": db-hardening 3/7 fail (NOT A BUG, environment-only)

- **Root cause**: better-sqlite3 rebuilt for Electron NODE_MODULE_VERSION 130 (electron-builder postinstall), vitest runs under raw Node 24 (NODE_MODULE_VERSION 137). The 3 failing tests are exactly the ones opening a `Database`.
- **Verification**: ran `npm rebuild better-sqlite3` -> 7/7 PASS.
- **CI is green throughout**: `.github/workflows/ci.yml` has a `Rebuild better-sqlite3 for Node` step right before `npm test`. The reviewer's local env was missing this rebuild.
- **No code change needed**.

## Test plan

- [x] `node scripts/harness-ui.mjs --only=tray` -> PASS
- [x] `node scripts/harness-ui.mjs --only=terminal-pane-mounted` -> PASS
- [x] `npm rebuild better-sqlite3 && npx vitest run electron/__tests__/db-hardening.test.ts` -> 7/7 PASS
- [x] `node scripts/harness-real-cli.mjs --only=new-session-chat` -> PASS (sanity)
- [x] Reverse-verify both harness-ui fixes (stash -> case 2 fails 3/3; case 1 still passes - flake confirmed not consistently reproducible)

## Notes for reviewer

- Test-only diff in `scripts/harness-ui.mjs`. No production code touched.
- If you want to reproduce bug 3 locally on Node >= 22, you'll need to first run `npx @electron/rebuild -f -o better-sqlite3 --build-from-source` to flip the binding back to the Electron ABI. Otherwise vitest will pass and main process won't start. CI uses Node 20 + the rebuild step so neither environment is broken there.
- For #575 baseline: all 3 reported failures are now resolved (1 fixed, 1 hardened, 1 was never broken). Baseline can proceed.