### PR TITLE
test(e2e): remove redundant outer .catch swallows from 6 polling sites (#580)

### DIFF
--- a/scripts/harness-real-cli.mjs
+++ b/scripts/harness-real-cli.mjs
@@ -243,7 +243,7 @@ async function caseNewSessionChat({ electronApp, win, tempDir }) {
   let lastLines = [];
   while (Date.now() - start < 90_000) {
     await sleep(2000);
-    lastLines = await readXtermLines(win, { lines: 60 }).catch(() => []);
+    lastLines = await readXtermLines(win, { lines: 60 });
     if (!lastLines.length) continue;
     const joined = lastLines.join('\n');
     const idx = joined.lastIndexOf(CHAT_PROMPT);
@@ -587,7 +587,7 @@ async function caseSwitchSessionKeepsChat({ electronApp, win, tempDir }) {
 
     // Advance any first-run prompts.
     for (let i = 0; i < 6; i++) {
-      const lines = await readXtermLines(win, { lines: 30 }).catch(() => []);
+      const lines = await readXtermLines(win, { lines: 30 });
       const tail = lines.join('\n');
       if (/│\s*>/m.test(tail) || /^\s*>\s/m.test(tail)) break;
       await sendToClaudeTui(win, '\r');
@@ -621,7 +621,7 @@ async function caseSwitchSessionKeepsChat({ electronApp, win, tempDir }) {
 
     // Re-dismiss trust/splash on the rebound terminal.
     for (let i = 0; i < 6; i++) {
-      const lines = await readXtermLines(win, { lines: 30 }).catch(() => []);
+      const lines = await readXtermLines(win, { lines: 30 });
       const tail = lines.join('\n');
       if (/│\s*>/m.test(tail) || /^\s*>\s/m.test(tail)) break;
       await sendToClaudeTui(win, '\r');
@@ -709,7 +709,7 @@ async function sendAndAwaitReply(win, prompt, replyToken, { timeout = 90000 } = 
   let lastTail = '';
   while (Date.now() < deadline) {
     await sleep(2000);
-    const lines = await readXtermLines(win, { lines: 200 }).catch(() => []);
+    const lines = await readXtermLines(win, { lines: 200 });
     const full = lines.join('\n');
     lastTail = full.slice(-800);
     const after = full.split(prompt).slice(1).join(prompt);
@@ -749,7 +749,7 @@ async function caseCwdProjectsClaude({ electronApp, win, tempDir }) {
   await sendToClaudeTui(win, PROMPT);
   await sleep(800);
   {
-    const tailLines = await readXtermLines(win, { lines: 12 }).catch(() => []);
+    const tailLines = await readXtermLines(win, { lines: 12 });
     if (!tailLines.some((l) => l.includes(MARKER_TOKEN.slice(0, 8)))) {
       await sleep(1000);
       await sendToClaudeTui(win, PROMPT);
@@ -1410,7 +1410,7 @@ async function caseReopenResume() {
     const start = Date.now();
     while (Date.now() - start < 90000) {
       await sleep(2000);
-      const lines = await readXtermLines(win2, { lines: 200 }).catch(() => []);
+      const lines = await readXtermLines(win2, { lines: 200 });
       const full = lines.join('\n');
       lastTail = full.slice(-1200);
       const parts = full.split(PROMPT_2);


### PR DESCRIPTION
## Context
PR #494 (merged 353bc06) consolidated `readXtermLines` transient-vs-real error handling at the inner site (`scripts/probe-utils-real-cli.mjs:151-157`):

```js
.catch((err) => {
  if (/Target closed|Execution context|page has been closed|context.*was destroyed/i.test(String(err))) return [];
  throw new Error(`readXtermLines.evaluate failed: ${err?.stack || err?.message || err}`);
});
```

PR #494 reviewer flagged that 6 outer `.catch(() => [])` sites in `scripts/harness-real-cli.mjs` still silently swallow whatever the inner gatekeeper rethrows — recreating the original #569/#574 misattribution pattern (real error inside polling loop becomes generic "timed out waiting for X").

## Decision: option 2 (remove all 6 outer catches)
Inner is the single gatekeeper:
- Transient driver errors -> `[]` (polling-friendly, unchanged behavior).
- Real errors -> rethrow with stack (now actually visible).

No site needed option 1 (discriminating outer catch); inner already classifies.

## Per-site changes (all `scripts/harness-real-cli.mjs`)
| Line | Case | Loop type | Change |
|------|------|-----------|--------|
| 246  | `caseNewSessionChat` | `while (Date.now()-start < 90_000)` | drop `.catch(() => [])` |
| 590  | `caseSwitchSessionKeepsChat` (first-run dismiss) | `for i<6` | drop `.catch(() => [])` |
| 624  | `caseSwitchSessionKeepsChat` (rebound dismiss) | `for i<6` | drop `.catch(() => [])` |
| 712  | `sendAndAwaitReply` (used by `caseSwitchSessionKeepsChat`) | `while (Date.now() < deadline)` | drop `.catch(() => [])` |
| 752  | `caseCwdProjectsClaude` | single-shot defensive marker check | drop `.catch(() => [])` |
| 1413 | `caseReopenResume` | `while (Date.now()-start < 90_000)` | drop `.catch(() => [])` |

## Affected-cases harness pass
```
PASS  new-session-chat                   21623ms
PASS  switch-session-keeps-chat          31240ms
PASS  cwd-projects-claude                17451ms
PASS  reopen-resume                      54475ms
total: 4/4 passed, 132.7s wall
```
(All 6 modified lines exercised; per `feedback_local_e2e_only.md` only affected cases run, full baseline lives on the dedicated node.)

## Reverse-verify (architectural)
Injected synthetic non-transient throw at `readXtermLines` (probe-utils-real-cli.mjs):
```js
if (process.env.SYNTHETIC_580) {
  throw new Error('synthetic-580-test: non-transient error in readXtermLines');
}
```

**With this PR (no outer catch on line 246):**
```
FAIL  new-session-chat  19607ms : synthetic-580-test: non-transient error in readXtermLines
```
Error surfaces in 19s with exact origin pinned.

**Without this PR (outer catch restored on line 246):**
```
FAIL  new-session-chat  107773ms : claude did not reply within 90s. Tail:
```
Polling burns full 90s timeout, then reports generic misattribution — exactly the pattern #494 reviewer warned about.

Synthetic throw + restored outer catch were both reverted before commit; only the 6-line removal landed.

## Diff stat
```
 scripts/harness-real-cli.mjs | 12 ++++++------
 1 file changed, 6 insertions(+), 6 deletions(-)
```

Closes #580.