### PR TITLE
fix(build): skip electron-builder npmRebuild (node-pty fallback already handled by postinstall) (#582)

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "appId": "com.ccsm.app",
     "productName": "CCSM",
     "copyright": "Copyright (c) 2026 Jiahui Gu",
+    "npmRebuild": false,
     "asar": true,
     "asarUnpack": [
       "**/node_modules/better-sqlite3/**",


### PR DESCRIPTION
## Bug

`npm run make:win` fails on first invocation from a clean state. electron-builder's built-in `install-app-deps` re-runs @electron/rebuild on every native module, hitting the well-known node-pty/winpty `GetCommitHash.bat` git-bash PATH error and aborting the build. Build worker for #581 worked around it with an ad-hoc `-c.npmRebuild=false` override.

Original failure (reproduced via reverse-verify, see below):

```
  • preparing       moduleName=node-pty arch=x64
'GetCommitHash.bat' is not recognized as an internal or external command,
operable program or batch file.
gyp: Call to 'cmd /c "cd shared && GetCommitHash.bat"' returned exit status 1 while in deps\winpty\src\winpty.gyp.
Error: `gyp` failed with exit code: 1
  ⨯ node-gyp failed to rebuild '...\node_modules\node-pty'
```

## Why postinstall.mjs is the right rebuild path

`scripts/postinstall.mjs` already implements the canonical rebuild flow:

1. Rebuild `better-sqlite3` via `@electron/rebuild` — failure is fatal (DB unusable at runtime).
2. Attempt to rebuild `node-pty` — failure is logged but **non-fatal**. node-pty 1.x ships a prebuilt `prebuilds/win32-x64/pty.node` that the runtime falls back to. The winpty `GetCommitHash.bat` failure is benign for that exact reason.
3. `scripts/after-pack.cjs` asserts ONE of the two binding paths exists in the packaged app; missing both is a hard build failure.

postinstall.mjs even contains a comment explicitly explaining why it does **not** use `electron-builder install-app-deps`: "it aborts the full rebuild on the first native module that fails — that turns the recoverable node-pty/winpty case into a hard failure." That same logic applies to electron-builder's own internal call during `make:win`.

## Fix (Option A)

Add `"npmRebuild": false` to the `build` block in `package.json`. This applies to every electron-builder invocation (`make` / `make:win` / `make:mac` / `make:linux`), so postinstall.mjs remains the single rebuild trigger across all platforms. Cleaner than per-script `-c.npmRebuild=false` flags (Option B) — no script duplication, no risk of forgetting on a new make script.

## Build success log (full make:win, clean state)

```
  • electron-builder  version=25.1.8 os=10.0.26200
  • loaded configuration  file=package.json ("build" field)
  • skipped dependencies rebuild  reason=npmRebuild is set to false
  • packaging       platform=win32 arch=x64 electron=33.4.11 appOutDir=release\win-unpacked
[after-pack] OK win32-x64: node-pty prebuilt binding present (296 KB) at .../prebuilds/win32-x64/pty.node
  • building        target=nsis file=release\CCSM-Setup-0.1.0-x64.exe archs=x64 oneClick=false perMachine=false
  • building block map  blockMapFile=release\CCSM-Setup-0.1.0-x64.exe.blockmap
```

- Wall time: **85 s**
- Installer: `release/CCSM-Setup-0.1.0-x64.exe`, **155,135,903 B (~148 MB)** — over the 100 MB threshold.
- after-pack hook ran and asserted the node-pty prebuilt binding.

## Reverse-verify

Stashed the fix, removed `release/ out/ dist/`, re-ran `npm run make:win` — failed in 30 s with the original `GetCommitHash.bat` / `node-gyp failed to rebuild '...\node_modules\node-pty'` error. Restored the fix, re-ran from clean state, succeeded again (the 85 s log above). Confirms the one-line change is both necessary and sufficient.

## Diff stat

```
 package.json | 1 +
 1 file changed, 1 insertion(+)
```

Single line: `"npmRebuild": false,` added to the `build` block.