### PR TITLE
test(e2e): clean sibling .catch swallows in probe-utils dismissFirstRunModals (#583)

### DIFF
--- a/scripts/probe-utils-real-cli.mjs
+++ b/scripts/probe-utils-real-cli.mjs
@@ -575,8 +575,10 @@ export async function dismissWelcomeSplash(
  *     card was dismissed.
  *
  * Returns once the input prompt regex matches, or after the iteration
- * budget is exhausted. Never throws — caller can verify ready state via
- * the next `readXtermLines` / `waitForXtermBuffer` call.
+ * budget is exhausted. Transient buffer-read errors (page closed / context
+ * destroyed) are swallowed by `readXtermLines` itself; real evaluation
+ * failures propagate so the calling case fails fast instead of looping
+ * blind.
  */
 export async function dismissFirstRunModals(win, opts = {}) {
   const {
@@ -589,7 +591,7 @@ export async function dismissFirstRunModals(win, opts = {}) {
 
   // Phase 1: trust + generic splash advance.
   for (let i = 0; i < maxIters; i++) {
-    const lines = await readXtermLines(win, { lines: 30 }).catch(() => []);
+    const lines = await readXtermLines(win, { lines: 30 });
     const screen = lines.join('\n');
     if (promptRe.test(screen)) return;
     if (trustRe.test(screen)) {
@@ -605,7 +607,7 @@ export async function dismissFirstRunModals(win, opts = {}) {
 
   // Phase 3: final settle.
   for (let i = 0; i < 4; i++) {
-    const lines = await readXtermLines(win, { lines: 12 }).catch(() => []);
+    const lines = await readXtermLines(win, { lines: 12 });
     const screen = lines.join('\n');
     if (promptRe.test(screen)) return;
     await sendToClaudeTui(win, '\r').catch(() => {});


### PR DESCRIPTION
## Context

Follow-up to PR #496 (#580). Reviewer flagged 2 remaining `.catch(() => [])` sibling swallows inside `dismissFirstRunModals` polling loops at `scripts/probe-utils-real-cli.mjs:592, 608` — same pattern as the 6 sites cleaned in #496, less risky (~7s timeout vs 90s) but worth scrubbing for consistency.

## Per-site change

| Site | Before | After |
| --- | --- | --- |
| `probe-utils-real-cli.mjs:592` (phase 1 trust loop) | `await readXtermLines(win, { lines: 30 }).catch(() => [])` | `await readXtermLines(win, { lines: 30 })` |
| `probe-utils-real-cli.mjs:608` (phase 3 final-settle loop) | `await readXtermLines(win, { lines: 12 }).catch(() => [])` | `await readXtermLines(win, { lines: 12 })` |
| `dismissFirstRunModals` JSDoc | "Never throws" | Transient buffer-read errors swallowed by `readXtermLines` itself (PR #494 discriminator); real evaluation failures propagate |

## Why safe

`readXtermLines` already has an inner discriminating catch (PR #494) that returns `[]` for `Target closed | Execution context | page has been closed | context.*was destroyed` and rethrows everything else. The outer `.catch(() => [])` only ever masked real evaluation failures — exactly what we want surfaced.

Sibling `.catch(() => {})` on `sendToClaudeTui` and `dismissWelcomeSplash` are intentional (best-effort dismiss) and untouched.

## Affected cases (all PASS post-fix)

```
new-session-chat                    21545ms
switch-session-keeps-chat           29213ms
new-session-focus-cli               16166ms
pty-pid-stable-across-switch        13650ms
```

(Other call sites: `session-state-becomes-idle`, `notify-fires-on-idle`, `reopen-resume` — same `dismissFirstRunModals` path, behaviorally equivalent.)

## Reverse-verify

Picked the L592 (phase 1) site. Injected `throw new Error('SYNTHETIC reverse-verify error')` in place of the `readXtermLines` call.

- **without `.catch(() => [])`** (post-fix shape): `FAIL new-session-chat 4131ms — SYNTHETIC reverse-verify error` — error propagates cleanly with stack pointing at the dismiss site.
- **with `.catch(() => [])` restored** (pre-fix shape): `PASS new-session-chat 21493ms` — error fully masked, case completes via phases 2+3 with no signal that the trust loop was broken. **This is the silent-failure mode the swallow enabled.**

Restored real call after verification.

## Diff stat

`1 file changed, 6 insertions(+), 4 deletions(-)` (4 of those are the JSDoc rewrite; code change is +2 -2).