### PR TITLE
feat(electron): add main-process SDK title bridge (#588)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -70,6 +70,11 @@ import { registerPtyHostIpc, killAllPtySessions } from './ptyHost';
 import { sessionWatcher } from './sessionWatcher';
 import { installNotifyBridge } from './notify';
 import { BadgeManager } from './notify/badge';
+import {
+  getSessionTitle,
+  renameSessionTitle,
+  listProjectSummaries,
+} from './sessionTitles';
 
 // ─────────────────────── IPC security helpers ────────────────────────────
 //
@@ -821,6 +826,23 @@ app.whenReady().then(() => {
     return res.models;
   });
   ipcMain.handle('app:getVersion', () => app.getVersion());
+
+  // ─────────────────────── sessionTitles bridge ──────────────────────────
+  // Thin wrapper around the SDK's getSessionInfo / renameSession /
+  // listSessions, with per-sid serialization, 2s TTL cache, and error
+  // normalization living in `./sessionTitles`. Renderer accesses via
+  // `window.ccsmSessionTitles.{get,rename,listForProject}`.
+  ipcMain.handle('sessionTitles:get', (_e, sid: string, dir?: string) =>
+    getSessionTitle(sid, dir)
+  );
+  ipcMain.handle(
+    'sessionTitles:rename',
+    (_e, sid: string, title: string, dir?: string) =>
+      renameSessionTitle(sid, title, dir)
+  );
+  ipcMain.handle('sessionTitles:listForProject', (_e, projectKey: string) =>
+    listProjectSummaries(projectKey)
+  );
 
   ipcMain.handle('window:minimize', (e) => {
     BrowserWindow.fromWebContents(e.sender)?.minimize();

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -304,3 +304,46 @@ const ccsmSession = {
 contextBridge.exposeInMainWorld('ccsmSession', ccsmSession);
 
 export type CCSMSessionAPI = typeof ccsmSession;
+
+// ─────────────────────────── ccsmSessionTitles ───────────────────────────
+//
+// Thin renderer-side bridge to the main-process `electron/sessionTitles`
+// module, which wraps `@anthropic-ai/claude-agent-sdk`'s
+// `getSessionInfo` / `renameSession` / `listSessions`. The substrate
+// concerns (per-sid serialization, 2s TTL cache, ENOENT classification,
+// pending-rename queue) live entirely on the main side; the renderer only
+// sees a flat get/rename/listForProject surface. Wired in PR2 by the
+// `renameSession` store action; consumed in PR3 by the watcher and PR4 by
+// launch-time backfill.
+
+type SessionTitleSummary = {
+  summary: string | null;
+  mtime: number | null;
+};
+
+type SessionTitleRenameResult =
+  | { ok: true }
+  | { ok: false; reason: 'no_jsonl' | 'sdk_threw'; message?: string };
+
+type SessionTitleProjectEntry = {
+  sid: string;
+  summary: string | null;
+  mtime: number;
+};
+
+const ccsmSessionTitles = {
+  get: (sid: string, dir?: string): Promise<SessionTitleSummary> =>
+    ipcRenderer.invoke('sessionTitles:get', sid, dir),
+  rename: (
+    sid: string,
+    title: string,
+    dir?: string
+  ): Promise<SessionTitleRenameResult> =>
+    ipcRenderer.invoke('sessionTitles:rename', sid, title, dir),
+  listForProject: (projectKey: string): Promise<SessionTitleProjectEntry[]> =>
+    ipcRenderer.invoke('sessionTitles:listForProject', projectKey),
+};
+
+contextBridge.exposeInMainWorld('ccsmSessionTitles', ccsmSessionTitles);
+
+export type CCSMSessionTitlesAPI = typeof ccsmSessionTitles;

--- a/electron/sessionTitles/__tests__/index.test.ts
+++ b/electron/sessionTitles/__tests__/index.test.ts
@@ -1,0 +1,180 @@
+// Unit tests for the main-process SDK title bridge. SDK is fully mocked so
+// these tests don't touch ~/.claude/projects/.
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Hoisted mock targets. `vi.mock` factories are hoisted to the top of the
+// file, so the spies must be declared via `vi.hoisted` (or assigned inside
+// the factory and re-imported) for the test bodies to control them.
+const sdkMocks = vi.hoisted(() => ({
+  getSessionInfo: vi.fn(),
+  renameSession: vi.fn(),
+  listSessions: vi.fn(),
+}));
+
+vi.mock('@anthropic-ai/claude-agent-sdk', () => sdkMocks);
+
+import {
+  getSessionTitle,
+  renameSessionTitle,
+  listProjectSummaries,
+  enqueuePendingRename,
+  flushPendingRename,
+  __resetForTests,
+} from '../index';
+
+beforeEach(() => {
+  __resetForTests();
+  sdkMocks.getSessionInfo.mockReset();
+  sdkMocks.renameSession.mockReset();
+  sdkMocks.listSessions.mockReset();
+});
+
+describe('getSessionTitle cache TTL', () => {
+  it('serves second call from cache within 2s window', async () => {
+    sdkMocks.getSessionInfo.mockResolvedValue({
+      sessionId: 'sid-1',
+      summary: 'first prompt',
+      lastModified: 1000,
+    });
+
+    const r1 = await getSessionTitle('sid-1');
+    const r2 = await getSessionTitle('sid-1');
+
+    expect(r1).toEqual({ summary: 'first prompt', mtime: 1000 });
+    expect(r2).toEqual({ summary: 'first prompt', mtime: 1000 });
+    expect(sdkMocks.getSessionInfo).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('cache invalidation on rename', () => {
+  it('refetches after a successful rename', async () => {
+    sdkMocks.getSessionInfo
+      .mockResolvedValueOnce({
+        sessionId: 'sid-2',
+        summary: 'before',
+        lastModified: 1,
+      })
+      .mockResolvedValueOnce({
+        sessionId: 'sid-2',
+        summary: 'after',
+        lastModified: 2,
+      });
+    sdkMocks.renameSession.mockResolvedValue(undefined);
+
+    const r1 = await getSessionTitle('sid-2');
+    expect(r1.summary).toBe('before');
+
+    const renamed = await renameSessionTitle('sid-2', 'after');
+    expect(renamed).toEqual({ ok: true });
+
+    const r2 = await getSessionTitle('sid-2');
+    expect(r2.summary).toBe('after');
+    expect(sdkMocks.getSessionInfo).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('per-sid serialization', () => {
+  it('orders concurrent renames against the same sid FIFO', async () => {
+    const observed: string[] = [];
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    sdkMocks.renameSession.mockImplementation(async (_sid: string, title: string) => {
+      if (title === 'A') {
+        await firstGate;
+      }
+      observed.push(title);
+    });
+
+    const pA = renameSessionTitle('sid-3', 'A');
+    const pB = renameSessionTitle('sid-3', 'B');
+
+    // Give the microtask queue a chance to start A but not finish it.
+    await Promise.resolve();
+    expect(observed).toEqual([]);
+
+    releaseFirst();
+    await Promise.all([pA, pB]);
+
+    expect(observed).toEqual(['A', 'B']);
+  });
+});
+
+describe('error normalization', () => {
+  it('classifies ENOENT as no_jsonl', async () => {
+    const err: NodeJS.ErrnoException = Object.assign(new Error('not found'), {
+      code: 'ENOENT',
+    });
+    sdkMocks.renameSession.mockRejectedValue(err);
+
+    const result = await renameSessionTitle('sid-4', 'whatever');
+    expect(result).toEqual({ ok: false, reason: 'no_jsonl' });
+  });
+
+  it('classifies non-ENOENT as sdk_threw with message', async () => {
+    sdkMocks.renameSession.mockRejectedValue(new Error('boom'));
+
+    const result = await renameSessionTitle('sid-5', 'whatever');
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.reason).toBe('sdk_threw');
+    expect(result.message).toBe('boom');
+  });
+});
+
+describe('pending rename flush', () => {
+  it('replays the queued title via renameSession', async () => {
+    sdkMocks.renameSession.mockResolvedValue(undefined);
+
+    enqueuePendingRename('sid-6', 'pending-title', '/some/dir');
+    expect(sdkMocks.renameSession).not.toHaveBeenCalled();
+
+    await flushPendingRename('sid-6');
+
+    expect(sdkMocks.renameSession).toHaveBeenCalledTimes(1);
+    expect(sdkMocks.renameSession).toHaveBeenCalledWith(
+      'sid-6',
+      'pending-title',
+      { dir: '/some/dir' }
+    );
+  });
+
+  it('re-queues when JSONL is still missing', async () => {
+    const err: NodeJS.ErrnoException = Object.assign(new Error('no file'), {
+      code: 'ENOENT',
+    });
+    sdkMocks.renameSession.mockRejectedValueOnce(err).mockResolvedValueOnce(undefined);
+
+    enqueuePendingRename('sid-7', 'queued');
+    await flushPendingRename('sid-7');
+    expect(sdkMocks.renameSession).toHaveBeenCalledTimes(1);
+
+    // Second flush should retry because the previous attempt re-queued.
+    await flushPendingRename('sid-7');
+    expect(sdkMocks.renameSession).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('listProjectSummaries', () => {
+  it('maps SDK SessionInfo to {sid, summary, mtime}', async () => {
+    sdkMocks.listSessions.mockResolvedValue([
+      { sessionId: 'a', summary: 'one', lastModified: 100 },
+      { sessionId: 'b', summary: 'two', lastModified: 200 },
+    ]);
+
+    const out = await listProjectSummaries('/proj');
+    expect(out).toEqual([
+      { sid: 'a', summary: 'one', mtime: 100 },
+      { sid: 'b', summary: 'two', mtime: 200 },
+    ]);
+    expect(sdkMocks.listSessions).toHaveBeenCalledWith({ dir: '/proj' });
+  });
+
+  it('returns [] on SDK throw rather than escalating', async () => {
+    sdkMocks.listSessions.mockRejectedValue(new Error('disk gone'));
+    const out = await listProjectSummaries('/proj');
+    expect(out).toEqual([]);
+  });
+});

--- a/electron/sessionTitles/index.ts
+++ b/electron/sessionTitles/index.ts
@@ -1,0 +1,214 @@
+/**
+ * Main-process bridge to `@anthropic-ai/claude-agent-sdk` session-title APIs.
+ *
+ * Exposes three operations to the renderer over IPC:
+ *   - `getSessionTitle(sid, dir?)`     → SDK `getSessionInfo`
+ *   - `renameSessionTitle(sid, t, d?)` → SDK `renameSession`
+ *   - `listProjectSummaries(projectKey)` → SDK `listSessions({ dir: projectKey })`
+ *
+ * Substrate concerns folded in here so callers (PR2 store wiring, PR3 watcher,
+ * PR4 backfill) never have to reimplement them:
+ *
+ * 1. Per-sid serialization. A `Map<sid, Promise<unknown>>` chains every
+ *    operation against the same sid. Two `renameSession(A)` calls fired in
+ *    rapid succession — or a rename racing a `getSessionInfo` — would
+ *    otherwise interleave SDK fs writes against the JSONL file. The chain
+ *    keeps each sid's operations strictly ordered FIFO. Different sids are
+ *    independent and run in parallel.
+ *
+ * 2. 2-second TTL cache on `getSessionTitle`. Renderer Sidebar can render the
+ *    same session row multiple times during a state burst; without a cache
+ *    each render would re-stat the JSONL file. Invalidated on any successful
+ *    rename of the same sid.
+ *
+ * 3. Error normalization. SDK throws raw fs errors (`ENOENT`) and validation
+ *    errors. We classify ENOENT as `'no_jsonl'` (session file not yet
+ *    written — common right after `query()` starts) and everything else as
+ *    `'sdk_threw'`. The IPC boundary always sees a result discriminated
+ *    union, never an exception.
+ *
+ * 4. `pendingRenames` queue. PR2 needs to "remember" a user-set title before
+ *    the first message has flushed the JSONL file (otherwise SDK's
+ *    `renameSession` will throw ENOENT). The store enqueues; PR3's watcher
+ *    flushes on the first frame. Lives here so the bridge owns all SDK
+ *    interaction in one place.
+ */
+
+import {
+  getSessionInfo,
+  renameSession,
+  listSessions,
+} from '@anthropic-ai/claude-agent-sdk';
+
+// ─────────────────────────── Public types ────────────────────────────────
+
+export type RenameResult =
+  | { ok: true }
+  | { ok: false; reason: 'no_jsonl' | 'sdk_threw'; message?: string };
+
+export type SummaryResult = {
+  summary: string | null;
+  mtime: number | null;
+};
+
+export type ProjectSummary = {
+  sid: string;
+  summary: string | null;
+  mtime: number;
+};
+
+// ─────────────────────────── Internal state ──────────────────────────────
+
+const CACHE_TTL_MS = 2000;
+
+type CacheEntry = { result: SummaryResult; expiresAt: number };
+const titleCache = new Map<string, CacheEntry>();
+
+// Per-sid op chain. Each new operation awaits the previous one (success OR
+// failure — we swallow the rejection inside the chain so a single failed call
+// doesn't poison every later call on the same sid). Independent sids never
+// touch each other.
+const opChains = new Map<string, Promise<unknown>>();
+
+function chain<T>(sid: string, fn: () => Promise<T>): Promise<T> {
+  const prev = opChains.get(sid) ?? Promise.resolve();
+  // `.catch(() => undefined)` so a prior failure doesn't reject the whole
+  // chain; each caller still sees its own resolved/rejected value below.
+  const next = prev.catch(() => undefined).then(fn);
+  opChains.set(
+    sid,
+    next.catch(() => undefined)
+  );
+  return next;
+}
+
+// Pending-rename queue (consumed by PR2). Stored verbatim and replayed by
+// `flushPendingRename` once the watcher reports the JSONL exists.
+type PendingRename = { title: string; dir?: string };
+const pendingRenames = new Map<string, PendingRename>();
+
+// ─────────────────────────── Helpers ─────────────────────────────────────
+
+function classifyError(err: unknown): { reason: 'no_jsonl' | 'sdk_threw'; message?: string } {
+  // node fs errors carry `.code`; SDK re-throws them verbatim (or wraps with a
+  // matching `.code` property). Treat anything ENOENT-shaped as the "session
+  // file does not exist yet" signal.
+  const code =
+    err && typeof err === 'object' && 'code' in err
+      ? (err as { code?: unknown }).code
+      : undefined;
+  if (code === 'ENOENT') return { reason: 'no_jsonl' };
+  const message =
+    err instanceof Error
+      ? err.message
+      : typeof err === 'string'
+        ? err
+        : undefined;
+  return { reason: 'sdk_threw', message };
+}
+
+// ─────────────────────────── Public API ──────────────────────────────────
+
+export async function getSessionTitle(
+  sid: string,
+  dir?: string
+): Promise<SummaryResult> {
+  const now = Date.now();
+  const cached = titleCache.get(sid);
+  if (cached && cached.expiresAt > now) {
+    return cached.result;
+  }
+
+  const result = await chain(sid, async (): Promise<SummaryResult> => {
+    try {
+      const info = await getSessionInfo(sid, dir ? { dir } : undefined);
+      if (!info) return { summary: null, mtime: null };
+      return {
+        summary: info.summary ?? null,
+        mtime: typeof info.lastModified === 'number' ? info.lastModified : null,
+      };
+    } catch (err) {
+      // Read-side errors are not surfaced; the renderer just sees "no title".
+      // We log so we can spot SDK-level breakage, but don't escalate.
+      const cls = classifyError(err);
+      if (cls.reason !== 'no_jsonl') {
+        console.warn(`[sessionTitles] getSessionInfo(${sid}) threw:`, cls.message);
+      }
+      return { summary: null, mtime: null };
+    }
+  });
+
+  titleCache.set(sid, { result, expiresAt: Date.now() + CACHE_TTL_MS });
+  return result;
+}
+
+export async function renameSessionTitle(
+  sid: string,
+  title: string,
+  dir?: string
+): Promise<RenameResult> {
+  return chain(sid, async (): Promise<RenameResult> => {
+    try {
+      await renameSession(sid, title, dir ? { dir } : undefined);
+      // Invalidate cached title — next read must reflect the new value.
+      titleCache.delete(sid);
+      return { ok: true };
+    } catch (err) {
+      const cls = classifyError(err);
+      return { ok: false, ...cls };
+    }
+  });
+}
+
+export async function listProjectSummaries(
+  projectKey: string
+): Promise<ProjectSummary[]> {
+  // Project-scoped reads are not per-sid serialized — they touch every
+  // session file in the project, and serializing per-project would defeat
+  // the parallelism that makes this useful for backfill.
+  try {
+    const sessions = await listSessions({ dir: projectKey });
+    return sessions.map((s) => ({
+      sid: s.sessionId,
+      summary: s.summary ?? null,
+      mtime: typeof s.lastModified === 'number' ? s.lastModified : 0,
+    }));
+  } catch (err) {
+    console.warn(
+      `[sessionTitles] listSessions(${projectKey}) threw:`,
+      err instanceof Error ? err.message : err
+    );
+    return [];
+  }
+}
+
+// ─────────────────────────── Pending queue (PR2) ─────────────────────────
+
+export function enqueuePendingRename(sid: string, title: string, dir?: string): void {
+  pendingRenames.set(sid, { title, dir });
+}
+
+export async function flushPendingRename(sid: string): Promise<void> {
+  const pending = pendingRenames.get(sid);
+  if (!pending) return;
+  pendingRenames.delete(sid);
+  const result = await renameSessionTitle(sid, pending.title, pending.dir);
+  if (!result.ok && result.reason === 'no_jsonl') {
+    // JSONL still not there — re-queue for the next flush attempt. PR3's
+    // watcher will retry on the next frame.
+    pendingRenames.set(sid, pending);
+  }
+}
+
+// ─────────────────────────── Test-only helpers ───────────────────────────
+
+/**
+ * Reset all module state. Test-only; never called from production code.
+ * Exported so the vitest suite can isolate cases without juggling module
+ * reloads.
+ */
+export function __resetForTests(): void {
+  titleCache.clear();
+  opChains.clear();
+  pendingRenames.clear();
+}


### PR DESCRIPTION
PR1 of 4 for session-name SDK sync (plan: #586).

## Scope
Substrate only — main-process wrapper for `@anthropic-ai/claude-agent-sdk`'s `renameSession` / `getSessionInfo` / `listSessions`, with per-sid serialization, 2s TTL cache, error normalization, and pending-rename queue (consumed by PR2).

Note on SDK surface: the plan referenced `listSessionSummaries` but that name only exists as a method on the `SessionStore` interface in `sdk.d.ts`. The top-level project-scoped read is `listSessions({ dir })` returning `SDKSessionInfo[]` (which already carries `summary` + `lastModified`), so `listProjectSummaries` is built on that. Same observable shape `{sid, summary, mtime}` — no API impact.

## API
- IPC: `sessionTitles:get`, `sessionTitles:rename`, `sessionTitles:listForProject`
- Preload: `window.ccsmSessionTitles.{get,rename,listForProject}` (separate top-level namespace, matching the existing `ccsmPty` / `ccsmSession` style — not nested under `window.ccsm`)
- Internal exports for PR2: `enqueuePendingRename`, `flushPendingRename`

## Tests
9 unit tests in `electron/sessionTitles/__tests__/index.test.ts` (placed under `__tests__/` per `vitest.config.ts` include pattern, not co-located) covering:
- Cache TTL: two `getSessionTitle` within 2s → SDK called once
- Cache invalidation on rename: read → rename → read → SDK called twice
- Per-sid FIFO serialization across concurrent renames
- ENOENT → `{ok:false, reason:'no_jsonl'}`
- Other throw → `{ok:false, reason:'sdk_threw', message}`
- `enqueuePendingRename` + `flushPendingRename` replays via SDK
- Pending re-queue when JSONL still missing
- `listProjectSummaries` happy-path mapping
- `listProjectSummaries` swallows SDK errors → `[]`

## Verification
- `npx tsc --noEmit -p tsconfig.electron.json` — clean
- `npx tsc --noEmit` (renderer) — clean
- `npx vitest run electron/sessionTitles` — 9/9 passing
- `npx eslint electron/sessionTitles electron/main.ts electron/preload.ts` — clean
- Full vitest suite: 300/303 passing; the 3 pre-existing failures are `better-sqlite3` ABI mismatches against Node 24 in the worktree (unrelated to this PR — postinstall flags it explicitly)

## Out of scope (later PRs)
- PR2: store wires `renameSession` action through this bridge
- PR3: `sessionWatcher` emits title-changed events
- PR4: launch-time backfill

## Anti-patterns avoided
- No `userRenamed` flag (SDK handles precedence)
- No watcher / store / sidebar / renderer changes
- No new chokidar dep
- IPC surface is exactly the 3 channels in the plan
- SDK only called from main; renderer never imports it
- Errors normalized to `{ok}` discriminated unions; never thrown across IPC

Closes #588.