### PR TITLE
feat(sessionWatcher): emit title-changed events from JSONL (#590)

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -253,9 +253,11 @@ export type CCSMPtyAPI = typeof ccsmPty;
 export type SessionState = 'idle' | 'running' | 'requires_action';
 type SessionStatePayload = { sid: string; state: SessionState };
 type SessionActivatePayload = { sid: string };
+type SessionTitlePayload = { sid: string; title: string };
 
 const sessionStateListeners = new Set<(e: SessionStatePayload) => void>();
 const sessionActivateListeners = new Set<(e: SessionActivatePayload) => void>();
+const sessionTitleListeners = new Set<(e: SessionTitlePayload) => void>();
 
 ipcRenderer.on('session:state', (_e: IpcRendererEvent, payload: SessionStatePayload) => {
   for (const cb of sessionStateListeners) {
@@ -263,6 +265,20 @@ ipcRenderer.on('session:state', (_e: IpcRendererEvent, payload: SessionStatePayl
       cb(payload);
     } catch (err) {
       console.error('[ccsmSession] onState listener threw', err);
+    }
+  }
+});
+
+// Title pushes from main: sourced by the JSONL tail-watcher
+// (electron/sessionWatcher) when the SDK-derived `summary` for a session
+// changes. Renderer subscribes via `window.ccsmSession.onTitle` and pipes
+// into the store's `_applyExternalTitle` action.
+ipcRenderer.on('session:title', (_e: IpcRendererEvent, payload: SessionTitlePayload) => {
+  for (const cb of sessionTitleListeners) {
+    try {
+      cb(payload);
+    } catch (err) {
+      console.error('[ccsmSession] onTitle listener threw', err);
     }
   }
 });
@@ -291,6 +307,12 @@ const ccsmSession = {
     sessionActivateListeners.add(cb);
     return () => {
       sessionActivateListeners.delete(cb);
+    };
+  },
+  onTitle: (cb: (e: SessionTitlePayload) => void): (() => void) => {
+    sessionTitleListeners.add(cb);
+    return () => {
+      sessionTitleListeners.delete(cb);
     };
   },
   // Renderer pushes its active session id to main so the notify bridge can

--- a/electron/ptyHost/index.ts
+++ b/electron/ptyHost/index.ts
@@ -240,7 +240,7 @@ function makeEntry(
   // CLAUDE_CONFIG_DIR/projects, fall back to ~/.claude/projects.
   try {
     const jsonlPath = resolveJsonlPath(claudeSid, cwd);
-    if (jsonlPath) sessionWatcher.startWatching(sid, jsonlPath);
+    if (jsonlPath) sessionWatcher.startWatching(sid, jsonlPath, cwd);
   } catch {
     /* watcher start is best-effort; PTY still owns its lifecycle */
   }
@@ -423,6 +423,20 @@ export function registerPtyHostIpc(
       if (wc.isDestroyed()) return;
       try {
         wc.send('session:state', evt);
+      } catch {
+        /* renderer gone */
+      }
+    });
+    // Title fan-out mirrors the state-changed bridge above. The watcher
+    // emits `{sid, title}` only when the SDK-derived summary changes, so
+    // there is no extra dedupe needed on this side.
+    sessionWatcher.on('title-changed', (evt) => {
+      const win = getMainWindow();
+      if (!win || win.isDestroyed()) return;
+      const wc = win.webContents;
+      if (wc.isDestroyed()) return;
+      try {
+        wc.send('session:title', evt);
       } catch {
         /* renderer gone */
       }

--- a/electron/sessionWatcher/__tests__/titleChanged.test.ts
+++ b/electron/sessionWatcher/__tests__/titleChanged.test.ts
@@ -1,0 +1,167 @@
+// Unit tests for the SessionWatcher's `title-changed` event path.
+//
+// Strategy:
+//   * Mock the SDK so we control what `getSessionInfo` returns per call.
+//   * Drive synthetic JSONL writes via a tmp dir + `__createForTest()` so
+//     we get a fresh watcher instance per test (no shared module state).
+//   * Assert the event fires once per change, not on no-op identical-title
+//     ticks, and that the dedupe is via the entry's `lastEmittedTitle`.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+// Mock the SDK module that `electron/sessionTitles/index.ts` imports.
+// `getSessionInfo` is the only call exercised by the title path. We control
+// the returned `summary` per call via the `summaryReturns` array, popping
+// the next value on each invocation.
+const summaryReturns: Array<{ summary: string | null; lastModified?: number }> = [];
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
+  getSessionInfo: vi.fn(async () => {
+    if (summaryReturns.length === 0) return null;
+    return summaryReturns.shift() ?? null;
+  }),
+  // Unused by these tests, stubbed so the import resolves.
+  renameSession: vi.fn(),
+  listSessions: vi.fn(),
+}));
+
+import { __createForTest, type TitleChangedEvent } from '../index';
+import { __resetForTests as __resetTitleBridge } from '../../sessionTitles';
+
+let tmpRoot: string;
+
+function freshTmp(): { jsonlPath: string } {
+  // Synthetic project-style layout under a unique tmp dir per test so the
+  // watcher's existence checks resolve correctly.
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sw-title-test-'));
+  const projectDir = path.join(tmpRoot, 'project');
+  fs.mkdirSync(projectDir, { recursive: true });
+  const jsonlPath = path.join(projectDir, 'sess.jsonl');
+  return { jsonlPath };
+}
+
+function appendFrame(jsonlPath: string, text: string): void {
+  fs.appendFileSync(jsonlPath, JSON.stringify({ type: 'user', text }) + '\n');
+}
+
+async function waitForCondition(
+  pred: () => boolean,
+  timeoutMs = 1500,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (pred()) return;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  throw new Error(`waitForCondition timed out after ${timeoutMs}ms`);
+}
+
+describe('SessionWatcher title-changed', () => {
+  beforeEach(() => {
+    summaryReturns.length = 0;
+    // Bridge has its own 2s TTL cache + per-sid op chain; reset between
+    // tests so cached `null` summaries from one test don't shadow the next.
+    __resetTitleBridge();
+  });
+
+  afterEach(() => {
+    if (tmpRoot && fs.existsSync(tmpRoot)) {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('emits title-changed once when SDK reports a new summary', async () => {
+    const { jsonlPath } = freshTmp();
+    const watcher = __createForTest();
+    const events: TitleChangedEvent[] = [];
+    watcher.on('title-changed', (e: TitleChangedEvent) => events.push(e));
+
+    summaryReturns.push({ summary: 'first derived title' });
+
+    fs.writeFileSync(jsonlPath, '');
+    watcher.startWatching('sid-A', jsonlPath);
+    appendFrame(jsonlPath, 'hello');
+
+    await waitForCondition(() => events.length >= 1);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ sid: 'sid-A', title: 'first derived title' });
+
+    watcher.closeAll();
+  });
+
+  it('dedupes identical titles via lastEmittedTitle', async () => {
+    const { jsonlPath } = freshTmp();
+    const watcher = __createForTest();
+    const events: TitleChangedEvent[] = [];
+    watcher.on('title-changed', (e: TitleChangedEvent) => events.push(e));
+
+    // Reset the bridge's TTL cache between SDK calls so we actually
+    // re-invoke `getSessionInfo` per tick (the cache has a 2s TTL — long
+    // enough to mask the second tick if we don't reset).
+    summaryReturns.push({ summary: 'same title' });
+
+    fs.writeFileSync(jsonlPath, '');
+    watcher.startWatching('sid-B', jsonlPath);
+    appendFrame(jsonlPath, 'first');
+    await waitForCondition(() => events.length >= 1);
+
+    // Second tick with the same SDK-reported summary — must NOT fire.
+    __resetTitleBridge();
+    summaryReturns.push({ summary: 'same title' });
+    appendFrame(jsonlPath, 'second');
+
+    // Allow plenty of time for any spurious second emit; if dedupe works
+    // we should still be at exactly one event.
+    await new Promise((r) => setTimeout(r, 300));
+    expect(events).toHaveLength(1);
+    expect(events[0].title).toBe('same title');
+
+    watcher.closeAll();
+  });
+
+  it('emits again when the SDK reports a different summary', async () => {
+    const { jsonlPath } = freshTmp();
+    const watcher = __createForTest();
+    const events: TitleChangedEvent[] = [];
+    watcher.on('title-changed', (e: TitleChangedEvent) => events.push(e));
+
+    summaryReturns.push({ summary: 'title v1' });
+    fs.writeFileSync(jsonlPath, '');
+    watcher.startWatching('sid-C', jsonlPath);
+    appendFrame(jsonlPath, 'first');
+    await waitForCondition(() => events.length >= 1);
+
+    __resetTitleBridge();
+    summaryReturns.push({ summary: 'title v2' });
+    appendFrame(jsonlPath, 'second');
+    await waitForCondition(() => events.length >= 2);
+
+    expect(events.map((e) => e.title)).toEqual(['title v1', 'title v2']);
+
+    watcher.closeAll();
+  });
+
+  it('skips emit when SDK returns null or empty summary', async () => {
+    const { jsonlPath } = freshTmp();
+    const watcher = __createForTest();
+    const events: TitleChangedEvent[] = [];
+    watcher.on('title-changed', (e: TitleChangedEvent) => events.push(e));
+
+    // Two ticks, both with no usable title.
+    summaryReturns.push({ summary: null });
+    summaryReturns.push({ summary: '' });
+
+    fs.writeFileSync(jsonlPath, '');
+    watcher.startWatching('sid-D', jsonlPath);
+    appendFrame(jsonlPath, 'first');
+    __resetTitleBridge();
+    appendFrame(jsonlPath, 'second');
+
+    await new Promise((r) => setTimeout(r, 300));
+    expect(events).toHaveLength(0);
+
+    watcher.closeAll();
+  });
+});

--- a/electron/sessionWatcher/__tests__/titleChanged.test.ts
+++ b/electron/sessionWatcher/__tests__/titleChanged.test.ts
@@ -28,7 +28,11 @@ vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
 }));
 
 import { __createForTest, type TitleChangedEvent } from '../index';
-import { __resetForTests as __resetTitleBridge } from '../../sessionTitles';
+import {
+  __resetForTests as __resetTitleBridge,
+  enqueuePendingRename,
+} from '../../sessionTitles';
+import { renameSession as renameSessionMock } from '@anthropic-ai/claude-agent-sdk';
 
 let tmpRoot: string;
 
@@ -64,6 +68,7 @@ describe('SessionWatcher title-changed', () => {
     // Bridge has its own 2s TTL cache + per-sid op chain; reset between
     // tests so cached `null` summaries from one test don't shadow the next.
     __resetTitleBridge();
+    (renameSessionMock as unknown as ReturnType<typeof vi.fn>).mockClear();
   });
 
   afterEach(() => {
@@ -161,6 +166,42 @@ describe('SessionWatcher title-changed', () => {
 
     await new Promise((r) => setTimeout(r, 300));
     expect(events).toHaveLength(0);
+
+    watcher.closeAll();
+  });
+
+  it('flushes pending rename exactly once on first JSONL appearance', async () => {
+    const { jsonlPath } = freshTmp();
+    const projectDir = path.dirname(jsonlPath);
+    const renameMock = renameSessionMock as unknown as ReturnType<typeof vi.fn>;
+
+    // PR2 path: a user-set title was queued before the JSONL existed
+    // (renameSession would have thrown ENOENT).
+    enqueuePendingRename('sid-E', 'pending-title', projectDir);
+
+    const watcher = __createForTest();
+    watcher.startWatching('sid-E', jsonlPath, projectDir);
+
+    // Initial tick fires immediate=true; file does NOT exist yet, so the
+    // flush guard (`fileExists && !entry.jsonlSeen`) must NOT fire.
+    await new Promise((r) => setTimeout(r, 100));
+    expect(renameMock).not.toHaveBeenCalled();
+
+    // Create the JSONL — dirWatcher should pick this up and schedule a
+    // read. After DEBOUNCE_MS the read sees the file, sets jsonlSeen, and
+    // calls flushPendingRename which in turn calls SDK renameSession.
+    fs.writeFileSync(jsonlPath, '');
+    appendFrame(jsonlPath, 'first');
+
+    await waitForCondition(() => renameMock.mock.calls.length >= 1);
+    expect(renameMock).toHaveBeenCalledTimes(1);
+    expect(renameMock).toHaveBeenCalledWith('sid-E', 'pending-title', { dir: projectDir });
+
+    // Subsequent appends must NOT re-flush — `jsonlSeen` is now true.
+    appendFrame(jsonlPath, 'second');
+    appendFrame(jsonlPath, 'third');
+    await new Promise((r) => setTimeout(r, 300));
+    expect(renameMock).toHaveBeenCalledTimes(1);
 
     watcher.closeAll();
   });

--- a/electron/sessionWatcher/index.ts
+++ b/electron/sessionWatcher/index.ts
@@ -28,6 +28,7 @@ import { EventEmitter } from 'node:events';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { classifyJsonlText, type WatcherState } from './inference';
+import { getSessionTitle, flushPendingRename } from '../sessionTitles';
 
 export type { WatcherState } from './inference';
 
@@ -36,9 +37,18 @@ export interface StateChangedEvent {
   state: WatcherState;
 }
 
+export interface TitleChangedEvent {
+  sid: string;
+  title: string;
+}
+
 interface Entry {
   sid: string;
   jsonlPath: string;
+  // Optional cwd, threaded through to `getSessionTitle({dir})` so the SDK
+  // resolves the right project's JSONL. Not required (SDK falls back to a
+  // global scan), but supplying it avoids an O(projects) probe per tick.
+  cwd?: string;
   // Watcher on the file itself (created lazily once the file exists) and a
   // fallback watcher on the parent directory (so we notice the first
   // creation even if claude hasn't written it at startWatching time).
@@ -51,6 +61,14 @@ interface Entry {
   ancestorWatcher: fs.FSWatcher | null;
   ancestorPath: string | null;
   lastEmitted: WatcherState | null;
+  // Last title we emitted to listeners. Used to dedupe `title-changed` —
+  // the watcher tick fires on every fs event, but only changes in the
+  // SDK-derived `summary` warrant a renderer update.
+  lastEmittedTitle: string | null;
+  // Tracks whether we've ever observed the JSONL file landing on disk.
+  // Used as the trigger for `flushPendingRename` (PR2's queue): the first
+  // time the file appears, we know `renameSession` will succeed.
+  jsonlSeen: boolean;
   // Coalesce bursts of fs events. fs.watch on Windows can fire 3-5 times
   // for a single append; we don't want to re-read + reclassify each time.
   pendingTimer: NodeJS.Timeout | null;
@@ -71,7 +89,7 @@ const MAX_READ_BYTES = 256 * 1024;
 class SessionWatcher extends EventEmitter {
   private entries = new Map<string, Entry>();
 
-  startWatching(sid: string, jsonlPath: string): void {
+  startWatching(sid: string, jsonlPath: string, cwd?: string): void {
     if (!sid || !jsonlPath) return;
     const existing = this.entries.get(sid);
     if (existing) {
@@ -84,11 +102,14 @@ class SessionWatcher extends EventEmitter {
     const entry: Entry = {
       sid,
       jsonlPath,
+      cwd,
       fileWatcher: null,
       dirWatcher: null,
       ancestorWatcher: null,
       ancestorPath: null,
       lastEmitted: null,
+      lastEmittedTitle: null,
+      jsonlSeen: false,
       pendingTimer: null,
       closed: false,
     };
@@ -261,8 +282,10 @@ class SessionWatcher extends EventEmitter {
 
   private readAndClassify(entry: Entry): void {
     let text = '';
+    let fileExists = false;
     try {
       const stat = fs.statSync(entry.jsonlPath);
+      fileExists = true;
       if (stat.size === 0) {
         text = '';
       } else if (stat.size <= MAX_READ_BYTES) {
@@ -290,6 +313,51 @@ class SessionWatcher extends EventEmitter {
       entry.lastEmitted = next;
       this.emit('state-changed', { sid: entry.sid, state: next } as StateChangedEvent);
     }
+
+    // First time we've ever seen the JSONL land for this sid: PR2 may have
+    // queued a user-set title before the file existed (renameSession would
+    // have thrown ENOENT). Flush now. Wrapped in try/catch so a queue
+    // failure never crashes the watcher tick.
+    if (fileExists && !entry.jsonlSeen) {
+      entry.jsonlSeen = true;
+      try {
+        void flushPendingRename(entry.sid);
+      } catch (err) {
+        console.warn(
+          `[sessionWatcher] flushPendingRename(${entry.sid}) threw:`,
+          err instanceof Error ? err.message : err
+        );
+      }
+    }
+
+    // Emit title-changed if the SDK-derived summary has changed since our
+    // last emission. We piggy-back on this same debounced tick (no second
+    // timer). Skip the SDK call entirely until the JSONL exists — without
+    // a file `getSessionInfo` would always return null.
+    if (fileExists) {
+      void this.maybeEmitTitle(entry);
+    }
+  }
+
+  private async maybeEmitTitle(entry: Entry): Promise<void> {
+    if (entry.closed) return;
+    let summary: string | null = null;
+    try {
+      const result = await getSessionTitle(entry.sid, entry.cwd);
+      summary = result.summary;
+    } catch {
+      // Bridge swallows ENOENT internally; anything reaching here is
+      // unexpected. Skip silently — the next tick will retry.
+      return;
+    }
+    if (entry.closed) return;
+    // Only emit when we have an actual non-empty title. Both null (no
+    // summary yet) and '' (empty string) are skipped — the renderer should
+    // keep its existing name until the SDK has something real.
+    if (typeof summary !== 'string' || summary.length === 0) return;
+    if (summary === entry.lastEmittedTitle) return;
+    entry.lastEmittedTitle = summary;
+    this.emit('title-changed', { sid: entry.sid, title: summary } as TitleChangedEvent);
   }
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,6 +77,7 @@ export default function App() {
 
   const selectSession = useStore((s) => s.selectSession);
   const focusGroup = useStore((s) => s.focusGroup);
+  const applyExternalTitle = useStore((s) => s._applyExternalTitle);
   const moveSession = useStore((s) => s.moveSession);
   const createSession = useStore((s) => s.createSession);
   const toggleSidebar = useStore((s) => s.toggleSidebar);
@@ -146,6 +147,25 @@ export default function App() {
       }
     });
   }, [selectSession]);
+
+  // Pipe `session:title` IPC events from main into the store. The watcher
+  // emits when the SDK-derived `summary` changes for a session; the store
+  // applies via `_applyExternalTitle` (no-ops if the row is missing or
+  // the name is already current). Bridge is a no-op in the
+  // test/storybook environments where `window.ccsmSession` is missing or
+  // the older preload didn't expose `onTitle`.
+  useEffect(() => {
+    type Bridge = {
+      onTitle?: (cb: (e: { sid: string; title: string }) => void) => () => void;
+    };
+    const bridge = (window as unknown as { ccsmSession?: Bridge }).ccsmSession;
+    if (!bridge || typeof bridge.onTitle !== 'function') return;
+    return bridge.onTitle((evt) => {
+      if (!evt || typeof evt.sid !== 'string' || typeof evt.title !== 'string') return;
+      if (evt.sid.length === 0 || evt.title.length === 0) return;
+      applyExternalTitle(evt.sid, evt.title);
+    });
+  }, [applyExternalTitle]);
 
   // Locale: ask main for the OS locale, feed it into the preferences store
   // so a "system" preference resolves correctly. Falls back to navigator.

--- a/src/session.d.ts
+++ b/src/session.d.ts
@@ -20,8 +20,14 @@ export interface SessionStatePayload {
   state: SessionState;
 }
 
+export interface SessionTitlePayload {
+  sid: string;
+  title: string;
+}
+
 export interface CcsmSessionApi {
   onState(cb: (e: SessionStatePayload) => void): () => void;
+  onTitle?(cb: (e: SessionTitlePayload) => void): () => void;
 }
 
 declare global {

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -198,6 +198,13 @@ type Actions = {
   createSession: (cwd: string | null | CreateSessionOptions) => void;
   importSession: (opts: { name: string; cwd: string; groupId: string; resumeSessionId: string; projectDir?: string }) => string;
   renameSession: (id: string, name: string) => void;
+  /** Internal: apply an externally-sourced title (from the JSONL
+   *  tail-watcher's `session:title` IPC). Skips if the row is missing or
+   *  the name is already current. Underscore prefix marks this as not
+   *  user-facing — callers are limited to the IPC subscriber wired in
+   *  src/App.tsx. SDK customTitle precedence guarantees user renames win
+   *  over SDK auto-summaries, so no userRenamed flag is needed here. */
+  _applyExternalTitle: (sid: string, title: string) => void;
   deleteSession: (id: string) => SessionSnapshot | null;
   /** Re-insert a session previously removed by `deleteSession`. Restores the
    *  row at its original index, plus messages, draft, and runtime flags. */
@@ -553,6 +560,17 @@ export const useStore = create<State & Actions>((set, get) => ({
     set((s) => ({
       sessions: s.sessions.map((x) => (x.id === id ? { ...x, name } : x))
     }));
+  },
+
+  _applyExternalTitle: (sid, title) => {
+    set((s) => {
+      const idx = s.sessions.findIndex((x) => x.id === sid);
+      if (idx === -1) return s;
+      if (s.sessions[idx].name === title) return s;
+      const next = s.sessions.slice();
+      next[idx] = { ...next[idx], name: title };
+      return { ...s, sessions: next };
+    });
   },
 
   importSession: ({ name, cwd, groupId, resumeSessionId, projectDir: _projectDir }) => {


### PR DESCRIPTION
PR3 of 4 for session-name SDK sync (plan: #586, PR1: #501, PR2: see #591).

## Scope
- sessionWatcher emits `title-changed` event from existing debounced tick
- ptyHost fans out via `session:title` IPC to the main window (mirrors `session:state`)
- preload exposes `ccsmSession.onTitle(cb)`
- Store gains `_applyExternalTitle(sid, title)` action (no userRenamed flag — SDK customTitle precedence handles user-rename precedence)
- `App.tsx` subscribes the IPC and pipes into the store
- Watcher also triggers `flushPendingRename` when JSONL first appears (consumes PR2's queue) — wrapped in try/catch so a failure never crashes the tick
- No new chokidar, no new timers, no userRenamed flag

## Tests
- Unit: `electron/sessionWatcher/__tests__/titleChanged.test.ts`
  - emits once on first SDK summary
  - dedupes identical titles via `lastEmittedTitle`
  - emits again on different summary
  - skips emit when SDK returns null/empty
- Vitest: 304 passing, 3 pre-existing better-sqlite3 ABI failures (per task spec, OK to ignore)

## Out of scope (later)
- PR4: launch-time backfill

## Notes
- Threaded `cwd` through `sessionWatcher.startWatching(sid, jsonlPath, cwd?)` so `getSessionTitle({dir})` resolves the right project. ptyHost already has `cwd` at the call site.
- The 2s TTL cache in PR1's bridge is preserved — the watcher just calls `getSessionTitle` and trusts dedupe via `lastEmittedTitle`.

Closes #590.