### PR TITLE
feat(store): wire renameSession through SDK writeback (#591)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -74,6 +74,8 @@ import {
   getSessionTitle,
   renameSessionTitle,
   listProjectSummaries,
+  enqueuePendingRename,
+  flushPendingRename,
 } from './sessionTitles';
 
 // ─────────────────────── IPC security helpers ────────────────────────────
@@ -842,6 +844,21 @@ app.whenReady().then(() => {
   );
   ipcMain.handle('sessionTitles:listForProject', (_e, projectKey: string) =>
     listProjectSummaries(projectKey)
+  );
+  // Pending-rename queue. Renderer enqueues when SDK reports `no_jsonl`
+  // (rename happened before the first message flushed the JSONL file). PR3's
+  // sessionWatcher is the only production caller of `flushPending` — it
+  // fires when the watcher first sees the JSONL appear. Exposed here so the
+  // renderer's store action can reach the in-memory queue that lives in
+  // `electron/sessionTitles`.
+  ipcMain.handle(
+    'sessionTitles:enqueuePending',
+    (_e, sid: string, title: string, dir?: string) => {
+      enqueuePendingRename(sid, title, dir);
+    }
+  );
+  ipcMain.handle('sessionTitles:flushPending', (_e, sid: string) =>
+    flushPendingRename(sid)
   );
 
   ipcMain.handle('window:minimize', (e) => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -364,6 +364,15 @@ const ccsmSessionTitles = {
     ipcRenderer.invoke('sessionTitles:rename', sid, title, dir),
   listForProject: (projectKey: string): Promise<SessionTitleProjectEntry[]> =>
     ipcRenderer.invoke('sessionTitles:listForProject', projectKey),
+  // Pending-rename queue (PR2). When `rename` returns `{ok:false,
+  // reason:'no_jsonl'}` the store calls `enqueuePending` so the title is
+  // remembered locally; PR3's sessionWatcher invokes `flushPending` once the
+  // JSONL appears. The queue lives in-memory in main and is intentionally
+  // not persisted — see `electron/sessionTitles/index.ts` header.
+  enqueuePending: (sid: string, title: string, dir?: string): Promise<void> =>
+    ipcRenderer.invoke('sessionTitles:enqueuePending', sid, title, dir),
+  flushPending: (sid: string): Promise<void> =>
+    ipcRenderer.invoke('sessionTitles:flushPending', sid),
 };
 
 contextBridge.exposeInMainWorld('ccsmSessionTitles', ccsmSessionTitles);

--- a/electron/sessionTitles/__tests__/index.test.ts
+++ b/electron/sessionTitles/__tests__/index.test.ts
@@ -2,16 +2,15 @@
 // these tests don't touch ~/.claude/projects/.
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-// Hoisted mock targets. `vi.mock` factories are hoisted to the top of the
-// file, so the spies must be declared via `vi.hoisted` (or assigned inside
-// the factory and re-imported) for the test bodies to control them.
-const sdkMocks = vi.hoisted(() => ({
+// The bridge resolves the ESM-only `@anthropic-ai/claude-agent-sdk` via a
+// `new Function('return import(spec)')` shim (see `loadSdk` in ../index.ts).
+// That shim defeats vitest's `vi.mock` resolver, so we inject fakes through
+// the bridge's `__setSdkForTests` test seam instead.
+const sdkMocks = {
   getSessionInfo: vi.fn(),
   renameSession: vi.fn(),
   listSessions: vi.fn(),
-}));
-
-vi.mock('@anthropic-ai/claude-agent-sdk', () => sdkMocks);
+};
 
 import {
   getSessionTitle,
@@ -20,6 +19,7 @@ import {
   enqueuePendingRename,
   flushPendingRename,
   __resetForTests,
+  __setSdkForTests,
 } from '../index';
 
 beforeEach(() => {
@@ -27,6 +27,9 @@ beforeEach(() => {
   sdkMocks.getSessionInfo.mockReset();
   sdkMocks.renameSession.mockReset();
   sdkMocks.listSessions.mockReset();
+  __setSdkForTests(
+    sdkMocks as unknown as Parameters<typeof __setSdkForTests>[0]
+  );
 });
 
 describe('getSessionTitle cache TTL', () => {

--- a/electron/sessionTitles/index.ts
+++ b/electron/sessionTitles/index.ts
@@ -34,11 +34,49 @@
  *    interaction in one place.
  */
 
-import {
-  getSessionInfo,
-  renameSession,
-  listSessions,
+import type {
+  getSessionInfo as GetSessionInfoFn,
+  renameSession as RenameSessionFn,
+  listSessions as ListSessionsFn,
 } from '@anthropic-ai/claude-agent-sdk';
+
+// `@anthropic-ai/claude-agent-sdk` is published as ESM-only (sdk.mjs). Our
+// Electron main bundle compiles to CommonJS (tsconfig.electron.json:
+// `module: CommonJS`), so a static `import { ... } from '...'` becomes a
+// `require()` call at runtime — which Node refuses for an ESM module
+// (ERR_REQUIRE_ESM, blocks the whole app from booting). We resolve the SDK
+// once via dynamic `import()` and cache the live exports for every later
+// call. The first SDK-touching IPC pays the import cost (~tens of ms);
+// every subsequent call is a Map / Promise hit only.
+type SdkExports = {
+  getSessionInfo: typeof GetSessionInfoFn;
+  renameSession: typeof RenameSessionFn;
+  listSessions: typeof ListSessionsFn;
+};
+let sdkPromise: Promise<SdkExports> | null = null;
+async function loadSdk(): Promise<SdkExports> {
+  if (!sdkPromise) {
+    // CommonJS-build trap: a literal `await import('@anthropic-ai/...')` is
+    // transpiled by `tsc` (with `module: CommonJS`) into `require(...)`,
+    // which Node refuses for an ESM-only package (ERR_REQUIRE_ESM). Wrap
+    // the dynamic import in `new Function` so the call survives transpile
+    // intact and is evaluated as a real ESM `import()` at runtime.
+    //
+    // Side effect: vitest's `vi.mock('@anthropic-ai/claude-agent-sdk', …)`
+    // can't intercept this loader (the mock resolver only sees static
+    // imports). Tests inject mocks via `__setSdkForTests` instead.
+    const dynamicImport = new Function(
+      'spec',
+      'return import(spec)'
+    ) as (spec: string) => Promise<typeof import('@anthropic-ai/claude-agent-sdk')>;
+    sdkPromise = dynamicImport('@anthropic-ai/claude-agent-sdk').then((mod) => ({
+      getSessionInfo: mod.getSessionInfo,
+      renameSession: mod.renameSession,
+      listSessions: mod.listSessions,
+    }));
+  }
+  return sdkPromise;
+}
 
 // ─────────────────────────── Public types ────────────────────────────────
 
@@ -121,6 +159,7 @@ export async function getSessionTitle(
 
   const result = await chain(sid, async (): Promise<SummaryResult> => {
     try {
+      const { getSessionInfo } = await loadSdk();
       const info = await getSessionInfo(sid, dir ? { dir } : undefined);
       if (!info) return { summary: null, mtime: null };
       return {
@@ -149,6 +188,7 @@ export async function renameSessionTitle(
 ): Promise<RenameResult> {
   return chain(sid, async (): Promise<RenameResult> => {
     try {
+      const { renameSession } = await loadSdk();
       await renameSession(sid, title, dir ? { dir } : undefined);
       // Invalidate cached title — next read must reflect the new value.
       titleCache.delete(sid);
@@ -167,6 +207,7 @@ export async function listProjectSummaries(
   // session file in the project, and serializing per-project would defeat
   // the parallelism that makes this useful for backfill.
   try {
+    const { listSessions } = await loadSdk();
     const sessions = await listSessions({ dir: projectKey });
     return sessions.map((s) => ({
       sid: s.sessionId,
@@ -211,4 +252,15 @@ export function __resetForTests(): void {
   titleCache.clear();
   opChains.clear();
   pendingRenames.clear();
+  sdkPromise = null;
+}
+
+/**
+ * Inject SDK fakes for tests. The real loader uses a `new Function`
+ * dynamic-import shim (see `loadSdk` above) to dodge tsc's CommonJS rewrite,
+ * which also dodges `vi.mock`. Tests call this with the same shape the
+ * production loader resolves to. Pass `null` to fall back to the real SDK.
+ */
+export function __setSdkForTests(fakes: SdkExports | null): void {
+  sdkPromise = fakes ? Promise.resolve(fakes) : null;
 }

--- a/scripts/harness-real-cli.mjs
+++ b/scripts/harness-real-cli.mjs
@@ -289,6 +289,125 @@ async function caseNewSessionChat({ electronApp, win, tempDir }) {
 }
 
 // ============================================================================
+// Case 1c: session-rename-writes-jsonl (PR2 — store renameSession → SDK writeback)
+// ============================================================================
+//
+// Verifies the renderer's renameSession action forwards the new title through
+// the main-process SDK bridge installed in PR1. End-to-end flow:
+//   1. Spawn a fresh session in an isolated CLAUDE_CONFIG_DIR.
+//   2. Send a one-shot prompt so the JSONL transcript exists on disk.
+//   3. Trigger renameSession via window.__ccsmStore.getState().renameSession.
+//      The store update is async; await it from inside win.evaluate.
+//   4. Locate <sid>.jsonl under <tempDir>/projects/<hash>/ and grep for the
+//      custom title. The SDK writes a `customTitle` discriminator frame
+//      (or stamps `customTitle` on the existing summary frame); both shapes
+//      contain the literal string we set. Asserting on the literal is
+//      schema-tolerant.
+async function caseSessionRenameWritesJsonl({ electronApp: _e, win, tempDir }) {
+  const RENAME_PROMPT = 'reply with the single word: ack';
+  const CUSTOM_TITLE = `pr2-rename-${Math.random().toString(36).slice(2, 10)}`;
+
+  await win.waitForFunction(
+    () => !document.querySelector('[data-testid="claude-availability-probing"]'),
+    null,
+    { timeout: 30000 },
+  );
+
+  const projectDir = path.join(tempDir, 'rename-project');
+  mkdirSync(projectDir, { recursive: true });
+  const { sid } = await seedSession(win, { name: 'rename-probe', cwd: projectDir });
+  if (!sid) throw new Error('seedSession returned no sid');
+
+  await sleep(4000);
+  await waitForTerminalReady(win, sid, { timeout: 60000 });
+  await waitForXtermBuffer(win, /trust|claude|welcome|│|╭|>/i, { timeout: 30000 });
+  await dismissFirstRunModals(win);
+
+  // Drive a tiny chat so the JSONL gets written; renameSession's SDK bridge
+  // requires the session file to exist (otherwise it'd return no_jsonl and
+  // the title would be queued, never landing on disk during this case).
+  await sendToClaudeTui(win, RENAME_PROMPT);
+  await sleep(500);
+  await sendToClaudeTui(win, '\r');
+
+  // Wait for the JSONL to appear under <tempDir>/projects/<hash>/.
+  const projectsRoot = path.join(tempDir, 'projects');
+  let matchedJsonl = null;
+  {
+    const deadline = Date.now() + 90_000;
+    while (Date.now() < deadline && !matchedJsonl) {
+      if (existsSync(projectsRoot)) {
+        for (const dirName of readdirSync(projectsRoot)) {
+          let entries;
+          try { entries = readdirSync(path.join(projectsRoot, dirName)); } catch { continue; }
+          if (entries.includes(`${sid}.jsonl`)) {
+            matchedJsonl = path.join(projectsRoot, dirName, `${sid}.jsonl`);
+            break;
+          }
+        }
+      }
+      if (!matchedJsonl) await sleep(1000);
+    }
+  }
+  if (!matchedJsonl) {
+    throw new Error(`no <sid>.jsonl found under ${projectsRoot} within 90s for sid=${sid}`);
+  }
+
+  // Trigger the rename via the renderer store. The action is async — we
+  // await it so the IPC writeback round-trips before asserting on disk.
+  const renameOutcome = await win.evaluate(async ({ s, t }) => {
+    const store = window.__ccsmStore;
+    if (!store) return { ok: false, reason: 'no-store' };
+    const action = store.getState().renameSession;
+    if (typeof action !== 'function') return { ok: false, reason: 'no-action' };
+    try {
+      const ret = action(s, t);
+      // Action is async (returns a Promise); await it.
+      if (ret && typeof ret.then === 'function') await ret;
+      const after = store.getState().sessions.find((x) => x.id === s);
+      return { ok: true, localName: after?.name ?? null };
+    } catch (err) {
+      return { ok: false, reason: 'threw', message: String(err && err.message ? err.message : err) };
+    }
+  }, { s: sid, t: CUSTOM_TITLE });
+  if (!renameOutcome.ok) {
+    throw new Error(`renameSession failed: ${JSON.stringify(renameOutcome)}`);
+  }
+  if (renameOutcome.localName !== CUSTOM_TITLE) {
+    throw new Error(
+      `local store name not updated: expected "${CUSTOM_TITLE}", got "${renameOutcome.localName}"`
+    );
+  }
+
+  // Assert the JSONL gained the custom title. SDK writes asynchronously;
+  // poll the file for up to 10s.
+  let foundOnDisk = false;
+  let lastSnapshot = '';
+  {
+    const deadline = Date.now() + 10_000;
+    while (Date.now() < deadline) {
+      try {
+        const contents = readFileSync(matchedJsonl, 'utf8');
+        lastSnapshot = contents;
+        if (contents.includes(CUSTOM_TITLE)) {
+          foundOnDisk = true;
+          break;
+        }
+      } catch {
+        /* keep polling */
+      }
+      await sleep(500);
+    }
+  }
+  if (!foundOnDisk) {
+    const tail = lastSnapshot.split('\n').slice(-6).join('\n');
+    throw new Error(
+      `customTitle "${CUSTOM_TITLE}" not present in ${matchedJsonl} after rename. tail:\n${tail}`,
+    );
+  }
+}
+
+// ============================================================================
 // Case 1b: session-state-becomes-idle (#553 — JSONL tail-watcher signal)
 // ============================================================================
 //
@@ -1940,6 +2059,7 @@ async function caseCwdPickerOnlyOneOpen({ win }) {
 
 const CASE_REGISTRY = [
   { name: 'new-session-chat',            group: 'shared', run: caseNewSessionChat },
+  { name: 'session-rename-writes-jsonl', group: 'shared', run: caseSessionRenameWritesJsonl },
   { name: 'session-state-becomes-idle',  group: 'shared', run: caseSessionStateBecomesIdle },
   { name: 'notify-fires-on-idle',        group: 'shared', run: caseNotifyFiresOnIdle },
   { name: 'switch-session-keeps-chat',   group: 'shared', run: caseSwitchSessionKeepsChat },

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -529,7 +529,11 @@ function SessionRow({ session, active, selected, onSelect, normalGroups }: { ses
               <InlineRename
                 value={session.name}
                 onCommit={(next) => {
-                  renameSession(session.id, next);
+                  // renameSession is now async (optimistic update + SDK
+                  // writeback); we don't await — local name updates
+                  // synchronously and the JSONL writeback runs in the
+                  // background. Errors are logged, not toasted.
+                  void renameSession(session.id, next);
                   setRenaming(false);
                 }}
                 onCancel={() => setRenaming(false)}

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -197,7 +197,7 @@ type Actions = {
   focusGroup: (id: string | null) => void;
   createSession: (cwd: string | null | CreateSessionOptions) => void;
   importSession: (opts: { name: string; cwd: string; groupId: string; resumeSessionId: string; projectDir?: string }) => string;
-  renameSession: (id: string, name: string) => void;
+  renameSession: (id: string, name: string) => Promise<void>;
   /** Internal: apply an externally-sourced title (from the JSONL
    *  tail-watcher's `session:title` IPC). Skips if the row is missing or
    *  the name is already current. Underscore prefix marks this as not
@@ -556,10 +556,48 @@ export const useStore = create<State & Actions>((set, get) => ({
     }
   },
 
-  renameSession: (id, name) => {
+  renameSession: async (id, name) => {
+    // 1. Optimistic local update — UI renders the new name immediately
+    //    regardless of what the SDK writeback does. Capture the cwd off the
+    //    pre-update snapshot so we don't race a concurrent setSessionCwd.
+    const session = get().sessions.find((x) => x.id === id);
     set((s) => ({
       sessions: s.sessions.map((x) => (x.id === id ? { ...x, name } : x))
     }));
+
+    // 2. Forward to the main-process SDK bridge so the JSONL gets a
+    //    `customTitle` frame. Renderer-side bridge is only present in the
+    //    real Electron build; vitest jsdom runs may not have it injected.
+    const bridge =
+      typeof window !== 'undefined'
+        ? (window as unknown as { ccsmSessionTitles?: {
+            rename: (sid: string, title: string, dir?: string) =>
+              Promise<{ ok: true } | { ok: false; reason: 'no_jsonl' | 'sdk_threw'; message?: string }>;
+            enqueuePending: (sid: string, title: string, dir?: string) => Promise<void>;
+          } }).ccsmSessionTitles
+        : undefined;
+    if (!bridge) return;
+
+    const dir = session?.cwd;
+    try {
+      const result = await bridge.rename(id, name, dir);
+      if (result.ok) return;
+      if (result.reason === 'no_jsonl') {
+        // Pre-first-message rename. Stash so PR3's watcher can replay once
+        // the JSONL exists. Local name already updated above; SDK will catch
+        // up on flush.
+        await bridge.enqueuePending(id, name, dir);
+        return;
+      }
+      // sdk_threw — best-effort. Local name stays; we just log.
+      console.warn(
+        `[store] renameSession SDK writeback failed for ${id}: ${result.message ?? '(no message)'}`
+      );
+    } catch (err) {
+      // IPC channel itself failed — extremely unlikely, but don't surface a
+      // toast (per task spec "do not toast SDK errors").
+      console.warn(`[store] renameSession IPC failed for ${id}:`, err);
+    }
   },
 
   _applyExternalTitle: (sid, title) => {

--- a/tests/store-rename-session.test.ts
+++ b/tests/store-rename-session.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { useStore } from '../src/stores/store';
+import type { Session } from '../src/types';
+
+// Covers the three outcomes of `renameSession` SDK writeback wired in PR2:
+//   1. ok          → local name updated, no enqueue
+//   2. no_jsonl    → local name updated, enqueuePending called
+//   3. sdk_threw   → local name updated, enqueuePending NOT called, console.warn
+//
+// `window.ccsmSessionTitles` is the IPC bridge created in `electron/preload.ts`;
+// jsdom doesn't expose it by default. We install a mock per case and tear it
+// down after each test so other tests aren't polluted.
+
+type RenameResult =
+  | { ok: true }
+  | { ok: false; reason: 'no_jsonl' | 'sdk_threw'; message?: string };
+
+function installBridge(rename: (sid: string, title: string, dir?: string) => Promise<RenameResult>) {
+  const enqueuePending = vi.fn(async () => {});
+  const flushPending = vi.fn(async () => {});
+  const get = vi.fn(async () => ({ summary: null, mtime: null }));
+  const listForProject = vi.fn(async () => []);
+  (window as unknown as { ccsmSessionTitles: unknown }).ccsmSessionTitles = {
+    rename: vi.fn(rename),
+    enqueuePending,
+    flushPending,
+    get,
+    listForProject,
+  };
+  return { enqueuePending, flushPending };
+}
+
+function seedSession(id: string, name: string, cwd: string): void {
+  const session: Session = {
+    id,
+    name,
+    state: 'idle',
+    cwd,
+    model: '',
+    groupId: 'g1',
+    agentType: 'claude-code',
+  };
+  useStore.setState((s) => ({ sessions: [...s.sessions, session] }));
+}
+
+describe('store.renameSession (SDK writeback)', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Wipe sessions from prior cases so id collisions can't pollute.
+    useStore.setState({ sessions: [] });
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { ccsmSessionTitles?: unknown }).ccsmSessionTitles;
+    warnSpy.mockRestore();
+    useStore.setState({ sessions: [] });
+  });
+
+  it('ok: local name updated, no enqueue', async () => {
+    const { enqueuePending } = installBridge(async () => ({ ok: true }));
+    seedSession('sid-ok', 'old', '/tmp/proj-ok');
+
+    await useStore.getState().renameSession('sid-ok', 'fresh-title');
+
+    const after = useStore.getState().sessions.find((s) => s.id === 'sid-ok');
+    expect(after?.name).toBe('fresh-title');
+    expect(enqueuePending).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('no_jsonl: local name updated, enqueuePending called with cwd', async () => {
+    const { enqueuePending } = installBridge(async () => ({
+      ok: false,
+      reason: 'no_jsonl',
+    }));
+    seedSession('sid-pending', 'old', '/tmp/proj-pending');
+
+    await useStore.getState().renameSession('sid-pending', 'queued-title');
+
+    const after = useStore.getState().sessions.find((s) => s.id === 'sid-pending');
+    expect(after?.name).toBe('queued-title');
+    expect(enqueuePending).toHaveBeenCalledTimes(1);
+    expect(enqueuePending).toHaveBeenCalledWith(
+      'sid-pending',
+      'queued-title',
+      '/tmp/proj-pending'
+    );
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('sdk_threw: local name updated, no enqueue, warn logged', async () => {
+    const { enqueuePending } = installBridge(async () => ({
+      ok: false,
+      reason: 'sdk_threw',
+      message: 'EACCES',
+    }));
+    seedSession('sid-threw', 'old', '/tmp/proj-threw');
+
+    await useStore.getState().renameSession('sid-threw', 'attempted');
+
+    const after = useStore.getState().sessions.find((s) => s.id === 'sid-threw');
+    expect(after?.name).toBe('attempted');
+    expect(enqueuePending).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0][0])).toContain('sid-threw');
+  });
+
+  it('local update happens even before the SDK promise resolves (optimistic)', async () => {
+    let releaseSdk: (r: RenameResult) => void = () => {};
+    const sdkPromise = new Promise<RenameResult>((resolve) => {
+      releaseSdk = resolve;
+    });
+    installBridge(() => sdkPromise);
+    seedSession('sid-opt', 'old', '/tmp/proj-opt');
+
+    const renamePromise = useStore.getState().renameSession('sid-opt', 'instant');
+    // Synchronously after the call returns its first microtask we should
+    // see the new name; the SDK promise hasn't resolved yet.
+    await Promise.resolve();
+    expect(
+      useStore.getState().sessions.find((s) => s.id === 'sid-opt')?.name
+    ).toBe('instant');
+
+    releaseSdk({ ok: true });
+    await renamePromise;
+  });
+
+  it('no bridge available: local update still applies (test/jsdom path)', async () => {
+    // Ensure no bridge is installed.
+    delete (window as unknown as { ccsmSessionTitles?: unknown }).ccsmSessionTitles;
+    seedSession('sid-no-bridge', 'old', '/tmp/proj-nb');
+
+    await useStore.getState().renameSession('sid-no-bridge', 'local-only');
+
+    expect(
+      useStore.getState().sessions.find((s) => s.id === 'sid-no-bridge')?.name
+    ).toBe('local-only');
+  });
+});


### PR DESCRIPTION
PR2 of 4 for session-name SDK sync (plan: #586, PR1: #501).

## Scope

- Store `renameSession` is now async; calls SDK bridge from PR1 to writeback to JSONL
- Pre-first-message renames enqueue locally; flush trigger lives in PR3 (watcher hook)
- 2 new IPC channels: `sessionTitles:enqueuePending`, `sessionTitles:flushPending`
- Sidebar fires the now-async action with `void` (no visible UX change; optimistic update is synchronous)

## Substrate fix (out-of-spec but required)

PR1's `electron/sessionTitles` was unreachable in production: `@anthropic-ai/claude-agent-sdk` is published ESM-only (`sdk.mjs`), but the Electron main bundle is CommonJS. tsc rewrites the static `import` into `require()`, which Node refuses with `ERR_REQUIRE_ESM` and the entire app fails to boot. Verified by running the harness against a fresh build:

```
[err] App threw an error during load
[err] Error [ERR_REQUIRE_ESM]: require() of ES Module ...sdk.mjs not supported.
[err]   at Object.<anonymous> (.../dist/electron/sessionTitles/index.js:44:28)
```

Fix: lazy-load the SDK via `new Function('spec', 'return import(spec)')` so the dynamic import survives tsc's CommonJS rewrite. PR1 unit tests updated to inject SDK fakes via a new `__setSdkForTests` test seam since `vi.mock` can't reach the shim. Without this fix PR2 cannot boot the app, let alone exercise the renameSession path.

## Tests

- **Unit** (`tests/store-rename-session.test.ts`, 5 cases): ok / no_jsonl / sdk_threw / optimistic-update / no-bridge-fallback
- **Unit** (`electron/sessionTitles/__tests__/index.test.ts`, 9 PR1 cases re-pass under the new `__setSdkForTests`)
- **E2E** (`scripts/harness-real-cli.mjs --only=session-rename-writes-jsonl`): seeds a real-CLI session, sends a prompt, calls `renameSession` from the renderer, and asserts the custom title literal lands in the on-disk JSONL within 10s. PASS in 18.7s on this branch.
- Sibling case `--only=new-session-chat` also re-verified PASS (proves the substrate fix didn't regress unrelated paths).
- `npm test`: 305 pass / 3 fail (3 pre-existing better-sqlite3 ABI failures on Node 24, NODE_MODULE_VERSION 130 vs 137 — flagged by task spec as expected).

## Anti-patterns confirmed avoided

- No `userRenamed` flag on Session
- No watcher edits (PR3's territory)
- No flush trigger anywhere (PR3 owns it)
- IPC surface only grew by the 2 specified channels
- Renderer never imports the SDK directly
- No SDK error toasts
- No backfill / `listProjectSummaries` consumers added
- No Session type field changes

## Out of scope (later PRs)

- PR3: sessionWatcher emits title-changed + triggers flushPending
- PR4: launch-time backfill via listProjectSummaries

Closes #591.