### PR TITLE
feat(ui): surface claude crash + clean-exit distinction (#594)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,6 +78,7 @@ export default function App() {
   const selectSession = useStore((s) => s.selectSession);
   const focusGroup = useStore((s) => s.focusGroup);
   const applyExternalTitle = useStore((s) => s._applyExternalTitle);
+  const applyPtyExit = useStore((s) => s._applyPtyExit);
   const moveSession = useStore((s) => s.moveSession);
   const createSession = useStore((s) => s.createSession);
   const toggleSidebar = useStore((s) => s.toggleSidebar);
@@ -147,6 +148,28 @@ export default function App() {
       }
     });
   }, [selectSession]);
+
+  // Pipe `pty:exit` events into the store UNCONDITIONALLY (not filtered
+  // by activeSid). TerminalPane has its own filtered listener that drives
+  // the active-pane red overlay; this second listener is what surfaces
+  // background-session deaths in the sidebar (red dot via
+  // `disconnectedSessions[sid]`). Both coexist — different concerns, no
+  // duplication risk because the store action is idempotent on payload.
+  useEffect(() => {
+    const pty = (window as unknown as {
+      ccsmPty?: {
+        onExit?: (cb: (e: { sessionId: string; code?: number | null; signal?: string | number | null }) => void) => () => void;
+      };
+    }).ccsmPty;
+    if (!pty?.onExit) return;
+    return pty.onExit((evt) => {
+      if (!evt || typeof evt.sessionId !== 'string' || evt.sessionId.length === 0) return;
+      applyPtyExit(evt.sessionId, {
+        code: evt.code ?? null,
+        signal: evt.signal ?? null,
+      });
+    });
+  }, [applyPtyExit]);
 
   // Pipe `session:title` IPC events from main into the store. The watcher
   // emits when the SDK-derived `summary` changes for a session; the store

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -410,6 +410,14 @@ function SessionRow({ session, active, selected, onSelect, normalGroups }: { ses
   // sid — sessions that have never been spawned in this app launch will
   // show no dot, matching the pre-watcher behaviour.
   const liveState = useSessionLiveState(session.id);
+  // Per-session pty disconnect classification — populated by the app-boot
+  // unconditional `pty:exit` listener (App.tsx). We surface the red dot
+  // ONLY for `crashed` (signal or non-zero exit) — `clean` exits are
+  // user-intentional (typed `/exit`) and shouldn't grab attention. The
+  // dot clears when the user retries (TerminalPane → `_clearPtyExit`).
+  const crashed = useStore(
+    (s) => s.disconnectedSessions[session.id]?.kind === 'crashed'
+  );
   // Perf: receive `normalGroups` as a prop computed once in the parent
   // <Sidebar>, rather than calling `s.groups.filter(...)` per row per render.
   const groups = normalGroups;
@@ -556,6 +564,23 @@ function SessionRow({ session, active, selected, onSelect, normalGroups }: { ses
           {!active && liveState && (
             <span className="sidebar-rail-cell sidebar-rail-cell--nested shrink-0">
               <SessionStateDot state={liveState} t={t} />
+            </span>
+          )}
+          {crashed && (
+            // Crash indicator — sits to the right of the existing
+            // state pip (separate rail cell so it doesn't displace
+            // the live-state dot when both apply, e.g. a previously-
+            // running session that just died). Reuses the canonical
+            // `bg-state-error` token (no new red shade introduced).
+            <span
+              className="sidebar-rail-cell sidebar-rail-cell--nested shrink-0"
+              data-session-crashed
+              title={t('sidebar.sessionCrashed')}
+            >
+              <span
+                aria-label={t('sidebar.sessionCrashed')}
+                className="shrink-0 inline-block w-1.5 h-1.5 rounded-full bg-state-error"
+              />
             </span>
           )}
         </li>

--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -7,6 +7,7 @@ import { Unicode11Addon } from '@xterm/addon-unicode11';
 import { CanvasAddon } from '@xterm/addon-canvas';
 import '@xterm/xterm/css/xterm.css';
 import { useTranslation } from '../i18n/useTranslation';
+import { useStore } from '../stores/store';
 
 // TerminalPane mounts a singleton xterm.js Terminal that we attach/detach
 // against per-session PTYs over IPC (window.ccsmPty). This is the React
@@ -53,6 +54,13 @@ type Props = {
 type State =
   | { kind: 'attaching' }
   | { kind: 'ready' }
+  // `exit` is the new shape — distinguishes user-intentional clean exit
+  // (no signal, code 0) from a crash. The former renders a neutral
+  // overlay + "claude exited" copy; the latter renders the red overlay
+  // + "claude crashed... not a ccsm bug" copy. Both show Retry. The
+  // legacy `error` shape stays for spawn/attach failures (spawn IPC
+  // returned !ok, ccsmPty unavailable, etc.) which are NOT pty exits.
+  | { kind: 'exit'; exitKind: 'clean' | 'crashed'; detail: string }
   | { kind: 'error'; message: string };
 
 // Module-scope singleton state. Initialised lazily on first mount so we
@@ -193,6 +201,15 @@ export function TerminalPane({ sessionId, cwd: _cwd }: Props) {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const [state, setState] = useState<State>({ kind: 'attaching' });
   const { t } = useTranslation();
+  // Store action — clear the disconnect entry on respawn success so the
+  // sidebar red dot disappears the moment the pty is back. Pulled via
+  // selector so this component re-renders only when the function ref
+  // changes (it doesn't, in practice — zustand actions are stable). We
+  // route through a ref so the attach effect doesn't need to depend on
+  // it (and re-run unnecessarily).
+  const clearPtyExit = useStore((s) => s._clearPtyExit);
+  const clearPtyExitRef = useRef(clearPtyExit);
+  clearPtyExitRef.current = clearPtyExit;
   // Tracks the sessionId we're currently attaching for so a stale resolve
   // from a previous session can't clobber the current one when the user
   // switches quickly.
@@ -359,6 +376,11 @@ export function TerminalPane({ sessionId, cwd: _cwd }: Props) {
         }
 
         if (!cancelled) setState({ kind: 'ready' });
+        // Successful (re-)attach means whatever pty is running for this
+        // sid is healthy — drop any stale disconnect entry so the
+        // sidebar red dot clears and a future crash starts from a clean
+        // slate. Idempotent if no entry exists.
+        clearPtyExitRef.current(sessionId);
       } catch (err) {
         if (cancelled || requestedSidRef.current !== sessionId) return;
         const message = err instanceof Error ? err.message : String(err);
@@ -372,26 +394,30 @@ export function TerminalPane({ sessionId, cwd: _cwd }: Props) {
     // attachNonce is intentional: bumping it re-runs the attach for Retry.
   }, [sessionId, attachNonce]);
 
-  // pty:exit subscription for the active session → flip to error state.
-  // `t` is intentionally excluded from deps: changing language while a
-  // session is alive should not re-subscribe; the localized string is
-  // resolved at exit time via a ref so it always reflects the current
-  // language.
-  const tRef = useRef(t);
-  tRef.current = t;
+  // pty:exit subscription for the active session → flip to exit state
+  // with a classification (clean vs crashed). The classification rule
+  // mirrors the store's `_applyPtyExit` logic — kept in lockstep
+  // intentionally so the active-pane overlay and the sidebar red-dot
+  // signal are always consistent. `t` is intentionally excluded from
+  // deps: changing language while a session is alive should not re-
+  // subscribe; localized strings are resolved at render time.
   useEffect(() => {
     const pty = window.ccsmPty;
     if (!pty?.onExit) return;
     const unsubscribe = pty.onExit(
       (evt: { sessionId: string; code?: number | null; signal?: string | number | null }) => {
         if (evt.sessionId !== activeSid) return;
+        const signal = evt.signal ?? null;
+        const code = evt.code ?? null;
+        const exitKind: 'clean' | 'crashed' =
+          signal == null && code === 0 ? 'clean' : 'crashed';
         const detail =
-          evt.signal != null
-            ? `signal ${evt.signal}`
-            : evt.code != null
-              ? `exit code ${evt.code}`
-              : 'unknown reason';
-        setState({ kind: 'error', message: `${tRef.current('terminal.exited')} (${detail})` });
+          signal != null
+            ? `signal ${signal}`
+            : code != null
+              ? `exit code ${code}`
+              : 'unknown';
+        setState({ kind: 'exit', exitKind, detail });
       },
     );
     return () => {
@@ -428,6 +454,41 @@ export function TerminalPane({ sessionId, cwd: _cwd }: Props) {
             className="px-3 py-1 rounded border border-neutral-700 text-neutral-200 hover:bg-neutral-800 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-neutral-400"
           >
             Retry
+          </button>
+        </div>
+      )}
+      {state.kind === 'exit' && (
+        // Two-tone overlay: clean exits get a neutral/dim background
+        // (user typed /exit on purpose, no alarm); crashed exits keep
+        // the red treatment so the user notices. Copy is locked in
+        // i18n — `terminal.exitedClean` reassures, `terminal.exitedCrash`
+        // explicitly disclaims ccsm involvement and points at the
+        // on-disk transcript so the user knows their work is safe.
+        <div
+          data-pty-exit-kind={state.exitKind}
+          className={
+            state.exitKind === 'crashed'
+              ? 'absolute inset-0 flex flex-col items-center justify-center gap-3 text-sm bg-black/80'
+              : 'absolute inset-0 flex flex-col items-center justify-center gap-3 text-sm bg-neutral-900/85'
+          }
+        >
+          <div
+            className={
+              state.exitKind === 'crashed'
+                ? 'text-state-error-text max-w-md text-center break-words px-4'
+                : 'text-neutral-300 max-w-md text-center break-words px-4'
+            }
+          >
+            {state.exitKind === 'crashed'
+              ? t('terminal.exitedCrash', { detail: state.detail })
+              : t('terminal.exitedClean')}
+          </div>
+          <button
+            type="button"
+            onClick={onRetry}
+            className="px-3 py-1 rounded border border-neutral-700 text-neutral-200 hover:bg-neutral-800 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-neutral-400"
+          >
+            {t('terminal.exitedRetry')}
           </button>
         </div>
       )}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -73,6 +73,7 @@ const en = {
     sessionStateIdle: 'Waiting for your reply',
     sessionStateRunning: 'Working',
     sessionStateRequiresAction: 'Needs your decision',
+    sessionCrashed: 'claude process crashed in this session',
     searchAria: 'Search',
     expandSidebarTooltip: 'Expand sidebar  Ctrl+B',
     expandSidebarAria: 'Expand sidebar',
@@ -284,7 +285,9 @@ const en = {
     starting: 'Starting…',
     spawnFailed: 'Failed to start terminal',
     retryButton: 'Retry',
-    exited: 'Terminal exited unexpectedly'
+    exitedClean: 'claude exited (you typed /exit or claude returned). Click Retry to start a new conversation in this session.',
+    exitedCrash: 'claude crashed ({{detail}}). This is not a ccsm bug — the underlying claude CLI exited unexpectedly. Your conversation is saved on disk; click Retry to resume.',
+    exitedRetry: 'Retry'
   },
   chat: {
     cwdChipNoneLabel: '(none)',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -69,6 +69,7 @@ const zh: EnCatalog = {
     sessionStateIdle: '等待你的回复',
     sessionStateRunning: '正在处理',
     sessionStateRequiresAction: '需要你的决定',
+    sessionCrashed: '本 session 的 claude 进程崩溃了',
     searchAria: '搜索',
     expandSidebarTooltip: '展开侧边栏  Ctrl+B',
     expandSidebarAria: '展开侧边栏',
@@ -273,7 +274,9 @@ const zh: EnCatalog = {
     starting: '启动中…',
     spawnFailed: '终端启动失败',
     retryButton: '重试',
-    exited: '终端意外退出'
+    exitedClean: 'claude 已退出（你输入了 /exit 或 claude 主动结束）。点 Retry 在本 session 开新对话。',
+    exitedCrash: 'claude 异常退出（{{detail}}）。这不是 ccsm 的问题，是底层 claude CLI 自己挂了。对话已保存到磁盘，点 Retry 恢复。',
+    exitedRetry: '重试'
   },
   chat: {
     cwdChipNoneLabel: '（无）',

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -144,6 +144,28 @@ type State = {
    */
   openPopoverId: string | null;
   /**
+   * Per-session pty exit classification. Populated by the app-boot
+   * unconditional `pty:exit` listener (App.tsx) so background-session
+   * deaths surface in the sidebar even when the user is focused on
+   * another session — previously this was invisible until the user
+   * clicked the dead session.
+   *
+   * `clean` → user typed `/exit` (or claude returned naturally) :
+   *   `signal == null && code === 0`. NO red dot in sidebar — this
+   *   is a user-intentional exit.
+   * `crashed` → anything else (signal, non-zero code, unknown). Surfaces
+   *   the red dot in the sidebar row and the red overlay in TerminalPane.
+   *
+   * Cleared when the renderer respawns the pty for that sid (TerminalPane
+   * Retry path → `_clearPtyExit`).
+   *
+   * NOT persisted — pty state is process-bound; re-derive on next boot.
+   */
+  disconnectedSessions: Record<
+    string,
+    { kind: 'clean' | 'crashed'; code: number | null; signal: string | number | null; at: number }
+  >;
+  /**
    * Most-recent cwd from the ccsm-owned `userCwds` LRU (head of the list),
    * cached in renderer state so `createSession` can read it synchronously
    * to default a new session's cwd. Seeded at boot from
@@ -205,6 +227,13 @@ type Actions = {
    *  src/App.tsx. SDK customTitle precedence guarantees user renames win
    *  over SDK auto-summaries, so no userRenamed flag is needed here. */
   _applyExternalTitle: (sid: string, title: string) => void;
+  /** Internal: classify and record a pty:exit event for `sid`. Decides
+   *  clean vs crashed using `signal == null && code === 0`. Idempotent —
+   *  calling twice with the same payload just overwrites the entry. */
+  _applyPtyExit: (sid: string, payload: { code: number | null; signal: string | number | null }) => void;
+  /** Internal: drop the disconnect entry for `sid`. Called from TerminalPane
+   *  when an attach/spawn succeeds so the red dot clears on respawn. */
+  _clearPtyExit: (sid: string) => void;
   deleteSession: (id: string) => SessionSnapshot | null;
   /** Re-insert a session previously removed by `deleteSession`. Restores the
    *  row at its original index, plus messages, draft, and runtime flags. */
@@ -442,6 +471,7 @@ export const useStore = create<State & Actions>((set, get) => ({
   installerCorrupt: false,
   openPopoverId: null,
   lastUsedCwd: null,
+  disconnectedSessions: {},
 
   selectSession: (id) => {
     set((s) => ({
@@ -608,6 +638,29 @@ export const useStore = create<State & Actions>((set, get) => ({
       const next = s.sessions.slice();
       next[idx] = { ...next[idx], name: title };
       return { ...s, sessions: next };
+    });
+  },
+
+  _applyPtyExit: (sid, payload) => {
+    // Clean = no signal AND exit code zero. Anything else (signal,
+    // non-zero code, or both null) is treated as a crash so the user
+    // gets the "this is not ccsm's fault" overlay + sidebar red dot.
+    const kind: 'clean' | 'crashed' =
+      payload.signal == null && payload.code === 0 ? 'clean' : 'crashed';
+    set((s) => ({
+      disconnectedSessions: {
+        ...s.disconnectedSessions,
+        [sid]: { kind, code: payload.code, signal: payload.signal, at: Date.now() },
+      },
+    }));
+  },
+
+  _clearPtyExit: (sid) => {
+    set((s) => {
+      if (!s.disconnectedSessions[sid]) return s;
+      const next = { ...s.disconnectedSessions };
+      delete next[sid];
+      return { disconnectedSessions: next };
     });
   },
 

--- a/tests/store-pty-exit.test.ts
+++ b/tests/store-pty-exit.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useStore } from '../src/stores/store';
+
+// Covers the renderer-side classification rule for `pty:exit` events.
+// Decision boundary is intentionally simple: signal == null && code === 0
+// → clean (user typed `/exit` or claude returned). Anything else
+// (signal present, non-zero code, both null) → crashed.
+//
+// `_clearPtyExit` is the cleanup hook called from TerminalPane when an
+// attach/spawn succeeds — it must drop the entry without touching
+// other sids.
+
+describe('store._applyPtyExit / _clearPtyExit', () => {
+  beforeEach(() => {
+    useStore.setState({ disconnectedSessions: {} });
+  });
+
+  it('classifies clean exit (no signal, code 0)', () => {
+    useStore.getState()._applyPtyExit('s-clean', { code: 0, signal: null });
+    const entry = useStore.getState().disconnectedSessions['s-clean'];
+    expect(entry?.kind).toBe('clean');
+    expect(entry?.code).toBe(0);
+    expect(entry?.signal).toBeNull();
+    expect(typeof entry?.at).toBe('number');
+  });
+
+  it('classifies non-zero exit code as crashed', () => {
+    useStore.getState()._applyPtyExit('s-code', { code: 1, signal: null });
+    expect(useStore.getState().disconnectedSessions['s-code']?.kind).toBe('crashed');
+  });
+
+  it('classifies signal exit as crashed (string signal)', () => {
+    useStore.getState()._applyPtyExit('s-sig', { code: null, signal: 'SIGTERM' });
+    const e = useStore.getState().disconnectedSessions['s-sig'];
+    expect(e?.kind).toBe('crashed');
+    expect(e?.signal).toBe('SIGTERM');
+  });
+
+  it('classifies signal exit as crashed (numeric signal)', () => {
+    useStore.getState()._applyPtyExit('s-sig-n', { code: null, signal: 15 });
+    expect(useStore.getState().disconnectedSessions['s-sig-n']?.kind).toBe('crashed');
+  });
+
+  it('classifies all-null payload as crashed (unknown reason)', () => {
+    useStore.getState()._applyPtyExit('s-unknown', { code: null, signal: null });
+    expect(useStore.getState().disconnectedSessions['s-unknown']?.kind).toBe('crashed');
+  });
+
+  it('overwrites existing entry on second exit for same sid', () => {
+    useStore.getState()._applyPtyExit('s-twice', { code: 0, signal: null });
+    expect(useStore.getState().disconnectedSessions['s-twice']?.kind).toBe('clean');
+    useStore.getState()._applyPtyExit('s-twice', { code: 137, signal: null });
+    expect(useStore.getState().disconnectedSessions['s-twice']?.kind).toBe('crashed');
+    expect(useStore.getState().disconnectedSessions['s-twice']?.code).toBe(137);
+  });
+
+  it('_clearPtyExit drops only the named sid', () => {
+    useStore.getState()._applyPtyExit('s-a', { code: 1, signal: null });
+    useStore.getState()._applyPtyExit('s-b', { code: 0, signal: null });
+    useStore.getState()._clearPtyExit('s-a');
+    expect(useStore.getState().disconnectedSessions['s-a']).toBeUndefined();
+    expect(useStore.getState().disconnectedSessions['s-b']?.kind).toBe('clean');
+  });
+
+  it('_clearPtyExit on unknown sid is a no-op (returns same map ref)', () => {
+    useStore.getState()._applyPtyExit('s-keep', { code: 1, signal: null });
+    const before = useStore.getState().disconnectedSessions;
+    useStore.getState()._clearPtyExit('s-nope');
+    const after = useStore.getState().disconnectedSessions;
+    // Same object reference — no spurious render churn for unrelated sids.
+    expect(after).toBe(before);
+  });
+});


### PR DESCRIPTION
## Summary

Two visibility fixes for claude PTY exits.

- **Background-session deaths now show a red dot in the sidebar** (previously invisible until user switched to that session). Wired via a new app-boot unconditional `pty:exit` listener in `App.tsx` that pipes events into a renderer-side `disconnectedSessions` classifier on the store. The existing TerminalPane filtered listener stays put for the active-pane red overlay (different concern, both coexist).
- **Clean `/exit` (code 0) now distinguished from crash with appropriate copy.** Classification rule (mirrored in store + TerminalPane): `signal == null && code === 0` → clean; anything else → crashed. Clean exits get a neutral overlay; crashes keep the red treatment.
- All copy explicitly says "claude" (never generic "session"/"terminal"); reassures conversation is saved on disk; crash copy explicitly notes "this is not a ccsm bug".

## Files changed

| File | Change |
|---|---|
| `src/stores/store.ts` | Add `disconnectedSessions` state + `_applyPtyExit` / `_clearPtyExit` actions |
| `src/App.tsx` | Subscribe unconditionally to `ccsmPty.onExit` → `_applyPtyExit` |
| `src/components/TerminalPane.tsx` | New `exit` state shape with `clean`/`crashed` kinds; branched overlay style; clear disconnect entry on respawn success |
| `src/components/Sidebar.tsx` | Render red dot (using existing `bg-state-error` token) when `disconnectedSessions[sid]?.kind === 'crashed'` |
| `src/i18n/locales/en.ts`, `zh.ts` | Replace `terminal.exited` with `exitedClean`/`exitedCrash`/`exitedRetry` + `sidebar.sessionCrashed` |
| `tests/store-pty-exit.test.ts` | 8 unit tests for classification + clear |

## Tests

- `npx vitest run tests/store-pty-exit.test.ts` — 8/8 pass (clean / non-zero code / string signal / numeric signal / all-null / overwrite / clear-only-named / no-op-on-unknown)
- `npx tsc --noEmit` — clean
- `npm run build` — clean (3 standard webpack size warnings, unrelated)
- `node -e \"require('./dist/electron/sessionTitles/index.js')\"` — exit 0 (PR1 ESM/CJS regression check)
- `npm test` — 314/321 pass. The 7 failing tests are pre-existing and unrelated to this PR:
  - 3 × `db-hardening.test.ts` — known better-sqlite3 ABI failures (per task spec, OK)
  - 4 × `electron/sessionWatcher/__tests__/titleChanged.test.ts` — verified flaky on baseline working tip (b9bc0ab) via `git stash` + rerun: same 4/5 fail without my changes. Pre-existing env issue.

## Manual smoke

E2E harness extension was not feasible without significantly broader scaffolding (harness-real-cli does not currently expose pty.kill); manual smoke required per acceptance #7. **NOT executed in this pool worker context** (no GUI Electron session available to me here). The three scenarios to verify before merge:

1. **Active session crash:** kill claude in active session → red overlay shows new "claude crashed... not a ccsm bug" copy → click Retry → resumes
2. **Background session crash:** open 2 sessions, kill the non-active one → red dot appears in sidebar → click it → red overlay → Retry → resumes → red dot clears
3. **Clean exit:** type `/exit` in claude → neutral overlay shows "claude exited" copy (NO red dot in sidebar)

Reviewer is requested to either run these manually OR dispatch a manual-smoke fixer worker before merge per the e2e-before-merge rule.

## Anti-patterns avoided
- No `pidAlive` field on Session type (state lives on store map)
- No toasts
- No auto-restart of background dead sessions (silent recovery on attach is intentional)
- No new red shade — reused `bg-state-error`
- ptyHost behavior unchanged (renderer-side classification only)
- TerminalPane filtered listener preserved (unchanged behavior, second unconditional listener added in App.tsx)
- All user-visible copy uses literal word "claude"
- i18n strings used verbatim from locked design (en + zh)

Closes #594

## Test plan
- [ ] Reviewer manually verifies the 3 smoke scenarios above OR dispatches a smoke-test worker
- [ ] Reviewer confirms red dot uses canonical `bg-state-error` token (no new color)
- [ ] Reviewer confirms zh strings render correctly when language=zh

🤖 Generated with [Claude Code](https://claude.com/claude-code)