### PR TITLE
feat(store): backfill session titles on launch + live-tail e2e (#593)

### DIFF
--- a/electron/sessionWatcher/__tests__/titleChanged.test.ts
+++ b/electron/sessionWatcher/__tests__/titleChanged.test.ts
@@ -1,7 +1,11 @@
 // Unit tests for the SessionWatcher's `title-changed` event path.
 //
 // Strategy:
-//   * Mock the SDK so we control what `getSessionInfo` returns per call.
+//   * Inject SDK fakes via `__setSdkForTests` on the title bridge — the
+//     production loader uses a `new Function('return import(spec)')` shim
+//     to dodge tsc's CommonJS rewrite of dynamic imports, which also
+//     dodges `vi.mock`. The bridge exposes `__setSdkForTests` exactly so
+//     unit tests can wire fakes.
 //   * Drive synthetic JSONL writes via a tmp dir + `__createForTest()` so
 //     we get a fresh watcher instance per test (no shared module state).
 //   * Assert the event fires once per change, not on no-op identical-title
@@ -12,27 +16,22 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-// Mock the SDK module that `electron/sessionTitles/index.ts` imports.
-// `getSessionInfo` is the only call exercised by the title path. We control
-// the returned `summary` per call via the `summaryReturns` array, popping
-// the next value on each invocation.
+// We control what `getSessionInfo` returns per call via the
+// `summaryReturns` array, popping the next value on each invocation.
 const summaryReturns: Array<{ summary: string | null; lastModified?: number }> = [];
-vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
-  getSessionInfo: vi.fn(async () => {
-    if (summaryReturns.length === 0) return null;
-    return summaryReturns.shift() ?? null;
-  }),
-  // Unused by these tests, stubbed so the import resolves.
-  renameSession: vi.fn(),
-  listSessions: vi.fn(),
-}));
+const renameSessionMock = vi.fn();
+const listSessionsMock = vi.fn();
+const getSessionInfoMock = vi.fn(async () => {
+  if (summaryReturns.length === 0) return null;
+  return summaryReturns.shift() ?? null;
+});
 
 import { __createForTest, type TitleChangedEvent } from '../index';
 import {
   __resetForTests as __resetTitleBridge,
+  __setSdkForTests as __setTitleBridgeSdk,
   enqueuePendingRename,
 } from '../../sessionTitles';
-import { renameSession as renameSessionMock } from '@anthropic-ai/claude-agent-sdk';
 
 let tmpRoot: string;
 
@@ -63,18 +62,38 @@ async function waitForCondition(
 }
 
 describe('SessionWatcher title-changed', () => {
+  // `__resetTitleBridge` clears `sdkPromise`, which would otherwise let the
+  // real loader take over on the next call. Re-install the fakes after every
+  // reset (initial setup + any in-test reset).
+  function installSdkFakes(): void {
+    __setTitleBridgeSdk({
+      getSessionInfo: getSessionInfoMock,
+      renameSession: renameSessionMock,
+      listSessions: listSessionsMock,
+    } as Parameters<typeof __setTitleBridgeSdk>[0]);
+  }
+
+  // Wrap reset+re-install for in-test cache flushes.
+  function flushBridgeCache(): void {
+    __resetTitleBridge();
+    installSdkFakes();
+  }
+
   beforeEach(() => {
     summaryReturns.length = 0;
     // Bridge has its own 2s TTL cache + per-sid op chain; reset between
     // tests so cached `null` summaries from one test don't shadow the next.
     __resetTitleBridge();
-    (renameSessionMock as unknown as ReturnType<typeof vi.fn>).mockClear();
+    installSdkFakes();
+    renameSessionMock.mockClear();
+    listSessionsMock.mockClear();
   });
 
   afterEach(() => {
     if (tmpRoot && fs.existsSync(tmpRoot)) {
       fs.rmSync(tmpRoot, { recursive: true, force: true });
     }
+    __setTitleBridgeSdk(null);
   });
 
   it('emits title-changed once when SDK reports a new summary', async () => {
@@ -113,7 +132,7 @@ describe('SessionWatcher title-changed', () => {
     await waitForCondition(() => events.length >= 1);
 
     // Second tick with the same SDK-reported summary — must NOT fire.
-    __resetTitleBridge();
+    flushBridgeCache();
     summaryReturns.push({ summary: 'same title' });
     appendFrame(jsonlPath, 'second');
 
@@ -138,7 +157,7 @@ describe('SessionWatcher title-changed', () => {
     appendFrame(jsonlPath, 'first');
     await waitForCondition(() => events.length >= 1);
 
-    __resetTitleBridge();
+    flushBridgeCache();
     summaryReturns.push({ summary: 'title v2' });
     appendFrame(jsonlPath, 'second');
     await waitForCondition(() => events.length >= 2);
@@ -161,7 +180,7 @@ describe('SessionWatcher title-changed', () => {
     fs.writeFileSync(jsonlPath, '');
     watcher.startWatching('sid-D', jsonlPath);
     appendFrame(jsonlPath, 'first');
-    __resetTitleBridge();
+    flushBridgeCache();
     appendFrame(jsonlPath, 'second');
 
     await new Promise((r) => setTimeout(r, 300));
@@ -173,7 +192,7 @@ describe('SessionWatcher title-changed', () => {
   it('flushes pending rename exactly once on first JSONL appearance', async () => {
     const { jsonlPath } = freshTmp();
     const projectDir = path.dirname(jsonlPath);
-    const renameMock = renameSessionMock as unknown as ReturnType<typeof vi.fn>;
+    const renameMock = renameSessionMock;
 
     // PR2 path: a user-set title was queued before the JSONL existed
     // (renameSession would have thrown ENOENT).

--- a/scripts/harness-real-cli.mjs
+++ b/scripts/harness-real-cli.mjs
@@ -408,6 +408,165 @@ async function caseSessionRenameWritesJsonl({ electronApp: _e, win, tempDir }) {
 }
 
 // ============================================================================
+// Case: session-title-syncs-from-jsonl (PR4 #593 — live-tail title backfill)
+// ============================================================================
+//
+// Verifies the live JSONL tail-watcher → IPC → store → sidebar flow for
+// SDK-derived session titles. This is the renderer-visible counterpart to
+// PR3's titleChanged.test.ts (which only covers main-process emission):
+//   1. Spawn a fresh session whose store name is the literal default
+//      'New session' (we set it explicitly so we have a known starting
+//      point regardless of what seedSession defaults to).
+//   2. Send a real prompt so claude writes the JSONL transcript and the
+//      SDK's session-summary derivation kicks in.
+//   3. Wait for `<sid>.jsonl` to land under <tempDir>/projects/<key>/ —
+//      the projectKey encoder mirrors the CLI's `[\\/:]` → `-` rule.
+//   4. Wait for the renderer's session row .name to flip from
+//      'New session' to a non-default value (the SDK summary). This is
+//      driven by `electron/sessionWatcher` → `session:title` IPC →
+//      `_applyExternalTitle` (App.tsx subscribes; PR3 wiring).
+//   5. Cross-check via `useStore.getState().sessions.find(...)` so we
+//      assert against the canonical store value, not just the rendered DOM.
+async function caseSessionTitleSyncsFromJsonl({ electronApp: _e, win, tempDir }) {
+  const PROMPT = 'reply with two short sentences about the moon.';
+
+  await win.waitForFunction(
+    () => !document.querySelector('[data-testid="claude-availability-probing"]'),
+    null,
+    { timeout: 30000 },
+  );
+
+  const projectDir = path.join(tempDir, 'title-sync-project');
+  mkdirSync(projectDir, { recursive: true });
+
+  // Seed with name 'New session' explicitly so the backfill / live-tail
+  // overwrite path has a known placeholder to swap. seedSession defaults
+  // to a custom name otherwise.
+  const { sid } = await seedSession(win, {
+    name: 'New session',
+    cwd: projectDir,
+  });
+  if (!sid) throw new Error('seedSession returned no sid');
+
+  await sleep(4000);
+  await waitForTerminalReady(win, sid, { timeout: 60000 });
+  await waitForXtermBuffer(win, /trust|claude|welcome|│|╭|>/i, { timeout: 30000 });
+  await dismissFirstRunModals(win);
+
+  // Send a substantive prompt so claude writes more than just an init frame —
+  // the SDK's summary derivation needs an actual user message + assistant
+  // response to produce a real summary string.
+  await sendToClaudeTui(win, PROMPT);
+  await sleep(500);
+  await sendToClaudeTui(win, '\r');
+
+  // Wait for the JSONL to appear under <tempDir>/projects/<hash>/.
+  const projectsRoot = path.join(tempDir, 'projects');
+  let matchedJsonl = null;
+  {
+    const deadline = Date.now() + 90_000;
+    while (Date.now() < deadline && !matchedJsonl) {
+      if (existsSync(projectsRoot)) {
+        for (const dirName of readdirSync(projectsRoot)) {
+          let entries;
+          try { entries = readdirSync(path.join(projectsRoot, dirName)); } catch { continue; }
+          if (entries.includes(`${sid}.jsonl`)) {
+            matchedJsonl = path.join(projectsRoot, dirName, `${sid}.jsonl`);
+            break;
+          }
+        }
+      }
+      if (!matchedJsonl) await sleep(1000);
+    }
+  }
+  if (!matchedJsonl) {
+    throw new Error(`no <sid>.jsonl found under ${projectsRoot} within 90s for sid=${sid}`);
+  }
+
+  // Wait for claude to actually finish replying so the SDK can derive a
+  // session summary. SDKSessionInfo.summary is "custom title, auto-derived
+  // summary, or first prompt" (per `node_modules/@anthropic-ai/claude-agent-sdk/sdk.d.ts`),
+  // so once the JSONL has at least the first user message frame, getSessionInfo
+  // returns a non-empty value. We poll the bridge directly instead of grepping
+  // disk — the SDK derives `summary` in-memory; there's no `"summary"` field
+  // written into the user/assistant frames.
+  let sdkSummary = null;
+  {
+    const deadline = Date.now() + 180_000;
+    while (Date.now() < deadline && !sdkSummary) {
+      const result = await win.evaluate(async ({ s, dir }) => {
+        const bridge = window.ccsmSessionTitles;
+        if (!bridge || typeof bridge.get !== 'function') return { err: 'no-bridge' };
+        try {
+          const info = await bridge.get(s, dir);
+          return { ok: true, summary: info?.summary ?? null };
+        } catch (e) {
+          return { err: String(e?.message || e) };
+        }
+      }, { s: sid, dir: projectDir });
+      if (result?.err === 'no-bridge') {
+        throw new Error('window.ccsmSessionTitles bridge missing — preload wiring broken');
+      }
+      if (result?.summary && typeof result.summary === 'string' && result.summary.length > 0) {
+        sdkSummary = result.summary;
+        break;
+      }
+      await sleep(2000);
+    }
+  }
+  if (!sdkSummary) {
+    throw new Error(
+      `bridge.get(${sid}) never returned a non-empty summary within 180s. ` +
+        `JSONL tail: ${readFileSync(matchedJsonl, 'utf8').split('\n').slice(-2).join('\n').slice(0, 800)}`,
+    );
+  }
+  console.log(`[HARNESS]   sdk-derived summary: ${JSON.stringify(sdkSummary)}`);
+
+  // Now wait for the renderer-side store.name to swap away from
+  // 'New session'. The watcher's debounce + IPC roundtrip + React render
+  // cycle is well under a second; budget 30s to absorb cold-cache /
+  // slow-CI variance.
+  let finalName = null;
+  {
+    const deadline = Date.now() + 30_000;
+    while (Date.now() < deadline) {
+      const observed = await win.evaluate((s) => {
+        const useStore = window.__ccsmStore;
+        if (!useStore) return null;
+        const sess = useStore.getState().sessions.find((x) => x.id === s);
+        return sess ? sess.name : null;
+      }, sid);
+      if (observed && observed !== 'New session') {
+        finalName = observed;
+        break;
+      }
+      await sleep(500);
+    }
+  }
+  if (!finalName) {
+    throw new Error(
+      `session ${sid} name still equals 'New session' after 30s — live-tail title sync did not fire. ` +
+        `sdkSummary=${JSON.stringify(sdkSummary)}`,
+    );
+  }
+  console.log(`[HARNESS]   store.name now: ${JSON.stringify(finalName)}`);
+
+  // Sanity: the rendered sidebar row should reflect the same value (DOM
+  // and store agree). data-session-id is set by the SessionRow component.
+  const domName = await win.evaluate((s) => {
+    const row = document.querySelector(`[data-session-id="${s}"]`);
+    return row ? (row.textContent || '').trim() : null;
+  }, sid);
+  if (!domName || !domName.includes(finalName)) {
+    // Don't fail hard — the sidebar template may add status pills etc.
+    // around the name. Log for visibility.
+    console.log(
+      `[HARNESS]   sidebar row text: ${JSON.stringify(domName)} (does not contain "${finalName}" verbatim — acceptable if wrapped)`,
+    );
+  }
+}
+
+// ============================================================================
 // Case 1b: session-state-becomes-idle (#553 — JSONL tail-watcher signal)
 // ============================================================================
 //
@@ -2060,6 +2219,7 @@ async function caseCwdPickerOnlyOneOpen({ win }) {
 const CASE_REGISTRY = [
   { name: 'new-session-chat',            group: 'shared', run: caseNewSessionChat },
   { name: 'session-rename-writes-jsonl', group: 'shared', run: caseSessionRenameWritesJsonl },
+  { name: 'session-title-syncs-from-jsonl', group: 'shared', run: caseSessionTitleSyncsFromJsonl },
   { name: 'session-state-becomes-idle',  group: 'shared', run: caseSessionStateBecomesIdle },
   { name: 'notify-fires-on-idle',        group: 'shared', run: caseNotifyFiresOnIdle },
   { name: 'switch-session-keeps-chat',   group: 'shared', run: caseSwitchSessionKeepsChat },

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -234,6 +234,18 @@ type Actions = {
   /** Internal: drop the disconnect entry for `sid`. Called from TerminalPane
    *  when an attach/spawn succeeds so the red dot clears on respawn. */
   _clearPtyExit: (sid: string) => void;
+  /**
+   * Launch-time backfill of session titles. After hydrate, group persisted
+   * sessions by their cwd's projectKey, batch one `listForProject` IPC per
+   * unique projectKey against the SDK bridge, and patch any session whose
+   * `name` is still a default placeholder ('New session' / '新会话') with
+   * the SDK-derived summary if available. User-renamed sessions and rows
+   * already carrying an auto-derived title are never touched. Silent +
+   * fire-and-forget — never throws, never toasts. Underscore prefix marks
+   * this as internal; only `hydrateStore()` calls it. Reuses the existing
+   * `_applyExternalTitle` action for the patch so the precedence rules
+   * stay in one place. */
+  _backfillTitles: () => Promise<void>;
   deleteSession: (id: string) => SessionSnapshot | null;
   /** Re-insert a session previously removed by `deleteSession`. Restores the
    *  row at its original index, plus messages, draft, and runtime flags. */
@@ -662,6 +674,84 @@ export const useStore = create<State & Actions>((set, get) => ({
       delete next[sid];
       return { disconnectedSessions: next };
     });
+  },
+
+  _backfillTitles: async () => {
+    // Renderer-side IPC bridge installed by `electron/preload.ts`. Absent in
+    // jsdom / non-Electron envs (tests without the bridge mock) — no-op.
+    type Bridge = {
+      listForProject: (projectKey: string) => Promise<Array<{
+        sid: string;
+        summary: string | null;
+        mtime: number;
+      }>>;
+    };
+    const bridge =
+      typeof window !== 'undefined'
+        ? (window as unknown as { ccsmSessionTitles?: Bridge }).ccsmSessionTitles
+        : undefined;
+    if (!bridge || typeof bridge.listForProject !== 'function') return;
+
+    // Default-name placeholders to overwrite. The store always writes the
+    // English literal at create time (see `createSession`); '新会话' is
+    // included because older persisted snapshots from a Chinese-locale build
+    // (when `createSession` briefly localized the name) may still carry it.
+    // Anything else (user rename, prior backfill) is treated as authoritative
+    // and never touched.
+    const defaults = new Set<string>(['New session', '新会话']);
+
+    // Group sessions whose name is still default by their projectKey, so we
+    // make ONE IPC call per project (not per session). projectKey encoding
+    // mirrors the CLI's `~/.claude/projects/<key>/<sid>.jsonl` convention:
+    // every `\` `/` `:` becomes `-`. The canonical encoder lives in
+    // `electron/sessionWatcher/projectKey.ts`; we duplicate the trivial
+    // replace here rather than ship that module to the renderer bundle.
+    const byProject = new Map<string, string[]>();
+    const sessions = get().sessions;
+    for (const s of sessions) {
+      if (!defaults.has(s.name)) continue;
+      if (typeof s.cwd !== 'string' || s.cwd.length === 0) continue;
+      const key = s.cwd.replace(/[\\/:]/g, '-');
+      const list = byProject.get(key);
+      if (list) list.push(s.id);
+      else byProject.set(key, [s.id]);
+    }
+    if (byProject.size === 0) return;
+
+    // Issue per-project lookups in parallel. Per-project errors are swallowed
+    // so one bad project (missing dir, SDK glitch) doesn't stall every other
+    // project's backfill.
+    await Promise.all(
+      Array.from(byProject.entries()).map(async ([projectKey, sids]) => {
+        let summaries: Array<{ sid: string; summary: string | null; mtime: number }>;
+        try {
+          summaries = await bridge.listForProject(projectKey);
+        } catch (err) {
+          console.warn('[store._backfillTitles] listForProject failed for', projectKey, err);
+          return;
+        }
+        if (!Array.isArray(summaries)) return;
+        const summaryMap = new Map<string, string | null>();
+        for (const entry of summaries) {
+          if (entry && typeof entry.sid === 'string') {
+            summaryMap.set(entry.sid, entry.summary);
+          }
+        }
+        const apply = get()._applyExternalTitle;
+        for (const sid of sids) {
+          const sum = summaryMap.get(sid);
+          // Re-check the current name on every apply — a concurrent live
+          // `session:title` IPC may have already overwritten the placeholder
+          // by the time we get here, in which case we leave it alone.
+          if (typeof sum === 'string' && sum.length > 0) {
+            const current = get().sessions.find((s) => s.id === sid);
+            if (current && defaults.has(current.name)) {
+              apply(sid, sum);
+            }
+          }
+        }
+      })
+    );
   },
 
   importSession: ({ name, cwd, groupId, resumeSessionId, projectDir: _projectDir }) => {
@@ -1191,6 +1281,12 @@ export async function hydrateStore(): Promise<void> {
   // until `models` populates and re-fire these themselves on mount.
   void useStore.getState().loadConnection();
   void useStore.getState().loadModels();
+
+  // PR4: backfill any default-named persisted sessions from the SDK's
+  // `listSessions` per-project view. Fire-and-forget — must not block
+  // hydrate completion or first paint. Sidebar names update in-place as
+  // `_applyExternalTitle` patches arrive (typically within ~1s of hydrate).
+  void useStore.getState()._backfillTitles();
 
   // After (potential) hydration, subscribe to write-through.
   // Perf: the subscriber fires on EVERY store mutation (including hot paths

--- a/tests/store-backfill-titles.test.ts
+++ b/tests/store-backfill-titles.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { useStore } from '../src/stores/store';
+import type { Session } from '../src/types';
+
+// Covers `_backfillTitles` action wired in PR4 (#593):
+//   1. Default-named sessions get patched with the SDK summary
+//   2. User-renamed sessions are NEVER touched
+//   3. Multiple sessions in the same projectKey use ONE listForProject call
+//      (batch by projectKey, not per-session)
+//   4. listForProject error → silent, no crash, other projects still patched
+//   5. No bridge installed (jsdom path) → no-op
+//   6. Empty summary string is ignored (counts as "no derived title yet")
+
+type Summary = { sid: string; summary: string | null; mtime: number };
+
+function installBridge(impl: (projectKey: string) => Promise<Summary[]>) {
+  const listForProject = vi.fn(impl);
+  (window as unknown as { ccsmSessionTitles: unknown }).ccsmSessionTitles = {
+    rename: vi.fn(async () => ({ ok: true })),
+    enqueuePending: vi.fn(async () => {}),
+    flushPending: vi.fn(async () => {}),
+    get: vi.fn(async () => ({ summary: null, mtime: null })),
+    listForProject,
+  };
+  return { listForProject };
+}
+
+function seed(id: string, name: string, cwd: string): Session {
+  const session: Session = {
+    id,
+    name,
+    state: 'idle',
+    cwd,
+    model: '',
+    groupId: 'g1',
+    agentType: 'claude-code',
+  };
+  useStore.setState((s) => ({ sessions: [...s.sessions, session] }));
+  return session;
+}
+
+describe('store._backfillTitles', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    useStore.setState({ sessions: [] });
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { ccsmSessionTitles?: unknown }).ccsmSessionTitles;
+    warnSpy.mockRestore();
+    useStore.setState({ sessions: [] });
+  });
+
+  it('patches default-named session with SDK summary', async () => {
+    installBridge(async () => [
+      { sid: 'sid-A', summary: 'Refactor login page', mtime: 1 },
+    ]);
+    seed('sid-A', 'New session', '/home/u/proj-A');
+
+    await useStore.getState()._backfillTitles();
+
+    expect(useStore.getState().sessions.find((s) => s.id === 'sid-A')?.name).toBe(
+      'Refactor login page'
+    );
+  });
+
+  it('also patches Chinese default name 新会话', async () => {
+    installBridge(async () => [
+      { sid: 'sid-zh', summary: 'Localized summary', mtime: 1 },
+    ]);
+    seed('sid-zh', '新会话', '/home/u/proj-zh');
+
+    await useStore.getState()._backfillTitles();
+
+    expect(useStore.getState().sessions.find((s) => s.id === 'sid-zh')?.name).toBe(
+      'Localized summary'
+    );
+  });
+
+  it('never overwrites a user-renamed session, even if SDK has a summary', async () => {
+    installBridge(async () => [
+      { sid: 'sid-keep', summary: 'auto-derived', mtime: 1 },
+    ]);
+    seed('sid-keep', 'My custom name', '/home/u/proj-keep');
+
+    await useStore.getState()._backfillTitles();
+
+    expect(useStore.getState().sessions.find((s) => s.id === 'sid-keep')?.name).toBe(
+      'My custom name'
+    );
+  });
+
+  it('batches sessions by projectKey: ONE IPC call for many sids in same project', async () => {
+    const { listForProject } = installBridge(async () => [
+      { sid: 'sid-1', summary: 's1', mtime: 1 },
+      { sid: 'sid-2', summary: 's2', mtime: 2 },
+      { sid: 'sid-3', summary: 's3', mtime: 3 },
+    ]);
+    seed('sid-1', 'New session', '/home/u/shared-proj');
+    seed('sid-2', 'New session', '/home/u/shared-proj');
+    seed('sid-3', 'New session', '/home/u/shared-proj');
+
+    await useStore.getState()._backfillTitles();
+
+    expect(listForProject).toHaveBeenCalledTimes(1);
+    // projectKey is `cwd.replace(/[\\/:]/g, '-')`.
+    expect(listForProject).toHaveBeenCalledWith('-home-u-shared-proj');
+    const after = useStore.getState().sessions;
+    expect(after.find((s) => s.id === 'sid-1')?.name).toBe('s1');
+    expect(after.find((s) => s.id === 'sid-2')?.name).toBe('s2');
+    expect(after.find((s) => s.id === 'sid-3')?.name).toBe('s3');
+  });
+
+  it('makes one IPC per unique projectKey when sessions span multiple projects', async () => {
+    const { listForProject } = installBridge(async (key) => {
+      if (key === '-a') return [{ sid: 'sid-a', summary: 'sum-a', mtime: 1 }];
+      if (key === '-b') return [{ sid: 'sid-b', summary: 'sum-b', mtime: 2 }];
+      return [];
+    });
+    seed('sid-a', 'New session', '/a');
+    seed('sid-b', 'New session', '/b');
+
+    await useStore.getState()._backfillTitles();
+
+    expect(listForProject).toHaveBeenCalledTimes(2);
+    const keys = listForProject.mock.calls.map((c) => c[0]).sort();
+    expect(keys).toEqual(['-a', '-b']);
+  });
+
+  it('listForProject rejects → silent warn, other projects still patched', async () => {
+    installBridge(async (key) => {
+      if (key === '-bad') throw new Error('boom');
+      if (key === '-good') return [{ sid: 'sid-g', summary: 'good-sum', mtime: 1 }];
+      return [];
+    });
+    seed('sid-bad', 'New session', '/bad');
+    seed('sid-g', 'New session', '/good');
+
+    await useStore.getState()._backfillTitles();
+
+    // Bad project: name unchanged.
+    expect(useStore.getState().sessions.find((s) => s.id === 'sid-bad')?.name).toBe(
+      'New session'
+    );
+    // Good project: still patched.
+    expect(useStore.getState().sessions.find((s) => s.id === 'sid-g')?.name).toBe(
+      'good-sum'
+    );
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('no bridge available: no-op, no throw', async () => {
+    delete (window as unknown as { ccsmSessionTitles?: unknown }).ccsmSessionTitles;
+    seed('sid-x', 'New session', '/x');
+
+    await expect(useStore.getState()._backfillTitles()).resolves.toBeUndefined();
+    expect(useStore.getState().sessions.find((s) => s.id === 'sid-x')?.name).toBe(
+      'New session'
+    );
+  });
+
+  it('null/empty summary is ignored (no overwrite with empty string)', async () => {
+    installBridge(async () => [
+      { sid: 'sid-null', summary: null, mtime: 1 },
+      { sid: 'sid-empty', summary: '', mtime: 2 },
+    ]);
+    seed('sid-null', 'New session', '/proj-empty');
+    seed('sid-empty', 'New session', '/proj-empty');
+
+    await useStore.getState()._backfillTitles();
+
+    expect(useStore.getState().sessions.find((s) => s.id === 'sid-null')?.name).toBe(
+      'New session'
+    );
+    expect(useStore.getState().sessions.find((s) => s.id === 'sid-empty')?.name).toBe(
+      'New session'
+    );
+  });
+
+  it('skips sessions with empty cwd (no projectKey to look up)', async () => {
+    const { listForProject } = installBridge(async () => []);
+    seed('sid-no-cwd', 'New session', '');
+
+    await useStore.getState()._backfillTitles();
+
+    expect(listForProject).not.toHaveBeenCalled();
+    expect(useStore.getState().sessions.find((s) => s.id === 'sid-no-cwd')?.name).toBe(
+      'New session'
+    );
+  });
+
+  it('summary for a sid not in our store is silently ignored', async () => {
+    installBridge(async () => [
+      { sid: 'unknown-sid', summary: 'dangling', mtime: 1 },
+      { sid: 'sid-known', summary: 'known-sum', mtime: 2 },
+    ]);
+    seed('sid-known', 'New session', '/proj-mixed');
+
+    await useStore.getState()._backfillTitles();
+
+    const sessions = useStore.getState().sessions;
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].name).toBe('known-sum');
+  });
+});


### PR DESCRIPTION
PR4 of 4 for session-name SDK sync (plan: #586). Closes the feature.
Prior PRs: #501 (substrate), #502 (watcher emit), #503 (rename writeback).

## Scope
- On hydrate, batch `listForProject` per unique projectKey, patch sessions whose name still matches default placeholder ('New session' / '新会话')
- User-renamed sessions never touched (equality check vs default set; no `userRenamed` flag added)
- One IPC per project, not per session
- Adds live-tail e2e case `session-title-syncs-from-jsonl` (PR3 reviewer requirement)

## Drive-by fix
`titleChanged.test.ts` (PR3) was silently 4/5 failing on `working` HEAD: PR1's `new Function('return import(spec)')` SDK loader (which dodges tsc's CJS rewrite) also dodges `vi.mock`. Switched the test to inject SDK fakes via `__setSdkForTests` (the bridge already exposes this exact escape hatch). Now 5/5 pass.

## Tests
- **Unit (new):** `tests/store-backfill-titles.test.ts` — 10/10 PASS. Covers defaults patched, Chinese default `新会话`, user-renamed never overwritten, batched per projectKey (one IPC for many sids), one IPC per unique project across multi-project sets, IPC error swallowed (other projects still patched), no-bridge no-op, null/empty summary ignored, empty cwd skipped, unknown sids ignored.
- **Unit (regression):** `electron/sessionWatcher/__tests__/titleChanged.test.ts` — 5/5 PASS (was 1/5 on working tip).
- **Vitest full:** 320/323 (3 known better-sqlite3 ABI failures, pre-existing).
- **E2E:** `node scripts/harness-real-cli.mjs --only=session-title-syncs-from-jsonl` PASS in 18.5s on real CLI.
- **Smoke:** `node -e "require('./dist/electron/sessionTitles/index.js')"` exits 0, no ERR_REQUIRE_ESM.

## Diff scope
- `src/stores/store.ts` — add `_backfillTitles` action + wire into `hydrateStore`
- `tests/store-backfill-titles.test.ts` — new
- `electron/sessionWatcher/__tests__/titleChanged.test.ts` — switch SDK mock injection
- `scripts/harness-real-cli.mjs` — new case `session-title-syncs-from-jsonl`

Closes #593.