### PR TITLE
fix(ui): rename input autofocuses + selects existing text (#599)

### DIFF
--- a/src/components/ui/InlineRename.tsx
+++ b/src/components/ui/InlineRename.tsx
@@ -36,8 +36,21 @@ export function InlineRename({
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
+    // Focus + select existing text so the user can immediately overwrite.
+    // We focus once synchronously AND once on the next animation frame.
+    // The deferred call is the load-bearing one when InlineRename is mounted
+    // from a Radix ContextMenuItem.onSelect — Radix restores focus to the
+    // context-menu trigger after the menu closes, which races with our mount
+    // effect and would otherwise steal focus from this input.
     el.focus();
     el.select();
+    const raf = requestAnimationFrame(() => {
+      const cur = ref.current;
+      if (!cur) return;
+      cur.focus();
+      cur.select();
+    });
+    return () => cancelAnimationFrame(raf);
   }, []);
 
   function commit() {


### PR DESCRIPTION
## Summary
Fixes #599 — right-click Session → Rename did not autofocus the inline rename `<input>`; user had to click into it before typing.

## Root cause
`InlineRename` already focused + selected on mount via `useEffect`, but the rename is triggered from a Radix `ContextMenuItem.onSelect`. After the menu closes, Radix restores focus to the context-menu trigger element. That restoration runs after our synchronous mount effect, so it steals focus right back from the just-mounted input.

## Fix
Defer a second `focus()` + `select()` to the next animation frame so it runs after Radix's focus restoration. Keep the synchronous call too (belt + braces for non-menu mount paths, e.g., the auto-rename-on-create flow for new groups).

Diff: 1 file, +13 LOC in `src/components/ui/InlineRename.tsx`.

## Test plan
- [x] `npm run build` clean (3 webpack size warnings only, pre-existing)
- [x] `node -e "require('./dist/electron/sessionTitles/index.js')"` — no ERR_REQUIRE_ESM
- [x] `npm test` — 328/331 (3 failures are the known better-sqlite3 ABI mismatch on Node 24 vs Electron's 130)
- [ ] Manual smoke: dev mode → right-click session → Rename → input focused immediately, name pre-selected, typing overwrites
- [ ] Same flow for Group rename (uses the same component)