### PR TITLE
fix(session): validate cwd before spawn + repair Retry + selectable error text (#597)

### DIFF
--- a/electron/ptyHost/__tests__/cwd-fallback.test.ts
+++ b/electron/ptyHost/__tests__/cwd-fallback.test.ts
@@ -1,0 +1,77 @@
+// Validates the cwd resolution that gates `pty.spawn`. Bug #597 (dogfood):
+// the 2nd new-session spawn failed with `error code:267` (Windows
+// ERROR_DIRECTORY) because node-pty was handed a stale / non-existent path
+// and surfaced it as a hard spawn failure. The fix in `electron/ptyHost`
+// validates the requested cwd up front and falls back to the user's home
+// directory; this test pins that contract so future refactors don't
+// regress the bug class.
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { join as pathJoin } from 'node:path';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// node-pty + @xterm/headless + electron pull native deps that aren't
+// available in the vitest jsdom env. The function under test has none of
+// those dependencies — stub the heavy imports so just the helper loads.
+vi.mock('node-pty', () => ({ spawn: vi.fn() }));
+vi.mock('@xterm/headless', () => ({ Terminal: class {} }));
+vi.mock('@xterm/addon-serialize', () => ({ SerializeAddon: class {} }));
+vi.mock('electron', () => ({}));
+vi.mock('../claudeResolver', () => ({ resolveClaude: () => null }));
+vi.mock('../../sessionWatcher', () => ({
+  sessionWatcher: { on: vi.fn(), startWatching: vi.fn(), stopWatching: vi.fn() },
+}));
+vi.mock('../../sessionWatcher/projectKey', () => ({ cwdToProjectKey: () => null }));
+
+import { resolveSpawnCwd } from '../index';
+
+describe('resolveSpawnCwd', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(pathJoin(tmpdir(), 'ccsm-cwd-fallback-'));
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    try { rmSync(tmp, { recursive: true, force: true }); } catch { /* noop */ }
+    vi.restoreAllMocks();
+  });
+
+  it('returns the requested path when it is an existing directory', () => {
+    expect(resolveSpawnCwd(tmp)).toBe(tmp);
+  });
+
+  it('falls back to homedir when requested path is empty', () => {
+    expect(resolveSpawnCwd('')).toBe(homedir());
+  });
+
+  it('falls back to homedir when requested path is null', () => {
+    expect(resolveSpawnCwd(null)).toBe(homedir());
+  });
+
+  it('falls back to homedir when requested path is undefined', () => {
+    expect(resolveSpawnCwd(undefined)).toBe(homedir());
+  });
+
+  it('falls back to homedir when requested path does not exist', () => {
+    const ghost = pathJoin(tmp, 'does-not-exist-' + Date.now());
+    expect(resolveSpawnCwd(ghost)).toBe(homedir());
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it('falls back to homedir when requested path is a file (not a directory)', () => {
+    const file = pathJoin(tmp, 'a-file');
+    writeFileSync(file, 'x');
+    expect(resolveSpawnCwd(file)).toBe(homedir());
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it('falls back to homedir for the dogfood placeholder /tmp/no-group-cwd on Windows', () => {
+    // Linux-style placeholder used in harness fixtures; Windows obviously
+    // can't spawn into it. Repro of the user-visible bug (error code:267)
+    // becomes a clean homedir fallback.
+    expect(resolveSpawnCwd('/tmp/no-group-cwd')).toBe(homedir());
+  });
+});

--- a/electron/ptyHost/index.ts
+++ b/electron/ptyHost/index.ts
@@ -31,6 +31,7 @@
 import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { existsSync, readdirSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { join as pathJoin } from 'node:path';
 import type { BrowserWindow, IpcMain, WebContents } from 'electron';
 import * as pty from 'node-pty';
@@ -155,6 +156,32 @@ function resolveJsonlPath(claudeSid: string, cwd: string): string | null {
   return pathJoin(root, 'projects', projectKey, `${claudeSid}.jsonl`);
 }
 
+// Resolve the cwd we'll hand to `pty.spawn`. node-pty surfaces an invalid
+// cwd as a hard spawn failure — on Windows this is `error code: 267`
+// (ERROR_DIRECTORY) which is not actionable for the user and looks like
+// ccsm crashing the CLI. Validate first; if the requested path is empty,
+// missing, or not a directory, fall back to the user's home directory
+// (always exists by definition for an interactive Electron session) and
+// log a warning so the cause is visible in the console. Exposed for
+// `electron/ptyHost/__tests__/cwd-fallback.test.ts`.
+export function resolveSpawnCwd(requested: string | null | undefined): string {
+  const fallback = homedir();
+  if (!requested || requested.length === 0) return fallback;
+  try {
+    const st = statSync(requested);
+    if (st.isDirectory()) return requested;
+    console.warn(
+      `[ptyHost] cwd ${JSON.stringify(requested)} is not a directory; falling back to ${fallback}`,
+    );
+    return fallback;
+  } catch (err) {
+    console.warn(
+      `[ptyHost] cwd ${JSON.stringify(requested)} unusable (${err instanceof Error ? err.message : String(err)}); falling back to ${fallback}`,
+    );
+    return fallback;
+  }
+}
+
 function makeEntry(
   sid: string,
   cwd: string,
@@ -166,11 +193,13 @@ function makeEntry(
   const flag = jsonlExistsForSid(claudeSid) ? '--resume' : '--session-id';
   const args = [flag, claudeSid];
 
+  const spawnCwd = resolveSpawnCwd(cwd);
+
   const p = pty.spawn(claudePath, args, {
     name: 'xterm-256color',
     cols,
     rows,
-    cwd: cwd && cwd.length > 0 ? cwd : process.cwd(),
+    cwd: spawnCwd,
     env: process.env as { [key: string]: string },
   });
 
@@ -239,8 +268,8 @@ function makeEntry(
   // Path resolution mirrors `jsonlExistsForSid` above: prefer
   // CLAUDE_CONFIG_DIR/projects, fall back to ~/.claude/projects.
   try {
-    const jsonlPath = resolveJsonlPath(claudeSid, cwd);
-    if (jsonlPath) sessionWatcher.startWatching(sid, jsonlPath, cwd);
+    const jsonlPath = resolveJsonlPath(claudeSid, spawnCwd);
+    if (jsonlPath) sessionWatcher.startWatching(sid, jsonlPath, spawnCwd);
   } catch {
     /* watcher start is best-effort; PTY still owns its lifecycle */
   }

--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -439,13 +439,19 @@ export function TerminalPane({ sessionId, cwd: _cwd }: Props) {
     >
       <div ref={hostRef} className="absolute inset-0" />
       {state.kind === 'attaching' && (
-        <div className="absolute inset-0 flex items-center justify-center text-neutral-400 text-sm pointer-events-none">
+        <div className="absolute inset-0 z-10 flex items-center justify-center text-neutral-400 text-sm pointer-events-none">
           Attaching...
         </div>
       )}
       {state.kind === 'error' && (
-        <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 text-sm bg-black/80">
-          <div className="text-red-400 max-w-md text-center break-words px-4">
+        // z-10 so the overlay sits above xterm's canvas layers (the canvas
+        // renderer stacks its own absolutely-positioned canvases inside the
+        // host div with non-zero z-index — without an explicit z here the
+        // Retry button is rendered but unclickable). select-text on the
+        // message so the user can highlight + Ctrl+C the error to share
+        // (e.g. "spawn_failed: ... error code:267") with support.
+        <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 text-sm bg-black/80">
+          <div className="text-red-400 max-w-md text-center break-words px-4 select-text">
             {state.message}
           </div>
           <button
@@ -464,19 +470,20 @@ export function TerminalPane({ sessionId, cwd: _cwd }: Props) {
         // i18n — `terminal.exitedClean` reassures, `terminal.exitedCrash`
         // explicitly disclaims ccsm involvement and points at the
         // on-disk transcript so the user knows their work is safe.
+        // z-10 + select-text rationale matches the `error` overlay above.
         <div
           data-pty-exit-kind={state.exitKind}
           className={
             state.exitKind === 'crashed'
-              ? 'absolute inset-0 flex flex-col items-center justify-center gap-3 text-sm bg-black/80'
-              : 'absolute inset-0 flex flex-col items-center justify-center gap-3 text-sm bg-neutral-900/85'
+              ? 'absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 text-sm bg-black/80'
+              : 'absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 text-sm bg-neutral-900/85'
           }
         >
           <div
             className={
               state.exitKind === 'crashed'
-                ? 'text-state-error-text max-w-md text-center break-words px-4'
-                : 'text-neutral-300 max-w-md text-center break-words px-4'
+                ? 'text-state-error-text max-w-md text-center break-words px-4 select-text'
+                : 'text-neutral-300 max-w-md text-center break-words px-4 select-text'
             }
           >
             {state.exitKind === 'crashed'


### PR DESCRIPTION
## Summary
Three dogfood-reported bugs from CCSM faada0e:

### Bug 1 (P0) — 2nd new-session spawn fails with `error code:267`
Windows `ERROR_DIRECTORY` from node-pty. Root cause: `electron/ptyHost/index.ts` only guarded against empty/null cwd, not against paths that don't exist or aren't directories. node-pty surfaces an invalid cwd as a hard spawn failure that looked like ccsm crashing the CLI.

**Fix**: extracted `resolveSpawnCwd` helper that validates with `statSync().isDirectory()` and falls back to `os.homedir()` with a `console.warn` so the cause stays visible. Also re-routed the JSONL watcher path through the resolved cwd so the watch target matches what the CLI actually uses.

### Bug 2 (P1) — Retry button not clickable on error overlay
Root cause: xterm's canvas renderer stacks its own absolutely-positioned canvases inside the host div with non-zero z-index. The error overlay had no explicit z-index, so it sat below the canvas in the stacking context. Visually the button rendered, but pointer events went to the canvas underneath.

**Fix**: added `z-10` to the `error` / `exit` / `attaching` overlays. Same fix applied to the exit overlay (PR #504) which had the same latent problem.

### Bug 3 (P2) — Error text not copyable
User had to retype the spawn error to share with support.

**Fix**: added `select-text` to the error / exit message containers so the user can highlight + Ctrl+C.

## Test plan
- [x] `npm run build` clean (3 pre-existing webpack size warnings)
- [x] `node -e "require('./dist/electron/sessionTitles/index.js')"` — no ERR_REQUIRE_ESM
- [x] `npx vitest run electron/ptyHost/__tests__/cwd-fallback.test.ts` — **7/7** (new unit test pins the cwd-fallback contract, including the exact `/tmp/no-group-cwd` placeholder seen in the dogfood report)
- [x] `npx vitest run electron/sessionWatcher/__tests__/titleChanged.test.ts` — 5/5
- [x] `npx vitest run tests/store-pty-exit.test.ts` — 8/8 (PR #504 regression)
- [x] `npx vitest run tests/store-backfill-titles.test.ts` — 10/10 (PR #505 regression)
- [x] `npm test` — 335/338 (3 pre-existing better-sqlite3 ABI env failures unrelated to this PR)

## Manual smoke (requires GUI; user/manager to confirm against installer)
- [ ] Create new session → works (unchanged path)
- [ ] Create 2nd new session immediately → works (no error 267 — cwd now validated + falls back to homedir)
- [ ] Force a spawn error (e.g. set session cwd to a non-existent path via dev tools, or kill claude.exe binary) → error overlay shows → Retry is clickable → Retry succeeds
- [ ] Error text in overlay can be selected with mouse and Ctrl+C copied

## Anti-patterns avoided
- No new state machine — kept the existing `error` / `exit` shapes, just fixed their CSS
- Spawn errors are logged via `console.warn`, not silently swallowed
- No i18n key changes outside scope (Retry / error text uses existing keys)
- No static `import` of `@anthropic-ai/claude-agent-sdk`
- Retry path unchanged structurally — same `bumpAttachNonce` flow that re-runs the attach effect, which now goes through the cwd-validated spawn

Refs dogfood report bug #597.