### PR TITLE
feat(notify): app icon flash for in-app attention (PR B of #600)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -69,6 +69,7 @@ import { listModelsFromSettings, readDefaultModelFromSettings } from './agent/li
 import { registerPtyHostIpc, killAllPtySessions } from './ptyHost';
 import { sessionWatcher } from './sessionWatcher';
 import { installNotifyBridge } from './notify';
+import { installAttentionFlash, type AttentionHandle } from './notify/attention';
 import { BadgeManager } from './notify/badge';
 import {
   getSessionTitle,
@@ -521,6 +522,11 @@ function createWindow() {
 
   win.on('focus', () => {
     clearBadgeForActiveIfFocused();
+    // Cancel any pending app-icon attention cue (Windows flashFrame /
+    // macOS dock bounce). Once the user is looking at the window, the
+    // signal has done its job.
+    try { attentionFlash?.cancel(); } catch { /* ignore */ }
+    try { win.flashFrame(false); } catch { /* ignore */ }
   });
 
   const emitMax = () => win.webContents.send('window:maximizedChanged', win.isMaximized());
@@ -616,6 +622,7 @@ function createWindow() {
 let tray: Tray | null = null;
 let isQuitting = false;
 let badgeManager: BadgeManager | null = null;
+let attentionFlash: AttentionHandle | null = null;
 
 function getTrayBaseImage() {
   return buildTrayIcon();
@@ -979,6 +986,9 @@ app.whenReady().then(() => {
     if (!fromMainFrame(e)) return;
     activeSidFromRenderer = typeof sid === 'string' && sid.length > 0 ? sid : null;
     clearBadgeForActiveIfFocused();
+    // The user just switched session in the sidebar — cancel any
+    // pending attention flash (the new selection IS the response).
+    try { attentionFlash?.cancel(); } catch { /* ignore */ }
   });
 
   // Desktop notification bridge — fires OS toasts on session 'idle' /
@@ -1000,6 +1010,21 @@ app.whenReady().then(() => {
     },
     onNotified: (sid) => {
       badgeManager?.incrementSid(sid);
+    },
+  });
+
+  // In-app attention flash. Mutually exclusive with the notify bridge:
+  // notify fires when the window is UNFOCUSED, attention-flash fires when
+  // the window IS focused but the user is on a different session. See
+  // electron/notify/attention.ts for platform mapping.
+  attentionFlash = installAttentionFlash({
+    sessionWatcher,
+    getMainWindow: () => BrowserWindow.getAllWindows()[0] ?? null,
+    isMutedFn: () => !loadNotifyEnabled(),
+    getActiveSidFn: () => activeSidFromRenderer,
+    isWindowFocusedFn: () => {
+      const w = BrowserWindow.getAllWindows()[0];
+      return !!(w && !w.isDestroyed() && w.isFocused());
     },
   });
 

--- a/electron/notify/__tests__/attention.test.ts
+++ b/electron/notify/__tests__/attention.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+
+// `attention.ts` imports `app` and a `BrowserWindow` type from electron.
+// Tests always inject `attentionImpl`, so the production paths that touch
+// `app.dock` / `win.flashFrame` are never reached. The mock prevents the
+// native module from loading in the vitest environment.
+vi.mock('electron', () => ({
+  app: {
+    dock: {
+      bounce: () => 1,
+      cancelBounce: () => { /* noop */ },
+    },
+  },
+}));
+
+import {
+  installAttentionFlash,
+  type AttentionImpl,
+  type AttentionEvent,
+} from '../attention';
+
+type StateEvt = { sid: string; state: 'idle' | 'running' | 'requires_action' };
+
+interface FlashCall {
+  payload: AttentionEvent;
+  handle: number | null;
+}
+
+interface CancelCall {
+  handle: number | null;
+}
+
+interface Harness {
+  emitter: EventEmitter;
+  flashes: FlashCall[];
+  cancels: CancelCall[];
+  attentionImpl: AttentionImpl;
+  isMuted: boolean;
+  activeSid: string | null;
+  windowFocused: boolean;
+  dispose: () => void;
+  cancel: () => void;
+}
+
+function makeHarness(opts?: {
+  isMuted?: boolean;
+  activeSid?: string | null;
+  windowFocused?: boolean;
+  /** When set, flash() returns this id (default: monotonically increasing). */
+  forceHandle?: number;
+}): Harness {
+  const emitter = new EventEmitter();
+  const flashes: FlashCall[] = [];
+  const cancels: CancelCall[] = [];
+  let nextId = 100;
+
+  const harness: Harness = {
+    emitter,
+    flashes,
+    cancels,
+    attentionImpl: {
+      flash(payload) {
+        const handle = opts?.forceHandle ?? nextId++;
+        // Mark kind so the install fn doesn't take the real flashFrame
+        // branch — "dockBounce" path is a pure no-op outside the impl.
+        payload.kind = 'dockBounce';
+        flashes.push({ payload, handle });
+        return handle;
+      },
+      cancel(handle, _win) {
+        cancels.push({ handle });
+      },
+    },
+    isMuted: opts?.isMuted ?? false,
+    activeSid: opts?.activeSid ?? null,
+    windowFocused: opts?.windowFocused ?? true,
+    dispose: () => { /* replaced */ },
+    cancel: () => { /* replaced */ },
+  };
+
+  const inst = installAttentionFlash({
+    sessionWatcher: emitter,
+    getMainWindow: () => null,
+    isMutedFn: () => harness.isMuted,
+    getActiveSidFn: () => harness.activeSid,
+    isWindowFocusedFn: () => harness.windowFocused,
+    attentionImpl: harness.attentionImpl,
+  });
+  harness.dispose = inst.dispose;
+  harness.cancel = inst.cancel;
+  return harness;
+}
+
+function emit(emitter: EventEmitter, evt: StateEvt): void {
+  emitter.emit('state-changed', evt);
+}
+
+describe('installAttentionFlash', () => {
+  it('flashes when focused + non-active sid + idle', () => {
+    const h = makeHarness({ windowFocused: true, activeSid: 'sid-other' });
+    emit(h.emitter, { sid: 'sid-target', state: 'idle' });
+    expect(h.flashes).toHaveLength(1);
+    expect(h.flashes[0].payload.sid).toBe('sid-target');
+    expect(h.flashes[0].payload.state).toBe('idle');
+    h.dispose();
+  });
+
+  it('flashes when focused + non-active sid + requires_action', () => {
+    const h = makeHarness({ windowFocused: true, activeSid: 'sid-other' });
+    emit(h.emitter, { sid: 'sid-x', state: 'requires_action' });
+    expect(h.flashes).toHaveLength(1);
+    expect(h.flashes[0].payload.state).toBe('requires_action');
+    h.dispose();
+  });
+
+  it('does NOT flash when focused + the active sid is the target', () => {
+    const h = makeHarness({ windowFocused: true, activeSid: 'sid-target' });
+    emit(h.emitter, { sid: 'sid-target', state: 'idle' });
+    expect(h.flashes).toHaveLength(0);
+    h.dispose();
+  });
+
+  it('does NOT flash when window is unfocused (notify path handles it)', () => {
+    const h = makeHarness({ windowFocused: false, activeSid: 'sid-other' });
+    emit(h.emitter, { sid: 'sid-target', state: 'idle' });
+    expect(h.flashes).toHaveLength(0);
+    h.dispose();
+  });
+
+  it('does NOT flash when muted', () => {
+    const h = makeHarness({ windowFocused: true, isMuted: true, activeSid: 'sid-other' });
+    emit(h.emitter, { sid: 'sid-target', state: 'idle' });
+    expect(h.flashes).toHaveLength(0);
+    h.dispose();
+  });
+
+  it('does NOT flash for running state', () => {
+    const h = makeHarness({ windowFocused: true, activeSid: 'sid-other' });
+    emit(h.emitter, { sid: 'sid-target', state: 'running' });
+    expect(h.flashes).toHaveLength(0);
+    h.dispose();
+  });
+
+  it('cancel() cancels the pending bounce handle', () => {
+    const h = makeHarness({ windowFocused: true, activeSid: 'sid-other', forceHandle: 42 });
+    emit(h.emitter, { sid: 'sid-target', state: 'idle' });
+    expect(h.flashes).toHaveLength(1);
+    h.cancel();
+    expect(h.cancels).toHaveLength(1);
+    expect(h.cancels[0].handle).toBe(42);
+    // Cancel-then-cancel is a no-op (handle slot already cleared).
+    h.cancel();
+    expect(h.cancels).toHaveLength(2);
+    expect(h.cancels[1].handle).toBeNull();
+    h.dispose();
+  });
+
+  it('a fresh flash supersedes the prior pending handle (cancels old)', () => {
+    const h = makeHarness({ windowFocused: true, activeSid: 'sid-other' });
+    emit(h.emitter, { sid: 'sid-A', state: 'idle' });
+    const firstHandle = h.flashes[0].handle;
+    emit(h.emitter, { sid: 'sid-B', state: 'idle' });
+    // Second flash should have triggered a cancel of the first handle.
+    expect(h.cancels.some((c) => c.handle === firstHandle)).toBe(true);
+    expect(h.flashes).toHaveLength(2);
+    h.dispose();
+  });
+
+  it('reads mute fresh on every event', () => {
+    const h = makeHarness({ windowFocused: true, isMuted: true, activeSid: 'sid-other' });
+    emit(h.emitter, { sid: 'sid-1', state: 'idle' });
+    expect(h.flashes).toHaveLength(0);
+    h.isMuted = false;
+    emit(h.emitter, { sid: 'sid-2', state: 'idle' });
+    expect(h.flashes).toHaveLength(1);
+    h.dispose();
+  });
+
+  it('dispose stops further flashes and cancels pending', () => {
+    const h = makeHarness({ windowFocused: true, activeSid: 'sid-other' });
+    emit(h.emitter, { sid: 'sid-1', state: 'idle' });
+    expect(h.flashes).toHaveLength(1);
+    h.dispose();
+    emit(h.emitter, { sid: 'sid-2', state: 'idle' });
+    expect(h.flashes).toHaveLength(1);
+    // Dispose called cancel on the still-pending handle.
+    expect(h.cancels.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('ignores malformed events', () => {
+    const h = makeHarness({ windowFocused: true, activeSid: 'sid-other' });
+    emit(h.emitter, { sid: '', state: 'idle' });
+    // @ts-expect-error — testing runtime guard
+    h.emitter.emit('state-changed', null);
+    expect(h.flashes).toHaveLength(0);
+    h.dispose();
+  });
+});

--- a/electron/notify/attention.ts
+++ b/electron/notify/attention.ts
@@ -1,0 +1,207 @@
+// In-app attention flash.
+//
+// Complements `electron/notify/index.ts` (OS-level desktop toasts) with the
+// "the window IS focused but the user is on a different session" case. The
+// two paths are mutually exclusive by design:
+//
+//   * window UNFOCUSED → notify bridge fires an OS toast.
+//   * window FOCUSED  → toast is suppressed by the notify bridge (user is
+//                       arguably already paying attention to ccsm); but if
+//                       another session in the sidebar transitions to idle /
+//                       requires_action, the user has no in-app cue. This
+//                       module flashes the OS taskbar / dock icon so the
+//                       attention indicator surfaces in their peripheral
+//                       vision without spawning a noisy toast.
+//
+// Platform mapping:
+//   * Windows: BrowserWindow.flashFrame(true) — taskbar button starts
+//     pulsing until the window receives focus, OR we explicitly call
+//     flashFrame(false). Cheap, idempotent, no id to track.
+//   * macOS:   app.dock.bounce('informational') — single bounce, returns
+//     a request id we can pass to app.dock.cancelBounce(id) when the user
+//     focuses the window or activates the affected sid. We deliberately do
+//     NOT use 'critical' (bounces forever — unacceptable for a
+//     turn-finished signal).
+//   * Linux:   no portable dock-bounce primitive. We still call flashFrame
+//     because Electron silently no-ops it on platforms without urgency
+//     hints, and several Linux WMs (KWin, Mutter via _NET_WM_STATE_DEMANDS_
+//     ATTENTION) do honor it.
+//
+// Test seam: when CCSM_NOTIFY_TEST_HOOK is set, attention events are
+// appended to `globalThis.__ccsmAttentionLog` (mirrors the notify pattern in
+// `index.ts`). The e2e harness reads the log via `electronApp.evaluate`.
+
+import { app, type BrowserWindow } from 'electron';
+import type { EventEmitter } from 'node:events';
+import type { WatcherState } from '../sessionWatcher';
+
+export interface AttentionEvent {
+  sid: string;
+  state: WatcherState;
+  ts: number;
+  /** Which platform path actually ran ('flashFrame' | 'dockBounce' | 'noop'). */
+  kind: 'flashFrame' | 'dockBounce' | 'noop';
+}
+
+export interface AttentionImpl {
+  /** Trigger the attention cue. Returns an opaque cancel handle (only
+   *  meaningful on macOS dock-bounce; other paths return null). */
+  flash(payload: AttentionEvent): number | null;
+  /** Cancel a pending cue by handle (no-op if handle is null or stale). */
+  cancel(handle: number | null, win: BrowserWindow | null): void;
+}
+
+export interface InstallAttentionFlashOptions {
+  sessionWatcher: EventEmitter;
+  getMainWindow: () => BrowserWindow | null;
+  isMutedFn: () => boolean;
+  getActiveSidFn: () => string | null;
+  isWindowFocusedFn: () => boolean;
+  /** Optional injected impl — defaults to the real Electron path. The unit
+   *  tests inject a fake; the e2e harness uses the test-log impl below. */
+  attentionImpl?: AttentionImpl;
+}
+
+export interface AttentionHandle {
+  /** Detach the state-changed listener and cancel any pending flash. */
+  dispose: () => void;
+  /** Cancel any pending cue (called from window-focus and session:setActive
+   *  in main.ts). Safe to call when nothing is pending. */
+  cancel: () => void;
+}
+
+function makeElectronAttentionImpl(): AttentionImpl {
+  return {
+    flash(payload) {
+      try {
+        if (process.platform === 'darwin') {
+          // 'informational' = single bounce. Returns a request id we can
+          // pass to cancelBounce when the user re-engages.
+          const id = app.dock?.bounce('informational');
+          payload.kind = 'dockBounce';
+          return typeof id === 'number' ? id : null;
+        }
+        // Windows (taskbar pulse) + Linux (best-effort urgency hint).
+        // Resolved at flash time inside the install fn — see below.
+        payload.kind = 'flashFrame';
+        return null;
+      } catch (err) {
+        console.warn('[attention] flash failed', err);
+        payload.kind = 'noop';
+        return null;
+      }
+    },
+    cancel(handle, win) {
+      try {
+        if (handle != null && process.platform === 'darwin') {
+          app.dock?.cancelBounce(handle);
+        }
+      } catch (err) {
+        console.warn('[attention] cancelBounce failed', err);
+      }
+      try {
+        if (win && !win.isDestroyed()) {
+          win.flashFrame(false);
+        }
+      } catch (err) {
+        console.warn('[attention] flashFrame(false) failed', err);
+      }
+    },
+  };
+}
+
+function makeTestAttentionImpl(): AttentionImpl {
+  const g = globalThis as unknown as { __ccsmAttentionLog?: AttentionEvent[] };
+  if (!g.__ccsmAttentionLog) g.__ccsmAttentionLog = [];
+  let nextId = 1;
+  return {
+    flash(payload) {
+      g.__ccsmAttentionLog!.push(payload);
+      // Return a unique fake handle so cancel() can verify pairing.
+      return nextId++;
+    },
+    cancel(_handle, _win) {
+      /* no-op for the log impl */
+    },
+  };
+}
+
+export function installAttentionFlash(opts: InstallAttentionFlashOptions): AttentionHandle {
+  const {
+    sessionWatcher,
+    getMainWindow,
+    isMutedFn,
+    getActiveSidFn,
+    isWindowFocusedFn,
+  } = opts;
+
+  const attentionImpl =
+    opts.attentionImpl ??
+    (process.env.CCSM_NOTIFY_TEST_HOOK ? makeTestAttentionImpl() : makeElectronAttentionImpl());
+
+  // Track the most recent pending handle so a focus / activate event can
+  // cancel it. Single slot is fine: only one window today, and a fresh
+  // flash supersedes the previous one (a new event already grabbed the
+  // user's attention; cancelling the old bounce id silently is harmless).
+  let pendingHandle: number | null = null;
+
+  function doCancel(): void {
+    const h = pendingHandle;
+    pendingHandle = null;
+    attentionImpl.cancel(h, getMainWindow());
+  }
+
+  const onStateChanged = (evt: { sid: string; state: WatcherState }): void => {
+    if (!evt || !evt.sid) return;
+    if (evt.state !== 'idle' && evt.state !== 'requires_action') return;
+
+    if (isMutedFn()) return;
+
+    // Exclusive with the notify path: notify fires when UNFOCUSED;
+    // attention-flash fires when FOCUSED. If we're not focused, let the
+    // toast carry the signal.
+    if (!isWindowFocusedFn()) return;
+
+    // The user is already looking at this session — no cue needed.
+    if (getActiveSidFn() === evt.sid) return;
+
+    const payload: AttentionEvent = {
+      sid: evt.sid,
+      state: evt.state,
+      ts: Date.now(),
+      kind: 'noop', // overwritten by impl
+    };
+
+    const handle = attentionImpl.flash(payload);
+
+    // Real flashFrame call lives here (not inside impl) so we can reach
+    // the live BrowserWindow without threading it through the impl signature.
+    if (payload.kind === 'flashFrame') {
+      try {
+        const win = getMainWindow();
+        if (win && !win.isDestroyed()) {
+          win.flashFrame(true);
+        }
+      } catch (err) {
+        console.warn('[attention] flashFrame(true) failed', err);
+      }
+    }
+
+    // Replace any prior pending handle. Cancel the old one first so we
+    // don't leak a dock-bounce id that nobody will ever cancel.
+    if (pendingHandle != null && pendingHandle !== handle) {
+      attentionImpl.cancel(pendingHandle, getMainWindow());
+    }
+    pendingHandle = handle;
+  };
+
+  sessionWatcher.on('state-changed', onStateChanged);
+
+  return {
+    dispose: () => {
+      sessionWatcher.off('state-changed', onStateChanged);
+      doCancel();
+    },
+    cancel: doCancel,
+  };
+}

--- a/electron/notify/index.ts
+++ b/electron/notify/index.ts
@@ -1,5 +1,10 @@
 // Desktop notification bridge.
 //
+// NOTE: This module owns the OS-toast path (window UNFOCUSED). The mutually
+// exclusive in-app attention path (window FOCUSED, different session) lives
+// in `./attention.ts` — both subscribe to the same `state-changed` events
+// and share the focus / mute / active-sid suppression rules.
+//
 // Subscribes to the in-process `sessionWatcher` ('state-changed' events) and
 // fires an OS notification via Electron's built-in `Notification` API when a
 // session transitions to a state the user actually cares about — `'idle'`


### PR DESCRIPTION
PR B of 2 for #600. Technically independent of PR A (sidebar cleanup), but full UX correctness lands once both are in.

## Summary
- New `electron/notify/attention.ts` (~110 LOC, ~210 with comments) — in-app attention flash that fires when the window IS focused but the user is on a DIFFERENT session and another session transitions to `idle` / `requires_action`.
- Mutually exclusive with the existing OS-toast notify bridge: notify fires when UNFOCUSED, attention-flash fires when FOCUSED. Same focus / mute / active-sid suppression rules.
- Wired into `electron/main.ts`: install after `installNotifyBridge`; `win.on('focus')` and `session:setActive` IPC both cancel any pending cue.
- `electron/notify/index.ts` gets a one-block comment cross-linking the two modules. No behavior change.

## Cross-platform
- Windows: `BrowserWindow.flashFrame(true)` — taskbar pulse until focus or `flashFrame(false)`.
- macOS: `app.dock.bounce('informational')` — single bounce, returns id, cancelled on focus / setActive. Deliberately NOT `'critical'` (would bounce forever).
- Linux: best-effort `flashFrame` (silently no-op on WMs without urgency hints; honoured by KWin / Mutter).

## Test plan
- [x] `npm run build` clean (only existing bundle-size warnings).
- [x] `node -e "require('./dist/electron/sessionTitles/index.js')"` no `ERR_REQUIRE_ESM`.
- [x] `npx vitest run electron/notify/__tests__/attention.test.ts` — 11/11 pass.
- [x] Full `npm test` — 346 pass; only failures are 3 unrelated `better-sqlite3` ABI-mismatch errors in this env (NODE_MODULE_VERSION 130 vs 137), no production code touched by this PR is in those tests.

## Test seam
Test hook mirrors notify pattern: `globalThis.__ccsmAttentionLog` populated when `CCSM_NOTIFY_TEST_HOOK` is set (e2e harness reads via `electronApp.evaluate`).

## Anti-patterns avoided
- No `'critical'` dock bounce.
- No new IPC channel.
- `BadgeManager` untouched (separate concern: out-of-app unread count).
- No i18n changes.
- No static import of `@anthropic-ai/claude-agent-sdk`.
- Flash and notify never both fire for the same event (focus rule is exclusive).
- Sidebar untouched (PR A).