### PR TITLE
fix(ui): remove per-group + and chevron, consolidate to top NewSession (#605)

### DIFF
--- a/scripts/harness-real-cli.mjs
+++ b/scripts/harness-real-cli.mjs
@@ -2078,56 +2078,6 @@ async function caseCwdPickerTopChevron({ win, tempDir }) {
   await _deleteActive(win);
 }
 
-// Case: cwd-picker-group
-//   Open a normal group's chevron → pick a cwd → new session lands in that
-//   group AND uses the picked cwd.
-async function caseCwdPickerGroup({ win, tempDir }) {
-  await _waitBoot(win);
-  const groupId = await _seedGroup(win, 'cwd-picker-group');
-  // Wait for the new group's right-rail cluster to render.
-  await win.waitForFunction(
-    (gid) => !!document.querySelector(`[data-group-header-id="${gid}"] [data-sidebar-group-newsession-cluster]`),
-    groupId,
-    { timeout: 4000 },
-  );
-  const pickPath = path.join(tempDir, 'group-pick-' + Math.random().toString(36).slice(2, 8));
-  await _seedRecentCwd(win, pickPath);
-  const target = _norm(pickPath);
-
-  const before = await _sessionCount(win);
-  await win.evaluate((gid) => {
-    const cluster = document.querySelector(`[data-group-header-id="${gid}"] [data-sidebar-group-newsession-cluster]`);
-    if (!cluster) throw new Error('group cluster not found');
-    const chevron = cluster.querySelector('[data-testid="sidebar-group-newsession-cwd-chevron"]');
-    if (!chevron) throw new Error('group chevron not found');
-    chevron.click();
-  }, groupId);
-  await win.waitForSelector('[data-testid="cwd-popover-panel"]', { timeout: 4000 });
-
-  await win.evaluate((needle) => {
-    const opts = Array.from(document.querySelectorAll('[data-testid="cwd-popover-panel"] [role="option"]'));
-    const hit = opts.find((el) => (el.getAttribute('title') || el.textContent || '').includes(needle.split(/[\\/]/).pop()));
-    if (!hit) throw new Error(`recent row not found for ${needle}`);
-    hit.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
-  }, target);
-  await sleep(300);
-
-  const after = await _sessionCount(win);
-  if (after - before !== 1) throw new Error(`expected 1 new session, got delta=${after - before}`);
-  const result = await win.evaluate(() => {
-    const st = window.__ccsmStore.getState();
-    const a = st.sessions.find((s) => s.id === st.activeId);
-    return { cwd: a?.cwd ?? null, groupId: a?.groupId ?? null };
-  });
-  if (_norm(result.cwd) !== target) {
-    throw new Error(`group chevron pick cwd mismatch. picked=${target} actual=${result.cwd}`);
-  }
-  if (result.groupId !== groupId) {
-    throw new Error(`group chevron pick targeted wrong group. expected=${groupId} actual=${result.groupId}`);
-  }
-  await _deleteActive(win);
-}
-
 // Case: cwd-picker-no-shortcut
 //   Cmd+N / Ctrl+N must NOT create a session anymore — the keyboard shortcut
 //   was removed in the same task. Holds for both unmodified `n` (always was
@@ -2160,58 +2110,6 @@ async function caseCwdPickerNoShortcut({ win }) {
   }
 }
 
-// Case: cwd-picker-only-one-open
-//   Open the top chevron popover → click a group chevron → top popover
-//   closes, group popover opens. Mutex behaviour — only one cwd picker at
-//   a time.
-async function caseCwdPickerOnlyOneOpen({ win }) {
-  await _waitBoot(win);
-  const groupId = await _seedGroup(win, 'cwd-picker-mutex');
-  await win.waitForFunction(
-    (gid) => !!document.querySelector(`[data-group-header-id="${gid}"] [data-sidebar-group-newsession-cluster]`),
-    groupId,
-    { timeout: 4000 },
-  );
-
-  // Open the TOP chevron.
-  await win.click('[data-testid="sidebar-newsession-cwd-chevron"]');
-  await win.waitForSelector('[data-testid="cwd-popover-panel"]', { timeout: 4000 });
-  const panelsAfterTop = await win.evaluate(
-    () => document.querySelectorAll('[data-testid="cwd-popover-panel"]').length,
-  );
-  if (panelsAfterTop !== 1) throw new Error(`expected exactly 1 panel after top, got ${panelsAfterTop}`);
-
-  // Open the GROUP chevron — top must close.
-  await win.evaluate((gid) => {
-    const chevron = document.querySelector(
-      `[data-group-header-id="${gid}"] [data-testid="sidebar-group-newsession-cwd-chevron"]`,
-    );
-    if (!chevron) throw new Error('group chevron not found');
-    chevron.click();
-  }, groupId);
-  // Settle for state propagation.
-  await sleep(200);
-  const panelsAfterGroup = await win.evaluate(
-    () => document.querySelectorAll('[data-testid="cwd-popover-panel"]').length,
-  );
-  if (panelsAfterGroup !== 1) {
-    throw new Error(`expected exactly 1 panel open at a time, got ${panelsAfterGroup}`);
-  }
-
-  // Sanity: the top chevron's aria-expanded must now be false.
-  const topExpanded = await win.evaluate(() => {
-    const el = document.querySelector('[data-testid="sidebar-newsession-cwd-chevron"]');
-    return el?.getAttribute('aria-expanded') ?? null;
-  });
-  if (topExpanded !== 'false') {
-    throw new Error(`top chevron should be aria-expanded=false after group opens, got ${topExpanded}`);
-  }
-
-  // Cleanup: close.
-  await win.keyboard.press('Escape');
-  await sleep(150);
-}
-
 // ============================================================================
 // Registry
 // ============================================================================
@@ -2230,9 +2128,7 @@ const CASE_REGISTRY = [
   { name: 'pty-pid-stable-across-switch',group: 'shared', run: casePtyPidStableAcrossSwitch },
   { name: 'cwd-picker-top-default',      group: 'shared', run: caseCwdPickerTopDefault },
   { name: 'cwd-picker-top-chevron',      group: 'shared', run: caseCwdPickerTopChevron },
-  { name: 'cwd-picker-group',            group: 'shared', run: caseCwdPickerGroup },
   { name: 'cwd-picker-no-shortcut',      group: 'shared', run: caseCwdPickerNoShortcut },
-  { name: 'cwd-picker-only-one-open',    group: 'shared', run: caseCwdPickerOnlyOneOpen },
   { name: 'reopen-resume',               group: 'standalone', run: caseReopenResume },
   { name: 'pty-subtree-killed-on-quit',  group: 'standalone', run: casePtySubtreeKilledOnQuit },
 ];

--- a/scripts/harness-real-cli.mjs
+++ b/scripts/harness-real-cli.mjs
@@ -2110,6 +2110,34 @@ async function caseCwdPickerNoShortcut({ win }) {
   }
 }
 
+// Case: sidebar-group-no-newsession-cluster
+//   Per-group `+` button + cwd chevron were removed (see PR #605). The only
+//   way to start a new session is now the top-of-sidebar NewSession cluster.
+//   Hard-asserts that no GroupRow renders any of the per-group split-button
+//   selectors, so the deletion can't silently regress.
+async function caseSidebarGroupHasNoNewSessionCluster({ win }) {
+  await _waitBoot(win);
+  // Seed >=1 user group so at least one <GroupRow> mounts. Without a group,
+  // the assertion would trivially pass even if the per-group cluster were
+  // re-introduced.
+  await _seedGroup(win, 'no-cluster-' + Math.random().toString(36).slice(2, 6));
+  // Give the sidebar a tick to render the new GroupRow.
+  await sleep(200);
+
+  const counts = await win.evaluate(() => ({
+    cluster: document.querySelectorAll('[data-sidebar-group-newsession-cluster]').length,
+    plus: document.querySelectorAll('[data-sidebar-group-newsession-plus]').length,
+    chevron: document.querySelectorAll('[data-sidebar-group-newsession-cwd-chevron]').length,
+    groupRows: document.querySelectorAll('[data-testid^="sidebar-group-row"], [data-sidebar-group-row]').length,
+  }));
+
+  if (counts.cluster !== 0 || counts.plus !== 0 || counts.chevron !== 0) {
+    throw new Error(
+      `per-group newsession cluster regressed: cluster=${counts.cluster} plus=${counts.plus} chevron=${counts.chevron}`,
+    );
+  }
+}
+
 // ============================================================================
 // Registry
 // ============================================================================
@@ -2129,6 +2157,7 @@ const CASE_REGISTRY = [
   { name: 'cwd-picker-top-default',      group: 'shared', run: caseCwdPickerTopDefault },
   { name: 'cwd-picker-top-chevron',      group: 'shared', run: caseCwdPickerTopChevron },
   { name: 'cwd-picker-no-shortcut',      group: 'shared', run: caseCwdPickerNoShortcut },
+  { name: 'sidebar-group-no-newsession-cluster', group: 'shared', run: caseSidebarGroupHasNoNewSessionCluster },
   { name: 'reopen-resume',               group: 'standalone', run: caseReopenResume },
   { name: 'pty-subtree-killed-on-quit',  group: 'standalone', run: casePtySubtreeKilledOnQuit },
 ];

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -131,9 +131,7 @@ function GroupRow({
   autoRename,
   onSelectSession,
   onFocus,
-  normalGroups,
-  cwdPopoverOpen,
-  onCwdPopoverOpenChange
+  normalGroups
 }: {
   group: Group;
   sessions: Session[];
@@ -149,11 +147,6 @@ function GroupRow({
   /** Pre-filtered list of normal (non-archive) groups, hoisted to the parent
    *  Sidebar so we don't recompute per SessionRow per render. */
   normalGroups: Group[];
-  /** True when THIS group's chevron popover is the currently-open one.
-   *  Sidebar centralises the picker state so only one popover is open at
-   *  a time (top OR exactly one group). */
-  cwdPopoverOpen: boolean;
-  onCwdPopoverOpenChange: (open: boolean) => void;
 }) {
   const { t } = useTranslation();
   const sessionIds = sessions.map((s) => s.id);
@@ -164,7 +157,6 @@ function GroupRow({
   const restoreGroup = useStore((s) => s.restoreGroup);
   const archiveGroup = useStore((s) => s.archiveGroup);
   const unarchiveGroup = useStore((s) => s.unarchiveGroup);
-  const createSession = useStore((s) => s.createSession);
   const toast = useToast();
   const collapsed = group.collapsed;
   const [renaming, setRenaming] = useState(!!autoRename);
@@ -201,11 +193,6 @@ function GroupRow({
       }
     };
   }, [isOver, collapsed, group.id, setGroupCollapsed]);
-  // Per-group chevron anchor + popover. The chevron sits next to the group's
-  // `+` button (task #552). Clicking `+` creates a session in this group
-  // with the LRU default cwd; clicking `▾` opens a popover so the user can
-  // pick a non-default cwd before creation.
-  const chevronRef = useRef<HTMLButtonElement>(null);
   return (
     <div className="mb-2">
       <ContextMenu>
@@ -272,31 +259,6 @@ function GroupRow({
                 </>
               )}
             </button>
-            {group.kind === 'normal' && !renaming && (
-              <span className="sidebar-rail-cell sidebar-rail-cell--nested shrink-0">
-                <NewSessionSplit
-                  chevronRef={chevronRef}
-                  cwdPopoverOpen={cwdPopoverOpen}
-                  onCwdPopoverOpenChange={onCwdPopoverOpenChange}
-                  onPlusClick={(e) => {
-                    e.stopPropagation();
-                    createSession({ groupId: group.id });
-                  }}
-                  onChevronClick={(e) => {
-                    e.stopPropagation();
-                    onCwdPopoverOpenChange(!cwdPopoverOpen);
-                  }}
-                  onPickCwd={(picked) => {
-                    createSession({ groupId: group.id, cwd: picked });
-                    onCwdPopoverOpenChange(false);
-                  }}
-                  plusAria={t('sidebar.newSessionInThisGroup')}
-                  plusTooltip={t('sidebar.newSessionInThisGroup')}
-                  chevronAria={t('sidebar.pickCwdAria')}
-                  chevronTooltip={t('sidebar.pickCwdTooltip')}
-                />
-              </span>
-            )}
           </div>
         </ContextMenuTrigger>
         <ContextMenuContent>
@@ -378,26 +340,6 @@ function GroupRow({
           }
         }}
       />
-      {/* Per-group cwd picker. Rendered at the GroupRow level (not inside
-          the rail cell) so the popover panel — which uses fixed positioning
-          to escape sidebar overflow:hidden — has a single owner regardless
-          of whether the row is collapsed. */}
-      {group.kind === 'normal' && (
-        <CwdPopover
-          open={cwdPopoverOpen}
-          onOpenChange={onCwdPopoverOpenChange}
-          anchorRef={chevronRef}
-          onPick={(picked) => {
-            createSession({ groupId: group.id, cwd: picked });
-            onCwdPopoverOpenChange(false);
-          }}
-          onBrowse={() => {
-            // No native folder picker IPC yet; user can paste a path
-            // into the popover input and press Enter to commit.
-            onCwdPopoverOpenChange(false);
-          }}
-        />
-      )}
     </div>
   );
 }
@@ -694,69 +636,6 @@ function NewSessionButton({
   );
 }
 
-/**
- * Per-group cluster: the small ghost `+` IconButton + a sibling `▾` chevron,
- * both visually grouped as one rounded-pill action. Used inside each group
- * header's right-rail cell. Shared between every GroupRow but kept top-level
- * (not inside <GroupRow>) so the prop wiring is explicit.
- */
-function NewSessionSplit({
-  chevronRef,
-  cwdPopoverOpen,
-  onCwdPopoverOpenChange,
-  onPlusClick,
-  onChevronClick,
-  onPickCwd: _onPickCwd, // popover lives on the parent GroupRow; this prop documents intent
-  plusAria,
-  plusTooltip,
-  chevronAria,
-  chevronTooltip
-}: {
-  chevronRef: React.RefObject<HTMLButtonElement>;
-  cwdPopoverOpen: boolean;
-  onCwdPopoverOpenChange: (open: boolean) => void;
-  onPlusClick: (e: React.MouseEvent) => void;
-  onChevronClick: (e: React.MouseEvent) => void;
-  onPickCwd: (cwd: string) => void;
-  plusAria: string;
-  plusTooltip: string;
-  chevronAria: string;
-  chevronTooltip: string;
-}) {
-  void onCwdPopoverOpenChange;
-  return (
-    <span className="inline-flex items-stretch shrink-0" data-sidebar-group-newsession-cluster>
-      <IconButton
-        size="xs"
-        variant="ghost"
-        aria-label={plusAria}
-        tooltip={plusTooltip}
-        tooltipSide="top"
-        onClick={onPlusClick}
-        className="shrink-0 !rounded-r-none"
-        data-testid="sidebar-group-newsession-plus"
-      >
-        <Plus size={12} className="stroke-[1.75]" />
-      </IconButton>
-      <IconButton
-        ref={chevronRef}
-        size="xs"
-        variant="ghost"
-        aria-label={chevronAria}
-        aria-expanded={cwdPopoverOpen}
-        aria-haspopup="dialog"
-        tooltip={chevronTooltip}
-        tooltipSide="top"
-        onClick={onChevronClick}
-        className="shrink-0 !rounded-l-none w-4"
-        data-testid="sidebar-group-newsession-cwd-chevron"
-      >
-        <ChevronDown size={10} className="stroke-[1.75]" />
-      </IconButton>
-    </span>
-  );
-}
-
 export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, onOpenImport, activeSessionId, focusedGroupId, onSelectSession, onFocusGroup, sessions, onMoveSession }: SidebarProps) {
   const { t } = useTranslation();
   const groups = useStore((s) => s.groups);
@@ -779,18 +658,10 @@ export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, onOpen
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
   const draggingSession = draggingId ? sessions.find((s) => s.id === draggingId) ?? null : null;
 
-  // Cwd picker mutex (task #552). Only ONE cwd popover may be open at a
-  // time across the whole sidebar — either the top "+ ▾" cluster or
-  // exactly one group's "+ ▾". Encoding it as a tagged-union picks the
-  // mutex without needing a string sentinel for the top slot.
-  const [openCwdPicker, setOpenCwdPicker] = useState<
-    { kind: 'top' } | { kind: 'group'; id: string } | null
-  >(null);
-  const topCwdPickerOpen = openCwdPicker?.kind === 'top';
-  const setTopCwdPickerOpen = (open: boolean) =>
-    setOpenCwdPicker(open ? { kind: 'top' } : null);
-  const setGroupCwdPickerOpen = (groupId: string, open: boolean) =>
-    setOpenCwdPicker(open ? { kind: 'group', id: groupId } : null);
+  // Cwd picker for the top "+ New session" cluster. The per-group chevron
+  // was removed (#605) — only the top picker remains, so a plain boolean
+  // suffices here.
+  const [topCwdPickerOpen, setTopCwdPickerOpen] = useState(false);
 
   // Anchor ref for the top New Session chevron — passed into both the
   // <NewSessionButton> (which forwards to the IconButton) and the top-level
@@ -1015,10 +886,6 @@ export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, onOpen
                 onSelectSession={onSelectSession}
                 onFocus={() => onFocusGroup(g.id)}
                 normalGroups={normal}
-                cwdPopoverOpen={
-                  openCwdPicker?.kind === 'group' && openCwdPicker.id === g.id
-                }
-                onCwdPopoverOpenChange={(o) => setGroupCwdPickerOpen(g.id, o)}
               />
             ))}
           </nav>
@@ -1062,10 +929,6 @@ export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, onOpen
                   onSelectSession={onSelectSession}
                   onFocus={() => onFocusGroup(g.id)}
                   normalGroups={normal}
-                  cwdPopoverOpen={
-                    openCwdPicker?.kind === 'group' && openCwdPicker.id === g.id
-                  }
-                  onCwdPopoverOpenChange={(o) => setGroupCwdPickerOpen(g.id, o)}
                 />
               ))}
             </nav>

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -42,7 +42,6 @@ const en = {
   },
   sidebar: {
     newSession: 'New Session',
-    newSessionInThisGroup: 'New session in this group',
     newGroup: 'New group',
     newGroupEllipsis: 'New group…',
     groups: 'Groups',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -42,7 +42,6 @@ const zh: EnCatalog = {
   },
   sidebar: {
     newSession: '新会话',
-    newSessionInThisGroup: '在此 Group 新建 Session',
     newGroup: '新建分组',
     newGroupEllipsis: '新建分组…',
     groups: '分组',


### PR DESCRIPTION
## Summary
- Removes the per-group `+` button and `▾` cwd chevron from every group row in the sidebar — the cluster was visually noisy and duplicated the canonical entry point at the top of the sidebar.
- The only way to create a new session is now the single `+ New Session` button at the top (its top-anchored chevron + popover are unchanged).
- Group rows still show: collapse arrow, name, and session count. Group collapse/expand still works.

## Changes
- `src/components/Sidebar.tsx` — drop `NewSessionSplit` JSX from `GroupRow`, drop the per-group `CwdPopover` instance, drop the `NewSessionSplit` component (no other callers), collapse the `openCwdPicker` tagged-union to a plain boolean.
- `src/i18n/locales/{en,zh}.ts` — drop the now-orphan `sidebar.newSessionInThisGroup` key (only the per-group cluster used it; top-cluster `pickCwdAria`/`pickCwdTooltip` keys retained).
- `scripts/harness-real-cli.mjs` — drop the `cwd-picker-group` and `cwd-picker-only-one-open` e2e cases (both depended on the per-group chevron). Top-cluster cases (`cwd-picker-top-default`, `cwd-picker-top-chevron`, `cwd-picker-no-shortcut`) preserved.

Diff: 4 files, +5 / -248.

## Test plan
- [x] `npm run build` clean
- [x] `node -e \"require('./dist/electron/sessionTitles/index.js')\"` no ERR_REQUIRE_ESM
- [x] `npm test` 335/338 (3 known native-module ABI fails: better-sqlite3 built for Electron Node 130 vs host Node v24 NODE_MODULE_VERSION 137 — pre-existing infra, unrelated)
- [ ] Manual smoke: top \`+ New session\` still spawns; groups have no per-row \`+\` or chevron; group collapse/expand arrow still works