### PR TITLE
fix(import): imported session resumes claude with --resume (#603)

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -254,10 +254,12 @@ export type SessionState = 'idle' | 'running' | 'requires_action';
 type SessionStatePayload = { sid: string; state: SessionState };
 type SessionActivatePayload = { sid: string };
 type SessionTitlePayload = { sid: string; title: string };
+type SessionCwdRedirectedPayload = { sid: string; newCwd: string };
 
 const sessionStateListeners = new Set<(e: SessionStatePayload) => void>();
 const sessionActivateListeners = new Set<(e: SessionActivatePayload) => void>();
 const sessionTitleListeners = new Set<(e: SessionTitlePayload) => void>();
+const sessionCwdRedirectedListeners = new Set<(e: SessionCwdRedirectedPayload) => void>();
 
 ipcRenderer.on('session:state', (_e: IpcRendererEvent, payload: SessionStatePayload) => {
   for (const cb of sessionStateListeners) {
@@ -282,6 +284,23 @@ ipcRenderer.on('session:title', (_e: IpcRendererEvent, payload: SessionTitlePayl
     }
   }
 });
+
+// Main pushes `session:cwdRedirected` after the import-resume copy helper
+// (#603) relocates a JSONL into the spawn cwd's projectDir. The renderer
+// patches `session.cwd` so the sessionTitles bridge (rename / list /
+// backfill) reads/writes the COPY rather than the now-frozen SOURCE.
+ipcRenderer.on(
+  'session:cwdRedirected',
+  (_e: IpcRendererEvent, payload: SessionCwdRedirectedPayload) => {
+    for (const cb of sessionCwdRedirectedListeners) {
+      try {
+        cb(payload);
+      } catch (err) {
+        console.error('[ccsmSession] onCwdRedirected listener threw', err);
+      }
+    }
+  },
+);
 
 // Main pushes `session:activate` when the user clicks a desktop notification.
 // Renderer subscribes via `window.ccsmSession.onActivate` and calls its
@@ -313,6 +332,12 @@ const ccsmSession = {
     sessionTitleListeners.add(cb);
     return () => {
       sessionTitleListeners.delete(cb);
+    };
+  },
+  onCwdRedirected: (cb: (e: SessionCwdRedirectedPayload) => void): (() => void) => {
+    sessionCwdRedirectedListeners.add(cb);
+    return () => {
+      sessionCwdRedirectedListeners.delete(cb);
     };
   },
   // Renderer pushes its active session id to main so the notify bridge can

--- a/electron/ptyHost/__tests__/import-resume-copy.test.ts
+++ b/electron/ptyHost/__tests__/import-resume-copy.test.ts
@@ -78,12 +78,16 @@ describe('ensureResumeJsonlAtSpawnCwd (#603)', () => {
     const expectedProjectDir = 'C--Users-jiahuigu';
     const expectedTarget = pathJoin(tmp, 'projects', expectedProjectDir, `${sid}.jsonl`);
 
-    ensureResumeJsonlAtSpawnCwd(sid, spawnCwd, source);
+    const result = ensureResumeJsonlAtSpawnCwd(sid, spawnCwd, source);
 
     const st = statSync(expectedTarget);
     expect(st.isFile()).toBe(true);
     expect(st.size).toBeGreaterThan(0);
     expect(readFileSync(expectedTarget, 'utf8')).toBe('{"type":"user"}\n');
+    // #603 reviewer Layer-1 fix — caller relies on `copied` to decide
+    // whether to fire the cwd-redirect IPC.
+    expect(result.copied).toBe(true);
+    expect(result.targetPath).toBe(expectedTarget);
   });
 
   it('is a no-op when source is already at the target path', () => {
@@ -93,11 +97,14 @@ describe('ensureResumeJsonlAtSpawnCwd (#603)', () => {
     const projectDir = 'C--Users-jiahuigu';
     const source = seedSourceJsonl(projectDir, sid, '{"type":"user"}\n');
 
-    ensureResumeJsonlAtSpawnCwd(sid, spawnCwd, source);
+    const result = ensureResumeJsonlAtSpawnCwd(sid, spawnCwd, source);
 
     // File untouched, only the one we seeded.
     const st = statSync(source);
     expect(st.isFile()).toBe(true);
+    // No copy → renderer must not see a redirect for the common case.
+    expect(result.copied).toBe(false);
+    expect(result.targetPath).toBe(source);
   });
 
   it('does not overwrite an existing destination JSONL', () => {
@@ -110,9 +117,13 @@ describe('ensureResumeJsonlAtSpawnCwd (#603)', () => {
     // Pretend the CLI already wrote a continuation here — we must not clobber it.
     writeFileSync(target, '{"existing":"do-not-touch"}\n', 'utf8');
 
-    ensureResumeJsonlAtSpawnCwd(sid, spawnCwd, source);
+    const result = ensureResumeJsonlAtSpawnCwd(sid, spawnCwd, source);
 
     expect(readFileSync(target, 'utf8')).toBe('{"existing":"do-not-touch"}\n');
+    // Destination already existed → no fresh copy this spawn, but we still
+    // surface the canonical target so callers can compare.
+    expect(result.copied).toBe(false);
+    expect(result.targetPath).toBe(target);
   });
 
   it('bails silently when projectsRoot is unresolvable', () => {
@@ -124,8 +135,10 @@ describe('ensureResumeJsonlAtSpawnCwd (#603)', () => {
     writeFileSync(source, 'x', 'utf8');
 
     // No throw — just a quiet no-op (caller logs at warn-level instead).
-    expect(() =>
-      ensureResumeJsonlAtSpawnCwd(sid, 'C:\\Users\\jiahuigu', source),
-    ).not.toThrow();
+    let result;
+    expect(() => {
+      result = ensureResumeJsonlAtSpawnCwd(sid, 'C:\\Users\\jiahuigu', source);
+    }).not.toThrow();
+    expect(result).toEqual({ copied: false, targetPath: null });
   });
 });

--- a/electron/ptyHost/__tests__/import-resume-copy.test.ts
+++ b/electron/ptyHost/__tests__/import-resume-copy.test.ts
@@ -1,0 +1,131 @@
+// Pins the import-resume copy contract that fixes #603. When the user
+// imports a JSONL whose recorded cwd no longer exists, `resolveSpawnCwd`
+// falls back to homedir, the spawn cwd's projectKey then mismatches the
+// JSONL's actual location, and `claude --resume <sid>` exits with
+// "No conversation found" — leaving the right pane blank. The fix copies
+// the JSONL into `<projectsRoot>/<cwdToProjectKey(spawnCwd)>/<sid>.jsonl`
+// so claude finds it without ever reaching the missing-cwd case.
+//
+// We mock the heavy imports (node-pty, headless terminal, electron, etc.)
+// the same way `cwd-fallback.test.ts` does so the helper loads in jsdom.
+
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join as pathJoin } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node-pty', () => ({ spawn: vi.fn() }));
+vi.mock('@xterm/headless', () => ({ Terminal: class {} }));
+vi.mock('@xterm/addon-serialize', () => ({ SerializeAddon: class {} }));
+vi.mock('electron', () => ({}));
+vi.mock('../claudeResolver', () => ({ resolveClaude: () => null }));
+vi.mock('../../sessionWatcher', () => ({
+  sessionWatcher: { on: vi.fn(), startWatching: vi.fn(), stopWatching: vi.fn() },
+}));
+// Real projectKey encoding — the helper depends on the round-trip between
+// the spawn cwd and the projectDir name, so a stub would defeat the test.
+vi.mock('../../sessionWatcher/projectKey', async () => {
+  return {
+    cwdToProjectKey: (cwd: string) =>
+      typeof cwd === 'string' && cwd.length > 0 ? cwd.replace(/[\\/:]/g, '-') : '',
+  };
+});
+
+import { ensureResumeJsonlAtSpawnCwd } from '../index';
+
+describe('ensureResumeJsonlAtSpawnCwd (#603)', () => {
+  let tmp: string;
+  let originalCfg: string | undefined;
+  let originalHome: string | undefined;
+  let originalUserprofile: string | undefined;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(pathJoin(tmpdir(), 'ccsm-import-resume-'));
+    originalCfg = process.env.CLAUDE_CONFIG_DIR;
+    originalHome = process.env.HOME;
+    originalUserprofile = process.env.USERPROFILE;
+    // Pin the projects root to a tmp dir so the test never touches the
+    // real `~/.claude/projects/`.
+    process.env.CLAUDE_CONFIG_DIR = tmp;
+    delete process.env.HOME;
+    delete process.env.USERPROFILE;
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (originalCfg === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = originalCfg;
+    if (originalHome !== undefined) process.env.HOME = originalHome;
+    if (originalUserprofile !== undefined) process.env.USERPROFILE = originalUserprofile;
+    try { rmSync(tmp, { recursive: true, force: true }); } catch { /* noop */ }
+    vi.restoreAllMocks();
+  });
+
+  function seedSourceJsonl(projectDirName: string, sid: string, body: string): string {
+    const dir = pathJoin(tmp, 'projects', projectDirName);
+    mkdirSync(dir, { recursive: true });
+    const file = pathJoin(dir, `${sid}.jsonl`);
+    writeFileSync(file, body, 'utf8');
+    return file;
+  }
+
+  it('copies the source JSONL into the projectDir matching spawn cwd', () => {
+    const sid = '003080a4-09c8-4fb4-a79a-4ec6cbf4ba28';
+    // Source lives under the originally-recorded cwd's projectDir.
+    const source = seedSourceJsonl('C--old-deleted-project', sid, '{"type":"user"}\n');
+    // User's spawn cwd: homedir fallback, encodes to a different projectKey.
+    const spawnCwd = 'C:\\Users\\jiahuigu';
+    const expectedProjectDir = 'C--Users-jiahuigu';
+    const expectedTarget = pathJoin(tmp, 'projects', expectedProjectDir, `${sid}.jsonl`);
+
+    ensureResumeJsonlAtSpawnCwd(sid, spawnCwd, source);
+
+    const st = statSync(expectedTarget);
+    expect(st.isFile()).toBe(true);
+    expect(st.size).toBeGreaterThan(0);
+    expect(readFileSync(expectedTarget, 'utf8')).toBe('{"type":"user"}\n');
+  });
+
+  it('is a no-op when source is already at the target path', () => {
+    const sid = 'aaaa1111-2222-4333-8444-555566667777';
+    // Source lives at exactly the path the spawn cwd resolves to → no copy.
+    const spawnCwd = 'C:\\Users\\jiahuigu';
+    const projectDir = 'C--Users-jiahuigu';
+    const source = seedSourceJsonl(projectDir, sid, '{"type":"user"}\n');
+
+    ensureResumeJsonlAtSpawnCwd(sid, spawnCwd, source);
+
+    // File untouched, only the one we seeded.
+    const st = statSync(source);
+    expect(st.isFile()).toBe(true);
+  });
+
+  it('does not overwrite an existing destination JSONL', () => {
+    const sid = 'bbbb2222-3333-4444-8555-666677778888';
+    const source = seedSourceJsonl('C--old-deleted-project', sid, '{"src":"original"}\n');
+    const spawnCwd = 'C:\\Users\\jiahuigu';
+    const targetDir = pathJoin(tmp, 'projects', 'C--Users-jiahuigu');
+    mkdirSync(targetDir, { recursive: true });
+    const target = pathJoin(targetDir, `${sid}.jsonl`);
+    // Pretend the CLI already wrote a continuation here — we must not clobber it.
+    writeFileSync(target, '{"existing":"do-not-touch"}\n', 'utf8');
+
+    ensureResumeJsonlAtSpawnCwd(sid, spawnCwd, source);
+
+    expect(readFileSync(target, 'utf8')).toBe('{"existing":"do-not-touch"}\n');
+  });
+
+  it('bails silently when projectsRoot is unresolvable', () => {
+    delete process.env.CLAUDE_CONFIG_DIR;
+    delete process.env.HOME;
+    delete process.env.USERPROFILE;
+    const sid = 'cccc3333-4444-4555-8666-777788889999';
+    const source = pathJoin(tmp, 'src.jsonl');
+    writeFileSync(source, 'x', 'utf8');
+
+    // No throw — just a quiet no-op (caller logs at warn-level instead).
+    expect(() =>
+      ensureResumeJsonlAtSpawnCwd(sid, 'C:\\Users\\jiahuigu', source),
+    ).not.toThrow();
+  });
+});

--- a/electron/ptyHost/index.ts
+++ b/electron/ptyHost/index.ts
@@ -221,34 +221,49 @@ function resolveProjectsRoot(): string | null {
 // CLI then writes back to that file). Failures are logged and swallowed;
 // worst case we keep the prior blank-terminal symptom but with a clear
 // reason in the console. Exposed for `__tests__/import-resume-copy.test.ts`.
+export interface EnsureResumeJsonlResult {
+  /** True when a copy actually happened on this call (source path differed
+   *  from target AND target didn't already exist). False otherwise — source
+   *  was already at the canonical location, target already existed, or a
+   *  precondition failed (no projectsRoot, no projectKey, copy threw). */
+  copied: boolean;
+  /** The canonical target path under the spawn cwd's projectDir, even when
+   *  no copy happened — callers use this to verify source==target and to
+   *  report the redirect destination back to the renderer. Null when we
+   *  couldn't resolve a projectsRoot or projectKey. */
+  targetPath: string | null;
+}
+
 export function ensureResumeJsonlAtSpawnCwd(
   claudeSid: string,
   spawnCwd: string,
   sourceJsonlPath: string,
-): void {
+): EnsureResumeJsonlResult {
   const projectsRoot = resolveProjectsRoot();
-  if (!projectsRoot) return;
+  if (!projectsRoot) return { copied: false, targetPath: null };
   const projectKey = cwdToProjectKey(spawnCwd);
-  if (!projectKey) return;
+  if (!projectKey) return { copied: false, targetPath: null };
   const targetPath = pathJoin(projectsRoot, projectKey, `${claudeSid}.jsonl`);
   // Already in place (the source IS the canonical location for this cwd,
   // or a previous spawn already copied it — never overwrite live transcripts).
-  if (targetPath === sourceJsonlPath) return;
+  if (targetPath === sourceJsonlPath) return { copied: false, targetPath };
   try {
     const st = statSync(targetPath);
-    if (st.isFile() && st.size > 0) return;
+    if (st.isFile() && st.size > 0) return { copied: false, targetPath };
   } catch {
     /* not present → fall through to copy */
   }
   try {
     mkdirSync(dirname(targetPath), { recursive: true });
     copyFileSync(sourceJsonlPath, targetPath);
+    return { copied: true, targetPath };
   } catch (err) {
     console.warn(
       `[ptyHost] failed to copy import JSONL ${JSON.stringify(sourceJsonlPath)} → ` +
         `${JSON.stringify(targetPath)} (${err instanceof Error ? err.message : String(err)}); ` +
         `claude --resume may report 'No conversation found'`,
     );
+    return { copied: false, targetPath };
   }
 }
 
@@ -258,6 +273,7 @@ function makeEntry(
   claudePath: string,
   cols: number,
   rows: number,
+  onCwdRedirect?: (newCwd: string) => void,
 ): Entry {
   const claudeSid = toClaudeSid(sid);
   const sourceJsonl = findJsonlForSid(claudeSid);
@@ -271,8 +287,25 @@ function makeEntry(
   // `claude --resume <sid>` can find it. No-op when source already lives
   // under the right projectKey (the common case for sessions originally
   // run from a still-existing cwd).
+  //
+  // When a copy actually happens, the live JSONL the CLI now appends to
+  // lives under `projectKey(spawnCwd)`, NOT under `projectKey(session.cwd)`.
+  // The renderer's sessionTitles bridge passes `session.cwd` to the SDK
+  // (`renameSession` / `getSessionInfo` / `listForProject`), so without a
+  // redirect the bridge would keep reading/writing the now-frozen SOURCE
+  // file (#603 reviewer Layer-1 finding). Notify the caller so it can
+  // patch `session.cwd` to `spawnCwd` in the renderer store.
   if (sourceJsonl) {
-    ensureResumeJsonlAtSpawnCwd(claudeSid, spawnCwd, sourceJsonl);
+    const result = ensureResumeJsonlAtSpawnCwd(claudeSid, spawnCwd, sourceJsonl);
+    if (result.copied && onCwdRedirect) {
+      try {
+        onCwdRedirect(spawnCwd);
+      } catch (err) {
+        console.warn(
+          `[ptyHost] cwd-redirect notify for ${sid} threw: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
   }
 
   const p = pty.spawn(claudePath, args, {
@@ -363,7 +396,7 @@ export function spawnPtySession(
   sid: string,
   cwd: string,
   claudePath: string,
-  opts?: { cols?: number; rows?: number },
+  opts?: { cols?: number; rows?: number; onCwdRedirect?: (newCwd: string) => void },
 ): PtySessionInfo {
   const existing = sessions.get(sid);
   if (existing) {
@@ -376,7 +409,7 @@ export function spawnPtySession(
   }
   const cols = opts?.cols ?? DEFAULT_COLS;
   const rows = opts?.rows ?? DEFAULT_ROWS;
-  const entry = makeEntry(sid, cwd, claudePath, cols, rows);
+  const entry = makeEntry(sid, cwd, claudePath, cols, rows, opts?.onCwdRedirect);
   sessions.set(sid, entry);
   return { sid, pid: entry.pty.pid, cols, rows };
 }
@@ -561,7 +594,26 @@ export function registerPtyHostIpc(
       return { ok: false, error: 'claude_not_found' };
     }
     try {
-      const info = spawnPtySession(sid, cwd, claudePath);
+      const info = spawnPtySession(sid, cwd, claudePath, {
+        // Import-resume cwd-redirect (#603 reviewer Layer-1 fix). When the
+        // copy helper relocates the JSONL into the spawn cwd's projectDir,
+        // the renderer's `session.cwd` (still pointing at the original
+        // recorded cwd, possibly missing) is now stale relative to the
+        // live JSONL. Push the new cwd to the renderer so the
+        // sessionTitles bridge (`store.ts:renameSession` / `_backfillTitles`
+        // / etc.) reads/writes the COPY, not the frozen SOURCE.
+        onCwdRedirect: (newCwd: string) => {
+          const win = getMainWindow();
+          if (!win || win.isDestroyed()) return;
+          const wc = win.webContents;
+          if (wc.isDestroyed()) return;
+          try {
+            wc.send('session:cwdRedirected', { sid, newCwd });
+          } catch {
+            /* renderer gone */
+          }
+        },
+      });
       return { ok: true, ...info };
     } catch (err) {
       return {

--- a/electron/ptyHost/index.ts
+++ b/electron/ptyHost/index.ts
@@ -30,9 +30,9 @@
 
 import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { existsSync, readdirSync, statSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdirSync, readdirSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join as pathJoin } from 'node:path';
+import { dirname, join as pathJoin } from 'node:path';
 import type { BrowserWindow, IpcMain, WebContents } from 'electron';
 import * as pty from 'node-pty';
 import { Terminal as HeadlessTerminal } from '@xterm/headless';
@@ -103,8 +103,10 @@ function toClaudeSid(ccsmSessionId: string): string {
 // default) for `<sid>.jsonl` with non-zero size. Mirrors the .cmd wrapper in
 // cliBridge/processManager.ts, just expressed in Node. Non-zero size guards
 // against the empty-file race where claude has created but not yet written
-// the transcript.
-function jsonlExistsForSid(sid: string): boolean {
+// the transcript. Returns the absolute path to the first matching file
+// found (so callers can locate the SOURCE for the import-resume copy-into-
+// place fix in `makeEntry`), or null when no transcript exists.
+export function findJsonlForSid(sid: string): string | null {
   const filename = `${sid}.jsonl`;
   const roots: string[] = [];
   const cfg = process.env.CLAUDE_CONFIG_DIR;
@@ -124,13 +126,21 @@ function jsonlExistsForSid(sid: string): boolean {
       const candidate = pathJoin(root, name, filename);
       try {
         const st = statSync(candidate);
-        if (st.isFile() && st.size > 0) return true;
+        if (st.isFile() && st.size > 0) return candidate;
       } catch {
         /* not present in this project dir */
       }
     }
   }
-  return false;
+  return null;
+}
+
+// Back-compat boolean wrapper. Internal callers prefer `findJsonlForSid`
+// (which surfaces the matched path so we can copy the JSONL into the
+// projectKey matching the spawn cwd — see `ensureResumeJsonlAtSpawnCwd`
+// for the import-resume fix #603).
+function jsonlExistsForSid(sid: string): boolean {
+  return findJsonlForSid(sid) !== null;
 }
 
 // Resolve the absolute path the CLI will write the session JSONL to:
@@ -182,6 +192,66 @@ export function resolveSpawnCwd(requested: string | null | undefined): string {
   }
 }
 
+// Resolve the CLI's projects ROOT directory (parent of every projectDir).
+// Mirrors `resolveJsonlPath` (above) but for the root, not the per-session
+// file. Returns null when neither CLAUDE_CONFIG_DIR nor $HOME / $USERPROFILE
+// is set — in that case there's nowhere to write and the import-resume copy
+// helper bails.
+function resolveProjectsRoot(): string | null {
+  const cfg = process.env.CLAUDE_CONFIG_DIR;
+  if (cfg) return pathJoin(cfg, 'projects');
+  const home = process.env.USERPROFILE || process.env.HOME;
+  if (home) return pathJoin(home, '.claude', 'projects');
+  return null;
+}
+
+// Import-resume fix (#603). `claude --resume <sid>` only finds a session
+// when the JSONL lives under the projectDir matching the CURRENT cwd's
+// projectKey. Imported transcripts can come from a cwd that no longer
+// exists — `resolveSpawnCwd` then falls back to homedir, the projectKey
+// mismatches the JSONL's actual location, claude exits with "No
+// conversation found", the pty terminates immediately, and the user sees a
+// blank terminal. Empirically reproduced by
+//   `cd /tmp && claude --resume <home-cwd-sid>`
+// → "No conversation found with session ID: ...".
+//
+// Fix: when the source JSONL exists but isn't already under the spawn
+// cwd's projectDir, copy it into place so `--resume` succeeds. Idempotent —
+// once the destination exists with non-zero size we leave it alone (the
+// CLI then writes back to that file). Failures are logged and swallowed;
+// worst case we keep the prior blank-terminal symptom but with a clear
+// reason in the console. Exposed for `__tests__/import-resume-copy.test.ts`.
+export function ensureResumeJsonlAtSpawnCwd(
+  claudeSid: string,
+  spawnCwd: string,
+  sourceJsonlPath: string,
+): void {
+  const projectsRoot = resolveProjectsRoot();
+  if (!projectsRoot) return;
+  const projectKey = cwdToProjectKey(spawnCwd);
+  if (!projectKey) return;
+  const targetPath = pathJoin(projectsRoot, projectKey, `${claudeSid}.jsonl`);
+  // Already in place (the source IS the canonical location for this cwd,
+  // or a previous spawn already copied it — never overwrite live transcripts).
+  if (targetPath === sourceJsonlPath) return;
+  try {
+    const st = statSync(targetPath);
+    if (st.isFile() && st.size > 0) return;
+  } catch {
+    /* not present → fall through to copy */
+  }
+  try {
+    mkdirSync(dirname(targetPath), { recursive: true });
+    copyFileSync(sourceJsonlPath, targetPath);
+  } catch (err) {
+    console.warn(
+      `[ptyHost] failed to copy import JSONL ${JSON.stringify(sourceJsonlPath)} → ` +
+        `${JSON.stringify(targetPath)} (${err instanceof Error ? err.message : String(err)}); ` +
+        `claude --resume may report 'No conversation found'`,
+    );
+  }
+}
+
 function makeEntry(
   sid: string,
   cwd: string,
@@ -190,10 +260,20 @@ function makeEntry(
   rows: number,
 ): Entry {
   const claudeSid = toClaudeSid(sid);
-  const flag = jsonlExistsForSid(claudeSid) ? '--resume' : '--session-id';
+  const sourceJsonl = findJsonlForSid(claudeSid);
+  const flag = sourceJsonl ? '--resume' : '--session-id';
   const args = [flag, claudeSid];
 
   const spawnCwd = resolveSpawnCwd(cwd);
+
+  // See `ensureResumeJsonlAtSpawnCwd` for the bug context (#603) — copies
+  // the import-source JSONL into the spawn cwd's projectDir so
+  // `claude --resume <sid>` can find it. No-op when source already lives
+  // under the right projectKey (the common case for sessions originally
+  // run from a still-existing cwd).
+  if (sourceJsonl) {
+    ensureResumeJsonlAtSpawnCwd(claudeSid, spawnCwd, sourceJsonl);
+  }
 
   const p = pty.spawn(claudePath, args, {
     name: 'xterm-256color',

--- a/scripts/harness-real-cli.mjs
+++ b/scripts/harness-real-cli.mjs
@@ -828,6 +828,93 @@ async function caseNotifyFiresOnIdle({ electronApp, win, tempDir }) {
 }
 
 // ============================================================================
+// Case: attention-flashes-on-nonactive-idle (PR #513 in-app attention flash)
+// ============================================================================
+//
+// Verifies installAttentionFlash via the test seam:
+//   - window FOCUSED + sid != active → flash recorded in __ccsmAttentionLog
+//   - window FOCUSED + sid == active → no entry (active-sid suppressed)
+//   - window UNFOCUSED → no entry (notify path takes over)
+//
+// Drives sessionWatcher synthetically through __ccsmAttentionTest seam to
+// avoid spinning two real CLI sessions just to flip state machines.
+
+async function caseAttentionFlashesOnNonActiveIdle({ electronApp }) {
+  const seamReady = await electronApp.evaluate(() => {
+    const t = globalThis.__ccsmAttentionTest;
+    if (!t || typeof t.emitStateChanged !== 'function') return false;
+    if (!Array.isArray(globalThis.__ccsmAttentionLog)) globalThis.__ccsmAttentionLog = [];
+    return true;
+  });
+  if (!seamReady) throw new Error('__ccsmAttentionTest seam not initialized (CCSM_NOTIFY_TEST_HOOK?)');
+
+  const sidA = `attn-A-${Date.now()}`;
+  const sidB = `attn-B-${Date.now() + 1}`;
+
+  // --- Sub-case 1: focused + B (non-active) idle → flash recorded ---
+  const sub1 = await electronApp.evaluate((_e, [sa, sb]) => {
+    const t = globalThis.__ccsmAttentionTest;
+    t.setFocusOverride(true);
+    t.setActiveSid(sa);
+    const baseline = globalThis.__ccsmAttentionLog.length;
+    t.emitStateChanged(sb, 'idle');
+    const added = globalThis.__ccsmAttentionLog.slice(baseline);
+    return { baseline, added };
+  }, [sidA, sidB]);
+  if (sub1.added.length !== 1) {
+    throw new Error(
+      `sub1 expected exactly 1 attention entry for non-active sid, got ${sub1.added.length}. Log delta: ${JSON.stringify(sub1.added)}`,
+    );
+  }
+  const entry1 = sub1.added[0];
+  if (entry1.sid !== sidB) throw new Error(`sub1 entry sid mismatch: ${JSON.stringify(entry1)}`);
+  if (entry1.state !== 'idle') throw new Error(`sub1 entry state mismatch: ${JSON.stringify(entry1)}`);
+  if (entry1.kind !== 'flashFrame' && entry1.kind !== 'dockBounce') {
+    throw new Error(`sub1 entry kind expected flashFrame|dockBounce, got: ${JSON.stringify(entry1)}`);
+  }
+  console.log(`[HARNESS]   sub1 OK: focused + non-active sid → ${entry1.kind} for ${entry1.sid}`);
+
+  // --- Sub-case 2: focused + A (active sid) idle → suppressed ---
+  const sub2 = await electronApp.evaluate((_e, [sa]) => {
+    const t = globalThis.__ccsmAttentionTest;
+    t.setFocusOverride(true);
+    t.setActiveSid(sa);
+    const baseline = globalThis.__ccsmAttentionLog.length;
+    t.emitStateChanged(sa, 'idle');
+    const added = globalThis.__ccsmAttentionLog.slice(baseline);
+    return { added };
+  }, [sidA]);
+  if (sub2.added.length !== 0) {
+    throw new Error(
+      `sub2 expected 0 entries (active-sid suppressed), got ${sub2.added.length}: ${JSON.stringify(sub2.added)}`,
+    );
+  }
+  console.log('[HARNESS]   sub2 OK: focused + active sid → suppressed');
+
+  // --- Sub-case 3: blurred + B idle → suppressed (notify path owns it) ---
+  const sub3 = await electronApp.evaluate((_e, [sa, sb]) => {
+    const t = globalThis.__ccsmAttentionTest;
+    t.setFocusOverride(false);
+    t.setActiveSid(sa);
+    const baseline = globalThis.__ccsmAttentionLog.length;
+    t.emitStateChanged(sb, 'idle');
+    const added = globalThis.__ccsmAttentionLog.slice(baseline);
+    return { added };
+  }, [sidA, sidB]);
+  if (sub3.added.length !== 0) {
+    throw new Error(
+      `sub3 expected 0 entries (window blurred → notify path), got ${sub3.added.length}: ${JSON.stringify(sub3.added)}`,
+    );
+  }
+  console.log('[HARNESS]   sub3 OK: blurred → attention skipped (notify path)');
+
+  // Cleanup the override so subsequent cases see real focus state.
+  await electronApp.evaluate(() => {
+    globalThis.__ccsmAttentionTest?.setFocusOverride(null);
+  });
+}
+
+// ============================================================================
 // Case 2: switch-session-keeps-chat (UX F)
 // ============================================================================
 
@@ -1299,6 +1386,232 @@ async function caseImportResume({ electronApp, win, tempDir }) {
   const exitsThisCase = exitsAfter.slice(exitCountBefore);
   if (exitsThisCase.length > 0) {
     throw new Error(`unexpected pty:exit during import-resume: ${JSON.stringify(exitsThisCase)}`);
+  }
+
+  // ===========================================================================
+  // Sub-leg: cwd-redirect for missing-cwd imports (#603 reviewer Layer-1 fix)
+  // ===========================================================================
+  //
+  // When the import-source JSONL was originally written from a cwd that no
+  // longer exists, `resolveSpawnCwd` falls back to homedir, the
+  // import-resume copy helper relocates the JSONL into the spawn cwd's
+  // projectDir, and the renderer must patch `session.cwd` to the spawn cwd
+  // so the sessionTitles SDK bridge (rename / list / get) targets the
+  // COPY rather than the now-frozen SOURCE.
+  //
+  // Setup: seed a JSONL whose recorded cwd is a path guaranteed not to
+  // exist on disk. Import. Spawn. Assert `session.cwd` flips to the
+  // homedir-resolved spawn cwd via the `session:cwdRedirected` IPC.
+  // NB: deliberately NOT prefixed `ccsm-` / `agentory-` and NOT under
+  // `/tmp` or any temp-root that the import scanner filters out
+  // (`isCCSMTempCwd`). We need a path the scanner WILL surface but disk
+  // physically lacks, so the spawn-cwd fallback fires.
+  const missingCwd = '/var/empty/probe-redirect-' + randomUUID().slice(0, 8);
+  const missingProjectDirName = encodeCwdForClaude(missingCwd);
+  const missingScannerDir = path.join(tempDir, '.claude', 'projects', missingProjectDirName);
+  // Note: deliberately NOT seeding under <tempDir>/projects/<missing>/ —
+  // the source must live ONLY at the scanner path so the copy helper
+  // has a real `targetPath !== sourcePath` to act on.
+  mkdirSync(missingScannerDir, { recursive: true });
+  const missingSid = randomUUID();
+  const missingJsonlPath = path.join(missingScannerDir, `${missingSid}.jsonl`);
+  const missingUserText = 'PROBE_REDIRECT_PING token PROBE_REDIRECT_TOKEN_' +
+    randomUUID().slice(0, 6).toUpperCase();
+  const missingUserUuid = randomUUID();
+  const missingFrames = [
+    {
+      parentUuid: null, isSidechain: false, type: 'user',
+      message: { role: 'user', content: missingUserText },
+      uuid: missingUserUuid, timestamp: new Date().toISOString(),
+      userType: 'external', cwd: missingCwd, sessionId: missingSid,
+      version: '2.1.119', gitBranch: 'HEAD',
+    },
+    {
+      parentUuid: missingUserUuid, isSidechain: false, type: 'assistant',
+      message: {
+        id: 'msg_' + randomUUID().replace(/-/g, '').slice(0, 24),
+        type: 'message', role: 'assistant', model: 'claude-sonnet-4-5-20250929',
+        content: [{ type: 'text', text: 'Acknowledged.' }],
+        stop_reason: 'end_turn', stop_sequence: null,
+        usage: { input_tokens: 1, output_tokens: 1 },
+      },
+      uuid: randomUUID(), timestamp: new Date().toISOString(),
+      userType: 'external', cwd: missingCwd, sessionId: missingSid,
+      version: '2.1.119', gitBranch: 'HEAD',
+    },
+  ];
+  writeFileSync(
+    missingJsonlPath,
+    missingFrames.map((f) => JSON.stringify(f)).join('\n') + '\n',
+  );
+  // Pre-trust homedir (= tempDir) since claude will fall back to it.
+  // Already trusted via `seedCwd = process.cwd()` above isn't relevant; the
+  // resolver falls back to USERPROFILE/HOME = tempDir, so we trust that path.
+  const homedirTrust = tempDir;
+  if (!claudeJson.projects[homedirTrust]) {
+    claudeJson.projects[homedirTrust] = {
+      allowedTools: [], mcpContextUris: [], mcpServers: {},
+      enabledMcpjsonServers: [], disabledMcpjsonServers: [],
+      hasClaudeMdExternalIncludesApproved: false,
+      hasClaudeMdExternalIncludesWarningShown: false,
+      hasTrustDialogAccepted: true,
+      projectOnboardingSeenCount: 1,
+    };
+    claudeJson.projects[homedirTrust.replace(/\\/g, '/')] = claudeJson.projects[homedirTrust];
+    writeFileSync(claudeJsonPath, JSON.stringify(claudeJson, null, 2));
+  }
+
+  const redirectExitCountBefore = (await readPtyExits(win)).length;
+
+  const importMissingResult = await win.evaluate(async (expectedSid) => {
+    const api = window.ccsm;
+    const useStore = window.__ccsmStore;
+    if (!api?.scanImportable) throw new Error('window.ccsm.scanImportable unavailable');
+    if (!useStore) throw new Error('window.__ccsmStore unavailable');
+    // Background-refresh policy: `getImportableSessions` returns the cache
+    // immediately while triggering an async re-scan. The seed for this leg
+    // landed AFTER the first leg's scan populated the cache, so the first
+    // call may not see it. Poll up to 8s, calling repeatedly to give the
+    // background re-scan a chance to land.
+    let found = null;
+    const deadline = Date.now() + 8000;
+    while (Date.now() < deadline) {
+      const rows = await api.scanImportable();
+      found = rows.find((r) => r.sessionId === expectedSid);
+      if (found) break;
+      await new Promise((r) => setTimeout(r, 250));
+    }
+    if (!found) {
+      const rowsFinal = await api.scanImportable();
+      return {
+        ok: false,
+        reason: 'missing-cwd-jsonl-not-in-scan',
+        rowCount: rowsFinal.length,
+      };
+    }
+    const { importSession, createGroup, groups } = useStore.getState();
+    let groupId = groups.find((g) => g.kind === 'normal' && g.name === 'Imported')?.id;
+    if (!groupId) groupId = createGroup('Imported');
+    const importedId = importSession({
+      name: found.title, cwd: found.cwd, groupId,
+      resumeSessionId: found.sessionId, projectDir: found.projectDir,
+    });
+    useStore.setState({ activeId: importedId, focusedGroupId: null });
+    const after = useStore.getState();
+    const session = after.sessions.find((s) => s.id === importedId);
+    return {
+      ok: true,
+      importedId,
+      cwdAtImport: session?.cwd,
+    };
+  }, missingSid);
+  if (!importMissingResult?.ok) {
+    throw new Error(`import-missing-cwd flow failed: ${JSON.stringify(importMissingResult)}`);
+  }
+  if (importMissingResult.cwdAtImport !== missingCwd) {
+    throw new Error(
+      `import: session.cwd should start as the recorded missing path; ` +
+        `expected=${missingCwd} got=${importMissingResult.cwdAtImport}`,
+    );
+  }
+  console.log(`[HARNESS]   redirect-leg: imported sid=${missingSid} cwd=${importMissingResult.cwdAtImport}`);
+
+  // Wait for the cwd-redirect IPC to land in the store. Polls
+  // `session.cwd`; passes once it's been patched away from the missing path.
+  // Bounded at 30s — same budget as the terminal-ready helper.
+  const redirectDeadline = Date.now() + 30000;
+  let redirectedCwd = null;
+  while (Date.now() < redirectDeadline) {
+    const cur = await win.evaluate((sid) => {
+      const useStore = window.__ccsmStore;
+      const sess = useStore?.getState().sessions.find((s) => s.id === sid);
+      return sess ? sess.cwd : null;
+    }, missingSid);
+    if (cur && cur !== missingCwd) {
+      redirectedCwd = cur;
+      break;
+    }
+    await sleep(250);
+  }
+  if (!redirectedCwd) {
+    throw new Error(
+      `cwd-redirect did not fire within 30s: session.cwd still ${missingCwd}. ` +
+        `Reviewer Layer-1 regression — main copies the JSONL but renderer ` +
+        `keeps reading the SOURCE via session.cwd.`,
+    );
+  }
+  console.log(`[HARNESS]   redirect-leg: cwd patched to ${redirectedCwd}`);
+  // The redirect target must equal the spawn cwd's project root
+  // (= homedir = tempDir under the harness env).
+  if (redirectedCwd !== tempDir && !redirectedCwd.startsWith(tempDir)) {
+    // Allow tempDir-equivalent paths (Windows short-name vs long-name etc.)
+    // but the major substring should match.
+    console.warn(
+      `[HARNESS] cwd-redirect landed at ${redirectedCwd}; expected ~${tempDir}. ` +
+        `Continuing — exact path may differ on macOS /private/var realpath.`,
+    );
+  }
+
+  // Sub-assert: a rename via the SDK bridge must persist into the COPY,
+  // not the SOURCE. We verify by reading both files after the bridge
+  // resolves. The COPY lives under the spawn-cwd's projectDir (resolved
+  // via `redirectedCwd`); the SOURCE stays at `missingJsonlPath`.
+  const renameTitle = 'redirect-probe-' + randomUUID().slice(0, 8);
+  const renameResult = await win.evaluate(
+    async ([sid, title]) => {
+      const useStore = window.__ccsmStore;
+      const { renameSession } = useStore.getState();
+      await renameSession(sid, title);
+      // Pull the post-rename session.cwd so the harness can map it to a
+      // projectDir on disk.
+      const sess = useStore.getState().sessions.find((s) => s.id === sid);
+      return { cwd: sess?.cwd ?? null, name: sess?.name ?? null };
+    },
+    [missingSid, renameTitle],
+  );
+  if (renameResult.name !== renameTitle) {
+    throw new Error(
+      `renameSession did not patch local name: expected ${renameTitle} got ${renameResult.name}`,
+    );
+  }
+  // Map the post-redirect cwd → projectDir on disk + check the COPY got
+  // the customTitle frame the SDK writeback appends.
+  const redirectedProjectDir = encodeCwdForClaude(renameResult.cwd);
+  const copyJsonlPath = path.join(
+    tempDir, 'projects', redirectedProjectDir, `${missingSid}.jsonl`,
+  );
+  // Wait for the SDK writeback to land on disk. Poll up to 15s.
+  const writebackDeadline = Date.now() + 15000;
+  let copyContent = '';
+  let sourceContent = '';
+  while (Date.now() < writebackDeadline) {
+    try { copyContent = readFileSync(copyJsonlPath, 'utf8'); } catch { /* not yet */ }
+    if (copyContent.includes(renameTitle)) break;
+    await sleep(250);
+  }
+  try { sourceContent = readFileSync(missingJsonlPath, 'utf8'); } catch { /* may be gone */ }
+  if (!copyContent.includes(renameTitle)) {
+    throw new Error(
+      `SDK rename writeback never reached the COPY (${copyJsonlPath}): ` +
+        `title ${renameTitle} not in copy. Reviewer Layer-1 fix incomplete — ` +
+        `bridge still targeting SOURCE.`,
+    );
+  }
+  if (sourceContent.includes(renameTitle)) {
+    throw new Error(
+      `SDK rename writeback hit the SOURCE (${missingJsonlPath}). The ` +
+        `redirect should have steered the bridge AWAY from the source — ` +
+        `imported-session titles will silently rot when the user renames.`,
+    );
+  }
+  console.log(`[HARNESS]   redirect-leg: rename ${renameTitle} written to COPY ${copyJsonlPath}, SOURCE clean`);
+
+  const exitsAfterRedirect = await readPtyExits(win);
+  const exitsRedirectLeg = exitsAfterRedirect.slice(redirectExitCountBefore);
+  if (exitsRedirectLeg.length > 0) {
+    throw new Error(
+      `unexpected pty:exit during cwd-redirect leg: ${JSON.stringify(exitsRedirectLeg)}`,
+    );
   }
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,6 +78,7 @@ export default function App() {
   const selectSession = useStore((s) => s.selectSession);
   const focusGroup = useStore((s) => s.focusGroup);
   const applyExternalTitle = useStore((s) => s._applyExternalTitle);
+  const applyCwdRedirect = useStore((s) => s._applyCwdRedirect);
   const applyPtyExit = useStore((s) => s._applyPtyExit);
   const moveSession = useStore((s) => s.moveSession);
   const createSession = useStore((s) => s.createSession);
@@ -189,6 +190,25 @@ export default function App() {
       applyExternalTitle(evt.sid, evt.title);
     });
   }, [applyExternalTitle]);
+
+  // Pipe `session:cwdRedirected` IPC events from main into the store. Fired
+  // by the ptyHost spawn handler when the import-resume copy helper (#603)
+  // relocates a JSONL into the spawn cwd's projectDir. Patching
+  // `session.cwd` is what keeps the sessionTitles SDK bridge pointing at
+  // the live COPY rather than the now-frozen SOURCE on subsequent
+  // `renameSession` / `getSessionInfo` / `listForProject` calls.
+  useEffect(() => {
+    type Bridge = {
+      onCwdRedirected?: (cb: (e: { sid: string; newCwd: string }) => void) => () => void;
+    };
+    const bridge = (window as unknown as { ccsmSession?: Bridge }).ccsmSession;
+    if (!bridge || typeof bridge.onCwdRedirected !== 'function') return;
+    return bridge.onCwdRedirected((evt) => {
+      if (!evt || typeof evt.sid !== 'string' || typeof evt.newCwd !== 'string') return;
+      if (evt.sid.length === 0 || evt.newCwd.length === 0) return;
+      applyCwdRedirect(evt.sid, evt.newCwd);
+    });
+  }, [applyCwdRedirect]);
 
   // Locale: ask main for the OS locale, feed it into the preferences store
   // so a "system" preference resolves correctly. Falls back to navigator.

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -227,6 +227,16 @@ type Actions = {
    *  src/App.tsx. SDK customTitle precedence guarantees user renames win
    *  over SDK auto-summaries, so no userRenamed flag is needed here. */
   _applyExternalTitle: (sid: string, title: string) => void;
+  /** Internal: patch `session.cwd` after the main-process import-resume copy
+   *  helper relocates the JSONL into the spawn cwd's projectDir (#603). The
+   *  sessionTitles SDK bridge keys off `session.cwd` to compute the
+   *  projectKey it passes to `getSessionInfo` / `renameSession` /
+   *  `listForProject` — without this patch the bridge would keep targeting
+   *  the original (now-frozen) SOURCE JSONL after every spawn while the
+   *  CLI appends to the COPY. No-op when the row is missing or `cwd` is
+   *  already current. Underscore prefix: only the `session:cwdRedirected`
+   *  IPC subscriber in src/App.tsx calls this. */
+  _applyCwdRedirect: (sid: string, newCwd: string) => void;
   /** Internal: classify and record a pty:exit event for `sid`. Decides
    *  clean vs crashed using `signal == null && code === 0`. Idempotent —
    *  calling twice with the same payload just overwrites the entry. */
@@ -649,6 +659,18 @@ export const useStore = create<State & Actions>((set, get) => ({
       if (s.sessions[idx].name === title) return s;
       const next = s.sessions.slice();
       next[idx] = { ...next[idx], name: title };
+      return { ...s, sessions: next };
+    });
+  },
+
+  _applyCwdRedirect: (sid, newCwd) => {
+    if (typeof newCwd !== 'string' || newCwd.length === 0) return;
+    set((s) => {
+      const idx = s.sessions.findIndex((x) => x.id === sid);
+      if (idx === -1) return s;
+      if (s.sessions[idx].cwd === newCwd) return s;
+      const next = s.sessions.slice();
+      next[idx] = { ...next[idx], cwd: newCwd };
       return { ...s, sessions: next };
     });
   },

--- a/tests/store-cwd-redirect.test.ts
+++ b/tests/store-cwd-redirect.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { useStore } from '../src/stores/store';
+import type { Session } from '../src/types';
+
+// Covers `_applyCwdRedirect` — the renderer-side patch invoked when main
+// pushes `session:cwdRedirected` after the import-resume copy helper
+// (#603 reviewer Layer-1 fix) relocates a JSONL into the spawn cwd's
+// projectDir. Without this patch the sessionTitles SDK bridge would keep
+// reading/writing the original (now-frozen) SOURCE JSONL because it keys
+// off `session.cwd` for projectKey resolution.
+
+function seedSession(id: string, cwd: string): void {
+  const session: Session = {
+    id,
+    name: 'test',
+    state: 'idle',
+    cwd,
+    model: '',
+    groupId: 'g1',
+    agentType: 'claude-code',
+  };
+  useStore.setState((s) => ({ sessions: [...s.sessions, session] }));
+}
+
+describe('store._applyCwdRedirect (#603)', () => {
+  beforeEach(() => {
+    useStore.setState({ sessions: [] });
+  });
+  afterEach(() => {
+    useStore.setState({ sessions: [] });
+  });
+
+  it('patches session.cwd to the new spawn cwd', () => {
+    seedSession('s-redirect', '/tmp/old-deleted');
+    useStore.getState()._applyCwdRedirect('s-redirect', 'C:\\Users\\jiahuigu');
+    const after = useStore.getState().sessions.find((s) => s.id === 's-redirect');
+    expect(after?.cwd).toBe('C:\\Users\\jiahuigu');
+  });
+
+  it('is a no-op when the row is missing', () => {
+    seedSession('s-other', '/tmp/other');
+    useStore.getState()._applyCwdRedirect('s-missing', '/tmp/new');
+    // Untouched neighbour proves we didn't accidentally append a ghost row.
+    const sessions = useStore.getState().sessions;
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].id).toBe('s-other');
+    expect(sessions[0].cwd).toBe('/tmp/other');
+  });
+
+  it('is a no-op when cwd is already current', () => {
+    seedSession('s-same', '/tmp/already-here');
+    const before = useStore.getState().sessions;
+    useStore.getState()._applyCwdRedirect('s-same', '/tmp/already-here');
+    // Reference-equal — we returned the original state object so subscribers
+    // don't fire a needless re-render on a no-op redirect.
+    expect(useStore.getState().sessions).toBe(before);
+  });
+
+  it('ignores empty newCwd', () => {
+    seedSession('s-empty', '/tmp/keep');
+    useStore.getState()._applyCwdRedirect('s-empty', '');
+    const after = useStore.getState().sessions.find((s) => s.id === 's-empty');
+    expect(after?.cwd).toBe('/tmp/keep');
+  });
+
+  it('only mutates the targeted session', () => {
+    seedSession('s-a', '/tmp/a');
+    seedSession('s-b', '/tmp/b');
+    useStore.getState()._applyCwdRedirect('s-a', '/tmp/a-new');
+    const sessions = useStore.getState().sessions;
+    expect(sessions.find((s) => s.id === 's-a')?.cwd).toBe('/tmp/a-new');
+    expect(sessions.find((s) => s.id === 's-b')?.cwd).toBe('/tmp/b');
+  });
+});


### PR DESCRIPTION
## Root cause

`claude --resume <sid>` only finds a session when the JSONL lives under the projectDir matching the CURRENT cwd's projectKey. When a user imports a JSONL whose recorded cwd no longer exists on disk:

1. `resolveSpawnCwd` (PR #507) falls back to `homedir()`.
2. Spawn cwd's projectKey now mismatches the JSONL's actual location.
3. `claude --resume <sid>` reports `No conversation found with session ID: ...` and exits.
4. The pty terminates immediately, leaving the right pane blank with no claude process running and no scrollback — exactly the user-reported symptom.

Empirically reproduced on Windows:
```bash
$ cd /tmp && claude --resume 003080a4-09c8-4fb4-a79a-4ec6cbf4ba28
No conversation found with session ID: 003080a4-09c8-4fb4-a79a-4ec6cbf4ba28
$ cd ~ && claude --resume 003080a4-09c8-4fb4-a79a-4ec6cbf4ba28 -p "say hi"
hi!
```
(The session was originally recorded under `~`.)

## Fix path

`electron/ptyHost/index.ts`:

- `jsonlExistsForSid` upgraded to `findJsonlForSid` returning the matched absolute path (back-compat boolean wrapper kept).
- New `ensureResumeJsonlAtSpawnCwd(claudeSid, spawnCwd, sourceJsonlPath)` copies the source JSONL into `<projectsRoot>/<cwdToProjectKey(spawnCwd)>/<sid>.jsonl` so `--resume` succeeds. Idempotent — never overwrites a live transcript at the target; quiet no-op when source already lives at the matching projectDir (the common case for sessions whose cwd still exists).
- `makeEntry` calls the helper after `resolveSpawnCwd` returns, before `pty.spawn`. Failures are logged at warn level and swallowed; worst case is the same blank-terminal symptom we already had, with a clear reason in the console.

## Anti-patterns avoided
- No static `@anthropic-ai/claude-agent-sdk` import.
- Import scanner unchanged (the bug is downstream of the scanner).
- PR #507's `resolveSpawnCwd` validation untouched (still needed for the new-session error 267 fix).
- Errors logged, not silently swallowed.

## Tests

Added `electron/ptyHost/__tests__/import-resume-copy.test.ts` (4 cases):
- copies into spawn-cwd projectDir when source elsewhere
- no-op when source path == target path
- never overwrites an existing destination
- bails silently when no projects root is resolvable

```
electron/ptyHost/__tests__/cwd-fallback.test.ts        7 tests passed
electron/ptyHost/__tests__/import-resume-copy.test.ts  4 tests passed
```

`npm test` — 339/342 (the 3 failing are a pre-existing `better-sqlite3` `NODE_MODULE_VERSION 130 vs 137` mismatch in `db-hardening.test.ts`, unrelated to this PR; was failing on `working` HEAD before this branch).

`npm run build` — clean.
`node -e "require('./dist/electron/sessionTitles/index.js')"` — clean (no `ERR_REQUIRE_ESM`).

## E2E

`harness-real-cli --only=import-resume`: PASS (3.8s). The probe seeds JSONL at the cwd-matching projectDir (happy path), which the new helper detects and short-circuits — no behavior change for that case.

The bug-affected case (JSONL recorded at a now-missing cwd) is covered by the new unit tests; reproducing it end-to-end would require the harness to seed an unreachable cwd path, which adds platform brittleness without extra coverage over the unit-level pin.

## Manual smoke (for the user to verify after merge)

1. Have an old `<sid>.jsonl` in `~/.claude/projects/<some-cwd-that-still-exists>/` and another in `~/.claude/projects/<some-cwd-that-was-deleted>/`.
2. Open ccsm → Import .jsonl → pick the deleted-cwd one.
3. Click the imported session.
4. Verify: claude resumes with prior conversation visible in the right pane. (Without this fix: blank terminal, no claude.)
5. Send a follow-up; verify claude replies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)