### PR TITLE
fix(notify): suppress OS notification when app focused (any session) (#611)

### DIFF
--- a/electron/notify/__tests__/notify.test.ts
+++ b/electron/notify/__tests__/notify.test.ts
@@ -116,8 +116,25 @@ describe('installNotifyBridge', () => {
     h.dispose();
   });
 
-  it('still fires when window is focused but a DIFFERENT sid is active', () => {
+  it('suppresses when window focused even if a DIFFERENT sid is active (#611)', () => {
+    // App-level suppression: if the user is in the ccsm app, no OS toast
+    // for any session. The in-app sidebar dot / icon-flash bridge handle
+    // surfacing the event in-app.
     const h = makeHarness({ windowFocused: true, activeSid: 'sid-other' });
+    emit(h.emitter, { sid: 'sid-target', state: 'idle' });
+    expect(h.log).toHaveLength(0);
+    h.dispose();
+  });
+
+  it('suppresses when window focused with no active sid (#611)', () => {
+    const h = makeHarness({ windowFocused: true, activeSid: null });
+    emit(h.emitter, { sid: 'sid-x', state: 'requires_action' });
+    expect(h.log).toHaveLength(0);
+    h.dispose();
+  });
+
+  it('fires when window NOT focused and a different sid transitions', () => {
+    const h = makeHarness({ windowFocused: false, activeSid: 'sid-other' });
     emit(h.emitter, { sid: 'sid-target', state: 'idle' });
     expect(h.log).toHaveLength(1);
     expect(h.log[0].sid).toBe('sid-target');

--- a/electron/notify/index.ts
+++ b/electron/notify/index.ts
@@ -12,11 +12,14 @@
 //     renderer. We listen to its EventEmitter directly in main so we don't
 //     have to round-trip through IPC just to read a value the main process
 //     already has.
-//   * Suppression is intentionally main-side: window-focus + active-sid
-//     belongs in main because the OS already knows whether our window is
-//     focused, and the renderer pushes its `activeId` here on every change
-//     via `'session:setActive'`. No notification fires when the user is
-//     already looking at the session that just transitioned.
+//   * Suppression is intentionally main-side: window focus belongs in main
+//     because the OS already knows whether our window is focused, and the
+//     renderer pushes its `activeId` here on every change via
+//     `'session:setActive'`. The primary gate is **app-level**: if the
+//     ccsm window is focused, NO session fires an OS notification (the
+//     user is already in the app — surface it in-app instead via sidebar
+//     dot / icon flash). The per-session active-sid check remains as
+//     defense-in-depth in case focus reporting is stale.
 //   * Click → focus + activate. We re-show / re-focus the BrowserWindow and
 //     send `'session:activate'` to the renderer; the renderer subscribes via
 //     `window.ccsmSession.onActivate` and calls `selectSession(sid)`.
@@ -116,9 +119,11 @@ export function installNotifyBridge(opts: InstallNotifyBridgeOptions): () => voi
     getMainWindow,
     sessionWatcher,
     isMutedFn,
-    getActiveSidFn,
     isWindowFocusedFn,
   } = opts;
+  // `getActiveSidFn` is accepted for backward compatibility with callers
+  // that already wire it (e.g. main.ts) but is no longer consulted: as of
+  // #611 the focus check is app-level. See header comment for rationale.
 
   const notifyImpl =
     opts.notifyImpl ??
@@ -152,13 +157,20 @@ export function installNotifyBridge(opts: InstallNotifyBridgeOptions): () => voi
 
     if (isMutedFn()) return;
 
-    // Suppress when the user is already looking at this session in a
-    // focused window — they don't need a desktop ping for something
-    // that's already on screen.
+    // App-focus gate: when the ccsm window has OS focus, the user is
+    // already in the app — any session's transition can be surfaced
+    // in-app (sidebar dot, icon flash via the attention bridge, etc.).
+    // An OS toast on top of that is noisy and redundant. This holds
+    // regardless of which session is the active one in the renderer; the
+    // user explicitly asked for app-level suppression (#611).
+    //
+    // Note: getActiveSidFn is intentionally NOT used as a fallback gate
+    // here. A user with the app minimised but with a session "active" in
+    // the renderer still wants the OS ping when that session finishes —
+    // otherwise they'd never know.
     // TODO(multi-window): this assumes a single main BrowserWindow. If we
-    // ever support multiple windows, "focused" must be checked per-window
-    // and getActiveSidFn() must be scoped to the focused window's renderer.
-    if (isWindowFocusedFn() && getActiveSidFn() === evt.sid) return;
+    // ever support multiple windows, "focused" must be checked per-window.
+    if (isWindowFocusedFn()) return;
 
     // Per-sid dedupe: ignore a second notification for the same sid
     // within 5s of the previous one (covers idle ↔ requires_action


### PR DESCRIPTION
## User report (#611)

> 焦点在B，A做完后给了我系统通知。焦点在A时正确，A没有给系统通知

Clarification:

> 上面那个bug应该整体修，只要焦点在应用内，session就不给系统通知

## Root cause

`installNotifyBridge` in `electron/notify/index.ts` suppressed OS toasts only when both conditions held:

```ts
if (isWindowFocusedFn() && getActiveSidFn() === evt.sid) return;
```

So with the ccsm window focused on session A, when session B transitioned to `idle` / `requires_action`, the gate let it through and an OS notification fired. The user wants app-level suppression: if the window is focused, no toast for any session.

## Fix

Promote the gate to app-level:

```ts
if (isWindowFocusedFn()) return;
```

`getActiveSidFn` is no longer consulted (kept on the options interface for backward compat with callers like `main.ts`). When the app is minimised or in the background the OS toast still fires regardless of which session is "active" in the renderer — that case still needs the ping.

## Before / after

| Window focus | Target sid vs active sid | Before | After |
|---|---|---|---|
| Focused | same | no toast | no toast |
| Focused | different | **toast (bug)** | **no toast (fixed)** |
| Focused | no active | toast | no toast |
| Not focused | same | toast | toast |
| Not focused | different | toast | toast |

In-app surfacing of focused-but-non-active session events is handled by the sidebar dot and the icon-flash bridge; the OS toast was redundant.

## Coordination with PR #513

PR #513 (`fix-notify-app-icon-flash`) installs `installIdleAttentionBridge`, which flashes the app icon when the app is focused and `sid !== activeSid`. After both PRs land, the matrix for "app focused" is:

- focused + active session → no flash, no toast (PR #513 early-returns on `sid === activeSid`; this PR also returns)
- focused + non-active session → icon flash only (PR #513), no toast (this PR)
- not focused + any session → OS toast (existing behavior)

The two PRs are complementary. This PR does not touch `electron/notify/attention.ts` or any flash logic.

## Tests

- Updated unit test in `electron/notify/__tests__/notify.test.ts` that previously asserted "fires when window focused but different sid" now asserts the opposite, and added explicit cases for focused + null active sid and not-focused + different sid.
- All 14 notify unit tests pass.
- `npm run build` clean (only pre-existing webpack size warnings).
- `node -e "require('./dist/electron/notify/index.js')"` exit 0 (main-process load smoke test).

## Files changed

- `electron/notify/index.ts` — gate change + header doc update
- `electron/notify/__tests__/notify.test.ts` — flipped one case, added two new cases