### PR TITLE
fix(notify): clear sessionNamesFromRenderer on session delete (#613)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -214,6 +214,13 @@ let activeSidFromRenderer: string | null = null;
 // rename / external-title update / new-session creation.
 const sessionNamesFromRenderer = new Map<string, string>();
 
+// Test seam: when CCSM_NOTIFY_TEST_HOOK is set, expose the names map on
+// globalThis so harness e2e probes can inspect it without an extra IPC
+// surface. Off by default; production never reads CCSM_NOTIFY_TEST_HOOK.
+if (process.env.CCSM_NOTIFY_TEST_HOOK) {
+  (globalThis as unknown as { __ccsmSessionNamesFromRenderer?: Map<string, string> }).__ccsmSessionNamesFromRenderer = sessionNamesFromRenderer;
+}
+
 
 //
 // The CLI transcripts under ~/.claude/projects can run into hundreds of

--- a/scripts/harness-real-cli.mjs
+++ b/scripts/harness-real-cli.mjs
@@ -2267,6 +2267,81 @@ async function caseSidebarGroupHasNoNewSessionCluster({ win }) {
 }
 
 // ============================================================================
+// Case: notify-name-cleared-on-session-delete (#613)
+// Renderer mirrors (sid, name) pairs to main's `sessionNamesFromRenderer`
+// Map so notify toasts can show the user-visible name. Before #613 the
+// renderer never emitted a clearing call when a session was deleted, so
+// the map grew unbounded. This case asserts that deleting a session
+// removes its sid key from the main-side map within a short window.
+// ============================================================================
+
+async function caseNotifyNameClearedOnSessionDelete({ electronApp, win, tempDir }) {
+  await win.waitForFunction(
+    () => !document.querySelector('[data-testid="claude-availability-probing"]'),
+    null,
+    { timeout: 30000 },
+  );
+
+  const seamReady = await electronApp.evaluate(() => {
+    return globalThis.__ccsmSessionNamesFromRenderer instanceof Map;
+  });
+  if (!seamReady) {
+    throw new Error('__ccsmSessionNamesFromRenderer seam missing — CCSM_NOTIFY_TEST_HOOK should be set in launch env');
+  }
+
+  const probeName = `DeleteMe-${randomUUID().slice(0, 8)}`;
+  const { sid } = await seedSession(win, { name: probeName, cwd: tempDir });
+  if (!sid) throw new Error('seedSession returned no sid');
+
+  // Wait for the renderer's setName mirror to propagate to main.
+  let propagated = false;
+  for (let i = 0; i < 30; i++) {
+    const present = await electronApp.evaluate(
+      (_e, [s, expected]) => globalThis.__ccsmSessionNamesFromRenderer.get(s) === expected,
+      [sid, probeName],
+    );
+    if (present) { propagated = true; break; }
+    await sleep(200);
+  }
+  if (!propagated) {
+    const snapshot = await electronApp.evaluate((_e, s) => ({
+      has: globalThis.__ccsmSessionNamesFromRenderer.has(s),
+      val: globalThis.__ccsmSessionNamesFromRenderer.get(s) ?? null,
+      size: globalThis.__ccsmSessionNamesFromRenderer.size,
+    }), sid);
+    throw new Error(`name mirror never propagated for sid=${sid} (expected="${probeName}"). Diag: ${JSON.stringify(snapshot)}`);
+  }
+  console.log(`[HARNESS]   name mirror propagated: sid=${sid} name="${probeName}"`);
+
+  // Delete the session via the store (same path the user takes via UI).
+  await win.evaluate((s) => {
+    const useStore = window.__ccsmStore;
+    const { deleteSession } = useStore.getState();
+    deleteSession?.(s);
+  }, sid);
+
+  // Wait for the clearing IPC to land in main.
+  let cleared = false;
+  for (let i = 0; i < 30; i++) {
+    await sleep(200);
+    const stillThere = await electronApp.evaluate(
+      (_e, s) => globalThis.__ccsmSessionNamesFromRenderer.has(s),
+      sid,
+    );
+    if (!stillThere) { cleared = true; break; }
+  }
+  if (!cleared) {
+    const snapshot = await electronApp.evaluate((_e, s) => ({
+      has: globalThis.__ccsmSessionNamesFromRenderer.has(s),
+      val: globalThis.__ccsmSessionNamesFromRenderer.get(s) ?? null,
+      size: globalThis.__ccsmSessionNamesFromRenderer.size,
+    }), sid);
+    throw new Error(`name entry NOT cleared after delete for sid=${sid}. Diag: ${JSON.stringify(snapshot)}`);
+  }
+  console.log(`[HARNESS]   name entry cleared after delete: sid=${sid}`);
+}
+
+// ============================================================================
 // Registry
 // ============================================================================
 
@@ -2276,6 +2351,7 @@ const CASE_REGISTRY = [
   { name: 'session-title-syncs-from-jsonl', group: 'shared', run: caseSessionTitleSyncsFromJsonl },
   { name: 'session-state-becomes-idle',  group: 'shared', run: caseSessionStateBecomesIdle },
   { name: 'notify-fires-on-idle',        group: 'shared', run: caseNotifyFiresOnIdle },
+  { name: 'notify-name-cleared-on-session-delete', group: 'shared', run: caseNotifyNameClearedOnSessionDelete },
   { name: 'switch-session-keeps-chat',   group: 'shared', run: caseSwitchSessionKeepsChat },
   { name: 'cwd-projects-claude',         group: 'shared', run: caseCwdProjectsClaude },
   { name: 'import-resume',               group: 'shared', run: caseImportResume },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { Plus, Download } from 'lucide-react';
 import { TooltipProvider } from './components/ui/Tooltip';
 import { ToastProvider, useToast } from './components/ui/Toast';
@@ -139,13 +139,27 @@ export default function App() {
   // and we don't want a renderer round-trip on the notify path. Diffs over
   // the previous snapshot so we only IPC for actual changes (mounts,
   // renames, SDK title arrivals, deletions).
+  //
+  // Also tracks sids seen in the previous render and clears (`setName(sid,
+  // null)`) any that have since disappeared, so main's
+  // `sessionNamesFromRenderer` map doesn't grow unbounded across the app
+  // lifetime as sessions are created and deleted (#613, follow-up to #509).
+  const prevSidsRef = useRef<Set<string>>(new Set());
   useEffect(() => {
     type Bridge = { setName: (sid: string, name: string | null) => void };
     const bridge = (window as unknown as { ccsmSession?: Bridge }).ccsmSession;
     if (!bridge || typeof bridge.setName !== 'function') return;
+    const currentSids = new Set<string>();
     for (const sess of sessions) {
       bridge.setName(sess.id, sess.name ?? null);
+      currentSids.add(sess.id);
     }
+    for (const staleSid of prevSidsRef.current) {
+      if (!currentSids.has(staleSid)) {
+        bridge.setName(staleSid, null);
+      }
+    }
+    prevSidsRef.current = currentSids;
   }, [sessions]);
 
   // Listen for `session:activate` from main (fired when the user clicks a


### PR DESCRIPTION
## Summary

Follow-up to merged #509 (reviewer-noted leak). The renderer mirrors per-session `(sid, name)` pairs to main's `sessionNamesFromRenderer` Map via `ccsmSession.setName` IPC so desktop-notify toasts can label with the friendly name instead of the bare UUID. Before this fix the renderer never emitted a clearing call when a sid disappeared from the sessions array, so main's map grew unbounded across the app lifetime (~50 bytes per ever-created session).

The IPC handler in `electron/main.ts:1030` already deletes the entry on null/empty name; this PR just plugs the missing renderer-side call.

## User impact

Bounded memory growth in the main process — previously, every created-then-deleted session left a stale name entry in main alive until app restart. Small per session, but unbounded over a long-running app session.

## Changes

- `src/App.tsx`: track previous sids in a `useRef<Set<string>>`; on each `sessions` update, emit `bridge.setName(staleSid, null)` for any sid no longer present, then refresh the snapshot.
- `electron/main.ts`: add a `CCSM_NOTIFY_TEST_HOOK`-gated test seam exposing the map on `globalThis.__ccsmSessionNamesFromRenderer` (production path unaffected).
- `scripts/harness-real-cli.mjs`: new case `notify-name-cleared-on-session-delete` — seeds a session with name `DeleteMe-<random>`, waits for mirror to propagate, deletes via store, asserts the sid key is absent from main's map.

## Test plan

- [x] `npm run build` clean
- [x] ESM smoke: `node -e \"require('./dist/electron/notify/index.js')\"` exit 0
- [x] New probe PASSES (~700ms, name propagated then cleared after delete)
- [x] Reverse-verify: temporarily commenting out the `bridge.setName(staleSid, null)` line makes the probe FAIL with `name entry NOT cleared after delete for sid=... Diag: {\"has\":true,\"val\":\"DeleteMe-...\",\"size\":1}` — confirming the assertion catches the regression
- [x] After restore: probe PASSES again