### PR TITLE
feat(store): re-wire session state with active-session waiting suppression

### DIFF
--- a/scripts/harness-real-cli.mjs
+++ b/scripts/harness-real-cli.mjs
@@ -1013,6 +1013,144 @@ async function caseNotifyShowsSessionName({ electronApp, win, tempDir }) {
 }
 
 // ============================================================================
+// Case: agent-icon-active-session-no-halo
+// ============================================================================
+//
+// Re-wire of the deleted `src/agent/lifecycle.ts` (commit 08bce04). The store
+// action `_applySessionState` carries the active-session suppression rule:
+// when the inbound IPC state would push the active session into 'waiting',
+// we KEEP it at 'idle' so the AgentIcon halo never pulses on the row the
+// user is currently looking at. (Mirrors selectSession's symmetric
+// waiting -> idle clear at click-time.)
+//
+// Strategy: drive the store action directly via window.__ccsmStore — no
+// claude.exe required, this is a pure store-rule + DOM assertion. The
+// upstream IPC plumbing is already covered by caseSessionStateBecomesIdle.
+// User intent quote: "唯一要抑制的只有我焦点在当前session, session上的icon
+// 不能闪" / "它可能闪了, 但是立刻被消除".
+async function caseAgentIconActiveSessionNoHalo({ win, tempDir }) {
+  await win.waitForFunction(
+    () => !document.querySelector('[data-testid="claude-availability-probing"]'),
+    null,
+    { timeout: 30000 },
+  );
+
+  // Two sessions; A will be active, B in the background.
+  const { sid: sidA } = await seedSession(win, { name: 'halo-active', cwd: tempDir });
+  const { sid: sidB } = await seedSession(win, { name: 'halo-bystander', cwd: tempDir });
+  if (!sidA || !sidB || sidA === sidB) {
+    throw new Error(`bad sids active=${sidA} bystander=${sidB}`);
+  }
+
+  // Make A the active session.
+  await win.evaluate((sa) => {
+    window.__ccsmStore.getState().selectSession(sa);
+  }, sidA);
+
+  // Drive the store action that the IPC bridge feeds: ask both sessions
+  // to enter 'waiting'.
+  const after = await win.evaluate(({ sa, sb }) => {
+    const apply = window.__ccsmStore.getState()._applySessionState;
+    if (typeof apply !== 'function') {
+      return { error: '_applySessionState action not on store' };
+    }
+    apply(sa, 'waiting');
+    apply(sb, 'waiting');
+    const sessions = window.__ccsmStore.getState().sessions;
+    const a = sessions.find((x) => x.id === sa);
+    const b = sessions.find((x) => x.id === sb);
+    return {
+      activeId: window.__ccsmStore.getState().activeId,
+      aState: a ? a.state : null,
+      bState: b ? b.state : null,
+    };
+  }, { sa: sidA, sb: sidB });
+
+  if (after.error) throw new Error(after.error);
+  if (after.activeId !== sidA) {
+    throw new Error(`activeId mismatch: expected ${sidA}, got ${after.activeId}`);
+  }
+  if (after.aState !== 'idle') {
+    throw new Error(
+      `active-session suppression broken: A's state should stay 'idle' on incoming 'waiting' (active sid). ` +
+      `Got state='${after.aState}'. This means the AgentIcon halo would pulse for the row the user ` +
+      `is already viewing — exactly the noise the user called out ` +
+      `("唯一要抑制的只有我焦点在当前session").`,
+    );
+  }
+  if (after.bState !== 'waiting') {
+    throw new Error(
+      `bystander session must enter 'waiting' on incoming 'waiting' IPC (no suppression). ` +
+      `Got B.state='${after.bState}'.`,
+    );
+  }
+  console.log('[HARNESS]   store rule OK: active stays idle, bystander goes waiting');
+
+  // Now assert the same on the DOM: the AgentIcon for A reports
+  // data-agent-icon-state="idle", and B reports "waiting".
+  await sleep(120);
+  const dom = await win.evaluate(({ sa, sb }) => {
+    function pick(sid) {
+      const row = document.querySelector(`[data-session-id="${sid}"]`);
+      if (!row) return { rowFound: false };
+      const icon = row.querySelector('[data-agent-icon-state]');
+      if (!icon) return { rowFound: true, iconFound: false };
+      return {
+        rowFound: true,
+        iconFound: true,
+        state: icon.getAttribute('data-agent-icon-state'),
+      };
+    }
+    return { a: pick(sa), b: pick(sb) };
+  }, { sa: sidA, sb: sidB });
+
+  if (!dom.a.rowFound || !dom.b.rowFound) {
+    throw new Error(`sidebar row(s) missing: a=${JSON.stringify(dom.a)} b=${JSON.stringify(dom.b)}`);
+  }
+  if (!dom.a.iconFound || !dom.b.iconFound) {
+    throw new Error(
+      `data-agent-icon-state attribute missing — AgentIcon e2e hook regressed: ` +
+      `a=${JSON.stringify(dom.a)} b=${JSON.stringify(dom.b)}`,
+    );
+  }
+  if (dom.a.state !== 'idle') {
+    throw new Error(
+      `AgentIcon for active session A should render data-agent-icon-state="idle" ` +
+      `(no halo). Got "${dom.a.state}".`,
+    );
+  }
+  if (dom.b.state !== 'waiting') {
+    throw new Error(
+      `AgentIcon for bystander B should render data-agent-icon-state="waiting" ` +
+      `(halo). Got "${dom.b.state}".`,
+    );
+  }
+  console.log('[HARNESS]   DOM OK: A icon=idle, B icon=waiting');
+
+  // Sub-case: switching A away (selecting B) and re-applying 'waiting' to A
+  // (now non-active) should let A enter 'waiting'.
+  const after2 = await win.evaluate(({ sa, sb }) => {
+    window.__ccsmStore.getState().selectSession(sb);
+    window.__ccsmStore.getState()._applySessionState(sa, 'waiting');
+    const sessions = window.__ccsmStore.getState().sessions;
+    return {
+      activeId: window.__ccsmStore.getState().activeId,
+      aState: sessions.find((x) => x.id === sa)?.state ?? null,
+    };
+  }, { sa: sidA, sb: sidB });
+  if (after2.activeId !== sidB) {
+    throw new Error(`expected B active after select, got ${after2.activeId}`);
+  }
+  if (after2.aState !== 'waiting') {
+    throw new Error(
+      `after switch-away: A (now non-active) should accept 'waiting'. Got '${after2.aState}'. ` +
+      `This means the suppression is over-suppressing — non-active sessions must still pulse.`,
+    );
+  }
+  console.log('[HARNESS]   switch-away OK: A enters waiting once non-active');
+}
+
+// ============================================================================
 // Case 2: switch-session-keeps-chat (UX F)
 // ============================================================================
 
@@ -2747,6 +2885,7 @@ const CASE_REGISTRY = [
   { name: 'session-rename-writes-jsonl', group: 'shared', run: caseSessionRenameWritesJsonl },
   { name: 'session-title-syncs-from-jsonl', group: 'shared', run: caseSessionTitleSyncsFromJsonl },
   { name: 'session-state-becomes-idle',  group: 'shared', run: caseSessionStateBecomesIdle },
+  { name: 'agent-icon-active-session-no-halo', group: 'shared', run: caseAgentIconActiveSessionNoHalo },
   { name: 'notify-fires-on-idle',        group: 'shared', run: caseNotifyFiresOnIdle },
   { name: 'notify-name-cleared-on-session-delete', group: 'shared', run: caseNotifyNameClearedOnSessionDelete },
   { name: 'notify-shows-session-name',   group: 'shared', run: caseNotifyShowsSessionName },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import { i18next } from './i18n';
 import { useTranslation } from './i18n/useTranslation';
 import { usePreferences } from './store/preferences';
 import { DURATION, EASING } from './lib/motion';
+import { subscribeAgentEvents } from './agent/lifecycle';
 
 // Initialise i18next once, before any component renders. Subsequent
 // language changes flow through `applyLanguage` (called by the store
@@ -220,6 +221,22 @@ export default function App() {
       applyExternalTitle(evt.sid, evt.title);
     });
   }, [applyExternalTitle]);
+
+  // Pipe `session:state` IPC events from main into the store. The watcher
+  // emits `'idle' | 'running' | 'requires_action'` for each session as the
+  // JSONL transcript transitions; subscribeAgentEvents() maps that into
+  // the renderer's two-state attention model and writes through the
+  // store's `_applySessionState` action — which carries the active-session
+  // suppression so the row the user is currently viewing never enters
+  // `'waiting'` (no halo flicker on the row already on screen). This is
+  // the re-wire of the deleted `src/agent/lifecycle.ts` (commit 08bce04
+  // dropped the SDK-event subscriber when ccsm switched to spawning the
+  // CLI as a subprocess; the AgentIcon halo went silently dark for every
+  // session). Bridge install is idempotent so StrictMode double-mount
+  // doesn't double-pipe events.
+  useEffect(() => {
+    return subscribeAgentEvents();
+  }, []);
 
   // Pipe `session:cwdRedirected` IPC events from main into the store. Fired
   // by the ptyHost spawn handler when the import-resume copy helper (#603)

--- a/src/agent/lifecycle.ts
+++ b/src/agent/lifecycle.ts
@@ -1,0 +1,81 @@
+// Renderer-side subscriber that pipes per-session state events from main
+// (sourced by the JSONL tail-watcher in `electron/sessionWatcher`, fanned
+// out over the `session:state` IPC channel and exposed on the preload
+// bridge as `window.ccsmSession.onState`) into the zustand store as
+// `Session.state` updates.
+//
+// History:
+//   * The previous `subscribeAgentEvents()` lived here and listened to
+//     SDK turn-result events to drive `setSessionState(sid, 'waiting')`
+//     when claude finished a turn for a non-active session (commit
+//     1b32c46 "fix(sidebar): never pulse the active session row" was
+//     the last shape of that gate).
+//   * The whole file was deleted in commit 08bce04 (ttyd refactor)
+//     because ccsm now spawns the CLI as a subprocess instead of
+//     consuming SDK events directly. The renderer lost its only writer
+//     to `Session.state`, so the AgentIcon halo (which still keys off
+//     `state === 'waiting'`) silently went dark for every session.
+//   * This file is the minimal re-wiring: same outcome (sidebar halo
+//     pulses when claude is waiting on the user) sourced from the
+//     replacement signal (JSONL watcher → `session:state` IPC).
+//
+// Mapping from CLI vocabulary → renderer two-state model:
+//   'idle'             (claude finished, user owes next move) → 'waiting'
+//   'requires_action'  (permission prompt)                    → 'waiting'
+//   'running'          (claude is mid-turn)                   → 'idle'
+//
+// Active-session suppression lives in the store action
+// (`_applySessionState`), not here, so the symmetric `waiting → idle`
+// clear in `selectSession` and the active-session guard live next to
+// each other and can't drift apart.
+
+import { useStore } from '../stores/store';
+import type { SessionState as IPCSessionState } from '../session';
+
+type Unsubscribe = () => void;
+
+function mapState(s: IPCSessionState): 'idle' | 'waiting' {
+  // 'idle' from the CLI means "claude finished its turn" — that's
+  // exactly when we want the halo to call the user. Likewise
+  // 'requires_action'. Only 'running' (claude busy) is non-attention.
+  return s === 'running' ? 'idle' : 'waiting';
+}
+
+let installed = false;
+
+/**
+ * Subscribe the zustand store to `window.ccsmSession.onState` events.
+ * Idempotent: a second call is a no-op so React StrictMode double-mount
+ * (or a stray HMR re-import) doesn't double-pipe events into the store.
+ *
+ * Returns an unsubscribe handle; calling it tears down the bridge AND
+ * clears the installed-guard so a subsequent `subscribeAgentEvents()`
+ * can re-install (used by tests; production calls this once at App
+ * mount and never tears down).
+ *
+ * Returns a no-op unsubscribe in environments where the preload bridge
+ * is missing (tests, storybook, the very first frame before
+ * contextBridge has run).
+ */
+export function subscribeAgentEvents(): Unsubscribe {
+  if (installed) return () => { /* noop — already installed */ };
+  const bridge = (typeof window !== 'undefined'
+    ? (window as unknown as { ccsmSession?: { onState?: (cb: (e: { sid: string; state: IPCSessionState }) => void) => Unsubscribe } }).ccsmSession
+    : undefined);
+  if (!bridge || typeof bridge.onState !== 'function') {
+    return () => { /* noop — no bridge in this environment */ };
+  }
+  installed = true;
+  const apply = useStore.getState()._applySessionState;
+  const off = bridge.onState((evt) => {
+    if (!evt || typeof evt.sid !== 'string' || evt.sid.length === 0) return;
+    if (evt.state !== 'idle' && evt.state !== 'running' && evt.state !== 'requires_action') {
+      return;
+    }
+    apply(evt.sid, mapState(evt.state));
+  });
+  return () => {
+    try { off(); } catch { /* already torn down */ }
+    installed = false;
+  };
+}

--- a/src/components/AgentIcon.tsx
+++ b/src/components/AgentIcon.tsx
@@ -46,6 +46,7 @@ export function AgentIcon({
   const inner = agentType === 'claude-code' ? <ClaudeAsterisk size={glyph} /> : null;
   return (
     <motion.span
+      data-agent-icon-state={state}
       className={cn(
         'relative inline-flex shrink-0 items-center justify-center rounded-md',
         'bg-bg-elevated border border-border-default text-fg-primary'

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -227,6 +227,21 @@ type Actions = {
    *  src/App.tsx. SDK customTitle precedence guarantees user renames win
    *  over SDK auto-summaries, so no userRenamed flag is needed here. */
   _applyExternalTitle: (sid: string, title: string) => void;
+  /** Internal: apply an externally-sourced session-state transition (sourced
+   *  from the JSONL tail-watcher's `session:state` IPC, mapped renderer-side
+   *  from the CLI's `'idle' | 'running' | 'requires_action'` vocabulary into
+   *  the renderer's two-state attention model `'idle' | 'waiting'`).
+   *
+   *  Active-session suppression: when `sid === activeId` and the incoming
+   *  mapped state is `'waiting'`, we KEEP the row at `'idle'` (skip the
+   *  transition entirely). The user is already looking at this session, so
+   *  pulsing its sidebar AgentIcon would be visual noise for content they
+   *  can already see. Mirrors selectSession's symmetric `waiting → idle`
+   *  clear so the rule lives in two places: at click and at write.
+   *  Underscore prefix marks this as not user-facing — only the
+   *  `subscribeAgentEvents()` IPC bridge wired in src/agent/lifecycle.ts
+   *  calls this. */
+  _applySessionState: (sid: string, state: 'idle' | 'waiting') => void;
   /** Internal: patch `session.cwd` after the main-process import-resume copy
    *  helper relocates the JSONL into the spawn cwd's projectDir (#603). The
    *  sessionTitles SDK bridge keys off `session.cwd` to compute the
@@ -503,6 +518,27 @@ export const useStore = create<State & Actions>((set, get) => ({
         x.id === id && x.state === 'waiting' ? { ...x, state: 'idle' } : x
       ),
     }));
+  },
+
+  _applySessionState: (sid, state) => {
+    set((s) => {
+      // Active-session suppression: never let the active row enter
+      // `'waiting'`. The user is already looking at it; pulsing the
+      // sidebar AgentIcon halo for the row they're focused on is noise
+      // for content they can already see. Mirrors the symmetric
+      // `waiting → idle` clear in selectSession() above so the rule
+      // lives in both directions (write-time and click-time).
+      const target =
+        state === 'waiting' && sid === s.activeId ? 'idle' : state;
+      let changed = false;
+      const sessions = s.sessions.map((x) => {
+        if (x.id !== sid) return x;
+        if (x.state === target) return x;
+        changed = true;
+        return { ...x, state: target };
+      });
+      return changed ? { sessions } : {};
+    });
   },
 
   focusGroup: (id) => set({ focusedGroupId: id }),


### PR DESCRIPTION
## Summary

Re-wires the renderer-side session-state subscription that was deleted in commit `08bce04` (ttyd refactor) and lost the AgentIcon halo on every session. The subscriber is back, sourced from the JSONL tail-watcher's `session:state` IPC, and carries the active-session suppression from the previous correct shape (`1b32c46` "fix(sidebar): never pulse the active session row") inside the store action.

## User intent quotes

- "应用内闪烁原本是做的sessionname左侧的icon闪烁"
- "唯一要抑制的只有我焦点在当前session，session上的icon不能闪"
- "之前都是做对了的，找回来就行"
- "它可能闪了，但是立刻被消除"

## Architecture

```
electron/sessionWatcher emits 'state-changed'
  -> ptyHost bridges to renderer ('session:state' IPC)
     -> preload fans out via window.ccsmSession.onState
        -> src/agent/lifecycle.ts subscribeAgentEvents()
           -> store._applySessionState (active-suppression)
              -> AgentIcon halo
```

The CLI's three-state vocabulary (`'idle' | 'running' | 'requires_action'`) maps into the renderer's two-state attention model:
- `'idle'` (claude finished, user owes next move) -> `'waiting'`
- `'requires_action'` (permission prompt) -> `'waiting'`
- `'running'` (claude busy) -> `'idle'`

## Active-session suppression rule

When `sid === activeId` AND incoming state is `'waiting'`, the store keeps the row at `'idle'`. The user is already looking at the session — pulsing its icon is noise for content already on screen. This mirrors `selectSession`'s symmetric `waiting -> idle` clear, so the rule lives at click-time AND write-time.

This is exactly the "halo flashed but immediately cleared" semantics the user described.

## Files changed

- `src/stores/store.ts`: new `_applySessionState` action with suppression rule
- `src/agent/lifecycle.ts`: minimal subscriber (re-creation of the deleted file at the same path)
- `src/App.tsx`: wire `subscribeAgentEvents()` in a `useEffect`
- `src/components/AgentIcon.tsx`: + `data-agent-icon-state` DOM hook (e2e)
- `scripts/harness-real-cli.mjs`: `caseAgentIconActiveSessionNoHalo`

## Test plan

- [x] `npm run build` clean
- [x] ESM smoke: `node -e "require('./dist/electron/sessionTitles/index.js')"` exits 0
- [x] New e2e `agent-icon-active-session-no-halo` PASS:
  ```
  [HARNESS]   store rule OK: active stays idle, bystander goes waiting
  [HARNESS]   DOM OK: A icon=idle, B icon=waiting
  [HARNESS]   switch-away OK: A enters waiting once non-active
  [HARNESS] <<< PASS agent-icon-active-session-no-halo (519ms)
  ```
- [x] Reverse-verify: remove the `if (sid === activeId)` guard in `_applySessionState`, rebuild, rerun -> probe FAILS with:
  ```
  active-session suppression broken: A's state should stay 'idle' on incoming 'waiting' (active sid). Got state='waiting'.
  ```
  Restored, re-runs PASS.
- [x] Existing `session-state-becomes-idle` still PASS (21.6s) — full IPC plumbing covered by that case.

## Hard rules respected

- `electron/notify/` untouched (PR #519 owns it)
- `AgentIcon.tsx` visual untouched (only added a `data-*` attribute)
- No re-introduction of `SessionStateDot` / `useSessionLiveState` (#511)
- `Sidebar.tsx` untouched (#517 hot-file overlap)
- gh pr create with explicit `--base working`

Refs: deleted `08bce04`, previous correct shape `1b32c46`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>