### PR TITLE
fix(sidebar): keep Move-to-group submenu visible with New Group when no other groups (#629)

### DIFF
--- a/scripts/harness-ui.mjs
+++ b/scripts/harness-ui.mjs
@@ -1656,12 +1656,6 @@ async function caseRename({ win, log }) {
     const header = win.locator(`[data-group-header-id="${groupId}"]`).first();
     await header.click({ button: 'right' });
     await win.getByRole('menuitem', { name: /^Rename$/ }).first().click();
-    await win.waitForTimeout(500);
-    const dump = await win.evaluate((gid) => {
-      const el = document.querySelector(`[data-group-header-id="${gid}"]`);
-      return el ? el.outerHTML : 'NOT_FOUND';
-    }, groupId);
-    console.log(`[DIAG openGroupRename ${groupId}] DOM:`, dump);
     const input = win.locator(`[data-group-header-id="${groupId}"] input`).first();
     await input.waitFor({ state: 'visible', timeout: 3000 });
     await input.click();

--- a/scripts/harness-ui.mjs
+++ b/scripts/harness-ui.mjs
@@ -1656,6 +1656,12 @@ async function caseRename({ win, log }) {
     const header = win.locator(`[data-group-header-id="${groupId}"]`).first();
     await header.click({ button: 'right' });
     await win.getByRole('menuitem', { name: /^Rename$/ }).first().click();
+    await win.waitForTimeout(500);
+    const dump = await win.evaluate((gid) => {
+      const el = document.querySelector(`[data-group-header-id="${gid}"]`);
+      return el ? el.outerHTML : 'NOT_FOUND';
+    }, groupId);
+    console.log(`[DIAG openGroupRename ${groupId}] DOM:`, dump);
     const input = win.locator(`[data-group-header-id="${groupId}"] input`).first();
     await input.waitFor({ state: 'visible', timeout: 3000 });
     await input.click();
@@ -2302,9 +2308,10 @@ async function caseTerminalPaneMounted({ win, log }) {
 
 // ---------- move-to-group-excludes-own-group ----------
 // PR #517 / commit a882478. Right-click → "Move to group" submenu must NOT
-// list the session's current group. When no other group exists, the entire
-// "Move to group" submenu trigger must be hidden (otherwise users see a
-// dead-end submenu with no destinations).
+// list the session's current group. PR #629 reverses the original "hide the
+// whole submenu when empty" behavior: the submenu is ALWAYS visible — when
+// no other group exists it shows only the "New group…" escape hatch so users
+// can still create a destination from the same place.
 async function caseMoveToGroupExcludesOwnGroup({ win, log }) {
   // ---- Subcase 1: multi-group → submenu lists OTHER groups only.
   await seedStore(win, {
@@ -2342,8 +2349,9 @@ async function caseMoveToGroupExcludesOwnGroup({ win, log }) {
   await win.keyboard.press('Escape');
   await win.waitForTimeout(150);
 
-  // ---- Subcase 2: single-group → entire "Move to group" submenu trigger
-  // must be hidden (no destinations, no dead-end submenu).
+  // ---- Subcase 2: single-group → submenu trigger is STILL visible (#629),
+  // and the submenu contains only the "New group…" escape hatch — no
+  // destination groups, including the session's own group.
   await seedStore(win, {
     groups: [
       { id: 'gOnly', name: 'Only Group', collapsed: false, kind: 'normal' }
@@ -2357,14 +2365,29 @@ async function caseMoveToGroupExcludesOwnGroup({ win, log }) {
   await win.locator('li[data-session-id="s-solo"]').first().click({ button: 'right' });
   // The Rename item still anchors the menu — wait for it as a sentinel.
   await win.getByRole('menuitem', { name: /^Rename$/ }).first().waitFor({ state: 'visible', timeout: 3000 });
-  const triggerCount = await win.locator('[data-testid="move-to-group-trigger"]').count();
-  if (triggerCount !== 0) {
-    throw new Error(`move-to-group submenu trigger must be hidden when no other groups exist; got ${triggerCount} trigger(s)`);
+  const soloTrigger = win.locator('[data-testid="move-to-group-trigger"]').first();
+  await soloTrigger.waitFor({ state: 'visible', timeout: 3000 });
+  await soloTrigger.hover();
+  const soloContent = win.locator('[data-testid="move-to-group-content"]').first();
+  await soloContent.waitFor({ state: 'visible', timeout: 3000 });
+
+  const soloGroupIds = await win.evaluate(() =>
+    Array.from(document.querySelectorAll('[data-move-to-group-item]'))
+      .map((el) => el.getAttribute('data-group-id'))
+  );
+  if (soloGroupIds.length !== 0) {
+    throw new Error(`single-group submenu must not list any destination groups; got ${JSON.stringify(soloGroupIds)}`);
   }
+  const newGroupItem = soloContent.getByRole('menuitem', { name: /New group/ });
+  const newGroupCount = await newGroupItem.count();
+  if (newGroupCount !== 1) {
+    throw new Error(`single-group submenu must contain exactly one "New group…" item; got ${newGroupCount}`);
+  }
+  await win.keyboard.press('Escape');
   await win.keyboard.press('Escape');
   await win.waitForTimeout(100);
 
-  log('multi-group: own group excluded from submenu; single-group: trigger hidden entirely');
+  log('multi-group: own group excluded from submenu; single-group: submenu visible with only "New group…" entry');
 }
 
 // ---------- harness spec ----------

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -467,9 +467,10 @@ function SessionRow({ session, active, selected, onSelect, normalGroups }: { ses
         <ContextMenuItem onSelect={() => setRenaming(true)}>{t('common.rename')}</ContextMenuItem>
         {(() => {
           // Exclude the session's current group from the destination list so
-          // users can only move TO another group (#612).
+          // users can only move TO another group (#612). The submenu is
+          // ALWAYS rendered so users can still create a new group via the
+          // "New group..." escape hatch even when no other group exists (#629).
           const otherGroups = groups.filter((g) => g.id !== session.groupId);
-          if (otherGroups.length === 0) return null;
           return (
             <ContextMenuSub>
               <ContextMenuSubTrigger data-testid="move-to-group-trigger">{t('sidebar.moveToGroup')}</ContextMenuSubTrigger>
@@ -484,7 +485,7 @@ function SessionRow({ session, active, selected, onSelect, normalGroups }: { ses
                     {g.name}
                   </ContextMenuItem>
                 ))}
-                <ContextMenuSeparator />
+                {otherGroups.length > 0 && <ContextMenuSeparator />}
                 <ContextMenuItem
                   onSelect={() => {
                     const id = createGroup();


### PR DESCRIPTION
## User report (#629)

> 如果只有1个group，右键session应该仍然有move to group，只是里面只有新建group，而不是现在这样没有move to group

PR #517 hid the entire Move-to-group submenu when the only existing group was the session's own group. The user reverses that rule: the submenu should always be available so users can still reach "New group..." from the same place — even when there is no other destination group yet.

## Changes

- `src/components/Sidebar.tsx`: drop the early-return that hid the submenu when the filtered destination list was empty. Render the inner separator only when at least one other group exists.
- `scripts/harness-ui.mjs` (`caseMoveToGroupExcludesOwnGroup` subcase 2): flip the assertion. Now expects the trigger to be visible, the submenu to contain exactly one "New group..." item, and zero destination groups.

Behavior matrix:

| Groups | Submenu trigger | Submenu contents |
|---|---|---|
| Multi-group (own + others) | visible | other groups + separator + "New group..." (unchanged from #517) |
| Single-group (only own) | visible (#629) | only "New group..." |

## E2E

Probe PASS:
```
[case=move-to-group-excludes-own-group] multi-group: own group excluded from submenu; single-group: submenu visible with only "New group…" entry
[case=move-to-group-excludes-own-group] OK
=== totals: 1 passed, 0 failed, 0 skipped, 1 total ===
```

Reverse-verify (revert Sidebar.tsx fix → rebuild → rerun probe) FAILS as expected:
```
[case=move-to-group-excludes-own-group] FAIL: locator.waitFor: Timeout 3000ms exceeded.
  - waiting for locator('[data-testid="move-to-group-trigger"]').first() to be visible
=== totals: 0 passed, 1 failed, 0 skipped, 1 total ===
```

ESM smoke: `node -e "require('./dist/electron/sessionTitles/index.js')"` exit 0.

## Test plan
- [x] `npm run build` clean
- [x] `node scripts/harness-ui.mjs --only=move-to-group-excludes-own-group` PASS
- [x] Reverse-verify FAIL with hide-when-empty guard restored