### PR TITLE
fix(spawn): wire cwd popover Browse to OS folder picker (#628)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -939,6 +939,34 @@ app.whenReady().then(() => {
     return pushUserCwd(p);
   });
   ipcMain.handle('app:userHome', () => os.homedir());
+  // OS folder picker for the cwd popover's "Browse..." button. Returns the
+  // chosen absolute path on success, or null when the user cancelled or no
+  // window is available. Anchored on the requesting BrowserWindow so the
+  // dialog is modal to the right surface (relevant when devtools are popped
+  // out into their own window). Bug #628: prior to this handler the Browse
+  // button was a no-op (just closed the popover) and users picking a cwd
+  // via Browse silently fell through to the LRU/home default — matching
+  // the dogfood report "在特定目录创建session，创建出来的session仍然在home目录".
+  ipcMain.handle('cwd:pick', async (e, opts?: { defaultPath?: string }) => {
+    const win = BrowserWindow.fromWebContents(e.sender);
+    if (!win || win.isDestroyed()) return null;
+    const defaultPath =
+      typeof opts?.defaultPath === 'string' && opts.defaultPath.length > 0
+        ? opts.defaultPath
+        : os.homedir();
+    try {
+      const result = await dialog.showOpenDialog(win, {
+        title: 'Pick working directory',
+        defaultPath,
+        properties: ['openDirectory', 'createDirectory', 'dontAddToRecent'],
+      });
+      if (result.canceled) return null;
+      const picked = result.filePaths[0];
+      return typeof picked === 'string' && picked.length > 0 ? picked : null;
+    } catch {
+      return null;
+    }
+  });
   // The new-session default model comes straight from the user's CLI
   // settings.json — same source the CLI itself reads for `--model`. Replaces
   // the old `import:topModel` frequency-vote IPC (PR #369), which produced

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -79,6 +79,16 @@ const api = {
   },
 
   /**
+   * Open the OS folder picker so the user can choose a working directory
+   * for a new session. Returns the picked absolute path on success, or
+   * `null` when the user cancelled. Backs the cwd popover's "Browse..."
+   * button (#628) — prior to this IPC the button was a no-op (just closed
+   * the popover), causing user-picked cwds to silently fall back to home.
+   */
+  pickCwd: (defaultPath?: string): Promise<string | null> =>
+    ipcRenderer.invoke('cwd:pick', { defaultPath }),
+
+  /**
    * The user's CLI default-model preference, read directly from
    * `~/.claude/settings.json`'s `model` field. Seeds the new-session model
    * picker so ccsm matches whatever the user already configured for the

--- a/electron/ptyHost/index.ts
+++ b/electron/ptyHost/index.ts
@@ -48,6 +48,12 @@ export interface PtySessionInfo {
   pid: number;
   cols: number;
   rows: number;
+  /** Working directory the PTY was actually spawned with (post-`resolveSpawnCwd`
+   *  fallback). Diverges from the renderer's `session.cwd` ONLY when the
+   *  requested cwd was missing/unreadable, in which case `resolveSpawnCwd`
+   *  falls back to homedir. Surfaced so e2e probes can verify that picked
+   *  cwds reach the real PTY (#628). */
+  cwd: string;
 }
 
 export interface AttachResult {
@@ -69,6 +75,9 @@ interface Entry {
   attached: Map<number, WebContents>;
   cols: number;
   rows: number;
+  /** Resolved spawn cwd (after `resolveSpawnCwd` fallback). Captured here
+   *  so `listPtySessions` / `getPtySession` can return it without re-deriving. */
+  cwd: string;
 }
 
 const sessions = new Map<string, Entry>();
@@ -332,6 +341,7 @@ function makeEntry(
     attached: new Map(),
     cols,
     rows,
+    cwd: spawnCwd,
   };
 
   p.onData((chunk) => {
@@ -405,13 +415,14 @@ export function spawnPtySession(
       pid: existing.pty.pid,
       cols: existing.cols,
       rows: existing.rows,
+      cwd: existing.cwd,
     };
   }
   const cols = opts?.cols ?? DEFAULT_COLS;
   const rows = opts?.rows ?? DEFAULT_ROWS;
   const entry = makeEntry(sid, cwd, claudePath, cols, rows, opts?.onCwdRedirect);
   sessions.set(sid, entry);
-  return { sid, pid: entry.pty.pid, cols, rows };
+  return { sid, pid: entry.pty.pid, cols, rows, cwd: entry.cwd };
 }
 
 export function listPtySessions(): PtySessionInfo[] {
@@ -420,6 +431,7 @@ export function listPtySessions(): PtySessionInfo[] {
     pid: e.pty.pid,
     cols: e.cols,
     rows: e.rows,
+    cwd: e.cwd,
   }));
 }
 
@@ -531,7 +543,7 @@ function killProcessSubtree(pid: number | undefined): void {
 export function getPtySession(sid: string): PtySessionInfo | null {
   const entry = sessions.get(sid);
   if (!entry) return null;
-  return { sid, pid: entry.pty.pid, cols: entry.cols, rows: entry.rows };
+  return { sid, pid: entry.pty.pid, cols: entry.cols, rows: entry.rows, cwd: entry.cwd };
 }
 
 // Kill every running pty. Call from app `before-quit` so renderer-side

--- a/scripts/harness-real-cli.mjs
+++ b/scripts/harness-real-cli.mjs
@@ -2651,6 +2651,33 @@ async function caseCwdPickerTopChevron({ win, tempDir }) {
   );
   if (stillOpen) throw new Error('cwd popover did not close after pick');
 
+  // #628: verify the picked cwd ALSO reaches the real PTY in main, not just
+  // the renderer store. ccsmPty.list() now returns each entry's resolved
+  // spawn cwd (post-`resolveSpawnCwd` fallback). If main were ignoring the
+  // renderer-supplied cwd (e.g. defaulting to homedir), this assert catches
+  // it even when the renderer-side store happens to look correct. Wait up
+  // to ~6s for the spawn to land — pty.attach drives spawn-on-attach-null.
+  const sid = await win.evaluate(() => window.__ccsmStore.getState().activeId);
+  let actualPtyCwd = null;
+  for (let i = 0; i < 60; i++) {
+    actualPtyCwd = await win.evaluate(async (s) => {
+      const list = await window.ccsmPty?.list?.();
+      if (!Array.isArray(list)) return null;
+      const entry = list.find((x) => x.sid === s);
+      return entry && typeof entry.cwd === 'string' ? entry.cwd : null;
+    }, sid);
+    if (actualPtyCwd) break;
+    await sleep(100);
+  }
+  if (!actualPtyCwd) {
+    throw new Error(`PTY entry never appeared in ccsmPty.list() for sid=${sid}`);
+  }
+  if (_norm(actualPtyCwd) !== target) {
+    throw new Error(
+      `top chevron pick did not reach the real PTY. picked=${target} pty.cwd=${_norm(actualPtyCwd)} (store.cwd=${actual})`,
+    );
+  }
+
   await _deleteActive(win);
 }
 
@@ -2684,6 +2711,95 @@ async function caseCwdPickerNoShortcut({ win }) {
   if (after !== before) {
     throw new Error(`Cmd/Ctrl+N (or +Shift+G) still creates sessions. before=${before} after=${after}`);
   }
+}
+
+// Case: cwd-picker-browse
+//   Click the chevron → popover opens → click "Browse..." → assert main's
+//   `cwd:pick` IPC fires AND the picked path lands in BOTH the renderer
+//   `session.cwd` AND the real PTY entry's `cwd`. Repros #628: prior to
+//   the fix the Browse button was a no-op (just closed the popover) and
+//   sessions silently fell back to the LRU/home default ("在特定目录创建
+//   session，创建出来的session仍然在home目录"). We stub `dialog.showOpenDialog`
+//   in the main process so the test is deterministic and headless.
+async function caseCwdPickerBrowse({ electronApp, win, tempDir }) {
+  await _waitBoot(win);
+  // The dir Browse "returns" via the stubbed dialog. Real path so
+  // `resolveSpawnCwd` doesn't fall back to homedir on the PTY side.
+  const browseTarget = path.join(tempDir, 'browse-pick-' + Math.random().toString(36).slice(2, 8));
+  mkdirSync(browseTarget, { recursive: true });
+
+  // Stub electron.dialog.showOpenDialog in the main process. Captures the
+  // call so we know Browse really hit the IPC.
+  await electronApp.evaluate(async ({ dialog }, picked) => {
+    globalThis.__ccsmBrowseStub = { calls: 0, lastDefault: null };
+    dialog.showOpenDialog = async (_win, opts) => {
+      globalThis.__ccsmBrowseStub.calls += 1;
+      globalThis.__ccsmBrowseStub.lastDefault = opts && opts.defaultPath ? opts.defaultPath : null;
+      return { canceled: false, filePaths: [picked] };
+    };
+  }, browseTarget);
+
+  const before = await _sessionCount(win);
+  await win.click('[data-testid="sidebar-newsession-cwd-chevron"]');
+  await win.waitForSelector('[data-testid="cwd-popover-panel"]', { timeout: 4000 });
+
+  // Click the "Browse..." button at the bottom of the panel. It commits via
+  // mousedown for the same blur-race reason the Recent rows do.
+  await win.evaluate(() => {
+    const panel = document.querySelector('[data-testid="cwd-popover-panel"]');
+    if (!panel) throw new Error('cwd popover panel not in DOM');
+    const buttons = Array.from(panel.querySelectorAll('button'));
+    const browse = buttons[buttons.length - 1]; // Browse is the last button in the panel.
+    if (!browse) throw new Error('browse button not found in cwd popover');
+    browse.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+  });
+
+  // Wait for the new session to appear (Browse → IPC → createSession is
+  // a few ticks of awaits across the main↔renderer boundary).
+  for (let i = 0; i < 40; i++) {
+    const n = await _sessionCount(win);
+    if (n - before === 1) break;
+    await sleep(100);
+  }
+  const after = await _sessionCount(win);
+  if (after - before !== 1) {
+    throw new Error(`Browse did not create a session. before=${before} after=${after}`);
+  }
+
+  // 1/ Renderer assertion: store cwd matches the picked path.
+  const storeCwd = _norm(await _activeCwd(win));
+  if (storeCwd !== _norm(browseTarget)) {
+    throw new Error(`Browse: store cwd != picked. picked=${browseTarget} store=${storeCwd}`);
+  }
+
+  // 2/ Main-side assertion: real PTY spawn cwd matches the picked path.
+  const sid = await win.evaluate(() => window.__ccsmStore.getState().activeId);
+  let actualPtyCwd = null;
+  for (let i = 0; i < 60; i++) {
+    actualPtyCwd = await win.evaluate(async (s) => {
+      const list = await window.ccsmPty?.list?.();
+      if (!Array.isArray(list)) return null;
+      const entry = list.find((x) => x.sid === s);
+      return entry && typeof entry.cwd === 'string' ? entry.cwd : null;
+    }, sid);
+    if (actualPtyCwd) break;
+    await sleep(100);
+  }
+  if (!actualPtyCwd) throw new Error(`Browse: PTY entry never appeared in ccsmPty.list() for sid=${sid}`);
+  if (_norm(actualPtyCwd) !== _norm(browseTarget)) {
+    throw new Error(
+      `Browse did not reach the real PTY. picked=${browseTarget} pty.cwd=${_norm(actualPtyCwd)} store.cwd=${storeCwd}`,
+    );
+  }
+
+  // 3/ Confirm the IPC stub really fired (proves Browse wired through, not
+  // some unrelated code path that happened to set cwd correctly).
+  const stubInfo = await electronApp.evaluate(() => globalThis.__ccsmBrowseStub || null);
+  if (!stubInfo || stubInfo.calls < 1) {
+    throw new Error(`Browse did not invoke dialog.showOpenDialog (calls=${stubInfo?.calls})`);
+  }
+
+  await _deleteActive(win);
 }
 
 // Case: sidebar-group-no-newsession-cluster
@@ -2811,6 +2927,7 @@ const CASE_REGISTRY = [
   { name: 'pty-pid-stable-across-switch',group: 'shared', run: casePtyPidStableAcrossSwitch },
   { name: 'cwd-picker-top-default',      group: 'shared', run: caseCwdPickerTopDefault },
   { name: 'cwd-picker-top-chevron',      group: 'shared', run: caseCwdPickerTopChevron },
+  { name: 'cwd-picker-browse',           group: 'shared', run: caseCwdPickerBrowse },
   { name: 'cwd-picker-no-shortcut',      group: 'shared', run: caseCwdPickerNoShortcut },
   { name: 'sidebar-group-no-newsession-cluster', group: 'shared', run: caseSidebarGroupHasNoNewSessionCluster },
   { name: 'reopen-resume',               group: 'standalone', run: caseReopenResume },

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -794,7 +794,17 @@ export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, onOpen
               createSession({ cwd: picked });
               setTopCwdPickerOpen(false);
             }}
-            onBrowse={() => setTopCwdPickerOpen(false)}
+            onBrowse={async () => {
+              // Close the popover synchronously so a slow OS dialog doesn't
+              // leave a dangling Recent list under the modal. The popover's
+              // own click-outside handler would catch the dialog click on
+              // some platforms anyway, but explicit > implicit.
+              setTopCwdPickerOpen(false);
+              const picked = await window.ccsm?.pickCwd?.();
+              if (typeof picked === 'string' && picked.length > 0) {
+                createSession({ cwd: picked });
+              }
+            }}
           />
 
           {/* Middle: work zone — Groups (flex-grow, scrollable) on top,

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -62,6 +62,13 @@ declare global {
       };
 
       /**
+       * Open the OS folder picker for the cwd popover's "Browse..." button.
+       * Returns the picked absolute path on success, or `null` when the
+       * user cancelled. Backs the popover Browse action (#628).
+       */
+      pickCwd: (defaultPath?: string) => Promise<string | null>;
+
+      /**
        * Default model from `~/.claude/settings.json`'s `model` field — the
        * same value the CLI consults for `--model` defaulting. Seeds the
        * new-session picker. Null when unset, missing, or unparseable.

--- a/src/pty.d.ts
+++ b/src/pty.d.ts
@@ -11,6 +11,8 @@ export interface PtySessionInfo {
   pid: number;
   cols: number;
   rows: number;
+  /** Working directory the PTY was actually spawned with (post-fallback). */
+  cwd: string;
 }
 
 export interface AttachResult {


### PR DESCRIPTION
## Summary

User dogfood report (verbatim): **"在特定目录创建session，创建出来的session仍然在home目录，我估计是你没把cwd传递对"**

User picked a working directory via the sidebar New Session chevron, but the resulting session landed at homedir instead.

## Root cause

The cwd popover's `Browse...` button was a no-op:

```tsx
// src/components/Sidebar.tsx (before)
onBrowse={() => setTopCwdPickerOpen(false)}
```

Clicking it just closed the popover — no OS folder picker, no cwd forwarded to `createSession`. Users seeing the Browse affordance naturally expected an OS folder picker; without one the popover silently dismissed and a subsequent ` + New session` click then defaulted through `lastUsedCwd ?? userHome` (homedir on a fresh install with an empty LRU), exactly matching the report.

## Fix

- new `cwd:pick` IPC in `electron/main.ts` that anchors `dialog.showOpenDialog` on the requesting `BrowserWindow` with `openDirectory` + `createDirectory` properties, returning the picked absolute path or `null` on cancel
- new `window.ccsm.pickCwd(defaultPath?)` preload bridge
- `Sidebar`'s `<CwdPopover onBrowse>` now closes the popover, awaits `pickCwd()`, and on a non-empty result calls `createSession({ cwd: picked })` — same path as the Recent row pick

## Verification surface

- `PtySessionInfo` (and the internal `Entry`) now carry the resolved spawn cwd so e2e probes can verify the picked cwd reached the real PTY, not just the renderer store. This catches the orthogonal regression \"renderer says cwd=X but main spawned at homedir\" if it ever shows up.
- Extended `cwd-picker-top-chevron` to assert `ccsmPty.list()[].cwd === picked` after a Recent-row pick.
- New `cwd-picker-browse` probe stubs `dialog.showOpenDialog` in main, drives the Browse button, and asserts BOTH renderer `session.cwd` AND `ccsmPty.list()[].cwd` equal the picked path AND that the dialog stub was actually invoked.

## E2E

```
PASS  cwd-picker-top-chevron             858ms
PASS  cwd-picker-browse                  488ms
```

Reverse-verify (revert `Sidebar` onBrowse to the no-op):
```
FAIL  cwd-picker-browse                  4581ms: Browse did not create a session. before=0 after=0
```

Sibling probes still green:
```
PASS  default-cwd-from-userCwds-lru
PASS  cwd-picker-top-default
PASS  cwd-picker-no-shortcut
```

## Test plan

- [x] cwd-picker-top-chevron: pick from Recent → store cwd + PTY cwd both equal picked
- [x] cwd-picker-browse: click Browse → main dialog stub invoked, store cwd + PTY cwd both equal picked
- [x] Reverse-verify: removing the Sidebar onBrowse rewire causes browse probe to fail
- [x] No regression on cwd-picker-top-default, cwd-picker-no-shortcut, default-cwd-from-userCwds-lru
- [x] ESM smoke: `node -e \"require('./dist/electron/sessionTitles/index.js')\"` + ptyHost both exit 0
- [x] PR #515 import-resume cwd-redirect path untouched (still gated on `result.copied === true` for sourceJsonl-bearing sessions)