### PR TITLE
fix(ui): right-click Rename input vanishes before user can type (#627)

### DIFF
--- a/src/components/ui/InlineRename.tsx
+++ b/src/components/ui/InlineRename.tsx
@@ -32,6 +32,20 @@ export function InlineRename({
   // a ref so blur / mousedown handlers (which don't see the keydown event)
   // can short-circuit too.
   const composingRef = useRef(false);
+  // "Armed" gate for the auto-cancel paths (onBlur + outside-mousedown).
+  // When InlineRename is mounted from a Radix ContextMenuItem.onSelect, Radix
+  // closes the menu and dispatches `onCloseAutoFocus` which calls .focus() on
+  // the trigger element AFTER our own mount-effect focus(). That trigger
+  // .focus() blurs our input → onBlur → commit() → onCancel() → row
+  // unmounts the rename input INSTANTLY before the user can type a single
+  // character. Same race fires the document-mousedown auto-commit listener
+  // for the synthetic events Radix dispatches during close. Gate both auto-
+  // cancel paths on `armedRef.current === true`, which we only set AFTER the
+  // deferred mount focus settles — by which time Radix's focus restoration
+  // has already lost the race for the input element. Explicit Enter/Escape
+  // keypresses bypass this gate (see onKeyDown) so the user can still
+  // commit/cancel even before the arm tick fires.
+  const armedRef = useRef(false);
 
   useEffect(() => {
     const el = ref.current;
@@ -50,7 +64,21 @@ export function InlineRename({
       cur.focus();
       cur.select();
     });
-    return () => cancelAnimationFrame(raf);
+    // Arm auto-cancel paths AFTER a short timer so any focus / blur /
+    // pointer events Radix dispatches during ContextMenu close + focus
+    // restoration are swallowed. rAF (~16ms) is too tight on slow renders;
+    // the second tick from setTimeout(0) bumps us past Radix's microtask
+    // queue + focus restoration. We still bypass this gate for explicit
+    // Enter/Escape keypresses (see onKeyDown) so the user can never be
+    // blocked from committing/cancelling even if their first keystroke
+    // lands within the arm window.
+    const armTimer = window.setTimeout(() => {
+      armedRef.current = true;
+    }, 50);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.clearTimeout(armTimer);
+    };
   }, []);
 
   function commit() {
@@ -69,6 +97,9 @@ export function InlineRename({
   // ourselves and commit/cancel when a click lands outside.
   useEffect(() => {
     function onPointerDown(e: MouseEvent) {
+      // Pre-arm: ignore synthetic mousedown events Radix may dispatch
+      // during context-menu close + focus restoration.
+      if (!armedRef.current) return;
       const el = ref.current;
       if (!el) return;
       if (e.target instanceof Node && el.contains(e.target)) return;
@@ -84,7 +115,16 @@ export function InlineRename({
       ref={ref}
       value={draft}
       onChange={(e) => setDraft(e.target.value)}
-      onBlur={commit}
+      onBlur={() => {
+        // Pre-arm: swallow the blur Radix triggers when its
+        // onCloseAutoFocus calls .focus() on the context-menu trigger
+        // element, which steals focus from this just-mounted input.
+        // Without this guard the very first blur (which fires before the
+        // user has had any chance to type) would call commit() →
+        // onCancel() → instant unmount.
+        if (!armedRef.current) return;
+        commit();
+      }}
       onCompositionStart={() => { composingRef.current = true; }}
       onCompositionEnd={() => { composingRef.current = false; }}
       onKeyDown={(e) => {


### PR DESCRIPTION
## User report

Dogfood, in Chinese: 右键 Rename 有 bug, 自己查吧, 懒得说了. ("Right-click Rename is broken, figure it out yourself, can't be bothered to explain.")

## Reproduction

- Right-click any sidebar group header → click "Rename"
- OR rename a session row a second time after a previous rename
- The inline input flashes in the DOM for ~15ms, never settles on screen, and the user sees nothing happen

Reproduces with 100% reliability via `node scripts/harness-ui.mjs --only=rename` (the existing `caseRename` probe was already checking the failing assertion but flaked depending on timing).

## Root cause race

1. `ContextMenuItem onSelect` fires `setRenaming(true)`
2. React commits → `InlineRename` mounts → mount `useEffect` calls `input.focus()`
3. Radix Menu closes and runs `onCloseAutoFocus`, which calls `.focus()` on the context-menu trigger element
4. That trigger `.focus()` blurs our input → React `onBlur` fires `commit()` → draft equals existing value → `onCancel()` → row unmounts InlineRename instantly

Same race fires the document-mousedown auto-commit listener for synthetic events Radix dispatches during close.

PR #506 already partially mitigated this by deferring the focus call with `requestAnimationFrame`, but only fixed the focus side of the race — the `onBlur` and document-mousedown side still fired and cancelled.

## Fix

Gate the auto-cancel paths (`onBlur` + outside-mousedown listener) on an `armedRef` that flips `true` 50ms after mount. Within that window only explicit Enter/Escape keypresses can commit/cancel — so the user is never blocked even if their first keystroke lands inside it. After 50ms, behavior is unchanged (blur-to-commit, click-outside-to-commit). 50ms reliably beats Radix's focus restoration which empirically fires at ~15ms after mount; rAF (~16ms) was too tight.

Touches only `src/components/ui/InlineRename.tsx`. No callsite changes; existing `onCommit` / `onCancel` contract preserved.

## Test plan

- [x] `node scripts/harness-ui.mjs --only=rename` PASS 3/3 consecutive runs (covers session Enter / session Escape / session whitespace-Enter / session click-outside / session IME composition / group Enter / group Escape — all 7 sub-cases)
- [x] Reverse-verify: `git stash` the InlineRename change, rebuild, 4/4 consecutive FAIL with exact symptom `waiting for locator(... input).first() to be visible` timeout
- [x] Restore: 3/3 consecutive PASS again
- [x] `npm run typecheck` clean
- [x] `npm run lint` (file scope) clean
- [x] ESM smoke: `node -e "require('./dist/electron/sessionTitles/index.js')"` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)