### PR TITLE
fix(rename): sidebar rename writes to JSONL via SDK + surface errors

### DIFF
--- a/electron/sessionTitles/__tests__/renameWriteback.integration.test.ts
+++ b/electron/sessionTitles/__tests__/renameWriteback.integration.test.ts
@@ -1,0 +1,147 @@
+// Integration test against the real `@anthropic-ai/claude-agent-sdk`.
+//
+// Reproduces the sidebar-rename writeback bug (eval #647 / task #650): the
+// renderer hands `renameSessionTitle` a `dir` that does not realpath-encode
+// to the project-key directory under which the session JSONL actually lives
+// (common on Windows when the cwd was renamed/moved/case-shifted between
+// session creation and the rename). The SDK's `eB` writer iterates only the
+// dir candidates that already exist on disk and throws
+// `Session <sid> not found in project directory for <dir>` when none match.
+// The bridge classifies that throw as `sdk_threw`, which the store silently
+// swallows — JSONL never gets the `custom-title` frame.
+//
+// This test exercises the real fs path: a real project-key directory and a
+// real `<sid>.jsonl` fixture, with the bridge calling the actual SDK (no
+// `__setSdkForTests`). It must FAIL on origin/working and PASS once the fix
+// (canonicalize-or-omit `dir` before calling SDK) is in place.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { promises as fsp } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+import {
+  renameSessionTitle,
+  __resetForTests,
+  __setSdkForTests,
+} from '../index';
+
+// SDK projectKey encoder (mirrors `_1` in sdk.mjs:285668): replace every
+// non-alphanumeric with `-`. We use it here ONLY to construct the canonical
+// fixture directory; production code in this repo must NOT depend on the
+// SDK's internal encoder beyond what the bridge does.
+function encodeProjectKey(absPath: string): string {
+  return absPath.replace(/[^a-zA-Z0-9]/g, '-');
+}
+
+let originalConfigDir: string | undefined;
+let tmpRoot = '';
+let projectsDir = '';
+
+beforeEach(async () => {
+  __resetForTests();
+  // Inject the REAL SDK exports. The bridge's production loader uses
+  // `new Function('return import(spec)')` to dodge tsc's CJS rewrite, but
+  // that shim is rejected under vitest/Vite ("dynamic import callback was
+  // not specified"). Importing the SDK normally here works because vitest
+  // is itself ESM-aware. The bridge's `__setSdkForTests` seam exists for
+  // exactly this reason — the SDK module instance is real, only the loader
+  // is bypassed.
+  const realSdk = await import('@anthropic-ai/claude-agent-sdk');
+  __setSdkForTests({
+    getSessionInfo: realSdk.getSessionInfo,
+    renameSession: realSdk.renameSession,
+    listSessions: realSdk.listSessions,
+  });
+  // Isolate ~/.claude/projects/ to a tmp tree so we never touch the user's
+  // real session store. SDK reads CLAUDE_CONFIG_DIR (see sdk.mjs y4 / 163796)
+  // exactly once per process and memoizes via `f6`. We import the bridge
+  // (and therefore the SDK module) BEFORE this hook runs, so the memoized
+  // value already captured the env var. To make the test deterministic we
+  // set the env var early (top of file would be too late: imports already
+  // ran) — but since the bridge uses a `new Function` shim that re-imports
+  // the SDK module, the SDK will respect the current env var on its own
+  // first call inside this file. To be safe across re-runs we set it here.
+  originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  tmpRoot = await fsp.mkdtemp(path.join(os.tmpdir(), 'ccsm-rename-it-'));
+  process.env.CLAUDE_CONFIG_DIR = tmpRoot;
+  projectsDir = path.join(tmpRoot, 'projects');
+  await fsp.mkdir(projectsDir, { recursive: true });
+});
+
+afterEach(async () => {
+  if (originalConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+  else process.env.CLAUDE_CONFIG_DIR = originalConfigDir;
+  if (tmpRoot) {
+    await fsp.rm(tmpRoot, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+describe('renameSessionTitle real-fs writeback', () => {
+  it(
+    'writes a custom-title frame to the JSONL even when the caller passes a dir that does not encode to the on-disk project key',
+    async () => {
+      const sid = randomUUID();
+      // Fixture: the JSONL lives under a project key derived from
+      // `realProjectCwd`. The renderer will hand us `staleCwd` (different
+      // path → different encoded key). Pre-fix this drives `Y6` to return
+      // [], `eB` throws, and the bridge returns `sdk_threw`.
+      const realProjectCwd = path.join(tmpRoot, 'project-real');
+      const staleCwd = path.join(tmpRoot, 'project-renamed');
+      await fsp.mkdir(realProjectCwd, { recursive: true });
+      // Note: we deliberately do NOT create staleCwd on disk. `p4` (sdk
+      // realpath helper) catches the ENOENT and falls back to NFC-normalizing
+      // the input, so the encoded key still differs from the real one.
+
+      const projectKey = encodeProjectKey(realProjectCwd);
+      const projectDirOnDisk = path.join(projectsDir, projectKey);
+      await fsp.mkdir(projectDirOnDisk, { recursive: true });
+      const jsonlPath = path.join(projectDirOnDisk, `${sid}.jsonl`);
+      // Minimal seed line so SDK's append guard (`size === 0` short-circuit
+      // in `pz`) does not skip the file.
+      await fsp.writeFile(
+        jsonlPath,
+        JSON.stringify({
+          type: 'user',
+          sessionId: sid,
+          timestamp: new Date().toISOString(),
+          message: { role: 'user', content: 'seed' },
+          cwd: realProjectCwd,
+        }) + '\n',
+        'utf8'
+      );
+
+      const newTitle = 'sidebar-rename-target';
+      const result = await renameSessionTitle(sid, newTitle, staleCwd);
+
+      // Read back and assert the SDK actually appended a custom-title frame.
+      const after = await fsp.readFile(jsonlPath, 'utf8');
+      const hasCustomTitle = after
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .some((line) => {
+          try {
+            const obj = JSON.parse(line);
+            return (
+              obj &&
+              obj.type === 'custom-title' &&
+              obj.customTitle === newTitle &&
+              obj.sessionId === sid
+            );
+          } catch {
+            return false;
+          }
+        });
+
+      expect(
+        result.ok,
+        result.ok
+          ? 'expected ok'
+          : `bridge returned reason=${result.reason} message=${result.message ?? ''}`
+      ).toBe(true);
+      expect(hasCustomTitle, `JSONL contents:\n${after}`).toBe(true);
+    },
+    15000
+  );
+});

--- a/electron/sessionTitles/index.ts
+++ b/electron/sessionTitles/index.ts
@@ -194,7 +194,33 @@ export async function renameSessionTitle(
       titleCache.delete(sid);
       return { ok: true };
     } catch (err) {
+      // Sidebar rename hands us `session.cwd`. SDK derives the on-disk
+      // project-key directory from that cwd via `_1(realpath(dir))`
+      // (sdk.mjs `k6`/`_1`); when the cwd was renamed/moved/case-shifted
+      // since the session was created — common on Windows — the encoded key
+      // does not match the directory the JSONL actually lives under, and
+      // SDK throws `Session <sid> not found in project directory for <dir>`.
+      // The dir-less SDK path iterates every `~/.claude/projects/*` and
+      // appends to whichever subdir owns `<sid>.jsonl` (sdk.d.ts:2204
+      // documents this), so retrying without `dir` is the bulletproof
+      // recovery. ENOENT (no JSONL anywhere) is a different signal — bubble
+      // it up unchanged so the store can enqueue a pending rename.
       const cls = classifyError(err);
+      const isProjectMismatch =
+        dir !== undefined &&
+        cls.reason === 'sdk_threw' &&
+        typeof cls.message === 'string' &&
+        cls.message.includes('not found in project directory');
+      if (isProjectMismatch) {
+        try {
+          const { renameSession } = await loadSdk();
+          await renameSession(sid, title, undefined);
+          titleCache.delete(sid);
+          return { ok: true };
+        } catch (retryErr) {
+          return { ok: false, ...classifyError(retryErr) };
+        }
+      }
       return { ok: false, ...cls };
     }
   });

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -677,14 +677,18 @@ export const useStore = create<State & Actions>((set, get) => ({
         await bridge.enqueuePending(id, name, dir);
         return;
       }
-      // sdk_threw — best-effort. Local name stays; we just log.
-      console.warn(
-        `[store] renameSession SDK writeback failed for ${id}: ${result.message ?? '(no message)'}`
+      // sdk_threw — best-effort. Local name stays so the user's intent
+      // doesn't visibly flicker back, but we elevate this to console.error
+      // (with a grep-friendly tag) so future regressions in the SDK
+      // writeback path are visible during dogfood instead of being silently
+      // swallowed (eval #647 / #650 root cause: warn was lost in noise).
+      console.error(
+        `[rename:writeback-failed] sid=${id} message=${result.message ?? '(no message)'}`
       );
     } catch (err) {
-      // IPC channel itself failed — extremely unlikely, but don't surface a
-      // toast (per task spec "do not toast SDK errors").
-      console.warn(`[store] renameSession IPC failed for ${id}:`, err);
+      // IPC channel itself failed — extremely unlikely, but still surface
+      // it as an error so the bug doesn't hide.
+      console.error(`[rename:writeback-failed] ipc sid=${id}`, err);
     }
   },
 

--- a/tests/store-rename-session.test.ts
+++ b/tests/store-rename-session.test.ts
@@ -5,7 +5,7 @@ import type { Session } from '../src/types';
 // Covers the three outcomes of `renameSession` SDK writeback wired in PR2:
 //   1. ok          → local name updated, no enqueue
 //   2. no_jsonl    → local name updated, enqueuePending called
-//   3. sdk_threw   → local name updated, enqueuePending NOT called, console.warn
+//   3. sdk_threw   → local name updated, enqueuePending NOT called, console.error
 //
 // `window.ccsmSessionTitles` is the IPC bridge created in `electron/preload.ts`;
 // jsdom doesn't expose it by default. We install a mock per case and tear it
@@ -45,16 +45,19 @@ function seedSession(id: string, name: string, cwd: string): void {
 
 describe('store.renameSession (SDK writeback)', () => {
   let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     // Wipe sessions from prior cases so id collisions can't pollute.
     useStore.setState({ sessions: [] });
     warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
     delete (window as unknown as { ccsmSessionTitles?: unknown }).ccsmSessionTitles;
     warnSpy.mockRestore();
+    errorSpy.mockRestore();
     useStore.setState({ sessions: [] });
   });
 
@@ -90,7 +93,7 @@ describe('store.renameSession (SDK writeback)', () => {
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  it('sdk_threw: local name updated, no enqueue, warn logged', async () => {
+  it('sdk_threw: local name updated, no enqueue, error logged', async () => {
     const { enqueuePending } = installBridge(async () => ({
       ok: false,
       reason: 'sdk_threw',
@@ -103,8 +106,13 @@ describe('store.renameSession (SDK writeback)', () => {
     const after = useStore.getState().sessions.find((s) => s.id === 'sid-threw');
     expect(after?.name).toBe('attempted');
     expect(enqueuePending).not.toHaveBeenCalled();
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(String(warnSpy.mock.calls[0][0])).toContain('sid-threw');
+    // sdk_threw escalates to console.error (not warn) so dogfood actually
+    // sees writeback regressions instead of silently shipping a UI-vs-JSONL
+    // split-brain (eval #647 root cause).
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(String(errorSpy.mock.calls[0][0])).toContain('sid-threw');
+    expect(String(errorSpy.mock.calls[0][0])).toContain('rename:writeback-failed');
   });
 
   it('local update happens even before the SDK promise resolves (optimistic)', async () => {


### PR DESCRIPTION
## Summary
Sidebar rename was silently failing to write to JSONL on a class of sessions (eval #647 / task #650). SDK errors were swallowed by `console.warn` in the store, leaving ccsm's local store and the CLI's JSONL view of session names out of sync — UI showed the new name, `cat <sid>.jsonl` showed the old one, `/rename` from CLI worked.

## Root cause
SDK derives the on-disk project-key directory from the cwd via `_1(realpath(dir))` (`sdk.mjs` `k6`/`_1`, → `~/.claude/projects/<encoded>`). When `session.cwd` was renamed, moved, or case-shifted between session creation and the rename — common on Windows — the encoded key no longer matches the directory the JSONL actually lives under. SDK's `eB` writer (`sdk.mjs:299198`) iterates only the candidates that exist on disk and throws:

```
Session <sid> not found in project directory for <dir>
```

The bridge classified that throw as `sdk_threw`; the store's `console.warn` then hid it. The reverse direction (CLI → sidebar via `sessionWatcher`) worked, masking the bug from casual inspection.

## Fix
- `electron/sessionTitles/index.ts`: when SDK throws "not found in project directory", retry once with `dir` omitted. SDK then iterates every `~/.claude/projects/*` and appends to whichever subdir owns `<sid>.jsonl` (`sdk.d.ts:2204` documents this fallback). Bulletproof recovery — no platform-specific path normalization needed.
- `src/stores/store.ts`: elevate `sdk_threw` and IPC-failure paths from `console.warn` to `console.error` with a grep-friendly `[rename:writeback-failed]` tag so future regressions surface during dogfood instead of being lost in noise. Optimistic local update is preserved (no flicker).
- `electron/sessionTitles/__tests__/renameWriteback.integration.test.ts`: new real-fs probe against the actual SDK. Sets `CLAUDE_CONFIG_DIR` to a tmp tree, plants a session JSONL under the canonical project key, then calls `renameSessionTitle` with a `dir` that does NOT encode to the real key. Asserts a `custom-title` frame appears in the JSONL.
- `tests/store-rename-session.test.ts`: update the existing `sdk_threw` unit test to assert on the new `console.error` contract.

## Reverse-verify
**Pre-fix (fix stashed, integration probe run):**
```
× renameSessionTitle real-fs writeback > writes a custom-title frame to the JSONL even when the caller passes a dir that does not encode to the on-disk project key
  → bridge returned reason=sdk_threw message=Session 2ef47e71-bcdc-44bf-988c-18e8b22298c4 not found in project directory for C:\Users\jiahuigu\AppData\Local\Temp\ccsm-rename-it-4tq84o\project-renamed
Test Files  1 failed (1)
     Tests  1 failed (1)
```

**Post-fix (stash popped, integration probe re-run):**
```
✓ electron/sessionTitles/__tests__/renameWriteback.integration.test.ts (1 test) 87ms
Test Files  1 passed (1)
     Tests  1 passed (1)
```

## Test plan
- [x] e2e probe (vitest real-fs against real SDK): rename via bridge writes `custom-title` frame even when caller's `dir` doesn't encode to the on-disk project key
- [x] `tsc --noEmit` clean (renderer + electron projects)
- [x] electron build + smoke `require('./dist/electron/sessionTitles/index.js')` loads
- [x] `eslint electron/sessionTitles src/stores/store.ts` clean
- [x] full vitest 370/373 (3 pre-existing better-sqlite3 failures unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)