### PR TITLE
chore(lint): clear 12 pre-existing errors on working

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,6 +15,7 @@ export default [
       'release/**',
       'scripts/**',
       'tests/**',
+      'docs/**',
       'webpack.config.js',
       'postcss.config.js',
       'eslint.config.js'
@@ -74,6 +75,7 @@ export default [
         getComputedStyle: 'readonly',
         requestAnimationFrame: 'readonly',
         cancelAnimationFrame: 'readonly',
+        ResizeObserver: 'readonly',
         // `NodeJS` namespace is also referenced from renderer-side .d.ts
         // files (e.g. cliBridge.d.ts) that mirror preload types — keep it
         // available alongside browser globals.

--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -154,7 +154,9 @@ function ensureTerminal(host: HTMLDivElement): Terminal {
       if (sel) {
         try {
           window.ccsmPty?.clipboard?.writeText(sel);
-        } catch {}
+        } catch {
+          // ignore clipboard failures — selection still highlights.
+        }
         return false;
       }
       return true;
@@ -163,7 +165,9 @@ function ensureTerminal(host: HTMLDivElement): Terminal {
       try {
         const text = window.ccsmPty?.clipboard?.readText();
         if (text && activeSid) window.ccsmPty.input(activeSid, text);
-      } catch {}
+      } catch {
+        // ignore clipboard failures — paste is best-effort.
+      }
       return false;
     }
     if (ev.ctrlKey && ev.shiftKey && isC) {
@@ -171,7 +175,9 @@ function ensureTerminal(host: HTMLDivElement): Terminal {
       if (sel) {
         try {
           window.ccsmPty?.clipboard?.writeText(sel);
-        } catch {}
+        } catch {
+          // ignore clipboard failures — selection still highlights.
+        }
       }
       return false;
     }
@@ -179,7 +185,9 @@ function ensureTerminal(host: HTMLDivElement): Terminal {
       try {
         const text = window.ccsmPty?.clipboard?.readText();
         if (text && activeSid) window.ccsmPty.input(activeSid, text);
-      } catch {}
+      } catch {
+        // ignore clipboard failures — paste is best-effort.
+      }
       return false;
     }
     return true;
@@ -267,13 +275,17 @@ export function TerminalPane({ sessionId, cwd: _cwd }: Props) {
         if (unsubscribeData) {
           try {
             unsubscribeData();
-          } catch {}
+          } catch {
+            // already torn down — safe to ignore.
+          }
           unsubscribeData = null;
         }
         if (inputDisposable) {
           try {
             inputDisposable.dispose();
-          } catch {}
+          } catch {
+            // already disposed — safe to ignore.
+          }
           inputDisposable = null;
         }
         try {
@@ -287,13 +299,17 @@ export function TerminalPane({ sessionId, cwd: _cwd }: Props) {
         if (unsubscribeData) {
           try {
             unsubscribeData();
-          } catch {}
+          } catch {
+            // already torn down — safe to ignore.
+          }
           unsubscribeData = null;
         }
         if (inputDisposable) {
           try {
             inputDisposable.dispose();
-          } catch {}
+          } catch {
+            // already disposed — safe to ignore.
+          }
           inputDisposable = null;
         }
       }
@@ -332,7 +348,9 @@ export function TerminalPane({ sessionId, cwd: _cwd }: Props) {
         if (term) {
           try {
             term.resize(cols, rows);
-          } catch {}
+          } catch {
+            // resize is best-effort — proceed with snapshot write.
+          }
           if (snapshot) term.write(snapshot);
         }
 
@@ -423,7 +441,9 @@ export function TerminalPane({ sessionId, cwd: _cwd }: Props) {
     return () => {
       try {
         unsubscribe?.();
-      } catch {}
+      } catch {
+        // already torn down — safe to ignore.
+      }
     };
   }, []);
 


### PR DESCRIPTION
## Summary
Pure lint compliance — no behavior changes. Clears 12 pre-existing ESLint errors on `working` that were masking lint-green CI (discovered after PR #530 merge, task #659).

**Before:** `12 errors, 3 warnings`
**After:** `0 errors, 3 warnings` (warnings pre-existing, untouched)

## Changes

**`eslint.config.js`**
- Add `docs/**` to the ignore list. ESLint v9 flat config doesn't honor `--ext` from the lint script, so the one-off `.mjs` capture scripts under `docs/screenshots/**` were being picked up by `js.configs.recommended` and flagged for missing browser globals. These scripts are throwaway Playwright capturers — not part of the shipped product.
- Add `ResizeObserver` to the `**/*.{ts,tsx}` browser globals list alongside the other DOM types already enumerated.

**`src/components/TerminalPane.tsx`**
- Add a one-line ignore-rationale comment inside each of the 10 empty `catch {}` blocks (clipboard / dispose / resize / unsubscribe). Each catch is intentionally swallowing best-effort cleanup/IO; the bodies stay empty in effect — the comment alone satisfies `no-empty`. Mirrors the existing commented catch on line 282.

## Test plan
- [x] `npm run lint` → 0 errors
- [x] `npm run build` → clean
- [x] `npm test` → 370 passed (3 db-hardening failures are a `better-sqlite3` NODE_MODULE_VERSION mismatch in this fresh worktree's npm rebuild — environmental, unrelated; would reproduce on any branch in this worktree)