### PR TITLE
chore(mvp): disable taskbar + tray badge count display

### DIFF
--- a/electron/notify/badge.ts
+++ b/electron/notify/badge.ts
@@ -15,6 +15,17 @@
 import { app, BrowserWindow, nativeImage, type NativeImage, type Tray } from 'electron';
 import { tBadge } from '../i18n';
 
+// MVP: OS-visible badge display is disabled (#667). User reported the count
+// shown on the taskbar overlay + tray icon was incorrect; rather than
+// re-derive the count logic before MVP we suppress every OS-facing call so
+// neither chrome surface shows a number. The internal `unread` map keeps
+// running because the e2e probe (caseNotifyFiresOnIdle) reads it via
+// `BadgeManager.getTotal()` to verify the notify bridge fired — that signal
+// is decoupled from the visual badge. Flip this flag back to false to
+// restore the previous tray composite + setOverlayIcon + setBadgeCount
+// behaviour without touching anything else.
+const BADGE_DISABLED = true;
+
 export interface BadgeManagerDeps {
   getTray: () => Tray | null;
   getBaseTrayImage: () => NativeImage;
@@ -65,6 +76,13 @@ export class BadgeManager {
 
   private apply(): void {
     const total = this.getTotal();
+
+    if (BADGE_DISABLED) {
+      // OS-visible badge suppressed (#667). Internal `unread` map still
+      // tracks per-sid counters for any consumer that cares (e.g., the
+      // notify-fires e2e probe reads `getTotal()`).
+      return;
+    }
 
     if (process.platform !== 'win32') {
       try {


### PR DESCRIPTION
## Why

User reported (#667) the unread badge count shown on the Windows taskbar overlay icon and tray composite icon is incorrect. They explicitly said: *"现在不对，但是我懒得修，先做mvp"* — defer fixing the count logic until after MVP, just hide the wrong number for now.

## What

Single-file change in `electron/notify/badge.ts`:

- Added `const BADGE_DISABLED = true` at the top of the file.
- `BadgeManager.apply()` early-returns when the flag is set, before any OS-facing call (`app.setBadgeCount`, `BrowserWindow.setOverlayIcon`, `tray.setImage`).
- Internal `unread` Map + `incrementSid` / `clearSid` / `getTotal` keep working unchanged — they're consumed by the `notify-fires-on-idle` e2e probe to verify the notify bridge actually fired (independent signal from the visual badge).

One-touch revert: flip `BADGE_DISABLED` back to `false` and the previous tray composite + taskbar overlay behaviour returns with no other plumbing changes.

## What is suppressed vs what stays

| Surface | Before | After |
| --- | --- | --- |
| Windows taskbar overlay icon (red number) | shown | not shown (`setOverlayIcon` skipped) |
| Windows tray icon (composited "C" + red number) | composited | plain "C" base icon (no `setImage` override) |
| macOS / Linux dock badge | `app.setBadgeCount(n)` | not called |
| Toast notification firing | unchanged | unchanged |
| Notify bridge `incrementSid` / internal counter | live | live (probe still reads it) |
| Tray icon visibility / tooltip / context menu | unchanged | unchanged |

## Quality gates

- `npm run typecheck` — clean.
- `npm run build` — clean (only the pre-existing bundle-size warnings).
- `npm run lint` — only the 3 pre-existing warnings on working (`nativeImage` unused in `main.ts`, `jsonlExistsForSid`, missing dep in `TerminalPane.tsx`).
- `npm test -- --run` — 370 passed; only the 3 known `db-hardening` env failures (NODE_MODULE_VERSION mismatch).
- `node scripts/harness-real-cli.mjs --only=notify-fires-on-idle` — **PASS** (18.8s):
  ```
  [HARNESS]   notify fired: state=idle title="Waiting for you" body="notify-probe needs your input"
  [HARNESS]   badge total after fire: 1 (platform=win32)
  [HARNESS]   badge total after clear: 0
  [HARNESS] <<< PASS notify-fires-on-idle
  ```
  The probe still reads `BadgeManager.getTotal()` (internal counter) on win32, so the assertion `>= 1` after fire passes without any test edit. Toast notification still fires.

## Manual verification

I'm a background subagent without an interactive desktop session, so I cannot eyeball the taskbar overlay / tray icon visually after `npm start`. The e2e probe above confirms:
- the notify bridge still fires the toast (probe asserts `entry.title` + `entry.body`),
- the internal counter increments (probe asserts `>= 1`).

The OS-call suppression itself is mechanical (early return before every `setOverlayIcon` / `setBadgeCount` / `tray.setImage` call site, all in one function), so the visual outcome is determined by the diff. Manager / user can confirm visually post-merge if desired.

## HEAD SHA / diff stats

- Base: `working` @ `6c6d651`
- Head: `e933262`
- Diff: `electron/notify/badge.ts | 18 ++++++++++++++++++` (1 file, +18, -0)