### PR TITLE
refactor(main): extract userCwds + badge controllers per #677 SRP

### DIFF
--- a/electron/__tests__/badgeController.test.ts
+++ b/electron/__tests__/badgeController.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest';
+import { decideBadgeClear, BadgeController } from '../badgeController';
+import type { BadgeManager } from '../notify/badge';
+
+describe('decideBadgeClear', () => {
+  // 4 truth combinations of (focused, activeSid present, hasBadge):
+  // only the all-true case clears.
+  it('clears when focused + activeSid + hasBadge', () => {
+    expect(decideBadgeClear({ focused: true, activeSid: 'sid-1', hasBadge: true })).toBe(true);
+  });
+  it('does not clear when not focused', () => {
+    expect(decideBadgeClear({ focused: false, activeSid: 'sid-1', hasBadge: true })).toBe(false);
+  });
+  it('does not clear when activeSid is null', () => {
+    expect(decideBadgeClear({ focused: true, activeSid: null, hasBadge: true })).toBe(false);
+  });
+  it('does not clear when activeSid is empty string', () => {
+    expect(decideBadgeClear({ focused: true, activeSid: '', hasBadge: true })).toBe(false);
+  });
+  it('does not clear when hasBadge is false (no manager wired)', () => {
+    expect(decideBadgeClear({ focused: true, activeSid: 'sid-1', hasBadge: false })).toBe(false);
+  });
+  it('does not clear when nothing is true', () => {
+    expect(decideBadgeClear({ focused: false, activeSid: null, hasBadge: false })).toBe(false);
+  });
+});
+
+describe('BadgeController.onFocusChange', () => {
+  function makeMgr() {
+    return {
+      clearSid: vi.fn<(sid: string) => void>(),
+    } as unknown as BadgeManager & { clearSid: ReturnType<typeof vi.fn> };
+  }
+
+  it('calls clearSid with the active sid when focused + sid present + manager wired', () => {
+    const mgr = makeMgr();
+    const ctrl = new BadgeController(() => mgr);
+    ctrl.onFocusChange({ focused: true, activeSid: 'sid-A' });
+    expect(mgr.clearSid).toHaveBeenCalledTimes(1);
+    expect(mgr.clearSid).toHaveBeenCalledWith('sid-A');
+  });
+
+  it('does NOT call clearSid when not focused', () => {
+    const mgr = makeMgr();
+    const ctrl = new BadgeController(() => mgr);
+    ctrl.onFocusChange({ focused: false, activeSid: 'sid-A' });
+    expect(mgr.clearSid).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call clearSid when activeSid is null', () => {
+    const mgr = makeMgr();
+    const ctrl = new BadgeController(() => mgr);
+    ctrl.onFocusChange({ focused: true, activeSid: null });
+    expect(mgr.clearSid).not.toHaveBeenCalled();
+  });
+
+  it('does NOT throw when manager getter returns null', () => {
+    const ctrl = new BadgeController(() => null);
+    expect(() => ctrl.onFocusChange({ focused: true, activeSid: 'sid-A' })).not.toThrow();
+  });
+
+  it('re-resolves the manager on every call (late-bound)', () => {
+    let mgr: ReturnType<typeof makeMgr> | null = null;
+    const ctrl = new BadgeController(() => mgr);
+    // First call: no manager — no-op.
+    ctrl.onFocusChange({ focused: true, activeSid: 'sid-A' });
+    // Wire up later.
+    mgr = makeMgr();
+    ctrl.onFocusChange({ focused: true, activeSid: 'sid-B' });
+    expect(mgr.clearSid).toHaveBeenCalledTimes(1);
+    expect(mgr.clearSid).toHaveBeenCalledWith('sid-B');
+  });
+});

--- a/electron/__tests__/userCwds.test.ts
+++ b/electron/__tests__/userCwds.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeCwd, pushLRU, withHomeFallback } from '../userCwds';
+
+describe('normalizeCwd', () => {
+  it('strips a single trailing slash', () => {
+    expect(normalizeCwd('/home/user/')).toBe('/home/user');
+  });
+  it('strips a single trailing backslash', () => {
+    expect(normalizeCwd('C:\\Users\\me\\')).toBe('C:\\Users\\me');
+  });
+  it('strips multiple trailing separators (mixed)', () => {
+    expect(normalizeCwd('C:\\Users\\me\\\\//')).toBe('C:\\Users\\me');
+  });
+  it('leaves a path without trailing separators alone', () => {
+    expect(normalizeCwd('/home/user')).toBe('/home/user');
+  });
+  it('preserves Windows drive-letter casing', () => {
+    expect(normalizeCwd('C:\\Foo\\Bar')).toBe('C:\\Foo\\Bar');
+  });
+  it('does not expand a relative path (no resolve)', () => {
+    expect(normalizeCwd('relative/path/')).toBe('relative/path');
+  });
+  it('returns empty string for empty input', () => {
+    expect(normalizeCwd('')).toBe('');
+  });
+});
+
+describe('pushLRU', () => {
+  it('inserts a new item at the head of an empty list', () => {
+    expect(pushLRU([], 'a')).toEqual(['a']);
+  });
+  it('inserts a new item at the head of a populated list', () => {
+    expect(pushLRU(['b', 'c'], 'a')).toEqual(['a', 'b', 'c']);
+  });
+  it('moves an existing item to the head (LRU dedupe)', () => {
+    expect(pushLRU(['a', 'b', 'c'], 'b')).toEqual(['b', 'a', 'c']);
+  });
+  it('dedupes case-insensitively', () => {
+    expect(pushLRU(['/Foo', '/bar'], '/FOO')).toEqual(['/FOO', '/bar']);
+  });
+  it('caps the list at the default max=20', () => {
+    const list = Array.from({ length: 20 }, (_, i) => `p${i}`);
+    const out = pushLRU(list, 'new');
+    expect(out).toHaveLength(20);
+    expect(out[0]).toBe('new');
+    expect(out[19]).toBe('p18'); // p19 dropped from tail
+  });
+  it('caps the list at a custom max', () => {
+    expect(pushLRU(['a', 'b', 'c'], 'd', 2)).toEqual(['d', 'a']);
+  });
+  it('does not mutate the input list', () => {
+    const input = ['a', 'b'];
+    pushLRU(input, 'c');
+    expect(input).toEqual(['a', 'b']);
+  });
+  it('returns a copy when item is empty (no mutation)', () => {
+    const input = ['a', 'b'];
+    const out = pushLRU(input, '');
+    expect(out).toEqual(['a', 'b']);
+    expect(out).not.toBe(input);
+  });
+});
+
+describe('withHomeFallback', () => {
+  it('returns [home] when list is empty', () => {
+    expect(withHomeFallback([], '/home/u')).toEqual(['/home/u']);
+  });
+  it('appends home at tail when not present', () => {
+    expect(withHomeFallback(['/a', '/b'], '/home/u')).toEqual(['/a', '/b', '/home/u']);
+  });
+  it('does not append home when already present (case-sensitive match)', () => {
+    expect(withHomeFallback(['/a', '/home/u'], '/home/u')).toEqual(['/a', '/home/u']);
+  });
+  it('does not append home when already present (case-insensitive match)', () => {
+    expect(withHomeFallback(['/a', '/Home/U'], '/home/u')).toEqual(['/a', '/Home/U']);
+  });
+  it('does not bump home to head when present in the middle', () => {
+    expect(withHomeFallback(['/a', '/home/u', '/b'], '/home/u')).toEqual(['/a', '/home/u', '/b']);
+  });
+  it('does not mutate the input list', () => {
+    const input = ['/a'];
+    withHomeFallback(input, '/home/u');
+    expect(input).toEqual(['/a']);
+  });
+});

--- a/electron/badgeController.ts
+++ b/electron/badgeController.ts
@@ -1,0 +1,61 @@
+// Focus → badge-clear controller.
+//
+// Extracted from electron/main.ts per #677 SRP. Two concerns split:
+//
+//   1. `decideBadgeClear` — pure decider. Given (focused, activeSid,
+//      hasBadge), returns whether to clear. No I/O; trivially unit-tested.
+//
+//   2. `BadgeController` — sink wrapper around BadgeManager.clearSid.
+//      `onFocusChange` calls the decider, and on `true` clears the active
+//      sid's badge. The renderer-pushed activeSid + the OS focus signal
+//      both flow through `onFocusChange`, keeping the call sites in
+//      main.ts to a single line each.
+//
+// The previous inline `clearBadgeForActiveIfFocused` mixed "is the window
+// focused?", "do we know the active sid?", and "tell the badge manager to
+// clear" all in one function and was called from two places (win.on('focus')
+// and ipcMain session:setActive). Splitting decider from sink lets us test
+// the conditions without spinning up an electron BrowserWindow.
+
+import type { BadgeManager } from './notify/badge';
+
+export interface BadgeDecisionInput {
+  focused: boolean;
+  activeSid: string | null;
+  hasBadge: boolean;
+}
+
+/**
+ * Pure 3-condition decider: clear the badge for the active sid only when
+ * the window is focused, we know which sid is active, and a BadgeManager
+ * is wired up. The `hasBadge` flag is named that way (vs "hasBadgeManager")
+ * because the call site can pass `false` whenever a clear would be a no-op
+ * (no manager OR manager unwired) — keeps the decider opinion-free about
+ * whether the dependency exists vs whether it's empty.
+ */
+export function decideBadgeClear(input: BadgeDecisionInput): boolean {
+  return input.focused && !!input.activeSid && input.hasBadge;
+}
+
+export interface FocusChangeInput {
+  focused: boolean;
+  activeSid: string | null;
+}
+
+export class BadgeController {
+  constructor(private getBadgeManager: () => BadgeManager | null) {}
+
+  /**
+   * Single sink. Fed from win.on('focus') (focused=true) and from the
+   * renderer's session:setActive IPC (focused = current window state).
+   * Caller computes `focused` from the BrowserWindow because asking
+   * electron for it inside the controller would couple this module to
+   * the electron import.
+   */
+  onFocusChange(input: FocusChangeInput): void {
+    const mgr = this.getBadgeManager();
+    if (!decideBadgeClear({ ...input, hasBadge: !!mgr })) return;
+    // input.activeSid is non-null here (decideBadgeClear checked it).
+    mgr!.clearSid(input.activeSid as string);
+  }
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -79,6 +79,8 @@ import {
   enqueuePendingRename,
   flushPendingRename,
 } from './sessionTitles';
+import { normalizeCwd, pushLRU, withHomeFallback } from './userCwds';
+import { BadgeController } from './badgeController';
 
 // ─────────────────────── IPC security helpers ────────────────────────────
 //
@@ -164,14 +166,23 @@ if (!skipSingleInstanceLock) {
 // (sub-millisecond) so the cost is negligible vs. the visible click latency.
 type CloseAction = 'ask' | 'tray' | 'quit';
 const CLOSE_ACTION_KEY = 'closeAction';
+
+// Pure parser for the persisted close-action value. Decider only — no I/O.
+// Invalid / missing values fall back to the platform default ('tray' on
+// macOS to match the OS red-light convention, 'ask' elsewhere).
+function parseCloseAction(raw: unknown, platform: NodeJS.Platform): CloseAction {
+  if (raw === 'ask' || raw === 'tray' || raw === 'quit') return raw;
+  return platform === 'darwin' ? 'tray' : 'ask';
+}
+
 function getCloseAction(): CloseAction {
+  let raw: string | null = null;
   try {
-    const raw = loadState(CLOSE_ACTION_KEY);
-    if (raw === 'ask' || raw === 'tray' || raw === 'quit') return raw;
+    raw = loadState(CLOSE_ACTION_KEY);
   } catch {
     /* fall through to default */
   }
-  return process.platform === 'darwin' ? 'tray' : 'ask';
+  return parseCloseAction(raw, process.platform);
 }
 function setCloseAction(value: CloseAction): void {
   try {
@@ -284,12 +295,9 @@ async function getImportableSessions(): Promise<ScannableSession[]> {
 const USER_CWDS_KEY = 'userCwds';
 const USER_CWDS_MAX = 20;
 
-function normalizeCwd(p: string): string {
-  // Trim trailing slashes/backslashes; leave the rest of the path raw so we
-  // don't accidentally break Windows drive-letter semantics. Comparison below
-  // also lower-cases for dedupe on case-insensitive filesystems.
-  return p.replace(/[\\/]+$/, '');
-}
+// I/O wrappers around the pure helpers in `./userCwds`. The decider logic
+// (LRU dedupe, normalize, cap, home-fallback) lives in that module; this
+// file only does the SQLite read/write side-effects.
 
 function readUserCwds(): string[] {
   try {
@@ -312,26 +320,13 @@ function writeUserCwds(list: string[]): void {
 }
 
 function getUserCwds(): string[] {
-  const list = readUserCwds();
-  const home = os.homedir();
-  // Spec: "永远至少有 home" — home must always be present in the recent list,
-  // even after the user has explicitly picked other cwds. We append home at
-  // the tail if it isn't already in the user list, so the home entry stays
-  // available as a fallback target without bumping it back to the head.
-  if (list.length === 0) return [home];
-  const lower = home.toLowerCase();
-  if (list.some((p) => p.toLowerCase() === lower)) return list;
-  return [...list, home];
+  return withHomeFallback(readUserCwds(), os.homedir());
 }
 
 function pushUserCwd(p: string): string[] {
   const norm = normalizeCwd(p);
   if (!norm) return readUserCwds();
-  const cur = readUserCwds();
-  // Case-insensitive dedupe (Windows + macOS default fs).
-  const lower = norm.toLowerCase();
-  const without = cur.filter((x) => x.toLowerCase() !== lower);
-  const next = [norm, ...without].slice(0, USER_CWDS_MAX);
+  const next = pushLRU(readUserCwds(), norm, USER_CWDS_MAX);
   writeUserCwds(next);
   return next;
 }
@@ -546,7 +541,7 @@ function createWindow() {
   });
 
   win.on('focus', () => {
-    clearBadgeForActiveIfFocused();
+    badgeController.onFocusChange({ focused: true, activeSid: activeSidFromRenderer });
   });
 
   const emitMax = () => win.webContents.send('window:maximizedChanged', win.isMaximized());
@@ -642,18 +637,15 @@ function createWindow() {
 let tray: Tray | null = null;
 let isQuitting = false;
 let badgeManager: BadgeManager | null = null;
+const badgeController = new BadgeController(() => badgeManager);
 
 function getTrayBaseImage() {
   return buildTrayIcon();
 }
 
-function clearBadgeForActiveIfFocused() {
-  if (!badgeManager) return;
+function isMainWindowFocused(): boolean {
   const w = BrowserWindow.getAllWindows()[0];
-  const focused = !!(w && !w.isDestroyed() && w.isFocused());
-  if (!focused) return;
-  if (!activeSidFromRenderer) return;
-  badgeManager.clearSid(activeSidFromRenderer);
+  return !!(w && !w.isDestroyed() && w.isFocused());
 }
 
 function applyTrayLocale() {
@@ -1017,7 +1009,7 @@ app.whenReady().then(() => {
   ipcMain.on('session:setActive', (e, sid: unknown) => {
     if (!fromMainFrame(e)) return;
     activeSidFromRenderer = typeof sid === 'string' && sid.length > 0 ? sid : null;
-    clearBadgeForActiveIfFocused();
+    badgeController.onFocusChange({ focused: isMainWindowFocused(), activeSid: activeSidFromRenderer });
   });
 
   // Renderer pushes the user-visible name for a sid so notify toasts can

--- a/electron/userCwds.ts
+++ b/electron/userCwds.ts
@@ -1,0 +1,56 @@
+// Pure helpers for the user-owned cwd LRU.
+//
+// Extracted from electron/main.ts per #677 SRP — these functions have zero
+// I/O (no SQLite, no fs, no electron imports) so they're trivially unit-
+// testable and can be reused by future cwd consumers without dragging in
+// the main-process module graph. The IPC handlers in main.ts call these
+// pure helpers, then own the saveState side-effect themselves.
+//
+// Producer/decider/sink split:
+//   - main.ts IPC handler reads from app_state (producer of raw list)
+//   - this module decides the next list (decider — pure transform)
+//   - main.ts writes back via saveState (sink)
+
+/**
+ * Trim trailing slashes/backslashes from a cwd. We deliberately don't
+ * lower-case, expand `~`, or resolve symlinks here — Windows drive-letter
+ * casing is preserved as-is, dedupe lower-cases on the comparison side.
+ */
+export function normalizeCwd(p: string): string {
+  return p.replace(/[\\/]+$/, '');
+}
+
+/**
+ * LRU-push `item` to the front of `list`, deduping case-insensitively
+ * (Windows + macOS default fs are case-insensitive, so two cwds that
+ * differ only in case are the same entry to the user). Caps the result
+ * at `max` entries by dropping from the tail.
+ *
+ * Pure — does not mutate `list`.
+ *
+ * Empty/whitespace items are skipped (caller should pre-validate); we
+ * just return `list` unchanged in that case so callers that route a
+ * normalized-empty value through here don't accidentally clear the LRU.
+ */
+export function pushLRU(list: readonly string[], item: string, max = 20): string[] {
+  if (!item) return [...list];
+  const lower = item.toLowerCase();
+  const without = list.filter((x) => x.toLowerCase() !== lower);
+  return [item, ...without].slice(0, max);
+}
+
+/**
+ * Append `home` to `list` if it isn't already present (case-insensitive).
+ * Used by `getUserCwds` so the cwd popover always has at least the home
+ * entry as a fallback target — the spec says "永远至少有 home" — without
+ * bumping it back to the LRU head when the user has explicitly picked
+ * other cwds since.
+ *
+ * If the list is empty, returns `[home]` (i.e. fresh-install fallback).
+ */
+export function withHomeFallback(list: readonly string[], home: string): string[] {
+  if (list.length === 0) return [home];
+  const lower = home.toLowerCase();
+  if (list.some((p) => p.toLowerCase() === lower)) return [...list];
+  return [...list, home];
+}


### PR DESCRIPTION
## Summary

Task #679 — implements eval #677's SRP recommendation for `electron/main.ts`. Splits decider logic out so each unit obeys producer/decider/sink single-responsibility (per `feedback_single_responsibility.md`).

## New files

- **`electron/userCwds.ts`** — pure helpers, zero I/O:
  - `normalizeCwd(p)` — strip trailing separators
  - `pushLRU(list, item, max=20)` — LRU + case-insensitive dedupe + cap
  - `withHomeFallback(list, home)` — append home if absent
- **`electron/badgeController.ts`**:
  - `decideBadgeClear({focused, activeSid, hasBadge})` — pure 3-condition decider
  - `BadgeController.onFocusChange({focused, activeSid})` — sink wrapper around `BadgeManager.clearSid`
- **`electron/__tests__/userCwds.test.ts`** — 21 cases
- **`electron/__tests__/badgeController.test.ts`** — 11 cases

## main.ts changes

- IPC `app:userCwds:get` / `app:userCwds:push` / `import:recentCwds` now call the pure helpers; only SQLite read/write stays.
- `win.on('focus')` and `ipcMain.on('session:setActive')` both route through `badgeController.onFocusChange` (replaces inlined `clearBadgeForActiveIfFocused`).
- `parseCloseAction(raw, platform)` extracted from `getCloseAction` (3-line pure decider, no new file).

main.ts: **1202 → 1194 lines** (raw line delta is small because we kept the I/O wrappers `readUserCwds` / `writeUserCwds` / `getUserCwds` / `pushUserCwd` next to their IPC handlers; the win is decider-extracted-and-tested, not LOC).

## Out of scope

- `_notifyEnabledCached` / `_crashOptOutCached` (independent caching concern).
- `electron/sessionWatcher/**` (Task #678), `electron/notify/**` + `electron/ptyHost/**` (Task #676).

## Verification

UT (vitest):
```
 PASS  electron/__tests__/userCwds.test.ts        (21 tests)
 PASS  electron/__tests__/badgeController.test.ts (11 tests)
 Test Files  2 passed (2)
      Tests  32 passed (32)
```

Require-load smoke (per `feedback_main_process_load_smoke_test.md`) — `npx electron` loading `dist/electron/main.js` + new modules:
```
[sentry] SENTRY_DSN not set — crash reporting disabled.
SMOKE_OK
```

E2E (`harness-real-cli.mjs`):
```
default-cwd-from-userCwds-lru   PASS  541ms
cwd-picker-top-default          PASS  740ms
cwd-picker-top-chevron          PASS  672ms
cwd-picker-browse               PASS  457ms
cwd-picker-no-shortcut          PASS  471ms
```

## Test plan

- [ ] CI vitest green
- [ ] Reviewer verifies decider/sink split semantics match prior inline behavior
- [ ] Reviewer confirms no regression in `default-cwd-from-userCwds-lru` and `cwd-picker-*` cases