### PR TITLE
refactor: extract pure classifyPtyExit decider per #677 SRP

### DIFF
--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -8,6 +8,7 @@ import { CanvasAddon } from '@xterm/addon-canvas';
 import '@xterm/xterm/css/xterm.css';
 import { useTranslation } from '../i18n/useTranslation';
 import { useStore } from '../stores/store';
+import { classifyPtyExit } from '../lib/ptyExitClassifier';
 
 // TerminalPane mounts a singleton xterm.js Terminal that we attach/detach
 // against per-session PTYs over IPC (window.ccsmPty). This is the React
@@ -432,13 +433,13 @@ export function TerminalPane({ sessionId, cwd: _cwd }: Props) {
     // attachNonce is intentional: bumping it re-runs the attach for Retry.
   }, [sessionId, attachNonce]);
 
-  // pty:exit subscription for the active session → flip to exit state
-  // with a classification (clean vs crashed). The classification rule
-  // mirrors the store's `_applyPtyExit` logic — kept in lockstep
-  // intentionally so the active-pane overlay and the sidebar red-dot
-  // signal are always consistent. `t` is intentionally excluded from
-  // deps: changing language while a session is alive should not re-
-  // subscribe; localized strings are resolved at render time.
+  // pty:exit subscription for the active session → flip to exit state with
+  // a classification (clean vs crashed) shared with the store via
+  // `classifyPtyExit` (src/lib/ptyExitClassifier.ts), so the active-pane
+  // overlay and the sidebar red-dot signal stay consistent. `t` is
+  // intentionally excluded from deps: changing language while a session is
+  // alive should not re-subscribe; localized strings are resolved at
+  // render time.
   useEffect(() => {
     const pty = window.ccsmPty;
     if (!pty?.onExit) return;
@@ -447,8 +448,7 @@ export function TerminalPane({ sessionId, cwd: _cwd }: Props) {
         if (evt.sessionId !== activeSid) return;
         const signal = evt.signal ?? null;
         const code = evt.code ?? null;
-        const exitKind: 'clean' | 'crashed' =
-          signal == null && code === 0 ? 'clean' : 'crashed';
+        const exitKind = classifyPtyExit({ code, signal });
         const detail =
           signal != null
             ? `signal ${signal}`

--- a/src/lib/ptyExitClassifier.ts
+++ b/src/lib/ptyExitClassifier.ts
@@ -1,0 +1,33 @@
+export type PtyExitKind = 'clean' | 'crashed';
+
+/**
+ * Pure decider: classify a pty exit event as clean or crashed.
+ *
+ * The active-pane overlay (TerminalPane) and the sidebar red-dot signal
+ * (store.disconnectedSessions) must agree, so both call sites share this
+ * single source of truth.
+ *
+ * Rule: clean iff signal is absent AND exit code is exactly 0.
+ * Anything else (any signal present, non-zero code, or both null) is a crash.
+ *
+ * | code     | signal       | result    |
+ * | -------- | ------------ | --------- |
+ * | 0        | null         | clean     |
+ * | 0        | SIGTERM      | crashed   |
+ * | non-zero | any          | crashed   |
+ * | null     | SIGKILL      | crashed   |
+ * | null     | null         | crashed   |
+ *
+ * Note: signal accepts `string | number | null` to match both upstream
+ * shapes — store payloads use `string | number | null`, the IPC bridge
+ * may surface either depending on platform (POSIX name vs numeric code).
+ */
+export function classifyPtyExit({
+  code,
+  signal,
+}: {
+  code: number | null;
+  signal: string | number | null;
+}): PtyExitKind {
+  return signal == null && code === 0 ? 'clean' : 'crashed';
+}

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -4,6 +4,7 @@ import { loadPersisted, schedulePersist, PERSISTED_KEYS, type PersistedState, ty
 import { hydrateDrafts, deleteDrafts, snapshotDraft, restoreDraft } from './drafts';
 import { i18next } from '../i18n';
 import type { ConnectionInfo } from '../shared/ipc-types';
+import { classifyPtyExit } from '../lib/ptyExitClassifier';
 
 // Resolve the localized default-group name with a hard-coded English fallback
 // so non-renderer call paths (tests, eager hydration before initI18n runs)
@@ -716,11 +717,7 @@ export const useStore = create<State & Actions>((set, get) => ({
   },
 
   _applyPtyExit: (sid, payload) => {
-    // Clean = no signal AND exit code zero. Anything else (signal,
-    // non-zero code, or both null) is treated as a crash so the user
-    // gets the "this is not ccsm's fault" overlay + sidebar red dot.
-    const kind: 'clean' | 'crashed' =
-      payload.signal == null && payload.code === 0 ? 'clean' : 'crashed';
+    const kind = classifyPtyExit({ code: payload.code, signal: payload.signal });
     set((s) => ({
       disconnectedSessions: {
         ...s.disconnectedSessions,

--- a/tests/pty-exit-classifier.test.ts
+++ b/tests/pty-exit-classifier.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { classifyPtyExit } from '../src/lib/ptyExitClassifier';
+
+describe('classifyPtyExit', () => {
+  it('clean: code=0, signal=null (graceful exit)', () => {
+    expect(classifyPtyExit({ code: 0, signal: null })).toBe('clean');
+  });
+
+  it('crashed: code=0, signal=SIGTERM (signal present overrides zero code)', () => {
+    // Per extracted logic: ANY signal makes it a crash, even with code=0.
+    // Note: the task spec table claimed this should be 'clean', but the
+    // real code in store.ts:723 and TerminalPane.tsx:451 both check
+    // `signal == null && code === 0` — i.e. signal must be absent.
+    expect(classifyPtyExit({ code: 0, signal: 'SIGTERM' })).toBe('crashed');
+  });
+
+  it('crashed: code=1, signal=null (non-zero exit)', () => {
+    expect(classifyPtyExit({ code: 1, signal: null })).toBe('crashed');
+  });
+
+  it('crashed: code=137, signal=SIGKILL (OOM-killed)', () => {
+    expect(classifyPtyExit({ code: 137, signal: 'SIGKILL' })).toBe('crashed');
+  });
+
+  it('crashed: code=null, signal=null (lost-without-trace)', () => {
+    expect(classifyPtyExit({ code: null, signal: null })).toBe('crashed');
+  });
+
+  it('crashed: code=null, signal=SIGTERM (signalled, no code)', () => {
+    // signal != null → crashed regardless of code.
+    expect(classifyPtyExit({ code: null, signal: 'SIGTERM' })).toBe('crashed');
+  });
+
+  it('crashed: code=null, signal=SIGKILL', () => {
+    expect(classifyPtyExit({ code: null, signal: 'SIGKILL' })).toBe('crashed');
+  });
+
+  it('crashed: code=2, signal=SIGINT (Ctrl-C interrupt)', () => {
+    expect(classifyPtyExit({ code: 2, signal: 'SIGINT' })).toBe('crashed');
+  });
+
+  it('crashed: code=0, signal=15 (numeric signal accepted)', () => {
+    expect(classifyPtyExit({ code: 0, signal: 15 })).toBe('crashed');
+  });
+
+  it('treats undefined-coerced null inputs uniformly', () => {
+    // Both call sites normalize `?? null` before invoking; this guards
+    // the contract: only literal null / number / string reach us.
+    expect(classifyPtyExit({ code: null, signal: null })).toBe('crashed');
+  });
+});


### PR DESCRIPTION
## Summary

Task #677 SRP cleanup: extract the duplicated 'clean' | 'crashed' pty-exit classification into a single pure decider at `src/lib/ptyExitClassifier.ts`. Both call sites (`store._applyPtyExit` and `TerminalPane`'s `pty:exit` useEffect) now delegate to it, so the active-pane overlay and the sidebar red-dot signal share one source of truth and cannot drift.

The TerminalPane comment explicitly admitted the smell: *"kept in lockstep intentionally"*. SRP per `feedback_single_responsibility.md` says decision logic gets its own producer/decider/sink boundary; the call sites become pure sinks (write store / set local state).

## Are the two existing logics truly identical?

Yes — both are byte-for-byte the same expression:

```ts
// src/stores/store.ts:723 (before)
const kind: 'clean' | 'crashed' =
  payload.signal == null && payload.code === 0 ? 'clean' : 'crashed';

// src/components/TerminalPane.tsx:450 (before)
const exitKind: 'clean' | 'crashed' =
  signal == null && code === 0 ? 'clean' : 'crashed';
```

Both normalize their inputs (`?? null`) before evaluating, and both treat `signal` as `string | number | null` upstream. No deviation found — the lockstep comment was honest. No latent bug exposed by the extraction.

## Note on the spec table vs the real code

The task spec table claimed `code=0, signal=SIGTERM → clean`, but the real code in both call sites checks `signal == null && code === 0` — i.e. **any** signal (including SIGTERM) makes it a crash even with code=0. I extracted the logic AS-IS (matching the actual code) and updated the doc table to reflect reality:

| code     | signal       | result    |
| -------- | ------------ | --------- |
| 0        | null         | clean     |
| 0        | SIGTERM      | crashed   |
| non-zero | any          | crashed   |
| null     | SIGKILL      | crashed   |
| null     | null         | crashed   |

The UT explicitly documents this (`crashed: code=0, signal=SIGTERM (signal present overrides zero code)`) so a future reader sees the rule.

## Files

- new: `src/lib/ptyExitClassifier.ts` (32 lines incl. doc)
- new: `tests/pty-exit-classifier.test.ts` (10 cases)
- modified: `src/stores/store.ts` (+1 import / -5 inline / +1 call)
- modified: `src/components/TerminalPane.tsx` (+1 import / -2 inline / +1 call, lockstep comment removed, replaced with pointer to classifier)

Net: +95 / -14.

## Verification

```
npx vitest run tests/pty-exit-classifier.test.ts
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

```
npx tsc --noEmit   # clean, no output
npx eslint src/lib/ptyExitClassifier.ts src/stores/store.ts src/components/TerminalPane.tsx tests/pty-exit-classifier.test.ts
# 0 errors. 1 pre-existing warning on TerminalPane:434 (`_cwd` exhaustive-deps) unrelated to this refactor.
```

## Test plan

- [x] vitest: 10 cases (clean baseline, signal-with-zero-code, non-zero exit, OOM 137/SIGKILL, both-null lost, null-with-signal, SIGINT 2, numeric signal 15, plus regression guard)
- [x] tsc clean
- [x] eslint clean on touched files
- [ ] reviewer: sanity check that the lockstep claim still holds and the SIGTERM-with-zero-code interpretation matches product intent

Task #677.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>