### PR TITLE
refactor(sessionTitles): extract 3 pure deciders per #677 SRP

### DIFF
--- a/electron/sessionTitles/__tests__/deciders.test.ts
+++ b/electron/sessionTitles/__tests__/deciders.test.ts
@@ -1,0 +1,119 @@
+// Unit tests for the pure decider functions extracted from sessionTitles
+// per #677 SRP cleanup. These functions are pure: no I/O, no mocks needed.
+import { describe, it, expect } from 'vitest';
+
+import { classifyError, decideRetry, decideRequeue } from '../deciders';
+
+describe('classifyError', () => {
+  it('returns no_jsonl when err.code === ENOENT', () => {
+    const err: NodeJS.ErrnoException = Object.assign(new Error('boom'), {
+      code: 'ENOENT',
+    });
+    expect(classifyError(err)).toEqual({ reason: 'no_jsonl' });
+  });
+
+  it('returns no_jsonl for plain object with code ENOENT', () => {
+    expect(classifyError({ code: 'ENOENT' })).toEqual({ reason: 'no_jsonl' });
+  });
+
+  it('returns sdk_threw with message for a generic Error', () => {
+    expect(classifyError(new Error('kaboom'))).toEqual({
+      reason: 'sdk_threw',
+      message: 'kaboom',
+    });
+  });
+
+  it('returns sdk_threw with the string when err is a string', () => {
+    expect(classifyError('plain text failure')).toEqual({
+      reason: 'sdk_threw',
+      message: 'plain text failure',
+    });
+  });
+
+  it('returns sdk_threw with no message for non-Error object', () => {
+    expect(classifyError({ random: 'shape' })).toEqual({ reason: 'sdk_threw' });
+  });
+
+  it('returns sdk_threw with no message for undefined', () => {
+    expect(classifyError(undefined)).toEqual({ reason: 'sdk_threw' });
+  });
+
+  it('returns sdk_threw with no message for null', () => {
+    expect(classifyError(null)).toEqual({ reason: 'sdk_threw' });
+  });
+
+  it('does not classify code other than ENOENT as no_jsonl', () => {
+    const err = Object.assign(new Error('access'), { code: 'EACCES' });
+    expect(classifyError(err)).toEqual({
+      reason: 'sdk_threw',
+      message: 'access',
+    });
+  });
+});
+
+describe('decideRetry', () => {
+  const mismatchErr = new Error(
+    'Session abc not found in project directory for /Users/x'
+  );
+
+  it('returns true when dir is set and message indicates project mismatch', () => {
+    expect(decideRetry(mismatchErr, '/Users/x')).toBe(true);
+  });
+
+  it('returns false when dir is undefined (nothing to retry away from)', () => {
+    expect(decideRetry(mismatchErr, undefined)).toBe(false);
+  });
+
+  it('returns false when dir is set but message does not match', () => {
+    expect(decideRetry(new Error('something else'), '/Users/x')).toBe(false);
+  });
+
+  it('returns false when err is ENOENT (no_jsonl, not a mismatch)', () => {
+    const err = Object.assign(new Error('enoent'), { code: 'ENOENT' });
+    expect(decideRetry(err, '/Users/x')).toBe(false);
+  });
+
+  it('treats a string error message as the message field', () => {
+    expect(decideRetry('not found in project directory', '/Users/x')).toBe(
+      true
+    );
+  });
+
+  it('returns false when err is a string that does not match', () => {
+    expect(decideRetry('some unrelated text', '/Users/x')).toBe(false);
+  });
+
+  it('returns false for non-Error object with no message', () => {
+    expect(decideRetry({}, '/Users/x')).toBe(false);
+  });
+});
+
+describe('decideRequeue', () => {
+  it('returns true when result is { ok: false, reason: "no_jsonl" }', () => {
+    expect(decideRequeue({ ok: false, reason: 'no_jsonl' })).toBe(true);
+  });
+
+  it('returns false when result is { ok: true }', () => {
+    expect(decideRequeue({ ok: true })).toBe(false);
+  });
+
+  it('returns false when result is { ok: false, reason: "sdk_threw" }', () => {
+    expect(decideRequeue({ ok: false, reason: 'sdk_threw' })).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(decideRequeue(null)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(decideRequeue(undefined)).toBe(false);
+  });
+
+  it('returns false for non-object', () => {
+    expect(decideRequeue('no_jsonl')).toBe(false);
+  });
+
+  it('returns false for malformed result missing ok', () => {
+    expect(decideRequeue({ reason: 'no_jsonl' })).toBe(false);
+  });
+});

--- a/electron/sessionTitles/deciders.ts
+++ b/electron/sessionTitles/deciders.ts
@@ -1,0 +1,81 @@
+/**
+ * Pure decision functions for session-title bridge.
+ *
+ * Extracted from `index.ts` per #677 SRP cleanup. These are decider-only:
+ * given inputs, return a classification or boolean. No I/O, no SDK calls,
+ * no mutation. Sinks (op-chain map, pending-rename map, TTL cache) and
+ * the SDK loader (producer) stay in `index.ts`.
+ */
+
+/**
+ * Classify an SDK error as either "JSONL not yet written" or "SDK threw".
+ *
+ * | err shape                          | result                        |
+ * | ---------------------------------- | ----------------------------- |
+ * | object with `code === 'ENOENT'`    | { reason: 'no_jsonl' }        |
+ * | Error                              | { reason: 'sdk_threw', message: err.message } |
+ * | string                             | { reason: 'sdk_threw', message: err } |
+ * | anything else                      | { reason: 'sdk_threw' }       |
+ *
+ * Node fs errors carry `.code`; the SDK re-throws them verbatim (or wraps
+ * with a matching `.code`). Anything ENOENT-shaped is the "session file does
+ * not exist yet" signal — common right after `query()` starts before the
+ * first message has flushed JSONL.
+ */
+export function classifyError(
+  err: unknown
+): { reason: 'no_jsonl' | 'sdk_threw'; message?: string } {
+  const code =
+    err && typeof err === 'object' && 'code' in err
+      ? (err as { code?: unknown }).code
+      : undefined;
+  if (code === 'ENOENT') return { reason: 'no_jsonl' };
+  const message =
+    err instanceof Error
+      ? err.message
+      : typeof err === 'string'
+        ? err
+        : undefined;
+  return { reason: 'sdk_threw', message };
+}
+
+/**
+ * Decide whether to retry `renameSession` without an explicit `dir` arg.
+ *
+ * The Sidebar rename hands us `session.cwd`. SDK derives the on-disk
+ * project-key directory from that cwd via realpath; when the cwd was
+ * renamed/moved/case-shifted since the session was created (common on
+ * Windows), the encoded key does not match the directory the JSONL actually
+ * lives under, and SDK throws "Session <sid> not found in project directory
+ * for <dir>". The dir-less SDK path scans every `~/.claude/projects/*`
+ * subdir and appends to the one that owns `<sid>.jsonl`, so retrying without
+ * `dir` is the bulletproof recovery.
+ *
+ * Returns true only when a `dir` was supplied (otherwise nothing to retry
+ * away from) AND the SDK error message matches the project-mismatch shape.
+ */
+export function decideRetry(err: unknown, dir: string | undefined): boolean {
+  if (dir === undefined) return false;
+  const cls = classifyError(err);
+  return (
+    cls.reason === 'sdk_threw' &&
+    typeof cls.message === 'string' &&
+    cls.message.includes('not found in project directory')
+  );
+}
+
+/**
+ * Decide whether a failed rename should be re-queued for the next flush
+ * attempt. Used by `flushPendingRename` after a pending replay: if the JSONL
+ * still does not exist on disk, the watcher will fire again on the next
+ * frame and we want the same pending entry to be retried.
+ *
+ * Returns true iff `result` is a `RenameResult`-shaped failure with reason
+ * `'no_jsonl'`. Anything else (success, sdk_threw, malformed) → false.
+ */
+export function decideRequeue(result: unknown): boolean {
+  if (!result || typeof result !== 'object') return false;
+  const r = result as { ok?: unknown; reason?: unknown };
+  if (r.ok !== false) return false;
+  return r.reason === 'no_jsonl';
+}

--- a/electron/sessionTitles/index.ts
+++ b/electron/sessionTitles/index.ts
@@ -40,6 +40,8 @@ import type {
   listSessions as ListSessionsFn,
 } from '@anthropic-ai/claude-agent-sdk';
 
+import { classifyError, decideRetry, decideRequeue } from './deciders';
+
 // `@anthropic-ai/claude-agent-sdk` is published as ESM-only (sdk.mjs). Our
 // Electron main bundle compiles to CommonJS (tsconfig.electron.json:
 // `module: CommonJS`), so a static `import { ... } from '...'` becomes a
@@ -126,24 +128,9 @@ type PendingRename = { title: string; dir?: string };
 const pendingRenames = new Map<string, PendingRename>();
 
 // ─────────────────────────── Helpers ─────────────────────────────────────
-
-function classifyError(err: unknown): { reason: 'no_jsonl' | 'sdk_threw'; message?: string } {
-  // node fs errors carry `.code`; SDK re-throws them verbatim (or wraps with a
-  // matching `.code` property). Treat anything ENOENT-shaped as the "session
-  // file does not exist yet" signal.
-  const code =
-    err && typeof err === 'object' && 'code' in err
-      ? (err as { code?: unknown }).code
-      : undefined;
-  if (code === 'ENOENT') return { reason: 'no_jsonl' };
-  const message =
-    err instanceof Error
-      ? err.message
-      : typeof err === 'string'
-        ? err
-        : undefined;
-  return { reason: 'sdk_threw', message };
-}
+// Pure deciders (classifyError, decideRetry, decideRequeue) live in
+// `./deciders.ts`. This file owns the side effects (caches, op chains,
+// pending queue) and the SDK loader; it imports the pure logic.
 
 // ─────────────────────────── Public API ──────────────────────────────────
 
@@ -205,13 +192,7 @@ export async function renameSessionTitle(
       // documents this), so retrying without `dir` is the bulletproof
       // recovery. ENOENT (no JSONL anywhere) is a different signal — bubble
       // it up unchanged so the store can enqueue a pending rename.
-      const cls = classifyError(err);
-      const isProjectMismatch =
-        dir !== undefined &&
-        cls.reason === 'sdk_threw' &&
-        typeof cls.message === 'string' &&
-        cls.message.includes('not found in project directory');
-      if (isProjectMismatch) {
+      if (decideRetry(err, dir)) {
         try {
           const { renameSession } = await loadSdk();
           await renameSession(sid, title, undefined);
@@ -221,7 +202,7 @@ export async function renameSessionTitle(
           return { ok: false, ...classifyError(retryErr) };
         }
       }
-      return { ok: false, ...cls };
+      return { ok: false, ...classifyError(err) };
     }
   });
 }
@@ -260,7 +241,7 @@ export async function flushPendingRename(sid: string): Promise<void> {
   if (!pending) return;
   pendingRenames.delete(sid);
   const result = await renameSessionTitle(sid, pending.title, pending.dir);
-  if (!result.ok && result.reason === 'no_jsonl') {
+  if (decideRequeue(result)) {
     // JSONL still not there — re-queue for the next flush attempt. PR3's
     // watcher will retry on the next frame.
     pendingRenames.set(sid, pending);


### PR DESCRIPTION
## Summary

Task #681 SRP cleanup. Extract three pure decision functions from `electron/sessionTitles/index.ts` (292 lines, mixed producer + decider + sink) into a new `electron/sessionTitles/deciders.ts`. The bridge file is left owning only the producer (SDK loader) and sinks (op-chain map, TTL cache, pending-rename map). No behavior change. Public API surface unchanged (callers across `electron/main.ts`, `electron/sessionWatcher`, store wiring untouched).

### Extracted

- `classifyError(err)` — was `index.ts:130-146`
- `decideRetry(err, dir)` — was inline `isProjectMismatch` predicate at `index.ts:209-213`
- `decideRequeue(result)` — was inline check inside `flushPendingRename` at `index.ts:263-267`

Per [feedback_single_responsibility.md](https://github.com/Jiahui-Gu/ccsm/blob/working/.claude/memory/feedback_single_responsibility.md): producer / decider / sink separation. Sinks (`titleCache`, `opChains`, `pendingRenames`) and the `loadSdk` ESM shim deliberately left in place — those are separate follow-ups.

### Out of scope (untouched)

- `loadSdk` dynamic-import shim
- `titleCache` TTL cache
- `opChains` per-sid serialization
- `pendingRenames` map
- All exported function signatures

## Files

- `electron/sessionTitles/deciders.ts` (new, 75 lines, JSDoc + table for `classifyError`)
- `electron/sessionTitles/__tests__/deciders.test.ts` (new, 22 cases)
- `electron/sessionTitles/index.ts` (replace inline logic with imports)

## Verification

### Vitest unit (deciders only)

```
RUN  v2.1.9
 PASS electron/sessionTitles/__tests__/deciders.test.ts (22 tests) 8ms
 Test Files  1 passed (1)
      Tests  22 passed (22)
```

### Vitest full sessionTitles suite (incl. existing index + integration)

```
 PASS electron/sessionTitles/__tests__/deciders.test.ts (22 tests) 8ms
 PASS electron/sessionTitles/__tests__/index.test.ts (9 tests) 9ms
 PASS electron/sessionTitles/__tests__/renameWriteback.integration.test.ts (1 test) 91ms
 Test Files  3 passed (3)
      Tests  32 passed (32)
```

### require-load smoke (per `feedback_main_process_load_smoke_test.md`)

```
$ node -e "require('./dist/electron/sessionTitles/index.js'); console.log('OK loaded sessionTitles/index')"
OK loaded sessionTitles/index

$ node -e "const d=require('./dist/electron/sessionTitles/deciders.js'); console.log('OK loaded deciders, exports:', Object.keys(d))"
OK loaded deciders, exports: [ 'classifyError', 'decideRetry', 'decideRequeue' ]
```

### tsc

`npx tsc -p tsconfig.electron.json` clean (no output).

## Test plan

- [x] Unit tests for all 3 deciders (22 cases) — pass
- [x] Existing `index.test.ts` (9 cases) — pass
- [x] `renameWriteback.integration.test.ts` — pass
- [x] tsc clean
- [x] require-load smoke for index.js + deciders.js
- [ ] Reviewer verifies behavior preservation in the 3 call sites