### PR TITLE
feat(notify): ptyHost OSC 0 title sniffer producer (phase B)

### DIFF
--- a/electron/ptyHost/__tests__/oscTitleSniffer.test.ts
+++ b/electron/ptyHost/__tests__/oscTitleSniffer.test.ts
@@ -1,0 +1,172 @@
+// UTs for the phase B notify producer (Task #688). Pins the OSC 0 escape
+// scanner contract: BEL/ST terminators, multi-OSC chunks, split-across-
+// chunk escapes, per-sid isolation, clear() semantics, and bounded-buffer
+// behaviour for hostile streams.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { OscTitleSniffer, type OscTitleEvent } from '../oscTitleSniffer';
+
+function collect(sniffer: OscTitleSniffer): OscTitleEvent[] {
+  const events: OscTitleEvent[] = [];
+  sniffer.on('osc-title', (e: OscTitleEvent) => events.push(e));
+  return events;
+}
+
+describe('OscTitleSniffer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-29T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('emits on a single OSC 0 BEL-terminated escape', () => {
+    const s = new OscTitleSniffer();
+    const events = collect(s);
+    s.feed('sid-1', '\x1b]0;hello\x07');
+    expect(events).toEqual([
+      { sid: 'sid-1', title: 'hello', ts: Date.now() },
+    ]);
+  });
+
+  it('emits on a single OSC 0 ST-terminated escape', () => {
+    const s = new OscTitleSniffer();
+    const events = collect(s);
+    s.feed('sid-1', '\x1b]0;hi\x1b\\');
+    expect(events).toEqual([
+      { sid: 'sid-1', title: 'hi', ts: Date.now() },
+    ]);
+  });
+
+  it('emits multiple OSC sequences from a single chunk in order', () => {
+    const s = new OscTitleSniffer();
+    const events = collect(s);
+    s.feed('sid-1', '\x1b]0;a\x07text\x1b]0;b\x07');
+    expect(events.map((e) => e.title)).toEqual(['a', 'b']);
+    expect(events.every((e) => e.sid === 'sid-1')).toBe(true);
+  });
+
+  it('handles an OSC escape split across two chunks (one emit only)', () => {
+    const s = new OscTitleSniffer();
+    const events = collect(s);
+    s.feed('sid-1', 'partial \x1b]0;wai');
+    expect(events).toHaveLength(0);
+    s.feed('sid-1', 'ting\x07');
+    expect(events).toEqual([
+      { sid: 'sid-1', title: 'waiting', ts: Date.now() },
+    ]);
+  });
+
+  it('keeps per-sid buffers isolated', () => {
+    const s = new OscTitleSniffer();
+    const events = collect(s);
+
+    s.feed('sid-A', 'noise \x1b]0;par'); // partial on A
+    s.feed('sid-B', '\x1b]0;done\x07'); // complete on B
+
+    expect(events).toEqual([
+      { sid: 'sid-B', title: 'done', ts: Date.now() },
+    ]);
+
+    s.feed('sid-A', 'tial\x07'); // finish A
+    expect(events).toEqual([
+      { sid: 'sid-B', title: 'done', ts: Date.now() },
+      { sid: 'sid-A', title: 'partial', ts: Date.now() },
+    ]);
+  });
+
+  it('does not emit on plain text chunks with no OSC', () => {
+    const s = new OscTitleSniffer();
+    const events = collect(s);
+    s.feed('sid-1', 'hello world\nno escapes here at all\n');
+    expect(events).toHaveLength(0);
+  });
+
+  it('clear(sid) drops any pending partial buffer', () => {
+    const s = new OscTitleSniffer();
+    const events = collect(s);
+
+    s.feed('sid-1', '\x1b]0;will-be-dropped'); // partial
+    s.clear('sid-1');
+
+    // Feeding the would-be terminator alone should not produce an emit
+    // because the prefix is gone.
+    s.feed('sid-1', '\x07');
+    expect(events).toHaveLength(0);
+
+    // And the sniffer should still work for a fresh OSC.
+    s.feed('sid-1', '\x1b]0;fresh\x07');
+    expect(events).toEqual([
+      { sid: 'sid-1', title: 'fresh', ts: Date.now() },
+    ]);
+  });
+
+  it('caps buffer growth on long OSC-free streams', () => {
+    const s = new OscTitleSniffer();
+    const events = collect(s);
+
+    const noise = 'x'.repeat(100 * 1024); // 100 KiB, no OSC
+    s.feed('sid-1', noise);
+
+    expect(events).toHaveLength(0);
+    // Internal map: tail must be at most a few bytes (we keep up to 3 to
+    // span a possible split escape prefix) — definitely << input.
+    const internal = (s as unknown as { buffers: Map<string, string> }).buffers;
+    const tail = internal.get('sid-1') ?? '';
+    expect(tail.length).toBeLessThanOrEqual(64 * 1024);
+    expect(tail.length).toBeLessThan(noise.length);
+
+    // And a follow-up OSC still parses.
+    s.feed('sid-1', '\x1b]0;ok\x07');
+    expect(events).toEqual([{ sid: 'sid-1', title: 'ok', ts: Date.now() }]);
+  });
+
+  it('caps buffer growth on a never-terminated OSC', () => {
+    const s = new OscTitleSniffer();
+    const events = collect(s);
+
+    // Open OSC, then 100 KiB of title bytes with no terminator.
+    s.feed('sid-1', '\x1b]0;' + 'A'.repeat(100 * 1024));
+    expect(events).toHaveLength(0);
+
+    const internal = (s as unknown as { buffers: Map<string, string> }).buffers;
+    const tail = internal.get('sid-1') ?? '';
+    expect(tail.length).toBeLessThanOrEqual(64 * 1024);
+  });
+
+  it('stamps ts from Date.now() on each emit', () => {
+    const s = new OscTitleSniffer();
+    const events = collect(s);
+
+    vi.setSystemTime(new Date('2026-04-29T12:00:00Z'));
+    const t1 = Date.now();
+    s.feed('sid-1', '\x1b]0;first\x07');
+
+    vi.setSystemTime(new Date('2026-04-29T12:00:05Z'));
+    const t2 = Date.now();
+    s.feed('sid-1', '\x1b]0;second\x07');
+
+    expect(events).toEqual([
+      { sid: 'sid-1', title: 'first', ts: t1 },
+      { sid: 'sid-1', title: 'second', ts: t2 },
+    ]);
+    expect(t2).toBeGreaterThan(t1);
+  });
+
+  it('ignores empty/null chunks safely', () => {
+    const s = new OscTitleSniffer();
+    const events = collect(s);
+    s.feed('sid-1', '');
+    s.feed('sid-1', Buffer.alloc(0));
+    expect(events).toHaveLength(0);
+  });
+
+  it('accepts Buffer input', () => {
+    const s = new OscTitleSniffer();
+    const events = collect(s);
+    s.feed('sid-1', Buffer.from('\x1b]0;buf\x07', 'utf8'));
+    expect(events).toEqual([{ sid: 'sid-1', title: 'buf', ts: Date.now() }]);
+  });
+});

--- a/electron/ptyHost/oscTitleSniffer.ts
+++ b/electron/ptyHost/oscTitleSniffer.ts
@@ -1,0 +1,114 @@
+// Phase B of the notify pipeline (Task #688): a pure producer that scans
+// PTY stdout byte streams for OSC 0 title escape sequences and emits the
+// raw title string. It does NOT interpret titles ('waiting'/'running'/etc.)
+// — that is the decider's job (Task #687). It does NOT wire into ptyHost or
+// IPC — that is the sink's job (Task #689). This file is a standalone
+// EventEmitter so each layer can be tested in isolation.
+//
+// OSC 0 spec:
+//   ESC ] 0 ; <title> BEL              (\x1b]0;<title>\x07)
+//   ESC ] 0 ; <title> ST               (\x1b]0;<title>\x1b\\)
+// Either terminator is valid; xterm/Windows Terminal/Claude CLI all use BEL
+// in practice, but we accept ST for robustness.
+//
+// Per-sid buffering is required because a chunk boundary can split an
+// escape sequence in half. We append, scan for complete sequences, emit,
+// then keep the incomplete tail (if any) for the next feed call.
+
+import { EventEmitter } from 'events';
+
+export interface OscTitleEvent {
+  sid: string;
+  title: string;
+  ts: number;
+}
+
+// Cap per-sid buffer growth to defend against pathological streams that
+// emit `\x1b]0;` and never terminate it (or just enormous non-OSC text).
+// 64 KiB is enough to span any realistic split escape across chunks.
+const MAX_BUFFER_BYTES = 64 * 1024;
+
+export class OscTitleSniffer extends EventEmitter {
+  private readonly buffers = new Map<string, string>();
+
+  feed(sid: string, chunk: string | Buffer): void {
+    if (chunk == null) return;
+    const text = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+    if (text.length === 0) return;
+
+    let buf = (this.buffers.get(sid) ?? '') + text;
+
+    // Scan for complete OSC 0 sequences. Loop because one chunk can hold
+    // multiple sequences.
+    let scanFrom = 0;
+    let lastEmitEnd = 0;
+    while (scanFrom < buf.length) {
+      const oscStart = buf.indexOf('\x1b]0;', scanFrom);
+      if (oscStart === -1) break;
+
+      const titleStart = oscStart + 4; // length of `\x1b]0;`
+
+      // Find terminator: BEL (\x07) or ST (\x1b\\). Pick the earlier one.
+      const belIdx = buf.indexOf('\x07', titleStart);
+      const stIdx = buf.indexOf('\x1b\\', titleStart);
+
+      let termIdx = -1;
+      let termLen = 0;
+      if (belIdx !== -1 && (stIdx === -1 || belIdx < stIdx)) {
+        termIdx = belIdx;
+        termLen = 1;
+      } else if (stIdx !== -1) {
+        termIdx = stIdx;
+        termLen = 2;
+      }
+
+      if (termIdx === -1) {
+        // Incomplete escape — leave it (and everything before it that we
+        // haven't yet consumed) for the next feed.
+        break;
+      }
+
+      const title = buf.slice(titleStart, termIdx);
+      this.emit('osc-title', {
+        sid,
+        title,
+        ts: Date.now(),
+      } satisfies OscTitleEvent);
+
+      scanFrom = termIdx + termLen;
+      lastEmitEnd = scanFrom;
+    }
+
+    // Keep only the tail starting at the first byte we haven't consumed.
+    // If we found incomplete OSC start, we want to keep from that point so
+    // the next feed can complete it. If no OSC at all, keep nothing
+    // (it's all plain text we don't care about) — but cap by
+    // MAX_BUFFER_BYTES in case the tail is huge.
+    let tail: string;
+    const incompleteOscStart = buf.indexOf('\x1b]0;', lastEmitEnd);
+    if (incompleteOscStart !== -1) {
+      tail = buf.slice(incompleteOscStart);
+    } else {
+      // No partial OSC pending. Discard plain text so the buffer doesn't
+      // grow unbounded. Keep last 3 bytes only so a split `\x1b]0` prefix
+      // straddling the chunk boundary still completes next round.
+      tail = buf.slice(Math.max(buf.length - 3, lastEmitEnd));
+    }
+
+    if (tail.length > MAX_BUFFER_BYTES) {
+      // Truncate from the LEFT — keep the most recent bytes since an OSC
+      // terminator (if it ever arrives) will appear later in the stream.
+      tail = tail.slice(tail.length - MAX_BUFFER_BYTES);
+    }
+
+    if (tail.length === 0) {
+      this.buffers.delete(sid);
+    } else {
+      this.buffers.set(sid, tail);
+    }
+  }
+
+  clear(sid: string): void {
+    this.buffers.delete(sid);
+  }
+}


### PR DESCRIPTION
## Summary

Task #688 — phase B of the notify pipeline. Adds a standalone OSC 0 title
sniffer that scans PTY stdout byte streams and emits raw title strings.
Pure producer, single responsibility: no ptyHost wiring, no decider logic,
no IPC, no main.ts changes. Wiring is the sink's job (Task #689); title
classification is the decider's job (Task #687).

## Interface

```ts
export interface OscTitleEvent {
  sid: string;
  title: string;
  ts: number;
}

export class OscTitleSniffer extends EventEmitter {
  feed(sid: string, chunk: string | Buffer): void;
  clear(sid: string): void;
}
// emits: 'osc-title' (event: OscTitleEvent)
```

## OSC 0 spec covered
- `\x1b]0;<title>\x07` (BEL terminator — xterm/Windows Terminal/Claude CLI default)
- `\x1b]0;<title>\x1b\` (ST terminator — accepted for robustness)
- Multiple OSCs in one chunk
- Escape split across chunks (per-sid buffer)
- Per-sid isolation
- Max buffer 64 KiB to defend against unterminated OSC / OSC-free flood

## UT output

```
 ✓ electron/ptyHost/__tests__/oscTitleSniffer.test.ts (12 tests) 10ms

 Test Files  1 passed (1)
      Tests  12 passed (12)
```

Cases: BEL emit, ST emit, multi-OSC chunk, split-across-chunks (single
emit), per-sid isolation, no-OSC plain text (no emit), clear() drops
partial buffer, 100 KiB OSC-free buffer cap, never-terminated OSC buffer
cap, ts stamping with fake timers, empty/null safe, Buffer input.

## Smoke (require-load per feedback_main_process_load_smoke_test)

```
$ node -e "const m=require('./dist/electron/ptyHost/oscTitleSniffer.js');
   const s=new m.OscTitleSniffer();
   s.on('osc-title', e=>console.log('emit:', JSON.stringify(e)));
   s.feed('sid-x','\x1b]0;smoke\x07');
   s.clear('sid-x');
   console.log('smoke OK');"
emit: {"sid":"sid-x","title":"smoke","ts":1777471325528}
smoke OK
```

`npx tsc -p tsconfig.electron.json` clean (no output).

## Phase context (notify pipeline)
- Task #687 — phase A: pure title decider (waiting/running/idle classifier)
- **Task #688 — phase B: this PR** (OSC 0 producer)
- Task #689 — phase C: sink (wires ptyHost.onData → sniffer.feed → decider → notify)

## Test plan
- [x] vitest UT (12 cases) green
- [x] tsc -p tsconfig.electron.json clean
- [x] require-load smoke under plain node CJS
- [ ] Sink wiring + e2e probe land in #689