### PR TITLE
feat(notify): pure decider for 7-rule spec (phase A)

### DIFF
--- a/electron/notify/__tests__/notifyDecider.test.ts
+++ b/electron/notify/__tests__/notifyDecider.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect } from 'vitest';
+import {
+  decide,
+  USER_INIT_MUTE_MS,
+  SHORT_TASK_MS,
+  DEDUPE_MS,
+  type Ctx,
+  type Event,
+} from '../notifyDecider';
+
+const NOW = 1_700_000_000_000;
+
+function makeCtx(overrides: Partial<Ctx> = {}): Ctx {
+  return {
+    focused: true,
+    activeSid: null,
+    lastUserInputTs: new Map(),
+    runStartTs: new Map(),
+    mutedSids: new Set(),
+    lastFiredTs: new Map(),
+    now: NOW,
+    ...overrides,
+  };
+}
+
+function waiting(sid: string, ts: number = NOW): Event {
+  return { type: 'osc-title', sid, title: 'waiting', ts };
+}
+
+describe('notifyDecider — 7 rules', () => {
+  it('rule 1: user-init mute within 60s suppresses everything', () => {
+    const ctx = makeCtx({
+      focused: false, // even with backgrounded ccsm, mute wins
+      lastUserInputTs: new Map([['s1', NOW - 30_000]]),
+    });
+    expect(decide(waiting('s1'), ctx)).toBeNull();
+  });
+
+  it('rule 1 boundary: > 60s ago no longer mutes — falls to other rule (unfocused)', () => {
+    const ctx = makeCtx({
+      focused: false,
+      lastUserInputTs: new Map([['s1', NOW - (USER_INIT_MUTE_MS + 1_000)]]),
+    });
+    expect(decide(waiting('s1'), ctx)).toEqual({
+      sid: 's1',
+      toast: true,
+      flash: true,
+    });
+  });
+
+  it('rule 2: foreground + active sid + short task → flash only, no toast', () => {
+    const ctx = makeCtx({
+      focused: true,
+      activeSid: 's1',
+      runStartTs: new Map([['s1', NOW - 30_000]]),
+    });
+    expect(decide(waiting('s1'), ctx)).toEqual({
+      sid: 's1',
+      toast: false,
+      flash: true,
+    });
+  });
+
+  it('rule 3: foreground + active sid + long task (>= 60s) → toast + flash', () => {
+    const ctx = makeCtx({
+      focused: true,
+      activeSid: 's1',
+      runStartTs: new Map([['s1', NOW - (SHORT_TASK_MS + 1_000)]]),
+    });
+    expect(decide(waiting('s1'), ctx)).toEqual({
+      sid: 's1',
+      toast: true,
+      flash: true,
+    });
+  });
+
+  it('rule 4: foreground but viewing other sid → toast + flash on the firing sid', () => {
+    const ctx = makeCtx({
+      focused: true,
+      activeSid: 'other',
+      runStartTs: new Map([['s1', NOW - 5_000]]),
+    });
+    expect(decide(waiting('s1'), ctx)).toEqual({
+      sid: 's1',
+      toast: true,
+      flash: true,
+    });
+  });
+
+  it('rule 5: ccsm not focused → toast + flash', () => {
+    const ctx = makeCtx({ focused: false });
+    expect(decide(waiting('s1'), ctx)).toEqual({
+      sid: 's1',
+      toast: true,
+      flash: true,
+    });
+  });
+
+  it('rule 6: multi-sid background concurrent — each sid evaluated independently', () => {
+    const ctx = makeCtx({
+      focused: false,
+      activeSid: null,
+    });
+    const a = decide(waiting('sid-A'), ctx);
+    const b = decide(waiting('sid-B'), ctx);
+    expect(a).toEqual({ sid: 'sid-A', toast: true, flash: true });
+    expect(b).toEqual({ sid: 'sid-B', toast: true, flash: true });
+    // Decisions are independent — neither sid affects the other's evaluation,
+    // and dedupe is per-sid (verified separately).
+  });
+
+  it('rule 7: muted sid → flash only, toast suppressed (even unfocused)', () => {
+    const ctx = makeCtx({
+      focused: false,
+      mutedSids: new Set(['s1']),
+    });
+    expect(decide(waiting('s1'), ctx)).toEqual({
+      sid: 's1',
+      toast: false,
+      flash: true,
+    });
+  });
+
+  it('rule 7: muted + foreground active short task → still flash only, no toast', () => {
+    const ctx = makeCtx({
+      focused: true,
+      activeSid: 's1',
+      runStartTs: new Map([['s1', NOW - 10_000]]),
+      mutedSids: new Set(['s1']),
+    });
+    expect(decide(waiting('s1'), ctx)).toEqual({
+      sid: 's1',
+      toast: false,
+      flash: true,
+    });
+  });
+});
+
+describe('notifyDecider — dedupe', () => {
+  it('suppresses fire when last fired within 5s', () => {
+    const ctx = makeCtx({
+      focused: false,
+      lastFiredTs: new Map([['s1', NOW - 3_000]]),
+    });
+    expect(decide(waiting('s1'), ctx)).toBeNull();
+  });
+
+  it('boundary: last fired > 5s ago — fires normally', () => {
+    const ctx = makeCtx({
+      focused: false,
+      lastFiredTs: new Map([['s1', NOW - (DEDUPE_MS + 1_000)]]),
+    });
+    expect(decide(waiting('s1'), ctx)).toEqual({
+      sid: 's1',
+      toast: true,
+      flash: true,
+    });
+  });
+
+  it('dedupe is per-sid — fire on sid-B not blocked by recent sid-A', () => {
+    const ctx = makeCtx({
+      focused: false,
+      lastFiredTs: new Map([['sid-A', NOW - 1_000]]),
+    });
+    expect(decide(waiting('sid-A'), ctx)).toBeNull();
+    expect(decide(waiting('sid-B'), ctx)).toEqual({
+      sid: 'sid-B',
+      toast: true,
+      flash: true,
+    });
+  });
+});
+
+describe('notifyDecider — context-update-only events return null', () => {
+  it('window-focus-change returns null', () => {
+    const ctx = makeCtx();
+    expect(
+      decide({ type: 'window-focus-change', focused: true }, ctx),
+    ).toBeNull();
+    expect(
+      decide({ type: 'window-focus-change', focused: false }, ctx),
+    ).toBeNull();
+  });
+
+  it('active-sid-change returns null', () => {
+    const ctx = makeCtx();
+    expect(
+      decide({ type: 'active-sid-change', sid: 's1' }, ctx),
+    ).toBeNull();
+    expect(
+      decide({ type: 'active-sid-change', sid: null }, ctx),
+    ).toBeNull();
+  });
+
+  it('user-input returns null', () => {
+    const ctx = makeCtx();
+    expect(
+      decide({ type: 'user-input', sid: 's1', ts: NOW }, ctx),
+    ).toBeNull();
+  });
+
+  it('non-waiting OSC title returns null', () => {
+    const ctx = makeCtx();
+    expect(
+      decide(
+        { type: 'osc-title', sid: 's1', title: '⠂ Claude Code', ts: NOW },
+        ctx,
+      ),
+    ).toBeNull();
+  });
+});
+
+describe('notifyDecider — purity', () => {
+  it('does not mutate the ctx maps/sets', () => {
+    const lastUserInputTs = new Map([['s1', NOW - 30_000]]);
+    const runStartTs = new Map([['s1', NOW - 10_000]]);
+    const mutedSids = new Set(['s2']);
+    const lastFiredTs = new Map([['s1', NOW - 10_000]]);
+    const ctx: Ctx = {
+      focused: false,
+      activeSid: 's1',
+      lastUserInputTs,
+      runStartTs,
+      mutedSids,
+      lastFiredTs,
+      now: NOW,
+    };
+    decide(waiting('s1'), ctx);
+    decide(waiting('s2'), ctx);
+    decide({ type: 'user-input', sid: 's3', ts: NOW }, ctx);
+
+    expect(lastUserInputTs.size).toBe(1);
+    expect(lastUserInputTs.get('s1')).toBe(NOW - 30_000);
+    expect(runStartTs.size).toBe(1);
+    expect(mutedSids.size).toBe(1);
+    expect(lastFiredTs.size).toBe(1);
+  });
+});

--- a/electron/notify/notifyDecider.ts
+++ b/electron/notify/notifyDecider.ts
@@ -1,0 +1,159 @@
+/**
+ * Notify decider — pure function mapping (event, ctx) to a notify Decision.
+ *
+ * 7-rule spec (user-confirmed):
+ *
+ * | # | trigger                                                                       | toast | flash |
+ * |---|-------------------------------------------------------------------------------|-------|-------|
+ * | 1 | user just acted on this sid (new/import/resume/switch) within 60s, OSC waits  |   x   |   x   |
+ * | 2 | ccsm focused + viewing this sid + task duration < 60s                         |   x   |   v   |
+ * | 3 | ccsm focused + viewing this sid + task duration >= 60s                        |   v   |   v   |
+ * | 4 | ccsm focused + viewing other sid (background sid finishes)                    |   v   |   v   |
+ * | 5 | ccsm not focused (window unfocused/minimized)                                 |   v   |   v   |
+ * | 6 | multi-sid background concurrent finishes — each sid evaluated independently   |  per  |  per  |
+ * | 7 | sid muted — toast suppressed but flash still fires                            |   x   |   v   |
+ *
+ * Dedupe: same sid within 5s suppressed entirely (returns null).
+ * Short-task threshold: 60s (from runStartTs).
+ *
+ * `decide` is pure — does NOT mutate ctx. Callers maintain ctx state
+ * (this is wired up by the pipeline / sink layer in #689).
+ */
+
+export const USER_INIT_MUTE_MS = 60_000;
+export const SHORT_TASK_MS = 60_000;
+export const DEDUPE_MS = 5_000;
+
+export type Event =
+  | { type: 'osc-title'; sid: string; title: string; ts: number }
+  | { type: 'window-focus-change'; focused: boolean }
+  | { type: 'active-sid-change'; sid: string | null }
+  | { type: 'user-input'; sid: string; ts: number };
+
+export interface Ctx {
+  focused: boolean;
+  activeSid: string | null;
+  /** per-sid last "user touched this session" timestamp (ms epoch) */
+  lastUserInputTs: Map<string, number>;
+  /** per-sid current run start timestamp (ms epoch); cleared on idle/waiting */
+  runStartTs: Map<string, number>;
+  mutedSids: Set<string>;
+  /** per-sid last toast fire timestamp (ms epoch), used for 5s dedupe */
+  lastFiredTs: Map<string, number>;
+  /** injected current time for test determinism */
+  now: number;
+}
+
+export type Decision = { toast: boolean; flash: boolean; sid: string };
+
+export type RuleKey =
+  | 'user-init-mute'
+  | 'foreground-active-short'
+  | 'foreground-active-long'
+  | 'foreground-other-sid'
+  | 'unfocused'
+  | 'muted';
+
+/**
+ * Returns true iff the given OSC title indicates the CLI is waiting for
+ * user input (the moment we want to notify on).
+ *
+ * The producer (#688) emits 'osc-title' events with the raw title string;
+ * we treat any title containing "waiting" (case-insensitive) as the
+ * waiting signal. This is intentionally permissive — the producer is
+ * expected to filter to actual transitions.
+ */
+function isWaitingTitle(title: string): boolean {
+  return /waiting/i.test(title);
+}
+
+/**
+ * Evaluate the 7 rules for an OSC waiting event.
+ * Returns the matched RuleKey + raw (toast, flash) before dedupe.
+ */
+function evalRules(
+  sid: string,
+  ctx: Ctx,
+): { rule: RuleKey; toast: boolean; flash: boolean } {
+  const { now, focused, activeSid, lastUserInputTs, runStartTs, mutedSids } = ctx;
+
+  // Rule 1: user-init mute — user touched this sid within 60s
+  const lastInput = lastUserInputTs.get(sid);
+  if (lastInput !== undefined && now - lastInput < USER_INIT_MUTE_MS) {
+    return { rule: 'user-init-mute', toast: false, flash: false };
+  }
+
+  // Rule 7: muted sid — flash still fires, toast suppressed
+  // (Evaluated before foreground rules so muted sids never toast,
+  //  even when active+visible. Flash semantics fall out of which
+  //  rule would otherwise apply, so we still compute the base decision.)
+  const muted = mutedSids.has(sid);
+
+  // Rule 5: not focused → toast + flash
+  if (!focused) {
+    const decision = { toast: true, flash: true };
+    return muted
+      ? { rule: 'muted', toast: false, flash: decision.flash }
+      : { rule: 'unfocused', ...decision };
+  }
+
+  // Foreground from here on.
+  // Rule 4: focused but viewing different sid → toast + flash
+  if (activeSid !== sid) {
+    const decision = { toast: true, flash: true };
+    return muted
+      ? { rule: 'muted', toast: false, flash: decision.flash }
+      : { rule: 'foreground-other-sid', ...decision };
+  }
+
+  // Foreground + viewing this sid: split by task duration.
+  const start = runStartTs.get(sid);
+  const elapsed = start === undefined ? 0 : now - start;
+
+  if (elapsed < SHORT_TASK_MS) {
+    // Rule 2: short task → flash only, no toast
+    const decision = { toast: false, flash: true };
+    return muted
+      ? { rule: 'muted', toast: false, flash: decision.flash }
+      : { rule: 'foreground-active-short', ...decision };
+  }
+
+  // Rule 3: long task → toast + flash
+  const decision = { toast: true, flash: true };
+  return muted
+    ? { rule: 'muted', toast: false, flash: decision.flash }
+    : { rule: 'foreground-active-long', ...decision };
+}
+
+/**
+ * Pure decider. Returns a Decision when an OSC waiting event passes
+ * all rules + dedupe; returns null otherwise (suppressed, deduped, or
+ * the event is purely a context-update event).
+ */
+export function decide(event: Event, ctx: Ctx): Decision | null {
+  // Context-update-only events produce no decision; the caller is
+  // responsible for updating ctx.
+  if (event.type !== 'osc-title') {
+    return null;
+  }
+
+  if (!isWaitingTitle(event.title)) {
+    return null;
+  }
+
+  const { sid } = event;
+  const result = evalRules(sid, ctx);
+
+  // If neither toast nor flash, nothing to fire.
+  if (!result.toast && !result.flash) {
+    return null;
+  }
+
+  // 5s dedupe per sid — suppress entirely if last fire was < 5s ago.
+  const lastFired = ctx.lastFiredTs.get(sid);
+  if (lastFired !== undefined && ctx.now - lastFired < DEDUPE_MS) {
+    return null;
+  }
+
+  return { toast: result.toast, flash: result.flash, sid };
+}


### PR DESCRIPTION
## Summary

Phase A of Task #687 — the pure `decide(event, ctx)` function + decision table for the 7-rule notify spec. **Scope-locked**: only `electron/notify/notifyDecider.ts` + its UT. No producer (#688), no sink (#689), no `main.ts` wiring.

## 7-rule decision table

| # | trigger                                                                     | toast | flash |
|---|-----------------------------------------------------------------------------|-------|-------|
| 1 | user just acted on this sid (new/import/resume/switch) within 60s, OSC waits |   x   |   x   |
| 2 | ccsm focused + viewing this sid + task duration < 60s                        |   x   |   v   |
| 3 | ccsm focused + viewing this sid + task duration >= 60s                       |   v   |   v   |
| 4 | ccsm focused + viewing other sid (background sid finishes)                   |   v   |   v   |
| 5 | ccsm not focused (window unfocused/minimized)                                |   v   |   v   |
| 6 | multi-sid background concurrent finishes — each sid evaluated independently  |  per  |  per  |
| 7 | sid muted — toast suppressed but flash still fires                           |   x   |   v   |

Plus 5s per-sid dedupe on fired Decisions.

## Interface

```ts
export const USER_INIT_MUTE_MS = 60_000;
export const SHORT_TASK_MS = 60_000;
export const DEDUPE_MS = 5_000;

export type Event =
  | { type: 'osc-title'; sid: string; title: string; ts: number }
  | { type: 'window-focus-change'; focused: boolean }
  | { type: 'active-sid-change'; sid: string | null }
  | { type: 'user-input'; sid: string; ts: number };

export interface Ctx {
  focused: boolean;
  activeSid: string | null;
  lastUserInputTs: Map<string, number>;
  runStartTs: Map<string, number>;
  mutedSids: Set<string>;
  lastFiredTs: Map<string, number>;
  now: number;
}

export type Decision = { toast: boolean; flash: boolean; sid: string };

export function decide(event: Event, ctx: Ctx): Decision | null;
```

`decide` is pure — does NOT mutate ctx. Ctx maintenance lives in the wiring layer (#689).

## UT output

```
RUN  v2.1.9
 ✓ electron/notify/__tests__/notifyDecider.test.ts (17 tests) 6ms

 Test Files  1 passed (1)
      Tests  17 passed (17)
```

Coverage: every rule + both 60s boundaries + both 5s dedupe boundaries + multi-sid independence + ctx-purity invariant + non-osc events return null + non-waiting OSC titles return null.

## Phasing

- **Phase A (this PR)**: pure decider + UT. Mergeable independently.
- **Phase B (#688)**: OSC title producer feeds `osc-title` events.
- **Phase C (#689)**: ctx maintenance + sink wiring (toast, flash) in main.

## Test plan

- [x] `npx vitest run electron/notify/__tests__/notifyDecider.test.ts` — 17/17 pass
- [x] `npx tsc --noEmit` — clean
- [ ] e2e harness — N/A this phase (no runtime wiring; e2e arrives with #689)