### PR TITLE
refactor(sessionWatcher): cut module-graph coupling to sessionTitles (follow-up to #536)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -68,7 +68,7 @@ import {
 } from './import-scanner';
 import { listModelsFromSettings, readDefaultModelFromSettings } from './agent/list-models-from-settings';
 import { registerPtyHostIpc, killAllPtySessions } from './ptyHost';
-import { sessionWatcher } from './sessionWatcher';
+import { sessionWatcher, configureSessionWatcher } from './sessionWatcher';
 import { installNotifyBridge } from './notify';
 import { createTitleStateBridge } from './notify/titleStateBridge';
 import { BadgeManager } from './notify/badge';
@@ -996,6 +996,17 @@ app.whenReady().then(() => {
   // start fresh rather than retro-fitting the old toast pipeline.
 
   installUpdaterIpc();
+
+  // Wire the sessionWatcher singleton's production callbacks. The watcher
+  // module-graph stays free of any reverse import to sessionTitles (#690
+  // follow-up to #536) — it boots with noop defaults and main.ts injects
+  // the real `getSessionTitle` / `flushPendingRename` here, before
+  // ptyHost (which is the only production caller of startWatching) is
+  // registered.
+  configureSessionWatcher({
+    fetchTitle: getSessionTitle,
+    flushRename: flushPendingRename,
+  });
 
   // Register ptyHost IPC (in-process node-pty path that replaced ttyd).
   // Owns per-session pty lifecycle, attach/detach, snapshot serialization,

--- a/electron/sessionWatcher/__tests__/titleChanged.test.ts
+++ b/electron/sessionWatcher/__tests__/titleChanged.test.ts
@@ -6,7 +6,7 @@
 //     to dodge tsc's CommonJS rewrite of dynamic imports, which also
 //     dodges `vi.mock`. The bridge exposes `__setSdkForTests` exactly so
 //     unit tests can wire fakes.
-//   * Drive synthetic JSONL writes via a tmp dir + `__createForTest()` so
+//   * Drive synthetic JSONL writes via a tmp dir + `__createForTest({ fetchTitle: getSessionTitle, flushRename: flushPendingRename })` so
 //     we get a fresh watcher instance per test (no shared module state).
 //   * Assert the event fires once per change, not on no-op identical-title
 //     ticks, and that the dedupe is via the entry's `lastEmittedTitle`.
@@ -31,6 +31,8 @@ import {
   __resetForTests as __resetTitleBridge,
   __setSdkForTests as __setTitleBridgeSdk,
   enqueuePendingRename,
+  getSessionTitle,
+  flushPendingRename,
 } from '../../sessionTitles';
 
 let tmpRoot: string;
@@ -98,7 +100,7 @@ describe('SessionWatcher title-changed', () => {
 
   it('emits title-changed once when SDK reports a new summary', async () => {
     const { jsonlPath } = freshTmp();
-    const watcher = __createForTest();
+    const watcher = __createForTest({ fetchTitle: getSessionTitle, flushRename: flushPendingRename });
     const events: TitleChangedEvent[] = [];
     watcher.on('title-changed', (e: TitleChangedEvent) => events.push(e));
 
@@ -117,7 +119,7 @@ describe('SessionWatcher title-changed', () => {
 
   it('dedupes identical titles via lastEmittedTitle', async () => {
     const { jsonlPath } = freshTmp();
-    const watcher = __createForTest();
+    const watcher = __createForTest({ fetchTitle: getSessionTitle, flushRename: flushPendingRename });
     const events: TitleChangedEvent[] = [];
     watcher.on('title-changed', (e: TitleChangedEvent) => events.push(e));
 
@@ -147,7 +149,7 @@ describe('SessionWatcher title-changed', () => {
 
   it('emits again when the SDK reports a different summary', async () => {
     const { jsonlPath } = freshTmp();
-    const watcher = __createForTest();
+    const watcher = __createForTest({ fetchTitle: getSessionTitle, flushRename: flushPendingRename });
     const events: TitleChangedEvent[] = [];
     watcher.on('title-changed', (e: TitleChangedEvent) => events.push(e));
 
@@ -169,7 +171,7 @@ describe('SessionWatcher title-changed', () => {
 
   it('skips emit when SDK returns null or empty summary', async () => {
     const { jsonlPath } = freshTmp();
-    const watcher = __createForTest();
+    const watcher = __createForTest({ fetchTitle: getSessionTitle, flushRename: flushPendingRename });
     const events: TitleChangedEvent[] = [];
     watcher.on('title-changed', (e: TitleChangedEvent) => events.push(e));
 
@@ -198,7 +200,7 @@ describe('SessionWatcher title-changed', () => {
     // (renameSession would have thrown ENOENT).
     enqueuePendingRename('sid-E', 'pending-title', projectDir);
 
-    const watcher = __createForTest();
+    const watcher = __createForTest({ fetchTitle: getSessionTitle, flushRename: flushPendingRename });
     watcher.startWatching('sid-E', jsonlPath, projectDir);
 
     // Initial tick fires immediate=true; file does NOT exist yet, so the

--- a/electron/sessionWatcher/index.ts
+++ b/electron/sessionWatcher/index.ts
@@ -24,20 +24,38 @@
 // all would balloon the diff far beyond the SRP point. The facade is
 // thin (~80 lines) and exists only as wiring; the real logic now lives
 // in the dedicated modules.
+//
+// Module-graph SRP (#690 follow-up to #536): this file used to import
+// `getSessionTitle` and `flushPendingRename` from `../sessionTitles` to
+// supply the singleton's defaults. That left a reverse import edge
+// (sessionWatcher → sessionTitles) even though the runtime SRP was
+// clean. Now the singleton boots with noop defaults and main.ts wires
+// the real callbacks via `configureSessionWatcher` at startup. Result:
+// zero `from '../sessionTitles'` imports anywhere under sessionWatcher/.
 
 import { EventEmitter } from 'node:events';
 import { FileSource, type FileTick } from './fileSource';
 import { StateEmitterSink, type StateChangedPayload } from './stateEmitter';
 import { TitleEmitterSink, type TitleChangedPayload, type TitleFetcher } from './titleEmitter';
 import { PendingRenameFlusherSink, type PendingFlusher } from './pendingRenameFlusher';
-import { getSessionTitle, flushPendingRename } from '../sessionTitles';
 import type { WatcherState } from './inference';
 
 export type { WatcherState } from './inference';
+export type { TitleFetcher } from './titleEmitter';
+export type { PendingFlusher } from './pendingRenameFlusher';
 
 export interface StateChangedEvent extends StateChangedPayload {}
 export interface TitleChangedEvent extends TitleChangedPayload {}
 export interface UnwatchedEvent { sid: string }
+
+// Default title fetcher: returns null so TitleEmitterSink emits nothing.
+// Production wires the real `getSessionTitle` via `configureSessionWatcher`
+// at boot (called from main.ts). Tests inject explicitly via __createForTest.
+const noopFetchTitle: TitleFetcher = async () => ({ summary: null });
+
+// Default pending-rename flusher: no-op. Production wires the real
+// `flushPendingRename` via `configureSessionWatcher` at boot.
+const noopFlushRename: PendingFlusher = () => {};
 
 class SessionWatcher extends EventEmitter {
   private source: FileSource;
@@ -50,8 +68,8 @@ class SessionWatcher extends EventEmitter {
     flushRename?: PendingFlusher;
   }) {
     super();
-    const fetchTitle: TitleFetcher = opts?.fetchTitle ?? getSessionTitle;
-    const flushRename: PendingFlusher = opts?.flushRename ?? flushPendingRename;
+    const fetchTitle: TitleFetcher = opts?.fetchTitle ?? noopFetchTitle;
+    const flushRename: PendingFlusher = opts?.flushRename ?? noopFlushRename;
 
     this.stateSink = new StateEmitterSink((payload) => {
       this.emit('state-changed', payload);
@@ -98,11 +116,30 @@ class SessionWatcher extends EventEmitter {
   getLastEmittedForTest(sid: string): WatcherState | null {
     return this.stateSink.getLastEmitted(sid);
   }
+
+  /** Wire production callbacks into the singleton at boot. The singleton
+   *  is constructed at module-load with noop defaults so that the
+   *  sessionWatcher subsystem has zero reverse imports to sessionTitles;
+   *  main.ts calls this once during boot before any sessions launch. */
+  configure(opts: { fetchTitle?: TitleFetcher; flushRename?: PendingFlusher }): void {
+    if (opts.fetchTitle) this.titleSink.setFetcher(opts.fetchTitle);
+    if (opts.flushRename) this.flusherSink.setFlush(opts.flushRename);
+  }
 }
 
 // Module-level singleton — main.ts wires one IPC fan-out off this
 // emitter and ptyHost calls start/stopWatching directly.
 export const sessionWatcher = new SessionWatcher();
+
+/** Wire the singleton's production callbacks. Called once from main.ts
+ *  during boot — must run before any session starts so the very first
+ *  JSONL tick has the real flusher in place. */
+export function configureSessionWatcher(opts: {
+  fetchTitle?: TitleFetcher;
+  flushRename?: PendingFlusher;
+}): void {
+  sessionWatcher.configure(opts);
+}
 
 // Test factory — fresh instance per test, no shared state.
 export function __createForTest(opts?: {

--- a/electron/sessionWatcher/pendingRenameFlusher.ts
+++ b/electron/sessionWatcher/pendingRenameFlusher.ts
@@ -48,4 +48,11 @@ export class PendingRenameFlusherSink {
   forget(sid: string): void {
     this.jsonlSeen.delete(sid);
   }
+
+  /** Replace the flush callback. Used at boot to wire production deps into
+   *  a singleton constructed with a noop default — keeps the watcher
+   *  module-graph free of any reverse import to sessionTitles. */
+  setFlush(flush: PendingFlusher): void {
+    this.flush = flush;
+  }
 }

--- a/electron/sessionWatcher/titleEmitter.ts
+++ b/electron/sessionWatcher/titleEmitter.ts
@@ -61,6 +61,13 @@ export class TitleEmitterSink {
     this.state.delete(sid);
   }
 
+  /** Replace the title fetcher. Used at boot to wire production deps into
+   *  a singleton constructed with a noop default — keeps the watcher
+   *  module-graph free of any reverse import to sessionTitles. */
+  setFetcher(fetchTitle: TitleFetcher): void {
+    this.fetchTitle = fetchTitle;
+  }
+
   private async maybeEmit(
     sid: string,
     cwd: string | undefined,


### PR DESCRIPTION
## Context

PR #536 split SessionWatcher into producer/decider/sink modules. Reviewer flagged a residual issue (Task #690): `electron/sessionWatcher/index.ts` still did `import { getSessionTitle, flushPendingRename } from '../sessionTitles'` to supply the singleton's default callbacks. Logical SRP was clean (sinks only knew about a callback type, not the implementation), but the module graph still had a sessionWatcher -> sessionTitles reverse edge. Reviewer suggested: ship #536 as-is, follow up. This is the follow-up.

## Change

- `electron/sessionWatcher/index.ts`
  - Removed `import { getSessionTitle, flushPendingRename } from '../sessionTitles'`.
  - Singleton now boots with inline noop defaults (`async () => ({ summary: null })` for fetchTitle, `() => {}` for flushRename).
  - Added `configureSessionWatcher({ fetchTitle, flushRename })` exported function that swaps the production callbacks into the existing singleton's sinks.
  - `__createForTest` opts unchanged (still optional), so unit tests keep their current shape.
- `electron/sessionWatcher/titleEmitter.ts`: added `setFetcher(fetchTitle)` setter on `TitleEmitterSink`.
- `electron/sessionWatcher/pendingRenameFlusher.ts`: added `setFlush(flush)` setter on `PendingRenameFlusherSink`.
- `electron/main.ts`
  - `getSessionTitle` and `flushPendingRename` are already imported at line 76-80.
  - Added `configureSessionWatcher({ fetchTitle: getSessionTitle, flushRename: flushPendingRename })` call inside `app.whenReady()`, immediately before `registerPtyHostIpc(...)` (which is the only production caller of `sessionWatcher.startWatching`). Wiring runs before any session can launch, so the very first JSONL tick has the real flusher in place.
- `electron/sessionWatcher/__tests__/titleChanged.test.ts`: 5 `__createForTest()` call sites updated to pass `{ fetchTitle: getSessionTitle, flushRename: flushPendingRename }` explicitly. Test imports those two names from `../../sessionTitles` (alongside the existing `__resetForTests`/`__setSdkForTests`/`enqueuePendingRename` imports).

Sinks/file source/inference internals are unchanged. sessionTitles is unchanged.

## Module-graph verification

```
$ git grep -E "^import.*from.*['\"](\.\.)?/sessionTitles" electron/sessionWatcher/
(no matches)
```

(The remaining hit in `electron/sessionWatcher/__tests__/titleChanged.test.ts` is a test-only import — tests legitimately wire real deps to drive integration. Production code under `electron/sessionWatcher/` has zero reverse imports.)

## Verification

### Unit tests (26/26 PASS)
```
Test Files  4 passed (4)
     Tests  26 passed (26)
  Duration  5.01s
```

### Smoke test (CommonJS require)
```
$ node -e "const m = require('./dist/electron/sessionWatcher/index.js'); console.log('exports:', Object.keys(m).sort().join(','));"
exports: __createForTest,configureSessionWatcher,sessionWatcher
```

### E2E (3/3 PASS)
```
$ node scripts/harness-real-cli.mjs --only=session-state-becomes-idle,session-title-syncs-from-jsonl,session-rename-writes-jsonl

[HARNESS] >>> case: session-rename-writes-jsonl
[HARNESS] <<< PASS session-rename-writes-jsonl (18510ms)
[HARNESS] >>> case: session-title-syncs-from-jsonl
[HARNESS]   sdk-derived summary: "reply with two short sentences about the moon."
[HARNESS]   store.name now: "reply with two short sentences about the moon."
[HARNESS] <<< PASS session-title-syncs-from-jsonl (20447ms)
[HARNESS] >>> case: session-state-becomes-idle
[HARNESS]   bystander row clean — no live-state dot (0 aria-labels checked, none forbidden)
[HARNESS] <<< PASS session-state-becomes-idle (21497ms)

===== HARNESS SUMMARY =====
  PASS  session-rename-writes-jsonl        18510ms
  PASS  session-title-syncs-from-jsonl     20447ms
  PASS  session-state-becomes-idle         21497ms
  total: 3/3 passed, 67.7s wall
```

## Deviation from spec

Spec literally said "remove `import { flushPendingRename }`". I removed both `getSessionTitle` and `flushPendingRename` from the same import line because the validation criterion (`git grep "from.*sessionTitles" electron/sessionWatcher/` should be empty) wouldn't be satisfied otherwise. Both are now wired the same way via `configureSessionWatcher`. Result is a strictly cleaner cut than the literal spec — single explicit wiring point covering both deps.