### PR TITLE
ci: apply audit recommendations (gating + release + e2e + caching)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,21 @@
 name: CI
 
 on:
-  workflow_dispatch:
   pull_request:
     branches: [main, working]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   lint-typecheck-test:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,64 @@
+name: e2e
+
+on:
+  pull_request:
+    branches: [main, working]
+    paths:
+      - 'electron/**'
+      - 'src/**'
+      - 'scripts/**'
+      - 'package.json'
+      - 'package-lock.json'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: e2e (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Cache Electron binary
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/electron
+            ~/.cache/electron-builder
+          key: electron-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+      - name: Install deps
+        run: npm ci --legacy-peer-deps
+      - name: Build
+        run: npm run build
+      - name: Run e2e (Linux with xvfb)
+        if: runner.os == 'Linux'
+        run: xvfb-run -a npm run probe:e2e
+      - name: Run e2e (mac/win)
+        if: runner.os != 'Linux'
+        run: npm run probe:e2e
+      - name: Upload e2e logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-logs-${{ matrix.os }}
+          path: |
+            dogfood-logs/
+            docs/screenshots/
+          retention-days: 7

--- a/.github/workflows/main-source-guard.yml
+++ b/.github/workflows/main-source-guard.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   check-source:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-no-silent-drops.yml
+++ b/.github/workflows/pr-no-silent-drops.yml
@@ -19,6 +19,10 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,13 @@
 name: Release
 
-# CI minutes are scarce — release artifacts are produced locally and
-# uploaded via `gh release create`. Re-enable the tag trigger once we
-# have CI budget back; until then, manual workflow_dispatch only.
+# Triggered by version tag pushes (vX.Y.Z) or manual dispatch for dry-runs.
+# Artifacts are published to a draft GitHub Release on real tag pushes only;
+# workflow_dispatch runs stop after the artifact upload so dry-runs don't
+# pollute the Releases tab.
 on:
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
     inputs:
       tag:
@@ -30,7 +34,7 @@ jobs:
           cache: 'npm'
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.11'
       - name: Install deps
         run: npm ci --legacy-peer-deps
         env:
@@ -48,6 +52,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - os: ubuntu-latest
+            platform: linux
+          - os: macos-latest
+            platform: mac
           - os: windows-latest
             platform: win
     runs-on: ${{ matrix.os }}
@@ -76,7 +84,15 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.11'
+
+      - name: Cache Electron binary
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/electron
+            ~/.cache/electron-builder
+          key: electron-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install deps
         run: npm ci --legacy-peer-deps


### PR DESCRIPTION
## Summary

Implements the CI audit recommendations from Task #696. Five workflow changes (4 edits + 1 new file).

### Changes per file

- **`.github/workflows/ci.yml`**
  - Added explicit `permissions: contents: read` (least-privilege; default token scopes are over-privileged).
  - Added `paths-ignore` to PR trigger so docs-only PRs (`**.md`, `docs/**`, `LICENSE`, `.gitignore`) skip the matrix.
- **`.github/workflows/main-source-guard.yml`**
  - Added `permissions: contents: read`.
- **`.github/workflows/pr-no-silent-drops.yml`**
  - Added concurrency block (`${{ github.workflow }}-${{ github.ref }}`, cancel-in-progress) to drop in-flight runs on force-push / synchronize.
- **`.github/workflows/release.yml`**
  - Re-enabled the `push: tags: ['v*']` trigger (kept `workflow_dispatch` for dry-runs).
  - Pinned `python-version: '3.11'` (was `'3.12'`) to match `ci.yml`. 3.12 removed distutils (PEP 632), which the older node-gyp invoked by `better-sqlite3` postinstall still needs.
  - Expanded build matrix from `windows-latest` only to `[ubuntu-latest, macos-latest, windows-latest]`.
  - Added Electron binary cache (`~/.cache/electron`, `~/.cache/electron-builder`) keyed on `package-lock.json` hash.
- **`.github/workflows/e2e.yml`** (new)
  - PR trigger filtered to `electron/`, `src/`, `scripts/`, `package*.json`; manual dispatch supported.
  - Three-OS matrix; `xvfb-run` on Linux, direct `npm run probe:e2e` on mac/win.
  - 20 min timeout, concurrency cancel-in-progress, Electron cache, failure-only artifact upload of `dogfood-logs/` and `docs/screenshots/`.

### YAML lint

All 5 files validated locally with `npx -y js-yaml`:
```
ci.yml OK
release.yml OK
main-source-guard.yml OK
pr-no-silent-drops.yml OK
e2e.yml OK
```

### Notes

- **First e2e run is expected to need stabilization.** xvfb config, electron headless quirks, missing system deps (libnss3 etc.), and probe-runner assumptions may surface only on the GitHub-hosted runners. The `paths` filter limits blast radius (docs/CI-only PRs skip e2e). Treat the first 1-2 red e2e runs on this PR as the stabilization signal, not a regression — separate follow-up will fix.
- **Branch protection NOT modified.** Manager will add `e2e` to required checks via `gh api` once the first green run lands.
- **No release business-logic changes** beyond the audit items (Python pin, matrix, cache, tag trigger). The two `if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')` gates are intentionally retained — they correctly differentiate dry-runs from real releases now that both triggers are live.

Refs: Task #696 (audit), Task #697 (this implementation).

## Test plan

- [ ] CI: `lint + typecheck + test` passes on ubuntu/macos/windows
- [ ] CI: `pr-no-silent-drops` passes
- [ ] CI: `e2e` runs (pass not required this PR — stabilization expected)
- [ ] Reviewer confirms permissions/concurrency/paths filters are correct
- [ ] Reviewer confirms release.yml matrix + cache wiring

Generated with Claude Code