### PR TITLE
refactor(store): extract resolvePreferredGroup pure helper (Task #706)

### DIFF
--- a/src/stores/lib/preferredGroupResolver.ts
+++ b/src/stores/lib/preferredGroupResolver.ts
@@ -1,0 +1,33 @@
+import type { Group } from '../../types';
+
+/**
+ * Resolve the preferred group id for a new session, BEFORE
+ * `ensureUsableGroup` runs its synthesis fallback.
+ *
+ * Preference order (preserved from the previous inline logic in
+ * `createSession`):
+ *   1. caller-provided `callerGroupId` (e.g. an explicit `opts.groupId`)
+ *   2. the currently focused group
+ *   3. the group of the active session
+ *   4. null — let `ensureUsableGroup` pick the first normal group or
+ *      synthesize a default one.
+ *
+ * A group is "usable" only when it exists in `groups` AND its `kind` is
+ * `'normal'` (archive groups never receive new sessions).
+ */
+export function resolvePreferredGroup(
+  groups: ReadonlyArray<Group>,
+  callerGroupId: string | null | undefined,
+  focusedGroupId: string | null | undefined,
+  activeGroupId: string | null | undefined,
+): string | null {
+  const isUsable = (gid: string | null | undefined): boolean => {
+    if (!gid) return false;
+    const g = groups.find((x) => x.id === gid);
+    return !!g && g.kind === 'normal';
+  };
+  if (isUsable(callerGroupId)) return callerGroupId!;
+  if (isUsable(focusedGroupId)) return focusedGroupId!;
+  if (isUsable(activeGroupId)) return activeGroupId!;
+  return null;
+}

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -5,6 +5,7 @@ import { hydrateDrafts, deleteDrafts, snapshotDraft, restoreDraft } from './draf
 import { i18next } from '../i18n';
 import type { ConnectionInfo } from '../shared/ipc-types';
 import { classifyPtyExit } from '../lib/ptyExitClassifier';
+import { resolvePreferredGroup } from './lib/preferredGroupResolver';
 
 // Resolve the localized default-group name with a hard-coded English fallback
 // so non-renderer call paths (tests, eager hydration before initI18n runs)
@@ -558,22 +559,16 @@ export const useStore = create<State & Actions>((set, get) => ({
       claudeSettingsDefaultModel,
       lastUsedCwd,
     } = get();
-    const isUsable = (gid: string | null | undefined) => {
-      if (!gid) return false;
-      const g = groups.find((x) => x.id === gid);
-      return !!g && g.kind === 'normal';
-    };
     const activeGroupId = sessions.find((s) => s.id === activeId)?.groupId;
     // Resolve preference order without touching synthesis: caller-provided →
     // focused → active session's group → ensureUsableGroup will pick first
     // normal group or synthesize one (with nameKey).
-    const preferred = isUsable(opts.groupId)
-      ? opts.groupId!
-      : isUsable(focusedGroupId)
-      ? focusedGroupId!
-      : isUsable(activeGroupId)
-      ? activeGroupId!
-      : null;
+    const preferred = resolvePreferredGroup(
+      groups,
+      opts.groupId,
+      focusedGroupId,
+      activeGroupId,
+    );
     const ensured = ensureUsableGroup(groups, preferred);
     const targetGroupId = ensured.groupId;
     const baseGroups = ensured.groups;

--- a/tests/preferredGroupResolver.test.ts
+++ b/tests/preferredGroupResolver.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { resolvePreferredGroup } from '../src/stores/lib/preferredGroupResolver';
+import type { Group } from '../src/types';
+
+function g(id: string, kind: 'normal' | 'archive' = 'normal'): Group {
+  return { id, name: id, collapsed: false, kind };
+}
+
+describe('resolvePreferredGroup', () => {
+  it('returns null when groups is empty', () => {
+    expect(resolvePreferredGroup([], null, null, null)).toBeNull();
+    expect(resolvePreferredGroup([], 'g1', 'g2', 'g3')).toBeNull();
+  });
+
+  it('returns caller-provided id when usable', () => {
+    const groups = [g('a'), g('b'), g('c')];
+    expect(resolvePreferredGroup(groups, 'b', 'a', 'c')).toBe('b');
+  });
+
+  it('falls back to focused when caller missing', () => {
+    const groups = [g('a'), g('b')];
+    expect(resolvePreferredGroup(groups, null, 'b', 'a')).toBe('b');
+    expect(resolvePreferredGroup(groups, undefined, 'a', 'b')).toBe('a');
+  });
+
+  it('falls back to active session group when caller + focused missing', () => {
+    const groups = [g('a'), g('b')];
+    expect(resolvePreferredGroup(groups, null, null, 'a')).toBe('a');
+  });
+
+  it('returns null when no candidate is usable', () => {
+    const groups = [g('a'), g('b')];
+    expect(resolvePreferredGroup(groups, null, null, null)).toBeNull();
+  });
+
+  it('skips ids that are not present in groups', () => {
+    const groups = [g('a')];
+    expect(resolvePreferredGroup(groups, 'ghost', null, null)).toBeNull();
+    expect(resolvePreferredGroup(groups, 'ghost', 'a', null)).toBe('a');
+  });
+
+  it('treats archive groups as not usable', () => {
+    const groups = [g('arc', 'archive'), g('norm', 'normal')];
+    // caller points at archive → skip to next candidate
+    expect(resolvePreferredGroup(groups, 'arc', 'norm', null)).toBe('norm');
+    // every candidate is archive → null
+    expect(resolvePreferredGroup(groups, 'arc', 'arc', 'arc')).toBeNull();
+  });
+
+  it('caller wins over focused when both are usable', () => {
+    const groups = [g('a'), g('b')];
+    expect(resolvePreferredGroup(groups, 'a', 'b', 'b')).toBe('a');
+  });
+
+  it('focused wins over active when caller missing', () => {
+    const groups = [g('a'), g('b')];
+    expect(resolvePreferredGroup(groups, null, 'a', 'b')).toBe('a');
+  });
+});


### PR DESCRIPTION
## Why
Phase B of SRP refactor for `src/stores/store.ts` (Task #706, per #702 evaluation). The "which group should a new session land in?" decision was inlined inside `createSession` as an `isUsable` closure plus a 4-level ternary. Extracting it to a pure module helper:
- makes the decision rule independently testable (no zustand store setup required)
- shrinks `createSession` and clarifies its single responsibility (allocate + insert a session)
- aligns with the producer / decider / sink single-responsibility rule (resolver is a pure decider)

## Scope
Strictly within the bounds the #702 evaluation locked:
- **New** `src/stores/lib/preferredGroupResolver.ts` — single pure function `resolvePreferredGroup(groups, callerGroupId, focusedGroupId, activeGroupId): string | null`. Behavior preserved exactly: caller -> focused -> activeSession's group -> null. "Usable" still means present in `groups` AND `kind === 'normal'`.
- **Modified** `src/stores/store.ts` — `createSession` now calls the resolver instead of declaring `isUsable` and the inline ternary chain. No other callers, no other behavior changes.
- **New** `tests/preferredGroupResolver.test.ts` — 9 vitest cases (empty groups, each fallback level, archive skip, ghost ids, precedence ties).

Out of scope (untouched): `_backfillTitles` (that's Phase A / Task #705 in pool-5), every other file.

Note on signature: the original Task #706 prompt sketched `(groups, lastUsedGroupId, repoHint)`, but the actual `createSession` decision uses `caller / focused / activeSession-group` -- there is no `lastUsedGroupId` or `repoHint` anywhere in this code path. The resolver was written to match the real behavior to preserve, not the hypothetical signature.

## Reverse-verify (resolver removed, test kept)
```
$ git stash push -- src/stores/lib/preferredGroupResolver.ts
$ npx vitest run tests/preferredGroupResolver.test.ts
FAIL  tests/preferredGroupResolver.test.ts
Error: Failed to resolve import "../src/stores/lib/preferredGroupResolver" ...
 Test Files  1 failed (1)
      Tests  no tests
```
After `git stash pop`:
```
$ npx vitest run tests/preferredGroupResolver.test.ts
 PASS  tests/preferredGroupResolver.test.ts (9 tests)
 Test Files  1 passed (1)
      Tests  9 passed (9)
```

## Full vitest
```
Test Files  1 failed | 51 passed (52)
     Tests  3 failed | 482 passed (485)
```
The 3 failures are all in `electron/__tests__/db-hardening.test.ts` and are caused by a pre-existing `better-sqlite3` NODE_MODULE_VERSION 137 mismatch in this pool-7 worktree (the native binding was compiled against a different Electron version). Confirmed identical failures on clean `origin/working` with my diff stashed -- unrelated to this refactor. All 482 other tests, including every store-* test, pass.

## Build
`npm run build` -> tsc + webpack clean (only the pre-existing 244 KiB bundle-size warnings).

## Test plan
- [x] new resolver test passes
- [x] reverse-verify: removing resolver -> test FAILS; restoring -> PASS
- [x] full vitest: only pre-existing native-binding failures (verified on origin/working)
- [x] `npm run build` clean