### PR TITLE
refactor(store): extract partitionSessionsForBackfill pure helper (Task #705)

### DIFF
--- a/src/stores/lib/sessionPartition.ts
+++ b/src/stores/lib/sessionPartition.ts
@@ -1,0 +1,31 @@
+import type { Session } from '../../types';
+
+// Default-name placeholders that backfill is allowed to overwrite. The store
+// always writes the English literal at create time; '新会话' is included
+// because older persisted snapshots from a Chinese-locale build (when
+// `createSession` briefly localized the name) may still carry it. Anything
+// else (user rename, prior backfill) is treated as authoritative.
+export const BACKFILL_DEFAULT_NAMES: ReadonlySet<string> = new Set<string>([
+  'New session',
+  '新会话',
+]);
+
+// Pure decider for `_backfillTitles`: groups sessions still using a default
+// name by their projectKey, so the action can issue ONE IPC call per project
+// instead of per session. projectKey encoding mirrors the CLI's
+// `~/.claude/projects/<key>/<sid>.jsonl` convention: every `\` `/` `:`
+// becomes `-`. Sessions with a non-default name or empty cwd are excluded.
+export function partitionSessionsForBackfill(
+  sessions: ReadonlyArray<Session>,
+): Map<string, string[]> {
+  const byProject = new Map<string, string[]>();
+  for (const s of sessions) {
+    if (!BACKFILL_DEFAULT_NAMES.has(s.name)) continue;
+    if (typeof s.cwd !== 'string' || s.cwd.length === 0) continue;
+    const key = s.cwd.replace(/[\\/:]/g, '-');
+    const list = byProject.get(key);
+    if (list) list.push(s.id);
+    else byProject.set(key, [s.id]);
+  }
+  return byProject;
+}

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import type { Group, Session } from '../types';
 import { loadPersisted, schedulePersist, PERSISTED_KEYS, type PersistedState, type PersistedKey } from './persist';
 import { hydrateDrafts, deleteDrafts, snapshotDraft, restoreDraft } from './drafts';
+import { partitionSessionsForBackfill, BACKFILL_DEFAULT_NAMES } from './lib/sessionPartition';
 import { i18next } from '../i18n';
 import type { ConnectionInfo } from '../shared/ipc-types';
 import { classifyPtyExit } from '../lib/ptyExitClassifier';
@@ -751,30 +752,7 @@ export const useStore = create<State & Actions>((set, get) => ({
         : undefined;
     if (!bridge || typeof bridge.listForProject !== 'function') return;
 
-    // Default-name placeholders to overwrite. The store always writes the
-    // English literal at create time (see `createSession`); '新会话' is
-    // included because older persisted snapshots from a Chinese-locale build
-    // (when `createSession` briefly localized the name) may still carry it.
-    // Anything else (user rename, prior backfill) is treated as authoritative
-    // and never touched.
-    const defaults = new Set<string>(['New session', '新会话']);
-
-    // Group sessions whose name is still default by their projectKey, so we
-    // make ONE IPC call per project (not per session). projectKey encoding
-    // mirrors the CLI's `~/.claude/projects/<key>/<sid>.jsonl` convention:
-    // every `\` `/` `:` becomes `-`. The canonical encoder lives in
-    // `electron/sessionWatcher/projectKey.ts`; we duplicate the trivial
-    // replace here rather than ship that module to the renderer bundle.
-    const byProject = new Map<string, string[]>();
-    const sessions = get().sessions;
-    for (const s of sessions) {
-      if (!defaults.has(s.name)) continue;
-      if (typeof s.cwd !== 'string' || s.cwd.length === 0) continue;
-      const key = s.cwd.replace(/[\\/:]/g, '-');
-      const list = byProject.get(key);
-      if (list) list.push(s.id);
-      else byProject.set(key, [s.id]);
-    }
+    const byProject = partitionSessionsForBackfill(get().sessions);
     if (byProject.size === 0) return;
 
     // Issue per-project lookups in parallel. Per-project errors are swallowed
@@ -804,7 +782,7 @@ export const useStore = create<State & Actions>((set, get) => ({
           // by the time we get here, in which case we leave it alone.
           if (typeof sum === 'string' && sum.length > 0) {
             const current = get().sessions.find((s) => s.id === sid);
-            if (current && defaults.has(current.name)) {
+            if (current && BACKFILL_DEFAULT_NAMES.has(current.name)) {
               apply(sid, sum);
             }
           }

--- a/tests/sessionPartition.test.ts
+++ b/tests/sessionPartition.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import type { Session } from '../src/types';
+import {
+  partitionSessionsForBackfill,
+  BACKFILL_DEFAULT_NAMES,
+} from '../src/stores/lib/sessionPartition';
+
+function makeSession(overrides: Partial<Session>): Session {
+  return {
+    id: 's',
+    name: 'New session',
+    state: 'idle',
+    cwd: 'C:/work/proj',
+    model: '',
+    groupId: 'g',
+    agentType: 'claude-code',
+    ...overrides,
+  };
+}
+
+describe('partitionSessionsForBackfill', () => {
+  it('returns an empty map for empty input', () => {
+    expect(partitionSessionsForBackfill([]).size).toBe(0);
+  });
+
+  it('keeps every default-named session and groups them by encoded cwd', () => {
+    const sessions: Session[] = [
+      makeSession({ id: 'a', cwd: 'C:/work/proj' }),
+      makeSession({ id: 'b', cwd: 'C:/work/proj' }),
+      makeSession({ id: 'c', name: '新会话', cwd: 'D:/other' }),
+    ];
+    const out = partitionSessionsForBackfill(sessions);
+    expect(out.size).toBe(2);
+    expect(out.get('C--work-proj')).toEqual(['a', 'b']);
+    expect(out.get('D--other')).toEqual(['c']);
+  });
+
+  it('drops sessions whose name is not a default placeholder', () => {
+    const sessions: Session[] = [
+      makeSession({ id: 'a', name: 'My renamed session' }),
+      makeSession({ id: 'b', name: 'Another' }),
+    ];
+    expect(partitionSessionsForBackfill(sessions).size).toBe(0);
+  });
+
+  it('drops sessions with empty or non-string cwd', () => {
+    const sessions: Session[] = [
+      makeSession({ id: 'a', cwd: '' }),
+      makeSession({ id: 'b', cwd: undefined as unknown as string }),
+    ];
+    expect(partitionSessionsForBackfill(sessions).size).toBe(0);
+  });
+
+  it('encodes backslashes, forward slashes, and colons to dashes', () => {
+    const sessions: Session[] = [
+      makeSession({ id: 'a', cwd: 'C:\\Users\\me\\proj' }),
+    ];
+    const out = partitionSessionsForBackfill(sessions);
+    expect(Array.from(out.keys())).toEqual(['C--Users-me-proj']);
+  });
+
+  it('mixes default and non-default sessions correctly', () => {
+    const sessions: Session[] = [
+      makeSession({ id: 'a', name: 'New session', cwd: '/x' }),
+      makeSession({ id: 'b', name: 'Renamed', cwd: '/x' }),
+      makeSession({ id: 'c', name: '新会话', cwd: '/x' }),
+    ];
+    const out = partitionSessionsForBackfill(sessions);
+    expect(out.get('-x')).toEqual(['a', 'c']);
+  });
+
+  it('exposes the default-name set used for filtering', () => {
+    expect(BACKFILL_DEFAULT_NAMES.has('New session')).toBe(true);
+    expect(BACKFILL_DEFAULT_NAMES.has('新会话')).toBe(true);
+    expect(BACKFILL_DEFAULT_NAMES.has('something else')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why
SRP Phase A for `src/stores/store.ts` (Task #705): the `_backfillTitles` Zustand action mixed three concerns (IPC bridge probe, default-name partition, rename application). The partition step is a pure decider — moving it to `src/stores/lib/sessionPartition.ts` lets it be unit-tested in isolation while the action keeps ownership of the side effects.

Per `feedback_single_responsibility.md`: producer / decider / sink. The action stays as the sink+orchestrator; the helper is the decider.

## Scope
- `src/stores/lib/sessionPartition.ts` (new, ~32 LoC) — `partitionSessionsForBackfill(sessions)` returns `Map<projectKey, sid[]>`, plus exported `BACKFILL_DEFAULT_NAMES` set.
- `src/stores/store.ts` — `_backfillTitles` now delegates to the helper. Net diff: -23 / +4 inside the action.
- `tests/sessionPartition.test.ts` (new) — 7 vitest cases.

### Note on signature
The task spec proposed `(sessions, now) => { stale, fresh }` keyed off `titleAt`. That field does not exist on `Session` (verified via grep) — `_backfillTitles` partitions by **default-name placeholder + valid cwd**, grouped by encoded projectKey. The helper signature follows the real partition logic rather than inventing a `titleAt` API. No other Phase A scope expansion.

## Reverse-verify (per `feedback_bug_fix_test_workflow.md`)

**Without `sessionPartition.ts` (file removed) → FAIL:**
```
 ❯ tests/sessionPartition.test.ts (0 test)
⎯⎯⎯ Failed Suites 1 ⎯⎯⎯
 FAIL  tests/sessionPartition.test.ts
Error: Failed to resolve import "../src/stores/lib/sessionPartition" from "tests/sessionPartition.test.ts". Does the file exist?
 Test Files  1 failed (1)
      Tests  no tests
```

**With `sessionPartition.ts` restored → PASS:**
```
 ✓ tests/sessionPartition.test.ts (7 tests) 6ms
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

## Vitest output (full suite)
```
Test Files  1 failed | 51 passed (52)
     Tests  3 failed | 480 passed (483)
```
The 3 failures are all in `electron/__tests__/db-hardening.test.ts` due to a pre-existing `better-sqlite3` `NODE_MODULE_VERSION` ABI mismatch in the env (Node 24 vs build target 137). Unrelated to this refactor — same failures exist on `origin/working` HEAD without these changes. All 480 non-db tests pass, including the 7 new ones.

## Build + smoke
- `npm run build` → tsc + webpack clean (only standard bundle-size warnings).
- `node -e "require('./dist/electron/main.js')"` → loads through to runtime; expected non-Electron Sentry runtime error (no syntax/import error from this PR).

## Out of scope (Phase B)
`createSession` extraction is Task #706, dispatched in parallel in pool-7. This PR does not touch it.