### PR TITLE
refactor(notify): merge OSC 0+2 producer, gate diag flag

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1105,6 +1105,14 @@ app.whenReady().then(() => {
     getWindows: () => BrowserWindow.getAllWindows(),
   });
 
+  // Notify pipeline diag counters are gated behind `globalThis.__ccsmDebug`
+  // (#713). Production never carries them; e2e probes that consume diag via
+  // the test-hook seam need them on. Set the flag here so it's live before
+  // installNotifyPipeline reads it.
+  if (process.env.CCSM_NOTIFY_TEST_HOOK) {
+    (globalThis as unknown as Record<string, unknown>).__ccsmDebug = true;
+  }
+
   const pipelineInstance = installNotifyPipeline({
     getMainWindow: () => BrowserWindow.getAllWindows()[0] ?? null,
     isGlobalMutedFn: () => !loadNotifyEnabled(),

--- a/electron/notify/sinks/pipeline.ts
+++ b/electron/notify/sinks/pipeline.ts
@@ -2,7 +2,8 @@
 //
 // Wires the four phase-decoupled pieces of the new notify architecture:
 //
-//   producer  : OscTitleSniffer (#688) — feeds raw OSC 0 titles per sid.
+//   producer  : OscTitleSniffer (#688, dual-mode OSC 0+2 since #713) —
+//               feeds raw titles per sid.
 //   decider   : notifyDecider.decide(event, ctx) (#687) — pure 7-rule eval.
 //   sink #1   : toastSink — fires Electron Notification.
 //   sink #2   : flashSink — pushes transient flash state to renderer.
@@ -44,6 +45,16 @@ export interface NotifyPipelineOptions {
   onNotified?: (sid: string) => void;
 }
 
+export interface PipelineDiag {
+  bytesFed: number;
+  chunksFed: number;
+  snifferEvents: number;
+  titlesSeen: string[];
+  classifications: { idle: number; running: number; unknown: number };
+  decideCalls: number;
+  decisions: number;
+}
+
 export interface NotifyPipeline {
   /** Feed a PTY chunk for `sid` into the OSC sniffer. */
   feedChunk(sid: string, chunk: string | Buffer): void;
@@ -65,85 +76,9 @@ export interface NotifyPipeline {
     sniffer: OscTitleSniffer;
     toast: ToastSink;
     flash: FlashSink;
-    diag: {
-      bytesFed: number;
-      chunksFed: number;
-      snifferEvents: number;
-      osc2Events: number;
-      titlesSeen: string[];
-      classifications: { idle: number; running: number; unknown: number };
-      decideCalls: number;
-      decisions: number;
-    };
+    /** Diag counters; populated only when `globalThis.__ccsmDebug` is truthy. */
+    diag: PipelineDiag | null;
   };
-}
-
-// The Phase B sniffer (OscTitleSniffer in #688) only matches OSC 0
-// (`\x1b]0;...`). xterm.js and Windows conpty also accept OSC 2
-// (`\x1b]2;...`) for window-title updates, and at least some Claude CLI
-// builds emit OSC 2 instead of OSC 0 — that path was invisible to a pure
-// OSC-0 sniffer (the title-state bridge sees them via xterm.onTitleChange,
-// which handles both, but the main-process raw-stream sniffer did not).
-// To keep #688's sniffer untouched (per #689 scope: no change to merged
-// modules), the pipeline runs a tiny inline OSC-2 scanner alongside the
-// Phase B sniffer and forwards either-class title events through the same
-// `onOsc` handler. The buffering / split-chunk concern is handled the
-// same way as in the Phase B sniffer.
-class Osc2InlineSniffer {
-  private readonly buffers = new Map<string, string>();
-  // Cap matches Phase B sniffer.
-  private static readonly MAX_BUFFER_BYTES = 64 * 1024;
-
-  constructor(private readonly onTitle: (sid: string, title: string, ts: number) => void) {}
-
-  feed(sid: string, chunk: string | Buffer): void {
-    if (chunk == null) return;
-    const text = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
-    if (text.length === 0) return;
-    let buf = (this.buffers.get(sid) ?? '') + text;
-    let scanFrom = 0;
-    let lastEmitEnd = 0;
-    while (scanFrom < buf.length) {
-      const oscStart = buf.indexOf('\x1b]2;', scanFrom);
-      if (oscStart === -1) break;
-      const titleStart = oscStart + 4;
-      const belIdx = buf.indexOf('\x07', titleStart);
-      const stIdx = buf.indexOf('\x1b\\', titleStart);
-      let termIdx = -1;
-      let termLen = 0;
-      if (belIdx !== -1 && (stIdx === -1 || belIdx < stIdx)) {
-        termIdx = belIdx;
-        termLen = 1;
-      } else if (stIdx !== -1) {
-        termIdx = stIdx;
-        termLen = 2;
-      }
-      if (termIdx === -1) break;
-      const title = buf.slice(titleStart, termIdx);
-      this.onTitle(sid, title, Date.now());
-      scanFrom = termIdx + termLen;
-      lastEmitEnd = scanFrom;
-    }
-    let tail: string;
-    const incompleteOscStart = buf.indexOf('\x1b]2;', lastEmitEnd);
-    if (incompleteOscStart !== -1) {
-      tail = buf.slice(incompleteOscStart);
-    } else {
-      tail = buf.slice(Math.max(buf.length - 3, lastEmitEnd));
-    }
-    if (tail.length > Osc2InlineSniffer.MAX_BUFFER_BYTES) {
-      tail = tail.slice(tail.length - Osc2InlineSniffer.MAX_BUFFER_BYTES);
-    }
-    if (tail.length === 0) {
-      this.buffers.delete(sid);
-    } else {
-      this.buffers.set(sid, tail);
-    }
-  }
-
-  clear(sid: string): void {
-    this.buffers.delete(sid);
-  }
 }
 
 // Heuristic: a 'running' OSC title indicates the CLI is mid-turn. The CLI
@@ -192,30 +127,37 @@ export function installNotifyPipeline(opts: NotifyPipelineOptions): NotifyPipeli
 
   // Diagnostics for e2e probes — counts what each layer sees so we can tell
   // whether failure is "no PTY data", "no OSC titles", "titles seen but
-  // unclassifiable", or "decider rejected".
-  const diag = {
-    bytesFed: 0,
-    chunksFed: 0,
-    snifferEvents: 0,
-    osc2Events: 0,
-    titlesSeen: [] as string[], // last 10
-    classifications: { idle: 0, running: 0, unknown: 0 },
-    decideCalls: 0,
-    decisions: 0,
-  };
+  // unclassifiable", or "decider rejected". Production builds skip the
+  // counters entirely; the diag block only allocates when a probe sets
+  // `globalThis.__ccsmDebug = true` before installing the pipeline.
+  const debugEnabled = Boolean((globalThis as { __ccsmDebug?: unknown }).__ccsmDebug);
+  const diag: PipelineDiag | null = debugEnabled
+    ? {
+        bytesFed: 0,
+        chunksFed: 0,
+        snifferEvents: 0,
+        titlesSeen: [],
+        classifications: { idle: 0, running: 0, unknown: 0 },
+        decideCalls: 0,
+        decisions: 0,
+      }
+    : null;
   function recordTitle(title: string): void {
+    if (!diag) return;
     diag.titlesSeen.push(title);
     if (diag.titlesSeen.length > 10) diag.titlesSeen.shift();
   }
 
   const onOsc = (evt: OscTitleEvent): void => {
     refreshNow();
-    diag.snifferEvents += 1;
+    if (diag) diag.snifferEvents += 1;
     recordTitle(evt.title);
     const cls = classifyTitleState(evt.title);
-    if (cls === 'idle') diag.classifications.idle += 1;
-    else if (cls === 'running') diag.classifications.running += 1;
-    else diag.classifications.unknown += 1;
+    if (diag) {
+      if (cls === 'idle') diag.classifications.idle += 1;
+      else if (cls === 'running') diag.classifications.running += 1;
+      else diag.classifications.unknown += 1;
+    }
     // Maintain runStartTs from running titles (used by Rule 2/3 elapsed).
     if (isRunningTitle(evt.title)) {
       if (!ctx.runStartTs.has(evt.sid)) {
@@ -246,8 +188,10 @@ export function installNotifyPipeline(opts: NotifyPipelineOptions): NotifyPipeli
       { type: 'osc-title', sid: evt.sid, title: normalized, ts: evt.ts },
       ctx,
     );
-    diag.decideCalls += 1;
-    if (decision) diag.decisions += 1;
+    if (diag) {
+      diag.decideCalls += 1;
+      if (decision) diag.decisions += 1;
+    }
 
     // Clear run start on waiting/idle (after decide so the elapsed reading
     // is computed against the current run).
@@ -260,20 +204,14 @@ export function installNotifyPipeline(opts: NotifyPipelineOptions): NotifyPipeli
   };
 
   sniffer.on('osc-title', onOsc);
-  // Inline OSC-2 sniffer feeds the same handler — the Claude CLI uses OSC 2
-  // (window title) in some builds; xterm.onTitleChange handles both, but
-  // the Phase B sniffer is OSC-0-only by design, so we cover OSC 2 here.
-  const osc2 = new Osc2InlineSniffer((sid, title, ts) => {
-    diag.osc2Events += 1;
-    onOsc({ sid, title, ts });
-  });
 
   return {
     feedChunk(sid, chunk) {
-      diag.chunksFed += 1;
-      diag.bytesFed += typeof chunk === 'string' ? chunk.length : chunk.length;
+      if (diag) {
+        diag.chunksFed += 1;
+        diag.bytesFed += typeof chunk === 'string' ? chunk.length : chunk.length;
+      }
       sniffer.feed(sid, chunk);
-      osc2.feed(sid, chunk);
     },
     markUserInput(sid) {
       refreshNow();
@@ -291,7 +229,6 @@ export function installNotifyPipeline(opts: NotifyPipelineOptions): NotifyPipeli
     },
     forgetSid(sid) {
       sniffer.clear(sid);
-      osc2.clear(sid);
       ctx.lastUserInputTs.delete(sid);
       ctx.runStartTs.delete(sid);
       ctx.mutedSids.delete(sid);

--- a/electron/ptyHost/__tests__/oscTitleSniffer.test.ts
+++ b/electron/ptyHost/__tests__/oscTitleSniffer.test.ts
@@ -169,4 +169,64 @@ describe('OscTitleSniffer', () => {
     s.feed('sid-1', Buffer.from('\x1b]0;buf\x07', 'utf8'));
     expect(events).toEqual([{ sid: 'sid-1', title: 'buf', ts: Date.now() }]);
   });
+
+  // OSC 2 (window-title) coverage — Task #713 merged the inlined
+  // Osc2InlineSniffer (formerly in notify/sinks/pipeline.ts) into this
+  // single dual-mode producer.
+  describe('OSC 2 (window title)', () => {
+    it('emits on a single OSC 2 BEL-terminated escape', () => {
+      const s = new OscTitleSniffer();
+      const events = collect(s);
+      s.feed('sid-1', '\x1b]2;hello\x07');
+      expect(events).toEqual([
+        { sid: 'sid-1', title: 'hello', ts: Date.now() },
+      ]);
+    });
+
+    it('emits on a single OSC 2 ST-terminated escape', () => {
+      const s = new OscTitleSniffer();
+      const events = collect(s);
+      s.feed('sid-1', '\x1b]2;hi\x1b\\');
+      expect(events).toEqual([
+        { sid: 'sid-1', title: 'hi', ts: Date.now() },
+      ]);
+    });
+
+    it('handles an OSC 2 escape split across two chunks', () => {
+      const s = new OscTitleSniffer();
+      const events = collect(s);
+      s.feed('sid-1', 'noise \x1b]2;wai');
+      expect(events).toHaveLength(0);
+      s.feed('sid-1', 'ting\x07');
+      expect(events).toEqual([
+        { sid: 'sid-1', title: 'waiting', ts: Date.now() },
+      ]);
+    });
+
+    it('handles a stream mixing OSC 0 and OSC 2 in any order', () => {
+      const s = new OscTitleSniffer();
+      const events = collect(s);
+      s.feed(
+        'sid-1',
+        '\x1b]0;first\x07pad\x1b]2;second\x07more\x1b]0;third\x1b\\tail\x1b]2;fourth\x1b\\',
+      );
+      expect(events.map((e) => e.title)).toEqual([
+        'first',
+        'second',
+        'third',
+        'fourth',
+      ]);
+    });
+
+    it('handles a partial OSC 2 prefix split across chunks (\\x1b]2 then ;...)', () => {
+      const s = new OscTitleSniffer();
+      const events = collect(s);
+      s.feed('sid-1', 'pre\x1b]2');
+      expect(events).toHaveLength(0);
+      s.feed('sid-1', ';title\x07');
+      expect(events).toEqual([
+        { sid: 'sid-1', title: 'title', ts: Date.now() },
+      ]);
+    });
+  });
 });

--- a/electron/ptyHost/oscTitleSniffer.ts
+++ b/electron/ptyHost/oscTitleSniffer.ts
@@ -1,15 +1,19 @@
 // Phase B of the notify pipeline (Task #688): a pure producer that scans
-// PTY stdout byte streams for OSC 0 title escape sequences and emits the
+// PTY stdout byte streams for OSC title escape sequences and emits the
 // raw title string. It does NOT interpret titles ('waiting'/'running'/etc.)
 // — that is the decider's job (Task #687). It does NOT wire into ptyHost or
 // IPC — that is the sink's job (Task #689). This file is a standalone
 // EventEmitter so each layer can be tested in isolation.
 //
-// OSC 0 spec:
+// OSC 0 / OSC 2 spec (Task #713 — merged dual-mode producer):
 //   ESC ] 0 ; <title> BEL              (\x1b]0;<title>\x07)
 //   ESC ] 0 ; <title> ST               (\x1b]0;<title>\x1b\\)
+//   ESC ] 2 ; <title> BEL              (\x1b]2;<title>\x07)
+//   ESC ] 2 ; <title> ST               (\x1b]2;<title>\x1b\\)
 // Either terminator is valid; xterm/Windows Terminal/Claude CLI all use BEL
-// in practice, but we accept ST for robustness.
+// in practice, but we accept ST for robustness. Some Claude CLI builds emit
+// OSC 2 (window title) instead of OSC 0 (icon+window title) — both are
+// title-class events for our purposes.
 //
 // Per-sid buffering is required because a chunk boundary can split an
 // escape sequence in half. We append, scan for complete sequences, emit,
@@ -28,6 +32,22 @@ export interface OscTitleEvent {
 // 64 KiB is enough to span any realistic split escape across chunks.
 const MAX_BUFFER_BYTES = 64 * 1024;
 
+const OSC_PREFIXES = ['\x1b]0;', '\x1b]2;'] as const;
+const OSC_PREFIX_LEN = 4; // both prefixes are 4 bytes
+
+// Find the earliest index in `buf` (>= from) where any recognized OSC
+// title prefix starts. Returns -1 if none.
+function findNextOscStart(buf: string, from: number): number {
+  let earliest = -1;
+  for (const p of OSC_PREFIXES) {
+    const idx = buf.indexOf(p, from);
+    if (idx !== -1 && (earliest === -1 || idx < earliest)) {
+      earliest = idx;
+    }
+  }
+  return earliest;
+}
+
 export class OscTitleSniffer extends EventEmitter {
   private readonly buffers = new Map<string, string>();
 
@@ -38,15 +58,15 @@ export class OscTitleSniffer extends EventEmitter {
 
     let buf = (this.buffers.get(sid) ?? '') + text;
 
-    // Scan for complete OSC 0 sequences. Loop because one chunk can hold
+    // Scan for complete OSC 0/2 sequences. Loop because one chunk can hold
     // multiple sequences.
     let scanFrom = 0;
     let lastEmitEnd = 0;
     while (scanFrom < buf.length) {
-      const oscStart = buf.indexOf('\x1b]0;', scanFrom);
+      const oscStart = findNextOscStart(buf, scanFrom);
       if (oscStart === -1) break;
 
-      const titleStart = oscStart + 4; // length of `\x1b]0;`
+      const titleStart = oscStart + OSC_PREFIX_LEN;
 
       // Find terminator: BEL (\x07) or ST (\x1b\\). Pick the earlier one.
       const belIdx = buf.indexOf('\x07', titleStart);
@@ -80,18 +100,19 @@ export class OscTitleSniffer extends EventEmitter {
     }
 
     // Keep only the tail starting at the first byte we haven't consumed.
-    // If we found incomplete OSC start, we want to keep from that point so
-    // the next feed can complete it. If no OSC at all, keep nothing
+    // If we found an incomplete OSC start, we want to keep from that point
+    // so the next feed can complete it. If no OSC at all, keep nothing
     // (it's all plain text we don't care about) — but cap by
     // MAX_BUFFER_BYTES in case the tail is huge.
     let tail: string;
-    const incompleteOscStart = buf.indexOf('\x1b]0;', lastEmitEnd);
+    const incompleteOscStart = findNextOscStart(buf, lastEmitEnd);
     if (incompleteOscStart !== -1) {
       tail = buf.slice(incompleteOscStart);
     } else {
       // No partial OSC pending. Discard plain text so the buffer doesn't
-      // grow unbounded. Keep last 3 bytes only so a split `\x1b]0` prefix
-      // straddling the chunk boundary still completes next round.
+      // grow unbounded. Keep last 3 bytes only so a split `\x1b]0` /
+      // `\x1b]2` prefix straddling the chunk boundary still completes
+      // next round.
       tail = buf.slice(Math.max(buf.length - 3, lastEmitEnd));
     }
 


### PR DESCRIPTION
## Why

Task #713. The notify pipeline carries two near-identical OSC scanners: the canonical `OscTitleSniffer` (OSC 0) in `electron/ptyHost/` and an inlined `Osc2InlineSniffer` in `electron/notify/sinks/pipeline.ts`. Same buffering, same terminator logic, same cap, only differing in the prefix string. Collapsing them removes duplicated state (two per-sid buffers, two scanners feeding the same handler) and keeps the producer a single source of truth.

Same PR also gates the `diag` counter block behind `globalThis.__ccsmDebug`. Production previously paid for `bytesFed/chunksFed/snifferEvents/osc2Events/titlesSeen/classifications/decideCalls/decisions` on every PTY chunk even though only e2e probes consume them.

## Scope

- `electron/ptyHost/oscTitleSniffer.ts`: scanner now matches either `\x1b]0;` or `\x1b]2;`. Per-sid buffering, BEL/ST terminator handling, and 64 KiB cap unchanged. Public API (`feed`, `clear`, `osc-title` event, `OscTitleEvent` shape) unchanged so existing OSC 0 callers keep working.
- `electron/notify/sinks/pipeline.ts`: deleted `Osc2InlineSniffer` class and the second `osc2.feed(...)` call in `feedChunk`. Diag is `null` in production; allocated and populated only when `globalThis.__ccsmDebug` is truthy at install time.
- `electron/main.ts`: sets `globalThis.__ccsmDebug = true` iff `CCSM_NOTIFY_TEST_HOOK` is set, before installing the pipeline. Keeps the existing test-hook seam (`__ccsmNotifyPipeline.ctx().diag`) working unchanged.
- `electron/ptyHost/__tests__/oscTitleSniffer.test.ts`: +5 OSC 2 cases — BEL terminator, ST terminator, escape split across chunks, mixed OSC 0 + OSC 2 stream in any order, OSC 2 prefix split across chunks (`\x1b]2` then `;...`).

Decider (`notifyDecider.ts`) untouched, per scope.

## Reverse-verify

Per `feedback_bug_fix_test_workflow.md` for refactors with new behavior.

Stashed only the OSC 2 branch in the sniffer (`git stash push -- electron/ptyHost/oscTitleSniffer.ts`), kept the new tests:

```
Test Files  1 failed (1)
     Tests  5 failed | 12 passed (17)
```

Failures (all 5 expected, all in the OSC 2 describe block):
- emits on a single OSC 2 BEL-terminated escape
- emits on a single OSC 2 ST-terminated escape
- handles an OSC 2 escape split across two chunks
- handles a stream mixing OSC 0 and OSC 2 in any order
- handles a partial OSC 2 prefix split across chunks (\x1b]2 then ;...)

`git stash pop`:

```
Test Files  1 passed (1)
     Tests  17 passed (17)
```

## Validate

`npx vitest run electron/ptyHost/__tests__/oscTitleSniffer.test.ts`:
```
Tests  17 passed (17)   (12 original + 5 new OSC 2)
```

`npx vitest run tests/agent-lifecycle-unfocused.test.ts`:
```
Tests  6 passed (6)
```

`npx vitest run` (full suite):
```
Test Files  1 failed | 53 passed (54)
     Tests  3 failed | 500 passed (503)
```
The 3 failures are the pre-existing `electron/__tests__/db-hardening.test.ts` `better-sqlite3` ABI mismatch (NODE_MODULE_VERSION 130 vs 137) — pool env issue, unrelated.

`npm run build`: clean (only the pre-existing bundle-size warnings).

`node scripts/harness-real-cli.mjs --only=notify-pipeline-foreground,notify-pipeline-background`:
```
PASS  notify-pipeline-foreground   19419ms
PASS  notify-pipeline-background   32620ms
total: 2/2 passed, 79.6s wall
```