### PR TITLE
fix(notify): setActive does not count as user input (Rule 1)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1023,14 +1023,14 @@ app.whenReady().then(() => {
     if (!fromMainFrame(e)) return;
     activeSidFromRenderer = typeof sid === 'string' && sid.length > 0 ? sid : null;
     badgeController.onFocusChange({ focused: isMainWindowFocused(), activeSid: activeSidFromRenderer });
-    // Notify pipeline (Phase C, #689) — keep ctx.activeSid in sync, and
-    // count the switch as a user-touch on that sid (Rule 1: 60s mute window
-    // after the user just acted on this session). The pipeline ignores
-    // null sid in setActiveSid; markUserInput skips empty sid implicitly.
+    // Notify pipeline (Phase C, #689) — keep ctx.activeSid in sync. Do NOT
+    // count a sidebar switch as user input: clicking a session in the
+    // sidebar is a navigation gesture, not user-typed input, and feeding
+    // it into Rule 1 would mute legitimate idle/waiting toasts for 60s
+    // every time the user merely opens the session (#715). Real user
+    // input is signalled separately via the `notify:userInput` IPC
+    // (PTY input + send-message + new/import/resume).
     notifyPipeline?.setActiveSid(activeSidFromRenderer);
-    if (activeSidFromRenderer) {
-      notifyPipeline?.markUserInput(activeSidFromRenderer);
-    }
   });
 
   // Explicit "user touched this session" IPC — fired by the renderer on
@@ -1166,15 +1166,6 @@ app.whenReady().then(() => {
         };
       },
       markUserInput: (sid: string) => pipelineInstance.markUserInput(sid),
-      // Test-only — wipe Rule-1 user-init mute by clearing lastUserInputTs.
-      // Probes need this to deterministically observe Rule-3 firing inside
-      // the 60s window (the implicit `setActive`+`markUserInput` from the
-      // probe's own session bookkeeping otherwise suppresses every event).
-      clearUserInput: (sid?: string) => {
-        const i = pipelineInstance._internals();
-        if (sid) i.ctx.lastUserInputTs.delete(sid);
-        else i.ctx.lastUserInputTs.clear();
-      },
     };
   }
 

--- a/scripts/harness-real-cli.mjs
+++ b/scripts/harness-real-cli.mjs
@@ -2937,9 +2937,11 @@ async function caseNotifyNameClearedOnSessionDelete({ electronApp, win, tempDir 
 //   * the flash signal reaches the renderer (`window.__ccsmFlashStates[sid]
 //     === 'flashing'` after the OSC waiting transition).
 //
-// To deterministically clear Rule 1 mute we use the `__ccsmNotifyPipeline`
-// debug seam to overwrite `lastUserInputTs` with a stale timestamp before
-// triggering the response, so the decider falls through to Rule 3.
+// To deterministically observe Rule 3 firing within 60s of session creation
+// we relied on a `clearUserInput` test seam to wipe `lastUserInputTs`. After
+// the #715 fix `session:setActive` no longer counts as user input, so the
+// implicit setActive plumbing the probe triggers no longer mutes Rule 3 —
+// the seam is gone and these probes run unaided.
 
 async function caseNotifyPipelineForeground({ electronApp, win, tempDir }) {
   await win.waitForFunction(
@@ -2966,9 +2968,8 @@ async function caseNotifyPipelineForeground({ electronApp, win, tempDir }) {
   await dismissFirstRunModals(win);
 
   // Foreground active-sid state — Rule 3 (foreground+active+long task) is
-  // the target. We push the OSC-waiting trigger by sending a real prompt;
-  // to make Rule 3 win over Rule 1 (60s post-user-input mute) we age out
-  // lastUserInputTs via the debug seam by clearing the map entirely.
+  // the target. After #715, setActive no longer feeds Rule 1's
+  // `lastUserInputTs`, so the next idle title lands on Rule 3 directly.
   await win.evaluate((s) => {
     const bridge = window.ccsmSession;
     if (bridge && typeof bridge.setActive === 'function') bridge.setActive(s);
@@ -2979,15 +2980,7 @@ async function caseNotifyPipelineForeground({ electronApp, win, tempDir }) {
   await sleep(300);
   await sendToClaudeTui(win, '\r');
 
-  // Clear Rule-1 user-init mute via the test seam so the next idle title
-  // event lands on Rule 3 (foreground+active+long) instead of being
-  // suppressed by the 60s post-user-input window. The CLI is mid-run at
-  // this point; clearing now is safe — the decider only consults
-  // lastUserInputTs at decision time (when the idle title arrives).
   await sleep(800);
-  await electronApp.evaluate(() => {
-    globalThis.__ccsmNotifyPipeline?.clearUserInput?.();
-  });
 
   // Poll the pipeline log for any entry on this sid. Up to 180s.
   const start = Date.now();
@@ -3084,14 +3077,6 @@ async function caseNotifyPipelineBackground({ electronApp, win, tempDir }) {
     if (bridge && typeof bridge.setActive === 'function') bridge.setActive(s);
   }, sidA);
   await sleep(500);
-
-  // Clear Rule-1 user-init mute via the test seam so B's idle title fires
-  // Rule 4 (foreground+other-sid) instead of being suppressed by the 60s
-  // post-user-input window. Both A and B accumulate lastUserInputTs from
-  // the seedSession setActive plumbing.
-  await electronApp.evaluate(() => {
-    globalThis.__ccsmNotifyPipeline?.clearUserInput?.();
-  });
 
   // Poll up to 180s for a B-sid toast OR flash.
   const start = Date.now();


### PR DESCRIPTION
## Why (production correctness, not just test ergonomics)

`session:setActive` is fired by the renderer on every sidebar click and on activate-on-toast-click. The IPC handler in `electron/main.ts` was calling `notifyPipeline.markUserInput()` in addition to `setActiveSid()`, so opening a session via the sidebar fed Rule 1's `lastUserInputTs` map and muted every idle/waiting toast for that sid for the next 60s. That is the wrong semantic — sidebar selection is a navigation gesture, not user input.

Real user input is already surfaced through the dedicated `notify:userInput` IPC (PTY input + send-message + new/import/resume), which is the correct and only signal Rule 1 should consume.

## Scope

- `electron/main.ts` — `session:setActive` no longer calls `markUserInput`. `setActiveSid` is still mirrored.
- `electron/main.ts` — removed the `__ccsmNotifyPipeline.clearUserInput` test seam. It existed only to work around the bug (probes had to wipe `lastUserInputTs` so Rule 3 could fire within the 60s window).
- `scripts/harness-real-cli.mjs` — removed the two `clearUserInput()` calls in `notify-pipeline-foreground` and `notify-pipeline-background`. Updated the case-header comment.
- No decider changes. `notifyPipeline.markUserInput` itself is unchanged.

## Reverse-verify (the meaningful one for this fix)

The fix-only flip: with the production fix in place but harness `clearUserInput` calls already removed, the e2e PASSES. With the production fix temporarily reverted (setActive bumps `lastUserInputTs` again) and harness changes kept, the e2e FAILS — exactly because Rule 1 mutes Rule 3.

**Reverted main.ts (bug restored), harness changes kept:**
```
[HARNESS] >>> case: notify-pipeline-foreground
[HARNESS] <<< FAIL notify-pipeline-foreground (198314ms): pipeline never fired for sid=943c7b67-... within 180s.
  Diag: lastUserInputTs={"943c7b67-...":1777475873315}, decideCalls:2, decisions:0

[HARNESS] >>> case: notify-pipeline-background
[HARNESS] <<< FAIL notify-pipeline-background (211815ms): pipeline never fired for background sid=8e12b1c8-... within 180s.
  Diag: lastUserInputTs={A,B,...}, decideCalls:5, decisions:0

  FAIL  notify-pipeline-foreground         198314ms
  FAIL  notify-pipeline-background         211815ms
  total: 0/2 passed
```

`decideCalls > 0, decisions = 0` is the signature: the decider is being called on idle titles but every call falls into Rule 1 (60s post-input mute) because `lastUserInputTs` is populated by the setActive plumbing.

**Fix re-applied:**
```
[HARNESS] >>> case: notify-pipeline-foreground
[HARNESS]   pipeline fg fired: toast=false flash=true
[HARNESS] <<< PASS notify-pipeline-foreground (19435ms)

[HARNESS] >>> case: notify-pipeline-background
[HARNESS]   pipeline bg fired for B: toast=true flash=true; A toasts=0
[HARNESS] <<< PASS notify-pipeline-background (32620ms)

  PASS  notify-pipeline-foreground         19435ms
  PASS  notify-pipeline-background         32620ms
  total: 2/2 passed, 61.0s wall
```

## vitest

```
$ npx vitest run tests/agent-lifecycle-unfocused.test.ts
 ✓ tests/agent-lifecycle-unfocused.test.ts (6 tests) 5ms
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

(No new pipeline UT — the bug lives in `main.ts` IPC wiring, not in `notifyDecider` or `pipeline.ts`. The decider's existing `lastUserInputTs`/Rule 1 unit coverage stays valid; the e2e probes are the meaningful regression guard for the wiring.)

## Build

```
webpack 5.106.2 compiled with 3 warnings (asset-size only) in 18240 ms
```

Refs Task #715.