### PR TITLE
refactor(badge): extract pure badgePixels + badgeLabel helpers (Task #722 Phase A)

### DIFF
--- a/electron/notify/badgeLabel.ts
+++ b/electron/notify/badgeLabel.ts
@@ -1,0 +1,15 @@
+// Pure label decider for the unread badge.
+//
+// Display rule (preserved verbatim from electron/notify/badge.ts):
+//   * n <= 0      -> ''     (no badge)
+//   * 1 <= n <= 9 -> '<n>'
+//   * n >= 10     -> '9+'
+//
+// Phase A of Task #722: this duplicates `badgeLabel` from badge.ts. Phase B
+// will switch the import in badge.ts and delete the original.
+
+export function badgeLabel(n: number): string {
+  if (n <= 0) return '';
+  if (n >= 10) return '9+';
+  return String(n);
+}

--- a/electron/notify/badgePixels.ts
+++ b/electron/notify/badgePixels.ts
@@ -1,0 +1,275 @@
+// Pure pixel rendering for the unread badge.
+//
+// This module is intentionally free of any `electron` import so it can be
+// unit-tested in plain Node and so the pixel logic stays a pure
+// (input -> bytes) sink. Callers in the Electron main process wrap the
+// returned RGBA buffers via `nativeImage.createFromBuffer`.
+//
+// Output buffers are tightly packed RGBA (4 bytes per pixel, row-major,
+// origin at top-left), suitable for `nativeImage.createFromBuffer({ width,
+// height })`.
+//
+// Phase A of Task #722: this is a copy of the pixel helpers currently in
+// `electron/notify/badge.ts`. badge.ts is unchanged in this PR; Phase B
+// will switch the import and delete the originals.
+
+export interface RgbaBitmap {
+  buffer: Buffer;
+  width: number;
+  height: number;
+}
+
+export interface BgraBitmap {
+  // Raw bitmap as returned by Electron's `NativeImage.toBitmap()`, which is
+  // BGRA on every platform we ship. Caller is responsible for sizing.
+  buffer: Buffer;
+  width: number;
+  height: number;
+}
+
+// 3x5 bitmap font for digits + '+'. Each glyph is 5 rows of 3 columns.
+// 1 = ink, 0 = transparent.
+export const GLYPHS: Record<string, number[][]> = {
+  '0': [
+    [1, 1, 1],
+    [1, 0, 1],
+    [1, 0, 1],
+    [1, 0, 1],
+    [1, 1, 1],
+  ],
+  '1': [
+    [0, 1, 0],
+    [1, 1, 0],
+    [0, 1, 0],
+    [0, 1, 0],
+    [1, 1, 1],
+  ],
+  '2': [
+    [1, 1, 1],
+    [0, 0, 1],
+    [1, 1, 1],
+    [1, 0, 0],
+    [1, 1, 1],
+  ],
+  '3': [
+    [1, 1, 1],
+    [0, 0, 1],
+    [0, 1, 1],
+    [0, 0, 1],
+    [1, 1, 1],
+  ],
+  '4': [
+    [1, 0, 1],
+    [1, 0, 1],
+    [1, 1, 1],
+    [0, 0, 1],
+    [0, 0, 1],
+  ],
+  '5': [
+    [1, 1, 1],
+    [1, 0, 0],
+    [1, 1, 1],
+    [0, 0, 1],
+    [1, 1, 1],
+  ],
+  '6': [
+    [1, 1, 1],
+    [1, 0, 0],
+    [1, 1, 1],
+    [1, 0, 1],
+    [1, 1, 1],
+  ],
+  '7': [
+    [1, 1, 1],
+    [0, 0, 1],
+    [0, 1, 0],
+    [0, 1, 0],
+    [0, 1, 0],
+  ],
+  '8': [
+    [1, 1, 1],
+    [1, 0, 1],
+    [1, 1, 1],
+    [1, 0, 1],
+    [1, 1, 1],
+  ],
+  '9': [
+    [1, 1, 1],
+    [1, 0, 1],
+    [1, 1, 1],
+    [0, 0, 1],
+    [1, 1, 1],
+  ],
+  '+': [
+    [0, 0, 0],
+    [0, 1, 0],
+    [1, 1, 1],
+    [0, 1, 0],
+    [0, 0, 0],
+  ],
+};
+
+export const GLYPH_W = 3;
+export const GLYPH_H = 5;
+
+export interface Rgba {
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+}
+
+export const RED: Rgba = { r: 0xdc, g: 0x26, b: 0x26, a: 0xff };
+export const WHITE: Rgba = { r: 0xff, g: 0xff, b: 0xff, a: 0xff };
+export const TRANSPARENT: Rgba = { r: 0, g: 0, b: 0, a: 0 };
+
+// Renders an unread-badge as a square RGBA bitmap.
+// Red filled circle background; white digit(s) centered on top.
+export function renderBadgeImage(label: string, size: number): RgbaBitmap {
+  const buf = Buffer.alloc(size * size * 4);
+  fillCircle(buf, size, RED);
+  drawLabel(buf, size, label, WHITE);
+  return { buffer: buf, width: size, height: size };
+}
+
+// Composites the badge onto the bottom-right corner of a square base bitmap.
+// `base` is taken as a raw BGRA bitmap (the format Electron's
+// `NativeImage.toBitmap()` returns); the output is RGBA.
+export function compositeTrayImage(
+  base: BgraBitmap,
+  label: string,
+  size: number,
+): RgbaBitmap {
+  const baseBuf = base.buffer;
+  const baseSize = { width: base.width, height: base.height };
+  const buf = Buffer.alloc(size * size * 4);
+
+  // Copy base (resize-fit if base isn't already the target size — simple
+  // nearest-neighbour, since the placeholder base is 16x16 too).
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const sx = Math.floor((x * baseSize.width) / size);
+      const sy = Math.floor((y * baseSize.height) / size);
+      const si = (sy * baseSize.width + sx) * 4;
+      const di = (y * size + x) * 4;
+      // Electron's toBitmap is BGRA on every platform we care about.
+      buf[di + 0] = baseBuf[si + 2];
+      buf[di + 1] = baseBuf[si + 1];
+      buf[di + 2] = baseBuf[si + 0];
+      buf[di + 3] = baseBuf[si + 3];
+    }
+  }
+
+  // Badge takes the bottom-right ~60% of the icon so digits stay readable.
+  const badgeSize = Math.round(size * 0.62);
+  const ox = size - badgeSize;
+  const oy = size - badgeSize;
+  const badge = Buffer.alloc(badgeSize * badgeSize * 4);
+  fillCircle(badge, badgeSize, RED);
+  drawLabel(badge, badgeSize, label, WHITE);
+  blit(buf, size, badge, badgeSize, ox, oy);
+
+  return { buffer: buf, width: size, height: size };
+}
+
+export function fillCircle(buf: Buffer, size: number, color: Rgba): void {
+  const cx = (size - 1) / 2;
+  const cy = (size - 1) / 2;
+  const r = size / 2;
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const dx = x - cx;
+      const dy = y - cy;
+      const d = Math.sqrt(dx * dx + dy * dy);
+      const i = (y * size + x) * 4;
+      if (d <= r - 0.5) {
+        buf[i + 0] = color.r;
+        buf[i + 1] = color.g;
+        buf[i + 2] = color.b;
+        buf[i + 3] = color.a;
+      } else if (d <= r + 0.5) {
+        // Soft 1px edge for anti-alias.
+        const t = Math.max(0, Math.min(1, r + 0.5 - d));
+        buf[i + 0] = color.r;
+        buf[i + 1] = color.g;
+        buf[i + 2] = color.b;
+        buf[i + 3] = Math.round(color.a * t);
+      } else {
+        buf[i + 0] = TRANSPARENT.r;
+        buf[i + 1] = TRANSPARENT.g;
+        buf[i + 2] = TRANSPARENT.b;
+        buf[i + 3] = TRANSPARENT.a;
+      }
+    }
+  }
+}
+
+// Lays out `label` characters horizontally, centered, scaled to fit ~70% of
+// the canvas height. White ink only.
+export function drawLabel(
+  buf: Buffer,
+  size: number,
+  label: string,
+  ink: Rgba,
+): void {
+  if (!label) return;
+  const targetH = Math.max(5, Math.floor(size * 0.62));
+  const scale = Math.max(1, Math.floor(targetH / GLYPH_H));
+  const glyphW = GLYPH_W * scale;
+  const glyphH = GLYPH_H * scale;
+  const gap = scale; // 1 scaled pixel between glyphs
+  const totalW = label.length * glyphW + (label.length - 1) * gap;
+  const startX = Math.round((size - totalW) / 2);
+  const startY = Math.round((size - glyphH) / 2);
+  for (let ci = 0; ci < label.length; ci++) {
+    const ch = label[ci];
+    const glyph = GLYPHS[ch];
+    if (!glyph) continue;
+    const gx0 = startX + ci * (glyphW + gap);
+    for (let gy = 0; gy < GLYPH_H; gy++) {
+      for (let gx = 0; gx < GLYPH_W; gx++) {
+        if (!glyph[gy][gx]) continue;
+        for (let sy = 0; sy < scale; sy++) {
+          for (let sx = 0; sx < scale; sx++) {
+            const px = gx0 + gx * scale + sx;
+            const py = startY + gy * scale + sy;
+            if (px < 0 || px >= size || py < 0 || py >= size) continue;
+            const i = (py * size + px) * 4;
+            buf[i + 0] = ink.r;
+            buf[i + 1] = ink.g;
+            buf[i + 2] = ink.b;
+            buf[i + 3] = ink.a;
+          }
+        }
+      }
+    }
+  }
+}
+
+export function blit(
+  dst: Buffer,
+  dstSize: number,
+  src: Buffer,
+  srcSize: number,
+  ox: number,
+  oy: number,
+): void {
+  for (let y = 0; y < srcSize; y++) {
+    for (let x = 0; x < srcSize; x++) {
+      const si = (y * srcSize + x) * 4;
+      const sa = src[si + 3];
+      if (sa === 0) continue;
+      const dx = ox + x;
+      const dy = oy + y;
+      if (dx < 0 || dx >= dstSize || dy < 0 || dy >= dstSize) continue;
+      const di = (dy * dstSize + dx) * 4;
+      // Source-over alpha blend.
+      const a = sa / 255;
+      const inv = 1 - a;
+      dst[di + 0] = Math.round(src[si + 0] * a + dst[di + 0] * inv);
+      dst[di + 1] = Math.round(src[si + 1] * a + dst[di + 1] * inv);
+      dst[di + 2] = Math.round(src[si + 2] * a + dst[di + 2] * inv);
+      dst[di + 3] = Math.max(dst[di + 3], sa);
+    }
+  }
+}

--- a/tests/badgeLabel.test.ts
+++ b/tests/badgeLabel.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { badgeLabel } from '../electron/notify/badgeLabel';
+
+describe('badgeLabel', () => {
+  it.each([
+    [-1, ''],
+    [0, ''],
+    [1, '1'],
+    [2, '2'],
+    [5, '5'],
+    [8, '8'],
+    [9, '9'],
+    [10, '9+'],
+    [11, '9+'],
+    [99, '9+'],
+    [1000, '9+'],
+  ])('badgeLabel(%i) === %j', (input, expected) => {
+    expect(badgeLabel(input)).toBe(expected);
+  });
+});

--- a/tests/badgePixels.test.ts
+++ b/tests/badgePixels.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'node:crypto';
+import {
+  renderBadgeImage,
+  compositeTrayImage,
+  fillCircle,
+  drawLabel,
+  RED,
+  WHITE,
+  TRANSPARENT,
+  GLYPH_W,
+  GLYPH_H,
+  type BgraBitmap,
+} from '../electron/notify/badgePixels';
+
+const digest = (buf: Buffer): string =>
+  createHash('sha256').update(buf).digest('hex').slice(0, 16);
+
+// Build a deterministic 16x16 BGRA "base tray" bitmap: solid mid-grey, opaque.
+function makeBaseBitmap(size = 16): BgraBitmap {
+  const buffer = Buffer.alloc(size * size * 4);
+  for (let i = 0; i < size * size; i++) {
+    const o = i * 4;
+    buffer[o + 0] = 0x40; // B
+    buffer[o + 1] = 0x40; // G
+    buffer[o + 2] = 0x40; // R
+    buffer[o + 3] = 0xff; // A
+  }
+  return { buffer, width: size, height: size };
+}
+
+describe('badgePixels.renderBadgeImage', () => {
+  it('returns the requested square dimensions', () => {
+    const img = renderBadgeImage('1', 16);
+    expect(img.width).toBe(16);
+    expect(img.height).toBe(16);
+    expect(img.buffer.length).toBe(16 * 16 * 4);
+  });
+
+  it('produces a stable pixel checksum for label "1" @ 16px', () => {
+    const img = renderBadgeImage('1', 16);
+    expect(digest(img.buffer)).toMatchInlineSnapshot(`"3d0326f99c4af9ce"`);
+  });
+
+  it('produces a stable pixel checksum for label "9" @ 16px', () => {
+    const img = renderBadgeImage('9', 16);
+    expect(digest(img.buffer)).toMatchInlineSnapshot(`"65339562b6c79e49"`);
+  });
+
+  it('produces a stable pixel checksum for label "9+" @ 16px', () => {
+    const img = renderBadgeImage('9+', 16);
+    expect(digest(img.buffer)).toMatchInlineSnapshot(`"57d7dbf8edcd092b"`);
+  });
+
+  it('empty label still draws the red circle background', () => {
+    const img = renderBadgeImage('', 16);
+    // Center pixel must be RED (filled circle, no glyph overlay).
+    const ci = (8 * 16 + 8) * 4;
+    expect(img.buffer[ci + 0]).toBe(RED.r);
+    expect(img.buffer[ci + 1]).toBe(RED.g);
+    expect(img.buffer[ci + 2]).toBe(RED.b);
+    expect(img.buffer[ci + 3]).toBe(RED.a);
+    // Top-left pixel (corner) is outside the circle => transparent.
+    expect(img.buffer[3]).toBe(TRANSPARENT.a);
+  });
+
+  it('different labels produce different pixels', () => {
+    const a = digest(renderBadgeImage('1', 16).buffer);
+    const b = digest(renderBadgeImage('9', 16).buffer);
+    const c = digest(renderBadgeImage('9+', 16).buffer);
+    expect(new Set([a, b, c]).size).toBe(3);
+  });
+});
+
+describe('badgePixels.compositeTrayImage', () => {
+  it('returns the requested square dimensions', () => {
+    const img = compositeTrayImage(makeBaseBitmap(16), '9+', 16);
+    expect(img.width).toBe(16);
+    expect(img.height).toBe(16);
+    expect(img.buffer.length).toBe(16 * 16 * 4);
+  });
+
+  it('produces a stable pixel checksum for "9+" overlay on grey base', () => {
+    const img = compositeTrayImage(makeBaseBitmap(16), '9+', 16);
+    expect(digest(img.buffer)).toMatchInlineSnapshot(`"e05874d349ee4892"`);
+  });
+
+  it('top-left pixel preserves the base (no badge in that corner)', () => {
+    const img = compositeTrayImage(makeBaseBitmap(16), '1', 16);
+    // Base is BGRA grey 0x40; output is RGBA, so R=G=B=0x40, A=0xff.
+    expect(img.buffer[0]).toBe(0x40);
+    expect(img.buffer[1]).toBe(0x40);
+    expect(img.buffer[2]).toBe(0x40);
+    expect(img.buffer[3]).toBe(0xff);
+  });
+});
+
+describe('badgePixels.fillCircle / drawLabel primitives', () => {
+  it('fillCircle fills the geometric centre with the requested colour', () => {
+    const buf = Buffer.alloc(16 * 16 * 4);
+    fillCircle(buf, 16, RED);
+    const ci = (8 * 16 + 8) * 4;
+    expect(buf[ci + 0]).toBe(RED.r);
+    expect(buf[ci + 3]).toBe(RED.a);
+  });
+
+  it('drawLabel is a no-op for empty string', () => {
+    const buf = Buffer.alloc(16 * 16 * 4);
+    drawLabel(buf, 16, '', WHITE);
+    // Buffer should remain all zeros.
+    expect(buf.every((b) => b === 0)).toBe(true);
+  });
+
+  it('GLYPH_W and GLYPH_H describe the 3x5 font cell', () => {
+    expect(GLYPH_W).toBe(3);
+    expect(GLYPH_H).toBe(5);
+  });
+});


### PR DESCRIPTION
## Scope (Task #722 Phase A)

NEW files only. `electron/notify/badge.ts` is **untouched** in this PR.
Phase B (separate PR, after this merges) will switch the import in
`badge.ts` and delete the now-duplicated originals.

- `electron/notify/badgePixels.ts` — pure RGBA pixel rendering. Exports
  `renderBadgeImage`, `compositeTrayImage`, `fillCircle`, `drawLabel`,
  `blit`, `GLYPHS`, `GLYPH_W/H`, `RED`/`WHITE`/`TRANSPARENT`. **No
  `electron` import**; returns `{ buffer, width, height }` rather than
  `NativeImage` so Phase B's caller can wrap via
  `nativeImage.createFromBuffer`. `compositeTrayImage` accepts a raw
  `BgraBitmap` (the format `NativeImage.toBitmap()` returns) so this
  module stays Node-pure.
- `electron/notify/badgeLabel.ts` — pure `badgeLabel(n: number): string`,
  preserving the existing rule (`<=0` → `''`, `10+` → `'9+'`, else digit).
- `tests/badgePixels.test.ts` — pixel-checksum snapshots for labels
  `'1'`, `'9'`, `'9+'`, `''`; composite-on-grey-base checksum; primitive
  sanity checks. 12 tests.
- `tests/badgeLabel.test.ts` — boundary table: `-1, 0, 1..9, 10, 11, 99,
  1000`. 11 tests.

## Why

SRP per `feedback_single_responsibility.md`. `badge.ts` currently mixes
three responsibilities: producer (the `unread` Map and `apply()` IPC
sink), decider (`badgeLabel`), and pure pixel-bytes generator (the
~210 LoC bitmap-font + circle + composite block). Phase A extracts the
two pure pieces into testable modules so Phase B can reduce `badge.ts`
to just the producer/sink that wires `electron`-specific APIs.

## Reverse-verify (per `feedback_bug_fix_test_workflow.md`)

**FAIL state — both source files removed, tests kept:**

```
FAIL  tests/badgePixels.test.ts [ tests/badgePixels.test.ts ]
Error: Failed to resolve import "../electron/notify/badgePixels" from "tests/badgePixels.test.ts". Does the file exist?
FAIL  tests/badgeLabel.test.ts [ tests/badgeLabel.test.ts ]
Error: Failed to resolve import "../electron/notify/badgeLabel" from "tests/badgeLabel.test.ts". Does the file exist?

 Test Files  2 failed (2)
      Tests  no tests
```

**PASS state — source files restored:**

```
 PASS  tests/badgePixels.test.ts (12 tests) 50ms
 PASS  tests/badgeLabel.test.ts (11 tests) 7ms

 Test Files  2 passed (2)
      Tests  23 passed (23)
```

## Validation

- `npx vitest run tests/badgePixels.test.ts tests/badgeLabel.test.ts` → 23/23 PASS
- `npx vitest run` (full suite) → 523 PASS / 3 FAIL. The 3 failures are
  all in `electron/__tests__/db-hardening.test.ts` and are pre-existing
  on `origin/working` (`better-sqlite3` `NODE_MODULE_VERSION 130 vs 137`
  native binding mismatch in this worktree's `node_modules`). Unrelated
  to this PR; no NEW failures.
- `npm run build` → clean (3 pre-existing webpack asset-size warnings,
  no errors).
- Main-process require-load smoke test (per `feedback_main_process_load_smoke_test.md`):
  ```
  node -e "require('./dist/electron/notify/badgePixels.js'); require('./dist/electron/notify/badgeLabel.js'); console.log('ok')"
  ok
  ```
- `grep "from 'electron'" electron/notify/badgePixels.ts` → no matches (Node-pure verified).

## Files changed

- `electron/notify/badgeLabel.ts` (NEW, 14 LoC)
- `electron/notify/badgePixels.ts` (NEW, ~245 LoC)
- `tests/badgeLabel.test.ts` (NEW, 21 LoC)
- `tests/badgePixels.test.ts` (NEW, ~115 LoC)
- `electron/notify/badge.ts` — UNCHANGED (Phase B)