### PR TITLE
refactor(notify): extract runStateTracker pure decider (Task #721 Phase A)

### DIFF
--- a/electron/notify/__tests__/runStateTracker.test.ts
+++ b/electron/notify/__tests__/runStateTracker.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import { createRunStateTracker } from '../runStateTracker';
+import { decide, DEDUPE_MS, SHORT_TASK_MS } from '../notifyDecider';
+
+const NOW = 1_700_000_000_000;
+
+describe('runStateTracker — pure decider', () => {
+  it('running → idle: fires a decision (Rule 5 unfocused branch)', () => {
+    const t = createRunStateTracker(decide);
+    t.setFocused(false); // Rule 5: not focused → toast + flash
+    expect(t.onTitle('s1', 'running', NOW)).toBeNull();
+    expect(t._internals().runStartTs.get('s1')).toBe(NOW);
+    const dec = t.onTitle('s1', 'idle', NOW + 1_000);
+    expect(dec).not.toBeNull();
+    expect(dec?.sid).toBe('s1');
+    expect(dec?.toast).toBe(true);
+    expect(dec?.flash).toBe(true);
+    // runStartTs cleared after non-running title
+    expect(t._internals().runStartTs.has('s1')).toBe(false);
+    // lastFiredTs recorded
+    expect(t._internals().lastFiredTs.get('s1')).toBe(NOW + 1_000);
+  });
+
+  it('dedupes back-to-back idle titles within DEDUPE_MS', () => {
+    const t = createRunStateTracker(decide);
+    t.setFocused(false);
+    t.onTitle('s1', 'running', NOW);
+    const first = t.onTitle('s1', 'idle', NOW + 100);
+    expect(first).not.toBeNull();
+    // Second idle within dedupe window — even with a fresh run in between
+    t.onTitle('s1', 'running', NOW + 200);
+    const second = t.onTitle('s1', 'idle', NOW + 100 + DEDUPE_MS - 1);
+    expect(second).toBeNull();
+  });
+
+  it('mute window prevents toast (Rule 7) but flash still fires', () => {
+    const t = createRunStateTracker(decide);
+    t.setFocused(false);
+    t.setMuted('s1', NOW + 60_000); // muted for the next minute
+    t.onTitle('s1', 'running', NOW);
+    const dec = t.onTitle('s1', 'idle', NOW + 1_000);
+    expect(dec).not.toBeNull();
+    expect(dec?.toast).toBe(false);
+    expect(dec?.flash).toBe(true);
+  });
+
+  it('expired mute (untilTs in the past) no longer suppresses toast', () => {
+    const t = createRunStateTracker(decide);
+    t.setFocused(false);
+    t.setMuted('s1', NOW - 1); // already expired
+    t.onTitle('s1', 'running', NOW);
+    const dec = t.onTitle('s1', 'idle', NOW + 1_000);
+    expect(dec?.toast).toBe(true);
+  });
+
+  it('setMuted(null) clears the mute', () => {
+    const t = createRunStateTracker(decide);
+    t.setFocused(false);
+    t.setMuted('s1', Number.POSITIVE_INFINITY); // sticky mute
+    t.setMuted('s1', null);
+    t.onTitle('s1', 'running', NOW);
+    const dec = t.onTitle('s1', 'idle', NOW + 1_000);
+    expect(dec?.toast).toBe(true);
+  });
+
+  it('forgetSid clears all per-sid state', () => {
+    const t = createRunStateTracker(decide);
+    t.setFocused(false);
+    // Populate user-input but with timestamp far in the past so Rule 1
+    // doesn't suppress the fire (we still need lastFiredTs populated).
+    t.markUserInput('s1', NOW - 10 * 60 * 1000);
+    t.setMuted('s1', NOW + 100_000);
+    t.onTitle('s1', 'running', NOW);
+    const dec = t.onTitle('s1', 'idle', NOW + 1_000);
+    expect(dec).not.toBeNull(); // ensures lastFiredTs got recorded
+
+    const before = t._internals();
+    expect(before.lastUserInputTs.has('s1')).toBe(true);
+    expect(before.mutedSids.has('s1')).toBe(true);
+    expect(before.lastFiredTs.has('s1')).toBe(true);
+
+    t.forgetSid('s1');
+    const after = t._internals();
+    expect(after.runStartTs.has('s1')).toBe(false);
+    expect(after.mutedSids.has('s1')).toBe(false);
+    expect(after.lastFiredTs.has('s1')).toBe(false);
+    expect(after.lastUserInputTs.has('s1')).toBe(false);
+  });
+
+  it('multiple sids tracked independently', () => {
+    const t = createRunStateTracker(decide);
+    t.setFocused(false);
+    t.onTitle('s1', 'running', NOW);
+    t.onTitle('s2', 'running', NOW + 500);
+    expect(t._internals().runStartTs.get('s1')).toBe(NOW);
+    expect(t._internals().runStartTs.get('s2')).toBe(NOW + 500);
+
+    const d1 = t.onTitle('s1', 'idle', NOW + 1_000);
+    expect(d1?.sid).toBe('s1');
+    // s2 should still be running and unaffected
+    expect(t._internals().runStartTs.get('s2')).toBe(NOW + 500);
+
+    const d2 = t.onTitle('s2', 'idle', NOW + 2_000);
+    expect(d2?.sid).toBe('s2');
+
+    // Forgetting s1 doesn't touch s2
+    t.forgetSid('s1');
+    expect(t._internals().lastFiredTs.has('s2')).toBe(true);
+  });
+
+  it('classification "unknown" is a no-op', () => {
+    const t = createRunStateTracker(decide);
+    t.setFocused(false);
+    expect(t.onTitle('s1', 'unknown', NOW)).toBeNull();
+    expect(t._internals().runStartTs.has('s1')).toBe(false);
+    expect(t._internals().lastFiredTs.has('s1')).toBe(false);
+  });
+
+  it('Rule 1: user-input within 60s suppresses fire', () => {
+    const t = createRunStateTracker(decide);
+    t.setFocused(false);
+    t.markUserInput('s1', NOW);
+    t.onTitle('s1', 'running', NOW + 100);
+    // Idle 1s later — Rule 1 mute window still active
+    const dec = t.onTitle('s1', 'idle', NOW + 1_000);
+    expect(dec).toBeNull();
+  });
+
+  it('Rule 2 vs Rule 3: foreground active sid splits on SHORT_TASK_MS', () => {
+    const t = createRunStateTracker(decide);
+    t.setFocused(true);
+    t.setActiveSid('s1');
+
+    // Short task — Rule 2: flash only, no toast → still a non-null Decision
+    t.onTitle('s1', 'running', NOW);
+    const shortDec = t.onTitle('s1', 'idle', NOW + 1_000);
+    expect(shortDec).not.toBeNull();
+    expect(shortDec?.toast).toBe(false);
+    expect(shortDec?.flash).toBe(true);
+
+    // Wait past dedupe, then long task — Rule 3: toast + flash
+    const t2 = NOW + DEDUPE_MS + 10_000;
+    t.onTitle('s1', 'running', t2);
+    const longDec = t.onTitle('s1', 'idle', t2 + SHORT_TASK_MS + 1_000);
+    expect(longDec).not.toBeNull();
+    expect(longDec?.toast).toBe(true);
+    expect(longDec?.flash).toBe(true);
+  });
+
+  it('Rule 4: foreground but viewing a different sid → toast + flash', () => {
+    const t = createRunStateTracker(decide);
+    t.setFocused(true);
+    t.setActiveSid('s2'); // viewing s2
+    t.onTitle('s1', 'running', NOW);
+    const dec = t.onTitle('s1', 'idle', NOW + 1_000);
+    expect(dec?.toast).toBe(true);
+    expect(dec?.flash).toBe(true);
+  });
+
+  it('runStartTs is cleared after every non-running title (even when no decision fires)', () => {
+    const t = createRunStateTracker(decide);
+    t.setFocused(false);
+    t.markUserInput('s1', NOW); // forces Rule 1 → null decision
+    t.onTitle('s1', 'running', NOW);
+    expect(t._internals().runStartTs.has('s1')).toBe(true);
+    const dec = t.onTitle('s1', 'idle', NOW + 1_000);
+    expect(dec).toBeNull();
+    expect(t._internals().runStartTs.has('s1')).toBe(false);
+  });
+});

--- a/electron/notify/runStateTracker.ts
+++ b/electron/notify/runStateTracker.ts
@@ -1,0 +1,146 @@
+// Pure run-state decider for the notify pipeline (Task #721 Phase A).
+//
+// Extracts the per-sid state-machine that lives inside `sinks/pipeline.ts`
+// today (runStartTs / mutedSids / lastFiredTs and the surrounding context
+// fields the decider reads) into a standalone, Electron-free module so it
+// can be unit-tested in isolation and re-used by Phase B (where pipeline
+// will switch over to delegate here).
+//
+// Design notes:
+//   * Pure — no Electron, no I/O. Only depends on the existing
+//     `notifyDecider.decide()` (injected so the test can stub it if it
+//     wants, and so we never hard-link to the module at construction).
+//   * Owns the mutable state that pipeline previously kept inline:
+//       - runStartTs:    Map<sid, ms>     — when the current run began
+//       - mutedSids:     Map<sid, untilTs>— per-sid mute window
+//                                            (untilTs === Infinity = sticky)
+//       - lastFiredTs:   Map<sid, ms>     — for the decider's 5s dedupe
+//       - lastUserInputTs / focused / activeSid — context fields the
+//                                            decider also reads. Exposed
+//                                            via small setters so the
+//                                            wiring layer (Phase B) can
+//                                            push lifecycle events in.
+//   * Single entry point for the title producer: `onTitle(sid, cls, ts)`.
+//       - 'running' → records runStartTs[sid], no decision.
+//       - 'idle' / 'waiting' → calls decide() with a synthesized Ctx.
+//                              On non-null decision, updates lastFiredTs.
+//                              Always clears runStartTs after decide.
+//       - 'unknown' → no-op.
+//   * `forgetSid(sid)` clears every per-sid map entry in one shot
+//                      (mirrors pipeline.forgetSid for the state it owns).
+
+import type { Ctx, Decision, Event } from './notifyDecider';
+
+export type TitleClassification = 'idle' | 'running' | 'waiting' | 'unknown';
+
+export interface RunStateTracker {
+  /** Producer entry — feed a classified title for `sid` at `nowTs`.
+   *  Returns the decision the decider produced (if any) so the caller
+   *  can wire sinks. Tracker itself never invokes sinks. */
+  onTitle(sid: string, classification: TitleClassification, nowTs: number): Decision | null;
+  /** Drop all per-sid state for `sid` (session teardown). */
+  forgetSid(sid: string): void;
+  /** Lifecycle setters — mirror pipeline's surface so Phase B can wire
+   *  them through unchanged. Pure state mutation, no side effects. */
+  setFocused(focused: boolean): void;
+  setActiveSid(sid: string | null): void;
+  markUserInput(sid: string, nowTs: number): void;
+  /** Mute `sid` until `untilTs` (use `Infinity` for sticky). Pass
+   *  `null` to clear. */
+  setMuted(sid: string, untilTs: number | null): void;
+  /** Test-only — read internal maps for assertion. */
+  _internals(): {
+    runStartTs: Map<string, number>;
+    mutedSids: Map<string, number>;
+    lastFiredTs: Map<string, number>;
+    lastUserInputTs: Map<string, number>;
+    focused: boolean;
+    activeSid: string | null;
+  };
+}
+
+export function createRunStateTracker(
+  decide: (event: Event, ctx: Ctx) => Decision | null,
+): RunStateTracker {
+  const runStartTs = new Map<string, number>();
+  /** Map<sid, untilTs> — entry present + nowTs < untilTs ⇒ sid is muted. */
+  const mutedSids = new Map<string, number>();
+  const lastFiredTs = new Map<string, number>();
+  const lastUserInputTs = new Map<string, number>();
+  let focused = true;
+  let activeSid: string | null = null;
+
+  function activeMutedSet(nowTs: number): Set<string> {
+    const out = new Set<string>();
+    for (const [sid, until] of mutedSids) {
+      if (nowTs < until) out.add(sid);
+    }
+    return out;
+  }
+
+  return {
+    onTitle(sid, classification, nowTs) {
+      if (classification === 'unknown') return null;
+
+      if (classification === 'running') {
+        if (!runStartTs.has(sid)) runStartTs.set(sid, nowTs);
+        return null;
+      }
+
+      // 'idle' or 'waiting' → ask the decider.
+      // The decider matches against the literal word "waiting"; both
+      // classifications represent the same user-attention signal, so we
+      // normalize to that token regardless of which one the producer
+      // emitted.
+      const ctx: Ctx = {
+        focused,
+        activeSid,
+        lastUserInputTs,
+        runStartTs,
+        mutedSids: activeMutedSet(nowTs),
+        lastFiredTs,
+        now: nowTs,
+      };
+      const event: Event = { type: 'osc-title', sid, title: 'waiting', ts: nowTs };
+      const decision = decide(event, ctx);
+
+      // Mirror pipeline behaviour: always clear runStartTs after a
+      // non-running title so the next run starts a fresh elapsed clock.
+      runStartTs.delete(sid);
+
+      if (decision !== null) {
+        lastFiredTs.set(sid, nowTs);
+      }
+      return decision;
+    },
+    forgetSid(sid) {
+      runStartTs.delete(sid);
+      mutedSids.delete(sid);
+      lastFiredTs.delete(sid);
+      lastUserInputTs.delete(sid);
+    },
+    setFocused(next) {
+      focused = next;
+    },
+    setActiveSid(sid) {
+      activeSid = sid;
+    },
+    markUserInput(sid, nowTs) {
+      lastUserInputTs.set(sid, nowTs);
+    },
+    setMuted(sid, untilTs) {
+      if (untilTs === null) mutedSids.delete(sid);
+      else mutedSids.set(sid, untilTs);
+    },
+    _internals() {
+      return {
+        runStartTs,
+        mutedSids,
+        lastFiredTs,
+        lastUserInputTs,
+        focused,
+        activeSid,
+      };
+    },
+  };
+}


### PR DESCRIPTION
## Scope (Phase A — new file only)

- **NEW** `electron/notify/runStateTracker.ts` (~135 LoC): pure, Electron-free module owning the per-sid state-machine that today lives inline in `electron/notify/sinks/pipeline.ts` (`runStartTs` / `mutedSids` / `lastFiredTs` plus the `focused` / `activeSid` / `lastUserInputTs` context fields the decider reads).
- **NEW** `electron/notify/__tests__/runStateTracker.test.ts` (12 cases).
- `sinks/pipeline.ts` is **NOT touched**. Phase B (separate PR) will switch the wiring layer to delegate to this tracker.

## Why

Single-responsibility split: today `pipeline.ts` mixes (a) producer wiring (sniffer events, sinks) with (b) the state-machine that decides whether/when to fire. Pulling the state-machine out lets it be unit-tested in isolation against `notifyDecider.decide()` and lets Phase B's `pipeline.ts` shrink to pure wiring.

Tracker is constructed with the decider injected (`createRunStateTracker(decide)`) so it never hard-links the module — keeps it pure, swappable, and trivially testable.

## API

```ts
export interface RunStateTracker {
  onTitle(sid, classification: 'idle'|'running'|'waiting'|'unknown', nowTs): Decision | null;
  forgetSid(sid): void;
  setFocused(focused): void;
  setActiveSid(sid | null): void;
  markUserInput(sid, nowTs): void;
  setMuted(sid, untilTs: number | null): void; // null clears
  _internals(): { ... }; // test-only
}
```

`mutedSids` is stored internally as `Map<sid, untilTs>` (per the task spec). The tracker bridges to the decider's `Set<string>` shape at decide-time by computing the active-muted set against `nowTs`.

## Tests (12 cases, all passing)

```
running -> idle: fires (Rule 5)
dedupes back-to-back idle within DEDUPE_MS
mute window prevents toast (Rule 7), flash still fires
expired mute no longer suppresses
setMuted(null) clears the mute
forgetSid clears all per-sid state
multiple sids tracked independently
classification 'unknown' is a no-op
Rule 1: user-input within 60s suppresses fire
Rule 2 vs Rule 3: SHORT_TASK_MS split (foreground active sid)
Rule 4: foreground but viewing other sid -> toast + flash
runStartTs cleared after every non-running title
```

## Reverse-verify

Removed `runStateTracker.ts` (kept the test) and re-ran:

```
Test Files  1 failed (1)
     Tests  no tests
```

(import error: source missing, as expected). Restored, re-ran:

```
Test Files  1 passed (1)
     Tests  12 passed (12)
```

## Vitest

- Tracker file: `12 passed (12)`
- Full suite: `512 passed`, `3 failed` — all 3 in `electron/__tests__/db-hardening.test.ts` due to a pre-existing `better-sqlite3` `NODE_MODULE_VERSION 137` mismatch (verified failing on `origin/working` baseline before my change). Unrelated to this PR.

## Build + smoke

- `npm run build` clean (3 webpack perf warnings, pre-existing).
- `node -e "require('./dist/electron/notify/runStateTracker.js'); console.log('ok')"` -> `ok`.

## Constraints honored

- `electron/notify/sinks/pipeline.ts` not modified.
- No Electron imports.
- No other files touched.