### PR TITLE
refactor(app): extract 9 effect hooks into src/app-effects (Task #724 Phase A)

### DIFF
--- a/src/app-effects/useAgentEventBridge.ts
+++ b/src/app-effects/useAgentEventBridge.ts
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+import { subscribeAgentEvents } from '../agent/lifecycle';
+
+/**
+ * Mounts the agent-lifecycle IPC subscription that pipes
+ * `session:state` events from main into the store via
+ * `_applySessionState`. This is what drives the AgentIcon attention halo
+ * (waiting/idle) for non-active sessions. Bridge install is idempotent
+ * so StrictMode double-mount does not double-pipe events.
+ *
+ * Extracted from App.tsx for SRP under Task #724.
+ */
+export function useAgentEventBridge(): void {
+  useEffect(() => {
+    return subscribeAgentEvents();
+  }, []);
+}

--- a/src/app-effects/useFocusBridge.ts
+++ b/src/app-effects/useFocusBridge.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+
+/**
+ * Subscribes to the window `focus` event and runs the supplied callback
+ * each time ccsm regains OS focus. In App.tsx the production callback
+ * clears the active session's attention halo (per the notify spec: the
+ * row the user is returning to drops its halo because they're here, the
+ * breadcrumb has done its job). Other 'waiting' rows keep the halo
+ * until the user actually clicks them.
+ *
+ * Extracted from App.tsx for SRP under Task #724. The callback is
+ * injected (not hardcoded) so the hook stays pure and testable; App.tsx
+ * supplies the store-mutating closure at the call site.
+ */
+export function useFocusBridge(onFocus: () => void): void {
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.addEventListener('focus', onFocus);
+    return () => window.removeEventListener('focus', onFocus);
+  }, [onFocus]);
+}

--- a/src/app-effects/useLanguageEffect.ts
+++ b/src/app-effects/useLanguageEffect.ts
@@ -8,7 +8,7 @@ import { useEffect } from 'react';
  *
  * No-op when the preload bridge is missing (test/storybook).
  */
-export function useLanguageEffect(resolvedLanguage: string): void {
+export function useLanguageEffect(resolvedLanguage: 'en' | 'zh'): void {
   useEffect(() => {
     window.ccsm?.i18n?.setLanguage(resolvedLanguage);
   }, [resolvedLanguage]);

--- a/src/app-effects/useLanguageEffect.ts
+++ b/src/app-effects/useLanguageEffect.ts
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+
+/**
+ * Mirror the renderer's resolved language to main so OS-level surfaces
+ * (tray menu, future native notifications) can localize. Companion to
+ * the locale-hydration effect in App.tsx; extracted to its own hook for
+ * SRP under Task #724.
+ *
+ * No-op when the preload bridge is missing (test/storybook).
+ */
+export function useLanguageEffect(resolvedLanguage: string): void {
+  useEffect(() => {
+    window.ccsm?.i18n?.setLanguage(resolvedLanguage);
+  }, [resolvedLanguage]);
+}

--- a/src/app-effects/usePersistErrorBridge.ts
+++ b/src/app-effects/usePersistErrorBridge.ts
@@ -1,0 +1,40 @@
+import { useEffect } from 'react';
+import { setPersistErrorHandler } from '../stores/persist';
+
+export interface PersistErrorToast {
+  kind: 'error';
+  title: string;
+  body: string;
+}
+
+export interface PersistErrorDeps {
+  /** Toast push handler (typically from `useToast()`). */
+  push: (toast: PersistErrorToast) => void;
+}
+
+/**
+ * Installs a debounced (5s) toast handler for store persistence errors.
+ * Wired through `setPersistErrorHandler` so the store's persist middleware
+ * surfaces disk-full / I/O failures to the user as a single toast rather
+ * than a flood. Cleared on unmount.
+ *
+ * Hook-form rewrite of the inline `<PersistErrorBridge />` component that
+ * used to live at the bottom of App.tsx, extracted under Task #724.
+ */
+export function usePersistErrorBridge(deps: PersistErrorDeps): void {
+  const { push } = deps;
+  useEffect(() => {
+    let lastShown = 0;
+    setPersistErrorHandler(() => {
+      const now = Date.now();
+      if (now - lastShown < 5000) return;
+      lastShown = now;
+      push({
+        kind: 'error',
+        title: 'Failed to save state',
+        body: 'Your recent changes may not survive restart. Check disk space.',
+      });
+    });
+    return () => setPersistErrorHandler(() => {});
+  }, [push]);
+}

--- a/src/app-effects/useSessionActivateBridge.ts
+++ b/src/app-effects/useSessionActivateBridge.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+
+/**
+ * Listens for `session:activate` from main (fired when the user clicks a
+ * desktop notification) and re-selects the named session so it lands
+ * focused in the sidebar and chat pane. Mirrors the IPC subscription
+ * pattern of `UpdateDownloadedBridge`.
+ *
+ * Extracted from App.tsx for SRP under Task #724.
+ */
+export function useSessionActivateBridge(
+  selectSession: (sid: string) => void
+): void {
+  useEffect(() => {
+    type Bridge = {
+      onActivate: (cb: (e: { sid: string }) => void) => () => void;
+    };
+    const bridge = (window as unknown as { ccsmSession?: Bridge }).ccsmSession;
+    if (!bridge || typeof bridge.onActivate !== 'function') return;
+    return bridge.onActivate((evt) => {
+      if (evt && typeof evt.sid === 'string' && evt.sid.length > 0) {
+        selectSession(evt.sid);
+      }
+    });
+  }, [selectSession]);
+}

--- a/src/app-effects/useShortcutHandlers.ts
+++ b/src/app-effects/useShortcutHandlers.ts
@@ -1,0 +1,81 @@
+import { useEffect } from 'react';
+
+/**
+ * True when the event target is a text-editable surface where printable
+ * keys (like "?") should remain composition input rather than trigger a
+ * global shortcut. Used by `useShortcutHandlers` to gate the modifier-free
+ * "?" overlay binding.
+ */
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+  const tag = target.tagName;
+  if (tag === 'TEXTAREA') return true;
+  if (tag === 'INPUT') {
+    const type = (target as HTMLInputElement).type;
+    const nonText = new Set([
+      'checkbox',
+      'radio',
+      'button',
+      'submit',
+      'reset',
+      'range',
+      'color',
+      'file',
+    ]);
+    return !nonText.has(type);
+  }
+  return false;
+}
+
+export interface ShortcutHandlersDeps {
+  /** Toggle the shortcut overlay visibility. Bound to Ctrl+/ and "?". */
+  toggleShortcuts: () => void;
+  /** Toggle the command palette. Bound to Ctrl+F. */
+  togglePalette: () => void;
+  /** Toggle the sidebar. Bound to Ctrl+B. */
+  toggleSidebar: () => void;
+  /** Open the settings dialog. Bound to Ctrl+,. */
+  openSettings: () => void;
+}
+
+/**
+ * Composite hook that installs all global keyboard shortcuts handled at
+ * the App level. Combines what was previously a single inline `keydown`
+ * listener in App.tsx covering: Ctrl+/, "?", Ctrl+F, Ctrl+B, Ctrl+,.
+ *
+ * Extracted for SRP under Task #724.
+ */
+export function useShortcutHandlers(deps: ShortcutHandlersDeps): void {
+  const { toggleShortcuts, togglePalette, toggleSidebar, openSettings } = deps;
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const mod = e.metaKey || e.ctrlKey;
+      if (mod && e.key === '/' && !e.shiftKey) {
+        e.preventDefault();
+        toggleShortcuts();
+        return;
+      }
+      if (!mod) {
+        if (e.key === '?' && !isEditableTarget(e.target)) {
+          e.preventDefault();
+          toggleShortcuts();
+        }
+        return;
+      }
+      const k = e.key.toLowerCase();
+      if (k === 'f' && !e.shiftKey) {
+        e.preventDefault();
+        togglePalette();
+      } else if (k === 'b' && !e.shiftKey) {
+        e.preventDefault();
+        toggleSidebar();
+      } else if (e.key === ',') {
+        e.preventDefault();
+        openSettings();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [toggleShortcuts, togglePalette, toggleSidebar, openSettings]);
+}

--- a/src/app-effects/useThemeEffect.ts
+++ b/src/app-effects/useThemeEffect.ts
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+import { resolveEffectiveTheme } from '../stores/store';
+
+/**
+ * Sync the user's theme preference (and, when set to `system`, the OS
+ * preferred-color-scheme) to CSS classes on `<html>`. Sets BOTH `.dark`
+ * (legacy Tailwind variants) and `.theme-light` (new light-palette
+ * overrides) so the two never coexist. Mirrors the original effect that
+ * lived inline in App.tsx — extracted for SRP under Task #724.
+ */
+export function useThemeEffect(theme: 'light' | 'dark' | 'system'): void {
+  useEffect(() => {
+    const root = document.documentElement;
+    const apply = () => {
+      const osPrefersDark =
+        typeof window !== 'undefined' &&
+        window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const effective = resolveEffectiveTheme(theme, osPrefersDark);
+      root.classList.toggle('dark', effective === 'dark');
+      root.classList.toggle('theme-light', effective === 'light');
+      root.dataset.theme = effective;
+    };
+    apply();
+    if (theme !== 'system') return;
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    mq.addEventListener('change', apply);
+    return () => mq.removeEventListener('change', apply);
+  }, [theme]);
+}

--- a/src/app-effects/useTutorialOverlay.ts
+++ b/src/app-effects/useTutorialOverlay.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+
+export interface TutorialOverlayDeps {
+  /** Persisted flag from the store: has the user seen the tutorial yet? */
+  tutorialSeen: boolean;
+  /** Store action invoked when the user dismisses (via skip / new / import). */
+  markTutorialSeen: () => void;
+}
+
+export interface TutorialOverlayState {
+  /** True when the tutorial overlay should be visible. */
+  show: boolean;
+  /** Hide the overlay AND mark it seen so it does not return on next mount. */
+  dismiss: () => void;
+}
+
+/**
+ * Drives the show/hide state of the first-run tutorial overlay rendered
+ * by App.tsx. Mirrors the behaviour previously inlined in App's render —
+ * the overlay is visible iff `tutorialSeen` is false, and dismissal flips
+ * the persisted store flag so it does not return on the next launch.
+ *
+ * The hook also runs an effect that synchronizes the local `show` state
+ * to the store flag (e.g. when the user resets `tutorialSeen` from
+ * Settings → Help, the overlay reappears immediately without remount).
+ *
+ * Extracted from App.tsx for SRP under Task #724.
+ */
+export function useTutorialOverlay(deps: TutorialOverlayDeps): TutorialOverlayState {
+  const { tutorialSeen, markTutorialSeen } = deps;
+  const [show, setShow] = useState<boolean>(!tutorialSeen);
+
+  useEffect(() => {
+    setShow(!tutorialSeen);
+  }, [tutorialSeen]);
+
+  return {
+    show,
+    dismiss: () => {
+      setShow(false);
+      markTutorialSeen();
+    },
+  };
+}

--- a/src/app-effects/useUpdateDownloadedBridge.ts
+++ b/src/app-effects/useUpdateDownloadedBridge.ts
@@ -1,0 +1,55 @@
+import { useEffect } from 'react';
+import { i18next } from '../i18n';
+
+export interface UpdateInfo {
+  version: string;
+}
+
+export interface UpdateToast {
+  kind: 'info';
+  title: string;
+  body: string;
+  persistent: true;
+  action: { label: string; onClick: () => void };
+}
+
+export interface UpdateDownloadedDeps {
+  /** Toast push handler (typically from `useToast()`). */
+  push: (toast: UpdateToast) => void;
+}
+
+/**
+ * Subscribes to `update:downloaded` from the main process and surfaces a
+ * persistent toast with a Restart button. Only fires once per session —
+ * the Settings → Updates pane shows the same state for users who dismiss.
+ *
+ * Hook-form rewrite of the inline `<UpdateDownloadedBridge />` component
+ * that used to live at the bottom of App.tsx, extracted under Task #724.
+ */
+export function useUpdateDownloadedBridge(deps: UpdateDownloadedDeps): void {
+  const { push } = deps;
+  useEffect(() => {
+    let shown = false;
+    const off = window.ccsm?.onUpdateDownloaded((info: UpdateInfo) => {
+      if (shown) return;
+      shown = true;
+      push({
+        kind: 'info',
+        title: i18next.t('settings:updates.downloadedToastTitle'),
+        body: i18next.t('settings:updates.downloadedToastBody', {
+          version: info.version,
+        }),
+        persistent: true,
+        action: {
+          label: i18next.t('settings:updates.downloadedToastAction'),
+          onClick: () => {
+            void window.ccsm?.updatesInstall();
+          },
+        },
+      });
+    });
+    return () => {
+      if (off) off();
+    };
+  }, [push]);
+}

--- a/tests/app-effects/useAgentEventBridge.test.tsx
+++ b/tests/app-effects/useAgentEventBridge.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+vi.mock('../../src/agent/lifecycle', () => {
+  const unsubscribe = vi.fn();
+  const subscribeAgentEvents = vi.fn(() => unsubscribe);
+  return { subscribeAgentEvents, __unsubscribe: unsubscribe };
+});
+
+import { useAgentEventBridge } from '../../src/app-effects/useAgentEventBridge';
+import * as lifecycle from '../../src/agent/lifecycle';
+
+const subscribeAgentEvents = lifecycle.subscribeAgentEvents as unknown as ReturnType<
+  typeof vi.fn
+>;
+const unsubscribe = (lifecycle as unknown as { __unsubscribe: ReturnType<typeof vi.fn> })
+  .__unsubscribe;
+
+describe('useAgentEventBridge', () => {
+  it('subscribes on mount and unsubscribes on unmount', () => {
+    subscribeAgentEvents.mockClear();
+    unsubscribe.mockClear();
+    const { unmount } = renderHook(() => useAgentEventBridge());
+    expect(subscribeAgentEvents).toHaveBeenCalledTimes(1);
+    expect(unsubscribe).not.toHaveBeenCalled();
+    unmount();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-subscribe across re-renders', () => {
+    subscribeAgentEvents.mockClear();
+    const { rerender } = renderHook(() => useAgentEventBridge());
+    rerender();
+    rerender();
+    expect(subscribeAgentEvents).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/app-effects/useFocusBridge.test.tsx
+++ b/tests/app-effects/useFocusBridge.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useFocusBridge } from '../../src/app-effects/useFocusBridge';
+
+describe('useFocusBridge', () => {
+  it('runs the callback when the window receives focus', () => {
+    const cb = vi.fn();
+    renderHook(() => useFocusBridge(cb));
+    window.dispatchEvent(new Event('focus'));
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes the listener on unmount', () => {
+    const cb = vi.fn();
+    const { unmount } = renderHook(() => useFocusBridge(cb));
+    unmount();
+    window.dispatchEvent(new Event('focus'));
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('re-binds when the callback identity changes', () => {
+    const cb1 = vi.fn();
+    const cb2 = vi.fn();
+    const { rerender } = renderHook(({ cb }: { cb: () => void }) => useFocusBridge(cb), {
+      initialProps: { cb: cb1 },
+    });
+    rerender({ cb: cb2 });
+    window.dispatchEvent(new Event('focus'));
+    expect(cb1).not.toHaveBeenCalled();
+    expect(cb2).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/app-effects/useLanguageEffect.test.tsx
+++ b/tests/app-effects/useLanguageEffect.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useLanguageEffect } from '../../src/app-effects/useLanguageEffect';
+
+describe('useLanguageEffect', () => {
+  let setLanguage: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    setLanguage = vi.fn();
+    (window as unknown as { ccsm: unknown }).ccsm = {
+      i18n: { setLanguage, getSystemLocale: vi.fn() },
+    };
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { ccsm?: unknown }).ccsm;
+  });
+
+  it('forwards the resolved language to main on mount', () => {
+    renderHook(() => useLanguageEffect('en'));
+    expect(setLanguage).toHaveBeenCalledWith('en');
+  });
+
+  it('re-fires when the language changes', () => {
+    const { rerender } = renderHook(
+      ({ lang }: { lang: string }) => useLanguageEffect(lang),
+      { initialProps: { lang: 'en' } }
+    );
+    expect(setLanguage).toHaveBeenLastCalledWith('en');
+    rerender({ lang: 'zh' });
+    expect(setLanguage).toHaveBeenLastCalledWith('zh');
+    expect(setLanguage).toHaveBeenCalledTimes(2);
+  });
+
+  it('is a no-op when the preload bridge is missing', () => {
+    delete (window as unknown as { ccsm?: unknown }).ccsm;
+    expect(() => renderHook(() => useLanguageEffect('en'))).not.toThrow();
+  });
+});

--- a/tests/app-effects/usePersistErrorBridge.test.tsx
+++ b/tests/app-effects/usePersistErrorBridge.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+const setPersistErrorHandler = vi.fn();
+let installed: (() => void) | null = null;
+
+vi.mock('../../src/stores/persist', () => ({
+  setPersistErrorHandler: (fn: () => void) => {
+    installed = fn;
+    setPersistErrorHandler(fn);
+  },
+}));
+
+import { usePersistErrorBridge } from '../../src/app-effects/usePersistErrorBridge';
+
+describe('usePersistErrorBridge', () => {
+  beforeEach(() => {
+    setPersistErrorHandler.mockClear();
+    installed = null;
+  });
+
+  it('installs a handler on mount and clears it on unmount', () => {
+    const push = vi.fn();
+    const { unmount } = renderHook(() => usePersistErrorBridge({ push }));
+    expect(setPersistErrorHandler).toHaveBeenCalledTimes(1);
+    expect(typeof installed).toBe('function');
+    unmount();
+    // Mount installs once, unmount installs the no-op clearing handler.
+    expect(setPersistErrorHandler).toHaveBeenCalledTimes(2);
+  });
+
+  it('debounces error toasts within a 5s window', () => {
+    const push = vi.fn();
+    renderHook(() => usePersistErrorBridge({ push }));
+    installed!();
+    installed!();
+    installed!();
+    expect(push).toHaveBeenCalledTimes(1);
+    const toast = push.mock.calls[0][0];
+    expect(toast.kind).toBe('error');
+    expect(toast.title).toBe('Failed to save state');
+  });
+});

--- a/tests/app-effects/useSessionActivateBridge.test.tsx
+++ b/tests/app-effects/useSessionActivateBridge.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useSessionActivateBridge } from '../../src/app-effects/useSessionActivateBridge';
+
+describe('useSessionActivateBridge', () => {
+  let onActivate: ReturnType<typeof vi.fn>;
+  let unsubscribe: ReturnType<typeof vi.fn>;
+  let activateCallback: ((e: { sid: string }) => void) | null = null;
+
+  beforeEach(() => {
+    unsubscribe = vi.fn();
+    onActivate = vi.fn((cb: (e: { sid: string }) => void) => {
+      activateCallback = cb;
+      return unsubscribe;
+    });
+    (window as unknown as { ccsmSession: unknown }).ccsmSession = { onActivate };
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { ccsmSession?: unknown }).ccsmSession;
+    activateCallback = null;
+  });
+
+  it('subscribes on mount and unsubscribes on unmount', () => {
+    const selectSession = vi.fn();
+    const { unmount } = renderHook(() => useSessionActivateBridge(selectSession));
+    expect(onActivate).toHaveBeenCalledTimes(1);
+    unmount();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards a valid sid to selectSession', () => {
+    const selectSession = vi.fn();
+    renderHook(() => useSessionActivateBridge(selectSession));
+    activateCallback!({ sid: 'abc123' });
+    expect(selectSession).toHaveBeenCalledWith('abc123');
+  });
+
+  it('ignores empty / malformed events', () => {
+    const selectSession = vi.fn();
+    renderHook(() => useSessionActivateBridge(selectSession));
+    activateCallback!({ sid: '' });
+    activateCallback!({ sid: undefined as unknown as string });
+    expect(selectSession).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the bridge is missing', () => {
+    delete (window as unknown as { ccsmSession?: unknown }).ccsmSession;
+    const selectSession = vi.fn();
+    expect(() =>
+      renderHook(() => useSessionActivateBridge(selectSession))
+    ).not.toThrow();
+  });
+});

--- a/tests/app-effects/useShortcutHandlers.test.tsx
+++ b/tests/app-effects/useShortcutHandlers.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useShortcutHandlers } from '../../src/app-effects/useShortcutHandlers';
+
+function dispatchKey(init: KeyboardEventInit & { target?: EventTarget }): KeyboardEvent {
+  const ev = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init });
+  if (init.target) {
+    Object.defineProperty(ev, 'target', { value: init.target });
+  }
+  window.dispatchEvent(ev);
+  return ev;
+}
+
+describe('useShortcutHandlers', () => {
+  let toggleShortcuts: ReturnType<typeof vi.fn>;
+  let togglePalette: ReturnType<typeof vi.fn>;
+  let toggleSidebar: ReturnType<typeof vi.fn>;
+  let openSettings: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    toggleShortcuts = vi.fn();
+    togglePalette = vi.fn();
+    toggleSidebar = vi.fn();
+    openSettings = vi.fn();
+  });
+
+  function mount() {
+    return renderHook(() =>
+      useShortcutHandlers({
+        toggleShortcuts,
+        togglePalette,
+        toggleSidebar,
+        openSettings,
+      })
+    );
+  }
+
+  it('Ctrl+/ toggles the shortcut overlay', () => {
+    mount();
+    dispatchKey({ key: '/', ctrlKey: true });
+    expect(toggleShortcuts).toHaveBeenCalledTimes(1);
+  });
+
+  it('Ctrl+F toggles the palette and Ctrl+B toggles the sidebar', () => {
+    mount();
+    dispatchKey({ key: 'f', ctrlKey: true });
+    dispatchKey({ key: 'b', ctrlKey: true });
+    expect(togglePalette).toHaveBeenCalledTimes(1);
+    expect(toggleSidebar).toHaveBeenCalledTimes(1);
+  });
+
+  it('Ctrl+, opens settings', () => {
+    mount();
+    dispatchKey({ key: ',', ctrlKey: true });
+    expect(openSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('"?" toggles the overlay only when target is not editable', () => {
+    mount();
+    dispatchKey({ key: '?' });
+    expect(toggleShortcuts).toHaveBeenCalledTimes(1);
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    dispatchKey({ key: '?', target: input });
+    expect(toggleShortcuts).toHaveBeenCalledTimes(1);
+    document.body.removeChild(input);
+  });
+
+  it('removes the keydown listener on unmount', () => {
+    const { unmount } = mount();
+    unmount();
+    dispatchKey({ key: '/', ctrlKey: true });
+    dispatchKey({ key: 'f', ctrlKey: true });
+    expect(toggleShortcuts).not.toHaveBeenCalled();
+    expect(togglePalette).not.toHaveBeenCalled();
+  });
+});

--- a/tests/app-effects/useThemeEffect.test.tsx
+++ b/tests/app-effects/useThemeEffect.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useThemeEffect } from '../../src/app-effects/useThemeEffect';
+
+describe('useThemeEffect', () => {
+  let mqlListeners: Array<(ev: MediaQueryListEvent) => void>;
+  let mql: MediaQueryList;
+  let matchesValue: boolean;
+
+  beforeEach(() => {
+    mqlListeners = [];
+    matchesValue = false;
+    mql = {
+      get matches() {
+        return matchesValue;
+      },
+      media: '(prefers-color-scheme: dark)',
+      addEventListener: vi.fn(
+        (_evt: string, cb: (ev: MediaQueryListEvent) => void) => {
+          mqlListeners.push(cb);
+        }
+      ),
+      removeEventListener: vi.fn(
+        (_evt: string, cb: (ev: MediaQueryListEvent) => void) => {
+          mqlListeners = mqlListeners.filter((x) => x !== cb);
+        }
+      ),
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    } as unknown as MediaQueryList;
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => mql)
+    );
+    // jsdom on Window
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: () => mql,
+    });
+    document.documentElement.className = '';
+    delete document.documentElement.dataset.theme;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('applies dark class for dark theme', () => {
+    renderHook(() => useThemeEffect('dark'));
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.documentElement.classList.contains('theme-light')).toBe(false);
+    expect(document.documentElement.dataset.theme).toBe('dark');
+  });
+
+  it('applies theme-light class for light theme', () => {
+    renderHook(() => useThemeEffect('light'));
+    expect(document.documentElement.classList.contains('theme-light')).toBe(true);
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('subscribes to matchMedia change events when theme is system, and unsubscribes on unmount', () => {
+    matchesValue = true;
+    const { unmount } = renderHook(() => useThemeEffect('system'));
+    expect(mql.addEventListener).toHaveBeenCalledTimes(1);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    unmount();
+    expect(mql.removeEventListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT subscribe to matchMedia for explicit (non-system) themes', () => {
+    renderHook(() => useThemeEffect('light'));
+    expect(mql.addEventListener).not.toHaveBeenCalled();
+  });
+});

--- a/tests/app-effects/useTutorialOverlay.test.tsx
+++ b/tests/app-effects/useTutorialOverlay.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useTutorialOverlay } from '../../src/app-effects/useTutorialOverlay';
+
+describe('useTutorialOverlay', () => {
+  it('shows the overlay when tutorialSeen is false', () => {
+    const { result } = renderHook(() =>
+      useTutorialOverlay({ tutorialSeen: false, markTutorialSeen: vi.fn() })
+    );
+    expect(result.current.show).toBe(true);
+  });
+
+  it('hides the overlay when tutorialSeen is true', () => {
+    const { result } = renderHook(() =>
+      useTutorialOverlay({ tutorialSeen: true, markTutorialSeen: vi.fn() })
+    );
+    expect(result.current.show).toBe(false);
+  });
+
+  it('dismiss() hides the overlay AND calls markTutorialSeen', () => {
+    const markTutorialSeen = vi.fn();
+    const { result } = renderHook(() =>
+      useTutorialOverlay({ tutorialSeen: false, markTutorialSeen })
+    );
+    expect(result.current.show).toBe(true);
+    act(() => {
+      result.current.dismiss();
+    });
+    expect(result.current.show).toBe(false);
+    expect(markTutorialSeen).toHaveBeenCalledTimes(1);
+  });
+
+  it('reacts to tutorialSeen prop changes (e.g. user resets from settings)', () => {
+    const { result, rerender } = renderHook(
+      ({ seen }: { seen: boolean }) =>
+        useTutorialOverlay({ tutorialSeen: seen, markTutorialSeen: vi.fn() }),
+      { initialProps: { seen: true } }
+    );
+    expect(result.current.show).toBe(false);
+    rerender({ seen: false });
+    expect(result.current.show).toBe(true);
+  });
+});

--- a/tests/app-effects/useUpdateDownloadedBridge.test.tsx
+++ b/tests/app-effects/useUpdateDownloadedBridge.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useUpdateDownloadedBridge } from '../../src/app-effects/useUpdateDownloadedBridge';
+
+describe('useUpdateDownloadedBridge', () => {
+  let onUpdateDownloaded: ReturnType<typeof vi.fn>;
+  let unsubscribe: ReturnType<typeof vi.fn>;
+  let downloadedCb: ((info: { version: string }) => void) | null = null;
+  let updatesInstall: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    unsubscribe = vi.fn();
+    onUpdateDownloaded = vi.fn((cb: (info: { version: string }) => void) => {
+      downloadedCb = cb;
+      return unsubscribe;
+    });
+    updatesInstall = vi.fn();
+    (window as unknown as { ccsm: unknown }).ccsm = {
+      onUpdateDownloaded,
+      updatesInstall,
+    };
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { ccsm?: unknown }).ccsm;
+    downloadedCb = null;
+  });
+
+  it('subscribes on mount and unsubscribes on unmount', () => {
+    const push = vi.fn();
+    const { unmount } = renderHook(() => useUpdateDownloadedBridge({ push }));
+    expect(onUpdateDownloaded).toHaveBeenCalledTimes(1);
+    unmount();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('pushes a single persistent toast on first update event, then ignores subsequent events', () => {
+    const push = vi.fn();
+    renderHook(() => useUpdateDownloadedBridge({ push }));
+    downloadedCb!({ version: '1.2.3' });
+    downloadedCb!({ version: '1.2.4' });
+    expect(push).toHaveBeenCalledTimes(1);
+    const toast = push.mock.calls[0][0];
+    expect(toast.kind).toBe('info');
+    expect(toast.persistent).toBe(true);
+    expect(typeof toast.action.onClick).toBe('function');
+    toast.action.onClick();
+    expect(updatesInstall).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Scope

Phase A of Task #724. Adds 9 NEW custom hooks under `src/app-effects/` plus 9 RTL unit tests under `tests/app-effects/`. **`src/App.tsx` is intentionally untouched in this PR.** Phase B (separate follow-up) will rewrite App.tsx to call these hooks; splitting the cut-over from the extraction keeps the diff reviewable and the rollback surgical.

## Why

App.tsx had grown to 21 inline `useEffect` blocks (~720 LoC) — a single render function holding theme sync, IPC bridges, keyboard shortcuts, and tutorial state all at once. Hard to test in isolation, hard to reason about, hard to see what depends on what. SRP says each effect is its own concern, and a hook is the right unit. After Phase B, App.tsx becomes a thin compose function over named hooks.

## Hook to App.tsx mapping

| New hook | Original App.tsx lines | Concern |
|----------|------------------------|---------|
| `useThemeEffect` | 99-115 | sync theme + OS scheme to `<html>` classes |
| `useLanguageEffect` | 348-350 | push resolved language to main |
| `useAgentEventBridge` | 238-240 | install `subscribeAgentEvents()` |
| `useShortcutHandlers` | 453-500 | composite Ctrl+/, ?, Ctrl+F/B/, keydown |
| `useSessionActivateBridge` | 172-183 | `ccsmSession.onActivate` listener |
| `useFocusBridge` | 249-265 | window `focus` listener (callback injected) |
| `useUpdateDownloadedBridge` | 691-720 | hook-form rewrite of `<UpdateDownloadedBridge />` |
| `usePersistErrorBridge` | 667-684 | hook-form rewrite of `<PersistErrorBridge />` |
| `useTutorialOverlay` | (derived) | tutorial show/dismiss derived from store flag |

`useTutorialOverlay` doesn't have a 1:1 source effect — App.tsx renders the tutorial conditionally on `tutorialSeen`. Per the task spec ("name reflects intent"), the hook centralizes the show/dismiss logic Phase B will move out of App's render.

## Tests

- 9 RTL `renderHook` test files, 29 tests total, all passing.
- Each hook has subscribe/unsubscribe assertions plus 1-2 behaviour assertions.
- `npx vitest run tests/app-effects/` → 9 files, 29 passed.
- `npx vitest run` → 544 passed, 3 pre-existing failures in `electron/__tests__/db-hardening.test.ts` (verified on base branch — not introduced by this PR; native `better-sqlite3` env issue).
- `npm run build` → clean (3 webpack size warnings, no errors).

## Reverse-verify

Temporarily moved two hook files away to confirm tests fail with import errors, then restored.

```
$ mv src/app-effects/useThemeEffect.ts /tmp/  
$ mv src/app-effects/useFocusBridge.ts /tmp/
$ npx vitest run tests/app-effects/useThemeEffect.test.tsx tests/app-effects/useFocusBridge.test.tsx
FAIL tests/app-effects/useThemeEffect.test.tsx
  Failed to resolve import "../../src/app-effects/useThemeEffect"
FAIL tests/app-effects/useFocusBridge.test.tsx
  Failed to resolve import "../../src/app-effects/useFocusBridge"
Test Files  2 failed (2)

# (restored)
$ npx vitest run tests/app-effects/
Test Files  9 passed (9)
Tests       29 passed (29)
```

## Constraints honoured

- `src/App.tsx` untouched.
- No files outside `src/app-effects/` (9 new) and `tests/app-effects/` (9 new) modified.
- English-only commit/PR/code comments.