### PR TITLE
refactor(terminal): extract 3 hooks (Task #734 Phase A)

### DIFF
--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -1,455 +1,38 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { Terminal } from '@xterm/xterm';
-import { FitAddon } from '@xterm/addon-fit';
-import { WebLinksAddon } from '@xterm/addon-web-links';
-import { ClipboardAddon } from '@xterm/addon-clipboard';
-import { Unicode11Addon } from '@xterm/addon-unicode11';
-import { CanvasAddon } from '@xterm/addon-canvas';
+import { useRef } from 'react';
 import '@xterm/xterm/css/xterm.css';
 import { useTranslation } from '../i18n/useTranslation';
-import { useStore } from '../stores/store';
-import { classifyPtyExit } from '../lib/ptyExitClassifier';
+import { useXtermSingleton } from '../terminal/useXtermSingleton';
+import { useTerminalResize } from '../terminal/useTerminalResize';
+import { usePtyAttach, type PtyAttachState } from '../terminal/usePtyAttach';
+// classifyPtyExit is re-exported for backward compat with any direct
+// importers; the actual exit classification now lives inside usePtyAttach.
+export { classifyPtyExit } from '../lib/ptyExitClassifier';
 
-// TerminalPane mounts a singleton xterm.js Terminal that we attach/detach
-// against per-session PTYs over IPC (window.ccsmPty). This is the React
-// port of the validated spike at spike/xterm-attach/src/renderer/renderer.mjs.
-//
-// Why a module-scope singleton (NOT per-React-mount):
-//   - Recreating the Terminal on every session switch is expensive: the
-//     canvas renderer rebuilds its glyph atlas, addons re-allocate, and
-//     in dev React StrictMode would double-invoke the constructor.
-//   - More importantly, ccsm's session-keepalive guarantee says the user
-//     can flip between sessions without the underlying terminal/PTY pairing
-//     being torn down. The PTY lives in the main process; the rendered
-//     view is a single xterm bound to whichever sid is active. Switching
-//     sessions = `term.reset()` + IPC re-attach with the new sid's
-//     snapshot, no DOM reconstruction.
-//
-// Lifecycle:
-//   1. First mount creates the singleton: addons (fit/weblinks/clipboard/
-//      unicode11/canvas), key handler, selection→clipboard, title→document.
-//   2. sessionId effect: detach prev (dispose subs, await pty.detach),
-//      term.reset(), pty.attach(new sid) → write snapshot, subscribe to
-//      pty.onData filtered by activeSid, wire term.onData → pty.input,
-//      then fit().
-//   3. ResizeObserver (80ms debounce) → fit + pty.resize.
-//   4. pty.onExit for active sid → flip to error state with Retry.
+// TerminalPane is the host shell for the singleton xterm view. The three
+// concerns it used to mash together — singleton bring-up, PTY lifecycle,
+// container resize — now live in dedicated hooks under src/terminal/.
+// This file is the host div + ExitState/ErrorState overlays + composition
+// of those three hooks. See:
+//   - src/terminal/xtermSingleton.ts    (module-singleton state + ensureTerminal)
+//   - src/terminal/useXtermSingleton.ts (mount-once bring-up)
+//   - src/terminal/usePtyAttach.ts      (attach/detach/snapshot/subscribe + exit)
+//   - src/terminal/useTerminalResize.ts (ResizeObserver + fit)
 //
 // The host div carries [data-terminal-host] and [data-active-sid={sessionId}]
 // so the e2e probes (PR-7) can locate the active terminal deterministically.
-
-declare global {
-  interface Window {
-    // Local stub until PR-3 lands the proper src/pty.d.ts. PR-8 收口 may
-    // remove this if the global declaration is in place by then.
-    ccsmPty: any;
-    __ccsmTerm?: Terminal;
-  }
-}
 
 type Props = {
   sessionId: string;
   cwd: string;
 };
 
-type State =
-  | { kind: 'attaching' }
-  | { kind: 'ready' }
-  // `exit` is the new shape — distinguishes user-intentional clean exit
-  // (no signal, code 0) from a crash. The former renders a neutral
-  // overlay + "claude exited" copy; the latter renders the red overlay
-  // + "claude crashed... not a ccsm bug" copy. Both show Retry. The
-  // legacy `error` shape stays for spawn/attach failures (spawn IPC
-  // returned !ok, ccsmPty unavailable, etc.) which are NOT pty exits.
-  | { kind: 'exit'; exitKind: 'clean' | 'crashed'; detail: string }
-  | { kind: 'error'; message: string };
-
-// Module-scope singleton state. Initialised lazily on first mount so we
-// don't run xterm constructors at import time (would explode in non-DOM
-// test environments).
-let term: Terminal | null = null;
-let fit: FitAddon | null = null;
-let activeSid: string | null = null;
-let unsubscribeData: (() => void) | null = null;
-let inputDisposable: { dispose: () => void } | null = null;
-
-function ensureTerminal(host: HTMLDivElement): Terminal {
-  if (term) {
-    // Re-open against the new host element if React remounted us into a
-    // different node (rare — App keeps the pane mounted — but harmless).
-    if ((term as any)._core?._parent !== host) {
-      try {
-        term.open(host);
-      } catch {
-        // open() throws if already attached to this exact host; ignore.
-      }
-    }
-    return term;
-  }
-
-  term = new Terminal({
-    fontFamily: 'Cascadia Mono, Consolas, "Courier New", monospace',
-    fontSize: 13,
-    cursorBlink: true,
-    allowProposedApi: true,
-    scrollback: 5000,
-    theme: { background: '#000000' },
-  });
-  fit = new FitAddon();
-  term.loadAddon(fit);
-  try {
-    term.loadAddon(new WebLinksAddon());
-  } catch (e) {
-    console.warn('[TerminalPane] web-links addon failed', e);
-  }
-  try {
-    term.loadAddon(new ClipboardAddon());
-  } catch (e) {
-    console.warn('[TerminalPane] clipboard addon failed', e);
-  }
-  try {
-    term.loadAddon(new Unicode11Addon());
-    term.unicode.activeVersion = '11';
-  } catch (e) {
-    console.warn('[TerminalPane] unicode11 addon failed', e);
-  }
-  // Canvas renderer is the safe middle ground (DOM is slow on dense
-  // output, WebGL flakes under RDP). Fall back silently to default DOM
-  // renderer if the GPU path can't initialise.
-  try {
-    term.loadAddon(new CanvasAddon());
-  } catch (e) {
-    console.warn('[TerminalPane] canvas addon failed, falling back to DOM', e);
-  }
-
-  term.open(host);
-
-  // ttyd-style: auto-copy on selection change. Works in alt-screen apps
-  // (claude/Ink) when user holds Shift to bypass mouse tracking and
-  // drags. Use Electron's clipboard via preload because navigator.clipboard
-  // requires user-activation that xterm's keydown swallow doesn't reliably
-  // propagate, and silently fails under default contextIsolation.
-  term.onSelectionChange(() => {
-    if (!term) return;
-    const sel = term.getSelection();
-    if (sel) {
-      try {
-        window.ccsmPty?.clipboard?.writeText(sel);
-      } catch {
-        // ignore clipboard failures — selection still highlights.
-      }
-    }
-  });
-
-  // Copy/paste keyboard shortcuts (Windows Terminal style):
-  //   Ctrl+C  → if selection, copy; else fall through to SIGINT
-  //   Ctrl+V  → paste
-  //   Ctrl+Shift+C / Ctrl+Shift+V → explicit always-clipboard
-  term.attachCustomKeyEventHandler((ev) => {
-    if (ev.type !== 'keydown') return true;
-    const isC = ev.key === 'C' || ev.key === 'c';
-    const isV = ev.key === 'V' || ev.key === 'v';
-
-    if (ev.ctrlKey && !ev.shiftKey && !ev.altKey && isC) {
-      const sel = term?.getSelection();
-      if (sel) {
-        try {
-          window.ccsmPty?.clipboard?.writeText(sel);
-        } catch {
-          // ignore clipboard failures — selection still highlights.
-        }
-        return false;
-      }
-      return true;
-    }
-    if (ev.ctrlKey && !ev.shiftKey && !ev.altKey && isV) {
-      try {
-        const text = window.ccsmPty?.clipboard?.readText();
-        if (text && activeSid) window.ccsmPty.input(activeSid, text);
-      } catch {
-        // ignore clipboard failures — paste is best-effort.
-      }
-      return false;
-    }
-    if (ev.ctrlKey && ev.shiftKey && isC) {
-      const sel = term?.getSelection();
-      if (sel) {
-        try {
-          window.ccsmPty?.clipboard?.writeText(sel);
-        } catch {
-          // ignore clipboard failures — selection still highlights.
-        }
-      }
-      return false;
-    }
-    if (ev.ctrlKey && ev.shiftKey && isV) {
-      try {
-        const text = window.ccsmPty?.clipboard?.readText();
-        if (text && activeSid) window.ccsmPty.input(activeSid, text);
-      } catch {
-        // ignore clipboard failures — paste is best-effort.
-      }
-      return false;
-    }
-    return true;
-  });
-
-  // Probe hook for e2e harness — exposed unconditionally because the
-  // direct-xterm probes (harness-real-cli pty-pid-stable-across-switch /
-  // switch-session-keeps-chat) drive the production webpack bundle and
-  // would otherwise have no way to reach the live Terminal handle. This
-  // mirrors the unconditional `window.__ccsmStore` exposure in App.tsx —
-  // a debug affordance, not a security boundary, since the renderer is
-  // already a single-origin Electron context with no remote content.
-  window.__ccsmTerm = term;
-
-  return term;
-}
-
-export function TerminalPane({ sessionId, cwd: _cwd }: Props) {
+export function TerminalPane({ sessionId, cwd }: Props) {
   const hostRef = useRef<HTMLDivElement | null>(null);
-  const [state, setState] = useState<State>({ kind: 'attaching' });
   const { t } = useTranslation();
-  // Store action — clear the disconnect entry on respawn success so the
-  // sidebar red dot disappears the moment the pty is back. Pulled via
-  // selector so this component re-renders only when the function ref
-  // changes (it doesn't, in practice — zustand actions are stable). We
-  // route through a ref so the attach effect doesn't need to depend on
-  // it (and re-run unnecessarily).
-  const clearPtyExit = useStore((s) => s._clearPtyExit);
-  const clearPtyExitRef = useRef(clearPtyExit);
-  clearPtyExitRef.current = clearPtyExit;
-  // Tracks the sessionId we're currently attaching for so a stale resolve
-  // from a previous session can't clobber the current one when the user
-  // switches quickly.
-  const requestedSidRef = useRef<string>(sessionId);
-  // Bumped by Retry to force the attach effect to re-run for the same sid.
-  const [attachNonce, setAttachNonce] = useState(0);
 
-  // Mount-once: instantiate the singleton against our host div.
-  useEffect(() => {
-    if (!hostRef.current) return;
-    ensureTerminal(hostRef.current);
-  }, []);
-
-  // ResizeObserver with 80ms debounce → fit + pty.resize.
-  useEffect(() => {
-    const host = hostRef.current;
-    if (!host) return;
-    let debounce: ReturnType<typeof setTimeout> | null = null;
-    const ro = new ResizeObserver(() => {
-      if (debounce) clearTimeout(debounce);
-      debounce = setTimeout(() => {
-        if (!term || !fit || !activeSid) return;
-        try {
-          fit.fit();
-          const { cols, rows } = term;
-          window.ccsmPty?.resize(activeSid, cols, rows);
-        } catch (e) {
-          console.warn('[TerminalPane] fit failed', e);
-        }
-      }, 80);
-    });
-    ro.observe(host);
-    return () => {
-      if (debounce) clearTimeout(debounce);
-      ro.disconnect();
-    };
-  }, []);
-
-  // Attach effect: on sessionId change (or Retry), detach the previous
-  // session, reset the terminal, attach the new one, and wire data flow.
-  useEffect(() => {
-    requestedSidRef.current = sessionId;
-    let cancelled = false;
-    setState({ kind: 'attaching' });
-
-    (async () => {
-      const pty = window.ccsmPty;
-      if (!pty) {
-        if (!cancelled) setState({ kind: 'error', message: 'ccsmPty unavailable' });
-        return;
-      }
-
-      const prevSid = activeSid;
-      if (prevSid && prevSid !== sessionId) {
-        if (unsubscribeData) {
-          try {
-            unsubscribeData();
-          } catch {
-            // already torn down — safe to ignore.
-          }
-          unsubscribeData = null;
-        }
-        if (inputDisposable) {
-          try {
-            inputDisposable.dispose();
-          } catch {
-            // already disposed — safe to ignore.
-          }
-          inputDisposable = null;
-        }
-        try {
-          await pty.detach(prevSid);
-        } catch {
-          // detach failure is non-fatal — main may already have torn it down.
-        }
-      } else if (prevSid === sessionId) {
-        // Same sid (Retry path): tear down stale subscriptions before re-attaching
-        // so we don't double-write incoming chunks.
-        if (unsubscribeData) {
-          try {
-            unsubscribeData();
-          } catch {
-            // already torn down — safe to ignore.
-          }
-          unsubscribeData = null;
-        }
-        if (inputDisposable) {
-          try {
-            inputDisposable.dispose();
-          } catch {
-            // already disposed — safe to ignore.
-          }
-          inputDisposable = null;
-        }
-      }
-
-      if (cancelled || requestedSidRef.current !== sessionId) return;
-
-      if (term) term.reset();
-
-      try {
-        // Spawn-on-attach-null fallback. The renderer drives session
-        // lifecycle, so an attach against a sid main has not seen yet
-        // returns null — we then ask main to spawn the pty (using the
-        // session's cwd) and re-attach. Subsequent attaches reuse the
-        // existing pty (spawnPtySession is idempotent on sid).
-        let res = (await pty.attach(sessionId)) as
-          | { snapshot: string; cols: number; rows: number; pid: number }
-          | null;
-        if (!res) {
-          const spawnResult = (await pty.spawn(sessionId, _cwd ?? '')) as
-            | { ok: true; sid: string; pid: number; cols: number; rows: number }
-            | { ok: false; error: string };
-          if (!spawnResult || spawnResult.ok === false) {
-            const reason =
-              spawnResult && spawnResult.ok === false ? spawnResult.error : 'spawn_failed';
-            throw new Error(reason);
-          }
-          res = (await pty.attach(sessionId)) as
-            | { snapshot: string; cols: number; rows: number; pid: number }
-            | null;
-          if (!res) throw new Error('attach_failed_after_spawn');
-        }
-        const { snapshot, cols, rows } = res;
-        if (cancelled || requestedSidRef.current !== sessionId) return;
-
-        activeSid = sessionId;
-        if (term) {
-          try {
-            term.resize(cols, rows);
-          } catch {
-            // resize is best-effort — proceed with snapshot write.
-          }
-          if (snapshot) term.write(snapshot);
-        }
-
-        unsubscribeData = pty.onData((payload: { sid: string; chunk: string }) => {
-          if (payload.sid !== activeSid) return;
-          term?.write(payload.chunk);
-        });
-
-        if (term) {
-          inputDisposable = term.onData((data: string) => {
-            if (activeSid) window.ccsmPty.input(activeSid, data);
-          });
-        }
-
-        // Push the current container size to the backend so claude
-        // re-wraps to the visible viewport rather than the spawn-time cols/rows.
-        if (fit && term && activeSid) {
-          try {
-            fit.fit();
-            window.ccsmPty.resize(activeSid, term.cols, term.rows);
-          } catch (e) {
-            console.warn('[TerminalPane] post-attach fit failed', e);
-          }
-        }
-
-        // Task #548 — transfer keyboard focus to the embedded xterm so the
-        // user's first keystroke after spawning / importing / resuming a
-        // session reaches claude's TUI rather than whichever sidebar
-        // button or shortcut element triggered the create. App.tsx blurs
-        // the trigger synchronously, but with no explicit handoff the
-        // body becomes the activeElement and Enter ends up as a no-op.
-        // Calling term.focus() here covers all entry paths (sidebar
-        // click, keyboard shortcut, import, reopen-resume) because they
-        // all funnel through this attach effect.
-        if (term) {
-          try {
-            term.focus();
-          } catch (e) {
-            console.warn('[TerminalPane] term.focus failed', e);
-          }
-        }
-
-        if (!cancelled) setState({ kind: 'ready' });
-        // Successful (re-)attach means whatever pty is running for this
-        // sid is healthy — drop any stale disconnect entry so the
-        // sidebar red dot clears and a future crash starts from a clean
-        // slate. Idempotent if no entry exists.
-        clearPtyExitRef.current(sessionId);
-      } catch (err) {
-        if (cancelled || requestedSidRef.current !== sessionId) return;
-        const message = err instanceof Error ? err.message : String(err);
-        setState({ kind: 'error', message });
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-    // attachNonce is intentional: bumping it re-runs the attach for Retry.
-  }, [sessionId, attachNonce]);
-
-  // pty:exit subscription for the active session → flip to exit state with
-  // a classification (clean vs crashed) shared with the store via
-  // `classifyPtyExit` (src/lib/ptyExitClassifier.ts), so the active-pane
-  // overlay and the sidebar red-dot signal stay consistent. `t` is
-  // intentionally excluded from deps: changing language while a session is
-  // alive should not re-subscribe; localized strings are resolved at
-  // render time.
-  useEffect(() => {
-    const pty = window.ccsmPty;
-    if (!pty?.onExit) return;
-    const unsubscribe = pty.onExit(
-      (evt: { sessionId: string; code?: number | null; signal?: string | number | null }) => {
-        if (evt.sessionId !== activeSid) return;
-        const signal = evt.signal ?? null;
-        const code = evt.code ?? null;
-        const exitKind = classifyPtyExit({ code, signal });
-        const detail =
-          signal != null
-            ? `signal ${signal}`
-            : code != null
-              ? `exit code ${code}`
-              : 'unknown';
-        setState({ kind: 'exit', exitKind, detail });
-      },
-    );
-    return () => {
-      try {
-        unsubscribe?.();
-      } catch {
-        // already torn down — safe to ignore.
-      }
-    };
-  }, []);
-
-  const onRetry = useCallback(() => {
-    setAttachNonce((n) => n + 1);
-  }, []);
+  useXtermSingleton(hostRef);
+  useTerminalResize(hostRef);
+  const { state, onRetry } = usePtyAttach(sessionId, cwd);
 
   return (
     <div
@@ -458,69 +41,88 @@ export function TerminalPane({ sessionId, cwd: _cwd }: Props) {
       data-active-sid={sessionId}
     >
       <div ref={hostRef} className="absolute inset-0" />
-      {state.kind === 'attaching' && (
-        <div className="absolute inset-0 z-10 flex items-center justify-center text-neutral-400 text-sm pointer-events-none">
-          Attaching...
-        </div>
-      )}
-      {state.kind === 'error' && (
-        // z-10 so the overlay sits above xterm's canvas layers (the canvas
-        // renderer stacks its own absolutely-positioned canvases inside the
-        // host div with non-zero z-index — without an explicit z here the
-        // Retry button is rendered but unclickable). select-text on the
-        // message so the user can highlight + Ctrl+C the error to share
-        // (e.g. "spawn_failed: ... error code:267") with support.
-        <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 text-sm bg-black/80">
-          <div className="text-red-400 max-w-md text-center break-words px-4 select-text">
-            {state.message}
-          </div>
-          <button
-            type="button"
-            onClick={onRetry}
-            className="px-3 py-1 rounded border border-neutral-700 text-neutral-200 hover:bg-neutral-800 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-neutral-400"
-          >
-            Retry
-          </button>
-        </div>
-      )}
-      {state.kind === 'exit' && (
-        // Two-tone overlay: clean exits get a neutral/dim background
-        // (user typed /exit on purpose, no alarm); crashed exits keep
-        // the red treatment so the user notices. Copy is locked in
-        // i18n — `terminal.exitedClean` reassures, `terminal.exitedCrash`
-        // explicitly disclaims ccsm involvement and points at the
-        // on-disk transcript so the user knows their work is safe.
-        // z-10 + select-text rationale matches the `error` overlay above.
-        <div
-          data-pty-exit-kind={state.exitKind}
-          className={
-            state.exitKind === 'crashed'
-              ? 'absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 text-sm bg-black/80'
-              : 'absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 text-sm bg-neutral-900/85'
-          }
-        >
-          <div
-            className={
-              state.exitKind === 'crashed'
-                ? 'text-state-error-text max-w-md text-center break-words px-4 select-text'
-                : 'text-neutral-300 max-w-md text-center break-words px-4 select-text'
-            }
-          >
-            {state.exitKind === 'crashed'
-              ? t('terminal.exitedCrash', { detail: state.detail })
-              : t('terminal.exitedClean')}
-          </div>
-          <button
-            type="button"
-            onClick={onRetry}
-            className="px-3 py-1 rounded border border-neutral-700 text-neutral-200 hover:bg-neutral-800 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-neutral-400"
-          >
-            {t('terminal.exitedRetry')}
-          </button>
-        </div>
-      )}
+      <Overlay state={state} onRetry={onRetry} t={t} />
     </div>
   );
+}
+
+function Overlay({
+  state,
+  onRetry,
+  t,
+}: {
+  state: PtyAttachState;
+  onRetry: () => void;
+  t: (key: string, opts?: Record<string, unknown>) => string;
+}) {
+  if (state.kind === 'attaching') {
+    return (
+      <div className="absolute inset-0 z-10 flex items-center justify-center text-neutral-400 text-sm pointer-events-none">
+        Attaching...
+      </div>
+    );
+  }
+  if (state.kind === 'error') {
+    // z-10 so the overlay sits above xterm's canvas layers (the canvas
+    // renderer stacks its own absolutely-positioned canvases inside the
+    // host div with non-zero z-index — without an explicit z here the
+    // Retry button is rendered but unclickable). select-text on the
+    // message so the user can highlight + Ctrl+C the error to share
+    // (e.g. "spawn_failed: ... error code:267") with support.
+    return (
+      <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 text-sm bg-black/80">
+        <div className="text-red-400 max-w-md text-center break-words px-4 select-text">
+          {state.message}
+        </div>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="px-3 py-1 rounded border border-neutral-700 text-neutral-200 hover:bg-neutral-800 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-neutral-400"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+  if (state.kind === 'exit') {
+    // Two-tone overlay: clean exits get a neutral/dim background (user
+    // typed /exit on purpose, no alarm); crashed exits keep the red
+    // treatment so the user notices. Copy is locked in i18n —
+    // `terminal.exitedClean` reassures, `terminal.exitedCrash` explicitly
+    // disclaims ccsm involvement and points at the on-disk transcript so
+    // the user knows their work is safe. z-10 + select-text rationale
+    // matches the `error` overlay above.
+    return (
+      <div
+        data-pty-exit-kind={state.exitKind}
+        className={
+          state.exitKind === 'crashed'
+            ? 'absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 text-sm bg-black/80'
+            : 'absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 text-sm bg-neutral-900/85'
+        }
+      >
+        <div
+          className={
+            state.exitKind === 'crashed'
+              ? 'text-state-error-text max-w-md text-center break-words px-4 select-text'
+              : 'text-neutral-300 max-w-md text-center break-words px-4 select-text'
+          }
+        >
+          {state.exitKind === 'crashed'
+            ? t('terminal.exitedCrash', { detail: state.detail })
+            : t('terminal.exitedClean')}
+        </div>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="px-3 py-1 rounded border border-neutral-700 text-neutral-200 hover:bg-neutral-800 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-neutral-400"
+        >
+          {t('terminal.exitedRetry')}
+        </button>
+      </div>
+    );
+  }
+  return null;
 }
 
 export default TerminalPane;

--- a/src/terminal/usePtyAttach.ts
+++ b/src/terminal/usePtyAttach.ts
@@ -1,0 +1,270 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useStore } from '../stores/store';
+import { classifyPtyExit } from '../lib/ptyExitClassifier';
+import {
+  getTerm,
+  getFit,
+  getActiveSid,
+  setActiveSid,
+  getUnsubscribeData,
+  setUnsubscribeData,
+  getInputDisposable,
+  setInputDisposable,
+} from './xtermSingleton';
+
+export type PtyAttachState =
+  | { kind: 'attaching' }
+  | { kind: 'ready' }
+  // `exit` distinguishes user-intentional clean exit (no signal, code 0)
+  // from a crash. The former renders a neutral overlay + "claude exited"
+  // copy; the latter renders the red overlay + "claude crashed... not a
+  // ccsm bug" copy. Both show Retry. The legacy `error` shape stays for
+  // spawn/attach failures (spawn IPC returned !ok, ccsmPty unavailable,
+  // etc.) which are NOT pty exits.
+  | { kind: 'exit'; exitKind: 'clean' | 'crashed'; detail: string }
+  | { kind: 'error'; message: string };
+
+export type UsePtyAttachResult = {
+  state: PtyAttachState;
+  onRetry: () => void;
+};
+
+/**
+ * Owns the PTY lifecycle for a given sessionId:
+ *   1. On sessionId (or Retry) change: detach previous, reset terminal,
+ *      attach new (with spawn-on-null fallback), write snapshot, wire
+ *      onData both directions, fit, focus.
+ *   2. Subscribes to `pty.onExit` for the active sid → flips state to
+ *      `exit` with classification (clean vs crashed) consistent with
+ *      `classifyPtyExit` so the overlay and the sidebar red-dot signal
+ *      stay aligned.
+ *   3. On successful (re-)attach, clears any stale disconnect entry from
+ *      the store so the sidebar red dot disappears.
+ *
+ * Returns `{ state, onRetry }` for the host component to render the
+ * appropriate overlay (attaching / error / exit) and Retry button.
+ */
+export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult {
+  const [state, setState] = useState<PtyAttachState>({ kind: 'attaching' });
+  // Store action — clear the disconnect entry on respawn success so the
+  // sidebar red dot disappears the moment the pty is back. Routed through
+  // a ref so the attach effect doesn't depend on it (and re-run unnecessarily).
+  const clearPtyExit = useStore((s) => s._clearPtyExit);
+  const clearPtyExitRef = useRef(clearPtyExit);
+  clearPtyExitRef.current = clearPtyExit;
+  // Tracks the sessionId we're currently attaching for so a stale resolve
+  // from a previous session can't clobber the current one when the user
+  // switches quickly.
+  const requestedSidRef = useRef<string>(sessionId);
+  // Bumped by Retry to force the attach effect to re-run for the same sid.
+  const [attachNonce, setAttachNonce] = useState(0);
+
+  // Attach effect: on sessionId change (or Retry), detach the previous
+  // session, reset the terminal, attach the new one, and wire data flow.
+  useEffect(() => {
+    requestedSidRef.current = sessionId;
+    let cancelled = false;
+    setState({ kind: 'attaching' });
+
+    (async () => {
+      const pty = window.ccsmPty;
+      if (!pty) {
+        if (!cancelled) setState({ kind: 'error', message: 'ccsmPty unavailable' });
+        return;
+      }
+
+      const prevSid = getActiveSid();
+      if (prevSid && prevSid !== sessionId) {
+        const unsub = getUnsubscribeData();
+        if (unsub) {
+          try {
+            unsub();
+          } catch {
+            // already torn down — safe to ignore.
+          }
+          setUnsubscribeData(null);
+        }
+        const inDisp = getInputDisposable();
+        if (inDisp) {
+          try {
+            inDisp.dispose();
+          } catch {
+            // already disposed — safe to ignore.
+          }
+          setInputDisposable(null);
+        }
+        try {
+          await pty.detach(prevSid);
+        } catch {
+          // detach failure is non-fatal — main may already have torn it down.
+        }
+      } else if (prevSid === sessionId) {
+        // Same sid (Retry path): tear down stale subscriptions before re-attaching
+        // so we don't double-write incoming chunks.
+        const unsub = getUnsubscribeData();
+        if (unsub) {
+          try {
+            unsub();
+          } catch {
+            // already torn down — safe to ignore.
+          }
+          setUnsubscribeData(null);
+        }
+        const inDisp = getInputDisposable();
+        if (inDisp) {
+          try {
+            inDisp.dispose();
+          } catch {
+            // already disposed — safe to ignore.
+          }
+          setInputDisposable(null);
+        }
+      }
+
+      if (cancelled || requestedSidRef.current !== sessionId) return;
+
+      const term = getTerm();
+      if (term) term.reset();
+
+      try {
+        // Spawn-on-attach-null fallback. The renderer drives session
+        // lifecycle, so an attach against a sid main has not seen yet
+        // returns null — we then ask main to spawn the pty (using the
+        // session's cwd) and re-attach. Subsequent attaches reuse the
+        // existing pty (spawnPtySession is idempotent on sid).
+        let res = (await pty.attach(sessionId)) as
+          | { snapshot: string; cols: number; rows: number; pid: number }
+          | null;
+        if (!res) {
+          const spawnResult = (await pty.spawn(sessionId, cwd ?? '')) as
+            | { ok: true; sid: string; pid: number; cols: number; rows: number }
+            | { ok: false; error: string };
+          if (!spawnResult || spawnResult.ok === false) {
+            const reason =
+              spawnResult && spawnResult.ok === false ? spawnResult.error : 'spawn_failed';
+            throw new Error(reason);
+          }
+          res = (await pty.attach(sessionId)) as
+            | { snapshot: string; cols: number; rows: number; pid: number }
+            | null;
+          if (!res) throw new Error('attach_failed_after_spawn');
+        }
+        const { snapshot, cols, rows } = res;
+        if (cancelled || requestedSidRef.current !== sessionId) return;
+
+        setActiveSid(sessionId);
+        const t2 = getTerm();
+        if (t2) {
+          try {
+            t2.resize(cols, rows);
+          } catch {
+            // resize is best-effort — proceed with snapshot write.
+          }
+          if (snapshot) t2.write(snapshot);
+        }
+
+        setUnsubscribeData(
+          pty.onData((payload: { sid: string; chunk: string }) => {
+            if (payload.sid !== getActiveSid()) return;
+            getTerm()?.write(payload.chunk);
+          }),
+        );
+
+        const t3 = getTerm();
+        if (t3) {
+          setInputDisposable(
+            t3.onData((data: string) => {
+              const sid = getActiveSid();
+              if (sid) window.ccsmPty.input(sid, data);
+            }),
+          );
+        }
+
+        // Push the current container size to the backend so claude
+        // re-wraps to the visible viewport rather than the spawn-time cols/rows.
+        const fit = getFit();
+        const t4 = getTerm();
+        const sid4 = getActiveSid();
+        if (fit && t4 && sid4) {
+          try {
+            fit.fit();
+            window.ccsmPty.resize(sid4, t4.cols, t4.rows);
+          } catch (e) {
+            console.warn('[TerminalPane] post-attach fit failed', e);
+          }
+        }
+
+        // Task #548 — transfer keyboard focus to the embedded xterm so the
+        // user's first keystroke after spawning / importing / resuming a
+        // session reaches claude's TUI rather than whichever sidebar
+        // button or shortcut element triggered the create. App.tsx blurs
+        // the trigger synchronously, but with no explicit handoff the
+        // body becomes the activeElement and Enter ends up as a no-op.
+        // Calling term.focus() here covers all entry paths (sidebar
+        // click, keyboard shortcut, import, reopen-resume) because they
+        // all funnel through this attach effect.
+        const t5 = getTerm();
+        if (t5) {
+          try {
+            t5.focus();
+          } catch (e) {
+            console.warn('[TerminalPane] term.focus failed', e);
+          }
+        }
+
+        if (!cancelled) setState({ kind: 'ready' });
+        // Successful (re-)attach means whatever pty is running for this
+        // sid is healthy — drop any stale disconnect entry so the
+        // sidebar red dot clears and a future crash starts from a clean
+        // slate. Idempotent if no entry exists.
+        clearPtyExitRef.current(sessionId);
+      } catch (err) {
+        if (cancelled || requestedSidRef.current !== sessionId) return;
+        const message = err instanceof Error ? err.message : String(err);
+        setState({ kind: 'error', message });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // attachNonce is intentional: bumping it re-runs the attach for Retry.
+  }, [sessionId, attachNonce, cwd]);
+
+  // pty:exit subscription for the active session → flip to exit state with
+  // a classification (clean vs crashed) shared with the store via
+  // `classifyPtyExit` (src/lib/ptyExitClassifier.ts), so the active-pane
+  // overlay and the sidebar red-dot signal stay consistent.
+  useEffect(() => {
+    const pty = window.ccsmPty;
+    if (!pty?.onExit) return;
+    const unsubscribe = pty.onExit(
+      (evt: { sessionId: string; code?: number | null; signal?: string | number | null }) => {
+        if (evt.sessionId !== getActiveSid()) return;
+        const signal = evt.signal ?? null;
+        const code = evt.code ?? null;
+        const exitKind = classifyPtyExit({ code, signal });
+        const detail =
+          signal != null
+            ? `signal ${signal}`
+            : code != null
+              ? `exit code ${code}`
+              : 'unknown';
+        setState({ kind: 'exit', exitKind, detail });
+      },
+    );
+    return () => {
+      try {
+        unsubscribe?.();
+      } catch {
+        // already torn down — safe to ignore.
+      }
+    };
+  }, []);
+
+  const onRetry = useCallback(() => {
+    setAttachNonce((n) => n + 1);
+  }, []);
+
+  return { state, onRetry };
+}

--- a/src/terminal/useTerminalResize.ts
+++ b/src/terminal/useTerminalResize.ts
@@ -1,0 +1,38 @@
+import { useEffect, type RefObject } from 'react';
+import { getTerm, getFit, getActiveSid } from './xtermSingleton';
+
+/**
+ * ResizeObserver hook: observes `hostRef` and, after an 80ms debounce,
+ * runs `fit.fit()` on the singleton terminal and pushes the new
+ * cols/rows to the active PTY via `window.ccsmPty.resize`. No-op if
+ * the singleton hasn't initialised yet or no session is attached.
+ */
+export function useTerminalResize(hostRef: RefObject<HTMLDivElement | null>): void {
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+    let debounce: ReturnType<typeof setTimeout> | null = null;
+    const ro = new ResizeObserver(() => {
+      if (debounce) clearTimeout(debounce);
+      debounce = setTimeout(() => {
+        const term = getTerm();
+        const fit = getFit();
+        const activeSid = getActiveSid();
+        if (!term || !fit || !activeSid) return;
+        try {
+          fit.fit();
+          const { cols, rows } = term;
+          window.ccsmPty?.resize(activeSid, cols, rows);
+        } catch (e) {
+          console.warn('[TerminalPane] fit failed', e);
+        }
+      }, 80);
+    });
+    ro.observe(host);
+    return () => {
+      if (debounce) clearTimeout(debounce);
+      ro.disconnect();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}

--- a/src/terminal/useXtermSingleton.ts
+++ b/src/terminal/useXtermSingleton.ts
@@ -1,0 +1,21 @@
+import { useEffect, type RefObject } from 'react';
+import { ensureTerminal } from './xtermSingleton';
+
+/**
+ * Mount-once hook: instantiates the module-singleton xterm against the
+ * provided host div on first render. Idempotent across remounts — calls
+ * `ensureTerminal` which itself caches.
+ *
+ * The singleton (term, addons, key handler, selection→clipboard auto-copy,
+ * `window.__ccsmTerm` probe handle) is created lazily inside the effect so
+ * we never run xterm constructors at import time (would explode in non-DOM
+ * test environments).
+ */
+export function useXtermSingleton(hostRef: RefObject<HTMLDivElement | null>): void {
+  useEffect(() => {
+    if (!hostRef.current) return;
+    ensureTerminal(hostRef.current);
+    // hostRef is a stable ref — no deps needed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}

--- a/src/terminal/xtermSingleton.ts
+++ b/src/terminal/xtermSingleton.ts
@@ -1,0 +1,220 @@
+import { Terminal } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import { WebLinksAddon } from '@xterm/addon-web-links';
+import { ClipboardAddon } from '@xterm/addon-clipboard';
+import { Unicode11Addon } from '@xterm/addon-unicode11';
+import { CanvasAddon } from '@xterm/addon-canvas';
+
+// Module-scope singleton state for the renderer's xterm view.
+//
+// Why a module-scope singleton (NOT per-React-mount):
+//   - Recreating the Terminal on every session switch is expensive: the
+//     canvas renderer rebuilds its glyph atlas, addons re-allocate, and
+//     in dev React StrictMode would double-invoke the constructor.
+//   - ccsm's session-keepalive guarantee: the user can flip between
+//     sessions without the underlying terminal/PTY pairing being torn
+//     down. The PTY lives in the main process; the rendered view is a
+//     single xterm bound to whichever sid is active. Switching sessions
+//     = `term.reset()` + IPC re-attach with the new sid's snapshot, no
+//     DOM reconstruction.
+//
+// All three terminal hooks (useXtermSingleton, usePtyAttach,
+// useTerminalResize) share this state via the accessors below.
+
+declare global {
+  interface Window {
+    // Local stub until PR-3 lands the proper src/pty.d.ts.
+    ccsmPty: any;
+    __ccsmTerm?: Terminal;
+  }
+}
+
+let term: Terminal | null = null;
+let fit: FitAddon | null = null;
+let activeSid: string | null = null;
+let unsubscribeData: (() => void) | null = null;
+let inputDisposable: { dispose: () => void } | null = null;
+
+export function getTerm(): Terminal | null {
+  return term;
+}
+
+export function getFit(): FitAddon | null {
+  return fit;
+}
+
+export function getActiveSid(): string | null {
+  return activeSid;
+}
+
+export function setActiveSid(sid: string | null): void {
+  activeSid = sid;
+}
+
+export function getUnsubscribeData(): (() => void) | null {
+  return unsubscribeData;
+}
+
+export function setUnsubscribeData(fn: (() => void) | null): void {
+  unsubscribeData = fn;
+}
+
+export function getInputDisposable(): { dispose: () => void } | null {
+  return inputDisposable;
+}
+
+export function setInputDisposable(d: { dispose: () => void } | null): void {
+  inputDisposable = d;
+}
+
+/**
+ * Create (or re-attach) the singleton Terminal against `host`. Idempotent:
+ * subsequent calls reuse the cached instance and only re-`open` if React
+ * remounted into a different DOM node.
+ */
+export function ensureTerminal(host: HTMLDivElement): Terminal {
+  if (term) {
+    if ((term as any)._core?._parent !== host) {
+      try {
+        term.open(host);
+      } catch {
+        // open() throws if already attached to this exact host; ignore.
+      }
+    }
+    return term;
+  }
+
+  term = new Terminal({
+    fontFamily: 'Cascadia Mono, Consolas, "Courier New", monospace',
+    fontSize: 13,
+    cursorBlink: true,
+    allowProposedApi: true,
+    scrollback: 5000,
+    theme: { background: '#000000' },
+  });
+  fit = new FitAddon();
+  term.loadAddon(fit);
+  try {
+    term.loadAddon(new WebLinksAddon());
+  } catch (e) {
+    console.warn('[TerminalPane] web-links addon failed', e);
+  }
+  try {
+    term.loadAddon(new ClipboardAddon());
+  } catch (e) {
+    console.warn('[TerminalPane] clipboard addon failed', e);
+  }
+  try {
+    term.loadAddon(new Unicode11Addon());
+    term.unicode.activeVersion = '11';
+  } catch (e) {
+    console.warn('[TerminalPane] unicode11 addon failed', e);
+  }
+  // Canvas renderer is the safe middle ground (DOM is slow on dense
+  // output, WebGL flakes under RDP). Fall back silently to default DOM
+  // renderer if the GPU path can't initialise.
+  try {
+    term.loadAddon(new CanvasAddon());
+  } catch (e) {
+    console.warn('[TerminalPane] canvas addon failed, falling back to DOM', e);
+  }
+
+  term.open(host);
+
+  // ttyd-style: auto-copy on selection change. Works in alt-screen apps
+  // (claude/Ink) when user holds Shift to bypass mouse tracking and
+  // drags. Use Electron's clipboard via preload because navigator.clipboard
+  // requires user-activation that xterm's keydown swallow doesn't reliably
+  // propagate, and silently fails under default contextIsolation.
+  term.onSelectionChange(() => {
+    if (!term) return;
+    const sel = term.getSelection();
+    if (sel) {
+      try {
+        window.ccsmPty?.clipboard?.writeText(sel);
+      } catch {
+        // ignore clipboard failures — selection still highlights.
+      }
+    }
+  });
+
+  // Copy/paste keyboard shortcuts (Windows Terminal style):
+  //   Ctrl+C  → if selection, copy; else fall through to SIGINT
+  //   Ctrl+V  → paste
+  //   Ctrl+Shift+C / Ctrl+Shift+V → explicit always-clipboard
+  term.attachCustomKeyEventHandler((ev) => {
+    if (ev.type !== 'keydown') return true;
+    const isC = ev.key === 'C' || ev.key === 'c';
+    const isV = ev.key === 'V' || ev.key === 'v';
+
+    if (ev.ctrlKey && !ev.shiftKey && !ev.altKey && isC) {
+      const sel = term?.getSelection();
+      if (sel) {
+        try {
+          window.ccsmPty?.clipboard?.writeText(sel);
+        } catch {
+          // ignore clipboard failures — selection still highlights.
+        }
+        return false;
+      }
+      return true;
+    }
+    if (ev.ctrlKey && !ev.shiftKey && !ev.altKey && isV) {
+      try {
+        const text = window.ccsmPty?.clipboard?.readText();
+        if (text && activeSid) window.ccsmPty.input(activeSid, text);
+      } catch {
+        // ignore clipboard failures — paste is best-effort.
+      }
+      return false;
+    }
+    if (ev.ctrlKey && ev.shiftKey && isC) {
+      const sel = term?.getSelection();
+      if (sel) {
+        try {
+          window.ccsmPty?.clipboard?.writeText(sel);
+        } catch {
+          // ignore clipboard failures — selection still highlights.
+        }
+      }
+      return false;
+    }
+    if (ev.ctrlKey && ev.shiftKey && isV) {
+      try {
+        const text = window.ccsmPty?.clipboard?.readText();
+        if (text && activeSid) window.ccsmPty.input(activeSid, text);
+      } catch {
+        // ignore clipboard failures — paste is best-effort.
+      }
+      return false;
+    }
+    return true;
+  });
+
+  // Probe hook for e2e harness — exposed unconditionally because the
+  // direct-xterm probes (harness-real-cli pty-pid-stable-across-switch /
+  // switch-session-keeps-chat) drive the production webpack bundle and
+  // would otherwise have no way to reach the live Terminal handle. This
+  // mirrors the unconditional `window.__ccsmStore` exposure in App.tsx —
+  // a debug affordance, not a security boundary, since the renderer is
+  // already a single-origin Electron context with no remote content.
+  window.__ccsmTerm = term;
+
+  return term;
+}
+
+/**
+ * Test-only: clear singleton state so each test starts from a clean slate.
+ * Intentionally NOT exported via barrel — only direct importers (tests)
+ * should reach for it.
+ */
+export function __resetSingletonForTests(): void {
+  term = null;
+  fit = null;
+  activeSid = null;
+  unsubscribeData = null;
+  inputDisposable = null;
+  if (typeof window !== 'undefined') {
+    delete window.__ccsmTerm;
+  }
+}

--- a/tests/terminal/usePtyAttach.test.tsx
+++ b/tests/terminal/usePtyAttach.test.tsx
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// Spy on the Terminal so usePtyAttach can call write/reset/resize/onData/focus.
+const writeSpy = vi.fn();
+const resetSpy = vi.fn();
+const resizeSpy = vi.fn();
+const focusSpy = vi.fn();
+const inputDisposableDispose = vi.fn();
+const onDataDisposable = { dispose: inputDisposableDispose };
+const onDataSpy = vi.fn(() => onDataDisposable);
+const fakeTerm = {
+  write: writeSpy,
+  reset: resetSpy,
+  resize: resizeSpy,
+  focus: focusSpy,
+  onData: onDataSpy,
+  cols: 80,
+  rows: 24,
+};
+const fitFitSpy = vi.fn();
+const fakeFit = { fit: fitFitSpy };
+
+// We bypass ensureTerminal by mocking the singleton module directly.
+vi.mock('../../src/terminal/xtermSingleton', async () => {
+  let activeSid: string | null = null;
+  let unsub: (() => void) | null = null;
+  let inDisp: { dispose: () => void } | null = null;
+  return {
+    ensureTerminal: vi.fn(),
+    getTerm: vi.fn(() => fakeTerm),
+    getFit: vi.fn(() => fakeFit),
+    getActiveSid: vi.fn(() => activeSid),
+    setActiveSid: vi.fn((s: string | null) => {
+      activeSid = s;
+    }),
+    getUnsubscribeData: vi.fn(() => unsub),
+    setUnsubscribeData: vi.fn((fn: (() => void) | null) => {
+      unsub = fn;
+    }),
+    getInputDisposable: vi.fn(() => inDisp),
+    setInputDisposable: vi.fn((d: { dispose: () => void } | null) => {
+      inDisp = d;
+    }),
+    __resetSingletonForTests: vi.fn(() => {
+      activeSid = null;
+      unsub = null;
+      inDisp = null;
+    }),
+  };
+});
+
+// Mock store — _clearPtyExit is the only piece usePtyAttach reads.
+const clearPtyExitSpy = vi.fn();
+vi.mock('../../src/stores/store', () => ({
+  useStore: (selector: (s: any) => any) => selector({ _clearPtyExit: clearPtyExitSpy }),
+}));
+
+import { usePtyAttach } from '../../src/terminal/usePtyAttach';
+import {
+  __resetSingletonForTests,
+  getActiveSid,
+} from '../../src/terminal/xtermSingleton';
+
+type AttachResp = { snapshot: string; cols: number; rows: number; pid: number } | null;
+
+function makePtyBridge(opts: { attach?: AttachResp } = {}) {
+  const attachResp: AttachResp =
+    opts.attach === undefined
+      ? { snapshot: 'snap', cols: 80, rows: 24, pid: 1234 }
+      : opts.attach;
+  let onDataHandler: ((p: { sid: string; chunk: string }) => void) | null = null;
+  let onExitHandler:
+    | ((evt: { sessionId: string; code?: number | null; signal?: string | number | null }) => void)
+    | null = null;
+  const detach = vi.fn(async (_sid: string) => undefined);
+  const attach = vi.fn(async (_sid: string) => attachResp);
+  const spawn = vi.fn(async (_sid: string, _cwd: string) => ({
+    ok: true as const,
+    sid: _sid,
+    pid: 999,
+    cols: 80,
+    rows: 24,
+  }));
+  const input = vi.fn();
+  const resize = vi.fn();
+  const onDataUnsub = vi.fn();
+  const onData = vi.fn((cb: (p: { sid: string; chunk: string }) => void) => {
+    onDataHandler = cb;
+    return onDataUnsub;
+  });
+  const onExitUnsub = vi.fn();
+  const onExit = vi.fn((cb: typeof onExitHandler) => {
+    onExitHandler = cb;
+    return onExitUnsub;
+  });
+  return {
+    bridge: { attach, detach, spawn, input, resize, onData, onExit },
+    spies: { attach, detach, spawn, onData, onDataUnsub, onExit, onExitUnsub, input, resize },
+    fire: {
+      data: (p: { sid: string; chunk: string }) => onDataHandler?.(p),
+      exit: (e: Parameters<NonNullable<typeof onExitHandler>>[0]) => onExitHandler?.(e),
+    },
+  };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+const flushAll = async () => {
+  await act(async () => {
+    await flush();
+    await flush();
+    await flush();
+  });
+};
+
+describe('usePtyAttach', () => {
+  beforeEach(() => {
+    __resetSingletonForTests();
+    writeSpy.mockClear();
+    resetSpy.mockClear();
+    resizeSpy.mockClear();
+    focusSpy.mockClear();
+    onDataSpy.mockClear();
+    inputDisposableDispose.mockClear();
+    fitFitSpy.mockClear();
+    clearPtyExitSpy.mockClear();
+  });
+
+  afterEach(() => {
+    delete (window as any).ccsmPty;
+    __resetSingletonForTests();
+  });
+
+  it('attaches on mount: writes snapshot, subscribes onData, sets activeSid, ready state', async () => {
+    const { bridge, spies } = makePtyBridge();
+    (window as any).ccsmPty = bridge;
+
+    const { result } = renderHook(() => usePtyAttach('sid-A', '/tmp'));
+    expect(result.current.state.kind).toBe('attaching');
+    await flushAll();
+
+    expect(spies.attach).toHaveBeenCalledWith('sid-A');
+    expect(resetSpy).toHaveBeenCalled();
+    expect(writeSpy).toHaveBeenCalledWith('snap');
+    expect(spies.onData).toHaveBeenCalled();
+    expect(getActiveSid()).toBe('sid-A');
+    expect(focusSpy).toHaveBeenCalled();
+    expect(clearPtyExitSpy).toHaveBeenCalledWith('sid-A');
+    expect(result.current.state.kind).toBe('ready');
+  });
+
+  it('on sessionId change: detaches previous, unsubscribes, re-attaches new', async () => {
+    const { bridge, spies } = makePtyBridge();
+    (window as any).ccsmPty = bridge;
+
+    const { rerender, result } = renderHook(({ sid }) => usePtyAttach(sid, '/tmp'), {
+      initialProps: { sid: 'sid-A' },
+    });
+    await flushAll();
+    expect(getActiveSid()).toBe('sid-A');
+    const firstUnsub = spies.onDataUnsub;
+    spies.onDataUnsub.mockClear();
+
+    await act(async () => {
+      rerender({ sid: 'sid-B' });
+      await flush();
+      await flush();
+    });
+
+    expect(spies.detach).toHaveBeenCalledWith('sid-A');
+    expect(firstUnsub).toHaveBeenCalled(); // previous onData subscription torn down
+    expect(inputDisposableDispose).toHaveBeenCalled();
+    expect(spies.attach).toHaveBeenCalledWith('sid-B');
+    expect(getActiveSid()).toBe('sid-B');
+    expect(result.current.state.kind).toBe('ready');
+  });
+
+  it('falls back to spawn when attach returns null', async () => {
+    let calls = 0;
+    const { bridge, spies } = makePtyBridge();
+    spies.attach.mockImplementation(async (_sid: string) => {
+      calls += 1;
+      if (calls === 1) return null;
+      return { snapshot: 'after-spawn', cols: 80, rows: 24, pid: 1 };
+    });
+    (window as any).ccsmPty = bridge;
+
+    renderHook(() => usePtyAttach('sid-C', '/cwd'));
+    await flushAll();
+
+    expect(spies.spawn).toHaveBeenCalledWith('sid-C', '/cwd');
+    expect(spies.attach).toHaveBeenCalledTimes(2);
+    expect(writeSpy).toHaveBeenCalledWith('after-spawn');
+  });
+
+  it('flips to error state when ccsmPty bridge is missing', async () => {
+    delete (window as any).ccsmPty;
+    const { result } = renderHook(() => usePtyAttach('sid-X', ''));
+    await flushAll();
+    expect(result.current.state).toEqual({ kind: 'error', message: 'ccsmPty unavailable' });
+  });
+
+  it('classifies pty exit: clean (code 0, no signal)', async () => {
+    const { bridge, fire } = makePtyBridge();
+    (window as any).ccsmPty = bridge;
+    const { result } = renderHook(() => usePtyAttach('sid-D', ''));
+    await flushAll();
+    fire.exit({ sessionId: 'sid-D', code: 0, signal: null });
+    await act(async () => {
+      await flush();
+    });
+    expect(result.current.state).toMatchObject({ kind: 'exit', exitKind: 'clean' });
+  });
+
+  it('classifies pty exit: crashed (signal set)', async () => {
+    const { bridge, fire } = makePtyBridge();
+    (window as any).ccsmPty = bridge;
+    const { result } = renderHook(() => usePtyAttach('sid-E', ''));
+    await flushAll();
+    fire.exit({ sessionId: 'sid-E', code: null, signal: 'SIGKILL' });
+    await act(async () => {
+      await flush();
+    });
+    expect(result.current.state).toMatchObject({ kind: 'exit', exitKind: 'crashed' });
+  });
+});

--- a/tests/terminal/useTerminalResize.test.tsx
+++ b/tests/terminal/useTerminalResize.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+const fitFitSpy = vi.fn();
+const fakeFit = { fit: fitFitSpy };
+const fakeTerm = { cols: 100, rows: 30 };
+
+vi.mock('../../src/terminal/xtermSingleton', () => {
+  let activeSid: string | null = 'sid-A';
+  return {
+    ensureTerminal: vi.fn(),
+    getTerm: vi.fn(() => fakeTerm),
+    getFit: vi.fn(() => fakeFit),
+    getActiveSid: vi.fn(() => activeSid),
+    setActiveSid: vi.fn((s: string | null) => {
+      activeSid = s;
+    }),
+    getUnsubscribeData: vi.fn(() => null),
+    setUnsubscribeData: vi.fn(),
+    getInputDisposable: vi.fn(() => null),
+    setInputDisposable: vi.fn(),
+    __resetSingletonForTests: vi.fn(),
+  };
+});
+
+import { useTerminalResize } from '../../src/terminal/useTerminalResize';
+
+// Capture the ResizeObserver callback so the test can fire it manually.
+let lastObserverCb: ResizeObserverCallback | null = null;
+const observeSpy = vi.fn();
+const disconnectSpy = vi.fn();
+
+class ROStub implements ResizeObserver {
+  constructor(cb: ResizeObserverCallback) {
+    lastObserverCb = cb;
+  }
+  observe(target: Element): void {
+    observeSpy(target);
+  }
+  unobserve(): void {}
+  disconnect(): void {
+    disconnectSpy();
+  }
+}
+
+describe('useTerminalResize', () => {
+  let originalRO: typeof globalThis.ResizeObserver;
+  let resizeBridge: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fitFitSpy.mockClear();
+    observeSpy.mockClear();
+    disconnectSpy.mockClear();
+    lastObserverCb = null;
+    originalRO = globalThis.ResizeObserver;
+    (globalThis as any).ResizeObserver = ROStub;
+    resizeBridge = vi.fn();
+    (window as any).ccsmPty = { resize: resizeBridge };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    (globalThis as any).ResizeObserver = originalRO;
+    delete (window as any).ccsmPty;
+  });
+
+  it('observes the host and runs fit + ccsmPty.resize after the 80ms debounce', () => {
+    const host = document.createElement('div');
+    const ref = { current: host };
+    renderHook(() => useTerminalResize(ref));
+    expect(observeSpy).toHaveBeenCalledWith(host);
+
+    // Trigger a resize event from the observer.
+    lastObserverCb!([] as unknown as ResizeObserverEntry[], {} as ResizeObserver);
+    expect(fitFitSpy).not.toHaveBeenCalled(); // debounced
+    vi.advanceTimersByTime(80);
+
+    expect(fitFitSpy).toHaveBeenCalledTimes(1);
+    expect(resizeBridge).toHaveBeenCalledWith('sid-A', 100, 30);
+  });
+
+  it('disconnects the observer on unmount', () => {
+    const host = document.createElement('div');
+    const ref = { current: host };
+    const { unmount } = renderHook(() => useTerminalResize(ref));
+    unmount();
+    expect(disconnectSpy).toHaveBeenCalled();
+  });
+});

--- a/tests/terminal/useXtermSingleton.test.tsx
+++ b/tests/terminal/useXtermSingleton.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+// Mock xterm constructors BEFORE importing the hook so the singleton
+// uses the spies. Use vi.hoisted because vi.mock factories run before
+// any top-level `const`.
+const { openSpy, loadAddonSpy, onSelectionChangeSpy, attachCustomKeyEventHandlerSpy, terminalCtor } =
+  vi.hoisted(() => {
+    const openSpy = vi.fn();
+    const loadAddonSpy = vi.fn();
+    const onSelectionChangeSpy = vi.fn();
+    const attachCustomKeyEventHandlerSpy = vi.fn();
+    const terminalCtor = vi.fn(() => ({
+      open: openSpy,
+      loadAddon: loadAddonSpy,
+      onSelectionChange: onSelectionChangeSpy,
+      attachCustomKeyEventHandler: attachCustomKeyEventHandlerSpy,
+      unicode: { activeVersion: '6' },
+      _core: { _parent: null },
+    }));
+    return { openSpy, loadAddonSpy, onSelectionChangeSpy, attachCustomKeyEventHandlerSpy, terminalCtor };
+  });
+
+vi.mock('@xterm/xterm', () => ({ Terminal: terminalCtor }));
+vi.mock('@xterm/addon-fit', () => ({ FitAddon: vi.fn(() => ({ fit: vi.fn() })) }));
+vi.mock('@xterm/addon-web-links', () => ({ WebLinksAddon: vi.fn() }));
+vi.mock('@xterm/addon-clipboard', () => ({ ClipboardAddon: vi.fn() }));
+vi.mock('@xterm/addon-unicode11', () => ({ Unicode11Addon: vi.fn() }));
+vi.mock('@xterm/addon-canvas', () => ({ CanvasAddon: vi.fn() }));
+
+import { useXtermSingleton } from '../../src/terminal/useXtermSingleton';
+import {
+  __resetSingletonForTests,
+  getTerm,
+} from '../../src/terminal/xtermSingleton';
+
+describe('useXtermSingleton', () => {
+  beforeEach(() => {
+    __resetSingletonForTests();
+    terminalCtor.mockClear();
+    openSpy.mockClear();
+    loadAddonSpy.mockClear();
+  });
+
+  afterEach(() => {
+    __resetSingletonForTests();
+  });
+
+  it('creates the Terminal singleton on first mount', () => {
+    const host = document.createElement('div');
+    const ref = { current: host };
+    renderHook(() => useXtermSingleton(ref));
+    expect(terminalCtor).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledWith(host);
+    // Selection→clipboard wiring + custom key handler installed.
+    expect(onSelectionChangeSpy).toHaveBeenCalledTimes(1);
+    expect(attachCustomKeyEventHandlerSpy).toHaveBeenCalledTimes(1);
+    // Probe handle exposed for e2e harness.
+    expect(window.__ccsmTerm).toBe(getTerm());
+  });
+
+  it('reuses the singleton across remounts (does NOT recreate)', () => {
+    const host = document.createElement('div');
+    const ref = { current: host };
+    const r1 = renderHook(() => useXtermSingleton(ref));
+    r1.unmount();
+    const r2 = renderHook(() => useXtermSingleton(ref));
+    r2.unmount();
+    // ctor called exactly once across both mounts — proves cache hit.
+    expect(terminalCtor).toHaveBeenCalledTimes(1);
+  });
+
+  it('no-ops when hostRef.current is null', () => {
+    const ref = { current: null };
+    renderHook(() => useXtermSingleton(ref));
+    expect(terminalCtor).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Scope

SRP split of `src/components/TerminalPane.tsx` into a thin host shell + three single-responsibility hooks under `src/terminal/`.

**New files**
- `src/terminal/xtermSingleton.ts` (~220 LoC) — module-singleton state (`term`, `fit`, `activeSid`, subscriptions) + `ensureTerminal` (addons, key handler, selection auto-copy, `__ccsmTerm` probe handle).
- `src/terminal/useXtermSingleton.ts` (~21 LoC) — mount-once bring-up.
- `src/terminal/usePtyAttach.ts` (~270 LoC) — sessionId effect (detach -> reset -> attach with spawn-on-null fallback -> snapshot -> subscribe -> fit -> focus); `pty:exit` subscription with `classifyPtyExit`; Retry handle. Returns `{ state, onRetry }`.
- `src/terminal/useTerminalResize.ts` (~38 LoC) — ResizeObserver with 80ms debounce -> `fit.fit()` + `ccsmPty.resize`.
- `tests/terminal/useXtermSingleton.test.tsx` (3 tests)
- `tests/terminal/usePtyAttach.test.tsx` (6 tests)
- `tests/terminal/useTerminalResize.test.tsx` (2 tests)

**Modified**
- `src/components/TerminalPane.tsx`: 526 -> 128 LoC. Pure composition: host div + `Overlay` (attaching / error / exit) + the three hooks. `classifyPtyExit` re-exported for back-compat.

## Why

Four orthogonal concerns (view, singleton lifecycle, per-sid PTY lifecycle, resize) were mashed into one ~526-line component. Splitting:
- unblocks per-concern unit tests (impossible before — the singleton + IPC + xterm DOM were entangled);
- isolates the keepalive contract (singleton + ensureTerminal) from the per-sid churn (usePtyAttach), so future work on either side stops touching the other;
- shrinks TerminalPane.tsx to ~128 LoC of pure JSX + hook composition.

Behavior preserved: module-singleton xterm, spawn-on-attach-null fallback, exit classification (`clean` vs `crashed`), Retry, focus handoff (Task #548), `_clearPtyExit` on successful re-attach, and all probe handles (`[data-terminal-host]`, `[data-active-sid]`, `window.__ccsmTerm`).

## Reverse-verify

Stubbed `src/terminal/usePtyAttach.ts` to a no-op returning `{ state: { kind: 'attaching' }, onRetry: () => {} }`:
```
Test Files  1 failed (1)
     Tests  6 failed (6)
```
Restored:
```
Test Files  1 passed (1)
     Tests  6 passed (6)
```

## Validation

- `npx vitest run tests/terminal/` -> **3 files / 11 tests, all PASS**.
- `npx vitest run` -> 528 pass / 3 fail. The 3 failures are in `electron/__tests__/db-hardening.test.ts` (better-sqlite3 native binding NODE_MODULE_VERSION mismatch) — **pre-existing on `working` HEAD**, confirmed by stashing my changes and running the same suite. Not introduced by this PR.
- `npx tsc --noEmit` -> clean.
- `npm run build` -> clean (only pre-existing webpack bundle-size warnings).
- `node scripts/harness-real-cli.mjs --only=switch-session-keeps-chat,pty-pid-stable-across-switch` -> **2/2 PASS** (47.2s + 15.6s).