### PR TITLE
refactor(app): App.tsx uses extracted effect hooks (Task #732 Phase B)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,14 +16,19 @@ import { DragRegion, WindowControls } from './components/WindowControls';
 import { Tutorial } from './components/Tutorial';
 import { InstallerCorruptBanner } from './components/InstallerCorruptBanner';
 import { useStore } from './stores/store';
-import { resolveEffectiveTheme } from './stores/store';
-import { setPersistErrorHandler } from './stores/persist';
 import { initI18n } from './i18n';
-import { i18next } from './i18n';
 import { useTranslation } from './i18n/useTranslation';
 import { usePreferences } from './store/preferences';
 import { DURATION, EASING } from './lib/motion';
-import { subscribeAgentEvents } from './agent/lifecycle';
+import { useThemeEffect } from './app-effects/useThemeEffect';
+import { useLanguageEffect } from './app-effects/useLanguageEffect';
+import { useAgentEventBridge } from './app-effects/useAgentEventBridge';
+import { useShortcutHandlers } from './app-effects/useShortcutHandlers';
+import { useSessionActivateBridge } from './app-effects/useSessionActivateBridge';
+import { useFocusBridge } from './app-effects/useFocusBridge';
+import { useUpdateDownloadedBridge } from './app-effects/useUpdateDownloadedBridge';
+import { usePersistErrorBridge } from './app-effects/usePersistErrorBridge';
+import { useTutorialOverlay } from './app-effects/useTutorialOverlay';
 
 // Initialise i18next once, before any component renders. Subsequent
 // language changes flow through `applyLanguage` (called by the store
@@ -41,24 +46,19 @@ if (typeof window !== 'undefined') {
 }
 
 /**
- * True when the event target is a text-editable surface where printable
- * keys (like "?") should remain composition input rather than trigger a
- * global shortcut. Checked by the document-level `keydown` listener in
- * `App` to gate the modifier-free "?" shortcut-overlay binding.
+ * Inner zero-render component that lives inside `<ToastProvider>` so it
+ * can call `useToast()`. Hosts the two toast-bound effect hooks
+ * (`useUpdateDownloadedBridge` + `usePersistErrorBridge`) that previously
+ * lived in standalone `<UpdateDownloadedBridge />` / `<PersistErrorBridge />`
+ * components at the bottom of this file. Keeping them in a single inner
+ * component (rather than two) avoids a second `useToast()` call and the
+ * extra component boundary.
  */
-function isEditableTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement)) return false;
-  if (target.isContentEditable) return true;
-  const tag = target.tagName;
-  if (tag === 'TEXTAREA') return true;
-  if (tag === 'INPUT') {
-    const type = (target as HTMLInputElement).type;
-    // checkbox/radio/button-like inputs don't capture printable keys;
-    // treat them as non-editable so "?" still opens the overlay there.
-    const nonText = new Set(['checkbox', 'radio', 'button', 'submit', 'reset', 'range', 'color', 'file']);
-    return !nonText.has(type);
-  }
-  return false;
+function AppEffectsBridge(): null {
+  const { push } = useToast();
+  useUpdateDownloadedBridge({ push });
+  usePersistErrorBridge({ push });
+  return null;
 }
 
 export default function App() {
@@ -90,29 +90,59 @@ export default function App() {
   const tutorialSeen = useStore((s) => s.tutorialSeen);
   const markTutorialSeen = useStore((s) => s.markTutorialSeen);
 
-  // Theme application — reactive to both the user's explicit choice AND, when
-  // the choice is `system`, the OS theme. We set BOTH `.dark` (historical,
-  // still referenced by legacy Tailwind variants) AND `.theme-light` (new,
-  // drives the light palette overrides in global.css). The mutual exclusion
-  // keeps the `html.theme-light` selector unambiguous — no `.dark.theme-light`
-  // combo will ever exist.
-  useEffect(() => {
-    const root = document.documentElement;
-    const apply = () => {
-      const osPrefersDark =
-        typeof window !== 'undefined' &&
-        window.matchMedia('(prefers-color-scheme: dark)').matches;
-      const effective = resolveEffectiveTheme(theme, osPrefersDark);
-      root.classList.toggle('dark', effective === 'dark');
-      root.classList.toggle('theme-light', effective === 'light');
-      root.dataset.theme = effective;
-    };
-    apply();
-    if (theme !== 'system') return;
-    const mq = window.matchMedia('(prefers-color-scheme: dark)');
-    mq.addEventListener('change', apply);
-    return () => mq.removeEventListener('change', apply);
-  }, [theme]);
+  const [settingsOpen, setSettingsOpen] = React.useState(false);
+  const [paletteOpen, setPaletteOpen] = React.useState(false);
+  const [importOpen, setImportOpen] = React.useState(false);
+  const [shortcutsOpen, setShortcutsOpen] = React.useState(false);
+
+  // ---- Extracted effect hooks (Task #732 Phase B) -----------------------
+  // Theme application — reactive to user choice + (when system) OS scheme.
+  useThemeEffect(theme);
+
+  // Pipe `session:state` IPC events into the store via subscribeAgentEvents.
+  // Drives the AgentIcon attention halo for non-active sessions.
+  useAgentEventBridge();
+
+  // `session:activate` from main → re-select the named session (desktop
+  // notification click).
+  useSessionActivateBridge(selectSession);
+
+  // OS focus regained → drop the active session's attention halo per
+  // notify spec (`_applySessionState` carries the symmetric suppression).
+  useFocusBridge(React.useCallback(() => {
+    const st = useStore.getState();
+    const id = st.activeId;
+    if (!id) return;
+    const sess = st.sessions.find((x) => x.id === id);
+    if (!sess || sess.state !== 'waiting') return;
+    useStore.setState((s) => ({
+      sessions: s.sessions.map((x) =>
+        x.id === id && x.state === 'waiting' ? { ...x, state: 'idle' } : x
+      ),
+    }));
+  }, []));
+
+  // Tutorial overlay show/hide derivation. `dismiss()` flips the persisted
+  // store flag so it does not return on the next launch.
+  const tutorial = useTutorialOverlay({ tutorialSeen, markTutorialSeen });
+
+  // Global keyboard shortcuts (Ctrl+/, "?", Ctrl+F, Ctrl+B, Ctrl+,).
+  useShortcutHandlers({
+    toggleShortcuts: React.useCallback(() => setShortcutsOpen((p) => !p), []),
+    togglePalette: React.useCallback(() => setPaletteOpen((p) => !p), []),
+    toggleSidebar,
+    openSettings: React.useCallback(() => setSettingsOpen(true), []),
+  });
+
+  // Mirror resolved language to main for OS-level surfaces (tray menu,
+  // future native notifications).
+  const hydrateSystemLocale = usePreferences((s) => s.hydrateSystemLocale);
+  const resolvedLanguage = usePreferences((s) => s.resolvedLanguage);
+  useLanguageEffect(resolvedLanguage);
+
+  // -----------------------------------------------------------------------
+  // Remaining inline effects (NOT extracted — Phase C territory).
+  // -----------------------------------------------------------------------
 
   // Font size slider applies via CSS variable on <html>. Child text utilities
   // honor this transitively through `font-size: var(--app-font-size)` on
@@ -165,23 +195,6 @@ export default function App() {
     prevSidsRef.current = currentSids;
   }, [sessions]);
 
-  // Listen for `session:activate` from main (fired when the user clicks a
-  // desktop notification). Re-selects the named session so it lands focused
-  // in the sidebar and chat pane. Mirrors the IPC subscription pattern of
-  // `UpdateDownloadedBridge`.
-  useEffect(() => {
-    type Bridge = {
-      onActivate: (cb: (e: { sid: string }) => void) => () => void;
-    };
-    const bridge = (window as unknown as { ccsmSession?: Bridge }).ccsmSession;
-    if (!bridge || typeof bridge.onActivate !== 'function') return;
-    return bridge.onActivate((evt) => {
-      if (evt && typeof evt.sid === 'string' && evt.sid.length > 0) {
-        selectSession(evt.sid);
-      }
-    });
-  }, [selectSession]);
-
   // Pipe `pty:exit` events into the store UNCONDITIONALLY (not filtered
   // by activeSid). TerminalPane has its own filtered listener that drives
   // the active-pane red overlay; this second listener is what surfaces
@@ -222,47 +235,6 @@ export default function App() {
       applyExternalTitle(evt.sid, evt.title);
     });
   }, [applyExternalTitle]);
-
-  // Pipe `session:state` IPC events from main into the store. The watcher
-  // emits `'idle' | 'running' | 'requires_action'` for each session as the
-  // JSONL transcript transitions; subscribeAgentEvents() maps that into
-  // the renderer's two-state attention model and writes through the
-  // store's `_applySessionState` action — which carries the active-session
-  // suppression so the row the user is currently viewing never enters
-  // `'waiting'` (no halo flicker on the row already on screen). This is
-  // the re-wire of the deleted `src/agent/lifecycle.ts` (commit 08bce04
-  // dropped the SDK-event subscriber when ccsm switched to spawning the
-  // CLI as a subprocess; the AgentIcon halo went silently dark for every
-  // session). Bridge install is idempotent so StrictMode double-mount
-  // doesn't double-pipe events.
-  useEffect(() => {
-    return subscribeAgentEvents();
-  }, []);
-
-  // Per the notify spec, when ccsm regains OS focus the row the user is
-  // returning to (the active sid) must drop its attention halo — they're
-  // here, the breadcrumb has done its job. Other 'waiting' rows keep the
-  // halo until the user actually clicks them (selectSession clears those
-  // symmetrically). Mirrors the rule encoded in `_applySessionState`'s
-  // active-session suppression: "the active row never pulses while the
-  // user is at the window".
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    const onFocus = () => {
-      const st = useStore.getState();
-      const id = st.activeId;
-      if (!id) return;
-      const sess = st.sessions.find((x) => x.id === id);
-      if (!sess || sess.state !== 'waiting') return;
-      useStore.setState((s) => ({
-        sessions: s.sessions.map((x) =>
-          x.id === id && x.state === 'waiting' ? { ...x, state: 'idle' } : x
-        ),
-      }));
-    };
-    window.addEventListener('focus', onFocus);
-    return () => window.removeEventListener('focus', onFocus);
-  }, []);
 
   // Pipe `notify:flash` IPC events from main into the store. The flash sink
   // (`electron/notify/sinks/flashSink.ts`) sets `flashStates[sid] = true`
@@ -322,10 +294,6 @@ export default function App() {
 
   // Locale: ask main for the OS locale, feed it into the preferences store
   // so a "system" preference resolves correctly. Falls back to navigator.
-  // Then mirror the resolved language to main for any OS-level surfaces
-  // (tray menu, future notifications) to consume.
-  const hydrateSystemLocale = usePreferences((s) => s.hydrateSystemLocale);
-  const resolvedLanguage = usePreferences((s) => s.resolvedLanguage);
   useEffect(() => {
     let cancelled = false;
     const bridge = window.ccsm;
@@ -345,9 +313,6 @@ export default function App() {
       cancelled = true;
     };
   }, [hydrateSystemLocale]);
-  useEffect(() => {
-    window.ccsm?.i18n?.setLanguage(resolvedLanguage);
-  }, [resolvedLanguage]);
 
   // Exit animation (UI-10 / #213):
   // When the user closes the window (Ctrl+W, X button) the Electron main
@@ -383,11 +348,6 @@ export default function App() {
       root.style.opacity = '';
     };
   }, []);
-
-  const [settingsOpen, setSettingsOpen] = React.useState(false);
-  const [paletteOpen, setPaletteOpen] = React.useState(false);
-  const [importOpen, setImportOpen] = React.useState(false);
-  const [shortcutsOpen, setShortcutsOpen] = React.useState(false);
 
   // Boot-time check: is the `claude` CLI on PATH? Cached in App-level
   // state because the install state doesn't change mid-session — only
@@ -450,55 +410,6 @@ export default function App() {
     [sessions, activeId]
   );
 
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      const mod = e.metaKey || e.ctrlKey;
-      // Ctrl+/ opens the shortcuts overlay. We handle it BEFORE the
-      // `if (!mod) return` guard below so it sits alongside the other
-      // modified-key bindings, even though the `?` alternative handled
-      // further down is modifier-free.
-      if (mod && e.key === '/' && !e.shiftKey) {
-        e.preventDefault();
-        setShortcutsOpen((p) => !p);
-        return;
-      }
-      if (!mod) {
-        // Modifier-free bindings: the "?" shortcut for the shortcuts
-        // overlay. We deliberately DO NOT fire when the user is typing
-        // into a text field — "?" is a printable glyph and must not be
-        // stolen mid-composition. Activating only when focus is on body
-        // or a non-editable element matches macOS/GitHub conventions.
-        if (e.key === '?' && !isEditableTarget(e.target)) {
-          e.preventDefault();
-          setShortcutsOpen((p) => !p);
-        }
-        return;
-      }
-      const k = e.key.toLowerCase();
-      if (k === 'f' && !e.shiftKey) {
-        // Ctrl+F opens the global Search / Command Palette. We
-        // explicitly preventDefault so the browser/Electron's default
-        // find-in-page (when present) doesn't also fire.
-        e.preventDefault();
-        setPaletteOpen((p) => !p);
-      } else if (k === 'b' && !e.shiftKey) {
-        e.preventDefault();
-        toggleSidebar();
-      } else if (e.key === ',') {
-        e.preventDefault();
-        setSettingsOpen(true);
-      }
-      // Task #552: Cmd+N (new session), Cmd+Shift+N (new session w/ picker
-      // — never shipped), and Cmd+Shift+G (new group) keyboard shortcuts
-      // were removed in favour of the chevron+popover affordance on the
-      // sidebar `+` triggers. The chevron is the single discoverable
-      // entry point for "new session, but with a different cwd"; the
-      // group `+` button (always visible) covers new-group.
-    };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [toggleSidebar]);
-
   if (!active) {
     // Pre-hydrate: render a content-shaped skeleton (sidebar placeholder
     // rows + main "Loading…" affordance) so the app does not paint as a
@@ -509,8 +420,7 @@ export default function App() {
       return (
         <TooltipProvider delayDuration={400} skipDelayDuration={100}>
           <ToastProvider>
-            <PersistErrorBridge />
-            <UpdateDownloadedBridge />
+            <AppEffectsBridge />
             <AppSkeleton />
           </ToastProvider>
         </TooltipProvider>
@@ -519,8 +429,7 @@ export default function App() {
     return (
       <TooltipProvider delayDuration={400} skipDelayDuration={100}>
         <ToastProvider>
-        <PersistErrorBridge />
-        <UpdateDownloadedBridge />
+        <AppEffectsBridge />
         <AppShell
           sidebar={
             <Sidebar
@@ -543,7 +452,7 @@ export default function App() {
               </DragRegion>
               <InstallerCorruptBanner />
               <div className="flex-1 flex items-center justify-center min-h-0">
-                  {tutorialSeen ? (
+                  {!tutorial.show ? (
                     // First-run / no-active-session empty state. Task #329 — we
                     // explicitly do NOT auto-create a session at boot; instead
                     // the user lands on this clean palette of CTAs. The wording
@@ -578,14 +487,14 @@ export default function App() {
                   ) : (
                     <Tutorial
                       onNewSession={() => {
-                        markTutorialSeen();
+                        tutorial.dismiss();
                         newSession();
                       }}
                       onImport={() => {
-                        markTutorialSeen();
+                        tutorial.dismiss();
                         setImportOpen(true);
                       }}
-                      onSkip={markTutorialSeen}
+                      onSkip={tutorial.dismiss}
                     />
                   )}
                 </div>
@@ -612,8 +521,7 @@ export default function App() {
   return (
     <TooltipProvider delayDuration={400} skipDelayDuration={100}>
       <ToastProvider>
-        <PersistErrorBridge />
-        <UpdateDownloadedBridge />
+        <AppEffectsBridge />
         <AppShell
           sidebar={
             <Sidebar
@@ -662,59 +570,4 @@ export default function App() {
       </ToastProvider>
     </TooltipProvider>
   );
-}
-
-function PersistErrorBridge() {
-  const { push } = useToast();
-  useEffect(() => {
-    let lastShown = 0;
-    setPersistErrorHandler(() => {
-      const now = Date.now();
-      if (now - lastShown < 5000) return;
-      lastShown = now;
-      push({
-        kind: 'error',
-        title: 'Failed to save state',
-        body: 'Your recent changes may not survive restart. Check disk space.'
-      });
-    });
-    return () => setPersistErrorHandler(() => {});
-  }, [push]);
-  return null;
-}
-
-/**
- * Listens for `update:downloaded` from the main process and shows a persistent
- * toast with a Restart button. We only show the toast once per session — the
- * Settings → Updates pane shows the same state for users who dismiss.
- */
-function UpdateDownloadedBridge() {
-  const { push } = useToast();
-  useEffect(() => {
-    let shown = false;
-    const off = window.ccsm?.onUpdateDownloaded((info) => {
-      if (shown) return;
-      shown = true;
-      // Strings live in `settings:updates.downloadedToast*` so the toast
-      // localizes alongside the Settings → Updates pane copy. Using
-      // `i18next.t` (not the React hook) keeps this callback pure — it
-      // fires from an IPC subscription, not a render.
-      push({
-        kind: 'info',
-        title: i18next.t('settings:updates.downloadedToastTitle'),
-        body: i18next.t('settings:updates.downloadedToastBody', { version: info.version }),
-        persistent: true,
-        action: {
-          label: i18next.t('settings:updates.downloadedToastAction'),
-          onClick: () => {
-            void window.ccsm?.updatesInstall();
-          }
-        }
-      });
-    });
-    return () => {
-      if (off) off();
-    };
-  }, [push]);
-  return null;
 }

--- a/tests/App.hooks.test.tsx
+++ b/tests/App.hooks.test.tsx
@@ -1,0 +1,184 @@
+// Task #732 Phase B — verify App.tsx wires the 9 effect hooks merged in
+// PR #552. Each hook module is mocked so we can assert it was called
+// exactly once per render. This pins the contract that the App
+// composition root delegates these effects to dedicated hooks rather than
+// inlining them — guards against future regressions where someone
+// re-inlines logic and silently bypasses the SRP boundary.
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { useStore } from '../src/stores/store';
+
+// Mock all 9 hook modules BEFORE importing App. Each export is a vi.fn so
+// we can introspect call counts after render. The hooks return either
+// `void` or, in the tutorial case, a `{ show, dismiss }` shape — match
+// the production return so App's render path doesn't crash.
+vi.mock('../src/app-effects/useThemeEffect', () => ({
+  useThemeEffect: vi.fn(),
+}));
+vi.mock('../src/app-effects/useLanguageEffect', () => ({
+  useLanguageEffect: vi.fn(),
+}));
+vi.mock('../src/app-effects/useAgentEventBridge', () => ({
+  useAgentEventBridge: vi.fn(),
+}));
+vi.mock('../src/app-effects/useShortcutHandlers', () => ({
+  useShortcutHandlers: vi.fn(),
+}));
+vi.mock('../src/app-effects/useSessionActivateBridge', () => ({
+  useSessionActivateBridge: vi.fn(),
+}));
+vi.mock('../src/app-effects/useFocusBridge', () => ({
+  useFocusBridge: vi.fn(),
+}));
+vi.mock('../src/app-effects/useUpdateDownloadedBridge', () => ({
+  useUpdateDownloadedBridge: vi.fn(),
+}));
+vi.mock('../src/app-effects/usePersistErrorBridge', () => ({
+  usePersistErrorBridge: vi.fn(),
+}));
+vi.mock('../src/app-effects/useTutorialOverlay', () => ({
+  useTutorialOverlay: vi.fn(() => ({ show: false, dismiss: vi.fn() })),
+}));
+
+// Imports MUST come after vi.mock calls (vi.mock is hoisted, but explicit
+// ordering keeps the read order obvious to humans).
+import App from '../src/App';
+import { useThemeEffect } from '../src/app-effects/useThemeEffect';
+import { useLanguageEffect } from '../src/app-effects/useLanguageEffect';
+import { useAgentEventBridge } from '../src/app-effects/useAgentEventBridge';
+import { useShortcutHandlers } from '../src/app-effects/useShortcutHandlers';
+import { useSessionActivateBridge } from '../src/app-effects/useSessionActivateBridge';
+import { useFocusBridge } from '../src/app-effects/useFocusBridge';
+import { useUpdateDownloadedBridge } from '../src/app-effects/useUpdateDownloadedBridge';
+import { usePersistErrorBridge } from '../src/app-effects/usePersistErrorBridge';
+import { useTutorialOverlay } from '../src/app-effects/useTutorialOverlay';
+
+const initial = useStore.getState();
+
+function stubCCSM() {
+  const api = {
+    pathsExist: vi.fn().mockResolvedValue({}),
+    recentCwds: vi.fn().mockResolvedValue([]),
+    defaultModel: vi.fn().mockResolvedValue(null),
+    onUpdateDownloaded: vi.fn().mockReturnValue(() => {}),
+    cliCheck: vi.fn().mockResolvedValue({ state: 'found', binaryPath: '/usr/bin/claude' }),
+    settingsLoad: vi.fn().mockResolvedValue({}),
+    modelsList: vi.fn().mockResolvedValue([]),
+    updatesInstall: vi.fn(),
+    window: {
+      onBeforeHide: vi.fn().mockReturnValue(() => {}),
+      onAfterShow: vi.fn().mockReturnValue(() => {}),
+      isMaximized: vi.fn().mockResolvedValue(false),
+      onMaximizedChanged: vi.fn().mockReturnValue(() => {}),
+      minimize: vi.fn(),
+      maximize: vi.fn(),
+      unmaximize: vi.fn(),
+      close: vi.fn(),
+    },
+    i18n: {
+      getSystemLocale: vi.fn().mockResolvedValue('en'),
+      setLanguage: vi.fn(),
+    },
+  };
+  (globalThis as unknown as { window: Window & { ccsm?: unknown } }).window.ccsm = api;
+  return api;
+}
+
+function stubMatchMedia() {
+  if (typeof window === 'undefined') return;
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
+beforeEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  useStore.setState(
+    {
+      ...initial,
+      sessions: [],
+      groups: [{ id: 'g-default', name: 'Sessions', collapsed: false, kind: 'normal' }],
+      activeId: '',
+      focusedGroupId: null,
+      tutorialSeen: true,
+      hydrated: true,
+      messagesBySession: {},
+      startedSessions: {},
+      runningSessions: {},
+      messageQueues: {},
+      focusInputNonce: 0,
+    },
+    true
+  );
+  stubCCSM();
+  stubMatchMedia();
+});
+
+describe('App composition root wires extracted effect hooks (Task #732)', () => {
+  it('calls each of the 9 app-effects hooks during render', () => {
+    render(<App />);
+    expect(useThemeEffect).toHaveBeenCalled();
+    expect(useLanguageEffect).toHaveBeenCalled();
+    expect(useAgentEventBridge).toHaveBeenCalled();
+    expect(useShortcutHandlers).toHaveBeenCalled();
+    expect(useSessionActivateBridge).toHaveBeenCalled();
+    expect(useFocusBridge).toHaveBeenCalled();
+    expect(useUpdateDownloadedBridge).toHaveBeenCalled();
+    expect(usePersistErrorBridge).toHaveBeenCalled();
+    expect(useTutorialOverlay).toHaveBeenCalled();
+  });
+
+  it('passes the resolved language to useLanguageEffect', () => {
+    render(<App />);
+    const calls = (useLanguageEffect as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    // First positional arg is the resolved language ('en' from stubCCSM
+    // setSystemLocale + initI18n).
+    expect(typeof calls[0][0]).toBe('string');
+  });
+
+  it('passes selectSession to useSessionActivateBridge', () => {
+    render(<App />);
+    const calls = (useSessionActivateBridge as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    expect(typeof calls[0][0]).toBe('function');
+  });
+
+  it('passes a deps object with toast push to useUpdateDownloadedBridge and usePersistErrorBridge', () => {
+    render(<App />);
+    const updateCalls = (useUpdateDownloadedBridge as unknown as { mock: { calls: Array<Array<{ push: unknown }>> } }).mock.calls;
+    const persistCalls = (usePersistErrorBridge as unknown as { mock: { calls: Array<Array<{ push: unknown }>> } }).mock.calls;
+    expect(updateCalls.length).toBeGreaterThan(0);
+    expect(persistCalls.length).toBeGreaterThan(0);
+    expect(typeof updateCalls[0][0].push).toBe('function');
+    expect(typeof persistCalls[0][0].push).toBe('function');
+  });
+
+  it('passes the current theme to useThemeEffect', () => {
+    render(<App />);
+    const calls = (useThemeEffect as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    expect(['light', 'dark', 'system']).toContain(calls[0][0]);
+  });
+
+  it('passes tutorialSeen + markTutorialSeen to useTutorialOverlay', () => {
+    render(<App />);
+    const calls = (useTutorialOverlay as unknown as { mock: { calls: Array<Array<{ tutorialSeen: unknown; markTutorialSeen: unknown }>> } }).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    expect(typeof calls[0][0].tutorialSeen).toBe('boolean');
+    expect(typeof calls[0][0].markTutorialSeen).toBe('function');
+  });
+});


### PR DESCRIPTION
## Scope

Task #732 Phase B — rewrite `src/App.tsx` to consume the 9 hooks merged in PR #552 under `src/app-effects/`.

- 9 inline `useEffect` blocks + 2 inline bridge components (`PersistErrorBridge`, `UpdateDownloadedBridge`) replaced by hook calls.
- `App.tsx`: **720 -> 573 LoC** (-147, -20%).
- The 12 useEffects NOT in scope for Phase A stay inline (font size, activeId mirror, names mirror, pty exit, title, flash, flashStates seam, cwdRedirect, locale hydrate, exit animation, claude availability, system locale fetch).

## Why

SRP — `App.tsx` becomes layout + composition only for the extracted concerns. Each hook has a dedicated test in `tests/app-effects/` already (PR #552); App-level test now pins the wiring contract.

## Implementation note: AppEffectsBridge

`useUpdateDownloadedBridge` and `usePersistErrorBridge` both depend on `useToast()`, which throws unless called inside `<ToastProvider>`. The original code solved this by rendering `<PersistErrorBridge />` / `<UpdateDownloadedBridge />` as children of `ToastProvider`. The hook-form replacements have the same constraint, so this PR introduces a tiny inner `AppEffectsBridge` component that:
1. Lives as a child of every `<ToastProvider>` (3 render branches: pre-hydrate skeleton, empty-state, active session).
2. Calls `useToast()` once and forwards `push` to both hooks.
3. Returns `null`.

This preserves the original mounting semantics (toast handlers wired exactly when `ToastProvider` is mounted) without requiring two component boundaries.

## Test plan

- [x] **New** `tests/App.hooks.test.tsx`: 6 tests using `vi.mock` to assert App calls each of the 9 hooks during render, plus 5 deps-forwarding asserts (theme, language, selectSession, push×2, tutorialSeen+markTutorialSeen). Result: **6/6 PASS**.
- [x] **Full vitest run**: 552 pass / 3 pre-existing failures in `electron/__tests__/db-hardening.test.ts` (better-sqlite3 NODE_MODULE_VERSION 130 vs 137 native binding mismatch — verified IDENTICAL fail on `origin/working` baseline before any patch). **No new failures.**
- [x] `npm run build` clean (3 webpack size warnings, unrelated).
- [x] `npx tsc --noEmit` clean.
- [x] **e2e BEFORE patch** (`origin/working`):
  ```
  PASS  new-session-chat                   22576ms
  PASS  switch-session-keeps-chat          54737ms
  total: 2/2 passed, 153.2s wall
  ```
- [x] **e2e AFTER patch**:
  ```
  PASS  new-session-chat                   21932ms
  PASS  switch-session-keeps-chat          37432ms
  total: 2/2 passed, 72.2s wall
  ```
  Identical pass/fail set. Refactor introduces no behavioural regression.

## Constraints

- ONLY `src/App.tsx` modified + 1 new test file `tests/App.hooks.test.tsx` (note: spec said `src/__tests__/` but project uses `tests/` per `vitest.config.ts` include glob).
- No hook files touched.
- No other components touched.
- English only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)