### PR TITLE
refactor(app): extract 8 more IPC-bridge effect hooks (Task #758 Phase C)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { Plus, Download } from 'lucide-react';
 import { TooltipProvider } from './components/ui/Tooltip';
 import { ToastProvider, useToast } from './components/ui/Toast';
@@ -19,7 +19,6 @@ import { useStore } from './stores/store';
 import { initI18n } from './i18n';
 import { useTranslation } from './i18n/useTranslation';
 import { usePreferences } from './store/preferences';
-import { DURATION, EASING } from './lib/motion';
 import { useThemeEffect } from './app-effects/useThemeEffect';
 import { useLanguageEffect } from './app-effects/useLanguageEffect';
 import { useAgentEventBridge } from './app-effects/useAgentEventBridge';
@@ -29,6 +28,14 @@ import { useFocusBridge } from './app-effects/useFocusBridge';
 import { useUpdateDownloadedBridge } from './app-effects/useUpdateDownloadedBridge';
 import { usePersistErrorBridge } from './app-effects/usePersistErrorBridge';
 import { useTutorialOverlay } from './app-effects/useTutorialOverlay';
+import { useSessionActiveBridge } from './app-effects/useSessionActiveBridge';
+import { useSessionNameBridge } from './app-effects/useSessionNameBridge';
+import { usePtyExitBridge } from './app-effects/usePtyExitBridge';
+import { useSessionTitleBridge } from './app-effects/useSessionTitleBridge';
+import { useNotifyFlashBridge } from './app-effects/useNotifyFlashBridge';
+import { useCwdRedirectedBridge } from './app-effects/useCwdRedirectedBridge';
+import { useHydrateSystemLocale } from './app-effects/useHydrateSystemLocale';
+import { useExitAnimation } from './app-effects/useExitAnimation';
 
 // Initialise i18next once, before any component renders. Subsequent
 // language changes flow through `applyLanguage` (called by the store
@@ -95,7 +102,7 @@ export default function App() {
   const [importOpen, setImportOpen] = React.useState(false);
   const [shortcutsOpen, setShortcutsOpen] = React.useState(false);
 
-  // ---- Extracted effect hooks (Task #732 Phase B) -----------------------
+  // ---- Extracted effect hooks (Task #732 Phase B + Task #758 Phase C) ----
   // Theme application — reactive to user choice + (when system) OS scheme.
   useThemeEffect(theme);
 
@@ -140,8 +147,41 @@ export default function App() {
   const resolvedLanguage = usePreferences((s) => s.resolvedLanguage);
   useLanguageEffect(resolvedLanguage);
 
+  // Mirror the renderer's active session id to main so the desktop-notify
+  // bridge can suppress toasts for the session the user is already on.
+  useSessionActiveBridge(activeId);
+
+  // Mirror per-session names to main; diffs over previous render and
+  // emits clears for sids that have disappeared.
+  useSessionNameBridge(sessions);
+
+  // Pipe `pty:exit` events into the store unconditionally (drives the
+  // sidebar red dot for background-session deaths).
+  usePtyExitBridge(applyPtyExit);
+
+  // Pipe `session:title` IPC events from main into the store (SDK-derived
+  // summary changes).
+  useSessionTitleBridge(applyExternalTitle);
+
+  // Pipe `notify:flash` IPC events from main into the store (transient
+  // pulses driven by the 7-rule decider).
+  useNotifyFlashBridge();
+
+  // Pipe `session:cwdRedirected` IPC events into the store (import-resume
+  // copy helper relocates a JSONL into the spawn cwd's projectDir).
+  useCwdRedirectedBridge(applyCwdRedirect);
+
+  // Boot-time: ask main for the OS locale and feed preferences. Falls
+  // back to navigator.
+  useHydrateSystemLocale(hydrateSystemLocale);
+
+  // Window hide-to-tray exit animation: fade <html> opacity in/out on
+  // `window:beforeHide` / `window:afterShow`.
+  useExitAnimation();
+
   // -----------------------------------------------------------------------
-  // Remaining inline effects (NOT extracted — Phase C territory).
+  // Remaining inline effects (intentionally NOT extracted — couple to
+  // local React state too tightly to be worth a hook indirection).
   // -----------------------------------------------------------------------
 
   // Font size slider applies via CSS variable on <html>. Child text utilities
@@ -152,105 +192,6 @@ export default function App() {
   useEffect(() => {
     document.documentElement.style.setProperty('--app-font-size', `${fontSizePx}px`);
   }, [fontSizePx]);
-
-  // Mirror the renderer's active session id to main so the desktop-notify
-  // bridge can suppress toasts for the session the user is already looking
-  // at. Fires once on mount and on every activeId change. Bridge is a
-  // no-op in the test/storybook environments where `window.ccsmSession` is
-  // missing.
-  useEffect(() => {
-    type Bridge = { setActive: (sid: string | null) => void };
-    const bridge = (window as unknown as { ccsmSession?: Bridge }).ccsmSession;
-    if (!bridge || typeof bridge.setActive !== 'function') return;
-    bridge.setActive(activeId || null);
-  }, [activeId]);
-
-  // Mirror per-session NAMES to main so the desktop-notify bridge can label
-  // toasts with the friendly name (custom rename or SDK auto-summary)
-  // instead of the bare UUID. Sister effect to `setActive` above; same
-  // reason — main needs a synchronous answer when an OS notification fires
-  // and we don't want a renderer round-trip on the notify path. Diffs over
-  // the previous snapshot so we only IPC for actual changes (mounts,
-  // renames, SDK title arrivals, deletions).
-  //
-  // Also tracks sids seen in the previous render and clears (`setName(sid,
-  // null)`) any that have since disappeared, so main's
-  // `sessionNamesFromRenderer` map doesn't grow unbounded across the app
-  // lifetime as sessions are created and deleted (#613, follow-up to #509).
-  const prevSidsRef = useRef<Set<string>>(new Set());
-  useEffect(() => {
-    type Bridge = { setName: (sid: string, name: string | null) => void };
-    const bridge = (window as unknown as { ccsmSession?: Bridge }).ccsmSession;
-    if (!bridge || typeof bridge.setName !== 'function') return;
-    const currentSids = new Set<string>();
-    for (const sess of sessions) {
-      bridge.setName(sess.id, sess.name ?? null);
-      currentSids.add(sess.id);
-    }
-    for (const staleSid of prevSidsRef.current) {
-      if (!currentSids.has(staleSid)) {
-        bridge.setName(staleSid, null);
-      }
-    }
-    prevSidsRef.current = currentSids;
-  }, [sessions]);
-
-  // Pipe `pty:exit` events into the store UNCONDITIONALLY (not filtered
-  // by activeSid). TerminalPane has its own filtered listener that drives
-  // the active-pane red overlay; this second listener is what surfaces
-  // background-session deaths in the sidebar (red dot via
-  // `disconnectedSessions[sid]`). Both coexist — different concerns, no
-  // duplication risk because the store action is idempotent on payload.
-  useEffect(() => {
-    const pty = (window as unknown as {
-      ccsmPty?: {
-        onExit?: (cb: (e: { sessionId: string; code?: number | null; signal?: string | number | null }) => void) => () => void;
-      };
-    }).ccsmPty;
-    if (!pty?.onExit) return;
-    return pty.onExit((evt) => {
-      if (!evt || typeof evt.sessionId !== 'string' || evt.sessionId.length === 0) return;
-      applyPtyExit(evt.sessionId, {
-        code: evt.code ?? null,
-        signal: evt.signal ?? null,
-      });
-    });
-  }, [applyPtyExit]);
-
-  // Pipe `session:title` IPC events from main into the store. The watcher
-  // emits when the SDK-derived `summary` changes for a session; the store
-  // applies via `_applyExternalTitle` (no-ops if the row is missing or
-  // the name is already current). Bridge is a no-op in the
-  // test/storybook environments where `window.ccsmSession` is missing or
-  // the older preload didn't expose `onTitle`.
-  useEffect(() => {
-    type Bridge = {
-      onTitle?: (cb: (e: { sid: string; title: string }) => void) => () => void;
-    };
-    const bridge = (window as unknown as { ccsmSession?: Bridge }).ccsmSession;
-    if (!bridge || typeof bridge.onTitle !== 'function') return;
-    return bridge.onTitle((evt) => {
-      if (!evt || typeof evt.sid !== 'string' || typeof evt.title !== 'string') return;
-      if (evt.sid.length === 0 || evt.title.length === 0) return;
-      applyExternalTitle(evt.sid, evt.title);
-    });
-  }, [applyExternalTitle]);
-
-  // Pipe `notify:flash` IPC events from main into the store. The flash sink
-  // (`electron/notify/sinks/flashSink.ts`) sets `flashStates[sid] = true`
-  // for transient pulses driven by the 7-rule decider — Rule 2 (foreground
-  // active sid + short task) is flash-only with no toast, so the AgentIcon
-  // halo MUST react to this signal in addition to `state === 'waiting'`.
-  // Auto-clear is driven by main's 4s timer, which pushes `{on:false}`.
-  useEffect(() => {
-    type Bridge = { onFlash?: (cb: (e: { sid: string; on: boolean }) => void) => () => void };
-    const bridge = (window as unknown as { ccsmNotify?: Bridge }).ccsmNotify;
-    if (!bridge || typeof bridge.onFlash !== 'function') return;
-    return bridge.onFlash((evt) => {
-      if (!evt || typeof evt.sid !== 'string' || evt.sid.length === 0) return;
-      useStore.getState()._setFlash(evt.sid, evt.on === true);
-    });
-  }, []);
 
   // E2E debug seam: project the per-sid attention state onto
   // `window.__ccsmFlashStates` as `{ sid: 'flashing' | undefined }` for the
@@ -272,82 +213,6 @@ export default function App() {
     }
     (window as unknown as { __ccsmFlashStates?: Record<string, 'flashing' | undefined> }).__ccsmFlashStates = map;
   }, [sessions, flashStates]);
-
-  // Pipe `session:cwdRedirected` IPC events from main into the store. Fired
-  // by the ptyHost spawn handler when the import-resume copy helper (#603)
-  // relocates a JSONL into the spawn cwd's projectDir. Patching
-  // `session.cwd` is what keeps the sessionTitles SDK bridge pointing at
-  // the live COPY rather than the now-frozen SOURCE on subsequent
-  // `renameSession` / `getSessionInfo` / `listForProject` calls.
-  useEffect(() => {
-    type Bridge = {
-      onCwdRedirected?: (cb: (e: { sid: string; newCwd: string }) => void) => () => void;
-    };
-    const bridge = (window as unknown as { ccsmSession?: Bridge }).ccsmSession;
-    if (!bridge || typeof bridge.onCwdRedirected !== 'function') return;
-    return bridge.onCwdRedirected((evt) => {
-      if (!evt || typeof evt.sid !== 'string' || typeof evt.newCwd !== 'string') return;
-      if (evt.sid.length === 0 || evt.newCwd.length === 0) return;
-      applyCwdRedirect(evt.sid, evt.newCwd);
-    });
-  }, [applyCwdRedirect]);
-
-  // Locale: ask main for the OS locale, feed it into the preferences store
-  // so a "system" preference resolves correctly. Falls back to navigator.
-  useEffect(() => {
-    let cancelled = false;
-    const bridge = window.ccsm;
-    void (async () => {
-      let locale: string | undefined;
-      try {
-        locale = await bridge?.i18n?.getSystemLocale();
-      } catch {
-        locale = undefined;
-      }
-      if (cancelled) return;
-      hydrateSystemLocale(
-        locale ?? (typeof navigator !== 'undefined' ? navigator.language : undefined)
-      );
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [hydrateSystemLocale]);
-
-  // Exit animation (UI-10 / #213):
-  // When the user closes the window (Ctrl+W, X button) the Electron main
-  // process hides-to-tray instead of destroying. It sends
-  // `window:beforeHide` with a duration first so we can fade the whole
-  // document out, then hides ~180ms later — giving the user a graceful
-  // exit rather than an abrupt disappearance. On restore, `window:afterShow`
-  // resets opacity. Uses the shared motion tokens (DURATION.standard /
-  // EASING.exit) for consistency with the rest of the app.
-  //
-  // Implementation note: we drive `document.documentElement.style.opacity`
-  // directly instead of wrapping the React tree in a `<motion.div>` — a
-  // root-level wrapper would be invasive and risk layout regressions,
-  // while this approach is zero-DOM, zero-rerender, and survives when
-  // React state is about to be torn down.
-  useEffect(() => {
-    const bridge = window.ccsm?.window;
-    if (!bridge?.onBeforeHide || !bridge?.onAfterShow) return;
-    const root = document.documentElement;
-    const transition = `opacity ${DURATION.standard}s cubic-bezier(${EASING.exit.join(',')})`;
-    const offHide = bridge.onBeforeHide(() => {
-      root.style.transition = transition;
-      root.style.opacity = '0';
-    });
-    const offShow = bridge.onAfterShow(() => {
-      root.style.transition = transition;
-      root.style.opacity = '1';
-    });
-    return () => {
-      offHide();
-      offShow();
-      root.style.transition = '';
-      root.style.opacity = '';
-    };
-  }, []);
 
   // Boot-time check: is the `claude` CLI on PATH? Cached in App-level
   // state because the install state doesn't change mid-session — only

--- a/src/app-effects/useCwdRedirectedBridge.ts
+++ b/src/app-effects/useCwdRedirectedBridge.ts
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+
+/**
+ * Pipe `session:cwdRedirected` IPC events from main into the store. Fired
+ * by the ptyHost spawn handler when the import-resume copy helper (#603)
+ * relocates a JSONL into the spawn cwd's projectDir. Patching
+ * `session.cwd` is what keeps the sessionTitles SDK bridge pointing at
+ * the live COPY rather than the now-frozen SOURCE on subsequent
+ * `renameSession` / `getSessionInfo` / `listForProject` calls.
+ *
+ * Extracted from App.tsx for SRP under Task #758 Phase C.
+ */
+export function useCwdRedirectedBridge(
+  applyCwdRedirect: (sid: string, newCwd: string) => void
+): void {
+  useEffect(() => {
+    type Bridge = {
+      onCwdRedirected?: (cb: (e: { sid: string; newCwd: string }) => void) => () => void;
+    };
+    const bridge = (window as unknown as { ccsmSession?: Bridge }).ccsmSession;
+    if (!bridge || typeof bridge.onCwdRedirected !== 'function') return;
+    return bridge.onCwdRedirected((evt) => {
+      if (!evt || typeof evt.sid !== 'string' || typeof evt.newCwd !== 'string') return;
+      if (evt.sid.length === 0 || evt.newCwd.length === 0) return;
+      applyCwdRedirect(evt.sid, evt.newCwd);
+    });
+  }, [applyCwdRedirect]);
+}

--- a/src/app-effects/useExitAnimation.ts
+++ b/src/app-effects/useExitAnimation.ts
@@ -1,0 +1,43 @@
+import { useEffect } from 'react';
+import { DURATION, EASING } from '../lib/motion';
+
+/**
+ * Exit animation (UI-10 / #213):
+ * When the user closes the window (Ctrl+W, X button) the Electron main
+ * process hides-to-tray instead of destroying. It sends
+ * `window:beforeHide` with a duration first so we can fade the whole
+ * document out, then hides ~180ms later — giving the user a graceful
+ * exit rather than an abrupt disappearance. On restore, `window:afterShow`
+ * resets opacity. Uses the shared motion tokens (DURATION.standard /
+ * EASING.exit) for consistency with the rest of the app.
+ *
+ * Implementation note: drives `document.documentElement.style.opacity`
+ * directly instead of wrapping the React tree in a `<motion.div>` — a
+ * root-level wrapper would be invasive and risk layout regressions,
+ * while this approach is zero-DOM, zero-rerender, and survives when
+ * React state is about to be torn down.
+ *
+ * Extracted from App.tsx for SRP under Task #758 Phase C.
+ */
+export function useExitAnimation(): void {
+  useEffect(() => {
+    const bridge = window.ccsm?.window;
+    if (!bridge?.onBeforeHide || !bridge?.onAfterShow) return;
+    const root = document.documentElement;
+    const transition = `opacity ${DURATION.standard}s cubic-bezier(${EASING.exit.join(',')})`;
+    const offHide = bridge.onBeforeHide(() => {
+      root.style.transition = transition;
+      root.style.opacity = '0';
+    });
+    const offShow = bridge.onAfterShow(() => {
+      root.style.transition = transition;
+      root.style.opacity = '1';
+    });
+    return () => {
+      offHide();
+      offShow();
+      root.style.transition = '';
+      root.style.opacity = '';
+    };
+  }, []);
+}

--- a/src/app-effects/useHydrateSystemLocale.ts
+++ b/src/app-effects/useHydrateSystemLocale.ts
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+
+/**
+ * Locale: ask main for the OS locale, feed it into the preferences store
+ * so a "system" preference resolves correctly. Falls back to navigator.
+ *
+ * Extracted from App.tsx for SRP under Task #758 Phase C. The hydrator
+ * action is injected so the hook stays pure and testable.
+ */
+export function useHydrateSystemLocale(
+  hydrateSystemLocale: (locale: string | undefined) => void
+): void {
+  useEffect(() => {
+    let cancelled = false;
+    const bridge = window.ccsm;
+    void (async () => {
+      let locale: string | undefined;
+      try {
+        locale = await bridge?.i18n?.getSystemLocale();
+      } catch {
+        locale = undefined;
+      }
+      if (cancelled) return;
+      hydrateSystemLocale(
+        locale ?? (typeof navigator !== 'undefined' ? navigator.language : undefined)
+      );
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [hydrateSystemLocale]);
+}

--- a/src/app-effects/useNotifyFlashBridge.ts
+++ b/src/app-effects/useNotifyFlashBridge.ts
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+import { useStore } from '../stores/store';
+
+/**
+ * Pipe `notify:flash` IPC events from main into the store. The flash sink
+ * (`electron/notify/sinks/flashSink.ts`) sets `flashStates[sid] = true`
+ * for transient pulses driven by the 7-rule decider — Rule 2 (foreground
+ * active sid + short task) is flash-only with no toast, so the AgentIcon
+ * halo MUST react to this signal in addition to `state === 'waiting'`.
+ * Auto-clear is driven by main's 4s timer, which pushes `{on:false}`.
+ *
+ * Extracted from App.tsx for SRP under Task #758 Phase C. Reaches into
+ * `useStore.getState()._setFlash` directly (not via injected dep) to
+ * preserve the original mount-once `[]` dependency semantics — the
+ * store's setter identity is stable for the app lifetime.
+ */
+export function useNotifyFlashBridge(): void {
+  useEffect(() => {
+    type Bridge = { onFlash?: (cb: (e: { sid: string; on: boolean }) => void) => () => void };
+    const bridge = (window as unknown as { ccsmNotify?: Bridge }).ccsmNotify;
+    if (!bridge || typeof bridge.onFlash !== 'function') return;
+    return bridge.onFlash((evt) => {
+      if (!evt || typeof evt.sid !== 'string' || evt.sid.length === 0) return;
+      useStore.getState()._setFlash(evt.sid, evt.on === true);
+    });
+  }, []);
+}

--- a/src/app-effects/usePtyExitBridge.ts
+++ b/src/app-effects/usePtyExitBridge.ts
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+
+export interface PtyExitEvent {
+  code: number | null;
+  signal: string | number | null;
+}
+
+/**
+ * Pipe `pty:exit` events into the store UNCONDITIONALLY (not filtered
+ * by activeSid). TerminalPane has its own filtered listener that drives
+ * the active-pane red overlay; this second listener is what surfaces
+ * background-session deaths in the sidebar (red dot via
+ * `disconnectedSessions[sid]`). Both coexist — different concerns, no
+ * duplication risk because the store action is idempotent on payload.
+ *
+ * Extracted from App.tsx for SRP under Task #758 Phase C.
+ */
+export function usePtyExitBridge(
+  applyPtyExit: (sid: string, evt: PtyExitEvent) => void
+): void {
+  useEffect(() => {
+    const pty = (window as unknown as {
+      ccsmPty?: {
+        onExit?: (
+          cb: (e: { sessionId: string; code?: number | null; signal?: string | number | null }) => void
+        ) => () => void;
+      };
+    }).ccsmPty;
+    if (!pty?.onExit) return;
+    return pty.onExit((evt) => {
+      if (!evt || typeof evt.sessionId !== 'string' || evt.sessionId.length === 0) return;
+      applyPtyExit(evt.sessionId, {
+        code: evt.code ?? null,
+        signal: evt.signal ?? null,
+      });
+    });
+  }, [applyPtyExit]);
+}

--- a/src/app-effects/useSessionActiveBridge.ts
+++ b/src/app-effects/useSessionActiveBridge.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+
+/**
+ * Mirror the renderer's active session id to main so the desktop-notify
+ * bridge can suppress toasts for the session the user is already looking
+ * at. Fires once on mount and on every activeId change. Bridge is a
+ * no-op in the test/storybook environments where `window.ccsmSession` is
+ * missing.
+ *
+ * Extracted from App.tsx for SRP under Task #758 Phase C.
+ */
+export function useSessionActiveBridge(activeId: string | null | undefined): void {
+  useEffect(() => {
+    type Bridge = { setActive: (sid: string | null) => void };
+    const bridge = (window as unknown as { ccsmSession?: Bridge }).ccsmSession;
+    if (!bridge || typeof bridge.setActive !== 'function') return;
+    bridge.setActive(activeId || null);
+  }, [activeId]);
+}

--- a/src/app-effects/useSessionNameBridge.ts
+++ b/src/app-effects/useSessionNameBridge.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from 'react';
+
+interface SessionLike {
+  id: string;
+  name?: string | null;
+}
+
+/**
+ * Mirror per-session NAMES to main so the desktop-notify bridge can label
+ * toasts with the friendly name (custom rename or SDK auto-summary)
+ * instead of the bare UUID. Sister effect to `useSessionActiveBridge` —
+ * main needs a synchronous answer when an OS notification fires and we
+ * don't want a renderer round-trip on the notify path. Diffs over the
+ * previous snapshot so we only IPC for actual changes (mounts, renames,
+ * SDK title arrivals, deletions).
+ *
+ * Also tracks sids seen in the previous render and clears (`setName(sid,
+ * null)`) any that have since disappeared, so main's
+ * `sessionNamesFromRenderer` map doesn't grow unbounded across the app
+ * lifetime as sessions are created and deleted (#613, follow-up to #509).
+ *
+ * Extracted from App.tsx for SRP under Task #758 Phase C.
+ */
+export function useSessionNameBridge(sessions: ReadonlyArray<SessionLike>): void {
+  const prevSidsRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    type Bridge = { setName: (sid: string, name: string | null) => void };
+    const bridge = (window as unknown as { ccsmSession?: Bridge }).ccsmSession;
+    if (!bridge || typeof bridge.setName !== 'function') return;
+    const currentSids = new Set<string>();
+    for (const sess of sessions) {
+      bridge.setName(sess.id, sess.name ?? null);
+      currentSids.add(sess.id);
+    }
+    for (const staleSid of prevSidsRef.current) {
+      if (!currentSids.has(staleSid)) {
+        bridge.setName(staleSid, null);
+      }
+    }
+    prevSidsRef.current = currentSids;
+  }, [sessions]);
+}

--- a/src/app-effects/useSessionTitleBridge.ts
+++ b/src/app-effects/useSessionTitleBridge.ts
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+
+/**
+ * Pipe `session:title` IPC events from main into the store. The watcher
+ * emits when the SDK-derived `summary` changes for a session; the store
+ * applies via `_applyExternalTitle` (no-ops if the row is missing or
+ * the name is already current). Bridge is a no-op in the
+ * test/storybook environments where `window.ccsmSession` is missing or
+ * the older preload didn't expose `onTitle`.
+ *
+ * Extracted from App.tsx for SRP under Task #758 Phase C.
+ */
+export function useSessionTitleBridge(
+  applyExternalTitle: (sid: string, title: string) => void
+): void {
+  useEffect(() => {
+    type Bridge = {
+      onTitle?: (cb: (e: { sid: string; title: string }) => void) => () => void;
+    };
+    const bridge = (window as unknown as { ccsmSession?: Bridge }).ccsmSession;
+    if (!bridge || typeof bridge.onTitle !== 'function') return;
+    return bridge.onTitle((evt) => {
+      if (!evt || typeof evt.sid !== 'string' || typeof evt.title !== 'string') return;
+      if (evt.sid.length === 0 || evt.title.length === 0) return;
+      applyExternalTitle(evt.sid, evt.title);
+    });
+  }, [applyExternalTitle]);
+}

--- a/tests/App.hooks.test.tsx
+++ b/tests/App.hooks.test.tsx
@@ -1,15 +1,16 @@
-// Task #732 Phase B — verify App.tsx wires the 9 effect hooks merged in
-// PR #552. Each hook module is mocked so we can assert it was called
-// exactly once per render. This pins the contract that the App
-// composition root delegates these effects to dedicated hooks rather than
-// inlining them — guards against future regressions where someone
-// re-inlines logic and silently bypasses the SRP boundary.
+// Task #732 Phase B + Task #758 Phase C — verify App.tsx wires the
+// extracted effect hooks merged in PR #552 / PR #559 / PR #758. Each hook
+// module is mocked so we can assert it was called exactly once per render.
+// This pins the contract that the App composition root delegates these
+// effects to dedicated hooks rather than inlining them — guards against
+// future regressions where someone re-inlines logic and silently bypasses
+// the SRP boundary.
 import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, cleanup } from '@testing-library/react';
 import { useStore } from '../src/stores/store';
 
-// Mock all 9 hook modules BEFORE importing App. Each export is a vi.fn so
+// Mock all hook modules BEFORE importing App. Each export is a vi.fn so
 // we can introspect call counts after render. The hooks return either
 // `void` or, in the tutorial case, a `{ show, dismiss }` shape — match
 // the production return so App's render path doesn't crash.
@@ -40,6 +41,31 @@ vi.mock('../src/app-effects/usePersistErrorBridge', () => ({
 vi.mock('../src/app-effects/useTutorialOverlay', () => ({
   useTutorialOverlay: vi.fn(() => ({ show: false, dismiss: vi.fn() })),
 }));
+// Phase C hooks (Task #758).
+vi.mock('../src/app-effects/useSessionActiveBridge', () => ({
+  useSessionActiveBridge: vi.fn(),
+}));
+vi.mock('../src/app-effects/useSessionNameBridge', () => ({
+  useSessionNameBridge: vi.fn(),
+}));
+vi.mock('../src/app-effects/usePtyExitBridge', () => ({
+  usePtyExitBridge: vi.fn(),
+}));
+vi.mock('../src/app-effects/useSessionTitleBridge', () => ({
+  useSessionTitleBridge: vi.fn(),
+}));
+vi.mock('../src/app-effects/useNotifyFlashBridge', () => ({
+  useNotifyFlashBridge: vi.fn(),
+}));
+vi.mock('../src/app-effects/useCwdRedirectedBridge', () => ({
+  useCwdRedirectedBridge: vi.fn(),
+}));
+vi.mock('../src/app-effects/useHydrateSystemLocale', () => ({
+  useHydrateSystemLocale: vi.fn(),
+}));
+vi.mock('../src/app-effects/useExitAnimation', () => ({
+  useExitAnimation: vi.fn(),
+}));
 
 // Imports MUST come after vi.mock calls (vi.mock is hoisted, but explicit
 // ordering keeps the read order obvious to humans).
@@ -53,6 +79,14 @@ import { useFocusBridge } from '../src/app-effects/useFocusBridge';
 import { useUpdateDownloadedBridge } from '../src/app-effects/useUpdateDownloadedBridge';
 import { usePersistErrorBridge } from '../src/app-effects/usePersistErrorBridge';
 import { useTutorialOverlay } from '../src/app-effects/useTutorialOverlay';
+import { useSessionActiveBridge } from '../src/app-effects/useSessionActiveBridge';
+import { useSessionNameBridge } from '../src/app-effects/useSessionNameBridge';
+import { usePtyExitBridge } from '../src/app-effects/usePtyExitBridge';
+import { useSessionTitleBridge } from '../src/app-effects/useSessionTitleBridge';
+import { useNotifyFlashBridge } from '../src/app-effects/useNotifyFlashBridge';
+import { useCwdRedirectedBridge } from '../src/app-effects/useCwdRedirectedBridge';
+import { useHydrateSystemLocale } from '../src/app-effects/useHydrateSystemLocale';
+import { useExitAnimation } from '../src/app-effects/useExitAnimation';
 
 const initial = useStore.getState();
 
@@ -128,7 +162,7 @@ beforeEach(() => {
 });
 
 describe('App composition root wires extracted effect hooks (Task #732)', () => {
-  it('calls each of the 9 app-effects hooks during render', () => {
+  it('calls each of the 9 Phase A/B app-effects hooks during render', () => {
     render(<App />);
     expect(useThemeEffect).toHaveBeenCalled();
     expect(useLanguageEffect).toHaveBeenCalled();
@@ -180,5 +214,57 @@ describe('App composition root wires extracted effect hooks (Task #732)', () => 
     expect(calls.length).toBeGreaterThan(0);
     expect(typeof calls[0][0].tutorialSeen).toBe('boolean');
     expect(typeof calls[0][0].markTutorialSeen).toBe('function');
+  });
+});
+
+describe('App composition root wires Phase C effect hooks (Task #758)', () => {
+  it('calls each of the 8 Phase C app-effects hooks during render', () => {
+    render(<App />);
+    expect(useSessionActiveBridge).toHaveBeenCalled();
+    expect(useSessionNameBridge).toHaveBeenCalled();
+    expect(usePtyExitBridge).toHaveBeenCalled();
+    expect(useSessionTitleBridge).toHaveBeenCalled();
+    expect(useNotifyFlashBridge).toHaveBeenCalled();
+    expect(useCwdRedirectedBridge).toHaveBeenCalled();
+    expect(useHydrateSystemLocale).toHaveBeenCalled();
+    expect(useExitAnimation).toHaveBeenCalled();
+  });
+
+  it('passes activeId (string or null/empty) to useSessionActiveBridge', () => {
+    render(<App />);
+    const calls = (useSessionActiveBridge as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    // activeId is '' on the empty fixture; the hook accepts string|null|undefined.
+    const first = calls[0][0];
+    expect(typeof first === 'string' || first === null || first === undefined).toBe(true);
+  });
+
+  it('passes the sessions array to useSessionNameBridge', () => {
+    render(<App />);
+    const calls = (useSessionNameBridge as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    expect(Array.isArray(calls[0][0])).toBe(true);
+  });
+
+  it('passes store action functions to the IPC-bridge hooks that take a callback', () => {
+    render(<App />);
+    const ptyCalls = (usePtyExitBridge as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    const titleCalls = (useSessionTitleBridge as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    const cwdCalls = (useCwdRedirectedBridge as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    const hydrateCalls = (useHydrateSystemLocale as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    expect(typeof ptyCalls[0][0]).toBe('function');
+    expect(typeof titleCalls[0][0]).toBe('function');
+    expect(typeof cwdCalls[0][0]).toBe('function');
+    expect(typeof hydrateCalls[0][0]).toBe('function');
+  });
+
+  it('useNotifyFlashBridge and useExitAnimation take no args (zero-arg subscriptions)', () => {
+    render(<App />);
+    const flashCalls = (useNotifyFlashBridge as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    const exitCalls = (useExitAnimation as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    expect(flashCalls.length).toBeGreaterThan(0);
+    expect(exitCalls.length).toBeGreaterThan(0);
+    expect(flashCalls[0].length).toBe(0);
+    expect(exitCalls[0].length).toBe(0);
   });
 });

--- a/tests/app-effects/useCwdRedirectedBridge.test.tsx
+++ b/tests/app-effects/useCwdRedirectedBridge.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useCwdRedirectedBridge } from '../../src/app-effects/useCwdRedirectedBridge';
+
+describe('useCwdRedirectedBridge', () => {
+  let onCwdRedirected: ReturnType<typeof vi.fn>;
+  let unsubscribe: ReturnType<typeof vi.fn>;
+  let cb: ((e: { sid: string; newCwd: string }) => void) | null = null;
+
+  beforeEach(() => {
+    unsubscribe = vi.fn();
+    onCwdRedirected = vi.fn((c: typeof cb) => {
+      cb = c;
+      return unsubscribe;
+    });
+    (window as unknown as { ccsmSession: unknown }).ccsmSession = { onCwdRedirected };
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { ccsmSession?: unknown }).ccsmSession;
+    cb = null;
+  });
+
+  it('subscribes on mount and unsubscribes on unmount', () => {
+    const apply = vi.fn();
+    const { unmount } = renderHook(() => useCwdRedirectedBridge(apply));
+    expect(onCwdRedirected).toHaveBeenCalledTimes(1);
+    unmount();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards valid events to applyCwdRedirect', () => {
+    const apply = vi.fn();
+    renderHook(() => useCwdRedirectedBridge(apply));
+    cb!({ sid: 'abc', newCwd: '/new/path' });
+    expect(apply).toHaveBeenCalledWith('abc', '/new/path');
+  });
+
+  it('ignores empty / malformed events', () => {
+    const apply = vi.fn();
+    renderHook(() => useCwdRedirectedBridge(apply));
+    cb!({ sid: '', newCwd: '/x' });
+    cb!({ sid: 'a', newCwd: '' });
+    cb!(undefined as unknown as { sid: string; newCwd: string });
+    expect(apply).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the bridge is missing', () => {
+    delete (window as unknown as { ccsmSession?: unknown }).ccsmSession;
+    expect(() => renderHook(() => useCwdRedirectedBridge(vi.fn()))).not.toThrow();
+  });
+});

--- a/tests/app-effects/useExitAnimation.test.tsx
+++ b/tests/app-effects/useExitAnimation.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useExitAnimation } from '../../src/app-effects/useExitAnimation';
+
+describe('useExitAnimation', () => {
+  let onBeforeHide: ReturnType<typeof vi.fn>;
+  let onAfterShow: ReturnType<typeof vi.fn>;
+  let offHide: ReturnType<typeof vi.fn>;
+  let offShow: ReturnType<typeof vi.fn>;
+  let hideCb: (() => void) | null = null;
+  let showCb: (() => void) | null = null;
+
+  beforeEach(() => {
+    offHide = vi.fn();
+    offShow = vi.fn();
+    onBeforeHide = vi.fn((cb: () => void) => {
+      hideCb = cb;
+      return offHide;
+    });
+    onAfterShow = vi.fn((cb: () => void) => {
+      showCb = cb;
+      return offShow;
+    });
+    (window as unknown as { ccsm: unknown }).ccsm = {
+      window: { onBeforeHide, onAfterShow },
+    };
+    document.documentElement.style.opacity = '';
+    document.documentElement.style.transition = '';
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { ccsm?: unknown }).ccsm;
+    hideCb = null;
+    showCb = null;
+    document.documentElement.style.opacity = '';
+    document.documentElement.style.transition = '';
+  });
+
+  it('subscribes on mount and unsubscribes on unmount', () => {
+    const { unmount } = renderHook(() => useExitAnimation());
+    expect(onBeforeHide).toHaveBeenCalledTimes(1);
+    expect(onAfterShow).toHaveBeenCalledTimes(1);
+    unmount();
+    expect(offHide).toHaveBeenCalledTimes(1);
+    expect(offShow).toHaveBeenCalledTimes(1);
+  });
+
+  it('fades opacity to 0 on beforeHide and back to 1 on afterShow', () => {
+    renderHook(() => useExitAnimation());
+    hideCb!();
+    expect(document.documentElement.style.opacity).toBe('0');
+    showCb!();
+    expect(document.documentElement.style.opacity).toBe('1');
+  });
+
+  it('clears inline opacity + transition on unmount', () => {
+    const { unmount } = renderHook(() => useExitAnimation());
+    hideCb!();
+    expect(document.documentElement.style.opacity).toBe('0');
+    unmount();
+    expect(document.documentElement.style.opacity).toBe('');
+    expect(document.documentElement.style.transition).toBe('');
+  });
+
+  it('is a no-op when the bridge is missing', () => {
+    delete (window as unknown as { ccsm?: unknown }).ccsm;
+    expect(() => renderHook(() => useExitAnimation())).not.toThrow();
+  });
+});

--- a/tests/app-effects/useHydrateSystemLocale.test.tsx
+++ b/tests/app-effects/useHydrateSystemLocale.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useHydrateSystemLocale } from '../../src/app-effects/useHydrateSystemLocale';
+
+describe('useHydrateSystemLocale', () => {
+  afterEach(() => {
+    delete (window as unknown as { ccsm?: unknown }).ccsm;
+  });
+
+  it('hydrates with the locale returned by main', async () => {
+    const getSystemLocale = vi.fn().mockResolvedValue('zh-CN');
+    (window as unknown as { ccsm: unknown }).ccsm = { i18n: { getSystemLocale } };
+    const hydrate = vi.fn();
+    renderHook(() => useHydrateSystemLocale(hydrate));
+    await waitFor(() => expect(hydrate).toHaveBeenCalledWith('zh-CN'));
+  });
+
+  it('falls back to navigator.language when bridge throws', async () => {
+    const getSystemLocale = vi.fn().mockRejectedValue(new Error('no'));
+    (window as unknown as { ccsm: unknown }).ccsm = { i18n: { getSystemLocale } };
+    const hydrate = vi.fn();
+    renderHook(() => useHydrateSystemLocale(hydrate));
+    await waitFor(() => expect(hydrate).toHaveBeenCalled());
+    const arg = hydrate.mock.calls[0][0];
+    expect(arg === navigator.language || arg === undefined).toBe(true);
+  });
+
+  it('does not call hydrate after unmount (cancellation)', async () => {
+    let resolve!: (v: string) => void;
+    const getSystemLocale = vi.fn().mockReturnValue(new Promise<string>((r) => { resolve = r; }));
+    (window as unknown as { ccsm: unknown }).ccsm = { i18n: { getSystemLocale } };
+    const hydrate = vi.fn();
+    const { unmount } = renderHook(() => useHydrateSystemLocale(hydrate));
+    unmount();
+    resolve('en');
+    // Give the microtask queue a beat to flush.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(hydrate).not.toHaveBeenCalled();
+  });
+});

--- a/tests/app-effects/useNotifyFlashBridge.test.tsx
+++ b/tests/app-effects/useNotifyFlashBridge.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useNotifyFlashBridge } from '../../src/app-effects/useNotifyFlashBridge';
+import { useStore } from '../../src/stores/store';
+
+describe('useNotifyFlashBridge', () => {
+  let onFlash: ReturnType<typeof vi.fn>;
+  let unsubscribe: ReturnType<typeof vi.fn>;
+  let flashCb: ((e: { sid: string; on: boolean }) => void) | null = null;
+  let setFlashSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    unsubscribe = vi.fn();
+    onFlash = vi.fn((cb: typeof flashCb) => {
+      flashCb = cb;
+      return unsubscribe;
+    });
+    (window as unknown as { ccsmNotify: unknown }).ccsmNotify = { onFlash };
+    setFlashSpy = vi.spyOn(useStore.getState(), '_setFlash');
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { ccsmNotify?: unknown }).ccsmNotify;
+    flashCb = null;
+    setFlashSpy.mockRestore();
+  });
+
+  it('subscribes on mount and unsubscribes on unmount', () => {
+    const { unmount } = renderHook(() => useNotifyFlashBridge());
+    expect(onFlash).toHaveBeenCalledTimes(1);
+    unmount();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards valid flash events to the store _setFlash action', () => {
+    renderHook(() => useNotifyFlashBridge());
+    flashCb!({ sid: 's1', on: true });
+    expect(setFlashSpy).toHaveBeenCalledWith('s1', true);
+    flashCb!({ sid: 's1', on: false });
+    expect(setFlashSpy).toHaveBeenCalledWith('s1', false);
+  });
+
+  it('ignores malformed events', () => {
+    renderHook(() => useNotifyFlashBridge());
+    flashCb!({ sid: '', on: true });
+    flashCb!(undefined as unknown as { sid: string; on: boolean });
+    expect(setFlashSpy).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the bridge is missing', () => {
+    delete (window as unknown as { ccsmNotify?: unknown }).ccsmNotify;
+    expect(() => renderHook(() => useNotifyFlashBridge())).not.toThrow();
+  });
+});

--- a/tests/app-effects/usePtyExitBridge.test.tsx
+++ b/tests/app-effects/usePtyExitBridge.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { usePtyExitBridge } from '../../src/app-effects/usePtyExitBridge';
+
+describe('usePtyExitBridge', () => {
+  let onExit: ReturnType<typeof vi.fn>;
+  let unsubscribe: ReturnType<typeof vi.fn>;
+  let exitCb: ((e: { sessionId: string; code?: number | null; signal?: string | number | null }) => void) | null = null;
+
+  beforeEach(() => {
+    unsubscribe = vi.fn();
+    onExit = vi.fn((cb: typeof exitCb) => {
+      exitCb = cb;
+      return unsubscribe;
+    });
+    (window as unknown as { ccsmPty: unknown }).ccsmPty = { onExit };
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { ccsmPty?: unknown }).ccsmPty;
+    exitCb = null;
+  });
+
+  it('subscribes on mount and unsubscribes on unmount', () => {
+    const apply = vi.fn();
+    const { unmount } = renderHook(() => usePtyExitBridge(apply));
+    expect(onExit).toHaveBeenCalledTimes(1);
+    unmount();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards valid exit events to applyPtyExit with normalized payload', () => {
+    const apply = vi.fn();
+    renderHook(() => usePtyExitBridge(apply));
+    exitCb!({ sessionId: 's1', code: 137, signal: 'SIGTERM' });
+    expect(apply).toHaveBeenCalledWith('s1', { code: 137, signal: 'SIGTERM' });
+    exitCb!({ sessionId: 's2' });
+    expect(apply).toHaveBeenCalledWith('s2', { code: null, signal: null });
+  });
+
+  it('ignores malformed events', () => {
+    const apply = vi.fn();
+    renderHook(() => usePtyExitBridge(apply));
+    exitCb!({ sessionId: '' });
+    exitCb!(undefined as unknown as { sessionId: string });
+    expect(apply).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the bridge is missing', () => {
+    delete (window as unknown as { ccsmPty?: unknown }).ccsmPty;
+    expect(() => renderHook(() => usePtyExitBridge(vi.fn()))).not.toThrow();
+  });
+});

--- a/tests/app-effects/useSessionActiveBridge.test.tsx
+++ b/tests/app-effects/useSessionActiveBridge.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useSessionActiveBridge } from '../../src/app-effects/useSessionActiveBridge';
+
+describe('useSessionActiveBridge', () => {
+  let setActive: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    setActive = vi.fn();
+    (window as unknown as { ccsmSession: unknown }).ccsmSession = { setActive };
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { ccsmSession?: unknown }).ccsmSession;
+  });
+
+  it('forwards a non-empty activeId on mount', () => {
+    renderHook(() => useSessionActiveBridge('abc'));
+    expect(setActive).toHaveBeenCalledWith('abc');
+  });
+
+  it('coerces empty / undefined / null to null', () => {
+    renderHook(() => useSessionActiveBridge(''));
+    expect(setActive).toHaveBeenLastCalledWith(null);
+    setActive.mockClear();
+    renderHook(() => useSessionActiveBridge(undefined));
+    expect(setActive).toHaveBeenLastCalledWith(null);
+    setActive.mockClear();
+    renderHook(() => useSessionActiveBridge(null));
+    expect(setActive).toHaveBeenLastCalledWith(null);
+  });
+
+  it('re-fires when activeId changes', () => {
+    const { rerender } = renderHook(({ id }: { id: string }) => useSessionActiveBridge(id), {
+      initialProps: { id: 'a' },
+    });
+    rerender({ id: 'b' });
+    expect(setActive).toHaveBeenNthCalledWith(1, 'a');
+    expect(setActive).toHaveBeenNthCalledWith(2, 'b');
+  });
+
+  it('is a no-op when the bridge is missing', () => {
+    delete (window as unknown as { ccsmSession?: unknown }).ccsmSession;
+    expect(() => renderHook(() => useSessionActiveBridge('x'))).not.toThrow();
+  });
+});

--- a/tests/app-effects/useSessionNameBridge.test.tsx
+++ b/tests/app-effects/useSessionNameBridge.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useSessionNameBridge } from '../../src/app-effects/useSessionNameBridge';
+
+describe('useSessionNameBridge', () => {
+  let setName: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    setName = vi.fn();
+    (window as unknown as { ccsmSession: unknown }).ccsmSession = { setName };
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { ccsmSession?: unknown }).ccsmSession;
+  });
+
+  it('emits setName for each session on mount', () => {
+    renderHook(() =>
+      useSessionNameBridge([
+        { id: 's1', name: 'Alpha' },
+        { id: 's2', name: null },
+      ])
+    );
+    expect(setName).toHaveBeenCalledWith('s1', 'Alpha');
+    expect(setName).toHaveBeenCalledWith('s2', null);
+  });
+
+  it('emits null clear for sids that disappear between renders', () => {
+    const { rerender } = renderHook(
+      ({ list }: { list: Array<{ id: string; name?: string | null }> }) =>
+        useSessionNameBridge(list),
+      {
+        initialProps: {
+          list: [
+            { id: 's1', name: 'Alpha' },
+            { id: 's2', name: 'Beta' },
+          ],
+        },
+      }
+    );
+    setName.mockClear();
+    rerender({ list: [{ id: 's1', name: 'Alpha' }] });
+    // s1 re-emitted, s2 cleared.
+    expect(setName).toHaveBeenCalledWith('s1', 'Alpha');
+    expect(setName).toHaveBeenCalledWith('s2', null);
+  });
+
+  it('is a no-op when the bridge is missing', () => {
+    delete (window as unknown as { ccsmSession?: unknown }).ccsmSession;
+    expect(() =>
+      renderHook(() => useSessionNameBridge([{ id: 's1', name: 'X' }]))
+    ).not.toThrow();
+  });
+});

--- a/tests/app-effects/useSessionTitleBridge.test.tsx
+++ b/tests/app-effects/useSessionTitleBridge.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useSessionTitleBridge } from '../../src/app-effects/useSessionTitleBridge';
+
+describe('useSessionTitleBridge', () => {
+  let onTitle: ReturnType<typeof vi.fn>;
+  let unsubscribe: ReturnType<typeof vi.fn>;
+  let titleCb: ((e: { sid: string; title: string }) => void) | null = null;
+
+  beforeEach(() => {
+    unsubscribe = vi.fn();
+    onTitle = vi.fn((cb: typeof titleCb) => {
+      titleCb = cb;
+      return unsubscribe;
+    });
+    (window as unknown as { ccsmSession: unknown }).ccsmSession = { onTitle };
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { ccsmSession?: unknown }).ccsmSession;
+    titleCb = null;
+  });
+
+  it('subscribes on mount and unsubscribes on unmount', () => {
+    const apply = vi.fn();
+    const { unmount } = renderHook(() => useSessionTitleBridge(apply));
+    expect(onTitle).toHaveBeenCalledTimes(1);
+    unmount();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards valid title events to applyExternalTitle', () => {
+    const apply = vi.fn();
+    renderHook(() => useSessionTitleBridge(apply));
+    titleCb!({ sid: 'abc', title: 'My session' });
+    expect(apply).toHaveBeenCalledWith('abc', 'My session');
+  });
+
+  it('ignores empty / malformed events', () => {
+    const apply = vi.fn();
+    renderHook(() => useSessionTitleBridge(apply));
+    titleCb!({ sid: '', title: 't' });
+    titleCb!({ sid: 'abc', title: '' });
+    titleCb!(undefined as unknown as { sid: string; title: string });
+    expect(apply).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the bridge is missing', () => {
+    delete (window as unknown as { ccsmSession?: unknown }).ccsmSession;
+    expect(() => renderHook(() => useSessionTitleBridge(vi.fn()))).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- Extracts 8 more inline IPC-bridge \`useEffect\`s from \`src/App.tsx\` into dedicated hooks under \`src/app-effects/\`, continuing the SRP cleanup begun in PR #559 (Task #732 Phase B). Selection of the 8 follows the explicit suggestion in the PR #755 review.
- App.tsx: **573 -> 438 LoC**. The 3 remaining inline effects are intentional per #755 review (font-size CSS var, \`__ccsmFlashStates\` test seam, \`claudeAvailable\` boot probe) — each couples to local React state too tightly to be worth a hook indirection.
- Each new hook ships with a focused per-hook test (subscribe / forward / ignore-malformed / no-op-when-bridge-missing) and \`tests/App.hooks.test.tsx\` is extended with composition-root assertions that all 8 new hooks are wired during render with the right argument shapes.

## New hooks (8)
- \`useSessionActiveBridge\` — \`ccsmSession.setActive\` mirror of activeId
- \`useSessionNameBridge\` — \`ccsmSession.setName\` diff over \`sessions[]\` (incl. clears for disappeared sids per #613)
- \`usePtyExitBridge\` — \`ccsmPty.onExit\` -> \`_applyPtyExit\`
- \`useSessionTitleBridge\` — \`ccsmSession.onTitle\` -> \`_applyExternalTitle\`
- \`useNotifyFlashBridge\` — \`ccsmNotify.onFlash\` -> \`_setFlash\` (zero-arg, reaches into \`useStore.getState()\` to preserve original mount-once semantics)
- \`useCwdRedirectedBridge\` — \`ccsmSession.onCwdRedirected\` -> \`_applyCwdRedirect\`
- \`useHydrateSystemLocale\` — async \`ccsm.i18n.getSystemLocale()\` boot fetch with cancellation
- \`useExitAnimation\` — \`window:beforeHide\` / \`window:afterShow\` <html> opacity fade (UI-10 / #213)

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` clean (3 pre-existing webpack size warnings)
- [x] vitest: 756/759 (3 pre-existing db-hardening fails — NODE_MODULE_VERSION mismatch in worktree env, unrelated to this PR)
- [x] All 18 hook test files PASS (70/70 tests), including 8 new per-hook tests + 5 new composition-root assertions
- [x] Reverse-verify on \`useExitAnimation\`: intentionally setting \`opacity = '0.5'\` instead of \`'0'\` causes 2 tests to FAIL; restore -> all PASS
- [x] e2e \`new-session-chat\` PASS (21.9s)
- [x] e2e \`switch-session-keeps-chat\` PASS (32.0s)