### PR TITLE
refactor(ptyHost): trim index.ts to lifecycle-only (Task #738 Phase B)

### DIFF
--- a/electron/ptyHost/__tests__/entryFactory.test.ts
+++ b/electron/ptyHost/__tests__/entryFactory.test.ts
@@ -1,0 +1,192 @@
+// Pins entryFactory.makeEntry's wiring contract (Task #738 Phase B):
+//   - Picks `--resume` when JSONL exists, `--session-id` when it doesn't.
+//   - Resolves the spawn cwd through `resolveSpawnCwd` BEFORE spawning.
+//   - Calls `onCwdRedirect(spawnCwd)` only when the import-resume helper
+//     actually copied the JSONL (#603 Layer-1 fix).
+//   - Wires pty.onExit to dispose the headless mirror, fan out `pty:exit`
+//     to attached webContents, AND invoke `deps.onExit(sid)` so the caller
+//     can drop the entry from its registry.
+//
+// All heavy native deps (node-pty, headless terminal, electron, sessionWatcher)
+// are stubbed so the factory loads in jsdom without binaries. vi.mock factories
+// are hoisted, so per-test state lives on globalThis (`__pf`) and the mocks
+// read it lazily.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+interface PtyFakeBus {
+  onData: ((chunk: string) => void) | null;
+  onExit: ((evt: { exitCode: number | null; signal: number | null }) => void) | null;
+  ptySpawn: ReturnType<typeof vi.fn>;
+  headlessDispose: ReturnType<typeof vi.fn>;
+  headlessWrite: ReturnType<typeof vi.fn>;
+  watcherStart: ReturnType<typeof vi.fn>;
+  watcherStop: ReturnType<typeof vi.fn>;
+  ensureJsonl: ReturnType<typeof vi.fn>;
+  emitData: ReturnType<typeof vi.fn>;
+  sourceJsonl: string | null;
+  ensureCopied: boolean;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function bus(): PtyFakeBus { return (globalThis as any).__pf as PtyFakeBus; }
+
+vi.mock('node-pty', () => ({
+  spawn: (...a: unknown[]) => {
+    const b = bus();
+    b.ptySpawn(...a);
+    return {
+      pid: 4242,
+      onData: (cb: (chunk: string) => void) => { b.onData = cb; },
+      onExit: (cb: (evt: { exitCode: number | null; signal: number | null }) => void) => {
+        b.onExit = cb;
+      },
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+    };
+  },
+}));
+
+vi.mock('@xterm/headless', () => ({
+  Terminal: class {
+    write = (...a: unknown[]) => bus().headlessWrite(...a);
+    dispose = () => bus().headlessDispose();
+    loadAddon = vi.fn();
+    resize = vi.fn();
+  },
+}));
+
+vi.mock('@xterm/addon-serialize', () => ({
+  SerializeAddon: class {
+    serialize = () => 'snap';
+  },
+}));
+
+vi.mock('electron', () => ({}));
+
+vi.mock('../../sessionWatcher', () => ({
+  sessionWatcher: {
+    on: vi.fn(),
+    startWatching: (...a: unknown[]) => bus().watcherStart(...a),
+    stopWatching: (...a: unknown[]) => bus().watcherStop(...a),
+  },
+}));
+
+vi.mock('../jsonlResolver', () => ({
+  toClaudeSid: (s: string) => s,
+  findJsonlForSid: () => bus().sourceJsonl,
+  resolveJsonlPath: () => '/tmp/live.jsonl',
+  ensureResumeJsonlAtSpawnCwd: (...a: unknown[]) => {
+    bus().ensureJsonl(...a);
+    return { copied: bus().ensureCopied, targetPath: '/tmp/target.jsonl' };
+  },
+}));
+
+vi.mock('../cwdResolver', () => ({
+  resolveSpawnCwd: (cwd: string) => (cwd ? cwd : '/home/u'),
+}));
+
+vi.mock('../dataFanout', () => ({
+  emitPtyData: (sid: string, chunk: string) => bus().emitData(sid, chunk),
+}));
+
+import { makeEntry } from '../entryFactory';
+
+describe('entryFactory.makeEntry', () => {
+  beforeEach(() => {
+    const b: PtyFakeBus = {
+      onData: null,
+      onExit: null,
+      ptySpawn: vi.fn(),
+      headlessDispose: vi.fn(),
+      headlessWrite: vi.fn(),
+      watcherStart: vi.fn(),
+      watcherStop: vi.fn(),
+      ensureJsonl: vi.fn(),
+      emitData: vi.fn(),
+      sourceJsonl: null,
+      ensureCopied: false,
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).__pf = b;
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (globalThis as any).__pf;
+  });
+
+  it('uses --session-id when no JSONL exists for the sid', () => {
+    bus().sourceJsonl = null;
+    makeEntry('sid-A', '/work', '/bin/claude', 100, 30, { onExit: vi.fn() });
+    const b = bus();
+    expect(b.ptySpawn).toHaveBeenCalledTimes(1);
+    const args = b.ptySpawn.mock.calls[0];
+    expect(args[0]).toBe('/bin/claude');
+    expect(args[1]).toEqual(['--session-id', 'sid-A']);
+    // ensureResumeJsonlAtSpawnCwd is gated on sourceJsonl being truthy.
+    expect(b.ensureJsonl).not.toHaveBeenCalled();
+  });
+
+  it('uses --resume when JSONL exists, and skips onCwdRedirect when no copy happened', () => {
+    bus().sourceJsonl = '/old/proj/sid-B.jsonl';
+    bus().ensureCopied = false;
+    const onCwdRedirect = vi.fn();
+    makeEntry('sid-B', '/work', '/bin/claude', 80, 24, { onExit: vi.fn(), onCwdRedirect });
+    expect(bus().ptySpawn.mock.calls[0][1]).toEqual(['--resume', 'sid-B']);
+    expect(bus().ensureJsonl).toHaveBeenCalledTimes(1);
+    expect(onCwdRedirect).not.toHaveBeenCalled();
+  });
+
+  it('fires onCwdRedirect(spawnCwd) when the import-resume helper copied', () => {
+    bus().sourceJsonl = '/old/proj/sid-C.jsonl';
+    bus().ensureCopied = true;
+    const onCwdRedirect = vi.fn();
+    makeEntry('sid-C', '/work', '/bin/claude', 80, 24, { onExit: vi.fn(), onCwdRedirect });
+    expect(onCwdRedirect).toHaveBeenCalledTimes(1);
+    expect(onCwdRedirect).toHaveBeenCalledWith('/work');
+  });
+
+  it('falls back to homedir-style spawnCwd when cwd is empty (resolveSpawnCwd contract)', () => {
+    makeEntry('sid-D', '', '/bin/claude', 80, 24, { onExit: vi.fn() });
+    const opts = bus().ptySpawn.mock.calls[0][2] as { cwd: string };
+    expect(opts.cwd).toBe('/home/u');
+  });
+
+  it('starts the JSONL tail-watcher with the spawn cwd', () => {
+    makeEntry('sid-E', '/work', '/bin/claude', 80, 24, { onExit: vi.fn() });
+    expect(bus().watcherStart).toHaveBeenCalledWith('sid-E', '/tmp/live.jsonl', '/work');
+  });
+
+  it('on pty exit: disposes headless, fires deps.onExit(sid), and stops the watcher', () => {
+    const onExit = vi.fn();
+    makeEntry('sid-F', '/work', '/bin/claude', 80, 24, { onExit });
+    const b = bus();
+    expect(b.onExit).toBeTypeOf('function');
+    b.onExit!({ exitCode: 0, signal: null });
+    expect(b.headlessDispose).toHaveBeenCalledTimes(1);
+    expect(onExit).toHaveBeenCalledWith('sid-F');
+    expect(b.watcherStop).toHaveBeenCalledWith('sid-F');
+  });
+
+  it('forwards pty data into headless write AND emitPtyData fanout', () => {
+    makeEntry('sid-G', '/work', '/bin/claude', 80, 24, { onExit: vi.fn() });
+    const b = bus();
+    expect(b.onData).toBeTypeOf('function');
+    b.onData!('hello');
+    expect(b.headlessWrite).toHaveBeenCalledWith('hello');
+    expect(b.emitData).toHaveBeenCalledWith('sid-G', 'hello');
+  });
+
+  it('returns an Entry exposing the pid/cols/rows/cwd captured at spawn', () => {
+    const e = makeEntry('sid-H', '/work', '/bin/claude', 100, 40, { onExit: vi.fn() });
+    expect(e.pty.pid).toBe(4242);
+    expect(e.cols).toBe(100);
+    expect(e.rows).toBe(40);
+    expect(e.cwd).toBe('/work');
+    expect(e.attached.size).toBe(0);
+  });
+});

--- a/electron/ptyHost/entryFactory.ts
+++ b/electron/ptyHost/entryFactory.ts
@@ -1,0 +1,190 @@
+// Per-session Entry construction.
+//
+// Extracted from electron/ptyHost/index.ts (Task #738 Phase B). The factory
+// owns the wiring of one PTY: it picks --resume vs --session-id, ensures the
+// import-resume JSONL is co-located with the spawn cwd's projectDir,
+// constructs the headless mirror, attaches the data/exit pumps, and starts
+// the JSONL tail-watcher.
+//
+// Side effects (sessions-map mutation, broadcast IPC) are NOT performed here;
+// the caller passes:
+//   - `onExit(sid)` — invoked AFTER the headless is disposed and per-attached
+//     `pty:exit` broadcast has fanned out, so the caller can drop the entry
+//     from its registry.
+//   - `onCwdRedirect(newCwd)` — bubbled up to the renderer when the import
+//     resume helper actually copied the JSONL into a new projectDir (#603).
+//
+// Keeping the factory I/O-typed via callbacks (rather than reaching back into
+// index.ts) makes it unit-testable without an Electron runtime.
+//
+// SRP: single responsibility = "build one Entry"; lifecycle ops over the
+// registry live in lifecycle.ts.
+
+import * as pty from 'node-pty';
+import { Terminal as HeadlessTerminal } from '@xterm/headless';
+import { SerializeAddon } from '@xterm/addon-serialize';
+import type { WebContents } from 'electron';
+import { sessionWatcher } from '../sessionWatcher';
+import {
+  ensureResumeJsonlAtSpawnCwd,
+  findJsonlForSid,
+  resolveJsonlPath,
+  toClaudeSid,
+} from './jsonlResolver';
+import { resolveSpawnCwd } from './cwdResolver';
+import { emitPtyData } from './dataFanout';
+
+export const DEFAULT_COLS = 120;
+export const DEFAULT_ROWS = 30;
+export const SCROLLBACK = 5000;
+
+export interface Entry {
+  pty: pty.IPty;
+  headless: HeadlessTerminal;
+  serialize: SerializeAddon;
+  // Multiple webContents may attach (e.g. devtools/preview windows); broadcast
+  // pty:data to all of them. Keyed by webContents id so detach cleanup is O(1)
+  // and we don't pin destroyed senders.
+  attached: Map<number, WebContents>;
+  cols: number;
+  rows: number;
+  /** Resolved spawn cwd (after `resolveSpawnCwd` fallback). Captured here
+   *  so `listPtySessions` / `getPtySession` can return it without re-deriving. */
+  cwd: string;
+}
+
+export interface MakeEntryDeps {
+  /** Called after the pty exits, the headless mirror is disposed and the
+   *  pty:exit IPC has fanned out. Caller drops the entry from its map here. */
+  onExit: (sid: string) => void;
+  /** Forwarded to `ensureResumeJsonlAtSpawnCwd` — fired only when the helper
+   *  actually copied the JSONL into a new projectDir (#603). */
+  onCwdRedirect?: (newCwd: string) => void;
+}
+
+export function makeEntry(
+  sid: string,
+  cwd: string,
+  claudePath: string,
+  cols: number,
+  rows: number,
+  deps: MakeEntryDeps,
+): Entry {
+  const claudeSid = toClaudeSid(sid);
+  const sourceJsonl = findJsonlForSid(claudeSid);
+  const flag = sourceJsonl ? '--resume' : '--session-id';
+  const args = [flag, claudeSid];
+
+  const spawnCwd = resolveSpawnCwd(cwd);
+
+  // See `ensureResumeJsonlAtSpawnCwd` for the bug context (#603) — copies
+  // the import-source JSONL into the spawn cwd's projectDir so
+  // `claude --resume <sid>` can find it. No-op when source already lives
+  // under the right projectKey (the common case for sessions originally
+  // run from a still-existing cwd).
+  //
+  // When a copy actually happens, the live JSONL the CLI now appends to
+  // lives under `projectKey(spawnCwd)`, NOT under `projectKey(session.cwd)`.
+  // The renderer's sessionTitles bridge passes `session.cwd` to the SDK
+  // (`renameSession` / `getSessionInfo` / `listForProject`), so without a
+  // redirect the bridge would keep reading/writing the now-frozen SOURCE
+  // file (#603 reviewer Layer-1 finding). Notify the caller so it can
+  // patch `session.cwd` to `spawnCwd` in the renderer store.
+  if (sourceJsonl) {
+    const result = ensureResumeJsonlAtSpawnCwd(claudeSid, spawnCwd, sourceJsonl);
+    if (result.copied && deps.onCwdRedirect) {
+      try {
+        deps.onCwdRedirect(spawnCwd);
+      } catch (err) {
+        console.warn(
+          `[ptyHost] cwd-redirect notify for ${sid} threw: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+  }
+
+  const p = pty.spawn(claudePath, args, {
+    name: 'xterm-256color',
+    cols,
+    rows,
+    cwd: spawnCwd,
+    env: process.env as { [key: string]: string },
+  });
+
+  const headless = new HeadlessTerminal({
+    cols,
+    rows,
+    scrollback: SCROLLBACK,
+    allowProposedApi: true,
+  });
+  const serialize = new SerializeAddon();
+  headless.loadAddon(serialize);
+
+  const entry: Entry = {
+    pty: p,
+    headless,
+    serialize,
+    attached: new Map(),
+    cols,
+    rows,
+    cwd: spawnCwd,
+  };
+
+  p.onData((chunk) => {
+    headless.write(chunk);
+    for (const wc of entry.attached.values()) {
+      if (!wc.isDestroyed()) {
+        try {
+          wc.send('pty:data', { sid, chunk });
+        } catch {
+          /* renderer gone — best effort */
+        }
+      }
+    }
+    // Fan out to module-level data listeners (notify pipeline OSC sniffer
+    // is the only production consumer today). Listeners are best-effort —
+    // throws don't propagate back to ptyHost so a misbehaving sink can't
+    // wedge the PTY.
+    emitPtyData(sid, chunk);
+  });
+
+  p.onExit(({ exitCode, signal }) => {
+    // Broadcast exit to anyone still listening, then drop the entry. Using
+    // `sessionId` in the payload (not just `sid`) matches the renderer-side
+    // ttyd-exit shape so the existing exit handler can be reused.
+    for (const wc of entry.attached.values()) {
+      if (!wc.isDestroyed()) {
+        try {
+          wc.send('pty:exit', {
+            sessionId: sid,
+            code: exitCode ?? null,
+            signal: signal ?? null,
+          });
+        } catch {
+          /* renderer gone */
+        }
+      }
+    }
+    try {
+      headless.dispose();
+    } catch {
+      /* already disposed */
+    }
+    deps.onExit(sid);
+    // Stop the JSONL tail-watcher so we don't keep an fs.watch handle
+    // pinned for a dead session.
+    try { sessionWatcher.stopWatching(sid); } catch { /* never throws */ }
+  });
+
+  // Start a JSONL tail-watcher for this session. The watcher emits
+  // 'state-changed' on the singleton in electron/sessionWatcher; main.ts
+  // bridges those events to the renderer (`session:state` IPC channel).
+  try {
+    const jsonlPath = resolveJsonlPath(claudeSid, spawnCwd);
+    if (jsonlPath) sessionWatcher.startWatching(sid, jsonlPath, spawnCwd);
+  } catch {
+    /* watcher start is best-effort; PTY still owns its lifecycle */
+  }
+
+  return entry;
+}

--- a/electron/ptyHost/index.ts
+++ b/electron/ptyHost/index.ts
@@ -19,28 +19,22 @@
 // because we own the pty lifecycle directly: each `spawnPtySession` call re-
 // scans the JSONL roots before invoking pty.spawn.
 //
-// SRP layout (Task #729 Phase A): this file owns the per-session lifecycle
-// (Entry creation + spawn / attach / detach / kill). Helpers split into:
+// SRP layout (Task #729 Phase A + Task #738 Phase B):
 //   - jsonlResolver.ts  pure deciders for the CLI's transcript paths
 //   - cwdResolver.ts    pure decider for the spawn cwd fallback
 //   - processKiller.ts  single sink (taskkill / kill -SIGTERM/SIGKILL)
 //   - dataFanout.ts     module-level pty:data subscriber registry
 //   - ipcRegistrar.ts   the eight `pty:*` IPC handlers + watcher bridge
+//   - entryFactory.ts   per-session Entry construction + pty/headless wiring
+//   - lifecycle.ts      pure spawn/attach/detach/input/resize/kill ops over
+//                       a registry Map
+//
+// This file is the lifecycle-singleton: it owns the one `sessions` Map,
+// binds the lifecycle ops to it, exposes the public API, and wires IPC.
 
-import type { BrowserWindow, IpcMain, WebContents } from 'electron';
-import * as pty from 'node-pty';
-import { Terminal as HeadlessTerminal } from '@xterm/headless';
-import { SerializeAddon } from '@xterm/addon-serialize';
-import { sessionWatcher } from '../sessionWatcher';
-import {
-  ensureResumeJsonlAtSpawnCwd,
-  findJsonlForSid,
-  resolveJsonlPath,
-  toClaudeSid,
-} from './jsonlResolver';
-import { resolveSpawnCwd } from './cwdResolver';
-import { killProcessSubtree } from './processKiller';
-import { emitPtyData } from './dataFanout';
+import type { BrowserWindow, IpcMain } from 'electron';
+import type { Entry } from './entryFactory';
+import * as L from './lifecycle';
 import { registerPtyIpc } from './ipcRegistrar';
 
 // Re-export the helpers callers historically imported from `ptyHost/index`.
@@ -57,306 +51,49 @@ export {
 } from './jsonlResolver';
 export type { EnsureResumeJsonlResult } from './jsonlResolver';
 export { resolveSpawnCwd } from './cwdResolver';
+export type { PtySessionInfo, AttachResult } from './lifecycle';
 
-// --- Public types ------------------------------------------------------------
-
-export interface PtySessionInfo {
-  sid: string;
-  pid: number;
-  cols: number;
-  rows: number;
-  /** Working directory the PTY was actually spawned with (post-`resolveSpawnCwd`
-   *  fallback). Diverges from the renderer's `session.cwd` ONLY when the
-   *  requested cwd was missing/unreadable, in which case `resolveSpawnCwd`
-   *  falls back to homedir. Surfaced so e2e probes can verify that picked
-   *  cwds reach the real PTY (#628). */
-  cwd: string;
-}
-
-export interface AttachResult {
-  snapshot: string;
-  cols: number;
-  rows: number;
-  pid: number;
-}
-
-// --- Internal state ----------------------------------------------------------
-
-interface Entry {
-  pty: pty.IPty;
-  headless: HeadlessTerminal;
-  serialize: SerializeAddon;
-  // Multiple webContents may attach (e.g. devtools/preview windows); broadcast
-  // pty:data to all of them. Keyed by webContents id so detach cleanup is O(1)
-  // and we don't pin destroyed senders.
-  attached: Map<number, WebContents>;
-  cols: number;
-  rows: number;
-  /** Resolved spawn cwd (after `resolveSpawnCwd` fallback). Captured here
-   *  so `listPtySessions` / `getPtySession` can return it without re-deriving. */
-  cwd: string;
-}
+// --- Singleton registry ------------------------------------------------------
 
 const sessions = new Map<string, Entry>();
 
-const DEFAULT_COLS = 120;
-const DEFAULT_ROWS = 30;
-const SCROLLBACK = 5000;
-
-// --- Entry construction ------------------------------------------------------
-
-function makeEntry(
-  sid: string,
-  cwd: string,
-  claudePath: string,
-  cols: number,
-  rows: number,
-  onCwdRedirect?: (newCwd: string) => void,
-): Entry {
-  const claudeSid = toClaudeSid(sid);
-  const sourceJsonl = findJsonlForSid(claudeSid);
-  const flag = sourceJsonl ? '--resume' : '--session-id';
-  const args = [flag, claudeSid];
-
-  const spawnCwd = resolveSpawnCwd(cwd);
-
-  // See `ensureResumeJsonlAtSpawnCwd` for the bug context (#603) — copies
-  // the import-source JSONL into the spawn cwd's projectDir so
-  // `claude --resume <sid>` can find it. No-op when source already lives
-  // under the right projectKey (the common case for sessions originally
-  // run from a still-existing cwd).
-  //
-  // When a copy actually happens, the live JSONL the CLI now appends to
-  // lives under `projectKey(spawnCwd)`, NOT under `projectKey(session.cwd)`.
-  // The renderer's sessionTitles bridge passes `session.cwd` to the SDK
-  // (`renameSession` / `getSessionInfo` / `listForProject`), so without a
-  // redirect the bridge would keep reading/writing the now-frozen SOURCE
-  // file (#603 reviewer Layer-1 finding). Notify the caller so it can
-  // patch `session.cwd` to `spawnCwd` in the renderer store.
-  if (sourceJsonl) {
-    const result = ensureResumeJsonlAtSpawnCwd(claudeSid, spawnCwd, sourceJsonl);
-    if (result.copied && onCwdRedirect) {
-      try {
-        onCwdRedirect(spawnCwd);
-      } catch (err) {
-        console.warn(
-          `[ptyHost] cwd-redirect notify for ${sid} threw: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-    }
-  }
-
-  const p = pty.spawn(claudePath, args, {
-    name: 'xterm-256color',
-    cols,
-    rows,
-    cwd: spawnCwd,
-    env: process.env as { [key: string]: string },
-  });
-
-  const headless = new HeadlessTerminal({
-    cols,
-    rows,
-    scrollback: SCROLLBACK,
-    allowProposedApi: true,
-  });
-  const serialize = new SerializeAddon();
-  headless.loadAddon(serialize);
-
-  const entry: Entry = {
-    pty: p,
-    headless,
-    serialize,
-    attached: new Map(),
-    cols,
-    rows,
-    cwd: spawnCwd,
-  };
-
-  p.onData((chunk) => {
-    headless.write(chunk);
-    for (const wc of entry.attached.values()) {
-      if (!wc.isDestroyed()) {
-        try {
-          wc.send('pty:data', { sid, chunk });
-        } catch {
-          /* renderer gone — best effort */
-        }
-      }
-    }
-    // Fan out to module-level data listeners (notify pipeline OSC sniffer
-    // is the only production consumer today). Listeners are best-effort —
-    // throws don't propagate back to ptyHost so a misbehaving sink can't
-    // wedge the PTY.
-    emitPtyData(sid, chunk);
-  });
-
-  p.onExit(({ exitCode, signal }) => {
-    // Broadcast exit to anyone still listening, then drop the entry. Using
-    // `sessionId` in the payload (not just `sid`) matches the renderer-side
-    // ttyd-exit shape so the existing exit handler can be reused.
-    for (const wc of entry.attached.values()) {
-      if (!wc.isDestroyed()) {
-        try {
-          wc.send('pty:exit', {
-            sessionId: sid,
-            code: exitCode ?? null,
-            signal: signal ?? null,
-          });
-        } catch {
-          /* renderer gone */
-        }
-      }
-    }
-    try {
-      headless.dispose();
-    } catch {
-      /* already disposed */
-    }
-    sessions.delete(sid);
-    // Stop the JSONL tail-watcher so we don't keep an fs.watch handle
-    // pinned for a dead session.
-    try { sessionWatcher.stopWatching(sid); } catch { /* never throws */ }
-  });
-
-  // Start a JSONL tail-watcher for this session. The watcher emits
-  // 'state-changed' on the singleton in electron/sessionWatcher; main.ts
-  // bridges those events to the renderer (`session:state` IPC channel).
-  try {
-    const jsonlPath = resolveJsonlPath(claudeSid, spawnCwd);
-    if (jsonlPath) sessionWatcher.startWatching(sid, jsonlPath, spawnCwd);
-  } catch {
-    /* watcher start is best-effort; PTY still owns its lifecycle */
-  }
-
-  return entry;
-}
-
-// --- Public API --------------------------------------------------------------
+// --- Public API (lifecycle ops bound to the singleton) -----------------------
 
 export function spawnPtySession(
   sid: string,
   cwd: string,
   claudePath: string,
   opts?: { cols?: number; rows?: number; onCwdRedirect?: (newCwd: string) => void },
-): PtySessionInfo {
-  const existing = sessions.get(sid);
-  if (existing) {
-    return {
-      sid,
-      pid: existing.pty.pid,
-      cols: existing.cols,
-      rows: existing.rows,
-      cwd: existing.cwd,
-    };
-  }
-  const cols = opts?.cols ?? DEFAULT_COLS;
-  const rows = opts?.rows ?? DEFAULT_ROWS;
-  const entry = makeEntry(sid, cwd, claudePath, cols, rows, opts?.onCwdRedirect);
-  sessions.set(sid, entry);
-  return { sid, pid: entry.pty.pid, cols, rows, cwd: entry.cwd };
+): L.PtySessionInfo {
+  return L.spawn(sessions, sid, cwd, claudePath, opts);
 }
 
-export function listPtySessions(): PtySessionInfo[] {
-  return Array.from(sessions.entries()).map(([sid, e]) => ({
-    sid,
-    pid: e.pty.pid,
-    cols: e.cols,
-    rows: e.rows,
-    cwd: e.cwd,
-  }));
-}
+export const listPtySessions = (): L.PtySessionInfo[] => L.list(sessions);
 
-export function attachPtySession(sid: string): AttachResult | null {
-  const entry = sessions.get(sid);
-  if (!entry) return null;
-  // Caller registers their webContents via the IPC handler (see
-  // registerPtyHostIpc) — the bare API only returns the snapshot. Renderer
-  // tests can use this without an IPC round-trip.
-  return {
-    snapshot: entry.serialize.serialize(),
-    cols: entry.cols,
-    rows: entry.rows,
-    pid: entry.pty.pid,
-  };
-}
+export const attachPtySession = (sid: string): L.AttachResult | null =>
+  L.attach(sessions, sid);
 
-export function detachPtySession(sid: string): void {
-  // No-op at the API level — IPC handler clears the per-webContents
-  // registration. Kept on the surface so the preload bridge has a symmetric
-  // attach/detach pair.
-  void sid;
-}
+export const detachPtySession = (sid: string): void => L.detach(sessions, sid);
 
-export function inputPtySession(sid: string, data: string): void {
-  const entry = sessions.get(sid);
-  if (!entry) return;
-  try {
-    entry.pty.write(data);
-  } catch {
-    /* pty already exited — exit handler will clean up */
-  }
-}
+export const inputPtySession = (sid: string, data: string): void =>
+  L.input(sessions, sid, data);
 
-export function resizePtySession(sid: string, cols: number, rows: number): void {
-  const entry = sessions.get(sid);
-  if (!entry) return;
-  if (cols < 2 || rows < 2) return;
-  try {
-    entry.pty.resize(cols, rows);
-    entry.headless.resize(cols, rows);
-    entry.cols = cols;
-    entry.rows = rows;
-  } catch (e) {
-    console.warn(
-      `[ptyHost] resize ${sid} failed: ${e instanceof Error ? e.message : String(e)}`,
-    );
-  }
-}
+export const resizePtySession = (sid: string, cols: number, rows: number): void =>
+  L.resize(sessions, sid, cols, rows);
 
-export function killPtySession(sid: string): boolean {
-  const entry = sessions.get(sid);
-  if (!entry) return false;
-  // Capture pid BEFORE pty.kill() — the binding may zero it after kill.
-  const pid = entry.pty.pid;
-  try {
-    entry.pty.kill();
-  } catch {
-    /* already dead */
-  }
-  // ConPTY's kill only terminates the cmd.exe / OpenConsole wrapper; on Windows
-  // the claude.exe child (and its grandchildren) survive as orphans. On
-  // mac/linux the pgid may also have stragglers. Walk the tree via a
-  // platform-native call to guarantee a clean shutdown.
-  killProcessSubtree(pid);
-  // Belt-and-braces: also stop the watcher synchronously here so a
-  // pty.kill that races with onExit can't leak the fs.watch handle.
-  // sessionWatcher.stopWatching is idempotent.
-  try { sessionWatcher.stopWatching(sid); } catch { /* never throws */ }
-  return true;
-}
+export const killPtySession = (sid: string): boolean => L.kill(sessions, sid);
 
-export function getPtySession(sid: string): PtySessionInfo | null {
-  const entry = sessions.get(sid);
-  if (!entry) return null;
-  return { sid, pid: entry.pty.pid, cols: entry.cols, rows: entry.rows, cwd: entry.cwd };
-}
+export const getPtySession = (sid: string): L.PtySessionInfo | null =>
+  L.get(sessions, sid);
 
-// Kill every running pty. Call from app `before-quit` so renderer-side
-// claude processes don't leak past Electron exit.
-export function killAllPtySessions(): void {
-  for (const sid of [...sessions.keys()]) {
-    killPtySession(sid);
-  }
-}
+export const killAllPtySessions = (): void => L.killAll(sessions);
 
 // --- IPC registration --------------------------------------------------------
 
 // Register all `pty:*` IPC handlers. Thin wrapper around `registerPtyIpc`
 // in ipcRegistrar.ts that wires the registrar's deps to this module's
 // lifecycle functions. Kept on this surface so main.ts wires up via a
-// single call (`registerPtyHostIpc(ipcMain, getMainWindow)`) — moving it
-// would touch main.ts which is out of scope for Task #729 Phase A.
+// single call (`registerPtyHostIpc(ipcMain, getMainWindow)`).
 export function registerPtyHostIpc(
   ipcMain: IpcMain,
   getMainWindow: () => BrowserWindow | null,

--- a/electron/ptyHost/lifecycle.ts
+++ b/electron/ptyHost/lifecycle.ts
@@ -1,0 +1,152 @@
+// Lifecycle ops over the per-session Entry registry.
+//
+// Extracted from electron/ptyHost/index.ts (Task #738 Phase B). Each function
+// takes the `sessions` Map as its first argument and otherwise has no module
+// state — index.ts owns the singleton map and binds these into the public
+// API. Keeping them pure-of-module-state makes the lifecycle layer
+// independently testable and lets a future ptyHost replacement (e.g. a
+// multi-process pool) swap registries without rewriting the operations.
+//
+// The `spawn` op delegates Entry construction to entryFactory.makeEntry; the
+// rest are direct map / pty.* operations. Process-tree cleanup on `kill`
+// goes through processKiller (Phase A helper).
+
+import { sessionWatcher } from '../sessionWatcher';
+import { killProcessSubtree } from './processKiller';
+import { DEFAULT_COLS, DEFAULT_ROWS, makeEntry } from './entryFactory';
+import type { Entry } from './entryFactory';
+
+export interface PtySessionInfo {
+  sid: string;
+  pid: number;
+  cols: number;
+  rows: number;
+  /** Working directory the PTY was actually spawned with (post-`resolveSpawnCwd`
+   *  fallback). Diverges from the renderer's `session.cwd` ONLY when the
+   *  requested cwd was missing/unreadable, in which case `resolveSpawnCwd`
+   *  falls back to homedir. Surfaced so e2e probes can verify that picked
+   *  cwds reach the real PTY (#628). */
+  cwd: string;
+}
+
+export interface AttachResult {
+  snapshot: string;
+  cols: number;
+  rows: number;
+  pid: number;
+}
+
+function infoFromEntry(sid: string, e: Entry): PtySessionInfo {
+  return { sid, pid: e.pty.pid, cols: e.cols, rows: e.rows, cwd: e.cwd };
+}
+
+export function spawn(
+  sessions: Map<string, Entry>,
+  sid: string,
+  cwd: string,
+  claudePath: string,
+  opts?: { cols?: number; rows?: number; onCwdRedirect?: (newCwd: string) => void },
+): PtySessionInfo {
+  const existing = sessions.get(sid);
+  if (existing) return infoFromEntry(sid, existing);
+  const cols = opts?.cols ?? DEFAULT_COLS;
+  const rows = opts?.rows ?? DEFAULT_ROWS;
+  const entry = makeEntry(sid, cwd, claudePath, cols, rows, {
+    onExit: (s) => { sessions.delete(s); },
+    onCwdRedirect: opts?.onCwdRedirect,
+  });
+  sessions.set(sid, entry);
+  return infoFromEntry(sid, entry);
+}
+
+export function list(sessions: Map<string, Entry>): PtySessionInfo[] {
+  return Array.from(sessions.entries()).map(([sid, e]) => infoFromEntry(sid, e));
+}
+
+export function attach(sessions: Map<string, Entry>, sid: string): AttachResult | null {
+  const entry = sessions.get(sid);
+  if (!entry) return null;
+  // Caller registers their webContents via the IPC handler (see
+  // registerPtyHostIpc) — the bare API only returns the snapshot. Renderer
+  // tests can use this without an IPC round-trip.
+  return {
+    snapshot: entry.serialize.serialize(),
+    cols: entry.cols,
+    rows: entry.rows,
+    pid: entry.pty.pid,
+  };
+}
+
+export function detach(_sessions: Map<string, Entry>, sid: string): void {
+  // No-op at the API level — IPC handler clears the per-webContents
+  // registration. Kept on the surface so the preload bridge has a symmetric
+  // attach/detach pair.
+  void sid;
+}
+
+export function input(sessions: Map<string, Entry>, sid: string, data: string): void {
+  const entry = sessions.get(sid);
+  if (!entry) return;
+  try {
+    entry.pty.write(data);
+  } catch {
+    /* pty already exited — exit handler will clean up */
+  }
+}
+
+export function resize(
+  sessions: Map<string, Entry>,
+  sid: string,
+  cols: number,
+  rows: number,
+): void {
+  const entry = sessions.get(sid);
+  if (!entry) return;
+  if (cols < 2 || rows < 2) return;
+  try {
+    entry.pty.resize(cols, rows);
+    entry.headless.resize(cols, rows);
+    entry.cols = cols;
+    entry.rows = rows;
+  } catch (e) {
+    console.warn(
+      `[ptyHost] resize ${sid} failed: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+}
+
+export function kill(sessions: Map<string, Entry>, sid: string): boolean {
+  const entry = sessions.get(sid);
+  if (!entry) return false;
+  // Capture pid BEFORE pty.kill() — the binding may zero it after kill.
+  const pid = entry.pty.pid;
+  try {
+    entry.pty.kill();
+  } catch {
+    /* already dead */
+  }
+  // ConPTY's kill only terminates the cmd.exe / OpenConsole wrapper; on Windows
+  // the claude.exe child (and its grandchildren) survive as orphans. On
+  // mac/linux the pgid may also have stragglers. Walk the tree via a
+  // platform-native call to guarantee a clean shutdown.
+  killProcessSubtree(pid);
+  // Belt-and-braces: also stop the watcher synchronously here so a
+  // pty.kill that races with onExit can't leak the fs.watch handle.
+  // sessionWatcher.stopWatching is idempotent.
+  try { sessionWatcher.stopWatching(sid); } catch { /* never throws */ }
+  return true;
+}
+
+export function get(sessions: Map<string, Entry>, sid: string): PtySessionInfo | null {
+  const entry = sessions.get(sid);
+  if (!entry) return null;
+  return infoFromEntry(sid, entry);
+}
+
+// Kill every running pty. Call from app `before-quit` so renderer-side
+// claude processes don't leak past Electron exit.
+export function killAll(sessions: Map<string, Entry>): void {
+  for (const sid of [...sessions.keys()]) {
+    kill(sessions, sid);
+  }
+}


### PR DESCRIPTION
## Summary

Phase A (#556) extracted 5 helpers but left 382 LoC in `electron/ptyHost/index.ts` — a 125-line `makeEntry` factory plus 7 lifecycle ops still mixed with the singleton `sessions` Map and IPC wiring. Phase B splits the residual into two SRP modules and trims `index.ts` to a thin lifecycle-singleton.

- **`entryFactory.ts`** (190 LoC) — `makeEntry()` owns one PTY's wiring: `--resume` vs `--session-id` picker, import-resume JSONL co-location (#603), node-pty + headless mirror construction, data/exit pumps, JSONL tail-watcher start. Side effects flow back through `onExit(sid)` / `onCwdRedirect(cwd)` callbacks so the factory loads in jsdom without Electron.
- **`lifecycle.ts`** (152 LoC) — pure spawn/list/attach/detach/input/resize/kill/get/killAll over a registry Map; `index.ts` owns the singleton and binds the ops to it.
- **`index.ts`** drops 382 -> 119 LoC (target was <=200): just the singleton, public-API binders, IPC registrar wiring, and the historical re-export shim (`onPtyData`, `resolveSpawnCwd`, `ensureResumeJsonlAtSpawnCwd`, ...). Callers in `electron/main.ts` and existing `__tests__` are unchanged.

## Test plan

- [x] `npx tsc --noEmit` clean (root + electron tsconfig)
- [x] `npm run build` clean
- [x] `node -e "require('./dist/electron/ptyHost/index.js')"` load smoke OK (also verified `entryFactory.js` + `lifecycle.js`)
- [x] vitest `electron/ptyHost` suite: 6 files, 72 tests pass (8 new in `entryFactory.test.ts`)
- [x] Reverse-verify: flipping the `--resume`/`--session-id` flag picker makes the new entryFactory test fail with the expected diff; restoring the constant restores green
- [x] e2e `new-session-chat` PASS (21.6s)
- [x] e2e `pty-pid-stable-across-switch` PASS (13.6s)
- [x] Full vitest: 729 pass / 3 pre-existing `better-sqlite3` ABI failures in `db-hardening.test.ts` (native module needs rebuild for Node module version 137; unrelated to this PR)

Public API preserved: `registerPtyHostIpc`, `killAllPtySessions`, `onPtyData`, `resolveSpawnCwd`, `ensureResumeJsonlAtSpawnCwd`, `findJsonlForSid`, `resolveJsonlPath`, `toClaudeSid`, `PtySessionInfo`, `AttachResult` all still exported from `electron/ptyHost`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)