### PR TITLE
refactor(sidebar): trim Sidebar.tsx (Task #735 Phase B)

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,22 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
-import {
-  ChevronRight,
-  Download,
-  Plus,
-  Search,
-  Settings
-} from 'lucide-react';
-import {
-  DndContext,
-  DragOverlay,
-  PointerSensor,
-  closestCenter,
-  useSensor,
-  useSensors,
-  type DragEndEvent,
-  type DragStartEvent
-} from '@dnd-kit/core';
+import { ChevronRight, Download, Plus, Search, Settings } from 'lucide-react';
+import { DndContext, DragOverlay, closestCenter } from '@dnd-kit/core';
 import { useStore } from '../stores/store';
 import { cn } from '../lib/cn';
 import { IconButton } from './ui/IconButton';
@@ -25,14 +10,13 @@ import { AgentIcon } from './AgentIcon';
 import { CwdPopover } from './CwdPopover';
 import { DragRegion } from './WindowControls';
 import { useTranslation } from '../i18n/useTranslation';
-import {
-  DURATION_RAW,
-  EASING,
-} from '../lib/motion';
+import { DURATION_RAW, EASING } from '../lib/motion';
 import type { Session } from '../types';
 import { GroupRow } from './sidebar/GroupRow';
 import { NewSessionButton } from './sidebar/NewSessionButton';
-import { parseHeaderDroppable } from './sidebar/dnd';
+import { CollapsedRail } from './sidebar/CollapsedRail';
+import { ArchivedSection } from './sidebar/ArchivedSection';
+import { useSidebarDnd } from './sidebar/useSidebarDnd';
 
 // Session order inside a group is user-controlled (drag to reorder) — not
 // derived from state. The array order handed down from the store is the
@@ -68,14 +52,17 @@ export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, onOpen
   // re-renders triggered by unrelated store mutations.
   const normal = useMemo(() => groups.filter((g) => g.kind === 'normal'), [groups]);
   const archived = useMemo(() => groups.filter((g) => g.kind === 'archive'), [groups]);
-  const [archiveOpen, setArchiveOpen] = useState(false);
-  const [draggingId, setDraggingId] = useState<string | null>(null);
   // J2: track the most recently created group so its <GroupRow> mounts in
   // inline-rename mode. Cleared after the next render cycle so toggling rename
   // off (or remounting) doesn't accidentally re-trigger it.
   const [justCreatedGroupId, setJustCreatedGroupId] = useState<string | null>(null);
-  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
-  const draggingSession = draggingId ? sessions.find((s) => s.id === draggingId) ?? null : null;
+
+  const { sensors, draggingSession, onDragStart, onDragEnd, onDragCancel } = useSidebarDnd({
+    groups,
+    normalGroups: normal,
+    sessions,
+    onMoveSession
+  });
 
   // Cwd picker for the top "+ New session" cluster. The per-group chevron
   // was removed (#605) — only the top picker remains, so a plain boolean
@@ -108,50 +95,13 @@ export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, onOpen
     return () => window.clearTimeout(h);
   }, [justCreatedGroupId]);
 
-  function handleDragStart(e: DragStartEvent) {
-    setDraggingId(String(e.active.id));
-  }
-
-  function handleDragEnd(e: DragEndEvent) {
-    setDraggingId(null);
-    const { active, over } = e;
-    if (!over || active.id === over.id) return;
-    const activeId = String(active.id);
-    const overId = String(over.id);
-    const headerGroupId = parseHeaderDroppable(overId);
-    if (headerGroupId) {
-      // J14: reject drops onto archived (or otherwise non-normal) group
-      // headers. The archive panel is a "viewer" surface — live sessions
-      // stay in their source group when the user accidentally hovers there.
-      const headerGroup = groups.find((g) => g.id === headerGroupId);
-      if (!headerGroup || headerGroup.kind !== 'normal') return;
-      // Dropped on a group header → append to that group.
-      onMoveSession(activeId, headerGroupId, null);
-      return;
-    }
-    const overSession = sessions.find((s) => s.id === overId);
-    if (overSession) {
-      onMoveSession(activeId, overSession.groupId, overSession.id);
-      return;
-    }
-    // Dropped on an empty SortableContext keyed by group id.
-    if (normal.some((g) => g.id === overId)) {
-      // Same archive guard: SortableContext for archived groups isn't
-      // rendered today, but defend anyway in case the archive list grows
-      // empty-drop targets later.
-      const target = groups.find((g) => g.id === overId);
-      if (!target || target.kind !== 'normal') return;
-      onMoveSession(activeId, overId, null);
-    }
-  }
-
   return (
     <DndContext
       sensors={sensors}
       collisionDetection={closestCenter}
-      onDragStart={handleDragStart}
-      onDragEnd={handleDragEnd}
-      onDragCancel={() => setDraggingId(null)}
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
+      onDragCancel={onDragCancel}
     >
     <motion.aside
       initial={false}
@@ -170,64 +120,13 @@ export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, onOpen
           as visually empty. */}
       <DragRegion className="shrink-0 w-full" style={{ height: window.ccsm?.window.platform === 'darwin' ? 40 : 8 }} />
       {collapsed ? (
-        <div className={`flex flex-col items-center w-full h-full gap-2 ${window.ccsm?.window.platform === 'darwin' ? 'py-1' : 'py-3'}`}>
-          <IconButton
-            variant="raised"
-            size="md"
-            onClick={toggleSidebar}
-            tooltip={t('sidebar.expandSidebarTooltip')}
-            tooltipSide="right"
-            aria-label={t('sidebar.expandSidebarAria')}
-            className="h-8 w-8"
-          >
-            <ChevronRight size={14} className="stroke-[1.5]" />
-          </IconButton>
-          <IconButton
-            variant="raised"
-            size="md"
-            onClick={() => onCreateSession?.()}
-            tooltip={t('sidebar.newSessionTooltip')}
-            tooltipSide="right"
-            aria-label={t('sidebar.newSessionAria')}
-            className="h-8 w-8"
-          >
-            <Plus size={14} className="stroke-[1.75]" />
-          </IconButton>
-          <IconButton
-            variant="raised"
-            size="md"
-            onClick={onOpenPalette}
-            tooltip={t('sidebar.searchTooltip')}
-            tooltipSide="right"
-            aria-label={t('sidebar.searchAriaShort')}
-            className="h-8 w-8"
-          >
-            <Search size={14} className="stroke-[1.5]" />
-          </IconButton>
-          <div className="flex-1" />
-          <IconButton
-            variant="raised"
-            size="md"
-            onClick={onOpenImport}
-            tooltip={t('sidebar.importTooltip')}
-            tooltipSide="right"
-            aria-label={t('sidebar.importAriaShort')}
-            className="h-8 w-8"
-          >
-            <Download size={14} className="stroke-[1.5]" />
-          </IconButton>
-          <IconButton
-            variant="raised"
-            size="md"
-            onClick={onOpenSettings}
-            tooltip={t('sidebar.settingsTooltip')}
-            tooltipSide="right"
-            aria-label={t('sidebar.settingsAria')}
-            className="h-8 w-8"
-          >
-            <Settings size={14} className="stroke-[1.5]" />
-          </IconButton>
-        </div>
+        <CollapsedRail
+          onToggleSidebar={toggleSidebar}
+          onCreateSession={onCreateSession}
+          onOpenPalette={onOpenPalette}
+          onOpenImport={onOpenImport}
+          onOpenSettings={onOpenSettings}
+        />
       ) : (
       <div className="flex flex-col w-full h-full">
           {/* Top: action zone — Search + New Session in one row.
@@ -327,47 +226,15 @@ export function Sidebar({ onCreateSession, onOpenSettings, onOpenPalette, onOpen
 
           {/* Archived Groups — pinned bottom block. Header is clickable to
               fold/unfold; folded by default so it stays out of the way. */}
-          <div data-testid="sidebar-divider-archived" className="border-t border-border-subtle shrink-0" />
-          <button
-            type="button"
-            onClick={() => setArchiveOpen((o) => !o)}
-            aria-expanded={archiveOpen}
-            className={cn(
-              'flex w-full items-center gap-1.5 px-3 py-2 outline-none shrink-0',
-              'text-label-faint transition-colors duration-150',
-              'hover:[&]:text-fg-tertiary'
-            )}
-          >
-            <motion.span
-              initial={false}
-              animate={{ rotate: archiveOpen ? 90 : 0 }}
-              transition={{ duration: DURATION_RAW.ms200, ease: EASING.enter }}
-              className="inline-flex shrink-0 text-fg-faint"
-            >
-              <ChevronRight size={12} className="stroke-[1.75]" />
-            </motion.span>
-            <span>{t('sidebar.archivedGroups')}</span>
-            <span className="ml-1 text-mono-sm leading-[14px] font-normal text-fg-faint tabular-nums">
-              {archived.length}
-            </span>
-          </button>
-          {archiveOpen && (
-            <nav className="h-40 shrink-0 overflow-y-auto px-1.5 py-1">
-              {archived.map((g) => (
-                <GroupRow
-                  key={g.id}
-                  group={g}
-                  sessions={sessions.filter((s) => s.groupId === g.id)}
-                  activeSessionId={activeSessionId}
-                  focused={focusedGroupId === g.id}
-                  anyGroupFocused={focusedGroupId !== null}
-                  onSelectSession={onSelectSession}
-                  onFocus={() => onFocusGroup(g.id)}
-                  normalGroups={normal}
-                />
-              ))}
-            </nav>
-          )}
+          <ArchivedSection
+            archivedGroups={archived}
+            normalGroups={normal}
+            sessions={sessions}
+            activeSessionId={activeSessionId}
+            focusedGroupId={focusedGroupId}
+            onSelectSession={onSelectSession}
+            onFocusGroup={onFocusGroup}
+          />
 
           {/* Settings — its own zone at the bottom. Mirrors the top zone's
               two-button rhythm (flex-1 text Button + fixed-width IconButton)

--- a/src/components/sidebar/ArchivedSection.tsx
+++ b/src/components/sidebar/ArchivedSection.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+import { motion } from 'framer-motion';
+import { ChevronRight } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { useTranslation } from '../../i18n/useTranslation';
+import { DURATION_RAW, EASING } from '../../lib/motion';
+import type { Group, Session } from '../../types';
+import { GroupRow } from './GroupRow';
+
+// Archived groups block — pinned to the bottom of the expanded sidebar above
+// the Settings cluster. Owns its own fold/unfold state because it's the only
+// caller; folded by default per #553 (keeps archived groups out of the way).
+//
+// J14: archived groups are a "viewer" surface — DnD onto archived headers is
+// rejected upstream in useSidebarDnd. The archived rows here intentionally
+// don't render their own SortableContext (no empty-drop targets either).
+export function ArchivedSection({
+  archivedGroups,
+  normalGroups,
+  sessions,
+  activeSessionId,
+  focusedGroupId,
+  onSelectSession,
+  onFocusGroup
+}: {
+  archivedGroups: Group[];
+  normalGroups: Group[];
+  sessions: Session[];
+  activeSessionId: string;
+  focusedGroupId: string | null;
+  onSelectSession: (id: string) => void;
+  onFocusGroup: (id: string) => void;
+}) {
+  const { t } = useTranslation();
+  const [archiveOpen, setArchiveOpen] = useState(false);
+  return (
+    <>
+      <div data-testid="sidebar-divider-archived" className="border-t border-border-subtle shrink-0" />
+      <button
+        type="button"
+        onClick={() => setArchiveOpen((o) => !o)}
+        aria-expanded={archiveOpen}
+        className={cn(
+          'flex w-full items-center gap-1.5 px-3 py-2 outline-none shrink-0',
+          'text-label-faint transition-colors duration-150',
+          'hover:[&]:text-fg-tertiary'
+        )}
+      >
+        <motion.span
+          initial={false}
+          animate={{ rotate: archiveOpen ? 90 : 0 }}
+          transition={{ duration: DURATION_RAW.ms200, ease: EASING.enter }}
+          className="inline-flex shrink-0 text-fg-faint"
+        >
+          <ChevronRight size={12} className="stroke-[1.75]" />
+        </motion.span>
+        <span>{t('sidebar.archivedGroups')}</span>
+        <span className="ml-1 text-mono-sm leading-[14px] font-normal text-fg-faint tabular-nums">
+          {archivedGroups.length}
+        </span>
+      </button>
+      {archiveOpen && (
+        <nav className="h-40 shrink-0 overflow-y-auto px-1.5 py-1">
+          {archivedGroups.map((g) => (
+            <GroupRow
+              key={g.id}
+              group={g}
+              sessions={sessions.filter((s) => s.groupId === g.id)}
+              activeSessionId={activeSessionId}
+              focused={focusedGroupId === g.id}
+              anyGroupFocused={focusedGroupId !== null}
+              onSelectSession={onSelectSession}
+              onFocus={() => onFocusGroup(g.id)}
+              normalGroups={normalGroups}
+            />
+          ))}
+        </nav>
+      )}
+    </>
+  );
+}

--- a/src/components/sidebar/CollapsedRail.tsx
+++ b/src/components/sidebar/CollapsedRail.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { ChevronRight, Download, Plus, Search, Settings } from 'lucide-react';
+import { IconButton } from '../ui/IconButton';
+import { useTranslation } from '../../i18n/useTranslation';
+
+// Collapsed sidebar rail (48px wide). Pure layout — no state, no derived
+// data. Hosts the same six action affordances as the expanded sidebar
+// (toggle, new session, search, import, settings) stacked vertically with
+// flex-1 spacer to push import/settings to the bottom. Extracted from
+// <Sidebar> in Task #735 Phase B; the parent stays a compose layer.
+//
+// macOS: tighter `py-1` to leave room for the stoplight buttons in the
+// drag region above; Windows/Linux: `py-3`.
+export function CollapsedRail({
+  onToggleSidebar,
+  onCreateSession,
+  onOpenPalette,
+  onOpenImport,
+  onOpenSettings
+}: {
+  onToggleSidebar: () => void;
+  onCreateSession?: () => void;
+  onOpenPalette?: () => void;
+  onOpenImport?: () => void;
+  onOpenSettings?: () => void;
+}) {
+  const { t } = useTranslation();
+  const isDarwin = window.ccsm?.window.platform === 'darwin';
+  return (
+    <div className={`flex flex-col items-center w-full h-full gap-2 ${isDarwin ? 'py-1' : 'py-3'}`}>
+      <IconButton
+        variant="raised"
+        size="md"
+        onClick={onToggleSidebar}
+        tooltip={t('sidebar.expandSidebarTooltip')}
+        tooltipSide="right"
+        aria-label={t('sidebar.expandSidebarAria')}
+        className="h-8 w-8"
+      >
+        <ChevronRight size={14} className="stroke-[1.5]" />
+      </IconButton>
+      <IconButton
+        variant="raised"
+        size="md"
+        onClick={() => onCreateSession?.()}
+        tooltip={t('sidebar.newSessionTooltip')}
+        tooltipSide="right"
+        aria-label={t('sidebar.newSessionAria')}
+        className="h-8 w-8"
+      >
+        <Plus size={14} className="stroke-[1.75]" />
+      </IconButton>
+      <IconButton
+        variant="raised"
+        size="md"
+        onClick={onOpenPalette}
+        tooltip={t('sidebar.searchTooltip')}
+        tooltipSide="right"
+        aria-label={t('sidebar.searchAriaShort')}
+        className="h-8 w-8"
+      >
+        <Search size={14} className="stroke-[1.5]" />
+      </IconButton>
+      <div className="flex-1" />
+      <IconButton
+        variant="raised"
+        size="md"
+        onClick={onOpenImport}
+        tooltip={t('sidebar.importTooltip')}
+        tooltipSide="right"
+        aria-label={t('sidebar.importAriaShort')}
+        className="h-8 w-8"
+      >
+        <Download size={14} className="stroke-[1.5]" />
+      </IconButton>
+      <IconButton
+        variant="raised"
+        size="md"
+        onClick={onOpenSettings}
+        tooltip={t('sidebar.settingsTooltip')}
+        tooltipSide="right"
+        aria-label={t('sidebar.settingsAria')}
+        className="h-8 w-8"
+      >
+        <Settings size={14} className="stroke-[1.5]" />
+      </IconButton>
+    </div>
+  );
+}

--- a/src/components/sidebar/useSidebarDnd.ts
+++ b/src/components/sidebar/useSidebarDnd.ts
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+import {
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent
+} from '@dnd-kit/core';
+import type { Group, Session } from '../../types';
+import { parseHeaderDroppable } from './dnd';
+
+// Sidebar DnD orchestration: sensors + active-id tracking + drag-end routing.
+// Lives outside <Sidebar> so the parent stays a thin compose layer (Task #735
+// Phase B). The hook owns three concerns that all serve the single purpose of
+// "which session goes where on drop":
+//   1. Sensor wiring (PointerSensor with 8px activation distance — keeps
+//      regular clicks on session rows from being swallowed by drag).
+//   2. The currently-dragged id, so <DragOverlay> can render a preview card.
+//   3. The drop-target → onMoveSession routing rules (J14: archived headers
+//      reject live-session drops; same guard for empty SortableContexts).
+export type SidebarDndDeps = {
+  groups: Group[];
+  normalGroups: Group[];
+  sessions: Session[];
+  onMoveSession: (sessionId: string, targetGroupId: string, beforeSessionId: string | null) => void;
+};
+
+export type SidebarDndApi = {
+  sensors: ReturnType<typeof useSensors>;
+  draggingSession: Session | null;
+  onDragStart: (e: DragStartEvent) => void;
+  onDragEnd: (e: DragEndEvent) => void;
+  onDragCancel: () => void;
+};
+
+export function useSidebarDnd({ groups, normalGroups, sessions, onMoveSession }: SidebarDndDeps): SidebarDndApi {
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
+  const draggingSession = draggingId ? sessions.find((s) => s.id === draggingId) ?? null : null;
+
+  function onDragStart(e: DragStartEvent) {
+    setDraggingId(String(e.active.id));
+  }
+
+  function onDragEnd(e: DragEndEvent) {
+    setDraggingId(null);
+    const { active, over } = e;
+    if (!over || active.id === over.id) return;
+    const activeId = String(active.id);
+    const overId = String(over.id);
+    const headerGroupId = parseHeaderDroppable(overId);
+    if (headerGroupId) {
+      // J14: reject drops onto archived (or otherwise non-normal) group
+      // headers. The archive panel is a "viewer" surface — live sessions
+      // stay in their source group when the user accidentally hovers there.
+      const headerGroup = groups.find((g) => g.id === headerGroupId);
+      if (!headerGroup || headerGroup.kind !== 'normal') return;
+      // Dropped on a group header → append to that group.
+      onMoveSession(activeId, headerGroupId, null);
+      return;
+    }
+    const overSession = sessions.find((s) => s.id === overId);
+    if (overSession) {
+      onMoveSession(activeId, overSession.groupId, overSession.id);
+      return;
+    }
+    // Dropped on an empty SortableContext keyed by group id.
+    if (normalGroups.some((g) => g.id === overId)) {
+      // Same archive guard: SortableContext for archived groups isn't
+      // rendered today, but defend anyway in case the archive list grows
+      // empty-drop targets later.
+      const target = groups.find((g) => g.id === overId);
+      if (!target || target.kind !== 'normal') return;
+      onMoveSession(activeId, overId, null);
+    }
+  }
+
+  function onDragCancel() {
+    setDraggingId(null);
+  }
+
+  return { sensors, draggingSession, onDragStart, onDragEnd, onDragCancel };
+}

--- a/tests/sidebar/useSidebarDnd.test.ts
+++ b/tests/sidebar/useSidebarDnd.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { DragEndEvent, DragStartEvent } from '@dnd-kit/core';
+import { useSidebarDnd } from '../../src/components/sidebar/useSidebarDnd';
+import { headerDroppableId } from '../../src/components/sidebar/dnd';
+import type { Group, Session } from '../../src/types';
+
+// useSidebarDnd: pure routing logic for sidebar DnD. Covers the four drop
+// targets routed by handleDragEnd plus the J14 archive guard.
+//   1. drop on a normal-group header  → onMoveSession(active, headerGroup, null)
+//   2. drop on an archived-group header → REJECTED (no callback)
+//   3. drop on another session         → onMoveSession(active, overSession.group, overSession.id)
+//   4. drop on an empty SortableContext keyed by group id → append to that group
+//   5. cancel / no overlap → no callback, draggingSession cleared
+
+const sessionDefaults = {
+  state: 'idle' as const,
+  cwd: '~',
+  model: 'claude-opus-4',
+  agentType: 'claude-code' as const
+};
+
+const grpNormal = (id: string): Group => ({ id, name: id, collapsed: false, kind: 'normal' });
+const grpArchive = (id: string): Group => ({ id, name: id, collapsed: false, kind: 'archive' });
+const sess = (id: string, groupId: string): Session => ({ id, name: id, groupId, ...sessionDefaults });
+
+function makeArgs(overrides?: Partial<Parameters<typeof useSidebarDnd>[0]>) {
+  const groups: Group[] = [grpNormal('g1'), grpNormal('g2'), grpArchive('garc')];
+  const sessions: Session[] = [sess('s1', 'g1'), sess('s2', 'g1'), sess('s3', 'g2')];
+  const onMoveSession = vi.fn();
+  return {
+    args: {
+      groups,
+      normalGroups: groups.filter((g) => g.kind === 'normal'),
+      sessions,
+      onMoveSession,
+      ...overrides
+    },
+    onMoveSession
+  };
+}
+
+const dragEnd = (activeId: string, overId: string | null): DragEndEvent =>
+  ({ active: { id: activeId }, over: overId ? { id: overId } : null } as unknown as DragEndEvent);
+
+describe('useSidebarDnd', () => {
+  it('routes drop on normal group header to append', () => {
+    const { args, onMoveSession } = makeArgs();
+    const { result } = renderHook(() => useSidebarDnd(args));
+    act(() => result.current.onDragEnd(dragEnd('s1', headerDroppableId('g2'))));
+    expect(onMoveSession).toHaveBeenCalledWith('s1', 'g2', null);
+  });
+
+  it('rejects drop on archived group header (J14)', () => {
+    const { args, onMoveSession } = makeArgs();
+    const { result } = renderHook(() => useSidebarDnd(args));
+    act(() => result.current.onDragEnd(dragEnd('s1', headerDroppableId('garc'))));
+    expect(onMoveSession).not.toHaveBeenCalled();
+  });
+
+  it('routes drop on another session to insert-before', () => {
+    const { args, onMoveSession } = makeArgs();
+    const { result } = renderHook(() => useSidebarDnd(args));
+    act(() => result.current.onDragEnd(dragEnd('s1', 's3')));
+    expect(onMoveSession).toHaveBeenCalledWith('s1', 'g2', 's3');
+  });
+
+  it('routes drop on empty SortableContext keyed by normal group id to append', () => {
+    const { args, onMoveSession } = makeArgs();
+    const { result } = renderHook(() => useSidebarDnd(args));
+    act(() => result.current.onDragEnd(dragEnd('s1', 'g2')));
+    expect(onMoveSession).toHaveBeenCalledWith('s1', 'g2', null);
+  });
+
+  it('rejects drop on empty SortableContext keyed by archived group id', () => {
+    const { args, onMoveSession } = makeArgs({
+      // Force archive id into normalGroups list to test downstream guard.
+      normalGroups: [grpNormal('g1'), grpNormal('g2'), grpArchive('garc') as Group]
+    });
+    const { result } = renderHook(() => useSidebarDnd(args));
+    act(() => result.current.onDragEnd(dragEnd('s1', 'garc')));
+    expect(onMoveSession).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when over is null', () => {
+    const { args, onMoveSession } = makeArgs();
+    const { result } = renderHook(() => useSidebarDnd(args));
+    act(() => result.current.onDragEnd(dragEnd('s1', null)));
+    expect(onMoveSession).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when active === over', () => {
+    const { args, onMoveSession } = makeArgs();
+    const { result } = renderHook(() => useSidebarDnd(args));
+    act(() => result.current.onDragEnd(dragEnd('s1', 's1')));
+    expect(onMoveSession).not.toHaveBeenCalled();
+  });
+
+  it('tracks draggingSession across start/cancel', () => {
+    const { args } = makeArgs();
+    const { result } = renderHook(() => useSidebarDnd(args));
+    expect(result.current.draggingSession).toBeNull();
+    act(() => result.current.onDragStart({ active: { id: 's1' } } as unknown as DragStartEvent));
+    expect(result.current.draggingSession?.id).toBe('s1');
+    act(() => result.current.onDragCancel());
+    expect(result.current.draggingSession).toBeNull();
+  });
+
+  it('clears draggingSession on drag-end', () => {
+    const { args } = makeArgs();
+    const { result } = renderHook(() => useSidebarDnd(args));
+    act(() => result.current.onDragStart({ active: { id: 's1' } } as unknown as DragStartEvent));
+    expect(result.current.draggingSession?.id).toBe('s1');
+    act(() => result.current.onDragEnd(dragEnd('s1', headerDroppableId('g2'))));
+    expect(result.current.draggingSession).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Phase B follow-up to #553. After GroupRow / SessionRow / NewSessionButton were extracted, `Sidebar.tsx` was still 426 LoC with three remaining SRP wins. This PR carves them out:

- **`useSidebarDnd()` hook** (`src/components/sidebar/useSidebarDnd.ts`, 83 LoC) — owns the PointerSensor, the dragging-id state, and the drag-end routing logic (header / session-row / empty SortableContext) including the J14 archive guard. Pure logic, exposes `{ sensors, draggingSession, onDragStart, onDragEnd, onDragCancel }`.
- **`<CollapsedRail>`** (`src/components/sidebar/CollapsedRail.tsx`, 89 LoC) — the 48px rail with the six collapsed-mode IconButtons (toggle / new / search / spacer / import / settings). No state, no derived data; macOS `py-1` vs Windows `py-3` retained.
- **`<ArchivedSection>`** (`src/components/sidebar/ArchivedSection.tsx`, 81 LoC) — owns its own `archiveOpen` fold/unfold state and renders the archived `GroupRow` list. Folded by default, matching #553 behavior.

`<DragOverlay>` card stayed inline (single call site, ~15 LoC of pure layout — extracting would have been gold-plating).

**Result: `Sidebar.tsx` 426 LoC -> 293 LoC (-31%)**. The compose layer is now mostly the JSX shell + child wiring + the `justCreatedGroupId` rename-bridge effect.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean (3 webpack size warnings, pre-existing)
- [x] `vitest tests/sidebar/` -> 13 passed (9 new in `useSidebarDnd.test.ts` covering all 4 drop-target branches + J14 archive guard + cancel/no-op edges + draggingSession lifecycle)
- [x] `harness-ui --only=sidebar-align` PASS
- [x] `harness-ui --only=sidebar-long-name-truncates` PASS
- [ ] `harness-dnd --only=dnd` — env-flaky on this Win11 box (electron+playwright launch crash repros identically on origin/working baseline; not a regression from this PR)