### PR TITLE
fix(notify): gate flash on hasObservedRunning to stop boot-time icon flash (#767)

### DIFF
--- a/electron/notify/__tests__/runStateTracker.test.ts
+++ b/electron/notify/__tests__/runStateTracker.test.ts
@@ -167,4 +167,80 @@ describe('runStateTracker — pure decider', () => {
     expect(dec).toBeNull();
     expect(t._internals().runStartTs.has('s1')).toBe(false);
   });
+
+  // ---------------------------------------------------------------------------
+  // Task #767 regression — `hasObservedRunning` gate
+  //
+  // Before the gate, the very first 'idle' / 'waiting' OSC title for a sid
+  // (which claude.exe emits within ~100-300ms of boot) would call decide()
+  // with no runStartTs entry. notifyDecider Rule 2 then computed
+  //   elapsed = start === undefined ? 0 : now - start  →  0
+  //   0 < SHORT_TASK_MS (60s)                          →  TRUE
+  // so it returned `{toast:false, flash:true}` unconditionally. flashSink
+  // lit `flashStates[sid]=true` for FLASH_DURATION_MS (4s), driving 2.5
+  // AgentIcon framer-motion breath cycles on every fresh / imported /
+  // resumed session — the bug user reported in #767.
+  //
+  // Fix: producer-layer gate — skip decide() until we've seen a 'running'
+  // title for this sid. notifyDecider stays pure / unchanged.
+  // ---------------------------------------------------------------------------
+  it('Task #767: does not fire when first title for a sid is "idle"', () => {
+    const t = createRunStateTracker(decide);
+    // Default focused=true + activeSid set to s1 reproduces the exact
+    // foreground+active context where the unguarded code path tripped
+    // Rule 2 ("foreground-active-short").
+    t.setFocused(true);
+    t.setActiveSid('s1');
+    const dec = t.onTitle('s1', 'idle', NOW);
+    expect(dec).toBeNull();
+    // No mutation: lastFiredTs must stay empty (the bug also poisoned the
+    // 5s dedupe window with a phantom fire).
+    expect(t._internals().lastFiredTs.has('s1')).toBe(false);
+  });
+
+  it('Task #767: does not fire when first title for a sid is "waiting"', () => {
+    const t = createRunStateTracker(decide);
+    t.setFocused(true);
+    t.setActiveSid('s1');
+    const dec = t.onTitle('s1', 'waiting', NOW);
+    expect(dec).toBeNull();
+    expect(t._internals().lastFiredTs.has('s1')).toBe(false);
+  });
+
+  it('Task #767 regression guard: still fires on idle AFTER a running title', () => {
+    // Sanity check that the gate only suppresses the boot-time false
+    // positive — once a real run has started, the existing rules apply
+    // exactly as before. This is the critical regression case: if the
+    // gate were too aggressive, legitimate Rule 2 flashes would silently
+    // disappear.
+    const t = createRunStateTracker(decide);
+    t.setFocused(true);
+    t.setActiveSid('s1');
+    // Real run starts.
+    expect(t.onTitle('s1', 'running', NOW)).toBeNull();
+    // Run finishes 1s later → Rule 2 (foreground+active+short) fires.
+    const dec = t.onTitle('s1', 'idle', NOW + 1_000);
+    expect(dec).not.toBeNull();
+    expect(dec?.toast).toBe(false);
+    expect(dec?.flash).toBe(true);
+  });
+
+  it('Task #767: forgetSid resets the hasObservedRunning gate', () => {
+    // After session teardown, a brand-new lifetime for the same sid (e.g.
+    // re-import with a recycled id) must start gated again.
+    const t = createRunStateTracker(decide);
+    t.setFocused(true);
+    t.setActiveSid('s1');
+    t.onTitle('s1', 'running', NOW);
+    const dec1 = t.onTitle('s1', 'idle', NOW + 1_000);
+    expect(dec1).not.toBeNull(); // gate open after running
+
+    t.forgetSid('s1');
+
+    // Without the forgetSid clearing hasObservedRunning, this fresh idle
+    // would erroneously fire (gate would still be open from the previous
+    // lifetime).
+    const dec2 = t.onTitle('s1', 'idle', NOW + 10_000);
+    expect(dec2).toBeNull();
+  });
 });

--- a/electron/notify/runStateTracker.ts
+++ b/electron/notify/runStateTracker.ts
@@ -67,6 +67,22 @@ export function createRunStateTracker(
   const mutedSids = new Map<string, number>();
   const lastFiredTs = new Map<string, number>();
   const lastUserInputTs = new Map<string, number>();
+  /**
+   * Per-sid gate (Task #767): true once we have observed a 'running' title
+   * for this sid in the current process lifetime. The decider's Rule 2
+   * ("foreground + active + short task") computes elapsed = now - start;
+   * when no 'running' was ever seen, runStartTs is unset and elapsed
+   * collapses to 0 < SHORT_TASK_MS, unconditionally tripping {flash:true}.
+   *
+   * claude.exe boot reliably emits an 'idle' / 'waiting' OSC title within
+   * a few hundred ms of spawn, so without this gate every fresh / imported /
+   * resumed session lights flashSink for FLASH_DURATION_MS, producing the
+   * 4-second AgentIcon "breath" the user reported in #767.
+   *
+   * Fix at the producer layer: skip decide() entirely until we've seen a
+   * legitimate run start. notifyDecider stays pure / unchanged.
+   */
+  const hasObservedRunning = new Set<string>();
   let focused = true;
   let activeSid: string | null = null;
 
@@ -84,6 +100,17 @@ export function createRunStateTracker(
 
       if (classification === 'running') {
         if (!runStartTs.has(sid)) runStartTs.set(sid, nowTs);
+        hasObservedRunning.add(sid);
+        return null;
+      }
+
+      // Task #767 gate: if we've never seen this sid go 'running', the
+      // incoming 'idle' / 'waiting' title is the CLI's boot banner (or a
+      // post-import resume settle). There is no real task to notify on, and
+      // the decider would otherwise mis-fire Rule 2 (elapsed = 0 < 60s).
+      if (!hasObservedRunning.has(sid)) {
+        // Still keep runStartTs clean if anything stray slipped in.
+        runStartTs.delete(sid);
         return null;
       }
 
@@ -118,6 +145,7 @@ export function createRunStateTracker(
       mutedSids.delete(sid);
       lastFiredTs.delete(sid);
       lastUserInputTs.delete(sid);
+      hasObservedRunning.delete(sid);
     },
     setFocused(next) {
       focused = next;


### PR DESCRIPTION
## Bug summary

Per Task #767 phase 1 investigation: `electron/notify/runStateTracker.ts` called `notifyDecider.decide()` for `onTitle(sid,'idle'|'waiting')` even when sid had never seen a `'running'` title. `notifyDecider.ts:111` then computed `elapsed = start === undefined ? 0 : now - start`, and `0 < SHORT_TASK_MS=60000` unconditionally tripped Rule 2 (`foreground-active-short`) -> `{toast:false, flash:true}`. flashSink lit `flashStates[sid]` for `FLASH_DURATION_MS = 4000ms`, driving ~2.5 AgentIcon framer-motion breath cycles. claude.exe boot reliably emits an idle/waiting OSC title within ~100-300ms of spawn, so the bug fired on every fresh / imported / resumed session. `Session.state` channel was already correctly suppressed by `_applySessionState`; the regression lived purely in the new flashStates channel from PR #689.

## Fix

Option A (producer-layer gate). `electron/notify/runStateTracker.ts`:

- Added per-sid `hasObservedRunning: Set<string>`.
- `onTitle(sid, 'running', _)`: adds sid to the set (alongside existing `runStartTs` seed).
- `onTitle(sid, 'idle' | 'waiting', _)`: if `!hasObservedRunning.has(sid)`, return null immediately - no `decide()` call, no `lastFiredTs` mutation. Otherwise existing path unchanged.
- `forgetSid(sid)`: also clears `hasObservedRunning[sid]` so a recycled sid (re-import) starts gated again.

`notifyDecider.ts` is untouched - decider stays pure. See diff at `electron/notify/runStateTracker.ts` (new gate inside `onTitle`, around the `'running'` branch + the new early-return for `idle`/`waiting`).

## Test 1: unit reverse-verify (mandatory)

3 new cases added to `electron/notify/__tests__/runStateTracker.test.ts` (path was `electron/notify/__tests__/...`, not `tests/stores/slices/...` as phase 1 report said):

1. `Task #767: does not fire when first title for a sid is "idle"` - reproduces the exact `focused=true + activeSid=s1` context where Rule 2 mis-fired.
2. `Task #767: does not fire when first title for a sid is "waiting"` - same with the other classification.
3. `Task #767 regression guard: still fires on idle AFTER a running title` - ensures the gate only suppresses the boot-time false positive; legitimate Rule 2 still fires.

Plus a 4th: `Task #767: forgetSid resets the hasObservedRunning gate` - regression for the teardown path.

### Reverse-verify FAIL (origin/working, fix stashed)

```
FAIL electron/notify/__tests__/runStateTracker.test.ts > runStateTracker - pure decider > Task #767: does not fire when first title for a sid is "idle"
AssertionError: expected { Object (toast, flash, ...) } to be null
- Expected: null
+ Received: { "flash": true, "sid": "s1", "toast": false }

FAIL electron/notify/__tests__/runStateTracker.test.ts > runStateTracker - pure decider > Task #767: does not fire when first title for a sid is "waiting"
AssertionError: expected { Object (toast, flash, ...) } to be null
- Expected: null
+ Received: { "flash": true, "sid": "s1", "toast": false }

FAIL electron/notify/__tests__/runStateTracker.test.ts > runStateTracker - pure decider > Task #767: forgetSid resets the hasObservedRunning gate
AssertionError: expected { Object (toast, flash, ...) } to be null
- Expected: null
+ Received: { "flash": true, "sid": "s1", "toast": false }

Test Files  1 failed (1)
     Tests  3 failed | 1 passed | 12 skipped (16)
```

The exact `{toast:false, flash:true}` payload confirms Rule 2 ("foreground-active-short") was the misfiring rule, matching the phase 1 root-cause analysis byte-for-byte.

### Reverse-verify PASS (with fix)

```
RUN  v2.1.9
 PASS  electron/notify/__tests__/runStateTracker.test.ts (16 tests) 14ms

Test Files  1 passed (1)
     Tests  16 passed (16)
```

## Test 2: e2e probe

Skipped per manager instruction mid-task: UT in the producer layer is the source of truth (the gate lives in pure logic, decider unchanged). CI's full e2e suite remains the end-to-end net per `feedback_trust_ci_mode.md`.

## Local checks

### typecheck

```
> ccsm@0.1.0 typecheck
> tsc --noEmit && tsc --noEmit -p tsconfig.electron.json
```
(clean - no errors)

### build

```
webpack 5.106.2 compiled with 3 warnings in 22502 ms
```
(only pre-existing bundle-size warnings; no errors)

### vitest run on touched file

```
Test Files  1 passed (1)
     Tests  16 passed (16)
```

## Links

- Closes Task #767.
- Phase 1 (read-only) investigation pinned origin/working at c9d0ed0 and identified `hasObservedRunning` gate (Option A) as the minimal fix.
- Bug surface introduced by PR #689 (flashStates channel).