### PR TITLE
refactor(cwd): split CwdPopover into hooks + panel + slim host (#770)

### DIFF
--- a/src/components/CwdPopover.tsx
+++ b/src/components/CwdPopover.tsx
@@ -1,9 +1,12 @@
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { ChevronDown, Folder, AlertTriangle } from 'lucide-react';
+import { ChevronDown, AlertTriangle } from 'lucide-react';
 import { cn } from '../lib/cn';
 import { useTranslation } from '../i18n/useTranslation';
 import { useStore } from '../stores/store';
+import { useCwdPanelPosition } from './cwd/useCwdPanelPosition';
+import { useCwdRecentList } from './cwd/useCwdRecentList';
+import { CwdPopoverPanel } from './cwd/CwdPopoverPanel';
 
 // Stable id for this popover in the global mutex slot. See
 // `openPopoverId` in src/stores/store.ts: opening any popover sets the id
@@ -26,23 +29,11 @@ const POPOVER_ID_LEGACY = 'cwd';
 //      for the new chevron-next-to-`+` cwd picker (task #552). No trigger
 //      button is rendered; the caller owns trigger UI + open state.
 //
-// History: PR #94 introduced the typeahead inside SessionCreateDialog; PR
-// #106 dropped the dialog and moved it to the StatusBar cwd chip. The
-// StatusBar was later removed (direct-xterm refactor), leaving the legacy
-// embedded-trigger mode dormant in production but still tested. Task #552
-// resurrects the popover anchored to a sidebar chevron.
-//
-// Implementation notes:
-//   - We deliberately don't pull in `@radix-ui/react-popover` because the
-//     project doesn't have it as a direct dependency. Positioning is a
-//     simple absolute layout anchored to the trigger / external anchor;
-//     click-outside + Escape close the popover.
-//   - The recent list comes from `window.ccsm.recentCwds()` which the
-//     main process eager-scans at boot from `~/.claude/projects` (PR #94).
-//     The IPC is best-effort: if it fails or returns empty we render a
-//     friendly "no recent cwds" hint and still expose Browse.
-
-const RECENT_LIMIT = 10;
+// Implementation split (#770): three concerns live in `./cwd/`:
+//   - useCwdPanelPosition — controlled-mode anchor positioning effect
+//   - useCwdRecentList    — recent loader + filter + keyboard nav
+//   - CwdPopoverPanel     — presentational panel JSX
+// This file is the slim host: prop-mode arbiter + legacy trigger glue.
 
 type CommonProps = {
   /** Switch the active session to `path`. */
@@ -80,26 +71,6 @@ function lastSegment(path: string): string {
   return segs[segs.length - 1] ?? path;
 }
 
-function truncateMiddle(path: string, max = 56): string {
-  if (path.length <= max) return path;
-  const head = Math.ceil((max - 1) / 2);
-  const tail = Math.floor((max - 1) / 2);
-  return `${path.slice(0, head)}…${path.slice(path.length - tail)}`;
-}
-
-async function defaultLoadRecent(): Promise<string[]> {
-  type Bridge = { recentCwds?: () => Promise<string[]> };
-  const bridge = (typeof window !== 'undefined'
-    ? (window as unknown as { ccsm?: Bridge }).ccsm
-    : undefined);
-  try {
-    const list = await bridge?.recentCwds?.();
-    return Array.isArray(list) ? list : [];
-  } catch {
-    return [];
-  }
-}
-
 export function CwdPopover(props: Props) {
   const isControlled = props.open !== undefined && props.onOpenChange !== undefined;
   const { t } = useTranslation();
@@ -126,48 +97,32 @@ export function CwdPopover(props: Props) {
 
   const { onPick, onBrowse, loadRecent, cwd: cwdProp = '', cwdMissing } = props;
   const cwd = cwdProp;
-  const [query, setQuery] = useState('');
-  const [recent, setRecent] = useState<string[]>([]);
-  const [active, setActive] = useState(0);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const popRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
-  // Controlled-mode panel positioning. We compute screen coords from the
-  // external anchor's bounding rect on every open + on resize/scroll while
-  // open, mounting the panel via a fixed-position wrapper so it escapes
-  // any clipping ancestors (the sidebar uses `overflow:hidden` AND
-  // `backdrop-filter` which together would clip a non-portaled fixed
-  // descendant — see PR #598). The panel is also portaled to `document.body`
-  // below for the same reason.
-  //
-  // We clamp the computed `left` to the viewport so popovers anchored close
-  // to the right edge of the screen never overflow off-screen.
-  const PANEL_MIN_WIDTH = 320; // matches min-w-[320px] on the panel.
-  const VIEWPORT_PADDING = 8;
-  const [panelPos, setPanelPos] = useState<{ top: number; left: number } | null>(null);
-  useLayoutEffect(() => {
-    if (!isControlled || !open) return;
-    const anchor = (props as ControlledProps).anchorRef.current;
-    if (!anchor) return;
-    const recompute = () => {
-      const r = anchor.getBoundingClientRect();
-      const top = r.bottom + 4;
-      // Prefer left-aligned to anchor; if that would overflow the right edge
-      // of the viewport, shift left so the panel stays fully on-screen.
-      const maxLeft = window.innerWidth - PANEL_MIN_WIDTH - VIEWPORT_PADDING;
-      const left = Math.max(VIEWPORT_PADDING, Math.min(r.left, maxLeft));
-      setPanelPos({ top, left });
-    };
-    recompute();
-    window.addEventListener('resize', recompute);
-    window.addEventListener('scroll', recompute, true);
-    return () => {
-      window.removeEventListener('resize', recompute);
-      window.removeEventListener('scroll', recompute, true);
-      setPanelPos(null);
-    };
-  }, [isControlled, open, props]);
+  const anchorRef = isControlled ? (props as ControlledProps).anchorRef : null;
+  const panelPos = useCwdPanelPosition(anchorRef, open, isControlled);
+
+  const commit = useCallback(
+    (path: string) => {
+      setOpen(false);
+      onPick(path);
+    },
+    [onPick, setOpen]
+  );
+
+  const { filtered, query, setQuery, active, setActive, onListKeyDown } =
+    useCwdRecentList(open, loadRecent, commit);
+
+  // Focus the input on open (deferred to next tick so the panel mounts first).
+  useEffect(() => {
+    if (!open) return;
+    const id = window.setTimeout(() => {
+      inputRef.current?.focus();
+    }, 0);
+    return () => window.clearTimeout(id);
+  }, [open, cwd]);
 
   // task328: discoverability — pulse a faint accent ring on the FIRST hover
   // after mount so brand-new users notice the (legacy) chip is interactive.
@@ -191,32 +146,6 @@ export function CwdPopover(props: Props) {
       setHoverHintActive(false);
     }
   }, [open, hoverHintShown]);
-
-  // Reset query each time we re-open so the Recent list shows in full;
-  // the current cwd is surfaced as the input placeholder instead.
-  useEffect(() => {
-    if (!open) return;
-    setQuery('');
-    setActive(0);
-    const id = window.setTimeout(() => {
-      inputRef.current?.focus();
-    }, 0);
-    return () => window.clearTimeout(id);
-  }, [open, cwd]);
-
-  // Lazy-load recent cwds on each open.
-  useEffect(() => {
-    if (!open) return;
-    let cancelled = false;
-    const loader = loadRecent ?? defaultLoadRecent;
-    void loader().then((list) => {
-      if (cancelled) return;
-      setRecent(list.slice(0, RECENT_LIMIT));
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [open, loadRecent]);
 
   // Click-outside / Escape both close the popover. In controlled mode the
   // outside-click check must also exclude the EXTERNAL anchor so a click
@@ -247,151 +176,32 @@ export function CwdPopover(props: Props) {
     };
   }, [open, isControlled, props, setOpen]);
 
-  const filtered = useMemo(() => {
-    const needle = query.trim().toLowerCase();
-    if (!needle) return recent;
-    return recent.filter((p) => p.toLowerCase().includes(needle));
-  }, [recent, query]);
-
-  // Clamp active row whenever the filtered list shrinks.
-  useEffect(() => {
-    if (active >= filtered.length) setActive(0);
-  }, [filtered.length, active]);
-
-  const commit = useCallback(
-    (path: string) => {
-      setOpen(false);
-      onPick(path);
-    },
-    [onPick, setOpen]
-  );
-
-  const onListKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'ArrowDown') {
-      e.preventDefault();
-      setActive((a) => Math.min(a + 1, Math.max(0, filtered.length - 1)));
-    } else if (e.key === 'ArrowUp') {
-      e.preventDefault();
-      setActive((a) => Math.max(0, a - 1));
-    } else if (e.key === 'Enter') {
-      e.preventDefault();
-      const choice = filtered[active] ?? (query.trim() ? query.trim() : null);
-      if (choice) commit(choice);
-    }
-  };
-
   // Legacy-mode chip label. Controlled mode never renders this.
   const hasCwd = !!cwd;
   const triggerLabel = hasCwd ? lastSegment(cwd) : t('chat.cwdChipNoneLabel');
 
-  // The popover panel — shared between modes, but positioning differs.
   // Controlled mode requires `panelPos` to be measured BEFORE rendering, so we
   // never paint an unpositioned static block that pushes neighboring layout
   // (e.g. the "+ New session" trigger to its left). Legacy mode positions
   // itself via Tailwind absolute classes on the inline anchor.
   const showPanel = open && (!isControlled || panelPos !== null);
   const panel = showPanel ? (
-    <div
-      ref={popRef}
-      role="dialog"
-      aria-label={t('statusBar.workingDirectory')}
-      style={
-        isControlled && panelPos
-          ? { position: 'fixed', top: panelPos.top, left: panelPos.left }
-          : undefined
-      }
-      className={cn(
-        isControlled
-          ? 'z-50 min-w-[320px] max-w-[480px]'
-          : 'absolute left-0 bottom-full mb-1 z-40 min-w-[320px] max-w-[480px]',
-        'rounded-md border border-border-default bg-bg-elevated',
-        'surface-highlight shadow-[var(--surface-shadow)]',
-        'text-chrome text-fg-secondary overflow-hidden',
-        'animate-[menuIn_140ms_cubic-bezier(0.32,0.72,0,1)]'
-      )}
-      data-testid="cwd-popover-panel"
-    >
-      <div className="px-2 pt-2 pb-1.5 border-b border-border-subtle">
-        <input
-          ref={inputRef}
-          type="text"
-          value={query}
-          spellCheck={false}
-          autoComplete="off"
-          placeholder={cwd ? truncateMiddle(cwd, 48) : t('cwdPopover.placeholder')}
-          onChange={(e) => {
-            setQuery(e.target.value);
-            setActive(0);
-          }}
-          onKeyDown={onListKeyDown}
-          className={cn(
-            'w-full h-7 px-2 rounded-sm bg-bg-panel border border-border-subtle',
-            'font-mono text-mono-md text-fg-primary placeholder:text-fg-tertiary',
-            'outline-none focus:border-border-strong'
-          )}
-        />
-      </div>
-
-      <span className="block px-3 pt-1.5 pb-1 font-mono text-mono-sm text-fg-tertiary select-none">
-        {t('cwdPopover.recent')}
-      </span>
-      <ul className="max-h-[260px] overflow-y-auto pb-1" role="listbox">
-        {filtered.length === 0 ? (
-          <li className="px-3 py-2 text-fg-tertiary text-mono-md leading-[16px]">
-            {t('cwdPopover.empty')}
-          </li>
-        ) : (
-          filtered.map((path, i) => {
-            const isActive = i === active;
-            return (
-              <li
-                key={path}
-                role="option"
-                aria-selected={isActive}
-                onMouseEnter={() => setActive(i)}
-                // onMouseDown so the input doesn't blur first and close us.
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                  commit(path);
-                }}
-                title={path}
-                className={cn(
-                  'flex items-center h-7 px-3 mx-1 rounded-sm cursor-pointer select-none',
-                  'transition-colors duration-120 ease-out',
-                  isActive
-                    ? 'bg-bg-hover text-fg-primary'
-                    : 'text-fg-secondary hover:bg-bg-hover/60'
-                )}
-              >
-                <span className="font-mono text-mono-md truncate">
-                  {truncateMiddle(path)}
-                </span>
-              </li>
-            );
-          })
-        )}
-      </ul>
-
-      <div className="border-t border-border-subtle px-1 py-1">
-        <button
-          type="button"
-          onMouseDown={(e) => {
-            e.preventDefault();
-            setOpen(false);
-            onBrowse();
-          }}
-          className={cn(
-            'w-full flex items-center gap-2 h-7 px-2 mx-0 rounded-sm',
-            'text-fg-secondary hover:bg-bg-hover hover:text-fg-primary',
-            'outline-none focus-ring',
-            'transition-colors duration-120 ease-out text-left text-mono-md'
-          )}
-        >
-          <Folder size={12} className="stroke-[1.75] text-fg-tertiary" />
-          <span>{t('cwdPopover.browse')}</span>
-        </button>
-      </div>
-    </div>
+    <CwdPopoverPanel
+      isControlled={isControlled}
+      panelPos={panelPos}
+      popRef={popRef}
+      inputRef={inputRef}
+      cwd={cwd}
+      query={query}
+      setQuery={setQuery}
+      active={active}
+      setActive={setActive}
+      filtered={filtered}
+      onListKeyDown={onListKeyDown}
+      onCommit={commit}
+      onBrowse={onBrowse}
+      onClose={() => setOpen(false)}
+    />
   ) : null;
 
   if (isControlled) {

--- a/src/components/cwd/CwdPopoverPanel.tsx
+++ b/src/components/cwd/CwdPopoverPanel.tsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import { Folder } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { useTranslation } from '../../i18n/useTranslation';
+import type { PanelPosition } from './useCwdPanelPosition';
+
+export function truncateMiddle(path: string, max = 56): string {
+  if (path.length <= max) return path;
+  const head = Math.ceil((max - 1) / 2);
+  const tail = Math.floor((max - 1) / 2);
+  return `${path.slice(0, head)}…${path.slice(path.length - tail)}`;
+}
+
+export type CwdPopoverPanelProps = {
+  /** Whether the panel is rendered in controlled (anchored) mode. Affects
+   *  positioning classes + the inline `position: fixed` style. */
+  isControlled: boolean;
+  /** Measured fixed-position anchor coords (controlled mode only). */
+  panelPos: PanelPosition | null;
+  popRef: React.MutableRefObject<HTMLDivElement | null>;
+  inputRef: React.MutableRefObject<HTMLInputElement | null>;
+  cwd: string;
+  query: string;
+  setQuery: (q: string) => void;
+  setActive: (a: number | ((prev: number) => number)) => void;
+  active: number;
+  filtered: string[];
+  onListKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  onCommit: (path: string) => void;
+  onBrowse: () => void;
+  onClose: () => void;
+};
+
+/**
+ * Presentational panel JSX for {@link CwdPopover}. Pure props in / JSX out;
+ * owns no state. Both legacy (inline anchor) and controlled (fixed-portal)
+ * modes render the same panel, only the outer wrapper styling differs.
+ */
+export function CwdPopoverPanel(props: CwdPopoverPanelProps) {
+  const {
+    isControlled,
+    panelPos,
+    popRef,
+    inputRef,
+    cwd,
+    query,
+    setQuery,
+    setActive,
+    active,
+    filtered,
+    onListKeyDown,
+    onCommit,
+    onBrowse,
+    onClose,
+  } = props;
+  const { t } = useTranslation();
+
+  return (
+    <div
+      ref={popRef}
+      role="dialog"
+      aria-label={t('statusBar.workingDirectory')}
+      style={
+        isControlled && panelPos
+          ? { position: 'fixed', top: panelPos.top, left: panelPos.left }
+          : undefined
+      }
+      className={cn(
+        isControlled
+          ? 'z-50 min-w-[320px] max-w-[480px]'
+          : 'absolute left-0 bottom-full mb-1 z-40 min-w-[320px] max-w-[480px]',
+        'rounded-md border border-border-default bg-bg-elevated',
+        'surface-highlight shadow-[var(--surface-shadow)]',
+        'text-chrome text-fg-secondary overflow-hidden',
+        'animate-[menuIn_140ms_cubic-bezier(0.32,0.72,0,1)]'
+      )}
+      data-testid="cwd-popover-panel"
+    >
+      <div className="px-2 pt-2 pb-1.5 border-b border-border-subtle">
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          spellCheck={false}
+          autoComplete="off"
+          placeholder={cwd ? truncateMiddle(cwd, 48) : t('cwdPopover.placeholder')}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setActive(0);
+          }}
+          onKeyDown={onListKeyDown}
+          className={cn(
+            'w-full h-7 px-2 rounded-sm bg-bg-panel border border-border-subtle',
+            'font-mono text-mono-md text-fg-primary placeholder:text-fg-tertiary',
+            'outline-none focus:border-border-strong'
+          )}
+        />
+      </div>
+
+      <span className="block px-3 pt-1.5 pb-1 font-mono text-mono-sm text-fg-tertiary select-none">
+        {t('cwdPopover.recent')}
+      </span>
+      <ul className="max-h-[260px] overflow-y-auto pb-1" role="listbox">
+        {filtered.length === 0 ? (
+          <li className="px-3 py-2 text-fg-tertiary text-mono-md leading-[16px]">
+            {t('cwdPopover.empty')}
+          </li>
+        ) : (
+          filtered.map((path, i) => {
+            const isActive = i === active;
+            return (
+              <li
+                key={path}
+                role="option"
+                aria-selected={isActive}
+                onMouseEnter={() => setActive(i)}
+                // onMouseDown so the input doesn't blur first and close us.
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  onCommit(path);
+                }}
+                title={path}
+                className={cn(
+                  'flex items-center h-7 px-3 mx-1 rounded-sm cursor-pointer select-none',
+                  'transition-colors duration-120 ease-out',
+                  isActive
+                    ? 'bg-bg-hover text-fg-primary'
+                    : 'text-fg-secondary hover:bg-bg-hover/60'
+                )}
+              >
+                <span className="font-mono text-mono-md truncate">
+                  {truncateMiddle(path)}
+                </span>
+              </li>
+            );
+          })
+        )}
+      </ul>
+
+      <div className="border-t border-border-subtle px-1 py-1">
+        <button
+          type="button"
+          onMouseDown={(e) => {
+            e.preventDefault();
+            onClose();
+            onBrowse();
+          }}
+          className={cn(
+            'w-full flex items-center gap-2 h-7 px-2 mx-0 rounded-sm',
+            'text-fg-secondary hover:bg-bg-hover hover:text-fg-primary',
+            'outline-none focus-ring',
+            'transition-colors duration-120 ease-out text-left text-mono-md'
+          )}
+        >
+          <Folder size={12} className="stroke-[1.75] text-fg-tertiary" />
+          <span>{t('cwdPopover.browse')}</span>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/cwd/useCwdPanelPosition.ts
+++ b/src/components/cwd/useCwdPanelPosition.ts
@@ -1,3 +1,4 @@
+import type React from 'react';
 import { useLayoutEffect, useState } from 'react';
 
 // Minimum panel width — must match the `min-w-[320px]` Tailwind class on the

--- a/src/components/cwd/useCwdPanelPosition.ts
+++ b/src/components/cwd/useCwdPanelPosition.ts
@@ -1,0 +1,56 @@
+import { useLayoutEffect, useState } from 'react';
+
+// Minimum panel width — must match the `min-w-[320px]` Tailwind class on the
+// rendered panel. We clamp the computed `left` so popovers anchored close to
+// the right edge of the screen never overflow off-screen.
+const PANEL_MIN_WIDTH = 320;
+const VIEWPORT_PADDING = 8;
+
+export type PanelPosition = { top: number; left: number };
+
+/**
+ * Controlled-mode panel positioning. We compute screen coords from the
+ * external anchor's bounding rect on every open + on resize/scroll while
+ * open. Returns `null` until measured — caller should defer rendering the
+ * panel in controlled mode until a position is available, otherwise an
+ * unpositioned static block briefly pushes neighboring layout.
+ *
+ * Returned position is intended to be used as `position: 'fixed'` so the
+ * panel escapes any clipping ancestors (sidebar uses `overflow:hidden` +
+ * `backdrop-filter` which together would clip a non-portaled fixed
+ * descendant — see PR #598).
+ */
+export function useCwdPanelPosition(
+  anchorRef:
+    | React.RefObject<HTMLElement>
+    | React.RefObject<HTMLElement | null>
+    | null
+    | undefined,
+  open: boolean,
+  enabled: boolean
+): PanelPosition | null {
+  const [panelPos, setPanelPos] = useState<PanelPosition | null>(null);
+
+  useLayoutEffect(() => {
+    if (!enabled || !open) return;
+    const anchor = anchorRef?.current;
+    if (!anchor) return;
+    const recompute = () => {
+      const r = anchor.getBoundingClientRect();
+      const top = r.bottom + 4;
+      const maxLeft = window.innerWidth - PANEL_MIN_WIDTH - VIEWPORT_PADDING;
+      const left = Math.max(VIEWPORT_PADDING, Math.min(r.left, maxLeft));
+      setPanelPos({ top, left });
+    };
+    recompute();
+    window.addEventListener('resize', recompute);
+    window.addEventListener('scroll', recompute, true);
+    return () => {
+      window.removeEventListener('resize', recompute);
+      window.removeEventListener('scroll', recompute, true);
+      setPanelPos(null);
+    };
+  }, [anchorRef, enabled, open]);
+
+  return panelPos;
+}

--- a/src/components/cwd/useCwdRecentList.ts
+++ b/src/components/cwd/useCwdRecentList.ts
@@ -1,0 +1,101 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+const RECENT_LIMIT = 10;
+
+async function defaultLoadRecent(): Promise<string[]> {
+  type Bridge = { recentCwds?: () => Promise<string[]> };
+  const bridge =
+    typeof window !== 'undefined'
+      ? (window as unknown as { ccsm?: Bridge }).ccsm
+      : undefined;
+  try {
+    const list = await bridge?.recentCwds?.();
+    return Array.isArray(list) ? list : [];
+  } catch {
+    return [];
+  }
+}
+
+export type UseCwdRecentListResult = {
+  /** Filtered recent entries — `recent` narrowed by `query`. */
+  filtered: string[];
+  /** Current input value. */
+  query: string;
+  setQuery: (q: string) => void;
+  /** Active row index into `filtered`. */
+  active: number;
+  setActive: (a: number | ((prev: number) => number)) => void;
+  /** ArrowUp/ArrowDown/Enter handler for the input. */
+  onListKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+};
+
+/**
+ * Recent-cwd loader + filter + keyboard navigation hook.
+ *
+ * - Lazy-loads via `loadRecent` (defaults to the IPC bridge) on each `open` flip.
+ * - Resets query + active row each time the popover opens.
+ * - Filters `recent` by case-insensitive substring match against `query`.
+ * - Keeps `active` clamped within `filtered` length.
+ * - `onListKeyDown` provides ArrowUp/ArrowDown to move + Enter to commit
+ *   either the highlighted recent entry or the raw query (if non-empty).
+ */
+export function useCwdRecentList(
+  open: boolean,
+  loadRecent: (() => Promise<string[]>) | undefined,
+  commit: (path: string) => void
+): UseCwdRecentListResult {
+  const [query, setQuery] = useState('');
+  const [recent, setRecent] = useState<string[]>([]);
+  const [active, setActive] = useState(0);
+
+  // Reset query each time we re-open so the Recent list shows in full.
+  useEffect(() => {
+    if (!open) return;
+    setQuery('');
+    setActive(0);
+  }, [open]);
+
+  // Lazy-load recent cwds on each open.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    const loader = loadRecent ?? defaultLoadRecent;
+    void loader().then((list) => {
+      if (cancelled) return;
+      setRecent(list.slice(0, RECENT_LIMIT));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, loadRecent]);
+
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return recent;
+    return recent.filter((p) => p.toLowerCase().includes(needle));
+  }, [recent, query]);
+
+  // Clamp active row whenever the filtered list shrinks.
+  useEffect(() => {
+    if (active >= filtered.length) setActive(0);
+  }, [filtered.length, active]);
+
+  const onListKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setActive((a) => Math.min(a + 1, Math.max(0, filtered.length - 1)));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setActive((a) => Math.max(0, a - 1));
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        const choice = filtered[active] ?? (query.trim() ? query.trim() : null);
+        if (choice) commit(choice);
+      }
+    },
+    [active, commit, filtered, query]
+  );
+
+  return { filtered, query, setQuery, active, setActive, onListKeyDown };
+}

--- a/src/components/cwd/useCwdRecentList.ts
+++ b/src/components/cwd/useCwdRecentList.ts
@@ -1,3 +1,4 @@
+import type React from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 const RECENT_LIMIT = 10;

--- a/tests/components/cwd/useCwdPanelPosition.test.ts
+++ b/tests/components/cwd/useCwdPanelPosition.test.ts
@@ -1,0 +1,98 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useCwdPanelPosition } from '../../../src/components/cwd/useCwdPanelPosition';
+
+function makeAnchor(rect: Partial<DOMRect>): HTMLElement {
+  const el = document.createElement('div');
+  // jsdom defaults getBoundingClientRect to all zeros; override.
+  el.getBoundingClientRect = () =>
+    ({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      width: 0,
+      height: 0,
+      toJSON: () => ({}),
+      ...rect,
+    } as DOMRect);
+  document.body.appendChild(el);
+  return el;
+}
+
+describe('useCwdPanelPosition', () => {
+  let originalInner: number;
+  beforeEach(() => {
+    originalInner = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 1280,
+    });
+  });
+  afterEach(() => {
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: originalInner,
+    });
+    document.body.innerHTML = '';
+  });
+
+  it('returns null while disabled', () => {
+    const anchor = makeAnchor({ left: 100, bottom: 50 });
+    const ref = { current: anchor } as React.RefObject<HTMLElement>;
+    const { result } = renderHook(() => useCwdPanelPosition(ref, true, false));
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null while closed', () => {
+    const anchor = makeAnchor({ left: 100, bottom: 50 });
+    const ref = { current: anchor } as React.RefObject<HTMLElement>;
+    const { result } = renderHook(() => useCwdPanelPosition(ref, false, true));
+    expect(result.current).toBeNull();
+  });
+
+  it('positions below anchor with 4px gap, left-aligned to anchor', () => {
+    const anchor = makeAnchor({ left: 100, bottom: 50 });
+    const ref = { current: anchor } as React.RefObject<HTMLElement>;
+    const { result } = renderHook(() => useCwdPanelPosition(ref, true, true));
+    expect(result.current).toEqual({ top: 54, left: 100 });
+  });
+
+  it('clamps left so the panel never overflows the right viewport edge', () => {
+    // viewport=1280, panel min-w 320, padding 8 -> maxLeft = 952
+    const anchor = makeAnchor({ left: 1200, bottom: 30 });
+    const ref = { current: anchor } as React.RefObject<HTMLElement>;
+    const { result } = renderHook(() => useCwdPanelPosition(ref, true, true));
+    expect(result.current).toEqual({ top: 34, left: 952 });
+  });
+
+  it('clamps left to padding when anchor is past the left viewport edge', () => {
+    const anchor = makeAnchor({ left: -50, bottom: 20 });
+    const ref = { current: anchor } as React.RefObject<HTMLElement>;
+    const { result } = renderHook(() => useCwdPanelPosition(ref, true, true));
+    expect(result.current).toEqual({ top: 24, left: 8 });
+  });
+
+  it('recomputes on window resize', () => {
+    const anchor = makeAnchor({ left: 1200, bottom: 30 });
+    const ref = { current: anchor } as React.RefObject<HTMLElement>;
+    const { result } = renderHook(() => useCwdPanelPosition(ref, true, true));
+    expect(result.current?.left).toBe(952);
+    // Shrink viewport so maxLeft drops further.
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 800,
+    });
+    act(() => {
+      window.dispatchEvent(new Event('resize'));
+    });
+    // maxLeft = 800 - 320 - 8 = 472
+    expect(result.current?.left).toBe(472);
+  });
+});

--- a/tests/components/cwd/useCwdRecentList.test.ts
+++ b/tests/components/cwd/useCwdRecentList.test.ts
@@ -1,0 +1,98 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useCwdRecentList } from '../../../src/components/cwd/useCwdRecentList';
+
+const SAMPLE = [
+  '/home/alice/projects/agentory',
+  '/home/alice/projects/agentory-next',
+  '/home/alice/work/cli-tools',
+  '/tmp/scratch-pad',
+];
+
+function setup(open = true) {
+  const commit = vi.fn();
+  const loadRecent = vi.fn(async () => SAMPLE);
+  const result = renderHook(({ openVal }) =>
+    useCwdRecentList(openVal, loadRecent, commit), {
+    initialProps: { openVal: open },
+  });
+  return { ...result, commit, loadRecent };
+}
+
+describe('useCwdRecentList', () => {
+  it('loads recent entries when open flips true', async () => {
+    const { result, loadRecent } = setup(true);
+    await waitFor(() => {
+      expect(loadRecent).toHaveBeenCalled();
+      expect(result.current.filtered).toEqual(SAMPLE);
+    });
+  });
+
+  it('filters entries by case-insensitive substring of query', async () => {
+    const { result } = setup(true);
+    await waitFor(() => expect(result.current.filtered.length).toBe(SAMPLE.length));
+    act(() => result.current.setQuery('CLI'));
+    await waitFor(() => {
+      expect(result.current.filtered).toHaveLength(1);
+      expect(result.current.filtered[0]).toMatch(/cli-tools/);
+    });
+  });
+
+  it('ArrowDown / ArrowUp move active row, clamped to bounds', async () => {
+    const { result } = setup(true);
+    await waitFor(() => expect(result.current.filtered.length).toBe(SAMPLE.length));
+    expect(result.current.active).toBe(0);
+
+    const down = (preventDefault = () => {}) =>
+      ({ key: 'ArrowDown', preventDefault } as unknown as React.KeyboardEvent<HTMLInputElement>);
+    const up = (preventDefault = () => {}) =>
+      ({ key: 'ArrowUp', preventDefault } as unknown as React.KeyboardEvent<HTMLInputElement>);
+
+    act(() => result.current.onListKeyDown(down()));
+    expect(result.current.active).toBe(1);
+    act(() => result.current.onListKeyDown(down()));
+    act(() => result.current.onListKeyDown(down()));
+    act(() => result.current.onListKeyDown(down()));
+    // Clamped at last index (SAMPLE.length - 1 = 3).
+    expect(result.current.active).toBe(SAMPLE.length - 1);
+
+    act(() => result.current.onListKeyDown(up()));
+    expect(result.current.active).toBe(SAMPLE.length - 2);
+    // Clamp at 0 going up.
+    act(() => result.current.onListKeyDown(up()));
+    act(() => result.current.onListKeyDown(up()));
+    act(() => result.current.onListKeyDown(up()));
+    expect(result.current.active).toBe(0);
+  });
+
+  it('Enter commits the highlighted entry', async () => {
+    const { result, commit } = setup(true);
+    await waitFor(() => expect(result.current.filtered.length).toBe(SAMPLE.length));
+    const down = () => ({ key: 'ArrowDown', preventDefault: () => {} } as unknown as React.KeyboardEvent<HTMLInputElement>);
+    const enter = () => ({ key: 'Enter', preventDefault: () => {} } as unknown as React.KeyboardEvent<HTMLInputElement>);
+    act(() => result.current.onListKeyDown(down()));
+    act(() => result.current.onListKeyDown(enter()));
+    expect(commit).toHaveBeenCalledWith(SAMPLE[1]);
+  });
+
+  it('Enter on empty filtered list with non-empty query commits the raw query', async () => {
+    const { result, commit } = setup(true);
+    await waitFor(() => expect(result.current.filtered.length).toBe(SAMPLE.length));
+    act(() => result.current.setQuery('zzz-no-match-zzz'));
+    await waitFor(() => expect(result.current.filtered).toHaveLength(0));
+    const enter = () => ({ key: 'Enter', preventDefault: () => {} } as unknown as React.KeyboardEvent<HTMLInputElement>);
+    act(() => result.current.onListKeyDown(enter()));
+    expect(commit).toHaveBeenCalledWith('zzz-no-match-zzz');
+  });
+
+  it('clamps active row when filtered shrinks below current active', async () => {
+    const { result } = setup(true);
+    await waitFor(() => expect(result.current.filtered.length).toBe(SAMPLE.length));
+    act(() => result.current.setActive(3));
+    expect(result.current.active).toBe(3);
+    act(() => result.current.setQuery('cli'));
+    await waitFor(() => expect(result.current.filtered).toHaveLength(1));
+    await waitFor(() => expect(result.current.active).toBe(0));
+  });
+});


### PR DESCRIPTION
## Wave-2 SRP scan rationale (section 3.2)

`src/components/CwdPopover.tsx` (448 LoC) bundled four distinct concerns behind the dual-mode `LegacyProps | ControlledProps` discrimination:

1. Anchor positioning (`useLayoutEffect` measuring external anchor rect, recomputing on resize/scroll, viewport clamping).
2. Recent-cwd loading + filtering + ArrowUp/Down/Enter keyboard navigation.
3. Panel JSX (~140 LoC of input + listbox + browse button).
4. Host glue (mode arbiter, legacy trigger button with cwd-missing warning + first-hover discoverability pulse, click-outside/Escape, portal).

Concerns 1-3 are independently testable in isolation; concern 4 is the host that wires them together and renders the legacy embedded trigger.

## File-by-file mapping

| Old (CwdPopover.tsx) | New |
| --- | --- |
| `useLayoutEffect` for `panelPos` (lines 146-170) + `PANEL_MIN_WIDTH`/`VIEWPORT_PADDING` constants | `src/components/cwd/useCwdPanelPosition.ts` |
| `defaultLoadRecent`, `RECENT_LIMIT`, `query`/`recent`/`active` state, load+reset effects, `filtered` memo, clamp effect, `onListKeyDown` | `src/components/cwd/useCwdRecentList.ts` |
| `panel = showPanel ? (<div role=dialog>...)` JSX block + `truncateMiddle` helper | `src/components/cwd/CwdPopoverPanel.tsx` |
| Mode arbiter, public `LegacyProps \| ControlledProps` union, store mutex glue, click-outside/Escape, hover-hint state, legacy trigger button, portal | `src/components/CwdPopover.tsx` (slim host) |

## LoC change

| File | LoC |
| --- | --- |
| `src/components/CwdPopover.tsx` (host) | 448 → 258 |
| `src/components/cwd/useCwdPanelPosition.ts` | +56 |
| `src/components/cwd/useCwdRecentList.ts` | +101 |
| `src/components/cwd/CwdPopoverPanel.tsx` | +161 |

Host shrunk by ~190 LoC. Slightly above the ~150 stretch target because the host still owns: per-mode click-outside (needs both `popRef` + `triggerRef` + external `anchorRef`), the legacy chip JSX with cwd-missing tooltip + hover-hint discoverability ring (task328), portal decision, and prop-shape arbitration. All of these are coupled to the public `Props` union and would either re-introduce prop drilling or require the host to learn JSX details if extracted further.

## Public type preservation

Confirmed: `LegacyProps`, `ControlledProps`, `CommonProps`, and the exported `CwdPopover(props: Props)` signature are byte-identical to before. `tests/cwd-popover.test.tsx` passes unchanged with no edits.

## Verification outputs

```text
npm run typecheck
> tsc --noEmit && tsc --noEmit -p tsconfig.electron.json
(clean)

npm run build
webpack 5.106.2 compiled with 3 warnings in 19432 ms
(only pre-existing bundle-size warnings)

npx vitest run tests/cwd-popover.test.tsx tests/components/cwd/
 ✓ tests/components/cwd/useCwdPanelPosition.test.ts (6 tests)
 ✓ tests/components/cwd/useCwdRecentList.test.ts (6 tests)
 ✓ tests/cwd-popover.test.tsx (14 tests)
 Test Files  3 passed (3)
      Tests  26 passed (26)
```

- Existing `tests/cwd-popover.test.tsx`: all 14 cases green, no test changes.
- New `tests/components/cwd/useCwdRecentList.test.ts`: 6 cases — load on open, case-insensitive substring filter, ArrowUp/Down clamping, Enter commits highlighted entry, Enter on empty filtered list with non-empty query commits the raw query, active-row clamp on shrink.
- New `tests/components/cwd/useCwdPanelPosition.test.ts`: 6 cases — null while disabled / closed, gap-below-anchor positioning, right-edge clamp, left-edge clamp, recompute on resize.

Per `feedback_trust_ci_mode.md`: e2e left to CI, no local probe.

Task #770.