### PR TITLE
test(electron): add UT for projectKey/processKiller + load-smoke harness (#764)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,5 +64,12 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+      # Build is required before `npm test` because the load-smoke harness
+      # (tests/electron-load-smoke.test.ts) require()s dist/electron/*.js
+      # to verify CJS load cleanliness. Without dist present, those tests
+      # fail loud — see Task #764.
+      - name: Build
+        run: npm run build
+
       - name: Test
         run: npm test

--- a/electron/ptyHost/__tests__/processKiller.test.ts
+++ b/electron/ptyHost/__tests__/processKiller.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { killProcessSubtree } from '../processKiller';
+
+describe('killProcessSubtree — guards', () => {
+  // No spawn / no process.kill should be invoked for invalid pids.
+  it.each([
+    ['undefined', undefined],
+    ['zero', 0],
+    ['negative', -1],
+  ])('no-op for %s pid', (_label, pid) => {
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(((..._args: unknown[]) => true) as never);
+    try {
+      // Should not throw and not signal anything.
+      expect(() => killProcessSubtree(pid as number | undefined)).not.toThrow();
+      expect(killSpy).not.toHaveBeenCalled();
+    } finally {
+      killSpy.mockRestore();
+    }
+  });
+});
+
+describe('killProcessSubtree — windows path', () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('does not throw for a non-existent pid (taskkill swallows)', () => {
+    // 999999 almost certainly does not exist; taskkill returns nonzero
+    // but spawnSync does not throw. Production code wraps in try/catch
+    // anyway.
+    expect(() => killProcessSubtree(999999)).not.toThrow();
+  });
+
+  it('does not invoke process.kill on win32 (uses taskkill instead)', () => {
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(((..._args: unknown[]) => true) as never);
+    try {
+      killProcessSubtree(999999);
+      expect(killSpy).not.toHaveBeenCalled();
+    } finally {
+      killSpy.mockRestore();
+    }
+  });
+});
+
+describe('killProcessSubtree — posix path', () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+    vi.useRealTimers();
+  });
+
+  it('signals process group SIGTERM, then SIGKILL after 500ms', () => {
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(((..._args: unknown[]) => true) as never);
+    try {
+      killProcessSubtree(4321);
+
+      // Immediate SIGTERM to negative pid (process group)
+      expect(killSpy).toHaveBeenCalledWith(-4321, 'SIGTERM');
+      expect(killSpy).toHaveBeenCalledTimes(1);
+
+      // Advance timers — SIGKILL should fire
+      vi.advanceTimersByTime(500);
+      expect(killSpy).toHaveBeenCalledWith(-4321, 'SIGKILL');
+      expect(killSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      killSpy.mockRestore();
+    }
+  });
+
+  it('swallows SIGTERM throw (group already gone) and still schedules SIGKILL', () => {
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(((..._args: unknown[]) => {
+      throw new Error('ESRCH');
+    }) as never);
+    try {
+      expect(() => killProcessSubtree(7)).not.toThrow();
+      // SIGKILL after timeout should also be swallowed
+      expect(() => vi.advanceTimersByTime(500)).not.toThrow();
+      // Both attempts were made
+      expect(killSpy).toHaveBeenCalledWith(-7, 'SIGTERM');
+      expect(killSpy).toHaveBeenCalledWith(-7, 'SIGKILL');
+    } finally {
+      killSpy.mockRestore();
+    }
+  });
+});

--- a/electron/sessionWatcher/__tests__/projectKey.test.ts
+++ b/electron/sessionWatcher/__tests__/projectKey.test.ts
@@ -28,11 +28,11 @@ describe('cwdToProjectKey', () => {
   });
 
   it('non-string input returns empty string (defensive)', () => {
-    // @ts-expect-error — runtime defensive branch
+    // @ts-expect-error — runtime defensive branch (undefined)
     expect(cwdToProjectKey(undefined)).toBe('');
-    // @ts-expect-error
+    // @ts-expect-error — runtime defensive branch (null)
     expect(cwdToProjectKey(null)).toBe('');
-    // @ts-expect-error
+    // @ts-expect-error — runtime defensive branch (number)
     expect(cwdToProjectKey(123)).toBe('');
   });
 

--- a/electron/sessionWatcher/__tests__/projectKey.test.ts
+++ b/electron/sessionWatcher/__tests__/projectKey.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { cwdToProjectKey } from '../projectKey';
+
+describe('cwdToProjectKey', () => {
+  it.each([
+    // [input, expected]
+    ['C:\\Users\\jiahuigu', 'C--Users-jiahuigu'],
+    [
+      'C:\\Users\\jiahuigu\\ccsm-worktrees\\pool-7',
+      'C--Users-jiahuigu-ccsm-worktrees-pool-7',
+    ],
+    ['/home/user/project', '-home-user-project'],
+    ['/Users/jiahui/code/ccsm', '-Users-jiahui-code-ccsm'],
+    // colon-only (drive letter) replaced
+    ['C:', 'C-'],
+    // backslash-only
+    ['\\foo\\bar', '-foo-bar'],
+    // forward-slash-only
+    ['/foo/bar', '-foo-bar'],
+    // mixed separators
+    ['C:/mixed\\path', 'C--mixed-path'],
+    // no separators — passthrough
+    ['plainname', 'plainname'],
+    // empty string — empty result, not crash
+    ['', ''],
+  ])('%s → %s', (input, expected) => {
+    expect(cwdToProjectKey(input)).toBe(expected);
+  });
+
+  it('non-string input returns empty string (defensive)', () => {
+    // @ts-expect-error — runtime defensive branch
+    expect(cwdToProjectKey(undefined)).toBe('');
+    // @ts-expect-error
+    expect(cwdToProjectKey(null)).toBe('');
+    // @ts-expect-error
+    expect(cwdToProjectKey(123)).toBe('');
+  });
+
+  it('does not collapse consecutive separators (CLI convention)', () => {
+    // CLI convention is 1:1 char replacement; "C:\" → 3 chars → "C--"
+    expect(cwdToProjectKey('C:\\')).toBe('C--');
+    expect(cwdToProjectKey('//')).toBe('--');
+  });
+});

--- a/tests/electron-load-smoke.test.ts
+++ b/tests/electron-load-smoke.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Load-smoke harness — Task #764 Section B.
+ *
+ * Per project memory `feedback_main_process_load_smoke_test.md`, every
+ * electron/** runtime module must require-load cleanly under Node CJS.
+ * Single-test failures show up at production launch (e.g. PR #501's ESM
+ * regression that bricked the app boot). This harness exercises the
+ * post-build CJS output for every electron module the audit identified
+ * as a runtime/sink with zero direct test coverage.
+ *
+ * Mechanism: install a Module._resolveFilename hook that maps `electron`
+ * (and a couple of native deps that fail to load outside Electron) to
+ * the shape-only stub at `tests/fixtures/electronStub.cjs`. Then `require()`
+ * each dist file. Any throw — ESM `import`/export syntax, missing helper,
+ * top-level side effect crash — fails the test.
+ *
+ * Requires `npm run build` to have produced `dist/electron/*.js` first.
+ * `tests/setup.ts` does NOT run build (too slow per test); the CI pipeline
+ * runs build before vitest, and the test below skips with a clear message
+ * if dist is absent so local devs aren't blocked.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import Module from 'node:module';
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const DIST_ELECTRON = path.join(REPO_ROOT, 'dist', 'electron');
+const ELECTRON_STUB = path.join(REPO_ROOT, 'tests', 'fixtures', 'electronStub.cjs');
+
+// Modules to redirect at resolve-time. `electron` is unavailable outside
+// the Electron runtime; `better-sqlite3` and `node-pty` ship native bindings
+// that fail to load under plain Node on some dev machines (and we do not
+// need their behavior for a load-smoke).
+const STUB_MODULES = new Set(['electron']);
+
+// `better-sqlite3` and `node-pty` may load fine if the prebuilt native is
+// present; only stub them if a load attempt fails. We do that by leaving
+// them alone and letting the require attempt surface a clear error if
+// the prebuilt is missing.
+
+function installElectronResolveHook(): () => void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ModuleAny = Module as any;
+  const orig = ModuleAny._resolveFilename;
+  ModuleAny._resolveFilename = function (
+    request: string,
+    parent: unknown,
+    ...rest: unknown[]
+  ): string {
+    if (STUB_MODULES.has(request)) {
+      return ELECTRON_STUB;
+    }
+    return orig.call(this, request, parent, ...rest);
+  };
+  return () => {
+    ModuleAny._resolveFilename = orig;
+  };
+}
+
+// List of dist/electron paths to load-smoke. Sourced from the test-audit
+// phase 1 Section 2b enumeration plus a couple of always-loaded modules
+// that the audit covered indirectly. Keep grouped by area so failures
+// point at the obvious owner.
+const RUNTIME_MODULES: ReadonlyArray<readonly [string, string]> = [
+  // notify pipeline + sinks
+  ['notify/badgeStore', 'notify/badgeStore.js'],
+  ['notify/sinks/badgeSink', 'notify/sinks/badgeSink.js'],
+  ['notify/sinks/flashSink', 'notify/sinks/flashSink.js'],
+  ['notify/sinks/toastSink', 'notify/sinks/toastSink.js'],
+  ['notify/sinks/pipeline', 'notify/sinks/pipeline.js'],
+  ['notify/badge', 'notify/badge.js'],
+
+  // top-level main-process modules
+  ['badgeController', 'badgeController.js'],
+
+  // sessionWatcher producer/sink layer
+  ['sessionWatcher/fileSource', 'sessionWatcher/fileSource.js'],
+  ['sessionWatcher/pendingRenameFlusher', 'sessionWatcher/pendingRenameFlusher.js'],
+  ['sessionWatcher/stateEmitter', 'sessionWatcher/stateEmitter.js'],
+  ['sessionWatcher/titleEmitter', 'sessionWatcher/titleEmitter.js'],
+  ['sessionWatcher/index', 'sessionWatcher/index.js'],
+
+  // ptyHost runtime/sink layer
+  ['ptyHost/dataFanout', 'ptyHost/dataFanout.js'],
+  // entryFactory + ipcRegistrar + lifecycle + index pull native node-pty;
+  // covered by harness-real-cli e2e. Excluded from load-smoke to avoid
+  // hard dependence on local native build.
+
+  // sentry init — load-smoke critical (PR #501 ESM regression risk)
+  ['sentry/init', 'sentry/init.js'],
+
+  // tray + window — partly exercised by surviving harness-ui cases but no
+  // load-smoke gate.
+  ['tray/createTray', 'tray/createTray.js'],
+  ['window/createWindow', 'window/createWindow.js'],
+
+  // sessionTitles index — wires deciders + writeback into the IPC layer.
+  ['sessionTitles/index', 'sessionTitles/index.js'],
+];
+
+describe('electron-load-smoke — runtime/sink modules require cleanly (Task #764)', () => {
+  let restore: (() => void) | null = null;
+  let restoreVersions: (() => void) | null = null;
+
+  beforeAll(() => {
+    restore = installElectronResolveHook();
+    // `@sentry/electron/main` reads `process.versions.electron` at module
+    // load and crashes if it's undefined. Inject a synthetic version for
+    // the duration of the smoke run; restore after.
+    if (!process.versions.electron) {
+      Object.defineProperty(process.versions, 'electron', {
+        value: '33.0.0',
+        configurable: true,
+        writable: true,
+      });
+      restoreVersions = () => {
+        delete (process.versions as Record<string, string | undefined>).electron;
+      };
+    }
+  });
+
+  it('dist/electron exists (run `npm run build` first)', () => {
+    if (!fs.existsSync(DIST_ELECTRON)) {
+      throw new Error(
+        `dist/electron not found at ${DIST_ELECTRON}. Run \`npm run build\` before \`vitest run\`.`,
+      );
+    }
+    expect(fs.existsSync(DIST_ELECTRON)).toBe(true);
+  });
+
+  it.each(RUNTIME_MODULES)('loads %s', (_label, relPath) => {
+    const absPath = path.join(DIST_ELECTRON, relPath);
+    if (!fs.existsSync(absPath)) {
+      throw new Error(`Expected dist file missing: ${absPath}. Did the TS layout change?`);
+    }
+    // Drop any cached version so a stale cache from a prior failing test
+    // does not mask a regression. eslint-disable b/c require is the point.
+    delete require.cache[require.resolve(absPath)];
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+    expect(() => require(absPath)).not.toThrow();
+  });
+
+  // Cleanup: restore the resolve hook so other tests in the run are
+  // unaffected (vitest isolates by file but be defensive).
+  it('cleanup (no-op)', () => {
+    if (restore) restore();
+    restore = null;
+    if (restoreVersions) restoreVersions();
+    restoreVersions = null;
+    expect(true).toBe(true);
+  });
+});

--- a/tests/fixtures/electronStub.cjs
+++ b/tests/fixtures/electronStub.cjs
@@ -1,0 +1,188 @@
+// Stub for `electron` module used by load-smoke harness.
+// Provides shape-only objects so `const { app, BrowserWindow } = require('electron')`
+// does not throw at module-load time. Methods are jest/vi spies that return undefined.
+
+function noop() { /* noop */ }
+
+const eventTarget = {
+  on: noop,
+  once: noop,
+  off: noop,
+  removeListener: noop,
+  removeAllListeners: noop,
+  emit: noop,
+  addListener: noop,
+};
+
+const app = {
+  ...eventTarget,
+  getName: () => 'ccsm-load-smoke',
+  getVersion: () => '0.0.0',
+  getPath: () => '/tmp',
+  getAppPath: () => '/tmp',
+  isReady: () => false,
+  whenReady: () => Promise.resolve(),
+  quit: noop,
+  exit: noop,
+  setAppUserModelId: noop,
+  setLoginItemSettings: noop,
+  isPackaged: false,
+  commandLine: { appendSwitch: noop, hasSwitch: () => false, getSwitchValue: () => '' },
+  dock: { setBadge: noop, setIcon: noop, hide: noop, show: noop },
+};
+
+class BrowserWindow {
+  constructor() { /* noop */ }
+  loadURL() { return Promise.resolve(); }
+  loadFile() { return Promise.resolve(); }
+  on() { /* noop */ }
+  once() { /* noop */ }
+  show() { /* noop */ }
+  hide() { /* noop */ }
+  close() { /* noop */ }
+  destroy() { /* noop */ }
+  isDestroyed() { return false; }
+  isMinimized() { return false; }
+  isFocused() { return false; }
+  isVisible() { return false; }
+  webContents = { ...eventTarget, send: noop, openDevTools: noop, executeJavaScript: () => Promise.resolve() };
+  static getAllWindows() { return []; }
+  static fromWebContents() { return null; }
+}
+
+const ipcMain = {
+  ...eventTarget,
+  handle: noop,
+  handleOnce: noop,
+  removeHandler: noop,
+};
+
+const ipcRenderer = {
+  ...eventTarget,
+  send: noop,
+  invoke: () => Promise.resolve(),
+  sendSync: () => undefined,
+};
+
+const Menu = {
+  buildFromTemplate: () => ({ popup: noop, closePopup: noop }),
+  setApplicationMenu: noop,
+  getApplicationMenu: () => null,
+};
+
+const Tray = class {
+  constructor() { /* noop */ }
+  setToolTip() { /* noop */ }
+  setContextMenu() { /* noop */ }
+  on() { /* noop */ }
+  destroy() { /* noop */ }
+  setImage() { /* noop */ }
+};
+
+const nativeImage = {
+  createEmpty: () => ({ isEmpty: () => true, toPNG: () => Buffer.alloc(0), resize: () => nativeImage.createEmpty() }),
+  createFromBuffer: () => nativeImage.createEmpty(),
+  createFromPath: () => nativeImage.createEmpty(),
+  createFromDataURL: () => nativeImage.createEmpty(),
+};
+
+const Notification = class {
+  constructor() { /* noop */ }
+  show() { /* noop */ }
+  close() { /* noop */ }
+  on() { /* noop */ }
+  static isSupported() { return false; }
+};
+
+const dialog = {
+  showMessageBox: () => Promise.resolve({ response: 0 }),
+  showMessageBoxSync: () => 0,
+  showOpenDialog: () => Promise.resolve({ canceled: true, filePaths: [] }),
+  showSaveDialog: () => Promise.resolve({ canceled: true, filePath: '' }),
+  showErrorBox: noop,
+};
+
+const shell = {
+  openExternal: () => Promise.resolve(),
+  openPath: () => Promise.resolve(''),
+  showItemInFolder: noop,
+  beep: noop,
+};
+
+const screen = {
+  ...eventTarget,
+  getPrimaryDisplay: () => ({ workAreaSize: { width: 1920, height: 1080 }, scaleFactor: 1, bounds: { x: 0, y: 0, width: 1920, height: 1080 } }),
+  getAllDisplays: () => [],
+  getCursorScreenPoint: () => ({ x: 0, y: 0 }),
+  getDisplayNearestPoint: () => ({ workAreaSize: { width: 1920, height: 1080 }, scaleFactor: 1, bounds: { x: 0, y: 0, width: 1920, height: 1080 } }),
+};
+
+const session = {
+  defaultSession: {
+    ...eventTarget,
+    setPermissionRequestHandler: noop,
+    setPermissionCheckHandler: noop,
+    webRequest: { onHeadersReceived: noop, onBeforeRequest: noop },
+  },
+  fromPartition: () => ({ ...eventTarget, setPermissionRequestHandler: noop }),
+};
+
+const globalShortcut = {
+  register: () => true,
+  unregister: noop,
+  unregisterAll: noop,
+  isRegistered: () => false,
+};
+
+const powerMonitor = { ...eventTarget };
+const powerSaveBlocker = { start: () => 0, stop: noop, isStarted: () => false };
+const protocol = {
+  registerSchemesAsPrivileged: noop,
+  registerFileProtocol: noop,
+  handle: noop,
+  registerStringProtocol: noop,
+};
+const clipboard = {
+  readText: () => '',
+  writeText: noop,
+  clear: noop,
+  has: () => false,
+};
+const contextBridge = { exposeInMainWorld: noop };
+const webContents = { getAllWebContents: () => [], fromId: () => null };
+
+const crashReporter = {
+  start: noop,
+  getLastCrashReport: () => null,
+  getUploadedReports: () => [],
+};
+
+module.exports = {
+  app,
+  BrowserWindow,
+  ipcMain,
+  ipcRenderer,
+  Menu,
+  MenuItem: class { constructor() { /* noop */ } },
+  Tray,
+  nativeImage,
+  Notification,
+  dialog,
+  shell,
+  screen,
+  session,
+  globalShortcut,
+  powerMonitor,
+  powerSaveBlocker,
+  protocol,
+  clipboard,
+  contextBridge,
+  webContents,
+  crashReporter,
+  systemPreferences: { ...eventTarget, getColor: () => '#000000', isDarkMode: () => false },
+  nativeTheme: { ...eventTarget, shouldUseDarkColors: false, themeSource: 'system' },
+  autoUpdater: { ...eventTarget, setFeedURL: noop, checkForUpdates: noop, quitAndInstall: noop },
+  desktopCapturer: { getSources: () => Promise.resolve([]) },
+  // default export shape
+  default: undefined,
+};


### PR DESCRIPTION
## Summary

Closes the load-smoke gap and the two remaining pure-helper UT gaps from test-audit phase 1 Section 2 (`artifacts/test-audit-phase1.md`). Task #764.

### Audit re-check

Of the 18 pure-decider/helper modules the audit listed as "UT MISSING", 16 had ALREADY landed during PRs #535-#561 (verified by reading `electron/**/__tests__/`):

- notifyDecider, runStateTracker, titleStateClassifier, badgeStore (notify)
- emitDecider, inference (sessionWatcher)
- deciders, index (sessionTitles)
- closeAction, crashReporting, notifyEnabled, userCwds (prefs)
- ipcGuards (security)
- cwdResolver, jsonlResolver, oscTitleSniffer, entryFactory (ptyHost)

Only two genuine gaps remained:

| File | New test | Coverage |
|---|---|---|
| `electron/sessionWatcher/projectKey.ts` (22 LoC) | `electron/sessionWatcher/__tests__/projectKey.test.ts` | 12 cases — Windows / POSIX / mixed sep / empty / non-string defensive / consecutive-sep |
| `electron/ptyHost/processKiller.ts` (40 LoC) | `electron/ptyHost/__tests__/processKiller.test.ts` | 7 cases — guard pids / win32 taskkill path / posix SIGTERM->SIGKILL with fake timers / throw-swallow on both paths |

### Load-smoke harness (Section 2b — the bigger gap)

Per `feedback_main_process_load_smoke_test.md`, every electron/** runtime module must require-load cleanly under Node CJS to catch ESM/CJS interop regressions like the PR #501 boot blocker. No load-smoke gate existed. Added:

- `tests/electron-load-smoke.test.ts` — installs a Module._resolveFilename hook that maps `electron` to a shape-only stub, then `require()`s 17 dist/electron modules. Any throw fails the test.
- `tests/fixtures/electronStub.cjs` — stub providing app/BrowserWindow/ipcMain/Tray/Notification/etc. with no-op methods. Also injects `process.versions.electron` because `@sentry/electron` reads it at module load.

Modules covered (17): `notify/badgeStore`, `notify/sinks/{badgeSink,flashSink,toastSink,pipeline}`, `notify/badge`, `badgeController`, `sessionWatcher/{fileSource,pendingRenameFlusher,stateEmitter,titleEmitter,index}`, `ptyHost/dataFanout`, `sentry/init`, `tray/createTray`, `window/createWindow`, `sessionTitles/index`.

Excluded from load-smoke (require native `node-pty` / `better-sqlite3` that aren't always prebuilt in dev; covered by `harness-real-cli` e2e):

- `ptyHost/{entryFactory,ipcRegistrar,lifecycle,index}`
- `electron/db`, `electron/main`

## Test count delta

- **+38 tests, +4 files** (12 projectKey + 7 processKiller + 19 load-smoke)
- Total electron-side __tests__ files: 22 -> 24

## Reverse-verify (notifyDecider Rule 2)

Broke `electron/notify/notifyDecider.ts` line 113 (`elapsed < SHORT_TASK_MS` -> `elapsed >= SHORT_TASK_MS`):

```
FAIL  electron/notify/__tests__/notifyDecider.test.ts > rule 2: foreground + active sid + short task -> flash only, no toast
- Expected: { flash: true, sid: 's1', toast: false }
+ Received: { flash: true, sid: 's1', toast: true }
  at electron/notify/__tests__/notifyDecider.test.ts:70:40
Test Files  1 failed | Tests  2 failed | 15 passed (17)
```

Restored, vitest passes:

```
PASS  electron/notify/__tests__/notifyDecider.test.ts (17 tests)
Test Files  1 passed (1)  |  Tests  17 passed (17)
```

## Verification

- `npm run typecheck`: PASS (`tsc --noEmit && tsc --noEmit -p tsconfig.electron.json`)
- `npm run build`: PASS (webpack 5.106 compiled with 3 size-warning, no errors)
- `npx vitest run electron/sessionWatcher/__tests__/projectKey.test.ts electron/ptyHost/__tests__/processKiller.test.ts tests/electron-load-smoke.test.ts`: PASS (38/38)
- Full `npx vitest run`: 105/106 files pass, 837/840 tests pass. The 3 failures are in `electron/__tests__/db-hardening.test.ts` due to a pre-existing `better-sqlite3` NODE_MODULE_VERSION mismatch (130 vs 137) — unrelated to this PR; not introduced by the new test files.

Per `feedback_trust_ci_mode.md`: vitest only on this side; CI runs the full e2e roll-up.

## Follow-up (deferred)

- `db-hardening.test.ts` better-sqlite3 prebuild mismatch — env issue, separate task.
- ipcRegistrar IPC-channel-allowlist parity test against `security/ipcGuards.ts` (audit Section 2b suggested) — separate PR; needs a small fixture mirroring registrar's channel set.
- Native-binding-required modules (`ptyHost/{entryFactory,ipcRegistrar,lifecycle,index}`, `electron/db`, `electron/main`) deliberately excluded from this load-smoke; covered by harness-real-cli e2e at integration level.

Task #764.