### PR TITLE
test(sidebar): add 3 RTL guards from PR #569 follow-up (#784 #785 #788)

### DIFF
--- a/tests/components/AgentIcon-state-attr.test.tsx
+++ b/tests/components/AgentIcon-state-attr.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { AgentIcon } from '../../src/components/AgentIcon';
+import type { SessionState } from '../../src/types';
+
+// Task #785: regression guard — AgentIcon must expose its current state via
+// the `data-agent-icon-state` attribute so e2e selectors that target
+// `[data-agent-icon-state="waiting"]` keep working. Silently dropping the
+// attribute would break harness-agent probes without breaking unit tests.
+describe('<AgentIcon /> data-agent-icon-state attribute (#785)', () => {
+  afterEach(() => cleanup());
+
+  // Mirrors the public union from src/types.ts — keep in sync if extended.
+  const STATES: SessionState[] = ['idle', 'waiting'];
+
+  for (const state of STATES) {
+    it(`renders data-agent-icon-state="${state}"`, () => {
+      const { container } = render(
+        <AgentIcon agentType="claude-code" state={state} />
+      );
+      const el = container.querySelector(`[data-agent-icon-state]`);
+      expect(el).toBeTruthy();
+      expect(el!.getAttribute('data-agent-icon-state')).toBe(state);
+    });
+  }
+});

--- a/tests/sidebar/session-row-dot-selection.test.tsx
+++ b/tests/sidebar/session-row-dot-selection.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { DndContext } from '@dnd-kit/core';
+import { SortableContext } from '@dnd-kit/sortable';
+import { SessionRow } from '../../src/components/sidebar/SessionRow';
+import { useStore } from '../../src/stores/store';
+import { ToastProvider } from '../../src/components/ui/Toast';
+import type { Group, Session } from '../../src/types';
+
+// Task #784: regression guard — only the active SessionRow should render the
+// "open in chat" selection dot (the small bg-accent pip on the right rail).
+// A prior regression leaked the dot to every row when the `active` gate was
+// dropped. We render three rows with one of them active and assert the dot
+// count is exactly one and lives on the active row.
+describe('<SessionRow /> selection dot — only on active row (#784)', () => {
+  beforeEach(() => {
+    useStore.setState({ flashStates: {}, disconnectedSessions: {} });
+    if (!(Element.prototype as { scrollIntoView?: unknown }).scrollIntoView) {
+      (Element.prototype as { scrollIntoView: () => void }).scrollIntoView = () => {};
+    }
+  });
+  afterEach(() => cleanup());
+
+  function makeSession(id: string, name: string): Session {
+    return {
+      id,
+      name,
+      state: 'idle',
+      cwd: '/tmp',
+      model: 'claude-sonnet-4',
+      groupId: 'g1',
+      agentType: 'claude-code',
+    };
+  }
+
+  it('renders the active selection dot on exactly the active row', () => {
+    const sessions = [
+      makeSession('s1', 'Session 1'),
+      makeSession('s2', 'Session 2'),
+      makeSession('s3', 'Session 3'),
+    ];
+    const activeId = 's2';
+    const group: Group = { id: 'g1', name: 'g', collapsed: false, kind: 'normal' };
+
+    const { container } = render(
+      <ToastProvider>
+        <DndContext>
+          <SortableContext items={sessions.map((s) => s.id)} id="g1">
+            <ul>
+              {sessions.map((s) => (
+                <SessionRow
+                  key={s.id}
+                  session={s}
+                  active={s.id === activeId}
+                  selected={s.id === activeId}
+                  onSelect={() => {}}
+                  normalGroups={[group]}
+                />
+              ))}
+            </ul>
+          </SortableContext>
+        </DndContext>
+      </ToastProvider>
+    );
+
+    // The active "open in chat" dot is the inner span carrying
+    // aria-label="Open in chat" + bg-accent. Anchor on aria-label so the
+    // assertion survives class-name churn.
+    const dots = container.querySelectorAll('[aria-label="Open in chat"]');
+    expect(dots.length).toBe(1);
+
+    const activeRow = container.querySelector('[data-session-id="s2"]');
+    expect(activeRow).toBeTruthy();
+    expect(activeRow!.querySelector('[aria-label="Open in chat"]')).toBeTruthy();
+
+    // Sanity: the other rows have no dot.
+    for (const id of ['s1', 's3']) {
+      const row = container.querySelector(`[data-session-id="${id}"]`);
+      expect(row).toBeTruthy();
+      expect(row!.querySelector('[aria-label="Open in chat"]')).toBeNull();
+    }
+  });
+});

--- a/tests/sidebar/session-row-name.test.tsx
+++ b/tests/sidebar/session-row-name.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { DndContext } from '@dnd-kit/core';
+import { SortableContext } from '@dnd-kit/sortable';
+import { SessionRow } from '../../src/components/sidebar/SessionRow';
+import { useStore } from '../../src/stores/store';
+import { ToastProvider } from '../../src/components/ui/Toast';
+import type { Group, Session } from '../../src/types';
+
+// Task #788: regression guard — SessionRow's visible label must come from
+// `session.name` (the user-visible name maintained by the store), NOT the
+// session id and NOT a derived alias. A regression where the row fell back
+// to id rendering would silently uglify the sidebar without breaking other
+// assertions; this pins the label to the store-supplied name.
+describe('<SessionRow /> renders store.name, not id (#788)', () => {
+  beforeEach(() => {
+    useStore.setState({ flashStates: {}, disconnectedSessions: {} });
+    if (!(Element.prototype as { scrollIntoView?: unknown }).scrollIntoView) {
+      (Element.prototype as { scrollIntoView: () => void }).scrollIntoView = () => {};
+    }
+  });
+  afterEach(() => cleanup());
+
+  it('shows session.name verbatim and does not fall back to session.id', () => {
+    const session: Session = {
+      id: 'sess-uuid-deadbeef-0001',
+      name: 'My Custom Name',
+      state: 'idle',
+      cwd: '/tmp',
+      model: 'claude-sonnet-4',
+      groupId: 'g1',
+      agentType: 'claude-code',
+    };
+    const group: Group = { id: 'g1', name: 'g', collapsed: false, kind: 'normal' };
+
+    const { container, getByText } = render(
+      <ToastProvider>
+        <DndContext>
+          <SortableContext items={[session.id]} id="g1">
+            <ul>
+              <SessionRow
+                session={session}
+                active={false}
+                selected={false}
+                onSelect={() => {}}
+                normalGroups={[group]}
+              />
+            </ul>
+          </SortableContext>
+        </DndContext>
+      </ToastProvider>
+    );
+
+    expect(getByText('My Custom Name')).toBeInTheDocument();
+    // The id must never appear as visible text content (it remains valid
+    // as the data-session-id attribute, which we explicitly ignore here).
+    const li = container.querySelector('[data-session-id]');
+    expect(li).toBeTruthy();
+    expect(li!.textContent ?? '').not.toContain(session.id);
+  });
+});


### PR DESCRIPTION
## Context

Per PR #569 reviewer follow-up: bundle three small RTL regression guards
covering sidebar selection-dot leakage, AgentIcon state-attr drop, and
SessionRow name fallback to id.

## Tests added

| Task | File | Guards against |
|------|------|----------------|
| #784 | `tests/sidebar/session-row-dot-selection.test.tsx` | "Open in chat" selection dot leaking to non-active rows when the `active &&` gate is dropped — renders 3 rows, asserts exactly 1 dot lives on the `activeId` row. |
| #785 | `tests/components/AgentIcon-state-attr.test.tsx` | `data-agent-icon-state` silently dropped from the rendered element — iterates all `SessionState` values (`idle`, `waiting`) and asserts the attribute matches the prop. e2e selectors depend on this. |
| #788 | `tests/sidebar/session-row-name.test.tsx` | Row visible label falling back to `session.id` instead of `session.name` — renders a session with an obviously-distinct name + id and asserts the visible text contains the name and never the id. |

## Reverse-verify (#784, the most regression-likely)

Stashed the `active &&` gate in `SessionRow.tsx` (replaced with `true &&`) → expected FAIL.

```
× <SessionRow /> selection dot — only on active row (#784)
  > renders the active selection dot on exactly the active row

AssertionError: expected 3 to be 1 // Object.is equality
- Expected
+ Received
- 1
+ 3

❯ tests/sidebar/session-row-dot-selection.test.tsx:71:25
```

Restored gate → expected PASS.

```
✓ tests/sidebar/session-row-dot-selection.test.tsx (1 test) 219ms

Test Files  1 passed (1)
     Tests  1 passed (1)
```

`git status` confirms only the three new test files remain (SessionRow.tsx restored cleanly).

## Verification

**typecheck**

```
> ccsm@0.1.0 typecheck
> tsc --noEmit && tsc --noEmit -p tsconfig.electron.json
```
(green, no diagnostics)

**build**

```
webpack 5.106.2 compiled with 3 warnings in 26742 ms
```
(only pre-existing bundle-size perf warnings)

**vitest run tests/sidebar tests/components/AgentIcon-state-attr**

```
✓ tests/sidebar/useSidebarDnd.test.ts (9 tests) 54ms
✓ tests/sidebar-resizer-keyboard.test.tsx (13 tests) 477ms
✓ tests/components/AgentIcon-state-attr.test.tsx (2 tests) 117ms
✓ tests/sidebar/session-row-name.test.tsx (1 test) 189ms
✓ tests/sidebar/session-row-dot-selection.test.tsx (1 test) 193ms
✓ tests/sidebar/SessionRow.test.tsx (2 tests) 380ms
✓ tests/sidebar/GroupRow.test.tsx (2 tests) 473ms

Test Files  7 passed (7)
     Tests  30 passed (30)
```

(4 new tests + 26 pre-existing — all green)

## Tasks

- Task #784
- Task #785
- Task #788

## Notes

- No production-code changes; tests-only PR.
- Anchored selectors on stable contracts (`aria-label`, `data-session-id`, `data-agent-icon-state`) rather than class names so the assertions survive style churn.
- AgentIcon state list mirrors the `SessionState` union in `src/types.ts` (`'idle' | 'waiting'`); a comment flags the need to extend if the union grows.