### PR TITLE
refactor(tsconfig): noUncheckedIndexedAccess + noImplicitOverride

### DIFF
--- a/electron/commands-loader.ts
+++ b/electron/commands-loader.ts
@@ -72,7 +72,7 @@ export function parseFrontmatter(raw: string): {
 } {
   const m = FRONTMATTER_RE.exec(raw);
   if (!m) return { data: {}, body: raw };
-  const yamlBlock = m[1];
+  const yamlBlock = m[1]!;
   const body = raw.slice(m[0].length);
   const data: Record<string, string> = {};
   for (const line of yamlBlock.split(/\r?\n/)) {

--- a/electron/notify/badgePixels.ts
+++ b/electron/notify/badgePixels.ts
@@ -153,10 +153,10 @@ export function compositeTrayImage(
       const si = (sy * baseSize.width + sx) * 4;
       const di = (y * size + x) * 4;
       // Electron's toBitmap is BGRA on every platform we care about.
-      buf[di + 0] = baseBuf[si + 2];
-      buf[di + 1] = baseBuf[si + 1];
-      buf[di + 2] = baseBuf[si + 0];
-      buf[di + 3] = baseBuf[si + 3];
+      buf[di + 0] = baseBuf[si + 2]!;
+      buf[di + 1] = baseBuf[si + 1]!;
+      buf[di + 2] = baseBuf[si + 0]!;
+      buf[di + 3] = baseBuf[si + 3]!;
     }
   }
 
@@ -222,13 +222,13 @@ export function drawLabel(
   const startX = Math.round((size - totalW) / 2);
   const startY = Math.round((size - glyphH) / 2);
   for (let ci = 0; ci < label.length; ci++) {
-    const ch = label[ci];
+    const ch = label[ci]!;
     const glyph = GLYPHS[ch];
     if (!glyph) continue;
     const gx0 = startX + ci * (glyphW + gap);
     for (let gy = 0; gy < GLYPH_H; gy++) {
       for (let gx = 0; gx < GLYPH_W; gx++) {
-        if (!glyph[gy][gx]) continue;
+        if (!glyph[gy]![gx]) continue;
         for (let sy = 0; sy < scale; sy++) {
           for (let sx = 0; sx < scale; sx++) {
             const px = gx0 + gx * scale + sx;
@@ -257,7 +257,7 @@ export function blit(
   for (let y = 0; y < srcSize; y++) {
     for (let x = 0; x < srcSize; x++) {
       const si = (y * srcSize + x) * 4;
-      const sa = src[si + 3];
+      const sa = src[si + 3]!;
       if (sa === 0) continue;
       const dx = ox + x;
       const dy = oy + y;
@@ -266,10 +266,10 @@ export function blit(
       // Source-over alpha blend.
       const a = sa / 255;
       const inv = 1 - a;
-      dst[di + 0] = Math.round(src[si + 0] * a + dst[di + 0] * inv);
-      dst[di + 1] = Math.round(src[si + 1] * a + dst[di + 1] * inv);
-      dst[di + 2] = Math.round(src[si + 2] * a + dst[di + 2] * inv);
-      dst[di + 3] = Math.max(dst[di + 3], sa);
+      dst[di + 0] = Math.round(src[si + 0]! * a + dst[di + 0]! * inv);
+      dst[di + 1] = Math.round(src[si + 1]! * a + dst[di + 1]! * inv);
+      dst[di + 2] = Math.round(src[si + 2]! * a + dst[di + 2]! * inv);
+      dst[di + 3] = Math.max(dst[di + 3]!, sa);
     }
   }
 }

--- a/electron/ptyHost/jsonlResolver.ts
+++ b/electron/ptyHost/jsonlResolver.ts
@@ -18,7 +18,7 @@ const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9
 export function toClaudeSid(ccsmSessionId: string): string {
   if (UUID_V4_RE.test(ccsmSessionId)) return ccsmSessionId.toLowerCase();
   const hex = createHash('sha256').update(ccsmSessionId).digest('hex');
-  const yNibble = (parseInt(hex[16], 16) & 0x3) | 0x8;
+  const yNibble = (parseInt(hex[16]!, 16) & 0x3) | 0x8;
   return (
     `${hex.slice(0, 8)}-${hex.slice(8, 12)}-4${hex.slice(13, 16)}-` +
     `${yNibble.toString(16)}${hex.slice(17, 20)}-${hex.slice(20, 32)}`

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -82,16 +82,16 @@ export function SettingsDialog({
     const order = TABS.map((x) => x.id);
     if (e.key === 'ArrowDown' || e.key === 'ArrowRight') {
       e.preventDefault();
-      focusTab(order[(idx + 1) % order.length]);
+      focusTab(order[(idx + 1) % order.length]!);
     } else if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
       e.preventDefault();
-      focusTab(order[(idx - 1 + order.length) % order.length]);
+      focusTab(order[(idx - 1 + order.length) % order.length]!);
     } else if (e.key === 'Home') {
       e.preventDefault();
-      focusTab(order[0]);
+      focusTab(order[0]!);
     } else if (e.key === 'End') {
       e.preventDefault();
-      focusTab(order[order.length - 1]);
+      focusTab(order[order.length - 1]!);
     }
   };
 

--- a/src/components/Tutorial.tsx
+++ b/src/components/Tutorial.tsx
@@ -48,7 +48,7 @@ export function Tutorial({ onNewSession, onImport, onSkip }: Props) {
     }
   ];
 
-  const step = steps[stepIdx];
+  const step = steps[stepIdx]!;
   const isLast = stepIdx === steps.length - 1;
   const isFirst = stepIdx === 0;
 

--- a/src/components/sidebar/GroupRow.tsx
+++ b/src/components/sidebar/GroupRow.tsx
@@ -246,7 +246,7 @@ export function GroupRow({
             else if (key === 'End') next = items.length - 1;
             if (next !== idx && items[next]) {
               e.preventDefault();
-              items[next].focus();
+              items[next]!.focus();
             }
           }}
         >

--- a/src/mentions/registry.ts
+++ b/src/mentions/registry.ts
@@ -41,9 +41,9 @@ export function detectAtTrigger(value: string, caret: number): AtTriggerState {
   // we're past the end of any candidate mention token.
   let i = caret - 1;
   while (i >= 0) {
-    const ch = value[i];
+    const ch = value[i]!;
     if (ch === '@') {
-      const prev = i === 0 ? '' : value[i - 1];
+      const prev = i === 0 ? '' : value[i - 1]!;
       if (i === 0 || /\s/.test(prev)) {
         return {
           active: true,

--- a/src/stores/slices/groupsSlice.ts
+++ b/src/stores/slices/groupsSlice.ts
@@ -92,7 +92,7 @@ export function createGroupsSlice(set: SetFn, get: GetFn): GroupsSlice {
       const prev = get();
       const groupIndex = prev.groups.findIndex((g) => g.id === id);
       if (groupIndex === -1) return null;
-      const group = prev.groups[groupIndex];
+      const group = prev.groups[groupIndex]!;
       const memberSnapshots: SessionSnapshot[] = prev.sessions
         .map((s, i) => ({ s, i }))
         .filter(({ s }) => s.groupId === id)

--- a/src/stores/slices/sessionCrudSlice.ts
+++ b/src/stores/slices/sessionCrudSlice.ts
@@ -282,7 +282,7 @@ export function createSessionCrudSlice(set: SetFn, get: GetFn): SessionCrudSlice
       const prev = get();
       const idx = prev.sessions.findIndex((x) => x.id === id);
       if (idx === -1) return null;
-      const target = prev.sessions[idx];
+      const target = prev.sessions[idx]!;
       const snapshot: SessionSnapshot = {
         session: target,
         index: idx,
@@ -303,9 +303,9 @@ export function createSessionCrudSlice(set: SetFn, get: GetFn): SessionCrudSlice
               .map((x, i) => ({ x, i }))
               .filter(({ x, i }) => x.groupId === sourceGroupId && i > idx);
             if (afterIdxOrig.length > 0) {
-              nextActive = afterIdxOrig[0].x.id;
+              nextActive = afterIdxOrig[0]!.x.id;
             } else if (beforeIdxOrig.length > 0) {
-              nextActive = beforeIdxOrig[beforeIdxOrig.length - 1].x.id;
+              nextActive = beforeIdxOrig[beforeIdxOrig.length - 1]!.x.id;
             } else {
               nextActive = remaining[0]?.id ?? '';
             }

--- a/src/stores/slices/sessionRuntimeSlice.ts
+++ b/src/stores/slices/sessionRuntimeSlice.ts
@@ -71,9 +71,9 @@ export function createSessionRuntimeSlice(
       set((s) => {
         const idx = s.sessions.findIndex((x) => x.id === sid);
         if (idx === -1) return s;
-        if (s.sessions[idx].cwd === newCwd) return s;
+        if (s.sessions[idx]!.cwd === newCwd) return s;
         const next = s.sessions.slice();
-        next[idx] = { ...next[idx], cwd: newCwd };
+        next[idx] = { ...next[idx]!, cwd: newCwd };
         return { ...s, sessions: next };
       });
     },

--- a/src/stores/slices/sessionTitleBackfillSlice.ts
+++ b/src/stores/slices/sessionTitleBackfillSlice.ts
@@ -31,9 +31,9 @@ export function createSessionTitleBackfillSlice(
       set((s) => {
         const idx = s.sessions.findIndex((x) => x.id === sid);
         if (idx === -1) return s;
-        if (s.sessions[idx].name === title) return s;
+        if (s.sessions[idx]!.name === title) return s;
         const next = s.sessions.slice();
-        next[idx] = { ...next[idx], name: title };
+        next[idx] = { ...next[idx]!, name: title };
         return { ...s, sessions: next };
       });
     },

--- a/src/utils/file-tree.ts
+++ b/src/utils/file-tree.ts
@@ -50,13 +50,13 @@ export function parseLsResult(text: string): string[] {
     if (raw.startsWith('NOTE:')) continue;
     const m = raw.match(/^(\s*)-\s+(.+?)\/?\s*$/);
     if (!m) continue;
-    const indent = m[1].length;
-    const namePart = m[2];
+    const indent = m[1]!.length;
+    const namePart = m[2]!;
     const isDir = /\/\s*$/.test(raw) || (!rootSet && namePart.includes('/'));
     const depth = Math.floor(indent / LS_INDENT);
 
-    while (stack.length && stack[stack.length - 1].depth >= depth) stack.pop();
-    const parent = stack.length ? stack[stack.length - 1].path : '';
+    while (stack.length && stack[stack.length - 1]!.depth >= depth) stack.pop();
+    const parent = stack.length ? stack[stack.length - 1]!.path : '';
     let full: string;
     if (!rootSet) {
       // The very first entry is the absolute root directory.
@@ -113,7 +113,7 @@ export function buildFileTree(paths: string[]): FileTreeNode[] {
     let cursor = root;
     let pathSoFar = isAbs && raw.startsWith('/') ? '' : '';
     for (let i = 0; i < segments.length; i++) {
-      const seg = segments[i];
+      const seg = segments[i]!;
       pathSoFar = pathSoFar ? `${pathSoFar}/${seg}` : (isAbs && raw.startsWith('/') ? `/${seg}` : seg);
       const isLast = i === segments.length - 1;
       const expectDir = !isLast || knownDirs.has(p);

--- a/tsconfig.electron.json
+++ b/tsconfig.electron.json
@@ -4,6 +4,8 @@
     "module": "CommonJS",
     "moduleResolution": "node",
     "strict": true,
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "outDir": "dist",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,8 @@
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "strict": true,
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Summary
Task #794. Tech-debt R7 from `tech-debt-07-toolchain.md` Top-3: enable two strict tsconfig flags in **both** `tsconfig.json` and `tsconfig.electron.json`:

- `noUncheckedIndexedAccess: true`
- `noImplicitOverride: true`

## Error counts

| Flag | Errors | Status |
|---|---|---|
| `noImplicitOverride` | 0 | clean (no subclasses needed `override`) |
| `noUncheckedIndexedAccess` | 46 (31 renderer + 15 electron) | all fixed |

## Fix categories

**Bounds-checked array access after `findIndex` / `length` guard** — assert with `!`:
- `groupsSlice.deleteGroup` (group lookup after `findIndex !== -1`)
- `sessionCrudSlice.deleteSession` (target session lookup; before/after-index nav arrays)
- `sessionRuntimeSlice._applyCwdRedirect` + `sessionTitleBackfillSlice._applyExternalTitle` (session reuse after `findIndex !== -1`)
- `Tutorial.step` (bounded by `stepIdx` clamp)
- `GroupRow` keyboard nav (`items[next]` after explicit truthiness check)
- `SettingsDialog` tab cycling (modulo over fixed `TABS` constant)

**String / Buffer / regex-group index access in pure decoders** — assert with `!`:
- `mentions/registry.detectAtTrigger` — char walk-back over user input
- `utils/file-tree.parseLsResult` + `buildFileTree` — segment iteration
- `electron/notify/badgePixels` — BGRA byte-pair operations in `blit` / `drawLabel` / base copy
- `electron/ptyHost/jsonlResolver.toClaudeSid` — `hex[16]` after sha256 (always 64 chars)
- `electron/commands-loader.parseFrontmatter` — regex `m[1]` capture group

## Real bugs uncovered

**None.** Every site was guarded by surrounding logic (`findIndex !== -1`, regex match capture groups guaranteed by pattern, fixed-iteration loops over known-size buffers, modulo over constant arrays). Asserts encode the existing invariant rather than masking holes. The audit specifically called out `messagesBySession[sid]` — that pattern lives in renderer slices that don't surface here, so no follow-up needed in this PR's scope.

## Defers

None.

## Verification

- `npm run typecheck` — clean
- `npm run build` — clean (3 pre-existing webpack perf warnings)
- `npm test` — 897 pass, 4 fail (all pre-existing `db-hardening` baseline from NODE_MODULE_VERSION mismatch on native binding rebuild; matches working tip)

## Test plan
- [x] typecheck clean with both new flags
- [x] webpack build clean
- [x] vitest baseline preserved (db-hardening fails are pre-existing)