### PR TITLE
refactor: tighten import-scanner JSONL types + ccsmPty ambient

### DIFF
--- a/electron/import-scanner.ts
+++ b/electron/import-scanner.ts
@@ -160,7 +160,7 @@ function readHead(file: string): Promise<Head | null> {
         return;
       }
       if (!line) return;
-      let d: any;
+      let d: unknown;
       try {
         d = JSON.parse(line);
       } catch {
@@ -174,16 +174,18 @@ function readHead(file: string): Promise<Head | null> {
           return;
         }
       }
-      if (typeof d.cwd === 'string' && !cwd) cwd = d.cwd;
-      if (d.type === 'ai-title' && typeof d.aiTitle === 'string') {
-        aiTitle = d.aiTitle;
+      const o = asRecord(d);
+      if (!o) return;
+      if (typeof o.cwd === 'string' && !cwd) cwd = o.cwd;
+      if (o.type === 'ai-title' && typeof o.aiTitle === 'string') {
+        aiTitle = o.aiTitle;
       }
-      if (!firstUserText && d.type === 'user' && d.message) {
-        const txt = extractUserText(d.message);
+      if (!firstUserText && o.type === 'user' && o.message) {
+        const txt = extractUserText(o.message);
         if (txt) firstUserText = truncate(txt, 80);
       }
       if (!model) {
-        const m = extractModel(d);
+        const m = extractModel(o);
         if (m) model = m;
       }
       if (cwd && aiTitle && model) {
@@ -195,13 +197,15 @@ function readHead(file: string): Promise<Head | null> {
   });
 }
 
-function extractUserText(message: any): string {
-  const c = message?.content;
+function extractUserText(message: unknown): string {
+  const m = asRecord(message);
+  const c = m?.content;
   if (typeof c === 'string') return cleanCommandWrapper(c);
   if (!Array.isArray(c)) return '';
   for (const part of c) {
-    if (part?.type === 'text' && typeof part.text === 'string') {
-      const cleaned = cleanCommandWrapper(part.text);
+    const p = asRecord(part);
+    if (p?.type === 'text' && typeof p.text === 'string') {
+      const cleaned = cleanCommandWrapper(p.text);
       if (cleaned) return cleaned;
     }
   }
@@ -285,7 +289,7 @@ export function parseHead(lines: string[]): Head | null {
   for (let i = 0; i < lines.length && i < MAX_HEAD_LINES; i++) {
     const line = lines[i];
     if (!line) continue;
-    let d: any;
+    let d: unknown;
     try {
       d = JSON.parse(line);
     } catch {
@@ -295,14 +299,16 @@ export function parseHead(lines: string[]): Head | null {
       firstFrameInspected = true;
       if (isSidechainFrame(d)) return null;
     }
-    if (typeof d.cwd === 'string' && !cwd) cwd = d.cwd;
-    if (d.type === 'ai-title' && typeof d.aiTitle === 'string') aiTitle = d.aiTitle;
-    if (!firstUserText && d.type === 'user' && d.message) {
-      const txt = extractUserText(d.message);
+    const o = asRecord(d);
+    if (!o) continue;
+    if (typeof o.cwd === 'string' && !cwd) cwd = o.cwd;
+    if (o.type === 'ai-title' && typeof o.aiTitle === 'string') aiTitle = o.aiTitle;
+    if (!firstUserText && o.type === 'user' && o.message) {
+      const txt = extractUserText(o.message);
       if (txt) firstUserText = truncate(txt, 80);
     }
     if (!model) {
-      const m = extractModel(d);
+      const m = extractModel(o);
       if (m) model = m;
     }
     if (cwd && aiTitle && model) break;
@@ -314,8 +320,18 @@ export function parseHead(lines: string[]): Head | null {
 
 // CLI transcripts carry the model on assistant frames as `message.model`.
 // Some older / synthetic frames may put it at the top level — accept both.
-function extractModel(d: any): string | null {
-  if (typeof d?.message?.model === 'string' && d.message.model) return d.message.model;
-  if (typeof d?.model === 'string' && d.model) return d.model;
+function extractModel(d: unknown): string | null {
+  const o = asRecord(d);
+  if (!o) return null;
+  const msg = asRecord(o.message);
+  if (msg && typeof msg.model === 'string' && msg.model) return msg.model;
+  if (typeof o.model === 'string' && o.model) return o.model;
   return null;
+}
+
+// Narrow `unknown` to `Record<string, unknown>` for safe property access on
+// JSONL frames. Mirrors the precedent set by `isSidechainFrame`.
+function asRecord(v: unknown): Record<string, unknown> | null {
+  if (!v || typeof v !== 'object') return null;
+  return v as Record<string, unknown>;
 }

--- a/src/app-effects/usePtyExitBridge.ts
+++ b/src/app-effects/usePtyExitBridge.ts
@@ -19,13 +19,7 @@ export function usePtyExitBridge(
   applyPtyExit: (sid: string, evt: PtyExitEvent) => void
 ): void {
   useEffect(() => {
-    const pty = (window as unknown as {
-      ccsmPty?: {
-        onExit?: (
-          cb: (e: { sessionId: string; code?: number | null; signal?: string | number | null }) => void
-        ) => () => void;
-      };
-    }).ccsmPty;
+    const pty = window.ccsmPty;
     if (!pty?.onExit) return;
     return pty.onExit((evt) => {
       if (!evt || typeof evt.sessionId !== 'string' || evt.sessionId.length === 0) return;

--- a/src/pty.d.ts
+++ b/src/pty.d.ts
@@ -40,6 +40,10 @@ export interface PtyDataEvent {
   chunk: string;
 }
 
+export type CheckClaudeAvailableResult =
+  | { available: true; path: string }
+  | { available: false };
+
 export interface CcsmPtyApi {
   list(): Promise<PtySessionInfo[]>;
   spawn(sid: string, cwd: string): Promise<SpawnResult>;
@@ -55,12 +59,13 @@ export interface CcsmPtyApi {
     readText(): string;
     writeText(text: string): void;
   };
+  checkClaudeAvailable(opts?: { force?: boolean }): Promise<CheckClaudeAvailableResult>;
 }
 
 declare global {
   interface Window {
     ccsmPty: CcsmPtyApi;
-    __ccsmTerm?: unknown;
+    __ccsmTerm?: import('@xterm/xterm').Terminal;
   }
 }
 

--- a/src/terminal/xtermSingleton.ts
+++ b/src/terminal/xtermSingleton.ts
@@ -20,14 +20,9 @@ import { CanvasAddon } from '@xterm/addon-canvas';
 //
 // All three terminal hooks (useXtermSingleton, usePtyAttach,
 // useTerminalResize) share this state via the accessors below.
-
-declare global {
-  interface Window {
-    // Local stub until PR-3 lands the proper src/pty.d.ts.
-    ccsmPty: any;
-    __ccsmTerm?: Terminal;
-  }
-}
+//
+// `window.ccsmPty` and `window.__ccsmTerm` are typed via `src/pty.d.ts`,
+// which is the canonical renderer-side view of the preload bridge surface.
 
 let term: Terminal | null = null;
 let fit: FitAddon | null = null;


### PR DESCRIPTION
## Summary

Resolves Task #793 — fixes the top 3 lazy offenders called out by `tech-debt-02-typesafety.md`:

1. **`electron/import-scanner.ts`** — 4 `: any` JSONL boundary sites → `: unknown` + `asRecord()` narrowing helper (mirrors existing `isSidechainFrame` precedent). Untrusted user-disk input now type-checked at downstream property accesses.
2. **`src/terminal/xtermSingleton.ts`** — drop the duplicate `interface Window { ccsmPty: any }` ambient ("PR-3 stub" per the source comment, but `src/pty.d.ts` has been the canonical typed bridge surface for a while). Single source of truth.
3. **`src/pty.d.ts`** — backfill `CcsmPtyApi.checkClaudeAvailable` (was on the real bridge, missing from the renderer-side type) and tighten `Window['__ccsmTerm']` from `unknown` to `Terminal`.
4. **`src/app-effects/usePtyExitBridge.ts`** — drop inline `as unknown as { ccsmPty?: ... }` cast now that `window.ccsmPty` is fully typed.

## LoC delta

`+46 / −36` (net +10).

Smaller than the audit's `−60 / +30` estimate because most production call sites already used `window.ccsmPty?.foo` directly — only **1** cast site (`usePtyExitBridge`) actually existed in `src/` to delete. Test-only `(window as any).ccsmPty = ...` mocks (5 sites in `tests/`) intentionally left alone: they assign partial bridge stubs that don't implement the full `CcsmPtyApi`, and `delete (window as unknown as ...).ccsmPty` is required because the typed property is non-optional.

## Verification

- `npm run typecheck` (both `tsconfig.json` and `tsconfig.electron.json`) — clean
- `npm run build` — clean (3 webpack bundle-size warnings, pre-existing, unrelated)
- `npm test` — **901/901** passing
- `grep ': any' electron/import-scanner.ts` — empty

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test` (full suite, 901 tests)

Refs: `artifacts/tech-debt-02-typesafety.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)