### PR TITLE
fix: main-process unhandledRejection net + IPC handler try/catch

### DIFF
--- a/electron/__tests__/error-safety-net.test.ts
+++ b/electron/__tests__/error-safety-net.test.ts
@@ -1,0 +1,83 @@
+// Verifies the main-process unhandledRejection / uncaughtException safety
+// net is wired in electron/main.ts. Audit risk #2 (tech-debt-03-errors.md):
+// without these listeners Node 20+ silently exits the main process on any
+// escaped rejection.
+//
+// Two layers of verification:
+//  1) Source-level: grep the actual main.ts file for the two `process.on`
+//     calls. Catches accidental deletion in a refactor.
+//  2) Behavior-level: simulate the listener body (log + don't exit) and
+//     assert the contract (no process.exit call).
+//
+// Reverse-verify: comment out the two `process.on(...)` blocks in main.ts
+// → the source-level test FAILS. Restore → PASSES.
+
+import { describe, it, expect, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const MAIN_TS = path.resolve(__dirname, '..', 'main.ts');
+
+describe('main-process error safety net (source wiring)', () => {
+  const source = fs.readFileSync(MAIN_TS, 'utf8');
+  // Strip line comments before matching so a commented-out reference
+  // doesn't satisfy the test (the contract is about live wiring, not
+  // documentation).
+  const live = source
+    .split('\n')
+    .filter((l) => !l.trim().startsWith('//'))
+    .join('\n');
+
+  it('registers process.on(unhandledRejection) before app.whenReady', () => {
+    const idxOn = live.search(/\bprocess\.on\(\s*['"]unhandledRejection['"]/);
+    const idxReady = live.indexOf('app.whenReady().then(');
+    expect(idxOn).toBeGreaterThan(-1);
+    expect(idxReady).toBeGreaterThan(-1);
+    expect(idxOn).toBeLessThan(idxReady);
+  });
+
+  it('registers process.on(uncaughtException) before app.whenReady', () => {
+    const idxOn = live.search(/\bprocess\.on\(\s*['"]uncaughtException['"]/);
+    const idxReady = live.indexOf('app.whenReady().then(');
+    expect(idxOn).toBeGreaterThan(-1);
+    expect(idxReady).toBeGreaterThan(-1);
+    expect(idxOn).toBeLessThan(idxReady);
+  });
+
+  it('does NOT call app.exit / process.exit from inside the safety-net handlers', () => {
+    // Slice from the first process.on to the initSentry() call — that's the
+    // safety-net block. Assert it doesn't auto-exit (preserves test default
+    // throw behavior + matches renderer "log + degrade" stance).
+    const start = live.search(/\bprocess\.on\(\s*['"]unhandledRejection['"]/);
+    const end = live.indexOf('initSentry()');
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const block = live.slice(start, end);
+    expect(block).not.toMatch(/app\.exit/);
+    expect(block).not.toMatch(/process\.exit/);
+  });
+});
+
+describe('main-process error safety net (behavior contract)', () => {
+  it('handler shape logs reason and does not call process.exit', () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(((_code?: number) => {
+        throw new Error('process.exit must not be called from safety net');
+      }) as never);
+
+    // Mirror the production handler body verbatim.
+    const handler = (reason: unknown) => {
+      console.error('[main] unhandledRejection:', reason);
+    };
+    handler('boom');
+    handler(new Error('kapow'));
+
+    expect(errSpy).toHaveBeenCalledTimes(2);
+    expect(exitSpy).not.toHaveBeenCalled();
+
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+});

--- a/electron/ipc/__tests__/dbIpc.test.ts
+++ b/electron/ipc/__tests__/dbIpc.test.ts
@@ -20,10 +20,18 @@ vi.mock('../../prefs/notifyEnabled', () => ({
 
 // Mock db so handleDbSave doesn't try to open SQLite.
 const saveStateCalls: Array<{ key: string; value: string }> = [];
+let saveStateThrows: Error | null = null;
+let loadStateThrows: Error | null = null;
+let loadStateReturn: string | null = null;
 vi.mock('../../db', () => ({
-  saveState: (key: string, value: string) =>
-    saveStateCalls.push({ key, value }),
-  loadState: (_k: string) => null,
+  saveState: (key: string, value: string) => {
+    if (saveStateThrows) throw saveStateThrows;
+    saveStateCalls.push({ key, value });
+  },
+  loadState: (_k: string) => {
+    if (loadStateThrows) throw loadStateThrows;
+    return loadStateReturn;
+  },
 }));
 
 // Mock validate so we control its responses.
@@ -40,7 +48,7 @@ vi.mock('../../security/ipcGuards', () => ({
   fromMainFrame: (_e: unknown) => allowGuard,
 }));
 
-import { dispatchSavedKeyInvalidation, handleDbSave } from '../dbIpc';
+import { dispatchSavedKeyInvalidation, handleDbSave, handleDbLoad } from '../dbIpc';
 import type { IpcMainInvokeEvent } from 'electron';
 
 const fakeEvent = {} as IpcMainInvokeEvent;
@@ -51,6 +59,9 @@ beforeEach(() => {
   saveStateCalls.length = 0;
   validateResult = { ok: true };
   allowGuard = true;
+  saveStateThrows = null;
+  loadStateThrows = null;
+  loadStateReturn = null;
 });
 
 describe('dispatchSavedKeyInvalidation', () => {
@@ -108,5 +119,51 @@ describe('handleDbSave', () => {
     handleDbSave(fakeEvent, 'unrelated', 'v');
     expect(invalidateCrash).not.toHaveBeenCalled();
     expect(invalidateNotify).not.toHaveBeenCalled();
+  });
+
+  // Audit risk #1 (tech-debt-03-errors.md): without try/catch around
+  // saveState(), a sqlite write error propagates as Electron's opaque
+  // "An object could not be cloned" rejection. Reverse-verify: remove the
+  // try/catch around saveState() in dbIpc.ts → this test FAILS with an
+  // uncaught throw.
+  it('returns {ok:false, error} when saveState throws (audit risk #1)', () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    saveStateThrows = new Error('SQLITE_FULL: database or disk is full');
+    const result = handleDbSave(fakeEvent, 'persist', 'payload');
+    expect(result).toEqual({
+      ok: false,
+      error: 'SQLITE_FULL: database or disk is full',
+    });
+    expect(errSpy).toHaveBeenCalled();
+    // Invalidation must NOT fire on failed save — would mislead consumers
+    // that the new value is committed.
+    expect(invalidateCrash).not.toHaveBeenCalled();
+    expect(invalidateNotify).not.toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+});
+
+describe('handleDbLoad', () => {
+  it('returns the loaded value on success', () => {
+    loadStateReturn = 'persisted-blob';
+    expect(handleDbLoad(fakeEvent, 'k')).toBe('persisted-blob');
+  });
+
+  it('returns null when no value exists', () => {
+    loadStateReturn = null;
+    expect(handleDbLoad(fakeEvent, 'k')).toBeNull();
+  });
+
+  // Audit risk #6: without try/catch, a sqlite read error crosses the IPC
+  // bridge as an opaque rejection → renderer boots into a blank app with
+  // zero diagnostic. Reverse-verify: remove the try/catch in handleDbLoad
+  // → this test FAILS with an uncaught throw.
+  it('returns null and logs when loadState throws (audit risk #6)', () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    loadStateThrows = new Error('SQLITE_CORRUPT: database disk image is malformed');
+    const result = handleDbLoad(fakeEvent, 'persist');
+    expect(result).toBeNull();
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
   });
 });

--- a/electron/ipc/__tests__/systemIpc.test.ts
+++ b/electron/ipc/__tests__/systemIpc.test.ts
@@ -4,15 +4,18 @@ import * as os from 'os';
 import * as path from 'path';
 
 vi.mock('electron', () => ({}));
+let listModelsImpl: () => Promise<{ models: unknown[] }> = async () => ({
+  models: [],
+});
 vi.mock('../../agent/list-models-from-settings', () => ({
-  listModelsFromSettings: async () => ({ models: [] }),
+  listModelsFromSettings: () => listModelsImpl(),
   readDefaultModelFromSettings: async () => null,
 }));
 vi.mock('../../security/ipcGuards', () => ({
   fromMainFrame: () => true,
 }));
 
-import { readConnectionView } from '../systemIpc';
+import { readConnectionView, handleModelsList } from '../systemIpc';
 
 let tmpDir = '';
 let tmpFile = '';
@@ -105,5 +108,34 @@ describe('readConnectionView', () => {
     );
     const v = readConnectionView({} as NodeJS.ProcessEnv, tmpFile);
     expect(v.hasAuthToken).toBe(false);
+  });
+});
+
+describe('handleModelsList', () => {
+  beforeEach(() => {
+    listModelsImpl = async () => ({ models: [] });
+  });
+
+  it('returns the models from settings on success', async () => {
+    listModelsImpl = async () => ({
+      models: [{ id: 'foo', label: 'Foo' }],
+    });
+    const result = await handleModelsList();
+    expect(result).toEqual([{ id: 'foo', label: 'Foo' }]);
+  });
+
+  // Audit risk #10 (tech-debt-03-errors.md): malformed settings.json must
+  // not propagate as an opaque IPC rejection — Settings pane should show
+  // an empty list, not a bridge crash. Reverse-verify: remove the try/catch
+  // in handleModelsList → this test FAILS with an uncaught throw.
+  it('returns [] and logs when listModelsFromSettings throws (audit risk #10)', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    listModelsImpl = async () => {
+      throw new SyntaxError('Unexpected token } in JSON at position 17');
+    };
+    const result = await handleModelsList();
+    expect(result).toEqual([]);
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
   });
 });

--- a/electron/ipc/dbIpc.ts
+++ b/electron/ipc/dbIpc.ts
@@ -65,14 +65,44 @@ export function handleDbSave(
     }
     return v;
   }
-  saveState(key, value);
+  // Wrap the sqlite write so a disk error (full disk, locked WAL, corrupt
+  // db) becomes a {ok:false} discriminant instead of crossing the IPC bridge
+  // as Electron's opaque "An object could not be cloned" rejection. The
+  // renderer's preload `saveState` wrapper unwraps this and re-throws so
+  // `setPersistErrorHandler` fires with a useful message. Audit risk #1.
+  try {
+    saveState(key, value);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[main] db:save failed for key=${key}:`, err);
+    return { ok: false, error: msg };
+  }
   dispatchSavedKeyInvalidation(key);
   return { ok: true };
 }
 
+/** Pure handler for `db:load`. Exported for unit testing. Returns `null` on
+ *  any sqlite read error so the renderer falls through to its default state
+ *  instead of receiving an opaque IPC rejection (Electron surfaces those as
+ *  "An object could not be cloned"). Audit risk #6. The cost of degrading to
+ *  null is a one-time blank app on a corrupt db; the alternative is a hard
+ *  bridge error with no diagnostic. The error is logged so dogfood surfaces
+ *  the underlying cause. */
+export function handleDbLoad(
+  _e: IpcMainInvokeEvent,
+  key: string,
+): string | null {
+  try {
+    return loadState(key);
+  } catch (err) {
+    console.error(`[main] db:load failed for key=${key}:`, err);
+    return null;
+  }
+}
+
 export function registerDbIpc(deps: DbIpcDeps): void {
   const { ipcMain } = deps;
-  ipcMain.handle('db:load', (_e, key: string) => loadState(key));
+  ipcMain.handle('db:load', handleDbLoad);
   // Cap renderer-supplied state values. Mirrors the per-block cap in the
   // (now-retired) db:saveMessages handler but tighter (1 MB total): a single
   // app_state row holds drafts/persist snapshots that should never approach

--- a/electron/ipc/systemIpc.ts
+++ b/electron/ipc/systemIpc.ts
@@ -77,6 +77,26 @@ export function readConnectionView(
   return { baseUrl, model, hasAuthToken };
 }
 
+/** Pure handler for `models:list`. Exported for unit testing. Returns `[]`
+ *  on any error (settings.json missing/malformed, fs error) so the renderer
+ *  Settings pane shows an empty model list instead of receiving an opaque
+ *  IPC rejection (Electron surfaces those as "An object could not be
+ *  cloned"). Audit risk #10. The renderer caller already catches and shows
+ *  an empty list on rejection, so the user-visible behavior is the same;
+ *  the win is a logged diagnostic in main + no bridge error in renderer
+ *  console. */
+export async function handleModelsList(): Promise<
+  Awaited<ReturnType<typeof listModelsFromSettings>>['models']
+> {
+  try {
+    const res = await listModelsFromSettings();
+    return res.models;
+  } catch (err) {
+    console.error('[main] models:list failed:', err);
+    return [];
+  }
+}
+
 export function registerSystemIpc(deps: SystemIpcDeps): void {
   const { ipcMain, app, applyAppMenuLocale, applyTrayLocale } = deps;
 
@@ -129,10 +149,7 @@ export function registerSystemIpc(deps: SystemIpcDeps): void {
     const result = await shell.openPath(file);
     return result === '' ? { ok: true } : { ok: false, error: result };
   });
-  ipcMain.handle('models:list', async () => {
-    const res = await listModelsFromSettings();
-    return res.models;
-  });
+  ipcMain.handle('models:list', handleModelsList);
   ipcMain.handle('app:getVersion', () => app.getVersion());
 
   // The new-session default model comes straight from the user's CLI

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -32,6 +32,21 @@ import { initSentry } from './sentry/init';
 import { createWindow as createMainWindowFactory } from './window/createWindow';
 import { createTray, type TrayController } from './tray/createTray';
 
+// safety net — escaped main-proc rejections kill app on Node 20+ default
+// (audit tech-debt-03-errors.md risk #2). Registered BEFORE app.whenReady so
+// any throw during bootstrap (initSentry, IPC registration, db open) lands
+// in the logger instead of silently terminating the process. We deliberately
+// do NOT call app.exit() — preserves current default-throw behavior in tests
+// and mirrors the renderer's "log + degrade" stance. TODO: forward to Sentry
+// once main-process Sentry transport is wired (currently renderer-only per
+// audit).
+process.on('unhandledRejection', (reason, _promise) => {
+  console.error('[main] unhandledRejection:', reason);
+});
+process.on('uncaughtException', (err) => {
+  console.error('[main] uncaughtException:', err);
+});
+
 // Sentry init reads SENTRY_DSN and wires up beforeSend → opt-out check. The
 // init is idempotent and a no-op when no DSN is set.
 initSentry();


### PR DESCRIPTION
## Summary

Tech-debt R3 (Task #803). Closes audit risks #1, #2, #6, #10 from `tech-debt-03-errors.md`.

- **Risk #2** — `electron/main.ts`: register `process.on('unhandledRejection')` + `uncaughtException` BEFORE `app.whenReady`. Log only — no auto-exit, preserves test default-throw behavior. TODO comment for Sentry forward (main-proc Sentry transport not yet wired).
- **Risk #1** — `electron/ipc/dbIpc.ts`: try/catch around `saveState()` in `handleDbSave` so sqlite write errors return `{ok:false, error}` instead of crossing the IPC bridge as Electron's opaque "An object could not be cloned" rejection. Renderer's preload `saveState` wrapper already unwraps `{ok:false}` and re-throws so `setPersistErrorHandler` still fires.
- **Risk #6** — same file: extract `handleDbLoad` with try/catch returning `null` on read error. Preserves the existing `string | null` preload contract; logs for diagnostics.
- **Risk #10** — `electron/ipc/systemIpc.ts`: extract `handleModelsList` with try/catch returning `[]` on settings.json parse error.

The optional `safeHandle(channel, fn)` helper from the audit is deliberately deferred — the three handlers here have three different return shapes (`string | null`, `{ok}`, `T[]`) so a single helper would force preload-contract churn for marginal gain. Tracked as a follow-up.

## Reverse-verify (per `feedback_bug_fix_test_workflow.md`)

Each fix has a paired test. Removed each try/catch + the two `process.on` calls; ran the new tests.

| File | Tests removed → expected to FAIL |
|---|---|
| `electron/__tests__/error-safety-net.test.ts` | 3 source-wiring tests fail (no `process.on(...)` matches in live source) |
| `electron/ipc/__tests__/dbIpc.test.ts` | `returns {ok:false} when saveState throws` → uncaught `Error: SQLITE_FULL` |
| `electron/ipc/__tests__/dbIpc.test.ts` | `returns null when loadState throws` → uncaught `Error: SQLITE_CORRUPT` |
| `electron/ipc/__tests__/systemIpc.test.ts` | `returns [] when listModelsFromSettings throws` → uncaught `SyntaxError` |

Restored → all 24 tests PASS. Recorded vitest output:

```
Test Files  3 passed (3)
     Tests  24 passed (24)
```

## Verification

- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean (3 unrelated webpack bundle-size warnings preexisting)
- [x] `node -e "require('./dist/electron/ipc/dbIpc.js')"` — loads, exports `handleDbLoad` + `handleDbSave`
- [x] `node -e "require('./dist/electron/ipc/systemIpc.js')"` — loads, exports `handleModelsList`
- [x] Full `npm test` — 4 failures pre-exist on origin/working (better-sqlite3 NODE_MODULE_VERSION mismatch in this worktree env + macOS UA test). Verified by checking out `origin/working` HEAD on the same env: same 3 db-hardening failures.

## Test plan

- [ ] Reviewer: confirm `electron/main.ts` registers both listeners before `app.whenReady().then(...)`.
- [ ] Reviewer: confirm preload `saveState` shape is unchanged (still `Promise<void>` that throws on `{ok:false}`).
- [ ] Reviewer: spot-check that no new `safeHandle` import was introduced (deferred per body).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)