### PR TITLE
fix(security): isSafePath sweep + sid pattern + nav-allowlist tighten

### DIFF
--- a/electron/ipc/__tests__/sessionIpcSecurity.test.ts
+++ b/electron/ipc/__tests__/sessionIpcSecurity.test.ts
@@ -1,0 +1,94 @@
+// Security gates for sessionTitles IPC handlers (#804 risk #5).
+//
+// `sessionTitles:get` / `:rename` / `:enqueuePending` accept a `dir`
+// argument that is forwarded straight into the Anthropic SDK, which fs.joins
+// it under ~/.claude/projects/<key>/.... Without the safety gate a hostile
+// renderer can pass a UNC path (`\\evil\share`) — once the SDK realpath()s
+// or stat()s it, Windows triggers an SMB handshake that leaks the user's
+// NTLM hash. The gate here scrubs the dir to `undefined` (which makes the
+// SDK fall back to scanning every project dir, the legacy safe path) when
+// the input fails `isSafePath`.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getSessionTitleMock = vi.fn(async () => ({ summary: null, mtime: null }));
+const renameSessionTitleMock = vi.fn(async () => ({ ok: true }));
+const enqueuePendingRenameMock = vi.fn();
+
+vi.mock('../../sessionTitles', () => ({
+  getSessionTitle: (...a: unknown[]) => getSessionTitleMock(...(a as [])),
+  renameSessionTitle: (...a: unknown[]) => renameSessionTitleMock(...(a as [])),
+  listProjectSummaries: vi.fn(async () => []),
+  enqueuePendingRename: (...a: unknown[]) => enqueuePendingRenameMock(...(a as [])),
+  flushPendingRename: vi.fn(async () => undefined),
+}));
+
+import { registerSessionIpc } from '../sessionIpc';
+
+type Handler = (e: unknown, ...args: unknown[]) => unknown;
+
+function fakeIpcMain() {
+  const handlers = new Map<string, Handler>();
+  const ipcMain = {
+    handle: (ch: string, fn: Handler) => handlers.set(ch, fn),
+    on: (ch: string, fn: Handler) => handlers.set(ch, fn),
+  } as unknown as Electron.IpcMain;
+  return { ipcMain, handlers };
+}
+
+const SAFE_DIR = process.platform === 'win32' ? 'C:\\Users\\me\\proj' : '/home/me/proj';
+
+describe('sessionTitles dir security gate (#804 risk #5)', () => {
+  let handlers: Map<string, Handler>;
+
+  beforeEach(() => {
+    getSessionTitleMock.mockClear();
+    renameSessionTitleMock.mockClear();
+    enqueuePendingRenameMock.mockClear();
+    const built = fakeIpcMain();
+    handlers = built.handlers;
+    registerSessionIpc({
+      ipcMain: built.ipcMain,
+      setActiveSid: () => {},
+      onActiveSidChanged: () => {},
+      setSessionName: () => {},
+      markUserInput: () => {},
+    });
+  });
+
+  it('forwards a safe absolute dir verbatim to getSessionTitle', async () => {
+    const fn = handlers.get('sessionTitles:get')!;
+    await fn({}, 'sid-1', SAFE_DIR);
+    expect(getSessionTitleMock).toHaveBeenCalledWith('sid-1', SAFE_DIR);
+  });
+
+  it('scrubs UNC dir (backslash) to undefined on get', async () => {
+    const fn = handlers.get('sessionTitles:get')!;
+    await fn({}, 'sid-1', '\\\\evil\\share\\bait');
+    expect(getSessionTitleMock).toHaveBeenCalledWith('sid-1', undefined);
+  });
+
+  it('scrubs UNC dir (forward slash) to undefined on rename', async () => {
+    const fn = handlers.get('sessionTitles:rename')!;
+    await fn({}, 'sid-1', 'new-title', '//evil/share/bait');
+    expect(renameSessionTitleMock).toHaveBeenCalledWith('sid-1', 'new-title', undefined);
+  });
+
+  it('scrubs relative dir to undefined on enqueuePending', async () => {
+    const fn = handlers.get('sessionTitles:enqueuePending')!;
+    await fn({}, 'sid-1', 'title', '../../etc');
+    expect(enqueuePendingRenameMock).toHaveBeenCalledWith('sid-1', 'title', undefined);
+  });
+
+  it('scrubs non-string dir to undefined', async () => {
+    const fn = handlers.get('sessionTitles:get')!;
+    await fn({}, 'sid-1', 42 as unknown as string);
+    expect(getSessionTitleMock).toHaveBeenCalledWith('sid-1', undefined);
+  });
+
+  it('forwards undefined dir as undefined (legacy callers)', async () => {
+    const fn = handlers.get('sessionTitles:get')!;
+    await fn({}, 'sid-1');
+    expect(getSessionTitleMock).toHaveBeenCalledWith('sid-1', undefined);
+  });
+});

--- a/electron/ipc/__tests__/utilityIpcSecurity.test.ts
+++ b/electron/ipc/__tests__/utilityIpcSecurity.test.ts
@@ -1,0 +1,104 @@
+// Security gates around utilityIpc handlers (#804 risk #4).
+//
+// `app:userCwds:push` MUST drop UNC / relative / non-absolute strings
+// BEFORE forwarding to `pushUserCwd`. The LRU here later flows into
+// `pty:spawn`'s `cwd` arg via the StatusBar cwd popover; without this
+// gate a single hostile push persists a UNC trap path (NTLM-leak primitive
+// the moment the user reopens the popover).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as os from 'os';
+
+const pushUserCwdMock = vi.fn((p: string) => [p, os.homedir()]);
+const getUserCwdsMock = vi.fn(() => [os.homedir()]);
+
+vi.mock('electron', () => ({
+  BrowserWindow: { fromWebContents: () => null },
+  dialog: { showOpenDialog: async () => ({ canceled: true, filePaths: [] }) },
+}));
+vi.mock('../../import-scanner', () => ({
+  scanImportableSessions: async () => [],
+}));
+vi.mock('../../prefs/userCwds', () => ({
+  getUserCwds: () => getUserCwdsMock(),
+  pushUserCwd: (p: string) => pushUserCwdMock(p),
+}));
+
+import { registerUtilityIpc } from '../utilityIpc';
+
+type Handler = (e: unknown, ...args: unknown[]) => unknown;
+
+function fakeIpcMain() {
+  const handlers = new Map<string, Handler>();
+  const ipcMain = {
+    handle: (ch: string, fn: Handler) => handlers.set(ch, fn),
+    on: (ch: string, fn: Handler) => handlers.set(ch, fn),
+  } as unknown as Electron.IpcMain;
+  return { ipcMain, handlers };
+}
+
+// Build an IpcMainInvokeEvent that passes the fromMainFrame guard.
+function mainFrameEvent(): Electron.IpcMainInvokeEvent {
+  const mainFrame = { id: 1 };
+  return {
+    sender: { mainFrame },
+    senderFrame: mainFrame,
+  } as unknown as Electron.IpcMainInvokeEvent;
+}
+
+describe('app:userCwds:push security gate (#804 risk #4)', () => {
+  let push: Handler;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    pushUserCwdMock.mockClear();
+    getUserCwdsMock.mockClear();
+    const { ipcMain, handlers } = fakeIpcMain();
+    registerUtilityIpc({ ipcMain });
+    push = handlers.get('app:userCwds:push')!;
+    expect(push).toBeDefined();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('accepts a safe absolute path', () => {
+    const safe = process.platform === 'win32' ? 'C:\\Users\\me\\proj' : '/home/me/proj';
+    push(mainFrameEvent(), safe);
+    expect(pushUserCwdMock).toHaveBeenCalledWith(safe);
+  });
+
+  it('rejects UNC path (backslash) without calling pushUserCwd', () => {
+    push(mainFrameEvent(), '\\\\evil-host\\share\\bait');
+    expect(pushUserCwdMock).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('rejected unsafe path'),
+    );
+  });
+
+  it('rejects UNC path (forward slash)', () => {
+    push(mainFrameEvent(), '//evil-host/share/bait');
+    expect(pushUserCwdMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects relative escape paths (../)', () => {
+    push(mainFrameEvent(), '../../etc/passwd');
+    expect(pushUserCwdMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-string payloads', () => {
+    push(mainFrameEvent(), 42);
+    push(mainFrameEvent(), null);
+    push(mainFrameEvent(), { path: '/x' });
+    expect(pushUserCwdMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects when sender is a sub-frame (fromMainFrame guard)', () => {
+    const subFrame = { id: 2 };
+    const e = {
+      sender: { mainFrame: { id: 1 } },
+      senderFrame: subFrame,
+    } as unknown as Electron.IpcMainInvokeEvent;
+    const safe = process.platform === 'win32' ? 'C:\\safe' : '/safe';
+    push(e, safe);
+    expect(pushUserCwdMock).not.toHaveBeenCalled();
+  });
+});

--- a/electron/ipc/sessionIpc.ts
+++ b/electron/ipc/sessionIpc.ts
@@ -26,7 +26,7 @@ import {
   enqueuePendingRename,
   flushPendingRename,
 } from '../sessionTitles';
-import { fromMainFrame } from '../security/ipcGuards';
+import { fromMainFrame, isSafePath } from '../security/ipcGuards';
 
 export interface SessionIpcDeps {
   ipcMain: IpcMain;
@@ -57,13 +57,20 @@ export function registerSessionIpc(deps: SessionIpcDeps): void {
   } = deps;
 
   // ─────────────────────── sessionTitles bridge ──────────────────────────
+  // Security gate (#804 risk #5): the renderer-supplied `dir` arg is
+  // forwarded straight into the Anthropic SDK which fs.joins it under
+  // ~/.claude/projects/<key>/... — UNC / relative dirs are an NTLM-leak +
+  // path-traversal primitive. Drop the `dir` (SDK falls back to scanning
+  // every project dir) when it fails the safety filter.
+  const safeDir = (dir: unknown): string | undefined =>
+    typeof dir === 'string' && isSafePath(dir) ? dir : undefined;
   ipcMain.handle('sessionTitles:get', (_e, sid: string, dir?: string) =>
-    getSessionTitle(sid, dir),
+    getSessionTitle(sid, safeDir(dir)),
   );
   ipcMain.handle(
     'sessionTitles:rename',
     (_e, sid: string, title: string, dir?: string) =>
-      renameSessionTitle(sid, title, dir),
+      renameSessionTitle(sid, title, safeDir(dir)),
   );
   ipcMain.handle('sessionTitles:listForProject', (_e, projectKey: string) =>
     listProjectSummaries(projectKey),
@@ -75,7 +82,7 @@ export function registerSessionIpc(deps: SessionIpcDeps): void {
   ipcMain.handle(
     'sessionTitles:enqueuePending',
     (_e, sid: string, title: string, dir?: string) => {
-      enqueuePendingRename(sid, title, dir);
+      enqueuePendingRename(sid, title, safeDir(dir));
     },
   );
   ipcMain.handle('sessionTitles:flushPending', (_e, sid: string) =>

--- a/electron/ipc/utilityIpc.ts
+++ b/electron/ipc/utilityIpc.ts
@@ -113,6 +113,17 @@ export function registerUtilityIpc(deps: UtilityIpcDeps): void {
   ipcMain.handle('app:userCwds:push', (e, p: unknown) => {
     if (!fromMainFrame(e)) return getUserCwds();
     if (typeof p !== 'string') return getUserCwds();
+    // Security gate (#804 risk #4): the LRU here feeds the cwd popover and
+    // is later replayed into `pty:spawn`. A single hostile push would
+    // persist a UNC trap path that statSync's later — see resolveSpawnCwd.
+    // Drop unsafe entries (UNC / relative / non-absolute) at the boundary
+    // so they never reach disk.
+    if (!isSafePath(p)) {
+      console.warn(
+        `[main] app:userCwds:push rejected unsafe path ${JSON.stringify(p)}`,
+      );
+      return getUserCwds();
+    }
     return pushUserCwd(p);
   });
   ipcMain.handle('app:userHome', () => os.homedir());

--- a/electron/ptyHost/__tests__/cwdResolver.test.ts
+++ b/electron/ptyHost/__tests__/cwdResolver.test.ts
@@ -48,4 +48,28 @@ describe('resolveSpawnCwd', () => {
     expect(resolveSpawnCwd(file)).toBe(homedir());
     expect(console.warn).toHaveBeenCalled();
   });
+
+  // #804 risk #1: UNC paths must be rejected BEFORE statSync — otherwise
+  // statSync('\\\\evil\\share') triggers an SMB handshake that leaks the
+  // user's NTLM hash to the named host.
+  it('rejects UNC cwd (backslash) without statSync, falls back to homedir', () => {
+    expect(resolveSpawnCwd('\\\\evil-host\\share\\probe')).toBe(homedir());
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('rejected by isSafePath'),
+    );
+  });
+
+  it('rejects UNC cwd (forward slash) without statSync', () => {
+    expect(resolveSpawnCwd('//evil-host/share/probe')).toBe(homedir());
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('rejected by isSafePath'),
+    );
+  });
+
+  it('rejects relative cwd without statSync', () => {
+    expect(resolveSpawnCwd('relative/path')).toBe(homedir());
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('rejected by isSafePath'),
+    );
+  });
 });

--- a/electron/ptyHost/__tests__/jsonlResolver.test.ts
+++ b/electron/ptyHost/__tests__/jsonlResolver.test.ts
@@ -73,18 +73,38 @@ describe('toClaudeSid', () => {
   });
 
   it('is deterministic across calls', () => {
-    expect(toClaudeSid('foo')).toBe(toClaudeSid('foo'));
+    expect(toClaudeSid('ccsm-session-foo')).toBe(toClaudeSid('ccsm-session-foo'));
   });
 
   it('produces different outputs for different inputs', () => {
-    expect(toClaudeSid('foo')).not.toBe(toClaudeSid('bar'));
+    expect(toClaudeSid('ccsm-session-foo')).not.toBe(toClaudeSid('ccsm-session-bar'));
   });
 
-  it('handles empty string deterministically', () => {
-    const a = toClaudeSid('');
-    const b = toClaudeSid('');
-    expect(a).toBe(b);
-    expect(a).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  // #804 risk #6: sid is argv to `pty.spawn`. Reject anything outside
+  // [a-zA-Z0-9_-]{8,64} so a hostile renderer cannot smuggle `--dangerous-flag`
+  // or empty-string into the CLI as a positional arg.
+  it('rejects empty string', () => {
+    expect(() => toClaudeSid('')).toThrow(/invalid sid/);
+  });
+
+  it('rejects too-short sid', () => {
+    expect(() => toClaudeSid('abc')).toThrow(/invalid sid/);
+  });
+
+  it('rejects too-long sid (>64 chars)', () => {
+    expect(() => toClaudeSid('a'.repeat(65))).toThrow(/invalid sid/);
+  });
+
+  it('rejects sid containing argv-injection characters', () => {
+    expect(() => toClaudeSid('--dangerous-flag')).toThrow(/invalid sid/);
+    expect(() => toClaudeSid('sid with space')).toThrow(/invalid sid/);
+    expect(() => toClaudeSid('sid;rm-rf/')).toThrow(/invalid sid/);
+  });
+
+  it('rejects non-string inputs', () => {
+    expect(() => toClaudeSid(undefined as unknown as string)).toThrow(/invalid sid/);
+    expect(() => toClaudeSid(null as unknown as string)).toThrow(/invalid sid/);
+    expect(() => toClaudeSid(42 as unknown as string)).toThrow(/invalid sid/);
   });
 });
 

--- a/electron/ptyHost/cwdResolver.ts
+++ b/electron/ptyHost/cwdResolver.ts
@@ -10,10 +10,22 @@
 
 import { statSync } from 'node:fs';
 import { homedir } from 'node:os';
+import { isSafePath } from '../security/ipcGuards';
 
 export function resolveSpawnCwd(requested: string | null | undefined): string {
   const fallback = homedir();
   if (!requested || requested.length === 0) return fallback;
+  // Security gate (#804 risk #1): reject UNC / relative / non-string paths
+  // BEFORE the statSync. On Windows `statSync('\\\\evil\\share')` triggers
+  // an SMB handshake that leaks the user's NTLM hash. The renderer-supplied
+  // cwd flows directly here from `pty:spawn`, so this is the only choke
+  // point that protects the entire spawn pipeline.
+  if (!isSafePath(requested)) {
+    console.warn(
+      `[ptyHost] cwd ${JSON.stringify(requested)} rejected by isSafePath (UNC / relative); falling back to ${fallback}`,
+    );
+    return fallback;
+  }
   try {
     const st = statSync(requested);
     if (st.isDirectory()) return requested;

--- a/electron/ptyHost/jsonlResolver.ts
+++ b/electron/ptyHost/jsonlResolver.ts
@@ -15,7 +15,20 @@ import { cwdToProjectKey } from '../sessionWatcher/projectKey';
 // (which requires a valid UUID for --session-id / --resume) accepts it.
 const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
+// Defense-in-depth (#804 risk #6): the ccsm sid eventually lands in
+// `pty.spawn(claudePath, [flag, claudeSid], …)` as a real argv slot. node-pty
+// does NOT shell-interpret, but a sid like `--dangerous-flag` would be picked
+// up by the CLI as a real flag. Constrain the input character set + length to
+// the shape the renderer's `crypto.randomUUID()` (and the legacy
+// `<prefix>-<random>` fallback) actually produce — alphanumerics, dashes, and
+// underscores, 8-64 chars, AND require an alphanumeric first char so a sid
+// starting with `-` cannot be smuggled into argv as a CLI flag.
+const VALID_SID_RE = /^[a-zA-Z0-9][a-zA-Z0-9_-]{7,63}$/;
+
 export function toClaudeSid(ccsmSessionId: string): string {
+  if (typeof ccsmSessionId !== 'string' || !VALID_SID_RE.test(ccsmSessionId)) {
+    throw new Error(`invalid sid: ${JSON.stringify(ccsmSessionId)}`);
+  }
   if (UUID_V4_RE.test(ccsmSessionId)) return ccsmSessionId.toLowerCase();
   const hex = createHash('sha256').update(ccsmSessionId).digest('hex');
   const yNibble = (parseInt(hex[16]!, 16) & 0x3) | 0x8;

--- a/electron/window/__tests__/createWindow.test.ts
+++ b/electron/window/__tests__/createWindow.test.ts
@@ -15,7 +15,7 @@ vi.mock('electron', () => {
   return { Menu };
 });
 
-import { installContextMenu } from '../createWindow';
+import { installContextMenu, isAllowedNavigation } from '../createWindow';
 
 interface ContextMenuParams {
   selectionText: string;
@@ -142,5 +142,45 @@ describe('installContextMenu', () => {
     const items = popupCalls[0].items as Array<Record<string, unknown>>;
     const paste = items.find((i) => i.role === 'paste');
     expect(paste?.enabled).toBe(false);
+  });
+});
+
+// #804 risk #7: the previous allowlist hardcoded `http://localhost:4100`
+// in addition to the env-driven port. Stale dev port + dev build = bypass
+// surface. The decider here only honors the env-driven origin (and `file:`
+// for the prod renderer load).
+describe('isAllowedNavigation (#804 risk #7)', () => {
+  it('allows the env-driven dev origin', () => {
+    expect(isAllowedNavigation('http://localhost:5174/foo', '5174')).toBe(true);
+  });
+
+  it('allows file: protocol for production renderer load', () => {
+    expect(isAllowedNavigation('file:///C:/app/renderer/index.html', '5174')).toBe(true);
+  });
+
+  it('falls back to port 4100 when env var unset', () => {
+    expect(isAllowedNavigation('http://localhost:4100/x', undefined)).toBe(true);
+    expect(isAllowedNavigation('http://localhost:4100/x', '')).toBe(true);
+  });
+
+  it('blocks the legacy hardcoded localhost:4100 when env points elsewhere', () => {
+    // The bug being fixed: when CCSM_DEV_PORT=5174, navigation to
+    // localhost:4100 must be denied. Previously both ports were allowed.
+    expect(isAllowedNavigation('http://localhost:4100/evil', '5174')).toBe(false);
+  });
+
+  it('blocks arbitrary external origins', () => {
+    expect(isAllowedNavigation('https://evil.example.com/', '5174')).toBe(false);
+    expect(isAllowedNavigation('http://attacker.test/x', '4100')).toBe(false);
+  });
+
+  it('blocks malformed URLs (returns false instead of throwing)', () => {
+    expect(isAllowedNavigation('not a url', '4100')).toBe(false);
+    expect(isAllowedNavigation('', '4100')).toBe(false);
+  });
+
+  it('blocks other protocols (javascript:, data:)', () => {
+    expect(isAllowedNavigation('javascript:alert(1)', '4100')).toBe(false);
+    expect(isAllowedNavigation('data:text/html,<script>x</script>', '4100')).toBe(false);
   });
 });

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -55,6 +55,26 @@ export interface CreateWindowDeps {
   setIsQuitting: (v: boolean) => void;
 }
 
+// Pure decider for the `will-navigate` allowlist (#804 risk #7). Allows the
+// env-driven dev server origin (`CCSM_DEV_PORT`, defaulting to 4100 when
+// unset) and any `file:` navigation (production renderer load). The literal
+// `localhost:4100` was previously allowed unconditionally in addition to the
+// env-driven origin — drop the literal so a stale dev port + dev build is not
+// a navigation-bypass surface. Exported for the `installContextMenu`-style
+// unit test in `__tests__/createWindow.test.ts`.
+export function isAllowedNavigation(
+  url: string,
+  envDevPort: string | undefined,
+): boolean {
+  try {
+    const u = new URL(url);
+    const devPort = envDevPort && envDevPort.length > 0 ? envDevPort : '4100';
+    return u.origin === `http://localhost:${devPort}` || u.protocol === 'file:';
+  } catch {
+    return false;
+  }
+}
+
 // Right-click context menu for the renderer — Copy/Cut/Paste/Select All,
 // contextually enabled based on selection + editable state. Attached per
 // window in createWindow().
@@ -186,15 +206,7 @@ export function createWindow(deps: CreateWindowDeps): BrowserWindow {
   // should never navigate; all external links go through `shell:openExternal`
   // (which itself filters to http(s) only).
   win.webContents.on('will-navigate', (event, url) => {
-    try {
-      const u = new URL(url);
-      const devPort = process.env.CCSM_DEV_PORT || '4100';
-      const allowed =
-        u.origin === `http://localhost:${devPort}` ||
-        u.origin === 'http://localhost:4100' ||
-        u.protocol === 'file:';
-      if (!allowed) event.preventDefault();
-    } catch {
+    if (!isAllowedNavigation(url, process.env.CCSM_DEV_PORT)) {
       event.preventDefault();
     }
   });


### PR DESCRIPTION
Tech-debt R8 (Task #804) — security S-cluster, addresses risks #1, #4, #5, #6, #7 from `artifacts/tech-debt-08-security.md`.

## Summary

Five small security gates closing the cheapest exploitability/impact items in the audit. All changes are leaf-level validators — no behavioural drift on the happy path.

| Risk | Where | Gate |
|---|---|---|
| #1 | `electron/ptyHost/cwdResolver.ts` | `isSafePath(cwd)` BEFORE `statSync` (Windows NTLM-leak primitive on UNC) |
| #4 | `electron/ipc/utilityIpc.ts` | `isSafePath(p)` on `app:userCwds:push` (LRU later replays into pty:spawn) |
| #5 | `electron/ipc/sessionIpc.ts` | `safeDir()` scrubs UNC/relative `dir` to undefined for `sessionTitles:{get,rename,enqueuePending}` |
| #6 | `electron/ptyHost/jsonlResolver.ts` | `toClaudeSid` rejects sid not matching `/^[a-zA-Z0-9][a-zA-Z0-9_-]{7,63}$/` (argv injection — required leading alphanumeric so `--dangerous-flag` cannot land as a CLI flag) |
| #7 | `electron/window/createWindow.ts` | drop hardcoded `http://localhost:4100` from `will-navigate` allowlist; only env-driven `CCSM_DEV_PORT` origin honored. Extracted `isAllowedNavigation()` as exported pure decider |

## Reverse-verify

Each gate has a green forward test AND a red reverse cycle (commenting out / replacing the guard makes the new tests fail). All five reverse-verify outputs captured below.

### #1 cwdResolver — gate disabled (`if (false && !isSafePath(...))`)

```
✗ rejects UNC cwd (backslash) without statSync, falls back to homedir
  AssertionError: warn called with "...unusable (ENOENT...)" instead of "rejected by isSafePath"
✗ rejects UNC cwd (forward slash) without statSync
✗ rejects relative cwd without statSync
Tests  3 failed | 5 passed (8)
```

### #4 utilityIpc userCwds:push — gate disabled

```
✗ rejects UNC path (backslash) without calling pushUserCwd
✗ rejects UNC path (forward slash)
✗ rejects relative escape paths (../)
Tests  3 failed | 3 passed (6)
```

### #5 sessionIpc safeDir — gate replaced with `dir.length > 0 ? dir : undefined`

```
✗ scrubs UNC dir (backslash) to undefined on get
✗ scrubs UNC dir (forward slash) to undefined on rename
✗ scrubs relative dir to undefined on enqueuePending
Tests  3 failed | 3 passed (6)
```

### #6 toClaudeSid — VALID_SID_RE.test() replaced with false

```
✗ toClaudeSid > rejects empty string
✗ toClaudeSid > rejects too-short sid
✗ toClaudeSid > rejects too-long sid (>64 chars)
✗ toClaudeSid > rejects sid containing argv-injection characters
Tests  4 failed | 5 passed | 26 skipped (35)
```

### #7 isAllowedNavigation — re-added literal `localhost:4100` to the OR

```
✗ blocks the legacy hardcoded localhost:4100 when env points elsewhere
  AssertionError: expected true to be false
Tests  1 failed | 6 passed (12)
```

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] Affected unit suites green (security + ipc + ptyHost + window)
- [x] Module load smoke (`node -e "require('./dist/electron/...')"`) green for all 5 modified main-process modules
- [x] Each gate reverse-verified (gate removed → red; gate restored → green)

## Notes

- For risk #1 I kept the existing fallback-to-homedir+warn contract on rejection rather than throwing. The function is called from the spawn lifecycle path; throwing would surface as a hard spawn failure to the user. Drop-with-warn matches the existing rejection pattern for non-existent / file paths and also matches `probePaths`'s drop-with-false pattern for unsafe paths. Security goal (no statSync of unsafe path) is preserved by the early return.
- For risk #6 I tightened the sid pattern to require a leading alphanumeric (not just any `[a-zA-Z0-9_-]`). Without this constraint `--dangerous-flag` would have matched `[a-zA-Z0-9_-]{8,64}` and been accepted. The renderer's `crypto.randomUUID()` always produces a hex-leading sid; the legacy `<prefix>-<random>` fallback uses an alphanumeric prefix. Real sids never start with `-`.
- For risk #5 the artifact mentions a "path is under `~/.claude/projects/`" extra check, but the `dir` arg here is actually a session **cwd** (e.g. `C:\Users\me\code`) that the SDK realpath-encodes into a project key. `isSafePath` is the right gate; an additional `path.relative(claudeProjectsDir, ...)` check would reject every legitimate caller. `listForProject` takes a `projectKey` (not a `dir`), so it's not in scope for this gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)