### PR TITLE
refactor: consolidate SessionState type to single source

### DIFF
--- a/electron/preload/bridges/ccsmSession.ts
+++ b/electron/preload/bridges/ccsmSession.ts
@@ -15,8 +15,12 @@
 
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron';
 
-export type SessionState = 'idle' | 'running' | 'requires_action';
-type SessionStatePayload = { sid: string; state: SessionState };
+// Canonical 3-state vocabulary lives in `src/shared/sessionState.ts` so
+// the renderer (`src/session.d.ts`), the watcher (`electron/sessionWatcher/
+// inference.ts` `WatcherState`), and this preload bridge all share one
+// definition. Tech-debt audit #10 item #2.
+export type { SessionState } from '../../../src/shared/sessionState';
+import type { SessionStatePayload } from '../../../src/shared/sessionState';
 type SessionActivatePayload = { sid: string };
 type SessionTitlePayload = { sid: string; title: string };
 type SessionCwdRedirectedPayload = { sid: string; newCwd: string };

--- a/electron/sessionWatcher/inference.ts
+++ b/electron/sessionWatcher/inference.ts
@@ -31,7 +31,12 @@
 //     hasn't written its first frame yet — caller's fs.watch will tick
 //     us again as soon as anything lands).
 
-export type WatcherState = 'idle' | 'running' | 'requires_action';
+// Alias of the canonical `SessionState` (`src/shared/sessionState.ts`).
+// Kept as `WatcherState` because every existing caller in this subtree
+// (emitDecider, stateEmitter, tests) imports it under that name. Tech-debt
+// audit #10 item #2: dedupe the 3-state union without churning callers.
+import type { SessionState } from '../../src/shared/sessionState';
+export type WatcherState = SessionState;
 
 interface ToolUseRef { id: string }
 

--- a/src/session.d.ts
+++ b/src/session.d.ts
@@ -1,7 +1,7 @@
 // Renderer-side view of the `window.ccsmSession` preload bridge defined
-// in `electron/preload.ts`. The signal originates from the JSONL
-// tail-watcher in `electron/sessionWatcher` and arrives over the
-// `session:state` IPC channel as `{sid, state}`.
+// in `electron/preload/bridges/ccsmSession.ts`. The signal originates
+// from the JSONL tail-watcher in `electron/sessionWatcher` and arrives
+// over the `session:state` IPC channel as `{sid, state}`.
 //
 // State name semantics (mirrors the SDK's authoritative
 // `SDKSessionStateChangedMessage.state` enum so we don't invent parallel
@@ -10,20 +10,22 @@
 //   * 'running'          — claude is mid-turn (tool call out, or user just typed).
 //   * 'requires_action'  — claude paused on a permission prompt.
 //
+// The canonical type lives in `src/shared/sessionState.ts` and is shared
+// with `electron/sessionWatcher/inference.ts` (`WatcherState` alias) and
+// the preload bridge. We just re-export here so renderer call sites that
+// already imported `from '../session'` keep working.
+//
 // Sidebar dot rules live in `src/components/Sidebar.tsx`. The notify
 // integration (PR-B) will subscribe to the same signal.
 
-export type SessionState = 'idle' | 'running' | 'requires_action';
-
-export interface SessionStatePayload {
-  sid: string;
-  state: SessionState;
-}
+export type { SessionState, SessionStatePayload } from './shared/sessionState';
 
 export interface SessionTitlePayload {
   sid: string;
   title: string;
 }
+
+import type { SessionStatePayload } from './shared/sessionState';
 
 export interface CcsmSessionApi {
   onState(cb: (e: SessionStatePayload) => void): () => void;

--- a/src/shared/sessionState.ts
+++ b/src/shared/sessionState.ts
@@ -1,0 +1,29 @@
+// Canonical IPC `SessionState` vocabulary — the single source of truth
+// for the 3-state union emitted by `electron/sessionWatcher` and forwarded
+// over the `session:state` IPC channel to the renderer (PR for tech-debt
+// audit #10 item #2: SessionState was previously redeclared in 4+ places
+// with already-present drift).
+//
+// Mirrors the SDK's authoritative `SDKSessionStateChangedMessage.state`
+// enum so we don't invent parallel vocabulary:
+//   * 'idle'             — claude finished its turn, the user owes the next move.
+//   * 'running'          — claude is mid-turn (tool call out, or user just typed).
+//   * 'requires_action'  — claude paused on a permission prompt.
+//
+// Lives under `src/shared/` because `tsconfig.electron.json` includes
+// `src/shared/**/*` — both the renderer bundle (via `tsconfig.json`'s
+// `src/**/*`) and the electron CJS compilation can import from this file
+// without crossing tree boundaries.
+//
+// IMPORTANT: This is the IPC vocabulary, NOT the renderer's mapped UI
+// state on `Session.state` (which is a 2-state `'idle' | 'waiting'`
+// model — see `src/types.ts`). The mapping IPC → UI lives in
+// `src/agent/lifecycle.ts:mapState`. Don't conflate the two even though
+// they share the `'idle'` literal.
+
+export type SessionState = 'idle' | 'running' | 'requires_action';
+
+export interface SessionStatePayload {
+  sid: string;
+  state: SessionState;
+}

--- a/src/stores/slices/types.ts
+++ b/src/stores/slices/types.ts
@@ -4,7 +4,7 @@
 // every slice). The store re-exports the public-facing types so existing
 // call sites continue to import from `../store`.
 
-import type { Group, Session } from '../../types';
+import type { Group, Session, SessionState } from '../../types';
 import type { ConnectionInfo } from '../../shared/ipc-types';
 
 export type ModelId = string;
@@ -104,7 +104,7 @@ export type Actions = {
   }) => string;
   renameSession: (id: string, name: string) => Promise<void>;
   _applyExternalTitle: (sid: string, title: string) => void;
-  _applySessionState: (sid: string, state: 'idle' | 'waiting') => void;
+  _applySessionState: (sid: string, state: SessionState) => void;
   _setFlash: (sid: string, on: boolean) => void;
   _applyCwdRedirect: (sid: string, newCwd: string) => void;
   _applyPtyExit: (

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,15 @@
+// Renderer-side UI display state for `Session.state` — a 2-state model
+// derived from the 3-state IPC vocabulary. The mapping CLI/IPC →
+// renderer lives in `src/agent/lifecycle.ts:mapState`:
+//   IPC 'idle' / 'requires_action'  → 'waiting'  (sidebar halo on)
+//   IPC 'running'                   → 'idle'     (no halo)
+//
+// This is NOT the IPC `SessionState` (3-state union); for that see
+// `src/shared/sessionState.ts`. Tech-debt audit #10 #2 — kept as a
+// distinct type because it represents a different abstraction (the
+// sidebar's two-state attention model), not a stale copy of the IPC
+// vocabulary. Don't fold these together without changing the renderer
+// halo logic.
 export type SessionState = 'idle' | 'waiting';
 
 // MVP scope is single-agent. Keeping this as a discriminated string lets us

--- a/tests/agent-lifecycle-unfocused.test.ts
+++ b/tests/agent-lifecycle-unfocused.test.ts
@@ -13,7 +13,9 @@ import { subscribeAgentEvents } from '../src/agent/lifecycle';
 // and rely on the unsubscribe handle to clear the install guard between
 // tests.
 
-type Listener = (e: { sid: string; state: 'idle' | 'running' | 'requires_action' }) => void;
+import type { SessionState } from '../src/shared/sessionState';
+
+type Listener = (e: { sid: string; state: SessionState }) => void;
 
 let fire: Listener = () => undefined;
 


### PR DESCRIPTION
## Summary

Tech-debt audit #10 item #2 (`tech-debt-10-DRY.md` #2): the 3-state IPC `SessionState` vocabulary (`'idle' | 'running' | 'requires_action'`) was redeclared inline in 4 places — preload bridge, watcher inference, `src/session.d.ts`, and a test — with the constant drift risk that any one site could fall out of sync (the SDK is the upstream authority).

Canonicalize on `src/shared/sessionState.ts`. `tsconfig.electron.json` already includes `src/shared/**/*` (matching the existing `src/shared/ipc-types.ts` pattern), so both renderer and main can import without crossing tree boundaries.

## Files touched

- `src/shared/sessionState.ts` (new) — canonical `SessionState` + `SessionStatePayload`
- `src/session.d.ts` — re-exports from canonical
- `electron/preload/bridges/ccsmSession.ts` — re-exports from canonical
- `electron/sessionWatcher/inference.ts` — `WatcherState` aliases canonical
- `tests/agent-lifecycle-unfocused.test.ts` — imports canonical
- `src/stores/slices/types.ts` — `_applySessionState` signature switched from inline `'idle' | 'waiting'` literal to the renderer `SessionState` from `src/types.ts`
- `src/types.ts` — comment-only: clarify this is the renderer 2-state UI model, NOT the IPC vocabulary

## Layer-1 note (audit divergence)

The audit flagged `src/types.ts` `SessionState = 'idle' | 'waiting'` as "STALE / WRONG", calling for its deletion. Reading `src/agent/lifecycle.ts:mapState` shows it is the renderer's mapped 2-state UI model (sidebar halo on/off) — `IPC 'idle' | 'requires_action' → 'waiting'`, `IPC 'running' → 'idle'`. It is a different abstraction, not a stale copy. Folding it into the IPC type would silently break sidebar halo logic and the active-session suppression in `_applySessionState`. Kept distinct with a doc-block calling out the difference and pointing at the canonical IPC type.

## Verification

- `npm run typecheck` clean (renderer + electron)
- `npm run build` clean
- `npm test` 961/961 pass
- **Reverse-verify**: temporarily removed `'requires_action'` from canonical → `tsc` fails at `electron/sessionWatcher/inference.ts(115,5): error TS2322: Type '"requires_action"' is not assignable to type 'SessionState'.` Confirms the consolidation is wired through; restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)