### PR TITLE
refactor: drop store.ts re-export wall, codemod call sites to slices

### DIFF
--- a/src/app-effects/useThemeEffect.ts
+++ b/src/app-effects/useThemeEffect.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { resolveEffectiveTheme } from '../stores/store';
+import { resolveEffectiveTheme } from '../stores/slices/appearanceSlice';
 
 /**
  * Sync the user's theme preference (and, when set to `system`, the OS

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -5,7 +5,8 @@ import { cn } from '../lib/cn';
 import { Dialog, DialogPortal, DialogOverlay } from './ui/Dialog';
 import * as RD from '@radix-ui/react-dialog';
 import { AgentIcon } from './AgentIcon';
-import { useStore, resolveEffectiveTheme } from '../stores/store';
+import { useStore } from '../stores/store';
+import { resolveEffectiveTheme } from '../stores/slices/appearanceSlice';
 import { useTranslation } from '../i18n/useTranslation';
 import { useFocusRestore } from '../lib/useFocusRestore';
 

--- a/src/components/SidebarResizer.tsx
+++ b/src/components/SidebarResizer.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useRef } from 'react';
+import { useStore } from '../stores/store';
 import {
-  useStore,
   sanitizeSidebarWidth,
   SIDEBAR_WIDTH_DEFAULT,
   SIDEBAR_WIDTH_MIN,
-  SIDEBAR_WIDTH_MAX
-} from '../stores/store';
+  SIDEBAR_WIDTH_MAX,
+} from '../stores/slices/appearanceSlice';
 import { useTranslation } from '../i18n/useTranslation';
 
 /**

--- a/src/stores/persist.ts
+++ b/src/stores/persist.ts
@@ -3,7 +3,7 @@ import type {
   Theme,
   FontSize,
   FontSizePx,
-} from './store';
+} from './slices/types';
 
 export const STATE_KEY = 'main';
 

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -10,54 +10,10 @@ import {
   legacyFontSizeToPx,
   sanitizeFontSizePx,
   resolvePersistedSidebarWidth,
-  SIDEBAR_WIDTH_DEFAULT,
-  SIDEBAR_WIDTH_MIN,
-  SIDEBAR_WIDTH_MAX,
-  sanitizeSidebarWidth,
-  resolveEffectiveTheme,
-  pxToLegacyFontSize,
 } from './slices/appearanceSlice';
 import { createModelPickerSlice } from './slices/modelPickerSlice';
 import { createPopoverSlice } from './slices/popoverSlice';
-import type { State, Actions, RootStore } from './slices/types';
-
-// Re-export the slice-owned types and helpers for back-compat with the
-// existing call sites that still import them from `./store` (Sidebar,
-// SidebarResizer, CommandPalette, settings panes, persist.ts, etc.).
-// The slice modules are the authoritative source — these are pass-through
-// re-exports so a caller swapping import paths is the only follow-up
-// needed if/when we ever flatten further.
-export type {
-  ModelId,
-  PermissionMode,
-  Theme,
-  FontSize,
-  FontSizePx,
-  EndpointKind,
-  ModelSource,
-  DiscoveredModel,
-  ConnectionInfo,
-  CreateSessionOptions,
-  SessionSnapshot,
-  GroupSnapshot,
-} from './slices/types';
-
-export {
-  legacyFontSizeToPx,
-  pxToLegacyFontSize,
-  sanitizeFontSizePx,
-  resolvePersistedSidebarWidth,
-  SIDEBAR_WIDTH_DEFAULT,
-  SIDEBAR_WIDTH_MIN,
-  SIDEBAR_WIDTH_MAX,
-  sanitizeSidebarWidth,
-  resolveEffectiveTheme,
-};
-
-// `migratePermission` and `migrateNotificationSettings` were removed in PR-D
-// alongside the `permission` and `notificationSettings` store fields. Older
-// persisted snapshots may still carry those keys; they're silently ignored
-// when `hydrateStore` builds its `setState` payload.
+import type { State, RootStore } from './slices/types';
 
 export const useStore = create<RootStore>((set, get) => ({
   ...createSessionCrudSlice(set, get),
@@ -267,6 +223,3 @@ export async function hydrateStore(): Promise<void> {
     schedulePersist(snapshot);
   });
 }
-
-// Re-export composite types for callers that imported them from store.ts.
-export type { State, Actions };

--- a/tests/appearance.test.ts
+++ b/tests/appearance.test.ts
@@ -9,7 +9,7 @@ import {
   SIDEBAR_WIDTH_DEFAULT,
   SIDEBAR_WIDTH_MIN,
   SIDEBAR_WIDTH_MAX,
-} from '../src/stores/store';
+} from '../src/stores/slices/appearanceSlice';
 
 describe('resolveEffectiveTheme', () => {
   it('dark selection is always dark regardless of OS', () => {

--- a/tests/sidebar-resizer-keyboard.test.tsx
+++ b/tests/sidebar-resizer-keyboard.test.tsx
@@ -8,7 +8,8 @@ import React from 'react';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { SidebarResizer, SIDEBAR_RESIZER_STEP, SIDEBAR_RESIZER_STEP_LARGE } from '../src/components/SidebarResizer';
-import { useStore, SIDEBAR_WIDTH_DEFAULT, SIDEBAR_WIDTH_MIN, SIDEBAR_WIDTH_MAX } from '../src/stores/store';
+import { useStore } from '../src/stores/store';
+import { SIDEBAR_WIDTH_DEFAULT, SIDEBAR_WIDTH_MIN, SIDEBAR_WIDTH_MAX } from '../src/stores/slices/appearanceSlice';
 
 describe('SidebarResizer keyboard a11y', () => {
   beforeEach(() => {

--- a/tests/store-appearance.test.ts
+++ b/tests/store-appearance.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from 'vitest';
+import { useStore } from '../src/stores/store';
 import {
-  useStore,
   SIDEBAR_WIDTH_DEFAULT,
   SIDEBAR_WIDTH_MIN,
-  SIDEBAR_WIDTH_MAX
-} from '../src/stores/store';
+  SIDEBAR_WIDTH_MAX,
+} from '../src/stores/slices/appearanceSlice';
 
 describe('appearance setters', () => {
   it('setFontSizePx updates both px and legacy enum', () => {


### PR DESCRIPTION
## Summary

Tech-debt R11#3: `src/stores/store.ts` had a 26-line back-compat re-export wall (lines 30-55) forwarding 12 types + 9 helpers from `slices/types` and `slices/appearanceSlice`. Header comment self-documented as pass-through "until we ever flatten further" — flattening now. Task #817.

## Consumers updated

Each consumer's import switched to the authoritative slice module:

| File | Names | New source |
|---|---|---|
| `src/stores/persist.ts` | `Theme`, `FontSize`, `FontSizePx` | `./slices/types` |
| `src/components/SidebarResizer.tsx` | `sanitizeSidebarWidth`, `SIDEBAR_WIDTH_DEFAULT/MIN/MAX` | `../stores/slices/appearanceSlice` |
| `src/components/CommandPalette.tsx` | `resolveEffectiveTheme` | `../stores/slices/appearanceSlice` |
| `src/app-effects/useThemeEffect.ts` | `resolveEffectiveTheme` | `../stores/slices/appearanceSlice` |
| `tests/appearance.test.ts` | all 9 helpers | `../src/stores/slices/appearanceSlice` |
| `tests/store-appearance.test.ts` | `SIDEBAR_WIDTH_*` | `../src/stores/slices/appearanceSlice` |
| `tests/sidebar-resizer-keyboard.test.tsx` | `SIDEBAR_WIDTH_*` | `../src/stores/slices/appearanceSlice` |

`useStore` / `hydrateStore` / `HydrationTrace` consumers are unchanged — those still legitimately live in `store.ts`.

Audit found **no consumers** of the type re-exports `ModelId`, `PermissionMode`, `EndpointKind`, `ModelSource`, `DiscoveredModel`, `ConnectionInfo`, `CreateSessionOptions`, `SessionSnapshot`, `GroupSnapshot`, `pxToLegacyFontSize`, or the trailing `State` / `Actions` re-export — all importers already pull directly from `slices/types`. Dead pass-throughs deleted.

Also pruned now-unused `appearanceSlice` imports inside `store.ts` (kept only `legacyFontSizeToPx`, `sanitizeFontSizePx`, `resolvePersistedSidebarWidth`, which `hydrateStore` itself calls).

## Stats

- `src/stores/store.ts`: **273 -> 225 LoC** (-48 lines, -18%)
- 8 files touched, +14 / -59 net

## Test plan

- [x] `npm run typecheck` clean (the gate — catches any missed call site)
- [x] `npm run build` clean
- [x] `npm test`: 966 pass / 3 unrelated fails (`electron/__tests__/db-hardening.test.ts` — `better-sqlite3` NODE_MODULE_VERSION 145 vs 137 native binding mismatch on this worktree, no relation to TS sources)