### PR TITLE
refactor(badge): hoist enable flag from sink to caller (Task #819)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -238,6 +238,12 @@ app.whenReady().then(() => {
     getTray: () => getTray(),
     getBaseTrayImage: getTrayBaseImage,
     getWindows: () => BrowserWindow.getAllWindows(),
+    // OS-visible taskbar overlay + tray composite suppressed at MVP because
+    // the count was incorrect (#667 / chore #534). The internal store keeps
+    // running so e2e probes can still verify the notify bridge fires. Flip
+    // to true once the count derivation is fixed; no other call sites need
+    // to change.
+    enabled: false,
   });
 
   const pipelineInstance = installNotifyPipelineWithProducers({

--- a/electron/notify/sinks/__tests__/badgeSink.test.ts
+++ b/electron/notify/sinks/__tests__/badgeSink.test.ts
@@ -1,0 +1,109 @@
+// Tests for createBadgeSink's `enabled` policy flag (Task #819).
+//
+// The flag was hoisted out of a hard-coded `BADGE_DISABLED = true` const
+// inside the sink so the policy lives at the construction site (#667 /
+// chore #534). These tests pin both branches of the gate so a future flip
+// at main.ts can't silently regress.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// `app.setBadgeCount` is the simplest leaf to assert against because it
+// runs on every non-win32 platform. We mock the whole electron surface the
+// sink imports — nativeImage just has to round-trip, and BrowserWindow /
+// Tray come from the deps the test passes in.
+const setBadgeCount = vi.fn<(n: number) => void>();
+const setOverlayIcon = vi.fn();
+const setTrayImage = vi.fn();
+
+vi.mock('electron', () => {
+  return {
+    app: {
+      setBadgeCount: (n: number) => setBadgeCount(n),
+    },
+    BrowserWindow: class {},
+    nativeImage: {
+      createFromBuffer: () => ({}),
+    },
+  };
+});
+
+import { createBadgeSink, type BadgeSinkDeps } from '../badgeSink';
+import { BadgeManager } from '../../badgeStore';
+
+function makeDeps(overrides: Partial<BadgeSinkDeps> = {}): BadgeSinkDeps {
+  return {
+    getTray: () => null,
+    getBaseTrayImage: () =>
+      ({
+        toBitmap: () => Buffer.alloc(16 * 16 * 4),
+        getSize: () => ({ width: 16, height: 16 }),
+      }) as unknown as Electron.NativeImage,
+    getWindows: () => [],
+    ...overrides,
+  };
+}
+
+describe('createBadgeSink — enabled policy', () => {
+  beforeEach(() => {
+    setBadgeCount.mockClear();
+    setOverlayIcon.mockClear();
+    setTrayImage.mockClear();
+  });
+
+  it('enabled defaults to false: store changes do NOT touch OS chrome', () => {
+    const store = new BadgeManager();
+    createBadgeSink(store, makeDeps());
+    store.incrementSid('s1');
+    store.incrementSid('s1');
+    expect(setBadgeCount).not.toHaveBeenCalled();
+  });
+
+  it('enabled=false explicit: same no-op behavior', () => {
+    const store = new BadgeManager();
+    createBadgeSink(store, makeDeps({ enabled: false }));
+    store.incrementSid('s1');
+    store.clearAll();
+    expect(setBadgeCount).not.toHaveBeenCalled();
+  });
+
+  it('enabled=true: forwards every total to app.setBadgeCount on non-win32', () => {
+    // The sink's win32 branch goes through Tray + setOverlayIcon; we pin
+    // the simpler app.setBadgeCount branch by faking platform=darwin for
+    // the duration of this test. process.platform is read inside `apply`,
+    // so it's safe to redefine before the change emits.
+    const original = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    try {
+      const store = new BadgeManager();
+      createBadgeSink(store, makeDeps({ enabled: true }));
+
+      store.incrementSid('s1');
+      store.incrementSid('s2');
+      store.clearAll();
+
+      // 1, 2, 0 — exact sequence proves the gate is open AND that totals
+      // are forwarded verbatim (no intermediate transformation).
+      expect(setBadgeCount.mock.calls.map((c) => c[0])).toEqual([1, 2, 0]);
+    } finally {
+      Object.defineProperty(process, 'platform', { value: original });
+    }
+  });
+
+  it('dispose() detaches the listener regardless of enabled state', () => {
+    const original = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    try {
+      const store = new BadgeManager();
+      const sink = createBadgeSink(store, makeDeps({ enabled: true }));
+      store.incrementSid('s1');
+      expect(setBadgeCount).toHaveBeenCalledTimes(1);
+
+      sink.dispose();
+      store.incrementSid('s2');
+      // No additional OS call after dispose.
+      expect(setBadgeCount).toHaveBeenCalledTimes(1);
+    } finally {
+      Object.defineProperty(process, 'platform', { value: original });
+    }
+  });
+});

--- a/electron/notify/sinks/badgeSink.ts
+++ b/electron/notify/sinks/badgeSink.ts
@@ -32,17 +32,6 @@ import {
   type BgraBitmap,
 } from '../badgePixels';
 
-// MVP: OS-visible badge display is disabled (#667). User reported the count
-// shown on the taskbar overlay + tray icon was incorrect; rather than
-// re-derive the count logic before MVP we suppress every OS-facing call so
-// neither chrome surface shows a number. The internal `unread` map keeps
-// running because the e2e probe (caseNotifyFiresOnIdle) reads it via
-// `BadgeManager.getTotal()` to verify the notify bridge fired — that signal
-// is decoupled from the visual badge. Flip this flag back to false to
-// restore the previous tray composite + setOverlayIcon + setBadgeCount
-// behaviour without touching anything else.
-const BADGE_DISABLED = true;
-
 const TRAY_SIZE = 16;
 const OVERLAY_SIZE = 16;
 
@@ -50,6 +39,20 @@ export interface BadgeSinkDeps {
   getTray: () => Tray | null;
   getBaseTrayImage: () => NativeImage;
   getWindows: () => BrowserWindow[];
+  /**
+   * When false (default), every OS-facing call is suppressed and this sink
+   * is effectively a no-op. The internal `unread` map on the store keeps
+   * running because the e2e probe (caseNotifyFiresOnIdle) reads it via
+   * `BadgeManager.getTotal()` to verify the notify bridge fired — that
+   * signal is decoupled from the visual badge.
+   *
+   * Defaults to false because of #667: the count shown on the taskbar
+   * overlay + tray icon was incorrect at MVP time and re-deriving the
+   * count logic was deferred. Flip to true (from the caller — see
+   * `electron/main.ts` BadgeManager construction) once the count logic
+   * is fixed to restore tray composite + setOverlayIcon + setBadgeCount.
+   */
+  enabled?: boolean;
 }
 
 export interface BadgeSink {
@@ -95,10 +98,11 @@ export function createBadgeSink(
   }
 
   function apply(total: number): void {
-    if (BADGE_DISABLED) {
+    if (!deps.enabled) {
       // OS-visible badge suppressed (#667). Internal `unread` map still
       // tracks per-sid counters for any consumer that cares (e.g., the
-      // notify-fires e2e probe reads `getTotal()`).
+      // notify-fires e2e probe reads `getTotal()`). Flip the `enabled`
+      // option at the construction site to restore the OS-facing calls.
       return;
     }
 


### PR DESCRIPTION
## Summary

Tech-debt R12 leak #3: `electron/notify/sinks/badgeSink.ts` had a hard-coded `const BADGE_DISABLED = true` short-circuit on every OS call. Policy belongs at the construction site, not buried in the executor. This PR hoists the flag out to a `BadgeSinkDeps.enabled` option (default `false`) and threads `enabled: false` through the single caller in `electron/main.ts`. **No behaviour change** — same surfaces are suppressed; flipping the visual badge back on becomes a one-line change at the wiring layer once the count logic is fixed.

## Investigation — Case A (feature wanted, currently broken)

Per the task brief's decision tree, I followed the investigation protocol before touching code.

**Why is the flag set?**
- `git blame` on the const points at commit `cd57c9e8` (Task #744 Phase B split — preserved the disable).
- Origin of the disable: `7c5b952 chore(mvp): disable taskbar + tray badge count display (#534)`.
- Root cause: bug #667 — user reported the badge count on taskbar overlay + tray was incorrect at MVP time. Re-deriving the count logic was deferred; the flag was added as a temporary suppression.

**Is the badge feature still desired?**
- Yes. The header comment on the const explicitly says: *"Flip this flag back to false to restore the previous tray composite + setOverlayIcon + setBadgeCount behaviour without touching anything else."* → not dead code, just gated.
- The internal `unread` map keeps running because the e2e probe `caseNotifyFiresOnIdle` reads it via `BadgeManager.getTotal()` to verify the notify bridge fired — this signal is decoupled from the visual badge and must remain intact regardless of the flag.

**Conclusion: Case A** — keep sink, hoist flag, default `false` to preserve current behavior.

## Changes

- `electron/notify/sinks/badgeSink.ts`
  - Drop `const BADGE_DISABLED = true`.
  - Add `enabled?: boolean` to `BadgeSinkDeps` (with documenting comment).
  - `apply()` early-returns when `!deps.enabled`.
- `electron/main.ts`
  - `new BadgeManager({...})` now passes `enabled: false` explicitly with a comment pointing at #667 / #534. One-line flip when count logic is fixed.
- `electron/notify/sinks/__tests__/badgeSink.test.ts` (new, 4 cases)
  - default (no `enabled` flag) — no `app.setBadgeCount` calls.
  - `enabled: false` explicit — same no-op.
  - `enabled: true` on darwin — forwards `[1, 2, 0]` verbatim to `app.setBadgeCount` for incrementSid/incrementSid/clearAll.
  - `dispose()` detaches the change listener regardless of state.

## Reverse-verify

- Removing the gate entirely → the two disabled tests fail (would receive `[1, 2, 0]` instead of `[]`).
- Pinning the gate to always-true → the enabled test fails (would receive `[]` instead of `[1, 2, 0]`).
- Both branches of the policy are pinned.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` clean (pre-existing webpack size warnings only)
- [x] New `badgeSink.test.ts` — 4/4 pass
- [x] `badgeStore.test.ts` — 8/8 pass (untouched)
- [x] `badgeController.test.ts` — 11/11 pass (untouched)
- [x] Full electron suite: 412 pass / 3 unrelated db-hardening failures from a local better-sqlite3 ABI mismatch (NODE_MODULE_VERSION 145 vs 137 — environmental, not introduced here)
- [x] `node -e "require('./dist/electron/notify/sinks/badgeSink.js')"` main-process smoke test loads cleanly

Note: badge OS rendering itself remains visually suppressed (same as today). E2E probe `caseNotifyFiresOnIdle` is unaffected — it reads `BadgeManager.getTotal()` from the store, which is independent of the sink.

Closes Task #819 (R12 leak #3).