### PR TITLE
refactor: decouple db:save from cache invalidations via stateSaved event bus

### DIFF
--- a/electron/ipc/__tests__/dbIpc.test.ts
+++ b/electron/ipc/__tests__/dbIpc.test.ts
@@ -1,21 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Mock electron — only the bits dbIpc imports transitively from prefs
-// (none directly). The handler uses `fromMainFrame` from security/ipcGuards
-// which inspects e.senderFrame; we provide a minimal stub.
+// Mock electron — handler uses `fromMainFrame` from security/ipcGuards which
+// inspects e.senderFrame; we provide a minimal stub.
 vi.mock('electron', () => ({}));
 
-// Mock the prefs cache invalidators so we can assert invocation without
-// touching the real cache.
-const invalidateCrash = vi.fn();
-const invalidateNotify = vi.fn();
-vi.mock('../../prefs/crashReporting', () => ({
-  CRASH_OPT_OUT_KEY: 'crash.optOut',
-  invalidateCrashReportingCache: () => invalidateCrash(),
-}));
-vi.mock('../../prefs/notifyEnabled', () => ({
-  NOTIFY_ENABLED_KEY: 'notify.enabled',
-  invalidateNotifyEnabledCache: () => invalidateNotify(),
+// Mock the stateSavedBus so we can assert emit invocation without wiring
+// real listeners. The handler should emit `stateSaved` after a successful
+// write and NOT emit on guard / validation / persist failure.
+const emitMock = vi.fn();
+vi.mock('../../shared/stateSavedBus', () => ({
+  emitStateSaved: (key: string) => emitMock(key),
 }));
 
 // Mock db so handleDbSave doesn't try to open SQLite.
@@ -48,40 +42,19 @@ vi.mock('../../security/ipcGuards', () => ({
   fromMainFrame: (_e: unknown) => allowGuard,
 }));
 
-import { dispatchSavedKeyInvalidation, handleDbSave, handleDbLoad } from '../dbIpc';
+import { handleDbSave, handleDbLoad } from '../dbIpc';
 import type { IpcMainInvokeEvent } from 'electron';
 
 const fakeEvent = {} as IpcMainInvokeEvent;
 
 beforeEach(() => {
-  invalidateCrash.mockClear();
-  invalidateNotify.mockClear();
+  emitMock.mockClear();
   saveStateCalls.length = 0;
   validateResult = { ok: true };
   allowGuard = true;
   saveStateThrows = null;
   loadStateThrows = null;
   loadStateReturn = null;
-});
-
-describe('dispatchSavedKeyInvalidation', () => {
-  it('invalidates crash-reporting cache when CRASH_OPT_OUT_KEY is saved', () => {
-    dispatchSavedKeyInvalidation('crash.optOut');
-    expect(invalidateCrash).toHaveBeenCalledTimes(1);
-    expect(invalidateNotify).not.toHaveBeenCalled();
-  });
-
-  it('invalidates notify cache when NOTIFY_ENABLED_KEY is saved', () => {
-    dispatchSavedKeyInvalidation('notify.enabled');
-    expect(invalidateNotify).toHaveBeenCalledTimes(1);
-    expect(invalidateCrash).not.toHaveBeenCalled();
-  });
-
-  it('is a no-op for unrelated keys', () => {
-    dispatchSavedKeyInvalidation('some.other.key');
-    expect(invalidateCrash).not.toHaveBeenCalled();
-    expect(invalidateNotify).not.toHaveBeenCalled();
-  });
 });
 
 describe('handleDbSave', () => {
@@ -96,29 +69,34 @@ describe('handleDbSave', () => {
     const result = handleDbSave(fakeEvent, 'foo', 'bar');
     expect(result).toEqual({ ok: false, error: 'rejected' });
     expect(saveStateCalls).toEqual([]);
+    // No save → no bus emission.
+    expect(emitMock).not.toHaveBeenCalled();
   });
 
-  it('returns validation error and does not persist', () => {
+  it('returns validation error and does not persist or emit', () => {
     validateResult = { ok: false, error: 'value_too_large' };
     const result = handleDbSave(fakeEvent, 'k', 'v');
     expect(result).toEqual({ ok: false, error: 'value_too_large' });
     expect(saveStateCalls).toEqual([]);
+    expect(emitMock).not.toHaveBeenCalled();
   });
 
-  it('triggers cache invalidation for known prefs after save', () => {
+  // Replaces the prior "triggers cache invalidation for known prefs" test:
+  // dbIpc no longer knows about specific keys (Task #818, leak #5). It just
+  // emits the saved key on the bus; cache owners decide what to do with it.
+  it('emits stateSaved with the key after a successful save', () => {
     handleDbSave(fakeEvent, 'crash.optOut', 'true');
-    expect(invalidateCrash).toHaveBeenCalledTimes(1);
+    expect(emitMock).toHaveBeenCalledTimes(1);
+    expect(emitMock).toHaveBeenCalledWith('crash.optOut');
+
     handleDbSave(fakeEvent, 'notify.enabled', 'false');
-    expect(invalidateNotify).toHaveBeenCalledTimes(1);
+    expect(emitMock).toHaveBeenCalledTimes(2);
+    expect(emitMock).toHaveBeenLastCalledWith('notify.enabled');
   });
 
-  // Reverse-verify: confirms the test would FAIL if dispatchSavedKeyInvalidation
-  // was unwired — saving the crash key without the dispatcher should leave
-  // the mock uncalled.
-  it('reverse-verify: invalidation is gated by the dispatcher, not save', () => {
-    handleDbSave(fakeEvent, 'unrelated', 'v');
-    expect(invalidateCrash).not.toHaveBeenCalled();
-    expect(invalidateNotify).not.toHaveBeenCalled();
+  it('emits stateSaved for any key, not just known prefs', () => {
+    handleDbSave(fakeEvent, 'arbitrary.key', 'v');
+    expect(emitMock).toHaveBeenCalledWith('arbitrary.key');
   });
 
   // Audit risk #1 (tech-debt-03-errors.md): without try/catch around
@@ -135,10 +113,9 @@ describe('handleDbSave', () => {
       error: 'SQLITE_FULL: database or disk is full',
     });
     expect(errSpy).toHaveBeenCalled();
-    // Invalidation must NOT fire on failed save — would mislead consumers
+    // Emit must NOT fire on failed save — would mislead cache subscribers
     // that the new value is committed.
-    expect(invalidateCrash).not.toHaveBeenCalled();
-    expect(invalidateNotify).not.toHaveBeenCalled();
+    expect(emitMock).not.toHaveBeenCalled();
     errSpy.mockRestore();
   });
 });

--- a/electron/ipc/dbIpc.ts
+++ b/electron/ipc/dbIpc.ts
@@ -3,52 +3,27 @@
 // Owns the renderer-facing key/value persistence surface backed by the SQLite
 // `app_state` table (see electron/db). Validation lives in electron/db-validate
 // so it can be unit-tested without an IPC round-trip; this module is a thin
-// wrapper that adds the security guard, oversize-rejection log, and the
-// per-key cache invalidation hooks for prefs whose values are cached in
-// process (Sentry opt-out, notify enabled).
+// wrapper that adds the security guard, oversize-rejection log, and emits a
+// `stateSaved` event after a successful write.
 //
-// Why DI: cache invalidation is a per-key concern owned by the prefs modules
-// (`electron/prefs/*`), not the db layer. Passing the invalidator callbacks
-// keeps this module free of a static dependency on every preference module
-// and lets the smoke test exercise the dispatcher with no-op stubs.
+// Decoupling note (Task #818 / `tech-debt-12-functional-core.md` leak #5):
+// this module no longer knows which prefs caches care about which keys. After
+// a successful save it just emits `stateSaved(key)` on the shared bus
+// (`electron/shared/stateSavedBus.ts`); cache owners (`electron/prefs/*`)
+// subscribe to the bus and decide for themselves whether the key is theirs.
 
 import type { IpcMain, IpcMainInvokeEvent } from 'electron';
 import { loadState, saveState } from '../db';
 import { validateSaveStateInput } from '../db-validate';
 import { fromMainFrame } from '../security/ipcGuards';
-import {
-  CRASH_OPT_OUT_KEY,
-  invalidateCrashReportingCache,
-} from '../prefs/crashReporting';
-import {
-  NOTIFY_ENABLED_KEY,
-  invalidateNotifyEnabledCache,
-} from '../prefs/notifyEnabled';
+import { emitStateSaved } from '../shared/stateSavedBus';
 
 export interface DbIpcDeps {
   ipcMain: IpcMain;
 }
 
-/** Map well-known preference keys to their cache invalidator. Pure helper —
- *  exported for unit testing. The dispatcher is intentionally a small switch
- *  rather than a registry so adding a new key requires a deliberate edit
- *  here AND in the corresponding prefs module. */
-export function dispatchSavedKeyInvalidation(key: string): void {
-  // Sentry's cached opt-out — invalidate so the toggle in Settings takes
-  // effect on the next error without an app restart.
-  if (key === CRASH_OPT_OUT_KEY) {
-    invalidateCrashReportingCache();
-    return;
-  }
-  // Notification mute toggle — invalidate so the next sessionWatcher event
-  // reads the fresh value without a restart.
-  if (key === NOTIFY_ENABLED_KEY) {
-    invalidateNotifyEnabledCache();
-  }
-}
-
 /** Pure handler for `db:save`. Exported for unit testing — verifies the
- *  guard / validation / persistence / invalidation chain without an actual
+ *  guard / validation / persistence / emit chain without an actual
  *  IPC round-trip. */
 export function handleDbSave(
   e: IpcMainInvokeEvent,
@@ -77,7 +52,9 @@ export function handleDbSave(
     console.error(`[main] db:save failed for key=${key}:`, err);
     return { ok: false, error: msg };
   }
-  dispatchSavedKeyInvalidation(key);
+  // Notify any subscribed cache owners that this key was written. Bus
+  // listeners are responsible for filtering by key (see prefs/*).
+  emitStateSaved(key);
   return { ok: true };
 }
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -63,7 +63,8 @@ import {
   getSessionTitle,
   flushPendingRename,
 } from './sessionTitles';
-import { loadNotifyEnabled } from './prefs/notifyEnabled';
+import { loadNotifyEnabled, subscribeNotifyEnabledInvalidation } from './prefs/notifyEnabled';
+import { subscribeCrashReportingInvalidation } from './prefs/crashReporting';
 import { BadgeController } from './badgeController';
 import { registerDbIpc } from './ipc/dbIpc';
 import { registerSystemIpc } from './ipc/systemIpc';
@@ -174,6 +175,12 @@ app.whenReady().then(() => {
   initDb();
 
   // ─────────────────────────── IPC registration ──────────────────────────
+  // Wire prefs cache invalidation to the stateSavedBus BEFORE registering
+  // the db:save handler so the very first renderer-driven save (e.g. an
+  // auto-persisted setting on first paint) reaches the cache subscribers.
+  // See `tech-debt-12-functional-core.md` leak #5 / Task #818.
+  subscribeCrashReportingInvalidation();
+  subscribeNotifyEnabledInvalidation();
   // Order is significant for systemIpc: it seeds the active i18n language
   // from the OS locale, so any subsequent producer that calls i18n.t()
   // sees the correct active language.

--- a/electron/prefs/__tests__/crashReporting.test.ts
+++ b/electron/prefs/__tests__/crashReporting.test.ts
@@ -62,3 +62,61 @@ describe('invalidateCrashReportingCache', () => {
     expect(loadCrashReportingOptOut()).toBe(false);
   });
 });
+
+// Task #818 / tech-debt-12 leak #5: cache invalidation predicate now lives
+// in this module and subscribes to the stateSavedBus rather than being
+// dispatched by the db:save handler. These tests verify the wiring.
+describe('subscribeCrashReportingInvalidation', () => {
+  it('invalidates the cache when stateSavedBus emits CRASH_OPT_OUT_KEY', async () => {
+    stateStore.set('crashReportingOptOut', 'true');
+    const { loadCrashReportingOptOut, subscribeCrashReportingInvalidation } =
+      await import('../crashReporting');
+    const { emitStateSaved, _resetStateSavedBusForTests } = await import(
+      '../../shared/stateSavedBus'
+    );
+    _resetStateSavedBusForTests();
+    const off = subscribeCrashReportingInvalidation();
+    expect(loadCrashReportingOptOut()).toBe(true);
+
+    stateStore.set('crashReportingOptOut', 'false');
+    emitStateSaved('crashReportingOptOut');
+    expect(loadCrashReportingOptOut()).toBe(false);
+    off();
+  });
+
+  it('ignores unrelated keys', async () => {
+    stateStore.set('crashReportingOptOut', 'true');
+    const { loadCrashReportingOptOut, subscribeCrashReportingInvalidation } =
+      await import('../crashReporting');
+    const { emitStateSaved, _resetStateSavedBusForTests } = await import(
+      '../../shared/stateSavedBus'
+    );
+    _resetStateSavedBusForTests();
+    const off = subscribeCrashReportingInvalidation();
+    expect(loadCrashReportingOptOut()).toBe(true);
+
+    stateStore.set('crashReportingOptOut', 'false');
+    emitStateSaved('notifyEnabled');
+    expect(loadCrashReportingOptOut()).toBe(true);
+    off();
+  });
+
+  // Reverse-verify: if the subscription is detached, a subsequent emit MUST
+  // NOT invalidate. Proves the bus subscription is what drives invalidation.
+  it('reverse-verify: unsubscribed listener no longer invalidates', async () => {
+    stateStore.set('crashReportingOptOut', 'true');
+    const { loadCrashReportingOptOut, subscribeCrashReportingInvalidation } =
+      await import('../crashReporting');
+    const { emitStateSaved, _resetStateSavedBusForTests } = await import(
+      '../../shared/stateSavedBus'
+    );
+    _resetStateSavedBusForTests();
+    const off = subscribeCrashReportingInvalidation();
+    loadCrashReportingOptOut(); // prime cache to true
+    off();
+
+    stateStore.set('crashReportingOptOut', 'false');
+    emitStateSaved('crashReportingOptOut');
+    expect(loadCrashReportingOptOut()).toBe(true);
+  });
+});

--- a/electron/prefs/__tests__/notifyEnabled.test.ts
+++ b/electron/prefs/__tests__/notifyEnabled.test.ts
@@ -62,3 +62,65 @@ describe('loadNotifyEnabled', () => {
     expect(loadNotifyEnabled()).toBe(true);
   });
 });
+
+// Task #818 / tech-debt-12 leak #5: cache invalidation predicate now lives
+// in this module and subscribes to the stateSavedBus rather than being
+// dispatched by the db:save handler. These tests verify the wiring.
+describe('subscribeNotifyEnabledInvalidation', () => {
+  it('invalidates the cache when stateSavedBus emits NOTIFY_ENABLED_KEY', async () => {
+    stateStore.set('notifyEnabled', 'false');
+    const { loadNotifyEnabled, subscribeNotifyEnabledInvalidation } =
+      await import('../notifyEnabled');
+    const { emitStateSaved, _resetStateSavedBusForTests } = await import(
+      '../../shared/stateSavedBus'
+    );
+    _resetStateSavedBusForTests();
+    const off = subscribeNotifyEnabledInvalidation();
+    expect(loadNotifyEnabled()).toBe(false);
+
+    // A renderer save flips the underlying value AND emits the bus event.
+    stateStore.set('notifyEnabled', 'true');
+    emitStateSaved('notifyEnabled');
+    expect(loadNotifyEnabled()).toBe(true);
+    off();
+  });
+
+  it('ignores unrelated keys', async () => {
+    stateStore.set('notifyEnabled', 'false');
+    const { loadNotifyEnabled, subscribeNotifyEnabledInvalidation } =
+      await import('../notifyEnabled');
+    const { emitStateSaved, _resetStateSavedBusForTests } = await import(
+      '../../shared/stateSavedBus'
+    );
+    _resetStateSavedBusForTests();
+    const off = subscribeNotifyEnabledInvalidation();
+    expect(loadNotifyEnabled()).toBe(false);
+
+    // An unrelated key save must NOT invalidate this cache.
+    stateStore.set('notifyEnabled', 'true');
+    emitStateSaved('crashReportingOptOut');
+    expect(loadNotifyEnabled()).toBe(false);
+    off();
+  });
+
+  // Reverse-verify: if the subscription is detached, a subsequent emit MUST
+  // NOT invalidate. Proves the bus subscription is what drives invalidation
+  // (not some other side path).
+  it('reverse-verify: unsubscribed listener no longer invalidates', async () => {
+    stateStore.set('notifyEnabled', 'false');
+    const { loadNotifyEnabled, subscribeNotifyEnabledInvalidation } =
+      await import('../notifyEnabled');
+    const { emitStateSaved, _resetStateSavedBusForTests } = await import(
+      '../../shared/stateSavedBus'
+    );
+    _resetStateSavedBusForTests();
+    const off = subscribeNotifyEnabledInvalidation();
+    loadNotifyEnabled(); // prime cache to false
+    off();
+
+    stateStore.set('notifyEnabled', 'true');
+    emitStateSaved('notifyEnabled');
+    // Cache still reports the stale value because the listener was removed.
+    expect(loadNotifyEnabled()).toBe(false);
+  });
+});

--- a/electron/prefs/crashReporting.ts
+++ b/electron/prefs/crashReporting.ts
@@ -8,11 +8,15 @@
 // to dropping a crash because the DB happened to be locked.
 //
 // Sentry's beforeSend runs on the hot error path, so we cache the value in
-// a module-scope variable after the first read. The `db:save` handler in
-// main.ts invalidates the cache when the renderer writes the key, so the
-// toggle in Settings still takes effect immediately.
+// a module-scope variable after the first read. To stay consistent with the
+// renderer Settings toggle without an app restart, the cache subscribes to
+// the `stateSavedBus` (see `electron/shared/stateSavedBus.ts`) at boot:
+// when `db:save` succeeds for our key, we drop the cache. Predicate ownership
+// lives here, not in the db handler — see `tech-debt-12-functional-core.md`
+// leak #5.
 
 import { loadState } from '../db';
+import { onStateSaved } from '../shared/stateSavedBus';
 
 export const CRASH_OPT_OUT_KEY = 'crashReportingOptOut';
 
@@ -31,9 +35,18 @@ export function loadCrashReportingOptOut(): boolean {
 }
 
 // Drop the cached value; the next `loadCrashReportingOptOut()` will re-read
-// from DB. Called by the `db:save` IPC handler in main.ts when the renderer
-// writes `crashReportingOptOut` so the Settings toggle takes effect on the
-// next error without an app restart.
+// from DB. Subscribed to the stateSavedBus from `subscribeCrashReportingInvalidation()`
+// so the renderer's Settings toggle takes effect on the next error without
+// an app restart.
 export function invalidateCrashReportingCache(): void {
   _crashOptOutCached = undefined;
+}
+
+/** Wire the cache invalidation to the stateSavedBus. Call once during boot
+ *  (before `registerDbIpc`). Returns the unsubscribe handle so tests can
+ *  reverse-verify (and so a future hot-reload could detach). */
+export function subscribeCrashReportingInvalidation(): () => void {
+  return onStateSaved((key) => {
+    if (key === CRASH_OPT_OUT_KEY) invalidateCrashReportingCache();
+  });
 }

--- a/electron/prefs/notifyEnabled.ts
+++ b/electron/prefs/notifyEnabled.ts
@@ -3,11 +3,13 @@
 //
 // Persisted in app_state under `notifyEnabled` (default true → notifications
 // on). Cached in main-process memory so the per-event check in the notify
-// bridge stays cheap; the `db:save` handler invalidates the cache when the
-// renderer writes the key so the Settings toggle takes effect without a
-// restart. Mirrors the `closeAction` / `crashReportingOptOut` patterns.
+// bridge stays cheap; the cache subscribes to the `stateSavedBus`
+// (see `electron/shared/stateSavedBus.ts`) so writes from the renderer
+// (db:save) invalidate it without an app restart. Predicate ownership lives
+// here — see `tech-debt-12-functional-core.md` leak #5.
 
 import { loadState } from '../db';
+import { onStateSaved } from '../shared/stateSavedBus';
 
 export const NOTIFY_ENABLED_KEY = 'notifyEnabled';
 
@@ -27,8 +29,16 @@ export function loadNotifyEnabled(): boolean {
 }
 
 // Drop the cached value; the next `loadNotifyEnabled()` will re-read from DB.
-// Called by the `db:save` IPC handler in main.ts when the renderer writes
-// `notifyEnabled` so the Settings toggle takes effect immediately.
+// Subscribed to the stateSavedBus from `subscribeNotifyEnabledInvalidation()`
+// so the renderer's Settings toggle takes effect immediately.
 export function invalidateNotifyEnabledCache(): void {
   _notifyEnabledCached = undefined;
+}
+
+/** Wire the cache invalidation to the stateSavedBus. Call once during boot
+ *  (before `registerDbIpc`). Returns the unsubscribe handle. */
+export function subscribeNotifyEnabledInvalidation(): () => void {
+  return onStateSaved((key) => {
+    if (key === NOTIFY_ENABLED_KEY) invalidateNotifyEnabledCache();
+  });
 }

--- a/electron/shared/__tests__/stateSavedBus.test.ts
+++ b/electron/shared/__tests__/stateSavedBus.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  emitStateSaved,
+  onStateSaved,
+  _resetStateSavedBusForTests,
+} from '../stateSavedBus';
+
+beforeEach(() => {
+  _resetStateSavedBusForTests();
+});
+
+describe('stateSavedBus', () => {
+  it('delivers emitted keys to a subscribed listener', () => {
+    const seen: string[] = [];
+    onStateSaved((k) => seen.push(k));
+    emitStateSaved('foo');
+    emitStateSaved('bar');
+    expect(seen).toEqual(['foo', 'bar']);
+  });
+
+  it('fans out a single emit to all subscribers', () => {
+    const a = vi.fn();
+    const b = vi.fn();
+    onStateSaved(a);
+    onStateSaved(b);
+    emitStateSaved('k');
+    expect(a).toHaveBeenCalledWith('k');
+    expect(b).toHaveBeenCalledWith('k');
+  });
+
+  it('returned unsubscribe function stops further deliveries', () => {
+    const fn = vi.fn();
+    const off = onStateSaved(fn);
+    emitStateSaved('first');
+    off();
+    emitStateSaved('second');
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('first');
+  });
+
+  it('isolates listener errors so a throwing listener does not break others', () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const downstream = vi.fn();
+    onStateSaved(() => {
+      throw new Error('boom');
+    });
+    onStateSaved(downstream);
+    // Producer must not see the error; downstream must still be called.
+    expect(() => emitStateSaved('k')).not.toThrow();
+    expect(downstream).toHaveBeenCalledWith('k');
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it('emit with no listeners is a no-op', () => {
+    expect(() => emitStateSaved('orphan')).not.toThrow();
+  });
+});

--- a/electron/shared/stateSavedBus.ts
+++ b/electron/shared/stateSavedBus.ts
@@ -1,0 +1,63 @@
+// Tiny typed event bus for "a renderer-driven app_state row was successfully
+// persisted". Producer: the `db:save` IPC handler in `electron/ipc/dbIpc.ts`.
+// Consumers: prefs modules (e.g. crash reporting opt-out, notify-enabled) that
+// hold an in-process cache of a single well-known key and need to invalidate
+// when that key is rewritten.
+//
+// Why a bus instead of inline switch/case in dbIpc:
+//   - Single Responsibility (per `feedback_single_responsibility.md`): the
+//     db:save handler is a sink for the persistence side-effect; deciding
+//     "which key invalidates which cache" is a per-cache concern owned by
+//     the cache module itself, not the executor.
+//   - Other subsystems' caches no longer have to be imported by the db layer.
+//     Adding a new cached pref now means: (a) export an `invalidate*` and
+//     (b) call `onStateSaved(...)` once from boot — zero edits to dbIpc.
+//
+// See `tech-debt-12-functional-core.md` leak #5.
+
+import { EventEmitter } from 'node:events';
+
+type SavedListener = (key: string) => void;
+
+// Module-singleton emitter. Listeners are registered once at boot from the
+// pref modules' `subscribe*Invalidation()` helpers; we don't expect a high
+// fan-out, but bumping max listeners well above the default 10 keeps any
+// future addition silent. 64 is arbitrary-but-generous.
+const bus = new EventEmitter();
+bus.setMaxListeners(64);
+
+const SAVED = 'saved' as const;
+
+/** Subscribe to "an app_state key was successfully written" events.
+ *  Returns an unsubscribe function. Listener errors are logged but do NOT
+ *  propagate to the producer (the db:save handler must still return ok to
+ *  the renderer even if a downstream cache invalidator throws). */
+export function onStateSaved(fn: SavedListener): () => void {
+  const wrapped: SavedListener = (key) => {
+    try {
+      fn(key);
+    } catch (err) {
+      // Cache invalidation failure is non-fatal; log and continue so other
+      // listeners still fire and the renderer still sees ok:true.
+      console.error('[stateSavedBus] listener threw for key', key, err);
+    }
+  };
+  bus.on(SAVED, wrapped);
+  return () => {
+    bus.off(SAVED, wrapped);
+  };
+}
+
+/** Emit a "key was saved" event. Called by the db:save handler AFTER a
+ *  successful sqlite write. Synchronous: listeners run on the same tick so
+ *  cache invalidation is visible to the very next read. */
+export function emitStateSaved(key: string): void {
+  bus.emit(SAVED, key);
+}
+
+/** Test-only: drop all listeners so a test that mounts a fresh subscription
+ *  isn't polluted by listeners registered by a sibling test. Not exported
+ *  via index — call directly from tests. */
+export function _resetStateSavedBusForTests(): void {
+  bus.removeAllListeners(SAVED);
+}


### PR DESCRIPTION
## Summary

Task #818 / `tech-debt-12-functional-core.md` leak #5.

The `db:save` IPC handler used to embed a per-key switch that called
`invalidateCrashReportingCache` / `invalidateNotifyEnabledCache` directly.
Adding a new cached preference required editing `dbIpc.ts` — the executor
held the decision table for unrelated subsystems' caches.

This PR introduces a tiny `EventEmitter`-backed bus
(`electron/shared/stateSavedBus.ts`) with `emitStateSaved(key)` /
`onStateSaved(fn)`. The db:save handler now just emits after a
successful sqlite write; each prefs module owns its own predicate via
a `subscribe*Invalidation()` helper wired once at boot in `main.ts`.

Cache modules now self-managing invalidation:
- `electron/prefs/crashReporting.ts` (`subscribeCrashReportingInvalidation`)
- `electron/prefs/notifyEnabled.ts` (`subscribeNotifyEnabledInvalidation`)

`dbIpc.ts` no longer imports any prefs module; `dispatchSavedKeyInvalidation`
is removed.

Single Responsibility (per `feedback_single_responsibility.md`):
- `dbIpc` = sink (persist + emit)
- `prefs/*` = decider+sink (predicate + invalidate)

No new dependencies (plain `node:events` EventEmitter; `typed-emitter` is
not in the tree).

## Reverse-verify

Temporarily commented out the predicate inside
`subscribeCrashReportingInvalidation`:
```
// if (key === CRASH_OPT_OUT_KEY) invalidateCrashReportingCache();
```
Result:
```
FAIL electron/prefs/__tests__/crashReporting.test.ts
> subscribeCrashReportingInvalidation
> invalidates the cache when stateSavedBus emits CRASH_OPT_OUT_KEY
AssertionError: expected true to be false
- Expected: false
+ Received: true
   83|     expect(loadCrashReportingOptOut()).toBe(false);
```
Restored after verification. Confirms the bus subscription (not some
back-channel) is what drives invalidation.

## Verification

- `npm run typecheck` — clean
- `npm run build` — clean (only pre-existing webpack size warnings)
- `npx vitest run electron/shared/__tests__/stateSavedBus.test.ts electron/ipc/__tests__/dbIpc.test.ts electron/prefs/__tests__/notifyEnabled.test.ts electron/prefs/__tests__/crashReporting.test.ts` — 32/32 passed
- `npx vitest run tests/electron-load-smoke.test.ts` — 19/19 passed (sentry/init still loads cleanly with the new subscriber wiring; main-process require chain intact)
- Pre-existing `electron/__tests__/db-hardening.test.ts` failures (3) reproduce on baseline `working` (better-sqlite3 native binding issue on this host) and are unrelated.

## Test plan

- [x] Unit tests for `stateSavedBus` (subscribe / fan-out / unsubscribe / listener-error isolation / no-listener emit)
- [x] `dbIpc` tests assert bus emission instead of cache calls
- [x] Each prefs module has subscription tests including reverse-verify of unsubscribe
- [x] `electron-load-smoke` passes (proves new module loads in CJS main)