### PR TITLE
refactor(App): dedup shell+modals across return branches

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -275,113 +275,83 @@ export default function App() {
     [sessions, activeId]
   );
 
-  if (!active) {
-    // Pre-hydrate: render a content-shaped skeleton (sidebar placeholder
-    // rows + main "Loading…" affordance) so the app does not paint as a
-    // blank white window during sqlite hydration. See AppSkeleton (#584).
-    // The first-run/empty CTA branch below is reserved for when we're
-    // CERTAIN there are no persisted sessions (i.e. hydrated === true).
-    if (!hydrated) {
-      return (
-        <TooltipProvider delayDuration={400} skipDelayDuration={100}>
-          <ToastProvider>
-            <AppEffectsBridge />
-            <AppSkeleton />
-          </ToastProvider>
-        </TooltipProvider>
-      );
-    }
+  // Pre-hydrate: render a content-shaped skeleton (sidebar placeholder
+  // rows + main "Loading…" affordance) so the app does not paint as a
+  // blank white window during sqlite hydration. See AppSkeleton (#584).
+  // The first-run/empty CTA branch below is reserved for when we're
+  // CERTAIN there are no persisted sessions (i.e. hydrated === true).
+  if (!active && !hydrated) {
     return (
       <TooltipProvider delayDuration={400} skipDelayDuration={100}>
         <ToastProvider>
-        <AppEffectsBridge />
-        <AppShell
-          sidebar={
-            <Sidebar
-              onCreateSession={newSession}
-              onOpenSettings={() => setSettingsOpen(true)}
-              onOpenPalette={() => setPaletteOpen(true)}
-              onOpenImport={() => setImportOpen(true)}
-              activeSessionId={activeId}
-              focusedGroupId={focusedGroupId}
-              onSelectSession={selectSession}
-              onFocusGroup={focusGroup}
-              sessions={sessions}
-              onMoveSession={moveSession}
-            />
-          }
-          main={
-            <main className="flex-1 flex flex-col min-w-0 right-pane-frame relative">
-              <DragRegion className="relative flex items-center justify-end shrink-0" style={{ height: 32 }}>
-                <WindowControls />
-              </DragRegion>
-              <InstallerCorruptBanner />
-              <div className="flex-1 flex items-center justify-center min-h-0">
-                  {!tutorial.show ? (
-                    // First-run / no-active-session empty state. Task #329 — we
-                    // explicitly do NOT auto-create a session at boot; instead
-                    // the user lands on this clean palette of CTAs. The wording
-                    // is sentence case and i18n-driven (firstRun.* keys).
-                    // Trimmed in #353 to just the two primary CTAs — the
-                    // welcome heading, "Create a new group" link, and tip line
-                    // were noise on first launch (group creation is reachable
-                    // from the sidebar; the tip didn't unlock any action).
-                    <div
-                      className="flex items-center gap-3"
-                      data-testid="first-run-empty"
-                    >
-                      <Button
-                        variant="primary"
-                        size="md"
-                        onClick={newSession}
-                        className="w-44 justify-center"
-                      >
-                        <Plus size={14} className="stroke-[2]" />
-                        <span>{t('firstRun.newSession')}</span>
-                      </Button>
-                      <Button
-                        variant="secondary"
-                        size="md"
-                        onClick={() => setImportOpen(true)}
-                        className="w-44 justify-center"
-                      >
-                        <Download size={14} className="stroke-[2]" />
-                        <span>{t('firstRun.importSession')}</span>
-                      </Button>
-                    </div>
-                  ) : (
-                    <Tutorial
-                      onNewSession={() => {
-                        tutorial.dismiss();
-                        newSession();
-                      }}
-                      onImport={() => {
-                        tutorial.dismiss();
-                        setImportOpen(true);
-                      }}
-                      onSkip={tutorial.dismiss}
-                    />
-                  )}
-                </div>
-              </main>
-            }
-          />
-          <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} />
-          <ImportDialog open={importOpen} onOpenChange={setImportOpen} />
-          <CommandPalette
-            open={paletteOpen}
-            onOpenChange={setPaletteOpen}
-            onOpenSettings={() => setSettingsOpen(true)}
-            onNewSession={newSession}
-            onOpenImport={() => setImportOpen(true)}
-            onSelectSession={selectSession}
-            onFocusGroup={focusGroup}
-          />
-          <ShortcutOverlay open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
+          <AppEffectsBridge />
+          <AppSkeleton />
         </ToastProvider>
       </TooltipProvider>
     );
   }
+
+  // Body that fills the right pane below the drag region + corrupt-installer
+  // banner. Two cases:
+  //   - no active session (post-hydrate) → first-run CTA / tutorial overlay
+  //   - active session → ClaudeMissingGuide / TerminalPane / probing spacer
+  const mainBody = !active ? (
+    <div className="flex-1 flex items-center justify-center min-h-0">
+      {!tutorial.show ? (
+        // First-run / no-active-session empty state. Task #329 — we
+        // explicitly do NOT auto-create a session at boot; instead
+        // the user lands on this clean palette of CTAs. The wording
+        // is sentence case and i18n-driven (firstRun.* keys).
+        // Trimmed in #353 to just the two primary CTAs — the
+        // welcome heading, "Create a new group" link, and tip line
+        // were noise on first launch (group creation is reachable
+        // from the sidebar; the tip didn't unlock any action).
+        <div
+          className="flex items-center gap-3"
+          data-testid="first-run-empty"
+        >
+          <Button
+            variant="primary"
+            size="md"
+            onClick={newSession}
+            className="w-44 justify-center"
+          >
+            <Plus size={14} className="stroke-[2]" />
+            <span>{t('firstRun.newSession')}</span>
+          </Button>
+          <Button
+            variant="secondary"
+            size="md"
+            onClick={() => setImportOpen(true)}
+            className="w-44 justify-center"
+          >
+            <Download size={14} className="stroke-[2]" />
+            <span>{t('firstRun.importSession')}</span>
+          </Button>
+        </div>
+      ) : (
+        <Tutorial
+          onNewSession={() => {
+            tutorial.dismiss();
+            newSession();
+          }}
+          onImport={() => {
+            tutorial.dismiss();
+            setImportOpen(true);
+          }}
+          onSkip={tutorial.dismiss}
+        />
+      )}
+    </div>
+  ) : claudeAvailable === false ? (
+    <ClaudeMissingGuide onResolved={() => setClaudeAvailable(true)} />
+  ) : claudeAvailable === true ? (
+    <TerminalPane sessionId={active.id} cwd={active.cwd ?? ''} />
+  ) : (
+    // Probing claude availability — render an empty flex spacer
+    // so the layout doesn't jump once the boot check resolves.
+    <div className="flex-1 min-h-0" data-testid="claude-availability-probing" />
+  );
 
   return (
     <TooltipProvider delayDuration={400} skipDelayDuration={100}>
@@ -408,15 +378,7 @@ export default function App() {
                 <WindowControls />
               </DragRegion>
               <InstallerCorruptBanner />
-              {claudeAvailable === false ? (
-                <ClaudeMissingGuide onResolved={() => setClaudeAvailable(true)} />
-              ) : claudeAvailable === true ? (
-                <TerminalPane sessionId={active.id} cwd={active.cwd ?? ''} />
-              ) : (
-                // Probing claude availability — render an empty flex spacer
-                // so the layout doesn't jump once the boot check resolves.
-                <div className="flex-1 min-h-0" data-testid="claude-availability-probing" />
-              )}
+              {mainBody}
             </main>
           }
         />


### PR DESCRIPTION
## Why

`src/App.tsx` had two return branches (the `!active && hydrated` no-active arm and the active-session arm) that rendered the same `TooltipProvider > ToastProvider > AppEffectsBridge > AppShell{Sidebar, main} > SettingsDialog / ImportDialog / CommandPalette / ShortcutOverlay` tree. Only the body inside `<main>` (below the DragRegion + InstallerCorruptBanner) differed.

This collapses the two branches into one return, picking `mainBody` from a single ternary on `!active`:
- `!active` -> first-run CTA / Tutorial overlay
- `active`  -> `ClaudeMissingGuide` / `TerminalPane` / probing spacer

The pre-hydrate skeleton branch (`!active && !hydrated`) is unchanged. All `data-testid`, `data-*`, key props, and render order preserved.

## LoC delta

```
src/App.tsx | 180 ++++++++++++++++++++++++------------------------------------
1 file changed, 71 insertions(+), 109 deletions(-)
```

Net -38 LoC in `src/App.tsx`.

## Verify

- `npm run lint` -> clean (4 pre-existing warnings, none in App.tsx)
- `npm run typecheck` -> clean
- `npm test -- --run` -> 981 passed / 0 failed (after `npm rebuild better-sqlite3` for env)
- e2e probe: `node scripts/harness-ui.mjs --only=sidebar-align`

```
[harness=ui] launching electron — 1/14 case(s)

[harness=ui] >>> case sidebar-align
[case=sidebar-align] aside=0.0/802.0 main=0.0/802.0 vh=802
[case=sidebar-align] OK

=== harness=ui summary (613ms wall) ===
  [OK] sidebar-align                               346ms

=== totals: 1 passed, 0 failed, 0 skipped, 1 total ===
```

`sidebar-align` exercises the unified shell mount path (TooltipProvider/ToastProvider/AppShell with sidebar+main rendered + measured), confirming the dedup preserves layout.

Closes #771