### PR TITLE
fix(ui): remove false Ctrl+N shortcut hints

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -120,7 +120,6 @@ export function CommandPalette({
         id: 'cmd:new-session',
         kind: 'command',
         label: t('commandPalette.cmdNewSession'),
-        hint: `${MOD}N`,
         icon: <Plus size={13} className="stroke-[1.75] text-fg-tertiary" />,
         onPick: () => {
           onOpenChange(false);

--- a/src/components/ShortcutOverlay.tsx
+++ b/src/components/ShortcutOverlay.tsx
@@ -37,8 +37,6 @@ function buildGroups(): Group[] {
       rows: [
         // App.tsx:169 — Ctrl+B toggles the sidebar.
         { keys: `${MOD} + B`, actionKey: 'shortcuts.actionToggleSidebar' },
-        // App.tsx:179 — Ctrl+N creates a new session.
-        { keys: `${MOD} + N`, actionKey: 'shortcuts.actionNewSession' },
         // App.tsx:175 — Ctrl+Shift+N creates a new group.
         { keys: `${MOD} + ${SHIFT} + N`, actionKey: 'shortcuts.actionNewGroup' }
       ]


### PR DESCRIPTION
ShortcutOverlay row + CommandPalette hint advertised Ctrl+N but no key handler exists. Removing the hints (per user 2026-04-30: not adding the shortcut). #857