### PR TITLE
feat(ptyHost): L4 PR-A headless buffer as session source-of-truth (#861)

### DIFF
--- a/electron/ptyHost/__tests__/bufferSnapshot.test.ts
+++ b/electron/ptyHost/__tests__/bufferSnapshot.test.ts
@@ -1,0 +1,152 @@
+// L4 PR-A (#861): pins the headless authoritative buffer + getBufferSnapshot
+// contract.
+//
+// Two layers of coverage:
+//   1. Real @xterm/headless + @xterm/addon-serialize wired with the
+//      production scrollback cap — pins write accumulation, scrollback
+//      truncation, and snapshot round-trip.
+//   2. Pure lifecycle.getBufferSnapshot over a fake sessions map — pins
+//      missing-sid behavior and the chunked-yield contract (each chunk
+//      yields a macrotask so the main thread isn't blocked on big buffers).
+//
+// Out of scope (PR-B/E): visible xterm replay, IPC wire format, detach/reattach.
+
+import { describe, it, expect } from 'vitest';
+import { Terminal as HeadlessTerminal } from '@xterm/headless';
+import { SerializeAddon } from '@xterm/addon-serialize';
+import { SCROLLBACK } from '../entryFactory';
+import {
+  getBufferSnapshot,
+  SNAPSHOT_CHUNK_LINES,
+} from '../lifecycle';
+import type { Entry } from '../entryFactory';
+
+function makeRealHeadless(): { term: HeadlessTerminal; serialize: SerializeAddon } {
+  const term = new HeadlessTerminal({
+    cols: 80,
+    rows: 24,
+    scrollback: SCROLLBACK,
+    allowProposedApi: true,
+  });
+  const serialize = new SerializeAddon();
+  term.loadAddon(serialize);
+  return { term, serialize };
+}
+
+// Build a fake Entry that just exposes a `serialize.serialize()` returning
+// the supplied string. Other Entry fields are stubbed because
+// getBufferSnapshot only reads `entry.serialize`.
+function fakeEntry(snapshot: string): Entry {
+  return {
+    pty: { pid: 0 } as Entry['pty'],
+    headless: {} as Entry['headless'],
+    serialize: { serialize: () => snapshot } as unknown as Entry['serialize'],
+    attached: new Map(),
+    cols: 80,
+    rows: 24,
+    cwd: '/tmp',
+  };
+}
+
+describe('headless authoritative buffer (PR-A real wiring)', () => {
+  it('SCROLLBACK is bumped to 10000 lines for L4', () => {
+    expect(SCROLLBACK).toBe(10000);
+  });
+
+  it('headless buffer accumulates writes across chunks', async () => {
+    const { term, serialize } = makeRealHeadless();
+    await new Promise<void>((r) => term.write('hello ', r));
+    await new Promise<void>((r) => term.write('world\r\n', r));
+    await new Promise<void>((r) => term.write('second line', r));
+    const snap = serialize.serialize();
+    expect(snap).toContain('hello world');
+    expect(snap).toContain('second line');
+  });
+
+  it('scrollback cap of 10000 truncates the OLDEST lines once exceeded', async () => {
+    const { term, serialize } = makeRealHeadless();
+    // Write 10500 distinct lines. After the cap, the first ~500 + the 24
+    // visible rows offset should be gone.
+    const TOTAL = 10500;
+    let buf = '';
+    for (let i = 0; i < TOTAL; i++) buf += `LINE${i}\r\n`;
+    await new Promise<void>((r) => term.write(buf, r));
+    const snap = serialize.serialize();
+    // Newest line must survive.
+    expect(snap).toContain(`LINE${TOTAL - 1}`);
+    // The very first line MUST have been evicted (well under the cap window).
+    expect(snap).not.toContain('LINE0\n');
+    expect(snap).not.toContain('LINE100\n');
+    // A line comfortably inside the surviving cap window must still be present.
+    expect(snap).toContain(`LINE${TOTAL - 100}`);
+  });
+
+  it('snapshot round-trips: writing the snapshot into a fresh terminal reproduces the visible text', async () => {
+    const { term, serialize } = makeRealHeadless();
+    await new Promise<void>((r) => term.write('alpha\r\nbeta\r\ngamma', r));
+    const snap = serialize.serialize();
+
+    const fresh = new HeadlessTerminal({ cols: 80, rows: 24, allowProposedApi: true });
+    await new Promise<void>((r) => fresh.write(snap, r));
+    // Read back the visible buffer line-by-line.
+    let restored = '';
+    for (let row = 0; row < fresh.buffer.active.length; row++) {
+      const line = fresh.buffer.active.getLine(row);
+      if (line) restored += line.translateToString(true) + '\n';
+    }
+    expect(restored).toContain('alpha');
+    expect(restored).toContain('beta');
+    expect(restored).toContain('gamma');
+  });
+});
+
+describe('lifecycle.getBufferSnapshot (PR-A async chunking)', () => {
+  it('returns "" when the sid is not registered', async () => {
+    const sessions = new Map<string, Entry>();
+    expect(await getBufferSnapshot(sessions, 'missing')).toBe('');
+  });
+
+  it('returns the full snapshot when the buffer fits in one chunk (no yield needed)', async () => {
+    const sessions = new Map<string, Entry>();
+    const small = Array.from({ length: 50 }, (_, i) => `row-${i}`).join('\n');
+    sessions.set('s1', fakeEntry(small));
+    const snap = await getBufferSnapshot(sessions, 's1');
+    expect(snap).toBe(small);
+  });
+
+  it('chunked path preserves the full string verbatim across yields', async () => {
+    const sessions = new Map<string, Entry>();
+    const N = SNAPSHOT_CHUNK_LINES * 3 + 17; // forces at least 4 chunks
+    const big = Array.from({ length: N }, (_, i) => `row-${i}`).join('\n');
+    sessions.set('s2', fakeEntry(big));
+    const snap = await getBufferSnapshot(sessions, 's2');
+    expect(snap).toBe(big);
+    expect(snap.split('\n')).toHaveLength(N);
+  });
+
+  it('chunked path yields a macrotask between chunks (does not block the event loop)', async () => {
+    const sessions = new Map<string, Entry>();
+    // Force exactly 5 chunks => 4 inter-chunk yields.
+    const N = SNAPSHOT_CHUNK_LINES * 5;
+    const big = Array.from({ length: N }, (_, i) => `r${i}`).join('\n');
+    sessions.set('s3', fakeEntry(big));
+
+    // A setImmediate scheduled BEFORE awaiting getBufferSnapshot must have
+    // a chance to fire WHILE the chunked loop is still running, proving the
+    // loop yields. We count immediates that fire before the snapshot
+    // resolves; with chunking >0, without chunking == 0.
+    let immediateFired = 0;
+    const tickEveryFrame = (): void => {
+      setImmediate(() => {
+        immediateFired += 1;
+        if (immediateFired < 10) tickEveryFrame();
+      });
+    };
+    tickEveryFrame();
+
+    await getBufferSnapshot(sessions, 's3');
+    // Expect at least the number of inter-chunk yields - 1; in practice
+    // we should see >= 3 immediates fire alongside 4 internal yields.
+    expect(immediateFired).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/electron/ptyHost/entryFactory.ts
+++ b/electron/ptyHost/entryFactory.ts
@@ -36,7 +36,11 @@ import { emitPtyData } from './dataFanout';
 
 export const DEFAULT_COLS = 120;
 export const DEFAULT_ROWS = 30;
-export const SCROLLBACK = 5000;
+// L4 PR-A (#861): scrollback bumped from 5000 -> 10000 lines so the headless
+// terminal becomes a session-level authoritative buffer suitable for serving
+// re-attach replays, not just the live screen. 10000 was 80/20-decided by the
+// owner; bump only here and in any future replay-budget calculation.
+export const SCROLLBACK = 10000;
 
 export interface Entry {
   pty: pty.IPty;

--- a/electron/ptyHost/index.ts
+++ b/electron/ptyHost/index.ts
@@ -88,6 +88,13 @@ export const getPtySession = (sid: string): L.PtySessionInfo | null =>
 
 export const killAllPtySessions = (): void => L.killAll(sessions);
 
+// L4 PR-A (#861): async chunked snapshot of the per-session authoritative
+// headless buffer. Returns '' when the sid isn't registered. Wire-format /
+// IPC channel comes in PR-B; this surface is the bare main-process API the
+// tests and PR-B's IPC handler will both consume.
+export const getBufferSnapshot = (sid: string): Promise<string> =>
+  L.getBufferSnapshot(sessions, sid);
+
 // --- IPC registration --------------------------------------------------------
 
 // Register all `pty:*` IPC handlers. Thin wrapper around `registerPtyIpc`

--- a/electron/ptyHost/lifecycle.ts
+++ b/electron/ptyHost/lifecycle.ts
@@ -143,6 +143,47 @@ export function get(sessions: Map<string, Entry>, sid: string): PtySessionInfo |
   return infoFromEntry(sid, entry);
 }
 
+// L4 PR-A (#861): async, chunked snapshot of the headless authoritative buffer.
+//
+// SerializeAddon.serialize() itself is synchronous and walks the entire
+// scrollback (cap 10000 lines). With the bumped cap the serialized string can
+// reach ~MBs for long sessions; concatenating + handing back the full string
+// in one tick would briefly block the main thread. We yield to the event loop
+// every CHUNK_LINES (~1000) lines via setImmediate so other I/O (IPC, JSONL
+// tail, OSC sniffer fanout) keeps making progress while a large snapshot is
+// being assembled. The returned value is still the FULL serialized string —
+// chunking is purely a yield strategy, not a streaming protocol. PR-B will
+// layer the streaming wire format on top; PR-A only owns "don't block".
+//
+// Returns '' when the sid isn't registered (callers treat empty as "no
+// snapshot available", same as `attach` returning null).
+export const SNAPSHOT_CHUNK_LINES = 1000;
+
+export async function getBufferSnapshot(
+  sessions: Map<string, Entry>,
+  sid: string,
+): Promise<string> {
+  const entry = sessions.get(sid);
+  if (!entry) return '';
+  const full = entry.serialize.serialize();
+  if (!full) return '';
+  // Split on '\n' so we yield on a line boundary; preserves the original
+  // separator on rejoin. setImmediate is available in Electron main (Node
+  // event loop). We deliberately avoid Promise.resolve()-style microtask
+  // yields — those don't drain macrotask I/O.
+  const lines = full.split('\n');
+  if (lines.length <= SNAPSHOT_CHUNK_LINES) return full;
+  const out: string[] = [];
+  for (let i = 0; i < lines.length; i += SNAPSHOT_CHUNK_LINES) {
+    out.push(lines.slice(i, i + SNAPSHOT_CHUNK_LINES).join('\n'));
+    if (i + SNAPSHOT_CHUNK_LINES < lines.length) {
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+  }
+  return out.join('\n');
+}
+
 // Kill every running pty. Call from app `before-quit` so renderer-side
 // claude processes don't leak past Electron exit.
 export function killAll(sessions: Map<string, Entry>): void {


### PR DESCRIPTION
## Scope (PR-A only)

Promote per-session `@xterm/headless` Terminal in `electron/ptyHost/entryFactory.ts` from a title-hash side-buffer to a session-level authoritative buffer. No behavior change to the visible terminal (still co-equal mirror today); this PR only widens the headless cap and adds the consumer surface that PR-B will switch the visible xterm onto.

Changes:
- `entryFactory.ts`: `SCROLLBACK` 5000 -> 10000 lines (owner-decided cap, comment cites #861).
- `lifecycle.ts`: new `getBufferSnapshot(sessions, sid): Promise<string>` + `SNAPSHOT_CHUNK_LINES = 1000`. Splits serialized output on `\n` and yields a macrotask via `setImmediate` between chunks so a multi-MB snapshot never blocks the main thread; result is still the full string verbatim (chunking is a yield strategy, not a wire format).
- `index.ts`: re-exports `getBufferSnapshot(sid)` from the ptyHost public surface.
- `@xterm/addon-serialize` was already a dependency and already attached in `entryFactory`. PTY `onData -> headless.write` was already wired (verified at `entryFactory.ts:133-149`). No new install needed.
- New UT: `electron/ptyHost/__tests__/bufferSnapshot.test.ts` (8 cases).

## Deferred (per eval doc PR #603)

- **PR-B** — visible xterm switched to paint-only mode against this buffer
- **PR-C** — renderer xterm in pure paint-only mode
- **PR-D** — SIGWINCH / viewport-reports-size protocol
- **PR-E** — detach/reattach replay via this buffer
- **PR-F** — remove PR #602 spawn-time-size hack

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx vitest run electron/ptyHost` -> 169/169 pass (12 files)
- [x] new bufferSnapshot suite -> 8/8 pass
- [x] reverse-verify: stash impl -> 5 fail / 3 pass; unstash -> 8/8 pass

### Reverse-verify FAIL (impl stashed)

```
FAIL  bufferSnapshot.test.ts > headless authoritative buffer (PR-A real wiring) > SCROLLBACK is bumped to 10000 lines for L4
FAIL  bufferSnapshot.test.ts > lifecycle.getBufferSnapshot ... > returns "" when the sid is not registered
  TypeError: getBufferSnapshot is not a function
FAIL  ... > returns the full snapshot when the buffer fits in one chunk
  TypeError: getBufferSnapshot is not a function
FAIL  ... > chunked path preserves the full string verbatim across yields
  TypeError: getBufferSnapshot is not a function
FAIL  ... > chunked path yields a macrotask between chunks
  TypeError: getBufferSnapshot is not a function

Test Files  1 failed (1)
Tests  5 failed | 3 passed (8)
```

### Reverse-verify PASS (impl restored)

```
Test Files  1 passed (1)
Tests  8 passed (8)
Duration  2.65s
```

### Full ptyHost suite

```
Test Files  12 passed (12)
Tests  169 passed (169)
Duration  16.17s
```

## Notes for reviewer

- This is a no-behavior-change PR for the live terminal — the visible xterm still consumes `pty:data` chunks directly (PR-B's job to redirect).
- Chunking strategy: 1000 lines per slice, `setImmediate` between slices. Returns the FULL serialized string; PR-B can layer a streaming wire format on top without changing this signature.
- See eval rationale: PR #603 (`docs/eval/l4-dual-buffer-mirror.md` on the `eval/l4-dual-buffer-mirror` branch).