### PR TITLE
feat(terminal): L4 PR-B visible xterm attach replays from headless buffer (#865)

### DIFF
--- a/electron/preload/bridges/ccsmPty.ts
+++ b/electron/preload/bridges/ccsmPty.ts
@@ -13,12 +13,13 @@
 
 import { contextBridge, ipcRenderer, clipboard, type IpcRendererEvent } from 'electron';
 
-type PtyDataPayload = { sid: string; chunk: string };
+type PtyDataPayload = { sid: string; chunk: string; seq: number };
 type PtyExitPayload = {
   sessionId: string;
   code: number | null;
   signal: number | null;
 };
+type BufferSnapshotPayload = { snapshot: string; seq: number };
 
 type CheckClaudeAvailableResult =
   | { available: true; path: string }
@@ -42,6 +43,12 @@ const ccsmPty = {
     ipcRenderer.invoke('pty:resize', sid, cols, rows),
   kill: (sid: string): Promise<unknown> => ipcRenderer.invoke('pty:kill', sid),
   get: (sid: string): Promise<unknown> => ipcRenderer.invoke('pty:get', sid),
+  // L4 PR-B (#865): visible xterm attach replay. Returns the serialized
+  // headless buffer plus the per-entry chunk seq captured atomically with
+  // the serialize call. Renderer uses the seq to dedupe live `pty:data`
+  // chunks already represented in the snapshot.
+  getBufferSnapshot: (sid: string): Promise<BufferSnapshotPayload> =>
+    ipcRenderer.invoke('pty:getBufferSnapshot', sid),
   onData: (cb: (e: PtyDataPayload) => void): (() => void) => {
     ptyDataListeners.add(cb);
     return () => {

--- a/electron/ptyHost/__tests__/bufferSnapshot.test.ts
+++ b/electron/ptyHost/__tests__/bufferSnapshot.test.ts
@@ -35,8 +35,8 @@ function makeRealHeadless(): { term: HeadlessTerminal; serialize: SerializeAddon
 
 // Build a fake Entry that just exposes a `serialize.serialize()` returning
 // the supplied string. Other Entry fields are stubbed because
-// getBufferSnapshot only reads `entry.serialize`.
-function fakeEntry(snapshot: string): Entry {
+// getBufferSnapshot only reads `entry.serialize` and `entry.seq`.
+function fakeEntry(snapshot: string, seq: number = 0): Entry {
   return {
     pty: { pid: 0 } as Entry['pty'],
     headless: {} as Entry['headless'],
@@ -45,6 +45,7 @@ function fakeEntry(snapshot: string): Entry {
     cols: 80,
     rows: 24,
     cwd: '/tmp',
+    seq,
   };
 }
 
@@ -100,28 +101,29 @@ describe('headless authoritative buffer (PR-A real wiring)', () => {
   });
 });
 
-describe('lifecycle.getBufferSnapshot (PR-A async chunking)', () => {
-  it('returns "" when the sid is not registered', async () => {
+describe('lifecycle.getBufferSnapshot (PR-A async chunking + PR-B seq capture)', () => {
+  it('returns empty snapshot + seq 0 when the sid is not registered', async () => {
     const sessions = new Map<string, Entry>();
-    expect(await getBufferSnapshot(sessions, 'missing')).toBe('');
+    expect(await getBufferSnapshot(sessions, 'missing')).toEqual({ snapshot: '', seq: 0 });
   });
 
-  it('returns the full snapshot when the buffer fits in one chunk (no yield needed)', async () => {
+  it('returns the full snapshot + entry.seq when the buffer fits in one chunk (no yield needed)', async () => {
     const sessions = new Map<string, Entry>();
     const small = Array.from({ length: 50 }, (_, i) => `row-${i}`).join('\n');
-    sessions.set('s1', fakeEntry(small));
-    const snap = await getBufferSnapshot(sessions, 's1');
-    expect(snap).toBe(small);
+    sessions.set('s1', fakeEntry(small, 42));
+    const result = await getBufferSnapshot(sessions, 's1');
+    expect(result).toEqual({ snapshot: small, seq: 42 });
   });
 
-  it('chunked path preserves the full string verbatim across yields', async () => {
+  it('chunked path preserves the full string verbatim across yields and returns entry.seq', async () => {
     const sessions = new Map<string, Entry>();
     const N = SNAPSHOT_CHUNK_LINES * 3 + 17; // forces at least 4 chunks
     const big = Array.from({ length: N }, (_, i) => `row-${i}`).join('\n');
-    sessions.set('s2', fakeEntry(big));
-    const snap = await getBufferSnapshot(sessions, 's2');
-    expect(snap).toBe(big);
-    expect(snap.split('\n')).toHaveLength(N);
+    sessions.set('s2', fakeEntry(big, 99));
+    const result = await getBufferSnapshot(sessions, 's2');
+    expect(result.snapshot).toBe(big);
+    expect(result.snapshot.split('\n')).toHaveLength(N);
+    expect(result.seq).toBe(99);
   });
 
   it('chunked path yields a macrotask between chunks (does not block the event loop)', async () => {
@@ -129,7 +131,7 @@ describe('lifecycle.getBufferSnapshot (PR-A async chunking)', () => {
     // Force exactly 5 chunks => 4 inter-chunk yields.
     const N = SNAPSHOT_CHUNK_LINES * 5;
     const big = Array.from({ length: N }, (_, i) => `r${i}`).join('\n');
-    sessions.set('s3', fakeEntry(big));
+    sessions.set('s3', fakeEntry(big, 1));
 
     // A setImmediate scheduled BEFORE awaiting getBufferSnapshot must have
     // a chance to fire WHILE the chunked loop is still running, proving the

--- a/electron/ptyHost/__tests__/ipcRegistrar.test.ts
+++ b/electron/ptyHost/__tests__/ipcRegistrar.test.ts
@@ -89,6 +89,7 @@ function makeDeps(over: Partial<PtyIpcDeps> = {}): PtyIpcDeps {
     resizePtySession: vi.fn(),
     killPtySession: vi.fn(() => true),
     getPtySession: vi.fn(() => null),
+    getBufferSnapshot: vi.fn(async () => ({ snapshot: '', seq: 0 })),
     ...over,
   };
 }
@@ -110,7 +111,7 @@ afterEach(() => {
 // ─── handler registration shape ───────────────────────────────────────────
 
 describe('registerPtyIpc handler registration', () => {
-  it('registers all eight pty:* channels', () => {
+  it('registers all nine pty:* channels (8 legacy + getBufferSnapshot)', () => {
     const ipc = makeFakeIpc();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps());
@@ -120,6 +121,7 @@ describe('registerPtyIpc handler registration', () => {
         'pty:checkClaudeAvailable',
         'pty:detach',
         'pty:get',
+        'pty:getBufferSnapshot',
         'pty:input',
         'pty:kill',
         'pty:list',
@@ -127,6 +129,22 @@ describe('registerPtyIpc handler registration', () => {
         'pty:spawn',
       ].sort(),
     );
+  });
+
+  // L4 PR-B (#865) — wire-format probe for the new channel.
+  it('pty:getBufferSnapshot delegates to deps.getBufferSnapshot and passes the sid', async () => {
+    const ipc = makeFakeIpc();
+    const deps = makeDeps({
+      getBufferSnapshot: vi.fn(async (sid: string) => ({
+        snapshot: `snap-for-${sid}`,
+        seq: 7,
+      })),
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerPtyIpc(ipc as any, deps);
+    const out = await ipc.handlers.get('pty:getBufferSnapshot')!({}, 'sid-Z');
+    expect(out).toEqual({ snapshot: 'snap-for-sid-Z', seq: 7 });
+    expect(deps.getBufferSnapshot).toHaveBeenCalledWith('sid-Z');
   });
 });
 

--- a/electron/ptyHost/entryFactory.ts
+++ b/electron/ptyHost/entryFactory.ts
@@ -55,6 +55,18 @@ export interface Entry {
   /** Resolved spawn cwd (after `resolveSpawnCwd` fallback). Captured here
    *  so `listPtySessions` / `getPtySession` can return it without re-deriving. */
   cwd: string;
+  /** L4 PR-B (#865): monotonic per-entry chunk counter, incremented on
+   *  every `p.onData` BEFORE the chunk is written to the headless / fanned
+   *  out. The renderer attach flow uses it together with
+   *  `getBufferSnapshot` to dedupe live chunks against the snapshot:
+   *  `getBufferSnapshot` returns `{snapshot, seq}` capturing the value of
+   *  this counter at snapshot time, and any live chunk with `chunk.seq <=
+   *  snap.seq` is already baked into the snapshot. Because Node's event
+   *  loop is single-threaded, increment + write + broadcast + snapshot
+   *  read all happen atomically relative to one another — there is no
+   *  window where `headless.write` runs but the broadcast carries a stale
+   *  seq. */
+  seq: number;
 }
 
 export interface MakeEntryDeps {
@@ -132,14 +144,20 @@ export function makeEntry(
     cols,
     rows,
     cwd: spawnCwd,
+    seq: 0,
   };
 
   p.onData((chunk) => {
+    // L4 PR-B (#865): bump seq BEFORE write/broadcast so the broadcast
+    // payload carries the same seq the renderer will use to dedupe
+    // against `getBufferSnapshot`.
+    entry.seq += 1;
+    const seq = entry.seq;
     headless.write(chunk);
     for (const wc of entry.attached.values()) {
       if (!wc.isDestroyed()) {
         try {
-          wc.send('pty:data', { sid, chunk });
+          wc.send('pty:data', { sid, chunk, seq });
         } catch {
           /* renderer gone — best effort */
         }

--- a/electron/ptyHost/index.ts
+++ b/electron/ptyHost/index.ts
@@ -51,7 +51,7 @@ export {
 } from './jsonlResolver';
 export type { EnsureResumeJsonlResult } from './jsonlResolver';
 export { resolveSpawnCwd } from './cwdResolver';
-export type { PtySessionInfo, AttachResult } from './lifecycle';
+export type { PtySessionInfo, AttachResult, BufferSnapshot } from './lifecycle';
 
 // --- Singleton registry ------------------------------------------------------
 
@@ -88,11 +88,11 @@ export const getPtySession = (sid: string): L.PtySessionInfo | null =>
 
 export const killAllPtySessions = (): void => L.killAll(sessions);
 
-// L4 PR-A (#861): async chunked snapshot of the per-session authoritative
-// headless buffer. Returns '' when the sid isn't registered. Wire-format /
-// IPC channel comes in PR-B; this surface is the bare main-process API the
-// tests and PR-B's IPC handler will both consume.
-export const getBufferSnapshot = (sid: string): Promise<string> =>
+// L4 PR-A (#861) + PR-B (#865): async chunked snapshot of the per-session
+// authoritative headless buffer paired with the per-entry chunk seq.
+// Returns `{snapshot:'', seq:0}` when the sid isn't registered. Renderer
+// uses the seq to dedupe live `pty:data` chunks against the snapshot.
+export const getBufferSnapshot = (sid: string): Promise<L.BufferSnapshot> =>
   L.getBufferSnapshot(sessions, sid);
 
 // --- IPC registration --------------------------------------------------------
@@ -114,6 +114,7 @@ export function registerPtyHostIpc(
     resizePtySession,
     killPtySession,
     getPtySession,
+    getBufferSnapshot,
   });
 }
 

--- a/electron/ptyHost/ipcRegistrar.ts
+++ b/electron/ptyHost/ipcRegistrar.ts
@@ -9,7 +9,7 @@
 import type { BrowserWindow, IpcMain } from 'electron';
 import { resolveClaude } from './claudeResolver';
 import { sessionWatcher } from '../sessionWatcher';
-import type { AttachResult, PtySessionInfo } from './lifecycle';
+import type { AttachResult, BufferSnapshot, PtySessionInfo } from './lifecycle';
 
 interface SessionEntryHandle {
   pty: { pid: number };
@@ -37,6 +37,11 @@ export interface PtyIpcDeps {
   resizePtySession: (sid: string, cols: number, rows: number) => void;
   killPtySession: (sid: string) => boolean;
   getPtySession: (sid: string) => PtySessionInfo | null;
+  /** L4 PR-B (#865): async chunked snapshot + capture seq. Routed through
+   *  the deps surface (rather than direct module import) so the registrar
+   *  stays decoupled from the lifecycle singleton — same pattern as the
+   *  other lifecycle ops above. */
+  getBufferSnapshot: (sid: string) => Promise<BufferSnapshot>;
 }
 
 // Module-singleton guard: registerPtyIpc may be called more than once
@@ -170,6 +175,15 @@ export function registerPtyIpc(ipcMain: IpcMain, deps: PtyIpcDeps): void {
   ipcMain.handle('pty:kill', (_event, sid: string) => deps.killPtySession(sid));
 
   ipcMain.handle('pty:get', (_event, sid: string) => deps.getPtySession(sid));
+
+  // L4 PR-B (#865) — visible xterm attach replay channel. Returns the
+  // serialized headless buffer plus the captured chunk seq so the
+  // renderer can drop live `pty:data` chunks already baked into the
+  // snapshot. Async so a multi-MB serialize doesn't block the main
+  // thread — `lifecycle.getBufferSnapshot` chunks the join.
+  ipcMain.handle('pty:getBufferSnapshot', (_event, sid: string) =>
+    deps.getBufferSnapshot(sid),
+  );
 
   // Claude CLI availability probe. Folded into ptyHost (post-PR-8) from
   // the deleted electron/cliBridge module: ccsm has a single CLI host

--- a/electron/ptyHost/lifecycle.ts
+++ b/electron/ptyHost/lifecycle.ts
@@ -143,7 +143,8 @@ export function get(sessions: Map<string, Entry>, sid: string): PtySessionInfo |
   return infoFromEntry(sid, entry);
 }
 
-// L4 PR-A (#861): async, chunked snapshot of the headless authoritative buffer.
+// L4 PR-A (#861) + PR-B (#865): async, chunked snapshot of the headless
+// authoritative buffer, paired with the per-entry monotonic chunk seq.
 //
 // SerializeAddon.serialize() itself is synchronous and walks the entire
 // scrollback (cap 10000 lines). With the bumped cap the serialized string can
@@ -152,27 +153,44 @@ export function get(sessions: Map<string, Entry>, sid: string): PtySessionInfo |
 // every CHUNK_LINES (~1000) lines via setImmediate so other I/O (IPC, JSONL
 // tail, OSC sniffer fanout) keeps making progress while a large snapshot is
 // being assembled. The returned value is still the FULL serialized string —
-// chunking is purely a yield strategy, not a streaming protocol. PR-B will
-// layer the streaming wire format on top; PR-A only owns "don't block".
+// chunking is purely a yield strategy, not a streaming protocol.
 //
-// Returns '' when the sid isn't registered (callers treat empty as "no
-// snapshot available", same as `attach` returning null).
+// PR-B adds the `seq` field: captured ATOMICALLY with `serialize.serialize()`
+// (both happen synchronously, no chunk can arrive between them under Node's
+// single-threaded event loop). The renderer compares each live `pty:data`
+// chunk's seq against this value to drop chunks already baked into the
+// snapshot, eliminating the race between attach-fanout and snapshot read.
+//
+// Returns `{snapshot:'', seq:0}` when the sid isn't registered (callers
+// treat empty as "no snapshot available", same as `attach` returning null).
 export const SNAPSHOT_CHUNK_LINES = 1000;
+
+export interface BufferSnapshot {
+  snapshot: string;
+  /** Value of `entry.seq` at the moment `serialize.serialize()` ran. Live
+   *  chunks delivered with `seq <= snapshot.seq` are already represented
+   *  in `snapshot` and must be dropped by the renderer; chunks with
+   *  `seq > snapshot.seq` are the post-snapshot live tail and must be
+   *  written after the snapshot. */
+  seq: number;
+}
 
 export async function getBufferSnapshot(
   sessions: Map<string, Entry>,
   sid: string,
-): Promise<string> {
+): Promise<BufferSnapshot> {
   const entry = sessions.get(sid);
-  if (!entry) return '';
+  if (!entry) return { snapshot: '', seq: 0 };
+  // Capture seq + serialized string atomically (both sync, no awaits).
+  const seq = entry.seq;
   const full = entry.serialize.serialize();
-  if (!full) return '';
+  if (!full) return { snapshot: '', seq };
   // Split on '\n' so we yield on a line boundary; preserves the original
   // separator on rejoin. setImmediate is available in Electron main (Node
   // event loop). We deliberately avoid Promise.resolve()-style microtask
   // yields — those don't drain macrotask I/O.
   const lines = full.split('\n');
-  if (lines.length <= SNAPSHOT_CHUNK_LINES) return full;
+  if (lines.length <= SNAPSHOT_CHUNK_LINES) return { snapshot: full, seq };
   const out: string[] = [];
   for (let i = 0; i < lines.length; i += SNAPSHOT_CHUNK_LINES) {
     out.push(lines.slice(i, i + SNAPSHOT_CHUNK_LINES).join('\n'));
@@ -181,7 +199,7 @@ export async function getBufferSnapshot(
       await new Promise<void>((resolve) => setImmediate(resolve));
     }
   }
-  return out.join('\n');
+  return { snapshot: out.join('\n'), seq };
 }
 
 // Kill every running pty. Call from app `before-quit` so renderer-side

--- a/scripts/harness-real-cli.mjs
+++ b/scripts/harness-real-cli.mjs
@@ -3090,11 +3090,179 @@ async function caseNotifyPipelineBackground({ electronApp, win, tempDir }) {
 }
 
 // ============================================================================
+// Case: attach-replay-from-headless-buffer (L4 PR-B, #865 / fixes #852)
+// ============================================================================
+//
+// Pins the snapshot-then-live attach contract:
+//
+//   1. window.ccsmPty.getBufferSnapshot(sid) IPC channel exists and returns
+//      `{ snapshot: string, seq: number }` — the new PR-B wire format.
+//   2. After spawning a fresh session, the visible xterm buffer ALREADY
+//      contains real output (claude's trust prompt or the welcome panel)
+//      WITHOUT the probe sending any keystroke. Pre-PR-B this was the #852
+//      bug: claude's alt-screen TUI doesn't repaint on terminal size change,
+//      so the visible xterm sat half-empty until the user typed.
+//   3. The visible xterm content matches the headless authoritative buffer
+//      content as reported by `getBufferSnapshot` — proving the snapshot
+//      replay path actually feeds the visible terminal (not just claude's
+//      live-paint via pty:data).
+//   4. Switching A→B→A re-runs the snapshot replay for A and the visible
+//      xterm restores its prior content WITHOUT typing — same path, exercised
+//      under the re-attach scenario.
+//
+// This case is the e2e probe for PR-B's IPC + replay; PR #602's spawn-time
+// size hack (#852 L1 fix) is still in place, so the trust prompt is also
+// visible at the right size — what we additionally pin here is the IPC
+// surface and the snapshot-feeds-view linkage. PR-F will revert #602's hack;
+// when it does, this probe must STILL pass on the strength of replay alone.
+
+async function caseAttachReplayFromHeadlessBuffer({ electronApp, win, tempDir }) {
+  await win.waitForFunction(
+    () => !document.querySelector('[data-testid="claude-availability-probing"]'),
+    null,
+    { timeout: 30000 },
+  );
+
+  // Probe 1: IPC surface — pty:getBufferSnapshot exists and returns the
+  // PR-B shape even for an unknown sid (`{snapshot:'', seq:0}`).
+  const surface = await win.evaluate(async () => {
+    if (!window.ccsmPty) return { ok: false, reason: 'no ccsmPty' };
+    if (typeof window.ccsmPty.getBufferSnapshot !== 'function') {
+      return { ok: false, reason: 'getBufferSnapshot is not a function' };
+    }
+    try {
+      const result = await window.ccsmPty.getBufferSnapshot('nonexistent-sid-probe');
+      return { ok: true, result };
+    } catch (e) {
+      return { ok: false, reason: `threw: ${String(e)}` };
+    }
+  });
+  if (!surface.ok) {
+    throw new Error(`[attach-replay] IPC surface check failed: ${surface.reason}`);
+  }
+  if (
+    !surface.result ||
+    typeof surface.result.snapshot !== 'string' ||
+    typeof surface.result.seq !== 'number'
+  ) {
+    throw new Error(
+      `[attach-replay] getBufferSnapshot returned wrong shape: ${JSON.stringify(surface.result)}`,
+    );
+  }
+  console.log(
+    `[HARNESS]   PR-B IPC ok: getBufferSnapshot('nonexistent') => snapshot=${JSON.stringify(surface.result.snapshot)} seq=${surface.result.seq}`,
+  );
+
+  // Probe 2: spawn a session, wait for terminal ready + first paint, then
+  // assert the visible xterm has substantial content WITHOUT typing
+  // anything. Pre-PR-B + pre-#602 the trust prompt was half-rendered; with
+  // either fix in place the trust panel is fully visible.
+  const { sid } = await seedSession(win, { name: 'pr-b-attach-replay', cwd: tempDir });
+  if (!sid) throw new Error('seedSession returned empty sid');
+  await sleep(4000);
+  await waitForTerminalReady(win, sid, { timeout: 60000 });
+  await waitForXtermBuffer(win, /trust|claude|welcome|│|╭|>/i, { timeout: 30000 });
+
+  // Probe 3: read the headless buffer via the new IPC and confirm the
+  // visible xterm shows the same content (trust prompt / welcome). This
+  // is the snapshot-feeds-view linkage: if PR-B's replay path is broken,
+  // the visible xterm relies entirely on live `pty:data` for new attaches
+  // — which on the L4 PR-A baseline would still work because the same
+  // chunks fan out, but on switch-back (probe 4) it would NOT.
+  const snap = await win.evaluate(async (s) => {
+    return await window.ccsmPty.getBufferSnapshot(s);
+  }, sid);
+  if (typeof snap.snapshot !== 'string' || typeof snap.seq !== 'number') {
+    throw new Error(`[attach-replay] post-spawn snapshot wrong shape: ${JSON.stringify(snap)}`);
+  }
+  if (snap.snapshot.length < 50) {
+    throw new Error(
+      `[attach-replay] headless snapshot suspiciously short (${snap.snapshot.length} bytes) — claude may not have written its first frame yet`,
+    );
+  }
+  if (snap.seq < 1) {
+    throw new Error(`[attach-replay] expected snap.seq >= 1 after first frame, got ${snap.seq}`);
+  }
+  console.log(
+    `[HARNESS]   PR-B headless snapshot for ${sid}: ${snap.snapshot.length} bytes, seq=${snap.seq}`,
+  );
+
+  // Probe 4: switch-away-and-back path — this is where PR-B is load-bearing.
+  // On switch-back, usePtyAttach calls getBufferSnapshot and writes it to
+  // the (reset-then-resized) visible xterm. If the IPC / replay protocol
+  // is broken, the visible xterm goes blank because claude (in alt-screen
+  // mode) does not voluntarily repaint on the resize that follows attach.
+  await dismissFirstRunModals(win);
+  const beforeSwitchLines = await readXtermLines(win, { lines: 60 });
+  const beforeSwitchText = beforeSwitchLines.join('\n');
+
+  // Spawn a second session to switch to.
+  const { sid: sidB } = await seedSession(win, { name: 'pr-b-bystander', cwd: tempDir });
+  if (!sidB || sidB === sid) throw new Error(`bad sidB=${sidB}`);
+  await win.evaluate((id) => window.__ccsmStore.getState().selectSession(id), sidB);
+  await waitForTerminalReady(win, sidB, { timeout: 30000 });
+  await waitForXtermBuffer(win, /trust|claude|welcome|│|╭|>/i, { timeout: 30000 });
+
+  // Switch back to A. After waitForTerminalReady resolves, usePtyAttach has
+  // run snapshot+drain and the visible xterm should already contain content
+  // — without us sending any keystroke. Allow a short settle for the
+  // snapshot write + post-attach fit() to land in the canvas before
+  // reading the buffer.
+  await win.evaluate((id) => window.__ccsmStore.getState().selectSession(id), sid);
+  await waitForTerminalReady(win, sid, { timeout: 30000 });
+  // Poll for content: snapshot replay should land within a couple of
+  // seconds of attach. This is intentionally a content check, not a
+  // wall-clock assertion — the failure mode we are guarding against is
+  // "blank forever until user types", not "took 500ms instead of 100ms".
+  await waitForXtermBuffer(win, /trust|claude|welcome|│|╭|>|\?\sfor\sshortcuts/i, { timeout: 20000 });
+
+  const afterRebindLines = await readXtermLines(win, { lines: 60 });
+  const afterRebindText = afterRebindLines.join('\n');
+  // The rebind buffer should not be empty. Pre-PR-B (in a hypothetical
+  // world without the legacy attach.snapshot path) the alt-screen would
+  // be blank until the user typed; with PR-B we replay from headless and
+  // see content immediately.
+  const nonBlankLines = afterRebindLines.filter((l) => /\S/.test(l));
+  if (nonBlankLines.length < 3) {
+    throw new Error(
+      `[attach-replay] visible xterm blank after switch-back (only ${nonBlankLines.length} non-blank lines). beforeSwitch had ${beforeSwitchLines.filter((l) => /\S/.test(l)).length}. tail:\n${afterRebindLines.slice(-10).join('\n')}`,
+    );
+  }
+
+  // Stronger check: the snapshot we just got from the headless buffer is
+  // present (in non-trivial part) in the visible xterm. We compare on a
+  // tail substring to avoid ANSI / wrap noise.
+  const liveSnap = await win.evaluate(async (s) => window.ccsmPty.getBufferSnapshot(s), sid);
+  // Strip ANSI to compare plain text.
+  const stripAnsi = (s) => s.replace(/\x1b\[[0-9;?]*[A-Za-z]/g, '').replace(/\r/g, '');
+  const headlessPlain = stripAnsi(liveSnap.snapshot);
+  const visiblePlain = stripAnsi(afterRebindText);
+  // Find any substantive line (>= 8 chars, contains a letter) from the
+  // headless that survives in the visible.
+  const headlessLines = headlessPlain.split('\n').map((l) => l.trim()).filter(
+    (l) => l.length >= 8 && /[A-Za-z]/.test(l),
+  );
+  let matched = 0;
+  for (const hl of headlessLines.slice(-30)) {
+    if (visiblePlain.includes(hl)) matched += 1;
+  }
+  if (matched === 0) {
+    throw new Error(
+      `[attach-replay] headless snapshot and visible xterm have no overlapping substantive line — replay path appears broken. headless tail:\n${headlessLines.slice(-10).join('\n')}\n\nvisible tail:\n${afterRebindLines.slice(-10).join('\n')}`,
+    );
+  }
+  console.log(
+    `[HARNESS]   PR-B replay verified: ${matched} headless lines visible after switch-back to ${sid}`,
+  );
+}
+
+// ============================================================================
 // Registry
 // ============================================================================
 
 const CASE_REGISTRY = [
   { name: 'new-session-chat',            group: 'shared', run: caseNewSessionChat },
+  { name: 'attach-replay-from-headless-buffer', group: 'shared', run: caseAttachReplayFromHeadlessBuffer },
   { name: 'session-rename-writes-jsonl', group: 'shared', run: caseSessionRenameWritesJsonl },
   { name: 'session-title-syncs-from-jsonl', group: 'shared', run: caseSessionTitleSyncsFromJsonl },
   { name: 'session-state-becomes-idle',  group: 'shared', run: caseSessionStateBecomesIdle },

--- a/src/pty.d.ts
+++ b/src/pty.d.ts
@@ -38,6 +38,21 @@ export interface PtyExitEvent {
 export interface PtyDataEvent {
   sid: string;
   chunk: string;
+  /** L4 PR-B (#865): per-entry monotonic chunk counter. Renderer uses
+   *  this together with `getBufferSnapshot().seq` to drop chunks already
+   *  baked into the replayed snapshot. */
+  seq: number;
+}
+
+export interface BufferSnapshotResult {
+  /** SerializeAddon output of the headless authoritative buffer. May be
+   *  empty if the sid is not registered or the buffer is empty. */
+  snapshot: string;
+  /** Value of the per-entry chunk seq captured atomically with the
+   *  serialize call. Live `pty:data` chunks with `seq <= this` are
+   *  already represented in `snapshot` and must be dropped by the
+   *  renderer. */
+  seq: number;
 }
 
 export type CheckClaudeAvailableResult =
@@ -53,6 +68,8 @@ export interface CcsmPtyApi {
   resize(sid: string, cols: number, rows: number): Promise<void>;
   kill(sid: string): Promise<{ ok: boolean; killed?: boolean }>;
   get(sid: string): Promise<PtySessionInfo | null>;
+  /** L4 PR-B (#865): visible xterm attach replay channel. */
+  getBufferSnapshot(sid: string): Promise<BufferSnapshotResult>;
   onData(cb: (e: PtyDataEvent) => void): () => void;
   onExit(cb: (e: PtyExitEvent) => void): () => void;
   clipboard: {

--- a/src/terminal/usePtyAttach.ts
+++ b/src/terminal/usePtyAttach.ts
@@ -192,7 +192,34 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
             | null;
           if (!res) throw new Error('attach_failed_after_spawn');
         }
-        const { snapshot, cols, rows } = res;
+        // L4 PR-B (#865): we no longer use `res.snapshot`. The legacy
+        // attach-time snapshot is a sync race with the live `pty:data`
+        // fanout: by the time the IPC return value reaches the renderer,
+        // additional chunks may have been broadcast that are NOT yet in
+        // the snapshot, leading to either lost data or duplicated bytes
+        // depending on which we wrote first. The new flow is:
+        //   1. attach     → registers our webContents in the entry's
+        //                   `attached` map (server now broadcasts to us).
+        //   2. subscribe  → install a `pty.onData` listener that BUFFERS
+        //                   chunks for this sid (seq tagged) instead of
+        //                   writing them to the visible terminal.
+        //   3. snapshot   → call `pty.getBufferSnapshot(sid)`, which
+        //                   captures `(serialize(), entry.seq)` ATOMICALLY
+        //                   under the main process's single-threaded loop.
+        //   4. write snap → flush the snapshot to the visible terminal.
+        //   5. drain      → write any buffered chunks with `seq > snapSeq`
+        //                   in arrival order; these are the live tail
+        //                   that arrived between steps 2 and 3.
+        //   6. flip       → switch the listener into "write directly"
+        //                   mode for all subsequent chunks (still seq
+        //                   filtered, defensively, since seq monotonic
+        //                   from this point).
+        // This eliminates the dependency on claude voluntarily repainting
+        // its alt-screen after attach (#852 root cause: alt-screen
+        // applications like claude's TUI don't repaint on terminal size
+        // change unless input arrives, so the visible xterm sat half-
+        // empty until the user typed something).
+        const { cols, rows } = res;
         if (cancelled || requestedSidRef.current !== sessionId) return;
 
         setActiveSid(sessionId);
@@ -208,15 +235,53 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
           } catch {
             // resize is best-effort — proceed with snapshot write.
           }
-          if (snapshot) t2.write(snapshot);
         }
 
+        // Step 2: install the listener BEFORE requesting the snapshot.
+        // `snapSeq` starts as null ("snapshot not yet landed, buffer
+        // everything") and flips to a number once snapshot resolves
+        // ("write directly, but defensively filter by seq").
+        let snapSeq: number | null = null;
+        const buffered: Array<{ seq: number; chunk: string }> = [];
         setUnsubscribeData(
-          pty.onData((payload: { sid: string; chunk: string }) => {
+          pty.onData((payload: { sid: string; chunk: string; seq: number }) => {
             if (payload.sid !== getActiveSid()) return;
-            getTerm()?.write(payload.chunk);
+            if (snapSeq === null) {
+              buffered.push({ seq: payload.seq, chunk: payload.chunk });
+              return;
+            }
+            // Post-snapshot: drop anything seq <= snapSeq (already in
+            // the snapshot we wrote) and write the rest live.
+            if (payload.seq > snapSeq) {
+              getTerm()?.write(payload.chunk);
+            }
           }),
         );
+
+        // Step 3: request the snapshot. Async so a multi-MB serialize
+        // doesn't block; chunks may continue to arrive on `pty.onData`
+        // during this await and are caught by the buffering listener.
+        const snap = (await pty.getBufferSnapshot(sessionId)) as {
+          snapshot: string;
+          seq: number;
+        };
+        if (cancelled || requestedSidRef.current !== sessionId) return;
+
+        // Step 4: write snapshot to the visible terminal.
+        const tSnap = getTerm();
+        if (tSnap && snap.snapshot) tSnap.write(snap.snapshot);
+
+        // Step 5: drain buffered chunks with seq > snapSeq, in order.
+        // Anything with seq <= snapSeq is already represented in the
+        // snapshot and would duplicate.
+        snapSeq = snap.seq;
+        const tDrain = getTerm();
+        if (tDrain) {
+          for (const b of buffered) {
+            if (b.seq > snapSeq) tDrain.write(b.chunk);
+          }
+        }
+        buffered.length = 0;
 
         const t3 = getTerm();
         if (t3) {

--- a/tests/terminal/usePtyAttach.test.tsx
+++ b/tests/terminal/usePtyAttach.test.tsx
@@ -65,12 +65,18 @@ import {
 
 type AttachResp = { snapshot: string; cols: number; rows: number; pid: number } | null;
 
-function makePtyBridge(opts: { attach?: AttachResp } = {}) {
+function makePtyBridge(opts: { attach?: AttachResp; snapshot?: { snapshot: string; seq: number } } = {}) {
   const attachResp: AttachResp =
     opts.attach === undefined
       ? { snapshot: 'snap', cols: 80, rows: 24, pid: 1234 }
       : opts.attach;
-  let onDataHandler: ((p: { sid: string; chunk: string }) => void) | null = null;
+  // L4 PR-B (#865): the snapshot the visible terminal actually paints
+  // comes from `getBufferSnapshot`, NOT from `attach.snapshot` (which is
+  // now only kept for cols/rows/pid). Default to the same string so
+  // existing assertions (`writeSpy was called with 'snap'`) still pass.
+  const snapshotResp: { snapshot: string; seq: number } =
+    opts.snapshot ?? { snapshot: 'snap', seq: 0 };
+  let onDataHandler: ((p: { sid: string; chunk: string; seq: number }) => void) | null = null;
   let onExitHandler:
     | ((evt: { sessionId: string; code?: number | null; signal?: string | number | null }) => void)
     | null = null;
@@ -86,7 +92,7 @@ function makePtyBridge(opts: { attach?: AttachResp } = {}) {
   const input = vi.fn();
   const resize = vi.fn();
   const onDataUnsub = vi.fn();
-  const onData = vi.fn((cb: (p: { sid: string; chunk: string }) => void) => {
+  const onData = vi.fn((cb: (p: { sid: string; chunk: string; seq: number }) => void) => {
     onDataHandler = cb;
     return onDataUnsub;
   });
@@ -95,11 +101,12 @@ function makePtyBridge(opts: { attach?: AttachResp } = {}) {
     onExitHandler = cb;
     return onExitUnsub;
   });
+  const getBufferSnapshot = vi.fn(async (_sid: string) => snapshotResp);
   return {
-    bridge: { attach, detach, spawn, input, resize, onData, onExit },
-    spies: { attach, detach, spawn, onData, onDataUnsub, onExit, onExitUnsub, input, resize },
+    bridge: { attach, detach, spawn, input, resize, onData, onExit, getBufferSnapshot },
+    spies: { attach, detach, spawn, onData, onDataUnsub, onExit, onExitUnsub, input, resize, getBufferSnapshot },
     fire: {
-      data: (p: { sid: string; chunk: string }) => onDataHandler?.(p),
+      data: (p: { sid: string; chunk: string; seq: number }) => onDataHandler?.(p),
       exit: (e: Parameters<NonNullable<typeof onExitHandler>>[0]) => onExitHandler?.(e),
     },
   };
@@ -180,11 +187,11 @@ describe('usePtyAttach', () => {
 
   it('falls back to spawn when attach returns null', async () => {
     let calls = 0;
-    const { bridge, spies } = makePtyBridge();
+    const { bridge, spies } = makePtyBridge({ snapshot: { snapshot: 'after-spawn', seq: 0 } });
     spies.attach.mockImplementation(async (_sid: string) => {
       calls += 1;
       if (calls === 1) return null;
-      return { snapshot: 'after-spawn', cols: 80, rows: 24, pid: 1 };
+      return { snapshot: 'ignored-now', cols: 80, rows: 24, pid: 1 };
     });
     (window as any).ccsmPty = bridge;
 
@@ -193,6 +200,8 @@ describe('usePtyAttach', () => {
 
     expect(spies.spawn).toHaveBeenCalledWith('sid-C', '/cwd', expect.objectContaining({}));
     expect(spies.attach).toHaveBeenCalledTimes(2);
+    // L4 PR-B (#865): the visible terminal paints the getBufferSnapshot
+    // string, NOT the legacy attach.snapshot.
     expect(writeSpy).toHaveBeenCalledWith('after-spawn');
   });
 
@@ -203,11 +212,11 @@ describe('usePtyAttach', () => {
   // visible 134x51 xterm stays a black void until the user types.
   it('forwards viewport-measured cols/rows to spawn (fixes #852 alt-screen divergence)', async () => {
     let calls = 0;
-    const { bridge, spies } = makePtyBridge();
+    const { bridge, spies } = makePtyBridge({ snapshot: { snapshot: 'after-spawn', seq: 0 } });
     spies.attach.mockImplementation(async (_sid: string) => {
       calls += 1;
       if (calls === 1) return null;
-      return { snapshot: 'after-spawn', cols: 134, rows: 51, pid: 1 };
+      return { snapshot: 'ignored-now', cols: 134, rows: 51, pid: 1 };
     });
     proposeDimensionsSpy.mockReturnValue({ cols: 134, rows: 51 });
     (window as any).ccsmPty = bridge;
@@ -229,11 +238,11 @@ describe('usePtyAttach', () => {
 
   it('omits cols/rows when FitAddon proposeDimensions returns undefined', async () => {
     let calls = 0;
-    const { bridge, spies } = makePtyBridge();
+    const { bridge, spies } = makePtyBridge({ snapshot: { snapshot: 'after-spawn', seq: 0 } });
     spies.attach.mockImplementation(async (_sid: string) => {
       calls += 1;
       if (calls === 1) return null;
-      return { snapshot: 'after-spawn', cols: 80, rows: 24, pid: 1 };
+      return { snapshot: 'ignored-now', cols: 80, rows: 24, pid: 1 };
     });
     proposeDimensionsSpy.mockReturnValue(undefined as unknown as { cols: number; rows: number });
     (window as any).ccsmPty = bridge;

--- a/tests/usePtyAttach-snapshot-replay.test.tsx
+++ b/tests/usePtyAttach-snapshot-replay.test.tsx
@@ -1,0 +1,256 @@
+// L4 PR-B (#865): visible xterm attach replays from headless via the new
+// `pty:getBufferSnapshot` IPC, then transitions to live `pty:data` stream
+// without dropping or duplicating chunks.
+//
+// Pins the snapshot-then-live contract:
+//   1. After attach, usePtyAttach calls window.ccsmPty.getBufferSnapshot(sid).
+//   2. The returned snapshot is written to the visible terminal.
+//   3. Live chunks delivered BEFORE the snapshot resolves are buffered and
+//      drained AFTER (filtered by seq > snapshot.seq) so nothing is lost.
+//   4. Live chunks delivered AFTER the snapshot are written directly.
+//   5. Re-attaching for a fresh sid (switch session) repeats the same flow
+//      and the second snapshot lands without losing the interleaved chunk.
+//
+// We mock window.ccsmPty + the xterm singleton so no real PTY / xterm is
+// constructed. The hook drives the state machine; we assert ordered writes
+// against the mocked Terminal.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { usePtyAttach } from '../src/terminal/usePtyAttach';
+import * as singleton from '../src/terminal/xtermSingleton';
+
+type DataCb = (e: { sid: string; chunk: string; seq: number }) => void;
+type ExitCb = (e: { sessionId: string; code?: number | null; signal?: string | number | null }) => void;
+
+interface MockState {
+  writes: string[];
+  attachCalls: string[];
+  spawnCalls: Array<{ sid: string; cwd: string }>;
+  detachCalls: string[];
+  snapshotCalls: string[];
+  resizeCalls: Array<{ sid: string; cols: number; rows: number }>;
+  // Test-controlled snapshot resolver — caller awaits this Promise to
+  // simulate the chunked-yield delay so we can fire live chunks DURING
+  // the await.
+  pendingSnapshot: { resolve: (v: { snapshot: string; seq: number }) => void; promise: Promise<{ snapshot: string; seq: number }> } | null;
+  dataCbs: Set<DataCb>;
+  exitCbs: Set<ExitCb>;
+}
+
+let M: MockState;
+
+function freshState(): MockState {
+  return {
+    writes: [],
+    attachCalls: [],
+    spawnCalls: [],
+    detachCalls: [],
+    snapshotCalls: [],
+    resizeCalls: [],
+    pendingSnapshot: null,
+    dataCbs: new Set(),
+    exitCbs: new Set(),
+  };
+}
+
+function newPendingSnapshot(): MockState['pendingSnapshot'] {
+  let resolveFn!: (v: { snapshot: string; seq: number }) => void;
+  const promise = new Promise<{ snapshot: string; seq: number }>((r) => { resolveFn = r; });
+  return { resolve: resolveFn, promise };
+}
+
+function installMockTerminal(): void {
+  const term = {
+    write: (s: string) => { M.writes.push(s); },
+    reset: () => { /* no-op for the mock */ },
+    resize: (_c: number, _r: number) => { /* no-op */ },
+    focus: () => { /* no-op */ },
+    onData: (_cb: (data: string) => void) => ({ dispose: () => {} }),
+    cols: 80,
+    rows: 24,
+  } as unknown as Parameters<typeof singleton.setActiveSid>[0] extends never ? never : ReturnType<typeof singleton.getTerm>;
+  // The mock has only the surface usePtyAttach touches.
+  vi.spyOn(singleton, 'getTerm').mockReturnValue(term as ReturnType<typeof singleton.getTerm>);
+  vi.spyOn(singleton, 'getFit').mockReturnValue({
+    proposeDimensions: () => ({ cols: 80, rows: 24 }),
+    fit: () => {},
+  } as unknown as ReturnType<typeof singleton.getFit>);
+}
+
+function installCcsmPty(): void {
+  const ccsmPty = {
+    list: vi.fn(),
+    spawn: vi.fn(async (sid: string, cwd: string) => {
+      M.spawnCalls.push({ sid, cwd });
+      return { ok: true as const, sid, pid: 1234, cols: 80, rows: 24 };
+    }),
+    attach: vi.fn(async (sid: string) => {
+      M.attachCalls.push(sid);
+      // PR-B: attach IPC return value is no longer load-bearing for snapshot;
+      // we keep the legacy shape because usePtyAttach still reads cols/rows
+      // but the snapshot field is now ignored in favour of getBufferSnapshot.
+      return { snapshot: '', cols: 80, rows: 24, pid: 1234 };
+    }),
+    detach: vi.fn(async (sid: string) => { M.detachCalls.push(sid); }),
+    input: vi.fn(),
+    resize: vi.fn(async (sid: string, cols: number, rows: number) => {
+      M.resizeCalls.push({ sid, cols, rows });
+    }),
+    kill: vi.fn(),
+    get: vi.fn(),
+    getBufferSnapshot: vi.fn(async (sid: string) => {
+      M.snapshotCalls.push(sid);
+      const pending = M.pendingSnapshot;
+      if (!pending) {
+        // Synchronous default: empty buffer at seq 0.
+        return { snapshot: '', seq: 0 };
+      }
+      return pending.promise;
+    }),
+    onData: (cb: DataCb) => {
+      M.dataCbs.add(cb);
+      return () => { M.dataCbs.delete(cb); };
+    },
+    onExit: (cb: ExitCb) => {
+      M.exitCbs.add(cb);
+      return () => { M.exitCbs.delete(cb); };
+    },
+    clipboard: {
+      readText: () => '',
+      writeText: () => {},
+    },
+    checkClaudeAvailable: vi.fn(),
+  };
+  (window as unknown as { ccsmPty: typeof ccsmPty }).ccsmPty = ccsmPty;
+}
+
+function emitData(sid: string, chunk: string, seq: number): void {
+  for (const cb of M.dataCbs) {
+    cb({ sid, chunk, seq });
+  }
+}
+
+describe('usePtyAttach — snapshot-then-live replay (L4 PR-B)', () => {
+  beforeEach(() => {
+    M = freshState();
+    installMockTerminal();
+    installCcsmPty();
+    singleton.setActiveSid(null);
+    singleton.setUnsubscribeData(null);
+    singleton.setInputDisposable(null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete (window as unknown as { ccsmPty?: unknown }).ccsmPty;
+  });
+
+  it('calls getBufferSnapshot after attach and writes the snapshot to the visible terminal', async () => {
+    M.pendingSnapshot = newPendingSnapshot();
+    const { result } = renderHook(() => usePtyAttach('sid-A', '/tmp'));
+
+    // The attach IPC fires synchronously; getBufferSnapshot is called with
+    // the same sid right after.
+    await waitFor(() => {
+      expect(M.attachCalls).toContain('sid-A');
+      expect(M.snapshotCalls).toContain('sid-A');
+    });
+
+    // Snapshot still pending — visible terminal must not have written
+    // anything yet (we ignore the legacy attach.snapshot field).
+    expect(M.writes).toEqual([]);
+
+    await act(async () => {
+      M.pendingSnapshot!.resolve({ snapshot: 'SNAPSHOT_BYTES', seq: 5 });
+    });
+
+    await waitFor(() => {
+      expect(M.writes[0]).toBe('SNAPSHOT_BYTES');
+      expect(result.current.state.kind).toBe('ready');
+    });
+  });
+
+  it('buffers live chunks delivered DURING snapshot resolution and drains them after, in order, with seq > snapSeq', async () => {
+    M.pendingSnapshot = newPendingSnapshot();
+    renderHook(() => usePtyAttach('sid-B', '/tmp'));
+
+    await waitFor(() => {
+      expect(M.snapshotCalls).toContain('sid-B');
+    });
+
+    // Live chunks arrive WHILE snapshot is pending. Some have seq <= the
+    // snapshot's captured seq (already baked in) and must be dropped;
+    // others have seq > snapSeq and must be replayed.
+    emitData('sid-B', 'OLD_CHUNK_3', 3);
+    emitData('sid-B', 'OLD_CHUNK_5', 5);
+    emitData('sid-B', 'NEW_CHUNK_6', 6);
+    emitData('sid-B', 'NEW_CHUNK_7', 7);
+
+    // Nothing should be on screen yet — snapshot has not landed.
+    expect(M.writes).toEqual([]);
+
+    await act(async () => {
+      M.pendingSnapshot!.resolve({ snapshot: 'SNAP', seq: 5 });
+    });
+
+    await waitFor(() => {
+      // Snapshot first, then only chunks with seq > 5, in arrival order.
+      expect(M.writes).toEqual(['SNAP', 'NEW_CHUNK_6', 'NEW_CHUNK_7']);
+    });
+  });
+
+  it('writes live chunks directly (no buffering) once snapshot has resolved', async () => {
+    M.pendingSnapshot = newPendingSnapshot();
+    renderHook(() => usePtyAttach('sid-C', '/tmp'));
+
+    await waitFor(() => expect(M.snapshotCalls).toContain('sid-C'));
+
+    await act(async () => {
+      M.pendingSnapshot!.resolve({ snapshot: 'SNAP_C', seq: 1 });
+    });
+    await waitFor(() => expect(M.writes[0]).toBe('SNAP_C'));
+
+    // Post-snapshot: chunk arrives with seq > 1 and must land immediately.
+    emitData('sid-C', 'LIVE_2', 2);
+    emitData('sid-C', 'LIVE_3', 3);
+
+    expect(M.writes).toEqual(['SNAP_C', 'LIVE_2', 'LIVE_3']);
+  });
+
+  it('switching sessions tears down the previous data subscription and runs snapshot+live for the new sid', async () => {
+    // Round 1: sid-X
+    M.pendingSnapshot = newPendingSnapshot();
+    const { rerender } = renderHook(({ sid }) => usePtyAttach(sid, '/tmp'), {
+      initialProps: { sid: 'sid-X' },
+    });
+    await waitFor(() => expect(M.snapshotCalls).toContain('sid-X'));
+    await act(async () => {
+      M.pendingSnapshot!.resolve({ snapshot: 'SNAP_X', seq: 0 });
+    });
+    await waitFor(() => expect(M.writes).toEqual(['SNAP_X']));
+
+    // Round 2: switch to sid-Y. usePtyAttach must detach sid-X then run
+    // attach + getBufferSnapshot for sid-Y.
+    M.pendingSnapshot = newPendingSnapshot();
+    rerender({ sid: 'sid-Y' });
+
+    await waitFor(() => {
+      expect(M.detachCalls).toContain('sid-X');
+      expect(M.snapshotCalls).toContain('sid-Y');
+    });
+
+    // While snapshot for Y is pending, an interleaved chunk arrives.
+    emitData('sid-Y', 'NEW_Y_2', 2);
+
+    await act(async () => {
+      M.pendingSnapshot!.resolve({ snapshot: 'SNAP_Y', seq: 1 });
+    });
+
+    await waitFor(() => {
+      // sid-X snapshot first (round 1), then sid-Y snapshot, then the
+      // interleaved chunk (seq 2 > captured seq 1).
+      expect(M.writes).toEqual(['SNAP_X', 'SNAP_Y', 'NEW_Y_2']);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

L4 PR-B promotes the main-process headless authoritative buffer (PR-A, #861) into the canonical source of truth that the visible xterm replays from on every attach. Eliminates the dependency on claude voluntarily repainting its alt-screen TUI after attach (the #852 root cause).

**Stacked on #605 (PR-A).** Manager will rebase on `working` after #605 merges.

## Wire format

- Per-session monotonic chunk `seq` added to `entryFactory.Entry`: incremented before `headless.write` + broadcast in `p.onData`. Each `pty:data` payload now carries `{sid, chunk, seq}`.
- New IPC `pty:getBufferSnapshot(sid)` → `{snapshot: string, seq: number}`.
  - `snapshot` = SerializeAddon output of the headless buffer.
  - `seq` = `entry.seq` captured atomically with `serialize()` (both sync, no await between under Node's single-threaded loop).

## Renderer attach flow (snapshot-then-live, race-free)

`usePtyAttach` replaces the legacy "write `attach.snapshot`, then subscribe" path with:
1. `attach` IPC (registers wc with `entry.attached`)
2. install `pty.onData` listener that **buffers** chunks (seq tagged)
3. `await pty.getBufferSnapshot(sid)`
4. write snapshot to visible terminal
5. drain buffered chunks where `seq > snapSeq` (drop chunks already baked into snapshot, keep live tail that arrived during step 3)
6. flip listener into "write directly" mode (still seq filtered defensively)

The seq counter makes dedup deterministic regardless of IPC timing — eliminates the sync-attach-vs-live race the legacy `attach.snapshot` had.

## UT FAIL → PASS

Initial test run (4/4 fail as expected, before impl):
```
 FAIL  tests/usePtyAttach-snapshot-replay.test.tsx (4 tests | 4 failed)
   × calls getBufferSnapshot after attach and writes the snapshot to the visible terminal
   × buffers live chunks delivered DURING snapshot resolution and drains them after, in order, with seq > snapSeq
   × writes live chunks directly (no buffering) once snapshot has resolved
   × switching sessions tears down the previous data subscription and runs snapshot+live for the new sid
 Test Files  1 failed (1)
      Tests  4 failed (4)
```

After impl, all 4 pass; combined run with PR-A pin (`bufferSnapshot.test.ts`) and existing `usePtyAttach.test.tsx` + new `ipcRegistrar` channel test:
```
 Test Files  14 passed (14)
      Tests  182 passed (182)
```

## E2E probe

New harness case: `scripts/harness-real-cli.mjs --only=attach-replay-from-headless-buffer`

Verifies:
1. `window.ccsmPty.getBufferSnapshot` exists with PR-B `{snapshot, seq}` shape (incl. empty case for unknown sid).
2. Spawning a session, headless snapshot accumulates >50 bytes with `seq >= 1`.
3. Switch A→B→A: visible xterm content overlaps the headless snapshot — proves the replay path actually feeds the view (the #852 scenario).

Local run:
```
[HARNESS] >>> case: attach-replay-from-headless-buffer
[HARNESS]   PR-B IPC ok: getBufferSnapshot('nonexistent') => snapshot="" seq=0
[HARNESS]   PR-B headless snapshot for 35d2a837-...: 1753 bytes, seq=9
[HARNESS]   PR-B replay verified: 2 headless lines visible after switch-back
[HARNESS] <<< PASS attach-replay-from-headless-buffer (18922ms)

===== HARNESS SUMMARY =====
  PASS  attach-replay-from-headless-buffer 18922ms
  total: 1/1 passed, 26.5s wall
```

Per memory `feedback_e2e_prefer_harness`: bundled into harness-real-cli rather than a standalone probe (harness already loads claude + the prod bundle).

## Out of scope (future PRs)

- PR-C double-write (already in place via entryFactory)
- PR-D resize / SIGWINCH protocol
- PR-E full detach/reattach lifecycle (only attach path covered here)
- PR-F revert of #602 spawn-time-size hack — when that lands, this probe **must still pass** on the strength of replay alone (annotated in case docs).

## Test plan

- [x] `npx vitest run tests/usePtyAttach-snapshot-replay.test.tsx` — 4/4 pass
- [x] `npx vitest run electron/ptyHost/__tests__/bufferSnapshot.test.ts electron/ptyHost/__tests__/ipcRegistrar.test.ts tests/terminal/usePtyAttach.test.tsx` — all pass
- [x] `npx tsc -p tsconfig.electron.json --noEmit` — clean
- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [x] `npm run build` — clean
- [x] `node scripts/harness-real-cli.mjs --only=attach-replay-from-headless-buffer` — PASS
- [ ] CI green
- [ ] Reviewer Layer 1 (necessity / direction) + Layer 2 (impl)

Fixes #852 root cause. Implements Task #865.