### PR TITLE
refactor(ptyHost): L4 PR-C explicit dispatchPtyChunk + backpressure observe (#863)

### DIFF
--- a/electron/ptyHost/__tests__/entryFactory.test.ts
+++ b/electron/ptyHost/__tests__/entryFactory.test.ts
@@ -26,6 +26,7 @@ interface PtyFakeBus {
   emitData: ReturnType<typeof vi.fn>;
   sourceJsonl: string | null;
   ensureCopied: boolean;
+  deferHeadlessWrite: boolean;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -50,7 +51,16 @@ vi.mock('node-pty', () => ({
 
 vi.mock('@xterm/headless', () => ({
   Terminal: class {
-    write = (...a: unknown[]) => bus().headlessWrite(...a);
+    // Mirror @xterm/headless's `write(data, callback?)` signature so tests
+    // can exercise PR-C backpressure (we count pending writes by deferring
+    // the callback until the test fires it).
+    write = (data: unknown, callback?: () => void) => {
+      bus().headlessWrite(data, callback);
+      // By default invoke synchronously (legacy behavior). Tests that need
+      // to model "pending" writes flip `bus().deferHeadlessWrite = true` and
+      // capture callbacks via the spy.
+      if (callback && !bus().deferHeadlessWrite) callback();
+    };
     dispose = () => bus().headlessDispose();
     loadAddon = vi.fn();
     resize = vi.fn();
@@ -107,6 +117,7 @@ describe('entryFactory.makeEntry', () => {
       emitData: vi.fn(),
       sourceJsonl: null,
       ensureCopied: false,
+      deferHeadlessWrite: false,
     };
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (globalThis as any).__pf = b;
@@ -177,7 +188,8 @@ describe('entryFactory.makeEntry', () => {
     const b = bus();
     expect(b.onData).toBeTypeOf('function');
     b.onData!('hello');
-    expect(b.headlessWrite).toHaveBeenCalledWith('hello');
+    // PR-C (#863): headless.write is now invoked with a backpressure callback.
+    expect(b.headlessWrite).toHaveBeenCalledWith('hello', expect.any(Function));
     expect(b.emitData).toHaveBeenCalledWith('sid-G', 'hello');
   });
 
@@ -188,5 +200,128 @@ describe('entryFactory.makeEntry', () => {
     expect(e.rows).toBe(40);
     expect(e.cwd).toBe('/work');
     expect(e.attached.size).toBe(0);
+  });
+});
+
+// L4 PR-C (#863): the onData handler is now an extracted, named
+// `dispatchPtyChunk(entry, chunk)` so the headless-write + broadcast
+// double-write is explicit (and a hook point for PR-D/E). These tests
+// pin its contract directly without going through node-pty.
+describe('entryFactory.dispatchPtyChunk', () => {
+  beforeEach(() => {
+    const b: PtyFakeBus = {
+      onData: null,
+      onExit: null,
+      ptySpawn: vi.fn(),
+      headlessDispose: vi.fn(),
+      headlessWrite: vi.fn(),
+      watcherStart: vi.fn(),
+      watcherStop: vi.fn(),
+      ensureJsonl: vi.fn(),
+      emitData: vi.fn(),
+      sourceJsonl: null,
+      ensureCopied: false,
+      deferHeadlessWrite: false,
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).__pf = b;
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (globalThis as any).__pf;
+  });
+
+  it('double-writes each chunk to headless AND broadcasts pty:data with monotonic seq', async () => {
+    const mod = await import('../entryFactory');
+    const entry = mod.makeEntry('sid-DW', '/work', '/bin/claude', 80, 24, { onExit: vi.fn() });
+    const sent: Array<{ chunk: string; seq: number }> = [];
+    const wc = {
+      isDestroyed: () => false,
+      send: (_ch: string, payload: { sid: string; chunk: string; seq: number }) => {
+        sent.push({ chunk: payload.chunk, seq: payload.seq });
+      },
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    entry.attached.set(1, wc as any);
+
+    mod.dispatchPtyChunk('sid-DW', entry, 'a');
+    mod.dispatchPtyChunk('sid-DW', entry, 'b');
+    mod.dispatchPtyChunk('sid-DW', entry, 'c');
+
+    const b = bus();
+    expect(b.headlessWrite).toHaveBeenCalledTimes(3);
+    expect(b.headlessWrite.mock.calls.map((c) => c[0])).toEqual(['a', 'b', 'c']);
+    expect(sent).toEqual([
+      { chunk: 'a', seq: 1 },
+      { chunk: 'b', seq: 2 },
+      { chunk: 'c', seq: 3 },
+    ]);
+    expect(entry.seq).toBe(3);
+    // dataFanout must also receive every chunk (notify pipeline depends on it).
+    expect(b.emitData).toHaveBeenCalledTimes(3);
+  });
+
+  it('warns once when pending headless writes cross BACKPRESSURE_WARN_THRESHOLD, no data dropped', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const mod = await import('../entryFactory');
+    const entry = mod.makeEntry('sid-BP', '/work', '/bin/claude', 80, 24, { onExit: vi.fn() });
+
+    // Defer write callbacks so writes stay "pending" until we manually drain.
+    bus().deferHeadlessWrite = true;
+    const threshold = mod.BACKPRESSURE_WARN_THRESHOLD;
+
+    // Fire `threshold + 1` chunks: the (threshold+1)-th increments the
+    // pending counter past the threshold and must trigger the warn.
+    for (let i = 0; i < threshold + 1; i++) {
+      mod.dispatchPtyChunk('sid-BP', entry, `c${i}`);
+    }
+
+    // All chunks must have been forwarded to headless.write — backpressure
+    // is observe-only, never drops.
+    expect(bus().headlessWrite).toHaveBeenCalledTimes(threshold + 1);
+    // Warn fired (at least once) for the over-threshold condition.
+    const bpWarns = warnSpy.mock.calls.filter((c) =>
+      typeof c[0] === 'string' && (c[0] as string).includes('backpressure'),
+    );
+    expect(bpWarns.length).toBeGreaterThanOrEqual(1);
+
+    // Drain: invoke each captured callback to clear pending, and verify a
+    // subsequent over-threshold burst can warn again (re-arm semantics).
+    const captured = bus().headlessWrite.mock.calls
+      .map((c) => c[1] as (() => void) | undefined)
+      .filter((cb): cb is () => void => typeof cb === 'function');
+    for (const cb of captured) cb();
+    warnSpy.mockClear();
+    for (let i = 0; i < threshold + 1; i++) {
+      mod.dispatchPtyChunk('sid-BP', entry, `d${i}`);
+    }
+    const bpWarns2 = warnSpy.mock.calls.filter((c) =>
+      typeof c[0] === 'string' && (c[0] as string).includes('backpressure'),
+    );
+    expect(bpWarns2.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('skips destroyed webContents but still writes to headless and bumps seq', async () => {
+    const mod = await import('../entryFactory');
+    const entry = mod.makeEntry('sid-DEAD', '/work', '/bin/claude', 80, 24, { onExit: vi.fn() });
+    const aliveSent: Array<number> = [];
+    const dead = { isDestroyed: () => true, send: vi.fn() };
+    const alive = {
+      isDestroyed: () => false,
+      send: (_ch: string, payload: { seq: number }) => aliveSent.push(payload.seq),
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    entry.attached.set(1, dead as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    entry.attached.set(2, alive as any);
+
+    mod.dispatchPtyChunk('sid-DEAD', entry, 'x');
+    expect(dead.send).not.toHaveBeenCalled();
+    expect(aliveSent).toEqual([1]);
+    expect(bus().headlessWrite).toHaveBeenCalledWith('x', expect.any(Function));
+    expect(entry.seq).toBe(1);
   });
 });

--- a/electron/ptyHost/entryFactory.ts
+++ b/electron/ptyHost/entryFactory.ts
@@ -42,6 +42,16 @@ export const DEFAULT_ROWS = 30;
 // owner; bump only here and in any future replay-budget calculation.
 export const SCROLLBACK = 10000;
 
+// L4 PR-C (#863): when the visible xterm cannot keep up with PTY output the
+// headless mirror's `write(data, cb)` callback is invoked asynchronously.
+// We track the number of in-flight (pending-callback) headless writes per
+// entry and `console.warn` once each time the count crosses this threshold,
+// so production lag is observable without dropping any data. Threshold of
+// 100 chunks is a coarse "something is wrong" signal — typical busy PTY
+// bursts settle in <10 pending writes. Re-arms after the count drains back
+// below the threshold.
+export const BACKPRESSURE_WARN_THRESHOLD = 100;
+
 export interface Entry {
   pty: pty.IPty;
   headless: HeadlessTerminal;
@@ -67,6 +77,16 @@ export interface Entry {
    *  window where `headless.write` runs but the broadcast carries a stale
    *  seq. */
   seq: number;
+  /** L4 PR-C (#863): count of headless `write(data, cb)` calls whose
+   *  callback has not yet fired. Bumped on every dispatch, decremented in
+   *  the write callback. Crossing `BACKPRESSURE_WARN_THRESHOLD` triggers a
+   *  one-shot console.warn (re-arms when the counter drains back below the
+   *  threshold). Observe-only — no chunk is ever dropped. */
+  pendingHeadlessWrites: number;
+  /** L4 PR-C (#863): edge-trigger guard for the backpressure warn so a
+   *  long stall doesn't spam the log. Reset to false when the counter
+   *  drops back below the threshold. */
+  backpressureWarned: boolean;
 }
 
 export interface MakeEntryDeps {
@@ -76,6 +96,87 @@ export interface MakeEntryDeps {
   /** Forwarded to `ensureResumeJsonlAtSpawnCwd` — fired only when the helper
    *  actually copied the JSONL into a new projectDir (#603). */
   onCwdRedirect?: (newCwd: string) => void;
+}
+
+/**
+ * L4 PR-C (#863): explicit per-chunk dispatch.
+ *
+ * One PTY chunk fans out to TWO sinks atomically (single-threaded JS event
+ * loop guarantee — no other code can interleave between these statements):
+ *
+ *   1. `entry.headless.write(chunk, cb)` — the headless terminal is the
+ *      session-level source-of-truth scrollback (PR-A #861). Visible xterm
+ *      attaches replay from a snapshot of this buffer (PR-B #865), and any
+ *      future feature that needs durable per-session output (search,
+ *      export, AI summary) reads from here.
+ *
+ *   2. `wc.send('pty:data', { sid, chunk, seq })` for every attached
+ *      webContents — the live wire to whichever visible xterm is currently
+ *      mirroring this session. `seq` is the same monotonic counter that
+ *      `getBufferSnapshot` captures, so the renderer can dedupe live
+ *      chunks against the snapshot replay (PR-B contract).
+ *
+ * `seq` is bumped BEFORE either sink runs so both observe the same value.
+ *
+ * Backpressure (observe-only): the headless write callback decrements
+ * `entry.pendingHeadlessWrites`. If a sustained burst pushes the counter
+ * past `BACKPRESSURE_WARN_THRESHOLD`, we `console.warn` once (re-arms
+ * after the counter drains). No chunk is ever dropped — this is purely a
+ * production diagnostic for slow-mirror conditions.
+ *
+ * This function is exported so PR-D (resize/SIGWINCH) and PR-E
+ * (detach/reattach) have a stable hook point: anything that needs to
+ * observe or wrap the per-chunk fan-out goes here, not in `p.onData`.
+ *
+ * Exported for unit tests; production code calls it via `p.onData` only.
+ */
+export function dispatchPtyChunk(sid: string, entry: Entry, chunk: string): void {
+  // Bump seq BEFORE write/broadcast so the broadcast payload carries the
+  // same seq the renderer will use to dedupe against `getBufferSnapshot`
+  // (PR-B contract). Single-threaded: no interleave possible.
+  entry.seq += 1;
+  const seq = entry.seq;
+
+  // Sink 1: headless source-of-truth buffer. Pass a callback so we can
+  // observe write completion for backpressure diagnostics.
+  entry.pendingHeadlessWrites += 1;
+  if (
+    entry.pendingHeadlessWrites > BACKPRESSURE_WARN_THRESHOLD &&
+    !entry.backpressureWarned
+  ) {
+    entry.backpressureWarned = true;
+    console.warn(
+      `[ptyHost] backpressure: sid=${sid} pendingHeadlessWrites=${entry.pendingHeadlessWrites} ` +
+        `(>${BACKPRESSURE_WARN_THRESHOLD}); visible xterm or headless mirror is lagging. ` +
+        `No data dropped — this is observe-only.`,
+    );
+  }
+  entry.headless.write(chunk, () => {
+    entry.pendingHeadlessWrites -= 1;
+    if (entry.pendingHeadlessWrites <= BACKPRESSURE_WARN_THRESHOLD) {
+      // Re-arm so the next over-threshold burst warns again.
+      entry.backpressureWarned = false;
+    }
+  });
+
+  // Sink 2: visible-xterm IPC fanout. Best-effort per attached webContents
+  // — a destroyed sender or an IPC throw must not wedge the PTY pump.
+  for (const wc of entry.attached.values()) {
+    if (!wc.isDestroyed()) {
+      try {
+        wc.send('pty:data', { sid, chunk, seq });
+      } catch {
+        /* renderer gone — best effort */
+      }
+    }
+  }
+
+  // Sink 3 (module-level listeners): notify pipeline OSC sniffer is the
+  // only production consumer today. Listeners are best-effort — throws
+  // don't propagate back to ptyHost so a misbehaving sink can't wedge
+  // the PTY. Kept inside dispatchPtyChunk (not a separate hook) so the
+  // single fan-out point is the only place chunk-handling lives.
+  emitPtyData(sid, chunk);
 }
 
 export function makeEntry(
@@ -145,30 +246,11 @@ export function makeEntry(
     rows,
     cwd: spawnCwd,
     seq: 0,
+    pendingHeadlessWrites: 0,
+    backpressureWarned: false,
   };
 
-  p.onData((chunk) => {
-    // L4 PR-B (#865): bump seq BEFORE write/broadcast so the broadcast
-    // payload carries the same seq the renderer will use to dedupe
-    // against `getBufferSnapshot`.
-    entry.seq += 1;
-    const seq = entry.seq;
-    headless.write(chunk);
-    for (const wc of entry.attached.values()) {
-      if (!wc.isDestroyed()) {
-        try {
-          wc.send('pty:data', { sid, chunk, seq });
-        } catch {
-          /* renderer gone — best effort */
-        }
-      }
-    }
-    // Fan out to module-level data listeners (notify pipeline OSC sniffer
-    // is the only production consumer today). Listeners are best-effort —
-    // throws don't propagate back to ptyHost so a misbehaving sink can't
-    // wedge the PTY.
-    emitPtyData(sid, chunk);
-  });
+  p.onData((chunk) => dispatchPtyChunk(sid, entry, chunk));
 
   p.onExit(({ exitCode, signal }) => {
     // Broadcast exit to anyone still listening, then drop the entry. Using


### PR DESCRIPTION
## Summary

L4 PR-C of the dual-buffer mirror series (Task #863). **Stacks on PR #606 (PR-B)** — manager will rebase to `working` after #606 merges.

- Extract the per-chunk fan-out from inline `p.onData` arrow into named, exported `dispatchPtyChunk(sid, entry, chunk)`. The headless + broadcast double-write is now explicit at the call site, and PR-D/E have a stable hook point.
- Add observe-only backpressure: `headless.write(chunk, cb)` callback decrements `entry.pendingHeadlessWrites`. Crossing `BACKPRESSURE_WARN_THRESHOLD = 100` emits one `console.warn` (re-arms after drain). **No chunk is ever dropped.**
- 3 new UTs pin `dispatchPtyChunk` directly (without going through node-pty).

No behavior change to the two existing sinks. Out of scope: PR-D resize, PR-E detach/reattach, PR-F hack removal, usePtyAttach (already rewritten by PR-B), broadcast/IPC protocol.

## Files

- `electron/ptyHost/entryFactory.ts` — extract `dispatchPtyChunk`, add `BACKPRESSURE_WARN_THRESHOLD`, add `pendingHeadlessWrites` + `backpressureWarned` to `Entry`.
- `electron/ptyHost/__tests__/entryFactory.test.ts` — 3 new tests + headless mock now mirrors `write(data, cb?)` signature with deferrable callback for backpressure modeling.

## Test plan

- [x] TDD: tests written first, FAIL on un-modified `entryFactory.ts` (4 fail), PASS after impl (11/11).
- [x] Reverse-verify: `git stash push electron/ptyHost/entryFactory.ts` → 4 FAIL; `git stash pop` → 11 PASS.
- [x] `npm run typecheck` clean.
- [x] `npm run lint` 0 errors.
- [x] Module load smoke: `node -e "require('./dist/electron/ptyHost/entryFactory.js')"` → `OK loaded` (CJS-Electron-main compatible).
- [x] Full vitest: only pre-existing failures unrelated to this PR (`tests/electron-load-smoke.test.ts` needs `npm run build` first; `electron/__tests__/db-hardening.test.ts` is db-layer, not ptyHost).

### TDD reverse-verify output

Stashed (4 FAIL):
```
Test Files  1 failed (1)
     Tests  4 failed | 7 passed (11)
  - dispatchPtyChunk > double-writes each chunk to headless AND broadcasts pty:data with monotonic seq
  - dispatchPtyChunk > warns once when pending headless writes cross BACKPRESSURE_WARN_THRESHOLD, no data dropped
  - dispatchPtyChunk > skips destroyed webContents but still writes to headless and bumps seq
  - makeEntry > forwards pty data into headless write AND emitPtyData fanout (callback-arg expectation)
```

Restored (11 PASS):
```
Test Files  1 passed (1)
     Tests  11 passed (11)
```

## Compatibility note for PR-D / PR-E / PR-F

`dispatchPtyChunk(sid, entry, chunk)` is now the **single** per-chunk fan-out point. Future PRs in the series should:

- **PR-D resize/SIGWINCH**: when resize happens, `dispatchPtyChunk` does not need changes — resize touches `entry.pty.resize` + `entry.headless.resize` separately, and chunk processing keeps flowing through `dispatchPtyChunk` unchanged.
- **PR-E detach/reattach**: detach removes a `WebContents` from `entry.attached` (already supported); reattach adds it back. No changes needed to `dispatchPtyChunk`. The seq counter continues monotonically across detach periods, so dedupe-against-snapshot keeps working.
- **PR-F (#602 hack removal)**: independent of `dispatchPtyChunk`; affects visible-xterm geometry, not the headless mirror.