### PR TITLE
feat(terminal): L4 PR-E detach/reattach via headless buffer (#864)

### DIFF
--- a/electron/ptyHost/__tests__/detachReattach.test.ts
+++ b/electron/ptyHost/__tests__/detachReattach.test.ts
@@ -1,0 +1,395 @@
+// L4 PR-E (#864): pins the detach/reattach contract — a visible-xterm
+// reattach must replay every PTY chunk that arrived while detached, fed
+// from the headless authoritative buffer (PR-A) via getBufferSnapshot
+// (PR-B), with NO request to the PTY for re-emission.
+//
+// What this proves end-to-end (main-process side):
+//   1. While detached (`entry.attached.size === 0`), `dispatchPtyChunk`
+//      keeps writing every chunk to the headless mirror — backlog
+//      preserved.
+//   2. While detached, the backpressure warn is suppressed (no human
+//      consumer; would be log noise on long-running background sessions).
+//      Re-attach restores normal threshold semantics.
+//   3. Re-attach replays via `serialize.serialize()` snapshot (this is
+//      the same path lifecycle.getBufferSnapshot uses) — captured atomically
+//      with `entry.seq`. Live chunks delivered AFTER the snapshot can be
+//      deduped by the renderer using `seq > snapSeq`.
+//   4. Multiple detach/reattach/detach/reattach cycles preserve a
+//      monotonic seq — no wrap, no decrement, no double-fanout.
+//   5. The PTY is never asked to re-emit; the only `pty.write` calls
+//      come from explicit user input (zero in this test).
+//
+// Out of scope (other PRs / dogfood): real Electron IPC roundtrip,
+// renderer-side xterm.write, multi-window fanout collisions.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+interface PtyFakeBus {
+  onData: ((chunk: string) => void) | null;
+  onExit: ((evt: { exitCode: number | null; signal: number | null }) => void) | null;
+  ptySpawn: ReturnType<typeof vi.fn>;
+  ptyWrite: ReturnType<typeof vi.fn>;
+  headlessDispose: ReturnType<typeof vi.fn>;
+  // We model the headless buffer as a plain string accumulator so the
+  // test can compare "what was written into the buffer" to "what a
+  // reattach snapshot replays" — full L4 contract.
+  headlessBuffer: string;
+  watcherStart: ReturnType<typeof vi.fn>;
+  watcherStop: ReturnType<typeof vi.fn>;
+  ensureJsonl: ReturnType<typeof vi.fn>;
+  emitData: ReturnType<typeof vi.fn>;
+  sourceJsonl: string | null;
+  ensureCopied: boolean;
+  // When true, headless.write defers its callback so tests can simulate
+  // a slow main-thread / scrollback flush and check pending counters.
+  deferHeadlessWrite: boolean;
+  pendingCallbacks: Array<() => void>;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function bus(): PtyFakeBus { return (globalThis as any).__pf as PtyFakeBus; }
+
+vi.mock('node-pty', () => ({
+  spawn: (...a: unknown[]) => {
+    const b = bus();
+    b.ptySpawn(...a);
+    return {
+      pid: 7777,
+      onData: (cb: (chunk: string) => void) => { b.onData = cb; },
+      onExit: (cb: (evt: { exitCode: number | null; signal: number | null }) => void) => {
+        b.onExit = cb;
+      },
+      // Capture pty.write so we can assert NO re-emission was requested
+      // during reattach — the whole point of L4 is "buffer replays, not pty".
+      write: (...wa: unknown[]) => bus().ptyWrite(...wa),
+      resize: vi.fn(),
+      kill: vi.fn(),
+    };
+  },
+}));
+
+vi.mock('@xterm/headless', () => ({
+  Terminal: class {
+    write = (data: unknown, callback?: () => void) => {
+      const b = bus();
+      if (typeof data === 'string') b.headlessBuffer += data;
+      if (callback) {
+        if (b.deferHeadlessWrite) b.pendingCallbacks.push(callback);
+        else callback();
+      }
+    };
+    dispose = () => bus().headlessDispose();
+    loadAddon = vi.fn();
+    resize = vi.fn();
+  },
+}));
+
+vi.mock('@xterm/addon-serialize', () => ({
+  // The fake serializer returns whatever the headless buffer has
+  // accumulated. This mirrors the real SerializeAddon.serialize() output
+  // shape closely enough for the L4 contract (renderer just writes it
+  // back into a fresh xterm).
+  SerializeAddon: class {
+    serialize = () => bus().headlessBuffer;
+  },
+}));
+
+vi.mock('electron', () => ({}));
+
+vi.mock('../../sessionWatcher', () => ({
+  sessionWatcher: {
+    on: vi.fn(),
+    startWatching: (...a: unknown[]) => bus().watcherStart(...a),
+    stopWatching: (...a: unknown[]) => bus().watcherStop(...a),
+  },
+}));
+
+vi.mock('../jsonlResolver', () => ({
+  toClaudeSid: (s: string) => s,
+  findJsonlForSid: () => bus().sourceJsonl,
+  resolveJsonlPath: () => '/tmp/live.jsonl',
+  ensureResumeJsonlAtSpawnCwd: (...a: unknown[]) => {
+    bus().ensureJsonl(...a);
+    return { copied: bus().ensureCopied, targetPath: '/tmp/target.jsonl' };
+  },
+}));
+
+vi.mock('../cwdResolver', () => ({
+  resolveSpawnCwd: (cwd: string) => (cwd ? cwd : '/home/u'),
+}));
+
+vi.mock('../dataFanout', () => ({
+  emitPtyData: (sid: string, chunk: string) => bus().emitData(sid, chunk),
+}));
+
+import { makeEntry, dispatchPtyChunk, BACKPRESSURE_WARN_THRESHOLD } from '../entryFactory';
+import { getBufferSnapshot } from '../lifecycle';
+import type { Entry } from '../entryFactory';
+
+// Models a "visible xterm" attached webContents. Records every chunk it
+// receives so we can compare to what the headless buffer accumulated
+// (the L4 invariant: visible xterm sees exactly what headless saw,
+// modulo the snapshot replay seam).
+interface FakeWc {
+  id: number;
+  destroyed: boolean;
+  received: Array<{ chunk: string; seq: number }>;
+  isDestroyed: () => boolean;
+  send: (ch: string, payload: { sid: string; chunk: string; seq: number }) => void;
+}
+
+function makeFakeWc(id: number): FakeWc {
+  const wc: FakeWc = {
+    id,
+    destroyed: false,
+    received: [],
+    isDestroyed: () => wc.destroyed,
+    send: (_ch, payload) => {
+      wc.received.push({ chunk: payload.chunk, seq: payload.seq });
+    },
+  };
+  return wc;
+}
+
+function freshBus(): PtyFakeBus {
+  return {
+    onData: null,
+    onExit: null,
+    ptySpawn: vi.fn(),
+    ptyWrite: vi.fn(),
+    headlessDispose: vi.fn(),
+    headlessBuffer: '',
+    watcherStart: vi.fn(),
+    watcherStop: vi.fn(),
+    ensureJsonl: vi.fn(),
+    emitData: vi.fn(),
+    sourceJsonl: null,
+    ensureCopied: false,
+    deferHeadlessWrite: false,
+    pendingCallbacks: [],
+  };
+}
+
+describe('L4 PR-E: detach/reattach via headless buffer (#864)', () => {
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).__pf = freshBus();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (globalThis as any).__pf;
+  });
+
+  it('detached: PTY chunks accumulate in headless, no visible-xterm writes (no attached wc)', () => {
+    const entry = makeEntry('sid-D', '/work', '/bin/claude', 80, 24, { onExit: vi.fn() });
+    expect(entry.attached.size).toBe(0);
+
+    // Drive PTY data while detached.
+    bus().onData!('chunk-1');
+    bus().onData!('chunk-2');
+    bus().onData!('chunk-3');
+
+    expect(bus().headlessBuffer).toBe('chunk-1chunk-2chunk-3');
+    expect(entry.seq).toBe(3);
+    // PTY must never be asked to re-emit. We only write input.
+    expect(bus().ptyWrite).not.toHaveBeenCalled();
+  });
+
+  it('reattach: snapshot replays the entire detached backlog from headless (no PTY re-emit)', async () => {
+    const sessions = new Map<string, Entry>();
+    const entry = makeEntry('sid-R', '/work', '/bin/claude', 80, 24, { onExit: vi.fn() });
+    sessions.set('sid-R', entry);
+
+    // Background activity while no visible xterm is attached.
+    bus().onData!('hello ');
+    bus().onData!('world\n');
+    bus().onData!('line-2\n');
+
+    // Visible xterm appears (reattach). PR-B contract: caller calls
+    // getBufferSnapshot, writes snapshot, then drains buffered chunks
+    // with seq > snapSeq. Here we test the main-side: snapshot must
+    // contain the full backlog, and seq must reflect entry.seq.
+    const snap = await getBufferSnapshot(sessions, 'sid-R');
+    expect(snap.snapshot).toBe('hello world\nline-2\n');
+    expect(snap.seq).toBe(3);
+
+    // Now register a wc (the freshly-mounted visible xterm).
+    const wc = makeFakeWc(1);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    entry.attached.set(wc.id, wc as any);
+
+    // A live chunk arrives strictly AFTER the snapshot — must be
+    // delivered with seq > snapSeq so the renderer keeps it.
+    bus().onData!('post-snap');
+    expect(wc.received).toEqual([{ chunk: 'post-snap', seq: 4 }]);
+    expect(wc.received[0].seq).toBeGreaterThan(snap.seq);
+
+    // PTY was never asked to replay anything.
+    expect(bus().ptyWrite).not.toHaveBeenCalled();
+  });
+
+  it('multi-cycle detach/reattach/detach/reattach: no data loss, monotonic seq, headless buffer is the SoT', async () => {
+    const sessions = new Map<string, Entry>();
+    const entry = makeEntry('sid-M', '/work', '/bin/claude', 80, 24, { onExit: vi.fn() });
+    sessions.set('sid-M', entry);
+
+    // Cycle 1: detached burst.
+    bus().onData!('A1');
+    bus().onData!('A2');
+    let snap = await getBufferSnapshot(sessions, 'sid-M');
+    expect(snap.snapshot).toBe('A1A2');
+    expect(snap.seq).toBe(2);
+
+    // Cycle 1 attach.
+    const wc1 = makeFakeWc(1);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    entry.attached.set(wc1.id, wc1 as any);
+    bus().onData!('A3');
+    expect(wc1.received).toEqual([{ chunk: 'A3', seq: 3 }]);
+
+    // Cycle 1 detach (visible xterm goes away — pane closed / sid switched).
+    entry.attached.delete(wc1.id);
+    expect(entry.attached.size).toBe(0);
+
+    // Cycle 2: another detached burst (background session activity).
+    bus().onData!('B1');
+    bus().onData!('B2');
+    bus().onData!('B3');
+    expect(bus().headlessBuffer).toBe('A1A2A3B1B2B3');
+
+    // Cycle 2 reattach: a NEW visible xterm (e.g. user navigated back
+    // to this session) gets a snapshot covering everything so far.
+    snap = await getBufferSnapshot(sessions, 'sid-M');
+    expect(snap.snapshot).toBe('A1A2A3B1B2B3');
+    expect(snap.seq).toBe(6);
+    // seq strictly increased across cycles.
+    expect(snap.seq).toBeGreaterThan(3);
+
+    const wc2 = makeFakeWc(2);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    entry.attached.set(wc2.id, wc2 as any);
+    bus().onData!('C1');
+    expect(wc2.received).toEqual([{ chunk: 'C1', seq: 7 }]);
+    // wc1 (already detached) MUST NOT have received C1.
+    expect(wc1.received).toEqual([{ chunk: 'A3', seq: 3 }]);
+
+    // Cycle 3: detach + reattach within the same wc id reuse (a Retry
+    // flow in the renderer that recreates the visible xterm). seq still
+    // monotonic from headless's POV.
+    entry.attached.delete(wc2.id);
+    bus().onData!('D1');
+    bus().onData!('D2');
+    snap = await getBufferSnapshot(sessions, 'sid-M');
+    expect(snap.snapshot).toBe('A1A2A3B1B2B3C1D1D2');
+    expect(snap.seq).toBe(9);
+
+    const wc3 = makeFakeWc(3);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    entry.attached.set(wc3.id, wc3 as any);
+    bus().onData!('E1');
+    expect(wc3.received).toEqual([{ chunk: 'E1', seq: 10 }]);
+
+    // Across all three cycles the PTY was never asked to replay.
+    expect(bus().ptyWrite).not.toHaveBeenCalled();
+  });
+
+  it('snapshot replay round-trips byte-for-byte through a new visible xterm (drain seam holds)', async () => {
+    // Simulates the exact PR-B renderer flow against the main-side
+    // contract: install live listener (buffer chunks) → request snapshot
+    // → write snapshot to "visible" → drain buffered with seq > snapSeq.
+    const sessions = new Map<string, Entry>();
+    const entry = makeEntry('sid-X', '/work', '/bin/claude', 80, 24, { onExit: vi.fn() });
+    sessions.set('sid-X', entry);
+
+    // Background activity.
+    bus().onData!('past-1');
+    bus().onData!('past-2');
+
+    // Reattach: register wc THEN start the snapshot await. Live chunks
+    // that arrive between the IPC-attach instant and the snapshot
+    // landing in the renderer must be deduped — the renderer's listener
+    // captures them with their seq and drops anything seq <= snapSeq.
+    const wc = makeFakeWc(1);
+    const liveBuffered: Array<{ chunk: string; seq: number }> = [];
+    // Replace the wc.send so we can route to "buffered listener" before
+    // snapshot, then to the visible terminal after.
+    let snapSeq: number | null = null;
+    const visibleTerminal: string[] = [];
+    wc.send = (_ch, payload) => {
+      if (snapSeq === null) {
+        liveBuffered.push({ chunk: payload.chunk, seq: payload.seq });
+      } else if (payload.seq > snapSeq) {
+        visibleTerminal.push(payload.chunk);
+      }
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    entry.attached.set(wc.id, wc as any);
+
+    // A live chunk arrives DURING the snapshot await; PR-B race window.
+    const snapPromise = getBufferSnapshot(sessions, 'sid-X');
+    bus().onData!('live-during');
+    const snap = await snapPromise;
+
+    // Renderer writes the snapshot and flips into "drain" mode.
+    visibleTerminal.push(snap.snapshot);
+    snapSeq = snap.seq;
+    for (const b of liveBuffered) {
+      if (b.seq > snapSeq) visibleTerminal.push(b.chunk);
+    }
+
+    // After this point all live chunks go straight in.
+    bus().onData!('post-attach');
+
+    // Visible terminal saw: snapshot (past-1 + past-2) + live-during +
+    // post-attach. NO duplicate of past-1 / past-2.
+    const visible = visibleTerminal.join('');
+    expect(visible).toBe('past-1past-2live-duringpost-attach');
+    // Sanity: the headless SoT matches.
+    expect(bus().headlessBuffer).toBe('past-1past-2live-duringpost-attach');
+  });
+
+  it('backpressure warn is SUPPRESSED while detached, RESUMES once a visible xterm reattaches', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const entry = makeEntry('sid-BP', '/work', '/bin/claude', 80, 24, { onExit: vi.fn() });
+    bus().deferHeadlessWrite = true;
+    const threshold = BACKPRESSURE_WARN_THRESHOLD;
+
+    // Detached: dispatch threshold+1 chunks. Counter crosses the
+    // threshold, but with no attached wc the warn must NOT fire (PR-E
+    // suppression: no human consumer to warn for).
+    for (let i = 0; i < threshold + 1; i++) {
+      dispatchPtyChunk('sid-BP', entry, `det-${i}`);
+    }
+    const detachedWarns = warnSpy.mock.calls.filter((c) =>
+      typeof c[0] === 'string' && (c[0] as string).includes('backpressure'),
+    );
+    expect(detachedWarns).toHaveLength(0);
+    // ...and yet every chunk reached the headless buffer (no drop).
+    expect(bus().headlessBuffer.startsWith('det-0det-1')).toBe(true);
+    // Pending count crossed the threshold (we deferred all callbacks).
+    expect(entry.pendingHeadlessWrites).toBe(threshold + 1);
+
+    // Drain so the next burst starts from a clean counter.
+    for (const cb of bus().pendingCallbacks) cb();
+    bus().pendingCallbacks = [];
+    expect(entry.pendingHeadlessWrites).toBe(0);
+
+    // Reattach: register a wc, then dispatch another over-threshold burst.
+    // Now the warn MUST fire (visible consumer is present and the lag
+    // is real-user-affecting).
+    const wc = makeFakeWc(1);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    entry.attached.set(wc.id, wc as any);
+    warnSpy.mockClear();
+    for (let i = 0; i < threshold + 1; i++) {
+      dispatchPtyChunk('sid-BP', entry, `att-${i}`);
+    }
+    const attachedWarns = warnSpy.mock.calls.filter((c) =>
+      typeof c[0] === 'string' && (c[0] as string).includes('backpressure'),
+    );
+    expect(attachedWarns.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/electron/ptyHost/__tests__/entryFactory.test.ts
+++ b/electron/ptyHost/__tests__/entryFactory.test.ts
@@ -269,6 +269,17 @@ describe('entryFactory.dispatchPtyChunk', () => {
     const mod = await import('../entryFactory');
     const entry = mod.makeEntry('sid-BP', '/work', '/bin/claude', 80, 24, { onExit: vi.fn() });
 
+    // L4 PR-E (#864): backpressure warn is gated on `entry.attached.size > 0`
+    // (no visible xterm = no human consumer = log spam suppressed for
+    // background sessions). Attach a fake wc so we exercise the original
+    // PR-C contract here.
+    const wc = {
+      isDestroyed: () => false,
+      send: vi.fn(),
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    entry.attached.set(1, wc as any);
+
     // Defer write callbacks so writes stay "pending" until we manually drain.
     bus().deferHeadlessWrite = true;
     const threshold = mod.BACKPRESSURE_WARN_THRESHOLD;

--- a/electron/ptyHost/entryFactory.ts
+++ b/electron/ptyHost/entryFactory.ts
@@ -128,6 +128,14 @@ export interface MakeEntryDeps {
  * (detach/reattach) have a stable hook point: anything that needs to
  * observe or wrap the per-chunk fan-out goes here, not in `p.onData`.
  *
+ * L4 PR-E (#864): the headless write here is what makes detach/reattach
+ * "free" — when `entry.attached` is empty (no visible xterm) the headless
+ * still receives every chunk, so a later reattach can replay the entire
+ * missed window via `getBufferSnapshot` + drain (PR-B contract). PR-E
+ * adds NO new code path here; it's the existing sink behavior + the
+ * tests under `__tests__/detachReattach.test.ts` that pin the contract
+ * across multiple detach/reattach cycles.
+ *
  * Exported for unit tests; production code calls it via `p.onData` only.
  */
 export function dispatchPtyChunk(sid: string, entry: Entry, chunk: string): void {
@@ -140,7 +148,16 @@ export function dispatchPtyChunk(sid: string, entry: Entry, chunk: string): void
   // Sink 1: headless source-of-truth buffer. Pass a callback so we can
   // observe write completion for backpressure diagnostics.
   entry.pendingHeadlessWrites += 1;
+  // L4 PR-E (#864): suppress the backpressure warn when no visible
+  // xterm is attached. While detached the headless mirror is the only
+  // consumer; pending writes there are self-paced (no slow IPC), and
+  // a long-running background session can still legitimately accumulate
+  // chunks before the user reattaches. Spamming `console.warn` for a
+  // session no human is currently watching is noise. When a renderer
+  // re-attaches, normal threshold semantics resume — and any stalled
+  // counter still re-arms via the write-callback re-arm branch below.
   if (
+    entry.attached.size > 0 &&
     entry.pendingHeadlessWrites > BACKPRESSURE_WARN_THRESHOLD &&
     !entry.backpressureWarned
   ) {

--- a/src/terminal/usePtyAttach.ts
+++ b/src/terminal/usePtyAttach.ts
@@ -340,6 +340,32 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
 
     return () => {
       cancelled = true;
+      // L4 PR-E (#864): explicit detach on unmount / sid change.
+      // Symmetric with the `pty.attach` we issued above; without this
+      // the entry's `attached` Map keeps a stale wc reference until
+      // the renderer is destroyed (only the `wc.once('destroyed')`
+      // handler in ipcRegistrar fires on full teardown). Stale entries
+      // are tolerated by `dispatchPtyChunk` (it isDestroyed-checks
+      // every send), but explicitly detaching here:
+      //   1. keeps `entry.attached.size` honest so the PR-E
+      //      backpressure-warn suppression activates as intended,
+      //   2. makes the detach/reattach lifecycle visible in tests,
+      //   3. lets a future "background sessions" UI accurately
+      //      report which sessions have a live viewer.
+      // No PTY data is lost: dispatchPtyChunk still writes to the
+      // headless mirror unconditionally, and a subsequent re-attach
+      // (initial mount, sid switch back, or Retry) replays via
+      // `getBufferSnapshot` + drain (PR-B contract).
+      const ptyApi = window.ccsmPty;
+      if (ptyApi) {
+        try {
+          // Fire-and-forget: detach is idempotent on main; we don't
+          // await because the React cleanup runs synchronously.
+          void ptyApi.detach(sessionId);
+        } catch {
+          // best-effort — main may be tearing down.
+        }
+      }
     };
     // attachNonce is intentional: bumping it re-runs the attach for Retry.
   }, [sessionId, attachNonce, cwd]);


### PR DESCRIPTION
## Scope

L4 dual-buffer mirror PR-E. Pin and exercise the contract that a visible-xterm detach/reattach cycle replays missed PTY data from the headless authoritative buffer (PR-A #861) via the seq-tagged snapshot (PR-B #865), with **no PTY re-emission**. Builds on top of:

- PR-A: scrollback bumped to 10000, headless = source of truth.
- PR-B: `getBufferSnapshot` returns `{snapshot, seq}` captured atomically; renderer attach uses snapshot+drain to dedupe live chunks against snapshot.
- PR-C: explicit `dispatchPtyChunk` + observe-only backpressure warn.

## Files changed

- `electron/ptyHost/entryFactory.ts` — suppress backpressure warn when `entry.attached.size === 0` (no visible xterm = no human consumer; background-session log noise). Warn re-arms once a renderer reattaches. Added PR-E doc paragraph noting that no new code path is needed in the dispatch — PR-A's headless-write + PR-B's snapshot already make detach/reattach free.
- `src/terminal/usePtyAttach.ts` — append `void ptyApi.detach(sessionId)` to the existing cleanup function so React unmount / sid switch performs an explicit detach. Without this the entry's `attached` Map kept the wc reference until the whole renderer was destroyed (only `wc.once('destroyed')` cleaned it up). Stale entries were tolerated by `dispatchPtyChunk` (isDestroyed check) but the new size-gated suppression needs honest attach state. **Touched minimally** to avoid PR-D resize-wiring collision (one append to the existing return cleanup; no resize code touched).
- `electron/ptyHost/__tests__/detachReattach.test.ts` — new file, 5 cases.
- `electron/ptyHost/__tests__/entryFactory.test.ts` — existing PR-C backpressure case updated to attach a fake wc (warn now gated on `size > 0`).

## UT output (vitest)

`npx vitest run electron/ptyHost`

```
Test Files  13 passed (13)
     Tests  178 passed (178)
  Duration  5.25s
```

New file `detachReattach.test.ts` (5/5):

```
Test Files  1 passed (1)
     Tests  5 passed (5)
  Duration  5.15s
```

Cases:
1. detached: PTY chunks accumulate in headless, no visible-xterm writes (no attached wc).
2. reattach: snapshot replays the entire detached backlog from headless (no PTY re-emit).
3. multi-cycle detach/reattach/detach/reattach: no data loss, monotonic seq (1→3→6→9→10), headless buffer is the SoT.
4. snapshot replay round-trips byte-for-byte through a new visible xterm (drain seam holds — exercises the PR-B race window: live chunk arriving DURING the snapshot await is buffered by the listener and replayed only if `seq > snapSeq`).
5. backpressure warn is SUPPRESSED while detached, RESUMES once a visible xterm reattaches.

## Reverse-verify

Sabotage: in `lifecycle.getBufferSnapshot`, return `{snapshot:'', seq:0}` unconditionally (drop the replay path).

```
FAIL > reattach: snapshot replays the entire detached backlog from headless (no PTY re-emit)
  AssertionError: expected '' to be 'hello world\nline-2\n'

FAIL > multi-cycle detach/reattach/detach/reattach: ... headless buffer is the SoT
  AssertionError: expected '' to be 'A1A2'

FAIL > snapshot replay round-trips byte-for-byte through a new visible xterm (drain seam holds)
  AssertionError: expected 'live-duringpost-attach' to be 'past-1past-2live-duringpost-attach'

Test Files  1 failed (1)
     Tests  3 failed | 2 passed (5)
```

Restored sabotage → 5/5 PASS again. The two pure-detach + backpressure cases stayed green under sabotage (they don't go through `getBufferSnapshot`), proving the three replay tests were the ones actually pinning the contract.

## Out of scope

- IPC roundtrip / Electron probe (covered by L4 dogfood loop separately).
- Multi-window fanout (single mainWindow today; the wiring is N-safe per PR-A doc).
- PR-D resize wiring is parallel; this PR touches `usePtyAttach.ts` only in the cleanup return (no overlap with resize).

## Risk

Low. The behavior change is one new IPC `pty:detach` call on unmount (was silently leaked-then-tolerated before) and one extra condition on the warn (suppression). No data path change; PTY → headless sink unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)