### PR TITLE
feat(terminal): L4 PR-D resize via headless buffer (#866)

### DIFF
--- a/src/terminal/usePtyAttach.ts
+++ b/src/terminal/usePtyAttach.ts
@@ -10,6 +10,7 @@ import {
   setUnsubscribeData,
   getInputDisposable,
   setInputDisposable,
+  setSnapshotReplay,
 } from './xtermSingleton';
 
 export type PtyAttachState =
@@ -75,6 +76,9 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
 
       const prevSid = getActiveSid();
       if (prevSid && prevSid !== sessionId) {
+        // L4 PR-D (#866): the previous attach's snapshot-replay closure is
+        // bound to the prev sid — drop it before installing the new one.
+        setSnapshotReplay(null);
         const unsub = getUnsubscribeData();
         if (unsub) {
           try {
@@ -101,6 +105,9 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
       } else if (prevSid === sessionId) {
         // Same sid (Retry path): tear down stale subscriptions before re-attaching
         // so we don't double-write incoming chunks.
+        // L4 PR-D (#866): also drop the prior attach's replay handler so a
+        // resize during re-attach doesn't fire against the stale closure.
+        setSnapshotReplay(null);
         const unsub = getUnsubscribeData();
         if (unsub) {
           try {
@@ -282,6 +289,64 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
           }
         }
         buffered.length = 0;
+
+        // L4 PR-D (#866): install the snapshot-replay handler used by
+        // `useTerminalResize` after a SIGWINCH. The handler re-runs
+        // steps 2-5 against the now-reflowed headless buffer:
+        //   1. flip back into "buffer everything" mode (snapSeq = null)
+        //      so live chunks arriving DURING the replay are captured,
+        //      not double-written
+        //   2. fetch a fresh `(snapshot, seq)` from the headless mirror
+        //      (which xterm's `Terminal.resize` has already reflowed)
+        //   3. clear the visible xterm and write the snapshot — this
+        //      replaces the now-stale pre-resize content with the
+        //      reflowed cell grid, so the user sees correct wrapping
+        //      WITHOUT depending on claude voluntarily repainting
+        //      (claude is alt-screen and won't repaint on SIGWINCH)
+        //   4. flip back into "write directly" mode and drain any
+        //      chunks buffered during steps 2-3 with seq > snapSeq
+        //
+        // Closures over `snapSeq` and `buffered` keep the dedupe state
+        // consistent with the listener installed at attach time — the
+        // listener always reads `snapSeq` lazily so flipping it back
+        // to null re-engages buffering.
+        setSnapshotReplay(async () => {
+          if (cancelled || requestedSidRef.current !== sessionId) return;
+          // Re-engage buffering — listener checks `snapSeq === null`.
+          snapSeq = null;
+          let snap2: { snapshot: string; seq: number };
+          try {
+            snap2 = (await pty.getBufferSnapshot(sessionId)) as {
+              snapshot: string;
+              seq: number;
+            };
+          } catch (e) {
+            console.warn('[TerminalPane] resize snapshot failed', e);
+            // Re-arm so the listener resumes writing live chunks even
+            // if the snapshot fetch failed — better stale grid than
+            // permanent buffer-stall.
+            snapSeq = 0;
+            return;
+          }
+          if (cancelled || requestedSidRef.current !== sessionId) return;
+          const tReplay = getTerm();
+          if (tReplay) {
+            try {
+              tReplay.reset();
+            } catch (e) {
+              console.warn('[TerminalPane] resize reset failed', e);
+            }
+            if (snap2.snapshot) tReplay.write(snap2.snapshot);
+          }
+          snapSeq = snap2.seq;
+          const tDrain2 = getTerm();
+          if (tDrain2) {
+            for (const b of buffered) {
+              if (b.seq > snapSeq) tDrain2.write(b.chunk);
+            }
+          }
+          buffered.length = 0;
+        });
 
         const t3 = getTerm();
         if (t3) {

--- a/src/terminal/useTerminalResize.ts
+++ b/src/terminal/useTerminalResize.ts
@@ -1,11 +1,22 @@
 import { useEffect, type RefObject } from 'react';
-import { getTerm, getFit, getActiveSid } from './xtermSingleton';
+import { getTerm, getFit, getActiveSid, getSnapshotReplay } from './xtermSingleton';
 
 /**
  * ResizeObserver hook: observes `hostRef` and, after an 80ms debounce,
  * runs `fit.fit()` on the singleton terminal and pushes the new
  * cols/rows to the active PTY via `window.ccsmPty.resize`. No-op if
  * the singleton hasn't initialised yet or no session is attached.
+ *
+ * L4 PR-D (#866): after the backend resize IPC settles (which resizes
+ * BOTH the PTY and the headless source-of-truth buffer — the latter
+ * triggers xterm's reflow on the cell grid), invoke the
+ * snapshot-replay handler installed by `usePtyAttach`. The replay
+ * resets the visible xterm and re-writes from the freshly-reflowed
+ * headless snapshot, so the user sees a correctly-wrapped buffer
+ * WITHOUT depending on claude voluntarily repainting (claude's TUI
+ * is alt-screen and does not repaint on SIGWINCH unless input
+ * arrives — same root cause as #852). PTY resize still propagates so
+ * subsequent claude output is sized correctly.
  */
 export function useTerminalResize(hostRef: RefObject<HTMLDivElement | null>): void {
   useEffect(() => {
@@ -22,7 +33,24 @@ export function useTerminalResize(hostRef: RefObject<HTMLDivElement | null>): vo
         try {
           fit.fit();
           const { cols, rows } = term;
-          window.ccsmPty?.resize(activeSid, cols, rows);
+          // Backend resize first — `lifecycle.resize` resizes both the
+          // pty and the headless mirror. The headless reflow is what we
+          // re-snapshot from in the next step.
+          const resizePromise = window.ccsmPty?.resize(activeSid, cols, rows);
+          // L4 PR-D (#866): replay from the reflowed headless buffer
+          // after the backend resize settles. The replay is best-effort —
+          // a failure here leaves the visible xterm with the pre-reflow
+          // grid; the next live chunk from claude will still write
+          // correctly because the pty IS resized.
+          const replay = getSnapshotReplay();
+          if (replay) {
+            const p = resizePromise && typeof (resizePromise as Promise<void>).then === 'function'
+              ? (resizePromise as Promise<void>)
+              : Promise.resolve();
+            void p
+              .then(() => replay())
+              .catch((e) => console.warn('[TerminalPane] resize replay failed', e));
+          }
         } catch (e) {
           console.warn('[TerminalPane] fit failed', e);
         }

--- a/src/terminal/xtermSingleton.ts
+++ b/src/terminal/xtermSingleton.ts
@@ -29,6 +29,18 @@ let fit: FitAddon | null = null;
 let activeSid: string | null = null;
 let unsubscribeData: (() => void) | null = null;
 let inputDisposable: { dispose: () => void } | null = null;
+// L4 PR-D (#866): callback installed by `usePtyAttach` once it has wired the
+// snapshot/dedupe-by-seq flow. Invoked by `useTerminalResize` AFTER pushing
+// a new size to the headless mirror so the visible xterm can re-render
+// from the reflowed buffer's cell content rather than waiting on claude
+// to repaint (claude's TUI is alt-screen and does not repaint on
+// SIGWINCH unless input arrives — same root cause as #852). The handler
+// is responsible for: (1) requesting a fresh `getBufferSnapshot`,
+// (2) re-installing the buffering listener so live chunks during the
+// replay window aren't lost, (3) writing the snapshot, (4) bumping
+// the per-attach `snapSeq` to the snapshot's seq so subsequent live
+// chunks dedupe correctly.
+let snapshotReplay: (() => Promise<void>) | null = null;
 
 export function getTerm(): Terminal | null {
   return term;
@@ -60,6 +72,20 @@ export function getInputDisposable(): { dispose: () => void } | null {
 
 export function setInputDisposable(d: { dispose: () => void } | null): void {
   inputDisposable = d;
+}
+
+/**
+ * L4 PR-D (#866): get the snapshot-replay handler installed by `usePtyAttach`.
+ * Returns null when no session is attached. Callers (currently only
+ * `useTerminalResize`) await the returned promise so they can sequence
+ * subsequent work after the replay completes.
+ */
+export function getSnapshotReplay(): (() => Promise<void>) | null {
+  return snapshotReplay;
+}
+
+export function setSnapshotReplay(fn: (() => Promise<void>) | null): void {
+  snapshotReplay = fn;
 }
 
 /**
@@ -209,6 +235,7 @@ export function __resetSingletonForTests(): void {
   activeSid = null;
   unsubscribeData = null;
   inputDisposable = null;
+  snapshotReplay = null;
   if (typeof window !== 'undefined') {
     delete window.__ccsmTerm;
   }

--- a/tests/terminal/usePtyAttach.test.tsx
+++ b/tests/terminal/usePtyAttach.test.tsx
@@ -27,6 +27,7 @@ vi.mock('../../src/terminal/xtermSingleton', async () => {
   let activeSid: string | null = null;
   let unsub: (() => void) | null = null;
   let inDisp: { dispose: () => void } | null = null;
+  let snapReplay: (() => Promise<void>) | null = null;
   return {
     ensureTerminal: vi.fn(),
     getTerm: vi.fn(() => fakeTerm),
@@ -43,10 +44,15 @@ vi.mock('../../src/terminal/xtermSingleton', async () => {
     setInputDisposable: vi.fn((d: { dispose: () => void } | null) => {
       inDisp = d;
     }),
+    getSnapshotReplay: vi.fn(() => snapReplay),
+    setSnapshotReplay: vi.fn((fn: (() => Promise<void>) | null) => {
+      snapReplay = fn;
+    }),
     __resetSingletonForTests: vi.fn(() => {
       activeSid = null;
       unsub = null;
       inDisp = null;
+      snapReplay = null;
     }),
   };
 });

--- a/tests/terminal/useTerminalResize.test.tsx
+++ b/tests/terminal/useTerminalResize.test.tsx
@@ -5,6 +5,8 @@ const fitFitSpy = vi.fn();
 const fakeFit = { fit: fitFitSpy };
 const fakeTerm = { cols: 100, rows: 30 };
 
+let snapshotReplayFn: (() => Promise<void>) | null = null;
+
 vi.mock('../../src/terminal/xtermSingleton', () => {
   let activeSid: string | null = 'sid-A';
   return {
@@ -19,6 +21,8 @@ vi.mock('../../src/terminal/xtermSingleton', () => {
     setUnsubscribeData: vi.fn(),
     getInputDisposable: vi.fn(() => null),
     setInputDisposable: vi.fn(),
+    getSnapshotReplay: vi.fn(() => snapshotReplayFn),
+    setSnapshotReplay: vi.fn((fn: (() => Promise<void>) | null) => { snapshotReplayFn = fn; }),
     __resetSingletonForTests: vi.fn(),
   };
 });
@@ -53,9 +57,10 @@ describe('useTerminalResize', () => {
     observeSpy.mockClear();
     disconnectSpy.mockClear();
     lastObserverCb = null;
+    snapshotReplayFn = null;
     originalRO = globalThis.ResizeObserver;
     (globalThis as any).ResizeObserver = ROStub;
-    resizeBridge = vi.fn();
+    resizeBridge = vi.fn(async () => {});
     (window as any).ccsmPty = { resize: resizeBridge };
   });
 
@@ -86,5 +91,46 @@ describe('useTerminalResize', () => {
     const { unmount } = renderHook(() => useTerminalResize(ref));
     unmount();
     expect(disconnectSpy).toHaveBeenCalled();
+  });
+
+  // L4 PR-D (#866): after resize, the visible xterm must replay from the
+  // headless buffer's reflowed cell content rather than waiting on claude
+  // to repaint. The hook must invoke the snapshot-replay handler installed
+  // by usePtyAttach AFTER the backend resize IPC settles.
+  it('PR-D: invokes the snapshot-replay handler after the resize IPC resolves', async () => {
+    const replaySpy = vi.fn(async () => {});
+    snapshotReplayFn = replaySpy;
+    let resolveResize!: () => void;
+    const resizePromise = new Promise<void>((r) => { resolveResize = r; });
+    resizeBridge.mockImplementationOnce(() => resizePromise);
+
+    const host = document.createElement('div');
+    const ref = { current: host };
+    renderHook(() => useTerminalResize(ref));
+    lastObserverCb!([] as unknown as ResizeObserverEntry[], {} as ResizeObserver);
+    vi.advanceTimersByTime(80);
+    expect(resizeBridge).toHaveBeenCalledWith('sid-A', 100, 30);
+    // Replay must NOT fire until the resize promise settles — otherwise we'd
+    // snapshot the headless buffer BEFORE its `resize()` had reflowed.
+    expect(replaySpy).not.toHaveBeenCalled();
+
+    await vi.runAllTimersAsync();
+    resolveResize();
+    // Use real microtasks to drain the .then().
+    vi.useRealTimers();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(replaySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('PR-D: skips the replay when no handler is installed (no session attached)', () => {
+    snapshotReplayFn = null;
+    const host = document.createElement('div');
+    const ref = { current: host };
+    renderHook(() => useTerminalResize(ref));
+    lastObserverCb!([] as unknown as ResizeObserverEntry[], {} as ResizeObserver);
+    vi.advanceTimersByTime(80);
+    // Resize still pushed to backend; absence of replay handler is non-fatal.
+    expect(resizeBridge).toHaveBeenCalledWith('sid-A', 100, 30);
   });
 });

--- a/tests/usePtyAttach-snapshot-replay.test.tsx
+++ b/tests/usePtyAttach-snapshot-replay.test.tsx
@@ -139,6 +139,7 @@ describe('usePtyAttach — snapshot-then-live replay (L4 PR-B)', () => {
     singleton.setActiveSid(null);
     singleton.setUnsubscribeData(null);
     singleton.setInputDisposable(null);
+    singleton.setSnapshotReplay(null);
   });
 
   afterEach(() => {
@@ -251,6 +252,74 @@ describe('usePtyAttach — snapshot-then-live replay (L4 PR-B)', () => {
       // sid-X snapshot first (round 1), then sid-Y snapshot, then the
       // interleaved chunk (seq 2 > captured seq 1).
       expect(M.writes).toEqual(['SNAP_X', 'SNAP_Y', 'NEW_Y_2']);
+    });
+  });
+
+  // L4 PR-D (#866): after attach, the hook must install a snapshot-replay
+  // handler on the singleton so `useTerminalResize` can re-render the
+  // visible xterm from the reflowed headless buffer post-SIGWINCH. The
+  // handler re-runs steps 2-5 (buffer / snapshot / reset+write / drain)
+  // against the SAME data subscription so live chunks during the replay
+  // window aren't duplicated or lost.
+  it('PR-D: installs a snapshot-replay handler on the singleton after attach', async () => {
+    M.pendingSnapshot = newPendingSnapshot();
+    renderHook(() => usePtyAttach('sid-D', '/tmp'));
+    await waitFor(() => expect(M.snapshotCalls).toContain('sid-D'));
+    await act(async () => {
+      M.pendingSnapshot!.resolve({ snapshot: 'SNAP_D', seq: 5 });
+    });
+    await waitFor(() => expect(M.writes).toEqual(['SNAP_D']));
+
+    // Replay handler must be installed.
+    const replay = singleton.getSnapshotReplay();
+    expect(typeof replay).toBe('function');
+
+    // Invoking the replay should request a fresh snapshot and write it.
+    const replaySnap = newPendingSnapshot();
+    M.pendingSnapshot = replaySnap;
+    const replayPromise = replay!();
+    await waitFor(() => expect(M.snapshotCalls.filter((s) => s === 'sid-D').length).toBe(2));
+
+    // Live chunks DURING the replay snapshot await must be buffered, not written.
+    emitData('sid-D', 'OLD_REPLAY_4', 4);
+    emitData('sid-D', 'NEW_REPLAY_8', 8);
+    expect(M.writes).toEqual(['SNAP_D']);
+
+    await act(async () => {
+      replaySnap.resolve({ snapshot: 'REFLOWED_SNAP', seq: 6 });
+      await replayPromise;
+    });
+
+    await waitFor(() => {
+      // After replay: original snapshot, reflowed snapshot, then only the
+      // chunk with seq > 6 (drain dedupe).
+      expect(M.writes).toEqual(['SNAP_D', 'REFLOWED_SNAP', 'NEW_REPLAY_8']);
+    });
+  });
+
+  it('PR-D: replay handler is replaced (not stacked) on session switch', async () => {
+    M.pendingSnapshot = newPendingSnapshot();
+    const { rerender } = renderHook(({ sid }) => usePtyAttach(sid, '/tmp'), {
+      initialProps: { sid: 'sid-E' },
+    });
+    await waitFor(() => expect(M.snapshotCalls).toContain('sid-E'));
+    await act(async () => {
+      M.pendingSnapshot!.resolve({ snapshot: 'SNAP_E', seq: 0 });
+    });
+    await waitFor(() => expect(singleton.getSnapshotReplay()).not.toBeNull());
+    const firstReplay = singleton.getSnapshotReplay();
+
+    // Switch.
+    M.pendingSnapshot = newPendingSnapshot();
+    rerender({ sid: 'sid-F' });
+    await waitFor(() => expect(M.detachCalls).toContain('sid-E'));
+    await act(async () => {
+      M.pendingSnapshot!.resolve({ snapshot: 'SNAP_F', seq: 0 });
+    });
+    await waitFor(() => {
+      const replay = singleton.getSnapshotReplay();
+      expect(replay).not.toBeNull();
+      expect(replay).not.toBe(firstReplay);
     });
   });
 });


### PR DESCRIPTION
## Scope

L4 dual-buffer architecture, PR-D of E. After PR-A (#605 SCROLLBACK 10000 + async snapshot), PR-B (#606 attach replay from buffer), PR-C (#607 dispatchPtyChunk + backpressure observe), the **resize path** now also goes through the headless buffer.

Closes the user-visible "alt-screen stays at pre-resize wrap until you type" gap (same family as #852): claude's TUI does not repaint on SIGWINCH, so without a buffer-driven replay the visible xterm is stuck on the pre-resize cell grid.

## What changed

**Renderer-only**, no backend changes:

- `electron` — **untouched**. `lifecycle.resize` already resizes both pty and headless mirror; `getBufferSnapshot` already captures `(serialize, seq)` atomically.
- `src/terminal/xtermSingleton.ts` — added `getSnapshotReplay` / `setSnapshotReplay` so `useTerminalResize` can drive a replay against the same attach closure that owns the seq-dedupe state.
- `src/terminal/usePtyAttach.ts` — **minimal** (hot-file rule for PR-E coordination): after the initial snapshot lands, install a snapshot-replay handler that re-runs steps 2-5 against the existing data subscription. Handler is dropped on session switch / Retry. 3 hunks total.
- `src/terminal/useTerminalResize.ts` — after `pty.resize` IPC settles (which triggers xterm's synchronous reflow on the headless mirror), invoke the replay handler. Best-effort; failure leaves the pre-reflow grid but next live chunk still renders correctly because the pty IS resized.

## Files

- `src/terminal/xtermSingleton.ts`
- `src/terminal/usePtyAttach.ts`
- `src/terminal/useTerminalResize.ts`
- `tests/terminal/usePtyAttach.test.tsx`
- `tests/terminal/useTerminalResize.test.tsx`
- `tests/usePtyAttach-snapshot-replay.test.tsx`

## UT output

```
$ npx vitest run tests/terminal/ tests/usePtyAttach-snapshot-replay.test.tsx electron/ptyHost/__tests__/

Test Files  16 passed (16)
     Tests  194 passed (194)
  Duration  16.70s
```

New PR-D tests added:
- `useTerminalResize > PR-D: invokes the snapshot-replay handler after the resize IPC resolves`
- `useTerminalResize > PR-D: skips the replay when no handler is installed (no session attached)`
- `usePtyAttach > PR-D: installs a snapshot-replay handler on the singleton after attach`
- `usePtyAttach > PR-D: replay handler is replaced (not stacked) on session switch`

## Reverse-verify (FAIL → PASS)

Gated the replay invocation in `useTerminalResize.ts`:
```ts
if (replay && false) { ... }   // deliberate bug
```

```
FAIL  tests/terminal/useTerminalResize.test.tsx > useTerminalResize > PR-D: invokes the snapshot-replay handler after the resize IPC resolves
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
 ❯ tests/terminal/useTerminalResize.test.tsx:123:23
    123|     expect(replaySpy).toHaveBeenCalledTimes(1);
                              ^

Test Files  1 failed (1)
     Tests  1 failed | 3 passed (4)
```

Restored fix:
```
Test Files  1 passed (1)
     Tests  4 passed (4)
```

## E2E

No dedicated resize e2e probe exists in the suite (`grep resize tests/` returns only UT files). Existing harness probes covering terminal lifecycle (`harness-real-cli pty-pid-stable-across-switch`, `switch-session-keeps-chat`) are unaffected by this PR — the data path stays identical, only the post-resize replay is new and is keyed off `useTerminalResize`'s existing 80ms debounce.

Per "trust CI mode (post-#554)": deferring full e2e to CI rollup.

## Pre-existing test failures (NOT caused by this PR)

Same 21 failures appear on `origin/working` (verified via `git stash` + re-run):
- `tests/electron-load-smoke.test.ts` — needs `npm run build` first (env, not regression)
- `electron/__tests__/db-hardening.test.ts` — better-sqlite3 native binding issue on this worker env

## Hot-file coordination

PR-E worker (detach/reattach) will also touch `usePtyAttach.ts`. PR-D's diff is intentionally minimal: 1 import line + 2 `setSnapshotReplay(null)` cleanup lines + 1 install block (after the existing post-snapshot drain). Should rebase trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)