### PR TITLE
ci: cache node_modules to skip npm ci on lockfile hit (#878)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,22 @@ jobs:
         with:
           python-version: '3.11'
 
+      # Cache node_modules directly (not ~/.npm) — `npm ci --legacy-peer-deps`
+      # on Windows is the dominant CI cost (~178s = 49% of total wall-clock,
+      # eval #877). Restoring node_modules verbatim skips install + native
+      # rebuilds (better-sqlite3, node-pty) baked into the cached tree.
+      # Key includes os/arch/node major + lockfile hash so any dep change
+      # busts the cache. Native ABI for Node-side tests is re-aligned by the
+      # `npm rebuild better-sqlite3` step below, which always runs.
+      - name: Cache node_modules
+        id: nm_cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: nm-${{ runner.os }}-${{ runner.arch }}-node20-${{ hashFiles('package-lock.json') }}
+
       - name: Install deps
+        if: steps.nm_cache.outputs.cache-hit != 'true'
         run: npm ci --legacy-peer-deps
         env:
           # electron-builder's postinstall needs this env to not fail on

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,6 +36,17 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+      # Cache node_modules directly — same rationale as ci.yml: `npm ci`
+      # is the dominant Windows CI cost. Cache hit skips install entirely
+      # and inherits the postinstall-rebuilt native bindings (better-sqlite3,
+      # node-pty) from the cached tree, which is what the Electron e2e
+      # actually loads.
+      - name: Cache node_modules
+        id: nm_cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: nm-${{ runner.os }}-${{ runner.arch }}-node20-${{ hashFiles('package-lock.json') }}
       - name: Cache Electron binary
         uses: actions/cache@v4
         with:
@@ -44,6 +55,7 @@ jobs:
             ~/.cache/electron-builder
           key: electron-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - name: Install deps
+        if: steps.nm_cache.outputs.cache-hit != 'true'
         run: npm ci --legacy-peer-deps
       - name: Build
         run: npm run build


### PR DESCRIPTION
## Why

Eval #877 profiled Windows CI wall-clock and found `npm ci --legacy-peer-deps` is the dominant cost: **~178s, ~49% of the total job**. `setup-node@v4`'s built-in `cache: npm` only caches the `~/.npm` tarball cache, which still leaves the unpack + native rebuild on the critical path.

## What

Cache `node_modules/` directly in both `ci.yml` and `e2e.yml`:

```yaml
- name: Cache node_modules
  id: nm_cache
  uses: actions/cache@v4
  with:
    path: node_modules
    key: nm-${{ runner.os }}-${{ runner.arch }}-node20-${{ hashFiles('package-lock.json') }}

- name: Install deps
  if: steps.nm_cache.outputs.cache-hit != 'true'
  run: npm ci --legacy-peer-deps
```

### Cache key design

`nm-${os}-${arch}-node20-${hash(package-lock.json)}`

- `os` + `arch` — native bindings differ per platform/arch
- `node20` — Node major; bump if we move off Node 20
- lockfile hash — any dep churn busts the cache cleanly

No fallback `restore-keys` on purpose: a partial restore (different lockfile) would leave a stale tree and `npm ci`'s "if it ran, the result is correct" guarantee no longer holds.

## Risk: native module ABI

`scripts/postinstall.mjs` rebuilds **better-sqlite3 (fatal)** and **node-pty (allowed-fail)** for the Electron ABI, writing the rebuilt `.node` binaries into `node_modules/`. Caching `node_modules` carries those rebuilt bindings forward verbatim, so cache hit produces the same on-disk state as a fresh install for Electron.

`ci.yml` then runs `npm rebuild better-sqlite3` (Node ABI) for the `npm test` runs — this step is **left unconditional** so the Node ABI is always re-aligned, regardless of cache hit/miss. It's ~2s and required.

postinstall.mjs is verified idempotent: it only invokes `@electron/rebuild` and writes inside `node_modules/`. No generated source files outside `node_modules/`, no cumulative side effects.

## Validation plan

- **This PR (cache miss)**: timing should match the pre-#878 baseline; this is expected and not a regression.
- **Subsequent PRs (cache hit)**: Windows job should drop from ~6m to **~3m30s** (saves the ~178s npm ci step). Linux/macOS see proportional but smaller wins.

Cache fills only when the `working` branch's CI runs, so the first PR after merge (against unchanged lockfile) sees the win immediately.

## Files changed

- `.github/workflows/ci.yml` — add `Cache node_modules` step + `if:` gate on Install deps
- `.github/workflows/e2e.yml` — same pattern, slot the new cache step before the existing Electron binary cache

Closes #878.