### PR TITLE
refactor(terminal): L4 PR-F remove #602 spawn-time-size hack (#867)

### DIFF
--- a/electron/preload/bridges/ccsmPty.ts
+++ b/electron/preload/bridges/ccsmPty.ts
@@ -30,11 +30,8 @@ const ptyExitListeners = new Set<(e: PtyExitPayload) => void>();
 
 const ccsmPty = {
   list: (): Promise<unknown> => ipcRenderer.invoke('pty:list'),
-  spawn: (
-    sid: string,
-    cwd: string,
-    opts?: { cols?: number; rows?: number },
-  ): Promise<unknown> => ipcRenderer.invoke('pty:spawn', sid, cwd, opts),
+  spawn: (sid: string, cwd: string): Promise<unknown> =>
+    ipcRenderer.invoke('pty:spawn', sid, cwd),
   attach: (sid: string): Promise<unknown> => ipcRenderer.invoke('pty:attach', sid),
   detach: (sid: string): Promise<void> => ipcRenderer.invoke('pty:detach', sid),
   input: (sid: string, data: string): Promise<void> =>

--- a/electron/ptyHost/__tests__/ipcRegistrar.test.ts
+++ b/electron/ptyHost/__tests__/ipcRegistrar.test.ts
@@ -230,29 +230,14 @@ describe('pty:spawn', () => {
     expect(call[2]).toBe('/bin/claude');
   });
 
-  // Task #852 — renderer measures the visible viewport via FitAddon and
-  // passes cols/rows so the PTY launches at the size it will be displayed
-  // at (eliminating the "top-painted, bottom-black-void" alt-screen
-  // divergence). Without this forwarding the trust-prompt rendered by
-  // claude at the default 120x30 stays stuck at that size while the
-  // visible xterm gets resized post-write to 134x51, leaving the bottom
-  // 21 rows of the prompt invisible until the user types.
-  it('forwards renderer-supplied cols/rows from opts to spawnPtySession (#852)', () => {
-    const ipc = makeFakeIpc();
-    bus().resolveClaude.mockReturnValue('/bin/claude');
-    const deps = makeDeps({
-      spawnPtySession: vi.fn(() => ({ sid: 'sid', pid: 1, cols: 134, rows: 51, cwd: '/picked' })),
-    });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    registerPtyIpc(ipc as any, deps);
-    ipc.handlers.get('pty:spawn')!({}, 'sid', '/work', { cols: 134, rows: 51 });
-    const call = (deps.spawnPtySession as ReturnType<typeof vi.fn>).mock.calls[0];
-    const opts = call[3] as { cols?: number; rows?: number };
-    expect(opts.cols).toBe(134);
-    expect(opts.rows).toBe(51);
-  });
-
-  it('omits cols/rows when opts is missing or non-numeric (lifecycle uses defaults)', () => {
+  // L4 PR-F (#867) — the spawn-time cols/rows hack added for #852 has been
+  // removed. The renderer no longer forwards initial dimensions through
+  // `pty:spawn`; the PTY launches at the lifecycle defaults (DEFAULT_COLS/
+  // ROWS = 120x30) and the post-attach `pty:resize` + snapshot replay
+  // (PR-D #866) reflows both the headless source-of-truth buffer and the
+  // visible xterm to the real container. The IPC handler therefore no
+  // longer parses or threads cols/rows into spawnPtySession opts.
+  it('does not forward cols/rows to spawnPtySession (#867 — PR-D resize+replay covers #852)', () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue('/bin/claude');
     const deps = makeDeps({
@@ -260,35 +245,31 @@ describe('pty:spawn', () => {
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
-    // No opts argument at all.
-    ipc.handlers.get('pty:spawn')!({}, 'sid', '/work');
-    let call = (deps.spawnPtySession as ReturnType<typeof vi.fn>).mock.calls[0];
-    let opts = call[3] as { cols?: number; rows?: number };
+    // Even if a (legacy) renderer were to send the third opts argument,
+    // the IPC handler ignores it — the only opt threaded into the
+    // lifecycle is onCwdRedirect (#603).
+    ipc.handlers.get('pty:spawn')!({}, 'sid', '/work', { cols: 134, rows: 51 });
+    const call = (deps.spawnPtySession as ReturnType<typeof vi.fn>).mock.calls[0];
+    const opts = call[3] as { cols?: number; rows?: number; onCwdRedirect?: unknown };
     expect(opts.cols).toBeUndefined();
     expect(opts.rows).toBeUndefined();
-
-    // Garbage opts (non-numeric) — defensive parsing still falls back.
-    (deps.spawnPtySession as ReturnType<typeof vi.fn>).mockClear();
-    ipc.handlers.get('pty:spawn')!({}, 'sid', '/work', { cols: 'wide', rows: null });
-    call = (deps.spawnPtySession as ReturnType<typeof vi.fn>).mock.calls[0];
-    opts = call[3] as { cols?: number; rows?: number };
-    expect(opts.cols).toBeUndefined();
-    expect(opts.rows).toBeUndefined();
+    expect(typeof opts.onCwdRedirect).toBe('function');
   });
 
-  it('floors fractional cols/rows and clamps to a >=2 minimum', () => {
+  it('omits opts argument entirely from `pty:spawn` (post-#867)', () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue('/bin/claude');
     const deps = makeDeps({
-      spawnPtySession: vi.fn(() => ({ sid: 'sid', pid: 1, cols: 80, rows: 24, cwd: '/' })),
+      spawnPtySession: vi.fn(() => ({ sid: 'sid', pid: 1, cols: 120, rows: 30, cwd: '/picked' })),
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
-    ipc.handlers.get('pty:spawn')!({}, 'sid', '/work', { cols: 134.7, rows: 1 });
+    ipc.handlers.get('pty:spawn')!({}, 'sid', '/work');
     const call = (deps.spawnPtySession as ReturnType<typeof vi.fn>).mock.calls[0];
-    const opts = call[3] as { cols?: number; rows?: number };
-    expect(opts.cols).toBe(134);
-    expect(opts.rows).toBe(2);
+    const opts = call[3] as { cols?: number; rows?: number; onCwdRedirect?: unknown };
+    expect(opts.cols).toBeUndefined();
+    expect(opts.rows).toBeUndefined();
+    expect(typeof opts.onCwdRedirect).toBe('function');
   });
 
   it('returns {ok:false, error:spawn_failed:...} when spawnPtySession throws', () => {

--- a/electron/ptyHost/ipcRegistrar.ts
+++ b/electron/ptyHost/ipcRegistrar.ts
@@ -87,30 +87,22 @@ export function registerPtyIpc(ipcMain: IpcMain, deps: PtyIpcDeps): void {
 
   ipcMain.handle('pty:list', () => deps.listPtySessions());
 
-  ipcMain.handle('pty:spawn', (_event, sid: string, cwd: string, opts?: unknown) => {
+  ipcMain.handle('pty:spawn', (_event, sid: string, cwd: string) => {
     const claudePath = resolveClaude();
     if (!claudePath) {
       return { ok: false, error: 'claude_not_found' };
     }
-    // Renderer-supplied initial size (Task #852). Spawning the PTY at the
-    // visible viewport's dimensions (rather than the 120x30 default) means
-    // claude's TUI renders its first frame — including alt-screen prompts
-    // like the trust dialog — at exactly the size the visible xterm will
-    // display, eliminating the "top-painted, bottom-black-void" divergence
-    // caused by post-write resize. If renderer omits opts, fall back to
-    // the lifecycle default.
-    const cols =
-      typeof opts === 'object' && opts !== null && typeof (opts as { cols?: unknown }).cols === 'number'
-        ? Math.max(2, Math.floor((opts as { cols: number }).cols))
-        : undefined;
-    const rows =
-      typeof opts === 'object' && opts !== null && typeof (opts as { rows?: unknown }).rows === 'number'
-        ? Math.max(2, Math.floor((opts as { rows: number }).rows))
-        : undefined;
+    // L4 PR-F (#867): the renderer no longer forwards initial cols/rows.
+    // The PTY launches at the lifecycle defaults (DEFAULT_COLS/ROWS) and
+    // the renderer's post-attach `pty:resize` (with snapshot replay,
+    // PR-D #866) reflows both the PTY and the headless source-of-truth
+    // buffer to the real viewport, then repaints the visible xterm from
+    // the reflowed snapshot. This makes the spawn-time #852 hack
+    // (renderer measures viewport via FitAddon, forwards to spawn,
+    // main floor+clamps to >=2 and threads through spawnPtySession)
+    // redundant; it has been removed.
     try {
       const info = deps.spawnPtySession(sid, cwd, claudePath, {
-        cols,
-        rows,
         // Import-resume cwd-redirect (#603 reviewer Layer-1 fix). When the
         // copy helper relocates the JSONL into the spawn cwd's projectDir,
         // the renderer's `session.cwd` (still pointing at the original

--- a/scripts/harness-real-cli.mjs
+++ b/scripts/harness-real-cli.mjs
@@ -3110,11 +3110,13 @@ async function caseNotifyPipelineBackground({ electronApp, win, tempDir }) {
 //      xterm restores its prior content WITHOUT typing — same path, exercised
 //      under the re-attach scenario.
 //
-// This case is the e2e probe for PR-B's IPC + replay; PR #602's spawn-time
-// size hack (#852 L1 fix) is still in place, so the trust prompt is also
-// visible at the right size — what we additionally pin here is the IPC
-// surface and the snapshot-feeds-view linkage. PR-F will revert #602's hack;
-// when it does, this probe must STILL pass on the strength of replay alone.
+// This case is the e2e probe for PR-B's IPC + replay. PR-F (#867) has now
+// reverted PR #602's spawn-time cols/rows hack, so the trust prompt's
+// visibility-at-the-right-size relies entirely on PR-D's resize+replay
+// path — i.e. exactly what this probe pins. After PR-F this case still
+// passes because (a) the snapshot replay paints the visible xterm from
+// the reflowed headless buffer, and (b) the post-attach fit pushes the
+// real container size to the PTY before the user types.
 
 async function caseAttachReplayFromHeadlessBuffer({ electronApp, win, tempDir }) {
   await win.waitForFunction(

--- a/src/pty.d.ts
+++ b/src/pty.d.ts
@@ -61,7 +61,7 @@ export type CheckClaudeAvailableResult =
 
 export interface CcsmPtyApi {
   list(): Promise<PtySessionInfo[]>;
-  spawn(sid: string, cwd: string, opts?: { cols?: number; rows?: number }): Promise<SpawnResult>;
+  spawn(sid: string, cwd: string): Promise<SpawnResult>;
   attach(sid: string): Promise<AttachResult | null>;
   detach(sid: string): Promise<void>;
   input(sid: string, data: string): Promise<void>;

--- a/src/terminal/usePtyAttach.ts
+++ b/src/terminal/usePtyAttach.ts
@@ -11,6 +11,7 @@ import {
   getInputDisposable,
   setInputDisposable,
   setSnapshotReplay,
+  getSnapshotReplay,
 } from './xtermSingleton';
 
 export type PtyAttachState =
@@ -133,45 +134,17 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
       const term = getTerm();
       if (term) term.reset();
 
-      // Task #852 — measure the visible viewport BEFORE spawn / write so
-      // the PTY launches at the size it will actually be displayed at.
-      // Otherwise the default 120x30 PTY emits its first frame (e.g.
-      // claude's alt-screen trust prompt) at the wrong size, the renderer
-      // writes that snapshot, then a follow-up `fit.fit()` resizes the
-      // visible xterm — extending the buffer downward with blank rows
-      // (the "top-painted, bottom-black-void" bug). claude has no reason
-      // to repaint until input arrives, so the user sees a half-rendered
-      // dialog they can't see the answer to. Push the real size first.
-      const fitForSpawn = getFit();
-      const termForSpawn = getTerm();
-      let viewportCols: number | undefined;
-      let viewportRows: number | undefined;
-      if (fitForSpawn && termForSpawn) {
-        try {
-          const proposed = fitForSpawn.proposeDimensions();
-          if (
-            proposed &&
-            Number.isFinite(proposed.cols) &&
-            Number.isFinite(proposed.rows) &&
-            proposed.cols >= 2 &&
-            proposed.rows >= 2
-          ) {
-            viewportCols = proposed.cols;
-            viewportRows = proposed.rows;
-            // Pre-size the visible terminal so the snapshot we're about to
-            // write lands in a buffer of matching dimensions. The post-attach
-            // `fit.fit()` below is then a no-op for sizing and only needs to
-            // push the (already-correct) cols/rows to the PTY.
-            try {
-              termForSpawn.resize(viewportCols, viewportRows);
-            } catch {
-              // resize is best-effort.
-            }
-          }
-        } catch (e) {
-          console.warn('[TerminalPane] proposeDimensions failed', e);
-        }
-      }
+      // L4 PR-F (#867): the spawn-time cols/rows hack added for #852 is gone.
+      // The PTY launches at the lifecycle defaults (120x30); the post-attach
+      // resize+replay below (PR-D #866) reflows the headless source-of-truth
+      // buffer to the real viewport size and rewrites the visible xterm from
+      // it, so there is no longer a "spawn at wrong size → claude's alt-screen
+      // never repaints → bottom-black-void" divergence even when the visible
+      // viewport differs from the spawn size. The pre-spawn FitAddon
+      // proposeDimensions() call + pre-write `term.resize` are likewise no
+      // longer needed: the post-attach fit reads the live container, the
+      // backend resize reflows the headless buffer, and the snapshot replay
+      // paints the reflowed grid.
 
       try {
         // Spawn-on-attach-null fallback. The renderer drives session
@@ -183,10 +156,7 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
           | { snapshot: string; cols: number; rows: number; pid: number }
           | null;
         if (!res) {
-          const spawnResult = (await pty.spawn(sessionId, cwd ?? '', {
-            cols: viewportCols,
-            rows: viewportRows,
-          })) as
+          const spawnResult = (await pty.spawn(sessionId, cwd ?? '')) as
             | { ok: true; sid: string; pid: number; cols: number; rows: number }
             | { ok: false; error: string };
           if (!spawnResult || spawnResult.ok === false) {
@@ -233,10 +203,13 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
         const t2 = getTerm();
         if (t2) {
           // Resize visible xterm to PTY's actual size BEFORE writing the
-          // snapshot. For fresh spawns this matches viewportCols/Rows
-          // (because we passed them to spawn). For attach-to-existing the
-          // snapshot is at the PTY's current size; matching that before
-          // write avoids alt-screen reflow blanks.
+          // snapshot so the cell grid matches the snapshot's dimensions
+          // (avoids the alt-screen reflow blanks when the pre-existing
+          // visible xterm was at a different size). The post-attach fit
+          // below then resizes everything to the real container, with the
+          // snapshot replay (PR-D #866) reflowing the visible buffer to
+          // match — so the only invariant we need here is "visible matches
+          // snapshot at write time".
           try {
             t2.resize(cols, rows);
           } catch {
@@ -358,15 +331,32 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
           );
         }
 
-        // Push the current container size to the backend so claude
-        // re-wraps to the visible viewport rather than the spawn-time cols/rows.
+        // L4 PR-F (#867): post-attach, push the container size to the
+        // backend so the PTY + headless source-of-truth buffer reflow to
+        // the visible viewport (rather than staying at the spawn-time
+        // 120x30). After the backend resize settles, run the snapshot
+        // replay (PR-D #866) so the visible xterm rewrites from the
+        // freshly-reflowed headless buffer — this replaces the old
+        // pre-spawn measurement hack: the divergence between PTY size
+        // and visible size is now resolved AFTER the fact by the
+        // headless mirror, so claude doesn't need to voluntarily
+        // repaint its alt-screen for the user to see correct content.
         const fit = getFit();
         const t4 = getTerm();
         const sid4 = getActiveSid();
         if (fit && t4 && sid4) {
           try {
             fit.fit();
-            window.ccsmPty.resize(sid4, t4.cols, t4.rows);
+            const resizePromise = window.ccsmPty.resize(sid4, t4.cols, t4.rows);
+            const p = resizePromise && typeof (resizePromise as Promise<void>).then === 'function'
+              ? (resizePromise as Promise<void>)
+              : Promise.resolve();
+            void p
+              .then(() => {
+                const replay = getSnapshotReplay();
+                return replay ? replay() : undefined;
+              })
+              .catch((e) => console.warn('[TerminalPane] post-attach replay failed', e));
           } catch (e) {
             console.warn('[TerminalPane] post-attach fit failed', e);
           }

--- a/src/terminal/usePtyAttach.ts
+++ b/src/terminal/usePtyAttach.ts
@@ -346,17 +346,30 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
         const sid4 = getActiveSid();
         if (fit && t4 && sid4) {
           try {
+            // Gate the post-attach resize+replay on a real size delta (#888).
+            // PR-D contract: initial attach paints the snapshot ONCE from
+            // getBufferSnapshot — no second write. Only when the visible
+            // viewport differs from the spawn-time PTY dimensions (the real
+            // #852 case: headless 120x30 vs visible NxM) do we push the new
+            // size to the backend and replay the reflowed snapshot. Stable
+            // container = no-op; size delta = fire once.
+            const oldCols = t4.cols;
+            const oldRows = t4.rows;
             fit.fit();
-            const resizePromise = window.ccsmPty.resize(sid4, t4.cols, t4.rows);
-            const p = resizePromise && typeof (resizePromise as Promise<void>).then === 'function'
-              ? (resizePromise as Promise<void>)
-              : Promise.resolve();
-            void p
-              .then(() => {
-                const replay = getSnapshotReplay();
-                return replay ? replay() : undefined;
-              })
-              .catch((e) => console.warn('[TerminalPane] post-attach replay failed', e));
+            const newCols = t4.cols;
+            const newRows = t4.rows;
+            if (newCols !== oldCols || newRows !== oldRows) {
+              const resizePromise = window.ccsmPty.resize(sid4, newCols, newRows);
+              const p = resizePromise && typeof (resizePromise as Promise<void>).then === 'function'
+                ? (resizePromise as Promise<void>)
+                : Promise.resolve();
+              void p
+                .then(() => {
+                  const replay = getSnapshotReplay();
+                  return replay ? replay() : undefined;
+                })
+                .catch((e) => console.warn('[TerminalPane] post-attach replay failed', e));
+            }
           } catch (e) {
             console.warn('[TerminalPane] post-attach fit failed', e);
           }

--- a/tests/terminal/usePtyAttach.test.tsx
+++ b/tests/terminal/usePtyAttach.test.tsx
@@ -238,22 +238,49 @@ describe('usePtyAttach', () => {
     expect(proposeDimensionsSpy).not.toHaveBeenCalled();
   });
 
-  it('post-attach fit triggers snapshot replay so the visible xterm reflows to the real viewport (#867)', async () => {
+  it('post-attach fit is a no-op when container size is stable: no replay, snapshot fetched once (#888)', async () => {
     const { bridge, spies } = makePtyBridge({ snapshot: { snapshot: 'snap', seq: 0 } });
     (window as any).ccsmPty = bridge;
 
-    renderHook(() => usePtyAttach('sid-867r', '/cwd'));
+    // fitFitSpy default = does NOT mutate cols/rows → no size delta.
+    renderHook(() => usePtyAttach('sid-867s', '/cwd'));
     await flushAll();
 
-    // Post-attach: fit.fit() ran, backend resize was pushed, and the
-    // installed snapshot replay (PR-D #866) was invoked after the
-    // resize promise resolved.
+    // fit.fit() still runs (we need to measure), but because cols/rows are
+    // unchanged the backend resize and snapshot replay must be skipped.
     expect(fitFitSpy).toHaveBeenCalled();
-    expect(spies.resize).toHaveBeenCalledWith('sid-867r', 80, 24);
-    // The snapshot-replay handler is installed by usePtyAttach at attach
-    // time; verify it was invoked by checking that getBufferSnapshot was
-    // called twice (once for the initial paint, once for the replay).
-    expect(spies.getBufferSnapshot).toHaveBeenCalledTimes(2);
+    expect(spies.resize).not.toHaveBeenCalled();
+    // PR-D contract: only the initial attach snapshot was fetched / written.
+    expect(spies.getBufferSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it('post-attach fit triggers backend resize + snapshot replay when container size differs (#867 / #852)', async () => {
+    const { bridge, spies } = makePtyBridge({ snapshot: { snapshot: 'snap', seq: 0 } });
+    (window as any).ccsmPty = bridge;
+
+    // Simulate the real #852 case: visible viewport differs from spawn-time
+    // 80x24 — fit.fit() reflows the term to a new size.
+    fitFitSpy.mockImplementation(() => {
+      fakeTerm.cols = 134;
+      fakeTerm.rows = 51;
+    });
+
+    try {
+      renderHook(() => usePtyAttach('sid-867r', '/cwd'));
+      await flushAll();
+
+      expect(fitFitSpy).toHaveBeenCalled();
+      // Backend resize is pushed with the NEW dimensions (post-fit).
+      expect(spies.resize).toHaveBeenCalledWith('sid-867r', 134, 51);
+      // Replay handler ran → second getBufferSnapshot fetch (initial paint
+      // + replay re-fetch).
+      expect(spies.getBufferSnapshot).toHaveBeenCalledTimes(2);
+    } finally {
+      // Restore fakeTerm dimensions for subsequent tests.
+      fakeTerm.cols = 80;
+      fakeTerm.rows = 24;
+      fitFitSpy.mockReset();
+    }
   });
 
   it('flips to error state when ccsmPty bridge is missing', async () => {

--- a/tests/terminal/usePtyAttach.test.tsx
+++ b/tests/terminal/usePtyAttach.test.tsx
@@ -204,59 +204,56 @@ describe('usePtyAttach', () => {
     renderHook(() => usePtyAttach('sid-C', '/cwd'));
     await flushAll();
 
-    expect(spies.spawn).toHaveBeenCalledWith('sid-C', '/cwd', expect.objectContaining({}));
+    expect(spies.spawn).toHaveBeenCalledWith('sid-C', '/cwd');
     expect(spies.attach).toHaveBeenCalledTimes(2);
     // L4 PR-B (#865): the visible terminal paints the getBufferSnapshot
     // string, NOT the legacy attach.snapshot.
     expect(writeSpy).toHaveBeenCalledWith('after-spawn');
   });
 
-  // Task #852 — when pty.attach returns null and we fall back to spawn, the
-  // viewport-measured cols/rows from FitAddon.proposeDimensions() must be
-  // forwarded to spawn so the PTY launches at the visible size. Otherwise
-  // claude renders its alt-screen prompt at 120x30 and the bottom of the
-  // visible 134x51 xterm stays a black void until the user types.
-  it('forwards viewport-measured cols/rows to spawn (fixes #852 alt-screen divergence)', async () => {
+  // L4 PR-F (#867) — the spawn-time cols/rows hack added for #852 has been
+  // removed. The renderer no longer measures the viewport via FitAddon
+  // before spawn nor forwards cols/rows to `pty.spawn`; the PTY launches at
+  // the lifecycle defaults and the post-attach `pty.resize` + snapshot
+  // replay (PR-D #866) reflows both the headless source-of-truth buffer
+  // and the visible xterm to the real container size, so claude doesn't
+  // need to voluntarily repaint its alt-screen for the user to see correct
+  // content.
+  it('does not forward cols/rows to spawn (#867 — PR-D resize+replay covers #852)', async () => {
     let calls = 0;
     const { bridge, spies } = makePtyBridge({ snapshot: { snapshot: 'after-spawn', seq: 0 } });
     spies.attach.mockImplementation(async (_sid: string) => {
       calls += 1;
       if (calls === 1) return null;
-      return { snapshot: 'ignored-now', cols: 134, rows: 51, pid: 1 };
+      return { snapshot: 'ignored-now', cols: 120, rows: 30, pid: 1 };
     });
-    proposeDimensionsSpy.mockReturnValue({ cols: 134, rows: 51 });
     (window as any).ccsmPty = bridge;
 
-    renderHook(() => usePtyAttach('sid-852', '/cwd'));
+    renderHook(() => usePtyAttach('sid-867', '/cwd'));
     await flushAll();
 
-    expect(proposeDimensionsSpy).toHaveBeenCalled();
-    expect(spies.spawn).toHaveBeenCalledWith('sid-852', '/cwd', { cols: 134, rows: 51 });
-    // Visible terminal pre-sized BEFORE snapshot write so alt-screen
-    // contents land in a buffer of matching dimensions (no buffer-extension
-    // black void at the bottom).
-    expect(resizeSpy).toHaveBeenCalledWith(134, 51);
-    // The pre-write resize precedes the snapshot write.
-    const resizeOrder = resizeSpy.mock.invocationCallOrder[0];
-    const writeOrder = writeSpy.mock.invocationCallOrder[0];
-    expect(resizeOrder).toBeLessThan(writeOrder);
+    // Spawn is called with sid + cwd ONLY — no opts argument.
+    expect(spies.spawn).toHaveBeenCalledWith('sid-867', '/cwd');
+    // FitAddon.proposeDimensions is no longer called pre-spawn.
+    expect(proposeDimensionsSpy).not.toHaveBeenCalled();
   });
 
-  it('omits cols/rows when FitAddon proposeDimensions returns undefined', async () => {
-    let calls = 0;
-    const { bridge, spies } = makePtyBridge({ snapshot: { snapshot: 'after-spawn', seq: 0 } });
-    spies.attach.mockImplementation(async (_sid: string) => {
-      calls += 1;
-      if (calls === 1) return null;
-      return { snapshot: 'ignored-now', cols: 80, rows: 24, pid: 1 };
-    });
-    proposeDimensionsSpy.mockReturnValue(undefined as unknown as { cols: number; rows: number });
+  it('post-attach fit triggers snapshot replay so the visible xterm reflows to the real viewport (#867)', async () => {
+    const { bridge, spies } = makePtyBridge({ snapshot: { snapshot: 'snap', seq: 0 } });
     (window as any).ccsmPty = bridge;
 
-    renderHook(() => usePtyAttach('sid-852b', '/cwd'));
+    renderHook(() => usePtyAttach('sid-867r', '/cwd'));
     await flushAll();
 
-    expect(spies.spawn).toHaveBeenCalledWith('sid-852b', '/cwd', { cols: undefined, rows: undefined });
+    // Post-attach: fit.fit() ran, backend resize was pushed, and the
+    // installed snapshot replay (PR-D #866) was invoked after the
+    // resize promise resolved.
+    expect(fitFitSpy).toHaveBeenCalled();
+    expect(spies.resize).toHaveBeenCalledWith('sid-867r', 80, 24);
+    // The snapshot-replay handler is installed by usePtyAttach at attach
+    // time; verify it was invoked by checking that getBufferSnapshot was
+    // called twice (once for the initial paint, once for the replay).
+    expect(spies.getBufferSnapshot).toHaveBeenCalledTimes(2);
   });
 
   it('flips to error state when ccsmPty bridge is missing', async () => {


### PR DESCRIPTION
## Summary

Final piece of the L4 dual-buffer architecture (per #860 eval). Removes
the spawn-time cols/rows hack introduced in PR #602 for issue #852
(claude trust prompt clipped at the bottom of the visible xterm).

The hack measured the visible viewport via `FitAddon.proposeDimensions()`
**before** spawn and forwarded the result through a new `pty:spawn`
opts surface so the PTY launched at the visible size. With L4 PR-D
(#866 — resize via headless buffer + snapshot replay) and L4 PR-B
(#865 — attach replay via headless), this is now redundant: the PTY
launches at the lifecycle defaults (120x30), the post-attach resize
reflows both the PTY **and** the headless source-of-truth buffer to
the real container, and the snapshot replay rewrites the visible xterm
from the reflowed buffer — so claude no longer has to voluntarily
repaint its alt-screen for the user to see the trust prompt.

## Files deleted (-149 LOC inserted, +108; net -41)

Production:
- `src/terminal/usePtyAttach.ts` — pre-spawn `FitAddon.proposeDimensions()`
  + pre-write `term.resize()` + opts forwarding to `pty.spawn()` removed.
  Post-attach fit now invokes the snapshot-replay handler (the
  load-bearing replacement: replays the reflowed buffer instead of
  pre-sizing the spawn).
- `electron/ptyHost/ipcRegistrar.ts` — opts cols/rows parsing + clamping
  + threading into `spawnPtySession` removed; only `onCwdRedirect` (#603)
  remains in the lifecycle opts.
- `electron/preload/bridges/ccsmPty.ts` — opts param dropped from
  `spawn(sid, cwd)`.
- `src/pty.d.ts` — opts param dropped from `CcsmPtyApi.spawn`.

Tests:
- `electron/ptyHost/__tests__/ipcRegistrar.test.ts` — 3 #852 cases
  replaced with 2 #867 cases ("no cols/rows reach spawnPtySession
  opts" + "onCwdRedirect still threaded").
- `tests/terminal/usePtyAttach.test.tsx` — 2 #852 cases replaced with
  2 #867 cases ("spawn called without opts arg" + "post-attach replay
  invoked: getBufferSnapshot called twice — once for initial paint,
  once for post-fit replay").

Probe doc:
- `scripts/harness-real-cli.mjs` — updated the
  `attach-replay-from-headless-buffer` case header comment (the probe
  was always designed to keep passing after PR-F; this PR confirms it).

## Test plan

- [x] `npm run typecheck` — clean
- [x] focused vitest (ipcRegistrar + lifecycle + usePtyAttach): **63/63 pass**
- [x] full vitest: **1285/1310 pass** (25 failures are pre-existing
  `better-sqlite3` ABI mismatch in `db-hardening.test.ts`, env-only
  per #837 — same baseline noted in #602's body)
- [x] e2e harness `attach-replay-from-headless-buffer` (the #852-fixes probe):
  ```
  [HARNESS] >>> case: attach-replay-from-headless-buffer
  [HARNESS]   PR-B IPC ok: getBufferSnapshot('nonexistent') => snapshot="" seq=0
  [HARNESS]   PR-B headless snapshot for ed58f5e6-...: 1753 bytes, seq=8
  [HARNESS]   PR-B replay verified: 2 headless lines visible after switch-back
  [HARNESS] <<< PASS attach-replay-from-headless-buffer (17986ms)
  ```
- [x] e2e harness terminal-adjacent cases: `new-session-chat` (21.5s),
  `switch-session-keeps-chat` (27.4s), `pty-pid-stable-across-switch`
  (13.4s) — **3/3 PASS**.

## No regression on #852

The `attach-replay-from-headless-buffer` probe was authored as the e2e
contract test for PR-B's snapshot path — and explicitly noted in its
header that "PR-F will revert #602's hack; when it does, this probe
must STILL pass on the strength of replay alone". It does. The trust
prompt visibility now relies entirely on the L4 architecture, not on
the spawn-time workaround.