### PR TITLE
chore(sessionTitles): add forgetSid to release per-sid memory (#881)

### DIFF
--- a/electron/notify/bootstrap/installPipeline.ts
+++ b/electron/notify/bootstrap/installPipeline.ts
@@ -16,6 +16,7 @@ import { app, BrowserWindow } from 'electron';
 import { installNotifyPipeline } from '../sinks/pipeline';
 import { onPtyData } from '../../ptyHost';
 import { sessionWatcher } from '../../sessionWatcher';
+import { forgetSid as forgetSessionTitleSid } from '../../sessionTitles';
 
 export type NotifyPipeline = ReturnType<typeof installNotifyPipeline>;
 
@@ -65,10 +66,13 @@ export function installNotifyPipelineWithProducers(
 
   // Drop sniffer/ctx state when a session is unwatched (PTY exit). The
   // existing 'unwatched' emitter is reused so we don't add another teardown
-  // path.
+  // path. Also release the per-sid Maps held by sessionTitles (titleCache /
+  // opChains / pendingRenames) — without this, every sid ever queried for a
+  // title sticks in memory for the lifetime of the app (audit #876, H1).
   sessionWatcher.on('unwatched', (evt: { sid?: unknown }) => {
     if (!evt || typeof evt.sid !== 'string' || evt.sid.length === 0) return;
     pipelineInstance.forgetSid(evt.sid);
+    forgetSessionTitleSid(evt.sid);
   });
 
   return pipelineInstance;

--- a/electron/sessionTitles/__tests__/forgetSid.test.ts
+++ b/electron/sessionTitles/__tests__/forgetSid.test.ts
@@ -1,0 +1,127 @@
+// Unit tests for `forgetSid` — the per-sid Map releaser added for tech-debt
+// H1 (audit #876, task #881). Verifies that all three internal Maps
+// (titleCache / opChains / pendingRenames) drop their entry for a sid, that
+// in-flight renames don't throw on cleanup, and that repeat calls are
+// idempotent. SDK is fully mocked via the same `__setSdkForTests` seam used
+// by the rest of the bridge suite.
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const sdkMocks = {
+  getSessionInfo: vi.fn(),
+  renameSession: vi.fn(),
+  listSessions: vi.fn(),
+};
+
+import {
+  getSessionTitle,
+  renameSessionTitle,
+  enqueuePendingRename,
+  forgetSid,
+  __resetForTests,
+  __setSdkForTests,
+  __hasSidStateForTests,
+} from '../index';
+
+beforeEach(() => {
+  __resetForTests();
+  sdkMocks.getSessionInfo.mockReset();
+  sdkMocks.renameSession.mockReset();
+  sdkMocks.listSessions.mockReset();
+  __setSdkForTests(
+    sdkMocks as unknown as Parameters<typeof __setSdkForTests>[0]
+  );
+});
+
+describe('forgetSid releases all three per-sid Maps', () => {
+  it('drops titleCache, opChains, and pendingRenames for the sid', async () => {
+    sdkMocks.getSessionInfo.mockResolvedValue({
+      sessionId: 'sid-keep',
+      summary: 'cached',
+      lastModified: 1,
+    });
+
+    // 1. populate titleCache via a successful read
+    await getSessionTitle('sid-keep');
+    // 2. populate opChains via a settled rename (chain is held even after
+    //    the op resolves, since the Map keeps the last-promise pointer)
+    sdkMocks.renameSession.mockResolvedValue(undefined);
+    await renameSessionTitle('sid-keep', 'new title');
+    // 3. populate pendingRenames directly
+    enqueuePendingRename('sid-keep', 'pending title');
+
+    expect(__hasSidStateForTests('sid-keep')).toBe(true);
+
+    forgetSid('sid-keep');
+
+    expect(__hasSidStateForTests('sid-keep')).toBe(false);
+  });
+
+  it('does not affect entries for other sids', async () => {
+    sdkMocks.getSessionInfo.mockResolvedValue({
+      sessionId: 'whatever',
+      summary: 's',
+      lastModified: 1,
+    });
+    await getSessionTitle('sid-a');
+    await getSessionTitle('sid-b');
+
+    forgetSid('sid-a');
+
+    expect(__hasSidStateForTests('sid-a')).toBe(false);
+    expect(__hasSidStateForTests('sid-b')).toBe(true);
+  });
+});
+
+describe('forgetSid does not break in-flight rename', () => {
+  it('lets a pending rename resolve normally even when called mid-flight', async () => {
+    let resolveRename: (() => void) | null = null;
+    sdkMocks.renameSession.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRename = () => resolve();
+        })
+    );
+
+    // start the rename but don't await it yet — the chain is in flight
+    const renamePromise = renameSessionTitle('sid-flight', 'title');
+
+    // wait until the SDK mock is actually invoked (chain() awaits loadSdk()
+    // first, which yields a few microtasks)
+    for (let i = 0; i < 50 && resolveRename === null; i++) {
+      await Promise.resolve();
+    }
+    expect(__hasSidStateForTests('sid-flight')).toBe(true);
+
+    // forget mid-flight: must not throw, must not reject the in-flight op
+    expect(() => forgetSid('sid-flight')).not.toThrow();
+
+    // now resolve the SDK call; the original caller should still get { ok: true }
+    expect(resolveRename).not.toBeNull();
+    resolveRename!();
+    const result = await renamePromise;
+    expect(result).toEqual({ ok: true });
+  });
+});
+
+describe('forgetSid is idempotent and tolerant', () => {
+  it('does not throw when called twice for the same sid', () => {
+    enqueuePendingRename('sid-x', 't');
+    expect(() => forgetSid('sid-x')).not.toThrow();
+    expect(() => forgetSid('sid-x')).not.toThrow();
+    expect(__hasSidStateForTests('sid-x')).toBe(false);
+  });
+
+  it('does not throw for a sid never seen by the module', () => {
+    expect(() => forgetSid('sid-unseen')).not.toThrow();
+  });
+
+  it('ignores empty / non-string sid', () => {
+    enqueuePendingRename('real-sid', 't');
+    // bad inputs should be no-ops; the real sid stays intact
+    forgetSid('');
+    forgetSid(undefined as unknown as string);
+    forgetSid(null as unknown as string);
+    forgetSid(123 as unknown as string);
+    expect(__hasSidStateForTests('real-sid')).toBe(true);
+  });
+});

--- a/electron/sessionTitles/index.ts
+++ b/electron/sessionTitles/index.ts
@@ -248,6 +248,35 @@ export async function flushPendingRename(sid: string): Promise<void> {
   }
 }
 
+// ─────────────────────────── Per-sid cleanup ─────────────────────────────
+
+/**
+ * Release every per-sid Map entry held by this module. Called from the
+ * `sessionWatcher.on('unwatched', …)` listener in
+ * `electron/notify/bootstrap/installPipeline.ts` so a long-running ccsm
+ * process doesn't accumulate one entry per sid ever queried for the lifetime
+ * of the app (audit #876, tech-debt H1).
+ *
+ * Safety:
+ *   - Idempotent. `Map.delete` of an absent key is a no-op; calling
+ *     `forgetSid` twice for the same sid is fine.
+ *   - Doesn't throw, so the unwatched-event chain never breaks even if the
+ *     sid was never seen by this module.
+ *   - Doesn't cancel an in-flight rename. The serialization chain is held by
+ *     the local `next` variable inside `chain()`; deleting the Map entry only
+ *     drops the *next* op's predecessor link. A pending SDK call already
+ *     awaiting `loadSdk()` / `renameSession()` runs to completion and resolves
+ *     its caller's promise normally. The dropped chain pointer just means a
+ *     fresh sid-reuse won't serialize against the old in-flight op — which is
+ *     correct (the sid is "gone" from this module's POV).
+ */
+export function forgetSid(sid: string): void {
+  if (typeof sid !== 'string' || sid.length === 0) return;
+  titleCache.delete(sid);
+  opChains.delete(sid);
+  pendingRenames.delete(sid);
+}
+
 // ─────────────────────────── Test-only helpers ───────────────────────────
 
 /**
@@ -260,6 +289,17 @@ export function __resetForTests(): void {
   opChains.clear();
   pendingRenames.clear();
   sdkPromise = null;
+}
+
+/**
+ * Inspect internal Map state for tests. Returns `true` when ANY of the three
+ * per-sid Maps still holds an entry for `sid`. Used by `forgetSid` tests to
+ * assert full cleanup without exporting the Maps themselves.
+ */
+export function __hasSidStateForTests(sid: string): boolean {
+  return (
+    titleCache.has(sid) || opChains.has(sid) || pendingRenames.has(sid)
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Tech-debt H1 from audit #876. `electron/sessionTitles/index.ts` holds three per-sid Maps (`titleCache` line 105, `opChains` line 111, `pendingRenames` line 128) that grow without bound for the lifetime of the app — every sid ever queried sticks forever, and `pendingRenames` is a dead-letter queue (only flushed by watcher events, never on session exit).

This PR adds `forgetSid(sid)` and wires it into the existing `sessionWatcher.on('unwatched', ...)` listener in `electron/notify/bootstrap/installPipeline.ts`, so cleanup rides the existing PTY-exit teardown path with no new subscription or lifecycle.

## Changes

| File | LOC | What |
|---|---|---|
| `electron/sessionTitles/index.ts` | +40 | Export `forgetSid(sid)` (deletes from all three Maps; idempotent; tolerant of empty/non-string sid) + `__hasSidStateForTests(sid)` test seam |
| `electron/notify/bootstrap/installPipeline.ts` | +5/-1 | Import `forgetSid as forgetSessionTitleSid` and call it from the existing `'unwatched'` listener |
| `electron/sessionTitles/__tests__/forgetSid.test.ts` | +127 (new) | 6 UT cases |

## In-flight rename safety

The serialization chain in `chain()` holds the `next` promise via a local variable; `opChains.delete(sid)` only drops the *next* op's predecessor link. Any pending SDK call already awaiting `loadSdk()` / `renameSession()` runs to completion and resolves its caller's Promise normally. Test case "lets a pending rename resolve normally even when called mid-flight" asserts this.

## UT output (all green)

```
RUN  v4.1.5 C:/Users/jiahuigu/ccsm-worktrees/pool-9

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Duration  2.93s
```

Surrounding suites (`electron/sessionTitles` + `electron/notify/bootstrap`):

```
 Test Files  5 passed (5)
      Tests  46 passed (46)
```

`npm run typecheck` clean (both renderer + electron tsconfig).

## Reverse-verify

Removed `titleCache.delete(sid)` from `forgetSid`:

```
 FAIL  electron/sessionTitles/__tests__/forgetSid.test.ts > forgetSid releases all three per-sid Maps > does not affect entries for other sids
AssertionError: expected true to be false
 ❯ electron/sessionTitles/__tests__/forgetSid.test.ts:70:44
     70|     expect(__hasSidStateForTests('sid-a')).toBe(false);
       |                                            ^
 Tests  1 failed | 5 passed (6)
```

Restored → 6/6 PASS.

## Refs

- Audit: `~/.claude/projects/C--Users-jiahuigu/memory/project_implicit_state_audit_876.md` (#876)
- Tracker: Task #881