### PR TITLE
docs(notify): explicit decision matrix + DEV-only invariants (#885)

### DIFF
--- a/electron/notify/__tests__/notifyDecider.test.ts
+++ b/electron/notify/__tests__/notifyDecider.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   decide,
+  assertNotifyContext,
   USER_INIT_MUTE_MS,
   SHORT_TASK_MS,
   DEDUPE_MS,
@@ -234,5 +235,70 @@ describe('notifyDecider — purity', () => {
     expect(runStartTs.size).toBe(1);
     expect(mutedSids.size).toBe(1);
     expect(lastFiredTs.size).toBe(1);
+  });
+});
+
+describe('assertNotifyContext — DEV-only invariants (audit #876)', () => {
+  it('passes a fully-valid ctx without throwing', () => {
+    expect(() => assertNotifyContext(makeCtx())).not.toThrow();
+  });
+
+  it('passes when activeSid is a real string', () => {
+    expect(() => assertNotifyContext(makeCtx({ activeSid: 's1' }))).not.toThrow();
+  });
+
+  it('throws when ctx itself is null', () => {
+    expect(() => assertNotifyContext(null as unknown as Ctx)).toThrow(
+      /ctx must be an object/,
+    );
+  });
+
+  it('throws when focused is not a boolean', () => {
+    const bad = { ...makeCtx(), focused: 'yes' as unknown as boolean };
+    expect(() => assertNotifyContext(bad)).toThrow(/focused must be boolean/);
+  });
+
+  it('throws when activeSid is a number', () => {
+    const bad = { ...makeCtx(), activeSid: 42 as unknown as string };
+    expect(() => assertNotifyContext(bad)).toThrow(
+      /activeSid must be string\|null/,
+    );
+  });
+
+  it('throws when now is not a finite number', () => {
+    const bad = { ...makeCtx(), now: 'never' as unknown as number };
+    expect(() => assertNotifyContext(bad)).toThrow(/now must be a finite number/);
+  });
+
+  it('throws when lastUserInputTs is not a Map', () => {
+    const bad = {
+      ...makeCtx(),
+      lastUserInputTs: {} as unknown as Map<string, number>,
+    };
+    expect(() => assertNotifyContext(bad)).toThrow(
+      /lastUserInputTs must be a Map/,
+    );
+  });
+
+  it('throws when mutedSids is not a Set', () => {
+    const bad = {
+      ...makeCtx(),
+      mutedSids: [] as unknown as Set<string>,
+    };
+    expect(() => assertNotifyContext(bad)).toThrow(/mutedSids must be a Set/);
+  });
+
+  it('decide() invokes the invariant: passing a number activeSid throws via decide', () => {
+    const prev = process.env.NODE_ENV;
+    // Force non-production so the gate inside decide runs.
+    process.env.NODE_ENV = 'test';
+    try {
+      const bad = { ...makeCtx(), activeSid: 7 as unknown as string };
+      expect(() => decide(waiting('s1'), bad)).toThrow(
+        /activeSid must be string\|null/,
+      );
+    } finally {
+      process.env.NODE_ENV = prev;
+    }
   });
 });

--- a/electron/notify/notifyDecider.ts
+++ b/electron/notify/notifyDecider.ts
@@ -126,11 +126,101 @@ function evalRules(
 }
 
 /**
- * Pure decider. Returns a Decision when an OSC waiting event passes
- * all rules + dedupe; returns null otherwise (suppressed, deduped, or
- * the event is purely a context-update event).
+ * DEV-only invariant assertion on Ctx shape (audit #876 cluster 2.2).
+ *
+ * Intent: catch wiring bugs at the seam between pipeline / runStateTracker
+ * and the pure decider. The decider never narrows these types at runtime,
+ * so a stray `undefined` / number / wrong-collection slipping through
+ * silently mis-fires Rule 2 ("elapsed = 0 < 60s") and lights flashSink
+ * for every fresh sid (the original #767 class of bug).
+ *
+ * Production builds skip this — the call site is gated on NODE_ENV. Tests
+ * import it directly to exercise the failure paths.
+ */
+export function assertNotifyContext(ctx: Ctx): void {
+  if (typeof ctx !== 'object' || ctx === null) {
+    throw new Error(`notifyDecider: ctx must be an object, got ${typeof ctx}`);
+  }
+  if (typeof ctx.focused !== 'boolean') {
+    throw new Error(
+      `notifyDecider: ctx.focused must be boolean, got ${typeof ctx.focused}`,
+    );
+  }
+  if (ctx.activeSid !== null && typeof ctx.activeSid !== 'string') {
+    throw new Error(
+      `notifyDecider: ctx.activeSid must be string|null, got ${typeof ctx.activeSid}`,
+    );
+  }
+  if (typeof ctx.now !== 'number' || !Number.isFinite(ctx.now)) {
+    throw new Error(
+      `notifyDecider: ctx.now must be a finite number, got ${ctx.now}`,
+    );
+  }
+  if (!(ctx.lastUserInputTs instanceof Map)) {
+    throw new Error('notifyDecider: ctx.lastUserInputTs must be a Map');
+  }
+  if (!(ctx.runStartTs instanceof Map)) {
+    throw new Error('notifyDecider: ctx.runStartTs must be a Map');
+  }
+  if (!(ctx.lastFiredTs instanceof Map)) {
+    throw new Error('notifyDecider: ctx.lastFiredTs must be a Map');
+  }
+  if (!(ctx.mutedSids instanceof Set)) {
+    throw new Error('notifyDecider: ctx.mutedSids must be a Set');
+  }
+}
+
+/**
+ * Notification decision matrix (audit #876 cluster 2.2).
+ *
+ * 5 dimensions feed the decision (the first 3 live in Ctx; `muted` is per-sid
+ * via ctx.mutedSids; `globalMuted` is enforced one layer up in pipeline.ts
+ * before the tracker is even called):
+ *
+ *   focused              - BrowserWindow focus state
+ *   activeSid===sid      - is the renderer currently viewing this sid?
+ *   hasObservedRunning   - tracker-level gate; has this sid ever gone
+ *                          'running' in this process? (#767 boot-banner fix)
+ *   muted                - per-sid mute (ctx.mutedSids); set permanently by
+ *                          pipeline.markUserInput (see pipeline.ts ~line 178)
+ *                          and toggled by setMuted IPC
+ *   globalMuted          - app-wide mute (pipeline.isGlobalMutedFn)
+ *
+ * Plus two additional gates the decider applies last:
+ *   userInputRecent      - Rule 1 (lastUserInputTs[sid] within 60s)
+ *   dedupe               - 5s per-sid suppression on lastFiredTs
+ *
+ * | focused | active | hasRun | muted | global | result        | rule        |
+ * |---------|--------|--------|-------|--------|---------------|-------------|
+ * | *       | *      | *      | *     | T      | null          | global gate |
+ * | *       | *      | F      | *     | F      | null          | #767 gate   |
+ * | *       | *      | T      | *     | F      | null (R1)     | user-init   |
+ * | F       | *      | T      | F     | F      | toast + flash | R5          |
+ * | F       | *      | T      | T     | F      | flash only    | R7 (muted)  |
+ * | T       | F      | T      | F     | F      | toast + flash | R4          |
+ * | T       | F      | T      | T     | F      | flash only    | R7 (muted)  |
+ * | T       | T      | T      | F     | F      | flash only    | R2 (<60s)   |
+ * | T       | T      | T      | F     | F      | toast + flash | R3 (>=60s)  |
+ * | T       | T      | T      | T     | F      | flash only    | R7 (muted)  |
+ *
+ * After rule eval, a 5s per-sid dedupe (DEDUPE_MS) collapses any
+ * still-positive decision back to null if lastFiredTs[sid] is recent.
+ *
+ * Hidden side effect to be aware of:
+ *   pipeline.markUserInput() (sinks/pipeline.ts ~line 178) sets a PERMANENT
+ *   mute (untilTs = +Infinity). Rationale: when the user creates / imports /
+ *   resumes a session, that's an explicit attention act and further toasts
+ *   on that sid would interrupt rather than help. The mute is cleared only
+ *   on forgetSid (session teardown) or an explicit setMuted(false) IPC.
+ *
+ * `decide` itself remains pure — it does not mutate ctx, does not perform
+ * I/O, and returns the same Decision for the same (event, ctx) input.
  */
 export function decide(event: Event, ctx: Ctx): Decision | null {
+  if (process.env.NODE_ENV !== 'production') {
+    assertNotifyContext(ctx);
+  }
+
   // Context-update-only events produce no decision; the caller is
   // responsible for updating ctx.
   if (event.type !== 'osc-title') {

--- a/electron/notify/sinks/pipeline.ts
+++ b/electron/notify/sinks/pipeline.ts
@@ -175,6 +175,13 @@ export function installNotifyPipeline(opts: NotifyPipelineOptions): NotifyPipeli
       // session is torn down (forgetSid clears the mute) or an explicit
       // un-mute lands. This supersedes the decider's Rule 1 60s window
       // for the create/import/resume IPC paths that go through here.
+      //
+      // audit #876 cluster 2.2: this is a HIDDEN SIDE EFFECT — the method
+      // name reads as "remember a user input event" but the actual
+      // operation is `setMuted(sid, +Infinity)`, i.e. PERMANENT mute on
+      // that sid. Cleared only by forgetSid (session teardown) or explicit
+      // setMuted(sid, false). If you rename or refactor this, surface the
+      // mute semantics in the new name (e.g. `markUserInitAndMute`).
       tracker.setMuted(sid, Number.POSITIVE_INFINITY);
     },
     setActiveSid(sid) {


### PR DESCRIPTION
## Scope

Tech-debt M3 from audit #876 cluster 2.2. **Comment-only + assertion changes; zero logic change.**

## Why

The notify subsystem decision uses 5 dimensions (`focused` x `activeSid===sid` x `hasObservedRunning` x `muted` x `globalMuted`) but the truth table was spread across three files (`notifyDecider.ts`, `runStateTracker.ts`, `sinks/pipeline.ts`). A future reader (or future me) could not see the full picture from any single entry point. Additionally, `pipeline.markUserInput()` has a hidden side effect: it sets a **permanent** mute (`untilTs = +Infinity`), which the method name does not advertise.

## What

1. **`notifyDecider.decide` doc block**: prepend an explicit 5x5 truth table covering all gates including `hasObservedRunning` (tracker layer) and `globalMuted` (pipeline layer), plus an explicit callout for the `markUserInput` permanent-mute side effect.
2. **`notifyDecider.assertNotifyContext`**: new DEV-only invariant function. Validates `Ctx` shape (focused boolean, activeSid string|null, now finite number, the four collections are real Map/Set instances). Called from `decide()` gated on `process.env.NODE_ENV !== 'production'`. Catches the wiring-bug class that originally produced #767 (a stray `undefined`/number slipping through silently mis-fires Rule 2's `elapsed = 0 < 60s` and lights flashSink for every fresh sid).
3. **`sinks/pipeline.ts` markUserInput**: amend existing comment to flag the permanent-mute semantic with explicit audit #876 tag, so any future rename/refactor surfaces the mute behavior in the new name.

## Decision matrix excerpt

```
| focused | active | hasRun | muted | global | result        | rule        |
|---------|--------|--------|-------|--------|---------------|-------------|
| *       | *      | *      | *     | T      | null          | global gate |
| *       | *      | F      | *     | F      | null          | #767 gate   |
| *       | *      | T      | *     | F      | null (R1)     | user-init   |
| F       | *      | T      | F     | F      | toast + flash | R5          |
| F       | *      | T      | T     | F      | flash only    | R7 (muted)  |
| T       | F      | T      | F     | F      | toast + flash | R4          |
| T       | T      | T      | F     | F      | flash only    | R2 (<60s)   |
| T       | T      | T      | F     | F      | toast + flash | R3 (>=60s)  |
```

## Tests

- 9 new cases for `assertNotifyContext`: valid ctx passes (2), each invalid field throws (6), `decide()` integration confirms the NODE_ENV gate fires (1).
- All 26 `notifyDecider.test.ts` cases PASS. Full notify suite: 71/71 PASS.
- Typecheck clean.

## Reverse-verify

Disabling the assertion gate (`if (false && process.env.NODE_ENV !== 'production')`) caused the integration case to FAIL exactly as expected:

```
FAIL  electron/notify/__tests__/notifyDecider.test.ts > assertNotifyContext - DEV-only invariants (audit #876) > decide() invokes the invariant: passing a number activeSid throws via decide
AssertionError: expected [Function] to throw an error
- Expected: null
+ Received: undefined
```

Restored gate -> 26/26 PASS.

## Out of scope

- No behavior change. Decider rule eval is byte-identical.
- No new state. No new IPC. No renderer change.
- Pre-existing failures in `tests/electron-load-smoke.test.ts` (18) and `electron/__tests__/db-hardening.test.ts` (3) verified on origin/working tip baseline; unrelated.

## Refs

- Audit: `~/.claude/projects/.../memory/project_implicit_state_audit_876.md` cluster 2.2
- Related: #767 (the bug class the invariant catches), #721 (tracker extraction), #743 (pipeline thinning)