### PR TITLE
feat(build): dual-install dev/prod variants (#891)

### DIFF
--- a/electron/__tests__/updater.test.ts
+++ b/electron/__tests__/updater.test.ts
@@ -25,6 +25,7 @@ const autoUpdaterEmitter = new EventEmitter();
 const state = {
   appIsPackaged: true,
   appVersion: '0.1.2',
+  appName: 'CCSM',
   checkForUpdatesImpl: (async () => ({ updateInfo: {} })) as () => Promise<unknown>,
   downloadUpdateImpl: (async () => undefined) as () => Promise<unknown>
 };
@@ -50,7 +51,8 @@ vi.mock('electron', () => {
     get isPackaged() {
       return state.appIsPackaged;
     },
-    getVersion: () => state.appVersion
+    getVersion: () => state.appVersion,
+    getName: () => state.appName
   };
   return { ipcMain, BrowserWindow, app };
 });
@@ -59,6 +61,7 @@ vi.mock('electron-updater', () => {
   const autoUpdater = {
     autoDownload: false,
     autoInstallOnAppQuit: false,
+    allowPrerelease: false,
     logger: null as unknown,
     on: (event: string, listener: Listener) => {
       autoUpdaterEmitter.on(event, listener);
@@ -79,6 +82,7 @@ function resetState() {
   quitAndInstallCalls.length = 0;
   state.appIsPackaged = true;
   state.appVersion = '0.1.2';
+  state.appName = 'CCSM';
   state.checkForUpdatesImpl = async () => ({ updateInfo: {} });
   state.downloadUpdateImpl = async () => undefined;
 }
@@ -118,6 +122,27 @@ describe('updater: IPC wiring', () => {
     const { autoUpdater } = await import('electron-updater');
     expect(autoUpdater.autoDownload).toBe(true);
     expect(autoUpdater.autoInstallOnAppQuit).toBe(true);
+  });
+
+  it('leaves allowPrerelease=false for the prod variant (#891)', async () => {
+    const { autoUpdater } = await import('electron-updater');
+    // Default reset state has appName='CCSM' so installUpdaterIpc must NOT
+    // flip allowPrerelease — prod users only see stable releases.
+    expect(autoUpdater.allowPrerelease).toBe(false);
+  });
+
+  it('flips allowPrerelease=true for the dev variant (#891)', async () => {
+    // Override appName before re-importing so the dual-install branch fires.
+    state.appName = 'CCSM Dev';
+    const mod = await import('../updater');
+    mod.__resetUpdaterForTests();
+    // Reset the mock field too — module-scoped mock object survives across
+    // freshModule() calls in beforeEach, so the prior installUpdaterIpc may
+    // have left it at its default. Force a known starting point.
+    const { autoUpdater } = await import('electron-updater');
+    autoUpdater.allowPrerelease = false;
+    mod.installUpdaterIpc();
+    expect(autoUpdater.allowPrerelease).toBe(true);
   });
 
   it('broadcasts status on update-available and fires update:available channel', () => {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -169,7 +169,12 @@ app.whenReady().then(() => {
   // On Windows, set a stable AppUserModelID so the OS attributes the app to
   // its taskbar / Start Menu entry instead of generic "electron.exe".
   if (process.platform === 'win32') {
-    app.setAppUserModelId('com.ccsm.app');
+    // Dual-install (#891): the dev variant ships as productName "CCSM Dev"
+    // and must use a distinct AUMID so its taskbar / toast attribution
+    // doesn't collide with a co-installed prod build.
+    const isDevVariant = app.getName().includes('Dev');
+    const aumid = isDevVariant ? 'com.ccsm.app.dev' : 'com.ccsm.app';
+    app.setAppUserModelId(aumid);
   }
 
   initDb();

--- a/electron/updater.ts
+++ b/electron/updater.ts
@@ -98,6 +98,14 @@ export function installUpdaterIpc(): void {
   autoUpdater.autoInstallOnAppQuit = true;
   autoUpdater.logger = null;
 
+  // Dual-install (#891): the dev variant pulls GitHub pre-releases so we can
+  // ship release candidates / dogfood builds without affecting prod users
+  // (prod's autoUpdater leaves allowPrerelease=false, so it skips them).
+  // No early return — dev MUST exercise the full updater flow to validate it.
+  if (app.getName().includes('Dev')) {
+    autoUpdater.allowPrerelease = true;
+  }
+
   autoUpdater.on('checking-for-update', () => broadcast({ kind: 'checking' }));
   autoUpdater.on('update-available', (info) =>
     broadcast({

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "probe:e2e": "npm run build && node scripts/run-all-e2e.mjs",
     "make": "npm run build && electron-builder --publish never",
     "make:win": "npm run build && electron-builder --win --publish never",
+    "make:win:dev": "npm run build && electron-builder --win --publish never --config.productName=\"CCSM Dev\" --config.extraMetadata.productName=\"CCSM Dev\" --config.appId=com.ccsm.app.dev --config.nsis.shortcutName=\"CCSM Dev\"",
     "make:mac": "npm run build && electron-builder --mac --publish never",
     "make:linux": "npm run build && electron-builder --linux --publish never",
     "build:icon": "electron scripts/build-icon.cjs",

--- a/scripts/setup-aumid.ps1
+++ b/scripts/setup-aumid.ps1
@@ -12,12 +12,19 @@
 
   Idempotent: re-running overwrites the shortcut in place.
 
+.PARAMETER Variant
+  Either `prod` (default) or `dev`. Picks the matching AUMID + shortcut
+  name pair for dual-install (#891). Explicit -AppId / -ShortcutName
+  override this default.
+
 .PARAMETER AppId
   The AUMID string to register. Must match the `appId` passed to
-  `Notifier.create` from `electron/main.ts` (currently `com.ccsm.app`).
+  `Notifier.create` from `electron/main.ts` (`com.ccsm.app` for prod,
+  `com.ccsm.app.dev` for dev). Defaults from -Variant if omitted.
 
 .PARAMETER ShortcutName
-  Display name of the Start Menu shortcut. Defaults to "CCSM Dev".
+  Display name of the Start Menu shortcut. Defaults from -Variant
+  (`CCSM` for prod, `CCSM Dev` for dev).
 
 .PARAMETER TargetExe
   Absolute path to the .exe Windows should launch when the toast body is
@@ -38,13 +45,25 @@
 
 [CmdletBinding()]
 param(
-  [string]$AppId = 'com.ccsm.app',
-  [string]$ShortcutName = 'CCSM Dev',
+  [ValidateSet('prod', 'dev')]
+  [string]$Variant = 'prod',
+  [string]$AppId = $null,
+  [string]$ShortcutName = $null,
   [string]$TargetExe = $null,
   [string]$Arguments = $null
 )
 
 $ErrorActionPreference = 'Stop'
+
+# Dual-install (#891): -Variant picks the AUMID + shortcut name pair so the
+# dev build's toasts route to its own Start Menu entry instead of colliding
+# with the prod install. Explicit -AppId / -ShortcutName still win.
+if (-not $AppId) {
+  $AppId = if ($Variant -eq 'dev') { 'com.ccsm.app.dev' } else { 'com.ccsm.app' }
+}
+if (-not $ShortcutName) {
+  $ShortcutName = if ($Variant -eq 'dev') { 'CCSM Dev' } else { 'CCSM' }
+}
 
 # Resolve the repo root (parent of /scripts).
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path


### PR DESCRIPTION
## Summary
Enable a co-installable **CCSM Dev** build that does not collide with the prod **CCSM** install on the same Windows machine. Implements task #891.

- AUMID derived from `app.getName()` (dev = `com.ccsm.app.dev`, prod = `com.ccsm.app`) so taskbar + toast attribution stays independent.
- electron-updater `allowPrerelease` flipped to `true` for the dev variant so we can ship release candidates / dogfood builds via GitHub pre-releases without touching prod users.
- New `make:win:dev` npm script uses electron-builder CLI overrides only — no second `electron-builder.yml`, no fork of the `build` block in `package.json`. Produces `release/CCSM Dev-Setup-<ver>-x64.exe`.
- `scripts/setup-aumid.ps1` gains a `-Variant {prod|dev}` parameter (default `prod`) so the dev AUMID can be registered for toast routing during ad-hoc dev runs.

`%APPDATA%` isolation comes for free: Electron derives `userData` from `appId`, so prod (`com.ccsm.app`) and dev (`com.ccsm.app.dev`) each get their own `%APPDATA%\CCSM*` folder and their own single-instance lock — verified by reading `electron/lifecycle/singleInstance.ts` (uses `app.requestSingleInstanceLock()` which is keyed on userData). No code change needed there.

`~/.claude` is shared by design (decision #2 — no isolation).

## Files changed
| File | +/- |
|---|---|
| `electron/main.ts` | +6 / −1 |
| `electron/updater.ts` | +8 / −0 |
| `package.json` | +1 / −0 |
| `scripts/setup-aumid.ps1` | +23 / −4 |
| `electron/__tests__/updater.test.ts` | +26 / −1 |
| **Total** | **+64 / −6** |

## Decisions inherited from manager
1. Dev productName = `"CCSM Dev"` (with space) — used as is.
2. `CLAUDE_CONFIG_DIR` is **shared** between prod and dev — no code change; default behavior already shares.
3. Auto-updater in dev must work end-to-end → `autoUpdater.allowPrerelease = true` for the dev variant. No early-return; same publish target (`Jiahui-Gu/ccsm` GitHub releases). Prod skips pre-releases by default.
4. Single `package.json` build block + CLI overrides + new `make:win:dev`. **No** new `electron-builder.dev.yml` file.

## Test plan
- [x] `npm run typecheck` — passes (both `tsc --noEmit` invocations).
- [x] `npx vitest run electron/__tests__/updater.test.ts` — 15/15 pass (13 original + 2 new for the prerelease branch).
- [x] `npm run make:win:dev` — produced `release/CCSM Dev-Setup-0.1.0-x64.exe` (173 MB, signtool-signed).
- [x] Verified the unpacked exe metadata via `Get-Item 'CCSM Dev.exe').VersionInfo`: `ProductName: CCSM Dev`, `FileVersion: 0.1.0`.
- [x] Extracted bundled `package.json` from `app.asar`: `productName: "CCSM Dev"` correctly merged via `extraMetadata`. Source `package.json` is untouched (`git diff` shows only the new script line).
- [ ] Manual install of the dev exe on a machine that already has prod CCSM installed — **NOT done by worker** (would mutate the user's machine). Manager / reviewer should smoke-install once and confirm:
  - Both shortcuts coexist in Start Menu (`CCSM` + `CCSM Dev`).
  - `%APPDATA%\CCSM` and `%APPDATA%\CCSM Dev` are independent.
  - Both apps can run simultaneously (single-instance lock is per-appId).

## Follow-ups (not addressed in this PR)
- **Sentry release tagging** — both variants currently report under the same Sentry project / release tag. If we want to split dev crashes from prod crashes in Sentry, we should tag the release with the variant in `electron/sentry/init.ts` (e.g. `release: \`ccsm-dev@${version}\` vs `ccsm@${version}`). Flagged for a follow-up task.
- `make:mac:dev` / `make:linux:dev` analogues are not in scope for this PR — Windows-only per #891.
- `setup-aumid.ps1`'s `-Variant` change is opt-in; existing callers without the flag continue to register the prod AUMID (same default as before).

## Layer 1 (necessity)
Already validated by the evaluator subagent before dispatch. No cheaper path discovered during implementation — portable build still wouldn't satisfy the "auto-updater works end-to-end in dev" requirement, and a single env var can't carve a separate `userData` directory after the fact (it would orphan prod's data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)