### PR TITLE
fix(lifecycle): complete deleteSession fan-out for badge/flash/crashed (#882)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -259,6 +259,13 @@ app.whenReady().then(() => {
     onNotified: (sid) => {
       badgeManager?.incrementSid(sid);
     },
+    // audit #876 H2: drop the sid's unread counter when the session is
+    // unwatched (PTY exit / kill). Without this the badgeStore.unread map
+    // accumulated entries forever — every notified sid stayed counted for
+    // the app lifetime even after the session was deleted.
+    onUnwatchedSid: (sid) => {
+      badgeManager?.clearSid(sid);
+    },
   });
   // Hoist into the module-level holder so the IPC handlers above (registered
   // earlier in app.whenReady) can reach the pipeline. The handlers run later

--- a/electron/notify/bootstrap/__tests__/installPipeline.test.ts
+++ b/electron/notify/bootstrap/__tests__/installPipeline.test.ts
@@ -208,6 +208,49 @@ describe('installNotifyPipelineWithProducers', () => {
     expect(h.lastPipeline.current!.forgetSid).not.toHaveBeenCalled();
   });
 
+  // audit #876 H2: when a session is unwatched, the badge unread counter
+  // for that sid must be drained too. Without this fan-out the badge
+  // store accumulated entries forever — every notified sid stayed counted
+  // for the app lifetime even after the session was deleted.
+  it("sessionWatcher 'unwatched' forwards onUnwatchedSid for badge drain", () => {
+    const onUnwatchedSid = vi.fn();
+    installNotifyPipelineWithProducers({
+      getNameFn: () => null,
+      isGlobalMutedFn: () => false,
+      onNotified: () => {},
+      onUnwatchedSid,
+    });
+    h.watcherEmitter.emit('unwatched', { sid: 's1' });
+    expect(onUnwatchedSid).toHaveBeenCalledWith('s1');
+    expect(h.lastPipeline.current!.forgetSid).toHaveBeenCalledWith('s1');
+  });
+
+  it("sessionWatcher 'unwatched' does not invoke onUnwatchedSid for malformed payloads", () => {
+    const onUnwatchedSid = vi.fn();
+    installNotifyPipelineWithProducers({
+      getNameFn: () => null,
+      isGlobalMutedFn: () => false,
+      onNotified: () => {},
+      onUnwatchedSid,
+    });
+    h.watcherEmitter.emit('unwatched', undefined);
+    h.watcherEmitter.emit('unwatched', null);
+    h.watcherEmitter.emit('unwatched', {});
+    h.watcherEmitter.emit('unwatched', { sid: 123 });
+    h.watcherEmitter.emit('unwatched', { sid: '' });
+    expect(onUnwatchedSid).not.toHaveBeenCalled();
+  });
+
+  it('omitting onUnwatchedSid is allowed (optional dep)', () => {
+    installNotifyPipelineWithProducers({
+      getNameFn: () => null,
+      isGlobalMutedFn: () => false,
+      onNotified: () => {},
+    });
+    expect(() => h.watcherEmitter.emit('unwatched', { sid: 's1' })).not.toThrow();
+    expect(h.lastPipeline.current!.forgetSid).toHaveBeenCalledWith('s1');
+  });
+
   it('returns the live pipeline instance', () => {
     const ret = installNotifyPipelineWithProducers({
       getNameFn: () => null,

--- a/electron/notify/bootstrap/installPipeline.ts
+++ b/electron/notify/bootstrap/installPipeline.ts
@@ -28,6 +28,11 @@ export interface NotifyPipelineDeps {
   isGlobalMutedFn: () => boolean;
   /** Side-effect when a notification fires (badge bump). */
   onNotified: (sid: string) => void;
+  /** Side-effect when a session is unwatched (PTY exit / kill).
+   *  Used to drain badge unread counts so deleted/torn-down sessions
+   *  don't leave stale entries that inflate the aggregate badge total
+   *  forever (audit #876 H2). Optional for tests that don't care. */
+  onUnwatchedSid?: (sid: string) => void;
 }
 
 /** Construct the pipeline and wire the producer subscriptions. Returns the
@@ -69,10 +74,14 @@ export function installNotifyPipelineWithProducers(
   // path. Also release the per-sid Maps held by sessionTitles (titleCache /
   // opChains / pendingRenames) — without this, every sid ever queried for a
   // title sticks in memory for the lifetime of the app (audit #876, H1).
+  // Finally, fan out to `onUnwatchedSid` so callers (main.ts) can drain
+  // their own per-sid stores — e.g. badgeManager.unread, which would
+  // otherwise inflate the aggregate badge total forever (audit #876 H2).
   sessionWatcher.on('unwatched', (evt: { sid?: unknown }) => {
     if (!evt || typeof evt.sid !== 'string' || evt.sid.length === 0) return;
     pipelineInstance.forgetSid(evt.sid);
     forgetSessionTitleSid(evt.sid);
+    deps.onUnwatchedSid?.(evt.sid);
   });
 
   return pipelineInstance;

--- a/src/stores/slices/sessionCrudSlice.ts
+++ b/src/stores/slices/sessionCrudSlice.ts
@@ -313,10 +313,27 @@ export function createSessionCrudSlice(set: SetFn, get: GetFn): SessionCrudSlice
             nextActive = remaining[0]?.id ?? '';
           }
         }
-        return {
+        // audit #876 H2: deleteSession fan-out must drain every per-sid
+        // store, not just the sessions array. Without this, flashStates
+        // and disconnectedSessions accumulate entries for deleted sids
+        // (the only other clear paths are PTY-exit IPC, which doesn't
+        // fire for sessions that never spawned a PTY, and a re-spawn that
+        // overwrites the entry — both are best-effort, not delete-time).
+        const patch: Partial<RootStore> = {
           sessions: remaining,
           activeId: nextActive,
         };
+        if (s.flashStates && s.flashStates[id]) {
+          const next = { ...s.flashStates };
+          delete next[id];
+          patch.flashStates = next;
+        }
+        if (s.disconnectedSessions && s.disconnectedSessions[id]) {
+          const next = { ...s.disconnectedSessions };
+          delete next[id];
+          patch.disconnectedSessions = next;
+        }
+        return patch;
       });
       deleteDrafts([id]);
       try {

--- a/tests/stores/slices/sessionCrudSlice.test.ts
+++ b/tests/stores/slices/sessionCrudSlice.test.ts
@@ -248,4 +248,70 @@ describe('sessionCrudSlice', () => {
     expect(h.state().sessions[0].id).toBe('uuid-y');
     expect(h.state().sessions[0].name).toBe('imported');
   });
+
+  // audit #876 H2: deleteSession fan-out must drain every per-sid renderer
+  // store, not just `sessions`. Without this fix flashStates[sid] and
+  // disconnectedSessions[sid] survived the delete and could re-attach to a
+  // re-imported session with the same sid (stale crashed badge / phantom
+  // halo). The cleanup is unconditional — even if the maps are empty, the
+  // delete path is the right place to express "forget everything about
+  // this sid".
+  describe('deleteSession fan-out (audit #876 H2)', () => {
+    it('clears flashStates[sid] for the deleted session', () => {
+      const h = harness({
+        sessions: [mkSession('a', 'g1'), mkSession('b', 'g1')],
+        groups: [{ id: 'g1', name: 'g1', collapsed: false, kind: 'normal' }],
+        activeId: 'a',
+        flashStates: { a: true, b: true },
+      });
+      h.sessions.deleteSession('a');
+      expect(h.state().flashStates).toEqual({ b: true });
+    });
+
+    it('clears disconnectedSessions[sid] for the deleted session', () => {
+      const h = harness({
+        sessions: [mkSession('a', 'g1'), mkSession('b', 'g1')],
+        groups: [{ id: 'g1', name: 'g1', collapsed: false, kind: 'normal' }],
+        activeId: 'a',
+        disconnectedSessions: {
+          a: { kind: 'crashed', code: 1, signal: null, at: 1 },
+          b: { kind: 'clean', code: 0, signal: null, at: 2 },
+        },
+      });
+      h.sessions.deleteSession('a');
+      expect(h.state().disconnectedSessions).toEqual({
+        b: { kind: 'clean', code: 0, signal: null, at: 2 },
+      });
+    });
+
+    it('preserves identity when the sid was not present in either map', () => {
+      const h = harness({
+        sessions: [mkSession('a', 'g1')],
+        groups: [{ id: 'g1', name: 'g1', collapsed: false, kind: 'normal' }],
+        activeId: 'a',
+        flashStates: { other: true },
+        disconnectedSessions: {
+          other: { kind: 'clean', code: 0, signal: null, at: 1 },
+        },
+      });
+      h.sessions.deleteSession('a');
+      // Untouched contents (and same map identity is preserved internally
+      // so React selectors don't needlessly re-render).
+      expect(h.state().flashStates).toEqual({ other: true });
+      expect(h.state().disconnectedSessions).toEqual({
+        other: { kind: 'clean', code: 0, signal: null, at: 1 },
+      });
+    });
+
+    it('tolerates missing maps (slice composed without sessionRuntimeSlice)', () => {
+      const h = harness({
+        sessions: [mkSession('a', 'g1')],
+        groups: [{ id: 'g1', name: 'g1', collapsed: false, kind: 'normal' }],
+        activeId: 'a',
+      });
+      // Both maps are undefined on this harness; delete must not throw.
+      expect(() => h.sessions.deleteSession('a')).not.toThrow();
+      expect(h.state().sessions).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Audit #876 H2: `deleteSession` left per-sid state in three sinks. This PR drains all three so a deleted session leaves no trace.

| Sink | Process | Leak path | Fix |
|---|---|---|---|
| `badgeStore.unread[id]` | main | toast fires → counter inflated forever; nothing called `clearSid` on session teardown | wire via existing `sessionWatcher.on('unwatched')` in `installPipeline.ts` (new optional `onUnwatchedSid` dep), `main.ts` passes `(sid) => badgeManager?.clearSid(sid)` |
| `flashStates[id]` | renderer | only cleared by main->renderer flashSink IPC, which fires on PTY exit; sessions with no PTY (or with stale flash from a previous run) leaked | `sessionCrudSlice.deleteSession` drains the entry directly |
| `disconnectedSessions[id]` | renderer | only cleared by `_applyPtyExit` on re-spawn — never on delete | same fix in `sessionCrudSlice.deleteSession` |

Pattern mirrors PR #881 (sessionTitles `forgetSid`). Single coherent fan-out expansion — not three unrelated cleanups.

## Files (5)
- `electron/main.ts` — pass `onUnwatchedSid` to drain badge.
- `electron/notify/bootstrap/installPipeline.ts` — accept `onUnwatchedSid`, invoke from existing unwatched handler.
- `electron/notify/bootstrap/__tests__/installPipeline.test.ts` — 3 new tests.
- `src/stores/slices/sessionCrudSlice.ts` — drain `flashStates[id]` + `disconnectedSessions[id]` in `deleteSession`. Identity-preserved when sid absent (no needless React re-renders); tolerates missing maps (slice composability).
- `tests/stores/slices/sessionCrudSlice.test.ts` — 4 new tests under `deleteSession fan-out (audit #876 H2)`.

## Test plan
- [x] Unit tests pass: `npx vitest run tests/stores/slices/sessionCrudSlice.test.ts electron/notify/bootstrap/__tests__/installPipeline.test.ts` -> **32 passed**.
- [x] Broader sanity: `npx vitest run electron/notify electron/sessionTitles tests/stores` -> **226 passed**.
- [x] Typecheck: `npx tsc --noEmit` -> clean.
- [x] Reverse-verify (cleanup disabled in both impl files, tests unchanged):
  ```
  Test Files  2 failed (2)
  Tests       3 failed | 29 passed (32)
  - flashStates[sid] for the deleted session: expected {b: true} got {a: true, b: true}
  - disconnectedSessions[sid] for the deleted session: expected {b:...} got {a:..., b:...}
  - onUnwatchedSid forwards for badge drain: expected vi.fn() called with ['s1'], called 0 times
  ```
  Restored:
  ```
  Test Files  2 passed (2)
  Tests       32 passed (32)
  ```
- [ ] CI green on PR.

Trust CI mode: not running e2e probe locally; the leak is a state-store assertion best covered by unit tests on the slice + the bootstrap wiring (the only observable signal of the fix is the Map size, which the unit test asserts directly).