### PR TITLE
fix(lifecycle): drain sessionNamesFromRenderer on unwatched (#897)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -270,6 +270,10 @@ app.whenReady().then(() => {
     // the app lifetime even after the session was deleted.
     onUnwatchedSid: (sid) => {
       badgeManager?.clearSid(sid);
+      // audit #876 Item 5: drop the renderer-pushed name mirror too. Without
+      // this, every renamed session leaks its entry forever — the map only
+      // grew, never shrank, since the IPC handler is the only producer.
+      sessionNamesFromRenderer.delete(sid);
     },
   });
   // Hoist into the module-level holder so the IPC handlers above (registered

--- a/electron/notify/bootstrap/__tests__/installPipeline.test.ts
+++ b/electron/notify/bootstrap/__tests__/installPipeline.test.ts
@@ -225,6 +225,27 @@ describe('installNotifyPipelineWithProducers', () => {
     expect(h.lastPipeline.current!.forgetSid).toHaveBeenCalledWith('s1');
   });
 
+  // audit #876 Item 5 (Task #897): main.ts holds a sessionNamesFromRenderer
+  // Map that the renderer pushes into via session:setName IPC. Without a
+  // drain in onUnwatchedSid, every renamed session leaks its entry forever.
+  // This test mirrors the main.ts wiring (a real Map + a delete in the
+  // onUnwatchedSid callback) to lock the contract end-to-end.
+  it("sessionWatcher 'unwatched' lets caller drain a per-sid Map (sessionNamesFromRenderer)", () => {
+    const sessionNamesFromRenderer = new Map<string, string>();
+    sessionNamesFromRenderer.set('sid-x', 'name-x');
+    installNotifyPipelineWithProducers({
+      getNameFn: (sid) => sessionNamesFromRenderer.get(sid) ?? null,
+      isGlobalMutedFn: () => false,
+      onNotified: () => {},
+      onUnwatchedSid: (sid) => {
+        sessionNamesFromRenderer.delete(sid);
+      },
+    });
+    expect(sessionNamesFromRenderer.has('sid-x')).toBe(true);
+    h.watcherEmitter.emit('unwatched', { sid: 'sid-x' });
+    expect(sessionNamesFromRenderer.has('sid-x')).toBe(false);
+  });
+
   it("sessionWatcher 'unwatched' does not invoke onUnwatchedSid for malformed payloads", () => {
     const onUnwatchedSid = vi.fn();
     installNotifyPipelineWithProducers({


### PR DESCRIPTION
## Bug

`electron/main.ts:103` declares `const sessionNamesFromRenderer = new Map<string, string>()`. The renderer pushes into it via `session:setName` IPC at `electron/main.ts:212-215`. Until now the entry was **never deleted** — every renamed session leaked its name string for the lifetime of the app (audit #876 Item 5).

## Fix

Hook the existing `onUnwatchedSid` fan-out at `electron/main.ts:271` (already used to drain `badgeStore.unread`). One added line:

```ts
onUnwatchedSid: (sid) => {
  badgeManager?.clearSid(sid);
  sessionNamesFromRenderer.delete(sid);  // NEW
},
```

The fan-out itself fires from `electron/notify/bootstrap/installPipeline.ts:84` on `sessionWatcher.emit('unwatched', { sid })` (PTY exit / kill). Same pattern as the badge drain and the title-cache drain (#876 H1/H2).

## Test

Added `installPipeline.test.ts` case that mirrors the main.ts wiring with a real `Map`, locks the contract end-to-end:

```
RUN  v4.1.5
Test Files  1 passed (1)
     Tests  12 passed (12)
  Duration  3.72s
```

## Reverse-verify

Commented out `sessionNamesFromRenderer.delete(sid)` in the test's onUnwatchedSid callback:

```
FAIL  electron/notify/bootstrap/__tests__/installPipeline.test.ts >
       sessionWatcher 'unwatched' lets caller drain a per-sid Map (sessionNamesFromRenderer)
AssertionError: expected true to be false
- false
+ true
 ❯ installPipeline.test.ts:247:51
   245|     expect(sessionNamesFromRenderer.has('sid-x')).toBe(true);
   246|     h.watcherEmitter.emit('unwatched', { sid: 'sid-x' });
   247|     expect(sessionNamesFromRenderer.has('sid-x')).toBe(false);

Test Files  1 failed (1)
     Tests  1 failed | 11 passed (12)
```

Restored → 12/12 pass.

## Diff

```
electron/main.ts                                    |  4 ++++
electron/notify/bootstrap/__tests__/installPipeline.test.ts | 21 +++++++++++++++++++++
2 files changed, 25 insertions(+)
```

## Quality gates

- `npm run lint`: 0 errors (92 pre-existing warnings, untouched)
- `npm run typecheck`: PASS
- `npm test`: 1282 pass / 21 fail — all 21 failures pre-existing env issues (`better-sqlite3` native binding rebuild + `electron-load-smoke` needing `dist/electron` from `npm run build`), unrelated to this change.