### PR TITLE
fix(app): gate newSession on claudeAvailable to prevent blank-pane (#900, #852)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { DragRegion, WindowControls } from './components/WindowControls';
 import { InstallerCorruptBanner } from './components/InstallerCorruptBanner';
 import { useStore } from './stores/store';
 import { initI18n } from './i18n';
+import { useTranslation } from './i18n/useTranslation';
 import { usePreferences } from './store/preferences';
 import { useThemeEffect } from './app-effects/useThemeEffect';
 import { useLanguageEffect } from './app-effects/useLanguageEffect';
@@ -64,6 +65,7 @@ function AppEffectsBridge(): null {
 }
 
 export default function App() {
+  const { t } = useTranslation();
   const sessions = useStore((s) => s.sessions);
   const flashStates = useStore((s) => s.flashStates);
   const activeId = useStore((s) => s.activeId);
@@ -246,7 +248,27 @@ export default function App() {
   // We still blur the trigger element synchronously so repeated Enter
   // presses on the "New session" button do not spawn extra sessions
   // before xterm has had a chance to take focus.
+  // `claudeAvailableRef` mirrors the boot probe state for the gate below.
+  // We read it inside `newSession` instead of closing over the React state
+  // because the callback is also passed down to long-lived consumers
+  // (Sidebar, CommandPalette) and we want the latest probe value without
+  // re-rendering them when it flips.
+  const claudeAvailableRef = React.useRef(claudeAvailable);
+  React.useEffect(() => {
+    claudeAvailableRef.current = claudeAvailable;
+  }, [claudeAvailable]);
+
   const newSession = React.useCallback(() => {
+    // Bug #852 / Task #900: clicking "new session" while the boot probe
+    // (`claudeAvailable === undefined`) is still pending would swap the
+    // right pane to the blank `[data-testid="claude-availability-probing"]`
+    // spacer (no PTY spawn). Short-circuit until the probe resolves so the
+    // user can't strand themselves on a blank pane. The probing spacer
+    // below now also shows a visible "Checking Claude CLI…" affordance
+    // for any pre-existing active session caught in the same window.
+    if (claudeAvailableRef.current !== true) {
+      return;
+    }
     if (typeof document !== 'undefined') {
       const active = document.activeElement;
       if (active instanceof HTMLElement && active !== document.body) {
@@ -289,9 +311,19 @@ export default function App() {
   ) : claudeAvailable === true ? (
     <TerminalPane sessionId={active.id} cwd={active.cwd ?? ''} />
   ) : (
-    // Probing claude availability — render an empty flex spacer
-    // so the layout doesn't jump once the boot check resolves.
-    <div className="flex-1 min-h-0" data-testid="claude-availability-probing" />
+    // Probing claude availability — the right pane would otherwise be a
+    // blank flex spacer for the duration of the boot probe, which made the
+    // pane look broken when a user clicked "new session" before the probe
+    // resolved (Task #900 / bug #852). Render a low-key "Checking…" line
+    // instead so the user understands the pane is intentional. The
+    // outer testid is preserved so existing harness probes that wait for
+    // it to disappear still work.
+    <div
+      className="flex-1 min-h-0 flex items-center justify-center text-xs text-[var(--muted-fg)]"
+      data-testid="claude-availability-probing"
+    >
+      <span>{t('claudeAvailability.probing')}</span>
+    </div>
   );
 
   return (

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -317,6 +317,12 @@ const en = {
     colShortcut: 'Shortcut',
     colAction: 'Action'
   },
+  // Right-pane affordance shown for the brief boot window between app
+  // mount and `ccsmPty.checkClaudeAvailable()` resolving. Without this
+  // line the pane would be entirely blank (bug #852 / task #900).
+  claudeAvailability: {
+    probing: 'Checking Claude CLI…'
+  },
   // Shown full-screen at boot when the `claude` CLI is not on PATH.
   // ccsm requires the user to install the Claude CLI separately; this
   // page links them to the install command and lets them re-check

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -300,6 +300,12 @@ const zh: EnCatalog = {
     colShortcut: '快捷键',
     colAction: '动作'
   },
+  // 右侧 pane 在 boot probe (`ccsmPty.checkClaudeAvailable()`) 期间显示，
+  // 之前是空白 flex spacer，导致用户在 probe 解析前点"新建会话"就看到一片空白
+  // (bug #852 / task #900)。
+  claudeAvailability: {
+    probing: '正在检测 Claude CLI…'
+  },
   // Boot-time full-screen page shown when `claude` CLI not on PATH.
   claudeMissing: {
     title: 'Claude CLI 未找到',

--- a/tests/claude-probe-race-900.test.tsx
+++ b/tests/claude-probe-race-900.test.tsx
@@ -1,0 +1,204 @@
+// Task #900 / bug #852 — gate `newSession` on the boot claudeAvailable
+// probe so users can't strand themselves on a blank right pane.
+//
+// Bug repro before the fix: while `App.tsx`'s boot effect at lines 227-247
+// is still awaiting `window.ccsmPty.checkClaudeAvailable()`,
+// `claudeAvailable` is `undefined`. Clicking the sidebar `+` button (or
+// the empty-state CTA) called `newSession()` → `createSession(null)` →
+// the new session became active, but the right-pane render branch fell
+// through to the empty `[data-testid="claude-availability-probing"]`
+// spacer (no PTY ever spawned). The pane stayed blank with no user-
+// visible explanation.
+//
+// Fix:
+//   - `newSession` short-circuits when `claudeAvailable !== true`.
+//   - The probing spacer now also renders a visible "Checking Claude
+//     CLI…" affordance so any pre-existing active session caught in
+//     the same race window has the SAME explanation surface.
+//
+// This test pins both behaviors against a controlled-resolution probe.
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, cleanup, act, fireEvent } from '@testing-library/react';
+import App from '../src/App';
+import { useStore } from '../src/stores/store';
+import { resetStore } from './util/resetStore';
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function stubMatchMedia() {
+  if (typeof window === 'undefined' || window.matchMedia) return;
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false
+    })
+  });
+}
+
+// jsdom doesn't ship Element.scrollIntoView; SessionRow calls it on
+// mount when a session is selected. Shim it so the third test (which
+// seeds an active session) doesn't crash before the assertions run.
+function stubScrollIntoView() {
+  if (!(Element.prototype as { scrollIntoView?: unknown }).scrollIntoView) {
+    (Element.prototype as { scrollIntoView: () => void }).scrollIntoView = () => {};
+  }
+}
+
+function stubCCSM() {
+  const api = {
+    pathsExist: vi.fn().mockResolvedValue({}),
+    recentCwds: vi.fn().mockResolvedValue([]),
+    defaultModel: vi.fn().mockResolvedValue(null),
+    onUpdateDownloaded: vi.fn().mockReturnValue(() => {}),
+    cliCheck: vi.fn().mockResolvedValue({ state: 'found', binaryPath: '/usr/bin/claude' }),
+    settingsLoad: vi.fn().mockResolvedValue({}),
+    modelsList: vi.fn().mockResolvedValue([]),
+    window: {
+      onBeforeHide: vi.fn().mockReturnValue(() => {}),
+      onAfterShow: vi.fn().mockReturnValue(() => {}),
+      isMaximized: vi.fn().mockResolvedValue(false),
+      onMaximizedChanged: vi.fn().mockReturnValue(() => {}),
+      minimize: vi.fn(),
+      maximize: vi.fn(),
+      unmaximize: vi.fn(),
+      close: vi.fn()
+    },
+    i18n: {
+      getSystemLocale: vi.fn().mockResolvedValue('en'),
+      setLanguage: vi.fn()
+    }
+  };
+  (globalThis as unknown as { window: Window & { ccsm?: unknown } }).window.ccsm = api;
+  return api;
+}
+
+let probe: Deferred<{ available: boolean; binaryPath?: string }>;
+
+beforeEach(() => {
+  cleanup();
+  probe = deferred();
+  // Stub the renderer-side preload bridge that App.tsx:230 reads. The
+  // boot probe awaits `bridge.checkClaudeAvailable()`; we hand back a
+  // deferred so the test can control when it resolves.
+  (globalThis as unknown as { window: Window & { ccsmPty?: unknown } }).window.ccsmPty = {
+    checkClaudeAvailable: () => probe.promise
+  };
+  stubCCSM();
+  stubMatchMedia();
+  stubScrollIntoView();
+  resetStore({
+    sessions: [],
+    groups: [{ id: 'g-default', name: 'Sessions', collapsed: false, kind: 'normal' }],
+    activeId: '',
+    focusedGroupId: null,
+    tutorialSeen: true,
+    hydrated: true,
+    messagesBySession: {},
+    startedSessions: {},
+    runningSessions: {},
+    messageQueues: {},
+    focusInputNonce: 0
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  delete (globalThis as unknown as { window: Window & { ccsmPty?: unknown } }).window.ccsmPty;
+});
+
+describe('claude-probe race gate (#900 / #852)', () => {
+  it('newSession is a no-op while the boot probe is pending', async () => {
+    render(<App />);
+
+    // Sanity: the probing-spacer also renders a visible affordance now,
+    // not a blank flex spacer. (Pre-#900 behavior was a fully empty div.)
+    // The empty-state branch is what shows when no session exists, so
+    // we look at the right-pane CTA path: clicking it must NOT spawn a
+    // session while the probe is unresolved.
+    const newBtn = screen.getByRole('button', { name: /^New Session$/ });
+    expect(useStore.getState().sessions).toHaveLength(0);
+
+    await act(async () => {
+      fireEvent.click(newBtn);
+    });
+
+    // The gate must have suppressed createSession — store is unchanged.
+    expect(useStore.getState().sessions).toHaveLength(0);
+    expect(useStore.getState().activeId).toBe('');
+  });
+
+  it('newSession works once the boot probe resolves true', async () => {
+    render(<App />);
+    const newBtn = screen.getByRole('button', { name: /^New Session$/ });
+
+    await act(async () => {
+      probe.resolve({ available: true, binaryPath: '/usr/bin/claude' });
+      // Yield so the React effect's `setClaudeAvailable(true)` lands AND
+      // the ref-mirror effect runs.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      fireEvent.click(newBtn);
+    });
+
+    expect(useStore.getState().sessions.length).toBeGreaterThan(0);
+  });
+
+  it('probing-spacer surfaces a visible "Checking Claude CLI…" affordance', async () => {
+    // Seed a pre-existing active session so the right pane takes the
+    // claudeAvailable branch (not the first-run CTA branch). This is the
+    // exact failure mode #852 reported: an active session whose right
+    // pane was a blank div for the duration of the probe.
+    resetStore({
+      sessions: [
+        {
+          id: 's-pre',
+          name: 'pre-existing',
+          state: 'idle',
+          cwd: '/',
+          model: 'claude-opus-4',
+          groupId: 'g-default',
+          agentType: 'claude-code'
+        }
+      ],
+      groups: [{ id: 'g-default', name: 'Sessions', collapsed: false, kind: 'normal' }],
+      activeId: 's-pre',
+      focusedGroupId: null,
+      tutorialSeen: true,
+      hydrated: true,
+      messagesBySession: { 's-pre': [] },
+      startedSessions: {},
+      runningSessions: {},
+      messageQueues: {},
+      focusInputNonce: 0
+    });
+
+    render(<App />);
+
+    // The probing-spacer is rendered (probe still pending). It must
+    // contain the visible affordance, not be an empty div.
+    const spacer = await screen.findByTestId('claude-availability-probing');
+    expect(spacer.textContent ?? '').toMatch(/Checking Claude CLI/i);
+  });
+});


### PR DESCRIPTION
## Bug (#852, per #896 audit Item 1)

User clicks the right-pane new-session trigger while `App.tsx`'s boot probe (the `window.ccsmPty.checkClaudeAvailable()` effect at lines 227-247) is still pending. Sequence:

1. `claudeAvailable` starts `undefined`.
2. Click new-session -> `createSession(null)` -> new sid becomes active.
3. Right-pane render branch falls through to the `[data-testid=\"claude-availability-probing\"]` spacer (a literal empty flex div) because `claudeAvailable` is still `undefined`.
4. No PTY is spawned. Pane stays blank, no user-visible explanation.

## Root cause

App.tsx render branch ladder (line ~346-354):

```tsx
) : claudeAvailable === false ? (
  <ClaudeMissingGuide ... />
) : claudeAvailable === true ? (
  <TerminalPane ... />
) : (
  // empty spacer when probe still pending
  <div className=\"flex-1 min-h-0\" data-testid=\"claude-availability-probing\" />
);
```

`newSession` (line ~263-271) had no awareness of probe state - clicking it during the brief boot window dropped the user on the empty branch.

## Fix

Two layers (belt-and-suspenders, same PR):

- **Gate**: `newSession` short-circuits when `claudeAvailableRef.current !== true`. Uses a ref mirror so the callback sees the latest probe value without re-rendering long-lived consumers (Sidebar, CommandPalette).
- **Visible affordance**: probing spacer now renders `t('claudeAvailability.probing')` ('Checking Claude CLI...' / '正在检测 Claude CLI...') instead of a blank div. Covers any pre-existing active session caught in the same boot window AND gives the user a reason for the pause. The `data-testid` is preserved so the existing harness probes that wait for it to disappear still work.

i18n key `claudeAvailability.probing` added to both `en.ts` and `zh.ts` (parity test pins this).

## Test plan

- [x] `tests/claude-probe-race-900.test.tsx` (new) - 3 contracts:
  - newSession is a no-op while boot probe is pending (deferred-promise stub)
  - newSession works once probe resolves true
  - Probing spacer surfaces the visible 'Checking Claude CLI...' affordance
- [x] **Reverse-verify** on pre-fix code (stash + rerun): 2/3 fail (the gate + visible-message contracts), 1/3 pass (the after-resolve test, expected - it's a strict superset).
- [x] **Post-fix**: 3/3 pass.
- [x] `npm run typecheck` clean.
- [x] `npm run lint` - 0 errors (92 pre-existing warnings unchanged).
- [x] `npx vitest run` - 1284 passed, 21 pre-existing better-sqlite3 ABI failures (NODE_MODULE_VERSION 145 vs 137, env issue, unrelated).
- [x] `tests/first-run-empty-state.test.tsx` + `tests/i18n-key-parity.test.ts` still pass.

### E2E harness rationale

Did NOT add a new harness-ui case. The race requires monkey-patching `window.ccsmPty.checkClaudeAvailable` via `addInitScript` before App boots (similar to `caseStartupPaintsBeforeHydrate`), then forcing reload, which adds ~30s and would need to be the last case (perturbs subsequent state). The vitest tests give deterministic, controlled-timing coverage of both the gate and the visible affordance - both are pure renderer-state assertions where jsdom + Chromium behave identically. Existing `terminal-pane-mounted` harness case still covers the `claudeAvailable=true` happy-path wiring.

## Files

- `src/App.tsx` - gate + visible spacer
- `src/i18n/locales/en.ts` + `zh.ts` - `claudeAvailability.probing` key
- `tests/claude-probe-race-900.test.tsx` - new test, 3 cases