### PR TITLE
ci(e2e): self-heal poisoned electron binary on cache hit (#913)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,6 +57,18 @@ jobs:
       - name: Install deps
         if: steps.nm_cache.outputs.cache-hit != 'true'
         run: npm ci --legacy-peer-deps
+      # Ensure the Electron binary (`node_modules/electron/dist/`) is present.
+      # The node_modules cache is shared with ci.yml, which runs `npm ci` with
+      # ELECTRON_SKIP_BINARY_DOWNLOAD=1 — when ci.yml wins the race to write
+      # the cache, the restored node_modules has the electron JS shim but no
+      # `dist/electron(.exe)` and no `path.txt`/`dist/version`, causing
+      # `electron.launch` to error with "Electron failed to install correctly".
+      # `electron/install.js` short-circuits via `isInstalled()` when the
+      # binary is already present, so this is a fast no-op on healthy caches
+      # and self-heals poisoned caches. Must NOT inherit the env var above.
+      # (Task #913)
+      - name: Ensure Electron binary
+        run: node node_modules/electron/install.js
       - name: Build
         run: npm run build
       - name: Run e2e (Linux with xvfb)


### PR DESCRIPTION
## Summary
- Fixes PR #618 Win e2e CI failure (4 reruns, same error: `Electron failed to install correctly`).
- Root cause: `e2e.yml` and `ci.yml` share the cache key `nm-${runner.os}-${runner.arch}-node20-${hashFiles('package-lock.json')}`. `ci.yml` runs `npm ci` with `ELECTRON_SKIP_BINARY_DOWNLOAD=1`, so when ci.yml wins the cache-write race, the cached `node_modules/electron/` lacks `dist/electron(.exe)`, `path.txt`, and `dist/version`. e2e.yml restores it, hits the cache, skips `npm ci` (and therefore postinstall), and crashes at `electron.launch`.
- Fix: add an unconditional `node node_modules/electron/install.js` step in e2e.yml after install. Its `isInstalled()` short-circuit makes it a fast no-op on healthy caches; on poisoned caches it downloads the missing binary. `ELECTRON_SKIP_BINARY_DOWNLOAD` is intentionally NOT set on this step.

## Evidence
Failed run [25155457558](https://github.com/Jiahui-Gu/ccsm/actions/runs/25155457558/job/73747808071) (PR #618):
```
Cache hit for: nm-Windows-X64-node20-a7ddb6...
Cache not found for input keys: electron-Windows-a7ddb6...
[Install deps]  (skipped — cache hit)
electron.launch: Electron failed to install correctly...
```

Passing run [25158370860](https://github.com/Jiahui-Gu/ccsm/actions/runs/25158370860/job/73745990230) (PR #624):
```
Cache not found for input keys: nm-Windows-X64-node20-a7ddb6...
[Install deps] npm ci --legacy-peer-deps  (full postinstall ran)
```

Both PRs have unchanged `package-lock.json`, so they share a cache key — pass/fail purely depends on which workflow wrote the cache first.

## Test plan
- [ ] Win e2e job on this PR passes (cache will likely be hit, exercising the self-heal path).
- [ ] After merge, rerun PR #618 Win e2e — should pass.