### PR TITLE
fix(lint): backport TerminalPane no-empty + ResizeObserver to release/v0.2.0

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,6 +15,7 @@ export default [
       'release/**',
       'scripts/**',
       'tests/**',
+      'docs/**',
       'webpack.config.js',
       'postcss.config.js',
       'eslint.config.js'
@@ -74,6 +75,7 @@ export default [
         getComputedStyle: 'readonly',
         requestAnimationFrame: 'readonly',
         cancelAnimationFrame: 'readonly',
+        ResizeObserver: 'readonly',
         // `NodeJS` namespace is also referenced from renderer-side .d.ts
         // files (e.g. cliBridge.d.ts) that mirror preload types — keep it
         // available alongside browser globals.

--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -146,7 +146,9 @@ function ensureTerminal(host: HTMLDivElement): Terminal {
       if (sel) {
         try {
           window.ccsmPty?.clipboard?.writeText(sel);
-        } catch {}
+        } catch {
+          // ignore clipboard failures — selection still highlights.
+        }
         return false;
       }
       return true;
@@ -155,7 +157,9 @@ function ensureTerminal(host: HTMLDivElement): Terminal {
       try {
         const text = window.ccsmPty?.clipboard?.readText();
         if (text && activeSid) window.ccsmPty.input(activeSid, text);
-      } catch {}
+      } catch {
+        // ignore clipboard failures — paste is best-effort.
+      }
       return false;
     }
     if (ev.ctrlKey && ev.shiftKey && isC) {
@@ -163,7 +167,9 @@ function ensureTerminal(host: HTMLDivElement): Terminal {
       if (sel) {
         try {
           window.ccsmPty?.clipboard?.writeText(sel);
-        } catch {}
+        } catch {
+          // ignore clipboard failures — selection still highlights.
+        }
       }
       return false;
     }
@@ -171,7 +177,9 @@ function ensureTerminal(host: HTMLDivElement): Terminal {
       try {
         const text = window.ccsmPty?.clipboard?.readText();
         if (text && activeSid) window.ccsmPty.input(activeSid, text);
-      } catch {}
+      } catch {
+        // ignore clipboard failures — paste is best-effort.
+      }
       return false;
     }
     return true;
@@ -250,13 +258,17 @@ export function TerminalPane({ sessionId, cwd: _cwd }: Props) {
         if (unsubscribeData) {
           try {
             unsubscribeData();
-          } catch {}
+          } catch {
+            // already torn down — safe to ignore.
+          }
           unsubscribeData = null;
         }
         if (inputDisposable) {
           try {
             inputDisposable.dispose();
-          } catch {}
+          } catch {
+            // already disposed — safe to ignore.
+          }
           inputDisposable = null;
         }
         try {
@@ -270,13 +282,17 @@ export function TerminalPane({ sessionId, cwd: _cwd }: Props) {
         if (unsubscribeData) {
           try {
             unsubscribeData();
-          } catch {}
+          } catch {
+            // already torn down — safe to ignore.
+          }
           unsubscribeData = null;
         }
         if (inputDisposable) {
           try {
             inputDisposable.dispose();
-          } catch {}
+          } catch {
+            // already disposed — safe to ignore.
+          }
           inputDisposable = null;
         }
       }
@@ -315,7 +331,9 @@ export function TerminalPane({ sessionId, cwd: _cwd }: Props) {
         if (term) {
           try {
             term.resize(cols, rows);
-          } catch {}
+          } catch {
+            // resize is best-effort — proceed with snapshot write.
+          }
           if (snapshot) term.write(snapshot);
         }
 
@@ -397,7 +415,9 @@ export function TerminalPane({ sessionId, cwd: _cwd }: Props) {
     return () => {
       try {
         unsubscribe?.();
-      } catch {}
+      } catch {
+        // already torn down — safe to ignore.
+      }
     };
   }, []);
 


### PR DESCRIPTION
## Summary
Unblocks v0.2.0 release PR #627. Lint job in #627 fails on `release/v0.2.0` with 11 errors in `src/components/TerminalPane.tsx` (10x `no-empty` + 1x `no-undef ResizeObserver`). These were already fixed on `working` by commit 6b8136e (`chore(lint): clear 12 pre-existing errors on working (#532)`), but never made it onto the release branch.

This PR cherry-picks 6b8136e onto `release/v0.2.0`. Pure lint compliance — no behavior change.

## Why not branch from `working`
Worker dispatch instructions assumed `working` itself was failing lint. It is not — `working` HEAD (767719f) lints clean (the file was further reduced in the #557 hook-extract refactor). The actual failing branch is `release/v0.2.0`, which predates the lint fix. The smallest, safest unblock is to backport the original lint-only commit. `--base release/v0.2.0` (not `working`) is intentional for the same reason.

## Changes
- `eslint.config.js`: add `docs/**` to ignores; add `ResizeObserver` to renderer browser globals.
- `src/components/TerminalPane.tsx`: replace 10 empty `catch {}` / empty blocks with `catch { /* swallow */ }` style stubs (intentional swallows preserved, no runtime change).

## Verification (local, this branch)
- `npx eslint src/components/TerminalPane.tsx` -> `0 errors, 1 warning` (pre-existing exhaustive-deps `_cwd` warning, not blocking — lint script does not use `--max-warnings`).
- `npm run lint` -> `0 errors`.
- `npm run typecheck` -> clean.

## Lint output before vs after on `release/v0.2.0`
Before (CI run 25163614590):
```
src/components/TerminalPane.tsx
  149:17  error  Empty block statement   no-empty
  158:15  error  Empty block statement   no-empty
  166:17  error  Empty block statement   no-empty
  174:15  error  Empty block statement   no-empty
  214:20  error  'ResizeObserver' is not defined  no-undef
  253:19  error  Empty block statement   no-empty
  259:19  error  Empty block statement   no-empty
  273:19  error  Empty block statement   no-empty
  279:19  error  Empty block statement   no-empty
  318:19  error  Empty block statement   no-empty
  373:6   warning React Hook useEffect has a missing dependency: '_cwd'  react-hooks/exhaustive-deps
  400:15  error  Empty block statement   no-empty
11 errors, 1 warning
```
After:
```
src/components/TerminalPane.tsx
  391:6   warning React Hook useEffect has a missing dependency: '_cwd'  react-hooks/exhaustive-deps
0 errors, 1 warning
```