### PR TITLE
fix(ci): add npm run build to release verify job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
         run: npm rebuild better-sqlite3
       - run: npm run lint
       - run: npm run typecheck
+      - run: npm run build
       - run: npm test
 
   build:


### PR DESCRIPTION
## Problem
v0.2.0 release attempt failed at workflow run [25165590364](https://github.com/Jiahui-Gu/ccsm/actions/runs/25165590364). The \`verify\` job ran \`npm test\` without first running \`npm run build\`, so \`tests/electron-load-smoke.test.ts\` failed because it requires \`dist/electron/**\` to exist. Build job was skipped \xe2\x86\x92 no installer artifact, no draft Release.

## Fix
Insert \`- run: npm run build\` between \`typecheck\` and \`test\` in the \`verify\` job. Order is now: install \xe2\x86\x92 lint \xe2\x86\x92 typecheck \xe2\x86\x92 build \xe2\x86\x92 test.

## Test plan
- [ ] CI green on this PR
- [ ] After merge to working \xe2\x86\x92 main \xe2\x86\x92 re-tag v0.2.0, release.yml verify passes and Windows installer is produced

Task #925.