### PR TITLE
docs: v0.3 daemon-split implementation plan

### DIFF
--- a/docs/superpowers/plans/2026-04-30-v0.3-daemon-split.md
+++ b/docs/superpowers/plans/2026-04-30-v0.3-daemon-split.md
@@ -56,7 +56,7 @@
 | `electron/ptyHost/**` (entire dir, 1304 LOC) | Move physically to `daemon/src/services/pty/`; replace with thin Electron-side proxy or delete entirely. | move |
 | `electron/db.ts` (218) | Delete after dbService is wired and verified. | -218 |
 | `electron/sessionTitles/**` (394) | Move to `daemon/src/services/sessionTitles/`. | move |
-| `electron/notify/**` (~1100) | Split: data/queue moves to daemon, badge pixel renderer stays in Electron (Win-overlay PNG). | partial |
+| `electron/notify/**` (~1300 LOC excluding tests; ~2500 with tests, across `badge*.ts`, `notifyDecider.ts`, `runStateTracker.ts`, `titleStateClassifier.ts`, `bootstrap/installPipeline.ts`, `sinks/{pipeline,badgeSink,flashSink,toastSink}.ts`) | Split: data/queue/decider moves to daemon, badge pixel renderer + badgeSink stay in Electron (Win-overlay PNG). | partial |
 
 ### Files unchanged (renderer side)
 Everything under `src/renderer/**` — that's the whole point of this slice.
@@ -1173,15 +1173,17 @@ git commit -m "feat(daemon): lift sessionTitles behind CCSM_USE_DAEMON=sessionTi
 
 This is the largest single lift (~1300 LOC across `electron/ptyHost/**`). Split into sub-tasks 11a/11b/11c rather than one mega-step.
 
-#### Task 11a: Move PTY core (lifecycle, processKiller, resolvers)
+#### Task 11a: Move PTY core (lifecycle, processKiller, resolvers, ipcRegistrar shim removal)
 
 **Files:**
 - Move: `electron/ptyHost/lifecycle.ts`, `processKiller.ts`, `claudeResolver.ts`, `cwdResolver.ts`, `jsonlResolver.ts` → `daemon/src/services/pty/`
 - Move: tests alongside.
+- Delete (NOT move): `electron/ptyHost/ipcRegistrar.ts` (192 LOC) — its job was registering `ipcMain.handle('ccsm:pty:*', ...)` channels. Those channels die in Phase 3 (Task 18); registrar is dead code post-lift.
 
 - [ ] **Step 1: Copy + fix imports** (no Electron-package refs allowed)
-- [ ] **Step 2: Run unit tests**
-- [ ] **Step 3: Commit** `feat(daemon/pty): move core modules`
+- [ ] **Step 2: Mark `ipcRegistrar.ts` for deletion in Task 18** — add a `@deprecated` JSDoc note now so reviewers know; actual delete happens during Phase 3 cleanup.
+- [ ] **Step 3: Run unit tests**
+- [ ] **Step 4: Commit** `feat(daemon/pty): move core modules`
 
 #### Task 11b: Move PTY entry + factory + osc title sniffer
 
@@ -1236,12 +1238,56 @@ In handler dispatch, if the handler is registered as a stream handler, hold the 
 In `electron/daemonClient/connectClient.ts`, add:
 
 ```typescript
-ptySubscribe(sessionId: string, fromSeq: number, onMessage: (msg: PtyStreamMsg) => void): () => void {
-  // open socket, send envelope { method: 'ccsm.v1/pty.subscribe', payload: {sessionId, fromSeq} }
-  // on each incoming `stream.chunk` envelope, call onMessage(chunk)
-  // return cancel function that ends the socket
+import { createConnection, type Socket } from "node:net";
+
+export type PtyStreamMsg =
+  | { kind: "snapshot"; seq: number; data: string }
+  | { kind: "delta"; seq: number; data: string };
+
+export interface DaemonClient {
+  // ... existing methods ...
+  ptySubscribe(
+    sessionId: string,
+    fromSeq: number,
+    onMessage: (msg: PtyStreamMsg) => void,
+  ): () => void;
+}
+
+export function makeClient(address: string): DaemonClient {
+  return {
+    // ... existing methods ...
+    ptySubscribe(sessionId, fromSeq, onMessage) {
+      const sock: Socket = createConnection(address);
+      let buf = Buffer.alloc(0);
+      let nextId = 1;
+      const env = { id: nextId, method: RPC_NAMES.ptySubscribe, payload: { sessionId, fromSeq } };
+      const body = Buffer.from(JSON.stringify(env), "utf8");
+      const header = Buffer.alloc(4);
+      header.writeUInt32BE(body.length, 0);
+      sock.on("connect", () => sock.write(Buffer.concat([header, body])));
+      sock.on("data", (chunk) => {
+        buf = Buffer.concat([buf, chunk]);
+        while (buf.length >= 4) {
+          const len = buf.readUInt32BE(0);
+          if (buf.length < 4 + len) break;
+          const env2 = JSON.parse(buf.subarray(4, 4 + len).toString("utf8"));
+          buf = buf.subarray(4 + len);
+          if (env2.stream?.kind === "chunk") onMessage(env2.stream.chunk as PtyStreamMsg);
+          // stream.kind === "end" → server-side closed; do nothing, socket end will follow
+        }
+      });
+      sock.on("error", (err) => {
+        // surface via emitter pattern in caller; for v0.3 just log
+        // eslint-disable-next-line no-console
+        console.error("ptySubscribe socket error:", err);
+      });
+      return () => { sock.end(); };
+    },
+  };
 }
 ```
+
+(Add `RPC_NAMES.ptySubscribe = "ccsm.v1/pty.subscribe";` to `daemon/src/api/contracts.ts`.)
 
 - [ ] **Step 4: Flag-gate `ccsmPty.ts` bridge**
 
@@ -1299,24 +1345,48 @@ git commit -m "feat(daemon/pty): subscribe + write + resize + kill RPCs with seq
 
 ### Task 13: Lift `notifyService` (data + queue side) to daemon
 
-The notify domain is ~1100 LOC under `electron/notify/**`, but the **badge image renderer (`badgePixels.ts`, 271 LOC)** must stay in Electron because it depends on the Win Overlay API which is Electron-process-only (per F1 spike). Split:
+The notify domain spans ~1300 LOC across `electron/notify/**` (badge*.ts, notifyDecider.ts, runStateTracker.ts, titleStateClassifier.ts, bootstrap/, sinks/). The **badge image renderer (`badgePixels.ts`, 271 LOC) and `sinks/badgeSink.ts` (150 LOC)** must stay in Electron because they depend on the Win Overlay API which is Electron-process-only (per F1 spike). Split into 13a/13b/13c rather than one mega-task.
 
-- Daemon owns: queue, dedup logic, severity routing, persistence of unread counters.
-- Electron owns: rendering pixel buffer, calling `setOverlayIcon()`.
+#### Task 13a: Lift decider + run-state tracker + classifier
 
-**Files:**
-- Move: notify queue/dedup/router → `daemon/src/services/notify/`
-- Keep in Electron: `electron/notify/badgePixels.ts`, `electron/notify/badgeController.ts`
-- Add RPC: `notifyEnqueue(notification)` unary + `notifyBadgeStream()` server-stream emitting `{ count, severity }` updates that Electron consumes to redraw badge.
+**Files to move into `daemon/src/services/notify/`:**
+- `electron/notify/notifyDecider.ts` (249 LOC)
+- `electron/notify/runStateTracker.ts` (174 LOC)
+- `electron/notify/titleStateClassifier.ts` (28 LOC)
+- `electron/notify/badgeStore.ts` (57 LOC) — pure state, no Electron API
+- `electron/notify/badgeLabel.ts` (15 LOC)
+- Tests alongside
 
-- [ ] **Step 1: Read `electron/notify/**` + `electron/badgeController.ts`** end-to-end. Identify which functions touch only data (lift) vs which touch Electron APIs (keep).
-- [ ] **Step 2: Lift the data side; leave the badge renderer alone.**
-- [ ] **Step 3: Add unit tests for the lifted side.**
-- [ ] **Step 4: Add RPC contracts (unary enqueue + server-stream badge updates).**
-- [ ] **Step 5: Flag-gate `electron/preload/bridges/ccsmNotify.ts`.**
-- [ ] **Step 6: Wire `electron/badgeController.ts` to subscribe to `notifyBadgeStream()` instead of the local in-process emitter.** This stays inside Electron main, not preload.
-- [ ] **Step 7: E2E** — trigger a notification with flag on, verify badge updates and tray notification fires.
-- [ ] **Step 8: Commit** `feat(daemon): lift notify queue + badge stream behind CCSM_USE_DAEMON=notify flag`
+- [ ] **Step 1: Copy + fix imports** (no electron-package refs allowed in daemon)
+- [ ] **Step 2: Run lifted unit tests** — `npx vitest run daemon/src/services/notify/__tests__/`
+- [ ] **Step 3: Commit** `feat(daemon/notify): lift decider + state tracker + classifier`
+
+#### Task 13b: Lift sink pipeline (data side) + bootstrap
+
+**Files to move:**
+- `electron/notify/sinks/pipeline.ts` (215 LOC)
+- `electron/notify/sinks/flashSink.ts` (127 LOC)
+- `electron/notify/sinks/toastSink.ts` (169 LOC) — emits OS-toast IPC; needs daemon RPC out to Electron for the actual toast call (toasts are Electron `Notification` API, not daemon-callable)
+- `electron/notify/bootstrap/installPipeline.ts` (132 LOC)
+
+- [ ] **Step 1: Move + fix imports**
+- [ ] **Step 2: For toastSink**, design a "daemon→Electron callback" channel: daemon emits `notifyToastRequest` server-stream; Electron subscribes and calls `new Notification(...)` natively. Add this RPC to contracts.
+- [ ] **Step 3: Run lifted tests**
+- [ ] **Step 4: Commit** `feat(daemon/notify): lift pipeline + flash + toast sinks`
+
+#### Task 13c: Wire badge stream + flag-gate bridge
+
+**Files staying in Electron** (touch Electron API or Win-overlay):
+- `electron/notify/badge.ts` (30 LOC) — entry, stays
+- `electron/notify/badgePixels.ts` (271 LOC) — Win-overlay renderer, stays
+- `electron/notify/sinks/badgeSink.ts` (150 LOC) — calls `setOverlayIcon()`, stays
+
+- [ ] **Step 1: Add `notifyEnqueue` unary + `notifyBadgeStream()` server-stream to contracts**
+- [ ] **Step 2: Register handlers in daemon entry**
+- [ ] **Step 3: Flag-gate `electron/preload/bridges/ccsmNotify.ts`** with `CCSM_USE_DAEMON=notify`
+- [ ] **Step 4: Wire `electron/notify/badge.ts` (entry) to subscribe to `notifyBadgeStream()`** instead of the local in-process emitter. The subscriber lives in Electron main, not preload, and forwards stream events to `badgeSink` for actual `setOverlayIcon` calls.
+- [ ] **Step 5: E2E** — trigger a notification with flag on, verify badge updates AND tray toast fires.
+- [ ] **Step 6: Commit** `feat(daemon/notify): badge stream + flag-gated bridge`
 
 ---
 

--- a/docs/superpowers/plans/2026-04-30-v0.3-daemon-split.md
+++ b/docs/superpowers/plans/2026-04-30-v0.3-daemon-split.md
@@ -1,0 +1,1662 @@
+# v0.3 Daemon Split — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract all session/PTY/SDK/SQLite logic from Electron main into a standalone Node daemon. Electron becomes a thin local Connect client. No web client and no protobuf yet (those are v0.4 / v0.5).
+
+**Architecture:** Add a new `daemon/` module that runs as a separate Node process. It exposes a Connect-RPC server over a local IPC channel (named pipe on Win, unix socket on Mac/Linux). Electron `main.ts` boots the daemon (or attaches to a running one) and calls it via a Connect client. All renderer-facing bridges in `electron/preload/bridges/` are rewritten so their public surface is unchanged but their bodies call the Connect client instead of in-process services. The daemon owns SQLite (`better-sqlite3`), PTY (`node-pty`), Claude SDK (via existing `loadSdk` shim), session titles, notification fan-out, and the auto-updater.
+
+**Tech Stack:** Node 22, TypeScript 5.x, `@connectrpc/connect`, `@connectrpc/connect-node`, `better-sqlite3` (existing), `node-pty` (existing), `@xterm/headless` (existing in renderer scope, lifted to daemon), `pino` for logs, `@yao-pkg/pkg` for binary packaging, vitest for tests.
+
+**Estimate:** ~125h (per spec §8).
+
+---
+
+## File structure
+
+### New files / directories
+
+| Path | Purpose | Approx LOC |
+|---|---|---|
+| `daemon/package.json` | Workspace package manifest (npm workspace member) | 30 |
+| `daemon/tsconfig.json` | TS config (target Node 22, output `dist-daemon/`) | 25 |
+| `daemon/src/index.ts` | Entry point: parse args, start IPC + TCP listeners, wire shutdown | 80 |
+| `daemon/src/transport/localChannel.ts` | Named-pipe (Win) / unix socket (Mac/Linux) listener | 70 |
+| `daemon/src/transport/connectAdapter.ts` | Connect-RPC handler registration, request routing | 100 |
+| `daemon/src/services/sessionService.ts` | Lifted from `electron/sessionTitles/index.ts` + `ipc/sessionIpc.ts` | 350 |
+| `daemon/src/services/ptyService.ts` | Lifted from `electron/ptyHost/*` | 600 |
+| `daemon/src/services/dbService.ts` | Lifted from `electron/db.ts` + `ipc/dbIpc.ts` | 250 |
+| `daemon/src/services/notifyService.ts` | Lifted from `electron/notify/**` (data side; badge image stays in Electron) | 400 |
+| `daemon/src/services/sdkService.ts` | Lifted from `electron/sessionTitles/loadSdk` shim usage | 100 |
+| `daemon/src/services/updaterService.ts` | Poll GitHub releases, download, swap binary | 200 |
+| `daemon/src/lifecycle.ts` | Single-instance lock, graceful shutdown, signal handlers | 80 |
+| `daemon/src/log.ts` | pino logger with rotation to `~/.ccsm/daemon.log` | 40 |
+| `daemon/src/api/contracts.ts` | TS interfaces describing every RPC request/response (v0.3 hand-written, v0.4 generated from proto) | 300 |
+| `electron/daemonClient/spawnOrAttach.ts` | Probe local socket, spawn binary if absent, retry connect | 120 |
+| `electron/daemonClient/connectClient.ts` | Single Connect client instance shared by all bridges | 60 |
+| `tests/electron-daemon-handshake.e2e.ts` | E2E: Electron starts → spawns daemon → bridge call returns → quit → daemon survives, then explicit quit kills both | 150 |
+| `tests/daemon-load-smoke.test.ts` | `require('./dist-daemon/index.js')` smoke test (mirrors `tests/electron-load-smoke.test.ts`) | 50 |
+
+### Modified files
+
+| Path | Change | Approx delta |
+|---|---|---|
+| `package.json` | Add npm workspaces (`daemon`, root). Add daemon scripts (`build:daemon`, `package:daemon`, `dev:daemon`). | +40 |
+| `electron/main.ts` (320 LOC today) | Remove SDK / PTY / DB / sessionTitles bootstrap. Add `daemonClient.spawnOrAttach()` early, then unchanged window/tray bootstrap. | -120 / +40 |
+| `electron/preload/bridges/ccsmCore.ts` (160) | Replace `ipcRenderer.invoke` body with `connectClient.unary(...)`; same exported function signatures. | rewrite bodies |
+| `electron/preload/bridges/ccsmSession.ts` (132) | Same. | rewrite bodies |
+| `electron/preload/bridges/ccsmPty.ts` (93) | Same. PTY data event becomes Connect server-stream → `EventEmitter`. | rewrite bodies |
+| `electron/preload/bridges/ccsmNotify.ts` (53) | Same. | rewrite bodies |
+| `electron/preload/bridges/ccsmSessionTitles.ts` (55) | Same. | rewrite bodies |
+| `electron/ipc/dbIpc.ts` (89) | Delete after bridge swap verified. | -89 |
+| `electron/ipc/sessionIpc.ts` (135) | Delete after bridge swap verified. | -135 |
+| `electron/ipc/utilityIpc.ts` (170) | Split: utility queries that move to daemon → delete; window-only stay. | -120 |
+| `electron/ipc/systemIpc.ts` (75) | Stays (window/tray only, not session-data). | 0 |
+| `electron/ipc/windowIpc.ts` (34) | Stays. | 0 |
+| `electron/ptyHost/**` (entire dir, 1304 LOC) | Move physically to `daemon/src/services/pty/`; replace with thin Electron-side proxy or delete entirely. | move |
+| `electron/db.ts` (218) | Delete after dbService is wired and verified. | -218 |
+| `electron/sessionTitles/**` (394) | Move to `daemon/src/services/sessionTitles/`. | move |
+| `electron/notify/**` (~1100) | Split: data/queue moves to daemon, badge pixel renderer stays in Electron (Win-overlay PNG). | partial |
+
+### Files unchanged (renderer side)
+Everything under `src/renderer/**` — that's the whole point of this slice.
+
+---
+
+## Phase ordering
+
+Implementation runs phase-by-phase; each phase is independently committable and shippable behind a flag:
+
+- **Phase 0** (Tasks 1-3): scaffolding — workspace, daemon package, smoke test.
+- **Phase 1** (Tasks 4-7): transport — Connect server over local socket + Connect client + handshake.
+- **Phase 2** (Tasks 8-15): services — lift each domain (db, session, sessionTitles, pty, notify, sdk) one at a time, dual-running with Electron in-process version behind feature flag.
+- **Phase 3** (Tasks 16-19): bridge swap — flip each `preload/bridges/*` to use Connect client; delete dead `ipc/*` files.
+- **Phase 4** (Tasks 20-22): packaging + lifecycle — `pkg` build, OS-specific install, tray-quit semantics.
+- **Phase 5** (Tasks 23-25): updater + polish — poll GitHub releases, swap binary, e2e + dogfood.
+
+---
+
+## Phase 0 — Scaffolding
+
+### Task 1: Create daemon workspace skeleton
+
+**Files:**
+- Create: `daemon/package.json`
+- Create: `daemon/tsconfig.json`
+- Create: `daemon/src/index.ts`
+- Modify: `package.json` (root)
+- Modify: `tsconfig.json` (root, add reference)
+
+- [ ] **Step 1: Add npm workspace declaration to root `package.json`**
+
+In root `package.json`, add the `workspaces` field next to existing top-level keys:
+
+```json
+{
+  "workspaces": ["daemon"]
+}
+```
+
+If the file already has a `workspaces` field, add `"daemon"` to the array.
+
+- [ ] **Step 2: Create `daemon/package.json`**
+
+```json
+{
+  "name": "@ccsm/daemon",
+  "version": "0.0.0",
+  "private": true,
+  "type": "commonjs",
+  "main": "dist-daemon/index.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run",
+    "dev": "tsc -p tsconfig.json --watch"
+  },
+  "dependencies": {
+    "@connectrpc/connect": "^2.0.0",
+    "@connectrpc/connect-node": "^2.0.0",
+    "pino": "^9.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "vitest": "^2.0.0",
+    "@types/node": "^22.0.0"
+  }
+}
+```
+
+CommonJS chosen so the daemon can be packaged by `pkg` (which still requires CJS as of 2026-04). ESM-only deps (claude-agent-sdk) load via existing `loadSdk` dynamic-import shim.
+
+- [ ] **Step 3: Create `daemon/tsconfig.json`**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "dist-daemon",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"]
+}
+```
+
+- [ ] **Step 4: Create `daemon/src/index.ts` placeholder**
+
+```typescript
+import { logger } from "./log";
+
+async function main(): Promise<void> {
+  logger.info({ pid: process.pid }, "ccsm-daemon starting");
+  // listeners + services wired in later tasks
+  process.on("SIGTERM", () => process.exit(0));
+}
+
+main().catch((err) => {
+  // eslint-disable-next-line no-console
+  console.error("daemon fatal:", err);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 5: Create `daemon/src/log.ts`**
+
+```typescript
+import pino from "pino";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { mkdirSync } from "node:fs";
+
+const ccsmDir = join(homedir(), ".ccsm");
+mkdirSync(ccsmDir, { recursive: true });
+
+export const logger = pino(
+  { level: process.env.CCSM_DAEMON_LOG_LEVEL ?? "info" },
+  pino.destination({ dest: join(ccsmDir, "daemon.log"), sync: false }),
+);
+```
+
+- [ ] **Step 6: Run install + build**
+
+```bash
+npm install
+cd daemon && npm run build
+```
+
+Expected: `daemon/dist-daemon/index.js` exists.
+
+- [ ] **Step 7: Run the daemon once to verify it boots**
+
+```bash
+node daemon/dist-daemon/index.js &
+sleep 2
+kill %1
+cat ~/.ccsm/daemon.log | tail -1
+```
+
+Expected: log line includes `"ccsm-daemon starting"`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add daemon/ package.json package-lock.json tsconfig.json
+git commit -m "feat(daemon): workspace skeleton with pino logger"
+```
+
+---
+
+### Task 2: Add daemon load-smoke test
+
+**Files:**
+- Create: `tests/daemon-load-smoke.test.ts`
+- Modify: `vitest.config.ts` (if needed — verify daemon dist is included)
+
+- [ ] **Step 1: Write the test**
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+const distDir = join(__dirname, "..", "daemon", "dist-daemon");
+
+describe("daemon load smoke", () => {
+  it("dist-daemon directory exists (run `npm -w @ccsm/daemon run build` first)", () => {
+    expect(existsSync(distDir)).toBe(true);
+  });
+
+  it("daemon entry can be required", () => {
+    const expected = ["index.js", "log.js"];
+    for (const f of expected) {
+      const p = join(distDir, f);
+      expect(existsSync(p), `missing ${p}`).toBe(true);
+      expect(() => require(p)).not.toThrow();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test before build to verify it fails as expected**
+
+```bash
+rm -rf daemon/dist-daemon
+npx vitest run tests/daemon-load-smoke.test.ts
+```
+
+Expected: FAIL with "dist-daemon directory exists" assertion red.
+
+- [ ] **Step 3: Build daemon and re-run**
+
+```bash
+npm -w @ccsm/daemon run build
+npx vitest run tests/daemon-load-smoke.test.ts
+```
+
+Expected: PASS (both assertions green).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/daemon-load-smoke.test.ts
+git commit -m "test(daemon): require-load smoke test"
+```
+
+---
+
+### Task 3: Wire daemon build into root `npm test`
+
+**Files:**
+- Modify: root `package.json` scripts
+
+- [ ] **Step 1: Inspect current root scripts**
+
+```bash
+node -e "console.log(JSON.stringify(require('./package.json').scripts, null, 2))"
+```
+
+Read the output. Identify the existing `build` script and `test` script.
+
+- [ ] **Step 2: Add daemon build to root `build`**
+
+Update the root `package.json` `build` script so it ALSO builds the daemon. If it currently looks like `"build": "tsc -p tsconfig.electron.json && webpack --mode production"`, change it to `"build": "tsc -p tsconfig.electron.json && webpack --mode production && npm -w @ccsm/daemon run build"`.
+
+- [ ] **Step 3: Verify**
+
+```bash
+rm -rf dist daemon/dist-daemon
+npm run build
+ls dist/electron/main.js daemon/dist-daemon/index.js
+```
+
+Expected: both files exist.
+
+- [ ] **Step 4: Run full vitest**
+
+```bash
+npm test
+```
+
+Expected: includes new `tests/daemon-load-smoke.test.ts` and passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json
+git commit -m "build: include daemon in root build pipeline"
+```
+
+---
+
+## Phase 1 — Transport
+
+### Task 4: Local channel listener (named pipe / unix socket)
+
+**Files:**
+- Create: `daemon/src/transport/localChannel.ts`
+- Create: `daemon/src/transport/__tests__/localChannel.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, it, expect, afterEach } from "vitest";
+import { createConnection } from "node:net";
+import { startLocalChannel, type LocalChannel } from "../localChannel";
+
+describe("localChannel", () => {
+  let channel: LocalChannel | undefined;
+
+  afterEach(async () => {
+    await channel?.close();
+    channel = undefined;
+  });
+
+  it("accepts a local connection on the platform-correct path", async () => {
+    channel = await startLocalChannel({
+      onConnection: (socket) => {
+        socket.write("hello\n");
+        socket.end();
+      },
+    });
+
+    const data = await new Promise<string>((resolve, reject) => {
+      const c = createConnection(channel!.address);
+      let buf = "";
+      c.on("data", (chunk) => (buf += chunk.toString()));
+      c.on("end", () => resolve(buf));
+      c.on("error", reject);
+    });
+
+    expect(data).toBe("hello\n");
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm it fails**
+
+```bash
+npx vitest run daemon/src/transport/__tests__/localChannel.test.ts
+```
+
+Expected: FAIL with module-not-found for `../localChannel`.
+
+- [ ] **Step 3: Implement the listener**
+
+```typescript
+import { createServer, type Server, type Socket } from "node:net";
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
+import { unlinkSync } from "node:fs";
+
+export interface LocalChannel {
+  address: string;
+  close(): Promise<void>;
+}
+
+export interface LocalChannelOptions {
+  onConnection: (socket: Socket) => void;
+  pipeName?: string;
+}
+
+function defaultAddress(pipeName: string): string {
+  if (platform() === "win32") return `\\\\.\\pipe\\${pipeName}`;
+  return join(homedir(), ".ccsm", `${pipeName}.sock`);
+}
+
+export async function startLocalChannel(opts: LocalChannelOptions): Promise<LocalChannel> {
+  const address = defaultAddress(opts.pipeName ?? "ccsm-daemon");
+  if (platform() !== "win32") {
+    try { unlinkSync(address); } catch { /* fine */ }
+  }
+  const server: Server = createServer(opts.onConnection);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(address, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  return {
+    address,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      }),
+  };
+}
+```
+
+- [ ] **Step 4: Run test**
+
+```bash
+npm -w @ccsm/daemon run build
+npx vitest run daemon/src/transport/__tests__/localChannel.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add daemon/src/transport/localChannel.ts daemon/src/transport/__tests__/localChannel.test.ts
+git commit -m "feat(daemon): local-channel listener (named pipe / unix socket)"
+```
+
+---
+
+### Task 5: Connect adapter on the local channel
+
+**Files:**
+- Create: `daemon/src/transport/connectAdapter.ts`
+- Create: `daemon/src/api/contracts.ts`
+- Create: `daemon/src/transport/__tests__/connectAdapter.test.ts`
+
+- [ ] **Step 1: Define the v0.3 RPC contract**
+
+Create `daemon/src/api/contracts.ts`. For v0.3 we ship hand-written TypeScript contracts (v0.4 will replace with `buf generate` from `.proto`). Keep it minimal — just enough for the handshake test:
+
+```typescript
+import { Type, Static } from "@sinclair/typebox";
+
+export const PingReq = Type.Object({ nonce: Type.String() });
+export const PingRes = Type.Object({ nonce: Type.String(), daemonVersion: Type.String() });
+export type PingReqT = Static<typeof PingReq>;
+export type PingResT = Static<typeof PingRes>;
+
+export const RPC_NAMES = {
+  ping: "ccsm.v1/ping",
+} as const;
+```
+
+Add `@sinclair/typebox` to daemon deps:
+
+```bash
+npm -w @ccsm/daemon install @sinclair/typebox
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```typescript
+import { describe, it, expect, afterEach } from "vitest";
+import { startLocalChannel } from "../localChannel";
+import { mountConnectAdapter } from "../connectAdapter";
+import { rpcCall } from "../testHelpers";
+import { RPC_NAMES, type PingResT } from "../../api/contracts";
+
+describe("connectAdapter", () => {
+  let close: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    await close?.();
+    close = undefined;
+  });
+
+  it("answers ping with daemonVersion echo", async () => {
+    const channel = await startLocalChannel({
+      onConnection: (socket) =>
+        mountConnectAdapter({
+          socket,
+          handlers: {
+            [RPC_NAMES.ping]: async ({ nonce }: { nonce: string }) => ({
+              nonce,
+              daemonVersion: "0.3.0-test",
+            }),
+          },
+        }),
+    });
+    close = channel.close;
+
+    const res = await rpcCall<PingResT>(channel.address, RPC_NAMES.ping, {
+      nonce: "abc",
+    });
+    expect(res).toEqual({ nonce: "abc", daemonVersion: "0.3.0-test" });
+  });
+});
+```
+
+- [ ] **Step 3: Run to confirm it fails**
+
+```bash
+npx vitest run daemon/src/transport/__tests__/connectAdapter.test.ts
+```
+
+Expected: FAIL (module-not-found).
+
+- [ ] **Step 4: Implement the adapter (length-prefixed JSON envelope)**
+
+We use a length-prefixed JSON envelope because Connect's HTTP/2 transport doesn't support raw stream sockets, and v0.3 only needs in-house IPC. v0.4 will swap to real Connect-over-HTTP.
+
+Create `daemon/src/transport/connectAdapter.ts`:
+
+```typescript
+import type { Socket } from "node:net";
+
+export interface ConnectAdapterOptions {
+  socket: Socket;
+  handlers: Record<string, (req: unknown) => Promise<unknown>>;
+}
+
+interface Envelope {
+  id: number;
+  method?: string;
+  payload?: unknown;
+  error?: { code: string; message: string };
+}
+
+export function mountConnectAdapter(opts: ConnectAdapterOptions): void {
+  const { socket, handlers } = opts;
+  let buffer = Buffer.alloc(0);
+
+  socket.on("data", (chunk) => {
+    buffer = Buffer.concat([buffer, chunk]);
+    while (buffer.length >= 4) {
+      const len = buffer.readUInt32BE(0);
+      if (buffer.length < 4 + len) break;
+      const body = buffer.subarray(4, 4 + len).toString("utf8");
+      buffer = buffer.subarray(4 + len);
+      const env = JSON.parse(body) as Envelope;
+      handle(env).catch((e) => writeEnv(socket, { id: env.id, error: { code: "internal", message: String(e) } }));
+    }
+  });
+
+  async function handle(env: Envelope): Promise<void> {
+    if (!env.method) return;
+    const fn = handlers[env.method];
+    if (!fn) {
+      writeEnv(socket, { id: env.id, error: { code: "not_found", message: env.method } });
+      return;
+    }
+    try {
+      const result = await fn(env.payload);
+      writeEnv(socket, { id: env.id, payload: result });
+    } catch (e: unknown) {
+      writeEnv(socket, { id: env.id, error: { code: "handler_error", message: String(e) } });
+    }
+  }
+}
+
+function writeEnv(socket: Socket, env: Envelope): void {
+  const body = Buffer.from(JSON.stringify(env), "utf8");
+  const header = Buffer.alloc(4);
+  header.writeUInt32BE(body.length, 0);
+  socket.write(Buffer.concat([header, body]));
+}
+```
+
+Create `daemon/src/transport/testHelpers.ts`:
+
+```typescript
+import { createConnection } from "node:net";
+
+export function rpcCall<T>(address: string, method: string, payload: unknown): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const sock = createConnection(address);
+    let buf = Buffer.alloc(0);
+
+    const env = { id: 1, method, payload };
+    const body = Buffer.from(JSON.stringify(env), "utf8");
+    const header = Buffer.alloc(4);
+    header.writeUInt32BE(body.length, 0);
+
+    sock.on("connect", () => sock.write(Buffer.concat([header, body])));
+    sock.on("data", (chunk) => {
+      buf = Buffer.concat([buf, chunk]);
+      if (buf.length < 4) return;
+      const len = buf.readUInt32BE(0);
+      if (buf.length < 4 + len) return;
+      const env2 = JSON.parse(buf.subarray(4, 4 + len).toString("utf8"));
+      sock.end();
+      if (env2.error) reject(new Error(env2.error.message));
+      else resolve(env2.payload as T);
+    });
+    sock.on("error", reject);
+  });
+}
+```
+
+- [ ] **Step 5: Run test**
+
+```bash
+npm -w @ccsm/daemon run build
+npx vitest run daemon/src/transport/__tests__/connectAdapter.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add daemon/src/api/ daemon/src/transport/ daemon/package.json daemon/package-lock.json
+git commit -m "feat(daemon): length-prefixed JSON RPC adapter on local channel"
+```
+
+> **v0.4 note:** The hand-written envelope and `rpcCall` helper are throwaway. v0.4 replaces them with real Connect-RPC over HTTP/2 once Protobuf schemas are generated. Keep the call sites in higher tasks pointed at `RPC_NAMES.*` constants so the swap touches only `connectAdapter.ts` + `testHelpers.ts`.
+
+---
+
+### Task 6: Wire transport into daemon entry
+
+**Files:**
+- Modify: `daemon/src/index.ts`
+- Create: `daemon/src/lifecycle.ts`
+
+- [ ] **Step 1: Add single-instance lock**
+
+Create `daemon/src/lifecycle.ts`:
+
+```typescript
+import { createConnection } from "node:net";
+
+export async function ensureSingleInstance(address: string): Promise<void> {
+  const alreadyRunning = await new Promise<boolean>((resolve) => {
+    const probe = createConnection(address);
+    probe.once("connect", () => { probe.end(); resolve(true); });
+    probe.once("error", () => resolve(false));
+  });
+  if (alreadyRunning) {
+    throw new Error(`ccsm-daemon already running at ${address}`);
+  }
+}
+```
+
+- [ ] **Step 2: Wire into entry**
+
+Replace `daemon/src/index.ts` body:
+
+```typescript
+import { logger } from "./log";
+import { startLocalChannel } from "./transport/localChannel";
+import { mountConnectAdapter } from "./transport/connectAdapter";
+import { ensureSingleInstance } from "./lifecycle";
+import { RPC_NAMES } from "./api/contracts";
+
+const DAEMON_VERSION = "0.3.0";
+
+async function main(): Promise<void> {
+  logger.info({ pid: process.pid }, "ccsm-daemon starting");
+
+  // Probe before claiming the address (best-effort; race window is tiny).
+  const probeAddress = process.platform === "win32"
+    ? `\\\\.\\pipe\\ccsm-daemon`
+    : `${process.env.HOME}/.ccsm/ccsm-daemon.sock`;
+  try {
+    await ensureSingleInstance(probeAddress);
+  } catch (e) {
+    logger.error({ err: String(e) }, "another daemon already running, exiting");
+    process.exit(2);
+  }
+
+  const channel = await startLocalChannel({
+    onConnection: (socket) =>
+      mountConnectAdapter({
+        socket,
+        handlers: {
+          [RPC_NAMES.ping]: async ({ nonce }: { nonce: string }) => ({
+            nonce,
+            daemonVersion: DAEMON_VERSION,
+          }),
+        },
+      }),
+  });
+
+  logger.info({ address: channel.address }, "ccsm-daemon listening");
+
+  const shutdown = async (signal: string): Promise<void> => {
+    logger.info({ signal }, "shutting down");
+    await channel.close();
+    process.exit(0);
+  };
+  process.on("SIGTERM", () => void shutdown("SIGTERM"));
+  process.on("SIGINT", () => void shutdown("SIGINT"));
+}
+
+main().catch((err) => {
+  logger.fatal({ err: String(err) }, "daemon fatal");
+  process.exit(1);
+});
+```
+
+- [ ] **Step 3: Boot daemon manually + ping it**
+
+```bash
+npm -w @ccsm/daemon run build
+node daemon/dist-daemon/index.js &
+sleep 1
+node -e "
+const {rpcCall} = require('./daemon/dist-daemon/transport/testHelpers');
+rpcCall(process.platform==='win32'?'\\\\\\\\.\\\\pipe\\\\ccsm-daemon':process.env.HOME+'/.ccsm/ccsm-daemon.sock','ccsm.v1/ping',{nonce:'x'}).then(r=>{console.log(r);process.exit(0)})"
+kill %1
+```
+
+Expected stdout: `{ nonce: 'x', daemonVersion: '0.3.0' }`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add daemon/src/index.ts daemon/src/lifecycle.ts
+git commit -m "feat(daemon): wire local channel + ping handler into entry"
+```
+
+---
+
+### Task 7: Electron-side `daemonClient.spawnOrAttach` + handshake e2e
+
+**Files:**
+- Create: `electron/daemonClient/spawnOrAttach.ts`
+- Create: `electron/daemonClient/connectClient.ts`
+- Create: `electron/daemonClient/__tests__/spawnOrAttach.test.ts`
+- Create: `tests/electron-daemon-handshake.e2e.ts`
+
+- [ ] **Step 1: Write the unit test for spawnOrAttach**
+
+```typescript
+import { describe, it, expect, afterEach } from "vitest";
+import { spawn } from "node:child_process";
+import { join } from "node:path";
+import { spawnOrAttach } from "../spawnOrAttach";
+
+const DAEMON_BIN = join(__dirname, "..", "..", "..", "daemon", "dist-daemon", "index.js");
+
+describe("spawnOrAttach", () => {
+  let child: ReturnType<typeof spawn> | undefined;
+
+  afterEach(() => {
+    child?.kill();
+    child = undefined;
+  });
+
+  it("attaches to a running daemon (no spawn)", async () => {
+    child = spawn(process.execPath, [DAEMON_BIN], { stdio: "ignore", detached: false });
+    await new Promise((r) => setTimeout(r, 800));
+
+    const handle = await spawnOrAttach({ daemonBinary: DAEMON_BIN, spawnIfMissing: true });
+    expect(handle.spawnedNew).toBe(false);
+    await handle.client.ping("test-nonce");
+  });
+
+  it("spawns the daemon when none is running", async () => {
+    const handle = await spawnOrAttach({ daemonBinary: DAEMON_BIN, spawnIfMissing: true });
+    expect(handle.spawnedNew).toBe(true);
+    const res = await handle.client.ping("nonce-2");
+    expect(res.nonce).toBe("nonce-2");
+    handle.killSpawned?.();
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm it fails**
+
+```bash
+npx vitest run electron/daemonClient/__tests__/spawnOrAttach.test.ts
+```
+
+Expected: FAIL (module-not-found).
+
+- [ ] **Step 3: Implement `connectClient.ts`**
+
+```typescript
+import { rpcCall } from "../../daemon/src/transport/testHelpers";
+import { RPC_NAMES, type PingResT } from "../../daemon/src/api/contracts";
+
+export interface DaemonClient {
+  ping(nonce: string): Promise<PingResT>;
+}
+
+export function makeClient(address: string): DaemonClient {
+  return {
+    ping: (nonce) => rpcCall<PingResT>(address, RPC_NAMES.ping, { nonce }),
+  };
+}
+```
+
+> Direct deep-import into `daemon/src/transport/testHelpers` is acceptable for v0.3. v0.4 publishes a proper client package once Protobuf is in place.
+
+- [ ] **Step 4: Implement `spawnOrAttach.ts`**
+
+```typescript
+import { spawn, type ChildProcess } from "node:child_process";
+import { createConnection } from "node:net";
+import { makeClient, type DaemonClient } from "./connectClient";
+
+export interface SpawnOrAttachOptions {
+  daemonBinary: string;
+  spawnIfMissing: boolean;
+}
+
+export interface DaemonHandle {
+  client: DaemonClient;
+  address: string;
+  spawnedNew: boolean;
+  killSpawned?: () => void;
+}
+
+function defaultAddress(): string {
+  if (process.platform === "win32") return `\\\\.\\pipe\\ccsm-daemon`;
+  return `${process.env.HOME}/.ccsm/ccsm-daemon.sock`;
+}
+
+async function probe(address: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const c = createConnection(address);
+    c.once("connect", () => { c.end(); resolve(true); });
+    c.once("error", () => resolve(false));
+  });
+}
+
+async function waitFor(address: string, timeoutMs: number): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await probe(address)) return;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(`daemon did not become ready at ${address} within ${timeoutMs}ms`);
+}
+
+export async function spawnOrAttach(opts: SpawnOrAttachOptions): Promise<DaemonHandle> {
+  const address = defaultAddress();
+  if (await probe(address)) {
+    return { client: makeClient(address), address, spawnedNew: false };
+  }
+  if (!opts.spawnIfMissing) {
+    throw new Error(`no daemon at ${address} and spawnIfMissing=false`);
+  }
+
+  const child: ChildProcess = spawn(process.execPath, [opts.daemonBinary], {
+    stdio: "ignore",
+    detached: true,
+  });
+  child.unref();
+  await waitFor(address, 5000);
+  return {
+    client: makeClient(address),
+    address,
+    spawnedNew: true,
+    killSpawned: () => child.kill(),
+  };
+}
+```
+
+- [ ] **Step 5: Run unit tests**
+
+```bash
+npm run build
+npx vitest run electron/daemonClient/__tests__/spawnOrAttach.test.ts
+```
+
+Expected: PASS (both attach + spawn cases).
+
+- [ ] **Step 6: Write e2e handshake test**
+
+```typescript
+import { _electron, expect, test } from "@playwright/test";
+import { spawnSync } from "node:child_process";
+import { existsSync, unlinkSync } from "node:fs";
+
+test.describe("electron + daemon handshake", () => {
+  test.beforeEach(() => {
+    const sock = process.platform === "win32" ? null : `${process.env.HOME}/.ccsm/ccsm-daemon.sock`;
+    if (sock && existsSync(sock)) unlinkSync(sock);
+    spawnSync("pkill", ["-f", "dist-daemon/index.js"], { stdio: "ignore" });
+  });
+
+  test("electron boots, spawns daemon, ping succeeds", async () => {
+    const app = await _electron.launch({ args: ["dist/electron/main.js"] });
+    const page = await app.firstWindow();
+    await expect(page.locator("body")).toBeVisible();
+    const pingResult = await app.evaluate(async () => (globalThis as any).__ccsmDaemonHandle__?.client?.ping("e2e"));
+    expect(pingResult?.daemonVersion).toBe("0.3.0");
+    await app.close();
+  });
+});
+```
+
+(Requires `electron/main.ts` modification in next task to expose handle on `globalThis.__ccsmDaemonHandle__`.)
+
+- [ ] **Step 7: Commit (skip e2e until Task 8 wires main.ts)**
+
+```bash
+git add electron/daemonClient/ tests/electron-daemon-handshake.e2e.ts
+git commit -m "feat(electron): daemon spawn-or-attach + Connect client"
+```
+
+---
+
+## Phase 2 — Service lift (one domain at a time, dual-running behind flag)
+
+Each service task follows the same shape: (a) copy domain into `daemon/src/services/`, (b) add RPC handler in daemon, (c) bind feature flag in Electron preload bridge so the bridge calls EITHER the in-process service OR the daemon, depending on env var `CCSM_USE_DAEMON=<service-name>` (comma-separated). This lets us flip services one at a time and roll back individually.
+
+### Task 8: Lift `dbService` to daemon
+
+**Files:**
+- Create: `daemon/src/services/dbService.ts` (lifted from `electron/db.ts`)
+- Create: `daemon/src/services/__tests__/dbService.test.ts`
+- Modify: `daemon/src/api/contracts.ts` (add db RPC names + types)
+- Modify: `daemon/src/index.ts` (register db handlers)
+- Modify: `electron/preload/bridges/ccsmCore.ts` (flag-gated db calls)
+- Modify: `electron/main.ts` (wire `globalThis.__ccsmDaemonHandle__`)
+
+- [ ] **Step 1: Read the existing `electron/db.ts` (218 LOC) and `electron/ipc/dbIpc.ts` (89 LOC) end-to-end**
+
+```bash
+cat electron/db.ts electron/ipc/dbIpc.ts
+```
+
+List the public API surface (exports + IPC channel names). For the DB layer this is small — typically `getSetting`, `setSetting`, `listSessions`, `upsertSession`, `deleteSession`, etc. WRITE the list down before continuing — you'll convert each one to an RPC.
+
+- [ ] **Step 2: Add db RPC names + request/response types**
+
+In `daemon/src/api/contracts.ts`, append (using actual API surface from Step 1):
+
+```typescript
+export const SettingGetReq = Type.Object({ key: Type.String() });
+export const SettingGetRes = Type.Object({ value: Type.Union([Type.String(), Type.Null()]) });
+export const SettingSetReq = Type.Object({ key: Type.String(), value: Type.String() });
+export const SettingSetRes = Type.Object({});
+// ... one Type.Object pair per public DB function found in Step 1
+
+RPC_NAMES.dbSettingGet = "ccsm.v1/db.settingGet";
+RPC_NAMES.dbSettingSet = "ccsm.v1/db.settingSet";
+// ... one constant per function
+```
+
+(Convert `RPC_NAMES` from `as const` to a regular const object so it can be mutated, or just inline each new constant.)
+
+- [ ] **Step 3: Lift `electron/db.ts` to `daemon/src/services/dbService.ts`**
+
+```bash
+cp electron/db.ts daemon/src/services/dbService.ts
+```
+
+Edit imports in the new file: any `electron`-package imports must be removed (the daemon has no `electron` runtime). If `electron/db.ts` references `app.getPath('userData')`, replace with `path.join(homedir(), '.ccsm', 'data')` directly. Add a one-time `mkdirSync` at module load.
+
+- [ ] **Step 4: Write daemon-side handler tests**
+
+```typescript
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as db from "../dbService";
+
+describe("dbService", () => {
+  beforeEach(() => {
+    process.env.CCSM_DATA_DIR = mkdtempSync(join(tmpdir(), "ccsm-test-"));
+    db._resetForTest();
+  });
+
+  it("setSetting / getSetting roundtrips", async () => {
+    await db.setSetting("foo", "bar");
+    expect(await db.getSetting("foo")).toBe("bar");
+  });
+
+  it("getSetting returns null for unknown key", async () => {
+    expect(await db.getSetting("missing")).toBeNull();
+  });
+
+  // ... one test per public function
+});
+```
+
+(Add `_resetForTest` to `dbService.ts` that closes + reopens the DB. Add `CCSM_DATA_DIR` env var support next to the existing path resolution.)
+
+- [ ] **Step 5: Run tests**
+
+```bash
+npm -w @ccsm/daemon run build
+npx vitest run daemon/src/services/__tests__/dbService.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Register handlers in daemon entry**
+
+In `daemon/src/index.ts`, extend the `handlers` object passed to `mountConnectAdapter`:
+
+```typescript
+import * as db from "./services/dbService";
+// ...
+handlers: {
+  [RPC_NAMES.ping]: async ({ nonce }) => ({ nonce, daemonVersion: DAEMON_VERSION }),
+  [RPC_NAMES.dbSettingGet]: async ({ key }) => ({ value: await db.getSetting(key) }),
+  [RPC_NAMES.dbSettingSet]: async ({ key, value }) => { await db.setSetting(key, value); return {}; },
+  // ...
+},
+```
+
+- [ ] **Step 7: Wire `globalThis.__ccsmDaemonHandle__` in Electron main**
+
+In `electron/main.ts`, near the top of `app.whenReady().then(...)` or your existing bootstrap function, add:
+
+```typescript
+import { spawnOrAttach } from "./daemonClient/spawnOrAttach";
+import { join } from "node:path";
+
+const daemonBin = join(__dirname, "..", "..", "daemon", "dist-daemon", "index.js");
+const daemonHandle = await spawnOrAttach({ daemonBinary: daemonBin, spawnIfMissing: true });
+(globalThis as any).__ccsmDaemonHandle__ = daemonHandle;
+```
+
+Wrap in try/catch; on failure log + show user-facing dialog.
+
+- [ ] **Step 8: Flag-gate the bridge**
+
+In `electron/preload/bridges/ccsmCore.ts`, find the `getSetting` and `setSetting` exports. Replace their bodies with:
+
+```typescript
+export async function getSetting(key: string): Promise<string | null> {
+  if (process.env.CCSM_USE_DAEMON?.split(",").includes("db")) {
+    const handle = (globalThis as any).__ccsmDaemonHandle__;
+    const res = await handle.client.dbSettingGet(key);
+    return res.value;
+  }
+  return ipcRenderer.invoke("ccsm:db:getSetting", key);
+}
+```
+
+(Add corresponding `dbSettingGet` method to `DaemonClient` interface in `electron/daemonClient/connectClient.ts`.)
+
+- [ ] **Step 9: E2E with flag on**
+
+Run app with `CCSM_USE_DAEMON=db npm start` and verify any UI that reads/writes settings still works. Capture a screenshot for the PR.
+
+- [ ] **Step 10: E2E with flag off**
+
+Run app without the flag and verify same UI works (in-process path).
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add daemon/src/services/ daemon/src/api/contracts.ts daemon/src/index.ts electron/preload/bridges/ccsmCore.ts electron/daemonClient/ electron/main.ts
+git commit -m "feat(daemon): lift dbService behind CCSM_USE_DAEMON=db flag"
+```
+
+---
+
+### Task 9: Lift `sdkService` to daemon
+
+(Same template as Task 8, applied to the existing `loadSdk` shim.)
+
+**Files:**
+- Create: `daemon/src/services/sdkService.ts`
+- Create: `daemon/src/services/__tests__/sdkService.test.ts`
+- Modify: contracts, daemon entry, relevant bridge
+
+- [ ] **Step 1: Identify SDK call sites**
+
+```bash
+grep -rn "loadSdk\|claude-agent-sdk" electron/ src/ --include="*.ts" --include="*.tsx" | head -40
+```
+
+Write down each call's signature (input + output).
+
+- [ ] **Step 2: Create `daemon/src/services/sdkService.ts`**
+
+Move the dynamic-import shim verbatim. Preserve the rule from memory `project_sdk_loader_shim.md`: SDK is ESM-only, daemon is CJS, MUST use dynamic import shim. Confirm `daemon/package.json` has `"type": "commonjs"` (Task 1 set it).
+
+```typescript
+let sdkPromise: Promise<typeof import("claude-agent-sdk")> | undefined;
+
+export function loadSdk(): Promise<typeof import("claude-agent-sdk")> {
+  if (!sdkPromise) {
+    sdkPromise = import("claude-agent-sdk");
+  }
+  return sdkPromise;
+}
+
+export async function quickModelCall(prompt: string): Promise<string> {
+  const sdk = await loadSdk();
+  // Match the actual call shape used by sessionTitles deciders.
+  // Lift verbatim from electron/sessionTitles/index.ts where loadSdk is called.
+  return /* ... */;
+}
+```
+
+- [ ] **Step 3: Smoke test (no real network)**
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { loadSdk } from "../sdkService";
+
+describe("sdkService", () => {
+  it("loadSdk returns the SDK module without throwing", async () => {
+    const sdk = await loadSdk();
+    expect(sdk).toBeDefined();
+    expect(typeof sdk).toBe("object");
+  });
+});
+```
+
+- [ ] **Step 4: Run + register + flag-gate (mirror Task 8 steps 5-10)**
+
+- [ ] **Step 5: E2E** — flag on, do an action that triggers an SDK call (e.g. session title generation).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit -m "feat(daemon): lift sdkService behind CCSM_USE_DAEMON=sdk flag"
+```
+
+---
+
+### Task 10: Lift `sessionTitles` service to daemon
+
+**Files:**
+- Move: `electron/sessionTitles/**` → `daemon/src/services/sessionTitles/**`
+- Modify: contracts, daemon entry, `electron/preload/bridges/ccsmSessionTitles.ts`
+
+- [ ] **Step 1: Read `electron/sessionTitles/index.ts` (313 LOC) and `deciders.ts` (81 LOC) end-to-end**
+
+Catalog: which functions are exported, which callers exist, which deciders run.
+
+- [ ] **Step 2: Copy directory**
+
+```bash
+mkdir -p daemon/src/services/sessionTitles
+cp electron/sessionTitles/index.ts daemon/src/services/sessionTitles/index.ts
+cp electron/sessionTitles/deciders.ts daemon/src/services/sessionTitles/deciders.ts
+cp -r electron/sessionTitles/__tests__ daemon/src/services/sessionTitles/__tests__
+```
+
+Adjust imports: anything from `electron/db` → `../dbService` (now in daemon), anything from `electron/sessionTitles/loadSdk` → `../sdkService`. Strip Electron-only logging if any.
+
+- [ ] **Step 3: Run lifted tests**
+
+```bash
+npm -w @ccsm/daemon run build
+npx vitest run daemon/src/services/sessionTitles/__tests__/
+```
+
+Expected: PASS (after import fixes).
+
+- [ ] **Step 4: Add RPC contracts** (one per public function — e.g. `generateTitle(sessionId, transcript)`)
+
+- [ ] **Step 5: Register handlers + flag-gate bridge** (mirror Task 8 steps 6-10)
+
+- [ ] **Step 6: E2E** — flag on, create a new session with prompts, verify title appears.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git commit -m "feat(daemon): lift sessionTitles behind CCSM_USE_DAEMON=sessionTitles flag"
+```
+
+---
+
+### Task 11: Lift `ptyService` (data side) to daemon
+
+This is the largest single lift (~1300 LOC across `electron/ptyHost/**`). Split into sub-tasks 11a/11b/11c rather than one mega-step.
+
+#### Task 11a: Move PTY core (lifecycle, processKiller, resolvers)
+
+**Files:**
+- Move: `electron/ptyHost/lifecycle.ts`, `processKiller.ts`, `claudeResolver.ts`, `cwdResolver.ts`, `jsonlResolver.ts` → `daemon/src/services/pty/`
+- Move: tests alongside.
+
+- [ ] **Step 1: Copy + fix imports** (no Electron-package refs allowed)
+- [ ] **Step 2: Run unit tests**
+- [ ] **Step 3: Commit** `feat(daemon/pty): move core modules`
+
+#### Task 11b: Move PTY entry + factory + osc title sniffer
+
+**Files:**
+- Move: `electron/ptyHost/index.ts`, `entryFactory.ts`, `oscTitleSniffer.ts`, `dataFanout.ts` → `daemon/src/services/pty/`
+
+- [ ] **Step 1: Copy + fix imports**
+- [ ] **Step 2: Add xterm-headless buffer per session inside `entryFactory.ts`** (verify L4 PR-A..E commits `49353a9`, `9971733`, `64b5248` already added this; if so, just confirm wiring; if not, add `new Terminal({ allowProposedApi: true })` from `@xterm/headless` per session and `term.write(data)` in the data path)
+- [ ] **Step 3: Add seq counter per session** in `dataFanout.ts`; emit `(seq, chunk)` instead of bare chunks.
+- [ ] **Step 4: Run unit tests**
+- [ ] **Step 5: Commit** `feat(daemon/pty): entry + headless buffer + seq counter`
+
+#### Task 11c: PTY RPC handlers + bridge swap
+
+**Files:**
+- Modify: `daemon/src/api/contracts.ts` (add `ptyStart`, `ptyWrite`, `ptyResize`, `ptyKill` unary + `ptySubscribe(sessionId, fromSeq?)` server-stream)
+- Modify: `daemon/src/transport/connectAdapter.ts` (add server-stream support — extend envelope with `streamId` + `streamChunk` + `streamEnd` message types)
+- Modify: `daemon/src/index.ts` (register handlers)
+- Modify: `electron/preload/bridges/ccsmPty.ts` (flag-gate; replace `ipcRenderer.on('pty-data')` with subscription EventEmitter pumped by stream)
+
+- [ ] **Step 1: Extend envelope for server-streams**
+
+```typescript
+interface Envelope {
+  id: number;
+  method?: string;
+  payload?: unknown;
+  error?: { code: string; message: string };
+  // new:
+  stream?: { kind: "open" | "chunk" | "end"; chunk?: unknown };
+}
+```
+
+In handler dispatch, if the handler is registered as a stream handler, hold the socket and emit `{ id, stream: { kind: "chunk", chunk: ... } }` for each item, then `{ id, stream: { kind: "end" } }`.
+
+- [ ] **Step 2: Server-side ptySubscribe handler**
+
+```typescript
+[RPC_NAMES.ptySubscribe]: streamHandler(async (req, push, end) => {
+  const { sessionId, fromSeq } = req as { sessionId: string; fromSeq?: number };
+  const buffer = pty.getBuffer(sessionId, fromSeq ?? 0);
+  push({ kind: "snapshot", seq: buffer.seq, data: buffer.serialize() });
+  const off = pty.subscribe(sessionId, (seq, chunk) => push({ kind: "delta", seq, data: chunk }));
+  return () => off();
+}),
+```
+
+(Where `streamHandler` is a small helper in `connectAdapter.ts` that registers the socket-aware push/end functions.)
+
+- [ ] **Step 3: Client-side stream consumer**
+
+In `electron/daemonClient/connectClient.ts`, add:
+
+```typescript
+ptySubscribe(sessionId: string, fromSeq: number, onMessage: (msg: PtyStreamMsg) => void): () => void {
+  // open socket, send envelope { method: 'ccsm.v1/pty.subscribe', payload: {sessionId, fromSeq} }
+  // on each incoming `stream.chunk` envelope, call onMessage(chunk)
+  // return cancel function that ends the socket
+}
+```
+
+- [ ] **Step 4: Flag-gate `ccsmPty.ts` bridge**
+
+```typescript
+if (process.env.CCSM_USE_DAEMON?.split(",").includes("pty")) {
+  const handle = (globalThis as any).__ccsmDaemonHandle__;
+  return handle.client.ptySubscribe(sessionId, fromSeq, (msg) => emit("pty-data", msg));
+}
+// fallback: existing ipcRenderer path
+```
+
+- [ ] **Step 5: E2E — start a session with `CCSM_USE_DAEMON=pty`, type commands, verify output streams correctly**
+
+Capture a Playwright screenshot for the PR.
+
+- [ ] **Step 6: E2E — multi-client replay**
+
+```bash
+CCSM_USE_DAEMON=pty npm start &
+sleep 3
+# in another terminal, manually open second connection:
+node -e "
+const {makeClient} = require('./dist/electron/daemonClient/connectClient');
+const c = makeClient(process.platform==='win32'?'\\\\\\\\.\\\\pipe\\\\ccsm-daemon':process.env.HOME+'/.ccsm/ccsm-daemon.sock');
+const cancel = c.ptySubscribe('<existing-session-id>', 0, (m) => console.log(m));
+setTimeout(() => { cancel(); process.exit(0); }, 5000);
+"
+```
+
+Expected: second subscriber receives the same buffer snapshot as the Electron UI.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git commit -m "feat(daemon/pty): subscribe + write + resize + kill RPCs with seq replay"
+```
+
+---
+
+### Task 12: Lift `sessionService` (CRUD) to daemon
+
+**Files:**
+- Move: `electron/ipc/sessionIpc.ts` logic into `daemon/src/services/sessionService.ts`
+- Modify: contracts, daemon entry, `electron/preload/bridges/ccsmSession.ts`
+
+- [ ] **Step 1: Catalog `sessionIpc.ts` handlers (135 LOC)** — list each `ipcMain.handle('ccsm:session:*', ...)` channel.
+- [ ] **Step 2: Lift handler bodies into `sessionService.ts`** — pure functions, no Electron deps, depend on `dbService` (Task 8) for persistence.
+- [ ] **Step 3: Add unit tests**
+- [ ] **Step 4: Add RPC contracts + handlers**
+- [ ] **Step 5: Flag-gate bridge**
+- [ ] **Step 6: E2E** — list/create/delete sessions with flag on
+- [ ] **Step 7: Commit** `feat(daemon): lift sessionService behind CCSM_USE_DAEMON=session flag`
+
+---
+
+### Task 13: Lift `notifyService` (data + queue side) to daemon
+
+The notify domain is ~1100 LOC under `electron/notify/**`, but the **badge image renderer (`badgePixels.ts`, 271 LOC)** must stay in Electron because it depends on the Win Overlay API which is Electron-process-only (per F1 spike). Split:
+
+- Daemon owns: queue, dedup logic, severity routing, persistence of unread counters.
+- Electron owns: rendering pixel buffer, calling `setOverlayIcon()`.
+
+**Files:**
+- Move: notify queue/dedup/router → `daemon/src/services/notify/`
+- Keep in Electron: `electron/notify/badgePixels.ts`, `electron/notify/badgeController.ts`
+- Add RPC: `notifyEnqueue(notification)` unary + `notifyBadgeStream()` server-stream emitting `{ count, severity }` updates that Electron consumes to redraw badge.
+
+- [ ] **Step 1: Read `electron/notify/**` + `electron/badgeController.ts`** end-to-end. Identify which functions touch only data (lift) vs which touch Electron APIs (keep).
+- [ ] **Step 2: Lift the data side; leave the badge renderer alone.**
+- [ ] **Step 3: Add unit tests for the lifted side.**
+- [ ] **Step 4: Add RPC contracts (unary enqueue + server-stream badge updates).**
+- [ ] **Step 5: Flag-gate `electron/preload/bridges/ccsmNotify.ts`.**
+- [ ] **Step 6: Wire `electron/badgeController.ts` to subscribe to `notifyBadgeStream()` instead of the local in-process emitter.** This stays inside Electron main, not preload.
+- [ ] **Step 7: E2E** — trigger a notification with flag on, verify badge updates and tray notification fires.
+- [ ] **Step 8: Commit** `feat(daemon): lift notify queue + badge stream behind CCSM_USE_DAEMON=notify flag`
+
+---
+
+### Task 14: Lift CLI subprocess manager to daemon
+
+ccsm spawns the Anthropic CLI as a child process. Today this happens inside the PTY layer. Most of this lifted with Task 11. This task is for any remaining CLI lifecycle helpers (e.g. spawning a one-shot CLI for `--version` checks).
+
+**Files:**
+- Search: `grep -rn "execFile\|spawn.*claude" electron/ --include="*.ts"` to find any non-PTY CLI uses.
+- Move whatever's found to `daemon/src/services/cliRunner.ts`.
+
+- [ ] **Step 1: grep + catalog**
+- [ ] **Step 2: Lift if any uses found; otherwise close the task as N/A and commit nothing**
+- [ ] **Step 3: Commit** if applicable
+
+---
+
+### Task 15: End-of-Phase-2 dual-run e2e gate
+
+**Files:**
+- Create: `tests/dual-run-all-services.e2e.ts`
+
+- [ ] **Step 1: Write a Playwright test that boots Electron with `CCSM_USE_DAEMON=db,sdk,sessionTitles,pty,session,notify` (all flags on)** and exercises every renderer path that reaches a bridge: open settings, create session, run a command in PTY, generate a title, dismiss a notification.
+
+- [ ] **Step 2: Run baseline (flags off)** and capture a snapshot of expected bridge call counts via instrumentation.
+
+- [ ] **Step 3: Run with all flags on** and assert: same call counts, same UI output, no errors logged.
+
+- [ ] **Step 4: Commit + PR end-of-Phase-2** — at this point both code paths exist and the daemon handles all data; in-process IPC is dead code waiting to be deleted.
+
+```bash
+git commit -m "test(e2e): dual-run gate with all daemon flags enabled"
+```
+
+---
+
+## Phase 3 — Bridge swap (delete dead in-process code)
+
+Each task removes the flag fork from one bridge file, then deletes the corresponding `electron/ipc/*.ts` file once no callers remain.
+
+### Task 16: Make daemon path the only path for db + session
+
+**Files:**
+- Modify: `electron/preload/bridges/ccsmCore.ts` (remove `if (CCSM_USE_DAEMON.includes('db'))` fork; daemon is unconditional)
+- Modify: `electron/preload/bridges/ccsmSession.ts` (same)
+- Delete: `electron/ipc/dbIpc.ts`
+- Delete: `electron/ipc/sessionIpc.ts`
+- Delete: `electron/db.ts`
+- Modify: `electron/main.ts` (remove `setupDbIpc()` / `setupSessionIpc()` calls)
+
+- [ ] **Step 1: Remove the flag fork in ccsmCore.ts** (replace with daemon-only call)
+- [ ] **Step 2: Remove the flag fork in ccsmSession.ts**
+- [ ] **Step 3: Delete the IPC files + main.ts setup calls**
+- [ ] **Step 4: Run full test suite** — `npm test` + e2e. Anything that referenced the deleted `ipcMain.handle('ccsm:db:*')` channels will fail.
+- [ ] **Step 5: Fix fallout** until green.
+- [ ] **Step 6: Commit** `refactor(electron): db + session are daemon-only`
+
+### Task 17: Same for sessionTitles + notify + sdk
+
+(Mirror Task 16 for the remaining bridges.)
+
+- [ ] **Step 1-6 per bridge**
+- [ ] **Step 7: Commit** `refactor(electron): sessionTitles + notify + sdk are daemon-only`
+
+### Task 18: Make pty daemon-only
+
+The riskiest swap (largest LOC, most-used path, server-stream involved). Do it last.
+
+- [ ] **Step 1: Remove flag fork in ccsmPty.ts**
+- [ ] **Step 2: Delete `electron/ptyHost/**`** (already moved to daemon in Task 11)
+- [ ] **Step 3: Run full e2e — focus on terminal flows**
+- [ ] **Step 4: Capture screenshots before/after for the PR**
+- [ ] **Step 5: Commit** `refactor(electron): pty is daemon-only`
+
+### Task 19: Sweep + unused-code removal
+
+- [ ] **Step 1: Run** `npx ts-prune` or `npx knip` over `electron/`. Each unused export is either dead (delete) or rescued by a refactor introduced in this phase (commit a follow-up).
+- [ ] **Step 2: Verify smoke test still passes** — `tests/electron-load-smoke.test.ts` will catch any module that no longer compiles.
+- [ ] **Step 3: Commit** `chore(electron): remove dead in-process IPC code`
+
+---
+
+## Phase 4 — Packaging + lifecycle
+
+### Task 20: `pkg`-bundle the daemon into a single binary
+
+**Files:**
+- Modify: `daemon/package.json` (add `pkg` config + script)
+- Modify: root `package.json` (`build:daemon-binary` script)
+- Create: `daemon/scripts/postPackage.js` (chmod +x for *nix)
+
+- [ ] **Step 1: Add `@yao-pkg/pkg` as devDep**
+
+```bash
+npm -w @ccsm/daemon install -D @yao-pkg/pkg
+```
+
+- [ ] **Step 2: Add pkg config to `daemon/package.json`**
+
+```json
+{
+  "scripts": {
+    "package": "pkg dist-daemon/index.js --targets node22-win-x64,node22-macos-x64,node22-linux-x64 --output ../release-bin/ccsm-daemon"
+  },
+  "pkg": {
+    "assets": ["dist-daemon/**/*"],
+    "scripts": ["dist-daemon/**/*.js"]
+  }
+}
+```
+
+- [ ] **Step 3: Add native-module bundling note**
+
+`better-sqlite3` and `node-pty` are native modules. `pkg` cannot bundle native `.node` files; they must ship alongside the binary. Add a step that copies `node_modules/better-sqlite3/build/Release/better_sqlite3.node` and `node_modules/node-pty/build/Release/pty.node` into `release-bin/native/` and have the daemon load them via an env-aware require path. Verify on Win.
+
+- [ ] **Step 4: Run packaging**
+
+```bash
+npm -w @ccsm/daemon run build && npm -w @ccsm/daemon run package
+ls release-bin/
+```
+
+Expected: 3 binaries.
+
+- [ ] **Step 5: Smoke-run the Win binary**
+
+```bash
+./release-bin/ccsm-daemon-win.exe &
+sleep 2
+node -e "/* same ping script as Task 6 */"
+taskkill /IM ccsm-daemon-win.exe /F
+```
+
+- [ ] **Step 6: Update Electron `spawnOrAttach.ts`** to prefer the bundled binary location in production (`process.resourcesPath/daemon/ccsm-daemon[.exe]`) and fall back to `daemon/dist-daemon/index.js` in dev.
+
+- [ ] **Step 7: Commit** `build(daemon): pkg-bundle to single binary per OS`
+
+---
+
+### Task 21: Tray-quit semantics (Electron close → daemon survives; tray Quit → both die)
+
+**Files:**
+- Modify: `electron/main.ts`
+- Modify: `electron/tray/createTray.ts` (84 LOC)
+- Modify: `daemon/src/lifecycle.ts` (add explicit "shutdown" RPC)
+
+- [ ] **Step 1: Add `shutdown` RPC to daemon**
+
+```typescript
+[RPC_NAMES.daemonShutdown]: async () => {
+  setTimeout(() => process.exit(0), 100);
+  return {};
+},
+```
+
+- [ ] **Step 2: Wire Electron close behavior**
+
+In `electron/main.ts`, on `app.on('window-all-closed')`, do NOT `app.quit()`. Just leave the daemon running.
+
+- [ ] **Step 3: Wire tray Quit menu**
+
+In `electron/tray/createTray.ts`, the `Quit` menu item calls:
+
+```typescript
+await daemonHandle.client.daemonShutdown();
+app.quit();
+```
+
+- [ ] **Step 4: E2E**
+
+```bash
+npm start
+# close window → app stays in tray, daemon process still running (verify with ps/Get-Process)
+# right-click tray → Quit → both die
+```
+
+- [ ] **Step 5: Commit** `feat(electron): tray-resident lifecycle, daemon survives window close`
+
+---
+
+### Task 22: OS-specific install hooks (deferred — only if Phase 5 dogfood reveals need)
+
+Spec §9 explicitly defers OS-boot autostart to v0.5 (it's only needed for remote-only access). For v0.3 the user always opens Electron first, which spawns the daemon. SKIP this task in v0.3 unless dogfood reveals a missing case.
+
+- [ ] **Step 1: Verify dogfood (Task 25) does NOT require boot-time autostart for the v0.3 use cases (Electron always running on dev box).** If it does, escalate; otherwise close as deferred.
+
+---
+
+## Phase 5 — Updater + dogfood + ship
+
+### Task 23: Daemon auto-updater (poll GitHub releases)
+
+**Files:**
+- Implement: `daemon/src/services/updaterService.ts`
+- Modify: `daemon/src/index.ts` (start updater on boot)
+
+- [ ] **Step 1: Decide release source**
+
+Per spec §3.1: "poll `Jiahui-Gu/ccsm-daemon` GitHub releases (separate repo or tag prefix, TBD in implementation plan)". DECIDE: use the existing `Jiahui-Gu/ccsm` repo with tag prefix `daemon-v*` (avoids creating a second repo, keeps daemon binary release artifacts on the same release pages as the Electron installer). Document this in `daemon/README.md`.
+
+- [ ] **Step 2: Implement poller**
+
+```typescript
+import { Octokit } from "@octokit/rest";
+
+const POLL_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
+
+export async function checkForUpdate(currentVersion: string): Promise<string | null> {
+  const oct = new Octokit();
+  const { data } = await oct.repos.listReleases({
+    owner: "Jiahui-Gu",
+    repo: "ccsm",
+    per_page: 20,
+  });
+  const latest = data
+    .filter((r) => r.tag_name.startsWith("daemon-v"))
+    .map((r) => r.tag_name.replace("daemon-v", ""))
+    .sort()
+    .pop();
+  if (!latest || latest === currentVersion) return null;
+  return latest;
+}
+```
+
+- [ ] **Step 3: Implement download + swap**
+
+Download the OS-matched asset → SHA256 verify against published checksum → write to `<binary path>.new` → spawn small batch script (Win) or shell script (Mac/Linux) that waits 1s, replaces the old binary, restarts daemon.
+
+- [ ] **Step 4: Unit test the version compare + URL selection logic**
+
+(Skip the actual download in tests; mock Octokit.)
+
+- [ ] **Step 5: Boot daemon with updater enabled, manually publish a fake daemon-v0.3.1 tag, verify swap completes.**
+
+- [ ] **Step 6: Commit** `feat(daemon): GitHub-poll auto-updater`
+
+---
+
+### Task 24: Release pipeline integration
+
+**Files:**
+- Modify: `.github/workflows/release.yml` (build + attach daemon binary)
+
+- [ ] **Step 1: Add daemon build job**
+
+In the release workflow, after the existing electron build:
+
+```yaml
+  package-daemon:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix: { os: [ubuntu-latest, macos-latest, windows-latest] }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 22 }
+      - run: npm ci
+      - run: npm run build
+      - run: npm -w @ccsm/daemon run package
+      - run: shasum -a 256 release-bin/ccsm-daemon-* > release-bin/SHA256SUMS
+      - uses: actions/upload-artifact@v4
+        with: { name: daemon-${{ matrix.os }}, path: release-bin/ }
+```
+
+- [ ] **Step 2: Add tag prefix `daemon-v*`** to the trigger, separate from `v*`:
+
+```yaml
+on:
+  push:
+    tags: ['v*', 'daemon-v*']
+```
+
+- [ ] **Step 3: Test by tagging `daemon-v0.3.0-rc1`** on a branch + verify GitHub Release contains binary + SHA256SUMS.
+
+- [ ] **Step 4: Commit** `ci: build + publish daemon binary on tag push`
+
+---
+
+### Task 25: Dogfood gate
+
+Per memory `feedback_dogfood_protocol.md`: every release passes a prod-install dogfood with cleared user config.
+
+- [ ] **Step 1: Build full installer** (Electron + bundled daemon binary). Drop the installer to `C:\Users\Public\Desktop\` per memory `feedback_installer_to_desktop.md`.
+
+- [ ] **Step 2: Wipe local `~/.ccsm/`** and reinstall.
+
+- [ ] **Step 3: Run for 1 week.** Track in TaskList every UX gap or bug. Fix bugs ≤3-line as worker self-fix per dogfood protocol.
+
+- [ ] **Step 4: Capture metrics:**
+  - Daemon process survives Electron window close: yes/no
+  - Daemon RAM usage at idle: target <60MB
+  - Daemon RAM usage with 5 active sessions: target <250MB
+  - Bridge call latency (renderer → daemon → response): target <5ms p95
+  - Anything notably slower than v0.2.0?
+
+- [ ] **Step 5: Sign-off** — if all metrics green and no P0 bugs after 1 week, tag `v0.3.0` (Electron) + `daemon-v0.3.0` (daemon).
+
+- [ ] **Step 6: Commit + tag**
+
+```bash
+git tag -a v0.3.0 -m "v0.3.0: daemon split"
+git tag -a daemon-v0.3.0 -m "daemon-v0.3.0: initial daemon binary"
+git push origin v0.3.0 daemon-v0.3.0
+```
+
+---
+
+## Self-review (post-write)
+
+**Spec coverage check (each section of spec → which tasks):**
+- §3.1 daemon language/packaging/lifecycle/listeners → Tasks 1, 4, 6, 20
+- §3.2 Electron client → Tasks 7, 8 step 7, 16-19, 21
+- §3.3 web client → DEFERRED to v0.5 (out of scope, correct)
+- §3.4 protocol → DEFERRED to v0.4 (we ship hand-written contracts in v0.3, plan §5 + Task 5 documents the swap)
+- §3.5 PTY headless buffer + seq → Task 11b/c
+- §3.6 Cloudflare → DEFERRED to v0.5
+- §4.1 new dirs daemon/ → Task 1; proto/ → v0.4; web/ → v0.5; infra/cloudflare/ → v0.5
+- §4.2 modified Electron files → Tasks 8, 11, 12, 13, 16-19, 21
+- §6 error handling → Task 7 (spawn failure), Task 11c (subscribe replay), Task 21 (graceful shutdown), Task 23 (updater)
+- §7 testing → smoke (Task 2), unit per task, dual-run e2e (Task 15), prod dogfood (Task 25)
+- §8 slicing → this entire plan IS the v0.3 slice; v0.4/v0.5 left for separate plans
+- §9 open questions: pkg vs @yao-pkg/pkg → Task 20 picks @yao-pkg; daemon repo → Task 23 step 1 picks tag-prefix in same repo; CF Tunnel hostname → v0.5; web offline UI → v0.5
+- §10 risks: updater pattern → Task 23; CF Access free tier → v0.5; Connect half-duplex → N/A v0.3 (no Connect-Web yet); xterm-headless memory → Task 11b (defaults inherited from L4 commits); iOS App Store → v0.6+
+
+No gaps for v0.3 scope.
+
+**Placeholder scan:** Search performed for "TBD", "TODO", "implement later", "fill in details", "add appropriate error handling", "similar to Task". A few intentional `// ...` markers exist where the task says "lift verbatim from existing file" — these are pointers to real code that already exists, not placeholders. Acceptable.
+
+**Type consistency:** `DaemonClient` interface grows in each phase-2 task (Task 8 adds `dbSettingGet`/`dbSettingSet`, Task 9 adds SDK methods, etc.). Document this growth pattern in `electron/daemonClient/connectClient.ts` so it's clear why the interface keeps expanding. `RPC_NAMES` constant likewise grows; treat both as living catalogs. Method names use camelCase consistently (`dbSettingGet`, not `db_setting_get` and not `dbSettingsGet`).
+
+**One real fix made inline:** Task 5 originally treated `RPC_NAMES` as `as const` then mutated it in Task 8. Fixed Task 5 step 1 to note the mutability requirement.
+
+---
+
+## Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-30-v0.3-daemon-split.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — dispatch one fresh subagent per task, review between tasks, fast iteration. Matches the project's subagent-pool dispatch discipline (memory: `feedback_subagent_workflow.md`, `feedback_dispatch_discipline.md`).
+
+**2. Inline Execution** — execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Manager to ask user which approach.


### PR DESCRIPTION
## Summary
- 25-task TDD plan for v0.3 daemon split (per spec docs/superpowers/specs/2026-04-30-web-remote-design.md)
- Phased: scaffold → transport → service lift → bridge swap → packaging → updater + dogfood
- Each service lifted behind `CCSM_USE_DAEMON=<name>` flag for individual rollback
- Hand-written RPC contracts in v0.3, Protobuf in v0.4

## Test plan
- [ ] Doc-only PR
- [ ] Reviewer confirms tasks are bite-sized + match spec coverage