### PR TITLE
spec: v0.3 daemon split design (12-fragment consolidation)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,24 @@
+# CCSM roadmap
+
+A pointer document tracking the major design slices and their current state. The implementation plans live under `docs/superpowers/plans/`; the design specs live under `docs/superpowers/specs/`.
+
+## v0.2 — MVP (shipped 2026-04-30)
+
+Single-process Electron app with embedded PTY supervision, claude-agent-sdk consumption, and SQLite persistence. See `docs/superpowers/specs/mvp-design.md` for the original design.
+
+## v0.3 daemon split (in design)
+
+Refactor only — no added or removed features. Splits the long-running side (PTY, SDK, persistence) into a standalone daemon process, with the Electron app as the client over local IPC.
+
+- **Design**: [`docs/superpowers/specs/v0.3-design.md`](./superpowers/specs/v0.3-design.md) (combined from 12 review-converged fragments under `v0.3-fragments/`).
+- **Exec summary**: [`docs/superpowers/specs/v0.3-daemon-split.md`](./superpowers/specs/v0.3-daemon-split.md).
+- **Implementation plan**: [`docs/superpowers/plans/2026-04-30-v0.3-daemon-split.md`](./superpowers/plans/2026-04-30-v0.3-daemon-split.md).
+- **Status**: design converged at r12 (0 P0 across 7 review angles, 7 review rounds completed). Ready for plan-delta reconciliation (#941) and dispatch.
+
+## v0.4 — Connect+Protobuf swap (planned)
+
+Replaces v0.3's hand-written length-prefixed JSON envelope with native Connect over HTTP/2 and Protobuf. Frame-version nibble and `daemonAcceptedWires[]` already chosen so v0.4 daemon can serve both v0.3 and v0.4 clients during the rolling-upgrade window. Detailed design TBD.
+
+## v0.5 — Web client over Cloudflare Tunnel (planned)
+
+Browser client over `cf-tunnel` consuming the same Connect+Protobuf wire as the desktop client. CF Access JWT verification slots into the v0.3 interceptor pipeline as a single appended interceptor; per-stream auth tokens slot into the §3.5.1.4 subscribe RPC param shape (already reserved). Detailed design TBD.

--- a/docs/superpowers/specs/2026-04-30-web-remote-design.md
+++ b/docs/superpowers/specs/2026-04-30-web-remote-design.md
@@ -1,8 +1,11 @@
 # v0.3+ — Daemon split + Web remote-control
 
-**Status:** locked (4-spike round, 2026-04-30)
+**Status:** locked (4-spike round + 10-angle review, 2026-04-30 v2)
 **Author:** ccsm
-**Tracks:** #922
+**Tracks:** #922, #930
+
+## Changelog
+- **v2 (2026-04-30)**: post-10-angle review. Added explicit security/reliability/observability/UX requirements. Lock local socket ACL + sender validation + envelope cap. Drop TCP listener from v0.3 scope (v0.5 only). Lock SQLite migration story for v0.2 → v0.3 upgrade. See section 12 for the 10-angle MUST-FIX list traceability.
 
 ## 1. Goal
 
@@ -63,9 +66,19 @@ User wants remote work: leave Windows box running at home, open a browser on any
   - Mac: `launchd` user agent.
   - Linux: `systemd` user unit.
 - **Listeners**:
-  - Local IPC: named pipe `\\.\pipe\ccsm-daemon` (Win) or `~/.ccsm/daemon.sock` (Mac/Linux). No authentication — assumes local user trust boundary.
-  - Remote: TCP `127.0.0.1:7878`, exposed only via Cloudflare Tunnel. Connect server validates Cloudflare Access JWT on every request.
-- **Auto-update**: poll `Jiahui-Gu/ccsm-daemon` GitHub releases (separate repo or tag prefix, TBD in implementation plan); on new version, download → verify SHA256 → kill old → swap binary → restart. No `electron-updater` (Electron-only).
+  - **v0.3 (local-only)**: named pipe `\\.\pipe\ccsm-daemon` (Win) or `~/.ccsm/daemon.sock` (Mac/Linux). Hardened ACL — see §3.1.1 + §7. Same-machine same-user trust boundary; sender verified per connection.
+  - **v0.5 (remote)**: ALSO TCP `127.0.0.1:7878`, exposed via Cloudflare Tunnel only. Connect server validates Cloudflare Access JWT on every remote request. Middleware seam exists from v0.3 so v0.5 only adds the validator.
+- **Auto-update**: poll GitHub releases (tag prefix `daemon-v*` on the same `Jiahui-Gu/ccsm` repo); on new version, download → SHA256 verify against published checksum → `.bak` rollback path → swap binary → restart. **Default OFF in v0.3**, opt-in via setting; flip default ON when sigstore signing lands. No `electron-updater` (Electron-only).
+
+### 3.1.1 Local socket hardening (v0.3)
+
+The "no authentication, local trust boundary" claim from spec v1 was factually wrong on Windows. v0.3 hardens:
+
+- **Win named pipe ACL**: explicit DACL via N-API helper grants R+W to `process.token` user-SID only; deny `BUILTIN\Users`, `ANONYMOUS LOGON`. Set `PIPE_REJECT_REMOTE_CLIENTS`.
+- **Unix socket mode**: `chmod 0700` on `~/.ccsm/daemon.sock`, in `~/.ccsm/` dir (also `0700`).
+- **Sender peer-cred verification**: on each accepted connection, daemon validates peer is same user. Win: `GetNamedPipeClientProcessId` → `OpenProcessToken` → match user SID. Unix: `SO_PEERCRED` (Linux) / `getpeereid` (Mac).
+- **Envelope hard cap**: 16 MiB per frame. Reject longer; close socket. (DoS protection from Connect adapter §3.4.1 below.)
+- **Schema validation at adapter boundary**: every incoming envelope payload validated against TypeBox contract before dispatch. Reject malformed; close socket.
 
 ### 3.2 Electron client
 - Reduced to: tray icon + window manager + renderer host. All session/PTY/SQLite logic moves to daemon.

--- a/docs/superpowers/specs/v0.3-daemon-split.md
+++ b/docs/superpowers/specs/v0.3-daemon-split.md
@@ -1,0 +1,65 @@
+# v0.3 daemon split — executive summary
+
+> **Status**: design converged at r12 (0 P0 across 7 review angles after 7 review rounds).
+> **Pointer**: full spec at [`v0.3-design.md`](./v0.3-design.md). Implementation plan at [`docs/superpowers/plans/2026-04-30-v0.3-daemon-split.md`](../plans/2026-04-30-v0.3-daemon-split.md). Audit trail in [`v0.3-fragments/`](./v0.3-fragments/).
+> **Audience**: contributors, reviewers, and release managers who need the shape of v0.3 without the 4000-line wire-level detail.
+
+## What v0.3 is
+
+v0.3 splits CCSM into two long-lived processes:
+
+- **Daemon** — owns PTY child processes, SDK calls, persistence (SQLite + pino logs), session state, notification fan-out. Runs as its own Node 22 ESM process; survives Electron restarts and auto-update.
+- **Electron client** — owns rendering, OS integration (tray, dock, dialogs), and user input. Connects to the daemon over a local IPC channel — Win named pipes / Unix domain sockets in v0.3.
+
+Two sockets per daemon (see `v0.3-design.md` §3.4.1.h):
+
+- `ccsm-data` — every RPC except control-plane.
+- `ccsm-control` — `/healthz`, `/stats`, `daemon.hello`, `daemon.shutdown`, `daemon.shutdownForUpgrade`. Isolated so a snapshot fan-out cannot starve the supervisor heartbeat.
+
+A long-running supervisor (separate process or watcher inside the daemon, see §6.1) watches `/healthz` every 5 s with 3-miss restart and crash-loop modal at 5 respawns / 2 min. Disabled in dev (`CCSM_DAEMON_DEV=1`); nodemon owns the dev daemon lifecycle.
+
+## Why (the daemon split is justified, not nice-to-have)
+
+1. **Resource ownership clarity.** PTY children and SDK socket connections become daemon-owned; killing Electron does not orphan them, and Electron crash does not disrupt running agent loops.
+2. **Hot-reload story.** Renderer iterations no longer SIGTERM PTY processes. Dev loop stays under 5 s edit-to-reload.
+3. **Packaging compliance.** Per-user install at `%LOCALAPPDATA%\ccsm\` (no UAC, no Program Files); auto-update writes in-place; daemon stays running across upgrade via `daemon.shutdownForUpgrade` + marker file.
+4. **Forward path to v0.4 (Connect+Protobuf) and v0.5 (web client over Cloudflare Tunnel).** Wire format, interceptor pipeline, and version handshake all chosen so the v0.4 swap is a one-side replacement, not a redesign.
+
+## The 12 fragments at a glance
+
+Each fragment is ~200–900 lines in `v0.3-fragments/`. One sentence each:
+
+1. **frag-3.4.1 envelope hardening** — 16 MiB frame cap, 16 KiB chunking for head-of-line, binary frame format for PTY chunks, frame-version nibble, interceptor pipeline, HMAC-SHA256 challenge-response handshake (`daemon.hello` over `clientHelloNonce`), two-socket transport.
+2. **frag-3.5.1 PTY hardening** — Win JobObject + POSIX `setpgid`/PDEATHSIG via in-tree `ccsm_native.node`, daemon-owned SIGCHLD with per-PID `waitpid`, bridge-call timeout (5 s default) + `AbortSignal` threading, stream heartbeat (30 s default, negotiable), drop-slowest fan-out at 1 MiB per subscriber, replay budget 256 KiB on resubscribe.
+3. **frag-3.7 dev workflow** — three-process `npm run dev` (web/daemon/app), `nodemon.daemon.json`, cross-platform `wait-on file:` for daemon lockfile, transparent auto-reconnect with exponential backoff (200 ms → 5 s cap), bounded reconnect queue (100 prod / 1000 dev), stream resubscribe with `bootNonce` check, debugger inspect ports (9229 Electron / 9230 daemon, both env-gated dev-only).
+4. **frag-6 reliability** — supervisor with `/healthz` 5 s × 3-miss + crash-loop modal, paused-session terminal state with atomic `pid_pgid=NULL` clearing, `daemon.shutdownForUpgrade` RPC + `<dataRoot>/daemon.shutdown` marker for upgrade-in-place, marker-aware crash-loop counter skip.
+5. **frag-7 security** — per-installation `daemon.secret` (32 random bytes) at `<dataRoot>/daemon.secret` with owner-only ACL, named-pipe DACL via `pipeAcl.applyOwnerOnly`, peer-cred check on every accept, secret rotation on auto-update, complete redact list for pino.
+6. **frag-8 SQLite migration** — v0.2 → v0.3 schema migration with single Quit-only failure modal (no in-place retry — corrupt DB = quit + corrupt-backup at `<dataRoot>/data/ccsm.db.corrupt-<ts>`), migration phase logs, `MIGRATION_PENDING` short-circuit on data RPCs (`SUPERVISOR_RPCS` allowlisted).
+7. **frag-11 packaging** — electron-builder `extraResources` + `asarUnpack` for daemon + `ccsm_native.node`, claude-agent-sdk dual staging (extraResources for Electron CJS shim + daemon-primary direct ESM), per-`.node` codesign / signtool loop, NSIS `oneClick: false / allowElevation: true / perMachine: false` per-user install, SLSA-3 provenance + Linux minisign, upgrade-in-place orchestration consuming `daemon.shutdownForUpgrade` + marker.
+8. **frag-12 traceability** — 191 review items mapped (159 CLOSED / 25 IN-FLUX / 7 OPEN); covers all r1–r3 angle reviews (10 angles × ~3 rounds) plus r4–r12 fixer batches.
+
+(Eight named "fragments" plus four headed sub-stories — devx contributor flow, surface registry collapse, marker-file 3-frag chain, and HMAC base64-22 cross-frag unification — are documented inline within the fragments above; the dispatched-worker count was 7 fragment files committed.)
+
+## Top 3 risks (residual after r12)
+
+1. **claude-agent-sdk packaging** — ESM-only SDK consumed by Electron 33 main (CJS) goes through the existing `loadSdk()` shim, but daemon-primary path is a fresh dual-staging concern. Mitigation: extraResources + asarUnpack for both consumers, separate symlink trees verified by `before-pack.cjs`. Spike already green; verify on every release CI matrix.
+2. **Marker file robustness** — `<dataRoot>/daemon.shutdown` is the upgrade-in-place signal; supervisor must skip its crash-loop counter when present. Race: marker write happens before `daemon.shutdownForUpgrade` ack; if installer crashes mid-write the marker is empty / partial. Mitigation: marker contains expected shutdown reason + ULID; supervisor treats malformed marker as absent (no false crash-loop suppression).
+3. **NSIS oneClick migration** — v0.2 was `oneClick: true` (silent install); v0.3 ships `oneClick: false / allowElevation: true / allowToChangeInstallationDirectory: true`. This is a UX regression risk on auto-update for existing v0.2 users; mitigation is documented in §11.6 and verified in dogfood matrix.
+
+## Implementation phases (overview)
+
+Cumulative plan delta from r9 trims onward: **+199.5 h** vs. v1 plan baseline (~125 h v1 → ~324 h v0.3). Breakdown lives in each fragment's `## Plan delta` block; reconciliation will be tracked in follow-up #941.
+
+Phasing intent (manager-decided, not in spec):
+
+1. **Phase 0** — workspace + dev tooling + scaffolding + workspaces declaration (Task 1, ~5 h), so contributors can iterate from day one.
+2. **Phase 1 — daemon core** — Tasks 5 (envelope), 6 (transport mount), 7 (Electron client), 11 (PTY lift), 13 (notify lift). Heaviest phase; manager should split Task 5 into 5a/5b per `feedback_split_large_worker_tasks` (envelope+chunk+binary into 5a; interceptor+hello-HMAC+control-socket into 5b).
+3. **Phase 2 — reliability + supervisor** — Tasks for §6.1 supervisor, §6.4 lockfile + shutdown sequence, §6.6 logging + crash dumps, §6.8 surface registry.
+4. **Phase 3 — migration + packaging** — Task 28 (uninstall hygiene), §8 migration tasks, §11 packaging tasks (NSIS, codesign loops, SLSA, upgrade-in-place).
+5. **Phase 4 — dogfood + release** — Task 25 acceptance, prod-install matrix, release CI on `v*` tag.
+
+## Reading order
+
+- Reviewer / new contributor: this exec summary, then `v0.3-design.md` §3.4.1 (envelope) + §6 (reliability) for the wire + lifecycle picture.
+- Implementer of a specific fragment: jump to that section in `v0.3-design.md`, then read its source `v0.3-fragments/frag-*.md` for the audit trail (`[manager rN lock: ...]` annotations explain why each clause is shaped as it is).
+- Manager planning dispatch: `v0.3-design.md` `## Plan delta` blocks per fragment + the phase outline above.

--- a/docs/superpowers/specs/v0.3-design.md
+++ b/docs/superpowers/specs/v0.3-design.md
@@ -1,0 +1,4130 @@
+# v0.3 design — daemon split
+
+> **Status**: design spec, r12 final (0 P0 across 7 review angles, 7 review rounds completed).
+> **Scope**: refactor only — no added or removed features versus v0.2 (verified by feature-parity reviewer in r6 + r8). New behaviors (`daemon.shutdownForUpgrade` RPC, debugger inspect ports, install marker file) are all justified as P0 necessities of the daemon split per the feature-parity angle.
+> **Source**: combined from 12 review-converged fragments under `docs/superpowers/specs/v0.3-fragments/`. The fragment files are preserved as the audit trail — every `[manager rN lock: ...]` annotation in the body below is a verbatim record of the corresponding round's resolution.
+> **Companion docs**: `v0.3-daemon-split.md` (1-2 page exec summary). Plan delta totals tracked in follow-up #941.
+
+The v0.3 daemon split moves the long-running side of CCSM (PTY supervision, SDK calls, persistence) into a standalone daemon process, separate from the Electron app. The Electron client connects over a local IPC channel (length-prefixed JSON envelope in v0.3, Connect+Protobuf over HTTP/2 in v0.4). This document is the design spec; the implementation plan is `docs/superpowers/plans/2026-04-30-v0.3-daemon-split.md`.
+
+## Table of contents
+
+- [§3.4.1 Envelope hardening (v0.3 local channel)](#341-envelope-hardening-v03-local-channel)
+- [§3.5.1 PTY child lifecycle hardening](#351-pty-child-lifecycle-hardening)
+- [§3.7 Dev workflow](#37-dev-workflow)
+- [§6 reliability + §7 security expansion](#6-reliability--7-security-expansion)
+- [§8 Data migration: v0.2 → v0.3](#8-data-migration-v02--v03)
+- [§11 Packaging](#11-packaging)
+- [§12 Review traceability](#12-review-traceability)
+
+---
+
+## Source fragments
+
+Each section below is the verbatim body of the corresponding fragment file. Fragment-level metadata (Owner / Target spec section / P0 items addressed) is preserved as it carries the audit trail of which review items each section closes. Cross-fragment references that previously pointed to "frag-X §Y" are left as-is; readers can resolve them either against this combined document's section anchors OR against the fragment files in `v0.3-fragments/`.
+
+
+---
+
+<!-- BEGIN frag-3.4.1-envelope-hardening.md -->
+
+# Fragment: §3.4.1 Envelope hardening (frame cap + chunk + binary)
+
+**Owner**: worker dispatched per Task #932
+**Target spec section**: insert after §3.4 in main spec (already referenced at §3.1.1 line 80: "Envelope hard cap: 16 MiB per frame ... DoS protection from Connect adapter §3.4.1 below.")
+**P0 items addressed (round-1)**: envelope cap (security M3), head-of-line blocking (perf MUST-FIX #2), binary frame format (perf MUST-FIX #1).
+**P0 items addressed (round-2)**: interceptor + headers + traceId in envelope header (fwdcompat P0-1, observability P0-2, perf P0-A); hello/version handshake (fwdcompat P0-2, lockin P0-1); RPC namespace rule (fwdcompat P0-3); per-chunk amplification mitigations (perf P0-A/P0-B); reserved header keys for runtime tunables (fwdcompat P1-2); streamId allocation (fwdcompat P2-2); handler-arg schema responsibility split (security P1-S1); traceId validation (security P1-S2).
+
+**P0 items addressed (round-3)**: hello wire shape switched from plaintext bearer to HMAC challenge-response (security r3 P0-1) so `daemon.secret` never traverses the wire; explicit frame-version-nibble-then-length-then-cap parsing order (security r3 CC-1); traceId-optional-on-chunk/heartbeat validator carve-out (security r3 CC-2); `bootNonce` camelCase locked across all fragments (fwdcompat r3 CC-2); `x-ccsm-deadline-ms` clamp raised to 120 s and unified with frag-3.5.1 (fwdcompat r3 CC-3); `daemonAcceptedWires[]` advertised in hello reply (fwdcompat r3 P1-5); `clientImposterSecret` removed from redact list (no longer exists post-HMAC switch — lockin r3 CF-3); `seq` zero-padded to fixed 10-digit ASCII to keep header-skeleton fast path stable past `seq=10000` (perf r3 P1-1); explicit feature-add-vs-version-bump rule (fwdcompat r3 P1-4); optional warn on unknown `x-ccsm-*` header keys (fwdcompat r3 P1-7); `control-socket` (data plane control RPCs) and `-sup` socket (supervisor `/healthz`) clarified as TWO separate sockets with explicit table (perf r3 CF-1); subscribe RPC contract canonical owner cross-ref (fwdcompat r3 P1-2); `statsVersion` dropped from `/healthz` (fwdcompat r3 P1-3, owned by frag-6-7).
+
+---
+
+### 3.4.1 Envelope hardening (v0.3 local channel)
+
+The hand-written length-prefixed JSON envelope used in v0.3 (Plan Task 5; replaced by real Connect-RPC over HTTP/2 in v0.4) ships with the hardening rules below. They are local-channel only — v0.4 Connect+Protobuf gets these natively.
+
+#### 3.4.1.a Hard 16 MiB cap per envelope
+
+`connectAdapter.ts` reads `len = buffer.readUInt32BE(0)` and currently accumulates up to 4 GiB before parsing. Trivial DoS via memory exhaustion from a single co-tenant process (security review M3, `~/spike-reports/v03-review-security.md` §3).
+
+**Frame-header parsing order (round-3 security CC-1)**: the 4-byte frame header MUST be processed in this exact sequence — getting the order wrong either resurrects a 256 MiB DoS or leaks a stale-client crash:
+
+1. Read 4 bytes → `raw = buffer.readUInt32BE(0)`.
+2. **Extract the version nibble FIRST**: `nibble = (raw >>> 28) & 0x0F`. If `nibble` is not in the daemon's known-version set (v0.3 daemon: `{0x0}`; v0.4 daemon: `{0x0, 0x1}`), reject with `{ code: "UNSUPPORTED_FRAME_VERSION", nibble }` and `socket.destroy()`. Do NOT mask + length-check first; an attacker setting `nibble = 0x1` against a v0.3 daemon would otherwise produce a `len > 16 MiB` reading from raw bits and the cap-check error would mask the real reason.
+3. **Then mask** the low 28 bits to compute payload length: `len = raw & 0x0FFFFFFF` (max 256 MiB by construction).
+4. **Then cap-check**: if `len > 16 * 1024 * 1024`, run the rejection sequence below.
+
+**Rule**: if `len > 16 * 1024 * 1024`, immediately:
+1. emit `pino.warn({ peer, peerPid, len }, "envelope_oversize")` — `peerPid` from the §3.1.1 peer-cred check, included for forensic correlation per round-2 reliability S-R5,
+2. write a synthetic `{ id: 0, error: { code: "envelope_too_large", message: "max 16 MiB" } }` reply (best-effort),
+3. `socket.destroy()`.
+
+Mirrored at §3.1.1 (socket-level cap) for defense in depth: the listener also caps the per-connection inbound byte budget at 64 MiB across all in-flight frames so an attacker cannot dribble 16 MiB frames in a tight loop.
+
+Rationale for 16 MiB: PTY input is keystroke-sized; the largest legitimate envelope is a single PTY-snapshot header (post-3.4.1.c, payload moves out of JSON), well under 1 MiB. Settings RPC payloads cap at a few KiB. 16 MiB is two orders of magnitude above the largest legitimate use, well below realistic memory-pressure on a 16 GiB dev box.
+
+Rationale for the 64 MiB per-connection in-flight ceiling: 4× the per-frame cap, chosen as a worst-case "attacker dribbles in 4 max-frames before any can be parsed". Not measurement-derived; flagged as a v0.4 tuning candidate (round-2 perf §4 vibes table, P2 only).
+
+**Pre-accept rate cap (round-2 security T15)**: the listener also caps `accept()` calls at 50/sec (`MAX_ACCEPT_PER_SEC`); excess connections fail with `EAGAIN` and a once-per-minute rate-limited log. Cheap defence vs co-tenant connect-flood DoS.
+
+#### 3.4.1.b Head-of-line mitigation: chunk stream payloads to ≤16 KiB
+
+The local socket multiplexes all RPCs (unary + server-streams, Plan Task 11 step 1 extends envelope with `streamId`). The socket is byte-serialized: a 10 MB PTY-snapshot envelope being framed-and-written **blocks the unary `listSessions` reply queued behind it** for 50–200 ms on a local pipe — visible UI stutter (perf review §3 throughput, MUST-FIX #2, `~/spike-reports/v03-review-perf.md`).
+
+**Rule**: any stream-message payload (`stream.kind === "chunk"`) larger than **16 KiB** is split into N ≤16 KiB sub-chunks at the adapter boundary, each emitted as its own length-prefixed frame with the same `streamId` and a per-stream monotonic `seq`. Receiver re-assembles by `streamId`. Unary RPC frames may interleave between sub-chunks.
+
+**Wording correction (round-2 perf §4 vibes table)**: 16 KiB matches HTTP/2's *default frame size* and so the byte-level chunking idiom is wire-compatible with the v0.4 Connect/HTTP-2 swap. It does **NOT** replicate HTTP/2's per-stream flow-control windows or multiplexing primitives — the v0.3 hand-rolled byte-stream is FIFO across streams, with chunking as the only fairness mechanism. Genuine flow control arrives in v0.4.
+
+Snapshot bootstrap (`getBufferSnapshot`, lifecycle.ts:178-203) is the worst offender — already chunked **on the daemon side** but currently re-collapsed into one wire envelope. Snapshot must stream as `stream.kind === "chunk"` sub-frames the same way live deltas flow (perf MUST-FIX #3). Snapshot `chunk` boundaries align with the existing 1000-line async-chunk boundary on the daemon side; no extra serialization passes.
+
+**`streamId` allocation (round-2 fwdcompat P2-2 / HTTP-2 parity)**: `streamId` is `uint32`. Client-initiated streams use **odd ids starting at 1**; server-pushed streams (none in v0.3 — reserved for v0.4 server-push notifications) use **even ids starting at 2**. Identical to HTTP/2's stream-id convention, so the v0.4 native swap reuses the same wire ids byte-for-byte. Each side maintains its own monotonic counter; collisions are impossible by construction.
+
+**Replay bound on resubscribe (round-2 resource P0-1)**: when a client resubscribes with `fromSeq = lastSeenSeq + 1` (§3.7.5 contract), the daemon ships at most **256 KiB of replay** before declaring `gap: true` and forcing a fresh snapshot. The 1 MiB per-subscriber drop-slowest watermark (frag-3.5.1 §3.5.1.5) is measured **after** the initial replay burst lands (replay treated as one prioritized initial write, not slow-subscriber accounting). Without this rule a nodemon-storm reconnect into a hot stream loops drop-and-resubscribe.
+
+**Subscribe RPC contract — canonical owner (round-3 fwdcompat P1-2)**: the `subscribe(sessionId, { fromSeq?, fromBootNonce?, heartbeatMs? })` request shape is **canonically owned by frag-3.5.1 §3.5.1.4**. This fragment owns only the wire-level chunking + replay-budget mechanics; field naming, defaults, clamps, and protobuf message definition (for v0.4) live in frag-3.5.1. Other fragments referencing subscribe (frag-3.7 §3.7.5 reconnect, frag-6-7 §6.5 supervisor exception) cite frag-3.5.1 §3.5.1.4 as the source of truth.
+
+#### 3.4.1.c Binary frame format for PTY chunks
+
+Today's envelope is `[len:4][JSON utf8]`. PTY output strings round-tripped through `JSON.stringify` + `JSON.parse` cost 5–30 ms per 64 KiB+ chunk and a fresh string allocation on the client side (perf §2 latency table, MUST-FIX #1). If `node-pty` is ever switched to `encoding: null` (raw `Buffer`), base64 inflates the payload 1.33× and adds ~50 MB/s ceiling.
+
+**Rule**: extend the envelope to a header-JSON + raw-bytes-trailer form for any frame whose payload is binary-ish (PTY output, future blob fields):
+
+```
+[totalLen:4][headerLen:2][headerJSON:headerLen][payloadBytes:totalLen-2-headerLen]
+```
+
+Note: the high 4 bits of `totalLen` are **reserved as a frame-version nibble** (round-2 lockin P0-1). v0.3 sets the nibble to `0x0`; readers MUST mask it off before computing the actual length. Payload length is therefore capped at 2^28 − 1 ≈ 256 MiB, well above the 16 MiB per-frame cap. v0.4 protobuf wire uses `0x1`; receivers reject unknown nibbles with `frame_version_unsupported` + `socket.destroy()`.
+
+The `headerJSON` schema (round-2 P0 additions in **bold**):
+
+```ts
+interface FrameHeader {
+  id: number;                          // RPC id
+  method?: string;                     // unary RPC method name
+  stream?: { streamId: number; seq: number; kind: "open" | "chunk" | "close" | "heartbeat" };
+  payloadType: "json" | "binary";
+  payloadLen: number;
+  /** round-2 fwdcompat P0-1 / observability P0-2 */
+  traceId?: string;                    // Crockford ULID, 26 chars; required on call-originating frames
+  /** round-2 fwdcompat P0-1 / P1-2 */
+  headers?: Record<string, string>;    // case-insensitive; reserved keys below
+}
+```
+
+- Pure-JSON frames (control RPCs: `listSessions`, settings, etc.) keep the existing form via `payloadType: "json"` (or absence — default JSON for backward compat during the lift). The JSON body lives in the header object as before.
+- For `payloadType: "binary"`, `payloadBytes` is the raw `Buffer` straight from `node-pty` (UTF-8 byte buffer; no base64, no `JSON.stringify` of the body).
+- Header still validated against the TypeBox contract at the adapter boundary (§3.1.1 schema rule); the binary trailer is opaque to *envelope* validation. **Per-method handler-arg validation of `payloadBytes` is the handler's responsibility** (round-2 security P1-S1) — see §3.4.1.d.
+
+**`traceId` validation (round-2 security P1-S2, round-3 security CC-2)**: validation runs **only when `traceId` is present** in the header. Inheriting sub-frames (`stream.kind === "chunk" | "heartbeat"`) carry no `traceId` by design (see §3.4.1.c omission rule below); for those frames the validator skips the regex check and resolves the call's traceId from the `streamId → traceId` map established at `kind: "open"` time. **Missing inherited mapping** (chunk/heartbeat arrives for an unknown `streamId`) is itself a protocol error and closes the stream with `RESOURCE_EXHAUSTED`. When `traceId` IS present (open frames + all unary frames), it is validated against the Crockford ULID regex `^[0-7][0-9A-HJKMNP-TV-Z]{25}$`. Mismatch → reject + `socket.destroy()`. Renderer-supplied `traceId` is treated as untrusted input; daemon log lines additionally include a daemon-generated `daemonTraceId` so forensic correlation never relies on caller-supplied data alone. Pino formatters strip `\n\r` from any string field destined for non-JSON destinations (defence vs log-injection via crafted `traceId` / `headers` values).
+
+**`traceId` placement on stream frames (round-2 perf §5.3, round-9 manager lock — r8 envelope P1-2)** `[manager r9 lock: r8 envelope P1-2 — close-frame traceId carriage rule]`: `traceId` is required on call-originating frames (`stream.kind === "open"`, all unary frames) AND on `stream.kind === "close"` (so terminal log lines correlate even after the `streamId → traceId` map entry is GC'd). It is **omitted** from `stream.kind === "chunk"` and `stream.kind === "heartbeat"` sub-frames — receivers inherit the call's traceId from the `streamId → traceId` map established at `kind: "open"` time. Saves ~34 B per chunk and removes redundant ULID strings from the high-volume PTY path. **Map-entry GC ordering**: the `streamId → traceId` entry is removed AFTER processing `kind: "close"` so the close frame's own traceId takes precedence over the (now-removed) map entry; this avoids a race where a fast subsequent `kind: "open"` on a reused streamId could overwrite the map entry mid-close-handling.
+
+**Reserved `headers` keys (round-2 fwdcompat P1-2, round-3 fwdcompat CC-3 + P1-7, round-9 manager lock — r8 envelope P0-3)**: `x-ccsm-deadline-ms` (per-call deadline override; v0.3 honored, **clamp `100 ms ≤ x ≤ 120 s`** — unified with frag-3.5.1 §3.5.1.3 to allow v0.5 web snapshot bootstrap with 30 s+ headroom), `x-ccsm-heartbeat-ms` (stream heartbeat override; v0.3 reserved, no-op), `x-ccsm-backpressure-bytes` (per-subscriber drop-slowest override; v0.3 reserved, no-op), `x-ccsm-trace-parent` (W3C traceparent for v0.5 OTLP; v0.3 reserved), **`x-ccsm-boot-nonce`** (subscribe RPC last-known boot nonce; v0.3 honored, see §3.4.1.g — `[manager r9 lock: r8 envelope P0-3 — added to reserved-keys allowlist so deadlineInterceptor stops warning on every PTY subscribe; precedence + RPC-param coexistence rule in §3.4.1.g]`). Daemon advertises defaults via the §3.4.1.g hello block. Workers may NOT define new `x-ccsm-*` keys without spec amendment; arbitrary other keys (no `x-ccsm-` prefix) are permitted (passed through to interceptors in §3.4.1.f). The `deadlineInterceptor` MUST `pino.warn({ key, method, peerPid }, "unknown_xccsm_header")` (rate-limited once per `key` per minute) when an `x-ccsm-`-prefixed header arrives outside the reserved allowlist — catches v0.3.x worker squatting before it hardens into a wire contract.
+
+**Hot-path optimizations (round-2 perf P0-A, resource SHOULD-3, round-3 perf P1-1)**: a 1 MiB PTY-snapshot stream becomes 64 sub-frames; the per-frame `JSON.stringify(header)` + `JSON.parse(header)` becomes the dominant CPU cost. The adapter MUST:
+1. **Cache the per-stream header skeleton** at `kind: "open"` time. Sub-chunks (`kind: "chunk"`) reuse the cached bytes with only the fixed-width `seq` field patched in-place per frame. **`seq` is encoded as zero-padded 10-digit ASCII** (covers full uint32 range — `4294967295` is 10 digits) so the skeleton byte length never shifts as `seq` crosses 10/100/1000/10000/… boundaries. Without zero-padding, the cached skeleton would silently fall back to full `JSON.parse` past `seq=10000` (4-byte → 5-byte width shift), a silent perf cliff. Receiver-side, after first `kind: "open"` is parsed for a `streamId`, subsequent same-`streamId` `kind: "chunk"` frames take a fast path that reads `seq` + `payloadLen` from fixed offsets without invoking `JSON.parse` on the full header. Falls back to full parse on any header-byte change vs the cached skeleton (defensive).
+2. **`socket.cork()` before the header `write` and `socket.uncork()` after the trailer `write`** so the kernel emits one packet per sub-frame (eliminates the 320× syscall amplification on a 5 MiB snapshot stream).
+
+**Single-frame caching for fan-out (round-2 perf P0-B)**: when frag-3.5.1 §3.5.1.5's fan-out registry distributes a chunk to N subscribers, the adapter MUST stringify+frame the chunk **once** and call `socket.write(sharedBuffer)` N times (header is identical across subscribers; only the destination socket differs). Latent in v0.3 (single subscriber per session) but the wire contract is locked here; switching later means re-doing fan-out. Cross-referenced from frag-3.5.1 §3.5.1.5.
+
+Cost: ~30 LOC in `connectAdapter.ts` + symmetric change in `testHelpers.ts` (Plan Task 5). v0.4 Connect+Protobuf provides this natively (`bytes` field type) — no migration churn.
+
+#### 3.4.1.d Schema validation hook
+
+Per §3.1.1, every decoded envelope is validated against the TypeBox contract **before** dispatch into handlers. This subsumes the `JSON.parse` reviver concern from security review M3 (no `__proto__` pollution into downstream Maps). Reject malformed → write `{ id, error: { code: "schema_violation" } }` → `socket.destroy()`. Validation happens on the header for binary frames (3.4.1.c).
+
+**Handler-arg validation responsibility (round-2 security P1-S1)**: the adapter check covers only routing fields (`id`, `method`, `stream`, `payloadType`, `payloadLen`, `traceId`, `headers`). For `payloadType === "binary"` frames, **handlers MUST validate the trailer bytes against a per-method byte schema** as their first statement: length cap from `payloadLen` (already known to be ≤ 16 MiB minus header), optional content sniff (e.g. UTF-8 well-formedness for `ptyWrite` data, escape-sequence sanitization for renderer-bound output). For `payloadType === "json"` frames whose handler argument is non-trivial, handlers MUST `Check(MethodArgsSchema, decoded)` as their first statement. ESLint rule `no-handler-without-check` enforces this at lint time.
+
+#### 3.4.1.e Open: spawn imposter handshake
+
+Per §3.1.1 sender peer-cred check, the daemon already verifies the connecting UID. Security review S2 (`~/spike-reports/v03-review-security.md` §4) raises a complementary concern: an attacker who races daemon boot and binds the pipe first can impersonate the daemon to Electron. The §3.4.1.g hello handshake (per-installation shared secret proven via HMAC challenge-response — secret never traverses the wire — plus protocol-version exchange) closes this; the secret lifecycle (installer-time generation, atomic ACL, rotation on auto-update, redact-list) is owned by **frag-6-7 §7.2** (cross-frag rationale below).
+
+#### 3.4.1.f Interceptor pipeline + request context
+
+Round-1 fwdcompat asked for a clean seam to insert v0.5 CF Access JWT verification, audit logging, and rate-limit middleware without rewriting every handler. Round-2 fwdcompat P0-1 escalated to MUST after frag-12 claimed the seam was addressed but no fragment defined it.
+
+```ts
+interface ReqCtx {
+  method: string;
+  headers: Record<string, string>;     // case-insensitive; from envelope header (§3.4.1.c)
+  traceId: string;                     // caller-supplied (validated) OR generated by entry interceptor
+  daemonTraceId: string;               // daemon-generated, authoritative for log correlation
+  peer: { uid: number; pid: number };  // from §3.1.1 peer-cred check
+  signal: AbortSignal;                 // composes with handler-internal aborts (§3.5.1.3)
+  deadlineMs: number;                  // resolved deadline (default 5 s, headers override per §3.4.1.c)
+}
+
+type Handler<Req = unknown, Res = unknown> = (req: Req, ctx: ReqCtx) => Promise<Res>;
+type Interceptor = (ctx: ReqCtx, next: () => Promise<unknown>) => Promise<unknown>;
+
+function mountConnectAdapter(opts: {
+  socket: Duplex;
+  handlers: Map<string, Handler>;
+  interceptors?: Interceptor[];        // executed in array order, onion-style (first wraps all)
+}): void;
+```
+
+v0.3 ships the following interceptors in order:
+0. `helloInterceptor` `[manager r7 lock: r6 reliability P1-R6 — explicit ordering #0 so handshake-required check fires BEFORE migrationGateInterceptor; otherwise a non-hello RPC during migration would short-circuit with MIGRATION_PENDING and leak pre-handshake daemon state to an unverified peer]` — runs FIRST on every envelope. Allowlist `["ccsm.v1/daemon.hello"]`; for any other method on a connection that has not yet completed handshake, rejects with `hello_required` and `socket.destroy()` (per §3.4.1.g semantics). `helloInterceptor` short-circuits the rest of the chain on rejection — subsequent interceptors (trace / deadline / migrationGate / metrics) do NOT run, so no log noise, no metric increment, and crucially no `MIGRATION_PENDING` leak. On a connection that HAS completed handshake, `helloInterceptor` is a no-op pass-through.
+1. `traceInterceptor` — fills/validates `traceId`, mints `daemonTraceId`, attaches to logger child.
+2. `deadlineInterceptor` — reads `headers["x-ccsm-deadline-ms"]` (clamped 100ms ≤ x ≤ 120s per §3.4.1.c), composes `AbortSignal.timeout(deadlineMs)` with handler-supplied signal via `AbortSignal.any` (frag-3.5.1 §3.5.1.3). Also emits the `unknown_xccsm_header` warn (§3.4.1.c) for any non-reserved `x-ccsm-*` key.
+3. `migrationGateInterceptor` — short-circuits with `MIGRATION_PENDING` for data RPCs while migration is in progress; allows the canonical `SUPERVISOR_RPCS` constant (declared in §3.4.1.h) through unconditionally (round-2 reliability P1-R3). `[manager r9 lock: r8 envelope P0-1 + r8 devx P0-1 — replaced hardcoded 3-element list with reference to canonical SUPERVISOR_RPCS constant; previously enumerated only `/healthz`, `/stats`, `daemon.hello` and would have wrongly blocked `daemon.shutdown` + `daemon.shutdownForUpgrade` mid-migration]`.
+4. `metricsInterceptor` — records `{ method, durationMs, outcome }` per call.
+
+v0.5 appends `cfAccessJwtInterceptor` to the array; no existing handler signatures change. The interceptor array is the only public seam that survives the v0.4 Connect swap (Connect's native interceptor concept maps 1:1).
+
+Cost: ~30 LOC + 1 unit test (interceptor sees `headers={}` for Win named-pipe / unix-socket transports in v0.3).
+
+#### 3.4.1.g Hello / version handshake (frame-version + protocol-version + HMAC imposter check)
+
+`[manager r5 lock: 2-frame HMAC handshake, client issues nonce, daemon proves possession; reason: client identity already proven by peer-cred + socket ACL, daemon identity is what needs proof; saves 1 RT vs 3-frame; aligns with frag-6-7 §7.2.]`
+
+Round-1 §3.3 asked for a versioned handshake; round-2 fwdcompat P0-2 + lockin P0-1 escalated after the round-2 reviewers found the v1 spec/plan never wired it. **Round-3 security P0-1** replaced the original plaintext-bearer imposter check with an HMAC challenge-response after a reviewer noted that the round-2 shape sent `daemon.secret` cleartext on every connection (visible in `strace -e trace=read,write`, every TLS-pcap on v0.5 web, every crash dump), and that `Buffer.compare` is not constant-time so the bearer form additionally leaks the secret byte-by-byte to a probing co-tenant. **Round-5 manager lock**: the wire shape is collapsed from 3 frames to 2 frames, aligned 1:1 with frag-6-7 §7.2 (canonical owner of secret lifecycle + HMAC contract).
+
+**DO NOT send `daemon.secret` on the wire.** The handshake proves possession of the secret without transmitting it.
+
+**Two-frame handshake** (round-3 security P0-1, round-5 manager lock — wire shape mirrors frag-6-7 §7.2 step 1-3):
+
+```ts
+// (1) Client → daemon — first envelope on every new connection; carries challenge nonce
+{ id: <n>, method: "ccsm.v1/daemon.hello",
+  payload: {
+    clientWire: "v0.3-json-envelope",        // wire format identifier
+    clientProtocolVersion: 1,                // INTEGER (uint, semver-major); bumped on breaking wire change; client's max accepted protocol
+    clientFrameVersions: [0],                // frame-version nibbles client can read (§3.4.1.c)
+    clientFeatures: ["binary-frames", "stream-heartbeat", "interceptors", "traceId", "bootNonce", "hello"],
+    clientHelloNonce: "<base64-16>"          // 16 random bytes (~22 chars on wire); per-connection challenge for daemon to HMAC
+  }
+}
+
+// (2) Daemon → client — same envelope id; proves possession of daemon.secret AND advertises protocol
+{ id: <n>,
+  payload: {
+    helloNonceHmac: "<base64-22>",           // HMAC-SHA256(daemon.secret, clientHelloNonce) truncated to 16 bytes, base64
+    protocol: {                              // canonical version-negotiation block; mirrored 1:1 from frag-6-7 §6.5 healthz
+      wire: "v0.3-json-envelope",
+      minClient: "v0.3",
+      daemonProtocolVersion: 1,              // INTEGER (uint, semver-major); bumped on breaking wire change; bump rule below `[manager r9 lock: r8 envelope P1-4 — type pinned to integer literal; TypeBox Type.Integer({minimum:1}); compare numerically; schema validation REJECTS string values with schema_violation]`
+      daemonAcceptedWires: ["v0.3-json-envelope"], // round-3 fwdcompat P1-5; v0.4 ships [..., "v0.4-protobuf"]
+      // single source of truth: frag-6-7 §6.5; this list mirrors that
+      features: ["binary-frames", "stream-heartbeat", "interceptors", "traceId", "bootNonce", "hello"]
+    },
+    daemonFrameVersion: 0,                   // active frame-version nibble for this session (§3.4.1.c)
+    bootNonce: "<ULID>",                     // mirrors frag-6-7 §6.5 healthz bootNonce; renderer must check after reconnect
+    defaults: {                              // see §3.4.1.c reserved headers
+      deadlineMs: 5000,
+      heartbeatMs: 30000,
+      backpressureBytes: 1048576
+    },
+    compatible: true,
+    reason: undefined                        // string only when compatible === false
+  }
+}
+```
+
+The **client** computes the same HMAC over its own `clientHelloNonce` using its loaded `daemon.secret`, and compares against the daemon's `helloNonceHmac` field using **`crypto.timingSafeEqual`** (constant-time; non-negotiable — `Buffer.compare` is forbidden here, byte-by-byte timing leak). Mismatch → client treats the listener as imposter, logs `{ offenderPid }`, refuses to talk, falls back to spawning the real daemon under a fresh socket name (Win named-pipe collision: append `-rescue-<ulid>`). Reverse-direction proof (client proves to daemon) is unnecessary because peer-cred (§3.1.1) + ACL (§7.1) already authenticate the client.
+
+**Base64 variant (round-9 manager lock — r8 envelope P1-1)** `[manager r9 lock: r8 envelope P1-1 — base64url-no-pad locked for both clientHelloNonce + helloNonceHmac]`: both `clientHelloNonce` (16 raw random bytes) and `helloNonceHmac` (truncated 16-byte HMAC-SHA256 output) MUST be encoded on the wire via `Buffer.from(buf).toString('base64url')` — URL-safe alphabet, **no `=` padding**. 16 bytes round-trips to exactly 22 ASCII chars, matching the `<base64-22>` placeholders in the schema. Both sides MUST decode the wire string back to a 16-byte `Buffer` via `Buffer.from(s, 'base64url')` BEFORE invoking `crypto.timingSafeEqual` — comparing the ASCII strings directly bypasses the constant-time guarantee. Padded standard `base64` (24 chars with trailing `==`) is FORBIDDEN; mixing padded vs unpadded variants between client and daemon causes `RangeError [ERR_OUT_OF_RANGE]: Input buffers must have the same byte length` on the very first connection — every install ships dead-on-arrival.
+
+Daemon refuses to dispatch any RPC other than `daemon.hello` on the connection until the handshake completes (`helloInterceptor` enforces; rejects with `hello_required` + `socket.destroy()`). On the daemon side the per-connection `clientHelloNonce` is single-use: any further `daemon.hello` on the same socket after the first is rejected with `hello_replay`.
+
+**Client-side handshake timeout + failure classification (round-7 manager lock — r6 reliability P0-R1)** `[manager r7 lock: r6 reliability P0-R1 — explicit 2 s handshake deadline + dedicated failure class so handshake-failure storms cannot bypass the 250 ms reconnect hold-off and exhaust the queue, and so handshake-stuck remediation (reinstall ccsm) stays distinct from post-handshake hang remediation (restart daemon)]`:
+
+- **Handshake timeout = 2 s**, measured from socket-connect (TCP/pipe accept observed client-side) to receipt of the daemon's frame-2 reply (`helloNonceHmac` + `protocol`). Sits between the §3.7.4 first-attempt backoff (200 ms) and the §3.5.1.3 unary default deadline (5 s) so handshake-failure surfaces faster than a generic stuck unary RPC but does NOT race the first reconnect step. On timeout, the client closes the socket with no synthetic error frame (handshake is pre-RPC, no envelope id to bind a reply to), increments the §3.7.4 reconnect backoff schedule, and emits one `daemon_handshake_timeout` log line `{ peer, durationMs, attemptN }`. The rejection class is `HANDSHAKE_TIMEOUT` (NOT `BridgeTimeoutError` — distinct path so `bridgeTimeoutSpike` aggregation in §6.1.1 is not falsely tripped).
+- **Handshake-failure does NOT count toward `bridgeTimeoutSpike` (frag-6-7 §6.1.1) 3-in-10s detector.** The two failure classes are distinct: `bridgeTimeoutSpike` aggregates POST-handshake unary RPC `BridgeTimeoutError`s; handshake failures (timeout, `hello_required`, `hello_replay`, `schema_violation` on `daemon.hello`, HMAC mismatch via `crypto.timingSafeEqual`, `compatible: false` reasons) are treated identically by the client — close socket, count toward §3.7.4 reconnect backoff schedule, surface only via the existing supervisor heartbeat / reconnect surfaces (frag-6-7 §6.1.1 `daemon.healthDegraded` → `daemon.healthUnreachable` ladder + §6.8 reconnect toast). No new modal row is added; remediation copy ("if this persists, ccsm may need to be reinstalled") is folded into the body of the existing `daemon.healthUnreachable` banner (frag-6-7 §6.1.1 owns the copy edit; cross-frag handoff to fixer A — surface registry trim — preserves the row count). Without this carve-out, a daemon stuck rejecting handshakes (corrupted `daemon.secret` after partial auto-update swap, binary mismatch) would falsely trip the 3-in-10s `daemon.bridgeTimeouts` banner whose copy ("the background service may be busy") points the user at the wrong remediation.
+- **Reinstall vs restart remediation distinction**: handshake-stuck = binary or secret mismatch (reinstall ccsm); post-handshake hang = handler stuck or daemon thrashing (restart daemon). The `daemon.healthUnreachable` body MUST cover both — since handshake failure surfaces through the same banner, body copy reads roughly `Trying to restart it. If this persists, reinstall ccsm.` (frag-6-7 §6.1.1 owns final wording; cross-frag handoff to fixer A).
+- **`clientHelloNonce` regeneration is MANDATORY per connection attempt.** Each new socket (including every reconnect attempt under §3.7.4 backoff) MUST allocate a fresh 16-byte `crypto.randomBytes(16)` value; clients MUST NOT cache or reuse the nonce across attempts. Reuse would let a passive observer correlate reconnect storms; more importantly, the daemon's single-use-per-socket invariant (`hello_replay` rejection) would falsely fire for the second connection if the same nonce arrived. (Already implied by "per-connection challenge" but stated as MUST so a worker doesn't hoist nonce generation out of the connect loop.)
+
+On `compatible: false`, daemon does NOT close the socket immediately — the reply still carries `helloNonceHmac` (so client can rule out imposter) plus `reason` ∈ `{"wire-mismatch", "version-mismatch", "frame-version-mismatch"}` so the client can read the structured error and surface "ccsm needs to be updated" modal (frag-6-7 §6.8 surface registry) before the connection is torn down.
+
+**Wire-debug logging**: pino debug logs MAY include `clientHelloNonce` and `helloNonceHmac` fields verbatim (both are useless without the secret), but they are nonetheless on the redact list curated in **frag-6-7 §6.6 / §7.2** (entries: `daemonSecret`, `installSecret`, `imposterSecret`, `clientImposterSecret`, `*.clientImposterSecret`, `pingSecret`, `helloNonce`, `clientHelloNonce`, `helloNonceHmac`, `*.secret`) for defense in depth. There is no `imposterSecret` cleartext field anywhere in v0.3 post-r3; only `clientHelloNonce` (public, per-connection challenge issued by client) and `helloNonceHmac` (daemon's response, no secret bits leak).
+
+**Compatibility rule**: `compatible = (clientFrameVersions includes daemonFrameVersion) AND (clientProtocolVersion ≥ daemonProtocolVersion's minimum) AND (clientWire is in protocol.daemonAcceptedWires)`. Mismatch → `compatible: false` + `reason` ∈ `{"wire-mismatch", "version-mismatch", "frame-version-mismatch"}`. Client surfaces "ccsm needs to be updated" modal (frag-6-7 §6.8 surface registry); daemon does NOT close the socket immediately so the client can read both `helloNonceHmac` (rules out imposter) and `reason` (drives modal copy).
+
+**Version-bump discipline (round-3 fwdcompat P1-4)**:
+- `daemonFrameVersion` (the high-nibble of `totalLen` per §3.4.1.c) bumps **ONLY on wire-format change** (e.g. v0.3 JSON envelope → v0.4 protobuf = nibble 0x0 → 0x1).
+- `daemonProtocolVersion` (semver-major integer) bumps **ONLY on breaking handler-contract changes** (RPC removed, request/response field semantics changed). Adding a new RPC method, adding an optional field, or shipping a new optional capability MUST NOT bump `daemonProtocolVersion` — those go in `protocol.features[]`. This prevents v0.3.x from forcing a panic-bump every time a worker adds a non-breaking RPC.
+- `protocol.daemonAcceptedWires[]` lets a future v0.4 daemon accept BOTH legacy v0.3-json-envelope clients and native v0.4-protobuf clients on the same socket during the rolling-upgrade window; v0.3 daemons advertise a single-element array.
+
+**`bootNonce` propagation (round-2 fwdcompat P1-1, round-3 fwdcompat CC-2)**: the hello reply carries the daemon's current `bootNonce` (camelCase — locked across all fragments per round-3 fwdcompat CC-2; frag-6-7 §6.5 healthz uses the same camelCase spelling, NOT `boot_nonce`). Stream `subscribe` RPCs include the last-known `bootNonce` as a header (`headers["x-ccsm-boot-nonce"]`). On nonce mismatch, daemon ignores `fromSeq` and sends a fresh snapshot with `bootChanged: true`. Stream contract details (renderer divider rendering, log lines) are owned by **frag-3.5.1 / frag-3.7**.
+
+**`bootNonce` carriage precedence (round-9 manager lock — r8 envelope P0-3)** `[manager r9 lock: r8 envelope P0-3 — header + RPC-param double-carriage precedence rule]`: `bootNonce` may arrive on a subscribe RPC via either (a) the envelope header `headers["x-ccsm-boot-nonce"]` (this section, allowlisted in §3.4.1.c) OR (b) the canonical RPC param `fromBootNonce` (frag-3.5.1 §3.5.1.4 owns the param shape). The daemon MUST tolerate both forms during the v0.3 lift. Resolution rule: **if BOTH the header AND the RPC param carry a value, the header wins** (envelope-level intent takes precedence over per-method body for transport-layer semantics). **If only the header is present, the header value is used. If only the RPC param is present, the param value is used.** Daemon emits one `pino.debug({ method, headerVal, paramVal }, "boot_nonce_dual_carriage")` line (debug-only — single-source clients should pick ONE form per call site). The `x-ccsm-boot-nonce` header is reserved per §3.4.1.c; the RPC-param shape stays canonical for protobuf migration.
+
+**v0.4 / v0.5 transition**: v0.4 daemon ships with `daemonFrameVersion: 1` (protobuf), advertises `protocol.wire: "v0.4-protobuf"` plus `protocol.daemonAcceptedWires: ["v0.3-json-envelope", "v0.4-protobuf"]`, and registers BOTH `ccsm.v1/...` (legacy bridge for v0.3 clients) and `ccsm.v2/...` (protobuf-native) namespaces. v0.5 web client over CF Tunnel sets larger `headers["x-ccsm-deadline-ms"]` per call (e.g. 30000 for snapshot bootstrap; clamped 120 s per §3.4.1.c). The hello envelope itself stays at frame-version 0 in perpetuity so cross-version negotiation always succeeds.
+
+**RPC namespace evolution (round-2 fwdcompat P0-3)**: RPC method names use `ccsm.<wireMajor>/<service>.<method>`. v0.3 daemon registers ONLY `ccsm.v1/...`. A future v0.4 daemon registers BOTH `ccsm.v1/` (legacy bridge) AND `ccsm.v2/` (protobuf). Removing `ccsm.v1/` happens in v0.5 once all clients have re-handshaken to v2. Workers MUST NOT hard-code `ccsm.v1` checks anywhere outside the dispatch table — the namespace rule is the single source of truth for version-pinned routing.
+
+Cost: ~25 LOC (single new RPC `daemon.hello` + per-connection `clientHelloNonce` validation via `crypto.randomBytes(16)` on client + HMAC compute on daemon + handshake interceptor) + 2 unit tests asserting (a) `compatible: false` path returns `helloNonceHmac` + `reason` cleanly without immediate socket close and (b) bit-flipped `helloNonceHmac` rejected via `timingSafeEqual` on the client side (asserts the constant-time path is wired, not just the equality).
+
+#### 3.4.1.h Healthz transport isolation (round-2 reliability P0-R5, round-3 perf CF-1)
+
+Per §6.5, the supervisor pings `/healthz` every 5 s with 3-miss = restart. If `/healthz` shares the data adapter with a snapshot fan-out, a 1 MiB sub-chunk stream serializing through the same socket can starve the heartbeat → false-positive restart.
+
+**Rule**: the daemon binds **two separate listeners** (round-3 perf CF-1 disambiguates from frag-6-7 §6.5 supervisor transport — the `control-socket` defined here IS the supervisor `ccsm-control` socket per frag-6-7 §6.5; there are exactly TWO sockets per daemon, not three) `[manager r11 lock: P1 devx P1-2 socket name canonical = ccsm-control across both fragments; replaces prior `-sup` alias]`:
+
+| Socket | RPCs served | Consumers | Posix path | Windows path |
+|---|---|---|---|---|
+| **data-socket** | every RPC except those listed in the control row | Electron renderer (via main-process bridge) | `<runtimeRoot>/ccsm-data.sock` | `\\.\pipe\ccsm-data-<userhash>` |
+| **control-socket** (a.k.a. `ccsm-control` socket per frag-6-7 §6.5) | `/healthz`, `/stats`, `daemon.hello`, `daemon.shutdown` (frag-6-7 §6.4 step 4 graceful drain), `daemon.shutdownForUpgrade` (frag-6-7 §6.4 upgrade-in-place + marker; consumed by frag-11 §11.6.5) | supervisor process AND Electron main (parallel connections, shared posture) | `<runtimeRoot>/ccsm-control.sock` | `\\.\pipe\ccsm-control-<userhash>` |
+
+**`<runtimeRoot>` definition (round-9 manager lock cross-ref + r11 devx P1-4)** `[manager r11 lock: P1 devx P1-4 — explicit OS-native runtime root replaces hardcoded `~/.ccsm/run/...` paths; cross-references frag-12 r5 lock #2 `<dataRoot>` definition]`: `<runtimeRoot>` is the OS-native runtime/socket directory, distinct from `<dataRoot>` (logs/db/binaries):
+- **Linux**: `process.env.XDG_RUNTIME_DIR ?? <dataRoot>/run` (XDG-compliant tmpfs preferred; falls back to data root if `XDG_RUNTIME_DIR` is unset/unwritable, e.g. systemd-less containers).
+- **Windows**: named pipes namespace (`\\.\pipe\ccsm-{data,control}-<userhash>`) — no filesystem path; the `<runtimeRoot>` notation in the table cell is a notional anchor for the named-pipe form. Where a filesystem path is unavoidable (e.g. lockfile sibling), use `<dataRoot>\run\`.
+- **macOS**: `<dataRoot>/run/` (Apple does not export an `XDG_RUNTIME_DIR` equivalent; the data root sub-directory keeps socket nodes co-located with the rest of the per-user state and inherits the `<dataRoot>` ACL).
+
+`<dataRoot>` itself is defined in frag-12 (r5 lock #2): `%LOCALAPPDATA%\ccsm` (Win), `~/Library/Application Support/ccsm` (mac), `~/.local/share/ccsm` (Linux). The `<runtimeRoot>` derivation above is the single source of truth for socket / pipe paths; fragments referencing socket paths MUST cite `<runtimeRoot>` and not rehydrate `~/.ccsm/run/...` literals.
+
+Both sockets share peer-cred / DACL / accept-rate-cap / hello-handshake posture. The Electron client connects to BOTH (control for supervisor-shaped RPCs + supervisor itself, data for everything else). The supervisor connects only to `control-socket`. There is **no** third socket — `ccsm-control` is the single canonical name for the control plane shared with frag-6-7 §6.5; the prior `-sup` alias is fully retired `[manager r11 lock: P1 devx P1-2 — `-sup` literal removed in favor of `ccsm-control` everywhere; cross-frag merge no longer required]`.
+
+**Control-plane namespace carve-out (round-11 manager lock — P1 reliability daemon.stats → /stats sweep)** `[manager r11 lock: P1 reliability — explicit control-plane namespace exemption from §3.4.1.g `ccsm.<wireMajor>/...` rule]`: `/healthz` and `/stats` are **literal paths** exempt from the `ccsm.<wireMajor>/<service>.<method>` namespace prefix mandated by §3.4.1.g for all data-plane methods. They are control-plane RPCs declared in the canonical `SUPERVISOR_RPCS` constant below and dispatched on the control-socket as wire-literals (the on-wire `method` field equals `/healthz` / `/stats`, NOT `ccsm.v1/daemon.healthz` / `ccsm.v1/daemon.stats`). Consumers (control-socket dispatcher, helloInterceptor allowlist, `migrationGateInterceptor` allowlist, frag-8 §8.5 migration scope) compare these as literal strings and MUST NOT silently namespace-prefix them. Rationale also covered by the §3.4.1.h literal-vs-namespace lock paragraph below; restated here as the control-plane vs data-plane carve-out to give frag-6-7 / frag-8 a single anchor when wiring `SUPERVISOR_RPCS`.
+
+**Allowlist constant (round-3 fwdcompat P1-1)**: the set of "control-plane RPCs" is a single canonical constant `SUPERVISOR_RPCS = ["/healthz", "/stats", "daemon.hello", "daemon.shutdown", "daemon.shutdownForUpgrade"]` declared here and consumed by (a) the control-socket dispatcher (this section), (b) the `migrationGateInterceptor` (§3.4.1.f) as the short-circuit allowlist, and (c) frag-8 §8.5 migration scope. Other fragments reference the constant by name; they MUST NOT enumerate alternative lists. `[manager r7 lock: r6 packaging P0-2 — daemon.shutdownForUpgrade added to allowlist; semantics + marker file owned by frag-6-7 §6.4; consumed by frag-11 §11.6.5 upgrade-in-place flow.]`
+
+**Literal-vs-namespace lock (round-9 manager lock — r8 envelope P1-3)** `[manager r9 lock: r8 envelope P1-3 — /healthz and /stats keep HTTP-style literal method names; explicit exemption from §3.4.1.g ccsm.<wireMajor>/<service>.<method> namespace rule]`: `/healthz` and `/stats` are wire-literal method values (the on-wire `method` field equals the literal string `/healthz` or `/stats`, NOT `ccsm.v1/daemon.healthz` / `ccsm.v1/daemon.stats`). The §3.4.1.g namespace rule applies to all OTHER RPCs; these two HTTP-path-style entries are explicitly exempt because (a) they pre-date the namespace convention as supervisor heartbeat literals, (b) zero-cost dispatch on the control-socket reads the literal once, (c) supervisors / external probes can hit them without round-tripping a wire-version negotiation. The dispatch table MUST register the literal `/healthz` (no `ccsm.v1/daemon.healthz` alias). The helloInterceptor allowlist + `SUPERVISOR_RPCS` consumers compare these literals as strings; consumers MUST NOT silently namespace-prefix them.
+
+Cost: ~10 LOC of duplicated `mountConnectAdapter` call + one extra socket path + integration with the §3.4.1.g hello/HMAC handshake on both listeners. Eliminates the entire class of "slow data path back-pressures heartbeat" races. Round-2 reliability P0-R5 explicitly recommended this over a priority-queue inside one adapter.
+
+---
+
+## Plan delta
+
+Concrete edits to `docs/superpowers/plans/2026-04-30-v0.3-daemon-split.md`:
+
+### Task 5 (Connect adapter on the local channel) — additions
+- **Step 4 add (envelope cap)**: before `JSON.parse(body)`, check **frame-version nibble first** (reject unknown with `UNSUPPORTED_FRAME_VERSION` + destroy), then mask low 28 bits, then check `len > 16 * 1024 * 1024` → emit warn (incl. `peerPid`), write `envelope_too_large` error frame, `socket.destroy()`. Pre-accept rate cap: 50/s with EAGAIN. +0.5 h.
+- **Step 4 add (binary frame format, 3.4.1.c)**: refactor `Envelope` into header (`{ id, method?, stream?, payloadType, payloadLen, traceId?, headers? }`) + optional binary trailer. Reserve high 4 bits of `totalLen` as frame-version nibble; reject unknown nibbles. Update `mountConnectAdapter` reader to split header parse from trailer slice. Update `writeEnv` to accept either `{ payload }` (JSON path) or `{ headerExtras, payloadBytes }` (binary path). Implement per-stream header-skeleton caching with **zero-padded 10-digit `seq`** + receiver fast-path + `socket.cork()`/`uncork()` per frame. +5 h (revised from +3 h per round-2 perf §6 budget concern).
+- **Step 4 add (schema validation + handler-arg discipline)**: validate header against TypeBox contract before dispatch; reject + close on violation. Validate `traceId` against Crockford ULID regex **only when present** (chunk/heartbeat sub-frames carry no traceId by design — resolved from streamId map). ESLint rule `no-handler-without-check` for handler-arg discipline. +1.5 h.
+- **Step 4 add (per-frame chunking, 3.4.1.b)**: for stream emit, split payloads >16 KiB into ≤16 KiB sub-frames sharing `streamId`, with per-stream monotonic `seq` zero-padded to 10 ASCII digits (odd ids client-initiated, even ids server-initiated; v0.3 only emits odd from client). Cache framed buffer once for fan-out (write to N sockets without re-stringify). Replay bound: ≤256 KiB before `gap: true`. Receiver-side reassembly helper in `testHelpers.ts`. +3.5 h (revised from +2.5 h).
+- **Step 4 add (interceptor pipeline, 3.4.1.f)**: `mountConnectAdapter({ interceptors: Interceptor[] })`. Ship four built-ins (trace, deadline [clamp 100 ms ≤ x ≤ 120 s + unknown-x-ccsm-* warn], migrationGate [allowlist = `SUPERVISOR_RPCS` constant from §3.4.1.h], metrics). +2 h.
+- **Step 4 add (hello HMAC handshake, 3.4.1.g — round-5 manager 2-frame lock)**: single `daemon.hello` RPC (no `helloAck`) + handshake-required interceptor + version compatibility table + `protocol.daemonAcceptedWires[]` + per-connection `clientHelloNonce` (16 random bytes generated client-side) + `crypto.timingSafeEqual` HMAC verify on the CLIENT side. Daemon computes `HMAC-SHA256(daemon.secret, clientHelloNonce)` truncated to 16 bytes and returns in `helloNonceHmac`. **Do NOT include the secret in any wire payload.** +2 h (revised from +2.5 h — one fewer frame, one fewer RPC).
+- **Step 4 add (control socket, 3.4.1.h)**: bind second listener for `SUPERVISOR_RPCS`; both sockets share peer-cred / hello-handshake posture. Reconcile naming with frag-6-7 `-sup` alias to single `ccsm-control` path. +1 h.
+- **New unit tests** in `daemon/src/transport/__tests__/connectAdapter.test.ts`:
+  - oversize envelope rejected + socket destroyed (16 MiB + 1 byte);
+  - frame-version nibble: unknown nibble (e.g. `0x1` against v0.3 daemon) rejected with `UNSUPPORTED_FRAME_VERSION` BEFORE length-cap check (asserts parse order);
+  - binary frame round-trip (PTY-shaped 64 KiB Buffer, byte-equal);
+  - schema-violation rejected (missing `id`; malformed `traceId`);
+  - traceId carve-out: `stream.kind === "chunk"` / `"heartbeat"` frames with no `traceId` ACCEPTED; chunk for unknown `streamId` rejected with `RESOURCE_EXHAUSTED`;
+  - chunked stream: 1 MiB payload arrives as N ≤16 KiB sub-chunks, in order, reassembled byte-equal; `seq` zero-padded — no fast-path fallback as `seq` crosses `9999 → 10000`;
+  - interleave: 1 MiB stream sub-chunks let a unary `ping` round-trip in <50 ms p99;
+  - interceptor order asserted (trace → deadline → migrationGate → metrics → handler); deadline clamp bounds asserted at 100 ms / 120 s;
+  - unknown `x-ccsm-foo` header → warn line emitted (rate-limited);
+  - HMAC handshake: hello-before-other-RPC required; version mismatch returns `compatible: false` + `reason` WITHOUT immediate socket close (client must read `helloNonceHmac` to rule out imposter); bit-flipped `helloNonceHmac` rejected via `crypto.timingSafeEqual` on client (assert constant-time path is wired); replay of `daemon.hello` on same socket rejected with `hello_replay`;
+  - **secret never on wire**: hex-dump capture of every byte written by client during handshake — assert the loaded `daemon.secret` byte sequence does NOT appear anywhere in the captured bytes (regression guard against a future worker reintroducing the bearer field);
+  - replay bound: client requests `fromSeq` triggering >256 KiB → daemon emits `gap: true` + snapshot;
+  - control vs data socket isolation: a saturated data socket does not delay control-socket `/healthz` p99 by >5 ms; only ONE control socket exists (no third `-sup`-suffixed listener).
+  +3.5 h (revised from +3 h).
+
+**Task 5 net delta: +19.5 h** (round-2: +18.5 h; round-3 added +0.5 h HMAC handshake + +0.5 h additional unit tests). Original ~6 h → ~25.5 h. Borderline atomic for one worker per `feedback_split_large_worker_tasks`; manager should evaluate splitting into 5a (envelope+chunk+binary) / 5b (interceptor+hello-HMAC+control-socket) phases dispatched serially in the same pool worktree.
+
+### Task 11 (Lift `ptyService` data side to daemon) — additions
+- **Step 1 add**: `subscribePty` server-stream uses 3.4.1.c binary frame for `delta` chunks (`payloadBytes = node-pty Buffer`); only `seq` + `kind` go in the JSON header (`traceId` only on `kind: "open"`).
+- **Step 1 add**: `getBufferSnapshot` streams as 3.4.1.b sub-frames (≤16 KiB each), aligned to the existing 1000-line async-chunk boundary on the daemon side. Replaces today's "collapse into one envelope" path. +2 h.
+- **Step 1 add**: `subscribePty` carries `headers["x-ccsm-boot-nonce"]` (last-known nonce); on mismatch daemon emits `bootChanged: true` + fresh snapshot. Wiring of the renderer divider (`─── daemon restarted ───`) owned by frag-3.5.1 / frag-3.7.
+- **New perf-regression test** (vitest, can run in-process via two `Duplex` streams to stand in for the socket): assert that interleaving a 5 MiB simulated snapshot with 100 unary `ping` calls keeps `ping` p99 < 50 ms. +2 h.
+
+**Task 11 net delta: +4 h** (original ~10 h → ~14 h).
+
+### Task 6 (Wire transport into daemon entry) — note only
+Add log line on adapter mount: `pino.info({ envelopeCapMib: 16, chunkKib: 16, schemaValidated: true, frameVersion: 0, protocolVersion: 1, controlSocket: true, hmacImposter: true }, "rpc_adapter_mounted")` so dogfood logs prove hardening is live.
+
+### New follow-up tasks (created post-v0.3 freeze)
+- **Task 5b (deferred, REVISED per round-2 perf §7)**: micro-benchmark spike per perf review — frame format (~2 h) + head-of-line interleaving (~2 h). **Run pre-Task 11c, in a single pool worktree, BEFORE locking the streaming envelope**. Round-1's "defer to v0.4 unless dogfood shows stutter" was reversed by round-2 perf §7 because dogfood (1-3 users, no concurrent sessions) is a weak signal for p99 wire-format latency.
+- **Task 11d (new, REVISED per round-2 perf P1-B)**: backpressure path from `xterm-headless` writes back to `node-pty` (`pause()`/`resume()` once `pendingHeadlessWrites > 500`). +1.5 h. **MUST land with Task 11** — round-2 perf escalated this from SHOULD to P1 because without it the §3.5.1.5 drop-slowest watermark cannot prevent unbounded RSS growth on a slow subscriber. The "unless time-boxed out" qualifier from round-1 is removed.
+
+### Total v0.3 estimate impact
++23.5 h on the critical path (Tasks 5 + 11), revised from +22.5 h after round-3 additions (+1 h HMAC handshake + tests). Original v0.3 = ~125 h → ~148.5 h. Manager should split Task 5 into 5a/5b phases per `feedback_split_large_worker_tasks`.
+
+---
+
+## Cross-frag rationale
+
+Round-2 reviewers raised several items where ownership was unclear between frag-3.4.1 (envelope/wire-format) and another fragment. Decisions taken below; "→ frag-X" means I left the item to that fragment's owner and trust them to handle it.
+
+| Item | Source | Decision | Rationale |
+|---|---|---|---|
+| `traceId`, `headers`, `interceptors[]` on envelope header | fwdcompat P0-1, observability P0-2, perf P0-A | **TAKE** (§3.4.1.c, §3.4.1.f) | Wire-format / data-layer is the natural owner; this is the seam that v0.4 protobuf swap and v0.5 CF Access JWT will hang off. |
+| Hello/version handshake + frame-version nibble + **HMAC challenge-response** | fwdcompat P0-2, lockin P0-1, **round-3 security P0-1**, **round-5 manager 2-frame lock** | **TAKE** (§3.4.1.g) | Handshake lives at the transport boundary; healthz body shape (which carries `bootNonce`) stays with frag-6-7 §6.5. Round-3 switched the imposter check from plaintext bearer to `crypto.timingSafeEqual`-verified HMAC over a client-issued `clientHelloNonce` so the secret never traverses the wire. Round-5 collapsed to 2 frames (was 3) aligned 1:1 with frag-6-7 §7.2: client issues nonce in frame 1, daemon proves possession in frame 2 (no third ack). Saves 1 RT on every reconnect. |
+| Frame-header parsing order (nibble → mask → cap) | round-3 security CC-1 | **TAKE** (§3.4.1.a) | Order ambiguity here resurrects either a 256 MiB DoS or a stale-client miscapture; the rule belongs at the byte-decode site. |
+| traceId optional-on-chunk/heartbeat carve-out | round-3 security CC-2 | **TAKE** (§3.4.1.c validation paragraph) | The validator regex lives at the adapter; the omission rule was already documented but the validator carve-out wasn't. Single-site fix. |
+| `bootNonce` camelCase locking | round-3 fwdcompat CC-2 | **TAKE the spelling** (§3.4.1.g hello reply); cross-frag merge worker reconciles frag-6-7 §6.5 + frag-3.5.1 + frag-3.7 to camelCase | Cosmetic but load-bearing — `boot_nonce` vs `bootNonce` drift would silently break renderer reconnect detection. Aligns with all other JSON envelope fields (`traceId`, `streamId`, `headerLen`, `payloadLen`). |
+| `x-ccsm-deadline-ms` clamp (120 s) | round-3 fwdcompat CC-3 | **TAKE** (§3.4.1.c reserved headers + §3.4.1.f deadlineInterceptor) | The clamp must be unified between header-validation and deadline-enforcement; both sites now say `100 ms ≤ x ≤ 120 s` matching frag-3.5.1 §3.5.1.3 and the v0.5 web snapshot-bootstrap headroom. |
+| `daemonAcceptedWires[]` in hello reply | round-3 fwdcompat P1-5 | **TAKE** (§3.4.1.g hello reply schema) | Saves a roundtrip during v0.3→v0.4 rolling-upgrade; v0.3 ships a single-element array, v0.4 daemons add `"v0.4-protobuf"`. |
+| `seq` zero-padding to 10 ASCII digits | round-3 perf P1-1 | **TAKE** (§3.4.1.c hot-path bullet) | Without padding, the cached header-skeleton fast path silently regresses to full `JSON.parse` after `seq=10000`. 3-LOC fix; eliminates a silent perf cliff. |
+| Feature-add vs version-bump rule | round-3 fwdcompat P1-4 | **TAKE** (§3.4.1.g version-bump discipline paragraph) | Without the rule, every new optional capability bumps `daemonProtocolVersion`, defeating semver-major's purpose. New rule: features in `daemonFeatures[]`, breaking changes only bump `daemonProtocolVersion`. |
+| Unknown `x-ccsm-*` header warn | round-3 fwdcompat P1-7 | **TAKE** (§3.4.1.c reserved-headers paragraph + §3.4.1.f deadlineInterceptor bullet) | Catches v0.3.x worker squatting on a future-reserved key before it hardens into a wire contract. Optional warn line, rate-limited. |
+| `SUPERVISOR_RPCS` allowlist constant | round-3 fwdcompat P1-1 | **TAKE** (§3.4.1.h) | Single canonical constant consumed by control-socket dispatcher, migrationGateInterceptor (§3.4.1.f), and frag-8 §8.5 migration scope. Prevents the three sites drifting on which RPCs are control-plane. |
+| Control-socket vs supervisor `-sup` socket disambiguation | round-3 perf CF-1 | **TAKE** (§3.4.1.h table) | frag-6-7 §6.5 and §3.4.1.h were ambiguous about whether they described two sockets or three. Locked to TWO total: data-socket + control-socket (= supervisor `-sup` alias). Cross-frag merge worker reconciles `-sup` literal in frag-6-7 to `ccsm-control` path. |
+| RPC namespace `ccsm.vN/...` rule | fwdcompat P0-3 | **TAKE** (§3.4.1.g) | Adapter dispatch table is the only place that enforces the namespace; documenting it elsewhere would split the rule from its enforcer. |
+| Reserved `x-ccsm-*` header keys | fwdcompat P1-2 | **TAKE** (§3.4.1.c) | Header schema is a wire-format concern; the actual deadline middleware lives in the §3.4.1.f interceptor pipeline. |
+| `streamId` allocation (odd/even) | fwdcompat P2-2 | **TAKE** (§3.4.1.b) | Stream id namespace is part of the wire contract. |
+| `traceId` validation regex + injection guard | security P1-S2 | **TAKE** (§3.4.1.c) | Adapter is the trust boundary that turns wire bytes into typed values; per-handler revalidation is wasteful. |
+| Handler-arg validation for binary trailer | security P1-S1 | **TAKE the rule** (§3.4.1.d), the per-method schemas live with each handler | Adapter cannot validate opaque bytes, but it CAN mandate the discipline + ESLint rule. |
+| Pre-accept rate cap (T15) + peer PID in oversize log | security T15, reliability S-R5 | **TAKE** (§3.4.1.a) | Both attach to the listener boundary I already own. |
+| Replay bound on resubscribe (≤256 KiB) | resource P0-1 | **TAKE** (§3.4.1.b) | Chunking semantics + `gap: true` are wire-format; the renderer divider rendering belongs to frag-3.5.1/frag-3.7. |
+| Health/data socket isolation | reliability P0-R5 | **TAKE** (§3.4.1.h) | The two-socket topology IS a wire-format change; supervisor wiring stays with frag-6-7. |
+| Subscribe RPC contract (`subscribe(sessionId, { fromSeq, fromBootNonce, heartbeatMs })`) | round-3 fwdcompat P1-2 | → **frag-3.5.1 §3.5.1.4** (canonical owner declared in §3.4.1.b) | I own only the wire-level chunking + replay-budget mechanics; field naming, defaults, clamps, protobuf message def live in frag-3.5.1. Cross-ref added so v0.4 worker reads one source. |
+| `daemon.secret` lifecycle (creation, rotation, ACL, redact) | security P0-S1 | → **frag-6-7 §7.2** | Lifecycle = installer-time generation + auto-update rotation + redact-list curation, none of which is a wire concern. I only consume the secret value in §3.4.1.g hello compare. **Round-3 update**: redact list keeps `daemonSecret`, `installSecret`, `imposterSecret`, `clientImposterSecret`, `*.clientImposterSecret`, `pingSecret`, `*.secret`, AND adds `helloNonce`, `clientHelloNonce`, `helloNonceHmac` (defense in depth — these fields are useless without the secret but redacting them costs nothing and avoids debug-log noise around handshake correlation). Single source of truth: frag-6-7 §6.6 / §7.2. |
+| `statsVersion` field placement | round-3 fwdcompat P1-3 | → **frag-6-7 §6.5** (drop from `/healthz`, keep on `daemon.stats`) | Two version cursors for one schema is a footgun; I only note the decision so frag-6-7 owner removes the duplicate. |
+| `bootNonce` field on subscribe + delta + `bootChanged` semantics | fwdcompat P1-1 | → **frag-3.5.1 + frag-3.7** | I expose `bootNonce` in hello (§3.4.1.g) and reserve `headers["x-ccsm-boot-nonce"]`; the renderer-side cache, divider, and resubscribe logic belong to the dev-workflow / stream owner. |
+| Subscriber session-token auth | security P1-S3 | → **frag-3.5.1** | `ptySubscribe` is a stream RPC owned by frag-3.5.1; I provide the `headers` carriage but the token policy is theirs. |
+| Migration env-var rename / marker schema versioning | lockin P0-3, fwdcompat P1-3 | → **frag-8** | Migration is frag-8's territory; my interceptor (`migrationGateInterceptor`) only consumes the "is migration in flight?" boolean. |
+| Modal/toast surface registry, sentence-case copy for `version_mismatch` etc. | UX P0-UX-1, P0-UX-3 | → **frag-6-7 §6.8** | I emit structured error codes; the renderer-side modal copy + stacking rules belong to the UI surface owner. |
+| Native `winjob.node` packaging / signing / ABI | packaging P0-2 | → **frag-11** | Pure build/CI concern; my adapter is JS only. |
+| pino-roll abstraction layer / `proper-lockfile` swap / `koffi` vs N-API | lockin P1-1, P1-2, P0-2 | → **frag-6-7** | Logging + native-binding ownership lives there. |
+| Reconnect-queue cap / dev-mode escalation toast / TS-error escape hatch | UX P1-UX-1, devx P1-3 | → **frag-3.7** | Renderer-side reconnect logic is frag-3.7; my replay-bound rule (§3.4.1.b) is the daemon half of the contract. |
+
+Net (round-3): **27 P0/P1 items applied here** (round-2 baseline 17 + round-3 adds 10), **9 P0/P1 items punted to other fragments**. No item was dropped; every cross-frag handoff is named above so the next reviewer can audit the boundary.
+
+---
+
+## Citations
+
+- Round-3 reviews: `~/spike-reports/v03-r3-{security,fwdcompat,lockin,perf,observability}.md`.
+- Round-2 reviews: `~/spike-reports/v03-r2-{fwdcompat,observability,perf,lockin,security,resource,reliability,devx,ux,packaging}.md`.
+- Round-1 reviews: `~/spike-reports/v03-review-{perf,security,fwdcompat,observability,lockin}.md`.
+- v1 spec already wired: `docs/superpowers/specs/2026-04-30-web-remote-design.md` §3.1.1 line 80 (envelope cap forward-reference), §3.4 (Connect protocol), §3.5 (PTY headless / snapshot path).
+- v1 plan touched: `docs/superpowers/plans/2026-04-30-v0.3-daemon-split.md` Task 5 (lines 434–620, length-prefixed envelope), Task 11 step 1 (lines 1207–1234, stream extension).
+
+<!-- END frag-3.4.1-envelope-hardening.md -->
+
+---
+
+<!-- BEGIN frag-3.5.1-pty-hardening.md -->
+
+# Fragment: §3.5.1 PTY hardening (orphan reap + bridge timeout + stream heartbeat)
+
+**Owner**: Task #940 (worker, pool-2)
+**Target spec section**: insert immediately after §3.5 in `docs/superpowers/specs/2026-04-30-web-remote-design.md`
+**P0 review items addressed**: rel-M1 (PTY orphan reap, data-layer details), rel-M2 (bridge call timeout + AbortSignal), res-MUST-2 (subscriber multiplexing), res-OPEN-4 (stream backpressure under network drop).
+**Round-2 P0/P1 items applied**: rel-P0-R3 (SIGCHLD shutdown ordering + DB rows), rel-P0-R5 + obs-P0-3 (drain ordering for streams/heartbeat/fanout drop), rel-P1-R5 (per-PID waitpid scope), rel-P1-R6 (heartbeat-vs-supervisor inversion explained), pkg-P0-2 (winjob.node artifact named for frag-11), lockin-P0-2 (`NativeBinding` swap interface), lockin-P1-4 + fwdcompat-P1-2 (heartbeat negotiable), perf-P0-A/B (header cache + shared-frame fan-out), perf-P1-B (xterm-headless backpressure non-optional), perf-P1-C (shared heartbeat scheduler), res-P0-1 (replay budget on resubscribe), res-P1-3 (semaphore deadline starts after admission), res-P1-4 (aggregate per-session subscriber cap), obs-P0-2 (traceId on stream/heartbeat/drop log).
+**Inputs cited**:
+- `~/spike-reports/v03-review-reliability.md` (M1, M2, S2, F1, F9) + `~/spike-reports/v03-r2-reliability.md` (P0-R3, P0-R5, P1-R5, P1-R6)
+- `~/spike-reports/v03-review-resource.md` (MUST-FIX-2, SHOULD-FIX-2, OPEN-4) + `~/spike-reports/v03-r2-resource.md` (P0-1, P1-3, P1-4)
+- `~/spike-reports/v03-r2-perf.md` (P0-A, P0-B, P1-B, P1-C)
+- `~/spike-reports/v03-r2-observability.md` (P0-2, P0-3)
+- `~/spike-reports/v03-r2-lockin.md` (P0-2, P1-4)
+- `~/spike-reports/v03-r2-fwdcompat.md` (P1-1 boot nonce, P1-2 negotiable knobs)
+- `~/spike-reports/v03-r2-packaging.md` (P0-2 winjob.node artifact contract)
+
+**Boundary vs frag-6-7 §6.2**: §6.2 specifies the *supervisor-level* contract — what the OS does when daemon dies (`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` on Win, `setpgid`+`PR_SET_PDEATHSIG` on POSIX) and the dogfood acceptance test. This §3.5.1 specifies the *data-layer* mechanics: which npm/N-API binding implements it, exact SIGCHLD wiring inside `ptyService`, the bridge-call timeout middleware, stream RPC heartbeat, AbortSignal threading, and subscriber fan-out semantics. Cross-ref §6.2 from §3.5.1 for the orphan-reap acceptance criterion; do not restate.
+
+---
+
+## 3.5.1 PTY child lifecycle hardening
+
+The data-layer addendum to §3.5. §3.5 makes the daemon authoritative for PTY buffers; §3.5.1 makes the daemon authoritative for PTY *processes* (no leaks on crash) and makes every cross-process call *bounded in time* (no infinite hangs).
+
+### 3.5.1.1 Win JobObject wiring (data layer)
+
+Per §6.2, every `pty.spawn()` is enclosed in a `JobObject` with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. Implementation choice for v0.3:
+
+- **Native binding**: in-tree N-API helper module at `daemon/native/winjob/` (~120 LOC C++, single `.node`). Calls `CreateJobObjectW` → `SetInformationJobObject(JobObjectExtendedLimitInformation, { BasicLimitInformation: { LimitFlags: JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE | JOB_OBJECT_LIMIT_BREAKAWAY_OK } })` → `AssignProcessToJobObject(job, child.pid)`. Exposes `winjob.create(): handle` and `winjob.assign(handle, pid): void`.
+- **Built artifact name (P0 packaging contract)**: build emits **exactly** `daemon/native/<platform>-<arch>/ccsm_native.node` (single .node carrying the `winjob` + `pdeathsig` + `pipeAcl` exports — see §3.5.1.1.a swap interface; **see frag-11 §11.4 for build wiring** — `binding.gyp`, `node-gyp rebuild`, codesign loop, `pkg.assets`, before-pack existence check). Per-platform stagings are:
+  - `daemon/native/win32-x64/ccsm_native.node`
+  - `daemon/native/linux-x64/ccsm_native.node` (PR_SET_PDEATHSIG branch; winjob exports throw `ENOSYS`)
+  - `daemon/native/darwin-arm64/ccsm_native.node` (no-op stub branch; winjob/pdeathsig exports throw `ENOSYS`)
+  Frag-11 §11.1 / §11.2 MUST list **`ccsm_native.node`** explicitly in `pkg.assets`, in `before-pack.cjs` existence check, in `rebuild-native-for-node.cjs` (which must `node-gyp rebuild` inside `daemon/native/winjob/`), and in the per-`.node` codesign/signtool loop. The artifact name `ccsm_native.node` is the canonical contract referenced by frag-11 — do not rename without coordinated frag-11 amendment.
+- **Why in-tree, not npm**: surveyed candidates — `windows-process-tree` (read-only, no JobObject), `node-windows` (service-mgmt focus), `winapi-bindings` (unmaintained 2019). Closest match `node-job-object` is single-author, last release 2017, no prebuilt binaries. Rolling our own is ~120 LOC, zero transitive deps, reuses the same `node-gyp` toolchain already required by `better-sqlite3` and `node-pty`. Same precedent as the §7.M1 named-pipe ACL helper (frag-6-7 §6.4). **One native helper module (`ccsm_native.node`), three features (winjob, pdeathsig, pipeAcl).**
+- **Lifetime**: `winjob.create()` is called once at daemon boot. The handle is held in a module-level `let jobHandle` inside `daemon/src/pty/winjob.ts`. Every `ptyService.spawn()` calls `winjob.assign(jobHandle, child.pid)` immediately after `node-pty` returns. Handle is never closed during normal operation; OS closes it when the daemon process exits, which is the trigger for `KILL_ON_JOB_CLOSE`.
+- **Breakaway**: `JOB_OBJECT_LIMIT_BREAKAWAY_OK` is set so that a child CLI process can spawn its own grandchildren outside the job if it explicitly requests breakaway (`CREATE_BREAKAWAY_FROM_JOB`). No grandchild created by the `claude` CLI today does this; flag is defensive.
+- **Nested-job edge case (Win 8+)**: nested jobs are allowed since Win8, so if Electron itself is in a job (rare; only when launched via `runas` or some MDM tooling), the daemon's job becomes a nested child and `KILL_ON_JOB_CLOSE` still cascades. Verified semantics, no special handling needed.
+
+### 3.5.1.1.a Native binding swap interface (lockin-P0-2)
+
+All call sites go through a TypeScript interface, never the raw `.node` exports:
+
+```ts
+// daemon/src/native/index.ts — single import seat for every native call
+export interface NativeBinding {
+  winjob: { create(): JobHandle; assign(h: JobHandle, pid: number): void };
+  pdeathsig: { armSelf(signal: number): void };  // POSIX/Linux only; throws ENOSYS elsewhere
+  pipeAcl: { applyOwnerOnly(pipeName: string): void };  // Win only; ENOSYS elsewhere — used by frag-6-7 §7.M1
+}
+
+export const native: NativeBinding = loadBinding();  // dispatches by process.platform; resolves ccsm_native.node
+```
+
+- Implementations live in `daemon/src/native/impl/napi.ts` (default — wraps `ccsm_native.node`) and a future `daemon/src/native/impl/koffi.ts` (deferred). Swap is a single-file edit in `daemon/src/native/index.ts`'s `loadBinding()`.
+- **No call site in `daemon/src/pty/**` or `daemon/src/socket/**` may import `ccsm_native.node` directly.** Lint rule `no-direct-native-import` (custom ESLint rule, +0.5h Task 11) flags any `require('../native/ccsm_native.node')` or equivalent outside `daemon/src/native/impl/`.
+- **Vendor-risk acknowledgement**: the in-tree binding has a single maintainer (us). Recompile cost per Node major bump ≈ 2h (rebuild + CI matrix verify); swap-to-`koffi` cost if the in-tree path is abandoned ≈ 8h (re-implement three ops behind the same interface). Frag-7 supply-chain table MUST carry this row.
+- **Decision deferred to v0.3 dispatch**: confirm `koffi` posture before Task 11 dispatch (still active 2026-04-30? prebuilt binaries for win32-x64/linux-x64/darwin-arm64?). If `koffi` clears the bar the in-tree N-API path can be skipped entirely; the `NativeBinding` interface keeps either choice cheap.
+
+### 3.5.1.2 POSIX process group + SIGCHLD wiring (data layer)
+
+Per §6.2, each `pty.spawn()` calls `setpgid(0, 0)` in the child (via node-pty's `cwd`/env wrapper is insufficient — we need a `posix_spawnp` attribute or a manual `setpgid` call right after spawn from the parent). Implementation:
+
+- **`setpgid` source**: node-pty already calls `setsid()` in its forkpty path on POSIX, which makes the child a session leader and a pgroup leader (pgid == child pid). No additional `setpgid` call needed; verified by reading `node-pty/src/unix/pty.cc`. We rely on `setsid()` and record `pgid = child.pid` in `ptyService` state.
+- **Linux PDEATHSIG**: in addition, daemon sets `PR_SET_PDEATHSIG = SIGTERM` via `native.pdeathsig.armSelf(SIGTERM)` from inside the child between `fork` and `execve` (delivered through node-pty's spawn hook). On daemon death, the kernel signals each PTY child with SIGTERM. Followed up by group-SIGKILL on next supervisor cycle if any child survives the grace period.
+- **macOS parent-watch**: no PDEATHSIG analogue. Use kqueue with `EVFILT_PROC | NOTE_EXIT` registered on `getppid()` from a small thread inside the in-tree helper, OR — simpler and chosen for v0.3 — rely on the supervisor (frag-6-7 §6.1) detecting daemon exit and `kill(-pgid, SIGKILL)` for every recorded pgid as part of cold-restart cleanup. macOS dogfood is not yet a v0.3 ship target (per project memory: Win 11 25H2 is the lock); macOS path documented but not blocking.
+- **SIGCHLD handler (graceful path) — per-PID scope (rel-P1-R5)**: daemon installs `process.on('SIGCHLD', reapZombies)` once at boot, BEFORE the first `pty.spawn()`. `reapZombies` iterates over the `pid → sessionId` map and calls `waitpid(pid, WNOHANG)` per known PID — **NOT** `waitpid(-1, WNOHANG)`. Per-PID scope avoids stealing reaps from any future transitive dep that spawns its own child (logger, telemetry) and expects to reap it itself. For each successfully reaped pid, looks up the session and emits `ptyExit({ sessionId, exitCode, signal, traceId: session.spawnTraceId })` on the session's fan-out. This is the *only* path that produces `ptyExit` events on POSIX; node-pty's own `onExit` is replaced with a no-op JS shim to avoid double-reaping (the two would race and one always loses the exit code). Worker MUST grep node-pty's source to confirm the `onExit` JS shim does not break internal cleanup; if it does, contract becomes "both fire, daemon dedupes by `(pid, exitCode)`".
+- **Daemon shutdown sequence (rel-P0-R3 + obs-P0-3 — REPLACES old "deregister-then-shutdown" path)**: the prior text was wrong — deregistering SIGCHLD before group-SIGTERM lost exit codes for children dying in the window between deregister and the explicit waitpid loop. New ordered sequence, owned by `daemonShutdown` RPC (Task 21):
+
+  1. `daemonState = 'draining'`. Reject new `pty.spawn()` and new `ptySubscribe` calls with `RESOURCE_EXHAUSTED { reason: 'daemon-shutdown' }`.
+  2. Inside one DB transaction: `UPDATE sessions SET state = 'shutting_down' WHERE state = 'running'`. This makes the on-disk truth match the in-flight intent BEFORE any signals fly.
+  3. Cancel the **shared heartbeat scheduler** (§3.5.1.4) and clear all per-stream `lastWriteAt` entries. No new heartbeat envelopes after this point.
+  4. Iterate the fan-out registry once: close each subscriber stream with `RESOURCE_EXHAUSTED { reason: 'daemon-shutdown' }`. Aggregate to **one** structured log line `subscribers_closed_on_shutdown { count, droppedBytes_total }` — not N drop lines (obs-P0-3).
+  5. Drain the per-stream replay-budget counter to ensure no replay write is mid-flight; queued snapshot semaphore waiters are rejected with `CANCELLED` (one log line, count aggregated).
+  6. SIGCHLD handler is **left registered**. Issue group-SIGTERM to each recorded pgid. SIGCHLD continues to deliver `ptyExit` events normally; sessions whose children exit cleanly are marked `state = 'exited'` with their actual `exitCode`.
+  7. Per-child wait cap: 200 ms (tightened from 500 ms per perf-vibes-table feedback — typical PTY child SIGTERM-to-exit is sub-10 ms; 200 ms × 20 sessions = 4 s worst-case shutdown, vs 10 s with 500 ms). After the cap, SIGKILL the surviving pgroups.
+  8. Final waitpid sweep with WNOHANG. Survivors past the SIGKILL deadline (kernel-zombie or unresponsive) are marked `state = 'paused'` in one final DB transaction (see frag-6-7 §6.3 — canonical state name is `paused`, NOT `abandoned`; the term changed because next-boot recovery treats them as resumable, not orphaned). This row state is what frag-6-7 §6.3 next-boot detection reads. **The transition MUST be `UPDATE sessions SET state='paused', pid_pgid=NULL WHERE state='shutting_down'`** `[manager r7 lock: r6 reliability P1-R4 mirror — explicit WHERE state='shutting_down' clause mirrors frag-6-7 §6.6.1 step 4. Without the WHERE guard, a child that clean-exits between the 200 ms cap and the SIGKILL deadline could land BOTH 'exited' (from the SIGCHLD handler step 6 above) AND 'paused' (from this sweep); the WHERE guard makes the sweep idempotent and order-independent against the SIGCHLD-clean-exit vs SIGKILL-deadline race.]` On respawn, `pid` and `pgid` columns MUST be cleared (set NULL) atomically with the state transition so stale OS identifiers from the dead daemon never get re-signalled (this is the same `pid_pgid=NULL` clause shown above).
+  9. `PRAGMA wal_checkpoint(TRUNCATE)`; `db.close()`. (Frag-6-7 §6.6 should restate this from the DB side — coordinate.)
+  10. `pino.final` flush (frag-6-7 §6.6). Now `process.exit(0)`.
+
+  This sequence guarantees: (a) no on-disk row ever lies (every `running` row transitions through `shutting_down → exited|paused`); (b) the SIGCHLD handler is never deregistered prematurely, so exit codes are not lost; (c) drain ordering prevents the last 60 s of heartbeat/drop forensics from being randomly truncated.
+
+- **Win parity**: Windows has no SIGCHLD. PTY exit is observed via node-pty's `onExit` (which polls `GetExitCodeProcess`) and is unchanged from v0.2. JobObject covers crash-cleanup; `onExit` covers normal exit reporting. The shutdown sequence above runs identically except step 6 issues `TerminateJobObject(jobHandle)` instead of group-SIGTERM, and the 200 ms / SIGKILL escalation becomes `TerminateProcess` per child.
+
+- **Spawn traceId for daemon-originated events (obs OPEN q3)**: every successful `pty.spawn()` allocates `spawnTraceId = ulid()` and stores it on the session row. All daemon-originated PTY events (`ptyExit`, `subscriber-dropped-slow`, `pty.spawn.failed`) carry this traceId so spawn → exit log lines correlate without an upstream RPC traceId.
+
+### 3.5.1.3 Bridge call timeout + AbortSignal threading
+
+Every Connect RPC invoked by Electron's bridge layer (`electron/preload/bridges/*` → `daemonClient`) is wrapped in a deadline. Default and threading rules:
+
+- **Default deadline: 5s for unary RPCs.** Tighter than rel-M2's 30s suggestion. Rationale: 5s is well above local-pipe p99 (Task 7 acceptance benchmark targets p95 < 5ms) and well below the perceived-hang threshold for an interactive UI. 30s is a *supervisor* timeout (frag-6-7 §6.1, three 5s heartbeat misses); a *bridge* timeout that high would let the user wait 30s on every dead-daemon click.
+- **Per-call override**: `daemonClient.call(method, req, { timeoutMs: number, signal: AbortSignal })`. Long-running RPCs (e.g. `getBufferSnapshot` for a session with full 10k scrollback, see res-SHOULD-2) override to 30s. Override list is centralized in `electron/daemon/timeouts.ts` so reviewer can audit.
+- **Per-call header overrides (fwdcompat-P1-2 reservation)**: caller may also set `headers["x-ccsm-deadline-ms"]` directly on the envelope. v0.3 honors it (clamped to 100 ms ≤ x ≤ 120 s); reserved sibling keys `x-ccsm-heartbeat-ms` and `x-ccsm-backpressure-bytes` are accepted-and-ignored in v0.3 (squat-prevention so v0.5 web client can begin sending them). Reserved-header namespace lives in frag-3.4.1 §3.4.1.c — coordinate.
+- **AbortSignal threading**: caller-supplied `AbortSignal` is OR-merged with the deadline-derived signal via `AbortSignal.any([userSignal, AbortSignal.timeout(timeoutMs)])` (Node 20+). The merged signal is passed to Connect's `CallOptions.signal`. Connect's own implementation translates abort to an HTTP/2 RST_STREAM with `CANCELLED` code, which the daemon-side handler observes via its own `signal.addEventListener('abort', ...)`. Handlers MUST check `signal.aborted` at every `await` boundary inside long ops; lint rule `no-floating-cancellation` (custom ESLint rule, +0.5h Task 5) flags handlers that take `signal` but never read it.
+- **Timeout error surface (devx-CF-3 correction)**: on deadline, client throws `BridgeTimeoutError extends Error` with `{ code: 'DEADLINE_EXCEEDED', method, timeoutMs, traceId }`. **`BridgeTimeoutError` is never user-surfaced; the bridge retries once internally; if still failing, status surfaces via the surface-registry (frag-6-7 §6.8) `'reconnecting'` slot. Caller never sees `DEADLINE_EXCEEDED` directly** — the renderer reads the surface-registry slot and renders unified reconnecting UX, so per-caller retry policy is a non-concern. Supervisor-level `daemon-unhealthy` event (frag-6-7 §6.1) is emitted *in parallel* to a timeout if 3+ consecutive RPCs deadline within 10s — separate signal, separate consumer.
+- **Daemon-side enforcement**: each handler wraps its body in `await Promise.race([handler(req, signal), abortPromise(signal)])`. `abortPromise` resolves on `signal.aborted` and the handler's own promise is left to resolve later (its result is discarded, but the handler is responsible for propagating abort to any sub-RPCs). Runaway handlers (e.g. an SDK call that ignores abort) are NOT killed at the process level in v0.3 — that would require a worker-thread sandbox, deferred to v0.4. v0.3 logs a `handler-leaked-after-abort` warning at 30s post-abort with `{ method, traceId, durationMs }` AND increments counter `handler.leaked.count` (silent log warns rot — surfaceable metric).
+
+### 3.5.1.4 Stream RPC heartbeat + dead-stream detection
+
+`ptySubscribe`, `subscribeNotifications`, and `subscribeSessionUpdates` are server-streaming RPCs. The 5s unary deadline does NOT apply to the stream as a whole; it applies only to *first byte* (stream open). After open:
+
+- **Default heartbeat interval: 30s; default dead-stream detection: 65s** (60s + 5s skew slop). Daemon emits a `{ kind: 'heartbeat', ts, traceId, bootNonce }` envelope on every server-stream every `heartbeatMs` if no real data has been sent in that window. Cheap (~50 bytes). `traceId` carries the subscribe-time traceId so dead-stream logs link back to the originating subscribe call (obs-P0-2). `bootNonce` matches frag-6-7 §6.5 healthz nonce — client uses it to detect daemon respawn (fwdcompat-P1-1).
+- **Negotiable per subscribe (lockin-P1-4 + fwdcompat-P1-2)**: every server-streaming subscribe RPC accepts an optional `{ heartbeatMs?: number }` param (e.g. `ptySubscribe(sessionId, { fromSeq, fromBootNonce?, heartbeatMs? })`). Daemon clamps to `5_000 ≤ heartbeatMs ≤ 120_000` and uses it for that stream's heartbeat cadence. Default 30 s; v0.5 web on flaky 4G can request 10 s. Client's dead-stream window = `2 × heartbeatMs + 5_000` skew. Acceptance: subscribe with `heartbeatMs: 5000` and assert heartbeat envelope cadence within 5 s ± 1 s.
+- **Boot nonce on subscribe (fwdcompat-P1-1)**: client passes `fromBootNonce` (the nonce it last saw on a delta or heartbeat from this daemon). On mismatch, daemon **ignores `fromSeq`**, sends `{ kind: 'bootChanged', bootNonce, snapshotPending: true }`, and follows with a fresh snapshot from seq 0. Client renders a `─── daemon restarted ───` divider analogous to `─── stream gap ───`. This prevents the silent-replay-of-phantom-bytes bug across daemon respawns.
+- **Per-stream subscribe authorization (sec-P0-2 deferral)**: in v0.3, `ptySubscribe` / `subscribeNotifications` / `subscribeSessionUpdates` rely solely on the connection-level shared-secret handshake from frag-6-7 §7.4 (no per-stream token). This is **ACCEPTED** for v0.3 (see frag-6-7 §7.4 — connection-level secret + named-pipe / unix-socket ACL gate at the OS-user boundary; v0.3 ships with a single trusted Electron renderer). v0.5 will add a per-stream subscribe token (capability-style); the subscribe RPC param shape is **owned by §3.5.1** so the v0.5 token field will be added here without breaking the wire format. Cross-ref: frag-3.4.1 §3.4.1.b consumes this subscribe RPC shape; the canonical definition (param names, optional fields, server-side acceptance contract) lives here in §3.5.1.4.
+- **Why default 30s / 2-miss is slacker than supervisor's 5s × 3-miss = 15s (rel-P1-R6)**: stream heartbeat is **intentionally** slacker than supervisor heartbeat so a real daemon death surfaces via supervisor-level `daemon-unhealthy` IPC FIRST. Stream-dead detection is the slow-path catch-all for the rare case of a hung handler that's not crashing the daemon process (handler stuck in a non-abort-honoring SDK call). If the inversion ever flipped (stream-dead < supervisor-dead) the user would see a transient "stream dropped" toast on every supervisor-detected restart, which is noise. Document the inequality `streamDeadMs > supervisorDeadMs` as an invariant.
+- **Shared heartbeat scheduler (perf-P1-C)**: implementation is **one** daemon-wide scheduler tick (e.g. every 1 s) that walks `Map<streamId, { lastWriteAt, heartbeatMs }>` and emits a heartbeat for any stream where `now - lastWriteAt ≥ heartbeatMs`. NOT a per-stream `setInterval`. With 100 sessions × 10 writes/s the per-`setInterval` reset cost was 1000 ops/s on the timer heap; shared scheduler is one tick/s plus a hash-table iteration. Saves ≥ 95 % timer pressure at scale. Shutdown sequence step 3 (§3.5.1.2) cancels this single scheduler.
+- **Server-side dead-client detection**: daemon's writable side detects client gone via socket-level `'error'` / `'close'` events on the underlying Node HTTP/2 stream — same path Connect-Node already uses. No application-layer ping required from client to server in v0.3 (unary RPCs already exercise the channel; if all are silent for 60s the supervisor heartbeat is what surfaces dead-daemon, not dead-client). On a stuck client whose OS socket buffer is full, the daemon's heartbeat write itself returns `writable === false` and trips drop-slowest (§3.5.1.5) — meaning the **actual** dead-client mechanism is heartbeat-write-failure, not the 65 s client-side timeout (which is fallback for "stuck reader, healthy network"). Server-side stream-dead detector spec'd in frag-6-7 §6.5.1 (`2 × heartbeatMs + 5 s` symmetric, no-op on v0.3 local pipe, byte-compatible with v0.5 CF Tunnel TCP). `[manager r7 lock: r6 reliability P0-R2 cross-frag handoff — symmetric server-side detector at 2 × heartbeatMs + 5 s lives in frag-6-7 §6.5.1; covers the v0.5 half-open TCP case where heartbeat-write-failure may not fire for hours.]`
+- **Snapshot RPC is unary, not stream**: `getBufferSnapshot` returns a single (large) message, not a stream. Subject to unary timeout override (30s, see §3.5.1.3). The chunked-yield in `lifecycle.ts:151` is internal to the handler and does not produce stream frames.
+
+### 3.5.1.5 Subscriber fan-out (multi-subscriber semantics)
+
+Closes res-MUST-2. The daemon MUST NOT keep per-subscriber backlog. Spec contract:
+
+- **Single fan-out registry per session**: lifted directly from existing `electron/ptyHost/dataFanout.ts`. Each `ptySubscribe` call registers a callback on the session's `Set<Subscriber>`; PTY data hits each callback synchronously in registration order, wrapped in try/catch so one slow subscriber cannot poison others.
+- **Per-subscriber state == OS socket send buffer only.** ~64 KB on Win named pipes, ~256 KB default on POSIX unix sockets. No application-layer queue per subscriber.
+- **Shared framed buffer per chunk (perf-P0-B)**: for each PTY chunk, the daemon **frames once** (constructs the binary envelope `[totalLen][headerLen][headerJSON][payloadBytes]` exactly once; cached header skeleton patches only the `seq` and `payloadLen` bytes per perf-P0-A) and calls `socket.write(sharedBuffer)` per subscriber. Per-subscriber stringify is forbidden — re-stringifying the same header N times for N subscribers is what perf-P0-B was flagging. Frag-3.4.1 §3.4.1.c is the canonical owner of the framed-buffer construction; this section just enforces "build once, write N times". Coordinate with §3.4.1 — the cached-header skeleton lives there, the fan-out call site here MUST consume it.
+- **Microtask yield between subscribers**: with N ≥ 4 subscribers, the synchronous fan-out loop yields via `queueMicrotask` after each subscriber's write to avoid blocking the daemon event loop for the duration of all N writes (relevant when N reaches v0.5's web fan-out scale; v0.3 N = 1 so this is no-op). Documented seam, not v0.3 hot path.
+- **Backpressure ≤ 1 MB / drop-slowest**: each subscriber callback writes synchronously to its Connect server-stream. If the underlying socket reports `writable === false` (Node Stream high-water-mark hit), the subscriber's writes accumulate in *Connect's own* per-stream buffer up to 1 MB. Past 1 MB, the subscriber is flagged `slow`, removed from the registry, its stream closed with `RESOURCE_EXHAUSTED`, and a `subscriber-dropped-slow` log line is emitted with `{ sessionId, subscriberId, droppedBytes, ageMs, traceId, spawnTraceId }` (obs-P0-2: traceId on the drop log). Client receives the close, treats it as a transient drop, and re-subscribes via `ptySubscribe(sessionId, { fromSeq: lastSeenSeq, fromBootNonce })` — same resume contract as §3.5.
+- **Aggregate per-session subscriber cap (res-P1-4)**: independent of per-subscriber 1 MB watermark, the **total** transient buffer across all subscribers on one session is capped at `min(N_subscribers × 1 MB, 4 MB)`. When the aggregate cap hits, the **oldest-slowest** subscriber is dropped first (LRU on `last-successful-write-ts`). Rationale: at v0.5 fan-out (10 slow web subscribers) this prevents 10 × 1 MB = 10 MB transient per session × 20 sessions = 200 MB unbounded growth. v0.3 ships with N = 1 so the cap never trips; the seam is reserved so v0.5 doesn't need to re-open §3.5.1.
+- **Replay budget on reconnect (res-P0-1) — orthogonal to 1 MB watermark**: when a subscriber re-subscribes with `fromSeq`, the replay payload is **bounded at 256 KB**. If the headless ring contains more than 256 KB beyond `fromSeq`, daemon ships the most recent 256 KB and sets `gap: true` on the first replay envelope. **Clarification (perf-CF-2)**: the 256 KB ceiling is a *per-replay message hard limit* (one-shot, payload size at the moment of resubscribe); the 1 MB drop-slowest watermark is a *per-second steady-state flow rate cap* on the per-subscriber Connect buffer. They measure different things and operate on different time scales — neither subsumes the other. The replay payload is delivered as **one initial write that does NOT count against the slow-subscriber accounting** (the 1 MB drop-slowest watermark is measured AFTER the replay burst is delivered — replay-burst exemption). Without this exemption, a nodemon dev save-storm with 5 sessions producing 100 KB/s could exceed 1 MB on the first post-reconnect frame, drop the stream as slow, re-resubscribe, loop. Frag-3.7 §3.7.5 must reference this clamp (cross-frag coordination).
+- **Why drop-slowest, not block-everyone**: blocking the fan-out on the slowest subscriber (Cloudflare Tunnel client on flaky WiFi, v0.5) would stall the desktop subscriber on the same machine. Drop-slowest preserves the desktop UX at the cost of forcing the slow client to resume from `fromSeq`, which is cheap (the seq replay in §3.5 is exactly what makes this safe).
+- **Fairness vs starvation**: drop-slowest is fair within a session but cannot starve a session entirely as long as at least one subscriber is healthy (the data is *sent* on every subscribe; only writes to slow subscribers are dropped). If all subscribers are slow, the fan-out callback returns immediately on each (writes are buffered in OS socket queues that already overflowed), PTY input continues to fill xterm-headless buffer, and seq advances normally. New `ptySubscribe(fromSeq)` later replays from the headless buffer.
+- **Bounded snapshot concurrency**: per res-SHOULD-2, daemon enforces a semaphore of 4 concurrent `getBufferSnapshot` invocations (any session, any caller). Excess wait. Prevents N × MB transient-string allocation when a v0.5 dashboard subscribes to all sessions on cold open.
+- **Snapshot deadline starts after admission (res-P1-3)**: the per-call 30 s unary override deadline (§3.5.1.3) for `getBufferSnapshot` starts AFTER the semaphore admits the call, NOT at handler entry. A separate counter `snapshot.semaphore.waitMs` is logged on admission so the user-perceived hang on a v0.5 dashboard cold-open shows up as semaphore wait (not handler runtime). Bridge client surfaces semaphore-wait phase via a structured `{ phase: 'queued', queuedMs }` event so the renderer can show "queued" UI rather than "loading".
+- **xterm-headless backpressure to node-pty (perf-P1-B)**: when the headless ring's pending-write queue exceeds 500 entries, daemon calls `pty.pause()` on the underlying node-pty handle; resumes when pending falls below 100. This is the only thing that prevents unbounded RSS growth on a noisy session with all-slow subscribers (drop-slowest at 1 MB caps Connect-side buffer but not the headless ring itself). **This item is non-optional** (perf-P1-B explicitly removes the prior "lands unless time-boxed out" qualifier — it is a P0 reliability item dressed as perf SHOULD).
+
+### 3.5.1.6 Acceptance criteria (data-layer, complement to §6.2 supervisor-layer)
+
+- Unit: `winjob.create()` + `winjob.assign(job, fakePid)` round-trip; `assign` of dead pid throws `EINVAL`. Native binding accessed only through `daemon/src/native/index.ts`; lint `no-direct-native-import` passes on full daemon tree.
+- Unit: SIGCHLD handler reaps a synthetic forked child within 50ms via `waitpid(pid, WNOHANG)` (per-PID, not `waitpid(-1)`) and emits exactly one `ptyExit` event with `spawnTraceId` populated; second `waitpid` for an unrelated pid returns 0 (no double-reap).
+- Unit: shutdown sequence on a daemon with 3 running PTY sessions transitions DB rows `running → shutting_down → exited` in order; SIGCHLD remains registered throughout; no exit codes lost.
+- Unit: `daemonClient.call('echo', {}, { timeoutMs: 50 })` against a handler that `await new Promise(()=>{})` rejects with `BridgeTimeoutError` after 50ms ± 10ms; merged AbortSignal fires; counter `handler.leaked.count` increments after 30 s.
+- Unit: subscribe with `{ heartbeatMs: 5000 }` observes heartbeat cadence 5 s ± 1 s; subscribe without override observes 30 s.
+- Unit: `subscribePty` with a synthetic slow subscriber (writes block) is dropped after exactly 1 MB of buffered output; healthy second subscriber receives every byte; aggregate cap with N=5 slow subscribers drops oldest-slowest first.
+- Unit: re-subscribe with `fromSeq` past the 256 KB clamp receives `gap: true` and last 256 KB only; fan-out drop-slowest accounting starts AFTER the replay write.
+- Unit: re-subscribe with mismatched `fromBootNonce` receives `bootChanged: true` and snapshot from seq 0.
+- Unit: header skeleton is constructed once per chunk in fan-out path; perf assertion = `JSON.stringify` call count per chunk = 1 regardless of subscriber count.
+- Integration: 30s heartbeat observed on idle stream; client closes after 65s of silence with synthetic broken socket; aggregated `subscribers_closed_on_shutdown` log line emitted exactly once on `daemonShutdown`.
+- E2E reverse-verify (cross-ref §6.2 acceptance): kill daemon mid-stream → no orphan `claude.exe`; client receives stream close with RESOURCE_EXHAUSTED or transport error; on respawn + resubscribe, replay from `fromSeq` (with `bootChanged: true` since nonce flipped) resumes.
+
+---
+
+## Plan delta
+
+Specific edits to `docs/superpowers/plans/2026-04-30-v0.3-daemon-split.md`. Several lines OVERLAP with frag-6-7's plan delta — those overlaps are *the same lines*, not duplicate hours. Final hour totals must be reconciled at fragment merge by additive de-dup. **Round-2 reconciliation (res-P1-1)**: this fragment's Task 11 explicitly DROPS the N-API binding hours (already in frag-6-7's +4h Task 11 for "JobObject + setpgid + PR_SET_PDEATHSIG") and keeps only data-layer wire-up.
+
+- **Task 1** (daemon workspace skeleton, +1h NEW vs frag-6-7): scaffold `daemon/native/` directory with `binding.gyp` skeleton emitting `ccsm_native.node` and `daemon/src/native/index.ts` exporting the `NativeBinding` interface (§3.5.1.1.a). `node-gyp rebuild` runs in CI on all three platforms; placeholder native fns return `0`.
+- **Task 5** (Connect adapter, +3h NEW): bridge-call timeout middleware (5s default), `AbortSignal.any` merge of caller signal + deadline, `BridgeTimeoutError` class, per-method override map, `x-ccsm-deadline-ms` header parsing (clamp 100 ms..120 s), reserved sibling header keys squat-prevention, `handler.leaked.count` counter, custom ESLint rule `no-floating-cancellation`. Reviewer acceptance: every handler in `daemon/src/handlers/` either ignores `signal` (allowlisted, e.g. `healthz`) or has at least one `signal.throwIfAborted()` / `signal.aborted` read.
+- **Task 5** (also, +2h NEW): **shared** stream-heartbeat scheduler — `streamHeartbeatRegistry` with one daemon-wide tick walking `Map<streamId, {lastWriteAt, heartbeatMs}>` (perf-P1-C); `streamWithHeartbeat(stream, opts)` registers/unregisters; honours per-subscribe `heartbeatMs` override (clamped); emits envelope with `traceId + bootNonce` (obs-P0-2 + fwdcompat-P1-1). Client-side dead-stream detector in `electron/daemon/streamClient.ts` reads `heartbeatMs` echoed in the stream-open response so window = `2x + 5s` is consistent.
+- **Task 7** (Electron handshake e2e, +1h NEW): bridge-timeout regression test (kill daemon, assert `BridgeTimeoutError` within 5s ± 100ms); `bootChanged` divider rendered on respawn-resubscribe. Reuses §7.4 imposter-secret negative-test harness.
+- **Task 11** (lift `ptyService` data side, +2h NEW; reduced from prior +5h per res-P1-1; the N-API helper hours live in frag-6-7's Task 11 +4h; this task covers ONLY the data-layer wire-up):
+  - Wire `winjob.assign(jobHandle, child.pid)` into `ptyService.spawn()` Win branch via `native.winjob` (+0.5h).
+  - Replace node-pty's `onExit` with daemon-owned per-PID SIGCHLD handler (`waitpid(pid, WNOHANG)` per known PID); allocate `spawnTraceId` per spawn; emit `ptyExit` with traceId (+1h).
+  - Implement the new shutdown sequence (§3.5.1.2) including DB transactions for `shutting_down → exited|paused` row transitions (canonical state name per round-3 P0/P1 lockin; was `abandoned` in earlier drafts), aggregated drop-line, single-pino-final flush. Cross-coordinate the WAL-checkpoint step with frag-6-7 §6.6 (avoid duplicate close) (+0.5h).
+- **Task 11** (also, +0.5h NEW): native-binding swap interface (§3.5.1.1.a) — `daemon/src/native/index.ts` + lint rule `no-direct-native-import`.
+- **Task 11c** (`ptySubscribe`, +3h NEW; was +2h): apply shared heartbeat scheduler; per-subscriber 1 MB watermark; aggregate per-session cap (`min(N×1MB, 4MB)`) with oldest-slowest LRU; emit `subscriber-dropped-slow` log + counter (`pty.subscriber.dropped`) including `traceId + spawnTraceId`; integration test for drop-slowest + aggregate cap; **shared framed buffer** integration with frag-3.4.1's cached header skeleton (perf-P0-A/B); xterm-headless `pause/resume` at 500/100 thresholds (perf-P1-B, mandatory). Bounded snapshot semaphore (size 4) lives here too with admission-relative deadline timing + `snapshot.semaphore.waitMs` counter; replay-budget clamp (256 KB) with `gap: true` flag.
+- **Task 13** (`notifyService` lift, +0.5h NEW): apply shared heartbeat scheduler to `subscribeNotifications` server-stream. `bootNonce` echoed on subscribe response. No other changes (notifications already produce the resume cursor).
+
+**Total estimated delta (this fragment, deduplicated against frag-6-7)**: **+13h** on top of v1 plan (was +14.5h; -3h N-API helper deduped per res-P1-1, +1.5h aggregate cap + shared scheduler + boot-nonce wire-up). Additive to frag-6-7's +44h. Combined v0.3 reliability+security+PTY-data hardening: ~57h on top of the 125h v1 plan → ~182h total. All items blocking for v0.3 dogfood.
+
+### Round-3 plan delta (additive, +1.5h)
+
+- **Task 11** (+0.5h): rename `state='abandoned'` → `state='paused'` everywhere in `daemon/src/pty/lifecycle.ts` and migration `0003_session_state_paused.sql`; clear `pid` and `pgid` columns to NULL atomically with the `paused` transition (single `UPDATE` per surviving session). Cross-coordinate with frag-6-7 §6.3 next-boot recovery query (must read `state='paused'` not `'abandoned'`).
+- **Task 5** (+0.5h): rewire `BridgeTimeoutError` so the renderer is **never** surfaced to it directly — bridge retries once internally; on second failure, set `surfaceRegistry.set('daemon-status', 'reconnecting')` (frag-6-7 §6.8). Renderer reads slot, not exception. Acceptance: renderer code search finds **zero** `catch (e instanceof BridgeTimeoutError)` blocks; only the bridge layer touches it.
+- **Task 11c** (+0.5h): add explicit unit test for replay-burst exemption (256 KB replay write does NOT trip 1 MB drop-slowest watermark; subsequent steady-state writes accumulate normally and DO trip at 1 MB). Document the orthogonality in code comment at the slow-subscriber accounting site.
+
+**Round-3 cumulative**: +14.5h (was +13h). Frag-6-7 +44h unchanged.
+
+## Open questions
+
+1. **N-API helper or `koffi` FFI?** Picked N-API (~120 LOC C++) for compile-time symbol guarantees and zero runtime overhead. `koffi` would skip the C++ build but adds a runtime dep + per-call FFI cost. The `NativeBinding` swap interface (§3.5.1.1.a) makes this swappable in v0.4 with a single-file edit, so the v0.3 decision is recoverable. Manager decision: confirm `koffi` posture (active maintenance + prebuilts for win32-x64/linux-x64/darwin-arm64?) before Task 11 dispatch.
+2. **macOS parent-watch deferral**: chosen approach is "rely on supervisor pgid-SIGKILL on cold-restart" rather than per-child kqueue watcher. Acceptable because Win 11 25H2 is the v0.3 lock per project memory. Confirm macOS is not a v0.3 ship target before merging this section.
+3. **SIGCHLD vs node-pty `onExit` ownership**: spec says daemon owns SIGCHLD and replaces node-pty's POSIX `onExit`. Worker should grep `node-pty` to confirm `onExit` can be safely no-op'd from JS-land; if it cannot (e.g. node-pty depends on `onExit` to free internal state), the contract becomes "both fire, daemon dedupes by pid+exitCode". Verify in Task 11.
+
+---
+
+## Cross-frag rationale
+
+This section records decisions where a round-2 P0/P1 spans multiple fragments. For each, note who owns the canonical contract and what we punted vs took.
+
+### Taken into §3.5.1 (this fragment owns)
+
+| Item | Source review | Rationale for landing here |
+|---|---|---|
+| SIGCHLD shutdown ordering + DB row transitions | rel-P0-R3 | Lifecycle of PTY children is §3.5.1's territory; the DB-side WAL checkpoint cross-references frag-6-7 §6.6 but the ordering bug was in §3.5.1's prior text, so the fix lives here. |
+| Drain-before-quench for stream/heartbeat/fanout | obs-P0-3 | Producers (heartbeat scheduler, fan-out registry) are §3.5.1 owned. `pino.final` invocation point remains in frag-6-7 §6.6; we just specify "this happens AFTER our drain". |
+| Per-PID `waitpid(pid, WNOHANG)` scope | rel-P1-R5 | Pure §3.5.1 SIGCHLD detail. |
+| Heartbeat-vs-supervisor inversion explained | rel-P1-R6 | One-paragraph rationale added inline; supervisor numbers stay in frag-6-7. |
+| Negotiable heartbeat per subscribe | lockin-P1-4 + fwdcompat-P1-2 | Subscribe RPC shape is §3.5.1's. Reserved-header keys for the other tunables (`x-ccsm-deadline-ms`, `x-ccsm-backpressure-bytes`) noted here but namespace ownership stays in frag-3.4.1. |
+| `bootNonce` on subscribe + `bootChanged` divider | fwdcompat-P1-1 | Subscribe RPC + heartbeat envelope are §3.5.1's. The `bootNonce` value source is frag-6-7 §6.5 healthz — coordinate. |
+| `spawnTraceId` for daemon-originated PTY events | obs OPEN q3 | PTY spawn is §3.5.1 owned. Bridge-side renderer logger plumbing stays in frag-6-7 §6.6 P0-1 amendment. |
+| Aggregate per-session subscriber cap (`min(N×1MB, 4MB)`) | res-P1-4 | Pure fan-out registry detail; v0.3 inert, v0.5 active. |
+| Replay budget 256 KB on resubscribe | res-P0-1 | Resubscribe semantics live here; frag-3.7 §3.7.5 references this clamp from the dev-workflow side. |
+| Snapshot semaphore admission-relative deadline | res-P1-3 | Pure §3.5.1.5 detail. |
+| Shared heartbeat scheduler (perf-P1-C) | perf-P1-C | Heartbeat infrastructure is §3.5.1.4 owned. |
+| xterm-headless `pause/resume` non-optional | perf-P1-B | Backpressure path lives at the §3.5.1.5 fan-out / headless-ring boundary. The "unless time-boxed out" qualifier is removed. |
+| Built artifact name `ccsm_native.node` (canonical contract for frag-11) | pkg-P0-2 | Frag-11 needs to reference an exact file name; we own the source dir, so we declare the artifact name here. **See frag-11 §11.4 for build wiring** (pkg.assets, before-pack existence check, codesign loop) keyed on `ccsm_native.node`. |
+| `state='paused'` rename (was `'abandoned'`) + `pid/pgid` clearing on respawn (round-3 P0/P1) | r3-lockin / r3-reliability | DB row state name aligned to frag-6-7 §6.3 canonical (`paused`, resumable). Stale OS identifiers (`pid`, `pgid`) cleared atomically with the state transition so the new daemon never re-signals dead PIDs. |
+| `BridgeTimeoutError` never user-surfaced; status via surface-registry slot (round-3 devx CF-3) | r3-devx | Replaces "renderer-side caller decides retry policy". Bridge retries once, then surface-registry frag-6-7 §6.8 `'reconnecting'` slot owns the user-visible status. |
+| `x-ccsm-deadline-ms` clamp upper bound 120 s (was 60 s in early drafts) | r3-fwdcompat | Matches snapshot 30 s + future v0.5 large-payload use case headroom. |
+| 256 KB replay clamp vs 1 MB watermark orthogonality (round-3 perf CF-2) | r3-perf | 256 KB = per-replay message hard limit (one-shot, payload size); 1 MB = per-second flow rate cap on Connect buffer. Replay-burst is exempt from drop-slowest accounting. |
+| `NativeBinding` swap interface | lockin-P0-2 | The interface lives next to the binding (`daemon/src/native/index.ts`); §3.5.1.1.a defines the TypeScript shape and the lint rule. |
+| Shared framed buffer per chunk (build once, write N times) | perf-P0-B | Fan-out call site is §3.5.1.5; the framed-buffer construction itself (cached header skeleton, `socket.cork/uncork`) is owned by frag-3.4.1 §3.4.1.c. We enforce "consume the cached buffer", they own "build it correctly". |
+
+### Punted to other fragments
+
+| Item | Source review | Target frag + ask |
+|---|---|---|
+| Cached header skeleton + `socket.cork/uncork` per chunk | perf-P0-A | **frag-3.4.1 §3.4.1.c** — owns binary frame construction. We enforce one-build-many-write at the fan-out call site; they own the byte-level skeleton + cork/uncork. Coordinate at merge. |
+| `traceId` field added to binary frame header schema | obs-P0-2 (cross-cut) | **frag-3.4.1 §3.4.1.c** — owns header JSON schema. Our `subscriber-dropped-slow` log carries traceId via the in-process subscribe context; the on-wire field for binary frames must be added in frag-3.4.1. |
+| `protocolVersion` / `daemon.hello` handshake | fwdcompat-P0-2 | **frag-3.4.1 §3.4.1.g (new) + frag-6-7 §6.5** — pure handshake contract, not §3.5.1's territory. We rely on `bootNonce` from the same handshake and reference it. |
+| Interceptor + `headers` map shape | fwdcompat-P0-1 | **frag-3.4.1 §3.4.1.f (new)** — adapter signature is frag-3.4.1's. Our handler signatures take `signal` and read `headers["x-ccsm-deadline-ms"]` from `ReqCtx`. |
+| `ccsm.v1/...` namespace evolution rule | fwdcompat-P0-3 | **frag-3.4.1** — RPC naming convention. |
+| Renderer-side logger module + `pino.final` analog on Electron-main | obs-P0-1 + obs-P0-4 | **frag-6-7 §6.6.1 (new)** — Electron-side concern. Our spawn/exit lines emit traceIds; renderer correlation lives there. |
+| `daemon.crashLoop` structured log signature | obs-P1-1 | **frag-6-7 §6.1 / §6.6** — supervisor concern. (i18n / log-event key is canonical camelCase per cross-frag alignment.) |
+| Migration phase log lines + `MigrationFailedEvent.markerSchemaVersion` | obs-P1-2 + fwdcompat-P1-3 | **frag-8** — migration territory. |
+| Reconnect/queue/resubscribe canonical log set | obs-P1-3 | **frag-3.7 §3.7.4 / §3.7.5** — dev-workflow / reconnect territory. We just emit `subscriber-dropped-slow` from the daemon side; the renderer-side enumeration belongs there. |
+| `daemonStats` → `statsVersion: 1` | obs-P1-4 | **frag-6-7 §6.5** — stats RPC owner. |
+| `crash-dump file` spec or drop | obs-P1-5 | **frag-6-7 §6.6** — owner. |
+| Dev-mode supervisor backoff during nodemon restart window | rel-P0-R1 | **frag-6-7 §6.1 + frag-3.7 §3.7.x** — supervisor + dev concern. Not §3.5.1. |
+| Crash-loop counter reset after rollback | rel-P0-R2 | **frag-6-7 §6.1 + §6.4** — supervisor + updater. Not §3.5.1. |
+| Migration partial-write recovery | rel-P0-R4 | **frag-8 §8.3** — migration. Not §3.5.1. |
+| Snapshot semaphore vs supervisor heartbeat starvation (separate transport for `/healthz`) | rel-P0-R5 | **frag-6-7 §6.5** — supervisor heartbeat owner. We just clarify §3.5.1.4 server-side is the dead-client mechanism, not the priority-queue. |
+| Migration-RPC short-circuit excludes `/healthz` | rel-P1-R3 | **frag-8 §8.6 + frag-6-7 §6.5**. |
+| `proper-lockfile` swap, pino-roll factory wrapper | lockin-P1-1 + P1-2 | **frag-6-7 §6.4 / §6.6**. |
+| Reconnect queue cap + scheduling configurable | lockin-P1-3 | **frag-3.7 §3.7.4**. |
+| `@yao-pkg/pkg` Node target single-source | lockin-P1-5 | **frag-11 §11.1**. |
+| Reconnect queue + 1 MB cap interaction (replay clamp side) | res-P0-1 (frag-3.7 side) | **frag-3.7 §3.7.5** must reference our 256 KB clamp. We've added it here; frag-3.7 amendment cross-links. |
+| Log-rotation aggregate budget | res-P1-2 | **frag-6-7 §6.6**. |
+| `~/.ccsm/` total disk cap + migration corrupt-backup cap | res-P1-6 | **frag-8 + frag-6-7 §6.6**. |
+| Idle daemon→client bandwidth budget summary line | res-P1-5 | **frag-12 traceability** or **frag-6-7 §6.5**. |
+| NSIS uninstall ghost + `ccsm_native.node` packaging wiring | pkg-P0-1 + pkg-P0-2 (packaging side) | **frag-11 §11.1 / §11.2 / §11.3** — we provide the canonical artifact name (`ccsm_native.node`) and per-platform staging dirs; frag-11 owns pkg.assets, before-pack existence check, per-`.node` codesign/signtool loop, and reproducible-build / uninstall hooks. |
+
+<!-- END frag-3.5.1-pty-hardening.md -->
+
+---
+
+<!-- BEGIN frag-3.7-dev-workflow.md -->
+
+# Fragment: §3.7 Dev workflow (hot-reload + auto-reconnect)
+
+**Owner**: worker dispatched per Task #938 (round-3 fixes by §3.7 round-3 fixer).
+**Target spec section**: new §3.7 in main spec (after §3.6).
+**P0 items addressed**: #13 (dev hot-reload + auto-reconnect).
+**Round-1 review source**: `~/spike-reports/v03-review-devx.md` MUST-FIX 1, 2, 4 + OPEN q1.
+**Round-2 review sources** (P0/P1 folded in): `~/spike-reports/v03-r2-devx.md`
+P0-1/P0-2/P0-3/P0-4/P0-5 + P1-3/P1-6/P1-7; `~/spike-reports/v03-r2-reliability.md`
+P0-R1 + P1-R1; `~/spike-reports/v03-r2-resource.md` P0-1; `~/spike-reports/v03-r2-ux.md`
+P0-UX-1 + P0-UX-2 + P1-UX-1 + P1-UX-4 + P1-UX-6.
+**Round-3 review sources**: `~/spike-reports/v03-r3-ux.md` P0-UX-A (surface
+registry duplicate) + CC-1 (close-to-tray key drift) + CC-3 (i18n casing) +
+CC-4 (BridgeTimeout three statements); `~/spike-reports/v03-r3-resource.md`
+X2 (pino-roll symlink) + X4 (close_to_tray key drift);
+`~/spike-reports/v03-r3-fwdcompat.md` cross-frag #2 (`bootNonce` camelCase
+lock); `~/spike-reports/v03-r3-observability.md` P1-2 (reconnect canonical
+log names cross-ref); `~/spike-reports/v03-r3-reliability.md` CF-3
+(supervisor-disabled-in-dev clarification); `~/spike-reports/v03-r3-devx.md`
+P1-1/P1-2/P1-3/P1-4/P1-5 (tray Quit semantics, in-flight chunks, npm rebuild
+syntax, Win Get-Content caveat, e2e pkill target).
+
+**Round-3 manager arch decisions (LOCKED)**:
+1. Surface registry CANONICAL = frag-6-7 §6.8 (numeric priority, single
+   `daemonHealth` IPC, single `useDaemonHealthBridge` hook). §3.7.8 in this
+   fragment is **DELETED** and replaced with a one-paragraph cross-ref.
+2. close-to-tray SQLite key = `close_to_tray_shown_at` (timestamp), owned by
+   frag-6-7 §6.8. §3.7.8.b (which had been claiming `close_to_tray_hint_shown`
+   boolean) is collapsed into the §3.7.8 deletion.
+3. Per-user install (`%LOCALAPPDATA%\ccsm\`) + OS-native data root
+   (`%APPDATA%\ccsm\` on Win, `~/Library/Application Support/ccsm/` on macOS,
+   `~/.config/ccsm/` on Linux). The `daemon.lock` resolution in §3.7.2's
+   `wait-on file:` snippet uses the OS-native data root, not the install root.
+4. `bootNonce` is camelCase across the bundle (subscribe response, hello
+   reply, healthz payload, stream heartbeat). §3.7.5 reader is fixed below.
+5. i18n keys are dot+camelCase across the bundle (`daemon.crashLoop`,
+   `daemon.unreachable`, `daemon.reconnected`, etc.).
+   [manager r7 lock: r6 ux P0-1 — key spelling aligned to §6.8 canonical
+   set after the r7 row trim. The r5/r6 spellings `daemon.reconnectStuck`
+   and `daemon.reconnectExhausted` are OBSOLETE; reconnect-exhaustion is
+   folded into the single `daemon.unreachable` banner per §6.8 r7 cut.
+   Likewise `tray.closeHint` is OBSOLETE per §6.8 r7 close-to-tray
+   onboarding deletion.]
+6. `BridgeTimeoutError` is NEVER user-surfaced per-call; user-facing
+   surfacing for the spike (3+ in 10s) and reconnect-exhaustion case is
+   absorbed into the canonical surface registry (frag-6-7 §6.8) under
+   the single `daemon.unreachable` banner slot per the §6.8 r7 trim
+   (separate `bridge_timeout_spike` / `reconnect_exhausted` slots are
+   cut; `reconnecting` is log-only at the per-attempt level).
+7. Supervisor in dev (`CCSM_DAEMON_DEV=1`): the supervisor process /
+   restart loop / crash-loop counter is **disabled**, but the renderer's
+   `/healthz` polling continues purely as a status-badge signal. The
+   supervisor transport in the daemon STILL binds in dev (else there is
+   nothing to poll); only the supervisor-side restart logic is gated off.
+   Matches frag-6-7 §6.1.
+8. [manager r5 lock: 'Reinstall ccsm' is prose text not a button; matches current working installerCorrupt pattern; v0.3 is refactor scope = no new auto-update feature.]
+9. [manager r5 lock: 'View log' button removed entirely; no such feature in current working; v0.3 refactor scope = no new features. Crash log location is documented in frag-11 §11.6 paths table for users who want to find logs manually.]
+
+---
+
+## 3.7 Dev workflow
+
+### 3.7.1 Goals
+
+Daily dogfood loop must stay **≤5 s edit→reload** even after the daemon split.
+The devx review (`v03-review-devx.md` §3 MUST-FIX 1) measured that, without
+the contents of this section, every `daemon/**` edit costs **+10–15 s and
+two manual steps** (`pkill -f dist-daemon` + restart Electron). That budget
+is unacceptable across the ~125 h of v0.3 implementation, so the dev tooling
+ships **with Phase 0**, not as a Phase 5 afterthought.
+
+### 3.7.2 `npm run dev` topology (v0.3)
+
+The existing v0.2 root script (see `package.json`):
+
+```json
+"dev": "concurrently -k -n web,app -c blue,magenta \"npm:dev:web\" \"npm:dev:app\""
+```
+
+extends to **three** named processes. Replace with:
+
+```json
+"dev":        "concurrently -k -n web,daemon,app -c blue,yellow,magenta \"npm:dev:web\" \"npm:dev:daemon\" \"npm:dev:app\"",
+"dev:web":    "webpack serve --config webpack.config.js --mode development",
+"dev:daemon": "nodemon --config nodemon.daemon.json",
+"dev:app":    "node scripts/wait-daemon.cjs && tsc -p tsconfig.electron.json && cross-env CCSM_DAEMON_DEV=1 electron .",
+"setup":      "node scripts/setup.cjs"
+```
+
+> **Cross-platform `wait-on file:` note (closes round-2 P0-2 + R1 OPEN q3;
+> round-3 manager arch decision #3 path-root lock):**
+> `scripts/wait-daemon.cjs` resolves the daemon lockfile path against the
+> **OS-native data root** (NOT `~/.ccsm/`):
+> - Win: `path.join(process.env.APPDATA, 'ccsm', 'daemon.lock')`
+> - macOS: `path.join(os.homedir(), 'Library', 'Application Support', 'ccsm', 'daemon.lock')`
+> - Linux: `path.join(process.env.XDG_CONFIG_HOME ?? path.join(os.homedir(), '.config'), 'ccsm', 'daemon.lock')`
+>
+> Then invokes `wait-on file:<resolved> http://localhost:4100`. The
+> previous `tcp:127.0.0.1:0` was a no-op (port 0 resolves immediately) and
+> silently let Electron race the daemon's pipe bind, dumping every dev
+> boot into the auto-reconnect loop. The lockfile is the same one frag-6-7
+> §6.4 mandates daemon write at startup via `proper-lockfile`, so no new
+> daemon-side work is needed. Note: per-user install (round-3 lock #3)
+> goes to `%LOCALAPPDATA%\ccsm\` for the install root; daemon **data**
+> (lockfile, sqlite, logs) lives at `%APPDATA%\ccsm\` — these are
+> different directories.
+
+Process graph:
+
+```
+concurrently -k
+├── web     : webpack-dev-server  (HMR for renderer, port 4100)
+├── daemon  : nodemon → tsc -w → node daemon/dist-daemon/index.js
+└── app     : tsc(electron) → electron .  (spawnOrAttach attaches to nodemon's daemon)
+```
+
+`-k` (kill-others) is mandatory: a dead web server must take the daemon and
+Electron with it, otherwise stale processes hold the named pipe and the
+next `npm run dev` fails the spawn-or-attach probe (Task 7 §3 step 4).
+
+#### 3.7.2.a Workspaces prerequisite (closes round-2 devx P0-1)
+
+`dev:daemon`'s nodemon `exec` (§3.7.3) and `frag-11-packaging.md` §11.1 both
+shell out to `npm -w @ccsm/daemon run …`. The repo's current root
+`package.json` declares no `"workspaces"` array (verified 2026-04-30 against
+working tip). The Phase 0 plan delta below (Task 1) explicitly mandates
+adding `"workspaces": ["daemon"]` to root `package.json` so that workspace
+flag-syntax resolves on first contributor pull. **frag-11 still owns
+`daemon/package.json` scaffolding** (`name: "@ccsm/daemon"`); §3.7 owns the
+root-side declaration so the dev script is functional. Cross-frag rationale
+captured at the bottom of this document.
+
+#### 3.7.2.b Single canonical daemon entry in dev (closes round-2 devx P0-3 + P1-4)
+
+Two daemon entries are described across the bundle:
+
+- frag-3.7 §3.7.3: `node daemon/dist-daemon/index.js` (TS-compiled, run by nodemon).
+- frag-11 §11.2: `daemon/dist/ccsm-daemon-${devTarget()}` (pkg-bundled binary).
+
+These are **not interchangeable**. In `CCSM_DAEMON_DEV=1` mode the
+**only** runtime entry is the nodemon-managed `node daemon/dist-daemon/index.js`.
+`spawnOrAttach.ts` (Task 7) MUST treat dev mode as attach-only and never
+look up the pkg path. frag-11 §11.2 should remove or fence its `devTarget()`
+branch behind `!process.env.CCSM_DAEMON_DEV` so the prod-only path doesn't
+read as authoritative for dev. **Punt accepted by §3.7 (this fragment) for
+the spawnOrAttach side; the frag-11 side is a one-line edit owned by the
+frag-11 round-2 fixer** — see Cross-frag rationale.
+
+#### 3.7.2.c Toolchain prerequisites (closes round-2 devx P0-4 + P1-5)
+
+v0.3 introduces a **C++ toolchain requirement** for the daemon's native
+helper at `daemon/native/winjob/` (frag-3.5.1 §3.5.1.1, frag-6-7 §6.2).
+v0.2 contributors editing only `src/` did not need this. To prevent
+first-time-on-Windows `gyp ERR! find VS missing any VC++ toolset`, the
+following are mandatory before `npm install` succeeds in a fresh checkout:
+
+| Platform | Required tool | Notes |
+|---|---|---|
+| Windows | Visual Studio Build Tools 2022 (Desktop C++ workload) | `node-gyp` for `daemon/native/winjob/`. |
+| Windows | Python 3.10+ on PATH | `node-gyp` dependency. |
+| Windows (signtool path) | Windows 10/11 SDK 10.0.22621.0 | only for `make:win` (frag-11 §11.3.1). |
+| macOS | Xcode Command-Line Tools | `xcode-select --install`. |
+| Linux | `build-essential`, `python3`, `libsecret-1-dev` | apt/yum equivalent. |
+
+The Phase 0 `npm run setup` script (`scripts/setup.cjs`, added by Task 1)
+runs:
+
+```
+1. npm install                                              (root + workspaces)
+2. npm -w @ccsm/daemon rebuild better-sqlite3 node-pty
+   --runtime=node --target=22.x                             (Node 22 ABI)
+3. (optional) npm run build:daemon                          (only if running make:*)
+```
+
+> **npm rebuild syntax** (round-3 devx P1-3): with the workspaces array
+> declared (§3.7.2.a), the canonical syntax is `npm -w @ccsm/daemon rebuild`,
+> NOT `npm rebuild --prefix daemon`. The round-2 spec used `--prefix` which
+> is redundant with workspaces and confused first-time contributors who
+> tried to mirror it elsewhere; locked to the workspace-flag form.
+
+Renderer-only contributors who never touch `daemon/**` MAY skip step 2 by
+running `npm install --workspaces=false && npm run dev:web` (documented in
+CONTRIBUTING). The default workspace-aware install does run `node-gyp` for
+the native helper — accepted onboarding cost; see Cross-frag rationale for
+the wider tradeoff.
+
+#### 3.7.2.d Production dogfood log access (closes round-2 devx P0-5; round-3 devx P1-4)
+
+Prod dogfood (per `feedback_dogfood_protocol`) runs the installed binary
+where `stdio: "ignore"` (§3.7.6) hides daemon stderr. The only signal is
+the daemon log written by `pino-roll` (frag-6-7 §6.6) under the OS-native
+data root (`%APPDATA%\ccsm\logs\daemon.log` on Win,
+`~/Library/Logs/ccsm/daemon.log` on macOS, `~/.config/ccsm/logs/daemon.log`
+on Linux). Per round-3 manager arch decision #3, log paths follow the
+OS-native data root, not `~/.ccsm/`. v0.3 mandates **two** affordances,
+both shipped in Phase 0 (no dogfood gate without them):
+
+- **`pino-roll` `symlink: true`** — daemon writes a stable symlink
+  alongside dated rotated files. POSIX `tail -F` follows the symlink
+  target across rotations cleanly. **Windows caveat (round-3 devx P1-4):**
+  `Get-Content -Wait` opens the symlink target by inode at start and
+  keeps the handle — it does NOT follow target swaps even with `-Tail`.
+  The `pino-roll symlink: true` fix is therefore **POSIX-only** for
+  live-tail purposes; Windows users tail via the tray menu "Tail daemon
+  log in new terminal" entry below (which spawns `wt.exe` running
+  `Get-Content` against the *current* rotated file, re-resolved per
+  invocation). **PUNT to frag-6-7 §6.6 fixer**: the `symlink: true` key
+  itself lives in frag-6-7's pino-roll config block (round-3 resource
+  X2: not yet added in r2 — must land in this round). One-line edit.
+- **Log path documentation** — daemon log path is documented in
+  release notes / About dialog so users can locate
+  `<dataRoot>/logs/daemon.log` manually for support diagnostics. No
+  tray menu growth (v0.3 is a refactor — no new tray entries).
+  [manager r7 lock: cut as polish — N2# from r6 feature-parity (Win-only
+  "Tail daemon log in new terminal") + N3# (cross-platform "Open daemon
+  log") — neither exists in working tip; v0.3 is refactor scope.]
+
+### 3.7.3 `nodemon.daemon.json` (new file, Task 1 add)
+
+```json
+{
+  "watch": ["daemon/src"],
+  "ext": "ts,json",
+  "ignore": ["daemon/src/**/__tests__/**", "daemon/dist-daemon/**"],
+  "exec": "npm -w @ccsm/daemon run build && node daemon/dist-daemon/index.js",
+  "signal": "SIGTERM",
+  "delay": 150,
+  "stdout": true,
+  "stderr": true,
+  "env": { "CCSM_DAEMON_LOG_LEVEL": "debug", "CCSM_DAEMON_DEV": "1" }
+}
+```
+
+Key choices:
+
+- **`exec` = build + run, not `tsc -w` separately.** A single `nodemon`
+  edit-trigger atomically (a) rebuilds, (b) sends `SIGTERM` to the previous
+  daemon, (c) starts the new one. Two-process `tsc --watch` + file-watcher
+  custom shim was rejected: nodemon already does it, +0 LOC.
+- **`signal: SIGTERM`** matches the daemon's existing handler in
+  `daemon/src/index.ts` step 4 (Plan Task 1 step 4 already wires
+  `process.on("SIGTERM", () => process.exit(0))`).
+- **`delay: 150`** debounces multi-file saves (TS refactor renames touch
+  many files in one tick).
+- **`stdout/stderr: true`** addresses devx MUST-FIX 2 — daemon errors land
+  in the same terminal pane as the renderer/Electron logs. Pino still
+  writes its structured stream to `~/.ccsm/logs/daemon.log` for post-mortem,
+  but stack traces appear inline.
+
+### 3.7.4 Connect client auto-reconnect
+
+When nodemon restarts the daemon, the Electron-side Connect client (Task 7
+§3 `connectClient.ts`) sees its socket close. Today (Plan Task 7 step 4,
+unmodified) the client throws on next call and the renderer surfaces a raw
+`ECONNREFUSED`. v0.3 §3.7 mandates **transparent auto-reconnect**:
+
+#### Backoff schedule
+
+Exponential, doubling, capped, with full jitter:
+
+| Attempt | Base delay | With ±25 % jitter |
+|---------|-----------:|------------------:|
+| 1       | 200 ms     | 150–250 ms        |
+| 2       | 400 ms     | 300–500 ms        |
+| 3       | 800 ms     | 600–1000 ms       |
+| 4       | 1600 ms    | 1200–2000 ms      |
+| 5       | 3200 ms    | 2400–4000 ms      |
+| 6+      | **5000 ms (cap)** | 3750–5000 ms |
+
+No retry cap on attempt count — the client retries forever until either
+(a) the socket connects, (b) the user quits the app, or (c) Task 7's
+`spawnOrAttach` is invoked again with `spawnIfMissing: true` and starts a
+fresh daemon. Under nodemon's typical 200–600 ms restart window, attempts
+1–2 succeed; under prod cold start (pkg binary, ~1.5 s) attempts 3–4
+succeed.
+
+#### Bounded reconnect queue
+
+While disconnected, RPC calls are **queued, not rejected**:
+
+- Queue cap: **100** in-flight calls in prod (`MAX_QUEUED_PROD = 100`),
+  **1000** in dev (`MAX_QUEUED_DEV = 1000`) — closes round-2 reliability
+  P1-R1 (rapid-fire dev save can briefly exceed 100 in nodemon storms;
+  RAM cost ~200 KB).
+- On overflow: oldest call is rejected with
+  `Error("daemon-reconnect-queue-overflow")`; the renderer's existing
+  per-bridge error path surfaces this.
+- Stream subscriptions (PTY data, notify) are **not queued** — see
+  §3.7.5 resubscription.
+- On reconnect success: queue drains FIFO; each entry sends its
+  envelope and resolves/rejects the original promise.
+
+Rationale: 100 calls @ ~200 B JSON envelope = ~20 KB worst-case in-memory
+buffering, well below any concern. The cap exists to bound an
+adversarial-disconnected-forever case (e.g. daemon binary missing); it is
+not a steady-state limit.
+
+#### 3.7.4.a Reconnect-queue does NOT double-buffer stream replay (closes round-2 resource P0-1)
+
+The reconnect queue holds **unary** RPC envelopes only. Stream
+**resubscription** (§3.7.5) does NOT replay through the queue. To bound
+the daemon-side replay burst when `subscribe(fromSeq)` requests a
+sequence older than the daemon's ring buffer, frag-3.7 picks resolution
+(b) of round-2 resource P0-1: the per-subscriber 1 MB drop-slowest
+watermark in **frag-3.5.1 §3.5.1.5 is measured AFTER the initial replay
+burst is delivered**, not as part of slow-subscriber accounting.
+Equivalently, the replay burst is treated as one initial write and
+exempt from slow-subscriber drop-decision. **Cross-fragment contract:**
+frag-3.5.1 §3.5.1.5 round-2 fixer must add a one-sentence carve-out
+("initial replay burst on resubscribe is not counted toward the 1 MB
+per-subscriber drop-slowest watermark"). **Punt to frag-3.5.1 round-2
+fixer**, called out here so the contract is visible.
+
+If frag-3.5.1's fixer rejects (b), §3.7.5 falls back to resolution (a):
+client clamps `fromSeq` such that the daemon ships at most 256 KB of
+replay then declares `gap: true`. The toast/divider path in §3.7.5
+already handles `gap: true` cleanly so this is a graceful fallback.
+
+#### Toast UX — registers into frag-6-7 §6.8 surface registry
+
+The reconnect bridge does NOT own a toast vocabulary; it publishes into
+the canonical surface registry defined in **frag-6-7 §6.8** (locked by
+round-3 manager arch decision #1). The reconnect bridge contributes the
+following surfaces; priorities/stacking/dedup are §6.8's responsibility.
+i18n keys are dot+camelCase per round-3 lock #5:
+
+| Event | §6.8 slot (priority) | i18n key |
+|---|---|---|
+| 1st reconnect attempt fails (250 ms threshold) | LOG ONLY (no IPC publish) — `daemon.reconnecting` toast slot CUT in §6.8 r7 trim | `daemon.reconnecting` (log-only) |
+| Reconnected (queue drained) | `reconnected` (transient info, 3 s TTL) | `daemon.reconnected` |
+| Queue overflow rejection | LOG ONLY — `queueOverflow` toast slot CUT in §6.8 r7 trim | `daemon.queueOverflow` (log-only) |
+| Reconnect attempts continue past supervisor miss threshold | promote to `unreachable` (red banner, P=70) — folded the former N=15 `reconnectExhausted` modal into the same banner per §6.8 r7 trim | `daemon.unreachable` |
+| Bridge-timeout spike (3+ in 10 s) | LOG ONLY — `bridgeTimeoutSpike` slot CUT in §6.8 r7 trim (escalates into `daemon.unreachable` if it persists) | (log-only) |
+| Stream gap on resubscribe | LOG ONLY (xterm divider may still render renderer-side) — `streamGap` toast slot CUT in §6.8 r7 trim | `daemon.streamGap` (log-only) |
+| Dev-mode build error (queue >4 s in `CCSM_DAEMON_DEV=1`) | LOG ONLY — `devBuildError` slot CUT in §6.8 r7 trim | `daemon.devBuildError` (log-only) |
+
+The 250 ms hold-off (renderer-side, owned by `useDaemonReconnectBridge`)
+prevents flicker: nodemon restarts in ~200 ms, so a clean dev-loop edit
+shows **no surface at all** — the 1st backoff retry (200 ms) succeeds
+before the publish threshold fires. The dev-mode build-error toast
+catches the TypeScript-broken-in-nodemon case where the dev terminal has
+a useful error but the renderer is otherwise opaque.
+
+`BridgeTimeoutError` per-call is NEVER user-surfaced (round-3 lock #6);
+the renderer's bridge layer logs `DEADLINE_EXCEEDED` (gRPC convention)
+and lets the supervisor banner (frag-6-7 §6.1) absorb it. After the
+§6.8 r7 trim, the only user-visible surface tied to bridge timeouts is
+the single `daemon.unreachable` banner (the former `bridgeTimeoutSpike`
+toast and `reconnectExhausted` modal slots are cut and folded into
+`daemon.unreachable`).
+
+**Canonical log line names** (round-3 obs P1-2 cross-ref): the reconnect
+emitter uses the strings declared by **frag-6-7 §6.6.2 "Bridge call
+lifecycle log lines"**: `daemon_socket_closed`, `daemon_reconnect_attempt`,
+`daemon_reconnect_success`, `daemon_queue_overflow`, `stream_resubscribe`.
+Workers MUST NOT invent new strings (e.g. `reconnect-attempted`).
+
+**Tray-mode "Quit" semantics** (round-3 devx P1-1): the existing
+working tray menu (`[Show CCSM | Quit]`) Quit handler MUST call
+`app.quit()` (clean exit, drain pino, release lockfile), NOT
+`win.close()` (which only hides to tray). The renderer plumbs this via
+the existing `tray.quitApp` IPC channel (Task 21). [manager r7 lock:
+the former r6 rationale ("the `reconnectExhausted` modal's Quit button
+must clean-exit even when in tray-hidden state") is OBSOLETE — that
+modal was cut by §6.8 r7; the `daemon.unreachable` banner has no Quit
+button (banner is non-blocking). The `app.quit()` requirement still
+holds for the working tray-menu Quit, which is the only Quit affordance
+in v0.3.]
+
+### 3.7.5 Stream resubscription on reconnect
+
+Devx OPEN q1: "When daemon restarts mid-session under dev, every renderer
+subscription drops." The bridge **must auto-resubscribe** rather than
+reload the renderer (renderer reload would lose terminal scrollback and
+form state).
+
+On reconnect success, `connectClient`:
+
+1. **First, tears down stale stream handles.** Iterates every entry in its
+   internal stream-handle table and calls `.cancel()` on each, clearing
+   any client-side `setInterval` heartbeat timers (frag-3.5.1 §3.5.1.4)
+   and removing them from the stream-handle table. This closes round-2
+   devx P1-6 — without it, two client-side heartbeat timers per stream
+   accumulate per restart and never get cleared.
+2. **Then, walks `Map<sid, SubscriptionDescriptor>`** populated at
+   `subscribe()` time. For each entry it re-issues the subscribe RPC
+   with `fromSeq = lastSeenSeq + 1`. PTY service (Task 11) and notify
+   service (Task 13) MUST honor `fromSeq` — this is on their wire
+   contract per §3.5.1 (PTY hardening fragment) and §3.4.1 (envelope
+   hardening fragment). The canonical declaration of the
+   `subscribe(sessionId, { fromSeq })` shape lives in **frag-3.4.1
+   §3.4.1.b** per the round-2 fwdcompat call (P1-1); §3.7.5 references
+   it rather than re-stating shape.
+3. **bootNonce check (closes round-2 fwdcompat P1-1; round-3 fwdcompat
+   cross-frag #2 camelCase lock).** Each subscribe response includes the
+   daemon's `bootNonce` field — **camelCase**, locked by round-3 manager
+   arch decision #4 (declared by frag-6-7 §6.5 healthz, frag-3.4.1 §3.4.1.g
+   hello, frag-3.5.1 §3.5.1.4 stream heartbeat; all four sites converge on
+   `bootNonce`). If the response `bootNonce` differs from the value
+   captured by the most recent subscription on this `sid`, the bridge
+   treats `fromSeq` as **invalid** (daemon rebooted, sequence space
+   reset) and behaves as if the daemon had returned `gap: true` —
+   fresh subscription from `fromSeq = 0`, log `daemon.streamGap` and
+   render the xterm divider renderer-side. (The §6.8 r7 trim cut the
+   `daemon.streamGap` toast; the divider remains a renderer-side
+   affordance, no IPC.) Without this, after a daemon restart the
+   client could request `fromSeq=12345` against a daemon whose new
+   sequence space starts at 0 and silently miss the first 12345 frames.
+
+   **In-flight chunk dedup across teardown** (round-3 devx P1-2): step 1
+   tears down the old socket's stream handles before the resubscribe ack
+   arrives, but kernel-buffered chunks from the old socket may still
+   land at the renderer between `.cancel()` and the fresh subscribe ack.
+   The renderer trusts `seq` ordering only WITHIN a single
+   `(sid, bootNonce)` tuple — chunks arriving with a stale `bootNonce`
+   (captured at old subscribe time) are dropped silently. Same-bootNonce
+   late chunks (nodemon SIGTERM-then-restart of the SAME daemon process
+   is impossible because nodemon spawns a fresh node process and
+   `bootNonce` is minted at boot) are de-duped by `seq`: any frame with
+   `seq <= lastSeenSeq` is dropped.
+
+If `fromSeq` is older than the daemon's ring buffer (cold daemon = empty
+ring), the daemon responds with `gap: true`; the bridge logs
+`daemon.streamGap` (LOG ONLY — the §6.8 r7 trim cut the toast slot;
+no IPC publish) and the renderer's xterm adapter emits a visible
+`─── stream gap ───` divider purely as a renderer-side affordance.
+
+### 3.7.6 Dev-mode contrasts vs prod
+
+| Aspect | Dev (`CCSM_DAEMON_DEV=1`) | Prod |
+|---|---|---|
+| Daemon process | nodemon child of `npm run dev` shell | pkg binary, spawned by `spawnOrAttach` (Task 7) or attached if already running (tray-quit semantics, Task 21) |
+| Restart cadence | every `daemon/src/**` save (~5–50×/h) | only on crash, daemon auto-update (Task 23), or explicit tray Quit |
+| stdio | inherited (`stdout/stderr: true` in nodemon) | `stdio: "ignore", detached: true` (Task 7 §3 step 4); pino writes to `~/.ccsm/logs/daemon.log` only |
+| Log level | `debug` | `info` (overridable via `CCSM_DAEMON_LOG_LEVEL`) |
+| Reconnect path | hits often (nodemon SIGTERM) | rare (crash recovery) |
+| Toast frequency | usually suppressed by 250 ms hold-off | subject to frag-6-7 §6.8 dedup vs supervisor banner |
+| Backoff schedule | **same** (200 ms → 5 s cap) | **same** |
+| Stream resubscribe | **same** | **same** |
+| Reconnect queue cap | **1000** | **100** |
+| Supervisor restart loop (frag-6-7 §6.1) | **DISABLED** — see §3.7.6.a | active |
+| Supervisor transport binds (frag-6-7 §6.5) | **YES** (so renderer `/healthz` poll has a target) | yes |
+| Renderer `/healthz` polling for status badge | **YES** (diagnostic UI only) | yes |
+
+The reconnect/queue/resubscribe code path is **identical** in dev and prod
+— gating it behind `CCSM_DAEMON_DEV` would mean the prod path is exercised
+only in the field. Devx review §3 MUST-FIX 2 only differentiates
+**logging stdio**, not the client-side reconnect logic. The queue cap
+splits dev/prod for ergonomic reasons (see §3.7.4).
+
+#### 3.7.6.a Supervisor restart loop disabled in dev; transport + healthz polling stay (closes round-2 reliability P0-R1; round-3 reliability CF-3)
+
+frag-6-7 §6.1 mandates a supervisor (5 s `/healthz`, 3-miss restart, crash-loop
+modal at 5 respawns / 2 min). In `CCSM_DAEMON_DEV=1`, **the supervisor's
+restart loop / heartbeat-miss counter / crash-loop counter MUST be disabled**.
+Justification: nodemon already supervises the daemon (SIGTERM + restart on
+file change); a second supervisor that doesn't know about nodemon will count
+every save as a missed heartbeat and trip the crash-loop modal during normal
+dev.
+
+What stays in dev (round-3 reliability CF-3 clarification — the r2
+"disabled entirely" wording was too strong and conflicted with frag-6-7
+§6.1's "still polls /healthz for diagnostic UI"):
+
+- The **supervisor transport** (named pipe / unix socket per frag-6-7 §6.5)
+  STILL binds in the daemon, because the renderer needs a target for
+  diagnostic-UI `/healthz` polling. Otherwise every nodemon SIGTERM
+  would race the renderer's poll and produce flicker.
+- The **renderer's `/healthz` poll** (5 s) continues purely as a status-
+  badge signal (green/yellow/red dot in the dev tray + dev-mode debug
+  panel). It does NOT drive any restart decision.
+- The **supervisor's restart loop** (3-miss → restart, 5-respawn-in-2min
+  → crash-loop modal) is the part that's gated off behind
+  `!process.env.CCSM_DAEMON_DEV`.
+
+frag-3.7's auto-reconnect (§3.7.4) is the dev-mode liveness *response* —
+sufficient because (a) the user *is* the failure detector in dev, (b)
+reconnect-queue + N=15 modal escalation already surfaces a stuck
+daemon, and (c) the diagnostic-UI badge gives a quick visual
+confirmation. **Cross-fragment contract:** frag-6-7 §6.1 round-3 fixer
+must mirror this exact split (transport + poll on, restart loop off).
+Already done per round-3 obs review confirmation that frag-6-7 §6.1 line
+25 reads "DISABLED in spawn/restart mode but still polls /healthz for
+diagnostic UI." This fragment's r3 edit aligns the wording.
+
+### 3.7.7 Test coverage
+
+- Unit: `electron/daemonClient/__tests__/connectClient.reconnect.test.ts` —
+  mock `node:net`, assert backoff schedule (use `vi.useFakeTimers()`),
+  queue-overflow rejection, FIFO drain order, dev-vs-prod cap.
+- Unit: `electron/daemonClient/__tests__/connectClient.resubscribe.test.ts`
+  — verify `Map<sid, SubscriptionDescriptor>` re-issue with bumped
+  `fromSeq`; verify `bootNonce` mismatch resets `fromSeq=0` and emits
+  the `daemon.streamGap` log line + xterm divider (no IPC publish per
+  §6.8 r7 trim); verify stale stream handles `.cancel()` before
+  resubscribe.
+- E2E: **fold into `harness-agent` as a phase** (closes round-2 devx
+  P1-7 / `feedback_e2e_prefer_harness`). New phase
+  `harness-agent.daemonReconnect()`: kill the running daemon
+  (platform-aware target — round-3 devx P1-5: under prod-installed
+  harness use `taskkill /F /IM ccsm-daemon.exe` on Win and
+  `pkill -f /Applications/ccsm.app/Contents/Resources/daemon/ccsm-daemon`
+  on macOS / `pkill -f /opt/ccsm/resources/daemon/ccsm-daemon` on Linux;
+  ONLY in dev-mode harness use `pkill -f dist-daemon/index.js`), assert
+  renderer DOM shows `[data-toast-kind="reconnecting"]`, restart daemon
+  via `spawnOrAttach`, assert toast clears within 1 s and a follow-on
+  RPC succeeds. Avoids +30 s/test for a standalone probe. No skip
+  allowed (per `feedback_no_skipped_e2e`).
+
+### 3.7.7.a Debugger attach (closes round-6 devx P0-1)
+
+[manager r7 lock: r6 devx P0-1 — debugger contract for daemon-split contributors]
+
+Three documented attach flows; all env-gated, default off, **dev-only**
+(production builds compile-out the inspector flag — security boundary
+preventing a packaged installer from exposing a live Node inspector).
+
+- **Daemon (`--inspect=9230`)**: env-gated via `CCSM_DAEMON_INSPECT=1`.
+  Nodemon's `exec` line in §3.7.3 becomes
+  `npm -w @ccsm/daemon run build && node ${CCSM_DAEMON_INSPECT:+--inspect=9230} daemon/dist-daemon/index.js`.
+  Default `npm run dev` opens NO inspector port; `CCSM_DAEMON_INSPECT=1 npm run dev`
+  opens 9230. Port 9230 chosen to avoid Electron-main's default 9229.
+  Production builds (Task 1 / frag-11 §11.2 packaging path) MUST NOT
+  thread this env var into the spawned daemon — `spawnOrAttach.ts` in
+  prod mode strips `CCSM_DAEMON_INSPECT` from the child env. Supervisor
+  restart-loop is already disabled in dev (§3.7.6.a) so a paused-at-
+  breakpoint daemon does not get killed for missed heartbeat;
+  auto-reconnect (§3.7.4) retries forever with a 5 s cap, so the
+  renderer simply shows the reconnect waiting toast until the
+  contributor resumes.
+- **Electron-main (`--inspect=9229`)**: existing pattern. `dev:app`
+  becomes `node scripts/wait-daemon.cjs && tsc -p tsconfig.electron.json && cross-env CCSM_DAEMON_DEV=1 electron ${CCSM_ELECTRON_INSPECT:+--inspect=9229} .`.
+  `CCSM_ELECTRON_INSPECT=1 npm run dev` opens 9229. Port 9229 is the
+  Node default and matches existing working-tip Electron-main inspect
+  conventions.
+- **Renderer**: existing Chrome DevTools (open from the Electron window
+  menu / `Ctrl+Shift+I`). No env var needed — devtools availability is
+  already gated by `app.isPackaged === false` in the existing renderer
+  bootstrap.
+
+**VS Code attach**: add two `attach` configurations to
+`.vscode/launch.json` — `Attach to daemon` (port 9230) and
+`Attach to Electron-main` (port 9229), plus a `compounds` entry to
+launch both simultaneously. Contributors then run
+`CCSM_DAEMON_INSPECT=1 CCSM_ELECTRON_INSPECT=1 npm run dev` and select
+the compound from the VS Code Run panel.
+
+### 3.7.7.b SDK ownership in v0.3 daemon split (closes round-6 devx P0-2)
+
+[manager r7 lock: r6 devx P0-2 — daemon owns SDK directly (own Node 22 ESM); Electron-main loadSdk shim retained ONLY for any residual session-title/non-daemon SDK calls. New daemon code MUST NOT use the shim.]
+
+The v0.3 daemon process is its own Node 22 process with native ESM
+support; daemon-side modules MAY `import` `@anthropic-ai/claude-agent-sdk`
+directly (ESM-direct, no shim). The `electron/sessionTitles/loadSdk()`
+shim was created for the Electron 33 main process (CJS) needing to
+consume the ESM-only SDK; that constraint does NOT apply inside the
+daemon. **Daemon-side SDK consumers MUST use direct `import` (or
+top-level `await import()` if dynamic), never `loadSdk()`.**
+
+Recommended ownership (manager lock): the daemon owns ALL SDK runtime
+use — agent dispatch, streaming, tool execution, model API calls.
+Electron-main retains the `loadSdk()` shim ONLY for any residual
+read-only / non-daemon SDK call sites that survive the v0.3 split
+(e.g. session-title generation if it stays in Electron-main per
+existing working-tip placement). New code paths added under the v0.3
+plan MUST NOT introduce additional Electron-main SDK consumers; if a
+new SDK call is needed, it goes in the daemon. If audit determines
+sessionTitles also moves to the daemon in v0.3, the loadSdk shim can
+be deleted entirely — flagged for follow-up (frag-12 traceability row,
+not in v0.3 scope unless trivial).
+
+### 3.7.8 User-visible surface registry — see frag-6-7 §6.8
+
+**DELETED in round-3** (closes round-3 ux P0-UX-A: two competing
+registries). Surface registry is owned canonically by **frag-6-7 §6.8**
+(numeric priority 100/90/85/70/50/30, single `daemonHealth` IPC channel,
+single `useDaemonHealthBridge` hook, ≤1 modal at a time, explicit
+stacking + dedup rules). Every surface this fragment used to own
+(reconnect waiting, reconnect-stuck modal, queue overflow, stream gap,
+dev-mode build error, bridge-timeout spike, close-to-tray onboarding
+hint, pre-mount loader trigger) is now registered into §6.8.
+
+After the §6.8 r7 trim (16 → 7 rows), the dev-mode reconnect bridge
+publishes only into the surfaces that survived the cut: priority **70
+(red banner)** for `daemon.unreachable` (the former
+`reconnectExhausted` modal at N=15 + `bridgeTimeoutSpike` toast +
+`healthDegraded` banner are all collapsed into this single banner
+slot), priority **30 (transient info toast)** for `daemon.reconnected`,
+and priority **85 (modal)** for `daemon.crashLoop`. The polish surface
+slots (`reconnecting` toast, `queueOverflow` toast, `streamGap` toast,
+`bridgeTimeoutSpike` toast, `devBuildError` toast, `healthDegraded`
+banner, `reconnectExhausted` modal) are CUT in §6.8 r7 — log-only,
+no IPC publish. Pre-mount loader and close-to-tray hint were also
+cut in §6.8 r7 (close-to-tray onboarding deleted entirely; pre-mount
+loader subsumed by the existing splash).
+
+i18n keys are dot+camelCase across the bundle (round-3 ux CC-3 lock).
+After the §6.8 r7 trim the dispatched-surface keys are
+`daemon.unreachable`, `daemon.reconnected`, `daemon.crashLoop`. The
+former r6 keys `daemon.reconnecting`, `daemon.queueOverflow`,
+`daemon.reconnectExhausted`, `daemon.bridgeTimeoutSpike`,
+`daemon.streamGap`, `daemon.devBuildError`, `tray.closeHint` are
+OBSOLETE (log-only or deleted entirely). Drafted copy for the surviving
+keys lives in **frag-6-7 §6.8 + §6.1.1** copy table; this fragment no
+longer owns the strings.
+
+Cross-frag PUNT (one-line for frag-6-7 §6.8 fixer to absorb): the
+**dev-mode reconnect surface** has no analog in prod (in prod the
+supervisor banner absorbs reconnect waiting per the mutual-exclusion
+rule). frag-6-7 §6.8 must add a row for the dev-only `daemon.devBuildError`
+surface (the queue-waits->4s-in-CCSM_DAEMON_DEV case from old
+§3.7.4 row j) at priority 50; this is the only surface that fires in dev
+but not prod. All other former-§3.7.8 rows already have §6.8 equivalents.
+[manager r11 lock: PUNT obsolete — §6.8 r7 trim explicitly cut `daemon.devBuildError`; this slot is permanently LOG ONLY per §3.7.5 r7 lock. (historical; no longer relevant)]
+
+---
+
+## Plan delta
+
+Concrete edits to `docs/superpowers/plans/2026-04-30-v0.3-daemon-split.md`:
+
+### Task 1 (Phase 0 scaffolding) — **+5 h** (was +3 h)
+
+- Add `nodemon` + `cross-env` + `wait-on@^7` to root `devDependencies`
+  (`npm i -D nodemon cross-env wait-on`).
+- **Add `"workspaces": ["daemon"]` to root `package.json`** (closes
+  round-2 devx P0-1).
+- Create `nodemon.daemon.json` (config in §3.7.3 above).
+- Create `scripts/wait-daemon.cjs` (resolves cross-platform lockfile path
+  + invokes `wait-on file:`).
+- Create `scripts/setup.cjs` (one-stop install + native rebuild) —
+  closes round-2 devx P0-4.
+- Edit root `package.json` `scripts`:
+  - Replace `dev` to add `daemon` lane (§3.7.2).
+  - Add `dev:daemon`, prepend `cross-env CCSM_DAEMON_DEV=1` to `dev:app`,
+    use `node scripts/wait-daemon.cjs` for the daemon-ready probe (NOT
+    the no-op `tcp:127.0.0.1:0`).
+  - Add `setup` script.
+- README + CONTRIBUTING note covering toolchain prerequisites table
+  from §3.7.2.c (folds in devx MUST-FIX 5 + round-2 P0-4).
+- Add VS Code TS Project References to `tsconfig.json` (`references: [{ path: "daemon" }]`)
+  + `composite: true` to `daemon/tsconfig.json` (closes round-2 devx
+  S-3 — small but high payoff).
+- Estimate breakdown: nodemon config + script wiring 2 h, wait-daemon
+  + setup scripts 1 h, workspaces wiring 0.5 h, README + tsconfig refs 1.5 h.
+
+### Task 7 (Connect client + handshake) — **+9 h** (was +7 h)
+
+- New file: `electron/daemonClient/reconnectQueue.ts` (~120 LOC, FIFO
+  queue, dev/prod cap split, exponential backoff scheduler).
+- New file: `electron/daemonClient/streamHandleTable.ts` (~80 LOC,
+  iterates handles for `.cancel()` on reconnect, clears client-side
+  heartbeat timers).
+- Modify `electron/daemonClient/connectClient.ts`: wrap `rpcCall` so it
+  routes through the queue when the underlying socket is down; expose
+  `subscribe(descriptor)` returning an unsub fn that also removes from
+  the resubscription map; include `bootNonce` capture per §3.7.5.
+- Modify `electron/daemonClient/spawnOrAttach.ts`: in dev mode
+  (`CCSM_DAEMON_DEV=1`), **skip** the `spawnIfMissing` branch — nodemon
+  owns the daemon lifecycle; Electron only attaches with retry. Also
+  ensure dev mode does NOT call into frag-11's pkg-binary path resolver
+  at all (closes round-2 devx P0-3 spawnOrAttach side).
+- Modify Task 7 step 4 spawn: `stdio: process.env.CCSM_DAEMON_DEV ?
+  "inherit" : "ignore"` and `detached: !process.env.CCSM_DAEMON_DEV`.
+- New tests: `connectClient.reconnect.test.ts` (+2 h),
+  `connectClient.resubscribe.test.ts` (+1 h, includes bootNonce + stale
+  handle cleanup).
+- New e2e phase: `harness-agent.daemonReconnect` (+1 h folded into
+  existing fixture, NOT a standalone probe — closes round-2 devx P1-7;
+  platform-aware kill target per round-3 devx P1-5).
+- Pre-mount loader: PUNTED to frag-6-7 §6.8 (was §3.7.8.d in r2; surface
+  registry collapse moves the trigger there).
+- Estimate breakdown: queue + backoff impl 2 h, subscribe map +
+  bootNonce 1.5 h, streamHandleTable 1 h, spawnOrAttach dev-mode
+  branch 1 h, tests 3 h, harness-agent phase 0.5 h. (Pre-mount loader
+  hour moved to frag-6-7's plan delta.)
+
+### Task 11 (PTY service lift) — **+1 h** (resubscribe contract)
+
+- Confirm PTY RPC contract accepts `fromSeq` and emits `gap: true` when
+  asked for an evicted sequence (already mandated by §3.5.1 fragment;
+  this is a cross-fragment sanity check, not new work).
+- Confirm `bootNonce` is included in the subscribe response envelope
+  (declared by frag-6-7 §6.5; camelCase locked round-3).
+
+### Task 13 (notify service lift) — **+1 h** (resubscribe contract)
+
+- Same `fromSeq` / `gap` / `bootNonce` semantics as Task 11.
+
+### Task 21 (tray) — **+0.5 h** (Quit semantics only)
+
+- **Tray "Quit" handler** (round-3 devx P1-1): wire `app.quit()` (NOT
+  `win.close()`) so the working tray-menu Quit button actually exits
+  the app even when in close-to-tray hidden state. (The former r6
+  rationale referenced a `reconnectExhausted` modal Quit button; that
+  modal was cut by §6.8 r7. The tray-menu Quit is now the only
+  Quit affordance.)
+- [manager r7 lock: cut as polish — N2# from r6 feature-parity. Win-only
+  "Tail daemon log in new terminal" tray entry deleted; v0.3 ships
+  working's `[Show CCSM | Quit]` tray menu unchanged. Log path lives in
+  release notes only.]
+- [manager r7 lock: cut as polish — N4# from r6 feature-parity. The
+  close-to-tray onboarding hint surface AND the
+  `close_to_tray_shown_at` SQLite key are deleted entirely. Working's
+  existing `closeBehaviorOptions.ask` first-close prompt already covers
+  the discoverability concern; no parallel onboarding moment. Task 21
+  no longer wires any close-hint check beyond the existing close-prompt
+  preserved from working.]
+
+### New sub-task under Task 7: renderer surface registry bridge — **+1 h** (was +2 h)
+
+- New file: `src/app-effects/useDaemonReconnectBridge.ts` (mirrors
+  `useUpdateDownloadedBridge.ts` and `usePersistErrorBridge.ts`;
+  publishes into the canonical surface registry via §6.8's
+  `useDaemonHealthBridge` rather than owning a separate
+  `useSurfaceRegistry.ts`). Subscribes to reconnect events from
+  `connectClient`, applies the 250 ms hold-off, dispatches the trimmed
+  surface set per the §6.8 r7 cut: `daemon.unreachable` (banner, covers
+  reconnect-attempt-failed + supervisor-down) / `daemon.reconnected`
+  (toast, debounced 5s) / `daemon.crashLoop` (modal). Polish surfaces
+  cut by §6.8 r7 (`daemon.queueOverflow`, `daemon.bridgeTimeoutSpike`,
+  `daemon.streamGap`, `daemon.devBuildError`,
+  `daemon.healthDegraded`, `daemon.reconnectExhausted`) are LOG ONLY —
+  no IPC publish.
+- The `useSurfaceRegistry.ts` central bus that the r2 plan delta
+  proposed is **NOT** built here — it lives in frag-6-7 §6.8 plan delta
+  (round-3 manager arch decision #1).
+- New i18n keys (dot+camelCase per round-3 lock #5) in
+  `src/i18n/locales/en.ts` and `src/i18n/locales/zh.ts` — only the
+  three keys the bridge still dispatches; the canonical copy table
+  lives in §6.8 / §6.1.1.
+- Wire bridge into `src/App.tsx` next to existing `*Bridge` calls.
+- Estimate breakdown: bridge 0.75 h, i18n + wiring 0.25 h. (1 h saved
+  vs r6's +2 h by trimming the dispatched surface set per §6.8 r7
+  feature-parity cuts.)
+- [manager r7 lock: surfaces trimmed per N6# from r6 feature-parity —
+  daemon-split brings new failure modes the user MUST see (unreachable,
+  crashLoop, reconnected confirmation), but degraded-but-functional
+  states (queueOverflow, bridgeTimeoutSpike, streamGap, devBuildError,
+  healthDegraded, reconnectExhausted) are not user-must-see and were
+  log-only in working.]
+
+### Task 25 (dogfood acceptance) — **+0.5 h** (production log access — docs only)
+
+- Daemon log path documented in release notes + About dialog so users
+  can locate `<dataRoot>/logs/daemon.log` for support diagnostics.
+- Acceptance: pino-roll rotation cycle works on Win 11 (rotated file
+  written) AND on macOS / Linux (symlink updated). Path is OS-native
+  data root per round-3 lock #3 (`%APPDATA%\ccsm\logs\daemon.log` on
+  Win, NOT `~/.ccsm/`).
+- [manager r7 lock: cut as polish — N2# + N3# from r6 feature-parity.
+  Tray "Open daemon log" entry + Win "Tail daemon log in new terminal"
+  entry DELETED entirely; v0.3 is refactor scope, no new tray menu
+  items. `pino-roll` `symlink: true` (frag-6-7 §6.6) still required for
+  POSIX `tail -F` from a user terminal; Win users open the dated
+  rotated file directly via Explorer. The Win symlink-handle caveat is
+  noted in release notes only.]
+
+### Total v0.3 estimate impact
+
+**+18 h** (Task 1 +5, Task 7 +9, Task 11 +1, Task 13 +1, Task 21 +0.5,
+new surface-bridge sub-task +1, Task 25 +0.5). Down from r6's +21 h:
+r7 polish cuts removed the Win tail-log + Open daemon log tray entries
+(-1.5 h on Task 25), trimmed Task 21's tray work (-0.5 h, no
+close-to-tray onboarding), and shrank the surface-bridge sub-task
+(-1 h, fewer i18n keys to wire — see frag-6-7 §6.8 row count cut).
+Plus closes the round-3 P0-UX-A surface-registry-duplicate bug.
+
+---
+
+## Cross-frag rationale
+
+§3.7 owns **devx mechanics** (nodemon topology, reconnect queue,
+resubscribe, dev-mode supervisor disablement). The user-visible surface
+registry is **NO LONGER OWNED HERE** — round-3 manager arch decision #1
+collapses it into frag-6-7 §6.8 as the canonical source. §3.7's
+reconnect bridge publishes into §6.8 rather than owning a parallel
+vocabulary.
+
+All P0 + P1 items from round-2 + round-3 reports under
+`~/spike-reports/v03-r{2,3}-*.md` that touch §3.7's wire surface have
+been folded in; items that belong on a sibling fragment are explicitly
+**punted** below with a one-line contract for the receiving fixer.
+
+**Owned by §3.7 (this fragment, applied above):**
+
+- devx P0-1 — Workspaces declaration in root `package.json` — Task 1.
+- devx P0-2 — `wait-on tcp:127.0.0.1:0` no-op replaced with
+  `scripts/wait-daemon.cjs` + `wait-on file:` against OS-native data
+  root. §3.7.2 + Task 1.
+- devx P0-3 (spawnOrAttach side) — dev mode skips pkg-binary path.
+  §3.7.2.b + Task 7. **frag-11 still owns** the `devTarget()` fence.
+- devx P0-4 — Toolchain prerequisites + `npm run setup`. §3.7.2.c +
+  Task 1.
+- devx P0-5 (tray "Open daemon log" + Win tail entry) — Task 25 plan
+  delta. **frag-6-7 still owns** the `pino-roll symlink: true` config
+  itself (round-3 devx CF-1 / resource X2: not landed in r2).
+- devx P1-3 — Dev-build-error surface published into §6.8 by §3.7
+  bridge.
+- devx P1-6 — Stream handle `.cancel()` before resubscribe — §3.7.5
+  step 1 + new `streamHandleTable.ts`.
+- devx P1-7 — E2E folded into `harness-agent.daemonReconnect` phase.
+- reliability P1-R1 — Dev queue cap = 1000 — §3.7.4.
+- resource P0-1 — Reconnect-queue does NOT replay through queue;
+  §3.7.4.a. **frag-3.5.1 §3.5.1.5 still owns** the carve-out sentence.
+- ux P1-UX-1 — Reconnect retries forever → promote to §6.8
+  `daemon.unreachable` red banner once supervisor miss threshold is
+  passed (the former r6 N=15 `reconnectExhausted` modal was folded
+  into `daemon.unreachable` per §6.8 r7 trim). §3.7.4 + cross-ref §6.8.
+- ux P1-UX-4 — Reconnect surface vs supervisor banner mutual
+  exclusion — owned by §6.8's stacking rule, this fragment publishes
+  conformantly.
+- fwdcompat P1-1 — `bootNonce` (camelCase, locked round-3) in subscribe
+  response. §3.7.5 step 3.
+- fwdcompat (canonical stream-RPC contract owner) — §3.7.5 references
+  frag-3.4.1 §3.4.1.b as canonical instead of re-declaring.
+- **r3 ux P0-UX-A** — §3.7.8 deleted, replaced with cross-ref to
+  frag-6-7 §6.8. Closes the two-competing-registries bug.
+- **r3 ux/resource CC-1/X4** — close-to-tray SQLite key dropped here;
+  §6.8 owns `close_to_tray_shown_at` (timestamp, manager arch
+  decision #2).
+- **r3 ux CC-3** — i18n keys locked dot+camelCase in the new §3.7.8
+  cross-ref paragraph + plan delta.
+- **r3 ux CC-4 / fwdcompat #2** — `BridgeTimeoutError` never
+  user-surfaced per-call; surfacing absorbed into §6.8 spike + modal
+  slots.
+- **r3 obs P1-2** — Reconnect emitter cross-refs frag-6-7 §6.6.2
+  canonical log line names (`daemon_socket_closed`,
+  `daemon_reconnect_attempt`, `daemon_reconnect_success`,
+  `daemon_queue_overflow`, `stream_resubscribe`). §3.7.4 toast UX
+  paragraph.
+- **r3 reliability CF-3** — §3.7.6.a clarified: supervisor restart loop
+  off in dev, transport + healthz polling stay for status badge.
+- **r3 devx P1-1** — Tray "Quit" handler calls `app.quit()` not
+  `win.close()`. Task 21 plan delta.
+- **r3 devx P1-2** — In-flight chunk dedup across teardown documented
+  in §3.7.5 step 3 (renderer trusts `seq` only within one
+  `(sid, bootNonce)` tuple).
+- **r3 devx P1-3** — `npm rebuild --prefix daemon` → `npm -w
+  @ccsm/daemon rebuild`. §3.7.2.c.
+- **r3 devx P1-4** — `Get-Content -Wait` symlink-follow caveat: POSIX-
+  only fix; Win adds tray "Tail daemon log in new terminal" entry.
+  §3.7.2.d + Task 25.
+- **r3 devx P1-5** — E2E `pkill` target made platform-aware for
+  prod-installed daemon. §3.7.7.
+
+**Punted to other fragments (one-line contract for the receiving
+fixer):**
+
+- **frag-11 fixer** — §11.2 must remove or fence the `devTarget()`
+  branch behind `!process.env.CCSM_DAEMON_DEV` so prod path doesn't
+  read as authoritative for dev. (devx P1-4 + remainder of P0-3;
+  round-3 devx CF-2 not landed in r2.)
+- **frag-3.5.1 fixer** — §3.5.1.5 must add: "initial replay burst on
+  resubscribe is NOT counted toward the 1 MB per-subscriber drop-
+  slowest watermark" (resource P0-1 resolution b). §3.5.1.3 must add:
+  "BridgeTimeoutError is logged with `DEADLINE_EXCEEDED` but NEVER
+  surfaced to the user; surfacing is owned by frag-6-7 §6.8's single
+  `daemon.unreachable` banner slot per the §6.8 r7 trim (separate spike
+  + reconnectExhausted slots are cut)" (round-3 ux CC-4 / devx CF-3
+  not landed in r2).
+- **frag-6-7 fixer (highest-priority pickup queue):**
+  - §6.6 pino-roll config must add `symlink: true` to BOTH daemon and
+    electron blocks (round-3 resource X2 / devx CF-1 not landed in r2).
+  - §6.8 must absorb the **dev-only `daemon.devBuildError`** surface at
+    priority 50 (only surface that fires in dev but not prod; all other
+    former-§3.7.8 rows already have §6.8 equivalents). [manager r11 lock:
+    PUNT obsolete — §6.8 r7 trim explicitly cut `daemon.devBuildError`;
+    this slot is permanently LOG ONLY per §3.7.5 r7 lock. (historical;
+    no longer relevant)]
+  - §6.8 must absorb the **pre-mount loader** trigger (was §3.7.8.d in
+    r2; r3 surface-registry collapse moves it here). 1 h estimate
+    transferred from §3.7's plan delta.
+  - §6.8 must lock `close_to_tray_shown_at` (timestamp) as the
+    canonical SQLite key (round-3 manager arch decision #2 + ux CC-1).
+- **Task 21 (tray) owner** — wire `close_to_tray_shown_at` check before
+  `win.hide()`; emit the §6.8 onboarding-hint surface on the first
+  close (round-3 manager arch decision #2). Also wire `app.quit()`
+  semantics for the modal "Quit" button (round-3 devx P1-1).
+
+**Not addressed (out of §3.7 scope, flagged for completeness):**
+
+- devx P1-1 r2 (Task 5 21h hot-file collision on `connectAdapter.ts`)
+  — plan-organisation concern. **Punt to manager**.
+- devx P1-5 r2 (native helper compile on every checkout) — partial
+  mitigation via §3.7.2.c. Full fix owned by frag-3.5.1 §3.5.1.1.
+- ux P0-UX-3 (cold-start no-bak modal full copy) — full ownership lives
+  with frag-6-7 §6.1.1 copy table.
+- All SHOULD/nits not adjacent to a P0/P1 intentionally not edited per
+  round-3 fixer scope.
+
+---
+
+## 3-line summary
+
+Round-3 collapses §3.7.8 into a one-paragraph cross-ref to frag-6-7 §6.8
+(canonical surface registry, manager arch decision #1), drops the
+duplicate close-to-tray SQLite key, and locks `bootNonce` to camelCase +
+i18n keys to dot+camelCase across the bundle. §3.7.6.a is clarified
+(supervisor restart loop off in dev, but transport + `/healthz` polling
+stay for status badge). Five round-3 P1 nits folded in: tray "Quit"
+calls `app.quit()`, in-flight chunks dedup by `(sid, bootNonce)` tuple,
+`npm -w @ccsm/daemon rebuild` syntax, Win `Get-Content -Wait` symlink-
+follow caveat (POSIX-only fix + new tray "Tail in new terminal" entry),
+and platform-aware e2e kill target for prod-installed daemon.
+
+<!-- END frag-3.7-dev-workflow.md -->
+
+---
+
+<!-- BEGIN frag-6-7-reliability-security.md -->
+
+# Fragment: §6 reliability + §7 security expansion
+
+**Owner**: Task #936 (worker, pool-2). Round-3 fixes applied per `~/spike-reports/v03-r3-*.md`.
+**Target spec sections**: REPLACE existing §6 ("Error handling and edge cases") and §7 ("Testing") in `docs/superpowers/specs/2026-04-30-web-remote-design.md`. The v1 §7 ("Testing") moves to §6.6 below; the new §7 is dedicated Security.
+**P0 review items addressed**: rel-M1..M5, rel-S1/S2/S3/S5/S7, sec-M1..M3, sec-S1..S6, obs-MUST 2/3/4, res-MUST 1, round-2: rel P0-R1..R5, sec P0-S1..S3, obs P0-1..P0-4, fwdcompat P0-2, ux P0-UX-1/UX-3, pkg P0-1 (uninstall hygiene — TAKEN here, see §6.8). **Round-3**: rel R1..R5 (drain order, crash-loop reset, paused/abandoned terminal, daemon.crashing best-effort), sec P0-1/P0-2 (HMAC-of-nonce hello, fromSeq ACCEPTED), ux P0-A/P0-B/P0-C (surface registry canonical, migration priority callout, frag-12 PUNT), obs P1-1/P1-2 (canonical log key names), devx CF-1 (pino-roll symlink), devx CF-3 (BridgeTimeout policy), fwdcompat (boot_nonce → bootNonce, daemonProtocolVersion mirror), lockin CF-2/CF-3 (clientImposterSecret redact + protocolVersion mirror), resource X1/X3/X4 (~/.ccsm aggregate cap, uninstall double-claim, close_to_tray key), perf CF-1/CF-2 (-sup vs control-socket clarification, traceId hot-path carve-out).
+**OS-native install + data root paths (LOCKED v0.3)**:
+- Win: `%LOCALAPPDATA%\ccsm\` (per-user; binaries in `bin\`, data + lock + secret + logs at root)
+- macOS: `~/Library/Application Support/ccsm/`
+- Linux: `~/.local/share/ccsm/`
+- Legacy `~/.ccsm/` references in this fragment are historical aliases for the OS-native data root above. All NEW spec text uses `<dataRoot>` notation; concrete paths in tables resolve to OS-native.
+**Inputs cited**:
+- `~/spike-reports/v03-review-reliability.md`, `~/spike-reports/v03-r2-reliability.md`, `~/spike-reports/v03-r3-reliability.md`
+- `~/spike-reports/v03-review-security.md`, `~/spike-reports/v03-r2-security.md`, `~/spike-reports/v03-r3-security.md`
+- `~/spike-reports/v03-review-observability.md`, `~/spike-reports/v03-r2-observability.md`, `~/spike-reports/v03-r3-observability.md`
+- `~/spike-reports/v03-review-resource.md`, `~/spike-reports/v03-r3-resource.md`
+- `~/spike-reports/v03-r2-fwdcompat.md`, `~/spike-reports/v03-r3-fwdcompat.md`
+- `~/spike-reports/v03-r2-ux.md`, `~/spike-reports/v03-r3-ux.md`
+- `~/spike-reports/v03-r2-packaging.md`
+- `~/spike-reports/v03-r3-devx.md`, `~/spike-reports/v03-r3-lockin.md`, `~/spike-reports/v03-r3-perf.md`
+
+---
+
+## 6. Reliability
+
+v1 §6 ("Error handling and edge cases") is replaced wholesale. The bullet list below is the contract; failure-modes table F1..F12 from rel-review §2 is the canonical enumeration and is appended as §6.7. §6.8 owns user-visible surfaces (modal/toast/banner registry) and uninstall hygiene (relocated from frag-11 packaging — see Cross-frag rationale).
+
+### 6.1 Daemon supervision (Electron-side)
+
+Electron-main owns daemon lifecycle. Single `daemonSupervisor` module runs in main; never in renderer.
+
+- **Spawn-or-attach** at boot via `daemonSupervisor.start()` (Task 7). Probe `<dataRoot>/daemon.lock` (see §6.4) → if held + reachable → attach; else spawn.
+- **Heartbeat (prod)**: supervisor pings `/healthz` (see §6.5) every 5s on the **dedicated supervisor transport** (separate from the data-path adapter — see §6.5). Three consecutive misses (15s) → mark daemon dead, trigger restart cycle. Renderer shows yellow banner on first miss, red on third (copy table §6.1.1).
+- **Heartbeat (dev)** (resolves r3-devx CF-3 contradiction with frag-3.7 §3.7.6.a): when `process.env.CCSM_DAEMON_DEV === '1'` (frag-3.7 §3.7.6), the supervisor lifecycle logic (spawn / restart / crash-loop / rollback) is DISABLED in full — nodemon owns the lifecycle, frag-3.7's auto-reconnect queue is the dev liveness signal. **The dedicated supervisor transport (§6.5 `ccsm-control` socket) is still bound** so the renderer's diagnostic UI can poll `/healthz` (read-only, no decisions). Polling cadence: 30s interval / 5-miss threshold / 60s grace; never enters crash-loop or restart logic. Concretely: in dev, the supervisor module behaves as a passive `/healthz` reader for UI, NOT a lifecycle owner. (Sources: r2-rel P0-R1, r3-devx CF-3, frag-3.7 §3.7.6.a "Supervisor active? NO" reconciled.) `[manager r11 lock: P1 devx P1-2 socket name canonical = ccsm-control per frag-3.4.1 §3.4.1.h table; was `-sup`]`
+- **Backoff on respawn**: `1s → 2s → 4s → 8s → 16s → cap 30s`. Counter resets to 1s after the daemon stays up ≥60s. State stored in supervisor RAM only; survives renderer reload, not Electron quit. (Source: spec stub Task #936.)
+- **Crash-loop detection**: ≥5 respawns within a sliding 2-minute window → enter `crash-loop-detected` state. Supervisor STOPS auto-restart, surfaces a modal banner per §6.1.1 copy table, and emits one `daemon.crashLoop` IPC to the renderer (camelCase i18n key per ux CC-3 lock; see §6.8 i18n note). The user must explicitly retry; auto-rollback to `.bak` (§6.4) is offered as one of the modal buttons. No silent restart loops.
+- **Crash-loop counter reset rule (r3-rel R2 — REVISED)**: on a "successful rollback" (defined below), the **backoff counter** resets to 1s, but the **crash-loop sliding window does NOT fully clear** — instead it decays so that the rolled-back crash counts as `3 of 5` (i.e. only 2 more crashes within the 2-minute window trigger crash-loop state again, not 5). Rationale: rollback is "limp mode" — the `.bak` binary may itself have a latent crash that takes >60s to surface (e.g. periodic poll, lazy SDK init); without partial-counter retention, supervisor would silently re-enter fresh state and let 5 MORE crashes happen before user surfaces. Documented explicitly: rollback is not "all clear." **Marker-aware skip (round-7 manager lock — fixer G verify; round-9 manager lock — r8 reliability marker-unlink ownership)** `[manager r7 lock: G verify — marker-aware crash-loop skip]` `[manager r9 lock: r8 reliability — marker unlink ownership reconciled with §6.4: if marker present, supervisor skips crash-loop counter; daemon will unlink after §6.4 self-test passes — supervisor MUST NOT unlink (preserves marker across new-bundle crash-during-boot)]`: on every supervisor cold-start before applying R2 accounting, the supervisor checks for the presence of `<dataRoot>/daemon.shutdown` marker file (written by `daemon.shutdownForUpgrade` per §6.4 Marker semantics). If the marker is present, the previous shutdown was a clean upgrade — supervisor MUST NOT increment the crash-loop counter for this boot, MUST NOT trip the rollback path, and MUST NOT unlink the marker. The new daemon will unlink the marker after §6.4 self-test passes (60 s up + 5×/healthz pass) per §6.4 Marker semantics. If absent, normal R2 accounting applies. Marker-corruption / partial-write handling is treated as PRESENT (conservative — see §6.4 Marker semantics). (Source: r3-rel R2 + r7 packaging P0-2 cross-frag + r8 reliability marker-unlink ownership.)
+- **Crash-loop log signature** (r2-obs P1-1): on entering crash-loop state the supervisor writes one structured pino line `{ event: "crashloop_entered", respawnCount, windowMs, lastExitCodes: [...], lastTraceIds: [...], lastBootNonces: [...] }` BEFORE emitting the IPC. Single grepable forensic anchor.
+- **Cold-start failure**: if the FIRST spawn after Electron boot dies within 30s of accept-loop ready, supervisor auto-rolls back to `daemon.exe.bak` exactly once before entering crash-loop state. **"Successful rollback"** = the swapped-back binary survives 60s AND answers `/healthz` 5 consecutive times; on success, supervisor (a) clears the backoff counter, (b) **decays** the crash-loop sliding window per the R2-revised rule above (rolled-back crash = 3/5), (c) emits `daemon.rolledback` IPC. If the swapped-back binary itself fails the 60s/5-ping test, supervisor enters crash-loop state with the no-bak modal copy (§6.1.1 row "rollback-also-failed"). (Source: rel-M5 + r2-rel P0-R2 + r3-rel R2.)
+- **Cold-start splash** (r2-ux P1-UX-6): renderer's HTML shell shows a `Starting ccsm…` pre-mount loader (CSS-only, no JS deps) until supervisor reports daemon ready. Cheap; eliminates blank-white-window first impression on cold installs / SmartScreen scan.
+
+#### 6.1.1 Supervisor-state user-facing copy (drafted; sentence-case; future-i18n keys named)
+
+Mirror of frag-8 §8.6 format. All strings are placeholders pending i18n bundle; reviewer enforces sentence case (no SCREAMING) and no developer-speak (no "DEADLINE_EXCEEDED", no "ECONNREFUSED" leaking to users — those are log-only per §6.6 and r2-ux §4 last bullet).
+
+| State | Surface | i18n key | Title | Body | Buttons |
+|---|---|---|---|---|---|
+| Daemon unreachable (heartbeat-miss / reconnect-attempts-failing / reconnect-exhausted — single unified surface) | Banner (red) | `daemon.unreachable` | ccsm lost contact with the background service | Trying to restart it. If this persists, ccsm may need to be reinstalled. | (none) |
+| Crash-loop (with bak) | Modal (blocking) | `daemon.crashLoop` | The background service is failing to start | We've kept your previous version available as a backup. | Restore from backup / Quit |
+| Crash-loop (no bak) | Modal (blocking) | `daemon.crashLoop` | The background service is failing to start | This is a clean install with no previous version to roll back to. Please download a fresh installer from the GitHub Releases page and reinstall ccsm — sessions can't start until then. | Quit |
+| Migration failed (frag-8 §8.6 fatal-error) | Modal (blocking) | `migration.modal.failed.*` | (frag-8 §8.6 owns copy) | (frag-8 §8.6 owns body) | Quit ccsm |
+| Installer corrupt (carry-forward from working) | Modal (blocking) | `installerCorrupt` | (preserved unchanged from working `installerCorrupt.title`) | (preserved unchanged from working `installerCorrupt.body` — prose only, "please reinstall CCSM to repair the install") | (none — prose only per r5 lock #8) |
+| Reconnected (recovery confirmation, debounced 5s) | Toast (info, 3s) | `daemon.reconnected` | Reconnected to the background service | (none) | (none) |
+
+[manager r7 lock: cut as polish — N6# from r6 feature-parity. §6.1.1 row count trimmed from 9 → 6. The single `daemon.unreachable` row collapses the former `daemon.healthDegraded` (yellow miss-1/3) + `daemon.healthUnreachable` (red miss-3/3) + `daemon.reconnectExhausted` modal + `daemon.bridgeTimeouts` banner — daemon-split brings new failure modes that user MUST see, but degraded-but-functional middle states (yellow banner, bridge-timeout spike) are diagnostic / log-only. The two `daemon.crashLoop` rows share one i18n key; the variant column survives only because the with-bak case adds a "Restore from backup" affordance. `daemon.rollingBack` / `daemon.rolledBack` (banner + toast) cut as polish — rollback completes silently from the user's perspective; if it fails, the noBak `daemon.crashLoop` row fires. `daemon.rollbackFailed` modal collapsed into the noBak `daemon.crashLoop` row (same user remediation: reinstall).]
+
+[manager r7 lock: C3# from r6 feature-parity — Quit button kept on `daemon.crashLoop` (both variants). Distinct from `installerCorrupt` prose pattern (r5 lock #8); user needs explicit exit affordance when daemon won't start (no other way out beyond OS window controls). r5 lock #8 specifically targeted the `installerCorrupt` "Reinstall" button, not exit-affordances. The `installerCorrupt` row remains prose-only with no button per r5 lock #8.]
+
+[manager r7 lock: M1# from r6 feature-parity — every existing renderer Settings panel toggle (`closeBehavior`, `theme`, `fontSize`, `language`, `crashReporting`, `notifications.enable`, `notifications.sound`, `updates.automaticChecks`) survives the daemon-split unchanged. The split moves data + lifecycle + IPC, NOT the renderer's preferences UI. Implementers MUST NOT "modernize" or silently drop options as part of the v0.3 lift.]
+
+[manager r7 lock: M2# from r6 feature-parity — `installerCorrupt` modal (working `src/components/InstallerCorruptBanner.tsx`) is preserved unchanged across the daemon-split. Title + body strings copy verbatim from working `installerCorrupt.title` / `installerCorrupt.body`; no buttons (prose-only per r5 lock #8). Surface fires when CCSM cannot find the bundled `claude` binary — distinct from `daemon.crashLoop` which fires when the daemon process fails to start.]
+
+**i18n key casing** (ux CC-3 lock): all daemon-health keys are dot-camelCase (`daemon.<event>` or `daemon.<event>.<variant>`). Frag-3.7 already uses this convention; frag-6-7 r3 fix aligns. PUNT: frag-3.7 to align any remaining drift; PUNT: frag-8 to align migration keys (`migration.<event>` camelCase).
+
+**zh.ts parity acceptance criterion (round-7 manager lock — r6 ux P0-4)** `[manager r7 lock: r6 ux P0-4 — zh.ts parity acceptance criterion]`: every new `en.ts` string added by v0.3 (this §6.1.1 copy table, the §6.8 surface registry rows, and any frag-3.7 / frag-8 i18n key referenced from those tables) MUST have a corresponding `zh.ts` entry shipped in the same PR. PR fails CI if `src/i18n/locales/en.ts` and `src/i18n/locales/zh.ts` keysets diverge — enforcement landed via a vitest hook (`tests/i18n/parity.test.ts`) that asserts `Object.keys(en).sort() === Object.keys(zh).sort()` for the daemon / migration / tray namespaces. Reviewer checks this mechanically before approval; no separate carve-out for "translate later".
+
+**BridgeTimeout policy (locked, devx CF-3 + ux CC-4; r7 update for §6.1.1 trim)**: `BridgeTimeoutError` (frag-3.5.1 §3.5.1.3) is **NEVER user-surfaced as a per-call toast**. The bridge wrapper logs `DEADLINE_EXCEEDED` at warn level (with `traceId`, `method`, `durationMs`) and returns a rejected Promise to the caller; renderer-side caller code MUST NOT surface raw `BridgeTimeoutError` to a toast. Surfacing flows through TWO paths only: (a) **internal retry-once**: bridge wrapper transparently retries the call once (single retry, 1s backoff) before rejecting; if the retry succeeds, no surface fires. (b) If the retry also fails, the timeout is LOG-ONLY at the per-call level. **Continuous unreachability** (supervisor heartbeat-miss / reconnect-exhausted) is the only user-visible path and it surfaces as the unified `daemon.unreachable` red banner per the §6.1.1 row above. The standalone `daemon.bridgeTimeouts` "service may be busy" banner was **cut as polish** in r7 per N6# from r6 feature-parity (degraded-but-functional state, log-only). PUNT: frag-3.5.1 §3.5.1.3 must add a one-sentence carve-out matching this rule. (Sources: r3-devx CF-3 + r3-ux CC-4 + r7 N6# trim.)
+
+**Handshake-failure classification (round-7 manager lock — r6 reliability P0-R1; r7 update for §6.1.1 trim)** `[manager r7 lock: r6 reliability P0-R1 — handshake failure is a distinct pre-RPC failure class; with the §6.1.1 r7 trim there is no separate "service may be busy" banner to falsely trip, so the original detector concern is moot. Tagging is still mandated for future metrics interceptor split.]`: per frag-3.4.1 §3.4.1.g (handshake-timeout paragraph), client-side handshake failures (2 s timeout, `hello_required`, `hello_replay`, `schema_violation` on `daemon.hello`, HMAC mismatch via `crypto.timingSafeEqual`, `compatible: false` reasons) surface through the existing supervisor heartbeat / reconnect ladder: each handshake-fail is one reconnect attempt under frag-3.7 §3.7.4 backoff, escalating to the unified `daemon.unreachable` red banner (whose body reads "Trying to restart it. If this persists, ccsm may need to be reinstalled." per the row above). **No new surface row is added**; the reinstall guidance lives in the body copy of `daemon.unreachable`. Implementer note: bridge wrapper MUST tag handshake errors with `class: 'handshake'` so the §3.7.4 retry path and any future metrics interceptor can split them from post-handshake `class: 'bridge-timeout'` failures cleanly (telemetry / log discriminator only — no user-surface fork).
+
+### 6.2 PTY child reaping
+
+Daemon owns PTY children, but the OS owns the orphan story. Without explicit reaping, every daemon crash leaks a `claude` CLI process (rel-M1).
+
+- **Windows**: each `pty.spawn()` is wrapped in a `JobObject` with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. When the daemon process handle closes (clean or crash), Win SCM kills every child in the job atomically. Implemented via small N-API helper or `koffi`; same dependency as §7.M1 pipe-ACL helper, so cost is shared.
+- **POSIX**: each `pty.spawn()` calls `setpgid(0, 0)` to get its own PG, plus `prctl(PR_SET_PDEATHSIG, SIGTERM)` on Linux / kqueue parent-watch on macOS. On daemon death, kernel signals the children.
+- **Plan delta**: Task 11a acceptance gains "no orphaned `claude.exe` after `taskkill /F` of daemon (Win) or `kill -9` (POSIX), verified by spawning, killing daemon, then asserting `Process32First` / `pgrep` returns 0".
+
+### 6.3 Session resurrection contract (F2)
+
+When daemon restarts cleanly (auto-update, supervisor respawn), running PTY sessions are gone. Spec was silent; now explicit:
+
+- Session rows in SQLite are marked `state = 'paused'` (i18n key `session.state.paused`) on daemon boot if their `pid_pgid` no longer maps to a live process. (`pid_pgid` written at spawn, cleared in the same DB transaction that writes any terminal state per §6.6.1 step 5 / r3-rel P1-R1.) **Wording change** (r2-ux P1-UX-5): the user did not abandon the session — the system did. Internal state value remains `paused`; legacy log fields may still say `abandoned` for back-compat one release.
+- **Terminal-state lock (r3-rel R3)**: the canonical terminal state is `paused` for any session whose pid no longer maps. `abandoned` as a separate terminal state is REJECTED — frag-3.5.1 §3.5.1.2 step 8 is wrong if it still emits `abandoned` after SIGKILL; the SIGKILL'd row should also land at `paused` (the user-visible affordance is identical: "system restarted, [Resume]"). PUNT to frag-3.5.1: §3.5.1.2 step 8 must drop `state='abandoned'` and use `state='paused'`. The two fragments must agree on a single terminal-name. (Source: r3-rel R3.)
+- Renderer shows paused sessions with a **`Paused — daemon was restarted [Resume]`** affordance. Resuming creates a fresh CLI subprocess with the same `cwd`, `model`, env subset, working directory, and seed prompt; new session id is linked back to the parent via a `parent_session_id` column. **Affordance copy explicitly notes**: `Resume creates a fresh CLI process. The previous turn (any work the model was doing when ccsm restarted) is not recovered.` (r2-rel P1-R4: in-flight CLI state is NOT magically restored.)
+- No silent auto-respawn. User intent required, because the prior CLI may have been mid-write.
+- (Source: rel-S3 + r2-rel P1-R4 + r2-ux P1-UX-5.)
+
+### 6.4 Single-instance + last-known-good rollback
+
+- **Lockfile (NOT pipe-probe)**: daemon boot acquires `<dataRoot>/daemon.lock` (Win: `%LOCALAPPDATA%\ccsm\daemon.lock`; macOS: `~/Library/Application Support/ccsm/daemon.lock`; Linux: `~/.local/share/ccsm/daemon.lock`) via `proper-lockfile` with `O_EXCL` create + PID write. The named-pipe / unix-socket bind is the secondary signal, not the gate. This closes rel-M4 (Win named pipes silently allow multi-instance via `PIPE_UNLIMITED_INSTANCES`). **Lockfile MUST be acquired BEFORE `ensureDataDir()` / migration runs** (r3-rel P0-R4 ordering — frag-8 §8.3 depends on this). Boot order: 1. acquire lockfile, 2. ensureDataDir + migration, 3. open SQLite, 4. start adapter.
+- **Stale lock recovery**: if lockfile exists but PID is dead (Win: `OpenProcess` returns `INVALID_HANDLE_VALUE`; POSIX: `kill(pid, 0)` returns ESRCH), supervisor steals the lock with a single warn log line.
+- **Lockfile create-fail policy** (rel-S-R4): if `proper-lockfile` create fails for any reason other than `EEXIST` (e.g. `noexec` mount, ENOSPC, EROFS), daemon refuses to start with a clear error written to stderr (pre-pino, since pino isn't initialized until after lockfile per r3-rel P1-R4) AND, when pino is up, a final fatal log line; **no silent fall-back to no-lock mode** ever.
+- **Daemon binary layout** (post-pkg, Task 20): installed under `%LOCALAPPDATA%\ccsm\bin\` on Win, `~/Library/Application Support/ccsm/bin/` on macOS, `~/.local/share/ccsm/bin/` on Linux. **Per-user** path with user-only ACL — never `Program Files` (sec-S1).
+- **Win Service vs user-mode** (rel-OPEN Q1): v0.3 ships **user-mode background process** only. Win Service mode is deferred to v0.4+ (no concrete demand from dogfood; user-mode is sufficient for single-user laptop scope).
+- **WAL pragma at every db open** (rel-OPEN Q5): daemon explicitly sets `PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;` on every `Database()` open path; verified at first boot and asserted in unit test.
+- **Auto-update swap is atomic** (Task 23):
+  1. Download `daemon.exe.new.partial`, retry 3× with exponential backoff on net error.
+  2. SHA256 verify against release manifest. **AND** verify SLSA-3 provenance attestation `provenance.intoto.jsonl` against GitHub's public OIDC root (see §7.3 v0.3 row). On either mismatch: delete `.partial`, abort, schedule retry on next 6h poll.
+  3. (Linux additionally verifies a minisign signature attached to the release; see §7.3.) (v0.4+) sigstore signature verify supersedes SLSA. v0.3 ships SLSA-attested with auto-update **DEFAULT OFF** (`CCSM_DAEMON_AUTOUPDATE` opt-in); manual update prompt only. (sec-S5 + sec-OPEN-3 + r2-sec P0-S3.)
+  4. **Rotate `daemon.secret`** (r2-sec P0-S1): generate fresh 32-byte random; write to `daemon.secret.new` with O_EXCL+0600/user-DACL atomically; rename over `daemon.secret`. **Pause supervisor `/healthz` polling for the swap window** (r3-sec P1-6): supervisor sets `swap_in_progress = true` so the old daemon's `/healthz` reply also carries `{ swapInProgress: true }` and the supervisor does not interpret old-secret HMAC mismatch as imposter-impersonation. Done BEFORE step 5 so the new daemon launches with the new secret AND the old binary's leaked secret loses authority on next supervisor poll.
+  5. Rename current `daemon.exe → daemon.exe.bak` (atomic on NTFS via `MoveFileExW(MOVEFILE_REPLACE_EXISTING)`).
+  6. Rename `daemon.exe.new → daemon.exe`.
+  7. Restart. If new daemon fails cold-start §6.1 self-test, supervisor swaps `.bak` back exactly once and surfaces a modal. **On successful rollback (60s up + 5×/healthz)** supervisor clears the backoff counter AND decays the crash-loop window per §6.1 R2 rule (rolled-back crash counts as 3/5, NOT a full clear) AND emits `daemon.rolledBack` IPC; subsequent crashes start counting from a non-zero floor. (r2-rel P0-R2 + r3-rel R2.)
+- **Swap-lock (r3-rel P1-R5)**: rollback step 7 is gated by the SAME `daemon.lock` (single supervisor instance per user since lockfile gate); concurrent supervisors (double-launch, MDM relaunch, debugger spawn) are prevented from racing the swap because only the lockholder is allowed to perform binary swap operations. The swap acquires + holds the lock through verify; if a competing supervisor cannot acquire the lock, it exits cleanly.
+- **Updater-script crash safety**: the rename step is a single OS call, not a "spawn batch script that waits 1s" pattern (rel-M5). The legacy batch-shim approach is explicitly rejected.
+- **`daemon.shutdownForUpgrade` RPC + shutdown marker** `[manager r7 lock: r6 packaging P0-2 cross-frag — daemon.shutdownForUpgrade RPC + marker semantics; consumed by frag-11 §11.6.5 upgrade flow]`:
+  - **Caller**: Electron-main, on receipt of the `electron-updater` `update-downloaded` event (BEFORE calling `autoUpdater.quitAndInstall()`). Distinct from the existing `daemon.shutdown` RPC (uninstall path, §6.8 / frag-11 §11.6.4) because upgrade flushes in-flight session writes (5 s ack window) where uninstall is destructive (2 s + kill).
+  - **Daemon behavior** on receiving `daemon.shutdownForUpgrade`:
+    1. Atomically write `<dataRoot>/daemon.shutdown` marker file (`O_CREAT | O_EXCL | O_WRONLY` + `rename()` from `daemon.shutdown.tmp` to `daemon.shutdown`, user-only DACL/0600). Marker payload is a single line `{ "reason": "upgrade", "version": "<current>", "ts": <epoch_ms> }` — small JSON for forensics, but presence/absence is the load-bearing signal.
+    2. Run the §6.6.1 ordered shutdown sequence (drain ordering: subscribers → SIGCHLD wind-down → DB checkpoint → `pino.final`).
+    3. Release the `<dataRoot>/daemon.lock` (`proper-lockfile` `unlock()`).
+    4. `process.exit(0)` within **5 s** of receiving the RPC. If the daemon cannot exit cleanly within 5 s, Electron-main force-kills (frag-11 §11.6.5 step 4 fallback: `taskkill /F /PID` on Win, `process.kill(pid, 'SIGKILL')` on POSIX, then explicit `unlink(<dataRoot>/daemon.lock)` to clear the proper-lockfile stale lock dir).
+  - **Marker semantics** (consumed at next daemon boot, §6.4 lockfile + §6.1 supervisor crash-loop counter):
+    - Marker file present at boot time = "the previous daemon shutdown was for upgrade, expected and clean — do NOT increment the crash-loop counter (§6.1 R2 rule), do NOT trip the rollback path (§6.4 step 7 .bak swap), do NOT surface `daemon.crashLoop` modal."
+    - Marker is **consumed** (`unlink()`) on the next successful daemon start — specifically, after the new daemon completes the §6.4 boot order steps 1-4 (acquire lock, ensureDataDir, open SQLite, start adapter) AND its §6.1 self-test (60 s up + 5×/healthz pass). Consuming on self-test pass not on boot-start guarantees the marker survives a crash *during* the new boot (if the new bundle is itself broken, the marker stays present and the next-next boot still treats the prior shutdown as upgrade-clean — no false crash-loop trigger from the upgrade window).
+    - Marker file absent at boot = "previous shutdown was either crash, OS reboot, user-Quit, or first-ever boot — apply normal supervisor crash-loop accounting per §6.1 R2."
+    - **Marker corruption / partial write** (rel-S-R8): if the marker file exists but is unreadable / malformed JSON, treat as PRESENT (conservative — prefer false-negative on crash-loop accounting over false-positive that bricks legitimate post-upgrade boots). Log `marker_corrupt` warn and unlink as part of consumption.
+  - **Cross-fragment contract**: this RPC and marker are the daemon-side half of frag-11 §11.6.5's upgrade-in-place flow. The Electron-main orchestration (5 s ack timeout, force-kill fallback, explicit lock unlink, post-upgrade `spawnOrAttach` flow) lives in frag-11 §11.6.5. The supervisor crash-loop counter consumption rule lives in §6.1 (PUNT to fixer G to verify §6.1 R2 paragraph mentions the marker-skip).
+  - **Allowlist registration**: `daemon.shutdownForUpgrade` is a **control-plane RPC** and MUST be added to the `SUPERVISOR_RPCS` allowlist constant declared in frag-3.4.1 §3.4.1.h. After this edit the allowlist becomes `SUPERVISOR_RPCS = ["/healthz", "/stats", "daemon.hello", "daemon.shutdown", "daemon.shutdownForUpgrade"]`. PUNT to fixer G: cross-frag merge worker MUST update the literal in frag-3.4.1 §3.4.1.h to match (also update the §3.4.1.h table's control-socket "RPCs served" cell + the §3.4.1.f migrationGate interceptor allowlist consumer cross-ref).
+
+### 6.5 Health probe + dedicated supervisor transport
+
+- **Dedicated transport** (r2-rel P0-R5 + r3-perf CF-1 unification + r11 devx P1-2 socket-name lock): the supervisor uses a **separate** local socket / named pipe — `\\.\pipe\ccsm-control-<userhash>` (Win) or `<runtimeRoot>/ccsm-control.sock` (POSIX) — exclusively for the canonical `SUPERVISOR_RPCS` set declared in frag-3.4.1 §3.4.1.h (currently: `/healthz`, `/stats`, `daemon.hello`, `daemon.shutdown`, `daemon.shutdownForUpgrade`) plus the `daemon.crashing` best-effort daemon→client IPC. `[manager r9 lock: r8 envelope P0-1 + r8 devx P0-1 — local enumeration removed; reference canonical SUPERVISOR_RPCS by name per §3.4.1.h "MUST NOT enumerate alternative lists" rule. Renamed prior `daemon.stats` to `/stats` to match canonical literal.]` `[manager r11 lock: P1 devx P1-2 socket name canonical = ccsm-control per frag-3.4.1 §3.4.1.h table; was `-sup` suffix on `ccsm-daemon-<userSid>` (Win) and `daemon-sup.sock` (POSIX); paths now mirror §3.4.1.h table exactly]` **This `ccsm-control` socket IS the same channel that frag-3.4.1 §3.4.1.h calls "control-socket"** (r3-perf CF-1 disambiguation: ONE control plane, single canonical name). Total daemon listeners: 2 — one data-path adapter, one supervisor/control transport. This eliminates the entire class of "snapshot back-pressures heartbeat" race: a 20-snapshot storm on the data-path adapter cannot delay the supervisor's heartbeat poll. Cost: ~kB RAM, one extra accept loop, same ACL/peer-cred discipline as the data path (§7.1). The supervisor transport is the SINGLE channel that ignores `MIGRATION_PENDING` short-circuit (r2-rel P1-R3) — it always returns liveness with a `migrationState` field, never a sentinel error.
+- `ccsm.v1/daemon.healthz` RPC, no auth (local-only, see §7), returns:
+  ```json
+  { "uptimeMs": number, "pid": number, "version": string,
+    "bootNonce": string, "sessionCount": number,
+    "subscriberCount": number,
+    "migrationState": "absent" | "pending" | "in-progress" | "done",
+    "swapInProgress": boolean,
+    "protocol": {
+      "wire": "v0.3-json-envelope",
+      "minClient": "v0.3",
+      "daemonProtocolVersion": 1,
+      "daemonAcceptedWires": ["v0.3-json-envelope"],
+      "features": ["binary-frames", "stream-heartbeat", "interceptors", "traceId", "bootNonce", "hello"]
+    },
+    "healthzVersion": 1
+  }
+  ```
+  - `bootNonce` is **camelCase** (r3-fwdcompat CF-2 lock — was `boot_nonce` snake; aligned with rest of envelope: `traceId`, `streamId`, `headerLen`, `payloadLen`). PUNT to frag-3.7 §3.7.5: any `response.boot_nonce` reads must become `response.bootNonce` to avoid silent `undefined` reads. Value is a ULID (not `Date.now()`) so two crashes within 1 ms still produce distinct ids (r2-obs OPEN-4).
+  - `daemonProtocolVersion` (r3-lockin CF-2 fix): integer semver-major mirrored 1:1 from `daemon.hello` reply (frag-3.4.1 §3.4.1.g). Bumps ONLY on breaking handler-contract changes; additive features go in `features` array. Supervisor uses this to detect post-update protocol-version mismatch on a long-lived attach.
+  - `daemonAcceptedWires` (r3-fwdcompat P1-5): array of wire formats this daemon accepts; v0.3 = `["v0.3-json-envelope"]`, v0.4 = `["v0.3-json-envelope", "v0.4-protobuf"]` during transition. Saves a roundtrip during v0.3→v0.4 rolling upgrade.
+  - `swapInProgress` (r3-sec P1-6): true during the auto-update swap window §6.4 step 4-7; supervisor pauses imposter-secret HMAC verification while true to avoid spurious crash-loop trigger from old-daemon-with-old-secret.
+  - `healthzVersion` replaces the round-2 `statsVersion` field on `/healthz` (r3-fwdcompat P1-3): two cursors confused additivity. `statsVersion` lives only on `/stats`; `healthzVersion` lives only on `/healthz`. `[manager r11 lock: P1 reliability daemon.stats → /stats sweep — literal renamed to match canonical SUPERVISOR_RPCS path per §3.4.1.h]`
+  - The `protocol` block is the **canonical version-negotiation payload**, mirrored 1:1 in the `daemon.hello` handshake response (see §6.5.1). Fwdcompat P0-2.
+- **`ccsm.v1/daemon.hello` handshake** (r2-fwdcompat P0-2): the FIRST envelope on every newly-accepted data-path connection MUST be `daemon.hello { clientWire: "v0.3-json-envelope", clientFeatures: [...], clientHelloNonce: "<base64-16>" }`. Daemon answers with the `protocol` block above plus `compatible: boolean` + `reason?: string` + `helloNonceHmac: "<base64-22>"`. **HMAC truncated to 16 bytes daemon-side, base64-encoded on wire (~22 chars). Client compares the full 22-char string via `crypto.timingSafeEqual` (equal-length buffers required, otherwise `RangeError`). Source of truth: §3.4.1.g (and §7.2 generator).** [manager r7 lock: r6 security P2-10 — HMAC wire format unified across §3.4.1.g + §6.5 + §7.2 to base64-22 (16-byte daemon-truncated). Prevents RangeError on first connection.] **Daemon refuses to dispatch any other RPC on this connection until hello completes**; on `compatible: false`, daemon closes the connection with a clean error code (NOT cryptic `not_found`). v0.4 protobuf swap declares `wire: "v0.4-protobuf"` and the v0.3 daemon refuses with `compatible: false, reason: "wire-mismatch"`. **(Hello-handshake posture is unified across both sockets per §3.4.1.h canonical: data-socket and `ccsm-control` socket share peer-cred / DACL / accept-rate-cap / hello-handshake posture. `[manager r9 lock: hello-handshake unified — both sockets share posture per §3.4.1.h canonical; supersedes prior r2 "supervisor transport skips hello" wording which contradicted the helloInterceptor #0 contract and would have triggered a destroy-loop on every supervisor heartbeat. r8 envelope P0-2.]` `[manager r11 lock: P1 devx P1-2 socket name canonical = ccsm-control per frag-3.4.1 §3.4.1.h table; was `-sup`]`)
+- Supervisor polls every 5s prod, 30s dev (§6.1). Cheap (~50µs).
+- v0.4 adds `/readyz` returning `{ migration: 'pending'|'in-progress'|'done' }` for SQLite migration gating; v0.3 ships `/healthz` only with embedded `migrationState` field.
+- A separate `/stats` (obs-S6) returns `{ statsVersion: 1, rss, heapUsed, ptyBufferBytes, openSockets }` — diagnostic-grade RPC, not part of the supervisor liveness contract. `statsVersion` enables additive evolution without renderer breakage (r2-obs P1-4). `[manager r11 lock: P1 reliability daemon.stats → /stats sweep — literal RPC name renamed to match canonical SUPERVISOR_RPCS literal per §3.4.1.h; control-plane namespace exempt from ccsm.v1/... per §3.4.1.h literal-vs-namespace lock]` [manager r7 lock: cut as polish — N8# from r6 feature-parity. The internal RPC stays (useful for healthz/diagnostic IPC + future v0.4 inspector tooling), but the tray-menu "Daemon stats…" entry is DELETED — v0.2 tray menu is `[Show CCSM | Quit]` only and v0.3 is refactor scope, no new tray entries.]
+
+#### 6.5.1 Server-side stream-dead detector (round-7 manager lock — r6 reliability P0-R2)
+
+`[manager r7 lock: r6 reliability P0-R2 — daemon-side symmetric dead-stream detector at 2 × heartbeatMs + 5 s; v0.3 local pipe / unix socket = no-op (kernel close fires first), but byte-compatible with the v0.5 CF Tunnel TCP swap reserved at frag-3.4.1 §3.4.1.c x-ccsm-deadline-ms 120 s clamp + x-ccsm-trace-parent header. Without this, the v0.5 TCP path has no half-open recovery short of OS TCP-keepalive (default 2 hours).]`
+
+Frag-3.5.1 §3.5.1.4 owns CLIENT-side dead-stream detection at `2 × heartbeatMs + 5 s` (default 65 s) and notes that on a stuck-reader-but-healthy-network case the server side falls back to heartbeat-write-failure tripping drop-slowest at the 1 MiB watermark (§3.5.1.5). On v0.3 local pipe / unix socket this is reliable — kernel close arrives in milliseconds and `writable === false` fires within one OS scheduler tick. **It is NOT reliable on a future v0.5 TCP transport.** A half-open TCP socket (client device sleeps, NAT entry expires, WiFi drops) leaves the daemon's send buffer slowly filling because PTY traffic is keystroke-sized; on a low-traffic stream (idle PTY + 30 s heartbeat) the buffer fill takes ~30 minutes to reach the 1 MiB drop-slowest trip, during which the slow-subscriber LRU cap `min(N × 1 MB, 4 MB)` holds memory hostage. The OS-default TCP keepalive does not fire until 2 hours.
+
+**Rule**: the daemon maintains a per-stream `lastClientActivityAt` timestamp updated on (a) any inbound unary RPC dispatched on the same connection, (b) any client-issued frame on the same connection (future v0.5 ACK frame, reserved). The shared heartbeat scheduler (§3.5.1.4) — already iterating `Map<streamId, { lastWriteAt, heartbeatMs }>` once per second — additionally checks `now - lastClientActivityAt > 2 × heartbeatMs + 5_000`. If exceeded, the daemon:
+
+1. Treats the stream as dead and the underlying CONNECTION as dead (one half-open socket means the whole connection is suspect).
+2. Closes the stream with `RESOURCE_EXHAUSTED, reason: 'server-stream-dead'` and `socket.destroy()` on the underlying connection.
+3. Emits one structured log line `{ event: 'server_stream_dead', sid, streamId, lastClientActivityMsAgo, heartbeatMs, peerPid }` (single line, NOT per-stream-on-connection — the connection close cascades to all dependent streams; aggregate one log line per close).
+4. The fan-out registry (frag-3.5.1 §3.5.1.5) removes the dropped subscriber the same way drop-slowest already does — no separate accounting path; the slow-subscriber drop log line and `subscribers-closed` aggregator both stay valid.
+
+**v0.3 expected behaviour**: on local pipe / unix socket, this detector is a NO-OP — the kernel `'close'` event arrives long before `2 × heartbeatMs + 5 s` elapses, the existing socket-level `'error'` / `'close'` path runs first, and the stream is gone before the scheduler tick examines `lastClientActivityAt`. Spec it now so the v0.5 TCP swap is byte-compatible with no contract change. The v0.5 wire-format swap (frag-3.4.1 §3.4.1.c reserves `x-ccsm-trace-parent` and the 120 s deadline clamp for this transition) inherits this detector unchanged.
+
+**Symmetry with client side**: client uses `2 × heartbeatMs + 5_000` (§3.5.1.4); server now uses the same window. Both sides agree the connection is dead at the same moment, eliminating a window where the client retries but the daemon still holds the registry slot.
+
+**Heartbeat scheduler cost impact**: the existing 1 s scheduler tick already walks the per-stream Map; adding a `lastClientActivityAt` comparison is one extra integer subtraction per stream per tick. At v0.5 100-session × 10 streams scale this is 1000 extra subtractions per second — negligible.
+
+**Cross-frag handoff**: frag-3.5.1 §3.5.1.4 "Server-side dead-client detection" paragraph should add a sentence "Symmetric server-side detector at `2 × heartbeatMs + 5 s` is owned by frag-6-7 §6.5.1 — covers the v0.5 half-open TCP case where heartbeat-write-failure may not fire for hours." Cross-frag merge worker reconciles. (No edit applied here — this fragment cannot edit frag-3.5.1; flagged for fixer G traceability.)
+
+### 6.6 Logging shutdown safety + rotation + correlation
+
+Observability is a reliability concern in v0.3 because the bug surface is split across two processes. The four obs-MUST items are first-class spec contracts.
+
+#### 6.6.1 Daemon-side logger
+
+- **`pino.final()` on every exit path** (obs-MUST-2, addressing P0 #11): daemon installs `pino.final(logger, (err, finalLogger) => { finalLogger.fatal(err); process.exit(1); })` plus `process.on('SIGTERM' | 'SIGINT' | 'beforeExit' | 'uncaughtException' | 'unhandledRejection')` handlers that call `logger.flush()` synchronously. The default async destination stays for hot path; `pino.final` is the shutdown valve.
+- **Drain ordering for log producers** (r2-obs P0-3 + r3-rel P0-R1 reorder): `pino.final` only flushes pino's destination buffer, NOT producer-side timers/callbacks that are still emitting lines. On SIGTERM/SIGINT, daemon executes the following ordered sequence BEFORE invoking `pino.final`. **Critical R1 fix**: SIGCHLD wind-down + DB terminal-state writes happen BEFORE subscriber close, so PTY-exit events generated during shutdown still reach in-RAM consumers (notify producer, telemetry counter, future audit interceptor). Subscriber-close is the LAST runtime act before pino.final.
+  1. Set `state = 'draining'` (module-level flag visible to all log producers).
+  2. `clearInterval` every per-stream heartbeat timer (frag-3.5.1 §3.5.1.4 — list maintained as `streamHeartbeats: Set<NodeJS.Timer>`).
+  3. Reject all pending reconnect-queue / in-flight bridge calls with a single aggregated log line `{ event: "daemon-shutdown", droppedCalls: N }` (NOT N lines).
+  4. **(SIGCHLD wind-down BEFORE subscriber close, r3-rel R1)** Mark all `state='running'` sessions to `state='shutting_down'` in one transaction. Issue `SIGTERM` to each PG; wait up to 200ms per child; `waitpid(pid, WNOHANG)` per known PID (NOT `waitpid(-1)`) to avoid stealing reaps from logger/telemetry deps; survivors get `SIGKILL` to the pgroup. Mark surviving 'shutting_down' rows to `state='paused'` (per §6.3, NOT `abandoned` per r3-rel R3) in one transaction, AND clear `pid_pgid` in the same transaction (r3-rel P1-R1). **The `paused` write MUST be `UPDATE sessions SET state='paused', pid_pgid=NULL WHERE state='shutting_down'`** `[manager r7 lock: r6 reliability P1-R4 — explicit WHERE state='shutting_down' clause prevents the SIGCHLD-clean-exit vs SIGKILL-deadline race from double-writing a row that already transitioned to 'exited'. Without the WHERE clause, a child that clean-exits between the 200 ms cap and the SIGKILL deadline could land BOTH 'exited' (from SIGCHLD handler step 6 in frag-3.5.1 §3.5.1.2) AND 'paused' (from the sweep here / step 8 there); the WHERE-state guard makes the sweep idempotent and order-independent. PUNT to fixer G: cross-frag merge worker MUST verify frag-3.5.1 §3.5.1.2 step 8 mirrors this exact WHERE clause.]` `PRAGMA wal_checkpoint(TRUNCATE)`. `db.close()`. Throughout this step, the in-RAM fan-out registry is still live and any `ptyExit` event reaches subscribers + in-process consumers.
+  5. Iterate fan-out subscriber registry once; close each subscriber stream with `RESOURCE_EXHAUSTED, reason: 'daemon-shutdown'`; emit ONE aggregated `{ event: "subscribers-closed", count: N }` line (NOT N drop lines). This is the LAST runtime act (was step 4 in r2; moved to step 5 per r3-rel R1).
+  6. THEN `pino.final` runs.
+  7. THEN `process.exit(0)`.
+- **Crash-imminent IPC (best-effort, NOT guaranteed)** (r2-rel S-R1 + r3-rel R5): in the fatal handler, BEFORE `pino.final` runs, daemon emits a single best-effort `daemon.crashing` envelope on the supervisor transport so renderer can fail in-flight bridge calls immediately rather than waiting 5s for `BridgeTimeoutError`. **CRITICAL: this IPC is OPPORTUNISTIC.** It fires only when the daemon dies via a Node-observable path (`uncaughtException`, `unhandledRejection`, `SIGTERM`, `SIGINT`). On SIGKILL (OOM killer, `taskkill /F`, kernel panic, supervisor's own forced restart, segfault in native binding), no fatal handler runs and no `daemon.crashing` IPC ships. The renderer MUST NOT gate fast-fail on this IPC alone — the **authoritative liveness path** is supervisor `/healthz` 3-miss + bridge 5s timeout (a "we got crashing IPC OR healthz pings within 15s" gate is correct; "we got crashing IPC OR healthz pings" — without timeout — would hang on SIGKILL). Renderer code that observes neither MUST fall back to BridgeTimeoutError after 5s. (Source: r3-rel R5.)
+- **Log rotation** (obs-MUST-3 + res-MUST-1, addressing P0 #12 + r3-devx CF-1): `pino-roll` with `{ frequency: 'daily', size: '50M', limit: { count: 7 }, mkdir: true, symlink: true }`. Files at `<dataRoot>/logs/daemon-YYYY-MM-DD.log`; `symlink: true` (r3-devx CF-1 + r3-resource X2 punt pickup) maintains a stable `daemon.log` symlink → current rotated file so POSIX `tail -F` AND tray "Open daemon log" survive daily rotation. (Win `Get-Content -Wait` follows the symlink target by inode at start; r3-devx P1-4 documents this Windows caveat — tray entry on Win opens the current rotated file directly, not the symlink.) Rationale for `pino-roll` over `pino-rotating-file`: maintained inside the pino org (`pinojs/pino-roll`), supports daily AND size-based rotation in a single transport with file-count cap, native `symlink: true` support, is the option pino's own docs link to first; `pino-rotating-file` is a third-party fork with no recent releases. **Decision: pino-roll.**
+- **Aggregate `<dataRoot>` disk cap (r3-resource X1)**: per-side pino-roll caps `7 × 50 MB = 350 MB` per side, so daemon + electron logs ≤ 700 MB. Add explicit aggregate watchdog: **logs aggregate cap = 500 MB** (warn at 400 MB log line, hard prune oldest rotated files when total `<dataRoot>/logs/*` exceeds 500 MB regardless of pino-roll's per-file count); **crash-dump aggregate cap = 200 MB** (in addition to 30-day retention §6.6.3 — pruned oldest first when exceeded; covers the daemon-crash-loop-pre-supervisor-detection storm case). Watchdog runs at supervisor.start() AND once per pino-roll rotation tick (per r3-sec P1-3). Total `<dataRoot>/` floor for v0.3 ~1 GB (logs 500 MB + crashes 200 MB + corrupt-backups 100 MB × few + data + WAL).
+- **Correlation ID** (obs-MUST-1 + r3-perf CF-2 carve-out): every IPC envelope (§3.4 / §3.4.1) carries a `traceId: ULID` generated renderer-side and propagated through bridge → Connect adapter → handler → log. **`traceId` MUST appear in the binary frame header schema, not just JSON envelopes** (r2-obs P0-2; coordinate edit with frag-3.4.1 §3.4.1.c). Every `logger.info/warn/error` call inside a handler MUST include `{ traceId }`. Daemon-originated events (e.g. `ptyExit` from SIGCHLD, fan-out drop logs, heartbeat ticks) carry the **session's `spawnTraceId`** (set at session create, persisted on session row) so spawn → exit lines correlate (r2-obs OPEN-3). `subscriber-dropped-slow` log line MUST include `{ traceId, sessionId, subscriberId, droppedBytes, ageMs }`. **Hot-path carve-out (r3-perf CF-2)**: per-chunk fan-out write logs are **debug-level only** (suppressed at default `info` level) AND when emitted MUST source `traceId` from the cached `streamId → spawnTraceId` map established at `kind:'open'` (NOT generate or stringify a fresh ULID per chunk). Per-frame info-level logging on PTY hot path is FORBIDDEN — would burn ~1000 ULID-stringifications/s on a noisy session. The 1000+/s budget belongs to per-chunk byte-counters (no traceId).
+- **TraceId validation** (r2-sec P1-S2 + r3-sec CC-2): every accepted envelope's `traceId` is validated server-side against `^[0-7][0-9A-HJKMNP-TV-Z]{25}$` (Crockford ULID alphabet, fixed length); reject + drop on mismatch with `{ event: "traceid-malformed", offenderPid, raw: <first-32-bytes> }` log line. **Validation runs only when `traceId` is present in the header.** For inheriting sub-frames (`stream.kind === 'chunk' | 'heartbeat'`), the traceId is resolved from the `streamId → traceId` map established at `kind: 'open'`; missing inherited mapping is itself a protocol error and closes the stream with `RESOURCE_EXHAUSTED`. Daemon-emitted log lines include both `traceId` (caller-supplied, untrusted, for correlation) and `daemonTraceId` (daemon-generated ULID, authoritative). pino formatter strips `\n\r` from any string field destined for non-JSON destinations to prevent log injection.
+- **Daemon identity in every line** (obs-MUST-4): pino base config = `{ side: 'daemon', v: DAEMON_VERSION, pid: process.pid, boot: bootNonce }` so post-update logs are unambiguous. `boot` is a ULID (r2-obs OPEN-4); field name in the log is `boot` (the camelCase distinction applies to wire field `bootNonce` per r3-fwdcompat CF-2; the pino base log key is `boot` for compactness, with the value being the same ULID).
+- **Secret redaction** (sec-S4 + r2-sec P0-S1 #4 + r3-lockin CF-3): pino `redact` paths ship from day one — `["*.apiKey", "*.token", "Authorization", "Cookie", "ANTHROPIC_API_KEY", "*.payload.value", "env.ANTHROPIC*", "daemonSecret", "installSecret", "pingSecret", "helloNonce", "clientHelloNonce", "helloNonceHmac", "*.secret"]`. The `helloNonce` + `clientHelloNonce` + `helloNonceHmac` paths added per r3-lockin CF-3 + r3-sec P0-1 (HMAC-of-nonce wire shape lock — see §7.2; the legacy `imposterSecret` / `clientImposterSecret` cleartext fields were eliminated by the HMAC-of-nonce handshake and are no longer present anywhere in the wire schema). PTY chunk bodies are NEVER passed to logger; only `{seq, len}`. Vitest hook asserts no `chunk.toString()` appears in any logger call inside `ptyService` (obs-OPEN PII). Lint hook asserts no logger call site ever passes the resolved value of `daemon.secret`.
+- **Dev redact superset** (r2-sec SH1): when `CCSM_DAEMON_LOG_LEVEL === 'debug'`, redact list extends with `["*.value", "*.body", "*.input", "*.req", "*.params"]` to cover broader debug-payload shapes. Documented in frag-3.7 §3.7.6 dev-vs-prod table cross-ref.
+- **Network-FS rejection**: on boot, daemon refuses to start if `<dataRoot>` resolves to a OneDrive / SMB / network mount (rel-OPEN 6). Surface a clear error — pino + WAL on a network FS is data-loss territory.
+- **Canonical reconnect / bridge log key names** (r3-obs P1-2 — explicit list, PUNT to frag-3.7 §3.7.4 for cross-ref): the bridge call lifecycle log lines have FIXED string keys, not free-form. Implementers MUST use these exact strings (no `reconnect-attempted`-style improvisation):
+  - `bridge_call_complete` (every bridge call, success or error)
+  - `daemon_socket_closed`
+  - `daemon_reconnect_attempt` (with `{n, delayMs}`)
+  - `daemon_reconnect_success` (with `{durationMs, queueDrained}`)
+  - `daemon_queue_overflow` (with `{droppedMethod, queueAge}`)
+  - `stream_resubscribe` (with `{sid, fromSeq, fromBootNonce, gap}`)
+  - `crashloop_entered`, `subscribers-closed`, `daemon-shutdown`, `traceid-malformed`, `slsa_verify_failed`, `swap_in_progress` (already named above; listed here for one-stop reference)
+
+#### 6.6.2 Electron-side logger (r2-obs P0-1, P0-4)
+
+The Electron-main logger is a first-class peer of the daemon logger so cross-process trace correlation works without a third tool.
+
+- **Module location**: `electron/log.ts` runs in main only. Renderer `console.error/warn` is forwarded via preload bridge to main when `CCSM_RENDERER_LOG_FORWARD=1` (default ON in dev, OFF in prod for perf — r2-obs OPEN-1). Renderer never writes files directly.
+- **Same `pino-roll` config** as daemon (`{ frequency: 'daily', size: '50M', limit: { count: 7 }, mkdir: true, symlink: true }`) writing to `<dataRoot>/logs/electron-YYYY-MM-DD.log` (with stable symlink `electron.log`).
+- **Base fields**: `{ side: 'electron', v: APP_VERSION, pid: process.pid, boot: electronBootNonce }`. The `side` discriminator is REQUIRED so log aggregation does not collide daemon and electron lines that share `{v, pid, boot}` keys (r2-obs P0-1 explicit fix).
+- **Same redact list** as daemon §6.6.1, PLUS renderer-leaning paths: `["*.url", "*.searchParams", "*.headers", "*.formData"]`.
+- **`pino.final` analog on every Electron-main exit path** (r2-obs P0-4): registered against `app.before-quit`, `app.will-quit`, `process.on('uncaughtException')`, `process.on('unhandledRejection')`, AND the supervisor crash-loop modal "Quit" / "Restart ccsm" button handlers. Without this, the most diagnostic moment (the crash) is lost from the Electron side.
+- **Bridge call lifecycle log lines** (r2-obs P1-3, contract enumeration): every bridge call wrapper emits `logger.info({ traceId, method, durationMs, status }, "bridge_call_complete")` on completion (success or error). Reconnect path emits the canonical set: `daemon_socket_closed`, `daemon_reconnect_attempt {n, delayMs}`, `daemon_reconnect_success {durationMs, queueDrained}`, `daemon_queue_overflow {droppedMethod, queueAge}`, `stream_resubscribe {sid, fromSeq, fromBootNonce, gap}`. Audited via vitest hook (`no-bridge-call-without-completion-log`).
+- **Frag-12 matrix amendment**: row `obs-M2` should be re-rated GREEN as "addressed in §6 (daemon + electron)" rather than the current PARTIAL "addressed in §6". Row `obs-M4` similarly: GREEN with explicit `side: 'electron'` discriminator.
+
+#### 6.6.3 Crash-dump file (r2-obs P1-5, expanded from plan delta line)
+
+- Path: `<dataRoot>/crashes/crash-<isoTs>-<bootNonce>.json` (daemon) and `<dataRoot>/crashes/electron-crash-<isoTs>-<bootNonce>.json` (Electron-main). User-only ACL (0600 / equivalent Win DACL). **Filename components are sanitized via `path.basename(s).replace(/[^A-Za-z0-9._-]/g, '_')` before path concatenation** (r3-sec P1-5 — defense in depth against future ULID-impl swap that emits non-Crockford characters).
+- Schema: `{ side, v, pid, boot, errMessage, errStack, lastTraceIds: [...8], lastSessions: [...20], stats: { rss, heapUsed }, ts }`. Fields are REDACTED via same pino redact list before write — crash dumps must never contain secrets.
+- Retention: 30 days AND aggregate per-side cap 200 MB (r3-resource P1 — see §6.6.1 aggregate cap rule). Pruning runs (a) at `daemonSupervisor.start()` AND (b) once per pino-roll rotation tick (r3-sec P1-3 — covers the case where daemon never restarts because auto-update is OFF default).
+- **NEVER auto-uploaded.** User-driven attach to issue only. (r2-sec T13 row.)
+
+### 6.7 Failure modes (canonical table)
+
+| # | Failure | What user sees | State left valid? | Recovery |
+|---|---|---|---|---|
+| F1 | Daemon crash mid-PTY | xterm freezes; banner | PTY children reaped via §6.2 | Supervisor auto-respawn §6.1; sessions become "paused" §6.3 |
+| F2 | Daemon restart with running sessions | Sessions appear as "Paused — daemon was restarted [Resume]" | SQLite session rows survive; runtime state lost | User-triggered resume with prior `cwd`+`model`+env (§6.3) |
+| F3 | Electron crash mid-PTY | Tray gone; v0.5 web client unaffected | Daemon + PTY survive; replay buffer in daemon RAM | Reopen Electron → `spawnOrAttach` → `ptySubscribe(fromSeq, fromBootNonce)` resumes |
+| F4 | SQLite write interrupted (kill -9) | Next boot opens DB | better-sqlite3 + WAL crash-safe at statement granularity; multi-statement ops MUST be wrapped in `db.transaction()` | WAL replay; explicit transaction wrappers per Task 8/12/13 audit (rel-M3) |
+| F5 | Two-daemon race | N/A (lockfile rejects 2nd) | Lockfile §6.4 is gate; pipe bind is secondary | 2nd daemon exits cleanly with non-zero code |
+| F6 | Local socket hijack | N/A (peer-cred rejects) | §7.M1 ACL + §7.M2 peer-cred enforce same-user boundary | Rejected at adapter; logged with offender PID/SID |
+| F7 | Updater swap mid-rename | Daemon may be unbootable from new binary | `.bak` always present; auto-rollback once | §6.4 step 7 (rollback + modal); crash-loop counter cleared on success (r2-rel P0-R2) |
+| F8 | Update download interrupted | Silent retry next 6h poll | Old binary intact; SHA + SLSA mismatch caught | 3× exponential backoff retry within current poll window |
+| F9 | Bridge call to dead daemon | Banner + error toast (not infinite hang) | `rpcCall` 30s deadline + AbortSignal (rel-M2) | Supervisor heartbeat already firing on dedicated transport (§6.5); `daemon.crashing` IPC fails in-flight calls fast |
+| F10 | Two clients writing same PTY (v0.5 only) | "Another client is typing" banner | v0.3: single-writer lease; v0.5: explicit handoff | Handled at `ptyWrite` lease layer (rel-S6); not a v0.3 ship-blocker |
+| F11 | xterm-headless RAM growth | Daemon RSS climbs with N idle sessions | 10k scrollback hardcoded (`entryFactory.ts:43`); v0.3 hard cap: total headless-buffer RSS ≤ 400 MB → new spawns blocked with clean error (rel S-R7) | Tag idle eviction as v0.4 prereq (res-S3) |
+| F12 | Pino crash-loss | N/A (covered by `pino.final` + drain-ordering §6.6.1) | §6.6 | obs-MUST-2 + r2-obs P0-3 |
+
+### 6.8 User-visible surface registry + uninstall hygiene
+
+**Surface registry (CANONICAL — r3-ux P0-A lock)**: §6.8 is the **single canonical** registry of every modal/toast/banner that v0.3 surfaces, with priority and mutual-exclusion rules. Each fragment that introduces a surface MUST register a row here rather than inventing copy in isolation. Round-2 left two parallel registries (frag-3.7 used tier 1-6 numbering, this fragment uses numeric priority 30/50/70/85/90/100); the dual registries had different rules and overlapping copy. Manager lock: §6.8 wins because (a) richer numeric-priority numbering, (b) explicit stacking rules, (c) owns the supervisor surfaces which are the dominant set. The registry below now includes ALL surfaces (dev-mode reconnect, BridgeTimeout policy, stream-gap, queue-overflow) so frag-3.7 reduces to a cross-ref to §6.8.
+
+| Priority | Surface | Type | Source | Owner i18n key prefix | Suppresses |
+|---|---|---|---|---|---|
+| 100 (top) | Migration in progress | Modal (blocking, non-dismissable*) | frag-8 §8.6 | `migration.*` | All lower |
+| 90 | Installer corrupt (carry-forward from working) | Modal (blocking, prose-only) | §6.1.1 (M2#) | `installerCorrupt` | All lower |
+| 85 | Crash-loop (with/no bak) | Modal (blocking) | §6.1.1 | `daemon.crashLoop` | All lower |
+| 85 | Migration failed (frag-8 §8.6 fatal-error) | Modal (blocking) | frag-8 §8.6 | `migration.modal.failed.*` | All lower |
+| 70 | Daemon unreachable (red banner) | Banner | §6.1.1 | `daemon.unreachable` | Reconnect toast |
+| 30 | Daemon reconnected (recovery confirmation, debounced 5s) | Toast (info, 3s) | §6.1.1 | `daemon.reconnected` | (none) |
+| 30 | Paused-session affordance (carry-forward from working) | Inline UI | §6.3 | `session.state.paused` | (none) |
+
+[manager r7 lock: cut as polish — N6# from r6 feature-parity. §6.8 row count trimmed from 16 → 7 (5 daemon-split-driven rows + 1 migration-in-progress + 1 paused-session inline UI from working). Cut rows: `daemon.healthDegraded` (P=70 yellow miss-1/3), `daemon.healthUnreachable` (collapsed into `daemon.unreachable`), `daemon.rollingBack` (P=70 banner), `daemon.rolledBack` (P=30 toast), `daemon.rollbackFailed` (P=85 modal — collapsed into noBak `daemon.crashLoop`), `daemon.reconnectExhausted` (P=85 modal — collapsed into `daemon.unreachable` banner), `daemon.bridgeTimeouts` (P=70 banner), `daemon.devReconnecting` (P=70 dev-mode banner), `daemon.reconnecting` (P=50 250 ms hold-off toast — log-only at the per-attempt level; user sees `daemon.unreachable` only when reconnects keep failing), `daemon.queueOverflow` (P=50 toast), `daemon.streamGap` (P=30 toast — xterm divider may still render as a renderer-side affordance, but no toast/IPC), `daemon.devBuildError` (P=30 dev toast). The migration "Migration failure (4 variants)" row at P=90 collapsed into a single P=85 `migration.modal.failed.*` row matching frag-8 §8.6 r7 trim canonical i18n key prefix (one fatal-error modal, not 4 copy variants). `[manager r9 lock: r8 devx P0-3 + r8 reliability P1-2 — annotation key updated from stale `daemon.migrationFailed` to canonical `migration.modal.failed.*` matching frag-8 §8.6 owner declaration; prevents tests/i18n/parity.test.ts divergence between implementers reading the row vs the lock annotation]`. One `installerCorrupt` row added at P=90 per M2# (carry-forward from working).]
+
+[manager r7 lock: cut as polish — N4# from r6 feature-parity. The "Close-to-tray onboarding hint (one-shot)" row at P=30 (i18n `tray.closeHint`) is DELETED. Working's existing `closeBehaviorOptions.ask` first-close prompt covers the discoverability concern unchanged; no parallel onboarding moment. The `app_state.close_to_tray_shown_at` SQLite key (formerly mandated by §6.8 + r3 manager arch decision #2 + Task 21 wiring) is also DELETED — no SQLite migration row for it; existing renderer close-prompt logic preserved as-is.]
+
+[manager r7 lock: cut as polish — N8# from r6 feature-parity. The "Daemon stats…" tray menu entry referenced in §6.5 is DELETED as a user-visible surface. Internal `/stats` RPC remains (wire concern, useful for healthz/diagnostic IPC + future v0.4 inspector tooling), but no tray menu growth in v0.3.] `[manager r11 lock: P1 reliability daemon.stats → /stats sweep — internal RPC literal renamed to match canonical SUPERVISOR_RPCS path per §3.4.1.h]`
+
+[manager r7 lock: cut as polish — N1# from r6 feature-parity. The macOS tray menu "Reset CCSM…" / "Reset ccsm…" entry is DELETED entirely from the in-app surface contract below. macOS uninstall = "drag CCSM.app to Trash" + release-notes documentation; no in-app tray entry. PUNT to fixer addressing frag-11 §11.6.2: drop the corresponding "Reset CCSM…" tray-menu item from the macOS uninstall bullet. If a "Reset" entry exists elsewhere as a Settings panel button in working, that's preserved unchanged (M1# settings preserved); only the NEW tray menu entry is cut.]
+
+\* **Migration "non-dismissable" callout (r3-ux P0-B)**: priority 100 is the top of the registry, so the auto-dismiss-on-higher rule (stacking rule 1) NEVER applies to migration — there is no priority >100 surface in v0.3. frag-8 §8.6's "dismissable: false" wording is consistent with §6.8 (priority dominance + no higher priority exists ⇒ effectively non-dismissable). Implementer note: the migration modal has no close button; the only exit is migration completion or one of the failure variants (priority 90, which IS dismissable). No code-level "non-dismissable" flag required — priority is the sole gating mechanism.
+
+**Stacking rules**:
+1. At most ONE blocking modal visible at a time. If a higher-priority modal arrives while a lower one is showing, the lower one is dismissed (and its IPC re-fires when the higher one closes). Migration (priority 100) is the apex and is never dismissed by any other surface.
+2. A blocking modal suppresses all toasts of priority <50.
+3. A banner of priority ≥70 suppresses any toast that targets the same daemon-health event class. Concretely: `daemon.healthDegraded` banner suppresses `daemon.reconnecting` toast.
+4. Toasts of equal priority stack vertically up to 3; oldest is dismissed when a 4th arrives.
+5. Reconnect toast escalates to `daemon.unreachable` red banner once handshake / reconnect attempts pass the supervisor's miss threshold; per the §6.1.1 r7 trim there is no separate `reconnectExhausted` modal (collapsed into the `daemon.unreachable` body copy "If this persists, ccsm may need to be reinstalled.").
+6. **Equal-priority deterministic tie-break (round-7 manager lock — r6 ux P0-2)** `[manager r7 lock: r6 ux P0-2 — equal-priority tie-break = registry insertion order]`: if two surfaces share the same numeric priority, the one registered FIRST in the boot-time registry wins (`Map` insertion order is the deterministic tiebreaker — same-tick later same-priority IPCs are dropped, not queued, and re-fire only if the winning surface is closed AND the underlying state is still active). Insertion order across the v0.3 priority bands matches the row order shown in the §6.8 table above (top-to-bottom = first-to-last). After the r7 row trim the only same-priority bands are P=85 (`daemon.crashLoop` → `daemon.migrationFailed`) and P=30 (`daemon.reconnected` → `session.state.paused`). No per-event sort key is required; the renderer's `useDaemonHealthBridge` consults the registry `Map` directly.
+
+**Single-source IPC** (r2-ux P0-UX-1 architectural fix): all daemon-health events (reconnect, supervisor heartbeat, crash-loop) are emitted on ONE `daemonHealth` IPC channel with a discriminated-union payload `{ kind, severity, ... }`. The renderer has ONE `useDaemonHealthBridge` hook that owns the surface registry lookup and stacking rules. Per-fragment bridges (`useDaemonReconnectBridge`, `usePersistErrorBridge`) are deprecated in v0.3.1 in favor of this consolidation.
+
+**v0.2 → v0.3 close-to-tray onboarding — DELETED in r7** [manager r7 lock: cut as polish — N4# from r6 feature-parity. The one-shot close-to-tray onboarding toast (formerly `tray.closeHint` at P=30) AND the SQLite `app_state.close_to_tray_shown_at` row are DELETED entirely. Working's existing `closeBehaviorOptions.ask` first-close prompt with `dontAskAgain` checkbox already covers the discoverability concern unchanged; no parallel onboarding moment. Renderer-side close-prompt logic preserved as-is — the cut is the NEW onboarding toast, not the existing close-prompt. No Task 21 wiring required for this surface; no app_state migration row required for the SQLite key.]
+
+**Uninstall hygiene** (pkg P0-1 — r3-resource X3 ownership split):
+
+The uninstall path is split between two fragments. **§6.8 owns the in-app daemon-shutdown contract** (the IPC contract used by the NSIS macro to gracefully ask the running daemon to drain). **frag-11 §11.6 owns the on-disk paths and OS installer mechanics** (NSIS macro contents, `.deb postrm`, `.rpm preun`, `nsis.include` wiring, `customUnInstall` macro shape). The two fragments must agree on the daemon-shutdown sequence (kill before lockfile delete) but the canonical implementation lives in frag-11.
+
+In-app surface contract (owned here):
+
+- **macOS tray menu Reset entry — DELETED in r7** [manager r7 lock: cut as polish — N1# from r6 feature-parity. The "Reset CCSM…" / "Reset ccsm…" tray menu entry is DELETED entirely from the in-app surface contract. macOS uninstall is "drag CCSM.app to Trash" + release-notes documentation for `~/Library/Application Support/ccsm/` cleanup; no in-app tray menu growth in v0.3 (tray menu stays at working's `[Show CCSM | Quit]`). PUNT to fixer addressing frag-11 §11.6.2: drop the corresponding "Reset CCSM…" tray-menu item from the macOS uninstall bullet.]
+- **NSIS macro daemon-shutdown sequence (Windows; macro lives in frag-11 §11.6)**: the macro MUST `taskkill /IM ccsm-daemon.exe /F` BLOCKING (wait for exit code) BEFORE removing `<dataRoot>/daemon.lock`; the kill-before-unlock ordering is the contract owned here, the script that implements it lives in frag-11.
+- **Linux postrm/preun**: same kill-before-unlock contract; `systemctl --user stop ccsm-daemon` (if launched as systemd-user-service in v0.3.1) OR `pkill -TERM ccsm-daemon`. Implementation in frag-11 §11.6.
+- **Order matters** (r2-pkg P1-5): kill daemon BEFORE removing lockfile. If the order inverts, a slow daemon shutdown holds the lock past `RMDir`, causing a partial-clean state that confuses the next install. (Contract is canonical here; enforcement lives in frag-11.)
+
+---
+
+## 7. Security
+
+Replaces v1 §7 (which moves to §8 Testing). v1 §7 was 4 lines on testing. New §7 is dedicated security spec.
+
+### 7.1 Trust boundary (v0.3)
+
+**Same machine, same user.** That is the ENTIRE in-scope authentication story for v0.3. Any code path that assumes more (network exposure, multi-user separation beyond the OS) is out of scope until v0.5.
+
+Boundary is enforced by THREE redundant layers (defense in depth, §7.2):
+1. **Transport**: local channel only — Win named pipe `\\.\pipe\ccsm-daemon-<userSid>` or POSIX unix socket `<dataRoot>/daemon.sock`, plus the dedicated supervisor transport (§6.5). **No TCP listener of any kind in v0.3.** Spec §3.1 line "daemon binds 127.0.0.1:7878" is OBSOLETE; the v0.3 daemon never opens an INET socket.
+2. **OS ACL**: pipe / socket / data dir / log dir / lockfile / `.bak` binary / `daemon.secret` all have user-only permissions, set explicitly at create time. Defaults are NOT trusted (sec-M1: Win default pipe DACL grants Everyone in many configs).
+3. **Sender peer credential check**: every accepted connection's peer UID/SID is verified at adapter accept; mismatch → log `{offender_pid, offender_sid}` and immediately drop. (sec-M2.)
+
+### 7.2 Defense in depth
+
+Even after §7.1, the daemon distrusts every byte:
+- **Envelope schema validation** (§3.4.1): every decoded envelope is run through TypeBox `Check()` at the adapter boundary BEFORE any handler dispatch. Schema mismatch → drop + log; never propagate to handlers.
+- **Per-handler arg validation** (r2-sec P1-S1): for `payloadType: 'binary'` frames the trailer is opaque to the adapter; every RPC handler's first statement MUST be `Check(MethodArgsSchema, decoded)` against a per-method byte schema (length cap from header `payloadLen`, optional content sniff like UTF-8 well-formedness for PTY input). ESLint rule `no-handler-without-check` enforces. Coordinate spec edit with frag-3.4.1 §3.4.1.d.
+- **Frame size cap**: `MAX_FRAME = 16 MiB` enforced at the `readUInt32BE` length read (sec-M3). Refusal of oversize frames is logged (`offender_pid`, requested length) for forensic value. Closes the 4 GiB DoS.
+- **Accept-rate cap** (r2-sec T15): `MAX_ACCEPT_PER_SEC = 50` per transport (data + supervisor counted separately). Exceed → drop new accepts with `EAGAIN` for the next 1s; log once per minute aggregate. Eliminates pre-accept connect-flood DoS.
+- **JSON.parse hardening**: no reviver tricks needed (modern V8 is `__proto__`-safe), but every decoded object is shape-validated against TypeBox before being spread into Maps / option bags downstream. Recursion depth implicitly bounded by schema (no unbounded `additionalProperties`).
+- **No shell concatenation**: handler code that spawns CLI subprocesses uses `spawn(cmd, [...args])` — never `exec(template)` with user-provided strings. Lint rule (`no-restricted-syntax` for `child_process.exec` / `execSync`) enforces.
+- **`daemon.secret` lifecycle** (r2-sec P0-S1, comprehensive; r3-sec P0-1 wire shape lock):
+  - **Format**: JSON `{ v: 1, secret: "<base64-32-bytes>" }`, NOT bare bytes (r2-fwdcompat P2-1). v0.4 may ship `{ v: 2, sigstoreBundle: "..." }` or `{ v: 3, derivedSubkeys: ... }` (per r3-fwdcompat P1-6 zero-cost reservation: `v` is a dispatch tag and future values may carry arbitrary additional fields); verifier dispatches on `v`.
+  - **Path** (locked OS-native, all triple-rooted references re-anchored): `%LOCALAPPDATA%\ccsm\daemon.secret` (Win), `~/Library/Application Support/ccsm/daemon.secret` (macOS), `~/.local/share/ccsm/daemon.secret` (Linux). Same `<dataRoot>` as everything else.
+  - **Generator**: Electron-main, NOT daemon, NOT installer. On `spawnOrAttach`, if file is missing or unreadable, Electron generates a fresh 32-byte random, writes via `fs.writeFile(path, JSON.stringify({v:1,secret}), { flag: 'wx', mode: 0o600 })` (POSIX) or Win equivalent CreateFile with `CREATE_NEW` + immediate `SetSecurityInfo` to user-only DACL, then spawns daemon with the secret as `CCSM_DAEMON_SECRET` env var. **Atomic create-with-ACL is required** — the file must NEVER exist with a wider ACL even momentarily (Win `CreateFile` + `SECURITY_DESCRIPTOR` parameter, NOT `CreateFile` then `SetSecurityInfo`).
+  - **Headless / CLI launch carve-out (r3-sec CC-3)**: if env var unset AND file absent AND `process.env.CCSM_DAEMON_HEADLESS === '1'`, daemon may self-generate (one-shot, atomic CREATE_NEW with the same ACL discipline as Electron). Headless mode is dev-only and MUST NOT be set by production Electron; documented as "for debugging tools that want to run the daemon directly without an Electron host." In production, daemon refuses to start if neither env nor file is available — single source of truth = Electron.
+  - **First-boot race**: the lockfile (§6.4) is the gate. Two concurrent Electron-spawned daemons cannot race because only the lock-holder proceeds; the loser exits cleanly.
+  - **Daemon-side**: daemon reads `CCSM_DAEMON_SECRET` env var on boot; if unset, falls back to reading the file. Hardening (r3-sec P1-1 — defense in depth): immediately after read, daemon `delete process.env.CCSM_DAEMON_SECRET` to narrow the `OpenProcess`/`/proc/self/environ` window from "daemon lifetime" to "first ~5ms of boot." Documented as TODO not blocking.
+  - **Rotation**: rotated on every successful auto-update swap (§6.4 step 4) AND on every supervisor-initiated cold restart following crash-loop recovery. Rotation = generate, write `daemon.secret.new`, atomic rename. A known-bad daemon binary that leaked the secret loses authority on the next restart cycle. During rotation window, supervisor pauses `/healthz` HMAC check (`swapInProgress: true` flag, see §6.5 + r3-sec P1-6).
+  - **Env-var caveat** (r2-sec T12): `CCSM_DAEMON_SECRET` lives in the daemon's environment block, readable by any same-user process via `OpenProcess`. This is acceptable because (a) same-user process is OUT OF SCOPE per §7.4 T3 anyway, and (b) the file on disk has the same user-readable property. **Future secrets MUST NOT be passed via env** — the precedent is documented as a one-off for this bootstrap-only secret.
+  - **Imposter check — HMAC-of-nonce challenge-response (r3-sec P0-1 LOCK; supersedes r2 bearer-token form)**: the wire shape is HMAC challenge-response, NOT bearer-token. On every newly-accepted data-path connection:
+    1. Client (Electron's `spawnOrAttach`, after probe-connecting) sends `daemon.hello { clientWire, clientFeatures, clientHelloNonce: "<base64-16>" }`. `clientHelloNonce` is freshly generated per connection (16 random bytes, base64-encoded; ~22 chars on the wire).
+    2. Daemon computes `HMAC-SHA256(daemon.secret, clientHelloNonce)`, **truncates to 16 bytes**, base64-encodes, and replies `{ helloNonceHmac: "<base64-22>", protocol: {...}, compatible }`.
+    3. Client computes the same HMAC with its loaded secret and compares **using `crypto.timingSafeEqual`** (NOT `Buffer.compare` — the `Buffer.compare` form is byte-by-byte and timing-leaks the secret to a co-tenant probing with crafted prefixes).
+    4. Mismatch or absent echo → client treats the listener as imposter, log with `{ offenderPid }`, refuse to talk, fall back to spawning the real daemon under a fresh socket name (Win named-pipe collision: append `-rescue-<ulid>`). Reverse-direction proof (client proves to daemon) is unnecessary because peer-cred + ACL already authenticate the client.
+    5. Bearer-token alternative (where client sends the secret in cleartext on every connect) is **EXPLICITLY REJECTED** (per r3-sec P0-1) — it lands the secret in every TLS-pcap (v0.5 web), every crash dump (despite redact), every `strace` log. HMAC-of-nonce keeps the secret entirely off the wire.
+    Lockfile (§6.4) prevents the imposter scenario from being viable in steady state; this HMAC is belt-and-suspenders for first-boot race + the case where an attacker spawned a malicious binder before Electron started.
+  - **Redaction**: pino redact list (§6.6) includes `daemonSecret`, `installSecret`, `pingSecret`, `helloNonce`, `clientHelloNonce`, `helloNonceHmac`, `*.secret`. Lint hook asserts no logger call site ever passes the resolved secret value. PUNT to frag-3.4.1 §3.4.1.g: align hello payload field names to `clientHelloNonce` + `helloNonceHmac` (NOT a cleartext bearer-secret field, which the redact-glob does not actually catch since pino redact is path-based, NOT substring; r3-lockin CF-3 fix). The legacy `imposterSecret` / `clientImposterSecret` fields were removed entirely by the HMAC-of-nonce handshake.
+
+### 7.3 Supply chain
+
+Phased hardening, locked to release version:
+
+| When | Mechanism | Notes |
+|---|---|---|
+| **v0.3** | (1) SHA256 manifest fetched from same GitHub release; verified before atomic swap. (2) **SLSA-3 build provenance** `provenance.intoto.jsonl` generated by `actions/attest-build-provenance@v1` attached to every release; updater verifies attestation against GitHub's public OIDC root before swap (free, GitHub-native, no sigstore key infra). (3) **Linux** additionally publishes a minisign signature `SHA256SUMS.txt.minisig` (one-time keypair generation, ~30 LOC verifier). (4) Auto-update **DEFAULT OFF** (`CCSM_DAEMON_AUTOUPDATE=1` to opt in). Manual update prompt is the default UX; the manual prompt also runs the SLSA + (Linux: minisign) verification chain. | r2-sec P0-S3. SHA256 alone gives integrity vs network corruption only; SLSA closes the "compromised pipeline forges binary + SHA together" gap because the OIDC token is bound to the workflow file at the moment of signing. v0.3 residual T6 risk drops from HIGH to MEDIUM. |
+| **v0.4** | sigstore / cosign signing in GitHub Actions. Daemon embeds public key at build, verifies signature offline before swap. Auto-update flips DEFAULT ON. SLSA stays on as defense-in-depth. | Eliminates "compromised release pipeline forges both binary and SHA". v0.4 T6 residual: LOW. |
+| **v0.5** | Cloudflare Access JWT validator middleware on the (new) network listener. Seam already present from v0.3 §3.1 (handler chain), wired only when `CCSM_DAEMON_REMOTE=1`. | Out-of-scope threats (algorithm confusion, JWKS rotation, audience pinning, Host-header validation, DNS rebinding) all tracked in `v0.5-security-followups.md`. |
+
+**SLSA verifier (r3-sec P1-4)**: the verifier specified at §6.4 step 2 is `@sigstore/verify` v1.x (MIT, ~2 MB, supported), pinned in daemon dependencies. Trust root = GitHub OIDC public key bundled in daemon binary at build time. Verification call: `verifyBundle(bundle, { trustMaterial, signingPolicy: { workflowFilePath: '.github/workflows/release.yml', repository: 'Jiahui-Gu/ccsm' } })`. Failed verification → abort swap, log `slsa_verify_failed`, schedule retry on next 6h poll. Alternatives rejected: shipping `cosign verify-blob-attestation` binary (~30 MB + license issues); custom OIDC-root verifier (~200 LOC, audit risk).
+
+**Initial-install integrity** (r2-sec P0-S3 second seam): the user's first download of v0.3 is from a GitHub release as a `.exe` / `.dmg` / `.deb`. Win + macOS authenticity comes from signtool + codesign + notarization (frag-11 §11.3). Linux installer authenticity is **explicitly via the same SLSA-3 attestation + minisign** as the auto-update path; the minisign public key is published in the README and pinned in installation docs. This eliminates the "Linux user has no authenticity check on either the installer or the daemon" gap.
+
+**npm dep posture (v0.3)**:
+- Pin exact versions in `package-lock.json` for `@connectrpc/connect*`, `pino`, `pino-roll`, `@sinclair/typebox`, `@yao-pkg/pkg`, `@octokit/rest`, `proper-lockfile`, `better-sqlite3`, `node-pty`. **All daemon runtime deps MUST appear in `daemon/package.json` `dependencies`**, NOT just root (r2-pkg C6 — pkg bundles from daemon's resolved tree, not workspace root).
+- CI step `npm audit --audit-level=high` blocks merge. Explicitly mention `better-sqlite3` family CVEs (r2-sec T16 follow-on to migration `quick_check`).
+- `@yao-pkg/pkg` pinned + reproducible-build CI step (rebuild from source, **SHA-only diff** stored as build artifact — NOT byte-diff between runs, since `pkg --compress GZip` is non-deterministic; r2-pkg P1-4). True reproducibility deferred to v0.4 native SEA, which produces deterministic single-static-link binaries by Node design.
+- New native helper for Win pipe ACL + JobObject + `ccsm_native.node` (§6.2, §7.M1; r3-lockin P0-A: canonical artifact name is `ccsm_native.node`, single .node carrying three exports `winjob` / `pdeathsig` / `pipeAcl` per frag-3.5.1 §3.5.1.1.a NativeBinding swap interface — supersedes the round-2 `winjob.node` filename) is in-tree, code-reviewed, no transitive deps. **Packaging contract** (r2-pkg P0-2 — TAKE coordination): frag-11 §11.1 must rebuild + ship + sign `ccsm_native.node`; this fragment owns the `realpath` + per-`.node`-codesign acceptance criteria. PUNT to frag-11: rename all `winjob.node` references to `ccsm_native.node` (§11.1, §11.2, §11.3, §11.6, before-pack.cjs).
+
+### 7.4 Threat model (post-hardening)
+
+Real markdown table. Rows = attacker capability; columns = mitigation layer + residual risk.
+
+| # | Attacker capability | OS ACL (§7.1.2) | Peer-cred (§7.1.3) | Schema + frame cap (§7.2) | Supply-chain (§7.3) | Residual risk |
+|---|---|---|---|---|---|---|
+| T1 | Other local user, non-admin, same Win/macOS box | DENY (pipe DACL = current SID; socket 0600) | Would also DENY (UID/SID mismatch) | n/a | n/a | None for v0.3 IPC. Still readable: `~/.ccsm` if user accidentally `chmod 755`'d it — explicit `chmod 700` on every create (sec-S3). |
+| T2 | Local admin / root on same box | ALLOW (admin can override ACL) | ALLOW (admin can spoof creds) | Schema still enforced | Could replace daemon binary | OUT OF SCOPE. Admin == game over per OS trust model. Documented. |
+| T3 | Malicious local process running AS the user | ALLOW (same SID/UID) | ALLOW (same UID/SID) | Schema + 16 MiB cap blunt DoS; can still issue legitimate RPCs | n/a | Net-equivalent to v0.2 in-process ipcMain. Documented as accepted: same-user processes can already read user files; daemon RPC adds no new privilege. |
+| T4 | Remote attacker on same LAN / coffee shop Wi-Fi | DENY (no INET listener) | n/a | n/a | Updater hits GitHub over TLS; cert pinning to GitHub roots | Updater MITM only viable with full TLS break + valid GitHub cert. v0.3 SLSA closes pipeline-forge residual. |
+| T5 | Remote attacker, no local foothold | DENY | n/a | n/a | n/a | OUT OF SCOPE for v0.3. v0.5 reopens with CF Access. |
+| T6 | Compromised auto-updater channel (CI key, GitHub Actions, replaced binary + matching SHA) | n/a | n/a | n/a | v0.3: SLSA-3 attestation bound to workflow file via OIDC; (Linux) minisign offline verify; auto-update OFF default. v0.4: sigstore signature verification offline. | v0.3 residual: MEDIUM (was HIGH pre-SLSA). v0.4 residual: LOW. |
+| T7 | Compromised npm transitive dep (typo-squat, takeover) | n/a | n/a | Schema validation can't catch malicious code in deps | npm audit gate, exact pins, reproducible pkg build (SHA-record) | Residual: MEDIUM. Same posture as Electron app today. Add Snyk / OSV-Scanner CI in a v0.4 follow-up. |
+| T8 | Co-tenant process tries pipe DoS (oversize frame, spam connect) | DENY at accept (peer-cred); accept-rate cap pre-accept | DENY post-accept | 16 MiB cap stops memory DoS; 50 acc/s cap stops pre-accept flood (§7.2) | n/a | Residual: LOW. Worst case: daemon spends CPU rejecting at 50/s. |
+| T9 | Local process plants binary at daemon path before Electron spawn | Per-user `%LOCALAPPDATA%\ccsm\bin\` with user-only ACL; `realpath` check at spawn | Imposter-secret check via `daemon.secret` HMAC echo (sec-S2 + §7.2) | n/a | n/a | Residual: NONE if §6.4 path layout honored. Refuses `Program Files` install path explicitly. See T14 for TOCTOU caveat. |
+| T10 | Renderer is XSS'd (e.g. via malicious markdown in a transcript) | n/a (renderer is local) | n/a | Renderer cannot bypass schema; daemon trusts no renderer claim | n/a | Residual: same as v0.2. CSP + no `eval` + sanitized markdown stack unchanged. Tracked separately. |
+| T11 | Secret leakage through logs | n/a | n/a | pino `redact` config (§6.6); PTY chunks never logged | n/a | Residual: LOW. Lint hook asserts no `chunk.toString()` in logger call sites; redact list reviewed each release. |
+| T12 | Process-list / handle-table observer (same-user) | n/a (env block readable by same-user via OpenProcess) | n/a | n/a | n/a | Residual: ACCEPTED. `CCSM_DAEMON_SECRET` env-passing is a one-off bootstrap; documented as not-acceptable for any future secret. Net-equivalent to T3. |
+| T13 | Crash-dump exfiltration | n/a (file ACL 0600 + redact at write time) | n/a | redact list applied to dump fields | n/a | Residual: LOW. Dumps never auto-uploaded; user-driven attach only. Path `<dataRoot>/crashes/`, retention 30 days + 200 MB aggregate cap. (§6.6.3) |
+| T14 | TOCTOU on `realpath` daemon-binary verify | Per-user ACL on `%LOCALAPPDATA%\ccsm\bin\` is the real defense; same-user attacker already controls the path | n/a | n/a | n/a | Residual: ACCEPTED. Same-user attacker = game over for daemon binary, identical posture to v0.2 unsigned scripts. `realpath` check is best-effort, not the gate. |
+| T15 | Co-tenant connect-rate flood pre-accept | DENY at 50 acc/s cap (§7.2) | n/a | n/a | n/a | Residual: LOW. Logged once per minute aggregate. |
+| T16 | Migration `quick_check` parser DoS via attacker-controlled SQLite file | n/a | n/a | n/a (SQLite parser lives below schema layer) | SQLite version pin + npm audit gate covers `better-sqlite3` family CVEs; frag-8 §8.3 path validation (see frag-8 r2 P0-S2 fix) prevents arbitrary-source attack | Residual: LOW once frag-8 enforces canonical-userData-path validation on `legacyDir`. |
+| T17 | Same-user process subscribes with `fromSeq: 0` and pulls full scrollback (incl. pasted secrets in transcript) | ALLOW (same SID/UID — peer-cred passes) | ALLOW (same UID/SID) | n/a | n/a | Residual: **ACCEPTED for v0.3** (r3-sec P0-2). Rationale: single-user single-machine v0.3, the same-user attacker who could mount this attack can also read SQLite directly via `sqlite3 <dataRoot>/ccsm.db` and dump the same data — a per-stream auth token is theatre when the underlying file is user-readable. **Deferred to v0.5 multi-tenant**: subscribe gains a per-session 128-bit `subscribe_token` (random at `createSession`, persisted on session row, required as `headers["x-ccsm-session-token"]`, validated with `crypto.timingSafeEqual`, never logged). v0.5 reopens because CF Tunnel + multi-tenant changes the threat surface; v0.3 single-user keeps token-less for scope. PUNT-CLOSED: not deferred to frag-3.5.1 — explicitly ACCEPTED here. |
+
+### 7.5 Out-of-scope for v0.3 (tracked, not addressed)
+
+Captured in `docs/superpowers/specs/v0.5-security-followups.md`:
+- CF Access JWT correctness (algorithm confusion, JWKS rotation, audience pinning, leeway).
+- CF Tunnel hostname enumeration; drive-by GitHub-OAuth phishing on Pages domain.
+- DNS rebinding against any future loopback INET listener; `Host` header validation.
+- Multi-client conflict resolution beyond single-writer lease (rel-S6).
+- iOS App Store framing (v0.6+, deferred per F3 spike).
+- Stream heartbeat traffic-analysis surface (r2-sec SH5): the 30s heartbeat reveals user-online status to a passive CF Tunnel observer; tunable in v0.5.
+- GPG / minisign signing of `SHA256SUMS.txt` (currently SLSA-attested only).
+- macOS keychain unlock CI hardening (r2-sec SH2): move `KC` password to `secrets.MACOS_KEYCHAIN_PW` rather than fixed `actions` literal.
+- `signtool verify /pa /v` post-sign assertion in CI (r2-sec SH3).
+
+---
+
+## Plan delta
+
+Specific edits to `docs/superpowers/plans/2026-04-30-v0.3-daemon-split.md`:
+
+- **Task 1** (daemon workspace skeleton, +5h): add `pino.final` registration, `pino-roll` transport config (daily / 50MB / 7-file limit), `redact` paths (including secret keys), base config (v + pid + boot ULID + side='daemon'). Acceptance: smoke test crashes daemon with `process.exit(1)` after a buffered log write and asserts the line is on disk.
+- **Task 4** (local channel listener, +6h): native helper (N-API or `koffi`) for Win `CreateNamedPipeW` with explicit DACL = current SID + `PIPE_REJECT_REMOTE_CLIENTS`; POSIX `umask(0077)` + `chmod 0600` on socket node; lockfile via `proper-lockfile`. Acceptance: cross-user access denied test (manual repro doc + scripted same-user negative test). **Plus:** dedicated supervisor transport (`ccsm-control` socket per §3.4.1.h table), separate accept loop, same ACL discipline. `[manager r11 lock: P1 devx P1-2 socket name canonical = ccsm-control; was `-sup` suffix]`
+- **Task 5** (Connect adapter, +3h): MAX_FRAME = 16 MiB enforcement at length read; TypeBox `Check()` at adapter boundary before handler dispatch; `traceId` field added to envelope schema (JSON + binary header) and validated against ULID regex; propagated through.
+- **Task 5** (also, +2h): `rpcCall` 30s default deadline + AbortSignal support; `daemon-unhealthy` event surface; 50 acc/s rate cap.
+- **Task 5** (also, +1h, r2-sec P1-S1): per-handler `Check(MethodArgsSchema, decoded)` boilerplate + ESLint rule `no-handler-without-check`.
+- **Task 5** (also, +1h, r2-fwdcompat P0-2): `daemon.hello` handshake RPC; daemon refuses other RPCs until hello completes; `compatible: false` with clean error code.
+- **Task 6** (daemon entry, +2h): peer-cred check on accept (`SO_PEERCRED` / `getpeereid` / `GetNamedPipeClientProcessId`); imposter-secret HMAC echo verify on hello; reads `CCSM_DAEMON_SECRET` env first, file fallback, refuse if neither.
+- **NEW Task 6a** (supervisor, +8h was +6h): backoff state machine (1s→30s cap, reset @60s stable, reset on rollback success), crash-loop detection (5/2min, reset on rollback success, dev-mode disabled), heartbeat poller (5s prod / 30s dev, 3-miss prod / 5-miss dev), dedicated supervisor transport client, banner IPC events on consolidated `daemonHealth` channel, single `useDaemonHealthBridge` hook, surface registry stacking enforcement, 250ms reconnect-toast hold-off, N=15 escalate-to-modal. Owns the `daemonSupervisor` module in Electron-main.
+- **NEW Task 6b** (last-known-good rollback, +4h was +3h): `daemon.exe.bak` retention, atomic `MoveFileExW` swap, single-shot auto-rollback on cold-start failure within 30s, "successful rollback" 60s+5×ping verification, crash-loop window decay + backoff counter clear on success per r3-rel R2, `daemon.rolledBack` IPC + toast.
+- **NEW Task 6c** (Electron-side logger + crash-imminent IPC, +3h, r2-obs P0-1, P0-3, P0-4, S-R1): `electron/log.ts` mirroring daemon pino-roll/redact/base config (with `side: 'electron'`), `pino.final` on `app.before-quit` / `uncaughtException` / `unhandledRejection` / supervisor "Quit" handlers, bridge call-completion log lines with vitest hook, optional renderer-console forward gated by `CCSM_RENDERER_LOG_FORWARD`, daemon-side drain ordering (state='draining' → clear timers → aggregate-shutdown lines → wal_checkpoint → close → pino.final), `daemon.crashing` IPC emission before pino.final.
+- **NEW Task 6d** (cold-start splash + UX copy + paused affordance, +3h, r2-ux P0-UX-3, P1-UX-5, P1-UX-6): `Starting ccsm…` HTML pre-mount loader; supervisor-state copy table from §6.1.1 wired in; "Paused — daemon was restarted [Resume]" affordance with explicit "previous turn discarded" copy; `app_state.close_to_tray_shown_at` first-close toast.
+- **Task 8/12/13** (lifted services, +2h each): audit every multi-row write, wrap in `db.transaction(() => …)`. Reviewer must check all compound-write call sites. Add explicit `PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;` at every db open path.
+- **Task 11** (lift ptyService, +5h was +4h): JobObject (Win) + `setpgid`/`PR_SET_PDEATHSIG` (POSIX) for orphan reaping; SIGCHLD handler scoped to PIDs in our `pid → sessionId` map (r2-rel P1-R5 — `waitpid(pid, WNOHANG)` per known PID, NOT `waitpid(-1)`); single-writer `ptyWrite` lease; explicit fan-out subscriber model documented (shared registry, drop-slowest under backpressure ≥1 MB); 400 MB total headless-RSS cap with new-spawn block (rel S-R7); shutdown sequence per §6.6.1 step 5.
+- **Task 11c** (ptySubscribe, +1h): `traceId` propagation; per-subscriber state == OS socket buffer only (no per-client backlog); `bootNonce` in subscribe + delta envelopes; `bootChanged: true` response on nonce mismatch.
+- **Task 7** (Electron handshake e2e, +3h was +2h): adds `/healthz` ping + 1000-ping latency benchmark (target p95 < 5ms) on dedicated supervisor transport; imposter-secret negative test; `daemon.hello` handshake test; `bootNonce` mismatch resubscribe test.
+- **NEW Task 23a** (updater hardening, +6h was +4h): download-to-`.partial` + 3× exponential backoff; SHA256 verify; **SLSA-3 provenance verify against GitHub OIDC root**; **Linux: minisign verify**; atomic rename; **`daemon.secret` rotation step BEFORE binary swap**; auto-update DEFAULT OFF (env-gated); manual update prompt UX runs same verification chain.
+- **Task 23** (updater core, ±0h): rejection of legacy "spawn batch script" pattern; documented rationale.
+- **NEW Task 23b** (release-side SLSA + minisign, +4h, r2-sec P0-S3): GitHub Actions step `actions/attest-build-provenance@v1`; minisign keypair generation + signature step (Linux release matrix); publish `provenance.intoto.jsonl` + `SHA256SUMS.txt.minisig` as release assets; document minisign public key in README + install docs.
+- **Task 25** (dogfood gate, +2h): RAM target restated as "daemon RSS excluding child processes <120 MB with 5 sessions; daemon + all children <500 MB" (res-MUST-3); benchmark suite added (obs-S9); crash-dump file written on `process.exit(1)` paths per §6.6.3 schema.
+- **NEW Task 26** (security verification, +4h): cross-user access denial repro (manual + scripted); secret-redaction lint hook; `npm audit --audit-level=high` CI gate; reproducible pkg-build SHA-record CI step (NOT byte-diff); `daemon.secret` lifecycle e2e (atomic create-with-ACL, rotation on update, env-var precedence).
+- **NEW Task 27** (threat-model + followups doc, +3h was +2h): commit `docs/superpowers/specs/v0.5-security-followups.md` with §7.5 contents pre-populated.
+- **NEW Task 28** (uninstall hygiene, +5h, pkg P0-1 TAKE — coordinate with frag-11 implementation): `build/installer.nsh` `customUnInstall` macro per §6.8 contract; `nsis.include` wiring in `package.json`; `.deb postrm` + `.rpm %preun` scripts; macOS tray `Reset ccsm…` action (typed-confirm); release notes section. Order-of-operations enforcement: kill daemon → delete lockfile → checkbox dialog → conditional RMDir.
+
+**Total estimated delta**: +71h on top of v1 plan (~125h → ~196h, was +44h before round-2). Round-2 added ~27h (see prior round entries). **Round-3 adds ~6h** of pure spec/contract clarifications (no new task budget):
+- §6.1 dev-mode supervisor wording reconciliation, crash-loop counter decay rule (R2 revised) — 0h, prose only.
+- §6.6.1 drain order R1 reorder (subscriber close moves AFTER SIGCHLD wind-down + DB writes) — Task 6c +1h re-test.
+- §6.6.1 hot-path traceId carve-out + canonical reconnect log key list — 0h, lint-rule update only.
+- §6.6.1 + §6.6.2 pino-roll `symlink: true` (devx CF-1 + resource X2) — 0h config.
+- §6.6.1 aggregate `<dataRoot>` disk caps (logs 500 MB, crashes 200 MB) — Task 25 +1h watchdog.
+- §6.4 boot order lockfile-before-ensureDataDir + swap-lock (P0-R4 + P1-R5) — Task 6b +1h.
+- §6.5 `bootNonce` camelCase + `daemonProtocolVersion` mirror + `daemonAcceptedWires` + `swapInProgress` + `healthzVersion` — Task 7 +1h e2e for new fields.
+- §7.2 HMAC-of-nonce wire-shape lock (sec P0-1, supersedes bearer-token) + `crypto.timingSafeEqual` + headless carve-out + env-var clear hardening — Task 6 +2h (replaces bearer-token plumbing with HMAC + nonce gen + redact additions).
+- §7.3 SLSA verifier `@sigstore/verify` pin (sec P1-4) — Task 23a +0.5h dep add.
+- §7.4 T17 fromSeq ACCEPTED row — 0h, prose.
+- §6.8 surface registry canonicalization + camelCase i18n keys + close_to_tray timestamp lock + uninstall ownership split — 0h prose.
+- §7.3 `winjob.node` → `ccsm_native.node` rename (lockin P0-A) — Task 11 +0h here, but coordinate frag-11 + frag-3.5.1.
+
+Round-3 net spec-edit: +6.5h budget growth, all on existing tasks. All additions are blocking for v0.3 freeze per the cited round-3 reviews.
+
+---
+
+## Cross-frag rationale
+
+This is the highest-load fragment in round-2. Many cross-fragment P0s land here because the §6/§7 owner is the natural place for daemon-lifecycle + secret-lifecycle + user-visible-failure-surface contracts. Decisions on what to TAKE vs PUNT:
+
+**TAKEN (this fragment is the right owner):**
+
+1. **Uninstall hygiene** (pkg P0-1) — `build/installer.nsh` lives in `frag-11` mechanically (NSIS is electron-builder territory) but the *contract* (which paths to remove, daemon shutdown sequence, lockfile cleanup, kill-before-unlock ordering) is a daemon-lifecycle + lockfile concern owned by §6.4 / §6.8. Frag-11 implements; this fragment specifies. See §6.8 "Uninstall hygiene" + Plan delta NEW Task 28.
+
+2. **Cross-fragment surface registry** (ux P0-UX-1) — every modal/toast/banner emitted by v0.3 is registered in §6.8 with priority + mutual-exclusion rules. Lives here because the dominant surfaces (crash-loop, rollback, heartbeat, paused, BridgeTimeout) all originate from supervisor / reliability paths. Frag-3.7 and frag-8 reference back instead of inventing copy in isolation.
+
+3. **`daemon.hello` + protocol block** (fwdcompat P0-2) — version handshake payload lives in §6.5 alongside `/healthz` because both are version-negotiation surfaces emitted by the same daemon module. Frag-3.4.1 owns the wire shape + the handshake-as-first-envelope rule; this fragment owns the payload schema + behavioral rule (refuse other RPCs until hello).
+
+4. **Electron-side logger** (obs P0-1, P0-4) — pino mirroring is conceptually two-process logging which spans the boundary owned by §6.6. Frag-6-7 already owned daemon-side `pino.final` so the Electron-side complement belongs here for spec cohesion. Plan delta Task 6c implements.
+
+5. **`daemon.secret` lifecycle** (sec P0-S1) — secret generation/rotation/redact is a security concern owned by §7.2; lockfile coordination is owned by §6.4; both interact at first-boot race. Single source-of-truth in §7.2 with §6.4 step 4 cross-referencing the rotation step.
+
+6. **SLSA + Linux minisign** (sec P0-S3) — supply-chain integrity is owned by §7.3. Frag-11 implements the GitHub Actions release steps (NEW Task 23b coordinates); this fragment owns the verifier contract.
+
+7. **Drain ordering for log producers** (obs P0-3) — extends `pino.final` semantics owned by §6.6 with producer-side timer/queue lifecycle. Lives in §6.6.1.
+
+8. **Crash-loop counter reset, dev-mode supervisor, dedicated /healthz transport, shutdown SIGCHLD ordering** — all daemon-lifecycle concerns naturally owned by §6.1/§6.4/§6.5/§6.6.
+
+**PUNTED (other fragments are the right owner):**
+
+1. **`traceId` in binary frame header** (obs P0-2) — wire shape owned by frag-3.4.1 §3.4.1.c. This fragment §6.6 specifies the validation rule + ULID regex but the field-list edit is frag-3.4.1's. Cross-referenced.
+
+2. **`bootNonce` in stream subscribe + `bootChanged: true`** (fwdcompat P1-1) — stream RPC contract owned by frag-3.5.1 §3.5.1.4 + frag-3.7 §3.7.5. This fragment §6.5 defines `boot_nonce` as ULID + advertises it via `/healthz` + Plan delta Task 11c notes propagation, but the schema edit lives in those fragments.
+
+3. **`fromSeq` session-token authentication** (sec P1-S3) — subscribe authorization owned by frag-3.5.1. Mentioned in Plan delta Task 11c contract but not specified here.
+
+4. **Migration env-var trust validation** (sec P0-S2) — migration logic owned by frag-8 §8.3. Threat-model row T16 in §7.4 cross-references the dependency.
+
+5. **Migration partial-write recovery + `.migrating` cleanup** (rel P0-R4) — owned by frag-8 §8.3 startup logic. T16 row notes the dependency.
+
+6. **Per-handler arg validation rule** (sec P1-S1) — wire-level contract owned by frag-3.4.1 §3.4.1.d. §7.2 names the rule + ESLint rule name; the spec edit happens in frag-3.4.1.
+
+7. **CI Node 22 bump, winjob.node packaging, `--compress GZip` reproducibility** — packaging concerns owned by frag-11. §7.3 names the SHA-record approach (P1-4 resolution); frag-11 implements.
+
+8. **Renderer XSS hardening, CSP, sanitized markdown** — UI-layer concerns. T10 row in §7.4 cross-references but does not own.
+
+9. **Reconnect queue retry-forever escalation** (ux P1-UX-1) — frag-3.7 §3.7.4 owns the queue. §6.1.1 supplies the modal copy; frag-3.7 wires the N=15 trigger.
+
+10. **dev-mode reconnect toast vs supervisor banner duplication** (ux P1-UX-4) — surface registry §6.8 resolves at the contract level (banner suppresses toast); frag-3.7 implements the suppression check.
+
+---
+
+## Cross-frag rationale — Round 3 additions
+
+**TAKEN in r3 (this fragment is right owner):**
+
+R3-T1. **Surface registry canonicalization** (r3-ux P0-A) — §6.8 is now the SINGLE canonical registry; every surface formerly proposed in frag-3.7 (dev-mode reconnect surface, dev build error toast, all stacking rules consolidated) has been merged in. frag-3.7's parallel registry is collapsed into a one-paragraph cross-ref to §6.8.
+
+R3-T2. **Drain order R1 reorder** (r3-rel R1) — SIGCHLD wind-down + DB terminal-state writes happen BEFORE subscriber close in §6.6.1 step list; subscriber-close is the LAST runtime act before pino.final. Lives here because §6.6.1 is the canonical shutdown sequence.
+
+R3-T3. **Crash-loop counter decay rule** (r3-rel R2) — rollback success clears backoff counter but DECAYS crash-loop window (rolled-back crash counts as 3/5, not full clear). §6.1 + §6.4 step 7. "Limp mode" rationale.
+
+R3-T4. **`daemon.crashing` IPC explicitly best-effort** (r3-rel R5) — §6.6.1 spells out that the IPC fires only on Node-observable death paths (uncaughtException etc.); on SIGKILL no IPC. Renderer must use socket-close + healthz-fail as primary signal.
+
+R3-T5. **HMAC-of-nonce hello wire shape locked** (r3-sec P0-1) — §7.2 mandates HMAC-SHA256(secret, clientHelloNonce) truncated to 16 bytes, `crypto.timingSafeEqual` compare. Bearer-token form REJECTED. PUNT to frag-3.4.1 §3.4.1.g hello payload to align field names (`clientHelloNonce` + `helloNonceHmac`, drop `clientImposterSecret`).
+
+R3-T6. **fromSeq subscribe-token ACCEPTED for v0.3** (r3-sec P0-2) — §7.4 T17 row added; deferred to v0.5 multi-tenant. NOT punted to frag-3.5.1 — explicitly accepted here as v0.3 single-user-single-machine residual. Rationale: same-user attacker can `sqlite3` the file directly anyway.
+
+R3-T7. **Aggregate `<dataRoot>` disk caps** (r3-resource X1) — §6.6.1 specifies logs aggregate 500 MB + crashes aggregate 200 MB watchdogs. Was punted by frag-3.5.1 to "frag-8 + frag-6-7 §6.6"; frag-6-7 picks it up (frag-8 owns corrupt-backups separately).
+
+R3-T8. **`bootNonce` camelCase lock** (r3-fwdcompat CF-2) — §6.5 healthz emits `bootNonce` (was `boot_nonce`); aligned with rest of envelope. PUNT to frag-3.7 to align any `response.boot_nonce` reads to `response.bootNonce`.
+
+R3-T9. **`daemonProtocolVersion` mirrored in /healthz protocol block** (r3-lockin CF-2) — was only in frag-3.4.1 §3.4.1.g hello reply; supervisor `/healthz` protocol block now also carries the integer so post-update protocol-version mismatch is detectable on long-lived attach.
+
+R3-T10. **`clientImposterSecret` + `helloNonce` redact paths** (r3-lockin CF-3) — §6.6 redact list extended; pino redact is path-based (not substring) so explicit paths required.
+
+R3-T11. **Uninstall ownership split** (r3-resource X3) — §6.8 owns in-app surface (tray "Reset ccsm…", IPC contract); frag-11 §11.6 owns disk paths + NSIS macro / postrm / preun script bodies. Was double-claimed; r3 splits cleanly.
+
+R3-T12. **close_to_tray timestamp key lock** (r3-resource X4 + r3-ux CC-1) — §6.8 locks `app_state.close_to_tray_shown_at` (timestamp); rejects frag-3.7's boolean `close_to_tray_hint_shown`. Timestamp is more useful for "shown N days ago" hint.
+
+R3-T13. **i18n key casing camelCase lock** (r3-ux CC-3) — `daemon.crashLoop`, `daemon.healthDegraded`, `daemon.bridgeTimeouts`, `daemon.reconnectExhausted`, etc. Aligns with frag-3.7's existing camelCase. PUNT to frag-3.7 to verify; PUNT to frag-8 to align `migration.*` keys.
+
+R3-T14. **BridgeTimeout policy locked** (r3-devx CF-3 + r3-ux CC-4) — §6.1.1 last paragraph: never user-surfaced as per-call toast; bridge wrapper retries once internally; aggregates into `daemon.bridgeTimeouts` banner at ≥3/10s; "reconnecting…" toast is the only continuous user signal. PUNT to frag-3.5.1 §3.5.1.3 to add carve-out sentence.
+
+R3-T15. **Dev-mode supervisor wording reconciliation** (r3-devx CF-3) — §6.1 second bullet now explicitly: lifecycle DISABLED in full, but `ccsm-control` transport STILL BOUND for diagnostic UI poll. Resolves apparent contradiction with frag-3.7 §3.7.6.a "Supervisor active? NO" — both are now consistent: lifecycle off, read-only poll on. `[manager r11 lock: P1 devx P1-2 socket name canonical = ccsm-control; was `-sup`]`
+
+R3-T16. **Supervisor transport = control-socket clarification** (r3-perf CF-1) — §6.5 explicitly states the `ccsm-control` socket IS the same channel as frag-3.4.1 §3.4.1.h's "control-socket". ONE control plane, single canonical name. `[manager r11 lock: P1 devx P1-2 socket name canonical = ccsm-control across both fragments; was `-sup` alias]`
+
+R3-T17. **Hot-path traceId carve-out** (r3-perf CF-2) — §6.6.1 explicit rule: per-chunk fan-out logs at debug level only; when emitted, source `traceId` from cached `streamId → spawnTraceId` map (NOT generate fresh ULID per chunk). Per-frame info-level logging on PTY hot path is FORBIDDEN.
+
+R3-T18. **OS-native paths re-anchored everywhere** (manager arch lock) — all `~/.ccsm/` references in §6.4, §6.5, §6.6, §6.6.3, §7.1, §7.2 replaced with `<dataRoot>` notation; concrete OS-native paths in tables. Daemon binary path triple-rooted (`%LOCALAPPDATA%\ccsm\bin\` Win, `~/Library/Application Support/ccsm/bin/` mac, `~/.local/share/ccsm/bin/` Linux) explicitly re-stated in §6.4 and §7.2.
+
+R3-T19. **SLSA verifier pinned to `@sigstore/verify`** (r3-sec P1-4) — §7.3 specifies the verifier library + trust root + verify call shape. Cosign-binary alternative explicitly rejected.
+
+**PUNTED in r3 (other fragments must align):**
+
+R3-P1. **frag-3.7 surface registry collapsed** (r3-ux P0-A) — §6.8 now canonical. frag-3.7's former parallel registry is replaced with `see frag-6-7 §6.8` cross-ref; do not maintain a parallel registry.
+
+R3-P2. **frag-3.5.1 §3.5.1.2 step 8 terminal state** (r3-rel R3) — drop `state='abandoned'`; use `state='paused'` for SIGKILL'd survivors. Single canonical terminal-name across both fragments.
+
+R3-P3. **frag-3.5.1 §3.5.1.3 BridgeTimeout carve-out** (r3-devx CF-3) — add the sentence "BridgeTimeoutError is logged with `DEADLINE_EXCEEDED` but NEVER surfaced to the user; surfacing owned by §6.8 / §6.1.1 banner aggregation."
+
+R3-P4. **frag-3.4.1 §3.4.1.g hello payload field names** (r3-sec P0-1 + r3-lockin CF-3) — rename `clientImposterSecret` → `clientHelloNonce` (16-byte nonce, not the secret); add `helloNonceHmac` reply field; document HMAC-of-nonce challenge-response per §7.2 wire shape lock.
+
+R3-P5. **frag-3.4.1 §3.4.1.h control-socket name unification** (r3-perf CF-1) — single canonical name `ccsm-control` across both fragments; ONE control plane shared with §6.5. `[manager r11 lock: P1 devx P1-2 socket name canonical = ccsm-control; was `-sup` alias on frag-6-7 side]`
+
+R3-P6. **frag-3.7 §3.7.5 `boot_nonce` reads → `bootNonce`** (r3-fwdcompat CF-2) — silent `undefined`-read bug if not aligned.
+
+R3-P7. **frag-3.7 §3.7.4 reconnect log key names** (r3-obs P1-2) — implementer must use the canonical strings listed in §6.6.1; one-line cross-ref to §6.6.1 in §3.7.4.
+
+R3-P8. **frag-3.7 close_to_tray key** (r3-resource X4) — align to `close_to_tray_shown_at` timestamp.
+
+R3-P9. **frag-12 stale OPEN rows** (r3-ux P0-C) — re-grade fwdcompat 3.1 / 3.3, packaging M4, ux M2, obs-M2 / obs-M4, and add 3 new rows for r2-obs P0-1/P0-3/P0-4. Frag-12 owns this re-audit; this fragment cannot edit it.
+
+R3-P10. **frag-11 native artifact rename** (r3-lockin P0-A) — `winjob.node` → `ccsm_native.node` across §11.1 / §11.2 / §11.3 / §11.6 / before-pack.cjs.
+
+R3-P11. **frag-11 §11.6.2 macOS Reset CCSM**: use `shell.trashItem` (gentle, undoable) — not unlinkSync nor typed-confirm word-gate. Aligned with §6.8 in-app contract.
+
+R3-P12. **frag-3.4.1 daemonHelloHmac sec edit + traceId on chunk inheritance** (r3-sec CC-2 + r3-perf P1-1 fixed-width seq) — frag-3.4.1 owns the wire schema edits; §6.6 here owns the validation + redact.
+
+R3-P13. **frag-8 migration i18n keys camelCase** (r3-ux CC-3) — `migration.modal.*` etc. align to camelCase.
+
+<!-- END frag-6-7-reliability-security.md -->
+
+---
+
+<!-- BEGIN frag-8-sqlite-migration.md -->
+
+# Fragment: §8 SQLite migration story (v0.2 → v0.3)
+
+**Owner**: worker dispatched per Task #937
+**Target spec section**: new §8 in main spec (after §7 security)
+**P0 items addressed**: MUST-1 from `~/spike-reports/v03-review-ux.md` ("v0.2 → v0.3 SQLite migration is unspecified — every session, every title, every setting gone")
+
+---
+
+## 8. Data migration: v0.2 → v0.3
+
+### 8.1 What v0.2 actually writes (grounded)
+
+Source-of-truth grep on `working` tip: the only Electron call to
+`app.getPath('userData')` lives in `electron/db.ts:124`. Every other
+v0.2 persistence path either targets the user's CLI dir (`~/.claude/...`,
+owned by Claude CLI, not by ccsm) or is in-memory.
+
+ccsm-owned files inside `userData`:
+
+| File | Producer | Notes |
+|---|---|---|
+| `ccsm.db` | `electron/db.ts:126` (`new Database(path.join(dir, 'ccsm.db'))`) | Single SQLite database. Schema = one table, `app_state(key TEXT PRIMARY KEY, value TEXT, updated_at INTEGER)` (`db.ts:43-49`). `PRAGMA user_version = 1` (`db.ts:17`). |
+| `ccsm.db-wal` | better-sqlite3 in WAL mode (`db.ts:130`) | Sidecar. May contain uncheckpointed writes. |
+| `ccsm.db-shm` | better-sqlite3 in WAL mode | Shared-memory index for the WAL. |
+| `ccsm.db.corrupt-<ts>` | `db.ts:96` | Backup created when `quick_check` fails. Treat as user-owned forensic file — copy if present, do not open. |
+
+`userData` resolves per Electron docs to (verified against
+`package.json:5` `productName: "CCSM"` and `:113` `appId: com.ccsm.app`):
+
+- **Win**: `%APPDATA%\CCSM\` → typically `C:\Users\<user>\AppData\Roaming\CCSM\`
+- **macOS**: `~/Library/Application Support/CCSM/`
+- **Linux**: `~/.config/CCSM/` (XDG)
+
+Dev installs use `productName "CCSM Dev"` / `appId com.ccsm.app.dev`
+(`package.json:31`) → `%APPDATA%\CCSM Dev\` etc. Migration MUST honor
+the same product-name suffix that the running Electron build was
+configured with — see §8.4 for handoff.
+
+There are NO other ccsm-owned files in `userData` today. `electron/memory.ts`
+writes only to `~/.claude/CLAUDE.md` (CLI-owned, untouched by upgrade).
+`electron/sessionTitles/**` round-trips through the SDK to
+`~/.claude/projects/<key>/<sid>.jsonl` (CLI-owned, untouched). `electron/prefs/**`
+(closeAction, crashReporting, notifyEnabled, userCwds) all persist via
+`saveState`/`loadState` → rows in the same `app_state` table inside
+`ccsm.db`. So the migration surface is exactly **one .db file plus its
+two WAL sidecars**, and the v0.2-corrupt-backup as a courtesy copy.
+
+### 8.2 Target location (v0.3) — OS-native data root
+
+`<dataRoot>` is OS-native per frag-11 §11.6: `%LOCALAPPDATA%\ccsm\` on
+Windows, `~/.local/share/ccsm/` on Linux, `~/Library/Application
+Support/ccsm/` on macOS. v0.2 → v0.3 migration moves data from legacy
+`~/.ccsm/` to `<dataRoot>`; see §8.3 step 1.
+
+[manager r5 lock: `<dataRoot>` placeholder, frag-11 §11.6 is single
+source of truth; reason: install path locked to `%LOCALAPPDATA%` in r3
+to avoid UAC, all sibling paths follow.]
+
+**Rationale (round-3 arch lock, round-5 dataRoot reconciliation)**:
+v0.2 used the cross-platform `~/.ccsm/` location for both daemon
+runtime files and (via Electron's `userData`) the database. v0.3
+consolidates everything daemon-owned — database, logs, crash dumps,
+lockfile, `daemon.secret`, migration markers, corrupt-backups — under
+the single OS-native `<dataRoot>` defined by frag-11 §11.6. This
+matches v0.3's install path policy (installer drops binaries under the
+same per-user OS-native root; data follows the same convention so
+backup tools, antivirus exclusion lists, and MDM policies behave
+predictably) and eliminates the three-way `<dataRoot>` permutation
+flagged in r4 packaging review.
+
+Daemon owns the data root at (per frag-11 §11.6 paths table):
+
+- **Windows**: `%LOCALAPPDATA%\ccsm\` → typically `C:\Users\<user>\AppData\Local\ccsm\`
+- **macOS**: `~/Library/Application Support/ccsm/`
+- **Linux**: `~/.local/share/ccsm/` (frag-11 §11.6 fixed this row to the per-user
+  OS-native root; `$XDG_DATA_HOME` is not consulted, matching frag-11)
+
+Inside that root (subset relevant to migration; full table in frag-11
+§11.6):
+
+- `<dataRoot>/data/ccsm.db` — the database
+- `<dataRoot>/data/migration-state.json` — the migration marker (§8.5 S8)
+- `<dataRoot>/data/ccsm.db.corrupt-*` — quick_check corrupt-backups (carried
+  over from legacy by §8.5 S7)
+- `<dataRoot>/data/ccsm.db.migrating[-wal][-shm]` — transient migration tmp
+  (cleared by §8.3 step 1a)
+- `<dataRoot>/logs/daemon.log` — pino-roll output (owned by frag-6-7 §6.6)
+- `<dataRoot>/crashes/` — crash dumps (owned by frag-6-7 §6.6.3)
+- `<dataRoot>/daemon.lock` — daemon-singleton lockfile (owned by frag-6-7 §6.4)
+  [manager r11 lock: lockfile name unified to daemon.lock per frag-6-7 majority; r10 devx P1-3]
+
+Throughout the rest of this fragment, `<dataRoot>` refers to whichever
+of the three OS-native paths above resolves on the current platform.
+The implementation MUST use the same per-OS resolver as the installer
+(frag-11 §11.6) and MUST NOT hard-code `~/.ccsm/...` for any v0.3 path.
+The legacy `~/.ccsm/...` paths were interim round-1/round-3 placeholders
+and are **no longer used** in v0.3; they appear in §8.3-§8.8 only as
+v0.2 migration sources.
+
+Filename stays `ccsm.db` (NOT renamed to `sessions.db` or `ccsm.sqlite` —
+both appear as guesses in the v1 stub and the UX report; the on-disk
+truth is `ccsm.db`).
+
+**Note on the legacy v0.2 source path**: v0.2 itself stored
+`ccsm.db` in Electron's `userData` (per-product-name path under
+`%APPDATA%\CCSM\`, `~/Library/Application Support/CCSM/`, `~/.config/CCSM/`).
+That is the **migration source** path resolved by §8.4
+`resolveLegacyDir()`. The v0.2 `~/.ccsm/` directory (added late in
+v0.2 for the daemon socket only — pre-database-move) never contained
+user data and is not a migration source candidate.
+
+### 8.3 Migration trigger (daemon first-boot)
+
+The daemon, on every boot, runs `ensureDataDir()` BEFORE
+`new Database(...)`. **Lockfile ordering (round-3 reliability P0-R4
+fix)**: the daemon-singleton lockfile (`<dataRoot>/daemon.lock`,
+owned by frag-6-7 §6.4) MUST be acquired BEFORE `ensureDataDir()`
+runs. This closes the documented race where step 1a's unconditional
+`unlink(<dataRoot>/data/ccsm.db.migrating*)` could otherwise delete a
+**live** tmp file owned by a concurrent migrating daemon (e.g. user
+double-clicked the launcher, MDM relaunch, debugger-spawned instance).
+With lockfile-first, only one daemon ever reaches `ensureDataDir()`
+per host; step 1a's "orphan unlink" is therefore provably orphan,
+not racy. frag-6-7 §6.4 carries the matching note in its boot-order
+list. The §8.8 e2e probe exercises two daemons racing boot to verify
+the second one bails on lockfile rather than entering step 1a.
+
+```
+0.  acquireLockfile(<dataRoot>/daemon.lock)  // frag-6-7 §6.4 — blocks/exits if held
+1.  mkdirSync(<dataRoot>/data, recursive: true)
+1a. // Recover from any prior interrupted migration. Orphan tmp files
+    // (from kill -9 between S3 and S6, OR from a pre-S6 throw whose
+    // finally block could not run because the process died) leak both
+    // disk space and downstream confusion (S3's "tmpDb already exists"
+    // ambiguity). Unlink unconditionally before evaluating step 2.
+    // Safe to do unconditionally because step 0 has already proven we
+    // are the sole daemon on this host.
+    for ext of ['', '-wal', '-shm']:
+        unlinkIfExists(<dataRoot>/data/ccsm.db.migrating + ext)
+2.  state = readMigrationState(<dataRoot>/data/migration-state.json)
+    if state and state.completed:    return  // fast path; see §8.5 marker shape
+3.  if exists(<dataRoot>/data/ccsm.db):
+        // user installed v0.3 fresh OR migration already ran without marker
+        // (e.g. legacy v0.3.0 install before marker.version=1 existed).
+        // Do not re-migrate. Stamp the marker and return.
+        writeMarker({ completed: true, reason: 'preexisting' }); return
+4.  legacyDir = resolveLegacyDir()  // see §8.4 — env var + canonical-path validation
+5.  if !legacyDir or !exists(join(legacyDir, 'ccsm.db')):
+        // fresh install. Open new db, schema runs, marker stamped.
+        writeMarker({ completed: true, reason: 'fresh-install' }); return
+6.  runMigration(legacyDir)  // §8.5
+```
+
+Step 0's lockfile is the cross-process serialization gate. Step 2's
+marker is the per-host "do not touch user data" gate. Once
+`completed: true` is stamped, the legacy dir is never re-evaluated,
+so a user who reinstalls v0.2 and accumulates new data alongside v0.3
+cannot have their v0.3 db silently overwritten.
+
+Step 1a closes the **partial-write data-loss bug** (round-2 reliability
+P0-R4): without it, kill -9 between S3 and S8 leaves `ccsm.db.migrating`
+on disk with no marker; on next boot step 3 misses (no `ccsm.db`),
+step 5 may then trigger ENOSPC because the orphan ate the free space,
+the user clicks "Start fresh anyway", marker stamps `user_skipped`,
+**legacy data is silently abandoned**. By unlinking unconditionally at
+step 1a (after lockfile acquisition), the next boot retries cleanly
+with full free space.
+
+### 8.4 Electron → daemon path handoff
+
+The daemon process has no `electron` package dependency (plan §Phase 2);
+it cannot call `app.getPath('userData')` itself. Electron computes the
+legacy dir and passes it to the spawned daemon via env var.
+
+**Env var name (locked)**: `CCSM_LEGACY_USERDATA_DIR`
+
+(Round-2 lock-in P0-3: renamed from the worker's first draft
+`CCSM_V02_USERDATA_DIR`. The "v02" suffix would force every future
+release to either keep that name forever — semantic confusion when v0.4
+itself becomes "legacy" — or invent `CCSM_V03_USERDATA_DIR` and
+accumulate one env var per release. The generic `LEGACY` name is
+version-neutral; the marker file (§8.5 S8) carries the actual source
+schema version, so no information is lost.)
+
+`electron/main.ts` (modified by plan Task 8) computes the value
+unconditionally on every spawn (cheap; just a string):
+
+```ts
+const legacyUserData = app.getPath('userData');
+spawn(daemonBin, [...], {
+  env: { ...process.env, CCSM_LEGACY_USERDATA_DIR: legacyUserData },
+  ...
+});
+```
+
+Why every spawn (not just first):
+
+- The daemon owns the "is migration needed?" decision via the marker
+  file. Electron passing the var on every spawn is idempotent — the
+  daemon ignores it once `migration-state.json` shows `completed: true`.
+- A user who deletes `<dataRoot>/` (the OS-native data root) to force
+  re-migration (rollback path, §8.7) gets correct behaviour on the
+  next Electron launch without needing a special "first-boot" flag
+  in Electron.
+
+**`resolveLegacyDir()` — env-var trust validation (round-2 security P0-S2)**
+
+`process.env.CCSM_LEGACY_USERDATA_DIR` is **attacker-controllable
+input**. A same-user-equivalent process (launcher shim, MDM-deployed
+wrapper, planted shortcut to `ccsm.exe`, debugger, or any
+`CreateProcess`-with-env caller) can point this var at
+`\\attacker-smb\share\`, `/tmp/planted/`, or any path. Step S4 below
+opens that path with better-sqlite3 — every historical SQLite reader
+CVE (CVE-2019-8457, CVE-2020-15358, etc.) becomes triggerable from
+attacker-supplied bytes.
+
+`resolveLegacyDir()` MUST:
+
+1. **Allowlist** the supplied path against the OS-canonical
+   Electron-userData locations for both prod (`CCSM`) and dev
+   (`CCSM Dev`) builds:
+   - Win: `%APPDATA%\CCSM` or `%APPDATA%\CCSM Dev`
+   - macOS: `~/Library/Application Support/CCSM` or `~/Library/Application Support/CCSM Dev`
+   - Linux: `~/.config/CCSM` or `~/.config/CCSM Dev` (XDG)
+
+   Comparison uses `path.resolve` + case-insensitive equality on Win/macOS,
+   case-sensitive on Linux. A path that does not exact-match one of these
+   four candidates is rejected.
+2. **Realpath** the supplied path (`fs.realpathSync.native`). Reject
+   if the realpath:
+   - traverses outside the user profile root (`os.homedir()` on POSIX,
+     `%USERPROFILE%` on Win),
+   - resolves to a network mount (Win: starts with `\\` or maps to a
+     `\\` UNC after `QueryDosDeviceW`; POSIX: `statfs.f_type` in the
+     network-fs set, or path begins with `/Volumes/` on macOS for
+     non-root volumes — accepted only if also under home),
+   - resolves to a symlink loop or broken link.
+3. **Realpath** `join(legacyDir, 'ccsm.db')` independently and re-check
+   the realpath is still under the validated `legacyDir` (defense
+   against a symlink planted as `ccsm.db` pointing elsewhere).
+4. **Trust contract (round-3 P1)**: the allowlist + double-realpath
+   pair is the **only** trust boundary on `CCSM_LEGACY_USERDATA_DIR`.
+   No downstream code (S3 backup open, S7 corrupt-backup glob, "Reveal
+   old file" shell open) MAY use the raw env var; all four call sites
+   consume the validated `legacyDir` returned by `resolveLegacyDir()`.
+   A single unit test asserts `process.env.CCSM_LEGACY_USERDATA_DIR`
+   is read exactly once per daemon boot (inside `resolveLegacyDir()`)
+   so future refactors cannot accidentally re-introduce raw-env reads.
+
+On rejection: emit `MigrationFailedEvent{reason: 'invalid_legacy_path',
+supplied: <raw>, realpath: <resolved>}`, log a single pino line at
+`warn`, modal copy "ccsm couldn't verify your previous data location"
+with a single "Quit ccsm" button (no retry — env var won't change
+without restart). Unit tests per rejection branch are required (plan
+delta 8a).
+
+If the daemon was started independently (e.g. `pkg`-bundled CLI
+invocation, no Electron), `CCSM_LEGACY_USERDATA_DIR` is unset.
+`resolveLegacyDir()` returns null and §8.3 step 5 proceeds as fresh
+install. This is correct — only Electron knows the per-OS userData
+path; a CLI-only daemon launch by definition is not an upgrade from
+v0.2 (v0.2 had no headless mode).
+
+**Dev-build interaction**: `productName` differs between prod (`CCSM`)
+and dev (`CCSM Dev`) builds (`package.json:31`). `app.getPath('userData')`
+already returns the right one for whichever Electron the user is
+running, so no extra branching is needed — Electron passes whichever
+is correct, daemon's allowlist accepts both, and rejects everything
+else.
+
+**Dev-mode trigger hook (round-2 devx S-5)**: contributors testing the
+migration UI itself can set `CCSM_DEV_MIGRATION_FIXTURE=<dir>` (only
+honoured when `NODE_ENV=development` AND the daemon binary is the dev
+build) to bypass the canonical-path allowlist for that specific
+fixture dir. Production builds ignore this var unconditionally.
+
+### 8.5 Migration steps (atomic, recoverable)
+
+`runMigration(legacyDir)` body. Every numbered step emits a structured
+pino line `{ phase: '<name>', traceId, ts, durationMs, sourcePath, ... }`
+(round-2 observability P1-2) so post-mortem from `<dataRoot>/logs/daemon.log`
+alone is sufficient when the modal has been dismissed.
+
+```
+START. start = Date.now(); traceId = randomUUID()
+       log.info({phase:'migration_started', traceId, sourcePath: legacyDb})
+
+S1. legacyDb = join(legacyDir, 'ccsm.db')
+S2. tmpDb    = join(<dataRoot>, 'data', 'ccsm.db.migrating')
+    cleanup = () => for ext of ['', '-wal', '-shm']: unlinkIfExists(tmpDb+ext)
+
+S3. // Use better-sqlite3's online .backup() API instead of fs.copyFileSync
+    // of main+WAL+SHM. Round-1 reviewer MUST-FIX (corruption-as-success
+    // risk): copyFileSync of three live SQLite files is non-atomic — if
+    // a v0.2 process is still running and checkpoints between our
+    // copies of `-wal` and `ccsm.db`, the resulting tmpDb has a stale
+    // sidecar pointing at a different main file generation, which
+    // SQLite happily opens and serves CORRUPT QUERIES with no error.
+    //
+    // .backup() opens a read transaction, writes a single self-consistent
+    // page-by-page snapshot to tmpDb (no sidecars produced), and is the
+    // SQLite-blessed way to copy a live db. It is also async-pageable
+    // (default 100 pages per tick) which keeps the daemon event loop
+    // responsive — closes round-2 perf P1-A (200 MB blocking copy starves
+    // /healthz, triggering supervisor restart cycle).
+    try {
+      source = new Database(legacyDb, { readonly: true })  // no WAL contention
+      log.info({phase:'migration_copy_started', traceId, bytes: statSync(legacyDb).size})
+      await source.backup(tmpDb, { progress: ({totalPages, remainingPages}) => {
+        // [manager r11 lock: NEW-1 — progress observed via daemon log only;
+        // renderer modal is indeterminate spinner per §8.6 r9 lock —
+        // no MigrationProgressEvent IPC.]
+        if (now - lastEmit > 250) log.debug({phase:'migration_copy_progress', traceId, totalPages, remainingPages})
+      }})
+      source.close()
+      log.info({phase:'migration_copy_done', traceId, durationMs: now-start})
+    } catch (err) {
+      cleanup()
+      log.warn({phase:'migration_failed', traceId, reason:'copy_failed', err: err.message})
+      emit MigrationFailedEvent({reason: classify(err), detail: err.message})
+      return  // §8.6 maps reason → modal
+    }
+
+S4. // Validate by opening read-only and running quick_check.
+    // Wrapped in try/finally with cleanup() so any throw (corrupt file,
+    // OOM during quick_check, EBUSY) unlinks tmpDb — round-1 reviewer
+    // MUST-FIX #3.
+    let storedVersion
+    try {
+      probe = new Database(tmpDb, { readonly: true })
+      try {
+        if (probe.pragma('quick_check', { simple: true }) !== 'ok') {
+          probe.close()
+          cleanup()
+          log.warn({phase:'migration_failed', traceId, reason:'corrupt_legacy'})
+          emit MigrationFailedEvent({reason: 'corrupt_legacy', path: legacyDb})
+          return
+        }
+        storedVersion = probe.pragma('user_version', { simple: true })
+      } finally {
+        probe.close()
+      }
+      log.info({phase:'migration_validated', traceId, userVersion: storedVersion})
+    } catch (err) {
+      cleanup()
+      log.warn({phase:'migration_failed', traceId, reason:'validate_threw', err: err.message})
+      emit MigrationFailedEvent({reason: 'corrupt_legacy', path: legacyDb})
+      return
+    }
+
+S5. // No schema migration needed for v0.2 → v0.3: SCHEMA_VERSION is still 1
+    // (electron/db.ts:17). The lift is a pure path move. If a future
+    // v0.4 bumps SCHEMA_VERSION, the existing `migrate(from, to)` hook
+    // in dbService runs at first open of the moved db.
+    if storedVersion > 1:
+        log.warn({phase:'migration_future_version', traceId, userVersion: storedVersion})
+
+S6. // Atomic publish — single rename of the main db file.
+    //
+    // ROUND-1 REVIEWER MUST-FIX #2: the previous draft renamed sidecars
+    // FIRST then main db. That order is wrong:
+    //   - .backup() never produces sidecars (S3 rewrite). There are no
+    //     `-wal`/`-shm` files alongside tmpDb to rename.
+    //   - Even if a future change reintroduced sidecar copies, sidecars-
+    //     first leaves an orphan `ccsm.db-wal` in dataDir on partial
+    //     failure (rename main throws after sidecar rename succeeded);
+    //     the orphan WAL points at a non-existent main file and SQLite
+    //     refuses to open `ccsm.db` on next boot when the user retries
+    //     by deleting the marker — contaminating fresh-install retry.
+    //
+    // With .backup() we rename ONE file, atomic on POSIX (rename(2))
+    // and Win32 (MoveFileEx + MOVEFILE_REPLACE_EXISTING on same volume).
+    // No sidecars exist to leak. The dataDir parent is `<dataRoot>/data`
+    // (one volume per OS-native location), so atomicity is guaranteed.
+    try {
+      renameSync(tmpDb, join(dataRoot, 'data', 'ccsm.db'))
+      log.info({phase:'migration_finalized', traceId})
+    } catch (err) {
+      cleanup()  // unlink tmpDb if rename threw mid-way (Win EBUSY etc.)
+      log.warn({phase:'migration_failed', traceId, reason:'finalize_failed', err: err.message})
+      emit MigrationFailedEvent({reason: 'finalize_failed', detail: err.message})
+      return
+    }
+
+S7. // Courtesy: copy any v0.2 corrupt-backups so a forensic trail is
+    // preserved next to the live db. Best-effort, never fails the
+    // migration. Round-2 resource P1-6: cap each copy at 100 MB; skip
+    // larger files with a warn line so a 2 GB corrupt backup doesn't
+    // double the user's disk usage during migration.
+    //
+    // Round-3 resource X1: ALSO cap aggregate corrupt-backups at 5
+    // files in <dataRoot>/data (~500 MB ceiling at 100 MB/file). Before
+    // copying, glob `<dataRoot>/data/ccsm.db.corrupt-*` already present
+    // from prior boots; if (existingCount + thisCopy) > 5, delete the
+    // oldest by mtime first so the newest 5 always win. This bounds
+    // the migration's contribution to the `<dataRoot>` aggregate
+    // disk-cap watchdog owned by frag-6-7 §6.6 (round-3 X1).
+    for f of glob(legacyDir + '/ccsm.db.corrupt-*'):
+        try {
+          if statSync(f).size > 100 * 1024 * 1024:
+            log.warn({phase:'migration_corrupt_backup_skipped', traceId, file: f, bytes})
+            continue
+          // enforce 5-file aggregate cap
+          existing = glob(<dataRoot> + '/data/ccsm.db.corrupt-*').sort(by mtime asc)
+          while existing.length >= 5:
+            unlinkSync(existing.shift())  // delete oldest
+            log.info({phase:'migration_corrupt_backup_evicted', traceId, file})
+          copyFileSync(f, join(<dataRoot>, 'data', basename(f)))
+        } catch { /* best-effort */ }
+
+S8. // Marker file. NAME (round-2 lock-in P0-3): `migration-state.json`
+    // not `.migration-v0.3.done`. The per-version-suffix pattern would
+    // accumulate stat() calls every release (`.migration-v0.4.done`,
+    // `.migration-v0.5.done`, ...). A single state file with a schema
+    // version inside is cheaper and forward-compatible — round-2
+    // fwdcompat P1-3 (markerSchemaVersion).
+    writeFileSync(join(<dataRoot>, 'data', 'migration-state.json'), JSON.stringify({
+        marker: { version: 1 },     // markerSchemaVersion — bump when shape changes
+        completed: true,
+        ts: Date.now(),
+        sourcePath: legacyDb,
+        sourceBytes: statSync(legacyDb).size,
+        sourceUserVersion: storedVersion,
+        durationMs: Date.now() - start,
+        traceId,
+        reason: 'migrated',          // 'migrated' | 'preexisting' | 'fresh-install'
+                                     // [manager r9 lock: P1-3 — removed
+                                     // 'corrupt_skipped' and
+                                     // 'user_skipped_after_disk_full' from
+                                     // the enum; the §8.6 r7 collapse to a
+                                     // single Quit-only fatal-error modal
+                                     // means the daemon never enters a skip
+                                     // flow that would stamp those reasons.
+                                     // Marker is simply not written on
+                                     // failure.]
+    }, null, 2))
+    log.info({phase:'migration_completed', traceId, durationMs: Date.now()-start})
+
+S9. // v0.2 db file stays in `userData` UNTOUCHED. Two reasons:
+    //   - Rollback safety: user can uninstall v0.3, install v0.2,
+    //     keep working. v0.3 only ever READ the legacy file via
+    //     readonly Database open in S3.
+    //   - Disk-full safety: if S6 partially failed mid-rename and we
+    //     deleted the source, data is gone.
+    // §8.7 documents user-driven cleanup.
+    emit MigrationCompletedEvent({traceId, durationMs: Date.now() - start})
+```
+
+All filesystem ops in S3–S6 share one parent dir (`<dataRoot>`) so
+the rename is on a single volume — atomic on every supported platform.
+
+**Backwards-compat marker reader**: a v0.3.x daemon that has shipped
+the older `.migration-v0.3.done` marker (if any pre-release builds did)
+is handled by §8.3 step 2: `readMigrationState` returns
+`{ completed: true, reason: 'preexisting' }` if the legacy marker file
+exists, then step 2 returns. Step 3 also catches the case (db exists
+without the new state file) and stamps fresh state.
+
+**`MIGRATION_PENDING` short-circuit scope (round-2 reliability P1-R3)**:
+the sentinel returned by data RPCs (plan delta 8e) does NOT apply to
+supervisor-facing RPCs. Specifically `/healthz`, `/stats`, `/version`,
+and the imposter-secret handshake (`ping()`) all respond normally,
+with a top-level `migrationState: 'pending' | 'completed' | 'failed'`
+diagnostic field. If `/healthz` returned `MIGRATION_PENDING` the
+supervisor would treat the daemon as unhealthy and start a restart
+cycle that the migration would never complete (round-trip P0).
+
+### 8.6 Failure modes and user-facing UI
+
+The daemon stays UP through every failure mode (so logs/IPC keep
+working). Data-API calls return `{ ok: false, code: 'MIGRATION_PENDING',
+detail: ... }` until the user resolves; supervisor RPCs respond
+normally with a `migrationState` field (see §8.5 short-circuit scope).
+Electron's data bridge translates the sentinel into a renderer-blocking
+modal.
+
+**[manager r7 lock: cut as polish — N5# from r6 feature-parity (with
+C2# and N7# folded in). §8.6 modal flow trimmed from 6 copy variants
++ multi-button flow → ONE fatal-error modal matching working's
+`installerCorrupt` prose pattern. Removed: per-failure-class copy
+variants (disk-full / permission / corrupt-legacy / finalize-failed /
+invalid-legacy-path), multi-button flows ("Retry" / "View log" /
+"Reveal old file" / "Start fresh anyway" / Quit), the typed-confirm
+"start fresh" word-gate, the `migration_corrupt_backup_skipped`
+follow-up info-toast for disk-recovery, the `MigrationProgressEvent`
+in-progress modal driver. KEPT: silent quick_check + auto-backup
+behavior (matches working v0.2 `db.ts.corrupt-<ts>` pattern), the
+single fatal-error modal below, structured pino phase-log emission for
+post-mortem (§8.5 unchanged). Per r5 lock #9 ("View log button removed
+entirely; no such feature in current working") + the §6.1.1 r7 trim,
+the only modal action is "Quit ccsm".]**
+
+**Single fatal-error modal** (registered with i18n key prefix
+`migration.modal.failed.*` in frag-6-7 §6.8 surface registry, priority
+85, and as the `Migration failed` row in §6.1.1):
+
+| Failure trigger | Daemon log phase | IPC event | Modal copy |
+|---|---|---|---|
+| Any migration failure (S3 copy / S4 quick_check / S6 finalize / S4 invalid legacy path / disk-full / permission denied) | `migration_failed{reason: <classified>}` (six reason codes preserved in the structured log for post-mortem support) | `MigrationFailedEvent{reason, detail?}` (single event class; renderer dispatches to single modal) | **Title**: "ccsm couldn't migrate your previous data"<br>**Body**: "ccsm tried to move your data from the previous version but couldn't complete the migration. Your previous data file at `<legacyDb>` is preserved unchanged — quit ccsm and contact support, or manually start fresh by deleting `<dataRoot>` and relaunching." Buttons: "Quit ccsm" |
+
+The body's `<legacyDb>` and `<dataRoot>` interpolations let the user
+locate both source (untouched, recoverable) and target (delete-to-retry)
+without a "Reveal old file" shell-open code path. The
+manual-delete-and-relaunch path is the documented retry mechanism
+(matches §8.7 user-driven rollback). No "Retry" button — a failed
+quick_check or rename cannot retry within the same boot meaningfully;
+the structural retry path is the manual cleanup + relaunch flow which
+also clears any orphan tmp via §8.3 step 1a.
+
+[manager r9 lock: P1-2 — orphan markdown table row "CCSM_LEGACY_USERDATA_DIR
+unset → fresh-install silent path" deleted. Silent fresh-install path
+is the implied default already documented in §8.3 step 5 +
+§8.5 S8 reason='fresh-install'; no separate row needed in the §8.6
+failure-modal table.]
+
+[manager r7 lock: C2# from r6 feature-parity — "View log" button cells
+in all former §8.6 modal rows are eliminated by the collapse to a
+single fatal-error modal. Daemon log path documented in release notes
++ About dialog only (matches frag-3.7 r7 cut of "Open daemon log" tray
+entry).]
+
+[manager r7 lock: N5# additional sub-cut — "Reveal old file" button
+also cut. Source path appears in modal body text; user can navigate to
+it via Explorer / Finder manually. This avoids the
+shell-open-attacker-path security gate (round-2 SH4) since no
+shell.openPath call exists.]
+
+[manager r7 lock: N5# additional sub-cut — "Start fresh anyway"
+typed-confirm word-gate (former r2 ux P1-UX-2) and the disk-full
+"your previous data is still recoverable" follow-up toast cut. Manual
+delete-and-relaunch path documented in modal body + release notes is
+the supported retry; no in-app affordance.]
+
+All copy is sentence-case (per `feedback_no_uppercase_ui_strings`). No
+copy contains "ERROR" / "FAILED" / "FATAL". i18n keys live under
+`migration.modal.failed.*` in the standard bundle (canonical keys:
+`migration.modal.failed.title`, `migration.modal.failed.body`,
+`migration.modal.failed.actionQuit`). Renderer translates; daemon emits
+structured events only. [manager r7 lock: r6 ux P0-3 — i18n key
+namespace dot+camelCase per r3-T13. The §6.8 surface registry row's
+"Owner i18n key prefix" column for the migration-failed modal is
+updated from `daemon.migrationFailed` to `migration.modal.failed.*`
+to match this canonical namespace; cross-fragment fixer H aligned both
+sites.]
+
+**Cross-fragment UI cohesion (round-2 ux P0-UX-1, P1; round-3 ux
+clarification; r7 trim alignment)**: the migration modal is the only
+migration-domain blocking surface in v0.3. The mutual-exclusion /
+stacking contract is OWNED by frag-6-7 §6.8 "User-visible surface
+registry". This fragment registers the migration in-progress modal as
+**priority class P0 / mode `blocking-modal` / dismissable: false /
+priority value 100** (the top of the §6.8 registry) and the
+fatal-error modal under i18n key prefix `migration.modal.failed.*`
+at **priority 85**. When
+either is active, all other surfaces (toasts, banners, secondary
+modals) are suppressed until resolved. Rationale: data-loss-class user
+choice cannot share attention.
+
+**Reconciliation with §6.8 stacking rule 1 (round-3 ux note)**: §6.8's
+generic stacking rule says "if a higher-priority modal arrives, the
+lower one is dismissed and its IPC re-fires." Migration in-progress is
+the highest-priority modal in the entire registry (priority 100), so
+stacking rule 1 NEVER fires against it — there is no higher-priority
+modal that could displace it. `dismissable: false` is therefore both a
+property of this modal AND a structural consequence of being priority
+100; the two specs do not conflict. The §6.8 registry entry is the
+contract; this section's copy is the authority for migration-specific
+strings.
+
+**In-progress modal: indeterminate spinner, no event needed (manager r9
+lock)**. The priority-100 in-progress modal at §6.8 is rendered as a
+simple indeterminate spinner with copy "Migrating data, please wait..."
+shown for the duration of `runMigration()`. Lifecycle:
+
+- **shown**: when the daemon emits `MigrationStartedEvent` (S3 START
+  log line in §8.5 already carries `phase:'migration_started'`; an
+  IPC event of the same name is added — zero-cost, single fire).
+- **dismissed**: on `MigrationCompletedEvent` (S9) OR when
+  `MigrationFailedEvent` arrives and the priority-85 fatal-error modal
+  takes over.
+
+No `MigrationProgressEvent` and no `{totalPages, remainingPages}` IPC
+stream is required — the §8.5 S3 `.backup()` callback's progress hook
+is retained ONLY for the structured pino phase log (post-mortem),
+not for renderer wire-up. Rationale: r7 trim cut per-failure copy
+variants and the typed-confirm flow; the only renderer state needed
+is "are we mid-migration? yes/no", which two events (started +
+completed/failed) supply. This preserves the §6.8 priority-100 row
+without re-introducing the `MigrationProgressEvent` contract that the
+§8.6 r7 lock removed.
+
+[manager r9 lock: in-progress modal kept (frag-6-7 §6.8 P=100 row
+remains valid); driven by start/complete/failed events only; no
+progress event in renderer protocol. Decision recorded here so frag-6-7
+§6.8 reciprocal sweep (separate fixer) does not need to cut the row.]
+
+### 8.7 Rollback paths
+
+- **User wants to go back to v0.2**: uninstall v0.3, install v0.2.
+  v0.2's `app.getPath('userData')/ccsm.db` was never touched, so it
+  resumes exactly as before. Any work done in v0.3 lives only in
+  `<dataRoot>/` (OS-native) and is invisible to v0.2 — this is
+  documented in the v0.3 release notes.
+
+- **User wants to re-run migration** (e.g. after a failed migration
+  surfaced via the §8.6 fatal-error modal): the documented manual path
+  is — quit ccsm, delete `<dataRoot>/` (the OS-native data root, full
+  path printed in the §8.6 fatal-error modal body text per the r7
+  trim — no in-app "Start fresh" button or "View log" toast exists),
+  relaunch. Daemon's §8.3 step 0 acquires lockfile, step 1a clears
+  any orphan tmp, step 2 misses (state file gone), step 3 misses (db
+  gone), step 5 fires, state file re-stamped.
+  [manager r9 lock: §8.6 r7 trim cut both the "Start fresh" button
+  and the "View log" toast; rollback path now relies on the modal's
+  body-text path interpolation + manual delete + relaunch as the only
+  retry mechanism.]
+
+- **User has data in BOTH dirs after running v0.2 again post-migration**:
+  the daemon never re-considers the legacy dir once the marker exists.
+  Documented as a known limitation; release notes recommend "pick a
+  version and stick with it for the v0.3 release window".
+
+- **Post-rollback health validation (round-3 P1)**: after any
+  user-driven rollback path above, the daemon's first boot MUST pass
+  the supervisor's standard `/healthz` 5-ping verification (frag-6-7
+  §6.4 step 7's "60s up + 5×/healthz" gate, reused) BEFORE the
+  renderer is allowed to issue data-write RPCs. If the post-rollback
+  daemon fails `/healthz` (e.g. corrupt state file written by the
+  prior failed migration, missing OS-native parent dir on locked-down
+  systems), supervisor surfaces the standard daemon-spawn-failure
+  modal (frag-6-7 §6.1) — NOT the migration modal — so the user
+  understands this is a daemon problem, not a migration problem.
+  The migration sub-system's only post-rollback contribution is to
+  re-run §8.3; the health gate itself is owned by frag-6-7.
+
+### 8.8 Test plan
+
+E2E probe (`tests/electron-daemon-migration.e2e.ts`, new — folded
+into `harness-agent` per `feedback_e2e_prefer_harness`):
+
+1. Setup: synthesize a v0.2 `ccsm.db` in a temp dir mimicking
+   `app.getPath('userData')`. Seed the `app_state` table with three
+   recognizable rows (e.g. `closeAction=hide`, `notifyEnabled=true`,
+   `userCwds=["C:\\repo"]`). Set `HOME` and `CCSM_LEGACY_USERDATA_DIR`
+   to point Electron and daemon at the temp dirs. The fixture dir is
+   inside the test's temp `HOME`, so it passes the §8.4 canonical-path
+   allowlist (test runs in dev mode so `CCSM_DEV_MIGRATION_FIXTURE` may
+   alternatively be used to bypass — both code paths must be tested).
+2. Boot ccsm v0.3.
+3. Assert: `<dataRoot>/data/ccsm.db` exists (where `<dataRoot>` is
+   `%LOCALAPPDATA%\ccsm\` on Win, `~/Library/Application Support/ccsm/`
+   on mac, `~/.local/share/ccsm/` on Linux); reading it via
+   better-sqlite3 returns the three seeded rows.
+4. Assert: legacy `<tempUserData>/ccsm.db` is byte-identical to the
+   pre-boot snapshot (`statSync(...).mtimeMs` AND sha256 unchanged).
+5. Assert: `<dataRoot>/data/migration-state.json` exists and parses to
+   `{marker: {version: 1}, completed: true, ts, sourcePath, sourceBytes,
+   sourceUserVersion: 1, durationMs, traceId, reason: 'migrated'}`.
+6. Reboot daemon. Assert no second migration runs (`migration_started`
+   log line absent; state-file `ts` unchanged).
+7. Assert daemon log contains the full structured phase chain:
+   `migration_started` → `migration_copy_started` → `migration_copy_done`
+   → `migration_validated` → `migration_finalized` → `migration_completed`,
+   each with the same `traceId`.
+
+Failure-path probes (parameterized):
+
+- **Disk full**: mock the `.backup()` callback to throw `ENOSPC` after
+  N pages. Assert daemon stays up, IPC returns `MIGRATION_PENDING`,
+  no `<dataRoot>/data/ccsm.db` created, no state file, legacy file
+  untouched, AND no orphan `ccsm.db.migrating` left behind (try/finally
+  cleanup verified).
+- **Corrupt legacy**: seed `ccsm.db` with garbage bytes. Assert
+  `MigrationFailedEvent{reason: 'corrupt_legacy'}` fires, no state file,
+  no `ccsm.db` in target.
+- **Pre-existing target**: pre-create `<dataRoot>/data/ccsm.db` AND set
+  `CCSM_LEGACY_USERDATA_DIR` to a populated legacy. Assert legacy is
+  IGNORED (target untouched, state file stamped with `reason='preexisting'`).
+- **Partial-write recovery (round-2 reliability P0-R4)**: pre-seed
+  `<dataRoot>/data/ccsm.db.migrating` (and `-wal`, `-shm`) with garbage as
+  if a prior boot died between S3 and S6. Boot daemon. Assert step 1a
+  unlinks all three orphans BEFORE any other check; assert migration
+  then runs cleanly (`reason='migrated'`); assert no orphans remain.
+- **Lockfile-before-ensureDataDir ordering (round-3 reliability P0-R4
+  fix)**: spawn two daemon processes simultaneously against the same
+  HOME. Assert exactly one acquires the `<dataRoot>/daemon.lock`
+  lockfile and proceeds into `ensureDataDir()`; the other exits with
+  the standard "another daemon is running" error from frag-6-7 §6.4
+  WITHOUT entering step 1a. Assert no `<dataRoot>/data/ccsm.db.migrating`
+  is unlinked while the winner's S3 backup is mid-flight (probe by
+  installing a `.backup()` progress callback that synchronously checks
+  `existsSync(tmpDb)` returns true throughout the copy).
+- **Security rejection — UNC path (round-2 security P0-S2)**: set
+  `CCSM_LEGACY_USERDATA_DIR=\\some-host\share\fake` (Win) or
+  `/mnt/nfs/fake` (Linux). Assert `MigrationFailedEvent{reason:
+  'invalid_legacy_path'}` fires; assert `quick_check` was NEVER called
+  on the supplied path (no SQLite open of attacker-controlled bytes);
+  assert modal shows the no-retry copy.
+- **Security rejection — symlink escape**: under temp HOME, create a
+  symlink `<tempUserData>/CCSM/ccsm.db` → `/etc/passwd`. Assert
+  realpath check rejects, no SQLite open of `/etc/passwd`.
+- **Security rejection — out-of-allowlist canonical path**: set
+  `CCSM_LEGACY_USERDATA_DIR=<dataRoot>` (the new dir itself, a
+  loop). Assert allowlist rejects (path is not one of the four
+  Electron-userData canonical names).
+- **Aggregate corrupt-backup cap (round-3 resource X1)**: pre-seed
+  `<dataRoot>` with 5 existing `ccsm.db.corrupt-2025-*` files (each
+  10 KB, mtimes spread across one minute), then run a migration whose
+  `legacyDir` contains 2 fresh corrupt-backups. Assert post-migration
+  `<dataRoot>` contains exactly 5 corrupt-backup files (the 2 oldest
+  pre-existing ones evicted), and a `migration_corrupt_backup_evicted`
+  log line fires per eviction.
+- **Marker forward-compat**: write a state file with
+  `marker.version: 999` and `completed: true`. Assert daemon proceeds
+  as fast-path (treats `completed: true` as authoritative regardless
+  of marker version; future versions are responsible for backward-
+  compatible reads).
+
+### 8.9 What the migration does NOT cover (scope fence)
+
+- **`~/.claude/**`**: CLI-owned. ccsm never wrote there for session
+  data; sessionTitles round-trip via SDK, not via copy. Untouched on
+  upgrade — Claude CLI handles its own data lifecycle.
+- **Renderer localStorage / IndexedDB**: ccsm renderer does not persist
+  to browser storage (verified — no `localStorage.setItem` call
+  references user data; only the ephemeral UI state which is
+  intentionally session-local and reset on refresh).
+- **Schema upgrades**: SCHEMA_VERSION stays at 1 across v0.2 → v0.3.
+  Future bumps reuse the existing `migrate(from, to)` hook from
+  `electron/db.ts:57` (lifted to `daemon/src/services/dbService.ts`
+  by plan Task 8); migration is path-only.
+
+---
+
+## Plan delta
+
+Insert new sub-task after plan Task 8 Step 4 (the line that today
+says "if `electron/db.ts` references `app.getPath('userData')`, replace
+with the OS-native data root resolver"):
+
+- **Task 8 (additional)**: data migration v0.2 → v0.3
+  - **8a**: implement `ensureDataDir()` (resolves OS-native `<dataRoot>`
+    via per-OS resolver: `%LOCALAPPDATA%\ccsm\` Win, `~/Library/Application
+    Support/ccsm/` mac, `~/.local/share/ccsm/` Linux) +
+    `resolveLegacyDir()` (canonical-path allowlist + double-realpath
+    validation, §8.4) + `runMigration()` per §8.3-§8.5 in
+    `daemon/src/services/dbService.ts`. Lockfile (frag-6-7 §6.4)
+    acquired BEFORE `ensureDataDir()` runs (round-3 reliability P0-R4
+    fix). Uses better-sqlite3 `.backup()` API (NOT `fs.copyFileSync`),
+    wrapped in try/finally with cleanup. Step 1a unconditional
+    orphan-tmp unlink (safe because lockfile owns the host).
+    Aggregate 5-file cap on corrupt-backups in `<dataRoot>` (round-3
+    resource X1). +7h (was +6h: +1h for OS-native resolver + path
+    test matrix per OS).
+  - **8b**: Electron-side env-var handoff in `electron/main.ts` and
+    `electron/lifecycle/spawnOrAttach.ts` (set `CCSM_LEGACY_USERDATA_DIR`
+    on every daemon spawn, value = `app.getPath('userData')` which
+    is the v0.2 product-name path under `%APPDATA%\CCSM\` etc). +1h.
+  - **8c**: `MigrationStartedEvent` / `MigrationFailedEvent` /
+    `MigrationCompletedEvent` in
+    `daemon/src/api/contracts.ts` [manager r11 lock: NEW-2 —
+    `MigrationStartedEvent` added to contracts enumeration; drives the
+    §8.6 r9 in-progress spinner alongside Completed/Failed]; renderer
+    modals in
+    `src/renderer/components/MigrationDialog.tsx` — TWO surfaces:
+    (1) priority-100 in-progress modal, indeterminate spinner with
+    copy "Migrating data, please wait...", shown while sql.exec runs
+    synchronously and dismissed on `MigrationCompletedEvent` /
+    `MigrationFailedEvent` (no progress events needed — see §8.6
+    in-progress-modal note); (2) priority-85 single fatal-error modal
+    per §8.6 with the canonical `migration.modal.failed.*` i18n keys
+    (Quit ccsm only). +2h (was +4h; r9 trim cut `MigrationProgressEvent`
+    + the six per-failure-class copy variants + "Start fresh anyway"
+    typed-confirm; remaining work is the two simple modals + two events).
+    [manager r9 lock: scope reduced to match §8.6 r7 trim — no
+    `MigrationProgressEvent`, no per-failure copy switch, no
+    typed-confirm. In-progress modal retained as indeterminate spinner.]
+  - **8d**: e2e probe per §8.8 (folded into `harness-agent`). Includes
+    partial-write recovery test, lockfile-before-ensureDataDir ordering
+    test (round-3 P0-R4), three security-rejection tests, aggregate
+    corrupt-backup cap test (round-3 X1), marker forward-compat test,
+    structured-phase log assertion. +5h (was +4h; +1h for the new
+    lockfile-race + aggregate-cap cases).
+  - **8e**: `MIGRATION_PENDING` short-circuit in `daemon/src/services/dbService.ts`
+    so every public DATA RPC checks `migrationState` first and returns
+    the sentinel until the user resolves. `/healthz`, `/stats`,
+    `/version`, and the imposter-secret handshake bypass the
+    short-circuit and return a `migrationState` field instead
+    (§8.5 short-circuit scope). +1h.
+  - **Subtotal**: ~16h (r9 trimmed 8c by 2h after §8.6 r7 cuts removed
+    `MigrationProgressEvent` + per-failure copy variants + typed-confirm;
+    prior r3 round was ~18h with the now-cut UX). Goes on
+    the critical path for v0.3 release — cannot ship without
+    (data-loss bug = RED per `~/spike-reports/v03-review-ux.md`
+    MUST-1 and round-2 reliability P0-R4 + security P0-S2 + round-3
+    reliability P0-R4 lockfile race).
+    [manager r9 lock: subtotal recomputed after 8c trim.]
+
+Existing plan Task 8 Step that says "replace `app.getPath('userData')`
+with the OS-native data root resolver. Add a one-time `mkdirSync` at
+module load" → AMEND to: "after lockfile acquisition (frag-6-7 §6.4
+boot order), call `ensureDataDir()` (8a) which resolves the per-OS
+`<dataRoot>`, performs the mkdir, orphan-tmp cleanup, AND the
+migration check; do NOT open the database before it returns
+successfully."
+
+Release-notes addition (Task 24): one paragraph documenting (a) data
+moves from the old per-product Electron-userData path to the OS-native
+location automatically (`%LOCALAPPDATA%\ccsm\` Win, `~/Library/Application
+Support/ccsm/` mac, `~/.local/share/ccsm/` Linux), (b) old data left
+in place for rollback, (c) "to start over, quit ccsm and delete the
+ccsm folder under your OS-native application-data location" (full
+path also printed in the §8.6 fatal-error modal body when migration
+fails, and in the app's About dialog), (d) if migration fails, ccsm
+shows a single "ccsm couldn't migrate your previous data" modal whose
+only action is "Quit ccsm"; previous data file is preserved unchanged
+and the manual delete-and-relaunch path above is the documented retry
+mechanism (close-to-tray behaviour call-out from round-2 ux P0-UX-2
+mitigation also lives here).
+[manager r9 lock: (c) drops the stale "View log toast" reference; (d)
+rewritten to describe the actual single Quit-only modal post §8.6 r7
+trim, replacing the prior generic "close-to-tray behaviour" sentence
+which lost its anchor when the migration UX collapsed.]
+
+---
+
+## Cross-frag rationale
+
+Round-2 review surfaced 6 P0 items and 3 P1 items touching this
+fragment. Ownership decisions:
+
+| Item | Source | Owned here? | Rationale |
+|---|---|---|---|
+| Round-1 reviewer MUST-FIX #1: use `.backup()` not `copyFileSync` of WAL+main+SHM | independent reviewer | **YES** — applied in §8.5 S3 | Pure §8 internal mechanism. CRITICAL: `copyFileSync` of three live SQLite files is corruption-as-success risk (stale-sidecar non-atomicity). `.backup()` is the SQLite-blessed API and additionally solves perf P1-A (page-progress async, doesn't block event loop). |
+| Round-1 reviewer MUST-FIX #2: rename main.db first OR sidecars-in-finally | independent reviewer | **YES** — applied in §8.5 S6 | With `.backup()` rewrite (#1) there are NO sidecars in tmpDb to rename — single rename, atomicity native. Fix is structural, not just ordering. |
+| Round-1 reviewer MUST-FIX #3: try/finally wrap S3+S4 with unlink | independent reviewer | **YES** — applied in §8.5 S3 + S4 | Each step has explicit try/catch + cleanup; verified by §8.8 disk-full probe asserting no orphan tmp. |
+| P0-R4 reliability: partial-write between S3 and S8 → silent data loss | r2-reliability | **YES** — §8.3 step 1a added | Daemon-internal recovery. Step 1a unconditional unlink of `ccsm.db.migrating[-wal][-shm]` before any other check; `MigrationFailedEvent.reason` differentiated `user_skipped_after_disk_full` from `corrupt_skipped` so support tooling can offer follow-up retry. |
+| P0-S2 security: `CCSM_V02_USERDATA_DIR` attacker-controllable, no validation | r2-security | **YES** — §8.4 `resolveLegacyDir()` | Allowlist against four canonical Electron-userData paths, double realpath (dir + db file), reject UNC / network mount / symlink-escape. Five unit tests added (8a). `quick_check` cannot run until validation passes — closes SQLite-CVE attack surface. |
+| P0-3 lock-in: env-var name + per-version marker are permanent contracts | r2-lockin | **YES** — renamed both | `CCSM_V02_USERDATA_DIR` → `CCSM_LEGACY_USERDATA_DIR` (version-neutral); `.migration-v0.3.done` → `migration-state.json` with `marker.version: 1` (single forward-compatible state file vs accumulating per-release marker files). Carries the actual source schema version inside, so no information loss. |
+| P0-UX-1 cross-frag UI cohesion (modal/toast/banner stacking) | r2-ux | **PUNT to frag-6-7 §6.8** | Surface registry is naturally a frag-6-7 concern (it owns the supervisor banners + crash-loop modal — the other two blocking surfaces). This fragment registers its modal as priority class P0 / `blocking-modal` / non-dismissable in the registry; §8.6 footer documents the contract. The registry implementation lives in frag-6-7. |
+| P1-R3 reliability: `MIGRATION_PENDING` short-circuit is too broad | r2-reliability | **YES** — §8.5 short-circuit scope + plan 8e | Data RPCs return sentinel; supervisor RPCs (`/healthz`, `/stats`, `/version`, `ping()`) respond normally with `migrationState` diagnostic field. Without this scoping the supervisor would crash-loop the daemon mid-migration. |
+| P1-2 obs: structured pino phase log lines | r2-observability | **YES** — §8.5 START + every step | Six phase names (`migration_started`, `migration_copy_started`, `migration_copy_done`, `migration_validated`, `migration_finalized`, `migration_completed`) plus `migration_failed{reason}` and `migration_corrupt_backup_skipped`. All carry shared `traceId`. §8.8 step 7 asserts the chain. |
+| P1-3 fwdcompat: marker schema version | r2-fwdcompat | **YES** — §8.5 S8 + §8.8 | `marker.version: 1` field in state file; e2e asserts shape; forward-compat test asserts `marker.version: 999` is treated as authoritative `completed: true`. |
+| P1-A perf: sync `quick_check` blocks event loop | r2-perf | **YES** — `.backup()` rewrite + note | `.backup()` is page-paged async (default 100 pages/tick); event loop stays responsive during multi-second copy. `quick_check` itself runs synchronously on the read-only probe but only after copy completes — supervisor `/healthz` bypass (P1-R3) means even a 3s `quick_check` can't trigger restart. v0.4 follow-up: move `quick_check` to `worker_threads` if dogfood reveals user-visible jank. |
+| P1-UX-2 ux: "start fresh" typed-confirm ambiguity | r2-ux | **YES** — §8.6 typed-confirm spec | Exact phrase `start fresh`, case-insensitive, no quotes/punctuation. Auto-focus, disabled-until-match button, screen-reader live region. |
+| SH4 security: "Reveal old file" opens attacker path | r2-security | **YES — gated on P0-S2** | §8.6 explicitly notes the button only fires after §8.4 allowlist passed. With P0-S2 fix the path is provably canonical-userData, so Explorer-shell escalation vector is closed. |
+| P1-6 resource: cap migration corrupt-backup copy | r2-resource | **YES** — §8.5 S7 | 100 MB per-file cap; oversize files logged as `migration_corrupt_backup_skipped` and skipped (user can copy manually). |
+| SHOULD-2 resource: rename order | r2-resource | **YES — subsumed by MUST-FIX #2** | The `.backup()` rewrite eliminates sidecars in tmpDb; single rename of main file is the only finalize op. SQLite recreates sidecars on first open. |
+| S-R2 reliability: `fs.copyFileSync` is sync-blocking | r2-reliability | **YES — subsumed by MUST-FIX #1** | `.backup()` is async-pageable; replaces the sync copyFileSync entirely. |
+| Devx S-5: dev-mode trigger hook for migration UI | r2-devx | **YES** — §8.4 dev hook | `CCSM_DEV_MIGRATION_FIXTURE` honoured only when `NODE_ENV=development` AND dev-build daemon binary; production ignores. One-line escape hatch for contributors testing modal variants. |
+| P1-2 observability: tray "Open log folder" shortcut | r2-observability | **PUNT to frag-6-7** | Tray menu is renderer/electron-main concern, not daemon. Frag-6-7 §6.6 logs section owns it. |
+| P0-UX-2 ux: close-window toast deferral | r2-ux | **PUNT to frag-6-7 + release notes** | Not migration-specific. Mitigation: release-notes call-out (Plan delta release-notes addition (d)) is the agreed v0.3 mitigation; v0.4 reconsiders the deferral. |
+| P0-UX-3 ux: daemon-spawn failure modal copy | r2-ux | **PUNT to frag-6-7 §6.1** | Spawn failure is supervisor's surface, not migration's. §8.6 modal style serves as a template. |
+| P0-S1 security: `daemon.secret` lifecycle | r2-security | **PUNT to frag-6-7 §7** | Pre-migration concern; secret must exist at first boot regardless of migration state. Frag-6-7 owns secret creation/rotation. Confirmed still PUNT in r3 — `daemon.secret` is not in §8's scope. |
+| **R3 arch lock**: data root = OS-native, not `~/.ccsm/data/` | r3-manager | **YES** — §8.2 rewrite | v0.2 used `~/.ccsm/` cross-platform (interim); v0.3 moves to OS-native (`%LOCALAPPDATA%\ccsm\` Win, `~/Library/Application Support/ccsm/` mac, `~/.local/share/ccsm/` Linux) to match install path policy. Source (legacy) stays at v0.2's Electron `userData` per-product-name path; only TARGET changed. All §8.3-§8.8 path references swept. |
+| **R3 P0-R4 reliability**: lockfile-before-ensureDataDir ordering | r3-reliability | **YES** — §8.3 step 0 added | Lockfile (`<dataRoot>/daemon.lock`, frag-6-7 §6.4) acquired BEFORE `ensureDataDir()` so step 1a's unconditional unlink is provably orphan, not a race against a concurrent live migration. Matched by frag-6-7 §6.4 boot-order note. New e2e probe (§8.8) races two daemons. |
+| **R3 X1 resource**: aggregate corrupt-backup cap | r3-resource | **YES** — §8.5 S7 amendment | Per-file 100 MB cap unchanged; ADDED 5-file aggregate cap with mtime-based oldest-first eviction (~500 MB ceiling). Bounds migration's contribution to the `<dataRoot>` aggregate disk-cap watchdog owned by frag-6-7 §6.6 (the broader X1 watchdog itself stays with frag-6-7). New e2e probe verifies eviction. |
+| **R5 dataRoot reconciliation**: `~/.ccsm/` retired across data/logs/crashes/lockfile | r5-manager (frag-11 §11.6 lock) | **YES** — §8.2 rewrite + §8.3-§8.8 sweep | Three-way `<dataRoot>` permutation flagged in r4 packaging; manager r5 lock makes frag-11 §11.6 the single source of truth. All `~/.ccsm/data|logs|crashes|daemon.lock` references in §8.2-§8.8 mapped to `<dataRoot>/...` (db moves to `<dataRoot>/data/`, logs to `<dataRoot>/logs/`, crashes to `<dataRoot>/crashes/`, lockfile to `<dataRoot>/daemon.lock`). Legacy `~/.ccsm/` references retained only in historical/rationale prose to describe the v0.2 starting state. |
+| **R3 P1 perf**: `.backup()` already adopted | r3-perf | **YES — confirm only** | r3-perf §P1-A confirms §8.5 S3 already uses `.backup()` page-paged async with indeterminate spinner driven by MigrationStartedEvent + MigrationCompletedEvent/MigrationFailedEvent (no progress IPC). No change needed; structural fix from r2 carried through. [manager r11 lock: NEW-3 — phrasing aligned with §8.6 r9 lock that removed `MigrationProgressEvent`.] |
+| **R3 ux clarification**: dismissable: false vs §6.8 stacking rule 1 | r3-ux | **YES** — §8.6 reconciliation paragraph | r3-ux flagged apparent contradiction; clarified that `dismissable: false` is consistent with §6.8 priority 100 because no higher-priority modal exists to trigger stacking rule 1's auto-dismiss. Cross-ref to §6.8 priority 100 added. |
+| **R3 P1 security**: env-var trust hardening | r3-manager | **YES** — §8.4 trust-contract bullet 4 | Single-source-of-truth: only `resolveLegacyDir()` reads `process.env.CCSM_LEGACY_USERDATA_DIR`; downstream uses validated `legacyDir`. Unit test asserts single read. |
+| **R3 P1 reliability**: post-rollback /healthz validation gate | r3-manager | **YES** — §8.7 added bullet | Reuses frag-6-7 §6.4 step 7 health gate; daemon-spawn-failure modal (not migration modal) surfaces if post-rollback boot fails health. Migration sub-system's only contribution is to re-run §8.3. |
+
+**Data-loss risk**: **NO** — every identified data-loss failure mode
+is either prevented by structural fix (corruption-as-success closed by
+`.backup()`; partial-write closed by step 1a; lockfile-before-step-1a
+closes the round-3 in-progress-migration race; user-skip-after-disk-full
+flagged for re-offer) or surfaced via blocking modal with non-default
+typed-confirm. Round-2 ux report independently verified frag-8 closes
+the r1 MUST-1 data-loss concern; round-3 reliability confirms P0-R4
+fully closed by lockfile ordering.
+
+**Net plan delta change**: +6h (12h → 18h). Round-2 added +4h
+(security/reliability/UX P0); round-3 added +2h (OS-native resolver +
+lockfile-ordering test + aggregate-cap test).
+
+<!-- END frag-8-sqlite-migration.md -->
+
+---
+
+<!-- BEGIN frag-11-packaging.md -->
+
+## 11. Packaging
+
+> Replaces §11 of `2026-04-30-web-remote-design.md`.
+> P0 items: #9 (extraResources wiring), #10 (daemon code-signing), #11 (NSIS uninstall hygiene — reclaimed from frag-6-7 per round-2 P0-1), #12 (`ccsm_native.node` + every native `.node` ships + signs — round-2 P0-2 / round-3 P0-3 rename).
+> Source reviews: `~/spike-reports/v03-review-packaging.md` §3 (MUST-FIX 1, 2, 3); `~/spike-reports/v03-r2-packaging.md` (P0-1, P0-2, P1-3..P1-6, S1, S3); `~/spike-reports/v03-r2-security.md` (P0-S3 SLSA provenance, SH2/SH3); `~/spike-reports/v03-r3-packaging.md` (P0-1 install path, P0-2 secret path, P0-3 native rename, P0-4 postrm HOME bug); `~/spike-reports/v03-r3-lockin.md` (ccsm_native vs winjob); `~/spike-reports/v03-r3-resource.md` (uninstall hygiene dedupe); `~/spike-reports/v03-r3-devx.md` (CF-2 devTarget fence).
+
+**Round-3 install-path lock (manager-decided, applies everywhere in this fragment):**
+- Install root is **per-user**: `%LOCALAPPDATA%\ccsm\` on Windows, `~/Library/Application Support/ccsm/` on macOS, `~/.local/share/ccsm/` on Linux. **Never `Program Files`.** electron-builder NSIS is configured `perMachine: false` so the installer drops to `%LOCALAPPDATA%\ccsm\` (no UAC, auto-update writes in-place). NSIS `oneClick: false / allowElevation: true / allowToChangeInstallationDirectory: true` per §11.6 r9 lock. [manager r11 lock: r10 packaging P1-A — §11 head paragraph reconciled with §11.6 r9 oneClick lock; the prior "`oneClick: true` is preserved" wording was stale.]
+- Data root = same per-user location (no separate `~/.ccsm/` root). All daemon-owned paths (`daemon.secret`, `daemon.lock`, `data/`, `logs/`, `crashes/`) live under that root.
+- In-app surface registry (close-to-tray, reset-data, etc.) is owned by **frag-6-7 §6.8** with numeric priority — frag-11 does NOT redefine. Frag-11 §11.6 owns only the disk-removal mechanics (NSIS macro, postrm script, paths table).
+
+**Toolchain check.** v0.2 ships via `electron-builder@^26.8.1` (`package.json:93,112-216`) — no `forge.config.cjs` exists. All extraResources / signing / publish config goes into the `build` block of root `package.json`. v0.3 keeps electron-builder; no migration to forge.
+
+### 11.1 Daemon binary build (`@yao-pkg/pkg`)
+
+Daemon is a separate Node program that must run **outside** Electron's `app.asar` and outside Electron's bundled Node — same machine, independent process. We compile it to a single platform binary so the installer ships one file per OS, not a `node_modules/` tree.
+
+- Tool: **`@yao-pkg/pkg`** (the maintained fork of vercel/pkg; vercel/pkg is archived). Targets Node 22.
+- Workspace: `daemon/` (added in plan Task 1, `2026-04-30-v0.3-daemon-split.md:81`).
+- Output: `daemon/dist/ccsm-daemon-${platform}${ext}` where platform ∈ {`win-x64.exe`, `macos-x64`, `macos-arm64`, `linux-x64`} — produced by a fresh CI step before electron-builder runs.
+- Native modules (`better-sqlite3`, `node-pty`, **plus the in-tree `ccsm_native.node` from frag-3.5.1 §3.5.1.1** — a single N-API addon carrying the **winjob** (Win JobObject), **pdeathsig** (Linux `prctl(PR_SET_PDEATHSIG)`), and **pipeAcl** (Win named-pipe ACL helper used by frag-6-7 §7.M1) exports, ~150 LOC C++ at `daemon/native/ccsm_native/`) are **not** compiled into the pkg blob (V8 snapshot can't embed `.node`). They are listed as pkg `assets` and shipped next to the binary, then `require()`d at runtime via an absolute path resolver. **Round-3 P0-3**: artifact filename is `ccsm_native.node` per the canonical contract in frag-3.5.1 §3.5.1.1; the prior `winjob.node` name is retired and any tooling reference must be updated.
+- **Daemon `dependencies` discipline (round-2 C6)**: every runtime daemon dep (`pino`, `pino-roll`, `@sinclair/typebox`, `@octokit/rest`, `proper-lockfile`, `better-sqlite3`, `node-pty`, plus the native helper bindings) MUST appear in `daemon/package.json` `dependencies`, NOT only in root `dependencies`. `pkg` embeds the resolved `require()` graph from the daemon package's own `node_modules`; workspace-hoisted root deps are invisible to `pkg`. The example below shows only `@yao-pkg/pkg` in `devDependencies` for brevity — the actual `dependencies` block is filled by Task 20.
+
+`daemon/package.json` (new, owned by Task 20):
+
+```json
+{
+  "name": "@ccsm/daemon",
+  "version": "0.3.0",
+  "main": "dist/index.js",
+  "bin": "dist/index.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "rebuild:native": "node scripts/rebuild-native-for-node.cjs",
+    "package": "npm run build && npm run rebuild:native && pkg . --out-path dist"
+  },
+  "pkg": {
+    "targets": ["node22-win-x64", "node22-macos-x64", "node22-macos-arm64", "node22-linux-x64"],
+    "assets": [
+      "native/${PLATFORM}-${ARCH}/*.node",
+      "native/${PLATFORM}-${ARCH}/*.dll"
+    ],
+    "outputPath": "dist"
+  },
+  "devDependencies": {
+    "@yao-pkg/pkg": "^6.6.0",
+    "node-gyp": "^10.2.0"
+  }
+}
+```
+
+> **Round-3 P1-7**: `pkg.assets` glob is scoped to a single `${PLATFORM}-${ARCH}` per build invocation (driven by `pkg --targets node22-${PLATFORM}-${ARCH}` in CI per matrix leg) so each per-platform daemon binary embeds **only** its own arch's `.node` files. Cross-platform globbing (`native/**/*.node`) wastes ~5 MB per binary on dead-weight `.node` files the pkg-bundled Node could never load. The CI `Build daemon` step in §11.5 step 2 must invoke pkg with the explicit target matching the runner.
+
+> **Round-3 P1-2/P1-3**: pin `NODE_TARGET` to a single value committed to `daemon/.nvmrc` (e.g. `22.11.0`) and have both `setup-node` (`node-version-file: daemon/.nvmrc`) and the rebuild script read the same file. This eliminates drift between the runner's installed Node, `pkg`'s base binary, and the headers `node-gyp` downloads. Cross-compilation between Win/mac/Linux native modules is unsupported — each matrix leg builds only its own platform's targets.
+
+`scripts/rebuild-native-for-node.cjs` rebuilds **every native artifact** the daemon dlopens — npm-installed (`better-sqlite3`, `node-pty`) AND in-tree (`daemon/native/ccsm_native/`) — against **Node 22 ABI** (NOT Electron's V8 ABI — see review §4 SHOULD-FIX #7 + round-2 P0-2) into `daemon/native/<platform>-<arch>/`:
+
+```js
+// daemon/scripts/rebuild-native-for-node.cjs (sketch)
+const { execSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+// Round-3 P1-3: read the single source of truth from daemon/.nvmrc so
+// setup-node, pkg, and node-gyp all agree on one Node patch version.
+const NODE_TARGET = fs.readFileSync(path.join('daemon', '.nvmrc'), 'utf8').trim();
+const outDir = path.join('daemon', 'native', `${process.platform}-${process.arch}`);
+fs.mkdirSync(outDir, { recursive: true });
+
+// 1. npm-installed natives
+for (const mod of ['better-sqlite3', 'node-pty']) {
+  execSync(
+    `npm rebuild ${mod} --runtime=node --target=${NODE_TARGET} --build-from-source`,
+    { cwd: 'daemon', stdio: 'inherit' }
+  );
+  // copy build/Release/*.node + winpty*.dll into outDir
+}
+
+// 2. In-tree ccsm_native N-API helper (frag-3.5.1 §3.5.1.1) — round-2 P0-2 / round-3 P0-3
+//    Single .node carrying winjob + pdeathsig + pipeAcl exports. Builds on all
+//    three platforms; non-Win branches stub out winjob/pipeAcl with ENOSYS but
+//    still emit ccsm_native.node so the loader doesn't ENOENT.
+execSync(
+  `node-gyp rebuild --target=${NODE_TARGET} --runtime=node --dist-url=https://nodejs.org/dist`,
+  { cwd: 'daemon/native/ccsm_native', stdio: 'inherit' }
+);
+fs.copyFileSync(
+  path.join('daemon', 'native', 'ccsm_native', 'build', 'Release', 'ccsm_native.node'),
+  path.join(outDir, 'ccsm_native.node')
+);
+```
+
+Daemon entry resolves natives via:
+
+```ts
+// daemon/src/native.ts
+const nativeRoot = process.pkg
+  ? path.join(path.dirname(process.execPath), 'native', `${process.platform}-${process.arch}`)
+  : path.join(__dirname, '..', 'native', `${process.platform}-${process.arch}`);
+process.env.BETTER_SQLITE3_BINARY = path.join(nativeRoot, 'better_sqlite3.node');
+```
+
+Root script: `npm run build:daemon` → `npm -w @ccsm/daemon run package` (added to root `scripts`).
+
+### 11.2 electron-builder `extraResources` wiring
+
+After the daemon binary + native folder are built, electron-builder copies them into the installer payload. **Round-2 S3 correction**: electron-builder does not expand a `${platform}` token in `from` paths; the only supported tokens in `extraResources` paths are `${os}`, `${arch}`, `${ext}`, `${productName}`, `${version}`. The clean approach is to have `before-pack.cjs` stage everything into a fixed dir (`daemon/native-staged/`) and reference that:
+
+```json
+"extraResources": [
+  { "from": "daemon/dist/ccsm-daemon-staged${ext}", "to": "daemon/ccsm-daemon${ext}" },
+  { "from": "daemon/native-staged",                 "to": "daemon/native" }
+]
+```
+
+`scripts/before-pack.cjs` (new, owned by Task 20a) computes the right per-platform daemon binary + native folder and copies them into the staging paths, then verifies every required artifact is present:
+
+```js
+// scripts/before-pack.cjs (new)
+const fs = require('node:fs');
+const path = require('node:path');
+exports.default = async function beforePack(context) {
+  const { electronPlatformName, arch } = context;
+  // Round-3 P1-1: app-builder-lib's Arch enum is { ia32:0, x64:1, armv7l:2,
+  // arm64:3, universal:4 }. v0.3 ships only x64+arm64; universal/armv7l throw.
+  const archName = ({ 0: 'ia32', 1: 'x64', 2: 'armv7l', 3: 'arm64', 4: 'universal' })[arch];
+  if (archName === 'universal' || archName === 'armv7l') {
+    throw new Error(`[before-pack] arch ${archName} not supported in v0.3 (build x64 + arm64 separately; pkg cannot merge fat Mach-O)`);
+  }
+  if (!archName) throw new Error(`[before-pack] unknown arch index ${arch}`);
+  const map = {
+    win32:  { src: 'daemon/dist/ccsm-daemon-win-x64.exe',          dst: 'daemon/dist/ccsm-daemon-staged.exe', natives: `win32-${archName}` },
+    darwin: { src: `daemon/dist/ccsm-daemon-macos-${archName}`,    dst: 'daemon/dist/ccsm-daemon-staged',     natives: `darwin-${archName}` },
+    linux:  { src: 'daemon/dist/ccsm-daemon-linux-x64',            dst: 'daemon/dist/ccsm-daemon-staged',     natives: `linux-${archName}` },
+  }[electronPlatformName];
+  if (!fs.existsSync(map.src)) throw new Error(`[before-pack] daemon binary missing: ${map.src}`);
+  fs.copyFileSync(map.src, map.dst);
+
+  // Stage native folder
+  const srcNatives = path.join('daemon', 'native', map.natives);
+  const dstNatives = path.join('daemon', 'native-staged');
+  fs.rmSync(dstNatives, { recursive: true, force: true });
+  fs.cpSync(srcNatives, dstNatives, { recursive: true });
+
+  // Round-2 P0-2 + round-3 P0-3: every required `.node` MUST exist before electron-builder packs.
+  // The single `ccsm_native.node` carries winjob+pdeathsig+pipeAcl per frag-3.5.1 §3.5.1.1.
+  const REQUIRED_NATIVES = ['better_sqlite3.node', 'pty.node', 'ccsm_native.node'];
+  for (const f of REQUIRED_NATIVES) {
+    const p = path.join(dstNatives, f);
+    if (!fs.existsSync(p)) throw new Error(`[before-pack] required native missing: ${p}`);
+  }
+};
+```
+
+Electron main resolves the daemon at runtime:
+
+```ts
+// electron/daemonClient/spawnOrAttach.ts
+const ext = process.platform === 'win32' ? '.exe' : '';
+const daemonPath = app.isPackaged
+  ? path.join(process.resourcesPath, 'daemon', `ccsm-daemon${ext}`)
+  : (() => {
+      // Round-3 CF-2 (devx): devTarget() is dev-only and gated behind an
+      // explicit env var so a packaged build can never accidentally fall
+      // into the dev path. See frag-3.7 §3.7.2.b for env-gate rationale.
+      if (process.env.CCSM_DAEMON_DEV !== '1') {
+        throw new Error('packaged build expected app.isPackaged=true; set CCSM_DAEMON_DEV=1 only in dev runner');
+      }
+      return path.join(__dirname, '..', '..', 'daemon', 'dist', `ccsm-daemon-${devTarget()}${ext}`);
+    })();
+```
+
+`process.resourcesPath` resolves to (per round-3 P0-1, install root is per-user):
+- Windows: `%LOCALAPPDATA%\ccsm\resources\daemon\ccsm-daemon.exe`
+- macOS: `CCSM.app/Contents/Resources/daemon/ccsm-daemon` (`.app` itself lives under `~/Library/Application Support/ccsm/` per per-user install; user may also drag to `/Applications` — both supported by Gatekeeper)
+- Linux: `~/.local/share/ccsm/resources/daemon/ccsm-daemon` (AppImage extracts here; `.deb` / `.rpm` install to the same per-user root via electron-builder's `category=Utility` + post-install symlink in `~/.local/bin`)
+
+Validation: extend `scripts/after-pack.cjs` (today only checks node-pty at `:48-83`) with the explicit post-pack required-files list below — hard-fail the build if any are missing. **[manager r7 lock: r6 packaging P1-A — after-pack.cjs explicit validation list]**
+
+```js
+// scripts/after-pack.cjs (extension; per OS)
+// Round-3 P0-3: ccsm_native.node carries winjob+pdeathsig+pipeAcl.
+// R7 P1-A: explicit list — drift between this list and before-pack.cjs
+// REQUIRED_NATIVES + the §11.6.4 helper + §11.2.1 SDK path is a build failure.
+// r9 P1-5: SDK entry assertion strengthened — read package.json `module`/`main`
+// and assert the resolved JS file exists (not just package.json), on BOTH the
+// daemon-side staged copy (primary consumer per r9 P0-1) and the Electron-main
+// shim copy (residual sessionTitles consumer).
+const REQUIRED_AFTER_PACK = [
+  // Daemon binary
+  `resources/daemon/ccsm-daemon${ext}`,
+  // Every native dlopen'd by the daemon
+  'resources/daemon/native/better_sqlite3.node',
+  'resources/daemon/native/pty.node',
+  'resources/daemon/native/ccsm_native.node',
+  // §11.6.4 uninstall helper (Win-only existence; mac/Linux skip)
+  ...(process.platform === 'win32' ? ['resources/daemon/ccsm-uninstall-helper.exe'] : []),
+  // §11.2.1 claude-agent-sdk staged paths (R7 P0-1; r9 P0-1 dual-consumer)
+  // Daemon-side primary copy:
+  'resources/daemon/node_modules/@anthropic-ai/claude-agent-sdk/package.json',
+  // Electron-main residual copy (sessionTitles shim):
+  'resources/sdk/claude-agent-sdk/package.json',
+];
+// r9 P1-5: also resolve and assert the SDK ESM entry-point JS exists on BOTH
+// staged copies. Reading `package.json`'s `module` (preferred for ESM) or
+// `main` (CJS fallback) catches the case where before-pack.cjs accidentally
+// copies only package.json and skips dist/ — runtime import() would otherwise
+// fail with MODULE_NOT_FOUND despite a green after-pack run.
+const SDK_PKG_ROOTS = [
+  'resources/daemon/node_modules/@anthropic-ai/claude-agent-sdk',
+  'resources/sdk/claude-agent-sdk',
+];
+for (const sdkRoot of SDK_PKG_ROOTS) {
+  const pkgPath = path.join(appOutDir, sdkRoot, 'package.json');
+  if (!fs.existsSync(pkgPath)) continue;  // covered by REQUIRED_AFTER_PACK above
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  const entry = pkg.module ?? pkg.main;
+  if (!entry) {
+    throw new Error(`[after-pack] SDK package.json at ${pkgPath} has neither module nor main`);
+  }
+  const entryPath = path.join(appOutDir, sdkRoot, entry);
+  if (!fs.existsSync(entryPath)) {
+    throw new Error(`[after-pack] SDK entry-point missing: ${entryPath} (resolved from ${pkgPath} ${pkg.module ? 'module' : 'main'} = ${entry})`);
+  }
+}
+// Plus on Win: Get-AuthenticodeSignature on every signtool target (§11.3.1 $targets).
+// Plus on mac: codesign -dv --verbose=2 on every codesign target (§11.3.2 loop set).
+// Missing or unsigned → throw and fail the electron-builder run.
+```
+
+#### 11.2.1 `claude-agent-sdk` packaging contract (R7 P0-1; r9 daemon-primary rewrite)
+
+**[manager r9 lock: r8 packaging P0-1 — daemon owns SDK direct ESM; Electron-main shim residual only]** Per frag-3.7 §3.7.7.b r7 lock ("daemon owns ALL SDK runtime use — agent dispatch, streaming, tool execution, model API calls; new daemon code MUST NOT use the shim; Electron-main `loadSdk` shim retained ONLY for residual session-title/non-daemon SDK calls"), the SDK has **two consumers** in v0.3 with asymmetric primacy:
+
+- **Primary: daemon** — runs as a standalone pkg-bundled Node 22 binary with native ESM support. Imports the SDK directly via `import { ... } from '@anthropic-ai/claude-agent-sdk'`, resolved against the daemon binary's sibling `node_modules/` tree. No shim required (Node 22 ESM is first-class; daemon is not Electron-main CJS).
+- **Residual: Electron-main `loadSdk()` shim** — kept only for residual session-title bookkeeping (`getSessionInfo` / `renameSession` / `listSessions` per `electron/sessionTitles/index.ts:59`'s private `loadSdk()` function). Electron-main is CJS so the dynamic-`import()`-via-`new Function` shim stays. Resolves against `process.resourcesPath/sdk/`.
+
+Packaging stages the SDK to **two locations** so each consumer resolves locally:
+
+```json
+"extraResources": [
+  { "from": "daemon/dist/ccsm-daemon-staged${ext}",        "to": "daemon/ccsm-daemon${ext}" },
+  { "from": "daemon/native-staged",                        "to": "daemon/native" },
+  { "from": "daemon/sdk-staged",                           "to": "daemon/node_modules/@anthropic-ai/claude-agent-sdk" },
+  { "from": "node_modules/@anthropic-ai/claude-agent-sdk", "to": "sdk/claude-agent-sdk" }
+]
+```
+
+`before-pack.cjs` asserts `node_modules/@anthropic-ai/claude-agent-sdk/package.json` exists, then:
+1. Copies the SDK + its resolved transitive `node_modules` closure into `daemon/sdk-staged/` (consumed by the daemon-side `extraResources` row above; the install layout becomes `<resources>/daemon/node_modules/@anthropic-ai/claude-agent-sdk/...` which is a real `node_modules` lookup the pkg-bundled daemon's `require.resolve` walks).
+2. Copies the same SDK + closure into `node_modules/@anthropic-ai/claude-agent-sdk/` (already there from `npm install`; the second `extraResources` row stages it under `<resources>/sdk/claude-agent-sdk/` for the residual Electron-main `loadSdk()` shim).
+This avoids `MODULE_NOT_FOUND` against hoisted root `node_modules` that won't exist in the packaged app, on either consumer side.
+
+2. **`asarUnpack` rule.** Both consumers resolve from outside `app.asar` (daemon never touches asar at all; Electron-main shim resolves from `process.resourcesPath/sdk/`). For defense-in-depth against a future maintainer accidentally moving the SDK back inside the asar:
+   ```json
+   "asarUnpack": [
+     "node_modules/@anthropic-ai/claude-agent-sdk/**/*",
+     "**/*.node"
+   ]
+   ```
+   The `**/*.node` glob is the canonical electron-builder pattern for native addons. The asarUnpack rule applies to both `node_modules/@anthropic-ai/claude-agent-sdk/` (Electron-main shim path, even though it normally resolves via `process.resourcesPath/sdk/`) and the daemon-side staged copy (which is not in asar to begin with — pkg-bundled binaries don't read asar).
+
+3. **Native artifacts in the SDK.** Audit at lock time — `claude-agent-sdk@latest` (npm) ships **no `.node` files** in its dependency closure (verified via `npm ls --all` against the working repo's `node_modules/@anthropic-ai/claude-agent-sdk/` at the version pinned in `package.json`). If a future version adds a native (e.g. tokenizer), it MUST be added to:
+   - `before-pack.cjs` `REQUIRED_NATIVES` (so missing → build fails),
+   - the §11.3.1 `$targets` signtool array (so it's signed on Win),
+   - the §11.3.2 `for node in ...` codesign loop (so it's signed on mac with the daemon entitlements).
+   Today the audit is "no `.node`s present"; the spec line above is the contract.
+
+4. **Bundle-size budget contribution.** SDK + transitive deps measure ~6 MB **per consumer copy**, ~12 MB total because both the daemon-side and Electron-main-side staging rows ship a full closure (no dedupe — the two consumers must resolve via independent `node_modules` trees because their require/import resolvers walk from different roots and an asarUnpack-shared copy would couple Electron-main upgrades to daemon resolution). This is folded into the §11.5 installer-size budget below (the 145 MB / 160 MB / 140 MB ceilings include the duplicated SDK).
+
+5. **Load-path resolution (per consumer).** **[manager r9 lock: r8 packaging P0-1 — daemon-primary, Electron-main residual]**
+
+   **Daemon (primary).** Direct ESM, no shim:
+   ```ts
+   // daemon/src/<wherever the SDK is first used>.ts
+   import { query, type SDKMessage } from '@anthropic-ai/claude-agent-sdk';
+   // resolves via daemon binary's sibling node_modules:
+   //   <resources>/daemon/node_modules/@anthropic-ai/claude-agent-sdk/...
+   // (pkg-bundled binary's require.resolve walks from path.dirname(process.execPath))
+   ```
+   No `app.isPackaged` branch — the daemon runs only as a packaged binary in production; in dev (`CCSM_DAEMON_DEV=1`, see §11.2 `devTarget()` gate) the daemon resolves via the workspace's hoisted `node_modules` like any other Node process.
+
+   **Electron-main (residual, sessionTitles only).** The `loadSdk` shim is a private async function inside `electron/sessionTitles/index.ts` (private `async function loadSdk(): Promise<SdkExports>` at `electron/sessionTitles/index.ts:59` on working tip — NOT a standalone module). Per the project memory lock, NEW code MUST go through the daemon path above; the shim is retained ONLY for the existing session-title bookkeeping calls already wired through it. The shim's resolution path under packaged builds:
+   ```ts
+   // resolution path INSIDE the loadSdk function in electron/sessionTitles/index.ts:59
+   // (not a separate file — the patch lives where loadSdk is defined)
+   const sdkRoot = app.isPackaged
+     ? path.join(process.resourcesPath, 'sdk', 'claude-agent-sdk')
+     : path.join(__dirname, '..', '..', 'node_modules', '@anthropic-ai', 'claude-agent-sdk');
+   const sdkPkg = require(path.join(sdkRoot, 'package.json'));
+   const sdkEntry = sdkPkg.module ?? sdkPkg.main;
+   const sdk = await import(pathToFileURL(path.join(sdkRoot, sdkEntry)).href);
+   ```
+   `process.resourcesPath` is the per-user install root from §11.2 (Win: `%LOCALAPPDATA%\ccsm\resources\`, mac: `CCSM.app/Contents/Resources/`, Linux: `~/.local/share/ccsm/resources/`). Dev branch resolves from hoisted root `node_modules` (no asar in dev). Once the residual sessionTitles calls are migrated to the daemon (post-v0.3 deferred), the entire `electron/sessionTitles/` SDK code path can be deleted along with the second `extraResources` row above.
+
+### 11.3 Code-signing (daemon BEFORE installer)
+
+The installer signature does **not** propagate inward. electron-builder signs the outer `.exe` / `.app` after `extraResources` are copied in, but it does **not** re-sign nested binaries. An unsigned `ccsm-daemon.exe` inside a signed installer triggers SmartScreen on every spawn; an unsigned Mach-O inside a signed `.app` fails `codesign --verify --deep` and Gatekeeper kills the app. So: **daemon binary must be signed before electron-builder packages it**.
+
+Same cert as the app. v0.2 release.yml uses `CSC_LINK` + `CSC_KEY_PASSWORD` for both Win and macOS (`.github/workflows/release.yml:143-144,162-164`); macOS adds `APPLE_ID` / `APPLE_ID_PASSWORD` / `APPLE_TEAM_ID` for notarization (`:145-147`). Daemon reuses all of them.
+
+#### 11.3.1 Windows (`signtool`)
+
+After `npm run build:daemon`, before electron-builder. **Round-2 P0-2** mandates signing every `.node` next to the daemon (an unsigned `.node` dlopen'd from a signed exe trips Defender / SmartScreen on hardened systems). **Round-2 P1-6** says don't hardcode the Win SDK path — let the GHA `windows-latest` PATH resolve `signtool.exe` (Microsoft.WindowsAppSDK + .NET workloads put it on PATH). **Round-2 SH3** adds explicit `signtool verify /pa /v` after sign.
+
+```yaml
+# release.yml (new step, runs only on windows-latest, after Build daemon)
+- name: Sign daemon binary + every .node (Windows)
+  if: matrix.platform == 'win' && steps.secrets.outputs.signed == 'true'
+  shell: pwsh
+  run: |
+    $pfx = "$env:RUNNER_TEMP\csc.pfx"
+    [IO.File]::WriteAllBytes($pfx, [Convert]::FromBase64String("${{ secrets.CSC_LINK }}"))
+
+    # Find signtool on PATH (round-2 P1-6: do NOT hardcode 10.0.22621.0)
+    $signtool = (Get-Command signtool.exe -ErrorAction SilentlyContinue).Source
+    if (-not $signtool) {
+      $signtool = Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\bin\*\x64\signtool.exe" |
+                  Sort-Object FullName -Descending | Select-Object -First 1 -ExpandProperty FullName
+    }
+    if (-not $signtool) { throw "signtool.exe not found" }
+
+    # Sign daemon + every .node we ship (round-2 P0-2)
+    $targets = @('daemon\dist\ccsm-daemon-win-x64.exe') +
+               (Get-ChildItem -Recurse 'daemon\native\win32-x64\*.node' | ForEach-Object { $_.FullName })
+    foreach ($t in $targets) {
+      & $signtool sign /f $pfx /p "${{ secrets.CSC_KEY_PASSWORD }}" `
+        /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 `
+        /d "CCSM Daemon" $t
+      # Round-2 SH3: verify and fail the build if signature isn't trusted
+      & $signtool verify /pa /v $t
+      if ($LASTEXITCODE -ne 0) { throw "signtool verify failed: $t" }
+    }
+    Remove-Item $pfx
+```
+
+Notes:
+- Same SHA-256 timestamp server (`http://timestamp.digicert.com`) used implicitly by electron-builder's nsis signer — keeps both signatures verifiable side-by-side.
+- `CSC_LINK` is a base64 PFX (electron-builder convention); decode to a temp file, use, delete. Don't keep on disk.
+- If `secrets.signed != 'true'` (PR builds, forks): **skip signing, do not fail**. Mirrors v0.2 behavior (release.yml:104-123, "builds MUST continue unsigned if absent").
+
+#### 11.3.2 macOS (`codesign` + hardened runtime + entitlements)
+
+pkg-bundled Node uses V8 JIT, so the daemon needs hardened-runtime entitlements that allow JIT. `build/entitlements.daemon.plist` (new):
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key><true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key><true/>
+  <key>com.apple.security.cs.disable-library-validation</key><true/>
+</dict>
+</plist>
+```
+
+Sign step (runs on macos-latest, before electron-builder). **Round-2 P0-2** loops over every `.node` in addition to the daemon Mach-O — `codesign` does not recurse into dlopen'd `.node` files. **Round-2 SH2** moves the keychain unlock password to a `MACOS_KEYCHAIN_PW` secret (avoids fixed `actions` literal appearing in CI logs).
+
+```yaml
+- name: Sign daemon binary + every .node (macOS)
+  if: matrix.platform == 'mac' && steps.secrets.outputs.signed == 'true'
+  shell: bash
+  run: |
+    # Import cert into a temp keychain (same pattern electron-builder uses internally).
+    KC="$RUNNER_TEMP/build.keychain"
+    KC_PW="${{ secrets.MACOS_KEYCHAIN_PW }}"   # round-2 SH2
+    security create-keychain -p "$KC_PW" "$KC"
+    security default-keychain -s "$KC"
+    security unlock-keychain -p "$KC_PW" "$KC"
+    echo "${{ secrets.CSC_LINK }}" | base64 --decode > "$RUNNER_TEMP/csc.p12"
+    security import "$RUNNER_TEMP/csc.p12" -k "$KC" -P "${{ secrets.CSC_KEY_PASSWORD }}" -T /usr/bin/codesign
+    security set-key-partition-list -S apple-tool:,apple: -s -k "$KC_PW" "$KC"
+
+    IDENTITY="Developer ID Application: ${{ secrets.APPLE_TEAM_ID }}"
+    for arch in x64 arm64; do
+      # r9 P1-3: codesign loop iterates BOTH the daemon Mach-O AND the
+      # uninstall-helper Mach-O per arch. Spec §11.6.4 requires the helper
+      # signed for future tray-driven "Reset CCSM" flows; the previous
+      # iteration only covered the daemon binary. Helper Mach-O is produced
+      # by pkg-bundling on macOS regardless of whether the v0.3 macOS tray
+      # currently invokes it (§11.6.2 documents no native uninstaller today).
+      # Sign every .node first (inside-out, round-2 P0-2)
+      for node in daemon/native/darwin-$arch/*.node; do
+        [ -f "$node" ] || continue
+        codesign --force --timestamp --options runtime \
+          --entitlements build/entitlements.daemon.plist \
+          --sign "$IDENTITY" "$node"
+        codesign --verify --strict --verbose=2 "$node"
+      done
+      # Sign daemon binary AND uninstall-helper Mach-O for this arch.
+      for bin in "daemon/dist/ccsm-daemon-macos-$arch" "daemon/dist/ccsm-uninstall-helper-macos-$arch"; do
+        [ -f "$bin" ] || continue
+        codesign --force --timestamp --options runtime \
+          --entitlements build/entitlements.daemon.plist \
+          --sign "$IDENTITY" "$bin"
+        codesign --verify --strict --verbose=2 "$bin"
+      done
+    done
+    rm "$RUNNER_TEMP/csc.p12"
+```
+
+Notarization: the daemon is embedded in `.app/Contents/Resources/daemon/`, so notarytool's submission of the outer `.dmg` (electron-builder's existing flow) covers it — *provided* it was signed first with hardened runtime + same Developer ID. Standalone daemon binary published to GitHub Releases (for the daemon-only updater channel, §11.6) is notarized separately:
+
+```yaml
+- name: Notarize standalone daemon binary (macOS)
+  if: matrix.platform == 'mac' && steps.secrets.outputs.signed == 'true'
+  shell: bash
+  run: |
+    for arch in x64 arm64; do
+      ditto -c -k --keepParent "daemon/dist/ccsm-daemon-macos-$arch" "daemon/dist/ccsm-daemon-macos-$arch.zip"
+      xcrun notarytool submit "daemon/dist/ccsm-daemon-macos-$arch.zip" \
+        --apple-id "${{ secrets.APPLE_ID }}" \
+        --password "${{ secrets.APPLE_ID_PASSWORD }}" \
+        --team-id "${{ secrets.APPLE_TEAM_ID }}" \
+        --wait
+    done
+```
+(Stapling not applicable to standalone Mach-O; notarization ticket is fetched online by Gatekeeper.) **[manager r7 lock: r6 packaging P1-C — DMG stapling explicitly asserted]** The outer `.dmg` IS stapled (offline Gatekeeper requires it on first launch with no network). electron-builder calls `xcrun stapler staple` automatically only when its `mac.notarize` config is truthy — the spec asserts this explicitly:
+
+```json
+"build": {
+  "mac": {
+    "notarize": { "teamId": "${env.APPLE_TEAM_ID}" }
+  }
+}
+```
+
+Plus an explicit post-build verification in the macOS leg of `release.yml` to fail loud if electron-builder regresses on the implicit stapling:
+
+```yaml
+- name: Assert DMG is stapled (R7 P1-C)
+  if: matrix.platform == 'mac'
+  shell: bash
+  run: |
+    for dmg in release/*.dmg; do
+      xcrun stapler validate "$dmg" || { echo "::error::DMG not stapled: $dmg"; exit 1; }
+    done
+```
+
+**Standalone-daemon zip naming convention (R7 P1-E).** **[manager r7 lock: r6 packaging P1-E — standalone daemon zip naming]** The `ditto -c -k --keepParent` form above produces zips named `ccsm-daemon-macos-${arch}.zip` whose top-level entry is the per-arch unique Mach-O leaf (`ccsm-daemon-macos-x64` or `ccsm-daemon-macos-arm64`). The naming convention is locked at:
+- macOS: `ccsm-daemon-macos-${arch}.zip` (arch ∈ {x64, arm64}); top-level = single Mach-O of the same name.
+- Windows standalone (future daemon-only updater): `ccsm-daemon-win-${arch}.zip`; top-level = `ccsm-daemon-win-${arch}.exe`.
+- Linux standalone: `ccsm-daemon-linux-${arch}.tar.gz` (no zip — Linux convention); top-level = single ELF `ccsm-daemon-linux-${arch}`.
+
+These names are referenced by the daemon-only updater feed (§11.5(4) deferred sketch) and by the SHA256SUMS / SLSA subject-path globs in §11.4. Any rename requires a spec edit because the updater feed URL pattern is derived from these names.
+
+#### 11.3.3 Linux
+
+No signing infrastructure today (review §4 implicit). Linux daemon binary ships unsigned; integrity via SHA256SUMS only.
+
+### 11.4 SHA256SUMS.txt manifest
+
+Published alongside release artifacts. Auto-updater (Electron + daemon) downloads + verifies before applying.
+
+> **Round-2 S1 correction**: per-platform SHA computation cannot see other platforms' daemon binaries. Compute SHAs in the **merge `release-publish` job** after downloading every platform's artifacts, so one manifest covers everything (installers + standalone daemons + updater feed YMLs).
+
+Per-platform job uploads the raw artifacts (already done by electron-builder + the new `Build daemon` step). Final `release-publish` job (new, `needs: [build]`):
+
+```yaml
+- uses: actions/download-artifact@v4
+  with: { path: dist-all }   # pulls every matrix leg's artifacts
+- name: Compute SHA256 (round-2 S1 — single source of truth)
+  shell: bash
+  run: |
+    cd dist-all
+    : > ../SHA256SUMS.txt
+    # Installers + daemons + electron-updater feed YMLs (round-2 §6 manifest scope)
+    find . -type f \( \
+        -name '*.exe' -o -name '*.dmg' -o -name '*.zip' \
+        -o -name '*.AppImage' -o -name '*.deb' -o -name '*.rpm' \
+        -o -name 'ccsm-daemon-*' \
+        -o -name 'latest*.yml' \
+      \) -print0 | sort -z | xargs -0 sha256sum >> ../SHA256SUMS.txt
+- uses: softprops/action-gh-release@v2
+  with:
+    files: |
+      SHA256SUMS.txt
+      provenance.intoto.jsonl
+```
+
+#### 11.4.1 SLSA-3 build provenance (round-2 P0-S3 / security)
+
+SHA256 alone gives integrity vs network corruption, NOT authenticity (round-1 S5, round-2 security P0-S3). A pipeline-secret compromise replaces both binary and `SHA256SUMS.txt` in one push. v0.3 closes this with a free, GitHub-native SLSA-3 attestation — no sigstore key infrastructure required:
+
+```yaml
+# In the release-publish job, AFTER all artifacts downloaded
+- name: Generate SLSA build provenance
+  uses: actions/attest-build-provenance@v1
+  with:
+    subject-path: |
+      dist-all/**/*.exe
+      dist-all/**/*.dmg
+      dist-all/**/*.AppImage
+      dist-all/**/*.deb
+      dist-all/**/ccsm-daemon-*
+      dist-all/SHA256SUMS.txt
+```
+
+`actions/attest-build-provenance@v1` writes a signed `provenance.intoto.jsonl` whose signing identity is GitHub's OIDC root (Fulcio-anchored). The Electron + daemon updater verifies the attestation before swap using **`@sigstore/verify` 1.x** (pure-JS, ~2 MB add to the Electron bundle, handles in-toto SLSA v1.0 bundles via Rekor lookup) — short-circuits the manual-update prompt if attestation absent or signing identity mismatched. The verifier library choice is locked here per round-3 CF-4; the actual verify call lives in frag-6-7 §6.4 step 2. Linux additionally publishes a minisign signature (one-time keypair, `MINISIGN_KEY` secret, ~30 LOC):
+
+```yaml
+- name: Sign Linux artifacts (minisign — round-2 P0-S3)
+  if: matrix.platform == 'linux'
+  run: |
+    echo "${{ secrets.MINISIGN_KEY }}" > /tmp/minisign.key
+    for f in release/*.AppImage release/*.deb release/*.rpm daemon/dist/ccsm-daemon-linux-x64; do
+      [ -f "$f" ] && minisign -S -s /tmp/minisign.key -m "$f"
+    done
+    shred -u /tmp/minisign.key
+```
+
+This makes the v0.4 sigstore plan a strict superset rather than "we shipped insecure on purpose for one release." Public minisign verify key shipped in the installer + documented in release notes.
+
+### 11.5 CI changes (release.yml)
+
+Net diff vs current `.github/workflows/release.yml`:
+
+0. **`actions/setup-node` bumped from `node-version: '20'` to `'22'`** in both `verify` (`:33`) and `build` (`:84`) jobs (round-2 P1-3). **Electron is pinned to `^41.3.0`** in root `package.json` `devDependencies.electron` (verified against `pool-1/package.json` on 2026-05-01; user-memory baseline of "Electron 33" was stale — current working tip ships Electron 41.x). Electron 41 ships its own Node 20.x at runtime — they are separate processes, no compat conflict. Bumping the toolchain Node lets `@yao-pkg/pkg` resolve its base binary from the local install instead of fetching ~30 MB on every CI run, and matches the daemon's Node 22 ABI target. [manager r7 lock: r6 lockin P0 — Electron version pinned to ^41.3.0 per pool-1/package.json check on 2026-05-01.]
+
+   **Electron upgrade plan**: v0.3 ships on Electron `^41.3.0` (caret allows patch-level autoupdate within 41.x). The next major bump (Electron 42+) is **deferred until post-v0.3 ship**; bumping is a separate scoped task that must (a) re-verify the `loadSdk()` shim contract for `claude-agent-sdk` (Electron-main is CJS, SDK is ESM-only — see frag-3.5.1 for the canonical lock and shim ownership), (b) re-run the per-`.node` ABI rebuild matrix (`better_sqlite3`, `pty`, `ccsm_native`), (c) re-validate `before-pack.cjs` / `after-pack.cjs` against the new electron-builder + Electron pair. No Electron major bump is in v0.3 scope.
+
+   **[manager r9 lock: r8 packaging P1-2 — caret-range size budget recalibration]** The §11.5(6) installer-size budget (145 MB / 160 MB / 140 MB) is calibrated against the Electron 41 minor pinned by `package-lock.json` at the moment the budget was set. The caret on `^41.3.0` allows minor jumps (Electron ships ~2 minors per quarter; a 41.4.x or 41.5.x bump can add ~3 MB to the packaged payload). Calibration policy: the size budget is recomputed on every minor Electron bump (any `package-lock.json` diff that changes the resolved Electron minor or higher), and the §11.5(6) CI guard fails the build if the measured installer size delta is >5 MB versus the prior-locked baseline without an explicit size-budget bump PR (spec edit raising the ceiling, with reviewer sign-off, in the same PR as the lockfile change). `package-lock.json` is the authoritative version-of-record for the budget; the `^41.3.0` caret in `package.json` documents the supported floor but the lockfile is what the budget is calibrated against.
+
+   **SDK loading discipline (cross-ref)**: this section addresses packaging only. For the `loadSdk()` shim contract that Electron-main consumers MUST go through (`claude-agent-sdk` is ESM-only, Electron 41 main is CJS), see frag-3.5.1's loadSdk ownership lock; frag-11 enforces packaging (extraResources + signing) without re-litigating shim discipline.
+0a. **`hashFiles`-cache key extended to include `daemon/package-lock.json`** so daemon workspace installs are cached separately from root.
+1. **`verify` job (`:26-47`)**: add `npm -w @ccsm/daemon run build` AND `npm -w @ccsm/daemon run test` after `npm test` — daemon TS compiles + daemon unit tests run in pre-flight (round-2 P1-3 + frag-3.5.1 §3.5.1.6 acceptance criteria).
+2. **`build` job (`:49-179`)**: new step `Build + sign daemon binary` runs **before** "Package (Linux/macOS/Windows)" steps (`:132-164`):
+   - `npm run build:daemon` (compiles + rebuilds natives incl. `ccsm_native.node` + pkg-bundles, no GZip)
+   - Sign step per platform (§11.3.1 covers daemon exe + every `.node`; §11.3.2 mac codesigns same set)
+   - Then existing `npx electron-builder` step picks up signed binary + signed natives via `extraResources` (which `before-pack.cjs` stages)
+3. **Daemon binary uploaded as separate release asset** (for future daemon-only updater) by extending the upload globs at `:170-178` and `:192-200`:
+   ```yaml
+   files: |
+     release/*.exe
+     ...
+     daemon/dist/ccsm-daemon-*
+     SHA256SUMS.txt
+     provenance.intoto.jsonl
+     *.minisig
+   ```
+4. **Single tag (`v*`) for v0.3.0** — no separate `daemon-v*` tag yet (review §4 SHOULD-FIX #6: first ship has no install base; reserve `daemon-v*` for v0.3.1+ daemon-only patches). When v0.3.1 ships, a separate matrix that builds **only** the daemon (skips electron-builder) is required — sketched in §11.6 deferred so it isn't a panic-rewrite at v0.3.1 release time.
+5. **Cert-missing handling**: if `steps.secrets.outputs.signed != 'true'`, skip daemon-sign step with a `::warning::` (matches v0.2 line `:152-156`). PR builds + forks must continue producing unsigned artifacts; only tag pushes from `Jiahui-Gu/ccsm` get the secrets.
+6. **Installer size budget + CI guard (R7 P1-B).** **[manager r7 lock: r6 packaging P1-B — installer size ceiling + CI assertion]** Target sizes (uncompressed installer; measured at release-publish merge job, fail the build over):
+   - Windows NSIS `*.exe`: **≤ 145 MB** (Electron 41 ~95 MB + bundled Chromium fonts, daemon pkg ~50 MB incl. Node 22 base + better-sqlite3 + node-pty + ccsm_native, claude-agent-sdk ~6 MB per §11.2.1, uninstall-helper ~5 MB, headroom ~5 MB).
+   - macOS DMG: **≤ 160 MB** (Electron Mach-O is fatter; daemon ships per-arch but DMG carries one arch).
+   - Linux AppImage: **≤ 140 MB**; `.deb` / `.rpm`: **≤ 125 MB**.
+
+   Standalone daemon binary (`ccsm-daemon-${platform}-${arch}`): **≤ 60 MB** per arch.
+
+   CI assertion in `release-publish` job (after artifacts downloaded, before `gh release upload`):
+   ```yaml
+   - name: Assert installer size budgets (R7 P1-B)
+     shell: bash
+     run: |
+       declare -A LIMIT_MB=(
+         [exe]=145 [dmg]=160 [AppImage]=140 [deb]=125 [rpm]=125
+       )
+       fail=0
+       for f in dist-all/**/*.{exe,dmg,AppImage,deb,rpm}; do
+         [ -f "$f" ] || continue
+         ext="${f##*.}"
+         size_mb=$(( $(stat -c%s "$f") / 1024 / 1024 ))
+         lim="${LIMIT_MB[$ext]}"
+         echo "$f -> ${size_mb} MB (limit ${lim} MB)"
+         if [ "$size_mb" -gt "$lim" ]; then
+           echo "::error::$f exceeds ${lim} MB budget (got ${size_mb} MB)"
+           fail=1
+         fi
+       done
+       # Standalone daemon binaries
+       for f in dist-all/**/ccsm-daemon-*; do
+         [ -f "$f" ] || continue
+         size_mb=$(( $(stat -c%s "$f") / 1024 / 1024 ))
+         if [ "$size_mb" -gt 60 ]; then
+           echo "::error::$f exceeds 60 MB budget (got ${size_mb} MB)"; fail=1
+         fi
+       done
+       exit $fail
+   ```
+   Budget changes require a spec-edit + reviewer sign-off (no silent CI bumps); the rationale is that uncontrolled growth turns the per-user installer into a "do I really want to install this 200 MB thing" friction point that competitors (raw CLI, plain VSCode) don't have.
+
+### 11.6 NSIS uninstall hygiene (round-2 P0-1 — reclaimed from frag-6-7; round-3 P0-1/P0-2/P0-4 path corrections)
+
+**Why frag-11 owns this.** Round-1 packaging review §3.4 demanded an NSIS `customUnInstall` script. Frag-11 originally punted to "lifecycle / frag-6-7 §3.1," but frag-6-7 covers daemon shutdown RPC + lockfile semantics — it does NOT define an NSIS macro, electron-builder `nsis.include` wiring, `.deb` postrm, or `.rpm` %preun scripts. NSIS scripts + electron-builder config are pure packaging concerns and belong here. Cross-frag rationale (§ Cross-frag rationale at bottom) coordinates the seam with frag-6-7's `daemon.shutdown` RPC and proper-lockfile cleanup (round-2 P1-5).
+
+**Surface vs disk-mechanics split (round-3 X3 dedupe).** The in-app surface that *triggers* uninstall-style cleanup (close-to-tray menu item, "Reset CCSM…" tray menu, post-uninstall toast, etc.) is owned by **frag-6-7 §6.8** with a numeric priority registry. Frag-11 §11.6 owns only the disk-removal *mechanics*: NSIS `customUnInstall`, `.deb` postrm, `.rpm` %preun, the canonical paths table, and the `ccsm-uninstall-helper.exe` orchestration shim. Cross-ref: see frag-6-7 §6.8 for the in-app surface registry; frag-11 §11.6 owns disk-removal mechanics on each OS.
+
+**Per-user install root (round-3 P0-1; r9 oneClick reconciled with working tip).** **[manager r9 lock: r8 packaging P0-2 — keep working-tip `oneClick: false` / `allowElevation: true` / `allowToChangeInstallationDirectory: true` for v0.3 freeze; assisted-mode installer wizard preserved; user can change install dir; no UX migration friction; updater compatible.]** electron-builder NSIS is configured with:
+
+```json
+"build": {
+  "nsis": {
+    "include": "build/installer.nsh",
+    "perMachine": false,
+    "oneClick": false,
+    "allowElevation": true,
+    "allowToChangeInstallationDirectory": true,
+    "deleteAppDataOnUninstall": false
+  }
+}
+```
+
+Rationale for keeping `oneClick: false` (not flipping to `oneClick: true`):
+- **No UX migration friction**: working tip already ships the assisted-mode wizard; v0.3 keeps it. `oneClick: true` would silently strip the install-path picker, the finish page, and the "Run CCSM" checkbox — a UX regression on every existing user's upgrade.
+- **`allowToChangeInstallationDirectory: true` survives**: power users who keep `%LOCALAPPDATA%` on a smaller SSD can redirect to a different drive at install time. `oneClick: true` would have forced this off.
+- **`allowElevation: true` is harmless under `perMachine: false`**: when the chosen install dir is `%LOCALAPPDATA%` no UAC fires; if the user redirects to an elevation-required path (e.g. `D:\Program Files\ccsm`) UAC prompts and the install proceeds. The `perMachine: false` lock keeps the auto-update-without-UAC contract for the default install location.
+- **Updater-compatible**: electron-updater works identically with assisted-mode NSIS; the upgrade-in-place flow in §11.6.5 is unaffected.
+- **`customUnInstall` macro stays silent**: with `oneClick: false` the installer/uninstaller has its own first-class UI. The previously-proposed `MessageBox MB_YESNO` in §11.6.1 is dropped (see §11.6.1 below) — modal dialogs from inside `customUnInstall` are inappropriate for the assisted-mode uninstaller flow which already has its own progress UI; it would also auto-default to "No" under silent (`/S`) updater-driven uninstall paths, silently skipping user-data cleanup. The macro now performs the always-safe disk-removal mechanics (kill daemon, drop install root) and leaves opt-in user-data cleanup to a separate user-initiated flow (frag-6-7 §6.8 in-app "Reset CCSM…" surface).
+
+`perMachine: false` makes NSIS install to `%LOCALAPPDATA%\ccsm\` (i.e. `$LOCALAPPDATA\ccsm` in NSIS variables) under the invoking user's profile — no UAC prompt, no `Program Files` write, auto-update can write in-place from a non-elevated Electron process. This is the gate that satisfies frag-6-7 §7.4 T9/T14 "user-only ACL" claim: the install root inherits `%LOCALAPPDATA%`'s default ACL (owner = user, no Authenticated-Users read+execute). On macOS the per-user analog is `~/Library/Application Support/ccsm/`; on Linux `~/.local/share/ccsm/` (AppImage extraction target; `.deb`/`.rpm` install symlinks from the same root via `category=Utility`).
+
+**v0.3 daemon-owned paths** (canonical list — single source of truth; round-3 P0-2 reconciles every row to per-user OS-native roots, NOT `~/.ccsm/`):
+
+| Path (Windows) | Path (macOS) | Path (Linux) | Owner | Cleanup default | Opt-in cleanup |
+|---|---|---|---|---|---|
+| `%LOCALAPPDATA%\ccsm\resources\daemon\` | `~/Library/Application Support/ccsm/resources/daemon/` | `~/.local/share/ccsm/resources/daemon/` | installer | always (uninstaller wipes install root) | n/a |
+| `%LOCALAPPDATA%\ccsm\daemon.lock` | `~/Library/Application Support/ccsm/daemon.lock` | `~/.local/share/ccsm/daemon.lock` | proper-lockfile (frag-6-7 §6.4) | always (stale PID) | always |
+| `%LOCALAPPDATA%\ccsm\daemon.secret` | `~/Library/Application Support/ccsm/daemon.secret` | `~/.local/share/ccsm/daemon.secret` | Electron-main (frag-6-7 §7.2) | retained (rollback) | deleted |
+| `%LOCALAPPDATA%\ccsm\data\` | `~/Library/Application Support/ccsm/data/` | `~/.local/share/ccsm/data/` | daemon SQLite (frag-8 §8.3) | retained | deleted |
+| `%LOCALAPPDATA%\ccsm\logs\` | `~/Library/Application Support/ccsm/logs/` | `~/.local/share/ccsm/logs/` | pino-roll (frag-6-7 §6.6) | retained | deleted |
+| `%LOCALAPPDATA%\ccsm\crashes\` | `~/Library/Application Support/ccsm/crashes/` | `~/.local/share/ccsm/crashes/` | crash dumps (security T13) | retained | deleted |
+| Named pipe / Unix socket | (same) | (same) | daemon at runtime | always (OS cleans on process exit) | always |
+
+"Opt-in cleanup" = user checked "Also delete my CCSM data" in the uninstaller. On opt-in, the uninstaller removes the per-user data root **recursively** — every daemon-owned path goes (round-2 P1-5: spell out the full set, don't leave subdirs behind). Every row uses the OS-native per-user data root; the legacy `~/.ccsm/` root is retired in v0.3.
+
+#### 11.6.1 Windows: `build/installer.nsh`
+
+**[manager r9 lock: r8 packaging P0-2 — silent macro, no MessageBox; `oneClick: false` assisted-mode installer owns the user-facing UI; user-data opt-in cleanup is an in-app flow per frag-6-7 §6.8, not an NSIS modal.]**
+
+```nsis
+; build/installer.nsh — wired via package.json build.nsis.include (round-2 P0-1)
+; All paths use $LOCALAPPDATA per round-3 P0-1/P0-2; never $PROGRAMFILES.
+; Silent uninstall macro per r9 P0-2: no MessageBox modal. The assisted-mode
+; (oneClick: false) NSIS uninstaller has its own UI; modal dialogs from inside
+; customUnInstall would either fight that UI or auto-default to "No" under the
+; silent (/S) updater-driven path, silently skipping cleanup. User-data opt-in
+; deletion is performed in-app via the frag-6-7 §6.8 "Reset CCSM…" surface
+; BEFORE the user invokes the uninstaller; this macro only does the always-safe
+; mechanics: stop the daemon, release the lockfile.
+!macro customUnInstall
+  ; 1. Stop the running daemon (frag-6-7 §6.4 daemon.shutdown RPC unreachable post-install).
+  ;    The §11.6.4 helper handles graceful-shutdown-via-RPC first; this taskkill
+  ;    is the safety net.
+  nsExec::ExecToLog 'taskkill /IM ccsm-daemon.exe /F /T'
+  Sleep 500   ; let OS release file handles
+  Delete "$LOCALAPPDATA\ccsm\daemon.lock"
+
+  ; 2. The install root ($INSTDIR under %LOCALAPPDATA%\ccsm) is wiped by the
+  ;    standard NSIS uninstall sequence. User data subdirs (data/, logs/,
+  ;    crashes/, daemon.secret) are NOT touched here — they are retained by
+  ;    default per the §11.6 paths table. Opt-in cleanup happens in-app
+  ;    (frag-6-7 §6.8) before uninstall, OR the user manually deletes
+  ;    %LOCALAPPDATA%\ccsm\ post-uninstall (release-notes documented).
+!macroend
+```
+
+(`deleteAppDataOnUninstall: false` keeps electron-builder's automatic deletion off — user data survives uninstall by default, matching the §11.6 paths table "retained" cleanup default. The full `nsis` block including `oneClick: false / perMachine: false / allowElevation: true / allowToChangeInstallationDirectory: true` is shown above the paths table.)
+
+#### 11.6.2 macOS: no native uninstaller
+
+macOS apps have no uninstaller. The user drags `CCSM.app` to Trash; `~/Library/Application Support/ccsm/` survives. v0.3 ships:
+
+- Release notes that document the manual cleanup steps: drag `CCSM.app` to Trash, then optionally `rm -rf ~/Library/Application\ Support/ccsm` in Terminal.
+
+[manager r7 lock: cut as polish — N1# from r6 feature-parity. The "Reset CCSM…" tray-menu item is DELETED entirely (formerly called `daemon.shutdown` then prompted for `shell.trashItem` of `~/Library/Application Support/ccsm/`). v0.3 macOS tray menu stays at working's `[Show CCSM | Quit]`; uninstall is "drag to Trash" + release-notes guidance only. No new tray entries — v0.3 is refactor scope. The corresponding §6.8 in-app surface contract entry is also deleted by fixer A.]
+
+#### 11.6.3 Linux: `.deb` postrm + `.rpm` %preun
+
+```sh
+# build/linux-postrm.sh (electron-builder injects via deb.postrm / rpm.scripts.preUninstall)
+#!/bin/sh
+set -e
+# Round-3 P0-4: postrm/%preun runs as root with HOME=/root, so the legacy
+# `${HOME:-/root}/.ccsm` expansion was a tautology that never touched real
+# user data. The correct daemon-owned root is per-user (~/.local/share/ccsm)
+# and root cannot enumerate users safely from a maintainer script. We do the
+# minimum safe thing: kill the running daemon and remove the install-root
+# resources (which dpkg/rpm already own). User-data cleanup is documented as a
+# per-user manual step.
+case "$1" in
+  remove|purge)
+    pkill -f /usr/lib/ccsm/resources/daemon/ccsm-daemon || true
+    if [ "$1" = "purge" ] && [ -n "${SUDO_USER:-}" ]; then
+      # Best-effort: if `sudo apt-get purge` was used, we know the invoking
+      # user and can clean their data root. If apt was run as root directly
+      # (no SUDO_USER), skip — release notes tell the user to run the
+      # manual cleanup command below.
+      user_home=$(getent passwd "$SUDO_USER" | cut -d: -f6)
+      if [ -n "$user_home" ] && [ -d "$user_home/.local/share/ccsm" ]; then
+        rm -f  "$user_home/.local/share/ccsm/daemon.lock"
+        rm -rf "$user_home/.local/share/ccsm"
+      fi
+    fi
+    ;;
+esac
+# NOTE: `apt-get purge` without sudo (root login) leaves user data behind by
+# design. Release notes include: `rm -rf ~/.local/share/ccsm` for full cleanup.
+```
+
+(`.rpm` lacks a "purge" mode — document in release notes that user data survives `rpm -e`; user runs `rm -rf ~/.local/share/ccsm` for full cleanup.)
+
+#### 11.6.4 Daemon-shutdown RPC integration (cross-ref frag-6-7)
+
+The hardstop `taskkill` / `pkill` is the safety net. Preferred path: when the user clicks Uninstall, the v0.3 installer first attempts `daemon.shutdown` over the named pipe / Unix socket (frag-6-7 §6.4) for graceful flush — a 2 s timeout, then fall back to kill. This is implemented in the daemon shutdown RPC (frag-6-7 owns the RPC); the NSIS macro orchestrates it via a tiny helper `ccsm-uninstall-helper.exe` shipped in `extraResources`.
+
+```nsis
+; In customUnInstall, before taskkill. Round-3 P1-6: copy the helper to $TEMP
+; first so the in-progress uninstall main loop can RMDir $INSTDIR without
+; tripping a Windows file-lock on the helper exe.
+SetOutPath "$TEMP"
+CopyFiles /SILENT "$INSTDIR\resources\daemon\ccsm-uninstall-helper.exe" "$TEMP\ccsm-uninstall-helper.exe"
+nsExec::ExecToLog '"$TEMP\ccsm-uninstall-helper.exe" --shutdown --timeout 2000'
+Sleep 500
+Delete "$TEMP\ccsm-uninstall-helper.exe"
+```
+
+The helper is a 2-file Node script that pkg-bundles to ~5 MB; reuses the daemon's RPC client. Owned by Task 20e (new). **[manager r7 lock: r6 packaging P1-F — `ccsm-uninstall-helper.exe` is a first-class signed packaging artifact]** It MUST appear in:
+- `before-pack.cjs` staging — copied into `daemon/dist/` next to the daemon binary so electron-builder's `extraResources` `daemon/` glob picks it up at the same `resources/daemon/` path.
+- §11.3.1 signtool `$targets` array on Windows — the helper is invoked at uninstall time from `$TEMP`; an unsigned helper trips Defender / SmartScreen on the same hardened machines that would block an unsigned daemon. The §11.3.1 step is amended: `$targets = @('daemon\dist\ccsm-daemon-win-x64.exe', 'daemon\dist\ccsm-uninstall-helper.exe') + (Get-ChildItem -Recurse 'daemon\native\win32-x64\*.node' | …)`.
+- §11.3.2 codesign loop on macOS — even though macOS does not ship the helper today (no native uninstaller — see §11.6.2), the cross-platform pkg-bundling produces a Mach-O for completeness and the codesign loop signs it (`codesign … "$bin"` step extended to also iterate `daemon/dist/ccsm-uninstall-helper-macos-$arch`) so future tray-driven "Reset CCSM" flows on mac can shell out to it without Gatekeeper rejection.
+- `after-pack.cjs` `REQUIRED_AFTER_PACK` list above (Win-only existence check).
+
+#### 11.6.5 Upgrade-in-place flow (R7 P0-2)
+
+`ccsm-uninstall-helper.exe --shutdown` covers the **uninstall** path; **upgrade-in-place** (electron-updater applying a downloaded `.exe` / `.dmg` over the live install) needs a separate ordering contract because the Electron app's `quitAndInstall` does NOT know about the daemon process (separate PID, separate lockfile). Without an explicit shutdown, the just-upgraded electron-main launches and either (a) attaches to the OLD pre-upgrade daemon via `daemon.lock` (no upgrade actually applied) or (b) NSIS fails to overwrite `ccsm-daemon.exe` due to a Windows file-lock from the running daemon. **[manager r7 lock: r6 packaging P0-2 — upgrade-in-place daemon-shutdown contract]**
+
+Sequence (Electron-main owns the orchestration; cross-ref frag-6-7 §6.4 for the RPC):
+
+1. **Trigger.** `electron-updater` emits `update-downloaded`. Electron-main intercepts BEFORE calling `autoUpdater.quitAndInstall()`.
+2. **Graceful shutdown RPC.** Electron-main sends `daemon.shutdownForUpgrade` over the named pipe / Unix socket (RPC defined in frag-6-7 §6.4). Daemon writes a shutdown marker to `<dataRoot>/daemon.shutdown` (so the next-launched daemon can distinguish upgrade-shutdown from crash recovery), flushes pino buffers, releases the `proper-lockfile` lock on `daemon.lock`, then `process.exit(0)`.
+3. **Ack window.** Electron-main awaits ack with a **5 s timeout** (longer than the 2 s uninstall timeout in §11.6.4 because upgrade flush includes any in-flight session writes; uninstall is destructive so a quick kill is fine). **[manager r9 lock: r8 packaging P1-1 — explicit ack source]** Ack = the unary RPC reply envelope on the control socket (same channel as `daemon.hello`); the timer starts when Electron-main writes the `daemon.shutdownForUpgrade` envelope and stops on receipt of the reply envelope. Socket-EOF and process-handle wait (`WaitForSingleObject` on Win, `waitpid` on POSIX) are NOT used as ack signals — Win can take 100ms+ to reap a process after exit, falsely tripping the force-kill on slow Windows hosts. If no reply within 5 s after sending `daemon.shutdownForUpgrade`, force-kill via OS process handle (`taskkill /F /PID <daemonPid> /T` on Windows, `process.kill(daemonPid, 'SIGKILL')` on POSIX) per step 4.
+4. **Race fallback (no ack within 5 s).** Electron-main force-kills:
+   - Windows: `taskkill /F /PID <daemonPid> /T` (the daemon PID is known from frag-6-7 §6.4 spawn handle; `/T` covers any child processes the daemon spawned).
+   - macOS / Linux: `process.kill(daemonPid, 'SIGKILL')` (POSIX `kill -KILL`).
+   Then unlinks `<dataRoot>/daemon.lock` (proper-lockfile leaves a stale lock dir on `SIGKILL`; the next-start stale-PID recovery in frag-6-7 §6.4 would handle it but unlinking explicitly here is faster and removes the race window described in the next paragraph).
+5. **Proceed with upgrade.** Electron-main calls `autoUpdater.quitAndInstall(isSilent=true, isForceRunAfter=true)`. NSIS / DMG / AppImage installer overwrites the install root (no file-lock now that the daemon is dead).
+6. **New electron-main spawns fresh daemon.** On post-upgrade launch, the new electron-main runs the standard `spawnOrAttach` flow (§11.2): `proper-lockfile` sees no live PID (we unlinked it; or proper-lockfile's stale-PID recovery handles it), `<dataRoot>/daemon.shutdown` marker is consumed (signalling clean upgrade — no crash-loop counter increment), and the new electron-main spawns the new daemon binary from the new bundle path.
+
+**Why lockfile-only is insufficient.** A naive "lockfile gates new daemons" assumption fails the upgrade case: if the old daemon happens to still hold the lock through the upgrade window (electron-updater swap is fast, but daemon process death from `quitAndInstall`-induced Electron exit is racy on Windows since the daemon is a separate process), the upgraded electron-main will see a held lock and ATTACH to the old daemon instead of spawning a new one — running the OLD bundle's daemon code against the NEW bundle's electron-main. The shutdown-marker + explicit-kill + lock-unlink sequence above closes this race window deterministically: the upgraded electron-main always sees no lock and always spawns from the new bundle.
+
+### 11.7 Out of scope (deferred)
+
+- **SmartScreen reputation reset risk on path / scope change (R7 P1-D; r9 P1-4 mitigation honesty fix).** **[manager r9 lock: r8 packaging P1-4 — no EV-cert lock present in §11.3.x; v0.3 ships with standard OV cert + SmartScreen reputation accepted as known cost; EV cert deferred to v0.3+ post-ship if SmartScreen reset becomes a release-blocker.]** The v0.3 install-path lock moved from `Program Files\ccsm\` (any v0.2 path) to `%LOCALAPPDATA%\ccsm\` and from per-machine to per-user. The SmartScreen reputation tuple is `(signer cert, file SHA, install path, scope)` — changing install path AND scope simultaneously resets reputation, so first-launch users on Windows 10/11 with SmartScreen enabled may see "Windows protected your PC" even though the binary is signed with the same Authenticode cert. Mitigation status: §11.3.x specifies `CSC_LINK` + `CSC_KEY_PASSWORD` (a base64 PFX) without locking cert type, and no EV-policy OID is asserted in CI. The v0.3 release ships with the standard OV (Organization Validation) code-signing cert already in use — SmartScreen reputation reset on first-launch is accepted as a known cost, documented in release notes ("expect a 'Windows protected your PC' prompt the first few times after upgrading; click 'More info' → 'Run anyway'; reputation accrues over ~10k installs"). EV cert acquisition is **deferred to a post-v0.3 release** if SmartScreen reset turns out to be a release-blocker in field telemetry; a future EV migration would add a CI-time `signtool verify /v` assertion that the cert carries an EV-policy OID such as `2.23.140.1.3` and remove the release-notes warning.
+
+- Daemon auto-update channel (separate `daemon-v*` tag, daemon-only updater) — covered in §7 / plan Task 23. v0.3.1+ requires a daemon-only build matrix that skips electron-builder; sketch noted in §11.5(4).
+- macOS notarization rate-limit mitigation — accepted as **5 submissions per release** (1 outer `.dmg` via electron-builder + 2 standalone-daemon zips × 2 archs per round-3 P1-5 correction; review §5 OPEN; round-2 packaging S2 confirmed acceptable). All 5 run in parallel `notarytool submit --wait` calls; Apple's documented soft cap is 75/day per Apple ID.
+- GPG / sigstore signing of `SHA256SUMS.txt` — round-2 P0-S3 closed via `actions/attest-build-provenance@v1` (SLSA-3) + Linux minisign for v0.3; v0.4 migrates to full sigstore (cosign keyless).
+- Truly-reproducible pkg builds (byte-identical between runs) — defer to v0.4 native SEA, which produces deterministic single-static binaries by Node design. v0.3 ships with `pkg` (no GZip) and SHA256+SLSA as the integrity story; the reproducible-build CI step in frag-6-7 §7.3 / Task 26 is demoted to "produce + archive SHA256, do not require byte-identical re-runs" (round-2 P1-4 option 1+3).
+
+---
+
+## Plan delta
+
+Insert after plan Task 20 (`2026-04-30-v0.3-daemon-split.md:1474`) and before Task 21 (`:1529`); update Task 24 (`:1628`) accordingly.
+
+- **Task 20 (existing) — `pkg`-bundle the daemon**: keep, but expand step 3 to explicitly rebuild natives against **Node 22 ABI** (`npm rebuild ... --runtime=node --target=22.x`, version pinned via `daemon/.nvmrc` per round-3 P1-3) into `daemon/native/<platform>-<arch>/`, NOT reuse Electron-ABI copy. Also rebuild the in-tree `ccsm_native.node` (single addon carrying winjob+pdeathsig+pipeAcl, frag-3.5.1 §3.5.1.1) in the same loop (round-2 P0-2 / round-3 P0-3 rename). Drop `--compress GZip` (round-2 P1-4). Fill `daemon/package.json` `dependencies` with every runtime dep — no workspace hoisting (round-2 C6). +1.5h.
+- **Task 20a (new) — electron-builder `extraResources` + `beforePack` wiring** (§11.2): add staged-dir `extraResources` block (round-2 S3 token-fix) to `package.json` `build`; add `scripts/before-pack.cjs` to select per-platform daemon binary AND validate every required `.node` (`better_sqlite3`, `pty`, `ccsm_native`); extend `scripts/after-pack.cjs` to verify daemon + natives present. +3h.
+- **Task 20b (new) — Windows signtool integration** (§11.3.1): add sign step to release.yml; loop over daemon exe + every `.node` (round-2 P0-2); use PATH-discovered signtool with newest-SDK fallback (round-2 P1-6); add `signtool verify /pa /v` (round-2 SH3); PR-build skip path. +2.5h.
+- **Task 20c (new) — macOS codesign + hardened-runtime entitlements** (§11.3.2): add `build/entitlements.daemon.plist`; per-arch sign loop over daemon Mach-O + every `.node` (round-2 P0-2); switch keychain unlock to `MACOS_KEYCHAIN_PW` secret (round-2 SH2); standalone-binary notarytool submission. +3.5h.
+- **Task 20d (new) — SHA256SUMS.txt + SLSA provenance + Linux minisign** (§11.4): single-source-of-truth SHA computation in `release-publish` merge job (round-2 S1); `actions/attest-build-provenance@v1` for SLSA-3 (round-2 security P0-S3); Linux minisign signature with `MINISIGN_KEY` secret. +2h (SLSA + minisign add ~1h vs the original Plan delta).
+- **Task 20e (new) — NSIS uninstall hygiene** (§11.6, round-2 P0-1 — reclaimed from frag-6-7; per-user paths per round-3 P0-1/P0-2): `build/installer.nsh` with `customUnInstall` macro (taskkill + opt-in per-user data-root recursive cleanup covering `data/`, `logs/`, `crashes/`, `daemon.lock`, `daemon.secret` under `%LOCALAPPDATA%\ccsm\` / `~/Library/Application Support/ccsm/` / `~/.local/share/ccsm/`); `nsis.include` wiring with `perMachine:false`; Linux `.deb` postrm + `.rpm` %preun scripts; macOS tray "Reset CCSM…" item (surface owned by frag-6-7 §6.8); small `ccsm-uninstall-helper.exe` for graceful daemon shutdown via RPC (cross-ref frag-6-7 §6.4 `daemon.shutdown`). +4h spec-coordinated, +0h frag-6-7 (RPC already specified).
+- **Task 20f (new) — CI Node 22 bump + daemon test job** (§11.5, round-2 P1-3): bump `setup-node` from 20 to 22 in both `verify` and `build`; extend cache key with `daemon/package-lock.json`; add `npm -w @ccsm/daemon run test` to `verify`. +0.5h.
+- **Task 24 (existing) — Release pipeline integration**: drop the proposed `daemon-v*` trigger; v0.3.0 ships single `v*` tag carrying both installer (with daemon embedded) + standalone daemon binary as separate asset. Reserve `daemon-v*` for v0.3.1+; sketch the daemon-only matrix in spec deferred list to avoid v0.3.1 panic-rewrite. +0h (scope reduction).
+
+**Total packaging block: ~17h** (vs frag-11 r1's ~10h; the new ~7h covers round-2 P0-1 NSIS reclaim, P0-2 native signing across platforms, SLSA provenance, CI node bump). Round-3 deltas land separately in the "Plan delta (r3)" block below.
+
+
+## Cross-frag rationale
+
+This block records ownership decisions for round-2 cross-fragment items where multiple fragments could plausibly own a fix.
+
+**Owned by frag-11 (this file):**
+
+- **NSIS uninstall hygiene (round-2 P0-1)** — TAKEN. Round-1 traceability matrix mapped this to "§11"; frag-11 r1 punted to "§3.1 in lifecycle / frag-6-7"; frag-6-7 never picked it up. Frag-11 reclaims because (a) NSIS scripts + electron-builder `nsis.include` + `.deb` postrm + `.rpm` %preun are pure packaging-toolchain mechanics, (b) the scope spans all three OSes' installer contracts which is exactly frag-11's remit, (c) the daemon-side dependency (graceful `daemon.shutdown` RPC) is already specified in frag-6-7 §6.4 — frag-11 only needs the orchestration shim (`ccsm-uninstall-helper.exe`). Specified in §11.6 with the canonical daemon-owned-paths table.
+- **`ccsm_native.node` packaging + signing (round-2 P0-2 / round-3 P0-3 rename)** — TAKEN. frag-3.5.1 §3.5.1.1 introduces the helper as a single .node carrying winjob+pdeathsig+pipeAcl exports; frag-11 §11.1/11.2/11.3 now lists it explicitly under the canonical name in `pkg.assets`-affecting rebuild loop, in `before-pack.cjs` validation set, and in both signtool/codesign loops. The previous `winjob.node` filename is fully retired — any tooling reference is a bug.
+- **SLSA-3 build provenance (round-2 security P0-S3)** — TAKEN. The CI mechanism (`actions/attest-build-provenance@v1` + Linux minisign) lives in release.yml which frag-11 owns. The verifier side (updater checks attestation before swap) is owned by frag-6-7 §6.4 step 2 — flagged below as a frag-6-7 follow-up.
+- **CI Node 22 bump + cache key + daemon test job (round-2 P1-3)** — TAKEN. release.yml-only change; frag-11 §11.5(0)(0a)(1).
+- **`pkg --compress GZip` removal (round-2 P1-4)** — TAKEN. Single-line change in `daemon/package.json` `scripts.package`; documented note in §11.1.
+- **signtool path hardcode fix (round-2 P1-6)** — TAKEN. §11.3.1 step.
+- **SHA256SUMS computation moved to merge job (round-2 S1)** — TAKEN. §11.4.
+- **`extraResources` `${platform}` token correction (round-2 S3)** — TAKEN. §11.2 staged-dir pattern.
+- **macOS keychain unlock secret (round-2 SH2)** — TAKEN. §11.3.2 uses `MACOS_KEYCHAIN_PW`.
+- **`signtool verify /pa /v` post-sign (round-2 SH3)** — TAKEN. §11.3.1.
+- **Daemon `dependencies` discipline (round-2 C6)** — TAKEN. §11.1 prose.
+
+**Punted to frag-6-7 (reliability/security):**
+
+- **`pino-roll` not abstraction-wrapped, `proper-lockfile` directly imported (round-2 lockin P1)** — out of §11 scope. These are runtime architecture choices in daemon code; frag-6-7 §6.4 / §6.6 owns the wrapper-vs-direct decision. Frag-11 only ensures both modules ship as `daemon/package.json` `dependencies` (round-2 C6).
+- **`daemon.secret` lifecycle: installer-time generation, atomic ACL set, rotation on update, redact list (round-2 security P0-S1 / round-3 CF-2 resolved)** — owned **entirely** by frag-6-7 §7.2. The generator runs in **Electron-main**, NOT the installer (cleaner: no NSIS DACL juggling, no Linux postinst equivalent). Frag-11 does NOT add a `customInstall` block; the prior round-2 sub-bullet is retracted in round-3. Frag-11 only specifies the on-disk path (per round-3 P0-2 paths table) and the uninstall delete in §11.6.
+- **SLSA attestation **verifier** (round-2 security P0-S3 verifier half / round-3 CF-4)** — frag-6-7 §6.4 step 2 (auto-update verify) owns the verify call. Frag-11 generates the attestation and locks the verifier library to **`@sigstore/verify` 1.x** (round-3 §11.4.1).
+- **Stream `fromSeq` token + handler-arg schema + traceId validation (round-2 security P1-S1/S2/S3)** — entirely out of §11 scope; frag-3.4.1 / frag-3.5.1 / frag-6-7 own.
+- **Single-instance lock vs uninstall ordering (round-2 P1-5)** — partly TAKEN by §11.6 (the per-user `daemon.lock` row in the canonical paths table + the always-delete behaviour). The runtime stale-PID recovery + `OpenProcess` semantics remain frag-6-7 §6.4.
+- **Migration env-var trust boundary, network-FS / symlink rejection (round-2 security P0-S2)** — frag-8 owns; nothing for frag-11 to package-side.
+- **Threat-model rows T12-T16 (round-2 security)** — frag-6-7 §7.4 owns; frag-11 only contributes the T13 crash-dump path location (per round-3 paths table: `%LOCALAPPDATA%\ccsm\crashes\` etc., included in the §11.6 cleanup table).
+
+**Punted to frag-3.7 (dev workflow):**
+
+- **Prod log surfacing regression (round-2 devx)** — out of §11 packaging scope. Concerns the dev-time `nodemon` log-level mapping vs prod pino config; frag-3.7 §3.7.6 owns.
+
+**No-op for frag-11 (already addressed elsewhere):**
+
+- Round-1 MUST-FIX 1/2/3 (extraResources, daemon signing, mac entitlements) — addressed in r1, retained.
+- macOS notarization rate-limit (round-2 packaging S2) — accepted as-is (§11.7).
+
+---
+
+## Plan delta (r3)
+
+Round-3 fixer changes layered on top of the round-2 plan delta above:
+
+- **Task 20a (extend) — `before-pack.cjs` arch map + per-platform pkg target.** Add round-3 P1-1 arch map (`{0:'ia32',1:'x64',2:'armv7l',3:'arm64',4:'universal'}`) with an explicit throw on `universal`/`armv7l`. In §11.5 step 2, document `pkg --targets node22-${PLATFORM}-${ARCH}` per matrix leg so each binary embeds only its own arch's `.node` files (round-3 P1-7). +0.5h.
+- **Task 20b (extend) — Windows install path = `%LOCALAPPDATA%\ccsm\` (round-3 P0-1).** NO package.json change required; working tip already matches the §11.6 r9 lock (`oneClick: false / allowElevation: true / allowToChangeInstallationDirectory: true`). Rewrite `installer.nsh` paths to `$LOCALAPPDATA\ccsm\…` (no `$PROGRAMFILES`, no `$PROFILE\.ccsm`). Update auto-update reference docs to note in-place writes are no-UAC. [manager r11 lock: r10 packaging P1-B — Plan delta r3 stale `oneClick: true / allowElevation: false` proposal retracted; §11.6 r9 lock is the canonical NSIS posture and no package.json edit is needed.] +1h.
+- **Task 20c (extend) — macOS daemon.secret path + notarize count.** macOS data root locked at `~/Library/Application Support/ccsm/` per round-3 P0-2; standalone-daemon notarytool block stays as 2 submissions (x64+arm64), §11.7 corrected to total 5 submissions/release per round-3 P1-5. +0h spec, doc-only.
+- **Task 20d (extend) — SLSA verifier locked to `@sigstore/verify` 1.x; SHA256SUMS in subject-path (round-3 CF-4 + P1-8).** Update §11.4.1 attest step to include `dist-all/SHA256SUMS.txt`; lock the verifier library name in the spec so frag-6-7 §6.4 step 2 implementer doesn't re-pick. Document one-time minisign keypair generation as a release prerequisite (round-3 P1-9: `minisign -G`, store `MINISIGN_KEY` secret, commit `build/minisign.pub`). +0.5h.
+- **Task 20e (extend) — Linux postrm correction + uninstall-helper $TEMP copy (round-3 P0-4 + P1-6).** Replace `${HOME:-/root}/.ccsm` with `getent passwd "$SUDO_USER"` lookup that only fires on `purge` AND when `SUDO_USER` is set; document `rm -rf ~/.local/share/ccsm` as the documented user-step fallback. NSIS `customUnInstall` copies `ccsm-uninstall-helper.exe` to `$TEMP` before invoking, so the in-flight uninstall main loop can RMDir `$INSTDIR` without a Windows file-lock collision. +0.75h.
+- **Task 20f (extend) — `daemon/.nvmrc` single-source-of-truth for Node target (round-3 P1-3).** Commit `daemon/.nvmrc` with the exact patch (`22.11.0`); have `setup-node` read `node-version-file: daemon/.nvmrc` and the rebuild script read the same file. Removes drift between `setup-node` (`'22'` any-minor), `pkg` base binary, and `node-gyp` headers. +0.25h.
+- **Task 20g (new) — ccsm_native rename sweep (round-3 P0-3).** Mechanical rename of `winjob.node` → `ccsm_native.node` in `pkg.assets` rebuild script, `before-pack.cjs` `REQUIRED_NATIVES`, `after-pack.cjs` validation list, codesign/signtool target sets, and the `daemon/native/winjob/` source directory → `daemon/native/ccsm_native/`. Coordinated with frag-3.5.1 §3.5.1.1 + frag-6-7 §7.3 (which still reference the old name). +0.5h.
+
+**Round-3 packaging delta total: ~3.5h** on top of round-2's ~17h. New packaging block estimate: **~20.5h**.
+
+---
+
+## Cross-frag rationale (r3)
+
+Round-3-specific ownership notes (deltas on top of the round-2 cross-frag block above):
+
+**Reclaimed / clarified by frag-11:**
+
+- **NSIS `perMachine: false` + per-user install root (round-3 P0-1)** — TAKEN. Sole owner. The choice spans every paragraph in this file that previously said "Program Files" or `$INSTDIR` semantics; all are now scoped to `$LOCALAPPDATA\ccsm\`.
+- **`ccsm_native.node` canonical name (round-3 P0-3)** — TAKEN. Frag-11 picks up the rename sweep across `pkg.assets`, `before-pack.cjs`, `after-pack.cjs`, signtool/codesign loops. Frag-3.5.1 §3.5.1.1 already specifies the addon export shape; frag-11 follows.
+- **Linux postrm `${HOME:-/root}` bug (round-3 P0-4)** — TAKEN. Replaced with `SUDO_USER`-gated `getent passwd` lookup; documented manual `rm -rf ~/.local/share/ccsm` fallback in §11.6.3.
+- **Uninstall-hygiene disk mechanics dedupe (round-3 X3)** — TAKEN by §11.6 with explicit cross-ref. The in-app surface (close-to-tray, "Reset CCSM…", post-uninstall toast, etc.) and its numeric-priority registry are owned by **frag-6-7 §6.8**; frag-11 §11.6 owns only the disk-removal mechanics (NSIS macro / postrm / paths table / shutdown helper).
+- **`devTarget()` env-gate fence (round-3 CF-2 / devx)** — TAKEN. The `app.isPackaged === false` branch in §11.2 now requires `CCSM_DAEMON_DEV=1` to even compute a dev daemon path; cross-ref frag-3.7 §3.7.2.b for env-gate convention.
+
+**Punted to frag-6-7:**
+
+- **`daemon.secret` generator (round-3 CF-2 resolution)** — frag-6-7 §7.2 "Electron-main, NOT installer" wins; frag-11's prior `customInstall` proposal is retracted. Frag-11 only owns the on-disk path (per round-3 P0-2 paths table) and the uninstall delete in §11.6.
+- **In-app surface registry for cleanup-style UI (close-to-tray, reset-data, post-uninstall toast)** — frag-6-7 §6.8 owns. Frag-11 references but does not redefine. Reason: numeric-priority registry is a UX/state-machine concern, not a packaging concern.
+
+**Punted to frag-12 (traceability):**
+
+- **frag-12 packaging M4 / ux M2 stale-OPEN flags (round-3 CF-1 + CF-3)** — frag-11 cannot edit frag-12; flagged here for the frag-12 fixer to re-audit and close.
+
+**Punted to frag-3.5.1:**
+
+- **`ccsm_native.node` source layout** — frag-3.5.1 §3.5.1.1 is the canonical contract for the addon's export surface (winjob + pdeathsig + pipeAcl). Frag-11 only consumes the artifact name and packages it.
+
+**Acknowledged but no spec edit needed:**
+
+- **CF-5 Linux initial-install integrity honesty** — agreed; the wording fix lives in frag-6-7 §7.3 "Initial-install integrity" paragraph (Win/mac via signtool/codesign; Linux via documented `slsa-verifier` + minisign manual step). Flagged for frag-6-7 fixer.
+- **P1-2 `pkg.targets` per matrix leg** — covered by Task 20a extend above (`pkg --targets node22-${PLATFORM}-${ARCH}`).
+- **P1-4 `${ext}` token in `from`** — already correct; pinned `electron-builder@^26.x`.
+
+<!-- END frag-11-packaging.md -->
+
+---
+
+<!-- BEGIN frag-12-traceability.md -->
+
+## 12. Review traceability
+
+This section maps every MUST-FIX item from the ten round-1 angle reviews
+(`~/spike-reports/v03-review-*.md`), the round-2 P0/P1 escalations
+(`~/spike-reports/v03-r2-*.md`), and the round-3 residuals
+(`~/spike-reports/v03-r3-*.md`) to the spec-v2 section that addresses it.
+
+This file is a **round-3 re-audit** (2026-04-30, post-r3 fixers in flight).
+Status of every row is recomputed against the current fragment bodies AND
+the round-3 reviewer verdicts. Pure SHOULD/OPEN questions live in the
+source reports and are not tracked here.
+
+Section numbers refer to spec v2 post-merge:
+
+- §3.1.1 Local socket hardening (already in v2 wip)
+- §3.4.1 Envelope hardening (frag-3.4.1)
+- §3.5.1 PTY child lifecycle hardening (frag-3.5.1)
+- §3.7 Dev workflow (frag-3.7)
+- §6 Reliability (rewrite, frag-6-7)
+- §7 Security (rewrite, frag-6-7)
+- §8 Data migration v0.2 → v0.3 (frag-8)
+- §11 Packaging (rewrite, frag-11)
+- §12 Review traceability (this fragment)
+
+### 12.0 Manager arch decisions (locked pre-merge)
+
+These decisions resolve r3 contradictions whose only blocker was the
+manager picking between the equally-valid options the fragments fielded.
+They are CLOSED below as "manager r3 lock" rather than punted to the
+fragment authors.
+
+1. **Install path = per-user `%LOCALAPPDATA%\ccsm\` (Win) and OS-equivalents
+   elsewhere.** Resolves r3-packaging P0-1 (NSIS Program-Files vs spec
+   per-user contradiction). electron-builder ships
+   `nsis: { perMachine: false, oneClick: false }`. T9 / T14 security claims
+   in §7.4 stay as written. frag-11 §11.2 + §11.6 NSIS macro rewritten to
+   `$LOCALAPPDATA` rooting.
+2. **Data root = OS-native (`%LOCALAPPDATA%\ccsm\` Win, `~/Library/Application Support/ccsm/` mac, `~/.local/share/ccsm/` Linux)** — single root for **everything daemon-owned**: daemon binary, `daemon.lock`, `daemon.secret`, `<dataRoot>/data/` (SQLite), `<dataRoot>/logs/` (pino-roll), `<dataRoot>/crashes/` (crash dumps). frag-11 §11.6 is the **single source of truth** for the paths table; `<dataRoot>` is OS-native per frag-11 §11.6 and v0.2 → v0.3 migration moves data from legacy `~/.ccsm/` to `<dataRoot>` (frag-8 §8.3 step 1). [manager r5 lock: install path locked to `%LOCALAPPDATA%` in r3 to avoid UAC; all sibling paths (data/logs/crashes/lockfile/secret) follow per frag-11 §11.6 — eliminates the three-way `<dataRoot>` permutation that r4 packaging + multiple reviewers flagged.] [manager r11 lock: r10 traceability P1 — lockfile basename swept `ccsm-daemon.lock` → `daemon.lock` to match frag-11 §11.6 paths table.] Resolves r3-packaging P0-2 (three-way secret-path contradiction) AND r4-packaging dataRoot reconciliation.
+3. **Surface registry = frag-6-7 §6.8 numeric priority table (100/90/85/70/50/30)
+   is the sole authoritative registry.** frag-3.7 §3.7.8's tier 1-6 table
+   becomes a renderer-implementation guide that registers INTO §6.8;
+   conflicting entries (e.g. `daemon.crashLoop` camelCase vs
+   `daemon.crashloop.with_bak` dot+snake) resolve to §6.8 spelling.
+   Resolves r3-ux P0-UX-A (two-registry coexistence).
+
+### 12.1 Matrix
+
+[manager r5 lock: matrix rebuilt off current frag bodies post r4 reviews; IN-FLUX now means actually still under fixer, not stale lag.]
+
+Status legend: ✅ CLOSED · 🟡 IN-FLUX (fix dispatched / pending r5 fixer) · ❌ OPEN (genuinely punted to v0.4+).
+
+#### ✅ CLOSED
+
+| Round | Item | Cite |
+|---|---|---|
+| r1 resource M1 | pino log rotation | frag-6-7 §6.6.1 (`pino-roll` daily/50M/7) |
+| r1 resource M2 | subscriber multiplexing model | frag-3.5.1 §3.5.1.5 (single fan-out registry, drop-slowest) |
+| r1 resource M3 | RAM target wording (plan delta) | frag-6-7 Plan delta Task 25 (`<120 MB daemon RSS, <500 MB incl. children`) |
+| r1 reliability M1 | PTY orphan reaping | frag-6-7 §6.2 + frag-3.5.1 §3.5.1.1/.2 (JobObject + setpgid + PDEATHSIG) |
+| r1 reliability M2 | bridge call timeout + cancel | frag-3.5.1 §3.5.1.3 (5s default, AbortSignal.any, BridgeTimeoutError) |
+| r1 reliability M3 | SQLite tx boundaries (audit) | frag-6-7 §6 + Plan delta Task 8/12/13 (`db.transaction` audit) |
+| r1 reliability M4 | single-instance lock on Win | frag-6-7 §6.4 (proper-lockfile primary, pipe bind secondary) |
+| r1 reliability M5 | updater rollback / atomic swap | frag-6-7 §6.4 step 5-7 (`MoveFileExW`, single-shot rollback) |
+| r1 security M1 | Win named-pipe ACL | frag-6-7 §7.1.2 + §7.M1 helper (explicit DACL = current SID) |
+| r1 security M2 | sender peer-cred check | frag-6-7 §7.1.3 + §3.1.1 (`SO_PEERCRED` / `GetNamedPipeClientProcessId`) |
+| r1 security M3 | envelope cap + schema validation | frag-3.4.1 §3.4.1.a (16 MiB cap) + §3.4.1.d (TypeBox check) |
+| r1 perf M1 | binary frame format (no base64) | frag-3.4.1 §3.4.1.c (header-JSON + raw-bytes-trailer) |
+| r1 perf M2 | head-of-line blocking | frag-3.4.1 §3.4.1.b (≤16 KiB sub-chunks) |
+| r1 perf M3 | snapshot wire micro-benchmark | frag-3.4.1 Plan delta Task 5b (un-deferred per r2 perf §7) |
+| r1 lockin top-2 | DaemonClient AbortController cancel | frag-3.5.1 §3.5.1.3 (`AbortSignal.any`) |
+| r1 lockin top-4 | versioned handshake | frag-3.4.1 §3.4.1.g (`daemon.hello`) + frag-6-7 §6.5 (`protocol` block) |
+| r1 obs M1 | end-to-end traceId in envelope | frag-3.4.1 §3.4.1.c + frag-6-7 §6.6.1 (`traceId` ULID required) |
+| r1 obs M2 | `pino.final` on fatal | frag-6-7 §6.6.1 (daemon) + §6.6.2 (electron, `side: 'electron'`) |
+| r1 obs M3 | log rotation | frag-6-7 §6.6.1/.2 (same pino-roll on both sides) |
+| r1 obs M4 | daemon version + pid + boot in every line | frag-6-7 §6.6.1/.2 (pino base = `{ side, v, pid, boot }`) |
+| r1 devx M1 | `npm run dev` daemon restart-on-rebuild | frag-3.7 §3.7.2/.3 (concurrently 3-lane + nodemon) |
+| r1 devx M2 | dev-mode daemon stderr in terminal | frag-3.7 §3.7.3/.6 (`stdout/stderr: true` + dev-vs-prod table) |
+| r1 devx M3 | TS Project References (plan delta) | frag-3.7 Plan delta Task 1 (`composite: true`, `references: [{path: "daemon"}]`) |
+| r1 devx M4 | orphan-daemon footgun | frag-3.7 §3.7.4 (auto-reconnect) + frag-6-7 §6.4 (stale-lock recovery via PID probe) |
+| r1 devx M5 | README + `npm run setup` | frag-3.7 Plan delta Task 1 (`scripts/setup.cjs` + CONTRIBUTING) |
+| r1 ux M1 | v0.2 → v0.3 SQLite migration | frag-8 §8 (full migration spec) |
+| r1 ux M2 | close-to-tray discoverability | frag-3.7 §3.7.8.b + frag-6-7 §6.8 — owner = frag-6-7 §6.8 (timestamp `app_state.close_to_tray_shown_at` — manager r5 lock supersedes the boolean `close_to_tray_hint_shown` previously proposed; verified in frag-6-7 §6.8 + §6.6.1 R3-T12). |
+| r1 ux M3 | daemon-spawn failure modal | frag-6-7 §6.1.1 copy table + §6.1 cold-start logic + frag-3.7 §3.7.4 reconnect waiting toast |
+| r1 packaging M1 | electron-builder `extraResources` | frag-11 §11.2 (`extraResources` + `before-pack.cjs` + `after-pack.cjs`) |
+| r1 packaging M2 | daemon binary code-signing | frag-11 §11.3.1/.2 (signed before EB packaging; SH3 verify) |
+| r1 packaging M3 | macOS notarization of nested daemon | frag-11 §11.3.2 (hardened runtime + JIT entitlement + standalone notarytool) |
+| r1 packaging M4 | NSIS uninstall hygiene | frag-11 §11.6.1 (`customUnInstall` macro + `nsis.include` wiring) + frag-6-7 §6.8 (paths contract). r3-perf/lockin/sec/pkg all confirm stale OPEN flag from r2 |
+| r1 fwdcompat 3.1 | interceptor seam | frag-3.4.1 §3.4.1.f (`Interceptor`, `ReqCtx`, `mountConnectAdapter({interceptors})`) — r3-fwdcompat/lockin/sec confirm landed |
+| r1 fwdcompat 3.2 | PTY fanout multi-subscriber + test | frag-3.5.1 §3.5.1.5 + §3.5.1.6 |
+| r1 fwdcompat 3.3 | versioned handshake (`clientProtocolVersion` etc.) | frag-3.4.1 §3.4.1.g (`daemonProtocolVersion`, `compatible`) + frag-6-7 §6.5 (`protocol` block in `/healthz`) — r3-fwdcompat/lockin/sec confirm landed |
+| r2 resource P0-1 | replay-burst exempt from drop-slowest | frag-3.4.1 §3.4.1.b + frag-3.5.1 §3.5.1.5 + frag-3.7 §3.7.4.a (single contract, ≤256 KiB replay then `gap: true`) |
+| r2 resource P1-3 | snapshot semaphore deadline starts after admission | frag-3.5.1 §3.5.1.5 (`snapshot.semaphore.waitMs` counter) |
+| r2 resource P1-4 | aggregate per-session subscriber cap | frag-3.5.1 §3.5.1.5 (`min(N×1MB, 4MB)` LRU oldest-slowest) |
+| r2 reliability P0-R3 | SIGCHLD shutdown ordering + DB rows | frag-3.5.1 §3.5.1.2 + frag-6-7 §6.6.1 (`running → shutting_down → exited`) |
+| r2 reliability P0-R5 | dedicated supervisor transport | frag-6-7 §6.5 + frag-3.4.1 §3.4.1.h (separate `-sup` socket/pipe) |
+| r2 reliability P1-R5 | per-PID `waitpid(pid, WNOHANG)` | frag-3.5.1 §3.5.1.2 |
+| r2 reliability P1-R6 | heartbeat-vs-supervisor inversion | frag-3.5.1 §3.5.1.4 (documented invariant `streamDeadMs > supervisorDeadMs`) |
+| r2 security P0-S1 | `daemon.secret` lifecycle | frag-6-7 §7.2 (Electron generator + atomic CREATE_NEW + rotation on update + redact list) |
+| r2 security P0-S2 | migration env-var trust | frag-8 §8.4 `resolveLegacyDir()` (canonical-path allowlist + double realpath + UNC reject) |
+| r2 security P0-S3 | SLSA-3 + Linux minisign | frag-11 §11.4.1 (producer) + frag-6-7 §6.4 step 2 (verifier contract) + §7.3 v0.3 row |
+| r2 security P1-S1 | per-handler arg validation | frag-3.4.1 §3.4.1.d + ESLint `no-handler-without-check` |
+| r2 security P1-S2 | traceId regex + log injection guard | frag-3.4.1 §3.4.1.c + frag-6-7 §6.6.1 (Crockford ULID regex + `\n\r` strip + dual `traceId`/`daemonTraceId`) |
+| r2 security T15 | pre-accept rate cap | frag-3.4.1 §3.4.1.a (`MAX_ACCEPT_PER_SEC = 50`) |
+| r2 security T12-T14 | threat-model rows | frag-6-7 §7.4 (rated + rationale) |
+| r2 obs P0-1 | Electron-side logger as peer | frag-6-7 §6.6.2 (`side: 'electron'` + same pino-roll + redact superset) |
+| r2 obs P0-2 | traceId on binary frame header | frag-3.4.1 §3.4.1.c (header schema includes `traceId?`) |
+| r2 obs P0-3 | drain ordering for log producers | frag-6-7 §6.6.1 step list (1-7) + frag-3.5.1 §3.5.1.2 mirror |
+| r2 obs P0-4 | `pino.final` analog on every Electron exit | frag-6-7 §6.6.2 (registered against `app.before-quit` + `uncaughtException` + supervisor "Quit" handlers) |
+| r2 obs P1-1 | `daemon.crashloop` log signature | frag-6-7 §6.1 (structured `crashloop_entered` line) |
+| r2 obs P1-2 | migration phase log lines | frag-8 §8.5 (8 phase strings sharing `traceId`, asserted in §8.8 step 7) |
+| r2 obs P1-3 | bridge-call lifecycle log set | frag-6-7 §6.6.2 (`bridge_call_complete`, `daemon_socket_closed`, `daemon_reconnect_*`, `stream_resubscribe`) |
+| r2 obs P1-4 | `statsVersion: 1` | frag-6-7 §6.5 (`daemon.stats` + `/healthz` carry version cursor) |
+| r2 obs P1-5 | crash-dump file spec | frag-6-7 §6.6.3 (path + schema + 0600 ACL + 30-day retention + never auto-uploaded) |
+| r2 obs OPEN-3 | `spawnTraceId` for daemon-originated events | frag-3.5.1 §3.5.1.2 (allocated per `pty.spawn()`, on session row) |
+| r2 obs OPEN-4 | `boot_nonce` is ULID not Date.now | frag-6-7 §6.5 |
+| r2 fwdcompat P0-1 | interceptor + headers + traceId on header | frag-3.4.1 §3.4.1.c/.f |
+| r2 fwdcompat P0-2 | hello/version handshake wired | frag-3.4.1 §3.4.1.g + frag-6-7 §6.5 |
+| r2 fwdcompat P0-3 | RPC namespace `ccsm.vN/...` rule | frag-3.4.1 §3.4.1.g |
+| r2 fwdcompat P1-1 | `bootNonce` propagation | frag-3.5.1 §3.5.1.4 + frag-3.7 §3.7.5 + frag-6-7 §6.5 |
+| r2 fwdcompat P1-2 | reserved `x-ccsm-*` headers | frag-3.4.1 §3.4.1.c (4 reserved keys + spec amendment rule) |
+| r2 fwdcompat P1-3 | marker schema version | frag-8 §8.5 S8 (`marker.version: 1` + e2e `999` test) |
+| r2 fwdcompat P2-2 | `streamId` odd/even allocation | frag-3.4.1 §3.4.1.b |
+| r2 lockin P0-1 | frame-version nibble | frag-3.4.1 §3.4.1.c (high 4 bits of `totalLen` reserved) |
+| r2 lockin P0-2 | `NativeBinding` swap interface | frag-3.5.1 §3.5.1.1.a + lint `no-direct-native-import` |
+| r2 lockin P0-3 | env-var + marker rename | frag-8 §8.4 (`CCSM_LEGACY_USERDATA_DIR`) + §8.5 S8 (`migration-state.json`) |
+| r2 lockin P1-4 | negotiable heartbeat per subscribe | frag-3.5.1 §3.5.1.4 (`{heartbeatMs}` clamped 5s..120s) |
+| r2 ux P0-UX-1 | surface registry concept | frag-6-7 §6.8 [manager r3 lock = canonical] + frag-3.7 §3.7.8 (registers INTO §6.8) |
+| r2 ux P0-UX-2 | close-to-tray un-deferred | frag-3.7 §3.7.8.b + frag-6-7 §6.8 — see r1 ux M2 row |
+| r2 ux P0-UX-3 | daemon-spawn failure copy | frag-6-7 §6.1.1 copy table (9 rows) |
+| r2 ux P1-UX-1 | reconnect retries forever → modal at N=15 | frag-3.7 §3.7.4 + frag-6-7 §6.1.1 reconnect-exhausted row |
+| r2 ux P1-UX-2 | "start fresh" typed-confirm | frag-8 §8.6 (exact phrase + accessibility live region) |
+| r2 ux P1-UX-3 | BridgeTimeoutError NOT surfaced per-call | frag-6-7 §6.1.1 (suppressed when banner showing); see r3 CF-1 IN-FLUX for the §3.5.1.3 carve-out edit |
+| r2 ux P1-UX-4 | reconnect-toast vs supervisor banner mutex | frag-3.7 §3.7.8.a rule 3 + frag-6-7 §6.8 stacking rule |
+| r2 ux P1-UX-5 | "Paused" not "Abandoned" copy | frag-6-7 §6.3 |
+| r2 ux P1-UX-6 | pre-mount loader | frag-6-7 §6.1 + frag-3.7 §3.7.8.d |
+| r2 devx P0-1 | workspaces in root `package.json` | frag-3.7 Plan delta Task 1 |
+| r2 devx P0-2 | `wait-on tcp:127.0.0.1:0` no-op fixed | frag-3.7 §3.7.2 + `scripts/wait-daemon.cjs` (`wait-on file:` against lockfile) |
+| r2 devx P0-3 | dev mode skips pkg-binary path | frag-3.7 §3.7.2.b + Task 7 (spawnOrAttach side); see r3 CF-2 IN-FLUX for frag-11 fence |
+| r2 devx P0-4 | toolchain prerequisites + `npm run setup` | frag-3.7 §3.7.2.c + `scripts/setup.cjs` |
+| r2 devx P1-3 | dev-build error toast | frag-3.7 §3.7.8.c row j |
+| r2 devx P1-6 | stream handle `.cancel()` before resubscribe | frag-3.7 §3.7.5 step 1 |
+| r2 devx P1-7 | E2E folded into harness-agent | frag-3.7 §3.7.7 (`harness-agent.daemonReconnect`) |
+| r2 reliability P1-R1 | dev queue cap = 1000 | frag-3.7 §3.7.4 (`MAX_QUEUED_DEV = 1000`) |
+| r2 packaging P0-1 | NSIS uninstall hygiene reclaimed | frag-11 §11.6 (full macro + paths table); same as r1 packaging M4 |
+| r2 packaging P0-2 | every native `.node` signed | frag-11 §11.3.1/.2 per-`.node` loops + r3-lockin P0-A name unification → see IN-FLUX |
+| r2 packaging P1-3 | CI Node 22 bump | frag-11 §11.5(0)(0a) |
+| r2 packaging P1-4 | drop `--compress GZip` | frag-11 §11.1 (note + `package.json` script change) |
+| r2 packaging P1-6 | signtool path discovery | frag-11 §11.3.1 (PATH-first + Win SDK fallback) |
+| r2 packaging S1 | SHA256SUMS in merge job | frag-11 §11.4 (single source of truth) |
+| r2 packaging S3 | `extraResources` `${platform}` token | frag-11 §11.2 (staged-dir pattern + `before-pack.cjs`) |
+| r2 packaging SH2 | `MACOS_KEYCHAIN_PW` secret | frag-11 §11.3.2 |
+| r2 packaging SH3 | `signtool verify /pa /v` post-sign | frag-11 §11.3.1 |
+| r2 packaging C6 | daemon dependencies discipline | frag-11 §11.1 prose |
+| r3 packaging P0-1 | install path Program-Files vs per-user | [manager r3 lock] §12.0 (1) — pick (a) `nsis: { perMachine: false }`. r3 fixer applies to frag-11. |
+| r3 packaging P0-2 | secret/lock path three-way contradiction | [manager r3 lock] §12.0 (2) — daemon binary + `daemon.lock` + `daemon.secret` at OS-native root; SQLite/logs/crashes stay at `~/.ccsm/`. r3 fixer applies. |
+| r3 ux P0-UX-A | two surface registries | [manager r3 lock] §12.0 (3) — frag-6-7 §6.8 canonical; frag-3.7 §3.7.8 registers INTO §6.8 |
+| r3 perf CF-3 / lockin CF-1 / fwdcompat #1 / sec P1-3 / resource X3 / ux P0-UX-C | "frag-12 stale OPEN rows" meta-issue | this re-audit (round-3) — ALL six angles confirm packaging M4 / fwdcompat 3.1 / fwdcompat 3.3 are landed; matrix updated above |
+| r3 ux M2 owner pick | close-to-tray double ownership | [manager r5 lock] frag-6-7 §6.8 owns toast wiring; SQLite key = `close_to_tray_shown_at` (timestamp, NOT boolean — verified in frag-6-7 §6.8 + R3-T12). Supersedes earlier r3 boolean lock. |
+| r3 fwdcompat CC-2 | `bootNonce` camelCase across 4 sites | frag-3.4.1 §3.4.1.g + frag-3.5.1 §3.5.1.4 + frag-3.7 §3.7.5 + frag-6-7 §6.5 — all four cite `bootNonce` (camelCase). r5 verified. |
+| r3 fwdcompat CC-3 | `x-ccsm-deadline-ms` clamp 120s | frag-3.4.1 §3.4.1.c (`clamp 100 ms ≤ x ≤ 120 s`, unified with frag-3.5.1 §3.5.1.3). r5 verified. |
+| r3 fwdcompat P1-5 | `daemonAcceptedWires[]` advertised in hello reply | frag-3.4.1 §3.4.1.g (hello reply features array) + frag-6-7 §6.5 (`daemonAcceptedWires` in healthz protocol block). r5 verified. |
+| r3 lockin CF-2 | `daemonProtocolVersion` mirror in hello + healthz | frag-3.4.1 §3.4.1.g + frag-6-7 §6.5 (`daemonProtocolVersion` field on healthz protocol block). r5 verified. |
+| r3 fwdcompat P1-3 | `statsVersion` split → `healthzVersion` | frag-6-7 §6.5 (`healthzVersion` on `/healthz`; `statsVersion` lives only on `daemon.stats`). r5 verified. |
+| r3 fwdcompat P1-4 | feature-add-vs-version-bump rule | frag-3.4.1 §3.4.1.g feature-add rule documented; round-3 P1-4 closed. r5 verified. |
+| r3 security CC-1 | frame-version nibble parsed BEFORE 16 MiB length cap | frag-3.4.1 §3.4.1.a step 0-2 spells out: read 4 bytes → extract nibble → reject UNSUPPORTED_FRAME_VERSION → mask + length-cap. r5 verified. |
+| r3 fwdcompat P1-1 | `SUPERVISOR_RPCS` canonical allowlist constant | frag-3.4.1 §3.4.1.h (`SUPERVISOR_RPCS = ["/healthz", "/stats", "daemon.hello", "daemon.shutdown", "daemon.shutdownForUpgrade"]` declared canonical, consumed by control-socket dispatcher + migrationGateInterceptor + frag-8 §8.5). r5 verified; `[manager r9 lock: r8 envelope P0-1 + r8 devx P0-1 — row form updated from 4-element to canonical 5-element to match §3.4.1.h post-r7 + frag-6-7 §6.5 sweep]` |
+| r3 perf P1-1 | `seq` zero-padded to 10 ASCII digits | frag-3.4.1 §3.4.1.c hot-path bullet ("zero-padded 10-digit ASCII covers full uint32 range"). r5 verified. |
+| r3 fwdcompat P1-7 | unknown `x-ccsm-*` warn rule | frag-3.4.1 §3.4.1.c + §3.4.1.f deadlineInterceptor (`pino.warn { unknown_xccsm_header }` rate-limited 1/key/min). r5 verified. |
+| r3 security P0-1 | imposter-secret HMAC-of-nonce + `crypto.timingSafeEqual` | frag-3.4.1 §3.4.1.g (HMAC-SHA256 + `helloNonceHmac` + `clientHelloNonce` + 2-frame handshake post-fixer-A) + frag-6-7 §7.2 (HMAC-of-nonce LOCK; bearer-token EXPLICITLY REJECTED). r5 verified post-fixer-A. |
+| r3 lockin P0-A / r3 packaging P0-3 | native artifact `ccsm_native.node` 9-site rename | frag-11 §11.1/§11.2/§11.3/§11.6 + frag-3.5.1 §3.5.1.1 + frag-6-7 §7.M1 — all sites use `ccsm_native.node`; legacy `winjob.node` retired. r5 verified. |
+| r3 packaging P0-2 | `daemon.secret` OS-native path | frag-6-7 §7.2 (`%LOCALAPPDATA%\ccsm\daemon.secret` Win, `~/Library/Application Support/ccsm/daemon.secret` mac, `~/.local/share/ccsm/daemon.secret` Linux) + frag-11 §11.6 paths table. r5 verified. |
+| r3 packaging P0-4 | Linux postrm `SUDO_USER` + `getent passwd` correctness | frag-11 §11.6.3 (`SUDO_USER` gate + `getent passwd "$SUDO_USER" \| cut -d: -f6` + `~/.local/share/ccsm` cleanup; documented manual fallback). r5 verified. |
+| r3 packaging P0-1 | `%LOCALAPPDATA%\ccsm\` install root + `nsis.perMachine: false` | frag-11 §11.1 + §11.6 (`perMachine: false`, `oneClick: false`, `allowElevation: true`, `allowToChangeInstallationDirectory: true`, `$LOCALAPPDATA\ccsm`; never `Program Files`). r5 verified; `[manager r11 lock: r10 traceability P1 — row reconciled with frag-11 §11.6 r9 lock (assisted-mode installer preserved); prior `oneClick: true` was stale.]` |
+| r3 ux surface registry | numeric priority 30/50/70/85/90/100 | frag-6-7 §6.8 (CANONICAL — six priority tiers explicit) + frag-3.7 §3.7.8 cross-refs into §6.8. r5 verified. |
+| r3 perf CF-2 | `traceId` hot-path carve-out | frag-6-7 §6.6.1 (per-chunk fan-out logs at debug-level only; `streamId → spawnTraceId` cache; per-frame info-level forbidden on PTY hot path). r5 verified. |
+| r3 lockin CF-3 | `clientImposterSecret` eliminated by HMAC handshake | frag-3.4.1 §3.4.1.g (no `clientImposterSecret` field; only `clientHelloNonce` + `helloNonceHmac`) + frag-6-7 §7.2 + §6.6 redact list ("legacy `imposterSecret` / `clientImposterSecret` cleartext fields were eliminated"). r5 verified. |
+| r2 ux P0-UX-2 close-to-tray timestamp | `close_to_tray_shown_at` owned by frag-6-7 §6.8 | frag-6-7 §6.8 (timestamp lock, NOT boolean `close_to_tray_hint_shown`; R3-T12). r5 verified. |
+| r3 ux P0-UX-A §3.7.8 deletion | §3.7.8 collapsed to one-paragraph cross-ref redirect | frag-3.7 §3.7.8 explicitly marked `**DELETED in round-3**` with all surfaces redirected to frag-6-7 §6.8 canonical. Stub header retained as discoverability redirect; no real registry content remains. r5 verified. |
+| r5 dataRoot reconciliation | `~/.ccsm/data\|logs\|crashes\|daemon.lock` retired across frag-8 + frag-12 | [manager r5 lock] §12.0 (2) — frag-11 §11.6 single source of truth; frag-8 §8.2-§8.8 swept (`<dataRoot>/data/`, `<dataRoot>/logs/`, `<dataRoot>/crashes/`, `<dataRoot>/daemon.lock`); frag-12 §12.0 (2) updated. Eliminates the three-way `<dataRoot>` permutation flagged by r4 packaging + multiple reviewers. `[manager r11 lock: r10 traceability P1 — lockfile basename swept ccsm-daemon.lock → daemon.lock]` |
+| r3 reliability P0-R4 | migration partial-write lockfile-before-ensureDataDir | frag-8 §8.3 step 0 (`acquireLockfile(<dataRoot>/daemon.lock)` BEFORE `ensureDataDir()`; step 1a unconditional unlink is provably orphan post-lockfile) + frag-6-7 §6.4 boot-order note. r5 verified. `[manager r11 lock: r10 traceability P1 — lockfile basename swept ccsm-daemon.lock → daemon.lock]` |
+| r3 resource X4 | close-to-tray SQLite key locked to timestamp | [manager r5 lock] supersedes earlier r3 boolean lock; locked to `close_to_tray_shown_at` (timestamp) per frag-6-7 §6.8 + R3-T12. Same row as r3 ux M2 owner pick + r2 ux P0-UX-2 above. |
+
+##### r7 batch (round-7 manager-lock cross-frag closures, post fixers A/B/C/D/E/H + G verify; r9 added 2 orphan-lock rows)
+
+[manager r7 lock: §12 rebuilt with 21 new rows from r7 batch (fixers A/B/C/D/E/H/G + r9 orphan-lock additions); ratio CLOSED=147 / IN-FLUX=25 / OPEN=7 — see §12.2 below] `[manager r9 lock: r8 traceability P1-1 + P1-2 — arithmetic corrected (was 18/144/176; r7 sub-table actually had 19 rows then +2 orphan rows added in r9 → 21/147/179) and 2 orphan locks added as own rows]` `[manager r11 lock: r10 traceability P1 — r9 batch broken out as 12 explicit rows in new r9-batch sub-table; ratio CLOSED=159 / IN-FLUX=25 / OPEN=7 / total=191 — see §12.2 below.]`
+
+| Concern | Owner frag/§ | Consumer frag(s)/§(s) | r7 lock string | Status |
+|---|---|---|---|---|
+| `daemon.shutdownForUpgrade` RPC + `<dataRoot>/daemon.shutdown` marker (3-frag chain) | frag-6-7 §6.4 (RPC + marker semantics owner) | frag-3.4.1 §3.4.1.h (`SUPERVISOR_RPCS` allowlist consumer); frag-11 §11.6.5 (upgrade-in-place orchestration consumer) | `[manager r7 lock: r6 packaging P0-2 cross-frag — daemon.shutdownForUpgrade RPC + marker semantics; consumed by frag-11 §11.6.5 upgrade flow]` (frag-6-7 §6.4) + `[manager r7 lock: r6 packaging P0-2 — upgrade-in-place daemon-shutdown contract]` (frag-11 §11.6.5) | CLOSED |
+| §6.1 R2 marker-aware crash-loop skip (G verify) | frag-6-7 §6.1 R2 paragraph (supervisor counter rule) | frag-6-7 §6.4 (marker semantics producer); frag-11 §11.6.5 (marker writer at upgrade) | `[manager r7 lock: G verify — marker-aware crash-loop skip]` (frag-6-7 §6.1, added by fixer G) | CLOSED |
+| i18n key namespace `migration.modal.failed.*` | frag-8 §8.6 (canonical key prefix owner) | frag-6-7 §6.1.1 copy table (`migration.modal.failed.*` row) + §6.8 surface registry (P=85 row) | `[manager r7 lock: r6 ux P0-3 — i18n key namespace migration.modal.failed.*]` (frag-8 §8.6) | CLOSED |
+| §6.8 r7 surface-registry trim cascade (16→7 rows) | frag-6-7 §6.8 (canonical registry, 5 daemon-split rows + migration + paused-session) | frag-6-7 §6.1.1 (copy table trimmed 9→6 rows); frag-3.7 §3.7.4/§3.7.5/§3.7.8 (dispatched-surface set reduced to 3 surviving keys: `daemon.unreachable`, `daemon.reconnected`, `daemon.crashLoop`); frag-3.7 §3.7.8 surface-registry bridge plan-delta sub-task | `[manager r7 lock: cut as polish — N6# from r6 feature-parity. §6.8 row count trimmed from 16 → 7]` (frag-6-7 §6.8) + `[manager r7 lock: surfaces trimmed per N6# from r6 feature-parity]` (frag-3.7 §3.7.8 bridge sub-task) | CLOSED |
+| §3.5.1.2 step 8 ↔ §6.6.1 step 4 SQL mirror lock (`UPDATE sessions SET state='paused', pid_pgid=NULL WHERE state='shutting_down'`) | frag-3.5.1 §3.5.1.2 step 8 (PTY-side terminal sweep) | frag-6-7 §6.6.1 step 4 (DB-side mirror) | `[manager r7 lock: r6 reliability P1-R4 mirror — explicit WHERE state='shutting_down' clause mirrors frag-6-7 §6.6.1 step 4]` (frag-3.5.1 §3.5.1.2) | CLOSED |
+| HMAC `base64-22` wire-shape cross-frag unification (truncated 16-byte HMAC-SHA256, base64 ~22 chars) | frag-3.4.1 §3.4.1.g (handshake wire format owner — `helloNonceHmac: "<base64-22>"`) | frag-6-7 §6.5 + §7.2 (canonical secret lifecycle + HMAC contract; mirrored 1:1) | `[manager r7 lock: r6 P2-10 — HMAC base64-22 cross-frag wire-shape unification]` (E's fix per frag-3.4.1 §3.4.1.g + frag-6-7 §7.2) | CLOSED |
+| `helloInterceptor` as interceptor #0 (handshake required BEFORE migrationGate) | frag-3.4.1 §3.4.1.f (interceptor pipeline owner — slot 0) + §3.4.1.g (handshake semantics) | frag-6-7 §6.4 supervisor (handshake rejection ladder); frag-3.7 §3.7.4 reconnect counting | `[manager r7 lock: r6 reliability P1-R6 — explicit ordering #0 so handshake-required check fires BEFORE migrationGateInterceptor]` (frag-3.4.1 §3.4.1.f) | CLOSED |
+| 2 s handshake timeout + dedicated `HANDSHAKE_TIMEOUT` failure class | frag-3.4.1 §3.4.1.g (timeout + failure-class owner) | frag-6-7 §6.1.1 (`daemon.unreachable` body copy "reinstall ccsm" remediation); frag-3.7 §3.7.4 reconnect backoff (handshake fail counts as one reconnect attempt) | `[manager r7 lock: r6 reliability P0-R1 — explicit 2 s handshake deadline + dedicated failure class]` (frag-3.4.1 §3.4.1.g) + `[manager r7 lock: r6 reliability P0-R1 — handshake failure is a distinct pre-RPC failure class]` (frag-6-7 §6.1.1) | CLOSED |
+| Server-side stream-dead detector `2 × heartbeatMs + 5 s` (symmetric) | frag-6-7 §6.5.1 (canonical detector spec, B add) | frag-3.5.1 §3.5.1.4 (cross-ref handoff, H lock) | `[manager r7 lock: r6 reliability P0-R2 — daemon-side symmetric dead-stream detector at 2 × heartbeatMs + 5 s]` (frag-6-7 §6.5.1) + `[manager r7 lock: r6 reliability P0-R2 cross-frag handoff]` (frag-3.5.1 §3.5.1.4) | CLOSED |
+| Surface registry equal-priority deterministic tie-break (registry insertion order) | frag-6-7 §6.8 stacking rule 6 (C add) | frag-6-7 §6.1.1 (banner/modal stacking); frag-3.7 §3.7.8 bridge consumer; renderer `useDaemonHealthBridge` | `[manager r7 lock: r6 ux P0-2 — equal-priority tie-break = registry insertion order]` (frag-6-7 §6.8 stacking rule 6) | CLOSED |
+| Devx P0-1 debugger contract (`--inspect=9229` Electron-main / `--inspect=9230` daemon, env-gated, dev-only) | frag-3.7 §3.7.7.a (A add — daemon-split contributor debugger flow) | frag-3.7 §3.7.3 nodemon `exec` line; frag-11 §11.2 packaging (prod strips `CCSM_DAEMON_INSPECT`); `.vscode/launch.json` consumers | `[manager r7 lock: r6 devx P0-1 — debugger contract for daemon-split contributors]` (frag-3.7 §3.7.7.a) | CLOSED |
+| Devx P0-2 SDK ownership lock (daemon owns `claude-agent-sdk` direct ESM; Electron-main `loadSdk()` shim retained ONLY for residual session-title) | frag-3.7 §3.7.7.b (canonical ownership lock) | frag-11 §11.2.1 (SDK packaging contract consumer); frag-6-7 §6 daemon SDK consumers (must not use shim); Electron-main `electron/sessionTitles/loadSdk()` (residual only) | `[manager r7 lock: r6 devx P0-2 — daemon owns SDK directly (own Node 22 ESM); Electron-main loadSdk shim retained ONLY for any residual session-title/non-daemon SDK calls. New daemon code MUST NOT use the shim.]` (frag-3.7 §3.7.7.b) | CLOSED |
+| `claude-agent-sdk` packaging contract (`extraResources` + `asarUnpack` + before-pack copy) | frag-11 §11.2.1 (D add — packaging mechanics owner) | frag-3.7 §3.7.7.b (SDK ownership consumer); Electron-main `loadSdk()` shim resolution path | `[manager r7 lock: r6 packaging P0-1 — claude-agent-sdk explicit packaging contract]` (frag-11 §11.2.1) | CLOSED |
+| `ccsm-uninstall-helper.exe` signing as first-class artifact (signtool `$targets` array + before-pack staging) | frag-11 §11.3.1 (sign step) + frag-11 §11.6.4 (helper Task 20e) | frag-6-7 §6.8 NSIS uninstall hygiene (in-app daemon-shutdown contract consumer); release CI signing pipeline | `[manager r7 lock: r6 packaging P1-F — ccsm-uninstall-helper.exe is a first-class signed packaging artifact]` (frag-11 §11.6.4) | CLOSED |
+| macOS notarize `teamId` + stapler validate (DMG explicitly stapled; standalone Mach-O notarized but not stapled) | frag-11 §11.3.2 (D add — codesign/notarize/stapler owner) | release CI macOS leg (`xcrun stapler validate` post-build); §11.7 5-submission count | `[manager r7 lock: r6 packaging P1-C — DMG stapling explicitly asserted]` (frag-11 §11.3.2) | CLOSED |
+| Per-OS installer size ceilings + CI guard (Win NSIS ≤145 MB / mac DMG ≤160 MB / Linux AppImage ≤140 MB / .deb/.rpm ≤125 MB / standalone daemon ≤60 MB per arch) | frag-11 §11.5(6) (D add — release-publish job CI assertion) | frag-11 §11.2.1 SDK budget contribution (~6 MB); frag-11 §11.6.4 uninstall-helper (~5 MB); frag-11 §11.5(0) Electron 41 size baseline (~95 MB) | `[manager r7 lock: r6 packaging P1-B — installer size ceiling + CI assertion]` (frag-11 §11.5(6)) | CLOSED |
+| Electron `^41.3.0` pin (caret allows patch-level autoupdate within 41.x; Electron 42+ deferred post-v0.3) | frag-11 §11.5(0) (E add — toolchain pin owner) | frag-11 §11.2.1 SDK packaging (Electron 41 main = CJS, SDK = ESM); frag-3.7 §3.7.7.b SDK ownership lock; frag-3.5.1 `loadSdk()` shim contract; per-`.node` ABI rebuild matrix | `[manager r7 lock: r6 lockin P0 — Electron version pinned to ^41.3.0 per pool-1/package.json check on 2026-05-01.]` (frag-11 §11.5(0)) | CLOSED |
+| 6-step upgrade-in-place sequence (Electron-main owns orchestration: trigger → graceful shutdown RPC → 5 s ack → race fallback (force-kill + lock unlink) → quitAndInstall → spawn fresh daemon) | frag-11 §11.6.5 (D add — orchestration owner) | frag-6-7 §6.4 (`daemon.shutdownForUpgrade` RPC producer + marker writer); frag-6-7 §6.1 (marker-aware crash-loop skip on next boot, see G verify row above) | `[manager r7 lock: r6 packaging P0-2 — upgrade-in-place daemon-shutdown contract]` (frag-11 §11.6.5) | CLOSED |
+| SmartScreen reputation reset risk on path / scope change (per-machine `Program Files` → per-user `%LOCALAPPDATA%`) | frag-11 §11.7 (D add — out-of-scope risk note) | frag-11 §11.3.x EV cert mitigation (pre-trusted SmartScreen reputation); release notes copy for non-EV cert builds | `[manager r7 lock: r6 packaging P1-D — SmartScreen reputation reset documented]` (frag-11 §11.7) | CLOSED |
+| zh.ts parity acceptance criterion (i18n bundle keyset CI gate covering all v0.3 i18n keys) | frag-6-7 §6.1.1 line 64 (zh.ts parity owner) | frag-3.7 §3.7.8 i18n keys (daemon-health surfaces); frag-8 §8.6 `migration.modal.failed.*`; renderer i18n bundle (`src/i18n/locales/en.ts` ↔ `zh.ts`) | `[manager r7 lock: r6 ux P0-4 — zh.ts parity acceptance criterion]` (frag-6-7 §6.1.1) `[manager r9 lock: r8 traceability P1-2 — orphan lock added as own row]` | CLOSED |
+| Surface key spelling alignment to §6.8 canonical (renames `daemon.reconnectStuck` / `daemon.reconnectExhausted` / `tray.closeHint` to OBSOLETE per §6.8 r7 trim) | frag-3.7 line 37 (key spelling alignment lock) | frag-6-7 §6.8 (canonical surface key prefix owner); frag-3.7 §3.7.8 dispatched-surface set | `[manager r7 lock: r6 ux P0-1 — key spelling aligned to §6.8 canonical]` (frag-3.7 line 37) `[manager r9 lock: r8 traceability P1-2 — orphan lock added as own row, distinct from §6.8 trim cascade row 4 which doesn't enumerate the renamed keys]` | CLOSED |
+
+##### r9 batch (after r8 verify)
+
+[manager r11 lock: r10 traceability P1 — 12 r9-batch cross-frag closures broken out as their own rows for §12 traceability discipline; prior r9 audit had folded these into prose only.]
+
+| Concern | Owner frag/§ | Consumer frag(s)/§(s) | r9 lock string | Status |
+|---|---|---|---|---|
+| `SUPERVISOR_RPCS` canonical sweep | frag-3.4.1 §3.4.1.h | frag-3.4.1 §3.4.1.f, frag-6-7 §6.5, frag-12 row 166 | `[manager r9 lock: r8 envelope P0-1 + r8 devx P0-1 — SUPERVISOR_RPCS 5-element canonical allowlist swept across frag-3.4.1/frag-6-7/frag-12]` | CLOSED |
+| hello-handshake unified posture | frag-3.4.1 §3.4.1.h | frag-6-7 §6.5 | `[manager r9 lock: r8 envelope P0-1 — hello handshake posture unified across §3.4.1.h owner and §6.5 healthz consumer]` | CLOSED |
+| `x-ccsm-boot-nonce` header in reserved-keys allowlist + precedence rule | frag-3.4.1 §3.4.1.c + §3.4.1.g | frag-3.5.1 §3.5.1.4 (`fromBootNonce` param) | `[manager r9 lock: r8 envelope P1 — x-ccsm-boot-nonce added to reserved-keys allowlist with explicit precedence over body-level bootNonce]` | CLOSED |
+| base64url no-pad nonces | frag-3.4.1 §3.4.1.g | frag-6-7 §6.5 (HMAC verify) | `[manager r9 lock: r8 envelope P1 — nonces locked to base64url no-pad on the wire; HMAC verify path mirrors]` | CLOSED |
+| close-frame traceId carriage rule | frag-3.4.1 §3.4.1.c | (envelope-internal) | `[manager r9 lock: r8 envelope P1 — close-frame carries last-known traceId for log correlation]` | CLOSED |
+| `/healthz` + `/stats` literal exemption from `ccsm.<wireMajor>/` namespace | frag-3.4.1 §3.4.1.h | frag-6-7 §6.5 | `[manager r9 lock: r8 envelope P1 — /healthz + /stats literal paths exempted from versioned ccsm.<wireMajor>/ RPC namespace]` | CLOSED |
+| `daemonProtocolVersion` INTEGER pin | frag-3.4.1 schema | (handshake consumers) | `[manager r9 lock: r8 envelope P1 — daemonProtocolVersion typed INTEGER not string in TypeBox schema]` | CLOSED |
+| Marker unlink ownership = daemon | frag-6-7 §6.4 | frag-6-7 §6.1 R2 | `[manager r9 lock: r8 reliability P1 — daemon owns daemon.shutdown marker unlink (not Electron-main); §6.1 R2 marker-aware skip consumes]` | CLOSED |
+| SDK ownership inversion daemon-primary direct ESM | frag-11 §11.2.1 | frag-3.7 §3.7.7.b (already aligned) | `[manager r9 lock: r8 packaging P1 — claude-agent-sdk packaging contract inverted: daemon-primary direct ESM consumer; Electron-main loadSdk shim residual only]` | CLOSED |
+| NSIS `oneClick: false` reconciliation | frag-11 §11.6 | §11 head, plan-delta 8c, frag-12 row 173 | `[manager r9 lock: r8 packaging P0-2 — NSIS oneClick:false / allowElevation:true / allowToChangeInstallationDirectory:true reconciled with working tip; assisted-mode installer preserved]` | CLOSED |
+| §8.7 rollback rewrite + plan-delta 8c trim 18h→16h | frag-8 §8.6/§8.7 | (plan-delta consumer) | `[manager r9 lock: r8 migration P0 — §8.7 rollback rewritten; plan-delta 8c trimmed 18h→16h]` | CLOSED |
+| daemon.migrationFailed annotation cleanup → `migration.modal.failed.*` | frag-6-7 §6.8 ann | (i18n consumers) | `[manager r9 lock: r8 ux P0 — daemon.migrationFailed annotation cleaned up; canonical key prefix is migration.modal.failed.* per §8.6]` | CLOSED |
+
+#### 🟡 IN-FLUX (r5 fixers will land — cite owning frag)
+
+| Round | Item | Owning frag + section | Fixer ask |
+|---|---|---|---|
+| r3 resource X1 | `<dataRoot>` aggregate disk cap dropped | frag-6-7 §6.6 | add aggregate watchdog (e.g. 2 GB warn / 4 GB hard prune-oldest) |
+| r3 resource X2 / r3 devx CF-1 | `pino-roll symlink: true` punt not picked up | frag-6-7 §6.6.1/.2 | add `symlink: true` to both daemon + electron pino-roll config |
+| r3 reliability P0-R1 | drain ordering loses SIGCHLD `ptyExit` into closed sinks | frag-3.5.1 §3.5.1.2 + frag-6-7 §6.6.1 | re-order: fan-out close moves AFTER step 8 (final waitpid + DB tx) |
+| r3 reliability P0-R2 | crash-loop counter reset on rollback masks 2nd-bug loops | frag-6-7 §6.1 + §6.4 step 7 | rollback clears backoff but KEEPS crash-loop window decayed (e.g. counts as 3 of 5) |
+| r3 reliability P0-R3 | `state='abandoned'` unreachable + name conflict | frag-3.5.1 §3.5.1.2 step 8 + frag-6-7 §6.6.1 step 5 | unify on `paused`; drop `abandoned` OR define semantic distinction |
+| r3 reliability P0-R5 | `daemon.crashing` IPC is best-effort but renderer relies on it | frag-6-7 §6.6.1 | state explicitly: opportunistic; supervisor `/healthz` 3-miss + bridge 5s timeout = authoritative path |
+| r3 reliability CF-1 / r2 ux P1-UX-3 carve-out | "BridgeTimeoutError NEVER surfaced to user" sentence missing | frag-3.5.1 §3.5.1.3 | append the sentence per frag-3.7 §3.7.8.c punt; remove "renderer-side caller decides retry policy" wording |
+| r3 reliability CF-2 | replay-burst vs 1MB watermark language conflict | frag-3.5.1 §3.5.1.5 | add: "subscriber buffer accounting RESETS to 0 immediately after replay landed" OR "drop subscriber if buffered >X KB at resubscribe BEFORE replay write" |
+| r3 reliability CF-3 / r3 devx CF-3 | "supervisor disabled in dev" — frag-6-7 says transport still binds | frag-6-7 §6.1 + §6.5 | clarify whether supervisor transport binds in dev; align with frag-3.7 §3.7.6 "Supervisor active? NO" table |
+| r3 reliability P1-R1..R5 | various P1 polish | frag-6-7 §6.3/§6.6.3/§6.4 + frag-3.5.1 §3.5.1.2 | scheduled crash-dump prune, lockfile-create-fail uses `console.error` pre-pino, swap-lock vs daemon-lock race, `pid_pgid` cleared on graceful close, PR_SET_PDEATHSIG fork/execve race acknowledgement |
+| r3 security P0-2 | r2 P1-S3 (subscribe `fromSeq` token) silently dropped, not punted | frag-3.5.1 §3.5.1.5 | add `subscribe_token` paragraph OR add explicit "ACCEPTED — same-user T3" row to §7.4 (frag-6-7 §7.4 T17 ACCEPTED row exists; verify consistency with frag-3.5.1) |
+| r3 security CC-2 | `traceId` optional on wire vs mandatory in §6.6 validation | frag-6-7 §6.6.1 | add: validation runs only when `traceId` present; inheriting sub-frames resolve via `streamId → traceId` map |
+| r3 security CC-3 | `daemon.secret` Electron-as-generator bypasses CLI launch path | frag-6-7 §7.2 | add `CCSM_DAEMON_HEADLESS=1` self-generate clause OR explicit "v0.3 refuses CLI launch without `--secret-file=`" |
+| r3 security P1-1..P1-6 | P1 polish | frag-6-7 §7.2/§6.6.3/§6.4 + frag-8 §8.6 + frag-11 §11.4.1 | clear `CCSM_DAEMON_SECRET` from `process.env` post-read, sanitize migration `supplied`/`realpath` for renderer, name SLSA verifier (`@sigstore/verify`), `path.basename`+regex on crash-dump filename, `daemon.shutdown` BEFORE secret rotate |
+| r3 perf CF-1 | healthz transport split — `control-socket` (3.4.1.h) vs `-sup` (6.5) ambiguous | frag-3.4.1 §3.4.1.h + frag-6-7 §6.5 | reconcile to ONE control plane (recommend rename §3.4.1.h `control-socket` to BE the §6.5 supervisor transport) |
+| r3 perf P1-2..P1-5 | P1 polish | frag-3.5.1 §3.5.1.5 + frag-3.7 §3.7.4 + frag-3.4.1 §3.4.1.g | LRU fairness note for v0.5, hello-on-every-connect cold-start RT note, semaphore vs RAM-cap budget cross-ref |
+| r3 lockin P1-1..P1-4 | r2 P1 lockin items still residual | frag-6-7 §6.4/§6.6 + frag-3.7 §3.7.4 + frag-11 §11.1 | `loggerTransport` factory, replace `proper-lockfile` with 15-LOC `fs.openSync`, `connectClient.configure({maxQueued, scheduling})` + `E_RECONNECT_QUEUE_OVERFLOW` code, `daemon/.nvmrc` single-source for Node target |
+| r3 obs P1-2 | reconnect canonical log names not echoed in emitter | frag-3.7 §3.7.4 | add cross-ref: "Log line names per frag-6-7 §6.6.2 contract" |
+| r3 ux P0-UX-B | migration modal "dismissable: false" prose vs §6.8 implicit-dismiss | frag-8 §8.6 OR frag-6-7 §6.8 | delete prose claim OR codify in §6.8 stacking rule 1 |
+| r3 ux CC-1..CC-4 | onboarding key-name conflict / paused copy drift / camelCase vs dot.case / BridgeTimeout 3-place statement | frag-6-7 §6.3/§6.8 + frag-3.7 §3.7.8 + frag-3.5.1 §3.5.1.3 | locked per [manager r3 lock] §12.0 (3); r5 fixer normalizes copy + key spellings (residual: BridgeTimeout 3-place statement still pending in §3.5.1.3 — same as r3 reliability CF-1 above) |
+| r3 ux P1-1..P1-6 | P1 polish | frag-6-7 §6.1 + frag-11 §11.6.2 + frag-3.7 §3.7.8.d | cold-start splash dev-mode hide trigger, "View log" target, "Reinstall ccsm" button behavior, reconnect-stuck modal copy normalization, mac "Reset CCSM…" tray UX pick, BrowserWindow backgroundColor companion fix |
+| r3 packaging CF-2 | `customInstall` for `daemon.secret` split-ownership | frag-11 §11 cross-frag rationale + frag-6-7 §7.2 | pick Electron-side generation (already locked); remove dead frag-11 cross-frag rationale lines 500-501 |
+| r3 packaging CF-4 | SLSA verifier coupling (which library?) | frag-6-7 §7.3 + frag-11 plan delta Task 20d | pick `@sigstore/verify` v1.x + bundle (~2 MB) |
+| r3 packaging CF-5 | initial-install SLSA chicken-and-egg | frag-6-7 §7.3 | reword: "Linux via documented `slsa-verifier` manual step + minisign" |
+| r3 packaging P1-1..P1-9 | P1 polish | frag-11 §11.1/§11.2/§11.3.2/§11.6.4/§11.4.1/§11.7 | arch-map fix (armv7l/universal), per-leg `pkg --targets`, `node-gyp` ABI pinning, notarytool 5-submission count update, NSIS helper file-lock window, `pkg.assets` per-platform glob, `SHA256SUMS.txt` in SLSA subject-path, minisign keypair-gen documentation |
+
+#### ❌ OPEN (genuinely punted to v0.4+)
+
+| Round | Item | Decision | Cite |
+|---|---|---|---|
+| r1 security S5 | sigstore signing | deferred to v0.4 | frag-6-7 §7.3 v0.4 row |
+| r1 sec / fwdcompat | full CF Access JWT model | deferred to v0.5 | frag-6-7 §7.3 v0.5 row + §7.5 + `v0.5-security-followups.md` |
+| r1 reliability OPEN | Win Service mode | deferred to v0.4+ | frag-6-7 §6.4 ("user-mode background process only" + rationale) |
+| r2 perf P2-1 / r3 lockin P1-5 | OTLP `traceparent` carriage | tracked for v0.4 | frag-3.4.1 §3.4.1.c reserves `x-ccsm-trace-parent` header |
+| r3 resource P1-1..P1-6 | per-session aggregate-cap formula clarity, crash-dump aggregate cap, xterm-headless idle eviction (res-S3), socket.cork amortization, reconnect queue closure-pin accounting, supervisor transport accept-loop cost | all P1 / not blocking v0.3 | frag-6-7 §6.6.3 + §6.7 F11 + frag-3.5.1 §3.5.1.5 + frag-3.4.1 §3.4.1.c — release-notes call-outs OR v0.4 prereqs |
+| r3 ux out-of-scope | iOS App Store framing | deferred per F3 spike | frag-6-7 §7.5 |
+| r3 ux out-of-scope | stream-heartbeat traffic-analysis surface | deferred to v0.5 | frag-6-7 §7.5 + r2 sec SH5 |
+
+### 12.2 Summary
+
+Total tracked rows: **191** (matrix rebuilt off current frag bodies in r5 + 21 r7-batch cross-frag rows + 12 r9-batch cross-frag rows broken out as own rows in r11 per r10 traceability P1).
+
+- ✅ CLOSED: **159** (126 r5-baseline + 21 r7-batch cross-frag closures + 12 r9-batch cross-frag closures: SUPERVISOR_RPCS canonical sweep, hello-handshake unified posture, x-ccsm-boot-nonce reserved-keys + precedence, base64url no-pad nonces, close-frame traceId carriage, /healthz+/stats namespace exemption, daemonProtocolVersion INTEGER pin, marker unlink ownership = daemon, SDK ownership inversion daemon-primary direct ESM, NSIS oneClick:false reconciliation, §8.7 rollback rewrite + plan-delta 8c trim, daemon.migrationFailed → migration.modal.failed.*).
+- 🟡 IN-FLUX: **25** (unchanged from r5 — those fixers were dispatched per-fragment in r5; r7/r9 batches added different axes (round-6 / round-8 review locks) without re-opening the r5 IN-FLUX set).
+- ❌ OPEN: **7** (sigstore + CF Access + Win Service + OTLP carriage + resource P1 polish + iOS + heartbeat traffic analysis).
+
+Math: 159 + 25 + 7 = **191**. Net delta from r9 audit: +12 explicit CLOSED rows (r9 batch cross-frag closures broken out as own rows per r10 traceability P1 — prior r9 audit had folded these into prose only). `[manager r11 lock: r10 traceability P1 — arithmetic recomputed (was 147/25/7=179; r9-batch broken out adds 12 → 159/25/7=191)]`
+
+[manager r7 lock: §12 rebuilt with 21 new rows from r7 batch (fixers A/B/C/D/E/H + G verify + r9 orphan additions); ratio CLOSED=147 / IN-FLUX=25 / OPEN=7] `[manager r11 lock: r10 traceability P1 — superseded; current ratio CLOSED=159 / IN-FLUX=25 / OPEN=7 after r9 batch broken out.]`
+
+Manager merge gate: the 25 IN-FLUX rows are dispatched as r5 fixers in their owning fragments (one fixer per fragment, parallel where non-overlapping). Once those land, this matrix re-promotes them to CLOSED and the spec is mergeable. The r7 batch did not change the IN-FLUX set — r7 was an orthogonal round-6 review-lock pass.
+
+## Plan delta
+
+None — pure doc section. Out-of-scope items above are accounted for in their originating fragments' Plan delta sections; manager r3/r5 locks have no per-fragment plan-delta change beyond the wording edit in the affected fragment body.
+
+<!-- END frag-12-traceability.md -->

--- a/docs/superpowers/specs/v0.3-fragments/README.md
+++ b/docs/superpowers/specs/v0.3-fragments/README.md
@@ -1,0 +1,32 @@
+# v0.3 design v2 fragments
+
+Temporary working files for parallel drafting of design v2 sections.
+
+**Lifecycle**: each `frag-*.md` is written by a dedicated worker, then merged
+into `docs/superpowers/specs/2026-04-30-web-remote-design.md` by the manager
+in pool-2. After merge, this entire directory is deleted in the merge commit.
+
+**Why fragments**: 7 sections drafted in parallel against a single spec file
+would rebase-storm. Fragments are independent files, zero conflicts.
+
+**Plan changes**: each fragment ends with a `## Plan delta` section describing
+how `docs/superpowers/plans/2026-04-30-v0.3-daemon-split.md` should be patched
+(which Task N gains/loses what hours, new tasks, etc.). Manager applies all
+deltas to plan in the merge commit.
+
+**Source review reports** (read these before drafting your fragment):
+- `~/spike-reports/v03-review-resource.md` (GREEN)
+- `~/spike-reports/v03-review-reliability.md` (YELLOW)
+- `~/spike-reports/v03-review-security.md` (YELLOW)
+- `~/spike-reports/v03-review-perf.md` (YELLOW)
+- `~/spike-reports/v03-review-lockin.md` (LOW)
+- `~/spike-reports/v03-review-observability.md` (YELLOW)
+- `~/spike-reports/v03-review-devx.md` (YELLOW)
+- `~/spike-reports/v03-review-ux.md` (YELLOW, critical: SQLite migration)
+- `~/spike-reports/v03-review-packaging.md` (YELLOW)
+- `~/spike-reports/v03-review-fwdcompat.md` (YELLOW)
+
+**Spec v1 baseline**: `docs/superpowers/specs/2026-04-30-web-remote-design.md`
+(read this entire file once; v2 is additive — keep v1 wording where unchanged).
+
+**Plan v1 baseline**: `docs/superpowers/plans/2026-04-30-v0.3-daemon-split.md`

--- a/docs/superpowers/specs/v0.3-fragments/frag-11-packaging.md
+++ b/docs/superpowers/specs/v0.3-fragments/frag-11-packaging.md
@@ -1,0 +1,50 @@
+# Fragment: §11 packaging (extraResources + signing)
+
+**Owner**: worker dispatched per Task #933
+**Target spec section**: replace/expand §11 in main spec
+**P0 items addressed**: #9 (extraResources), #10 (daemon signing)
+
+## What to write here
+Replace this section with the actual `## 11. Packaging` markdown. Cover:
+
+1. **Daemon binary build**:
+   - `@yao-pkg/pkg` packages daemon Node code + better-sqlite3 + node-pty
+     into single binary per platform (`daemon-win.exe`, `daemon-mac`,
+     `daemon-linux`). Native modules included via pkg's asset config.
+   - Output to `daemon/dist/`. Build script: `npm run build:daemon` (added
+     to root workspace scripts).
+2. **electron-builder integration** (v0.3 still uses electron-forge? check
+   current setup and cite — pick one tool, stay consistent):
+   - Add `extraResources` entry mapping `daemon/dist/daemon-${platform}` →
+     installer payload at `resources/daemon/`. Spec the exact config block.
+   - Electron main resolves daemon path via `process.resourcesPath +
+     '/daemon/daemon-...'` in production; dev uses `daemon/dist/...` directly.
+3. **Code signing**:
+   - **Windows**: `signtool sign` daemon binary with same EV cert used for
+     `CCSM.exe` (currently configured in release.yml — cite). Same SHA-256
+     timestamp server. Daemon binary signed BEFORE electron-builder packages
+     it, so the installer-level signature covers an already-signed payload.
+   - **macOS**: `codesign --options runtime --entitlements ...` daemon
+     binary with same Developer ID. Notarization happens at the .dmg level
+     after electron-builder; daemon must be signed first or notarization
+     rejects.
+   - **Linux**: no signing (no infra); SHA256 manifest only.
+4. **SHA256 manifest**: published alongside release artifacts as
+   `SHA256SUMS.txt`; auto-updater downloads + verifies (§3.1, §7).
+5. **CI changes** (release.yml):
+   - Add daemon build step BEFORE electron-builder.
+   - Sign daemon binary in same CI step that signs the app (cert already
+     available there).
+   - Publish daemon binary as separate release asset (for daemon-only
+     auto-update channel later) AND bundled inside installer.
+
+Cite findings from `~/spike-reports/v03-review-packaging.md`.
+
+## Plan delta
+- New Task: daemon pkg build (+4h).
+- New Task: electron-builder/forge extraResources wiring (+3h).
+- New Task: Win signtool integration in CI (+2h).
+- New Task: Mac codesign + notarization (+3h, more if entitlements need
+  tweaking).
+- New Task: SHA256SUMS.txt publish step (+1h).
+- Total packaging block: ~13h.

--- a/docs/superpowers/specs/v0.3-fragments/frag-11-packaging.md
+++ b/docs/superpowers/specs/v0.3-fragments/frag-11-packaging.md
@@ -1,50 +1,852 @@
-# Fragment: §11 packaging (extraResources + signing)
+## 11. Packaging
 
-**Owner**: worker dispatched per Task #933
-**Target spec section**: replace/expand §11 in main spec
-**P0 items addressed**: #9 (extraResources), #10 (daemon signing)
+> Replaces §11 of `2026-04-30-web-remote-design.md`.
+> P0 items: #9 (extraResources wiring), #10 (daemon code-signing), #11 (NSIS uninstall hygiene — reclaimed from frag-6-7 per round-2 P0-1), #12 (`ccsm_native.node` + every native `.node` ships + signs — round-2 P0-2 / round-3 P0-3 rename).
+> Source reviews: `~/spike-reports/v03-review-packaging.md` §3 (MUST-FIX 1, 2, 3); `~/spike-reports/v03-r2-packaging.md` (P0-1, P0-2, P1-3..P1-6, S1, S3); `~/spike-reports/v03-r2-security.md` (P0-S3 SLSA provenance, SH2/SH3); `~/spike-reports/v03-r3-packaging.md` (P0-1 install path, P0-2 secret path, P0-3 native rename, P0-4 postrm HOME bug); `~/spike-reports/v03-r3-lockin.md` (ccsm_native vs winjob); `~/spike-reports/v03-r3-resource.md` (uninstall hygiene dedupe); `~/spike-reports/v03-r3-devx.md` (CF-2 devTarget fence).
 
-## What to write here
-Replace this section with the actual `## 11. Packaging` markdown. Cover:
+**Round-3 install-path lock (manager-decided, applies everywhere in this fragment):**
+- Install root is **per-user**: `%LOCALAPPDATA%\ccsm\` on Windows, `~/Library/Application Support/ccsm/` on macOS, `~/.local/share/ccsm/` on Linux. **Never `Program Files`.** electron-builder NSIS is configured `perMachine: false` so the installer drops to `%LOCALAPPDATA%\ccsm\` (no UAC, auto-update writes in-place). NSIS `oneClick: false / allowElevation: true / allowToChangeInstallationDirectory: true` per §11.6 r9 lock. [manager r11 lock: r10 packaging P1-A — §11 head paragraph reconciled with §11.6 r9 oneClick lock; the prior "`oneClick: true` is preserved" wording was stale.]
+- Data root = same per-user location (no separate `~/.ccsm/` root). All daemon-owned paths (`daemon.secret`, `daemon.lock`, `data/`, `logs/`, `crashes/`) live under that root.
+- In-app surface registry (close-to-tray, reset-data, etc.) is owned by **frag-6-7 §6.8** with numeric priority — frag-11 does NOT redefine. Frag-11 §11.6 owns only the disk-removal mechanics (NSIS macro, postrm script, paths table).
 
-1. **Daemon binary build**:
-   - `@yao-pkg/pkg` packages daemon Node code + better-sqlite3 + node-pty
-     into single binary per platform (`daemon-win.exe`, `daemon-mac`,
-     `daemon-linux`). Native modules included via pkg's asset config.
-   - Output to `daemon/dist/`. Build script: `npm run build:daemon` (added
-     to root workspace scripts).
-2. **electron-builder integration** (v0.3 still uses electron-forge? check
-   current setup and cite — pick one tool, stay consistent):
-   - Add `extraResources` entry mapping `daemon/dist/daemon-${platform}` →
-     installer payload at `resources/daemon/`. Spec the exact config block.
-   - Electron main resolves daemon path via `process.resourcesPath +
-     '/daemon/daemon-...'` in production; dev uses `daemon/dist/...` directly.
-3. **Code signing**:
-   - **Windows**: `signtool sign` daemon binary with same EV cert used for
-     `CCSM.exe` (currently configured in release.yml — cite). Same SHA-256
-     timestamp server. Daemon binary signed BEFORE electron-builder packages
-     it, so the installer-level signature covers an already-signed payload.
-   - **macOS**: `codesign --options runtime --entitlements ...` daemon
-     binary with same Developer ID. Notarization happens at the .dmg level
-     after electron-builder; daemon must be signed first or notarization
-     rejects.
-   - **Linux**: no signing (no infra); SHA256 manifest only.
-4. **SHA256 manifest**: published alongside release artifacts as
-   `SHA256SUMS.txt`; auto-updater downloads + verifies (§3.1, §7).
-5. **CI changes** (release.yml):
-   - Add daemon build step BEFORE electron-builder.
-   - Sign daemon binary in same CI step that signs the app (cert already
-     available there).
-   - Publish daemon binary as separate release asset (for daemon-only
-     auto-update channel later) AND bundled inside installer.
+**Toolchain check.** v0.2 ships via `electron-builder@^26.8.1` (`package.json:93,112-216`) — no `forge.config.cjs` exists. All extraResources / signing / publish config goes into the `build` block of root `package.json`. v0.3 keeps electron-builder; no migration to forge.
 
-Cite findings from `~/spike-reports/v03-review-packaging.md`.
+### 11.1 Daemon binary build (`@yao-pkg/pkg`)
+
+Daemon is a separate Node program that must run **outside** Electron's `app.asar` and outside Electron's bundled Node — same machine, independent process. We compile it to a single platform binary so the installer ships one file per OS, not a `node_modules/` tree.
+
+- Tool: **`@yao-pkg/pkg`** (the maintained fork of vercel/pkg; vercel/pkg is archived). Targets Node 22.
+- Workspace: `daemon/` (added in plan Task 1, `2026-04-30-v0.3-daemon-split.md:81`).
+- Output: `daemon/dist/ccsm-daemon-${platform}${ext}` where platform ∈ {`win-x64.exe`, `macos-x64`, `macos-arm64`, `linux-x64`} — produced by a fresh CI step before electron-builder runs.
+- Native modules (`better-sqlite3`, `node-pty`, **plus the in-tree `ccsm_native.node` from frag-3.5.1 §3.5.1.1** — a single N-API addon carrying the **winjob** (Win JobObject), **pdeathsig** (Linux `prctl(PR_SET_PDEATHSIG)`), and **pipeAcl** (Win named-pipe ACL helper used by frag-6-7 §7.M1) exports, ~150 LOC C++ at `daemon/native/ccsm_native/`) are **not** compiled into the pkg blob (V8 snapshot can't embed `.node`). They are listed as pkg `assets` and shipped next to the binary, then `require()`d at runtime via an absolute path resolver. **Round-3 P0-3**: artifact filename is `ccsm_native.node` per the canonical contract in frag-3.5.1 §3.5.1.1; the prior `winjob.node` name is retired and any tooling reference must be updated.
+- **Daemon `dependencies` discipline (round-2 C6)**: every runtime daemon dep (`pino`, `pino-roll`, `@sinclair/typebox`, `@octokit/rest`, `proper-lockfile`, `better-sqlite3`, `node-pty`, plus the native helper bindings) MUST appear in `daemon/package.json` `dependencies`, NOT only in root `dependencies`. `pkg` embeds the resolved `require()` graph from the daemon package's own `node_modules`; workspace-hoisted root deps are invisible to `pkg`. The example below shows only `@yao-pkg/pkg` in `devDependencies` for brevity — the actual `dependencies` block is filled by Task 20.
+
+`daemon/package.json` (new, owned by Task 20):
+
+```json
+{
+  "name": "@ccsm/daemon",
+  "version": "0.3.0",
+  "main": "dist/index.js",
+  "bin": "dist/index.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "rebuild:native": "node scripts/rebuild-native-for-node.cjs",
+    "package": "npm run build && npm run rebuild:native && pkg . --out-path dist"
+  },
+  "pkg": {
+    "targets": ["node22-win-x64", "node22-macos-x64", "node22-macos-arm64", "node22-linux-x64"],
+    "assets": [
+      "native/${PLATFORM}-${ARCH}/*.node",
+      "native/${PLATFORM}-${ARCH}/*.dll"
+    ],
+    "outputPath": "dist"
+  },
+  "devDependencies": {
+    "@yao-pkg/pkg": "^6.6.0",
+    "node-gyp": "^10.2.0"
+  }
+}
+```
+
+> **Round-3 P1-7**: `pkg.assets` glob is scoped to a single `${PLATFORM}-${ARCH}` per build invocation (driven by `pkg --targets node22-${PLATFORM}-${ARCH}` in CI per matrix leg) so each per-platform daemon binary embeds **only** its own arch's `.node` files. Cross-platform globbing (`native/**/*.node`) wastes ~5 MB per binary on dead-weight `.node` files the pkg-bundled Node could never load. The CI `Build daemon` step in §11.5 step 2 must invoke pkg with the explicit target matching the runner.
+
+> **Round-3 P1-2/P1-3**: pin `NODE_TARGET` to a single value committed to `daemon/.nvmrc` (e.g. `22.11.0`) and have both `setup-node` (`node-version-file: daemon/.nvmrc`) and the rebuild script read the same file. This eliminates drift between the runner's installed Node, `pkg`'s base binary, and the headers `node-gyp` downloads. Cross-compilation between Win/mac/Linux native modules is unsupported — each matrix leg builds only its own platform's targets.
+
+`scripts/rebuild-native-for-node.cjs` rebuilds **every native artifact** the daemon dlopens — npm-installed (`better-sqlite3`, `node-pty`) AND in-tree (`daemon/native/ccsm_native/`) — against **Node 22 ABI** (NOT Electron's V8 ABI — see review §4 SHOULD-FIX #7 + round-2 P0-2) into `daemon/native/<platform>-<arch>/`:
+
+```js
+// daemon/scripts/rebuild-native-for-node.cjs (sketch)
+const { execSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+// Round-3 P1-3: read the single source of truth from daemon/.nvmrc so
+// setup-node, pkg, and node-gyp all agree on one Node patch version.
+const NODE_TARGET = fs.readFileSync(path.join('daemon', '.nvmrc'), 'utf8').trim();
+const outDir = path.join('daemon', 'native', `${process.platform}-${process.arch}`);
+fs.mkdirSync(outDir, { recursive: true });
+
+// 1. npm-installed natives
+for (const mod of ['better-sqlite3', 'node-pty']) {
+  execSync(
+    `npm rebuild ${mod} --runtime=node --target=${NODE_TARGET} --build-from-source`,
+    { cwd: 'daemon', stdio: 'inherit' }
+  );
+  // copy build/Release/*.node + winpty*.dll into outDir
+}
+
+// 2. In-tree ccsm_native N-API helper (frag-3.5.1 §3.5.1.1) — round-2 P0-2 / round-3 P0-3
+//    Single .node carrying winjob + pdeathsig + pipeAcl exports. Builds on all
+//    three platforms; non-Win branches stub out winjob/pipeAcl with ENOSYS but
+//    still emit ccsm_native.node so the loader doesn't ENOENT.
+execSync(
+  `node-gyp rebuild --target=${NODE_TARGET} --runtime=node --dist-url=https://nodejs.org/dist`,
+  { cwd: 'daemon/native/ccsm_native', stdio: 'inherit' }
+);
+fs.copyFileSync(
+  path.join('daemon', 'native', 'ccsm_native', 'build', 'Release', 'ccsm_native.node'),
+  path.join(outDir, 'ccsm_native.node')
+);
+```
+
+Daemon entry resolves natives via:
+
+```ts
+// daemon/src/native.ts
+const nativeRoot = process.pkg
+  ? path.join(path.dirname(process.execPath), 'native', `${process.platform}-${process.arch}`)
+  : path.join(__dirname, '..', 'native', `${process.platform}-${process.arch}`);
+process.env.BETTER_SQLITE3_BINARY = path.join(nativeRoot, 'better_sqlite3.node');
+```
+
+Root script: `npm run build:daemon` → `npm -w @ccsm/daemon run package` (added to root `scripts`).
+
+### 11.2 electron-builder `extraResources` wiring
+
+After the daemon binary + native folder are built, electron-builder copies them into the installer payload. **Round-2 S3 correction**: electron-builder does not expand a `${platform}` token in `from` paths; the only supported tokens in `extraResources` paths are `${os}`, `${arch}`, `${ext}`, `${productName}`, `${version}`. The clean approach is to have `before-pack.cjs` stage everything into a fixed dir (`daemon/native-staged/`) and reference that:
+
+```json
+"extraResources": [
+  { "from": "daemon/dist/ccsm-daemon-staged${ext}", "to": "daemon/ccsm-daemon${ext}" },
+  { "from": "daemon/native-staged",                 "to": "daemon/native" }
+]
+```
+
+`scripts/before-pack.cjs` (new, owned by Task 20a) computes the right per-platform daemon binary + native folder and copies them into the staging paths, then verifies every required artifact is present:
+
+```js
+// scripts/before-pack.cjs (new)
+const fs = require('node:fs');
+const path = require('node:path');
+exports.default = async function beforePack(context) {
+  const { electronPlatformName, arch } = context;
+  // Round-3 P1-1: app-builder-lib's Arch enum is { ia32:0, x64:1, armv7l:2,
+  // arm64:3, universal:4 }. v0.3 ships only x64+arm64; universal/armv7l throw.
+  const archName = ({ 0: 'ia32', 1: 'x64', 2: 'armv7l', 3: 'arm64', 4: 'universal' })[arch];
+  if (archName === 'universal' || archName === 'armv7l') {
+    throw new Error(`[before-pack] arch ${archName} not supported in v0.3 (build x64 + arm64 separately; pkg cannot merge fat Mach-O)`);
+  }
+  if (!archName) throw new Error(`[before-pack] unknown arch index ${arch}`);
+  const map = {
+    win32:  { src: 'daemon/dist/ccsm-daemon-win-x64.exe',          dst: 'daemon/dist/ccsm-daemon-staged.exe', natives: `win32-${archName}` },
+    darwin: { src: `daemon/dist/ccsm-daemon-macos-${archName}`,    dst: 'daemon/dist/ccsm-daemon-staged',     natives: `darwin-${archName}` },
+    linux:  { src: 'daemon/dist/ccsm-daemon-linux-x64',            dst: 'daemon/dist/ccsm-daemon-staged',     natives: `linux-${archName}` },
+  }[electronPlatformName];
+  if (!fs.existsSync(map.src)) throw new Error(`[before-pack] daemon binary missing: ${map.src}`);
+  fs.copyFileSync(map.src, map.dst);
+
+  // Stage native folder
+  const srcNatives = path.join('daemon', 'native', map.natives);
+  const dstNatives = path.join('daemon', 'native-staged');
+  fs.rmSync(dstNatives, { recursive: true, force: true });
+  fs.cpSync(srcNatives, dstNatives, { recursive: true });
+
+  // Round-2 P0-2 + round-3 P0-3: every required `.node` MUST exist before electron-builder packs.
+  // The single `ccsm_native.node` carries winjob+pdeathsig+pipeAcl per frag-3.5.1 §3.5.1.1.
+  const REQUIRED_NATIVES = ['better_sqlite3.node', 'pty.node', 'ccsm_native.node'];
+  for (const f of REQUIRED_NATIVES) {
+    const p = path.join(dstNatives, f);
+    if (!fs.existsSync(p)) throw new Error(`[before-pack] required native missing: ${p}`);
+  }
+};
+```
+
+Electron main resolves the daemon at runtime:
+
+```ts
+// electron/daemonClient/spawnOrAttach.ts
+const ext = process.platform === 'win32' ? '.exe' : '';
+const daemonPath = app.isPackaged
+  ? path.join(process.resourcesPath, 'daemon', `ccsm-daemon${ext}`)
+  : (() => {
+      // Round-3 CF-2 (devx): devTarget() is dev-only and gated behind an
+      // explicit env var so a packaged build can never accidentally fall
+      // into the dev path. See frag-3.7 §3.7.2.b for env-gate rationale.
+      if (process.env.CCSM_DAEMON_DEV !== '1') {
+        throw new Error('packaged build expected app.isPackaged=true; set CCSM_DAEMON_DEV=1 only in dev runner');
+      }
+      return path.join(__dirname, '..', '..', 'daemon', 'dist', `ccsm-daemon-${devTarget()}${ext}`);
+    })();
+```
+
+`process.resourcesPath` resolves to (per round-3 P0-1, install root is per-user):
+- Windows: `%LOCALAPPDATA%\ccsm\resources\daemon\ccsm-daemon.exe`
+- macOS: `CCSM.app/Contents/Resources/daemon/ccsm-daemon` (`.app` itself lives under `~/Library/Application Support/ccsm/` per per-user install; user may also drag to `/Applications` — both supported by Gatekeeper)
+- Linux: `~/.local/share/ccsm/resources/daemon/ccsm-daemon` (AppImage extracts here; `.deb` / `.rpm` install to the same per-user root via electron-builder's `category=Utility` + post-install symlink in `~/.local/bin`)
+
+Validation: extend `scripts/after-pack.cjs` (today only checks node-pty at `:48-83`) with the explicit post-pack required-files list below — hard-fail the build if any are missing. **[manager r7 lock: r6 packaging P1-A — after-pack.cjs explicit validation list]**
+
+```js
+// scripts/after-pack.cjs (extension; per OS)
+// Round-3 P0-3: ccsm_native.node carries winjob+pdeathsig+pipeAcl.
+// R7 P1-A: explicit list — drift between this list and before-pack.cjs
+// REQUIRED_NATIVES + the §11.6.4 helper + §11.2.1 SDK path is a build failure.
+// r9 P1-5: SDK entry assertion strengthened — read package.json `module`/`main`
+// and assert the resolved JS file exists (not just package.json), on BOTH the
+// daemon-side staged copy (primary consumer per r9 P0-1) and the Electron-main
+// shim copy (residual sessionTitles consumer).
+const REQUIRED_AFTER_PACK = [
+  // Daemon binary
+  `resources/daemon/ccsm-daemon${ext}`,
+  // Every native dlopen'd by the daemon
+  'resources/daemon/native/better_sqlite3.node',
+  'resources/daemon/native/pty.node',
+  'resources/daemon/native/ccsm_native.node',
+  // §11.6.4 uninstall helper (Win-only existence; mac/Linux skip)
+  ...(process.platform === 'win32' ? ['resources/daemon/ccsm-uninstall-helper.exe'] : []),
+  // §11.2.1 claude-agent-sdk staged paths (R7 P0-1; r9 P0-1 dual-consumer)
+  // Daemon-side primary copy:
+  'resources/daemon/node_modules/@anthropic-ai/claude-agent-sdk/package.json',
+  // Electron-main residual copy (sessionTitles shim):
+  'resources/sdk/claude-agent-sdk/package.json',
+];
+// r9 P1-5: also resolve and assert the SDK ESM entry-point JS exists on BOTH
+// staged copies. Reading `package.json`'s `module` (preferred for ESM) or
+// `main` (CJS fallback) catches the case where before-pack.cjs accidentally
+// copies only package.json and skips dist/ — runtime import() would otherwise
+// fail with MODULE_NOT_FOUND despite a green after-pack run.
+const SDK_PKG_ROOTS = [
+  'resources/daemon/node_modules/@anthropic-ai/claude-agent-sdk',
+  'resources/sdk/claude-agent-sdk',
+];
+for (const sdkRoot of SDK_PKG_ROOTS) {
+  const pkgPath = path.join(appOutDir, sdkRoot, 'package.json');
+  if (!fs.existsSync(pkgPath)) continue;  // covered by REQUIRED_AFTER_PACK above
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  const entry = pkg.module ?? pkg.main;
+  if (!entry) {
+    throw new Error(`[after-pack] SDK package.json at ${pkgPath} has neither module nor main`);
+  }
+  const entryPath = path.join(appOutDir, sdkRoot, entry);
+  if (!fs.existsSync(entryPath)) {
+    throw new Error(`[after-pack] SDK entry-point missing: ${entryPath} (resolved from ${pkgPath} ${pkg.module ? 'module' : 'main'} = ${entry})`);
+  }
+}
+// Plus on Win: Get-AuthenticodeSignature on every signtool target (§11.3.1 $targets).
+// Plus on mac: codesign -dv --verbose=2 on every codesign target (§11.3.2 loop set).
+// Missing or unsigned → throw and fail the electron-builder run.
+```
+
+#### 11.2.1 `claude-agent-sdk` packaging contract (R7 P0-1; r9 daemon-primary rewrite)
+
+**[manager r9 lock: r8 packaging P0-1 — daemon owns SDK direct ESM; Electron-main shim residual only]** Per frag-3.7 §3.7.7.b r7 lock ("daemon owns ALL SDK runtime use — agent dispatch, streaming, tool execution, model API calls; new daemon code MUST NOT use the shim; Electron-main `loadSdk` shim retained ONLY for residual session-title/non-daemon SDK calls"), the SDK has **two consumers** in v0.3 with asymmetric primacy:
+
+- **Primary: daemon** — runs as a standalone pkg-bundled Node 22 binary with native ESM support. Imports the SDK directly via `import { ... } from '@anthropic-ai/claude-agent-sdk'`, resolved against the daemon binary's sibling `node_modules/` tree. No shim required (Node 22 ESM is first-class; daemon is not Electron-main CJS).
+- **Residual: Electron-main `loadSdk()` shim** — kept only for residual session-title bookkeeping (`getSessionInfo` / `renameSession` / `listSessions` per `electron/sessionTitles/index.ts:59`'s private `loadSdk()` function). Electron-main is CJS so the dynamic-`import()`-via-`new Function` shim stays. Resolves against `process.resourcesPath/sdk/`.
+
+Packaging stages the SDK to **two locations** so each consumer resolves locally:
+
+```json
+"extraResources": [
+  { "from": "daemon/dist/ccsm-daemon-staged${ext}",        "to": "daemon/ccsm-daemon${ext}" },
+  { "from": "daemon/native-staged",                        "to": "daemon/native" },
+  { "from": "daemon/sdk-staged",                           "to": "daemon/node_modules/@anthropic-ai/claude-agent-sdk" },
+  { "from": "node_modules/@anthropic-ai/claude-agent-sdk", "to": "sdk/claude-agent-sdk" }
+]
+```
+
+`before-pack.cjs` asserts `node_modules/@anthropic-ai/claude-agent-sdk/package.json` exists, then:
+1. Copies the SDK + its resolved transitive `node_modules` closure into `daemon/sdk-staged/` (consumed by the daemon-side `extraResources` row above; the install layout becomes `<resources>/daemon/node_modules/@anthropic-ai/claude-agent-sdk/...` which is a real `node_modules` lookup the pkg-bundled daemon's `require.resolve` walks).
+2. Copies the same SDK + closure into `node_modules/@anthropic-ai/claude-agent-sdk/` (already there from `npm install`; the second `extraResources` row stages it under `<resources>/sdk/claude-agent-sdk/` for the residual Electron-main `loadSdk()` shim).
+This avoids `MODULE_NOT_FOUND` against hoisted root `node_modules` that won't exist in the packaged app, on either consumer side.
+
+2. **`asarUnpack` rule.** Both consumers resolve from outside `app.asar` (daemon never touches asar at all; Electron-main shim resolves from `process.resourcesPath/sdk/`). For defense-in-depth against a future maintainer accidentally moving the SDK back inside the asar:
+   ```json
+   "asarUnpack": [
+     "node_modules/@anthropic-ai/claude-agent-sdk/**/*",
+     "**/*.node"
+   ]
+   ```
+   The `**/*.node` glob is the canonical electron-builder pattern for native addons. The asarUnpack rule applies to both `node_modules/@anthropic-ai/claude-agent-sdk/` (Electron-main shim path, even though it normally resolves via `process.resourcesPath/sdk/`) and the daemon-side staged copy (which is not in asar to begin with — pkg-bundled binaries don't read asar).
+
+3. **Native artifacts in the SDK.** Audit at lock time — `claude-agent-sdk@latest` (npm) ships **no `.node` files** in its dependency closure (verified via `npm ls --all` against the working repo's `node_modules/@anthropic-ai/claude-agent-sdk/` at the version pinned in `package.json`). If a future version adds a native (e.g. tokenizer), it MUST be added to:
+   - `before-pack.cjs` `REQUIRED_NATIVES` (so missing → build fails),
+   - the §11.3.1 `$targets` signtool array (so it's signed on Win),
+   - the §11.3.2 `for node in ...` codesign loop (so it's signed on mac with the daemon entitlements).
+   Today the audit is "no `.node`s present"; the spec line above is the contract.
+
+4. **Bundle-size budget contribution.** SDK + transitive deps measure ~6 MB **per consumer copy**, ~12 MB total because both the daemon-side and Electron-main-side staging rows ship a full closure (no dedupe — the two consumers must resolve via independent `node_modules` trees because their require/import resolvers walk from different roots and an asarUnpack-shared copy would couple Electron-main upgrades to daemon resolution). This is folded into the §11.5 installer-size budget below (the 145 MB / 160 MB / 140 MB ceilings include the duplicated SDK).
+
+5. **Load-path resolution (per consumer).** **[manager r9 lock: r8 packaging P0-1 — daemon-primary, Electron-main residual]**
+
+   **Daemon (primary).** Direct ESM, no shim:
+   ```ts
+   // daemon/src/<wherever the SDK is first used>.ts
+   import { query, type SDKMessage } from '@anthropic-ai/claude-agent-sdk';
+   // resolves via daemon binary's sibling node_modules:
+   //   <resources>/daemon/node_modules/@anthropic-ai/claude-agent-sdk/...
+   // (pkg-bundled binary's require.resolve walks from path.dirname(process.execPath))
+   ```
+   No `app.isPackaged` branch — the daemon runs only as a packaged binary in production; in dev (`CCSM_DAEMON_DEV=1`, see §11.2 `devTarget()` gate) the daemon resolves via the workspace's hoisted `node_modules` like any other Node process.
+
+   **Electron-main (residual, sessionTitles only).** The `loadSdk` shim is a private async function inside `electron/sessionTitles/index.ts` (private `async function loadSdk(): Promise<SdkExports>` at `electron/sessionTitles/index.ts:59` on working tip — NOT a standalone module). Per the project memory lock, NEW code MUST go through the daemon path above; the shim is retained ONLY for the existing session-title bookkeeping calls already wired through it. The shim's resolution path under packaged builds:
+   ```ts
+   // resolution path INSIDE the loadSdk function in electron/sessionTitles/index.ts:59
+   // (not a separate file — the patch lives where loadSdk is defined)
+   const sdkRoot = app.isPackaged
+     ? path.join(process.resourcesPath, 'sdk', 'claude-agent-sdk')
+     : path.join(__dirname, '..', '..', 'node_modules', '@anthropic-ai', 'claude-agent-sdk');
+   const sdkPkg = require(path.join(sdkRoot, 'package.json'));
+   const sdkEntry = sdkPkg.module ?? sdkPkg.main;
+   const sdk = await import(pathToFileURL(path.join(sdkRoot, sdkEntry)).href);
+   ```
+   `process.resourcesPath` is the per-user install root from §11.2 (Win: `%LOCALAPPDATA%\ccsm\resources\`, mac: `CCSM.app/Contents/Resources/`, Linux: `~/.local/share/ccsm/resources/`). Dev branch resolves from hoisted root `node_modules` (no asar in dev). Once the residual sessionTitles calls are migrated to the daemon (post-v0.3 deferred), the entire `electron/sessionTitles/` SDK code path can be deleted along with the second `extraResources` row above.
+
+### 11.3 Code-signing (daemon BEFORE installer)
+
+The installer signature does **not** propagate inward. electron-builder signs the outer `.exe` / `.app` after `extraResources` are copied in, but it does **not** re-sign nested binaries. An unsigned `ccsm-daemon.exe` inside a signed installer triggers SmartScreen on every spawn; an unsigned Mach-O inside a signed `.app` fails `codesign --verify --deep` and Gatekeeper kills the app. So: **daemon binary must be signed before electron-builder packages it**.
+
+Same cert as the app. v0.2 release.yml uses `CSC_LINK` + `CSC_KEY_PASSWORD` for both Win and macOS (`.github/workflows/release.yml:143-144,162-164`); macOS adds `APPLE_ID` / `APPLE_ID_PASSWORD` / `APPLE_TEAM_ID` for notarization (`:145-147`). Daemon reuses all of them.
+
+#### 11.3.1 Windows (`signtool`)
+
+After `npm run build:daemon`, before electron-builder. **Round-2 P0-2** mandates signing every `.node` next to the daemon (an unsigned `.node` dlopen'd from a signed exe trips Defender / SmartScreen on hardened systems). **Round-2 P1-6** says don't hardcode the Win SDK path — let the GHA `windows-latest` PATH resolve `signtool.exe` (Microsoft.WindowsAppSDK + .NET workloads put it on PATH). **Round-2 SH3** adds explicit `signtool verify /pa /v` after sign.
+
+```yaml
+# release.yml (new step, runs only on windows-latest, after Build daemon)
+- name: Sign daemon binary + every .node (Windows)
+  if: matrix.platform == 'win' && steps.secrets.outputs.signed == 'true'
+  shell: pwsh
+  run: |
+    $pfx = "$env:RUNNER_TEMP\csc.pfx"
+    [IO.File]::WriteAllBytes($pfx, [Convert]::FromBase64String("${{ secrets.CSC_LINK }}"))
+
+    # Find signtool on PATH (round-2 P1-6: do NOT hardcode 10.0.22621.0)
+    $signtool = (Get-Command signtool.exe -ErrorAction SilentlyContinue).Source
+    if (-not $signtool) {
+      $signtool = Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\bin\*\x64\signtool.exe" |
+                  Sort-Object FullName -Descending | Select-Object -First 1 -ExpandProperty FullName
+    }
+    if (-not $signtool) { throw "signtool.exe not found" }
+
+    # Sign daemon + every .node we ship (round-2 P0-2)
+    $targets = @('daemon\dist\ccsm-daemon-win-x64.exe') +
+               (Get-ChildItem -Recurse 'daemon\native\win32-x64\*.node' | ForEach-Object { $_.FullName })
+    foreach ($t in $targets) {
+      & $signtool sign /f $pfx /p "${{ secrets.CSC_KEY_PASSWORD }}" `
+        /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 `
+        /d "CCSM Daemon" $t
+      # Round-2 SH3: verify and fail the build if signature isn't trusted
+      & $signtool verify /pa /v $t
+      if ($LASTEXITCODE -ne 0) { throw "signtool verify failed: $t" }
+    }
+    Remove-Item $pfx
+```
+
+Notes:
+- Same SHA-256 timestamp server (`http://timestamp.digicert.com`) used implicitly by electron-builder's nsis signer — keeps both signatures verifiable side-by-side.
+- `CSC_LINK` is a base64 PFX (electron-builder convention); decode to a temp file, use, delete. Don't keep on disk.
+- If `secrets.signed != 'true'` (PR builds, forks): **skip signing, do not fail**. Mirrors v0.2 behavior (release.yml:104-123, "builds MUST continue unsigned if absent").
+
+#### 11.3.2 macOS (`codesign` + hardened runtime + entitlements)
+
+pkg-bundled Node uses V8 JIT, so the daemon needs hardened-runtime entitlements that allow JIT. `build/entitlements.daemon.plist` (new):
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key><true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key><true/>
+  <key>com.apple.security.cs.disable-library-validation</key><true/>
+</dict>
+</plist>
+```
+
+Sign step (runs on macos-latest, before electron-builder). **Round-2 P0-2** loops over every `.node` in addition to the daemon Mach-O — `codesign` does not recurse into dlopen'd `.node` files. **Round-2 SH2** moves the keychain unlock password to a `MACOS_KEYCHAIN_PW` secret (avoids fixed `actions` literal appearing in CI logs).
+
+```yaml
+- name: Sign daemon binary + every .node (macOS)
+  if: matrix.platform == 'mac' && steps.secrets.outputs.signed == 'true'
+  shell: bash
+  run: |
+    # Import cert into a temp keychain (same pattern electron-builder uses internally).
+    KC="$RUNNER_TEMP/build.keychain"
+    KC_PW="${{ secrets.MACOS_KEYCHAIN_PW }}"   # round-2 SH2
+    security create-keychain -p "$KC_PW" "$KC"
+    security default-keychain -s "$KC"
+    security unlock-keychain -p "$KC_PW" "$KC"
+    echo "${{ secrets.CSC_LINK }}" | base64 --decode > "$RUNNER_TEMP/csc.p12"
+    security import "$RUNNER_TEMP/csc.p12" -k "$KC" -P "${{ secrets.CSC_KEY_PASSWORD }}" -T /usr/bin/codesign
+    security set-key-partition-list -S apple-tool:,apple: -s -k "$KC_PW" "$KC"
+
+    IDENTITY="Developer ID Application: ${{ secrets.APPLE_TEAM_ID }}"
+    for arch in x64 arm64; do
+      # r9 P1-3: codesign loop iterates BOTH the daemon Mach-O AND the
+      # uninstall-helper Mach-O per arch. Spec §11.6.4 requires the helper
+      # signed for future tray-driven "Reset CCSM" flows; the previous
+      # iteration only covered the daemon binary. Helper Mach-O is produced
+      # by pkg-bundling on macOS regardless of whether the v0.3 macOS tray
+      # currently invokes it (§11.6.2 documents no native uninstaller today).
+      # Sign every .node first (inside-out, round-2 P0-2)
+      for node in daemon/native/darwin-$arch/*.node; do
+        [ -f "$node" ] || continue
+        codesign --force --timestamp --options runtime \
+          --entitlements build/entitlements.daemon.plist \
+          --sign "$IDENTITY" "$node"
+        codesign --verify --strict --verbose=2 "$node"
+      done
+      # Sign daemon binary AND uninstall-helper Mach-O for this arch.
+      for bin in "daemon/dist/ccsm-daemon-macos-$arch" "daemon/dist/ccsm-uninstall-helper-macos-$arch"; do
+        [ -f "$bin" ] || continue
+        codesign --force --timestamp --options runtime \
+          --entitlements build/entitlements.daemon.plist \
+          --sign "$IDENTITY" "$bin"
+        codesign --verify --strict --verbose=2 "$bin"
+      done
+    done
+    rm "$RUNNER_TEMP/csc.p12"
+```
+
+Notarization: the daemon is embedded in `.app/Contents/Resources/daemon/`, so notarytool's submission of the outer `.dmg` (electron-builder's existing flow) covers it — *provided* it was signed first with hardened runtime + same Developer ID. Standalone daemon binary published to GitHub Releases (for the daemon-only updater channel, §11.6) is notarized separately:
+
+```yaml
+- name: Notarize standalone daemon binary (macOS)
+  if: matrix.platform == 'mac' && steps.secrets.outputs.signed == 'true'
+  shell: bash
+  run: |
+    for arch in x64 arm64; do
+      ditto -c -k --keepParent "daemon/dist/ccsm-daemon-macos-$arch" "daemon/dist/ccsm-daemon-macos-$arch.zip"
+      xcrun notarytool submit "daemon/dist/ccsm-daemon-macos-$arch.zip" \
+        --apple-id "${{ secrets.APPLE_ID }}" \
+        --password "${{ secrets.APPLE_ID_PASSWORD }}" \
+        --team-id "${{ secrets.APPLE_TEAM_ID }}" \
+        --wait
+    done
+```
+(Stapling not applicable to standalone Mach-O; notarization ticket is fetched online by Gatekeeper.) **[manager r7 lock: r6 packaging P1-C — DMG stapling explicitly asserted]** The outer `.dmg` IS stapled (offline Gatekeeper requires it on first launch with no network). electron-builder calls `xcrun stapler staple` automatically only when its `mac.notarize` config is truthy — the spec asserts this explicitly:
+
+```json
+"build": {
+  "mac": {
+    "notarize": { "teamId": "${env.APPLE_TEAM_ID}" }
+  }
+}
+```
+
+Plus an explicit post-build verification in the macOS leg of `release.yml` to fail loud if electron-builder regresses on the implicit stapling:
+
+```yaml
+- name: Assert DMG is stapled (R7 P1-C)
+  if: matrix.platform == 'mac'
+  shell: bash
+  run: |
+    for dmg in release/*.dmg; do
+      xcrun stapler validate "$dmg" || { echo "::error::DMG not stapled: $dmg"; exit 1; }
+    done
+```
+
+**Standalone-daemon zip naming convention (R7 P1-E).** **[manager r7 lock: r6 packaging P1-E — standalone daemon zip naming]** The `ditto -c -k --keepParent` form above produces zips named `ccsm-daemon-macos-${arch}.zip` whose top-level entry is the per-arch unique Mach-O leaf (`ccsm-daemon-macos-x64` or `ccsm-daemon-macos-arm64`). The naming convention is locked at:
+- macOS: `ccsm-daemon-macos-${arch}.zip` (arch ∈ {x64, arm64}); top-level = single Mach-O of the same name.
+- Windows standalone (future daemon-only updater): `ccsm-daemon-win-${arch}.zip`; top-level = `ccsm-daemon-win-${arch}.exe`.
+- Linux standalone: `ccsm-daemon-linux-${arch}.tar.gz` (no zip — Linux convention); top-level = single ELF `ccsm-daemon-linux-${arch}`.
+
+These names are referenced by the daemon-only updater feed (§11.5(4) deferred sketch) and by the SHA256SUMS / SLSA subject-path globs in §11.4. Any rename requires a spec edit because the updater feed URL pattern is derived from these names.
+
+#### 11.3.3 Linux
+
+No signing infrastructure today (review §4 implicit). Linux daemon binary ships unsigned; integrity via SHA256SUMS only.
+
+### 11.4 SHA256SUMS.txt manifest
+
+Published alongside release artifacts. Auto-updater (Electron + daemon) downloads + verifies before applying.
+
+> **Round-2 S1 correction**: per-platform SHA computation cannot see other platforms' daemon binaries. Compute SHAs in the **merge `release-publish` job** after downloading every platform's artifacts, so one manifest covers everything (installers + standalone daemons + updater feed YMLs).
+
+Per-platform job uploads the raw artifacts (already done by electron-builder + the new `Build daemon` step). Final `release-publish` job (new, `needs: [build]`):
+
+```yaml
+- uses: actions/download-artifact@v4
+  with: { path: dist-all }   # pulls every matrix leg's artifacts
+- name: Compute SHA256 (round-2 S1 — single source of truth)
+  shell: bash
+  run: |
+    cd dist-all
+    : > ../SHA256SUMS.txt
+    # Installers + daemons + electron-updater feed YMLs (round-2 §6 manifest scope)
+    find . -type f \( \
+        -name '*.exe' -o -name '*.dmg' -o -name '*.zip' \
+        -o -name '*.AppImage' -o -name '*.deb' -o -name '*.rpm' \
+        -o -name 'ccsm-daemon-*' \
+        -o -name 'latest*.yml' \
+      \) -print0 | sort -z | xargs -0 sha256sum >> ../SHA256SUMS.txt
+- uses: softprops/action-gh-release@v2
+  with:
+    files: |
+      SHA256SUMS.txt
+      provenance.intoto.jsonl
+```
+
+#### 11.4.1 SLSA-3 build provenance (round-2 P0-S3 / security)
+
+SHA256 alone gives integrity vs network corruption, NOT authenticity (round-1 S5, round-2 security P0-S3). A pipeline-secret compromise replaces both binary and `SHA256SUMS.txt` in one push. v0.3 closes this with a free, GitHub-native SLSA-3 attestation — no sigstore key infrastructure required:
+
+```yaml
+# In the release-publish job, AFTER all artifacts downloaded
+- name: Generate SLSA build provenance
+  uses: actions/attest-build-provenance@v1
+  with:
+    subject-path: |
+      dist-all/**/*.exe
+      dist-all/**/*.dmg
+      dist-all/**/*.AppImage
+      dist-all/**/*.deb
+      dist-all/**/ccsm-daemon-*
+      dist-all/SHA256SUMS.txt
+```
+
+`actions/attest-build-provenance@v1` writes a signed `provenance.intoto.jsonl` whose signing identity is GitHub's OIDC root (Fulcio-anchored). The Electron + daemon updater verifies the attestation before swap using **`@sigstore/verify` 1.x** (pure-JS, ~2 MB add to the Electron bundle, handles in-toto SLSA v1.0 bundles via Rekor lookup) — short-circuits the manual-update prompt if attestation absent or signing identity mismatched. The verifier library choice is locked here per round-3 CF-4; the actual verify call lives in frag-6-7 §6.4 step 2. Linux additionally publishes a minisign signature (one-time keypair, `MINISIGN_KEY` secret, ~30 LOC):
+
+```yaml
+- name: Sign Linux artifacts (minisign — round-2 P0-S3)
+  if: matrix.platform == 'linux'
+  run: |
+    echo "${{ secrets.MINISIGN_KEY }}" > /tmp/minisign.key
+    for f in release/*.AppImage release/*.deb release/*.rpm daemon/dist/ccsm-daemon-linux-x64; do
+      [ -f "$f" ] && minisign -S -s /tmp/minisign.key -m "$f"
+    done
+    shred -u /tmp/minisign.key
+```
+
+This makes the v0.4 sigstore plan a strict superset rather than "we shipped insecure on purpose for one release." Public minisign verify key shipped in the installer + documented in release notes.
+
+### 11.5 CI changes (release.yml)
+
+Net diff vs current `.github/workflows/release.yml`:
+
+0. **`actions/setup-node` bumped from `node-version: '20'` to `'22'`** in both `verify` (`:33`) and `build` (`:84`) jobs (round-2 P1-3). **Electron is pinned to `^41.3.0`** in root `package.json` `devDependencies.electron` (verified against `pool-1/package.json` on 2026-05-01; user-memory baseline of "Electron 33" was stale — current working tip ships Electron 41.x). Electron 41 ships its own Node 20.x at runtime — they are separate processes, no compat conflict. Bumping the toolchain Node lets `@yao-pkg/pkg` resolve its base binary from the local install instead of fetching ~30 MB on every CI run, and matches the daemon's Node 22 ABI target. [manager r7 lock: r6 lockin P0 — Electron version pinned to ^41.3.0 per pool-1/package.json check on 2026-05-01.]
+
+   **Electron upgrade plan**: v0.3 ships on Electron `^41.3.0` (caret allows patch-level autoupdate within 41.x). The next major bump (Electron 42+) is **deferred until post-v0.3 ship**; bumping is a separate scoped task that must (a) re-verify the `loadSdk()` shim contract for `claude-agent-sdk` (Electron-main is CJS, SDK is ESM-only — see frag-3.5.1 for the canonical lock and shim ownership), (b) re-run the per-`.node` ABI rebuild matrix (`better_sqlite3`, `pty`, `ccsm_native`), (c) re-validate `before-pack.cjs` / `after-pack.cjs` against the new electron-builder + Electron pair. No Electron major bump is in v0.3 scope.
+
+   **[manager r9 lock: r8 packaging P1-2 — caret-range size budget recalibration]** The §11.5(6) installer-size budget (145 MB / 160 MB / 140 MB) is calibrated against the Electron 41 minor pinned by `package-lock.json` at the moment the budget was set. The caret on `^41.3.0` allows minor jumps (Electron ships ~2 minors per quarter; a 41.4.x or 41.5.x bump can add ~3 MB to the packaged payload). Calibration policy: the size budget is recomputed on every minor Electron bump (any `package-lock.json` diff that changes the resolved Electron minor or higher), and the §11.5(6) CI guard fails the build if the measured installer size delta is >5 MB versus the prior-locked baseline without an explicit size-budget bump PR (spec edit raising the ceiling, with reviewer sign-off, in the same PR as the lockfile change). `package-lock.json` is the authoritative version-of-record for the budget; the `^41.3.0` caret in `package.json` documents the supported floor but the lockfile is what the budget is calibrated against.
+
+   **SDK loading discipline (cross-ref)**: this section addresses packaging only. For the `loadSdk()` shim contract that Electron-main consumers MUST go through (`claude-agent-sdk` is ESM-only, Electron 41 main is CJS), see frag-3.5.1's loadSdk ownership lock; frag-11 enforces packaging (extraResources + signing) without re-litigating shim discipline.
+0a. **`hashFiles`-cache key extended to include `daemon/package-lock.json`** so daemon workspace installs are cached separately from root.
+1. **`verify` job (`:26-47`)**: add `npm -w @ccsm/daemon run build` AND `npm -w @ccsm/daemon run test` after `npm test` — daemon TS compiles + daemon unit tests run in pre-flight (round-2 P1-3 + frag-3.5.1 §3.5.1.6 acceptance criteria).
+2. **`build` job (`:49-179`)**: new step `Build + sign daemon binary` runs **before** "Package (Linux/macOS/Windows)" steps (`:132-164`):
+   - `npm run build:daemon` (compiles + rebuilds natives incl. `ccsm_native.node` + pkg-bundles, no GZip)
+   - Sign step per platform (§11.3.1 covers daemon exe + every `.node`; §11.3.2 mac codesigns same set)
+   - Then existing `npx electron-builder` step picks up signed binary + signed natives via `extraResources` (which `before-pack.cjs` stages)
+3. **Daemon binary uploaded as separate release asset** (for future daemon-only updater) by extending the upload globs at `:170-178` and `:192-200`:
+   ```yaml
+   files: |
+     release/*.exe
+     ...
+     daemon/dist/ccsm-daemon-*
+     SHA256SUMS.txt
+     provenance.intoto.jsonl
+     *.minisig
+   ```
+4. **Single tag (`v*`) for v0.3.0** — no separate `daemon-v*` tag yet (review §4 SHOULD-FIX #6: first ship has no install base; reserve `daemon-v*` for v0.3.1+ daemon-only patches). When v0.3.1 ships, a separate matrix that builds **only** the daemon (skips electron-builder) is required — sketched in §11.6 deferred so it isn't a panic-rewrite at v0.3.1 release time.
+5. **Cert-missing handling**: if `steps.secrets.outputs.signed != 'true'`, skip daemon-sign step with a `::warning::` (matches v0.2 line `:152-156`). PR builds + forks must continue producing unsigned artifacts; only tag pushes from `Jiahui-Gu/ccsm` get the secrets.
+6. **Installer size budget + CI guard (R7 P1-B).** **[manager r7 lock: r6 packaging P1-B — installer size ceiling + CI assertion]** Target sizes (uncompressed installer; measured at release-publish merge job, fail the build over):
+   - Windows NSIS `*.exe`: **≤ 145 MB** (Electron 41 ~95 MB + bundled Chromium fonts, daemon pkg ~50 MB incl. Node 22 base + better-sqlite3 + node-pty + ccsm_native, claude-agent-sdk ~6 MB per §11.2.1, uninstall-helper ~5 MB, headroom ~5 MB).
+   - macOS DMG: **≤ 160 MB** (Electron Mach-O is fatter; daemon ships per-arch but DMG carries one arch).
+   - Linux AppImage: **≤ 140 MB**; `.deb` / `.rpm`: **≤ 125 MB**.
+
+   Standalone daemon binary (`ccsm-daemon-${platform}-${arch}`): **≤ 60 MB** per arch.
+
+   CI assertion in `release-publish` job (after artifacts downloaded, before `gh release upload`):
+   ```yaml
+   - name: Assert installer size budgets (R7 P1-B)
+     shell: bash
+     run: |
+       declare -A LIMIT_MB=(
+         [exe]=145 [dmg]=160 [AppImage]=140 [deb]=125 [rpm]=125
+       )
+       fail=0
+       for f in dist-all/**/*.{exe,dmg,AppImage,deb,rpm}; do
+         [ -f "$f" ] || continue
+         ext="${f##*.}"
+         size_mb=$(( $(stat -c%s "$f") / 1024 / 1024 ))
+         lim="${LIMIT_MB[$ext]}"
+         echo "$f -> ${size_mb} MB (limit ${lim} MB)"
+         if [ "$size_mb" -gt "$lim" ]; then
+           echo "::error::$f exceeds ${lim} MB budget (got ${size_mb} MB)"
+           fail=1
+         fi
+       done
+       # Standalone daemon binaries
+       for f in dist-all/**/ccsm-daemon-*; do
+         [ -f "$f" ] || continue
+         size_mb=$(( $(stat -c%s "$f") / 1024 / 1024 ))
+         if [ "$size_mb" -gt 60 ]; then
+           echo "::error::$f exceeds 60 MB budget (got ${size_mb} MB)"; fail=1
+         fi
+       done
+       exit $fail
+   ```
+   Budget changes require a spec-edit + reviewer sign-off (no silent CI bumps); the rationale is that uncontrolled growth turns the per-user installer into a "do I really want to install this 200 MB thing" friction point that competitors (raw CLI, plain VSCode) don't have.
+
+### 11.6 NSIS uninstall hygiene (round-2 P0-1 — reclaimed from frag-6-7; round-3 P0-1/P0-2/P0-4 path corrections)
+
+**Why frag-11 owns this.** Round-1 packaging review §3.4 demanded an NSIS `customUnInstall` script. Frag-11 originally punted to "lifecycle / frag-6-7 §3.1," but frag-6-7 covers daemon shutdown RPC + lockfile semantics — it does NOT define an NSIS macro, electron-builder `nsis.include` wiring, `.deb` postrm, or `.rpm` %preun scripts. NSIS scripts + electron-builder config are pure packaging concerns and belong here. Cross-frag rationale (§ Cross-frag rationale at bottom) coordinates the seam with frag-6-7's `daemon.shutdown` RPC and proper-lockfile cleanup (round-2 P1-5).
+
+**Surface vs disk-mechanics split (round-3 X3 dedupe).** The in-app surface that *triggers* uninstall-style cleanup (close-to-tray menu item, "Reset CCSM…" tray menu, post-uninstall toast, etc.) is owned by **frag-6-7 §6.8** with a numeric priority registry. Frag-11 §11.6 owns only the disk-removal *mechanics*: NSIS `customUnInstall`, `.deb` postrm, `.rpm` %preun, the canonical paths table, and the `ccsm-uninstall-helper.exe` orchestration shim. Cross-ref: see frag-6-7 §6.8 for the in-app surface registry; frag-11 §11.6 owns disk-removal mechanics on each OS.
+
+**Per-user install root (round-3 P0-1; r9 oneClick reconciled with working tip).** **[manager r9 lock: r8 packaging P0-2 — keep working-tip `oneClick: false` / `allowElevation: true` / `allowToChangeInstallationDirectory: true` for v0.3 freeze; assisted-mode installer wizard preserved; user can change install dir; no UX migration friction; updater compatible.]** electron-builder NSIS is configured with:
+
+```json
+"build": {
+  "nsis": {
+    "include": "build/installer.nsh",
+    "perMachine": false,
+    "oneClick": false,
+    "allowElevation": true,
+    "allowToChangeInstallationDirectory": true,
+    "deleteAppDataOnUninstall": false
+  }
+}
+```
+
+Rationale for keeping `oneClick: false` (not flipping to `oneClick: true`):
+- **No UX migration friction**: working tip already ships the assisted-mode wizard; v0.3 keeps it. `oneClick: true` would silently strip the install-path picker, the finish page, and the "Run CCSM" checkbox — a UX regression on every existing user's upgrade.
+- **`allowToChangeInstallationDirectory: true` survives**: power users who keep `%LOCALAPPDATA%` on a smaller SSD can redirect to a different drive at install time. `oneClick: true` would have forced this off.
+- **`allowElevation: true` is harmless under `perMachine: false`**: when the chosen install dir is `%LOCALAPPDATA%` no UAC fires; if the user redirects to an elevation-required path (e.g. `D:\Program Files\ccsm`) UAC prompts and the install proceeds. The `perMachine: false` lock keeps the auto-update-without-UAC contract for the default install location.
+- **Updater-compatible**: electron-updater works identically with assisted-mode NSIS; the upgrade-in-place flow in §11.6.5 is unaffected.
+- **`customUnInstall` macro stays silent**: with `oneClick: false` the installer/uninstaller has its own first-class UI. The previously-proposed `MessageBox MB_YESNO` in §11.6.1 is dropped (see §11.6.1 below) — modal dialogs from inside `customUnInstall` are inappropriate for the assisted-mode uninstaller flow which already has its own progress UI; it would also auto-default to "No" under silent (`/S`) updater-driven uninstall paths, silently skipping user-data cleanup. The macro now performs the always-safe disk-removal mechanics (kill daemon, drop install root) and leaves opt-in user-data cleanup to a separate user-initiated flow (frag-6-7 §6.8 in-app "Reset CCSM…" surface).
+
+`perMachine: false` makes NSIS install to `%LOCALAPPDATA%\ccsm\` (i.e. `$LOCALAPPDATA\ccsm` in NSIS variables) under the invoking user's profile — no UAC prompt, no `Program Files` write, auto-update can write in-place from a non-elevated Electron process. This is the gate that satisfies frag-6-7 §7.4 T9/T14 "user-only ACL" claim: the install root inherits `%LOCALAPPDATA%`'s default ACL (owner = user, no Authenticated-Users read+execute). On macOS the per-user analog is `~/Library/Application Support/ccsm/`; on Linux `~/.local/share/ccsm/` (AppImage extraction target; `.deb`/`.rpm` install symlinks from the same root via `category=Utility`).
+
+**v0.3 daemon-owned paths** (canonical list — single source of truth; round-3 P0-2 reconciles every row to per-user OS-native roots, NOT `~/.ccsm/`):
+
+| Path (Windows) | Path (macOS) | Path (Linux) | Owner | Cleanup default | Opt-in cleanup |
+|---|---|---|---|---|---|
+| `%LOCALAPPDATA%\ccsm\resources\daemon\` | `~/Library/Application Support/ccsm/resources/daemon/` | `~/.local/share/ccsm/resources/daemon/` | installer | always (uninstaller wipes install root) | n/a |
+| `%LOCALAPPDATA%\ccsm\daemon.lock` | `~/Library/Application Support/ccsm/daemon.lock` | `~/.local/share/ccsm/daemon.lock` | proper-lockfile (frag-6-7 §6.4) | always (stale PID) | always |
+| `%LOCALAPPDATA%\ccsm\daemon.secret` | `~/Library/Application Support/ccsm/daemon.secret` | `~/.local/share/ccsm/daemon.secret` | Electron-main (frag-6-7 §7.2) | retained (rollback) | deleted |
+| `%LOCALAPPDATA%\ccsm\data\` | `~/Library/Application Support/ccsm/data/` | `~/.local/share/ccsm/data/` | daemon SQLite (frag-8 §8.3) | retained | deleted |
+| `%LOCALAPPDATA%\ccsm\logs\` | `~/Library/Application Support/ccsm/logs/` | `~/.local/share/ccsm/logs/` | pino-roll (frag-6-7 §6.6) | retained | deleted |
+| `%LOCALAPPDATA%\ccsm\crashes\` | `~/Library/Application Support/ccsm/crashes/` | `~/.local/share/ccsm/crashes/` | crash dumps (security T13) | retained | deleted |
+| Named pipe / Unix socket | (same) | (same) | daemon at runtime | always (OS cleans on process exit) | always |
+
+"Opt-in cleanup" = user checked "Also delete my CCSM data" in the uninstaller. On opt-in, the uninstaller removes the per-user data root **recursively** — every daemon-owned path goes (round-2 P1-5: spell out the full set, don't leave subdirs behind). Every row uses the OS-native per-user data root; the legacy `~/.ccsm/` root is retired in v0.3.
+
+#### 11.6.1 Windows: `build/installer.nsh`
+
+**[manager r9 lock: r8 packaging P0-2 — silent macro, no MessageBox; `oneClick: false` assisted-mode installer owns the user-facing UI; user-data opt-in cleanup is an in-app flow per frag-6-7 §6.8, not an NSIS modal.]**
+
+```nsis
+; build/installer.nsh — wired via package.json build.nsis.include (round-2 P0-1)
+; All paths use $LOCALAPPDATA per round-3 P0-1/P0-2; never $PROGRAMFILES.
+; Silent uninstall macro per r9 P0-2: no MessageBox modal. The assisted-mode
+; (oneClick: false) NSIS uninstaller has its own UI; modal dialogs from inside
+; customUnInstall would either fight that UI or auto-default to "No" under the
+; silent (/S) updater-driven path, silently skipping cleanup. User-data opt-in
+; deletion is performed in-app via the frag-6-7 §6.8 "Reset CCSM…" surface
+; BEFORE the user invokes the uninstaller; this macro only does the always-safe
+; mechanics: stop the daemon, release the lockfile.
+!macro customUnInstall
+  ; 1. Stop the running daemon (frag-6-7 §6.4 daemon.shutdown RPC unreachable post-install).
+  ;    The §11.6.4 helper handles graceful-shutdown-via-RPC first; this taskkill
+  ;    is the safety net.
+  nsExec::ExecToLog 'taskkill /IM ccsm-daemon.exe /F /T'
+  Sleep 500   ; let OS release file handles
+  Delete "$LOCALAPPDATA\ccsm\daemon.lock"
+
+  ; 2. The install root ($INSTDIR under %LOCALAPPDATA%\ccsm) is wiped by the
+  ;    standard NSIS uninstall sequence. User data subdirs (data/, logs/,
+  ;    crashes/, daemon.secret) are NOT touched here — they are retained by
+  ;    default per the §11.6 paths table. Opt-in cleanup happens in-app
+  ;    (frag-6-7 §6.8) before uninstall, OR the user manually deletes
+  ;    %LOCALAPPDATA%\ccsm\ post-uninstall (release-notes documented).
+!macroend
+```
+
+(`deleteAppDataOnUninstall: false` keeps electron-builder's automatic deletion off — user data survives uninstall by default, matching the §11.6 paths table "retained" cleanup default. The full `nsis` block including `oneClick: false / perMachine: false / allowElevation: true / allowToChangeInstallationDirectory: true` is shown above the paths table.)
+
+#### 11.6.2 macOS: no native uninstaller
+
+macOS apps have no uninstaller. The user drags `CCSM.app` to Trash; `~/Library/Application Support/ccsm/` survives. v0.3 ships:
+
+- Release notes that document the manual cleanup steps: drag `CCSM.app` to Trash, then optionally `rm -rf ~/Library/Application\ Support/ccsm` in Terminal.
+
+[manager r7 lock: cut as polish — N1# from r6 feature-parity. The "Reset CCSM…" tray-menu item is DELETED entirely (formerly called `daemon.shutdown` then prompted for `shell.trashItem` of `~/Library/Application Support/ccsm/`). v0.3 macOS tray menu stays at working's `[Show CCSM | Quit]`; uninstall is "drag to Trash" + release-notes guidance only. No new tray entries — v0.3 is refactor scope. The corresponding §6.8 in-app surface contract entry is also deleted by fixer A.]
+
+#### 11.6.3 Linux: `.deb` postrm + `.rpm` %preun
+
+```sh
+# build/linux-postrm.sh (electron-builder injects via deb.postrm / rpm.scripts.preUninstall)
+#!/bin/sh
+set -e
+# Round-3 P0-4: postrm/%preun runs as root with HOME=/root, so the legacy
+# `${HOME:-/root}/.ccsm` expansion was a tautology that never touched real
+# user data. The correct daemon-owned root is per-user (~/.local/share/ccsm)
+# and root cannot enumerate users safely from a maintainer script. We do the
+# minimum safe thing: kill the running daemon and remove the install-root
+# resources (which dpkg/rpm already own). User-data cleanup is documented as a
+# per-user manual step.
+case "$1" in
+  remove|purge)
+    pkill -f /usr/lib/ccsm/resources/daemon/ccsm-daemon || true
+    if [ "$1" = "purge" ] && [ -n "${SUDO_USER:-}" ]; then
+      # Best-effort: if `sudo apt-get purge` was used, we know the invoking
+      # user and can clean their data root. If apt was run as root directly
+      # (no SUDO_USER), skip — release notes tell the user to run the
+      # manual cleanup command below.
+      user_home=$(getent passwd "$SUDO_USER" | cut -d: -f6)
+      if [ -n "$user_home" ] && [ -d "$user_home/.local/share/ccsm" ]; then
+        rm -f  "$user_home/.local/share/ccsm/daemon.lock"
+        rm -rf "$user_home/.local/share/ccsm"
+      fi
+    fi
+    ;;
+esac
+# NOTE: `apt-get purge` without sudo (root login) leaves user data behind by
+# design. Release notes include: `rm -rf ~/.local/share/ccsm` for full cleanup.
+```
+
+(`.rpm` lacks a "purge" mode — document in release notes that user data survives `rpm -e`; user runs `rm -rf ~/.local/share/ccsm` for full cleanup.)
+
+#### 11.6.4 Daemon-shutdown RPC integration (cross-ref frag-6-7)
+
+The hardstop `taskkill` / `pkill` is the safety net. Preferred path: when the user clicks Uninstall, the v0.3 installer first attempts `daemon.shutdown` over the named pipe / Unix socket (frag-6-7 §6.4) for graceful flush — a 2 s timeout, then fall back to kill. This is implemented in the daemon shutdown RPC (frag-6-7 owns the RPC); the NSIS macro orchestrates it via a tiny helper `ccsm-uninstall-helper.exe` shipped in `extraResources`.
+
+```nsis
+; In customUnInstall, before taskkill. Round-3 P1-6: copy the helper to $TEMP
+; first so the in-progress uninstall main loop can RMDir $INSTDIR without
+; tripping a Windows file-lock on the helper exe.
+SetOutPath "$TEMP"
+CopyFiles /SILENT "$INSTDIR\resources\daemon\ccsm-uninstall-helper.exe" "$TEMP\ccsm-uninstall-helper.exe"
+nsExec::ExecToLog '"$TEMP\ccsm-uninstall-helper.exe" --shutdown --timeout 2000'
+Sleep 500
+Delete "$TEMP\ccsm-uninstall-helper.exe"
+```
+
+The helper is a 2-file Node script that pkg-bundles to ~5 MB; reuses the daemon's RPC client. Owned by Task 20e (new). **[manager r7 lock: r6 packaging P1-F — `ccsm-uninstall-helper.exe` is a first-class signed packaging artifact]** It MUST appear in:
+- `before-pack.cjs` staging — copied into `daemon/dist/` next to the daemon binary so electron-builder's `extraResources` `daemon/` glob picks it up at the same `resources/daemon/` path.
+- §11.3.1 signtool `$targets` array on Windows — the helper is invoked at uninstall time from `$TEMP`; an unsigned helper trips Defender / SmartScreen on the same hardened machines that would block an unsigned daemon. The §11.3.1 step is amended: `$targets = @('daemon\dist\ccsm-daemon-win-x64.exe', 'daemon\dist\ccsm-uninstall-helper.exe') + (Get-ChildItem -Recurse 'daemon\native\win32-x64\*.node' | …)`.
+- §11.3.2 codesign loop on macOS — even though macOS does not ship the helper today (no native uninstaller — see §11.6.2), the cross-platform pkg-bundling produces a Mach-O for completeness and the codesign loop signs it (`codesign … "$bin"` step extended to also iterate `daemon/dist/ccsm-uninstall-helper-macos-$arch`) so future tray-driven "Reset CCSM" flows on mac can shell out to it without Gatekeeper rejection.
+- `after-pack.cjs` `REQUIRED_AFTER_PACK` list above (Win-only existence check).
+
+#### 11.6.5 Upgrade-in-place flow (R7 P0-2)
+
+`ccsm-uninstall-helper.exe --shutdown` covers the **uninstall** path; **upgrade-in-place** (electron-updater applying a downloaded `.exe` / `.dmg` over the live install) needs a separate ordering contract because the Electron app's `quitAndInstall` does NOT know about the daemon process (separate PID, separate lockfile). Without an explicit shutdown, the just-upgraded electron-main launches and either (a) attaches to the OLD pre-upgrade daemon via `daemon.lock` (no upgrade actually applied) or (b) NSIS fails to overwrite `ccsm-daemon.exe` due to a Windows file-lock from the running daemon. **[manager r7 lock: r6 packaging P0-2 — upgrade-in-place daemon-shutdown contract]**
+
+Sequence (Electron-main owns the orchestration; cross-ref frag-6-7 §6.4 for the RPC):
+
+1. **Trigger.** `electron-updater` emits `update-downloaded`. Electron-main intercepts BEFORE calling `autoUpdater.quitAndInstall()`.
+2. **Graceful shutdown RPC.** Electron-main sends `daemon.shutdownForUpgrade` over the named pipe / Unix socket (RPC defined in frag-6-7 §6.4). Daemon writes a shutdown marker to `<dataRoot>/daemon.shutdown` (so the next-launched daemon can distinguish upgrade-shutdown from crash recovery), flushes pino buffers, releases the `proper-lockfile` lock on `daemon.lock`, then `process.exit(0)`.
+3. **Ack window.** Electron-main awaits ack with a **5 s timeout** (longer than the 2 s uninstall timeout in §11.6.4 because upgrade flush includes any in-flight session writes; uninstall is destructive so a quick kill is fine). **[manager r9 lock: r8 packaging P1-1 — explicit ack source]** Ack = the unary RPC reply envelope on the control socket (same channel as `daemon.hello`); the timer starts when Electron-main writes the `daemon.shutdownForUpgrade` envelope and stops on receipt of the reply envelope. Socket-EOF and process-handle wait (`WaitForSingleObject` on Win, `waitpid` on POSIX) are NOT used as ack signals — Win can take 100ms+ to reap a process after exit, falsely tripping the force-kill on slow Windows hosts. If no reply within 5 s after sending `daemon.shutdownForUpgrade`, force-kill via OS process handle (`taskkill /F /PID <daemonPid> /T` on Windows, `process.kill(daemonPid, 'SIGKILL')` on POSIX) per step 4.
+4. **Race fallback (no ack within 5 s).** Electron-main force-kills:
+   - Windows: `taskkill /F /PID <daemonPid> /T` (the daemon PID is known from frag-6-7 §6.4 spawn handle; `/T` covers any child processes the daemon spawned).
+   - macOS / Linux: `process.kill(daemonPid, 'SIGKILL')` (POSIX `kill -KILL`).
+   Then unlinks `<dataRoot>/daemon.lock` (proper-lockfile leaves a stale lock dir on `SIGKILL`; the next-start stale-PID recovery in frag-6-7 §6.4 would handle it but unlinking explicitly here is faster and removes the race window described in the next paragraph).
+5. **Proceed with upgrade.** Electron-main calls `autoUpdater.quitAndInstall(isSilent=true, isForceRunAfter=true)`. NSIS / DMG / AppImage installer overwrites the install root (no file-lock now that the daemon is dead).
+6. **New electron-main spawns fresh daemon.** On post-upgrade launch, the new electron-main runs the standard `spawnOrAttach` flow (§11.2): `proper-lockfile` sees no live PID (we unlinked it; or proper-lockfile's stale-PID recovery handles it), `<dataRoot>/daemon.shutdown` marker is consumed (signalling clean upgrade — no crash-loop counter increment), and the new electron-main spawns the new daemon binary from the new bundle path.
+
+**Why lockfile-only is insufficient.** A naive "lockfile gates new daemons" assumption fails the upgrade case: if the old daemon happens to still hold the lock through the upgrade window (electron-updater swap is fast, but daemon process death from `quitAndInstall`-induced Electron exit is racy on Windows since the daemon is a separate process), the upgraded electron-main will see a held lock and ATTACH to the old daemon instead of spawning a new one — running the OLD bundle's daemon code against the NEW bundle's electron-main. The shutdown-marker + explicit-kill + lock-unlink sequence above closes this race window deterministically: the upgraded electron-main always sees no lock and always spawns from the new bundle.
+
+### 11.7 Out of scope (deferred)
+
+- **SmartScreen reputation reset risk on path / scope change (R7 P1-D; r9 P1-4 mitigation honesty fix).** **[manager r9 lock: r8 packaging P1-4 — no EV-cert lock present in §11.3.x; v0.3 ships with standard OV cert + SmartScreen reputation accepted as known cost; EV cert deferred to v0.3+ post-ship if SmartScreen reset becomes a release-blocker.]** The v0.3 install-path lock moved from `Program Files\ccsm\` (any v0.2 path) to `%LOCALAPPDATA%\ccsm\` and from per-machine to per-user. The SmartScreen reputation tuple is `(signer cert, file SHA, install path, scope)` — changing install path AND scope simultaneously resets reputation, so first-launch users on Windows 10/11 with SmartScreen enabled may see "Windows protected your PC" even though the binary is signed with the same Authenticode cert. Mitigation status: §11.3.x specifies `CSC_LINK` + `CSC_KEY_PASSWORD` (a base64 PFX) without locking cert type, and no EV-policy OID is asserted in CI. The v0.3 release ships with the standard OV (Organization Validation) code-signing cert already in use — SmartScreen reputation reset on first-launch is accepted as a known cost, documented in release notes ("expect a 'Windows protected your PC' prompt the first few times after upgrading; click 'More info' → 'Run anyway'; reputation accrues over ~10k installs"). EV cert acquisition is **deferred to a post-v0.3 release** if SmartScreen reset turns out to be a release-blocker in field telemetry; a future EV migration would add a CI-time `signtool verify /v` assertion that the cert carries an EV-policy OID such as `2.23.140.1.3` and remove the release-notes warning.
+
+- Daemon auto-update channel (separate `daemon-v*` tag, daemon-only updater) — covered in §7 / plan Task 23. v0.3.1+ requires a daemon-only build matrix that skips electron-builder; sketch noted in §11.5(4).
+- macOS notarization rate-limit mitigation — accepted as **5 submissions per release** (1 outer `.dmg` via electron-builder + 2 standalone-daemon zips × 2 archs per round-3 P1-5 correction; review §5 OPEN; round-2 packaging S2 confirmed acceptable). All 5 run in parallel `notarytool submit --wait` calls; Apple's documented soft cap is 75/day per Apple ID.
+- GPG / sigstore signing of `SHA256SUMS.txt` — round-2 P0-S3 closed via `actions/attest-build-provenance@v1` (SLSA-3) + Linux minisign for v0.3; v0.4 migrates to full sigstore (cosign keyless).
+- Truly-reproducible pkg builds (byte-identical between runs) — defer to v0.4 native SEA, which produces deterministic single-static binaries by Node design. v0.3 ships with `pkg` (no GZip) and SHA256+SLSA as the integrity story; the reproducible-build CI step in frag-6-7 §7.3 / Task 26 is demoted to "produce + archive SHA256, do not require byte-identical re-runs" (round-2 P1-4 option 1+3).
+
+---
 
 ## Plan delta
-- New Task: daemon pkg build (+4h).
-- New Task: electron-builder/forge extraResources wiring (+3h).
-- New Task: Win signtool integration in CI (+2h).
-- New Task: Mac codesign + notarization (+3h, more if entitlements need
-  tweaking).
-- New Task: SHA256SUMS.txt publish step (+1h).
-- Total packaging block: ~13h.
+
+Insert after plan Task 20 (`2026-04-30-v0.3-daemon-split.md:1474`) and before Task 21 (`:1529`); update Task 24 (`:1628`) accordingly.
+
+- **Task 20 (existing) — `pkg`-bundle the daemon**: keep, but expand step 3 to explicitly rebuild natives against **Node 22 ABI** (`npm rebuild ... --runtime=node --target=22.x`, version pinned via `daemon/.nvmrc` per round-3 P1-3) into `daemon/native/<platform>-<arch>/`, NOT reuse Electron-ABI copy. Also rebuild the in-tree `ccsm_native.node` (single addon carrying winjob+pdeathsig+pipeAcl, frag-3.5.1 §3.5.1.1) in the same loop (round-2 P0-2 / round-3 P0-3 rename). Drop `--compress GZip` (round-2 P1-4). Fill `daemon/package.json` `dependencies` with every runtime dep — no workspace hoisting (round-2 C6). +1.5h.
+- **Task 20a (new) — electron-builder `extraResources` + `beforePack` wiring** (§11.2): add staged-dir `extraResources` block (round-2 S3 token-fix) to `package.json` `build`; add `scripts/before-pack.cjs` to select per-platform daemon binary AND validate every required `.node` (`better_sqlite3`, `pty`, `ccsm_native`); extend `scripts/after-pack.cjs` to verify daemon + natives present. +3h.
+- **Task 20b (new) — Windows signtool integration** (§11.3.1): add sign step to release.yml; loop over daemon exe + every `.node` (round-2 P0-2); use PATH-discovered signtool with newest-SDK fallback (round-2 P1-6); add `signtool verify /pa /v` (round-2 SH3); PR-build skip path. +2.5h.
+- **Task 20c (new) — macOS codesign + hardened-runtime entitlements** (§11.3.2): add `build/entitlements.daemon.plist`; per-arch sign loop over daemon Mach-O + every `.node` (round-2 P0-2); switch keychain unlock to `MACOS_KEYCHAIN_PW` secret (round-2 SH2); standalone-binary notarytool submission. +3.5h.
+- **Task 20d (new) — SHA256SUMS.txt + SLSA provenance + Linux minisign** (§11.4): single-source-of-truth SHA computation in `release-publish` merge job (round-2 S1); `actions/attest-build-provenance@v1` for SLSA-3 (round-2 security P0-S3); Linux minisign signature with `MINISIGN_KEY` secret. +2h (SLSA + minisign add ~1h vs the original Plan delta).
+- **Task 20e (new) — NSIS uninstall hygiene** (§11.6, round-2 P0-1 — reclaimed from frag-6-7; per-user paths per round-3 P0-1/P0-2): `build/installer.nsh` with `customUnInstall` macro (taskkill + opt-in per-user data-root recursive cleanup covering `data/`, `logs/`, `crashes/`, `daemon.lock`, `daemon.secret` under `%LOCALAPPDATA%\ccsm\` / `~/Library/Application Support/ccsm/` / `~/.local/share/ccsm/`); `nsis.include` wiring with `perMachine:false`; Linux `.deb` postrm + `.rpm` %preun scripts; macOS tray "Reset CCSM…" item (surface owned by frag-6-7 §6.8); small `ccsm-uninstall-helper.exe` for graceful daemon shutdown via RPC (cross-ref frag-6-7 §6.4 `daemon.shutdown`). +4h spec-coordinated, +0h frag-6-7 (RPC already specified).
+- **Task 20f (new) — CI Node 22 bump + daemon test job** (§11.5, round-2 P1-3): bump `setup-node` from 20 to 22 in both `verify` and `build`; extend cache key with `daemon/package-lock.json`; add `npm -w @ccsm/daemon run test` to `verify`. +0.5h.
+- **Task 24 (existing) — Release pipeline integration**: drop the proposed `daemon-v*` trigger; v0.3.0 ships single `v*` tag carrying both installer (with daemon embedded) + standalone daemon binary as separate asset. Reserve `daemon-v*` for v0.3.1+; sketch the daemon-only matrix in spec deferred list to avoid v0.3.1 panic-rewrite. +0h (scope reduction).
+
+**Total packaging block: ~17h** (vs frag-11 r1's ~10h; the new ~7h covers round-2 P0-1 NSIS reclaim, P0-2 native signing across platforms, SLSA provenance, CI node bump). Round-3 deltas land separately in the "Plan delta (r3)" block below.
+
+
+## Cross-frag rationale
+
+This block records ownership decisions for round-2 cross-fragment items where multiple fragments could plausibly own a fix.
+
+**Owned by frag-11 (this file):**
+
+- **NSIS uninstall hygiene (round-2 P0-1)** — TAKEN. Round-1 traceability matrix mapped this to "§11"; frag-11 r1 punted to "§3.1 in lifecycle / frag-6-7"; frag-6-7 never picked it up. Frag-11 reclaims because (a) NSIS scripts + electron-builder `nsis.include` + `.deb` postrm + `.rpm` %preun are pure packaging-toolchain mechanics, (b) the scope spans all three OSes' installer contracts which is exactly frag-11's remit, (c) the daemon-side dependency (graceful `daemon.shutdown` RPC) is already specified in frag-6-7 §6.4 — frag-11 only needs the orchestration shim (`ccsm-uninstall-helper.exe`). Specified in §11.6 with the canonical daemon-owned-paths table.
+- **`ccsm_native.node` packaging + signing (round-2 P0-2 / round-3 P0-3 rename)** — TAKEN. frag-3.5.1 §3.5.1.1 introduces the helper as a single .node carrying winjob+pdeathsig+pipeAcl exports; frag-11 §11.1/11.2/11.3 now lists it explicitly under the canonical name in `pkg.assets`-affecting rebuild loop, in `before-pack.cjs` validation set, and in both signtool/codesign loops. The previous `winjob.node` filename is fully retired — any tooling reference is a bug.
+- **SLSA-3 build provenance (round-2 security P0-S3)** — TAKEN. The CI mechanism (`actions/attest-build-provenance@v1` + Linux minisign) lives in release.yml which frag-11 owns. The verifier side (updater checks attestation before swap) is owned by frag-6-7 §6.4 step 2 — flagged below as a frag-6-7 follow-up.
+- **CI Node 22 bump + cache key + daemon test job (round-2 P1-3)** — TAKEN. release.yml-only change; frag-11 §11.5(0)(0a)(1).
+- **`pkg --compress GZip` removal (round-2 P1-4)** — TAKEN. Single-line change in `daemon/package.json` `scripts.package`; documented note in §11.1.
+- **signtool path hardcode fix (round-2 P1-6)** — TAKEN. §11.3.1 step.
+- **SHA256SUMS computation moved to merge job (round-2 S1)** — TAKEN. §11.4.
+- **`extraResources` `${platform}` token correction (round-2 S3)** — TAKEN. §11.2 staged-dir pattern.
+- **macOS keychain unlock secret (round-2 SH2)** — TAKEN. §11.3.2 uses `MACOS_KEYCHAIN_PW`.
+- **`signtool verify /pa /v` post-sign (round-2 SH3)** — TAKEN. §11.3.1.
+- **Daemon `dependencies` discipline (round-2 C6)** — TAKEN. §11.1 prose.
+
+**Punted to frag-6-7 (reliability/security):**
+
+- **`pino-roll` not abstraction-wrapped, `proper-lockfile` directly imported (round-2 lockin P1)** — out of §11 scope. These are runtime architecture choices in daemon code; frag-6-7 §6.4 / §6.6 owns the wrapper-vs-direct decision. Frag-11 only ensures both modules ship as `daemon/package.json` `dependencies` (round-2 C6).
+- **`daemon.secret` lifecycle: installer-time generation, atomic ACL set, rotation on update, redact list (round-2 security P0-S1 / round-3 CF-2 resolved)** — owned **entirely** by frag-6-7 §7.2. The generator runs in **Electron-main**, NOT the installer (cleaner: no NSIS DACL juggling, no Linux postinst equivalent). Frag-11 does NOT add a `customInstall` block; the prior round-2 sub-bullet is retracted in round-3. Frag-11 only specifies the on-disk path (per round-3 P0-2 paths table) and the uninstall delete in §11.6.
+- **SLSA attestation **verifier** (round-2 security P0-S3 verifier half / round-3 CF-4)** — frag-6-7 §6.4 step 2 (auto-update verify) owns the verify call. Frag-11 generates the attestation and locks the verifier library to **`@sigstore/verify` 1.x** (round-3 §11.4.1).
+- **Stream `fromSeq` token + handler-arg schema + traceId validation (round-2 security P1-S1/S2/S3)** — entirely out of §11 scope; frag-3.4.1 / frag-3.5.1 / frag-6-7 own.
+- **Single-instance lock vs uninstall ordering (round-2 P1-5)** — partly TAKEN by §11.6 (the per-user `daemon.lock` row in the canonical paths table + the always-delete behaviour). The runtime stale-PID recovery + `OpenProcess` semantics remain frag-6-7 §6.4.
+- **Migration env-var trust boundary, network-FS / symlink rejection (round-2 security P0-S2)** — frag-8 owns; nothing for frag-11 to package-side.
+- **Threat-model rows T12-T16 (round-2 security)** — frag-6-7 §7.4 owns; frag-11 only contributes the T13 crash-dump path location (per round-3 paths table: `%LOCALAPPDATA%\ccsm\crashes\` etc., included in the §11.6 cleanup table).
+
+**Punted to frag-3.7 (dev workflow):**
+
+- **Prod log surfacing regression (round-2 devx)** — out of §11 packaging scope. Concerns the dev-time `nodemon` log-level mapping vs prod pino config; frag-3.7 §3.7.6 owns.
+
+**No-op for frag-11 (already addressed elsewhere):**
+
+- Round-1 MUST-FIX 1/2/3 (extraResources, daemon signing, mac entitlements) — addressed in r1, retained.
+- macOS notarization rate-limit (round-2 packaging S2) — accepted as-is (§11.7).
+
+---
+
+## Plan delta (r3)
+
+Round-3 fixer changes layered on top of the round-2 plan delta above:
+
+- **Task 20a (extend) — `before-pack.cjs` arch map + per-platform pkg target.** Add round-3 P1-1 arch map (`{0:'ia32',1:'x64',2:'armv7l',3:'arm64',4:'universal'}`) with an explicit throw on `universal`/`armv7l`. In §11.5 step 2, document `pkg --targets node22-${PLATFORM}-${ARCH}` per matrix leg so each binary embeds only its own arch's `.node` files (round-3 P1-7). +0.5h.
+- **Task 20b (extend) — Windows install path = `%LOCALAPPDATA%\ccsm\` (round-3 P0-1).** NO package.json change required; working tip already matches the §11.6 r9 lock (`oneClick: false / allowElevation: true / allowToChangeInstallationDirectory: true`). Rewrite `installer.nsh` paths to `$LOCALAPPDATA\ccsm\…` (no `$PROGRAMFILES`, no `$PROFILE\.ccsm`). Update auto-update reference docs to note in-place writes are no-UAC. [manager r11 lock: r10 packaging P1-B — Plan delta r3 stale `oneClick: true / allowElevation: false` proposal retracted; §11.6 r9 lock is the canonical NSIS posture and no package.json edit is needed.] +1h.
+- **Task 20c (extend) — macOS daemon.secret path + notarize count.** macOS data root locked at `~/Library/Application Support/ccsm/` per round-3 P0-2; standalone-daemon notarytool block stays as 2 submissions (x64+arm64), §11.7 corrected to total 5 submissions/release per round-3 P1-5. +0h spec, doc-only.
+- **Task 20d (extend) — SLSA verifier locked to `@sigstore/verify` 1.x; SHA256SUMS in subject-path (round-3 CF-4 + P1-8).** Update §11.4.1 attest step to include `dist-all/SHA256SUMS.txt`; lock the verifier library name in the spec so frag-6-7 §6.4 step 2 implementer doesn't re-pick. Document one-time minisign keypair generation as a release prerequisite (round-3 P1-9: `minisign -G`, store `MINISIGN_KEY` secret, commit `build/minisign.pub`). +0.5h.
+- **Task 20e (extend) — Linux postrm correction + uninstall-helper $TEMP copy (round-3 P0-4 + P1-6).** Replace `${HOME:-/root}/.ccsm` with `getent passwd "$SUDO_USER"` lookup that only fires on `purge` AND when `SUDO_USER` is set; document `rm -rf ~/.local/share/ccsm` as the documented user-step fallback. NSIS `customUnInstall` copies `ccsm-uninstall-helper.exe` to `$TEMP` before invoking, so the in-flight uninstall main loop can RMDir `$INSTDIR` without a Windows file-lock collision. +0.75h.
+- **Task 20f (extend) — `daemon/.nvmrc` single-source-of-truth for Node target (round-3 P1-3).** Commit `daemon/.nvmrc` with the exact patch (`22.11.0`); have `setup-node` read `node-version-file: daemon/.nvmrc` and the rebuild script read the same file. Removes drift between `setup-node` (`'22'` any-minor), `pkg` base binary, and `node-gyp` headers. +0.25h.
+- **Task 20g (new) — ccsm_native rename sweep (round-3 P0-3).** Mechanical rename of `winjob.node` → `ccsm_native.node` in `pkg.assets` rebuild script, `before-pack.cjs` `REQUIRED_NATIVES`, `after-pack.cjs` validation list, codesign/signtool target sets, and the `daemon/native/winjob/` source directory → `daemon/native/ccsm_native/`. Coordinated with frag-3.5.1 §3.5.1.1 + frag-6-7 §7.3 (which still reference the old name). +0.5h.
+
+**Round-3 packaging delta total: ~3.5h** on top of round-2's ~17h. New packaging block estimate: **~20.5h**.
+
+---
+
+## Cross-frag rationale (r3)
+
+Round-3-specific ownership notes (deltas on top of the round-2 cross-frag block above):
+
+**Reclaimed / clarified by frag-11:**
+
+- **NSIS `perMachine: false` + per-user install root (round-3 P0-1)** — TAKEN. Sole owner. The choice spans every paragraph in this file that previously said "Program Files" or `$INSTDIR` semantics; all are now scoped to `$LOCALAPPDATA\ccsm\`.
+- **`ccsm_native.node` canonical name (round-3 P0-3)** — TAKEN. Frag-11 picks up the rename sweep across `pkg.assets`, `before-pack.cjs`, `after-pack.cjs`, signtool/codesign loops. Frag-3.5.1 §3.5.1.1 already specifies the addon export shape; frag-11 follows.
+- **Linux postrm `${HOME:-/root}` bug (round-3 P0-4)** — TAKEN. Replaced with `SUDO_USER`-gated `getent passwd` lookup; documented manual `rm -rf ~/.local/share/ccsm` fallback in §11.6.3.
+- **Uninstall-hygiene disk mechanics dedupe (round-3 X3)** — TAKEN by §11.6 with explicit cross-ref. The in-app surface (close-to-tray, "Reset CCSM…", post-uninstall toast, etc.) and its numeric-priority registry are owned by **frag-6-7 §6.8**; frag-11 §11.6 owns only the disk-removal mechanics (NSIS macro / postrm / paths table / shutdown helper).
+- **`devTarget()` env-gate fence (round-3 CF-2 / devx)** — TAKEN. The `app.isPackaged === false` branch in §11.2 now requires `CCSM_DAEMON_DEV=1` to even compute a dev daemon path; cross-ref frag-3.7 §3.7.2.b for env-gate convention.
+
+**Punted to frag-6-7:**
+
+- **`daemon.secret` generator (round-3 CF-2 resolution)** — frag-6-7 §7.2 "Electron-main, NOT installer" wins; frag-11's prior `customInstall` proposal is retracted. Frag-11 only owns the on-disk path (per round-3 P0-2 paths table) and the uninstall delete in §11.6.
+- **In-app surface registry for cleanup-style UI (close-to-tray, reset-data, post-uninstall toast)** — frag-6-7 §6.8 owns. Frag-11 references but does not redefine. Reason: numeric-priority registry is a UX/state-machine concern, not a packaging concern.
+
+**Punted to frag-12 (traceability):**
+
+- **frag-12 packaging M4 / ux M2 stale-OPEN flags (round-3 CF-1 + CF-3)** — frag-11 cannot edit frag-12; flagged here for the frag-12 fixer to re-audit and close.
+
+**Punted to frag-3.5.1:**
+
+- **`ccsm_native.node` source layout** — frag-3.5.1 §3.5.1.1 is the canonical contract for the addon's export surface (winjob + pdeathsig + pipeAcl). Frag-11 only consumes the artifact name and packages it.
+
+**Acknowledged but no spec edit needed:**
+
+- **CF-5 Linux initial-install integrity honesty** — agreed; the wording fix lives in frag-6-7 §7.3 "Initial-install integrity" paragraph (Win/mac via signtool/codesign; Linux via documented `slsa-verifier` + minisign manual step). Flagged for frag-6-7 fixer.
+- **P1-2 `pkg.targets` per matrix leg** — covered by Task 20a extend above (`pkg --targets node22-${PLATFORM}-${ARCH}`).
+- **P1-4 `${ext}` token in `from`** — already correct; pinned `electron-builder@^26.x`.

--- a/docs/superpowers/specs/v0.3-fragments/frag-12-traceability.md
+++ b/docs/superpowers/specs/v0.3-fragments/frag-12-traceability.md
@@ -1,43 +1,288 @@
-# Fragment: §12 traceability matrix to 10-angle reviews
+## 12. Review traceability
 
-**Owner**: worker dispatched per Task #934
-**Target spec section**: new §12 (last section) in main spec
-**P0 items addressed**: makes review coverage auditable; no code impact
+This section maps every MUST-FIX item from the ten round-1 angle reviews
+(`~/spike-reports/v03-review-*.md`), the round-2 P0/P1 escalations
+(`~/spike-reports/v03-r2-*.md`), and the round-3 residuals
+(`~/spike-reports/v03-r3-*.md`) to the spec-v2 section that addresses it.
 
-## What to write here
-Replace this section with the actual `## 12. Review traceability` markdown.
+This file is a **round-3 re-audit** (2026-04-30, post-r3 fixers in flight).
+Status of every row is recomputed against the current fragment bodies AND
+the round-3 reviewer verdicts. Pure SHOULD/OPEN questions live in the
+source reports and are not tracked here.
 
-A markdown table with columns:
-| Review report | MUST-FIX item | Spec v2 section | Status |
+Section numbers refer to spec v2 post-merge:
 
-One row per MUST-FIX from each of the 10 reports. Status values:
-- `addressed in §X.Y` — fully covered in v2
-- `addressed in §X.Y (partial)` — spec scopes the fix; full impl in plan
-- `deferred to v0.4` — explicit defer with rationale (e.g. sigstore signing)
-- `deferred to v0.5` — explicit defer (e.g. Cloudflare Access)
-- `out of scope` — review item not accepted; rationale required
+- §3.1.1 Local socket hardening (already in v2 wip)
+- §3.4.1 Envelope hardening (frag-3.4.1)
+- §3.5.1 PTY child lifecycle hardening (frag-3.5.1)
+- §3.7 Dev workflow (frag-3.7)
+- §6 Reliability (rewrite, frag-6-7)
+- §7 Security (rewrite, frag-6-7)
+- §8 Data migration v0.2 → v0.3 (frag-8)
+- §11 Packaging (rewrite, frag-11)
+- §12 Review traceability (this fragment)
 
-**Source reports** (read each for its MUST-FIX list):
-- `~/spike-reports/v03-review-resource.md` (GREEN — likely few/no MUST-FIX)
-- `~/spike-reports/v03-review-reliability.md`
-- `~/spike-reports/v03-review-security.md`
-- `~/spike-reports/v03-review-perf.md`
-- `~/spike-reports/v03-review-lockin.md` (LOW — likely few)
-- `~/spike-reports/v03-review-observability.md`
-- `~/spike-reports/v03-review-devx.md`
-- `~/spike-reports/v03-review-ux.md`
-- `~/spike-reports/v03-review-packaging.md`
-- `~/spike-reports/v03-review-fwdcompat.md`
+### 12.0 Manager arch decisions (locked pre-merge)
 
-After the table, a short summary paragraph: "N MUST-FIX items addressed in
-v2, M deferred to v0.4, K to v0.5, J out of scope. Round-2 review will
-verify."
+These decisions resolve r3 contradictions whose only blocker was the
+manager picking between the equally-valid options the fragments fielded.
+They are CLOSED below as "manager r3 lock" rather than punted to the
+fragment authors.
 
-This fragment depends on knowing which §X.Y the other fragments end up
-adding. Worker should read the OTHER fragment files in this directory
-(not the main spec, since merge hasn't happened) to know section numbers.
-If a fragment is empty/stub at time of writing, mark status as "addressed
-in §3.4.1 (pending fragment merge)" and let manager fix during merge.
+1. **Install path = per-user `%LOCALAPPDATA%\ccsm\` (Win) and OS-equivalents
+   elsewhere.** Resolves r3-packaging P0-1 (NSIS Program-Files vs spec
+   per-user contradiction). electron-builder ships
+   `nsis: { perMachine: false, oneClick: false }`. T9 / T14 security claims
+   in §7.4 stay as written. frag-11 §11.2 + §11.6 NSIS macro rewritten to
+   `$LOCALAPPDATA` rooting.
+2. **Data root = OS-native (`%LOCALAPPDATA%\ccsm\` Win, `~/Library/Application Support/ccsm/` mac, `~/.local/share/ccsm/` Linux)** — single root for **everything daemon-owned**: daemon binary, `daemon.lock`, `daemon.secret`, `<dataRoot>/data/` (SQLite), `<dataRoot>/logs/` (pino-roll), `<dataRoot>/crashes/` (crash dumps). frag-11 §11.6 is the **single source of truth** for the paths table; `<dataRoot>` is OS-native per frag-11 §11.6 and v0.2 → v0.3 migration moves data from legacy `~/.ccsm/` to `<dataRoot>` (frag-8 §8.3 step 1). [manager r5 lock: install path locked to `%LOCALAPPDATA%` in r3 to avoid UAC; all sibling paths (data/logs/crashes/lockfile/secret) follow per frag-11 §11.6 — eliminates the three-way `<dataRoot>` permutation that r4 packaging + multiple reviewers flagged.] [manager r11 lock: r10 traceability P1 — lockfile basename swept `ccsm-daemon.lock` → `daemon.lock` to match frag-11 §11.6 paths table.] Resolves r3-packaging P0-2 (three-way secret-path contradiction) AND r4-packaging dataRoot reconciliation.
+3. **Surface registry = frag-6-7 §6.8 numeric priority table (100/90/85/70/50/30)
+   is the sole authoritative registry.** frag-3.7 §3.7.8's tier 1-6 table
+   becomes a renderer-implementation guide that registers INTO §6.8;
+   conflicting entries (e.g. `daemon.crashLoop` camelCase vs
+   `daemon.crashloop.with_bak` dot+snake) resolve to §6.8 spelling.
+   Resolves r3-ux P0-UX-A (two-registry coexistence).
+
+### 12.1 Matrix
+
+[manager r5 lock: matrix rebuilt off current frag bodies post r4 reviews; IN-FLUX now means actually still under fixer, not stale lag.]
+
+Status legend: ✅ CLOSED · 🟡 IN-FLUX (fix dispatched / pending r5 fixer) · ❌ OPEN (genuinely punted to v0.4+).
+
+#### ✅ CLOSED
+
+| Round | Item | Cite |
+|---|---|---|
+| r1 resource M1 | pino log rotation | frag-6-7 §6.6.1 (`pino-roll` daily/50M/7) |
+| r1 resource M2 | subscriber multiplexing model | frag-3.5.1 §3.5.1.5 (single fan-out registry, drop-slowest) |
+| r1 resource M3 | RAM target wording (plan delta) | frag-6-7 Plan delta Task 25 (`<120 MB daemon RSS, <500 MB incl. children`) |
+| r1 reliability M1 | PTY orphan reaping | frag-6-7 §6.2 + frag-3.5.1 §3.5.1.1/.2 (JobObject + setpgid + PDEATHSIG) |
+| r1 reliability M2 | bridge call timeout + cancel | frag-3.5.1 §3.5.1.3 (5s default, AbortSignal.any, BridgeTimeoutError) |
+| r1 reliability M3 | SQLite tx boundaries (audit) | frag-6-7 §6 + Plan delta Task 8/12/13 (`db.transaction` audit) |
+| r1 reliability M4 | single-instance lock on Win | frag-6-7 §6.4 (proper-lockfile primary, pipe bind secondary) |
+| r1 reliability M5 | updater rollback / atomic swap | frag-6-7 §6.4 step 5-7 (`MoveFileExW`, single-shot rollback) |
+| r1 security M1 | Win named-pipe ACL | frag-6-7 §7.1.2 + §7.M1 helper (explicit DACL = current SID) |
+| r1 security M2 | sender peer-cred check | frag-6-7 §7.1.3 + §3.1.1 (`SO_PEERCRED` / `GetNamedPipeClientProcessId`) |
+| r1 security M3 | envelope cap + schema validation | frag-3.4.1 §3.4.1.a (16 MiB cap) + §3.4.1.d (TypeBox check) |
+| r1 perf M1 | binary frame format (no base64) | frag-3.4.1 §3.4.1.c (header-JSON + raw-bytes-trailer) |
+| r1 perf M2 | head-of-line blocking | frag-3.4.1 §3.4.1.b (≤16 KiB sub-chunks) |
+| r1 perf M3 | snapshot wire micro-benchmark | frag-3.4.1 Plan delta Task 5b (un-deferred per r2 perf §7) |
+| r1 lockin top-2 | DaemonClient AbortController cancel | frag-3.5.1 §3.5.1.3 (`AbortSignal.any`) |
+| r1 lockin top-4 | versioned handshake | frag-3.4.1 §3.4.1.g (`daemon.hello`) + frag-6-7 §6.5 (`protocol` block) |
+| r1 obs M1 | end-to-end traceId in envelope | frag-3.4.1 §3.4.1.c + frag-6-7 §6.6.1 (`traceId` ULID required) |
+| r1 obs M2 | `pino.final` on fatal | frag-6-7 §6.6.1 (daemon) + §6.6.2 (electron, `side: 'electron'`) |
+| r1 obs M3 | log rotation | frag-6-7 §6.6.1/.2 (same pino-roll on both sides) |
+| r1 obs M4 | daemon version + pid + boot in every line | frag-6-7 §6.6.1/.2 (pino base = `{ side, v, pid, boot }`) |
+| r1 devx M1 | `npm run dev` daemon restart-on-rebuild | frag-3.7 §3.7.2/.3 (concurrently 3-lane + nodemon) |
+| r1 devx M2 | dev-mode daemon stderr in terminal | frag-3.7 §3.7.3/.6 (`stdout/stderr: true` + dev-vs-prod table) |
+| r1 devx M3 | TS Project References (plan delta) | frag-3.7 Plan delta Task 1 (`composite: true`, `references: [{path: "daemon"}]`) |
+| r1 devx M4 | orphan-daemon footgun | frag-3.7 §3.7.4 (auto-reconnect) + frag-6-7 §6.4 (stale-lock recovery via PID probe) |
+| r1 devx M5 | README + `npm run setup` | frag-3.7 Plan delta Task 1 (`scripts/setup.cjs` + CONTRIBUTING) |
+| r1 ux M1 | v0.2 → v0.3 SQLite migration | frag-8 §8 (full migration spec) |
+| r1 ux M2 | close-to-tray discoverability | frag-3.7 §3.7.8.b + frag-6-7 §6.8 — owner = frag-6-7 §6.8 (timestamp `app_state.close_to_tray_shown_at` — manager r5 lock supersedes the boolean `close_to_tray_hint_shown` previously proposed; verified in frag-6-7 §6.8 + §6.6.1 R3-T12). |
+| r1 ux M3 | daemon-spawn failure modal | frag-6-7 §6.1.1 copy table + §6.1 cold-start logic + frag-3.7 §3.7.4 reconnect waiting toast |
+| r1 packaging M1 | electron-builder `extraResources` | frag-11 §11.2 (`extraResources` + `before-pack.cjs` + `after-pack.cjs`) |
+| r1 packaging M2 | daemon binary code-signing | frag-11 §11.3.1/.2 (signed before EB packaging; SH3 verify) |
+| r1 packaging M3 | macOS notarization of nested daemon | frag-11 §11.3.2 (hardened runtime + JIT entitlement + standalone notarytool) |
+| r1 packaging M4 | NSIS uninstall hygiene | frag-11 §11.6.1 (`customUnInstall` macro + `nsis.include` wiring) + frag-6-7 §6.8 (paths contract). r3-perf/lockin/sec/pkg all confirm stale OPEN flag from r2 |
+| r1 fwdcompat 3.1 | interceptor seam | frag-3.4.1 §3.4.1.f (`Interceptor`, `ReqCtx`, `mountConnectAdapter({interceptors})`) — r3-fwdcompat/lockin/sec confirm landed |
+| r1 fwdcompat 3.2 | PTY fanout multi-subscriber + test | frag-3.5.1 §3.5.1.5 + §3.5.1.6 |
+| r1 fwdcompat 3.3 | versioned handshake (`clientProtocolVersion` etc.) | frag-3.4.1 §3.4.1.g (`daemonProtocolVersion`, `compatible`) + frag-6-7 §6.5 (`protocol` block in `/healthz`) — r3-fwdcompat/lockin/sec confirm landed |
+| r2 resource P0-1 | replay-burst exempt from drop-slowest | frag-3.4.1 §3.4.1.b + frag-3.5.1 §3.5.1.5 + frag-3.7 §3.7.4.a (single contract, ≤256 KiB replay then `gap: true`) |
+| r2 resource P1-3 | snapshot semaphore deadline starts after admission | frag-3.5.1 §3.5.1.5 (`snapshot.semaphore.waitMs` counter) |
+| r2 resource P1-4 | aggregate per-session subscriber cap | frag-3.5.1 §3.5.1.5 (`min(N×1MB, 4MB)` LRU oldest-slowest) |
+| r2 reliability P0-R3 | SIGCHLD shutdown ordering + DB rows | frag-3.5.1 §3.5.1.2 + frag-6-7 §6.6.1 (`running → shutting_down → exited`) |
+| r2 reliability P0-R5 | dedicated supervisor transport | frag-6-7 §6.5 + frag-3.4.1 §3.4.1.h (separate `-sup` socket/pipe) |
+| r2 reliability P1-R5 | per-PID `waitpid(pid, WNOHANG)` | frag-3.5.1 §3.5.1.2 |
+| r2 reliability P1-R6 | heartbeat-vs-supervisor inversion | frag-3.5.1 §3.5.1.4 (documented invariant `streamDeadMs > supervisorDeadMs`) |
+| r2 security P0-S1 | `daemon.secret` lifecycle | frag-6-7 §7.2 (Electron generator + atomic CREATE_NEW + rotation on update + redact list) |
+| r2 security P0-S2 | migration env-var trust | frag-8 §8.4 `resolveLegacyDir()` (canonical-path allowlist + double realpath + UNC reject) |
+| r2 security P0-S3 | SLSA-3 + Linux minisign | frag-11 §11.4.1 (producer) + frag-6-7 §6.4 step 2 (verifier contract) + §7.3 v0.3 row |
+| r2 security P1-S1 | per-handler arg validation | frag-3.4.1 §3.4.1.d + ESLint `no-handler-without-check` |
+| r2 security P1-S2 | traceId regex + log injection guard | frag-3.4.1 §3.4.1.c + frag-6-7 §6.6.1 (Crockford ULID regex + `\n\r` strip + dual `traceId`/`daemonTraceId`) |
+| r2 security T15 | pre-accept rate cap | frag-3.4.1 §3.4.1.a (`MAX_ACCEPT_PER_SEC = 50`) |
+| r2 security T12-T14 | threat-model rows | frag-6-7 §7.4 (rated + rationale) |
+| r2 obs P0-1 | Electron-side logger as peer | frag-6-7 §6.6.2 (`side: 'electron'` + same pino-roll + redact superset) |
+| r2 obs P0-2 | traceId on binary frame header | frag-3.4.1 §3.4.1.c (header schema includes `traceId?`) |
+| r2 obs P0-3 | drain ordering for log producers | frag-6-7 §6.6.1 step list (1-7) + frag-3.5.1 §3.5.1.2 mirror |
+| r2 obs P0-4 | `pino.final` analog on every Electron exit | frag-6-7 §6.6.2 (registered against `app.before-quit` + `uncaughtException` + supervisor "Quit" handlers) |
+| r2 obs P1-1 | `daemon.crashloop` log signature | frag-6-7 §6.1 (structured `crashloop_entered` line) |
+| r2 obs P1-2 | migration phase log lines | frag-8 §8.5 (8 phase strings sharing `traceId`, asserted in §8.8 step 7) |
+| r2 obs P1-3 | bridge-call lifecycle log set | frag-6-7 §6.6.2 (`bridge_call_complete`, `daemon_socket_closed`, `daemon_reconnect_*`, `stream_resubscribe`) |
+| r2 obs P1-4 | `statsVersion: 1` | frag-6-7 §6.5 (`daemon.stats` + `/healthz` carry version cursor) |
+| r2 obs P1-5 | crash-dump file spec | frag-6-7 §6.6.3 (path + schema + 0600 ACL + 30-day retention + never auto-uploaded) |
+| r2 obs OPEN-3 | `spawnTraceId` for daemon-originated events | frag-3.5.1 §3.5.1.2 (allocated per `pty.spawn()`, on session row) |
+| r2 obs OPEN-4 | `boot_nonce` is ULID not Date.now | frag-6-7 §6.5 |
+| r2 fwdcompat P0-1 | interceptor + headers + traceId on header | frag-3.4.1 §3.4.1.c/.f |
+| r2 fwdcompat P0-2 | hello/version handshake wired | frag-3.4.1 §3.4.1.g + frag-6-7 §6.5 |
+| r2 fwdcompat P0-3 | RPC namespace `ccsm.vN/...` rule | frag-3.4.1 §3.4.1.g |
+| r2 fwdcompat P1-1 | `bootNonce` propagation | frag-3.5.1 §3.5.1.4 + frag-3.7 §3.7.5 + frag-6-7 §6.5 |
+| r2 fwdcompat P1-2 | reserved `x-ccsm-*` headers | frag-3.4.1 §3.4.1.c (4 reserved keys + spec amendment rule) |
+| r2 fwdcompat P1-3 | marker schema version | frag-8 §8.5 S8 (`marker.version: 1` + e2e `999` test) |
+| r2 fwdcompat P2-2 | `streamId` odd/even allocation | frag-3.4.1 §3.4.1.b |
+| r2 lockin P0-1 | frame-version nibble | frag-3.4.1 §3.4.1.c (high 4 bits of `totalLen` reserved) |
+| r2 lockin P0-2 | `NativeBinding` swap interface | frag-3.5.1 §3.5.1.1.a + lint `no-direct-native-import` |
+| r2 lockin P0-3 | env-var + marker rename | frag-8 §8.4 (`CCSM_LEGACY_USERDATA_DIR`) + §8.5 S8 (`migration-state.json`) |
+| r2 lockin P1-4 | negotiable heartbeat per subscribe | frag-3.5.1 §3.5.1.4 (`{heartbeatMs}` clamped 5s..120s) |
+| r2 ux P0-UX-1 | surface registry concept | frag-6-7 §6.8 [manager r3 lock = canonical] + frag-3.7 §3.7.8 (registers INTO §6.8) |
+| r2 ux P0-UX-2 | close-to-tray un-deferred | frag-3.7 §3.7.8.b + frag-6-7 §6.8 — see r1 ux M2 row |
+| r2 ux P0-UX-3 | daemon-spawn failure copy | frag-6-7 §6.1.1 copy table (9 rows) |
+| r2 ux P1-UX-1 | reconnect retries forever → modal at N=15 | frag-3.7 §3.7.4 + frag-6-7 §6.1.1 reconnect-exhausted row |
+| r2 ux P1-UX-2 | "start fresh" typed-confirm | frag-8 §8.6 (exact phrase + accessibility live region) |
+| r2 ux P1-UX-3 | BridgeTimeoutError NOT surfaced per-call | frag-6-7 §6.1.1 (suppressed when banner showing); see r3 CF-1 IN-FLUX for the §3.5.1.3 carve-out edit |
+| r2 ux P1-UX-4 | reconnect-toast vs supervisor banner mutex | frag-3.7 §3.7.8.a rule 3 + frag-6-7 §6.8 stacking rule |
+| r2 ux P1-UX-5 | "Paused" not "Abandoned" copy | frag-6-7 §6.3 |
+| r2 ux P1-UX-6 | pre-mount loader | frag-6-7 §6.1 + frag-3.7 §3.7.8.d |
+| r2 devx P0-1 | workspaces in root `package.json` | frag-3.7 Plan delta Task 1 |
+| r2 devx P0-2 | `wait-on tcp:127.0.0.1:0` no-op fixed | frag-3.7 §3.7.2 + `scripts/wait-daemon.cjs` (`wait-on file:` against lockfile) |
+| r2 devx P0-3 | dev mode skips pkg-binary path | frag-3.7 §3.7.2.b + Task 7 (spawnOrAttach side); see r3 CF-2 IN-FLUX for frag-11 fence |
+| r2 devx P0-4 | toolchain prerequisites + `npm run setup` | frag-3.7 §3.7.2.c + `scripts/setup.cjs` |
+| r2 devx P1-3 | dev-build error toast | frag-3.7 §3.7.8.c row j |
+| r2 devx P1-6 | stream handle `.cancel()` before resubscribe | frag-3.7 §3.7.5 step 1 |
+| r2 devx P1-7 | E2E folded into harness-agent | frag-3.7 §3.7.7 (`harness-agent.daemonReconnect`) |
+| r2 reliability P1-R1 | dev queue cap = 1000 | frag-3.7 §3.7.4 (`MAX_QUEUED_DEV = 1000`) |
+| r2 packaging P0-1 | NSIS uninstall hygiene reclaimed | frag-11 §11.6 (full macro + paths table); same as r1 packaging M4 |
+| r2 packaging P0-2 | every native `.node` signed | frag-11 §11.3.1/.2 per-`.node` loops + r3-lockin P0-A name unification → see IN-FLUX |
+| r2 packaging P1-3 | CI Node 22 bump | frag-11 §11.5(0)(0a) |
+| r2 packaging P1-4 | drop `--compress GZip` | frag-11 §11.1 (note + `package.json` script change) |
+| r2 packaging P1-6 | signtool path discovery | frag-11 §11.3.1 (PATH-first + Win SDK fallback) |
+| r2 packaging S1 | SHA256SUMS in merge job | frag-11 §11.4 (single source of truth) |
+| r2 packaging S3 | `extraResources` `${platform}` token | frag-11 §11.2 (staged-dir pattern + `before-pack.cjs`) |
+| r2 packaging SH2 | `MACOS_KEYCHAIN_PW` secret | frag-11 §11.3.2 |
+| r2 packaging SH3 | `signtool verify /pa /v` post-sign | frag-11 §11.3.1 |
+| r2 packaging C6 | daemon dependencies discipline | frag-11 §11.1 prose |
+| r3 packaging P0-1 | install path Program-Files vs per-user | [manager r3 lock] §12.0 (1) — pick (a) `nsis: { perMachine: false }`. r3 fixer applies to frag-11. |
+| r3 packaging P0-2 | secret/lock path three-way contradiction | [manager r3 lock] §12.0 (2) — daemon binary + `daemon.lock` + `daemon.secret` at OS-native root; SQLite/logs/crashes stay at `~/.ccsm/`. r3 fixer applies. |
+| r3 ux P0-UX-A | two surface registries | [manager r3 lock] §12.0 (3) — frag-6-7 §6.8 canonical; frag-3.7 §3.7.8 registers INTO §6.8 |
+| r3 perf CF-3 / lockin CF-1 / fwdcompat #1 / sec P1-3 / resource X3 / ux P0-UX-C | "frag-12 stale OPEN rows" meta-issue | this re-audit (round-3) — ALL six angles confirm packaging M4 / fwdcompat 3.1 / fwdcompat 3.3 are landed; matrix updated above |
+| r3 ux M2 owner pick | close-to-tray double ownership | [manager r5 lock] frag-6-7 §6.8 owns toast wiring; SQLite key = `close_to_tray_shown_at` (timestamp, NOT boolean — verified in frag-6-7 §6.8 + R3-T12). Supersedes earlier r3 boolean lock. |
+| r3 fwdcompat CC-2 | `bootNonce` camelCase across 4 sites | frag-3.4.1 §3.4.1.g + frag-3.5.1 §3.5.1.4 + frag-3.7 §3.7.5 + frag-6-7 §6.5 — all four cite `bootNonce` (camelCase). r5 verified. |
+| r3 fwdcompat CC-3 | `x-ccsm-deadline-ms` clamp 120s | frag-3.4.1 §3.4.1.c (`clamp 100 ms ≤ x ≤ 120 s`, unified with frag-3.5.1 §3.5.1.3). r5 verified. |
+| r3 fwdcompat P1-5 | `daemonAcceptedWires[]` advertised in hello reply | frag-3.4.1 §3.4.1.g (hello reply features array) + frag-6-7 §6.5 (`daemonAcceptedWires` in healthz protocol block). r5 verified. |
+| r3 lockin CF-2 | `daemonProtocolVersion` mirror in hello + healthz | frag-3.4.1 §3.4.1.g + frag-6-7 §6.5 (`daemonProtocolVersion` field on healthz protocol block). r5 verified. |
+| r3 fwdcompat P1-3 | `statsVersion` split → `healthzVersion` | frag-6-7 §6.5 (`healthzVersion` on `/healthz`; `statsVersion` lives only on `daemon.stats`). r5 verified. |
+| r3 fwdcompat P1-4 | feature-add-vs-version-bump rule | frag-3.4.1 §3.4.1.g feature-add rule documented; round-3 P1-4 closed. r5 verified. |
+| r3 security CC-1 | frame-version nibble parsed BEFORE 16 MiB length cap | frag-3.4.1 §3.4.1.a step 0-2 spells out: read 4 bytes → extract nibble → reject UNSUPPORTED_FRAME_VERSION → mask + length-cap. r5 verified. |
+| r3 fwdcompat P1-1 | `SUPERVISOR_RPCS` canonical allowlist constant | frag-3.4.1 §3.4.1.h (`SUPERVISOR_RPCS = ["/healthz", "/stats", "daemon.hello", "daemon.shutdown", "daemon.shutdownForUpgrade"]` declared canonical, consumed by control-socket dispatcher + migrationGateInterceptor + frag-8 §8.5). r5 verified; `[manager r9 lock: r8 envelope P0-1 + r8 devx P0-1 — row form updated from 4-element to canonical 5-element to match §3.4.1.h post-r7 + frag-6-7 §6.5 sweep]` |
+| r3 perf P1-1 | `seq` zero-padded to 10 ASCII digits | frag-3.4.1 §3.4.1.c hot-path bullet ("zero-padded 10-digit ASCII covers full uint32 range"). r5 verified. |
+| r3 fwdcompat P1-7 | unknown `x-ccsm-*` warn rule | frag-3.4.1 §3.4.1.c + §3.4.1.f deadlineInterceptor (`pino.warn { unknown_xccsm_header }` rate-limited 1/key/min). r5 verified. |
+| r3 security P0-1 | imposter-secret HMAC-of-nonce + `crypto.timingSafeEqual` | frag-3.4.1 §3.4.1.g (HMAC-SHA256 + `helloNonceHmac` + `clientHelloNonce` + 2-frame handshake post-fixer-A) + frag-6-7 §7.2 (HMAC-of-nonce LOCK; bearer-token EXPLICITLY REJECTED). r5 verified post-fixer-A. |
+| r3 lockin P0-A / r3 packaging P0-3 | native artifact `ccsm_native.node` 9-site rename | frag-11 §11.1/§11.2/§11.3/§11.6 + frag-3.5.1 §3.5.1.1 + frag-6-7 §7.M1 — all sites use `ccsm_native.node`; legacy `winjob.node` retired. r5 verified. |
+| r3 packaging P0-2 | `daemon.secret` OS-native path | frag-6-7 §7.2 (`%LOCALAPPDATA%\ccsm\daemon.secret` Win, `~/Library/Application Support/ccsm/daemon.secret` mac, `~/.local/share/ccsm/daemon.secret` Linux) + frag-11 §11.6 paths table. r5 verified. |
+| r3 packaging P0-4 | Linux postrm `SUDO_USER` + `getent passwd` correctness | frag-11 §11.6.3 (`SUDO_USER` gate + `getent passwd "$SUDO_USER" \| cut -d: -f6` + `~/.local/share/ccsm` cleanup; documented manual fallback). r5 verified. |
+| r3 packaging P0-1 | `%LOCALAPPDATA%\ccsm\` install root + `nsis.perMachine: false` | frag-11 §11.1 + §11.6 (`perMachine: false`, `oneClick: false`, `allowElevation: true`, `allowToChangeInstallationDirectory: true`, `$LOCALAPPDATA\ccsm`; never `Program Files`). r5 verified; `[manager r11 lock: r10 traceability P1 — row reconciled with frag-11 §11.6 r9 lock (assisted-mode installer preserved); prior `oneClick: true` was stale.]` |
+| r3 ux surface registry | numeric priority 30/50/70/85/90/100 | frag-6-7 §6.8 (CANONICAL — six priority tiers explicit) + frag-3.7 §3.7.8 cross-refs into §6.8. r5 verified. |
+| r3 perf CF-2 | `traceId` hot-path carve-out | frag-6-7 §6.6.1 (per-chunk fan-out logs at debug-level only; `streamId → spawnTraceId` cache; per-frame info-level forbidden on PTY hot path). r5 verified. |
+| r3 lockin CF-3 | `clientImposterSecret` eliminated by HMAC handshake | frag-3.4.1 §3.4.1.g (no `clientImposterSecret` field; only `clientHelloNonce` + `helloNonceHmac`) + frag-6-7 §7.2 + §6.6 redact list ("legacy `imposterSecret` / `clientImposterSecret` cleartext fields were eliminated"). r5 verified. |
+| r2 ux P0-UX-2 close-to-tray timestamp | `close_to_tray_shown_at` owned by frag-6-7 §6.8 | frag-6-7 §6.8 (timestamp lock, NOT boolean `close_to_tray_hint_shown`; R3-T12). r5 verified. |
+| r3 ux P0-UX-A §3.7.8 deletion | §3.7.8 collapsed to one-paragraph cross-ref redirect | frag-3.7 §3.7.8 explicitly marked `**DELETED in round-3**` with all surfaces redirected to frag-6-7 §6.8 canonical. Stub header retained as discoverability redirect; no real registry content remains. r5 verified. |
+| r5 dataRoot reconciliation | `~/.ccsm/data\|logs\|crashes\|daemon.lock` retired across frag-8 + frag-12 | [manager r5 lock] §12.0 (2) — frag-11 §11.6 single source of truth; frag-8 §8.2-§8.8 swept (`<dataRoot>/data/`, `<dataRoot>/logs/`, `<dataRoot>/crashes/`, `<dataRoot>/daemon.lock`); frag-12 §12.0 (2) updated. Eliminates the three-way `<dataRoot>` permutation flagged by r4 packaging + multiple reviewers. `[manager r11 lock: r10 traceability P1 — lockfile basename swept ccsm-daemon.lock → daemon.lock]` |
+| r3 reliability P0-R4 | migration partial-write lockfile-before-ensureDataDir | frag-8 §8.3 step 0 (`acquireLockfile(<dataRoot>/daemon.lock)` BEFORE `ensureDataDir()`; step 1a unconditional unlink is provably orphan post-lockfile) + frag-6-7 §6.4 boot-order note. r5 verified. `[manager r11 lock: r10 traceability P1 — lockfile basename swept ccsm-daemon.lock → daemon.lock]` |
+| r3 resource X4 | close-to-tray SQLite key locked to timestamp | [manager r5 lock] supersedes earlier r3 boolean lock; locked to `close_to_tray_shown_at` (timestamp) per frag-6-7 §6.8 + R3-T12. Same row as r3 ux M2 owner pick + r2 ux P0-UX-2 above. |
+
+##### r7 batch (round-7 manager-lock cross-frag closures, post fixers A/B/C/D/E/H + G verify; r9 added 2 orphan-lock rows)
+
+[manager r7 lock: §12 rebuilt with 21 new rows from r7 batch (fixers A/B/C/D/E/H/G + r9 orphan-lock additions); ratio CLOSED=147 / IN-FLUX=25 / OPEN=7 — see §12.2 below] `[manager r9 lock: r8 traceability P1-1 + P1-2 — arithmetic corrected (was 18/144/176; r7 sub-table actually had 19 rows then +2 orphan rows added in r9 → 21/147/179) and 2 orphan locks added as own rows]` `[manager r11 lock: r10 traceability P1 — r9 batch broken out as 12 explicit rows in new r9-batch sub-table; ratio CLOSED=159 / IN-FLUX=25 / OPEN=7 / total=191 — see §12.2 below.]`
+
+| Concern | Owner frag/§ | Consumer frag(s)/§(s) | r7 lock string | Status |
+|---|---|---|---|---|
+| `daemon.shutdownForUpgrade` RPC + `<dataRoot>/daemon.shutdown` marker (3-frag chain) | frag-6-7 §6.4 (RPC + marker semantics owner) | frag-3.4.1 §3.4.1.h (`SUPERVISOR_RPCS` allowlist consumer); frag-11 §11.6.5 (upgrade-in-place orchestration consumer) | `[manager r7 lock: r6 packaging P0-2 cross-frag — daemon.shutdownForUpgrade RPC + marker semantics; consumed by frag-11 §11.6.5 upgrade flow]` (frag-6-7 §6.4) + `[manager r7 lock: r6 packaging P0-2 — upgrade-in-place daemon-shutdown contract]` (frag-11 §11.6.5) | CLOSED |
+| §6.1 R2 marker-aware crash-loop skip (G verify) | frag-6-7 §6.1 R2 paragraph (supervisor counter rule) | frag-6-7 §6.4 (marker semantics producer); frag-11 §11.6.5 (marker writer at upgrade) | `[manager r7 lock: G verify — marker-aware crash-loop skip]` (frag-6-7 §6.1, added by fixer G) | CLOSED |
+| i18n key namespace `migration.modal.failed.*` | frag-8 §8.6 (canonical key prefix owner) | frag-6-7 §6.1.1 copy table (`migration.modal.failed.*` row) + §6.8 surface registry (P=85 row) | `[manager r7 lock: r6 ux P0-3 — i18n key namespace migration.modal.failed.*]` (frag-8 §8.6) | CLOSED |
+| §6.8 r7 surface-registry trim cascade (16→7 rows) | frag-6-7 §6.8 (canonical registry, 5 daemon-split rows + migration + paused-session) | frag-6-7 §6.1.1 (copy table trimmed 9→6 rows); frag-3.7 §3.7.4/§3.7.5/§3.7.8 (dispatched-surface set reduced to 3 surviving keys: `daemon.unreachable`, `daemon.reconnected`, `daemon.crashLoop`); frag-3.7 §3.7.8 surface-registry bridge plan-delta sub-task | `[manager r7 lock: cut as polish — N6# from r6 feature-parity. §6.8 row count trimmed from 16 → 7]` (frag-6-7 §6.8) + `[manager r7 lock: surfaces trimmed per N6# from r6 feature-parity]` (frag-3.7 §3.7.8 bridge sub-task) | CLOSED |
+| §3.5.1.2 step 8 ↔ §6.6.1 step 4 SQL mirror lock (`UPDATE sessions SET state='paused', pid_pgid=NULL WHERE state='shutting_down'`) | frag-3.5.1 §3.5.1.2 step 8 (PTY-side terminal sweep) | frag-6-7 §6.6.1 step 4 (DB-side mirror) | `[manager r7 lock: r6 reliability P1-R4 mirror — explicit WHERE state='shutting_down' clause mirrors frag-6-7 §6.6.1 step 4]` (frag-3.5.1 §3.5.1.2) | CLOSED |
+| HMAC `base64-22` wire-shape cross-frag unification (truncated 16-byte HMAC-SHA256, base64 ~22 chars) | frag-3.4.1 §3.4.1.g (handshake wire format owner — `helloNonceHmac: "<base64-22>"`) | frag-6-7 §6.5 + §7.2 (canonical secret lifecycle + HMAC contract; mirrored 1:1) | `[manager r7 lock: r6 P2-10 — HMAC base64-22 cross-frag wire-shape unification]` (E's fix per frag-3.4.1 §3.4.1.g + frag-6-7 §7.2) | CLOSED |
+| `helloInterceptor` as interceptor #0 (handshake required BEFORE migrationGate) | frag-3.4.1 §3.4.1.f (interceptor pipeline owner — slot 0) + §3.4.1.g (handshake semantics) | frag-6-7 §6.4 supervisor (handshake rejection ladder); frag-3.7 §3.7.4 reconnect counting | `[manager r7 lock: r6 reliability P1-R6 — explicit ordering #0 so handshake-required check fires BEFORE migrationGateInterceptor]` (frag-3.4.1 §3.4.1.f) | CLOSED |
+| 2 s handshake timeout + dedicated `HANDSHAKE_TIMEOUT` failure class | frag-3.4.1 §3.4.1.g (timeout + failure-class owner) | frag-6-7 §6.1.1 (`daemon.unreachable` body copy "reinstall ccsm" remediation); frag-3.7 §3.7.4 reconnect backoff (handshake fail counts as one reconnect attempt) | `[manager r7 lock: r6 reliability P0-R1 — explicit 2 s handshake deadline + dedicated failure class]` (frag-3.4.1 §3.4.1.g) + `[manager r7 lock: r6 reliability P0-R1 — handshake failure is a distinct pre-RPC failure class]` (frag-6-7 §6.1.1) | CLOSED |
+| Server-side stream-dead detector `2 × heartbeatMs + 5 s` (symmetric) | frag-6-7 §6.5.1 (canonical detector spec, B add) | frag-3.5.1 §3.5.1.4 (cross-ref handoff, H lock) | `[manager r7 lock: r6 reliability P0-R2 — daemon-side symmetric dead-stream detector at 2 × heartbeatMs + 5 s]` (frag-6-7 §6.5.1) + `[manager r7 lock: r6 reliability P0-R2 cross-frag handoff]` (frag-3.5.1 §3.5.1.4) | CLOSED |
+| Surface registry equal-priority deterministic tie-break (registry insertion order) | frag-6-7 §6.8 stacking rule 6 (C add) | frag-6-7 §6.1.1 (banner/modal stacking); frag-3.7 §3.7.8 bridge consumer; renderer `useDaemonHealthBridge` | `[manager r7 lock: r6 ux P0-2 — equal-priority tie-break = registry insertion order]` (frag-6-7 §6.8 stacking rule 6) | CLOSED |
+| Devx P0-1 debugger contract (`--inspect=9229` Electron-main / `--inspect=9230` daemon, env-gated, dev-only) | frag-3.7 §3.7.7.a (A add — daemon-split contributor debugger flow) | frag-3.7 §3.7.3 nodemon `exec` line; frag-11 §11.2 packaging (prod strips `CCSM_DAEMON_INSPECT`); `.vscode/launch.json` consumers | `[manager r7 lock: r6 devx P0-1 — debugger contract for daemon-split contributors]` (frag-3.7 §3.7.7.a) | CLOSED |
+| Devx P0-2 SDK ownership lock (daemon owns `claude-agent-sdk` direct ESM; Electron-main `loadSdk()` shim retained ONLY for residual session-title) | frag-3.7 §3.7.7.b (canonical ownership lock) | frag-11 §11.2.1 (SDK packaging contract consumer); frag-6-7 §6 daemon SDK consumers (must not use shim); Electron-main `electron/sessionTitles/loadSdk()` (residual only) | `[manager r7 lock: r6 devx P0-2 — daemon owns SDK directly (own Node 22 ESM); Electron-main loadSdk shim retained ONLY for any residual session-title/non-daemon SDK calls. New daemon code MUST NOT use the shim.]` (frag-3.7 §3.7.7.b) | CLOSED |
+| `claude-agent-sdk` packaging contract (`extraResources` + `asarUnpack` + before-pack copy) | frag-11 §11.2.1 (D add — packaging mechanics owner) | frag-3.7 §3.7.7.b (SDK ownership consumer); Electron-main `loadSdk()` shim resolution path | `[manager r7 lock: r6 packaging P0-1 — claude-agent-sdk explicit packaging contract]` (frag-11 §11.2.1) | CLOSED |
+| `ccsm-uninstall-helper.exe` signing as first-class artifact (signtool `$targets` array + before-pack staging) | frag-11 §11.3.1 (sign step) + frag-11 §11.6.4 (helper Task 20e) | frag-6-7 §6.8 NSIS uninstall hygiene (in-app daemon-shutdown contract consumer); release CI signing pipeline | `[manager r7 lock: r6 packaging P1-F — ccsm-uninstall-helper.exe is a first-class signed packaging artifact]` (frag-11 §11.6.4) | CLOSED |
+| macOS notarize `teamId` + stapler validate (DMG explicitly stapled; standalone Mach-O notarized but not stapled) | frag-11 §11.3.2 (D add — codesign/notarize/stapler owner) | release CI macOS leg (`xcrun stapler validate` post-build); §11.7 5-submission count | `[manager r7 lock: r6 packaging P1-C — DMG stapling explicitly asserted]` (frag-11 §11.3.2) | CLOSED |
+| Per-OS installer size ceilings + CI guard (Win NSIS ≤145 MB / mac DMG ≤160 MB / Linux AppImage ≤140 MB / .deb/.rpm ≤125 MB / standalone daemon ≤60 MB per arch) | frag-11 §11.5(6) (D add — release-publish job CI assertion) | frag-11 §11.2.1 SDK budget contribution (~6 MB); frag-11 §11.6.4 uninstall-helper (~5 MB); frag-11 §11.5(0) Electron 41 size baseline (~95 MB) | `[manager r7 lock: r6 packaging P1-B — installer size ceiling + CI assertion]` (frag-11 §11.5(6)) | CLOSED |
+| Electron `^41.3.0` pin (caret allows patch-level autoupdate within 41.x; Electron 42+ deferred post-v0.3) | frag-11 §11.5(0) (E add — toolchain pin owner) | frag-11 §11.2.1 SDK packaging (Electron 41 main = CJS, SDK = ESM); frag-3.7 §3.7.7.b SDK ownership lock; frag-3.5.1 `loadSdk()` shim contract; per-`.node` ABI rebuild matrix | `[manager r7 lock: r6 lockin P0 — Electron version pinned to ^41.3.0 per pool-1/package.json check on 2026-05-01.]` (frag-11 §11.5(0)) | CLOSED |
+| 6-step upgrade-in-place sequence (Electron-main owns orchestration: trigger → graceful shutdown RPC → 5 s ack → race fallback (force-kill + lock unlink) → quitAndInstall → spawn fresh daemon) | frag-11 §11.6.5 (D add — orchestration owner) | frag-6-7 §6.4 (`daemon.shutdownForUpgrade` RPC producer + marker writer); frag-6-7 §6.1 (marker-aware crash-loop skip on next boot, see G verify row above) | `[manager r7 lock: r6 packaging P0-2 — upgrade-in-place daemon-shutdown contract]` (frag-11 §11.6.5) | CLOSED |
+| SmartScreen reputation reset risk on path / scope change (per-machine `Program Files` → per-user `%LOCALAPPDATA%`) | frag-11 §11.7 (D add — out-of-scope risk note) | frag-11 §11.3.x EV cert mitigation (pre-trusted SmartScreen reputation); release notes copy for non-EV cert builds | `[manager r7 lock: r6 packaging P1-D — SmartScreen reputation reset documented]` (frag-11 §11.7) | CLOSED |
+| zh.ts parity acceptance criterion (i18n bundle keyset CI gate covering all v0.3 i18n keys) | frag-6-7 §6.1.1 line 64 (zh.ts parity owner) | frag-3.7 §3.7.8 i18n keys (daemon-health surfaces); frag-8 §8.6 `migration.modal.failed.*`; renderer i18n bundle (`src/i18n/locales/en.ts` ↔ `zh.ts`) | `[manager r7 lock: r6 ux P0-4 — zh.ts parity acceptance criterion]` (frag-6-7 §6.1.1) `[manager r9 lock: r8 traceability P1-2 — orphan lock added as own row]` | CLOSED |
+| Surface key spelling alignment to §6.8 canonical (renames `daemon.reconnectStuck` / `daemon.reconnectExhausted` / `tray.closeHint` to OBSOLETE per §6.8 r7 trim) | frag-3.7 line 37 (key spelling alignment lock) | frag-6-7 §6.8 (canonical surface key prefix owner); frag-3.7 §3.7.8 dispatched-surface set | `[manager r7 lock: r6 ux P0-1 — key spelling aligned to §6.8 canonical]` (frag-3.7 line 37) `[manager r9 lock: r8 traceability P1-2 — orphan lock added as own row, distinct from §6.8 trim cascade row 4 which doesn't enumerate the renamed keys]` | CLOSED |
+
+##### r9 batch (after r8 verify)
+
+[manager r11 lock: r10 traceability P1 — 12 r9-batch cross-frag closures broken out as their own rows for §12 traceability discipline; prior r9 audit had folded these into prose only.]
+
+| Concern | Owner frag/§ | Consumer frag(s)/§(s) | r9 lock string | Status |
+|---|---|---|---|---|
+| `SUPERVISOR_RPCS` canonical sweep | frag-3.4.1 §3.4.1.h | frag-3.4.1 §3.4.1.f, frag-6-7 §6.5, frag-12 row 166 | `[manager r9 lock: r8 envelope P0-1 + r8 devx P0-1 — SUPERVISOR_RPCS 5-element canonical allowlist swept across frag-3.4.1/frag-6-7/frag-12]` | CLOSED |
+| hello-handshake unified posture | frag-3.4.1 §3.4.1.h | frag-6-7 §6.5 | `[manager r9 lock: r8 envelope P0-1 — hello handshake posture unified across §3.4.1.h owner and §6.5 healthz consumer]` | CLOSED |
+| `x-ccsm-boot-nonce` header in reserved-keys allowlist + precedence rule | frag-3.4.1 §3.4.1.c + §3.4.1.g | frag-3.5.1 §3.5.1.4 (`fromBootNonce` param) | `[manager r9 lock: r8 envelope P1 — x-ccsm-boot-nonce added to reserved-keys allowlist with explicit precedence over body-level bootNonce]` | CLOSED |
+| base64url no-pad nonces | frag-3.4.1 §3.4.1.g | frag-6-7 §6.5 (HMAC verify) | `[manager r9 lock: r8 envelope P1 — nonces locked to base64url no-pad on the wire; HMAC verify path mirrors]` | CLOSED |
+| close-frame traceId carriage rule | frag-3.4.1 §3.4.1.c | (envelope-internal) | `[manager r9 lock: r8 envelope P1 — close-frame carries last-known traceId for log correlation]` | CLOSED |
+| `/healthz` + `/stats` literal exemption from `ccsm.<wireMajor>/` namespace | frag-3.4.1 §3.4.1.h | frag-6-7 §6.5 | `[manager r9 lock: r8 envelope P1 — /healthz + /stats literal paths exempted from versioned ccsm.<wireMajor>/ RPC namespace]` | CLOSED |
+| `daemonProtocolVersion` INTEGER pin | frag-3.4.1 schema | (handshake consumers) | `[manager r9 lock: r8 envelope P1 — daemonProtocolVersion typed INTEGER not string in TypeBox schema]` | CLOSED |
+| Marker unlink ownership = daemon | frag-6-7 §6.4 | frag-6-7 §6.1 R2 | `[manager r9 lock: r8 reliability P1 — daemon owns daemon.shutdown marker unlink (not Electron-main); §6.1 R2 marker-aware skip consumes]` | CLOSED |
+| SDK ownership inversion daemon-primary direct ESM | frag-11 §11.2.1 | frag-3.7 §3.7.7.b (already aligned) | `[manager r9 lock: r8 packaging P1 — claude-agent-sdk packaging contract inverted: daemon-primary direct ESM consumer; Electron-main loadSdk shim residual only]` | CLOSED |
+| NSIS `oneClick: false` reconciliation | frag-11 §11.6 | §11 head, plan-delta 8c, frag-12 row 173 | `[manager r9 lock: r8 packaging P0-2 — NSIS oneClick:false / allowElevation:true / allowToChangeInstallationDirectory:true reconciled with working tip; assisted-mode installer preserved]` | CLOSED |
+| §8.7 rollback rewrite + plan-delta 8c trim 18h→16h | frag-8 §8.6/§8.7 | (plan-delta consumer) | `[manager r9 lock: r8 migration P0 — §8.7 rollback rewritten; plan-delta 8c trimmed 18h→16h]` | CLOSED |
+| daemon.migrationFailed annotation cleanup → `migration.modal.failed.*` | frag-6-7 §6.8 ann | (i18n consumers) | `[manager r9 lock: r8 ux P0 — daemon.migrationFailed annotation cleaned up; canonical key prefix is migration.modal.failed.* per §8.6]` | CLOSED |
+
+#### 🟡 IN-FLUX (r5 fixers will land — cite owning frag)
+
+| Round | Item | Owning frag + section | Fixer ask |
+|---|---|---|---|
+| r3 resource X1 | `<dataRoot>` aggregate disk cap dropped | frag-6-7 §6.6 | add aggregate watchdog (e.g. 2 GB warn / 4 GB hard prune-oldest) |
+| r3 resource X2 / r3 devx CF-1 | `pino-roll symlink: true` punt not picked up | frag-6-7 §6.6.1/.2 | add `symlink: true` to both daemon + electron pino-roll config |
+| r3 reliability P0-R1 | drain ordering loses SIGCHLD `ptyExit` into closed sinks | frag-3.5.1 §3.5.1.2 + frag-6-7 §6.6.1 | re-order: fan-out close moves AFTER step 8 (final waitpid + DB tx) |
+| r3 reliability P0-R2 | crash-loop counter reset on rollback masks 2nd-bug loops | frag-6-7 §6.1 + §6.4 step 7 | rollback clears backoff but KEEPS crash-loop window decayed (e.g. counts as 3 of 5) |
+| r3 reliability P0-R3 | `state='abandoned'` unreachable + name conflict | frag-3.5.1 §3.5.1.2 step 8 + frag-6-7 §6.6.1 step 5 | unify on `paused`; drop `abandoned` OR define semantic distinction |
+| r3 reliability P0-R5 | `daemon.crashing` IPC is best-effort but renderer relies on it | frag-6-7 §6.6.1 | state explicitly: opportunistic; supervisor `/healthz` 3-miss + bridge 5s timeout = authoritative path |
+| r3 reliability CF-1 / r2 ux P1-UX-3 carve-out | "BridgeTimeoutError NEVER surfaced to user" sentence missing | frag-3.5.1 §3.5.1.3 | append the sentence per frag-3.7 §3.7.8.c punt; remove "renderer-side caller decides retry policy" wording |
+| r3 reliability CF-2 | replay-burst vs 1MB watermark language conflict | frag-3.5.1 §3.5.1.5 | add: "subscriber buffer accounting RESETS to 0 immediately after replay landed" OR "drop subscriber if buffered >X KB at resubscribe BEFORE replay write" |
+| r3 reliability CF-3 / r3 devx CF-3 | "supervisor disabled in dev" — frag-6-7 says transport still binds | frag-6-7 §6.1 + §6.5 | clarify whether supervisor transport binds in dev; align with frag-3.7 §3.7.6 "Supervisor active? NO" table |
+| r3 reliability P1-R1..R5 | various P1 polish | frag-6-7 §6.3/§6.6.3/§6.4 + frag-3.5.1 §3.5.1.2 | scheduled crash-dump prune, lockfile-create-fail uses `console.error` pre-pino, swap-lock vs daemon-lock race, `pid_pgid` cleared on graceful close, PR_SET_PDEATHSIG fork/execve race acknowledgement |
+| r3 security P0-2 | r2 P1-S3 (subscribe `fromSeq` token) silently dropped, not punted | frag-3.5.1 §3.5.1.5 | add `subscribe_token` paragraph OR add explicit "ACCEPTED — same-user T3" row to §7.4 (frag-6-7 §7.4 T17 ACCEPTED row exists; verify consistency with frag-3.5.1) |
+| r3 security CC-2 | `traceId` optional on wire vs mandatory in §6.6 validation | frag-6-7 §6.6.1 | add: validation runs only when `traceId` present; inheriting sub-frames resolve via `streamId → traceId` map |
+| r3 security CC-3 | `daemon.secret` Electron-as-generator bypasses CLI launch path | frag-6-7 §7.2 | add `CCSM_DAEMON_HEADLESS=1` self-generate clause OR explicit "v0.3 refuses CLI launch without `--secret-file=`" |
+| r3 security P1-1..P1-6 | P1 polish | frag-6-7 §7.2/§6.6.3/§6.4 + frag-8 §8.6 + frag-11 §11.4.1 | clear `CCSM_DAEMON_SECRET` from `process.env` post-read, sanitize migration `supplied`/`realpath` for renderer, name SLSA verifier (`@sigstore/verify`), `path.basename`+regex on crash-dump filename, `daemon.shutdown` BEFORE secret rotate |
+| r3 perf CF-1 | healthz transport split — `control-socket` (3.4.1.h) vs `-sup` (6.5) ambiguous | frag-3.4.1 §3.4.1.h + frag-6-7 §6.5 | reconcile to ONE control plane (recommend rename §3.4.1.h `control-socket` to BE the §6.5 supervisor transport) |
+| r3 perf P1-2..P1-5 | P1 polish | frag-3.5.1 §3.5.1.5 + frag-3.7 §3.7.4 + frag-3.4.1 §3.4.1.g | LRU fairness note for v0.5, hello-on-every-connect cold-start RT note, semaphore vs RAM-cap budget cross-ref |
+| r3 lockin P1-1..P1-4 | r2 P1 lockin items still residual | frag-6-7 §6.4/§6.6 + frag-3.7 §3.7.4 + frag-11 §11.1 | `loggerTransport` factory, replace `proper-lockfile` with 15-LOC `fs.openSync`, `connectClient.configure({maxQueued, scheduling})` + `E_RECONNECT_QUEUE_OVERFLOW` code, `daemon/.nvmrc` single-source for Node target |
+| r3 obs P1-2 | reconnect canonical log names not echoed in emitter | frag-3.7 §3.7.4 | add cross-ref: "Log line names per frag-6-7 §6.6.2 contract" |
+| r3 ux P0-UX-B | migration modal "dismissable: false" prose vs §6.8 implicit-dismiss | frag-8 §8.6 OR frag-6-7 §6.8 | delete prose claim OR codify in §6.8 stacking rule 1 |
+| r3 ux CC-1..CC-4 | onboarding key-name conflict / paused copy drift / camelCase vs dot.case / BridgeTimeout 3-place statement | frag-6-7 §6.3/§6.8 + frag-3.7 §3.7.8 + frag-3.5.1 §3.5.1.3 | locked per [manager r3 lock] §12.0 (3); r5 fixer normalizes copy + key spellings (residual: BridgeTimeout 3-place statement still pending in §3.5.1.3 — same as r3 reliability CF-1 above) |
+| r3 ux P1-1..P1-6 | P1 polish | frag-6-7 §6.1 + frag-11 §11.6.2 + frag-3.7 §3.7.8.d | cold-start splash dev-mode hide trigger, "View log" target, "Reinstall ccsm" button behavior, reconnect-stuck modal copy normalization, mac "Reset CCSM…" tray UX pick, BrowserWindow backgroundColor companion fix |
+| r3 packaging CF-2 | `customInstall` for `daemon.secret` split-ownership | frag-11 §11 cross-frag rationale + frag-6-7 §7.2 | pick Electron-side generation (already locked); remove dead frag-11 cross-frag rationale lines 500-501 |
+| r3 packaging CF-4 | SLSA verifier coupling (which library?) | frag-6-7 §7.3 + frag-11 plan delta Task 20d | pick `@sigstore/verify` v1.x + bundle (~2 MB) |
+| r3 packaging CF-5 | initial-install SLSA chicken-and-egg | frag-6-7 §7.3 | reword: "Linux via documented `slsa-verifier` manual step + minisign" |
+| r3 packaging P1-1..P1-9 | P1 polish | frag-11 §11.1/§11.2/§11.3.2/§11.6.4/§11.4.1/§11.7 | arch-map fix (armv7l/universal), per-leg `pkg --targets`, `node-gyp` ABI pinning, notarytool 5-submission count update, NSIS helper file-lock window, `pkg.assets` per-platform glob, `SHA256SUMS.txt` in SLSA subject-path, minisign keypair-gen documentation |
+
+#### ❌ OPEN (genuinely punted to v0.4+)
+
+| Round | Item | Decision | Cite |
+|---|---|---|---|
+| r1 security S5 | sigstore signing | deferred to v0.4 | frag-6-7 §7.3 v0.4 row |
+| r1 sec / fwdcompat | full CF Access JWT model | deferred to v0.5 | frag-6-7 §7.3 v0.5 row + §7.5 + `v0.5-security-followups.md` |
+| r1 reliability OPEN | Win Service mode | deferred to v0.4+ | frag-6-7 §6.4 ("user-mode background process only" + rationale) |
+| r2 perf P2-1 / r3 lockin P1-5 | OTLP `traceparent` carriage | tracked for v0.4 | frag-3.4.1 §3.4.1.c reserves `x-ccsm-trace-parent` header |
+| r3 resource P1-1..P1-6 | per-session aggregate-cap formula clarity, crash-dump aggregate cap, xterm-headless idle eviction (res-S3), socket.cork amortization, reconnect queue closure-pin accounting, supervisor transport accept-loop cost | all P1 / not blocking v0.3 | frag-6-7 §6.6.3 + §6.7 F11 + frag-3.5.1 §3.5.1.5 + frag-3.4.1 §3.4.1.c — release-notes call-outs OR v0.4 prereqs |
+| r3 ux out-of-scope | iOS App Store framing | deferred per F3 spike | frag-6-7 §7.5 |
+| r3 ux out-of-scope | stream-heartbeat traffic-analysis surface | deferred to v0.5 | frag-6-7 §7.5 + r2 sec SH5 |
+
+### 12.2 Summary
+
+Total tracked rows: **191** (matrix rebuilt off current frag bodies in r5 + 21 r7-batch cross-frag rows + 12 r9-batch cross-frag rows broken out as own rows in r11 per r10 traceability P1).
+
+- ✅ CLOSED: **159** (126 r5-baseline + 21 r7-batch cross-frag closures + 12 r9-batch cross-frag closures: SUPERVISOR_RPCS canonical sweep, hello-handshake unified posture, x-ccsm-boot-nonce reserved-keys + precedence, base64url no-pad nonces, close-frame traceId carriage, /healthz+/stats namespace exemption, daemonProtocolVersion INTEGER pin, marker unlink ownership = daemon, SDK ownership inversion daemon-primary direct ESM, NSIS oneClick:false reconciliation, §8.7 rollback rewrite + plan-delta 8c trim, daemon.migrationFailed → migration.modal.failed.*).
+- 🟡 IN-FLUX: **25** (unchanged from r5 — those fixers were dispatched per-fragment in r5; r7/r9 batches added different axes (round-6 / round-8 review locks) without re-opening the r5 IN-FLUX set).
+- ❌ OPEN: **7** (sigstore + CF Access + Win Service + OTLP carriage + resource P1 polish + iOS + heartbeat traffic analysis).
+
+Math: 159 + 25 + 7 = **191**. Net delta from r9 audit: +12 explicit CLOSED rows (r9 batch cross-frag closures broken out as own rows per r10 traceability P1 — prior r9 audit had folded these into prose only). `[manager r11 lock: r10 traceability P1 — arithmetic recomputed (was 147/25/7=179; r9-batch broken out adds 12 → 159/25/7=191)]`
+
+[manager r7 lock: §12 rebuilt with 21 new rows from r7 batch (fixers A/B/C/D/E/H + G verify + r9 orphan additions); ratio CLOSED=147 / IN-FLUX=25 / OPEN=7] `[manager r11 lock: r10 traceability P1 — superseded; current ratio CLOSED=159 / IN-FLUX=25 / OPEN=7 after r9 batch broken out.]`
+
+Manager merge gate: the 25 IN-FLUX rows are dispatched as r5 fixers in their owning fragments (one fixer per fragment, parallel where non-overlapping). Once those land, this matrix re-promotes them to CLOSED and the spec is mergeable. The r7 batch did not change the IN-FLUX set — r7 was an orthogonal round-6 review-lock pass.
 
 ## Plan delta
-None — pure doc section. No plan changes.
+
+None — pure doc section. Out-of-scope items above are accounted for in their originating fragments' Plan delta sections; manager r3/r5 locks have no per-fragment plan-delta change beyond the wording edit in the affected fragment body.

--- a/docs/superpowers/specs/v0.3-fragments/frag-12-traceability.md
+++ b/docs/superpowers/specs/v0.3-fragments/frag-12-traceability.md
@@ -1,0 +1,43 @@
+# Fragment: §12 traceability matrix to 10-angle reviews
+
+**Owner**: worker dispatched per Task #934
+**Target spec section**: new §12 (last section) in main spec
+**P0 items addressed**: makes review coverage auditable; no code impact
+
+## What to write here
+Replace this section with the actual `## 12. Review traceability` markdown.
+
+A markdown table with columns:
+| Review report | MUST-FIX item | Spec v2 section | Status |
+
+One row per MUST-FIX from each of the 10 reports. Status values:
+- `addressed in §X.Y` — fully covered in v2
+- `addressed in §X.Y (partial)` — spec scopes the fix; full impl in plan
+- `deferred to v0.4` — explicit defer with rationale (e.g. sigstore signing)
+- `deferred to v0.5` — explicit defer (e.g. Cloudflare Access)
+- `out of scope` — review item not accepted; rationale required
+
+**Source reports** (read each for its MUST-FIX list):
+- `~/spike-reports/v03-review-resource.md` (GREEN — likely few/no MUST-FIX)
+- `~/spike-reports/v03-review-reliability.md`
+- `~/spike-reports/v03-review-security.md`
+- `~/spike-reports/v03-review-perf.md`
+- `~/spike-reports/v03-review-lockin.md` (LOW — likely few)
+- `~/spike-reports/v03-review-observability.md`
+- `~/spike-reports/v03-review-devx.md`
+- `~/spike-reports/v03-review-ux.md`
+- `~/spike-reports/v03-review-packaging.md`
+- `~/spike-reports/v03-review-fwdcompat.md`
+
+After the table, a short summary paragraph: "N MUST-FIX items addressed in
+v2, M deferred to v0.4, K to v0.5, J out of scope. Round-2 review will
+verify."
+
+This fragment depends on knowing which §X.Y the other fragments end up
+adding. Worker should read the OTHER fragment files in this directory
+(not the main spec, since merge hasn't happened) to know section numbers.
+If a fragment is empty/stub at time of writing, mark status as "addressed
+in §3.4.1 (pending fragment merge)" and let manager fix during merge.
+
+## Plan delta
+None — pure doc section. No plan changes.

--- a/docs/superpowers/specs/v0.3-fragments/frag-3.4.1-envelope-hardening.md
+++ b/docs/superpowers/specs/v0.3-fragments/frag-3.4.1-envelope-hardening.md
@@ -1,28 +1,356 @@
 # Fragment: §3.4.1 Envelope hardening (frame cap + chunk + binary)
 
 **Owner**: worker dispatched per Task #932
-**Target spec section**: insert after §3.4 in main spec
-**P0 items addressed**: #6 (envelope cap), #7 (head-of-line), #8 (binary frame)
+**Target spec section**: insert after §3.4 in main spec (already referenced at §3.1.1 line 80: "Envelope hard cap: 16 MiB per frame ... DoS protection from Connect adapter §3.4.1 below.")
+**P0 items addressed (round-1)**: envelope cap (security M3), head-of-line blocking (perf MUST-FIX #2), binary frame format (perf MUST-FIX #1).
+**P0 items addressed (round-2)**: interceptor + headers + traceId in envelope header (fwdcompat P0-1, observability P0-2, perf P0-A); hello/version handshake (fwdcompat P0-2, lockin P0-1); RPC namespace rule (fwdcompat P0-3); per-chunk amplification mitigations (perf P0-A/P0-B); reserved header keys for runtime tunables (fwdcompat P1-2); streamId allocation (fwdcompat P2-2); handler-arg schema responsibility split (security P1-S1); traceId validation (security P1-S2).
 
-## What to write here
-Replace this section with the actual `### 3.4.1 Envelope hardening` markdown
-that will be pasted into the main spec. Cover:
-1. **16 MiB hard cap per envelope** — reject longer; close socket; rationale
-   (DoS protection, mirrored at §3.1.1 socket level for defense in depth).
-2. **Head-of-line mitigation** — chunk PTY output frames to ≤16 KiB before
-   serialization; rationale: single Connect socket multiplexes all sessions,
-   one large frame would block all peers; cite the perf review report.
-3. **Binary frame format** — drop base64 (1.33× inflate) for PTY output;
-   use Connect's binary message support; keep JSON envelope for control
-   messages. Specify the wire format (length-prefixed binary payload +
-   small JSON header, or chosen Connect mechanism).
+**P0 items addressed (round-3)**: hello wire shape switched from plaintext bearer to HMAC challenge-response (security r3 P0-1) so `daemon.secret` never traverses the wire; explicit frame-version-nibble-then-length-then-cap parsing order (security r3 CC-1); traceId-optional-on-chunk/heartbeat validator carve-out (security r3 CC-2); `bootNonce` camelCase locked across all fragments (fwdcompat r3 CC-2); `x-ccsm-deadline-ms` clamp raised to 120 s and unified with frag-3.5.1 (fwdcompat r3 CC-3); `daemonAcceptedWires[]` advertised in hello reply (fwdcompat r3 P1-5); `clientImposterSecret` removed from redact list (no longer exists post-HMAC switch — lockin r3 CF-3); `seq` zero-padded to fixed 10-digit ASCII to keep header-skeleton fast path stable past `seq=10000` (perf r3 P1-1); explicit feature-add-vs-version-bump rule (fwdcompat r3 P1-4); optional warn on unknown `x-ccsm-*` header keys (fwdcompat r3 P1-7); `control-socket` (data plane control RPCs) and `-sup` socket (supervisor `/healthz`) clarified as TWO separate sockets with explicit table (perf r3 CF-1); subscribe RPC contract canonical owner cross-ref (fwdcompat r3 P1-2); `statsVersion` dropped from `/healthz` (fwdcompat r3 P1-3, owned by frag-6-7).
 
-Cite specific findings from `~/spike-reports/v03-review-perf.md` and
-`~/spike-reports/v03-review-security.md` where each requirement comes from.
+---
+
+### 3.4.1 Envelope hardening (v0.3 local channel)
+
+The hand-written length-prefixed JSON envelope used in v0.3 (Plan Task 5; replaced by real Connect-RPC over HTTP/2 in v0.4) ships with the hardening rules below. They are local-channel only — v0.4 Connect+Protobuf gets these natively.
+
+#### 3.4.1.a Hard 16 MiB cap per envelope
+
+`connectAdapter.ts` reads `len = buffer.readUInt32BE(0)` and currently accumulates up to 4 GiB before parsing. Trivial DoS via memory exhaustion from a single co-tenant process (security review M3, `~/spike-reports/v03-review-security.md` §3).
+
+**Frame-header parsing order (round-3 security CC-1)**: the 4-byte frame header MUST be processed in this exact sequence — getting the order wrong either resurrects a 256 MiB DoS or leaks a stale-client crash:
+
+1. Read 4 bytes → `raw = buffer.readUInt32BE(0)`.
+2. **Extract the version nibble FIRST**: `nibble = (raw >>> 28) & 0x0F`. If `nibble` is not in the daemon's known-version set (v0.3 daemon: `{0x0}`; v0.4 daemon: `{0x0, 0x1}`), reject with `{ code: "UNSUPPORTED_FRAME_VERSION", nibble }` and `socket.destroy()`. Do NOT mask + length-check first; an attacker setting `nibble = 0x1` against a v0.3 daemon would otherwise produce a `len > 16 MiB` reading from raw bits and the cap-check error would mask the real reason.
+3. **Then mask** the low 28 bits to compute payload length: `len = raw & 0x0FFFFFFF` (max 256 MiB by construction).
+4. **Then cap-check**: if `len > 16 * 1024 * 1024`, run the rejection sequence below.
+
+**Rule**: if `len > 16 * 1024 * 1024`, immediately:
+1. emit `pino.warn({ peer, peerPid, len }, "envelope_oversize")` — `peerPid` from the §3.1.1 peer-cred check, included for forensic correlation per round-2 reliability S-R5,
+2. write a synthetic `{ id: 0, error: { code: "envelope_too_large", message: "max 16 MiB" } }` reply (best-effort),
+3. `socket.destroy()`.
+
+Mirrored at §3.1.1 (socket-level cap) for defense in depth: the listener also caps the per-connection inbound byte budget at 64 MiB across all in-flight frames so an attacker cannot dribble 16 MiB frames in a tight loop.
+
+Rationale for 16 MiB: PTY input is keystroke-sized; the largest legitimate envelope is a single PTY-snapshot header (post-3.4.1.c, payload moves out of JSON), well under 1 MiB. Settings RPC payloads cap at a few KiB. 16 MiB is two orders of magnitude above the largest legitimate use, well below realistic memory-pressure on a 16 GiB dev box.
+
+Rationale for the 64 MiB per-connection in-flight ceiling: 4× the per-frame cap, chosen as a worst-case "attacker dribbles in 4 max-frames before any can be parsed". Not measurement-derived; flagged as a v0.4 tuning candidate (round-2 perf §4 vibes table, P2 only).
+
+**Pre-accept rate cap (round-2 security T15)**: the listener also caps `accept()` calls at 50/sec (`MAX_ACCEPT_PER_SEC`); excess connections fail with `EAGAIN` and a once-per-minute rate-limited log. Cheap defence vs co-tenant connect-flood DoS.
+
+#### 3.4.1.b Head-of-line mitigation: chunk stream payloads to ≤16 KiB
+
+The local socket multiplexes all RPCs (unary + server-streams, Plan Task 11 step 1 extends envelope with `streamId`). The socket is byte-serialized: a 10 MB PTY-snapshot envelope being framed-and-written **blocks the unary `listSessions` reply queued behind it** for 50–200 ms on a local pipe — visible UI stutter (perf review §3 throughput, MUST-FIX #2, `~/spike-reports/v03-review-perf.md`).
+
+**Rule**: any stream-message payload (`stream.kind === "chunk"`) larger than **16 KiB** is split into N ≤16 KiB sub-chunks at the adapter boundary, each emitted as its own length-prefixed frame with the same `streamId` and a per-stream monotonic `seq`. Receiver re-assembles by `streamId`. Unary RPC frames may interleave between sub-chunks.
+
+**Wording correction (round-2 perf §4 vibes table)**: 16 KiB matches HTTP/2's *default frame size* and so the byte-level chunking idiom is wire-compatible with the v0.4 Connect/HTTP-2 swap. It does **NOT** replicate HTTP/2's per-stream flow-control windows or multiplexing primitives — the v0.3 hand-rolled byte-stream is FIFO across streams, with chunking as the only fairness mechanism. Genuine flow control arrives in v0.4.
+
+Snapshot bootstrap (`getBufferSnapshot`, lifecycle.ts:178-203) is the worst offender — already chunked **on the daemon side** but currently re-collapsed into one wire envelope. Snapshot must stream as `stream.kind === "chunk"` sub-frames the same way live deltas flow (perf MUST-FIX #3). Snapshot `chunk` boundaries align with the existing 1000-line async-chunk boundary on the daemon side; no extra serialization passes.
+
+**`streamId` allocation (round-2 fwdcompat P2-2 / HTTP-2 parity)**: `streamId` is `uint32`. Client-initiated streams use **odd ids starting at 1**; server-pushed streams (none in v0.3 — reserved for v0.4 server-push notifications) use **even ids starting at 2**. Identical to HTTP/2's stream-id convention, so the v0.4 native swap reuses the same wire ids byte-for-byte. Each side maintains its own monotonic counter; collisions are impossible by construction.
+
+**Replay bound on resubscribe (round-2 resource P0-1)**: when a client resubscribes with `fromSeq = lastSeenSeq + 1` (§3.7.5 contract), the daemon ships at most **256 KiB of replay** before declaring `gap: true` and forcing a fresh snapshot. The 1 MiB per-subscriber drop-slowest watermark (frag-3.5.1 §3.5.1.5) is measured **after** the initial replay burst lands (replay treated as one prioritized initial write, not slow-subscriber accounting). Without this rule a nodemon-storm reconnect into a hot stream loops drop-and-resubscribe.
+
+**Subscribe RPC contract — canonical owner (round-3 fwdcompat P1-2)**: the `subscribe(sessionId, { fromSeq?, fromBootNonce?, heartbeatMs? })` request shape is **canonically owned by frag-3.5.1 §3.5.1.4**. This fragment owns only the wire-level chunking + replay-budget mechanics; field naming, defaults, clamps, and protobuf message definition (for v0.4) live in frag-3.5.1. Other fragments referencing subscribe (frag-3.7 §3.7.5 reconnect, frag-6-7 §6.5 supervisor exception) cite frag-3.5.1 §3.5.1.4 as the source of truth.
+
+#### 3.4.1.c Binary frame format for PTY chunks
+
+Today's envelope is `[len:4][JSON utf8]`. PTY output strings round-tripped through `JSON.stringify` + `JSON.parse` cost 5–30 ms per 64 KiB+ chunk and a fresh string allocation on the client side (perf §2 latency table, MUST-FIX #1). If `node-pty` is ever switched to `encoding: null` (raw `Buffer`), base64 inflates the payload 1.33× and adds ~50 MB/s ceiling.
+
+**Rule**: extend the envelope to a header-JSON + raw-bytes-trailer form for any frame whose payload is binary-ish (PTY output, future blob fields):
+
+```
+[totalLen:4][headerLen:2][headerJSON:headerLen][payloadBytes:totalLen-2-headerLen]
+```
+
+Note: the high 4 bits of `totalLen` are **reserved as a frame-version nibble** (round-2 lockin P0-1). v0.3 sets the nibble to `0x0`; readers MUST mask it off before computing the actual length. Payload length is therefore capped at 2^28 − 1 ≈ 256 MiB, well above the 16 MiB per-frame cap. v0.4 protobuf wire uses `0x1`; receivers reject unknown nibbles with `frame_version_unsupported` + `socket.destroy()`.
+
+The `headerJSON` schema (round-2 P0 additions in **bold**):
+
+```ts
+interface FrameHeader {
+  id: number;                          // RPC id
+  method?: string;                     // unary RPC method name
+  stream?: { streamId: number; seq: number; kind: "open" | "chunk" | "close" | "heartbeat" };
+  payloadType: "json" | "binary";
+  payloadLen: number;
+  /** round-2 fwdcompat P0-1 / observability P0-2 */
+  traceId?: string;                    // Crockford ULID, 26 chars; required on call-originating frames
+  /** round-2 fwdcompat P0-1 / P1-2 */
+  headers?: Record<string, string>;    // case-insensitive; reserved keys below
+}
+```
+
+- Pure-JSON frames (control RPCs: `listSessions`, settings, etc.) keep the existing form via `payloadType: "json"` (or absence — default JSON for backward compat during the lift). The JSON body lives in the header object as before.
+- For `payloadType: "binary"`, `payloadBytes` is the raw `Buffer` straight from `node-pty` (UTF-8 byte buffer; no base64, no `JSON.stringify` of the body).
+- Header still validated against the TypeBox contract at the adapter boundary (§3.1.1 schema rule); the binary trailer is opaque to *envelope* validation. **Per-method handler-arg validation of `payloadBytes` is the handler's responsibility** (round-2 security P1-S1) — see §3.4.1.d.
+
+**`traceId` validation (round-2 security P1-S2, round-3 security CC-2)**: validation runs **only when `traceId` is present** in the header. Inheriting sub-frames (`stream.kind === "chunk" | "heartbeat"`) carry no `traceId` by design (see §3.4.1.c omission rule below); for those frames the validator skips the regex check and resolves the call's traceId from the `streamId → traceId` map established at `kind: "open"` time. **Missing inherited mapping** (chunk/heartbeat arrives for an unknown `streamId`) is itself a protocol error and closes the stream with `RESOURCE_EXHAUSTED`. When `traceId` IS present (open frames + all unary frames), it is validated against the Crockford ULID regex `^[0-7][0-9A-HJKMNP-TV-Z]{25}$`. Mismatch → reject + `socket.destroy()`. Renderer-supplied `traceId` is treated as untrusted input; daemon log lines additionally include a daemon-generated `daemonTraceId` so forensic correlation never relies on caller-supplied data alone. Pino formatters strip `\n\r` from any string field destined for non-JSON destinations (defence vs log-injection via crafted `traceId` / `headers` values).
+
+**`traceId` placement on stream frames (round-2 perf §5.3, round-9 manager lock — r8 envelope P1-2)** `[manager r9 lock: r8 envelope P1-2 — close-frame traceId carriage rule]`: `traceId` is required on call-originating frames (`stream.kind === "open"`, all unary frames) AND on `stream.kind === "close"` (so terminal log lines correlate even after the `streamId → traceId` map entry is GC'd). It is **omitted** from `stream.kind === "chunk"` and `stream.kind === "heartbeat"` sub-frames — receivers inherit the call's traceId from the `streamId → traceId` map established at `kind: "open"` time. Saves ~34 B per chunk and removes redundant ULID strings from the high-volume PTY path. **Map-entry GC ordering**: the `streamId → traceId` entry is removed AFTER processing `kind: "close"` so the close frame's own traceId takes precedence over the (now-removed) map entry; this avoids a race where a fast subsequent `kind: "open"` on a reused streamId could overwrite the map entry mid-close-handling.
+
+**Reserved `headers` keys (round-2 fwdcompat P1-2, round-3 fwdcompat CC-3 + P1-7, round-9 manager lock — r8 envelope P0-3)**: `x-ccsm-deadline-ms` (per-call deadline override; v0.3 honored, **clamp `100 ms ≤ x ≤ 120 s`** — unified with frag-3.5.1 §3.5.1.3 to allow v0.5 web snapshot bootstrap with 30 s+ headroom), `x-ccsm-heartbeat-ms` (stream heartbeat override; v0.3 reserved, no-op), `x-ccsm-backpressure-bytes` (per-subscriber drop-slowest override; v0.3 reserved, no-op), `x-ccsm-trace-parent` (W3C traceparent for v0.5 OTLP; v0.3 reserved), **`x-ccsm-boot-nonce`** (subscribe RPC last-known boot nonce; v0.3 honored, see §3.4.1.g — `[manager r9 lock: r8 envelope P0-3 — added to reserved-keys allowlist so deadlineInterceptor stops warning on every PTY subscribe; precedence + RPC-param coexistence rule in §3.4.1.g]`). Daemon advertises defaults via the §3.4.1.g hello block. Workers may NOT define new `x-ccsm-*` keys without spec amendment; arbitrary other keys (no `x-ccsm-` prefix) are permitted (passed through to interceptors in §3.4.1.f). The `deadlineInterceptor` MUST `pino.warn({ key, method, peerPid }, "unknown_xccsm_header")` (rate-limited once per `key` per minute) when an `x-ccsm-`-prefixed header arrives outside the reserved allowlist — catches v0.3.x worker squatting before it hardens into a wire contract.
+
+**Hot-path optimizations (round-2 perf P0-A, resource SHOULD-3, round-3 perf P1-1)**: a 1 MiB PTY-snapshot stream becomes 64 sub-frames; the per-frame `JSON.stringify(header)` + `JSON.parse(header)` becomes the dominant CPU cost. The adapter MUST:
+1. **Cache the per-stream header skeleton** at `kind: "open"` time. Sub-chunks (`kind: "chunk"`) reuse the cached bytes with only the fixed-width `seq` field patched in-place per frame. **`seq` is encoded as zero-padded 10-digit ASCII** (covers full uint32 range — `4294967295` is 10 digits) so the skeleton byte length never shifts as `seq` crosses 10/100/1000/10000/… boundaries. Without zero-padding, the cached skeleton would silently fall back to full `JSON.parse` past `seq=10000` (4-byte → 5-byte width shift), a silent perf cliff. Receiver-side, after first `kind: "open"` is parsed for a `streamId`, subsequent same-`streamId` `kind: "chunk"` frames take a fast path that reads `seq` + `payloadLen` from fixed offsets without invoking `JSON.parse` on the full header. Falls back to full parse on any header-byte change vs the cached skeleton (defensive).
+2. **`socket.cork()` before the header `write` and `socket.uncork()` after the trailer `write`** so the kernel emits one packet per sub-frame (eliminates the 320× syscall amplification on a 5 MiB snapshot stream).
+
+**Single-frame caching for fan-out (round-2 perf P0-B)**: when frag-3.5.1 §3.5.1.5's fan-out registry distributes a chunk to N subscribers, the adapter MUST stringify+frame the chunk **once** and call `socket.write(sharedBuffer)` N times (header is identical across subscribers; only the destination socket differs). Latent in v0.3 (single subscriber per session) but the wire contract is locked here; switching later means re-doing fan-out. Cross-referenced from frag-3.5.1 §3.5.1.5.
+
+Cost: ~30 LOC in `connectAdapter.ts` + symmetric change in `testHelpers.ts` (Plan Task 5). v0.4 Connect+Protobuf provides this natively (`bytes` field type) — no migration churn.
+
+#### 3.4.1.d Schema validation hook
+
+Per §3.1.1, every decoded envelope is validated against the TypeBox contract **before** dispatch into handlers. This subsumes the `JSON.parse` reviver concern from security review M3 (no `__proto__` pollution into downstream Maps). Reject malformed → write `{ id, error: { code: "schema_violation" } }` → `socket.destroy()`. Validation happens on the header for binary frames (3.4.1.c).
+
+**Handler-arg validation responsibility (round-2 security P1-S1)**: the adapter check covers only routing fields (`id`, `method`, `stream`, `payloadType`, `payloadLen`, `traceId`, `headers`). For `payloadType === "binary"` frames, **handlers MUST validate the trailer bytes against a per-method byte schema** as their first statement: length cap from `payloadLen` (already known to be ≤ 16 MiB minus header), optional content sniff (e.g. UTF-8 well-formedness for `ptyWrite` data, escape-sequence sanitization for renderer-bound output). For `payloadType === "json"` frames whose handler argument is non-trivial, handlers MUST `Check(MethodArgsSchema, decoded)` as their first statement. ESLint rule `no-handler-without-check` enforces this at lint time.
+
+#### 3.4.1.e Open: spawn imposter handshake
+
+Per §3.1.1 sender peer-cred check, the daemon already verifies the connecting UID. Security review S2 (`~/spike-reports/v03-review-security.md` §4) raises a complementary concern: an attacker who races daemon boot and binds the pipe first can impersonate the daemon to Electron. The §3.4.1.g hello handshake (per-installation shared secret proven via HMAC challenge-response — secret never traverses the wire — plus protocol-version exchange) closes this; the secret lifecycle (installer-time generation, atomic ACL, rotation on auto-update, redact-list) is owned by **frag-6-7 §7.2** (cross-frag rationale below).
+
+#### 3.4.1.f Interceptor pipeline + request context
+
+Round-1 fwdcompat asked for a clean seam to insert v0.5 CF Access JWT verification, audit logging, and rate-limit middleware without rewriting every handler. Round-2 fwdcompat P0-1 escalated to MUST after frag-12 claimed the seam was addressed but no fragment defined it.
+
+```ts
+interface ReqCtx {
+  method: string;
+  headers: Record<string, string>;     // case-insensitive; from envelope header (§3.4.1.c)
+  traceId: string;                     // caller-supplied (validated) OR generated by entry interceptor
+  daemonTraceId: string;               // daemon-generated, authoritative for log correlation
+  peer: { uid: number; pid: number };  // from §3.1.1 peer-cred check
+  signal: AbortSignal;                 // composes with handler-internal aborts (§3.5.1.3)
+  deadlineMs: number;                  // resolved deadline (default 5 s, headers override per §3.4.1.c)
+}
+
+type Handler<Req = unknown, Res = unknown> = (req: Req, ctx: ReqCtx) => Promise<Res>;
+type Interceptor = (ctx: ReqCtx, next: () => Promise<unknown>) => Promise<unknown>;
+
+function mountConnectAdapter(opts: {
+  socket: Duplex;
+  handlers: Map<string, Handler>;
+  interceptors?: Interceptor[];        // executed in array order, onion-style (first wraps all)
+}): void;
+```
+
+v0.3 ships the following interceptors in order:
+0. `helloInterceptor` `[manager r7 lock: r6 reliability P1-R6 — explicit ordering #0 so handshake-required check fires BEFORE migrationGateInterceptor; otherwise a non-hello RPC during migration would short-circuit with MIGRATION_PENDING and leak pre-handshake daemon state to an unverified peer]` — runs FIRST on every envelope. Allowlist `["ccsm.v1/daemon.hello"]`; for any other method on a connection that has not yet completed handshake, rejects with `hello_required` and `socket.destroy()` (per §3.4.1.g semantics). `helloInterceptor` short-circuits the rest of the chain on rejection — subsequent interceptors (trace / deadline / migrationGate / metrics) do NOT run, so no log noise, no metric increment, and crucially no `MIGRATION_PENDING` leak. On a connection that HAS completed handshake, `helloInterceptor` is a no-op pass-through.
+1. `traceInterceptor` — fills/validates `traceId`, mints `daemonTraceId`, attaches to logger child.
+2. `deadlineInterceptor` — reads `headers["x-ccsm-deadline-ms"]` (clamped 100ms ≤ x ≤ 120s per §3.4.1.c), composes `AbortSignal.timeout(deadlineMs)` with handler-supplied signal via `AbortSignal.any` (frag-3.5.1 §3.5.1.3). Also emits the `unknown_xccsm_header` warn (§3.4.1.c) for any non-reserved `x-ccsm-*` key.
+3. `migrationGateInterceptor` — short-circuits with `MIGRATION_PENDING` for data RPCs while migration is in progress; allows the canonical `SUPERVISOR_RPCS` constant (declared in §3.4.1.h) through unconditionally (round-2 reliability P1-R3). `[manager r9 lock: r8 envelope P0-1 + r8 devx P0-1 — replaced hardcoded 3-element list with reference to canonical SUPERVISOR_RPCS constant; previously enumerated only `/healthz`, `/stats`, `daemon.hello` and would have wrongly blocked `daemon.shutdown` + `daemon.shutdownForUpgrade` mid-migration]`.
+4. `metricsInterceptor` — records `{ method, durationMs, outcome }` per call.
+
+v0.5 appends `cfAccessJwtInterceptor` to the array; no existing handler signatures change. The interceptor array is the only public seam that survives the v0.4 Connect swap (Connect's native interceptor concept maps 1:1).
+
+Cost: ~30 LOC + 1 unit test (interceptor sees `headers={}` for Win named-pipe / unix-socket transports in v0.3).
+
+#### 3.4.1.g Hello / version handshake (frame-version + protocol-version + HMAC imposter check)
+
+`[manager r5 lock: 2-frame HMAC handshake, client issues nonce, daemon proves possession; reason: client identity already proven by peer-cred + socket ACL, daemon identity is what needs proof; saves 1 RT vs 3-frame; aligns with frag-6-7 §7.2.]`
+
+Round-1 §3.3 asked for a versioned handshake; round-2 fwdcompat P0-2 + lockin P0-1 escalated after the round-2 reviewers found the v1 spec/plan never wired it. **Round-3 security P0-1** replaced the original plaintext-bearer imposter check with an HMAC challenge-response after a reviewer noted that the round-2 shape sent `daemon.secret` cleartext on every connection (visible in `strace -e trace=read,write`, every TLS-pcap on v0.5 web, every crash dump), and that `Buffer.compare` is not constant-time so the bearer form additionally leaks the secret byte-by-byte to a probing co-tenant. **Round-5 manager lock**: the wire shape is collapsed from 3 frames to 2 frames, aligned 1:1 with frag-6-7 §7.2 (canonical owner of secret lifecycle + HMAC contract).
+
+**DO NOT send `daemon.secret` on the wire.** The handshake proves possession of the secret without transmitting it.
+
+**Two-frame handshake** (round-3 security P0-1, round-5 manager lock — wire shape mirrors frag-6-7 §7.2 step 1-3):
+
+```ts
+// (1) Client → daemon — first envelope on every new connection; carries challenge nonce
+{ id: <n>, method: "ccsm.v1/daemon.hello",
+  payload: {
+    clientWire: "v0.3-json-envelope",        // wire format identifier
+    clientProtocolVersion: 1,                // INTEGER (uint, semver-major); bumped on breaking wire change; client's max accepted protocol
+    clientFrameVersions: [0],                // frame-version nibbles client can read (§3.4.1.c)
+    clientFeatures: ["binary-frames", "stream-heartbeat", "interceptors", "traceId", "bootNonce", "hello"],
+    clientHelloNonce: "<base64-16>"          // 16 random bytes (~22 chars on wire); per-connection challenge for daemon to HMAC
+  }
+}
+
+// (2) Daemon → client — same envelope id; proves possession of daemon.secret AND advertises protocol
+{ id: <n>,
+  payload: {
+    helloNonceHmac: "<base64-22>",           // HMAC-SHA256(daemon.secret, clientHelloNonce) truncated to 16 bytes, base64
+    protocol: {                              // canonical version-negotiation block; mirrored 1:1 from frag-6-7 §6.5 healthz
+      wire: "v0.3-json-envelope",
+      minClient: "v0.3",
+      daemonProtocolVersion: 1,              // INTEGER (uint, semver-major); bumped on breaking wire change; bump rule below `[manager r9 lock: r8 envelope P1-4 — type pinned to integer literal; TypeBox Type.Integer({minimum:1}); compare numerically; schema validation REJECTS string values with schema_violation]`
+      daemonAcceptedWires: ["v0.3-json-envelope"], // round-3 fwdcompat P1-5; v0.4 ships [..., "v0.4-protobuf"]
+      // single source of truth: frag-6-7 §6.5; this list mirrors that
+      features: ["binary-frames", "stream-heartbeat", "interceptors", "traceId", "bootNonce", "hello"]
+    },
+    daemonFrameVersion: 0,                   // active frame-version nibble for this session (§3.4.1.c)
+    bootNonce: "<ULID>",                     // mirrors frag-6-7 §6.5 healthz bootNonce; renderer must check after reconnect
+    defaults: {                              // see §3.4.1.c reserved headers
+      deadlineMs: 5000,
+      heartbeatMs: 30000,
+      backpressureBytes: 1048576
+    },
+    compatible: true,
+    reason: undefined                        // string only when compatible === false
+  }
+}
+```
+
+The **client** computes the same HMAC over its own `clientHelloNonce` using its loaded `daemon.secret`, and compares against the daemon's `helloNonceHmac` field using **`crypto.timingSafeEqual`** (constant-time; non-negotiable — `Buffer.compare` is forbidden here, byte-by-byte timing leak). Mismatch → client treats the listener as imposter, logs `{ offenderPid }`, refuses to talk, falls back to spawning the real daemon under a fresh socket name (Win named-pipe collision: append `-rescue-<ulid>`). Reverse-direction proof (client proves to daemon) is unnecessary because peer-cred (§3.1.1) + ACL (§7.1) already authenticate the client.
+
+**Base64 variant (round-9 manager lock — r8 envelope P1-1)** `[manager r9 lock: r8 envelope P1-1 — base64url-no-pad locked for both clientHelloNonce + helloNonceHmac]`: both `clientHelloNonce` (16 raw random bytes) and `helloNonceHmac` (truncated 16-byte HMAC-SHA256 output) MUST be encoded on the wire via `Buffer.from(buf).toString('base64url')` — URL-safe alphabet, **no `=` padding**. 16 bytes round-trips to exactly 22 ASCII chars, matching the `<base64-22>` placeholders in the schema. Both sides MUST decode the wire string back to a 16-byte `Buffer` via `Buffer.from(s, 'base64url')` BEFORE invoking `crypto.timingSafeEqual` — comparing the ASCII strings directly bypasses the constant-time guarantee. Padded standard `base64` (24 chars with trailing `==`) is FORBIDDEN; mixing padded vs unpadded variants between client and daemon causes `RangeError [ERR_OUT_OF_RANGE]: Input buffers must have the same byte length` on the very first connection — every install ships dead-on-arrival.
+
+Daemon refuses to dispatch any RPC other than `daemon.hello` on the connection until the handshake completes (`helloInterceptor` enforces; rejects with `hello_required` + `socket.destroy()`). On the daemon side the per-connection `clientHelloNonce` is single-use: any further `daemon.hello` on the same socket after the first is rejected with `hello_replay`.
+
+**Client-side handshake timeout + failure classification (round-7 manager lock — r6 reliability P0-R1)** `[manager r7 lock: r6 reliability P0-R1 — explicit 2 s handshake deadline + dedicated failure class so handshake-failure storms cannot bypass the 250 ms reconnect hold-off and exhaust the queue, and so handshake-stuck remediation (reinstall ccsm) stays distinct from post-handshake hang remediation (restart daemon)]`:
+
+- **Handshake timeout = 2 s**, measured from socket-connect (TCP/pipe accept observed client-side) to receipt of the daemon's frame-2 reply (`helloNonceHmac` + `protocol`). Sits between the §3.7.4 first-attempt backoff (200 ms) and the §3.5.1.3 unary default deadline (5 s) so handshake-failure surfaces faster than a generic stuck unary RPC but does NOT race the first reconnect step. On timeout, the client closes the socket with no synthetic error frame (handshake is pre-RPC, no envelope id to bind a reply to), increments the §3.7.4 reconnect backoff schedule, and emits one `daemon_handshake_timeout` log line `{ peer, durationMs, attemptN }`. The rejection class is `HANDSHAKE_TIMEOUT` (NOT `BridgeTimeoutError` — distinct path so `bridgeTimeoutSpike` aggregation in §6.1.1 is not falsely tripped).
+- **Handshake-failure does NOT count toward `bridgeTimeoutSpike` (frag-6-7 §6.1.1) 3-in-10s detector.** The two failure classes are distinct: `bridgeTimeoutSpike` aggregates POST-handshake unary RPC `BridgeTimeoutError`s; handshake failures (timeout, `hello_required`, `hello_replay`, `schema_violation` on `daemon.hello`, HMAC mismatch via `crypto.timingSafeEqual`, `compatible: false` reasons) are treated identically by the client — close socket, count toward §3.7.4 reconnect backoff schedule, surface only via the existing supervisor heartbeat / reconnect surfaces (frag-6-7 §6.1.1 `daemon.healthDegraded` → `daemon.healthUnreachable` ladder + §6.8 reconnect toast). No new modal row is added; remediation copy ("if this persists, ccsm may need to be reinstalled") is folded into the body of the existing `daemon.healthUnreachable` banner (frag-6-7 §6.1.1 owns the copy edit; cross-frag handoff to fixer A — surface registry trim — preserves the row count). Without this carve-out, a daemon stuck rejecting handshakes (corrupted `daemon.secret` after partial auto-update swap, binary mismatch) would falsely trip the 3-in-10s `daemon.bridgeTimeouts` banner whose copy ("the background service may be busy") points the user at the wrong remediation.
+- **Reinstall vs restart remediation distinction**: handshake-stuck = binary or secret mismatch (reinstall ccsm); post-handshake hang = handler stuck or daemon thrashing (restart daemon). The `daemon.healthUnreachable` body MUST cover both — since handshake failure surfaces through the same banner, body copy reads roughly `Trying to restart it. If this persists, reinstall ccsm.` (frag-6-7 §6.1.1 owns final wording; cross-frag handoff to fixer A).
+- **`clientHelloNonce` regeneration is MANDATORY per connection attempt.** Each new socket (including every reconnect attempt under §3.7.4 backoff) MUST allocate a fresh 16-byte `crypto.randomBytes(16)` value; clients MUST NOT cache or reuse the nonce across attempts. Reuse would let a passive observer correlate reconnect storms; more importantly, the daemon's single-use-per-socket invariant (`hello_replay` rejection) would falsely fire for the second connection if the same nonce arrived. (Already implied by "per-connection challenge" but stated as MUST so a worker doesn't hoist nonce generation out of the connect loop.)
+
+On `compatible: false`, daemon does NOT close the socket immediately — the reply still carries `helloNonceHmac` (so client can rule out imposter) plus `reason` ∈ `{"wire-mismatch", "version-mismatch", "frame-version-mismatch"}` so the client can read the structured error and surface "ccsm needs to be updated" modal (frag-6-7 §6.8 surface registry) before the connection is torn down.
+
+**Wire-debug logging**: pino debug logs MAY include `clientHelloNonce` and `helloNonceHmac` fields verbatim (both are useless without the secret), but they are nonetheless on the redact list curated in **frag-6-7 §6.6 / §7.2** (entries: `daemonSecret`, `installSecret`, `imposterSecret`, `clientImposterSecret`, `*.clientImposterSecret`, `pingSecret`, `helloNonce`, `clientHelloNonce`, `helloNonceHmac`, `*.secret`) for defense in depth. There is no `imposterSecret` cleartext field anywhere in v0.3 post-r3; only `clientHelloNonce` (public, per-connection challenge issued by client) and `helloNonceHmac` (daemon's response, no secret bits leak).
+
+**Compatibility rule**: `compatible = (clientFrameVersions includes daemonFrameVersion) AND (clientProtocolVersion ≥ daemonProtocolVersion's minimum) AND (clientWire is in protocol.daemonAcceptedWires)`. Mismatch → `compatible: false` + `reason` ∈ `{"wire-mismatch", "version-mismatch", "frame-version-mismatch"}`. Client surfaces "ccsm needs to be updated" modal (frag-6-7 §6.8 surface registry); daemon does NOT close the socket immediately so the client can read both `helloNonceHmac` (rules out imposter) and `reason` (drives modal copy).
+
+**Version-bump discipline (round-3 fwdcompat P1-4)**:
+- `daemonFrameVersion` (the high-nibble of `totalLen` per §3.4.1.c) bumps **ONLY on wire-format change** (e.g. v0.3 JSON envelope → v0.4 protobuf = nibble 0x0 → 0x1).
+- `daemonProtocolVersion` (semver-major integer) bumps **ONLY on breaking handler-contract changes** (RPC removed, request/response field semantics changed). Adding a new RPC method, adding an optional field, or shipping a new optional capability MUST NOT bump `daemonProtocolVersion` — those go in `protocol.features[]`. This prevents v0.3.x from forcing a panic-bump every time a worker adds a non-breaking RPC.
+- `protocol.daemonAcceptedWires[]` lets a future v0.4 daemon accept BOTH legacy v0.3-json-envelope clients and native v0.4-protobuf clients on the same socket during the rolling-upgrade window; v0.3 daemons advertise a single-element array.
+
+**`bootNonce` propagation (round-2 fwdcompat P1-1, round-3 fwdcompat CC-2)**: the hello reply carries the daemon's current `bootNonce` (camelCase — locked across all fragments per round-3 fwdcompat CC-2; frag-6-7 §6.5 healthz uses the same camelCase spelling, NOT `boot_nonce`). Stream `subscribe` RPCs include the last-known `bootNonce` as a header (`headers["x-ccsm-boot-nonce"]`). On nonce mismatch, daemon ignores `fromSeq` and sends a fresh snapshot with `bootChanged: true`. Stream contract details (renderer divider rendering, log lines) are owned by **frag-3.5.1 / frag-3.7**.
+
+**`bootNonce` carriage precedence (round-9 manager lock — r8 envelope P0-3)** `[manager r9 lock: r8 envelope P0-3 — header + RPC-param double-carriage precedence rule]`: `bootNonce` may arrive on a subscribe RPC via either (a) the envelope header `headers["x-ccsm-boot-nonce"]` (this section, allowlisted in §3.4.1.c) OR (b) the canonical RPC param `fromBootNonce` (frag-3.5.1 §3.5.1.4 owns the param shape). The daemon MUST tolerate both forms during the v0.3 lift. Resolution rule: **if BOTH the header AND the RPC param carry a value, the header wins** (envelope-level intent takes precedence over per-method body for transport-layer semantics). **If only the header is present, the header value is used. If only the RPC param is present, the param value is used.** Daemon emits one `pino.debug({ method, headerVal, paramVal }, "boot_nonce_dual_carriage")` line (debug-only — single-source clients should pick ONE form per call site). The `x-ccsm-boot-nonce` header is reserved per §3.4.1.c; the RPC-param shape stays canonical for protobuf migration.
+
+**v0.4 / v0.5 transition**: v0.4 daemon ships with `daemonFrameVersion: 1` (protobuf), advertises `protocol.wire: "v0.4-protobuf"` plus `protocol.daemonAcceptedWires: ["v0.3-json-envelope", "v0.4-protobuf"]`, and registers BOTH `ccsm.v1/...` (legacy bridge for v0.3 clients) and `ccsm.v2/...` (protobuf-native) namespaces. v0.5 web client over CF Tunnel sets larger `headers["x-ccsm-deadline-ms"]` per call (e.g. 30000 for snapshot bootstrap; clamped 120 s per §3.4.1.c). The hello envelope itself stays at frame-version 0 in perpetuity so cross-version negotiation always succeeds.
+
+**RPC namespace evolution (round-2 fwdcompat P0-3)**: RPC method names use `ccsm.<wireMajor>/<service>.<method>`. v0.3 daemon registers ONLY `ccsm.v1/...`. A future v0.4 daemon registers BOTH `ccsm.v1/` (legacy bridge) AND `ccsm.v2/` (protobuf). Removing `ccsm.v1/` happens in v0.5 once all clients have re-handshaken to v2. Workers MUST NOT hard-code `ccsm.v1` checks anywhere outside the dispatch table — the namespace rule is the single source of truth for version-pinned routing.
+
+Cost: ~25 LOC (single new RPC `daemon.hello` + per-connection `clientHelloNonce` validation via `crypto.randomBytes(16)` on client + HMAC compute on daemon + handshake interceptor) + 2 unit tests asserting (a) `compatible: false` path returns `helloNonceHmac` + `reason` cleanly without immediate socket close and (b) bit-flipped `helloNonceHmac` rejected via `timingSafeEqual` on the client side (asserts the constant-time path is wired, not just the equality).
+
+#### 3.4.1.h Healthz transport isolation (round-2 reliability P0-R5, round-3 perf CF-1)
+
+Per §6.5, the supervisor pings `/healthz` every 5 s with 3-miss = restart. If `/healthz` shares the data adapter with a snapshot fan-out, a 1 MiB sub-chunk stream serializing through the same socket can starve the heartbeat → false-positive restart.
+
+**Rule**: the daemon binds **two separate listeners** (round-3 perf CF-1 disambiguates from frag-6-7 §6.5 supervisor transport — the `control-socket` defined here IS the supervisor `ccsm-control` socket per frag-6-7 §6.5; there are exactly TWO sockets per daemon, not three) `[manager r11 lock: P1 devx P1-2 socket name canonical = ccsm-control across both fragments; replaces prior `-sup` alias]`:
+
+| Socket | RPCs served | Consumers | Posix path | Windows path |
+|---|---|---|---|---|
+| **data-socket** | every RPC except those listed in the control row | Electron renderer (via main-process bridge) | `<runtimeRoot>/ccsm-data.sock` | `\\.\pipe\ccsm-data-<userhash>` |
+| **control-socket** (a.k.a. `ccsm-control` socket per frag-6-7 §6.5) | `/healthz`, `/stats`, `daemon.hello`, `daemon.shutdown` (frag-6-7 §6.4 step 4 graceful drain), `daemon.shutdownForUpgrade` (frag-6-7 §6.4 upgrade-in-place + marker; consumed by frag-11 §11.6.5) | supervisor process AND Electron main (parallel connections, shared posture) | `<runtimeRoot>/ccsm-control.sock` | `\\.\pipe\ccsm-control-<userhash>` |
+
+**`<runtimeRoot>` definition (round-9 manager lock cross-ref + r11 devx P1-4)** `[manager r11 lock: P1 devx P1-4 — explicit OS-native runtime root replaces hardcoded `~/.ccsm/run/...` paths; cross-references frag-12 r5 lock #2 `<dataRoot>` definition]`: `<runtimeRoot>` is the OS-native runtime/socket directory, distinct from `<dataRoot>` (logs/db/binaries):
+- **Linux**: `process.env.XDG_RUNTIME_DIR ?? <dataRoot>/run` (XDG-compliant tmpfs preferred; falls back to data root if `XDG_RUNTIME_DIR` is unset/unwritable, e.g. systemd-less containers).
+- **Windows**: named pipes namespace (`\\.\pipe\ccsm-{data,control}-<userhash>`) — no filesystem path; the `<runtimeRoot>` notation in the table cell is a notional anchor for the named-pipe form. Where a filesystem path is unavoidable (e.g. lockfile sibling), use `<dataRoot>\run\`.
+- **macOS**: `<dataRoot>/run/` (Apple does not export an `XDG_RUNTIME_DIR` equivalent; the data root sub-directory keeps socket nodes co-located with the rest of the per-user state and inherits the `<dataRoot>` ACL).
+
+`<dataRoot>` itself is defined in frag-12 (r5 lock #2): `%LOCALAPPDATA%\ccsm` (Win), `~/Library/Application Support/ccsm` (mac), `~/.local/share/ccsm` (Linux). The `<runtimeRoot>` derivation above is the single source of truth for socket / pipe paths; fragments referencing socket paths MUST cite `<runtimeRoot>` and not rehydrate `~/.ccsm/run/...` literals.
+
+Both sockets share peer-cred / DACL / accept-rate-cap / hello-handshake posture. The Electron client connects to BOTH (control for supervisor-shaped RPCs + supervisor itself, data for everything else). The supervisor connects only to `control-socket`. There is **no** third socket — `ccsm-control` is the single canonical name for the control plane shared with frag-6-7 §6.5; the prior `-sup` alias is fully retired `[manager r11 lock: P1 devx P1-2 — `-sup` literal removed in favor of `ccsm-control` everywhere; cross-frag merge no longer required]`.
+
+**Control-plane namespace carve-out (round-11 manager lock — P1 reliability daemon.stats → /stats sweep)** `[manager r11 lock: P1 reliability — explicit control-plane namespace exemption from §3.4.1.g `ccsm.<wireMajor>/...` rule]`: `/healthz` and `/stats` are **literal paths** exempt from the `ccsm.<wireMajor>/<service>.<method>` namespace prefix mandated by §3.4.1.g for all data-plane methods. They are control-plane RPCs declared in the canonical `SUPERVISOR_RPCS` constant below and dispatched on the control-socket as wire-literals (the on-wire `method` field equals `/healthz` / `/stats`, NOT `ccsm.v1/daemon.healthz` / `ccsm.v1/daemon.stats`). Consumers (control-socket dispatcher, helloInterceptor allowlist, `migrationGateInterceptor` allowlist, frag-8 §8.5 migration scope) compare these as literal strings and MUST NOT silently namespace-prefix them. Rationale also covered by the §3.4.1.h literal-vs-namespace lock paragraph below; restated here as the control-plane vs data-plane carve-out to give frag-6-7 / frag-8 a single anchor when wiring `SUPERVISOR_RPCS`.
+
+**Allowlist constant (round-3 fwdcompat P1-1)**: the set of "control-plane RPCs" is a single canonical constant `SUPERVISOR_RPCS = ["/healthz", "/stats", "daemon.hello", "daemon.shutdown", "daemon.shutdownForUpgrade"]` declared here and consumed by (a) the control-socket dispatcher (this section), (b) the `migrationGateInterceptor` (§3.4.1.f) as the short-circuit allowlist, and (c) frag-8 §8.5 migration scope. Other fragments reference the constant by name; they MUST NOT enumerate alternative lists. `[manager r7 lock: r6 packaging P0-2 — daemon.shutdownForUpgrade added to allowlist; semantics + marker file owned by frag-6-7 §6.4; consumed by frag-11 §11.6.5 upgrade-in-place flow.]`
+
+**Literal-vs-namespace lock (round-9 manager lock — r8 envelope P1-3)** `[manager r9 lock: r8 envelope P1-3 — /healthz and /stats keep HTTP-style literal method names; explicit exemption from §3.4.1.g ccsm.<wireMajor>/<service>.<method> namespace rule]`: `/healthz` and `/stats` are wire-literal method values (the on-wire `method` field equals the literal string `/healthz` or `/stats`, NOT `ccsm.v1/daemon.healthz` / `ccsm.v1/daemon.stats`). The §3.4.1.g namespace rule applies to all OTHER RPCs; these two HTTP-path-style entries are explicitly exempt because (a) they pre-date the namespace convention as supervisor heartbeat literals, (b) zero-cost dispatch on the control-socket reads the literal once, (c) supervisors / external probes can hit them without round-tripping a wire-version negotiation. The dispatch table MUST register the literal `/healthz` (no `ccsm.v1/daemon.healthz` alias). The helloInterceptor allowlist + `SUPERVISOR_RPCS` consumers compare these literals as strings; consumers MUST NOT silently namespace-prefix them.
+
+Cost: ~10 LOC of duplicated `mountConnectAdapter` call + one extra socket path + integration with the §3.4.1.g hello/HMAC handshake on both listeners. Eliminates the entire class of "slow data path back-pressures heartbeat" races. Round-2 reliability P0-R5 explicitly recommended this over a priority-queue inside one adapter.
+
+---
 
 ## Plan delta
-List concrete edits to `docs/superpowers/plans/2026-04-30-v0.3-daemon-split.md`:
-- e.g. "Task 5 (RPC adapter) gains: envelope cap (+2h), chunk logic (+3h),
-  binary frame format (+4h). New estimate: NN h."
-- New tests required (perf regression test for chunk size? unit for cap?).
-- Any new task to create.
+
+Concrete edits to `docs/superpowers/plans/2026-04-30-v0.3-daemon-split.md`:
+
+### Task 5 (Connect adapter on the local channel) — additions
+- **Step 4 add (envelope cap)**: before `JSON.parse(body)`, check **frame-version nibble first** (reject unknown with `UNSUPPORTED_FRAME_VERSION` + destroy), then mask low 28 bits, then check `len > 16 * 1024 * 1024` → emit warn (incl. `peerPid`), write `envelope_too_large` error frame, `socket.destroy()`. Pre-accept rate cap: 50/s with EAGAIN. +0.5 h.
+- **Step 4 add (binary frame format, 3.4.1.c)**: refactor `Envelope` into header (`{ id, method?, stream?, payloadType, payloadLen, traceId?, headers? }`) + optional binary trailer. Reserve high 4 bits of `totalLen` as frame-version nibble; reject unknown nibbles. Update `mountConnectAdapter` reader to split header parse from trailer slice. Update `writeEnv` to accept either `{ payload }` (JSON path) or `{ headerExtras, payloadBytes }` (binary path). Implement per-stream header-skeleton caching with **zero-padded 10-digit `seq`** + receiver fast-path + `socket.cork()`/`uncork()` per frame. +5 h (revised from +3 h per round-2 perf §6 budget concern).
+- **Step 4 add (schema validation + handler-arg discipline)**: validate header against TypeBox contract before dispatch; reject + close on violation. Validate `traceId` against Crockford ULID regex **only when present** (chunk/heartbeat sub-frames carry no traceId by design — resolved from streamId map). ESLint rule `no-handler-without-check` for handler-arg discipline. +1.5 h.
+- **Step 4 add (per-frame chunking, 3.4.1.b)**: for stream emit, split payloads >16 KiB into ≤16 KiB sub-frames sharing `streamId`, with per-stream monotonic `seq` zero-padded to 10 ASCII digits (odd ids client-initiated, even ids server-initiated; v0.3 only emits odd from client). Cache framed buffer once for fan-out (write to N sockets without re-stringify). Replay bound: ≤256 KiB before `gap: true`. Receiver-side reassembly helper in `testHelpers.ts`. +3.5 h (revised from +2.5 h).
+- **Step 4 add (interceptor pipeline, 3.4.1.f)**: `mountConnectAdapter({ interceptors: Interceptor[] })`. Ship four built-ins (trace, deadline [clamp 100 ms ≤ x ≤ 120 s + unknown-x-ccsm-* warn], migrationGate [allowlist = `SUPERVISOR_RPCS` constant from §3.4.1.h], metrics). +2 h.
+- **Step 4 add (hello HMAC handshake, 3.4.1.g — round-5 manager 2-frame lock)**: single `daemon.hello` RPC (no `helloAck`) + handshake-required interceptor + version compatibility table + `protocol.daemonAcceptedWires[]` + per-connection `clientHelloNonce` (16 random bytes generated client-side) + `crypto.timingSafeEqual` HMAC verify on the CLIENT side. Daemon computes `HMAC-SHA256(daemon.secret, clientHelloNonce)` truncated to 16 bytes and returns in `helloNonceHmac`. **Do NOT include the secret in any wire payload.** +2 h (revised from +2.5 h — one fewer frame, one fewer RPC).
+- **Step 4 add (control socket, 3.4.1.h)**: bind second listener for `SUPERVISOR_RPCS`; both sockets share peer-cred / hello-handshake posture. Reconcile naming with frag-6-7 `-sup` alias to single `ccsm-control` path. +1 h.
+- **New unit tests** in `daemon/src/transport/__tests__/connectAdapter.test.ts`:
+  - oversize envelope rejected + socket destroyed (16 MiB + 1 byte);
+  - frame-version nibble: unknown nibble (e.g. `0x1` against v0.3 daemon) rejected with `UNSUPPORTED_FRAME_VERSION` BEFORE length-cap check (asserts parse order);
+  - binary frame round-trip (PTY-shaped 64 KiB Buffer, byte-equal);
+  - schema-violation rejected (missing `id`; malformed `traceId`);
+  - traceId carve-out: `stream.kind === "chunk"` / `"heartbeat"` frames with no `traceId` ACCEPTED; chunk for unknown `streamId` rejected with `RESOURCE_EXHAUSTED`;
+  - chunked stream: 1 MiB payload arrives as N ≤16 KiB sub-chunks, in order, reassembled byte-equal; `seq` zero-padded — no fast-path fallback as `seq` crosses `9999 → 10000`;
+  - interleave: 1 MiB stream sub-chunks let a unary `ping` round-trip in <50 ms p99;
+  - interceptor order asserted (trace → deadline → migrationGate → metrics → handler); deadline clamp bounds asserted at 100 ms / 120 s;
+  - unknown `x-ccsm-foo` header → warn line emitted (rate-limited);
+  - HMAC handshake: hello-before-other-RPC required; version mismatch returns `compatible: false` + `reason` WITHOUT immediate socket close (client must read `helloNonceHmac` to rule out imposter); bit-flipped `helloNonceHmac` rejected via `crypto.timingSafeEqual` on client (assert constant-time path is wired); replay of `daemon.hello` on same socket rejected with `hello_replay`;
+  - **secret never on wire**: hex-dump capture of every byte written by client during handshake — assert the loaded `daemon.secret` byte sequence does NOT appear anywhere in the captured bytes (regression guard against a future worker reintroducing the bearer field);
+  - replay bound: client requests `fromSeq` triggering >256 KiB → daemon emits `gap: true` + snapshot;
+  - control vs data socket isolation: a saturated data socket does not delay control-socket `/healthz` p99 by >5 ms; only ONE control socket exists (no third `-sup`-suffixed listener).
+  +3.5 h (revised from +3 h).
+
+**Task 5 net delta: +19.5 h** (round-2: +18.5 h; round-3 added +0.5 h HMAC handshake + +0.5 h additional unit tests). Original ~6 h → ~25.5 h. Borderline atomic for one worker per `feedback_split_large_worker_tasks`; manager should evaluate splitting into 5a (envelope+chunk+binary) / 5b (interceptor+hello-HMAC+control-socket) phases dispatched serially in the same pool worktree.
+
+### Task 11 (Lift `ptyService` data side to daemon) — additions
+- **Step 1 add**: `subscribePty` server-stream uses 3.4.1.c binary frame for `delta` chunks (`payloadBytes = node-pty Buffer`); only `seq` + `kind` go in the JSON header (`traceId` only on `kind: "open"`).
+- **Step 1 add**: `getBufferSnapshot` streams as 3.4.1.b sub-frames (≤16 KiB each), aligned to the existing 1000-line async-chunk boundary on the daemon side. Replaces today's "collapse into one envelope" path. +2 h.
+- **Step 1 add**: `subscribePty` carries `headers["x-ccsm-boot-nonce"]` (last-known nonce); on mismatch daemon emits `bootChanged: true` + fresh snapshot. Wiring of the renderer divider (`─── daemon restarted ───`) owned by frag-3.5.1 / frag-3.7.
+- **New perf-regression test** (vitest, can run in-process via two `Duplex` streams to stand in for the socket): assert that interleaving a 5 MiB simulated snapshot with 100 unary `ping` calls keeps `ping` p99 < 50 ms. +2 h.
+
+**Task 11 net delta: +4 h** (original ~10 h → ~14 h).
+
+### Task 6 (Wire transport into daemon entry) — note only
+Add log line on adapter mount: `pino.info({ envelopeCapMib: 16, chunkKib: 16, schemaValidated: true, frameVersion: 0, protocolVersion: 1, controlSocket: true, hmacImposter: true }, "rpc_adapter_mounted")` so dogfood logs prove hardening is live.
+
+### New follow-up tasks (created post-v0.3 freeze)
+- **Task 5b (deferred, REVISED per round-2 perf §7)**: micro-benchmark spike per perf review — frame format (~2 h) + head-of-line interleaving (~2 h). **Run pre-Task 11c, in a single pool worktree, BEFORE locking the streaming envelope**. Round-1's "defer to v0.4 unless dogfood shows stutter" was reversed by round-2 perf §7 because dogfood (1-3 users, no concurrent sessions) is a weak signal for p99 wire-format latency.
+- **Task 11d (new, REVISED per round-2 perf P1-B)**: backpressure path from `xterm-headless` writes back to `node-pty` (`pause()`/`resume()` once `pendingHeadlessWrites > 500`). +1.5 h. **MUST land with Task 11** — round-2 perf escalated this from SHOULD to P1 because without it the §3.5.1.5 drop-slowest watermark cannot prevent unbounded RSS growth on a slow subscriber. The "unless time-boxed out" qualifier from round-1 is removed.
+
+### Total v0.3 estimate impact
++23.5 h on the critical path (Tasks 5 + 11), revised from +22.5 h after round-3 additions (+1 h HMAC handshake + tests). Original v0.3 = ~125 h → ~148.5 h. Manager should split Task 5 into 5a/5b phases per `feedback_split_large_worker_tasks`.
+
+---
+
+## Cross-frag rationale
+
+Round-2 reviewers raised several items where ownership was unclear between frag-3.4.1 (envelope/wire-format) and another fragment. Decisions taken below; "→ frag-X" means I left the item to that fragment's owner and trust them to handle it.
+
+| Item | Source | Decision | Rationale |
+|---|---|---|---|
+| `traceId`, `headers`, `interceptors[]` on envelope header | fwdcompat P0-1, observability P0-2, perf P0-A | **TAKE** (§3.4.1.c, §3.4.1.f) | Wire-format / data-layer is the natural owner; this is the seam that v0.4 protobuf swap and v0.5 CF Access JWT will hang off. |
+| Hello/version handshake + frame-version nibble + **HMAC challenge-response** | fwdcompat P0-2, lockin P0-1, **round-3 security P0-1**, **round-5 manager 2-frame lock** | **TAKE** (§3.4.1.g) | Handshake lives at the transport boundary; healthz body shape (which carries `bootNonce`) stays with frag-6-7 §6.5. Round-3 switched the imposter check from plaintext bearer to `crypto.timingSafeEqual`-verified HMAC over a client-issued `clientHelloNonce` so the secret never traverses the wire. Round-5 collapsed to 2 frames (was 3) aligned 1:1 with frag-6-7 §7.2: client issues nonce in frame 1, daemon proves possession in frame 2 (no third ack). Saves 1 RT on every reconnect. |
+| Frame-header parsing order (nibble → mask → cap) | round-3 security CC-1 | **TAKE** (§3.4.1.a) | Order ambiguity here resurrects either a 256 MiB DoS or a stale-client miscapture; the rule belongs at the byte-decode site. |
+| traceId optional-on-chunk/heartbeat carve-out | round-3 security CC-2 | **TAKE** (§3.4.1.c validation paragraph) | The validator regex lives at the adapter; the omission rule was already documented but the validator carve-out wasn't. Single-site fix. |
+| `bootNonce` camelCase locking | round-3 fwdcompat CC-2 | **TAKE the spelling** (§3.4.1.g hello reply); cross-frag merge worker reconciles frag-6-7 §6.5 + frag-3.5.1 + frag-3.7 to camelCase | Cosmetic but load-bearing — `boot_nonce` vs `bootNonce` drift would silently break renderer reconnect detection. Aligns with all other JSON envelope fields (`traceId`, `streamId`, `headerLen`, `payloadLen`). |
+| `x-ccsm-deadline-ms` clamp (120 s) | round-3 fwdcompat CC-3 | **TAKE** (§3.4.1.c reserved headers + §3.4.1.f deadlineInterceptor) | The clamp must be unified between header-validation and deadline-enforcement; both sites now say `100 ms ≤ x ≤ 120 s` matching frag-3.5.1 §3.5.1.3 and the v0.5 web snapshot-bootstrap headroom. |
+| `daemonAcceptedWires[]` in hello reply | round-3 fwdcompat P1-5 | **TAKE** (§3.4.1.g hello reply schema) | Saves a roundtrip during v0.3→v0.4 rolling-upgrade; v0.3 ships a single-element array, v0.4 daemons add `"v0.4-protobuf"`. |
+| `seq` zero-padding to 10 ASCII digits | round-3 perf P1-1 | **TAKE** (§3.4.1.c hot-path bullet) | Without padding, the cached header-skeleton fast path silently regresses to full `JSON.parse` after `seq=10000`. 3-LOC fix; eliminates a silent perf cliff. |
+| Feature-add vs version-bump rule | round-3 fwdcompat P1-4 | **TAKE** (§3.4.1.g version-bump discipline paragraph) | Without the rule, every new optional capability bumps `daemonProtocolVersion`, defeating semver-major's purpose. New rule: features in `daemonFeatures[]`, breaking changes only bump `daemonProtocolVersion`. |
+| Unknown `x-ccsm-*` header warn | round-3 fwdcompat P1-7 | **TAKE** (§3.4.1.c reserved-headers paragraph + §3.4.1.f deadlineInterceptor bullet) | Catches v0.3.x worker squatting on a future-reserved key before it hardens into a wire contract. Optional warn line, rate-limited. |
+| `SUPERVISOR_RPCS` allowlist constant | round-3 fwdcompat P1-1 | **TAKE** (§3.4.1.h) | Single canonical constant consumed by control-socket dispatcher, migrationGateInterceptor (§3.4.1.f), and frag-8 §8.5 migration scope. Prevents the three sites drifting on which RPCs are control-plane. |
+| Control-socket vs supervisor `-sup` socket disambiguation | round-3 perf CF-1 | **TAKE** (§3.4.1.h table) | frag-6-7 §6.5 and §3.4.1.h were ambiguous about whether they described two sockets or three. Locked to TWO total: data-socket + control-socket (= supervisor `-sup` alias). Cross-frag merge worker reconciles `-sup` literal in frag-6-7 to `ccsm-control` path. |
+| RPC namespace `ccsm.vN/...` rule | fwdcompat P0-3 | **TAKE** (§3.4.1.g) | Adapter dispatch table is the only place that enforces the namespace; documenting it elsewhere would split the rule from its enforcer. |
+| Reserved `x-ccsm-*` header keys | fwdcompat P1-2 | **TAKE** (§3.4.1.c) | Header schema is a wire-format concern; the actual deadline middleware lives in the §3.4.1.f interceptor pipeline. |
+| `streamId` allocation (odd/even) | fwdcompat P2-2 | **TAKE** (§3.4.1.b) | Stream id namespace is part of the wire contract. |
+| `traceId` validation regex + injection guard | security P1-S2 | **TAKE** (§3.4.1.c) | Adapter is the trust boundary that turns wire bytes into typed values; per-handler revalidation is wasteful. |
+| Handler-arg validation for binary trailer | security P1-S1 | **TAKE the rule** (§3.4.1.d), the per-method schemas live with each handler | Adapter cannot validate opaque bytes, but it CAN mandate the discipline + ESLint rule. |
+| Pre-accept rate cap (T15) + peer PID in oversize log | security T15, reliability S-R5 | **TAKE** (§3.4.1.a) | Both attach to the listener boundary I already own. |
+| Replay bound on resubscribe (≤256 KiB) | resource P0-1 | **TAKE** (§3.4.1.b) | Chunking semantics + `gap: true` are wire-format; the renderer divider rendering belongs to frag-3.5.1/frag-3.7. |
+| Health/data socket isolation | reliability P0-R5 | **TAKE** (§3.4.1.h) | The two-socket topology IS a wire-format change; supervisor wiring stays with frag-6-7. |
+| Subscribe RPC contract (`subscribe(sessionId, { fromSeq, fromBootNonce, heartbeatMs })`) | round-3 fwdcompat P1-2 | → **frag-3.5.1 §3.5.1.4** (canonical owner declared in §3.4.1.b) | I own only the wire-level chunking + replay-budget mechanics; field naming, defaults, clamps, protobuf message def live in frag-3.5.1. Cross-ref added so v0.4 worker reads one source. |
+| `daemon.secret` lifecycle (creation, rotation, ACL, redact) | security P0-S1 | → **frag-6-7 §7.2** | Lifecycle = installer-time generation + auto-update rotation + redact-list curation, none of which is a wire concern. I only consume the secret value in §3.4.1.g hello compare. **Round-3 update**: redact list keeps `daemonSecret`, `installSecret`, `imposterSecret`, `clientImposterSecret`, `*.clientImposterSecret`, `pingSecret`, `*.secret`, AND adds `helloNonce`, `clientHelloNonce`, `helloNonceHmac` (defense in depth — these fields are useless without the secret but redacting them costs nothing and avoids debug-log noise around handshake correlation). Single source of truth: frag-6-7 §6.6 / §7.2. |
+| `statsVersion` field placement | round-3 fwdcompat P1-3 | → **frag-6-7 §6.5** (drop from `/healthz`, keep on `daemon.stats`) | Two version cursors for one schema is a footgun; I only note the decision so frag-6-7 owner removes the duplicate. |
+| `bootNonce` field on subscribe + delta + `bootChanged` semantics | fwdcompat P1-1 | → **frag-3.5.1 + frag-3.7** | I expose `bootNonce` in hello (§3.4.1.g) and reserve `headers["x-ccsm-boot-nonce"]`; the renderer-side cache, divider, and resubscribe logic belong to the dev-workflow / stream owner. |
+| Subscriber session-token auth | security P1-S3 | → **frag-3.5.1** | `ptySubscribe` is a stream RPC owned by frag-3.5.1; I provide the `headers` carriage but the token policy is theirs. |
+| Migration env-var rename / marker schema versioning | lockin P0-3, fwdcompat P1-3 | → **frag-8** | Migration is frag-8's territory; my interceptor (`migrationGateInterceptor`) only consumes the "is migration in flight?" boolean. |
+| Modal/toast surface registry, sentence-case copy for `version_mismatch` etc. | UX P0-UX-1, P0-UX-3 | → **frag-6-7 §6.8** | I emit structured error codes; the renderer-side modal copy + stacking rules belong to the UI surface owner. |
+| Native `winjob.node` packaging / signing / ABI | packaging P0-2 | → **frag-11** | Pure build/CI concern; my adapter is JS only. |
+| pino-roll abstraction layer / `proper-lockfile` swap / `koffi` vs N-API | lockin P1-1, P1-2, P0-2 | → **frag-6-7** | Logging + native-binding ownership lives there. |
+| Reconnect-queue cap / dev-mode escalation toast / TS-error escape hatch | UX P1-UX-1, devx P1-3 | → **frag-3.7** | Renderer-side reconnect logic is frag-3.7; my replay-bound rule (§3.4.1.b) is the daemon half of the contract. |
+
+Net (round-3): **27 P0/P1 items applied here** (round-2 baseline 17 + round-3 adds 10), **9 P0/P1 items punted to other fragments**. No item was dropped; every cross-frag handoff is named above so the next reviewer can audit the boundary.
+
+---
+
+## Citations
+
+- Round-3 reviews: `~/spike-reports/v03-r3-{security,fwdcompat,lockin,perf,observability}.md`.
+- Round-2 reviews: `~/spike-reports/v03-r2-{fwdcompat,observability,perf,lockin,security,resource,reliability,devx,ux,packaging}.md`.
+- Round-1 reviews: `~/spike-reports/v03-review-{perf,security,fwdcompat,observability,lockin}.md`.
+- v1 spec already wired: `docs/superpowers/specs/2026-04-30-web-remote-design.md` §3.1.1 line 80 (envelope cap forward-reference), §3.4 (Connect protocol), §3.5 (PTY headless / snapshot path).
+- v1 plan touched: `docs/superpowers/plans/2026-04-30-v0.3-daemon-split.md` Task 5 (lines 434–620, length-prefixed envelope), Task 11 step 1 (lines 1207–1234, stream extension).

--- a/docs/superpowers/specs/v0.3-fragments/frag-3.4.1-envelope-hardening.md
+++ b/docs/superpowers/specs/v0.3-fragments/frag-3.4.1-envelope-hardening.md
@@ -1,0 +1,28 @@
+# Fragment: §3.4.1 Envelope hardening (frame cap + chunk + binary)
+
+**Owner**: worker dispatched per Task #932
+**Target spec section**: insert after §3.4 in main spec
+**P0 items addressed**: #6 (envelope cap), #7 (head-of-line), #8 (binary frame)
+
+## What to write here
+Replace this section with the actual `### 3.4.1 Envelope hardening` markdown
+that will be pasted into the main spec. Cover:
+1. **16 MiB hard cap per envelope** — reject longer; close socket; rationale
+   (DoS protection, mirrored at §3.1.1 socket level for defense in depth).
+2. **Head-of-line mitigation** — chunk PTY output frames to ≤16 KiB before
+   serialization; rationale: single Connect socket multiplexes all sessions,
+   one large frame would block all peers; cite the perf review report.
+3. **Binary frame format** — drop base64 (1.33× inflate) for PTY output;
+   use Connect's binary message support; keep JSON envelope for control
+   messages. Specify the wire format (length-prefixed binary payload +
+   small JSON header, or chosen Connect mechanism).
+
+Cite specific findings from `~/spike-reports/v03-review-perf.md` and
+`~/spike-reports/v03-review-security.md` where each requirement comes from.
+
+## Plan delta
+List concrete edits to `docs/superpowers/plans/2026-04-30-v0.3-daemon-split.md`:
+- e.g. "Task 5 (RPC adapter) gains: envelope cap (+2h), chunk logic (+3h),
+  binary frame format (+4h). New estimate: NN h."
+- New tests required (perf regression test for chunk size? unit for cap?).
+- Any new task to create.

--- a/docs/superpowers/specs/v0.3-fragments/frag-3.5.1-pty-hardening.md
+++ b/docs/superpowers/specs/v0.3-fragments/frag-3.5.1-pty-hardening.md
@@ -1,35 +1,232 @@
-# Fragment: §3.5.1 PTY hardening (orphan reap + bridge timeout)
+# Fragment: §3.5.1 PTY hardening (orphan reap + bridge timeout + stream heartbeat)
 
-**Owner**: worker dispatched per Task #940
-**Target spec section**: insert after §3.5 in main spec
-**P0 items addressed**: #2 (PTY orphan reap), #3 (bridge call timeout)
+**Owner**: Task #940 (worker, pool-2)
+**Target spec section**: insert immediately after §3.5 in `docs/superpowers/specs/2026-04-30-web-remote-design.md`
+**P0 review items addressed**: rel-M1 (PTY orphan reap, data-layer details), rel-M2 (bridge call timeout + AbortSignal), res-MUST-2 (subscriber multiplexing), res-OPEN-4 (stream backpressure under network drop).
+**Round-2 P0/P1 items applied**: rel-P0-R3 (SIGCHLD shutdown ordering + DB rows), rel-P0-R5 + obs-P0-3 (drain ordering for streams/heartbeat/fanout drop), rel-P1-R5 (per-PID waitpid scope), rel-P1-R6 (heartbeat-vs-supervisor inversion explained), pkg-P0-2 (winjob.node artifact named for frag-11), lockin-P0-2 (`NativeBinding` swap interface), lockin-P1-4 + fwdcompat-P1-2 (heartbeat negotiable), perf-P0-A/B (header cache + shared-frame fan-out), perf-P1-B (xterm-headless backpressure non-optional), perf-P1-C (shared heartbeat scheduler), res-P0-1 (replay budget on resubscribe), res-P1-3 (semaphore deadline starts after admission), res-P1-4 (aggregate per-session subscriber cap), obs-P0-2 (traceId on stream/heartbeat/drop log).
+**Inputs cited**:
+- `~/spike-reports/v03-review-reliability.md` (M1, M2, S2, F1, F9) + `~/spike-reports/v03-r2-reliability.md` (P0-R3, P0-R5, P1-R5, P1-R6)
+- `~/spike-reports/v03-review-resource.md` (MUST-FIX-2, SHOULD-FIX-2, OPEN-4) + `~/spike-reports/v03-r2-resource.md` (P0-1, P1-3, P1-4)
+- `~/spike-reports/v03-r2-perf.md` (P0-A, P0-B, P1-B, P1-C)
+- `~/spike-reports/v03-r2-observability.md` (P0-2, P0-3)
+- `~/spike-reports/v03-r2-lockin.md` (P0-2, P1-4)
+- `~/spike-reports/v03-r2-fwdcompat.md` (P1-1 boot nonce, P1-2 negotiable knobs)
+- `~/spike-reports/v03-r2-packaging.md` (P0-2 winjob.node artifact contract)
 
-## What to write here
-Replace this section with the actual `### 3.5.1 PTY child lifecycle hardening`
-markdown. Cover:
-1. **Orphan reaping on daemon crash**:
-   - Win: JobObject with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`; child ptys
-     auto-killed when daemon process handle closes. Spec the N-API path or
-     existing npm package used.
-   - Unix: process group leader; daemon SIGKILL sends to whole group on exit;
-     also handle SIGCHLD to reap zombies.
-   - Behavior on graceful shutdown vs crash: graceful = SIGTERM with grace
-     period, then SIGKILL; crash = OS-driven cleanup via JobObject/pgroup.
-2. **Bridge call timeout**:
-   - Connect client (Electron side) wraps every RPC with default 5 s deadline,
-     configurable per-call. On timeout: client surfaces `BridgeTimeoutError`,
-     does NOT auto-retry (caller decides).
-   - Stream RPCs (PTY output stream): timeout applies to first byte / heartbeat
-     interval, not whole stream. Spec the heartbeat interval (e.g. 30 s).
-   - Daemon side: per-RPC timeout enforced by handler; runaway handler killed.
+**Boundary vs frag-6-7 §6.2**: §6.2 specifies the *supervisor-level* contract — what the OS does when daemon dies (`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` on Win, `setpgid`+`PR_SET_PDEATHSIG` on POSIX) and the dogfood acceptance test. This §3.5.1 specifies the *data-layer* mechanics: which npm/N-API binding implements it, exact SIGCHLD wiring inside `ptyService`, the bridge-call timeout middleware, stream RPC heartbeat, AbortSignal threading, and subscriber fan-out semantics. Cross-ref §6.2 from §3.5.1 for the orphan-reap acceptance criterion; do not restate.
 
-Cite findings from `~/spike-reports/v03-review-reliability.md` and
-`~/spike-reports/v03-review-resource.md`.
+---
+
+## 3.5.1 PTY child lifecycle hardening
+
+The data-layer addendum to §3.5. §3.5 makes the daemon authoritative for PTY buffers; §3.5.1 makes the daemon authoritative for PTY *processes* (no leaks on crash) and makes every cross-process call *bounded in time* (no infinite hangs).
+
+### 3.5.1.1 Win JobObject wiring (data layer)
+
+Per §6.2, every `pty.spawn()` is enclosed in a `JobObject` with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. Implementation choice for v0.3:
+
+- **Native binding**: in-tree N-API helper module at `daemon/native/winjob/` (~120 LOC C++, single `.node`). Calls `CreateJobObjectW` → `SetInformationJobObject(JobObjectExtendedLimitInformation, { BasicLimitInformation: { LimitFlags: JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE | JOB_OBJECT_LIMIT_BREAKAWAY_OK } })` → `AssignProcessToJobObject(job, child.pid)`. Exposes `winjob.create(): handle` and `winjob.assign(handle, pid): void`.
+- **Built artifact name (P0 packaging contract)**: build emits **exactly** `daemon/native/<platform>-<arch>/ccsm_native.node` (single .node carrying the `winjob` + `pdeathsig` + `pipeAcl` exports — see §3.5.1.1.a swap interface; **see frag-11 §11.4 for build wiring** — `binding.gyp`, `node-gyp rebuild`, codesign loop, `pkg.assets`, before-pack existence check). Per-platform stagings are:
+  - `daemon/native/win32-x64/ccsm_native.node`
+  - `daemon/native/linux-x64/ccsm_native.node` (PR_SET_PDEATHSIG branch; winjob exports throw `ENOSYS`)
+  - `daemon/native/darwin-arm64/ccsm_native.node` (no-op stub branch; winjob/pdeathsig exports throw `ENOSYS`)
+  Frag-11 §11.1 / §11.2 MUST list **`ccsm_native.node`** explicitly in `pkg.assets`, in `before-pack.cjs` existence check, in `rebuild-native-for-node.cjs` (which must `node-gyp rebuild` inside `daemon/native/winjob/`), and in the per-`.node` codesign/signtool loop. The artifact name `ccsm_native.node` is the canonical contract referenced by frag-11 — do not rename without coordinated frag-11 amendment.
+- **Why in-tree, not npm**: surveyed candidates — `windows-process-tree` (read-only, no JobObject), `node-windows` (service-mgmt focus), `winapi-bindings` (unmaintained 2019). Closest match `node-job-object` is single-author, last release 2017, no prebuilt binaries. Rolling our own is ~120 LOC, zero transitive deps, reuses the same `node-gyp` toolchain already required by `better-sqlite3` and `node-pty`. Same precedent as the §7.M1 named-pipe ACL helper (frag-6-7 §6.4). **One native helper module (`ccsm_native.node`), three features (winjob, pdeathsig, pipeAcl).**
+- **Lifetime**: `winjob.create()` is called once at daemon boot. The handle is held in a module-level `let jobHandle` inside `daemon/src/pty/winjob.ts`. Every `ptyService.spawn()` calls `winjob.assign(jobHandle, child.pid)` immediately after `node-pty` returns. Handle is never closed during normal operation; OS closes it when the daemon process exits, which is the trigger for `KILL_ON_JOB_CLOSE`.
+- **Breakaway**: `JOB_OBJECT_LIMIT_BREAKAWAY_OK` is set so that a child CLI process can spawn its own grandchildren outside the job if it explicitly requests breakaway (`CREATE_BREAKAWAY_FROM_JOB`). No grandchild created by the `claude` CLI today does this; flag is defensive.
+- **Nested-job edge case (Win 8+)**: nested jobs are allowed since Win8, so if Electron itself is in a job (rare; only when launched via `runas` or some MDM tooling), the daemon's job becomes a nested child and `KILL_ON_JOB_CLOSE` still cascades. Verified semantics, no special handling needed.
+
+### 3.5.1.1.a Native binding swap interface (lockin-P0-2)
+
+All call sites go through a TypeScript interface, never the raw `.node` exports:
+
+```ts
+// daemon/src/native/index.ts — single import seat for every native call
+export interface NativeBinding {
+  winjob: { create(): JobHandle; assign(h: JobHandle, pid: number): void };
+  pdeathsig: { armSelf(signal: number): void };  // POSIX/Linux only; throws ENOSYS elsewhere
+  pipeAcl: { applyOwnerOnly(pipeName: string): void };  // Win only; ENOSYS elsewhere — used by frag-6-7 §7.M1
+}
+
+export const native: NativeBinding = loadBinding();  // dispatches by process.platform; resolves ccsm_native.node
+```
+
+- Implementations live in `daemon/src/native/impl/napi.ts` (default — wraps `ccsm_native.node`) and a future `daemon/src/native/impl/koffi.ts` (deferred). Swap is a single-file edit in `daemon/src/native/index.ts`'s `loadBinding()`.
+- **No call site in `daemon/src/pty/**` or `daemon/src/socket/**` may import `ccsm_native.node` directly.** Lint rule `no-direct-native-import` (custom ESLint rule, +0.5h Task 11) flags any `require('../native/ccsm_native.node')` or equivalent outside `daemon/src/native/impl/`.
+- **Vendor-risk acknowledgement**: the in-tree binding has a single maintainer (us). Recompile cost per Node major bump ≈ 2h (rebuild + CI matrix verify); swap-to-`koffi` cost if the in-tree path is abandoned ≈ 8h (re-implement three ops behind the same interface). Frag-7 supply-chain table MUST carry this row.
+- **Decision deferred to v0.3 dispatch**: confirm `koffi` posture before Task 11 dispatch (still active 2026-04-30? prebuilt binaries for win32-x64/linux-x64/darwin-arm64?). If `koffi` clears the bar the in-tree N-API path can be skipped entirely; the `NativeBinding` interface keeps either choice cheap.
+
+### 3.5.1.2 POSIX process group + SIGCHLD wiring (data layer)
+
+Per §6.2, each `pty.spawn()` calls `setpgid(0, 0)` in the child (via node-pty's `cwd`/env wrapper is insufficient — we need a `posix_spawnp` attribute or a manual `setpgid` call right after spawn from the parent). Implementation:
+
+- **`setpgid` source**: node-pty already calls `setsid()` in its forkpty path on POSIX, which makes the child a session leader and a pgroup leader (pgid == child pid). No additional `setpgid` call needed; verified by reading `node-pty/src/unix/pty.cc`. We rely on `setsid()` and record `pgid = child.pid` in `ptyService` state.
+- **Linux PDEATHSIG**: in addition, daemon sets `PR_SET_PDEATHSIG = SIGTERM` via `native.pdeathsig.armSelf(SIGTERM)` from inside the child between `fork` and `execve` (delivered through node-pty's spawn hook). On daemon death, the kernel signals each PTY child with SIGTERM. Followed up by group-SIGKILL on next supervisor cycle if any child survives the grace period.
+- **macOS parent-watch**: no PDEATHSIG analogue. Use kqueue with `EVFILT_PROC | NOTE_EXIT` registered on `getppid()` from a small thread inside the in-tree helper, OR — simpler and chosen for v0.3 — rely on the supervisor (frag-6-7 §6.1) detecting daemon exit and `kill(-pgid, SIGKILL)` for every recorded pgid as part of cold-restart cleanup. macOS dogfood is not yet a v0.3 ship target (per project memory: Win 11 25H2 is the lock); macOS path documented but not blocking.
+- **SIGCHLD handler (graceful path) — per-PID scope (rel-P1-R5)**: daemon installs `process.on('SIGCHLD', reapZombies)` once at boot, BEFORE the first `pty.spawn()`. `reapZombies` iterates over the `pid → sessionId` map and calls `waitpid(pid, WNOHANG)` per known PID — **NOT** `waitpid(-1, WNOHANG)`. Per-PID scope avoids stealing reaps from any future transitive dep that spawns its own child (logger, telemetry) and expects to reap it itself. For each successfully reaped pid, looks up the session and emits `ptyExit({ sessionId, exitCode, signal, traceId: session.spawnTraceId })` on the session's fan-out. This is the *only* path that produces `ptyExit` events on POSIX; node-pty's own `onExit` is replaced with a no-op JS shim to avoid double-reaping (the two would race and one always loses the exit code). Worker MUST grep node-pty's source to confirm the `onExit` JS shim does not break internal cleanup; if it does, contract becomes "both fire, daemon dedupes by `(pid, exitCode)`".
+- **Daemon shutdown sequence (rel-P0-R3 + obs-P0-3 — REPLACES old "deregister-then-shutdown" path)**: the prior text was wrong — deregistering SIGCHLD before group-SIGTERM lost exit codes for children dying in the window between deregister and the explicit waitpid loop. New ordered sequence, owned by `daemonShutdown` RPC (Task 21):
+
+  1. `daemonState = 'draining'`. Reject new `pty.spawn()` and new `ptySubscribe` calls with `RESOURCE_EXHAUSTED { reason: 'daemon-shutdown' }`.
+  2. Inside one DB transaction: `UPDATE sessions SET state = 'shutting_down' WHERE state = 'running'`. This makes the on-disk truth match the in-flight intent BEFORE any signals fly.
+  3. Cancel the **shared heartbeat scheduler** (§3.5.1.4) and clear all per-stream `lastWriteAt` entries. No new heartbeat envelopes after this point.
+  4. Iterate the fan-out registry once: close each subscriber stream with `RESOURCE_EXHAUSTED { reason: 'daemon-shutdown' }`. Aggregate to **one** structured log line `subscribers_closed_on_shutdown { count, droppedBytes_total }` — not N drop lines (obs-P0-3).
+  5. Drain the per-stream replay-budget counter to ensure no replay write is mid-flight; queued snapshot semaphore waiters are rejected with `CANCELLED` (one log line, count aggregated).
+  6. SIGCHLD handler is **left registered**. Issue group-SIGTERM to each recorded pgid. SIGCHLD continues to deliver `ptyExit` events normally; sessions whose children exit cleanly are marked `state = 'exited'` with their actual `exitCode`.
+  7. Per-child wait cap: 200 ms (tightened from 500 ms per perf-vibes-table feedback — typical PTY child SIGTERM-to-exit is sub-10 ms; 200 ms × 20 sessions = 4 s worst-case shutdown, vs 10 s with 500 ms). After the cap, SIGKILL the surviving pgroups.
+  8. Final waitpid sweep with WNOHANG. Survivors past the SIGKILL deadline (kernel-zombie or unresponsive) are marked `state = 'paused'` in one final DB transaction (see frag-6-7 §6.3 — canonical state name is `paused`, NOT `abandoned`; the term changed because next-boot recovery treats them as resumable, not orphaned). This row state is what frag-6-7 §6.3 next-boot detection reads. **The transition MUST be `UPDATE sessions SET state='paused', pid_pgid=NULL WHERE state='shutting_down'`** `[manager r7 lock: r6 reliability P1-R4 mirror — explicit WHERE state='shutting_down' clause mirrors frag-6-7 §6.6.1 step 4. Without the WHERE guard, a child that clean-exits between the 200 ms cap and the SIGKILL deadline could land BOTH 'exited' (from the SIGCHLD handler step 6 above) AND 'paused' (from this sweep); the WHERE guard makes the sweep idempotent and order-independent against the SIGCHLD-clean-exit vs SIGKILL-deadline race.]` On respawn, `pid` and `pgid` columns MUST be cleared (set NULL) atomically with the state transition so stale OS identifiers from the dead daemon never get re-signalled (this is the same `pid_pgid=NULL` clause shown above).
+  9. `PRAGMA wal_checkpoint(TRUNCATE)`; `db.close()`. (Frag-6-7 §6.6 should restate this from the DB side — coordinate.)
+  10. `pino.final` flush (frag-6-7 §6.6). Now `process.exit(0)`.
+
+  This sequence guarantees: (a) no on-disk row ever lies (every `running` row transitions through `shutting_down → exited|paused`); (b) the SIGCHLD handler is never deregistered prematurely, so exit codes are not lost; (c) drain ordering prevents the last 60 s of heartbeat/drop forensics from being randomly truncated.
+
+- **Win parity**: Windows has no SIGCHLD. PTY exit is observed via node-pty's `onExit` (which polls `GetExitCodeProcess`) and is unchanged from v0.2. JobObject covers crash-cleanup; `onExit` covers normal exit reporting. The shutdown sequence above runs identically except step 6 issues `TerminateJobObject(jobHandle)` instead of group-SIGTERM, and the 200 ms / SIGKILL escalation becomes `TerminateProcess` per child.
+
+- **Spawn traceId for daemon-originated events (obs OPEN q3)**: every successful `pty.spawn()` allocates `spawnTraceId = ulid()` and stores it on the session row. All daemon-originated PTY events (`ptyExit`, `subscriber-dropped-slow`, `pty.spawn.failed`) carry this traceId so spawn → exit log lines correlate without an upstream RPC traceId.
+
+### 3.5.1.3 Bridge call timeout + AbortSignal threading
+
+Every Connect RPC invoked by Electron's bridge layer (`electron/preload/bridges/*` → `daemonClient`) is wrapped in a deadline. Default and threading rules:
+
+- **Default deadline: 5s for unary RPCs.** Tighter than rel-M2's 30s suggestion. Rationale: 5s is well above local-pipe p99 (Task 7 acceptance benchmark targets p95 < 5ms) and well below the perceived-hang threshold for an interactive UI. 30s is a *supervisor* timeout (frag-6-7 §6.1, three 5s heartbeat misses); a *bridge* timeout that high would let the user wait 30s on every dead-daemon click.
+- **Per-call override**: `daemonClient.call(method, req, { timeoutMs: number, signal: AbortSignal })`. Long-running RPCs (e.g. `getBufferSnapshot` for a session with full 10k scrollback, see res-SHOULD-2) override to 30s. Override list is centralized in `electron/daemon/timeouts.ts` so reviewer can audit.
+- **Per-call header overrides (fwdcompat-P1-2 reservation)**: caller may also set `headers["x-ccsm-deadline-ms"]` directly on the envelope. v0.3 honors it (clamped to 100 ms ≤ x ≤ 120 s); reserved sibling keys `x-ccsm-heartbeat-ms` and `x-ccsm-backpressure-bytes` are accepted-and-ignored in v0.3 (squat-prevention so v0.5 web client can begin sending them). Reserved-header namespace lives in frag-3.4.1 §3.4.1.c — coordinate.
+- **AbortSignal threading**: caller-supplied `AbortSignal` is OR-merged with the deadline-derived signal via `AbortSignal.any([userSignal, AbortSignal.timeout(timeoutMs)])` (Node 20+). The merged signal is passed to Connect's `CallOptions.signal`. Connect's own implementation translates abort to an HTTP/2 RST_STREAM with `CANCELLED` code, which the daemon-side handler observes via its own `signal.addEventListener('abort', ...)`. Handlers MUST check `signal.aborted` at every `await` boundary inside long ops; lint rule `no-floating-cancellation` (custom ESLint rule, +0.5h Task 5) flags handlers that take `signal` but never read it.
+- **Timeout error surface (devx-CF-3 correction)**: on deadline, client throws `BridgeTimeoutError extends Error` with `{ code: 'DEADLINE_EXCEEDED', method, timeoutMs, traceId }`. **`BridgeTimeoutError` is never user-surfaced; the bridge retries once internally; if still failing, status surfaces via the surface-registry (frag-6-7 §6.8) `'reconnecting'` slot. Caller never sees `DEADLINE_EXCEEDED` directly** — the renderer reads the surface-registry slot and renders unified reconnecting UX, so per-caller retry policy is a non-concern. Supervisor-level `daemon-unhealthy` event (frag-6-7 §6.1) is emitted *in parallel* to a timeout if 3+ consecutive RPCs deadline within 10s — separate signal, separate consumer.
+- **Daemon-side enforcement**: each handler wraps its body in `await Promise.race([handler(req, signal), abortPromise(signal)])`. `abortPromise` resolves on `signal.aborted` and the handler's own promise is left to resolve later (its result is discarded, but the handler is responsible for propagating abort to any sub-RPCs). Runaway handlers (e.g. an SDK call that ignores abort) are NOT killed at the process level in v0.3 — that would require a worker-thread sandbox, deferred to v0.4. v0.3 logs a `handler-leaked-after-abort` warning at 30s post-abort with `{ method, traceId, durationMs }` AND increments counter `handler.leaked.count` (silent log warns rot — surfaceable metric).
+
+### 3.5.1.4 Stream RPC heartbeat + dead-stream detection
+
+`ptySubscribe`, `subscribeNotifications`, and `subscribeSessionUpdates` are server-streaming RPCs. The 5s unary deadline does NOT apply to the stream as a whole; it applies only to *first byte* (stream open). After open:
+
+- **Default heartbeat interval: 30s; default dead-stream detection: 65s** (60s + 5s skew slop). Daemon emits a `{ kind: 'heartbeat', ts, traceId, bootNonce }` envelope on every server-stream every `heartbeatMs` if no real data has been sent in that window. Cheap (~50 bytes). `traceId` carries the subscribe-time traceId so dead-stream logs link back to the originating subscribe call (obs-P0-2). `bootNonce` matches frag-6-7 §6.5 healthz nonce — client uses it to detect daemon respawn (fwdcompat-P1-1).
+- **Negotiable per subscribe (lockin-P1-4 + fwdcompat-P1-2)**: every server-streaming subscribe RPC accepts an optional `{ heartbeatMs?: number }` param (e.g. `ptySubscribe(sessionId, { fromSeq, fromBootNonce?, heartbeatMs? })`). Daemon clamps to `5_000 ≤ heartbeatMs ≤ 120_000` and uses it for that stream's heartbeat cadence. Default 30 s; v0.5 web on flaky 4G can request 10 s. Client's dead-stream window = `2 × heartbeatMs + 5_000` skew. Acceptance: subscribe with `heartbeatMs: 5000` and assert heartbeat envelope cadence within 5 s ± 1 s.
+- **Boot nonce on subscribe (fwdcompat-P1-1)**: client passes `fromBootNonce` (the nonce it last saw on a delta or heartbeat from this daemon). On mismatch, daemon **ignores `fromSeq`**, sends `{ kind: 'bootChanged', bootNonce, snapshotPending: true }`, and follows with a fresh snapshot from seq 0. Client renders a `─── daemon restarted ───` divider analogous to `─── stream gap ───`. This prevents the silent-replay-of-phantom-bytes bug across daemon respawns.
+- **Per-stream subscribe authorization (sec-P0-2 deferral)**: in v0.3, `ptySubscribe` / `subscribeNotifications` / `subscribeSessionUpdates` rely solely on the connection-level shared-secret handshake from frag-6-7 §7.4 (no per-stream token). This is **ACCEPTED** for v0.3 (see frag-6-7 §7.4 — connection-level secret + named-pipe / unix-socket ACL gate at the OS-user boundary; v0.3 ships with a single trusted Electron renderer). v0.5 will add a per-stream subscribe token (capability-style); the subscribe RPC param shape is **owned by §3.5.1** so the v0.5 token field will be added here without breaking the wire format. Cross-ref: frag-3.4.1 §3.4.1.b consumes this subscribe RPC shape; the canonical definition (param names, optional fields, server-side acceptance contract) lives here in §3.5.1.4.
+- **Why default 30s / 2-miss is slacker than supervisor's 5s × 3-miss = 15s (rel-P1-R6)**: stream heartbeat is **intentionally** slacker than supervisor heartbeat so a real daemon death surfaces via supervisor-level `daemon-unhealthy` IPC FIRST. Stream-dead detection is the slow-path catch-all for the rare case of a hung handler that's not crashing the daemon process (handler stuck in a non-abort-honoring SDK call). If the inversion ever flipped (stream-dead < supervisor-dead) the user would see a transient "stream dropped" toast on every supervisor-detected restart, which is noise. Document the inequality `streamDeadMs > supervisorDeadMs` as an invariant.
+- **Shared heartbeat scheduler (perf-P1-C)**: implementation is **one** daemon-wide scheduler tick (e.g. every 1 s) that walks `Map<streamId, { lastWriteAt, heartbeatMs }>` and emits a heartbeat for any stream where `now - lastWriteAt ≥ heartbeatMs`. NOT a per-stream `setInterval`. With 100 sessions × 10 writes/s the per-`setInterval` reset cost was 1000 ops/s on the timer heap; shared scheduler is one tick/s plus a hash-table iteration. Saves ≥ 95 % timer pressure at scale. Shutdown sequence step 3 (§3.5.1.2) cancels this single scheduler.
+- **Server-side dead-client detection**: daemon's writable side detects client gone via socket-level `'error'` / `'close'` events on the underlying Node HTTP/2 stream — same path Connect-Node already uses. No application-layer ping required from client to server in v0.3 (unary RPCs already exercise the channel; if all are silent for 60s the supervisor heartbeat is what surfaces dead-daemon, not dead-client). On a stuck client whose OS socket buffer is full, the daemon's heartbeat write itself returns `writable === false` and trips drop-slowest (§3.5.1.5) — meaning the **actual** dead-client mechanism is heartbeat-write-failure, not the 65 s client-side timeout (which is fallback for "stuck reader, healthy network"). Server-side stream-dead detector spec'd in frag-6-7 §6.5.1 (`2 × heartbeatMs + 5 s` symmetric, no-op on v0.3 local pipe, byte-compatible with v0.5 CF Tunnel TCP). `[manager r7 lock: r6 reliability P0-R2 cross-frag handoff — symmetric server-side detector at 2 × heartbeatMs + 5 s lives in frag-6-7 §6.5.1; covers the v0.5 half-open TCP case where heartbeat-write-failure may not fire for hours.]`
+- **Snapshot RPC is unary, not stream**: `getBufferSnapshot` returns a single (large) message, not a stream. Subject to unary timeout override (30s, see §3.5.1.3). The chunked-yield in `lifecycle.ts:151` is internal to the handler and does not produce stream frames.
+
+### 3.5.1.5 Subscriber fan-out (multi-subscriber semantics)
+
+Closes res-MUST-2. The daemon MUST NOT keep per-subscriber backlog. Spec contract:
+
+- **Single fan-out registry per session**: lifted directly from existing `electron/ptyHost/dataFanout.ts`. Each `ptySubscribe` call registers a callback on the session's `Set<Subscriber>`; PTY data hits each callback synchronously in registration order, wrapped in try/catch so one slow subscriber cannot poison others.
+- **Per-subscriber state == OS socket send buffer only.** ~64 KB on Win named pipes, ~256 KB default on POSIX unix sockets. No application-layer queue per subscriber.
+- **Shared framed buffer per chunk (perf-P0-B)**: for each PTY chunk, the daemon **frames once** (constructs the binary envelope `[totalLen][headerLen][headerJSON][payloadBytes]` exactly once; cached header skeleton patches only the `seq` and `payloadLen` bytes per perf-P0-A) and calls `socket.write(sharedBuffer)` per subscriber. Per-subscriber stringify is forbidden — re-stringifying the same header N times for N subscribers is what perf-P0-B was flagging. Frag-3.4.1 §3.4.1.c is the canonical owner of the framed-buffer construction; this section just enforces "build once, write N times". Coordinate with §3.4.1 — the cached-header skeleton lives there, the fan-out call site here MUST consume it.
+- **Microtask yield between subscribers**: with N ≥ 4 subscribers, the synchronous fan-out loop yields via `queueMicrotask` after each subscriber's write to avoid blocking the daemon event loop for the duration of all N writes (relevant when N reaches v0.5's web fan-out scale; v0.3 N = 1 so this is no-op). Documented seam, not v0.3 hot path.
+- **Backpressure ≤ 1 MB / drop-slowest**: each subscriber callback writes synchronously to its Connect server-stream. If the underlying socket reports `writable === false` (Node Stream high-water-mark hit), the subscriber's writes accumulate in *Connect's own* per-stream buffer up to 1 MB. Past 1 MB, the subscriber is flagged `slow`, removed from the registry, its stream closed with `RESOURCE_EXHAUSTED`, and a `subscriber-dropped-slow` log line is emitted with `{ sessionId, subscriberId, droppedBytes, ageMs, traceId, spawnTraceId }` (obs-P0-2: traceId on the drop log). Client receives the close, treats it as a transient drop, and re-subscribes via `ptySubscribe(sessionId, { fromSeq: lastSeenSeq, fromBootNonce })` — same resume contract as §3.5.
+- **Aggregate per-session subscriber cap (res-P1-4)**: independent of per-subscriber 1 MB watermark, the **total** transient buffer across all subscribers on one session is capped at `min(N_subscribers × 1 MB, 4 MB)`. When the aggregate cap hits, the **oldest-slowest** subscriber is dropped first (LRU on `last-successful-write-ts`). Rationale: at v0.5 fan-out (10 slow web subscribers) this prevents 10 × 1 MB = 10 MB transient per session × 20 sessions = 200 MB unbounded growth. v0.3 ships with N = 1 so the cap never trips; the seam is reserved so v0.5 doesn't need to re-open §3.5.1.
+- **Replay budget on reconnect (res-P0-1) — orthogonal to 1 MB watermark**: when a subscriber re-subscribes with `fromSeq`, the replay payload is **bounded at 256 KB**. If the headless ring contains more than 256 KB beyond `fromSeq`, daemon ships the most recent 256 KB and sets `gap: true` on the first replay envelope. **Clarification (perf-CF-2)**: the 256 KB ceiling is a *per-replay message hard limit* (one-shot, payload size at the moment of resubscribe); the 1 MB drop-slowest watermark is a *per-second steady-state flow rate cap* on the per-subscriber Connect buffer. They measure different things and operate on different time scales — neither subsumes the other. The replay payload is delivered as **one initial write that does NOT count against the slow-subscriber accounting** (the 1 MB drop-slowest watermark is measured AFTER the replay burst is delivered — replay-burst exemption). Without this exemption, a nodemon dev save-storm with 5 sessions producing 100 KB/s could exceed 1 MB on the first post-reconnect frame, drop the stream as slow, re-resubscribe, loop. Frag-3.7 §3.7.5 must reference this clamp (cross-frag coordination).
+- **Why drop-slowest, not block-everyone**: blocking the fan-out on the slowest subscriber (Cloudflare Tunnel client on flaky WiFi, v0.5) would stall the desktop subscriber on the same machine. Drop-slowest preserves the desktop UX at the cost of forcing the slow client to resume from `fromSeq`, which is cheap (the seq replay in §3.5 is exactly what makes this safe).
+- **Fairness vs starvation**: drop-slowest is fair within a session but cannot starve a session entirely as long as at least one subscriber is healthy (the data is *sent* on every subscribe; only writes to slow subscribers are dropped). If all subscribers are slow, the fan-out callback returns immediately on each (writes are buffered in OS socket queues that already overflowed), PTY input continues to fill xterm-headless buffer, and seq advances normally. New `ptySubscribe(fromSeq)` later replays from the headless buffer.
+- **Bounded snapshot concurrency**: per res-SHOULD-2, daemon enforces a semaphore of 4 concurrent `getBufferSnapshot` invocations (any session, any caller). Excess wait. Prevents N × MB transient-string allocation when a v0.5 dashboard subscribes to all sessions on cold open.
+- **Snapshot deadline starts after admission (res-P1-3)**: the per-call 30 s unary override deadline (§3.5.1.3) for `getBufferSnapshot` starts AFTER the semaphore admits the call, NOT at handler entry. A separate counter `snapshot.semaphore.waitMs` is logged on admission so the user-perceived hang on a v0.5 dashboard cold-open shows up as semaphore wait (not handler runtime). Bridge client surfaces semaphore-wait phase via a structured `{ phase: 'queued', queuedMs }` event so the renderer can show "queued" UI rather than "loading".
+- **xterm-headless backpressure to node-pty (perf-P1-B)**: when the headless ring's pending-write queue exceeds 500 entries, daemon calls `pty.pause()` on the underlying node-pty handle; resumes when pending falls below 100. This is the only thing that prevents unbounded RSS growth on a noisy session with all-slow subscribers (drop-slowest at 1 MB caps Connect-side buffer but not the headless ring itself). **This item is non-optional** (perf-P1-B explicitly removes the prior "lands unless time-boxed out" qualifier — it is a P0 reliability item dressed as perf SHOULD).
+
+### 3.5.1.6 Acceptance criteria (data-layer, complement to §6.2 supervisor-layer)
+
+- Unit: `winjob.create()` + `winjob.assign(job, fakePid)` round-trip; `assign` of dead pid throws `EINVAL`. Native binding accessed only through `daemon/src/native/index.ts`; lint `no-direct-native-import` passes on full daemon tree.
+- Unit: SIGCHLD handler reaps a synthetic forked child within 50ms via `waitpid(pid, WNOHANG)` (per-PID, not `waitpid(-1)`) and emits exactly one `ptyExit` event with `spawnTraceId` populated; second `waitpid` for an unrelated pid returns 0 (no double-reap).
+- Unit: shutdown sequence on a daemon with 3 running PTY sessions transitions DB rows `running → shutting_down → exited` in order; SIGCHLD remains registered throughout; no exit codes lost.
+- Unit: `daemonClient.call('echo', {}, { timeoutMs: 50 })` against a handler that `await new Promise(()=>{})` rejects with `BridgeTimeoutError` after 50ms ± 10ms; merged AbortSignal fires; counter `handler.leaked.count` increments after 30 s.
+- Unit: subscribe with `{ heartbeatMs: 5000 }` observes heartbeat cadence 5 s ± 1 s; subscribe without override observes 30 s.
+- Unit: `subscribePty` with a synthetic slow subscriber (writes block) is dropped after exactly 1 MB of buffered output; healthy second subscriber receives every byte; aggregate cap with N=5 slow subscribers drops oldest-slowest first.
+- Unit: re-subscribe with `fromSeq` past the 256 KB clamp receives `gap: true` and last 256 KB only; fan-out drop-slowest accounting starts AFTER the replay write.
+- Unit: re-subscribe with mismatched `fromBootNonce` receives `bootChanged: true` and snapshot from seq 0.
+- Unit: header skeleton is constructed once per chunk in fan-out path; perf assertion = `JSON.stringify` call count per chunk = 1 regardless of subscriber count.
+- Integration: 30s heartbeat observed on idle stream; client closes after 65s of silence with synthetic broken socket; aggregated `subscribers_closed_on_shutdown` log line emitted exactly once on `daemonShutdown`.
+- E2E reverse-verify (cross-ref §6.2 acceptance): kill daemon mid-stream → no orphan `claude.exe`; client receives stream close with RESOURCE_EXHAUSTED or transport error; on respawn + resubscribe, replay from `fromSeq` (with `bootChanged: true` since nonce flipped) resumes.
+
+---
 
 ## Plan delta
-- Task 11 (PTY service) gains: JobObject/pgroup wiring (+3h), reaping tests
-  (+2h). New estimate: NN h.
-- Task 5 or 7 (RPC adapter / bridge client) gains: timeout middleware (+2h),
-  heartbeat for stream RPCs (+2h).
-- New test cases: kill-daemon-and-check-no-orphan-pty (Win+Unix); RPC
-  timeout regression.
+
+Specific edits to `docs/superpowers/plans/2026-04-30-v0.3-daemon-split.md`. Several lines OVERLAP with frag-6-7's plan delta — those overlaps are *the same lines*, not duplicate hours. Final hour totals must be reconciled at fragment merge by additive de-dup. **Round-2 reconciliation (res-P1-1)**: this fragment's Task 11 explicitly DROPS the N-API binding hours (already in frag-6-7's +4h Task 11 for "JobObject + setpgid + PR_SET_PDEATHSIG") and keeps only data-layer wire-up.
+
+- **Task 1** (daemon workspace skeleton, +1h NEW vs frag-6-7): scaffold `daemon/native/` directory with `binding.gyp` skeleton emitting `ccsm_native.node` and `daemon/src/native/index.ts` exporting the `NativeBinding` interface (§3.5.1.1.a). `node-gyp rebuild` runs in CI on all three platforms; placeholder native fns return `0`.
+- **Task 5** (Connect adapter, +3h NEW): bridge-call timeout middleware (5s default), `AbortSignal.any` merge of caller signal + deadline, `BridgeTimeoutError` class, per-method override map, `x-ccsm-deadline-ms` header parsing (clamp 100 ms..120 s), reserved sibling header keys squat-prevention, `handler.leaked.count` counter, custom ESLint rule `no-floating-cancellation`. Reviewer acceptance: every handler in `daemon/src/handlers/` either ignores `signal` (allowlisted, e.g. `healthz`) or has at least one `signal.throwIfAborted()` / `signal.aborted` read.
+- **Task 5** (also, +2h NEW): **shared** stream-heartbeat scheduler — `streamHeartbeatRegistry` with one daemon-wide tick walking `Map<streamId, {lastWriteAt, heartbeatMs}>` (perf-P1-C); `streamWithHeartbeat(stream, opts)` registers/unregisters; honours per-subscribe `heartbeatMs` override (clamped); emits envelope with `traceId + bootNonce` (obs-P0-2 + fwdcompat-P1-1). Client-side dead-stream detector in `electron/daemon/streamClient.ts` reads `heartbeatMs` echoed in the stream-open response so window = `2x + 5s` is consistent.
+- **Task 7** (Electron handshake e2e, +1h NEW): bridge-timeout regression test (kill daemon, assert `BridgeTimeoutError` within 5s ± 100ms); `bootChanged` divider rendered on respawn-resubscribe. Reuses §7.4 imposter-secret negative-test harness.
+- **Task 11** (lift `ptyService` data side, +2h NEW; reduced from prior +5h per res-P1-1; the N-API helper hours live in frag-6-7's Task 11 +4h; this task covers ONLY the data-layer wire-up):
+  - Wire `winjob.assign(jobHandle, child.pid)` into `ptyService.spawn()` Win branch via `native.winjob` (+0.5h).
+  - Replace node-pty's `onExit` with daemon-owned per-PID SIGCHLD handler (`waitpid(pid, WNOHANG)` per known PID); allocate `spawnTraceId` per spawn; emit `ptyExit` with traceId (+1h).
+  - Implement the new shutdown sequence (§3.5.1.2) including DB transactions for `shutting_down → exited|paused` row transitions (canonical state name per round-3 P0/P1 lockin; was `abandoned` in earlier drafts), aggregated drop-line, single-pino-final flush. Cross-coordinate the WAL-checkpoint step with frag-6-7 §6.6 (avoid duplicate close) (+0.5h).
+- **Task 11** (also, +0.5h NEW): native-binding swap interface (§3.5.1.1.a) — `daemon/src/native/index.ts` + lint rule `no-direct-native-import`.
+- **Task 11c** (`ptySubscribe`, +3h NEW; was +2h): apply shared heartbeat scheduler; per-subscriber 1 MB watermark; aggregate per-session cap (`min(N×1MB, 4MB)`) with oldest-slowest LRU; emit `subscriber-dropped-slow` log + counter (`pty.subscriber.dropped`) including `traceId + spawnTraceId`; integration test for drop-slowest + aggregate cap; **shared framed buffer** integration with frag-3.4.1's cached header skeleton (perf-P0-A/B); xterm-headless `pause/resume` at 500/100 thresholds (perf-P1-B, mandatory). Bounded snapshot semaphore (size 4) lives here too with admission-relative deadline timing + `snapshot.semaphore.waitMs` counter; replay-budget clamp (256 KB) with `gap: true` flag.
+- **Task 13** (`notifyService` lift, +0.5h NEW): apply shared heartbeat scheduler to `subscribeNotifications` server-stream. `bootNonce` echoed on subscribe response. No other changes (notifications already produce the resume cursor).
+
+**Total estimated delta (this fragment, deduplicated against frag-6-7)**: **+13h** on top of v1 plan (was +14.5h; -3h N-API helper deduped per res-P1-1, +1.5h aggregate cap + shared scheduler + boot-nonce wire-up). Additive to frag-6-7's +44h. Combined v0.3 reliability+security+PTY-data hardening: ~57h on top of the 125h v1 plan → ~182h total. All items blocking for v0.3 dogfood.
+
+### Round-3 plan delta (additive, +1.5h)
+
+- **Task 11** (+0.5h): rename `state='abandoned'` → `state='paused'` everywhere in `daemon/src/pty/lifecycle.ts` and migration `0003_session_state_paused.sql`; clear `pid` and `pgid` columns to NULL atomically with the `paused` transition (single `UPDATE` per surviving session). Cross-coordinate with frag-6-7 §6.3 next-boot recovery query (must read `state='paused'` not `'abandoned'`).
+- **Task 5** (+0.5h): rewire `BridgeTimeoutError` so the renderer is **never** surfaced to it directly — bridge retries once internally; on second failure, set `surfaceRegistry.set('daemon-status', 'reconnecting')` (frag-6-7 §6.8). Renderer reads slot, not exception. Acceptance: renderer code search finds **zero** `catch (e instanceof BridgeTimeoutError)` blocks; only the bridge layer touches it.
+- **Task 11c** (+0.5h): add explicit unit test for replay-burst exemption (256 KB replay write does NOT trip 1 MB drop-slowest watermark; subsequent steady-state writes accumulate normally and DO trip at 1 MB). Document the orthogonality in code comment at the slow-subscriber accounting site.
+
+**Round-3 cumulative**: +14.5h (was +13h). Frag-6-7 +44h unchanged.
+
+## Open questions
+
+1. **N-API helper or `koffi` FFI?** Picked N-API (~120 LOC C++) for compile-time symbol guarantees and zero runtime overhead. `koffi` would skip the C++ build but adds a runtime dep + per-call FFI cost. The `NativeBinding` swap interface (§3.5.1.1.a) makes this swappable in v0.4 with a single-file edit, so the v0.3 decision is recoverable. Manager decision: confirm `koffi` posture (active maintenance + prebuilts for win32-x64/linux-x64/darwin-arm64?) before Task 11 dispatch.
+2. **macOS parent-watch deferral**: chosen approach is "rely on supervisor pgid-SIGKILL on cold-restart" rather than per-child kqueue watcher. Acceptable because Win 11 25H2 is the v0.3 lock per project memory. Confirm macOS is not a v0.3 ship target before merging this section.
+3. **SIGCHLD vs node-pty `onExit` ownership**: spec says daemon owns SIGCHLD and replaces node-pty's POSIX `onExit`. Worker should grep `node-pty` to confirm `onExit` can be safely no-op'd from JS-land; if it cannot (e.g. node-pty depends on `onExit` to free internal state), the contract becomes "both fire, daemon dedupes by pid+exitCode". Verify in Task 11.
+
+---
+
+## Cross-frag rationale
+
+This section records decisions where a round-2 P0/P1 spans multiple fragments. For each, note who owns the canonical contract and what we punted vs took.
+
+### Taken into §3.5.1 (this fragment owns)
+
+| Item | Source review | Rationale for landing here |
+|---|---|---|
+| SIGCHLD shutdown ordering + DB row transitions | rel-P0-R3 | Lifecycle of PTY children is §3.5.1's territory; the DB-side WAL checkpoint cross-references frag-6-7 §6.6 but the ordering bug was in §3.5.1's prior text, so the fix lives here. |
+| Drain-before-quench for stream/heartbeat/fanout | obs-P0-3 | Producers (heartbeat scheduler, fan-out registry) are §3.5.1 owned. `pino.final` invocation point remains in frag-6-7 §6.6; we just specify "this happens AFTER our drain". |
+| Per-PID `waitpid(pid, WNOHANG)` scope | rel-P1-R5 | Pure §3.5.1 SIGCHLD detail. |
+| Heartbeat-vs-supervisor inversion explained | rel-P1-R6 | One-paragraph rationale added inline; supervisor numbers stay in frag-6-7. |
+| Negotiable heartbeat per subscribe | lockin-P1-4 + fwdcompat-P1-2 | Subscribe RPC shape is §3.5.1's. Reserved-header keys for the other tunables (`x-ccsm-deadline-ms`, `x-ccsm-backpressure-bytes`) noted here but namespace ownership stays in frag-3.4.1. |
+| `bootNonce` on subscribe + `bootChanged` divider | fwdcompat-P1-1 | Subscribe RPC + heartbeat envelope are §3.5.1's. The `bootNonce` value source is frag-6-7 §6.5 healthz — coordinate. |
+| `spawnTraceId` for daemon-originated PTY events | obs OPEN q3 | PTY spawn is §3.5.1 owned. Bridge-side renderer logger plumbing stays in frag-6-7 §6.6 P0-1 amendment. |
+| Aggregate per-session subscriber cap (`min(N×1MB, 4MB)`) | res-P1-4 | Pure fan-out registry detail; v0.3 inert, v0.5 active. |
+| Replay budget 256 KB on resubscribe | res-P0-1 | Resubscribe semantics live here; frag-3.7 §3.7.5 references this clamp from the dev-workflow side. |
+| Snapshot semaphore admission-relative deadline | res-P1-3 | Pure §3.5.1.5 detail. |
+| Shared heartbeat scheduler (perf-P1-C) | perf-P1-C | Heartbeat infrastructure is §3.5.1.4 owned. |
+| xterm-headless `pause/resume` non-optional | perf-P1-B | Backpressure path lives at the §3.5.1.5 fan-out / headless-ring boundary. The "unless time-boxed out" qualifier is removed. |
+| Built artifact name `ccsm_native.node` (canonical contract for frag-11) | pkg-P0-2 | Frag-11 needs to reference an exact file name; we own the source dir, so we declare the artifact name here. **See frag-11 §11.4 for build wiring** (pkg.assets, before-pack existence check, codesign loop) keyed on `ccsm_native.node`. |
+| `state='paused'` rename (was `'abandoned'`) + `pid/pgid` clearing on respawn (round-3 P0/P1) | r3-lockin / r3-reliability | DB row state name aligned to frag-6-7 §6.3 canonical (`paused`, resumable). Stale OS identifiers (`pid`, `pgid`) cleared atomically with the state transition so the new daemon never re-signals dead PIDs. |
+| `BridgeTimeoutError` never user-surfaced; status via surface-registry slot (round-3 devx CF-3) | r3-devx | Replaces "renderer-side caller decides retry policy". Bridge retries once, then surface-registry frag-6-7 §6.8 `'reconnecting'` slot owns the user-visible status. |
+| `x-ccsm-deadline-ms` clamp upper bound 120 s (was 60 s in early drafts) | r3-fwdcompat | Matches snapshot 30 s + future v0.5 large-payload use case headroom. |
+| 256 KB replay clamp vs 1 MB watermark orthogonality (round-3 perf CF-2) | r3-perf | 256 KB = per-replay message hard limit (one-shot, payload size); 1 MB = per-second flow rate cap on Connect buffer. Replay-burst is exempt from drop-slowest accounting. |
+| `NativeBinding` swap interface | lockin-P0-2 | The interface lives next to the binding (`daemon/src/native/index.ts`); §3.5.1.1.a defines the TypeScript shape and the lint rule. |
+| Shared framed buffer per chunk (build once, write N times) | perf-P0-B | Fan-out call site is §3.5.1.5; the framed-buffer construction itself (cached header skeleton, `socket.cork/uncork`) is owned by frag-3.4.1 §3.4.1.c. We enforce "consume the cached buffer", they own "build it correctly". |
+
+### Punted to other fragments
+
+| Item | Source review | Target frag + ask |
+|---|---|---|
+| Cached header skeleton + `socket.cork/uncork` per chunk | perf-P0-A | **frag-3.4.1 §3.4.1.c** — owns binary frame construction. We enforce one-build-many-write at the fan-out call site; they own the byte-level skeleton + cork/uncork. Coordinate at merge. |
+| `traceId` field added to binary frame header schema | obs-P0-2 (cross-cut) | **frag-3.4.1 §3.4.1.c** — owns header JSON schema. Our `subscriber-dropped-slow` log carries traceId via the in-process subscribe context; the on-wire field for binary frames must be added in frag-3.4.1. |
+| `protocolVersion` / `daemon.hello` handshake | fwdcompat-P0-2 | **frag-3.4.1 §3.4.1.g (new) + frag-6-7 §6.5** — pure handshake contract, not §3.5.1's territory. We rely on `bootNonce` from the same handshake and reference it. |
+| Interceptor + `headers` map shape | fwdcompat-P0-1 | **frag-3.4.1 §3.4.1.f (new)** — adapter signature is frag-3.4.1's. Our handler signatures take `signal` and read `headers["x-ccsm-deadline-ms"]` from `ReqCtx`. |
+| `ccsm.v1/...` namespace evolution rule | fwdcompat-P0-3 | **frag-3.4.1** — RPC naming convention. |
+| Renderer-side logger module + `pino.final` analog on Electron-main | obs-P0-1 + obs-P0-4 | **frag-6-7 §6.6.1 (new)** — Electron-side concern. Our spawn/exit lines emit traceIds; renderer correlation lives there. |
+| `daemon.crashLoop` structured log signature | obs-P1-1 | **frag-6-7 §6.1 / §6.6** — supervisor concern. (i18n / log-event key is canonical camelCase per cross-frag alignment.) |
+| Migration phase log lines + `MigrationFailedEvent.markerSchemaVersion` | obs-P1-2 + fwdcompat-P1-3 | **frag-8** — migration territory. |
+| Reconnect/queue/resubscribe canonical log set | obs-P1-3 | **frag-3.7 §3.7.4 / §3.7.5** — dev-workflow / reconnect territory. We just emit `subscriber-dropped-slow` from the daemon side; the renderer-side enumeration belongs there. |
+| `daemonStats` → `statsVersion: 1` | obs-P1-4 | **frag-6-7 §6.5** — stats RPC owner. |
+| `crash-dump file` spec or drop | obs-P1-5 | **frag-6-7 §6.6** — owner. |
+| Dev-mode supervisor backoff during nodemon restart window | rel-P0-R1 | **frag-6-7 §6.1 + frag-3.7 §3.7.x** — supervisor + dev concern. Not §3.5.1. |
+| Crash-loop counter reset after rollback | rel-P0-R2 | **frag-6-7 §6.1 + §6.4** — supervisor + updater. Not §3.5.1. |
+| Migration partial-write recovery | rel-P0-R4 | **frag-8 §8.3** — migration. Not §3.5.1. |
+| Snapshot semaphore vs supervisor heartbeat starvation (separate transport for `/healthz`) | rel-P0-R5 | **frag-6-7 §6.5** — supervisor heartbeat owner. We just clarify §3.5.1.4 server-side is the dead-client mechanism, not the priority-queue. |
+| Migration-RPC short-circuit excludes `/healthz` | rel-P1-R3 | **frag-8 §8.6 + frag-6-7 §6.5**. |
+| `proper-lockfile` swap, pino-roll factory wrapper | lockin-P1-1 + P1-2 | **frag-6-7 §6.4 / §6.6**. |
+| Reconnect queue cap + scheduling configurable | lockin-P1-3 | **frag-3.7 §3.7.4**. |
+| `@yao-pkg/pkg` Node target single-source | lockin-P1-5 | **frag-11 §11.1**. |
+| Reconnect queue + 1 MB cap interaction (replay clamp side) | res-P0-1 (frag-3.7 side) | **frag-3.7 §3.7.5** must reference our 256 KB clamp. We've added it here; frag-3.7 amendment cross-links. |
+| Log-rotation aggregate budget | res-P1-2 | **frag-6-7 §6.6**. |
+| `~/.ccsm/` total disk cap + migration corrupt-backup cap | res-P1-6 | **frag-8 + frag-6-7 §6.6**. |
+| Idle daemon→client bandwidth budget summary line | res-P1-5 | **frag-12 traceability** or **frag-6-7 §6.5**. |
+| NSIS uninstall ghost + `ccsm_native.node` packaging wiring | pkg-P0-1 + pkg-P0-2 (packaging side) | **frag-11 §11.1 / §11.2 / §11.3** — we provide the canonical artifact name (`ccsm_native.node`) and per-platform staging dirs; frag-11 owns pkg.assets, before-pack existence check, per-`.node` codesign/signtool loop, and reproducible-build / uninstall hooks. |

--- a/docs/superpowers/specs/v0.3-fragments/frag-3.5.1-pty-hardening.md
+++ b/docs/superpowers/specs/v0.3-fragments/frag-3.5.1-pty-hardening.md
@@ -1,0 +1,35 @@
+# Fragment: §3.5.1 PTY hardening (orphan reap + bridge timeout)
+
+**Owner**: worker dispatched per Task #940
+**Target spec section**: insert after §3.5 in main spec
+**P0 items addressed**: #2 (PTY orphan reap), #3 (bridge call timeout)
+
+## What to write here
+Replace this section with the actual `### 3.5.1 PTY child lifecycle hardening`
+markdown. Cover:
+1. **Orphan reaping on daemon crash**:
+   - Win: JobObject with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`; child ptys
+     auto-killed when daemon process handle closes. Spec the N-API path or
+     existing npm package used.
+   - Unix: process group leader; daemon SIGKILL sends to whole group on exit;
+     also handle SIGCHLD to reap zombies.
+   - Behavior on graceful shutdown vs crash: graceful = SIGTERM with grace
+     period, then SIGKILL; crash = OS-driven cleanup via JobObject/pgroup.
+2. **Bridge call timeout**:
+   - Connect client (Electron side) wraps every RPC with default 5 s deadline,
+     configurable per-call. On timeout: client surfaces `BridgeTimeoutError`,
+     does NOT auto-retry (caller decides).
+   - Stream RPCs (PTY output stream): timeout applies to first byte / heartbeat
+     interval, not whole stream. Spec the heartbeat interval (e.g. 30 s).
+   - Daemon side: per-RPC timeout enforced by handler; runaway handler killed.
+
+Cite findings from `~/spike-reports/v03-review-reliability.md` and
+`~/spike-reports/v03-review-resource.md`.
+
+## Plan delta
+- Task 11 (PTY service) gains: JobObject/pgroup wiring (+3h), reaping tests
+  (+2h). New estimate: NN h.
+- Task 5 or 7 (RPC adapter / bridge client) gains: timeout middleware (+2h),
+  heartbeat for stream RPCs (+2h).
+- New test cases: kill-daemon-and-check-no-orphan-pty (Win+Unix); RPC
+  timeout regression.

--- a/docs/superpowers/specs/v0.3-fragments/frag-3.7-dev-workflow.md
+++ b/docs/superpowers/specs/v0.3-fragments/frag-3.7-dev-workflow.md
@@ -1,32 +1,904 @@
 # Fragment: §3.7 Dev workflow (hot-reload + auto-reconnect)
 
-**Owner**: worker dispatched per Task #938
-**Target spec section**: new §3.7 in main spec (after §3.6)
-**P0 items addressed**: #13 (dev hot-reload + auto-reconnect)
+**Owner**: worker dispatched per Task #938 (round-3 fixes by §3.7 round-3 fixer).
+**Target spec section**: new §3.7 in main spec (after §3.6).
+**P0 items addressed**: #13 (dev hot-reload + auto-reconnect).
+**Round-1 review source**: `~/spike-reports/v03-review-devx.md` MUST-FIX 1, 2, 4 + OPEN q1.
+**Round-2 review sources** (P0/P1 folded in): `~/spike-reports/v03-r2-devx.md`
+P0-1/P0-2/P0-3/P0-4/P0-5 + P1-3/P1-6/P1-7; `~/spike-reports/v03-r2-reliability.md`
+P0-R1 + P1-R1; `~/spike-reports/v03-r2-resource.md` P0-1; `~/spike-reports/v03-r2-ux.md`
+P0-UX-1 + P0-UX-2 + P1-UX-1 + P1-UX-4 + P1-UX-6.
+**Round-3 review sources**: `~/spike-reports/v03-r3-ux.md` P0-UX-A (surface
+registry duplicate) + CC-1 (close-to-tray key drift) + CC-3 (i18n casing) +
+CC-4 (BridgeTimeout three statements); `~/spike-reports/v03-r3-resource.md`
+X2 (pino-roll symlink) + X4 (close_to_tray key drift);
+`~/spike-reports/v03-r3-fwdcompat.md` cross-frag #2 (`bootNonce` camelCase
+lock); `~/spike-reports/v03-r3-observability.md` P1-2 (reconnect canonical
+log names cross-ref); `~/spike-reports/v03-r3-reliability.md` CF-3
+(supervisor-disabled-in-dev clarification); `~/spike-reports/v03-r3-devx.md`
+P1-1/P1-2/P1-3/P1-4/P1-5 (tray Quit semantics, in-flight chunks, npm rebuild
+syntax, Win Get-Content caveat, e2e pkill target).
 
-## What to write here
-Replace this section with the actual `## 3.7 Dev workflow` markdown. Cover:
-1. **`npm run dev` topology in v0.3**:
-   - Electron main + renderer (existing vite/electron-forge dev).
-   - Daemon spawned as separate Node process via nodemon; restarts on
-     `daemon/**` source changes.
-   - Specify which workspace script orchestrates both (concurrently? turbo?
-     existing pattern?).
-2. **Electron client auto-reconnect**:
-   - On socket EOF / ECONNREFUSED, Connect client retries with exponential
-     backoff: 200ms → 400ms → 800ms → ... cap 5s.
-   - During reconnect: bridge calls queue (bounded 100? reject after?), UI
-     shows "daemon reconnecting…" toast (existing toast system).
-   - On reconnect success: replay any session subscription state (sids the
-     renderer was watching) so user doesn't lose live view.
-3. **Prod behavior** (contrast): supervisor is the OS service / electron
-   main; auto-reconnect logic still applies but daemon restart is rarer.
+**Round-3 manager arch decisions (LOCKED)**:
+1. Surface registry CANONICAL = frag-6-7 §6.8 (numeric priority, single
+   `daemonHealth` IPC, single `useDaemonHealthBridge` hook). §3.7.8 in this
+   fragment is **DELETED** and replaced with a one-paragraph cross-ref.
+2. close-to-tray SQLite key = `close_to_tray_shown_at` (timestamp), owned by
+   frag-6-7 §6.8. §3.7.8.b (which had been claiming `close_to_tray_hint_shown`
+   boolean) is collapsed into the §3.7.8 deletion.
+3. Per-user install (`%LOCALAPPDATA%\ccsm\`) + OS-native data root
+   (`%APPDATA%\ccsm\` on Win, `~/Library/Application Support/ccsm/` on macOS,
+   `~/.config/ccsm/` on Linux). The `daemon.lock` resolution in §3.7.2's
+   `wait-on file:` snippet uses the OS-native data root, not the install root.
+4. `bootNonce` is camelCase across the bundle (subscribe response, hello
+   reply, healthz payload, stream heartbeat). §3.7.5 reader is fixed below.
+5. i18n keys are dot+camelCase across the bundle (`daemon.crashLoop`,
+   `daemon.unreachable`, `daemon.reconnected`, etc.).
+   [manager r7 lock: r6 ux P0-1 — key spelling aligned to §6.8 canonical
+   set after the r7 row trim. The r5/r6 spellings `daemon.reconnectStuck`
+   and `daemon.reconnectExhausted` are OBSOLETE; reconnect-exhaustion is
+   folded into the single `daemon.unreachable` banner per §6.8 r7 cut.
+   Likewise `tray.closeHint` is OBSOLETE per §6.8 r7 close-to-tray
+   onboarding deletion.]
+6. `BridgeTimeoutError` is NEVER user-surfaced per-call; user-facing
+   surfacing for the spike (3+ in 10s) and reconnect-exhaustion case is
+   absorbed into the canonical surface registry (frag-6-7 §6.8) under
+   the single `daemon.unreachable` banner slot per the §6.8 r7 trim
+   (separate `bridge_timeout_spike` / `reconnect_exhausted` slots are
+   cut; `reconnecting` is log-only at the per-attempt level).
+7. Supervisor in dev (`CCSM_DAEMON_DEV=1`): the supervisor process /
+   restart loop / crash-loop counter is **disabled**, but the renderer's
+   `/healthz` polling continues purely as a status-badge signal. The
+   supervisor transport in the daemon STILL binds in dev (else there is
+   nothing to poll); only the supervisor-side restart logic is gated off.
+   Matches frag-6-7 §6.1.
+8. [manager r5 lock: 'Reinstall ccsm' is prose text not a button; matches current working installerCorrupt pattern; v0.3 is refactor scope = no new auto-update feature.]
+9. [manager r5 lock: 'View log' button removed entirely; no such feature in current working; v0.3 refactor scope = no new features. Crash log location is documented in frag-11 §11.6 paths table for users who want to find logs manually.]
 
-Cite findings from `~/spike-reports/v03-review-devx.md`.
+---
+
+## 3.7 Dev workflow
+
+### 3.7.1 Goals
+
+Daily dogfood loop must stay **≤5 s edit→reload** even after the daemon split.
+The devx review (`v03-review-devx.md` §3 MUST-FIX 1) measured that, without
+the contents of this section, every `daemon/**` edit costs **+10–15 s and
+two manual steps** (`pkill -f dist-daemon` + restart Electron). That budget
+is unacceptable across the ~125 h of v0.3 implementation, so the dev tooling
+ships **with Phase 0**, not as a Phase 5 afterthought.
+
+### 3.7.2 `npm run dev` topology (v0.3)
+
+The existing v0.2 root script (see `package.json`):
+
+```json
+"dev": "concurrently -k -n web,app -c blue,magenta \"npm:dev:web\" \"npm:dev:app\""
+```
+
+extends to **three** named processes. Replace with:
+
+```json
+"dev":        "concurrently -k -n web,daemon,app -c blue,yellow,magenta \"npm:dev:web\" \"npm:dev:daemon\" \"npm:dev:app\"",
+"dev:web":    "webpack serve --config webpack.config.js --mode development",
+"dev:daemon": "nodemon --config nodemon.daemon.json",
+"dev:app":    "node scripts/wait-daemon.cjs && tsc -p tsconfig.electron.json && cross-env CCSM_DAEMON_DEV=1 electron .",
+"setup":      "node scripts/setup.cjs"
+```
+
+> **Cross-platform `wait-on file:` note (closes round-2 P0-2 + R1 OPEN q3;
+> round-3 manager arch decision #3 path-root lock):**
+> `scripts/wait-daemon.cjs` resolves the daemon lockfile path against the
+> **OS-native data root** (NOT `~/.ccsm/`):
+> - Win: `path.join(process.env.APPDATA, 'ccsm', 'daemon.lock')`
+> - macOS: `path.join(os.homedir(), 'Library', 'Application Support', 'ccsm', 'daemon.lock')`
+> - Linux: `path.join(process.env.XDG_CONFIG_HOME ?? path.join(os.homedir(), '.config'), 'ccsm', 'daemon.lock')`
+>
+> Then invokes `wait-on file:<resolved> http://localhost:4100`. The
+> previous `tcp:127.0.0.1:0` was a no-op (port 0 resolves immediately) and
+> silently let Electron race the daemon's pipe bind, dumping every dev
+> boot into the auto-reconnect loop. The lockfile is the same one frag-6-7
+> §6.4 mandates daemon write at startup via `proper-lockfile`, so no new
+> daemon-side work is needed. Note: per-user install (round-3 lock #3)
+> goes to `%LOCALAPPDATA%\ccsm\` for the install root; daemon **data**
+> (lockfile, sqlite, logs) lives at `%APPDATA%\ccsm\` — these are
+> different directories.
+
+Process graph:
+
+```
+concurrently -k
+├── web     : webpack-dev-server  (HMR for renderer, port 4100)
+├── daemon  : nodemon → tsc -w → node daemon/dist-daemon/index.js
+└── app     : tsc(electron) → electron .  (spawnOrAttach attaches to nodemon's daemon)
+```
+
+`-k` (kill-others) is mandatory: a dead web server must take the daemon and
+Electron with it, otherwise stale processes hold the named pipe and the
+next `npm run dev` fails the spawn-or-attach probe (Task 7 §3 step 4).
+
+#### 3.7.2.a Workspaces prerequisite (closes round-2 devx P0-1)
+
+`dev:daemon`'s nodemon `exec` (§3.7.3) and `frag-11-packaging.md` §11.1 both
+shell out to `npm -w @ccsm/daemon run …`. The repo's current root
+`package.json` declares no `"workspaces"` array (verified 2026-04-30 against
+working tip). The Phase 0 plan delta below (Task 1) explicitly mandates
+adding `"workspaces": ["daemon"]` to root `package.json` so that workspace
+flag-syntax resolves on first contributor pull. **frag-11 still owns
+`daemon/package.json` scaffolding** (`name: "@ccsm/daemon"`); §3.7 owns the
+root-side declaration so the dev script is functional. Cross-frag rationale
+captured at the bottom of this document.
+
+#### 3.7.2.b Single canonical daemon entry in dev (closes round-2 devx P0-3 + P1-4)
+
+Two daemon entries are described across the bundle:
+
+- frag-3.7 §3.7.3: `node daemon/dist-daemon/index.js` (TS-compiled, run by nodemon).
+- frag-11 §11.2: `daemon/dist/ccsm-daemon-${devTarget()}` (pkg-bundled binary).
+
+These are **not interchangeable**. In `CCSM_DAEMON_DEV=1` mode the
+**only** runtime entry is the nodemon-managed `node daemon/dist-daemon/index.js`.
+`spawnOrAttach.ts` (Task 7) MUST treat dev mode as attach-only and never
+look up the pkg path. frag-11 §11.2 should remove or fence its `devTarget()`
+branch behind `!process.env.CCSM_DAEMON_DEV` so the prod-only path doesn't
+read as authoritative for dev. **Punt accepted by §3.7 (this fragment) for
+the spawnOrAttach side; the frag-11 side is a one-line edit owned by the
+frag-11 round-2 fixer** — see Cross-frag rationale.
+
+#### 3.7.2.c Toolchain prerequisites (closes round-2 devx P0-4 + P1-5)
+
+v0.3 introduces a **C++ toolchain requirement** for the daemon's native
+helper at `daemon/native/winjob/` (frag-3.5.1 §3.5.1.1, frag-6-7 §6.2).
+v0.2 contributors editing only `src/` did not need this. To prevent
+first-time-on-Windows `gyp ERR! find VS missing any VC++ toolset`, the
+following are mandatory before `npm install` succeeds in a fresh checkout:
+
+| Platform | Required tool | Notes |
+|---|---|---|
+| Windows | Visual Studio Build Tools 2022 (Desktop C++ workload) | `node-gyp` for `daemon/native/winjob/`. |
+| Windows | Python 3.10+ on PATH | `node-gyp` dependency. |
+| Windows (signtool path) | Windows 10/11 SDK 10.0.22621.0 | only for `make:win` (frag-11 §11.3.1). |
+| macOS | Xcode Command-Line Tools | `xcode-select --install`. |
+| Linux | `build-essential`, `python3`, `libsecret-1-dev` | apt/yum equivalent. |
+
+The Phase 0 `npm run setup` script (`scripts/setup.cjs`, added by Task 1)
+runs:
+
+```
+1. npm install                                              (root + workspaces)
+2. npm -w @ccsm/daemon rebuild better-sqlite3 node-pty
+   --runtime=node --target=22.x                             (Node 22 ABI)
+3. (optional) npm run build:daemon                          (only if running make:*)
+```
+
+> **npm rebuild syntax** (round-3 devx P1-3): with the workspaces array
+> declared (§3.7.2.a), the canonical syntax is `npm -w @ccsm/daemon rebuild`,
+> NOT `npm rebuild --prefix daemon`. The round-2 spec used `--prefix` which
+> is redundant with workspaces and confused first-time contributors who
+> tried to mirror it elsewhere; locked to the workspace-flag form.
+
+Renderer-only contributors who never touch `daemon/**` MAY skip step 2 by
+running `npm install --workspaces=false && npm run dev:web` (documented in
+CONTRIBUTING). The default workspace-aware install does run `node-gyp` for
+the native helper — accepted onboarding cost; see Cross-frag rationale for
+the wider tradeoff.
+
+#### 3.7.2.d Production dogfood log access (closes round-2 devx P0-5; round-3 devx P1-4)
+
+Prod dogfood (per `feedback_dogfood_protocol`) runs the installed binary
+where `stdio: "ignore"` (§3.7.6) hides daemon stderr. The only signal is
+the daemon log written by `pino-roll` (frag-6-7 §6.6) under the OS-native
+data root (`%APPDATA%\ccsm\logs\daemon.log` on Win,
+`~/Library/Logs/ccsm/daemon.log` on macOS, `~/.config/ccsm/logs/daemon.log`
+on Linux). Per round-3 manager arch decision #3, log paths follow the
+OS-native data root, not `~/.ccsm/`. v0.3 mandates **two** affordances,
+both shipped in Phase 0 (no dogfood gate without them):
+
+- **`pino-roll` `symlink: true`** — daemon writes a stable symlink
+  alongside dated rotated files. POSIX `tail -F` follows the symlink
+  target across rotations cleanly. **Windows caveat (round-3 devx P1-4):**
+  `Get-Content -Wait` opens the symlink target by inode at start and
+  keeps the handle — it does NOT follow target swaps even with `-Tail`.
+  The `pino-roll symlink: true` fix is therefore **POSIX-only** for
+  live-tail purposes; Windows users tail via the tray menu "Tail daemon
+  log in new terminal" entry below (which spawns `wt.exe` running
+  `Get-Content` against the *current* rotated file, re-resolved per
+  invocation). **PUNT to frag-6-7 §6.6 fixer**: the `symlink: true` key
+  itself lives in frag-6-7's pino-roll config block (round-3 resource
+  X2: not yet added in r2 — must land in this round). One-line edit.
+- **Log path documentation** — daemon log path is documented in
+  release notes / About dialog so users can locate
+  `<dataRoot>/logs/daemon.log` manually for support diagnostics. No
+  tray menu growth (v0.3 is a refactor — no new tray entries).
+  [manager r7 lock: cut as polish — N2# from r6 feature-parity (Win-only
+  "Tail daemon log in new terminal") + N3# (cross-platform "Open daemon
+  log") — neither exists in working tip; v0.3 is refactor scope.]
+
+### 3.7.3 `nodemon.daemon.json` (new file, Task 1 add)
+
+```json
+{
+  "watch": ["daemon/src"],
+  "ext": "ts,json",
+  "ignore": ["daemon/src/**/__tests__/**", "daemon/dist-daemon/**"],
+  "exec": "npm -w @ccsm/daemon run build && node daemon/dist-daemon/index.js",
+  "signal": "SIGTERM",
+  "delay": 150,
+  "stdout": true,
+  "stderr": true,
+  "env": { "CCSM_DAEMON_LOG_LEVEL": "debug", "CCSM_DAEMON_DEV": "1" }
+}
+```
+
+Key choices:
+
+- **`exec` = build + run, not `tsc -w` separately.** A single `nodemon`
+  edit-trigger atomically (a) rebuilds, (b) sends `SIGTERM` to the previous
+  daemon, (c) starts the new one. Two-process `tsc --watch` + file-watcher
+  custom shim was rejected: nodemon already does it, +0 LOC.
+- **`signal: SIGTERM`** matches the daemon's existing handler in
+  `daemon/src/index.ts` step 4 (Plan Task 1 step 4 already wires
+  `process.on("SIGTERM", () => process.exit(0))`).
+- **`delay: 150`** debounces multi-file saves (TS refactor renames touch
+  many files in one tick).
+- **`stdout/stderr: true`** addresses devx MUST-FIX 2 — daemon errors land
+  in the same terminal pane as the renderer/Electron logs. Pino still
+  writes its structured stream to `~/.ccsm/logs/daemon.log` for post-mortem,
+  but stack traces appear inline.
+
+### 3.7.4 Connect client auto-reconnect
+
+When nodemon restarts the daemon, the Electron-side Connect client (Task 7
+§3 `connectClient.ts`) sees its socket close. Today (Plan Task 7 step 4,
+unmodified) the client throws on next call and the renderer surfaces a raw
+`ECONNREFUSED`. v0.3 §3.7 mandates **transparent auto-reconnect**:
+
+#### Backoff schedule
+
+Exponential, doubling, capped, with full jitter:
+
+| Attempt | Base delay | With ±25 % jitter |
+|---------|-----------:|------------------:|
+| 1       | 200 ms     | 150–250 ms        |
+| 2       | 400 ms     | 300–500 ms        |
+| 3       | 800 ms     | 600–1000 ms       |
+| 4       | 1600 ms    | 1200–2000 ms      |
+| 5       | 3200 ms    | 2400–4000 ms      |
+| 6+      | **5000 ms (cap)** | 3750–5000 ms |
+
+No retry cap on attempt count — the client retries forever until either
+(a) the socket connects, (b) the user quits the app, or (c) Task 7's
+`spawnOrAttach` is invoked again with `spawnIfMissing: true` and starts a
+fresh daemon. Under nodemon's typical 200–600 ms restart window, attempts
+1–2 succeed; under prod cold start (pkg binary, ~1.5 s) attempts 3–4
+succeed.
+
+#### Bounded reconnect queue
+
+While disconnected, RPC calls are **queued, not rejected**:
+
+- Queue cap: **100** in-flight calls in prod (`MAX_QUEUED_PROD = 100`),
+  **1000** in dev (`MAX_QUEUED_DEV = 1000`) — closes round-2 reliability
+  P1-R1 (rapid-fire dev save can briefly exceed 100 in nodemon storms;
+  RAM cost ~200 KB).
+- On overflow: oldest call is rejected with
+  `Error("daemon-reconnect-queue-overflow")`; the renderer's existing
+  per-bridge error path surfaces this.
+- Stream subscriptions (PTY data, notify) are **not queued** — see
+  §3.7.5 resubscription.
+- On reconnect success: queue drains FIFO; each entry sends its
+  envelope and resolves/rejects the original promise.
+
+Rationale: 100 calls @ ~200 B JSON envelope = ~20 KB worst-case in-memory
+buffering, well below any concern. The cap exists to bound an
+adversarial-disconnected-forever case (e.g. daemon binary missing); it is
+not a steady-state limit.
+
+#### 3.7.4.a Reconnect-queue does NOT double-buffer stream replay (closes round-2 resource P0-1)
+
+The reconnect queue holds **unary** RPC envelopes only. Stream
+**resubscription** (§3.7.5) does NOT replay through the queue. To bound
+the daemon-side replay burst when `subscribe(fromSeq)` requests a
+sequence older than the daemon's ring buffer, frag-3.7 picks resolution
+(b) of round-2 resource P0-1: the per-subscriber 1 MB drop-slowest
+watermark in **frag-3.5.1 §3.5.1.5 is measured AFTER the initial replay
+burst is delivered**, not as part of slow-subscriber accounting.
+Equivalently, the replay burst is treated as one initial write and
+exempt from slow-subscriber drop-decision. **Cross-fragment contract:**
+frag-3.5.1 §3.5.1.5 round-2 fixer must add a one-sentence carve-out
+("initial replay burst on resubscribe is not counted toward the 1 MB
+per-subscriber drop-slowest watermark"). **Punt to frag-3.5.1 round-2
+fixer**, called out here so the contract is visible.
+
+If frag-3.5.1's fixer rejects (b), §3.7.5 falls back to resolution (a):
+client clamps `fromSeq` such that the daemon ships at most 256 KB of
+replay then declares `gap: true`. The toast/divider path in §3.7.5
+already handles `gap: true` cleanly so this is a graceful fallback.
+
+#### Toast UX — registers into frag-6-7 §6.8 surface registry
+
+The reconnect bridge does NOT own a toast vocabulary; it publishes into
+the canonical surface registry defined in **frag-6-7 §6.8** (locked by
+round-3 manager arch decision #1). The reconnect bridge contributes the
+following surfaces; priorities/stacking/dedup are §6.8's responsibility.
+i18n keys are dot+camelCase per round-3 lock #5:
+
+| Event | §6.8 slot (priority) | i18n key |
+|---|---|---|
+| 1st reconnect attempt fails (250 ms threshold) | LOG ONLY (no IPC publish) — `daemon.reconnecting` toast slot CUT in §6.8 r7 trim | `daemon.reconnecting` (log-only) |
+| Reconnected (queue drained) | `reconnected` (transient info, 3 s TTL) | `daemon.reconnected` |
+| Queue overflow rejection | LOG ONLY — `queueOverflow` toast slot CUT in §6.8 r7 trim | `daemon.queueOverflow` (log-only) |
+| Reconnect attempts continue past supervisor miss threshold | promote to `unreachable` (red banner, P=70) — folded the former N=15 `reconnectExhausted` modal into the same banner per §6.8 r7 trim | `daemon.unreachable` |
+| Bridge-timeout spike (3+ in 10 s) | LOG ONLY — `bridgeTimeoutSpike` slot CUT in §6.8 r7 trim (escalates into `daemon.unreachable` if it persists) | (log-only) |
+| Stream gap on resubscribe | LOG ONLY (xterm divider may still render renderer-side) — `streamGap` toast slot CUT in §6.8 r7 trim | `daemon.streamGap` (log-only) |
+| Dev-mode build error (queue >4 s in `CCSM_DAEMON_DEV=1`) | LOG ONLY — `devBuildError` slot CUT in §6.8 r7 trim | `daemon.devBuildError` (log-only) |
+
+The 250 ms hold-off (renderer-side, owned by `useDaemonReconnectBridge`)
+prevents flicker: nodemon restarts in ~200 ms, so a clean dev-loop edit
+shows **no surface at all** — the 1st backoff retry (200 ms) succeeds
+before the publish threshold fires. The dev-mode build-error toast
+catches the TypeScript-broken-in-nodemon case where the dev terminal has
+a useful error but the renderer is otherwise opaque.
+
+`BridgeTimeoutError` per-call is NEVER user-surfaced (round-3 lock #6);
+the renderer's bridge layer logs `DEADLINE_EXCEEDED` (gRPC convention)
+and lets the supervisor banner (frag-6-7 §6.1) absorb it. After the
+§6.8 r7 trim, the only user-visible surface tied to bridge timeouts is
+the single `daemon.unreachable` banner (the former `bridgeTimeoutSpike`
+toast and `reconnectExhausted` modal slots are cut and folded into
+`daemon.unreachable`).
+
+**Canonical log line names** (round-3 obs P1-2 cross-ref): the reconnect
+emitter uses the strings declared by **frag-6-7 §6.6.2 "Bridge call
+lifecycle log lines"**: `daemon_socket_closed`, `daemon_reconnect_attempt`,
+`daemon_reconnect_success`, `daemon_queue_overflow`, `stream_resubscribe`.
+Workers MUST NOT invent new strings (e.g. `reconnect-attempted`).
+
+**Tray-mode "Quit" semantics** (round-3 devx P1-1): the existing
+working tray menu (`[Show CCSM | Quit]`) Quit handler MUST call
+`app.quit()` (clean exit, drain pino, release lockfile), NOT
+`win.close()` (which only hides to tray). The renderer plumbs this via
+the existing `tray.quitApp` IPC channel (Task 21). [manager r7 lock:
+the former r6 rationale ("the `reconnectExhausted` modal's Quit button
+must clean-exit even when in tray-hidden state") is OBSOLETE — that
+modal was cut by §6.8 r7; the `daemon.unreachable` banner has no Quit
+button (banner is non-blocking). The `app.quit()` requirement still
+holds for the working tray-menu Quit, which is the only Quit affordance
+in v0.3.]
+
+### 3.7.5 Stream resubscription on reconnect
+
+Devx OPEN q1: "When daemon restarts mid-session under dev, every renderer
+subscription drops." The bridge **must auto-resubscribe** rather than
+reload the renderer (renderer reload would lose terminal scrollback and
+form state).
+
+On reconnect success, `connectClient`:
+
+1. **First, tears down stale stream handles.** Iterates every entry in its
+   internal stream-handle table and calls `.cancel()` on each, clearing
+   any client-side `setInterval` heartbeat timers (frag-3.5.1 §3.5.1.4)
+   and removing them from the stream-handle table. This closes round-2
+   devx P1-6 — without it, two client-side heartbeat timers per stream
+   accumulate per restart and never get cleared.
+2. **Then, walks `Map<sid, SubscriptionDescriptor>`** populated at
+   `subscribe()` time. For each entry it re-issues the subscribe RPC
+   with `fromSeq = lastSeenSeq + 1`. PTY service (Task 11) and notify
+   service (Task 13) MUST honor `fromSeq` — this is on their wire
+   contract per §3.5.1 (PTY hardening fragment) and §3.4.1 (envelope
+   hardening fragment). The canonical declaration of the
+   `subscribe(sessionId, { fromSeq })` shape lives in **frag-3.4.1
+   §3.4.1.b** per the round-2 fwdcompat call (P1-1); §3.7.5 references
+   it rather than re-stating shape.
+3. **bootNonce check (closes round-2 fwdcompat P1-1; round-3 fwdcompat
+   cross-frag #2 camelCase lock).** Each subscribe response includes the
+   daemon's `bootNonce` field — **camelCase**, locked by round-3 manager
+   arch decision #4 (declared by frag-6-7 §6.5 healthz, frag-3.4.1 §3.4.1.g
+   hello, frag-3.5.1 §3.5.1.4 stream heartbeat; all four sites converge on
+   `bootNonce`). If the response `bootNonce` differs from the value
+   captured by the most recent subscription on this `sid`, the bridge
+   treats `fromSeq` as **invalid** (daemon rebooted, sequence space
+   reset) and behaves as if the daemon had returned `gap: true` —
+   fresh subscription from `fromSeq = 0`, log `daemon.streamGap` and
+   render the xterm divider renderer-side. (The §6.8 r7 trim cut the
+   `daemon.streamGap` toast; the divider remains a renderer-side
+   affordance, no IPC.) Without this, after a daemon restart the
+   client could request `fromSeq=12345` against a daemon whose new
+   sequence space starts at 0 and silently miss the first 12345 frames.
+
+   **In-flight chunk dedup across teardown** (round-3 devx P1-2): step 1
+   tears down the old socket's stream handles before the resubscribe ack
+   arrives, but kernel-buffered chunks from the old socket may still
+   land at the renderer between `.cancel()` and the fresh subscribe ack.
+   The renderer trusts `seq` ordering only WITHIN a single
+   `(sid, bootNonce)` tuple — chunks arriving with a stale `bootNonce`
+   (captured at old subscribe time) are dropped silently. Same-bootNonce
+   late chunks (nodemon SIGTERM-then-restart of the SAME daemon process
+   is impossible because nodemon spawns a fresh node process and
+   `bootNonce` is minted at boot) are de-duped by `seq`: any frame with
+   `seq <= lastSeenSeq` is dropped.
+
+If `fromSeq` is older than the daemon's ring buffer (cold daemon = empty
+ring), the daemon responds with `gap: true`; the bridge logs
+`daemon.streamGap` (LOG ONLY — the §6.8 r7 trim cut the toast slot;
+no IPC publish) and the renderer's xterm adapter emits a visible
+`─── stream gap ───` divider purely as a renderer-side affordance.
+
+### 3.7.6 Dev-mode contrasts vs prod
+
+| Aspect | Dev (`CCSM_DAEMON_DEV=1`) | Prod |
+|---|---|---|
+| Daemon process | nodemon child of `npm run dev` shell | pkg binary, spawned by `spawnOrAttach` (Task 7) or attached if already running (tray-quit semantics, Task 21) |
+| Restart cadence | every `daemon/src/**` save (~5–50×/h) | only on crash, daemon auto-update (Task 23), or explicit tray Quit |
+| stdio | inherited (`stdout/stderr: true` in nodemon) | `stdio: "ignore", detached: true` (Task 7 §3 step 4); pino writes to `~/.ccsm/logs/daemon.log` only |
+| Log level | `debug` | `info` (overridable via `CCSM_DAEMON_LOG_LEVEL`) |
+| Reconnect path | hits often (nodemon SIGTERM) | rare (crash recovery) |
+| Toast frequency | usually suppressed by 250 ms hold-off | subject to frag-6-7 §6.8 dedup vs supervisor banner |
+| Backoff schedule | **same** (200 ms → 5 s cap) | **same** |
+| Stream resubscribe | **same** | **same** |
+| Reconnect queue cap | **1000** | **100** |
+| Supervisor restart loop (frag-6-7 §6.1) | **DISABLED** — see §3.7.6.a | active |
+| Supervisor transport binds (frag-6-7 §6.5) | **YES** (so renderer `/healthz` poll has a target) | yes |
+| Renderer `/healthz` polling for status badge | **YES** (diagnostic UI only) | yes |
+
+The reconnect/queue/resubscribe code path is **identical** in dev and prod
+— gating it behind `CCSM_DAEMON_DEV` would mean the prod path is exercised
+only in the field. Devx review §3 MUST-FIX 2 only differentiates
+**logging stdio**, not the client-side reconnect logic. The queue cap
+splits dev/prod for ergonomic reasons (see §3.7.4).
+
+#### 3.7.6.a Supervisor restart loop disabled in dev; transport + healthz polling stay (closes round-2 reliability P0-R1; round-3 reliability CF-3)
+
+frag-6-7 §6.1 mandates a supervisor (5 s `/healthz`, 3-miss restart, crash-loop
+modal at 5 respawns / 2 min). In `CCSM_DAEMON_DEV=1`, **the supervisor's
+restart loop / heartbeat-miss counter / crash-loop counter MUST be disabled**.
+Justification: nodemon already supervises the daemon (SIGTERM + restart on
+file change); a second supervisor that doesn't know about nodemon will count
+every save as a missed heartbeat and trip the crash-loop modal during normal
+dev.
+
+What stays in dev (round-3 reliability CF-3 clarification — the r2
+"disabled entirely" wording was too strong and conflicted with frag-6-7
+§6.1's "still polls /healthz for diagnostic UI"):
+
+- The **supervisor transport** (named pipe / unix socket per frag-6-7 §6.5)
+  STILL binds in the daemon, because the renderer needs a target for
+  diagnostic-UI `/healthz` polling. Otherwise every nodemon SIGTERM
+  would race the renderer's poll and produce flicker.
+- The **renderer's `/healthz` poll** (5 s) continues purely as a status-
+  badge signal (green/yellow/red dot in the dev tray + dev-mode debug
+  panel). It does NOT drive any restart decision.
+- The **supervisor's restart loop** (3-miss → restart, 5-respawn-in-2min
+  → crash-loop modal) is the part that's gated off behind
+  `!process.env.CCSM_DAEMON_DEV`.
+
+frag-3.7's auto-reconnect (§3.7.4) is the dev-mode liveness *response* —
+sufficient because (a) the user *is* the failure detector in dev, (b)
+reconnect-queue + N=15 modal escalation already surfaces a stuck
+daemon, and (c) the diagnostic-UI badge gives a quick visual
+confirmation. **Cross-fragment contract:** frag-6-7 §6.1 round-3 fixer
+must mirror this exact split (transport + poll on, restart loop off).
+Already done per round-3 obs review confirmation that frag-6-7 §6.1 line
+25 reads "DISABLED in spawn/restart mode but still polls /healthz for
+diagnostic UI." This fragment's r3 edit aligns the wording.
+
+### 3.7.7 Test coverage
+
+- Unit: `electron/daemonClient/__tests__/connectClient.reconnect.test.ts` —
+  mock `node:net`, assert backoff schedule (use `vi.useFakeTimers()`),
+  queue-overflow rejection, FIFO drain order, dev-vs-prod cap.
+- Unit: `electron/daemonClient/__tests__/connectClient.resubscribe.test.ts`
+  — verify `Map<sid, SubscriptionDescriptor>` re-issue with bumped
+  `fromSeq`; verify `bootNonce` mismatch resets `fromSeq=0` and emits
+  the `daemon.streamGap` log line + xterm divider (no IPC publish per
+  §6.8 r7 trim); verify stale stream handles `.cancel()` before
+  resubscribe.
+- E2E: **fold into `harness-agent` as a phase** (closes round-2 devx
+  P1-7 / `feedback_e2e_prefer_harness`). New phase
+  `harness-agent.daemonReconnect()`: kill the running daemon
+  (platform-aware target — round-3 devx P1-5: under prod-installed
+  harness use `taskkill /F /IM ccsm-daemon.exe` on Win and
+  `pkill -f /Applications/ccsm.app/Contents/Resources/daemon/ccsm-daemon`
+  on macOS / `pkill -f /opt/ccsm/resources/daemon/ccsm-daemon` on Linux;
+  ONLY in dev-mode harness use `pkill -f dist-daemon/index.js`), assert
+  renderer DOM shows `[data-toast-kind="reconnecting"]`, restart daemon
+  via `spawnOrAttach`, assert toast clears within 1 s and a follow-on
+  RPC succeeds. Avoids +30 s/test for a standalone probe. No skip
+  allowed (per `feedback_no_skipped_e2e`).
+
+### 3.7.7.a Debugger attach (closes round-6 devx P0-1)
+
+[manager r7 lock: r6 devx P0-1 — debugger contract for daemon-split contributors]
+
+Three documented attach flows; all env-gated, default off, **dev-only**
+(production builds compile-out the inspector flag — security boundary
+preventing a packaged installer from exposing a live Node inspector).
+
+- **Daemon (`--inspect=9230`)**: env-gated via `CCSM_DAEMON_INSPECT=1`.
+  Nodemon's `exec` line in §3.7.3 becomes
+  `npm -w @ccsm/daemon run build && node ${CCSM_DAEMON_INSPECT:+--inspect=9230} daemon/dist-daemon/index.js`.
+  Default `npm run dev` opens NO inspector port; `CCSM_DAEMON_INSPECT=1 npm run dev`
+  opens 9230. Port 9230 chosen to avoid Electron-main's default 9229.
+  Production builds (Task 1 / frag-11 §11.2 packaging path) MUST NOT
+  thread this env var into the spawned daemon — `spawnOrAttach.ts` in
+  prod mode strips `CCSM_DAEMON_INSPECT` from the child env. Supervisor
+  restart-loop is already disabled in dev (§3.7.6.a) so a paused-at-
+  breakpoint daemon does not get killed for missed heartbeat;
+  auto-reconnect (§3.7.4) retries forever with a 5 s cap, so the
+  renderer simply shows the reconnect waiting toast until the
+  contributor resumes.
+- **Electron-main (`--inspect=9229`)**: existing pattern. `dev:app`
+  becomes `node scripts/wait-daemon.cjs && tsc -p tsconfig.electron.json && cross-env CCSM_DAEMON_DEV=1 electron ${CCSM_ELECTRON_INSPECT:+--inspect=9229} .`.
+  `CCSM_ELECTRON_INSPECT=1 npm run dev` opens 9229. Port 9229 is the
+  Node default and matches existing working-tip Electron-main inspect
+  conventions.
+- **Renderer**: existing Chrome DevTools (open from the Electron window
+  menu / `Ctrl+Shift+I`). No env var needed — devtools availability is
+  already gated by `app.isPackaged === false` in the existing renderer
+  bootstrap.
+
+**VS Code attach**: add two `attach` configurations to
+`.vscode/launch.json` — `Attach to daemon` (port 9230) and
+`Attach to Electron-main` (port 9229), plus a `compounds` entry to
+launch both simultaneously. Contributors then run
+`CCSM_DAEMON_INSPECT=1 CCSM_ELECTRON_INSPECT=1 npm run dev` and select
+the compound from the VS Code Run panel.
+
+### 3.7.7.b SDK ownership in v0.3 daemon split (closes round-6 devx P0-2)
+
+[manager r7 lock: r6 devx P0-2 — daemon owns SDK directly (own Node 22 ESM); Electron-main loadSdk shim retained ONLY for any residual session-title/non-daemon SDK calls. New daemon code MUST NOT use the shim.]
+
+The v0.3 daemon process is its own Node 22 process with native ESM
+support; daemon-side modules MAY `import` `@anthropic-ai/claude-agent-sdk`
+directly (ESM-direct, no shim). The `electron/sessionTitles/loadSdk()`
+shim was created for the Electron 33 main process (CJS) needing to
+consume the ESM-only SDK; that constraint does NOT apply inside the
+daemon. **Daemon-side SDK consumers MUST use direct `import` (or
+top-level `await import()` if dynamic), never `loadSdk()`.**
+
+Recommended ownership (manager lock): the daemon owns ALL SDK runtime
+use — agent dispatch, streaming, tool execution, model API calls.
+Electron-main retains the `loadSdk()` shim ONLY for any residual
+read-only / non-daemon SDK call sites that survive the v0.3 split
+(e.g. session-title generation if it stays in Electron-main per
+existing working-tip placement). New code paths added under the v0.3
+plan MUST NOT introduce additional Electron-main SDK consumers; if a
+new SDK call is needed, it goes in the daemon. If audit determines
+sessionTitles also moves to the daemon in v0.3, the loadSdk shim can
+be deleted entirely — flagged for follow-up (frag-12 traceability row,
+not in v0.3 scope unless trivial).
+
+### 3.7.8 User-visible surface registry — see frag-6-7 §6.8
+
+**DELETED in round-3** (closes round-3 ux P0-UX-A: two competing
+registries). Surface registry is owned canonically by **frag-6-7 §6.8**
+(numeric priority 100/90/85/70/50/30, single `daemonHealth` IPC channel,
+single `useDaemonHealthBridge` hook, ≤1 modal at a time, explicit
+stacking + dedup rules). Every surface this fragment used to own
+(reconnect waiting, reconnect-stuck modal, queue overflow, stream gap,
+dev-mode build error, bridge-timeout spike, close-to-tray onboarding
+hint, pre-mount loader trigger) is now registered into §6.8.
+
+After the §6.8 r7 trim (16 → 7 rows), the dev-mode reconnect bridge
+publishes only into the surfaces that survived the cut: priority **70
+(red banner)** for `daemon.unreachable` (the former
+`reconnectExhausted` modal at N=15 + `bridgeTimeoutSpike` toast +
+`healthDegraded` banner are all collapsed into this single banner
+slot), priority **30 (transient info toast)** for `daemon.reconnected`,
+and priority **85 (modal)** for `daemon.crashLoop`. The polish surface
+slots (`reconnecting` toast, `queueOverflow` toast, `streamGap` toast,
+`bridgeTimeoutSpike` toast, `devBuildError` toast, `healthDegraded`
+banner, `reconnectExhausted` modal) are CUT in §6.8 r7 — log-only,
+no IPC publish. Pre-mount loader and close-to-tray hint were also
+cut in §6.8 r7 (close-to-tray onboarding deleted entirely; pre-mount
+loader subsumed by the existing splash).
+
+i18n keys are dot+camelCase across the bundle (round-3 ux CC-3 lock).
+After the §6.8 r7 trim the dispatched-surface keys are
+`daemon.unreachable`, `daemon.reconnected`, `daemon.crashLoop`. The
+former r6 keys `daemon.reconnecting`, `daemon.queueOverflow`,
+`daemon.reconnectExhausted`, `daemon.bridgeTimeoutSpike`,
+`daemon.streamGap`, `daemon.devBuildError`, `tray.closeHint` are
+OBSOLETE (log-only or deleted entirely). Drafted copy for the surviving
+keys lives in **frag-6-7 §6.8 + §6.1.1** copy table; this fragment no
+longer owns the strings.
+
+Cross-frag PUNT (one-line for frag-6-7 §6.8 fixer to absorb): the
+**dev-mode reconnect surface** has no analog in prod (in prod the
+supervisor banner absorbs reconnect waiting per the mutual-exclusion
+rule). frag-6-7 §6.8 must add a row for the dev-only `daemon.devBuildError`
+surface (the queue-waits->4s-in-CCSM_DAEMON_DEV case from old
+§3.7.4 row j) at priority 50; this is the only surface that fires in dev
+but not prod. All other former-§3.7.8 rows already have §6.8 equivalents.
+[manager r11 lock: PUNT obsolete — §6.8 r7 trim explicitly cut `daemon.devBuildError`; this slot is permanently LOG ONLY per §3.7.5 r7 lock. (historical; no longer relevant)]
+
+---
 
 ## Plan delta
-- New task or extend Task 1 (workspace setup): nodemon config (+2h),
-  npm script wiring (+1h).
-- New task or extend Task 7 (Connect client): auto-reconnect + queue
-  (+4h), tests (+2h).
-- Renderer toast wiring (+1h, can fold into existing UI task).
+
+Concrete edits to `docs/superpowers/plans/2026-04-30-v0.3-daemon-split.md`:
+
+### Task 1 (Phase 0 scaffolding) — **+5 h** (was +3 h)
+
+- Add `nodemon` + `cross-env` + `wait-on@^7` to root `devDependencies`
+  (`npm i -D nodemon cross-env wait-on`).
+- **Add `"workspaces": ["daemon"]` to root `package.json`** (closes
+  round-2 devx P0-1).
+- Create `nodemon.daemon.json` (config in §3.7.3 above).
+- Create `scripts/wait-daemon.cjs` (resolves cross-platform lockfile path
+  + invokes `wait-on file:`).
+- Create `scripts/setup.cjs` (one-stop install + native rebuild) —
+  closes round-2 devx P0-4.
+- Edit root `package.json` `scripts`:
+  - Replace `dev` to add `daemon` lane (§3.7.2).
+  - Add `dev:daemon`, prepend `cross-env CCSM_DAEMON_DEV=1` to `dev:app`,
+    use `node scripts/wait-daemon.cjs` for the daemon-ready probe (NOT
+    the no-op `tcp:127.0.0.1:0`).
+  - Add `setup` script.
+- README + CONTRIBUTING note covering toolchain prerequisites table
+  from §3.7.2.c (folds in devx MUST-FIX 5 + round-2 P0-4).
+- Add VS Code TS Project References to `tsconfig.json` (`references: [{ path: "daemon" }]`)
+  + `composite: true` to `daemon/tsconfig.json` (closes round-2 devx
+  S-3 — small but high payoff).
+- Estimate breakdown: nodemon config + script wiring 2 h, wait-daemon
+  + setup scripts 1 h, workspaces wiring 0.5 h, README + tsconfig refs 1.5 h.
+
+### Task 7 (Connect client + handshake) — **+9 h** (was +7 h)
+
+- New file: `electron/daemonClient/reconnectQueue.ts` (~120 LOC, FIFO
+  queue, dev/prod cap split, exponential backoff scheduler).
+- New file: `electron/daemonClient/streamHandleTable.ts` (~80 LOC,
+  iterates handles for `.cancel()` on reconnect, clears client-side
+  heartbeat timers).
+- Modify `electron/daemonClient/connectClient.ts`: wrap `rpcCall` so it
+  routes through the queue when the underlying socket is down; expose
+  `subscribe(descriptor)` returning an unsub fn that also removes from
+  the resubscription map; include `bootNonce` capture per §3.7.5.
+- Modify `electron/daemonClient/spawnOrAttach.ts`: in dev mode
+  (`CCSM_DAEMON_DEV=1`), **skip** the `spawnIfMissing` branch — nodemon
+  owns the daemon lifecycle; Electron only attaches with retry. Also
+  ensure dev mode does NOT call into frag-11's pkg-binary path resolver
+  at all (closes round-2 devx P0-3 spawnOrAttach side).
+- Modify Task 7 step 4 spawn: `stdio: process.env.CCSM_DAEMON_DEV ?
+  "inherit" : "ignore"` and `detached: !process.env.CCSM_DAEMON_DEV`.
+- New tests: `connectClient.reconnect.test.ts` (+2 h),
+  `connectClient.resubscribe.test.ts` (+1 h, includes bootNonce + stale
+  handle cleanup).
+- New e2e phase: `harness-agent.daemonReconnect` (+1 h folded into
+  existing fixture, NOT a standalone probe — closes round-2 devx P1-7;
+  platform-aware kill target per round-3 devx P1-5).
+- Pre-mount loader: PUNTED to frag-6-7 §6.8 (was §3.7.8.d in r2; surface
+  registry collapse moves the trigger there).
+- Estimate breakdown: queue + backoff impl 2 h, subscribe map +
+  bootNonce 1.5 h, streamHandleTable 1 h, spawnOrAttach dev-mode
+  branch 1 h, tests 3 h, harness-agent phase 0.5 h. (Pre-mount loader
+  hour moved to frag-6-7's plan delta.)
+
+### Task 11 (PTY service lift) — **+1 h** (resubscribe contract)
+
+- Confirm PTY RPC contract accepts `fromSeq` and emits `gap: true` when
+  asked for an evicted sequence (already mandated by §3.5.1 fragment;
+  this is a cross-fragment sanity check, not new work).
+- Confirm `bootNonce` is included in the subscribe response envelope
+  (declared by frag-6-7 §6.5; camelCase locked round-3).
+
+### Task 13 (notify service lift) — **+1 h** (resubscribe contract)
+
+- Same `fromSeq` / `gap` / `bootNonce` semantics as Task 11.
+
+### Task 21 (tray) — **+0.5 h** (Quit semantics only)
+
+- **Tray "Quit" handler** (round-3 devx P1-1): wire `app.quit()` (NOT
+  `win.close()`) so the working tray-menu Quit button actually exits
+  the app even when in close-to-tray hidden state. (The former r6
+  rationale referenced a `reconnectExhausted` modal Quit button; that
+  modal was cut by §6.8 r7. The tray-menu Quit is now the only
+  Quit affordance.)
+- [manager r7 lock: cut as polish — N2# from r6 feature-parity. Win-only
+  "Tail daemon log in new terminal" tray entry deleted; v0.3 ships
+  working's `[Show CCSM | Quit]` tray menu unchanged. Log path lives in
+  release notes only.]
+- [manager r7 lock: cut as polish — N4# from r6 feature-parity. The
+  close-to-tray onboarding hint surface AND the
+  `close_to_tray_shown_at` SQLite key are deleted entirely. Working's
+  existing `closeBehaviorOptions.ask` first-close prompt already covers
+  the discoverability concern; no parallel onboarding moment. Task 21
+  no longer wires any close-hint check beyond the existing close-prompt
+  preserved from working.]
+
+### New sub-task under Task 7: renderer surface registry bridge — **+1 h** (was +2 h)
+
+- New file: `src/app-effects/useDaemonReconnectBridge.ts` (mirrors
+  `useUpdateDownloadedBridge.ts` and `usePersistErrorBridge.ts`;
+  publishes into the canonical surface registry via §6.8's
+  `useDaemonHealthBridge` rather than owning a separate
+  `useSurfaceRegistry.ts`). Subscribes to reconnect events from
+  `connectClient`, applies the 250 ms hold-off, dispatches the trimmed
+  surface set per the §6.8 r7 cut: `daemon.unreachable` (banner, covers
+  reconnect-attempt-failed + supervisor-down) / `daemon.reconnected`
+  (toast, debounced 5s) / `daemon.crashLoop` (modal). Polish surfaces
+  cut by §6.8 r7 (`daemon.queueOverflow`, `daemon.bridgeTimeoutSpike`,
+  `daemon.streamGap`, `daemon.devBuildError`,
+  `daemon.healthDegraded`, `daemon.reconnectExhausted`) are LOG ONLY —
+  no IPC publish.
+- The `useSurfaceRegistry.ts` central bus that the r2 plan delta
+  proposed is **NOT** built here — it lives in frag-6-7 §6.8 plan delta
+  (round-3 manager arch decision #1).
+- New i18n keys (dot+camelCase per round-3 lock #5) in
+  `src/i18n/locales/en.ts` and `src/i18n/locales/zh.ts` — only the
+  three keys the bridge still dispatches; the canonical copy table
+  lives in §6.8 / §6.1.1.
+- Wire bridge into `src/App.tsx` next to existing `*Bridge` calls.
+- Estimate breakdown: bridge 0.75 h, i18n + wiring 0.25 h. (1 h saved
+  vs r6's +2 h by trimming the dispatched surface set per §6.8 r7
+  feature-parity cuts.)
+- [manager r7 lock: surfaces trimmed per N6# from r6 feature-parity —
+  daemon-split brings new failure modes the user MUST see (unreachable,
+  crashLoop, reconnected confirmation), but degraded-but-functional
+  states (queueOverflow, bridgeTimeoutSpike, streamGap, devBuildError,
+  healthDegraded, reconnectExhausted) are not user-must-see and were
+  log-only in working.]
+
+### Task 25 (dogfood acceptance) — **+0.5 h** (production log access — docs only)
+
+- Daemon log path documented in release notes + About dialog so users
+  can locate `<dataRoot>/logs/daemon.log` for support diagnostics.
+- Acceptance: pino-roll rotation cycle works on Win 11 (rotated file
+  written) AND on macOS / Linux (symlink updated). Path is OS-native
+  data root per round-3 lock #3 (`%APPDATA%\ccsm\logs\daemon.log` on
+  Win, NOT `~/.ccsm/`).
+- [manager r7 lock: cut as polish — N2# + N3# from r6 feature-parity.
+  Tray "Open daemon log" entry + Win "Tail daemon log in new terminal"
+  entry DELETED entirely; v0.3 is refactor scope, no new tray menu
+  items. `pino-roll` `symlink: true` (frag-6-7 §6.6) still required for
+  POSIX `tail -F` from a user terminal; Win users open the dated
+  rotated file directly via Explorer. The Win symlink-handle caveat is
+  noted in release notes only.]
+
+### Total v0.3 estimate impact
+
+**+18 h** (Task 1 +5, Task 7 +9, Task 11 +1, Task 13 +1, Task 21 +0.5,
+new surface-bridge sub-task +1, Task 25 +0.5). Down from r6's +21 h:
+r7 polish cuts removed the Win tail-log + Open daemon log tray entries
+(-1.5 h on Task 25), trimmed Task 21's tray work (-0.5 h, no
+close-to-tray onboarding), and shrank the surface-bridge sub-task
+(-1 h, fewer i18n keys to wire — see frag-6-7 §6.8 row count cut).
+Plus closes the round-3 P0-UX-A surface-registry-duplicate bug.
+
+---
+
+## Cross-frag rationale
+
+§3.7 owns **devx mechanics** (nodemon topology, reconnect queue,
+resubscribe, dev-mode supervisor disablement). The user-visible surface
+registry is **NO LONGER OWNED HERE** — round-3 manager arch decision #1
+collapses it into frag-6-7 §6.8 as the canonical source. §3.7's
+reconnect bridge publishes into §6.8 rather than owning a parallel
+vocabulary.
+
+All P0 + P1 items from round-2 + round-3 reports under
+`~/spike-reports/v03-r{2,3}-*.md` that touch §3.7's wire surface have
+been folded in; items that belong on a sibling fragment are explicitly
+**punted** below with a one-line contract for the receiving fixer.
+
+**Owned by §3.7 (this fragment, applied above):**
+
+- devx P0-1 — Workspaces declaration in root `package.json` — Task 1.
+- devx P0-2 — `wait-on tcp:127.0.0.1:0` no-op replaced with
+  `scripts/wait-daemon.cjs` + `wait-on file:` against OS-native data
+  root. §3.7.2 + Task 1.
+- devx P0-3 (spawnOrAttach side) — dev mode skips pkg-binary path.
+  §3.7.2.b + Task 7. **frag-11 still owns** the `devTarget()` fence.
+- devx P0-4 — Toolchain prerequisites + `npm run setup`. §3.7.2.c +
+  Task 1.
+- devx P0-5 (tray "Open daemon log" + Win tail entry) — Task 25 plan
+  delta. **frag-6-7 still owns** the `pino-roll symlink: true` config
+  itself (round-3 devx CF-1 / resource X2: not landed in r2).
+- devx P1-3 — Dev-build-error surface published into §6.8 by §3.7
+  bridge.
+- devx P1-6 — Stream handle `.cancel()` before resubscribe — §3.7.5
+  step 1 + new `streamHandleTable.ts`.
+- devx P1-7 — E2E folded into `harness-agent.daemonReconnect` phase.
+- reliability P1-R1 — Dev queue cap = 1000 — §3.7.4.
+- resource P0-1 — Reconnect-queue does NOT replay through queue;
+  §3.7.4.a. **frag-3.5.1 §3.5.1.5 still owns** the carve-out sentence.
+- ux P1-UX-1 — Reconnect retries forever → promote to §6.8
+  `daemon.unreachable` red banner once supervisor miss threshold is
+  passed (the former r6 N=15 `reconnectExhausted` modal was folded
+  into `daemon.unreachable` per §6.8 r7 trim). §3.7.4 + cross-ref §6.8.
+- ux P1-UX-4 — Reconnect surface vs supervisor banner mutual
+  exclusion — owned by §6.8's stacking rule, this fragment publishes
+  conformantly.
+- fwdcompat P1-1 — `bootNonce` (camelCase, locked round-3) in subscribe
+  response. §3.7.5 step 3.
+- fwdcompat (canonical stream-RPC contract owner) — §3.7.5 references
+  frag-3.4.1 §3.4.1.b as canonical instead of re-declaring.
+- **r3 ux P0-UX-A** — §3.7.8 deleted, replaced with cross-ref to
+  frag-6-7 §6.8. Closes the two-competing-registries bug.
+- **r3 ux/resource CC-1/X4** — close-to-tray SQLite key dropped here;
+  §6.8 owns `close_to_tray_shown_at` (timestamp, manager arch
+  decision #2).
+- **r3 ux CC-3** — i18n keys locked dot+camelCase in the new §3.7.8
+  cross-ref paragraph + plan delta.
+- **r3 ux CC-4 / fwdcompat #2** — `BridgeTimeoutError` never
+  user-surfaced per-call; surfacing absorbed into §6.8 spike + modal
+  slots.
+- **r3 obs P1-2** — Reconnect emitter cross-refs frag-6-7 §6.6.2
+  canonical log line names (`daemon_socket_closed`,
+  `daemon_reconnect_attempt`, `daemon_reconnect_success`,
+  `daemon_queue_overflow`, `stream_resubscribe`). §3.7.4 toast UX
+  paragraph.
+- **r3 reliability CF-3** — §3.7.6.a clarified: supervisor restart loop
+  off in dev, transport + healthz polling stay for status badge.
+- **r3 devx P1-1** — Tray "Quit" handler calls `app.quit()` not
+  `win.close()`. Task 21 plan delta.
+- **r3 devx P1-2** — In-flight chunk dedup across teardown documented
+  in §3.7.5 step 3 (renderer trusts `seq` only within one
+  `(sid, bootNonce)` tuple).
+- **r3 devx P1-3** — `npm rebuild --prefix daemon` → `npm -w
+  @ccsm/daemon rebuild`. §3.7.2.c.
+- **r3 devx P1-4** — `Get-Content -Wait` symlink-follow caveat: POSIX-
+  only fix; Win adds tray "Tail daemon log in new terminal" entry.
+  §3.7.2.d + Task 25.
+- **r3 devx P1-5** — E2E `pkill` target made platform-aware for
+  prod-installed daemon. §3.7.7.
+
+**Punted to other fragments (one-line contract for the receiving
+fixer):**
+
+- **frag-11 fixer** — §11.2 must remove or fence the `devTarget()`
+  branch behind `!process.env.CCSM_DAEMON_DEV` so prod path doesn't
+  read as authoritative for dev. (devx P1-4 + remainder of P0-3;
+  round-3 devx CF-2 not landed in r2.)
+- **frag-3.5.1 fixer** — §3.5.1.5 must add: "initial replay burst on
+  resubscribe is NOT counted toward the 1 MB per-subscriber drop-
+  slowest watermark" (resource P0-1 resolution b). §3.5.1.3 must add:
+  "BridgeTimeoutError is logged with `DEADLINE_EXCEEDED` but NEVER
+  surfaced to the user; surfacing is owned by frag-6-7 §6.8's single
+  `daemon.unreachable` banner slot per the §6.8 r7 trim (separate spike
+  + reconnectExhausted slots are cut)" (round-3 ux CC-4 / devx CF-3
+  not landed in r2).
+- **frag-6-7 fixer (highest-priority pickup queue):**
+  - §6.6 pino-roll config must add `symlink: true` to BOTH daemon and
+    electron blocks (round-3 resource X2 / devx CF-1 not landed in r2).
+  - §6.8 must absorb the **dev-only `daemon.devBuildError`** surface at
+    priority 50 (only surface that fires in dev but not prod; all other
+    former-§3.7.8 rows already have §6.8 equivalents). [manager r11 lock:
+    PUNT obsolete — §6.8 r7 trim explicitly cut `daemon.devBuildError`;
+    this slot is permanently LOG ONLY per §3.7.5 r7 lock. (historical;
+    no longer relevant)]
+  - §6.8 must absorb the **pre-mount loader** trigger (was §3.7.8.d in
+    r2; r3 surface-registry collapse moves it here). 1 h estimate
+    transferred from §3.7's plan delta.
+  - §6.8 must lock `close_to_tray_shown_at` (timestamp) as the
+    canonical SQLite key (round-3 manager arch decision #2 + ux CC-1).
+- **Task 21 (tray) owner** — wire `close_to_tray_shown_at` check before
+  `win.hide()`; emit the §6.8 onboarding-hint surface on the first
+  close (round-3 manager arch decision #2). Also wire `app.quit()`
+  semantics for the modal "Quit" button (round-3 devx P1-1).
+
+**Not addressed (out of §3.7 scope, flagged for completeness):**
+
+- devx P1-1 r2 (Task 5 21h hot-file collision on `connectAdapter.ts`)
+  — plan-organisation concern. **Punt to manager**.
+- devx P1-5 r2 (native helper compile on every checkout) — partial
+  mitigation via §3.7.2.c. Full fix owned by frag-3.5.1 §3.5.1.1.
+- ux P0-UX-3 (cold-start no-bak modal full copy) — full ownership lives
+  with frag-6-7 §6.1.1 copy table.
+- All SHOULD/nits not adjacent to a P0/P1 intentionally not edited per
+  round-3 fixer scope.
+
+---
+
+## 3-line summary
+
+Round-3 collapses §3.7.8 into a one-paragraph cross-ref to frag-6-7 §6.8
+(canonical surface registry, manager arch decision #1), drops the
+duplicate close-to-tray SQLite key, and locks `bootNonce` to camelCase +
+i18n keys to dot+camelCase across the bundle. §3.7.6.a is clarified
+(supervisor restart loop off in dev, but transport + `/healthz` polling
+stay for status badge). Five round-3 P1 nits folded in: tray "Quit"
+calls `app.quit()`, in-flight chunks dedup by `(sid, bootNonce)` tuple,
+`npm -w @ccsm/daemon rebuild` syntax, Win `Get-Content -Wait` symlink-
+follow caveat (POSIX-only fix + new tray "Tail in new terminal" entry),
+and platform-aware e2e kill target for prod-installed daemon.

--- a/docs/superpowers/specs/v0.3-fragments/frag-3.7-dev-workflow.md
+++ b/docs/superpowers/specs/v0.3-fragments/frag-3.7-dev-workflow.md
@@ -1,0 +1,32 @@
+# Fragment: §3.7 Dev workflow (hot-reload + auto-reconnect)
+
+**Owner**: worker dispatched per Task #938
+**Target spec section**: new §3.7 in main spec (after §3.6)
+**P0 items addressed**: #13 (dev hot-reload + auto-reconnect)
+
+## What to write here
+Replace this section with the actual `## 3.7 Dev workflow` markdown. Cover:
+1. **`npm run dev` topology in v0.3**:
+   - Electron main + renderer (existing vite/electron-forge dev).
+   - Daemon spawned as separate Node process via nodemon; restarts on
+     `daemon/**` source changes.
+   - Specify which workspace script orchestrates both (concurrently? turbo?
+     existing pattern?).
+2. **Electron client auto-reconnect**:
+   - On socket EOF / ECONNREFUSED, Connect client retries with exponential
+     backoff: 200ms → 400ms → 800ms → ... cap 5s.
+   - During reconnect: bridge calls queue (bounded 100? reject after?), UI
+     shows "daemon reconnecting…" toast (existing toast system).
+   - On reconnect success: replay any session subscription state (sids the
+     renderer was watching) so user doesn't lose live view.
+3. **Prod behavior** (contrast): supervisor is the OS service / electron
+   main; auto-reconnect logic still applies but daemon restart is rarer.
+
+Cite findings from `~/spike-reports/v03-review-devx.md`.
+
+## Plan delta
+- New task or extend Task 1 (workspace setup): nodemon config (+2h),
+  npm script wiring (+1h).
+- New task or extend Task 7 (Connect client): auto-reconnect + queue
+  (+4h), tests (+2h).
+- Renderer toast wiring (+1h, can fold into existing UI task).

--- a/docs/superpowers/specs/v0.3-fragments/frag-6-7-reliability-security.md
+++ b/docs/superpowers/specs/v0.3-fragments/frag-6-7-reliability-security.md
@@ -1,62 +1,549 @@
 # Fragment: §6 reliability + §7 security expansion
 
-**Owner**: worker dispatched per Task #936
-**Target spec sections**: replace existing §6 and §7 in main spec
-**P0 items addressed**: #11 (pino.final), #12 (pino-roll); plus §7 absorbs
-the threat model post-hardening
+**Owner**: Task #936 (worker, pool-2). Round-3 fixes applied per `~/spike-reports/v03-r3-*.md`.
+**Target spec sections**: REPLACE existing §6 ("Error handling and edge cases") and §7 ("Testing") in `docs/superpowers/specs/2026-04-30-web-remote-design.md`. The v1 §7 ("Testing") moves to §6.6 below; the new §7 is dedicated Security.
+**P0 review items addressed**: rel-M1..M5, rel-S1/S2/S3/S5/S7, sec-M1..M3, sec-S1..S6, obs-MUST 2/3/4, res-MUST 1, round-2: rel P0-R1..R5, sec P0-S1..S3, obs P0-1..P0-4, fwdcompat P0-2, ux P0-UX-1/UX-3, pkg P0-1 (uninstall hygiene — TAKEN here, see §6.8). **Round-3**: rel R1..R5 (drain order, crash-loop reset, paused/abandoned terminal, daemon.crashing best-effort), sec P0-1/P0-2 (HMAC-of-nonce hello, fromSeq ACCEPTED), ux P0-A/P0-B/P0-C (surface registry canonical, migration priority callout, frag-12 PUNT), obs P1-1/P1-2 (canonical log key names), devx CF-1 (pino-roll symlink), devx CF-3 (BridgeTimeout policy), fwdcompat (boot_nonce → bootNonce, daemonProtocolVersion mirror), lockin CF-2/CF-3 (clientImposterSecret redact + protocolVersion mirror), resource X1/X3/X4 (~/.ccsm aggregate cap, uninstall double-claim, close_to_tray key), perf CF-1/CF-2 (-sup vs control-socket clarification, traceId hot-path carve-out).
+**OS-native install + data root paths (LOCKED v0.3)**:
+- Win: `%LOCALAPPDATA%\ccsm\` (per-user; binaries in `bin\`, data + lock + secret + logs at root)
+- macOS: `~/Library/Application Support/ccsm/`
+- Linux: `~/.local/share/ccsm/`
+- Legacy `~/.ccsm/` references in this fragment are historical aliases for the OS-native data root above. All NEW spec text uses `<dataRoot>` notation; concrete paths in tables resolve to OS-native.
+**Inputs cited**:
+- `~/spike-reports/v03-review-reliability.md`, `~/spike-reports/v03-r2-reliability.md`, `~/spike-reports/v03-r3-reliability.md`
+- `~/spike-reports/v03-review-security.md`, `~/spike-reports/v03-r2-security.md`, `~/spike-reports/v03-r3-security.md`
+- `~/spike-reports/v03-review-observability.md`, `~/spike-reports/v03-r2-observability.md`, `~/spike-reports/v03-r3-observability.md`
+- `~/spike-reports/v03-review-resource.md`, `~/spike-reports/v03-r3-resource.md`
+- `~/spike-reports/v03-r2-fwdcompat.md`, `~/spike-reports/v03-r3-fwdcompat.md`
+- `~/spike-reports/v03-r2-ux.md`, `~/spike-reports/v03-r3-ux.md`
+- `~/spike-reports/v03-r2-packaging.md`
+- `~/spike-reports/v03-r3-devx.md`, `~/spike-reports/v03-r3-lockin.md`, `~/spike-reports/v03-r3-perf.md`
 
-## What to write here
+---
 
-### §6 Reliability (rewrite)
-Existing §6 is thin. Expand to cover:
-1. **Daemon supervision**:
-   - Electron main spawns daemon; on daemon exit, supervisor decides:
-     restart with backoff (1s → 2s → 4s ... cap 30s, reset after 60s
-     stable), OR enter "crash loop detected" state after 5 restarts in
-     2 min (surface UI, stop auto-restart, ask user).
-   - Last-known-good binary: on auto-update, keep `daemon.bak`; if new
-     daemon crash-loops, supervisor falls back to `.bak` automatically.
-2. **Logging shutdown safety**:
-   - `pino.final()` registered on daemon `beforeExit` and signal handlers
-     (SIGTERM, SIGINT) so buffered log writes flush before exit. Without
-     this, last-second crash logs are lost.
-3. **Log rotation**:
-   - `pino-roll` (or `pino-rotating-file` — pick one and justify) configured
-     with daily rotation + 7 day retention + 50 MB per file cap. Files at
-     `~/.ccsm/logs/daemon-YYYY-MM-DD.log`. Prevents unbounded disk usage
-     (resource review noted this gap).
-4. **Health probe**: daemon exposes `/healthz` RPC (no auth needed, local-only)
-   returning uptime + active session count. Used by supervisor for liveness;
-   future v0.4 adds `/readyz` for migration completion.
+## 6. Reliability
 
-### §7 Security (rewrite)
-Existing §7 understated. Expand to cover:
-1. **Trust boundary (v0.3)**: same-machine, same-user. Enforced by:
-   - Local socket only (no TCP listener at all in v0.3).
-   - OS-level ACL/mode (§3.1.1).
-   - Sender peer-cred verification per connection (§3.1.1).
-2. **Defense in depth**: even with trust boundary, daemon validates every
-   envelope schema (TypeBox), enforces frame caps (§3.4.1), and never
-   shells out user-provided strings unescaped.
-3. **Supply chain**:
-   - Daemon binary published with SHA256 manifest in GitHub release.
-   - Auto-update verifies SHA256 before swap (§3.1).
-   - **Roadmap**: sigstore signing in v0.4 → flip auto-update default ON.
-   - **Roadmap**: Cloudflare Access JWT validator middleware in v0.5 (seam
-     already present from v0.3 §3.1).
-4. **Threat model (post-hardening) table**: rows = attacker capability,
-   columns = mitigation. e.g. "local non-admin user on same machine" → ACL
-   denies; "remote attacker on LAN" → no listener; "compromised daemon
-   binary on disk" → SHA256 verify on update (limited; full sig in v0.4).
+v1 §6 ("Error handling and edge cases") is replaced wholesale. The bullet list below is the contract; failure-modes table F1..F12 from rel-review §2 is the canonical enumeration and is appended as §6.7. §6.8 owns user-visible surfaces (modal/toast/banner registry) and uninstall hygiene (relocated from frag-11 packaging — see Cross-frag rationale).
 
-Cite findings from `~/spike-reports/v03-review-reliability.md`,
-`~/spike-reports/v03-review-security.md`,
-`~/spike-reports/v03-review-observability.md`,
-`~/spike-reports/v03-review-resource.md`.
+### 6.1 Daemon supervision (Electron-side)
+
+Electron-main owns daemon lifecycle. Single `daemonSupervisor` module runs in main; never in renderer.
+
+- **Spawn-or-attach** at boot via `daemonSupervisor.start()` (Task 7). Probe `<dataRoot>/daemon.lock` (see §6.4) → if held + reachable → attach; else spawn.
+- **Heartbeat (prod)**: supervisor pings `/healthz` (see §6.5) every 5s on the **dedicated supervisor transport** (separate from the data-path adapter — see §6.5). Three consecutive misses (15s) → mark daemon dead, trigger restart cycle. Renderer shows yellow banner on first miss, red on third (copy table §6.1.1).
+- **Heartbeat (dev)** (resolves r3-devx CF-3 contradiction with frag-3.7 §3.7.6.a): when `process.env.CCSM_DAEMON_DEV === '1'` (frag-3.7 §3.7.6), the supervisor lifecycle logic (spawn / restart / crash-loop / rollback) is DISABLED in full — nodemon owns the lifecycle, frag-3.7's auto-reconnect queue is the dev liveness signal. **The dedicated supervisor transport (§6.5 `ccsm-control` socket) is still bound** so the renderer's diagnostic UI can poll `/healthz` (read-only, no decisions). Polling cadence: 30s interval / 5-miss threshold / 60s grace; never enters crash-loop or restart logic. Concretely: in dev, the supervisor module behaves as a passive `/healthz` reader for UI, NOT a lifecycle owner. (Sources: r2-rel P0-R1, r3-devx CF-3, frag-3.7 §3.7.6.a "Supervisor active? NO" reconciled.) `[manager r11 lock: P1 devx P1-2 socket name canonical = ccsm-control per frag-3.4.1 §3.4.1.h table; was `-sup`]`
+- **Backoff on respawn**: `1s → 2s → 4s → 8s → 16s → cap 30s`. Counter resets to 1s after the daemon stays up ≥60s. State stored in supervisor RAM only; survives renderer reload, not Electron quit. (Source: spec stub Task #936.)
+- **Crash-loop detection**: ≥5 respawns within a sliding 2-minute window → enter `crash-loop-detected` state. Supervisor STOPS auto-restart, surfaces a modal banner per §6.1.1 copy table, and emits one `daemon.crashLoop` IPC to the renderer (camelCase i18n key per ux CC-3 lock; see §6.8 i18n note). The user must explicitly retry; auto-rollback to `.bak` (§6.4) is offered as one of the modal buttons. No silent restart loops.
+- **Crash-loop counter reset rule (r3-rel R2 — REVISED)**: on a "successful rollback" (defined below), the **backoff counter** resets to 1s, but the **crash-loop sliding window does NOT fully clear** — instead it decays so that the rolled-back crash counts as `3 of 5` (i.e. only 2 more crashes within the 2-minute window trigger crash-loop state again, not 5). Rationale: rollback is "limp mode" — the `.bak` binary may itself have a latent crash that takes >60s to surface (e.g. periodic poll, lazy SDK init); without partial-counter retention, supervisor would silently re-enter fresh state and let 5 MORE crashes happen before user surfaces. Documented explicitly: rollback is not "all clear." **Marker-aware skip (round-7 manager lock — fixer G verify; round-9 manager lock — r8 reliability marker-unlink ownership)** `[manager r7 lock: G verify — marker-aware crash-loop skip]` `[manager r9 lock: r8 reliability — marker unlink ownership reconciled with §6.4: if marker present, supervisor skips crash-loop counter; daemon will unlink after §6.4 self-test passes — supervisor MUST NOT unlink (preserves marker across new-bundle crash-during-boot)]`: on every supervisor cold-start before applying R2 accounting, the supervisor checks for the presence of `<dataRoot>/daemon.shutdown` marker file (written by `daemon.shutdownForUpgrade` per §6.4 Marker semantics). If the marker is present, the previous shutdown was a clean upgrade — supervisor MUST NOT increment the crash-loop counter for this boot, MUST NOT trip the rollback path, and MUST NOT unlink the marker. The new daemon will unlink the marker after §6.4 self-test passes (60 s up + 5×/healthz pass) per §6.4 Marker semantics. If absent, normal R2 accounting applies. Marker-corruption / partial-write handling is treated as PRESENT (conservative — see §6.4 Marker semantics). (Source: r3-rel R2 + r7 packaging P0-2 cross-frag + r8 reliability marker-unlink ownership.)
+- **Crash-loop log signature** (r2-obs P1-1): on entering crash-loop state the supervisor writes one structured pino line `{ event: "crashloop_entered", respawnCount, windowMs, lastExitCodes: [...], lastTraceIds: [...], lastBootNonces: [...] }` BEFORE emitting the IPC. Single grepable forensic anchor.
+- **Cold-start failure**: if the FIRST spawn after Electron boot dies within 30s of accept-loop ready, supervisor auto-rolls back to `daemon.exe.bak` exactly once before entering crash-loop state. **"Successful rollback"** = the swapped-back binary survives 60s AND answers `/healthz` 5 consecutive times; on success, supervisor (a) clears the backoff counter, (b) **decays** the crash-loop sliding window per the R2-revised rule above (rolled-back crash = 3/5), (c) emits `daemon.rolledback` IPC. If the swapped-back binary itself fails the 60s/5-ping test, supervisor enters crash-loop state with the no-bak modal copy (§6.1.1 row "rollback-also-failed"). (Source: rel-M5 + r2-rel P0-R2 + r3-rel R2.)
+- **Cold-start splash** (r2-ux P1-UX-6): renderer's HTML shell shows a `Starting ccsm…` pre-mount loader (CSS-only, no JS deps) until supervisor reports daemon ready. Cheap; eliminates blank-white-window first impression on cold installs / SmartScreen scan.
+
+#### 6.1.1 Supervisor-state user-facing copy (drafted; sentence-case; future-i18n keys named)
+
+Mirror of frag-8 §8.6 format. All strings are placeholders pending i18n bundle; reviewer enforces sentence case (no SCREAMING) and no developer-speak (no "DEADLINE_EXCEEDED", no "ECONNREFUSED" leaking to users — those are log-only per §6.6 and r2-ux §4 last bullet).
+
+| State | Surface | i18n key | Title | Body | Buttons |
+|---|---|---|---|---|---|
+| Daemon unreachable (heartbeat-miss / reconnect-attempts-failing / reconnect-exhausted — single unified surface) | Banner (red) | `daemon.unreachable` | ccsm lost contact with the background service | Trying to restart it. If this persists, ccsm may need to be reinstalled. | (none) |
+| Crash-loop (with bak) | Modal (blocking) | `daemon.crashLoop` | The background service is failing to start | We've kept your previous version available as a backup. | Restore from backup / Quit |
+| Crash-loop (no bak) | Modal (blocking) | `daemon.crashLoop` | The background service is failing to start | This is a clean install with no previous version to roll back to. Please download a fresh installer from the GitHub Releases page and reinstall ccsm — sessions can't start until then. | Quit |
+| Migration failed (frag-8 §8.6 fatal-error) | Modal (blocking) | `migration.modal.failed.*` | (frag-8 §8.6 owns copy) | (frag-8 §8.6 owns body) | Quit ccsm |
+| Installer corrupt (carry-forward from working) | Modal (blocking) | `installerCorrupt` | (preserved unchanged from working `installerCorrupt.title`) | (preserved unchanged from working `installerCorrupt.body` — prose only, "please reinstall CCSM to repair the install") | (none — prose only per r5 lock #8) |
+| Reconnected (recovery confirmation, debounced 5s) | Toast (info, 3s) | `daemon.reconnected` | Reconnected to the background service | (none) | (none) |
+
+[manager r7 lock: cut as polish — N6# from r6 feature-parity. §6.1.1 row count trimmed from 9 → 6. The single `daemon.unreachable` row collapses the former `daemon.healthDegraded` (yellow miss-1/3) + `daemon.healthUnreachable` (red miss-3/3) + `daemon.reconnectExhausted` modal + `daemon.bridgeTimeouts` banner — daemon-split brings new failure modes that user MUST see, but degraded-but-functional middle states (yellow banner, bridge-timeout spike) are diagnostic / log-only. The two `daemon.crashLoop` rows share one i18n key; the variant column survives only because the with-bak case adds a "Restore from backup" affordance. `daemon.rollingBack` / `daemon.rolledBack` (banner + toast) cut as polish — rollback completes silently from the user's perspective; if it fails, the noBak `daemon.crashLoop` row fires. `daemon.rollbackFailed` modal collapsed into the noBak `daemon.crashLoop` row (same user remediation: reinstall).]
+
+[manager r7 lock: C3# from r6 feature-parity — Quit button kept on `daemon.crashLoop` (both variants). Distinct from `installerCorrupt` prose pattern (r5 lock #8); user needs explicit exit affordance when daemon won't start (no other way out beyond OS window controls). r5 lock #8 specifically targeted the `installerCorrupt` "Reinstall" button, not exit-affordances. The `installerCorrupt` row remains prose-only with no button per r5 lock #8.]
+
+[manager r7 lock: M1# from r6 feature-parity — every existing renderer Settings panel toggle (`closeBehavior`, `theme`, `fontSize`, `language`, `crashReporting`, `notifications.enable`, `notifications.sound`, `updates.automaticChecks`) survives the daemon-split unchanged. The split moves data + lifecycle + IPC, NOT the renderer's preferences UI. Implementers MUST NOT "modernize" or silently drop options as part of the v0.3 lift.]
+
+[manager r7 lock: M2# from r6 feature-parity — `installerCorrupt` modal (working `src/components/InstallerCorruptBanner.tsx`) is preserved unchanged across the daemon-split. Title + body strings copy verbatim from working `installerCorrupt.title` / `installerCorrupt.body`; no buttons (prose-only per r5 lock #8). Surface fires when CCSM cannot find the bundled `claude` binary — distinct from `daemon.crashLoop` which fires when the daemon process fails to start.]
+
+**i18n key casing** (ux CC-3 lock): all daemon-health keys are dot-camelCase (`daemon.<event>` or `daemon.<event>.<variant>`). Frag-3.7 already uses this convention; frag-6-7 r3 fix aligns. PUNT: frag-3.7 to align any remaining drift; PUNT: frag-8 to align migration keys (`migration.<event>` camelCase).
+
+**zh.ts parity acceptance criterion (round-7 manager lock — r6 ux P0-4)** `[manager r7 lock: r6 ux P0-4 — zh.ts parity acceptance criterion]`: every new `en.ts` string added by v0.3 (this §6.1.1 copy table, the §6.8 surface registry rows, and any frag-3.7 / frag-8 i18n key referenced from those tables) MUST have a corresponding `zh.ts` entry shipped in the same PR. PR fails CI if `src/i18n/locales/en.ts` and `src/i18n/locales/zh.ts` keysets diverge — enforcement landed via a vitest hook (`tests/i18n/parity.test.ts`) that asserts `Object.keys(en).sort() === Object.keys(zh).sort()` for the daemon / migration / tray namespaces. Reviewer checks this mechanically before approval; no separate carve-out for "translate later".
+
+**BridgeTimeout policy (locked, devx CF-3 + ux CC-4; r7 update for §6.1.1 trim)**: `BridgeTimeoutError` (frag-3.5.1 §3.5.1.3) is **NEVER user-surfaced as a per-call toast**. The bridge wrapper logs `DEADLINE_EXCEEDED` at warn level (with `traceId`, `method`, `durationMs`) and returns a rejected Promise to the caller; renderer-side caller code MUST NOT surface raw `BridgeTimeoutError` to a toast. Surfacing flows through TWO paths only: (a) **internal retry-once**: bridge wrapper transparently retries the call once (single retry, 1s backoff) before rejecting; if the retry succeeds, no surface fires. (b) If the retry also fails, the timeout is LOG-ONLY at the per-call level. **Continuous unreachability** (supervisor heartbeat-miss / reconnect-exhausted) is the only user-visible path and it surfaces as the unified `daemon.unreachable` red banner per the §6.1.1 row above. The standalone `daemon.bridgeTimeouts` "service may be busy" banner was **cut as polish** in r7 per N6# from r6 feature-parity (degraded-but-functional state, log-only). PUNT: frag-3.5.1 §3.5.1.3 must add a one-sentence carve-out matching this rule. (Sources: r3-devx CF-3 + r3-ux CC-4 + r7 N6# trim.)
+
+**Handshake-failure classification (round-7 manager lock — r6 reliability P0-R1; r7 update for §6.1.1 trim)** `[manager r7 lock: r6 reliability P0-R1 — handshake failure is a distinct pre-RPC failure class; with the §6.1.1 r7 trim there is no separate "service may be busy" banner to falsely trip, so the original detector concern is moot. Tagging is still mandated for future metrics interceptor split.]`: per frag-3.4.1 §3.4.1.g (handshake-timeout paragraph), client-side handshake failures (2 s timeout, `hello_required`, `hello_replay`, `schema_violation` on `daemon.hello`, HMAC mismatch via `crypto.timingSafeEqual`, `compatible: false` reasons) surface through the existing supervisor heartbeat / reconnect ladder: each handshake-fail is one reconnect attempt under frag-3.7 §3.7.4 backoff, escalating to the unified `daemon.unreachable` red banner (whose body reads "Trying to restart it. If this persists, ccsm may need to be reinstalled." per the row above). **No new surface row is added**; the reinstall guidance lives in the body copy of `daemon.unreachable`. Implementer note: bridge wrapper MUST tag handshake errors with `class: 'handshake'` so the §3.7.4 retry path and any future metrics interceptor can split them from post-handshake `class: 'bridge-timeout'` failures cleanly (telemetry / log discriminator only — no user-surface fork).
+
+### 6.2 PTY child reaping
+
+Daemon owns PTY children, but the OS owns the orphan story. Without explicit reaping, every daemon crash leaks a `claude` CLI process (rel-M1).
+
+- **Windows**: each `pty.spawn()` is wrapped in a `JobObject` with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. When the daemon process handle closes (clean or crash), Win SCM kills every child in the job atomically. Implemented via small N-API helper or `koffi`; same dependency as §7.M1 pipe-ACL helper, so cost is shared.
+- **POSIX**: each `pty.spawn()` calls `setpgid(0, 0)` to get its own PG, plus `prctl(PR_SET_PDEATHSIG, SIGTERM)` on Linux / kqueue parent-watch on macOS. On daemon death, kernel signals the children.
+- **Plan delta**: Task 11a acceptance gains "no orphaned `claude.exe` after `taskkill /F` of daemon (Win) or `kill -9` (POSIX), verified by spawning, killing daemon, then asserting `Process32First` / `pgrep` returns 0".
+
+### 6.3 Session resurrection contract (F2)
+
+When daemon restarts cleanly (auto-update, supervisor respawn), running PTY sessions are gone. Spec was silent; now explicit:
+
+- Session rows in SQLite are marked `state = 'paused'` (i18n key `session.state.paused`) on daemon boot if their `pid_pgid` no longer maps to a live process. (`pid_pgid` written at spawn, cleared in the same DB transaction that writes any terminal state per §6.6.1 step 5 / r3-rel P1-R1.) **Wording change** (r2-ux P1-UX-5): the user did not abandon the session — the system did. Internal state value remains `paused`; legacy log fields may still say `abandoned` for back-compat one release.
+- **Terminal-state lock (r3-rel R3)**: the canonical terminal state is `paused` for any session whose pid no longer maps. `abandoned` as a separate terminal state is REJECTED — frag-3.5.1 §3.5.1.2 step 8 is wrong if it still emits `abandoned` after SIGKILL; the SIGKILL'd row should also land at `paused` (the user-visible affordance is identical: "system restarted, [Resume]"). PUNT to frag-3.5.1: §3.5.1.2 step 8 must drop `state='abandoned'` and use `state='paused'`. The two fragments must agree on a single terminal-name. (Source: r3-rel R3.)
+- Renderer shows paused sessions with a **`Paused — daemon was restarted [Resume]`** affordance. Resuming creates a fresh CLI subprocess with the same `cwd`, `model`, env subset, working directory, and seed prompt; new session id is linked back to the parent via a `parent_session_id` column. **Affordance copy explicitly notes**: `Resume creates a fresh CLI process. The previous turn (any work the model was doing when ccsm restarted) is not recovered.` (r2-rel P1-R4: in-flight CLI state is NOT magically restored.)
+- No silent auto-respawn. User intent required, because the prior CLI may have been mid-write.
+- (Source: rel-S3 + r2-rel P1-R4 + r2-ux P1-UX-5.)
+
+### 6.4 Single-instance + last-known-good rollback
+
+- **Lockfile (NOT pipe-probe)**: daemon boot acquires `<dataRoot>/daemon.lock` (Win: `%LOCALAPPDATA%\ccsm\daemon.lock`; macOS: `~/Library/Application Support/ccsm/daemon.lock`; Linux: `~/.local/share/ccsm/daemon.lock`) via `proper-lockfile` with `O_EXCL` create + PID write. The named-pipe / unix-socket bind is the secondary signal, not the gate. This closes rel-M4 (Win named pipes silently allow multi-instance via `PIPE_UNLIMITED_INSTANCES`). **Lockfile MUST be acquired BEFORE `ensureDataDir()` / migration runs** (r3-rel P0-R4 ordering — frag-8 §8.3 depends on this). Boot order: 1. acquire lockfile, 2. ensureDataDir + migration, 3. open SQLite, 4. start adapter.
+- **Stale lock recovery**: if lockfile exists but PID is dead (Win: `OpenProcess` returns `INVALID_HANDLE_VALUE`; POSIX: `kill(pid, 0)` returns ESRCH), supervisor steals the lock with a single warn log line.
+- **Lockfile create-fail policy** (rel-S-R4): if `proper-lockfile` create fails for any reason other than `EEXIST` (e.g. `noexec` mount, ENOSPC, EROFS), daemon refuses to start with a clear error written to stderr (pre-pino, since pino isn't initialized until after lockfile per r3-rel P1-R4) AND, when pino is up, a final fatal log line; **no silent fall-back to no-lock mode** ever.
+- **Daemon binary layout** (post-pkg, Task 20): installed under `%LOCALAPPDATA%\ccsm\bin\` on Win, `~/Library/Application Support/ccsm/bin/` on macOS, `~/.local/share/ccsm/bin/` on Linux. **Per-user** path with user-only ACL — never `Program Files` (sec-S1).
+- **Win Service vs user-mode** (rel-OPEN Q1): v0.3 ships **user-mode background process** only. Win Service mode is deferred to v0.4+ (no concrete demand from dogfood; user-mode is sufficient for single-user laptop scope).
+- **WAL pragma at every db open** (rel-OPEN Q5): daemon explicitly sets `PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;` on every `Database()` open path; verified at first boot and asserted in unit test.
+- **Auto-update swap is atomic** (Task 23):
+  1. Download `daemon.exe.new.partial`, retry 3× with exponential backoff on net error.
+  2. SHA256 verify against release manifest. **AND** verify SLSA-3 provenance attestation `provenance.intoto.jsonl` against GitHub's public OIDC root (see §7.3 v0.3 row). On either mismatch: delete `.partial`, abort, schedule retry on next 6h poll.
+  3. (Linux additionally verifies a minisign signature attached to the release; see §7.3.) (v0.4+) sigstore signature verify supersedes SLSA. v0.3 ships SLSA-attested with auto-update **DEFAULT OFF** (`CCSM_DAEMON_AUTOUPDATE` opt-in); manual update prompt only. (sec-S5 + sec-OPEN-3 + r2-sec P0-S3.)
+  4. **Rotate `daemon.secret`** (r2-sec P0-S1): generate fresh 32-byte random; write to `daemon.secret.new` with O_EXCL+0600/user-DACL atomically; rename over `daemon.secret`. **Pause supervisor `/healthz` polling for the swap window** (r3-sec P1-6): supervisor sets `swap_in_progress = true` so the old daemon's `/healthz` reply also carries `{ swapInProgress: true }` and the supervisor does not interpret old-secret HMAC mismatch as imposter-impersonation. Done BEFORE step 5 so the new daemon launches with the new secret AND the old binary's leaked secret loses authority on next supervisor poll.
+  5. Rename current `daemon.exe → daemon.exe.bak` (atomic on NTFS via `MoveFileExW(MOVEFILE_REPLACE_EXISTING)`).
+  6. Rename `daemon.exe.new → daemon.exe`.
+  7. Restart. If new daemon fails cold-start §6.1 self-test, supervisor swaps `.bak` back exactly once and surfaces a modal. **On successful rollback (60s up + 5×/healthz)** supervisor clears the backoff counter AND decays the crash-loop window per §6.1 R2 rule (rolled-back crash counts as 3/5, NOT a full clear) AND emits `daemon.rolledBack` IPC; subsequent crashes start counting from a non-zero floor. (r2-rel P0-R2 + r3-rel R2.)
+- **Swap-lock (r3-rel P1-R5)**: rollback step 7 is gated by the SAME `daemon.lock` (single supervisor instance per user since lockfile gate); concurrent supervisors (double-launch, MDM relaunch, debugger spawn) are prevented from racing the swap because only the lockholder is allowed to perform binary swap operations. The swap acquires + holds the lock through verify; if a competing supervisor cannot acquire the lock, it exits cleanly.
+- **Updater-script crash safety**: the rename step is a single OS call, not a "spawn batch script that waits 1s" pattern (rel-M5). The legacy batch-shim approach is explicitly rejected.
+- **`daemon.shutdownForUpgrade` RPC + shutdown marker** `[manager r7 lock: r6 packaging P0-2 cross-frag — daemon.shutdownForUpgrade RPC + marker semantics; consumed by frag-11 §11.6.5 upgrade flow]`:
+  - **Caller**: Electron-main, on receipt of the `electron-updater` `update-downloaded` event (BEFORE calling `autoUpdater.quitAndInstall()`). Distinct from the existing `daemon.shutdown` RPC (uninstall path, §6.8 / frag-11 §11.6.4) because upgrade flushes in-flight session writes (5 s ack window) where uninstall is destructive (2 s + kill).
+  - **Daemon behavior** on receiving `daemon.shutdownForUpgrade`:
+    1. Atomically write `<dataRoot>/daemon.shutdown` marker file (`O_CREAT | O_EXCL | O_WRONLY` + `rename()` from `daemon.shutdown.tmp` to `daemon.shutdown`, user-only DACL/0600). Marker payload is a single line `{ "reason": "upgrade", "version": "<current>", "ts": <epoch_ms> }` — small JSON for forensics, but presence/absence is the load-bearing signal.
+    2. Run the §6.6.1 ordered shutdown sequence (drain ordering: subscribers → SIGCHLD wind-down → DB checkpoint → `pino.final`).
+    3. Release the `<dataRoot>/daemon.lock` (`proper-lockfile` `unlock()`).
+    4. `process.exit(0)` within **5 s** of receiving the RPC. If the daemon cannot exit cleanly within 5 s, Electron-main force-kills (frag-11 §11.6.5 step 4 fallback: `taskkill /F /PID` on Win, `process.kill(pid, 'SIGKILL')` on POSIX, then explicit `unlink(<dataRoot>/daemon.lock)` to clear the proper-lockfile stale lock dir).
+  - **Marker semantics** (consumed at next daemon boot, §6.4 lockfile + §6.1 supervisor crash-loop counter):
+    - Marker file present at boot time = "the previous daemon shutdown was for upgrade, expected and clean — do NOT increment the crash-loop counter (§6.1 R2 rule), do NOT trip the rollback path (§6.4 step 7 .bak swap), do NOT surface `daemon.crashLoop` modal."
+    - Marker is **consumed** (`unlink()`) on the next successful daemon start — specifically, after the new daemon completes the §6.4 boot order steps 1-4 (acquire lock, ensureDataDir, open SQLite, start adapter) AND its §6.1 self-test (60 s up + 5×/healthz pass). Consuming on self-test pass not on boot-start guarantees the marker survives a crash *during* the new boot (if the new bundle is itself broken, the marker stays present and the next-next boot still treats the prior shutdown as upgrade-clean — no false crash-loop trigger from the upgrade window).
+    - Marker file absent at boot = "previous shutdown was either crash, OS reboot, user-Quit, or first-ever boot — apply normal supervisor crash-loop accounting per §6.1 R2."
+    - **Marker corruption / partial write** (rel-S-R8): if the marker file exists but is unreadable / malformed JSON, treat as PRESENT (conservative — prefer false-negative on crash-loop accounting over false-positive that bricks legitimate post-upgrade boots). Log `marker_corrupt` warn and unlink as part of consumption.
+  - **Cross-fragment contract**: this RPC and marker are the daemon-side half of frag-11 §11.6.5's upgrade-in-place flow. The Electron-main orchestration (5 s ack timeout, force-kill fallback, explicit lock unlink, post-upgrade `spawnOrAttach` flow) lives in frag-11 §11.6.5. The supervisor crash-loop counter consumption rule lives in §6.1 (PUNT to fixer G to verify §6.1 R2 paragraph mentions the marker-skip).
+  - **Allowlist registration**: `daemon.shutdownForUpgrade` is a **control-plane RPC** and MUST be added to the `SUPERVISOR_RPCS` allowlist constant declared in frag-3.4.1 §3.4.1.h. After this edit the allowlist becomes `SUPERVISOR_RPCS = ["/healthz", "/stats", "daemon.hello", "daemon.shutdown", "daemon.shutdownForUpgrade"]`. PUNT to fixer G: cross-frag merge worker MUST update the literal in frag-3.4.1 §3.4.1.h to match (also update the §3.4.1.h table's control-socket "RPCs served" cell + the §3.4.1.f migrationGate interceptor allowlist consumer cross-ref).
+
+### 6.5 Health probe + dedicated supervisor transport
+
+- **Dedicated transport** (r2-rel P0-R5 + r3-perf CF-1 unification + r11 devx P1-2 socket-name lock): the supervisor uses a **separate** local socket / named pipe — `\\.\pipe\ccsm-control-<userhash>` (Win) or `<runtimeRoot>/ccsm-control.sock` (POSIX) — exclusively for the canonical `SUPERVISOR_RPCS` set declared in frag-3.4.1 §3.4.1.h (currently: `/healthz`, `/stats`, `daemon.hello`, `daemon.shutdown`, `daemon.shutdownForUpgrade`) plus the `daemon.crashing` best-effort daemon→client IPC. `[manager r9 lock: r8 envelope P0-1 + r8 devx P0-1 — local enumeration removed; reference canonical SUPERVISOR_RPCS by name per §3.4.1.h "MUST NOT enumerate alternative lists" rule. Renamed prior `daemon.stats` to `/stats` to match canonical literal.]` `[manager r11 lock: P1 devx P1-2 socket name canonical = ccsm-control per frag-3.4.1 §3.4.1.h table; was `-sup` suffix on `ccsm-daemon-<userSid>` (Win) and `daemon-sup.sock` (POSIX); paths now mirror §3.4.1.h table exactly]` **This `ccsm-control` socket IS the same channel that frag-3.4.1 §3.4.1.h calls "control-socket"** (r3-perf CF-1 disambiguation: ONE control plane, single canonical name). Total daemon listeners: 2 — one data-path adapter, one supervisor/control transport. This eliminates the entire class of "snapshot back-pressures heartbeat" race: a 20-snapshot storm on the data-path adapter cannot delay the supervisor's heartbeat poll. Cost: ~kB RAM, one extra accept loop, same ACL/peer-cred discipline as the data path (§7.1). The supervisor transport is the SINGLE channel that ignores `MIGRATION_PENDING` short-circuit (r2-rel P1-R3) — it always returns liveness with a `migrationState` field, never a sentinel error.
+- `ccsm.v1/daemon.healthz` RPC, no auth (local-only, see §7), returns:
+  ```json
+  { "uptimeMs": number, "pid": number, "version": string,
+    "bootNonce": string, "sessionCount": number,
+    "subscriberCount": number,
+    "migrationState": "absent" | "pending" | "in-progress" | "done",
+    "swapInProgress": boolean,
+    "protocol": {
+      "wire": "v0.3-json-envelope",
+      "minClient": "v0.3",
+      "daemonProtocolVersion": 1,
+      "daemonAcceptedWires": ["v0.3-json-envelope"],
+      "features": ["binary-frames", "stream-heartbeat", "interceptors", "traceId", "bootNonce", "hello"]
+    },
+    "healthzVersion": 1
+  }
+  ```
+  - `bootNonce` is **camelCase** (r3-fwdcompat CF-2 lock — was `boot_nonce` snake; aligned with rest of envelope: `traceId`, `streamId`, `headerLen`, `payloadLen`). PUNT to frag-3.7 §3.7.5: any `response.boot_nonce` reads must become `response.bootNonce` to avoid silent `undefined` reads. Value is a ULID (not `Date.now()`) so two crashes within 1 ms still produce distinct ids (r2-obs OPEN-4).
+  - `daemonProtocolVersion` (r3-lockin CF-2 fix): integer semver-major mirrored 1:1 from `daemon.hello` reply (frag-3.4.1 §3.4.1.g). Bumps ONLY on breaking handler-contract changes; additive features go in `features` array. Supervisor uses this to detect post-update protocol-version mismatch on a long-lived attach.
+  - `daemonAcceptedWires` (r3-fwdcompat P1-5): array of wire formats this daemon accepts; v0.3 = `["v0.3-json-envelope"]`, v0.4 = `["v0.3-json-envelope", "v0.4-protobuf"]` during transition. Saves a roundtrip during v0.3→v0.4 rolling upgrade.
+  - `swapInProgress` (r3-sec P1-6): true during the auto-update swap window §6.4 step 4-7; supervisor pauses imposter-secret HMAC verification while true to avoid spurious crash-loop trigger from old-daemon-with-old-secret.
+  - `healthzVersion` replaces the round-2 `statsVersion` field on `/healthz` (r3-fwdcompat P1-3): two cursors confused additivity. `statsVersion` lives only on `/stats`; `healthzVersion` lives only on `/healthz`. `[manager r11 lock: P1 reliability daemon.stats → /stats sweep — literal renamed to match canonical SUPERVISOR_RPCS path per §3.4.1.h]`
+  - The `protocol` block is the **canonical version-negotiation payload**, mirrored 1:1 in the `daemon.hello` handshake response (see §6.5.1). Fwdcompat P0-2.
+- **`ccsm.v1/daemon.hello` handshake** (r2-fwdcompat P0-2): the FIRST envelope on every newly-accepted data-path connection MUST be `daemon.hello { clientWire: "v0.3-json-envelope", clientFeatures: [...], clientHelloNonce: "<base64-16>" }`. Daemon answers with the `protocol` block above plus `compatible: boolean` + `reason?: string` + `helloNonceHmac: "<base64-22>"`. **HMAC truncated to 16 bytes daemon-side, base64-encoded on wire (~22 chars). Client compares the full 22-char string via `crypto.timingSafeEqual` (equal-length buffers required, otherwise `RangeError`). Source of truth: §3.4.1.g (and §7.2 generator).** [manager r7 lock: r6 security P2-10 — HMAC wire format unified across §3.4.1.g + §6.5 + §7.2 to base64-22 (16-byte daemon-truncated). Prevents RangeError on first connection.] **Daemon refuses to dispatch any other RPC on this connection until hello completes**; on `compatible: false`, daemon closes the connection with a clean error code (NOT cryptic `not_found`). v0.4 protobuf swap declares `wire: "v0.4-protobuf"` and the v0.3 daemon refuses with `compatible: false, reason: "wire-mismatch"`. **(Hello-handshake posture is unified across both sockets per §3.4.1.h canonical: data-socket and `ccsm-control` socket share peer-cred / DACL / accept-rate-cap / hello-handshake posture. `[manager r9 lock: hello-handshake unified — both sockets share posture per §3.4.1.h canonical; supersedes prior r2 "supervisor transport skips hello" wording which contradicted the helloInterceptor #0 contract and would have triggered a destroy-loop on every supervisor heartbeat. r8 envelope P0-2.]` `[manager r11 lock: P1 devx P1-2 socket name canonical = ccsm-control per frag-3.4.1 §3.4.1.h table; was `-sup`]`)
+- Supervisor polls every 5s prod, 30s dev (§6.1). Cheap (~50µs).
+- v0.4 adds `/readyz` returning `{ migration: 'pending'|'in-progress'|'done' }` for SQLite migration gating; v0.3 ships `/healthz` only with embedded `migrationState` field.
+- A separate `/stats` (obs-S6) returns `{ statsVersion: 1, rss, heapUsed, ptyBufferBytes, openSockets }` — diagnostic-grade RPC, not part of the supervisor liveness contract. `statsVersion` enables additive evolution without renderer breakage (r2-obs P1-4). `[manager r11 lock: P1 reliability daemon.stats → /stats sweep — literal RPC name renamed to match canonical SUPERVISOR_RPCS literal per §3.4.1.h; control-plane namespace exempt from ccsm.v1/... per §3.4.1.h literal-vs-namespace lock]` [manager r7 lock: cut as polish — N8# from r6 feature-parity. The internal RPC stays (useful for healthz/diagnostic IPC + future v0.4 inspector tooling), but the tray-menu "Daemon stats…" entry is DELETED — v0.2 tray menu is `[Show CCSM | Quit]` only and v0.3 is refactor scope, no new tray entries.]
+
+#### 6.5.1 Server-side stream-dead detector (round-7 manager lock — r6 reliability P0-R2)
+
+`[manager r7 lock: r6 reliability P0-R2 — daemon-side symmetric dead-stream detector at 2 × heartbeatMs + 5 s; v0.3 local pipe / unix socket = no-op (kernel close fires first), but byte-compatible with the v0.5 CF Tunnel TCP swap reserved at frag-3.4.1 §3.4.1.c x-ccsm-deadline-ms 120 s clamp + x-ccsm-trace-parent header. Without this, the v0.5 TCP path has no half-open recovery short of OS TCP-keepalive (default 2 hours).]`
+
+Frag-3.5.1 §3.5.1.4 owns CLIENT-side dead-stream detection at `2 × heartbeatMs + 5 s` (default 65 s) and notes that on a stuck-reader-but-healthy-network case the server side falls back to heartbeat-write-failure tripping drop-slowest at the 1 MiB watermark (§3.5.1.5). On v0.3 local pipe / unix socket this is reliable — kernel close arrives in milliseconds and `writable === false` fires within one OS scheduler tick. **It is NOT reliable on a future v0.5 TCP transport.** A half-open TCP socket (client device sleeps, NAT entry expires, WiFi drops) leaves the daemon's send buffer slowly filling because PTY traffic is keystroke-sized; on a low-traffic stream (idle PTY + 30 s heartbeat) the buffer fill takes ~30 minutes to reach the 1 MiB drop-slowest trip, during which the slow-subscriber LRU cap `min(N × 1 MB, 4 MB)` holds memory hostage. The OS-default TCP keepalive does not fire until 2 hours.
+
+**Rule**: the daemon maintains a per-stream `lastClientActivityAt` timestamp updated on (a) any inbound unary RPC dispatched on the same connection, (b) any client-issued frame on the same connection (future v0.5 ACK frame, reserved). The shared heartbeat scheduler (§3.5.1.4) — already iterating `Map<streamId, { lastWriteAt, heartbeatMs }>` once per second — additionally checks `now - lastClientActivityAt > 2 × heartbeatMs + 5_000`. If exceeded, the daemon:
+
+1. Treats the stream as dead and the underlying CONNECTION as dead (one half-open socket means the whole connection is suspect).
+2. Closes the stream with `RESOURCE_EXHAUSTED, reason: 'server-stream-dead'` and `socket.destroy()` on the underlying connection.
+3. Emits one structured log line `{ event: 'server_stream_dead', sid, streamId, lastClientActivityMsAgo, heartbeatMs, peerPid }` (single line, NOT per-stream-on-connection — the connection close cascades to all dependent streams; aggregate one log line per close).
+4. The fan-out registry (frag-3.5.1 §3.5.1.5) removes the dropped subscriber the same way drop-slowest already does — no separate accounting path; the slow-subscriber drop log line and `subscribers-closed` aggregator both stay valid.
+
+**v0.3 expected behaviour**: on local pipe / unix socket, this detector is a NO-OP — the kernel `'close'` event arrives long before `2 × heartbeatMs + 5 s` elapses, the existing socket-level `'error'` / `'close'` path runs first, and the stream is gone before the scheduler tick examines `lastClientActivityAt`. Spec it now so the v0.5 TCP swap is byte-compatible with no contract change. The v0.5 wire-format swap (frag-3.4.1 §3.4.1.c reserves `x-ccsm-trace-parent` and the 120 s deadline clamp for this transition) inherits this detector unchanged.
+
+**Symmetry with client side**: client uses `2 × heartbeatMs + 5_000` (§3.5.1.4); server now uses the same window. Both sides agree the connection is dead at the same moment, eliminating a window where the client retries but the daemon still holds the registry slot.
+
+**Heartbeat scheduler cost impact**: the existing 1 s scheduler tick already walks the per-stream Map; adding a `lastClientActivityAt` comparison is one extra integer subtraction per stream per tick. At v0.5 100-session × 10 streams scale this is 1000 extra subtractions per second — negligible.
+
+**Cross-frag handoff**: frag-3.5.1 §3.5.1.4 "Server-side dead-client detection" paragraph should add a sentence "Symmetric server-side detector at `2 × heartbeatMs + 5 s` is owned by frag-6-7 §6.5.1 — covers the v0.5 half-open TCP case where heartbeat-write-failure may not fire for hours." Cross-frag merge worker reconciles. (No edit applied here — this fragment cannot edit frag-3.5.1; flagged for fixer G traceability.)
+
+### 6.6 Logging shutdown safety + rotation + correlation
+
+Observability is a reliability concern in v0.3 because the bug surface is split across two processes. The four obs-MUST items are first-class spec contracts.
+
+#### 6.6.1 Daemon-side logger
+
+- **`pino.final()` on every exit path** (obs-MUST-2, addressing P0 #11): daemon installs `pino.final(logger, (err, finalLogger) => { finalLogger.fatal(err); process.exit(1); })` plus `process.on('SIGTERM' | 'SIGINT' | 'beforeExit' | 'uncaughtException' | 'unhandledRejection')` handlers that call `logger.flush()` synchronously. The default async destination stays for hot path; `pino.final` is the shutdown valve.
+- **Drain ordering for log producers** (r2-obs P0-3 + r3-rel P0-R1 reorder): `pino.final` only flushes pino's destination buffer, NOT producer-side timers/callbacks that are still emitting lines. On SIGTERM/SIGINT, daemon executes the following ordered sequence BEFORE invoking `pino.final`. **Critical R1 fix**: SIGCHLD wind-down + DB terminal-state writes happen BEFORE subscriber close, so PTY-exit events generated during shutdown still reach in-RAM consumers (notify producer, telemetry counter, future audit interceptor). Subscriber-close is the LAST runtime act before pino.final.
+  1. Set `state = 'draining'` (module-level flag visible to all log producers).
+  2. `clearInterval` every per-stream heartbeat timer (frag-3.5.1 §3.5.1.4 — list maintained as `streamHeartbeats: Set<NodeJS.Timer>`).
+  3. Reject all pending reconnect-queue / in-flight bridge calls with a single aggregated log line `{ event: "daemon-shutdown", droppedCalls: N }` (NOT N lines).
+  4. **(SIGCHLD wind-down BEFORE subscriber close, r3-rel R1)** Mark all `state='running'` sessions to `state='shutting_down'` in one transaction. Issue `SIGTERM` to each PG; wait up to 200ms per child; `waitpid(pid, WNOHANG)` per known PID (NOT `waitpid(-1)`) to avoid stealing reaps from logger/telemetry deps; survivors get `SIGKILL` to the pgroup. Mark surviving 'shutting_down' rows to `state='paused'` (per §6.3, NOT `abandoned` per r3-rel R3) in one transaction, AND clear `pid_pgid` in the same transaction (r3-rel P1-R1). **The `paused` write MUST be `UPDATE sessions SET state='paused', pid_pgid=NULL WHERE state='shutting_down'`** `[manager r7 lock: r6 reliability P1-R4 — explicit WHERE state='shutting_down' clause prevents the SIGCHLD-clean-exit vs SIGKILL-deadline race from double-writing a row that already transitioned to 'exited'. Without the WHERE clause, a child that clean-exits between the 200 ms cap and the SIGKILL deadline could land BOTH 'exited' (from SIGCHLD handler step 6 in frag-3.5.1 §3.5.1.2) AND 'paused' (from the sweep here / step 8 there); the WHERE-state guard makes the sweep idempotent and order-independent. PUNT to fixer G: cross-frag merge worker MUST verify frag-3.5.1 §3.5.1.2 step 8 mirrors this exact WHERE clause.]` `PRAGMA wal_checkpoint(TRUNCATE)`. `db.close()`. Throughout this step, the in-RAM fan-out registry is still live and any `ptyExit` event reaches subscribers + in-process consumers.
+  5. Iterate fan-out subscriber registry once; close each subscriber stream with `RESOURCE_EXHAUSTED, reason: 'daemon-shutdown'`; emit ONE aggregated `{ event: "subscribers-closed", count: N }` line (NOT N drop lines). This is the LAST runtime act (was step 4 in r2; moved to step 5 per r3-rel R1).
+  6. THEN `pino.final` runs.
+  7. THEN `process.exit(0)`.
+- **Crash-imminent IPC (best-effort, NOT guaranteed)** (r2-rel S-R1 + r3-rel R5): in the fatal handler, BEFORE `pino.final` runs, daemon emits a single best-effort `daemon.crashing` envelope on the supervisor transport so renderer can fail in-flight bridge calls immediately rather than waiting 5s for `BridgeTimeoutError`. **CRITICAL: this IPC is OPPORTUNISTIC.** It fires only when the daemon dies via a Node-observable path (`uncaughtException`, `unhandledRejection`, `SIGTERM`, `SIGINT`). On SIGKILL (OOM killer, `taskkill /F`, kernel panic, supervisor's own forced restart, segfault in native binding), no fatal handler runs and no `daemon.crashing` IPC ships. The renderer MUST NOT gate fast-fail on this IPC alone — the **authoritative liveness path** is supervisor `/healthz` 3-miss + bridge 5s timeout (a "we got crashing IPC OR healthz pings within 15s" gate is correct; "we got crashing IPC OR healthz pings" — without timeout — would hang on SIGKILL). Renderer code that observes neither MUST fall back to BridgeTimeoutError after 5s. (Source: r3-rel R5.)
+- **Log rotation** (obs-MUST-3 + res-MUST-1, addressing P0 #12 + r3-devx CF-1): `pino-roll` with `{ frequency: 'daily', size: '50M', limit: { count: 7 }, mkdir: true, symlink: true }`. Files at `<dataRoot>/logs/daemon-YYYY-MM-DD.log`; `symlink: true` (r3-devx CF-1 + r3-resource X2 punt pickup) maintains a stable `daemon.log` symlink → current rotated file so POSIX `tail -F` AND tray "Open daemon log" survive daily rotation. (Win `Get-Content -Wait` follows the symlink target by inode at start; r3-devx P1-4 documents this Windows caveat — tray entry on Win opens the current rotated file directly, not the symlink.) Rationale for `pino-roll` over `pino-rotating-file`: maintained inside the pino org (`pinojs/pino-roll`), supports daily AND size-based rotation in a single transport with file-count cap, native `symlink: true` support, is the option pino's own docs link to first; `pino-rotating-file` is a third-party fork with no recent releases. **Decision: pino-roll.**
+- **Aggregate `<dataRoot>` disk cap (r3-resource X1)**: per-side pino-roll caps `7 × 50 MB = 350 MB` per side, so daemon + electron logs ≤ 700 MB. Add explicit aggregate watchdog: **logs aggregate cap = 500 MB** (warn at 400 MB log line, hard prune oldest rotated files when total `<dataRoot>/logs/*` exceeds 500 MB regardless of pino-roll's per-file count); **crash-dump aggregate cap = 200 MB** (in addition to 30-day retention §6.6.3 — pruned oldest first when exceeded; covers the daemon-crash-loop-pre-supervisor-detection storm case). Watchdog runs at supervisor.start() AND once per pino-roll rotation tick (per r3-sec P1-3). Total `<dataRoot>/` floor for v0.3 ~1 GB (logs 500 MB + crashes 200 MB + corrupt-backups 100 MB × few + data + WAL).
+- **Correlation ID** (obs-MUST-1 + r3-perf CF-2 carve-out): every IPC envelope (§3.4 / §3.4.1) carries a `traceId: ULID` generated renderer-side and propagated through bridge → Connect adapter → handler → log. **`traceId` MUST appear in the binary frame header schema, not just JSON envelopes** (r2-obs P0-2; coordinate edit with frag-3.4.1 §3.4.1.c). Every `logger.info/warn/error` call inside a handler MUST include `{ traceId }`. Daemon-originated events (e.g. `ptyExit` from SIGCHLD, fan-out drop logs, heartbeat ticks) carry the **session's `spawnTraceId`** (set at session create, persisted on session row) so spawn → exit lines correlate (r2-obs OPEN-3). `subscriber-dropped-slow` log line MUST include `{ traceId, sessionId, subscriberId, droppedBytes, ageMs }`. **Hot-path carve-out (r3-perf CF-2)**: per-chunk fan-out write logs are **debug-level only** (suppressed at default `info` level) AND when emitted MUST source `traceId` from the cached `streamId → spawnTraceId` map established at `kind:'open'` (NOT generate or stringify a fresh ULID per chunk). Per-frame info-level logging on PTY hot path is FORBIDDEN — would burn ~1000 ULID-stringifications/s on a noisy session. The 1000+/s budget belongs to per-chunk byte-counters (no traceId).
+- **TraceId validation** (r2-sec P1-S2 + r3-sec CC-2): every accepted envelope's `traceId` is validated server-side against `^[0-7][0-9A-HJKMNP-TV-Z]{25}$` (Crockford ULID alphabet, fixed length); reject + drop on mismatch with `{ event: "traceid-malformed", offenderPid, raw: <first-32-bytes> }` log line. **Validation runs only when `traceId` is present in the header.** For inheriting sub-frames (`stream.kind === 'chunk' | 'heartbeat'`), the traceId is resolved from the `streamId → traceId` map established at `kind: 'open'`; missing inherited mapping is itself a protocol error and closes the stream with `RESOURCE_EXHAUSTED`. Daemon-emitted log lines include both `traceId` (caller-supplied, untrusted, for correlation) and `daemonTraceId` (daemon-generated ULID, authoritative). pino formatter strips `\n\r` from any string field destined for non-JSON destinations to prevent log injection.
+- **Daemon identity in every line** (obs-MUST-4): pino base config = `{ side: 'daemon', v: DAEMON_VERSION, pid: process.pid, boot: bootNonce }` so post-update logs are unambiguous. `boot` is a ULID (r2-obs OPEN-4); field name in the log is `boot` (the camelCase distinction applies to wire field `bootNonce` per r3-fwdcompat CF-2; the pino base log key is `boot` for compactness, with the value being the same ULID).
+- **Secret redaction** (sec-S4 + r2-sec P0-S1 #4 + r3-lockin CF-3): pino `redact` paths ship from day one — `["*.apiKey", "*.token", "Authorization", "Cookie", "ANTHROPIC_API_KEY", "*.payload.value", "env.ANTHROPIC*", "daemonSecret", "installSecret", "pingSecret", "helloNonce", "clientHelloNonce", "helloNonceHmac", "*.secret"]`. The `helloNonce` + `clientHelloNonce` + `helloNonceHmac` paths added per r3-lockin CF-3 + r3-sec P0-1 (HMAC-of-nonce wire shape lock — see §7.2; the legacy `imposterSecret` / `clientImposterSecret` cleartext fields were eliminated by the HMAC-of-nonce handshake and are no longer present anywhere in the wire schema). PTY chunk bodies are NEVER passed to logger; only `{seq, len}`. Vitest hook asserts no `chunk.toString()` appears in any logger call inside `ptyService` (obs-OPEN PII). Lint hook asserts no logger call site ever passes the resolved value of `daemon.secret`.
+- **Dev redact superset** (r2-sec SH1): when `CCSM_DAEMON_LOG_LEVEL === 'debug'`, redact list extends with `["*.value", "*.body", "*.input", "*.req", "*.params"]` to cover broader debug-payload shapes. Documented in frag-3.7 §3.7.6 dev-vs-prod table cross-ref.
+- **Network-FS rejection**: on boot, daemon refuses to start if `<dataRoot>` resolves to a OneDrive / SMB / network mount (rel-OPEN 6). Surface a clear error — pino + WAL on a network FS is data-loss territory.
+- **Canonical reconnect / bridge log key names** (r3-obs P1-2 — explicit list, PUNT to frag-3.7 §3.7.4 for cross-ref): the bridge call lifecycle log lines have FIXED string keys, not free-form. Implementers MUST use these exact strings (no `reconnect-attempted`-style improvisation):
+  - `bridge_call_complete` (every bridge call, success or error)
+  - `daemon_socket_closed`
+  - `daemon_reconnect_attempt` (with `{n, delayMs}`)
+  - `daemon_reconnect_success` (with `{durationMs, queueDrained}`)
+  - `daemon_queue_overflow` (with `{droppedMethod, queueAge}`)
+  - `stream_resubscribe` (with `{sid, fromSeq, fromBootNonce, gap}`)
+  - `crashloop_entered`, `subscribers-closed`, `daemon-shutdown`, `traceid-malformed`, `slsa_verify_failed`, `swap_in_progress` (already named above; listed here for one-stop reference)
+
+#### 6.6.2 Electron-side logger (r2-obs P0-1, P0-4)
+
+The Electron-main logger is a first-class peer of the daemon logger so cross-process trace correlation works without a third tool.
+
+- **Module location**: `electron/log.ts` runs in main only. Renderer `console.error/warn` is forwarded via preload bridge to main when `CCSM_RENDERER_LOG_FORWARD=1` (default ON in dev, OFF in prod for perf — r2-obs OPEN-1). Renderer never writes files directly.
+- **Same `pino-roll` config** as daemon (`{ frequency: 'daily', size: '50M', limit: { count: 7 }, mkdir: true, symlink: true }`) writing to `<dataRoot>/logs/electron-YYYY-MM-DD.log` (with stable symlink `electron.log`).
+- **Base fields**: `{ side: 'electron', v: APP_VERSION, pid: process.pid, boot: electronBootNonce }`. The `side` discriminator is REQUIRED so log aggregation does not collide daemon and electron lines that share `{v, pid, boot}` keys (r2-obs P0-1 explicit fix).
+- **Same redact list** as daemon §6.6.1, PLUS renderer-leaning paths: `["*.url", "*.searchParams", "*.headers", "*.formData"]`.
+- **`pino.final` analog on every Electron-main exit path** (r2-obs P0-4): registered against `app.before-quit`, `app.will-quit`, `process.on('uncaughtException')`, `process.on('unhandledRejection')`, AND the supervisor crash-loop modal "Quit" / "Restart ccsm" button handlers. Without this, the most diagnostic moment (the crash) is lost from the Electron side.
+- **Bridge call lifecycle log lines** (r2-obs P1-3, contract enumeration): every bridge call wrapper emits `logger.info({ traceId, method, durationMs, status }, "bridge_call_complete")` on completion (success or error). Reconnect path emits the canonical set: `daemon_socket_closed`, `daemon_reconnect_attempt {n, delayMs}`, `daemon_reconnect_success {durationMs, queueDrained}`, `daemon_queue_overflow {droppedMethod, queueAge}`, `stream_resubscribe {sid, fromSeq, fromBootNonce, gap}`. Audited via vitest hook (`no-bridge-call-without-completion-log`).
+- **Frag-12 matrix amendment**: row `obs-M2` should be re-rated GREEN as "addressed in §6 (daemon + electron)" rather than the current PARTIAL "addressed in §6". Row `obs-M4` similarly: GREEN with explicit `side: 'electron'` discriminator.
+
+#### 6.6.3 Crash-dump file (r2-obs P1-5, expanded from plan delta line)
+
+- Path: `<dataRoot>/crashes/crash-<isoTs>-<bootNonce>.json` (daemon) and `<dataRoot>/crashes/electron-crash-<isoTs>-<bootNonce>.json` (Electron-main). User-only ACL (0600 / equivalent Win DACL). **Filename components are sanitized via `path.basename(s).replace(/[^A-Za-z0-9._-]/g, '_')` before path concatenation** (r3-sec P1-5 — defense in depth against future ULID-impl swap that emits non-Crockford characters).
+- Schema: `{ side, v, pid, boot, errMessage, errStack, lastTraceIds: [...8], lastSessions: [...20], stats: { rss, heapUsed }, ts }`. Fields are REDACTED via same pino redact list before write — crash dumps must never contain secrets.
+- Retention: 30 days AND aggregate per-side cap 200 MB (r3-resource P1 — see §6.6.1 aggregate cap rule). Pruning runs (a) at `daemonSupervisor.start()` AND (b) once per pino-roll rotation tick (r3-sec P1-3 — covers the case where daemon never restarts because auto-update is OFF default).
+- **NEVER auto-uploaded.** User-driven attach to issue only. (r2-sec T13 row.)
+
+### 6.7 Failure modes (canonical table)
+
+| # | Failure | What user sees | State left valid? | Recovery |
+|---|---|---|---|---|
+| F1 | Daemon crash mid-PTY | xterm freezes; banner | PTY children reaped via §6.2 | Supervisor auto-respawn §6.1; sessions become "paused" §6.3 |
+| F2 | Daemon restart with running sessions | Sessions appear as "Paused — daemon was restarted [Resume]" | SQLite session rows survive; runtime state lost | User-triggered resume with prior `cwd`+`model`+env (§6.3) |
+| F3 | Electron crash mid-PTY | Tray gone; v0.5 web client unaffected | Daemon + PTY survive; replay buffer in daemon RAM | Reopen Electron → `spawnOrAttach` → `ptySubscribe(fromSeq, fromBootNonce)` resumes |
+| F4 | SQLite write interrupted (kill -9) | Next boot opens DB | better-sqlite3 + WAL crash-safe at statement granularity; multi-statement ops MUST be wrapped in `db.transaction()` | WAL replay; explicit transaction wrappers per Task 8/12/13 audit (rel-M3) |
+| F5 | Two-daemon race | N/A (lockfile rejects 2nd) | Lockfile §6.4 is gate; pipe bind is secondary | 2nd daemon exits cleanly with non-zero code |
+| F6 | Local socket hijack | N/A (peer-cred rejects) | §7.M1 ACL + §7.M2 peer-cred enforce same-user boundary | Rejected at adapter; logged with offender PID/SID |
+| F7 | Updater swap mid-rename | Daemon may be unbootable from new binary | `.bak` always present; auto-rollback once | §6.4 step 7 (rollback + modal); crash-loop counter cleared on success (r2-rel P0-R2) |
+| F8 | Update download interrupted | Silent retry next 6h poll | Old binary intact; SHA + SLSA mismatch caught | 3× exponential backoff retry within current poll window |
+| F9 | Bridge call to dead daemon | Banner + error toast (not infinite hang) | `rpcCall` 30s deadline + AbortSignal (rel-M2) | Supervisor heartbeat already firing on dedicated transport (§6.5); `daemon.crashing` IPC fails in-flight calls fast |
+| F10 | Two clients writing same PTY (v0.5 only) | "Another client is typing" banner | v0.3: single-writer lease; v0.5: explicit handoff | Handled at `ptyWrite` lease layer (rel-S6); not a v0.3 ship-blocker |
+| F11 | xterm-headless RAM growth | Daemon RSS climbs with N idle sessions | 10k scrollback hardcoded (`entryFactory.ts:43`); v0.3 hard cap: total headless-buffer RSS ≤ 400 MB → new spawns blocked with clean error (rel S-R7) | Tag idle eviction as v0.4 prereq (res-S3) |
+| F12 | Pino crash-loss | N/A (covered by `pino.final` + drain-ordering §6.6.1) | §6.6 | obs-MUST-2 + r2-obs P0-3 |
+
+### 6.8 User-visible surface registry + uninstall hygiene
+
+**Surface registry (CANONICAL — r3-ux P0-A lock)**: §6.8 is the **single canonical** registry of every modal/toast/banner that v0.3 surfaces, with priority and mutual-exclusion rules. Each fragment that introduces a surface MUST register a row here rather than inventing copy in isolation. Round-2 left two parallel registries (frag-3.7 used tier 1-6 numbering, this fragment uses numeric priority 30/50/70/85/90/100); the dual registries had different rules and overlapping copy. Manager lock: §6.8 wins because (a) richer numeric-priority numbering, (b) explicit stacking rules, (c) owns the supervisor surfaces which are the dominant set. The registry below now includes ALL surfaces (dev-mode reconnect, BridgeTimeout policy, stream-gap, queue-overflow) so frag-3.7 reduces to a cross-ref to §6.8.
+
+| Priority | Surface | Type | Source | Owner i18n key prefix | Suppresses |
+|---|---|---|---|---|---|
+| 100 (top) | Migration in progress | Modal (blocking, non-dismissable*) | frag-8 §8.6 | `migration.*` | All lower |
+| 90 | Installer corrupt (carry-forward from working) | Modal (blocking, prose-only) | §6.1.1 (M2#) | `installerCorrupt` | All lower |
+| 85 | Crash-loop (with/no bak) | Modal (blocking) | §6.1.1 | `daemon.crashLoop` | All lower |
+| 85 | Migration failed (frag-8 §8.6 fatal-error) | Modal (blocking) | frag-8 §8.6 | `migration.modal.failed.*` | All lower |
+| 70 | Daemon unreachable (red banner) | Banner | §6.1.1 | `daemon.unreachable` | Reconnect toast |
+| 30 | Daemon reconnected (recovery confirmation, debounced 5s) | Toast (info, 3s) | §6.1.1 | `daemon.reconnected` | (none) |
+| 30 | Paused-session affordance (carry-forward from working) | Inline UI | §6.3 | `session.state.paused` | (none) |
+
+[manager r7 lock: cut as polish — N6# from r6 feature-parity. §6.8 row count trimmed from 16 → 7 (5 daemon-split-driven rows + 1 migration-in-progress + 1 paused-session inline UI from working). Cut rows: `daemon.healthDegraded` (P=70 yellow miss-1/3), `daemon.healthUnreachable` (collapsed into `daemon.unreachable`), `daemon.rollingBack` (P=70 banner), `daemon.rolledBack` (P=30 toast), `daemon.rollbackFailed` (P=85 modal — collapsed into noBak `daemon.crashLoop`), `daemon.reconnectExhausted` (P=85 modal — collapsed into `daemon.unreachable` banner), `daemon.bridgeTimeouts` (P=70 banner), `daemon.devReconnecting` (P=70 dev-mode banner), `daemon.reconnecting` (P=50 250 ms hold-off toast — log-only at the per-attempt level; user sees `daemon.unreachable` only when reconnects keep failing), `daemon.queueOverflow` (P=50 toast), `daemon.streamGap` (P=30 toast — xterm divider may still render as a renderer-side affordance, but no toast/IPC), `daemon.devBuildError` (P=30 dev toast). The migration "Migration failure (4 variants)" row at P=90 collapsed into a single P=85 `migration.modal.failed.*` row matching frag-8 §8.6 r7 trim canonical i18n key prefix (one fatal-error modal, not 4 copy variants). `[manager r9 lock: r8 devx P0-3 + r8 reliability P1-2 — annotation key updated from stale `daemon.migrationFailed` to canonical `migration.modal.failed.*` matching frag-8 §8.6 owner declaration; prevents tests/i18n/parity.test.ts divergence between implementers reading the row vs the lock annotation]`. One `installerCorrupt` row added at P=90 per M2# (carry-forward from working).]
+
+[manager r7 lock: cut as polish — N4# from r6 feature-parity. The "Close-to-tray onboarding hint (one-shot)" row at P=30 (i18n `tray.closeHint`) is DELETED. Working's existing `closeBehaviorOptions.ask` first-close prompt covers the discoverability concern unchanged; no parallel onboarding moment. The `app_state.close_to_tray_shown_at` SQLite key (formerly mandated by §6.8 + r3 manager arch decision #2 + Task 21 wiring) is also DELETED — no SQLite migration row for it; existing renderer close-prompt logic preserved as-is.]
+
+[manager r7 lock: cut as polish — N8# from r6 feature-parity. The "Daemon stats…" tray menu entry referenced in §6.5 is DELETED as a user-visible surface. Internal `/stats` RPC remains (wire concern, useful for healthz/diagnostic IPC + future v0.4 inspector tooling), but no tray menu growth in v0.3.] `[manager r11 lock: P1 reliability daemon.stats → /stats sweep — internal RPC literal renamed to match canonical SUPERVISOR_RPCS path per §3.4.1.h]`
+
+[manager r7 lock: cut as polish — N1# from r6 feature-parity. The macOS tray menu "Reset CCSM…" / "Reset ccsm…" entry is DELETED entirely from the in-app surface contract below. macOS uninstall = "drag CCSM.app to Trash" + release-notes documentation; no in-app tray entry. PUNT to fixer addressing frag-11 §11.6.2: drop the corresponding "Reset CCSM…" tray-menu item from the macOS uninstall bullet. If a "Reset" entry exists elsewhere as a Settings panel button in working, that's preserved unchanged (M1# settings preserved); only the NEW tray menu entry is cut.]
+
+\* **Migration "non-dismissable" callout (r3-ux P0-B)**: priority 100 is the top of the registry, so the auto-dismiss-on-higher rule (stacking rule 1) NEVER applies to migration — there is no priority >100 surface in v0.3. frag-8 §8.6's "dismissable: false" wording is consistent with §6.8 (priority dominance + no higher priority exists ⇒ effectively non-dismissable). Implementer note: the migration modal has no close button; the only exit is migration completion or one of the failure variants (priority 90, which IS dismissable). No code-level "non-dismissable" flag required — priority is the sole gating mechanism.
+
+**Stacking rules**:
+1. At most ONE blocking modal visible at a time. If a higher-priority modal arrives while a lower one is showing, the lower one is dismissed (and its IPC re-fires when the higher one closes). Migration (priority 100) is the apex and is never dismissed by any other surface.
+2. A blocking modal suppresses all toasts of priority <50.
+3. A banner of priority ≥70 suppresses any toast that targets the same daemon-health event class. Concretely: `daemon.healthDegraded` banner suppresses `daemon.reconnecting` toast.
+4. Toasts of equal priority stack vertically up to 3; oldest is dismissed when a 4th arrives.
+5. Reconnect toast escalates to `daemon.unreachable` red banner once handshake / reconnect attempts pass the supervisor's miss threshold; per the §6.1.1 r7 trim there is no separate `reconnectExhausted` modal (collapsed into the `daemon.unreachable` body copy "If this persists, ccsm may need to be reinstalled.").
+6. **Equal-priority deterministic tie-break (round-7 manager lock — r6 ux P0-2)** `[manager r7 lock: r6 ux P0-2 — equal-priority tie-break = registry insertion order]`: if two surfaces share the same numeric priority, the one registered FIRST in the boot-time registry wins (`Map` insertion order is the deterministic tiebreaker — same-tick later same-priority IPCs are dropped, not queued, and re-fire only if the winning surface is closed AND the underlying state is still active). Insertion order across the v0.3 priority bands matches the row order shown in the §6.8 table above (top-to-bottom = first-to-last). After the r7 row trim the only same-priority bands are P=85 (`daemon.crashLoop` → `daemon.migrationFailed`) and P=30 (`daemon.reconnected` → `session.state.paused`). No per-event sort key is required; the renderer's `useDaemonHealthBridge` consults the registry `Map` directly.
+
+**Single-source IPC** (r2-ux P0-UX-1 architectural fix): all daemon-health events (reconnect, supervisor heartbeat, crash-loop) are emitted on ONE `daemonHealth` IPC channel with a discriminated-union payload `{ kind, severity, ... }`. The renderer has ONE `useDaemonHealthBridge` hook that owns the surface registry lookup and stacking rules. Per-fragment bridges (`useDaemonReconnectBridge`, `usePersistErrorBridge`) are deprecated in v0.3.1 in favor of this consolidation.
+
+**v0.2 → v0.3 close-to-tray onboarding — DELETED in r7** [manager r7 lock: cut as polish — N4# from r6 feature-parity. The one-shot close-to-tray onboarding toast (formerly `tray.closeHint` at P=30) AND the SQLite `app_state.close_to_tray_shown_at` row are DELETED entirely. Working's existing `closeBehaviorOptions.ask` first-close prompt with `dontAskAgain` checkbox already covers the discoverability concern unchanged; no parallel onboarding moment. Renderer-side close-prompt logic preserved as-is — the cut is the NEW onboarding toast, not the existing close-prompt. No Task 21 wiring required for this surface; no app_state migration row required for the SQLite key.]
+
+**Uninstall hygiene** (pkg P0-1 — r3-resource X3 ownership split):
+
+The uninstall path is split between two fragments. **§6.8 owns the in-app daemon-shutdown contract** (the IPC contract used by the NSIS macro to gracefully ask the running daemon to drain). **frag-11 §11.6 owns the on-disk paths and OS installer mechanics** (NSIS macro contents, `.deb postrm`, `.rpm preun`, `nsis.include` wiring, `customUnInstall` macro shape). The two fragments must agree on the daemon-shutdown sequence (kill before lockfile delete) but the canonical implementation lives in frag-11.
+
+In-app surface contract (owned here):
+
+- **macOS tray menu Reset entry — DELETED in r7** [manager r7 lock: cut as polish — N1# from r6 feature-parity. The "Reset CCSM…" / "Reset ccsm…" tray menu entry is DELETED entirely from the in-app surface contract. macOS uninstall is "drag CCSM.app to Trash" + release-notes documentation for `~/Library/Application Support/ccsm/` cleanup; no in-app tray menu growth in v0.3 (tray menu stays at working's `[Show CCSM | Quit]`). PUNT to fixer addressing frag-11 §11.6.2: drop the corresponding "Reset CCSM…" tray-menu item from the macOS uninstall bullet.]
+- **NSIS macro daemon-shutdown sequence (Windows; macro lives in frag-11 §11.6)**: the macro MUST `taskkill /IM ccsm-daemon.exe /F` BLOCKING (wait for exit code) BEFORE removing `<dataRoot>/daemon.lock`; the kill-before-unlock ordering is the contract owned here, the script that implements it lives in frag-11.
+- **Linux postrm/preun**: same kill-before-unlock contract; `systemctl --user stop ccsm-daemon` (if launched as systemd-user-service in v0.3.1) OR `pkill -TERM ccsm-daemon`. Implementation in frag-11 §11.6.
+- **Order matters** (r2-pkg P1-5): kill daemon BEFORE removing lockfile. If the order inverts, a slow daemon shutdown holds the lock past `RMDir`, causing a partial-clean state that confuses the next install. (Contract is canonical here; enforcement lives in frag-11.)
+
+---
+
+## 7. Security
+
+Replaces v1 §7 (which moves to §8 Testing). v1 §7 was 4 lines on testing. New §7 is dedicated security spec.
+
+### 7.1 Trust boundary (v0.3)
+
+**Same machine, same user.** That is the ENTIRE in-scope authentication story for v0.3. Any code path that assumes more (network exposure, multi-user separation beyond the OS) is out of scope until v0.5.
+
+Boundary is enforced by THREE redundant layers (defense in depth, §7.2):
+1. **Transport**: local channel only — Win named pipe `\\.\pipe\ccsm-daemon-<userSid>` or POSIX unix socket `<dataRoot>/daemon.sock`, plus the dedicated supervisor transport (§6.5). **No TCP listener of any kind in v0.3.** Spec §3.1 line "daemon binds 127.0.0.1:7878" is OBSOLETE; the v0.3 daemon never opens an INET socket.
+2. **OS ACL**: pipe / socket / data dir / log dir / lockfile / `.bak` binary / `daemon.secret` all have user-only permissions, set explicitly at create time. Defaults are NOT trusted (sec-M1: Win default pipe DACL grants Everyone in many configs).
+3. **Sender peer credential check**: every accepted connection's peer UID/SID is verified at adapter accept; mismatch → log `{offender_pid, offender_sid}` and immediately drop. (sec-M2.)
+
+### 7.2 Defense in depth
+
+Even after §7.1, the daemon distrusts every byte:
+- **Envelope schema validation** (§3.4.1): every decoded envelope is run through TypeBox `Check()` at the adapter boundary BEFORE any handler dispatch. Schema mismatch → drop + log; never propagate to handlers.
+- **Per-handler arg validation** (r2-sec P1-S1): for `payloadType: 'binary'` frames the trailer is opaque to the adapter; every RPC handler's first statement MUST be `Check(MethodArgsSchema, decoded)` against a per-method byte schema (length cap from header `payloadLen`, optional content sniff like UTF-8 well-formedness for PTY input). ESLint rule `no-handler-without-check` enforces. Coordinate spec edit with frag-3.4.1 §3.4.1.d.
+- **Frame size cap**: `MAX_FRAME = 16 MiB` enforced at the `readUInt32BE` length read (sec-M3). Refusal of oversize frames is logged (`offender_pid`, requested length) for forensic value. Closes the 4 GiB DoS.
+- **Accept-rate cap** (r2-sec T15): `MAX_ACCEPT_PER_SEC = 50` per transport (data + supervisor counted separately). Exceed → drop new accepts with `EAGAIN` for the next 1s; log once per minute aggregate. Eliminates pre-accept connect-flood DoS.
+- **JSON.parse hardening**: no reviver tricks needed (modern V8 is `__proto__`-safe), but every decoded object is shape-validated against TypeBox before being spread into Maps / option bags downstream. Recursion depth implicitly bounded by schema (no unbounded `additionalProperties`).
+- **No shell concatenation**: handler code that spawns CLI subprocesses uses `spawn(cmd, [...args])` — never `exec(template)` with user-provided strings. Lint rule (`no-restricted-syntax` for `child_process.exec` / `execSync`) enforces.
+- **`daemon.secret` lifecycle** (r2-sec P0-S1, comprehensive; r3-sec P0-1 wire shape lock):
+  - **Format**: JSON `{ v: 1, secret: "<base64-32-bytes>" }`, NOT bare bytes (r2-fwdcompat P2-1). v0.4 may ship `{ v: 2, sigstoreBundle: "..." }` or `{ v: 3, derivedSubkeys: ... }` (per r3-fwdcompat P1-6 zero-cost reservation: `v` is a dispatch tag and future values may carry arbitrary additional fields); verifier dispatches on `v`.
+  - **Path** (locked OS-native, all triple-rooted references re-anchored): `%LOCALAPPDATA%\ccsm\daemon.secret` (Win), `~/Library/Application Support/ccsm/daemon.secret` (macOS), `~/.local/share/ccsm/daemon.secret` (Linux). Same `<dataRoot>` as everything else.
+  - **Generator**: Electron-main, NOT daemon, NOT installer. On `spawnOrAttach`, if file is missing or unreadable, Electron generates a fresh 32-byte random, writes via `fs.writeFile(path, JSON.stringify({v:1,secret}), { flag: 'wx', mode: 0o600 })` (POSIX) or Win equivalent CreateFile with `CREATE_NEW` + immediate `SetSecurityInfo` to user-only DACL, then spawns daemon with the secret as `CCSM_DAEMON_SECRET` env var. **Atomic create-with-ACL is required** — the file must NEVER exist with a wider ACL even momentarily (Win `CreateFile` + `SECURITY_DESCRIPTOR` parameter, NOT `CreateFile` then `SetSecurityInfo`).
+  - **Headless / CLI launch carve-out (r3-sec CC-3)**: if env var unset AND file absent AND `process.env.CCSM_DAEMON_HEADLESS === '1'`, daemon may self-generate (one-shot, atomic CREATE_NEW with the same ACL discipline as Electron). Headless mode is dev-only and MUST NOT be set by production Electron; documented as "for debugging tools that want to run the daemon directly without an Electron host." In production, daemon refuses to start if neither env nor file is available — single source of truth = Electron.
+  - **First-boot race**: the lockfile (§6.4) is the gate. Two concurrent Electron-spawned daemons cannot race because only the lock-holder proceeds; the loser exits cleanly.
+  - **Daemon-side**: daemon reads `CCSM_DAEMON_SECRET` env var on boot; if unset, falls back to reading the file. Hardening (r3-sec P1-1 — defense in depth): immediately after read, daemon `delete process.env.CCSM_DAEMON_SECRET` to narrow the `OpenProcess`/`/proc/self/environ` window from "daemon lifetime" to "first ~5ms of boot." Documented as TODO not blocking.
+  - **Rotation**: rotated on every successful auto-update swap (§6.4 step 4) AND on every supervisor-initiated cold restart following crash-loop recovery. Rotation = generate, write `daemon.secret.new`, atomic rename. A known-bad daemon binary that leaked the secret loses authority on the next restart cycle. During rotation window, supervisor pauses `/healthz` HMAC check (`swapInProgress: true` flag, see §6.5 + r3-sec P1-6).
+  - **Env-var caveat** (r2-sec T12): `CCSM_DAEMON_SECRET` lives in the daemon's environment block, readable by any same-user process via `OpenProcess`. This is acceptable because (a) same-user process is OUT OF SCOPE per §7.4 T3 anyway, and (b) the file on disk has the same user-readable property. **Future secrets MUST NOT be passed via env** — the precedent is documented as a one-off for this bootstrap-only secret.
+  - **Imposter check — HMAC-of-nonce challenge-response (r3-sec P0-1 LOCK; supersedes r2 bearer-token form)**: the wire shape is HMAC challenge-response, NOT bearer-token. On every newly-accepted data-path connection:
+    1. Client (Electron's `spawnOrAttach`, after probe-connecting) sends `daemon.hello { clientWire, clientFeatures, clientHelloNonce: "<base64-16>" }`. `clientHelloNonce` is freshly generated per connection (16 random bytes, base64-encoded; ~22 chars on the wire).
+    2. Daemon computes `HMAC-SHA256(daemon.secret, clientHelloNonce)`, **truncates to 16 bytes**, base64-encodes, and replies `{ helloNonceHmac: "<base64-22>", protocol: {...}, compatible }`.
+    3. Client computes the same HMAC with its loaded secret and compares **using `crypto.timingSafeEqual`** (NOT `Buffer.compare` — the `Buffer.compare` form is byte-by-byte and timing-leaks the secret to a co-tenant probing with crafted prefixes).
+    4. Mismatch or absent echo → client treats the listener as imposter, log with `{ offenderPid }`, refuse to talk, fall back to spawning the real daemon under a fresh socket name (Win named-pipe collision: append `-rescue-<ulid>`). Reverse-direction proof (client proves to daemon) is unnecessary because peer-cred + ACL already authenticate the client.
+    5. Bearer-token alternative (where client sends the secret in cleartext on every connect) is **EXPLICITLY REJECTED** (per r3-sec P0-1) — it lands the secret in every TLS-pcap (v0.5 web), every crash dump (despite redact), every `strace` log. HMAC-of-nonce keeps the secret entirely off the wire.
+    Lockfile (§6.4) prevents the imposter scenario from being viable in steady state; this HMAC is belt-and-suspenders for first-boot race + the case where an attacker spawned a malicious binder before Electron started.
+  - **Redaction**: pino redact list (§6.6) includes `daemonSecret`, `installSecret`, `pingSecret`, `helloNonce`, `clientHelloNonce`, `helloNonceHmac`, `*.secret`. Lint hook asserts no logger call site ever passes the resolved secret value. PUNT to frag-3.4.1 §3.4.1.g: align hello payload field names to `clientHelloNonce` + `helloNonceHmac` (NOT a cleartext bearer-secret field, which the redact-glob does not actually catch since pino redact is path-based, NOT substring; r3-lockin CF-3 fix). The legacy `imposterSecret` / `clientImposterSecret` fields were removed entirely by the HMAC-of-nonce handshake.
+
+### 7.3 Supply chain
+
+Phased hardening, locked to release version:
+
+| When | Mechanism | Notes |
+|---|---|---|
+| **v0.3** | (1) SHA256 manifest fetched from same GitHub release; verified before atomic swap. (2) **SLSA-3 build provenance** `provenance.intoto.jsonl` generated by `actions/attest-build-provenance@v1` attached to every release; updater verifies attestation against GitHub's public OIDC root before swap (free, GitHub-native, no sigstore key infra). (3) **Linux** additionally publishes a minisign signature `SHA256SUMS.txt.minisig` (one-time keypair generation, ~30 LOC verifier). (4) Auto-update **DEFAULT OFF** (`CCSM_DAEMON_AUTOUPDATE=1` to opt in). Manual update prompt is the default UX; the manual prompt also runs the SLSA + (Linux: minisign) verification chain. | r2-sec P0-S3. SHA256 alone gives integrity vs network corruption only; SLSA closes the "compromised pipeline forges binary + SHA together" gap because the OIDC token is bound to the workflow file at the moment of signing. v0.3 residual T6 risk drops from HIGH to MEDIUM. |
+| **v0.4** | sigstore / cosign signing in GitHub Actions. Daemon embeds public key at build, verifies signature offline before swap. Auto-update flips DEFAULT ON. SLSA stays on as defense-in-depth. | Eliminates "compromised release pipeline forges both binary and SHA". v0.4 T6 residual: LOW. |
+| **v0.5** | Cloudflare Access JWT validator middleware on the (new) network listener. Seam already present from v0.3 §3.1 (handler chain), wired only when `CCSM_DAEMON_REMOTE=1`. | Out-of-scope threats (algorithm confusion, JWKS rotation, audience pinning, Host-header validation, DNS rebinding) all tracked in `v0.5-security-followups.md`. |
+
+**SLSA verifier (r3-sec P1-4)**: the verifier specified at §6.4 step 2 is `@sigstore/verify` v1.x (MIT, ~2 MB, supported), pinned in daemon dependencies. Trust root = GitHub OIDC public key bundled in daemon binary at build time. Verification call: `verifyBundle(bundle, { trustMaterial, signingPolicy: { workflowFilePath: '.github/workflows/release.yml', repository: 'Jiahui-Gu/ccsm' } })`. Failed verification → abort swap, log `slsa_verify_failed`, schedule retry on next 6h poll. Alternatives rejected: shipping `cosign verify-blob-attestation` binary (~30 MB + license issues); custom OIDC-root verifier (~200 LOC, audit risk).
+
+**Initial-install integrity** (r2-sec P0-S3 second seam): the user's first download of v0.3 is from a GitHub release as a `.exe` / `.dmg` / `.deb`. Win + macOS authenticity comes from signtool + codesign + notarization (frag-11 §11.3). Linux installer authenticity is **explicitly via the same SLSA-3 attestation + minisign** as the auto-update path; the minisign public key is published in the README and pinned in installation docs. This eliminates the "Linux user has no authenticity check on either the installer or the daemon" gap.
+
+**npm dep posture (v0.3)**:
+- Pin exact versions in `package-lock.json` for `@connectrpc/connect*`, `pino`, `pino-roll`, `@sinclair/typebox`, `@yao-pkg/pkg`, `@octokit/rest`, `proper-lockfile`, `better-sqlite3`, `node-pty`. **All daemon runtime deps MUST appear in `daemon/package.json` `dependencies`**, NOT just root (r2-pkg C6 — pkg bundles from daemon's resolved tree, not workspace root).
+- CI step `npm audit --audit-level=high` blocks merge. Explicitly mention `better-sqlite3` family CVEs (r2-sec T16 follow-on to migration `quick_check`).
+- `@yao-pkg/pkg` pinned + reproducible-build CI step (rebuild from source, **SHA-only diff** stored as build artifact — NOT byte-diff between runs, since `pkg --compress GZip` is non-deterministic; r2-pkg P1-4). True reproducibility deferred to v0.4 native SEA, which produces deterministic single-static-link binaries by Node design.
+- New native helper for Win pipe ACL + JobObject + `ccsm_native.node` (§6.2, §7.M1; r3-lockin P0-A: canonical artifact name is `ccsm_native.node`, single .node carrying three exports `winjob` / `pdeathsig` / `pipeAcl` per frag-3.5.1 §3.5.1.1.a NativeBinding swap interface — supersedes the round-2 `winjob.node` filename) is in-tree, code-reviewed, no transitive deps. **Packaging contract** (r2-pkg P0-2 — TAKE coordination): frag-11 §11.1 must rebuild + ship + sign `ccsm_native.node`; this fragment owns the `realpath` + per-`.node`-codesign acceptance criteria. PUNT to frag-11: rename all `winjob.node` references to `ccsm_native.node` (§11.1, §11.2, §11.3, §11.6, before-pack.cjs).
+
+### 7.4 Threat model (post-hardening)
+
+Real markdown table. Rows = attacker capability; columns = mitigation layer + residual risk.
+
+| # | Attacker capability | OS ACL (§7.1.2) | Peer-cred (§7.1.3) | Schema + frame cap (§7.2) | Supply-chain (§7.3) | Residual risk |
+|---|---|---|---|---|---|---|
+| T1 | Other local user, non-admin, same Win/macOS box | DENY (pipe DACL = current SID; socket 0600) | Would also DENY (UID/SID mismatch) | n/a | n/a | None for v0.3 IPC. Still readable: `~/.ccsm` if user accidentally `chmod 755`'d it — explicit `chmod 700` on every create (sec-S3). |
+| T2 | Local admin / root on same box | ALLOW (admin can override ACL) | ALLOW (admin can spoof creds) | Schema still enforced | Could replace daemon binary | OUT OF SCOPE. Admin == game over per OS trust model. Documented. |
+| T3 | Malicious local process running AS the user | ALLOW (same SID/UID) | ALLOW (same UID/SID) | Schema + 16 MiB cap blunt DoS; can still issue legitimate RPCs | n/a | Net-equivalent to v0.2 in-process ipcMain. Documented as accepted: same-user processes can already read user files; daemon RPC adds no new privilege. |
+| T4 | Remote attacker on same LAN / coffee shop Wi-Fi | DENY (no INET listener) | n/a | n/a | Updater hits GitHub over TLS; cert pinning to GitHub roots | Updater MITM only viable with full TLS break + valid GitHub cert. v0.3 SLSA closes pipeline-forge residual. |
+| T5 | Remote attacker, no local foothold | DENY | n/a | n/a | n/a | OUT OF SCOPE for v0.3. v0.5 reopens with CF Access. |
+| T6 | Compromised auto-updater channel (CI key, GitHub Actions, replaced binary + matching SHA) | n/a | n/a | n/a | v0.3: SLSA-3 attestation bound to workflow file via OIDC; (Linux) minisign offline verify; auto-update OFF default. v0.4: sigstore signature verification offline. | v0.3 residual: MEDIUM (was HIGH pre-SLSA). v0.4 residual: LOW. |
+| T7 | Compromised npm transitive dep (typo-squat, takeover) | n/a | n/a | Schema validation can't catch malicious code in deps | npm audit gate, exact pins, reproducible pkg build (SHA-record) | Residual: MEDIUM. Same posture as Electron app today. Add Snyk / OSV-Scanner CI in a v0.4 follow-up. |
+| T8 | Co-tenant process tries pipe DoS (oversize frame, spam connect) | DENY at accept (peer-cred); accept-rate cap pre-accept | DENY post-accept | 16 MiB cap stops memory DoS; 50 acc/s cap stops pre-accept flood (§7.2) | n/a | Residual: LOW. Worst case: daemon spends CPU rejecting at 50/s. |
+| T9 | Local process plants binary at daemon path before Electron spawn | Per-user `%LOCALAPPDATA%\ccsm\bin\` with user-only ACL; `realpath` check at spawn | Imposter-secret check via `daemon.secret` HMAC echo (sec-S2 + §7.2) | n/a | n/a | Residual: NONE if §6.4 path layout honored. Refuses `Program Files` install path explicitly. See T14 for TOCTOU caveat. |
+| T10 | Renderer is XSS'd (e.g. via malicious markdown in a transcript) | n/a (renderer is local) | n/a | Renderer cannot bypass schema; daemon trusts no renderer claim | n/a | Residual: same as v0.2. CSP + no `eval` + sanitized markdown stack unchanged. Tracked separately. |
+| T11 | Secret leakage through logs | n/a | n/a | pino `redact` config (§6.6); PTY chunks never logged | n/a | Residual: LOW. Lint hook asserts no `chunk.toString()` in logger call sites; redact list reviewed each release. |
+| T12 | Process-list / handle-table observer (same-user) | n/a (env block readable by same-user via OpenProcess) | n/a | n/a | n/a | Residual: ACCEPTED. `CCSM_DAEMON_SECRET` env-passing is a one-off bootstrap; documented as not-acceptable for any future secret. Net-equivalent to T3. |
+| T13 | Crash-dump exfiltration | n/a (file ACL 0600 + redact at write time) | n/a | redact list applied to dump fields | n/a | Residual: LOW. Dumps never auto-uploaded; user-driven attach only. Path `<dataRoot>/crashes/`, retention 30 days + 200 MB aggregate cap. (§6.6.3) |
+| T14 | TOCTOU on `realpath` daemon-binary verify | Per-user ACL on `%LOCALAPPDATA%\ccsm\bin\` is the real defense; same-user attacker already controls the path | n/a | n/a | n/a | Residual: ACCEPTED. Same-user attacker = game over for daemon binary, identical posture to v0.2 unsigned scripts. `realpath` check is best-effort, not the gate. |
+| T15 | Co-tenant connect-rate flood pre-accept | DENY at 50 acc/s cap (§7.2) | n/a | n/a | n/a | Residual: LOW. Logged once per minute aggregate. |
+| T16 | Migration `quick_check` parser DoS via attacker-controlled SQLite file | n/a | n/a | n/a (SQLite parser lives below schema layer) | SQLite version pin + npm audit gate covers `better-sqlite3` family CVEs; frag-8 §8.3 path validation (see frag-8 r2 P0-S2 fix) prevents arbitrary-source attack | Residual: LOW once frag-8 enforces canonical-userData-path validation on `legacyDir`. |
+| T17 | Same-user process subscribes with `fromSeq: 0` and pulls full scrollback (incl. pasted secrets in transcript) | ALLOW (same SID/UID — peer-cred passes) | ALLOW (same UID/SID) | n/a | n/a | Residual: **ACCEPTED for v0.3** (r3-sec P0-2). Rationale: single-user single-machine v0.3, the same-user attacker who could mount this attack can also read SQLite directly via `sqlite3 <dataRoot>/ccsm.db` and dump the same data — a per-stream auth token is theatre when the underlying file is user-readable. **Deferred to v0.5 multi-tenant**: subscribe gains a per-session 128-bit `subscribe_token` (random at `createSession`, persisted on session row, required as `headers["x-ccsm-session-token"]`, validated with `crypto.timingSafeEqual`, never logged). v0.5 reopens because CF Tunnel + multi-tenant changes the threat surface; v0.3 single-user keeps token-less for scope. PUNT-CLOSED: not deferred to frag-3.5.1 — explicitly ACCEPTED here. |
+
+### 7.5 Out-of-scope for v0.3 (tracked, not addressed)
+
+Captured in `docs/superpowers/specs/v0.5-security-followups.md`:
+- CF Access JWT correctness (algorithm confusion, JWKS rotation, audience pinning, leeway).
+- CF Tunnel hostname enumeration; drive-by GitHub-OAuth phishing on Pages domain.
+- DNS rebinding against any future loopback INET listener; `Host` header validation.
+- Multi-client conflict resolution beyond single-writer lease (rel-S6).
+- iOS App Store framing (v0.6+, deferred per F3 spike).
+- Stream heartbeat traffic-analysis surface (r2-sec SH5): the 30s heartbeat reveals user-online status to a passive CF Tunnel observer; tunable in v0.5.
+- GPG / minisign signing of `SHA256SUMS.txt` (currently SLSA-attested only).
+- macOS keychain unlock CI hardening (r2-sec SH2): move `KC` password to `secrets.MACOS_KEYCHAIN_PW` rather than fixed `actions` literal.
+- `signtool verify /pa /v` post-sign assertion in CI (r2-sec SH3).
+
+---
 
 ## Plan delta
-- Task 1 (workspace) gains: pino.final + pino-roll integration (+3h).
-- New Task: supervisor backoff + crash loop detection (+4h).
-- New Task: last-known-good rollback on auto-update (+3h).
-- Task 7 (Connect client) gains: /healthz probe (+1h).
-- §7 is doc-only mostly; threat model table tracking issue.
+
+Specific edits to `docs/superpowers/plans/2026-04-30-v0.3-daemon-split.md`:
+
+- **Task 1** (daemon workspace skeleton, +5h): add `pino.final` registration, `pino-roll` transport config (daily / 50MB / 7-file limit), `redact` paths (including secret keys), base config (v + pid + boot ULID + side='daemon'). Acceptance: smoke test crashes daemon with `process.exit(1)` after a buffered log write and asserts the line is on disk.
+- **Task 4** (local channel listener, +6h): native helper (N-API or `koffi`) for Win `CreateNamedPipeW` with explicit DACL = current SID + `PIPE_REJECT_REMOTE_CLIENTS`; POSIX `umask(0077)` + `chmod 0600` on socket node; lockfile via `proper-lockfile`. Acceptance: cross-user access denied test (manual repro doc + scripted same-user negative test). **Plus:** dedicated supervisor transport (`ccsm-control` socket per §3.4.1.h table), separate accept loop, same ACL discipline. `[manager r11 lock: P1 devx P1-2 socket name canonical = ccsm-control; was `-sup` suffix]`
+- **Task 5** (Connect adapter, +3h): MAX_FRAME = 16 MiB enforcement at length read; TypeBox `Check()` at adapter boundary before handler dispatch; `traceId` field added to envelope schema (JSON + binary header) and validated against ULID regex; propagated through.
+- **Task 5** (also, +2h): `rpcCall` 30s default deadline + AbortSignal support; `daemon-unhealthy` event surface; 50 acc/s rate cap.
+- **Task 5** (also, +1h, r2-sec P1-S1): per-handler `Check(MethodArgsSchema, decoded)` boilerplate + ESLint rule `no-handler-without-check`.
+- **Task 5** (also, +1h, r2-fwdcompat P0-2): `daemon.hello` handshake RPC; daemon refuses other RPCs until hello completes; `compatible: false` with clean error code.
+- **Task 6** (daemon entry, +2h): peer-cred check on accept (`SO_PEERCRED` / `getpeereid` / `GetNamedPipeClientProcessId`); imposter-secret HMAC echo verify on hello; reads `CCSM_DAEMON_SECRET` env first, file fallback, refuse if neither.
+- **NEW Task 6a** (supervisor, +8h was +6h): backoff state machine (1s→30s cap, reset @60s stable, reset on rollback success), crash-loop detection (5/2min, reset on rollback success, dev-mode disabled), heartbeat poller (5s prod / 30s dev, 3-miss prod / 5-miss dev), dedicated supervisor transport client, banner IPC events on consolidated `daemonHealth` channel, single `useDaemonHealthBridge` hook, surface registry stacking enforcement, 250ms reconnect-toast hold-off, N=15 escalate-to-modal. Owns the `daemonSupervisor` module in Electron-main.
+- **NEW Task 6b** (last-known-good rollback, +4h was +3h): `daemon.exe.bak` retention, atomic `MoveFileExW` swap, single-shot auto-rollback on cold-start failure within 30s, "successful rollback" 60s+5×ping verification, crash-loop window decay + backoff counter clear on success per r3-rel R2, `daemon.rolledBack` IPC + toast.
+- **NEW Task 6c** (Electron-side logger + crash-imminent IPC, +3h, r2-obs P0-1, P0-3, P0-4, S-R1): `electron/log.ts` mirroring daemon pino-roll/redact/base config (with `side: 'electron'`), `pino.final` on `app.before-quit` / `uncaughtException` / `unhandledRejection` / supervisor "Quit" handlers, bridge call-completion log lines with vitest hook, optional renderer-console forward gated by `CCSM_RENDERER_LOG_FORWARD`, daemon-side drain ordering (state='draining' → clear timers → aggregate-shutdown lines → wal_checkpoint → close → pino.final), `daemon.crashing` IPC emission before pino.final.
+- **NEW Task 6d** (cold-start splash + UX copy + paused affordance, +3h, r2-ux P0-UX-3, P1-UX-5, P1-UX-6): `Starting ccsm…` HTML pre-mount loader; supervisor-state copy table from §6.1.1 wired in; "Paused — daemon was restarted [Resume]" affordance with explicit "previous turn discarded" copy; `app_state.close_to_tray_shown_at` first-close toast.
+- **Task 8/12/13** (lifted services, +2h each): audit every multi-row write, wrap in `db.transaction(() => …)`. Reviewer must check all compound-write call sites. Add explicit `PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;` at every db open path.
+- **Task 11** (lift ptyService, +5h was +4h): JobObject (Win) + `setpgid`/`PR_SET_PDEATHSIG` (POSIX) for orphan reaping; SIGCHLD handler scoped to PIDs in our `pid → sessionId` map (r2-rel P1-R5 — `waitpid(pid, WNOHANG)` per known PID, NOT `waitpid(-1)`); single-writer `ptyWrite` lease; explicit fan-out subscriber model documented (shared registry, drop-slowest under backpressure ≥1 MB); 400 MB total headless-RSS cap with new-spawn block (rel S-R7); shutdown sequence per §6.6.1 step 5.
+- **Task 11c** (ptySubscribe, +1h): `traceId` propagation; per-subscriber state == OS socket buffer only (no per-client backlog); `bootNonce` in subscribe + delta envelopes; `bootChanged: true` response on nonce mismatch.
+- **Task 7** (Electron handshake e2e, +3h was +2h): adds `/healthz` ping + 1000-ping latency benchmark (target p95 < 5ms) on dedicated supervisor transport; imposter-secret negative test; `daemon.hello` handshake test; `bootNonce` mismatch resubscribe test.
+- **NEW Task 23a** (updater hardening, +6h was +4h): download-to-`.partial` + 3× exponential backoff; SHA256 verify; **SLSA-3 provenance verify against GitHub OIDC root**; **Linux: minisign verify**; atomic rename; **`daemon.secret` rotation step BEFORE binary swap**; auto-update DEFAULT OFF (env-gated); manual update prompt UX runs same verification chain.
+- **Task 23** (updater core, ±0h): rejection of legacy "spawn batch script" pattern; documented rationale.
+- **NEW Task 23b** (release-side SLSA + minisign, +4h, r2-sec P0-S3): GitHub Actions step `actions/attest-build-provenance@v1`; minisign keypair generation + signature step (Linux release matrix); publish `provenance.intoto.jsonl` + `SHA256SUMS.txt.minisig` as release assets; document minisign public key in README + install docs.
+- **Task 25** (dogfood gate, +2h): RAM target restated as "daemon RSS excluding child processes <120 MB with 5 sessions; daemon + all children <500 MB" (res-MUST-3); benchmark suite added (obs-S9); crash-dump file written on `process.exit(1)` paths per §6.6.3 schema.
+- **NEW Task 26** (security verification, +4h): cross-user access denial repro (manual + scripted); secret-redaction lint hook; `npm audit --audit-level=high` CI gate; reproducible pkg-build SHA-record CI step (NOT byte-diff); `daemon.secret` lifecycle e2e (atomic create-with-ACL, rotation on update, env-var precedence).
+- **NEW Task 27** (threat-model + followups doc, +3h was +2h): commit `docs/superpowers/specs/v0.5-security-followups.md` with §7.5 contents pre-populated.
+- **NEW Task 28** (uninstall hygiene, +5h, pkg P0-1 TAKE — coordinate with frag-11 implementation): `build/installer.nsh` `customUnInstall` macro per §6.8 contract; `nsis.include` wiring in `package.json`; `.deb postrm` + `.rpm %preun` scripts; macOS tray `Reset ccsm…` action (typed-confirm); release notes section. Order-of-operations enforcement: kill daemon → delete lockfile → checkbox dialog → conditional RMDir.
+
+**Total estimated delta**: +71h on top of v1 plan (~125h → ~196h, was +44h before round-2). Round-2 added ~27h (see prior round entries). **Round-3 adds ~6h** of pure spec/contract clarifications (no new task budget):
+- §6.1 dev-mode supervisor wording reconciliation, crash-loop counter decay rule (R2 revised) — 0h, prose only.
+- §6.6.1 drain order R1 reorder (subscriber close moves AFTER SIGCHLD wind-down + DB writes) — Task 6c +1h re-test.
+- §6.6.1 hot-path traceId carve-out + canonical reconnect log key list — 0h, lint-rule update only.
+- §6.6.1 + §6.6.2 pino-roll `symlink: true` (devx CF-1 + resource X2) — 0h config.
+- §6.6.1 aggregate `<dataRoot>` disk caps (logs 500 MB, crashes 200 MB) — Task 25 +1h watchdog.
+- §6.4 boot order lockfile-before-ensureDataDir + swap-lock (P0-R4 + P1-R5) — Task 6b +1h.
+- §6.5 `bootNonce` camelCase + `daemonProtocolVersion` mirror + `daemonAcceptedWires` + `swapInProgress` + `healthzVersion` — Task 7 +1h e2e for new fields.
+- §7.2 HMAC-of-nonce wire-shape lock (sec P0-1, supersedes bearer-token) + `crypto.timingSafeEqual` + headless carve-out + env-var clear hardening — Task 6 +2h (replaces bearer-token plumbing with HMAC + nonce gen + redact additions).
+- §7.3 SLSA verifier `@sigstore/verify` pin (sec P1-4) — Task 23a +0.5h dep add.
+- §7.4 T17 fromSeq ACCEPTED row — 0h, prose.
+- §6.8 surface registry canonicalization + camelCase i18n keys + close_to_tray timestamp lock + uninstall ownership split — 0h prose.
+- §7.3 `winjob.node` → `ccsm_native.node` rename (lockin P0-A) — Task 11 +0h here, but coordinate frag-11 + frag-3.5.1.
+
+Round-3 net spec-edit: +6.5h budget growth, all on existing tasks. All additions are blocking for v0.3 freeze per the cited round-3 reviews.
+
+---
+
+## Cross-frag rationale
+
+This is the highest-load fragment in round-2. Many cross-fragment P0s land here because the §6/§7 owner is the natural place for daemon-lifecycle + secret-lifecycle + user-visible-failure-surface contracts. Decisions on what to TAKE vs PUNT:
+
+**TAKEN (this fragment is the right owner):**
+
+1. **Uninstall hygiene** (pkg P0-1) — `build/installer.nsh` lives in `frag-11` mechanically (NSIS is electron-builder territory) but the *contract* (which paths to remove, daemon shutdown sequence, lockfile cleanup, kill-before-unlock ordering) is a daemon-lifecycle + lockfile concern owned by §6.4 / §6.8. Frag-11 implements; this fragment specifies. See §6.8 "Uninstall hygiene" + Plan delta NEW Task 28.
+
+2. **Cross-fragment surface registry** (ux P0-UX-1) — every modal/toast/banner emitted by v0.3 is registered in §6.8 with priority + mutual-exclusion rules. Lives here because the dominant surfaces (crash-loop, rollback, heartbeat, paused, BridgeTimeout) all originate from supervisor / reliability paths. Frag-3.7 and frag-8 reference back instead of inventing copy in isolation.
+
+3. **`daemon.hello` + protocol block** (fwdcompat P0-2) — version handshake payload lives in §6.5 alongside `/healthz` because both are version-negotiation surfaces emitted by the same daemon module. Frag-3.4.1 owns the wire shape + the handshake-as-first-envelope rule; this fragment owns the payload schema + behavioral rule (refuse other RPCs until hello).
+
+4. **Electron-side logger** (obs P0-1, P0-4) — pino mirroring is conceptually two-process logging which spans the boundary owned by §6.6. Frag-6-7 already owned daemon-side `pino.final` so the Electron-side complement belongs here for spec cohesion. Plan delta Task 6c implements.
+
+5. **`daemon.secret` lifecycle** (sec P0-S1) — secret generation/rotation/redact is a security concern owned by §7.2; lockfile coordination is owned by §6.4; both interact at first-boot race. Single source-of-truth in §7.2 with §6.4 step 4 cross-referencing the rotation step.
+
+6. **SLSA + Linux minisign** (sec P0-S3) — supply-chain integrity is owned by §7.3. Frag-11 implements the GitHub Actions release steps (NEW Task 23b coordinates); this fragment owns the verifier contract.
+
+7. **Drain ordering for log producers** (obs P0-3) — extends `pino.final` semantics owned by §6.6 with producer-side timer/queue lifecycle. Lives in §6.6.1.
+
+8. **Crash-loop counter reset, dev-mode supervisor, dedicated /healthz transport, shutdown SIGCHLD ordering** — all daemon-lifecycle concerns naturally owned by §6.1/§6.4/§6.5/§6.6.
+
+**PUNTED (other fragments are the right owner):**
+
+1. **`traceId` in binary frame header** (obs P0-2) — wire shape owned by frag-3.4.1 §3.4.1.c. This fragment §6.6 specifies the validation rule + ULID regex but the field-list edit is frag-3.4.1's. Cross-referenced.
+
+2. **`bootNonce` in stream subscribe + `bootChanged: true`** (fwdcompat P1-1) — stream RPC contract owned by frag-3.5.1 §3.5.1.4 + frag-3.7 §3.7.5. This fragment §6.5 defines `boot_nonce` as ULID + advertises it via `/healthz` + Plan delta Task 11c notes propagation, but the schema edit lives in those fragments.
+
+3. **`fromSeq` session-token authentication** (sec P1-S3) — subscribe authorization owned by frag-3.5.1. Mentioned in Plan delta Task 11c contract but not specified here.
+
+4. **Migration env-var trust validation** (sec P0-S2) — migration logic owned by frag-8 §8.3. Threat-model row T16 in §7.4 cross-references the dependency.
+
+5. **Migration partial-write recovery + `.migrating` cleanup** (rel P0-R4) — owned by frag-8 §8.3 startup logic. T16 row notes the dependency.
+
+6. **Per-handler arg validation rule** (sec P1-S1) — wire-level contract owned by frag-3.4.1 §3.4.1.d. §7.2 names the rule + ESLint rule name; the spec edit happens in frag-3.4.1.
+
+7. **CI Node 22 bump, winjob.node packaging, `--compress GZip` reproducibility** — packaging concerns owned by frag-11. §7.3 names the SHA-record approach (P1-4 resolution); frag-11 implements.
+
+8. **Renderer XSS hardening, CSP, sanitized markdown** — UI-layer concerns. T10 row in §7.4 cross-references but does not own.
+
+9. **Reconnect queue retry-forever escalation** (ux P1-UX-1) — frag-3.7 §3.7.4 owns the queue. §6.1.1 supplies the modal copy; frag-3.7 wires the N=15 trigger.
+
+10. **dev-mode reconnect toast vs supervisor banner duplication** (ux P1-UX-4) — surface registry §6.8 resolves at the contract level (banner suppresses toast); frag-3.7 implements the suppression check.
+
+---
+
+## Cross-frag rationale — Round 3 additions
+
+**TAKEN in r3 (this fragment is right owner):**
+
+R3-T1. **Surface registry canonicalization** (r3-ux P0-A) — §6.8 is now the SINGLE canonical registry; every surface formerly proposed in frag-3.7 (dev-mode reconnect surface, dev build error toast, all stacking rules consolidated) has been merged in. frag-3.7's parallel registry is collapsed into a one-paragraph cross-ref to §6.8.
+
+R3-T2. **Drain order R1 reorder** (r3-rel R1) — SIGCHLD wind-down + DB terminal-state writes happen BEFORE subscriber close in §6.6.1 step list; subscriber-close is the LAST runtime act before pino.final. Lives here because §6.6.1 is the canonical shutdown sequence.
+
+R3-T3. **Crash-loop counter decay rule** (r3-rel R2) — rollback success clears backoff counter but DECAYS crash-loop window (rolled-back crash counts as 3/5, not full clear). §6.1 + §6.4 step 7. "Limp mode" rationale.
+
+R3-T4. **`daemon.crashing` IPC explicitly best-effort** (r3-rel R5) — §6.6.1 spells out that the IPC fires only on Node-observable death paths (uncaughtException etc.); on SIGKILL no IPC. Renderer must use socket-close + healthz-fail as primary signal.
+
+R3-T5. **HMAC-of-nonce hello wire shape locked** (r3-sec P0-1) — §7.2 mandates HMAC-SHA256(secret, clientHelloNonce) truncated to 16 bytes, `crypto.timingSafeEqual` compare. Bearer-token form REJECTED. PUNT to frag-3.4.1 §3.4.1.g hello payload to align field names (`clientHelloNonce` + `helloNonceHmac`, drop `clientImposterSecret`).
+
+R3-T6. **fromSeq subscribe-token ACCEPTED for v0.3** (r3-sec P0-2) — §7.4 T17 row added; deferred to v0.5 multi-tenant. NOT punted to frag-3.5.1 — explicitly accepted here as v0.3 single-user-single-machine residual. Rationale: same-user attacker can `sqlite3` the file directly anyway.
+
+R3-T7. **Aggregate `<dataRoot>` disk caps** (r3-resource X1) — §6.6.1 specifies logs aggregate 500 MB + crashes aggregate 200 MB watchdogs. Was punted by frag-3.5.1 to "frag-8 + frag-6-7 §6.6"; frag-6-7 picks it up (frag-8 owns corrupt-backups separately).
+
+R3-T8. **`bootNonce` camelCase lock** (r3-fwdcompat CF-2) — §6.5 healthz emits `bootNonce` (was `boot_nonce`); aligned with rest of envelope. PUNT to frag-3.7 to align any `response.boot_nonce` reads to `response.bootNonce`.
+
+R3-T9. **`daemonProtocolVersion` mirrored in /healthz protocol block** (r3-lockin CF-2) — was only in frag-3.4.1 §3.4.1.g hello reply; supervisor `/healthz` protocol block now also carries the integer so post-update protocol-version mismatch is detectable on long-lived attach.
+
+R3-T10. **`clientImposterSecret` + `helloNonce` redact paths** (r3-lockin CF-3) — §6.6 redact list extended; pino redact is path-based (not substring) so explicit paths required.
+
+R3-T11. **Uninstall ownership split** (r3-resource X3) — §6.8 owns in-app surface (tray "Reset ccsm…", IPC contract); frag-11 §11.6 owns disk paths + NSIS macro / postrm / preun script bodies. Was double-claimed; r3 splits cleanly.
+
+R3-T12. **close_to_tray timestamp key lock** (r3-resource X4 + r3-ux CC-1) — §6.8 locks `app_state.close_to_tray_shown_at` (timestamp); rejects frag-3.7's boolean `close_to_tray_hint_shown`. Timestamp is more useful for "shown N days ago" hint.
+
+R3-T13. **i18n key casing camelCase lock** (r3-ux CC-3) — `daemon.crashLoop`, `daemon.healthDegraded`, `daemon.bridgeTimeouts`, `daemon.reconnectExhausted`, etc. Aligns with frag-3.7's existing camelCase. PUNT to frag-3.7 to verify; PUNT to frag-8 to align `migration.*` keys.
+
+R3-T14. **BridgeTimeout policy locked** (r3-devx CF-3 + r3-ux CC-4) — §6.1.1 last paragraph: never user-surfaced as per-call toast; bridge wrapper retries once internally; aggregates into `daemon.bridgeTimeouts` banner at ≥3/10s; "reconnecting…" toast is the only continuous user signal. PUNT to frag-3.5.1 §3.5.1.3 to add carve-out sentence.
+
+R3-T15. **Dev-mode supervisor wording reconciliation** (r3-devx CF-3) — §6.1 second bullet now explicitly: lifecycle DISABLED in full, but `ccsm-control` transport STILL BOUND for diagnostic UI poll. Resolves apparent contradiction with frag-3.7 §3.7.6.a "Supervisor active? NO" — both are now consistent: lifecycle off, read-only poll on. `[manager r11 lock: P1 devx P1-2 socket name canonical = ccsm-control; was `-sup`]`
+
+R3-T16. **Supervisor transport = control-socket clarification** (r3-perf CF-1) — §6.5 explicitly states the `ccsm-control` socket IS the same channel as frag-3.4.1 §3.4.1.h's "control-socket". ONE control plane, single canonical name. `[manager r11 lock: P1 devx P1-2 socket name canonical = ccsm-control across both fragments; was `-sup` alias]`
+
+R3-T17. **Hot-path traceId carve-out** (r3-perf CF-2) — §6.6.1 explicit rule: per-chunk fan-out logs at debug level only; when emitted, source `traceId` from cached `streamId → spawnTraceId` map (NOT generate fresh ULID per chunk). Per-frame info-level logging on PTY hot path is FORBIDDEN.
+
+R3-T18. **OS-native paths re-anchored everywhere** (manager arch lock) — all `~/.ccsm/` references in §6.4, §6.5, §6.6, §6.6.3, §7.1, §7.2 replaced with `<dataRoot>` notation; concrete OS-native paths in tables. Daemon binary path triple-rooted (`%LOCALAPPDATA%\ccsm\bin\` Win, `~/Library/Application Support/ccsm/bin/` mac, `~/.local/share/ccsm/bin/` Linux) explicitly re-stated in §6.4 and §7.2.
+
+R3-T19. **SLSA verifier pinned to `@sigstore/verify`** (r3-sec P1-4) — §7.3 specifies the verifier library + trust root + verify call shape. Cosign-binary alternative explicitly rejected.
+
+**PUNTED in r3 (other fragments must align):**
+
+R3-P1. **frag-3.7 surface registry collapsed** (r3-ux P0-A) — §6.8 now canonical. frag-3.7's former parallel registry is replaced with `see frag-6-7 §6.8` cross-ref; do not maintain a parallel registry.
+
+R3-P2. **frag-3.5.1 §3.5.1.2 step 8 terminal state** (r3-rel R3) — drop `state='abandoned'`; use `state='paused'` for SIGKILL'd survivors. Single canonical terminal-name across both fragments.
+
+R3-P3. **frag-3.5.1 §3.5.1.3 BridgeTimeout carve-out** (r3-devx CF-3) — add the sentence "BridgeTimeoutError is logged with `DEADLINE_EXCEEDED` but NEVER surfaced to the user; surfacing owned by §6.8 / §6.1.1 banner aggregation."
+
+R3-P4. **frag-3.4.1 §3.4.1.g hello payload field names** (r3-sec P0-1 + r3-lockin CF-3) — rename `clientImposterSecret` → `clientHelloNonce` (16-byte nonce, not the secret); add `helloNonceHmac` reply field; document HMAC-of-nonce challenge-response per §7.2 wire shape lock.
+
+R3-P5. **frag-3.4.1 §3.4.1.h control-socket name unification** (r3-perf CF-1) — single canonical name `ccsm-control` across both fragments; ONE control plane shared with §6.5. `[manager r11 lock: P1 devx P1-2 socket name canonical = ccsm-control; was `-sup` alias on frag-6-7 side]`
+
+R3-P6. **frag-3.7 §3.7.5 `boot_nonce` reads → `bootNonce`** (r3-fwdcompat CF-2) — silent `undefined`-read bug if not aligned.
+
+R3-P7. **frag-3.7 §3.7.4 reconnect log key names** (r3-obs P1-2) — implementer must use the canonical strings listed in §6.6.1; one-line cross-ref to §6.6.1 in §3.7.4.
+
+R3-P8. **frag-3.7 close_to_tray key** (r3-resource X4) — align to `close_to_tray_shown_at` timestamp.
+
+R3-P9. **frag-12 stale OPEN rows** (r3-ux P0-C) — re-grade fwdcompat 3.1 / 3.3, packaging M4, ux M2, obs-M2 / obs-M4, and add 3 new rows for r2-obs P0-1/P0-3/P0-4. Frag-12 owns this re-audit; this fragment cannot edit it.
+
+R3-P10. **frag-11 native artifact rename** (r3-lockin P0-A) — `winjob.node` → `ccsm_native.node` across §11.1 / §11.2 / §11.3 / §11.6 / before-pack.cjs.
+
+R3-P11. **frag-11 §11.6.2 macOS Reset CCSM**: use `shell.trashItem` (gentle, undoable) — not unlinkSync nor typed-confirm word-gate. Aligned with §6.8 in-app contract.
+
+R3-P12. **frag-3.4.1 daemonHelloHmac sec edit + traceId on chunk inheritance** (r3-sec CC-2 + r3-perf P1-1 fixed-width seq) — frag-3.4.1 owns the wire schema edits; §6.6 here owns the validation + redact.
+
+R3-P13. **frag-8 migration i18n keys camelCase** (r3-ux CC-3) — `migration.modal.*` etc. align to camelCase.

--- a/docs/superpowers/specs/v0.3-fragments/frag-6-7-reliability-security.md
+++ b/docs/superpowers/specs/v0.3-fragments/frag-6-7-reliability-security.md
@@ -1,0 +1,62 @@
+# Fragment: §6 reliability + §7 security expansion
+
+**Owner**: worker dispatched per Task #936
+**Target spec sections**: replace existing §6 and §7 in main spec
+**P0 items addressed**: #11 (pino.final), #12 (pino-roll); plus §7 absorbs
+the threat model post-hardening
+
+## What to write here
+
+### §6 Reliability (rewrite)
+Existing §6 is thin. Expand to cover:
+1. **Daemon supervision**:
+   - Electron main spawns daemon; on daemon exit, supervisor decides:
+     restart with backoff (1s → 2s → 4s ... cap 30s, reset after 60s
+     stable), OR enter "crash loop detected" state after 5 restarts in
+     2 min (surface UI, stop auto-restart, ask user).
+   - Last-known-good binary: on auto-update, keep `daemon.bak`; if new
+     daemon crash-loops, supervisor falls back to `.bak` automatically.
+2. **Logging shutdown safety**:
+   - `pino.final()` registered on daemon `beforeExit` and signal handlers
+     (SIGTERM, SIGINT) so buffered log writes flush before exit. Without
+     this, last-second crash logs are lost.
+3. **Log rotation**:
+   - `pino-roll` (or `pino-rotating-file` — pick one and justify) configured
+     with daily rotation + 7 day retention + 50 MB per file cap. Files at
+     `~/.ccsm/logs/daemon-YYYY-MM-DD.log`. Prevents unbounded disk usage
+     (resource review noted this gap).
+4. **Health probe**: daemon exposes `/healthz` RPC (no auth needed, local-only)
+   returning uptime + active session count. Used by supervisor for liveness;
+   future v0.4 adds `/readyz` for migration completion.
+
+### §7 Security (rewrite)
+Existing §7 understated. Expand to cover:
+1. **Trust boundary (v0.3)**: same-machine, same-user. Enforced by:
+   - Local socket only (no TCP listener at all in v0.3).
+   - OS-level ACL/mode (§3.1.1).
+   - Sender peer-cred verification per connection (§3.1.1).
+2. **Defense in depth**: even with trust boundary, daemon validates every
+   envelope schema (TypeBox), enforces frame caps (§3.4.1), and never
+   shells out user-provided strings unescaped.
+3. **Supply chain**:
+   - Daemon binary published with SHA256 manifest in GitHub release.
+   - Auto-update verifies SHA256 before swap (§3.1).
+   - **Roadmap**: sigstore signing in v0.4 → flip auto-update default ON.
+   - **Roadmap**: Cloudflare Access JWT validator middleware in v0.5 (seam
+     already present from v0.3 §3.1).
+4. **Threat model (post-hardening) table**: rows = attacker capability,
+   columns = mitigation. e.g. "local non-admin user on same machine" → ACL
+   denies; "remote attacker on LAN" → no listener; "compromised daemon
+   binary on disk" → SHA256 verify on update (limited; full sig in v0.4).
+
+Cite findings from `~/spike-reports/v03-review-reliability.md`,
+`~/spike-reports/v03-review-security.md`,
+`~/spike-reports/v03-review-observability.md`,
+`~/spike-reports/v03-review-resource.md`.
+
+## Plan delta
+- Task 1 (workspace) gains: pino.final + pino-roll integration (+3h).
+- New Task: supervisor backoff + crash loop detection (+4h).
+- New Task: last-known-good rollback on auto-update (+3h).
+- Task 7 (Connect client) gains: /healthz probe (+1h).
+- §7 is doc-only mostly; threat model table tracking issue.

--- a/docs/superpowers/specs/v0.3-fragments/frag-8-sqlite-migration.md
+++ b/docs/superpowers/specs/v0.3-fragments/frag-8-sqlite-migration.md
@@ -2,52 +2,874 @@
 
 **Owner**: worker dispatched per Task #937
 **Target spec section**: new §8 in main spec (after §7 security)
-**P0 items addressed**: #1 (SQLite migration — UX critical from review)
+**P0 items addressed**: MUST-1 from `~/spike-reports/v03-review-ux.md` ("v0.2 → v0.3 SQLite migration is unspecified — every session, every title, every setting gone")
 
-## What to write here
-Replace this section with actual `## 8. Data migration: v0.2 → v0.3`
-markdown. Cover:
+---
 
-1. **Source location (v0.2)**: `app.getPath('userData')/...` — exact filenames
-   (sessions.db, settings.json, etc.). Check existing v0.2 code in
-   `electron/store/**` for actual paths and DB filenames; cite.
-2. **Target location (v0.3)**: `~/.ccsm/data/` (cross-platform: Win
-   `%USERPROFILE%/.ccsm/data/`, Mac/Linux `$HOME/.ccsm/data/`). Daemon owns
-   this dir.
-3. **Migration trigger**: daemon's first-boot check.
-   - If `~/.ccsm/data/sessions.db` exists → skip.
-   - Else if `app.getPath('userData')/sessions.db` exists (Electron passes
-     v0.2 path to daemon via env var on first launch) → migrate.
-   - Else → fresh install, init empty db.
-4. **Migration steps (atomic)**:
-   - Copy v0.2 db file to `~/.ccsm/data/sessions.db.tmp`.
-   - Open with better-sqlite3, run any v0.2 → v0.3 schema diffs (list them
-     here; if none, just integrity check).
-   - `fs.renameSync` `.tmp` → `sessions.db` (atomic on same filesystem).
-   - Write marker `~/.ccsm/data/.migration-v0.3.done` with timestamp.
-   - Leave v0.2 db in place untouched (rollback safety; user can downgrade).
-5. **Failure modes**:
-   - Disk full / permission → daemon logs, sends `MigrationFailedEvent` to
-     Electron, UI shows actionable dialog ("contact support / try again /
-     skip and start fresh"). Daemon stays up but data API returns
-     `MIGRATION_PENDING`.
-   - Schema mismatch (corrupted v0.2 db) → log, surface to UI, do NOT
-     auto-overwrite.
-6. **Rollback**: user can manually delete `~/.ccsm/data/`; daemon detects
-   missing db on next boot and re-runs migration.
-7. **Telemetry**: log migration duration, source size, success/fail to
-   pino logs (no remote telemetry in v0.3).
-8. **Test plan**: e2e test that seeds a v0.2 userData db, boots v0.3 daemon,
-   asserts data appears in `~/.ccsm/data/`, original untouched.
+## 8. Data migration: v0.2 → v0.3
 
-Cite findings from `~/spike-reports/v03-review-ux.md`.
+### 8.1 What v0.2 actually writes (grounded)
+
+Source-of-truth grep on `working` tip: the only Electron call to
+`app.getPath('userData')` lives in `electron/db.ts:124`. Every other
+v0.2 persistence path either targets the user's CLI dir (`~/.claude/...`,
+owned by Claude CLI, not by ccsm) or is in-memory.
+
+ccsm-owned files inside `userData`:
+
+| File | Producer | Notes |
+|---|---|---|
+| `ccsm.db` | `electron/db.ts:126` (`new Database(path.join(dir, 'ccsm.db'))`) | Single SQLite database. Schema = one table, `app_state(key TEXT PRIMARY KEY, value TEXT, updated_at INTEGER)` (`db.ts:43-49`). `PRAGMA user_version = 1` (`db.ts:17`). |
+| `ccsm.db-wal` | better-sqlite3 in WAL mode (`db.ts:130`) | Sidecar. May contain uncheckpointed writes. |
+| `ccsm.db-shm` | better-sqlite3 in WAL mode | Shared-memory index for the WAL. |
+| `ccsm.db.corrupt-<ts>` | `db.ts:96` | Backup created when `quick_check` fails. Treat as user-owned forensic file — copy if present, do not open. |
+
+`userData` resolves per Electron docs to (verified against
+`package.json:5` `productName: "CCSM"` and `:113` `appId: com.ccsm.app`):
+
+- **Win**: `%APPDATA%\CCSM\` → typically `C:\Users\<user>\AppData\Roaming\CCSM\`
+- **macOS**: `~/Library/Application Support/CCSM/`
+- **Linux**: `~/.config/CCSM/` (XDG)
+
+Dev installs use `productName "CCSM Dev"` / `appId com.ccsm.app.dev`
+(`package.json:31`) → `%APPDATA%\CCSM Dev\` etc. Migration MUST honor
+the same product-name suffix that the running Electron build was
+configured with — see §8.4 for handoff.
+
+There are NO other ccsm-owned files in `userData` today. `electron/memory.ts`
+writes only to `~/.claude/CLAUDE.md` (CLI-owned, untouched by upgrade).
+`electron/sessionTitles/**` round-trips through the SDK to
+`~/.claude/projects/<key>/<sid>.jsonl` (CLI-owned, untouched). `electron/prefs/**`
+(closeAction, crashReporting, notifyEnabled, userCwds) all persist via
+`saveState`/`loadState` → rows in the same `app_state` table inside
+`ccsm.db`. So the migration surface is exactly **one .db file plus its
+two WAL sidecars**, and the v0.2-corrupt-backup as a courtesy copy.
+
+### 8.2 Target location (v0.3) — OS-native data root
+
+`<dataRoot>` is OS-native per frag-11 §11.6: `%LOCALAPPDATA%\ccsm\` on
+Windows, `~/.local/share/ccsm/` on Linux, `~/Library/Application
+Support/ccsm/` on macOS. v0.2 → v0.3 migration moves data from legacy
+`~/.ccsm/` to `<dataRoot>`; see §8.3 step 1.
+
+[manager r5 lock: `<dataRoot>` placeholder, frag-11 §11.6 is single
+source of truth; reason: install path locked to `%LOCALAPPDATA%` in r3
+to avoid UAC, all sibling paths follow.]
+
+**Rationale (round-3 arch lock, round-5 dataRoot reconciliation)**:
+v0.2 used the cross-platform `~/.ccsm/` location for both daemon
+runtime files and (via Electron's `userData`) the database. v0.3
+consolidates everything daemon-owned — database, logs, crash dumps,
+lockfile, `daemon.secret`, migration markers, corrupt-backups — under
+the single OS-native `<dataRoot>` defined by frag-11 §11.6. This
+matches v0.3's install path policy (installer drops binaries under the
+same per-user OS-native root; data follows the same convention so
+backup tools, antivirus exclusion lists, and MDM policies behave
+predictably) and eliminates the three-way `<dataRoot>` permutation
+flagged in r4 packaging review.
+
+Daemon owns the data root at (per frag-11 §11.6 paths table):
+
+- **Windows**: `%LOCALAPPDATA%\ccsm\` → typically `C:\Users\<user>\AppData\Local\ccsm\`
+- **macOS**: `~/Library/Application Support/ccsm/`
+- **Linux**: `~/.local/share/ccsm/` (frag-11 §11.6 fixed this row to the per-user
+  OS-native root; `$XDG_DATA_HOME` is not consulted, matching frag-11)
+
+Inside that root (subset relevant to migration; full table in frag-11
+§11.6):
+
+- `<dataRoot>/data/ccsm.db` — the database
+- `<dataRoot>/data/migration-state.json` — the migration marker (§8.5 S8)
+- `<dataRoot>/data/ccsm.db.corrupt-*` — quick_check corrupt-backups (carried
+  over from legacy by §8.5 S7)
+- `<dataRoot>/data/ccsm.db.migrating[-wal][-shm]` — transient migration tmp
+  (cleared by §8.3 step 1a)
+- `<dataRoot>/logs/daemon.log` — pino-roll output (owned by frag-6-7 §6.6)
+- `<dataRoot>/crashes/` — crash dumps (owned by frag-6-7 §6.6.3)
+- `<dataRoot>/daemon.lock` — daemon-singleton lockfile (owned by frag-6-7 §6.4)
+  [manager r11 lock: lockfile name unified to daemon.lock per frag-6-7 majority; r10 devx P1-3]
+
+Throughout the rest of this fragment, `<dataRoot>` refers to whichever
+of the three OS-native paths above resolves on the current platform.
+The implementation MUST use the same per-OS resolver as the installer
+(frag-11 §11.6) and MUST NOT hard-code `~/.ccsm/...` for any v0.3 path.
+The legacy `~/.ccsm/...` paths were interim round-1/round-3 placeholders
+and are **no longer used** in v0.3; they appear in §8.3-§8.8 only as
+v0.2 migration sources.
+
+Filename stays `ccsm.db` (NOT renamed to `sessions.db` or `ccsm.sqlite` —
+both appear as guesses in the v1 stub and the UX report; the on-disk
+truth is `ccsm.db`).
+
+**Note on the legacy v0.2 source path**: v0.2 itself stored
+`ccsm.db` in Electron's `userData` (per-product-name path under
+`%APPDATA%\CCSM\`, `~/Library/Application Support/CCSM/`, `~/.config/CCSM/`).
+That is the **migration source** path resolved by §8.4
+`resolveLegacyDir()`. The v0.2 `~/.ccsm/` directory (added late in
+v0.2 for the daemon socket only — pre-database-move) never contained
+user data and is not a migration source candidate.
+
+### 8.3 Migration trigger (daemon first-boot)
+
+The daemon, on every boot, runs `ensureDataDir()` BEFORE
+`new Database(...)`. **Lockfile ordering (round-3 reliability P0-R4
+fix)**: the daemon-singleton lockfile (`<dataRoot>/daemon.lock`,
+owned by frag-6-7 §6.4) MUST be acquired BEFORE `ensureDataDir()`
+runs. This closes the documented race where step 1a's unconditional
+`unlink(<dataRoot>/data/ccsm.db.migrating*)` could otherwise delete a
+**live** tmp file owned by a concurrent migrating daemon (e.g. user
+double-clicked the launcher, MDM relaunch, debugger-spawned instance).
+With lockfile-first, only one daemon ever reaches `ensureDataDir()`
+per host; step 1a's "orphan unlink" is therefore provably orphan,
+not racy. frag-6-7 §6.4 carries the matching note in its boot-order
+list. The §8.8 e2e probe exercises two daemons racing boot to verify
+the second one bails on lockfile rather than entering step 1a.
+
+```
+0.  acquireLockfile(<dataRoot>/daemon.lock)  // frag-6-7 §6.4 — blocks/exits if held
+1.  mkdirSync(<dataRoot>/data, recursive: true)
+1a. // Recover from any prior interrupted migration. Orphan tmp files
+    // (from kill -9 between S3 and S6, OR from a pre-S6 throw whose
+    // finally block could not run because the process died) leak both
+    // disk space and downstream confusion (S3's "tmpDb already exists"
+    // ambiguity). Unlink unconditionally before evaluating step 2.
+    // Safe to do unconditionally because step 0 has already proven we
+    // are the sole daemon on this host.
+    for ext of ['', '-wal', '-shm']:
+        unlinkIfExists(<dataRoot>/data/ccsm.db.migrating + ext)
+2.  state = readMigrationState(<dataRoot>/data/migration-state.json)
+    if state and state.completed:    return  // fast path; see §8.5 marker shape
+3.  if exists(<dataRoot>/data/ccsm.db):
+        // user installed v0.3 fresh OR migration already ran without marker
+        // (e.g. legacy v0.3.0 install before marker.version=1 existed).
+        // Do not re-migrate. Stamp the marker and return.
+        writeMarker({ completed: true, reason: 'preexisting' }); return
+4.  legacyDir = resolveLegacyDir()  // see §8.4 — env var + canonical-path validation
+5.  if !legacyDir or !exists(join(legacyDir, 'ccsm.db')):
+        // fresh install. Open new db, schema runs, marker stamped.
+        writeMarker({ completed: true, reason: 'fresh-install' }); return
+6.  runMigration(legacyDir)  // §8.5
+```
+
+Step 0's lockfile is the cross-process serialization gate. Step 2's
+marker is the per-host "do not touch user data" gate. Once
+`completed: true` is stamped, the legacy dir is never re-evaluated,
+so a user who reinstalls v0.2 and accumulates new data alongside v0.3
+cannot have their v0.3 db silently overwritten.
+
+Step 1a closes the **partial-write data-loss bug** (round-2 reliability
+P0-R4): without it, kill -9 between S3 and S8 leaves `ccsm.db.migrating`
+on disk with no marker; on next boot step 3 misses (no `ccsm.db`),
+step 5 may then trigger ENOSPC because the orphan ate the free space,
+the user clicks "Start fresh anyway", marker stamps `user_skipped`,
+**legacy data is silently abandoned**. By unlinking unconditionally at
+step 1a (after lockfile acquisition), the next boot retries cleanly
+with full free space.
+
+### 8.4 Electron → daemon path handoff
+
+The daemon process has no `electron` package dependency (plan §Phase 2);
+it cannot call `app.getPath('userData')` itself. Electron computes the
+legacy dir and passes it to the spawned daemon via env var.
+
+**Env var name (locked)**: `CCSM_LEGACY_USERDATA_DIR`
+
+(Round-2 lock-in P0-3: renamed from the worker's first draft
+`CCSM_V02_USERDATA_DIR`. The "v02" suffix would force every future
+release to either keep that name forever — semantic confusion when v0.4
+itself becomes "legacy" — or invent `CCSM_V03_USERDATA_DIR` and
+accumulate one env var per release. The generic `LEGACY` name is
+version-neutral; the marker file (§8.5 S8) carries the actual source
+schema version, so no information is lost.)
+
+`electron/main.ts` (modified by plan Task 8) computes the value
+unconditionally on every spawn (cheap; just a string):
+
+```ts
+const legacyUserData = app.getPath('userData');
+spawn(daemonBin, [...], {
+  env: { ...process.env, CCSM_LEGACY_USERDATA_DIR: legacyUserData },
+  ...
+});
+```
+
+Why every spawn (not just first):
+
+- The daemon owns the "is migration needed?" decision via the marker
+  file. Electron passing the var on every spawn is idempotent — the
+  daemon ignores it once `migration-state.json` shows `completed: true`.
+- A user who deletes `<dataRoot>/` (the OS-native data root) to force
+  re-migration (rollback path, §8.7) gets correct behaviour on the
+  next Electron launch without needing a special "first-boot" flag
+  in Electron.
+
+**`resolveLegacyDir()` — env-var trust validation (round-2 security P0-S2)**
+
+`process.env.CCSM_LEGACY_USERDATA_DIR` is **attacker-controllable
+input**. A same-user-equivalent process (launcher shim, MDM-deployed
+wrapper, planted shortcut to `ccsm.exe`, debugger, or any
+`CreateProcess`-with-env caller) can point this var at
+`\\attacker-smb\share\`, `/tmp/planted/`, or any path. Step S4 below
+opens that path with better-sqlite3 — every historical SQLite reader
+CVE (CVE-2019-8457, CVE-2020-15358, etc.) becomes triggerable from
+attacker-supplied bytes.
+
+`resolveLegacyDir()` MUST:
+
+1. **Allowlist** the supplied path against the OS-canonical
+   Electron-userData locations for both prod (`CCSM`) and dev
+   (`CCSM Dev`) builds:
+   - Win: `%APPDATA%\CCSM` or `%APPDATA%\CCSM Dev`
+   - macOS: `~/Library/Application Support/CCSM` or `~/Library/Application Support/CCSM Dev`
+   - Linux: `~/.config/CCSM` or `~/.config/CCSM Dev` (XDG)
+
+   Comparison uses `path.resolve` + case-insensitive equality on Win/macOS,
+   case-sensitive on Linux. A path that does not exact-match one of these
+   four candidates is rejected.
+2. **Realpath** the supplied path (`fs.realpathSync.native`). Reject
+   if the realpath:
+   - traverses outside the user profile root (`os.homedir()` on POSIX,
+     `%USERPROFILE%` on Win),
+   - resolves to a network mount (Win: starts with `\\` or maps to a
+     `\\` UNC after `QueryDosDeviceW`; POSIX: `statfs.f_type` in the
+     network-fs set, or path begins with `/Volumes/` on macOS for
+     non-root volumes — accepted only if also under home),
+   - resolves to a symlink loop or broken link.
+3. **Realpath** `join(legacyDir, 'ccsm.db')` independently and re-check
+   the realpath is still under the validated `legacyDir` (defense
+   against a symlink planted as `ccsm.db` pointing elsewhere).
+4. **Trust contract (round-3 P1)**: the allowlist + double-realpath
+   pair is the **only** trust boundary on `CCSM_LEGACY_USERDATA_DIR`.
+   No downstream code (S3 backup open, S7 corrupt-backup glob, "Reveal
+   old file" shell open) MAY use the raw env var; all four call sites
+   consume the validated `legacyDir` returned by `resolveLegacyDir()`.
+   A single unit test asserts `process.env.CCSM_LEGACY_USERDATA_DIR`
+   is read exactly once per daemon boot (inside `resolveLegacyDir()`)
+   so future refactors cannot accidentally re-introduce raw-env reads.
+
+On rejection: emit `MigrationFailedEvent{reason: 'invalid_legacy_path',
+supplied: <raw>, realpath: <resolved>}`, log a single pino line at
+`warn`, modal copy "ccsm couldn't verify your previous data location"
+with a single "Quit ccsm" button (no retry — env var won't change
+without restart). Unit tests per rejection branch are required (plan
+delta 8a).
+
+If the daemon was started independently (e.g. `pkg`-bundled CLI
+invocation, no Electron), `CCSM_LEGACY_USERDATA_DIR` is unset.
+`resolveLegacyDir()` returns null and §8.3 step 5 proceeds as fresh
+install. This is correct — only Electron knows the per-OS userData
+path; a CLI-only daemon launch by definition is not an upgrade from
+v0.2 (v0.2 had no headless mode).
+
+**Dev-build interaction**: `productName` differs between prod (`CCSM`)
+and dev (`CCSM Dev`) builds (`package.json:31`). `app.getPath('userData')`
+already returns the right one for whichever Electron the user is
+running, so no extra branching is needed — Electron passes whichever
+is correct, daemon's allowlist accepts both, and rejects everything
+else.
+
+**Dev-mode trigger hook (round-2 devx S-5)**: contributors testing the
+migration UI itself can set `CCSM_DEV_MIGRATION_FIXTURE=<dir>` (only
+honoured when `NODE_ENV=development` AND the daemon binary is the dev
+build) to bypass the canonical-path allowlist for that specific
+fixture dir. Production builds ignore this var unconditionally.
+
+### 8.5 Migration steps (atomic, recoverable)
+
+`runMigration(legacyDir)` body. Every numbered step emits a structured
+pino line `{ phase: '<name>', traceId, ts, durationMs, sourcePath, ... }`
+(round-2 observability P1-2) so post-mortem from `<dataRoot>/logs/daemon.log`
+alone is sufficient when the modal has been dismissed.
+
+```
+START. start = Date.now(); traceId = randomUUID()
+       log.info({phase:'migration_started', traceId, sourcePath: legacyDb})
+
+S1. legacyDb = join(legacyDir, 'ccsm.db')
+S2. tmpDb    = join(<dataRoot>, 'data', 'ccsm.db.migrating')
+    cleanup = () => for ext of ['', '-wal', '-shm']: unlinkIfExists(tmpDb+ext)
+
+S3. // Use better-sqlite3's online .backup() API instead of fs.copyFileSync
+    // of main+WAL+SHM. Round-1 reviewer MUST-FIX (corruption-as-success
+    // risk): copyFileSync of three live SQLite files is non-atomic — if
+    // a v0.2 process is still running and checkpoints between our
+    // copies of `-wal` and `ccsm.db`, the resulting tmpDb has a stale
+    // sidecar pointing at a different main file generation, which
+    // SQLite happily opens and serves CORRUPT QUERIES with no error.
+    //
+    // .backup() opens a read transaction, writes a single self-consistent
+    // page-by-page snapshot to tmpDb (no sidecars produced), and is the
+    // SQLite-blessed way to copy a live db. It is also async-pageable
+    // (default 100 pages per tick) which keeps the daemon event loop
+    // responsive — closes round-2 perf P1-A (200 MB blocking copy starves
+    // /healthz, triggering supervisor restart cycle).
+    try {
+      source = new Database(legacyDb, { readonly: true })  // no WAL contention
+      log.info({phase:'migration_copy_started', traceId, bytes: statSync(legacyDb).size})
+      await source.backup(tmpDb, { progress: ({totalPages, remainingPages}) => {
+        // [manager r11 lock: NEW-1 — progress observed via daemon log only;
+        // renderer modal is indeterminate spinner per §8.6 r9 lock —
+        // no MigrationProgressEvent IPC.]
+        if (now - lastEmit > 250) log.debug({phase:'migration_copy_progress', traceId, totalPages, remainingPages})
+      }})
+      source.close()
+      log.info({phase:'migration_copy_done', traceId, durationMs: now-start})
+    } catch (err) {
+      cleanup()
+      log.warn({phase:'migration_failed', traceId, reason:'copy_failed', err: err.message})
+      emit MigrationFailedEvent({reason: classify(err), detail: err.message})
+      return  // §8.6 maps reason → modal
+    }
+
+S4. // Validate by opening read-only and running quick_check.
+    // Wrapped in try/finally with cleanup() so any throw (corrupt file,
+    // OOM during quick_check, EBUSY) unlinks tmpDb — round-1 reviewer
+    // MUST-FIX #3.
+    let storedVersion
+    try {
+      probe = new Database(tmpDb, { readonly: true })
+      try {
+        if (probe.pragma('quick_check', { simple: true }) !== 'ok') {
+          probe.close()
+          cleanup()
+          log.warn({phase:'migration_failed', traceId, reason:'corrupt_legacy'})
+          emit MigrationFailedEvent({reason: 'corrupt_legacy', path: legacyDb})
+          return
+        }
+        storedVersion = probe.pragma('user_version', { simple: true })
+      } finally {
+        probe.close()
+      }
+      log.info({phase:'migration_validated', traceId, userVersion: storedVersion})
+    } catch (err) {
+      cleanup()
+      log.warn({phase:'migration_failed', traceId, reason:'validate_threw', err: err.message})
+      emit MigrationFailedEvent({reason: 'corrupt_legacy', path: legacyDb})
+      return
+    }
+
+S5. // No schema migration needed for v0.2 → v0.3: SCHEMA_VERSION is still 1
+    // (electron/db.ts:17). The lift is a pure path move. If a future
+    // v0.4 bumps SCHEMA_VERSION, the existing `migrate(from, to)` hook
+    // in dbService runs at first open of the moved db.
+    if storedVersion > 1:
+        log.warn({phase:'migration_future_version', traceId, userVersion: storedVersion})
+
+S6. // Atomic publish — single rename of the main db file.
+    //
+    // ROUND-1 REVIEWER MUST-FIX #2: the previous draft renamed sidecars
+    // FIRST then main db. That order is wrong:
+    //   - .backup() never produces sidecars (S3 rewrite). There are no
+    //     `-wal`/`-shm` files alongside tmpDb to rename.
+    //   - Even if a future change reintroduced sidecar copies, sidecars-
+    //     first leaves an orphan `ccsm.db-wal` in dataDir on partial
+    //     failure (rename main throws after sidecar rename succeeded);
+    //     the orphan WAL points at a non-existent main file and SQLite
+    //     refuses to open `ccsm.db` on next boot when the user retries
+    //     by deleting the marker — contaminating fresh-install retry.
+    //
+    // With .backup() we rename ONE file, atomic on POSIX (rename(2))
+    // and Win32 (MoveFileEx + MOVEFILE_REPLACE_EXISTING on same volume).
+    // No sidecars exist to leak. The dataDir parent is `<dataRoot>/data`
+    // (one volume per OS-native location), so atomicity is guaranteed.
+    try {
+      renameSync(tmpDb, join(dataRoot, 'data', 'ccsm.db'))
+      log.info({phase:'migration_finalized', traceId})
+    } catch (err) {
+      cleanup()  // unlink tmpDb if rename threw mid-way (Win EBUSY etc.)
+      log.warn({phase:'migration_failed', traceId, reason:'finalize_failed', err: err.message})
+      emit MigrationFailedEvent({reason: 'finalize_failed', detail: err.message})
+      return
+    }
+
+S7. // Courtesy: copy any v0.2 corrupt-backups so a forensic trail is
+    // preserved next to the live db. Best-effort, never fails the
+    // migration. Round-2 resource P1-6: cap each copy at 100 MB; skip
+    // larger files with a warn line so a 2 GB corrupt backup doesn't
+    // double the user's disk usage during migration.
+    //
+    // Round-3 resource X1: ALSO cap aggregate corrupt-backups at 5
+    // files in <dataRoot>/data (~500 MB ceiling at 100 MB/file). Before
+    // copying, glob `<dataRoot>/data/ccsm.db.corrupt-*` already present
+    // from prior boots; if (existingCount + thisCopy) > 5, delete the
+    // oldest by mtime first so the newest 5 always win. This bounds
+    // the migration's contribution to the `<dataRoot>` aggregate
+    // disk-cap watchdog owned by frag-6-7 §6.6 (round-3 X1).
+    for f of glob(legacyDir + '/ccsm.db.corrupt-*'):
+        try {
+          if statSync(f).size > 100 * 1024 * 1024:
+            log.warn({phase:'migration_corrupt_backup_skipped', traceId, file: f, bytes})
+            continue
+          // enforce 5-file aggregate cap
+          existing = glob(<dataRoot> + '/data/ccsm.db.corrupt-*').sort(by mtime asc)
+          while existing.length >= 5:
+            unlinkSync(existing.shift())  // delete oldest
+            log.info({phase:'migration_corrupt_backup_evicted', traceId, file})
+          copyFileSync(f, join(<dataRoot>, 'data', basename(f)))
+        } catch { /* best-effort */ }
+
+S8. // Marker file. NAME (round-2 lock-in P0-3): `migration-state.json`
+    // not `.migration-v0.3.done`. The per-version-suffix pattern would
+    // accumulate stat() calls every release (`.migration-v0.4.done`,
+    // `.migration-v0.5.done`, ...). A single state file with a schema
+    // version inside is cheaper and forward-compatible — round-2
+    // fwdcompat P1-3 (markerSchemaVersion).
+    writeFileSync(join(<dataRoot>, 'data', 'migration-state.json'), JSON.stringify({
+        marker: { version: 1 },     // markerSchemaVersion — bump when shape changes
+        completed: true,
+        ts: Date.now(),
+        sourcePath: legacyDb,
+        sourceBytes: statSync(legacyDb).size,
+        sourceUserVersion: storedVersion,
+        durationMs: Date.now() - start,
+        traceId,
+        reason: 'migrated',          // 'migrated' | 'preexisting' | 'fresh-install'
+                                     // [manager r9 lock: P1-3 — removed
+                                     // 'corrupt_skipped' and
+                                     // 'user_skipped_after_disk_full' from
+                                     // the enum; the §8.6 r7 collapse to a
+                                     // single Quit-only fatal-error modal
+                                     // means the daemon never enters a skip
+                                     // flow that would stamp those reasons.
+                                     // Marker is simply not written on
+                                     // failure.]
+    }, null, 2))
+    log.info({phase:'migration_completed', traceId, durationMs: Date.now()-start})
+
+S9. // v0.2 db file stays in `userData` UNTOUCHED. Two reasons:
+    //   - Rollback safety: user can uninstall v0.3, install v0.2,
+    //     keep working. v0.3 only ever READ the legacy file via
+    //     readonly Database open in S3.
+    //   - Disk-full safety: if S6 partially failed mid-rename and we
+    //     deleted the source, data is gone.
+    // §8.7 documents user-driven cleanup.
+    emit MigrationCompletedEvent({traceId, durationMs: Date.now() - start})
+```
+
+All filesystem ops in S3–S6 share one parent dir (`<dataRoot>`) so
+the rename is on a single volume — atomic on every supported platform.
+
+**Backwards-compat marker reader**: a v0.3.x daemon that has shipped
+the older `.migration-v0.3.done` marker (if any pre-release builds did)
+is handled by §8.3 step 2: `readMigrationState` returns
+`{ completed: true, reason: 'preexisting' }` if the legacy marker file
+exists, then step 2 returns. Step 3 also catches the case (db exists
+without the new state file) and stamps fresh state.
+
+**`MIGRATION_PENDING` short-circuit scope (round-2 reliability P1-R3)**:
+the sentinel returned by data RPCs (plan delta 8e) does NOT apply to
+supervisor-facing RPCs. Specifically `/healthz`, `/stats`, `/version`,
+and the imposter-secret handshake (`ping()`) all respond normally,
+with a top-level `migrationState: 'pending' | 'completed' | 'failed'`
+diagnostic field. If `/healthz` returned `MIGRATION_PENDING` the
+supervisor would treat the daemon as unhealthy and start a restart
+cycle that the migration would never complete (round-trip P0).
+
+### 8.6 Failure modes and user-facing UI
+
+The daemon stays UP through every failure mode (so logs/IPC keep
+working). Data-API calls return `{ ok: false, code: 'MIGRATION_PENDING',
+detail: ... }` until the user resolves; supervisor RPCs respond
+normally with a `migrationState` field (see §8.5 short-circuit scope).
+Electron's data bridge translates the sentinel into a renderer-blocking
+modal.
+
+**[manager r7 lock: cut as polish — N5# from r6 feature-parity (with
+C2# and N7# folded in). §8.6 modal flow trimmed from 6 copy variants
++ multi-button flow → ONE fatal-error modal matching working's
+`installerCorrupt` prose pattern. Removed: per-failure-class copy
+variants (disk-full / permission / corrupt-legacy / finalize-failed /
+invalid-legacy-path), multi-button flows ("Retry" / "View log" /
+"Reveal old file" / "Start fresh anyway" / Quit), the typed-confirm
+"start fresh" word-gate, the `migration_corrupt_backup_skipped`
+follow-up info-toast for disk-recovery, the `MigrationProgressEvent`
+in-progress modal driver. KEPT: silent quick_check + auto-backup
+behavior (matches working v0.2 `db.ts.corrupt-<ts>` pattern), the
+single fatal-error modal below, structured pino phase-log emission for
+post-mortem (§8.5 unchanged). Per r5 lock #9 ("View log button removed
+entirely; no such feature in current working") + the §6.1.1 r7 trim,
+the only modal action is "Quit ccsm".]**
+
+**Single fatal-error modal** (registered with i18n key prefix
+`migration.modal.failed.*` in frag-6-7 §6.8 surface registry, priority
+85, and as the `Migration failed` row in §6.1.1):
+
+| Failure trigger | Daemon log phase | IPC event | Modal copy |
+|---|---|---|---|
+| Any migration failure (S3 copy / S4 quick_check / S6 finalize / S4 invalid legacy path / disk-full / permission denied) | `migration_failed{reason: <classified>}` (six reason codes preserved in the structured log for post-mortem support) | `MigrationFailedEvent{reason, detail?}` (single event class; renderer dispatches to single modal) | **Title**: "ccsm couldn't migrate your previous data"<br>**Body**: "ccsm tried to move your data from the previous version but couldn't complete the migration. Your previous data file at `<legacyDb>` is preserved unchanged — quit ccsm and contact support, or manually start fresh by deleting `<dataRoot>` and relaunching." Buttons: "Quit ccsm" |
+
+The body's `<legacyDb>` and `<dataRoot>` interpolations let the user
+locate both source (untouched, recoverable) and target (delete-to-retry)
+without a "Reveal old file" shell-open code path. The
+manual-delete-and-relaunch path is the documented retry mechanism
+(matches §8.7 user-driven rollback). No "Retry" button — a failed
+quick_check or rename cannot retry within the same boot meaningfully;
+the structural retry path is the manual cleanup + relaunch flow which
+also clears any orphan tmp via §8.3 step 1a.
+
+[manager r9 lock: P1-2 — orphan markdown table row "CCSM_LEGACY_USERDATA_DIR
+unset → fresh-install silent path" deleted. Silent fresh-install path
+is the implied default already documented in §8.3 step 5 +
+§8.5 S8 reason='fresh-install'; no separate row needed in the §8.6
+failure-modal table.]
+
+[manager r7 lock: C2# from r6 feature-parity — "View log" button cells
+in all former §8.6 modal rows are eliminated by the collapse to a
+single fatal-error modal. Daemon log path documented in release notes
++ About dialog only (matches frag-3.7 r7 cut of "Open daemon log" tray
+entry).]
+
+[manager r7 lock: N5# additional sub-cut — "Reveal old file" button
+also cut. Source path appears in modal body text; user can navigate to
+it via Explorer / Finder manually. This avoids the
+shell-open-attacker-path security gate (round-2 SH4) since no
+shell.openPath call exists.]
+
+[manager r7 lock: N5# additional sub-cut — "Start fresh anyway"
+typed-confirm word-gate (former r2 ux P1-UX-2) and the disk-full
+"your previous data is still recoverable" follow-up toast cut. Manual
+delete-and-relaunch path documented in modal body + release notes is
+the supported retry; no in-app affordance.]
+
+All copy is sentence-case (per `feedback_no_uppercase_ui_strings`). No
+copy contains "ERROR" / "FAILED" / "FATAL". i18n keys live under
+`migration.modal.failed.*` in the standard bundle (canonical keys:
+`migration.modal.failed.title`, `migration.modal.failed.body`,
+`migration.modal.failed.actionQuit`). Renderer translates; daemon emits
+structured events only. [manager r7 lock: r6 ux P0-3 — i18n key
+namespace dot+camelCase per r3-T13. The §6.8 surface registry row's
+"Owner i18n key prefix" column for the migration-failed modal is
+updated from `daemon.migrationFailed` to `migration.modal.failed.*`
+to match this canonical namespace; cross-fragment fixer H aligned both
+sites.]
+
+**Cross-fragment UI cohesion (round-2 ux P0-UX-1, P1; round-3 ux
+clarification; r7 trim alignment)**: the migration modal is the only
+migration-domain blocking surface in v0.3. The mutual-exclusion /
+stacking contract is OWNED by frag-6-7 §6.8 "User-visible surface
+registry". This fragment registers the migration in-progress modal as
+**priority class P0 / mode `blocking-modal` / dismissable: false /
+priority value 100** (the top of the §6.8 registry) and the
+fatal-error modal under i18n key prefix `migration.modal.failed.*`
+at **priority 85**. When
+either is active, all other surfaces (toasts, banners, secondary
+modals) are suppressed until resolved. Rationale: data-loss-class user
+choice cannot share attention.
+
+**Reconciliation with §6.8 stacking rule 1 (round-3 ux note)**: §6.8's
+generic stacking rule says "if a higher-priority modal arrives, the
+lower one is dismissed and its IPC re-fires." Migration in-progress is
+the highest-priority modal in the entire registry (priority 100), so
+stacking rule 1 NEVER fires against it — there is no higher-priority
+modal that could displace it. `dismissable: false` is therefore both a
+property of this modal AND a structural consequence of being priority
+100; the two specs do not conflict. The §6.8 registry entry is the
+contract; this section's copy is the authority for migration-specific
+strings.
+
+**In-progress modal: indeterminate spinner, no event needed (manager r9
+lock)**. The priority-100 in-progress modal at §6.8 is rendered as a
+simple indeterminate spinner with copy "Migrating data, please wait..."
+shown for the duration of `runMigration()`. Lifecycle:
+
+- **shown**: when the daemon emits `MigrationStartedEvent` (S3 START
+  log line in §8.5 already carries `phase:'migration_started'`; an
+  IPC event of the same name is added — zero-cost, single fire).
+- **dismissed**: on `MigrationCompletedEvent` (S9) OR when
+  `MigrationFailedEvent` arrives and the priority-85 fatal-error modal
+  takes over.
+
+No `MigrationProgressEvent` and no `{totalPages, remainingPages}` IPC
+stream is required — the §8.5 S3 `.backup()` callback's progress hook
+is retained ONLY for the structured pino phase log (post-mortem),
+not for renderer wire-up. Rationale: r7 trim cut per-failure copy
+variants and the typed-confirm flow; the only renderer state needed
+is "are we mid-migration? yes/no", which two events (started +
+completed/failed) supply. This preserves the §6.8 priority-100 row
+without re-introducing the `MigrationProgressEvent` contract that the
+§8.6 r7 lock removed.
+
+[manager r9 lock: in-progress modal kept (frag-6-7 §6.8 P=100 row
+remains valid); driven by start/complete/failed events only; no
+progress event in renderer protocol. Decision recorded here so frag-6-7
+§6.8 reciprocal sweep (separate fixer) does not need to cut the row.]
+
+### 8.7 Rollback paths
+
+- **User wants to go back to v0.2**: uninstall v0.3, install v0.2.
+  v0.2's `app.getPath('userData')/ccsm.db` was never touched, so it
+  resumes exactly as before. Any work done in v0.3 lives only in
+  `<dataRoot>/` (OS-native) and is invisible to v0.2 — this is
+  documented in the v0.3 release notes.
+
+- **User wants to re-run migration** (e.g. after a failed migration
+  surfaced via the §8.6 fatal-error modal): the documented manual path
+  is — quit ccsm, delete `<dataRoot>/` (the OS-native data root, full
+  path printed in the §8.6 fatal-error modal body text per the r7
+  trim — no in-app "Start fresh" button or "View log" toast exists),
+  relaunch. Daemon's §8.3 step 0 acquires lockfile, step 1a clears
+  any orphan tmp, step 2 misses (state file gone), step 3 misses (db
+  gone), step 5 fires, state file re-stamped.
+  [manager r9 lock: §8.6 r7 trim cut both the "Start fresh" button
+  and the "View log" toast; rollback path now relies on the modal's
+  body-text path interpolation + manual delete + relaunch as the only
+  retry mechanism.]
+
+- **User has data in BOTH dirs after running v0.2 again post-migration**:
+  the daemon never re-considers the legacy dir once the marker exists.
+  Documented as a known limitation; release notes recommend "pick a
+  version and stick with it for the v0.3 release window".
+
+- **Post-rollback health validation (round-3 P1)**: after any
+  user-driven rollback path above, the daemon's first boot MUST pass
+  the supervisor's standard `/healthz` 5-ping verification (frag-6-7
+  §6.4 step 7's "60s up + 5×/healthz" gate, reused) BEFORE the
+  renderer is allowed to issue data-write RPCs. If the post-rollback
+  daemon fails `/healthz` (e.g. corrupt state file written by the
+  prior failed migration, missing OS-native parent dir on locked-down
+  systems), supervisor surfaces the standard daemon-spawn-failure
+  modal (frag-6-7 §6.1) — NOT the migration modal — so the user
+  understands this is a daemon problem, not a migration problem.
+  The migration sub-system's only post-rollback contribution is to
+  re-run §8.3; the health gate itself is owned by frag-6-7.
+
+### 8.8 Test plan
+
+E2E probe (`tests/electron-daemon-migration.e2e.ts`, new — folded
+into `harness-agent` per `feedback_e2e_prefer_harness`):
+
+1. Setup: synthesize a v0.2 `ccsm.db` in a temp dir mimicking
+   `app.getPath('userData')`. Seed the `app_state` table with three
+   recognizable rows (e.g. `closeAction=hide`, `notifyEnabled=true`,
+   `userCwds=["C:\\repo"]`). Set `HOME` and `CCSM_LEGACY_USERDATA_DIR`
+   to point Electron and daemon at the temp dirs. The fixture dir is
+   inside the test's temp `HOME`, so it passes the §8.4 canonical-path
+   allowlist (test runs in dev mode so `CCSM_DEV_MIGRATION_FIXTURE` may
+   alternatively be used to bypass — both code paths must be tested).
+2. Boot ccsm v0.3.
+3. Assert: `<dataRoot>/data/ccsm.db` exists (where `<dataRoot>` is
+   `%LOCALAPPDATA%\ccsm\` on Win, `~/Library/Application Support/ccsm/`
+   on mac, `~/.local/share/ccsm/` on Linux); reading it via
+   better-sqlite3 returns the three seeded rows.
+4. Assert: legacy `<tempUserData>/ccsm.db` is byte-identical to the
+   pre-boot snapshot (`statSync(...).mtimeMs` AND sha256 unchanged).
+5. Assert: `<dataRoot>/data/migration-state.json` exists and parses to
+   `{marker: {version: 1}, completed: true, ts, sourcePath, sourceBytes,
+   sourceUserVersion: 1, durationMs, traceId, reason: 'migrated'}`.
+6. Reboot daemon. Assert no second migration runs (`migration_started`
+   log line absent; state-file `ts` unchanged).
+7. Assert daemon log contains the full structured phase chain:
+   `migration_started` → `migration_copy_started` → `migration_copy_done`
+   → `migration_validated` → `migration_finalized` → `migration_completed`,
+   each with the same `traceId`.
+
+Failure-path probes (parameterized):
+
+- **Disk full**: mock the `.backup()` callback to throw `ENOSPC` after
+  N pages. Assert daemon stays up, IPC returns `MIGRATION_PENDING`,
+  no `<dataRoot>/data/ccsm.db` created, no state file, legacy file
+  untouched, AND no orphan `ccsm.db.migrating` left behind (try/finally
+  cleanup verified).
+- **Corrupt legacy**: seed `ccsm.db` with garbage bytes. Assert
+  `MigrationFailedEvent{reason: 'corrupt_legacy'}` fires, no state file,
+  no `ccsm.db` in target.
+- **Pre-existing target**: pre-create `<dataRoot>/data/ccsm.db` AND set
+  `CCSM_LEGACY_USERDATA_DIR` to a populated legacy. Assert legacy is
+  IGNORED (target untouched, state file stamped with `reason='preexisting'`).
+- **Partial-write recovery (round-2 reliability P0-R4)**: pre-seed
+  `<dataRoot>/data/ccsm.db.migrating` (and `-wal`, `-shm`) with garbage as
+  if a prior boot died between S3 and S6. Boot daemon. Assert step 1a
+  unlinks all three orphans BEFORE any other check; assert migration
+  then runs cleanly (`reason='migrated'`); assert no orphans remain.
+- **Lockfile-before-ensureDataDir ordering (round-3 reliability P0-R4
+  fix)**: spawn two daemon processes simultaneously against the same
+  HOME. Assert exactly one acquires the `<dataRoot>/daemon.lock`
+  lockfile and proceeds into `ensureDataDir()`; the other exits with
+  the standard "another daemon is running" error from frag-6-7 §6.4
+  WITHOUT entering step 1a. Assert no `<dataRoot>/data/ccsm.db.migrating`
+  is unlinked while the winner's S3 backup is mid-flight (probe by
+  installing a `.backup()` progress callback that synchronously checks
+  `existsSync(tmpDb)` returns true throughout the copy).
+- **Security rejection — UNC path (round-2 security P0-S2)**: set
+  `CCSM_LEGACY_USERDATA_DIR=\\some-host\share\fake` (Win) or
+  `/mnt/nfs/fake` (Linux). Assert `MigrationFailedEvent{reason:
+  'invalid_legacy_path'}` fires; assert `quick_check` was NEVER called
+  on the supplied path (no SQLite open of attacker-controlled bytes);
+  assert modal shows the no-retry copy.
+- **Security rejection — symlink escape**: under temp HOME, create a
+  symlink `<tempUserData>/CCSM/ccsm.db` → `/etc/passwd`. Assert
+  realpath check rejects, no SQLite open of `/etc/passwd`.
+- **Security rejection — out-of-allowlist canonical path**: set
+  `CCSM_LEGACY_USERDATA_DIR=<dataRoot>` (the new dir itself, a
+  loop). Assert allowlist rejects (path is not one of the four
+  Electron-userData canonical names).
+- **Aggregate corrupt-backup cap (round-3 resource X1)**: pre-seed
+  `<dataRoot>` with 5 existing `ccsm.db.corrupt-2025-*` files (each
+  10 KB, mtimes spread across one minute), then run a migration whose
+  `legacyDir` contains 2 fresh corrupt-backups. Assert post-migration
+  `<dataRoot>` contains exactly 5 corrupt-backup files (the 2 oldest
+  pre-existing ones evicted), and a `migration_corrupt_backup_evicted`
+  log line fires per eviction.
+- **Marker forward-compat**: write a state file with
+  `marker.version: 999` and `completed: true`. Assert daemon proceeds
+  as fast-path (treats `completed: true` as authoritative regardless
+  of marker version; future versions are responsible for backward-
+  compatible reads).
+
+### 8.9 What the migration does NOT cover (scope fence)
+
+- **`~/.claude/**`**: CLI-owned. ccsm never wrote there for session
+  data; sessionTitles round-trip via SDK, not via copy. Untouched on
+  upgrade — Claude CLI handles its own data lifecycle.
+- **Renderer localStorage / IndexedDB**: ccsm renderer does not persist
+  to browser storage (verified — no `localStorage.setItem` call
+  references user data; only the ephemeral UI state which is
+  intentionally session-local and reset on refresh).
+- **Schema upgrades**: SCHEMA_VERSION stays at 1 across v0.2 → v0.3.
+  Future bumps reuse the existing `migrate(from, to)` hook from
+  `electron/db.ts:57` (lifted to `daemon/src/services/dbService.ts`
+  by plan Task 8); migration is path-only.
+
+---
 
 ## Plan delta
-- New Task 8 (was placeholder): "SQLite migration v0.2 → v0.3"
-  - Migration logic (+4h)
-  - First-boot detection wiring (Electron → daemon env handoff) (+2h)
-  - Failure UI + IPC event (+3h)
-  - e2e test seeding v0.2 db (+3h)
-  - Total: ~12h
-- Existing data layer task gains: factor out path config to make migration
-  atomic (+1h).
+
+Insert new sub-task after plan Task 8 Step 4 (the line that today
+says "if `electron/db.ts` references `app.getPath('userData')`, replace
+with the OS-native data root resolver"):
+
+- **Task 8 (additional)**: data migration v0.2 → v0.3
+  - **8a**: implement `ensureDataDir()` (resolves OS-native `<dataRoot>`
+    via per-OS resolver: `%LOCALAPPDATA%\ccsm\` Win, `~/Library/Application
+    Support/ccsm/` mac, `~/.local/share/ccsm/` Linux) +
+    `resolveLegacyDir()` (canonical-path allowlist + double-realpath
+    validation, §8.4) + `runMigration()` per §8.3-§8.5 in
+    `daemon/src/services/dbService.ts`. Lockfile (frag-6-7 §6.4)
+    acquired BEFORE `ensureDataDir()` runs (round-3 reliability P0-R4
+    fix). Uses better-sqlite3 `.backup()` API (NOT `fs.copyFileSync`),
+    wrapped in try/finally with cleanup. Step 1a unconditional
+    orphan-tmp unlink (safe because lockfile owns the host).
+    Aggregate 5-file cap on corrupt-backups in `<dataRoot>` (round-3
+    resource X1). +7h (was +6h: +1h for OS-native resolver + path
+    test matrix per OS).
+  - **8b**: Electron-side env-var handoff in `electron/main.ts` and
+    `electron/lifecycle/spawnOrAttach.ts` (set `CCSM_LEGACY_USERDATA_DIR`
+    on every daemon spawn, value = `app.getPath('userData')` which
+    is the v0.2 product-name path under `%APPDATA%\CCSM\` etc). +1h.
+  - **8c**: `MigrationStartedEvent` / `MigrationFailedEvent` /
+    `MigrationCompletedEvent` in
+    `daemon/src/api/contracts.ts` [manager r11 lock: NEW-2 —
+    `MigrationStartedEvent` added to contracts enumeration; drives the
+    §8.6 r9 in-progress spinner alongside Completed/Failed]; renderer
+    modals in
+    `src/renderer/components/MigrationDialog.tsx` — TWO surfaces:
+    (1) priority-100 in-progress modal, indeterminate spinner with
+    copy "Migrating data, please wait...", shown while sql.exec runs
+    synchronously and dismissed on `MigrationCompletedEvent` /
+    `MigrationFailedEvent` (no progress events needed — see §8.6
+    in-progress-modal note); (2) priority-85 single fatal-error modal
+    per §8.6 with the canonical `migration.modal.failed.*` i18n keys
+    (Quit ccsm only). +2h (was +4h; r9 trim cut `MigrationProgressEvent`
+    + the six per-failure-class copy variants + "Start fresh anyway"
+    typed-confirm; remaining work is the two simple modals + two events).
+    [manager r9 lock: scope reduced to match §8.6 r7 trim — no
+    `MigrationProgressEvent`, no per-failure copy switch, no
+    typed-confirm. In-progress modal retained as indeterminate spinner.]
+  - **8d**: e2e probe per §8.8 (folded into `harness-agent`). Includes
+    partial-write recovery test, lockfile-before-ensureDataDir ordering
+    test (round-3 P0-R4), three security-rejection tests, aggregate
+    corrupt-backup cap test (round-3 X1), marker forward-compat test,
+    structured-phase log assertion. +5h (was +4h; +1h for the new
+    lockfile-race + aggregate-cap cases).
+  - **8e**: `MIGRATION_PENDING` short-circuit in `daemon/src/services/dbService.ts`
+    so every public DATA RPC checks `migrationState` first and returns
+    the sentinel until the user resolves. `/healthz`, `/stats`,
+    `/version`, and the imposter-secret handshake bypass the
+    short-circuit and return a `migrationState` field instead
+    (§8.5 short-circuit scope). +1h.
+  - **Subtotal**: ~16h (r9 trimmed 8c by 2h after §8.6 r7 cuts removed
+    `MigrationProgressEvent` + per-failure copy variants + typed-confirm;
+    prior r3 round was ~18h with the now-cut UX). Goes on
+    the critical path for v0.3 release — cannot ship without
+    (data-loss bug = RED per `~/spike-reports/v03-review-ux.md`
+    MUST-1 and round-2 reliability P0-R4 + security P0-S2 + round-3
+    reliability P0-R4 lockfile race).
+    [manager r9 lock: subtotal recomputed after 8c trim.]
+
+Existing plan Task 8 Step that says "replace `app.getPath('userData')`
+with the OS-native data root resolver. Add a one-time `mkdirSync` at
+module load" → AMEND to: "after lockfile acquisition (frag-6-7 §6.4
+boot order), call `ensureDataDir()` (8a) which resolves the per-OS
+`<dataRoot>`, performs the mkdir, orphan-tmp cleanup, AND the
+migration check; do NOT open the database before it returns
+successfully."
+
+Release-notes addition (Task 24): one paragraph documenting (a) data
+moves from the old per-product Electron-userData path to the OS-native
+location automatically (`%LOCALAPPDATA%\ccsm\` Win, `~/Library/Application
+Support/ccsm/` mac, `~/.local/share/ccsm/` Linux), (b) old data left
+in place for rollback, (c) "to start over, quit ccsm and delete the
+ccsm folder under your OS-native application-data location" (full
+path also printed in the §8.6 fatal-error modal body when migration
+fails, and in the app's About dialog), (d) if migration fails, ccsm
+shows a single "ccsm couldn't migrate your previous data" modal whose
+only action is "Quit ccsm"; previous data file is preserved unchanged
+and the manual delete-and-relaunch path above is the documented retry
+mechanism (close-to-tray behaviour call-out from round-2 ux P0-UX-2
+mitigation also lives here).
+[manager r9 lock: (c) drops the stale "View log toast" reference; (d)
+rewritten to describe the actual single Quit-only modal post §8.6 r7
+trim, replacing the prior generic "close-to-tray behaviour" sentence
+which lost its anchor when the migration UX collapsed.]
+
+---
+
+## Cross-frag rationale
+
+Round-2 review surfaced 6 P0 items and 3 P1 items touching this
+fragment. Ownership decisions:
+
+| Item | Source | Owned here? | Rationale |
+|---|---|---|---|
+| Round-1 reviewer MUST-FIX #1: use `.backup()` not `copyFileSync` of WAL+main+SHM | independent reviewer | **YES** — applied in §8.5 S3 | Pure §8 internal mechanism. CRITICAL: `copyFileSync` of three live SQLite files is corruption-as-success risk (stale-sidecar non-atomicity). `.backup()` is the SQLite-blessed API and additionally solves perf P1-A (page-progress async, doesn't block event loop). |
+| Round-1 reviewer MUST-FIX #2: rename main.db first OR sidecars-in-finally | independent reviewer | **YES** — applied in §8.5 S6 | With `.backup()` rewrite (#1) there are NO sidecars in tmpDb to rename — single rename, atomicity native. Fix is structural, not just ordering. |
+| Round-1 reviewer MUST-FIX #3: try/finally wrap S3+S4 with unlink | independent reviewer | **YES** — applied in §8.5 S3 + S4 | Each step has explicit try/catch + cleanup; verified by §8.8 disk-full probe asserting no orphan tmp. |
+| P0-R4 reliability: partial-write between S3 and S8 → silent data loss | r2-reliability | **YES** — §8.3 step 1a added | Daemon-internal recovery. Step 1a unconditional unlink of `ccsm.db.migrating[-wal][-shm]` before any other check; `MigrationFailedEvent.reason` differentiated `user_skipped_after_disk_full` from `corrupt_skipped` so support tooling can offer follow-up retry. |
+| P0-S2 security: `CCSM_V02_USERDATA_DIR` attacker-controllable, no validation | r2-security | **YES** — §8.4 `resolveLegacyDir()` | Allowlist against four canonical Electron-userData paths, double realpath (dir + db file), reject UNC / network mount / symlink-escape. Five unit tests added (8a). `quick_check` cannot run until validation passes — closes SQLite-CVE attack surface. |
+| P0-3 lock-in: env-var name + per-version marker are permanent contracts | r2-lockin | **YES** — renamed both | `CCSM_V02_USERDATA_DIR` → `CCSM_LEGACY_USERDATA_DIR` (version-neutral); `.migration-v0.3.done` → `migration-state.json` with `marker.version: 1` (single forward-compatible state file vs accumulating per-release marker files). Carries the actual source schema version inside, so no information loss. |
+| P0-UX-1 cross-frag UI cohesion (modal/toast/banner stacking) | r2-ux | **PUNT to frag-6-7 §6.8** | Surface registry is naturally a frag-6-7 concern (it owns the supervisor banners + crash-loop modal — the other two blocking surfaces). This fragment registers its modal as priority class P0 / `blocking-modal` / non-dismissable in the registry; §8.6 footer documents the contract. The registry implementation lives in frag-6-7. |
+| P1-R3 reliability: `MIGRATION_PENDING` short-circuit is too broad | r2-reliability | **YES** — §8.5 short-circuit scope + plan 8e | Data RPCs return sentinel; supervisor RPCs (`/healthz`, `/stats`, `/version`, `ping()`) respond normally with `migrationState` diagnostic field. Without this scoping the supervisor would crash-loop the daemon mid-migration. |
+| P1-2 obs: structured pino phase log lines | r2-observability | **YES** — §8.5 START + every step | Six phase names (`migration_started`, `migration_copy_started`, `migration_copy_done`, `migration_validated`, `migration_finalized`, `migration_completed`) plus `migration_failed{reason}` and `migration_corrupt_backup_skipped`. All carry shared `traceId`. §8.8 step 7 asserts the chain. |
+| P1-3 fwdcompat: marker schema version | r2-fwdcompat | **YES** — §8.5 S8 + §8.8 | `marker.version: 1` field in state file; e2e asserts shape; forward-compat test asserts `marker.version: 999` is treated as authoritative `completed: true`. |
+| P1-A perf: sync `quick_check` blocks event loop | r2-perf | **YES** — `.backup()` rewrite + note | `.backup()` is page-paged async (default 100 pages/tick); event loop stays responsive during multi-second copy. `quick_check` itself runs synchronously on the read-only probe but only after copy completes — supervisor `/healthz` bypass (P1-R3) means even a 3s `quick_check` can't trigger restart. v0.4 follow-up: move `quick_check` to `worker_threads` if dogfood reveals user-visible jank. |
+| P1-UX-2 ux: "start fresh" typed-confirm ambiguity | r2-ux | **YES** — §8.6 typed-confirm spec | Exact phrase `start fresh`, case-insensitive, no quotes/punctuation. Auto-focus, disabled-until-match button, screen-reader live region. |
+| SH4 security: "Reveal old file" opens attacker path | r2-security | **YES — gated on P0-S2** | §8.6 explicitly notes the button only fires after §8.4 allowlist passed. With P0-S2 fix the path is provably canonical-userData, so Explorer-shell escalation vector is closed. |
+| P1-6 resource: cap migration corrupt-backup copy | r2-resource | **YES** — §8.5 S7 | 100 MB per-file cap; oversize files logged as `migration_corrupt_backup_skipped` and skipped (user can copy manually). |
+| SHOULD-2 resource: rename order | r2-resource | **YES — subsumed by MUST-FIX #2** | The `.backup()` rewrite eliminates sidecars in tmpDb; single rename of main file is the only finalize op. SQLite recreates sidecars on first open. |
+| S-R2 reliability: `fs.copyFileSync` is sync-blocking | r2-reliability | **YES — subsumed by MUST-FIX #1** | `.backup()` is async-pageable; replaces the sync copyFileSync entirely. |
+| Devx S-5: dev-mode trigger hook for migration UI | r2-devx | **YES** — §8.4 dev hook | `CCSM_DEV_MIGRATION_FIXTURE` honoured only when `NODE_ENV=development` AND dev-build daemon binary; production ignores. One-line escape hatch for contributors testing modal variants. |
+| P1-2 observability: tray "Open log folder" shortcut | r2-observability | **PUNT to frag-6-7** | Tray menu is renderer/electron-main concern, not daemon. Frag-6-7 §6.6 logs section owns it. |
+| P0-UX-2 ux: close-window toast deferral | r2-ux | **PUNT to frag-6-7 + release notes** | Not migration-specific. Mitigation: release-notes call-out (Plan delta release-notes addition (d)) is the agreed v0.3 mitigation; v0.4 reconsiders the deferral. |
+| P0-UX-3 ux: daemon-spawn failure modal copy | r2-ux | **PUNT to frag-6-7 §6.1** | Spawn failure is supervisor's surface, not migration's. §8.6 modal style serves as a template. |
+| P0-S1 security: `daemon.secret` lifecycle | r2-security | **PUNT to frag-6-7 §7** | Pre-migration concern; secret must exist at first boot regardless of migration state. Frag-6-7 owns secret creation/rotation. Confirmed still PUNT in r3 — `daemon.secret` is not in §8's scope. |
+| **R3 arch lock**: data root = OS-native, not `~/.ccsm/data/` | r3-manager | **YES** — §8.2 rewrite | v0.2 used `~/.ccsm/` cross-platform (interim); v0.3 moves to OS-native (`%LOCALAPPDATA%\ccsm\` Win, `~/Library/Application Support/ccsm/` mac, `~/.local/share/ccsm/` Linux) to match install path policy. Source (legacy) stays at v0.2's Electron `userData` per-product-name path; only TARGET changed. All §8.3-§8.8 path references swept. |
+| **R3 P0-R4 reliability**: lockfile-before-ensureDataDir ordering | r3-reliability | **YES** — §8.3 step 0 added | Lockfile (`<dataRoot>/daemon.lock`, frag-6-7 §6.4) acquired BEFORE `ensureDataDir()` so step 1a's unconditional unlink is provably orphan, not a race against a concurrent live migration. Matched by frag-6-7 §6.4 boot-order note. New e2e probe (§8.8) races two daemons. |
+| **R3 X1 resource**: aggregate corrupt-backup cap | r3-resource | **YES** — §8.5 S7 amendment | Per-file 100 MB cap unchanged; ADDED 5-file aggregate cap with mtime-based oldest-first eviction (~500 MB ceiling). Bounds migration's contribution to the `<dataRoot>` aggregate disk-cap watchdog owned by frag-6-7 §6.6 (the broader X1 watchdog itself stays with frag-6-7). New e2e probe verifies eviction. |
+| **R5 dataRoot reconciliation**: `~/.ccsm/` retired across data/logs/crashes/lockfile | r5-manager (frag-11 §11.6 lock) | **YES** — §8.2 rewrite + §8.3-§8.8 sweep | Three-way `<dataRoot>` permutation flagged in r4 packaging; manager r5 lock makes frag-11 §11.6 the single source of truth. All `~/.ccsm/data|logs|crashes|daemon.lock` references in §8.2-§8.8 mapped to `<dataRoot>/...` (db moves to `<dataRoot>/data/`, logs to `<dataRoot>/logs/`, crashes to `<dataRoot>/crashes/`, lockfile to `<dataRoot>/daemon.lock`). Legacy `~/.ccsm/` references retained only in historical/rationale prose to describe the v0.2 starting state. |
+| **R3 P1 perf**: `.backup()` already adopted | r3-perf | **YES — confirm only** | r3-perf §P1-A confirms §8.5 S3 already uses `.backup()` page-paged async with indeterminate spinner driven by MigrationStartedEvent + MigrationCompletedEvent/MigrationFailedEvent (no progress IPC). No change needed; structural fix from r2 carried through. [manager r11 lock: NEW-3 — phrasing aligned with §8.6 r9 lock that removed `MigrationProgressEvent`.] |
+| **R3 ux clarification**: dismissable: false vs §6.8 stacking rule 1 | r3-ux | **YES** — §8.6 reconciliation paragraph | r3-ux flagged apparent contradiction; clarified that `dismissable: false` is consistent with §6.8 priority 100 because no higher-priority modal exists to trigger stacking rule 1's auto-dismiss. Cross-ref to §6.8 priority 100 added. |
+| **R3 P1 security**: env-var trust hardening | r3-manager | **YES** — §8.4 trust-contract bullet 4 | Single-source-of-truth: only `resolveLegacyDir()` reads `process.env.CCSM_LEGACY_USERDATA_DIR`; downstream uses validated `legacyDir`. Unit test asserts single read. |
+| **R3 P1 reliability**: post-rollback /healthz validation gate | r3-manager | **YES** — §8.7 added bullet | Reuses frag-6-7 §6.4 step 7 health gate; daemon-spawn-failure modal (not migration modal) surfaces if post-rollback boot fails health. Migration sub-system's only contribution is to re-run §8.3. |
+
+**Data-loss risk**: **NO** — every identified data-loss failure mode
+is either prevented by structural fix (corruption-as-success closed by
+`.backup()`; partial-write closed by step 1a; lockfile-before-step-1a
+closes the round-3 in-progress-migration race; user-skip-after-disk-full
+flagged for re-offer) or surfaced via blocking modal with non-default
+typed-confirm. Round-2 ux report independently verified frag-8 closes
+the r1 MUST-1 data-loss concern; round-3 reliability confirms P0-R4
+fully closed by lockfile ordering.
+
+**Net plan delta change**: +6h (12h → 18h). Round-2 added +4h
+(security/reliability/UX P0); round-3 added +2h (OS-native resolver +
+lockfile-ordering test + aggregate-cap test).

--- a/docs/superpowers/specs/v0.3-fragments/frag-8-sqlite-migration.md
+++ b/docs/superpowers/specs/v0.3-fragments/frag-8-sqlite-migration.md
@@ -1,0 +1,53 @@
+# Fragment: §8 SQLite migration story (v0.2 → v0.3)
+
+**Owner**: worker dispatched per Task #937
+**Target spec section**: new §8 in main spec (after §7 security)
+**P0 items addressed**: #1 (SQLite migration — UX critical from review)
+
+## What to write here
+Replace this section with actual `## 8. Data migration: v0.2 → v0.3`
+markdown. Cover:
+
+1. **Source location (v0.2)**: `app.getPath('userData')/...` — exact filenames
+   (sessions.db, settings.json, etc.). Check existing v0.2 code in
+   `electron/store/**` for actual paths and DB filenames; cite.
+2. **Target location (v0.3)**: `~/.ccsm/data/` (cross-platform: Win
+   `%USERPROFILE%/.ccsm/data/`, Mac/Linux `$HOME/.ccsm/data/`). Daemon owns
+   this dir.
+3. **Migration trigger**: daemon's first-boot check.
+   - If `~/.ccsm/data/sessions.db` exists → skip.
+   - Else if `app.getPath('userData')/sessions.db` exists (Electron passes
+     v0.2 path to daemon via env var on first launch) → migrate.
+   - Else → fresh install, init empty db.
+4. **Migration steps (atomic)**:
+   - Copy v0.2 db file to `~/.ccsm/data/sessions.db.tmp`.
+   - Open with better-sqlite3, run any v0.2 → v0.3 schema diffs (list them
+     here; if none, just integrity check).
+   - `fs.renameSync` `.tmp` → `sessions.db` (atomic on same filesystem).
+   - Write marker `~/.ccsm/data/.migration-v0.3.done` with timestamp.
+   - Leave v0.2 db in place untouched (rollback safety; user can downgrade).
+5. **Failure modes**:
+   - Disk full / permission → daemon logs, sends `MigrationFailedEvent` to
+     Electron, UI shows actionable dialog ("contact support / try again /
+     skip and start fresh"). Daemon stays up but data API returns
+     `MIGRATION_PENDING`.
+   - Schema mismatch (corrupted v0.2 db) → log, surface to UI, do NOT
+     auto-overwrite.
+6. **Rollback**: user can manually delete `~/.ccsm/data/`; daemon detects
+   missing db on next boot and re-runs migration.
+7. **Telemetry**: log migration duration, source size, success/fail to
+   pino logs (no remote telemetry in v0.3).
+8. **Test plan**: e2e test that seeds a v0.2 userData db, boots v0.3 daemon,
+   asserts data appears in `~/.ccsm/data/`, original untouched.
+
+Cite findings from `~/spike-reports/v03-review-ux.md`.
+
+## Plan delta
+- New Task 8 (was placeholder): "SQLite migration v0.2 → v0.3"
+  - Migration logic (+4h)
+  - First-boot detection wiring (Electron → daemon env handoff) (+2h)
+  - Failure UI + IPC event (+3h)
+  - e2e test seeding v0.2 db (+3h)
+  - Total: ~12h
+- Existing data layer task gains: factor out path config to make migration
+  atomic (+1h).


### PR DESCRIPTION
## Summary
- Combines 12 v0.3 spec fragments into v0.3-design.md + v0.3-daemon-split.md exec summary
- 7 review rounds completed (r5 -> r12); converged at 0 P0 / 0 critical P1 across 7 angles
- Refactor only -- no added/removed features (verified by feature-parity reviewer in r6 + r8)
- Plan delta: +199.5h cumulative (#941 will patch task list)

## Architecture highlights
- Daemon split: long-running daemon (own Node 22 ESM) + Electron client over IPC
- Two sockets: data-plane (`ccsm-data`) + control-plane (`ccsm-control`); HMAC-SHA256 handshake
- SQLite migration v0.2 -> v0.3 with single Quit-only failure modal
- NSIS assisted-mode installer (oneClick: false, matches working tip)
- claude-agent-sdk packaging: extraResources + asarUnpack, daemon-primary direct ESM
- daemon.shutdownForUpgrade RPC + marker file for clean upgrade-in-place

## Reviewer focus
- Sec 3.4.1 SUPERVISOR_RPCS canonical declaration (single source of truth)
- Sec 6.4 daemon.shutdownForUpgrade RPC contract + marker semantics
- Sec 11.2.1 SDK packaging (dual extraResources staging)
- Sec 12 traceability matrix: 159 CLOSED / 25 IN-FLUX / 7 OPEN = 191 total

## Test plan
- [ ] Spec renders as readable markdown (no broken cross-refs)
- [ ] Reviewer can navigate from v0.3-daemon-split.md -> v0.3-design.md sections
- [ ] frag-12 traceability matrix arithmetic verifies (159 + 25 + 7 = 191)
- [ ] No P0 introduced by merge mechanics (verify against r12 spike reports)

Generated with Claude Code