### PR TITLE
ci: skip pr-no-silent-drops on docs-only PRs

### DIFF
--- a/.github/workflows/pr-no-silent-drops.yml
+++ b/.github/workflows/pr-no-silent-drops.yml
@@ -18,6 +18,11 @@ name: pr-no-silent-drops
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Adds paths-ignore to pr-no-silent-drops.yml mirroring ci.yml (\`**.md\`, \`docs/**\`, \`LICENSE\`, \`.gitignore\`)
- ci.yml + e2e.yml already correctly skip docs-only PRs; this aligns the third workflow

## Why
PR #636 (v0.3 spec consolidation, 4130 lines, docs-only) ran pr-no-silent-drops as the only check (~7s). Cheap but unnecessary; aligning paths-ignore makes the intent explicit and saves a queue slot.

## Test plan
- [ ] CI shows 0 checks queued on this PR (since this PR itself only touches \`.github/workflows/\`, not \`docs/\`, ci.yml WILL run — that's correct)
- [ ] After merge: open a docs-only PR; verify pr-no-silent-drops doesn't trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)