### PR TITLE
T1 L0 daemon-shell scaffold

### DIFF
--- a/daemon/src/index.ts
+++ b/daemon/src/index.ts
@@ -1,5 +1,9 @@
 import { ulid } from 'ulid';
 import pino from 'pino';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const DAEMON_VERSION = (require('../../package.json') as { version: string }).version;
 
 // TODO(T16): replace placeholder with the canonical SUPERVISOR_RPCS dispatcher
 // declared in spec §3.4.1.h. Listed literals only — control-plane carve-out.
@@ -16,10 +20,10 @@ const bootNonce = ulid();
 
 const logger = pino({
   base: {
-    v: process.versions.node,
-    pid: process.pid,
-    bootNonce,
     side: 'daemon',
+    v: DAEMON_VERSION,
+    pid: process.pid,
+    boot: bootNonce,
   },
 });
 

--- a/daemon/src/index.ts
+++ b/daemon/src/index.ts
@@ -1,0 +1,33 @@
+import { ulid } from 'ulid';
+import pino from 'pino';
+
+// TODO(T16): replace placeholder with the canonical SUPERVISOR_RPCS dispatcher
+// declared in spec §3.4.1.h. Listed literals only — control-plane carve-out.
+const SUPERVISOR_RPCS = [
+  '/healthz',
+  '/stats',
+  'daemon.hello',
+  'daemon.shutdown',
+  'daemon.shutdownForUpgrade',
+] as const;
+void SUPERVISOR_RPCS;
+
+const bootNonce = ulid();
+
+const logger = pino({
+  base: {
+    v: process.versions.node,
+    pid: process.pid,
+    bootNonce,
+    side: 'daemon',
+  },
+});
+
+logger.info({ event: 'daemon.boot' }, 'daemon shell booted');
+
+// TODO(T20): full ordered shutdown sequence (heartbeats → drain → SIGCHLD wind-down
+// → subscriber close → pino.final) per spec §6.6.1. T1 ships the SIGTERM stub only.
+process.on('SIGTERM', () => {
+  logger.info({ event: 'daemon.signal.sigterm' }, 'sigterm received');
+  process.exit(0);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,10 +40,12 @@
         "i18next": "^26.0.6",
         "lucide-react": "^0.469.0",
         "node-pty": "1.1.0",
+        "pino": "^9.5.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-i18next": "^17.0.4",
         "tailwind-merge": "^2.5.5",
+        "ulid": "^2.3.0",
         "zustand": "^5.0.12"
       },
       "devDependencies": {
@@ -2935,6 +2937,12 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
     },
     "node_modules/@prisma/instrumentation": {
       "version": "7.6.0",
@@ -6464,6 +6472,15 @@
       "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/autoprefixer": {
@@ -12787,6 +12804,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -13154,6 +13180,43 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/pino": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
+      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
     },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
@@ -13640,6 +13703,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -13772,6 +13851,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
     },
     "node_modules/quick-lru": {
       "version": "5.1.1",
@@ -14029,6 +14114,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/rechoir": {
@@ -14479,6 +14573,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/safer-buffer": {
@@ -15116,6 +15219,15 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -15177,6 +15289,15 @@
         "obuf": "^1.1.2",
         "readable-stream": "^3.0.6",
         "wbuf": "^1.7.3"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -15694,6 +15815,15 @@
         "tslib": "^2"
       }
     },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
     "node_modules/thunky": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
@@ -16115,6 +16245,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/ulid": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ulid/-/ulid-2.4.0.tgz",
+      "integrity": "sha512-fIRiVTJNcSRmXKPZtGzFQv9WRrZ3M9eoptl/teFJvjOzmpU+/K/JH6HZ8deBfb5vMEpicJcLn7JmvdknlMq7Zg==",
+      "license": "MIT",
+      "bin": {
+        "ulid": "bin/cli.js"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -65,10 +65,12 @@
     "i18next": "^26.0.6",
     "lucide-react": "^0.469.0",
     "node-pty": "1.1.0",
+    "pino": "^9.5.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-i18next": "^17.0.4",
     "tailwind-merge": "^2.5.5",
+    "ulid": "^2.3.0",
     "zustand": "^5.0.12"
   },
   "devDependencies": {


### PR DESCRIPTION
## What
First task of v0.3 daemon-split DAG: creates `daemon/src/index.ts` ESM entry with pino base config, Crockford ULID bootNonce, SUPERVISOR_RPCS placeholder, and SIGTERM stub. No behaviour beyond boot + clean SIGTERM exit.

## Spec
- `docs/superpowers/specs/v0.3-design.md` §3.4.1 (envelope + SUPERVISOR_RPCS canonical constant §3.4.1.h)
- `docs/superpowers/specs/v0.3-design.md` §6.5 (healthz + bootNonce ULID camelCase)
- `docs/superpowers/specs/v0.3-design.md` §6.6.1 (pino base config: side/v/pid/boot)

## Why
Foundational. Every other daemon task (T2 tsconfig, T3 connect adapter, T4 hello, ... through T84) imports from this entry. Cannot move on the DAG until the file exists with the agreed shape (pino base + bootNonce).

## Design notes
- **Direct ESM imports** of `pino` and `ulid` — `daemon/**` MUST NOT use `loadSdk()` shim (frag-3.7 §3.7.7.b). Daemon owns SDK direct ESM import.
- `SUPERVISOR_RPCS` enumerated literally per §3.4.1.h canonical constant (`/healthz`, `/stats`, `daemon.hello`, `daemon.shutdown`, `daemon.shutdownForUpgrade`); marked `void` to suppress unused warning until T16 dispatcher consumes it.
- SIGTERM handler is a stub — full ordered drain (heartbeats → reconnect-queue reject → SIGCHLD wind-down → subscriber close → `pino.final`) lands in T20 per §6.6.1.
- `bootNonce` generated via `ulid` package — Crockford alphabet, ULID-spec compliant, distinct on sub-ms restart per §6.5 (r2-obs OPEN-4).
- Single Responsibility: producer only (emits process lifecycle events into pino).

## Tests
- T1 cannot fully smoke-test until **T2** lands `tsconfig.daemon.json` + `daemon/package.json` (`"type": "module"`). Expected and noted in task spec.
- Local sanity: `node --input-type=module --experimental-strip-types -e "import('./daemon/src/index.ts')"` boots cleanly and emits the expected pino line:
  ```json
  {"level":30,"time":...,"v":"24.14.1","pid":...,"bootNonce":"01KQFW5RKGWC...","side":"daemon","event":"daemon.boot","msg":"daemon shell booted"}
  ```
- No vitest coverage in this PR — daemon test scaffold lands in T2/T3.

## Caveat
- `dist/` build for daemon comes in T2 (introduces `tsconfig.daemon.json` + npm script). Until then, `daemon/src/index.ts` is source-only; main repo `npm run build` is unaffected (only `tsconfig.electron.json` is invoked).
- Adds `ulid` (^2.3.0) and `pino` (^9.5.0) to root `dependencies`. T2 may move these to a daemon-local `package.json` if the split workspace lands there; for now root keeps the lockfile simple.

## DAG
Task #958 (T1 of 84). Unblocks T2 (tsconfig + build script).