### PR TITLE
T66 L7 electron-main --inspect=9229 env-gated debugger

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,3 +4,13 @@
 
 - Use Node 20.x for local builds. CI runs on 20.x.
 - On Windows, native modules require VS Build Tools with C++/CX SDK (full VS 2022, not just BuildTools).
+
+## Debugging the Electron main process
+
+Set `CCSM_ELECTRON_INSPECT=1` when running `npm run dev:app` (or `npm run dev`) to spawn the Electron main process with `--inspect=9229`. Without the env var, no inspector port is opened.
+
+```sh
+CCSM_ELECTRON_INSPECT=1 npm run dev:app
+```
+
+Attach Chrome DevTools via `chrome://inspect` or a VS Code launch config (T67 wires a launch.json compound).

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "dev": "concurrently -k -n web,app -c blue,magenta \"npm:dev:web\" \"npm:dev:app\"",
     "dev:web": "webpack serve --config webpack.config.js --mode development",
-    "dev:app": "wait-on http://localhost:4100 && tsc -p tsconfig.electron.json && electron .",
+    "dev:app": "wait-on http://localhost:4100 && tsc -p tsconfig.electron.json && node scripts/dev-electron.cjs",
     "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
     "build": "npm run clean && tsc -p tsconfig.electron.json && webpack --mode production && node -e \"const fs=require('fs');const p='dist/renderer/bundle.js';const t=Date.now()/1000;fs.utimesSync(p,t,t)\"",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.electron.json",

--- a/scripts/dev-electron.cjs
+++ b/scripts/dev-electron.cjs
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+const { spawn } = require('child_process');
+const path = require('path');
+
+const electronBin = require('electron');
+const args = [];
+if (process.env.CCSM_ELECTRON_INSPECT === '1') {
+  args.push('--inspect=9229');
+}
+args.push(path.resolve(__dirname, '..'));
+
+const child = spawn(electronBin, args, { stdio: 'inherit' });
+child.on('exit', (code, signal) => {
+  if (signal) process.kill(process.pid, signal);
+  else process.exit(code ?? 0);
+});


### PR DESCRIPTION
## What

Wrap the `dev:app` electron launch in `scripts/dev-electron.cjs`. When `CCSM_ELECTRON_INSPECT=1` is set in env, spawn electron with `--inspect=9229`; otherwise no inspector port is opened (idempotent).

Documents usage in CONTRIBUTING.md under a new "Debugging the Electron main process" section.

## Spec

`docs/superpowers/specs/v0.3-design.md` frag-3.7 §3.7 (dev tooling).

T67 will wire a VS Code `launch.json` compound that attaches to port 9229.

## Smoke output

Baseline (no env):
```
$ node scripts/dev-electron.cjs &
$ netstat -an | grep 9229
[no output — no listener]
```

With env:
```
$ CCSM_ELECTRON_INSPECT=1 node scripts/dev-electron.cjs &
$ netstat -an | grep 9229
  TCP    127.0.0.1:9229         0.0.0.0:0              LISTENING

Debugger listening on ws://127.0.0.1:9229/f3b91190-6b2d-4455-9f3c-ab2e208163d7
For help, see: https://nodejs.org/en/docs/inspector
```

## Files

- `scripts/dev-electron.cjs` (new) — single-responsibility launcher: read env, build args, spawn electron, forward exit
- `package.json` — `dev:app` now invokes `node scripts/dev-electron.cjs` instead of `electron .`
- `CONTRIBUTING.md` — debugging section