### PR TITLE
T49 L6 extraResources dual-stage SDK staging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ docs/screenshots/dogfood-happy-path/
 *.rpm
 *.blockmap
 .pool-synced-at-*
+daemon/dist/
+daemon/native/
+daemon/native-staged/
+daemon/sdk-staged/
+daemon/deps-staged/

--- a/package.json
+++ b/package.json
@@ -119,9 +119,18 @@
     "asar": true,
     "asarUnpack": [
       "**/node_modules/better-sqlite3/**",
-      "**/node_modules/node-pty/**"
+      "**/node_modules/node-pty/**",
+      "node_modules/@anthropic-ai/claude-agent-sdk/**/*",
+      "**/*.node"
     ],
+    "beforePack": "scripts/before-pack.cjs",
     "afterPack": "scripts/after-pack.cjs",
+    "extraResources": [
+      { "from": "daemon/native-staged", "to": "daemon/native" },
+      { "from": "daemon/sdk-staged", "to": "daemon/node_modules/@anthropic-ai/claude-agent-sdk" },
+      { "from": "daemon/deps-staged", "to": "daemon/node_modules" },
+      { "from": "node_modules/@anthropic-ai/claude-agent-sdk", "to": "sdk/claude-agent-sdk" }
+    ],
     "files": [
       "dist/**/*",
       "package.json",
@@ -151,7 +160,10 @@
         }
       ],
       "icon": "build/icon.ico",
-      "artifactName": "${productName}-Setup-${version}-${arch}.${ext}"
+      "artifactName": "${productName}-Setup-${version}-${arch}.${ext}",
+      "extraResources": [
+        { "from": "daemon/dist/ccsm-daemon-staged.exe", "to": "daemon/ccsm-daemon.exe" }
+      ]
     },
     "nsis": {
       "oneClick": false,
@@ -183,7 +195,10 @@
       "category": "public.app-category.developer-tools",
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
-      "artifactName": "${productName}-${version}-${arch}.${ext}"
+      "artifactName": "${productName}-${version}-${arch}.${ext}",
+      "extraResources": [
+        { "from": "daemon/dist/ccsm-daemon-staged", "to": "daemon/ccsm-daemon" }
+      ]
     },
     "dmg": {
       "writeUpdateInfo": false
@@ -213,7 +228,10 @@
       "maintainer": "Jiahui Gu <noreply@ccsm.dev>",
       "synopsis": "CCSM (Claude Code Session Manager) — group-first manager for many Claude Code sessions",
       "icon": "build/icon.png",
-      "artifactName": "${productName}-${version}-${arch}.${ext}"
+      "artifactName": "${productName}-${version}-${arch}.${ext}",
+      "extraResources": [
+        { "from": "daemon/dist/ccsm-daemon-staged", "to": "daemon/ccsm-daemon" }
+      ]
     }
   }
 }

--- a/scripts/before-pack.cjs
+++ b/scripts/before-pack.cjs
@@ -1,0 +1,220 @@
+// electron-builder beforePack hook (Task #1006 / spec frag-11 §11.2 + §11.2.1).
+//
+// Stages the per-platform daemon binary, native dlopen targets, and the
+// claude-agent-sdk + daemon ESM-dep closure into fixed paths that the
+// `build.extraResources` rules in package.json can copy verbatim.
+//
+// electron-builder does NOT expand a ${platform} token inside `from` paths
+// (only ${os}, ${arch}, ${ext}, ${productName}, ${version}). So the hook
+// MUST resolve the per-platform paths at pack time and stage everything
+// into platform-agnostic destinations.
+//
+// Layout (post-hook, pre-pack):
+//   daemon/dist/ccsm-daemon-staged${ext}      <- per-platform daemon binary
+//   daemon/native-staged/                     <- per-platform native folder
+//   daemon/sdk-staged/                        <- claude-agent-sdk + closure
+//                                                (consumed by daemon-side
+//                                                 node_modules row)
+//   daemon/deps-staged/                       <- daemon's own ESM deps (pino,
+//                                                ulid) merged into the same
+//                                                node_modules tree as the SDK
+//
+// T49 ships the staging mechanics. T2 (build glue) provides the daemon
+// binary + native folder; T57 adds the after-pack required-files
+// validation. When T2 hasn't merged yet (or before `npm run build:daemon`
+// has run locally), the binary/native sources won't exist — we emit a loud
+// warning and fall back to empty placeholder files so electron-builder's
+// extraResources copy still succeeds for smoke-test purposes.
+// REMOVE THIS FALLBACK WHEN T2 LANDS — after-pack validation (T57) will
+// then catch any missing artifact as a hard build failure.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+// app-builder-lib's Arch enum: 0=ia32, 1=x64, 2=armv7l, 3=arm64, 4=universal.
+const ARCH_NAMES = { 0: 'ia32', 1: 'x64', 2: 'armv7l', 3: 'arm64', 4: 'universal' };
+
+// REQUIRED_NATIVES — every `.node` the daemon dlopens. Drift between this
+// list and the after-pack REQUIRED_AFTER_PACK list (T57) is a build bug.
+const REQUIRED_NATIVES = ['better_sqlite3.node', 'pty.node', 'ccsm_native.node'];
+
+// Daemon ESM deps — copied alongside the SDK so the pkg-bundled daemon's
+// require.resolve walks find them under <resources>/daemon/node_modules/.
+// Keep in sync with daemon/src/*.ts imports. T2 will replace this with a
+// real per-package staging step once daemon has its own package.json.
+const DAEMON_ESM_DEPS = ['pino', 'ulid'];
+
+function rmrf(p) {
+  fs.rmSync(p, { recursive: true, force: true });
+}
+
+function copyDir(src, dst) {
+  fs.mkdirSync(path.dirname(dst), { recursive: true });
+  fs.cpSync(src, dst, { recursive: true });
+}
+
+function stagePlaceholder(dst, label) {
+  // Emits a marker file so electron-builder's extraResources copy still
+  // finds something at the expected path. The marker is text so the
+  // installer is self-documenting if a user ever inspects it.
+  fs.mkdirSync(path.dirname(dst), { recursive: true });
+  fs.writeFileSync(
+    dst,
+    `placeholder: ${label} not yet built (T2 build glue pending). ` +
+      `This file ships only in pre-T2 smoke builds; T57 after-pack ` +
+      `validation will fail the build once T2 lands.\n`,
+  );
+}
+
+function stageDaemonBinary(electronPlatformName, archName) {
+  const ext = electronPlatformName === 'win32' ? '.exe' : '';
+  const map = {
+    win32: `ccsm-daemon-win-${archName}.exe`,
+    darwin: `ccsm-daemon-macos-${archName}`,
+    linux: `ccsm-daemon-linux-${archName}`,
+  };
+  const srcName = map[electronPlatformName];
+  if (!srcName) {
+    throw new Error(`[before-pack] unsupported electronPlatformName: ${electronPlatformName}`);
+  }
+
+  const src = path.join(REPO_ROOT, 'daemon', 'dist', srcName);
+  const dst = path.join(REPO_ROOT, 'daemon', 'dist', `ccsm-daemon-staged${ext}`);
+
+  if (fs.existsSync(src)) {
+    fs.copyFileSync(src, dst);
+    console.log(`[before-pack] staged daemon binary: ${srcName} -> ccsm-daemon-staged${ext}`);
+  } else {
+    console.warn(
+      `[before-pack] WARN daemon binary missing: ${src}. ` +
+        `Falling back to placeholder (T2 build glue not yet merged).`,
+    );
+    stagePlaceholder(dst, `daemon binary for ${electronPlatformName}-${archName}`);
+  }
+}
+
+function stageNatives(electronPlatformName, archName) {
+  const folder = `${electronPlatformName}-${archName}`;
+  const src = path.join(REPO_ROOT, 'daemon', 'native', folder);
+  const dst = path.join(REPO_ROOT, 'daemon', 'native-staged');
+
+  rmrf(dst);
+  fs.mkdirSync(dst, { recursive: true });
+
+  if (fs.existsSync(src)) {
+    fs.cpSync(src, dst, { recursive: true });
+    for (const f of REQUIRED_NATIVES) {
+      const p = path.join(dst, f);
+      if (!fs.existsSync(p)) {
+        throw new Error(`[before-pack] required native missing after staging: ${p}`);
+      }
+    }
+    console.log(`[before-pack] staged natives from ${folder} (${REQUIRED_NATIVES.length} required)`);
+  } else {
+    console.warn(
+      `[before-pack] WARN native folder missing: ${src}. ` +
+        `Falling back to placeholders (T2 build glue not yet merged).`,
+    );
+    for (const f of REQUIRED_NATIVES) {
+      stagePlaceholder(path.join(dst, f), `native ${f} for ${folder}`);
+    }
+  }
+}
+
+function stageSdk() {
+  // Daemon-side SDK staging: copies the SDK package tree into a fixed
+  // dir consumed by the `daemon/sdk-staged -> daemon/node_modules/...` row.
+  // The Electron-main residual shim consumes the unstaged hoisted root
+  // copy directly via the second extraResources row.
+  const sdkSrc = path.join(REPO_ROOT, 'node_modules', '@anthropic-ai', 'claude-agent-sdk');
+  const sdkDst = path.join(REPO_ROOT, 'daemon', 'sdk-staged');
+
+  rmrf(sdkDst);
+
+  if (!fs.existsSync(sdkSrc)) {
+    console.warn(
+      `[before-pack] WARN SDK source missing: ${sdkSrc}. ` +
+        `Falling back to placeholder package.json (run \`npm install\` to populate).`,
+    );
+    fs.mkdirSync(sdkDst, { recursive: true });
+    fs.writeFileSync(
+      path.join(sdkDst, 'package.json'),
+      JSON.stringify(
+        { name: '@anthropic-ai/claude-agent-sdk', version: '0.0.0-placeholder', main: 'index.js' },
+        null,
+        2,
+      ),
+    );
+    fs.writeFileSync(
+      path.join(sdkDst, 'index.js'),
+      '// placeholder; T2 will provision real SDK via npm install\n',
+    );
+  } else {
+    copyDir(sdkSrc, sdkDst);
+    console.log(`[before-pack] staged SDK: ${sdkSrc} -> ${sdkDst}`);
+  }
+}
+
+function stageDaemonDeps() {
+  // Stages daemon's own ESM deps (pino, ulid, ...) into a fixed dir that
+  // the `daemon/deps-staged -> daemon/node_modules` extraResources row
+  // merges into the same node_modules tree as the SDK. Each package is
+  // copied with its full transitive closure (electron-builder's `from`
+  // copies the directory recursively as-is — so we stage each top-level
+  // dep dir; nested deps under node_modules/<dep>/node_modules/ are
+  // included by recursive copy).
+  //
+  // T2 will replace this with `npm --prefix daemon ci --omit=dev` once
+  // daemon has its own package.json; for now we copy from the hoisted
+  // root node_modules.
+  const dst = path.join(REPO_ROOT, 'daemon', 'deps-staged');
+  rmrf(dst);
+  fs.mkdirSync(dst, { recursive: true });
+
+  for (const dep of DAEMON_ESM_DEPS) {
+    const src = path.join(REPO_ROOT, 'node_modules', dep);
+    const out = path.join(dst, dep);
+    if (!fs.existsSync(src)) {
+      console.warn(
+        `[before-pack] WARN daemon dep missing: ${src}. ` +
+          `Skipping (run \`npm install\` to populate).`,
+      );
+      // Placeholder so the dst dir is non-empty and extraResources copy
+      // doesn't end up with a missing target.
+      fs.mkdirSync(out, { recursive: true });
+      fs.writeFileSync(
+        path.join(out, 'package.json'),
+        JSON.stringify({ name: dep, version: '0.0.0-placeholder', main: 'index.js' }, null, 2),
+      );
+      fs.writeFileSync(path.join(out, 'index.js'), `// placeholder for ${dep}\n`);
+      continue;
+    }
+    copyDir(src, out);
+  }
+  console.log(`[before-pack] staged daemon deps: ${DAEMON_ESM_DEPS.join(', ')}`);
+}
+
+exports.default = async function beforePack(context) {
+  const { electronPlatformName, arch } = context;
+  const archName = ARCH_NAMES[arch];
+
+  if (archName === 'universal' || archName === 'armv7l') {
+    throw new Error(
+      `[before-pack] arch ${archName} not supported in v0.3 (build x64 + arm64 separately; pkg cannot merge fat Mach-O)`,
+    );
+  }
+  if (!archName) {
+    throw new Error(`[before-pack] unknown arch index ${arch}`);
+  }
+
+  console.log(`[before-pack] staging for ${electronPlatformName}-${archName}`);
+
+  stageDaemonBinary(electronPlatformName, archName);
+  stageNatives(electronPlatformName, archName);
+  stageSdk();
+  stageDaemonDeps();
+
+  console.log('[before-pack] staging complete');
+};


### PR DESCRIPTION
## What

Adds the electron-builder `extraResources` wiring + `beforePack` hook for the v0.3 daemon-split packaging contract.

- New `scripts/before-pack.cjs` stages per-platform daemon binary, native dlopen targets (`better_sqlite3.node`, `pty.node`, `ccsm_native.node`), claude-agent-sdk closure, and daemon ESM deps (`pino`, `ulid`) into fixed paths.
- `package.json` `build` block:
  - `beforePack: scripts/before-pack.cjs`
  - `extraResources` (top-level): `daemon/native`, `daemon/node_modules/@anthropic-ai/claude-agent-sdk`, `daemon/node_modules` (deps), `sdk/claude-agent-sdk` (Electron-main shim residual)
  - `extraResources` (per-platform `win`/`mac`/`linux`): `daemon/ccsm-daemon{.exe}` — split out because electron-builder does not expand `${ext}` inside `from` paths
  - `asarUnpack` extended with SDK glob + `**/*.node`
- `.gitignore` excludes the `daemon/{dist,native,*-staged}/` build artifacts.

## Spec

- `docs/superpowers/specs/v0.3-fragments/frag-11-packaging.md` §11.2 + §11.2.1
- Daemon-side primary (direct ESM, Node 22) + Electron-main residual (`loadSdk` shim) dual-consumer SDK staging.

## Stub note (T2 dependency)

T2 (build glue) and T60 (electron-rebuild path) have not merged yet, so `daemon/dist/<binary>` and `daemon/native/<platform>-<arch>/` do not exist on origin/working. The hook emits a loud `[before-pack] WARN ...` and falls back to placeholder files so the staging mechanism can be smoke-tested. T57 will add hard `after-pack` validation that fails the build if any required artifact is missing — at that point the placeholders will trigger build failure unless real artifacts are in place.

## Smoke

`npx electron-builder --dir --linux --publish never` (cross-build from Windows):

```
[before-pack] staging for linux-x64
[before-pack] WARN daemon binary missing: .../daemon/dist/ccsm-daemon-linux-x64. Falling back to placeholder (T2 build glue not yet merged).
[before-pack] WARN native folder missing: .../daemon/native/linux-x64. Falling back to placeholders (T2 build glue not yet merged).
[before-pack] staged SDK: .../node_modules/@anthropic-ai/claude-agent-sdk -> .../daemon/sdk-staged
[before-pack] staged daemon deps: pino, ulid
[before-pack] staging complete
  • packaging       platform=linux arch=x64 electron=41.3.0 appOutDir=release\linux-unpacked
```

`find release/ -path '*/resources/daemon*' -o -path '*/resources/sdk*' | head -20`:

```
release/linux-unpacked/resources/daemon
release/linux-unpacked/resources/daemon/ccsm-daemon
release/linux-unpacked/resources/daemon/native
release/linux-unpacked/resources/daemon/native/better_sqlite3.node
release/linux-unpacked/resources/daemon/native/ccsm_native.node
release/linux-unpacked/resources/daemon/native/pty.node
release/linux-unpacked/resources/daemon/node_modules
release/linux-unpacked/resources/daemon/node_modules/@anthropic-ai/claude-agent-sdk
release/linux-unpacked/resources/daemon/node_modules/@anthropic-ai/claude-agent-sdk/package.json
release/linux-unpacked/resources/daemon/node_modules/@anthropic-ai/claude-agent-sdk/sdk.mjs
release/linux-unpacked/resources/daemon/node_modules/pino
release/linux-unpacked/resources/daemon/node_modules/ulid
release/linux-unpacked/resources/sdk
release/linux-unpacked/resources/sdk/claude-agent-sdk
release/linux-unpacked/resources/sdk/claude-agent-sdk/package.json
release/linux-unpacked/resources/sdk/claude-agent-sdk/sdk.mjs
```

Note: the existing `after-pack.cjs` node-pty check fails on this cross-build (Windows host packaging Linux without the linux node-pty prebuild), but that is unrelated to T49 and not introduced by this PR. The before-pack staging + extraResources copy completed successfully before that check ran.

## Follow-ups

- T2 (build glue) provisions real `daemon/dist/<binary>` + `daemon/native/<platform>` content; the hook then no-ops the placeholder branch automatically.
- T57 extends `after-pack.cjs` with the `REQUIRED_AFTER_PACK` list (daemon binary, every `.node`, both SDK staged copies + entry-point JS resolution) per spec §11.2 r9 P1-5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)