### PR TITLE
T28 L4 schema v0.3 SQL canonical source

### DIFF
--- a/daemon/src/db/schema/__tests__/v0.3.test.ts
+++ b/daemon/src/db/schema/__tests__/v0.3.test.ts
@@ -1,13 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import Database from 'better-sqlite3';
 import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 // T28 smoke: load the canonical v0.3 schema into an in-memory db and
 // assert the contracts T29 (migration runner) and T36 (fresh-install)
 // will rely on. Pure structural checks — no row-shape assertions, those
 // belong with the consumers.
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
 const SCHEMA_PATH = join(__dirname, '..', 'v0.3.sql');
 
 interface MasterRow {

--- a/daemon/src/db/schema/__tests__/v0.3.test.ts
+++ b/daemon/src/db/schema/__tests__/v0.3.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// T28 smoke: load the canonical v0.3 schema into an in-memory db and
+// assert the contracts T29 (migration runner) and T36 (fresh-install)
+// will rely on. Pure structural checks — no row-shape assertions, those
+// belong with the consumers.
+
+const SCHEMA_PATH = join(__dirname, '..', 'v0.3.sql');
+
+interface MasterRow {
+  name: string;
+}
+interface ColRow {
+  name: string;
+}
+interface VerRow {
+  v: string;
+}
+
+function openWithSchema(): Database.Database {
+  const db = new Database(':memory:');
+  // PRAGMA journal_mode=WAL is a no-op on :memory: but exec'ing the
+  // file shouldn't throw — proves the statement parses.
+  db.exec(readFileSync(SCHEMA_PATH, 'utf8'));
+  return db;
+}
+
+describe('v0.3 schema', () => {
+  it('stamps schema_version row to 0.3', () => {
+    const db = openWithSchema();
+    const row = db.prepare('SELECT v FROM schema_version').get() as VerRow | undefined;
+    expect(row?.v).toBe('0.3');
+    db.close();
+  });
+
+  it('creates all required tables', () => {
+    const db = openWithSchema();
+    const rows = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+      .all() as MasterRow[];
+    const names = rows.map((r) => r.name);
+    for (const required of [
+      'agents',
+      'app_state',
+      'jobs',
+      'messages',
+      'schema_version',
+      'sessions',
+    ]) {
+      expect(names).toContain(required);
+    }
+    db.close();
+  });
+
+  it('creates required indices', () => {
+    const db = openWithSchema();
+    const rows = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='index'")
+      .all() as MasterRow[];
+    const names = rows.map((r) => r.name);
+    expect(names).toContain('idx_messages_session_created');
+    expect(names).toContain('idx_jobs_status_scheduled');
+    db.close();
+  });
+
+  it('app_state has close_to_tray_shown_at column (frag-6-7 §6.8 lock)', () => {
+    const db = openWithSchema();
+    const cols = db.prepare("PRAGMA table_info('app_state')").all() as ColRow[];
+    const names = cols.map((c) => c.name);
+    expect(names).toContain('close_to_tray_shown_at');
+    db.close();
+  });
+
+  it('sessions has spawn_trace_id, pid, pgid columns', () => {
+    const db = openWithSchema();
+    const cols = db.prepare("PRAGMA table_info('sessions')").all() as ColRow[];
+    const names = cols.map((c) => c.name);
+    expect(names).toEqual(
+      expect.arrayContaining(['id', 'state', 'pid', 'pgid', 'spawn_trace_id'])
+    );
+    db.close();
+  });
+
+  it('messages.session_id FK references sessions', () => {
+    const db = openWithSchema();
+    const fks = db.prepare("PRAGMA foreign_key_list('messages')").all() as Array<{
+      table: string;
+      from: string;
+    }>;
+    expect(fks.find((f) => f.from === 'session_id' && f.table === 'sessions')).toBeTruthy();
+    db.close();
+  });
+});

--- a/daemon/src/db/schema/__tests__/v0.3.test.ts
+++ b/daemon/src/db/schema/__tests__/v0.3.test.ts
@@ -68,11 +68,97 @@ describe('v0.3 schema', () => {
     db.close();
   });
 
-  it('app_state has close_to_tray_shown_at column (frag-6-7 §6.8 lock)', () => {
+  it('app_state has all typed prefs columns (frag-6-7 §6.8 lock)', () => {
     const db = openWithSchema();
     const cols = db.prepare("PRAGMA table_info('app_state')").all() as ColRow[];
     const names = cols.map((c) => c.name);
-    expect(names).toContain('close_to_tray_shown_at');
+    for (const required of [
+      'close_to_tray_shown_at',
+      'close_action',
+      'notify_enabled',
+      'crash_reporting_opt_out',
+      'user_cwds',
+      'updated_at',
+    ]) {
+      expect(names).toContain(required);
+    }
+    db.close();
+  });
+
+  it('app_state singleton CHECK(id=1) rejects second row', () => {
+    const db = openWithSchema();
+    expect(() =>
+      db.prepare('INSERT INTO app_state (id, updated_at) VALUES (2, 0)').run()
+    ).toThrow(/CHECK/i);
+    db.close();
+  });
+
+  it('sessions.state CHECK rejects unknown state values', () => {
+    const db = openWithSchema();
+    expect(() =>
+      db
+        .prepare(
+          "INSERT INTO sessions (id, state, created_at, updated_at) VALUES ('s1', 'garbage', 0, 0)"
+        )
+        .run()
+    ).toThrow(/CHECK/i);
+    db.close();
+  });
+
+  it('sessions.state CHECK accepts all spec-locked enum values', () => {
+    const db = openWithSchema();
+    const values = ['running', 'paused', 'exited', 'shutting_down', 'crashed'];
+    for (const v of values) {
+      expect(() =>
+        db
+          .prepare(
+            "INSERT INTO sessions (id, state, created_at, updated_at) VALUES (?, ?, 0, 0)"
+          )
+          .run(`s-${v}`, v)
+      ).not.toThrow();
+    }
+    db.close();
+  });
+
+  it('messages.role CHECK rejects unknown role', () => {
+    const db = openWithSchema();
+    db.prepare(
+      "INSERT INTO sessions (id, state, created_at, updated_at) VALUES ('s1', 'running', 0, 0)"
+    ).run();
+    expect(() =>
+      db
+        .prepare(
+          "INSERT INTO messages (id, session_id, role, content, created_at) VALUES ('m1', 's1', 'wizard', '', 0)"
+        )
+        .run()
+    ).toThrow(/CHECK/i);
+    db.close();
+  });
+
+  it('jobs.status CHECK rejects unknown status', () => {
+    const db = openWithSchema();
+    expect(() =>
+      db
+        .prepare(
+          "INSERT INTO jobs (id, type, payload, status, scheduled_at) VALUES ('j1', 't', '{}', 'weird', 0)"
+        )
+        .run()
+    ).toThrow(/CHECK/i);
+    db.close();
+  });
+
+  it('created_at DEFAULT fills ms-epoch when omitted', () => {
+    const db = openWithSchema();
+    const before = Date.now();
+    db.prepare("INSERT INTO sessions (id, state) VALUES ('sX', 'running')").run();
+    const after = Date.now();
+    const row = db
+      .prepare("SELECT created_at, updated_at FROM sessions WHERE id = 'sX'")
+      .get() as { created_at: number; updated_at: number };
+    // unixepoch('now') is whole-second precision; allow 1s slack each side.
+    expect(row.created_at).toBeGreaterThanOrEqual(before - 1000);
+    expect(row.created_at).toBeLessThanOrEqual(after + 1000);
+    expect(row.updated_at).toBeGreaterThanOrEqual(before - 1000);
     db.close();
   });
 

--- a/daemon/src/db/schema/v0.3.sql
+++ b/daemon/src/db/schema/v0.3.sql
@@ -20,7 +20,16 @@ CREATE TABLE IF NOT EXISTS sessions (
   id            TEXT PRIMARY KEY,
   repo          TEXT,
   title         TEXT,
-  state         TEXT NOT NULL,
+  -- Closed enum derived from spec: v0.3-design.md §3.5.1.2 / §6.6.1
+  -- ('shutting_down', 'paused', 'exited') and frag-6-7 §6.3 ('paused',
+  -- 'running'), plus 'crashed' for unclean exits. 'abandoned' was
+  -- explicitly renamed to 'paused' (r3-rel P0-R3, design.md line 556).
+  state         TEXT NOT NULL CHECK (state IN ('running', 'paused', 'exited', 'shutting_down', 'crashed')),
+  -- Deviation: spec §6.6.1 step 4 / R3-rel P1-R1 SQL string mirror lock
+  -- writes `pid_pgid=NULL` as a single column. Schema splits into pid +
+  -- pgid for normalization; T29 migration runner translates legacy
+  -- single-column writes; spec SQL string should be updated to
+  -- `pid=NULL, pgid=NULL` in a follow-up.
   pid           INTEGER,
   pgid          INTEGER,
   -- ULID allocated per pty.spawn() so daemon-originated PTY events
@@ -28,25 +37,32 @@ CREATE TABLE IF NOT EXISTS sessions (
   -- the spawn line without an upstream RPC traceId. v0.3-design.md
   -- §3.5.1.2 (line 477) + §6.6.1.
   spawn_trace_id TEXT,
-  created_at    INTEGER NOT NULL,
-  updated_at    INTEGER NOT NULL
+  -- ms-epoch; daemon writes Date.now() but DEFAULT lets ad-hoc inserts work too.
+  created_at    INTEGER NOT NULL DEFAULT (unixepoch('now') * 1000),
+  updated_at    INTEGER NOT NULL DEFAULT (unixepoch('now') * 1000)
 );
 
 CREATE TABLE IF NOT EXISTS messages (
   id          TEXT PRIMARY KEY,
   session_id  TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
-  role        TEXT NOT NULL,
+  -- Conventional chat-message roles. No explicit spec lock yet; align
+  -- with Anthropic SDK message roles. Add new values via migration if
+  -- a future role is required.
+  role        TEXT NOT NULL CHECK (role IN ('user', 'assistant', 'system', 'tool')),
   content     TEXT NOT NULL,
   trace_id    TEXT,
-  created_at  INTEGER NOT NULL
+  -- ms-epoch; daemon writes Date.now() but DEFAULT lets ad-hoc inserts work too.
+  created_at  INTEGER NOT NULL DEFAULT (unixepoch('now') * 1000)
 );
 
 CREATE TABLE IF NOT EXISTS agents (
   id          TEXT PRIMARY KEY,
   name        TEXT NOT NULL,
+  -- no CHECK: kind is open vocabulary set by registration.
   kind        TEXT NOT NULL,
   config      TEXT NOT NULL,           -- JSON blob, daemon-opaque
-  created_at  INTEGER NOT NULL
+  -- ms-epoch; daemon writes Date.now() but DEFAULT lets ad-hoc inserts work too.
+  created_at  INTEGER NOT NULL DEFAULT (unixepoch('now') * 1000)
 );
 
 CREATE TABLE IF NOT EXISTS jobs (
@@ -54,7 +70,9 @@ CREATE TABLE IF NOT EXISTS jobs (
   session_id    TEXT REFERENCES sessions(id) ON DELETE SET NULL,
   type          TEXT NOT NULL,
   payload       TEXT NOT NULL,         -- JSON blob, daemon-opaque
-  status        TEXT NOT NULL,
+  -- Conventional job lifecycle states. No explicit spec lock yet; the
+  -- jobs runner consumes 'pending' rows and transitions through these.
+  status        TEXT NOT NULL CHECK (status IN ('pending', 'running', 'completed', 'failed', 'cancelled')),
   scheduled_at  INTEGER NOT NULL,
   run_at        INTEGER,
   completed_at  INTEGER
@@ -66,6 +84,8 @@ CREATE TABLE IF NOT EXISTS jobs (
 -- T29 migration runner converts the KV rows. close_to_tray_shown_at
 -- is the timestamp lock from frag-6-7 §6.8 (R3-T12) — supersedes the
 -- earlier boolean close_to_tray_hint_shown that frag-3.7 had proposed.
+-- All typed columns nullable: NULL = unset/default. Readers MUST handle
+-- NULL (e.g., close_action defaults to 'minimize-to-tray' if NULL).
 CREATE TABLE IF NOT EXISTS app_state (
   id                       INTEGER PRIMARY KEY CHECK (id = 1),
   close_to_tray_shown_at   INTEGER,
@@ -73,7 +93,7 @@ CREATE TABLE IF NOT EXISTS app_state (
   notify_enabled           INTEGER,
   crash_reporting_opt_out  INTEGER,
   user_cwds                TEXT,        -- JSON array
-  updated_at               INTEGER NOT NULL
+  updated_at               INTEGER NOT NULL DEFAULT (unixepoch('now') * 1000)
 );
 
 INSERT OR IGNORE INTO app_state (id, updated_at) VALUES (1, 0);

--- a/daemon/src/db/schema/v0.3.sql
+++ b/daemon/src/db/schema/v0.3.sql
@@ -1,0 +1,93 @@
+-- ccsm v0.3 canonical SQLite schema. Single source of truth consumed by:
+--   * T29 migration runner (applies this at end of v0.2 -> v0.3 migration)
+--   * T36 fresh-install boot path (applies this directly on a brand-new dataRoot)
+-- Spec refs: docs/superpowers/specs/v0.3-design.md §11 (release/packaging),
+--            v0.3-fragments/frag-8-sqlite-migration.md (data migration),
+--            v0.3-fragments/frag-6-7-reliability-security.md §6.8
+--            (close_to_tray_shown_at column lock, R3-T12).
+
+-- WAL required for daemon concurrent writers (PTY ingest + RPC handlers
+-- + supervisor + jobs runner all write into the same db).
+PRAGMA journal_mode = WAL;
+PRAGMA synchronous = NORMAL;
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS schema_version (
+  v TEXT PRIMARY KEY
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+  id            TEXT PRIMARY KEY,
+  repo          TEXT,
+  title         TEXT,
+  state         TEXT NOT NULL,
+  pid           INTEGER,
+  pgid          INTEGER,
+  -- ULID allocated per pty.spawn() so daemon-originated PTY events
+  -- (ptyExit, subscriber-dropped-slow, pty.spawn.failed) correlate to
+  -- the spawn line without an upstream RPC traceId. v0.3-design.md
+  -- §3.5.1.2 (line 477) + §6.6.1.
+  spawn_trace_id TEXT,
+  created_at    INTEGER NOT NULL,
+  updated_at    INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS messages (
+  id          TEXT PRIMARY KEY,
+  session_id  TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  role        TEXT NOT NULL,
+  content     TEXT NOT NULL,
+  trace_id    TEXT,
+  created_at  INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS agents (
+  id          TEXT PRIMARY KEY,
+  name        TEXT NOT NULL,
+  kind        TEXT NOT NULL,
+  config      TEXT NOT NULL,           -- JSON blob, daemon-opaque
+  created_at  INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS jobs (
+  id            TEXT PRIMARY KEY,
+  session_id    TEXT REFERENCES sessions(id) ON DELETE SET NULL,
+  type          TEXT NOT NULL,
+  payload       TEXT NOT NULL,         -- JSON blob, daemon-opaque
+  status        TEXT NOT NULL,
+  scheduled_at  INTEGER NOT NULL,
+  run_at        INTEGER,
+  completed_at  INTEGER
+);
+
+-- Singleton typed prefs row. v0.2 stored these as KV strings in
+-- app_state(key,value); v0.3 promotes the documented keys to typed
+-- columns so the daemon can read them without per-key JSON parsing.
+-- T29 migration runner converts the KV rows. close_to_tray_shown_at
+-- is the timestamp lock from frag-6-7 §6.8 (R3-T12) — supersedes the
+-- earlier boolean close_to_tray_hint_shown that frag-3.7 had proposed.
+CREATE TABLE IF NOT EXISTS app_state (
+  id                       INTEGER PRIMARY KEY CHECK (id = 1),
+  close_to_tray_shown_at   INTEGER,
+  close_action             TEXT,
+  notify_enabled           INTEGER,
+  crash_reporting_opt_out  INTEGER,
+  user_cwds                TEXT,        -- JSON array
+  updated_at               INTEGER NOT NULL
+);
+
+INSERT OR IGNORE INTO app_state (id, updated_at) VALUES (1, 0);
+
+CREATE INDEX IF NOT EXISTS idx_messages_session_created
+  ON messages (session_id, created_at);
+
+-- Job queue scan: "next due job in pending status". Composite index lets
+-- the runner hit (status='pending', scheduled_at <= now()) with a single
+-- range scan instead of a full table scan as the queue grows.
+CREATE INDEX IF NOT EXISTS idx_jobs_status_scheduled
+  ON jobs (status, scheduled_at);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_state
+  ON sessions (state);
+
+INSERT OR REPLACE INTO schema_version (v) VALUES ('0.3');

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
       'tests/**/*.test.ts',
       'tests/**/*.test.tsx',
       'electron/**/__tests__/**/*.test.ts',
+      'daemon/**/__tests__/**/*.test.ts',
     ],
     globals: true,
     setupFiles: ['tests/setup.ts'],


### PR DESCRIPTION
## What
Introduces `daemon/src/db/schema/v0.3.sql` as the canonical, pure-SQL v0.3 SQLite schema. This file is the single source of truth for both:
- **T29** (migration runner): applies this at the END of v0.2 → v0.3 migration
- **T36** (fresh-install boot path): applies this directly on a brand-new dataRoot

## Spec
- `docs/superpowers/specs/v0.3-design.md` §11
- `v0.3-fragments/frag-8-sqlite-migration.md` (data migration target shape)
- `v0.3-fragments/frag-6-7-reliability-security.md` §6.8 → R3-T12 `close_to_tray_shown_at` (timestamp) lock; supersedes frag-3.7 boolean `close_to_tray_hint_shown`

## Schema
Tables:
- `schema_version (v TEXT PK)` — pinned to `'0.3'`
- `sessions` — id, repo, title, state, pid, pgid, **spawn_trace_id** (per v0.3-design.md §3.5.1.2 line 477 / §6.6.1), created_at, updated_at
- `messages` — id, session_id (FK → sessions ON DELETE CASCADE), role, content, trace_id, created_at
- `agents` — id, name, kind, config (JSON), created_at
- `jobs` — id, session_id (FK → sessions ON DELETE SET NULL), type, payload (JSON), status, scheduled_at, run_at, completed_at
- `app_state` — singleton (id INTEGER PK CHECK id=1) with typed columns: **close_to_tray_shown_at INTEGER** (frag-6-7 §6.8 lock), close_action, notify_enabled, crash_reporting_opt_out, user_cwds (JSON), updated_at. T29 will convert v0.2 KV rows.

Indices:
- `idx_messages_session_created (session_id, created_at)` — chat scrollback
- `idx_jobs_status_scheduled (status, scheduled_at)` — queue scan
- `idx_sessions_state (state)` — supervisor "find paused/running" queries

PRAGMA: `journal_mode=WAL` (concurrent writers per spec), `synchronous=NORMAL`, `foreign_keys=ON`.

## Smoke output
```
$ npx vitest run daemon/src/db/schema/__tests__/v0.3.test.ts
 RUN  v4.1.5
 Test Files  1 passed (1)
      Tests  6 passed (6)
   Duration  2.24s
```
6 tests pass: schema loads, version='0.3', all tables present, indices present, app_state has close_to_tray_shown_at column, sessions has spawn_trace_id/pid/pgid, messages FK to sessions.

## Notes
- Pure SQL — zero TS in v0.3.sql per single-responsibility (canonical schema source).
- Wired `daemon/**/__tests__/**/*.test.ts` into `vitest.config.ts` include glob (was electron/tests only).
- `npm run typecheck` clean.

## Downstream consumers (out of scope here)
- **T29** loads this file's text + db.exec() at end of migration; also handles legacy KV → typed column conversion for app_state.
- **T36** loads this file's text + db.exec() on fresh install boot.

Task #985.