### PR TITLE
feat(daemon/envelope): T3 base64url helper

### DIFF
--- a/daemon/src/envelope/__tests__/base64url.test.ts
+++ b/daemon/src/envelope/__tests__/base64url.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { Buffer } from 'node:buffer';
+import { randomBytes } from 'node:crypto';
+import { encode, decode } from '../base64url.js';
+
+describe('base64url', () => {
+  const sizes = [0, 1, 7, 16, 22, 32];
+
+  for (const n of sizes) {
+    it(`round-trips ${n}-byte buffer`, () => {
+      const input = n === 0 ? Buffer.alloc(0) : randomBytes(n);
+      const encoded = encode(input);
+      const decoded = decode(encoded);
+      expect(decoded.equals(input)).toBe(true);
+    });
+  }
+
+  it('emits no `=` padding on output', () => {
+    for (const n of sizes) {
+      const input = n === 0 ? Buffer.alloc(0) : randomBytes(n);
+      expect(encode(input)).not.toMatch(/=/);
+    }
+  });
+
+  it('uses base64url alphabet (no `+` or `/`)', () => {
+    // Bytes 0xfb, 0xff produce `+` / `/` under standard base64; ensure we map
+    // them to `-` / `_` instead.
+    const buf = Buffer.from([0xfb, 0xff, 0xbf]);
+    const out = encode(buf);
+    expect(out).not.toMatch(/[+/]/);
+    expect(decode(out).equals(buf)).toBe(true);
+  });
+
+  it('decode tolerates input WITH padding', () => {
+    const input = Buffer.from('hello'); // 5 bytes -> base64 needs 1 `=`
+    const unpadded = encode(input);
+    const padded = unpadded + '='.repeat((4 - (unpadded.length % 4)) % 4);
+    expect(padded).toMatch(/=$/);
+    expect(decode(padded).equals(input)).toBe(true);
+    expect(decode(unpadded).equals(input)).toBe(true);
+  });
+
+  it('decode rejects garbage characters', () => {
+    expect(() => decode('!@#')).toThrow(/invalid input/);
+    expect(() => decode('abc$')).toThrow(/invalid input/);
+    expect(() => decode('héllo')).toThrow(/invalid input/);
+  });
+
+  it('decode rejects invalid length', () => {
+    // length % 4 === 1 is impossible for any valid base64 payload
+    expect(() => decode('a')).toThrow(/invalid input length/);
+    expect(() => decode('abcde')).toThrow(/invalid input length/);
+  });
+
+  it('decode handles empty string', () => {
+    expect(decode('').length).toBe(0);
+  });
+});

--- a/daemon/src/envelope/base64url.ts
+++ b/daemon/src/envelope/base64url.ts
@@ -1,0 +1,22 @@
+import { Buffer } from 'node:buffer';
+
+const BASE64URL_RE = /^[A-Za-z0-9_-]*={0,2}$/;
+
+export function encode(buf: Buffer): string {
+  return buf.toString('base64url');
+}
+
+export function decode(s: string): Buffer {
+  if (typeof s !== 'string' || !BASE64URL_RE.test(s)) {
+    throw new Error('base64url: invalid input');
+  }
+  // Node accepts both padded and unpadded base64url; normalise to no-padding
+  // first so we control what gets re-padded and reject garbage like `===`.
+  const stripped = s.replace(/=+$/, '');
+  const pad = (4 - (stripped.length % 4)) % 4;
+  if (pad === 3) {
+    // Length % 4 === 1 is never a valid base64url payload.
+    throw new Error('base64url: invalid input length');
+  }
+  return Buffer.from(stripped + '='.repeat(pad), 'base64url');
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
       'tests/**/*.test.ts',
       'tests/**/*.test.tsx',
       'electron/**/__tests__/**/*.test.ts',
+      'daemon/**/__tests__/**/*.test.ts',
     ],
     globals: true,
     setupFiles: ['tests/setup.ts'],


### PR DESCRIPTION
## Summary
- Pure base64url encode/decode for daemon envelope HMAC nonce + reserved keys
- Encode emits no trailing `=` padding per RFC 4648 §5
- Decode tolerates padding presence/absence; rejects invalid chars and impossible lengths
- Wires `daemon/**/__tests__/**/*.test.ts` into root `vitest.config.ts` so the workspace's tests run alongside the existing electron suites

## Test plan
- [x] Round-trip 0/1/7/16/22/32 byte buffers
- [x] Encode output free of `=`
- [x] Encode uses base64url alphabet (no `+`/`/`)
- [x] Decode tolerant of padding (with and without)
- [x] Decode rejects garbage characters (`!@#`, non-ASCII, etc.)
- [x] Decode rejects impossible lengths (% 4 === 1)
- [x] Decode handles empty string

`npx vitest run daemon/src/envelope --no-coverage` -> 12/12 passed
`npx eslint daemon/src/envelope/` -> clean
`npx tsc --noEmit -p daemon/tsconfig.json` -> clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)