### PR TITLE
feat(daemon/envelope): T11 SUPERVISOR_RPCS canonical

### DIFF
--- a/daemon/src/envelope/__tests__/supervisor-rpcs.test.ts
+++ b/daemon/src/envelope/__tests__/supervisor-rpcs.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { SUPERVISOR_RPCS, isSupervisorRpc } from '../supervisor-rpcs.js';
+
+describe('SUPERVISOR_RPCS (spec §3.4.1.h)', () => {
+  it('contains exactly the five canonical control-plane RPCs', () => {
+    // Frozen comparison against the spec table row "control-socket".
+    expect([...SUPERVISOR_RPCS]).toEqual([
+      '/healthz',
+      '/stats',
+      'daemon.hello',
+      'daemon.shutdown',
+      'daemon.shutdownForUpgrade',
+    ]);
+    expect(SUPERVISOR_RPCS).toHaveLength(5);
+  });
+
+  it('is a readonly tuple at the type level (compile-time guard)', () => {
+    // `as const` makes the array frozen at the literal type; runtime mutation
+    // attempts via index assignment would still be allowed under non-strict
+    // mode unless explicitly frozen. Document intent + verify shape.
+    const arr: readonly string[] = SUPERVISOR_RPCS;
+    expect(Array.isArray(arr)).toBe(true);
+  });
+});
+
+describe('isSupervisorRpc', () => {
+  it.each([...SUPERVISOR_RPCS])('returns true for canonical RPC %s', (name) => {
+    expect(isSupervisorRpc(name)).toBe(true);
+  });
+
+  it.each([
+    'daemon.foo',
+    '',
+    'daemon.shutdown.fake',
+    'daemon.hello.x',
+    '/healthz/extra',
+    '/stat',
+    'daemon.HELLO',
+    ' daemon.hello',
+    'daemon.hello ',
+    'session.subscribe',
+    '/',
+  ])('returns false for non-canonical name %j', (name) => {
+    expect(isSupervisorRpc(name)).toBe(false);
+  });
+
+  it('does no prefix or wildcard matching', () => {
+    expect(isSupervisorRpc('daemon')).toBe(false);
+    expect(isSupervisorRpc('daemon.')).toBe(false);
+    expect(isSupervisorRpc('daemon.shutdownForUpgradeNow')).toBe(false);
+  });
+});

--- a/daemon/src/envelope/supervisor-rpcs.ts
+++ b/daemon/src/envelope/supervisor-rpcs.ts
@@ -1,0 +1,39 @@
+// Control-plane carve-out — exempt from envelope HMAC + hello-required gate.
+// Allowlist only; mutation requires spec round.
+//
+// Single source of truth for the §3.4.1.h supervisor / control-socket RPC set.
+// Consumers (per spec):
+//   - control-socket dispatcher (T16) routes ONLY these names.
+//   - migrationGateInterceptor (§3.4.1.f) uses this allowlist to decide
+//     which RPCs survive a migration window.
+//   - frag-8 §8.5 migration scope references the same constant to keep the
+//     three sites from drifting on what counts as control-plane.
+//
+// Spec citation: docs/superpowers/specs/v0.3-fragments/frag-3.4.1-envelope-hardening.md §3.4.1.h
+// (table row "control-socket": `/healthz`, `/stats`, `daemon.hello`,
+//  `daemon.shutdown`, `daemon.shutdownForUpgrade`).
+
+export const SUPERVISOR_RPCS = [
+  '/healthz',
+  '/stats',
+  'daemon.hello',
+  'daemon.shutdown',
+  'daemon.shutdownForUpgrade',
+] as const;
+
+export type SupervisorRpc = (typeof SUPERVISOR_RPCS)[number];
+
+// Pre-built Set for O(1) predicate lookup; the tuple itself stays the
+// canonical ordered export (frozen by `as const`).
+const SUPERVISOR_RPC_SET: ReadonlySet<string> = new Set(SUPERVISOR_RPCS);
+
+/**
+ * Returns true iff `name` is one of the canonical control-plane RPC names.
+ *
+ * Pure predicate — no normalisation, no prefix matching, no wildcards.
+ * Anything outside the literal allowlist is data-plane and MUST go through
+ * the full envelope HMAC + hello-required gate.
+ */
+export function isSupervisorRpc(name: string): boolean {
+  return SUPERVISOR_RPC_SET.has(name);
+}

--- a/daemon/src/index.ts
+++ b/daemon/src/index.ts
@@ -1,19 +1,14 @@
 import { ulid } from 'ulid';
 import pino from 'pino';
 import { createRequire } from 'node:module';
+import { SUPERVISOR_RPCS } from './envelope/supervisor-rpcs.js';
 
 const require = createRequire(import.meta.url);
 const DAEMON_VERSION = (require('../../package.json') as { version: string }).version;
 
-// TODO(T16): replace placeholder with the canonical SUPERVISOR_RPCS dispatcher
-// declared in spec §3.4.1.h. Listed literals only — control-plane carve-out.
-const SUPERVISOR_RPCS = [
-  '/healthz',
-  '/stats',
-  'daemon.hello',
-  'daemon.shutdown',
-  'daemon.shutdownForUpgrade',
-] as const;
+// T11 landed the canonical export; T16 owns the control-socket dispatcher
+// that actually routes on this allowlist. Keep a `void` reference here so
+// the import stays live until T16 wires it.
 void SUPERVISOR_RPCS;
 
 const bootNonce = ulid();


### PR DESCRIPTION
## Summary

Task #967 [T11] L1 envelope: control-plane carve-out.

Promotes the placeholder \`SUPERVISOR_RPCS\` literal in \`daemon/src/index.ts\` to the canonical module \`daemon/src/envelope/supervisor-rpcs.ts\` per spec **§3.4.1.h** (\`docs/superpowers/specs/v0.3-fragments/frag-3.4.1-envelope-hardening.md\`).

- New module exports:
  - \`SUPERVISOR_RPCS\` — readonly tuple of the 5 control-plane RPCs.
  - \`isSupervisorRpc(name: string): boolean\` — pure predicate, O(1) Set lookup, no normalisation / prefix matching.
- \`daemon/src/index.ts\` now imports the canonical export (placeholder block removed; \`void\` reference kept until T16 wires the dispatcher).
- \`vitest.config.ts\` include pattern extended for \`daemon/src/**/__tests__/\`.

## Spec citation (5-RPC list)

frag-3.4.1-envelope-hardening.md §3.4.1.h, table row "control-socket":

> RPCs served: \`/healthz\`, \`/stats\`, \`daemon.hello\`, \`daemon.shutdown\` (frag-6-7 §6.4 step 4 graceful drain), \`daemon.shutdownForUpgrade\` (frag-6-7 §6.4 upgrade-in-place + marker).

Cross-referenced by §3.4.1.f migrationGateInterceptor (allowlist source) and frag-8 §8.5 migration scope — single canonical constant prevents the three sites drifting.

## Test plan

- [x] \`npx vitest run daemon/src/envelope --no-coverage\` → 1 file, **19 tests** pass.
  - 5 RPCs each return true via \`it.each\`.
  - 11 non-canonical names return false (\`daemon.foo\`, \`''\`, \`daemon.shutdown.fake\`, case variants, whitespace variants, partial prefixes).
  - Const inventory equality + length assertion.
  - Explicit no-prefix-match guard (\`daemon.shutdownForUpgradeNow\` → false).
- [x] \`npx eslint daemon/src/envelope/ daemon/src/index.ts\` → clean.
- [x] \`npx tsc --noEmit -p daemon/tsconfig.json\` → clean.
- [x] \`npm run build:daemon\` → emits \`dist-daemon/envelope/supervisor-rpcs.{js,d.ts,js.map}\`.

## Out of scope

- T16 control-socket dispatcher (consumes this constant).
- migrationGateInterceptor wiring (§3.4.1.f).