### PR TITLE
feat(daemon/envelope): T5 envelope core

### DIFF
--- a/daemon/src/envelope/__tests__/envelope.test.ts
+++ b/daemon/src/envelope/__tests__/envelope.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+import { Buffer } from 'node:buffer';
+
+import {
+  decodeFrame,
+  encodeFrame,
+  ENVELOPE_LIMITS,
+  EnvelopeError,
+} from '../envelope.js';
+
+const enc = (h: object, p?: Buffer): Buffer =>
+  encodeFrame({
+    headerJson: Buffer.from(JSON.stringify(h), 'utf8'),
+    payload: p,
+  });
+
+describe('envelope.encodeFrame / decodeFrame', () => {
+  it('round-trips a small JSON-only frame byte-equal', () => {
+    const header = { id: 7, method: 'ccsm.v1/daemon.hello', payloadType: 'json', payloadLen: 0 };
+    const frame = enc(header);
+    const decoded = decodeFrame(frame);
+    expect(decoded.version).toBe(0x0);
+    expect(JSON.parse(decoded.headerJson.toString('utf8'))).toEqual(header);
+    expect(decoded.payload.length).toBe(0);
+  });
+
+  it('round-trips a binary frame with header + trailer split correctly', () => {
+    const header = { id: 11, payloadType: 'binary', payloadLen: 64 };
+    const trailer = Buffer.alloc(64, 0xab);
+    const frame = enc(header, trailer);
+    const decoded = decodeFrame(frame);
+    expect(decoded.version).toBe(0x0);
+    expect(JSON.parse(decoded.headerJson.toString('utf8'))).toEqual(header);
+    expect(decoded.payload.length).toBe(64);
+    expect(decoded.payload.equals(trailer)).toBe(true);
+  });
+
+  it('encodes the version nibble in the high 4 bits of the totalLen prefix', () => {
+    const frame = enc({ id: 1 });
+    const raw = frame.readUInt32BE(0);
+    expect((raw >>> 28) & 0x0f).toBe(0x0);
+    // Low 28 bits equal the byte-count after the 4-byte prefix.
+    expect(raw & 0x0fffffff).toBe(frame.length - 4);
+  });
+
+  it('rejects a frame whose payload would exceed 16 MiB', () => {
+    // Synthesize a header claiming 16 MiB + 1 payload by hand-crafting the
+    // 4-byte prefix; encodeFrame would refuse to produce one for us.
+    const oversize = ENVELOPE_LIMITS.MAX_PAYLOAD_BYTES + 1;
+    const buf = Buffer.alloc(4);
+    // nibble=0x0, len=oversize
+    buf.writeUInt32BE((0x0 << 28) | (oversize & 0x0fffffff), 0);
+    expect(() => decodeFrame(buf)).toThrowError(EnvelopeError);
+    try {
+      decodeFrame(buf);
+    } catch (e) {
+      expect(e).toBeInstanceOf(EnvelopeError);
+      expect((e as EnvelopeError).code).toBe('envelope_too_large');
+    }
+  });
+
+  it('encodeFrame refuses to build an oversize frame', () => {
+    const big = Buffer.alloc(ENVELOPE_LIMITS.MAX_PAYLOAD_BYTES);
+    try {
+      encodeFrame({ headerJson: Buffer.from('{}'), payload: big });
+      expect.fail('expected throw');
+    } catch (e) {
+      expect(e).toBeInstanceOf(EnvelopeError);
+      expect((e as EnvelopeError).code).toBe('envelope_too_large');
+    }
+  });
+
+  it('rejects an unknown frame-version nibble (e.g. 0x1) BEFORE cap-checking', () => {
+    // Construct a frame whose nibble is 0x1 and whose masked length is small.
+    // Spec §3.4.1.a CC-1: nibble check must run BEFORE the length cap so the
+    // attacker's "set high bit and confuse the cap-check" trick is blocked.
+    const buf = Buffer.alloc(4);
+    buf.writeUInt32BE((0x1 << 28) | (16 & 0x0fffffff), 0);
+    try {
+      decodeFrame(buf);
+      expect.fail('expected throw');
+    } catch (e) {
+      expect(e).toBeInstanceOf(EnvelopeError);
+      expect((e as EnvelopeError).code).toBe('UNSUPPORTED_FRAME_VERSION');
+      expect((e as EnvelopeError).nibble).toBe(0x1);
+    }
+  });
+
+  it('rejects a truncated frame (prefix says N bytes, buffer has fewer)', () => {
+    const frame = enc({ id: 5 }, Buffer.alloc(128, 0x01));
+    const truncated = frame.subarray(0, frame.length - 10);
+    try {
+      decodeFrame(truncated);
+      expect.fail('expected throw');
+    } catch (e) {
+      expect(e).toBeInstanceOf(EnvelopeError);
+      expect((e as EnvelopeError).code).toBe('truncated_frame');
+    }
+  });
+
+  it('rejects a buffer too short for even the 4-byte prefix', () => {
+    try {
+      decodeFrame(Buffer.alloc(2));
+      expect.fail('expected throw');
+    } catch (e) {
+      expect(e).toBeInstanceOf(EnvelopeError);
+      expect((e as EnvelopeError).code).toBe('truncated_frame');
+    }
+  });
+
+  it('rejects a frame whose headerLen overflows the declared payload', () => {
+    // Build a hand-crafted frame with payloadLen = 4 but headerLen = 100.
+    const payloadLen = 4;
+    const buf = Buffer.alloc(4 + payloadLen);
+    buf.writeUInt32BE((0x0 << 28) | payloadLen, 0);
+    buf.writeUInt16BE(100, 4); // bogus headerLen
+    try {
+      decodeFrame(buf);
+      expect.fail('expected throw');
+    } catch (e) {
+      expect(e).toBeInstanceOf(EnvelopeError);
+      expect((e as EnvelopeError).code).toBe('corrupt_header_len');
+    }
+  });
+
+  it('decoded headerJson + payload are zero-copy views into the input buffer', () => {
+    const trailer = Buffer.from('hello world', 'utf8');
+    const frame = enc({ id: 99, payloadType: 'binary' }, trailer);
+    const decoded = decodeFrame(frame);
+    // Mutating the source buffer must show through the decoded views — proves
+    // we did not allocate fresh copies on the hot PTY path.
+    frame[frame.length - 1] = 0x21;
+    expect(decoded.payload[decoded.payload.length - 1]).toBe(0x21);
+  });
+
+  it('handles an exactly-at-cap frame (16 MiB payload boundary)', () => {
+    // Header = "{}" (2 bytes) + headerLen field (2 bytes) + filler trailer up
+    // to the cap. Verifies the boundary is INCLUSIVE on the cap value.
+    const headerJson = Buffer.from('{}', 'utf8');
+    const trailerLen =
+      ENVELOPE_LIMITS.MAX_PAYLOAD_BYTES -
+      ENVELOPE_LIMITS.HEADER_LEN_FIELD -
+      headerJson.length;
+    const trailer = Buffer.alloc(trailerLen, 0x55);
+    const frame = encodeFrame({ headerJson, payload: trailer });
+    expect(frame.length).toBe(
+      ENVELOPE_LIMITS.PREFIX_LEN + ENVELOPE_LIMITS.MAX_PAYLOAD_BYTES,
+    );
+    const decoded = decodeFrame(frame);
+    expect(decoded.payload.length).toBe(trailerLen);
+  });
+});

--- a/daemon/src/envelope/envelope.ts
+++ b/daemon/src/envelope/envelope.ts
@@ -1,0 +1,202 @@
+// Envelope wire-format core (spec §3.4.1.a + §3.4.1.c).
+//
+// Wire layout (binary frame format):
+//   [totalLen:4][headerLen:2][headerJSON:headerLen][payloadBytes:totalLen-2-headerLen]
+//
+// - The 4-byte `totalLen` prefix carries TWO logical fields packed together:
+//     * high 4 bits   = frame-version nibble (v0.3 daemon: 0x0; v0.4: 0x1)
+//     * low  28 bits  = payload length in bytes (everything AFTER the 4-byte
+//                       prefix: the 2-byte headerLen + headerJSON + payloadBytes)
+//   Max addressable payload is therefore 2^28 - 1 ≈ 256 MiB; we cap it at 16 MiB
+//   per spec §3.4.1.a.
+//
+// Parse order is NON-NEGOTIABLE (spec §3.4.1.a round-3 security CC-1):
+//   1. Read 4-byte big-endian header → `raw`.
+//   2. Extract version nibble FIRST: `nibble = (raw >>> 28) & 0x0F`. If unknown,
+//      throw `UNSUPPORTED_FRAME_VERSION` BEFORE masking — getting this wrong
+//      either resurrects a 256 MiB DoS or masks the real reject reason on a
+//      v0.4-from-future client.
+//   3. THEN mask low 28 bits: `len = raw & 0x0FFFFFFF`.
+//   4. THEN cap-check: `len > 16 MiB` → throw `envelope_too_large`.
+//
+// This module is pure encode/decode. It does NOT compute or verify HMACs (T4
+// owns `hmac.ts`); it does NOT validate header schemas (the adapter's TypeBox
+// hook owns that, spec §3.4.1.d). It only splits bytes.
+
+const FRAME_VERSION_V03 = 0x0;
+const KNOWN_FRAME_VERSIONS: ReadonlySet<number> = new Set([FRAME_VERSION_V03]);
+
+// 16 MiB hard cap on per-frame payload length (spec §3.4.1.a).
+const MAX_PAYLOAD_BYTES = 16 * 1024 * 1024;
+
+// Width of the fixed-size length+nibble prefix in bytes.
+const PREFIX_LEN = 4;
+// Width of the 16-bit headerLen field in bytes.
+const HEADER_LEN_FIELD = 2;
+// uint16 max — JSON header fits in 64 KiB by construction.
+const MAX_HEADER_LEN = 0xffff;
+
+/**
+ * Result of decoding one wire frame. `headerJson` is the raw UTF-8 bytes of the
+ * JSON header (left as Buffer so the caller can `JSON.parse` AFTER schema
+ * validation, per spec §3.4.1.d). `payload` is the opaque trailer (binary PTY
+ * bytes for `payloadType: "binary"`, or empty for pure-JSON frames).
+ */
+export interface DecodedFrame {
+  readonly version: number;
+  readonly headerJson: Buffer;
+  readonly payload: Buffer;
+}
+
+export interface EncodeOptions {
+  /** Frame-version nibble; defaults to v0.3 (0x0). */
+  readonly version?: number;
+  /** UTF-8 bytes of the JSON header. Caller is responsible for `JSON.stringify`. */
+  readonly headerJson: Buffer;
+  /** Opaque trailer bytes; empty Buffer for pure-JSON frames. */
+  readonly payload?: Buffer;
+}
+
+export class EnvelopeError extends Error {
+  public readonly code: string;
+  public readonly nibble?: number;
+  public readonly len?: number;
+
+  constructor(code: string, message: string, extras?: { nibble?: number; len?: number }) {
+    super(message);
+    this.name = 'EnvelopeError';
+    this.code = code;
+    if (extras?.nibble !== undefined) this.nibble = extras.nibble;
+    if (extras?.len !== undefined) this.len = extras.len;
+  }
+}
+
+/**
+ * Encode a wire frame from header + optional trailer bytes.
+ *
+ * Throws `EnvelopeError` with `code = "envelope_too_large"` if the resulting
+ * payload exceeds 16 MiB, or `code = "header_too_large"` if the JSON header
+ * exceeds the uint16 headerLen field.
+ */
+export function encodeFrame(opts: EncodeOptions): Buffer {
+  const version = opts.version ?? FRAME_VERSION_V03;
+  if (!KNOWN_FRAME_VERSIONS.has(version)) {
+    throw new EnvelopeError(
+      'UNSUPPORTED_FRAME_VERSION',
+      `unknown frame-version nibble 0x${version.toString(16)}`,
+      { nibble: version },
+    );
+  }
+  const headerJson = opts.headerJson;
+  const payload = opts.payload ?? Buffer.alloc(0);
+  const headerLen = headerJson.length;
+  if (headerLen > MAX_HEADER_LEN) {
+    throw new EnvelopeError(
+      'header_too_large',
+      `header bytes ${headerLen} exceed uint16 max ${MAX_HEADER_LEN}`,
+      { len: headerLen },
+    );
+  }
+  const payloadLen = HEADER_LEN_FIELD + headerLen + payload.length;
+  if (payloadLen > MAX_PAYLOAD_BYTES) {
+    throw new EnvelopeError(
+      'envelope_too_large',
+      `frame payload ${payloadLen} exceeds 16 MiB cap`,
+      { len: payloadLen },
+    );
+  }
+  // Pack version nibble into high 4 bits of totalLen.
+  const raw = ((version & 0x0f) << 28) | (payloadLen & 0x0fffffff);
+  const out = Buffer.allocUnsafe(PREFIX_LEN + payloadLen);
+  out.writeUInt32BE(raw >>> 0, 0);
+  out.writeUInt16BE(headerLen, PREFIX_LEN);
+  headerJson.copy(out, PREFIX_LEN + HEADER_LEN_FIELD);
+  if (payload.length > 0) {
+    payload.copy(out, PREFIX_LEN + HEADER_LEN_FIELD + headerLen);
+  }
+  return out;
+}
+
+/**
+ * Decode one full wire frame from `buf`. The caller is responsible for buffer
+ * accumulation across socket `data` events; this function expects `buf` to
+ * contain at least one complete frame starting at offset 0 and returns an
+ * error if it does not.
+ *
+ * Throws `EnvelopeError` on:
+ *   - truncated prefix / header / payload (`code = "truncated_frame"`)
+ *   - unknown version nibble (`code = "UNSUPPORTED_FRAME_VERSION"`)
+ *   - oversize payload (`code = "envelope_too_large"`)
+ *   - headerLen > remaining payload (`code = "corrupt_header_len"`)
+ */
+export function decodeFrame(buf: Buffer): DecodedFrame {
+  if (buf.length < PREFIX_LEN) {
+    throw new EnvelopeError('truncated_frame', 'buffer too short for 4-byte prefix');
+  }
+  const raw = buf.readUInt32BE(0);
+
+  // Step 1: extract nibble FIRST (spec §3.4.1.a step 2).
+  const nibble = (raw >>> 28) & 0x0f;
+  if (!KNOWN_FRAME_VERSIONS.has(nibble)) {
+    throw new EnvelopeError(
+      'UNSUPPORTED_FRAME_VERSION',
+      `unknown frame-version nibble 0x${nibble.toString(16)}`,
+      { nibble },
+    );
+  }
+
+  // Step 2: mask low 28 bits to compute payload length.
+  const payloadLen = raw & 0x0fffffff;
+
+  // Step 3: cap-check.
+  if (payloadLen > MAX_PAYLOAD_BYTES) {
+    throw new EnvelopeError(
+      'envelope_too_large',
+      `frame payload ${payloadLen} exceeds 16 MiB cap`,
+      { len: payloadLen },
+    );
+  }
+
+  // Step 4: ensure the buffer holds the full frame.
+  const totalNeeded = PREFIX_LEN + payloadLen;
+  if (buf.length < totalNeeded) {
+    throw new EnvelopeError(
+      'truncated_frame',
+      `buffer ${buf.length} bytes < expected ${totalNeeded}`,
+      { len: payloadLen },
+    );
+  }
+  if (payloadLen < HEADER_LEN_FIELD) {
+    throw new EnvelopeError(
+      'corrupt_header_len',
+      `payload ${payloadLen} bytes too small for headerLen field`,
+      { len: payloadLen },
+    );
+  }
+
+  // Step 5: split header / payload.
+  const headerLen = buf.readUInt16BE(PREFIX_LEN);
+  const headerStart = PREFIX_LEN + HEADER_LEN_FIELD;
+  const headerEnd = headerStart + headerLen;
+  if (headerEnd > totalNeeded) {
+    throw new EnvelopeError(
+      'corrupt_header_len',
+      `headerLen ${headerLen} overflows frame payload ${payloadLen}`,
+      { len: headerLen },
+    );
+  }
+
+  // Slice (zero-copy views over the input buffer).
+  const headerJson = buf.subarray(headerStart, headerEnd);
+  const payload = buf.subarray(headerEnd, totalNeeded);
+
+  return { version: nibble, headerJson, payload };
+}
+
+export const ENVELOPE_LIMITS = Object.freeze({
+  MAX_PAYLOAD_BYTES,
+  MAX_HEADER_LEN,
+  PREFIX_LEN,
+  HEADER_LEN_FIELD,
+  FRAME_VERSION_V03,
+});


### PR DESCRIPTION
## Summary

Implements **Task #966 [T5] L1**: `daemon/src/envelope/envelope.ts` — the v0.3 wire-frame encode/decode core.

Spec citations:
- `docs/superpowers/specs/v0.3-fragments/frag-3.4.1-envelope-hardening.md` §3.4.1.a (16 MiB cap + parse order CC-1) and §3.4.1.c (binary frame format `[totalLen:4][headerLen:2][headerJSON:headerLen][payloadBytes:totalLen-2-headerLen]`).

Key properties:
- **Frame-version nibble** in high 4 bits of `totalLen`; v0.3 = `0x0`. Unknown nibbles (e.g. `0x1` from a future v0.4 client) rejected with `UNSUPPORTED_FRAME_VERSION` **before** the length cap-check (spec §3.4.1.a round-3 security CC-1).
- **16 MiB hard cap** on per-frame payload length (`MAX_PAYLOAD_BYTES = 16 * 1024 * 1024`).
- **Header / trailer split** returned as zero-copy `Buffer.subarray` views over the input — keeps the hot PTY path allocation-free.
- **Single Responsibility**: pure encode/decode. Does NOT compute HMACs (T4 owns `hmac.ts`); does NOT validate header schemas (the adapter's TypeBox hook owns that, spec §3.4.1.d). Only splits bytes.
- Custom `EnvelopeError` class with `code` field carrying spec-canonical strings (`UNSUPPORTED_FRAME_VERSION`, `envelope_too_large`, `truncated_frame`, `corrupt_header_len`, `header_too_large`).

Vitest config now matches `daemon/src/**/__tests__/**/*.test.ts` (mirrors the existing `electron/**/__tests__/**` glob).

## Test plan

- [x] `npx vitest run daemon/src/envelope --no-coverage` — **11/11 pass** in 2.1s
- [x] `npx eslint daemon/src/envelope/` — clean
- [x] `npx tsc --noEmit -p daemon/tsconfig.json` — clean

Test cases (11):
1. round-trip JSON-only frame byte-equal
2. round-trip binary frame with header + trailer split
3. nibble correctly encoded in high 4 bits of `totalLen` prefix
4. reject >16 MiB payload via crafted prefix (decode side)
5. `encodeFrame` refuses to build oversize frame
6. reject unknown nibble `0x1` **BEFORE** length cap-check (asserts CC-1 parse order)
7. reject truncated frame (prefix says N bytes, buffer has fewer)
8. reject buffer too short for 4-byte prefix
9. reject `headerLen` that overflows declared payload (`corrupt_header_len`)
10. decoded views are zero-copy (mutate source → see through views)
11. exactly-at-cap 16 MiB boundary frame round-trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)