### PR TITLE
feat(daemon/db): T30 migration event contracts

### DIFF
--- a/daemon/src/db/__tests__/migration-events.test.ts
+++ b/daemon/src/db/__tests__/migration-events.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, expectTypeOf } from 'vitest';
+import {
+  MIGRATION_EVENT_NAMES,
+  MIGRATION_FAILURE_REASONS,
+  isMigrationCompleted,
+  isMigrationFailed,
+  isMigrationStarted,
+  type MigrationCompletedEvent,
+  type MigrationEvent,
+  type MigrationEventName,
+  type MigrationFailedEvent,
+  type MigrationFailureReason,
+  type MigrationStartedEvent,
+} from '../migration-events.js';
+
+// T30 contract tests — type-level + runtime narrowing only. No schema
+// runtime validator (frag-8 §8.6: closed in-process contract; envelope
+// validation is T12's job at the IPC boundary).
+
+describe('MIGRATION_EVENT_NAMES', () => {
+  it('exposes exactly the three event names locked by frag-8 §8.6', () => {
+    expect(Object.values(MIGRATION_EVENT_NAMES).sort()).toEqual([
+      'migration.completed',
+      'migration.failed',
+      'migration.started',
+    ]);
+  });
+
+  it('has no progress event (manager r9 lock removed it)', () => {
+    expect(Object.values(MIGRATION_EVENT_NAMES)).not.toContain('migration.progress');
+  });
+
+  it('union type MigrationEventName matches the constants', () => {
+    expectTypeOf<MigrationEventName>().toEqualTypeOf<
+      'migration.started' | 'migration.completed' | 'migration.failed'
+    >();
+  });
+});
+
+describe('MIGRATION_FAILURE_REASONS', () => {
+  it('contains every reason classified by §8.4–§8.6 emit sites', () => {
+    for (const r of [
+      'invalid_legacy_path',
+      'copy_failed',
+      'corrupt_legacy',
+      'finalize_failed',
+      'disk_full',
+      'permission_denied',
+      'user_skipped_after_disk_full',
+      'corrupt_skipped',
+    ] as const) {
+      expect(MIGRATION_FAILURE_REASONS).toContain(r);
+    }
+  });
+
+  it('reason union narrows from the readonly tuple', () => {
+    const r: MigrationFailureReason = 'corrupt_legacy';
+    expect(MIGRATION_FAILURE_REASONS).toContain(r);
+  });
+});
+
+describe('discriminated union narrowing', () => {
+  const started: MigrationStartedEvent = {
+    event: MIGRATION_EVENT_NAMES.started,
+    traceId: 't-1',
+    sourcePath: 'C:/Users/u/AppData/Roaming/CCSM/ccsm.db',
+    fromVersion: 1,
+    toVersion: 3,
+    startedAt: 1_700_000_000_000,
+  };
+  const completed: MigrationCompletedEvent = {
+    event: MIGRATION_EVENT_NAMES.completed,
+    traceId: 't-1',
+    fromVersion: 1,
+    toVersion: 3,
+    durationMs: 1234,
+    rowsConverted: 42,
+  };
+  const failed: MigrationFailedEvent = {
+    event: MIGRATION_EVENT_NAMES.failed,
+    traceId: 't-1',
+    fromVersion: 1,
+    toVersion: 3,
+    reason: 'corrupt_legacy',
+    errorMessage: 'database disk image is malformed',
+    errorCode: 'SQLITE_CORRUPT',
+  };
+
+  it('switch on .event narrows each branch to its concrete type', () => {
+    function describeEvent(e: MigrationEvent): string {
+      switch (e.event) {
+        case MIGRATION_EVENT_NAMES.started:
+          // Inside this branch the type is MigrationStartedEvent — sourcePath is required.
+          expectTypeOf(e).toEqualTypeOf<MigrationStartedEvent>();
+          return `started:${e.sourcePath}`;
+        case MIGRATION_EVENT_NAMES.completed:
+          expectTypeOf(e).toEqualTypeOf<MigrationCompletedEvent>();
+          return `completed:${e.rowsConverted}`;
+        case MIGRATION_EVENT_NAMES.failed:
+          expectTypeOf(e).toEqualTypeOf<MigrationFailedEvent>();
+          return `failed:${e.reason}`;
+      }
+    }
+
+    expect(describeEvent(started)).toBe('started:C:/Users/u/AppData/Roaming/CCSM/ccsm.db');
+    expect(describeEvent(completed)).toBe('completed:42');
+    expect(describeEvent(failed)).toBe('failed:corrupt_legacy');
+  });
+
+  it('type guards narrow the union', () => {
+    const events: MigrationEvent[] = [started, completed, failed];
+
+    const startedFiltered = events.filter(isMigrationStarted);
+    expect(startedFiltered).toHaveLength(1);
+    expect(startedFiltered[0]?.sourcePath).toBe(started.sourcePath);
+
+    const completedFiltered = events.filter(isMigrationCompleted);
+    expect(completedFiltered).toHaveLength(1);
+    expect(completedFiltered[0]?.rowsConverted).toBe(42);
+
+    const failedFiltered = events.filter(isMigrationFailed);
+    expect(failedFiltered).toHaveLength(1);
+    expect(failedFiltered[0]?.reason).toBe('corrupt_legacy');
+  });
+
+  it('failed event leaves errorCode optional', () => {
+    const minimal: MigrationFailedEvent = {
+      event: MIGRATION_EVENT_NAMES.failed,
+      traceId: 't-2',
+      fromVersion: 1,
+      toVersion: 3,
+      reason: 'invalid_legacy_path',
+      errorMessage: 'realpath outside allowlist',
+    };
+    expect(minimal.errorCode).toBeUndefined();
+    expect(isMigrationFailed(minimal)).toBe(true);
+  });
+});
+
+describe('event names round-trip with the schema constants', () => {
+  it('every event in the union carries one of the canonical names', () => {
+    const all: MigrationEvent[] = [
+      {
+        event: MIGRATION_EVENT_NAMES.started,
+        traceId: 'x',
+        sourcePath: '/x',
+        fromVersion: 1,
+        toVersion: 3,
+        startedAt: 0,
+      },
+      {
+        event: MIGRATION_EVENT_NAMES.completed,
+        traceId: 'x',
+        fromVersion: 1,
+        toVersion: 3,
+        durationMs: 0,
+        rowsConverted: 0,
+      },
+      {
+        event: MIGRATION_EVENT_NAMES.failed,
+        traceId: 'x',
+        fromVersion: 1,
+        toVersion: 3,
+        reason: 'finalize_failed',
+        errorMessage: 'rename EBUSY',
+        errorCode: 'EBUSY',
+      },
+    ];
+    for (const e of all) {
+      expect(Object.values(MIGRATION_EVENT_NAMES)).toContain(e.event);
+    }
+  });
+});

--- a/daemon/src/db/migration-events.ts
+++ b/daemon/src/db/migration-events.ts
@@ -1,0 +1,151 @@
+// T30: migration event contracts (frag-8 §8.5, §8.6).
+//
+// SCHEMAS ONLY — this file declares the discriminated union of events
+// emitted by the migration runner (T29) and consumed by the in-progress
+// modal driver (T33). NO emitter, NO consumer, NO side effects live
+// here. Single Responsibility producer/decider/sink: this is the wire
+// contract that producer (T29) and sink (T33) both compile against.
+//
+// Library choice: pure TypeScript discriminated union, no TypeBox / zod.
+// Rationale:
+//   - Spec frag-8 §8.6 (manager r9 lock) defines exactly THREE events:
+//     started, completed, failed. No `progress` event — the in-progress
+//     modal is an indeterminate spinner driven by start/complete/failed
+//     transitions only. Closed contract surface, not a wire schema that
+//     needs runtime validation against untrusted input.
+//   - Both producer (T29 daemon) and consumer (T33 renderer) are inside
+//     the trust boundary; the IPC adapter (frag-3.4.1, T12) will run
+//     TypeBox `Check()` on the *envelope*, so payload structure is
+//     already gated upstream once T12 lands.
+//   - daemon/package.json carries no schema lib yet; adding TypeBox
+//     here would be the first non-test dep and is better introduced
+//     systematically in T12 alongside the envelope contracts. This
+//     module can migrate to TypeBox without touching call sites by
+//     deriving the same types via `Static<typeof Schema>`.
+//
+// Failure reasons enumerated from frag-8 §8.4–§8.6 emit sites
+// (`MigrationFailedEvent({reason: ...})`).
+
+/** Canonical event names, used as the discriminator on `event`. */
+export const MIGRATION_EVENT_NAMES = {
+  started: 'migration.started',
+  completed: 'migration.completed',
+  failed: 'migration.failed',
+} as const;
+
+export type MigrationEventName =
+  (typeof MIGRATION_EVENT_NAMES)[keyof typeof MIGRATION_EVENT_NAMES];
+
+/**
+ * Failure reason codes emitted by the migration runner.
+ *
+ * Source: frag-8 §8.4 (`invalid_legacy_path`), §8.5 S3 (`copy_failed`
+ * and OS-classified subtypes), §8.5 S4 (`corrupt_legacy`), §8.5 S6
+ * (`finalize_failed`), §8.3 step 1a (`user_skipped_after_disk_full`,
+ * `corrupt_skipped`).
+ */
+export const MIGRATION_FAILURE_REASONS = [
+  'invalid_legacy_path',
+  'copy_failed',
+  'corrupt_legacy',
+  'finalize_failed',
+  'disk_full',
+  'permission_denied',
+  'user_skipped_after_disk_full',
+  'corrupt_skipped',
+] as const;
+
+export type MigrationFailureReason = (typeof MIGRATION_FAILURE_REASONS)[number];
+
+/**
+ * Migration started — emitted at S3 START in §8.5.
+ *
+ * Carries enough context for the modal to render an initial line and
+ * for support post-mortem to correlate against the daemon log
+ * (`traceId` chains every subsequent `migration_*` log line).
+ */
+export interface MigrationStartedEvent {
+  readonly event: typeof MIGRATION_EVENT_NAMES.started;
+  readonly traceId: string;
+  /** Resolved legacy ccsm.db path (frag-8 §8.5 S1). */
+  readonly sourcePath: string;
+  /** Source schema version (PRAGMA user_version on legacy db, e.g. 1). */
+  readonly fromVersion: number;
+  /** Target schema version (e.g. 3 for v0.3). */
+  readonly toVersion: number;
+  /** Daemon wall-clock ms when migration started. */
+  readonly startedAt: number;
+}
+
+/**
+ * Migration completed — emitted at the end of §8.5 S8 just before the
+ * state file is stamped `reason='migrated'`.
+ */
+export interface MigrationCompletedEvent {
+  readonly event: typeof MIGRATION_EVENT_NAMES.completed;
+  readonly traceId: string;
+  readonly fromVersion: number;
+  readonly toVersion: number;
+  /** Wall-clock duration since the started event. */
+  readonly durationMs: number;
+  /**
+   * Total rows copied from legacy db. The legacy schema is
+   * `app_state(key, value, updated_at)` so this is the count of
+   * key/value rows preserved.
+   */
+  readonly rowsConverted: number;
+}
+
+/**
+ * Migration failed — single event class per §8.6; renderer dispatches
+ * to a single fatal-error modal (`migration.modal.failed.*` i18n
+ * namespace). `reason` is the classified code; `errorMessage` and
+ * `errorCode` carry the raw OS / SQLite detail for support tooling.
+ */
+export interface MigrationFailedEvent {
+  readonly event: typeof MIGRATION_EVENT_NAMES.failed;
+  readonly traceId: string;
+  readonly fromVersion: number;
+  readonly toVersion: number;
+  readonly reason: MigrationFailureReason;
+  /** Raw error message (already user-safe per §8.6 — no PII). */
+  readonly errorMessage: string;
+  /** OS / SQLite errno or short code, when available (e.g. 'ENOSPC'). */
+  readonly errorCode?: string;
+}
+
+/**
+ * Discriminated union over the three migration events. Switch on
+ * `event` to narrow:
+ *
+ * ```ts
+ * function handle(e: MigrationEvent) {
+ *   switch (e.event) {
+ *     case MIGRATION_EVENT_NAMES.started:   // e: MigrationStartedEvent
+ *     case MIGRATION_EVENT_NAMES.completed: // e: MigrationCompletedEvent
+ *     case MIGRATION_EVENT_NAMES.failed:    // e: MigrationFailedEvent
+ *   }
+ * }
+ * ```
+ */
+export type MigrationEvent =
+  | MigrationStartedEvent
+  | MigrationCompletedEvent
+  | MigrationFailedEvent;
+
+/**
+ * Type guard helpers — useful for consumers (T33) that subscribe to a
+ * single event name and want to narrow without an exhaustive switch.
+ * Pure structural checks; no runtime schema validation.
+ */
+export function isMigrationStarted(e: MigrationEvent): e is MigrationStartedEvent {
+  return e.event === MIGRATION_EVENT_NAMES.started;
+}
+
+export function isMigrationCompleted(e: MigrationEvent): e is MigrationCompletedEvent {
+  return e.event === MIGRATION_EVENT_NAMES.completed;
+}
+
+export function isMigrationFailed(e: MigrationEvent): e is MigrationFailedEvent {
+  return e.event === MIGRATION_EVENT_NAMES.failed;
+}


### PR DESCRIPTION
## Summary

Task #987 [T30] — wire-contract module that the v0.2 -> v0.3 migration runner (T29) emits and the in-progress modal driver (T33) consumes.

- **Schemas only** — no emitter, no consumer, no side effects. Single Responsibility: T29 imports for emission, T33 imports for consumption.
- **Three events** per frag-8 §8.6 (manager r9 lock):
  - `migration.started` — `{ traceId, sourcePath, fromVersion, toVersion, startedAt }`
  - `migration.completed` — `{ traceId, fromVersion, toVersion, durationMs, rowsConverted }`
  - `migration.failed` — `{ traceId, fromVersion, toVersion, reason, errorMessage, errorCode? }`
- **No `migration.progress` event.** The priority-100 in-progress modal is an indeterminate spinner driven by start/complete/failed transitions only (frag-8 §8.6 manager r9 lock removed `MigrationProgressEvent` in favor of indeterminate UX + daemon-log-only progress observability via `.backup()` callback). The task brief mentioned a progress event as optional; the spec lock makes it explicit-out, so it is omitted with that justification documented in the file header.
- **Failure reason enum** covers all six classified codes from §8.4–§8.6 emit sites (`invalid_legacy_path`, `copy_failed`, `corrupt_legacy`, `finalize_failed`) plus the §8.3 step-1a recovery codes (`disk_full`, `permission_denied`, `user_skipped_after_disk_full`, `corrupt_skipped`).
- **Library: pure TypeScript discriminated union**, not TypeBox / zod. Rationale documented in-file:
  - Closed in-process contract; both producer (daemon) and consumer (renderer) inside the trust boundary.
  - The IPC envelope will get TypeBox `Check()` upstream when T12 lands (frag-3.4.1 / §3.1.1) — payload structure gated there.
  - `daemon/package.json` has no schema lib yet; introducing TypeBox systematically with the envelope work in T12 is cleaner than adding it ad-hoc here. Module can migrate to `Static<typeof Schema>` without touching call sites.
- **Type guards** exported for consumers that subscribe to a single event name and want to narrow without an exhaustive switch.

## Test plan

- [x] `npx vitest run daemon/src/db/__tests__/migration-events.test.ts --no-coverage` — 9 passed
- [x] `npx eslint daemon/src/db/migration-events.ts daemon/src/db/__tests__/migration-events.test.ts` — clean
- [x] `npx tsc --noEmit -p daemon/tsconfig.json` — clean
- [x] `npx tsc --noEmit` (root, picks up the test file too) — clean
- [ ] Reviewer to confirm event payload shape matches T29 emit sites once T29 PR lands; wire-up review covered by T33 PR.

Test coverage:
1. `MIGRATION_EVENT_NAMES` exposes exactly the three locked names; no `migration.progress`.
2. `MigrationEventName` union matches the constants (type-level).
3. `MIGRATION_FAILURE_REASONS` contains every classified reason from §8.4–§8.6.
4. `MigrationFailureReason` narrows from the readonly tuple.
5. Switch on `.event` narrows to each concrete payload type (compile + runtime).
6. `isMigrationStarted` / `isMigrationCompleted` / `isMigrationFailed` type guards narrow correctly.
7. `errorCode` on `MigrationFailedEvent` is optional.
8. Every event in the union carries one of the canonical names (round-trip).

Note: `daemon/src/db/schema/__tests__/v0.3.test.ts` (T28) is unaffected by this PR; the local probe of those tests fails on this worktree only because `npm install --ignore-scripts` was used after `git clean -fdx` and `better-sqlite3` was not rebuilt. CI will rebuild natives normally.