### PR TITLE
feat(daemon/envelope): T6 chunk reassembly (16KiB sub-frames + 256KiB replay)

### DIFF
--- a/daemon/src/envelope/__tests__/chunk-reassembly.test.ts
+++ b/daemon/src/envelope/__tests__/chunk-reassembly.test.ts
@@ -1,0 +1,220 @@
+import { Buffer } from 'node:buffer';
+import { describe, expect, it } from 'vitest';
+
+import {
+  CHUNK_LIMITS,
+  ChunkReassembler,
+  MAX_REPLAY_BYTES,
+  MAX_SUBFRAME_BYTES,
+  acceptChunk,
+} from '../chunk-reassembly.js';
+
+const buf = (size: number, fill = 0xab): Buffer => Buffer.alloc(size, fill);
+
+describe('ChunkReassembler.accept (round-trip)', () => {
+  it('1 chunk = 1 message when final flag set on the first frame', () => {
+    const r = new ChunkReassembler();
+    const payload = Buffer.from('hello world', 'utf8');
+    const result = r.accept({ streamId: 's1', seq: 0, final: true }, payload);
+    expect(result.error).toBeUndefined();
+    expect(result.complete).toBe(true);
+    expect(result.message?.toString('utf8')).toBe('hello world');
+  });
+
+  it('reassembles 4 ordered chunks into one message byte-equal', () => {
+    const r = new ChunkReassembler();
+    const parts = ['alpha-', 'beta-', 'gamma-', 'delta'].map((s) => Buffer.from(s, 'utf8'));
+    let last;
+    for (let i = 0; i < parts.length; i += 1) {
+      const final = i === parts.length - 1;
+      const part = parts[i];
+      if (part === undefined) throw new Error('test bug');
+      last = r.accept({ streamId: 's2', seq: i, final }, part);
+      expect(last.error).toBeUndefined();
+      expect(last.complete).toBe(final);
+    }
+    expect(last?.message?.toString('utf8')).toBe('alpha-beta-gamma-delta');
+  });
+
+  it('reassembles two back-to-back logical messages on the same stream', () => {
+    const r = new ChunkReassembler();
+    // Message 1: seq 0, 1 (final)
+    expect(r.accept({ streamId: 's3', seq: 0 }, Buffer.from('a')).complete).toBe(false);
+    const m1 = r.accept({ streamId: 's3', seq: 1, final: true }, Buffer.from('b'));
+    expect(m1.complete).toBe(true);
+    expect(m1.message?.toString()).toBe('ab');
+    // Message 2: seq 2, 3 (final). pending must have been cleared.
+    expect(r.accept({ streamId: 's3', seq: 2 }, Buffer.from('c')).complete).toBe(false);
+    const m2 = r.accept({ streamId: 's3', seq: 3, final: true }, Buffer.from('d'));
+    expect(m2.complete).toBe(true);
+    expect(m2.message?.toString()).toBe('cd');
+  });
+});
+
+describe('ChunkReassembler.accept (rejections)', () => {
+  it('rejects sub-frame larger than 16 KiB', () => {
+    const r = new ChunkReassembler();
+    const oversized = buf(MAX_SUBFRAME_BYTES + 1);
+    const result = r.accept({ streamId: 's4', seq: 0 }, oversized);
+    expect(result.complete).toBe(false);
+    expect(result.error).toMatch(/exceeds 16384/);
+    // State unchanged — next legit accept on seq 0 still works.
+    const ok = r.accept({ streamId: 's4', seq: 0, final: true }, Buffer.from('ok'));
+    expect(ok.complete).toBe(true);
+    expect(ok.message?.toString()).toBe('ok');
+  });
+
+  it('accepts exactly 16 KiB (boundary)', () => {
+    const r = new ChunkReassembler();
+    const at = buf(MAX_SUBFRAME_BYTES);
+    const result = r.accept({ streamId: 's5', seq: 0, final: true }, at);
+    expect(result.error).toBeUndefined();
+    expect(result.complete).toBe(true);
+    expect(result.message?.length).toBe(MAX_SUBFRAME_BYTES);
+  });
+
+  it('rejects seq jump (1, 3 instead of 1, 2)', () => {
+    const r = new ChunkReassembler();
+    expect(r.accept({ streamId: 's6', seq: 0 }, Buffer.from('a')).error).toBeUndefined();
+    expect(r.accept({ streamId: 's6', seq: 1 }, Buffer.from('b')).error).toBeUndefined();
+    const jumped = r.accept({ streamId: 's6', seq: 3 }, Buffer.from('d'));
+    expect(jumped.error).toMatch(/seq out of order: expected 2 got 3/);
+    // lastSeq unchanged after rejection.
+    expect(r.getLastSeq('s6')).toBe(1);
+  });
+
+  it('rejects duplicate seq (1, 1)', () => {
+    const r = new ChunkReassembler();
+    expect(r.accept({ streamId: 's7', seq: 0 }, Buffer.from('a')).error).toBeUndefined();
+    expect(r.accept({ streamId: 's7', seq: 1 }, Buffer.from('b')).error).toBeUndefined();
+    const dup = r.accept({ streamId: 's7', seq: 1 }, Buffer.from('b2'));
+    expect(dup.error).toMatch(/seq out of order: expected 2 got 1/);
+  });
+
+  it('first frame on a fresh stream must be seq 0', () => {
+    const r = new ChunkReassembler();
+    const wrong = r.accept({ streamId: 's8', seq: 5 }, Buffer.from('x'));
+    expect(wrong.error).toMatch(/first frame on streamId=s8 must be seq 0/);
+  });
+
+  it('rejects negative or non-integer seq', () => {
+    const r = new ChunkReassembler();
+    const neg = r.accept({ streamId: 's9', seq: -1 }, Buffer.from('x'));
+    expect(neg.error).toMatch(/first frame on streamId=s9 must be seq 0/);
+  });
+
+  it('rejects mismatched streamId at the pure-function layer', () => {
+    // Direct acceptChunk call; the class wrapper guarantees match by lookup.
+    const state = {
+      streamId: 's10',
+      lastSeq: -1,
+      pending: [] as Buffer[],
+      replayBytes: 0,
+      replay: [] as { seq: number; payload: Buffer }[],
+    };
+    const result = acceptChunk(state, { streamId: 'OTHER', seq: 0 }, Buffer.from('x'));
+    expect(result.error).toMatch(/streamId mismatch/);
+  });
+});
+
+describe('ChunkReassembler replay buffer (256 KiB cap)', () => {
+  it('retains chunks under the cap', () => {
+    const r = new ChunkReassembler();
+    // 4 KiB × 4 = 16 KiB, well under 256 KiB.
+    for (let i = 0; i < 4; i += 1) {
+      r.accept({ streamId: 'sR1', seq: i }, buf(4 * 1024, i));
+    }
+    expect(r.getReplayBytes('sR1')).toBe(16 * 1024);
+    expect(r.getReplayWindow('sR1').length).toBe(4);
+  });
+
+  it('evicts oldest entries FIFO when total exceeds 256 KiB', () => {
+    const r = new ChunkReassembler();
+    const chunkSize = MAX_SUBFRAME_BYTES; // 16 KiB
+    // 256 KiB / 16 KiB = 16 entries fit exactly.
+    const fits = MAX_REPLAY_BYTES / chunkSize; // 16
+    // Push 20 chunks; 4 oldest must be evicted, newest 16 remain.
+    for (let i = 0; i < fits + 4; i += 1) {
+      const r1 = r.accept({ streamId: 'sR2', seq: i }, buf(chunkSize, i & 0xff));
+      expect(r1.error).toBeUndefined();
+    }
+    expect(r.getReplayBytes('sR2')).toBeLessThanOrEqual(MAX_REPLAY_BYTES);
+    const window = r.getReplayWindow('sR2');
+    expect(window.length).toBe(fits);
+    // Oldest retained seq is 4 (we evicted 0,1,2,3); newest is 19.
+    expect(window[0]?.seq).toBe(4);
+    expect(window[window.length - 1]?.seq).toBe(fits + 3);
+  });
+
+  it('replay-buffer eviction does not break in-progress reassembly', () => {
+    // The pending[] for the in-flight logical message is independent of the
+    // replay buffer's eviction — losing a chunk from the replay window
+    // (used only for resubscribe) must not corrupt the message we're still
+    // assembling. Push enough chunks to evict early ones, then close with
+    // final on a later seq and assert the assembled message contains every
+    // pushed byte in order.
+    const r = new ChunkReassembler();
+    const chunkSize = MAX_SUBFRAME_BYTES;
+    const total = (MAX_REPLAY_BYTES / chunkSize) + 4; // 20
+    let totalBytes = 0;
+    for (let i = 0; i < total; i += 1) {
+      const isFinal = i === total - 1;
+      const result = r.accept({ streamId: 'sR3', seq: i, final: isFinal }, buf(chunkSize, i & 0xff));
+      expect(result.error).toBeUndefined();
+      totalBytes += chunkSize;
+      if (isFinal) {
+        expect(result.complete).toBe(true);
+        expect(result.message?.length).toBe(totalBytes);
+      }
+    }
+  });
+});
+
+describe('ChunkReassembler.getReplayWindow', () => {
+  it('returns ordered chunks (oldest → newest) with seq + payload', () => {
+    const r = new ChunkReassembler();
+    const payloads = [Buffer.from('aa'), Buffer.from('bbb'), Buffer.from('cccc')];
+    payloads.forEach((p, i) => {
+      r.accept({ streamId: 'sW1', seq: i }, p);
+    });
+    const window = r.getReplayWindow('sW1');
+    expect(window.map((e) => e.seq)).toEqual([0, 1, 2]);
+    expect(window.map((e) => e.payload.toString('utf8'))).toEqual(['aa', 'bbb', 'cccc']);
+  });
+
+  it('returns an empty array for an unknown stream', () => {
+    const r = new ChunkReassembler();
+    expect(r.getReplayWindow('nope')).toEqual([]);
+    expect(r.getReplayBytes('nope')).toBe(0);
+    expect(r.getLastSeq('nope')).toBe(-1);
+  });
+
+  it('returned array is a copy (mutating it does not affect internal state)', () => {
+    const r = new ChunkReassembler();
+    r.accept({ streamId: 'sW2', seq: 0 }, Buffer.from('x'));
+    const window = r.getReplayWindow('sW2');
+    window.length = 0;
+    expect(r.getReplayWindow('sW2').length).toBe(1);
+  });
+});
+
+describe('ChunkReassembler.forget', () => {
+  it('drops state so a new stream with the same id can start at seq 0', () => {
+    const r = new ChunkReassembler();
+    r.accept({ streamId: 'sF1', seq: 0 }, Buffer.from('x'));
+    r.accept({ streamId: 'sF1', seq: 1, final: true }, Buffer.from('y'));
+    r.forget('sF1');
+    expect(r.getLastSeq('sF1')).toBe(-1);
+    const ok = r.accept({ streamId: 'sF1', seq: 0, final: true }, Buffer.from('z'));
+    expect(ok.complete).toBe(true);
+    expect(ok.message?.toString()).toBe('z');
+  });
+});
+
+describe('CHUNK_LIMITS', () => {
+  it('exposes the spec-mandated caps as a frozen object', () => {
+    expect(CHUNK_LIMITS.MAX_SUBFRAME_BYTES).toBe(16 * 1024);
+    expect(CHUNK_LIMITS.MAX_REPLAY_BYTES).toBe(256 * 1024);
+    expect(Object.isFrozen(CHUNK_LIMITS)).toBe(true);
+  });
+});

--- a/daemon/src/envelope/chunk-reassembly.ts
+++ b/daemon/src/envelope/chunk-reassembly.ts
@@ -1,0 +1,230 @@
+// Chunk reassembly for stream sub-frames (spec §3.4.1.b).
+//
+// The wire layer chunks any stream-message payload larger than 16 KiB into
+// N ≤16 KiB sub-frames sharing the same `streamId` and a per-stream monotonic
+// `seq`. Receivers reassemble the original logical message by `streamId`. This
+// module is the pure state machine for that reassembly: it owns sequence
+// validation, the bounded replay buffer used for resubscribe support, and the
+// final-flag-driven message materialization. It does NOT touch sockets, HMACs,
+// or the envelope encode/decode path (`envelope.ts` owns that).
+//
+// Key invariants enforced (spec §3.4.1.b + Task 5 step-4 chunking bullet):
+//   1. Sub-frame payload is ≤ MAX_SUBFRAME_BYTES (16 KiB). Larger payloads are
+//      a producer bug; reject so the bug is loud, not silent corruption.
+//   2. `seq` is strictly monotonically increasing per stream, starting at 0
+//      (or whatever `firstSeq` was passed at construction). No jumps, no
+//      duplicates, no out-of-order delivery — the underlying socket is
+//      byte-serialized FIFO so any gap signals corruption or a missed frame.
+//   3. The replay buffer is bounded at MAX_REPLAY_BYTES (256 KiB total bytes
+//      across retained chunk payloads). When a new chunk would push the total
+//      over the cap, the OLDEST retained chunks are evicted FIFO until the
+//      budget fits. A consumer requesting a `fromSeq` older than the oldest
+//      retained chunk is the trigger for the daemon to emit `gap: true` +
+//      snapshot (that policy lives in the adapter; here we only expose the
+//      window via `getReplayWindow`).
+//
+// This module deliberately does NOT validate `kind` against the spec enum
+// (`"open" | "chunk" | "close" | "heartbeat"`); kind discrimination is the
+// adapter's job (heartbeats don't carry payload, opens carry no chunk seq).
+// We only see `chunk`-kind sub-frames and the `final` flag that closes a
+// logical message. `final` is the API surface the task description asks for;
+// at the wire level it is implied when the next frame on `streamId` is the
+// `kind: "close"` frame OR when the producer flushes a logical message
+// boundary. Either way the adapter sets `final: true` on the last sub-frame
+// of a logical message before handing to this reassembler.
+
+import { Buffer } from 'node:buffer';
+
+/** ≤16 KiB per sub-frame payload — spec §3.4.1.b. */
+export const MAX_SUBFRAME_BYTES = 16 * 1024;
+
+/** ≤256 KiB total replay-buffer bytes per stream — spec §3.4.1.b replay bound. */
+export const MAX_REPLAY_BYTES = 256 * 1024;
+
+/**
+ * One retained sub-frame in the replay buffer. The original `payload` is held
+ * by reference (zero-copy); callers MUST treat it as immutable.
+ */
+export interface ReplayEntry {
+  readonly seq: number;
+  readonly payload: Buffer;
+}
+
+/** Header fields the reassembler reads off each incoming sub-frame. */
+export interface ChunkHeader {
+  readonly streamId: string;
+  readonly seq: number;
+  /** True on the last sub-frame of a logical message. */
+  readonly final?: boolean;
+}
+
+/**
+ * Per-stream reassembly state. Constructed lazily on first sub-frame for a
+ * `streamId`. `lastSeq` starts at -1 so the first accepted seq is 0 (matches
+ * spec wording "per-stream monotonic seq" without baking in a 1-based
+ * convention).
+ */
+export interface StreamState {
+  readonly streamId: string;
+  /** Highest `seq` accepted on this stream, or -1 if none yet. */
+  lastSeq: number;
+  /** Sub-frames held for the in-progress logical message (cleared on `final`). */
+  pending: Buffer[];
+  /** Total bytes currently held in `replay` (sum of `replay[i].payload.length`). */
+  replayBytes: number;
+  /** FIFO replay buffer for resubscribe support; evicted oldest-first at cap. */
+  replay: ReplayEntry[];
+}
+
+/**
+ * Result of `acceptChunk`. Exactly one of `error` or (optionally) `message`
+ * is meaningful per call:
+ *   - `error` set → the sub-frame was rejected; stream state is UNCHANGED.
+ *   - `complete: true` + `message` set → `final` flag closed a logical
+ *      message; `message` is the concatenated payload bytes.
+ *   - `complete: false` → sub-frame accepted into pending; no message yet.
+ */
+export interface AcceptResult {
+  readonly complete: boolean;
+  readonly message?: Buffer;
+  readonly error?: string;
+}
+
+const newState = (streamId: string): StreamState => ({
+  streamId,
+  lastSeq: -1,
+  pending: [],
+  replayBytes: 0,
+  replay: [],
+});
+
+/**
+ * Pure (state-mutating) accept of one sub-frame. Returns success/error result
+ * without throwing — the adapter classifies `error` strings into the right
+ * wire-level RPC error code (`RESOURCE_EXHAUSTED`, `seq_jump`, etc.).
+ *
+ * Errors leave `state` UNCHANGED so a recoverable adapter could reject the
+ * frame, log, and keep the stream open if the policy ever changes. Today's
+ * policy (per spec §3.4.1.a oversize handling) is to log + destroy the socket;
+ * we keep the no-mutate-on-error contract anyway because it makes unit tests
+ * deterministic.
+ */
+export function acceptChunk(
+  state: StreamState,
+  header: ChunkHeader,
+  payload: Buffer,
+): AcceptResult {
+  if (header.streamId !== state.streamId) {
+    return { complete: false, error: `streamId mismatch: state=${state.streamId} header=${header.streamId}` };
+  }
+  if (payload.length > MAX_SUBFRAME_BYTES) {
+    return {
+      complete: false,
+      error: `sub-frame payload ${payload.length} exceeds ${MAX_SUBFRAME_BYTES}`,
+    };
+  }
+  if (!Number.isInteger(header.seq) || header.seq < 0) {
+    return { complete: false, error: `invalid seq ${String(header.seq)}` };
+  }
+  const expected = state.lastSeq + 1;
+  if (header.seq !== expected) {
+    return {
+      complete: false,
+      error: `seq out of order: expected ${expected} got ${header.seq}`,
+    };
+  }
+
+  // Accept: append to pending + replay; advance lastSeq.
+  state.pending.push(payload);
+  state.lastSeq = header.seq;
+  state.replay.push({ seq: header.seq, payload });
+  state.replayBytes += payload.length;
+
+  // Evict oldest replay entries until we fit under the cap. Per spec the
+  // adapter is what emits `gap: true` when a consumer asks for a seq older
+  // than what survived eviction; here we just hold the bound.
+  while (state.replayBytes > MAX_REPLAY_BYTES && state.replay.length > 0) {
+    const dropped = state.replay.shift();
+    if (dropped === undefined) break;
+    state.replayBytes -= dropped.payload.length;
+  }
+
+  if (header.final === true) {
+    const assembled = Buffer.concat(state.pending);
+    state.pending = [];
+    return { complete: true, message: assembled };
+  }
+  return { complete: false };
+}
+
+/**
+ * `ChunkReassembler` is a thin convenience wrapper over the pure functions
+ * for the common adapter use-case where a single instance owns many streams
+ * keyed by `streamId`. Adapters that prefer to manage their own per-stream
+ * `StreamState` map (e.g. for sharded locking) can skip the class entirely
+ * and call `acceptChunk` directly.
+ */
+export class ChunkReassembler {
+  private readonly streams = new Map<string, StreamState>();
+
+  /**
+   * Reset / discard a stream's state — called on `kind: "close"`, on a
+   * fatal error, or when the supervisor notifies us the producer is gone.
+   */
+  forget(streamId: string): void {
+    this.streams.delete(streamId);
+  }
+
+  /**
+   * Accept one sub-frame. Allocates the per-stream state lazily on the first
+   * frame we see for a streamId.
+   */
+  accept(header: ChunkHeader, payload: Buffer): AcceptResult {
+    let state = this.streams.get(header.streamId);
+    if (state === undefined) {
+      // First frame on this stream MUST be seq 0; reject jumps at open too,
+      // not just mid-stream, so resubscribe-from-mid-seq is an explicit
+      // adapter-level operation (it loads a snapshot first, then issues a
+      // fresh subscribe at seq 0).
+      if (header.seq !== 0) {
+        return {
+          complete: false,
+          error: `first frame on streamId=${header.streamId} must be seq 0, got ${header.seq}`,
+        };
+      }
+      state = newState(header.streamId);
+      this.streams.set(header.streamId, state);
+    }
+    return acceptChunk(state, header, payload);
+  }
+
+  /**
+   * Snapshot of the current replay buffer for `streamId`, ordered oldest →
+   * newest. Returns an empty array if the stream is unknown. The returned
+   * array is a fresh copy; mutating it does not affect internal state.
+   * Buffer payloads are NOT copied (zero-copy view by reference).
+   */
+  getReplayWindow(streamId: string): ReplayEntry[] {
+    const state = this.streams.get(streamId);
+    if (state === undefined) return [];
+    return state.replay.slice();
+  }
+
+  /**
+   * Total replay bytes currently held for `streamId`. Useful for tests + the
+   * adapter's `gap: true` decision when a `fromSeq` request arrives.
+   */
+  getReplayBytes(streamId: string): number {
+    return this.streams.get(streamId)?.replayBytes ?? 0;
+  }
+
+  /** Highest seq accepted on `streamId`, or -1 if unknown. */
+  getLastSeq(streamId: string): number {
+    return this.streams.get(streamId)?.lastSeq ?? -1;
+  }
+}
+
+export const CHUNK_LIMITS = Object.freeze({
+  MAX_SUBFRAME_BYTES,
+  MAX_REPLAY_BYTES,
+});


### PR DESCRIPTION
## Summary

Task #962 [T6] — pure state machine for stream sub-frame reassembly per spec
§3.4.1.b. Builds on T5's wire-frame primitives (envelope.ts) and gives the
v0.3 Connect adapter a deterministic, tested place to reassemble chunked
stream payloads.

- `daemon/src/envelope/chunk-reassembly.ts` — `ChunkReassembler` class +
  pure `acceptChunk` function + `StreamState` interface. No I/O, no socket,
  no HMAC — single responsibility per
  `feedback_single_responsibility`.
- Constants: `MAX_SUBFRAME_BYTES = 16 * 1024`, `MAX_REPLAY_BYTES = 256 * 1024`.
- Per-stream state: `{ streamId, lastSeq, pending[], replay[], replayBytes }`.
- API:
  - `accept(header, payload)` — validates streamId, payload size, monotonic
    seq; appends to pending + replay; returns assembled message on `final`.
  - `getReplayWindow(streamId)` — ordered (oldest→newest) `ReplayEntry[]`
    for resubscribe support; the adapter compares `fromSeq` against the
    oldest retained seq to decide `gap: true`.
  - `getReplayBytes` / `getLastSeq` / `forget` helpers.
- Replay buffer is FIFO-evicted at the 256 KiB cap; in-progress reassembly
  (`pending[]`) is independent of replay eviction so losing a replay-window
  entry never corrupts the message currently being assembled.

## Spec citations

- §3.4.1.b chunking rule (≤16 KiB sub-frames, per-stream monotonic seq,
  receiver re-assembles by streamId).
- §3.4.1.b replay bound (≤256 KiB before `gap: true`); the adapter owns
  the `gap: true` emission, this module owns the bound.
- Task 5 step-4 chunking bullet: "Replay bound: ≤256 KiB before gap: true.
  Receiver-side reassembly helper in testHelpers.ts."

## Tests (60 pass — all envelope suites green)

`daemon/src/envelope/__tests__/chunk-reassembly.test.ts`:

- Round-trip 1 chunk = 1 message (final on first frame).
- Round-trip 4 ordered chunks reassemble byte-equal.
- Two back-to-back logical messages on the same stream (pending cleared on final).
- Reject sub-frame > 16 KiB (state unchanged after rejection).
- Accept exactly 16 KiB (boundary).
- Reject seq jump (1, 3 instead of 1, 2); lastSeq unchanged.
- Reject duplicate seq (1, 1).
- First frame on a fresh stream must be seq 0.
- Reject negative seq.
- streamId mismatch at the pure-function layer.
- Replay buffer retains chunks under the cap.
- Replay buffer FIFO-evicts oldest entries when total exceeds 256 KiB
  (push 20 × 16 KiB → newest 16 retained, oldest 4 dropped).
- Replay eviction does not break in-progress reassembly.
- `getReplayWindow` returns ordered chunks; copy semantics; empty for unknown stream.
- `forget` lets a new stream with the same id restart at seq 0.
- `CHUNK_LIMITS` frozen, correct values.

## Test plan

- [x] `npx vitest run daemon/src/envelope --no-coverage` — 60/60 pass
- [x] `npx eslint daemon/src/envelope/` — clean
- [x] `npx tsc --noEmit -p daemon/tsconfig.json` — clean

T7 will wire this into `connectAdapter.ts` (chunk-on-emit + reassemble-on-recv).