### PR TITLE
feat(daemon/envelope): T10 migrationGate

### DIFF
--- a/daemon/src/envelope/__tests__/migration-gate-interceptor.test.ts
+++ b/daemon/src/envelope/__tests__/migration-gate-interceptor.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { checkMigrationGate } from '../migration-gate-interceptor.js';
+import { SUPERVISOR_RPCS } from '../supervisor-rpcs.js';
+
+describe('checkMigrationGate (spec §3.4.1.f)', () => {
+  describe('migrationPending = false (fast path)', () => {
+    it.each([...SUPERVISOR_RPCS])(
+      'allows supervisor RPC %s when no migration is pending',
+      (rpcName) => {
+        expect(checkMigrationGate({ rpcName, migrationPending: false })).toEqual({
+          allowed: true,
+        });
+      },
+    );
+
+    it.each([
+      'ccsm.v1/session.subscribe',
+      'ccsm.v1/session.send',
+      'ccsm.v1/pty.write',
+      'daemon.foo',
+      '',
+    ])('allows data-plane RPC %j when no migration is pending', (rpcName) => {
+      expect(checkMigrationGate({ rpcName, migrationPending: false })).toEqual({
+        allowed: true,
+      });
+    });
+  });
+
+  describe('migrationPending = true (gate engaged)', () => {
+    it.each([...SUPERVISOR_RPCS])(
+      'allows supervisor RPC %s during migration (carve-out)',
+      (rpcName) => {
+        expect(checkMigrationGate({ rpcName, migrationPending: true })).toEqual({
+          allowed: true,
+        });
+      },
+    );
+
+    it.each([
+      'ccsm.v1/session.subscribe',
+      'ccsm.v1/session.send',
+      'ccsm.v1/pty.write',
+      'ccsm.v1/daemon.stats',
+      'daemon.shutdownForUpgradeNow',
+      'daemon.HELLO',
+      ' daemon.hello',
+      'daemon.hello ',
+      '/healthz/extra',
+      '/stat',
+      '',
+    ])('blocks non-supervisor RPC %j during migration', (rpcName) => {
+      const decision = checkMigrationGate({ rpcName, migrationPending: true });
+      expect(decision.allowed).toBe(false);
+      if (decision.allowed === false) {
+        expect(decision.error.code).toBe('MIGRATION_PENDING');
+        expect(decision.error.message).toContain(rpcName);
+      }
+    });
+
+    it('error message identifies the rejected rpcName for debug', () => {
+      const decision = checkMigrationGate({
+        rpcName: 'ccsm.v1/session.subscribe',
+        migrationPending: true,
+      });
+      expect(decision).toEqual({
+        allowed: false,
+        error: {
+          code: 'MIGRATION_PENDING',
+          message: expect.stringContaining('ccsm.v1/session.subscribe'),
+        },
+      });
+    });
+  });
+
+  describe('purity / no normalisation', () => {
+    it('does not prefix-match supervisor names during migration', () => {
+      // `daemon.shutdownForUpgradeNow` shares a prefix with the canonical
+      // `daemon.shutdownForUpgrade`, but literal-compare per §3.4.1.h means
+      // it must be blocked.
+      expect(
+        checkMigrationGate({
+          rpcName: 'daemon.shutdownForUpgradeNow',
+          migrationPending: true,
+        }),
+      ).toMatchObject({ allowed: false, error: { code: 'MIGRATION_PENDING' } });
+    });
+
+    it('treats whitespace-padded supervisor names as data-plane', () => {
+      expect(
+        checkMigrationGate({
+          rpcName: ' daemon.hello',
+          migrationPending: true,
+        }),
+      ).toMatchObject({ allowed: false, error: { code: 'MIGRATION_PENDING' } });
+    });
+  });
+});

--- a/daemon/src/envelope/migration-gate-interceptor.ts
+++ b/daemon/src/envelope/migration-gate-interceptor.ts
@@ -1,0 +1,68 @@
+// migrationGate interceptor — short-circuits data-plane RPCs while a
+// SQLite migration is in flight, but lets the canonical control-plane
+// allowlist through unconditionally.
+//
+// Spec citations:
+//   - docs/superpowers/specs/v0.3-fragments/frag-3.4.1-envelope-hardening.md
+//     §3.4.1.f (interceptor pipeline, position #3 — runs after helloInterceptor
+//     and deadlineInterceptor, before metrics).
+//   - Same fragment §3.4.1.h (canonical SUPERVISOR_RPCS allowlist; mutation
+//     requires a spec round).
+//   - frag-8 §8.5 references the same constant for migration scope.
+//
+// Single Responsibility: pure decider. This module does NOT
+//   - read or store the MIGRATION_PENDING flag (owned by frag-8 / supervisor),
+//   - perform any I/O (logging, metrics, socket writes happen at call sites),
+//   - normalise the rpcName (literal compare, per §3.4.1.h carve-out lock).
+//
+// The caller is responsible for sourcing `migrationPending` from the supervisor
+// state and translating `{ allowed: false }` into the wire-level rejection
+// frame (per §3.4.1.f short-circuit semantics).
+
+import { isSupervisorRpc } from './supervisor-rpcs.js';
+
+export interface MigrationGateContext {
+  /** Wire-literal RPC method name (e.g. `ccsm.v1/session.subscribe` or `/healthz`). */
+  rpcName: string;
+  /** True iff the supervisor's SQLite migration is currently in flight. */
+  migrationPending: boolean;
+}
+
+export type MigrationGateDecision =
+  | { allowed: true }
+  | {
+      allowed: false;
+      error: {
+        code: 'MIGRATION_PENDING';
+        message: string;
+      };
+    };
+
+/**
+ * Decide whether an envelope-bearing RPC may proceed under the current
+ * migration state.
+ *
+ * Decision table (spec §3.4.1.f / §3.4.1.h):
+ *   migrationPending=false                    → allowed (fast path)
+ *   migrationPending=true  ∧ supervisor RPC   → allowed (control-plane carve-out)
+ *   migrationPending=true  ∧ data-plane RPC   → blocked with MIGRATION_PENDING
+ *
+ * Pure function — no side effects, no flag storage.
+ */
+export function checkMigrationGate(
+  ctx: MigrationGateContext,
+): MigrationGateDecision {
+  if (!ctx.migrationPending) {
+    return { allowed: true };
+  }
+  if (isSupervisorRpc(ctx.rpcName)) {
+    return { allowed: true };
+  }
+  return {
+    allowed: false,
+    error: {
+      code: 'MIGRATION_PENDING',
+      message: `RPC ${ctx.rpcName} rejected: SQLite migration in progress; only SUPERVISOR_RPCS are accepted until migration completes`,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

T10 implements the `migrationGateInterceptor` — pure decider for spec §3.4.1.f position #3 — that short-circuits data-plane RPCs while a SQLite migration is in flight, while letting the canonical `SUPERVISOR_RPCS` set through unconditionally.

- New: `daemon/src/envelope/migration-gate-interceptor.ts` — `checkMigrationGate({ rpcName, migrationPending }) -> { allowed: true } | { allowed: false; error: { code: 'MIGRATION_PENDING'; message } }`.
- New: `daemon/src/envelope/__tests__/migration-gate-interceptor.test.ts` — 28 cases covering fast path, carve-out for each of the 5 supervisor RPCs, blocking of representative data-plane RPCs, and literal-compare purity (no prefix/whitespace normalisation).

Builds on T11's canonical `SUPERVISOR_RPCS` export (#646, be64053) — imports `isSupervisorRpc` rather than re-enumerating, satisfying the §3.4.1.h "single canonical constant" lock.

## Single Responsibility

Pure decider — no flag storage (owned by supervisor / frag-8), no I/O, no rpcName normalisation. Caller is responsible for sourcing `migrationPending` and translating `{ allowed: false }` into the wire-level rejection frame.

## Spec citations

- `docs/superpowers/specs/v0.3-fragments/frag-3.4.1-envelope-hardening.md` §3.4.1.f bullet #3 ("`migrationGateInterceptor` — short-circuits with `MIGRATION_PENDING` for data RPCs while migration is in progress; allows the canonical `SUPERVISOR_RPCS` constant ... through unconditionally").
- Same fragment §3.4.1.h (canonical 5-RPC allowlist; literal-compare lock).
- Same fragment "Allowlist constant" paragraph at line 251 (single canonical constant consumed by control-socket dispatcher, migrationGate, and frag-8 §8.5).

## Test plan

- [x] `npx vitest run daemon/src/envelope --no-coverage` -> 4 files / 71 tests passed
- [x] `npx eslint daemon/src/envelope/` -> clean
- [x] `npx tsc --noEmit -p daemon/tsconfig.json` -> clean

Implements Task #965.