### PR TITLE
feat(daemon/envelope): T12 protocol version + boot nonce precedence

### DIFF
--- a/daemon/package.json
+++ b/daemon/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@ccsm/daemon",
   "private": true,
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "@sinclair/typebox": "^0.34.49"
+  }
 }

--- a/daemon/src/envelope/__tests__/boot-nonce-precedence.test.ts
+++ b/daemon/src/envelope/__tests__/boot-nonce-precedence.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  BOOT_NONCE_HEADER,
+  applyBootNoncePrecedence,
+} from '../boot-nonce-precedence.js';
+
+describe('boot-nonce-precedence: applyBootNoncePrecedence()', () => {
+  it('daemon nonce overrides client nonce (anti-spoof)', () => {
+    const result = applyBootNoncePrecedence(
+      { [BOOT_NONCE_HEADER]: 'daemon-ULID-AAA' },
+      { [BOOT_NONCE_HEADER]: 'client-tried-BBB' },
+    );
+    expect(result[BOOT_NONCE_HEADER]).toBe('daemon-ULID-AAA');
+  });
+
+  it('client nonce kept when daemon does not set one', () => {
+    const result = applyBootNoncePrecedence(
+      {},
+      { [BOOT_NONCE_HEADER]: 'client-known-CCC' },
+    );
+    expect(result[BOOT_NONCE_HEADER]).toBe('client-known-CCC');
+  });
+
+  it('daemon nonce passes through when client absent', () => {
+    const result = applyBootNoncePrecedence(
+      { [BOOT_NONCE_HEADER]: 'daemon-ULID-DDD' },
+      {},
+    );
+    expect(result[BOOT_NONCE_HEADER]).toBe('daemon-ULID-DDD');
+  });
+
+  it('omits the boot-nonce key when neither side sets it', () => {
+    const result = applyBootNoncePrecedence({}, {});
+    expect(BOOT_NONCE_HEADER in result).toBe(false);
+  });
+
+  it('handles null/undefined inputs without throwing', () => {
+    expect(applyBootNoncePrecedence(null, null)).toEqual({});
+    expect(applyBootNoncePrecedence(undefined, undefined)).toEqual({});
+    expect(applyBootNoncePrecedence(null, { [BOOT_NONCE_HEADER]: 'x' })).toEqual({
+      [BOOT_NONCE_HEADER]: 'x',
+    });
+    expect(applyBootNoncePrecedence({ [BOOT_NONCE_HEADER]: 'y' }, null)).toEqual({
+      [BOOT_NONCE_HEADER]: 'y',
+    });
+  });
+
+  it('preserves other headers from both sides (last-writer-wins for non-reserved)', () => {
+    const result = applyBootNoncePrecedence(
+      { 'x-ccsm-deadline-ms': '5000', [BOOT_NONCE_HEADER]: 'D' },
+      { 'x-ccsm-trace-id': '01HXXXXXXXXXXXXXXXXXXXXXXX', 'x-ccsm-deadline-ms': '120000' },
+    );
+    expect(result['x-ccsm-trace-id']).toBe('01HXXXXXXXXXXXXXXXXXXXXXXX');
+    // daemon overrides client deadline (general last-writer rule).
+    expect(result['x-ccsm-deadline-ms']).toBe('5000');
+    expect(result[BOOT_NONCE_HEADER]).toBe('D');
+  });
+
+  it('does not mutate the daemon header input', () => {
+    const daemon = Object.freeze({ [BOOT_NONCE_HEADER]: 'D', other: '1' });
+    const client = { [BOOT_NONCE_HEADER]: 'C', extra: '2' };
+    const before = { ...daemon };
+    applyBootNoncePrecedence(daemon, client);
+    expect({ ...daemon }).toEqual(before);
+  });
+
+  it('does not mutate the client header input', () => {
+    const daemon = { [BOOT_NONCE_HEADER]: 'D' };
+    const client = Object.freeze({ [BOOT_NONCE_HEADER]: 'C', kept: 'yes' });
+    const snapshot = { ...client };
+    const result = applyBootNoncePrecedence(daemon, client);
+    expect({ ...client }).toEqual(snapshot);
+    expect(result.kept).toBe('yes');
+  });
+
+  it('returns a fresh object each call (no shared reference)', () => {
+    const daemon = { [BOOT_NONCE_HEADER]: 'D' };
+    const client = { other: 'x' };
+    const a = applyBootNoncePrecedence(daemon, client);
+    const b = applyBootNoncePrecedence(daemon, client);
+    expect(a).not.toBe(b);
+    expect(a).toEqual(b);
+  });
+
+  it('daemon overrides client even when daemon value is empty string (explicit assertion)', () => {
+    // If daemon explicitly asserts an empty boot nonce, that still wins —
+    // an empty string is a meaningful daemon-asserted value, not absence.
+    const result = applyBootNoncePrecedence(
+      { [BOOT_NONCE_HEADER]: '' },
+      { [BOOT_NONCE_HEADER]: 'client-spoof' },
+    );
+    expect(result[BOOT_NONCE_HEADER]).toBe('');
+  });
+});

--- a/daemon/src/envelope/__tests__/protocol-version.test.ts
+++ b/daemon/src/envelope/__tests__/protocol-version.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import { Value } from '@sinclair/typebox/value';
+
+import {
+  DAEMON_PROTOCOL_VERSION,
+  DaemonProtocolVersionSchema,
+  checkProtocolVersion,
+  type DaemonProtocolVersion,
+} from '../protocol-version.js';
+
+describe('protocol-version: TypeBox schema', () => {
+  it('accepts the pinned integer literal', () => {
+    expect(Value.Check(DaemonProtocolVersionSchema, DAEMON_PROTOCOL_VERSION)).toBe(true);
+    expect(Value.Check(DaemonProtocolVersionSchema, 1)).toBe(true);
+  });
+
+  it('rejects string values per r9 lock (REJECTS string with schema_violation)', () => {
+    expect(Value.Check(DaemonProtocolVersionSchema, '1')).toBe(false);
+    expect(Value.Check(DaemonProtocolVersionSchema, '0.3')).toBe(false);
+  });
+
+  it('rejects other integers and undefined', () => {
+    expect(Value.Check(DaemonProtocolVersionSchema, 0)).toBe(false);
+    expect(Value.Check(DaemonProtocolVersionSchema, 2)).toBe(false);
+    expect(Value.Check(DaemonProtocolVersionSchema, undefined)).toBe(false);
+  });
+
+  it('Static<typeof Schema> resolves to the pinned literal at compile time', () => {
+    // If the Static type is wrong, this assignment fails to typecheck.
+    const v: DaemonProtocolVersion = DAEMON_PROTOCOL_VERSION;
+    expect(v).toBe(1);
+  });
+});
+
+describe('protocol-version: checkProtocolVersion()', () => {
+  it('accepts the pinned integer', () => {
+    const r = checkProtocolVersion({ daemonProtocolVersion: DAEMON_PROTOCOL_VERSION });
+    expect(r.valid).toBe(true);
+  });
+
+  it('rejects undefined headers with PROTOCOL_VERSION_MISMATCH (no got)', () => {
+    const r = checkProtocolVersion(undefined);
+    expect(r.valid).toBe(false);
+    if (!r.valid) {
+      expect(r.error.code).toBe('PROTOCOL_VERSION_MISMATCH');
+      expect(r.error.expected).toBe(DAEMON_PROTOCOL_VERSION);
+      expect(r.error.got).toBeUndefined();
+    }
+  });
+
+  it('rejects null headers', () => {
+    const r = checkProtocolVersion(null);
+    expect(r.valid).toBe(false);
+    if (!r.valid) {
+      expect(r.error.code).toBe('PROTOCOL_VERSION_MISMATCH');
+      expect(r.error.got).toBeUndefined();
+    }
+  });
+
+  it('rejects missing daemonProtocolVersion field with no got', () => {
+    const r = checkProtocolVersion({ otherField: 'x' });
+    expect(r.valid).toBe(false);
+    if (!r.valid) {
+      expect(r.error.code).toBe('PROTOCOL_VERSION_MISMATCH');
+      expect(r.error.expected).toBe(1);
+      expect(r.error.got).toBeUndefined();
+    }
+  });
+
+  it('rejects integer 0 and echoes got', () => {
+    const r = checkProtocolVersion({ daemonProtocolVersion: 0 });
+    expect(r.valid).toBe(false);
+    if (!r.valid) {
+      expect(r.error.code).toBe('PROTOCOL_VERSION_MISMATCH');
+      expect(r.error.got).toBe(0);
+    }
+  });
+
+  it('rejects integer 2 (future major) and echoes got', () => {
+    const r = checkProtocolVersion({ daemonProtocolVersion: 2 });
+    expect(r.valid).toBe(false);
+    if (!r.valid) {
+      expect(r.error.got).toBe(2);
+    }
+  });
+
+  it('rejects string "1" (r9 lock — string MUST fail)', () => {
+    const r = checkProtocolVersion({ daemonProtocolVersion: '1' });
+    expect(r.valid).toBe(false);
+    if (!r.valid) {
+      expect(r.error.got).toBe('1');
+    }
+  });
+
+  it('rejects string "0.4" and echoes got', () => {
+    const r = checkProtocolVersion({ daemonProtocolVersion: '0.4' });
+    expect(r.valid).toBe(false);
+    if (!r.valid) {
+      expect(r.error.got).toBe('0.4');
+    }
+  });
+
+  it('rejects float 1.5 (Number.isInteger guard)', () => {
+    const r = checkProtocolVersion({ daemonProtocolVersion: 1.5 });
+    expect(r.valid).toBe(false);
+    if (!r.valid) {
+      expect(r.error.got).toBe(1.5);
+    }
+  });
+
+  it('rejects null value and echoes got', () => {
+    const r = checkProtocolVersion({ daemonProtocolVersion: null });
+    expect(r.valid).toBe(false);
+    if (!r.valid) {
+      expect(r.error.got).toBeNull();
+    }
+  });
+});

--- a/daemon/src/envelope/boot-nonce-precedence.ts
+++ b/daemon/src/envelope/boot-nonce-precedence.ts
@@ -1,0 +1,68 @@
+// Reserved-key precedence merger for `x-ccsm-boot-nonce` (spec §3.4.1.c +
+// frag-3.4.1 r9 lock line 4059):
+//
+//   `[manager r9 lock: r8 envelope P1 — x-ccsm-boot-nonce added to
+//    reserved-keys allowlist with explicit precedence over body-level
+//    bootNonce]`
+//
+// Security rationale: the daemon mints `bootNonce` (ULID) at supervisor boot
+// (spec §3.4.1.g hello reply, frag-6-7 §6.5 healthz). A client must never be
+// able to impersonate that value — if a client sends its own
+// `x-ccsm-boot-nonce` header on, e.g., a `subscribePty` resubscribe, the
+// daemon-set value MUST take precedence so the daemon's view of "did we
+// restart between the two subscriptions?" cannot be spoofed.
+//
+// Single Responsibility: pure header-merge. No socket, no boot-nonce
+// generation, no comparison logic — those live in the adapter / lifecycle
+// owner. This file only enforces the precedence rule.
+
+/** Reserved header key. Lowercase per spec §3.4.1.c case-insensitive rule. */
+export const BOOT_NONCE_HEADER = 'x-ccsm-boot-nonce' as const;
+
+/**
+ * Merge two header maps, with daemon-set headers winning on the reserved
+ * `x-ccsm-boot-nonce` key. All other keys follow last-writer-wins semantics
+ * with `daemonHeaders` overriding `clientHeaders` (consistent with the
+ * security posture: the daemon is the trust anchor for any reserved key it
+ * chooses to set on a given frame).
+ *
+ * Pure: never mutates either input. Returns a fresh object.
+ *
+ * Behavior matrix for `x-ccsm-boot-nonce`:
+ *   - daemon set, client set    → daemon value wins (security: anti-spoof)
+ *   - daemon set, client absent → daemon value
+ *   - daemon absent, client set → client value (daemon hasn't asserted)
+ *   - both absent               → key omitted from output
+ */
+export function applyBootNoncePrecedence(
+  daemonHeaders: Readonly<Record<string, string>> | null | undefined,
+  clientHeaders: Readonly<Record<string, string>> | null | undefined,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+
+  // Step 1: copy client headers as the base (lowest precedence).
+  if (clientHeaders) {
+    for (const [k, v] of Object.entries(clientHeaders)) {
+      out[k] = v;
+    }
+  }
+
+  // Step 2: overlay daemon headers (general last-writer-wins).
+  if (daemonHeaders) {
+    for (const [k, v] of Object.entries(daemonHeaders)) {
+      out[k] = v;
+    }
+  }
+
+  // Step 3: enforce the reserved-key precedence rule explicitly. If the
+  // daemon set the boot nonce, it wins over any client value regardless of
+  // iteration order; if not, leave the client value (or omission) intact.
+  // Step 2 already produces this outcome, but the explicit assertion guards
+  // against future refactors that change merge order.
+  const daemonNonce = daemonHeaders?.[BOOT_NONCE_HEADER];
+  if (daemonNonce !== undefined) {
+    out[BOOT_NONCE_HEADER] = daemonNonce;
+  }
+
+  return out;
+}

--- a/daemon/src/envelope/protocol-version.ts
+++ b/daemon/src/envelope/protocol-version.ts
@@ -1,0 +1,79 @@
+// Daemon protocol-version validator (spec §3.4.1.g + frag-3.4.1 r9 lock).
+//
+// `daemonProtocolVersion` is an INTEGER (uint, semver-major) — pinned to the
+// integer literal in TypeBox per `[manager r9 lock: r8 envelope P1-4 — type
+// pinned to integer literal; TypeBox Type.Integer({minimum:1}); compare
+// numerically; schema validation REJECTS string values with schema_violation]`
+// (spec line 177 / 4063). v0.3 ships `1`. The version bumps ONLY on breaking
+// handler-contract changes; additive features go in `protocol.features[]`
+// (spec §3.4.1.g version-bump discipline).
+//
+// Single Responsibility: produce a `{ valid, error? }` decision from a header
+// candidate. No I/O, no socket close — caller (adapter) owns the side effect.
+
+import { Type, type Static } from '@sinclair/typebox';
+
+/** Current daemon protocol-version integer. v0.3 = 1. */
+export const DAEMON_PROTOCOL_VERSION = 1 as const;
+
+/**
+ * TypeBox schema for the `daemonProtocolVersion` header field. Pinned to the
+ * exact integer literal of the running daemon so a client carrying any other
+ * value (string '1', integer 2, undefined) is rejected at schema validation
+ * before dispatch (spec §3.4.1.d).
+ */
+export const DaemonProtocolVersionSchema = Type.Literal(DAEMON_PROTOCOL_VERSION);
+
+/** Static type derived from the schema; resolves to `1`. */
+export type DaemonProtocolVersion = Static<typeof DaemonProtocolVersionSchema>;
+
+export interface ProtocolVersionMismatchError {
+  readonly code: 'PROTOCOL_VERSION_MISMATCH';
+  readonly expected: number;
+  readonly got?: unknown;
+}
+
+export type ProtocolVersionCheckResult =
+  | { readonly valid: true }
+  | { readonly valid: false; readonly error: ProtocolVersionMismatchError };
+
+/**
+ * Check the `daemonProtocolVersion` header field against the running daemon's
+ * pinned version. Returns a discriminated result; never throws.
+ *
+ * Rejects:
+ *   - missing field (`got` omitted from error)
+ *   - non-integer values (string '1', float 1.5, null, etc. — `got` echoed back)
+ *   - integers other than `DAEMON_PROTOCOL_VERSION`
+ */
+export function checkProtocolVersion(
+  headers: Readonly<Record<string, unknown>> | null | undefined,
+): ProtocolVersionCheckResult {
+  if (headers === null || headers === undefined) {
+    return {
+      valid: false,
+      error: { code: 'PROTOCOL_VERSION_MISMATCH', expected: DAEMON_PROTOCOL_VERSION },
+    };
+  }
+  const raw = headers['daemonProtocolVersion'];
+  if (raw === undefined) {
+    return {
+      valid: false,
+      error: { code: 'PROTOCOL_VERSION_MISMATCH', expected: DAEMON_PROTOCOL_VERSION },
+    };
+  }
+  // Strict integer literal match — string '1' is a schema violation per the
+  // r9 lock (spec line 4063). Use Number.isInteger to guard against floats,
+  // NaN, and the `1.0 === 1` JS quirk for non-integers.
+  if (typeof raw !== 'number' || !Number.isInteger(raw) || raw !== DAEMON_PROTOCOL_VERSION) {
+    return {
+      valid: false,
+      error: {
+        code: 'PROTOCOL_VERSION_MISMATCH',
+        expected: DAEMON_PROTOCOL_VERSION,
+        got: raw,
+      },
+    };
+  }
+  return { valid: true };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,10 @@
       }
     },
     "daemon": {
-      "name": "@ccsm/daemon"
+      "name": "@ccsm/daemon",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.49"
+      }
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.4",
@@ -4731,6 +4734,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "license": "MIT"
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",


### PR DESCRIPTION
## Summary

Task #968 [T12] L1 envelope hardening: two pure header validators per spec frag-3.4.1.

- **`daemon/src/envelope/protocol-version.ts`** — TypeBox `Type.Literal(1)` schema for `daemonProtocolVersion` and `checkProtocolVersion(headers)` returning a discriminated `{ valid } | { valid:false, error }`. Pinned to **integer literal `1`** per spec line 177 + r9 lock line 4063 (`daemonProtocolVersion INTEGER pin — daemonProtocolVersion typed INTEGER not string in TypeBox schema`). String `"1"` is rejected with `PROTOCOL_VERSION_MISMATCH`.
- **`daemon/src/envelope/boot-nonce-precedence.ts`** — `applyBootNoncePrecedence(daemonHeaders, clientHeaders)` merges the two header maps with the daemon-set `x-ccsm-boot-nonce` winning over any client-provided value, per r9 lock line 4059 (`x-ccsm-boot-nonce added to reserved-keys allowlist with explicit precedence over body-level bootNonce`). Anti-spoof: a malicious client cannot impersonate the daemon's boot nonce on a resubscribe.

Both modules are pure (no I/O, no socket close, no mutation of inputs) — the adapter owns the side effect of acting on the result.

### Spec deviation from task prompt

Task prompt suggested `Type.Literal('0.3')` (string). The spec is unambiguous: `daemonProtocolVersion: 1` integer (`Type.Integer({minimum:1})`, schema validation REJECTS string values). Used the spec value `1`.

### Citations

- `docs/superpowers/specs/v0.3-fragments/frag-3.4.1-envelope-hardening.md`
  - L177: `daemonProtocolVersion: 1, // INTEGER (uint, semver-major); ... TypeBox Type.Integer({minimum:1}); compare numerically; schema validation REJECTS string values with schema_violation`
  - L246: version-bump discipline (only on breaking handler-contract changes)
  - L4059: `x-ccsm-boot-nonce` reserved-keys allowlist with explicit precedence over body-level `bootNonce`
  - L4063: `daemonProtocolVersion INTEGER pin`
- `docs/superpowers/specs/v0.3-design.md` L1685, L1677 — mirrors the same integer pin

### Dependency

Added `@sinclair/typebox@^0.34.49` to the `daemon` workspace.

## Test plan

- [x] `npx vitest run daemon/src/envelope --no-coverage` → **66/66 passed** (24 new across the two test files; existing 42 still pass)
- [x] `npx eslint daemon/src/envelope/` → clean
- [x] `npx tsc --noEmit -p daemon/tsconfig.json` → clean
- [x] Static type check verified: `Static<typeof DaemonProtocolVersionSchema>` resolves to literal `1` (compile-time assertion in tests)
- [x] Reserved-key precedence covered: daemon overrides client, client kept when daemon absent, neither side → omitted, no input mutation, fresh return object per call

Generated with Claude Opus 4.7 (1M context).