### PR TITLE
feat(daemon/envelope): T9 deadline interceptor

### DIFF
--- a/daemon/src/envelope/__tests__/deadline-interceptor.test.ts
+++ b/daemon/src/envelope/__tests__/deadline-interceptor.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyDeadline,
+  DEADLINE_HEADER,
+  DEFAULT_DEADLINE_MS,
+  MAX_DEADLINE_MS,
+  MIN_DEADLINE_MS,
+  type DeadlineInterceptorContext,
+} from '../deadline-interceptor.js';
+
+const ctx = (
+  headers: Record<string, string | number>,
+  rpcName = 'ccsm.v1/test.method',
+): DeadlineInterceptorContext => ({ headers, rpcName });
+
+describe('applyDeadline — accept path', () => {
+  it('accepts the lower bound 100 ms', () => {
+    const out = applyDeadline(ctx({ [DEADLINE_HEADER]: 100 }));
+    expect(out).toEqual({ deadlineMs: 100 });
+  });
+
+  it('accepts a typical 30 s deadline', () => {
+    const out = applyDeadline(ctx({ [DEADLINE_HEADER]: 30_000 }));
+    expect(out).toEqual({ deadlineMs: 30_000 });
+  });
+
+  it('accepts the upper bound 120 s', () => {
+    const out = applyDeadline(ctx({ [DEADLINE_HEADER]: 120_000 }));
+    expect(out).toEqual({ deadlineMs: 120_000 });
+  });
+
+  it('parses a numeric string header (canonical wire form)', () => {
+    const out = applyDeadline(ctx({ [DEADLINE_HEADER]: '5000' }));
+    expect(out).toEqual({ deadlineMs: 5_000 });
+  });
+
+  it('tolerates surrounding whitespace on a string header', () => {
+    const out = applyDeadline(ctx({ [DEADLINE_HEADER]: '  5000  ' }));
+    expect(out).toEqual({ deadlineMs: 5_000 });
+  });
+});
+
+describe('applyDeadline — default path', () => {
+  it('returns DEFAULT_DEADLINE_MS when the header is missing', () => {
+    const out = applyDeadline(ctx({}));
+    expect(out).toEqual({ deadlineMs: DEFAULT_DEADLINE_MS });
+    expect(DEFAULT_DEADLINE_MS).toBe(5_000);
+  });
+
+  it('returns DEFAULT_DEADLINE_MS when the header is an empty string', () => {
+    const out = applyDeadline(ctx({ [DEADLINE_HEADER]: '' }));
+    expect(out).toEqual({ deadlineMs: DEFAULT_DEADLINE_MS });
+  });
+
+  it('returns DEFAULT_DEADLINE_MS for a whitespace-only string', () => {
+    const out = applyDeadline(ctx({ [DEADLINE_HEADER]: '   ' }));
+    expect(out).toEqual({ deadlineMs: DEFAULT_DEADLINE_MS });
+  });
+});
+
+describe('applyDeadline — reject path (out of range)', () => {
+  it('rejects 99 ms with deadline_too_small', () => {
+    const out = applyDeadline(ctx({ [DEADLINE_HEADER]: 99 }));
+    expect(out).toEqual({
+      error: {
+        code: 'deadline_too_small',
+        message: expect.stringContaining(`below minimum ${MIN_DEADLINE_MS}`),
+      },
+    });
+  });
+
+  it('rejects 0 ms with deadline_too_small', () => {
+    const out = applyDeadline(ctx({ [DEADLINE_HEADER]: 0 }));
+    expect(out).toMatchObject({ error: { code: 'deadline_too_small' } });
+  });
+
+  it('rejects negative deadline with deadline_too_small', () => {
+    const out = applyDeadline(ctx({ [DEADLINE_HEADER]: -1 }));
+    expect(out).toMatchObject({ error: { code: 'deadline_too_small' } });
+  });
+
+  it('rejects 120001 ms with deadline_too_large', () => {
+    const out = applyDeadline(ctx({ [DEADLINE_HEADER]: 120_001 }));
+    expect(out).toEqual({
+      error: {
+        code: 'deadline_too_large',
+        message: expect.stringContaining(`above maximum ${MAX_DEADLINE_MS}`),
+      },
+    });
+  });
+
+  it('rejects a 10-minute deadline with deadline_too_large', () => {
+    const out = applyDeadline(ctx({ [DEADLINE_HEADER]: 600_000 }));
+    expect(out).toMatchObject({ error: { code: 'deadline_too_large' } });
+  });
+});
+
+describe('applyDeadline — reject path (malformed)', () => {
+  it('rejects a non-numeric string with deadline_invalid', () => {
+    const out = applyDeadline(ctx({ [DEADLINE_HEADER]: 'abc' }));
+    expect(out).toMatchObject({ error: { code: 'deadline_invalid' } });
+  });
+
+  it('rejects a fractional string with deadline_invalid', () => {
+    const out = applyDeadline(ctx({ [DEADLINE_HEADER]: '5000.5' }));
+    expect(out).toMatchObject({ error: { code: 'deadline_invalid' } });
+  });
+
+  it('rejects scientific notation strings with deadline_invalid', () => {
+    const out = applyDeadline(ctx({ [DEADLINE_HEADER]: '5e3' }));
+    expect(out).toMatchObject({ error: { code: 'deadline_invalid' } });
+  });
+
+  it('rejects a fractional numeric value with deadline_invalid', () => {
+    const out = applyDeadline(ctx({ [DEADLINE_HEADER]: 5_000.5 }));
+    expect(out).toMatchObject({ error: { code: 'deadline_invalid' } });
+  });
+
+  it('rejects NaN with deadline_invalid', () => {
+    const out = applyDeadline(ctx({ [DEADLINE_HEADER]: Number.NaN }));
+    expect(out).toMatchObject({ error: { code: 'deadline_invalid' } });
+  });
+
+  it('rejects Infinity with deadline_invalid', () => {
+    const out = applyDeadline(ctx({ [DEADLINE_HEADER]: Number.POSITIVE_INFINITY }));
+    expect(out).toMatchObject({ error: { code: 'deadline_invalid' } });
+  });
+});
+
+describe('applyDeadline — purity', () => {
+  it('does not mutate the input headers', () => {
+    const headers = { [DEADLINE_HEADER]: '5000' };
+    const snapshot = { ...headers };
+    applyDeadline(ctx(headers));
+    expect(headers).toEqual(snapshot);
+  });
+
+  it('ignores unrelated headers (single responsibility)', () => {
+    // The unknown_xccsm_header warn is the caller's concern; this decider
+    // must not branch on or reject for unknown keys.
+    const out = applyDeadline(
+      ctx({
+        [DEADLINE_HEADER]: 1_000,
+        'x-ccsm-future-thing': 'whatever',
+        'x-trace-id': '01ABCXYZ',
+      }),
+    );
+    expect(out).toEqual({ deadlineMs: 1_000 });
+  });
+});

--- a/daemon/src/envelope/deadline-interceptor.ts
+++ b/daemon/src/envelope/deadline-interceptor.ts
@@ -1,0 +1,138 @@
+// L1 envelope deadline interceptor (spec §3.4.1.f deadlineInterceptor + §3.4.1.c
+// reserved-headers paragraph; cross-frag bound to frag-3.5.1 §3.5.1.3 unary
+// AbortSignal composition).
+//
+// Reads the reserved `x-ccsm-deadline-ms` header, validates it sits inside the
+// canonical [100 ms .. 120 s] envelope, and resolves a numeric deadline in
+// milliseconds. The default of 5000 ms mirrors the daemon-side hello reply
+// `defaults.deadlineMs` field (spec §3.4.1.g) so a client that omits the
+// header gets the same deadline the daemon advertises.
+//
+// Single Responsibility: this module is a PURE header-policy decider. It does
+// NOT install timers, does NOT wire `AbortSignal.timeout`, does NOT compose
+// signals — those are the caller's job (interceptor pipeline owns that
+// composition per spec §3.4.1.f). It also does NOT emit the
+// `unknown_xccsm_header` warn line (separate concern; same interceptor in the
+// pipeline emits it but logging is a sink, not a decision).
+
+/** Lower clamp bound for the resolved deadline (spec §3.4.1.c / §3.4.1.f). */
+export const MIN_DEADLINE_MS = 100;
+
+/** Upper clamp bound for the resolved deadline (spec §3.4.1.c / §3.4.1.f). */
+export const MAX_DEADLINE_MS = 120_000;
+
+/**
+ * Default deadline applied when the client omits `x-ccsm-deadline-ms`. Mirrors
+ * the daemon hello reply `defaults.deadlineMs` (spec §3.4.1.g, frag-3.5.1
+ * §3.5.1.3 — "5s for unary RPCs").
+ */
+export const DEFAULT_DEADLINE_MS = 5_000;
+
+/** Canonical reserved header key (spec §3.4.1.c reserved-headers list). */
+export const DEADLINE_HEADER = 'x-ccsm-deadline-ms';
+
+export interface DeadlineInterceptorContext {
+  /**
+   * Envelope headers as parsed by the wire-format layer (spec §3.4.1.c). Keys
+   * are case-insensitive on the wire; the caller is responsible for
+   * lower-casing keys before they reach this interceptor (the upstream
+   * `traceInterceptor` already normalizes). Values may arrive as `string`
+   * (canonical form for an incoming JSON envelope) or `number` (a programmatic
+   * caller may set it directly without going through `JSON.stringify`).
+   */
+  readonly headers: Record<string, string | number>;
+  /** Method name solely for diagnostics; this interceptor does not branch on it. */
+  readonly rpcName: string;
+}
+
+/** Canonical error codes the interceptor can emit (spec §3.4.1.c reject path). */
+export type DeadlineErrorCode = 'deadline_too_small' | 'deadline_too_large' | 'deadline_invalid';
+
+export interface DeadlineResult {
+  readonly deadlineMs: number;
+}
+
+export interface DeadlineRejection {
+  readonly error: {
+    readonly code: DeadlineErrorCode;
+    readonly message: string;
+  };
+}
+
+/**
+ * Resolve the per-RPC deadline from envelope headers.
+ *
+ * Returns either `{ deadlineMs }` (caller wires `AbortSignal.timeout` from
+ * this) or `{ error }` (caller writes a `schema_violation`-shaped reject frame
+ * and short-circuits the interceptor chain — same posture as the schema
+ * validator at spec §3.4.1.d).
+ *
+ * Header resolution rules (spec §3.4.1.c + task brief):
+ *   - Missing / `undefined` / `null` / empty string → `DEFAULT_DEADLINE_MS`.
+ *   - Non-numeric string (e.g. `"abc"`) → reject `deadline_invalid`.
+ *   - Non-integer numeric (NaN, Infinity, fractional) → reject `deadline_invalid`.
+ *   - Integer < `MIN_DEADLINE_MS` → reject `deadline_too_small`.
+ *   - Integer > `MAX_DEADLINE_MS` → reject `deadline_too_large`.
+ *   - Otherwise → `{ deadlineMs: <integer> }`.
+ *
+ * Note on "clamp" wording (spec §3.4.1.c uses "clamped 100ms ≤ x ≤ 120s"):
+ * the v0.3 lock per task brief is REJECT on out-of-range, not silent clamp,
+ * so a buggy v0.5 web client cannot accidentally hide an absurd 10-minute
+ * deadline behind a silent 120 s coercion — easier to detect during the
+ * v0.5 cutover. The bounds themselves match the spec; only the policy on
+ * violation is "reject" not "coerce".
+ */
+export function applyDeadline(
+  ctx: DeadlineInterceptorContext,
+): DeadlineResult | DeadlineRejection {
+  const raw = ctx.headers[DEADLINE_HEADER];
+
+  if (raw === undefined || raw === null || raw === '') {
+    return { deadlineMs: DEFAULT_DEADLINE_MS };
+  }
+
+  let value: number;
+  if (typeof raw === 'number') {
+    value = raw;
+  } else {
+    // String path: tolerate leading/trailing whitespace from a sloppy client
+    // but reject anything else (including hex / scientific / `+5000`).
+    const trimmed = raw.trim();
+    if (trimmed === '') {
+      return { deadlineMs: DEFAULT_DEADLINE_MS };
+    }
+    if (!/^-?\d+$/.test(trimmed)) {
+      return reject(
+        'deadline_invalid',
+        `header ${DEADLINE_HEADER}=${JSON.stringify(raw)} is not an integer`,
+      );
+    }
+    value = Number.parseInt(trimmed, 10);
+  }
+
+  if (!Number.isFinite(value) || !Number.isInteger(value)) {
+    return reject(
+      'deadline_invalid',
+      `header ${DEADLINE_HEADER}=${JSON.stringify(raw)} is not a finite integer`,
+    );
+  }
+
+  if (value < MIN_DEADLINE_MS) {
+    return reject(
+      'deadline_too_small',
+      `header ${DEADLINE_HEADER}=${value} below minimum ${MIN_DEADLINE_MS}`,
+    );
+  }
+  if (value > MAX_DEADLINE_MS) {
+    return reject(
+      'deadline_too_large',
+      `header ${DEADLINE_HEADER}=${value} above maximum ${MAX_DEADLINE_MS}`,
+    );
+  }
+
+  return { deadlineMs: value };
+}
+
+function reject(code: DeadlineErrorCode, message: string): DeadlineRejection {
+  return { error: { code, message } };
+}


### PR DESCRIPTION
## Summary

Task #964 [T9] — L1 envelope `deadlineInterceptor` (header-policy half).

- New `daemon/src/envelope/deadline-interceptor.ts`:
  - `applyDeadline(ctx)`: pure decider, returns `{ deadlineMs }` or
    `{ error: { code, message } }`.
  - Constants: `MIN_DEADLINE_MS = 100`, `MAX_DEADLINE_MS = 120_000`,
    `DEFAULT_DEADLINE_MS = 5_000`, `DEADLINE_HEADER = 'x-ccsm-deadline-ms'`.
  - Canonical reject codes: `deadline_too_small`, `deadline_too_large`,
    `deadline_invalid`.
- New tests `daemon/src/envelope/__tests__/deadline-interceptor.test.ts`
  covering accept / default / out-of-range / malformed / purity / SRP.

## Spec citations

- `docs/superpowers/specs/v0.3-fragments/frag-3.4.1-envelope-hardening.md`
  - L140: `deadlineInterceptor` reads `headers["x-ccsm-deadline-ms"]`,
    clamp 100ms ≤ x ≤ 120s, composes `AbortSignal.timeout` with handler
    signal (composition is the caller's job — out of scope here).
  - L185: hello reply `defaults.deadlineMs: 5000` → `DEFAULT_DEADLINE_MS`.
  - L268, L279, L320: clamp bounds 100ms / 120s; r3 fwdcompat CC-3 unified
    bounds across header-validation and deadline-enforcement.
- `docs/superpowers/specs/v0.3-design.md`
  - L154, L170, L215, L298, L309, L350, L485, L593: same canonical bounds +
    5s default unary deadline (frag-3.5.1 §3.5.1.3).

Note on "clamp" wording: spec says "clamped 100ms ≤ x ≤ 120s"; per task
brief #964 the v0.3 lock is REJECT on out-of-range, not silent coerce, so
buggy v0.5 web clients can't hide an absurd 10-minute deadline behind a
silent 120s cap. Bounds match spec exactly.

## Single Responsibility

Pure header-policy decider:
- No I/O.
- No timer setup (caller wires `AbortSignal.timeout(deadlineMs)`).
- No `unknown_xccsm_header` warn (separate concern; sink, not decision).
- Does not mutate input headers (test asserts).

## Test plan

- [x] `npx vitest run daemon/src/envelope --no-coverage` — 4 files / 63 tests pass
- [x] `npx eslint daemon/src/envelope/` — clean
- [x] `npx tsc --noEmit -p daemon/tsconfig.json` — clean

Coverage:
- Accept: 100 / 30000 / 120000 / `'5000'` / whitespace-padded `'  5000  '`
- Default: missing header / empty string / whitespace-only string → 5000
- Reject `deadline_too_small`: 99, 0, -1
- Reject `deadline_too_large`: 120001, 600000
- Reject `deadline_invalid`: `'abc'`, `'5000.5'`, `'5e3'`, `5000.5`, `NaN`, `Infinity`
- Purity: no header mutation; unrelated `x-ccsm-future-thing` ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)