### PR TITLE
feat(i18n): T31 en.ts migration.modal.failed strings

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -186,6 +186,21 @@ const en = {
     title: 'Claude binary missing from this install',
     body: 'CCSM ships the Claude binary inside the installer, but we couldn’t find it on disk. Please reinstall CCSM to repair the install — sessions can’t start until then.'
   },
+  // Migration fatal-error modal (v0.3 design §6.8 surface registry,
+  // priority 85; canonical copy + key namespace owned by frag-8 §8.6).
+  // Sentence-case per feedback_no_uppercase_ui_strings; no
+  // ERROR/FAILED/FATAL terms. Only action is "Quit ccsm" — manual
+  // delete-and-relaunch (using the {{legacyDb}} / {{dataRoot}} paths
+  // surfaced in the body) is the documented retry mechanism.
+  migration: {
+    modal: {
+      failed: {
+        title: 'ccsm couldn’t migrate your previous data',
+        body: 'ccsm tried to move your data from the previous version but couldn’t complete the migration. Your previous data file at {{legacyDb}} is preserved unchanged — quit ccsm and contact support, or manually start fresh by deleting {{dataRoot}} and relaunching.',
+        actionQuit: 'Quit ccsm'
+      }
+    }
+  },
   importDialog: {
     title: 'Import sessions from Claude Code',
     description: 'Pick existing CLI transcripts to surface in CCSM. They resume on open.',


### PR DESCRIPTION
## Summary

Task #988 — adds the `migration.modal.failed.*` key tree to `src/i18n/locales/en.ts` per v0.3-design.md frag-8 §8.6 + §6.1.1 / §6.8 (priority-85 blocking modal, single fatal-error surface).

## Keys added

| Key | Value |
|---|---|
| `migration.modal.failed.title` | `ccsm couldn't migrate your previous data` |
| `migration.modal.failed.body` | Full prose with `{{legacyDb}}` / `{{dataRoot}}` interpolations (source path preserved unchanged; manual delete-and-relaunch documented as the retry path). |
| `migration.modal.failed.actionQuit` | `Quit ccsm` |

Copy lifted verbatim from §8.6 modal-copy table. Only one action (`Quit ccsm`) — `Retry` / `View log` / `Reveal old file` / `Start fresh anyway` were all cut by r5 lock #9 + r7 trims (see frag-8 §8.6 inline `manager r7 lock` notes).

## Spec references

- `docs/superpowers/specs/v0.3-design.md` line 1593 — §6.1.1 surface table row "Migration failed"
- `docs/superpowers/specs/v0.3-design.md` line 1794 — §6.8 surface registry P=85 row
- `docs/superpowers/specs/v0.3-design.md` lines 2592-2643 — frag-8 §8.6 canonical key prefix + copy owner
- `docs/superpowers/specs/v0.3-design.md` line 2092 — R3-P13 (camelCase namespace lock)

## Style compliance

- Sentence case throughout (no SCREAMING per `feedback_no_uppercase_ui_strings`).
- No `ERROR` / `FAILED` / `FATAL` strings (per §8.6 "All copy is sentence-case … No copy contains ERROR / FAILED / FATAL").
- Dot+camelCase namespace (`migration.modal.failed.*`) per r3-T13 / r6 ux P0-3 lock.

## Known CI breakage — intentional, T32 follows

This PR alone **breaks** both `tests/i18n-key-parity.test.ts` and the renderer typecheck:

- `tests/i18n-key-parity.test.ts` — `missingInZh: ['migration.modal.failed.actionQuit', 'migration.modal.failed.body', 'migration.modal.failed.title']`
- `tsc --noEmit` — `src/i18n/locales/zh.ts(13,7): error TS2741: Property 'migration' is missing` (zh.ts is typed `EnCatalog`, so a missing branch is a hard TS error, not just a runtime parity gap).

Per task #988 spec: zh.ts parity is a **separate task #991 (T32)**, intentionally not touched here. Recommended landing path: stack #991 atop this PR or merge them together so `working` never sees a red CI step.

## Test plan

- [ ] T32 (#991) lands on top, restoring green typecheck + parity.
- [ ] After merge, search bundle for `migration.modal.failed` and confirm renderer modal wiring (separate task — this PR is strings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)