### PR TITLE
feat(daemon): T37 PTY lifecycle FSM

### DIFF
--- a/daemon/src/pty/__tests__/lifecycle.test.ts
+++ b/daemon/src/pty/__tests__/lifecycle.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PTY_LIFECYCLE_STATES,
+  transition,
+  type PtyLifecycleEvent,
+  type PtyLifecycleEventKind,
+  type PtyLifecycleResult,
+  type PtyLifecycleState,
+  type PtyLifecycleStateOrInitial,
+} from '../lifecycle.js';
+
+// T37 — pure FSM tests. No I/O, no DB, no PTY. Verifies every legal and
+// illegal (state, event) pair against the spec table in lifecycle.ts.
+
+const ALL_STATES: PtyLifecycleStateOrInitial[] = [
+  'initial',
+  ...PTY_LIFECYCLE_STATES,
+];
+
+const ALL_EVENT_KINDS: PtyLifecycleEventKind[] = [
+  'start',
+  'pause',
+  'resume',
+  'exit',
+  'shutdown_request',
+  'crash',
+  'force_kill',
+];
+
+function makeEvent(kind: PtyLifecycleEventKind, exitCode = 0): PtyLifecycleEvent {
+  switch (kind) {
+    case 'start':
+      return { kind: 'start' };
+    case 'pause':
+      return { kind: 'pause' };
+    case 'resume':
+      return { kind: 'resume' };
+    case 'exit':
+      return { kind: 'exit', exitCode };
+    case 'shutdown_request':
+      return { kind: 'shutdown_request' };
+    case 'crash':
+      return { kind: 'crash', reason: 'test' };
+    case 'force_kill':
+      return { kind: 'force_kill' };
+  }
+}
+
+function expectOk(
+  result: PtyLifecycleResult,
+): asserts result is Extract<PtyLifecycleResult, { ok: true }> {
+  if (!result.ok) {
+    throw new Error(
+      `expected ok transition, got illegal_transition from=${result.error.from} event=${result.error.event}`,
+    );
+  }
+}
+
+function expectIllegal(
+  result: PtyLifecycleResult,
+  from: PtyLifecycleStateOrInitial,
+  event: PtyLifecycleEventKind,
+): void {
+  expect(result.ok).toBe(false);
+  if (result.ok) return;
+  expect(result.error).toEqual({ kind: 'illegal_transition', from, event });
+}
+
+describe('PTY_LIFECYCLE_STATES — T28 schema source-of-truth', () => {
+  it('matches sessions.state CHECK enum', () => {
+    expect([...PTY_LIFECYCLE_STATES].sort()).toEqual(
+      ['running', 'paused', 'exited', 'shutting_down', 'crashed'].sort(),
+    );
+  });
+});
+
+describe('legal transitions (per frag-3.5.1 §3.5.1.2)', () => {
+  it('initial.start → running', () => {
+    const r = transition('initial', { kind: 'start' });
+    expectOk(r);
+    expect(r.transition.state).toBe<PtyLifecycleState>('running');
+    expect(r.transition.output).toBeUndefined();
+  });
+
+  it('running.shutdown_request → shutting_down (step 2)', () => {
+    const r = transition('running', { kind: 'shutdown_request' });
+    expectOk(r);
+    expect(r.transition.state).toBe('shutting_down');
+  });
+
+  it('running.exit(0) → exited with output.exitCode=0', () => {
+    const r = transition('running', { kind: 'exit', exitCode: 0 });
+    expectOk(r);
+    expect(r.transition.state).toBe('exited');
+    expect(r.transition.output).toEqual({ exitCode: 0, signal: null });
+  });
+
+  it('running.exit(non-zero) → crashed (clean spec mapping)', () => {
+    const r = transition('running', { kind: 'exit', exitCode: 137 });
+    expectOk(r);
+    expect(r.transition.state).toBe('crashed');
+    expect(r.transition.output).toEqual({ exitCode: 137, signal: null });
+  });
+
+  it('running.exit carries signal field through output', () => {
+    const r = transition('running', {
+      kind: 'exit',
+      exitCode: 143,
+      signal: 'SIGTERM',
+    });
+    expectOk(r);
+    expect(r.transition.output).toEqual({ exitCode: 143, signal: 'SIGTERM' });
+  });
+
+  it('running.crash(reason) → crashed with output.reason', () => {
+    const r = transition('running', { kind: 'crash', reason: 'jobobject_term' });
+    expectOk(r);
+    expect(r.transition.state).toBe('crashed');
+    expect(r.transition.output).toEqual({ reason: 'jobobject_term' });
+  });
+
+  it('running.pause → paused', () => {
+    const r = transition('running', { kind: 'pause' });
+    expectOk(r);
+    expect(r.transition.state).toBe('paused');
+  });
+
+  it('running.force_kill → running (signal-only, no state change)', () => {
+    const r = transition('running', { kind: 'force_kill' });
+    expectOk(r);
+    expect(r.transition.state).toBe('running');
+  });
+
+  it('shutting_down.exit(0) → exited (step 6 clean reap)', () => {
+    const r = transition('shutting_down', { kind: 'exit', exitCode: 0 });
+    expectOk(r);
+    expect(r.transition.state).toBe('exited');
+    expect(r.transition.output).toEqual({ exitCode: 0, signal: null });
+  });
+
+  it('shutting_down.exit(non-zero) → crashed', () => {
+    const r = transition('shutting_down', { kind: 'exit', exitCode: 1 });
+    expectOk(r);
+    expect(r.transition.state).toBe('crashed');
+  });
+
+  it('shutting_down.pause → paused (step 8 final sweep survivor)', () => {
+    const r = transition('shutting_down', { kind: 'pause' });
+    expectOk(r);
+    expect(r.transition.state).toBe('paused');
+  });
+
+  it('shutting_down.crash → crashed', () => {
+    const r = transition('shutting_down', { kind: 'crash', reason: 'kill9' });
+    expectOk(r);
+    expect(r.transition.state).toBe('crashed');
+  });
+
+  it('shutting_down.shutdown_request → shutting_down (idempotent drain)', () => {
+    const r = transition('shutting_down', { kind: 'shutdown_request' });
+    expectOk(r);
+    expect(r.transition.state).toBe('shutting_down');
+  });
+
+  it('shutting_down.force_kill → shutting_down (escalation, no state change)', () => {
+    const r = transition('shutting_down', { kind: 'force_kill' });
+    expectOk(r);
+    expect(r.transition.state).toBe('shutting_down');
+  });
+
+  it('paused.resume → running (frag-6-7 §6.3 next-boot recovery)', () => {
+    const r = transition('paused', { kind: 'resume' });
+    expectOk(r);
+    expect(r.transition.state).toBe('running');
+  });
+});
+
+describe('illegal transitions — typed error', () => {
+  it('initial rejects every event except start', () => {
+    for (const kind of ALL_EVENT_KINDS) {
+      if (kind === 'start') continue;
+      const r = transition('initial', makeEvent(kind));
+      expectIllegal(r, 'initial', kind);
+    }
+  });
+
+  it('running rejects start and resume', () => {
+    expectIllegal(transition('running', { kind: 'start' }), 'running', 'start');
+    expectIllegal(transition('running', { kind: 'resume' }), 'running', 'resume');
+  });
+
+  it('shutting_down rejects start and resume', () => {
+    expectIllegal(
+      transition('shutting_down', { kind: 'start' }),
+      'shutting_down',
+      'start',
+    );
+    expectIllegal(
+      transition('shutting_down', { kind: 'resume' }),
+      'shutting_down',
+      'resume',
+    );
+  });
+
+  it('paused rejects every event except resume', () => {
+    for (const kind of ALL_EVENT_KINDS) {
+      if (kind === 'resume') continue;
+      const r = transition('paused', makeEvent(kind));
+      expectIllegal(r, 'paused', kind);
+    }
+  });
+
+  it('exited rejects every event (terminal — idempotency)', () => {
+    for (const kind of ALL_EVENT_KINDS) {
+      const r = transition('exited', makeEvent(kind));
+      expectIllegal(r, 'exited', kind);
+    }
+  });
+
+  it('exited.exit(code) is illegal (already exited — idempotency)', () => {
+    const r = transition('exited', { kind: 'exit', exitCode: 0 });
+    expectIllegal(r, 'exited', 'exit');
+  });
+
+  it('crashed rejects every event including start (no in-place restart)', () => {
+    for (const kind of ALL_EVENT_KINDS) {
+      const r = transition('crashed', makeEvent(kind));
+      expectIllegal(r, 'crashed', kind);
+    }
+  });
+
+  it('crashed.start is explicitly illegal (fresh session row required)', () => {
+    const r = transition('crashed', { kind: 'start' });
+    expectIllegal(r, 'crashed', 'start');
+  });
+});
+
+describe('full (state × event) coverage matrix', () => {
+  it('every (state, event) pair returns either ok or typed illegal_transition', () => {
+    for (const from of ALL_STATES) {
+      for (const kind of ALL_EVENT_KINDS) {
+        const r = transition(from, makeEvent(kind));
+        if (r.ok) {
+          expect(PTY_LIFECYCLE_STATES).toContain(r.transition.state);
+        } else {
+          expect(r.error.kind).toBe('illegal_transition');
+          expect(r.error.from).toBe(from);
+          expect(r.error.event).toBe(kind);
+        }
+      }
+    }
+  });
+});
+
+describe('purity', () => {
+  it('repeated calls with the same input return equal results (no hidden state)', () => {
+    const a = transition('running', { kind: 'exit', exitCode: 0 });
+    const b = transition('running', { kind: 'exit', exitCode: 0 });
+    expect(a).toEqual(b);
+  });
+
+  it('does not mutate the input event object', () => {
+    const ev: PtyLifecycleEvent = { kind: 'exit', exitCode: 7, signal: 'SIGSEGV' };
+    const snapshot = JSON.parse(JSON.stringify(ev));
+    transition('running', ev);
+    expect(ev).toEqual(snapshot);
+  });
+});

--- a/daemon/src/pty/lifecycle.ts
+++ b/daemon/src/pty/lifecycle.ts
@@ -1,0 +1,220 @@
+// T37 — PTY lifecycle FSM (pure decider).
+//
+// Per feedback_single_responsibility: this module is the DECIDER. It maps
+// (state, event) → next state via a static transition table. It performs no
+// I/O, no waitpid, no DB writes, no fan-out, no logging. Producers (PTY
+// SIGCHLD handler, supervisor) feed events in; sinks (DB UPDATE, fan-out
+// emits) consume the resulting state.
+//
+// State enum is the source-of-truth from T28 schema:
+//   sessions.state CHECK IN ('running', 'paused', 'exited', 'shutting_down', 'crashed')
+// (see daemon/src/db/schema/v0.3.sql line 27).
+//
+// Transition table is derived from frag-3.5.1 §3.5.1.2:
+//   - running → shutting_down (daemonShutdown begins, step 2)
+//   - shutting_down → exited  (clean SIGCHLD reap during drain, step 6)
+//   - shutting_down → paused  (final sweep, survivors past SIGKILL, step 8)
+//   - running → exited        (clean exit outside shutdown — graceful path)
+//   - running → crashed       (unclean exit / signal kill)
+//   - paused  → running       (next-boot resume per frag-6-7 §6.3)
+//
+// Spec invariants enforced:
+//   - exited / crashed are TERMINAL. `crashed → start` is rejected: a fresh
+//     session row is required (matches frag-6-7 §6.3 — only `paused` is
+//     resumable on next-boot recovery).
+//   - Idempotency: `exited.exit(code)` is illegal (already exited).
+//   - `shutting_down → shutting_down` via repeated shutdown_request or
+//     force_kill is allowed as a no-op (drain is already in progress); the
+//     FSM does not double-fire side effects since the state is unchanged.
+
+/** Canonical state set — matches sessions.state CHECK constraint (T28). */
+export const PTY_LIFECYCLE_STATES = [
+  'running',
+  'paused',
+  'exited',
+  'shutting_down',
+  'crashed',
+] as const;
+
+export type PtyLifecycleState = (typeof PTY_LIFECYCLE_STATES)[number];
+
+/** Initial pseudo-state: a session row before `start` has been observed. */
+export type PtyLifecycleStateOrInitial = PtyLifecycleState | 'initial';
+
+/**
+ * Events consumed by the FSM. Names locked by Task #994 spec.
+ *
+ * - `start`              — child spawn succeeded (initial → running).
+ * - `pause`              — daemon-shutdown final sweep marks a surviving
+ *                          child as paused (frag-3.5.1 §3.5.1.2 step 8).
+ * - `resume`             — next-boot recovery respawns a paused session
+ *                          (frag-6-7 §6.3).
+ * - `exit(exitCode)`     — child exited (clean or with code). Decider maps
+ *                          to `exited` (code === 0) or `crashed` (non-zero).
+ * - `shutdown_request`   — daemonShutdown RPC entered draining
+ *                          (frag-3.5.1 §3.5.1.2 step 2 — running →
+ *                          shutting_down).
+ * - `crash(reason)`      — out-of-band crash signal not delivering exit
+ *                          code via the normal `exit` path (e.g. native
+ *                          binding crash, JobObject termination on Win).
+ * - `force_kill`         — supervisor escalated to SIGKILL / TerminateProcess
+ *                          (frag-3.5.1 §3.5.1.2 step 7). Does not change
+ *                          state by itself; the resulting reap arrives via
+ *                          `exit` or `crash`. Allowed in `running` and
+ *                          `shutting_down` as a no-op state-wise.
+ */
+export type PtyLifecycleEvent =
+  | { kind: 'start' }
+  | { kind: 'pause' }
+  | { kind: 'resume' }
+  | { kind: 'exit'; exitCode: number; signal?: string | null }
+  | { kind: 'shutdown_request' }
+  | { kind: 'crash'; reason: string }
+  | { kind: 'force_kill' };
+
+export type PtyLifecycleEventKind = PtyLifecycleEvent['kind'];
+
+/** Optional structured side-output for callers (no I/O performed here). */
+export interface PtyLifecycleOutput {
+  /** Set on transitions caused by `exit`. */
+  exitCode?: number;
+  /** Set on transitions caused by `exit` if a signal was reported. */
+  signal?: string | null;
+  /** Set on transitions caused by `crash`. */
+  reason?: string;
+}
+
+export interface PtyLifecycleTransition {
+  state: PtyLifecycleStateOrInitial;
+  output?: PtyLifecycleOutput;
+}
+
+/** Typed error returned for any rejected (illegal) transition. */
+export interface PtyLifecycleIllegalTransition {
+  kind: 'illegal_transition';
+  from: PtyLifecycleStateOrInitial;
+  event: PtyLifecycleEventKind;
+}
+
+export type PtyLifecycleResult =
+  | { ok: true; transition: PtyLifecycleTransition }
+  | { ok: false; error: PtyLifecycleIllegalTransition };
+
+/**
+ * Pure transition function. Caller decides what to do with the new state
+ * (DB UPDATE, fan-out emit, supervisor metric, etc.).
+ */
+export function transition(
+  from: PtyLifecycleStateOrInitial,
+  event: PtyLifecycleEvent,
+): PtyLifecycleResult {
+  switch (from) {
+    case 'initial':
+      if (event.kind === 'start') {
+        return ok('running');
+      }
+      return illegal(from, event.kind);
+
+    case 'running':
+      switch (event.kind) {
+        case 'pause':
+          // Direct pause from running is allowed (e.g. test harness or
+          // future v0.4 user-initiated pause). The shutdown path uses
+          // running → shutting_down → paused; both terminate at paused.
+          return ok('paused');
+        case 'shutdown_request':
+          return ok('shutting_down');
+        case 'exit':
+          return ok(exitCodeToState(event.exitCode), {
+            exitCode: event.exitCode,
+            signal: event.signal ?? null,
+          });
+        case 'crash':
+          return ok('crashed', { reason: event.reason });
+        case 'force_kill':
+          // Signal-only; reap arrives later via `exit` / `crash`. State
+          // unchanged so the FSM does not invent a row update.
+          return ok('running');
+        case 'start':
+        case 'resume':
+          return illegal(from, event.kind);
+      }
+      return illegal(from, (event as PtyLifecycleEvent).kind);
+
+    case 'shutting_down':
+      switch (event.kind) {
+        case 'exit':
+          return ok(exitCodeToState(event.exitCode), {
+            exitCode: event.exitCode,
+            signal: event.signal ?? null,
+          });
+        case 'pause':
+          // Final sweep: survivors past SIGKILL deadline marked paused
+          // (frag-3.5.1 §3.5.1.2 step 8).
+          return ok('paused');
+        case 'crash':
+          return ok('crashed', { reason: event.reason });
+        case 'shutdown_request':
+        case 'force_kill':
+          // Drain already in progress / supervisor escalation. No state
+          // change — the resulting reap will deliver exit/crash.
+          return ok('shutting_down');
+        case 'start':
+        case 'resume':
+          return illegal(from, event.kind);
+      }
+      return illegal(from, (event as PtyLifecycleEvent).kind);
+
+    case 'paused':
+      switch (event.kind) {
+        case 'resume':
+          // Next-boot recovery respawn (frag-6-7 §6.3). Caller is
+          // responsible for clearing pid/pgid columns BEFORE calling.
+          return ok('running');
+        case 'start':
+        case 'pause':
+        case 'exit':
+        case 'shutdown_request':
+        case 'crash':
+        case 'force_kill':
+          return illegal(from, event.kind);
+      }
+      return illegal(from, (event as PtyLifecycleEvent).kind);
+
+    case 'exited':
+    case 'crashed':
+      // Terminal states. `crashed → start` is explicitly rejected — a
+      // fresh session row is required (frag-6-7 §6.3 only resumes
+      // `paused`). Same for `exited`.
+      return illegal(from, event.kind);
+  }
+
+  // Exhaustiveness: TypeScript should make this unreachable.
+  const _exhaustive: never = from;
+  void _exhaustive;
+  return illegal(from, event.kind);
+}
+
+function ok(
+  state: PtyLifecycleStateOrInitial,
+  output?: PtyLifecycleOutput,
+): PtyLifecycleResult {
+  return output === undefined
+    ? { ok: true, transition: { state } }
+    : { ok: true, transition: { state, output } };
+}
+
+function illegal(
+  from: PtyLifecycleStateOrInitial,
+  event: PtyLifecycleEventKind,
+): PtyLifecycleResult {
+  return { ok: false, error: { kind: 'illegal_transition', from, event } };
+}
+
+function exitCodeToState(code: number): PtyLifecycleState {
+  // Convention (frag-3.5.1 §3.5.1.2): a clean exit (code === 0, no fatal
+  // signal) → `exited`; non-zero → `crashed`. Caller may pass signal info
+  // through `output.signal` but the state mapping is purely on exitCode
+  // to keep the decider table testable.
+  return code === 0 ? 'exited' : 'crashed';
+}


### PR DESCRIPTION
## Summary

Pure decider FSM for PTY child lifecycle (Task #994 / T37). Maps `(state, event) -> next state` with no I/O. Producers (SIGCHLD handler, supervisor) feed events; sinks (DB UPDATE, fan-out emits, waitpid) act on the returned state.

State enum is the **source-of-truth from T28 schema** (`daemon/src/db/schema/v0.3.sql:27`):
`running | paused | exited | shutting_down | crashed`.

Spec: `docs/superpowers/specs/v0.3-fragments/frag-3.5.1-pty-hardening.md` §3.5.1.2 (the canonical PTY lifecycle text — `v0.3-design.md` §3.5 references this fragment).

## Files

- `daemon/src/pty/lifecycle.ts` (new) — pure `transition(state, event)` returning `{ ok: true, transition: { state, output? } } | { ok: false, error: { kind: 'illegal_transition', from, event } }`.
- `daemon/src/pty/__tests__/lifecycle.test.ts` (new) — 27 cases.

## Transition table

| from | event | to | notes |
|---|---|---|---|
| `initial` | `start` | `running` | spawn succeeded |
| `running` | `shutdown_request` | `shutting_down` | §3.5.1.2 step 2 |
| `running` | `exit(0)` | `exited` | clean SIGCHLD reap |
| `running` | `exit(!=0)` | `crashed` | non-zero exit |
| `running` | `crash(reason)` | `crashed` | out-of-band crash signal |
| `running` | `pause` | `paused` | direct pause path |
| `running` | `force_kill` | `running` | signal-only, no state change |
| `shutting_down` | `exit(0)` | `exited` | §3.5.1.2 step 6 |
| `shutting_down` | `exit(!=0)` | `crashed` | |
| `shutting_down` | `pause` | `paused` | §3.5.1.2 step 8 final sweep survivor |
| `shutting_down` | `crash` | `crashed` | |
| `shutting_down` | `shutdown_request` / `force_kill` | `shutting_down` | idempotent drain / escalation |
| `paused` | `resume` | `running` | frag-6-7 §6.3 next-boot recovery |
| `exited` | _any_ | reject | terminal |
| `crashed` | _any_ | reject | terminal — fresh session row required |

All other (state, event) pairs return `{ ok: false, error: { kind: 'illegal_transition', from, event } }`.

## Layer 1 (necessity / direction)

- The daemon-shutdown sequence in §3.5.1.2 already implies the FSM via the `running -> shutting_down -> exited|paused` path. T28 schema enforces the enum at the row level. T37 is the in-memory decider that callers (T11 `ptyService`, T11c subscribe path, T20 daemonShutdown) consult before they UPDATE rows or fan out events. Without it, every call site re-derives the table and they will drift (already saw this drift between r3 and r6 — `abandoned` vs `paused`).
- Pure decider only. No PTY handle, no `waitpid`, no DB import. Side effects belong to the producer/sink modules per `feedback_single_responsibility`.

## Spec invariants enforced

- `crashed -> start` is **rejected** (frag-6-7 §6.3 — only `paused` is resumable on next-boot recovery; a crashed row requires a fresh session).
- `exited.exit(code)` is **rejected** (idempotency — already exited).
- `shutdown_request` / `force_kill` while in `shutting_down` are no-op state-wise (drain already in progress).

## Test plan

- [x] `npx tsc --noEmit -p daemon/tsconfig.json` — clean.
- [x] `npx vitest run daemon/src/pty/__tests__/lifecycle.test.ts` — 27/27 pass (24 ms).
- [x] Build smoke: `tsc -p daemon/tsconfig.json && node -e "require('./daemon/dist-daemon/pty/lifecycle.js').transition('initial', { kind: 'start' })"` returned `{ ok: true, transition: { state: 'running' } }`.
- [x] `eslint daemon/src/pty/` — clean.
- [x] No new `daemon/src/pty/**` import touches `db/` or `native/` (decider purity).

Refs: Task #994.