### PR TITLE
feat(devx): T67 .vscode launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,45 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Attach to Electron-main",
+      "type": "node",
+      "request": "attach",
+      "port": 9229,
+      "address": "localhost",
+      "restart": true,
+      "protocol": "inspector",
+      "skipFiles": ["<node_internals>/**", "${workspaceFolder}/node_modules/**"],
+      "sourceMaps": true,
+      "outFiles": [
+        "${workspaceFolder}/dist/electron/**/*.js",
+        "!**/node_modules/**"
+      ],
+      "presentation": { "group": "ccsm-dev", "order": 1 }
+    },
+    {
+      "name": "Attach to daemon",
+      "type": "node",
+      "request": "attach",
+      "port": 9230,
+      "address": "localhost",
+      "restart": true,
+      "protocol": "inspector",
+      "skipFiles": ["<node_internals>/**", "${workspaceFolder}/node_modules/**"],
+      "sourceMaps": true,
+      "outFiles": [
+        "${workspaceFolder}/daemon/dist-daemon/**/*.js",
+        "!**/node_modules/**"
+      ],
+      "presentation": { "group": "ccsm-dev", "order": 2 }
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Attach to both (Electron-main + daemon)",
+      "configurations": ["Attach to Electron-main", "Attach to daemon"],
+      "stopAll": true,
+      "presentation": { "group": "ccsm-dev", "order": 0 }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds `.vscode/launch.json` with two `node` `attach` configurations and a `compounds` entry, per spec **frag-3.7 §3.7.7.a** (`docs/superpowers/specs/v0.3-design.md` lines 1149–1177).

Contributors run `CCSM_DAEMON_INSPECT=1 CCSM_ELECTRON_INSPECT=1 npm run dev`, then pick the compound from the VS Code Run panel to attach to both processes simultaneously.

## Ports

| Config | Process | Port | outFiles |
|---|---|---|---|
| Attach to Electron-main | Electron main | `9229` | `dist/electron/**/*.js` |
| Attach to daemon | Daemon (Node 22) | `9230` | `daemon/dist-daemon/**/*.js` |
| Attach to both (compound) | Both | 9229 + 9230 | — |

Port 9229 = Node default (matches existing Electron-main inspect convention, T66 already merged). Port 9230 chosen to avoid collision (T65 daemon `--inspect=9230` pending; this PR can land first since it only declares the attach side).

Each config sets `restart: true`, `protocol: inspector`, `sourceMaps: true`, and `skipFiles` for `<node_internals>/**` and `node_modules/**`. Compound uses `stopAll: true` so detaching one stops the other.

## Spec ref

- frag-3.7 §3.7.7.a — debugger contract for daemon-split contributors (`[manager r7 lock: r6 devx P0-1]`)
- frag-3.7 §3.7.3 — nodemon `exec` line wires `CCSM_DAEMON_INSPECT` → `--inspect=9230`
- frag-12 traceability row L4039 — closed

## Sandbox note

Initial Write/Bash mkdir for `.vscode/` was hard-denied by sandbox despite `Write(*)` / `Bash(*)` in `permissions.allow` and no hook restriction. Manager unblocked by writing the file directly; this PR only stages/commits/pushes the file. Worth a follow-up to add `.vscode/**` to a worker-writable allowlist so future IDE-config tasks don't need manager intervention.

## Test plan

- [ ] Open repo in VS Code → Run panel shows three entries: "Attach to Electron-main", "Attach to daemon", "Attach to both (Electron-main + daemon)".
- [ ] `CCSM_ELECTRON_INSPECT=1 npm run dev` (after T66) → "Attach to Electron-main" connects, breakpoints hit in `electron/**.ts` source files via source maps.
- [ ] `CCSM_DAEMON_INSPECT=1 npm run dev` (after T65 lands) → "Attach to daemon" connects, breakpoints hit in `daemon/src/**.ts`.
- [ ] Compound entry attaches to both; Stop on one detaches both (`stopAll: true`).

No unit tests — IDE config only.