### PR TITLE
feat(daemon): T22 marker corruption-treat-as-PRESENT

### DIFF
--- a/daemon/src/marker/__tests__/reader.test.ts
+++ b/daemon/src/marker/__tests__/reader.test.ts
@@ -1,0 +1,180 @@
+// T22 — marker reader: corruption-treat-as-PRESENT.
+// Spec ref: docs/superpowers/specs/v0.3-design.md §6.4 (Marker semantics
+// "rel-S-R8"): "if the marker file exists but is unreadable / malformed
+// JSON, treat as PRESENT".
+
+import { promises as fs } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  DAEMON_SHUTDOWN_MARKER_FILENAME,
+  readMarker,
+  type MarkerReadResult,
+} from '../reader.js';
+
+let dir: string;
+let markerPath: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'ccsm-marker-'));
+  markerPath = join(dir, DAEMON_SHUTDOWN_MARKER_FILENAME);
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe('readMarker — decision table', () => {
+  it('ENOENT (no file) -> absent', async () => {
+    const result = await readMarker(markerPath);
+    expect(result).toEqual<MarkerReadResult>({ kind: 'absent' });
+  });
+
+  it('empty file -> present (corruption: empty)', async () => {
+    await fs.writeFile(markerPath, '');
+    const result = await readMarker(markerPath);
+    expect(result).toEqual<MarkerReadResult>({
+      kind: 'present',
+      reason: 'empty',
+    });
+  });
+
+  it('whitespace-only file -> present (corruption: empty)', async () => {
+    await fs.writeFile(markerPath, '   \n\t  ');
+    const result = await readMarker(markerPath);
+    expect(result.kind).toBe('present');
+    if (result.kind === 'present') {
+      expect(result.reason).toBe('empty');
+      expect(result.payload).toBeUndefined();
+    }
+  });
+
+  it('partial / unparseable JSON -> present (corruption: invalid-json)', async () => {
+    // Realistic mid-write fragment — opening brace + half a key, no close.
+    await fs.writeFile(markerPath, '{"reason":"upg');
+    const result = await readMarker(markerPath);
+    expect(result.kind).toBe('present');
+    if (result.kind === 'present') {
+      expect(result.reason).toBe('invalid-json');
+      expect(result.payload).toBeUndefined();
+    }
+  });
+
+  it('non-JSON garbage -> present (corruption: invalid-json)', async () => {
+    await fs.writeFile(markerPath, 'not json at all');
+    const result = await readMarker(markerPath);
+    expect(result.kind).toBe('present');
+    if (result.kind === 'present') {
+      expect(result.reason).toBe('invalid-json');
+    }
+  });
+
+  it('valid JSON missing required fields -> present (corruption: missing-fields)', async () => {
+    await fs.writeFile(markerPath, JSON.stringify({ reason: 'upgrade' }));
+    const result = await readMarker(markerPath);
+    expect(result.kind).toBe('present');
+    if (result.kind === 'present') {
+      expect(result.reason).toBe('missing-fields');
+      expect(result.payload).toBeUndefined();
+    }
+  });
+
+  it('valid JSON with wrong types -> present (corruption: missing-fields)', async () => {
+    await fs.writeFile(
+      markerPath,
+      JSON.stringify({ reason: 'upgrade', version: '0.3.0', ts: 'not-a-number' }),
+    );
+    const result = await readMarker(markerPath);
+    expect(result.kind).toBe('present');
+    if (result.kind === 'present') {
+      expect(result.reason).toBe('missing-fields');
+    }
+  });
+
+  it('valid JSON with all required fields -> present + payload (no corruption reason)', async () => {
+    const payload = { reason: 'upgrade' as const, version: '0.3.0', ts: 1_700_000_000_000 };
+    await fs.writeFile(markerPath, JSON.stringify(payload));
+    const result = await readMarker(markerPath);
+    expect(result).toEqual<MarkerReadResult>({
+      kind: 'present',
+      payload,
+    });
+  });
+
+  it('valid JSON with extra fields -> present + payload (forward-compat)', async () => {
+    const payload = {
+      reason: 'upgrade' as const,
+      version: '0.3.1',
+      ts: 1_700_000_000_001,
+      futureField: 'allowed',
+    };
+    await fs.writeFile(markerPath, JSON.stringify(payload));
+    const result = await readMarker(markerPath);
+    expect(result.kind).toBe('present');
+    if (result.kind === 'present') {
+      expect(result.reason).toBeUndefined();
+      expect(result.payload).toBeDefined();
+      expect(result.payload?.reason).toBe('upgrade');
+      expect(result.payload?.version).toBe('0.3.1');
+      expect(result.payload?.ts).toBe(1_700_000_000_001);
+    }
+  });
+
+  it('JSON with leading BOM -> still parses cleanly', async () => {
+    const payload = { reason: 'upgrade' as const, version: '0.3.0', ts: 1 };
+    await fs.writeFile(markerPath, '﻿' + JSON.stringify(payload));
+    const result = await readMarker(markerPath);
+    expect(result.kind).toBe('present');
+    if (result.kind === 'present') {
+      expect(result.payload).toEqual(payload);
+    }
+  });
+
+  it('I/O error (e.g. EACCES) -> present (corruption: io-error, fail-safe)', async () => {
+    const eacces = Object.assign(new Error('permission denied'), { code: 'EACCES' });
+    const spy = vi.spyOn(fs, 'readFile').mockRejectedValue(eacces);
+
+    const result = await readMarker(markerPath);
+    expect(spy).toHaveBeenCalledOnce();
+    expect(result).toEqual<MarkerReadResult>({
+      kind: 'present',
+      reason: 'io-error',
+    });
+  });
+
+  it('I/O error EISDIR -> present (corruption: io-error)', async () => {
+    const eisdir = Object.assign(new Error('is a directory'), { code: 'EISDIR' });
+    vi.spyOn(fs, 'readFile').mockRejectedValue(eisdir);
+
+    const result = await readMarker(markerPath);
+    expect(result.kind).toBe('present');
+    if (result.kind === 'present') {
+      expect(result.reason).toBe('io-error');
+    }
+  });
+
+  it('never throws — even on bizarre non-Error rejections', async () => {
+    vi.spyOn(fs, 'readFile').mockRejectedValue('string rejection' as unknown as Error);
+    await expect(readMarker(markerPath)).resolves.toEqual({
+      kind: 'present',
+      reason: 'io-error',
+    });
+  });
+});
+
+describe('readMarker — invariants', () => {
+  it('only ENOENT yields absent', async () => {
+    // Sanity sweep: run a sample of corruption flavours and verify NONE return absent.
+    const samples = ['', '   ', 'garbage', '{"reason":"x"}', '﻿{}'];
+    for (const s of samples) {
+      await fs.writeFile(markerPath, s);
+      const r = await readMarker(markerPath);
+      expect(r.kind).toBe('present');
+    }
+  });
+});

--- a/daemon/src/marker/reader.ts
+++ b/daemon/src/marker/reader.ts
@@ -1,0 +1,118 @@
+// Marker file reader (T22, v0.3 spec §6.4 + §3 — "Marker corruption /
+// partial write (rel-S-R8): if the marker file exists but is unreadable
+// / malformed JSON, treat as PRESENT").
+//
+// Decision table (single source of truth):
+//
+//   File state                            -> result
+//   -----------------------------------------------------------------
+//   ENOENT (no file)                       -> { kind: 'absent' }
+//   Empty file                             -> { kind: 'present' }     // partial-write window: O_CREAT done, content not yet rename()'d
+//   Unparseable JSON                       -> { kind: 'present' }     // half-flushed bytes, treat as PRESENT
+//   JSON missing required fields           -> { kind: 'present' }     // forward-compat: don't reject
+//   Valid JSON with required fields        -> { kind: 'present', payload }
+//   Any other I/O error (EACCES/EBUSY/...) -> { kind: 'present' }     // fail-safe: assume marker exists
+//
+// Rationale (spec §6.4 + §6.1 R2): we prefer a false-negative on the
+// crash-loop counter (a "marker present" reading suppresses the
+// counter increment for one boot) over a false-positive that would
+// trip the rollback path on a legitimate post-upgrade boot. Treating
+// any non-ENOENT condition as PRESENT is the conservative read.
+//
+// T13 runtimeRoot is not yet merged at the time of writing (parallel
+// worker). The default marker path constant below is a placeholder
+// derived directly from the spec wording ("`<dataRoot>/daemon.shutdown`
+// marker file"). Once T13 lands, the wiring layer will pass an
+// absolute path computed from `runtimeRoot`/`dataRoot` and this
+// constant becomes irrelevant — the reader itself is path-agnostic.
+
+import { promises as fs } from 'node:fs';
+
+/** Default marker filename per spec §6.4. Joined under `dataRoot` by the wiring layer. */
+export const DAEMON_SHUTDOWN_MARKER_FILENAME = 'daemon.shutdown';
+
+/** Spec-defined payload shape (§6.4 line "Marker payload is a single line"). */
+export interface ShutdownMarkerPayload {
+  reason: 'upgrade' | string;
+  version: string;
+  ts: number;
+}
+
+export type MarkerReadResult =
+  | { kind: 'absent' }
+  | { kind: 'present'; payload?: ShutdownMarkerPayload; reason?: MarkerCorruptionReason };
+
+/**
+ * Why the reader downgraded to "present without payload". Useful for
+ * the caller to emit the `marker_corrupt` warn log (spec §6.4).
+ */
+export type MarkerCorruptionReason =
+  | 'empty'
+  | 'invalid-json'
+  | 'missing-fields'
+  | 'io-error';
+
+/**
+ * Read the daemon-shutdown marker. See decision table above.
+ *
+ * IMPORTANT: This function never throws. Anything other than ENOENT is
+ * a "present" result by spec.
+ */
+export async function readMarker(path: string): Promise<MarkerReadResult> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(path, 'utf8');
+  } catch (err) {
+    if (isEnoent(err)) {
+      return { kind: 'absent' };
+    }
+    // EACCES, EBUSY, EISDIR, EMFILE, etc. — fail safe.
+    return { kind: 'present', reason: 'io-error' };
+  }
+
+  // O_CREAT happened but content not yet written (or fully truncated).
+  // Treat as a half-written marker == present.
+  if (raw.length === 0) {
+    return { kind: 'present', reason: 'empty' };
+  }
+
+  // Strip BOM / surrounding whitespace before JSON parse so a single
+  // trailing newline doesn't accidentally count as "valid".
+  const trimmed = raw.replace(/^﻿/, '').trim();
+  if (trimmed.length === 0) {
+    return { kind: 'present', reason: 'empty' };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return { kind: 'present', reason: 'invalid-json' };
+  }
+
+  if (!isShutdownMarkerPayload(parsed)) {
+    return { kind: 'present', reason: 'missing-fields' };
+  }
+
+  return { kind: 'present', payload: parsed };
+}
+
+function isEnoent(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code: unknown }).code === 'ENOENT'
+  );
+}
+
+function isShutdownMarkerPayload(value: unknown): value is ShutdownMarkerPayload {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.reason === 'string' &&
+    typeof v.version === 'string' &&
+    typeof v.ts === 'number' &&
+    Number.isFinite(v.ts)
+  );
+}


### PR DESCRIPTION
## Summary

Implements the daemon-shutdown marker reader for v0.3 split-process upgrade flow.

**Spec ref**: `docs/superpowers/specs/v0.3-design.md` §6.4 ("Marker semantics" / rel-S-R8) and §6.1 R2 (marker-aware crash-loop skip).

> Marker corruption / partial write (rel-S-R8): if the marker file exists but is unreadable / malformed JSON, treat as PRESENT (conservative — prefer false-negative on crash-loop accounting over false-positive that bricks legitimate post-upgrade boots).

## Decision table (in `daemon/src/marker/reader.ts`)

| File state                              | Result                                  |
|-----------------------------------------|-----------------------------------------|
| ENOENT (no file)                        | `{ kind: 'absent' }`                    |
| Empty / whitespace-only                 | `{ kind: 'present', reason: 'empty' }`  |
| Unparseable JSON                        | `{ kind: 'present', reason: 'invalid-json' }` |
| Valid JSON missing required fields      | `{ kind: 'present', reason: 'missing-fields' }` |
| Valid JSON `{reason, version, ts}`      | `{ kind: 'present', payload }`          |
| Any other I/O error (EACCES/EISDIR/...) | `{ kind: 'present', reason: 'io-error' }` |

The `reason` field lets the consumer emit the spec-mandated `marker_corrupt` warn log without a second parse pass.

## Files

- `daemon/src/marker/reader.ts` — `readMarker(path)` + `DAEMON_SHUTDOWN_MARKER_FILENAME` constant + `ShutdownMarkerPayload` shape. Never throws.
- `daemon/src/marker/__tests__/reader.test.ts` — 14 cases covering every decision-table row, BOM tolerance, forward-compat extra fields, non-Error rejection paths, plus an invariant sweep.

## T13 dependency

T13 (runtimeRoot) is not merged yet (parallel worker). Reader is **path-agnostic** — only ships the spec-defined `daemon.shutdown` filename constant. Wiring layer (separate task) joins it under `runtimeRoot`/`dataRoot`. No block.

## Test plan

- [x] `npx vitest run daemon/src/marker/__tests__/reader.test.ts` — 14/14 pass
- [x] `npx tsc --noEmit -p daemon/tsconfig.json` — clean
- [x] **Reverse-verify**: flipped ENOENT branch to return `present` and confirmed the absent-case test fails (1/14 fail), then restored.
- [ ] Wiring + e2e: deferred to the consumer task that integrates this with the §6.1 supervisor crash-loop counter (out of scope per spec — `[manager r9 lock]` "Marker unlink ownership = daemon" wires up in §6.4 producer side).