### PR TITLE
feat(daemon): T40 snapshot semaphore

### DIFF
--- a/daemon/src/pty/__tests__/snapshot-semaphore.test.ts
+++ b/daemon/src/pty/__tests__/snapshot-semaphore.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+import {
+  SNAPSHOT_SEMAPHORE_DEFAULT_CAPACITY,
+  SNAPSHOT_SEMAPHORE_GLOBAL_KEY,
+  SnapshotSemaphoreCancelledError,
+  SnapshotSemaphoreTimeoutError,
+  createSnapshotSemaphore,
+} from '../snapshot-semaphore.js';
+
+describe('snapshot-semaphore: spec-default constants (frag-3.5.1 §3.5.1.5)', () => {
+  it('exports capacity 4 — global pool, any session, any caller', () => {
+    expect(SNAPSHOT_SEMAPHORE_DEFAULT_CAPACITY).toBe(4);
+  });
+
+  it('exports the conventional global key', () => {
+    expect(SNAPSHOT_SEMAPHORE_GLOBAL_KEY).toBe('global');
+  });
+});
+
+describe('snapshot-semaphore: construction', () => {
+  it('rejects non-positive capacity', () => {
+    expect(() => createSnapshotSemaphore({ capacity: 0 })).toThrow(RangeError);
+    expect(() => createSnapshotSemaphore({ capacity: -1 })).toThrow(RangeError);
+    expect(() => createSnapshotSemaphore({ capacity: 1.5 })).toThrow(RangeError);
+    expect(() => createSnapshotSemaphore({ capacity: Number.NaN })).toThrow(RangeError);
+  });
+
+  it('accepts capacity = 1', () => {
+    const sem = createSnapshotSemaphore({ capacity: 1 });
+    expect(sem.stats('k').active).toBe(0);
+  });
+});
+
+describe('snapshot-semaphore: acquire/release', () => {
+  it('admits up to capacity synchronously with waitMs = 0', async () => {
+    const sem = createSnapshotSemaphore({ capacity: 3 });
+    const a = await sem.acquire('k', 1000);
+    const b = await sem.acquire('k', 1000);
+    const c = await sem.acquire('k', 1000);
+    expect(a.waitMs).toBe(0);
+    expect(b.waitMs).toBe(0);
+    expect(c.waitMs).toBe(0);
+    expect(sem.stats('k')).toEqual({ active: 3, queued: 0 });
+    a.release();
+    b.release();
+    c.release();
+    expect(sem.stats('k')).toEqual({ active: 0, queued: 0 });
+  });
+
+  it('queues over-capacity callers; release admits the head waiter FIFO', async () => {
+    const sem = createSnapshotSemaphore({ capacity: 1 });
+    const first = await sem.acquire('k', 1000);
+    let secondResolved = false;
+    let thirdResolved = false;
+    const second = sem.acquire('k', 1000).then((l) => {
+      secondResolved = true;
+      return l;
+    });
+    const third = sem.acquire('k', 1000).then((l) => {
+      thirdResolved = true;
+      return l;
+    });
+    await Promise.resolve();
+    expect(secondResolved).toBe(false);
+    expect(thirdResolved).toBe(false);
+    expect(sem.stats('k')).toEqual({ active: 1, queued: 2 });
+    first.release();
+    const s = await second;
+    expect(secondResolved).toBe(true);
+    expect(thirdResolved).toBe(false);
+    expect(sem.stats('k')).toEqual({ active: 1, queued: 1 });
+    s.release();
+    const t = await third;
+    expect(thirdResolved).toBe(true);
+    t.release();
+    expect(sem.stats('k')).toEqual({ active: 0, queued: 0 });
+  });
+
+  it('reports waitMs measured from enqueue to admission via injected clock', async () => {
+    let nowVal = 1000;
+    const sem = createSnapshotSemaphore({ capacity: 1, now: () => nowVal });
+    const first = await sem.acquire('k', 10_000);
+    const queued = sem.acquire('k', 10_000);
+    nowVal += 250; // simulate 250 ms passing
+    first.release();
+    const second = await queued;
+    expect(second.waitMs).toBe(250);
+  });
+
+  it('release is idempotent — second call is a no-op', async () => {
+    const sem = createSnapshotSemaphore({ capacity: 1 });
+    const a = await sem.acquire('k', 1000);
+    a.release();
+    expect(sem.stats('k').active).toBe(0);
+    // Re-release must not push active negative or admit phantom waiters.
+    a.release();
+    a.release();
+    expect(sem.stats('k').active).toBe(0);
+    // A fresh acquire must still work after the redundant releases.
+    const b = await sem.acquire('k', 1000);
+    expect(b.waitMs).toBe(0);
+    b.release();
+  });
+});
+
+describe('snapshot-semaphore: per-key independence', () => {
+  it('different keys do not share permits', async () => {
+    const sem = createSnapshotSemaphore({ capacity: 1 });
+    const a = await sem.acquire('keyA', 1000);
+    // keyB has its own permit pool.
+    const b = await sem.acquire('keyB', 1000);
+    expect(a.waitMs).toBe(0);
+    expect(b.waitMs).toBe(0);
+    expect(sem.stats('keyA')).toEqual({ active: 1, queued: 0 });
+    expect(sem.stats('keyB')).toEqual({ active: 1, queued: 0 });
+    a.release();
+    b.release();
+  });
+
+  it('queue on keyA does not block keyB', async () => {
+    const sem = createSnapshotSemaphore({ capacity: 1 });
+    const aHeld = await sem.acquire('keyA', 1000);
+    const aQueued = sem.acquire('keyA', 1000); // will queue
+    // Meanwhile keyB stays fully responsive.
+    const b = await sem.acquire('keyB', 1000);
+    expect(b.waitMs).toBe(0);
+    b.release();
+    aHeld.release();
+    (await aQueued).release();
+  });
+});
+
+describe('snapshot-semaphore: timeout', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('rejects with SnapshotSemaphoreTimeoutError when the budget elapses while queued', async () => {
+    const sem = createSnapshotSemaphore({ capacity: 1 });
+    const held = await sem.acquire('k', 60_000);
+    const queued = sem.acquire('k', 100);
+    const onReject = vi.fn();
+    queued.catch(onReject);
+    // Advance past the 100 ms budget.
+    await vi.advanceTimersByTimeAsync(150);
+    expect(onReject).toHaveBeenCalledOnce();
+    const err = onReject.mock.calls[0]![0] as SnapshotSemaphoreTimeoutError;
+    expect(err).toBeInstanceOf(SnapshotSemaphoreTimeoutError);
+    expect(err.code).toBe('SNAPSHOT_SEMAPHORE_TIMEOUT');
+    expect(err.key).toBe('k');
+    expect(err.timeoutMs).toBe(100);
+    expect(err.waitedMs).toBeGreaterThanOrEqual(100);
+    held.release();
+    // After the holder releases, no phantom admission should resolve the
+    // timed-out waiter — it has already been settled.
+    await vi.advanceTimersByTimeAsync(10);
+    expect(sem.stats('k')).toEqual({ active: 0, queued: 0 });
+  });
+
+  it('does NOT time out a holder that has already been admitted', async () => {
+    const sem = createSnapshotSemaphore({ capacity: 1 });
+    const a = await sem.acquire('k', 50);
+    // The 50 ms budget only governs the queue wait — a is already admitted.
+    await vi.advanceTimersByTimeAsync(200);
+    expect(sem.stats('k').active).toBe(1);
+    a.release();
+  });
+
+  it('admits the next non-timed-out waiter after a stale entry is skipped', async () => {
+    const sem = createSnapshotSemaphore({ capacity: 1 });
+    const held = await sem.acquire('k', 60_000);
+    const willTimeout = sem.acquire('k', 100);
+    const willSucceed = sem.acquire('k', 60_000);
+    willTimeout.catch(() => {
+      /* expected */
+    });
+    await vi.advanceTimersByTimeAsync(150);
+    held.release();
+    const ok = await willSucceed;
+    expect(ok.waitMs).toBeGreaterThanOrEqual(150);
+    ok.release();
+  });
+});
+
+describe('snapshot-semaphore: input validation', () => {
+  it('rejects acquire with non-positive timeoutMs', async () => {
+    const sem = createSnapshotSemaphore({ capacity: 1 });
+    await expect(sem.acquire('k', 0)).rejects.toBeInstanceOf(RangeError);
+    await expect(sem.acquire('k', -1)).rejects.toBeInstanceOf(RangeError);
+    await expect(sem.acquire('k', Number.POSITIVE_INFINITY)).rejects.toBeInstanceOf(
+      RangeError,
+    );
+    await expect(sem.acquire('k', Number.NaN)).rejects.toBeInstanceOf(RangeError);
+  });
+});
+
+describe('snapshot-semaphore: drain (spec §3.5.1.2 step 5)', () => {
+  it('rejects every queued waiter with CANCELLED and returns the count', async () => {
+    const sem = createSnapshotSemaphore({ capacity: 1 });
+    const held = await sem.acquire('k', 60_000);
+    const queuedA = sem.acquire('k', 60_000);
+    const queuedB = sem.acquire('k', 60_000);
+    const onA = vi.fn();
+    const onB = vi.fn();
+    queuedA.catch(onA);
+    queuedB.catch(onB);
+    const rejected = sem.drain('daemonShutdown');
+    expect(rejected).toBe(2);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(onA).toHaveBeenCalledOnce();
+    expect(onB).toHaveBeenCalledOnce();
+    const err = onA.mock.calls[0]![0] as SnapshotSemaphoreCancelledError;
+    expect(err).toBeInstanceOf(SnapshotSemaphoreCancelledError);
+    expect(err.code).toBe('CANCELLED');
+    expect(err.key).toBe('k');
+    expect(err.reason).toBe('daemonShutdown');
+    // Holder is untouched — caller manages its own release path.
+    expect(sem.stats('k').active).toBe(1);
+    held.release();
+    expect(sem.stats('k')).toEqual({ active: 0, queued: 0 });
+  });
+
+  it('drain across multiple keys reports total rejected', async () => {
+    const sem = createSnapshotSemaphore({ capacity: 1 });
+    const ha = await sem.acquire('A', 60_000);
+    const hb = await sem.acquire('B', 60_000);
+    const qa = sem.acquire('A', 60_000);
+    const qb = sem.acquire('B', 60_000);
+    qa.catch(() => {});
+    qb.catch(() => {});
+    expect(sem.drain('shutdown')).toBe(2);
+    ha.release();
+    hb.release();
+  });
+
+  it('drain with no waiters returns 0', () => {
+    const sem = createSnapshotSemaphore({ capacity: 4 });
+    expect(sem.drain('noop')).toBe(0);
+  });
+});
+
+describe('snapshot-semaphore: stats for unknown keys', () => {
+  it('returns 0/0 for never-touched keys without allocating state', () => {
+    const sem = createSnapshotSemaphore({ capacity: 1 });
+    expect(sem.stats('never')).toEqual({ active: 0, queued: 0 });
+  });
+});

--- a/daemon/src/pty/snapshot-semaphore.ts
+++ b/daemon/src/pty/snapshot-semaphore.ts
@@ -1,0 +1,292 @@
+// PTY snapshot semaphore (spec §3.5.1.5 / frag-3.5.1 lines 123-124).
+//
+// Pure admission-control primitive used by the `getBufferSnapshot` handler
+// path. The spec mandates **bounded snapshot concurrency** (size 4, any
+// session, any caller) so a v0.5 dashboard cold-open subscribing to N
+// sessions does not allocate N × MB transient strings simultaneously
+// (res-SHOULD-2).
+//
+// The primitive is keyed so callers can pick the scope:
+//   - frag-3.5.1 §3.5.1.5 default: ONE shared key (e.g. `'global'`) with
+//     capacity 4 — the canonical v0.3 wiring.
+//   - alternative scope (per-session, per-caller) is available without
+//     changing this file; the caller picks the key.
+//
+// Single Responsibility (per `feedback_single_responsibility`):
+//   - producer of admission decisions + queued `waitMs` measurement;
+//   - decider for ordering (FIFO per key) and timeout cancellation;
+//   - NOT a sink: no PTY I/O, no logging, no metric emission. The caller
+//     that wraps the actual `getBufferSnapshot` work is responsible for:
+//       * logging `snapshot.semaphore.waitMs` (spec line 124);
+//       * surfacing `{ phase: 'queued', queuedMs }` to the bridge client;
+//       * starting the 30 s unary deadline AFTER `acquire()` resolves
+//         (admission-relative deadline, res-P1-3 / spec line 124);
+//       * calling `release()` exactly once (idempotent here so try/finally
+//         + cancellation paths are both safe).
+//
+// On daemon shutdown (spec §3.5.1.2 step 5, line 73), the caller invokes
+// `drain()` which rejects every still-queued waiter with a `CANCELLED`
+// typed error. In-flight holders keep their permits — the caller aggregates
+// the drop-line. `drain()` does NOT close the semaphore for new acquires
+// because the spec does not mandate that here; the caller stops dispatching
+// new snapshot RPCs at the same point it calls drain.
+
+/**
+ * Typed error returned when a queued waiter exceeds its `timeoutMs` budget
+ * before being admitted.
+ */
+export class SnapshotSemaphoreTimeoutError extends Error {
+  readonly code = 'SNAPSHOT_SEMAPHORE_TIMEOUT' as const;
+  readonly key: string;
+  readonly timeoutMs: number;
+  readonly waitedMs: number;
+  constructor(key: string, timeoutMs: number, waitedMs: number) {
+    super(
+      `snapshot semaphore acquire timed out after ${waitedMs}ms ` +
+        `(budget ${timeoutMs}ms, key=${key})`,
+    );
+    this.name = 'SnapshotSemaphoreTimeoutError';
+    this.key = key;
+    this.timeoutMs = timeoutMs;
+    this.waitedMs = waitedMs;
+  }
+}
+
+/**
+ * Typed error returned when a queued waiter is rejected by `drain()`
+ * (e.g. daemon shutdown — spec §3.5.1.2 step 5).
+ */
+export class SnapshotSemaphoreCancelledError extends Error {
+  readonly code = 'CANCELLED' as const;
+  readonly key: string;
+  readonly reason: string;
+  constructor(key: string, reason: string) {
+    super(`snapshot semaphore acquire cancelled: ${reason} (key=${key})`);
+    this.name = 'SnapshotSemaphoreCancelledError';
+    this.key = key;
+    this.reason = reason;
+  }
+}
+
+/** Result of a successful `acquire()`. */
+export interface SnapshotSemaphoreLease {
+  /**
+   * Idempotent permit release. Second and subsequent calls are no-ops so
+   * the caller can safely combine try/finally with cancellation paths.
+   */
+  readonly release: () => void;
+  /**
+   * Milliseconds the waiter spent queued before admission, measured against
+   * the injected clock. Caller logs this as `snapshot.semaphore.waitMs`.
+   * Always `≥ 0`. Equals `0` for a fast-path admission.
+   */
+  readonly waitMs: number;
+}
+
+/** Construction options. */
+export interface SnapshotSemaphoreOptions {
+  /**
+   * Maximum concurrent permits per key. Spec default for the canonical
+   * shared key is `4` (frag-3.5.1 line 123). Must be a positive integer.
+   */
+  readonly capacity: number;
+  /**
+   * Injected monotonic clock for tests. Defaults to `Date.now`. Production
+   * callers can pass `() => performance.now()` if they prefer; the absolute
+   * scale is irrelevant — only deltas are observed.
+   */
+  readonly now?: () => number;
+}
+
+interface QueueEntry {
+  readonly enqueuedAt: number;
+  readonly timeoutMs: number;
+  resolve: (lease: SnapshotSemaphoreLease) => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout> | null;
+  settled: boolean;
+}
+
+interface KeyState {
+  active: number;
+  queue: QueueEntry[];
+}
+
+export interface SnapshotSemaphore {
+  /**
+   * Acquire one permit for `key`. Resolves with a lease whose `release()`
+   * returns the permit. Rejects with `SnapshotSemaphoreTimeoutError` if the
+   * waiter is still queued at `timeoutMs`, or `SnapshotSemaphoreCancelledError`
+   * if `drain()` is called first.
+   *
+   * `timeoutMs` MUST be a positive finite number (the caller is responsible
+   * for clamping, mirroring the §3.4.1.f deadline header clamp).
+   */
+  acquire(key: string, timeoutMs: number): Promise<SnapshotSemaphoreLease>;
+  /**
+   * Reject every currently-queued waiter with `SnapshotSemaphoreCancelledError`.
+   * In-flight holders are NOT touched — they release through their normal
+   * `release()` path. Returns the number of waiters rejected so the caller
+   * can emit a single aggregated log line per spec §3.5.1.2 step 5.
+   */
+  drain(reason: string): number;
+  /**
+   * Test/observability accessors. Return current snapshot of in-flight and
+   * queued counts for `key` (or `0/0` if the key has no state yet).
+   */
+  stats(key: string): { active: number; queued: number };
+}
+
+/**
+ * Construct a snapshot semaphore. The instance is single-purpose — keep
+ * one per daemon (or one per scope) and share it across handlers.
+ */
+export function createSnapshotSemaphore(
+  opts: SnapshotSemaphoreOptions,
+): SnapshotSemaphore {
+  const capacity = opts.capacity;
+  if (!Number.isInteger(capacity) || capacity <= 0) {
+    throw new RangeError(
+      `snapshot semaphore capacity must be a positive integer, got ${capacity}`,
+    );
+  }
+  const now = opts.now ?? Date.now;
+  const states = new Map<string, KeyState>();
+
+  function getState(key: string): KeyState {
+    let s = states.get(key);
+    if (!s) {
+      s = { active: 0, queue: [] };
+      states.set(key, s);
+    }
+    return s;
+  }
+
+  function pruneEmpty(key: string, s: KeyState): void {
+    if (s.active === 0 && s.queue.length === 0) {
+      states.delete(key);
+    }
+  }
+
+  function makeLease(key: string, waitMs: number): SnapshotSemaphoreLease {
+    let released = false;
+    return {
+      waitMs,
+      release: () => {
+        if (released) return;
+        released = true;
+        const s = states.get(key);
+        if (!s) return; // defensive — should not happen
+        s.active = Math.max(0, s.active - 1);
+        // Pump the queue: a free permit goes to the head waiter.
+        // Loop because `Math.max` admission can satisfy multiple waiters
+        // only if a release coincided with a settled-but-not-yet-pruned
+        // entry; in practice we admit at most one per release, but the
+        // loop is defensive and bounded by `capacity - active`.
+        while (s.active < capacity && s.queue.length > 0) {
+          const next = s.queue.shift()!;
+          if (next.settled) continue; // stale (timed out / cancelled)
+          if (next.timer) {
+            clearTimeout(next.timer);
+            next.timer = null;
+          }
+          next.settled = true;
+          s.active += 1;
+          const waitedMs = Math.max(0, now() - next.enqueuedAt);
+          next.resolve(makeLease(key, waitedMs));
+        }
+        pruneEmpty(key, s);
+      },
+    };
+  }
+
+  function acquire(key: string, timeoutMs: number): Promise<SnapshotSemaphoreLease> {
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+      return Promise.reject(
+        new RangeError(
+          `snapshot semaphore timeoutMs must be a positive finite number, got ${timeoutMs}`,
+        ),
+      );
+    }
+    const s = getState(key);
+    // Fast path: capacity available, admit synchronously (waitMs = 0).
+    if (s.active < capacity) {
+      s.active += 1;
+      return Promise.resolve(makeLease(key, 0));
+    }
+    // Slow path: enqueue with a per-waiter timeout.
+    return new Promise<SnapshotSemaphoreLease>((resolve, reject) => {
+      const enqueuedAt = now();
+      const entry: QueueEntry = {
+        enqueuedAt,
+        timeoutMs,
+        resolve,
+        reject,
+        timer: null,
+        settled: false,
+      };
+      entry.timer = setTimeout(() => {
+        if (entry.settled) return;
+        entry.settled = true;
+        entry.timer = null;
+        // Leave the stale entry in the queue; it will be skipped on the
+        // next pump. We cannot splice cheaply without scanning, and the
+        // pump loop already handles `settled` entries.
+        const waitedMs = Math.max(0, now() - enqueuedAt);
+        reject(new SnapshotSemaphoreTimeoutError(key, timeoutMs, waitedMs));
+        // Best-effort prune of fully-settled tail to keep the map tidy.
+        pruneEmpty(key, s);
+      }, timeoutMs);
+      // Allow the Node event loop to exit even if a waiter is still queued
+      // (relevant for tests; production callers always release or drain).
+      if (typeof entry.timer === 'object' && entry.timer && 'unref' in entry.timer) {
+        (entry.timer as { unref: () => void }).unref();
+      }
+      s.queue.push(entry);
+    });
+  }
+
+  function drain(reason: string): number {
+    let rejected = 0;
+    for (const [key, s] of states) {
+      for (const entry of s.queue) {
+        if (entry.settled) continue;
+        entry.settled = true;
+        if (entry.timer) {
+          clearTimeout(entry.timer);
+          entry.timer = null;
+        }
+        entry.reject(new SnapshotSemaphoreCancelledError(key, reason));
+        rejected += 1;
+      }
+      s.queue.length = 0;
+      pruneEmpty(key, s);
+    }
+    return rejected;
+  }
+
+  function stats(key: string): { active: number; queued: number } {
+    const s = states.get(key);
+    if (!s) return { active: 0, queued: 0 };
+    // Exclude settled-but-not-yet-pruned entries from `queued`.
+    let queued = 0;
+    for (const e of s.queue) if (!e.settled) queued += 1;
+    return { active: s.active, queued };
+  }
+
+  return { acquire, drain, stats };
+}
+
+/**
+ * Spec-default capacity for the canonical shared key (frag-3.5.1 §3.5.1.5
+ * line 123: "semaphore of 4 concurrent `getBufferSnapshot` invocations").
+ * Re-exported as a named constant so the wiring site reads as
+ * `createSnapshotSemaphore({ capacity: SNAPSHOT_SEMAPHORE_DEFAULT_CAPACITY })`.
+ */
+export const SNAPSHOT_SEMAPHORE_DEFAULT_CAPACITY = 4 as const;
+
+/**
+ * Conventional shared key for the global v0.3 wiring. Callers that want
+ * the spec's "any session, any caller" pool pass this constant.
+ */
+export const SNAPSHOT_SEMAPHORE_GLOBAL_KEY = 'global' as const;


### PR DESCRIPTION
## Summary

Implements **Task #997 — T40 L5 snapshot semaphore** (spec `docs/superpowers/specs/v0.3-fragments/frag-3.5.1-pty-hardening.md` §3.5.1.5 lines 123-124, traceability res-SHOULD-2 / res-P1-3).

Pure admission-control primitive in `daemon/src/pty/snapshot-semaphore.ts` that callers wrap around `getBufferSnapshot` invocations to bound transient-string allocation when N subscribers cold-open simultaneously (e.g. v0.5 dashboard).

## Spec compliance

| Requirement | Spec ref | Implementation |
| --- | --- | --- |
| Bounded snapshot concurrency, capacity 4, any session/any caller | frag-3.5.1 line 123 | `SNAPSHOT_SEMAPHORE_DEFAULT_CAPACITY = 4`, `SNAPSHOT_SEMAPHORE_GLOBAL_KEY = 'global'` for the canonical shared-pool wiring |
| Excess wait | frag-3.5.1 line 123 | FIFO queue per key |
| Deadline starts AFTER admission | frag-3.5.1 line 124 / res-P1-3 | `acquire()` returns lease only after admission; caller starts the 30 s unary deadline post-resolve |
| `snapshot.semaphore.waitMs` counter | frag-3.5.1 line 124 | Lease carries `waitMs`; caller logs the metric (sink kept out of primitive per Single Responsibility) |
| Bridge surfaces `{ phase: 'queued', queuedMs }` | frag-3.5.1 line 124 | Same — `waitMs` returned to caller for surfacing |
| Drain queued waiters with `CANCELLED` on shutdown | frag-3.5.1 §3.5.1.2 step 5 (line 73) | `drain(reason)` rejects with `SnapshotSemaphoreCancelledError` (`code: 'CANCELLED'`), returns count for the aggregated drop-line |

## API surface

```ts
createSnapshotSemaphore({ capacity, now? }): SnapshotSemaphore
sem.acquire(key, timeoutMs): Promise<{ release(): void; waitMs: number }>
sem.drain(reason): number   // queued waiters rejected
sem.stats(key): { active, queued }
```

- `release()` is **idempotent** — second call is a no-op (try/finally + cancellation safe).
- Timeout rejects with typed `SnapshotSemaphoreTimeoutError` (`code: 'SNAPSHOT_SEMAPHORE_TIMEOUT'`, exposes `key`/`timeoutMs`/`waitedMs`).
- Different keys do **not** share permits (primitive is key-keyed; canonical wiring passes the shared global key, alternative scopes available without re-opening this file).

## Single Responsibility (per `feedback_single_responsibility`)

- **Producer** of admission decisions + queued-wait measurement.
- **Decider** for ordering (FIFO per key) and timeout cancellation.
- **NOT a sink**: no PTY I/O, no logging, no metric emission. The caller (Task 11c wiring) owns log/metric/bridge-event side effects.

## Layer 1 check

Verified daemon workspace carries only `@sinclair/typebox` — no `p-limit`/`async-sema`/other semaphore lib in deps. Hand-roll justified.

## Test plan

- [x] `npx vitest run daemon/src/pty/__tests__/snapshot-semaphore.test.ts` — **18/18 passing**
  - construction validation (non-positive / non-integer capacity)
  - sequential admit-up-to-capacity with `waitMs = 0`
  - FIFO queue: head waiter admitted on release
  - injected-clock waitMs measurement
  - idempotent release (no negative `active`, no phantom admissions)
  - per-key independence (queue on A does not block B)
  - fake-timer timeout rejection + stale-entry skip + post-timeout admission of next waiter
  - holder NOT timed out by its own queue-budget
  - input validation (acquire with `0` / negative / `Infinity` / `NaN` rejects)
  - drain rejects all queued waiters with `CANCELLED`, leaves holders untouched, returns count, multi-key sum
- [x] `npm run typecheck` — clean (root + electron + daemon)
- [x] `npm run build:daemon` — clean
- [x] Smoke: `node --input-type=module -e "import('./daemon/dist-daemon/pty/snapshot-semaphore.js')..."` — module loads as ESM, constructs, `stats('global') === { active: 0, queued: 0 }`

## Wiring (out of scope — follow-up task)

Per spec, Task 11c (`ptySubscribe` lift) wires this primitive into `getBufferSnapshot`. This PR only lands the primitive + tests; no handler call sites changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)