### PR TITLE
feat(daemon): T16 control-socket dispatcher skeleton (consumes T11 SUPERVISOR_RPCS, stubs T17-T21)

### DIFF
--- a/daemon/src/__tests__/dispatcher.test.ts
+++ b/daemon/src/__tests__/dispatcher.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  Dispatcher,
+  createSupervisorDispatcher,
+  type DispatchContext,
+  type Handler,
+} from '../dispatcher.js';
+import { SUPERVISOR_RPCS } from '../envelope/supervisor-rpcs.js';
+
+const ctx: DispatchContext = { traceId: '01HZZZTESTULIDXXXXXXXXX' };
+
+describe('Dispatcher (spec §3.4.1.h control-socket router)', () => {
+  describe('allowlist enforcement', () => {
+    it('rejects non-supervisor methods with NOT_ALLOWED', async () => {
+      const d = new Dispatcher();
+      const r = await d.dispatch('session.list', {}, ctx);
+      expect(r.ok).toBe(false);
+      if (r.ok) return; // type narrowing
+      expect(r.error.code).toBe('NOT_ALLOWED');
+      expect(r.error.method).toBe('session.list');
+      expect(r.error.message).toContain('SUPERVISOR_RPCS');
+    });
+
+    it.each([
+      'ccsm.v1/session.subscribe',
+      'daemon.foo',
+      '',
+      'daemon.HELLO', // case-sensitive — literal compare per §3.4.1.h
+      ' daemon.hello',
+      '/healthz/extra',
+      '/',
+    ])('rejects %j with NOT_ALLOWED on the supervisor dispatcher', async (m) => {
+      const d = new Dispatcher();
+      const r = await d.dispatch(m, {}, ctx);
+      expect(r.ok).toBe(false);
+      if (r.ok) return;
+      expect(r.error.code).toBe('NOT_ALLOWED');
+    });
+
+    it('register() refuses non-supervisor methods', () => {
+      const d = new Dispatcher();
+      const noop: Handler = async () => undefined;
+      expect(() => d.register('session.list', noop)).toThrow(/non-supervisor RPC/);
+    });
+  });
+
+  describe('UNKNOWN_METHOD path', () => {
+    it.each([...SUPERVISOR_RPCS])(
+      'returns UNKNOWN_METHOD for allowlisted %s when no handler is registered',
+      async (method) => {
+        const d = new Dispatcher(); // bare — no stubs
+        const r = await d.dispatch(method, {}, ctx);
+        expect(r.ok).toBe(false);
+        if (r.ok) return;
+        expect(r.error.code).toBe('UNKNOWN_METHOD');
+        expect(r.error.method).toBe(method);
+      },
+    );
+  });
+
+  describe('handler registration / replacement', () => {
+    it('register → has → dispatch chain', async () => {
+      const d = new Dispatcher();
+      expect(d.has('daemon.hello')).toBe(false);
+      const handler = vi.fn<Handler>(async () => ({ pong: true }));
+      d.register('daemon.hello', handler);
+      expect(d.has('daemon.hello')).toBe(true);
+      const r = await d.dispatch('daemon.hello', { hi: 1 }, ctx);
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      expect(r.value).toEqual({ pong: true });
+      expect(handler).toHaveBeenCalledWith({ hi: 1 }, ctx);
+    });
+
+    it('register replaces an existing handler', async () => {
+      const d = createSupervisorDispatcher();
+      const replacement = vi.fn<Handler>(async () => 'replaced');
+      d.register('/healthz', replacement);
+      const r = await d.dispatch('/healthz', undefined, ctx);
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      expect(r.value).toBe('replaced');
+      expect(replacement).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not swallow non-stub handler exceptions', async () => {
+      const d = new Dispatcher();
+      d.register('daemon.shutdown', async () => {
+        throw new Error('boom');
+      });
+      await expect(d.dispatch('daemon.shutdown', {}, ctx)).rejects.toThrow('boom');
+    });
+  });
+
+  describe('createSupervisorDispatcher() default stubs (T17–T21 placeholders)', () => {
+    it('pre-registers exactly the five SUPERVISOR_RPCS', () => {
+      const d = createSupervisorDispatcher();
+      for (const m of SUPERVISOR_RPCS) {
+        expect(d.has(m)).toBe(true);
+      }
+    });
+
+    it.each([...SUPERVISOR_RPCS])(
+      'stub for %s returns NOT_IMPLEMENTED echoing the method name',
+      async (method) => {
+        const d = createSupervisorDispatcher();
+        const r = await d.dispatch(method, {}, ctx);
+        expect(r.ok).toBe(false);
+        if (r.ok) return;
+        expect(r.error.code).toBe('NOT_IMPLEMENTED');
+        expect(r.error.method).toBe(method);
+        expect(r.error.message).toContain(method);
+      },
+    );
+
+    it('still rejects non-supervisor methods even with stubs registered', async () => {
+      const d = createSupervisorDispatcher();
+      const r = await d.dispatch('session.list', {}, ctx);
+      expect(r.ok).toBe(false);
+      if (r.ok) return;
+      expect(r.error.code).toBe('NOT_ALLOWED');
+    });
+  });
+});

--- a/daemon/src/dispatcher.ts
+++ b/daemon/src/dispatcher.ts
@@ -1,0 +1,201 @@
+// Control-socket dispatcher (T16) — literal-method router for the canonical
+// SUPERVISOR_RPCS allowlist (frag-3.4.1 §3.4.1.h).
+//
+// Spec citations:
+//   - docs/superpowers/specs/v0.3-fragments/frag-3.4.1-envelope-hardening.md
+//     §3.4.1.h (control-socket: `/healthz`, `/stats`, `daemon.hello`,
+//     `daemon.shutdown`, `daemon.shutdownForUpgrade`).
+//   - frag-6-7 §6.5 (supervisor transport = the `ccsm-control` socket; the
+//     control-socket dispatcher is the routing surface on that transport).
+//   - T11 (PR #646) landed the canonical `SUPERVISOR_RPCS` constant + the
+//     `isSupervisorRpc` predicate; this dispatcher is its first consumer.
+//
+// Single Responsibility: pure decider + handler invoker.
+//   - Producers: the control-socket transport (T14, parallel) parses envelopes
+//     and calls `dispatch(method, req, ctx)`.
+//   - Decider: the dispatcher checks the allowlist and routes to a handler.
+//   - Sink: the registered handler performs the actual side effect (read
+//     `/healthz` snapshot, write `/stats`, run shutdown, etc.). Handlers are
+//     stub implementations until T17–T21 replace them.
+//
+// This module performs ZERO socket I/O. Wiring to a Duplex stream is the
+// caller's responsibility (T14 control-socket.ts).
+
+import { isSupervisorRpc, SUPERVISOR_RPCS } from './envelope/supervisor-rpcs.js';
+
+/** Opaque per-call context. Shape locked by T14/T19 — for T16 the dispatcher
+ *  treats it as opaque and just forwards it to the registered handler. */
+export interface DispatchContext {
+  /** Crockford ULID of the originating client request (envelope `traceId`). */
+  readonly traceId?: string;
+  /** Wall-clock deadline derived from `x-ccsm-deadline-ms` (§3.4.1.c).
+   *  Forwarded to handlers; the dispatcher itself does NOT enforce it. */
+  readonly signal?: AbortSignal;
+}
+
+/** Generic handler signature. Payload + reply types are method-specific and
+ *  validated by each handler against its TypeBox schema (per §3.4.1.d
+ *  handler-arg discipline). The dispatcher is method-name-typed only. */
+export type Handler = (
+  req: unknown,
+  ctx: DispatchContext,
+) => Promise<unknown>;
+
+/** Typed error envelope returned to the caller. Mirrors the wire-level
+ *  rejection-frame shape used by other interceptors (e.g. migrationGate
+ *  `MIGRATION_PENDING`). The transport layer (T14) is responsible for
+ *  serialising this into an envelope error frame. */
+export interface DispatcherError {
+  readonly code:
+    | 'UNKNOWN_METHOD'
+    | 'NOT_ALLOWED'
+    | 'NOT_IMPLEMENTED';
+  readonly method: string;
+  readonly message: string;
+}
+
+export interface DispatchOk {
+  readonly ok: true;
+  readonly value: unknown;
+}
+
+export interface DispatchErr {
+  readonly ok: false;
+  readonly error: DispatcherError;
+}
+
+export type DispatchResult = DispatchOk | DispatchErr;
+
+/** Stub reply emitted by the placeholder handlers for T17–T21. Each
+ *  follow-up task replaces the corresponding stub with a real handler. */
+function stubHandler(method: string): Handler {
+  return async (_req, _ctx): Promise<never> => {
+    // Throwing a sentinel here would couple the stub to the dispatcher's error
+    // path. Instead we return a value the dispatcher recognises and converts
+    // into a NOT_IMPLEMENTED error envelope. Keeps the stub contract pure.
+    throw new NotImplementedError(method);
+  };
+}
+
+class NotImplementedError extends Error {
+  readonly method: string;
+  constructor(method: string) {
+    super(`handler for ${method} is not implemented yet`);
+    this.name = 'NotImplementedError';
+    this.method = method;
+  }
+}
+
+/** Build the default dispatcher pre-wired with NOT_IMPLEMENTED stubs for the
+ *  five canonical SUPERVISOR_RPCS. T17–T21 each call `register()` (or build
+ *  their own dispatcher in tests) to swap a stub for a real handler. */
+export function createSupervisorDispatcher(): Dispatcher {
+  const d = new Dispatcher();
+  // Stub registration order mirrors the SUPERVISOR_RPCS tuple so the wire
+  // contract row in §3.4.1.h and this file stay visually 1:1.
+  for (const method of SUPERVISOR_RPCS) {
+    d.register(method, stubHandler(method));
+  }
+  return d;
+}
+
+/**
+ * Literal-method router for the supervisor / control-socket plane.
+ *
+ * Responsibilities:
+ *   1. Reject non-allowlisted method names with NOT_ALLOWED (defence in depth
+ *      — the data-socket has its own dispatcher with a disjoint allowlist).
+ *   2. Reject unknown allowlisted methods (e.g. an allowlisted name with no
+ *      registered handler) with UNKNOWN_METHOD.
+ *   3. Invoke the registered handler and forward its resolved value.
+ *   4. Convert a thrown `NotImplementedError` from a stub into a typed
+ *      NOT_IMPLEMENTED reply (does NOT escape as an unhandled rejection).
+ *
+ * Non-responsibilities (intentional, per Single Responsibility):
+ *   - No envelope parsing / serialisation (lives in T14 control-socket).
+ *   - No deadline enforcement (deadlineInterceptor §3.4.1.f).
+ *   - No metrics emission (metricsInterceptor §3.4.1.f).
+ *   - No allowlist mutation — `SUPERVISOR_RPCS` is the single source of truth.
+ *   - No normalisation (literal compare, per §3.4.1.h carve-out lock).
+ */
+export class Dispatcher {
+  readonly #handlers: Map<string, Handler> = new Map();
+
+  /** Register or replace the handler for a canonical RPC method.
+   *
+   *  Throws if `method` is not a SUPERVISOR_RPCS member — registering a
+   *  handler the dispatcher would never call is a programming error and must
+   *  fail loud at boot (per Single Responsibility: producer must use the
+   *  canonical allowlist). */
+  register(method: string, handler: Handler): void {
+    if (!isSupervisorRpc(method)) {
+      throw new Error(
+        `Dispatcher.register: refusing to register non-supervisor RPC ${JSON.stringify(method)}; only SUPERVISOR_RPCS (§3.4.1.h) are routable on the control socket`,
+      );
+    }
+    this.#handlers.set(method, handler);
+  }
+
+  /** Inspect whether a handler is currently registered (test-facing helper). */
+  has(method: string): boolean {
+    return this.#handlers.has(method);
+  }
+
+  /**
+   * Route an inbound RPC to its handler.
+   *
+   * Decision table:
+   *   isSupervisorRpc=false                       → NOT_ALLOWED
+   *   isSupervisorRpc=true  ∧ no handler          → UNKNOWN_METHOD
+   *   isSupervisorRpc=true  ∧ handler throws stub → NOT_IMPLEMENTED
+   *   isSupervisorRpc=true  ∧ handler resolves    → { ok: true, value }
+   *
+   * Handler exceptions OTHER than the stub sentinel are NOT swallowed —
+   * they propagate to the caller (T14) which owns wire-level error mapping.
+   */
+  async dispatch(
+    method: string,
+    req: unknown,
+    ctx: DispatchContext,
+  ): Promise<DispatchResult> {
+    if (!isSupervisorRpc(method)) {
+      return {
+        ok: false,
+        error: {
+          code: 'NOT_ALLOWED',
+          method,
+          message: `RPC ${JSON.stringify(method)} is not on the control-socket allowlist (SUPERVISOR_RPCS, §3.4.1.h)`,
+        },
+      };
+    }
+
+    const handler = this.#handlers.get(method);
+    if (!handler) {
+      return {
+        ok: false,
+        error: {
+          code: 'UNKNOWN_METHOD',
+          method,
+          message: `no handler registered for control-socket RPC ${method}`,
+        },
+      };
+    }
+
+    try {
+      const value = await handler(req, ctx);
+      return { ok: true, value };
+    } catch (err) {
+      if (err instanceof NotImplementedError) {
+        return {
+          ok: false,
+          error: {
+            code: 'NOT_IMPLEMENTED',
+            method: err.method,
+            message: err.message,
+          },
+        };
+      }
+      throw err;
+    }
+  }
+}

--- a/daemon/src/index.ts
+++ b/daemon/src/index.ts
@@ -1,15 +1,16 @@
 import { ulid } from 'ulid';
 import pino from 'pino';
 import { createRequire } from 'node:module';
-import { SUPERVISOR_RPCS } from './envelope/supervisor-rpcs.js';
+import { createSupervisorDispatcher } from './dispatcher.js';
 
 const require = createRequire(import.meta.url);
 const DAEMON_VERSION = (require('../../package.json') as { version: string }).version;
 
-// T11 landed the canonical export; T16 owns the control-socket dispatcher
-// that actually routes on this allowlist. Keep a `void` reference here so
-// the import stays live until T16 wires it.
-void SUPERVISOR_RPCS;
+// T16 wires the control-socket dispatcher; T17–T21 each replace one of the
+// SUPERVISOR_RPCS stubs (NOT_IMPLEMENTED today) with a real handler. The
+// transport binding (T14) consumes this dispatcher from a Duplex socket.
+const supervisorDispatcher = createSupervisorDispatcher();
+void supervisorDispatcher;
 
 const bootNonce = ulid();
 


### PR DESCRIPTION
## Summary

Task #976 — T16 control-socket dispatcher skeleton. (Re-spec: T11 #646 already
landed the canonical `SUPERVISOR_RPCS` const + `isSupervisorRpc` predicate;
this PR is the **dispatcher itself**, not the const.)

Builds the literal-method router that the supervisor / control-socket
transport (T14, parallel) will mount on its Duplex stream.

- `daemon/src/dispatcher.ts` (NEW): `Dispatcher` class with
  `register / has / dispatch`, plus `createSupervisorDispatcher()` factory
  pre-wired with NOT_IMPLEMENTED stubs for the five canonical RPCs.
- Allowlist enforced via `isSupervisorRpc()` from the T11 module — non-
  allowlisted methods fail closed with `NOT_ALLOWED`. Data-socket has its
  own (separate) allowlist per spec; this dispatcher is supervisor-only.
- `register()` also refuses non-supervisor method names (fail-loud at boot).
- Pure decider: zero socket I/O, no envelope parse/serialise, no deadline /
  metrics enforcement (those live in §3.4.1.f interceptors). T14 owns the
  Duplex wiring; T17–T21 each just `register()` a real handler over the
  matching stub.
- `daemon/src/index.ts`: replaces the `void SUPERVISOR_RPCS` placeholder
  comment (left by T11 explicitly for T16) with
  `createSupervisorDispatcher()` so the router is live at boot.

## Spec citations

- `docs/superpowers/specs/v0.3-fragments/frag-3.4.1-envelope-hardening.md`
  §3.4.1.h — control-socket: `/healthz`, `/stats`, `daemon.hello`,
  `daemon.shutdown`, `daemon.shutdownForUpgrade`.
- frag-6-7 §6.5 — supervisor transport = the `ccsm-control` socket; this
  dispatcher is the routing surface mounted on it.
- T11 (PR #646) — canonical `SUPERVISOR_RPCS` const + `isSupervisorRpc`
  predicate (single source of truth).

## Hand-off note

T11's hand-off comment in `daemon/src/index.ts` ("T16 owns the control-socket
dispatcher that actually routes on this allowlist") is now resolved. Each of
T17–T21 just calls `supervisorDispatcher.register('<method>', realHandler)`
to swap a stub for the real handler — no further wiring required.

T14 (control-socket transport, parallel worker) consumes the `Dispatcher`
type from `./dispatcher.js` and calls `dispatch(method, req, ctx)` after
parsing each envelope.

## Test plan

- [x] `npx tsc --noEmit -p daemon/tsconfig.json` — clean
- [x] `npx vitest run daemon/src/__tests__/dispatcher.test.ts` — 24/24 pass
- [x] `npm run build:daemon` — builds; dispatcher.js loads via dynamic import
- [x] Full daemon vitest suite — 12 files pass, 2 pre-existing db failures
      from missing better-sqlite3 native binding (unrelated to this PR).

Test cases:
- Unknown method → `UNKNOWN_METHOD` error.
- Non-supervisor method (`session.list` etc.) on supervisor dispatcher →
  `NOT_ALLOWED`.
- Each of the 5 stub methods → `NOT_IMPLEMENTED` with method name echoed.
- `register / replace / dispatch` chain.
- `register()` refuses non-supervisor names.
- Non-stub handler exceptions are NOT swallowed (propagate to caller).