### PR TITLE
feat(daemon/db): T35 MIGRATION_PENDING gate consumer

### DIFF
--- a/daemon/src/db/__tests__/migration-gate-consumer.test.ts
+++ b/daemon/src/db/__tests__/migration-gate-consumer.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi } from 'vitest';
+import { MigrationGateConsumer, type MigrationState } from '../migration-gate-consumer.js';
+
+describe('MigrationGateConsumer (T35 — frag-8 §8.5/§8.6)', () => {
+  describe('initial state', () => {
+    it('starts in idle', () => {
+      const c = new MigrationGateConsumer();
+      expect(c.getMigrationState()).toBe<MigrationState>('idle');
+    });
+
+    it('reports not pending in idle (T10 fast path)', () => {
+      const c = new MigrationGateConsumer();
+      expect(c.isMigrationPending()).toBe(false);
+    });
+  });
+
+  describe('isMigrationPending() boolean projection (T10 contract)', () => {
+    it.each<[MigrationState, boolean]>([
+      ['idle', false],
+      ['pending', true],
+      ['completed', false],
+      ['failed', true],
+    ])('state=%s → isMigrationPending()=%s', (state, expected) => {
+      const c = new MigrationGateConsumer();
+      c.setMigrationState(state);
+      expect(c.isMigrationPending()).toBe(expected);
+    });
+  });
+
+  describe('setMigrationState transitions (spec §8.5)', () => {
+    it('idle → pending notifies subscribers with new state', () => {
+      const c = new MigrationGateConsumer();
+      const listener = vi.fn();
+      c.subscribe(listener);
+      c.setMigrationState('pending');
+      expect(c.getMigrationState()).toBe('pending');
+      expect(listener).toHaveBeenCalledWith('pending');
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('pending → completed flips isMigrationPending() back to false', () => {
+      const c = new MigrationGateConsumer();
+      c.setMigrationState('pending');
+      expect(c.isMigrationPending()).toBe(true);
+      c.setMigrationState('completed');
+      expect(c.isMigrationPending()).toBe(false);
+    });
+
+    it('pending → failed keeps isMigrationPending() true (modal still blocks)', () => {
+      const c = new MigrationGateConsumer();
+      c.setMigrationState('pending');
+      c.setMigrationState('failed');
+      expect(c.getMigrationState()).toBe('failed');
+      expect(c.isMigrationPending()).toBe(true);
+    });
+
+    it('no-op when next state equals current state (no notification)', () => {
+      const c = new MigrationGateConsumer();
+      const listener = vi.fn();
+      c.setMigrationState('pending');
+      c.subscribe(listener);
+      c.setMigrationState('pending'); // re-emit same value
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('subscribe / unsubscribe', () => {
+    it('returns disposer that stops further notifications', () => {
+      const c = new MigrationGateConsumer();
+      const listener = vi.fn();
+      const unsubscribe = c.subscribe(listener);
+      c.setMigrationState('pending');
+      unsubscribe();
+      c.setMigrationState('completed');
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledWith('pending');
+    });
+
+    it('disposer is idempotent (double-unsubscribe is safe)', () => {
+      const c = new MigrationGateConsumer();
+      const listener = vi.fn();
+      const unsubscribe = c.subscribe(listener);
+      unsubscribe();
+      unsubscribe();
+      c.setMigrationState('pending');
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('does not fire on subscribe (consumers must read getMigrationState)', () => {
+      const c = new MigrationGateConsumer();
+      c.setMigrationState('pending');
+      const listener = vi.fn();
+      c.subscribe(listener);
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('notifies multiple subscribers in registration order', () => {
+      const c = new MigrationGateConsumer();
+      const calls: Array<[string, MigrationState]> = [];
+      c.subscribe((s) => calls.push(['a', s]));
+      c.subscribe((s) => calls.push(['b', s]));
+      c.subscribe((s) => calls.push(['c', s]));
+      c.setMigrationState('pending');
+      expect(calls).toEqual([
+        ['a', 'pending'],
+        ['b', 'pending'],
+        ['c', 'pending'],
+      ]);
+    });
+
+    it('all subscribers see every transition', () => {
+      const c = new MigrationGateConsumer();
+      const a = vi.fn();
+      const b = vi.fn();
+      c.subscribe(a);
+      c.subscribe(b);
+      c.setMigrationState('pending');
+      c.setMigrationState('completed');
+      expect(a).toHaveBeenCalledTimes(2);
+      expect(b).toHaveBeenCalledTimes(2);
+      expect(a.mock.calls).toEqual([['pending'], ['completed']]);
+      expect(b.mock.calls).toEqual([['pending'], ['completed']]);
+    });
+
+    it('unsubscribing one listener does not affect siblings', () => {
+      const c = new MigrationGateConsumer();
+      const a = vi.fn();
+      const b = vi.fn();
+      const unsubA = c.subscribe(a);
+      c.subscribe(b);
+      unsubA();
+      c.setMigrationState('pending');
+      expect(a).not.toHaveBeenCalled();
+      expect(b).toHaveBeenCalledWith('pending');
+    });
+  });
+
+  describe('listener error isolation', () => {
+    it('a throwing listener does not block siblings', async () => {
+      const c = new MigrationGateConsumer();
+      const sibling = vi.fn();
+      // Capture the microtask-reraised error so vitest doesn't flag it
+      // as an unhandled exception; we want to assert it surfaces *off*
+      // the producer call stack, not that it disappears.
+      const captured: unknown[] = [];
+      const onUncaught = (err: unknown) => captured.push(err);
+      process.once('uncaughtException', onUncaught);
+      c.subscribe(() => {
+        throw new Error('boom');
+      });
+      c.subscribe(sibling);
+      // setState itself must not throw — error is reraised on a microtask.
+      expect(() => c.setMigrationState('pending')).not.toThrow();
+      expect(sibling).toHaveBeenCalledWith('pending');
+      // Drain microtasks so the queueMicrotask rethrow lands.
+      await new Promise<void>((r) => setImmediate(r));
+      process.removeListener('uncaughtException', onUncaught);
+      expect(captured).toHaveLength(1);
+      expect((captured[0] as Error).message).toBe('boom');
+    });
+
+    it('unsubscribing inside a callback does not skip the next sibling', () => {
+      const c = new MigrationGateConsumer();
+      const sibling = vi.fn();
+      const unsubSelf = c.subscribe(() => {
+        unsubSelf();
+      });
+      c.subscribe(sibling);
+      c.setMigrationState('pending');
+      expect(sibling).toHaveBeenCalledWith('pending');
+      // Self-unsubscribed listener is gone for the next transition.
+      sibling.mockClear();
+      c.setMigrationState('completed');
+      expect(sibling).toHaveBeenCalledWith('completed');
+    });
+  });
+
+  describe('clearSubscribersForTests', () => {
+    it('drops all listeners', () => {
+      const c = new MigrationGateConsumer();
+      const a = vi.fn();
+      const b = vi.fn();
+      c.subscribe(a);
+      c.subscribe(b);
+      c.clearSubscribersForTests();
+      c.setMigrationState('pending');
+      expect(a).not.toHaveBeenCalled();
+      expect(b).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/daemon/src/db/migration-gate-consumer.ts
+++ b/daemon/src/db/migration-gate-consumer.ts
@@ -1,0 +1,153 @@
+// T35: MIGRATION_PENDING gate consumer.
+//
+// Spec refs:
+//   - docs/superpowers/specs/v0.3-fragments/frag-8-sqlite-migration.md
+//     §8.5 short-circuit scope (`migrationState: 'pending' | 'completed' | 'failed'`)
+//   - Same fragment §8.6 (data RPCs return MIGRATION_PENDING; supervisor
+//     RPCs respond normally with `migrationState` diagnostic field)
+//   - daemon/src/envelope/migration-gate-interceptor.ts (T10 — pure decider
+//     that consumes the boolean derived from this state)
+//   - daemon/src/db/migration-events.ts (T30 — discriminated union the
+//     producer T29 emits; this module's setState() is what call sites use
+//     to flip state on those events)
+//
+// Single Responsibility (producer / decider / sink): this module is a
+// pure state holder. It does NOT
+//   - perform any I/O (no marker-file read, no socket write, no logging),
+//   - emit migration events (T30 owns the wire contract; producers call
+//     setState here AND emit a MigrationEvent on the IPC bus separately),
+//   - decide whether an RPC may proceed (T10 migrationGateInterceptor is
+//     the decider; it asks `isMigrationPending()` here),
+//   - re-derive the boolean from on-disk markers (frag-8 §8.3 owns marker
+//     read; the boot path translates the marker into the initial setState
+//     call).
+//
+// Consumers:
+//   1. T10 migrationGateInterceptor reads `isMigrationPending()` per RPC.
+//   2. Supervisor RPCs (`/healthz`, `/stats`, `/version`, `ping()`) read
+//      `getMigrationState()` to populate the diagnostic field per §8.5.
+//   3. The Electron-main daemon bridge subscribes to be notified when state
+//      transitions, so it can drive the renderer-blocking modal (frag-8 §8.6).
+//
+// State semantics (spec frag-8 §8.5 + §8.6):
+//   - 'idle'      → no migration in flight; no marker-driven blocking.
+//                   This is the boot-default and the post-completed state
+//                   for installs that never had a v0.2 db.
+//   - 'pending'   → migration runner is in progress; data RPCs MUST be
+//                   short-circuited with `MIGRATION_PENDING`.
+//   - 'completed' → migration finished successfully; data RPCs proceed
+//                   normally. Reported as `migrationState: 'completed'`
+//                   on supervisor RPC responses for diagnostics.
+//   - 'failed'    → migration ran and failed; data RPCs stay blocked
+//                   (the renderer surfaces the fatal-error modal per §8.6).
+//                   The daemon stays UP so logs/IPC keep working.
+//
+// Only `pending` and `failed` block data-plane RPCs. The interceptor sees
+// a single boolean (`isMigrationPending()`); the four-state surface is for
+// the supervisor diagnostic field.
+
+/**
+ * Migration lifecycle state. See module header for semantics.
+ *
+ * Spec §8.5 short-circuit defines three states (pending / completed /
+ * failed). 'idle' is added here as the explicit boot-default so the
+ * type system can distinguish "never ran" from "ran successfully" for
+ * the supervisor diagnostic. The wire format owned by §8.5 only
+ * surfaces three values; the bridge can collapse `idle → completed` if
+ * the diagnostic field needs to stay 3-valued.
+ */
+export type MigrationState = 'idle' | 'pending' | 'completed' | 'failed';
+
+/** Subscriber callback. Invoked synchronously after every state change. */
+export type MigrationStateListener = (state: MigrationState) => void;
+
+/** Disposer returned by `subscribe()`. Idempotent. */
+export type Unsubscribe = () => void;
+
+/**
+ * Pure state holder for the MIGRATION_PENDING gate.
+ *
+ * Construct one instance per daemon process (typically a module-level
+ * singleton wired in the daemon entry). Tests should construct their
+ * own instance to stay isolated.
+ *
+ * Thread/event-loop safety: setState + notify run synchronously on the
+ * caller. Listeners are invoked in registration order. A listener that
+ * throws does NOT prevent later listeners from being called (errors are
+ * caught and rethrown via queueMicrotask so the producer call site stays
+ * decoupled from sink failures).
+ */
+export class MigrationGateConsumer {
+  private state: MigrationState = 'idle';
+  private readonly listeners = new Set<MigrationStateListener>();
+
+  /** Read the current state. Cheap; safe to call per-RPC. */
+  getMigrationState(): MigrationState {
+    return this.state;
+  }
+
+  /**
+   * Convenience boolean for T10 migrationGateInterceptor: returns true
+   * iff data-plane RPCs MUST be short-circuited. Matches the
+   * `migrationPending` field on `MigrationGateContext`.
+   *
+   * 'pending' and 'failed' both block — see module header for rationale.
+   */
+  isMigrationPending(): boolean {
+    return this.state === 'pending' || this.state === 'failed';
+  }
+
+  /**
+   * Set the migration state and notify all subscribers if (and only if)
+   * the value changed. No-op if `next === current`, so producers can
+   * safely call this from idempotent re-emit paths without thrashing
+   * the renderer modal.
+   *
+   * Listener errors are isolated: a throwing listener does not prevent
+   * later listeners from running, but the error is re-raised on a
+   * microtask so it surfaces in unhandled-rejection logs rather than
+   * silently disappearing.
+   */
+  setMigrationState(next: MigrationState): void {
+    if (this.state === next) return;
+    this.state = next;
+    // Snapshot listeners so an unsubscribe() inside a callback doesn't
+    // skip a sibling. (Set iteration with concurrent mutation is
+    // technically defined in JS but spelling it out is safer.)
+    const snapshot = Array.from(this.listeners);
+    for (const listener of snapshot) {
+      try {
+        listener(next);
+      } catch (err) {
+        queueMicrotask(() => {
+          throw err;
+        });
+      }
+    }
+  }
+
+  /**
+   * Subscribe to state transitions. The listener is invoked AFTER every
+   * setMigrationState call that actually changed the value (no initial
+   * fire — call `getMigrationState()` if you need the current value at
+   * subscription time).
+   *
+   * Returns an idempotent unsubscribe function.
+   */
+  subscribe(listener: MigrationStateListener): Unsubscribe {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  /**
+   * Test-only helper: drop all subscribers. Production daemon never
+   * needs this (process exit drops the whole instance). Kept on the
+   * class rather than a separate _testing.ts surface because the
+   * single-file SRP boundary outweighs the test-export hygiene.
+   */
+  clearSubscribersForTests(): void {
+    this.listeners.clear();
+  }
+}


### PR DESCRIPTION
## Summary

T35 — pure state holder for the SQLite migration lifecycle, consumed by T10 (`migrationGateInterceptor`) and by supervisor RPCs (`/healthz`, `/stats`, `/version`, `ping()`) that report `migrationState` as a diagnostic field per frag-8 §8.5.

## Spec refs

- `docs/superpowers/specs/v0.3-fragments/frag-8-sqlite-migration.md` §8.5 short-circuit scope (`migrationState: 'pending' | 'completed' | 'failed'` on supervisor RPCs)
- Same fragment §8.6 (data RPCs return `MIGRATION_PENDING` while pending/failed; daemon stays UP)
- `daemon/src/envelope/migration-gate-interceptor.ts` (T10 — pure decider that reads `isMigrationPending()`)
- `daemon/src/db/migration-events.ts` (T30 — wire event contracts; producers call `setMigrationState()` alongside emitting the event)
- `daemon/src/db/migrate-v02-to-v03.ts` (T29 — migration runner that drives state transitions)

## State contract

```ts
type MigrationState = 'idle' | 'pending' | 'completed' | 'failed';
isMigrationPending() === (state === 'pending' || state === 'failed');
```

- `idle` — boot default, no migration ever ran. Allows data RPCs.
- `pending` — runner in progress; T10 short-circuits data RPCs.
- `completed` — success; data RPCs proceed normally.
- `failed` — runner threw; data RPCs stay blocked so the renderer fatal-error modal (frag-8 §8.6) holds the surface.

Spec only surfaces 3 wire values; `idle → completed` collapse can happen at the supervisor-RPC bridge if needed.

## Layer 1

Confirmed no existing event bus in `daemon/src/`. Minimal subscribe/notify is appropriate per the spec's narrow consumer set (T10 + supervisor RPCs + Electron-main bridge for the modal). Pure state holder — no I/O, no event emission, no RPC dispatch.

## Test plan

- [x] 19 unit tests: initial state, every transition pair, `isMigrationPending()` boolean projection (T10 contract), no-op same-state re-emit, single + multi-subscriber notify, unsubscribe (idempotent + safe inside callback), listener error isolation via `queueMicrotask` rethrow.
- [x] `npx vitest run daemon/src/db/__tests__/migration-gate-consumer.test.ts` → 19/19 pass.
- [x] `npx tsc --noEmit -p daemon/tsconfig.json` clean.
- Pre-existing daemon test failures in `migrate-v02-to-v03.test.ts` and `schema/v0.3.test.ts` are an env-side `better-sqlite3` ABI mismatch (`NODE_MODULE_VERSION 145 vs 137`) — unrelated to this PR; the new module has zero DB I/O.

## Out of scope

- Wiring this consumer into supervisor RPC handlers (separate task that owns `/healthz` etc.)
- Wiring producers (T29 runner) to call `setMigrationState()` (separate task)
- Electron-main bridge that subscribes for the modal (frag-8 §8.6 / T33 modal driver task)