### PR TITLE
feat(i18n): T32 zh.ts migration.modal.failed parity (stacks on #657)

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -186,6 +186,21 @@ const en = {
     title: 'Claude binary missing from this install',
     body: 'CCSM ships the Claude binary inside the installer, but we couldn’t find it on disk. Please reinstall CCSM to repair the install — sessions can’t start until then.'
   },
+  // Migration fatal-error modal (v0.3 design §6.8 surface registry,
+  // priority 85; canonical copy + key namespace owned by frag-8 §8.6).
+  // Sentence-case per feedback_no_uppercase_ui_strings; no
+  // ERROR/FAILED/FATAL terms. Only action is "Quit ccsm" — manual
+  // delete-and-relaunch (using the {{legacyDb}} / {{dataRoot}} paths
+  // surfaced in the body) is the documented retry mechanism.
+  migration: {
+    modal: {
+      failed: {
+        title: 'ccsm couldn’t migrate your previous data',
+        body: 'ccsm tried to move your data from the previous version but couldn’t complete the migration. Your previous data file at {{legacyDb}} is preserved unchanged — quit ccsm and contact support, or manually start fresh by deleting {{dataRoot}} and relaunching.',
+        actionQuit: 'Quit ccsm'
+      }
+    }
+  },
   importDialog: {
     title: 'Import sessions from Claude Code',
     description: 'Pick existing CLI transcripts to surface in CCSM. They resume on open.',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -175,6 +175,15 @@ const zh: EnCatalog = {
     title: '安装包内的 Claude 程序缺失',
     body: 'CCSM 在安装包里附带了 Claude 程序，但在硬盘上找不到它。请重新安装 CCSM 以修复 — 修复之前会话无法启动。'
   },
+  migration: {
+    modal: {
+      failed: {
+        title: 'ccsm 无法迁移您之前的数据',
+        body: 'ccsm 尝试把上一版本的数据搬过来，但没能完成迁移。您之前的数据文件位于 {{legacyDb}}，保持原样未做改动 — 请退出 ccsm 并联系支持团队，或手动删除 {{dataRoot}} 后重新启动以从头开始。',
+        actionQuit: '退出 ccsm'
+      }
+    }
+  },
   importDialog: {
     title: '从 Claude Code 导入会话',
     description: '挑选已有的 CLI 对话在 CCSM 中显示。打开时会自动 resume。',


### PR DESCRIPTION
## Summary

Stacked on **PR #657** (T31 en.ts migration.modal.failed). T31 intentionally broke CI by adding 3 new keys to `EnCatalog` without mirroring them in `zh.ts`; this PR closes the gap so the pair can merge together.

## CRITICAL merge order

**This PR MUST merge AFTER #657.** It targets `working` only because the bash-discipline hook blocks non-`working` bases (per `feedback_gh_pr_explicit_base.md`). The diff itself only adds zh keys for the en strings introduced by #657, so:

- Merging this BEFORE #657 -> `working` CI breaks (zh has keys the en catalog doesn't define)
- Merging this AFTER #657 -> CI restored

## Keys added to `src/i18n/locales/zh.ts`

- `migration.modal.failed.title` -> `ccsm 无法迁移您之前的数据`
- `migration.modal.failed.body` -> Chinese translation, **preserves `{{legacyDb}}` and `{{dataRoot}}` interpolations**
- `migration.modal.failed.actionQuit` -> `退出 ccsm`

Sentence-case, natural conversational Chinese (no all-caps / no FAILED / no FATAL terminology), per `feedback_no_uppercase_ui_strings` and §8.6 spec.

## Verification

- `npm run typecheck` -> clean (TS2741 from missing zh keys is gone)
- `npx vitest run tests/i18n-key-parity.test.ts` -> 2/2 passed (Test Files 1 passed, Tests 2 passed)

Refs spec: `docs/superpowers/specs/v0.3-design.md` §8.6
Closes Task #991

## Test plan

- [x] Typecheck passes locally on stacked branch tip
- [x] i18n key parity test passes (2/2)
- [ ] CI green after #657 merges to `working` and this rebases