### PR TITLE
feat(daemon): T41 fan-out registry

### DIFF
--- a/daemon/src/pty/__tests__/fanout-registry.test.ts
+++ b/daemon/src/pty/__tests__/fanout-registry.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createFanoutRegistry,
+  type DrainReason,
+  type Subscriber,
+} from '../fanout-registry.js';
+
+type Msg = string;
+
+function makeSubscriber(): Subscriber<Msg> & {
+  delivered: Msg[];
+  closedWith: DrainReason[];
+} {
+  const delivered: Msg[] = [];
+  const closedWith: DrainReason[] = [];
+  return {
+    delivered,
+    closedWith,
+    deliver(msg) {
+      delivered.push(msg);
+    },
+    close(reason) {
+      closedWith.push(reason);
+    },
+  };
+}
+
+describe('createFanoutRegistry', () => {
+  it('subscribe + broadcast → all subscribers receive in registration order', () => {
+    const reg = createFanoutRegistry<Msg>();
+    const a = makeSubscriber();
+    const b = makeSubscriber();
+    reg.subscribe('s1', a);
+    reg.subscribe('s1', b);
+    reg.broadcast('s1', 'hello');
+    expect(a.delivered).toEqual(['hello']);
+    expect(b.delivered).toEqual(['hello']);
+  });
+
+  it('subscribe + unsubscribe via returned fn → next broadcast skips that subscriber', () => {
+    const reg = createFanoutRegistry<Msg>();
+    const a = makeSubscriber();
+    const b = makeSubscriber();
+    const offA = reg.subscribe('s1', a);
+    reg.subscribe('s1', b);
+    reg.broadcast('s1', 'first');
+    offA();
+    reg.broadcast('s1', 'second');
+    expect(a.delivered).toEqual(['first']);
+    expect(b.delivered).toEqual(['first', 'second']);
+  });
+
+  it('returned unsubscribe fn is idempotent', () => {
+    const reg = createFanoutRegistry<Msg>();
+    const a = makeSubscriber();
+    const off = reg.subscribe('s1', a);
+    off();
+    off(); // must not throw
+    expect(reg.getSubscribers('s1')).toEqual([]);
+  });
+
+  it('explicit unsubscribe(sessionId, sub) works equivalently', () => {
+    const reg = createFanoutRegistry<Msg>();
+    const a = makeSubscriber();
+    reg.subscribe('s1', a);
+    reg.unsubscribe('s1', a);
+    reg.broadcast('s1', 'x');
+    expect(a.delivered).toEqual([]);
+  });
+
+  it('explicit unsubscribe does NOT invoke close()', () => {
+    const reg = createFanoutRegistry<Msg>();
+    const a = makeSubscriber();
+    reg.subscribe('s1', a);
+    reg.unsubscribe('s1', a);
+    expect(a.closedWith).toEqual([]);
+  });
+
+  it('multiple sessions are isolated — broadcast to A does not reach B', () => {
+    const reg = createFanoutRegistry<Msg>();
+    const a = makeSubscriber();
+    const b = makeSubscriber();
+    reg.subscribe('s1', a);
+    reg.subscribe('s2', b);
+    reg.broadcast('s1', 'for-a');
+    expect(a.delivered).toEqual(['for-a']);
+    expect(b.delivered).toEqual([]);
+    reg.broadcast('s2', 'for-b');
+    expect(a.delivered).toEqual(['for-a']);
+    expect(b.delivered).toEqual(['for-b']);
+  });
+
+  it('drainSession invokes close on every subscriber with the given reason', () => {
+    const reg = createFanoutRegistry<Msg>();
+    const a = makeSubscriber();
+    const b = makeSubscriber();
+    reg.subscribe('s1', a);
+    reg.subscribe('s1', b);
+    const reason: DrainReason = { kind: 'pty-exit', detail: 'code=0' };
+    reg.drainSession('s1', reason);
+    expect(a.closedWith).toEqual([reason]);
+    expect(b.closedWith).toEqual([reason]);
+  });
+
+  it('drainSession empties the session — subsequent broadcast is a no-op', () => {
+    const reg = createFanoutRegistry<Msg>();
+    const a = makeSubscriber();
+    reg.subscribe('s1', a);
+    reg.drainSession('s1', { kind: 'pty-exit' });
+    reg.broadcast('s1', 'after-drain');
+    expect(a.delivered).toEqual([]);
+    expect(reg.getSubscribers('s1')).toEqual([]);
+  });
+
+  it('drainSession does NOT cross sessions', () => {
+    const reg = createFanoutRegistry<Msg>();
+    const a = makeSubscriber();
+    const b = makeSubscriber();
+    reg.subscribe('s1', a);
+    reg.subscribe('s2', b);
+    reg.drainSession('s1', { kind: 'daemon-shutdown' });
+    expect(a.closedWith.length).toBe(1);
+    expect(b.closedWith).toEqual([]);
+    reg.broadcast('s2', 'still-alive');
+    expect(b.delivered).toEqual(['still-alive']);
+  });
+
+  it('subscribe-during-broadcast: snapshot iteration — newcomer does NOT receive current message', () => {
+    const reg = createFanoutRegistry<Msg>();
+    const newcomer = makeSubscriber();
+    const inserter: Subscriber<Msg> = {
+      deliver() {
+        reg.subscribe('s1', newcomer);
+      },
+      close() {},
+    };
+    reg.subscribe('s1', inserter);
+    reg.broadcast('s1', 'first');
+    expect(newcomer.delivered).toEqual([]);
+    reg.broadcast('s1', 'second');
+    expect(newcomer.delivered).toEqual(['second']);
+  });
+
+  it('unsubscribe-during-broadcast: does not crash, peers still receive', () => {
+    const reg = createFanoutRegistry<Msg>();
+    const a = makeSubscriber();
+    const c = makeSubscriber();
+    const selfRemoving: Subscriber<Msg> = {
+      deliver() {
+        reg.unsubscribe('s1', selfRemoving);
+      },
+      close() {},
+    };
+    reg.subscribe('s1', a);
+    reg.subscribe('s1', selfRemoving);
+    reg.subscribe('s1', c);
+    expect(() => reg.broadcast('s1', 'msg')).not.toThrow();
+    // a and c both delivered (snapshot was taken); selfRemoving is gone
+    // for next broadcast.
+    expect(a.delivered).toEqual(['msg']);
+    expect(c.delivered).toEqual(['msg']);
+    expect(reg.getSubscribers('s1')).toEqual([a, c]);
+    reg.broadcast('s1', 'msg2');
+    expect(a.delivered).toEqual(['msg', 'msg2']);
+    expect(c.delivered).toEqual(['msg', 'msg2']);
+  });
+
+  it('broadcast to a session with no subscribers is a no-op (no throw)', () => {
+    const reg = createFanoutRegistry<Msg>();
+    expect(() => reg.broadcast('nonexistent', 'x')).not.toThrow();
+  });
+
+  it('drainSession on a session with no subscribers is a no-op (no throw)', () => {
+    const reg = createFanoutRegistry<Msg>();
+    expect(() =>
+      reg.drainSession('nonexistent', { kind: 'pty-exit' }),
+    ).not.toThrow();
+  });
+
+  it('subscriber that throws in deliver does not poison peers; error logged via onSubscriberError', () => {
+    const onSubscriberError = vi.fn();
+    const reg = createFanoutRegistry<Msg>({ onSubscriberError });
+    const bad: Subscriber<Msg> = {
+      deliver() {
+        throw new Error('boom');
+      },
+      close() {},
+    };
+    const good = makeSubscriber();
+    reg.subscribe('s1', bad);
+    reg.subscribe('s1', good);
+    reg.broadcast('s1', 'msg');
+    expect(good.delivered).toEqual(['msg']);
+    expect(onSubscriberError).toHaveBeenCalledTimes(1);
+    const [err, ctx] = onSubscriberError.mock.calls[0]!;
+    expect((err as Error).message).toBe('boom');
+    expect(ctx).toEqual({ sessionId: 's1', phase: 'deliver' });
+  });
+
+  it('subscriber that throws in close does not block peers; error logged', () => {
+    const onSubscriberError = vi.fn();
+    const reg = createFanoutRegistry<Msg>({ onSubscriberError });
+    const bad: Subscriber<Msg> = {
+      deliver() {},
+      close() {
+        throw new Error('close-boom');
+      },
+    };
+    const good = makeSubscriber();
+    reg.subscribe('s1', bad);
+    reg.subscribe('s1', good);
+    reg.drainSession('s1', { kind: 'daemon-shutdown' });
+    expect(good.closedWith.length).toBe(1);
+    expect(onSubscriberError).toHaveBeenCalledTimes(1);
+    expect(onSubscriberError.mock.calls[0]![1]).toEqual({
+      sessionId: 's1',
+      phase: 'close',
+    });
+  });
+
+  it('getSubscribers returns a snapshot — mutating it does not affect registry', () => {
+    const reg = createFanoutRegistry<Msg>();
+    const a = makeSubscriber();
+    reg.subscribe('s1', a);
+    const snap = reg.getSubscribers('s1') as Subscriber<Msg>[];
+    snap.length = 0;
+    expect(reg.getSubscribers('s1')).toEqual([a]);
+  });
+
+  it('same Subscriber object on two different sessions is independent', () => {
+    const reg = createFanoutRegistry<Msg>();
+    const shared = makeSubscriber();
+    reg.subscribe('s1', shared);
+    reg.subscribe('s2', shared);
+    reg.broadcast('s1', 'a');
+    reg.broadcast('s2', 'b');
+    expect(shared.delivered).toEqual(['a', 'b']);
+    reg.drainSession('s1', { kind: 'pty-exit' });
+    // s2 still has it
+    expect(reg.getSubscribers('s2')).toEqual([shared]);
+    reg.broadcast('s2', 'c');
+    expect(shared.delivered).toEqual(['a', 'b', 'c']);
+  });
+
+  it('double-subscribe of same subscriber to same session is deduped (Set semantics)', () => {
+    const reg = createFanoutRegistry<Msg>();
+    const a = makeSubscriber();
+    reg.subscribe('s1', a);
+    reg.subscribe('s1', a);
+    reg.broadcast('s1', 'msg');
+    expect(a.delivered).toEqual(['msg']); // delivered exactly once
+    expect(reg.getSubscribers('s1')).toEqual([a]);
+  });
+});

--- a/daemon/src/pty/fanout-registry.ts
+++ b/daemon/src/pty/fanout-registry.ts
@@ -1,0 +1,218 @@
+// Per-session fan-out registry for PTY data subscribers.
+//
+// Spec: docs/superpowers/specs/v0.3-fragments/frag-3.5.1-pty-hardening.md
+// §3.5.1.5 — "Single fan-out registry per session ... Each ptySubscribe
+// call registers a callback on the session's Set<Subscriber>; PTY data hits
+// each callback synchronously in registration order, wrapped in try/catch
+// so one slow subscriber cannot poison others."
+//
+// Single Responsibility (per feedback_single_responsibility): this module
+// is the SINK side of the producer/decider/sink trio.
+//   - Producer: PTY `onData` event (NOT here — T42-T48 territory).
+//   - Decider: T40 snapshot semaphore + T43 drop-slowest watermark
+//     (separate modules; this registry must not enforce backpressure).
+//   - Sink (this file): hold the per-session subscriber set and route
+//     broadcasts to it.
+//
+// Hard non-goals (do NOT add here, push back if asked):
+//   - No serialization / framing — caller passes already-built message.
+//   - No backpressure / drop-slowest accounting — owned by T43.
+//   - No PTY event listening — owned by T42 producer wiring.
+//   - No lifecycle FSM — drainSession is invoked BY the lifecycle
+//     module (T37) at exit/crash transitions; this file just executes
+//     the bulk-close.
+
+/**
+ * A subscriber is identified by an opaque object reference (Set identity).
+ * The registry only invokes `deliver` on broadcast and `close` on drain.
+ * Callers (T42 producer, T44 stream RPC) own the Subscriber instance and
+ * provide it on subscribe; the registry never inspects fields like
+ * `lastAck`, `streamId`, `bufferQueue` — those are owned by callers and
+ * by T43's drop-slowest decider.
+ */
+export interface Subscriber<TMessage = unknown> {
+  /** Invoked once per broadcast. MUST NOT throw to caller — registry
+   *  catches and logs so one slow subscriber cannot poison others
+   *  (§3.5.1.5). */
+  deliver(message: TMessage): void;
+  /** Invoked once when the registry drains the session (e.g. PTY exit,
+   *  daemon shutdown). The registry passes the structured reason; the
+   *  subscriber is responsible for closing its underlying stream and
+   *  releasing resources. MUST NOT throw to caller. */
+  close(reason: DrainReason): void;
+}
+
+/** Structured close reason for `drainSession`. The registry is reason-
+ *  agnostic — callers (T37 lifecycle FSM, shutdown sequence §3.5.1.2)
+ *  pick the appropriate enum and optional human-readable detail. */
+export interface DrainReason {
+  /** Coarse cause. Mirrors §3.5.1.2 / §3.5.1.5 vocabulary.
+   *  - `'pty-exit'`: session exited normally; lifecycle FSM transition
+   *    to `exited`.
+   *  - `'pty-crashed'`: session exited abnormally; lifecycle FSM
+   *    transition to `crashed`.
+   *  - `'daemon-shutdown'`: daemon-wide shutdown (§3.5.1.2 step 4).
+   *  - `'session-removed'`: session row deleted while subscribers still
+   *    attached (defensive). */
+  kind: 'pty-exit' | 'pty-crashed' | 'daemon-shutdown' | 'session-removed';
+  /** Optional free-form detail for log lines. */
+  detail?: string;
+}
+
+export interface FanoutRegistry<TMessage = unknown> {
+  /** Register `subscriber` for `sessionId`. Returns an unsubscribe
+   *  function that removes only this subscriber (idempotent — calling
+   *  the returned fn twice is a no-op). The same Subscriber object can
+   *  be subscribed to multiple sessions; identity is per (sessionId,
+   *  subscriber) pair. */
+  subscribe(sessionId: string, subscriber: Subscriber<TMessage>): () => void;
+  /** Remove `subscriber` from `sessionId`. No-op if not present. Does
+   *  NOT invoke `subscriber.close()` — the caller is performing the
+   *  removal voluntarily and owns its own cleanup. */
+  unsubscribe(sessionId: string, subscriber: Subscriber<TMessage>): void;
+  /** Synchronously deliver `message` to every subscriber currently
+   *  registered for `sessionId`. Iteration is over a snapshot taken at
+   *  call entry, so subscribers added/removed mid-broadcast do not
+   *  affect this broadcast (§3.5.1.5: "registration order, wrapped in
+   *  try/catch"). No-op if the session has no subscribers. */
+  broadcast(sessionId: string, message: TMessage): void;
+  /** Return the current set of subscribers for `sessionId` as an
+   *  immutable array snapshot. Primarily for tests and for T43's
+   *  drop-slowest decider to enumerate candidates. Empty array if the
+   *  session has no subscribers. */
+  getSubscribers(sessionId: string): ReadonlyArray<Subscriber<TMessage>>;
+  /** Bulk-close every subscriber for `sessionId`. Each subscriber's
+   *  `close(reason)` is invoked exactly once (errors caught & logged),
+   *  the session entry is removed from the registry, and subsequent
+   *  broadcasts to that sessionId are no-ops until a new `subscribe`
+   *  re-creates the entry. No-op if the session has no subscribers. */
+  drainSession(sessionId: string, reason: DrainReason): void;
+}
+
+export interface FanoutRegistryOptions {
+  /** Optional logger for caught subscriber errors. Defaults to
+   *  `console.warn`. The daemon will pass a pino child logger in
+   *  wiring (T42); tests can pass a spy. */
+  onSubscriberError?: (
+    err: unknown,
+    ctx: { sessionId: string; phase: 'deliver' | 'close' },
+  ) => void;
+}
+
+const defaultErrorLogger: NonNullable<FanoutRegistryOptions['onSubscriberError']> = (
+  err,
+  ctx,
+) => {
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[fanout-registry] subscriber threw during ${ctx.phase} for session ${ctx.sessionId}`,
+    err,
+  );
+};
+
+/**
+ * Create a new fan-out registry instance. The daemon process holds one
+ * instance shared across all PTY sessions; tests typically create a
+ * fresh instance per case to avoid cross-test state.
+ */
+export function createFanoutRegistry<TMessage = unknown>(
+  opts: FanoutRegistryOptions = {},
+): FanoutRegistry<TMessage> {
+  const onError = opts.onSubscriberError ?? defaultErrorLogger;
+  // Per-session subscriber set. We use Set for O(1) add/remove and to
+  // dedupe accidental double-subscribe of the same Subscriber object.
+  // Insertion order is preserved (Set semantics), satisfying the spec's
+  // "registration order" requirement (§3.5.1.5).
+  const bySession = new Map<string, Set<Subscriber<TMessage>>>();
+
+  function subscribe(
+    sessionId: string,
+    subscriber: Subscriber<TMessage>,
+  ): () => void {
+    let set = bySession.get(sessionId);
+    if (!set) {
+      set = new Set();
+      bySession.set(sessionId, set);
+    }
+    set.add(subscriber);
+    let unsubscribed = false;
+    return () => {
+      if (unsubscribed) return;
+      unsubscribed = true;
+      unsubscribe(sessionId, subscriber);
+    };
+  }
+
+  function unsubscribe(
+    sessionId: string,
+    subscriber: Subscriber<TMessage>,
+  ): void {
+    const set = bySession.get(sessionId);
+    if (!set) return;
+    set.delete(subscriber);
+    if (set.size === 0) {
+      bySession.delete(sessionId);
+    }
+  }
+
+  function broadcast(sessionId: string, message: TMessage): void {
+    const set = bySession.get(sessionId);
+    if (!set || set.size === 0) return;
+    // Snapshot-then-iterate. A subscriber that calls subscribe() or
+    // unsubscribe() inside its deliver() callback must NOT mutate the
+    // current broadcast's iteration (§3.5.1.5: a slow subscriber
+    // cannot poison others — and a re-entrant one likewise cannot
+    // skip/double-deliver to peers). Set iteration in JS is live; the
+    // copy is mandatory.
+    const snapshot = Array.from(set);
+    for (const subscriber of snapshot) {
+      try {
+        subscriber.deliver(message);
+      } catch (err) {
+        onError(err, { sessionId, phase: 'deliver' });
+      }
+    }
+  }
+
+  function getSubscribers(
+    sessionId: string,
+  ): ReadonlyArray<Subscriber<TMessage>> {
+    const set = bySession.get(sessionId);
+    if (!set || set.size === 0) return [];
+    return Array.from(set);
+  }
+
+  function drainSession(sessionId: string, reason: DrainReason): void {
+    const set = bySession.get(sessionId);
+    if (!set || set.size === 0) {
+      // Still ensure the entry is gone (defensive — empty Sets are
+      // already pruned by unsubscribe(), but a caller might drain a
+      // session that never had subscribers, which is fine).
+      bySession.delete(sessionId);
+      return;
+    }
+    // Snapshot first, then evict the session entry, THEN invoke close
+    // on each subscriber. This ordering means any close() callback
+    // that re-enters subscribe(sessionId, ...) creates a fresh entry
+    // (the session is "drained" by the time close fires), which
+    // matches the lifecycle FSM intent: drain marks the OLD generation
+    // closed; new subscribers attach to a fresh registry slot.
+    const snapshot = Array.from(set);
+    bySession.delete(sessionId);
+    for (const subscriber of snapshot) {
+      try {
+        subscriber.close(reason);
+      } catch (err) {
+        onError(err, { sessionId, phase: 'close' });
+      }
+    }
+  }
+
+  return {
+    subscribe,
+    unsubscribe,
+    broadcast,
+    getSubscribers,
+    drainSession,
+  };
+}


### PR DESCRIPTION
## Summary

Task #998 — v0.3 PTY hardening **T41**: per-session fan-out registry. The SINK side of the producer/decider/sink trio (per `feedback_single_responsibility`).

Spec: `docs/superpowers/specs/v0.3-fragments/frag-3.5.1-pty-hardening.md` §3.5.1.5 ("Subscriber fan-out (multi-subscriber semantics)") — single registry per session, callbacks fired in registration order, slow subscriber cannot poison peers.

## API (`daemon/src/pty/fanout-registry.ts`)

```ts
createFanoutRegistry<TMessage>({ onSubscriberError? }) -> {
  subscribe(sessionId, subscriber): unsubscribeFn
  unsubscribe(sessionId, subscriber): void
  broadcast(sessionId, message): void
  getSubscribers(sessionId): ReadonlyArray<Subscriber>
  drainSession(sessionId, reason): void
}

interface Subscriber<TMessage> {
  deliver(message: TMessage): void
  close(reason: DrainReason): void
}

interface DrainReason {
  kind: 'pty-exit' | 'pty-crashed' | 'daemon-shutdown' | 'session-removed'
  detail?: string
}
```

## Invariants

- Per-session `Map<sessionId, Set<Subscriber>>`; insertion order preserved (§3.5.1.5 "registration order").
- `broadcast` snapshots before iterating — `subscribe` / `unsubscribe` re-entrancy inside a `deliver()` callback cannot poison the current broadcast (newcomers wait until next broadcast; self-removers complete this round).
- Subscriber errors in `deliver()` / `close()` are caught and routed to `onSubscriberError` (default `console.warn`). One slow subscriber cannot poison peers.
- `drainSession` evicts the session entry **before** invoking `close()`, so a re-entrant `subscribe()` inside `close()` opens a fresh slot for the new generation.
- Empty sessions pruned on `unsubscribe`; `broadcast` / `drain` on nonexistent sessions are no-ops.
- Unsubscribe fn is idempotent.
- Same `Subscriber` instance on two different sessions is independent.

## Hard non-goals (push back, owned elsewhere)

- **No serialization / framing** — caller passes pre-built message (§3.4.1.c owns the framed buffer).
- **No backpressure / drop-slowest accounting** — T43 owns the 1 MB watermark and aggregate cap (§3.5.1.5 lines 118–119).
- **No PTY event listening** — T42 producer wires `p.onData -> broadcast`.
- **No lifecycle FSM** — T37 lifecycle invokes `drainSession` at exit/crash transitions; this file just executes the bulk-close.

## Test plan

- [x] `npx tsc --noEmit -p daemon/tsconfig.json` — clean
- [x] `npx vitest run daemon/src/pty/__tests__/fanout-registry.test.ts` — **18/18 pass**
  - subscribe + broadcast → all receive in registration order
  - unsubscribe via returned fn / explicit / idempotent / no `close()`
  - multi-session isolation (broadcast / drain don't cross)
  - drainSession invokes `close()` with reason; subsequent broadcast is no-op
  - subscribe-during-broadcast: snapshot iteration (newcomer skipped)
  - unsubscribe-during-broadcast: peers still receive, no crash
  - throw-in-`deliver()` / throw-in-`close()`: peers unaffected, `onSubscriberError` invoked with `{ sessionId, phase }`
  - broadcast / drain on nonexistent session: no-op
  - `getSubscribers` returns mutable snapshot that doesn't mutate registry
  - same Subscriber across sessions is independent
  - double-subscribe dedupes (Set semantics)
- [x] main-process smoke: `npm run build:daemon` + `node -e "import('./daemon/dist-daemon/pty/fanout-registry.js')"` round-trip — OK

## Layer 1 check

Pure SRP sink. No producer logic (PTY listener belongs to T42), no decider logic (drop-slowest belongs to T43). Caller-owned `Subscriber` shape stays opaque (registry never inspects `lastAck` / `streamId` / `bufferQueue`).