### PR TITLE
feat(daemon): T17 /healthz handler

### DIFF
--- a/daemon/src/handlers/__tests__/healthz.test.ts
+++ b/daemon/src/handlers/__tests__/healthz.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest';
+
+import { DAEMON_PROTOCOL_VERSION } from '../../envelope/protocol-version.js';
+import {
+  HEALTHZ_DAEMON_ACCEPTED_WIRES,
+  HEALTHZ_FEATURES,
+  HEALTHZ_MIN_CLIENT,
+  HEALTHZ_VERSION,
+  HEALTHZ_WIRE,
+  handleHealthz,
+  makeHealthzHandler,
+  type HealthzContext,
+} from '../healthz.js';
+
+/** Fake-clock helper — the handler reads `ctx.now()` exactly once per call,
+ *  so an array-pop counter is enough to verify monotonicity below. */
+function makeCtx(overrides: Partial<HealthzContext> = {}): HealthzContext {
+  return {
+    bootNonce: '01HK9Z9Z9Z9Z9Z9Z9Z9Z9Z9Z9Z',
+    pid: 12345,
+    version: '0.3.0-test',
+    bootedAtMs: 1_000_000,
+    now: () => 1_000_000,
+    ...overrides,
+  };
+}
+
+describe('handleHealthz: response shape (frag-6-7 §6.5)', () => {
+  it('returns every field documented in the spec body', () => {
+    const reply = handleHealthz({}, makeCtx({ now: () => 1_000_500 }));
+
+    // Required scalar fields per §6.5 lines 124-140.
+    expect(reply).toMatchObject({
+      uptimeMs: 500,
+      pid: 12345,
+      version: '0.3.0-test',
+      bootNonce: '01HK9Z9Z9Z9Z9Z9Z9Z9Z9Z9Z9Z',
+      sessionCount: 0,
+      subscriberCount: 0,
+      migrationState: 'absent',
+      swapInProgress: false,
+      healthzVersion: HEALTHZ_VERSION,
+    });
+
+    // The protocol block is mirrored 1:1 from `daemon.hello` reply
+    // (§6.5 "canonical version-negotiation payload, mirrored 1:1").
+    expect(reply.protocol).toEqual({
+      wire: HEALTHZ_WIRE,
+      minClient: HEALTHZ_MIN_CLIENT,
+      daemonProtocolVersion: DAEMON_PROTOCOL_VERSION,
+      daemonAcceptedWires: HEALTHZ_DAEMON_ACCEPTED_WIRES,
+      features: HEALTHZ_FEATURES,
+    });
+  });
+
+  it('omits no documented spec keys (defensive against typo regressions)', () => {
+    const reply = handleHealthz({}, makeCtx());
+    const keys = Object.keys(reply).sort();
+    expect(keys).toEqual(
+      [
+        'bootNonce',
+        'healthzVersion',
+        'migrationState',
+        'pid',
+        'protocol',
+        'sessionCount',
+        'subscriberCount',
+        'swapInProgress',
+        'uptimeMs',
+        'version',
+      ].sort(),
+    );
+  });
+
+  it('healthzVersion is the spec literal 1 (frag-6-7 §6.5 r3 P1-3)', () => {
+    expect(HEALTHZ_VERSION).toBe(1);
+    expect(handleHealthz({}, makeCtx()).healthzVersion).toBe(1);
+  });
+
+  it('daemonProtocolVersion is the spec literal 1 (frag-3.4.1 §3.4.1.g r9 lock)', () => {
+    expect(DAEMON_PROTOCOL_VERSION).toBe(1);
+    expect(handleHealthz({}, makeCtx()).protocol.daemonProtocolVersion).toBe(1);
+  });
+
+  it("v0.3 daemonAcceptedWires is exactly ['v0.3-json-envelope'] (r3 P1-5)", () => {
+    expect(HEALTHZ_DAEMON_ACCEPTED_WIRES).toEqual(['v0.3-json-envelope']);
+  });
+
+  it('features array contains the six v0.3-locked capability strings', () => {
+    expect(HEALTHZ_FEATURES).toEqual([
+      'binary-frames',
+      'stream-heartbeat',
+      'interceptors',
+      'traceId',
+      'bootNonce',
+      'hello',
+    ]);
+  });
+});
+
+describe('handleHealthz: uptime monotonicity', () => {
+  it('uptime increases with the injected clock', () => {
+    let now = 1_000_000;
+    const ctx = makeCtx({ bootedAtMs: 1_000_000, now: () => now });
+
+    const a = handleHealthz({}, ctx).uptimeMs;
+    now = 1_000_250;
+    const b = handleHealthz({}, ctx).uptimeMs;
+    now = 1_005_000;
+    const c = handleHealthz({}, ctx).uptimeMs;
+
+    expect(a).toBe(0);
+    expect(b).toBe(250);
+    expect(c).toBe(5_000);
+    expect(b).toBeGreaterThan(a);
+    expect(c).toBeGreaterThan(b);
+  });
+
+  it('clamps uptime to >=0 on clock rewind (NTP step / hibernate resume)', () => {
+    // Spec: /healthz must NEVER error (§6.5 "always returns liveness"),
+    // so a backwards clock collapses to 0 instead of throwing or going
+    // negative — the supervisor reads liveness, not absolute time.
+    const ctx = makeCtx({ bootedAtMs: 5_000, now: () => 1_000 });
+    expect(handleHealthz({}, ctx).uptimeMs).toBe(0);
+  });
+});
+
+describe('handleHealthz: injected providers', () => {
+  it('forwards live counter snapshots from the providers', () => {
+    let sessions = 7;
+    let subs = 13;
+    const ctx = makeCtx({
+      getSessionCount: () => sessions,
+      getSubscriberCount: () => subs,
+    });
+
+    const r1 = handleHealthz({}, ctx);
+    expect(r1.sessionCount).toBe(7);
+    expect(r1.subscriberCount).toBe(13);
+
+    sessions = 0;
+    subs = 0;
+    const r2 = handleHealthz({}, ctx);
+    expect(r2.sessionCount).toBe(0);
+    expect(r2.subscriberCount).toBe(0);
+  });
+
+  it('migrationState reflects the injected provider', () => {
+    for (const state of ['absent', 'pending', 'in-progress', 'done'] as const) {
+      const reply = handleHealthz({}, makeCtx({ getMigrationState: () => state }));
+      expect(reply.migrationState).toBe(state);
+    }
+  });
+
+  it('swapInProgress reflects the injected provider (frag-6-7 §6.4 step 4-7)', () => {
+    expect(handleHealthz({}, makeCtx({ getSwapInProgress: () => true })).swapInProgress).toBe(true);
+    expect(handleHealthz({}, makeCtx({ getSwapInProgress: () => false })).swapInProgress).toBe(false);
+  });
+
+  it('defaults: missing providers yield 0 / "absent" / false', () => {
+    const reply = handleHealthz({}, makeCtx());
+    expect(reply.sessionCount).toBe(0);
+    expect(reply.subscriberCount).toBe(0);
+    expect(reply.migrationState).toBe('absent');
+    expect(reply.swapInProgress).toBe(false);
+  });
+});
+
+describe('handleHealthz: purity (no I/O, ignores req)', () => {
+  it('produces identical replies for identical clocks regardless of req', () => {
+    const ctx = makeCtx({ now: () => 1_000_100 });
+    const a = handleHealthz({}, ctx);
+    const b = handleHealthz({ junk: 'ignored' }, ctx);
+    const c = handleHealthz(undefined, ctx);
+    expect(a).toEqual(b);
+    expect(b).toEqual(c);
+  });
+
+  it('does not mutate the injected context', () => {
+    const ctx = makeCtx();
+    const snapshot = JSON.stringify(ctx);
+    handleHealthz({}, ctx);
+    expect(JSON.stringify(ctx)).toBe(snapshot);
+  });
+});
+
+describe('makeHealthzHandler: T16 dispatcher adapter', () => {
+  it('returns an async handler that resolves to the same shape', async () => {
+    let now = 2_000_000;
+    const ctx = makeCtx({ bootedAtMs: 2_000_000, now: () => now });
+    const handler = makeHealthzHandler(ctx);
+
+    const r1 = await handler({});
+    expect(r1.uptimeMs).toBe(0);
+
+    now = 2_005_000;
+    const r2 = await handler({});
+    expect(r2.uptimeMs).toBe(5_000);
+    expect(r2.healthzVersion).toBe(1);
+  });
+
+  it('handler signature is compatible with the Dispatcher.Handler contract', async () => {
+    // Compile-time + runtime check: the returned function is `(req) => Promise`.
+    const handler = makeHealthzHandler(makeCtx());
+    const result = handler('any-req-payload');
+    expect(result).toBeInstanceOf(Promise);
+    await expect(result).resolves.toBeDefined();
+  });
+});

--- a/daemon/src/handlers/healthz.ts
+++ b/daemon/src/handlers/healthz.ts
@@ -1,0 +1,176 @@
+// /healthz handler (T17) — control-socket liveness probe.
+//
+// Spec citations:
+//   - frag-6-7 §6.5 "Health probe + dedicated supervisor transport" — canonical
+//     owner of the response payload shape.
+//   - frag-3.4.1 §3.4.1.h — `/healthz` is a wire-literal control-plane RPC
+//     (NOT `ccsm.v1/daemon.healthz`); registered on the control-socket
+//     dispatcher (T16) as the literal string.
+//   - frag-3.4.1 §3.4.1.f — supervisor transport is the SINGLE channel that
+//     ignores `MIGRATION_PENDING` short-circuit; `/healthz` ALWAYS returns a
+//     liveness body, never a sentinel error. The body carries `migrationState`
+//     so the supervisor can observe the migration window inline.
+//
+// Response shape (frag-6-7 §6.5):
+//   { uptimeMs, pid, version, bootNonce, sessionCount, subscriberCount,
+//     migrationState, swapInProgress,
+//     protocol: { wire, minClient, daemonProtocolVersion, daemonAcceptedWires,
+//                 features },
+//     healthzVersion: 1 }
+//
+// Single Responsibility: pure decider. Reads injected boot context + counter
+// providers, returns a snapshot. Performs ZERO socket I/O and ZERO database
+// queries (per §6.5 "Cheap (~50µs)" budget — three consecutive misses inside
+// a 15 s window restart the daemon, so the handler MUST stay branch-free of
+// any path that can block).
+//
+// The boot-time / counter providers are injected so:
+//   1. The daemon shell (T1 / index.ts) owns the live values; this module
+//      stays a pure function and is trivially testable with a fake clock.
+//   2. T18-T21 (other supervisor RPCs) and the dispatcher wiring (T16) can
+//      build the context once at boot and share it across handlers.
+//   3. v0.4 protobuf swap can reuse the handler verbatim — only the wire
+//      serialiser changes.
+
+import { DAEMON_PROTOCOL_VERSION } from '../envelope/protocol-version.js';
+
+/** Migration FSM states surfaced via `/healthz` (frag-6-7 §6.5 + frag-8 §8.5).
+ *  v0.3 ships SQLite migration; the four states are the canonical FSM. */
+export type MigrationState = 'absent' | 'pending' | 'in-progress' | 'done';
+
+/** Wire-literal canonical for v0.3 (frag-3.4.1 §3.4.1.g). */
+export const HEALTHZ_WIRE = 'v0.3-json-envelope' as const;
+
+/** Lowest client wire-version this daemon will negotiate (frag-3.4.1 §3.4.1.g). */
+export const HEALTHZ_MIN_CLIENT = 'v0.3' as const;
+
+/** v0.3 daemon accepts only the v0.3 envelope (frag-3.4.1 §3.4.1.g r3 P1-5).
+ *  v0.4 will append `'v0.4-protobuf'` during the rolling-upgrade window. */
+export const HEALTHZ_DAEMON_ACCEPTED_WIRES = [
+  'v0.3-json-envelope',
+] as const;
+
+/** Feature advertisement string list — additive evolution (frag-6-7 §6.5,
+ *  matches the `protocol.features` array embedded in `daemon.hello` reply per
+ *  frag-3.4.1 §3.4.1.g and §6.5.1 mirror rule). */
+export const HEALTHZ_FEATURES = [
+  'binary-frames',
+  'stream-heartbeat',
+  'interceptors',
+  'traceId',
+  'bootNonce',
+  'hello',
+] as const;
+
+/** Healthz schema-version cursor (frag-6-7 §6.5 r3 P1-3). Bumps only on
+ *  breaking shape changes; additive fields do NOT bump it (consumers MUST
+ *  treat unknown fields as forward-compatible per frag-3.4.1 §3.4.1.g rule).
+ *  v0.3 = 1. */
+export const HEALTHZ_VERSION = 1 as const;
+
+/** Injected boot/runtime context. The daemon shell (T1) owns the live values
+ *  and constructs this once; the handler reads only — no mutation here. */
+export interface HealthzContext {
+  /** Crockford ULID minted at daemon boot (frag-6-7 §6.5 r3 CF-2 lock —
+   *  camelCase across all fragments; ULID, NOT `Date.now()`). */
+  readonly bootNonce: string;
+  /** Daemon process PID (frag-6-7 §6.5). */
+  readonly pid: number;
+  /** Semver-string of the daemon binary (frag-6-7 §6.5 `version` field). */
+  readonly version: string;
+  /** Monotonic boot time in milliseconds since epoch — captured ONCE at boot
+   *  (frag-6-7 §6.5: the supervisor uses `uptimeMs` to detect daemon restart
+   *  AND validate clock-skew against its own boot wall-clock). */
+  readonly bootedAtMs: number;
+  /** Clock for `now` — injected so tests can advance time deterministically.
+   *  Production = `() => Date.now()`. */
+  readonly now: () => number;
+  /** Live session count snapshot (frag-6-7 §6.5). 0 until the session
+   *  registry (frag-3.5.1) is wired; T17 ships a default-0 producer so the
+   *  field is always present on the wire. */
+  readonly getSessionCount?: () => number;
+  /** Live stream-subscriber count snapshot (frag-3.5.1 §3.5.1.4 fan-out
+   *  registry). 0 until wired (see `getSessionCount`). */
+  readonly getSubscriberCount?: () => number;
+  /** Migration FSM read-side. Default `'absent'` (no migration ever ran on a
+   *  fresh install). frag-8 §8.5 owns the producer. */
+  readonly getMigrationState?: () => MigrationState;
+  /** Auto-update swap window flag (frag-6-7 §6.4 step 4-7 + §6.5 r3 sec
+   *  P1-6). When true, supervisor pauses imposter-secret HMAC verification. */
+  readonly getSwapInProgress?: () => boolean;
+}
+
+/** Frozen `protocol` block returned inside the healthz body (frag-6-7 §6.5).
+ *  Mirrored 1:1 in the `daemon.hello` reply — same constants, no drift. */
+export interface HealthzProtocolBlock {
+  readonly wire: typeof HEALTHZ_WIRE;
+  readonly minClient: typeof HEALTHZ_MIN_CLIENT;
+  readonly daemonProtocolVersion: typeof DAEMON_PROTOCOL_VERSION;
+  readonly daemonAcceptedWires: ReadonlyArray<string>;
+  readonly features: ReadonlyArray<string>;
+}
+
+/** Full `/healthz` response shape (frag-6-7 §6.5 lines 124-140). */
+export interface HealthzReply {
+  readonly uptimeMs: number;
+  readonly pid: number;
+  readonly version: string;
+  readonly bootNonce: string;
+  readonly sessionCount: number;
+  readonly subscriberCount: number;
+  readonly migrationState: MigrationState;
+  readonly swapInProgress: boolean;
+  readonly protocol: HealthzProtocolBlock;
+  readonly healthzVersion: typeof HEALTHZ_VERSION;
+}
+
+/**
+ * Build the canonical `/healthz` reply.
+ *
+ * Pure: same `(req, ctx)` always yields the same output for the same clock
+ * value. Performs no I/O, never throws on a well-formed context.
+ *
+ * The `req` argument is intentionally unused — `/healthz` takes no parameters
+ * per frag-6-7 §6.5 (supervisor pings with an empty payload). Accepting it as
+ * a Handler-compatible signature keeps wiring trivial for T16.
+ */
+export function handleHealthz(_req: unknown, ctx: HealthzContext): HealthzReply {
+  // Clamp uptime to >=0 — protects against pathological clock-rewind cases
+  // where an injected `now()` returns a value below `bootedAtMs` (NTP step,
+  // hibernate-resume on Win 11). Spec assumes monotonic; we clamp instead of
+  // throwing because /healthz must never error (§6.5 "always returns liveness").
+  const rawUptime = ctx.now() - ctx.bootedAtMs;
+  const uptimeMs = rawUptime < 0 ? 0 : rawUptime;
+
+  return {
+    uptimeMs,
+    pid: ctx.pid,
+    version: ctx.version,
+    bootNonce: ctx.bootNonce,
+    sessionCount: ctx.getSessionCount?.() ?? 0,
+    subscriberCount: ctx.getSubscriberCount?.() ?? 0,
+    migrationState: ctx.getMigrationState?.() ?? 'absent',
+    swapInProgress: ctx.getSwapInProgress?.() ?? false,
+    protocol: {
+      wire: HEALTHZ_WIRE,
+      minClient: HEALTHZ_MIN_CLIENT,
+      daemonProtocolVersion: DAEMON_PROTOCOL_VERSION,
+      daemonAcceptedWires: HEALTHZ_DAEMON_ACCEPTED_WIRES,
+      features: HEALTHZ_FEATURES,
+    },
+    healthzVersion: HEALTHZ_VERSION,
+  };
+}
+
+/** Adapter to the T16 `Dispatcher.Handler` signature. T16's handler returns
+ *  `Promise<unknown>`; healthz is synchronous but we wrap so `register()`
+ *  accepts it without coupling the pure function to Promise plumbing.
+ *
+ *  Usage (post-T16-merge follow-up commit):
+ *    dispatcher.register('/healthz', makeHealthzHandler(ctx));
+ */
+export function makeHealthzHandler(
+  ctx: HealthzContext,
+): (req: unknown) => Promise<HealthzReply> {
+  return async (req: unknown) => handleHealthz(req, ctx);
+}


### PR DESCRIPTION
## Summary
- Adds `daemon/src/handlers/healthz.ts` — pure `handleHealthz(req, ctx)` returning the canonical control-socket liveness body per **frag-6-7 §6.5** (lines 124-140).
- Adds `makeHealthzHandler(ctx)` adapter compatible with the T16 `Dispatcher.Handler` signature for the post-T16 wiring commit.
- 16 vitest cases covering shape, uptime monotonicity, clock-rewind clamp, provider injection, defaults, purity, and the dispatcher adapter.

## Spec citations
- `docs/superpowers/specs/v0.3-fragments/frag-6-7-reliability-security.md` §6.5 — canonical owner of the response body.
- `docs/superpowers/specs/v0.3-fragments/frag-3.4.1-envelope-hardening.md` §3.4.1.h — `/healthz` is a wire-literal control-plane RPC (NOT `ccsm.v1/daemon.healthz`).

## Response shape
```json
{ "uptimeMs": number, "pid": number, "version": string,
  "bootNonce": string, "sessionCount": number,
  "subscriberCount": number,
  "migrationState": "absent" | "pending" | "in-progress" | "done",
  "swapInProgress": boolean,
  "protocol": {
    "wire": "v0.3-json-envelope",
    "minClient": "v0.3",
    "daemonProtocolVersion": 1,
    "daemonAcceptedWires": ["v0.3-json-envelope"],
    "features": ["binary-frames","stream-heartbeat","interceptors","traceId","bootNonce","hello"]
  },
  "healthzVersion": 1 }
```

## Single Responsibility
- **Decider only.** Reads injected `HealthzContext` (bootNonce / pid / version / bootedAtMs / now + optional counter providers); returns a snapshot.
- **No I/O.** No socket writes, no DB queries. Per §6.5 the supervisor pings every 5s with 3-miss = restart, so the handler stays branch-free of any blocking path.
- **No mutation.** Counters arrive via injected `() => number` providers (default 0) so T18-T21 / migration FSM owners can wire live values without re-touching this file.

## T16 coordination
T16 dispatcher (PR #665) is open with a `NOT_IMPLEMENTED` stub on `/healthz`. This PR ships the standalone handler from `origin/working`; the one-line `dispatcher.register('/healthz', makeHealthzHandler(ctx))` integration commit follows after T16 merges. No file conflict — T17 only adds new files under `daemon/src/handlers/`.

## Verification
- `npm run typecheck` — clean (web + electron + daemon tsconfigs).
- `npx vitest run daemon/src/handlers/__tests__/healthz.test.ts` — **16/16 passed**.
- `npm run build:daemon` — clean.
- ESM require-load smoke test against `dist-daemon/handlers/healthz.js` — exports load, `handleHealthz()` returns the spec-shaped reply with `uptimeMs=500` for `bootedAtMs=0, now=()=>500`.

## Test plan
- [x] Spec shape matches `frag-6-7 §6.5` body field-for-field.
- [x] `uptimeMs` strictly increases as the injected clock advances.
- [x] `daemonProtocolVersion === 1` (matches `DAEMON_PROTOCOL_VERSION` literal).
- [x] `healthzVersion === 1`.
- [x] Clock-rewind clamps uptime to 0 (handler must never error per §6.5).
- [x] Counter providers default to 0 / 'absent' / false when omitted.
- [x] Pure: same `(req, ctx)` produces identical replies; ignores `req`; does not mutate `ctx`.