### PR TITLE
feat(daemon): T36 fresh-install silent path (boot orchestrator)

### DIFF
--- a/daemon/src/db/__tests__/boot-orchestrator.test.ts
+++ b/daemon/src/db/__tests__/boot-orchestrator.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { existsSync, mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { bootDb } from '../boot-orchestrator.js';
+import type { EnsuredDataDir } from '../ensure-data-dir.js';
+
+// T36 tests: verify the boot orchestrator forks correctly between the
+// fresh-install silent path and the existing-db delegate path.
+//
+// Spec: docs/superpowers/specs/v0.3-fragments/frag-8-sqlite-migration.md §8.3
+
+interface MasterRow {
+  name: string;
+}
+interface VersionRow {
+  v: string;
+}
+
+let tmpDir: string;
+let dataDir: string;
+let dbPath: string;
+
+function ensured(kind: 'fresh' | 'existing'): EnsuredDataDir {
+  return {
+    dataRoot: tmpDir,
+    dataDir,
+    dbPath,
+    kind,
+    orphansRemoved: 0,
+  };
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'ccsm-boot-orch-t36-'));
+  dataDir = join(tmpDir, 'data');
+  mkdirSync(dataDir, { recursive: true });
+  dbPath = join(dataDir, 'ccsm.db');
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('bootDb — fresh-install silent path (§8.3 step 5)', () => {
+  it("returns outcome 'fresh-install' when ensureDataDir reports kind='fresh'", () => {
+    const runMigration = vi.fn();
+    const result = bootDb({
+      ensureDataDir: () => ensured('fresh'),
+      runMigration,
+    });
+    expect(result.outcome).toBe('fresh-install');
+    expect(result.ensured.kind).toBe('fresh');
+  });
+
+  it("does NOT invoke runMigration on the fresh path", () => {
+    const runMigration = vi.fn();
+    bootDb({
+      ensureDataDir: () => ensured('fresh'),
+      runMigration,
+    });
+    // The single load-bearing assertion: silent path skips the runner
+    // entirely so no `migration.*` events can fire.
+    expect(runMigration).not.toHaveBeenCalled();
+  });
+
+  it("invokes applyFreshSchema with the canonical db path", () => {
+    const applyFreshSchema = vi.fn();
+    bootDb({
+      ensureDataDir: () => ensured('fresh'),
+      applyFreshSchema,
+      runMigration: vi.fn(),
+    });
+    expect(applyFreshSchema).toHaveBeenCalledTimes(1);
+    expect(applyFreshSchema).toHaveBeenCalledWith(dbPath);
+  });
+
+  it("creates a real v0.3 db file (default applyFreshSchema, real sqlite)", () => {
+    bootDb({
+      ensureDataDir: () => ensured('fresh'),
+      runMigration: vi.fn(),
+      // default applyFreshSchema → opens better-sqlite3, exec()s v0.3.sql
+    });
+    expect(existsSync(dbPath)).toBe(true);
+    const db = new Database(dbPath, { readonly: true });
+    try {
+      const tables = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+        .all() as MasterRow[];
+      const names = new Set(tables.map((t) => t.name));
+      // Spot-check: every v0.3.sql table is present.
+      expect(names.has('schema_version')).toBe(true);
+      expect(names.has('sessions')).toBe(true);
+      expect(names.has('messages')).toBe(true);
+      expect(names.has('agents')).toBe(true);
+      expect(names.has('jobs')).toBe(true);
+      expect(names.has('app_state')).toBe(true);
+
+      const ver = db.prepare('SELECT v FROM schema_version').get() as VersionRow;
+      expect(ver.v).toBe('0.3');
+    } finally {
+      db.close();
+    }
+  });
+
+  it("returns the unmodified EnsuredDataDir from the producer", () => {
+    const e: EnsuredDataDir = {
+      dataRoot: tmpDir,
+      dataDir,
+      dbPath,
+      kind: 'fresh',
+      orphansRemoved: 3,
+    };
+    const result = bootDb({
+      ensureDataDir: () => e,
+      applyFreshSchema: vi.fn(),
+      runMigration: vi.fn(),
+    });
+    expect(result.ensured).toBe(e);
+    expect(result.ensured.orphansRemoved).toBe(3);
+  });
+});
+
+describe('bootDb — existing-db delegate path (§8.3 step 3)', () => {
+  it("returns outcome 'existing' when ensureDataDir reports kind='existing'", () => {
+    const result = bootDb({
+      ensureDataDir: () => ensured('existing'),
+      runMigration: vi.fn(),
+    });
+    expect(result.outcome).toBe('existing');
+  });
+
+  it("invokes runMigration with the canonical db path", () => {
+    const runMigration = vi.fn();
+    bootDb({
+      ensureDataDir: () => ensured('existing'),
+      runMigration,
+    });
+    expect(runMigration).toHaveBeenCalledTimes(1);
+    expect(runMigration).toHaveBeenCalledWith(dbPath);
+  });
+
+  it("does NOT invoke applyFreshSchema on the existing path", () => {
+    const applyFreshSchema = vi.fn();
+    bootDb({
+      ensureDataDir: () => ensured('existing'),
+      runMigration: vi.fn(),
+      applyFreshSchema,
+    });
+    expect(applyFreshSchema).not.toHaveBeenCalled();
+  });
+
+  it("with a real pre-existing v0.3 db, the default runner is a no-op (idempotent)", () => {
+    // Seed a real v0.3-shaped db at dbPath, then call bootDb with the
+    // default runMigration. T29's `isAlreadyV03` guard MUST short-circuit
+    // so no DDL re-runs and no events fire.
+    {
+      const db = new Database(dbPath);
+      db.exec(`
+        CREATE TABLE schema_version (v TEXT PRIMARY KEY);
+        INSERT INTO schema_version (v) VALUES ('0.3');
+        CREATE TABLE sessions (id TEXT PRIMARY KEY);
+      `);
+      db.close();
+    }
+    const result = bootDb({
+      ensureDataDir: () => ensured('existing'),
+      // default runMigration → migrateV02ToV03 (T29). Should detect
+      // already-v0.3 and return without touching the file.
+    });
+    expect(result.outcome).toBe('existing');
+
+    // Re-open and confirm the seeded schema is intact (no ALTER, no DROP).
+    const db = new Database(dbPath, { readonly: true });
+    try {
+      const ver = db.prepare('SELECT v FROM schema_version').get() as VersionRow;
+      expect(ver.v).toBe('0.3');
+      const sessionsCols = db
+        .prepare("PRAGMA table_info('sessions')")
+        .all() as Array<{ name: string }>;
+      // The seed had only `id`; if T29 ran it would have added all
+      // v0.3.sql columns. Idempotency check: still just `id`.
+      expect(sessionsCols.map((c) => c.name)).toEqual(['id']);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("with a real pre-existing v0.2 db, the default runner DOES migrate", () => {
+    // Inverse check: if a v0.2-shaped db sits at the v0.3 target path
+    // (rare — would require manual file copy since v0.2 wrote elsewhere),
+    // the existing-path delegate calls T29 which migrates in place.
+    {
+      const db = new Database(dbPath);
+      db.exec(`
+        CREATE TABLE app_state (
+          key TEXT PRIMARY KEY,
+          value TEXT NOT NULL,
+          updated_at INTEGER NOT NULL
+        );
+      `);
+      db.pragma('user_version = 1');
+      db.prepare('INSERT INTO app_state (key, value, updated_at) VALUES (?, ?, ?)').run(
+        'closeAction',
+        'tray',
+        Date.now(),
+      );
+      db.close();
+    }
+    const result = bootDb({
+      ensureDataDir: () => ensured('existing'),
+    });
+    expect(result.outcome).toBe('existing');
+
+    const db = new Database(dbPath, { readonly: true });
+    try {
+      const ver = db.prepare('SELECT v FROM schema_version').get() as VersionRow;
+      expect(ver.v).toBe('0.3');
+      // After migration, app_state is the singleton with typed columns.
+      const cols = db.prepare("PRAGMA table_info('app_state')").all() as Array<{ name: string }>;
+      const colNames = new Set(cols.map((c) => c.name));
+      expect(colNames.has('id')).toBe(true);
+      expect(colNames.has('close_action')).toBe(true);
+    } finally {
+      db.close();
+    }
+  });
+});
+
+describe('bootDb — defaults wiring', () => {
+  it('uses defaultEnsureDataDir when no override is supplied (smoke)', () => {
+    // Without an override, ensureDataDir reads real env + writes to
+    // %LOCALAPPDATA%\ccsm. We don't want to pollute the host on test
+    // run, so we override ensureDataDir but leave applyFreshSchema and
+    // runMigration as defaults — this asserts the dep-injection
+    // surface compiles + accepts partial overrides.
+    const result = bootDb({
+      ensureDataDir: () => ensured('fresh'),
+    });
+    expect(result.outcome).toBe('fresh-install');
+    expect(existsSync(dbPath)).toBe(true);
+  });
+});

--- a/daemon/src/db/boot-orchestrator.ts
+++ b/daemon/src/db/boot-orchestrator.ts
@@ -1,0 +1,176 @@
+// T36: fresh-install silent path — boot orchestrator.
+//
+// Spec refs:
+//   - docs/superpowers/specs/v0.3-fragments/frag-8-sqlite-migration.md
+//     §8.3 step 2-3 + step 5 (fresh-install branch).
+//   - daemon/src/db/ensure-data-dir.ts (T34) — produces `kind: 'fresh' |
+//     'existing'`.
+//   - daemon/src/db/migrate-v02-to-v03.ts (T29) — idempotent runner that
+//     handles already-v0.3 as a no-op.
+//   - daemon/src/db/schema/v0.3.sql (T28) — canonical schema (also stamps
+//     `INSERT OR REPLACE INTO schema_version VALUES ('0.3')` itself, so
+//     fresh-install needs nothing more than `db.exec(sql)`).
+//
+// Single Responsibility (producer / decider / sink): DECIDER. This module
+// composes T34 (producer of `EnsuredDataDir`) and the migration runner
+// (sink) into a single boot decision: when the canonical db file does
+// NOT yet exist we silently apply the v0.3 schema (no events, no modal,
+// no progress); when it DOES exist we delegate to the migration runner
+// which is responsible for detecting "already current" as a no-op.
+//
+// "Silent" is the load-bearing word. The fresh-install branch MUST NOT
+// emit any `migration.*` event (T30 contracts) so the renderer-side
+// modal driver (T33, future) stays dormant. A first-time user opening
+// ccsm sees no modal flash.
+//
+// Pure composition: this module owns no I/O of its own beyond:
+//   1. invoking the injected `ensureDataDir()`
+//   2. on `kind: 'fresh'`, opening a `Database(dbPath)` and `exec()`-ing
+//      the v0.3 schema text
+//   3. on `kind: 'existing'`, invoking the injected `runMigration(dbPath)`
+//
+// No lockfile acquisition, no marker file write, no event emission, no
+// log line — all of those are owned by other tasks (lockfile: frag-6-7
+// §6.4; marker file: §8.5 S8 / a future task; events: T30 + the runner;
+// log line: the boot path that calls bootDb()).
+
+import Database from 'better-sqlite3';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { ensureDataDir as defaultEnsureDataDir, type EnsuredDataDir } from './ensure-data-dir.js';
+import { migrateV02ToV03 as defaultRunMigration } from './migrate-v02-to-v03.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Path to the canonical v0.3 schema file. Same source the migration
+ * runner reads (T29) — both code paths converge on a single SQL truth.
+ */
+const V03_SCHEMA_PATH = join(__dirname, 'schema', 'v0.3.sql');
+
+/** Lazy-cached schema text. Read once per process, reused across boots. */
+let cachedSchemaText: string | null = null;
+
+function loadV03Schema(): string {
+  if (cachedSchemaText !== null) return cachedSchemaText;
+  cachedSchemaText = readFileSync(V03_SCHEMA_PATH, 'utf8');
+  return cachedSchemaText;
+}
+
+/**
+ * Outcome of `bootDb()`:
+ *
+ * - `'fresh-install'` — `<dataRoot>/data/ccsm.db` did not exist before
+ *   this call; the orchestrator created it and applied the v0.3 schema
+ *   silently. No migration events fired.
+ * - `'existing'` — the canonical db file already existed; the
+ *   orchestrator delegated to the migration runner. The runner's own
+ *   idempotency guard (T29 `isAlreadyV03`) handles already-current
+ *   files as a no-op without emitting events.
+ */
+export type BootDbOutcome = 'fresh-install' | 'existing';
+
+/**
+ * Result of `bootDb()`. `ensured` is the unmodified return value of
+ * `ensureDataDir()`; useful for callers that want to log the resolved
+ * paths and orphan-cleanup count.
+ */
+export interface BootDbResult {
+  readonly ensured: EnsuredDataDir;
+  readonly outcome: BootDbOutcome;
+}
+
+/**
+ * Dependency injection seam. Tests (and the future legacy-resolver
+ * wiring) replace `ensureDataDir`, `runMigration`, and/or
+ * `applyFreshSchema` to control the fork without touching real fs.
+ *
+ * `applyFreshSchema(dbPath)` exists as a separate seam (vs hard-coded
+ * `db.exec(loadV03Schema())`) so tests can assert "fresh path called
+ * applyFreshSchema, NOT runMigration" without spinning a real sqlite
+ * file when better-sqlite3's prebuilt ABI doesn't match the host node.
+ */
+export interface BootDbDeps {
+  /** T34 producer. Defaults to the real `ensureDataDir`. */
+  readonly ensureDataDir?: () => EnsuredDataDir;
+  /**
+   * T29 runner. Defaults to `migrateV02ToV03`. Called only when
+   * `ensured.kind === 'existing'`. Receives the canonical db file path.
+   */
+  readonly runMigration?: (dbPath: string) => void;
+  /**
+   * Fresh-install schema applier. Defaults to "open `dbPath` with
+   * better-sqlite3, exec the v0.3 schema text, close". Called only
+   * when `ensured.kind === 'fresh'`.
+   */
+  readonly applyFreshSchema?: (dbPath: string) => void;
+}
+
+/**
+ * Default fresh-schema applier. Opens `dbPath` (creates the file),
+ * runs the entire v0.3 schema (which itself stamps
+ * `schema_version (v) VALUES ('0.3')`), and closes the handle.
+ *
+ * Synchronous because better-sqlite3 is sync; matches the daemon's
+ * boot path which already runs sync DB ops on the main thread before
+ * the event loop is busy (T29 docstring same rationale).
+ */
+function defaultApplyFreshSchema(dbPath: string): void {
+  const db = new Database(dbPath);
+  try {
+    db.exec(loadV03Schema());
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Orchestrate the daemon-boot db decision per frag-8 §8.3 steps 2-3 +
+ * step 5 (fresh-install branch).
+ *
+ * Sequence:
+ *   1. Call `ensureDataDir()` (T34): provisions `<dataRoot>/data`,
+ *      cleans orphan tmp files, probes for the canonical db file.
+ *   2. Fork on `ensured.kind`:
+ *      - `'fresh'`  → `applyFreshSchema(ensured.dbPath)` then return
+ *                     `{ ensured, outcome: 'fresh-install' }`. NO events.
+ *      - `'existing'` → `runMigration(ensured.dbPath)` then return
+ *                       `{ ensured, outcome: 'existing' }`. The runner
+ *                       owns event emission (T30) for the truly-needs-
+ *                       migration case; for already-v0.3 it returns
+ *                       silently (T29 `isAlreadyV03` guard).
+ *
+ * Throws whatever `ensureDataDir`, `applyFreshSchema`, or `runMigration`
+ * throw — the caller (boot path) is responsible for surfacing fatals as
+ * the §8.6 daemon-spawn-failure modal.
+ */
+export function bootDb(deps: BootDbDeps = {}): BootDbResult {
+  const ensureDataDirFn = deps.ensureDataDir ?? defaultEnsureDataDir;
+  const runMigrationFn = deps.runMigration ?? defaultRunMigration;
+  const applyFreshSchemaFn = deps.applyFreshSchema ?? defaultApplyFreshSchema;
+
+  const ensured = ensureDataDirFn();
+
+  if (ensured.kind === 'fresh') {
+    // §8.3 step 5: fresh install. Open new db, schema runs, NO events.
+    // The marker file write (`writeMarker({ completed: true, reason:
+    // 'fresh-install' })`) lives in a separate task — T36's scope is
+    // strictly the silent-schema branch; the marker is the boot path's
+    // responsibility once the marker writer module lands.
+    applyFreshSchemaFn(ensured.dbPath);
+    return { ensured, outcome: 'fresh-install' };
+  }
+
+  // §8.3 step 3: db exists at the v0.3 target. Delegate to the migration
+  // runner. T29 detects already-current via `isAlreadyV03` and returns
+  // immediately — no events, no work — so the legacy-v0.3 reinstall path
+  // is also silent. The genuine "v0.2-shaped data sitting at the v0.3
+  // target" case (which would only happen via manual user file copy,
+  // since v0.2 wrote to a different per-OS path) DOES produce a
+  // migration: T29 will translate it and the events the runner emits
+  // are the source of truth.
+  runMigrationFn(ensured.dbPath);
+  return { ensured, outcome: 'existing' };
+}


### PR DESCRIPTION
## Summary

Adds `daemon/src/db/boot-orchestrator.ts` — a pure decider that composes T34 `ensureDataDir` + T29 `migrateV02ToV03` per **frag-8 §8.3 step 2-3 + step 5**. Fresh-install path is silent (no migration events, modal stays dormant); existing-db path delegates to T29's idempotent runner.

## Branch dependency

Builds on **PR #664** (T34 ensureDataDir, currently OPEN). The first commit on this branch (`a094a5d`) cherry-picks the T34 patch so the new T36 module can import `EnsuredDataDir`. Once #664 merges, please rebase this branch onto `working` to drop the duplicate commit; the only T36 file consuming T34 is the typed `EnsuredDataDir` import.

## Spec refs

- `docs/superpowers/specs/v0.3-fragments/frag-8-sqlite-migration.md` §8.3 step 2-3 + step 5
- `daemon/src/db/ensure-data-dir.ts` (T34, PR #664)
- `daemon/src/db/migrate-v02-to-v03.ts` (T29)
- `daemon/src/db/schema/v0.3.sql` (T28)

## Flow

```
bootDb()
  └─ ensureDataDir()                  // T34 producer
       ├─ kind: 'fresh'    → applyFreshSchema(dbPath)   // silent — no events
       │                       └─ Database(dbPath) + db.exec(v0.3.sql) + close
       │                       (v0.3.sql self-stamps INSERT OR REPLACE INTO schema_version VALUES ('0.3'))
       │                     return { ensured, outcome: 'fresh-install' }
       │
       └─ kind: 'existing' → runMigration(dbPath)       // T29 idempotent
                              ├─ already-v0.3 → isAlreadyV03 short-circuits, no events
                              └─ v0.2-shaped  → real migration, events fire
                              return { ensured, outcome: 'existing' }
```

## Single Responsibility split

- **producer**: T34 `ensureDataDir` (returns `EnsuredDataDir{kind, dataRoot, dataDir, dbPath, orphansRemoved}`)
- **decider**: T36 `bootDb` (this PR) — fork on `kind`, no I/O of its own beyond default applyFreshSchema
- **sinks**: T29 `migrateV02ToV03` / better-sqlite3 schema exec

## Out of scope (owned elsewhere)

- Lockfile acquisition (frag-6-7 §6.4) — caller must hold lock before `bootDb`
- Marker file write `migration-state.json` (§8.5 S8) — separate task
- Event emission for the fresh path (intentionally none — silent path)
- Log line emission (boot path's responsibility)
- `resolveLegacyDir` + the legacy-`<dataRoot>` migrate branch (§8.3 step 4-6) — separate task; this PR only handles the in-target fork

## Test results

```
 RUN  v4.1.5 C:/Users/jiahuigu/ccsm-worktrees/pool-3
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

11 tests covering:
- Fresh path: outcome, no-runMigration call, applyFreshSchema invocation + path, real-sqlite v0.3 schema verification, EnsuredDataDir passthrough
- Existing path: outcome, runMigration invocation + path, no applyFreshSchema call, real-sqlite v0.3 idempotency (T29 `isAlreadyV03` short-circuits — sessions table left untouched), real-sqlite v0.2 migrate (singleton app_state with typed columns)
- Defaults wiring smoke

Full daemon db suite (T28/T29/T30/T34/T36): **65 passed**.
Full project typecheck: **clean**.

Note on local sqlite ABI: `npm rebuild better-sqlite3` was required against host Node 24 (electron-rebuild leaves the binding at electron's ABI 145; host node was ABI 137). CI runs Node 20 with its own rebuild, no special handling needed.

## Test plan

- [x] `npx vitest run daemon/src/db/__tests__/boot-orchestrator.test.ts` — 11/11 pass
- [x] `npx vitest run daemon/src/db/` — 65/65 pass (no regression on T29/T30/T34)
- [x] `npm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)