### PR TITLE
feat(daemon): T19 daemon.hello handler (HMAC compute, anti-imposter)

### DIFF
--- a/daemon/src/handlers/__tests__/daemon-hello.test.ts
+++ b/daemon/src/handlers/__tests__/daemon-hello.test.ts
@@ -1,0 +1,440 @@
+import { describe, it, expect } from 'vitest';
+import { Buffer } from 'node:buffer';
+import { createHmac, randomBytes } from 'node:crypto';
+
+import {
+  createDaemonHelloHandler,
+  decideHelloReply,
+  DaemonHelloSchemaError,
+  DAEMON_ACCEPTED_WIRES,
+  DAEMON_DEFAULTS,
+  DAEMON_FEATURES,
+  DAEMON_FRAME_VERSION,
+  DAEMON_WIRE,
+  HELLO_METHOD_LITERAL,
+  HELLO_METHOD_NAMESPACED,
+  type HelloReplyPayload,
+  type HelloRequestPayload,
+} from '../daemon-hello.js';
+import {
+  encode as base64urlEncode,
+  decode as base64urlDecode,
+} from '../../envelope/base64url.js';
+import { DAEMON_PROTOCOL_VERSION } from '../../envelope/protocol-version.js';
+import { HMAC_TAG_LENGTH, NONCE_BYTES } from '../../envelope/hmac.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const TEST_SECRET = Buffer.from(
+  'test-daemon-secret-32-bytes-long-fixture-not-real',
+  'utf8',
+);
+const TEST_BOOT_NONCE = '01HX8VJ6Q9KZ5YBDGXMTNCAVT0';
+
+function makeNonce(seedByte: number): string {
+  // Deterministic 16-byte nonce so reference HMACs are reproducible.
+  const buf = Buffer.alloc(NONCE_BYTES, seedByte);
+  return base64urlEncode(buf);
+}
+
+function validRequest(
+  overrides: Partial<HelloRequestPayload> = {},
+): HelloRequestPayload {
+  return {
+    clientWire: DAEMON_WIRE,
+    clientProtocolVersion: DAEMON_PROTOCOL_VERSION,
+    clientFrameVersions: [DAEMON_FRAME_VERSION],
+    clientFeatures: ['binary-frames', 'hello'],
+    clientHelloNonce: makeNonce(0x42),
+    ...overrides,
+  };
+}
+
+function decide(req: unknown): HelloReplyPayload {
+  return decideHelloReply(req, {
+    secret: TEST_SECRET,
+    bootNonce: TEST_BOOT_NONCE,
+    minClient: 'v0.3',
+  });
+}
+
+/** Independent reference HMAC: never touches the implementation under test. */
+function referenceHmac(secret: Buffer, nonceB64url: string): string {
+  const nonceBytes = base64urlDecode(nonceB64url);
+  const full = createHmac('sha256', secret).update(nonceBytes).digest();
+  return base64urlEncode(full.subarray(0, NONCE_BYTES));
+}
+
+// ---------------------------------------------------------------------------
+// Wire constants
+// ---------------------------------------------------------------------------
+
+describe('daemon.hello wire constants', () => {
+  it('exposes both control-plane literal and data-plane namespaced method names', () => {
+    expect(HELLO_METHOD_LITERAL).toBe('daemon.hello');
+    expect(HELLO_METHOD_NAMESPACED).toBe('ccsm.v1/daemon.hello');
+  });
+
+  it('advertises a single-element wires array on v0.3 (spec §3.4.1.g)', () => {
+    expect(DAEMON_ACCEPTED_WIRES).toEqual([DAEMON_WIRE]);
+    expect(DAEMON_WIRE).toBe('v0.3-json-envelope');
+  });
+
+  it('declares frame-version 0 for v0.3 (spec §3.4.1.c)', () => {
+    expect(DAEMON_FRAME_VERSION).toBe(0);
+  });
+
+  it('mirrors the canonical features list (spec §3.4.1.g schema)', () => {
+    expect(DAEMON_FEATURES).toEqual([
+      'binary-frames',
+      'stream-heartbeat',
+      'interceptors',
+      'traceId',
+      'bootNonce',
+      'hello',
+    ]);
+  });
+
+  it('mirrors the canonical defaults block (spec §3.4.1.g)', () => {
+    expect(DAEMON_DEFAULTS).toEqual({
+      deadlineMs: 5_000,
+      heartbeatMs: 30_000,
+      backpressureBytes: 1_048_576,
+    });
+    // Defensively frozen — handler returns the same object on every call.
+    expect(Object.isFrozen(DAEMON_DEFAULTS)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe('decideHelloReply — valid request', () => {
+  it('returns compatible: true with a 22-char base64url HMAC', () => {
+    const reply = decide(validRequest());
+    expect(reply.compatible).toBe(true);
+    expect(reply.reason).toBeUndefined();
+    expect(reply.helloNonceHmac).toHaveLength(HMAC_TAG_LENGTH);
+    expect(reply.helloNonceHmac).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(reply.helloNonceHmac).not.toContain('=');
+  });
+
+  it('echoes the protocol block with daemonProtocolVersion=1 (spec §3.4.1.g)', () => {
+    const reply = decide(validRequest());
+    expect(reply.protocol.wire).toBe(DAEMON_WIRE);
+    expect(reply.protocol.minClient).toBe('v0.3');
+    expect(reply.protocol.daemonProtocolVersion).toBe(DAEMON_PROTOCOL_VERSION);
+    expect(reply.protocol.daemonProtocolVersion).toBe(1);
+    expect(reply.protocol.daemonAcceptedWires).toEqual([DAEMON_WIRE]);
+    expect(reply.protocol.features).toEqual(DAEMON_FEATURES);
+  });
+
+  it('surfaces bootNonce + daemonFrameVersion + defaults', () => {
+    const reply = decide(validRequest());
+    expect(reply.bootNonce).toBe(TEST_BOOT_NONCE);
+    expect(reply.daemonFrameVersion).toBe(0);
+    expect(reply.defaults).toEqual(DAEMON_DEFAULTS);
+  });
+
+  it('HMAC matches an independently-computed reference value (test vector)', () => {
+    const nonce = makeNonce(0xAB);
+    const reply = decide(validRequest({ clientHelloNonce: nonce }));
+    expect(reply.helloNonceHmac).toBe(referenceHmac(TEST_SECRET, nonce));
+  });
+
+  it('produces stable HMAC for a fixed (secret, nonce) pair across calls', () => {
+    const nonce = makeNonce(0x07);
+    const a = decide(validRequest({ clientHelloNonce: nonce }));
+    const b = decide(validRequest({ clientHelloNonce: nonce }));
+    expect(a.helloNonceHmac).toBe(b.helloNonceHmac);
+  });
+
+  it('produces different HMACs for different nonces under the same secret', () => {
+    const a = decide(validRequest({ clientHelloNonce: makeNonce(0x01) }));
+    const b = decide(validRequest({ clientHelloNonce: makeNonce(0x02) }));
+    expect(a.helloNonceHmac).not.toBe(b.helloNonceHmac);
+  });
+
+  it('produces different HMACs for the same nonce under different secrets', () => {
+    const nonce = makeNonce(0x11);
+    const replyA = decide(validRequest({ clientHelloNonce: nonce }));
+    const replyB = decideHelloReply(validRequest({ clientHelloNonce: nonce }), {
+      secret: Buffer.from('different-secret-bytes-here', 'utf8'),
+      bootNonce: TEST_BOOT_NONCE,
+      minClient: 'v0.3',
+    });
+    expect(replyA.helloNonceHmac).not.toBe(replyB.helloNonceHmac);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Round-9 base64url lock — HMAC is computed over decoded BYTES, not ASCII.
+// ---------------------------------------------------------------------------
+
+describe('HMAC compute — bytes vs ASCII regression (spec §3.4.1.g round-9 lock)', () => {
+  it('HMAC equals HMAC over decoded 16-byte buffer, NOT over the 22-char ASCII string', () => {
+    const nonce = makeNonce(0x55);
+    const reply = decide(validRequest({ clientHelloNonce: nonce }));
+
+    // Compute the WRONG way (ASCII) and assert we did NOT do that.
+    const wrong = createHmac('sha256', TEST_SECRET).update(nonce, 'ascii').digest();
+    const wrongTag = base64urlEncode(wrong.subarray(0, NONCE_BYTES));
+    expect(reply.helloNonceHmac).not.toBe(wrongTag);
+
+    // Compute the RIGHT way (decoded bytes) and assert we did.
+    expect(reply.helloNonceHmac).toBe(referenceHmac(TEST_SECRET, nonce));
+  });
+
+  it('HMAC of all-zero nonce bytes != HMAC of literal "0" * 22 ASCII string', () => {
+    const allZeros = base64urlEncode(Buffer.alloc(NONCE_BYTES, 0));
+    const reply = decide(validRequest({ clientHelloNonce: allZeros }));
+
+    const asciiHmac = createHmac('sha256', TEST_SECRET).update(allZeros, 'ascii').digest();
+    const asciiTag = base64urlEncode(asciiHmac.subarray(0, NONCE_BYTES));
+
+    expect(reply.helloNonceHmac).not.toBe(asciiTag);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Anti-imposter: incompatible reply still carries helloNonceHmac.
+// ---------------------------------------------------------------------------
+
+describe('decideHelloReply — incompatible (anti-imposter, spec §3.4.1.g lines 195/208/212)', () => {
+  it('wire-mismatch still surfaces helloNonceHmac', () => {
+    const req = validRequest({ clientWire: 'v0.4-protobuf' });
+    const reply = decide(req);
+    expect(reply.compatible).toBe(false);
+    expect(reply.reason).toBe('wire-mismatch');
+    // Anti-imposter: HMAC MUST be present so client can rule out imposter
+    // before the daemon tears down the socket.
+    expect(reply.helloNonceHmac).toHaveLength(HMAC_TAG_LENGTH);
+    expect(reply.helloNonceHmac).toBe(
+      referenceHmac(TEST_SECRET, req.clientHelloNonce),
+    );
+  });
+
+  it('version-mismatch (clientProtocolVersion=2) still surfaces helloNonceHmac', () => {
+    const req = validRequest({ clientProtocolVersion: 2 });
+    const reply = decide(req);
+    expect(reply.compatible).toBe(false);
+    expect(reply.reason).toBe('version-mismatch');
+    expect(reply.helloNonceHmac).toBe(
+      referenceHmac(TEST_SECRET, req.clientHelloNonce),
+    );
+  });
+
+  it('frame-version-mismatch ([1] only — daemon serves 0) still surfaces helloNonceHmac', () => {
+    const req = validRequest({ clientFrameVersions: [1] });
+    const reply = decide(req);
+    expect(reply.compatible).toBe(false);
+    expect(reply.reason).toBe('frame-version-mismatch');
+    expect(reply.helloNonceHmac).toBe(
+      referenceHmac(TEST_SECRET, req.clientHelloNonce),
+    );
+  });
+
+  it('compatibility checks are evaluated wire → version → frame-version (deterministic)', () => {
+    // Wire AND version both wrong — wire wins (listed first in spec).
+    const reply = decide(
+      validRequest({ clientWire: 'bogus', clientProtocolVersion: 99 }),
+    );
+    expect(reply.reason).toBe('wire-mismatch');
+  });
+
+  it('compatible: true reply does NOT include the optional reason field', () => {
+    const reply = decide(validRequest());
+    expect(reply.compatible).toBe(true);
+    expect('reason' in reply).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Schema rejection
+// ---------------------------------------------------------------------------
+
+describe('decideHelloReply — schema rejection', () => {
+  it('rejects null payload', () => {
+    expect(() => decide(null)).toThrow(DaemonHelloSchemaError);
+  });
+
+  it('rejects non-object payload', () => {
+    expect(() => decide('not an object')).toThrow(DaemonHelloSchemaError);
+    expect(() => decide(42)).toThrow(DaemonHelloSchemaError);
+  });
+
+  it('rejects missing clientWire', () => {
+    const r = validRequest();
+    const broken = { ...r } as Partial<HelloRequestPayload>;
+    delete broken.clientWire;
+    expect(() => decide(broken)).toThrow(/clientWire/);
+  });
+
+  it('rejects empty-string clientWire', () => {
+    expect(() => decide(validRequest({ clientWire: '' }))).toThrow(/clientWire/);
+  });
+
+  it('rejects clientProtocolVersion of wrong type (string "1")', () => {
+    expect(() =>
+      decide({ ...validRequest(), clientProtocolVersion: '1' }),
+    ).toThrow(/clientProtocolVersion/);
+  });
+
+  it('rejects non-integer clientProtocolVersion (1.5)', () => {
+    expect(() => decide(validRequest({ clientProtocolVersion: 1.5 }))).toThrow(
+      /clientProtocolVersion/,
+    );
+  });
+
+  it('rejects clientProtocolVersion < 1', () => {
+    expect(() => decide(validRequest({ clientProtocolVersion: 0 }))).toThrow(
+      /clientProtocolVersion/,
+    );
+  });
+
+  it('rejects non-array clientFrameVersions', () => {
+    expect(() =>
+      decide({ ...validRequest(), clientFrameVersions: 0 as unknown as number[] }),
+    ).toThrow(/clientFrameVersions/);
+  });
+
+  it('rejects clientFrameVersions with non-integer entries', () => {
+    expect(() =>
+      decide(validRequest({ clientFrameVersions: [0.5] as unknown as number[] })),
+    ).toThrow(/clientFrameVersions/);
+  });
+
+  it('rejects non-array clientFeatures', () => {
+    expect(() =>
+      decide({ ...validRequest(), clientFeatures: 'binary-frames' as unknown as string[] }),
+    ).toThrow(/clientFeatures/);
+  });
+
+  it('rejects non-string clientFeatures entries', () => {
+    expect(() =>
+      decide(validRequest({ clientFeatures: [1 as unknown as string] })),
+    ).toThrow(/clientFeatures/);
+  });
+
+  it('rejects missing clientHelloNonce', () => {
+    const broken = validRequest() as Partial<HelloRequestPayload>;
+    delete broken.clientHelloNonce;
+    expect(() => decide(broken)).toThrow(/clientHelloNonce/);
+  });
+
+  it('rejects clientHelloNonce of wrong length (21 chars)', () => {
+    expect(() =>
+      decide(validRequest({ clientHelloNonce: 'a'.repeat(21) })),
+    ).toThrow(/clientHelloNonce/);
+  });
+
+  it('rejects clientHelloNonce of wrong length (23 chars)', () => {
+    expect(() =>
+      decide(validRequest({ clientHelloNonce: 'a'.repeat(23) })),
+    ).toThrow(/clientHelloNonce/);
+  });
+
+  it('rejects clientHelloNonce with invalid base64url alphabet', () => {
+    // 22 chars but contains '+' and '/' which are NOT in the base64url alphabet.
+    expect(() =>
+      decide(validRequest({ clientHelloNonce: '++++++++++++++++++++++' })),
+    ).toThrow(/clientHelloNonce/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Factory contract
+// ---------------------------------------------------------------------------
+
+describe('createDaemonHelloHandler — factory + dispatcher contract', () => {
+  it('returns an async function that resolves to the same value as decideHelloReply', async () => {
+    const handler = createDaemonHelloHandler({
+      getSecret: () => TEST_SECRET,
+      getBootNonce: () => TEST_BOOT_NONCE,
+    });
+    const req = validRequest();
+    const direct = decide(req);
+    const viaHandler = await handler(req);
+    expect(viaHandler).toEqual(direct);
+  });
+
+  it('calls getSecret() on each request (supports rotation)', async () => {
+    let calls = 0;
+    const secrets = [
+      Buffer.from('secret-A', 'utf8'),
+      Buffer.from('secret-B', 'utf8'),
+    ];
+    const handler = createDaemonHelloHandler({
+      getSecret: () => secrets[calls++ % 2]!,
+      getBootNonce: () => TEST_BOOT_NONCE,
+    });
+    const nonce = makeNonce(0x77);
+    const req = validRequest({ clientHelloNonce: nonce });
+
+    const replyA = (await handler(req)) as HelloReplyPayload;
+    const replyB = (await handler(req)) as HelloReplyPayload;
+
+    expect(calls).toBe(2);
+    expect(replyA.helloNonceHmac).toBe(referenceHmac(secrets[0]!, nonce));
+    expect(replyB.helloNonceHmac).toBe(referenceHmac(secrets[1]!, nonce));
+    expect(replyA.helloNonceHmac).not.toBe(replyB.helloNonceHmac);
+  });
+
+  it('calls getBootNonce() on each request (supports daemon restart in long-lived dispatcher)', async () => {
+    const bootNonces = ['BOOT-AAAAAAAAAAAAAAAAAAAA', 'BOOT-BBBBBBBBBBBBBBBBBBBB'];
+    let i = 0;
+    const handler = createDaemonHelloHandler({
+      getSecret: () => TEST_SECRET,
+      getBootNonce: () => bootNonces[i++ % 2]!,
+    });
+
+    const a = (await handler(validRequest())) as HelloReplyPayload;
+    const b = (await handler(validRequest())) as HelloReplyPayload;
+    expect(a.bootNonce).toBe('BOOT-AAAAAAAAAAAAAAAAAAAA');
+    expect(b.bootNonce).toBe('BOOT-BBBBBBBBBBBBBBBBBBBB');
+  });
+
+  it('rejects (Promise rejection) on schema-violating payload', async () => {
+    const handler = createDaemonHelloHandler({
+      getSecret: () => TEST_SECRET,
+      getBootNonce: () => TEST_BOOT_NONCE,
+    });
+    await expect(handler(null)).rejects.toBeInstanceOf(DaemonHelloSchemaError);
+  });
+
+  it('uses default minClient v0.3 when not overridden', async () => {
+    const handler = createDaemonHelloHandler({
+      getSecret: () => TEST_SECRET,
+      getBootNonce: () => TEST_BOOT_NONCE,
+    });
+    const reply = (await handler(validRequest())) as HelloReplyPayload;
+    expect(reply.protocol.minClient).toBe('v0.3');
+  });
+
+  it('honors a custom minClient override', async () => {
+    const handler = createDaemonHelloHandler({
+      getSecret: () => TEST_SECRET,
+      getBootNonce: () => TEST_BOOT_NONCE,
+      minClient: 'v0.5',
+    });
+    const reply = (await handler(validRequest())) as HelloReplyPayload;
+    expect(reply.protocol.minClient).toBe('v0.5');
+  });
+
+  it('handles many random nonces without divergence from reference HMAC', async () => {
+    const handler = createDaemonHelloHandler({
+      getSecret: () => TEST_SECRET,
+      getBootNonce: () => TEST_BOOT_NONCE,
+    });
+    for (let i = 0; i < 50; i++) {
+      const nonce = base64urlEncode(randomBytes(NONCE_BYTES));
+      const reply = (await handler(
+        validRequest({ clientHelloNonce: nonce }),
+      )) as HelloReplyPayload;
+      expect(reply.helloNonceHmac).toBe(referenceHmac(TEST_SECRET, nonce));
+    }
+  });
+});

--- a/daemon/src/handlers/daemon-hello.ts
+++ b/daemon/src/handlers/daemon-hello.ts
@@ -1,0 +1,352 @@
+// T19 — `daemon.hello` RPC handler (control-socket dispatcher slot).
+//
+// Spec citation:
+//   docs/superpowers/specs/v0.3-fragments/frag-3.4.1-envelope-hardening.md
+//   §3.4.1.g — 2-frame HMAC handshake. The DAEMON computes
+//   `helloNonceHmac = HMAC-SHA256(daemon.secret, clientHelloNonce-bytes)`
+//   truncated to 16 bytes, base64url-no-pad. The client verifies. We do
+//   NOT verify any client HMAC — the client's identity is already proven
+//   by peer-cred (§3.1.1) + ACL (§7.1).
+//
+//   Anti-imposter contract (spec lines 195, 208, 212): the reply MUST
+//   carry `helloNonceHmac` even when `compatible: false`, so the client
+//   can rule out an imposter listener BEFORE the daemon tears down the
+//   socket. Returning a bare error on incompatibility would defeat the
+//   whole point of the HMAC challenge-response.
+//
+// Relationship to T8 (PR #663) helloInterceptor:
+//   - T8 is the slot-#0 envelope interceptor that gates non-hello RPCs
+//     pre-handshake (`hello_required`) and rejects replays
+//     (`hello_replay`). It currently inlines the HMAC compute itself.
+//   - T19 (this file) is the canonical wire-level handler that the
+//     control-socket dispatcher (T16, PR #665) registers in place of
+//     the NOT_IMPLEMENTED stub for `daemon.hello`. It is the same
+//     pure decision T8 makes on a successful first hello, factored out
+//     so the dispatcher slot is real instead of throwing
+//     NotImplementedError, and so a future cleanup can have T8 delegate
+//     here (de-duplicating the compute path).
+//
+// Single Responsibility (producer / decider / sink discipline):
+//   PURE DECIDER. Inputs:
+//     - per-call request payload (validated here, schema-rejected on
+//       malformed shape — same rules T8 enforces),
+//     - daemon-wide config injected by factory: `getSecret()`,
+//       `getBootNonce()`, optional `minClient`.
+//   Outputs:
+//     - on valid request: a HelloReplyPayload (helloNonceHmac +
+//       protocol block + compatibility verdict).
+//     - on malformed request: throws `DaemonHelloSchemaError` so the
+//       dispatcher's caller (T14 control-socket transport) maps it to a
+//       wire-level `schema_violation` rejection frame. This handler
+//       does NOT touch the socket — sink ownership stays in T14.
+//   No socket I/O, no per-connection state (the interceptor T8 owns
+//   that), no key material on disk reads (factory injects the secret so
+//   tests don't need a real keystore).
+
+import { Buffer } from 'node:buffer';
+import { decode as base64urlDecode } from '../envelope/base64url.js';
+import {
+  computeHmac,
+  HMAC_TAG_LENGTH,
+  NONCE_BYTES,
+} from '../envelope/hmac.js';
+import { DAEMON_PROTOCOL_VERSION } from '../envelope/protocol-version.js';
+
+// ---------------------------------------------------------------------------
+// Wire constants (mirror the helloInterceptor exports — single source of truth
+// is currently split between T8 and T19; a follow-up should consolidate into
+// one module once the interceptor delegates here).
+// ---------------------------------------------------------------------------
+
+/** Canonical hello RPC method name (spec §3.4.1.g, namespaced per §3.4.1.g
+ *  RPC-namespace rule `ccsm.<wireMajor>/<service>.<method>`). The dispatcher's
+ *  SUPERVISOR_RPCS allowlist accepts the literal `daemon.hello` (control-plane
+ *  carve-out, spec line 249); on the data-plane the same handler is reached
+ *  via the namespaced form. The handler itself is namespace-agnostic. */
+export const HELLO_METHOD_NAMESPACED = 'ccsm.v1/daemon.hello';
+export const HELLO_METHOD_LITERAL = 'daemon.hello';
+
+/** Canonical wire-format identifier for v0.3 (spec §3.4.1.g). */
+export const DAEMON_WIRE = 'v0.3-json-envelope' as const;
+
+/** Daemon-accepted wire formats list (spec §3.4.1.g `daemonAcceptedWires`).
+ *  v0.3 ships a single-element array; v0.4 will append `'v0.4-protobuf'`. */
+export const DAEMON_ACCEPTED_WIRES: readonly string[] = [DAEMON_WIRE] as const;
+
+/** Active frame-version nibble (spec §3.4.1.c). v0.3 = 0; v0.4 = 1. */
+export const DAEMON_FRAME_VERSION = 0;
+
+/** Active feature flags announced in `protocol.features[]` (spec §3.4.1.g). */
+export const DAEMON_FEATURES: readonly string[] = [
+  'binary-frames',
+  'stream-heartbeat',
+  'interceptors',
+  'traceId',
+  'bootNonce',
+  'hello',
+] as const;
+
+/** Defaults block surfaced in the hello reply (spec §3.4.1.g `defaults`). */
+export const DAEMON_DEFAULTS = Object.freeze({
+  deadlineMs: 5_000,
+  heartbeatMs: 30_000,
+  backpressureBytes: 1_048_576,
+});
+
+const DEFAULT_MIN_CLIENT = 'v0.3';
+
+// ---------------------------------------------------------------------------
+// Wire payload shapes (mirror spec §3.4.1.g frame 1 / frame 2 schema).
+// ---------------------------------------------------------------------------
+
+export interface HelloRequestPayload {
+  readonly clientWire: string;
+  readonly clientProtocolVersion: number;
+  readonly clientFrameVersions: readonly number[];
+  readonly clientFeatures: readonly string[];
+  readonly clientHelloNonce: string;
+}
+
+export interface HelloReplyPayload {
+  readonly helloNonceHmac: string;
+  readonly protocol: {
+    readonly wire: string;
+    readonly minClient: string;
+    readonly daemonProtocolVersion: number;
+    readonly daemonAcceptedWires: readonly string[];
+    readonly features: readonly string[];
+  };
+  readonly daemonFrameVersion: number;
+  readonly bootNonce: string;
+  readonly defaults: typeof DAEMON_DEFAULTS;
+  readonly compatible: boolean;
+  readonly reason?: CompatibilityReason;
+}
+
+export type CompatibilityReason =
+  | 'wire-mismatch'
+  | 'version-mismatch'
+  | 'frame-version-mismatch';
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/** Thrown on malformed `daemon.hello` payload. The control-socket transport
+ *  (T14) maps this to a wire-level `schema_violation` rejection frame and is
+ *  responsible for the post-reply `socket.destroy()` per spec §3.4.1.g. */
+export class DaemonHelloSchemaError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DaemonHelloSchemaError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export interface DaemonHelloHandlerConfig {
+  /** Returns the daemon.secret bytes for HMAC compute. Indirected through a
+   *  getter so tests don't need a real keystore and so secret rotation
+   *  (frag-6-7 §7.2) can swap the value live without rebuilding the
+   *  dispatcher registry. */
+  readonly getSecret: () => Buffer;
+  /** Returns the per-process boot nonce (ULID). Same value the supervisor
+   *  surfaces on `/healthz` (spec §3.4.1.g). Getter — not a constant —
+   *  because the daemon's bootNonce is allocated at boot and the handler
+   *  module is imported earlier in the dependency graph. */
+  readonly getBootNonce: () => string;
+  /** Optional override for the `minClient` advertised in the reply. Default
+   *  `'v0.3'`. Tests may pass a stub. */
+  readonly minClient?: string;
+}
+
+/**
+ * Construct the `daemon.hello` handler bound to a given secret/bootNonce
+ * source. The returned function matches the dispatcher's `Handler` shape
+ * (`(req: unknown, ctx) => Promise<unknown>`) so it can be registered via
+ * `dispatcher.register('daemon.hello', createDaemonHelloHandler({...}))`.
+ *
+ * Decision flow (single envelope):
+ *   1. Validate request shape — throw `DaemonHelloSchemaError` on bad input.
+ *   2. Compute `helloNonceHmac` over the DECODED 16-byte nonce buffer
+ *      (NOT the ASCII string — spec §3.4.1.g round-9 base64url lock).
+ *   3. Decide `compatible` per spec §3.4.1.g compatibility rule.
+ *   4. Return reply payload with `helloNonceHmac` populated even when
+ *      `compatible: false` (anti-imposter — spec lines 195, 208, 212).
+ */
+export function createDaemonHelloHandler(
+  config: DaemonHelloHandlerConfig,
+): (req: unknown) => Promise<HelloReplyPayload> {
+  const minClient = config.minClient ?? DEFAULT_MIN_CLIENT;
+
+  return async function handleDaemonHello(
+    req: unknown,
+  ): Promise<HelloReplyPayload> {
+    return decideHelloReply(req, {
+      secret: config.getSecret(),
+      bootNonce: config.getBootNonce(),
+      minClient,
+    });
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pure decision (exported for direct unit testing without the async wrapper).
+// ---------------------------------------------------------------------------
+
+interface DecideArgs {
+  readonly secret: Buffer;
+  readonly bootNonce: string;
+  readonly minClient: string;
+}
+
+/** Synchronous pure decider. Throws `DaemonHelloSchemaError` on bad payload;
+ *  otherwise returns the reply payload. The async factory above wraps this
+ *  for the dispatcher contract; tests prefer this entry point because they
+ *  can assert against the throw without `await expect(...).rejects`. */
+export function decideHelloReply(
+  req: unknown,
+  args: DecideArgs,
+): HelloReplyPayload {
+  const validated = validateHelloRequest(req);
+  const compatibility = checkCompatibility(validated, args.minClient);
+
+  // Decode the wire string back to bytes BEFORE HMAC compute. Comparing the
+  // ASCII strings would bypass the constant-time guarantee on the client
+  // side AND produce a different HMAC value (HMAC over 22 ASCII bytes !==
+  // HMAC over 16 raw bytes). Spec §3.4.1.g round-9 base64url lock.
+  const nonceBytes = base64urlDecode(validated.clientHelloNonce);
+  const helloNonceHmac = computeHmac(args.secret, nonceBytes);
+
+  const reply: HelloReplyPayload = {
+    helloNonceHmac,
+    protocol: {
+      wire: DAEMON_WIRE,
+      minClient: args.minClient,
+      daemonProtocolVersion: DAEMON_PROTOCOL_VERSION,
+      daemonAcceptedWires: DAEMON_ACCEPTED_WIRES,
+      features: DAEMON_FEATURES,
+    },
+    daemonFrameVersion: DAEMON_FRAME_VERSION,
+    bootNonce: args.bootNonce,
+    defaults: DAEMON_DEFAULTS,
+    compatible: compatibility.compatible,
+    ...(compatibility.compatible ? {} : { reason: compatibility.reason }),
+  };
+
+  return reply;
+}
+
+// ---------------------------------------------------------------------------
+// Validation (strict on fields the handler reads; lenient on extras so a
+// future v0.4 client carrying additional optional fields still handshakes).
+// ---------------------------------------------------------------------------
+
+function validateHelloRequest(payload: unknown): HelloRequestPayload {
+  if (payload === null || typeof payload !== 'object') {
+    throw new DaemonHelloSchemaError(
+      'daemon.hello payload must be an object',
+    );
+  }
+  const p = payload as Record<string, unknown>;
+
+  if (typeof p['clientWire'] !== 'string' || p['clientWire'].length === 0) {
+    throw new DaemonHelloSchemaError(
+      'daemon.hello.clientWire must be a non-empty string',
+    );
+  }
+  if (
+    typeof p['clientProtocolVersion'] !== 'number' ||
+    !Number.isInteger(p['clientProtocolVersion']) ||
+    (p['clientProtocolVersion'] as number) < 1
+  ) {
+    throw new DaemonHelloSchemaError(
+      'daemon.hello.clientProtocolVersion must be a positive integer',
+    );
+  }
+  if (!Array.isArray(p['clientFrameVersions'])) {
+    throw new DaemonHelloSchemaError(
+      'daemon.hello.clientFrameVersions must be an array of integers',
+    );
+  }
+  for (const v of p['clientFrameVersions'] as unknown[]) {
+    if (typeof v !== 'number' || !Number.isInteger(v)) {
+      throw new DaemonHelloSchemaError(
+        'daemon.hello.clientFrameVersions entries must be integers',
+      );
+    }
+  }
+  if (!Array.isArray(p['clientFeatures'])) {
+    throw new DaemonHelloSchemaError(
+      'daemon.hello.clientFeatures must be an array of strings',
+    );
+  }
+  for (const v of p['clientFeatures'] as unknown[]) {
+    if (typeof v !== 'string') {
+      throw new DaemonHelloSchemaError(
+        'daemon.hello.clientFeatures entries must be strings',
+      );
+    }
+  }
+
+  const nonce = p['clientHelloNonce'];
+  if (typeof nonce !== 'string' || nonce.length !== HMAC_TAG_LENGTH) {
+    throw new DaemonHelloSchemaError(
+      `daemon.hello.clientHelloNonce must be a ${HMAC_TAG_LENGTH}-char base64url string`,
+    );
+  }
+  // Decode-check: every accepted nonce must be exactly NONCE_BYTES bytes
+  // post-decode. The 22-char length filter above already rules out most
+  // bad inputs but the explicit decode catches non-base64url alphabet.
+  let decoded: Buffer;
+  try {
+    decoded = base64urlDecode(nonce);
+  } catch {
+    throw new DaemonHelloSchemaError(
+      'daemon.hello.clientHelloNonce is not valid base64url',
+    );
+  }
+  if (decoded.length !== NONCE_BYTES) {
+    throw new DaemonHelloSchemaError(
+      `daemon.hello.clientHelloNonce must decode to ${NONCE_BYTES} bytes`,
+    );
+  }
+
+  return {
+    clientWire: p['clientWire'] as string,
+    clientProtocolVersion: p['clientProtocolVersion'] as number,
+    clientFrameVersions: p['clientFrameVersions'] as readonly number[],
+    clientFeatures: p['clientFeatures'] as readonly string[],
+    clientHelloNonce: nonce,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Compatibility (spec §3.4.1.g compatibility rule, line 212).
+// ---------------------------------------------------------------------------
+
+interface CompatibilityResult {
+  readonly compatible: boolean;
+  readonly reason?: CompatibilityReason;
+}
+
+function checkCompatibility(
+  req: HelloRequestPayload,
+  _minClient: string,
+): CompatibilityResult {
+  // Order: wire → version → frame-version. Matches the order the spec lists
+  // the three reasons; deterministic so a client receiving multiple
+  // mismatches always gets the same `reason` value across daemons.
+  if (!DAEMON_ACCEPTED_WIRES.includes(req.clientWire)) {
+    return { compatible: false, reason: 'wire-mismatch' };
+  }
+  if (req.clientProtocolVersion !== DAEMON_PROTOCOL_VERSION) {
+    return { compatible: false, reason: 'version-mismatch' };
+  }
+  if (!req.clientFrameVersions.includes(DAEMON_FRAME_VERSION)) {
+    return { compatible: false, reason: 'frame-version-mismatch' };
+  }
+  return { compatible: true };
+}


### PR DESCRIPTION
## Summary

Implements **T19** — the wire-level `daemon.hello` RPC handler for the control-socket dispatcher slot, per spec **§3.4.1.g** (`docs/superpowers/specs/v0.3-fragments/frag-3.4.1-envelope-hardening.md`).

**Two-frame HMAC challenge-response, daemon side:**
1. Client sends `clientHelloNonce` (16 random bytes, base64url-no-pad).
2. Daemon computes `helloNonceHmac = HMAC-SHA256(daemon.secret, decoded-16-byte-nonce)` truncated to 16 bytes, base64url, and returns it alongside the protocol/compatibility block.
3. Client verifies via `crypto.timingSafeEqual` (client-side concern; not this handler).

The daemon does **NOT** verify any client HMAC. Client identity is already proven by peer-cred (§3.1.1) + ACL (§7.1). The handler's job is to PROVE the listener possesses `daemon.secret` so the client can rule out an imposter listener.

### Interpretation note (re: brief wording)

The dispatch brief said "HMAC verify" — but per spec §3.4.1.g and PR #663 reviewer confirmation, the daemon **computes** the HMAC for the client to verify; it does not verify a client HMAC. This handler implements the spec-canonical compute-and-reply.

### Anti-imposter (spec lines 195, 208, 212)

The reply MUST carry `helloNonceHmac` even when `compatible: false`, so the client can rule out an imposter listener BEFORE the daemon tears down the socket. Returning a bare error on incompatibility would defeat the whole point of the challenge-response. Three regression tests assert this for each `reason` value.

### Single Responsibility

PURE DECIDER. Inputs: per-call request payload + factory-injected `getSecret()` / `getBootNonce()`. Outputs: a `HelloReplyPayload` or `DaemonHelloSchemaError` on malformed input. No socket I/O, no per-connection state (T8 helloInterceptor owns that), no key material reads (factory injects so tests don't need a real keystore and so secret rotation per frag-6-7 §7.2 can swap the value live).

### Implementation highlights

- **Round-9 base64url lock** (spec §3.4.1.g): HMAC computed over the DECODED 16-byte buffer, NOT the 22-char ASCII string. Regression test asserts the wrong-way value is NOT produced AND the right-way value matches an independently-computed reference.
- **Strict schema validation** on every field the handler reads. Throws `DaemonHelloSchemaError`; T14 control-socket transport maps this to a wire-level `schema_violation` rejection frame.
- **Compatibility check order**: wire → version → frame-version (matches spec listing order so the same multi-failure case always reports the same `reason` across daemons).
- **Factory contract**: `createDaemonHelloHandler({ getSecret, getBootNonce, minClient? })` returns a function matching the dispatcher's `Handler` shape. Both getters are called PER REQUEST so a long-lived dispatcher transparently picks up a rotated secret or a bootNonce allocated after handler construction.

### Relationship to neighbouring tasks

- **T8 (PR #663) helloInterceptor** — slot-#0 envelope interceptor that gates non-hello RPCs (`hello_required`) and rejects replays (`hello_replay`). Currently inlines the HMAC compute itself; a follow-up should refactor it to delegate here so there's a single source of truth.
- **T16 (PR #665) dispatcher** — registers a `NOT_IMPLEMENTED` stub for `daemon.hello`. Once T16 lands, wiring this handler in is one line: `dispatcher.register('daemon.hello', helloHandler)`.
- **T11 (PR #646, merged) SUPERVISOR_RPCS** — the dispatcher allowlist carries the literal `daemon.hello` (control-plane carve-out, spec line 249). The handler exports BOTH `HELLO_METHOD_LITERAL = 'daemon.hello'` and `HELLO_METHOD_NAMESPACED = 'ccsm.v1/daemon.hello'`.
- **T4 (PR #648, merged) hmac.ts** — reused for `computeHmac` / `NONCE_BYTES` / `HMAC_TAG_LENGTH`. No duplication.

## Test vectors (spec §3.4.1.g compliance)

```
TEST_SECRET     = utf8('test-daemon-secret-32-bytes-long-fixture-not-real')
nonce(seed=0xAB) = base64url(Buffer.alloc(16, 0xAB))   = 'q6urq6urq6urq6urq6urqw'
expected HMAC   = base64url(HMAC-SHA256(secret, decoded-nonce-bytes).subarray(0,16))
                ─ matches an independently-computed reference (test asserts equality
                  via createHmac('sha256', secret).update(decoded).digest())
```

A 50-iteration random-nonce sweep cross-checks every produced HMAC against the reference.

## Test plan

- [x] `npm run typecheck` (renderer + electron + daemon) — clean.
- [x] `npx vitest run daemon/src/handlers/__tests__/daemon-hello.test.ts` — **41/41 passed** (3.59s).
- [x] Main-process smoke: `node --input-type=module -e "import('./daemon/dist-daemon/handlers/daemon-hello.js')..."` loads the compiled ESM module and `createDaemonHelloHandler({...})(req)` returns `{ compatible: true, helloNonceHmac.length === 22, protocol.daemonProtocolVersion === 1, bootNonce, ... }`.
- [ ] CI green (Windows + Linux + typecheck + lint).

### Coverage by case

- Wire constants match spec (5 cases).
- Valid request → compatible: true, 22-char HMAC, full protocol block, bootNonce, defaults (6 cases).
- HMAC matches an independently-computed reference; stable across calls; divergent on different nonces / different secrets (3 cases).
- Round-9 base64url-bytes-not-ASCII regression (2 cases).
- Anti-imposter: `compatible: false` paths (wire / version / frame-version) all surface correct `helloNonceHmac` (4 cases).
- Schema rejection: null, non-object, missing/empty/wrong-type fields, wrong-length nonce, invalid base64url alphabet (14 cases).
- Factory contract: per-request `getSecret()` / `getBootNonce()`, custom + default `minClient`, promise rejection on schema error, 50-iteration random nonce sweep (7 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)