### PR TITLE
feat(daemon): T38 SIGCHLD parallel waitpid reaper (Unix)

### DIFF
--- a/daemon/src/pty/__tests__/sigchld-reaper.test.ts
+++ b/daemon/src/pty/__tests__/sigchld-reaper.test.ts
@@ -1,0 +1,339 @@
+// T38 — SIGCHLD reaper tests.
+//
+// Spec: frag-3.5.1 §3.5.1.2 + §3.5.1.6 acceptance.
+//
+// The reaper itself is portable (pure producer with injected deps) so
+// the contract tests run on every platform with FAKE deps. Only the
+// real-spawn e2e is gated to non-Windows.
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { spawn } from 'node:child_process';
+
+import {
+  installSigchldReaper,
+  type SigchldReaperDeps,
+  type SigchldReaperHandle,
+  type WaitpidResult,
+} from '../sigchld-reaper.js';
+
+// -- Fake deps -------------------------------------------------------------
+
+interface FakeDeps extends SigchldReaperDeps {
+  /** Manually fire SIGCHLD to all subscribed handlers. */
+  fireSigchld(): void;
+  /** Queue an exit result for the next waitpid(pid) call. */
+  setExit(pid: number, exitCode: number, signal?: string | null): void;
+  /** Subscriber count (for testing uninstall detach). */
+  subscriberCount(): number;
+  /** Throw on next waitpid for this pid. */
+  setWaitpidError(pid: number, err: unknown): void;
+  /** Number of waitpid calls per pid (drain semantics). */
+  waitpidCallsFor(pid: number): number;
+}
+
+function createFakeDeps(): FakeDeps {
+  const subscribers = new Set<() => void>();
+  // Pending exits per pid: FIFO queue. waitpid returns the head (and
+  // pops) if present, else 'no-state-change'.
+  const pending = new Map<number, WaitpidResult[]>();
+  const errors = new Map<number, unknown>();
+  const calls = new Map<number, number>();
+
+  return {
+    onSigchld(handler) {
+      subscribers.add(handler);
+      return () => subscribers.delete(handler);
+    },
+    waitpid(pid) {
+      calls.set(pid, (calls.get(pid) ?? 0) + 1);
+      if (errors.has(pid)) {
+        const err = errors.get(pid)!;
+        errors.delete(pid);
+        throw err;
+      }
+      const queue = pending.get(pid);
+      if (!queue || queue.length === 0) {
+        return { state: 'no-state-change' };
+      }
+      return queue.shift()!;
+    },
+    fireSigchld() {
+      // Snapshot — handler may detach itself.
+      for (const h of Array.from(subscribers)) h();
+    },
+    setExit(pid, exitCode, signal = null) {
+      const q = pending.get(pid) ?? [];
+      q.push({ state: 'exited', exitCode, signal });
+      pending.set(pid, q);
+    },
+    subscriberCount() {
+      return subscribers.size;
+    },
+    setWaitpidError(pid, err) {
+      errors.set(pid, err);
+    },
+    waitpidCallsFor(pid) {
+      return calls.get(pid) ?? 0;
+    },
+  };
+}
+
+// -- Platform guard --------------------------------------------------------
+
+describe('sigchld-reaper: platform guard', () => {
+  it.skipIf(process.platform === 'win32')(
+    'installs successfully on Unix',
+    () => {
+      const deps = createFakeDeps();
+      const handle = installSigchldReaper({
+        onChildExit: () => {},
+        deps,
+      });
+      handle.uninstall();
+      expect(deps.subscriberCount()).toBe(0);
+    },
+  );
+
+  it.skipIf(process.platform !== 'win32')(
+    'throws on Windows (use JobObject — T39)',
+    () => {
+      expect(() =>
+        installSigchldReaper({
+          onChildExit: () => {},
+          deps: createFakeDeps(),
+        }),
+      ).toThrow(/Unix only/);
+    },
+  );
+});
+
+// -- Contract tests (portable: fake deps everywhere) ----------------------
+
+// Skip the entire contract suite on Windows because installSigchldReaper
+// throws there before deps can take over. Production wiring on Win goes
+// through T39's JobObject path.
+describe.skipIf(process.platform === 'win32')(
+  'sigchld-reaper: producer contract',
+  () => {
+    let handle: SigchldReaperHandle | null = null;
+    afterEach(() => {
+      handle?.uninstall();
+      handle = null;
+    });
+
+    it('drains 5 fast children on a single SIGCHLD (coalescing)', () => {
+      const deps = createFakeDeps();
+      const exits: Array<{ pid: number; exitCode: number }> = [];
+      handle = installSigchldReaper({
+        onChildExit: (pid, st) => exits.push({ pid, exitCode: st.exitCode }),
+        initialPids: [1001, 1002, 1003, 1004, 1005],
+        deps,
+      });
+
+      // Simulate POSIX coalescing: 5 children exit, kernel delivers
+      // ONE SIGCHLD. Reaper must drain all five in this single pass.
+      for (const pid of [1001, 1002, 1003, 1004, 1005]) {
+        deps.setExit(pid, 0);
+      }
+      deps.fireSigchld();
+
+      expect(exits).toEqual([
+        { pid: 1001, exitCode: 0 },
+        { pid: 1002, exitCode: 0 },
+        { pid: 1003, exitCode: 0 },
+        { pid: 1004, exitCode: 0 },
+        { pid: 1005, exitCode: 0 },
+      ]);
+      expect(handle.registered()).toEqual([]);
+    });
+
+    it('uses per-PID waitpid (not waitpid(-1)) — only registered PIDs are queried', () => {
+      const deps = createFakeDeps();
+      handle = installSigchldReaper({
+        onChildExit: () => {},
+        initialPids: [42],
+        deps,
+      });
+      // Queue an exit for an UNREGISTERED pid; must not be reaped.
+      deps.setExit(99, 0);
+      deps.fireSigchld();
+
+      // Registered pid was waitpid'd exactly once.
+      expect(deps.waitpidCallsFor(42)).toBe(1);
+      // Unregistered pid was never queried — proves per-PID scope.
+      expect(deps.waitpidCallsFor(99)).toBe(0);
+    });
+
+    it('fires onChildExit exactly once per pid; no double-reap on second SIGCHLD', () => {
+      const deps = createFakeDeps();
+      const exits: number[] = [];
+      handle = installSigchldReaper({
+        onChildExit: (pid) => exits.push(pid),
+        initialPids: [777],
+        deps,
+      });
+      deps.setExit(777, 0);
+      deps.fireSigchld();
+      deps.fireSigchld(); // coalesced spurious second delivery
+      deps.fireSigchld();
+
+      expect(exits).toEqual([777]);
+      // pid was removed from set after first reap, so second/third
+      // SIGCHLD do not waitpid it again.
+      expect(deps.waitpidCallsFor(777)).toBe(1);
+    });
+
+    it('forwards exitCode and signal verbatim', () => {
+      const deps = createFakeDeps();
+      const exits: Array<{ pid: number; exitCode: number; signal: string | null }> = [];
+      handle = installSigchldReaper({
+        onChildExit: (pid, st) =>
+          exits.push({ pid, exitCode: st.exitCode, signal: st.signal }),
+        initialPids: [10, 11, 12],
+        deps,
+      });
+      deps.setExit(10, 0, null);
+      deps.setExit(11, 137, 'SIGKILL');
+      deps.setExit(12, 1, null);
+      deps.fireSigchld();
+
+      expect(exits).toEqual([
+        { pid: 10, exitCode: 0, signal: null },
+        { pid: 11, exitCode: 137, signal: 'SIGKILL' },
+        { pid: 12, exitCode: 1, signal: null },
+      ]);
+    });
+
+    it('drain() collects exits without a SIGCHLD (used by daemonShutdown)', () => {
+      const deps = createFakeDeps();
+      const exits: number[] = [];
+      handle = installSigchldReaper({
+        onChildExit: (pid) => exits.push(pid),
+        initialPids: [200, 201],
+        deps,
+      });
+      deps.setExit(200, 0);
+      deps.setExit(201, 0);
+      handle.drain();
+      expect(exits).toEqual([200, 201]);
+    });
+
+    it('register / unregister / registered behave as a set', () => {
+      const deps = createFakeDeps();
+      handle = installSigchldReaper({ onChildExit: () => {}, deps });
+      expect(handle.registered()).toEqual([]);
+      handle.register(1);
+      handle.register(2);
+      handle.register(1); // idempotent
+      expect(handle.registered().sort((a, b) => a - b)).toEqual([1, 2]);
+      handle.unregister(1);
+      handle.unregister(99); // idempotent
+      expect(handle.registered()).toEqual([2]);
+    });
+
+    it('waitpid throw is forwarded to onWaitpidError; drain continues with remaining pids', () => {
+      const deps = createFakeDeps();
+      const exits: number[] = [];
+      const errs: Array<{ pid: number; err: unknown }> = [];
+      handle = installSigchldReaper({
+        onChildExit: (pid) => exits.push(pid),
+        onWaitpidError: (pid, err) => errs.push({ pid, err }),
+        initialPids: [1, 2, 3],
+        deps,
+      });
+      deps.setWaitpidError(2, new Error('ECHILD-ish'));
+      deps.setExit(1, 0);
+      deps.setExit(3, 0);
+      deps.fireSigchld();
+
+      expect(exits).toEqual([1, 3]);
+      expect(errs).toHaveLength(1);
+      expect(errs[0]!.pid).toBe(2);
+      // pid 2 stays registered since the throw was not a successful
+      // reap — a future SIGCHLD can retry.
+      expect(handle.registered()).toEqual([2]);
+    });
+
+    it('uninstall detaches the SIGCHLD handler and clears the set', () => {
+      const deps = createFakeDeps();
+      const onExit = vi.fn();
+      handle = installSigchldReaper({
+        onChildExit: onExit,
+        initialPids: [50],
+        deps,
+      });
+      expect(deps.subscriberCount()).toBe(1);
+      handle.uninstall();
+      expect(deps.subscriberCount()).toBe(0);
+      expect(handle.registered()).toEqual([]);
+      // Post-uninstall SIGCHLDs are no-ops (handler detached).
+      deps.setExit(50, 0);
+      deps.fireSigchld();
+      expect(onExit).not.toHaveBeenCalled();
+    });
+
+    it('default deps loader throws a clear error until T39 lands the binding', () => {
+      // No deps passed — must direct caller to T39 / inject.
+      expect(() =>
+        installSigchldReaper({ onChildExit: () => {} }),
+      ).toThrow(/no default native deps|T39/);
+    });
+  },
+);
+
+// -- Real-spawn smoke (Unix only) -----------------------------------------
+//
+// This proves the producer contract holds when wired against a tiny
+// node:child_process-backed fake that mirrors real spawn/exit ordering.
+// We do NOT depend on the kernel SIGCHLD signal here because Node has
+// no first-class SIGCHLD listener — that is the native binding's job
+// (T39). This test just demonstrates the reaper drains real PIDs when
+// fed a real-ish exit signal.
+
+describe.skipIf(process.platform === 'win32')(
+  'sigchld-reaper: real spawn smoke (Unix)',
+  () => {
+    it('drains 5 real /bin/true children when a single drain pass fires', async () => {
+      // Spawn 5 fast children. Use a portable command — `true` exists
+      // on every POSIX system. Wait for all five to exit (so the
+      // kernel has stamped their exit status) before draining.
+      const children = await Promise.all(
+        Array.from({ length: 5 }, async () => {
+          const child = spawn('true');
+          const exited = new Promise<void>((resolve) => {
+            child.on('exit', () => resolve());
+          });
+          await exited;
+          return child.pid!;
+        }),
+      );
+
+      // Build a fake `waitpid` that says "exited code 0" exactly once
+      // per known pid — emulating what the native binding will do.
+      const reaped = new Set<number>();
+      const deps: SigchldReaperDeps = {
+        onSigchld: () => () => {},
+        waitpid: (pid) =>
+          reaped.has(pid)
+            ? { state: 'no-state-change' }
+            : (reaped.add(pid), { state: 'exited', exitCode: 0, signal: null }),
+      };
+
+      const exits: number[] = [];
+      const handle = installSigchldReaper({
+        onChildExit: (pid) => exits.push(pid),
+        initialPids: children,
+        deps,
+      });
+      try {
+        handle.drain();
+        expect(exits.sort((a, b) => a - b)).toEqual(
+          [...children].sort((a, b) => a - b),
+        );
+        expect(handle.registered()).toEqual([]);
+      } finally {
+        handle.uninstall();
+      }
+    });
+  },
+);

--- a/daemon/src/pty/sigchld-reaper.ts
+++ b/daemon/src/pty/sigchld-reaper.ts
@@ -1,0 +1,249 @@
+// T38 — SIGCHLD parallel waitpid reaper (Unix only).
+//
+// Per feedback_single_responsibility: this module is a pure PRODUCER. On
+// each SIGCHLD delivery from the kernel, it drains every exited child it
+// owns by calling per-PID `waitpid(pid, WNOHANG)` and emits one
+// `onChildExit(pid, status)` event per successful reap. It performs no
+// state mutation, no DB write, no fan-out: the decider (T37 lifecycle
+// FSM, `lifecycle.ts`) maps `(pid, status)` to a state transition; sinks
+// (DB UPDATE row, fan-out emit `ptyExit`) live elsewhere.
+//
+// Spec: frag-3.5.1 §3.5.1.2 — daemon-owned SIGCHLD with per-PID
+// `waitpid(pid, WNOHANG)` (not `waitpid(-1)`). Acceptance criterion
+// (§3.5.1.6): "SIGCHLD handler reaps a synthetic forked child within
+// 50ms via `waitpid(pid, WNOHANG)` (per-PID, not `waitpid(-1)`) and
+// emits exactly one `ptyExit` event with `spawnTraceId` populated;
+// second `waitpid` for an unrelated pid returns 0 (no double-reap)."
+//
+// Why per-PID instead of `waitpid(-1, WNOHANG)`?
+//
+//   The §3.5.1.2 contract is that the daemon owns SIGCHLD exclusively.
+//   Any pid the daemon does not have on its registered set is by
+//   construction not the daemon's concern; calling `waitpid(-1)` would
+//   reap children the daemon never spawned (e.g. helper subprocesses
+//   from libuv, native modules, or subagents). Per-PID waitpid keeps
+//   ownership scoped and is easier to reason about under coalescing.
+//
+// SIGCHLD coalescing problem:
+//
+//   POSIX coalesces standard signals — N rapid SIGCHLDs may deliver as
+//   one. The reaper MUST iterate the full registered-PID set on every
+//   signal and call `waitpid(pid, WNOHANG)` for each one, otherwise
+//   exits get lost. WNOHANG is mandatory — blocking would freeze the
+//   handler.
+//
+// Test injection:
+//
+//   Node has no first-class SIGCHLD support in pure JS (libuv reserves
+//   it for child_process bookkeeping). The production wiring delivers
+//   SIGCHLD via the in-tree `ccsm_native.node` binding (T39, separate
+//   PR). For unit-testability and to keep this module pure, both the
+//   signal subscription and the per-PID waitpid call are injected via
+//   the `Deps` parameter. Tests pass fakes; production passes the
+//   native binding.
+//
+// Cross-platform: Windows has no SIGCHLD (PTY exit is observed via
+// node-pty `onExit` + JobObject — see frag-3.5.1 §3.5.1.2 "Win parity"
+// paragraph). `installSigchldReaper` throws on Windows — callers must
+// guard with `process.platform !== 'win32'`. T39 provides the Win
+// equivalent via JobObject completion-port.
+
+/** Result of a `waitpid(pid, WNOHANG)` call. */
+export interface WaitpidResult {
+  /**
+   * - `'exited'` — child exited (cleanly or via signal). `exitCode`
+   *   and `signal` carry the status. Equivalent to `WIFEXITED` /
+   *   `WIFSIGNALED` returning true.
+   * - `'no-state-change'` — child is still running OR has already been
+   *   reaped OR is not a child of this process (POSIX `waitpid`
+   *   returning 0 or -1/ECHILD). The reaper treats both as "nothing to
+   *   do for this pid right now". The native binding maps both kernel
+   *   outcomes to this single state — the daemon does not need to
+   *   distinguish them at this layer.
+   */
+  state: 'exited' | 'no-state-change';
+  /** Decoded exit code (`WEXITSTATUS`). Set when state === 'exited'. */
+  exitCode?: number;
+  /**
+   * Decoded fatal signal name (`WTERMSIG` resolved to a string like
+   * `'SIGTERM'`). Set when state === 'exited' AND the child died by
+   * signal. Mutually exclusive with a non-zero exitCode in practice but
+   * the reaper does not enforce this — it forwards what the kernel
+   * reported.
+   */
+  signal?: string | null;
+}
+
+/** Status payload emitted by `onChildExit`. */
+export interface ChildExitStatus {
+  /** Decoded exit code. May be 0 even when `signal` is set if the kernel reported both. */
+  exitCode: number;
+  /** Fatal signal name if the child died by signal, else null. */
+  signal: string | null;
+}
+
+export type OnChildExit = (pid: number, status: ChildExitStatus) => void;
+
+/**
+ * Injected dependencies. Production wires these to the in-tree native
+ * binding (T39); tests pass fakes. Keeping this surface tiny is what
+ * makes the reaper a pure producer.
+ */
+export interface SigchldReaperDeps {
+  /**
+   * Subscribe to SIGCHLD delivery. The returned function MUST detach
+   * the subscription. The reaper calls the supplied handler exactly
+   * once per delivery (the handler internally drains all PIDs).
+   */
+  onSigchld: (handler: () => void) => () => void;
+  /**
+   * Per-PID non-blocking waitpid. MUST NOT block. MUST return
+   * `{ state: 'no-state-change' }` if the child is still running or is
+   * not a child of this process. MUST return `{ state: 'exited', ... }`
+   * exactly once per child exit (subsequent calls return
+   * `'no-state-change'`).
+   */
+  waitpid: (pid: number) => WaitpidResult;
+}
+
+export interface InstallSigchldReaperOptions {
+  /** Sink callback fired once per reaped child. Pure producer — caller decides what to do. */
+  onChildExit: OnChildExit;
+  /**
+   * Initial set of PIDs to reap. Optional; callers usually `register`
+   * each PID at spawn time instead.
+   */
+  initialPids?: Iterable<number>;
+  /**
+   * Optional dependency injection. Defaults to the in-tree native
+   * binding loader. Tests always inject fakes; production code may
+   * also inject when exercising on a non-Unix sandbox.
+   */
+  deps?: SigchldReaperDeps;
+  /**
+   * Optional structured-error sink. The reaper itself does no logging
+   * (single responsibility); if a per-pid waitpid throws, this
+   * callback is invoked so callers can route the diagnostic. Default:
+   * swallowed — the reaper continues draining the remaining PIDs.
+   */
+  onWaitpidError?: (pid: number, err: unknown) => void;
+}
+
+export interface SigchldReaperHandle {
+  /** Add a PID to the reap set. Idempotent. */
+  register(pid: number): void;
+  /** Remove a PID from the reap set without reaping. Idempotent. */
+  unregister(pid: number): void;
+  /** Snapshot of currently registered PIDs (for diagnostics / tests). */
+  registered(): number[];
+  /**
+   * Manually trigger a drain pass (without waiting for SIGCHLD). Used
+   * by the daemon-shutdown sequence (frag-3.5.1 §3.5.1.2 step 6) to
+   * collect any reaps that arrived while a SIGTERM batch was in
+   * flight. Also useful in tests.
+   */
+  drain(): void;
+  /** Detach the SIGCHLD handler and clear the registered set. */
+  uninstall(): void;
+}
+
+/**
+ * Install a SIGCHLD reaper. Unix-only — throws on win32.
+ *
+ * Contract:
+ *   - On every SIGCHLD delivery, iterates the registered-PID set and
+ *     calls `deps.waitpid(pid)` for each.
+ *   - Each `state === 'exited'` result fires `onChildExit(pid, status)`
+ *     EXACTLY ONCE and removes pid from the registered set.
+ *   - `state === 'no-state-change'` is silent: pid remains registered.
+ *   - `deps.waitpid` throwing is forwarded to `onWaitpidError` (if
+ *     supplied) and the drain continues with the next pid; the pid
+ *     stays registered so a later signal can retry.
+ */
+export function installSigchldReaper(
+  options: InstallSigchldReaperOptions,
+): SigchldReaperHandle {
+  if (process.platform === 'win32') {
+    throw new Error(
+      'installSigchldReaper: Unix only. Windows uses JobObject completion-port (T39).',
+    );
+  }
+
+  const deps = options.deps ?? loadDefaultDeps();
+  const onExit = options.onChildExit;
+  const onWaitpidError = options.onWaitpidError;
+  const pids = new Set<number>();
+  for (const pid of options.initialPids ?? []) {
+    pids.add(pid);
+  }
+
+  let detach: (() => void) | null = null;
+  let uninstalled = false;
+
+  const drain = (): void => {
+    if (uninstalled) return;
+    // Snapshot to a local array so register/unregister calls fired
+    // from inside `onExit` don't mutate the iteration.
+    const snapshot = Array.from(pids);
+    for (const pid of snapshot) {
+      let result: WaitpidResult;
+      try {
+        result = deps.waitpid(pid);
+      } catch (err) {
+        if (onWaitpidError) onWaitpidError(pid, err);
+        continue;
+      }
+      if (result.state !== 'exited') continue;
+      // Remove BEFORE firing the callback so re-entrant register of the
+      // same pid (rare, but a fast respawn path could do it) is not
+      // immediately undone.
+      pids.delete(pid);
+      const status: ChildExitStatus = {
+        exitCode: result.exitCode ?? 0,
+        signal: result.signal ?? null,
+      };
+      onExit(pid, status);
+    }
+  };
+
+  detach = deps.onSigchld(drain);
+
+  return {
+    register(pid: number): void {
+      if (uninstalled) return;
+      pids.add(pid);
+    },
+    unregister(pid: number): void {
+      pids.delete(pid);
+    },
+    registered(): number[] {
+      return Array.from(pids);
+    },
+    drain,
+    uninstall(): void {
+      if (uninstalled) return;
+      uninstalled = true;
+      if (detach) {
+        try {
+          detach();
+        } finally {
+          detach = null;
+        }
+      }
+      pids.clear();
+    },
+  };
+}
+
+/**
+ * Production-default dependency loader. The in-tree `ccsm_native.node`
+ * binding is owned by T39; until it lands, this throws a clear error
+ * directing callers to inject deps. Tests always inject; the daemon
+ * runtime path will be wired in T39's PR alongside the binding.
+ */
+function loadDefaultDeps(): SigchldReaperDeps {
+  throw new Error(
+    'installSigchldReaper: no default native deps available yet. ' +
+      'Pass `options.deps` until T39 lands the ccsm_native binding.',
+  );
+}


### PR DESCRIPTION
## Summary

T38 — Pure producer for the daemon-owned SIGCHLD reap path
(`daemon/src/pty/sigchld-reaper.ts`). On each SIGCHLD, drains the
registered-PID set with per-PID `waitpid(pid, WNOHANG)` and emits
one `onChildExit(pid, status)` per reaped child.

## Spec

- frag-3.5.1 §3.5.1.2 (POSIX process group + SIGCHLD wiring): "daemon
  owns SIGCHLD with per-PID `waitpid`". Per-PID — not `waitpid(-1)` —
  keeps ownership scoped to children the daemon spawned.
- §3.5.1.6 acceptance: "SIGCHLD handler reaps a synthetic forked
  child within 50ms via `waitpid(pid, WNOHANG)` (per-PID, not
  `waitpid(-1)`) and emits exactly one `ptyExit` event ... second
  `waitpid` for an unrelated pid returns 0 (no double-reap)."

## Design

- **Single responsibility — producer only.** No state mutation, no DB,
  no fan-out, no logging. Decider = T37 lifecycle FSM
  (`lifecycle.ts`); sinks (DB UPDATE, `ptyExit` emit) live elsewhere.
- **SIGCHLD coalescing handled.** POSIX may collapse N rapid SIGCHLDs
  into one delivery — the reaper iterates the FULL registered-PID set
  on every signal, so all exits get drained per signal.
- **Per-PID waitpid (not `waitpid(-1)`).** Spec contract: daemon does
  not reap children it never spawned (libuv helpers, native modules,
  subagents).
- **Deps injected.** `onSigchld` and `waitpid` are passed in. Tests
  use fakes; production wires the in-tree `ccsm_native.node` binding
  in T39's PR (default-deps loader currently throws a clear "wire
  T39" error).
- **`drain()` exposed** for `daemonShutdown` step 6 (frag-3.5.1
  §3.5.1.2) — collects reaps that arrived between SIGTERM batch and
  the next signal.
- **Windows: throws on install.** Win has no SIGCHLD; T39's JobObject
  completion-port covers Win parity.

## Test plan

- [x] Typecheck: `tsc --noEmit -p daemon/tsconfig.json` clean.
- [x] Vitest: `npx vitest run daemon/src/pty/__tests__` → 46 pass,
      11 contract tests skip on Windows by design (will run on Linux
      CI).
- [x] Platform guard test passes on Win (1/1).
- [x] Reverse-verified the producer logic on Windows by temporarily
      forcing `process.platform = 'linux'` and exercising the contract
      with fakes — green; introduced a `slice(0, 1)` bug → test fails
      as expected; restored.
- [ ] Linux CI runs the full skipped contract suite (8 tests) plus
      the real-spawn `/bin/true` smoke (5 children).

## Single-responsibility audit

| Piece | Role |
|---|---|
| `installSigchldReaper` | producer (drain + emit) |
| T37 `transition()` | decider (status → next state) |
| (later) DB UPDATE / `ptyExit` fan-out | sinks |