### PR TITLE
feat(daemon): T43 drop-slowest 1MB watermark

### DIFF
--- a/daemon/src/pty/__tests__/drop-slowest.test.ts
+++ b/daemon/src/pty/__tests__/drop-slowest.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DROP_SLOWEST_DEFAULT_THRESHOLD_BYTES,
+  createDropSlowest,
+} from '../drop-slowest.js';
+
+describe('drop-slowest: spec-default constant (frag-3.5.1 §3.5.1.5 line 118)', () => {
+  it('exports threshold = 1 MiB (1_048_576 bytes)', () => {
+    expect(DROP_SLOWEST_DEFAULT_THRESHOLD_BYTES).toBe(1024 * 1024);
+    expect(DROP_SLOWEST_DEFAULT_THRESHOLD_BYTES).toBe(1_048_576);
+  });
+});
+
+describe('drop-slowest: construction', () => {
+  it('rejects non-positive thresholdBytes', () => {
+    expect(() => createDropSlowest({ thresholdBytes: 0 })).toThrow(RangeError);
+    expect(() => createDropSlowest({ thresholdBytes: -1 })).toThrow(RangeError);
+    expect(() => createDropSlowest({ thresholdBytes: 1.5 })).toThrow(RangeError);
+    expect(() => createDropSlowest({ thresholdBytes: Number.NaN })).toThrow(RangeError);
+  });
+
+  it('defaults to the spec threshold', () => {
+    const d = createDropSlowest();
+    d.record('s', DROP_SLOWEST_DEFAULT_THRESHOLD_BYTES);
+    expect(d.getOverlimit()).toEqual([]);
+    d.record('s', 1);
+    expect(d.getOverlimit()).toEqual(['s']);
+  });
+});
+
+describe('drop-slowest: single subscriber accumulation', () => {
+  it('flags overlimit only after pending strictly exceeds 1 MiB', () => {
+    const d = createDropSlowest();
+    // Half a MiB — well below.
+    d.record('a', 512 * 1024);
+    expect(d.pending('a')).toBe(512 * 1024);
+    expect(d.getOverlimit()).toEqual([]);
+    // Up to exactly 1 MiB — boundary, NOT overlimit (strict greater-than).
+    d.record('a', 512 * 1024);
+    expect(d.pending('a')).toBe(1_048_576);
+    expect(d.getOverlimit()).toEqual([]);
+    // One byte over — flagged.
+    d.record('a', 1);
+    expect(d.pending('a')).toBe(1_048_577);
+    expect(d.getOverlimit()).toEqual(['a']);
+  });
+
+  it('does not flag a subscriber that stays below threshold', () => {
+    const d = createDropSlowest({ thresholdBytes: 1000 });
+    d.record('a', 999);
+    expect(d.getOverlimit()).toEqual([]);
+    d.record('a', 1); // 1000 — boundary, still not overlimit
+    expect(d.getOverlimit()).toEqual([]);
+  });
+});
+
+describe('drop-slowest: flush decrements tally', () => {
+  it('drops back below threshold after flush', () => {
+    const d = createDropSlowest({ thresholdBytes: 100 });
+    d.record('a', 150);
+    expect(d.getOverlimit()).toEqual(['a']);
+    d.flush('a', 100); // 50 pending now
+    expect(d.pending('a')).toBe(50);
+    expect(d.getOverlimit()).toEqual([]);
+  });
+
+  it('clamps tally at zero on over-decrement (race-safe)', () => {
+    const d = createDropSlowest({ thresholdBytes: 100 });
+    d.record('a', 50);
+    d.flush('a', 999); // way more than pending — clamp to 0
+    expect(d.pending('a')).toBe(0);
+    d.flush('unknown-sub', 10); // unknown subscriber — silently ignored
+    expect(d.pending('unknown-sub')).toBe(0);
+  });
+});
+
+describe('drop-slowest: reset', () => {
+  it('zeroes tally without forgetting the subscriber', () => {
+    const d = createDropSlowest({ thresholdBytes: 100 });
+    d.record('a', 200);
+    expect(d.getOverlimit()).toEqual(['a']);
+    d.reset('a');
+    expect(d.pending('a')).toBe(0);
+    expect(d.getOverlimit()).toEqual([]);
+    // Subsequent record() accumulates from 0.
+    d.record('a', 50);
+    expect(d.pending('a')).toBe(50);
+  });
+
+  it('is a no-op for unknown subscribers', () => {
+    const d = createDropSlowest();
+    d.reset('never-seen'); // must not throw
+    expect(d.pending('never-seen')).toBe(0);
+  });
+});
+
+describe('drop-slowest: multiple subscribers, only over-threshold returned', () => {
+  it('returns only the over-threshold subset, in insertion order', () => {
+    const d = createDropSlowest({ thresholdBytes: 100 });
+    d.record('a', 50); // under
+    d.record('b', 200); // over
+    d.record('c', 100); // boundary, under
+    d.record('d', 101); // over
+    expect(d.getOverlimit()).toEqual(['b', 'd']);
+  });
+
+  it('isolates subscriber tallies', () => {
+    const d = createDropSlowest({ thresholdBytes: 100 });
+    d.record('a', 200);
+    d.record('b', 50);
+    d.flush('a', 200);
+    expect(d.pending('a')).toBe(0);
+    expect(d.pending('b')).toBe(50);
+    expect(d.getOverlimit()).toEqual([]);
+  });
+});
+
+describe('drop-slowest: forget cleans up state', () => {
+  it('removes the subscriber entirely', () => {
+    const d = createDropSlowest({ thresholdBytes: 100 });
+    d.record('a', 200);
+    expect(d.getOverlimit()).toEqual(['a']);
+    d.forget('a');
+    expect(d.pending('a')).toBe(0);
+    expect(d.getOverlimit()).toEqual([]);
+  });
+
+  it('is idempotent', () => {
+    const d = createDropSlowest();
+    d.forget('never-seen');
+    d.record('a', 10);
+    d.forget('a');
+    d.forget('a'); // second forget — no throw
+    expect(d.pending('a')).toBe(0);
+  });
+});
+
+describe('drop-slowest: replay-burst exemption seam (T47 / task #1004)', () => {
+  it('skips accounting when { exempt: true } is passed', () => {
+    const d = createDropSlowest();
+    // Simulate a 256 KB replay burst delivered as one initial write — must
+    // NOT count toward the steady-state watermark.
+    d.record('a', 256 * 1024, { exempt: true });
+    expect(d.pending('a')).toBe(0);
+    expect(d.getOverlimit()).toEqual([]);
+    // Subsequent steady-state writes accumulate normally and DO trip at 1 MB.
+    d.record('a', 1_048_576);
+    expect(d.getOverlimit()).toEqual([]);
+    d.record('a', 1);
+    expect(d.getOverlimit()).toEqual(['a']);
+  });
+
+  it('reset() after replay write is the alternative seam', () => {
+    const d = createDropSlowest();
+    // Caller chose record-then-reset path: include replay in tally to keep
+    // ordering simple, then clear before steady-state accounting begins.
+    d.record('a', 256 * 1024);
+    d.reset('a');
+    expect(d.pending('a')).toBe(0);
+    d.record('a', 1_048_576);
+    expect(d.getOverlimit()).toEqual([]);
+    d.record('a', 1);
+    expect(d.getOverlimit()).toEqual(['a']);
+  });
+});
+
+describe('drop-slowest: input validation', () => {
+  it('rejects negative byteCount on record', () => {
+    const d = createDropSlowest();
+    expect(() => d.record('a', -1)).toThrow(RangeError);
+  });
+
+  it('rejects non-integer byteCount on record', () => {
+    const d = createDropSlowest();
+    expect(() => d.record('a', 1.5)).toThrow(RangeError);
+    expect(() => d.record('a', Number.NaN)).toThrow(RangeError);
+    expect(() => d.record('a', Number.POSITIVE_INFINITY)).toThrow(RangeError);
+  });
+
+  it('rejects negative byteCount on flush', () => {
+    const d = createDropSlowest();
+    expect(() => d.flush('a', -1)).toThrow(RangeError);
+  });
+
+  it('zero-byte record is a no-op but registers the subscriber', () => {
+    const d = createDropSlowest();
+    d.record('a', 0);
+    expect(d.pending('a')).toBe(0);
+    expect(d.getOverlimit()).toEqual([]);
+  });
+});

--- a/daemon/src/pty/drop-slowest.ts
+++ b/daemon/src/pty/drop-slowest.ts
@@ -1,0 +1,191 @@
+// PTY subscriber drop-slowest watermark (spec §3.5.1.5 / frag-3.5.1 lines
+// 118, 134, 165, 201).
+//
+// Pure decider primitive used by the per-session fan-out registry. The spec
+// mandates a per-subscriber 1 MiB pending-bytes watermark: once a subscriber's
+// in-flight (Connect-buffered) byte count strictly exceeds the threshold, the
+// subscriber is flagged `slow` and the caller closes its server-stream with
+// `RESOURCE_EXHAUSTED` and unregisters it. Drop-slowest preserves desktop UX
+// at the cost of forcing the slow client to resume from `fromSeq` (cheap —
+// the seq replay in §3.5 is exactly what makes this safe).
+//
+// Single Responsibility (per `feedback_single_responsibility`):
+//   - producer of an in-flight byte count per subscriber;
+//   - decider for the threshold predicate (strict greater-than);
+//   - NOT a sink: no socket close, no log emission, no metric. The caller
+//     reads `getOverlimit()` and performs the close + log + unregister.
+//
+// Replay-burst exemption seam (spec line 120, 135, 165, 201) — TRACKED IN
+// SEPARATE TASK #1004 / T47:
+//   The 256 KB replay payload delivered as the first post-resubscribe write
+//   does NOT count toward this watermark. The contract here exposes two
+//   compatible seams:
+//     * `reset(subId)` — caller calls it AFTER the replay write has flushed
+//       so steady-state accounting starts from zero (the spec's "watermark is
+//       measured AFTER the replay burst is delivered" wording maps to this
+//       sequencing).
+//     * `record(subId, byteCount, { exempt: true })` — caller may instead
+//       record the replay write with the `exempt` flag set; the decider
+//       short-circuits and does NOT add to the tally. This is the seam T47
+//       wires into the resubscribe code path so the replay write and any
+//       coincident steady-state writes can be ordered freely.
+//   Both seams are intentionally redundant — T47 picks one. Documented here
+//   so this file does not need re-opening when T47 lands.
+//
+// Threshold semantics (spec line 134, "after exactly 1 MB"):
+//   Strict greater-than. Exactly 1 MiB pending = NOT yet overlimit. Tally
+//   crosses the threshold only on the write that pushes pending past
+//   1_048_576 bytes. This matches the spec's "past 1 MB" wording (line 118).
+
+/** 1 MiB — the spec-mandated default per-subscriber watermark. */
+export const DROP_SLOWEST_DEFAULT_THRESHOLD_BYTES = 1_048_576 as const;
+
+/** Construction options. */
+export interface DropSlowestOptions {
+  /**
+   * Per-subscriber pending-bytes watermark. Strict greater-than: a subscriber
+   * is overlimit only when its tally is `> thresholdBytes`. Defaults to
+   * `DROP_SLOWEST_DEFAULT_THRESHOLD_BYTES` (1 MiB). Must be a positive
+   * integer.
+   */
+  readonly thresholdBytes?: number;
+}
+
+/** Per-`record()` options. */
+export interface DropSlowestRecordOptions {
+  /**
+   * If `true`, the byte count is NOT added to the subscriber's tally. Used
+   * by the resubscribe path (T47) to deliver the bounded replay payload
+   * without tripping the steady-state watermark. See file header for the
+   * cross-task contract.
+   *
+   * Default `false`.
+   */
+  readonly exempt?: boolean;
+}
+
+export interface DropSlowest {
+  /**
+   * Add `byteCount` to the subscriber's pending-bytes tally. Caller invokes
+   * this on each enqueue (i.e. each `socket.write` whose bytes are now sitting
+   * in Connect's per-stream buffer). `byteCount` MUST be a non-negative
+   * finite integer; zero is a no-op. Negative values throw.
+   *
+   * Pass `{ exempt: true }` to skip accounting (replay-burst exemption seam,
+   * see file header).
+   */
+  record(subId: string, byteCount: number, opts?: DropSlowestRecordOptions): void;
+  /**
+   * Decrement the subscriber's pending tally by `byteCount` (caller invokes
+   * this when a previously-enqueued chunk has flushed to the OS socket /
+   * has been consumed by Connect's drain). Tally is clamped at 0 — a stray
+   * over-decrement is silently absorbed rather than thrown so a flush-callback
+   * race cannot crash the daemon. `byteCount` MUST be non-negative finite.
+   *
+   * Convenience name `flush` is exposed alongside `record(neg)` because the
+   * caller's intent ("bytes left the buffer") reads more clearly than a
+   * signed `record`.
+   */
+  flush(subId: string, byteCount: number): void;
+  /**
+   * Reset a subscriber's tally to 0. Used (a) when the caller has dropped the
+   * subscriber and is about to forget it (followed by `forget()`), and (b)
+   * after the replay write has flushed on resubscribe (T47 exemption seam,
+   * see file header).
+   */
+  reset(subId: string): void;
+  /**
+   * Forget a subscriber entirely (no tally, no entry). Caller invokes this
+   * after closing the stream so the internal map does not leak. Idempotent.
+   */
+  forget(subId: string): void;
+  /**
+   * Return the list of subscribers whose tally is strictly greater than
+   * `thresholdBytes`. Caller iterates the result and closes each stream with
+   * `RESOURCE_EXHAUSTED`, then calls `forget(subId)`. Order is insertion
+   * order of first `record()` per subscriber; callers that need oldest-slowest
+   * ordering (aggregate cap, frag-3.5.1 line 119, separate task) layer their
+   * own LRU on top.
+   */
+  getOverlimit(): string[];
+  /**
+   * Test/observability accessor. Returns the current pending-bytes tally for
+   * `subId` (0 if unknown).
+   */
+  pending(subId: string): number;
+}
+
+/**
+ * Construct a drop-slowest decider. One instance per fan-out registry (i.e.
+ * one per session) — keeps subscriber-id scope local to the registry that
+ * owns the IDs.
+ */
+export function createDropSlowest(opts: DropSlowestOptions = {}): DropSlowest {
+  const thresholdBytes = opts.thresholdBytes ?? DROP_SLOWEST_DEFAULT_THRESHOLD_BYTES;
+  if (!Number.isInteger(thresholdBytes) || thresholdBytes <= 0) {
+    throw new RangeError(
+      `drop-slowest thresholdBytes must be a positive integer, got ${thresholdBytes}`,
+    );
+  }
+
+  // Insertion-ordered for stable `getOverlimit()` output. `Map` preserves
+  // insertion order per ECMAScript spec, which is what we want.
+  const tally = new Map<string, number>();
+
+  function assertNonNegByteCount(byteCount: number, fnName: string): void {
+    if (!Number.isFinite(byteCount) || byteCount < 0 || !Number.isInteger(byteCount)) {
+      throw new RangeError(
+        `drop-slowest ${fnName} byteCount must be a non-negative integer, got ${byteCount}`,
+      );
+    }
+  }
+
+  function record(
+    subId: string,
+    byteCount: number,
+    recordOpts?: DropSlowestRecordOptions,
+  ): void {
+    assertNonNegByteCount(byteCount, 'record');
+    if (recordOpts?.exempt) return;
+    if (byteCount === 0) {
+      // Touch the entry so insertion order is established even on a no-op,
+      // mirroring the contract that `pending(subId)` returns 0 (not undefined)
+      // after any `record()` has been called for that subscriber.
+      if (!tally.has(subId)) tally.set(subId, 0);
+      return;
+    }
+    const prev = tally.get(subId) ?? 0;
+    tally.set(subId, prev + byteCount);
+  }
+
+  function flush(subId: string, byteCount: number): void {
+    assertNonNegByteCount(byteCount, 'flush');
+    if (byteCount === 0) return;
+    const prev = tally.get(subId);
+    if (prev === undefined) return; // never recorded — nothing to flush
+    const next = prev - byteCount;
+    tally.set(subId, next > 0 ? next : 0);
+  }
+
+  function reset(subId: string): void {
+    if (tally.has(subId)) tally.set(subId, 0);
+  }
+
+  function forget(subId: string): void {
+    tally.delete(subId);
+  }
+
+  function getOverlimit(): string[] {
+    const out: string[] = [];
+    for (const [subId, bytes] of tally) {
+      if (bytes > thresholdBytes) out.push(subId);
+    }
+    return out;
+  }
+
+  function pending(subId: string): number {
+    return tally.get(subId) ?? 0;
+  }
+
+  return { record, flush, reset, forget, getOverlimit, pending };
+}


### PR DESCRIPTION
## Summary

Pure decider primitive for the per-subscriber pending-bytes watermark mandated by frag-3.5.1 §3.5.1.5 (lines 118, 134, 165, 201). New module `daemon/src/pty/drop-slowest.ts` exposes `createDropSlowest({ thresholdBytes })` returning `{ record, flush, reset, forget, getOverlimit, pending }`.

- **Threshold**: `1_048_576` bytes (1 MiB), strict greater-than. Exactly 1 MiB pending is NOT overlimit — matches the spec's "past 1 MB" wording (line 118) and the acceptance "after exactly 1 MB" (line 134) which is read as `> 1 MiB` since the drop fires on the write that pushes past.
- **Single Responsibility**: producer of pending byte tally + decider for the predicate. NOT a sink — caller (fan-out registry) is responsible for closing the slow stream with `RESOURCE_EXHAUSTED`, emitting the `subscriber-dropped-slow` log line, and unregistering.
- **Replay-burst exemption seam (T47 / task #1004 — separate)**: contract exposes two compatible seams so this file does not need to reopen when T47 lands:
  - `record(subId, byteCount, { exempt: true })` — short-circuits accounting; T47 wires the bounded 256 KB replay write through this.
  - `reset(subId)` — alternative path: include replay in tally then clear before steady-state begins. Caller picks one; both behaviours covered by tests.
  Documented at length in the file header so the cross-task contract is discoverable from the call site.

## Spec references
- `docs/superpowers/specs/v0.3-fragments/frag-3.5.1-pty-hardening.md` line 118 (drop-slowest contract), line 120 (replay-burst exemption clarification), line 134 (unit acceptance: "after exactly 1 MB"), line 165 (Task 11c explicit replay-exemption test mandate), line 201 (256 KB vs 1 MB orthogonality).

## Test plan
- [x] `npx vitest run daemon/src/pty/__tests__/drop-slowest.test.ts` → 19/19 pass (boundary, multi-subscriber, flush clamp, exemption seam, input validation).
- [x] `npx tsc -p daemon/tsconfig.json --noEmit` clean.
- [x] Require-load smoke against emitted `dist-daemon/pty/drop-slowest.js` (1 MiB + 1 byte → overlimit list `['a']`).
- [ ] Wired into `daemon/src/pty/fanout-registry.ts` — out of scope for this task; T43 is the pure decider only. Wiring task is downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)