### PR TITLE
feat(daemon): T14 control-socket transport

### DIFF
--- a/daemon/src/sockets/__tests__/control-socket.test.ts
+++ b/daemon/src/sockets/__tests__/control-socket.test.ts
@@ -1,0 +1,376 @@
+// T14 control-socket transport tests.
+//
+// Strategy: drive the real `net.createServer`-based transport over a
+// per-test temp directory. We force `platform: 'linux'` for the path
+// shape assertions so a Windows host CI run still exercises the POSIX
+// branches; the actual on-disk listener uses the Node default (Unix
+// socket node on POSIX, named pipe on Win32 — Node hides the difference
+// for us when given a `\\.\pipe\...` address).
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createConnection, type Socket } from 'node:net';
+import {
+  createControlSocketServer,
+  defaultControlSocketPath,
+  MAX_ACCEPT_PER_SEC,
+  type ControlSocketServer,
+} from '../control-socket.js';
+
+const isWin = process.platform === 'win32';
+
+let scratch: string;
+let started: ControlSocketServer[] = [];
+let opened: Socket[] = [];
+
+beforeEach(() => {
+  scratch = mkdtempSync(join(tmpdir(), 'ccsm-control-socket-'));
+  started = [];
+  opened = [];
+});
+
+afterEach(async () => {
+  for (const c of opened) {
+    try {
+      c.destroy();
+    } catch {
+      // ignore
+    }
+  }
+  for (const s of started) {
+    try {
+      await s.close();
+    } catch {
+      // ignore
+    }
+  }
+  try {
+    rmSync(scratch, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});
+
+/** Win32 named pipes don't tolerate per-test reuse (they live in a single
+ *  global namespace), so randomise the path in every test that drives a
+ *  real listener on Windows. POSIX uses the scratch dir. */
+function uniqueAddress(): string {
+  if (isWin) {
+    return `\\\\.\\pipe\\ccsm-control-test-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  }
+  return join(scratch, 'ccsm-control.sock');
+}
+
+function connectAndWait(address: string): Promise<Socket> {
+  return new Promise((resolve, reject) => {
+    const c = createConnection(address);
+    opened.push(c);
+    c.once('connect', () => resolve(c));
+    c.once('error', reject);
+  });
+}
+
+describe('defaultControlSocketPath', () => {
+  it('resolves POSIX path under runtimeRoot', () => {
+    const p = defaultControlSocketPath('linux', '/run/user/1000/ccsm');
+    expect(p).toBe('/run/user/1000/ccsm/ccsm-control.sock');
+  });
+
+  it('resolves macOS path under runtimeRoot', () => {
+    const p = defaultControlSocketPath('darwin', '/Users/x/Library/Application Support/ccsm/run');
+    expect(p).toBe('/Users/x/Library/Application Support/ccsm/run/ccsm-control.sock');
+  });
+
+  it('resolves Windows named-pipe with stable userhash prefix', () => {
+    const p = defaultControlSocketPath('win32', 'C:\\ignored');
+    // Shape: \\.\pipe\ccsm-control-<8 hex>
+    expect(p.startsWith('\\\\.\\pipe\\ccsm-control-')).toBe(true);
+    const tail = p.slice('\\\\.\\pipe\\ccsm-control-'.length);
+    expect(tail).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it('userhash is stable across calls (same user/host)', () => {
+    const a = defaultControlSocketPath('win32', 'C:\\x');
+    const b = defaultControlSocketPath('win32', 'C:\\x');
+    expect(a).toBe(b);
+  });
+});
+
+describe('createControlSocketServer — listen + accept', () => {
+  it('starts and accepts a client connection (onConnection called with Duplex)', async () => {
+    const address = uniqueAddress();
+    const handed: Socket[] = [];
+    let handResolve!: () => void;
+    const handed1 = new Promise<void>((r) => { handResolve = r; });
+    const srv = createControlSocketServer({
+      runtimeRoot: scratch,
+      socketPath: address,
+      onConnection: (sock) => {
+        handed.push(sock);
+        handResolve();
+      },
+    });
+    started.push(srv);
+
+    await srv.listen();
+    expect(srv.address).toBe(address);
+
+    const client = await connectAndWait(address);
+    await handed1;
+    expect(handed.length).toBe(1);
+    // The handed object must be a Duplex (Socket extends Duplex).
+    expect(typeof handed[0]?.write).toBe('function');
+    expect(typeof handed[0]?.on).toBe('function');
+
+    client.destroy();
+  });
+
+  it('writes from server side reach the client (raw Duplex pass-through)', async () => {
+    const address = uniqueAddress();
+    const srv = createControlSocketServer({
+      runtimeRoot: scratch,
+      socketPath: address,
+      onConnection: (sock) => {
+        sock.write('PING\n');
+      },
+    });
+    started.push(srv);
+    await srv.listen();
+
+    const client = await connectAndWait(address);
+    const got = await new Promise<string>((resolve) => {
+      const chunks: Buffer[] = [];
+      client.on('data', (c: Buffer) => {
+        chunks.push(c);
+        const s = Buffer.concat(chunks).toString('utf8');
+        if (s.includes('\n')) resolve(s);
+      });
+    });
+    expect(got).toBe('PING\n');
+  });
+
+  it('accepts multiple parallel connections', async () => {
+    const address = uniqueAddress();
+    let count = 0;
+    const target = 4;
+    let allResolve!: () => void;
+    const allDone = new Promise<void>((r) => { allResolve = r; });
+    const srv = createControlSocketServer({
+      runtimeRoot: scratch,
+      socketPath: address,
+      onConnection: () => {
+        count += 1;
+        if (count === target) allResolve();
+      },
+    });
+    started.push(srv);
+    await srv.listen();
+
+    const clients = await Promise.all([
+      connectAndWait(address),
+      connectAndWait(address),
+      connectAndWait(address),
+      connectAndWait(address),
+    ]);
+    await allDone;
+    expect(count).toBe(target);
+    for (const c of clients) c.destroy();
+  });
+});
+
+describe('createControlSocketServer — POSIX socket-node hygiene', () => {
+  it.skipIf(isWin)('chmods the socket node to 0o600', async () => {
+    const address = uniqueAddress();
+    const srv = createControlSocketServer({
+      runtimeRoot: scratch,
+      socketPath: address,
+      onConnection: () => {},
+    });
+    started.push(srv);
+    await srv.listen();
+
+    const st = statSync(address);
+    // Mask out type bits — only check perm bits.
+    expect(st.mode & 0o777).toBe(0o600);
+  });
+
+  it.skipIf(isWin)('cleans up the socket node on close()', async () => {
+    const address = uniqueAddress();
+    const srv = createControlSocketServer({
+      runtimeRoot: scratch,
+      socketPath: address,
+      onConnection: () => {},
+    });
+    await srv.listen();
+    expect(() => statSync(address)).not.toThrow();
+    await srv.close();
+    expect(() => statSync(address)).toThrow();
+  });
+
+  it.skipIf(isWin)('pre-cleans a stale socket node from a prior crashed run', async () => {
+    const address = uniqueAddress();
+    // First boot — bind, then forcibly skip cleanup to simulate a crash.
+    const srv1 = createControlSocketServer({
+      runtimeRoot: scratch,
+      socketPath: address,
+      onConnection: () => {},
+    });
+    await srv1.listen();
+    // Don't call close() — leak the inode.
+    expect(() => statSync(address)).not.toThrow();
+
+    // Second boot — must reuse the address without EADDRINUSE.
+    const srv2 = createControlSocketServer({
+      runtimeRoot: scratch,
+      socketPath: address,
+      onConnection: () => {},
+    });
+    started.push(srv2);
+    await expect(srv2.listen()).resolves.toBeUndefined();
+
+    // First server's underlying handle is now orphaned but the test will
+    // tear scratch down in afterEach.
+  });
+});
+
+describe('createControlSocketServer — close() drains', () => {
+  it('close() resolves and refuses subsequent connections', async () => {
+    const address = uniqueAddress();
+    const srv = createControlSocketServer({
+      runtimeRoot: scratch,
+      socketPath: address,
+      onConnection: () => {},
+    });
+    await srv.listen();
+    await srv.close();
+
+    await expect(connectAndWait(address)).rejects.toBeTruthy();
+  });
+
+  it('close() is idempotent', async () => {
+    const address = uniqueAddress();
+    const srv = createControlSocketServer({
+      runtimeRoot: scratch,
+      socketPath: address,
+      onConnection: () => {},
+    });
+    await srv.listen();
+    await srv.close();
+    // Second close MUST not throw.
+    await expect(srv.close()).resolves.toBeUndefined();
+  });
+});
+
+describe('createControlSocketServer — pre-accept rate cap', () => {
+  it('exports MAX_ACCEPT_PER_SEC = 50 (spec §3.4.1.a)', () => {
+    expect(MAX_ACCEPT_PER_SEC).toBe(50);
+  });
+
+  it('drops connections beyond the cap within a single window', async () => {
+    const address = uniqueAddress();
+    let kept = 0;
+    let destroyed = 0;
+    const srv = createControlSocketServer({
+      runtimeRoot: scratch,
+      socketPath: address,
+      maxAcceptPerSec: 2,
+      now: () => 1_000_000, // frozen clock — same window for every accept
+      onConnection: (sock) => {
+        kept += 1;
+        sock.on('close', () => {
+          // no-op
+        });
+      },
+    });
+    started.push(srv);
+    await srv.listen();
+
+    // Fire 5 connections in the same frozen-time window. Cap is 2 → 2 kept,
+    // 3 destroyed pre-handler.
+    const clients: Socket[] = [];
+    for (let i = 0; i < 5; i += 1) {
+      const c = createConnection(address);
+      opened.push(c);
+      clients.push(c);
+      c.on('close', () => {
+        destroyed += 1;
+      });
+    }
+
+    // Wait for all to reach a terminal state (connected or closed).
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(kept).toBe(2);
+    // 3 over the cap should have been destroyed by the server. The 2 kept
+    // ones are still open, so destroyed count is 3 (plus they fire close
+    // when the test cleans up — but at this assertion point only the
+    // dropped sockets have closed).
+    expect(destroyed).toBeGreaterThanOrEqual(3);
+  });
+
+  it('replenishes the bucket when the window rolls over', async () => {
+    const address = uniqueAddress();
+    let kept = 0;
+    let nowMs = 1_000_000;
+    const srv = createControlSocketServer({
+      runtimeRoot: scratch,
+      socketPath: address,
+      maxAcceptPerSec: 1,
+      now: () => nowMs,
+      onConnection: () => {
+        kept += 1;
+      },
+    });
+    started.push(srv);
+    await srv.listen();
+
+    // Window 1: cap 1, fire 2, only 1 kept.
+    const c1 = await connectAndWait(address);
+    const c2 = createConnection(address);
+    opened.push(c2);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(kept).toBe(1);
+
+    // Roll the clock past RATE_WINDOW_MS = 1000 → bucket resets.
+    nowMs += 2_000;
+    const c3 = await connectAndWait(address);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(kept).toBe(2);
+
+    c1.destroy();
+    c3.destroy();
+  });
+});
+
+describe('createControlSocketServer — onConnection contract', () => {
+  it('isolates a throwing onConnection (server keeps accepting)', async () => {
+    const address = uniqueAddress();
+    let calls = 0;
+    let secondResolve!: () => void;
+    const secondCall = new Promise<void>((r) => { secondResolve = r; });
+    const srv = createControlSocketServer({
+      runtimeRoot: scratch,
+      socketPath: address,
+      onConnection: () => {
+        calls += 1;
+        if (calls === 1) throw new Error('boom');
+        if (calls === 2) secondResolve();
+      },
+    });
+    started.push(srv);
+    await srv.listen();
+
+    const c1 = createConnection(address);
+    opened.push(c1);
+    // Wait for the first accept to land + throw before opening c2.
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Despite the throw, second connection must still be accepted.
+    const c2 = await connectAndWait(address);
+    await secondCall;
+    expect(calls).toBe(2);
+    c2.destroy();
+  });
+});

--- a/daemon/src/sockets/control-socket.ts
+++ b/daemon/src/sockets/control-socket.ts
@@ -1,0 +1,364 @@
+// T14 — control-socket transport.
+//
+// Spec citations:
+//   - docs/superpowers/specs/v0.3-design.md §3.1.1 / §3.4.1.h table:
+//       control-socket path = `<runtimeRoot>/ccsm-control.sock` (POSIX) or
+//       `\\.\pipe\ccsm-control-<userhash>` (Windows). Carries the canonical
+//       `SUPERVISOR_RPCS` set ONLY (`/healthz`, `/stats`, `daemon.hello`,
+//       `daemon.shutdown`, `daemon.shutdownForUpgrade`) — but THIS module is
+//       a pure transport: it has no opinion on RPC method names. The T16
+//       dispatcher (already merged at 7b4586e) is the consumer that owns the
+//       allowlist; this file just hands off raw Duplex streams to a callback.
+//   - §3.1.1 "sender peer-cred check" + §7.1 ACL + §3.4.1.a pre-accept
+//     `MAX_ACCEPT_PER_SEC = 50` rate cap (round-2 security T15).
+//   - T13 PR (34ff871): `<runtimeRoot>` resolver — single source of truth for
+//     where this socket node lives on POSIX. We import it.
+//
+// Single Responsibility: this module is a *producer* of `connection` events.
+//   - Sets up the OS-native listener (`net.createServer` over a Unix socket
+//     node OR a Windows named pipe — Node's `net` module abstracts both).
+//   - Applies pre-accept rate cap (drop excess accepts with EAGAIN-style
+//     destroy + once/min log).
+//   - Stamps the per-connection peer credentials onto the Duplex (best-effort
+//     — full DACL / SO_PEERCRED enforcement is layered by the T15 sister
+//     module + frag-6-7 §7.1 native helper; we expose UID/PID where Node
+//     gives them to us for free, and leave a structured hook for richer
+//     identity to be merged in T-future).
+//   - Hands the raw Duplex to the caller via `onConnection(socket, peer)`.
+//     The caller wires it into the envelope adapter (§3.4.1) and ultimately
+//     into the T16 dispatcher.
+//
+// Non-responsibilities (intentional):
+//   - No envelope parsing or framing.
+//   - No method-name routing or allowlist enforcement (that's T16).
+//   - No hello-handshake (helloInterceptor #0, §3.4.1.g — adapter's job).
+//   - No DACL creation on Windows (frag-6-7 §7.1 native helper hook).
+
+import {
+  createServer,
+  type Server,
+  type Socket,
+} from 'node:net';
+import { unlinkSync, statSync, chmodSync } from 'node:fs';
+import { dirname, posix } from 'node:path';
+import { hostname, userInfo } from 'node:os';
+import { createHash } from 'node:crypto';
+
+/** Pre-accept rate cap, per spec §3.4.1.a (round-2 security T15). Counted
+ *  PER LISTENER — control-socket and data-socket each have their own bucket. */
+export const MAX_ACCEPT_PER_SEC = 50;
+
+/** Window over which the rate cap is measured. Tokens replenish in full at
+ *  each tick boundary (cheap; the rate cap is best-effort DoS shedding, not
+ *  precise QoS). */
+const RATE_WINDOW_MS = 1_000;
+
+/** Throttle for the "we dropped accepts" log line. Spec wording: "log once
+ *  per minute aggregate" (§3.4.1.a). */
+const DROP_LOG_INTERVAL_MS = 60_000;
+
+/** Identity of the connecting peer, populated best-effort. The structured
+ *  shape mirrors §3.1.1 ("`{ uid: number; pid: number }`"); fields are
+ *  optional because Node's stock `net.Socket` exposes neither on Windows
+ *  named pipes (full PID via `GetNamedPipeClientProcessId` requires the
+ *  frag-6-7 §7.1 native helper, wired separately). */
+export interface PeerCred {
+  /** UID of the peer process — POSIX only; undefined on Windows. */
+  readonly uid?: number;
+  /** PID of the peer process — populated where the OS gives it cheaply
+   *  (POSIX via getpeereid where available; Windows only with native helper
+   *  — undefined here). */
+  readonly pid?: number;
+}
+
+/** Caller-supplied logger surface. We keep it minimal so this module does
+ *  not pull in pino (the daemon main wires real pino at the boundary). */
+export interface ControlSocketLogger {
+  warn(obj: Record<string, unknown>, msg: string): void;
+  info(obj: Record<string, unknown>, msg: string): void;
+}
+
+/** Connection callback. The transport delivers a raw Duplex (the `Socket`
+ *  itself is a Duplex) plus the best-effort peer identity. The callback is
+ *  expected to mount the envelope adapter on top — pure handoff. */
+export type ConnectionHandler = (socket: Socket, peer: PeerCred) => void;
+
+export interface CreateControlSocketServerOptions {
+  /** `<runtimeRoot>` from T13 (POSIX socket-node parent dir; ignored on
+   *  Windows where the named-pipe namespace is `\\.\pipe\`). */
+  readonly runtimeRoot: string;
+  /** Caller-supplied connection sink. Required even though no dispatcher is
+   *  wired yet (T-future) — the transport refuses to swallow connections
+   *  silently. */
+  readonly onConnection: ConnectionHandler;
+  /** Override the platform — used by tests to force POSIX on Windows hosts
+   *  or vice versa. Defaults to `process.platform`. */
+  readonly platform?: NodeJS.Platform;
+  /** Override the rate cap (tests). Default `MAX_ACCEPT_PER_SEC = 50`. */
+  readonly maxAcceptPerSec?: number;
+  /** Override the wall clock (tests). Default `Date.now`. */
+  readonly now?: () => number;
+  /** Optional logger; defaults to a silent stub so unit tests don't need
+   *  to plumb one. */
+  readonly logger?: ControlSocketLogger;
+  /** Override the auto-derived socket path. When provided, we trust the
+   *  caller (test harness, alternative deployment) and skip the userhash
+   *  derivation. POSIX path or `\\.\pipe\<name>`. */
+  readonly socketPath?: string;
+}
+
+export interface ControlSocketServer {
+  /** Begin accepting connections. Resolves once the listener is bound. */
+  listen(): Promise<void>;
+  /** Stop accepting new connections AND wait for existing ones to close.
+   *  Honours the standard `Server.close` callback semantics: idempotent,
+   *  resolves once the kernel-level listener is fully torn down. */
+  close(): Promise<void>;
+  /** Resolved socket path / pipe name. Available immediately (does not
+   *  require `listen()` to have completed). */
+  readonly address: string;
+}
+
+/** Compute the canonical socket path for the current platform.
+ *
+ *  POSIX: `<runtimeRoot>/ccsm-control.sock`.
+ *  Windows: `\\.\pipe\ccsm-control-<userhash>` where `<userhash>` is a
+ *           short SHA-256 of `username@hostname` (8 hex chars — spec is
+ *           silent on width; 32 bits of entropy is plenty for a same-host
+ *           same-user collision space and keeps the pipe name short).
+ */
+export function defaultControlSocketPath(
+  platform: NodeJS.Platform,
+  runtimeRoot: string,
+): string {
+  if (platform === 'win32') {
+    const ui = userInfo();
+    const tag = `${ui.username}@${hostname()}`;
+    const userhash = createHash('sha256').update(tag).digest('hex').slice(0, 8);
+    return `\\\\.\\pipe\\ccsm-control-${userhash}`;
+  }
+  // POSIX: explicitly use forward-slash join so a Windows-host test forcing
+  // `platform: 'linux'` still yields a POSIX-shaped path (the on-disk
+  // listener uses the host's `path.join` separately when bound).
+  return posix.join(runtimeRoot, 'ccsm-control.sock');
+}
+
+const NOOP_LOGGER: ControlSocketLogger = {
+  warn: () => {},
+  info: () => {},
+};
+
+/**
+ * Create the control-socket transport server.
+ *
+ * Lifecycle:
+ *   1. `listen()` — binds the OS listener. On POSIX we pre-clean any stale
+ *      socket node from a prior crashed run (idempotent — same posture as
+ *      pidfile cleanup) and `chmod 0600` after bind so the inode is never
+ *      world-readable even momentarily.
+ *   2. Per accept — increment the per-second token bucket; if exhausted,
+ *      destroy the socket immediately (EAGAIN-equivalent) and log at most
+ *      once per minute. Otherwise extract best-effort peer credentials and
+ *      hand the Duplex to `onConnection`.
+ *   3. `close()` — `server.close()` (refuses new connections, waits for
+ *      existing to drain), then on POSIX unlinks the socket node so the
+ *      next boot does not need cleanup.
+ */
+export function createControlSocketServer(
+  opts: CreateControlSocketServerOptions,
+): ControlSocketServer {
+  const platform = opts.platform ?? process.platform;
+  const isWindows = platform === 'win32';
+  const maxAcceptPerSec = opts.maxAcceptPerSec ?? MAX_ACCEPT_PER_SEC;
+  const now = opts.now ?? Date.now;
+  const log = opts.logger ?? NOOP_LOGGER;
+  const address = opts.socketPath ?? defaultControlSocketPath(platform, opts.runtimeRoot);
+
+  // Token bucket: counts accepts in the current 1-second window.
+  let windowStart = now();
+  let acceptedInWindow = 0;
+  // Drops since the last warn-log emit + when we last emitted.
+  let droppedSinceLog = 0;
+  let lastDropLog = 0;
+
+  const server: Server = createServer((socket: Socket) => {
+    const t = now();
+    if (t - windowStart >= RATE_WINDOW_MS) {
+      windowStart = t;
+      acceptedInWindow = 0;
+    }
+    acceptedInWindow += 1;
+
+    if (acceptedInWindow > maxAcceptPerSec) {
+      // Pre-accept rate cap exceeded. We can't actually refuse a TCP-style
+      // ACCEPT here (Node has already accepted), but destroying the socket
+      // immediately is the documented EAGAIN-equivalent in §3.4.1.a.
+      droppedSinceLog += 1;
+      if (t - lastDropLog >= DROP_LOG_INTERVAL_MS) {
+        log.warn(
+          {
+            transport: 'control-socket',
+            address,
+            droppedSinceLog,
+            cap: maxAcceptPerSec,
+          },
+          'control_socket_accept_rate_capped',
+        );
+        droppedSinceLog = 0;
+        lastDropLog = t;
+      }
+      // Best-effort destroy. The socket may already be writable; we don't
+      // attempt to write a friendly error frame because (a) the pre-accept
+      // posture is "shed first, log second", and (b) writing one would
+      // burn cycles defeating the DoS-defence purpose of the cap.
+      try {
+        socket.destroy();
+      } catch {
+        // best-effort
+      }
+      return;
+    }
+
+    const peer: PeerCred = extractPeer(socket, platform);
+    try {
+      opts.onConnection(socket, peer);
+    } catch (err) {
+      // The handler should never throw synchronously — if it does, we
+      // can't keep the connection open without an envelope adapter, so
+      // destroy the socket and log loud (this is a wiring bug, not a
+      // peer behaviour issue).
+      log.warn(
+        {
+          transport: 'control-socket',
+          address,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        'control_socket_onconnection_threw',
+      );
+      try {
+        socket.destroy();
+      } catch {
+        // best-effort
+      }
+    }
+  });
+
+  // Defensive: surface listener errors so callers see EADDRINUSE etc.
+  server.on('error', (err) => {
+    log.warn(
+      { transport: 'control-socket', address, err: err.message },
+      'control_socket_server_error',
+    );
+  });
+
+  return {
+    address,
+    async listen(): Promise<void> {
+      if (!isWindows) {
+        // Pre-clean stale POSIX socket node from a prior crashed run.
+        // mkdir for parent is the runtime-root resolver's job (T13);
+        // we only touch the socket-node inode here.
+        try {
+          const st = statSync(address);
+          if (st.isSocket()) {
+            unlinkSync(address);
+          }
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+            // stat failed for some reason other than missing — let the
+            // listen() call surface the real binding error a moment later.
+          }
+        }
+        // Ensure parent dir exists (defensive — T13 normally creates it).
+        // We do NOT create it here because that would silently mask a T13
+        // mis-wire; we only assert it exists.
+        const parent = dirname(address);
+        try {
+          statSync(parent);
+        } catch {
+          throw new Error(
+            `control-socket parent dir does not exist: ${parent} (T13 resolveRuntimeRoot must run with ensure:true before listen())`,
+          );
+        }
+      }
+
+      await new Promise<void>((resolve, reject) => {
+        const onError = (err: Error): void => {
+          server.removeListener('listening', onListening);
+          reject(err);
+        };
+        const onListening = (): void => {
+          server.removeListener('error', onError);
+          resolve();
+        };
+        server.once('error', onError);
+        server.once('listening', onListening);
+        server.listen(address);
+      });
+
+      if (!isWindows) {
+        // Tighten the socket-node mode to 0600 (user-only). Spec §7.1 +
+        // T1/T8 threat-model rows. Done AFTER listen() bound the inode.
+        try {
+          chmodSync(address, 0o600);
+        } catch (err) {
+          // chmod failure is non-fatal at boot but loud — typically only
+          // happens on exotic FS without POSIX perms (e.g. some FUSE
+          // mounts). Defence in depth: we still have the parent-dir 0700
+          // guard from T13.
+          log.warn(
+            {
+              transport: 'control-socket',
+              address,
+              err: (err as Error).message,
+            },
+            'control_socket_chmod_failed',
+          );
+        }
+      }
+
+      log.info(
+        {
+          transport: 'control-socket',
+          address,
+          maxAcceptPerSec,
+        },
+        'control_socket_listening',
+      );
+    },
+    async close(): Promise<void> {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+      if (!isWindows) {
+        try {
+          unlinkSync(address);
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+            log.warn(
+              {
+                transport: 'control-socket',
+                address,
+                err: (err as Error).message,
+              },
+              'control_socket_unlink_failed',
+            );
+          }
+        }
+      }
+    },
+  };
+}
+
+/** Best-effort peer-credential extraction. Node's `net.Socket` does not
+ *  expose `SO_PEERCRED` directly; the rich identity check (UID/PID/SID
+ *  match against the daemon's owning user) lives in the frag-6-7 §7.1
+ *  native helper. Until that lands, we surface the `remoteAddress` /
+ *  `remotePort` shape Node gives us — undefined for Unix sockets and
+ *  named pipes, which is the honest answer. */
+function extractPeer(_socket: Socket, _platform: NodeJS.Platform): PeerCred {
+  // Intentionally empty — Node's stock APIs return nothing useful for
+  // unix sockets / named pipes. Fields are typed optional so consumers
+  // can light up later without a wire-format change.
+  return {};
+}


### PR DESCRIPTION
## Summary

T14 — Layer-2 control-socket transport. Pure wire plumbing for the canonical control plane; the T16 dispatcher (#665) is the consumer that owns SUPERVISOR_RPCS routing.

**Spec refs:** docs/superpowers/specs/v0.3-design.md §3.1.1 / §3.4.1.h table + frag-6-7 §6.5 (canonical socket name `ccsm-control`, post-r11 `-sup` retirement).

## Per-OS path table

| OS      | Address                                                | ACL/perm                        |
|---------|--------------------------------------------------------|---------------------------------|
| POSIX   | `<runtimeRoot>/ccsm-control.sock`                      | `chmod 0600` post-bind          |
| Windows | `\.\pipe\ccsm-control-<userhash>` (8-hex SHA-256 of `username@hostname`) | DACL via §7.1 native helper hook |

`<runtimeRoot>` resolved by T13 (`runtime-root.ts`, PR #merged via 34ff871).

## Layer-1 single responsibility

Pure producer of `connection` events. Hands the raw Duplex to `onConnection(socket, peer)` and stops there.

- NO envelope parsing (T6/T7 adapter's job)
- NO method-name routing or allowlist enforcement (T16 dispatcher #665)
- NO hello-handshake (helloInterceptor #0, §3.4.1.g)
- NO Win DACL synthesis (frag-6-7 §7.1 native helper)

## Behaviours

- Pre-accept rate cap `MAX_ACCEPT_PER_SEC = 50` per §3.4.1.a (round-2 security T15) with 1-second token bucket and 1-minute aggregate drop log
- POSIX socket-node hygiene: pre-clean stale inode from prior crashed run, `chmod 0600` after bind (defence in depth on top of T13's parent-dir 0700), `unlink` on `close()`
- `close()` drains existing connections and is idempotent
- Throwing `onConnection` is isolated — server keeps accepting subsequent connections
- Best-effort `PeerCred { uid?, pid? }` surface stubbed; rich identity check lives in §7.1 native helper

## Dispatcher integration note

`createControlSocketServer({ runtimeRoot, onConnection, ... })` is transport-only. The wire plumbing for "envelope → T16 `Dispatcher.dispatch(method, req, ctx)`" is a separate task (envelope adapter mount on top of the handed Duplex). T16 already exposes the dispatcher API; T14 hands it the raw stream and steps back.

## Tests

13 passing, 3 POSIX-only skipped on the Windows host:

- Default path resolution per OS (POSIX explicit, Windows userhash shape + stability)
- `listen()` + accept + multi-connection (4 parallel) + raw Duplex passthrough
- POSIX: `chmod 0600` on socket node, `close()` cleans up inode, pre-clean of stale inode from prior boot
- `close()` rejects new connections + is idempotent
- Rate cap: drops connections beyond cap under frozen clock
- Rate cap: bucket replenishes when 1-second window rolls over
- Throwing `onConnection` is isolated

## Verify

- `tsc --noEmit -p daemon/tsconfig.json` — clean
- `tsc --noEmit && tsc --noEmit -p tsconfig.electron.json` — clean
- `vitest run daemon/src/sockets` — 26 passed | 3 skipped
- `npm run build:daemon` — clean
- Smoke import: `import('./daemon/dist-daemon/sockets/control-socket.js')` exports `MAX_ACCEPT_PER_SEC`, `createControlSocketServer`, `defaultControlSocketPath`

## Test plan

- [ ] Reviewer: confirm Layer-1 — no allowlist string in this file (`grep -n "/healthz\|daemon\." daemon/src/sockets/control-socket.ts` → 0 hits except the file header citation)
- [ ] Reviewer: confirm pre-accept rate cap actually destroys excess connections under frozen clock (test `drops connections beyond the cap within a single window`)
- [ ] Reviewer: confirm POSIX socket-node ends up `0o600` after bind
- [ ] Reviewer: confirm close() is idempotent (no double-unlink crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)