### PR TITLE
feat(daemon): T18 /stats handler

### DIFF
--- a/daemon/src/handlers/__tests__/healthz.test.ts
+++ b/daemon/src/handlers/__tests__/healthz.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest';
+
+import { DAEMON_PROTOCOL_VERSION } from '../../envelope/protocol-version.js';
+import {
+  HEALTHZ_DAEMON_ACCEPTED_WIRES,
+  HEALTHZ_FEATURES,
+  HEALTHZ_MIN_CLIENT,
+  HEALTHZ_VERSION,
+  HEALTHZ_WIRE,
+  handleHealthz,
+  makeHealthzHandler,
+  type HealthzContext,
+} from '../healthz.js';
+
+/** Fake-clock helper — the handler reads `ctx.now()` exactly once per call,
+ *  so an array-pop counter is enough to verify monotonicity below. */
+function makeCtx(overrides: Partial<HealthzContext> = {}): HealthzContext {
+  return {
+    bootNonce: '01HK9Z9Z9Z9Z9Z9Z9Z9Z9Z9Z9Z',
+    pid: 12345,
+    version: '0.3.0-test',
+    bootedAtMs: 1_000_000,
+    now: () => 1_000_000,
+    ...overrides,
+  };
+}
+
+describe('handleHealthz: response shape (frag-6-7 §6.5)', () => {
+  it('returns every field documented in the spec body', () => {
+    const reply = handleHealthz({}, makeCtx({ now: () => 1_000_500 }));
+
+    // Required scalar fields per §6.5 lines 124-140.
+    expect(reply).toMatchObject({
+      uptimeMs: 500,
+      pid: 12345,
+      version: '0.3.0-test',
+      bootNonce: '01HK9Z9Z9Z9Z9Z9Z9Z9Z9Z9Z9Z',
+      sessionCount: 0,
+      subscriberCount: 0,
+      migrationState: 'absent',
+      swapInProgress: false,
+      healthzVersion: HEALTHZ_VERSION,
+    });
+
+    // The protocol block is mirrored 1:1 from `daemon.hello` reply
+    // (§6.5 "canonical version-negotiation payload, mirrored 1:1").
+    expect(reply.protocol).toEqual({
+      wire: HEALTHZ_WIRE,
+      minClient: HEALTHZ_MIN_CLIENT,
+      daemonProtocolVersion: DAEMON_PROTOCOL_VERSION,
+      daemonAcceptedWires: HEALTHZ_DAEMON_ACCEPTED_WIRES,
+      features: HEALTHZ_FEATURES,
+    });
+  });
+
+  it('omits no documented spec keys (defensive against typo regressions)', () => {
+    const reply = handleHealthz({}, makeCtx());
+    const keys = Object.keys(reply).sort();
+    expect(keys).toEqual(
+      [
+        'bootNonce',
+        'healthzVersion',
+        'migrationState',
+        'pid',
+        'protocol',
+        'sessionCount',
+        'subscriberCount',
+        'swapInProgress',
+        'uptimeMs',
+        'version',
+      ].sort(),
+    );
+  });
+
+  it('healthzVersion is the spec literal 1 (frag-6-7 §6.5 r3 P1-3)', () => {
+    expect(HEALTHZ_VERSION).toBe(1);
+    expect(handleHealthz({}, makeCtx()).healthzVersion).toBe(1);
+  });
+
+  it('daemonProtocolVersion is the spec literal 1 (frag-3.4.1 §3.4.1.g r9 lock)', () => {
+    expect(DAEMON_PROTOCOL_VERSION).toBe(1);
+    expect(handleHealthz({}, makeCtx()).protocol.daemonProtocolVersion).toBe(1);
+  });
+
+  it("v0.3 daemonAcceptedWires is exactly ['v0.3-json-envelope'] (r3 P1-5)", () => {
+    expect(HEALTHZ_DAEMON_ACCEPTED_WIRES).toEqual(['v0.3-json-envelope']);
+  });
+
+  it('features array contains the six v0.3-locked capability strings', () => {
+    expect(HEALTHZ_FEATURES).toEqual([
+      'binary-frames',
+      'stream-heartbeat',
+      'interceptors',
+      'traceId',
+      'bootNonce',
+      'hello',
+    ]);
+  });
+});
+
+describe('handleHealthz: uptime monotonicity', () => {
+  it('uptime increases with the injected clock', () => {
+    let now = 1_000_000;
+    const ctx = makeCtx({ bootedAtMs: 1_000_000, now: () => now });
+
+    const a = handleHealthz({}, ctx).uptimeMs;
+    now = 1_000_250;
+    const b = handleHealthz({}, ctx).uptimeMs;
+    now = 1_005_000;
+    const c = handleHealthz({}, ctx).uptimeMs;
+
+    expect(a).toBe(0);
+    expect(b).toBe(250);
+    expect(c).toBe(5_000);
+    expect(b).toBeGreaterThan(a);
+    expect(c).toBeGreaterThan(b);
+  });
+
+  it('clamps uptime to >=0 on clock rewind (NTP step / hibernate resume)', () => {
+    // Spec: /healthz must NEVER error (§6.5 "always returns liveness"),
+    // so a backwards clock collapses to 0 instead of throwing or going
+    // negative — the supervisor reads liveness, not absolute time.
+    const ctx = makeCtx({ bootedAtMs: 5_000, now: () => 1_000 });
+    expect(handleHealthz({}, ctx).uptimeMs).toBe(0);
+  });
+});
+
+describe('handleHealthz: injected providers', () => {
+  it('forwards live counter snapshots from the providers', () => {
+    let sessions = 7;
+    let subs = 13;
+    const ctx = makeCtx({
+      getSessionCount: () => sessions,
+      getSubscriberCount: () => subs,
+    });
+
+    const r1 = handleHealthz({}, ctx);
+    expect(r1.sessionCount).toBe(7);
+    expect(r1.subscriberCount).toBe(13);
+
+    sessions = 0;
+    subs = 0;
+    const r2 = handleHealthz({}, ctx);
+    expect(r2.sessionCount).toBe(0);
+    expect(r2.subscriberCount).toBe(0);
+  });
+
+  it('migrationState reflects the injected provider', () => {
+    for (const state of ['absent', 'pending', 'in-progress', 'done'] as const) {
+      const reply = handleHealthz({}, makeCtx({ getMigrationState: () => state }));
+      expect(reply.migrationState).toBe(state);
+    }
+  });
+
+  it('swapInProgress reflects the injected provider (frag-6-7 §6.4 step 4-7)', () => {
+    expect(handleHealthz({}, makeCtx({ getSwapInProgress: () => true })).swapInProgress).toBe(true);
+    expect(handleHealthz({}, makeCtx({ getSwapInProgress: () => false })).swapInProgress).toBe(false);
+  });
+
+  it('defaults: missing providers yield 0 / "absent" / false', () => {
+    const reply = handleHealthz({}, makeCtx());
+    expect(reply.sessionCount).toBe(0);
+    expect(reply.subscriberCount).toBe(0);
+    expect(reply.migrationState).toBe('absent');
+    expect(reply.swapInProgress).toBe(false);
+  });
+});
+
+describe('handleHealthz: purity (no I/O, ignores req)', () => {
+  it('produces identical replies for identical clocks regardless of req', () => {
+    const ctx = makeCtx({ now: () => 1_000_100 });
+    const a = handleHealthz({}, ctx);
+    const b = handleHealthz({ junk: 'ignored' }, ctx);
+    const c = handleHealthz(undefined, ctx);
+    expect(a).toEqual(b);
+    expect(b).toEqual(c);
+  });
+
+  it('does not mutate the injected context', () => {
+    const ctx = makeCtx();
+    const snapshot = JSON.stringify(ctx);
+    handleHealthz({}, ctx);
+    expect(JSON.stringify(ctx)).toBe(snapshot);
+  });
+});
+
+describe('makeHealthzHandler: T16 dispatcher adapter', () => {
+  it('returns an async handler that resolves to the same shape', async () => {
+    let now = 2_000_000;
+    const ctx = makeCtx({ bootedAtMs: 2_000_000, now: () => now });
+    const handler = makeHealthzHandler(ctx);
+
+    const r1 = await handler({});
+    expect(r1.uptimeMs).toBe(0);
+
+    now = 2_005_000;
+    const r2 = await handler({});
+    expect(r2.uptimeMs).toBe(5_000);
+    expect(r2.healthzVersion).toBe(1);
+  });
+
+  it('handler signature is compatible with the Dispatcher.Handler contract', async () => {
+    // Compile-time + runtime check: the returned function is `(req) => Promise`.
+    const handler = makeHealthzHandler(makeCtx());
+    const result = handler('any-req-payload');
+    expect(result).toBeInstanceOf(Promise);
+    await expect(result).resolves.toBeDefined();
+  });
+});

--- a/daemon/src/handlers/__tests__/stats.test.ts
+++ b/daemon/src/handlers/__tests__/stats.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  defaultMemoryUsageProvider,
+  handleStats,
+  makeStatsHandler,
+  STATS_VERSION,
+  type MemorySnapshot,
+  type StatsContext,
+} from '../stats.js';
+
+/** Pinned-memory helper — tests inject deterministic counter values so
+ *  the snapshot is byte-for-byte predictable. */
+function makeCtx(overrides: Partial<StatsContext> = {}): StatsContext {
+  return {
+    getMemoryUsage: () => ({ rss: 100_000, heapUsed: 50_000 }),
+    ...overrides,
+  };
+}
+
+describe('handleStats: response shape (frag-6-7 §6.5 line 150)', () => {
+  it('returns every field documented in the spec body', () => {
+    const reply = handleStats({}, makeCtx());
+
+    expect(reply).toEqual({
+      statsVersion: STATS_VERSION,
+      rss: 100_000,
+      heapUsed: 50_000,
+      ptyBufferBytes: 0,
+      openSockets: 0,
+    });
+  });
+
+  it('omits no documented spec keys (defensive against typo regressions)', () => {
+    const reply = handleStats({}, makeCtx());
+    const keys = Object.keys(reply).sort();
+    expect(keys).toEqual(
+      [
+        'heapUsed',
+        'openSockets',
+        'ptyBufferBytes',
+        'rss',
+        'statsVersion',
+      ].sort(),
+    );
+  });
+
+  it('statsVersion is the spec literal 1 (frag-6-7 §6.5 r2 obs P1-4 + r3 P1-3)', () => {
+    expect(STATS_VERSION).toBe(1);
+    expect(handleStats({}, makeCtx()).statsVersion).toBe(1);
+  });
+
+  it('statsVersion lives ONLY on /stats (r3 P1-3 split — not on /healthz)', () => {
+    // This is a structural assertion: the /stats reply MUST carry
+    // statsVersion, and a sister assertion in healthz.test.ts verifies
+    // /healthz does NOT carry it (it carries healthzVersion instead).
+    const reply = handleStats({}, makeCtx());
+    expect(reply).toHaveProperty('statsVersion');
+    expect(reply).not.toHaveProperty('healthzVersion');
+  });
+});
+
+describe('handleStats: injected providers (counter zero-state defaults)', () => {
+  it('forwards live memory snapshots from the provider', () => {
+    let rss = 1_000_000;
+    let heapUsed = 500_000;
+    const ctx = makeCtx({ getMemoryUsage: () => ({ rss, heapUsed }) });
+
+    const r1 = handleStats({}, ctx);
+    expect(r1.rss).toBe(1_000_000);
+    expect(r1.heapUsed).toBe(500_000);
+
+    rss = 2_000_000;
+    heapUsed = 800_000;
+    const r2 = handleStats({}, ctx);
+    expect(r2.rss).toBe(2_000_000);
+    expect(r2.heapUsed).toBe(800_000);
+  });
+
+  it('forwards live ptyBufferBytes from the provider', () => {
+    let bytes = 16_384;
+    const ctx = makeCtx({ getPtyBufferBytes: () => bytes });
+
+    expect(handleStats({}, ctx).ptyBufferBytes).toBe(16_384);
+    bytes = 0;
+    expect(handleStats({}, ctx).ptyBufferBytes).toBe(0);
+    bytes = 262_144;
+    expect(handleStats({}, ctx).ptyBufferBytes).toBe(262_144);
+  });
+
+  it('forwards live openSockets from the provider', () => {
+    let sockets = 3;
+    const ctx = makeCtx({ getOpenSockets: () => sockets });
+
+    expect(handleStats({}, ctx).openSockets).toBe(3);
+    sockets = 0;
+    expect(handleStats({}, ctx).openSockets).toBe(0);
+    sockets = 42;
+    expect(handleStats({}, ctx).openSockets).toBe(42);
+  });
+
+  it('defaults: missing optional providers yield 0', () => {
+    const reply = handleStats({}, makeCtx());
+    expect(reply.ptyBufferBytes).toBe(0);
+    expect(reply.openSockets).toBe(0);
+  });
+
+  it('all providers wired together produces the combined snapshot', () => {
+    const ctx: StatsContext = {
+      getMemoryUsage: () => ({ rss: 12_345_678, heapUsed: 9_876_543 }),
+      getPtyBufferBytes: () => 65_536,
+      getOpenSockets: () => 7,
+    };
+    expect(handleStats({}, ctx)).toEqual({
+      statsVersion: 1,
+      rss: 12_345_678,
+      heapUsed: 9_876_543,
+      ptyBufferBytes: 65_536,
+      openSockets: 7,
+    });
+  });
+});
+
+describe('handleStats: purity (no I/O, ignores req)', () => {
+  it('produces identical replies for identical providers regardless of req', () => {
+    const ctx = makeCtx();
+    const a = handleStats({}, ctx);
+    const b = handleStats({ junk: 'ignored' }, ctx);
+    const c = handleStats(undefined, ctx);
+    expect(a).toEqual(b);
+    expect(b).toEqual(c);
+  });
+
+  it('does not mutate the injected context', () => {
+    const ctx: StatsContext = {
+      getMemoryUsage: () => ({ rss: 1, heapUsed: 2 }),
+      getPtyBufferBytes: () => 3,
+      getOpenSockets: () => 4,
+    };
+    const before = {
+      hasMem: typeof ctx.getMemoryUsage,
+      hasPty: typeof ctx.getPtyBufferBytes,
+      hasSock: typeof ctx.getOpenSockets,
+    };
+    handleStats({}, ctx);
+    expect({
+      hasMem: typeof ctx.getMemoryUsage,
+      hasPty: typeof ctx.getPtyBufferBytes,
+      hasSock: typeof ctx.getOpenSockets,
+    }).toEqual(before);
+  });
+});
+
+describe('makeStatsHandler: T16 dispatcher adapter', () => {
+  it('returns an async handler that resolves to the same shape', async () => {
+    let rss = 200_000;
+    const ctx: StatsContext = {
+      getMemoryUsage: () => ({ rss, heapUsed: 100_000 }),
+      getPtyBufferBytes: () => 1024,
+      getOpenSockets: () => 2,
+    };
+    const handler = makeStatsHandler(ctx);
+
+    const r1 = await handler({});
+    expect(r1).toEqual({
+      statsVersion: 1,
+      rss: 200_000,
+      heapUsed: 100_000,
+      ptyBufferBytes: 1024,
+      openSockets: 2,
+    });
+
+    rss = 300_000;
+    const r2 = await handler({});
+    expect(r2.rss).toBe(300_000);
+    expect(r2.statsVersion).toBe(1);
+  });
+
+  it('handler signature is compatible with the Dispatcher.Handler contract', async () => {
+    // Compile-time + runtime check: the returned function is `(req) => Promise`.
+    const handler = makeStatsHandler(makeCtx());
+    const result = handler('any-req-payload');
+    expect(result).toBeInstanceOf(Promise);
+    await expect(result).resolves.toBeDefined();
+  });
+
+  it('the wrapped handler produces a structurally-stable reply across calls', async () => {
+    const handler = makeStatsHandler(makeCtx());
+    const a = await handler({});
+    const b = await handler({});
+    expect(Object.keys(a).sort()).toEqual(Object.keys(b).sort());
+  });
+});
+
+describe('defaultMemoryUsageProvider: production wiring helper', () => {
+  it('returns a function that surfaces real process.memoryUsage() values', () => {
+    const provider = defaultMemoryUsageProvider();
+    const snap: MemorySnapshot = provider();
+
+    // We cannot pin exact values, but rss and heapUsed must be positive
+    // integers when read from a live Node process.
+    expect(typeof snap.rss).toBe('number');
+    expect(typeof snap.heapUsed).toBe('number');
+    expect(snap.rss).toBeGreaterThan(0);
+    expect(snap.heapUsed).toBeGreaterThan(0);
+    expect(Number.isInteger(snap.rss)).toBe(true);
+    expect(Number.isInteger(snap.heapUsed)).toBe(true);
+  });
+
+  it('produces a snapshot whose shape exactly matches MemorySnapshot', () => {
+    const snap = defaultMemoryUsageProvider()();
+    expect(Object.keys(snap).sort()).toEqual(['heapUsed', 'rss']);
+  });
+});

--- a/daemon/src/handlers/healthz.ts
+++ b/daemon/src/handlers/healthz.ts
@@ -1,0 +1,176 @@
+// /healthz handler (T17) — control-socket liveness probe.
+//
+// Spec citations:
+//   - frag-6-7 §6.5 "Health probe + dedicated supervisor transport" — canonical
+//     owner of the response payload shape.
+//   - frag-3.4.1 §3.4.1.h — `/healthz` is a wire-literal control-plane RPC
+//     (NOT `ccsm.v1/daemon.healthz`); registered on the control-socket
+//     dispatcher (T16) as the literal string.
+//   - frag-3.4.1 §3.4.1.f — supervisor transport is the SINGLE channel that
+//     ignores `MIGRATION_PENDING` short-circuit; `/healthz` ALWAYS returns a
+//     liveness body, never a sentinel error. The body carries `migrationState`
+//     so the supervisor can observe the migration window inline.
+//
+// Response shape (frag-6-7 §6.5):
+//   { uptimeMs, pid, version, bootNonce, sessionCount, subscriberCount,
+//     migrationState, swapInProgress,
+//     protocol: { wire, minClient, daemonProtocolVersion, daemonAcceptedWires,
+//                 features },
+//     healthzVersion: 1 }
+//
+// Single Responsibility: pure decider. Reads injected boot context + counter
+// providers, returns a snapshot. Performs ZERO socket I/O and ZERO database
+// queries (per §6.5 "Cheap (~50µs)" budget — three consecutive misses inside
+// a 15 s window restart the daemon, so the handler MUST stay branch-free of
+// any path that can block).
+//
+// The boot-time / counter providers are injected so:
+//   1. The daemon shell (T1 / index.ts) owns the live values; this module
+//      stays a pure function and is trivially testable with a fake clock.
+//   2. T18-T21 (other supervisor RPCs) and the dispatcher wiring (T16) can
+//      build the context once at boot and share it across handlers.
+//   3. v0.4 protobuf swap can reuse the handler verbatim — only the wire
+//      serialiser changes.
+
+import { DAEMON_PROTOCOL_VERSION } from '../envelope/protocol-version.js';
+
+/** Migration FSM states surfaced via `/healthz` (frag-6-7 §6.5 + frag-8 §8.5).
+ *  v0.3 ships SQLite migration; the four states are the canonical FSM. */
+export type MigrationState = 'absent' | 'pending' | 'in-progress' | 'done';
+
+/** Wire-literal canonical for v0.3 (frag-3.4.1 §3.4.1.g). */
+export const HEALTHZ_WIRE = 'v0.3-json-envelope' as const;
+
+/** Lowest client wire-version this daemon will negotiate (frag-3.4.1 §3.4.1.g). */
+export const HEALTHZ_MIN_CLIENT = 'v0.3' as const;
+
+/** v0.3 daemon accepts only the v0.3 envelope (frag-3.4.1 §3.4.1.g r3 P1-5).
+ *  v0.4 will append `'v0.4-protobuf'` during the rolling-upgrade window. */
+export const HEALTHZ_DAEMON_ACCEPTED_WIRES = [
+  'v0.3-json-envelope',
+] as const;
+
+/** Feature advertisement string list — additive evolution (frag-6-7 §6.5,
+ *  matches the `protocol.features` array embedded in `daemon.hello` reply per
+ *  frag-3.4.1 §3.4.1.g and §6.5.1 mirror rule). */
+export const HEALTHZ_FEATURES = [
+  'binary-frames',
+  'stream-heartbeat',
+  'interceptors',
+  'traceId',
+  'bootNonce',
+  'hello',
+] as const;
+
+/** Healthz schema-version cursor (frag-6-7 §6.5 r3 P1-3). Bumps only on
+ *  breaking shape changes; additive fields do NOT bump it (consumers MUST
+ *  treat unknown fields as forward-compatible per frag-3.4.1 §3.4.1.g rule).
+ *  v0.3 = 1. */
+export const HEALTHZ_VERSION = 1 as const;
+
+/** Injected boot/runtime context. The daemon shell (T1) owns the live values
+ *  and constructs this once; the handler reads only — no mutation here. */
+export interface HealthzContext {
+  /** Crockford ULID minted at daemon boot (frag-6-7 §6.5 r3 CF-2 lock —
+   *  camelCase across all fragments; ULID, NOT `Date.now()`). */
+  readonly bootNonce: string;
+  /** Daemon process PID (frag-6-7 §6.5). */
+  readonly pid: number;
+  /** Semver-string of the daemon binary (frag-6-7 §6.5 `version` field). */
+  readonly version: string;
+  /** Monotonic boot time in milliseconds since epoch — captured ONCE at boot
+   *  (frag-6-7 §6.5: the supervisor uses `uptimeMs` to detect daemon restart
+   *  AND validate clock-skew against its own boot wall-clock). */
+  readonly bootedAtMs: number;
+  /** Clock for `now` — injected so tests can advance time deterministically.
+   *  Production = `() => Date.now()`. */
+  readonly now: () => number;
+  /** Live session count snapshot (frag-6-7 §6.5). 0 until the session
+   *  registry (frag-3.5.1) is wired; T17 ships a default-0 producer so the
+   *  field is always present on the wire. */
+  readonly getSessionCount?: () => number;
+  /** Live stream-subscriber count snapshot (frag-3.5.1 §3.5.1.4 fan-out
+   *  registry). 0 until wired (see `getSessionCount`). */
+  readonly getSubscriberCount?: () => number;
+  /** Migration FSM read-side. Default `'absent'` (no migration ever ran on a
+   *  fresh install). frag-8 §8.5 owns the producer. */
+  readonly getMigrationState?: () => MigrationState;
+  /** Auto-update swap window flag (frag-6-7 §6.4 step 4-7 + §6.5 r3 sec
+   *  P1-6). When true, supervisor pauses imposter-secret HMAC verification. */
+  readonly getSwapInProgress?: () => boolean;
+}
+
+/** Frozen `protocol` block returned inside the healthz body (frag-6-7 §6.5).
+ *  Mirrored 1:1 in the `daemon.hello` reply — same constants, no drift. */
+export interface HealthzProtocolBlock {
+  readonly wire: typeof HEALTHZ_WIRE;
+  readonly minClient: typeof HEALTHZ_MIN_CLIENT;
+  readonly daemonProtocolVersion: typeof DAEMON_PROTOCOL_VERSION;
+  readonly daemonAcceptedWires: ReadonlyArray<string>;
+  readonly features: ReadonlyArray<string>;
+}
+
+/** Full `/healthz` response shape (frag-6-7 §6.5 lines 124-140). */
+export interface HealthzReply {
+  readonly uptimeMs: number;
+  readonly pid: number;
+  readonly version: string;
+  readonly bootNonce: string;
+  readonly sessionCount: number;
+  readonly subscriberCount: number;
+  readonly migrationState: MigrationState;
+  readonly swapInProgress: boolean;
+  readonly protocol: HealthzProtocolBlock;
+  readonly healthzVersion: typeof HEALTHZ_VERSION;
+}
+
+/**
+ * Build the canonical `/healthz` reply.
+ *
+ * Pure: same `(req, ctx)` always yields the same output for the same clock
+ * value. Performs no I/O, never throws on a well-formed context.
+ *
+ * The `req` argument is intentionally unused — `/healthz` takes no parameters
+ * per frag-6-7 §6.5 (supervisor pings with an empty payload). Accepting it as
+ * a Handler-compatible signature keeps wiring trivial for T16.
+ */
+export function handleHealthz(_req: unknown, ctx: HealthzContext): HealthzReply {
+  // Clamp uptime to >=0 — protects against pathological clock-rewind cases
+  // where an injected `now()` returns a value below `bootedAtMs` (NTP step,
+  // hibernate-resume on Win 11). Spec assumes monotonic; we clamp instead of
+  // throwing because /healthz must never error (§6.5 "always returns liveness").
+  const rawUptime = ctx.now() - ctx.bootedAtMs;
+  const uptimeMs = rawUptime < 0 ? 0 : rawUptime;
+
+  return {
+    uptimeMs,
+    pid: ctx.pid,
+    version: ctx.version,
+    bootNonce: ctx.bootNonce,
+    sessionCount: ctx.getSessionCount?.() ?? 0,
+    subscriberCount: ctx.getSubscriberCount?.() ?? 0,
+    migrationState: ctx.getMigrationState?.() ?? 'absent',
+    swapInProgress: ctx.getSwapInProgress?.() ?? false,
+    protocol: {
+      wire: HEALTHZ_WIRE,
+      minClient: HEALTHZ_MIN_CLIENT,
+      daemonProtocolVersion: DAEMON_PROTOCOL_VERSION,
+      daemonAcceptedWires: HEALTHZ_DAEMON_ACCEPTED_WIRES,
+      features: HEALTHZ_FEATURES,
+    },
+    healthzVersion: HEALTHZ_VERSION,
+  };
+}
+
+/** Adapter to the T16 `Dispatcher.Handler` signature. T16's handler returns
+ *  `Promise<unknown>`; healthz is synchronous but we wrap so `register()`
+ *  accepts it without coupling the pure function to Promise plumbing.
+ *
+ *  Usage (post-T16-merge follow-up commit):
+ *    dispatcher.register('/healthz', makeHealthzHandler(ctx));
+ */
+export function makeHealthzHandler(
+  ctx: HealthzContext,
+): (req: unknown) => Promise<HealthzReply> {
+  return async (req: unknown) => handleHealthz(req, ctx);
+}

--- a/daemon/src/handlers/stats.ts
+++ b/daemon/src/handlers/stats.ts
@@ -1,0 +1,139 @@
+// /stats handler (T18) — control-socket diagnostic-grade RPC.
+//
+// Spec citations:
+//   - frag-6-7 §6.5 (line 150) — canonical owner of the response payload:
+//       "A separate `/stats` (obs-S6) returns
+//        { statsVersion: 1, rss, heapUsed, ptyBufferBytes, openSockets } —
+//        diagnostic-grade RPC, not part of the supervisor liveness contract.
+//        statsVersion enables additive evolution without renderer breakage
+//        (r2-obs P1-4)."
+//   - frag-3.4.1 §3.4.1.h — `/stats` is a wire-literal control-plane RPC
+//     (NOT `ccsm.v1/daemon.stats`); registered on the control-socket
+//     dispatcher (T16) as the literal string. See r9 + r11 manager locks
+//     ("/stats keeps HTTP-style literal method name; explicit exemption
+//     from §3.4.1.g ccsm.<wireMajor>/... namespace rule").
+//   - frag-3.4.1 §3.4.1.f — supervisor transport ignores MIGRATION_PENDING
+//     short-circuit (same posture as `/healthz`); `/stats` is a diagnostic
+//     surface and MUST stay reachable across migration windows.
+//   - v0.3-design.md §6.5 r3 P1-3 lock — `statsVersion` lives ONLY on
+//     `/stats`; `healthzVersion` lives ONLY on `/healthz`. Two cursors for
+//     one schema is a footgun; we keep them separated.
+//
+// Single Responsibility: pure decider. Reads injected counter providers
+// (memory, PTY buffer, socket count) and returns a snapshot. Performs ZERO
+// socket I/O and ZERO database queries. Counters are in-memory; the providers
+// themselves are owned by their respective subsystems (PTY fan-out registry
+// for `ptyBufferBytes`; control/data socket transports for `openSockets`).
+//
+// The provider injection mirrors T17 `/healthz`:
+//   1. The daemon shell (T1 / index.ts) owns the live counter sources; this
+//      module stays a pure function and is trivially testable with stubs.
+//   2. T16 dispatcher swaps the NOT_IMPLEMENTED stub via `register('/stats',
+//      makeStatsHandler(ctx))` once this module lands.
+//   3. v0.4 protobuf swap can reuse the handler verbatim — only the wire
+//      serialiser changes.
+//
+// Why `/stats` is "diagnostic-grade", not "liveness-grade":
+//   - The supervisor liveness contract is `/healthz` (§6.5 — three misses
+//     inside a 15s window restart the daemon). `/stats` is a separate poll
+//     surface used by the future v0.4 inspector tooling and ad-hoc IPC
+//     debugging; missing a `/stats` reply does NOT trigger a restart.
+//   - Consequence: the handler is pure + cheap, but does not have the same
+//     "must never throw" obligation as `/healthz`. We still keep it
+//     branch-free of any blocking path because it shares the control-socket
+//     accept loop with `/healthz` (frag-6-7 §6.5 dedicated transport).
+
+/** Memory snapshot fields read by the handler — subset of
+ *  `NodeJS.MemoryUsage`. Declared explicitly so test stubs do not need to
+ *  fake the entire `process.memoryUsage()` shape. */
+export interface MemorySnapshot {
+  /** Resident set size in bytes (frag-6-7 §6.5 `rss`). */
+  readonly rss: number;
+  /** V8 heap-used in bytes (frag-6-7 §6.5 `heapUsed`). */
+  readonly heapUsed: number;
+}
+
+/** Stats schema-version cursor (frag-6-7 §6.5 line 150 + r2 obs P1-4).
+ *  Bumps only on breaking shape changes; additive fields do NOT bump it
+ *  (consumers MUST treat unknown fields as forward-compatible per
+ *  frag-3.4.1 §3.4.1.g rule). v0.3 = 1. */
+export const STATS_VERSION = 1 as const;
+
+/** Injected runtime context. The daemon shell (T1) owns the live values
+ *  and constructs this once; the handler reads only — no mutation here. */
+export interface StatsContext {
+  /** Memory snapshot producer. Production = `() => {
+   *    const m = process.memoryUsage();
+   *    return { rss: m.rss, heapUsed: m.heapUsed };
+   *  }`. Injected so tests can pin the values without spawning a process. */
+  readonly getMemoryUsage: () => MemorySnapshot;
+  /** Total bytes currently held in PTY fan-out replay buffers (frag-3.5.1
+   *  §3.5.1.4). 0 until the fan-out registry (T41) is wired into the daemon
+   *  shell; T18 ships a default-0 producer so the field is always present
+   *  on the wire. */
+  readonly getPtyBufferBytes?: () => number;
+  /** Count of currently-open accept-side sockets across the data-path
+   *  adapter + control-socket transport. 0 until the socket layer is wired;
+   *  see `getPtyBufferBytes` for the same default-0 rationale. */
+  readonly getOpenSockets?: () => number;
+}
+
+/** Full `/stats` response shape (frag-6-7 §6.5 line 150). */
+export interface StatsReply {
+  readonly statsVersion: typeof STATS_VERSION;
+  readonly rss: number;
+  readonly heapUsed: number;
+  readonly ptyBufferBytes: number;
+  readonly openSockets: number;
+}
+
+/**
+ * Build the canonical `/stats` reply.
+ *
+ * Pure: same `(req, ctx)` always yields the same output for the same
+ * provider readings. Performs no I/O.
+ *
+ * The `req` argument is intentionally unused — `/stats` takes no parameters
+ * per frag-6-7 §6.5 (the diagnostic poller hits it with an empty payload).
+ * Accepting it as a Handler-compatible signature keeps wiring trivial for
+ * the T16 dispatcher.
+ *
+ * Counter zero-state: missing optional providers fall back to 0 so the
+ * field is always present on the wire (forward-compatible with the
+ * subsystems that will wire them in later — fan-out registry T41,
+ * socket layer T14/etc.).
+ */
+export function handleStats(_req: unknown, ctx: StatsContext): StatsReply {
+  const mem = ctx.getMemoryUsage();
+  return {
+    statsVersion: STATS_VERSION,
+    rss: mem.rss,
+    heapUsed: mem.heapUsed,
+    ptyBufferBytes: ctx.getPtyBufferBytes?.() ?? 0,
+    openSockets: ctx.getOpenSockets?.() ?? 0,
+  };
+}
+
+/** Adapter to the T16 `Dispatcher.Handler` signature. T16's handler returns
+ *  `Promise<unknown>`; stats is synchronous but we wrap so `register()`
+ *  accepts it without coupling the pure function to Promise plumbing.
+ *
+ *  Usage (post-T16-merge follow-up commit):
+ *    dispatcher.register('/stats', makeStatsHandler(ctx));
+ */
+export function makeStatsHandler(
+  ctx: StatsContext,
+): (req: unknown) => Promise<StatsReply> {
+  return async (req: unknown) => handleStats(req, ctx);
+}
+
+/** Convenience builder for the production memory-usage provider — kept here
+ *  (vs. inline at the daemon-shell call site) so the `process.memoryUsage()`
+ *  surface area is in one place. Tests do NOT use this; they inject a
+ *  pinned stub. */
+export function defaultMemoryUsageProvider(): () => MemorySnapshot {
+  return () => {
+    const m = process.memoryUsage();
+    return { rss: m.rss, heapUsed: m.heapUsed };
+  };
+}


### PR DESCRIPTION
## Summary

T18 — control-socket `/stats` handler. Sister of T17 `/healthz` (PR #670).

Spec: `docs/superpowers/specs/v0.3-fragments/frag-6-7-reliability-security.md` §6.5 line 150 — canonical `/stats` body.

### Spec-locked response shape (frag-6-7 §6.5 line 150)

```json
{
  "statsVersion": 1,
  "rss": <bytes>,
  "heapUsed": <bytes>,
  "ptyBufferBytes": <bytes>,
  "openSockets": <count>
}
```

Diagnostic-grade RPC (NOT part of supervisor liveness contract — that's `/healthz`).

### Counter provider contract (`StatsContext`)

- `getMemoryUsage(): { rss, heapUsed }` — REQUIRED. Production: `process.memoryUsage()` slice via `defaultMemoryUsageProvider()`.
- `getPtyBufferBytes?(): number` — optional, default 0. Wired by fan-out registry (T41) once daemon-shell integration lands.
- `getOpenSockets?(): number` — optional, default 0. Wired by socket layer (T14/etc.).

Default-0 fallback so the wire shape is always complete (forward-compatible with subsystems wiring counters later).

### Spec citations

- frag-6-7 §6.5 line 150 — payload shape (`{ statsVersion: 1, rss, heapUsed, ptyBufferBytes, openSockets }`).
- frag-6-7 §6.5 line 145 — `statsVersion` lives ONLY on `/stats`; `healthzVersion` lives ONLY on `/healthz` (r3 P1-3 split).
- frag-3.4.1 §3.4.1.h — `/stats` is wire-literal, exempt from `ccsm.<wireMajor>/...` namespace (r9 + r11 manager locks).
- frag-3.4.1 §3.4.1.f — supervisor transport ignores `MIGRATION_PENDING` short-circuit; `/stats` reachable across migration windows.

### Single Responsibility

Pure decider. Reads injected counter providers, returns snapshot. Zero socket I/O, zero database queries. Ready for T16 dispatcher follow-up wiring via `dispatcher.register('/stats', makeStatsHandler(ctx))`.

### Stacks on

PR #670 (T17 `/healthz`) — same `ctx`-provider pattern, sister handler. Will rebase to `working` once #670 merges.

## Test plan

- [x] `npx vitest run daemon/src/handlers/__tests__/stats.test.ts` — 16/16 PASS
- [x] `npm run typecheck` — clean
- [x] ESM smoke: `import('./daemon/dist-daemon/handlers/stats.js')` loads + `handleStats()` returns spec-shaped body
- [x] All spec fields present + statsVersion = 1 + counter zero-state defaults + provider injection + dispatcher adapter integration + purity (req-ignored, no ctx mutation)