### PR TITLE
feat(daemon): T21 daemon.shutdownForUpgrade + atomic marker

### DIFF
--- a/daemon/src/handlers/__tests__/daemon-shutdown-for-upgrade.test.ts
+++ b/daemon/src/handlers/__tests__/daemon-shutdown-for-upgrade.test.ts
@@ -1,0 +1,463 @@
+// T21 — daemon.shutdownForUpgrade handler tests.
+// Spec: docs/superpowers/specs/v0.3-design.md / frag-6-7 §6.4
+// "`daemon.shutdownForUpgrade` RPC + shutdown marker".
+
+import { promises as fs } from 'node:fs';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  DAEMON_SHUTDOWN_MARKER_FILENAME,
+  readMarker,
+} from '../../marker/reader.js';
+import {
+  DAEMON_SHUTDOWN_MARKER_TMP_SUFFIX,
+  SHUTDOWN_MARKER_REASON_UPGRADE,
+  defaultWriteShutdownMarker,
+  executeShutdownForUpgrade,
+  makeShutdownForUpgradeHandler,
+  planShutdownForUpgrade,
+  type ShutdownForUpgradeActions,
+  type ShutdownForUpgradeContext,
+  type ShutdownForUpgradePlan,
+} from '../daemon-shutdown-for-upgrade.js';
+
+const FROZEN_TS = 1_700_000_000_000;
+
+function makeCtx(overrides: Partial<ShutdownForUpgradeContext> = {}): ShutdownForUpgradeContext {
+  return {
+    version: '0.3.0-test',
+    now: () => FROZEN_TS,
+    markerDir: '/var/run/ccsm',
+    ...overrides,
+  };
+}
+
+function makeRecordingActions(overrides: Partial<ShutdownForUpgradeActions> = {}): {
+  actions: ShutdownForUpgradeActions;
+  calls: string[];
+  exitCode: number | null;
+} {
+  const calls: string[] = [];
+  let exitCode: number | null = null;
+  const actions: ShutdownForUpgradeActions = {
+    writeMarker: async () => {
+      calls.push('writeMarker');
+    },
+    runShutdownSequence: async () => {
+      calls.push('runShutdownSequence');
+    },
+    releaseLock: async () => {
+      calls.push('releaseLock');
+    },
+    exit: (code) => {
+      calls.push(`exit:${code}`);
+      exitCode = code;
+    },
+    ...overrides,
+  };
+  return {
+    actions,
+    calls,
+    get exitCode(): number | null {
+      return exitCode;
+    },
+  } as { actions: ShutdownForUpgradeActions; calls: string[]; exitCode: number | null };
+}
+
+// ---------------------------------------------------------------------------
+// planShutdownForUpgrade — pure decider
+// ---------------------------------------------------------------------------
+
+describe('planShutdownForUpgrade — decider (pure)', () => {
+  it('returns ack { accepted: true, reason: "upgrade" }', () => {
+    const plan = planShutdownForUpgrade({}, makeCtx());
+    expect(plan.ack).toEqual({
+      accepted: true,
+      reason: SHUTDOWN_MARKER_REASON_UPGRADE,
+    });
+  });
+
+  it('markerPayload shape matches T22 reader expectation (reason/version/ts)', () => {
+    const plan = planShutdownForUpgrade({}, makeCtx({ version: '1.2.3' }));
+    expect(plan.markerPayload).toEqual({
+      reason: 'upgrade',
+      version: '1.2.3',
+      ts: FROZEN_TS,
+    });
+  });
+
+  it('markerPath = <markerDir>/daemon.shutdown ; tmp = path + ".tmp"', () => {
+    const plan = planShutdownForUpgrade({}, makeCtx({ markerDir: '/runtime' }));
+    expect(plan.markerPath).toBe(join('/runtime', DAEMON_SHUTDOWN_MARKER_FILENAME));
+    expect(plan.markerTmpPath).toBe(plan.markerPath + DAEMON_SHUTDOWN_MARKER_TMP_SUFFIX);
+  });
+
+  it('planSteps emit the §6.4 ordered sequence', () => {
+    const plan = planShutdownForUpgrade({}, makeCtx());
+    expect(plan.planSteps).toEqual([
+      'write-marker',
+      'run-shutdown-sequence',
+      'release-lock',
+      'exit',
+    ]);
+  });
+
+  it('is pure: same (req, ctx, clock) yields equal plans', () => {
+    const ctx = makeCtx();
+    const a = planShutdownForUpgrade({}, ctx);
+    const b = planShutdownForUpgrade({}, ctx);
+    expect(a).toEqual(b);
+  });
+
+  it('reads the clock exactly once per call', () => {
+    const now = vi.fn(() => FROZEN_TS);
+    planShutdownForUpgrade({}, makeCtx({ now }));
+    expect(now).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// executeShutdownForUpgrade — sink executor
+// ---------------------------------------------------------------------------
+
+describe('executeShutdownForUpgrade — sink (action ordering)', () => {
+  it('invokes actions in plan order: marker → shutdown → unlock → exit(0)', async () => {
+    const plan = planShutdownForUpgrade({}, makeCtx());
+    const recording = makeRecordingActions();
+    await executeShutdownForUpgrade(plan, recording.actions);
+    expect(recording.calls).toEqual([
+      'writeMarker',
+      'runShutdownSequence',
+      'releaseLock',
+      'exit:0',
+    ]);
+  });
+
+  it('aborts the sequence if writeMarker throws (no shutdown / no exit)', async () => {
+    const plan = planShutdownForUpgrade({}, makeCtx());
+    const recording = makeRecordingActions({
+      writeMarker: async () => {
+        throw new Error('disk full');
+      },
+    });
+    await expect(
+      executeShutdownForUpgrade(plan, recording.actions),
+    ).rejects.toThrow('disk full');
+    // Critically: NEITHER drain NOR exit ran. The caller (Electron-main)
+    // owns the force-kill fallback per frag-11 §11.6.5 step 4.
+    expect(recording.calls).toEqual([]);
+  });
+
+  it('does NOT call process.exit directly (exit goes through injected action)', async () => {
+    const plan = planShutdownForUpgrade({}, makeCtx());
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => {
+      throw new Error('process.exit was called directly — Layer-1 violation');
+    }) as never);
+    const recording = makeRecordingActions();
+    await executeShutdownForUpgrade(plan, recording.actions);
+    expect(exitSpy).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// defaultWriteShutdownMarker — atomic write protocol
+// ---------------------------------------------------------------------------
+
+describe('defaultWriteShutdownMarker — atomic write (real fs)', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'ccsm-t21-'));
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('writes a marker the T22 reader parses as PRESENT with full payload', async () => {
+    const plan = planShutdownForUpgrade({}, makeCtx({ markerDir: dir }));
+    await defaultWriteShutdownMarker(plan);
+
+    const result = await readMarker(plan.markerPath);
+    expect(result).toEqual({
+      kind: 'present',
+      payload: {
+        reason: 'upgrade',
+        version: '0.3.0-test',
+        ts: FROZEN_TS,
+      },
+    });
+  });
+
+  it('removes the .tmp file (renamed, not copied)', async () => {
+    const plan = planShutdownForUpgrade({}, makeCtx({ markerDir: dir }));
+    await defaultWriteShutdownMarker(plan);
+
+    await expect(fs.stat(plan.markerTmpPath)).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+    // Final marker exists.
+    await expect(fs.stat(plan.markerPath)).resolves.toBeDefined();
+  });
+
+  it('recovers from a stale .tmp leftover (previous crashed write)', async () => {
+    const plan = planShutdownForUpgrade({}, makeCtx({ markerDir: dir }));
+    // Simulate a previous daemon crash that left a half-written tmp.
+    await fs.writeFile(plan.markerTmpPath, 'stale garbage', { mode: 0o600 });
+
+    await defaultWriteShutdownMarker(plan);
+
+    const result = await readMarker(plan.markerPath);
+    expect(result.kind).toBe('present');
+    expect((result as { payload?: unknown }).payload).toEqual({
+      reason: 'upgrade',
+      version: '0.3.0-test',
+      ts: FROZEN_TS,
+    });
+  });
+
+  it('atomic: a synthetic crash before rename leaves NO daemon.shutdown (only the tmp)', async () => {
+    // Simulate the failure window: open + write + sync the tmp, then "crash"
+    // BEFORE the rename. The final marker must not exist; T22 reader sees
+    // ENOENT → absent, the conservative "previous boot was a crash, not an
+    // upgrade" reading. This is the safety guarantee.
+    const plan = planShutdownForUpgrade({}, makeCtx({ markerDir: dir }));
+    const handle = await fs.open(plan.markerTmpPath, 'wx', 0o600);
+    await handle.writeFile(JSON.stringify(plan.markerPayload));
+    await handle.sync();
+    await handle.close();
+    // crash here — no rename.
+
+    const finalRead = await readMarker(plan.markerPath);
+    expect(finalRead).toEqual({ kind: 'absent' });
+    // tmp exists (recoverable on next attempt via the EEXIST retry path).
+    await expect(fs.stat(plan.markerTmpPath)).resolves.toBeDefined();
+  });
+
+  it('atomic: a half-flushed FINAL marker is treated as PRESENT by T22 (rel-S-R8)', async () => {
+    // The T22 reader spec invariant we depend on — verify it still holds for
+    // a marker file that is post-rename but partially-flushed (here we
+    // simulate the worst case = empty file, which the reader must call
+    // `present` not `absent`).
+    const plan = planShutdownForUpgrade({}, makeCtx({ markerDir: dir }));
+    await fs.writeFile(plan.markerPath, '', { mode: 0o600 });
+    const result = await readMarker(plan.markerPath);
+    expect(result.kind).toBe('present');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// defaultWriteShutdownMarker — write sequence (mocked fs)
+// ---------------------------------------------------------------------------
+
+describe('defaultWriteShutdownMarker — write sequence (mocked)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sequence: open(tmp) → writeFile → fsync(file) → close → rename(tmp→final) → fsync(dir)', async () => {
+    const plan = planShutdownForUpgrade({}, makeCtx({ markerDir: '/fake/runtime' }));
+    const events: string[] = [];
+
+    const fileHandle = {
+      writeFile: vi.fn(async (data: unknown) => {
+        events.push(`writeFile:${String(data).length}`);
+      }),
+      sync: vi.fn(async () => {
+        events.push('file.sync');
+      }),
+      close: vi.fn(async () => {
+        events.push('file.close');
+      }),
+    };
+    const dirHandle = {
+      sync: vi.fn(async () => {
+        events.push('dir.sync');
+      }),
+      close: vi.fn(async () => {
+        events.push('dir.close');
+      }),
+    };
+
+    const openSpy = vi.spyOn(fs, 'open').mockImplementation((async (
+      path: unknown,
+      flags?: unknown,
+    ) => {
+      events.push(`open:${String(path)}:${String(flags)}`);
+      if (String(flags) === 'r') {
+        return dirHandle as unknown as import('node:fs/promises').FileHandle;
+      }
+      return fileHandle as unknown as import('node:fs/promises').FileHandle;
+    }) as typeof fs.open);
+    const renameSpy = vi.spyOn(fs, 'rename').mockImplementation((async (
+      from: unknown,
+      to: unknown,
+    ) => {
+      events.push(`rename:${String(from)}->${String(to)}`);
+    }) as typeof fs.rename);
+
+    await defaultWriteShutdownMarker(plan);
+
+    // Required ordering invariants (only checks that matter for correctness):
+    const idxOpenTmp = events.findIndex((e) => e.startsWith('open:') && e.includes('.tmp') && e.endsWith(':wx'));
+    const idxWrite = events.indexOf(events.find((e) => e.startsWith('writeFile:')) ?? '');
+    const idxFsyncFile = events.indexOf('file.sync');
+    const idxClose = events.indexOf('file.close');
+    const idxRename = events.indexOf(events.find((e) => e.startsWith('rename:')) ?? '');
+
+    expect(idxOpenTmp).toBeGreaterThanOrEqual(0);
+    expect(idxWrite).toBeGreaterThan(idxOpenTmp);
+    expect(idxFsyncFile).toBeGreaterThan(idxWrite);
+    expect(idxClose).toBeGreaterThan(idxFsyncFile);
+    expect(idxRename).toBeGreaterThan(idxClose);
+
+    expect(openSpy).toHaveBeenCalled();
+    expect(renameSpy).toHaveBeenCalledWith(plan.markerTmpPath, plan.markerPath);
+    expect(fileHandle.sync).toHaveBeenCalledTimes(1);
+    expect(fileHandle.writeFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('writeFile payload is the canonical marker JSON (T22 reader parseable)', async () => {
+    const plan = planShutdownForUpgrade({}, makeCtx({ markerDir: '/fake/runtime' }));
+    let written: string | null = null;
+    const fileHandle = {
+      writeFile: vi.fn(async (data: string) => {
+        written = data;
+      }),
+      sync: vi.fn(async () => undefined),
+      close: vi.fn(async () => undefined),
+    };
+    vi.spyOn(fs, 'open').mockImplementation((async () =>
+      fileHandle as unknown as import('node:fs/promises').FileHandle) as typeof fs.open);
+    vi.spyOn(fs, 'rename').mockImplementation((async () => undefined) as typeof fs.rename);
+
+    await defaultWriteShutdownMarker(plan);
+
+    expect(written).not.toBeNull();
+    const parsed: unknown = JSON.parse(written as unknown as string);
+    expect(parsed).toEqual({
+      reason: 'upgrade',
+      version: '0.3.0-test',
+      ts: FROZEN_TS,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// makeShutdownForUpgradeHandler — dispatcher adapter
+// ---------------------------------------------------------------------------
+
+describe('makeShutdownForUpgradeHandler — wire ack', () => {
+  it('returns ack PROMPTLY before side effects complete', async () => {
+    let writeStarted = false;
+    let releaseAck: (() => void) | null = null;
+    const sideEffectsDone = new Promise<void>((resolve) => {
+      releaseAck = resolve;
+    });
+    const actions: ShutdownForUpgradeActions = {
+      writeMarker: async () => {
+        writeStarted = true;
+        // Block forever-ish until the test releases — proves the ack does
+        // NOT wait on the marker write.
+        await sideEffectsDone;
+      },
+      runShutdownSequence: async () => undefined,
+      releaseLock: async () => undefined,
+      exit: () => undefined,
+    };
+    const handler = makeShutdownForUpgradeHandler(makeCtx(), actions);
+
+    const ack = await handler({});
+    expect(ack).toEqual({ accepted: true, reason: 'upgrade' });
+    // The side effects are scheduled (queueMicrotask) but the marker write
+    // hasn't necessarily started yet — flush microtasks then a real tick:
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(writeStarted).toBe(true);
+
+    // Cleanup so the dangling promise resolves.
+    if (releaseAck) (releaseAck as () => void)();
+  });
+
+  it('surfaces marker-write errors to the injected onError callback', async () => {
+    const onError = vi.fn();
+    const actions: ShutdownForUpgradeActions = {
+      writeMarker: async () => {
+        throw new Error('marker write failed');
+      },
+      runShutdownSequence: async () => undefined,
+      releaseLock: async () => undefined,
+      exit: () => undefined,
+    };
+    const handler = makeShutdownForUpgradeHandler(makeCtx(), actions, onError);
+
+    await handler({});
+    // Drain microtasks + one macrotask for the catch handler.
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]?.[0]).toBeInstanceOf(Error);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// e2e — decider + default sink + reader (round-trip)
+// ---------------------------------------------------------------------------
+
+describe('shutdownForUpgrade — round-trip with T22 reader', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'ccsm-t21-rt-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('decider → defaultWriteShutdownMarker → readMarker yields exact payload', async () => {
+    const ctx = makeCtx({ markerDir: dir, version: '0.3.42' });
+    const plan = planShutdownForUpgrade({}, ctx);
+
+    let exitCalledWith: number | null = null;
+    const actions: ShutdownForUpgradeActions = {
+      writeMarker: defaultWriteShutdownMarker,
+      runShutdownSequence: async () => undefined,
+      releaseLock: async () => undefined,
+      exit: (code) => {
+        exitCalledWith = code;
+      },
+    };
+    await executeShutdownForUpgrade(plan, actions);
+
+    expect(exitCalledWith).toBe(0);
+
+    const onDisk = await readFile(
+      join(dir, DAEMON_SHUTDOWN_MARKER_FILENAME),
+      'utf8',
+    );
+    expect(JSON.parse(onDisk)).toEqual({
+      reason: 'upgrade',
+      version: '0.3.42',
+      ts: FROZEN_TS,
+    });
+
+    const readResult = await readMarker(join(dir, DAEMON_SHUTDOWN_MARKER_FILENAME));
+    expect(readResult.kind).toBe('present');
+  });
+
+  // Reverse-verify: with the implementation removed, the round-trip would
+  // fail at `readMarker.kind === 'present'`. Verified manually pre-commit
+  // by stubbing `defaultWriteShutdownMarker` to no-op.
+  it('plan exposes markerPath/markerTmpPath consumers can pre-allocate', () => {
+    const plan: ShutdownForUpgradePlan = planShutdownForUpgrade({}, makeCtx({ markerDir: dir }));
+    expect(plan.markerPath.endsWith(DAEMON_SHUTDOWN_MARKER_FILENAME)).toBe(true);
+    expect(plan.markerTmpPath.endsWith(DAEMON_SHUTDOWN_MARKER_FILENAME + DAEMON_SHUTDOWN_MARKER_TMP_SUFFIX)).toBe(true);
+  });
+});

--- a/daemon/src/handlers/daemon-shutdown-for-upgrade.ts
+++ b/daemon/src/handlers/daemon-shutdown-for-upgrade.ts
@@ -1,0 +1,321 @@
+// daemon.shutdownForUpgrade handler (T21) — control-socket RPC that prepares
+// the daemon for an in-place auto-update by writing a clean-shutdown marker
+// the next supervisor boot will treat as "do not increment crash-loop counter".
+//
+// Spec citations:
+//   - docs/superpowers/specs/v0.3-design.md / frag-6-7 §6.4
+//     "`daemon.shutdownForUpgrade` RPC + shutdown marker" lock — caller is
+//     Electron-main on `update-downloaded`; daemon MUST atomically write
+//     `<dataRoot>/daemon.shutdown` (O_CREAT|O_EXCL on `.tmp` → fsync → rename),
+//     then run the §6.6.1 ordered shutdown sequence, release the daemon.lock,
+//     and process.exit(0) within 5 s.
+//   - frag-6-7 §6.4 "Marker payload is a single line
+//     `{ "reason": "upgrade", "version": "<current>", "ts": <epoch_ms> }`"
+//     — schema MUST match the T22 reader (`ShutdownMarkerPayload`).
+//   - frag-6-7 §6.4 "Marker corruption / partial write (rel-S-R8)" — the T22
+//     reader treats any non-ENOENT condition as PRESENT, so even a half-flushed
+//     `daemon.shutdown` (post-rename, pre-fsync of dir entry) is safe; the
+//     write protocol below preserves that invariant.
+//   - T22 reader (a797826): exposes `DAEMON_SHUTDOWN_MARKER_FILENAME` constant
+//     + `ShutdownMarkerPayload` shape — this writer matches both.
+//   - T13 runtimeRoot (34ff871): caller injects `markerDir = resolveRuntimeRoot()`
+//     so this module stays path-agnostic and trivially testable.
+//
+// Single Responsibility (per repo memory `feedback_single_responsibility.md`):
+//   - PRODUCER: callers (control-socket transport) deliver an empty `req` and
+//     a `ShutdownForUpgradeContext` containing the current daemon version +
+//     a clock + the marker dir.
+//   - DECIDER: `planShutdownForUpgrade` returns a fully-formed plan
+//     (`markerPayload` + ordered `planSteps`) — a pure function. ZERO I/O.
+//   - SINK: `executeShutdownForUpgrade(plan, actions)` invokes the injected
+//     `ShutdownForUpgradeActions` (writeMarker, runShutdownSequence,
+//     releaseLock, exit). The default action provider performs the real
+//     side effects; tests inject fakes. The handler NEVER calls process.exit
+//     directly (spec §6.4 step 4 ownership lives in the actions sink, not the
+//     decider).
+//
+// Distinct from T20 `daemon.shutdown` (uninstall path): T20 has no marker and
+// a 2 s force-kill budget. T21's marker is the load-bearing signal that lets
+// the next-boot supervisor distinguish "planned upgrade" from "crash" — the
+// difference between a clean upgrade and a false crash-loop trip.
+
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  DAEMON_SHUTDOWN_MARKER_FILENAME,
+  type ShutdownMarkerPayload,
+} from '../marker/reader.js';
+
+/** Marker reason MUST be the literal `'upgrade'` for the T22 reader to map it
+ *  to the §6.1 R2 "do not increment crash-loop counter" branch. The reader's
+ *  `ShutdownMarkerPayload.reason` is widened to `'upgrade' | string` for
+ *  forward-compat, but the writer is the single producer and stays narrow. */
+export const SHUTDOWN_MARKER_REASON_UPGRADE = 'upgrade' as const;
+
+/** Tmp-file suffix per spec §6.4 step 1 (atomic write protocol:
+ *  `daemon.shutdown.tmp` → rename → `daemon.shutdown`). Exported so wiring
+ *  layer + tests share one literal. */
+export const DAEMON_SHUTDOWN_MARKER_TMP_SUFFIX = '.tmp' as const;
+
+/** Daemon protocol version field surfaced inside the marker payload alongside
+ *  the daemon binary semver. The spec calls it `version` (the daemon binary
+ *  semver), not the protocol version — kept narrow to match the reader. */
+export interface ShutdownForUpgradeContext {
+  /** Semver-string of the running daemon binary (matches `/healthz.version`).
+   *  Becomes `markerPayload.version`. */
+  readonly version: string;
+  /** Epoch-ms clock — injected so tests get deterministic `ts`. Production =
+   *  `() => Date.now()`. */
+  readonly now: () => number;
+  /** Absolute path to the directory under which `daemon.shutdown` lives.
+   *  Production = `resolveRuntimeRoot()` (T13). */
+  readonly markerDir: string;
+}
+
+/** RPC ack returned over the wire. The caller (Electron-main) uses
+ *  `accepted: true` as the 5 s ack window confirmation per frag-11 §11.6.5. */
+export interface ShutdownForUpgradeAck {
+  readonly accepted: true;
+  /** Echo back the planned reason so the supervisor log entry on the caller
+   *  side carries it without needing to mirror the constant. */
+  readonly reason: typeof SHUTDOWN_MARKER_REASON_UPGRADE;
+}
+
+/** Step IDs in the order the actions sink MUST execute them. The decider
+ *  emits this fixed sequence; the sink iterates and invokes the matching
+ *  action. Naming mirrors the spec §6.4 step numbering 1→4. */
+export type ShutdownForUpgradePlanStep =
+  | 'write-marker'
+  | 'run-shutdown-sequence'
+  | 'release-lock'
+  | 'exit';
+
+export interface ShutdownForUpgradePlan {
+  readonly ack: ShutdownForUpgradeAck;
+  readonly markerPayload: ShutdownMarkerPayload;
+  readonly markerPath: string;
+  readonly markerTmpPath: string;
+  /** Ordered: marker → §6.6.1 drain → unlock → exit(0). */
+  readonly planSteps: ReadonlyArray<ShutdownForUpgradePlanStep>;
+}
+
+/** Pure decider. No I/O. No clock side effects beyond the injected `now()`.
+ *  Same `(req, ctx)` always yields the same plan for the same clock value. */
+export function planShutdownForUpgrade(
+  _req: unknown,
+  ctx: ShutdownForUpgradeContext,
+): ShutdownForUpgradePlan {
+  const ts = ctx.now();
+  const markerPayload: ShutdownMarkerPayload = {
+    reason: SHUTDOWN_MARKER_REASON_UPGRADE,
+    version: ctx.version,
+    ts,
+  };
+  const markerPath = join(ctx.markerDir, DAEMON_SHUTDOWN_MARKER_FILENAME);
+  const markerTmpPath = markerPath + DAEMON_SHUTDOWN_MARKER_TMP_SUFFIX;
+
+  return {
+    ack: { accepted: true, reason: SHUTDOWN_MARKER_REASON_UPGRADE },
+    markerPayload,
+    markerPath,
+    markerTmpPath,
+    planSteps: [
+      'write-marker',
+      'run-shutdown-sequence',
+      'release-lock',
+      'exit',
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Sink — actions provider + executor
+// ---------------------------------------------------------------------------
+
+/** Injected side-effect surface. The default provider wires real fs / lock /
+ *  shutdown / exit; tests pass fakes that record call order. */
+export interface ShutdownForUpgradeActions {
+  /** Atomic marker write: tmp → fsync(file) → fsync(dir) → rename. MUST be
+   *  crash-safe so a power loss mid-write never leaves a partially-renamed
+   *  `daemon.shutdown`. */
+  writeMarker(plan: ShutdownForUpgradePlan): Promise<void>;
+  /** §6.6.1 drain ordering: subscribers → SIGCHLD wind-down → DB checkpoint
+   *  → pino.final. Owned by the daemon shell; injected here as an opaque
+   *  callback so this handler stays decoupled from session/db modules. */
+  runShutdownSequence(): Promise<void>;
+  /** `proper-lockfile` `unlock(<dataRoot>/daemon.lock)`. Injected so tests
+   *  don't touch a real lockfile. */
+  releaseLock(): Promise<void>;
+  /** `process.exit(0)`. Last call; never returns under production. Injected
+   *  so tests can verify it was called WITHOUT actually exiting the worker. */
+  exit(code: number): void;
+}
+
+/** Default marker-write implementation. Spec §6.4 step 1 mandates
+ *  `O_CREAT | O_EXCL | O_WRONLY` on the tmp file, then `rename()` over the
+ *  final name. We add `fsync(file)` + `fsync(dir)` so the entry is durable
+ *  before the rename — without the dir fsync the rename can be lost on a
+ *  power-cut and the next boot sees no marker (false crash-loop trip).
+ *
+ *  If the tmp file already exists (left over from a previous crashed write),
+ *  EEXIST is the spec-correct response per O_EXCL — but a stale tmp is also
+ *  the literal "partial-write window" the T22 reader is designed to tolerate
+ *  on the FINAL marker, not the tmp. We unlink + retry once: a stale tmp is
+ *  unrecoverable garbage (no other process owns it; the daemon is the single
+ *  writer per §6.4) and refusing to retry would brick every subsequent
+ *  upgrade after a single crashed shutdown.
+ */
+export async function defaultWriteShutdownMarker(
+  plan: ShutdownForUpgradePlan,
+): Promise<void> {
+  const data = JSON.stringify(plan.markerPayload);
+
+  // Open the tmp with O_CREAT|O_EXCL|O_WRONLY (mode 0o600 → user-only; on
+  // Windows this maps to inherited per-user ACL). On EEXIST, unlink stale
+  // tmp and retry once (see jsdoc rationale).
+  let handle: import('node:fs/promises').FileHandle;
+  try {
+    handle = await fs.open(plan.markerTmpPath, 'wx', 0o600);
+  } catch (err) {
+    if (isEexist(err)) {
+      await fs.unlink(plan.markerTmpPath).catch(() => undefined);
+      handle = await fs.open(plan.markerTmpPath, 'wx', 0o600);
+    } else {
+      throw err;
+    }
+  }
+
+  try {
+    await handle.writeFile(data);
+    // fsync the file so the data is on disk BEFORE the rename. Without this,
+    // a power-cut between rename and journal-flush can produce a zero-length
+    // marker — the T22 reader does treat that as PRESENT (good), but we
+    // prefer the payload land too so forensics work.
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+
+  // Atomic rename: on POSIX rename(2) is atomic within the same filesystem;
+  // on Windows fs.promises.rename uses MoveFileExW with REPLACE_EXISTING for
+  // the cross-volume case (here always same dir = same volume).
+  await fs.rename(plan.markerTmpPath, plan.markerPath);
+
+  // fsync the directory so the rename is durable. Best-effort: Windows
+  // doesn't support fsync on a directory handle and will throw EPERM /
+  // EISDIR depending on the libuv version — swallow those, the rename
+  // itself is already journalled by NTFS.
+  try {
+    const dirHandle = await fs.open(
+      dirnameOf(plan.markerPath),
+      'r',
+    );
+    try {
+      await dirHandle.sync();
+    } finally {
+      await dirHandle.close();
+    }
+  } catch {
+    // Best-effort; see jsdoc.
+  }
+}
+
+function isEexist(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code: unknown }).code === 'EEXIST'
+  );
+}
+
+function dirnameOf(p: string): string {
+  // node:path/posix.dirname would mangle Windows paths; use a tiny inline
+  // split that handles both separators without dragging in `node:path` here
+  // (the only other path use in this file is `join` in the decider).
+  const lastSep = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\'));
+  return lastSep <= 0 ? p : p.slice(0, lastSep);
+}
+
+/**
+ * Sink executor. Iterates `plan.planSteps` in order, invoking the matching
+ * action. Returns AFTER `release-lock`; the `exit` step is invoked but the
+ * default `exit` action calls `process.exit(0)` and never returns, so any
+ * code after this call should not be relied on in production.
+ *
+ * Tests inject an `exit` action that records the code; the function returns
+ * normally so the `await` at the call site resolves.
+ *
+ * Failure mode: if `writeMarker` throws, the error propagates and the
+ * remaining steps are NOT executed. The caller (control-socket transport)
+ * surfaces this to Electron-main, which then falls back to its 5 s force-kill
+ * (frag-11 §11.6.5 step 4). This preserves the spec invariant: a failed
+ * marker write means "no upgrade marker" → next boot applies normal
+ * crash-loop accounting, which is the conservative correct behaviour.
+ */
+export async function executeShutdownForUpgrade(
+  plan: ShutdownForUpgradePlan,
+  actions: ShutdownForUpgradeActions,
+): Promise<void> {
+  for (const step of plan.planSteps) {
+    switch (step) {
+      case 'write-marker':
+        await actions.writeMarker(plan);
+        break;
+      case 'run-shutdown-sequence':
+        await actions.runShutdownSequence();
+        break;
+      case 'release-lock':
+        await actions.releaseLock();
+        break;
+      case 'exit':
+        actions.exit(0);
+        break;
+      default: {
+        // Exhaustiveness guard — if a new step is added to the plan tuple
+        // without updating this switch, TypeScript flags it at compile time.
+        const _exhaustive: never = step;
+        void _exhaustive;
+      }
+    }
+  }
+}
+
+/**
+ * Convenience adapter for the T16 dispatcher signature
+ * `(req) => Promise<unknown>`. Wires the pure decider to the injected
+ * actions sink and returns the ack synchronously after kicking off the
+ * shutdown sequence in the background.
+ *
+ * The shutdown sequence runs AFTER the ack is returned (fire-and-forget
+ * with a `.catch` to surface marker-write failures to the injected logger).
+ * This matches spec §6.4 "ack within 5 s" — the caller MUST receive the ack
+ * before the daemon starts tearing down, so the 5 s budget covers the full
+ * marker → drain → unlock → exit window starting AFTER the wire reply.
+ *
+ * Wiring (post-T21-merge follow-up commit):
+ *   dispatcher.register(
+ *     'daemon.shutdownForUpgrade',
+ *     makeShutdownForUpgradeHandler(ctx, actions, onError),
+ *   );
+ */
+export function makeShutdownForUpgradeHandler(
+  ctx: ShutdownForUpgradeContext,
+  actions: ShutdownForUpgradeActions,
+  onError?: (err: unknown) => void,
+): (req: unknown) => Promise<ShutdownForUpgradeAck> {
+  return async (req: unknown) => {
+    const plan = planShutdownForUpgrade(req, ctx);
+    // Fire-and-forget the side effects. The caller awaits only the ack.
+    // We schedule via queueMicrotask so the wire-level reply is flushed
+    // before the marker write begins; this guarantees the ack arrives at
+    // the supervisor BEFORE process.exit(0) tears down the socket.
+    queueMicrotask(() => {
+      executeShutdownForUpgrade(plan, actions).catch((err) => {
+        if (onError) onError(err);
+      });
+    });
+    return plan.ack;
+  };
+}


### PR DESCRIPTION
## Summary

Implements **T21** — `daemon.shutdownForUpgrade` control-socket RPC + atomic shutdown-marker writer.

**Spec**: docs/superpowers/specs/v0.3-design.md / frag-6-7 §6.4 — *"daemon.shutdownForUpgrade RPC + shutdown marker"* (`[manager r7 lock: r6 packaging P0-2 cross-frag — daemon.shutdownForUpgrade RPC + marker semantics]`).

Distinct from T20 `daemon.shutdown` (uninstall path, no marker, 2 s force-kill): T21 writes the load-bearing marker file the next-boot supervisor (§6.1 R2) uses to suppress the crash-loop counter for a planned upgrade.

## Architecture (Layer 1: Single Responsibility)

- **Producer** — control-socket transport (T16) delivers empty `req` + `ShutdownForUpgradeContext { version, now, markerDir }`.
- **Decider** — `planShutdownForUpgrade(req, ctx)` is pure: returns `{ ack, markerPayload, markerPath, markerTmpPath, planSteps }`. Zero I/O. Reads the clock exactly once.
- **Sink** — `executeShutdownForUpgrade(plan, actions)` iterates `planSteps` invoking the injected `ShutdownForUpgradeActions { writeMarker, runShutdownSequence, releaseLock, exit }`. **Handler NEVER calls `process.exit` directly** — exit is an injected action so tests verify behaviour without terminating the worker.

## Marker schema (matches T22 reader exactly)

```json
{ "reason": "upgrade", "version": "<daemon-semver>", "ts": <epoch_ms> }
```

`reason` is the literal `'upgrade'` constant (`SHUTDOWN_MARKER_REASON_UPGRADE`); the T22 reader's `ShutdownMarkerPayload.reason` widens to `'upgrade' | string` for forward-compat, but this writer is the single producer and stays narrow.

## Atomic write protocol (defaultWriteShutdownMarker)

```
open(`<runtimeRoot>/daemon.shutdown.tmp`, 'wx', 0o600)   // O_CREAT|O_EXCL|O_WRONLY, user-only
  → handle.writeFile(JSON.stringify(payload))
  → handle.sync()                                        // fsync(file) — payload durable
  → handle.close()
  → fs.rename(tmpPath, finalPath)                        // atomic on POSIX + NTFS (MoveFileExW)
  → fsync(dir, best-effort)                              // EPERM/EISDIR swallowed on Win
```

**EEXIST on the tmp** triggers a single unlink+retry. Stale tmp from a previous crashed write is unrecoverable garbage — the daemon is the single writer per §6.4 — and refusing to retry would brick every subsequent upgrade after a single crashed shutdown.

**Failure mode**: if `writeMarker` throws, the remaining steps DO NOT execute; the error propagates so the caller (Electron-main) falls back to its 5 s force-kill (frag-11 §11.6.5 step 4). This preserves the spec invariant — a failed marker write means "no upgrade marker" → next boot applies normal crash-loop accounting (conservative correct behaviour).

## Atomicity proof (covered by tests)

- **Synthetic crash before rename leaves NO `daemon.shutdown`** — only the tmp. T22 reader sees ENOENT → `{kind: 'absent'}`, the conservative "previous boot was a crash" reading. Verified explicitly in `atomic: a synthetic crash before rename leaves NO daemon.shutdown`.
- **Half-flushed FINAL marker is treated as PRESENT** — verified the T22 rel-S-R8 invariant (an empty file post-rename → `{kind: 'present'}`) still holds, so a power-cut between rename and journal-flush still suppresses the crash-loop counter.
- **Stale tmp recovery** — pre-existing `daemon.shutdown.tmp` does not break the next upgrade attempt.

## Wire ack timing

`makeShutdownForUpgradeHandler` returns the ack from the decider, then schedules `executeShutdownForUpgrade` via `queueMicrotask` so the wire reply is flushed BEFORE side effects begin. Matches frag-11 §11.6.5 "5 s ack window" — the 5 s budget covers the full marker → drain → unlock → exit window starting AFTER the supervisor receives `{accepted: true}`.

## Test plan

- [x] `npx vitest run daemon/src/handlers/__tests__/daemon-shutdown-for-upgrade.test.ts` — **20/20 pass** (3.0 s)
  - decider: ack shape, payload shape, path computation, planSteps order, purity, single-clock-read
  - sink: ordered execution (marker → drain → unlock → exit), abort-on-marker-failure, no direct `process.exit`
  - atomic write (real fs): T22-reader round-trip, `.tmp` cleanup, stale-tmp recovery, synthetic crash before rename = absent, half-flushed final = present
  - mocked-fs sequence: `open(tmp,'wx') → writeFile → fsync(file) → close → rename → fsync(dir)`
  - dispatcher adapter: ack returned BEFORE side effects begin, error surfaced via `onError`
  - e2e round-trip: decider + default sink + T22 reader yield exact payload
- [x] `npx tsc --noEmit -p daemon/tsconfig.json` — clean
- [x] `npm run build:daemon` — clean
- [x] Require-load smoke: `node -e "import('./daemon/dist-daemon/handlers/daemon-shutdown-for-upgrade.js')"` — exports `{planShutdownForUpgrade, executeShutdownForUpgrade, defaultWriteShutdownMarker, makeShutdownForUpgradeHandler, SHUTDOWN_MARKER_REASON_UPGRADE, DAEMON_SHUTDOWN_MARKER_TMP_SUFFIX}`
- [x] Full daemon vitest — only 2 pre-existing failures (better-sqlite3 native binding on Windows worker; unrelated to this PR; T21 + all other handler tests green)

## Follow-up (not in this PR)

- Wiring into the T16 dispatcher (`dispatcher.register('daemon.shutdownForUpgrade', makeShutdownForUpgradeHandler(ctx, actions, onError))`) — separate post-T21 commit per the T16 stub-replacement pattern (same as T17 healthz).
- Default `runShutdownSequence` action implementation lives in T20-adjacent code (§6.6.1 drain ordering) — this PR keeps the action injected so T20 + T21 share one drain implementation when wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)