### PR TITLE
feat(daemon): T44 stream-dead detector

### DIFF
--- a/daemon/src/pty/__tests__/stream-dead-detector.test.ts
+++ b/daemon/src/pty/__tests__/stream-dead-detector.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createStreamDeadDetector,
+  type StreamDeadDetector,
+} from '../stream-dead-detector.js';
+
+// Hermetic clock helper. Tests pass `now` explicitly to `onAck` /
+// `track` / `check` so the detector never observes wall-clock time.
+function makeDetector(deadlineMs = 1000): StreamDeadDetector {
+  // Inject a clock that throws — every entry point used in tests passes
+  // an explicit `at` / `now`, so an accidental fallback to the clock
+  // would surface immediately as a thrown test failure rather than as
+  // wall-clock flakiness.
+  return createStreamDeadDetector({
+    deadlineMs,
+    now: () => {
+      throw new Error('detector should not consult ambient clock in tests');
+    },
+  });
+}
+
+describe('stream-dead-detector: construction', () => {
+  it('rejects non-positive deadline', () => {
+    expect(() => createStreamDeadDetector({ deadlineMs: 0 })).toThrow(RangeError);
+    expect(() => createStreamDeadDetector({ deadlineMs: -1 })).toThrow(RangeError);
+  });
+  it('rejects non-integer / non-finite deadline', () => {
+    expect(() => createStreamDeadDetector({ deadlineMs: 1.5 })).toThrow(RangeError);
+    expect(() => createStreamDeadDetector({ deadlineMs: Number.NaN })).toThrow(RangeError);
+    expect(() => createStreamDeadDetector({ deadlineMs: Infinity })).toThrow(RangeError);
+  });
+  it('accepts the spec-canonical 65 s default (2 × 30 s + 5 s)', () => {
+    expect(() => createStreamDeadDetector({ deadlineMs: 65_000 })).not.toThrow();
+  });
+});
+
+describe('stream-dead-detector: liveness window', () => {
+  it('untracked subscriber is never reported', () => {
+    const det = makeDetector(1000);
+    expect(det.check(10_000_000)).toEqual([]);
+    expect(det.size()).toBe(0);
+  });
+
+  it('fresh subscriber registered via track is alive until deadlineMs elapses', () => {
+    const det = makeDetector(1000);
+    det.track('sub-a', 1000);
+    expect(det.check(1000)).toEqual([]); // age 0
+    expect(det.check(1999)).toEqual([]); // age 999, just under
+    expect(det.check(2000)).toEqual([]); // age 1000, NOT strictly older
+    expect(det.check(2001)).toEqual(['sub-a']); // age 1001, dead
+  });
+
+  it('onAck on an unknown id implicitly registers it (re-arm semantics)', () => {
+    const det = makeDetector(1000);
+    det.onAck('sub-a', 5000);
+    expect(det.size()).toBe(1);
+    expect(det.check(5500)).toEqual([]);
+    expect(det.check(6001)).toEqual(['sub-a']);
+  });
+
+  it('onAck refreshes lastAck and revives a subscriber close to the deadline', () => {
+    const det = makeDetector(1000);
+    det.track('sub-a', 1000);
+    // About to die...
+    expect(det.check(1999)).toEqual([]);
+    det.onAck('sub-a', 1999);
+    // ...but the ack reset the clock; lastAck = 1999, deadline = 1000.
+    // Dead when age strictly > 1000, i.e. when now >= 3000.
+    expect(det.check(2999)).toEqual([]); // age 1000, alive
+    expect(det.check(3000)).toEqual(['sub-a']); // age 1001, dead
+  });
+
+  it('track is a no-op for an already-tracked id (does not bump timestamp)', () => {
+    const det = makeDetector(1000);
+    det.track('sub-a', 1000);
+    det.track('sub-a', 5000); // ignored — onAck is the bumper
+    expect(det.check(2001)).toEqual(['sub-a']);
+  });
+});
+
+describe('stream-dead-detector: check is pure', () => {
+  it('repeated check() returns the same dead set without mutating state', () => {
+    const det = makeDetector(1000);
+    det.track('sub-a', 1000);
+    expect(det.check(2001)).toEqual(['sub-a']);
+    expect(det.check(2001)).toEqual(['sub-a']);
+    expect(det.check(2001)).toEqual(['sub-a']);
+    expect(det.size()).toBe(1); // still tracked — caller must forget()
+  });
+
+  it('forget removes the subscriber so check no longer returns it', () => {
+    const det = makeDetector(1000);
+    det.track('sub-a', 1000);
+    expect(det.check(2001)).toEqual(['sub-a']);
+    det.forget('sub-a');
+    expect(det.check(2001)).toEqual([]);
+    expect(det.size()).toBe(0);
+  });
+
+  it('forget is idempotent on unknown id', () => {
+    const det = makeDetector(1000);
+    expect(() => det.forget('never-tracked')).not.toThrow();
+  });
+});
+
+describe('stream-dead-detector: multiple subscribers', () => {
+  it('only old subscribers are reported, fresh ones are not', () => {
+    const det = makeDetector(1000);
+    det.track('sub-old-1', 1000);
+    det.track('sub-old-2', 1000);
+    det.track('sub-fresh', 5000);
+    det.onAck('sub-recent', 5500);
+    const dead = det.check(6000);
+    // sub-old-1, sub-old-2: age 5000, dead
+    // sub-fresh: age 1000 — NOT strictly older than deadline, alive
+    // sub-recent: age 500, alive
+    expect(dead).toEqual(['sub-old-1', 'sub-old-2']);
+  });
+
+  it('returns dead ids in ASCII lexical order regardless of insertion order', () => {
+    const det = makeDetector(1000);
+    // Insert deliberately out of sort order.
+    det.track('zeta', 1000);
+    det.track('alpha', 1000);
+    det.track('mike', 1000);
+    det.track('bravo', 1000);
+    expect(det.check(2001)).toEqual(['alpha', 'bravo', 'mike', 'zeta']);
+  });
+
+  it('mixed live + dead set: only the dead ones come back, sorted', () => {
+    const det = makeDetector(1000);
+    det.track('c', 1000); // dead at 2001
+    det.track('a', 1500); // alive at 2001 (age 501)
+    det.track('b', 1000); // dead at 2001
+    det.track('d', 1900); // alive at 2001 (age 101)
+    expect(det.check(2001)).toEqual(['b', 'c']);
+  });
+
+  it('large fan-out: 100 subs, half ack just in time, half time out', () => {
+    const det = makeDetector(1000);
+    for (let i = 0; i < 100; i++) {
+      const id = `sub-${String(i).padStart(3, '0')}`;
+      det.track(id, 1000);
+      if (i % 2 === 0) det.onAck(id, 1500); // even indices ack mid-window
+    }
+    const dead = det.check(2001);
+    // odds are dead (50 ids), evens were ack'ed at 1500 → age 501 alive
+    expect(dead.length).toBe(50);
+    expect(dead[0]).toBe('sub-001');
+    expect(dead[dead.length - 1]).toBe('sub-099');
+    // Verify all returned ids are odd-indexed.
+    for (const id of dead) {
+      const n = Number(id.replace('sub-', ''));
+      expect(n % 2).toBe(1);
+    }
+  });
+});
+
+describe('stream-dead-detector: clock injection', () => {
+  it('falls back to injected clock when caller omits explicit timestamps', () => {
+    let nowVal = 1000;
+    const det = createStreamDeadDetector({
+      deadlineMs: 1000,
+      now: () => nowVal,
+    });
+    det.track('sub-a'); // uses clock => 1000
+    nowVal = 1500;
+    det.onAck('sub-b'); // uses clock => 1500
+    nowVal = 2001;
+    expect(det.check()).toEqual(['sub-a']); // sub-a age 1001, sub-b age 501
+    nowVal = 2501;
+    expect(det.check()).toEqual(['sub-a', 'sub-b']); // both dead
+  });
+});

--- a/daemon/src/pty/stream-dead-detector.ts
+++ b/daemon/src/pty/stream-dead-detector.ts
@@ -1,0 +1,183 @@
+// Per-subscriber liveness detector for the PTY fan-out path.
+//
+// Spec: docs/superpowers/specs/v0.3-design.md
+//   - frag-3.5.1 §3.5.1.4 — client-side dead-stream detection at
+//     `2 × heartbeatMs + 5 s`; cross-frag handoff notes the symmetric
+//     server-side detector lives in §6.5.1.
+//   - frag-6-7 §6.5.1 (lines 1695-1714) — canonical server-side
+//     stream-dead detector (round-7 manager lock, r6 reliability
+//     P0-R2). Daemon maintains a per-stream `lastClientActivityAt`
+//     timestamp; the shared heartbeat scheduler (already iterating
+//     once per second) checks `now - lastClientActivityAt
+//     > 2 × heartbeatMs + 5_000` and treats the stream + connection as
+//     dead. The v0.3 local-pipe / unix-socket transport makes this a
+//     no-op in practice (kernel `'close'` fires first), but the
+//     contract is byte-compatible with the v0.5 CF Tunnel TCP swap
+//     where half-open sockets need an application-layer detector.
+//
+// Single Responsibility (per `feedback_single_responsibility`):
+//   - PRODUCER: `onAck(subscriberId)` — caller feeds liveness signals
+//     (any inbound RPC on the same connection per spec line 1701, or
+//     any client frame on the same connection in v0.5).
+//   - DECIDER: `check(now)` — pure function over the in-memory map;
+//     returns the list of subscriber ids whose `lastAck` is older than
+//     `deadlineMs`. **Does NOT** close sockets, **does NOT** unsubscribe
+//     from the fan-out registry (frag-3.5.1 §3.5.1.5 / `fanout-registry.ts`),
+//     **does NOT** emit log lines. The shared heartbeat scheduler that
+//     wires this up owns those side effects (spec §6.5.1 step 2-4).
+//   - This is NOT a sink. The wiring layer (T42 producer / shared
+//     heartbeat scheduler) is responsible for translating the returned
+//     ids into `subscriber-dropped` log lines + registry `unsubscribe`
+//     calls + `socket.destroy()`.
+//
+// Hard non-goals (push back if asked):
+//   - No socket I/O, no log emission, no registry coupling.
+//   - No heartbeat **sending** — that lives in the T42 shared heartbeat
+//     scheduler. This module only detects subscribers that have stopped
+//     ack'ing (i.e. liveness from the OTHER direction).
+//   - No deadline arithmetic against `2 × heartbeatMs + 5_000` — the
+//     caller computes `deadlineMs` from the negotiated heartbeat
+//     interval and passes it in. Keeping the formula at the wiring
+//     layer means a single source of truth even if the heartbeat
+//     interval is renegotiated mid-stream (frag-3.4.1 §3.4.1.c
+//     `x-ccsm-heartbeat-ms`).
+
+/**
+ * Opaque subscriber identifier. The detector treats ids as bare
+ * strings — it never inspects shape or relates them to the fan-out
+ * registry's `Subscriber` object identity. Callers pick the id space
+ * (e.g. monotonic stream id from the dispatcher) and feed the same
+ * id to `onAck` and observe it in `check()` output.
+ */
+export type SubscriberId = string;
+
+/**
+ * Options for `createStreamDeadDetector`.
+ */
+export interface StreamDeadDetectorOptions {
+  /**
+   * The liveness window in milliseconds. A subscriber whose most recent
+   * `onAck` (or, if none, its registration timestamp) is older than
+   * `deadlineMs` at the moment `check(now)` is called is considered
+   * dead and returned by `check()`.
+   *
+   * Per spec §6.5.1 the canonical wiring uses
+   * `2 × heartbeatMs + 5_000` — but the formula stays at the caller so
+   * this module is decoupled from the heartbeat interval.
+   *
+   * Must be a positive finite integer.
+   */
+  deadlineMs: number;
+  /**
+   * Optional clock injection for hermetic tests. Defaults to `Date.now`.
+   * Production wiring may pass a monotonic clock if it ever wants to
+   * decouple from wall-clock NTP jumps; v0.3 has no such requirement.
+   */
+  now?: () => number;
+}
+
+export interface StreamDeadDetector {
+  /**
+   * Mark `subscriberId` as freshly observed at `now()` (or at the
+   * timestamp passed in). Idempotent. Implicitly registers the
+   * subscriber if not yet known — this means the first `onAck` after
+   * subscribe acts as a re-arm; callers that want to start the deadline
+   * clock at registration time should additionally call `track()`.
+   */
+  onAck(subscriberId: SubscriberId, at?: number): void;
+  /**
+   * Begin tracking `subscriberId` with `lastAck = at ?? now()` without
+   * counting it as a fresh ack. Used by the wiring layer at subscribe
+   * time so a subscriber that never ack'ed still trips the detector
+   * after `deadlineMs`. Idempotent — re-tracking an already-tracked id
+   * is a no-op (does NOT bump the timestamp; use `onAck` for that).
+   */
+  track(subscriberId: SubscriberId, at?: number): void;
+  /**
+   * Stop tracking `subscriberId`. Used by the wiring layer when the
+   * subscriber leaves voluntarily (registry `unsubscribe`) or when
+   * `check()` flagged it dead and the caller has finished tearing
+   * down. Idempotent — untracking an unknown id is a no-op.
+   */
+  forget(subscriberId: SubscriberId): void;
+  /**
+   * Return the sorted list of subscriber ids whose `lastAck` (or
+   * `track()` timestamp) is **strictly older** than `now - deadlineMs`.
+   * Pure read — does NOT mutate the internal map; callers MUST call
+   * `forget()` after acting on the returned ids, or the next tick will
+   * return the same ids again.
+   *
+   * Sort is ASCII lexical on the id, deterministic for tests and for
+   * the spec §6.5.1 single-aggregated-log-line requirement.
+   *
+   * @param now - timestamp to compare against; defaults to the
+   *   detector's clock (`opts.now ?? Date.now`). Tests pass an explicit
+   *   value for hermeticity.
+   */
+  check(now?: number): SubscriberId[];
+  /**
+   * Number of currently-tracked subscribers. For tests + diagnostics
+   * only; no spec contract.
+   */
+  size(): number;
+}
+
+/**
+ * Create a fresh stream-dead detector. The daemon process holds one
+ * instance shared across all PTY sessions (the shared heartbeat
+ * scheduler at frag-3.5.1 §3.5.1.4 is also process-wide); tests
+ * typically create a fresh instance per case.
+ */
+export function createStreamDeadDetector(
+  opts: StreamDeadDetectorOptions,
+): StreamDeadDetector {
+  if (
+    !Number.isFinite(opts.deadlineMs) ||
+    !Number.isInteger(opts.deadlineMs) ||
+    opts.deadlineMs <= 0
+  ) {
+    throw new RangeError(
+      `stream-dead-detector: deadlineMs must be a positive integer, got ${String(opts.deadlineMs)}`,
+    );
+  }
+  const deadlineMs = opts.deadlineMs;
+  const clock = opts.now ?? Date.now;
+
+  // subscriberId -> last-ack timestamp (ms). Map iteration order is
+  // insertion order in JS, but we sort lexically in `check()` so the
+  // wiring-layer aggregated log line is deterministic across runs.
+  const lastAck = new Map<SubscriberId, number>();
+
+  function onAck(subscriberId: SubscriberId, at?: number): void {
+    lastAck.set(subscriberId, at ?? clock());
+  }
+
+  function track(subscriberId: SubscriberId, at?: number): void {
+    if (lastAck.has(subscriberId)) return;
+    lastAck.set(subscriberId, at ?? clock());
+  }
+
+  function forget(subscriberId: SubscriberId): void {
+    lastAck.delete(subscriberId);
+  }
+
+  function check(now?: number): SubscriberId[] {
+    const t = now ?? clock();
+    const cutoff = t - deadlineMs;
+    const dead: SubscriberId[] = [];
+    for (const [id, ts] of lastAck) {
+      if (ts < cutoff) dead.push(id);
+    }
+    // Stable lexical sort — single aggregated log line in spec §6.5.1
+    // wants reproducible ordering across daemon restarts so log
+    // grepping works.
+    dead.sort();
+    return dead;
+  }
+
+  function size(): number {
+    return lastAck.size;
+  }
+
+  return { onAck, track, forget, check, size };
+}


### PR DESCRIPTION
## Summary
Task #1000 / T44 — pure decider that detects subscribers whose ack stream has gone silent. Lives at the layer above T41 fan-out registry; caller wires returned ids to registry `unsubscribe` + `socket.destroy()` + the `server_stream_dead` log line.

## Spec
- `docs/superpowers/specs/v0.3-design.md` frag-3.5.1 §3.5.1.4 — client-side dead-stream detection at `2 x heartbeatMs + 5 s`; cross-frag handoff to symmetric server-side.
- `docs/superpowers/specs/v0.3-design.md` frag-6-7 §6.5.1 (lines 1695-1714, round-7 manager lock, r6 reliability P0-R2) — canonical server-side stream-dead detector. Daemon maintains `lastClientActivityAt`; the shared heartbeat scheduler checks `now - lastClientActivityAt > 2 x heartbeatMs + 5 s`. v0.3 local-pipe transport makes this a no-op in practice (kernel `'close'` fires first), but byte-compatible with the v0.5 CF Tunnel TCP swap where half-open sockets need an application-layer detector.

## Deadline contract
- `deadlineMs` is computed by the caller (typically `2 x heartbeatMs + 5_000` per spec §6.5.1 — formula owned by the heartbeat scheduler so a single source of truth survives `x-ccsm-heartbeat-ms` renegotiation, frag-3.4.1 §3.4.1.c).
- Boundary: `check(now)` returns ids whose `lastAck` is **strictly older** than `now - deadlineMs`. Equal age = alive.
- Sort: ASCII lexical, deterministic for the spec's single-aggregated-log-line rule.

## Single Responsibility
- **Producer**: caller feeds `onAck(subscriberId)` on inbound RPC / client frame on the same connection (spec line 1701).
- **Decider**: pure `check(now)` — read-only over the in-memory map.
- **Not a sink**: does NOT close sockets, does NOT touch the fan-out registry, does NOT emit log lines. Wiring layer owns those side effects (spec §6.5.1 steps 2-4).
- **Not a heartbeat sender**: T42 owns the shared heartbeat scheduler; this module only watches the OTHER direction (subs that stop ack'ing).

## Caller wiring note
Wiring layer (T42 producer / shared heartbeat scheduler) is expected to:
1. Call `track(subId)` at fan-out subscribe time so a never-ack'ed sub still trips after `deadlineMs`.
2. Call `onAck(subId)` on every inbound RPC / client frame on the connection backing that subscriber.
3. Tick `check(now)` once per scheduler iteration (existing 1 s tick per spec line 1712).
4. For each returned id: emit one structured `server_stream_dead` log line (spec §6.5.1 step 3 — single aggregated line per connection close), call registry `unsubscribe`, `socket.destroy()` the underlying connection, then `forget(subId)`. (Without `forget`, the next tick returns the same id — by design, so a half-finished teardown still makes progress.)

## Test plan
- [x] `npx tsc --noEmit -p daemon/tsconfig.json` — clean
- [x] `npx vitest run daemon/src/pty/__tests__/stream-dead-detector.test.ts` — 16/16 pass
- [x] `npm run build:daemon` + `import('./daemon/dist-daemon/pty/stream-dead-detector.js')` smoke — loads in Node ESM
- [x] Hermetic clock: tests inject a clock that throws unless callers pass explicit timestamps; covers the v0.5 monotonic-clock substitution path.

Tests cover: construction validation, age boundary (`<` not `<=`), `onAck` re-arm + implicit register, `track` no-op on duplicate, `check` purity, `forget` idempotency, mixed live + dead set, ASCII-sorted output, 100-subscriber fan-out, clock-injection fallback.