### PR TITLE
feat(daemon): T20 daemon.shutdown handler (graceful sequence)

### DIFF
--- a/daemon/src/handlers/__tests__/daemon-shutdown.test.ts
+++ b/daemon/src/handlers/__tests__/daemon-shutdown.test.ts
@@ -1,0 +1,349 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  createDaemonShutdownHandler,
+  DAEMON_SHUTDOWN_METHOD,
+  SHUTDOWN_DEFAULT_DEADLINE_MS,
+  SHUTDOWN_PLAN,
+  SHUTDOWN_STEPS,
+  type DaemonShutdownContext,
+  type ShutdownActions,
+  type ShutdownStep,
+} from '../daemon-shutdown.js';
+import { isSupervisorRpc } from '../../envelope/supervisor-rpcs.js';
+
+function makeActions(overrides: Partial<ShutdownActions> = {}): ShutdownActions & {
+  callOrder: ShutdownStep[];
+} {
+  const callOrder: ShutdownStep[] = [];
+  const record = (step: ShutdownStep) => {
+    callOrder.push(step);
+  };
+  const base: ShutdownActions = {
+    markDraining: vi.fn(() => {
+      record('mark-draining');
+    }),
+    clearHeartbeats: vi.fn(() => {
+      record('clear-heartbeats');
+    }),
+    rejectPendingCalls: vi.fn(() => {
+      record('reject-pending');
+    }),
+    drainSnapshotSemaphore: vi.fn((_reason: string) => {
+      record('drain-snapshot-semaphore');
+    }),
+    windDownSessions: vi.fn((_opts) => {
+      record('wind-down-sessions');
+    }),
+    closeSubscribers: vi.fn((_reason: string) => {
+      record('close-subscribers');
+    }),
+    finalizeLogger: vi.fn(() => {
+      record('finalize-logger');
+    }),
+    exitProcess: vi.fn((_code: number) => {
+      record('exit-process');
+    }),
+    recordStepError: vi.fn(),
+    recordDeadlineOverrun: vi.fn(),
+  };
+  return Object.assign({ callOrder }, base, overrides);
+}
+
+const ctx: DaemonShutdownContext = {
+  traceId: '01HZZZTESTULIDXXXXXXXXX0',
+  bootNonce: '01HZZZBOOTNONCEXXXXXXXX0',
+};
+
+describe('daemon.shutdown handler (T20 — frag-6-7 §6.6.1)', () => {
+  describe('contract / spec wiring', () => {
+    it('method literal is on SUPERVISOR_RPCS allowlist', () => {
+      expect(DAEMON_SHUTDOWN_METHOD).toBe('daemon.shutdown');
+      expect(isSupervisorRpc(DAEMON_SHUTDOWN_METHOD)).toBe(true);
+    });
+
+    it('SHUTDOWN_PLAN is in the canonical spec order', () => {
+      expect(SHUTDOWN_PLAN.map((s) => s.step)).toEqual([
+        'mark-draining',
+        'clear-heartbeats',
+        'reject-pending',
+        'drain-snapshot-semaphore',
+        'wind-down-sessions',
+        'close-subscribers',
+        'finalize-logger',
+        'exit-process',
+      ]);
+    });
+
+    it('SHUTDOWN_STEPS and SHUTDOWN_PLAN agree', () => {
+      expect(SHUTDOWN_PLAN.map((s) => s.step)).toEqual([...SHUTDOWN_STEPS]);
+    });
+
+    it('SHUTDOWN_PLAN is frozen', () => {
+      expect(Object.isFrozen(SHUTDOWN_PLAN)).toBe(true);
+    });
+
+    it('every plan step carries a spec ref', () => {
+      for (const s of SHUTDOWN_PLAN) {
+        expect(s.specRef).toMatch(/frag-(3\.5\.1|6-7)/);
+        expect(s.description.length).toBeGreaterThan(10);
+      }
+    });
+  });
+
+  describe('ack returned promptly (before side effects)', () => {
+    it('handle() resolves with ack BEFORE process.exit runs', async () => {
+      // Block markDraining so the drain chain cannot complete; verify the
+      // ack still resolves and exitProcess has NOT been called yet.
+      let release: (() => void) | undefined;
+      const blocker = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const actions = makeActions({
+        markDraining: vi.fn(async () => {
+          await blocker;
+        }),
+      });
+      const h = createDaemonShutdownHandler(actions);
+      const reply = await h.handle(undefined, ctx);
+      expect(reply.ack).toBe('ok');
+      expect(reply.idempotency).toBe('first');
+      expect(reply.bootNonce).toBe(ctx.bootNonce);
+      expect(reply.planSteps).toEqual([...SHUTDOWN_STEPS]);
+      // Drain chain is parked at markDraining — exit MUST NOT have fired.
+      expect(actions.exitProcess).not.toHaveBeenCalled();
+      expect(actions.finalizeLogger).not.toHaveBeenCalled();
+      release!();
+      await h.whenDrained();
+      expect(actions.exitProcess).toHaveBeenCalledWith(0);
+    });
+
+    it('default deadline is 5_000 ms when caller omits', async () => {
+      const h = createDaemonShutdownHandler(makeActions());
+      const reply = await h.handle(undefined, ctx);
+      expect(reply.deadlineMs).toBe(SHUTDOWN_DEFAULT_DEADLINE_MS);
+      expect(reply.deadlineMs).toBe(5_000);
+    });
+
+    it('caller-supplied deadline is respected (after clamp)', async () => {
+      const h = createDaemonShutdownHandler(makeActions());
+      const reply = await h.handle({ deadlineMs: 2_000 }, ctx);
+      expect(reply.deadlineMs).toBe(2_000);
+    });
+
+    it.each([
+      [0, SHUTDOWN_DEFAULT_DEADLINE_MS],
+      [-1, SHUTDOWN_DEFAULT_DEADLINE_MS],
+      [Number.NaN, SHUTDOWN_DEFAULT_DEADLINE_MS],
+      [Number.POSITIVE_INFINITY, SHUTDOWN_DEFAULT_DEADLINE_MS],
+      [10, 50], // clamped UP to 50ms floor
+      [10_000_000, 60_000], // clamped DOWN to 60s ceiling
+    ])('clamps %j → %j', async (input, expected) => {
+      const h = createDaemonShutdownHandler(makeActions());
+      const reply = await h.handle({ deadlineMs: input }, ctx);
+      expect(reply.deadlineMs).toBe(expected);
+    });
+  });
+
+  describe('actions invoked in spec order', () => {
+    it('runs all 8 steps in canonical order', async () => {
+      const actions = makeActions();
+      const h = createDaemonShutdownHandler(actions);
+      await h.handle(undefined, ctx);
+      const ran = await h.whenDrained();
+      expect(actions.callOrder).toEqual([...SHUTDOWN_STEPS]);
+      expect(ran).toEqual([...SHUTDOWN_STEPS]);
+    });
+
+    it('passes the reason string to the drain sinks', async () => {
+      const actions = makeActions();
+      const h = createDaemonShutdownHandler(actions);
+      await h.handle({ reason: 'uninstall' }, ctx);
+      await h.whenDrained();
+      expect(actions.drainSnapshotSemaphore).toHaveBeenCalledWith('uninstall');
+      expect(actions.closeSubscribers).toHaveBeenCalledWith('uninstall');
+    });
+
+    it("default reason is 'daemon-shutdown' (matches spec log event)", async () => {
+      const actions = makeActions();
+      const h = createDaemonShutdownHandler(actions);
+      await h.handle(undefined, ctx);
+      await h.whenDrained();
+      expect(actions.drainSnapshotSemaphore).toHaveBeenCalledWith('daemon-shutdown');
+      expect(actions.closeSubscribers).toHaveBeenCalledWith('daemon-shutdown');
+    });
+
+    it('passes 200ms per-child deadline to wind-down (§6.6.1 step 4)', async () => {
+      const actions = makeActions();
+      const h = createDaemonShutdownHandler(actions);
+      await h.handle(undefined, ctx);
+      await h.whenDrained();
+      expect(actions.windDownSessions).toHaveBeenCalledWith({ perChildDeadlineMs: 200 });
+    });
+
+    it('exits with code 0', async () => {
+      const actions = makeActions();
+      const h = createDaemonShutdownHandler(actions);
+      await h.handle(undefined, ctx);
+      await h.whenDrained();
+      expect(actions.exitProcess).toHaveBeenCalledWith(0);
+      expect(actions.exitProcess).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('error tolerance (partial drain over silent abort)', () => {
+    it('continues running subsequent steps when a middle step throws', async () => {
+      const actions = makeActions({
+        windDownSessions: vi.fn(() => {
+          throw new Error('SIGCHLD reap failed');
+        }),
+      });
+      const h = createDaemonShutdownHandler(actions);
+      await h.handle(undefined, ctx);
+      await h.whenDrained();
+      // exit-process MUST still be called even though wind-down threw —
+      // §6.6.1 partial-drain principle.
+      expect(actions.finalizeLogger).toHaveBeenCalled();
+      expect(actions.exitProcess).toHaveBeenCalledWith(0);
+      expect(actions.recordStepError).toHaveBeenCalledWith(
+        'wind-down-sessions',
+        expect.any(Error),
+      );
+    });
+
+    it('async rejection is captured by recordStepError', async () => {
+      const actions = makeActions({
+        closeSubscribers: vi.fn(async () => {
+          throw new Error('subscriber map locked');
+        }),
+      });
+      const h = createDaemonShutdownHandler(actions);
+      await h.handle(undefined, ctx);
+      await h.whenDrained();
+      expect(actions.recordStepError).toHaveBeenCalledWith(
+        'close-subscribers',
+        expect.any(Error),
+      );
+      expect(actions.finalizeLogger).toHaveBeenCalled();
+      expect(actions.exitProcess).toHaveBeenCalled();
+    });
+  });
+
+  describe('idempotency (second daemon.shutdown is a no-op)', () => {
+    it('second call returns ack with idempotency=replay and runs no actions', async () => {
+      const actions = makeActions();
+      const h = createDaemonShutdownHandler(actions);
+      const first = await h.handle(undefined, ctx);
+      await h.whenDrained();
+      const callCountAfterFirst = (actions.markDraining as ReturnType<typeof vi.fn>).mock.calls
+        .length;
+
+      const second = await h.handle(undefined, ctx);
+      expect(first.idempotency).toBe('first');
+      expect(second.idempotency).toBe('replay');
+      expect(second.ack).toBe('ok');
+      expect(second.planSteps).toEqual([...SHUTDOWN_STEPS]);
+
+      // No additional action invocations.
+      expect((actions.markDraining as ReturnType<typeof vi.fn>).mock.calls.length).toBe(
+        callCountAfterFirst,
+      );
+      expect((actions.exitProcess as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1);
+    });
+
+    it('replay returns the deadline from the first call', async () => {
+      const h = createDaemonShutdownHandler(makeActions());
+      await h.handle({ deadlineMs: 1_500 }, ctx);
+      const replay = await h.handle({ deadlineMs: 9_999 }, ctx);
+      expect(replay.deadlineMs).toBe(1_500);
+    });
+
+    it('concurrent re-call mid-drain returns replay (state=draining)', async () => {
+      // Block the drain on a controllable promise so we can re-enter while
+      // the state is still 'draining'.
+      let release: (() => void) | undefined;
+      const blocker = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const actions = makeActions({
+        markDraining: vi.fn(async () => {
+          await blocker;
+        }),
+      });
+      const h = createDaemonShutdownHandler(actions);
+      const first = await h.handle(undefined, ctx);
+      expect(h.state).toBe('draining');
+      const second = await h.handle(undefined, ctx);
+      expect(first.idempotency).toBe('first');
+      expect(second.idempotency).toBe('replay');
+      release!();
+      await h.whenDrained();
+      expect(h.state).toBe('drained');
+    });
+  });
+
+  describe('deadline overrun reporting (T25 escalation hook)', () => {
+    it('invokes recordDeadlineOverrun when wall-clock > deadlineMs at close-subscribers', async () => {
+      const actions = makeActions({
+        windDownSessions: vi.fn(async () => {
+          await new Promise<void>((r) => setTimeout(r, 80));
+        }),
+      });
+      const h = createDaemonShutdownHandler(actions);
+      await h.handle({ deadlineMs: 50 }, ctx);
+      await h.whenDrained();
+      expect(actions.recordDeadlineOverrun).toHaveBeenCalledWith(
+        expect.any(Number),
+        50,
+      );
+      const [elapsed, deadline] = (
+        actions.recordDeadlineOverrun as ReturnType<typeof vi.fn>
+      ).mock.calls[0]!;
+      expect(elapsed).toBeGreaterThanOrEqual(deadline);
+    });
+
+    it('does NOT invoke recordDeadlineOverrun when within deadline', async () => {
+      const actions = makeActions();
+      const h = createDaemonShutdownHandler(actions);
+      await h.handle({ deadlineMs: 60_000 }, ctx);
+      await h.whenDrained();
+      expect(actions.recordDeadlineOverrun).not.toHaveBeenCalled();
+    });
+
+    it('still calls finalize-logger + exit even after deadline overrun', async () => {
+      const actions = makeActions({
+        windDownSessions: vi.fn(async () => {
+          await new Promise<void>((r) => setTimeout(r, 80));
+        }),
+      });
+      const h = createDaemonShutdownHandler(actions);
+      await h.handle({ deadlineMs: 50 }, ctx);
+      await h.whenDrained();
+      expect(actions.finalizeLogger).toHaveBeenCalled();
+      expect(actions.exitProcess).toHaveBeenCalledWith(0);
+    });
+  });
+
+  describe('integration with T16 dispatcher', () => {
+    it('handler can be registered as the daemon.shutdown stub replacement', async () => {
+      const { Dispatcher } = await import('../../dispatcher.js');
+      const actions = makeActions();
+      const h = createDaemonShutdownHandler(actions);
+      const d = new Dispatcher();
+      d.register(DAEMON_SHUTDOWN_METHOD, async (req, dctx) =>
+        h.handle(req as Parameters<typeof h.handle>[0], { traceId: dctx.traceId }),
+      );
+      const r = await d.dispatch(
+        DAEMON_SHUTDOWN_METHOD,
+        { reason: 'manual' },
+        { traceId: ctx.traceId },
+      );
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      const reply = r.value as { ack: string; idempotency: string };
+      expect(reply.ack).toBe('ok');
+      expect(reply.idempotency).toBe('first');
+      await h.whenDrained();
+      expect(actions.exitProcess).toHaveBeenCalledWith(0);
+    });
+  });
+});

--- a/daemon/src/handlers/daemon-shutdown.ts
+++ b/daemon/src/handlers/daemon-shutdown.ts
@@ -1,0 +1,373 @@
+// T20 — daemon.shutdown handler (graceful drain sequence).
+//
+// Spec citations:
+//   - docs/superpowers/specs/v0.3-fragments/frag-6-7-reliability-security.md
+//     §6.6.1 "Daemon-side logger" → ordered shutdown sequence (the
+//     authoritative 7-step drain ordering, r2-obs P0-3 + r3-rel P0-R1).
+//   - docs/superpowers/specs/v0.3-fragments/frag-3.5.1-pty-hardening.md
+//     §3.5.1.2 step 5 (snapshot semaphore drain on shutdown).
+//   - docs/superpowers/specs/v0.3-fragments/frag-3.4.1-envelope-hardening.md
+//     §3.4.1.h (this RPC is on the SUPERVISOR_RPCS allowlist; routed by T16
+//     dispatcher).
+//   - docs/superpowers/specs/v0.3-design.md §6.4 (this `daemon.shutdown` RPC
+//     is the uninstall/manual path — distinct from `daemon.shutdownForUpgrade`
+//     T21 which writes the atomic marker file. T20 writes NO marker.)
+//
+// Single Responsibility (per feedback_single_responsibility):
+//   - Decider (this module): builds the ordered shutdown plan from a fixed
+//     spec table and runs the steps in order against an injected actions
+//     provider. Owns step ordering, idempotency, deadline accounting.
+//   - Producer: T14 control-socket transport receives the inbound envelope
+//     and calls `createDaemonShutdownHandler(actions).handle(req, ctx)`.
+//   - Sinks: every actual side effect (stop accepting spawns, drain the
+//     snapshot semaphore, mark sessions shutting_down/paused, close
+//     subscribers, checkpoint+close DB, pino.final, process.exit) lives
+//     behind the `ShutdownActions` interface. The handler invokes them in
+//     spec order and never performs the I/O itself. This keeps the handler
+//     testable end-to-end with vi.fn() mocks and lets each action evolve
+//     independently as the corresponding subsystem (T37 lifecycle, T40
+//     semaphore, T41 fan-out, T28 schema, T22 marker) lands.
+//
+// What this handler does NOT own (deferred to other tasks):
+//   - T25 force-kill fallback after the deadline elapses. The plan exposes
+//     `forceKillDeadlineMs` (5_000 ms) and the handler logs / records
+//     deadline overrun; the actual SIGKILL escalation is T25 territory.
+//   - The atomic shutdown marker write (T21 `daemon.shutdownForUpgrade`).
+//     T20 explicitly skips this — the spec distinguishes the two RPCs by
+//     marker presence so the supervisor crash-loop counter (frag-6-7 §6.1)
+//     can tell upgrade-clean from manual/uninstall shutdown.
+//   - `pino.final` flush + `process.exit(0)`: these are sinks injected by
+//     `actions.finalizeLogger` and `actions.exitProcess`. The handler
+//     resolves its reply BEFORE invoking exit so the ack reaches the wire.
+
+import { isSupervisorRpc } from '../envelope/supervisor-rpcs.js';
+
+/** Ordered step identifiers — match the spec sequence in §6.6.1 1..7 (the
+ *  pure-pino step 6 is collapsed into `finalizeLogger` here; `exitProcess`
+ *  is step 7). The literal strings appear in the plan + log lines so a
+ *  reader can grep §6.6.1 step N → this handler. */
+export const SHUTDOWN_STEPS = [
+  'mark-draining', // step 1: state = 'draining' (rejects new spawns/subscribes).
+  'clear-heartbeats', // step 2: clearInterval all per-stream heartbeats.
+  'reject-pending', // step 3: aggregate-reject pending bridge calls.
+  'drain-snapshot-semaphore', // §3.5.1.2 step 5: cancel queued snapshot waiters.
+  'wind-down-sessions', // step 4: SIGTERM/SIGKILL children, mark exited/paused, WAL checkpoint, db.close.
+  'close-subscribers', // step 5: drain fan-out registry, ONE aggregated log line.
+  'finalize-logger', // step 6: pino.final flush.
+  'exit-process', // step 7: process.exit(0).
+] as const;
+
+export type ShutdownStep = (typeof SHUTDOWN_STEPS)[number];
+
+/**
+ * Why each step exists, lifted from §6.6.1 + §3.5.1.2 + §3.5.1.5 — kept on
+ * the plan so the wire response is self-explanatory and the spec ordering is
+ * machine-checkable from a snapshot test. The order MUST NOT change without
+ * a spec edit (r3-rel R1 reorder lock).
+ */
+export interface ShutdownPlanStep {
+  readonly step: ShutdownStep;
+  readonly specRef: string;
+  readonly description: string;
+}
+
+/** Authoritative, ordered, frozen plan. Exported for snapshot tests + for
+ *  T21 (shutdownForUpgrade) to layer the marker write on top of the same
+ *  drain sequence without re-deriving the ordering. */
+export const SHUTDOWN_PLAN: readonly ShutdownPlanStep[] = Object.freeze([
+  {
+    step: 'mark-draining',
+    specRef: 'frag-6-7 §6.6.1 step 1',
+    description:
+      "set daemonState='draining'; reject new pty.spawn() and ptySubscribe with RESOURCE_EXHAUSTED { reason: 'daemon-shutdown' }",
+  },
+  {
+    step: 'clear-heartbeats',
+    specRef: 'frag-6-7 §6.6.1 step 2',
+    description: 'clearInterval every per-stream heartbeat timer (frag-3.5.1 §3.5.1.4)',
+  },
+  {
+    step: 'reject-pending',
+    specRef: 'frag-6-7 §6.6.1 step 3',
+    description:
+      'reject pending reconnect-queue / in-flight bridge calls; ONE aggregated log line { event: "daemon-shutdown", droppedCalls: N }',
+  },
+  {
+    step: 'drain-snapshot-semaphore',
+    specRef: 'frag-3.5.1 §3.5.1.2 step 5',
+    description:
+      "drain the snapshot semaphore: queued waiters reject with CANCELLED { reason: 'daemon-shutdown' }; in-flight holders keep their permits",
+  },
+  {
+    step: 'wind-down-sessions',
+    specRef: 'frag-6-7 §6.6.1 step 4',
+    description:
+      "mark running→shutting_down (one txn); SIGTERM each pgroup, 200ms per child; SIGKILL survivors; sweep shutting_down→paused (UPDATE … WHERE state='shutting_down'); PRAGMA wal_checkpoint(TRUNCATE); db.close()",
+  },
+  {
+    step: 'close-subscribers',
+    specRef: 'frag-6-7 §6.6.1 step 5',
+    description:
+      "iterate fan-out subscriber registry once; close each with RESOURCE_EXHAUSTED reason='daemon-shutdown'; ONE aggregated { event: 'subscribers-closed', count: N } line",
+  },
+  {
+    step: 'finalize-logger',
+    specRef: 'frag-6-7 §6.6.1 step 6',
+    description: 'pino.final flushes destination buffer (last logging act)',
+  },
+  {
+    step: 'exit-process',
+    specRef: 'frag-6-7 §6.6.1 step 7',
+    description: 'process.exit(0) — clean exit, supervisor sees normal child reap',
+  },
+]);
+
+// Spec contract: the shutdown deadline is owned by the caller (electron-main
+// uses 2 s for uninstall per §11.6.4, 5 s for upgrade per §11.6.5). The
+// handler defaults to 5 s if the caller omits a deadline; T25 owns the
+// post-deadline force-kill escalation that overlays this handler.
+export const SHUTDOWN_DEFAULT_DEADLINE_MS = 5_000 as const;
+
+/**
+ * Inbound payload — see §6.6.1 (no formal schema in spec; v0.3 RPCs use
+ * TypeBox per §3.4.1.d and the validation lives at the envelope layer). For
+ * the handler we only consume the optional `deadlineMs` override.
+ */
+export interface DaemonShutdownRequest {
+  readonly deadlineMs?: number;
+  /** Optional human reason recorded on the ack + structured log line.
+   *  Examples: 'uninstall', 'manual', 'tray-quit'. NOT 'upgrade' — that
+   *  request goes through `daemon.shutdownForUpgrade` (T21). */
+  readonly reason?: string;
+}
+
+/** The wire reply. Returned BEFORE side-effecting steps run so the ack
+ *  reaches the supervisor before the daemon exits. */
+export interface DaemonShutdownReply {
+  readonly ack: 'ok';
+  readonly bootNonce?: string;
+  readonly deadlineMs: number;
+  /** Plan steps in execution order — readable forensic field, also lets
+   *  the supervisor verify the daemon understood the contract. */
+  readonly planSteps: readonly ShutdownStep[];
+  /** First call returns 'first', subsequent calls return 'replay' so the
+   *  caller can distinguish initial ack from idempotent re-ack. */
+  readonly idempotency: 'first' | 'replay';
+}
+
+/**
+ * Side-effect provider — every method is invoked at most once per shutdown.
+ * Each method MAY be async; the handler awaits in spec order. Errors thrown
+ * from any action are caught, logged via `recordStepError`, and the
+ * sequence CONTINUES — partial drain is better than silent abort. After
+ * `wind-down-sessions` and `close-subscribers` the handler MUST still call
+ * `finalizeLogger` + `exitProcess` so the daemon does not hang.
+ *
+ * Test doubles construct a `ShutdownActions` with all methods as
+ * `vi.fn().mockResolvedValue(undefined)` and assert call order via
+ * `toHaveBeenCalledBefore`.
+ */
+export interface ShutdownActions {
+  /** Step 1 — flip module-level `daemonState='draining'`. After this resolves
+   *  the producer-side gates MUST reject new sessions/subscribes. */
+  markDraining(): Promise<void> | void;
+  /** Step 2 — clearInterval over the streamHeartbeats Set. */
+  clearHeartbeats(): Promise<void> | void;
+  /** Step 3 — reject pending reconnect-queue / in-flight bridge calls;
+   *  emit ONE aggregated `{event:"daemon-shutdown",droppedCalls:N}` line. */
+  rejectPendingCalls(): Promise<void> | void;
+  /** Step 4a (§3.5.1.2 step 5) — drain snapshot semaphore queued waiters. */
+  drainSnapshotSemaphore(reason: string): Promise<void> | void;
+  /** Step 4b (§6.6.1 step 4) — SIGTERM PG, 200ms wait, SIGKILL survivors,
+   *  paused sweep, WAL checkpoint, db.close. Owns the per-child deadline. */
+  windDownSessions(opts: { perChildDeadlineMs: number }): Promise<void> | void;
+  /** Step 5 (§6.6.1 step 5) — close fan-out subscribers; ONE aggregated
+   *  `{event:"subscribers-closed",count:N}` line. */
+  closeSubscribers(reason: string): Promise<void> | void;
+  /** Step 6 — `pino.final()` flush. After this MUST NOT be followed by
+   *  any further `logger.*` calls. */
+  finalizeLogger(): Promise<void> | void;
+  /** Step 7 — `process.exit(0)`. The handler awaits this; in tests pass a
+   *  resolved no-op so the test process doesn't actually exit. */
+  exitProcess(code: number): Promise<void> | void;
+  /** Telemetry sink — invoked when an action throws. The handler does NOT
+   *  re-throw so subsequent steps still run. Implementation should log via
+   *  pino with the step name + spec ref. */
+  recordStepError(step: ShutdownStep, err: unknown): void;
+  /** Optional — record deadline overrun (the wall-clock from
+   *  `markDraining` start to `closeSubscribers` end exceeded `deadlineMs`).
+   *  T25 owns the actual SIGKILL escalation; this hook lets the handler
+   *  surface the timing without entangling its sink. */
+  recordDeadlineOverrun?(elapsedMs: number, deadlineMs: number): void;
+}
+
+export interface DaemonShutdownContext {
+  /** Caller-supplied trace ID — forwarded to `recordStepError` via the
+   *  pino logger the action provider closes over. The handler itself does
+   *  NOT log — staying out of the I/O business. */
+  readonly traceId?: string;
+  /** Daemon boot nonce — included in the ack so the supervisor can match
+   *  the reply to the daemon instance it asked to shut down. */
+  readonly bootNonce?: string;
+}
+
+export interface DaemonShutdownHandler {
+  /** Wire-facing entry point. Called by T16 dispatcher with the inbound
+   *  payload. Resolves with the ack reply. Side-effecting steps execute
+   *  asynchronously after the reply resolves (`queueMicrotask`) so the
+   *  ack envelope is on the wire before the daemon starts exiting. */
+  handle(
+    req: DaemonShutdownRequest | undefined,
+    ctx: DaemonShutdownContext,
+  ): Promise<DaemonShutdownReply>;
+  /** Test-facing — wait for the side-effect chain (spawned by handle) to
+   *  settle. Production callers do not need this; the daemon process is
+   *  about to exit anyway. Resolves with the steps that actually ran. */
+  whenDrained(): Promise<readonly ShutdownStep[]>;
+  /** Test-facing — current internal idempotency state. */
+  readonly state: 'idle' | 'draining' | 'drained';
+}
+
+/** Method literal — kept here as a constant so callers do not stringly
+ *  spell `'daemon.shutdown'` at the wiring site. */
+export const DAEMON_SHUTDOWN_METHOD = 'daemon.shutdown' as const;
+
+// Compile-time guard: the literal MUST be on the supervisor allowlist or
+// T16 dispatcher would reject it as NOT_ALLOWED. We surface this as a runtime
+// assertion at module load to fail loud during boot rather than at first RPC.
+if (!isSupervisorRpc(DAEMON_SHUTDOWN_METHOD)) {
+  // c8 ignore next 3 — defensive; the allowlist is constant.
+  throw new Error(
+    `daemon-shutdown handler boot guard: ${DAEMON_SHUTDOWN_METHOD} missing from SUPERVISOR_RPCS (frag-3.4.1 §3.4.1.h)`,
+  );
+}
+
+/**
+ * Build a handler bound to a concrete `ShutdownActions` provider.
+ *
+ * Lifecycle / idempotency:
+ *   - First call: state idle → draining; return `{ idempotency: 'first', ... }`
+ *     and schedule the side-effect chain.
+ *   - Concurrent re-call (state draining): return `{ idempotency: 'replay' }`
+ *     immediately — NO actions invoked.
+ *   - Post-drain re-call (state drained): same as concurrent — replay ack.
+ */
+export function createDaemonShutdownHandler(
+  actions: ShutdownActions,
+): DaemonShutdownHandler {
+  let state: 'idle' | 'draining' | 'drained' = 'idle';
+  let firstReply: DaemonShutdownReply | null = null;
+  let drainPromise: Promise<readonly ShutdownStep[]> | null = null;
+
+  function clampDeadline(reqMs: number | undefined): number {
+    if (typeof reqMs !== 'number' || !Number.isFinite(reqMs) || reqMs <= 0) {
+      return SHUTDOWN_DEFAULT_DEADLINE_MS;
+    }
+    // Hard floor: a 0/negative deadline is meaningless; hard ceiling avoids
+    // a malicious / typo'd 24h hang. 60 s is well above the spec's 5 s
+    // upgrade window and the daemon's own 200 ms × 20 sessions = 4 s
+    // worst-case wind-down (§6.6.1 step 4).
+    return Math.min(Math.max(Math.trunc(reqMs), 50), 60_000);
+  }
+
+  async function runDrainSequence(reason: string, deadlineMs: number): Promise<readonly ShutdownStep[]> {
+    const ran: ShutdownStep[] = [];
+    const startMs = Date.now();
+    let overrunReported = false;
+
+    // The 4 "drain" steps run BEFORE we check the deadline-overrun hook.
+    // `finalize-logger` + `exit-process` always run, even on overrun, because
+    // the daemon must not be left hanging (T25 owns the escalation, but the
+    // process MUST still exit).
+    type StepDef = readonly [ShutdownStep, () => Promise<void> | void];
+    const steps: readonly StepDef[] = [
+      ['mark-draining', () => actions.markDraining()],
+      ['clear-heartbeats', () => actions.clearHeartbeats()],
+      ['reject-pending', () => actions.rejectPendingCalls()],
+      ['drain-snapshot-semaphore', () => actions.drainSnapshotSemaphore(reason)],
+      ['wind-down-sessions', () => actions.windDownSessions({ perChildDeadlineMs: 200 })],
+      ['close-subscribers', () => actions.closeSubscribers(reason)],
+      ['finalize-logger', () => actions.finalizeLogger()],
+      ['exit-process', () => actions.exitProcess(0)],
+    ];
+
+    for (const [step, fn] of steps) {
+      try {
+        await fn();
+        ran.push(step);
+      } catch (err) {
+        // Spec §6.6.1: partial drain is better than silent abort. Record +
+        // continue so subsequent sinks (DB close, logger flush, exit) still
+        // get to run.
+        actions.recordStepError(step, err);
+        ran.push(step); // record attempted — caller can grep recordStepError to see failure.
+      }
+      // After `close-subscribers` (the LAST runtime act per §6.6.1 step 5)
+      // check whether we blew the deadline. `finalize-logger` and
+      // `exit-process` are bookkeeping; the deadline applies to the
+      // user-observable drain only.
+      if (!overrunReported && step === 'close-subscribers') {
+        const elapsed = Date.now() - startMs;
+        if (elapsed > deadlineMs && actions.recordDeadlineOverrun) {
+          actions.recordDeadlineOverrun(elapsed, deadlineMs);
+          overrunReported = true;
+        }
+      }
+    }
+
+    state = 'drained';
+    return Object.freeze(ran);
+  }
+
+  return {
+    get state() {
+      return state;
+    },
+    async handle(req, ctx) {
+      if (state !== 'idle') {
+        // Idempotent replay — same ack shape, idempotency: 'replay'.
+        // We DELIBERATELY do not re-run any actions even if the original
+        // run failed — re-running step 1 (mark-draining) on a partially
+        // drained daemon would be a no-op anyway (state already draining)
+        // but re-running step 4 (wind-down) could double-SIGKILL surviving
+        // children. Caller observes failure via `recordStepError` log lines.
+        return {
+          ack: 'ok',
+          bootNonce: ctx.bootNonce,
+          deadlineMs: firstReply?.deadlineMs ?? SHUTDOWN_DEFAULT_DEADLINE_MS,
+          planSteps: SHUTDOWN_PLAN.map((s) => s.step),
+          idempotency: 'replay',
+        };
+      }
+
+      state = 'draining';
+      const deadlineMs = clampDeadline(req?.deadlineMs);
+      const reason = req?.reason ?? 'daemon-shutdown';
+      const reply: DaemonShutdownReply = {
+        ack: 'ok',
+        bootNonce: ctx.bootNonce,
+        deadlineMs,
+        planSteps: SHUTDOWN_PLAN.map((s) => s.step),
+        idempotency: 'first',
+      };
+      firstReply = reply;
+
+      // Schedule the drain AFTER the ack resolves so the wire reply is
+      // observable to the supervisor before `process.exit` runs. Promise
+      // construction is synchronous; the actual chain runs on the next
+      // microtask. We capture the promise so `whenDrained()` can await it
+      // in tests.
+      drainPromise = Promise.resolve().then(() => runDrainSequence(reason, deadlineMs));
+      // Surface unexpected rejections to the action provider so they cannot
+      // become silent unhandledRejections — every per-step throw is already
+      // caught above; this is belt-and-braces for the orchestration itself.
+      drainPromise.catch((err) => actions.recordStepError('exit-process', err));
+
+      return reply;
+    },
+    async whenDrained() {
+      if (!drainPromise) return Object.freeze<readonly ShutdownStep[]>([]);
+      return drainPromise;
+    },
+  };
+}

--- a/daemon/src/index.ts
+++ b/daemon/src/index.ts
@@ -2,15 +2,15 @@ import { ulid } from 'ulid';
 import pino from 'pino';
 import { createRequire } from 'node:module';
 import { createSupervisorDispatcher } from './dispatcher.js';
+import {
+  createDaemonShutdownHandler,
+  DAEMON_SHUTDOWN_METHOD,
+  type ShutdownActions,
+  type ShutdownStep,
+} from './handlers/daemon-shutdown.js';
 
 const require = createRequire(import.meta.url);
 const DAEMON_VERSION = (require('../../package.json') as { version: string }).version;
-
-// T16 wires the control-socket dispatcher; T17–T21 each replace one of the
-// SUPERVISOR_RPCS stubs (NOT_IMPLEMENTED today) with a real handler. The
-// transport binding (T14) consumes this dispatcher from a Duplex socket.
-const supervisorDispatcher = createSupervisorDispatcher();
-void supervisorDispatcher;
 
 const bootNonce = ulid();
 
@@ -23,11 +23,67 @@ const logger = pino({
   },
 });
 
+// T20 — real daemon.shutdown handler replaces the NOT_IMPLEMENTED stub. The
+// per-subsystem sinks (T37 lifecycle, T40 semaphore, T41 fan-out, T28 schema)
+// are still landing; for now we wire log-only sinks that observe the spec
+// ordering. As each subsystem lands its driver, swap the corresponding action
+// here for the real I/O — the handler stays pure.
+const shutdownActions: ShutdownActions = {
+  markDraining: () => {
+    logger.info({ event: 'daemon-shutdown', step: 'mark-draining' }, 'state=draining');
+  },
+  clearHeartbeats: () => {
+    logger.info({ event: 'daemon-shutdown', step: 'clear-heartbeats' }, 'heartbeats cleared');
+  },
+  rejectPendingCalls: () => {
+    logger.info({ event: 'daemon-shutdown', droppedCalls: 0 }, 'pending calls aggregated-rejected');
+  },
+  drainSnapshotSemaphore: (reason) => {
+    logger.info({ event: 'daemon-shutdown', step: 'drain-snapshot-semaphore', reason }, 'snapshot semaphore drained');
+  },
+  windDownSessions: ({ perChildDeadlineMs }) => {
+    logger.info({ event: 'daemon-shutdown', step: 'wind-down-sessions', perChildDeadlineMs }, 'sessions wound down');
+  },
+  closeSubscribers: (reason) => {
+    logger.info({ event: 'subscribers-closed', count: 0, reason }, 'fan-out subscribers closed');
+  },
+  finalizeLogger: () => {
+    // pino.final flush — synchronous; logger.flush is best-effort under the
+    // default async destination but is the documented shutdown valve.
+    if (typeof logger.flush === 'function') logger.flush();
+  },
+  exitProcess: (code) => {
+    process.exit(code);
+  },
+  recordStepError: (step: ShutdownStep, err: unknown) => {
+    logger.error({ event: 'daemon-shutdown.step-failed', step, err: String(err) }, 'shutdown step failed');
+  },
+  recordDeadlineOverrun: (elapsedMs, deadlineMs) => {
+    logger.warn(
+      { event: 'daemon-shutdown.deadline-overrun', elapsedMs, deadlineMs },
+      'shutdown drain exceeded deadline (T25 force-kill territory)',
+    );
+  },
+};
+
+const daemonShutdownHandler = createDaemonShutdownHandler(shutdownActions);
+
+const supervisorDispatcher = createSupervisorDispatcher();
+supervisorDispatcher.register(DAEMON_SHUTDOWN_METHOD, async (req, ctx) =>
+  daemonShutdownHandler.handle(req as Parameters<typeof daemonShutdownHandler.handle>[0], {
+    traceId: ctx.traceId,
+    bootNonce,
+  }),
+);
+void supervisorDispatcher;
+
 logger.info({ event: 'daemon.boot' }, 'daemon shell booted');
 
-// TODO(T20): full ordered shutdown sequence (heartbeats → drain → SIGCHLD wind-down
-// → subscriber close → pino.final) per spec §6.6.1. T1 ships the SIGTERM stub only.
-process.on('SIGTERM', () => {
-  logger.info({ event: 'daemon.signal.sigterm' }, 'sigterm received');
-  process.exit(0);
-});
+// SIGTERM/SIGINT funnel through the same handler so the spec sequence runs
+// regardless of whether the trigger is the supervisor RPC or a kill signal.
+function shutdownFromSignal(signal: 'SIGTERM' | 'SIGINT'): void {
+  logger.info({ event: `daemon.signal.${signal.toLowerCase()}` }, `${signal} received`);
+  void daemonShutdownHandler.handle({ reason: signal }, { bootNonce });
+}
+process.on('SIGTERM', () => shutdownFromSignal('SIGTERM'));
+process.on('SIGINT', () => shutdownFromSignal('SIGINT'));


### PR DESCRIPTION
## Summary

Replaces the T16 NOT_IMPLEMENTED stub for `daemon.shutdown` with the real graceful-drain handler, per **frag-6-7 §6.6.1** (ordered shutdown sequence) + **frag-3.5.1 §3.5.1.2 step 5** (snapshot semaphore drain on shutdown). This is the uninstall / manual / SIGTERM / SIGINT path; the upgrade-with-marker path is **T21** (`daemon.shutdownForUpgrade`).

## Spec sequence (frozen, snapshot-tested)

| # | Step | Spec ref |
|---|---|---|
| 1 | `mark-draining` | §6.6.1 step 1 |
| 2 | `clear-heartbeats` | §6.6.1 step 2 |
| 3 | `reject-pending` | §6.6.1 step 3 |
| 4 | `drain-snapshot-semaphore` | §3.5.1.2 step 5 |
| 5 | `wind-down-sessions` | §6.6.1 step 4 |
| 6 | `close-subscribers` | §6.6.1 step 5 |
| 7 | `finalize-logger` | §6.6.1 step 6 |
| 8 | `exit-process` | §6.6.1 step 7 |

## Layer 1 (architecture)

- **Pure decider** — `daemon/src/handlers/daemon-shutdown.ts` owns ordering, idempotency, deadline accounting; performs zero I/O.
- **Action injection** — every side effect (drain semaphore, wind-down PTY, close fan-out, pino.final, process.exit) lives behind `ShutdownActions`. As T37/T40/T41/T28 land their drivers, swap individual actions in `daemon/src/index.ts` — handler stays untouched.
- **Ack-before-exit** — `handle()` resolves the reply synchronously; the drain chain runs on the next microtask, so the supervisor receives the ack envelope before `process.exit(0)`.
- **Idempotent** — second call returns `{ idempotency: 'replay' }` and runs zero actions (avoids double-SIGKILL on surviving children).
- **Partial drain over silent abort** — per-step throws captured by `recordStepError`; sequence continues so DB close + pino.final still run after a wind-down failure.
- **Deadline policy** — 5s default (§11.6.5 ack window), clamped 50ms..60s. Overrun surfaced via `recordDeadlineOverrun` hook. Actual SIGKILL escalation is **T25** (out of scope here, documented in module header).
- **No marker file** — distinct from T21 per §6.4 / §6.1 R2 crash-loop accounting.

## Wiring

- Dispatcher: `supervisorDispatcher.register(DAEMON_SHUTDOWN_METHOD, handler.handle)` replaces the T16 stub.
- Signal handlers: `SIGTERM` and `SIGINT` funnel through the same handler so all three triggers (RPC, kill, console-Ctrl-C) share the spec sequence.
- index.ts sinks are intentionally log-only for now — they observe ordering and emit the canonical log keys (`daemon-shutdown`, `subscribers-closed`) from §6.6.1's "Canonical reconnect / bridge log key names" list. Real I/O slots in as subsystems land.

## Tests (28 cases)

- Spec wiring: method on `SUPERVISOR_RPCS`, plan order, plan frozen, every step has spec ref.
- Ack-before-exit (verified by parking `markDraining` on a blocker promise).
- Deadline clamp matrix (NaN, ±Infinity, 0, negative, 10ms → 50ms floor, 10M → 60s ceiling).
- Action invocation order matches `SHUTDOWN_STEPS`; reason string + 200ms per-child deadline propagated.
- Error tolerance: sync + async throws → `recordStepError` called, subsequent steps still run, exit fires.
- Idempotency: post-drain replay, concurrent re-call mid-drain (state=`draining`), replay returns first-call deadline.
- Deadline overrun: hook fires when wall-clock > deadline at `close-subscribers`; not fired when within budget; finalize+exit still run after overrun.
- T16 dispatcher integration: handler registers cleanly, dispatch returns `ok:true` with the right reply shape.

## Test plan

- [x] Typecheck (`npm run typecheck`) — pass
- [x] Daemon non-DB tests (`npx vitest run daemon/ --exclude 'daemon/src/db/**'`) — 325/325 pass
- [x] Handler tests (`npx vitest run daemon/src/handlers/`) — 85/85 pass (T17 + T19 + T20)
- [x] Build daemon (`npm run build:daemon`) — pass
- [x] ESM require-load smoke (`node --input-type=module -e "import('./daemon/dist-daemon/index.js')"`) — boots, logs `daemon.boot` event
- [x] Rebased onto latest origin/working (T17/T19/T36 sibling PRs landed)

DB-suite failures pre-exist (better-sqlite3 NODE_MODULE_VERSION 145 vs 137 mismatch on this Node) and are unrelated to this change.

Refs Task #973.

🤖 Generated with [Claude Code](https://claude.com/claude-code)