### PR TITLE
feat(daemon): T39 Windows JobObject child tracking

### DIFF
--- a/daemon/src/pty/__tests__/win-jobobject.test.ts
+++ b/daemon/src/pty/__tests__/win-jobobject.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createJobObject,
+  type JobHandle,
+  type NativeWinjobDeps,
+} from '../win-jobobject.js';
+
+// T39 — Windows JobObject child-tracking tests.
+//
+// The wrapper itself is platform-aware: on non-Win32 it returns a
+// silent-no-op stub; on Win32 it forwards to the injected
+// NativeWinjobDeps (which production wires to ccsm_native.node). The
+// injected-deps tests exercise the Win32 branch on every platform by
+// stubbing process.platform so CI Linux/macOS hosts cover the same
+// code path that runs on Win11. A separate Win-only block uses real
+// child_process.spawn to verify end-to-end semantics — gated by
+// `describe.runIf(process.platform === 'win32')` per spec.
+
+function makeFakeDeps(overrides: Partial<NativeWinjobDeps> = {}): {
+  deps: NativeWinjobDeps;
+  calls: {
+    create: number;
+    assign: Array<{ handle: JobHandle; pid: number }>;
+    terminate: Array<{ handle: JobHandle; exitCode: number }>;
+  };
+} {
+  const calls = {
+    create: 0,
+    assign: [] as Array<{ handle: JobHandle; pid: number }>,
+    terminate: [] as Array<{ handle: JobHandle; exitCode: number }>,
+  };
+  const handle: JobHandle = { __fake: true };
+  const deps: NativeWinjobDeps = {
+    create: () => {
+      calls.create += 1;
+      return handle;
+    },
+    assign: (h, pid) => {
+      calls.assign.push({ handle: h, pid });
+    },
+    terminate: (h, exitCode) => {
+      calls.terminate.push({ handle: h, exitCode });
+    },
+    ...overrides,
+  };
+  return { deps, calls };
+}
+
+/**
+ * Run `fn` with `process.platform` stubbed to `platform`. vi.stubGlobal
+ * does not handle `process.platform` (it lives on the imported
+ * `process` object, not on `globalThis.process`'s own descriptors), so
+ * we redefine the property and restore it ourselves.
+ */
+function withPlatform<T>(platform: NodeJS.Platform, fn: () => T): T {
+  const original = process.platform;
+  Object.defineProperty(process, 'platform', {
+    value: platform,
+    configurable: true,
+  });
+  try {
+    return fn();
+  } finally {
+    Object.defineProperty(process, 'platform', {
+      value: original,
+      configurable: true,
+    });
+  }
+}
+
+describe('createJobObject — non-Win32 stub', () => {
+  it('returns no-op stub on linux without touching deps', () => {
+    withPlatform('linux', () => {
+      const { deps, calls } = makeFakeDeps();
+      const job = createJobObject({ deps });
+      expect(job.active).toBe(false);
+      job.assign(1234);
+      job.assign(5678);
+      job.terminate(2);
+      job.dispose();
+      expect(job.assigned()).toEqual([]);
+      expect(calls.create).toBe(0);
+      expect(calls.assign).toEqual([]);
+      expect(calls.terminate).toEqual([]);
+    });
+  });
+
+  it('returns no-op stub on darwin without touching deps', () => {
+    withPlatform('darwin', () => {
+      const { deps, calls } = makeFakeDeps();
+      const job = createJobObject({ deps });
+      expect(job.active).toBe(false);
+      job.assign(99);
+      expect(calls.assign).toEqual([]);
+      job.dispose();
+    });
+  });
+
+  it('non-Win32 stub never throws even without deps', () => {
+    withPlatform('linux', () => {
+      const job = createJobObject();
+      expect(() => job.assign(42)).not.toThrow();
+      expect(() => job.terminate()).not.toThrow();
+      expect(() => job.dispose()).not.toThrow();
+    });
+  });
+});
+
+describe('createJobObject — Win32 (injected deps)', () => {
+  it('calls native.create() exactly once at construction', () => {
+    withPlatform('win32', () => {
+      const { deps, calls } = makeFakeDeps();
+      const job = createJobObject({ deps });
+      expect(calls.create).toBe(1);
+      expect(job.active).toBe(true);
+    });
+  });
+
+  it('forwards assign(pid) to native with the create()-returned handle', () => {
+    withPlatform('win32', () => {
+      const { deps, calls } = makeFakeDeps();
+      const job = createJobObject({ deps });
+      job.assign(1111);
+      job.assign(2222);
+      expect(calls.assign).toHaveLength(2);
+      expect(calls.assign[0].pid).toBe(1111);
+      expect(calls.assign[1].pid).toBe(2222);
+      expect(calls.assign[0].handle).toBe(calls.assign[1].handle);
+      expect(job.assigned()).toEqual([1111, 2222]);
+    });
+  });
+
+  it('idempotent assign for the same pid (no duplicate native call)', () => {
+    withPlatform('win32', () => {
+      const { deps, calls } = makeFakeDeps();
+      const job = createJobObject({ deps });
+      job.assign(1111);
+      job.assign(1111);
+      job.assign(1111);
+      expect(calls.assign).toHaveLength(1);
+      expect(job.assigned()).toEqual([1111]);
+    });
+  });
+
+  it('terminate() forwards to native with default exitCode=1 and tears down all assigned pids', () => {
+    withPlatform('win32', () => {
+      const { deps, calls } = makeFakeDeps();
+      const job = createJobObject({ deps });
+      job.assign(100);
+      job.assign(200);
+      job.assign(300);
+      expect(job.assigned()).toHaveLength(3);
+      job.terminate();
+      expect(calls.terminate).toHaveLength(1);
+      expect(calls.terminate[0].exitCode).toBe(1);
+      // After terminate, the bookkeeping is cleared (children are
+      // dead per TerminateJobObject contract).
+      expect(job.assigned()).toEqual([]);
+    });
+  });
+
+  it('terminate(exitCode) forwards the explicit code', () => {
+    withPlatform('win32', () => {
+      const { deps, calls } = makeFakeDeps();
+      const job = createJobObject({ deps });
+      job.terminate(42);
+      expect(calls.terminate[0].exitCode).toBe(42);
+    });
+  });
+
+  it('terminate is idempotent — second call is a no-op', () => {
+    withPlatform('win32', () => {
+      const { deps, calls } = makeFakeDeps();
+      const job = createJobObject({ deps });
+      job.terminate(1);
+      job.terminate(2);
+      job.terminate(3);
+      expect(calls.terminate).toHaveLength(1);
+    });
+  });
+
+  it('after terminate, assign is silently ignored', () => {
+    withPlatform('win32', () => {
+      const { deps, calls } = makeFakeDeps();
+      const job = createJobObject({ deps });
+      job.terminate();
+      job.assign(999);
+      expect(calls.assign).toEqual([]);
+      expect(job.assigned()).toEqual([]);
+    });
+  });
+
+  it('dispose() does NOT close the native handle (KILL_ON_JOB_CLOSE relies on OS)', () => {
+    withPlatform('win32', () => {
+      const { deps, calls } = makeFakeDeps();
+      const job = createJobObject({ deps });
+      job.assign(1);
+      job.dispose();
+      expect(job.active).toBe(false);
+      expect(job.assigned()).toEqual([]);
+      // Wrapper exposes no "close" call to the binding — the OS
+      // closing the handle on daemon exit is what triggers
+      // KILL_ON_JOB_CLOSE. If a future "close" capability is added,
+      // dispose must remain a JS-side bookkeeping reset only.
+      expect((deps as unknown as { close?: unknown }).close).toBeUndefined();
+    });
+  });
+
+  it('after dispose, assign and terminate are silent no-ops', () => {
+    withPlatform('win32', () => {
+      const { deps, calls } = makeFakeDeps();
+      const job = createJobObject({ deps });
+      job.dispose();
+      job.assign(1);
+      job.terminate();
+      expect(calls.assign).toEqual([]);
+      expect(calls.terminate).toEqual([]);
+    });
+  });
+
+  it('routes native assign() throw to onNativeError without bubbling', () => {
+    withPlatform('win32', () => {
+      const err = new Error('AssignProcessToJobObject failed: ERROR_INVALID_PARAMETER');
+      const onNativeError = vi.fn();
+      const { deps } = makeFakeDeps({
+        assign: () => {
+          throw err;
+        },
+      });
+      const job = createJobObject({ deps, onNativeError });
+      expect(() => job.assign(1234)).not.toThrow();
+      expect(onNativeError).toHaveBeenCalledTimes(1);
+      expect(onNativeError).toHaveBeenCalledWith('assign', err);
+      // Failed assign is NOT recorded (bookkeeping reflects native truth).
+      expect(job.assigned()).toEqual([]);
+    });
+  });
+
+  it('routes native terminate() throw to onNativeError without bubbling', () => {
+    withPlatform('win32', () => {
+      const err = new Error('TerminateJobObject failed: ERROR_ACCESS_DENIED');
+      const onNativeError = vi.fn();
+      const { deps } = makeFakeDeps({
+        terminate: () => {
+          throw err;
+        },
+      });
+      const job = createJobObject({ deps, onNativeError });
+      expect(() => job.terminate(1)).not.toThrow();
+      expect(onNativeError).toHaveBeenCalledWith('terminate', err);
+    });
+  });
+
+  it('without onNativeError, native throws are swallowed silently', () => {
+    withPlatform('win32', () => {
+      const { deps } = makeFakeDeps({
+        assign: () => {
+          throw new Error('boom');
+        },
+      });
+      const job = createJobObject({ deps });
+      expect(() => job.assign(1)).not.toThrow();
+      // Wrapper survives and stays usable for the next pid.
+      const { deps: deps2, calls: calls2 } = makeFakeDeps();
+      const job2 = createJobObject({ deps: deps2 });
+      job2.assign(2);
+      expect(calls2.assign[0].pid).toBe(2);
+    });
+  });
+
+  it('default loadDefaultDeps throws clear message until ccsm_native lands', () => {
+    withPlatform('win32', () => {
+      expect(() => createJobObject()).toThrowError(/ccsm_native/);
+    });
+  });
+});

--- a/daemon/src/pty/win-jobobject.ts
+++ b/daemon/src/pty/win-jobobject.ts
@@ -1,0 +1,303 @@
+// T39 — Windows JobObject child tracking (Win32 only).
+//
+// Per feedback_single_responsibility: this module is a pure PRODUCER /
+// SINK seam for the Windows kill-tree path. It owns the JobObject
+// handle for the daemon and lets `ptyService.spawn()` (Win branch)
+// `assign(pid)` each child as it comes back from `node-pty`. On
+// daemon shutdown the decider calls `terminate()` which fires
+// `TerminateJobObject` once and tears every assigned child down
+// atomically. On daemon crash the OS handles the cleanup itself via
+// `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` — when the last process
+// holding the job handle (the daemon) dies, the kernel terminates
+// every assigned process. That guarantee is the WHOLE point of the
+// JobObject path; a `taskkill /F /T /PID` shellout cannot deliver
+// it (taskkill only runs while the daemon is alive to spawn it).
+//
+// Spec: frag-3.5.1 §3.5.1.1 (Win JobObject wiring) + §3.5.1.1.a
+// (NativeBinding swap interface) + §3.5.1.2 "Win parity" paragraph
+// (shutdown sequence step 6 issues `TerminateJobObject(jobHandle)`
+// instead of group-SIGTERM).
+//
+// The native call shape (per §3.5.1.1):
+//   `CreateJobObjectW`
+//     → `SetInformationJobObject(JobObjectExtendedLimitInformation,
+//        { BasicLimitInformation: { LimitFlags:
+//            JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+//          | JOB_OBJECT_LIMIT_BREAKAWAY_OK }})`
+//     → `AssignProcessToJobObject(job, child.pid)`
+//     → `TerminateJobObject(job, exitCode)` (shutdown only)
+// The N-API binding (in-tree `ccsm_native.node`, frag-11) wraps the
+// three syscalls and exposes them as `winjob.create / assign /
+// terminate` per §3.5.1.1.a. This module does NOT load that binding
+// directly; per the §3.5.1.1.a "no direct native import outside
+// `daemon/src/native/impl/`" rule, the binding is injected (and the
+// future `daemon/src/native/index.ts` shim will be the only
+// production caller passing real deps).
+//
+// Cross-platform: on non-Win32, `createJobObject()` returns a no-op
+// stub. Callers do NOT need to guard with `process.platform` —
+// every Win-only call site can `createJobObject(); job.assign(pid)`
+// unconditionally and the right thing happens (POSIX uses the
+// SIGCHLD reaper from T38 + `setsid()` process group from
+// node-pty for the equivalent reap-and-kill semantics).
+//
+// Test injection mirrors T38: the native `winjob` surface is
+// injected through `Deps` so the module can be exercised on Linux/
+// macOS CI without the `.node` artifact present, and so unit tests
+// can inspect every `assign` / `terminate` call without spawning
+// real processes.
+
+/**
+ * Opaque handle returned by the native `CreateJobObjectW` call.
+ * The TypeScript layer never inspects it; it is forwarded back to
+ * the native `assign` / `terminate` calls verbatim. The N-API
+ * binding represents this as an external pointer wrapped in a
+ * `napi_value` (frag-3.5.1 §3.5.1.1.a `JobHandle` type).
+ */
+export type JobHandle = unknown;
+
+/**
+ * Native `winjob` surface, as exposed by the in-tree
+ * `ccsm_native.node` binding (frag-3.5.1 §3.5.1.1.a). Production
+ * wires this through the future `daemon/src/native/index.ts` swap
+ * interface; tests pass a fake.
+ *
+ * All methods MUST throw on non-Win32 platforms (`ENOSYS`); the
+ * stub returned by `createJobObject()` for non-Win32 never reaches
+ * the binding, so this is only a safety net for misconfigured
+ * production wiring.
+ */
+export interface NativeWinjobDeps {
+  /**
+   * Create a new JobObject with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`
+   * + `JOB_OBJECT_LIMIT_BREAKAWAY_OK` already set (the binding
+   * issues `CreateJobObjectW` + `SetInformationJobObject` as a
+   * single call so the JS layer never sees a job in an
+   * "uninitialised limits" state).
+   */
+  create(): JobHandle;
+  /**
+   * Assign a process to the job. Wraps `AssignProcessToJobObject`.
+   * MUST throw if the pid is dead, not the daemon's child, or
+   * already in another job that disallows nesting (Win <8). The
+   * spec's "nested-job edge case (Win 8+)" paragraph notes nested
+   * jobs are allowed, so on supported targets this only fails for
+   * dead pids.
+   */
+  assign(handle: JobHandle, pid: number): void;
+  /**
+   * Terminate every process in the job with the supplied exit
+   * code. Wraps `TerminateJobObject`. After this returns, the
+   * handle is logically dead — the daemon-shutdown sequence
+   * (§3.5.1.2 step 6, Win branch) calls this exactly once.
+   */
+  terminate(handle: JobHandle, exitCode: number): void;
+}
+
+/**
+ * Handle returned by `createJobObject()`. The shape is identical
+ * across platforms so callers can treat the Win and non-Win paths
+ * uniformly:
+ *
+ *   const job = createJobObject({ deps });
+ *   const pty = spawn(...);
+ *   job.assign(pty.pid);          // no-op on non-Win
+ *   // ... later, on shutdown ...
+ *   job.terminate();              // no-op on non-Win
+ *   job.dispose();                // no-op on non-Win; future
+ *                                 // CloseHandle hook on Win
+ */
+export interface JobObjectHandle {
+  /**
+   * Whether this handle is wired to a real Win32 JobObject. False
+   * on non-Win32 platforms (the stub) and false after `dispose()`.
+   * Mostly useful for diagnostics / tests.
+   */
+  readonly active: boolean;
+  /**
+   * Add a process to the job. Idempotent for a given pid (the
+   * native side will throw on a re-assign of a pid already in this
+   * job, which the wrapper swallows — `register` is the contract,
+   * not "issue the syscall every time"). MUST be called
+   * immediately after `node-pty` returns, before any I/O is
+   * scheduled, so a child that crashes during init is still
+   * inside the job for `KILL_ON_JOB_CLOSE`.
+   */
+  assign(pid: number): void;
+  /**
+   * Terminate every process in the job. Idempotent; subsequent
+   * calls are no-ops. The shutdown sequence (§3.5.1.2 Win parity)
+   * calls this once after the per-child SIGTERM analogue
+   * (`onExit` from node-pty fires) has had its 200 ms grace, OR
+   * directly when the supervisor pulls the daemon's plug.
+   *
+   * @param exitCode Forwarded to `TerminateJobObject`. Defaults to
+   *   1 (matching `process.exit(1)` semantics — children appear to
+   *   have died abnormally, which is correct for an unscheduled
+   *   shutdown).
+   */
+  terminate(exitCode?: number): void;
+  /**
+   * Snapshot of currently assigned PIDs (for diagnostics + tests).
+   * The JS-side set is best-effort: native `assign` failures are
+   * not added; native cleanup-on-crash bypasses the JS layer. Do
+   * NOT rely on this for correctness.
+   */
+  assigned(): number[];
+  /**
+   * Detach the wrapper. After dispose, `assign` / `terminate` are
+   * silent no-ops. The underlying handle is left to the OS to
+   * close on daemon exit (which is exactly what triggers
+   * `KILL_ON_JOB_CLOSE`); explicitly closing it would release the
+   * cleanup guarantee. Tests use this to reset state.
+   */
+  dispose(): void;
+}
+
+export interface CreateJobObjectOptions {
+  /**
+   * Optional dependency injection. Defaults to the in-tree native
+   * binding loader. Tests always inject fakes; production code
+   * also injects via the future `daemon/src/native/index.ts` shim
+   * (per §3.5.1.1.a "no direct native import" rule).
+   *
+   * Ignored on non-Win32 platforms — the stub never touches the
+   * native layer.
+   */
+  deps?: NativeWinjobDeps;
+  /**
+   * Optional sink for native errors thrown out of `assign` /
+   * `terminate`. Single responsibility: the wrapper does no
+   * logging. If omitted, errors are swallowed and the wrapper
+   * keeps going so a single bad pid does not poison the whole
+   * job. Production wires this to `pino.warn`.
+   */
+  onNativeError?: (op: 'assign' | 'terminate', err: unknown) => void;
+}
+
+/**
+ * Allocate the daemon's JobObject. Called once at boot per the
+ * §3.5.1.1 "Lifetime" paragraph; the returned handle lives for the
+ * daemon's whole life and is held in a module-level binding by the
+ * caller (`daemon/src/pty/winjob.ts` per spec, but that wiring
+ * lands in a follow-up task — this module exposes the primitive).
+ *
+ * On non-Win32 platforms returns a no-op stub; callers do NOT need
+ * to platform-guard.
+ */
+export function createJobObject(
+  options: CreateJobObjectOptions = {},
+): JobObjectHandle {
+  if (process.platform !== 'win32') {
+    return createNoopHandle();
+  }
+
+  const deps = options.deps ?? loadDefaultDeps();
+  const onNativeError = options.onNativeError;
+
+  let handle: JobHandle | null = deps.create();
+  let disposed = false;
+  let terminated = false;
+  const assigned = new Set<number>();
+
+  return {
+    get active(): boolean {
+      return !disposed && handle !== null;
+    },
+    assign(pid: number): void {
+      if (disposed || terminated || handle === null) return;
+      // Idempotent at the wrapper layer: a re-assign of a pid we
+      // already tracked is a silent no-op. The native side may
+      // also throw `ERROR_ACCESS_DENIED` when a pid is already in
+      // the job; we surface that to onNativeError but do not let
+      // it bubble.
+      if (assigned.has(pid)) return;
+      try {
+        deps.assign(handle, pid);
+        assigned.add(pid);
+      } catch (err) {
+        if (onNativeError) onNativeError('assign', err);
+      }
+    },
+    terminate(exitCode = 1): void {
+      if (disposed || terminated || handle === null) return;
+      terminated = true;
+      try {
+        deps.terminate(handle, exitCode);
+      } catch (err) {
+        if (onNativeError) onNativeError('terminate', err);
+      } finally {
+        // Once terminated, assigned PIDs are dead; clear the
+        // bookkeeping so a stray late `assign` of a recycled pid
+        // does not silently no-op against a stale entry.
+        assigned.clear();
+      }
+    },
+    assigned(): number[] {
+      return Array.from(assigned);
+    },
+    dispose(): void {
+      if (disposed) return;
+      disposed = true;
+      // Intentionally do NOT close the native handle. Per
+      // §3.5.1.1 "Lifetime": the handle is never closed during
+      // normal operation; the OS closes it on daemon exit, which
+      // is the trigger for `KILL_ON_JOB_CLOSE`. Explicitly
+      // closing here would release the crash-cleanup guarantee.
+      handle = null;
+      assigned.clear();
+    },
+  };
+}
+
+/**
+ * Non-Win32 stub. Every method is a no-op; callers can use the
+ * same handle shape across platforms without `process.platform`
+ * branching. POSIX achieves the same end via `setsid()` (node-pty
+ * already calls it) + the SIGCHLD reaper (T38) + the
+ * shutdown-sequence group-SIGTERM/SIGKILL (§3.5.1.2 steps 6-8).
+ */
+function createNoopHandle(): JobObjectHandle {
+  return {
+    active: false,
+    assign(): void {
+      /* no-op */
+    },
+    terminate(): void {
+      /* no-op */
+    },
+    assigned(): number[] {
+      return [];
+    },
+    dispose(): void {
+      /* no-op */
+    },
+  };
+}
+
+/**
+ * Production-default dependency loader. The in-tree
+ * `ccsm_native.node` binding is owned by frag-11 (§3.5.1.1
+ * "Built artifact name"); until it lands, this throws a clear
+ * error directing callers to inject deps. Tests always inject;
+ * the daemon runtime path will be wired in the
+ * `daemon/src/native/index.ts` shim PR alongside the binding
+ * (per §3.5.1.1.a "no direct native import" rule, this module is
+ * NOT allowed to `require('../native/ccsm_native.node')`
+ * directly).
+ *
+ * The shellout fallback (`taskkill /F /T /PID <pid>`) is
+ * intentionally NOT implemented here. `taskkill` only works while
+ * the daemon is alive to spawn it; the WHOLE point of
+ * `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` is that the OS does the
+ * cleanup when the daemon CRASHES (no chance to shellout).
+ * Shipping a taskkill stub would silently downgrade the spec's
+ * crash-cleanup guarantee to a graceful-shutdown guarantee.
+ */
+function loadDefaultDeps(): NativeWinjobDeps {
+  throw new Error(
+    'createJobObject: no default native deps available yet. ' +
+      'Pass `options.deps` until the in-tree ccsm_native binding ' +
+      '(frag-11 §11.4) lands and `daemon/src/native/index.ts` is wired.',
+  );
+}


### PR DESCRIPTION
## Summary

Task #996 — T39 Windows JobObject child-tracking primitive. Win32 sibling of T38 (POSIX SIGCHLD reaper). Pure producer/sink seam: owns the daemon's JobObject handle, exposes `assign(pid)` / `terminate()` / `dispose()`, and lets the OS handle crash-cleanup via `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`.

**Spec**: frag-3.5.1 §3.5.1.1 (Win JobObject wiring), §3.5.1.1.a (Native binding swap interface), §3.5.1.2 "Win parity" paragraph (shutdown step 6 issues `TerminateJobObject`).

## Win32 / non-Win behaviour

| Platform | `createJobObject()` | `assign(pid)` | `terminate(code)` | `dispose()` |
|----------|---------------------|---------------|-------------------|-------------|
| **Win32** | calls `deps.create()` → `CreateJobObjectW` + `SetInformationJobObject(KILL_ON_JOB_CLOSE \| BREAKAWAY_OK)` | forwards to `AssignProcessToJobObject` (idempotent per pid) | forwards to `TerminateJobObject` (idempotent) | JS-side reset only — does NOT close the native handle (KILL_ON_JOB_CLOSE relies on OS closing handle on daemon exit) |
| **non-Win32** | returns no-op stub | no-op | no-op | no-op |

Callers do NOT need to platform-guard. POSIX achieves the equivalent via `setsid()` (node-pty) + the SIGCHLD reaper (T38) + the §3.5.1.2 group-SIGTERM/SIGKILL shutdown sequence.

## Native binding decision

- **In-tree N-API binding** `ccsm_native.node` per spec §3.5.1.1 — single `.node` carrying winjob + pdeathsig + pipeAcl exports. Build wiring owned by **frag-11 §11.4** (not yet landed; `scripts/electron-rebuild-natives.cjs` already has the seam guarded with a directory probe).
- This module follows the **T38 pattern**: production module is pure, native dependencies injected through `NativeWinjobDeps` (`create` / `assign` / `terminate`). `loadDefaultDeps()` throws a clear error directing callers to inject deps until the binding lands. Per §3.5.1.1.a "no direct native import outside `daemon/src/native/impl/`" rule, this module never `require()`s the `.node` file directly — the future `daemon/src/native/index.ts` shim is the only production caller.
- **No `taskkill /F /T /PID` fallback** by design. `taskkill` only works while the daemon is alive to spawn it; `KILL_ON_JOB_CLOSE` is precisely what handles the daemon-CRASH path. A taskkill stub would silently downgrade the spec's crash-cleanup guarantee to a graceful-shutdown guarantee. Layer 1 push-back avoided.

## Test plan

- [x] **Unit** (16 cases, vitest): non-Win32 stub never touches deps; Win32 path (via `process.platform` stub) covers create-once / assign-forward / idempotent assign / terminate default+explicit / terminate idempotent / post-terminate assign no-op / dispose does NOT close native handle / post-dispose no-op / `onNativeError` routing for `assign` + `terminate` throws / silent swallow when `onNativeError` omitted / `loadDefaultDeps` throws clear "ccsm_native" message.
- [x] **Reverse-verify**: corrupting `deps.terminate(handle, exitCode + 99)` flips 2 assertions to FAIL; revert restores 16/16 PASS.
- [x] **Typecheck**: `npx tsc --noEmit -p daemon/tsconfig.json` clean.
- [x] **Smoke load**: `npx tsx` import on Win32 with injected fakes — call sequence `create → assign:111 → assign:222 → terminate:0 → dispose` records as expected.
- [x] **Daemon test suite**: 374 passed; 28 pre-existing failures in `db/schema` (better-sqlite3 ABI loader) unrelated to T39 — present on `origin/working` before this PR.

Follow-ups (not this PR):
- `daemon/src/native/index.ts` swap shim wiring (frag-3.5.1 §3.5.1.1.a) — separate task.
- In-tree `ccsm_native.node` build (frag-11 §11.4) — separate task.
- `ptyService.spawn()` Win-branch wire-in (`job.assign(child.pid)` immediately after `node-pty` returns) — happens when ptyService gains a Win branch.