### PR TITLE
feat(installer): T51 NSIS perMachine:true (Task #1007)

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     },
     "nsis": {
       "oneClick": false,
-      "perMachine": false,
+      "perMachine": true,
       "allowToChangeInstallationDirectory": true,
       "allowElevation": true,
       "deleteAppDataOnUninstall": false,


### PR DESCRIPTION
## Summary
- Flip NSIS \`perMachine: false\` → \`true\`. Required for daemon-at-boot (HKLM Run key, per-machine Task Scheduler entry, service-style install).
- \`oneClick: false\` and \`allowElevation: true\` were ALREADY set from earlier installer work — verified preserved (no-op for those two).
- Effective diff is one line.

## Required for downstream
- #1014 (T52 customUnInstall silent) — needs wizard-style installer (oneClick:false ✓ already).
- #1019 — same NSIS area.
- T53 ccsm-uninstall-helper.exe — needs per-machine install path resolution.

## Diff
\`\`\`diff
     "nsis": {
       "oneClick": false,
-      "perMachine": false,
+      "perMachine": true,
       "allowToChangeInstallationDirectory": true,
       "allowElevation": true,
\`\`\`

## Test plan
- [x] JSON parse OK (\`node -e \"console.log(JSON.stringify(require('./package.json').build.nsis, null, 2))\"\`).
- [ ] Real installer build deferred to build worker (manager dispatches separately).
- Reviewer: confirm \`perMachine: true\` field name matches current electron-builder NSIS schema; sanity-check no conflict with \`allowToChangeInstallationDirectory: true\` (both supported per electron-builder docs).

## Notes
- Manager: original task asked for all three flags but two were pre-existing. Effective change is perMachine only.