### PR TITLE
feat(daemon): T47 replay-burst exemption

### DIFF
--- a/daemon/src/pty/__tests__/replay-burst-exemption.test.ts
+++ b/daemon/src/pty/__tests__/replay-burst-exemption.test.ts
@@ -1,0 +1,154 @@
+// Tests for replay-burst exemption (T47, frag-3.5.1 §3.5.1.5 line 120, 165).
+//
+// Verifies the spec contract:
+//   - 256 KB (or even 5 MB stress) replay write does NOT trip the 1 MiB
+//     drop-slowest watermark while in replay-mode.
+//   - exitReplay resets accounting; subsequent steady-state writes accrue
+//     normally and DO trip at >1 MiB.
+//   - Reverse-verify: WITHOUT enterReplay (i.e. plain dropSlowest.record),
+//     a 5 MB write trips the watermark — proves the exemption is what's
+//     suppressing the trip in the positive cases.
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  DROP_SLOWEST_DEFAULT_THRESHOLD_BYTES,
+  createDropSlowest,
+} from '../drop-slowest.js';
+import { createReplayBurstExemption } from '../replay-burst-exemption.js';
+
+const KIB = 1024;
+const MIB = 1024 * 1024;
+
+describe('replay-burst-exemption: construction', () => {
+  it('throws when dropSlowest is missing', () => {
+    // @ts-expect-error - intentionally invalid
+    expect(() => createReplayBurstExemption({})).toThrow(TypeError);
+  });
+});
+
+describe('replay-burst-exemption: enter/exit lifecycle', () => {
+  it('isInReplay reflects enter/exit', () => {
+    const dropSlowest = createDropSlowest();
+    const ex = createReplayBurstExemption({ dropSlowest });
+    expect(ex.isInReplay('s')).toBe(false);
+    ex.enterReplay('s');
+    expect(ex.isInReplay('s')).toBe(true);
+    ex.exitReplay('s');
+    expect(ex.isInReplay('s')).toBe(false);
+  });
+
+  it('enterReplay is idempotent (second call returns a usable recorder)', () => {
+    const dropSlowest = createDropSlowest();
+    const ex = createReplayBurstExemption({ dropSlowest });
+    const r1 = ex.enterReplay('s');
+    const r2 = ex.enterReplay('s');
+    r1(256 * KIB);
+    r2(256 * KIB);
+    // Both writes should be exempt — tally stays 0.
+    expect(dropSlowest.pending('s')).toBe(0);
+    expect(dropSlowest.getOverlimit()).toEqual([]);
+  });
+
+  it('exitReplay is idempotent (no-op when not in replay)', () => {
+    const dropSlowest = createDropSlowest();
+    const ex = createReplayBurstExemption({ dropSlowest });
+    expect(() => ex.exitReplay('never-entered')).not.toThrow();
+    ex.enterReplay('s');
+    ex.exitReplay('s');
+    expect(() => ex.exitReplay('s')).not.toThrow();
+  });
+});
+
+describe('replay-burst-exemption: spec §3.5.1.5 line 120 — replay does not trip watermark', () => {
+  it('256 KB replay write does not flag overlimit', () => {
+    const dropSlowest = createDropSlowest();
+    const ex = createReplayBurstExemption({ dropSlowest });
+    const record = ex.enterReplay('s');
+    record(256 * KIB);
+    expect(dropSlowest.pending('s')).toBe(0);
+    expect(dropSlowest.getOverlimit()).toEqual([]);
+  });
+
+  it('5 MB stress replay write does not flag overlimit while in replay-mode', () => {
+    const dropSlowest = createDropSlowest();
+    const ex = createReplayBurstExemption({ dropSlowest });
+    const record = ex.enterReplay('s');
+    // Five 1 MiB chunks — well past the 1 MiB watermark in steady state.
+    for (let i = 0; i < 5; i += 1) {
+      record(MIB);
+    }
+    expect(dropSlowest.pending('s')).toBe(0);
+    expect(dropSlowest.getOverlimit()).toEqual([]);
+  });
+});
+
+describe('replay-burst-exemption: spec line 165 — post-exit steady-state accumulates normally', () => {
+  it('after exitReplay, normal writes accrue and trip at >1 MiB', () => {
+    const dropSlowest = createDropSlowest();
+    const ex = createReplayBurstExemption({ dropSlowest });
+    const record = ex.enterReplay('s');
+    record(5 * MIB); // huge replay burst, exempt
+    expect(dropSlowest.pending('s')).toBe(0);
+    ex.exitReplay('s');
+    // Steady-state writes now go through the SAME recorder reference but
+    // the lifecycle-contract says they record as non-exempt.
+    record(DROP_SLOWEST_DEFAULT_THRESHOLD_BYTES); // exactly 1 MiB
+    expect(dropSlowest.pending('s')).toBe(DROP_SLOWEST_DEFAULT_THRESHOLD_BYTES);
+    expect(dropSlowest.getOverlimit()).toEqual([]); // boundary, not over
+    record(1); // strictly over
+    expect(dropSlowest.getOverlimit()).toEqual(['s']);
+  });
+
+  it('exitReplay resets a tally that accrued from coincident steady-state writes', () => {
+    // Simulate a steady-state write landing during the replay window via the
+    // raw drop-slowest API (the exemption module is not the only writer in
+    // the wiring — broadcasts can race the snapshot).
+    const dropSlowest = createDropSlowest();
+    const ex = createReplayBurstExemption({ dropSlowest });
+    ex.enterReplay('s');
+    // Coincident steady-state write straight through dropSlowest:
+    dropSlowest.record('s', 900 * KIB);
+    expect(dropSlowest.pending('s')).toBe(900 * KIB);
+    // exitReplay collapses the tally — spec "watermark measured AFTER burst".
+    ex.exitReplay('s');
+    expect(dropSlowest.pending('s')).toBe(0);
+    expect(dropSlowest.getOverlimit()).toEqual([]);
+  });
+});
+
+describe('replay-burst-exemption: reverse-verify (proves exemption is load-bearing)', () => {
+  it('WITHOUT enterReplay, a 5 MB write trips the watermark', () => {
+    const dropSlowest = createDropSlowest();
+    // No exemption module — directly exercise drop-slowest.
+    dropSlowest.record('s', 5 * MIB);
+    expect(dropSlowest.pending('s')).toBe(5 * MIB);
+    expect(dropSlowest.getOverlimit()).toEqual(['s']);
+  });
+
+  it('WITHOUT enterReplay, exemption module records as non-exempt and trips watermark', () => {
+    // Belt-and-braces: a recorder obtained then the sub exited — subsequent
+    // writes should accrue normally (not silently exempt).
+    const dropSlowest = createDropSlowest();
+    const ex = createReplayBurstExemption({ dropSlowest });
+    const record = ex.enterReplay('s');
+    ex.exitReplay('s');
+    record(5 * MIB);
+    expect(dropSlowest.pending('s')).toBe(5 * MIB);
+    expect(dropSlowest.getOverlimit()).toEqual(['s']);
+  });
+});
+
+describe('replay-burst-exemption: per-subscriber isolation', () => {
+  it('replay-mode on one sub does not exempt writes for another', () => {
+    const dropSlowest = createDropSlowest();
+    const ex = createReplayBurstExemption({ dropSlowest });
+    const recA = ex.enterReplay('a');
+    recA(5 * MIB); // exempt
+    // Subscriber 'b' is NOT in replay-mode; raw write trips.
+    dropSlowest.record('b', 5 * MIB);
+    expect(dropSlowest.pending('a')).toBe(0);
+    expect(dropSlowest.pending('b')).toBe(5 * MIB);
+    expect(dropSlowest.getOverlimit()).toEqual(['b']);
+  });
+});

--- a/daemon/src/pty/replay-burst-exemption.ts
+++ b/daemon/src/pty/replay-burst-exemption.ts
@@ -1,0 +1,150 @@
+// PTY replay-burst exemption (spec §3.5.1.5 / frag-3.5.1 lines 120, 135, 165, 201).
+//
+// Wraps the per-subscriber replay window so the bounded (256 KB) snapshot
+// payload delivered as the first post-resubscribe write is EXEMPT from the
+// T43 drop-slowest 1 MiB watermark accounting.
+//
+// Why the exemption exists (spec line 120):
+//   The 256 KB replay payload is a *one-shot, per-message hard limit* on the
+//   resubscribe burst; the 1 MiB drop-slowest watermark is a *steady-state
+//   per-second flow rate cap* on the per-subscriber Connect buffer. They
+//   measure different things on different time scales. Without this seam, a
+//   nodemon dev save-storm with 5 sessions producing 100 KB/s could exceed
+//   1 MiB on the first post-reconnect frame, drop the stream as slow,
+//   re-resubscribe, loop. The exemption breaks that loop.
+//
+// Single Responsibility (per `feedback_single_responsibility`):
+//   - producer of replay-mode lifecycle events (enter/exit) keyed by subId;
+//   - decider for the per-write `exempt` flag during replay-mode;
+//   - NOT a sink: does not write bytes, does not log, does not emit metrics.
+//     The fan-out caller (T44 wiring) calls `enterReplay(subId)` before
+//     pushing the snapshot bytes through the returned recorder and
+//     `exitReplay(subId)` once the snapshot has flushed; both calls are
+//     idempotent enough that the lifecycle is a single decision point.
+//
+// Coordination with T43 drop-slowest:
+//   The drop-slowest module exposes two compatible seams (see its file
+//   header lines 18-33). This module USES BOTH:
+//     * `record(subId, byteCount, { exempt: true })` for every write that
+//       lands during replay-mode — covers the "snapshot bytes interleaved
+//       with steady-state writes" race the T43 header calls out.
+//     * `reset(subId)` on `exitReplay` so steady-state accounting starts
+//       from zero immediately AFTER the burst, matching the spec wording
+//       "watermark is measured AFTER the replay burst is delivered."
+//   The redundancy is intentional: ordering of the snapshot writes vs any
+//   coincident broadcast writes is therefore safe; the post-burst reset
+//   collapses any residual tally to zero before normal accounting resumes.
+//
+// Hard non-goals (do NOT add here, push back if asked):
+//   - No socket I/O (caller owns the actual `socket.write`).
+//   - No replay-payload framing or 256 KB clamping (frag-3.7 / T44 territory).
+//   - No `gap: true` flag handling (resubscribe RPC owns it).
+//   - No drop-slowest threshold enforcement (T43 owns `getOverlimit()`).
+
+import type { DropSlowest } from './drop-slowest.js';
+
+/**
+ * Per-write recorder returned by `enterReplay`. Caller invokes this for each
+ * snapshot byte chunk that lands during the replay window. Internally it
+ * forwards to the underlying drop-slowest with `{ exempt: true }`.
+ *
+ * `byteCount` MUST be a non-negative integer (the underlying drop-slowest
+ * enforces this and throws on violation).
+ */
+export type ExemptRecorder = (byteCount: number) => void;
+
+/**
+ * Public surface of the replay-burst exemption module.
+ *
+ * Lifecycle contract:
+ *   enterReplay(subId) → exemptRecord(...)+ → exitReplay(subId)
+ *
+ *   - `enterReplay` is idempotent: calling it twice for the same `subId`
+ *     without an intervening `exitReplay` returns a recorder bound to the
+ *     same replay window (no double-count, no crash). Useful when the
+ *     caller's resubscribe path is re-entrant (e.g. retried snapshot fetch).
+ *   - `exitReplay` is idempotent: calling it on a `subId` that is not in
+ *     replay-mode is a no-op (no throw). This means the caller's try/finally
+ *     can safely run `exitReplay` even on the cancellation path.
+ *   - Calling `exemptRecord` AFTER `exitReplay` for that subId records as a
+ *     normal (non-exempt) write through the underlying drop-slowest. This
+ *     mirrors the spec semantics: the exemption window closes precisely at
+ *     `exitReplay`; subsequent writes are steady-state.
+ */
+export interface ReplayBurstExemption {
+  /**
+   * Mark `subId` as in replay-mode. Returns a recorder that the caller uses
+   * for every snapshot byte chunk written during this window. Idempotent
+   * (see lifecycle contract).
+   */
+  enterReplay(subId: string): ExemptRecorder;
+  /**
+   * End the replay window for `subId` and reset the underlying drop-slowest
+   * tally for `subId` to 0 (so steady-state accounting starts fresh after
+   * the burst). Idempotent. No-op if `subId` was not in replay-mode.
+   */
+  exitReplay(subId: string): void;
+  /**
+   * Test/observability accessor — returns `true` iff `subId` is currently in
+   * replay-mode. Not used by production callers.
+   */
+  isInReplay(subId: string): boolean;
+}
+
+/** Construction options. */
+export interface ReplayBurstExemptionOptions {
+  /**
+   * The drop-slowest decider whose accounting this module is exempting from.
+   * Typically the per-session instance owned by the fan-out registry wiring.
+   */
+  readonly dropSlowest: DropSlowest;
+}
+
+/**
+ * Construct a replay-burst exemption. One instance per drop-slowest decider
+ * (i.e. one per session, mirroring the drop-slowest construction site).
+ */
+export function createReplayBurstExemption(
+  opts: ReplayBurstExemptionOptions,
+): ReplayBurstExemption {
+  const dropSlowest = opts.dropSlowest;
+  if (!dropSlowest) {
+    throw new TypeError(
+      'createReplayBurstExemption requires opts.dropSlowest',
+    );
+  }
+  // Set of subIds currently in replay-mode. Identity-only — no per-sub state
+  // needed since the exempt flag is a single bit decided by membership.
+  const inReplay = new Set<string>();
+
+  function enterReplay(subId: string): ExemptRecorder {
+    inReplay.add(subId);
+    // Bind the recorder to the subId at enterReplay time. Membership in
+    // `inReplay` is checked at each invocation so a write that lands AFTER
+    // exitReplay records as steady-state (see lifecycle contract).
+    return (byteCount: number) => {
+      if (inReplay.has(subId)) {
+        dropSlowest.record(subId, byteCount, { exempt: true });
+      } else {
+        dropSlowest.record(subId, byteCount);
+      }
+    };
+  }
+
+  function exitReplay(subId: string): void {
+    if (!inReplay.has(subId)) return;
+    inReplay.delete(subId);
+    // Reset the tally so any residual exempt-bookkeeping (none today, but
+    // the seam is documented) AND any coincident steady-state writes that
+    // landed during the burst are collapsed to zero. Spec line 120:
+    // "1 MB drop-slowest watermark is measured AFTER the replay burst is
+    // delivered."
+    dropSlowest.reset(subId);
+  }
+
+  function isInReplay(subId: string): boolean {
+    return inReplay.has(subId);
+  }
+
+  return { enterReplay, exitReplay, isInReplay };
+}


### PR DESCRIPTION
## Summary

Implements T47 (frag-3.5.1 §3.5.1.5 line 120, 165): wraps the per-subscriber replay window so snapshot/replay bytes are EXEMPT from the T43 drop-slowest 1 MiB watermark accounting. Without this exemption, a fresh-attach client receiving the bounded 256 KB replay payload (or a steady-state burst coincident with snapshot delivery) would immediately trip the watermark and be dropped, then re-resubscribe, looping.

## Approach: B (separate module)

Picked option B from the task brief — new module `daemon/src/pty/replay-burst-exemption.ts` that owns the replay-mode lifecycle as its single responsibility. Justification:

- SRP win: fanout-registry's job is fan-out, not accounting policy. Pushing the exemption seam into a separate module keeps fanout-registry's hard non-goals (no backpressure / no drop-slowest accounting) intact.
- Cleaner test surface: the lifecycle (`enterReplay` → recorder → `exitReplay`) is hermetically testable against a real `createDropSlowest()` (it's pure) without spinning up the registry.
- No cross-file change required this PR — the wiring side (T44 stream RPC / T42 producer) will call `enterReplay/exitReplay` when it lands. This PR introduces the seam only.

Uses BOTH T43 seams documented in `drop-slowest.ts` lines 18-33:
- `record(subId, bytes, { exempt: true })` for every write during replay-mode (handles snapshot writes interleaved with steady-state broadcast races).
- `reset(subId)` on `exitReplay` so steady-state accounting starts from zero immediately AFTER the burst — matches spec wording \"watermark is measured AFTER the replay burst is delivered.\"

## Files

- `daemon/src/pty/replay-burst-exemption.ts` (new, ~120 LOC)
- `daemon/src/pty/__tests__/replay-burst-exemption.test.ts` (new, 11 tests)

No changes to `fanout-registry.ts` or any other file. Single-file fixer.

## Verification

- typecheck: PASS (`npm run typecheck` → 0 errors)
- unit: 11/11 PASS (`npx vitest run daemon/src/pty/__tests__/replay-burst-exemption.test.ts` → 11 passed, 12 ms tests / 7.78 s wall)
- build: PASS (`npm run build:daemon` → emits `daemon/dist-daemon/`)

### Reverse-verify (proves exemption is load-bearing)

Two reverse-verify cases in the test file:
1. WITHOUT enterReplay, a 5 MiB write straight through `dropSlowest.record(...)` trips the watermark (`getOverlimit() === ['s']`).
2. WITHOUT enterReplay (after `exitReplay`), the recorder records as non-exempt and a 5 MiB write trips (`getOverlimit() === ['s']`).

Both prove that the exemption is what suppresses the trip in the positive cases.

### Spec-positive cases

- 256 KB replay write while in replay-mode → pending stays 0, no overlimit.
- 5 MiB stress replay (5 × 1 MiB chunks) while in replay-mode → pending stays 0, no overlimit.
- After `exitReplay`, 1 MiB exact = boundary (NOT over, strict-greater-than per T43); +1 byte trips.
- Per-subscriber isolation: replay-mode on 'a' does not exempt 'b'.
- Coincident steady-state writes during replay-mode are collapsed by the `reset(subId)` on `exitReplay`.

## Layer 1 (necessity / direction)

Spec line 165 explicitly tasks T47 with this seam. Without it the loop described in spec line 120 (\"nodemon dev save-storm with 5 sessions producing 100 KB/s could exceed 1 MB on the first post-reconnect frame, drop the stream as slow, re-resubscribe, loop\") is unfixed. Single-responsibility module placement preferred over inlining into fanout-registry per the manager note.

## Layer 2 (implementation)

Hermetic tests against real `createDropSlowest()` (it's pure — no fakes needed). Covers construction, lifecycle (idempotent enter/exit), spec positive cases, post-exit steady-state, reverse-verify, per-sub isolation. 11 cases total.

## Migration-window CI tolerance

Per memory: ignoring lint/typecheck CI red on working migration window. Local typecheck PASSES.