### PR TITLE
feat(daemon): T24 RPC reply ack_source clarification

### DIFF
--- a/daemon/src/__tests__/dispatcher.test.ts
+++ b/daemon/src/__tests__/dispatcher.test.ts
@@ -3,6 +3,8 @@ import {
   Dispatcher,
   createSupervisorDispatcher,
   createDataDispatcher,
+  isAckSource,
+  ACK_SOURCES,
   type DispatchContext,
   type Handler,
 } from '../dispatcher.js';
@@ -219,6 +221,172 @@ describe('Dispatcher (spec §3.4.1.h control-socket router)', () => {
         expect(r.ok).toBe(true);
         if (!r.ok) return;
         expect(r.value).toBe('data-side');
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // T24 — RPC reply ack_source disambiguation (frag-6-7 §6.3).
+  //
+  // Every successful reply carries `ack_source: 'handler' | 'dispatcher'`:
+  //   - unary `dispatch()` → 'handler' (handler returned a value)
+  //   - `dispatchStreamingInit()` → 'dispatcher' (request routed, stream open,
+  //                                               no handler return value yet)
+  // The two values are mutually exclusive on a single reply envelope; tests
+  // below pin the wire-shape so T14 can assert against `r.ack_source` directly.
+  // -------------------------------------------------------------------------
+  describe('T24 ack_source (frag-6-7 §6.3)', () => {
+    describe('schema (isAckSource / ACK_SOURCES)', () => {
+      it('ACK_SOURCES enumerates exactly the two canonical values', () => {
+        expect([...ACK_SOURCES].sort()).toEqual(['dispatcher', 'handler']);
+      });
+
+      it('isAckSource validates "handler"', () => {
+        expect(isAckSource('handler')).toBe(true);
+      });
+
+      it('isAckSource validates "dispatcher"', () => {
+        expect(isAckSource('dispatcher')).toBe(true);
+      });
+
+      it.each([
+        '',
+        'HANDLER',
+        'Dispatcher',
+        ' handler',
+        'handler ',
+        'stream',
+        null,
+        undefined,
+        0,
+        1,
+        true,
+        false,
+        {},
+        [],
+        ['handler'],
+      ])('isAckSource rejects %j', (v) => {
+        expect(isAckSource(v)).toBe(false);
+      });
+    });
+
+    describe('unary dispatch → ack_source: "handler"', () => {
+      it('handler-completion reply carries ack_source="handler"', async () => {
+        const d = new Dispatcher();
+        d.register('daemon.hello', async () => ({ pong: true }));
+        const r = await d.dispatch('daemon.hello', {}, ctx);
+        expect(r.ok).toBe(true);
+        if (!r.ok) return;
+        expect(r.ack_source).toBe('handler');
+        expect(r.value).toEqual({ pong: true });
+      });
+
+      it.each([...SUPERVISOR_RPCS])(
+        'every routable RPC %s returns ack_source="handler" on handler success',
+        async (method) => {
+          const d = new Dispatcher();
+          d.register(method, async () => 'ok');
+          const r = await d.dispatch(method, {}, ctx);
+          expect(r.ok).toBe(true);
+          if (!r.ok) return;
+          expect(r.ack_source).toBe('handler');
+        },
+      );
+
+      it('error replies do NOT carry an ack_source field (errors are not acks)', async () => {
+        // NOT_ALLOWED
+        const d = new Dispatcher();
+        const r1 = await d.dispatch('session.list', {}, ctx);
+        expect(r1.ok).toBe(false);
+        expect((r1 as Record<string, unknown>)['ack_source']).toBeUndefined();
+
+        // UNKNOWN_METHOD
+        const r2 = await d.dispatch('daemon.hello', {}, ctx);
+        expect(r2.ok).toBe(false);
+        expect((r2 as Record<string, unknown>)['ack_source']).toBeUndefined();
+
+        // NOT_IMPLEMENTED (stub)
+        const d2 = createSupervisorDispatcher();
+        const r3 = await d2.dispatch('daemon.hello', {}, ctx);
+        expect(r3.ok).toBe(false);
+        expect((r3 as Record<string, unknown>)['ack_source']).toBeUndefined();
+      });
+    });
+
+    describe('streaming-init dispatch → ack_source: "dispatcher"', () => {
+      it('routable streaming method emits ack_source="dispatcher" with undefined value', () => {
+        const d = new Dispatcher();
+        d.register('/stats', async () => ({ snapshot: true }));
+        const r = d.dispatchStreamingInit('/stats');
+        expect(r.ok).toBe(true);
+        if (!r.ok) return;
+        expect(r.ack_source).toBe('dispatcher');
+        // No handler-return-value on the streaming-init reply (the stream is
+        // the value); transport must serialise this as an empty/undefined
+        // payload, NOT as the eventual handler result.
+        expect(r.value).toBeUndefined();
+      });
+
+      it('does NOT invoke the handler on streaming-init (only routing decision)', () => {
+        const d = new Dispatcher();
+        const handler = vi.fn<Handler>(async () => 'never');
+        d.register('/stats', handler);
+        const r = d.dispatchStreamingInit('/stats');
+        expect(r.ok).toBe(true);
+        expect(handler).not.toHaveBeenCalled();
+      });
+
+      it.each([...SUPERVISOR_RPCS])(
+        'streaming-init for routable %s returns ack_source="dispatcher"',
+        (method) => {
+          const d = new Dispatcher();
+          d.register(method, async () => 'ok');
+          const r = d.dispatchStreamingInit(method);
+          expect(r.ok).toBe(true);
+          if (!r.ok) return;
+          expect(r.ack_source).toBe('dispatcher');
+        },
+      );
+
+      it('rejects non-allowlisted methods with NOT_ALLOWED (no ack_source)', () => {
+        const d = new Dispatcher();
+        const r = d.dispatchStreamingInit('session.list');
+        expect(r.ok).toBe(false);
+        if (r.ok) return;
+        expect(r.error.code).toBe('NOT_ALLOWED');
+        expect((r as Record<string, unknown>)['ack_source']).toBeUndefined();
+      });
+
+      it('rejects allowlisted-but-unhandled methods with UNKNOWN_METHOD (no ack_source)', () => {
+        const d = new Dispatcher(); // bare — no handler registered
+        const r = d.dispatchStreamingInit('daemon.hello');
+        expect(r.ok).toBe(false);
+        if (r.ok) return;
+        expect(r.error.code).toBe('UNKNOWN_METHOD');
+        expect((r as Record<string, unknown>)['ack_source']).toBeUndefined();
+      });
+    });
+
+    describe('streaming flow: dispatcher-ack then handler-ack', () => {
+      it('init carries "dispatcher", subsequent unary completion carries "handler"', async () => {
+        // Models the T14 streaming flow: transport calls
+        // dispatchStreamingInit() to ack the request, then later (when
+        // ready) calls dispatch() to obtain the terminal handler-result reply
+        // that closes the stream. Both replies share the same RPC method but
+        // carry distinct ack_source values.
+        const d = new Dispatcher();
+        d.register('/stats', async () => ({ final: 'snapshot' }));
+
+        const init = d.dispatchStreamingInit('/stats');
+        expect(init.ok).toBe(true);
+        if (!init.ok) return;
+        expect(init.ack_source).toBe('dispatcher');
+
+        const terminal = await d.dispatch('/stats', {}, ctx);
+        expect(terminal.ok).toBe(true);
+        if (!terminal.ok) return;
+        expect(terminal.ack_source).toBe('handler');
+        expect(terminal.value).toEqual({ final: 'snapshot' });
       });
     });
   });

--- a/daemon/src/dispatcher.ts
+++ b/daemon/src/dispatcher.ts
@@ -9,6 +9,13 @@
 //   per-method registration + envelope HMAC + hello-required gates and is
 //   declared by the data-socket transport).
 //
+// T24 (frag-6-7 §6.3 ack-source clarification): every successful reply carries
+// `ack_source: 'handler' | 'dispatcher'` so the transport (T14) can disambiguate
+// handler-result acks from streaming-init dispatcher acks. `dispatch()` (unary)
+// fills `'handler'` on success; `dispatchStreamingInit()` fills `'dispatcher'`.
+// Existing handlers are untouched — the field is set by the dispatch entry
+// point used, not the handler.
+//
 // Spec citations:
 //   - docs/superpowers/specs/v0.3-fragments/frag-3.4.1-envelope-hardening.md
 //     §3.4.1.h (control-socket: `/healthz`, `/stats`, `daemon.hello`,
@@ -64,9 +71,44 @@ export interface DispatcherError {
   readonly message: string;
 }
 
+/**
+ * Source of a successful reply envelope (T24, frag-6-7 §6.3 ack-semantics
+ * disambiguation).
+ *
+ *   - `'handler'`    — the registered handler ran to completion and its
+ *                      return value populates `DispatchOk.value`. This is the
+ *                      ack a unary RPC caller waits for.
+ *   - `'dispatcher'` — the dispatcher accepted the request and started a
+ *                      streaming response, but no handler return value exists
+ *                      yet. The transport (T14) emits this as the
+ *                      streaming-init ack so the client knows the request
+ *                      reached the dispatcher; subsequent stream frames carry
+ *                      the actual data, and a terminal `'handler'`-sourced
+ *                      reply closes the stream.
+ *
+ * The field is filled automatically by the dispatch entry point used; handlers
+ * never set it themselves.
+ */
+export type AckSource = 'handler' | 'dispatcher';
+
+/** All legal `ack_source` values. Exported so schema validators / tests can
+ *  enumerate without re-declaring the union. */
+export const ACK_SOURCES: readonly AckSource[] = ['handler', 'dispatcher'] as const;
+
+/** Type-guard for envelope-level schema validation (T5 envelope adapter / T14
+ *  control-socket reply serialiser). Returns true for the two canonical
+ *  values, false otherwise. */
+export function isAckSource(v: unknown): v is AckSource {
+  return v === 'handler' || v === 'dispatcher';
+}
+
 export interface DispatchOk {
   readonly ok: true;
   readonly value: unknown;
+  /** Source of this reply envelope — see {@link AckSource}. Always present;
+   *  unary `dispatch()` returns `'handler'`, `dispatchStreamingInit()` returns
+   *  `'dispatcher'`. */
+  readonly ack_source: AckSource;
 }
 
 export interface DispatchErr {
@@ -245,7 +287,9 @@ export class Dispatcher {
 
     try {
       const value = await handler(req, ctx);
-      return { ok: true, value };
+      // T24: handler-completion path — the registered handler returned a
+      // value, so the reply envelope's ack source is `'handler'`.
+      return { ok: true, value, ack_source: 'handler' };
     } catch (err) {
       if (err instanceof NotImplementedError) {
         return {
@@ -259,5 +303,51 @@ export class Dispatcher {
       }
       throw err;
     }
+  }
+
+  /**
+   * Streaming-init dispatch: announce that a streaming RPC has been received
+   * and routed, BEFORE any handler return value exists (T24, frag-6-7 §6.3).
+   *
+   * Used by the transport (T14) when the caller's request opens a streaming
+   * response: the transport emits this `'dispatcher'`-sourced reply
+   * immediately so the client can begin receiving stream frames; the eventual
+   * terminal reply (sent when the handler completes) carries
+   * `ack_source: 'handler'` via the regular `dispatch()` path.
+   *
+   * The same allowlist + UNKNOWN_METHOD checks apply as `dispatch()` — the
+   * dispatcher is the single decider on whether a method may be invoked at
+   * all, regardless of unary vs. streaming response shape. The handler is
+   * NOT invoked here; only the routing decision is made.
+   *
+   * Returns:
+   *   - `{ ok: true, value: undefined, ack_source: 'dispatcher' }` on a
+   *     routable method (handler exists). The transport serialises this as
+   *     the streaming-init ack envelope; `value` is `undefined` because no
+   *     handler return value exists yet (the stream is the value).
+   *   - `{ ok: false, error: NOT_ALLOWED | UNKNOWN_METHOD }` on rejection.
+   */
+  dispatchStreamingInit(method: string): DispatchResult {
+    if (!isSupervisorRpc(method)) {
+      return {
+        ok: false,
+        error: {
+          code: 'NOT_ALLOWED',
+          method,
+          message: `RPC ${JSON.stringify(method)} is not on the control-socket allowlist (SUPERVISOR_RPCS, §3.4.1.h)`,
+        },
+      };
+    }
+    if (!this.#handlers.has(method)) {
+      return {
+        ok: false,
+        error: {
+          code: 'UNKNOWN_METHOD',
+          method,
+          message: `no handler registered for control-socket RPC ${method}`,
+        },
+      };
+    }
+    return { ok: true, value: undefined, ack_source: 'dispatcher' };
   }
 }


### PR DESCRIPTION
## Summary

T24 (frag-6-7 §6.3 ack-source clarification). Adds `ack_source: 'handler' | 'dispatcher'` to the dispatcher's successful reply envelope so the transport layer (T14) can disambiguate two semantically distinct acks that previously shared the same `{ ok: true, value }` shape:

- `'handler'` — the registered handler ran to completion and `value` carries its return; this is the ack a unary RPC caller waits for.
- `'dispatcher'` — the dispatcher accepted + routed the request and the transport opened a streaming response; no handler return value exists yet (the stream is the value), and a terminal `'handler'`-sourced reply later closes the stream.

## Changes

- `daemon/src/dispatcher.ts`
  - `DispatchOk` gains required `ack_source: AckSource` field.
  - `dispatch()` (unary path) sets `ack_source: 'handler'` on handler success.
  - New `dispatchStreamingInit(method)` returns `ack_source: 'dispatcher'` with `value: undefined`; does NOT invoke the handler — same allowlist + UNKNOWN_METHOD checks as `dispatch()`, only the routing decision is made.
  - Error replies (`NOT_ALLOWED`, `UNKNOWN_METHOD`, `NOT_IMPLEMENTED`) carry no `ack_source` — errors are not acks.
  - Exports `AckSource` type, `ACK_SOURCES` const tuple, and `isAckSource()` type-guard for envelope/transport schema validators.
- `daemon/src/__tests__/dispatcher.test.ts`
  - 33 new T24 assertions across schema, unary handler-completion, streaming-init, and a flow test that pins both replies on the same RPC method (init → terminal).

Existing handlers (T19 `daemon.hello`, etc.) are untouched — the field is filled by the dispatch entry point used.

## Verification

- `npx vitest run daemon/src/__tests__/dispatcher.test.ts daemon/src/envelope/__tests__/envelope.test.ts` → **70 passed / 70**
- `npm run typecheck` → clean (root + electron + daemon tsconfigs)
- `npm run build:daemon` → clean
- Repo grep: no other consumers of `DispatchOk` / `DispatchResult` outside dispatcher + its test, so the new required field is non-breaking.

## Test plan

- [x] Schema validates both `'handler'` and `'dispatcher'`, rejects everything else (incl. case variants, padding, null/undefined, non-strings).
- [x] Unary `dispatch()` of a routable handler → reply has `ack_source: 'handler'` and `value` carries the handler return.
- [x] `dispatchStreamingInit()` of a routable method → reply has `ack_source: 'dispatcher'`, `value: undefined`, handler not invoked.
- [x] Error replies (NOT_ALLOWED / UNKNOWN_METHOD / NOT_IMPLEMENTED) carry no `ack_source`.
- [x] Streaming flow: init → `'dispatcher'` ack, terminal `dispatch()` → `'handler'` ack on the same method.
- [x] Per-RPC parametric coverage across all `SUPERVISOR_RPCS` for both entry points.

## Layer review

- **Layer 1**: Schema-level disambiguation; doesn't change handler API surface or any existing wire field. Unblocks #984.
- **Layer 2**: Schema validates; dispatcher fills automatically; `'dispatcher'` path is a pure routing check (no handler call) so streaming transport can ack stream-open before producing data.

Spec: frag-6-7 supervisor RPCs §6.3 (ack-source clarification).