### PR TITLE
feat(daemon): T45 Windows named-pipe ACL hardening

### DIFF
--- a/daemon/src/pty/__tests__/pipe-acl.test.ts
+++ b/daemon/src/pty/__tests__/pipe-acl.test.ts
@@ -1,0 +1,143 @@
+// T45 — Windows named-pipe ACL hardening tests.
+//
+// Spec: frag-3.5.1 §3.5.1.6 + §3.5.1.1.a (NativeBinding swap
+// interface) + v0.3-design §3.1.1 + frag-6-7 §7.M1.
+//
+// The wrapper is portable (pure sink with injected deps) so the
+// contract tests run on every platform with FAKE deps. The Win32
+// platform branch is asserted on Win32; the non-Win32 silent no-op
+// is asserted everywhere else.
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  applyPipeAcl,
+  type NativePipeAclDeps,
+} from '../pipe-acl.js';
+
+// -- Fake deps -------------------------------------------------------------
+
+interface FakeDeps extends NativePipeAclDeps {
+  /** All paths passed to applyOwnerOnly, in call order. */
+  calls: string[];
+  /** Make the next applyOwnerOnly call throw. */
+  setError(err: unknown): void;
+}
+
+function createFakeDeps(): FakeDeps {
+  const calls: string[] = [];
+  let pendingError: unknown | undefined;
+  return {
+    calls,
+    applyOwnerOnly(pipePath: string): void {
+      if (pendingError !== undefined) {
+        const err = pendingError;
+        pendingError = undefined;
+        throw err;
+      }
+      calls.push(pipePath);
+    },
+    setError(err: unknown): void {
+      pendingError = err;
+    },
+  };
+}
+
+// -- Cross-platform contract: non-Win32 silent no-op ----------------------
+
+describe.skipIf(process.platform === 'win32')(
+  'pipe-acl: non-Win32 silent no-op',
+  () => {
+    it('returns silently without invoking deps on non-Win32', () => {
+      const deps = createFakeDeps();
+      // Even with deps that would record a call, non-Win32 path
+      // returns BEFORE touching deps — the unix-socket chmod 0600
+      // owned by socket/listener.ts is the POSIX-side guarantee.
+      expect(() =>
+        applyPipeAcl('\\\\.\\pipe\\ccsm-daemon-test', { deps }),
+      ).not.toThrow();
+      expect(deps.calls).toEqual([]);
+    });
+
+    it('returns silently even without deps (no default loader invoked)', () => {
+      // The default loader throws "frag-11 / ccsm_native" — proving
+      // we did not invoke it requires showing applyPipeAcl does NOT
+      // throw with no deps on non-Win32.
+      expect(() => applyPipeAcl('\\\\.\\pipe\\ccsm-daemon-test')).not.toThrow();
+    });
+  },
+);
+
+// -- Win32 platform branch ------------------------------------------------
+
+describe.skipIf(process.platform !== 'win32')(
+  'pipe-acl: Win32 sink contract',
+  () => {
+    it('forwards the pipe path to deps.applyOwnerOnly verbatim', () => {
+      const deps = createFakeDeps();
+      const pipePath = '\\\\.\\pipe\\ccsm-daemon-S-1-5-21-1234';
+      applyPipeAcl(pipePath, { deps });
+      expect(deps.calls).toEqual([pipePath]);
+    });
+
+    it('invokes the binding exactly once per call (no retries, no double-fire)', () => {
+      const deps = createFakeDeps();
+      const spy = vi.spyOn(deps, 'applyOwnerOnly');
+      applyPipeAcl('\\\\.\\pipe\\ccsm-daemon-a', { deps });
+      applyPipeAcl('\\\\.\\pipe\\ccsm-daemon-b', { deps });
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenNthCalledWith(1, '\\\\.\\pipe\\ccsm-daemon-a');
+      expect(spy).toHaveBeenNthCalledWith(2, '\\\\.\\pipe\\ccsm-daemon-b');
+    });
+
+    it('propagates native errors to caller (fail-loud — boot must abort)', () => {
+      const deps = createFakeDeps();
+      const err = new Error('ERROR_ACCESS_DENIED');
+      deps.setError(err);
+      // Decider (listener) decides whether a failure is fatal; the
+      // wrapper does not swallow. Per frag-6-7 §7.M1 spec, a pipe
+      // with the default Everyone-DACL is a security failure that
+      // must fail boot, not log-and-continue — hence no try/catch
+      // in the wrapper.
+      expect(() =>
+        applyPipeAcl('\\\\.\\pipe\\ccsm-daemon-fail', { deps }),
+      ).toThrow(err);
+    });
+
+    it('default deps loader throws a clear error pointing at frag-11 / ccsm_native', () => {
+      // No deps passed — must direct caller to frag-11 / inject.
+      // Mirrors T38/T39 loadDefaultDeps() contract.
+      expect(() => applyPipeAcl('\\\\.\\pipe\\ccsm-daemon-x')).toThrow(
+        /no default native deps|frag-11|ccsm_native/,
+      );
+    });
+  },
+);
+
+// -- Default-loader contract (portable via process.platform stub) ---------
+//
+// The default loader must throw a clear "wire ccsm_native (frag-11)"
+// pointer regardless of host OS. On non-Win32 the platform branch
+// short-circuits before the loader is consulted; we stub
+// `process.platform = 'win32'` to exercise the loader-call path on
+// any CI host. Mirrors T38's "default deps loader" test.
+
+describe('pipe-acl: default loader pointer (portable)', () => {
+  it('default loader throws referencing frag-11 / ccsm_native when no deps injected', () => {
+    const original = process.platform;
+    Object.defineProperty(process, 'platform', {
+      value: 'win32',
+      configurable: true,
+    });
+    try {
+      expect(() => applyPipeAcl('\\\\.\\pipe\\ccsm-daemon-loader-test')).toThrow(
+        /no default native deps|frag-11|ccsm_native/,
+      );
+    } finally {
+      Object.defineProperty(process, 'platform', {
+        value: original,
+        configurable: true,
+      });
+    }
+  });
+});

--- a/daemon/src/pty/pipe-acl.ts
+++ b/daemon/src/pty/pipe-acl.ts
@@ -1,0 +1,171 @@
+// T45 — Windows named-pipe ACL hardening (Win32 only).
+//
+// Per feedback_single_responsibility: this module is a pure SINK seam
+// for the Windows named-pipe DACL hardening path. It has one job:
+// after `net.createServer().listen(pipePath)` returns and the pipe
+// kernel object exists, call the native `pipeAcl.applyOwnerOnly`
+// binding to overwrite the pipe's default DACL with an explicit
+// owner-only ACL. No bookkeeping, no logging, no state. The call site
+// (`daemon/src/socket/listener.ts` per spec, but that wiring lands in
+// a follow-up task — this module exposes the primitive) is the
+// decider; this module is the pure binding wrapper.
+//
+// Spec: frag-3.5.1 §3.5.1.6 (Win named-pipe ACL hardening) +
+// frag-3.5.1 §3.5.1.1.a (NativeBinding swap interface) + v0.3-design
+// §3.1.1 (transport hardening) + frag-6-7 §7.1.2 + §7.M1
+// (explicit DACL = current SID).
+//
+// Spec quote (v0.3-design §7.1.2 / sec-M1): "Win default pipe DACL
+// grants Everyone in many configs. Defaults are NOT trusted."
+//
+// What the native binding does (per frag-6-7 §7.M1, implemented in
+// frag-11's `ccsm_native.node` `pipeAcl.applyOwnerOnly` export):
+//   1. Resolve the current process token's user SID
+//      (`OpenProcessToken` + `GetTokenInformation(TokenUser)`).
+//   2. Build a fresh DACL via `InitializeAcl` +
+//      `AddAccessAllowedAce(GENERIC_READ | GENERIC_WRITE,
+//      currentUserSid)`.
+//   3. Add explicit `AddAccessDeniedAce` entries for
+//      `BUILTIN\Users` (S-1-5-32-545) and `ANONYMOUS LOGON`
+//      (S-1-5-7) so a future ACL re-evaluation cannot accidentally
+//      grant them via group inheritance.
+//   4. Set the security descriptor on the pipe handle via
+//      `SetSecurityInfo(pipeHandle, SE_KERNEL_OBJECT,
+//      DACL_SECURITY_INFORMATION, ...)`.
+//   5. Set `PIPE_REJECT_REMOTE_CLIENTS` on the pipe state via
+//      `SetNamedPipeHandleState` so even an admin from a remote
+//      machine cannot connect over `\\<host>\pipe\...`.
+//
+// Why a single wrapper call instead of exposing each primitive on
+// the JS side: the five steps must be atomic — a window where the
+// pipe exists with the default DACL is a real attack window (other
+// local users could connect in that gap). The binding does all five
+// inside one C++ call so JS never sees an "intermediate" state.
+//
+// Cross-platform: on non-Win32, `applyPipeAcl` returns silently. The
+// POSIX side already gets owner-only access via the unix-socket
+// `chmod 0600` performed by `daemon/src/socket/listener.ts`; the
+// data dir's `0700` enclosing-directory permission is a second
+// layer. Callers do NOT need to platform-guard.
+//
+// Test injection mirrors T38 (sigchld-reaper) / T39 (win-jobobject):
+// the native `pipeAcl` surface is injected through `Deps` so the
+// module can be exercised on Linux/macOS CI without the `.node`
+// artifact present, and so unit tests can inspect every call shape
+// without creating real Win32 pipes.
+
+/**
+ * Native `pipeAcl` surface, as exposed by the in-tree
+ * `ccsm_native.node` binding (frag-3.5.1 §3.5.1.1.a). Production
+ * wires this through the future `daemon/src/native/index.ts` swap
+ * interface; tests pass a fake.
+ *
+ * Methods MUST throw on non-Win32 platforms (`ENOSYS`); the wrapper
+ * never reaches the binding on non-Win32 (it returns early), so this
+ * is only a safety net for misconfigured production wiring.
+ */
+export interface NativePipeAclDeps {
+  /**
+   * Apply the owner-only DACL to an existing named pipe.
+   *
+   * Contract (per frag-6-7 §7.M1):
+   *   - Grants `GENERIC_READ | GENERIC_WRITE` to the current
+   *     process-token user SID only.
+   *   - Adds explicit `AddAccessDeniedAce` for `BUILTIN\Users`
+   *     (S-1-5-32-545) and `ANONYMOUS LOGON` (S-1-5-7).
+   *   - Sets `PIPE_REJECT_REMOTE_CLIENTS` on the pipe state.
+   *   - All five syscalls happen inside the native call so JS
+   *     never observes an intermediate-DACL state.
+   *
+   * MUST throw if the pipe does not exist, if the current process
+   * lacks `WRITE_DAC` on the pipe handle, or if `OpenProcessToken`
+   * fails. The wrapper does not catch — callers (decider) decide
+   * whether a failure is fatal (it is, for the daemon listener: a
+   * pipe with the default Everyone-DACL is a security failure that
+   * must fail boot, not log-and-continue).
+   *
+   * @param pipePath Full path of the named pipe, e.g.
+   *   `\\.\pipe\ccsm-daemon-<userSid>`. The native binding opens
+   *   the pipe with `CreateFile` to obtain a writable handle, so
+   *   the pipe must already exist (created by `net.Server.listen`)
+   *   before this call.
+   */
+  applyOwnerOnly(pipePath: string): void;
+}
+
+/**
+ * Optional dependency injection. Defaults to the in-tree native
+ * binding loader. Tests always inject fakes; production code also
+ * injects via the future `daemon/src/native/index.ts` shim (per
+ * §3.5.1.1.a "no direct native import" rule).
+ *
+ * Ignored on non-Win32 platforms — the wrapper returns silently
+ * without touching the native layer.
+ */
+export interface ApplyPipeAclOptions {
+  deps?: NativePipeAclDeps;
+}
+
+/**
+ * Apply the owner-only DACL to a named pipe.
+ *
+ * On Win32: invokes `deps.applyOwnerOnly(pipePath)` synchronously.
+ * Throws if the binding throws (fail-loud — see contract on
+ * `NativePipeAclDeps.applyOwnerOnly`).
+ *
+ * On non-Win32: returns silently. POSIX gets owner-only access via
+ * the unix-socket `chmod 0600` already performed by the socket
+ * listener module; the enclosing data-dir `0700` is a second layer.
+ *
+ * Callers do NOT need to platform-guard with
+ * `process.platform === 'win32'` — the cross-platform no-op stub
+ * makes the call site uniform.
+ *
+ * @param pipePath Full path of the named pipe (e.g.
+ *   `\\.\pipe\ccsm-daemon-<userSid>`). Ignored on non-Win32.
+ * @param options Optional dependency injection. Defaults to the
+ *   in-tree native binding loader (which throws until frag-11 lands
+ *   the `ccsm_native.node` binding).
+ */
+export function applyPipeAcl(
+  pipePath: string,
+  options: ApplyPipeAclOptions = {},
+): void {
+  if (process.platform !== 'win32') {
+    // POSIX path: unix-socket chmod 0600 is owned by
+    // daemon/src/socket/listener.ts; this wrapper is intentionally
+    // a no-op so call sites can be platform-agnostic.
+    return;
+  }
+
+  const deps = options.deps ?? loadDefaultDeps();
+  deps.applyOwnerOnly(pipePath);
+}
+
+/**
+ * Production-default dependency loader. The in-tree
+ * `ccsm_native.node` binding is owned by frag-11 (§3.5.1.1
+ * "Built artifact name"); until it lands, this throws a clear
+ * error directing callers to inject deps. Tests always inject; the
+ * daemon runtime path will be wired in the
+ * `daemon/src/native/index.ts` shim PR alongside the binding (per
+ * §3.5.1.1.a "no direct native import" rule, this module is NOT
+ * allowed to `require('../native/ccsm_native.node')` directly).
+ *
+ * The shellout fallback (`icacls "<pipePath>" /grant ...` or
+ * `taskkill`-style hacks) is intentionally NOT implemented here.
+ * `icacls` does not operate on named-pipe handles (it only handles
+ * filesystem ACLs) and there is no shell command that can set
+ * `PIPE_REJECT_REMOTE_CLIENTS` on an existing pipe — the spec
+ * contract is the native binding, period. Shipping a shellout stub
+ * would silently downgrade the spec's M1 "explicit DACL = current
+ * SID" guarantee to "best-effort grant of filesystem ACL on a
+ * non-existent path".
+ */
+function loadDefaultDeps(): NativePipeAclDeps {
+  throw new Error(
+    'applyPipeAcl: no default native deps available yet. ' +
+      'Pass `options.deps` until the in-tree ccsm_native binding ' +
+      '(frag-11 §11.4) lands and `daemon/src/native/index.ts` is wired.',
+  );
+}


### PR DESCRIPTION
## Summary
- Pure module `daemon/src/pty/pipe-acl.ts`: applies DACL to named pipes per spec §3.5.1.6.
- DI seam (`NativePipeAclDeps`) — mirrors T38/T39 patterns. `loadDefaultDeps()` throws until frag-11 wires `ccsm_native` binding.
- Non-Win32: silent no-op stub (POSIX socket modules already use chmod 0600).

## Verification
- `npm run typecheck`: clean (root + electron + daemon tsconfigs).
- `npx vitest run daemon/src/pty/__tests__/pipe-acl.test.ts`: 5 passed | 2 skipped (Win32-host run; non-Win32 skip block).
- `npm run build:daemon`: clean.
- ESM smoke load: `import('./daemon/dist-daemon/pty/pipe-acl.js')` exports `[ 'applyPipeAcl' ]`.
- Reverse-verified: corrupting `deps.applyOwnerOnly(pipePath + '_BUG')` flips two assertions to FAIL; reverting restores 5/5 PASS.

## Test plan
- [x] vitest: deps injection + reverse-verified
- [x] typecheck clean
- [x] ESM smoke load