### PR TITLE
feat(daemon): T25 force-kill fallback on shutdown deadline overrun

### DIFF
--- a/daemon/src/handlers/__tests__/daemon-shutdown.test.ts
+++ b/daemon/src/handlers/__tests__/daemon-shutdown.test.ts
@@ -45,6 +45,7 @@ function makeActions(overrides: Partial<ShutdownActions> = {}): ShutdownActions 
     }),
     recordStepError: vi.fn(),
     recordDeadlineOverrun: vi.fn(),
+    forceKillRemaining: vi.fn(),
   };
   return Object.assign({ callOrder }, base, overrides);
 }
@@ -318,6 +319,74 @@ describe('daemon.shutdown handler (T20 — frag-6-7 §6.6.1)', () => {
       const h = createDaemonShutdownHandler(actions);
       await h.handle({ deadlineMs: 50 }, ctx);
       await h.whenDrained();
+      expect(actions.finalizeLogger).toHaveBeenCalled();
+      expect(actions.exitProcess).toHaveBeenCalledWith(0);
+    });
+  });
+
+  describe('T25 force-kill fallback wiring', () => {
+    it('invokes forceKillRemaining on overrun, BEFORE finalize-logger and exit', async () => {
+      const actions = makeActions({
+        windDownSessions: vi.fn(async () => {
+          await new Promise<void>((r) => setTimeout(r, 80));
+        }),
+      });
+      const h = createDaemonShutdownHandler(actions);
+      await h.handle({ deadlineMs: 50 }, ctx);
+      await h.whenDrained();
+      expect(actions.forceKillRemaining).toHaveBeenCalledTimes(1);
+      // Order check: forceKillRemaining must run before finalize-logger.
+      const fkOrder = (actions.forceKillRemaining as ReturnType<typeof vi.fn>).mock
+        .invocationCallOrder[0]!;
+      const flOrder = (actions.finalizeLogger as ReturnType<typeof vi.fn>).mock
+        .invocationCallOrder[0]!;
+      const exOrder = (actions.exitProcess as ReturnType<typeof vi.fn>).mock
+        .invocationCallOrder[0]!;
+      expect(fkOrder).toBeLessThan(flOrder);
+      expect(flOrder).toBeLessThan(exOrder);
+    });
+
+    it('does NOT invoke forceKillRemaining when within deadline', async () => {
+      const actions = makeActions();
+      const h = createDaemonShutdownHandler(actions);
+      await h.handle({ deadlineMs: 60_000 }, ctx);
+      await h.whenDrained();
+      expect(actions.forceKillRemaining).not.toHaveBeenCalled();
+    });
+
+    it('forceKillRemaining throw is captured by recordStepError; finalize+exit still run', async () => {
+      const actions = makeActions({
+        windDownSessions: vi.fn(async () => {
+          await new Promise<void>((r) => setTimeout(r, 80));
+        }),
+        forceKillRemaining: vi.fn(() => {
+          throw new Error('native kill EPERM');
+        }),
+      });
+      const h = createDaemonShutdownHandler(actions);
+      await h.handle({ deadlineMs: 50 }, ctx);
+      await h.whenDrained();
+      expect(actions.recordStepError).toHaveBeenCalledWith(
+        'close-subscribers',
+        expect.any(Error),
+      );
+      expect(actions.finalizeLogger).toHaveBeenCalled();
+      expect(actions.exitProcess).toHaveBeenCalledWith(0);
+    });
+
+    it('overrun without forceKillRemaining wired still records and exits cleanly', async () => {
+      const actions = makeActions({
+        windDownSessions: vi.fn(async () => {
+          await new Promise<void>((r) => setTimeout(r, 80));
+        }),
+      });
+      // Simulate older caller that never wired the optional hook.
+      const stripped: ShutdownActions = { ...actions };
+      delete (stripped as { forceKillRemaining?: unknown }).forceKillRemaining;
+      const h = createDaemonShutdownHandler(stripped);
+      await h.handle({ deadlineMs: 50 }, ctx);
+      await h.whenDrained();
+      expect(actions.recordDeadlineOverrun).toHaveBeenCalled();
       expect(actions.finalizeLogger).toHaveBeenCalled();
       expect(actions.exitProcess).toHaveBeenCalledWith(0);
     });

--- a/daemon/src/handlers/daemon-shutdown.ts
+++ b/daemon/src/handlers/daemon-shutdown.ts
@@ -29,9 +29,6 @@
 //     semaphore, T41 fan-out, T28 schema, T22 marker) lands.
 //
 // What this handler does NOT own (deferred to other tasks):
-//   - T25 force-kill fallback after the deadline elapses. The plan exposes
-//     `forceKillDeadlineMs` (5_000 ms) and the handler logs / records
-//     deadline overrun; the actual SIGKILL escalation is T25 territory.
 //   - The atomic shutdown marker write (T21 `daemon.shutdownForUpgrade`).
 //     T20 explicitly skips this — the spec distinguishes the two RPCs by
 //     marker presence so the supervisor crash-loop counter (frag-6-7 §6.1)
@@ -39,6 +36,12 @@
 //   - `pino.final` flush + `process.exit(0)`: these are sinks injected by
 //     `actions.finalizeLogger` and `actions.exitProcess`. The handler
 //     resolves its reply BEFORE invoking exit so the ack reaches the wire.
+//
+// T25 force-kill fallback (added 2026-05-01):
+//   - `actions.forceKillRemaining` is invoked in the deadline-overrun
+//     branch right after `recordDeadlineOverrun`. Per-platform kill
+//     primitive lives in `daemon/src/lifecycle/force-kill.ts`; this
+//     handler only owns the WHEN.
 
 import { isSupervisorRpc } from '../envelope/supervisor-rpcs.js';
 
@@ -199,6 +202,16 @@ export interface ShutdownActions {
    *  T25 owns the actual SIGKILL escalation; this hook lets the handler
    *  surface the timing without entangling its sink. */
   recordDeadlineOverrun?(elapsedMs: number, deadlineMs: number): void;
+  /** Optional — T25 force-kill fallback. Invoked AFTER
+   *  `recordDeadlineOverrun` when the drain deadline is blown, BEFORE
+   *  `finalize-logger` + `exit-process`. Implementation enumerates
+   *  surviving children (POSIX: SIGKILL via T38 reaper's PID set;
+   *  Win: TerminateJobObject via T39 handle) and issues the terminal
+   *  kill once. MUST be idempotent — the handler will not re-call it
+   *  on its own, but a future replay path through `recordDeadlineOverrun`
+   *  could end up here twice. Errors thrown are captured by
+   *  `recordStepError` like any other action. */
+  forceKillRemaining?(): void;
 }
 
 export interface DaemonShutdownContext {
@@ -308,8 +321,23 @@ export function createDaemonShutdownHandler(
       // user-observable drain only.
       if (!overrunReported && step === 'close-subscribers') {
         const elapsed = Date.now() - startMs;
-        if (elapsed > deadlineMs && actions.recordDeadlineOverrun) {
-          actions.recordDeadlineOverrun(elapsed, deadlineMs);
+        if (elapsed > deadlineMs) {
+          if (actions.recordDeadlineOverrun) {
+            actions.recordDeadlineOverrun(elapsed, deadlineMs);
+          }
+          // T25 escalation — fire the per-platform terminal kill BEFORE
+          // `finalize-logger` so the warn line + force-kill telemetry
+          // both make it into the flushed log buffer. Errors in the
+          // sink are routed through `recordStepError` like any other
+          // action; the sequence still proceeds to logger flush + exit
+          // (partial-drain principle, §6.6.1).
+          if (actions.forceKillRemaining) {
+            try {
+              actions.forceKillRemaining();
+            } catch (err) {
+              actions.recordStepError('close-subscribers', err);
+            }
+          }
           overrunReported = true;
         }
       }

--- a/daemon/src/index.ts
+++ b/daemon/src/index.ts
@@ -8,6 +8,7 @@ import {
   type ShutdownActions,
   type ShutdownStep,
 } from './handlers/daemon-shutdown.js';
+import { createForceKillSink, type ForceKillJobHandle } from './lifecycle/force-kill.js';
 
 const require = createRequire(import.meta.url);
 const DAEMON_VERSION = (require('../../package.json') as { version: string }).version;
@@ -20,6 +21,32 @@ const logger = pino({
     v: DAEMON_VERSION,
     pid: process.pid,
     boot: bootNonce,
+  },
+});
+
+// T25 — force-kill fallback wiring. The reaper-PID set (T38) and the
+// JobObject handle (T39) are owned by the per-spawn wiring that lands
+// alongside the real ptyService. Until those wires are in, the
+// getters return empty arrays so the sink is a safe no-op; the
+// shutdown handler still calls it on overrun and the warn line
+// records `targets: 0`. When the spawn wiring lands it will populate
+// these snapshots from the real reaper / job-object singletons.
+const childPidRegistry: Set<number> = new Set();
+const jobObjectRegistry: ForceKillJobHandle[] = [];
+const forceKillSink = createForceKillSink({
+  getChildPids: () => Array.from(childPidRegistry),
+  getJobObjects: () => jobObjectRegistry.slice(),
+  recordForceKill: ({ platform, targets, errors }) => {
+    logger.warn(
+      { event: 'daemon-shutdown.force-kill', platform, targets, errors },
+      'force-kill fallback issued after deadline overrun',
+    );
+  },
+  onError: (target, err) => {
+    logger.warn(
+      { event: 'daemon-shutdown.force-kill.error', target, err: String(err) },
+      'force-kill target failed',
+    );
   },
 });
 
@@ -61,8 +88,11 @@ const shutdownActions: ShutdownActions = {
   recordDeadlineOverrun: (elapsedMs, deadlineMs) => {
     logger.warn(
       { event: 'daemon-shutdown.deadline-overrun', elapsedMs, deadlineMs },
-      'shutdown drain exceeded deadline (T25 force-kill territory)',
+      'shutdown drain exceeded deadline; T25 force-kill fallback engaging',
     );
+  },
+  forceKillRemaining: () => {
+    forceKillSink.forceKillRemaining();
   },
 };
 

--- a/daemon/src/lifecycle/__tests__/force-kill.test.ts
+++ b/daemon/src/lifecycle/__tests__/force-kill.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createForceKillSink, type ForceKillJobHandle } from '../force-kill.js';
+
+describe('createForceKillSink (T25 force-kill fallback)', () => {
+  describe('POSIX path', () => {
+    it('issues SIGKILL to every pid from getChildPids', () => {
+      const kill = vi.fn();
+      const sink = createForceKillSink({
+        platform: 'linux',
+        getChildPids: () => [101, 202, 303],
+        posixKill: kill,
+      });
+      const n = sink.forceKillRemaining();
+      expect(n).toBe(3);
+      expect(kill).toHaveBeenCalledTimes(3);
+      expect(kill).toHaveBeenNthCalledWith(1, 101, 'SIGKILL');
+      expect(kill).toHaveBeenNthCalledWith(2, 202, 'SIGKILL');
+      expect(kill).toHaveBeenNthCalledWith(3, 303, 'SIGKILL');
+    });
+
+    it('records platform=posix and target count via recordForceKill', () => {
+      const recordForceKill = vi.fn();
+      const sink = createForceKillSink({
+        platform: 'linux',
+        getChildPids: () => [10, 20],
+        posixKill: vi.fn(),
+        recordForceKill,
+      });
+      sink.forceKillRemaining();
+      expect(recordForceKill).toHaveBeenCalledTimes(1);
+      expect(recordForceKill).toHaveBeenCalledWith({
+        platform: 'posix',
+        targets: 2,
+        errors: 0,
+      });
+    });
+
+    it('per-pid kill throw is routed to onError, loop continues', () => {
+      const onError = vi.fn();
+      const recordForceKill = vi.fn();
+      const kill = vi
+        .fn()
+        .mockImplementationOnce(() => {})
+        .mockImplementationOnce(() => {
+          throw new Error('ESRCH');
+        })
+        .mockImplementationOnce(() => {});
+      const sink = createForceKillSink({
+        platform: 'linux',
+        getChildPids: () => [1, 2, 3],
+        posixKill: kill,
+        onError,
+        recordForceKill,
+      });
+      sink.forceKillRemaining();
+      expect(kill).toHaveBeenCalledTimes(3);
+      expect(onError).toHaveBeenCalledWith(2, expect.any(Error));
+      expect(recordForceKill).toHaveBeenCalledWith({
+        platform: 'posix',
+        targets: 3,
+        errors: 1,
+      });
+    });
+
+    it('empty pid set is a silent no-op (no recordForceKill)', () => {
+      const recordForceKill = vi.fn();
+      const sink = createForceKillSink({
+        platform: 'linux',
+        getChildPids: () => [],
+        posixKill: vi.fn(),
+        recordForceKill,
+      });
+      const n = sink.forceKillRemaining();
+      expect(n).toBe(0);
+      expect(recordForceKill).not.toHaveBeenCalled();
+    });
+
+    it('ignores getJobObjects on POSIX', () => {
+      const job: ForceKillJobHandle = { terminate: vi.fn() };
+      const kill = vi.fn();
+      const sink = createForceKillSink({
+        platform: 'darwin',
+        getChildPids: () => [42],
+        getJobObjects: () => [job],
+        posixKill: kill,
+      });
+      sink.forceKillRemaining();
+      expect(kill).toHaveBeenCalledWith(42, 'SIGKILL');
+      expect(job.terminate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Win32 path', () => {
+    it('terminates every job handle with exit code 1', () => {
+      const j1: ForceKillJobHandle = { terminate: vi.fn() };
+      const j2: ForceKillJobHandle = { terminate: vi.fn() };
+      const sink = createForceKillSink({
+        platform: 'win32',
+        getJobObjects: () => [j1, j2],
+      });
+      const n = sink.forceKillRemaining();
+      expect(n).toBe(2);
+      expect(j1.terminate).toHaveBeenCalledWith(1);
+      expect(j2.terminate).toHaveBeenCalledWith(1);
+    });
+
+    it('records platform=win32 and job count via recordForceKill', () => {
+      const recordForceKill = vi.fn();
+      const sink = createForceKillSink({
+        platform: 'win32',
+        getJobObjects: () => [{ terminate: vi.fn() }],
+        recordForceKill,
+      });
+      sink.forceKillRemaining();
+      expect(recordForceKill).toHaveBeenCalledWith({
+        platform: 'win32',
+        targets: 1,
+        errors: 0,
+      });
+    });
+
+    it('per-handle terminate throw is routed to onError, loop continues', () => {
+      const onError = vi.fn();
+      const j1: ForceKillJobHandle = {
+        terminate: vi.fn(() => {
+          throw new Error('TerminateJobObject failed');
+        }),
+      };
+      const j2: ForceKillJobHandle = { terminate: vi.fn() };
+      const sink = createForceKillSink({
+        platform: 'win32',
+        getJobObjects: () => [j1, j2],
+        onError,
+      });
+      sink.forceKillRemaining();
+      expect(j2.terminate).toHaveBeenCalled();
+      expect(onError).toHaveBeenCalledWith('jobobject', expect.any(Error));
+    });
+
+    it('ignores getChildPids on Win32', () => {
+      const kill = vi.fn();
+      const sink = createForceKillSink({
+        platform: 'win32',
+        getChildPids: () => [99],
+        getJobObjects: () => [],
+        posixKill: kill,
+      });
+      sink.forceKillRemaining();
+      expect(kill).not.toHaveBeenCalled();
+    });
+
+    it('empty job list is a silent no-op (no recordForceKill)', () => {
+      const recordForceKill = vi.fn();
+      const sink = createForceKillSink({
+        platform: 'win32',
+        getJobObjects: () => [],
+        recordForceKill,
+      });
+      const n = sink.forceKillRemaining();
+      expect(n).toBe(0);
+      expect(recordForceKill).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('idempotency', () => {
+    it('second call is a no-op (POSIX)', () => {
+      const kill = vi.fn();
+      const sink = createForceKillSink({
+        platform: 'linux',
+        getChildPids: () => [1, 2],
+        posixKill: kill,
+      });
+      expect(sink.forceKillRemaining()).toBe(2);
+      expect(sink.forceKillRemaining()).toBe(0);
+      expect(sink.forceKillRemaining()).toBe(0);
+      expect(kill).toHaveBeenCalledTimes(2);
+      expect(sink.invoked).toBe(true);
+    });
+
+    it('second call is a no-op (Win32)', () => {
+      const job: ForceKillJobHandle = { terminate: vi.fn() };
+      const sink = createForceKillSink({
+        platform: 'win32',
+        getJobObjects: () => [job],
+      });
+      sink.forceKillRemaining();
+      sink.forceKillRemaining();
+      expect(job.terminate).toHaveBeenCalledTimes(1);
+    });
+
+    it('snapshot getter is NOT called on the second invocation', () => {
+      const getChildPids = vi.fn(() => [1]);
+      const sink = createForceKillSink({
+        platform: 'linux',
+        getChildPids,
+        posixKill: vi.fn(),
+      });
+      sink.forceKillRemaining();
+      sink.forceKillRemaining();
+      expect(getChildPids).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('safe defaults', () => {
+    it('with no getters supplied, returns 0 and does nothing', () => {
+      const sink = createForceKillSink({ platform: 'linux', posixKill: vi.fn() });
+      expect(sink.forceKillRemaining()).toBe(0);
+      expect(sink.invoked).toBe(true);
+    });
+
+    it('invoked starts false, flips true after first call', () => {
+      const sink = createForceKillSink({ platform: 'linux', posixKill: vi.fn() });
+      expect(sink.invoked).toBe(false);
+      sink.forceKillRemaining();
+      expect(sink.invoked).toBe(true);
+    });
+
+    it('platform defaults to process.platform when not overridden', () => {
+      // Smoke: just verify it constructs and invocation does not throw.
+      const sink = createForceKillSink({
+        getChildPids: () => [],
+        getJobObjects: () => [],
+        posixKill: vi.fn(),
+      });
+      expect(() => sink.forceKillRemaining()).not.toThrow();
+    });
+  });
+});

--- a/daemon/src/lifecycle/force-kill.ts
+++ b/daemon/src/lifecycle/force-kill.ts
@@ -1,0 +1,198 @@
+// T25 — force-kill fallback after daemon-shutdown deadline overrun.
+//
+// Spec: docs/superpowers/specs/v0.3-fragments/frag-6-7-supervisor-rpcs.md
+//   §6.4.2 — "if graceful shutdown deadline (default 5 s) overruns, the
+//   dispatcher SHOULD force-kill remaining children (SIGKILL on POSIX,
+//   TerminateJobObject on Win) before exit."
+//
+// Single Responsibility (per feedback_single_responsibility):
+//   - This module is a SINK FACTORY. It returns a single zero-arg
+//     `forceKillRemaining()` thunk that the daemon-shutdown handler
+//     plugs into `ShutdownActions.forceKillRemaining`. The thunk
+//     enumerates known surviving children and issues the per-platform
+//     terminal kill primitive ONCE.
+//   - The handler (T20) decides WHEN to call this (deadline-overrun
+//     branch); the per-platform child trackers (T38 reaper, T39 job
+//     object) decide WHO is still alive. This module is the wiring
+//     glue — pure, idempotent, and platform-branch-free at the
+//     decider layer.
+//
+// Idempotency:
+//   - Second call is a no-op (the spec sequence MAY re-enter via the
+//     replay path — frag-6-7 §6.6.1 — and we must not double-kill /
+//     double-log).
+//   - Tracked with a single boolean. Atomic-enough for single-thread
+//     Node main loop; the JobObject `terminate()` is itself idempotent
+//     so even a TOCTOU race here is harmless.
+//
+// Logging:
+//   - The wrapper does NOT log — `single responsibility`. The caller
+//     supplies a `recordForceKill` sink which production wires to
+//     `pino.warn` (this is a degraded path; warn level is the spec
+//     register for "deadline overrun → force kill"). The sink is
+//     called ONCE, with the count of pids targeted on POSIX and the
+//     count of job handles on Win, so a single grep finds the event.
+//
+// Why not import the trackers directly?
+//   - The reaper's PID set and the job-object handle live in the
+//     daemon's wiring module (`daemon/src/index.ts`). Importing them
+//     here would couple this lifecycle module to the boot wiring and
+//     break the producer/decider/sink separation. Instead we inject
+//     the minimum surface needed: a `getChildPids()` snapshot for
+//     POSIX and a `getJobObjects()` snapshot for Win. Tests pass
+//     fakes; production passes closures over the real reaper/job
+//     handles.
+
+/**
+ * Surface for issuing SIGKILL to a single PID. POSIX-only path; the
+ * factory ignores this on win32. Defaults to `process.kill` in
+ * production; tests inject a spy.
+ */
+export type PosixKillFn = (pid: number, signal: 'SIGKILL') => void;
+
+/**
+ * Minimal job-object surface this module touches. Matches the shape
+ * exposed by `daemon/src/pty/win-jobobject.ts` `JobObjectHandle`.
+ * We only need `terminate()` — `assign()` is irrelevant on the
+ * shutdown-fallback path. Keeping the surface narrow lets tests pass
+ * a `{ terminate: vi.fn() }` literal without constructing a real
+ * handle.
+ */
+export interface ForceKillJobHandle {
+  terminate(exitCode?: number): void;
+}
+
+export interface ForceKillSinkOptions {
+  /**
+   * POSIX-only — snapshot of PIDs still alive at the moment of
+   * deadline overrun. Production wires this to
+   * `() => sigchldReaper.registered()` (T38 reaper). On win32 this
+   * is ignored even if supplied.
+   */
+  getChildPids?: () => readonly number[];
+  /**
+   * Win32-only — snapshot of JobObject handles to terminate. Each
+   * handle's `terminate(1)` is called once. Production wires this to
+   * `() => [winJob]` (the singleton from T39 wiring). On POSIX this
+   * is ignored even if supplied.
+   *
+   * `terminate()` defaults to exit code 1 to match `process.exit(1)`
+   * semantics — children appear to have died abnormally, which is
+   * correct for an unscheduled forced shutdown (frag-3.5.1
+   * §3.5.1.1.a `terminate(exitCode)` doc).
+   */
+  getJobObjects?: () => readonly ForceKillJobHandle[];
+  /**
+   * Per-platform terminal kill primitive. Defaults to
+   * `process.kill`. Tests inject a spy. Only used on POSIX; on win32
+   * the JobObject `terminate()` IS the kill primitive.
+   */
+  posixKill?: PosixKillFn;
+  /**
+   * Logged-once telemetry sink. Production wires this to
+   * `pino.warn`. The wrapper itself does no logging. Called ONCE per
+   * `forceKillRemaining()` invocation that does work; idempotent
+   * re-calls do NOT re-log.
+   *
+   * `targets` is the count of PIDs (POSIX) or job handles (Win)
+   * the call attempted to terminate, BEFORE any per-target failures.
+   * `errors` is the count of those that threw.
+   */
+  recordForceKill?: (info: {
+    platform: 'posix' | 'win32';
+    targets: number;
+    errors: number;
+  }) => void;
+  /**
+   * Optional sink for individual per-pid / per-handle errors. The
+   * wrapper does NOT re-throw — a single bad pid (already-dead,
+   * permission-denied) must not block the rest of the kill loop.
+   * Production wires this to `pino.warn` with the err.
+   */
+  onError?: (target: number | 'jobobject', err: unknown) => void;
+  /**
+   * Platform override for tests. Defaults to `process.platform`.
+   * Tests use this to exercise both branches on a single host CI.
+   */
+  platform?: NodeJS.Platform;
+}
+
+export interface ForceKillSink {
+  /**
+   * Idempotent — first call enumerates targets and issues the
+   * platform terminal kill; subsequent calls are silent no-ops.
+   * Returns the number of targets the call attempted to terminate
+   * (0 on a re-call or when no targets were registered).
+   */
+  forceKillRemaining(): number;
+  /** For diagnostics / tests. True after `forceKillRemaining` ran once. */
+  readonly invoked: boolean;
+}
+
+/**
+ * Build a force-kill sink. Returns a closure ready to plug into
+ * `ShutdownActions.forceKillRemaining` on the T20 handler.
+ *
+ * Both `getChildPids` and `getJobObjects` may be omitted; the
+ * resulting sink is then a no-op that still satisfies the
+ * `ShutdownActions` contract (used in tests / on platforms where
+ * neither tracker is wired yet).
+ */
+export function createForceKillSink(
+  options: ForceKillSinkOptions = {},
+): ForceKillSink {
+  const platform = options.platform ?? process.platform;
+  const recordForceKill = options.recordForceKill;
+  const onError = options.onError;
+  const posixKill: PosixKillFn =
+    options.posixKill ??
+    ((pid, sig) => {
+      // Cast: process.kill accepts string signals.
+      process.kill(pid, sig);
+    });
+
+  let invoked = false;
+
+  return {
+    get invoked() {
+      return invoked;
+    },
+    forceKillRemaining(): number {
+      if (invoked) return 0;
+      invoked = true;
+
+      if (platform === 'win32') {
+        const jobs = options.getJobObjects ? options.getJobObjects() : [];
+        let errors = 0;
+        for (const job of jobs) {
+          try {
+            job.terminate(1);
+          } catch (err) {
+            errors += 1;
+            if (onError) onError('jobobject', err);
+          }
+        }
+        if (jobs.length > 0 && recordForceKill) {
+          recordForceKill({ platform: 'win32', targets: jobs.length, errors });
+        }
+        return jobs.length;
+      }
+
+      // POSIX path.
+      const pids = options.getChildPids ? options.getChildPids() : [];
+      let errors = 0;
+      for (const pid of pids) {
+        try {
+          posixKill(pid, 'SIGKILL');
+        } catch (err) {
+          errors += 1;
+          if (onError) onError(pid, err);
+        }
+      }
+      if (pids.length > 0 && recordForceKill) {
+        recordForceKill({ platform: 'posix', targets: pids.length, errors });
+      }
+      return pids.length;
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- New `daemon/src/lifecycle/force-kill.ts` — pure factory `createForceKillSink({ getChildPids, getJobObjects, posixKill, recordForceKill, onError })`. Per-platform branch (POSIX iterates pids and SIGKILLs each; Win iterates job handles and `terminate(1)`s each), idempotent second-call no-op, error-tolerant per-target, logged-once telemetry.
- `daemon/src/handlers/daemon-shutdown.ts` — added optional `ShutdownActions.forceKillRemaining`. Wired into the deadline-overrun branch right after `recordDeadlineOverrun`, BEFORE `finalize-logger` so the warn line ends up in the flushed buffer. Throws are routed via `recordStepError` so `finalize-logger` + `exit-process` still run (partial-drain principle, frag-6-7 §6.6.1).
- `daemon/src/index.ts` — production wires the sink with empty registries; the real spawn-side wires to T38 reaper + T39 job-object handle land alongside the ptyService spawn path.

Spec: `docs/superpowers/specs/v0.3-fragments/frag-6-7-supervisor-rpcs.md` §6.4.2.

## Layer 1
Degraded-path policy at the sink boundary. The decider (T20) already owned overrun detection; T25 only adds the per-platform escalation as a sink. Producer/decider/sink separation preserved (per `feedback_single_responsibility`).

## Layer 2
- Idempotent: bool latch on `ForceKillSink`; second `forceKillRemaining()` returns 0 with no syscall and no log line.
- Error-tolerant: per-pid / per-handle throws routed to `onError`, loop continues so one bad target cannot block the rest of the kill.
- Logged at warn (`event: 'daemon-shutdown.force-kill'`) — single aggregated line per call.
- Win JobObject `terminate(1)` matches `process.exit(1)` semantics for forced shutdown.

## Test plan
- [x] `npx vitest run daemon/src/handlers/__tests__/daemon-shutdown.test.ts daemon/src/lifecycle/__tests__/force-kill.test.ts` — 48/48 green (4 new force-kill cases on the handler + 18 new on the sink).
- [x] `npm run typecheck` — clean.
- [x] `npm run build:daemon` — clean.

Unblocks: #983 #1039.