### PR TITLE
feat(daemon): T42 stream-heartbeat scheduler

### DIFF
--- a/daemon/src/pty/__tests__/stream-heartbeat-scheduler.test.ts
+++ b/daemon/src/pty/__tests__/stream-heartbeat-scheduler.test.ts
@@ -1,0 +1,335 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createHeartbeatScheduler,
+  DEFAULT_HEARTBEAT_MS,
+  MAX_HEARTBEAT_MS,
+  MIN_HEARTBEAT_MS,
+  type HeartbeatScheduler,
+} from '../stream-heartbeat-scheduler.js';
+
+// Hermetic timing — vi.useFakeTimers() patches global setInterval /
+// clearInterval, which the scheduler picks up via its default timer
+// hooks. No injection needed for the common path; the
+// "custom-timers" suite exercises the injection seam separately.
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('stream-heartbeat-scheduler: construction', () => {
+  it('rejects missing sendHeartbeat', () => {
+    expect(() =>
+      // @ts-expect-error — exercise runtime guard
+      createHeartbeatScheduler({ intervalMs: 30_000 }),
+    ).toThrow(TypeError);
+  });
+  it('rejects non-finite / non-integer intervals', () => {
+    expect(() =>
+      createHeartbeatScheduler({ intervalMs: Number.NaN, sendHeartbeat: () => {} }),
+    ).toThrow(RangeError);
+    expect(() =>
+      createHeartbeatScheduler({ intervalMs: Infinity, sendHeartbeat: () => {} }),
+    ).toThrow(RangeError);
+    expect(() =>
+      createHeartbeatScheduler({ intervalMs: 30_000.5, sendHeartbeat: () => {} }),
+    ).toThrow(RangeError);
+  });
+  it('clamps below-min interval to MIN_HEARTBEAT_MS', () => {
+    const send = vi.fn();
+    const sch = createHeartbeatScheduler({ intervalMs: 100, sendHeartbeat: send });
+    sch.start('a');
+    vi.advanceTimersByTime(MIN_HEARTBEAT_MS - 1);
+    expect(send).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(send).toHaveBeenCalledWith('a');
+    sch.stop('a');
+  });
+  it('clamps above-max interval to MAX_HEARTBEAT_MS', () => {
+    const send = vi.fn();
+    const sch = createHeartbeatScheduler({
+      intervalMs: 10 * 60 * 1000, // 10 min — over cap
+      sendHeartbeat: send,
+    });
+    sch.start('a');
+    vi.advanceTimersByTime(MAX_HEARTBEAT_MS - 1);
+    expect(send).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(send).toHaveBeenCalledWith('a');
+    sch.stop('a');
+  });
+  it('defaults to 30 s when intervalMs omitted', () => {
+    const send = vi.fn();
+    const sch = createHeartbeatScheduler({ sendHeartbeat: send });
+    sch.start('a');
+    vi.advanceTimersByTime(DEFAULT_HEARTBEAT_MS - 1);
+    expect(send).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(send).toHaveBeenCalledTimes(1);
+    sch.stop('a');
+  });
+});
+
+describe('stream-heartbeat-scheduler: start / stop lifecycle', () => {
+  let send: ReturnType<typeof vi.fn>;
+  let sch: HeartbeatScheduler;
+
+  beforeEach(() => {
+    send = vi.fn();
+    sch = createHeartbeatScheduler({ intervalMs: 10_000, sendHeartbeat: send });
+  });
+
+  it('emits at intervalMs cadence', () => {
+    sch.start('s1');
+    expect(sch.running()).toBe(1);
+    vi.advanceTimersByTime(10_000);
+    expect(send).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(10_000);
+    expect(send).toHaveBeenCalledTimes(2);
+    vi.advanceTimersByTime(10_000);
+    expect(send).toHaveBeenCalledTimes(3);
+    expect(send).toHaveBeenLastCalledWith('s1');
+  });
+
+  it('first tick is one full interval after start, not immediate', () => {
+    sch.start('s1');
+    vi.advanceTimersByTime(9_999);
+    expect(send).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('stop cancels future ticks', () => {
+    sch.start('s1');
+    vi.advanceTimersByTime(10_000);
+    expect(send).toHaveBeenCalledTimes(1);
+    sch.stop('s1');
+    expect(sch.running()).toBe(0);
+    vi.advanceTimersByTime(60_000);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('double-start is idempotent (no phase reset, no double schedule)', () => {
+    sch.start('s1');
+    vi.advanceTimersByTime(5_000);
+    sch.start('s1'); // must NOT reset phase, must NOT add a second timer
+    expect(sch.running()).toBe(1);
+    vi.advanceTimersByTime(5_000);
+    // If start had reset phase, send count would still be 0 here.
+    // If start had double-scheduled, send count would be 2.
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('stop on unknown subId is a silent no-op', () => {
+    expect(() => sch.stop('never-started')).not.toThrow();
+    expect(sch.running()).toBe(0);
+  });
+
+  it('isolates multiple subIds', () => {
+    sch.start('a');
+    sch.start('b');
+    sch.start('c');
+    expect(sch.running()).toBe(3);
+    vi.advanceTimersByTime(10_000);
+    expect(send).toHaveBeenCalledTimes(3);
+    const calls = send.mock.calls.map((c) => c[0] as string).sort();
+    expect(calls).toEqual(['a', 'b', 'c']);
+
+    sch.stop('b');
+    send.mockClear();
+    vi.advanceTimersByTime(10_000);
+    const second = send.mock.calls.map((c) => c[0] as string).sort();
+    expect(second).toEqual(['a', 'c']);
+  });
+
+  it('swallows sendHeartbeat throws so one bad subId cannot starve others', () => {
+    const calls: string[] = [];
+    const sch2 = createHeartbeatScheduler({
+      intervalMs: 10_000,
+      sendHeartbeat: (id) => {
+        calls.push(id);
+        if (id === 'bad') throw new Error('boom');
+      },
+    });
+    sch2.start('bad');
+    sch2.start('good');
+    expect(() => vi.advanceTimersByTime(10_000)).not.toThrow();
+    expect(calls.sort()).toEqual(['bad', 'good']);
+    // Next tick still happens for both — bad subId did not get
+    // unscheduled by the throw.
+    calls.length = 0;
+    vi.advanceTimersByTime(10_000);
+    expect(calls.sort()).toEqual(['bad', 'good']);
+    sch2.stop('bad');
+    sch2.stop('good');
+  });
+
+  it('ticks counter is monotonic across all subIds', () => {
+    sch.start('a');
+    sch.start('b');
+    vi.advanceTimersByTime(10_000);
+    expect(sch.ticks()).toBe(2);
+    vi.advanceTimersByTime(10_000);
+    expect(sch.ticks()).toBe(4);
+    sch.stop('a');
+    sch.stop('b');
+  });
+});
+
+describe('stream-heartbeat-scheduler: updateInterval', () => {
+  it('applies on next tick — shortened interval', () => {
+    const send = vi.fn();
+    const sch = createHeartbeatScheduler({ intervalMs: 30_000, sendHeartbeat: send });
+    sch.start('a');
+    vi.advanceTimersByTime(30_000);
+    expect(send).toHaveBeenCalledTimes(1);
+    sch.updateInterval(5_000);
+    // Next tick should land 5_000 after the updateInterval call,
+    // not 30_000 — old timer torn down.
+    vi.advanceTimersByTime(4_999);
+    expect(send).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(1);
+    expect(send).toHaveBeenCalledTimes(2);
+    vi.advanceTimersByTime(5_000);
+    expect(send).toHaveBeenCalledTimes(3);
+    sch.stop('a');
+  });
+
+  it('applies on next tick — lengthened interval', () => {
+    const send = vi.fn();
+    const sch = createHeartbeatScheduler({ intervalMs: 5_000, sendHeartbeat: send });
+    sch.start('a');
+    vi.advanceTimersByTime(5_000);
+    expect(send).toHaveBeenCalledTimes(1);
+    sch.updateInterval(60_000);
+    vi.advanceTimersByTime(5_000);
+    expect(send).toHaveBeenCalledTimes(1); // old 5 s would have fired here
+    vi.advanceTimersByTime(55_000);
+    expect(send).toHaveBeenCalledTimes(2);
+    sch.stop('a');
+  });
+
+  it('applies to all running subIds at once', () => {
+    const send = vi.fn();
+    const sch = createHeartbeatScheduler({ intervalMs: 30_000, sendHeartbeat: send });
+    sch.start('a');
+    sch.start('b');
+    sch.updateInterval(5_000);
+    vi.advanceTimersByTime(5_000);
+    expect(send).toHaveBeenCalledTimes(2);
+    const ids = send.mock.calls.map((c) => c[0] as string).sort();
+    expect(ids).toEqual(['a', 'b']);
+    sch.stop('a');
+    sch.stop('b');
+  });
+
+  it('no-op when newMs equals current interval (no timer churn)', () => {
+    const cleared: unknown[] = [];
+    const set: unknown[] = [];
+    const sch = createHeartbeatScheduler({
+      intervalMs: 10_000,
+      sendHeartbeat: () => {},
+      timers: {
+        setInterval: (cb, ms) => {
+          const h = setInterval(cb, ms);
+          set.push(h);
+          return h;
+        },
+        clearInterval: (h) => {
+          cleared.push(h);
+          clearInterval(h as ReturnType<typeof setInterval>);
+        },
+      },
+    });
+    sch.start('a');
+    expect(set).toHaveLength(1);
+    sch.updateInterval(10_000); // same value — must not churn
+    expect(set).toHaveLength(1);
+    expect(cleared).toHaveLength(0);
+    sch.stop('a');
+  });
+
+  it('clamps newMs below MIN_HEARTBEAT_MS', () => {
+    const send = vi.fn();
+    const sch = createHeartbeatScheduler({ intervalMs: 30_000, sendHeartbeat: send });
+    sch.start('a');
+    sch.updateInterval(100); // → clamped to 5_000
+    vi.advanceTimersByTime(MIN_HEARTBEAT_MS - 1);
+    expect(send).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(send).toHaveBeenCalledTimes(1);
+    sch.stop('a');
+  });
+
+  it('clamps newMs above MAX_HEARTBEAT_MS', () => {
+    const send = vi.fn();
+    const sch = createHeartbeatScheduler({ intervalMs: 30_000, sendHeartbeat: send });
+    sch.start('a');
+    sch.updateInterval(60 * 60 * 1000); // 1 h → clamped to 5 min
+    vi.advanceTimersByTime(MAX_HEARTBEAT_MS - 1);
+    expect(send).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(send).toHaveBeenCalledTimes(1);
+    sch.stop('a');
+  });
+
+  it('rejects non-integer / non-finite newMs', () => {
+    const sch = createHeartbeatScheduler({
+      intervalMs: 30_000,
+      sendHeartbeat: () => {},
+    });
+    expect(() => sch.updateInterval(Number.NaN)).toThrow(RangeError);
+    expect(() => sch.updateInterval(Infinity)).toThrow(RangeError);
+    expect(() => sch.updateInterval(10_000.5)).toThrow(RangeError);
+  });
+
+  it('does NOT notify or restart anything beyond its own timers (decoupled from T44)', () => {
+    // Contract test: updateInterval mutates ONLY the scheduler's own
+    // setInterval handles. There is no callback hook for "interval
+    // changed" — the wiring layer recomputes the detector deadline on
+    // its own schedule per spec §6.5.1.
+    const sch = createHeartbeatScheduler({
+      intervalMs: 30_000,
+      sendHeartbeat: () => {},
+    });
+    // The returned shape exposes exactly the 5 documented members.
+    // Adding a side-effect hook would surface here as a public API
+    // breakage — that's the test's whole point.
+    expect(Object.keys(sch).sort()).toEqual(
+      ['running', 'start', 'stop', 'ticks', 'updateInterval'].sort(),
+    );
+  });
+});
+
+describe('stream-heartbeat-scheduler: custom timer hook injection', () => {
+  it('routes setInterval / clearInterval through injected hooks', () => {
+    let scheduledMs: number | undefined;
+    let scheduledCb: (() => void) | undefined;
+    let cleared = false;
+    const fakeHandle = Symbol('fake-timer');
+    const sch = createHeartbeatScheduler({
+      intervalMs: 30_000,
+      sendHeartbeat: vi.fn(),
+      timers: {
+        setInterval: (cb, ms) => {
+          scheduledCb = cb;
+          scheduledMs = ms;
+          return fakeHandle;
+        },
+        clearInterval: (h) => {
+          expect(h).toBe(fakeHandle);
+          cleared = true;
+        },
+      },
+    });
+    sch.start('a');
+    expect(scheduledMs).toBe(30_000);
+    expect(typeof scheduledCb).toBe('function');
+    sch.stop('a');
+    expect(cleared).toBe(true);
+  });
+});

--- a/daemon/src/pty/stream-heartbeat-scheduler.ts
+++ b/daemon/src/pty/stream-heartbeat-scheduler.ts
@@ -1,0 +1,253 @@
+// Per-subscriber heartbeat sender for the PTY fan-out path.
+//
+// Spec: docs/superpowers/specs/v0.3-fragments/frag-3.5.1-pty-hardening.md
+//   - §3.5.1.4 — server-streaming RPCs (`ptySubscribe`,
+//     `subscribeNotifications`, `subscribeSessionUpdates`) emit a
+//     periodic heartbeat envelope so the client-side T44
+//     stream-dead-detector + the v0.5 CF Tunnel half-open-socket
+//     detector have a positive liveness signal even on idle streams.
+//   - frag-6-7 §6.5.1 — the symmetric server-side dead-stream
+//     detector uses the formula `2 × heartbeatMs + 5_000`. That
+//     formula lives at the WIRING layer, not here and not in the
+//     detector — so renegotiating `heartbeatMs` mid-stream needs no
+//     detector restart (this scheduler picks up the new interval on
+//     the next tick).
+//   - frag-3.4.1 §3.4.1.c `x-ccsm-heartbeat-ms` envelope header
+//     drives the negotiated interval. Default 30_000 ms; clamp range
+//     5_000..300_000 ms (5 s..5 min) — below 5 s would beat the
+//     local-pipe p99 budget, above 5 min would defeat the half-open
+//     detector contract.
+//
+// Single Responsibility (per `feedback_single_responsibility`):
+//   - This module is a SCHEDULER (timing + lifecycle) only.
+//   - PRODUCER role: the timer fires `sendHeartbeat(subId)` —
+//     `sendHeartbeat` is INJECTED by the wiring layer. The scheduler
+//     does not know how to transmit, what envelope shape to write,
+//     which socket to write to, or how to mark the registry. All of
+//     that lives in the caller (T48 fromBootNonce wiring is one such
+//     caller).
+//   - DECIDER role: NONE. There is no decision logic here — fixed
+//     interval per subId, period adjustable via `updateInterval`.
+//   - SINK role: NONE. No socket I/O, no log emission, no registry
+//     coupling, no ack tracking (that is T44's stream-dead-detector).
+//
+// Hard non-goals (push back if asked):
+//   - No socket writes — caller wires `sendHeartbeat` to fanout.
+//   - No envelope construction — caller owns wire format.
+//   - No detector coupling — the `2 × heartbeatMs + 5_000` formula
+//     and the `lastClientActivityAt` map are NOT in this module.
+//   - No log emission — schedule/cancel/tick events are silent;
+//     production wiring may instrument by wrapping `sendHeartbeat`.
+//   - No clamp policy in the sender path — clamp happens once at
+//     `createHeartbeatScheduler` and again at `updateInterval`. We
+//     do NOT silently coerce on every tick.
+
+/**
+ * Opaque subscriber identifier. Same id space as
+ * `stream-dead-detector.SubscriberId`; the scheduler treats ids as
+ * bare strings and never relates them to fan-out registry objects.
+ */
+export type SubscriberId = string;
+
+/**
+ * Default heartbeat interval per spec §3.5.1.4 (frag-3.4.1
+ * `x-ccsm-heartbeat-ms` reservation).
+ */
+export const DEFAULT_HEARTBEAT_MS = 30_000;
+
+/**
+ * Inclusive lower clamp on the negotiated heartbeat interval.
+ * 5 s — leaves headroom over local-pipe p99 (Task 7 acceptance
+ * benchmark targets p95 < 5 ms) so the heartbeat path is never the
+ * dominant traffic.
+ */
+export const MIN_HEARTBEAT_MS = 5_000;
+
+/**
+ * Inclusive upper clamp on the negotiated heartbeat interval.
+ * 5 min — beyond this the half-open-socket detector window
+ * (`2 × heartbeatMs + 5_000`) exceeds practical patience for a CF
+ * Tunnel reconnection; v0.5 will revisit if the wire pricing model
+ * changes.
+ */
+export const MAX_HEARTBEAT_MS = 300_000;
+
+/**
+ * Indirection over `setInterval` / `clearInterval` for hermetic tests
+ * that do NOT want to enable `vi.useFakeTimers()` globally. If unset,
+ * the scheduler falls back to the host `setInterval` / `clearInterval`
+ * — vitest's fake timers patch those at the host level, so the common
+ * test path still works without injecting anything.
+ */
+export interface TimerHooks {
+  setInterval: (cb: () => void, ms: number) => unknown;
+  clearInterval: (handle: unknown) => void;
+}
+
+export interface HeartbeatSchedulerOptions {
+  /**
+   * Initial heartbeat interval in milliseconds. Will be validated +
+   * clamped to `[MIN_HEARTBEAT_MS, MAX_HEARTBEAT_MS]`. Defaults to
+   * `DEFAULT_HEARTBEAT_MS` (30 s) if unset.
+   */
+  intervalMs?: number;
+  /**
+   * Wiring-layer transmit callback. Invoked once per scheduled tick
+   * per active subId. The scheduler does NOT inspect the return
+   * value, NOR await a returned Promise (heartbeats are
+   * fire-and-forget — backpressure is the caller's drop-slowest
+   * problem, not the scheduler's). Throws are caught and swallowed
+   * so a single bad subscriber cannot starve the others on the
+   * shared timer.
+   */
+  sendHeartbeat: (subId: SubscriberId) => void;
+  /**
+   * Optional clock injection (mirrors stream-dead-detector). The
+   * scheduler does not actually consult the clock for tick timing
+   * (the timer hook owns that) — `now` is exposed only for the
+   * `ticks` counter's debug story. Defaults to `Date.now`.
+   */
+  now?: () => number;
+  /**
+   * Optional timer hook injection (see `TimerHooks`). Defaults to the
+   * host `setInterval` / `clearInterval`.
+   */
+  timers?: TimerHooks;
+}
+
+export interface HeartbeatScheduler {
+  /**
+   * Begin emitting heartbeats for `subId`. Idempotent — calling
+   * `start` on an already-running subId is a no-op (does NOT reset
+   * the in-flight timer phase, does NOT double-schedule). The first
+   * heartbeat fires after one full `intervalMs`, NOT immediately —
+   * subscribe-time the wiring layer typically writes the snapshot
+   * frame anyway, so an immediate heartbeat would be redundant.
+   */
+  start(subId: SubscriberId): void;
+  /**
+   * Stop emitting heartbeats for `subId`. Idempotent — stopping an
+   * unknown subId is a silent no-op (matches `forget()` semantics on
+   * the detector side: the wiring layer can fire stop on every
+   * unsubscribe path without checking).
+   */
+  stop(subId: SubscriberId): void;
+  /**
+   * Replace the interval. Validates + clamps to
+   * `[MIN_HEARTBEAT_MS, MAX_HEARTBEAT_MS]` (non-finite / non-integer
+   * inputs throw `RangeError` — silent coercion would mask bugs in
+   * the negotiation path). All currently-running subIds pick up the
+   * new interval on their NEXT tick: the scheduler tears down each
+   * timer and re-arms with the new period. Critically this does NOT
+   * notify the T44 stream-dead-detector — per spec §6.5.1 the
+   * detector formula lives at the wiring layer, so the wiring layer
+   * is responsible for recomputing `deadlineMs` if it cares.
+   */
+  updateInterval(newMs: number): void;
+  /**
+   * Number of currently-running subIds. For tests + diagnostics.
+   */
+  running(): number;
+  /**
+   * Total tick count across all subIds since construction. Monotonic.
+   * For tests + diagnostics — production wiring should instrument
+   * via wrapping `sendHeartbeat` if it wants per-subId counters.
+   */
+  ticks(): number;
+}
+
+function validateInterval(ms: number, label: string): number {
+  if (!Number.isFinite(ms) || !Number.isInteger(ms)) {
+    throw new RangeError(
+      `stream-heartbeat-scheduler: ${label} must be a finite integer, got ${String(ms)}`,
+    );
+  }
+  if (ms < MIN_HEARTBEAT_MS) return MIN_HEARTBEAT_MS;
+  if (ms > MAX_HEARTBEAT_MS) return MAX_HEARTBEAT_MS;
+  return ms;
+}
+
+/**
+ * Create a heartbeat scheduler. The daemon process holds one shared
+ * instance across all PTY sessions (perf-P1-C — single setInterval is
+ * cheaper than one-per-subscriber); tests typically construct a fresh
+ * instance per case.
+ */
+export function createHeartbeatScheduler(
+  opts: HeartbeatSchedulerOptions,
+): HeartbeatScheduler {
+  if (typeof opts.sendHeartbeat !== 'function') {
+    throw new TypeError(
+      'stream-heartbeat-scheduler: sendHeartbeat callback is required',
+    );
+  }
+  let intervalMs = validateInterval(
+    opts.intervalMs ?? DEFAULT_HEARTBEAT_MS,
+    'intervalMs',
+  );
+  const sendHeartbeat = opts.sendHeartbeat;
+  // `now` is only used by `ticks()` consumers indirectly; we retain
+  // the option for symmetry with stream-dead-detector even though the
+  // scheduler does not need wall-clock arithmetic.
+  void (opts.now ?? Date.now);
+
+  const hostTimers: TimerHooks = opts.timers ?? {
+    setInterval: (cb, ms) => setInterval(cb, ms),
+    clearInterval: (handle) => clearInterval(handle as ReturnType<typeof setInterval>),
+  };
+
+  // subId -> active timer handle. Map presence === "running".
+  const handles = new Map<SubscriberId, unknown>();
+  let totalTicks = 0;
+
+  function arm(subId: SubscriberId): unknown {
+    return hostTimers.setInterval(() => {
+      totalTicks++;
+      try {
+        sendHeartbeat(subId);
+      } catch {
+        // Swallow — one bad subscriber must not starve the shared
+        // scheduler. Wiring layer is expected to instrument by
+        // wrapping `sendHeartbeat` if it wants observability.
+      }
+    }, intervalMs);
+  }
+
+  function start(subId: SubscriberId): void {
+    if (handles.has(subId)) return; // idempotent — no phase reset
+    handles.set(subId, arm(subId));
+  }
+
+  function stop(subId: SubscriberId): void {
+    const h = handles.get(subId);
+    if (h === undefined) return; // idempotent — no-op on unknown
+    hostTimers.clearInterval(h);
+    handles.delete(subId);
+  }
+
+  function updateInterval(newMs: number): void {
+    const next = validateInterval(newMs, 'newMs');
+    if (next === intervalMs) return; // no churn on no-op renegotiation
+    intervalMs = next;
+    // Re-arm every running subId at the new period. Tearing down +
+    // re-arming means the next tick lands at `now + newMs`, which is
+    // the correct semantic for "applies on next tick" — leaving the
+    // old timer to fire one last time would defeat the whole point
+    // of a renegotiation that shortens the interval (e.g. supervisor
+    // dropping it from 30 s to 5 s during an active diagnostic).
+    for (const [subId, h] of handles) {
+      hostTimers.clearInterval(h);
+      handles.set(subId, arm(subId));
+    }
+  }
+
+  function running(): number {
+    return handles.size;
+  }
+
+  function ticks(): number {
+    return totalTicks;
+  }
+
+  return { start, stop, updateInterval, running, ticks };
+}


### PR DESCRIPTION
## Summary
- Pure scheduler companion to T44 stream-dead detector (already merged).
- `sendHeartbeat` injected — scheduler is timing/lifecycle only; no socket I/O, no log emission, no registry coupling.
- `updateInterval` applies on next tick; detector unaffected per spec contract (`2 × heartbeatMs + 5_000` formula stays at the WIRING layer per frag-6-7 §6.5.1).
- Default 30 s, clamped to [5 s, 5 min]; renegotiation via `x-ccsm-heartbeat-ms` envelope header.

## Spec
- `docs/superpowers/specs/v0.3-fragments/frag-3.5.1-pty-hardening.md` §3.5.1.4 (heartbeat sender)
- `docs/superpowers/specs/v0.3-fragments/frag-6-7-reliability-security.md` §6.5.1 (cross-frag handoff: detector formula at wiring layer)

## API
- `createHeartbeatScheduler({ intervalMs?, sendHeartbeat, now?, timers? })` → `{ start, stop, updateInterval, running, ticks }`
- `start(subId)` idempotent, no phase reset, no double-schedule
- `stop(subId)` idempotent, silent on unknown
- `updateInterval(newMs)` validates + clamps + re-arms all running subIds (next tick lands at `now + newMs`)

## Test plan
- [x] vitest with `vi.useFakeTimers()` — 22/22 hermetic cases pass
- [x] Reverse-verify: removed `updateInterval` re-arm loop → 5 tests fail; reverted → 22/22 pass
- [x] `npm run typecheck` clean
- [x] `npm run build:daemon` clean
- [x] ESM smoke load: `import('./daemon/dist-daemon/pty/stream-heartbeat-scheduler.js')` exposes `createHeartbeatScheduler`, `DEFAULT_HEARTBEAT_MS`, `MIN_HEARTBEAT_MS`, `MAX_HEARTBEAT_MS`

## Layer 1 (necessity / approach)
- Required by spec §3.5.1.4 — symmetric companion to T44 detector (already merged).
- Pure scheduler split per `feedback_single_responsibility`: producer (timer fires) / decider (none — fixed interval) / sink (none — caller owns transmit).
- No detector coupling matches frag-6-7 §6.5.1 explicit decoupling requirement so `heartbeatMs` renegotiation is cheap.

## Downstream
Unblocks #1005 (T48 fromBootNonce wiring) which will inject the actual `sendHeartbeat` callback into the fanout-registry.