### PR TITLE
feat(electron): T33 migration in-progress modal driver

### DIFF
--- a/electron/migration/__tests__/modal-driver.test.ts
+++ b/electron/migration/__tests__/modal-driver.test.ts
@@ -1,0 +1,564 @@
+// Hermetic tests for the migration modal driver (T33).
+//
+// Coverage:
+//   - Pure decider `reduce`: every state × event transition incl. no-ops.
+//   - Driver wiring: IPC send fires on transitions, `done` auto-hide
+//     timer, `failed` sticky-until-dismiss, dispose cleans up timers
+//     and listeners.
+//   - IPC payload parser: structurally invalid events are dropped.
+//   - Wire-contract parity: event-name constants match the daemon-side
+//     T30 source-of-truth file.
+//   - Reverse-verify: each invariant is re-checked after a counter-
+//     scenario to guard against the test passing for trivial reasons.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// `electron` is a runtime-only dep in main; mock it so the test runs in
+// plain node. We only use `BrowserWindow` as a type here; the real type
+// shape is satisfied by our stub.
+vi.mock('electron', () => ({
+  BrowserWindow: class {},
+}));
+
+import {
+  reduce,
+  createModalDriver,
+  HIDDEN_STATE,
+  DEFAULT_DONE_FLASH_MS,
+  IPC_CHANNEL_MODAL_STATE,
+  IPC_CHANNEL_RELAY_EVENT,
+  IPC_CHANNEL_DISMISS,
+  MIGRATION_EVENT_NAMES,
+  type ModalState,
+  type MigrationEvent,
+  type MigrationStartedEvent,
+  type MigrationCompletedEvent,
+  type MigrationFailedEvent,
+  __testing,
+} from '../modal-driver';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function startedEvent(over: Partial<MigrationStartedEvent> = {}): MigrationStartedEvent {
+  return {
+    event: MIGRATION_EVENT_NAMES.started,
+    traceId: 'trace-1',
+    sourcePath: 'C:/legacy/ccsm.db',
+    fromVersion: 1,
+    toVersion: 3,
+    startedAt: 1_700_000_000_000,
+    ...over,
+  };
+}
+
+function completedEvent(
+  over: Partial<MigrationCompletedEvent> = {}
+): MigrationCompletedEvent {
+  return {
+    event: MIGRATION_EVENT_NAMES.completed,
+    traceId: 'trace-1',
+    fromVersion: 1,
+    toVersion: 3,
+    durationMs: 320,
+    rowsConverted: 42,
+    ...over,
+  };
+}
+
+function failedEvent(over: Partial<MigrationFailedEvent> = {}): MigrationFailedEvent {
+  return {
+    event: MIGRATION_EVENT_NAMES.failed,
+    traceId: 'trace-1',
+    fromVersion: 1,
+    toVersion: 3,
+    reason: 'copy_failed',
+    errorMessage: 'EBUSY: file locked',
+    errorCode: 'EBUSY',
+    ...over,
+  };
+}
+
+interface StubWebContents {
+  isDestroyed: () => boolean;
+  send: ReturnType<typeof vi.fn>;
+}
+interface StubWin {
+  isDestroyed: () => boolean;
+  webContents: StubWebContents;
+}
+function makeStubWin(opts: { destroyed?: boolean; wcDestroyed?: boolean } = {}): StubWin {
+  return {
+    isDestroyed: () => Boolean(opts.destroyed),
+    webContents: {
+      isDestroyed: () => Boolean(opts.wcDestroyed),
+      send: vi.fn(),
+    },
+  };
+}
+
+// EventEmitter satisfies the subset of IpcMain we use (`on`, `removeListener`).
+function makeIpcMain(): EventEmitter & { sentChannels(): string[] } {
+  const ee = new EventEmitter() as EventEmitter & { sentChannels(): string[] };
+  ee.sentChannels = () => ee.eventNames().map(String);
+  return ee;
+}
+
+// ---------------------------------------------------------------------------
+// Pure decider tests
+// ---------------------------------------------------------------------------
+
+describe('reduce — state machine', () => {
+  it('hidden + started → in_progress carrying full started payload', () => {
+    const ev = startedEvent({ traceId: 't-x', startedAt: 9000 });
+    const next = reduce(HIDDEN_STATE, ev);
+    expect(next.status).toBe('in_progress');
+    if (next.status !== 'in_progress') throw new Error('narrow');
+    expect(next.traceId).toBe('t-x');
+    expect(next.sourcePath).toBe('C:/legacy/ccsm.db');
+    expect(next.fromVersion).toBe(1);
+    expect(next.toVersion).toBe(3);
+    expect(next.startedAt).toBe(9000);
+  });
+
+  it('in_progress + completed → done carrying duration + rows', () => {
+    const inProg = reduce(HIDDEN_STATE, startedEvent());
+    const next = reduce(inProg, completedEvent({ durationMs: 555, rowsConverted: 7 }));
+    expect(next.status).toBe('done');
+    if (next.status !== 'done') throw new Error('narrow');
+    expect(next.durationMs).toBe(555);
+    expect(next.rowsConverted).toBe(7);
+  });
+
+  it('in_progress + failed → failed carrying reason + error', () => {
+    const inProg = reduce(HIDDEN_STATE, startedEvent());
+    const next = reduce(
+      inProg,
+      failedEvent({ reason: 'disk_full', errorMessage: 'no space', errorCode: 'ENOSPC' })
+    );
+    expect(next.status).toBe('failed');
+    if (next.status !== 'failed') throw new Error('narrow');
+    expect(next.reason).toBe('disk_full');
+    expect(next.errorMessage).toBe('no space');
+    expect(next.errorCode).toBe('ENOSPC');
+  });
+
+  it('double-start while in_progress is ignored (first banner wins)', () => {
+    const first = reduce(HIDDEN_STATE, startedEvent({ traceId: 'first' }));
+    const after = reduce(first, startedEvent({ traceId: 'second' }));
+    expect(after).toBe(first);
+    if (after.status !== 'in_progress') throw new Error('narrow');
+    expect(after.traceId).toBe('first');
+  });
+
+  it('completed/failed while hidden are ignored (out-of-order events)', () => {
+    expect(reduce(HIDDEN_STATE, completedEvent())).toBe(HIDDEN_STATE);
+    expect(reduce(HIDDEN_STATE, failedEvent())).toBe(HIDDEN_STATE);
+  });
+
+  it('terminal states (done, failed) ignore further events', () => {
+    const inProg = reduce(HIDDEN_STATE, startedEvent());
+    const done = reduce(inProg, completedEvent());
+    expect(reduce(done, startedEvent({ traceId: 'x' }))).toBe(done);
+    expect(reduce(done, failedEvent())).toBe(done);
+    expect(reduce(done, completedEvent())).toBe(done);
+
+    const failed = reduce(inProg, failedEvent());
+    expect(reduce(failed, startedEvent({ traceId: 'x' }))).toBe(failed);
+    expect(reduce(failed, completedEvent())).toBe(failed);
+    expect(reduce(failed, failedEvent({ reason: 'corrupt_legacy' }))).toBe(failed);
+  });
+
+  it('full happy-path sequence: hidden → in_progress → done', () => {
+    let s: ModalState = HIDDEN_STATE;
+    s = reduce(s, startedEvent());
+    expect(s.status).toBe('in_progress');
+    s = reduce(s, completedEvent());
+    expect(s.status).toBe('done');
+  });
+
+  it('reverse-verify: a completed delivered without a prior started never flips state', () => {
+    // If reduce silently accepted any completed, the previous "ignored
+    // when hidden" assertion could pass for the wrong reason. Confirm by
+    // hammering many completeds against hidden — none should flip.
+    let s: ModalState = HIDDEN_STATE;
+    for (let i = 0; i < 5; i += 1) s = reduce(s, completedEvent());
+    expect(s.status).toBe('hidden');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Driver wiring tests
+// ---------------------------------------------------------------------------
+
+describe('createModalDriver — IPC + timers', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('pushes ModalState over IPC_CHANNEL_MODAL_STATE on each transition', () => {
+    const win = makeStubWin();
+    const ipcMain = makeIpcMain();
+    const driver = createModalDriver({
+      getMainWindow: () => win as never,
+      ipcMain: ipcMain as never,
+    });
+
+    driver.applyEvent(startedEvent());
+    driver.applyEvent(completedEvent());
+
+    const calls = win.webContents.send.mock.calls;
+    expect(calls.length).toBe(2);
+    expect(calls[0][0]).toBe(IPC_CHANNEL_MODAL_STATE);
+    expect((calls[0][1] as ModalState).status).toBe('in_progress');
+    expect((calls[1][1] as ModalState).status).toBe('done');
+
+    driver.dispose();
+  });
+
+  it('does NOT push when the decider returns the same state (no-op events)', () => {
+    const win = makeStubWin();
+    const ipcMain = makeIpcMain();
+    const driver = createModalDriver({
+      getMainWindow: () => win as never,
+      ipcMain: ipcMain as never,
+    });
+
+    // Hidden + completed = no transition.
+    driver.applyEvent(completedEvent());
+    expect(win.webContents.send).not.toHaveBeenCalled();
+
+    driver.applyEvent(startedEvent());
+    expect(win.webContents.send).toHaveBeenCalledTimes(1);
+
+    // Double-start: no second send.
+    driver.applyEvent(startedEvent({ traceId: 'second' }));
+    expect(win.webContents.send).toHaveBeenCalledTimes(1);
+
+    driver.dispose();
+  });
+
+  it('done auto-hides after the flash window (default 1000ms)', () => {
+    expect(DEFAULT_DONE_FLASH_MS).toBe(1_000);
+    const win = makeStubWin();
+    const ipcMain = makeIpcMain();
+    const driver = createModalDriver({
+      getMainWindow: () => win as never,
+      ipcMain: ipcMain as never,
+    });
+
+    driver.applyEvent(startedEvent());
+    driver.applyEvent(completedEvent());
+    expect(driver.peek().status).toBe('done');
+
+    vi.advanceTimersByTime(DEFAULT_DONE_FLASH_MS - 1);
+    expect(driver.peek().status).toBe('done');
+    vi.advanceTimersByTime(1);
+    expect(driver.peek().status).toBe('hidden');
+
+    // Verify the hidden push reached the renderer.
+    const lastCall = win.webContents.send.mock.calls.at(-1);
+    expect(lastCall?.[0]).toBe(IPC_CHANNEL_MODAL_STATE);
+    expect((lastCall?.[1] as ModalState).status).toBe('hidden');
+
+    driver.dispose();
+  });
+
+  it('honours doneFlashMs override', () => {
+    const win = makeStubWin();
+    const ipcMain = makeIpcMain();
+    const driver = createModalDriver({
+      getMainWindow: () => win as never,
+      ipcMain: ipcMain as never,
+      doneFlashMs: 50,
+    });
+    driver.applyEvent(startedEvent());
+    driver.applyEvent(completedEvent());
+    vi.advanceTimersByTime(49);
+    expect(driver.peek().status).toBe('done');
+    vi.advanceTimersByTime(1);
+    expect(driver.peek().status).toBe('hidden');
+    driver.dispose();
+  });
+
+  it('failed is sticky and does NOT auto-hide', () => {
+    const win = makeStubWin();
+    const ipcMain = makeIpcMain();
+    const driver = createModalDriver({
+      getMainWindow: () => win as never,
+      ipcMain: ipcMain as never,
+    });
+    driver.applyEvent(startedEvent());
+    driver.applyEvent(failedEvent());
+
+    // Even after a long time, failed remains.
+    vi.advanceTimersByTime(60_000);
+    expect(driver.peek().status).toBe('failed');
+
+    driver.dispose();
+  });
+
+  it('dismiss() clears failed back to hidden + pushes hidden state', () => {
+    const win = makeStubWin();
+    const ipcMain = makeIpcMain();
+    const driver = createModalDriver({
+      getMainWindow: () => win as never,
+      ipcMain: ipcMain as never,
+    });
+    driver.applyEvent(startedEvent());
+    driver.applyEvent(failedEvent());
+    win.webContents.send.mockClear();
+
+    const after = driver.dismiss();
+    expect(after.status).toBe('hidden');
+    expect(win.webContents.send).toHaveBeenCalledTimes(1);
+    expect((win.webContents.send.mock.calls[0][1] as ModalState).status).toBe('hidden');
+
+    driver.dispose();
+  });
+
+  it('dismiss() while not failed is a no-op (does not clear in_progress)', () => {
+    const win = makeStubWin();
+    const ipcMain = makeIpcMain();
+    const driver = createModalDriver({
+      getMainWindow: () => win as never,
+      ipcMain: ipcMain as never,
+    });
+    driver.applyEvent(startedEvent());
+    win.webContents.send.mockClear();
+
+    const after = driver.dismiss();
+    expect(after.status).toBe('in_progress');
+    expect(win.webContents.send).not.toHaveBeenCalled();
+
+    driver.dispose();
+  });
+
+  it('skips send when window is destroyed (no throw, state still tracked)', () => {
+    let destroyed = false;
+    const win: StubWin = {
+      isDestroyed: () => destroyed,
+      webContents: {
+        isDestroyed: () => destroyed,
+        send: vi.fn(),
+      },
+    };
+    const ipcMain = makeIpcMain();
+    const driver = createModalDriver({
+      getMainWindow: () => win as never,
+      ipcMain: ipcMain as never,
+    });
+    destroyed = true;
+    expect(() => driver.applyEvent(startedEvent())).not.toThrow();
+    expect(win.webContents.send).not.toHaveBeenCalled();
+    expect(driver.peek().status).toBe('in_progress');
+    driver.dispose();
+  });
+
+  it('skips send when getMainWindow returns null', () => {
+    const ipcMain = makeIpcMain();
+    const driver = createModalDriver({
+      getMainWindow: () => null,
+      ipcMain: ipcMain as never,
+    });
+    expect(() => driver.applyEvent(startedEvent())).not.toThrow();
+    expect(driver.peek().status).toBe('in_progress');
+    driver.dispose();
+  });
+
+  it('IPC relay channel feeds applyEvent (renderer → main path)', () => {
+    const win = makeStubWin();
+    const ipcMain = makeIpcMain();
+    const driver = createModalDriver({
+      getMainWindow: () => win as never,
+      ipcMain: ipcMain as never,
+    });
+
+    ipcMain.emit(IPC_CHANNEL_RELAY_EVENT, {} as never, startedEvent());
+    expect(driver.peek().status).toBe('in_progress');
+    ipcMain.emit(IPC_CHANNEL_RELAY_EVENT, {} as never, completedEvent());
+    expect(driver.peek().status).toBe('done');
+
+    driver.dispose();
+  });
+
+  it('IPC dismiss channel triggers dismiss', () => {
+    const win = makeStubWin();
+    const ipcMain = makeIpcMain();
+    const driver = createModalDriver({
+      getMainWindow: () => win as never,
+      ipcMain: ipcMain as never,
+    });
+    driver.applyEvent(startedEvent());
+    driver.applyEvent(failedEvent());
+    expect(driver.peek().status).toBe('failed');
+
+    ipcMain.emit(IPC_CHANNEL_DISMISS, {} as never);
+    expect(driver.peek().status).toBe('hidden');
+
+    driver.dispose();
+  });
+
+  it('relay drops malformed events without throwing', () => {
+    const win = makeStubWin();
+    const ipcMain = makeIpcMain();
+    const driver = createModalDriver({
+      getMainWindow: () => win as never,
+      ipcMain: ipcMain as never,
+    });
+
+    ipcMain.emit(IPC_CHANNEL_RELAY_EVENT, {} as never, { event: 'bogus' });
+    ipcMain.emit(IPC_CHANNEL_RELAY_EVENT, {} as never, null);
+    ipcMain.emit(IPC_CHANNEL_RELAY_EVENT, {} as never, { event: MIGRATION_EVENT_NAMES.started });
+    expect(driver.peek().status).toBe('hidden');
+    expect(win.webContents.send).not.toHaveBeenCalled();
+
+    driver.dispose();
+  });
+
+  it('dispose removes IPC listeners and clears the done timer', () => {
+    const win = makeStubWin();
+    const ipcMain = makeIpcMain();
+    const driver = createModalDriver({
+      getMainWindow: () => win as never,
+      ipcMain: ipcMain as never,
+    });
+    expect(ipcMain.listenerCount(IPC_CHANNEL_RELAY_EVENT)).toBe(1);
+    expect(ipcMain.listenerCount(IPC_CHANNEL_DISMISS)).toBe(1);
+
+    driver.applyEvent(startedEvent());
+    driver.applyEvent(completedEvent());
+    win.webContents.send.mockClear();
+
+    driver.dispose();
+    expect(ipcMain.listenerCount(IPC_CHANNEL_RELAY_EVENT)).toBe(0);
+    expect(ipcMain.listenerCount(IPC_CHANNEL_DISMISS)).toBe(0);
+
+    // Timer should be cleared — advancing past flash window must not push.
+    vi.advanceTimersByTime(DEFAULT_DONE_FLASH_MS * 2);
+    expect(win.webContents.send).not.toHaveBeenCalled();
+
+    // Repeated dispose is a no-op.
+    expect(() => driver.dispose()).not.toThrow();
+  });
+
+  it('reverse-verify: WITHOUT dispose, listeners stay attached (proves dispose actually does work)', () => {
+    const win = makeStubWin();
+    const ipcMain = makeIpcMain();
+    const driver = createModalDriver({
+      getMainWindow: () => win as never,
+      ipcMain: ipcMain as never,
+    });
+    expect(ipcMain.listenerCount(IPC_CHANNEL_RELAY_EVENT)).toBe(1);
+    // Don't dispose — count remains 1, and a second driver doubles it.
+    const driver2 = createModalDriver({
+      getMainWindow: () => win as never,
+      ipcMain: ipcMain as never,
+    });
+    expect(ipcMain.listenerCount(IPC_CHANNEL_RELAY_EVENT)).toBe(2);
+    driver.dispose();
+    driver2.dispose();
+    expect(ipcMain.listenerCount(IPC_CHANNEL_RELAY_EVENT)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Parser tests (defensive structural validation)
+// ---------------------------------------------------------------------------
+
+describe('parseEvent — structural validation', () => {
+  const { parseEvent } = __testing;
+
+  it('accepts valid started/completed/failed payloads', () => {
+    expect(parseEvent(startedEvent())?.event).toBe(MIGRATION_EVENT_NAMES.started);
+    expect(parseEvent(completedEvent())?.event).toBe(MIGRATION_EVENT_NAMES.completed);
+    expect(parseEvent(failedEvent())?.event).toBe(MIGRATION_EVENT_NAMES.failed);
+  });
+
+  it('drops null / non-object / wrong type', () => {
+    expect(parseEvent(null)).toBeNull();
+    expect(parseEvent(undefined)).toBeNull();
+    expect(parseEvent('migration.started')).toBeNull();
+    expect(parseEvent(42)).toBeNull();
+    expect(parseEvent({})).toBeNull();
+  });
+
+  it('drops payloads with unknown event name', () => {
+    expect(parseEvent({ event: 'migration.progress', traceId: 't' })).toBeNull();
+  });
+
+  it('drops payloads missing required fields', () => {
+    expect(parseEvent({ event: MIGRATION_EVENT_NAMES.started })).toBeNull();
+    expect(
+      parseEvent({
+        event: MIGRATION_EVENT_NAMES.completed,
+        traceId: 't',
+        fromVersion: 1,
+        toVersion: 3,
+        // missing durationMs + rowsConverted
+      })
+    ).toBeNull();
+    expect(
+      parseEvent({
+        event: MIGRATION_EVENT_NAMES.failed,
+        traceId: 't',
+        fromVersion: 1,
+        toVersion: 3,
+        reason: 'copy_failed',
+        // missing errorMessage
+      })
+    ).toBeNull();
+  });
+
+  it('accepts failed without optional errorCode', () => {
+    const ev = parseEvent({
+      event: MIGRATION_EVENT_NAMES.failed,
+      traceId: 't',
+      fromVersion: 1,
+      toVersion: 3,
+      reason: 'copy_failed',
+      errorMessage: 'oops',
+    });
+    expect(ev?.event).toBe(MIGRATION_EVENT_NAMES.failed);
+    if (ev?.event !== MIGRATION_EVENT_NAMES.failed) throw new Error('narrow');
+    expect(ev.errorCode).toBeUndefined();
+  });
+
+  it('rejects failed with non-string errorCode', () => {
+    expect(
+      parseEvent({
+        event: MIGRATION_EVENT_NAMES.failed,
+        traceId: 't',
+        fromVersion: 1,
+        toVersion: 3,
+        reason: 'copy_failed',
+        errorMessage: 'oops',
+        errorCode: 42,
+      })
+    ).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wire-contract parity with daemon T30 source-of-truth
+// ---------------------------------------------------------------------------
+
+describe('wire-contract parity with daemon/src/db/migration-events.ts (T30)', () => {
+  // We can't import from daemon/ in the electron tsconfig context, so
+  // grep the file at test time and assert the canonical constant strings
+  // match. If T30 ever renames an event, this trip-wires immediately.
+  it('event-name string constants match T30', () => {
+    const t30Path = path.resolve(__dirname, '../../../daemon/src/db/migration-events.ts');
+    const src = fs.readFileSync(t30Path, 'utf8');
+    expect(src).toContain(`started: '${MIGRATION_EVENT_NAMES.started}'`);
+    expect(src).toContain(`completed: '${MIGRATION_EVENT_NAMES.completed}'`);
+    expect(src).toContain(`failed: '${MIGRATION_EVENT_NAMES.failed}'`);
+  });
+});

--- a/electron/migration/modal-driver.ts
+++ b/electron/migration/modal-driver.ts
@@ -1,0 +1,440 @@
+// T33 — Migration in-progress modal driver (frag-8 §8.5 / §8.6).
+//
+// SRP layering (per project rules `feedback_single_responsibility`):
+//   * PRODUCER: the daemon migration runner (T29) emits MigrationEvent
+//     records over IPC. We do not own production here.
+//   * DECIDER: `reduce(state, event)` — pure state-transition function
+//     turning the {hidden, in_progress, failed, done} state machine.
+//     Hermetically testable, no I/O.
+//   * SINK: `createModalDriver` wires the IPC stream to the decider and
+//     pushes the resolved ModalState to the renderer over channel
+//     `migration:modalState`. Side effect is exactly one `webContents.send`
+//     per state transition.
+//
+// State machine (frag-8 §8.6 manager r9 lock — indeterminate spinner,
+// progress event NOT in the wire contract; T30 declares only the three
+// events `migration.started` / `migration.completed` / `migration.failed`):
+//
+//   hidden ──started──▶ in_progress ──completed──▶ done ──(1s)──▶ hidden
+//                                  └──failed─────▶ failed (sticky until
+//                                                          dismiss())
+//   any other event from `hidden`              → ignored
+//   `started` while in_progress / done / failed → ignored (double-start
+//                                                 is a no-op, the first
+//                                                 banner stays sticky;
+//                                                 frag-8 §8.5 S1 ensures
+//                                                 only one runner ever
+//                                                 fires per boot, but the
+//                                                 driver is defensive).
+//
+// `done` is a brief flash (DEFAULT_DONE_FLASH_MS = 1000ms) that auto-
+// transitions to `hidden`. `failed` is sticky — only `dismiss()` (renderer
+// modal X / Quit-button click handler) can clear it back to `hidden`.
+// Per spec the failed modal's only action is "Quit ccsm" so in production
+// the dismiss path is mostly academic, but exposing it keeps the driver
+// usable from tests and from any future renderer that wants to clear the
+// state on quit.
+//
+// IPC channel naming follows the existing convention in
+// `electron/notify/sinks/flashSink.ts`: `<domain>:<event>` lower-camel.
+
+import type { BrowserWindow, IpcMain, IpcMainEvent } from 'electron';
+
+// ---------------------------------------------------------------------------
+// Wire-contract types — structural mirror of `daemon/src/db/migration-events.ts`.
+//
+// We cannot `import` from `daemon/` because `tsconfig.electron.json` has
+// `include: ["electron/**/*", "src/shared/**/*"]` and excludes the daemon
+// source tree. Re-declaring the union keeps the electron build self-
+// contained; the contract is closed (only three events ever) and the
+// daemon-side file is the source of truth. If T30 ever grows a fourth
+// event, both files must be updated together — the test
+// `modal-driver.test.ts > 'wire-contract event names match T30 constants'`
+// will fail loud if these strings drift.
+// ---------------------------------------------------------------------------
+
+export const MIGRATION_EVENT_NAMES = {
+  started: 'migration.started',
+  completed: 'migration.completed',
+  failed: 'migration.failed',
+} as const;
+
+export type MigrationEventName =
+  (typeof MIGRATION_EVENT_NAMES)[keyof typeof MIGRATION_EVENT_NAMES];
+
+export interface MigrationStartedEvent {
+  readonly event: typeof MIGRATION_EVENT_NAMES.started;
+  readonly traceId: string;
+  readonly sourcePath: string;
+  readonly fromVersion: number;
+  readonly toVersion: number;
+  readonly startedAt: number;
+}
+
+export interface MigrationCompletedEvent {
+  readonly event: typeof MIGRATION_EVENT_NAMES.completed;
+  readonly traceId: string;
+  readonly fromVersion: number;
+  readonly toVersion: number;
+  readonly durationMs: number;
+  readonly rowsConverted: number;
+}
+
+export interface MigrationFailedEvent {
+  readonly event: typeof MIGRATION_EVENT_NAMES.failed;
+  readonly traceId: string;
+  readonly fromVersion: number;
+  readonly toVersion: number;
+  readonly reason: string;
+  readonly errorMessage: string;
+  readonly errorCode?: string;
+}
+
+export type MigrationEvent =
+  | MigrationStartedEvent
+  | MigrationCompletedEvent
+  | MigrationFailedEvent;
+
+// ---------------------------------------------------------------------------
+// Modal state — what the renderer sees.
+// ---------------------------------------------------------------------------
+
+export type ModalStatus = 'hidden' | 'in_progress' | 'failed' | 'done';
+
+/**
+ * Discriminated union sent to the renderer. Renderer translates via the
+ * `migration.modal.in_progress.*` / `migration.modal.failed.*` i18n keys.
+ *
+ * - `hidden`        — modal not shown.
+ * - `in_progress`   — indeterminate spinner; carries `traceId` for support
+ *                     correlation with daemon log.
+ * - `done`          — brief success flash before auto-hiding.
+ * - `failed`        — sticky fatal-error modal; carries the reason +
+ *                     errorMessage so the renderer can surface support
+ *                     details (frag-8 §8.6 modal copy).
+ */
+export type ModalState =
+  | { status: 'hidden' }
+  | {
+      status: 'in_progress';
+      traceId: string;
+      sourcePath: string;
+      fromVersion: number;
+      toVersion: number;
+      startedAt: number;
+    }
+  | {
+      status: 'done';
+      traceId: string;
+      fromVersion: number;
+      toVersion: number;
+      durationMs: number;
+      rowsConverted: number;
+    }
+  | {
+      status: 'failed';
+      traceId: string;
+      fromVersion: number;
+      toVersion: number;
+      reason: string;
+      errorMessage: string;
+      errorCode?: string;
+    };
+
+export const HIDDEN_STATE: ModalState = { status: 'hidden' };
+
+/** Default flash duration before `done` → `hidden`. 1s per task spec. */
+export const DEFAULT_DONE_FLASH_MS = 1_000;
+
+/** IPC channel for state push: main → renderer. */
+export const IPC_CHANNEL_MODAL_STATE = 'migration:modalState';
+
+/** IPC channel renderer → main: forwards a daemon migration event. The
+ *  daemon talks to the renderer over the existing daemon socket; the
+ *  renderer relays each event through this channel so the driver (which
+ *  runs in main, where the BrowserWindow lives) can compute state and
+ *  push the result back. Keeping the relay in the renderer side avoids
+ *  giving main a second daemon connection just to listen for migration
+ *  events.
+ *
+ *  Alternative (when wired): if a future task gives main a direct
+ *  daemon-event subscription, the driver can call `applyEvent` from there
+ *  and this channel becomes unused. Exposed as a constant so the renderer
+ *  bridge has a single source of truth. */
+export const IPC_CHANNEL_RELAY_EVENT = 'migration:relayEvent';
+
+/** IPC channel renderer → main: user dismissed the failed modal. */
+export const IPC_CHANNEL_DISMISS = 'migration:dismiss';
+
+// ---------------------------------------------------------------------------
+// Pure decider — `reduce(state, event)`.
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the next modal state from the current state + an incoming event.
+ *
+ * Rules (see file header diagram):
+ *   - `hidden + started`            → `in_progress`
+ *   - `in_progress + completed`     → `done`         (caller schedules
+ *                                                     the auto-hide)
+ *   - `in_progress + failed`        → `failed`
+ *   - `started` while non-`hidden`  → unchanged (defensive double-start)
+ *   - any non-`started` event while `hidden` → unchanged (out-of-order /
+ *                                                          stray event)
+ *   - `completed` / `failed` while `done` or `failed` → unchanged
+ *     (terminal; only `dismiss` resets to hidden)
+ */
+export function reduce(state: ModalState, event: MigrationEvent): ModalState {
+  switch (event.event) {
+    case MIGRATION_EVENT_NAMES.started: {
+      if (state.status !== 'hidden') {
+        // Double-start: the first transition wins. Logging is the caller's
+        // job; the decider stays pure.
+        return state;
+      }
+      return {
+        status: 'in_progress',
+        traceId: event.traceId,
+        sourcePath: event.sourcePath,
+        fromVersion: event.fromVersion,
+        toVersion: event.toVersion,
+        startedAt: event.startedAt,
+      };
+    }
+    case MIGRATION_EVENT_NAMES.completed: {
+      if (state.status !== 'in_progress') return state;
+      return {
+        status: 'done',
+        traceId: event.traceId,
+        fromVersion: event.fromVersion,
+        toVersion: event.toVersion,
+        durationMs: event.durationMs,
+        rowsConverted: event.rowsConverted,
+      };
+    }
+    case MIGRATION_EVENT_NAMES.failed: {
+      if (state.status !== 'in_progress') return state;
+      return {
+        status: 'failed',
+        traceId: event.traceId,
+        fromVersion: event.fromVersion,
+        toVersion: event.toVersion,
+        reason: event.reason,
+        errorMessage: event.errorMessage,
+        errorCode: event.errorCode,
+      };
+    }
+    default: {
+      // Exhaustiveness guard — if T30 ever adds a fourth event, this
+      // forces a compile error (`never` narrowing).
+      const _exhaustive: never = event;
+      void _exhaustive;
+      return state;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sink wiring — connects IPC + timers + state to the renderer.
+// ---------------------------------------------------------------------------
+
+export interface ModalDriverOptions {
+  /** Returns the BrowserWindow we should push state to, or null if the
+   *  window isn't ready yet. Mirrors flashSink's pattern. */
+  getMainWindow: () => BrowserWindow | null;
+  /** ipcMain handle (passed in for testability). */
+  ipcMain: IpcMain;
+  /** Override the `done` auto-hide duration in tests. */
+  doneFlashMs?: number;
+}
+
+export interface ModalDriver {
+  /**
+   * Apply a migration event. Computes next state, sends to renderer if
+   * the state changed, schedules auto-hide on `done`.
+   *
+   * Returns the resolved next state (useful for tests + callers that want
+   * to log).
+   */
+  applyEvent(event: MigrationEvent): ModalState;
+  /** User dismissed the failed modal — reset to `hidden`. */
+  dismiss(): ModalState;
+  /** Inspect current state (test seam). */
+  peek(): ModalState;
+  /** Tear down listeners + timers. Idempotent. */
+  dispose(): void;
+}
+
+export function createModalDriver(opts: ModalDriverOptions): ModalDriver {
+  const doneFlashMs = opts.doneFlashMs ?? DEFAULT_DONE_FLASH_MS;
+  let state: ModalState = HIDDEN_STATE;
+  let doneTimer: NodeJS.Timeout | null = null;
+  let disposed = false;
+
+  function send(next: ModalState): void {
+    const win = opts.getMainWindow();
+    if (!win || win.isDestroyed()) return;
+    if (win.webContents.isDestroyed()) return;
+    try {
+      win.webContents.send(IPC_CHANNEL_MODAL_STATE, next);
+    } catch (err) {
+      console.warn('[migration/modal-driver] send failed', err);
+    }
+  }
+
+  function clearDoneTimer(): void {
+    if (doneTimer) {
+      clearTimeout(doneTimer);
+      doneTimer = null;
+    }
+  }
+
+  function scheduleDoneAutoHide(): void {
+    clearDoneTimer();
+    const t = setTimeout(() => {
+      doneTimer = null;
+      // Only flip to hidden if we're still in `done`; if a new migration
+      // somehow started in the meantime (shouldn't happen but defensive)
+      // don't clobber its state.
+      if (state.status === 'done') {
+        state = HIDDEN_STATE;
+        send(state);
+      }
+    }, doneFlashMs);
+    if (typeof t.unref === 'function') t.unref();
+    doneTimer = t;
+  }
+
+  function transitionTo(next: ModalState): ModalState {
+    if (next === state) return state;
+    state = next;
+    send(state);
+    if (state.status === 'done') scheduleDoneAutoHide();
+    return state;
+  }
+
+  // IPC bridge from renderer relay channel.
+  function onRelay(_e: IpcMainEvent, raw: unknown): void {
+    if (disposed) return;
+    const ev = parseEvent(raw);
+    if (!ev) return;
+    applyEvent(ev);
+  }
+  function onDismiss(_e: IpcMainEvent): void {
+    if (disposed) return;
+    dismiss();
+  }
+
+  opts.ipcMain.on(IPC_CHANNEL_RELAY_EVENT, onRelay);
+  opts.ipcMain.on(IPC_CHANNEL_DISMISS, onDismiss);
+
+  function applyEvent(event: MigrationEvent): ModalState {
+    const next = reduce(state, event);
+    return transitionTo(next);
+  }
+
+  function dismiss(): ModalState {
+    // Only meaningful from `failed`; ignore otherwise (e.g. a stray
+    // dismiss while `in_progress` would be a UI bug — the modal is
+    // dismissable: false in that state per frag-8 §6.8).
+    if (state.status !== 'failed') return state;
+    return transitionTo(HIDDEN_STATE);
+  }
+
+  return {
+    applyEvent,
+    dismiss,
+    peek() {
+      return state;
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      clearDoneTimer();
+      opts.ipcMain.removeListener(IPC_CHANNEL_RELAY_EVENT, onRelay);
+      opts.ipcMain.removeListener(IPC_CHANNEL_DISMISS, onDismiss);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Defensive event parser for the IPC relay path.
+//
+// IPC payloads cross a trust boundary (renderer can technically push any
+// shape). We do a structural check matching the T30 contract; anything
+// that doesn't match is dropped silently (caller logs at the IPC layer
+// if it cares).
+// ---------------------------------------------------------------------------
+
+function parseEvent(raw: unknown): MigrationEvent | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const obj = raw as Record<string, unknown>;
+  const name = obj.event;
+  if (typeof name !== 'string') return null;
+  switch (name) {
+    case MIGRATION_EVENT_NAMES.started: {
+      if (
+        typeof obj.traceId === 'string' &&
+        typeof obj.sourcePath === 'string' &&
+        typeof obj.fromVersion === 'number' &&
+        typeof obj.toVersion === 'number' &&
+        typeof obj.startedAt === 'number'
+      ) {
+        return {
+          event: MIGRATION_EVENT_NAMES.started,
+          traceId: obj.traceId,
+          sourcePath: obj.sourcePath,
+          fromVersion: obj.fromVersion,
+          toVersion: obj.toVersion,
+          startedAt: obj.startedAt,
+        };
+      }
+      return null;
+    }
+    case MIGRATION_EVENT_NAMES.completed: {
+      if (
+        typeof obj.traceId === 'string' &&
+        typeof obj.fromVersion === 'number' &&
+        typeof obj.toVersion === 'number' &&
+        typeof obj.durationMs === 'number' &&
+        typeof obj.rowsConverted === 'number'
+      ) {
+        return {
+          event: MIGRATION_EVENT_NAMES.completed,
+          traceId: obj.traceId,
+          fromVersion: obj.fromVersion,
+          toVersion: obj.toVersion,
+          durationMs: obj.durationMs,
+          rowsConverted: obj.rowsConverted,
+        };
+      }
+      return null;
+    }
+    case MIGRATION_EVENT_NAMES.failed: {
+      if (
+        typeof obj.traceId === 'string' &&
+        typeof obj.fromVersion === 'number' &&
+        typeof obj.toVersion === 'number' &&
+        typeof obj.reason === 'string' &&
+        typeof obj.errorMessage === 'string' &&
+        (obj.errorCode === undefined || typeof obj.errorCode === 'string')
+      ) {
+        return {
+          event: MIGRATION_EVENT_NAMES.failed,
+          traceId: obj.traceId,
+          fromVersion: obj.fromVersion,
+          toVersion: obj.toVersion,
+          reason: obj.reason,
+          errorMessage: obj.errorMessage,
+          errorCode: obj.errorCode as string | undefined,
+        };
+      }
+      return null;
+    }
+    default:
+      return null;
+  }
+}
+
+// Test-only export for parser coverage.
+export const __testing = { parseEvent };

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -198,6 +198,19 @@ const en = {
         title: 'ccsm couldn’t migrate your previous data',
         body: 'ccsm tried to move your data from the previous version but couldn’t complete the migration. Your previous data file at {{legacyDb}} is preserved unchanged — quit ccsm and contact support, or manually start fresh by deleting {{dataRoot}} and relaunching.',
         actionQuit: 'Quit ccsm'
+      },
+      // Migration in-progress modal (frag-8 §6.8 surface registry priority
+      // 100, mode `blocking-modal`, dismissable: false; T33 driver). Per
+      // frag-8 §8.6 manager r9 lock the spinner is indeterminate — there is
+      // no per-event progress fraction in the wire contract (T30 defines
+      // started/completed/failed only), so copy here is progress-agnostic.
+      // `cancel_blocked` is shown if the user attempts to dismiss / quit
+      // mid-migration (UX safety; modal itself is non-dismissable).
+      in_progress: {
+        title: 'Migrating your previous data',
+        body: 'ccsm is moving your data from the previous version. This usually takes a few seconds — please keep ccsm open until it finishes.',
+        steps_label: 'Copying database…',
+        cancel_blocked: 'Migration can’t be cancelled mid-way — your data could be left in an inconsistent state. Please wait for it to finish.'
       }
     }
   },

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -181,6 +181,12 @@ const zh: EnCatalog = {
         title: 'ccsm 无法迁移您之前的数据',
         body: 'ccsm 尝试把上一版本的数据搬过来，但没能完成迁移。您之前的数据文件位于 {{legacyDb}}，保持原样未做改动 — 请退出 ccsm 并联系支持团队，或手动删除 {{dataRoot}} 后重新启动以从头开始。',
         actionQuit: '退出 ccsm'
+      },
+      in_progress: {
+        title: '正在迁移您之前的数据',
+        body: 'ccsm 正在把上一版本的数据搬过来。这通常只需几秒钟 — 请在迁移完成前不要关闭 ccsm。',
+        steps_label: '正在复制数据库…',
+        cancel_blocked: '迁移过程中无法取消 — 中断会让您的数据处于不一致状态。请耐心等待迁移完成。'
       }
     }
   },


### PR DESCRIPTION
## Summary

T33 — Electron-main side driver bridging T30 migration events to a modal state stream consumed by the renderer (frag-8 §8.5 / §8.6).

- **Pure decider** \`reduce(state, event)\`: closed state machine over \`hidden | in_progress | failed | done\`. Hermetic, no I/O.
- **Sink** \`createModalDriver\`: subscribes \`migration:relayEvent\` from renderer (renderer relays daemon-socket events), pushes \`ModalState\` over \`migration:modalState\`, schedules 1s flash auto-hide on \`done\`, accepts \`migration:dismiss\` to clear sticky \`failed\`.
- **i18n keys** \`migration.modal.in_progress.{title,body,steps_label,cancel_blocked}\` added to \`src/i18n/locales/{en,zh}.ts\` (renderer source of truth — main has no in-progress notification copy). Sentence case, en/zh parity, English-only commit/PR per project convention.

### Spec deviation note

The task brief mentioned \`progress\` events with a \`{progress}\` placeholder body. **Honoured the spec instead**: frag-8 §8.6 manager r9 lock + T30 contracts (\`daemon/src/db/migration-events.ts\`) explicitly define an **indeterminate spinner** — there is no \`progress\` event in the wire contract, only \`started\` / \`completed\` / \`failed\`. The state machine and copy are therefore progress-fraction-free. Spec quote (frag-8 line 570): *"In-progress modal: indeterminate spinner, no event needed (manager r9 lock)"*.

### Single Responsibility (Layer 1)

- Producer: daemon migration runner (T29). Out of scope.
- Decider: \`reduce\` — pure transition function.
- Sink: \`createModalDriver\` — IPC \`webContents.send\` only.
- Renderer modal UI: separate task (downstream — #1028 / #1032 / #1033 / #1041).

## Test plan

- [x] \`npx vitest run electron/migration/__tests__/modal-driver.test.ts\` — **29/29 pass**.
- [x] \`npx vitest run tests/i18n-key-parity.test.ts\` — **2/2 pass** (en/zh structural parity).
- [x] \`npm run typecheck\` — clean (root + electron + daemon).
- [x] \`npx tsc -p tsconfig.electron.json\` — clean compile.
- [x] Main-process require-load smoke test (per \`feedback_main_process_load_smoke_test\`): \`node -e "require('./dist/electron/migration/modal-driver.js')"\` loads cleanly, exports the full surface.
- [x] Reverse-verify cases included for state-machine no-ops and dispose.

### Test coverage highlights

- Every state × event transition (incl. terminal-state no-ops, double-start, out-of-order events).
- Done auto-hide timer (default + override).
- Failed sticky-until-dismiss; dismiss is no-op when not failed.
- IPC channels (\`migration:relayEvent\`, \`migration:dismiss\`).
- Defensive payload parser (drops malformed events).
- Wire-contract parity trip-wire: greps \`daemon/src/db/migration-events.ts\` to confirm event-name strings still match (catches T30 renames).
- dispose tears down listeners + timers; reverse-verify case proves dispose actually does work.

Unblocks: #1028 #1032 #1033 #1041.

Task #989.