### PR TITLE
feat(installer): T53 ccsm-uninstall-helper.exe

### DIFF
--- a/installer/uninstall-helper/__tests__/helper.test.ts
+++ b/installer/uninstall-helper/__tests__/helper.test.ts
@@ -1,0 +1,82 @@
+// Smoke tests for ccsm-uninstall-helper (T53).
+//
+// We test the pure decider parts (arg parsing, pipe-path derivation, frame
+// encode) directly. The graceful-shutdown round-trip against a real daemon
+// is left to the e2e install/uninstall path (T1019).
+//
+// Reverse-verify: removing `--shutdown` from parseArgs falls back to help
+// (covered) and the userhash slice MUST stay 8 hex chars (regression bait
+// if anyone "improves" the SHA-256 truncation).
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { Buffer } from 'node:buffer';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const requireCjs = createRequire(import.meta.url);
+const helper = requireCjs(resolve(__dirname, '..', 'index.js'));
+
+describe('uninstall-helper / parseArgs', () => {
+  it('defaults to no-op (help) when --shutdown is absent', () => {
+    const a = helper.parseArgs([]);
+    expect(a.shutdown).toBe(false);
+    expect(a.timeoutMs).toBe(2000);
+  });
+
+  it('parses --shutdown --timeout 5000', () => {
+    const a = helper.parseArgs(['--shutdown', '--timeout', '5000']);
+    expect(a.shutdown).toBe(true);
+    expect(a.timeoutMs).toBe(5000);
+  });
+
+  it('ignores invalid --timeout values, keeping default', () => {
+    const a = helper.parseArgs(['--shutdown', '--timeout', 'banana']);
+    expect(a.timeoutMs).toBe(2000);
+  });
+
+  it('recognises --help', () => {
+    expect(helper.parseArgs(['--help']).help).toBe(true);
+    expect(helper.parseArgs(['-h']).help).toBe(true);
+  });
+});
+
+describe('uninstall-helper / controlPipePath', () => {
+  it('returns a Windows-shaped \\\\.\\pipe\\ccsm-control-<8hex> path', () => {
+    const p = helper.controlPipePath();
+    expect(p).toMatch(/^\\\\\.\\pipe\\ccsm-control-[0-9a-f]{8}$/);
+  });
+
+  it('is deterministic for same user+host (called twice → equal)', () => {
+    expect(helper.controlPipePath()).toBe(helper.controlPipePath());
+  });
+});
+
+describe('uninstall-helper / encodeJsonFrame', () => {
+  it('produces a valid v0.3 JSON frame matching daemon envelope layout', () => {
+    const header = {
+      id: 1,
+      method: 'daemon.shutdownForUpgrade',
+      payloadType: 'json',
+      payloadLen: 0,
+    };
+    const frame = helper.encodeJsonFrame(header);
+    // Prefix: 4 bytes; high nibble = 0x0 (v0.3), low 28 = payloadLen.
+    const raw = frame.readUInt32BE(0);
+    const nibble = (raw >>> 28) & 0x0f;
+    const payloadLen = raw & 0x0fffffff;
+    expect(nibble).toBe(0x0);
+    // payloadLen = 2 (headerLen field) + headerJson bytes.
+    const headerJson = Buffer.from(JSON.stringify(header), 'utf8');
+    expect(payloadLen).toBe(2 + headerJson.length);
+    // headerLen field at offset 4, big-endian uint16.
+    expect(frame.readUInt16BE(4)).toBe(headerJson.length);
+    // Header JSON immediately follows.
+    expect(frame.subarray(6, 6 + headerJson.length).toString('utf8')).toBe(
+      JSON.stringify(header),
+    );
+    // Total frame length matches.
+    expect(frame.length).toBe(4 + payloadLen);
+  });
+});

--- a/installer/uninstall-helper/index.js
+++ b/installer/uninstall-helper/index.js
@@ -1,0 +1,330 @@
+#!/usr/bin/env node
+// ccsm-uninstall-helper — NSIS uninstall pre-step (Task #1009 / T53).
+//
+// Spec citations:
+//   - docs/superpowers/specs/v0.3-fragments/frag-11-packaging.md §11.6.4
+//     "Daemon-shutdown RPC integration (cross-ref frag-6-7)" — invoked by
+//     NSIS customUnInstall as `"$TEMP\\ccsm-uninstall-helper.exe" --shutdown
+//     --timeout 2000` BEFORE the main uninstall payload deletes files.
+//   - frag-6-7 §6.4 + daemon/src/handlers/daemon-shutdown-for-upgrade.ts —
+//     the daemon's `daemon.shutdownForUpgrade` RPC writes the clean-shutdown
+//     marker, runs the §6.6.1 drain sequence, releases the lock, exit(0).
+//   - daemon/src/sockets/control-socket.ts — Windows pipe namespace
+//     `\\.\pipe\ccsm-control-<userhash>` where `<userhash>` = first 8 hex
+//     chars of SHA-256(`<username>@<hostname>`). Same derivation as T14;
+//     replicated locally so the helper has zero runtime deps.
+//   - daemon/src/envelope/envelope.ts — wire frame format
+//     `[totalLen:4][headerLen:2][headerJSON:headerLen][payload]`. Control-
+//     plane RPCs (`SUPERVISOR_RPCS`, frag-3.4.1 §3.4.1.h) are EXEMPT from
+//     the HMAC handshake / hello gate, so the helper can speak the wire
+//     directly without `daemon.secret`.
+//
+// Single Responsibility:
+//   PRODUCER: parses CLI args, derives pipe path.
+//   DECIDER:  decides graceful (RPC reachable) vs hardstop (TerminateProcess).
+//   SINK:     opens the named pipe, writes the frame, OR enumerates ccsm
+//             processes via `tasklist` + kills via `taskkill /F`.
+//
+// Exit semantics (spec §11.6.4 + task brief):
+//   0 — graceful shutdown OR daemon already dead (idempotent).
+//   1 — hard error (couldn't kill processes that needed killing).
+//
+// Logging: best-effort to %TEMP%\ccsm-uninstall.log (single line per run).
+//
+// Bundled into a single .exe via @yao-pkg/pkg (target node22-win-x64).
+
+'use strict';
+
+const net = require('node:net');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+const crypto = require('node:crypto');
+const { execFile } = require('node:child_process');
+
+// ---------------------------------------------------------------------------
+// CLI args
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = { shutdown: false, timeoutMs: 2000, help: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--shutdown') args.shutdown = true;
+    else if (a === '--timeout') {
+      const v = argv[++i];
+      const n = Number.parseInt(v, 10);
+      if (Number.isFinite(n) && n > 0) args.timeoutMs = n;
+    } else if (a === '--help' || a === '-h') {
+      args.help = true;
+    }
+  }
+  return args;
+}
+
+const HELP = `ccsm-uninstall-helper — NSIS uninstall pre-step
+
+Usage:
+  ccsm-uninstall-helper --shutdown [--timeout MS]
+
+Options:
+  --shutdown      Send daemon.shutdownForUpgrade over the control-socket pipe.
+                  Falls back to TerminateProcess on the daemon executable.
+  --timeout MS    Timeout for the graceful RPC ack (default: 2000).
+  --help, -h      Show this help.
+
+Exit codes:
+  0  graceful shutdown OR daemon already gone (idempotent)
+  1  hard error (couldn't kill orphan processes)
+`;
+
+// ---------------------------------------------------------------------------
+// Pipe path derivation (mirrors daemon/src/sockets/control-socket.ts)
+// ---------------------------------------------------------------------------
+
+function controlPipePath() {
+  const username = (os.userInfo().username || process.env.USERNAME || 'unknown');
+  const host = os.hostname();
+  const tag = `${username}@${host}`;
+  const userhash = crypto.createHash('sha256').update(tag).digest('hex').slice(0, 8);
+  return `\\\\.\\pipe\\ccsm-control-${userhash}`;
+}
+
+// ---------------------------------------------------------------------------
+// Logging — best-effort, single line, never throws
+// ---------------------------------------------------------------------------
+
+function logLine(msg) {
+  try {
+    const tmp = process.env.TEMP || process.env.TMP || os.tmpdir();
+    const logPath = path.join(tmp, 'ccsm-uninstall.log');
+    const ts = new Date().toISOString();
+    fs.appendFileSync(logPath, `[${ts}] ${msg}\n`, { encoding: 'utf8' });
+  } catch {
+    // best-effort; uninstall must never fail because we couldn't log.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Envelope encode (mirrors daemon/src/envelope/envelope.ts encodeFrame for
+// JSON-only frames; v0.3 nibble = 0x0; payloadLen low 28 bits)
+// ---------------------------------------------------------------------------
+
+function encodeJsonFrame(headerObj) {
+  const headerJson = Buffer.from(JSON.stringify(headerObj), 'utf8');
+  const headerLen = headerJson.length;
+  // payloadLen = 2 (headerLen field) + headerLen + 0 (no trailer)
+  const payloadLen = 2 + headerLen;
+  // version nibble 0x0 in high 4 bits
+  const raw = (0 << 28) | (payloadLen & 0x0fffffff);
+  const out = Buffer.allocUnsafe(4 + payloadLen);
+  out.writeUInt32BE(raw >>> 0, 0);
+  out.writeUInt16BE(headerLen, 4);
+  headerJson.copy(out, 6);
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Graceful path: connect to the pipe, send daemon.shutdownForUpgrade, wait
+// for either an ack frame OR the daemon to close the pipe (it exits after
+// the shutdown sequence).
+// ---------------------------------------------------------------------------
+
+function gracefulShutdown(pipePath, timeoutMs) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      try { sock.destroy(); } catch { /* noop */ }
+      clearTimeout(timer);
+      resolve(result);
+    };
+
+    const sock = net.createConnection(pipePath);
+
+    const timer = setTimeout(() => {
+      logLine(`graceful: timeout after ${timeoutMs}ms`);
+      finish({ ok: false, reason: 'timeout' });
+    }, timeoutMs);
+
+    sock.once('error', (err) => {
+      // ENOENT / EPIPE / ECONNREFUSED — daemon not running. Idempotent OK.
+      logLine(`graceful: pipe error ${err && err.code ? err.code : err}`);
+      finish({ ok: false, reason: 'unreachable', code: err && err.code });
+    });
+
+    sock.once('connect', () => {
+      // Build the request frame. Header schema mirrors daemon/src/envelope
+      // tests: { id, method, payloadType, payloadLen }. Method is the bare
+      // SUPERVISOR_RPC name (no "ccsm.v1/" prefix; cf. dispatcher.ts).
+      const header = {
+        id: 1,
+        method: 'daemon.shutdownForUpgrade',
+        payloadType: 'json',
+        payloadLen: 0,
+      };
+      try {
+        const frame = encodeJsonFrame(header);
+        sock.write(frame);
+      } catch (err) {
+        logLine(`graceful: encode error ${err && err.message}`);
+        finish({ ok: false, reason: 'encode_error' });
+        return;
+      }
+    });
+
+    // Either we receive an ack (any data) or the daemon closes the pipe
+    // after exit(0). Both are "graceful succeeded" outcomes per spec.
+    sock.once('data', () => {
+      logLine('graceful: ack received');
+      // Give the daemon a moment to run its drain sequence + exit(0).
+      setTimeout(() => finish({ ok: true, reason: 'ack' }), 250);
+    });
+
+    sock.once('end', () => {
+      logLine('graceful: pipe closed by daemon');
+      finish({ ok: true, reason: 'pipe_closed' });
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Hard fallback: enumerate ccsm processes via tasklist, taskkill /F.
+// Uses CSV output for robust parsing. Best-effort; errors are logged but
+// do not abort uninstall (idempotency over precision).
+// ---------------------------------------------------------------------------
+
+const CCSM_IMAGE_NAMES = [
+  'ccsm-daemon.exe',
+  'CCSM.exe',
+  'CCSM Dev.exe',
+];
+
+function execFileP(file, args, opts) {
+  return new Promise((resolve) => {
+    execFile(file, args, opts || {}, (err, stdout, stderr) => {
+      resolve({ err, stdout: stdout || '', stderr: stderr || '' });
+    });
+  });
+}
+
+async function listCcsmPids() {
+  const pids = [];
+  for (const image of CCSM_IMAGE_NAMES) {
+    const { err, stdout } = await execFileP(
+      'tasklist',
+      ['/FI', `IMAGENAME eq ${image}`, '/FO', 'CSV', '/NH'],
+      { windowsHide: true },
+    );
+    if (err) {
+      logLine(`tasklist ${image} failed: ${err.message}`);
+      continue;
+    }
+    // CSV rows: "image","pid","session","sessionnum","memusage"
+    // tasklist emits "INFO: No tasks ..." on stdout when no match — skip.
+    if (/^INFO:/i.test(stdout.trim())) continue;
+    for (const line of stdout.split(/\r?\n/)) {
+      const m = line.match(/^"([^"]+)","(\d+)"/);
+      if (m) pids.push({ image: m[1], pid: Number.parseInt(m[2], 10) });
+    }
+  }
+  return pids;
+}
+
+async function killPid(pid) {
+  const { err, stderr } = await execFileP(
+    'taskkill',
+    ['/F', '/T', '/PID', String(pid)],
+    { windowsHide: true },
+  );
+  if (err) {
+    logLine(`taskkill ${pid} failed: ${err.message} ${stderr.trim()}`);
+    return false;
+  }
+  return true;
+}
+
+async function hardstop() {
+  const pids = await listCcsmPids();
+  if (pids.length === 0) {
+    logLine('hardstop: no ccsm processes found (already stopped)');
+    return { ok: true, killed: 0, failed: 0 };
+  }
+  let killed = 0;
+  let failed = 0;
+  for (const p of pids) {
+    logLine(`hardstop: killing ${p.image} pid=${p.pid}`);
+    if (await killPid(p.pid)) killed++;
+    else failed++;
+  }
+  return { ok: failed === 0, killed, failed };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  if (!args.shutdown) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+
+  logLine(`start pid=${process.pid} timeoutMs=${args.timeoutMs}`);
+
+  // Step 1: try graceful RPC.
+  const pipePath = controlPipePath();
+  logLine(`graceful: connecting ${pipePath}`);
+  const g = await gracefulShutdown(pipePath, args.timeoutMs);
+  if (g.ok) {
+    logLine(`graceful: ok reason=${g.reason}; exit 0`);
+    return 0;
+  }
+
+  // Step 2: hardstop fallback. ALWAYS runs even when graceful succeeded
+  // would have been preferred — a daemon that didn't ack within the
+  // timeout might still be alive but wedged.
+  logLine(`graceful: failed reason=${g.reason}; falling back to hardstop`);
+  const h = await hardstop();
+  if (h.ok) {
+    logLine(`hardstop: ok killed=${h.killed} failed=${h.failed}; exit 0`);
+    return 0;
+  }
+  logLine(`hardstop: hard error killed=${h.killed} failed=${h.failed}; exit 1`);
+  return 1;
+}
+
+// Top-level entry. We deliberately catch every error and log/exit so NSIS
+// never sees an uncaught throw (which would surface as cryptic non-zero).
+// Gated on `require.main === module` so tests can `require()` this file
+// without triggering process.exit.
+if (require.main === module) {
+  main()
+    .then((code) => {
+      process.exit(code);
+    })
+    .catch((err) => {
+      logLine(`fatal: ${err && err.stack ? err.stack : String(err)}`);
+      // Exit 0 anyway: a fatal in the helper itself shouldn't block
+      // uninstall. Hard error is reserved for "we tried to kill and
+      // couldn't".
+      process.exit(0);
+    });
+} else {
+  // Exports for unit tests.
+  module.exports = {
+    parseArgs,
+    controlPipePath,
+    encodeJsonFrame,
+    gracefulShutdown,
+    hardstop,
+    listCcsmPids,
+    main,
+  };
+}

--- a/installer/uninstall-helper/package.json
+++ b/installer/uninstall-helper/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@ccsm/uninstall-helper",
+  "version": "0.3.0",
+  "private": true,
+  "description": "ccsm-uninstall-helper.exe — NSIS uninstall pre-step (T53). Sends daemon.shutdownForUpgrade over the control-socket named pipe; falls back to TerminateProcess; idempotent. Spec frag-11 §11.6.4.",
+  "bin": {
+    "ccsm-uninstall-helper": "./index.js"
+  },
+  "main": "index.js",
+  "type": "commonjs",
+  "scripts": {
+    "build": "pkg . --target node22-win-x64 --output ../../daemon/dist/ccsm-uninstall-helper.exe --compress GZip"
+  },
+  "pkg": {
+    "scripts": [
+      "index.js"
+    ],
+    "targets": [
+      "node22-win-x64"
+    ],
+    "outputPath": "../../daemon/dist/"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "make:linux": "npm run build && electron-builder --linux --publish never",
     "build:icon": "electron scripts/build-icon.cjs",
     "rebuild:natives": "node scripts/electron-rebuild-natives.cjs",
+    "build:uninstall-helper": "cd installer/uninstall-helper && pkg . --target node22-win-x64 --output ../../daemon/dist/ccsm-uninstall-helper.exe --compress GZip",
     "postinstall": "node scripts/postinstall.mjs"
   },
   "dependencies": {
@@ -170,7 +171,8 @@
       "icon": "build/icon.ico",
       "artifactName": "${productName}-Setup-${version}-${arch}.${ext}",
       "extraResources": [
-        { "from": "daemon/dist/ccsm-daemon-staged.exe", "to": "daemon/ccsm-daemon.exe" }
+        { "from": "daemon/dist/ccsm-daemon-staged.exe", "to": "daemon/ccsm-daemon.exe" },
+        { "from": "daemon/dist/ccsm-uninstall-helper.exe", "to": "daemon/ccsm-uninstall-helper.exe" }
       ]
     },
     "nsis": {

--- a/scripts/before-pack.cjs
+++ b/scripts/before-pack.cjs
@@ -157,6 +157,32 @@ function stageSdk() {
   }
 }
 
+function stageUninstallHelper(electronPlatformName) {
+  // Spec frag-11 §11.6.4 — `ccsm-uninstall-helper.exe` is a Windows-only
+  // NSIS uninstall pre-step. The helper is built ahead of time by
+  // `npm run build:uninstall-helper` (pkg-bundles installer/uninstall-helper/
+  // into `daemon/dist/ccsm-uninstall-helper.exe`).
+  //
+  // The Windows extraResources row in package.json points at this file
+  // directly; this stage step exists only to (a) emit a placeholder when
+  // the toolchain hasn't run yet (pre-T54 build worker), so the smoke
+  // build doesn't fail, and (b) document the dependency in one place.
+  if (electronPlatformName !== 'win32') return;
+
+  const dst = path.join(REPO_ROOT, 'daemon', 'dist', 'ccsm-uninstall-helper.exe');
+  if (fs.existsSync(dst)) {
+    console.log('[before-pack] uninstall helper present (built by build:uninstall-helper)');
+    return;
+  }
+  console.warn(
+    `[before-pack] WARN uninstall helper missing: ${dst}. ` +
+      `Run \`npm run build:uninstall-helper\` (requires @yao-pkg/pkg). ` +
+      `Falling back to placeholder for smoke builds; T57 after-pack ` +
+      `validation will fail the build once the helper is wired into CI.`,
+  );
+  stagePlaceholder(dst, 'ccsm-uninstall-helper.exe');
+}
+
 function stageDaemonDeps() {
   // Stages daemon's own ESM deps (pino, ulid, ...) into a fixed dir that
   // the `daemon/deps-staged -> daemon/node_modules` extraResources row
@@ -213,6 +239,7 @@ exports.default = async function beforePack(context) {
 
   stageDaemonBinary(electronPlatformName, archName);
   stageNatives(electronPlatformName, archName);
+  stageUninstallHelper(electronPlatformName);
   stageSdk();
   stageDaemonDeps();
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
       'tests/**/*.test.tsx',
       'electron/**/__tests__/**/*.test.ts',
       'daemon/**/__tests__/**/*.test.ts',
+      'installer/**/__tests__/**/*.test.ts',
     ],
     globals: true,
     setupFiles: ['tests/setup.ts'],


### PR DESCRIPTION
## Summary
- **Approach (Layer 1)**: Node + `@yao-pkg/pkg`. Spec frag-11 §11.6.4 explicitly locks "2-file Node script that pkg-bundles to ~5 MB, reuses the daemon's RPC client". Pkg is already the toolchain that produces `ccsm-daemon.exe`; adding Rust would diverge from the spec and add a new toolchain dependency for one .exe. Estimated binary size ~50 MB uncompressed (pkg base node22-win-x64 ~45 MB) → ~15-20 MB after `--compress GZip`. The spec's "~5 MB" claim is optimistic; actual will be measured by the build worker. The installer-size budget at frag-11 §11.5 already includes 5 MB for the helper, so any overage rolls into the 5 MB headroom (target 145 MB).
- **Helper behaviour** (single responsibility — does ONE thing, gracefully stop daemon then exit):
  - Sends `daemon.shutdownForUpgrade` over `\.\pipe\ccsm-control-<userhash>` and waits up to `--timeout` ms for either an ack frame or pipe close.
  - Falls back to `tasklist` + `taskkill /F /T` against `ccsm-daemon.exe`, `CCSM.exe`, `CCSM Dev.exe` if the RPC path is unreachable.
  - Idempotent — exits 0 if daemon already gone.
  - Logs each step to `%TEMP%\ccsm-uninstall.log`.
  - Exits 1 only when orphan kill itself fails (NSIS can warn user and continue).
- **Wire format** mirrors `daemon/src/envelope/envelope.ts` `encodeFrame` (v0.3 nibble 0x0). SUPERVISOR_RPCS are exempt from the HMAC handshake (frag-3.4.1 §3.4.1.h), so the helper has zero runtime crypto deps and doesn't need `daemon.secret`.
- **Userhash derivation** (`SHA-256(username@hostname).slice(0, 8)`) duplicated locally from `daemon/src/sockets/control-socket.ts` so the bundled helper has zero workspace deps. Drift bait — guarded by a unit test that asserts the `\.\pipe\ccsm-control-[0-9a-f]{8}` shape.

## Wiring
- `installer/uninstall-helper/{index.js, package.json, __tests__/helper.test.ts}` — the helper itself + 7 smoke tests.
- `package.json`:
  - `scripts.build:uninstall-helper` → `pkg . --target node22-win-x64 --output ../../daemon/dist/ccsm-uninstall-helper.exe --compress GZip`.
  - `build.win.extraResources` ships the .exe next to `ccsm-daemon.exe` at `<resources>/daemon/ccsm-uninstall-helper.exe` (the path NSIS `customUnInstall` will copy from per spec §11.6.4).
- `scripts/before-pack.cjs` — `stageUninstallHelper()` warns + writes a placeholder when the binary hasn't been built yet (mirrors the existing daemon-binary fallback so pre-CI smoke builds keep working).
- `vitest.config.ts` — `installer/**/__tests__/**/*.test.ts` added to the include list.

## Verification
- `npm run typecheck` — clean (no TypeScript).
- `npx vitest run installer/uninstall-helper/__tests__/helper.test.ts` — **7/7 passing** (parseArgs ×4, controlPipePath shape + determinism, encodeJsonFrame round-trip against daemon envelope layout).
- Real installer build deferred to manager-dispatched build worker (T54 / clean Win box w/ `@yao-pkg/pkg` installed). Build command documented in package.json + commit message.

## Test plan
- [x] code compiles locally (TypeScript clean; the helper itself is plain CJS so no compile)
- [x] unit smoke tests pass (7/7)
- [ ] `npm run build:uninstall-helper` produces a working .exe — deferred to build worker
- [ ] e2e on Win 11 install/uninstall path: T1019 (T62 NSIS daemon-shutdown sequence) will exercise the full path

## Coordination
- Unblocks **#1011 (T54 Win signtool)** — needs the .exe present at `daemon/dist/ccsm-uninstall-helper.exe` to add to its sign target list (per spec §11.3.1 amendment in frag-11 §11.6.4).
- Unblocks **#1014 (T52 NSIS customUnInstall macro)** — the macro shells out to `$TEMP\ccsm-uninstall-helper.exe --shutdown --timeout 2000`.
- Unblocks **#1019 (T62 NSIS daemon-shutdown sequence)** — full e2e of install → run → uninstall with daemon shutdown.

## Migration-window CI tolerance
Per `feedback_migration_window_ci_tolerance` — lint/typecheck CI red is acceptable during the v0.3 window; reviewer + local typecheck (clean here) gate merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)