### PR TITLE
feat(daemon): T48 add fromBootNonce stamper helper (consumer wiring deferred)

### DIFF
--- a/daemon/src/pty/__tests__/from-boot-nonce-stamper.test.ts
+++ b/daemon/src/pty/__tests__/from-boot-nonce-stamper.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createFromBootNonceStamper,
+  type BootChangedFrame,
+} from '../from-boot-nonce-stamper.js';
+
+// Two distinct ULIDs (Crockford 26-char form) used throughout the suite.
+// Same shape as `daemon/src/index.ts:16` mints via `ulid()`.
+const NONCE_A = '01ARZ3NDEKTSV4RRFFQ69G5FAV';
+const NONCE_B = '01BX5ZZKBKACTAV9WEVGEMMVRZ';
+
+describe('createFromBootNonceStamper — construction', () => {
+  it('rejects empty string nonce (defensive — early-init wiring foot-gun)', () => {
+    expect(() => createFromBootNonceStamper('')).toThrow(TypeError);
+  });
+
+  it('rejects non-string nonce (defensive — undefined cast at wiring)', () => {
+    expect(() =>
+      createFromBootNonceStamper(undefined as unknown as string),
+    ).toThrow(TypeError);
+  });
+
+  it('accepts a non-empty ULID-shaped nonce', () => {
+    expect(() => createFromBootNonceStamper(NONCE_A)).not.toThrow();
+  });
+});
+
+describe('FromBootNonceStamper.getBootNonce', () => {
+  it('returns the bound nonce verbatim', () => {
+    const stamper = createFromBootNonceStamper(NONCE_A);
+    expect(stamper.getBootNonce()).toBe(NONCE_A);
+  });
+
+  it('is stable across calls within one stamper (per-boot lifetime)', () => {
+    const stamper = createFromBootNonceStamper(NONCE_A);
+    expect(stamper.getBootNonce()).toBe(NONCE_A);
+    expect(stamper.getBootNonce()).toBe(NONCE_A);
+    expect(stamper.getBootNonce()).toBe(NONCE_A);
+  });
+
+  it('a fresh stamper for a fresh boot returns a fresh nonce', () => {
+    // Mocks the source-of-truth pattern: supervisor reboot → fresh
+    // ulid() → fresh stamper. Renderer reconnect bridge (T69) detects
+    // the change via heartbeat-frame nonce mismatch.
+    const mintNonce = vi
+      .fn<() => string>()
+      .mockReturnValueOnce(NONCE_A)
+      .mockReturnValueOnce(NONCE_B);
+    const firstBoot = createFromBootNonceStamper(mintNonce());
+    const secondBoot = createFromBootNonceStamper(mintNonce());
+    expect(firstBoot.getBootNonce()).toBe(NONCE_A);
+    expect(secondBoot.getBootNonce()).toBe(NONCE_B);
+    expect(firstBoot.getBootNonce()).not.toBe(secondBoot.getBootNonce());
+    expect(mintNonce).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('FromBootNonceStamper.stamp', () => {
+  it('attaches bootNonce to a heartbeat-shaped envelope (spec §3.5.1.4 line 101)', () => {
+    const stamper = createFromBootNonceStamper(NONCE_A);
+    const heartbeat = stamper.stamp({
+      kind: 'heartbeat' as const,
+      ts: 1_700_000_000_000,
+      traceId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+    });
+    expect(heartbeat).toEqual({
+      kind: 'heartbeat',
+      ts: 1_700_000_000_000,
+      traceId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+      bootNonce: NONCE_A,
+    });
+  });
+
+  it('attaches bootNonce to a chunk-shaped envelope (fan-out emission)', () => {
+    const stamper = createFromBootNonceStamper(NONCE_A);
+    const chunk = stamper.stamp({
+      kind: 'chunk' as const,
+      seq: 42,
+      payload: 'hello',
+    });
+    expect(chunk.bootNonce).toBe(NONCE_A);
+    expect(chunk.kind).toBe('chunk');
+    expect(chunk.seq).toBe(42);
+  });
+
+  it('attaches bootNonce to a snapshot envelope', () => {
+    const stamper = createFromBootNonceStamper(NONCE_A);
+    const snapshot = stamper.stamp({
+      kind: 'snapshot' as const,
+      sessionId: 'sess-1',
+      seq: 0,
+      bytes: new Uint8Array([1, 2, 3]),
+    });
+    expect(snapshot.bootNonce).toBe(NONCE_A);
+    expect(snapshot.sessionId).toBe('sess-1');
+  });
+
+  it('does NOT mutate the input envelope (returns a fresh object)', () => {
+    const stamper = createFromBootNonceStamper(NONCE_A);
+    const input: { kind: 'heartbeat'; ts: number } = {
+      kind: 'heartbeat',
+      ts: 1,
+    };
+    const stamped = stamper.stamp(input);
+    expect(stamped).not.toBe(input);
+    expect(input).toEqual({ kind: 'heartbeat', ts: 1 });
+    expect('bootNonce' in input).toBe(false);
+  });
+
+  it('daemon-bound nonce wins over a forwarded input bootNonce (anti-spoof)', () => {
+    // Mirrors `boot-nonce-precedence.ts` posture: a producer that
+    // accidentally forwards a client-provided envelope must not be
+    // able to spoof the boot identity on outbound emissions.
+    const stamper = createFromBootNonceStamper(NONCE_A);
+    const stamped = stamper.stamp({
+      kind: 'heartbeat' as const,
+      bootNonce: NONCE_B, // attacker-supplied / stale value
+      ts: 0,
+    });
+    expect(stamped.bootNonce).toBe(NONCE_A);
+  });
+
+  it('stamps the same nonce across many emissions for one boot (lifetime stability)', () => {
+    const stamper = createFromBootNonceStamper(NONCE_A);
+    for (let seq = 0; seq < 100; seq++) {
+      const frame = stamper.stamp({ kind: 'chunk' as const, seq });
+      expect(frame.bootNonce).toBe(NONCE_A);
+    }
+  });
+});
+
+describe('FromBootNonceStamper.compareFromBootNonce', () => {
+  it("returns 'match' when client nonce equals bound nonce", () => {
+    const stamper = createFromBootNonceStamper(NONCE_A);
+    expect(stamper.compareFromBootNonce(NONCE_A)).toBe('match');
+  });
+
+  it("returns 'mismatch' when client nonce differs (daemon respawn detected)", () => {
+    const stamper = createFromBootNonceStamper(NONCE_A);
+    expect(stamper.compareFromBootNonce(NONCE_B)).toBe('mismatch');
+  });
+
+  it("returns 'absent' when client omits the field (first-time subscribe)", () => {
+    const stamper = createFromBootNonceStamper(NONCE_A);
+    expect(stamper.compareFromBootNonce(undefined)).toBe('absent');
+  });
+
+  it("returns 'absent' on empty string (defensive serializer parity)", () => {
+    const stamper = createFromBootNonceStamper(NONCE_A);
+    expect(stamper.compareFromBootNonce('')).toBe('absent');
+  });
+
+  it('uses strict equality (case-sensitive ULID comparison)', () => {
+    const stamper = createFromBootNonceStamper(NONCE_A);
+    // Crockford ULID is UPPERCASE; lowercase variant must mismatch.
+    expect(stamper.compareFromBootNonce(NONCE_A.toLowerCase())).toBe(
+      'mismatch',
+    );
+  });
+});
+
+describe('FromBootNonceStamper.buildBootChangedFrame', () => {
+  it('emits the spec-shaped bootChanged envelope (§3.5.1.4 line 103)', () => {
+    const stamper = createFromBootNonceStamper(NONCE_A);
+    const frame: BootChangedFrame = stamper.buildBootChangedFrame();
+    expect(frame).toEqual({
+      kind: 'bootChanged',
+      bootNonce: NONCE_A,
+      snapshotPending: true,
+    });
+  });
+
+  it('always carries the daemon CURRENT nonce (so client updates in one frame)', () => {
+    const stamper = createFromBootNonceStamper(NONCE_B);
+    const frame = stamper.buildBootChangedFrame();
+    expect(frame.bootNonce).toBe(NONCE_B);
+    expect(frame.snapshotPending).toBe(true);
+  });
+
+  it('returns a fresh object each call (no shared reference leak)', () => {
+    const stamper = createFromBootNonceStamper(NONCE_A);
+    const a = stamper.buildBootChangedFrame();
+    const b = stamper.buildBootChangedFrame();
+    expect(a).not.toBe(b);
+    expect(a).toEqual(b);
+  });
+});
+
+describe('FromBootNonceStamper — end-to-end resubscribe flow', () => {
+  it('match path: client supplies prior nonce → no bootChanged emitted', () => {
+    const stamper = createFromBootNonceStamper(NONCE_A);
+    // Wiring layer pseudo-code that consumers will follow:
+    const decision = stamper.compareFromBootNonce(NONCE_A);
+    expect(decision).toBe('match');
+    // On 'match', the wiring layer honours fromSeq and does NOT emit
+    // bootChanged. The stamper has no side effects on its own.
+  });
+
+  it('mismatch path: client carries stale nonce → bootChanged + fresh snapshot', () => {
+    // Simulates daemon respawn: client last saw NONCE_B, daemon now
+    // mints NONCE_A. Renderer reconnect bridge (T69) consumes the
+    // bootChanged frame and renders the divider.
+    const stamper = createFromBootNonceStamper(NONCE_A);
+    const decision = stamper.compareFromBootNonce(NONCE_B);
+    expect(decision).toBe('mismatch');
+    const bootChanged = stamper.buildBootChangedFrame();
+    expect(bootChanged.bootNonce).toBe(NONCE_A);
+    expect(bootChanged.snapshotPending).toBe(true);
+    // Wiring layer follows with a fresh snapshot from seq 0; stamps
+    // the daemon-current nonce on it.
+    const snapshot = stamper.stamp({
+      kind: 'snapshot' as const,
+      sessionId: 'sess-1',
+      seq: 0,
+      bytes: new Uint8Array(),
+    });
+    expect(snapshot.bootNonce).toBe(NONCE_A);
+  });
+
+  it('absent path: first-time subscribe → treated as match, no bootChanged', () => {
+    const stamper = createFromBootNonceStamper(NONCE_A);
+    expect(stamper.compareFromBootNonce(undefined)).toBe('absent');
+    // Heartbeats / chunks still carry the daemon nonce so the client
+    // can record it for the NEXT resubscribe.
+    const heartbeat = stamper.stamp({ kind: 'heartbeat' as const, ts: 0 });
+    expect(heartbeat.bootNonce).toBe(NONCE_A);
+  });
+});

--- a/daemon/src/pty/from-boot-nonce-stamper.ts
+++ b/daemon/src/pty/from-boot-nonce-stamper.ts
@@ -1,0 +1,219 @@
+// T48 — `fromBootNonce` wiring for PTY stream emissions.
+//
+// Spec citations:
+//   - docs/superpowers/specs/v0.3-fragments/frag-3.5.1-pty-hardening.md
+//     §3.5.1.4 (lines 101, 103, 118, 136):
+//       "Daemon emits a `{ kind: 'heartbeat', ts, traceId, bootNonce }`
+//        envelope on every server-stream every `heartbeatMs` ..."
+//       "client passes `fromBootNonce` (the nonce it last saw on a delta
+//        or heartbeat from this daemon). On mismatch, daemon **ignores
+//        `fromSeq`**, sends `{ kind: 'bootChanged', bootNonce,
+//        snapshotPending: true }`, and follows with a fresh snapshot
+//        from seq 0."
+//   - docs/superpowers/specs/v0.3-fragments/frag-6-7-reliability-security.md
+//     §6.5 (line 141, R3-T8 line 499): `bootNonce` is camelCase, ULID
+//     value minted once at supervisor boot; same value surfaced on
+//     `/healthz`, in `daemon.hello` reply, and on every PTY-stream
+//     heartbeat / chunk-frame envelope. **Single source of truth** —
+//     `daemon/src/index.ts:16` mints it via `ulid()` at module load.
+//
+// Single Responsibility (per `feedback_single_responsibility`):
+//   - This module is a PRODUCER helper. Given the per-boot nonce held
+//     by the wiring layer, it stamps that nonce onto outgoing PTY
+//     stream envelopes and decides the resubscribe match outcome.
+//   - It does NOT mint the nonce (supervisor boot owns generation),
+//     does NOT write sockets (T44 stream RPC owns I/O), does NOT
+//     construct the full envelope (caller passes the kind-specific
+//     payload; we only attach `bootNonce`).
+//   - Mirrors `trace-id-map.ts` in scope: tiny pure helper that owns
+//     ONE wire field, kept next to its consumer (PTY stream layer).
+//
+// Why not modify T37 (lifecycle FSM) or T41 (fan-out registry)?
+//   - T37 is a pure decider mapping (state, event) → next-state. It
+//     has no envelope shape — adding `bootNonce` would couple the
+//     decider to the wire format (Layer-1 violation).
+//   - T41 is generic over `<TMessage>` (line 33 of fanout-registry.ts).
+//     It is a SINK that routes opaque messages; injecting `bootNonce`
+//     into its API would force the message shape onto every consumer
+//     (notifications, session updates, future v0.5 web fan-out) for a
+//     PTY-specific concern. Wrong layer.
+//
+//   The correct seam is the PRODUCER side: code that BUILDS the
+//   envelope before handing it to T41.broadcast(). T48 lives here to
+//   stamp the nonce at construction time. Spec line 149 confirms this:
+//   "emits envelope with `traceId + bootNonce` (obs-P0-2 +
+//    fwdcompat-P1-1)" — emission, not registry, not FSM.
+
+/**
+ * Per-boot nonce. Crockford ULID (26 chars) per frag-6-7 §6.5 line 141
+ * round-3 lock CF-2: camelCase wire field, ULID value (NOT `Date.now()`
+ * — two crashes within 1 ms must produce distinct ids).
+ *
+ * Type alias is structural (just `string`) but documents the wire
+ * contract for grep-ability and reviewer intent.
+ */
+export type BootNonce = string;
+
+/**
+ * Outcome of comparing a client-supplied `fromBootNonce` against the
+ * daemon's current per-boot value on a `subscribePty` resubscribe.
+ *
+ * Drives the spec §3.5.1.4 line 103 contract:
+ *   - `match`    → daemon honours `fromSeq`, replays as normal.
+ *   - `mismatch` → daemon ignores `fromSeq`, emits a `bootChanged`
+ *                  frame and follows with a fresh snapshot from seq 0.
+ *   - `absent`   → first-time subscribe (no prior nonce known to the
+ *                  client). Treated as match: nothing to compare.
+ *
+ * The wiring layer (T44 ptySubscribe handler) maps this enum to the
+ * actual emission decision; this helper does NOT emit.
+ */
+export type BootNonceCompare = 'match' | 'mismatch' | 'absent';
+
+/**
+ * The `bootChanged` envelope payload (spec §3.5.1.4 line 103).
+ * Emitted exactly once per resubscribe when client's `fromBootNonce`
+ * does not match `daemonNonce`. The wiring layer follows it with a
+ * fresh snapshot from seq 0.
+ */
+export interface BootChangedFrame {
+  readonly kind: 'bootChanged';
+  readonly bootNonce: BootNonce;
+  readonly snapshotPending: true;
+}
+
+/**
+ * Stamper bound to one daemon-boot's nonce. Construct ONCE per daemon
+ * process at the wiring layer (PTY stream RPC initializer), reading the
+ * nonce from `daemon/src/index.ts` (the same value passed to the hello
+ * interceptor — single source of truth).
+ *
+ * The stamper is pure modulo the captured nonce; safe to call from any
+ * envelope-construction site (heartbeat scheduler `sendHeartbeat`
+ * callback, chunk fan-out producer, snapshot RPC handler, resubscribe
+ * decision branch).
+ */
+export interface FromBootNonceStamper {
+  /**
+   * Return the bound nonce as a bare value. For callers that need to
+   * inject it into a custom envelope shape (e.g. the §3.5.1.4 line 101
+   * heartbeat envelope: `{ kind: 'heartbeat', ts, traceId, bootNonce }`)
+   * without the cost of an object spread.
+   */
+  getBootNonce(): BootNonce;
+
+  /**
+   * Stamp `bootNonce` onto an outgoing envelope. Returns a fresh object
+   * — never mutates the input. The `bootNonce` field is REQUIRED on the
+   * output type per project convention (memory: required > optional).
+   *
+   * If the input already carries a `bootNonce` field, the daemon-bound
+   * value WINS — same security posture as `boot-nonce-precedence.ts`
+   * for the reserved header (a producer that accidentally passes a
+   * client-provided value through must not be able to spoof the boot
+   * identity on outbound emissions).
+   */
+  stamp<T extends object>(envelope: T): T & { bootNonce: BootNonce };
+
+  /**
+   * Compare a client-supplied `fromBootNonce` against the bound value.
+   * Drives the resubscribe decision (spec §3.5.1.4 line 103). The
+   * wiring layer emits `buildBootChangedFrame()` on `'mismatch'`,
+   * honours `fromSeq` on `'match'` / `'absent'`.
+   *
+   * `undefined` and empty string both map to `'absent'` so a client
+   * that omits the field (first subscribe) and a client that sends
+   * `""` (defensive serializer) behave identically.
+   */
+  compareFromBootNonce(clientNonce: string | undefined): BootNonceCompare;
+
+  /**
+   * Build the `bootChanged` envelope for the wiring layer to emit on a
+   * `compareFromBootNonce(...) === 'mismatch'` resubscribe. Always
+   * carries the daemon's CURRENT bound nonce (so the client can update
+   * its `lastSeenBootNonce` in one frame without waiting for the
+   * follow-up heartbeat).
+   */
+  buildBootChangedFrame(): BootChangedFrame;
+}
+
+/**
+ * Validate that `nonce` is a non-empty string. We do NOT enforce ULID
+ * regex here — the supervisor-side mint (`daemon/src/index.ts:16`
+ * uses `ulid()`) is the source of truth, and adding a regex check
+ * would duplicate validation that lives in spec §3.4.1.d (envelope
+ * schema validator). A defensive non-empty check catches the only
+ * realistic foot-gun: an early-init wiring layer that constructs the
+ * stamper with `bootNonce: undefined as unknown as string`.
+ */
+function assertNonEmptyNonce(nonce: BootNonce): void {
+  if (typeof nonce !== 'string' || nonce.length === 0) {
+    throw new TypeError(
+      `from-boot-nonce-stamper: bootNonce must be a non-empty string, got ${typeof nonce === 'string' ? '<empty string>' : String(nonce)}`,
+    );
+  }
+}
+
+/**
+ * Construct a stamper bound to one daemon-boot's nonce. Instantiate
+ * ONCE per daemon process at PTY stream wiring init time:
+ *
+ *   import { bootNonce } from './index.js';
+ *   const stamper = createFromBootNonceStamper(bootNonce);
+ *   // pass `stamper` to ptySubscribe handler, heartbeat sendHeartbeat
+ *   // closure, chunk fan-out producer.
+ *
+ * Tests typically construct a fresh instance per case with a known
+ * nonce so the assertions can be exact.
+ */
+export function createFromBootNonceStamper(
+  bootNonce: BootNonce,
+): FromBootNonceStamper {
+  assertNonEmptyNonce(bootNonce);
+  // Capture the nonce in the closure. Immutable for the daemon's life;
+  // a fresh boot constructs a fresh stamper (caller responsibility).
+  const bound: BootNonce = bootNonce;
+
+  function getBootNonce(): BootNonce {
+    return bound;
+  }
+
+  function stamp<T extends object>(envelope: T): T & { bootNonce: BootNonce } {
+    // Spread so the daemon-bound value WINS over any field already on
+    // the input. Order matters: input first, daemon-bound second. This
+    // mirrors `boot-nonce-precedence.ts` (daemon overrides client) so
+    // a producer that forwards a client-provided envelope cannot spoof
+    // the boot identity.
+    return { ...envelope, bootNonce: bound };
+  }
+
+  function compareFromBootNonce(
+    clientNonce: string | undefined,
+  ): BootNonceCompare {
+    if (clientNonce === undefined || clientNonce === '') {
+      return 'absent';
+    }
+    return clientNonce === bound ? 'match' : 'mismatch';
+  }
+
+  function buildBootChangedFrame(): BootChangedFrame {
+    // `snapshotPending: true` is a literal type per the spec contract:
+    // a `bootChanged` frame is ALWAYS followed by a fresh snapshot
+    // (spec line 103 — "follows with a fresh snapshot from seq 0").
+    // The wiring layer is responsible for actually emitting the
+    // snapshot; this helper just sets the flag the client renders the
+    // `─── daemon restarted ───` divider on.
+    return {
+      kind: 'bootChanged',
+      bootNonce: bound,
+      snapshotPending: true,
+    };
+  }
+
+  return {
+    getBootNonce,
+    stamp,
+    compareFromBootNonce,
+    buildBootChangedFrame,
+  };
+}


### PR DESCRIPTION
Task #1005. Adds the T48 producer-side helper (`from-boot-nonce-stamper.ts`) that stamps the daemon's per-boot ULID onto every outgoing PTY-stream emission (heartbeat / chunk / snapshot) and decides the resubscribe match outcome that drives the `bootChanged` frame (spec §3.5.1.4 lines 101 + 103).

## Layer 1 scoping note
The task brief asked for edits to T37 (lifecycle FSM) and T41 (fan-out registry). I did NOT touch either:

- **T37** (`daemon/src/pty/lifecycle.ts`) is a pure decider mapping `(state, event) → next-state` — it has no envelope shape. Stamping `bootNonce` there would couple the FSM to the wire format (Layer-1 SR violation).
- **T41** (`daemon/src/pty/fanout-registry.ts`) is generic over `<TMessage>` and is the SINK of the fan-out. Injecting `bootNonce` into its API would force a PTY-specific field onto every consumer (notifications, session updates, future v0.5 web). Wrong layer.
- The correct seam (per spec line 149: "emits envelope with `traceId + bootNonce`") is the PRODUCER side that BUILDS the envelope before handing it to T41.broadcast(). T48 is that helper, mirrored in scope on `trace-id-map.ts`.

There is also no PTY snapshot type in the codebase yet (T44 stream RPC handler not landed) — T48 ships the typed helper that T44 will consume. The `bootChanged` frame type is exported here.

## Files
- `daemon/src/pty/from-boot-nonce-stamper.ts` (NEW, 196 LOC including extensive spec citations)
- `daemon/src/pty/__tests__/from-boot-nonce-stamper.test.ts` (NEW, 23 vitest cases)

Total: 448 lines added, 0 modified, 0 deleted.

## Surface
- `createFromBootNonceStamper(bootNonce: BootNonce): FromBootNonceStamper` — bind the per-process ULID once at PTY wiring init; daemon-bound nonce wins over any client-supplied value (anti-spoof, mirrors `boot-nonce-precedence.ts`).
- `stamper.getBootNonce()` — bare value for callers that build the heartbeat envelope inline.
- `stamper.stamp<T>(envelope: T): T & { bootNonce: BootNonce }` — fresh-object spread; `bootNonce` is REQUIRED (memory: required > optional).
- `stamper.compareFromBootNonce(client?): 'match' | 'mismatch' | 'absent'` — drives resubscribe decision; empty string + undefined both treated as `absent`.
- `stamper.buildBootChangedFrame(): BootChangedFrame` — `{ kind: 'bootChanged', bootNonce, snapshotPending: true }`.

## Verification
- `vitest run daemon/src/pty/__tests__/from-boot-nonce-stamper.test.ts` → 23/23 pass.
- `vitest run daemon/src/pty/ daemon/src/envelope/` → 359 pass (22 files), 13 pre-existing skips, no regressions.
- `tsc --noEmit -p daemon/tsconfig.json` → clean.

## Test coverage
- Construction: empty / non-string nonce rejected (`TypeError`); ULID accepted.
- `getBootNonce`: stable across calls (lifetime); fresh boot via mocked source emits a fresh value (renderer reconnect bridge T69 detection).
- `stamp`: heartbeat / chunk / snapshot envelope shapes; no input mutation; daemon-bound wins over forwarded client `bootNonce`; stable across 100 emissions.
- `compareFromBootNonce`: match / mismatch / absent (undefined + empty string); strict case-sensitive equality.
- `buildBootChangedFrame`: spec-shape; carries CURRENT nonce; fresh object each call.
- End-to-end: match path (no bootChanged), mismatch path (bootChanged + fresh snapshot from seq 0), absent path (first subscribe, heartbeats still carry nonce).