### PR TITLE
feat(dev): T64 wait-daemon helper (CI + nodemon ready-gate)

### DIFF
--- a/scripts/wait-daemon.cjs
+++ b/scripts/wait-daemon.cjs
@@ -1,0 +1,276 @@
+#!/usr/bin/env node
+// T64 — wait-daemon.cjs (frag-3.7 §3.7.2 + Task 1).
+//
+// Spec citations:
+//   - docs/superpowers/specs/v0.3-fragments/frag-3.7-dev-workflow.md L85, L91-105,
+//     L628-636: `scripts/wait-daemon.cjs` is the dev-script gate that BLOCKS
+//     `dev:app` until the daemon process has written its `daemon.lock` to the
+//     OS-native data root. Replaces the round-1 `wait-on tcp:127.0.0.1:0`
+//     no-op which let Electron race the named-pipe bind and dumped every dev
+//     boot into the auto-reconnect loop.
+//   - docs/superpowers/specs/v0.3-fragments/frag-6-7-reliability-security.md
+//     §6.4: the daemon writes `<dataRoot>/daemon.lock` via `proper-lockfile`
+//     during boot — single source of truth for "daemon is ready to accept
+//     RPCs". No new daemon-side work needed.
+//   - docs/superpowers/specs/v0.3-fragments/frag-12-traceability.md r5 lock #2
+//     and daemon/src/sockets/runtime-root.ts: canonical `<dataRoot>` resolver
+//     uses LOCALAPPDATA/Library/Application Support/(XDG_DATA_HOME ??
+//     ~/.local/share). frag-3.7's inline path snippet (APPDATA on Win,
+//     XDG_CONFIG_HOME on Linux) is older and conflicts with the runtime-root
+//     resolver — we follow the runtime-root resolver because (a) it is the
+//     module the daemon actually uses to write the lockfile, and (b) frag-12
+//     r5 lock #2 explicitly canonicalises the data-root layout. Drift between
+//     this script's path derivation and runtime-root.ts is guarded by a unit
+//     test (tests/wait-daemon.test.ts).
+//
+// Probe path decision (Layer 1):
+//   The Task #1021 brief proposes a control-socket `daemon.hello` or
+//   `/healthz` round-trip. Spec frag-3.7 §3.7.2 explicitly mandates a
+//   lockfile-existence probe instead, for three reasons captured in the spec:
+//     1. The lockfile is the single load-bearing "daemon process is up"
+//        signal already mandated by frag-6-7 §6.4 — no new contract.
+//     2. The control-socket bind happens AFTER lockfile acquisition in the
+//        daemon boot order (frag-6-7 §6.1 "cold-start"), so a lockfile probe
+//        is strictly not-before "socket is bindable" — equivalent guarantee
+//        for the dev-script use case.
+//     3. Polling a file is zero-deps and works in a fresh CI clone with no
+//        workspace install (the brief's "zero-workspace-deps" requirement).
+//        A control-socket round-trip would force this script to either
+//        duplicate the envelope/HMAC framing OR import @ccsm/daemon — both
+//        are violations of the standalone-helper contract.
+//   We follow the spec.
+//
+// CLI:
+//   node scripts/wait-daemon.cjs [--timeout-ms <N>] [--poll-interval-ms <N>] [--verbose]
+//
+// Exit codes:
+//   0  daemon.lock present (daemon ready)
+//   1  timeout
+//   2  bad CLI argument or unrecoverable error
+//
+// Single Responsibility:
+//   - Producer of one ready-or-timeout signal (exit code).
+//   - Pure path derivation + fs.statSync polling. No envelope, no socket.
+//
+// Usage from package.json:
+//   "dev:app": "node scripts/wait-daemon.cjs && tsc -p tsconfig.electron.json && cross-env CCSM_DAEMON_DEV=1 electron ."
+
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const DEFAULT_TIMEOUT_MS = 15000;
+const DEFAULT_POLL_INTERVAL_MS = 200;
+const LOCKFILE_NAME = 'daemon.lock';
+
+/**
+ * Resolve `<dataRoot>` for the current platform.
+ *
+ * MUST stay byte-for-byte identical to `resolveDataRoot()` in
+ * `daemon/src/sockets/runtime-root.ts`. Drift is caught by
+ * `tests/wait-daemon.test.ts` (drift guard).
+ *
+ * Why duplicate vs import: this script is a CI-friendly standalone helper
+ * with zero workspace dependencies (frag-3.7 §3.7.2 — runs before
+ * `npm install` on first contributor checkout in some flows; runs from
+ * fresh clones in CI before workspace symlinks exist).
+ */
+function resolveDataRoot(platform, env, home) {
+  if (platform === 'win32') {
+    const local = env.LOCALAPPDATA;
+    if (local && local.length > 0) return path.join(local, 'ccsm');
+    return path.join(home, 'AppData', 'Local', 'ccsm');
+  }
+  if (platform === 'darwin') {
+    return path.join(home, 'Library', 'Application Support', 'ccsm');
+  }
+  // Linux + every other POSIX
+  const xdgData = env.XDG_DATA_HOME;
+  if (xdgData && xdgData.length > 0) return path.join(xdgData, 'ccsm');
+  return path.join(home, '.local', 'share', 'ccsm');
+}
+
+/** Resolve the full lockfile path (`<dataRoot>/daemon.lock`). */
+function resolveLockfilePath(opts) {
+  const platform = (opts && opts.platform) || process.platform;
+  const env = (opts && opts.env) || process.env;
+  const home = (opts && opts.home) || os.homedir();
+  return path.join(resolveDataRoot(platform, env, home), LOCKFILE_NAME);
+}
+
+/**
+ * Parse argv (skipping node + script). Returns `{ ok, value, error }`.
+ * Strict: unknown flag → error. Negative / non-finite numbers → error.
+ */
+function parseArgs(argv) {
+  const out = {
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+    pollIntervalMs: DEFAULT_POLL_INTERVAL_MS,
+    verbose: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--verbose' || arg === '-v') {
+      out.verbose = true;
+      continue;
+    }
+    if (arg === '--help' || arg === '-h') {
+      return { ok: false, help: true };
+    }
+    if (arg === '--timeout-ms' || arg === '--poll-interval-ms') {
+      const next = argv[i + 1];
+      if (next === undefined) {
+        return { ok: false, error: `${arg} requires a value` };
+      }
+      const n = Number(next);
+      if (!Number.isFinite(n) || n <= 0 || !Number.isInteger(n)) {
+        return { ok: false, error: `${arg} expects a positive integer, got ${JSON.stringify(next)}` };
+      }
+      if (arg === '--timeout-ms') out.timeoutMs = n;
+      else out.pollIntervalMs = n;
+      i += 1;
+      continue;
+    }
+    return { ok: false, error: `unknown argument: ${arg}` };
+  }
+  if (out.pollIntervalMs > out.timeoutMs) {
+    return { ok: false, error: `--poll-interval-ms (${out.pollIntervalMs}) exceeds --timeout-ms (${out.timeoutMs})` };
+  }
+  return { ok: true, value: out };
+}
+
+/** Synchronous existence check. We accept anything (file / lock-dir from
+ *  proper-lockfile) — proper-lockfile creates a directory; older stubs may
+ *  create a regular file. Existence is the load-bearing signal; type is
+ *  out of scope here. */
+function lockfileExists(lockPath) {
+  try {
+    fs.statSync(lockPath);
+    return true;
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return false;
+    // EACCES / EPERM / other unexpected fs error: surface to caller.
+    throw err;
+  }
+}
+
+/**
+ * Poll for the lockfile. Returns a promise resolving to `{ ready, elapsedMs }`.
+ *
+ * `clock.now()` and `clock.sleep(ms)` are injected so tests can drive
+ * deterministic time without sleeping wall-clock seconds. Production
+ * defaults: `Date.now` + `setTimeout`.
+ */
+async function waitForLockfile(opts) {
+  const lockPath = opts.lockfilePath;
+  const timeoutMs = opts.timeoutMs;
+  const pollIntervalMs = opts.pollIntervalMs;
+  const verbose = !!opts.verbose;
+  const log = opts.log || ((msg) => process.stderr.write(`${msg}\n`));
+  const now = (opts.clock && opts.clock.now) || Date.now;
+  const sleep = (opts.clock && opts.clock.sleep) ||
+    ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+  const exists = opts.exists || lockfileExists;
+
+  const started = now();
+  let polls = 0;
+  for (;;) {
+    polls += 1;
+    let present = false;
+    try {
+      present = exists(lockPath);
+    } catch (err) {
+      const msg = err && err.message ? err.message : String(err);
+      log(`wait-daemon: fs error probing ${lockPath}: ${msg}`);
+      return { ready: false, elapsedMs: now() - started, polls, error: err };
+    }
+    if (present) {
+      const elapsedMs = now() - started;
+      if (verbose) {
+        log(`wait-daemon: ready after ${elapsedMs}ms (${polls} poll${polls === 1 ? '' : 's'})`);
+      }
+      return { ready: true, elapsedMs, polls };
+    }
+    const elapsedMs = now() - started;
+    if (elapsedMs >= timeoutMs) {
+      log(
+        `wait-daemon: timeout after ${elapsedMs}ms waiting for ${lockPath} ` +
+          `(daemon did not write daemon.lock — is dev:daemon running?)`,
+      );
+      return { ready: false, elapsedMs, polls };
+    }
+    if (verbose) {
+      log(`wait-daemon: poll #${polls} miss at +${elapsedMs}ms (${lockPath})`);
+    }
+    // Sleep, but never overshoot the timeout deadline.
+    const remainingMs = timeoutMs - elapsedMs;
+    await sleep(Math.min(pollIntervalMs, remainingMs));
+  }
+}
+
+const HELP_TEXT = `Usage: node scripts/wait-daemon.cjs [options]
+
+Blocks until the ccsm daemon writes <dataRoot>/daemon.lock at boot
+(frag-3.7 §3.7.2 + frag-6-7 §6.4).
+
+Options:
+  --timeout-ms <N>        Max wait in milliseconds (default ${DEFAULT_TIMEOUT_MS}).
+  --poll-interval-ms <N>  Poll cadence in milliseconds (default ${DEFAULT_POLL_INTERVAL_MS}).
+  --verbose, -v           Log each poll to stderr.
+  --help, -h              Print this message and exit 2.
+
+Exit codes:
+  0  daemon ready
+  1  timeout
+  2  bad argument
+`;
+
+async function main(argv) {
+  const parsed = parseArgs(argv);
+  if (!parsed.ok) {
+    if (parsed.help) {
+      process.stderr.write(HELP_TEXT);
+      return 2;
+    }
+    process.stderr.write(`wait-daemon: ${parsed.error}\n${HELP_TEXT}`);
+    return 2;
+  }
+  const opts = parsed.value;
+  const lockfilePath = resolveLockfilePath();
+  if (opts.verbose) {
+    process.stderr.write(
+      `wait-daemon: probing ${lockfilePath} (timeout ${opts.timeoutMs}ms, poll ${opts.pollIntervalMs}ms)\n`,
+    );
+  }
+  const result = await waitForLockfile({
+    lockfilePath,
+    timeoutMs: opts.timeoutMs,
+    pollIntervalMs: opts.pollIntervalMs,
+    verbose: opts.verbose,
+  });
+  return result.ready ? 0 : 1;
+}
+
+// Export internals for unit tests. Detect "run as script" via require.main.
+module.exports = {
+  resolveDataRoot,
+  resolveLockfilePath,
+  parseArgs,
+  waitForLockfile,
+  lockfileExists,
+  DEFAULT_TIMEOUT_MS,
+  DEFAULT_POLL_INTERVAL_MS,
+  LOCKFILE_NAME,
+};
+
+if (require.main === module) {
+  main(process.argv.slice(2)).then(
+    (code) => process.exit(code),
+    (err) => {
+      process.stderr.write(`wait-daemon: unexpected error: ${err && err.stack ? err.stack : String(err)}\n`);
+      process.exit(2);
+    },
+  );
+}

--- a/tests/wait-daemon.test.ts
+++ b/tests/wait-daemon.test.ts
@@ -1,0 +1,324 @@
+// T64 — wait-daemon.cjs unit tests + drift guard against
+// daemon/src/sockets/runtime-root.ts.
+//
+// Spec: docs/superpowers/specs/v0.3-fragments/frag-3.7-dev-workflow.md §3.7.2.
+// Drift guard rationale: scripts/wait-daemon.cjs duplicates `resolveDataRoot`
+// because it must run with zero workspace deps in fresh CI clones. The
+// duplication is intentional but fragile — these tests pin both helpers to
+// byte-for-byte identical paths across every supported (platform, env)
+// combination. If the daemon-side resolver changes, this test fails loud and
+// forces a same-PR update to the script.
+
+import { describe, expect, it, vi } from 'vitest';
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+
+interface WaitDaemonModule {
+  resolveDataRoot: (
+    platform: NodeJS.Platform,
+    env: NodeJS.ProcessEnv,
+    home: string,
+  ) => string;
+  resolveLockfilePath: (opts?: {
+    platform?: NodeJS.Platform;
+    env?: NodeJS.ProcessEnv;
+    home?: string;
+  }) => string;
+  parseArgs: (argv: string[]) =>
+    | { ok: true; value: { timeoutMs: number; pollIntervalMs: number; verbose: boolean } }
+    | { ok: false; help?: boolean; error?: string };
+  waitForLockfile: (opts: {
+    lockfilePath: string;
+    timeoutMs: number;
+    pollIntervalMs: number;
+    verbose?: boolean;
+    log?: (msg: string) => void;
+    clock?: { now: () => number; sleep: (ms: number) => Promise<void> };
+    exists?: (p: string) => boolean;
+  }) => Promise<{ ready: boolean; elapsedMs: number; polls: number; error?: unknown }>;
+  lockfileExists: (p: string) => boolean;
+  DEFAULT_TIMEOUT_MS: number;
+  DEFAULT_POLL_INTERVAL_MS: number;
+  LOCKFILE_NAME: string;
+}
+
+const requireCjs = createRequire(import.meta.url);
+const {
+  resolveDataRoot,
+  resolveLockfilePath,
+  parseArgs,
+  waitForLockfile,
+  lockfileExists,
+  DEFAULT_TIMEOUT_MS,
+  DEFAULT_POLL_INTERVAL_MS,
+  LOCKFILE_NAME,
+} = requireCjs('../scripts/wait-daemon.cjs') as WaitDaemonModule;
+
+// Re-implement the daemon-side resolveDataRoot identically to the source at
+// daemon/src/sockets/runtime-root.ts. We deliberately mirror the literal
+// branches rather than importing the module, because the daemon source is
+// ESM with .js extension imports and pulls in `node:fs` mkdir side effects
+// that are not appropriate in a unit test.
+function daemonResolveDataRoot(
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+  home: string,
+): string {
+  if (platform === 'win32') {
+    const local = env.LOCALAPPDATA;
+    if (local && local.length > 0) return join(local, 'ccsm');
+    return join(home, 'AppData', 'Local', 'ccsm');
+  }
+  if (platform === 'darwin') {
+    return join(home, 'Library', 'Application Support', 'ccsm');
+  }
+  const xdgData = env.XDG_DATA_HOME;
+  if (xdgData && xdgData.length > 0) return join(xdgData, 'ccsm');
+  return join(home, '.local', 'share', 'ccsm');
+}
+
+describe('wait-daemon: drift guard vs daemon/src/sockets/runtime-root.ts', () => {
+  const home = process.platform === 'win32' ? 'C:\\Users\\test' : '/home/test';
+  const cases: ReadonlyArray<{
+    name: string;
+    platform: NodeJS.Platform;
+    env: NodeJS.ProcessEnv;
+  }> = [
+    { name: 'win32 with LOCALAPPDATA', platform: 'win32', env: { LOCALAPPDATA: 'C:\\Users\\test\\AppData\\Local' } },
+    { name: 'win32 missing LOCALAPPDATA', platform: 'win32', env: {} },
+    { name: 'darwin (env irrelevant)', platform: 'darwin', env: { LOCALAPPDATA: 'ignored' } },
+    { name: 'linux with XDG_DATA_HOME', platform: 'linux', env: { XDG_DATA_HOME: '/home/test/.local/share' } },
+    { name: 'linux missing XDG_DATA_HOME', platform: 'linux', env: {} },
+    { name: 'linux with empty XDG_DATA_HOME', platform: 'linux', env: { XDG_DATA_HOME: '' } },
+    { name: 'freebsd (POSIX fallback)', platform: 'freebsd' as NodeJS.Platform, env: {} },
+  ];
+
+  for (const c of cases) {
+    it(`matches daemon helper byte-for-byte: ${c.name}`, () => {
+      const ours = resolveDataRoot(c.platform, c.env, home);
+      const theirs = daemonResolveDataRoot(c.platform, c.env, home);
+      expect(ours).toBe(theirs);
+    });
+  }
+});
+
+describe('wait-daemon: resolveLockfilePath', () => {
+  it('appends daemon.lock to the platform data root', () => {
+    const home = '/home/test';
+    const lock = resolveLockfilePath({
+      platform: 'linux',
+      env: { XDG_DATA_HOME: '/home/test/.local/share' },
+      home,
+    });
+    expect(lock).toBe(join('/home/test/.local/share', 'ccsm', 'daemon.lock'));
+  });
+
+  it('uses LOCALAPPDATA on Windows when present', () => {
+    const lock = resolveLockfilePath({
+      platform: 'win32',
+      env: { LOCALAPPDATA: 'C:\\Users\\test\\AppData\\Local' },
+      home: 'C:\\Users\\test',
+    });
+    expect(lock).toBe(join('C:\\Users\\test\\AppData\\Local', 'ccsm', 'daemon.lock'));
+  });
+
+  it('exposes the spec-mandated lockfile filename', () => {
+    expect(LOCKFILE_NAME).toBe('daemon.lock');
+  });
+});
+
+describe('wait-daemon: parseArgs', () => {
+  it('returns defaults for empty argv', () => {
+    const r = parseArgs([]);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value).toEqual({
+        timeoutMs: DEFAULT_TIMEOUT_MS,
+        pollIntervalMs: DEFAULT_POLL_INTERVAL_MS,
+        verbose: false,
+      });
+    }
+  });
+
+  it('parses --timeout-ms and --poll-interval-ms', () => {
+    const r = parseArgs(['--timeout-ms', '5000', '--poll-interval-ms', '50']);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value.timeoutMs).toBe(5000);
+      expect(r.value.pollIntervalMs).toBe(50);
+    }
+  });
+
+  it('parses --verbose and -v', () => {
+    expect(parseArgs(['--verbose'])).toMatchObject({ ok: true, value: { verbose: true } });
+    expect(parseArgs(['-v'])).toMatchObject({ ok: true, value: { verbose: true } });
+  });
+
+  it('rejects unknown flags', () => {
+    const r = parseArgs(['--bogus']);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/unknown argument/);
+  });
+
+  it('rejects missing values', () => {
+    expect(parseArgs(['--timeout-ms']).ok).toBe(false);
+  });
+
+  it('rejects non-positive integers', () => {
+    expect(parseArgs(['--timeout-ms', '0']).ok).toBe(false);
+    expect(parseArgs(['--timeout-ms', '-5']).ok).toBe(false);
+    expect(parseArgs(['--timeout-ms', '1.5']).ok).toBe(false);
+    expect(parseArgs(['--timeout-ms', 'abc']).ok).toBe(false);
+  });
+
+  it('rejects poll-interval > timeout', () => {
+    const r = parseArgs(['--timeout-ms', '100', '--poll-interval-ms', '500']);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/exceeds/);
+  });
+
+  it('treats --help as a non-ok response', () => {
+    const r = parseArgs(['--help']);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.help).toBe(true);
+  });
+});
+
+describe('wait-daemon: waitForLockfile', () => {
+  function fakeClock() {
+    let t = 1_000_000;
+    return {
+      now: () => t,
+      sleep: async (ms: number): Promise<void> => {
+        t += ms;
+      },
+      advance: (ms: number): void => {
+        t += ms;
+      },
+    };
+  }
+
+  it('returns ready immediately when lockfile is present on first poll', async () => {
+    const clock = fakeClock();
+    const exists = vi.fn().mockReturnValue(true);
+    const log = vi.fn();
+    const r = await waitForLockfile({
+      lockfilePath: '/tmp/daemon.lock',
+      timeoutMs: 1000,
+      pollIntervalMs: 100,
+      clock,
+      exists,
+      log,
+    });
+    expect(r.ready).toBe(true);
+    expect(r.polls).toBe(1);
+    expect(exists).toHaveBeenCalledTimes(1);
+  });
+
+  it('polls until ready, then returns ready', async () => {
+    const clock = fakeClock();
+    const log = vi.fn();
+    let calls = 0;
+    const exists = vi.fn().mockImplementation(() => {
+      calls += 1;
+      return calls >= 4; // ready on 4th poll
+    });
+    const r = await waitForLockfile({
+      lockfilePath: '/tmp/daemon.lock',
+      timeoutMs: 10_000,
+      pollIntervalMs: 100,
+      clock,
+      exists,
+      log,
+    });
+    expect(r.ready).toBe(true);
+    expect(r.polls).toBe(4);
+    // 3 misses × 100ms sleeps each
+    expect(r.elapsedMs).toBe(300);
+  });
+
+  it('returns timeout when lockfile never appears', async () => {
+    const clock = fakeClock();
+    const log = vi.fn();
+    const r = await waitForLockfile({
+      lockfilePath: '/tmp/daemon.lock',
+      timeoutMs: 500,
+      pollIntervalMs: 100,
+      clock,
+      exists: () => false,
+      log,
+    });
+    expect(r.ready).toBe(false);
+    expect(r.elapsedMs).toBeGreaterThanOrEqual(500);
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/timeout after \d+ms/));
+  });
+
+  it('does not overshoot the timeout deadline on the final sleep', async () => {
+    const clock = fakeClock();
+    // poll-interval (1000) exceeds remaining time after first miss; sleep
+    // must clamp so we exit at exactly the timeout boundary.
+    const r = await waitForLockfile({
+      lockfilePath: '/tmp/daemon.lock',
+      timeoutMs: 250,
+      pollIntervalMs: 1000,
+      clock,
+      exists: () => false,
+      log: () => {},
+    });
+    expect(r.ready).toBe(false);
+    // First poll at t=0 misses, sleep clamped to 250, second poll at t=250
+    // misses and triggers timeout exit.
+    expect(r.elapsedMs).toBe(250);
+    expect(r.polls).toBe(2);
+  });
+
+  it('surfaces unexpected fs errors as not-ready with error', async () => {
+    const clock = fakeClock();
+    const log = vi.fn();
+    const boom = Object.assign(new Error('EACCES'), { code: 'EACCES' });
+    const exists = vi.fn().mockImplementation(() => {
+      throw boom;
+    });
+    const r = await waitForLockfile({
+      lockfilePath: '/tmp/daemon.lock',
+      timeoutMs: 1000,
+      pollIntervalMs: 100,
+      clock,
+      exists,
+      log,
+    });
+    expect(r.ready).toBe(false);
+    expect(r.error).toBe(boom);
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/fs error probing/));
+  });
+
+  it('verbose mode logs each poll', async () => {
+    const clock = fakeClock();
+    const log = vi.fn();
+    let calls = 0;
+    const exists = vi.fn().mockImplementation(() => {
+      calls += 1;
+      return calls >= 3;
+    });
+    await waitForLockfile({
+      lockfilePath: '/tmp/daemon.lock',
+      timeoutMs: 10_000,
+      pollIntervalMs: 100,
+      verbose: true,
+      clock,
+      exists,
+      log,
+    });
+    // 2 miss logs + 1 ready log = 3
+    const miss = log.mock.calls.filter((c) => /miss at/.test(String(c[0]))).length;
+    const ready = log.mock.calls.filter((c) => /ready after/.test(String(c[0]))).length;
+    expect(miss).toBe(2);
+    expect(ready).toBe(1);
+  });
+});
+
+describe('wait-daemon: lockfileExists (real fs)', () => {
+  it('returns false for a non-existent path', () => {
+    expect(lockfileExists('/nonexistent/path/that/should/not/exist/daemon.lock')).toBe(false);
+  });
+});


### PR DESCRIPTION
Task #1021. Standalone Node helper that BLOCKS until the daemon writes its lockfile during boot. Used by `dev:app`, e2e probes, and harness-agent daemon-mode (T68 future).

## Files

- `scripts/wait-daemon.cjs` (~250 LOC, CommonJS, zero workspace deps)
- `tests/wait-daemon.test.ts` (25 vitest cases)

## Probe path decision

The brief proposes a control-socket `daemon.hello` or `/healthz` round-trip. Spec frag-3.7 §3.7.2 (L85, L91-105, L628-636) and frag-12 traceability table both explicitly mandate **`wait-on file:<dataRoot>/daemon.lock`** instead. Three reasons captured in spec:

1. The lockfile is the load-bearing "daemon up" signal already mandated by frag-6-7 §6.4 — no new contract to add.
2. The daemon writes the lockfile BEFORE binding the control socket (frag-6-7 §6.1 cold-start order), so a lockfile probe is strictly not-before "socket bindable" — equivalent guarantee for the dev-script use case.
3. Polling a file is zero-deps and works in fresh CI clones with no workspace install. A control-socket round-trip would force this script to either duplicate envelope/HMAC framing OR import `@ccsm/daemon` — both violate the standalone-helper contract.

Spec wins; brief deviation is documented at the top of the script.

## Path-root divergence between fragments

frag-3.7 inline snippet says `APPDATA` (Win) / `XDG_CONFIG_HOME` (Linux) for the lockfile path. **frag-12 r5 lock #2** and `daemon/src/sockets/runtime-root.ts` use `LOCALAPPDATA` / `Library/Application Support` / (`XDG_DATA_HOME` ?? `~/.local/share`).

This script follows **runtime-root.ts** because it is the module the daemon actually uses to write the lockfile — picking the older spec snippet would point the script at a non-existent file.

A drift-guard unit test pins `scripts/wait-daemon.cjs#resolveDataRoot` to a re-implementation of the daemon-side logic across 7 (platform, env) combinations. If the daemon resolver changes, this test fails loud and forces a same-PR sync.

## CLI contract

```
node scripts/wait-daemon.cjs [--timeout-ms <N>] [--poll-interval-ms <N>] [--verbose]
```

| Default | Value |
|---|---|
| `--timeout-ms` | 15000 |
| `--poll-interval-ms` | 200 |
| `--verbose` | off |

Exit codes:
- `0` — daemon ready (lockfile present)
- `1` — timeout
- `2` — bad CLI argument / `--help`

Stdout reserved for future structured output; all logs to stderr.

## Test summary

25 vitest cases passing:
- 7 drift-guard cases (`resolveDataRoot` matches daemon helper byte-for-byte across win32/darwin/linux/freebsd × env permutations)
- `resolveLockfilePath` (3 cases)
- `parseArgs` (8 cases — defaults, valid flags, unknowns, missing values, non-positive ints, poll>timeout, --help)
- `waitForLockfile` (6 cases — ready-on-first-poll, polls-then-ready, timeout, sleep-clamp on final poll, fs-error surface, verbose log lines)
- `lockfileExists` (1 real-fs case)

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run --no-coverage tests/wait-daemon.test.ts` — 25/25 pass
- Manual smoke: `node scripts/wait-daemon.cjs --timeout-ms 200 --poll-interval-ms 50` exits 1 with timeout message
- Manual smoke: `node scripts/wait-daemon.cjs --bogus` exits 2 with usage

## Wiring

Script-only addition; no changes to `package.json` `dev:app` (kept out per hot-file avoidance — installer PRs queued). Wiring into `dev:app` is a follow-up one-liner.

## Hot-file avoidance respected

No edits to `daemon/src/dispatcher.ts`, `daemon/src/pty/*`, or `package.json`.