### PR TITLE
feat(installer): T52 NSIS customUnInstall runs T53 helper pre-wipe

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,0 +1,60 @@
+; build/installer.nsh — wired via package.json build.nsis.include (round-2 P0-1).
+;
+; Spec citations:
+;   - frag-11-packaging.md §11.6.1 — silent customUnInstall macro (no MessageBox).
+;     [manager r9 lock: r8 packaging P0-2] oneClick:false assisted-mode installer
+;     owns the user-facing UI; modal dialogs from inside customUnInstall would
+;     either fight that UI or auto-default to "No" under the silent (/S) updater
+;     path, silently skipping cleanup. The macro performs the always-safe
+;     mechanics only (graceful RPC shutdown, taskkill safety net, lockfile
+;     delete). User-data opt-in deletion is performed in-app via the frag-6-7
+;     §6.8 "Reset CCSM..." surface BEFORE the user invokes the uninstaller.
+;   - frag-11-packaging.md §11.6.4 — Daemon-shutdown RPC integration. Preferred
+;     path: invoke ccsm-uninstall-helper.exe (T53, #691) which speaks the
+;     control-socket pipe and sends `daemon.shutdownForUpgrade` so the daemon
+;     flushes pino buffers + releases proper-lockfile cleanly. The helper exits
+;     0 on graceful OR daemon-already-dead (idempotent), 1 on hard error. The
+;     subsequent taskkill is the safety net for the exit-1 / helper-missing
+;     paths.
+;   - frag-11-packaging.md §11.6.4 round-3 P1-6 — copy the helper to $TEMP
+;     BEFORE invoking so the in-progress uninstall main loop can RMDir $INSTDIR
+;     without tripping a Windows file-lock on the helper exe itself.
+;   - installer/uninstall-helper/index.js — exit semantics: 0 = graceful or
+;     idempotent, 1 = hard error. CLI: `--shutdown --timeout <ms>`.
+;
+; All paths use $LOCALAPPDATA per round-3 P0-1/P0-2; never $PROGRAMFILES.
+
+!macro customUnInstall
+  ; 1. Graceful shutdown via T53 helper (frag-11 §11.6.4). Best-effort: if the
+  ;    helper exe is missing (older install, manually deleted) we skip silently
+  ;    and fall through to the taskkill safety net. The CopyFiles /SILENT
+  ;    suppresses any user-visible dialog; IfFileExists guards the source so a
+  ;    missing helper does not leave a stale $TEMP copy from a prior uninstall.
+  IfFileExists "$INSTDIR\resources\daemon\ccsm-uninstall-helper.exe" 0 +5
+    SetOutPath "$TEMP"
+    CopyFiles /SILENT "$INSTDIR\resources\daemon\ccsm-uninstall-helper.exe" "$TEMP\ccsm-uninstall-helper.exe"
+    nsExec::ExecToLog '"$TEMP\ccsm-uninstall-helper.exe" --shutdown --timeout 2000'
+    Pop $0  ; helper exit code (logged via ExecToLog; not branched on per r9 P0-2 silent contract)
+
+  ; 2. Hardstop safety net (frag-11 §11.6.1). Covers: helper missing, helper
+  ;    exit-1 (hard error), or daemon respawned between graceful shutdown and
+  ;    install-root wipe. /T also kills any child processes.
+  nsExec::ExecToLog 'taskkill /IM ccsm-daemon.exe /F /T'
+  Sleep 500   ; let OS release file handles before $INSTDIR RMDir
+
+  ; 3. Lockfile cleanup (frag-6-7 §6.4 — proper-lockfile leaves a stale lock
+  ;    dir on SIGKILL; explicit unlink here closes the race window).
+  Delete "$LOCALAPPDATA\ccsm\daemon.lock"
+
+  ; 4. Drop the staged $TEMP helper copy. Best-effort: if step 1 was skipped
+  ;    (no helper installed) this is a no-op. We do this AFTER taskkill so the
+  ;    helper file is not held open by its own process.
+  Delete "$TEMP\ccsm-uninstall-helper.exe"
+
+  ; 5. The install root ($INSTDIR under %LOCALAPPDATA%\ccsm) is wiped by the
+  ;    standard NSIS uninstall sequence after this macro returns. User data
+  ;    subdirs (data/, logs/, crashes/, daemon.secret) are NOT touched here —
+  ;    retained by default per the §11.6 paths table. Opt-in cleanup happens
+  ;    in-app (frag-6-7 §6.8) BEFORE uninstall, OR the user manually deletes
+  ;    %LOCALAPPDATA%\ccsm\ post-uninstall (release-notes documented).
+!macroend

--- a/package.json
+++ b/package.json
@@ -183,7 +183,8 @@
       "deleteAppDataOnUninstall": false,
       "createDesktopShortcut": true,
       "createStartMenuShortcut": true,
-      "shortcutName": "CCSM"
+      "shortcutName": "CCSM",
+      "include": "build/installer.nsh"
     },
     "mac": {
       "target": [


### PR DESCRIPTION
Task #1014. Wires NSIS `customUnInstall` macro to invoke the T53 helper (`$INSTDIR\resources\daemon\ccsm-uninstall-helper.exe`) before the install root is wiped, so the daemon flushes pino buffers + releases proper-lockfile cleanly via `daemon.shutdownForUpgrade` RPC.

## Layer 1 — spec alignment

The task brief proposed an `MB_YESNO` MessageBox on helper exit-non-zero. Spec **frag-11-packaging.md §11.6.1 [manager r9 lock: r8 packaging P0-2]** explicitly retracts the MessageBox: with `oneClick: false` the assisted-mode uninstaller owns the user-facing UI; modal dialogs from inside `customUnInstall` would (a) fight that UI and (b) auto-default to "No" under the silent (`/S`) electron-updater path, silently skipping cleanup. Macro is therefore **silent** per spec; the always-safe taskkill safety net runs unconditionally regardless of helper exit code.

The brief also said `--timeout-ms 8000`. Helper CLI per `installer/uninstall-helper/index.js` accepts `--shutdown --timeout <ms>` (no `-ms` suffix); spec §11.6.4 example uses `--shutdown --timeout 2000`. Followed spec.

## Files changed (2 files, +62 / -1)

- `build/installer.nsh` (NEW, 60 LOC): `!macro customUnInstall` — IfFileExists guard + CopyFiles to `$TEMP` (round-3 P1-6 file-lock avoidance) + `nsExec::ExecToLog '"$TEMP\ccsm-uninstall-helper.exe" --shutdown --timeout 2000'` + `taskkill /IM ccsm-daemon.exe /F /T` safety net + `Sleep 500` + `Delete $LOCALAPPDATA\ccsm\daemon.lock` + `Delete $TEMP\ccsm-uninstall-helper.exe`.
- `package.json` (3-line hunk): added `"include": "build/installer.nsh"` to `build.nsis` block. No version bump, no other edits.

## Behavior matrix

| Scenario | Helper invoked? | Helper exit | taskkill | Outcome |
|---|---|---|---|---|
| Daemon running, RPC reachable | yes | 0 (graceful) | finds nothing, no-op | clean |
| Daemon running, RPC unreachable | yes | 1 (hard error) | hard-kills daemon | clean (best effort) |
| Daemon already dead | yes | 0 (idempotent) | finds nothing | clean |
| Helper exe missing | skipped (IfFileExists) | n/a | hard-kills if present | falls back to taskkill |

## Verification

- `node -e "JSON.parse(...)"` → package.json valid.
- `npx tsc --noEmit` → clean (no TS code touched).
- Vitest baseline unchanged (no test files touched).
- NSIS scripts have no harness — manual smoke required.

## Manual smoke required (cannot run installer in worker env; needs user / build-worker handoff before #1019/#1035 unblock)

- (a) Install + start daemon + uninstall → assert `%TEMP%\ccsm-uninstall.log` shows "graceful shutdown" and ccsm-daemon.exe exits before $INSTDIR wipe (no "file in use" errors in NSIS log).
- (b) Install + `taskkill /F /IM ccsm-daemon.exe` + uninstall → helper exit 0 (idempotent), taskkill is no-op, $INSTDIR wipes cleanly.
- (c) Install + manually `del $INSTDIR\resources\daemon\ccsm-uninstall-helper.exe` + uninstall → IfFileExists skips helper block, taskkill safety net runs, no NSIS error.
- (d) Silent uninstall via electron-updater (`/S` flag) → no MessageBox blocks the flow (spec r9 P0-2 contract).

## Hot file note

package.json hunk is `nsis.include` only; #695 (T48) just merged on `working`, #1021 (T64) in flight may touch scripts — no overlap. `installer/uninstall-helper/*` not modified (T53 just merged).