### PR TITLE
feat(electron): T71 streamHandleTable inventory (debug + e2e support)

### DIFF
--- a/electron/daemonClient/__tests__/streamHandleTable.test.ts
+++ b/electron/daemonClient/__tests__/streamHandleTable.test.ts
@@ -1,0 +1,196 @@
+// Tests for streamHandleTable — pure registry, no I/O, no clock.
+// Spec: frag-3.7 §3.7.5 step 1 (reconnect tears down stale handles).
+
+import { describe, it, expect, vi } from 'vitest';
+import { createStreamHandleTable } from '../streamHandleTable';
+
+describe('createStreamHandleTable', () => {
+  it('starts empty', () => {
+    const table = createStreamHandleTable();
+    expect(table.count()).toBe(0);
+    expect(table.snapshot()).toEqual([]);
+  });
+
+  it('register adds an entry visible in snapshot + count', () => {
+    const table = createStreamHandleTable();
+    table.register({
+      handleId: 'h1',
+      streamType: 'pty-subscribe',
+      subId: 'sid-1',
+      subscriberId: 'sub-A',
+      openedAt: 100,
+    });
+    expect(table.count()).toBe(1);
+    const snap = table.snapshot();
+    expect(snap).toHaveLength(1);
+    expect(snap[0]).toMatchObject({
+      handleId: 'h1',
+      streamType: 'pty-subscribe',
+      subId: 'sid-1',
+      subscriberId: 'sub-A',
+      openedAt: 100,
+    });
+  });
+
+  it('snapshot sorts by openedAt ascending', () => {
+    const table = createStreamHandleTable();
+    table.register({ handleId: 'late', streamType: 'data-stream', openedAt: 300 });
+    table.register({ handleId: 'early', streamType: 'data-stream', openedAt: 100 });
+    table.register({ handleId: 'mid', streamType: 'data-stream', openedAt: 200 });
+    expect(table.snapshot().map((e) => e.handleId)).toEqual([
+      'early',
+      'mid',
+      'late',
+    ]);
+  });
+
+  it('snapshot entries are frozen and exclude cancel callback', () => {
+    const table = createStreamHandleTable();
+    table.register({
+      handleId: 'h1',
+      streamType: 'control-stream',
+      openedAt: 100,
+      cancel: () => {},
+    });
+    const entry = table.snapshot()[0] as Record<string, unknown>;
+    expect(Object.isFrozen(entry)).toBe(true);
+    expect(entry.cancel).toBeUndefined();
+  });
+
+  it('register returns RAII unregister', () => {
+    const table = createStreamHandleTable();
+    const reg = table.register({
+      handleId: 'h1',
+      streamType: 'pty-subscribe',
+      openedAt: 100,
+    });
+    expect(table.count()).toBe(1);
+    reg.unregister();
+    expect(table.count()).toBe(0);
+  });
+
+  it('double unregister is a no-op (idempotent)', () => {
+    const table = createStreamHandleTable();
+    const reg = table.register({
+      handleId: 'h1',
+      streamType: 'pty-subscribe',
+      openedAt: 100,
+    });
+    reg.unregister();
+    expect(() => reg.unregister()).not.toThrow();
+    expect(table.count()).toBe(0);
+  });
+
+  it('unregister(handleId) removes the entry', () => {
+    const table = createStreamHandleTable();
+    table.register({ handleId: 'h1', streamType: 'pty-subscribe', openedAt: 100 });
+    table.register({ handleId: 'h2', streamType: 'pty-subscribe', openedAt: 200 });
+    table.unregister('h1');
+    expect(table.count()).toBe(1);
+    expect(table.snapshot()[0].handleId).toBe('h2');
+  });
+
+  it('unregister of unknown id is a no-op', () => {
+    const table = createStreamHandleTable();
+    expect(() => table.unregister('ghost')).not.toThrow();
+  });
+
+  it('clear() empties the table without invoking cancel', () => {
+    const table = createStreamHandleTable();
+    const cancel = vi.fn();
+    table.register({
+      handleId: 'h1',
+      streamType: 'pty-subscribe',
+      openedAt: 100,
+      cancel,
+    });
+    table.clear();
+    expect(table.count()).toBe(0);
+    expect(cancel).not.toHaveBeenCalled();
+  });
+
+  it('cancelAll() invokes every cancel and empties the table', async () => {
+    const table = createStreamHandleTable();
+    const c1 = vi.fn();
+    const c2 = vi.fn();
+    table.register({ handleId: 'h1', streamType: 'pty-subscribe', openedAt: 100, cancel: c1 });
+    table.register({ handleId: 'h2', streamType: 'control-stream', openedAt: 200, cancel: c2 });
+    await table.cancelAll();
+    expect(c1).toHaveBeenCalledTimes(1);
+    expect(c2).toHaveBeenCalledTimes(1);
+    expect(table.count()).toBe(0);
+  });
+
+  it('cancelAll() awaits async cancels', async () => {
+    const table = createStreamHandleTable();
+    let resolved = false;
+    table.register({
+      handleId: 'h1',
+      streamType: 'data-stream',
+      openedAt: 100,
+      cancel: async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        resolved = true;
+      },
+    });
+    await table.cancelAll();
+    expect(resolved).toBe(true);
+  });
+
+  it('cancelAll() swallows errors so one bad handle does not strand others', async () => {
+    const table = createStreamHandleTable();
+    const good = vi.fn();
+    table.register({
+      handleId: 'bad',
+      streamType: 'pty-subscribe',
+      openedAt: 100,
+      cancel: () => {
+        throw new Error('boom');
+      },
+    });
+    table.register({
+      handleId: 'good',
+      streamType: 'pty-subscribe',
+      openedAt: 200,
+      cancel: good,
+    });
+    await expect(table.cancelAll()).resolves.toBeUndefined();
+    expect(good).toHaveBeenCalledTimes(1);
+    expect(table.count()).toBe(0);
+  });
+
+  it('cancelAll() with no handles resolves cleanly', async () => {
+    const table = createStreamHandleTable();
+    await expect(table.cancelAll()).resolves.toBeUndefined();
+  });
+
+  it('register with duplicate handleId replaces the prior entry; old RAII is inert', () => {
+    const table = createStreamHandleTable();
+    const oldReg = table.register({
+      handleId: 'h1',
+      streamType: 'pty-subscribe',
+      openedAt: 100,
+    });
+    table.register({
+      handleId: 'h1',
+      streamType: 'control-stream',
+      openedAt: 200,
+    });
+    // Old RAII must NOT remove the new entry.
+    oldReg.unregister();
+    expect(table.count()).toBe(1);
+    expect(table.snapshot()[0]).toMatchObject({
+      handleId: 'h1',
+      streamType: 'control-stream',
+      openedAt: 200,
+    });
+  });
+
+  it('factory returns independent instances', () => {
+    const a = createStreamHandleTable();
+    const b = createStreamHandleTable();
+    a.register({ handleId: 'h1', streamType: 'pty-subscribe', openedAt: 100 });
+    expect(a.count()).toBe(1);
+    expect(b.count()).toBe(0);
+  });
+});

--- a/electron/daemonClient/streamHandleTable.ts
+++ b/electron/daemonClient/streamHandleTable.ts
@@ -1,0 +1,160 @@
+// Stream-handle table — debug + cleanup registry for active daemon stream
+// subscriptions (PTY subscribe streams, control streams, data streams).
+//
+// Spec: docs/superpowers/specs/v0.3-fragments/frag-3.7-dev-workflow.md
+// §3.7.5 step 1 + Task 7 plan delta (~80 LOC). Used by:
+//   - connectClient reconnect path: iterates handles, calls `.cancel()` on
+//     each (closes round-2 devx P1-6 — clears client-side heartbeat
+//     setInterval timers per frag-3.5.1 §3.5.1.4 so they don't accumulate
+//     across nodemon restarts).
+//   - T78 e2e probe "reconnect after stream-dead": asserts table empty
+//     after stream cleanup.
+//   - T68 harness-agent dev mode: debug overlay snapshot.
+//   - Future cross-process leak audit.
+//
+// Single Responsibility — this is a **producer** (snapshot/count) and a
+// **registry sink** for handle entries. It does NOT call into PTY/socket
+// subsystems itself; the caller registers a `cancel` callback that the
+// caller decides how to wire (close socket, clear setInterval, etc.).
+// The table just iterates and invokes them on `cancelAll()`.
+//
+// Design choices:
+//   - Factory pattern (`createStreamHandleTable()`), no module-level
+//     singleton. Each connectClient instance owns one. Lets tests build
+//     fresh tables without mutual contamination.
+//   - Caller passes `openedAt` (no clock dep). `snapshot()` sorts by
+//     `openedAt` ascending so debug output reads chronologically.
+//   - `register()` returns `{ unregister }` for RAII cleanup at the call
+//     site. Double-unregister is a no-op (idempotent).
+//   - `cancelAll()` calls every registered handle's `cancel` callback,
+//     swallowing errors so one bad handle can't strand the rest, then
+//     clears the table. This is the operation §3.7.5 step 1 needs.
+
+export type StreamHandleType =
+  | 'pty-subscribe'
+  | 'control-stream'
+  | 'data-stream';
+
+/** Caller-supplied entry payload. `cancel` is invoked by `cancelAll()`. */
+export interface StreamHandleRegistration {
+  /** Stable identifier the caller owns; used as the table key. */
+  handleId: string;
+  /** Coarse classification for debug overlays / leak audits. */
+  streamType: StreamHandleType;
+  /** Session id, when the handle is sid-scoped (PTY/data streams). */
+  subId?: string;
+  /** Subscriber id, when multiple consumers share a sid (fan-out). */
+  subscriberId?: string;
+  /** Caller-supplied open timestamp (ms). Keeps the table clock-free. */
+  openedAt: number;
+  /** Tear-down callback; invoked by `cancelAll()`. May be sync or async. */
+  cancel?: () => void | Promise<void>;
+}
+
+/** Frozen view returned from `snapshot()`. `cancel` is intentionally omitted. */
+export interface StreamHandleSnapshotEntry {
+  handleId: string;
+  streamType: StreamHandleType;
+  subId?: string;
+  subscriberId?: string;
+  openedAt: number;
+}
+
+export interface StreamHandleTable {
+  /** Add a handle. Returns `{ unregister }` for RAII cleanup. */
+  register(entry: StreamHandleRegistration): { unregister: () => void };
+  /** Remove a handle by id. No-op if absent. */
+  unregister(handleId: string): void;
+  /** Frozen list of current handles, sorted by `openedAt` ascending. */
+  snapshot(): readonly StreamHandleSnapshotEntry[];
+  /** Current number of registered handles. Cheap; safe in assertions. */
+  count(): number;
+  /**
+   * Invoke every registered handle's `cancel` callback (errors swallowed
+   * so a bad handle can't strand the rest), then empty the table.
+   * Returns a Promise that resolves after all callbacks settle. This is
+   * the operation `connectClient` uses on reconnect (frag-3.7 §3.7.5
+   * step 1 — closes round-2 devx P1-6 heartbeat-timer leak).
+   */
+  cancelAll(): Promise<void>;
+  /**
+   * Empty the table without invoking any `cancel` callbacks. Test reset
+   * helper; production code should use `cancelAll()`.
+   */
+  clear(): void;
+}
+
+interface InternalEntry extends StreamHandleRegistration {}
+
+export function createStreamHandleTable(): StreamHandleTable {
+  const handles = new Map<string, InternalEntry>();
+
+  const register: StreamHandleTable['register'] = (entry) => {
+    // Last-writer-wins on duplicate handleId; the previous registration's
+    // RAII unregister becomes a no-op (idempotent semantics below).
+    handles.set(entry.handleId, { ...entry });
+    let unregistered = false;
+    return {
+      unregister: () => {
+        if (unregistered) return;
+        unregistered = true;
+        // Only unregister if the entry in the map is still ours; if a
+        // later register() with the same id replaced it, leave the new
+        // one alone.
+        const current = handles.get(entry.handleId);
+        if (current && current.openedAt === entry.openedAt) {
+          handles.delete(entry.handleId);
+        }
+      },
+    };
+  };
+
+  const unregister: StreamHandleTable['unregister'] = (handleId) => {
+    handles.delete(handleId);
+  };
+
+  const snapshot: StreamHandleTable['snapshot'] = () => {
+    const entries = Array.from(handles.values())
+      .sort((a, b) => a.openedAt - b.openedAt)
+      .map<StreamHandleSnapshotEntry>((e) => {
+        const out: StreamHandleSnapshotEntry = {
+          handleId: e.handleId,
+          streamType: e.streamType,
+          openedAt: e.openedAt,
+        };
+        if (e.subId !== undefined) out.subId = e.subId;
+        if (e.subscriberId !== undefined) out.subscriberId = e.subscriberId;
+        return Object.freeze(out);
+      });
+    return Object.freeze(entries);
+  };
+
+  const count: StreamHandleTable['count'] = () => handles.size;
+
+  const cancelAll: StreamHandleTable['cancelAll'] = async () => {
+    // Snapshot the cancel callbacks first, then clear the table BEFORE
+    // invoking — this way if a `cancel` callback re-enters the table
+    // (e.g. registers a fresh handle on its own) it sees a clean slate.
+    const cancels: Array<() => void | Promise<void>> = [];
+    for (const entry of handles.values()) {
+      if (entry.cancel) cancels.push(entry.cancel);
+    }
+    handles.clear();
+    await Promise.all(
+      cancels.map(async (cancel) => {
+        try {
+          await cancel();
+        } catch {
+          // Swallow: one bad handle MUST NOT strand the rest. Caller can
+          // log via its own cancel callback if it wants visibility.
+        }
+      }),
+    );
+  };
+
+  const clear: StreamHandleTable['clear'] = () => {
+    handles.clear();
+  };
+
+  return { register, unregister, snapshot, count, cancelAll, clear };
+}


### PR DESCRIPTION
Task #1024.

## Summary
Pure registry of currently-active daemon stream handles (PTY subscribe, control, data). Factory pattern, no module singleton, no I/O, no clock dep.

## API
`createStreamHandleTable()` returns `{ register, unregister, snapshot, count, cancelAll, clear }`.
- `register(entry)` returns `{ unregister }` for RAII cleanup. Idempotent double-unregister.
- `snapshot()` returns frozen, `openedAt`-ascending list (cancel callback omitted).
- `cancelAll()` invokes every entry's cancel (errors swallowed) and empties — the operation `connectClient` needs on reconnect per frag-3.7 §3.7.5 step 1 (closes round-2 devx P1-6 heartbeat-timer leak).
- `clear()` empties without invoking cancel (test reset only).

## Placement
`electron/daemonClient/streamHandleTable.ts` — exact path mandated by frag-3.7-dev-workflow.md §Task 7 plan delta (~80 LOC). Directory created fresh; no other consumers yet.

## Spec divergence
Brief said "INVENTORY only — does NOT hold actual handles". Spec says it iterates handles and calls `.cancel()`. Per Layer 1 discipline (spec wins on placement/contract), entry holds an optional `cancel` callback so `cancelAll()` can satisfy spec semantics. Snapshot still excludes the callback so it's pure debug data.

## Used by
- T78 e2e probe "reconnect after stream-dead" (assert `count() === 0` after teardown).
- T68 harness-agent dev mode debug overlay.
- Future cross-process leak audit.

## Verification
- `npx vitest run --no-coverage electron/daemonClient/__tests__/streamHandleTable.test.ts` -> 15 passed.
- `npx tsc --noEmit -p tsconfig.electron.json` -> clean.
- 2 files added, ~200 LOC source + ~155 LOC tests, no edits to existing files.

## Test plan
- [x] register/unregister/snapshot ordering
- [x] double-unregister no-throw, idempotent
- [x] count()
- [x] clear() does not invoke cancel
- [x] cancelAll() invokes sync + async cancels, swallows errors, empties table
- [x] duplicate handleId replace + stale RAII inert
- [x] factory returns independent instances
- [x] snapshot entries frozen + cancel callback omitted