### PR TITLE
feat(ci): T58 installer size guard (disabled per v0.3 window)

### DIFF
--- a/.github/workflows/installer-size-guard.yml
+++ b/.github/workflows/installer-size-guard.yml
@@ -1,0 +1,85 @@
+name: installer-size-guard
+
+# Task #1015 (T58) — Installer size CI guard.
+#
+# Builds the installer for each OS and runs scripts/check-installer-size.mjs
+# against the artifact. FAILS if size exceeds the absolute per-extension
+# ceiling from frag-11-packaging.md §11.5(6) OR if size grew >10% vs the
+# baseline in installer/size-baseline.json (>5% emits a warning).
+#
+# DISABLED for the v0.3 migration window per Task #1047 (mirrors ci.yml /
+# e2e.yml gating). Will be re-enabled by Task #1048.
+
+on:
+  pull_request:
+    branches: [main, working]
+    paths:
+      - 'electron/**'
+      - 'src/**'
+      - 'daemon/**'
+      - 'scripts/check-installer-size.mjs'
+      - 'installer/size-baseline.json'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'electron-builder.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: installer-size-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  size-guard:
+    if: false  # DISABLED for v0.3 migration window — see Task #1048 to restore
+    name: size-guard (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            platform: win
+          - os: macos-latest
+            platform: mac
+          - os: ubuntu-latest
+            platform: linux
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install deps
+        run: npm ci --legacy-peer-deps
+
+      - name: Build installer (${{ matrix.platform }})
+        run: npx electron-builder --${{ matrix.platform }} --publish never
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check installer size
+        run: node scripts/check-installer-size.mjs --dir release
+
+      - name: Upload installer artifacts (debug)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: installer-${{ matrix.platform }}
+          path: |
+            release/*.exe
+            release/*.dmg
+            release/*.AppImage
+            release/*.deb
+            release/*.rpm
+          if-no-files-found: warn
+          retention-days: 7

--- a/installer/size-baseline.json
+++ b/installer/size-baseline.json
@@ -1,0 +1,14 @@
+{
+  "_comment": "Installer size baseline (bytes) for Task #1015 / T58 size guard. Per-extension entries; checked by scripts/check-installer-size.mjs. Bump only via dedicated PR with reviewer sign-off (NEVER auto-commit from CI). Spec: docs/superpowers/specs/v0.3-fragments/frag-11-packaging.md §11.5(6).",
+  "_placeholder": true,
+  "_placeholder_reason": "Pool-10 env cannot run `npm run make:win` reliably (missing native toolchain on this checkout); these byte counts are conservative estimates from frag-11 §11.5(6) component breakdown (Electron 41 ~95 MB + daemon ~50 MB + SDK ~6 MB + uninstall-helper ~5 MB) and MUST be replaced by the first green CI build that produces real artifacts. Until then the absolute ceiling check is the real guard. See Task #1015 follow-up.",
+  "version": 1,
+  "updated": "2026-05-01",
+  "entries": {
+    "exe": 130023424,
+    "dmg": 146800640,
+    "AppImage": 125829120,
+    "deb": 110100480,
+    "rpm": 110100480
+  }
+}

--- a/scripts/check-installer-size.mjs
+++ b/scripts/check-installer-size.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+// Installer size guard — Task #1015 (T58).
+//
+// Measures the installer artifact produced by `npm run make:<platform>` and
+// compares against:
+//   1. Per-extension absolute ceilings from frag-11 §11.5(6) (HARD fail).
+//   2. A delta vs the recorded baseline in `installer/size-baseline.json`:
+//        > 10% growth -> FAIL
+//        >  5% growth ->  WARN (CI annotation, exit 0)
+//
+// The baseline file stores the last-blessed size per OS+ext. To bump it,
+// edit `installer/size-baseline.json` in a separate PR (manual approval —
+// NEVER auto-commit from CI per spec).
+//
+// Usage:
+//   node scripts/check-installer-size.mjs                # auto-detect
+//   node scripts/check-installer-size.mjs --dir release  # custom search dir
+//   node scripts/check-installer-size.mjs --file path/to/installer.exe
+//
+// Exit codes:
+//   0 = within budget (may print warnings)
+//   1 = over absolute ceiling OR > 10% over baseline
+//   2 = no installer artifact found / bad invocation
+//
+// CI gh-actions friendly: emits ::error:: / ::warning:: annotations.
+
+import { readFileSync, statSync, existsSync, readdirSync } from 'node:fs';
+import { join, extname, resolve, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+const BASELINE_PATH = join(REPO_ROOT, 'installer', 'size-baseline.json');
+
+// Per-extension absolute ceilings in MB. Locked in
+// docs/superpowers/specs/v0.3-fragments/frag-11-packaging.md §11.5(6).
+// Bumping these requires a spec edit + reviewer sign-off.
+const CEILING_MB = {
+  exe: 145,
+  dmg: 160,
+  AppImage: 140,
+  deb: 125,
+  rpm: 125,
+};
+
+const WARN_PCT = 5;
+const FAIL_PCT = 10;
+
+function emit(level, msg) {
+  // GitHub Actions log command; prints plain when run locally.
+  if (process.env.GITHUB_ACTIONS === 'true') {
+    process.stdout.write(`::${level}::${msg}\n`);
+  } else {
+    process.stdout.write(`[${level}] ${msg}\n`);
+  }
+}
+
+function parseArgs(argv) {
+  const out = { dir: null, file: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--dir') out.dir = argv[++i];
+    else if (a === '--file') out.file = argv[++i];
+  }
+  return out;
+}
+
+function findInstallers(searchDir) {
+  if (!existsSync(searchDir)) return [];
+  const out = [];
+  const stack = [searchDir];
+  while (stack.length) {
+    const d = stack.pop();
+    let entries;
+    try {
+      entries = readdirSync(d, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const ent of entries) {
+      const p = join(d, ent.name);
+      if (ent.isDirectory()) {
+        // Skip blockmap / unpacked dirs — only top-level installer artifacts matter.
+        if (ent.name === 'win-unpacked' || ent.name === 'mac' || ent.name === 'linux-unpacked') continue;
+        stack.push(p);
+      } else if (ent.isFile()) {
+        const ext = extname(ent.name).slice(1);
+        if (ext in CEILING_MB) out.push(p);
+      }
+    }
+  }
+  return out;
+}
+
+function loadBaseline() {
+  if (!existsSync(BASELINE_PATH)) {
+    emit('warning', `baseline file not found at ${BASELINE_PATH} — skipping delta check`);
+    return null;
+  }
+  try {
+    return JSON.parse(readFileSync(BASELINE_PATH, 'utf8'));
+  } catch (err) {
+    emit('warning', `failed to parse baseline: ${err.message}`);
+    return null;
+  }
+}
+
+function bytesToMB(n) {
+  return n / 1024 / 1024;
+}
+
+function checkOne(filePath, baseline) {
+  const ext = extname(filePath).slice(1);
+  const ceilMB = CEILING_MB[ext];
+  if (ceilMB === undefined) {
+    emit('warning', `unknown installer ext: ${filePath}`);
+    return { fail: false, warn: false };
+  }
+  const sizeBytes = statSync(filePath).size;
+  const sizeMB = bytesToMB(sizeBytes);
+  const sizeMBRounded = Math.round(sizeMB * 100) / 100;
+
+  let fail = false;
+  let warn = false;
+
+  process.stdout.write(`\n${filePath}\n`);
+  process.stdout.write(`  size:    ${sizeMBRounded} MB (${sizeBytes} bytes)\n`);
+  process.stdout.write(`  ceiling: ${ceilMB} MB (.${ext})\n`);
+
+  if (sizeMB > ceilMB) {
+    emit('error', `${basename(filePath)} exceeds absolute ceiling: ${sizeMBRounded} MB > ${ceilMB} MB`);
+    fail = true;
+  }
+
+  if (baseline && baseline.entries) {
+    const key = baseline.entries[ext] != null ? ext : null;
+    if (key) {
+      const baselineBytes = baseline.entries[ext];
+      const baselineMB = Math.round(bytesToMB(baselineBytes) * 100) / 100;
+      const deltaPct = ((sizeBytes - baselineBytes) / baselineBytes) * 100;
+      const deltaPctRounded = Math.round(deltaPct * 100) / 100;
+      process.stdout.write(`  baseline: ${baselineMB} MB (delta ${deltaPctRounded > 0 ? '+' : ''}${deltaPctRounded}%)\n`);
+
+      if (deltaPct > FAIL_PCT) {
+        emit('error', `${basename(filePath)} grew ${deltaPctRounded}% vs baseline (>${FAIL_PCT}% fail threshold)`);
+        fail = true;
+      } else if (deltaPct > WARN_PCT) {
+        emit('warning', `${basename(filePath)} grew ${deltaPctRounded}% vs baseline (>${WARN_PCT}% warn threshold)`);
+        warn = true;
+      }
+    } else {
+      emit('warning', `no baseline entry for .${ext} — skipping delta check (add to installer/size-baseline.json)`);
+    }
+  }
+
+  return { fail, warn };
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  let files = [];
+  if (args.file) {
+    if (!existsSync(args.file)) {
+      emit('error', `--file does not exist: ${args.file}`);
+      process.exit(2);
+    }
+    files = [resolve(args.file)];
+  } else {
+    const searchDir = args.dir
+      ? resolve(args.dir)
+      : join(REPO_ROOT, 'release');
+    files = findInstallers(searchDir);
+    if (files.length === 0) {
+      emit('error', `no installer artifacts found under ${searchDir} (expected .exe/.dmg/.AppImage/.deb/.rpm)`);
+      process.exit(2);
+    }
+  }
+
+  const baseline = loadBaseline();
+  let anyFail = false;
+  let anyWarn = false;
+
+  for (const f of files) {
+    const r = checkOne(f, baseline);
+    anyFail = anyFail || r.fail;
+    anyWarn = anyWarn || r.warn;
+  }
+
+  process.stdout.write('\n');
+  if (anyFail) {
+    process.stdout.write('RESULT: FAIL — installer size budget exceeded\n');
+    process.exit(1);
+  }
+  if (anyWarn) {
+    process.stdout.write('RESULT: PASS (with warnings)\n');
+  } else {
+    process.stdout.write('RESULT: PASS\n');
+  }
+  process.exit(0);
+}
+
+main();


### PR DESCRIPTION
Task #1015 (T58) — installer size CI guard.

## Summary
- New workflow `.github/workflows/installer-size-guard.yml` runs `npx electron-builder --<platform> --publish never` for win/mac/linux, then `node scripts/check-installer-size.mjs --dir release`.
- Script enforces TWO checks per artifact:
  1. **Absolute ceiling** from frag-11 §11.5(6): Win `.exe` <=145 MB, mac `.dmg` <=160 MB, `.AppImage` <=140 MB, `.deb`/`.rpm` <=125 MB. HARD fail.
  2. **Delta vs baseline** (`installer/size-baseline.json`): >10% growth fails, >5% warns (via `::warning::` annotation).
- Emits `::error::` / `::warning::` annotations for GitHub Actions.

## Files
- `scripts/check-installer-size.mjs` (203 LOC) — Node ESM script, no deps, no TS (CI fast).
- `installer/size-baseline.json` (14 LOC) — placeholder per-extension byte counts.
- `.github/workflows/installer-size-guard.yml` (85 LOC) — new workflow, `if: false` per v0.3 window.

Total: 302 LOC, 3 new files. No existing files touched (per hot-file avoidance: package.json / electron-builder config / existing workflows untouched).

## Workflow gating
Job is gated `if: false` matching the convention in `ci.yml:22` and `e2e.yml:23`. Will be re-enabled by Task #1048 alongside the rest.

## Baseline values
**Placeholder** — pool-10 has no native toolchain; cannot run `make:win` locally. Values derived conservatively from spec component breakdown (Electron 41 ~95 MB + daemon ~50 MB + SDK ~6 MB + uninstall-helper ~5 MB):
- exe: 130_023_424 (~124 MB)
- dmg: 146_800_640 (~140 MB)
- AppImage: 125_829_120 (~120 MB)
- deb / rpm: 110_100_480 (~105 MB)

These give comfortable headroom under the absolute ceilings so first real builds don't tripwire the delta check on a cold baseline. **First green CI build must replace these via a separate manual-approval PR** (per spec: no auto-commit from CI). Until then, the absolute ceiling is the real guard.

## Local verification
Smoke-tested all four code paths against synthetic files:
- 120 MB exe -> PASS (-3.23% vs baseline)
- 132 MB exe -> PASS with `::warning::` (+6.45%, >5%)
- 140 MB exe -> FAIL with `::error::` (+12.9%, >10%)
- 150 MB exe -> FAIL with `::error::` (>145 MB ceiling)

JSON validates. YAML mirrors structure of `e2e.yml` / `ci.yml`.

## Layer-1 spec check
Spec frag-11 §11.5(6) places the assertion in the `release-publish` job (release-time only). Brief asks for a separate workflow on PRs. I went with brief: a dedicated PR-time workflow gives faster feedback than waiting until tag push, and gating it `if: false` for the v0.3 freeze means zero risk before #1048. The `release-publish` integration is left to a future task if reviewer/manager want both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)