### PR TITLE
feat(dev): T65 daemon --inspect=9230 + VSCode attach config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,3 +14,13 @@ CCSM_ELECTRON_INSPECT=1 npm run dev:app
 ```
 
 Attach Chrome DevTools via `chrome://inspect` or a VS Code launch config (T67 wires a launch.json compound).
+
+## Debugging the daemon process
+
+Set `CCSM_DAEMON_INSPECT=1` when running `npm run dev:daemon` (or `npm run dev`) to spawn the daemon tsx child with `--inspect=9230`. Without the env var, no inspector port is opened.
+
+```sh
+CCSM_DAEMON_INSPECT=1 npm run dev:daemon
+```
+
+Attach via the "Attach to daemon" launch config (or the compound that targets both 9229 + 9230).

--- a/scripts/dev-watch.ts
+++ b/scripts/dev-watch.ts
@@ -25,7 +25,14 @@ function pipe(stream: NodeJS.ReadableStream, sink: NodeJS.WriteStream): void {
 const isWin = process.platform === 'win32';
 const nodemonBin = isWin ? 'nodemon.cmd' : 'nodemon';
 
-const child = spawn(nodemonBin, ['--config', configPath], {
+const nodemonArgs = ['--config', configPath];
+if (process.env.CCSM_DAEMON_INSPECT === '1') {
+  // Override nodemon.daemon.json `exec` to inject --inspect=9230 on the tsx
+  // child process. Env-gated so prod / default dev stays portless.
+  nodemonArgs.push('--exec', 'tsx --inspect=9230 daemon/src/index.ts');
+}
+
+const child = spawn(nodemonBin, nodemonArgs, {
   cwd: repoRoot,
   stdio: ['inherit', 'pipe', 'pipe'],
   env: process.env,


### PR DESCRIPTION
Task #1027. Mirrors T66 (#639) electron-main --inspect=9229 pattern for the daemon child.

## Changes
- `scripts/dev-watch.ts`: when `CCSM_DAEMON_INSPECT=1`, override the nodemon `exec` with `tsx --inspect=9230 daemon/src/index.ts`. Default (env unset) keeps zero inspector port.
- `CONTRIBUTING.md`: documents the env-gate + the existing T67 "Attach to daemon" launch config.
- `.vscode/launch.json`: untouched - T67 (#659) already added the 9230 attach entry + compound.

## Layer 1
Env-gated, off by default. No prod surface change. Same security posture as T66.

## Smoke (manual, to be confirmed by reviewer/dogfood)
1. CCSM_DAEMON_INSPECT=1 npm run dev:daemon
2. VSCode: Run > "Attach to daemon" (port 9230).
3. Set breakpoint in daemon/src/index.ts; verify it hits on next event.

LOC: 18 (+18 -1).