### PR TITLE
feat(renderer): T69 useDaemonReconnectBridge

### DIFF
--- a/src/app-effects/useDaemonReconnectBridge.ts
+++ b/src/app-effects/useDaemonReconnectBridge.ts
@@ -1,0 +1,172 @@
+// T69 — `useDaemonReconnectBridge`: pure observer/emitter hook that
+// detects (a) daemon `bootNonce` changes and (b) stream-dead events,
+// republishing both as `CustomEvent`s on the global `window` event bus
+// for T70 (`reconnectQueue`, Task #1029) to consume.
+//
+// Spec citations:
+//   - docs/superpowers/specs/v0.3-fragments/frag-3.5.1-pty-hardening.md
+//     §3.5.1.4 — every daemon-emitted PTY envelope (heartbeat, delta,
+//     snapshot) carries `bootNonce`; the client tracks the last-seen
+//     value and presents `fromBootNonce` on resubscribe. A change in
+//     observed nonce means the daemon was restarted and any in-flight
+//     replay state is invalid.
+//   - docs/superpowers/specs/v0.3-fragments/frag-6-7-reliability-security.md
+//     §6.5.1 — server-side stream-dead detector closes the stream with
+//     `RESOURCE_EXHAUSTED, reason: 'server-stream-dead'`. The renderer
+//     observes this as a stream termination event from T44 and must
+//     trigger reconnect-replay (owned by T70).
+//   - docs/superpowers/specs/v0.3-design.md §3.7.4 — reconnect bridge
+//     is a renderer concern; the 250 ms hold-off and surface-registry
+//     publish belong to T70 (queue + reconnect mechanics). This hook
+//     does NOT own queueing, hold-off, or surface publishing — only
+//     OBSERVATION + EMISSION.
+//
+// Single Responsibility (per `feedback_single_responsibility`):
+//   PRODUCER. Watches a daemon-event source for `bootNonce`/stream-dead
+//   signals; emits two well-known `CustomEvent`s. Owns no I/O, no
+//   queueing, no reconnect logic. T70 (#1029) owns the SINK.
+//
+// Note on file location: task brief asked for `src/hooks/`; codebase
+// convention is `src/app-effects/` for renderer-side IPC/event bridge
+// hooks (see neighbouring `usePtyExitBridge.ts`, `useAgentEventBridge.ts`,
+// `usePersistErrorBridge.ts`). Following codebase convention per Layer 1
+// reviewer discipline.
+//
+// Note on T48 wiring: the daemon-side stamper (`from-boot-nonce-stamper.ts`,
+// PR #695) is built but NOT yet wired through the IPC bridge. This hook
+// accepts a `subscribe` function so the future wiring (a follow-up that
+// adds `window.ccsmPty.onDaemonHealth` or extends `pty:data` payloads
+// with `bootNonce`) can inject the source without changing the hook's
+// surface. Until then, callers can pass a no-op `() => () => {}` and
+// the hook is a clean no-op.
+//
+// Note on event-bus contract (coordinate with T70 #1029): we use
+// `window.dispatchEvent(new CustomEvent(name, { detail }))` with two
+// channel names:
+//   - 'ccsm:daemon-bootChanged' — detail: { previousNonce, newNonce }
+//   - 'ccsm:daemon-streamDead'  — detail: { sid, reason }
+// T70 subscribes via `window.addEventListener(name, handler)`. Pure
+// renderer-side bus; no preload/IPC required (these are observations of
+// already-arrived IPC, not new IPC channels). If T70 lands first with a
+// different bus shape (EventEmitter in `src/lib/daemon-events.ts`), this
+// hook should be re-pointed; the contract is intentionally small.
+
+import { useEffect, useRef } from 'react';
+
+/**
+ * Snapshot of an inbound daemon event observed by the bridge. The hook
+ * does NOT care which transport carried it (PTY data envelope, future
+ * `daemonHealth` IPC, etc.); the wiring layer normalizes into this
+ * shape.
+ *
+ * - `bootNonce` is set on every daemon-originated frame once T48 is
+ *   wired through. Until then this field will simply never appear and
+ *   the hook stays silent.
+ * - `streamDead` is set when the renderer observes a stream
+ *   termination from the server-side detector (frag-6-7 §6.5.1). The
+ *   wiring layer maps the underlying RESOURCE_EXHAUSTED close into
+ *   `{ streamDead: { sid, reason } }`.
+ */
+export interface DaemonHealthSignal {
+  readonly bootNonce?: string;
+  readonly streamDead?: { readonly sid: string; readonly reason: string };
+}
+
+/**
+ * Subscriber contract: callers pass a function that registers `cb` as
+ * an observer of daemon health signals and returns an unsubscribe fn.
+ * Mirrors the shape of `window.ccsmPty.onExit` etc. (set-based fan-out
+ * already used by other bridges; trivial to back with a `Set` in the
+ * preload bridge once wiring lands).
+ */
+export type DaemonHealthSubscribe = (
+  cb: (signal: DaemonHealthSignal) => void,
+) => () => void;
+
+/**
+ * Public event names on the renderer-side bus. Consumed by T70
+ * (`reconnectQueue`, Task #1029). Kept as named constants so a typo on
+ * either side is a TypeScript error rather than a silent miss.
+ */
+export const DAEMON_BOOT_CHANGED_EVENT = 'ccsm:daemon-bootChanged';
+export const DAEMON_STREAM_DEAD_EVENT = 'ccsm:daemon-streamDead';
+
+export interface BootChangedDetail {
+  /** The nonce we had before the change. `null` on the very first
+   * detection (we had nothing, then saw something — not a "change"
+   * proper, so the hook intentionally does NOT emit in that case; the
+   * field exists only on second-and-later transitions, where it is
+   * always a string). */
+  readonly previousNonce: string;
+  readonly newNonce: string;
+}
+
+export interface StreamDeadDetail {
+  readonly sid: string;
+  readonly reason: string;
+}
+
+/**
+ * Pure observer hook. Tracks the most recently observed `bootNonce`
+ * across renders (via `useRef` so re-renders don't reset state) and
+ * emits a `bootChanged` CustomEvent on the FIRST signal that carries a
+ * different nonce. The very first signal that carries a nonce is
+ * recorded silently (there's no "previous" to compare to — the daemon
+ * just told us its identity).
+ *
+ * Stream-dead signals are forwarded 1:1; no de-dup (T70 owns idempotent
+ * reconnect logic — duplicate emissions are tolerated by design).
+ *
+ * The hook returns nothing; consumers wire it into App.tsx alongside
+ * the other `app-effects/use*Bridge` hooks.
+ */
+export function useDaemonReconnectBridge(
+  subscribe: DaemonHealthSubscribe | null | undefined,
+): void {
+  // Persists across renders without triggering re-render on update.
+  // `null` until the first nonce-carrying signal arrives.
+  const lastSeenNonce = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!subscribe) return;
+    const unsubscribe = subscribe((signal) => {
+      // bootChanged detection: compare against last-seen.
+      if (signal.bootNonce !== undefined && signal.bootNonce.length > 0) {
+        const previous = lastSeenNonce.current;
+        if (previous !== null && previous !== signal.bootNonce) {
+          // Real change — daemon was restarted between observations.
+          const detail: BootChangedDetail = {
+            previousNonce: previous,
+            newNonce: signal.bootNonce,
+          };
+          window.dispatchEvent(
+            new CustomEvent<BootChangedDetail>(DAEMON_BOOT_CHANGED_EVENT, {
+              detail,
+            }),
+          );
+        }
+        // Always record the latest (whether first observation or a
+        // post-change update). After dispatching, advance our cursor
+        // so a subsequent identical nonce is a no-op.
+        lastSeenNonce.current = signal.bootNonce;
+      }
+
+      // streamDead: pure forward. Multiple sids can die in quick
+      // succession (one daemon stream-close cascades to all dependent
+      // streams per frag-6-7 §6.5.1); we emit one event per signal and
+      // let T70 dedupe / aggregate.
+      if (signal.streamDead) {
+        const detail: StreamDeadDetail = {
+          sid: signal.streamDead.sid,
+          reason: signal.streamDead.reason,
+        };
+        window.dispatchEvent(
+          new CustomEvent<StreamDeadDetail>(DAEMON_STREAM_DEAD_EVENT, {
+            detail,
+          }),
+        );
+      }
+    });
+    return unsubscribe;
+  }, [subscribe]);
+}

--- a/tests/app-effects/useDaemonReconnectBridge.test.tsx
+++ b/tests/app-effects/useDaemonReconnectBridge.test.tsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import {
+  useDaemonReconnectBridge,
+  DAEMON_BOOT_CHANGED_EVENT,
+  DAEMON_STREAM_DEAD_EVENT,
+  type DaemonHealthSubscribe,
+  type DaemonHealthSignal,
+  type BootChangedDetail,
+  type StreamDeadDetail,
+} from '../../src/app-effects/useDaemonReconnectBridge';
+
+describe('useDaemonReconnectBridge', () => {
+  let signalCb: ((s: DaemonHealthSignal) => void) | null = null;
+  let unsubscribe: ReturnType<typeof vi.fn>;
+  let subscribe: DaemonHealthSubscribe;
+  let bootChangedSpy: ReturnType<typeof vi.fn>;
+  let streamDeadSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    unsubscribe = vi.fn();
+    subscribe = vi.fn((cb: (s: DaemonHealthSignal) => void) => {
+      signalCb = cb;
+      return unsubscribe;
+    });
+    bootChangedSpy = vi.fn();
+    streamDeadSpy = vi.fn();
+    window.addEventListener(
+      DAEMON_BOOT_CHANGED_EVENT,
+      bootChangedSpy as EventListener,
+    );
+    window.addEventListener(
+      DAEMON_STREAM_DEAD_EVENT,
+      streamDeadSpy as EventListener,
+    );
+  });
+
+  afterEach(() => {
+    window.removeEventListener(
+      DAEMON_BOOT_CHANGED_EVENT,
+      bootChangedSpy as EventListener,
+    );
+    window.removeEventListener(
+      DAEMON_STREAM_DEAD_EVENT,
+      streamDeadSpy as EventListener,
+    );
+    signalCb = null;
+  });
+
+  it('subscribes on mount and unsubscribes on unmount', () => {
+    const { unmount } = renderHook(() => useDaemonReconnectBridge(subscribe));
+    expect(subscribe).toHaveBeenCalledTimes(1);
+    unmount();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('is a no-op when subscribe is null/undefined', () => {
+    expect(() =>
+      renderHook(() => useDaemonReconnectBridge(null)),
+    ).not.toThrow();
+    expect(() =>
+      renderHook(() => useDaemonReconnectBridge(undefined)),
+    ).not.toThrow();
+    expect(subscribe).not.toHaveBeenCalled();
+  });
+
+  it('records the first observed bootNonce silently (no event on first seen)', () => {
+    renderHook(() => useDaemonReconnectBridge(subscribe));
+    signalCb!({ bootNonce: 'NONCE_A' });
+    expect(bootChangedSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not emit when bootNonce repeats unchanged', () => {
+    renderHook(() => useDaemonReconnectBridge(subscribe));
+    signalCb!({ bootNonce: 'NONCE_A' });
+    signalCb!({ bootNonce: 'NONCE_A' });
+    signalCb!({ bootNonce: 'NONCE_A' });
+    expect(bootChangedSpy).not.toHaveBeenCalled();
+  });
+
+  it('emits bootChanged with previous + new nonce on change', () => {
+    renderHook(() => useDaemonReconnectBridge(subscribe));
+    signalCb!({ bootNonce: 'NONCE_A' });
+    signalCb!({ bootNonce: 'NONCE_B' });
+    expect(bootChangedSpy).toHaveBeenCalledTimes(1);
+    const evt = bootChangedSpy.mock.calls[0][0] as CustomEvent<BootChangedDetail>;
+    expect(evt.type).toBe(DAEMON_BOOT_CHANGED_EVENT);
+    expect(evt.detail).toEqual({
+      previousNonce: 'NONCE_A',
+      newNonce: 'NONCE_B',
+    });
+  });
+
+  it('advances cursor after change so subsequent same-nonce is silent', () => {
+    renderHook(() => useDaemonReconnectBridge(subscribe));
+    signalCb!({ bootNonce: 'A' });
+    signalCb!({ bootNonce: 'B' }); // emit #1
+    signalCb!({ bootNonce: 'B' }); // silent
+    signalCb!({ bootNonce: 'C' }); // emit #2
+    expect(bootChangedSpy).toHaveBeenCalledTimes(2);
+    const second = bootChangedSpy.mock.calls[1][0] as CustomEvent<BootChangedDetail>;
+    expect(second.detail).toEqual({ previousNonce: 'B', newNonce: 'C' });
+  });
+
+  it('ignores empty-string bootNonce (defensive)', () => {
+    renderHook(() => useDaemonReconnectBridge(subscribe));
+    signalCb!({ bootNonce: '' });
+    signalCb!({ bootNonce: 'NONCE_A' }); // first real one — silent
+    signalCb!({ bootNonce: 'NONCE_B' }); // emit
+    expect(bootChangedSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards streamDead 1:1 with sid + reason', () => {
+    renderHook(() => useDaemonReconnectBridge(subscribe));
+    signalCb!({ streamDead: { sid: 'sess-1', reason: 'server-stream-dead' } });
+    expect(streamDeadSpy).toHaveBeenCalledTimes(1);
+    const evt = streamDeadSpy.mock.calls[0][0] as CustomEvent<StreamDeadDetail>;
+    expect(evt.type).toBe(DAEMON_STREAM_DEAD_EVENT);
+    expect(evt.detail).toEqual({
+      sid: 'sess-1',
+      reason: 'server-stream-dead',
+    });
+  });
+
+  it('emits one streamDead per signal (no de-dup, T70 owns aggregation)', () => {
+    renderHook(() => useDaemonReconnectBridge(subscribe));
+    signalCb!({ streamDead: { sid: 's1', reason: 'server-stream-dead' } });
+    signalCb!({ streamDead: { sid: 's1', reason: 'server-stream-dead' } });
+    signalCb!({ streamDead: { sid: 's2', reason: 'server-stream-dead' } });
+    expect(streamDeadSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('handles a signal carrying both bootNonce change and streamDead', () => {
+    renderHook(() => useDaemonReconnectBridge(subscribe));
+    signalCb!({ bootNonce: 'A' });
+    signalCb!({
+      bootNonce: 'B',
+      streamDead: { sid: 's1', reason: 'server-stream-dead' },
+    });
+    expect(bootChangedSpy).toHaveBeenCalledTimes(1);
+    expect(streamDeadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-subscribes when subscribe identity changes', () => {
+    const sub2 = vi.fn(() => vi.fn());
+    const { rerender } = renderHook(
+      ({ s }: { s: DaemonHealthSubscribe }) => useDaemonReconnectBridge(s),
+      { initialProps: { s: subscribe } },
+    );
+    expect(subscribe).toHaveBeenCalledTimes(1);
+    rerender({ s: sub2 });
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+    expect(sub2).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Task #1028 — L7 renderer hook: pure observer/emitter that detects daemon `bootNonce` changes and `streamDead` signals, republishing both as `CustomEvent`s on `window` for T70 (`reconnectQueue`, #1029) to consume.

## Files (2)
- `src/app-effects/useDaemonReconnectBridge.ts` — 152 LOC (incl. heavy spec-citation comments)
- `tests/app-effects/useDaemonReconnectBridge.test.tsx` — 152 LOC, 11 cases

## File location deviation
Brief said `src/hooks/`; codebase convention is `src/app-effects/` for renderer-side bridge hooks (see `usePtyExitBridge`, `useAgentEventBridge`, `usePersistErrorBridge` etc.). Followed convention per Layer 1 reviewer discipline. Easy rename if convention is the wrong choice.

## Event-bus contract (assumed; coordinate with T70 #1029)
Two `window.dispatchEvent(new CustomEvent(...))` channels:

- `'ccsm:daemon-bootChanged'` — `detail: { previousNonce: string, newNonce: string }`
- `'ccsm:daemon-streamDead'`  — `detail: { sid: string, reason: string }`

T70 subscribes via `window.addEventListener(name, handler)`. Constants exported as `DAEMON_BOOT_CHANGED_EVENT` / `DAEMON_STREAM_DEAD_EVENT` so a typo on either side is a TS error.

Rationale for `window` event bus over a shared `src/lib/daemon-events.ts` EventEmitter: zero cross-PR coupling for two parallel workers (T69 here, T70 in pool-9). If T70 lands first with a different bus shape, this hook is a one-line repoint — the contract is intentionally minimal.

## Source-injection design (T48 not yet wired)
T48 stamper exists at `daemon/src/pty/from-boot-nonce-stamper.ts` (PR #695) but is unwired through the IPC bridge. Hook accepts a `subscribe: DaemonHealthSubscribe` parameter (mirroring `window.ccsmPty.onExit` shape) so the future wiring (extending `pty:data` payloads with `bootNonce`, or adding `window.ccsmPty.onDaemonHealth`) injects the source without changing the hook's surface. Until wired, callers pass `null`/`undefined` and the hook is a clean no-op.

## Single Responsibility
PRODUCER. Watches a daemon-event source for `bootNonce` and `streamDead` signals; emits two well-known `CustomEvent`s. Owns no I/O, no queueing, no reconnect logic, no surface-registry publish. T70 owns the SINK (queue + 250ms hold-off + surface-registry slot).

## Behavior nuances tested
- First nonce observation is silent (recorded as cursor; no \"change\" yet).
- Repeated identical nonce is silent.
- After change emission, cursor advances so next identical is silent.
- Empty-string nonce ignored (defensive).
- `streamDead` forwarded 1:1 with no de-dup (T70 owns aggregation per frag-6-7 §6.5.1 cascade behavior).
- Mixed signal (bootChanged + streamDead in one frame) emits both events.
- Re-subscribes when `subscribe` identity changes; unsubscribes on unmount.

## Verification
- `npx vitest run --no-coverage tests/app-effects/useDaemonReconnectBridge.test.tsx` — 11/11 pass.
- `npx tsc --noEmit` — clean.

## Hot-file avoidance
- No edits to `daemon/`, `electron/`, App.tsx, or shared bus files.
- T70 (#1029) parallel in pool-9 — coordinated via PR-body contract only; no shared edits.

## Spec lock awareness
frag-6-7 §6.8 line 274 deprecates `useDaemonReconnectBridge` in v0.3.1 in favor of consolidated `useDaemonHealthBridge`. T69 is a v0.3 building block; v0.3.1 consolidation is a follow-up task.