### PR TITLE
feat(renderer): T70 reconnect queue (bootChanged + streamDead)

### DIFF
--- a/src/lib/daemon-events.ts
+++ b/src/lib/daemon-events.ts
@@ -1,0 +1,117 @@
+/**
+ * Renderer-side daemon event bus.
+ *
+ * Producers: T69 useDaemonReconnectBridge (preload) translates main-process
+ * IPC into 'bootChanged' / 'streamDead' / 'reconnected' / 'unreachable'
+ * events. Consumers: T70 reconnect-queue (this file's sibling) and any UI
+ * surface that wants to react to daemon connectivity transitions.
+ *
+ * Pure singleton EventEmitter wrapper — zero socket / IPC awareness, so it
+ * can be unit-tested without a daemon. Producers call `emit`; consumers call
+ * `on` / `off`.
+ *
+ * Coordinates with T69 (#1028). If T69 already lands a daemon-events module,
+ * the manager picks one in conflict resolution; both sides agree on event
+ * names and payload shapes (see types below).
+ */
+
+export type ActiveSubId = string;
+
+/**
+ * Daemon process restarted (new bootNonce). All subscriptions belong to the
+ * old daemon and must be re-established from seq 0 with the new nonce. Emit
+ * source: client receives `{ kind: 'bootChanged', bootNonce }` on any open
+ * stream (frag-3.5.1 §3.5.1.4) OR supervisor crosses heartbeat threshold
+ * (frag-6-7 §6.5).
+ */
+export interface BootChangedEvent {
+  bootNonce: string;
+}
+
+/**
+ * A single per-subscription stream went silent (heartbeat missed, transport
+ * closed, RESOURCE_EXHAUSTED slow-subscriber drop, etc.). The daemon may
+ * still be healthy; only this one subId needs a resubscribe + replay from
+ * lastSeq.
+ */
+export interface StreamDeadEvent {
+  subId: ActiveSubId;
+  /** Last seq the consumer has applied; undefined = subscribe fresh. */
+  lastSeq?: number;
+  /** Optional reason for logs/UI; not load-bearing. */
+  reason?: string;
+}
+
+/**
+ * Bridge call recovered (used by §6.1.1 toast and to clear unreachable
+ * banner). Reconnect-queue does not consume this directly; UI does.
+ */
+export interface ReconnectedEvent {
+  bootNonce: string;
+}
+
+/** Bridge gave up after retries (banner red). */
+export interface UnreachableEvent {
+  reason: string;
+}
+
+export interface DaemonEventMap {
+  bootChanged: BootChangedEvent;
+  streamDead: StreamDeadEvent;
+  reconnected: ReconnectedEvent;
+  unreachable: UnreachableEvent;
+}
+
+export type DaemonEventName = keyof DaemonEventMap;
+export type DaemonEventListener<K extends DaemonEventName> = (
+  payload: DaemonEventMap[K]
+) => void;
+
+/**
+ * Tiny typed pub/sub. We deliberately do NOT use Node's EventEmitter — the
+ * renderer bundle ships to browsers (jsdom in tests, Electron renderer at
+ * runtime) and the polyfill bloat is not worth it for four event types.
+ */
+export class DaemonEventBus {
+  private readonly listeners: {
+    [K in DaemonEventName]: Set<DaemonEventListener<K>>;
+  } = {
+    bootChanged: new Set(),
+    streamDead: new Set(),
+    reconnected: new Set(),
+    unreachable: new Set(),
+  };
+
+  on<K extends DaemonEventName>(event: K, fn: DaemonEventListener<K>): () => void {
+    this.listeners[event].add(fn);
+    return () => this.off(event, fn);
+  }
+
+  off<K extends DaemonEventName>(event: K, fn: DaemonEventListener<K>): void {
+    this.listeners[event].delete(fn);
+  }
+
+  emit<K extends DaemonEventName>(event: K, payload: DaemonEventMap[K]): void {
+    // Snapshot so a listener that unsubscribes mid-fanout doesn't skip a sibling.
+    const snapshot = Array.from(this.listeners[event]);
+    for (const fn of snapshot) {
+      try {
+        fn(payload);
+      } catch (err) {
+        // Bus must never throw across listeners. Surface to console for
+        // dev visibility; the renderer log forwarder (frag-6-7 §6.6.2)
+        // ships these to electron-main when CCSM_RENDERER_LOG_FORWARD=1.
+        // eslint-disable-next-line no-console
+        console.error('[daemon-events] listener threw', event, err);
+      }
+    }
+  }
+
+  /** Test helper — drop all listeners. Not used in production. */
+  removeAll(): void {
+    for (const set of Object.values(this.listeners)) set.clear();
+  }
+}
+
+/** Module-level singleton. Producers and consumers share this instance. */
+export const daemonEventBus = new DaemonEventBus();

--- a/src/lib/reconnect-queue.ts
+++ b/src/lib/reconnect-queue.ts
@@ -1,0 +1,239 @@
+/**
+ * Reconnect queue (renderer, T70).
+ *
+ * Listens to the daemon-events bus and serializes reconnect-replay attempts
+ * for active stream subscriptions:
+ *
+ *   - 'bootChanged'  → enqueue a "full re-subscribe" task per active sub
+ *                      (lastSeq cleared; daemon will replay from seq 0 with
+ *                      new bootNonce, per frag-3.5.1 §3.5.1.4).
+ *   - 'streamDead'   → enqueue a single resubscribe + replay seq>lastSeq
+ *                      task for that subId (frag-6-7 §6.6.1
+ *                      `stream_resubscribe`).
+ *
+ * Concurrency cap: at most N concurrent reconnect attempts (default 3).
+ * Backoff: exponential per task, 200ms → 400ms → 800ms cap 5s. Each task
+ * tracks its own attempt counter; success removes it.
+ *
+ * Pure logic + injected `reconnectFn(subId, lastSeq?)` — no socket I/O here.
+ * The actual bridge call lives in the preload reconnect bridge (T69 hook),
+ * which constructs a queue with its own reconnectFn at boot.
+ */
+
+import {
+  daemonEventBus as defaultBus,
+  type DaemonEventBus,
+  type ActiveSubId,
+} from './daemon-events';
+
+/** Result of a single reconnect attempt. */
+export type ReconnectOutcome = 'ok' | 'retry' | 'fatal';
+
+/**
+ * Caller-supplied bridge call. Resolves 'ok' (or void) on success, 'retry'
+ * to schedule another attempt with backoff, 'fatal' to drop the task. Any
+ * thrown / rejected value is treated as 'retry'.
+ */
+export type ReconnectFn = (
+  subId: ActiveSubId,
+  lastSeq: number | undefined,
+) => Promise<ReconnectOutcome | void>;
+
+export interface ActiveSubscription {
+  subId: ActiveSubId;
+  lastSeq?: number;
+}
+
+export interface ReconnectQueueOptions {
+  concurrency?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  bus?: DaemonEventBus;
+  scheduler?: {
+    setTimeout: (fn: () => void, ms: number) => unknown;
+    clearTimeout: (handle: unknown) => void;
+  };
+}
+
+interface QueuedTask {
+  subId: ActiveSubId;
+  lastSeq: number | undefined;
+  attempt: number;
+  inFlight: boolean;
+}
+
+const DEFAULTS = { concurrency: 3, baseDelayMs: 200, maxDelayMs: 5000 };
+
+/**
+ * attempt 0 → 0; attempt N → base * 2^(N-1), capped at maxDelayMs.
+ * Pulled out as a pure function for unit-test readability.
+ */
+export function computeBackoff(
+  attempt: number,
+  baseDelayMs = DEFAULTS.baseDelayMs,
+  maxDelayMs = DEFAULTS.maxDelayMs,
+): number {
+  if (attempt <= 0) return 0;
+  return Math.min(baseDelayMs * 2 ** (attempt - 1), maxDelayMs);
+}
+
+export class ReconnectQueue {
+  private readonly concurrency: number;
+  private readonly baseDelayMs: number;
+  private readonly maxDelayMs: number;
+  private readonly bus: DaemonEventBus;
+  private readonly scheduler: NonNullable<ReconnectQueueOptions['scheduler']>;
+  private readonly reconnectFn: ReconnectFn;
+
+  private readonly active = new Map<ActiveSubId, ActiveSubscription>();
+  private readonly tasks: QueuedTask[] = [];
+  private readonly pendingTimers = new Set<unknown>();
+  private inFlightCount = 0;
+  private disposed = false;
+  private readonly unsubs: Array<() => void> = [];
+
+  constructor(reconnectFn: ReconnectFn, opts: ReconnectQueueOptions = {}) {
+    this.reconnectFn = reconnectFn;
+    this.concurrency = opts.concurrency ?? DEFAULTS.concurrency;
+    this.baseDelayMs = opts.baseDelayMs ?? DEFAULTS.baseDelayMs;
+    this.maxDelayMs = opts.maxDelayMs ?? DEFAULTS.maxDelayMs;
+    this.bus = opts.bus ?? defaultBus;
+    this.scheduler = opts.scheduler ?? {
+      setTimeout: (fn, ms) => globalThis.setTimeout(fn, ms),
+      clearTimeout: (h) => globalThis.clearTimeout(h as ReturnType<typeof setTimeout>),
+    };
+
+    this.unsubs.push(this.bus.on('bootChanged', () => this.onBootChanged()));
+    this.unsubs.push(
+      this.bus.on('streamDead', (e) => this.onStreamDead(e.subId, e.lastSeq)),
+    );
+  }
+
+  // -- Subscription registry --------------------------------------------
+
+  register(sub: ActiveSubscription): void {
+    this.active.set(sub.subId, { ...sub });
+  }
+  updateLastSeq(subId: ActiveSubId, lastSeq: number): void {
+    const sub = this.active.get(subId);
+    if (sub) sub.lastSeq = lastSeq;
+  }
+  unregister(subId: ActiveSubId): void {
+    this.active.delete(subId);
+  }
+  getActiveCount(): number { return this.active.size; }
+  getQueueDepth(): number { return this.tasks.length; }
+  getInFlightCount(): number { return this.inFlightCount; }
+
+  // -- Event handlers ---------------------------------------------------
+
+  private onBootChanged(): void {
+    if (this.disposed) return;
+    // Clear lastSeq so daemon replays from 0 under the new bootNonce
+    // (frag-3.5.1 §3.5.1.4 bootChanged path).
+    for (const sub of this.active.values()) {
+      this.enqueue({ subId: sub.subId, lastSeq: undefined });
+    }
+    this.pump();
+  }
+
+  private onStreamDead(subId: ActiveSubId, lastSeqFromEvent?: number): void {
+    if (this.disposed) return;
+    // Prefer tracked lastSeq (consumer may be ahead of event payload).
+    const sub = this.active.get(subId);
+    const lastSeq = sub?.lastSeq ?? lastSeqFromEvent;
+    this.enqueue({ subId, lastSeq });
+    this.pump();
+  }
+
+  // -- Queue mechanics --------------------------------------------------
+
+  private enqueue(seed: { subId: ActiveSubId; lastSeq: number | undefined }): void {
+    // Coalesce on subId. If a queued (not-yet-fired) task exists, refresh
+    // its lastSeq so the most recent intent wins. If an in-flight task
+    // exists, leave it alone — it will complete or schedule its own retry.
+    // Either way, no duplicate per subId, so bursts can't pile up.
+    const existing = this.tasks.find((t) => t.subId === seed.subId);
+    if (existing) {
+      if (!existing.inFlight) {
+        existing.lastSeq = seed.lastSeq;
+        existing.attempt = 0;
+      }
+      return;
+    }
+    this.tasks.push({ subId: seed.subId, lastSeq: seed.lastSeq, attempt: 0, inFlight: false });
+  }
+
+  private pump(): void {
+    if (this.disposed) return;
+    while (this.inFlightCount < this.concurrency) {
+      const task = this.tasks.find((t) => !t.inFlight);
+      if (!task) return;
+      task.inFlight = true;
+      this.inFlightCount++;
+      this.runWithDelay(task);
+    }
+  }
+
+  private runWithDelay(task: QueuedTask): void {
+    const delay = computeBackoff(task.attempt, this.baseDelayMs, this.maxDelayMs);
+    const fire = () => this.fire(task);
+    if (delay <= 0) {
+      // Yield a microtask so consumers always see async behavior, even on
+      // attempt 0 from inside an event handler.
+      Promise.resolve().then(fire);
+    } else {
+      const handle = this.scheduler.setTimeout(() => {
+        this.pendingTimers.delete(handle);
+        fire();
+      }, delay);
+      this.pendingTimers.add(handle);
+    }
+  }
+
+  private fire(task: QueuedTask): void {
+    if (this.disposed) {
+      this.finish(task);
+      return;
+    }
+    Promise.resolve()
+      .then(() => this.reconnectFn(task.subId, task.lastSeq))
+      .then(
+        (outcome) => {
+          if (outcome === 'fatal' || outcome === 'ok' || outcome === undefined) {
+            this.finish(task);
+          } else {
+            // 'retry': bump attempt, re-arm with backoff. Slot stays held.
+            task.attempt++;
+            this.runWithDelay(task);
+          }
+        },
+        () => {
+          // Thrown / rejected = retry.
+          task.attempt++;
+          this.runWithDelay(task);
+        },
+      );
+  }
+
+  private finish(task: QueuedTask): void {
+    const idx = this.tasks.indexOf(task);
+    if (idx >= 0) this.tasks.splice(idx, 1);
+    this.inFlightCount = Math.max(0, this.inFlightCount - 1);
+    if (!this.disposed) this.pump();
+  }
+
+  // -- Lifecycle --------------------------------------------------------
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    for (const u of this.unsubs) u();
+    this.unsubs.length = 0;
+    for (const h of this.pendingTimers) this.scheduler.clearTimeout(h);
+    this.pendingTimers.clear();
+    this.tasks.length = 0;
+    this.active.clear();
+    this.inFlightCount = 0;
+  }
+}

--- a/tests/reconnect-queue.test.ts
+++ b/tests/reconnect-queue.test.ts
@@ -1,0 +1,323 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  computeBackoff,
+  ReconnectQueue,
+  type ReconnectFn,
+} from '../src/lib/reconnect-queue';
+import { DaemonEventBus } from '../src/lib/daemon-events';
+
+describe('computeBackoff', () => {
+  it('attempt 0 = no delay (immediate first try)', () => {
+    expect(computeBackoff(0)).toBe(0);
+  });
+  it('attempt 1 = base 200ms', () => {
+    expect(computeBackoff(1)).toBe(200);
+  });
+  it('attempt 2 = 400ms', () => {
+    expect(computeBackoff(2)).toBe(400);
+  });
+  it('attempt 3 = 800ms', () => {
+    expect(computeBackoff(3)).toBe(800);
+  });
+  it('caps at maxDelayMs (5000) on high attempts', () => {
+    expect(computeBackoff(10)).toBe(5000);
+    expect(computeBackoff(20)).toBe(5000);
+  });
+  it('honors custom base + cap', () => {
+    expect(computeBackoff(1, 100, 1000)).toBe(100);
+    expect(computeBackoff(5, 100, 1000)).toBe(1000);
+  });
+});
+
+describe('ReconnectQueue', () => {
+  let bus: DaemonEventBus;
+  let queue: ReconnectQueue | undefined;
+  let calls: Array<{ subId: string; lastSeq: number | undefined }>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    bus = new DaemonEventBus();
+    calls = [];
+  });
+
+  afterEach(() => {
+    queue?.dispose();
+    queue = undefined;
+    vi.useRealTimers();
+  });
+
+  function makeQueue(fn: ReconnectFn, concurrency = 3): ReconnectQueue {
+    queue = new ReconnectQueue(fn, {
+      bus,
+      concurrency,
+      baseDelayMs: 200,
+      maxDelayMs: 5000,
+    });
+    return queue;
+  }
+
+  /** Drain microtasks + advance fake timers so awaiting code progresses. */
+  async function flush(ms = 0): Promise<void> {
+    if (ms > 0) vi.advanceTimersByTime(ms);
+    // Multiple rounds because the queue chains promises through scheduleRetry.
+    for (let i = 0; i < 10; i++) {
+      await Promise.resolve();
+    }
+  }
+
+  it('streamDead enqueues exactly 1 reconnect for that subId', async () => {
+    const fn: ReconnectFn = async (subId, lastSeq) => {
+      calls.push({ subId, lastSeq });
+      return 'ok';
+    };
+    const q = makeQueue(fn);
+    q.register({ subId: 's1', lastSeq: 42 });
+    q.register({ subId: 's2', lastSeq: 7 });
+
+    bus.emit('streamDead', { subId: 's1' });
+    await flush();
+
+    expect(calls).toEqual([{ subId: 's1', lastSeq: 42 }]);
+    expect(q.getQueueDepth()).toBe(0);
+  });
+
+  it('streamDead falls back to event lastSeq when sub not registered', async () => {
+    const fn: ReconnectFn = async (subId, lastSeq) => {
+      calls.push({ subId, lastSeq });
+      return 'ok';
+    };
+    const q = makeQueue(fn);
+    bus.emit('streamDead', { subId: 'orphan', lastSeq: 99 });
+    await flush();
+    expect(calls).toEqual([{ subId: 'orphan', lastSeq: 99 }]);
+  });
+
+  it('bootChanged enqueues N tasks (one per active subscription)', async () => {
+    const fn: ReconnectFn = async (subId, lastSeq) => {
+      calls.push({ subId, lastSeq });
+      return 'ok';
+    };
+    const q = makeQueue(fn);
+    q.register({ subId: 'a', lastSeq: 1 });
+    q.register({ subId: 'b', lastSeq: 2 });
+    q.register({ subId: 'c', lastSeq: 3 });
+
+    bus.emit('bootChanged', { bootNonce: 'nonce-2' });
+    await flush();
+
+    // bootChanged clears lastSeq → all undefined (daemon replays from 0).
+    expect(calls).toHaveLength(3);
+    expect(calls.map((c) => c.subId).sort()).toEqual(['a', 'b', 'c']);
+    for (const c of calls) expect(c.lastSeq).toBeUndefined();
+  });
+
+  it('respects concurrency cap (N=3) when 5 subs are active on bootChanged', async () => {
+    let inFlight = 0;
+    let peakInFlight = 0;
+    const release: Array<() => void> = [];
+
+    const fn: ReconnectFn = (subId) => {
+      inFlight++;
+      peakInFlight = Math.max(peakInFlight, inFlight);
+      calls.push({ subId, lastSeq: undefined });
+      return new Promise<'ok'>((resolve) => {
+        release.push(() => {
+          inFlight--;
+          resolve('ok');
+        });
+      });
+    };
+    const q = makeQueue(fn, 3);
+    for (const id of ['a', 'b', 'c', 'd', 'e']) {
+      q.register({ subId: id, lastSeq: 0 });
+    }
+
+    bus.emit('bootChanged', { bootNonce: 'x' });
+    await flush();
+
+    expect(calls).toHaveLength(3);
+    expect(peakInFlight).toBe(3);
+    expect(q.getInFlightCount()).toBe(3);
+
+    // Release one slot; another should pick up.
+    release.shift()!();
+    await flush();
+    expect(calls).toHaveLength(4);
+
+    // Release the rest.
+    while (release.length) release.shift()!();
+    await flush();
+    expect(calls).toHaveLength(5);
+    expect(peakInFlight).toBe(3);
+  });
+
+  it('exponential backoff schedule: 200 → 400 → 800 on consecutive failures', async () => {
+    const timestamps: number[] = [];
+    let start = 0;
+    const fn: ReconnectFn = async (subId) => {
+      timestamps.push(Date.now() - start);
+      calls.push({ subId, lastSeq: undefined });
+      if (calls.length < 4) throw new Error('boom');
+      return 'ok';
+    };
+    const q = makeQueue(fn, 1);
+    q.register({ subId: 's1', lastSeq: 0 });
+
+    start = Date.now();
+    bus.emit('streamDead', { subId: 's1' });
+
+    // Attempt 1: immediate (microtask).
+    await flush();
+    expect(calls).toHaveLength(1);
+
+    // Attempt 2: after 200ms.
+    await flush(200);
+    expect(calls).toHaveLength(2);
+
+    // Attempt 3: after 400ms more.
+    await flush(400);
+    expect(calls).toHaveLength(3);
+
+    // Attempt 4 (success): after 800ms more.
+    await flush(800);
+    expect(calls).toHaveLength(4);
+
+    // Verify the recorded delays line up with the expected schedule
+    // (allowing tiny microtask slop).
+    expect(timestamps[0]).toBe(0);
+    expect(timestamps[1]).toBe(200);
+    expect(timestamps[2]).toBe(600);
+    expect(timestamps[3]).toBe(1400);
+
+    expect(q.getQueueDepth()).toBe(0);
+  });
+
+  it('backoff caps at maxDelayMs (5000) after enough failures', async () => {
+    let attempt = 0;
+    const fn: ReconnectFn = async () => {
+      attempt++;
+      // Always fail to force the cap.
+      throw new Error('still down');
+    };
+    const q = makeQueue(fn, 1);
+    q.register({ subId: 's1', lastSeq: 0 });
+    bus.emit('streamDead', { subId: 's1' });
+
+    await flush(); // attempt 1 immediate
+    expect(attempt).toBe(1);
+    await flush(200); // attempt 2
+    await flush(400); // attempt 3
+    await flush(800); // attempt 4
+    await flush(1600); // attempt 5
+    await flush(3200); // attempt 6
+    expect(attempt).toBe(6);
+
+    // Next delay should be capped at 5000, not 6400.
+    await flush(4999);
+    expect(attempt).toBe(6);
+    await flush(1);
+    expect(attempt).toBe(7);
+  });
+
+  it("'fatal' outcome aborts the task without retry", async () => {
+    let n = 0;
+    const fn: ReconnectFn = async () => {
+      n++;
+      return 'fatal';
+    };
+    const q = makeQueue(fn, 1);
+    q.register({ subId: 's1', lastSeq: 0 });
+    bus.emit('streamDead', { subId: 's1' });
+    await flush(10000);
+    expect(n).toBe(1);
+    expect(q.getQueueDepth()).toBe(0);
+  });
+
+  it('coalesces duplicate streamDead bursts for the same subId', async () => {
+    let resolveCall: (() => void) | undefined;
+    const fn: ReconnectFn = (subId) => {
+      calls.push({ subId, lastSeq: undefined });
+      return new Promise<'ok'>((r) => {
+        resolveCall = () => r('ok');
+      });
+    };
+    const q = makeQueue(fn, 3);
+    q.register({ subId: 's1', lastSeq: 0 });
+
+    // Three bursts before the first attempt completes.
+    bus.emit('streamDead', { subId: 's1' });
+    bus.emit('streamDead', { subId: 's1' });
+    bus.emit('streamDead', { subId: 's1' });
+    await flush();
+
+    // Only one call in flight; the 2nd/3rd bursts coalesced because the
+    // first task is in-flight (no queued duplicate).
+    expect(calls).toHaveLength(1);
+
+    resolveCall!();
+    await flush();
+    expect(calls).toHaveLength(1);
+  });
+
+  it('uses tracked lastSeq from updateLastSeq, not stale registration value', async () => {
+    const fn: ReconnectFn = async (subId, lastSeq) => {
+      calls.push({ subId, lastSeq });
+      return 'ok';
+    };
+    const q = makeQueue(fn);
+    q.register({ subId: 's1', lastSeq: 10 });
+    q.updateLastSeq('s1', 55);
+    bus.emit('streamDead', { subId: 's1' });
+    await flush();
+    expect(calls).toEqual([{ subId: 's1', lastSeq: 55 }]);
+  });
+
+  it('dispose() unsubscribes from bus and ignores subsequent events', async () => {
+    const fn: ReconnectFn = async (subId) => {
+      calls.push({ subId, lastSeq: undefined });
+      return 'ok';
+    };
+    const q = makeQueue(fn);
+    q.register({ subId: 's1', lastSeq: 0 });
+    q.dispose();
+    queue = undefined; // prevent afterEach double-dispose
+    bus.emit('streamDead', { subId: 's1' });
+    bus.emit('bootChanged', { bootNonce: 'x' });
+    await flush(10000);
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe('DaemonEventBus', () => {
+  it('delivers events to all subscribed listeners', () => {
+    const bus = new DaemonEventBus();
+    const seen: string[] = [];
+    bus.on('bootChanged', (e) => seen.push(`a:${e.bootNonce}`));
+    bus.on('bootChanged', (e) => seen.push(`b:${e.bootNonce}`));
+    bus.emit('bootChanged', { bootNonce: 'n1' });
+    expect(seen).toEqual(['a:n1', 'b:n1']);
+  });
+
+  it('off() / returned unsub stops delivery', () => {
+    const bus = new DaemonEventBus();
+    let count = 0;
+    const unsub = bus.on('streamDead', () => count++);
+    bus.emit('streamDead', { subId: 's' });
+    unsub();
+    bus.emit('streamDead', { subId: 's' });
+    expect(count).toBe(1);
+  });
+
+  it('listener throw does not break sibling listeners', () => {
+    const bus = new DaemonEventBus();
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    let sib = 0;
+    bus.on('reconnected', () => {
+      throw new Error('bad listener');
+    });
+    bus.on('reconnected', () => sib++);
+    bus.emit('reconnected', { bootNonce: 'n' });
+    expect(sib).toBe(1);
+    errSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Task #1029. L7 reconnectQueue (renderer).

## Summary

- `src/lib/daemon-events.ts` (117 LOC): tiny typed pub/sub for daemon events. Producers (T69 useDaemonReconnectBridge, preload) call `emit`; consumers (this queue + UI surfaces) call `on`/`off`. No EventEmitter polyfill — renderer-only, four event types.
- `src/lib/reconnect-queue.ts` (239 LOC): pure logic + injected `reconnectFn(subId, lastSeq?)`.
  - `bootChanged` → enqueues a full re-subscribe per active sub, `lastSeq` cleared (daemon replays from seq 0 with new bootNonce — frag-3.5.1 §3.5.1.4).
  - `streamDead` → enqueues 1 task for that subId, prefers tracked `lastSeq` over event payload.
  - Concurrency cap N=3 (default, configurable).
  - Backoff: 200 → 400 → 800 → 1600 → 3200 → cap 5000 ms (`computeBackoff` exported as a pure helper for unit-test readability).
  - Coalesces per-subId so bursts don't pile up duplicate tasks.
  - `'fatal'` outcome aborts task; `'retry'` or thrown rejection schedules backoff; `'ok'` / void = success.
- `tests/reconnect-queue.test.ts` (323 LOC, 19 tests, all passing): fake timers, mock `reconnectFn`. Covers backoff schedule, concurrency cap (5 active subs vs N=3 → peak in-flight = 3), `bootChanged` fan-out, `streamDead` single enqueue, fallback to event lastSeq, coalescing, `'fatal'` outcome, `updateLastSeq` use, dispose, and bus listener isolation.

## Event-bus contract (coordinates with T69 #1028)

Both sides agree on this shape (from `src/lib/daemon-events.ts`):

- `bootChanged: { bootNonce: string }` — daemon respawn, fan out full resubscribe.
- `streamDead: { subId: string; lastSeq?: number; reason?: string }` — single stream went silent.
- `reconnected: { bootNonce: string }` — recovery (consumed by UI toast, not the queue).
- `unreachable: { reason: string }` — bridge gave up (consumed by UI banner, not the queue).

If T69's PR also creates `daemon-events.ts`, manager picks one in conflict resolution; the contract is the same.

## Layer 1

Spec frag-6-7 §6.6.1 lists the canonical reconnect log keys (`daemon_reconnect_attempt`, `stream_resubscribe`) on the **bridge** side (preload / electron-main). This task ships the **renderer** queue that drives those bridge calls — pure, transport-agnostic, injectable. The actual logging happens in T69's bridge hook when it calls `reconnectFn` from inside this queue. Renderer-side scheduling is correct here because the renderer is the one tracking active subscriptions; main-process can't enumerate them without crossing the bridge.

## Verify

- `npx vitest run --no-coverage tests/reconnect-queue.test.ts` → 19/19 pass.
- `npx tsc --noEmit` → clean.

## Files

- src/lib/daemon-events.ts (new, 117 LOC)
- src/lib/reconnect-queue.ts (new, 239 LOC)
- tests/reconnect-queue.test.ts (new, 323 LOC, 19 tests)