### PR TITLE
feat(dev): T72 double-bind guard (nodemon ready-check)

### DIFF
--- a/scripts/dev-watch.ts
+++ b/scripts/dev-watch.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
+import { shouldSpawnDaemon } from './double-bind-guard.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
@@ -22,40 +23,60 @@ function pipe(stream: NodeJS.ReadableStream, sink: NodeJS.WriteStream): void {
   });
 }
 
-const isWin = process.platform === 'win32';
-const nodemonBin = isWin ? 'nodemon.cmd' : 'nodemon';
+function startNodemon(): void {
+  const isWin = process.platform === 'win32';
+  const nodemonBin = isWin ? 'nodemon.cmd' : 'nodemon';
 
-const nodemonArgs = ['--config', configPath];
-if (process.env.CCSM_DAEMON_INSPECT === '1') {
-  // Override nodemon.daemon.json `exec` to inject --inspect=9230 on the tsx
-  // child process. Env-gated so prod / default dev stays portless.
-  nodemonArgs.push('--exec', 'tsx --inspect=9230 daemon/src/index.ts');
+  const nodemonArgs = ['--config', configPath];
+  if (process.env.CCSM_DAEMON_INSPECT === '1') {
+    // Override nodemon.daemon.json `exec` to inject --inspect=9230 on the tsx
+    // child process. Env-gated so prod / default dev stays portless.
+    nodemonArgs.push('--exec', 'tsx --inspect=9230 daemon/src/index.ts');
+  }
+
+  const child = spawn(nodemonBin, nodemonArgs, {
+    cwd: repoRoot,
+    stdio: ['inherit', 'pipe', 'pipe'],
+    env: process.env,
+    shell: isWin,
+  });
+
+  if (child.stdout) pipe(child.stdout, process.stdout);
+  if (child.stderr) pipe(child.stderr, process.stderr);
+
+  const forward = (signal: NodeJS.Signals): void => {
+    if (!child.killed) child.kill(signal);
+  };
+
+  process.on('SIGINT', () => forward('SIGINT'));
+  process.on('SIGTERM', () => forward('SIGTERM'));
+  process.on('SIGHUP', () => forward('SIGHUP'));
+
+  child.on('exit', (code, signal) => {
+    process.stdout.write(`${PREFIX}nodemon exited (code=${code ?? 'null'}, signal=${signal ?? 'null'})\n`);
+    process.exit(code ?? (signal ? 1 : 0));
+  });
+
+  child.on('error', (err) => {
+    process.stderr.write(`${PREFIX}failed to spawn nodemon: ${err.message}\n`);
+    process.exit(1);
+  });
 }
 
-const child = spawn(nodemonBin, nodemonArgs, {
-  cwd: repoRoot,
-  stdio: ['inherit', 'pipe', 'pipe'],
-  env: process.env,
-  shell: isWin,
-});
-
-if (child.stdout) pipe(child.stdout, process.stdout);
-if (child.stderr) pipe(child.stderr, process.stderr);
-
-const forward = (signal: NodeJS.Signals): void => {
-  if (!child.killed) child.kill(signal);
-};
-
-process.on('SIGINT', () => forward('SIGINT'));
-process.on('SIGTERM', () => forward('SIGTERM'));
-process.on('SIGHUP', () => forward('SIGHUP'));
-
-child.on('exit', (code, signal) => {
-  process.stdout.write(`${PREFIX}nodemon exited (code=${code ?? 'null'}, signal=${signal ?? 'null'})\n`);
-  process.exit(code ?? (signal ? 1 : 0));
-});
-
-child.on('error', (err) => {
-  process.stderr.write(`${PREFIX}failed to spawn nodemon: ${err.message}\n`);
-  process.exit(1);
-});
+// T72 — pre-spawn double-bind guard. nodemon double-fires on rapid file
+// saves; if a previous daemon is still bound to the control socket, the new
+// node child trips EADDRINUSE. Probe first, exit cleanly if a daemon is
+// already alive (the operator can re-trigger by saving again, and nodemon
+// will pick up after the previous process releases the bind).
+shouldSpawnDaemon().then(
+  (proceed) => {
+    if (!proceed) {
+      process.exit(0);
+    }
+    startNodemon();
+  },
+  (err: Error) => {
+    process.stderr.write(`${PREFIX}double-bind-guard failed: ${err.message}; spawning anyway\n`);
+    startNodemon();
+  },
+);

--- a/scripts/double-bind-guard.ts
+++ b/scripts/double-bind-guard.ts
@@ -1,0 +1,195 @@
+// T72 — dev nodemon double-bind guard.
+//
+// Spec citations:
+//   - docs/superpowers/specs/v0.3-fragments/frag-3.7-dev-workflow.md §3.7.6.a
+//     ("Supervisor restart loop disabled in dev; transport + healthz polling
+//     stay"): in `CCSM_DAEMON_DEV=1`, nodemon is the de-facto supervisor.
+//     But nodemon double-fires on rapid file saves — if a previous daemon is
+//     still bound to the control socket, the new node process trips
+//     EADDRINUSE and the dev shell shows a confusing crash. This guard
+//     catches that race BEFORE nodemon spawns: probe the control socket
+//     first, exit cleanly with "skip" if a daemon is already bound.
+//   - docs/superpowers/specs/v0.3-design.md §3.1.1 — control-socket path:
+//       POSIX:   `<runtimeRoot>/ccsm-control.sock`
+//       Windows: `\\.\pipe\ccsm-control-<userhash>` (sha256 of
+//                `username@hostname`, 8-hex truncated)
+//
+// Probe strategy (connect-only, NOT full daemon.hello HMAC):
+//   - Attempt `net.connect(controlSocketPath)` with a short timeout.
+//   - SUCCESS → daemon already bound → exit 0, "skip spawn".
+//   - ECONNREFUSED / ENOENT (POSIX), `EPIPE` / "connect ENOENT" (Win) →
+//     no daemon → caller proceeds with spawn.
+//   - Connect returns but no data within timeout → treat as zombie:
+//     log warning, still proceed with spawn (nodemon's own error surface
+//     will catch any actual bind conflict).
+//
+//   Full daemon.hello HMAC envelope was considered and rejected: it would
+//   require importing the daemon secret + envelope codec into a dev script
+//   that must stay zero-dep (mirrors T64 wait-daemon's reasoning). Connect
+//   success on the OS-native socket node is sufficient evidence that
+//   *something* owns the bind slot; if it's a zombie, the operator restarts
+//   nodemon manually after killing it (rare; logged loudly).
+//
+// Drift guard: the control-socket path computation is a byte-for-byte mirror
+// of `daemon/src/sockets/control-socket.ts::defaultControlSocketPath` +
+// `daemon/src/sockets/runtime-root.ts::resolveRuntimeRoot`. We do NOT import
+// from daemon/ to keep the dev script zero-dep and runnable from a fresh
+// clone. A unit test pins both byte-for-byte across the matrix.
+//
+// Single Responsibility: PURE DECIDER. Inputs: env + platform + a connect
+// probe. Output: ProbeResult discriminated union. Caller (dev-watch.ts)
+// owns the sink (process.exit / spawn).
+
+import { connect, type Socket } from 'node:net';
+import { homedir, hostname, userInfo } from 'node:os';
+import { createHash } from 'node:crypto';
+import { join, posix, win32 } from 'node:path';
+
+export type ProbeOutcome =
+  | { kind: 'alive'; socketPath: string }
+  | { kind: 'absent'; socketPath: string; reason: string }
+  | { kind: 'zombie'; socketPath: string; reason: string };
+
+export interface ProbeOptions {
+  /** Override for tests; defaults to current process platform. */
+  platform?: NodeJS.Platform;
+  /** Override for tests; defaults to current process env. */
+  env?: NodeJS.ProcessEnv;
+  /** Connect timeout, ms. Defaults to 500 (matches brief). */
+  timeoutMs?: number;
+  /** Test seam: a custom connector returning a Socket-like object. */
+  connector?: (socketPath: string) => Socket;
+}
+
+/** Platform-aware path joiner so a Windows-host test forcing
+ *  `platform: 'linux'` still yields a POSIX-shaped path (mirrors daemon
+ *  control-socket.ts: it uses `posix.join` for the POSIX branch). */
+function joinFor(platform: NodeJS.Platform, ...parts: string[]): string {
+  return platform === 'win32' ? win32.join(...parts) : posix.join(...parts);
+}
+
+/** Mirror of daemon/src/sockets/runtime-root.ts (drift-guarded). */
+export function resolveDataRoot(
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+): string {
+  if (platform === 'win32') {
+    const local = env.LOCALAPPDATA;
+    if (local && local.length > 0) return win32.join(local, 'ccsm');
+    return win32.join(homedir(), 'AppData', 'Local', 'ccsm');
+  }
+  if (platform === 'darwin') {
+    return joinFor(platform, homedir(), 'Library', 'Application Support', 'ccsm');
+  }
+  const xdgData = env.XDG_DATA_HOME;
+  if (xdgData && xdgData.length > 0) return joinFor(platform, xdgData, 'ccsm');
+  return joinFor(platform, homedir(), '.local', 'share', 'ccsm');
+}
+
+/** Mirror of daemon/src/sockets/runtime-root.ts (drift-guarded). */
+export function resolveRuntimeRoot(
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+): string {
+  if (platform === 'linux') {
+    const xdgRuntime = env.XDG_RUNTIME_DIR;
+    if (xdgRuntime && xdgRuntime.length > 0) return joinFor(platform, xdgRuntime, 'ccsm');
+  }
+  return joinFor(platform, resolveDataRoot(platform, env), 'run');
+}
+
+/** Mirror of daemon/src/sockets/control-socket.ts::defaultControlSocketPath. */
+export function resolveControlSocketPath(
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+): string {
+  if (platform === 'win32') {
+    const ui = userInfo();
+    const tag = `${ui.username}@${hostname()}`;
+    const userhash = createHash('sha256').update(tag).digest('hex').slice(0, 8);
+    return `\\\\.\\pipe\\ccsm-control-${userhash}`;
+  }
+  return posix.join(resolveRuntimeRoot(platform, env), 'ccsm-control.sock');
+}
+
+/**
+ * Probe the control socket. Resolves on outcome; never rejects (all errors
+ * map to `absent` or `zombie`).
+ */
+export function probeControlSocket(opts: ProbeOptions = {}): Promise<ProbeOutcome> {
+  const platform = opts.platform ?? process.platform;
+  const env = opts.env ?? process.env;
+  const timeoutMs = opts.timeoutMs ?? 500;
+  const socketPath = resolveControlSocketPath(platform, env);
+
+  return new Promise<ProbeOutcome>((resolve) => {
+    const sock = opts.connector
+      ? opts.connector(socketPath)
+      : connect(socketPath);
+
+    let settled = false;
+    const finish = (outcome: ProbeOutcome): void => {
+      if (settled) return;
+      settled = true;
+      try {
+        sock.destroy();
+      } catch {
+        /* ignore */
+      }
+      resolve(outcome);
+    };
+
+    const timer = setTimeout(() => {
+      finish({
+        kind: 'zombie',
+        socketPath,
+        reason: `no connect verdict within ${timeoutMs}ms`,
+      });
+    }, timeoutMs);
+    timer.unref?.();
+
+    sock.once('connect', () => {
+      clearTimeout(timer);
+      finish({ kind: 'alive', socketPath });
+    });
+    sock.once('error', (err: NodeJS.ErrnoException) => {
+      clearTimeout(timer);
+      finish({
+        kind: 'absent',
+        socketPath,
+        reason: err.code ?? err.message ?? 'unknown',
+      });
+    });
+  });
+}
+
+/**
+ * Top-level guard: probe and decide. Returns `true` if the caller should
+ * proceed to spawn nodemon, `false` if it should exit cleanly.
+ *
+ * Side effect: prints a single tagged log line to stderr describing the
+ * decision. Does NOT call process.exit — the caller owns that sink.
+ */
+export async function shouldSpawnDaemon(
+  opts: ProbeOptions = {},
+): Promise<boolean> {
+  const outcome = await probeControlSocket(opts);
+  const tag = '[daemon-guard]';
+  switch (outcome.kind) {
+    case 'alive':
+      process.stderr.write(
+        `${tag} daemon already bound at ${outcome.socketPath}, skipping spawn\n`,
+      );
+      return false;
+    case 'absent':
+      process.stderr.write(
+        `${tag} no daemon at ${outcome.socketPath} (${outcome.reason}), spawning\n`,
+      );
+      return true;
+    case 'zombie':
+      process.stderr.write(
+        `${tag} WARN: control socket at ${outcome.socketPath} appears wedged (${outcome.reason}); spawning anyway, nodemon will surface any bind conflict\n`,
+      );
+      return true;
+  }
+}

--- a/tests/double-bind-guard.test.ts
+++ b/tests/double-bind-guard.test.ts
@@ -1,0 +1,300 @@
+// T72 — double-bind guard tests.
+//
+// Coverage matrix:
+//   - resolveControlSocketPath: drift guard against
+//     daemon/src/sockets/control-socket.ts + runtime-root.ts
+//     (same posture as tests/wait-daemon.test.ts §drift-guard).
+//   - probeControlSocket: outcome variants (alive / absent / zombie) using
+//     a fake connector — no real socket bind, deterministic.
+//   - shouldSpawnDaemon: end-to-end decision wrapper, stderr capture.
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { hostname, userInfo } from 'node:os';
+import { createHash } from 'node:crypto';
+import {
+  probeControlSocket,
+  resolveControlSocketPath,
+  resolveDataRoot,
+  resolveRuntimeRoot,
+  shouldSpawnDaemon,
+} from '../scripts/double-bind-guard.js';
+
+// ---------------------------------------------------------------------------
+// Fake socket: minimal `net.Socket` stand-in for `connect`/`error` events.
+// ---------------------------------------------------------------------------
+class FakeSocket extends EventEmitter {
+  destroyed = false;
+  destroy(): void {
+    this.destroyed = true;
+  }
+  emitConnectAsync(): void {
+    setImmediate(() => this.emit('connect'));
+  }
+  emitErrorAsync(code: string, message = code): void {
+    setImmediate(() => {
+      const err = new Error(message) as NodeJS.ErrnoException;
+      err.code = code;
+      this.emit('error', err);
+    });
+  }
+  emitNothing(): void {
+    /* simulate wedged listener: never resolves */
+  }
+}
+
+// ---------------------------------------------------------------------------
+// resolveControlSocketPath drift guards.
+// ---------------------------------------------------------------------------
+describe('resolveDataRoot', () => {
+  it('Linux: prefers XDG_DATA_HOME', () => {
+    expect(
+      resolveDataRoot('linux', { XDG_DATA_HOME: '/xdg/data' }),
+    ).toBe('/xdg/data/ccsm');
+  });
+  it('Linux: falls back to ~/.local/share/ccsm', () => {
+    const r = resolveDataRoot('linux', {});
+    expect(r.endsWith('.local/share/ccsm') || r.endsWith('.local\\share\\ccsm')).toBe(true);
+  });
+  it('Windows: prefers LOCALAPPDATA', () => {
+    expect(
+      resolveDataRoot('win32', { LOCALAPPDATA: 'C:\\Users\\u\\AppData\\Local' }),
+    ).toBe('C:\\Users\\u\\AppData\\Local\\ccsm');
+  });
+  it('Windows: falls back to homedir AppData/Local/ccsm when LOCALAPPDATA missing', () => {
+    const r = resolveDataRoot('win32', {});
+    expect(r).toMatch(/AppData[\\/]Local[\\/]ccsm$/);
+  });
+  it('macOS: returns ~/Library/Application Support/ccsm', () => {
+    const r = resolveDataRoot('darwin', {});
+    expect(r).toMatch(/Library[\\/]Application Support[\\/]ccsm$/);
+  });
+});
+
+describe('resolveRuntimeRoot', () => {
+  it('Linux: uses XDG_RUNTIME_DIR if set', () => {
+    expect(
+      resolveRuntimeRoot('linux', {
+        XDG_RUNTIME_DIR: '/run/user/1000',
+        XDG_DATA_HOME: '/xdg/data',
+      }),
+    ).toBe('/run/user/1000/ccsm');
+  });
+  it('Linux: falls back to <dataRoot>/run', () => {
+    expect(
+      resolveRuntimeRoot('linux', { XDG_DATA_HOME: '/xdg/data' }),
+    ).toBe('/xdg/data/ccsm/run');
+  });
+  it('macOS: <dataRoot>/run', () => {
+    const r = resolveRuntimeRoot('darwin', {});
+    expect(r).toMatch(/Library[\\/]Application Support[\\/]ccsm[\\/]run$/);
+  });
+  it('Windows: <dataRoot>\\run', () => {
+    expect(
+      resolveRuntimeRoot('win32', {
+        LOCALAPPDATA: 'C:\\Users\\u\\AppData\\Local',
+      }),
+    ).toBe('C:\\Users\\u\\AppData\\Local\\ccsm\\run');
+  });
+});
+
+describe('resolveControlSocketPath', () => {
+  it('POSIX: <runtimeRoot>/ccsm-control.sock', () => {
+    expect(
+      resolveControlSocketPath('linux', {
+        XDG_RUNTIME_DIR: '/run/user/1000',
+      }),
+    ).toBe('/run/user/1000/ccsm/ccsm-control.sock');
+  });
+  it('Windows: \\\\.\\pipe\\ccsm-control-<userhash>', () => {
+    const got = resolveControlSocketPath('win32', {
+      LOCALAPPDATA: 'C:\\x',
+    });
+    const ui = userInfo();
+    const tag = `${ui.username}@${hostname()}`;
+    const expectHash = createHash('sha256').update(tag).digest('hex').slice(0, 8);
+    expect(got).toBe(`\\\\.\\pipe\\ccsm-control-${expectHash}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// probeControlSocket outcome matrix.
+// ---------------------------------------------------------------------------
+describe('probeControlSocket', () => {
+  it('hello-success path → kind=alive when connector emits connect', async () => {
+    const sock = new FakeSocket();
+    const p = probeControlSocket({
+      platform: 'linux',
+      env: { XDG_RUNTIME_DIR: '/run/user/1000' },
+      timeoutMs: 200,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      connector: () => sock as any,
+    });
+    sock.emitConnectAsync();
+    const out = await p;
+    expect(out.kind).toBe('alive');
+    expect(out.socketPath).toBe('/run/user/1000/ccsm/ccsm-control.sock');
+    expect(sock.destroyed).toBe(true);
+  });
+
+  it('connect-refused → kind=absent (ECONNREFUSED)', async () => {
+    const sock = new FakeSocket();
+    const p = probeControlSocket({
+      platform: 'linux',
+      env: { XDG_DATA_HOME: '/xdg' },
+      timeoutMs: 200,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      connector: () => sock as any,
+    });
+    sock.emitErrorAsync('ECONNREFUSED');
+    const out = await p;
+    expect(out.kind).toBe('absent');
+    if (out.kind === 'absent') {
+      expect(out.reason).toBe('ECONNREFUSED');
+    }
+  });
+
+  it('socket-not-found → kind=absent (ENOENT)', async () => {
+    const sock = new FakeSocket();
+    const p = probeControlSocket({
+      platform: 'linux',
+      env: { XDG_DATA_HOME: '/xdg' },
+      timeoutMs: 200,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      connector: () => sock as any,
+    });
+    sock.emitErrorAsync('ENOENT');
+    const out = await p;
+    expect(out.kind).toBe('absent');
+    if (out.kind === 'absent') {
+      expect(out.reason).toBe('ENOENT');
+    }
+  });
+
+  it('hello-timeout (wedged listener) → kind=zombie', async () => {
+    const sock = new FakeSocket();
+    const p = probeControlSocket({
+      platform: 'linux',
+      env: { XDG_DATA_HOME: '/xdg' },
+      timeoutMs: 30,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      connector: () => sock as any,
+    });
+    sock.emitNothing();
+    const out = await p;
+    expect(out.kind).toBe('zombie');
+    if (out.kind === 'zombie') {
+      expect(out.reason).toMatch(/30ms/);
+    }
+    expect(sock.destroyed).toBe(true);
+  });
+
+  it('post-settle events do not flip outcome', async () => {
+    const sock = new FakeSocket();
+    const p = probeControlSocket({
+      platform: 'linux',
+      env: { XDG_DATA_HOME: '/xdg' },
+      timeoutMs: 200,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      connector: () => sock as any,
+    });
+    sock.emitConnectAsync();
+    const out = await p;
+    expect(out.kind).toBe('alive');
+    // late error after settle: must not throw or change result
+    sock.emit('error', Object.assign(new Error('late'), { code: 'EPIPE' }));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shouldSpawnDaemon decision wrapper.
+// ---------------------------------------------------------------------------
+describe('shouldSpawnDaemon', () => {
+  let writes: string[];
+  let origWrite: typeof process.stderr.write;
+  beforeEach(() => {
+    writes = [];
+    origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+      writes.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'));
+      return true;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any;
+  });
+  afterEach(() => {
+    process.stderr.write = origWrite;
+  });
+
+  it('returns false + logs "skipping" when daemon already alive', async () => {
+    const sock = new FakeSocket();
+    const p = shouldSpawnDaemon({
+      platform: 'linux',
+      env: { XDG_RUNTIME_DIR: '/run/user/1000' },
+      timeoutMs: 100,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      connector: () => sock as any,
+    });
+    sock.emitConnectAsync();
+    const proceed = await p;
+    expect(proceed).toBe(false);
+    expect(writes.join('')).toMatch(/already bound.*skipping spawn/);
+  });
+
+  it('returns true + logs "spawning" when no daemon present', async () => {
+    const sock = new FakeSocket();
+    const p = shouldSpawnDaemon({
+      platform: 'linux',
+      env: { XDG_DATA_HOME: '/xdg' },
+      timeoutMs: 100,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      connector: () => sock as any,
+    });
+    sock.emitErrorAsync('ECONNREFUSED');
+    const proceed = await p;
+    expect(proceed).toBe(true);
+    expect(writes.join('')).toMatch(/no daemon.*ECONNREFUSED.*spawning/);
+  });
+
+  it('returns true + logs WARN when listener is wedged', async () => {
+    const sock = new FakeSocket();
+    const p = shouldSpawnDaemon({
+      platform: 'linux',
+      env: { XDG_DATA_HOME: '/xdg' },
+      timeoutMs: 30,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      connector: () => sock as any,
+    });
+    sock.emitNothing();
+    const proceed = await p;
+    expect(proceed).toBe(true);
+    expect(writes.join('')).toMatch(/WARN.*wedged.*spawning anyway/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Drift guard: re-import the daemon-side path computers and assert the
+// dev-script mirrors them byte-for-byte across a representative matrix.
+// Same posture as tests/wait-daemon.test.ts.
+// ---------------------------------------------------------------------------
+describe('drift guard against daemon/src/sockets/*', () => {
+  it('matches defaultControlSocketPath across (platform, env) cases', async () => {
+    const { defaultControlSocketPath } = await import(
+      '../daemon/src/sockets/control-socket.js'
+    );
+    // We can't import resolveRuntimeRoot's full mkdir-side-effect impl here
+    // because it touches the FS. Instead, inline the same input-only branches
+    // by computing the expected runtimeRoot via our pure mirror, and feed
+    // BOTH that path into defaultControlSocketPath() and compare.
+    const cases: Array<{ platform: NodeJS.Platform; env: NodeJS.ProcessEnv }> = [
+      { platform: 'linux', env: { XDG_RUNTIME_DIR: '/run/user/1000' } },
+      { platform: 'linux', env: { XDG_DATA_HOME: '/xdg/data' } },
+      { platform: 'darwin', env: {} },
+      { platform: 'win32', env: { LOCALAPPDATA: 'C:\\Users\\u\\AppData\\Local' } },
+    ];
+    for (const { platform, env } of cases) {
+      const ours = resolveControlSocketPath(platform, env);
+      const theirs = defaultControlSocketPath(platform, resolveRuntimeRoot(platform, env));
+      expect(ours).toBe(theirs);
+    }
+  });
+});


### PR DESCRIPTION
Task #1025.

## Summary
Pre-spawn probe of the daemon control-socket so dev nodemon refuses to start a second daemon when one is already bound (common dev pain when nodemon double-fires on rapid file saves -> EADDRINUSE noise).

## Probe outcomes
(frag-3.7-dev-workflow.md S3.7.6.a; design.md S3.1.1)
- **alive** (connect succeeds) -> log "skipping spawn", exit 0
- **absent** (ECONNREFUSED / ENOENT) -> log "spawning", proceed
- **zombie** (no connect verdict <500ms) -> log WARN, proceed; let nodemon surface any actual bind conflict downstream

## Probe path: connect-only
Full daemon.hello HMAC envelope was rejected for the same reason as T64 wait-daemon (#1021): the dev script must stay zero-dep / runnable from a fresh clone, no daemon-secret import. Connect success on the OS-native control-socket node is sufficient evidence that *something* owns the bind slot. Zombie / wedged listener is logged loudly but does not block the spawn (operator can kill the offending process; nodemon's own EADDRINUSE will surface if the bind actually conflicts).

## Drift guard
Socket-path computation mirrors `daemon/src/sockets/control-socket.ts::defaultControlSocketPath` + `runtime-root.ts::resolveRuntimeRoot` byte-for-byte. A unit test pins both across (linux+XDG_RUNTIME_DIR / linux+XDG_DATA_HOME / darwin / win32+LOCALAPPDATA). Mirror posture matches T64 — daemon symbols are NOT imported (zero-dep dev script).

## Wiring
`scripts/dev-watch.ts` (the `npm run dev:daemon` entrypoint) now runs the guard as a `.then()` pre-check before spawning nodemon. A guard error (caught path) still spawns nodemon so a guard bug never blocks dev.

## Files
- `scripts/double-bind-guard.ts` (new, 195 LOC) — pure decider
- `tests/double-bind-guard.test.ts` (new, 300 LOC)
- `scripts/dev-watch.ts` (modified, +33/-9)

## Tests
20 vitest passing:
- `resolveDataRoot/RuntimeRoot/ControlSocketPath` matrix (10)
- `probeControlSocket` alive / absent-ECONNREFUSED / absent-ENOENT / zombie-timeout / post-settle-noop (5)
- `shouldSpawnDaemon` skip / spawn / WARN-spawn (3)
- drift guard vs `daemon/src/sockets/control-socket.ts::defaultControlSocketPath` (1+1)

```
 Test Files  1 passed (1)
      Tests  20 passed (20)
```

## tsc
`npx tsc --noEmit` (root) + `npx tsc --noEmit -p daemon/tsconfig.json`: both clean.

## End-to-end smoke
Ran `tsx scripts/dev-watch.ts` on Win11; observed
```
[daemon-guard] no daemon at \.\pipe\ccsm-control-c0ea1bfb (ENOENT), spawning
[daemon] [nodemon] starting `tsx daemon/src/index.ts`
[daemon] {"event":"daemon.boot","msg":"daemon shell booted"}
```
First-run absent path verified end-to-end. Alive path is exercised by the unit test (deterministic fake connector).

## Test plan
- [x] vitest passes (20/20)
- [x] tsc --noEmit clean (root + daemon)
- [x] dev-watch.ts smoke run on Win11 — guard logs decision, nodemon then spawns
- [ ] CI green
- [ ] Reviewer pass (auto-dispatched)