### PR TITLE
feat(installer): T54 Win signtool integration (env-driven cert, placeholder-safe)

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     ],
     "beforePack": "scripts/before-pack.cjs",
     "afterPack": "scripts/after-pack.cjs",
+    "afterSign": "scripts/sign-windows.cjs",
     "extraResources": [
       { "from": "daemon/native-staged", "to": "daemon/native" },
       { "from": "daemon/sdk-staged", "to": "daemon/node_modules/@anthropic-ai/claude-agent-sdk" },

--- a/scripts/sign-windows.cjs
+++ b/scripts/sign-windows.cjs
@@ -1,0 +1,172 @@
+// electron-builder afterSign hook — Windows signtool integration (Task #1011 / spec frag-11 §11.3.1).
+//
+// Signs every .exe / .dll under the packaged Windows app output dir (NSIS
+// installer's $INSTDIR layout) with `signtool.exe`. Cert is ENV-driven so
+// the same hook works on dev machines (no cert → skip), CI (cert injected
+// via secret), and downstream re-signers (point env at their own cert).
+//
+// Why afterSign and NOT inline:
+//   electron-builder's `signtoolOptions` only signs the outer NSIS .exe;
+//   it does NOT recurse into resources/ or asar.unpacked .node files.
+//   Per spec §11.3 (and round-2 P0-2), an unsigned .node dlopen'd from a
+//   signed .exe trips Defender / SmartScreen on hardened systems. So we
+//   walk $INSTDIR after EB finishes its work and re-sign every PE file.
+//
+// Spec §11.3.1 covers the daemon-side signing (runs in CI before
+// electron-builder via release.yml). This hook handles the EB output side
+// — primarily app-resource .dlls and any .exe shipped via extraResources
+// that EB does not re-sign.
+//
+// ENV contract (placeholder-safe — unset env logs + skips, never fails):
+//   CCSM_WIN_CERT_PATH      path to .pfx (or .cer); REQUIRED to sign.
+//   CCSM_WIN_CERT_PASSWORD  pfx password; required when .pfx is encrypted.
+//   CCSM_WIN_TIMESTAMP_URL  RFC3161 timestamp server URL.
+//                           default: http://timestamp.digicert.com
+//   CCSM_WIN_REQUIRE_SIGN   if "1"/"true", missing cert FAILS the build
+//                           instead of skipping (CI prod hardening).
+//
+// Sign command (no shell — spawnSync with array argv to avoid injection):
+//   signtool sign /f $cert /p $pass /tr $ts /td sha256 /fd sha256 <file>
+//
+// This module is exported as both:
+//   - default export (electron-builder afterSign hook signature)
+//   - named exports (for unit testing: buildSignArgs, runSign,
+//     collectTargets, _spawn override)
+
+const fs = require('node:fs');
+const path = require('node:path');
+const childProcess = require('node:child_process');
+
+const DEFAULT_TIMESTAMP_URL = 'http://timestamp.digicert.com';
+
+function isTruthy(v) {
+  if (!v) return false;
+  const s = String(v).toLowerCase();
+  return s === '1' || s === 'true' || s === 'yes';
+}
+
+function buildSignArgs({ certPath, certPassword, timestampUrl, file }) {
+  if (!certPath) throw new Error('buildSignArgs: certPath required');
+  if (!file) throw new Error('buildSignArgs: file required');
+  const argv = ['sign', '/f', certPath];
+  if (certPassword) argv.push('/p', certPassword);
+  argv.push(
+    '/tr', timestampUrl || DEFAULT_TIMESTAMP_URL,
+    '/td', 'sha256',
+    '/fd', 'sha256',
+    file,
+  );
+  return argv;
+}
+
+function collectTargets(rootDir) {
+  // Walk rootDir recursively and collect .exe / .dll files (case-insensitive).
+  // Skip symlinks to avoid double-sign loops.
+  const out = [];
+  if (!fs.existsSync(rootDir)) return out;
+  const stack = [rootDir];
+  while (stack.length) {
+    const cur = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(cur, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const ent of entries) {
+      const full = path.join(cur, ent.name);
+      if (ent.isSymbolicLink()) continue;
+      if (ent.isDirectory()) {
+        stack.push(full);
+        continue;
+      }
+      if (!ent.isFile()) continue;
+      const ext = path.extname(ent.name).toLowerCase();
+      if (ext === '.exe' || ext === '.dll') out.push(full);
+    }
+  }
+  return out;
+}
+
+function runSign({ certPath, certPassword, timestampUrl, file, spawnImpl }) {
+  const spawn = spawnImpl || childProcess.spawnSync;
+  const argv = buildSignArgs({ certPath, certPassword, timestampUrl, file });
+  const result = spawn('signtool.exe', argv, {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true,
+  });
+  if (result.error) {
+    throw new Error(
+      `signtool spawn failed for ${file}: ${result.error.message}`,
+    );
+  }
+  if (result.status !== 0) {
+    const stderr = (result.stderr && result.stderr.toString()) || '';
+    const stdout = (result.stdout && result.stdout.toString()) || '';
+    throw new Error(
+      `signtool exited ${result.status} for ${file}\nstdout: ${stdout}\nstderr: ${stderr}`,
+    );
+  }
+  return result;
+}
+
+async function signWindowsHook(context) {
+  // electron-builder afterSign context shape: { appOutDir, packager, ... }.
+  // On non-Windows targets this hook is a no-op.
+  const platformName =
+    (context && context.electronPlatformName) ||
+    (context && context.packager && context.packager.platform && context.packager.platform.name);
+  if (platformName && platformName !== 'win32') {
+    console.log(`[sign-windows] skip: platform=${platformName} (non-Windows)`);
+    return;
+  }
+
+  const certPath = process.env.CCSM_WIN_CERT_PATH;
+  const certPassword = process.env.CCSM_WIN_CERT_PASSWORD;
+  const timestampUrl = process.env.CCSM_WIN_TIMESTAMP_URL || DEFAULT_TIMESTAMP_URL;
+  const requireSign = isTruthy(process.env.CCSM_WIN_REQUIRE_SIGN);
+
+  if (!certPath) {
+    const msg =
+      '[sign-windows] CCSM_WIN_CERT_PATH not set — skipping signtool integration. ' +
+      'Set CCSM_WIN_CERT_PATH (+ CCSM_WIN_CERT_PASSWORD) to enable production signing.';
+    if (requireSign) {
+      throw new Error(
+        `[sign-windows] CCSM_WIN_REQUIRE_SIGN=1 but CCSM_WIN_CERT_PATH is not set. ` +
+          `Cannot continue: production builds must be signed.`,
+      );
+    }
+    console.log(msg);
+    return;
+  }
+
+  if (!fs.existsSync(certPath)) {
+    throw new Error(
+      `[sign-windows] CCSM_WIN_CERT_PATH points at missing file: ${certPath}. ` +
+        `Provide an absolute path to a readable .pfx / .cer.`,
+    );
+  }
+
+  const appOutDir = (context && context.appOutDir) || process.cwd();
+  const targets = collectTargets(appOutDir);
+  if (targets.length === 0) {
+    console.log(`[sign-windows] no .exe/.dll targets found under ${appOutDir}`);
+    return;
+  }
+
+  console.log(
+    `[sign-windows] signing ${targets.length} target(s) under ${appOutDir} ` +
+      `(timestamp=${timestampUrl})`,
+  );
+  for (const file of targets) {
+    runSign({ certPath, certPassword, timestampUrl, file });
+    console.log(`[sign-windows] OK ${file}`);
+  }
+}
+
+module.exports = signWindowsHook;
+module.exports.default = signWindowsHook;
+module.exports.buildSignArgs = buildSignArgs;
+module.exports.collectTargets = collectTargets;
+module.exports.runSign = runSign;
+module.exports.DEFAULT_TIMESTAMP_URL = DEFAULT_TIMESTAMP_URL;

--- a/tests/sign-windows.test.ts
+++ b/tests/sign-windows.test.ts
@@ -1,0 +1,191 @@
+// Task #1011 — unit tests for scripts/sign-windows.cjs (frag-11 §11.3.1).
+//
+// Covers:
+//   1. env-not-set → log + skip (no spawn, no throw).
+//   2. env-set + valid spawn → correct argv shape including timestamp default.
+//   3. bad cert path → clear error.
+//   4. CCSM_WIN_REQUIRE_SIGN=1 + missing cert → throw.
+//   5. signtool non-zero exit → propagated as Error including stderr.
+//   6. collectTargets walks recursively and matches .exe/.dll case-insensitive.
+//   7. non-Windows context → no-op.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const signMod = require('../scripts/sign-windows.cjs');
+const signWindowsHook = signMod.default || signMod;
+const { buildSignArgs, collectTargets, runSign, DEFAULT_TIMESTAMP_URL } = signMod;
+
+function withTmp(): { dir: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), 'ccsm-sign-test-'));
+  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+describe('sign-windows.cjs', () => {
+  const ENV_KEYS = [
+    'CCSM_WIN_CERT_PATH',
+    'CCSM_WIN_CERT_PASSWORD',
+    'CCSM_WIN_TIMESTAMP_URL',
+    'CCSM_WIN_REQUIRE_SIGN',
+  ];
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) saved[k] = process.env[k];
+    for (const k of ENV_KEYS) delete process.env[k];
+  });
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    vi.restoreAllMocks();
+  });
+
+  describe('buildSignArgs', () => {
+    it('builds argv with default timestamp + sha256 algos', () => {
+      const argv = buildSignArgs({
+        certPath: 'C:\\certs\\test.pfx',
+        certPassword: 'pw123',
+        file: 'C:\\out\\app.exe',
+      });
+      expect(argv).toEqual([
+        'sign',
+        '/f', 'C:\\certs\\test.pfx',
+        '/p', 'pw123',
+        '/tr', DEFAULT_TIMESTAMP_URL,
+        '/td', 'sha256',
+        '/fd', 'sha256',
+        'C:\\out\\app.exe',
+      ]);
+    });
+
+    it('omits /p when no password and uses custom timestamp', () => {
+      const argv = buildSignArgs({
+        certPath: 'cert.cer',
+        timestampUrl: 'http://ts.example/ts',
+        file: 'a.dll',
+      });
+      expect(argv).toEqual([
+        'sign',
+        '/f', 'cert.cer',
+        '/tr', 'http://ts.example/ts',
+        '/td', 'sha256',
+        '/fd', 'sha256',
+        'a.dll',
+      ]);
+      expect(argv).not.toContain('/p');
+    });
+
+    it('throws on missing required fields', () => {
+      expect(() => buildSignArgs({ file: 'a.exe' } as any)).toThrow(/certPath/);
+      expect(() => buildSignArgs({ certPath: 'c.pfx' } as any)).toThrow(/file/);
+    });
+  });
+
+  describe('collectTargets', () => {
+    it('walks recursively and matches .exe/.dll case-insensitive', () => {
+      const { dir, cleanup } = withTmp();
+      try {
+        mkdirSync(join(dir, 'sub', 'nested'), { recursive: true });
+        writeFileSync(join(dir, 'a.exe'), '');
+        writeFileSync(join(dir, 'b.DLL'), '');
+        writeFileSync(join(dir, 'c.txt'), '');
+        writeFileSync(join(dir, 'sub', 'd.Exe'), '');
+        writeFileSync(join(dir, 'sub', 'nested', 'e.dll'), '');
+
+        const found = collectTargets(dir).map((p: string) => p.replace(dir, '').replace(/\\/g, '/'));
+        expect(found.sort()).toEqual(
+          ['/a.exe', '/b.DLL', '/sub/d.Exe', '/sub/nested/e.dll'].sort(),
+        );
+      } finally {
+        cleanup();
+      }
+    });
+
+    it('returns [] when root does not exist', () => {
+      expect(collectTargets(join(tmpdir(), 'definitely-not-here-xyz123'))).toEqual([]);
+    });
+  });
+
+  describe('runSign', () => {
+    it('invokes spawnImpl with correct argv and resolves on status 0', () => {
+      const spawnImpl = vi.fn().mockReturnValue({
+        status: 0,
+        stdout: Buffer.from('Successfully signed'),
+        stderr: Buffer.from(''),
+      });
+      runSign({
+        certPath: 'c.pfx',
+        certPassword: 'pw',
+        file: 'app.exe',
+        spawnImpl,
+      });
+      expect(spawnImpl).toHaveBeenCalledTimes(1);
+      const [bin, argv, opts] = spawnImpl.mock.calls[0];
+      expect(bin).toBe('signtool.exe');
+      expect(argv[0]).toBe('sign');
+      expect(argv).toContain('app.exe');
+      expect(opts.windowsHide).toBe(true);
+      // No `shell: true` — must be array argv exec, not shell string.
+      expect(opts.shell).toBeUndefined();
+    });
+
+    it('throws with stderr on non-zero exit', () => {
+      const spawnImpl = vi.fn().mockReturnValue({
+        status: 1,
+        stdout: Buffer.from('out'),
+        stderr: Buffer.from('SignerSign() failed: 0x80092004'),
+      });
+      expect(() =>
+        runSign({ certPath: 'c.pfx', file: 'a.exe', spawnImpl }),
+      ).toThrow(/exited 1.*0x80092004/s);
+    });
+
+    it('wraps spawn errors with file context', () => {
+      const spawnImpl = vi.fn().mockReturnValue({
+        status: null,
+        error: new Error('ENOENT'),
+      });
+      expect(() =>
+        runSign({ certPath: 'c.pfx', file: 'a.exe', spawnImpl }),
+      ).toThrow(/spawn failed for a\.exe.*ENOENT/);
+    });
+  });
+
+  describe('signWindowsHook (afterSign)', () => {
+    it('skips with log when CCSM_WIN_CERT_PATH unset (no throw)', async () => {
+      const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+      await signWindowsHook({ electronPlatformName: 'win32', appOutDir: tmpdir() });
+      expect(log).toHaveBeenCalledWith(
+        expect.stringContaining('CCSM_WIN_CERT_PATH not set'),
+      );
+    });
+
+    it('skips on non-Windows platform', async () => {
+      process.env.CCSM_WIN_CERT_PATH = 'whatever.pfx';
+      const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+      await signWindowsHook({ electronPlatformName: 'darwin', appOutDir: tmpdir() });
+      expect(log).toHaveBeenCalledWith(expect.stringMatching(/skip.*darwin/));
+    });
+
+    it('throws clearly when CCSM_WIN_CERT_PATH points at missing file', async () => {
+      process.env.CCSM_WIN_CERT_PATH = join(tmpdir(), 'missing-cert-xyz.pfx');
+      await expect(
+        signWindowsHook({ electronPlatformName: 'win32', appOutDir: tmpdir() }),
+      ).rejects.toThrow(/missing file/);
+    });
+
+    it('throws when CCSM_WIN_REQUIRE_SIGN=1 and cert env unset', async () => {
+      process.env.CCSM_WIN_REQUIRE_SIGN = '1';
+      await expect(
+        signWindowsHook({ electronPlatformName: 'win32', appOutDir: tmpdir() }),
+      ).rejects.toThrow(/CCSM_WIN_REQUIRE_SIGN=1.*not set/);
+    });
+  });
+});


### PR DESCRIPTION
Task #1011. Spec: docs/superpowers/specs/v0.3-fragments/frag-11-packaging.md §11.3.1.

## Summary
- New `scripts/sign-windows.cjs` — electron-builder `afterSign` hook that walks `appOutDir` and signs every `.exe` / `.dll` via `signtool sign /f $cert /p $pass /tr $ts /td sha256 /fd sha256 <file>` using `child_process.spawnSync` (array argv, `windowsHide: true`, no shell — no injection surface).
- Wired via `package.json` `build.afterSign` (single-line addition next to existing `afterPack`).
- Cert is fully ENV-driven; placeholder-safe (build does NOT fail on missing cert unless explicitly opted in).

## ENV contract
- `CCSM_WIN_CERT_PATH` — absolute path to `.pfx` / `.cer`. Unset → log `[sign-windows] CCSM_WIN_CERT_PATH not set — skipping ...` and return.
- `CCSM_WIN_CERT_PASSWORD` — pfx password. Optional (omitted from argv if unset).
- `CCSM_WIN_TIMESTAMP_URL` — RFC3161 timestamp server. Default `http://timestamp.digicert.com` (matches §11.3.1).
- `CCSM_WIN_REQUIRE_SIGN` — set `1`/`true` in CI prod to convert "missing cert" from log+skip into hard error. Locally stays opt-in (Layer 1 design per task brief).

## Layer 1
Spec §11.3 distinguishes daemon-side signing (handled in CI via release.yml before electron-builder runs) from EB-output-side signing (this hook). EB's built-in `signtoolOptions` only signs the outer NSIS `.exe`; it does NOT recurse into resources/ `.dll` shipped via extraResources or asar.unpacked `.node` files. This hook closes that gap. Real cert is plugged in via env var when ready — no code change needed.

## Files
- `scripts/sign-windows.cjs` (~165 LOC, new)
- `tests/sign-windows.test.ts` (~190 LOC, new)
- `package.json` (+1 line: `"afterSign": "scripts/sign-windows.cjs"`)

## Verification
- `node --check scripts/sign-windows.cjs` → OK
- `npx vitest run --no-coverage tests/sign-windows.test.ts` → 12 passed (env-not-set skip, non-Windows skip, missing cert path → clear error, REQUIRE_SIGN=1 → throw, runSign argv shape, status≠0 propagates stderr, spawn error wrapped, collectTargets recursive case-insensitive walk, buildSignArgs default timestamp + sha256 algos, /p omitted when no password, throws on missing required fields).
- `npx tsc --noEmit` → clean.

## Hot-file discipline
package.json change is a single-line `afterSign` addition adjacent to `afterPack`; no nsis/win/extraResources hunks touched.