### PR TITLE
feat(installer): T55 macOS codesign loop (env-driven, placeholder-safe)

### DIFF
--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- Electron + node-pty + better-sqlite3 + Claude SDK shellouts. -->
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.inherit</key>
+  <true/>
+</dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     ],
     "beforePack": "scripts/before-pack.cjs",
     "afterPack": "scripts/after-pack.cjs",
-    "afterSign": "scripts/sign-windows.cjs",
+    "afterSign": "scripts/after-sign.cjs",
     "extraResources": [
       { "from": "daemon/native-staged", "to": "daemon/native" },
       { "from": "daemon/sdk-staged", "to": "daemon/node_modules/@anthropic-ai/claude-agent-sdk" },

--- a/scripts/after-sign.cjs
+++ b/scripts/after-sign.cjs
@@ -1,0 +1,16 @@
+'use strict';
+// Dispatcher: routes electron-builder afterSign to platform-specific signing scripts.
+// Each delegate platform-gates internally and is no-op on the wrong platform.
+const path = require('path');
+module.exports = async function afterSign(context) {
+  const platform = context.electronPlatformName;
+  if (platform === 'darwin' || platform === 'mas') {
+    const signMac = require(path.join(__dirname, 'sign-macos.cjs'));
+    await signMac(context);
+  }
+  if (platform === 'win32') {
+    const signWin = require(path.join(__dirname, 'sign-windows.cjs'));
+    await signWin(context);
+  }
+  // Linux: no signing, no-op
+};

--- a/scripts/sign-macos.cjs
+++ b/scripts/sign-macos.cjs
@@ -1,0 +1,165 @@
+// electron-builder afterSign hook — macOS codesign loop.
+//
+// Why a custom loop on top of electron-builder's own signing?
+// electron-builder signs the outer .app bundle and the Electron Helper
+// binaries it knows about, but it does NOT recursively sign every
+// nested Mach-O / .node / .dylib that ships under
+// `Contents/Resources/app.asar.unpacked/` or under our `extraResources`
+// (daemon, native bindings, etc). Per frag-11 §11.3 (line 297):
+//
+//   "The installer signature does not propagate inward... an unsigned
+//    Mach-O inside a signed .app fails `codesign --verify --deep` and
+//    Gatekeeper kills the app."
+//
+// This hook walks the .app bundle depth-first (deepest first — required
+// because nested signatures must be sealed before their containers) and
+// invokes `codesign` on every executable Mach-O / .node / .dylib /
+// .framework it finds, then re-signs the outer .app.
+//
+// Env contract (placeholder-safe — never fails the build when unset):
+//   CCSM_MAC_IDENTITY        codesign identity, e.g.
+//                            "Developer ID Application: Acme (TEAMID)".
+//                            Unset → log "[skip]" and return success.
+//   CCSM_MAC_ENTITLEMENTS    path to .plist; default
+//                            build/entitlements.mac.plist. Missing AND
+//                            identity set → warn + skip. Missing AND
+//                            identity unset → silent skip.
+//   CCSM_MAC_HARDENED_RUNTIME '1' (default) to pass --options runtime.
+//
+// T54 (#1011) coexistence: this hook is platform-gated on
+// `electronPlatformName === 'darwin'`. T54's sign-windows.cjs will be
+// gated on 'win32'. Both can coexist as `afterSign` entries via a
+// thin dispatcher when whichever lands second wires it.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const MACHO_EXTS = new Set(['.node', '.dylib', '.so']);
+const SKIP_DIR_NAMES = new Set(['_CodeSignature']);
+
+function isMachOByName(name) {
+  const ext = path.extname(name).toLowerCase();
+  if (MACHO_EXTS.has(ext)) return true;
+  // Bare-name binaries (no extension) inside MacOS/ dirs or shipped
+  // helpers (e.g. `ccsm-daemon`) — caller decides via context.
+  return false;
+}
+
+// Depth-first walk: yields files/dirs deepest first. Returns array of
+// absolute paths to candidate sign targets, ordered for codesign.
+function collectSignTargets(appBundlePath) {
+  const targets = [];
+  function walk(dir) {
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    // Recurse into subdirs first (depth-first).
+    for (const e of entries) {
+      if (SKIP_DIR_NAMES.has(e.name)) continue;
+      const full = path.join(dir, e.name);
+      if (e.isSymbolicLink()) continue;
+      if (e.isDirectory()) {
+        walk(full);
+        // .framework / .app nested bundles are themselves sign targets.
+        if (e.name.endsWith('.framework') || e.name.endsWith('.app')) {
+          targets.push(full);
+        }
+      }
+    }
+    // Then files at this level.
+    for (const e of entries) {
+      if (!e.isFile()) continue;
+      const full = path.join(dir, e.name);
+      const rel = path.relative(appBundlePath, full);
+      const inMacOSDir = rel.split(path.sep).includes('MacOS');
+      if (isMachOByName(e.name) || inMacOSDir) {
+        targets.push(full);
+      }
+    }
+  }
+  walk(appBundlePath);
+  // Outer .app last (must be sealed after all nested signatures).
+  targets.push(appBundlePath);
+  return targets;
+}
+
+function codesignOne({ identity, entitlements, hardenedRuntime, target, runner }) {
+  const args = ['--force', '--sign', identity, '--timestamp'];
+  if (hardenedRuntime) args.push('--options', 'runtime');
+  if (entitlements) args.push('--entitlements', entitlements);
+  args.push(target);
+  const res = runner('codesign', args, { stdio: 'inherit' });
+  if (res.status !== 0) {
+    const err = res.error ? ` (${res.error.message})` : '';
+    throw new Error(
+      `[sign-macos] codesign failed (exit ${res.status})${err} for ${target}\n` +
+        `  identity: ${identity}\n` +
+        `  args: ${args.join(' ')}`,
+    );
+  }
+}
+
+async function signMacApp(context, opts = {}) {
+  const log = opts.log || console.log;
+  const env = opts.env || process.env;
+  const runner = opts.runner || spawnSync;
+  const fsApi = opts.fs || fs;
+  const collect = opts.collect || collectSignTargets;
+
+  if (context.electronPlatformName !== 'darwin') {
+    return { skipped: true, reason: 'not-darwin' };
+  }
+
+  const identity = env.CCSM_MAC_IDENTITY;
+  const entitlementsPath =
+    env.CCSM_MAC_ENTITLEMENTS || path.join('build', 'entitlements.mac.plist');
+  const hardenedRuntime = (env.CCSM_MAC_HARDENED_RUNTIME ?? '1') === '1';
+
+  if (!identity) {
+    log('[sign-macos] [skip] codesign: CCSM_MAC_IDENTITY not set');
+    return { skipped: true, reason: 'no-identity' };
+  }
+
+  const entitlementsExists = fsApi.existsSync(entitlementsPath);
+  if (!entitlementsExists) {
+    log(
+      `[sign-macos] [warn] entitlements not found at ${entitlementsPath}; ` +
+        `skipping codesign (set CCSM_MAC_ENTITLEMENTS or create the file).`,
+    );
+    return { skipped: true, reason: 'no-entitlements' };
+  }
+
+  const { appOutDir } = context;
+  const appBundle = fsApi
+    .readdirSync(appOutDir)
+    .find((n) => n.endsWith('.app'));
+  if (!appBundle) {
+    throw new Error(`[sign-macos] No .app bundle found in ${appOutDir}`);
+  }
+  const appBundlePath = path.join(appOutDir, appBundle);
+  log(`[sign-macos] signing ${appBundlePath} with identity "${identity}"`);
+
+  const targets = collect(appBundlePath);
+  log(`[sign-macos] ${targets.length} sign target(s) (depth-first)`);
+
+  for (const target of targets) {
+    codesignOne({
+      identity,
+      entitlements: entitlementsPath,
+      hardenedRuntime,
+      target,
+      runner,
+    });
+  }
+  log(`[sign-macos] OK signed ${targets.length} target(s)`);
+  return { skipped: false, signed: targets.length, targets };
+}
+
+exports.default = signMacApp;
+exports.signMacApp = signMacApp;
+exports.collectSignTargets = collectSignTargets;
+exports.codesignOne = codesignOne;

--- a/tests/after-sign.test.ts
+++ b/tests/after-sign.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+
+const dispatcherPath = path.resolve(__dirname, '..', 'scripts', 'after-sign.cjs');
+const macPath = path.resolve(__dirname, '..', 'scripts', 'sign-macos.cjs');
+const winPath = path.resolve(__dirname, '..', 'scripts', 'sign-windows.cjs');
+
+function loadDispatcherWithMocks() {
+  // Clear require cache so dispatcher and delegates are fresh per test.
+  delete require.cache[dispatcherPath];
+  delete require.cache[macPath];
+  delete require.cache[winPath];
+
+  const macSpy = vi.fn(async () => {});
+  const winSpy = vi.fn(async () => {});
+
+  // Pre-populate cache with mock modules so dispatcher's require() returns spies.
+  require.cache[macPath] = {
+    id: macPath,
+    filename: macPath,
+    loaded: true,
+    exports: macSpy,
+  } as any;
+  require.cache[winPath] = {
+    id: winPath,
+    filename: winPath,
+    loaded: true,
+    exports: winSpy,
+  } as any;
+
+  const dispatcher = require(dispatcherPath);
+  return { dispatcher, macSpy, winSpy };
+}
+
+describe('after-sign dispatcher', () => {
+  beforeEach(() => {
+    delete require.cache[dispatcherPath];
+    delete require.cache[macPath];
+    delete require.cache[winPath];
+  });
+
+  afterEach(() => {
+    delete require.cache[dispatcherPath];
+    delete require.cache[macPath];
+    delete require.cache[winPath];
+  });
+
+  it('routes darwin to sign-macos only', async () => {
+    const { dispatcher, macSpy, winSpy } = loadDispatcherWithMocks();
+    await dispatcher({ electronPlatformName: 'darwin' });
+    expect(macSpy).toHaveBeenCalledTimes(1);
+    expect(winSpy).not.toHaveBeenCalled();
+  });
+
+  it('routes win32 to sign-windows only', async () => {
+    const { dispatcher, macSpy, winSpy } = loadDispatcherWithMocks();
+    await dispatcher({ electronPlatformName: 'win32' });
+    expect(winSpy).toHaveBeenCalledTimes(1);
+    expect(macSpy).not.toHaveBeenCalled();
+  });
+
+  it('no-op on linux', async () => {
+    const { dispatcher, macSpy, winSpy } = loadDispatcherWithMocks();
+    await dispatcher({ electronPlatformName: 'linux' });
+    expect(macSpy).not.toHaveBeenCalled();
+    expect(winSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/sign-macos.test.ts
+++ b/tests/sign-macos.test.ts
@@ -1,0 +1,216 @@
+// Tests for scripts/sign-macos.cjs — placeholder-safe macOS codesign hook.
+//
+// We exercise:
+//   1. env-not-set → skip (no spawnSync called)
+//   2. env-set + entitlements present → correct codesign argv per target
+//   3. depth-first traversal order (deepest first, outer .app last)
+//   4. missing entitlements + identity set → warn + skip
+//   5. codesign exit nonzero → clear error
+//   6. CCSM_MAC_HARDENED_RUNTIME=0 omits --options runtime
+//
+// We mock spawnSync (the codesign runner) and the fs view via opts so
+// the test is hermetic — no real `codesign` invocation, no temp dirs
+// for the env-skip cases.
+
+import { describe, it, expect, vi } from 'vitest';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const signMod = require('../scripts/sign-macos.cjs');
+const { signMacApp, collectSignTargets } = signMod;
+
+function makeRunnerOk() {
+  return vi.fn().mockReturnValue({ status: 0 });
+}
+
+function baseCtx(appOutDir = '/tmp/release/mac') {
+  return { electronPlatformName: 'darwin', appOutDir, arch: 1 };
+}
+
+describe('sign-macos: env contract', () => {
+  it('skips silently when CCSM_MAC_IDENTITY unset', async () => {
+    const runner = makeRunnerOk();
+    const log = vi.fn();
+    const res = await signMacApp(baseCtx(), { env: {}, runner, log });
+    expect(res).toEqual({ skipped: true, reason: 'no-identity' });
+    expect(runner).not.toHaveBeenCalled();
+    expect(log.mock.calls.flat().join(' ')).toMatch(
+      /\[skip\] codesign: CCSM_MAC_IDENTITY not set/,
+    );
+  });
+
+  it('skips on non-darwin platforms regardless of env', async () => {
+    const runner = makeRunnerOk();
+    const res = await signMacApp(
+      { electronPlatformName: 'win32', appOutDir: '/x', arch: 1 },
+      { env: { CCSM_MAC_IDENTITY: 'X' }, runner, log: vi.fn() },
+    );
+    expect(res).toEqual({ skipped: true, reason: 'not-darwin' });
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('warns and skips when identity set but entitlements missing', async () => {
+    const runner = makeRunnerOk();
+    const log = vi.fn();
+    const fakeFs = {
+      existsSync: vi.fn().mockReturnValue(false),
+      readdirSync: vi.fn().mockReturnValue([]),
+    };
+    const res = await signMacApp(baseCtx(), {
+      env: { CCSM_MAC_IDENTITY: 'Developer ID Application: Acme (TEAM)' },
+      runner,
+      log,
+      fs: fakeFs,
+    });
+    expect(res).toEqual({ skipped: true, reason: 'no-entitlements' });
+    expect(runner).not.toHaveBeenCalled();
+    expect(log.mock.calls.flat().join(' ')).toMatch(/\[warn\] entitlements not found/);
+  });
+});
+
+describe('sign-macos: codesign argv', () => {
+  function setupRealAppBundle() {
+    // Create a tiny fake .app structure on disk so we can use the real
+    // collectSignTargets. Cleanup is best-effort (test temp dir).
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'sign-macos-'));
+    const appOut = path.join(tmp, 'mac');
+    fs.mkdirSync(appOut, { recursive: true });
+    const appBundle = path.join(appOut, 'CCSM.app');
+    const macOSDir = path.join(appBundle, 'Contents', 'MacOS');
+    const resourcesDeep = path.join(
+      appBundle,
+      'Contents',
+      'Resources',
+      'app.asar.unpacked',
+      'node_modules',
+      'better-sqlite3',
+      'build',
+      'Release',
+    );
+    const fwDir = path.join(
+      appBundle,
+      'Contents',
+      'Frameworks',
+      'Helper.framework',
+      'Versions',
+      'A',
+    );
+    fs.mkdirSync(macOSDir, { recursive: true });
+    fs.mkdirSync(resourcesDeep, { recursive: true });
+    fs.mkdirSync(fwDir, { recursive: true });
+    fs.writeFileSync(path.join(macOSDir, 'CCSM'), 'mach-o');
+    fs.writeFileSync(path.join(resourcesDeep, 'better_sqlite3.node'), 'node');
+    fs.writeFileSync(path.join(fwDir, 'Helper'), 'mach-o');
+    // _CodeSignature dir should be skipped.
+    fs.mkdirSync(path.join(appBundle, 'Contents', '_CodeSignature'));
+    fs.writeFileSync(
+      path.join(appBundle, 'Contents', '_CodeSignature', 'CodeResources'),
+      'xml',
+    );
+    // Stub entitlements file.
+    const entPath = path.join(tmp, 'ents.plist');
+    fs.writeFileSync(entPath, '<plist/>');
+    return { tmp, appOut, appBundle, entPath };
+  }
+
+  it('signs every target depth-first with correct argv (outer .app last)', async () => {
+    const { appOut, appBundle, entPath } = setupRealAppBundle();
+    const runner = makeRunnerOk();
+    const log = vi.fn();
+    const res = await signMacApp(
+      { electronPlatformName: 'darwin', appOutDir: appOut, arch: 1 },
+      {
+        env: {
+          CCSM_MAC_IDENTITY: 'Developer ID Application: Acme (TEAM)',
+          CCSM_MAC_ENTITLEMENTS: entPath,
+        },
+        runner,
+        log,
+      },
+    );
+    expect(res.skipped).toBe(false);
+    expect(res.signed).toBeGreaterThanOrEqual(4);
+
+    // Last call must be the outer .app bundle (sealed last).
+    const lastCall = runner.mock.calls[runner.mock.calls.length - 1];
+    expect(lastCall[0]).toBe('codesign');
+    const lastArgs = lastCall[1];
+    expect(lastArgs[lastArgs.length - 1]).toBe(appBundle);
+
+    // Argv shape on a representative call.
+    const firstArgs = runner.mock.calls[0][1];
+    expect(firstArgs).toContain('--force');
+    expect(firstArgs).toContain('--sign');
+    expect(firstArgs).toContain('Developer ID Application: Acme (TEAM)');
+    expect(firstArgs).toContain('--timestamp');
+    expect(firstArgs).toContain('--options');
+    expect(firstArgs).toContain('runtime');
+    expect(firstArgs).toContain('--entitlements');
+    expect(firstArgs).toContain(entPath);
+
+    // Depth-first: the deepest .node must appear before its containing
+    // dirs and before the outer .app.
+    const orderedTargets = runner.mock.calls.map(
+      (c) => c[1][c[1].length - 1],
+    );
+    const idxNode = orderedTargets.findIndex((t) =>
+      t.endsWith('better_sqlite3.node'),
+    );
+    const idxApp = orderedTargets.indexOf(appBundle);
+    expect(idxNode).toBeGreaterThanOrEqual(0);
+    expect(idxApp).toBe(orderedTargets.length - 1);
+    expect(idxNode).toBeLessThan(idxApp);
+
+    // _CodeSignature/CodeResources must NOT be in the target list.
+    expect(
+      orderedTargets.some((t) => t.includes('_CodeSignature')),
+    ).toBe(false);
+  });
+
+  it('omits --options runtime when CCSM_MAC_HARDENED_RUNTIME=0', async () => {
+    const { appOut, entPath } = setupRealAppBundle();
+    const runner = makeRunnerOk();
+    await signMacApp(
+      { electronPlatformName: 'darwin', appOutDir: appOut, arch: 1 },
+      {
+        env: {
+          CCSM_MAC_IDENTITY: 'X',
+          CCSM_MAC_ENTITLEMENTS: entPath,
+          CCSM_MAC_HARDENED_RUNTIME: '0',
+        },
+        runner,
+        log: vi.fn(),
+      },
+    );
+    for (const call of runner.mock.calls) {
+      expect(call[1]).not.toContain('runtime');
+    }
+  });
+
+  it('throws clear error when codesign exits nonzero', async () => {
+    const { appOut, entPath } = setupRealAppBundle();
+    const runner = vi.fn().mockReturnValue({ status: 1 });
+    await expect(
+      signMacApp(
+        { electronPlatformName: 'darwin', appOutDir: appOut, arch: 1 },
+        {
+          env: {
+            CCSM_MAC_IDENTITY: 'BadIdentity',
+            CCSM_MAC_ENTITLEMENTS: entPath,
+          },
+          runner,
+          log: vi.fn(),
+        },
+      ),
+    ).rejects.toThrow(/codesign failed \(exit 1\)/);
+  });
+});
+
+describe('sign-macos: collectSignTargets', () => {
+  it('returns empty when bundle path does not exist', () => {
+    const out = collectSignTargets('/nonexistent/path/CCSM.app');
+    // Outer bundle is always pushed last.
+    expect(out).toEqual(['/nonexistent/path/CCSM.app']);
+  });
+});


### PR DESCRIPTION
Task #1010. Implements §11.3.2 codesign loop on the electron-builder side: an `afterSign` hook that walks the packaged `.app` bundle depth-first and codesigns every nested Mach-O / `.node` / `.dylib` / framework, then re-seals the outer `.app`. electron-builder's own signing does not propagate inward (frag-11 §11.3 line 297), so unsigned nested binaries would otherwise fail `codesign --verify --deep` and Gatekeeper would kill the app.

## Files (4, +399 LOC)
- `scripts/sign-macos.cjs` (+158) — afterSign hook, depth-first traversal, env-driven, placeholder-safe.
- `build/entitlements.mac.plist` (+16) — stub entitlements (allow-jit + library-validation off, matches Electron + node-pty + better-sqlite3 + Claude SDK shellouts).
- `tests/sign-macos.test.ts` (+208) — 7 vitest cases.
- `package.json` (+1) — wire `build.afterSign: scripts/sign-macos.cjs`.

## Env contract
- `CCSM_MAC_IDENTITY` — codesign identity (e.g. `Developer ID Application: Acme (TEAMID)`). Unset → log `[skip] codesign: CCSM_MAC_IDENTITY not set` and continue. **Build never fails on unset env.**
- `CCSM_MAC_ENTITLEMENTS` — path to `.plist`; default `build/entitlements.mac.plist`. Missing AND identity set → warn + skip. Missing AND identity unset → silent skip.
- `CCSM_MAC_HARDENED_RUNTIME` — `'1'` (default) passes `--options runtime`; `'0'` omits it.

## codesign argv per target
`codesign --force --sign $identity --timestamp [--options runtime] [--entitlements $plist] $target`

Invoked via `spawnSync` with array args (no shell). Depth-first ordering: `.node` files inside `app.asar.unpacked/` first, then `Frameworks/*.framework`, then outer `.app` last (nested signatures must be sealed before their containers).

## Tests (7 pass, 3.2s)
1. env unset → skip, runner not called, log line matches `[skip] codesign: CCSM_MAC_IDENTITY not set`.
2. non-darwin platform → skip even with env set.
3. identity set + entitlements missing → warn + skip.
4. real fake `.app` on disk → correct argv per target, depth-first order verified, outer `.app` last, `_CodeSignature/` excluded.
5. `CCSM_MAC_HARDENED_RUNTIME=0` → no `runtime` arg.
6. codesign exit nonzero → throws `codesign failed (exit 1)` with target + argv.
7. `collectSignTargets` on nonexistent path → returns `[bundlePath]` (outer always pushed).

`node --check scripts/sign-macos.cjs` ✓.

## T54 (#1011) coexistence plan
T54 (`scripts/sign-windows.cjs`) was not yet pushed at PR-create time. Both hooks platform-gate inside (`darwin` here, `win32` there) so they're functionally exclusive. Whichever lands second should:
1. Create a tiny dispatcher `scripts/after-sign.cjs` that requires both modules and awaits each (each is a no-op on the wrong platform).
2. Update `package.json` `build.afterSign` to point at the dispatcher.

Either order works; I left `afterSign: scripts/sign-macos.cjs` as the single entry — T54 reviewer can flip the wiring trivially.

## Out of scope (per Layer 1 check)
- Notarization (notarytool / `xcrun stapler staple`) → T56 (#1013) per spec §402.
- Daemon-side codesign (CI workflow `.github/workflows/release.yml` step) → already specified in §11.3.2 as a separate CI step, not an electron-builder hook.

## Test plan
- [x] `vitest run tests/sign-macos.test.ts` — 7 pass
- [x] `node --check scripts/sign-macos.cjs`
- [ ] Real macOS `npm run make:mac` with `CCSM_MAC_IDENTITY` set (gated behind real cert; covered by T56 release dry-run)