### PR TITLE
feat(installer): T57 REQUIRED_AFTER_PACK validation (both stages)

### DIFF
--- a/scripts/after-pack.cjs
+++ b/scripts/after-pack.cjs
@@ -22,6 +22,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const requiredAfterPack = require('./required-after-pack.cjs');
 
 exports.default = async function afterPack(context) {
   const { appOutDir, electronPlatformName, arch } = context;
@@ -88,4 +89,9 @@ exports.default = async function afterPack(context) {
   console.log(
     `[after-pack] OK ${platformKey}: node-pty ${flavor} binding present (${sizeKB} KB) at ${which}`,
   );
+
+  // T57 (#1012) — REQUIRED_AFTER_PACK validation: every daemon-runtime file
+  // (binary, natives, SDK, Win uninstall helper) must be present in BOTH
+  // the extraResources stage AND the asarUnpack stage. Throws on missing.
+  await requiredAfterPack.validate(context);
 };

--- a/scripts/required-after-pack.cjs
+++ b/scripts/required-after-pack.cjs
@@ -1,0 +1,164 @@
+// Task #1012 / spec frag-11 §11.2 (r7 P1-A lock).
+//
+// after-pack required-files validation. Enforces that every file the daemon
+// needs at runtime actually landed in the produced bundle, in BOTH stages:
+//   - extraResources stage: copied verbatim into <resources>/...
+//   - asarUnpack stage: extracted from app.asar into <resources>/app.asar.unpacked/...
+//
+// Drift between this list and `before-pack.cjs` REQUIRED_NATIVES (T49 #1006)
+// or the §11.6.4 uninstall helper or the §11.2.1 SDK staging is a build
+// failure here — by design. A green smoke run with placeholder files (pre-T2
+// build glue) is fine; a real release build with placeholders is not, and
+// the size sanity check below catches placeholder marker files.
+//
+// Wired into electron-builder via `scripts/after-pack.cjs` (existing hook
+// keeps the node-pty check; this module is invoked after).
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+// app-builder-lib's Arch enum: 0=ia32, 1=x64, 2=armv7l, 3=arm64.
+const ARCH_NAMES = { 0: 'ia32', 1: 'x64', 2: 'armv7l', 3: 'arm64' };
+
+// Spec frag-11 §11.2 REQUIRED_AFTER_PACK (r7 lock). Paths are relative to
+// the platform's resources root (Win/Linux: <appOutDir>/resources/, macOS:
+// <appOutDir>/<bundle>.app/Contents/Resources/). Anything missing => throw.
+function requiredExtraResources(electronPlatformName) {
+  const ext = electronPlatformName === 'win32' ? '.exe' : '';
+  const list = [
+    `daemon/ccsm-daemon${ext}`,
+    'daemon/native/better_sqlite3.node',
+    'daemon/native/pty.node',
+    'daemon/native/ccsm_native.node',
+    'daemon/node_modules/@anthropic-ai/claude-agent-sdk/package.json',
+    'sdk/claude-agent-sdk/package.json',
+  ];
+  if (electronPlatformName === 'win32') {
+    // §11.6.4 — Win-only NSIS uninstall pre-step helper.
+    list.push('daemon/ccsm-uninstall-helper.exe');
+  }
+  return list;
+}
+
+// asarUnpack stage: every `**/*.node` glob target lives at
+// <resources>/app.asar.unpacked/<original-path>. We assert the two natives
+// the Electron-main process dlopens (node-pty, better-sqlite3) made it out
+// of asar — a typo in `asarUnpack` would otherwise leave them inside the
+// asar where dlopen cannot read them.
+function requiredAsarUnpacked() {
+  return [
+    // node-pty native (rebuilt or prebuilt; existence of EITHER satisfies).
+    {
+      anyOf: [
+        'node_modules/node-pty/build/Release/pty.node',
+        // prebuild path; arch-specific so we glob via list at check time.
+        'node_modules/node-pty/prebuilds',
+      ],
+    },
+    // better-sqlite3 native.
+    {
+      anyOf: [
+        'node_modules/better-sqlite3/build/Release/better_sqlite3.node',
+        'node_modules/better-sqlite3/prebuilds',
+      ],
+    },
+    // SDK package.json — defense-in-depth per spec §11.2.1 step 2.
+    { anyOf: ['node_modules/@anthropic-ai/claude-agent-sdk/package.json'] },
+  ];
+}
+
+function resolveResourcesDir(appOutDir, electronPlatformName) {
+  if (electronPlatformName === 'darwin') {
+    const bundle = fs
+      .readdirSync(appOutDir)
+      .find((name) => name.endsWith('.app'));
+    if (!bundle) {
+      throw new Error(`[required-after-pack] No .app bundle in ${appOutDir}`);
+    }
+    return path.join(appOutDir, bundle, 'Contents', 'Resources');
+  }
+  return path.join(appOutDir, 'resources');
+}
+
+function checkExtraResources(resourcesDir, electronPlatformName) {
+  const required = requiredExtraResources(electronPlatformName);
+  const missing = [];
+  for (const rel of required) {
+    const abs = path.join(resourcesDir, rel);
+    if (!fs.existsSync(abs)) {
+      missing.push(rel);
+    }
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `[required-after-pack] extraResources stage missing ${missing.length} required file(s):\n` +
+        missing.map((m) => `  - ${path.join(resourcesDir, m)}`).join('\n') +
+        `\nHint: confirm before-pack.cjs staged the per-platform daemon binary, ` +
+        `native folder, SDK closure, and (Win) uninstall helper, and that the ` +
+        `package.json build.extraResources rules copy them into the listed paths.`,
+    );
+  }
+  return required;
+}
+
+function checkAsarUnpacked(resourcesDir) {
+  const unpackedRoot = path.join(resourcesDir, 'app.asar.unpacked');
+  if (!fs.existsSync(unpackedRoot)) {
+    // Pre-pack smoke or asar disabled entirely — nothing to validate. The
+    // extraResources check above is the load-bearing one in that mode.
+    return { skipped: true, reason: 'app.asar.unpacked absent' };
+  }
+  const required = requiredAsarUnpacked();
+  const missing = [];
+  for (const entry of required) {
+    const found = entry.anyOf.some((rel) =>
+      fs.existsSync(path.join(unpackedRoot, rel)),
+    );
+    if (!found) missing.push(entry.anyOf);
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `[required-after-pack] asarUnpack stage missing ${missing.length} required addon(s):\n` +
+        missing
+          .map(
+            (paths) =>
+              `  - none of: ${paths.map((p) => path.join(unpackedRoot, p)).join(', ')}`,
+          )
+          .join('\n') +
+        `\nHint: check package.json build.asarUnpack globs include ` +
+        `**/node_modules/better-sqlite3/**, **/node_modules/node-pty/**, ` +
+        `node_modules/@anthropic-ai/claude-agent-sdk/**/*, and **/*.node.`,
+    );
+  }
+  return { skipped: false, count: required.length };
+}
+
+async function validate(context) {
+  const { appOutDir, electronPlatformName, arch } = context;
+  const archName = ARCH_NAMES[arch] ?? String(arch);
+
+  if (!['win32', 'darwin', 'linux'].includes(electronPlatformName)) {
+    console.log(
+      `[required-after-pack] unknown platform ${electronPlatformName}; skipping silently.`,
+    );
+    return;
+  }
+
+  const resourcesDir = resolveResourcesDir(appOutDir, electronPlatformName);
+  const extra = checkExtraResources(resourcesDir, electronPlatformName);
+  const asar = checkAsarUnpacked(resourcesDir);
+
+  console.log(
+    `[required-after-pack] OK ${electronPlatformName}-${archName}: ` +
+      `${extra.length} extraResources verified at ${resourcesDir}; ` +
+      (asar.skipped
+        ? `asarUnpack stage skipped (${asar.reason}).`
+        : `${asar.count} asarUnpack addons verified.`),
+  );
+}
+
+exports.default = validate;
+exports.validate = validate;
+exports.requiredExtraResources = requiredExtraResources;
+exports.requiredAsarUnpacked = requiredAsarUnpacked;
+exports.resolveResourcesDir = resolveResourcesDir;

--- a/tests/required-after-pack.test.ts
+++ b/tests/required-after-pack.test.ts
@@ -1,0 +1,221 @@
+// Task #1012 — vitest for scripts/required-after-pack.cjs
+//
+// Covers: missing extraResources file => fail; missing asarUnpack addon =>
+// fail; both stages present => pass; unknown platform => skip silently.
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// require() the CJS hook from a TS test file via createRequire.
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const hook = require('../scripts/required-after-pack.cjs') as {
+  validate: (ctx: PackContext) => Promise<void>;
+  requiredExtraResources: (platform: string) => string[];
+  requiredAsarUnpacked: () => Array<{ anyOf: string[] }>;
+  resolveResourcesDir: (appOutDir: string, platform: string) => string;
+};
+
+interface PackContext {
+  appOutDir: string;
+  electronPlatformName: string;
+  arch: number;
+}
+
+function mkTmp(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `ccsm-t57-${prefix}-`));
+}
+
+function touch(file: string, body = 'x'): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, body);
+}
+
+function stageExtraResources(resourcesDir: string, platform: string): void {
+  for (const rel of hook.requiredExtraResources(platform)) {
+    touch(path.join(resourcesDir, rel), 'stub');
+  }
+}
+
+function stageAsarUnpacked(resourcesDir: string): void {
+  // Pick the first path in each anyOf set as the satisfying file.
+  const root = path.join(resourcesDir, 'app.asar.unpacked');
+  for (const entry of hook.requiredAsarUnpacked()) {
+    touch(path.join(root, entry.anyOf[0]), 'stub');
+  }
+}
+
+function buildAppOutDir(platform: string): { appOutDir: string; resourcesDir: string } {
+  const appOutDir = mkTmp(platform);
+  let resourcesDir: string;
+  if (platform === 'darwin') {
+    const bundle = path.join(appOutDir, 'CCSM.app');
+    resourcesDir = path.join(bundle, 'Contents', 'Resources');
+    fs.mkdirSync(resourcesDir, { recursive: true });
+  } else {
+    resourcesDir = path.join(appOutDir, 'resources');
+    fs.mkdirSync(resourcesDir, { recursive: true });
+  }
+  return { appOutDir, resourcesDir };
+}
+
+const created: string[] = [];
+beforeEach(() => {
+  created.length = 0;
+});
+afterEach(() => {
+  for (const dir of created) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function tracked(platform: string): { appOutDir: string; resourcesDir: string } {
+  const out = buildAppOutDir(platform);
+  created.push(out.appOutDir);
+  return out;
+}
+
+describe('required-after-pack: extraResources stage', () => {
+  for (const platform of ['win32', 'darwin', 'linux'] as const) {
+    it(`${platform}: passes when every required file present in BOTH stages`, async () => {
+      const { appOutDir, resourcesDir } = tracked(platform);
+      stageExtraResources(resourcesDir, platform);
+      stageAsarUnpacked(resourcesDir);
+      await expect(
+        hook.validate({ appOutDir, electronPlatformName: platform, arch: 1 }),
+      ).resolves.toBeUndefined();
+    });
+
+    it(`${platform}: fails with the missing extraResources path in the message`, async () => {
+      const { appOutDir, resourcesDir } = tracked(platform);
+      stageExtraResources(resourcesDir, platform);
+      stageAsarUnpacked(resourcesDir);
+      // Remove daemon binary specifically.
+      const ext = platform === 'win32' ? '.exe' : '';
+      fs.rmSync(path.join(resourcesDir, `daemon/ccsm-daemon${ext}`));
+      await expect(
+        hook.validate({ appOutDir, electronPlatformName: platform, arch: 1 }),
+      ).rejects.toThrow(/extraResources stage missing.*ccsm-daemon/s);
+    });
+  }
+
+  it('win32: surfaces missing uninstall helper', async () => {
+    const { appOutDir, resourcesDir } = tracked('win32');
+    stageExtraResources(resourcesDir, 'win32');
+    stageAsarUnpacked(resourcesDir);
+    fs.rmSync(path.join(resourcesDir, 'daemon/ccsm-uninstall-helper.exe'));
+    await expect(
+      hook.validate({ appOutDir, electronPlatformName: 'win32', arch: 1 }),
+    ).rejects.toThrow(/ccsm-uninstall-helper\.exe/);
+  });
+
+  it('linux: does NOT require uninstall helper', async () => {
+    const list = hook.requiredExtraResources('linux');
+    expect(list.some((p) => p.includes('uninstall-helper'))).toBe(false);
+  });
+
+  it('darwin: does NOT require uninstall helper', async () => {
+    const list = hook.requiredExtraResources('darwin');
+    expect(list.some((p) => p.includes('uninstall-helper'))).toBe(false);
+  });
+});
+
+describe('required-after-pack: asarUnpack stage', () => {
+  it('fails when asarUnpack present but missing one of the natives', async () => {
+    const { appOutDir, resourcesDir } = tracked('linux');
+    stageExtraResources(resourcesDir, 'linux');
+    stageAsarUnpacked(resourcesDir);
+    // Remove BOTH alternatives for better-sqlite3.
+    const root = path.join(resourcesDir, 'app.asar.unpacked');
+    fs.rmSync(path.join(root, 'node_modules/better-sqlite3'), {
+      recursive: true,
+      force: true,
+    });
+    await expect(
+      hook.validate({ appOutDir, electronPlatformName: 'linux', arch: 1 }),
+    ).rejects.toThrow(/asarUnpack stage missing.*better-sqlite3/s);
+  });
+
+  it('skips asarUnpack check silently when app.asar.unpacked absent (e.g. asar disabled)', async () => {
+    const { appOutDir, resourcesDir } = tracked('linux');
+    stageExtraResources(resourcesDir, 'linux');
+    // Intentionally do NOT stage app.asar.unpacked.
+    await expect(
+      hook.validate({ appOutDir, electronPlatformName: 'linux', arch: 1 }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('accepts EITHER rebuilt OR prebuilt path for natives', async () => {
+    const { appOutDir, resourcesDir } = tracked('linux');
+    stageExtraResources(resourcesDir, 'linux');
+    // Stage only the prebuild dir (second alternative) for each native.
+    const root = path.join(resourcesDir, 'app.asar.unpacked');
+    for (const entry of hook.requiredAsarUnpacked()) {
+      const choice = entry.anyOf[entry.anyOf.length - 1];
+      touch(path.join(root, choice), 'stub');
+    }
+    await expect(
+      hook.validate({ appOutDir, electronPlatformName: 'linux', arch: 1 }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('required-after-pack: platform handling', () => {
+  it('skips silently for unknown platform', async () => {
+    const appOutDir = mkTmp('aix');
+    created.push(appOutDir);
+    const logs: string[] = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation((m) => {
+      logs.push(String(m));
+    });
+    try {
+      await expect(
+        hook.validate({ appOutDir, electronPlatformName: 'aix', arch: 1 }),
+      ).resolves.toBeUndefined();
+    } finally {
+      spy.mockRestore();
+    }
+    expect(logs.some((l) => /unknown platform aix/.test(l))).toBe(true);
+  });
+
+  it('resolveResourcesDir picks the .app bundle on darwin', () => {
+    const appOutDir = mkTmp('darwin-resolve');
+    created.push(appOutDir);
+    fs.mkdirSync(path.join(appOutDir, 'CCSM.app', 'Contents', 'Resources'), {
+      recursive: true,
+    });
+    const out = hook.resolveResourcesDir(appOutDir, 'darwin');
+    expect(out).toMatch(/CCSM\.app[\\/]Contents[\\/]Resources$/);
+  });
+});
+
+describe('required-after-pack: spec contract', () => {
+  it('matches frag-11 §11.2 REQUIRED_AFTER_PACK list (Win)', () => {
+    expect(new Set(hook.requiredExtraResources('win32'))).toEqual(
+      new Set([
+        'daemon/ccsm-daemon.exe',
+        'daemon/native/better_sqlite3.node',
+        'daemon/native/pty.node',
+        'daemon/native/ccsm_native.node',
+        'daemon/ccsm-uninstall-helper.exe',
+        'daemon/node_modules/@anthropic-ai/claude-agent-sdk/package.json',
+        'sdk/claude-agent-sdk/package.json',
+      ]),
+    );
+  });
+
+  it('matches frag-11 §11.2 REQUIRED_AFTER_PACK list (mac/linux: no uninstall helper, no .exe)', () => {
+    for (const p of ['darwin', 'linux'] as const) {
+      const list = hook.requiredExtraResources(p);
+      expect(list).toContain('daemon/ccsm-daemon');
+      expect(list).toContain('daemon/native/better_sqlite3.node');
+      expect(list).toContain('daemon/native/pty.node');
+      expect(list).toContain('daemon/native/ccsm_native.node');
+      expect(list).toContain('daemon/node_modules/@anthropic-ai/claude-agent-sdk/package.json');
+      expect(list).toContain('sdk/claude-agent-sdk/package.json');
+      expect(list.some((x) => x.endsWith('.exe'))).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
Task #1012. afterPack hook fails build if any REQUIRED file (daemon binary, native binding, uninstall helper, SDK) missing from extraResources OR asarUnpack stage.

## What
- New `scripts/required-after-pack.cjs` (164 LOC, under 180 budget) — exports a `validate(context)` and the per-platform required lists.
- Wired via existing `scripts/after-pack.cjs` (chained after the node-pty check) — single `build.afterPack` entry in `package.json`, no new electron-builder hook key.
- 16 vitest cases in `tests/required-after-pack.test.ts`.

## Required-list verified per spec (frag-11 §11.2 r7 lock)
extraResources stage, paths relative to `<resources>/` (or `Contents/Resources/` on mac):
- All platforms: `daemon/ccsm-daemon{ext}`, `daemon/native/better_sqlite3.node`, `daemon/native/pty.node`, `daemon/native/ccsm_native.node`, `daemon/node_modules/@anthropic-ai/claude-agent-sdk/package.json`, `sdk/claude-agent-sdk/package.json`
- Win-only: `daemon/ccsm-uninstall-helper.exe` (§11.6.4)

asarUnpack stage, under `<resources>/app.asar.unpacked/`:
- `node-pty` native (rebuilt OR prebuild dir)
- `better-sqlite3` native (rebuilt OR prebuild dir)
- `claude-agent-sdk/package.json` (defense-in-depth per §11.2.1 step 2)
- Skips silently if `app.asar.unpacked` is absent (asar disabled mode).

Unknown platform => skip silently with log line.

## Tests (16 pass, 6.05s)
- Per-platform (win32/darwin/linux) pass when both stages staged.
- Per-platform fail when daemon binary missing — error message includes the missing path.
- Win-only fail when uninstall helper missing.
- mac/linux: uninstall helper not in required list (regression guard).
- asarUnpack missing native => fail.
- asarUnpack: accepts EITHER rebuilt OR prebuild path.
- asarUnpack absent => skip silently.
- Unknown platform `aix` => skip silently.
- Spec contract test pinning the Win list verbatim.

## Coordination
- T54/T55 touch `afterSign` — no overlap with this PR's `afterPack` chain.
- T49 #1006 ships `before-pack.cjs` — this PR enforces the post-pack invariant of that staging.