### PR TITLE
fix(electron): dev electron should skip single-instance lock when unpackaged

### DIFF
--- a/electron/lifecycle/__tests__/singleInstance.test.ts
+++ b/electron/lifecycle/__tests__/singleInstance.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect, vi } from 'vitest';
 
 // Mock electron — singleInstance.ts top-level imports `app` and `BrowserWindow`,
 // which triggers "Electron failed to install correctly" on the lint+test runner
-// (no electron binary available on CI).
-vi.mock('electron', () => ({}));
+// (no electron binary available on CI). Default to packaged so the dev-mode
+// branch is inert; individual tests override via vi.doMock if they need
+// app.isPackaged === false behavior.
+vi.mock('electron', () => ({ app: { isPackaged: true } }));
 
 import { shouldSkipSingleInstanceLock } from '../singleInstance';
 
@@ -22,7 +24,7 @@ describe('shouldSkipSingleInstanceLock', () => {
     ).toBe(true);
   });
 
-  it('does NOT skip in production env (no opt-out vars)', () => {
+  it('does NOT skip in production env (no opt-out vars, packaged)', () => {
     expect(shouldSkipSingleInstanceLock({} as NodeJS.ProcessEnv)).toBe(false);
   });
 
@@ -33,5 +35,16 @@ describe('shouldSkipSingleInstanceLock', () => {
         CCSM_E2E_NO_SINGLE_INSTANCE: 'false',
       } as NodeJS.ProcessEnv),
     ).toBe(false);
+  });
+
+  it('skips when app is unpackaged (dev mode via `npm run dev`)', async () => {
+    // Reset module + re-mock electron with isPackaged: false to simulate dev.
+    vi.resetModules();
+    vi.doMock('electron', () => ({ app: { isPackaged: false } }));
+    const { shouldSkipSingleInstanceLock: devFn } = await import(
+      '../singleInstance'
+    );
+    expect(devFn({} as NodeJS.ProcessEnv)).toBe(true);
+    vi.doUnmock('electron');
   });
 });

--- a/electron/lifecycle/singleInstance.ts
+++ b/electron/lifecycle/singleInstance.ts
@@ -14,12 +14,29 @@
 
 import { app, BrowserWindow } from 'electron';
 
-/** Returns true iff the env opts out of the lock (E2E probes). Pure
- *  helper — exported for unit tests. */
-export function shouldSkipSingleInstanceLock(env: NodeJS.ProcessEnv): boolean {
-  return (
-    env.CCSM_E2E_HIDDEN === '1' || env.CCSM_E2E_NO_SINGLE_INSTANCE === '1'
-  );
+/** Returns true iff we should opt out of the lock. Pure helper — exported
+ *  for unit tests.
+ *
+ *  Skips when:
+ *  - E2E env vars are set (probes spawn the app multiple times in parallel)
+ *  - The current electron is unpackaged (dev mode via `npm run dev`). This
+ *    prevents the dev electron from silently exiting when the user's
+ *    installed (packaged) CCSM.exe is also running and already holds the
+ *    global single-instance lock. Production (packaged) builds keep the
+ *    lock so double-clicking the desktop icon doesn't spawn duplicates. */
+export function shouldSkipSingleInstanceLock(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (env.CCSM_E2E_HIDDEN === '1') return true;
+  if (env.CCSM_E2E_NO_SINGLE_INSTANCE === '1') return true;
+  // Dev mode: skip lock so `npm run dev` doesn't lose the contest when the
+  // user's installed (packaged) CCSM is also running.
+  try {
+    if (app && app.isPackaged === false) return true;
+  } catch {
+    // app may be unavailable in unit tests — treat as packaged (don't skip).
+  }
+  return false;
 }
 
 /** Acquire the single-instance lock + register the second-instance focus


### PR DESCRIPTION
Closes blocker for Task #1065 (and unblocks v0.2 README screenshot work in #1061).

## Bug
When the user's installed CCSM.exe (packaged) is running and they launch \`npm run dev\`, the dev electron loses the single-instance lock contest and silently exits via \`app.quit() + process.exit(0)\`. No window appears, no error logged.

## Fix
\`shouldSkipSingleInstanceLock\` now also returns \`true\` when \`!app.isPackaged\` (dev mode). Production (packaged) behavior is unchanged — desktop double-click still de-duplicates correctly.

## Files changed
- \`electron/lifecycle/singleInstance.ts\` — add \`!app.isPackaged\` skip branch (try/catch around \`app\` access for unit-test safety).
- \`electron/lifecycle/__tests__/singleInstance.test.ts\` — default mock \`app.isPackaged: true\`; new test covers unpackaged → skip via \`vi.resetModules + vi.doMock\`.

## Verification
- \`npx vitest run electron/lifecycle/__tests__/singleInstance.test.ts\` → 5/5 passed.
- \`npx tsc --noEmit -p tsconfig.electron.json\` → clean.

Diagnosed by the debug worker for #1065.