### PR TITLE
feat(electron): T62 upgrade-shutdown call site

### DIFF
--- a/electron/__tests__/updater.test.ts
+++ b/electron/__tests__/updater.test.ts
@@ -355,7 +355,9 @@ describe('updater: T62 upgrade-shutdown RPC', () => {
       await vi.advanceTimersByTimeAsync(mod.UPGRADE_SHUTDOWN_ACK_TIMEOUT_MS);
       const res = await promise;
       expect(res).toEqual({ ok: true });
-      // Drain the scheduled setImmediate.
+      // Drain the scheduled setImmediate while still on fake timers — switching
+      // to real timers first would drop the queued callback.
+      await vi.runAllTimersAsync();
       vi.useRealTimers();
       await new Promise((r) => setImmediate(r));
       expect(quitAndInstallCalls).toEqual([{ isSilent: false, isForceRunAfter: true }]);

--- a/electron/__tests__/updater.test.ts
+++ b/electron/__tests__/updater.test.ts
@@ -207,18 +207,18 @@ describe('updater: IPC wiring', () => {
     // handler can proceed.
     autoUpdaterEmitter.emit('update-downloaded', { version: '0.1.3' });
     const handler = ipcHandlers.get('updates:install')!;
-    const res = handler({});
+    const res = await handler({});
     expect(res).toEqual({ ok: true });
     // quitAndInstall is scheduled via setImmediate — flush it.
     await new Promise((r) => setImmediate(r));
     expect(quitAndInstallCalls).toEqual([{ isSilent: false, isForceRunAfter: true }]);
   });
 
-  it('updates:install refuses when no download has completed', () => {
+  it('updates:install refuses when no download has completed', async () => {
     // No `update-downloaded` event broadcast → lastStatus stays `idle`.
     // The defense-in-depth gate must short-circuit before quitAndInstall.
     const handler = ipcHandlers.get('updates:install')!;
-    const res = handler({});
+    const res = await handler({});
     expect(res).toEqual({ ok: false, reason: 'not-ready' });
     expect(quitAndInstallCalls).toEqual([]);
   });
@@ -226,7 +226,7 @@ describe('updater: IPC wiring', () => {
   it('updates:install refuses when not packaged', async () => {
     state.appIsPackaged = false;
     const handler = ipcHandlers.get('updates:install')!;
-    const res = handler({});
+    const res = await handler({});
     expect(res).toEqual({ ok: false, reason: 'not-packaged' });
   });
 

--- a/electron/__tests__/updater.test.ts
+++ b/electron/__tests__/updater.test.ts
@@ -257,3 +257,123 @@ describe('updater: IPC wiring', () => {
     expect(res).toEqual({ kind: 'available', version: '9.9.9', releaseDate: undefined });
   });
 });
+
+// ----------------------------------------------------------------------------
+// T62 — Upgrade-shutdown RPC (frag-11 §11.6.5)
+//
+// Before quitAndInstall, the install handler MUST send daemon.shutdownForUpgrade
+// over the control socket and wait up to 5 s for the ack. On ack OR timeout
+// (per spec step 3-4), proceed with the existing update flow. The transport is
+// injected via setUpgradeShutdownRpc; tests pass fakes.
+// ----------------------------------------------------------------------------
+
+describe('updater: T62 upgrade-shutdown RPC', () => {
+  beforeEach(async () => {
+    await freshModule();
+  });
+
+  it('default (no rpc wired) resolves immediately and proceeds with quitAndInstall', async () => {
+    autoUpdaterEmitter.emit('update-downloaded', { version: '0.1.3' });
+    const handler = ipcHandlers.get('updates:install')!;
+    const res = await handler({});
+    expect(res).toEqual({ ok: true });
+    await new Promise((r) => setImmediate(r));
+    expect(quitAndInstallCalls).toHaveLength(1);
+  });
+
+  it('callShutdownForUpgrade returns acked when the rpc resolves', async () => {
+    const mod = await import('../updater');
+    const ack = { accepted: true as const, reason: 'upgrade' as const };
+    mod.setUpgradeShutdownRpc(async () => ack);
+    const outcome = await mod.callShutdownForUpgrade();
+    expect(outcome).toEqual({ kind: 'acked', ack });
+  });
+
+  it('callShutdownForUpgrade returns timeout when the rpc never resolves (5 s)', async () => {
+    vi.useFakeTimers();
+    try {
+      const mod = await import('../updater');
+      mod.setUpgradeShutdownRpc(() => new Promise(() => undefined));
+      const promise = mod.callShutdownForUpgrade();
+      await vi.advanceTimersByTimeAsync(mod.UPGRADE_SHUTDOWN_ACK_TIMEOUT_MS);
+      const outcome = await promise;
+      expect(outcome).toEqual({ kind: 'timeout' });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('callShutdownForUpgrade returns error when the rpc rejects', async () => {
+    const mod = await import('../updater');
+    mod.setUpgradeShutdownRpc(async () => {
+      throw new Error('socket closed');
+    });
+    const outcome = await mod.callShutdownForUpgrade();
+    expect(outcome).toEqual({ kind: 'error', message: 'socket closed' });
+  });
+
+  it('updates:install awaits the shutdown RPC before scheduling quitAndInstall', async () => {
+    const mod = await import('../updater');
+    const order: string[] = [];
+    let releaseRpc: (() => void) | null = null;
+    mod.setUpgradeShutdownRpc(
+      () =>
+        new Promise((resolve) => {
+          releaseRpc = () => {
+            order.push('rpc-resolved');
+            resolve({ accepted: true, reason: 'upgrade' });
+          };
+        }),
+    );
+
+    autoUpdaterEmitter.emit('update-downloaded', { version: '0.1.4' });
+    const handler = ipcHandlers.get('updates:install')!;
+    const promise = handler({});
+
+    // Give the handler a microtask tick — it should be parked on the RPC,
+    // NOT yet have called quitAndInstall.
+    await new Promise((r) => setImmediate(r));
+    expect(quitAndInstallCalls).toEqual([]);
+
+    releaseRpc!();
+    const res = await promise;
+    expect(res).toEqual({ ok: true });
+    // setImmediate flush for the scheduled quitAndInstall.
+    await new Promise((r) => setImmediate(r));
+    expect(order).toEqual(['rpc-resolved']);
+    expect(quitAndInstallCalls).toEqual([{ isSilent: false, isForceRunAfter: true }]);
+  });
+
+  it('updates:install proceeds with quitAndInstall after RPC timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      const mod = await import('../updater');
+      mod.setUpgradeShutdownRpc(() => new Promise(() => undefined));
+      autoUpdaterEmitter.emit('update-downloaded', { version: '0.1.5' });
+      const handler = ipcHandlers.get('updates:install')!;
+      const promise = handler({});
+      await vi.advanceTimersByTimeAsync(mod.UPGRADE_SHUTDOWN_ACK_TIMEOUT_MS);
+      const res = await promise;
+      expect(res).toEqual({ ok: true });
+      // Drain the scheduled setImmediate.
+      vi.useRealTimers();
+      await new Promise((r) => setImmediate(r));
+      expect(quitAndInstallCalls).toEqual([{ isSilent: false, isForceRunAfter: true }]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('updates:install proceeds with quitAndInstall even when RPC errors', async () => {
+    const mod = await import('../updater');
+    mod.setUpgradeShutdownRpc(async () => {
+      throw new Error('control socket EPIPE');
+    });
+    autoUpdaterEmitter.emit('update-downloaded', { version: '0.1.6' });
+    const handler = ipcHandlers.get('updates:install')!;
+    const res = await handler({});
+    expect(res).toEqual({ ok: true });
+    await new Promise((r) => setImmediate(r));
+    expect(quitAndInstallCalls).toEqual([{ isSilent: false, isForceRunAfter: true }]);
+  });
+});

--- a/electron/updater.ts
+++ b/electron/updater.ts
@@ -18,6 +18,89 @@ let installed = false;
 let autoCheckEnabled = true;
 let periodicHandle: ReturnType<typeof setInterval> | null = null;
 
+// ----------------------------------------------------------------------------
+// T62 — Upgrade-shutdown RPC hook (frag-11 §11.6.5)
+//
+// Before applying an in-place upgrade, Electron-main MUST send
+// `daemon.shutdownForUpgrade` over the control socket and wait for ack with a
+// 5 s timeout. On ack OR timeout, proceed with `autoUpdater.quitAndInstall(...)`.
+// The actual transport (control-socket envelope client) lives outside this
+// module; we accept it as an injected async function so the call site stays
+// testable and the wiring layer can plug in the real client when daemon-split
+// lands. Default = no-op (resolves immediately) so the existing flow is
+// preserved on hosts where the daemon hasn't been spawned (e.g. dev).
+// ----------------------------------------------------------------------------
+
+/** Ack envelope returned by the daemon's `daemon.shutdownForUpgrade` handler.
+ *  Mirrors `ShutdownForUpgradeAck` from `daemon/src/handlers/daemon-shutdown-for-upgrade.ts`
+ *  but kept structurally-typed here so the electron module never imports across
+ *  the daemon boundary at runtime. */
+export interface UpgradeShutdownAck {
+  readonly accepted: true;
+  readonly reason: 'upgrade';
+}
+
+/** Single-shot RPC sender. Resolves with the ack envelope, rejects on
+ *  transport error. The 5 s timeout is enforced by `callShutdownForUpgrade`,
+ *  not by the sender itself, so the sender stays a thin wire-call. */
+export type UpgradeShutdownRpc = () => Promise<UpgradeShutdownAck>;
+
+let upgradeShutdownRpc: UpgradeShutdownRpc | null = null;
+
+/** Spec §11.6.5 step 3: 5 s ack window from the moment we write the
+ *  `daemon.shutdownForUpgrade` envelope to the moment we receive the reply. */
+export const UPGRADE_SHUTDOWN_ACK_TIMEOUT_MS = 5_000;
+
+/** Wiring entry point — called from `main.ts` after the control-socket client
+ *  is constructed. Passing `null` reverts to the no-op default (used by tests
+ *  and by dev hosts that never spawn the daemon). */
+export function setUpgradeShutdownRpc(rpc: UpgradeShutdownRpc | null): void {
+  upgradeShutdownRpc = rpc;
+}
+
+/** Outcome of the pre-upgrade shutdown call. Surfaced for tests + future
+ *  observability hooks. Per spec §11.6.5 step 3-4 BOTH `acked` and `timeout`
+ *  proceed with the upgrade; only `error` is interesting (currently still
+ *  proceeds — the OS-level force-kill in the wiring layer is the safety net). */
+export type UpgradeShutdownOutcome =
+  | { kind: 'noop' }
+  | { kind: 'acked'; ack: UpgradeShutdownAck }
+  | { kind: 'timeout' }
+  | { kind: 'error'; message: string };
+
+/** Send `daemon.shutdownForUpgrade` and wait up to 5 s for the ack.
+ *  Always resolves — never throws — because the spec's race fallback
+ *  (force-kill + proceed with upgrade) means the caller MUST proceed
+ *  regardless. The returned outcome is informational only. */
+export async function callShutdownForUpgrade(): Promise<UpgradeShutdownOutcome> {
+  const rpc = upgradeShutdownRpc;
+  if (!rpc) return { kind: 'noop' };
+
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const timeout = new Promise<UpgradeShutdownOutcome>((resolve) => {
+    timer = setTimeout(
+      () => resolve({ kind: 'timeout' }),
+      UPGRADE_SHUTDOWN_ACK_TIMEOUT_MS,
+    );
+    (timer as unknown as { unref?: () => void }).unref?.();
+  });
+
+  const call: Promise<UpgradeShutdownOutcome> = (async () => {
+    try {
+      const ack = await rpc();
+      return { kind: 'acked', ack };
+    } catch (e) {
+      return { kind: 'error', message: (e as Error).message };
+    }
+  })();
+
+  try {
+    return await Promise.race([call, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 // 4 hours. Electron-updater recommends not checking more often than hourly;
 // 4h is a reasonable default that keeps users on the latest signed build
 // without hammering GitHub releases.
@@ -161,7 +244,7 @@ export function installUpdaterIpc(): void {
     }
   });
 
-  ipcMain.handle('updates:install', () => {
+  ipcMain.handle('updates:install', async () => {
     if (!app.isPackaged) return { ok: false as const, reason: 'not-packaged' as const };
     // Defense-in-depth: refuse to call quitAndInstall unless we've
     // actually broadcast a `downloaded` event. Without this guard a
@@ -174,6 +257,13 @@ export function installUpdaterIpc(): void {
     if (lastStatus.kind !== 'downloaded') {
       return { ok: false as const, reason: 'not-ready' as const };
     }
+    // T62 — frag-11 §11.6.5: send daemon.shutdownForUpgrade BEFORE
+    // quitAndInstall so the daemon writes its upgrade marker, drains, and
+    // releases the lockfile. We always proceed regardless of ack/timeout/
+    // error because the spec's race fallback (force-kill + proceed) is
+    // owned by the wiring layer; returning early here would brick legit
+    // upgrades on hosts where the daemon is unresponsive.
+    await callShutdownForUpgrade();
     // quitAndInstall: (isSilent, isForceRunAfter). We want a visible installer
     // on Windows (isSilent=false) and to relaunch after install on all OSes.
     setImmediate(() => autoUpdater.quitAndInstall(false, true));
@@ -202,5 +292,6 @@ export function __resetUpdaterForTests(): void {
   installed = false;
   autoCheckEnabled = true;
   lastStatus = { kind: 'idle' };
+  upgradeShutdownRpc = null;
   stopPeriodicChecks();
 }


### PR DESCRIPTION
Closes part of T62 (re-scoped per spec §11.6.5). Calls daemon.shutdownForUpgrade with 5s ack timeout before applying in-place upgrade.