### PR TITLE
fix(spec/v0.4-web): 11 references — fold R6 P0/P1

### DIFF
--- a/docs/superpowers/specs/v0.4-web-chapters/11-references.md
+++ b/docs/superpowers/specs/v0.4-web-chapters/11-references.md
@@ -32,7 +32,7 @@ This spec stands on top of v0.3's daemon-split work and the predecessor all-in-o
 | Path | What it provides | v0.4 impact |
 |---|---|---|
 | `daemon/src/index.ts` | Daemon entry point | M1: bind Connect HTTP/2 server alongside envelope on data socket |
-| `daemon/src/sockets/data-socket.ts` | Data-socket transport (T15) | M1-M2: Connect server replaces envelope handlers |
+| `daemon/src/sockets/data-socket.ts` | Data-socket transport (hosts the round-2 security pre-accept rate cap labelled "T15" in `v0.3-design.md` §3.4.1.a) | M1-M2: Connect server replaces envelope handlers; pre-accept rate cap stays on the listener boundary |
 | `daemon/src/sockets/runtime-root.ts` | Listener selection / transport tagging | M4: tag local vs. remote requests for JWT bypass |
 | `daemon/src/dispatcher.ts` | RPC method router (control socket) | Unchanged in v0.4 (control socket stays envelope) |
 | `daemon/src/handlers/healthz.ts` | `/healthz` handler | Unchanged (control socket) |


### PR DESCRIPTION
## Summary

Stage-3 fix for chapter 11 (References) of the v0.4-web spec, folding R6 (Naming / consistency / clarity) P0/P1 findings inline.

## Findings dispositions

| Finding | Severity | Action |
|---|---|---|
| R6 P1-1 ("(T15)" opaque in §2 row) | P1 | Folded |
| R6 P2-1 (mapping `v0.3 §X.Y.Z` <-> `frag-*` not stated) | P2 | Skipped (stage-3 P0/P1 only) |
| R6 P2-2 (bare URL formatting) | P2 | Skipped |

Counts: P0 folded = 0, P1 folded = 1, P2 skipped = 2, rebuttals = 0.

## P1-1 fold detail

Reviewer flagged "(T15)" in the `daemon/src/sockets/data-socket.ts` row of §2 as an opaque label with no glossary anchor. Investigation: T15 is not a v0.3 plan-task ID; it is the round-2 security finding "pre-accept rate cap" documented in `v0.3-design.md` §3.4.1.a and `v0.3-fragments/frag-3.4.1-envelope-hardening.md` §3.4.1.a (`MAX_ACCEPT_PER_SEC = 50`).

Rewrote the row to expand the label inline and cite the v0.3 source section, so chapter 11 readers can resolve it without external context.

## Cross-file note

R6 P1-1 bundles with chapter 02's "after T14" finding (R6 P1-2 in `02-protocol.R6.review.r1.md`). That sibling delta is left for the chapter-02 fixer per stage-3 cross-file rules.

## Test plan

- [x] Markdown only; no build/test impact
- [x] Reviewer `.review.r1.md` files left in place
- [x] No other chapter files touched