### PR TITLE
fix(spec/v0.4-web): 10 risks — fold R2/R3/R4 P0/P1

### DIFF
--- a/docs/superpowers/specs/v0.4-web-chapters/10-risks.md
+++ b/docs/superpowers/specs/v0.4-web-chapters/10-risks.md
@@ -60,19 +60,56 @@ v0.4 introduces a published wire surface, a new client (web), and a third-party 
 
 ### R5. xterm-headless memory caps under many idle sessions
 
-**What:** v0.3 sets default xterm-headless scrollback to 10k lines per session. With N sessions live and full scrollback, memory grows. Web client adds another subscriber to each session's fanout buffer (per-subscriber 1 MiB cap; chapter 06 §7).
+**What:** v0.3 sets default xterm-headless scrollback to 10k lines per session. With N sessions live and full scrollback, memory grows. Web client adds another subscriber to each session's fanout buffer (per-subscriber 1 MiB cap; chapter 06 §7). Multi-client amplifier: each subscriber adds 1 MiB cap × N streams × M sessions to the daemon's working set; a second web client doubles the per-session buffer footprint.
 
-**Trigger:** long-running daemon (>1 week) with 20+ sessions reports >2 GB resident memory.
+**Trigger:** RSS > 500 MB after 7 days with realistic single-user load (5+ sessions, 1-2 web clients) warrants investigation. Hard fail at RSS > 1.5 GB after 7 days under typical usage (5-10 sessions, 1 web client open) — this trips R5 as a release-blocker for v0.4 and forces the eviction policy to ship.
 
 **Mitigation:**
-- v0.3 already enforces the per-subscriber 1 MiB cap (drop-slowest).
+- v0.3 already enforces the per-subscriber 1 MiB cap (drop-slowest). Cross-ref chapter 06 R4 P0-2 (subscriber cap is the related upstream control).
 - v0.4 adds nothing here unless web introduces persistent extra subscribers.
-- Long-term mitigation (v0.5+): scrollback eviction policy for idle sessions.
-- v0.4 dogfood (post-M4 7-day) monitors memory growth as part of the gate.
+- v0.4 instrumentation (NEW): daemon samples RSS every 5 min, emits `pino.info({ event: 'rss_sample', rssBytes, sessionCount, subscriberCount })`, and exposes the latest sample on the `/stats` endpoint. Without instrumentation the dogfood gate is operationally vacuous.
+- Long-term mitigation: scrollback eviction policy for idle sessions. If R5 trips at the 1.5 GB threshold during dogfood, the eviction policy [cross-file: see chapter 05 §P1-2] becomes a v0.4 ship-gate item, not a v0.5 deferral.
+- v0.4 dogfood (post-M4 7-day) monitors the RSS trend with the thresholds above.
+
+### R5b. Daemon JS event-loop saturation under multi-client streaming (NEW)
+
+**What:** Node.js is single-threaded for JS execution. The daemon executes on one event loop: HTTP/2 frame parsing (libuv thread is fine), Connect interceptor stack per RPC (JS), protobuf encode/decode for every PTY chunk and every keystroke (JS), xterm-headless ANSI parsing for every byte from `node-pty` (JS), pino log serialization (JS unless `pino.transport()`), JWT verify on every remote RPC (~1-2 ms per call, JS), and snapshot serialization (multi-MB CPU work, JS). Worst case: 5 sessions producing hot PTY output × 2 web clients each subscribed × a snapshot RPC mid-flight saturates the event loop. New incoming RPCs back up; the control-socket `/healthz` shares the same loop, so the supervisor sees a `/healthz` timeout, respawns the daemon, and a cascading failure ensues [cross-file: see chapter 06 R4 P0-2 and chapter 07].
+
+This is not theoretical: v0.3 already runs ANSI parsing in-process; v0.4 adds JWT + protobuf overhead atop the same loop.
+
+**Trigger:** event-loop lag (`perf_hooks.monitorEventLoopDelay`) p99 > 50 ms sustained over a 5-min window with 3+ active sessions, or `/healthz` timeout from supervisor coinciding with `/stats` showing >2 active streams.
+
+**Mitigation:**
+- v0.4 instruments event-loop delay using `perf_hooks.monitorEventLoopDelay` (cheap, built into Node) and exports p50/p99 on `/stats`.
+- Document worst-case session count in the user-facing tray "About" / health view.
+- Consider moving snapshot serialization to a `worker_thread` (defer to v0.5 unless dogfood R5b trips).
+- Cross-file: this risk crosses chapter 06 (streaming) and chapter 07 (failure modes). [cross-file: see chapter 06, chapter 07].
+
+### R6. Same-user-local-process compromise of daemon (NEW — R2 P1-1)
+
+**What:** any process running as the daemon's user (compromised dev tool, malicious npm postinstall, exploited browser extension, drive-by binary) can connect to the local socket and exercise the full RPC surface — PTY input/output (= shell command execution), spawn commands, read settings including the Cloudflare tunnel token. v0.3 had an HMAC handshake on the local socket as a second line of defense; v0.4 drops it [cross-file: see chapter 02 §8 + chapter 02 R2 P1-1].
+
+**Trigger:** any local-malware report on a user's machine; unexplained daemon RPC activity in pino logs that doesn't correspond to a known client (Electron app, web tab, CLI helper).
+
+**Mitigation:**
+- Per chapter 02 R2 P1-1 lock: either restore HMAC on the local socket (recommended) or document acceptance and target re-introduction in v0.5. v0.4 inherits whichever lock chapter 02 ships with.
+- Local socket is bound to user-only filesystem permissions (Unix domain socket mode 0600, Windows named pipe with explicit user-SID ACL).
+- Daemon logs every authenticated local-RPC's PID + executable path (where the OS allows) for forensic correlation.
+
+### R7. GitHub OAuth session compromise → daemon RCE (NEW — R2 P1-2)
+
+**What:** an attacker who acquires a valid GitHub session for the author's email gets a Cloudflare Access JWT (chapter 05 §3 includes-emails policy + 24 h sessions), then drives any RPC including PTY input. PTY input is shell command execution. This is the highest-impact remote-attack vector in v0.4 and was previously implicit; it must be ranked.
+
+**Trigger:** GitHub security advisory affecting the author's account; suspicious sign-in notification from GitHub or Cloudflare; unexplained PTY activity in daemon logs not matching user-driven sessions.
+
+**Mitigation:**
+- Per chapter 05 R2 P0-2 lock: require Cloudflare Access MFA on the GitHub-IdP rule, reduce session duration from 24 h to a tighter window, daemon-side IP audit on every authenticated RPC, documented compromise-recovery flow (revoke Cloudflare session, rotate tunnel credentials, rotate GitHub OAuth token) [cross-file: see chapter 05].
+- Daemon logs `{ event: 'rpc_authenticated', sourceIp, cfRayId, jwtIat, rpcName }` for every remote call so the user can audit "was this me?".
+- Tray menu surfaces a "recent remote sessions" view sourced from these logs (M4 deliverable).
 
 ## 2. Medium risks
 
-### R6. Cloudflare Tunnel hostname leak
+### R8. Cloudflare Tunnel hostname leak
 
 **What:** the auto-generated `<random>.cfargotunnel.com` hostname looks like a random string but is enumerable. If leaked (e.g. browser history, screen share), the hostname is visible. Cloudflare Access still requires JWT, so leak alone is not a breach — but it removes a layer of obscurity.
 
@@ -81,9 +118,10 @@ v0.4 introduces a published wire surface, a new client (web), and a third-party 
 **Mitigation:**
 - Cloudflare Access enforces auth on every request. Hostname-knowledge alone grants nothing.
 - Document in chapter 05 / setup wizard: "the hostname is one of two security layers; the other (Access) blocks unauthorized users."
+- Daemon-side detection (NEW): every rejected JWT attempt is logged at `pino.warn({ event: 'jwt_rejected', sourceIp, reason, traceId })`, providing a forensic trail so "was I being scanned / attacked?" is answerable post-incident. [cross-file: see chapter 02 §8 + chapter 05 §4 — both currently silent on rejection logging; this risk drives the requirement.]
 - Optional v0.5+: rotate hostname (delete and recreate tunnel). Out of scope for v0.4.
 
-### R7. Browser tab kept open across daemon upgrade
+### R9. Browser tab kept open across daemon upgrade
 
 **What:** user has the web client open at version v0.4.0; daemon upgrades to v0.4.1 in the background. The open tab's bundle has stale proto types.
 
@@ -91,10 +129,10 @@ v0.4 introduces a published wire surface, a new client (web), and a third-party 
 
 **Mitigation:**
 - Field-level back-compat (chapter 02 §7) — old client gracefully ignores new fields.
-- `Ping` RPC returns daemon version; SPA SHOULD show a "new version available, refresh to update" banner if version differs from build-embedded version. (M4 deliverable, MAY be deferred to v0.5 if scope tight.)
+- `Ping` RPC returns daemon version; SPA MUST show a "new version available, refresh to update" banner if the version differs from the build-embedded version. Promoted from MAY-deferred to MUST for M4: this banner is the only mechanism by which the user can detect a stale build, and deferring it makes upgrade-window stale-tab behavior silently undetectable. Scope is small (Ping RPC + 5-line UI banner).
 - Worst case: user reloads the tab on next interaction; gets fresh bundle.
 
-### R8. CSP / cross-origin issues in browser
+### R10. CSP / cross-origin issues in browser
 
 **What:** Cloudflare Access's auth-redirect flow involves cross-origin cookies and redirects. Browser CSP (Content Security Policy) configured incorrectly on either Pages or Tunnel could break the auth handshake.
 
@@ -105,31 +143,31 @@ v0.4 introduces a published wire surface, a new client (web), and a third-party 
 - M3 dogfood explicitly tests Safari + Chrome + Firefox (the major browsers each handle third-party cookies differently as of 2026).
 - If breakage: scope to one browser, document, advise alternate browser. Not a release blocker.
 
-### R9. `cloudflared` binary supply chain
+### R11. `cloudflared` binary supply chain
 
 **What:** daemon ships `cloudflared` binary in the installer. If `cloudflared` upstream is compromised (or our pinned version has a CVE), users are exposed.
 
 **Trigger:** Cloudflare publishes security advisory for `cloudflared`.
 
 **Mitigation:**
-- Pin `cloudflared` version in build script; version tracked in `daemon/scripts/cloudflared-version.txt` (or similar).
+- Pin `cloudflared` version in build script; version tracked in `daemon/scripts/cloudflared-version.txt` (or similar). Supply-chain pin uses SHA + signature verification per chapter 05 locked supply-chain story [cross-file: see chapter 05].
 - Quarterly review for security advisories.
 - Auto-update (separate from daemon auto-update) of `cloudflared` itself: NOT in v0.4. Defer.
 
-### R10. SPA bundle size grows unchecked
+### R12. SPA bundle size grows unchecked
 
 **What:** Vite bundle bloats over time as features are added (xterm addons, larger icon set, etc.). Web client first-load latency degrades.
 
-**Trigger:** deploy log shows bundle >1 MB gzipped; users on slow connections complain.
+**Trigger:** deploy log shows bundle exceeds the locked threshold; users on slow connections complain.
 
 **Mitigation:**
 - Chapter 04 §2 sets target ~600 KB gzipped first-load.
-- CI lint: bundle-size check (`size-limit` package) on PRs touching `web/` or `src/`. Fail on >800 KB. Lock-in for M3 PR.
+- CI lint: bundle-size check (`size-limit` package) on PRs touching `web/` or `src/`. The fail threshold is **not** pre-set at 800 KB; instead it is locked at M1 spike to `actual_first_build + 15%` so the gate cannot trip on day one and trigger a ritual relaxation [cross-file: see chapter 04 R4 P1-1]. A gate destined to be relaxed is worse than no gate.
 - Manual chunk splitting (chapter 04 §3) keeps cache-friendly chunks.
 
 ## 3. Low risks (acknowledged, not blocking)
 
-### R11. `buf` binary upgrade churn
+### R13. `buf` binary upgrade churn
 
 **What:** `buf` CLI gets breaking changes; CI gate breaks on a `buf` upgrade.
 
@@ -137,7 +175,7 @@ v0.4 introduces a published wire surface, a new client (web), and a third-party 
 
 **Mitigation:** pin `buf` version in `package.json`. Routine maintenance.
 
-### R12. Auto-start at OS boot conflicts with antivirus
+### R14. Auto-start at OS boot conflicts with antivirus
 
 **What:** AV on Win flags the auto-start registry / startup-folder entry as suspicious.
 
@@ -147,17 +185,17 @@ v0.4 introduces a published wire surface, a new client (web), and a third-party 
 - Default OFF (chapter 01 G6). Users opt in.
 - Use standard mechanisms (Win startup folder shortcut, not registry HKCU\Run) to minimize false-positive risk.
 
-### R13. Installer size increases with `cloudflared` bundled
+### R15. Installer size increases with `cloudflared` bundled
 
-**What:** `cloudflared` binary is ~20 MB per platform. Installer grows accordingly.
+**What:** `cloudflared` binary is ~30-40 MB per platform on Win/Mac/Linux. Per-platform installer grows accordingly.
 
 **Trigger:** installer download takes noticeably longer.
 
 **Mitigation:**
-- Acceptable cost. Installer was ~80 MB; will be ~100 MB. Negligible.
+- Acceptable cost. Per-platform installer was ~80 MB; will be ~110-120 MB. Negligible.
 - Alternative: download `cloudflared` on first remote-enable. Adds setup-wizard friction; not chosen.
 
-### R14. Multi-client typing UX is confusing
+### R16. Multi-client typing UX is confusing
 
 **What:** two clients on the same session: characters interleave. User might find this surprising.
 
@@ -167,7 +205,7 @@ v0.4 introduces a published wire surface, a new client (web), and a third-party 
 - Documentation note: "if you type from two devices simultaneously, output interleaves."
 - No UI lock in v0.4. If demand emerges, future feature (v0.5+).
 
-### R15. Web client clipboard quirks
+### R17. Web client clipboard quirks
 
 **What:** `navigator.clipboard.writeText` requires user gesture in some browsers; differs from Electron's unrestricted access.
 
@@ -195,6 +233,6 @@ v0.4 introduces a published wire surface, a new client (web), and a third-party 
 
 **Why accepted:** the user's machine is the source of truth. If it's offline, there's nothing to display. Auto-start at boot (G6) reduces "I forgot to start it" cases. Cloud-resident daemon (N4) is a different product.
 
-### A5. JWT-replay attacks not prevented (no nonce/jti store)
+### A5. JWT replay-mid-validity not prevented (no nonce/jti store), but the compromise is auditable
 
-**Why accepted:** single-user. Attacker who has the JWT cookie has the same identity as the legitimate user. Multi-user model would change this.
+**Why accepted:** single-user model — an attacker who has the JWT cookie has the same identity as the legitimate user from the daemon's authorization standpoint. The earlier framing ("no defense") masked an undetectable compromise; this version is honest about the consequence and the recovery path. The daemon logs every authenticated RPC's source IP + Cf-Ray + jwt-iat [cross-file: see chapter 07 R2 P1-2 + chapter 05 §4], so the user can audit "was this me?" after the fact. Cloudflare's session-revoke endpoint provides instant invalidation if compromise is suspected. The acceptance is therefore "no in-band prevention, but full post-hoc audit trail and fast revocation," not "no defense."


### PR DESCRIPTION
## Summary

Folds reviewer P0/P1 findings from R2/R3/R4 into `docs/superpowers/specs/v0.4-web-chapters/10-risks.md`. Task #1049.

## Finding counts

- **P0 folded**: 0 (none filed across R2/R3/R4)
- **P1 folded**: 9 (R2: 3, R3: 3, R4: 3)
- **P2 skipped**: 6 (R2: 2, R3: 2, R4: 2) — out of scope per task
- **Rebuttals**: 0 — all P1 findings in-scope and consistent with chapter intent

## P1 findings folded

### R2 (security)
- **P1-1** new top risk **R6**: same-user-local-process compromise of daemon (cross-ref ch02 §8 / R2 P1-1 for HMAC decision)
- **P1-2** new top risk **R7**: GitHub OAuth session compromise → daemon RCE (cross-ref ch05 R2 P0-2 for MFA / session-duration / IP audit)
- **P1-3** **A5** rewritten: now distinguishes "no defense" vs "no in-band prevention but full audit trail + fast revoke" (cross-ref ch07 R2 P1-2 + ch05 §4)

### R3 (reliability / observability)
- **P1-1** **R5** thresholds made concrete: warn at RSS > 500 MB / fail at RSS > 1.5 GB after 7 days; if tripped, eviction policy promoted to v0.4 ship-gate
- **P1-2** **R6** (now R8 after renumber) gains daemon-side rejected-JWT logging for forensic trail
- **P1-3** **R7** (now R9) version-skew banner promoted from MAY-deferred to MUST in M4

### R4 (scalability / performance)
- **P1-1** **R5** instrumentation added (RSS sample every 5 min via pino + /stats), multi-client amplifier called out, trigger lowered to realistic single-user numbers, cross-ref ch06 R4 P0-2
- **P1-2** **R10** (now R12) bundle-size gate changed from fixed 800 KB to actual_first_build + 15% locked at M1 spike (cross-ref ch04 R4 P1-1)
- **P1-3** new top risk **R5b**: daemon JS event-loop saturation under multi-client streaming, with perf_hooks.monitorEventLoopDelay instrumentation, p99 > 50 ms trigger, cross-ref ch06 / ch07

## Renumbering note

Adding R6 + R7 shifted downstream entries: old R6→R8, R7→R9, R8→R10, R9→R11, R10→R12, R11→R13, R12→R14, R13→R15, R14→R16, R15→R17. R5b inserted under §1 adjacent to R5. A1-A5 unchanged.

## Files touched

- docs/superpowers/specs/v0.4-web-chapters/10-risks.md

Reviewer .review.r1.md files left in place per task instructions.