### PR TITLE
fix(spec/v0.4-web): 09 release-slicing — fold R1/R2/R3/R5/R6 P0/P1

### DIFF
--- a/docs/superpowers/specs/v0.4-web-chapters/09-release-slicing.md
+++ b/docs/superpowers/specs/v0.4-web-chapters/09-release-slicing.md
@@ -26,6 +26,10 @@ v0.4 covers protocol formalization + bridge swap + web client + Cloudflare layer
 
 **Total: ~110 hours.** ~3-4× the predecessor doc's "~30h v0.4 + ~30-50h v0.5" estimate (predecessor undercounted bridge-swap and CF wiring scope).
 
+> **Bridge count canonical: ~46.** This is the canonical inventory from chapter 03. If chapters 00/01/02 cite a smaller number (e.g. "~22"), those are stale and must be brought *up* to ~46 — do NOT bring chapter 09 *down*. [cross-file: see chapters 00, 01, 02 for the ~22 → ~46 corrections]
+
+> **Sub-batch naming convention.** Sub-batches use letter suffixes (`M2.A`, `M2.B`, `M2.C`); the trailing cleanup PR uses `.Z` to signal "final cleanup, run after all sibling sub-batches land." Only M2 has sub-batches in v0.4; M1/M3/M4 ship as single-milestone bundles.
+
 ## 2. M1 — `proto/` locked + first bridge swapped end-to-end
 
 **Goal:** end-to-end Connect request travels from renderer → preload → daemon and back, with proto + buf CI enforcing schema. Pick the smallest read-only RPC for the swap (`app:getVersion`) so blast radius is minimal if anything is broken.
@@ -44,7 +48,7 @@ v0.4 covers protocol formalization + bridge swap + web client + Cloudflare layer
 
 ### Done definition
 
-- v0.4-rc1 installer builds.
+- v0.4.0-rc1 installer builds.
 - Author runs the installer; everything works as v0.3 except `getVersion()` is now over Connect (verifiable in daemon log: `pino.info({transport: 'connect', method: 'GetVersion'})`).
 - 24h dogfood with no regressions.
 
@@ -68,11 +72,21 @@ v0.4 covers protocol formalization + bridge swap + web client + Cloudflare layer
 5. Multi-client coherence test (L5) passes between two Electron instances on the same daemon (web is M3).
 6. Tests: full L1+L2+L3+L5 suite green.
 
+### M2.Z preconditions (parity-test deletion gate)
+
+M2.Z is the irreversible point: once parity tests are deleted, regressions can no longer be A/B-compared against the envelope handler. M2.Z PR MUST NOT merge until ALL of the following hold:
+
+1. All 12 batch PRs (M2.A.1–4, M2.B.1–5, M2.C.1–3) are merged to `working`.
+2. Each batch PR's parity test ran green at merge time AND is still green on `working` HEAD.
+3. A final cross-bridge integration test (all ~46 RPCs exercised in one e2e session) passes on `working` HEAD.
+4. The post-M2 7-day dogfood window has CLOSED (i.e. parity tests survive the dogfood window — they are the safety net during it). M2.Z runs only after dogfood close, never during. [cross-file: see chapter 03 §6/§7 for the parity-test framework spec.]
+
 ### Done definition
 
-- v0.4-rc2 installer builds.
+- v0.4.0-rc2 installer builds.
 - Author runs the installer; all v0.3 functionality works; no envelope code on data socket (verifiable: `grep -r 'envelope' daemon/src/sockets/data-socket.ts` returns nothing).
 - 1-week dogfood with no regressions.
+- **Force-update probe:** force-update from `v0.4.0-rc1` to `v0.4.0-rc2` succeeds on a test machine; force-rollback from rc2 to rc1 succeeds (manual installer step OK). [cross-file: see chapter 07 P1-3 for the auto-update force-test framework.]
 
 ## 4. M3 — Web client functional (local-only)
 
@@ -84,10 +98,18 @@ v0.4 covers protocol formalization + bridge swap + web client + Cloudflare layer
 2. `web/src/main.tsx` mounts shared `src/App.tsx`.
 3. `web/src/bridges/*` web flavor of preload bridges, calling Connect-Web against the dev TCP listener.
 4. `src/platform/getPlatform.ts` (or equivalent) — abstracts `process.platform` reads.
-5. Dev TCP listener on daemon (`CCSM_DAEMON_DEV_TCP=7878`); MUST refuse to bind in production builds (compile-time gate via `process.env.NODE_ENV` check or build flag).
+5. **Dev TCP listener on daemon — locked production gate.** Spec is concrete; the worker has no choice of mechanism:
+   1. Dev TCP listener code lives in `daemon/src/dev/dev-tcp-listener.ts`.
+   2. The entire `daemon/src/dev/**` tree is excluded from production builds via `tsconfig.production.json` `exclude: ["src/dev/**"]`.
+   3. Daemon entry imports the dev listener via `await import(...)` gated on `process.env.CCSM_BUILD !== 'production'`. If `process.env.CCSM_BUILD === 'production'` AND a `daemon/src/dev/**` module is somehow loaded (transitively), the entry calls `assert.fail('dev module loaded in production')` and the daemon exits non-zero.
+   4. Activation env var is `CCSM_DAEMON_DEV_TCP=<port>`. In production builds the variable has no effect because the module is not present.
+   5. Listener requires a per-launch shared secret negotiated at daemon start (printed to dev console, consumed by the web dev bridge); see chapter 04 R2 P0-1 for the secret protocol.
+   6. **Banned mechanisms:** `process.env.NODE_ENV === 'development'` checks alone are insufficient (NODE_ENV is externally settable on a packaged binary and would be a trivial bypass) and MUST NOT be the gate.
+   7. L4 e2e test verifies: prod-build daemon binary refuses to bind even with `CCSM_DAEMON_DEV_TCP=7878` AND `NODE_ENV=development` set; dev-build daemon binary binds only when the per-launch secret is provided. [cross-file: see chapter 04 R2 P0-1 for the parallel lock.]
 6. `npm run web:dev` runs Vite + the web client; talks to a locally running daemon.
 7. Tests: L4 web e2e suite green (~6 cases). L5 multi-client e2e extended to include web client.
 8. `web/dist/` build artifact produced by `npm run build:web`. Cloudflare Pages NOT wired yet.
+9. **Web client error reporting wired.** New RPC `ReportClientError` exposed by the daemon; web client catches uncaught exceptions + unhandled promise rejections and posts them. Daemon writes them to `~/.ccsm/web-client-errors.log` (rotated). Hidden-settings "copy diagnostics" button packs the last N entries for paste into a bug report. Without this, the M3 dogfood gate has no telemetry to evaluate. [cross-file: see chapter 04 P1-1 for the error-reporting RPC contract.]
 
 ### Done definition
 
@@ -96,9 +118,15 @@ v0.4 covers protocol formalization + bridge swap + web client + Cloudflare layer
   2. `npm run web:dev` → Vite dev server.
   3. Open `http://localhost:5174` → SPA loads, sees session list, opens session, types into terminal.
 - Multi-client test (L5) passes: Electron and web on the same session see each other's input/output.
-- 3-day dogfood: web client used at least 4-5 hours of real work locally with no critical regressions.
+- **Dogfood: 3 days OR 12 cumulative hours of active web-client use, whichever is later.** Must include:
+  - ≥1 backgrounded-tab session lasting >2h (catches throttled-tab reconnect bugs and leaked subscribers per chapter 06 §5).
+  - ≥1 multi-client session (Electron + web on the same session) lasting ≥1h.
+  - ≥1 reconnect after intentional network drop (toggle Wi-Fi off/on; web client must recover without reload).
+- 4-5 hours of typical interactive use is too thin a sample; the wider gate is what triggers the M3 risk gate fairly.
 
 **Risk gate before M4:** if M3 dogfood reveals significant UX gaps (e.g. xterm.js rendering glitches in browser, keyboard shortcut conflicts), pause M4 and address. Don't paper over with Cloudflare polish.
+
+**Feature-scope discovery during M3 dogfood:** if dogfood reveals desirable new features (better keyboard mappings for browsers, web-specific gestures, mobile-friendly chrome, etc.), file them as v0.5+ candidates. v0.4 does NOT extend feature scope based on M3 findings; it only fixes regressions and addresses gaps that block the +frontend deliverable.
 
 ## 5. M4 — Cloudflare wired, remote access live
 
@@ -109,10 +137,10 @@ v0.4 covers protocol formalization + bridge swap + web client + Cloudflare layer
 1. `cloudflared` binaries bundled in installer (Win/Mac/Linux x64+ARM64). Installer drops them in app resources path.
 2. Daemon: `cloudflared` spawn/supervise logic (chapter 05 §1).
 3. Daemon: JWT validation interceptor on remote ingress (chapter 05 §4).
-4. Daemon: SQLite settings rows for tunnel token, CF team name, CF app AUD; encrypted at rest via OS keychain.
+4. **SQLite settings rows for tunnel token, CF team name, CF app AUD; encrypted at rest via OS keychain — locked scheme.** The encryption-at-rest scheme is fully defined in chapter 05 §1.X; M4 implements that lock without re-deciding. Summary of the lock: secrets live in the OS keychain only (Win Credential Manager, macOS Keychain, libsecret on Linux); SQLite stores ONLY a keyring pointer (account/service identifier), never the secret bytes; Linux fallback (no libsecret) is documented and surfaces a setup-wizard warning rather than silently downgrading; setup wizard handles missing-keychain and rotation flows per chapter 05. [cross-file: see chapter 05 R2 P0-1 for the binding lock.]
 5. Electron Settings UI: "Remote access" pane with the 3-step setup wizard (chapter 05 §6).
 6. Cloudflare Pages: GitHub integration set up; first deploy from `main` succeeds.
-7. Auto-start at OS boot setting (chapter 01 G6) — opt-in toggle, default OFF, persists across reboots.
+7. **Auto-start at OS boot — bounded scope.** A SINGLE toggle in Settings → Remote access pane. Default OFF. Persists across reboots via the standard mechanism per chapter 01 G6 + R12 (Win startup folder shortcut, launchd `RunAtLoad`, systemd user unit). Explicitly NOT in scope for v0.4: tray menu item, first-run nudge, system-tray indicator for boot-state, OS notification on boot. No additional UX in v0.4. [cross-file: see chapter 01 R1 P1-1 for the matched scope-narrowing language.]
 8. `daemon.unreachable` and `cloudflare.unreachable` banners surface correctly.
 9. Tests: L6 Cloudflare smoke green on a CI tunnel + service-token JWT.
 10. Documentation: `docs/web-remote-setup.md` user guide.
@@ -122,6 +150,7 @@ v0.4 covers protocol formalization + bridge swap + web client + Cloudflare layer
 - v0.4.0 installer ready to ship.
 - Author runs setup wizard, gets `<random>.cfargotunnel.com` hostname, opens `https://app.<author-domain>` (or `<deploy>.pages.dev`) from a phone tether (cellular network), signs in with GitHub, sees session list, opens session, types in terminal, sees Electron desktop mirror the input.
 - 7-day dogfood per chapter 00 success criteria.
+- **Manual auto-start verification.** On a real Win box: flip the auto-start toggle ON, reboot, log in, observe daemon comes up before Electron launch, web client reachable within 30s of OS login. Result recorded in release notes for the `v0.4.0` tag. This is a manual test (reboots are not cheaply automatable in CI); chapter 08 §9 manual-checklist tracks it as a per-release gate. [cross-file: see chapter 00 success criterion #6 + chapter 08 §9.]
 - Release tag `v0.4.0` cut.
 
 ## 6. Release tagging + version bumps
@@ -133,9 +162,21 @@ v0.4 covers protocol formalization + bridge swap + web client + Cloudflare layer
 | `v0.4.0-rc3` | M3 done | Local installer; web NOT yet on Pages |
 | `v0.4.0` | M4 done + 7-day dogfood passed | Push to update channel; Pages live |
 
+Tag prose is canonical `v0.4.0-rcN` (full semver); avoid the shorter `v0.4-rcN` form anywhere in the spec.
+
 **Why rcN tags during the milestones:** preserves "this is M2-complete" snapshot in git history. Useful if M3 hits trouble and we need to bisect or roll back.
 
 **Daemon binary tag:** `daemon-v0.4.0-rcN` matching the Electron tag. Single installer, lockstep versions (chapter 02 §7).
+
+### Auto-update default for v0.4
+
+The v0.4.0 release ships with auto-update default-ON UNLESS the explicit reliability gate trips during M2 dogfood. The gate is binary, not judgment:
+
+> **Gate:** if ≥1 stuck-upgrade reproduction occurs during the M2 7-day dogfood window, auto-update for v0.4.0 ships default-OFF and requires user-initiated install. If 0 reproductions occur, auto-update ships default-ON.
+>
+> The author is the only dogfood user; ANY occurrence (n=1) trips the gate. No quorum, no severity ladder. Recorded in `docs/release-notes/v0.4.0.md` with a one-line citation of the dogfood log.
+
+Without this binary criterion, "serious problems" is a release-time judgment call and reliability bugs leak through. [cross-file: see chapter 10 R1 for the auto-update channel mechanics.]
 
 ## 7. Dogfood gates between milestones
 
@@ -144,11 +185,24 @@ Per `feedback_dogfood_protocol`: each milestone closure requires a dogfood windo
 | Gate | Duration | What's tested |
 |---|---|---|
 | Post-M1 | 24h | Connect path doesn't break first RPC; no daemon crash |
-| Post-M2 | 7 days | Full Electron usage on Connect; multi-client (Electron+Electron) coherent; no regression vs v0.3 baseline |
-| Post-M3 | 3 days | Web client operates sessions locally; matches Electron behavior |
+| Post-M2 | 7 days | Full Electron usage on Connect; multi-client (Electron+Electron) coherent; no regression vs v0.3 baseline; auto-update gate (§6) evaluated |
+| Post-M3 | 3 days OR 12 cumulative hours active use, whichever later | Web client operates sessions locally; matches Electron behavior; backgrounded-tab + reconnect probes per §4 done definition |
 | Post-M4 | 7 days | End-to-end remote access stable; auto-start works after OS reboot |
 
 **Dogfood failures during a gate:** open issues; if HIGH severity (data loss, crash loop), pause next milestone until fixed. Per `feedback_correctness_over_cost`: never skip an issue to advance the schedule.
+
+**Dogfood-gate stuck signal.** If a dogfood gate exceeds 2× its planned duration without closing (e.g. post-M2 still open at day 14, post-M3 still open at 24 cumulative hours of attempted use), escalate to the user. Either ship a hot-fix mid-gate to unstick the probe or pause the release and re-evaluate the milestone scope. Without this signal, a stale-mid-flight milestone (e.g. M3 done, M4 lingering for weeks while context evaporates) is invisible to the manager.
+
+**R1 sanity check (no scope creep) at every gate.** Before closing a milestone, the manager scans the milestone's PRs for any user-visible new surface that was NOT in the milestone's deliverables list — new bridge method, new UI component, new Settings row, new tray entry, new keyboard shortcut, new notification, new modal. Each MUST be traceable to a spec-listed deliverable; otherwise it is scope creep and gets reverted or deferred to v0.5+.
+
+**Pre-M4 security gate.** Between the post-M3 dogfood close and M4 start, dispatch a security-focused reviewer to audit:
+
+- (a) JWT interceptor implementation against chapter 05 §4 lock,
+- (b) keychain integration against chapter 05 §1.X,
+- (c) dev TCP listener prod-gate against §4 deliverable 5 of this chapter,
+- (d) `cloudflared` spawn-arg + binary supply-chain checks.
+
+Any HIGH-severity finding blocks M4 release until resolved. Process suggestion, not rigid; can be skipped only with explicit user sign-off recorded in the M4 plan.
 
 ## 8. Rollback strategy
 
@@ -164,5 +218,15 @@ Per `feedback_dogfood_protocol`: each milestone closure requires a dogfood windo
 - Catastrophic regression: `v0.4.1` hot-fix release within 24h.
 - Cloudflare Pages: rollback to previous deploy via dashboard (one click, ~30s).
 - Auto-update: pinned channel until hotfix verified.
+- **Hotfix path probe (optional, recommended in M4 dogfood):** during the M4 7-day window, exercise the hotfix flow once — bump patch version on a throwaway tag, push to a test update channel, verify auto-update on a test machine picks it up. Confirms the hotfix path still works on v0.4 binaries before it is needed under pressure.
 
-**Why no "downgrade to v0.3" rollback path:** v0.4 changes the SQLite schema only additively (no destructive migrations expected); v0.3 binary against v0.4 SQLite would work but lose any v0.4-only data. Acceptable; documented but not engineered as a one-click flow.
+**Schema-additive enforcement (no destructive migrations).** v0.4's "no downgrade-to-v0.3 rollback" assumption rests on SQLite migrations being purely additive. To prevent this from silently breaking, CI runs a **schema-additive lint** that parses every migration file in `daemon/src/db/migrations/` between the v0.3 baseline and the current HEAD and fails the build if any migration:
+
+- drops a table or column,
+- alters a column type,
+- adds a `NOT NULL` column without a default,
+- renames a column or table.
+
+A future PR that needs a destructive migration must first land an explicit "v0.5 schema break — downgrade no longer supported" announcement and version bump. Without this gate, a future PR could quietly break the implicit promise and a v0.4.x → v0.3 fallback could lose user data. [cross-file: see chapter 08 testing for the CI workflow specification.]
+
+**Why no "downgrade to v0.3" rollback path:** v0.4 changes the SQLite schema only additively (enforced by the lint above); v0.3 binary against v0.4 SQLite would work but lose any v0.4-only data. Acceptable; documented but not engineered as a one-click flow.


### PR DESCRIPTION
## Summary

Folds reviewer findings from R1/R2/R3/R5/R6 round-1 reviews into chapter 09 (release slicing) of the v0.4 web design spec. Pure markdown edit; no code changes.

## Finding counts

| Reviewer | P0 | P1 folded | P2 folded | P2 skipped | Rebutted |
|---|---|---|---|---|---|
| R1 (feature-preservation) | 0 | 1 | 2 | 0 | 0 |
| R2 (security) | 0 | 2 | 1 | 0 | 0 |
| R3 (reliability/observability) | 0 | 3 | 1 | 1 | 0 |
| R5 (testability) | 0 | 3 | 1 | 0 | 0 |
| R6 (naming/consistency) | 0 | 1 (no-op + cross-file note) | 2 | 0 | 0 |
| **Total** | **0** | **10** | **7** | **1** | **0** |

P2s were folded opportunistically when they were low-cost prose adds that strengthened existing gates/sections (R1 P2-1/P2-2, R2 P2-1, R3 P2-2, R5 P2-1, R6 P2-1/P2-2). One R3 P2 (M3 web error reporting wiring) was upgraded into the M3 deliverable list as deliverable #9 because without it the M3 dogfood gate has no telemetry.

R6 P1-1 (~46 bridge count) required no in-chapter edit but is now explicitly tagged inside chapter 09 to prevent the cross-file fixer from \"correcting\" 09 down to 22.

## Key folds

- **M3 dev TCP listener** (R2 P1-1): vague \"NODE_ENV check OR build flag\" replaced with a concrete 7-step lock (tsconfig exclude + dynamic-import gate + assert.fail tripwire + per-launch shared secret + L4 prod-build refusal test). NODE_ENV-only gating is now an explicitly banned mechanism.
- **M2.Z parity-test deletion gate** (R5 P1-1): added a 4-precondition checklist; M2.Z cannot run until all batch PRs landed, parity tests still green, cross-bridge integration green, AND post-M2 dogfood window has CLOSED.
- **Auto-update default reliability gate** (R3 P1-1): replaced the missing/vague criterion with a binary n=1 gate evaluated during M2 dogfood.
- **Schema-additive CI lint** (R3 P1-2): added enforcement catching drops, alters, NOT-NULL adds, and renames.
- **M3 dogfood window** (R5 P1-2): widened from \"3 days, 4-5h\" to \"3 days OR 12 cumulative hours, whichever later\" with required backgrounded-tab, multi-client, and reconnect probes.
- **M4 auto-start scope tightening** (R1 P1-1) + **manual test plan** (R5 P1-3): bounded to a single Settings toggle with an explicit per-release manual checklist row.
- **Pre-M4 security gate** (R2 P2-1): inserted between post-M3 dogfood close and M4 start.
- **Dogfood-gate stuck signal** (R3 P1-3): 2x planned duration triggers escalation.
- **R1 sanity check at every gate** (R1 P2-2): manager scans milestone PRs for unspecced user-visible surface.

## Cross-file deltas (tagged inline, NOT edited here)

- chapters 00/01/02 — bring \"~22 bridges\" up to \"~46\"
- chapter 01 — auto-start scope (matched language)
- chapter 03 — parity-test framework
- chapter 04 — dev TCP per-launch secret protocol; ReportClientError RPC contract
- chapter 05 — keychain encryption-at-rest binding lock
- chapter 07 — auto-update force-test framework
- chapter 08 — schema-additive lint CI workflow; manual-checklist row
- chapter 10 — auto-update channel mechanics

## Rebuttals

None. All P1s were applicable to chapter 09.

## Test plan

- [ ] Reviewer reads through chapter 09 against the five .review.r1.md files and confirms each P1 is folded or rebutted
- [ ] Cross-file tags are present at every cross-chapter dependency
- [ ] Reviewer .review.r1.md files are still present in the directory (not deleted)