### PR TITLE
test(e2e): T73 daemon-boot+hello probe

### DIFF
--- a/tests/harness-daemon-mode.test.ts
+++ b/tests/harness-daemon-mode.test.ts
@@ -20,7 +20,33 @@ import { Readable } from 'node:stream';
 import { spawn, type ChildProcess } from 'node:child_process';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve as resolvePath } from 'node:path';
+import { Buffer } from 'node:buffer';
+import { createHmac, randomBytes } from 'node:crypto';
+
+// T73 — daemon-boot+hello e2e probe imports. The probe spawns the real
+// `daemon/src/index.ts` to assert the boot supervisor signal (ready
+// marker) and then in-process exercises the canonical `daemon.hello`
+// handler against a known config. Socket-bound RPC is out of scope
+// today (T16/T19 merged but `daemon/src/index.ts` has not yet wired
+// `controlSocket.listen()` per the helper's own §3.4.1.h note); the
+// probe degrades to "boot + handler-contract" until the binding lands,
+// at which point a follow-up swaps the in-process call for a real
+// socket round-trip without changing the asserted invariants.
+import {
+  createDaemonHelloHandler,
+  DAEMON_WIRE,
+  DAEMON_FRAME_VERSION,
+  DaemonHelloSchemaError,
+  type HelloReplyPayload,
+  type HelloRequestPayload,
+} from '../daemon/src/handlers/daemon-hello.js';
+import { DAEMON_PROTOCOL_VERSION } from '../daemon/src/envelope/protocol-version.js';
+import {
+  HMAC_TAG_LENGTH,
+  NONCE_BYTES,
+} from '../daemon/src/envelope/hmac.js';
+import { encode as base64urlEncode } from '../daemon/src/envelope/base64url.js';
 
 // Helper module is plain ESM JS; vitest resolves the .mjs extension fine
 // via dynamic import. Type as `any` since it ships JSDoc only.
@@ -290,4 +316,179 @@ describe('bootDaemon (real spawn smoke)', () => {
     // or a signal-driven null exitCode (Windows).
     expect(code === 0 || code === null).toBe(true);
   }, 15_000);
+});
+
+// ---------------------------------------------------------------------------
+// T73 — daemon-boot + hello probe (e2e, folded into harness-agent surface)
+//
+// Why fold into this harness vitest file (not a standalone .probe.test.ts):
+//   `feedback_e2e_prefer_harness.md` — every additional standalone probe
+//   adds ~30s to e2e wall time; a harness fold is the default. The
+//   T68 helper (`harness-daemon-mode.mjs`) is the v0.3 daemon-mode
+//   surface (per fragment-3.7-dev-workflow §3.7.7), so its vitest
+//   companion is the canonical home for daemon-boot probes.
+//
+// Asserted invariants:
+//   1. Boot supervisor signal — the real daemon child reaches its
+//      canonical "daemon shell booted" stdout marker within the spec
+//      §6.6 boot deadline (10s headroom on the helper default).
+//   2. Hello handshake reply shape — `createDaemonHelloHandler` returns
+//      a reply where (a) `bootNonce` echoes the configured value
+//      (forward-compat surface for renderer reconnect detection), (b)
+//      `helloNonceHmac` matches a reference HMAC over the DECODED nonce
+//      bytes (anti-imposter contract per spec §3.4.1.g lines 195/208/212),
+//      and (c) `protocol.wire` / `daemonFrameVersion` /
+//      `daemonProtocolVersion` match the daemon constants.
+//   3. Reverse-verify, mutation A — when the handler is configured with
+//      a getBootNonce that returns the wrong value, the bootNonce-echo
+//      assertion FAILS with a clear AssertionError surfacing the
+//      mismatch ("expected 'BOOT-WRONG' to be 'BOOT-RIGHT-...'").
+//   4. Reverse-verify, mutation B — a malformed hello request (missing
+//      clientWire) makes the handler reject with `DaemonHelloSchemaError`,
+//      which a positive-path assertion would mis-handle, demonstrating
+//      the schema gate is load-bearing for the probe's contract.
+//
+// Out of scope today (deliberate, documented):
+//   - Real socket round-trip (`daemon/src/index.ts` does not yet bind
+//     the control socket — see helper file's §3.4.1.h note). Once the
+//     binding lands, swap the in-process handler call for a `net.connect`
+//     + envelope round-trip; invariants 1-4 stay the same.
+// ---------------------------------------------------------------------------
+
+const DAEMON_ENTRY = resolvePath(__dirname, '..', 'daemon', 'src', 'index.ts');
+const T73_BOOT_NONCE = 'BOOT-RIGHT-AAAAAAAAAAAAA';
+const T73_SECRET = Buffer.from(
+  'test-secret-T73-deterministic-fixture-32B!',
+  'utf8',
+);
+
+/** Build a canonical valid hello request — mirrors spec §3.4.1.g frame 1. */
+function makeValidHelloRequest(
+  overrides: Partial<HelloRequestPayload> = {},
+): HelloRequestPayload {
+  const nonce = base64urlEncode(randomBytes(NONCE_BYTES));
+  return {
+    clientWire: DAEMON_WIRE,
+    clientProtocolVersion: DAEMON_PROTOCOL_VERSION,
+    clientFrameVersions: [DAEMON_FRAME_VERSION],
+    clientFeatures: ['hello'],
+    clientHelloNonce: nonce,
+    ...overrides,
+  };
+}
+
+/** Reference HMAC over the DECODED nonce bytes (spec §3.4.1.g round-9
+ *  base64url lock — handler MUST hash the 16 raw bytes, NOT the 22 ASCII
+ *  chars). Provides an independent oracle the probe checks against. */
+function referenceHmac(secret: Buffer, base64urlNonce: string): string {
+  const raw = Buffer.from(
+    base64urlNonce.replace(/-/g, '+').replace(/_/g, '/'),
+    'base64',
+  );
+  const full = createHmac('sha256', secret).update(raw).digest();
+  return full
+    .subarray(0, NONCE_BYTES)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+describe('T73 — daemon-boot + hello probe (e2e harness fold)', () => {
+  it('boots the real daemon to ready marker AND validates hello handler contract', async () => {
+    const { bootDaemon } = (await helperPromise) as { bootDaemon: Function };
+
+    // ---- Phase 1: boot the real daemon to its ready marker ---------------
+    // Uses the canonical T68 helper. The helper spawns `tsx daemon/src/index.ts`
+    // and resolves `ready` once "daemon shell booted" is observed on
+    // stdout/stderr. A real spawn (NOT the fake-daemon.cjs smoke) is what
+    // makes this an e2e probe — any regression in `daemon/src/index.ts`
+    // (e.g. an import crash before pino logs the boot line) surfaces here.
+    const handle = bootDaemon({
+      entry: DAEMON_ENTRY,
+      bootTimeoutMs: 15_000,
+    });
+
+    try {
+      await handle.ready;
+
+      // ---- Phase 2: hello handler contract --------------------------------
+      // The control socket isn't bound yet; we exercise the canonical
+      // handler in-process with the same factory the dispatcher will
+      // register once `daemon/src/index.ts` wires it. This is the
+      // contract the wire RPC will inherit.
+      const handler = createDaemonHelloHandler({
+        getSecret: () => T73_SECRET,
+        getBootNonce: () => T73_BOOT_NONCE,
+      });
+      const req = makeValidHelloRequest();
+      const reply = (await handler(req)) as HelloReplyPayload;
+
+      // Invariant 2a — bootNonce echoed (forward-compat for renderer
+      // reconnect / boot-change detection per spec §3.4.1.g + frag-3.5.1).
+      expect(reply.bootNonce).toBe(T73_BOOT_NONCE);
+
+      // Invariant 2b — helloNonceHmac is the reference HMAC over the
+      // DECODED nonce bytes. This is the anti-imposter signal the
+      // client uses to rule out a same-pipe squatter.
+      expect(reply.helloNonceHmac).toBe(
+        referenceHmac(T73_SECRET, req.clientHelloNonce),
+      );
+      expect(reply.helloNonceHmac.length).toBe(HMAC_TAG_LENGTH);
+
+      // Invariant 2c — protocol block matches daemon constants and
+      // signals compatibility on a canonical client request.
+      expect(reply.protocol.wire).toBe(DAEMON_WIRE);
+      expect(reply.protocol.daemonProtocolVersion).toBe(DAEMON_PROTOCOL_VERSION);
+      expect(reply.daemonFrameVersion).toBe(DAEMON_FRAME_VERSION);
+      expect(reply.compatible).toBe(true);
+      expect(reply.reason).toBeUndefined();
+    } finally {
+      // Always reap the daemon child — leaving an orphaned tsx process
+      // would block the next harness run on Windows (held file locks).
+      try { await handle.shutdown(); } catch { /* swallow on teardown */ }
+    }
+  }, 30_000);
+
+  it('reverse-verify A — wrong-bootNonce handler trips the bootNonce-echo invariant', async () => {
+    // Mutates the handler config so getBootNonce returns a value that
+    // does NOT match the expected echo. The positive-path assertion
+    // from the boot+hello test would FAIL with:
+    //   AssertionError: expected 'BOOT-WRONG-AAAAAAAAAAAA' to be 'BOOT-RIGHT-AAAAAAAAAAAAA'
+    // Here we assert the inverse so the probe stays green while still
+    // proving the invariant detects the mutation.
+    const handler = createDaemonHelloHandler({
+      getSecret: () => T73_SECRET,
+      getBootNonce: () => 'BOOT-WRONG-AAAAAAAAAAAA',
+    });
+    const reply = (await handler(makeValidHelloRequest())) as HelloReplyPayload;
+    expect(reply.bootNonce).not.toBe(T73_BOOT_NONCE);
+
+    // Confirm the positive-path expectation would actually throw — this
+    // is the reverse-verify proof: the assertion is load-bearing, not
+    // a tautology.
+    let threw = false;
+    try {
+      expect(reply.bootNonce).toBe(T73_BOOT_NONCE);
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(true);
+  });
+
+  it('reverse-verify B — malformed hello payload rejects with schema error', async () => {
+    // Drops `clientWire` — the spec §3.4.1.g handler MUST reject this
+    // with `DaemonHelloSchemaError` (mapped by the T14 transport to a
+    // wire-level `schema_violation`). Without this gate, the boot+hello
+    // probe could silently coerce nonsense into a "compatible:false"
+    // reply and miss real wire-shape regressions.
+    const handler = createDaemonHelloHandler({
+      getSecret: () => T73_SECRET,
+      getBootNonce: () => T73_BOOT_NONCE,
+    });
+    const bad = { ...makeValidHelloRequest(), clientWire: undefined };
+    await expect(handler(bad as unknown)).rejects.toBeInstanceOf(
+      DaemonHelloSchemaError,
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Task #1030 — folds the T73 L8 daemon-boot+hello probe into `tests/harness-daemon-mode.test.ts` (NOT a standalone `.probe.test.ts`, per `feedback_e2e_prefer_harness.md`). Spawns the real `daemon/src/index.ts` to its canonical ready marker and asserts the §3.4.1.g hello handler contract.

- Boot probe: real `tsx daemon/src/index.ts` reaches "daemon shell booted" within 15s (uses the T68 `bootDaemon` helper).
- Hello handshake contract: `createDaemonHelloHandler` reply carries (a) `bootNonce` echoed from `getBootNonce()`, (b) `helloNonceHmac` matching the reference HMAC over the DECODED 16-byte nonce (anti-imposter, spec lines 195/208/212), (c) `protocol.wire`/`daemonFrameVersion`/`daemonProtocolVersion` matching daemon constants, (d) `compatible: true`.

## Asserted invariants

1. **Boot supervisor signal** — daemon child emits the "daemon shell booted" stdout marker within the spec §6.6 boot deadline.
2. **bootNonce echoed** — `reply.bootNonce === getBootNonce()` (forward-compat for renderer reconnect / `bootChanged` detection per frag-3.5.1).
3. **helloNonceHmac correctness** — equal to reference HMAC-SHA256 over the decoded nonce bytes, truncated to 16 bytes, base64url-no-pad. Length is exactly `HMAC_TAG_LENGTH` (22).
4. **Protocol block** — `protocol.wire === 'v0.3-json-envelope'`, `daemonProtocolVersion === 1`, `daemonFrameVersion === 0`.
5. **Compatibility** — `compatible: true` on a canonical client; `reason` undefined.

## Reverse-verify (mutations actually run + observed FAIL output)

**Mutation A — break bootNonce-echo expectation** (changed `T73_BOOT_NONCE` to `'BOOT-WRONG'` in the positive-path assert):

```
FAIL  tests/harness-daemon-mode.test.ts > T73 — daemon-boot + hello probe (e2e harness fold) > boots the real daemon to ready marker AND validates hello handler contract
AssertionError: expected 'BOOT-RIGHT-AAAAAAAAAAAAA' to be 'BOOT-WRONG'
Expected: "BOOT-WRONG"
Received: "BOOT-RIGHT-AAAAAAAAAAAAA"
```

**Mutation B — make the malformed payload valid** (removed `clientWire: undefined` so the schema rejection no longer triggers):

```
FAIL  tests/harness-daemon-mode.test.ts > T73 — daemon-boot + hello probe (e2e harness fold) > reverse-verify B — malformed hello payload rejects with schema error
AssertionError: promise resolved "{ helloNonceHmac: ..., protocol: { wire: 'v0.3-json-envelope', minClient: 'v0.3', ... } }" instead of rejecting
```

After restore: 20/20 tests pass (17 pre-existing + 3 new T73 tests), 2.93s wall.

## Out of scope (deliberate, documented in code)

- **Real socket round-trip.** `daemon/src/index.ts` has not yet wired `controlSocket.listen()` (the T68 helper itself notes this — its `socketPath` smoke check is gated on path existence). The probe degrades to "boot + handler-contract"; once the binding lands a follow-up swaps the in-process handler call for `net.connect` + envelope round-trip without changing invariants 2-5.

## Test plan

- [x] `npx vitest run tests/harness-daemon-mode.test.ts` → 20 passed, 0 failed
- [x] Reverse-verify mutation A produces clean AssertionError on the bootNonce-echo invariant
- [x] Reverse-verify mutation B produces clean AssertionError on the schema-reject invariant
- [x] No production code touched (probe-only, per task brief)
- [x] No standalone `.probe.test.ts` added (folded into existing harness-daemon-mode test, per `feedback_e2e_prefer_harness.md`)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)