### PR TITLE
spec: v0.4 web — consolidate 12 chapters + implementation DAG

### DIFF
--- a/docs/superpowers/specs/2026-05-01-v0.4-web-design.md
+++ b/docs/superpowers/specs/2026-05-01-v0.4-web-design.md
@@ -1,0 +1,3174 @@
+# v0.4 web design (consolidated)
+
+**Status:** locked
+**Approved:** 2026-05-01 stage-4 r2 (R1-R6 all APPROVE post-#741 #742)
+**Sources:** docs/superpowers/specs/v0.4-web-chapters/00-overview.md..11-references.md @ commit a292ddbe364381bf4553f1420f53e9adc2cd707c
+**Spec:** ccsm v0.4 — Web client + Connect/Protobuf protocol formalization
+**Author:** ccsm
+**Base:** v0.3 daemon split (already merged on `working`)
+**Predecessor design doc:** `docs/superpowers/specs/2026-04-30-web-remote-design.md`
+
+## Document conventions
+
+This consolidated spec promotes each former chapter file (00..11) to a top-level `## N. <title>` section. Internal subsection headings within each chapter are shifted down one level (former `## TOC` becomes `### TOC`, former `### 1.1` becomes `#### 1.1`, etc.). Cross-chapter references that previously read "chapter NN §M" remain phrased that way; readers should resolve them to the corresponding `## NN.` top-level section in this document.
+
+The 12 source chapter files at `docs/superpowers/specs/v0.4-web-chapters/` are deleted by the same commit that lands this consolidated file; this document is the single canonical v0.4 design source going forward.
+
+---
+
+
+## 0. Overview
+
+**Spec:** ccsm v0.4 — Web client + Connect/Protobuf protocol formalization
+**Status:** draft (spec-pipeline stage 1)
+**Author:** ccsm
+**Base:** v0.3 daemon split (already merged on `working`)
+**Predecessor design doc:** `docs/superpowers/specs/2026-04-30-web-remote-design.md`
+
+### Context block
+
+ccsm v0.3 split the Electron app into two processes — a headless Node `daemon/` (sessions, PTY, SQLite, CLI subprocess, Claude SDK) and a thin Electron client (tray + window + renderer). The two communicate over a same-machine same-user **named pipe (Win)** / **Unix socket (Mac/Linux)** using a **hand-rolled length-prefixed JSON envelope** with HMAC handshake, deadline / migration-gate interceptors, and per-frame chunking. Renderer still calls preload bridges (`window.ccsm*`) which today wrap `ipcRenderer.invoke` against Electron main; main forwards into the local daemon.
+
+v0.4 finishes the long arc the v0.3 design doc sketched: **(a)** replace the hand-rolled envelope with **Connect + Protobuf** generated from a versioned `proto/` schema, **(b)** swap every preload bridge from `ipcRenderer.invoke` to a Connect client (bridge surface unchanged so the renderer is untouched), and **(c)** ship a **Web client** — a Vite SPA reusing the same React renderer code, deployed on **Cloudflare Pages**, talking to the user's local daemon via **Cloudflare Tunnel** with **Cloudflare Access (GitHub OAuth IdP)** in front and JWT validation middleware on the daemon.
+
+Per user clarification 2026-05-01, v0.4 = "do the web client". The §8 release-slicing of the predecessor doc split this across v0.4 (protobuf only) + v0.5 (web + Cloudflare). v0.4 now bundles both. v0.5 becomes the next slice (mobile, multi-user sharing, etc. — out of scope here).
+
+### What v0.4 ships
+
+1. **`proto/` schema directory** — Protobuf v3 service + message definitions covering every existing IPC bridge call. `buf` toolchain (`buf lint`, `buf breaking`, `buf generate`) wired into CI. TypeScript bindings emitted into `gen/ts/` and consumed by both Electron renderer and the new Web client.
+2. **Connect protocol on the daemon** — `@connectrpc/connect-node` server replacing the hand-rolled envelope on the data socket. The control socket (supervisor `/healthz`, `daemon.hello`, `daemon.shutdown*`, `/stats`) stays on the v0.3 hand-rolled envelope on a separate transport (per chapter 02 §6 — moving the supervisor surface to Connect is a v0.5 housekeeping item). Local socket peer-cred verification, ACL, and 16 MiB frame cap all preserved (Connect HTTP/2 framing inherits the cap natively).
+3. **Bridge swap, all ~46 calls** — every `ipcRenderer.invoke('foo', ...)` in `electron/preload/bridges/*.ts` is replaced with a Connect client call; bridge function signatures unchanged so renderer code is untouched. Per chapter 03 §1 inventory: 31 unary + 4 fire-and-forget + 11 streams = 46 cross-boundary calls. Done in 4 PR-sized batches grouped by domain (read-only, then write, then streams).
+4. **Web client (`web/` package)** — Vite SPA wrapping the same `src/` renderer code as Electron. Static build deployed to Cloudflare Pages on push to `main`. In dev, runs on `vite dev` against a locally running daemon (with Tunnel optional).
+5. **Cloudflare layer** — `cloudflared` Tunnel (spawned by daemon when remote access is enabled), Cloudflare Access zero-trust application with GitHub OAuth IdP, JWT validation middleware on daemon's remote ingress.
+6. **Auto-start at OS boot** — opt-in setting (default OFF), so remote-only access works when the desktop is closed. Surfaced in tray menu and Settings.
+
+### Who it's for
+
+Single-user remote access. The author's primary use case: Windows box at home running the daemon with sessions in flight; open `app.<your-domain>` from a work laptop or phone browser; pick up exactly where you left off. Multi-user / multi-tenant is explicitly out of scope (see chapter 01).
+
+### Success criteria
+
+A v0.4 release succeeds when **all** of the following hold for 7 consecutive days of dogfood:
+
+1. **Electron path unchanged for end users** — no visible regression vs v0.3 in latency, throughput, reliability, or UI behavior. Local-only users notice nothing.
+2. **Web client end-to-end** — author opens `https://app.<your-domain>` from a non-author network (work, phone-tether), authenticates via GitHub OAuth, lists sessions, opens a session, sees live PTY output, types into the session, and sees the result mirrored on the desktop client. No daemon restart required.
+3. **Multi-client coherence** — Electron and Web simultaneously attached to the same session both see the same PTY buffer (snapshot + live ops). Inputs from either side are honored in arrival order; neither side diverges.
+4. **Reconnect** — Web client survives a 30-minute network drop and resumes via `fromSeq` replay when within the fanout-buffer window OR via fresh snapshot when the drop exceeds the buffer (no data loss; user sees current PTY state on resume). Electron does the same when the daemon restarts. Per chapter 06 §6, the 256 KiB replay budget covers ~minutes of typical chat output but not 30 min of busy compile logs; the snapshot fallback covers the long tail. Chapter 08 §5 includes both short-drop (seq replay) and long-drop (snapshot fallback) tests.
+5. **Protocol gate** — `buf breaking` against the previous tagged release (`v0.4.0-rc1` etc.) passes on every PR touching `proto/`. Schema changes that would break wire compat are blocked at CI.
+6. **Auto-start works** — opt-in setting flipped ON, machine rebooted, daemon comes up before Electron is launched, web client is reachable within 30s of OS login.
+
+### Why this matters
+
+v0.3 paid the architecture cost (process split, daemon lifecycle, PTY headless buffer + seq replay, supervisor surface, SQLite migration). Without v0.4, that cost is invisible to the user — Electron talks to a local daemon over a private pipe, exactly as before. v0.4 cashes in the investment: the protocol becomes a real published wire surface (`buf` codegen, breaking-change gate), and the same daemon now serves a browser anywhere on the internet. Every future client (mobile, CLI, IDE plugin, alt UI) is downstream of v0.4's `proto/` + Connect server work.
+
+### Out of scope (one-line each, expanded in chapter 01)
+
+- Mobile (iOS/Android native) — deferred to v0.5+.
+- Multi-user / multi-tenant daemon — single user only.
+- Feature redesigns of the renderer (sidebar, terminal display, agent list, notify, etc.) — v0.4 is +frontend, not +features.
+- Daemon-on-cloud (SaaS) — daemon stays on user's machine; Cloudflare is ingress only.
+- Headless daemon with no Electron present — Electron remains the primary install path; web is additive.
+
+### Document map
+
+- **00 Overview** (this file)
+- **01 Goals + non-goals**
+- **02 Protocol** (Connect, Protobuf, `proto/` layout, `buf` CI)
+- **03 Bridge swap** (`ipcRenderer.invoke` → Connect client, per-bridge plan)
+- **04 Web client** (Vite SPA, shared-renderer packaging, Cloudflare Pages)
+- **05 Cloudflare layer** (Tunnel, Access GitHub OAuth, JWT middleware)
+- **06 Streaming + multi-client** (Connect server-stream, heartbeats, seq replay)
+- **07 Error handling + edge cases**
+- **08 Testing** (proto contract tests, Electron+web e2e, `buf` CI)
+- **09 Release slicing** (M1–M4 inside v0.4)
+- **10 Risks**
+- **11 References**
+
+## 1. Goals and non-goals
+
+### Context block
+
+v0.4 is fundamentally a **+frontend** change: it adds a second client (web browser) to the v0.3 daemon, and it formalizes the wire protocol so any future client speaks the same schema. It is **not** a feature redesign. The user's Q1 message reaffirmed this: v0.4 also adds a frontend, and like the daemon split it should avoid changing product features. Every goal below either (a) makes the new client possible, (b) closes a gap that the new client exposes, or (c) is a hard prerequisite for shipping safely. Anything that doesn't fit one of those three buckets is rejected and listed under non-goals with a "**Why deferred:**" note.
+
+### TOC
+
+- 1. Primary goals (must ship for v0.4 to be called shipped)
+- 2. Secondary goals (ship if the implementation falls out cleanly)
+- 3. Non-goals (deferred / out of scope)
+- 4. Anti-goals (we explicitly will NOT do these)
+- 5. Conformance language
+
+### 1. Primary goals
+
+**Invariant for §1:** every primary goal is either (a) the new client itself, (b) the protocol formalization required by the new client, or (c) a hard prerequisite for the new client to function. Goals that don't fit are demoted to non-goals.
+
+**G1. Connect+Protobuf wire protocol on the daemon.** Replace the hand-rolled length-prefixed JSON envelope (v0.3 §3.4.1) on the **data socket** with `@connectrpc/connect-node` over HTTP/2. Schema lives in `proto/` and is the single source of truth for both the Electron renderer (via Connect-Node-over-IPC adapter, see chapter 03 §3) and the web client (via `@connectrpc/connect-web`).
+
+**Why:** v0.3 explicitly punted real Connect to v0.4 ("the hand-written length-prefixed JSON envelope used in v0.3 (Plan Task 5; replaced by real Connect-RPC over HTTP/2 in v0.4)" — frag-3.4.1). Without it, codegen, breaking-change detection, and any non-TS client are all blocked.
+
+**G2. `buf` toolchain in CI.** `buf lint` (style + breaking-policy enforcement) and `buf breaking` (vs latest tagged release) MUST pass on every PR touching `proto/`. `buf generate` MUST run as part of the build and produce TypeScript code committed to `gen/ts/` (vendored, not in `.gitignore`).
+
+**Why:** without `buf breaking`, every protobuf edit is a potential silent wire break against any deployed older client (the user's browser tab from yesterday, an Electron client that hasn't auto-updated yet). The gate catches this at PR time.
+
+**Why vendored codegen:** consumers (renderer, web SPA) build with stock Vite/tsc and shouldn't need a `buf` toolchain at install time. Vendoring keeps bootstrap simple; CI verifies the vendored output matches `buf generate`.
+
+**G3. Full bridge swap.** All ~46 cross-boundary IPC calls in `electron/preload/bridges/*.ts` (5 bridge files: `ccsmCore`, `ccsmSession`, `ccsmPty`, `ccsmNotify`, `ccsmSessionTitles`) plus the `electron/ipc/*` main-process handlers route through Connect — per chapter 03 §1 inventory: 31 unary + 4 fire-and-forget + 11 streams. After v0.4, no `ipcRenderer.invoke` call survives in `electron/preload/bridges/`. Window-only / clipboard-only IPCs (e.g. `window:minimize`, `clipboard.readText`) MAY stay on `ipcRenderer` because they don't cross the daemon boundary — see chapter 03 §2.
+
+**Why:** partial swap leaves two parallel transports indefinitely (envelope + Connect), which is exactly the maintenance burden v0.4 exists to retire. A complete swap also means the Web client (which has no `ipcRenderer`) sees the same bridge surface.
+
+**G4. Web client reachable via Cloudflare Tunnel.** Author opens a browser from any network, hits `https://app.<your-domain>`, authenticates via GitHub OAuth (Cloudflare Access), and reaches the live daemon. Sessions, PTY, settings — all functional.
+
+**Why:** this is the user-visible value. Without it, v0.4 is invisible plumbing.
+
+**G5. Multi-client coherence.** Electron and Web attached to the same session see the same PTY view (already enabled by v0.3's headless buffer + seq replay; v0.4 just exercises it for real). Inputs from either side are honored in PTY-input-queue arrival order.
+
+**Why:** the headline use case is "leave Electron running at home, also use web from laptop". If the two clients diverge, the feature is broken.
+
+**G6. Auto-start at OS boot (opt-in).** A Settings toggle + tray menu item enables daemon auto-start at login (Win startup folder shortcut / launchd `RunAtLoad` / systemd `WantedBy=default.target`). Default OFF in v0.4.
+
+**Why:** remote access depends on the daemon being up. This goal exists ONLY as a hard prerequisite for G4 (web client reachable when desktop is closed); it is not a generally-useful product feature. Until the user explicitly enables auto-start, the remote URL works only while Electron is running. This goal closes that gap and nothing more.
+
+**Why surfaced in tray menu (not just Settings):** Settings pane visibility requires opening the desktop app, which defeats the purpose for users who keep the app minimized. The tray menu item is the minimal additional surface to make the toggle discoverable without scope-creeping the auto-start UX. The single tray entry mirrors the Settings toggle and does not introduce new states (scheduling, conditional auto-start, etc.).
+
+**Why default OFF:** least-surprise on first install; flipping the user's boot state without consent is hostile. Promote default to ON in a later release once the dogfood week is clean.
+
+### 2. Secondary goals
+
+**S1. Custom-domain support for the Tunnel hostname.** Default is the auto-generated `<random>.cfargotunnel.com`. If the user owns a domain configured in Cloudflare DNS, surface a Settings field to use `daemon.<your-domain>` instead. Pure config, no protocol change.
+
+**Why secondary:** the random hostname works end-to-end; custom domain is polish.
+
+**S2. Web client offline UX.** When the daemon is unreachable, show a skeleton + retry banner (chapter 04 §6). No service worker / PWA caching of session content in v0.4.
+
+**Why secondary:** the retry banner is a small visible behavior; PWA caching is a separate large work item with its own coherence problems (stale data shown to user on reconnect). Defer the cache.
+
+**S3. Daemon emits structured logs for the new Connect surface.** Pino lines tagged `transport=connect`, `method=<rpc>`, `peer=<local|tunnel>`, `traceId=<ulid>`. Reuses the v0.3 traceId convention.
+
+**Why secondary:** observability is essential, but inherits the v0.3 logging infrastructure unchanged. Listed here as a reminder to wire the new surface into the existing logger, not as a new system.
+
+### 3. Non-goals (deferred / out of scope)
+
+**N1. Mobile (iOS / Android native).**
+**Why deferred:** Swift / Kotlin codegen is emitted by `buf generate` (see chapter 02 §3), so the protocol is mobile-ready from v0.4. The actual SwiftUI / Compose client work is its own multi-week effort and is the primary content of v0.5+.
+
+**N2. Multi-user / multi-tenant daemon.**
+**Why deferred:** v0.4 is single-user. The Cloudflare Access policy is `email == <author's GitHub email>`; daemon RPC handlers do not carry an authenticated user identity. Multi-tenant requires per-user data isolation in SQLite (per-user PTYs, per-user settings), per-user ACL on every RPC, and a separate billing/quota layer. Out of scope. Target: v0.7+ if author chooses to share with friends.
+
+**N3. Feature redesigns of the renderer.**
+**Why deferred:** v0.4 is +frontend additive. The renderer (`src/`) ships unchanged except for any small adjustments forced by the bridge swap or the web build packaging (e.g. `process.platform` no longer available in browser). Sidebar layout, terminal display, agent list, notify behavior — none change. **If the implementation finds itself proposing UI changes, that's a scope leak and the change is rejected unless re-justified as a v0.4 prerequisite.**
+
+**N4. Daemon-on-cloud (SaaS).**
+**Why deferred:** the daemon stays on the user's machine. Cloudflare is **ingress only** (Tunnel + Access). Moving the daemon to the cloud means moving SQLite + the PTYs + the Claude SDK + the user's filesystem access — a fundamentally different product. Not happening.
+
+**N5. Headless daemon with no Electron.**
+**Why deferred:** Electron remains the primary install path. The daemon ships inside the Electron installer; there is no standalone "daemon only" install in v0.4. A headless install is a 1-2-day follow-up but adds OS service installer surface (Win Service, launchd plist, systemd unit) that's not justified until at least one user wants it.
+
+**N6. Replacing the v0.3 control socket / supervisor RPC surface with Connect.**
+**Why deferred:** the control socket (`/healthz`, `daemon.hello`, `daemon.shutdown*`, `/stats`) is **kept** as a separate transport with its own narrow allowlist, per v0.3 §3.4.1.h. v0.4 swaps the **data socket** to Connect. The control socket can also move to Connect later but is currently fine and changing it adds risk to the supervisor / restart paths that the user already relies on. Target: v0.5 housekeeping.
+
+**N7. Sigstore / signed daemon binaries (so we can flip auto-update default ON).**
+**Why deferred:** v0.3 already shipped daemon auto-update as opt-in. v0.4 keeps the same default. Signing infrastructure (sigstore, GitHub OIDC keyless) is a tangential concern. Target: parallel track.
+
+**N8. Web push notifications.**
+**Why deferred:** the web client receives notifications **only while the tab is open** (regular browser Notification API). Web push (server-pushes-while-tab-closed) requires VAPID keys, a Service Worker, and a push subscription stored on the daemon. Enough complexity that it gets its own slice. Target: v0.5+.
+
+**N9. Performance optimization passes on the new wire.**
+**Why deferred:** v0.4 must not regress vs v0.3. It MAY also not be faster. If we discover the Connect-Web client over Tunnel adds noticeable latency, we measure, log, and fix in a follow-up unless it crosses the "user notices stutter" threshold (see chapter 10 risks).
+
+### 4. Anti-goals
+
+**A1. We will NOT keep the hand-rolled envelope alongside Connect.**
+**Why:** dual transports forever is the trap. M1–M4 (chapter 09) sequence the swap; once a bridge is on Connect it stays on Connect.
+
+**A2. We will NOT introduce a new authentication identity for local Electron.**
+**Why:** local socket peer-cred + ACL is the v0.3 trust boundary and remains in v0.4. Adding a JWT requirement to the local path would be theatre and would break headless dev (`vite dev` against the local daemon has no JWT).
+
+**A3. We will NOT couple Electron and daemon versions tighter than they already are.**
+**Why:** v0.3 ships them in lockstep via one installer (frag-11 §11). v0.4 keeps that. Separating release cadences is N6's parallel track.
+
+**A4. We will NOT redesign the renderer for "responsive web" (mobile breakpoints, touch).**
+**Why:** the web client is the same React renderer, sized for laptop browsers. Mobile is N1. If a phone browser opens it, it works (because the layout is fluid enough), but designing-for-touch is a separate large effort.
+
+**A5. We will NOT iterate on auto-start UX in v0.4 beyond the single Settings toggle + matching tray menu item.**
+**Why:** G6 is a remote-access prerequisite, not a feature axis. Scheduling, conditional auto-start, polish passes, etc. are all out of scope for v0.4.
+
+### 5. Conformance language
+
+This spec uses RFC 2119 keywords. **MUST** = blocking requirement; **MUST NOT** = forbidden; **SHOULD** = strongly recommended, deviations need explicit justification in the implementation PR; **SHOULD NOT** = strongly discouraged, same; **MAY** = optional, choose freely. Each architectural decision in subsequent chapters is followed by `**Why:**` justifying it. Each non-goal carries `**Why deferred:**` plus a target version where applicable.
+
+## 2. Protocol (Connect + Protobuf + buf)
+
+### Context block
+
+v0.3's data socket runs a hand-rolled length-prefixed JSON envelope (`daemon/src/envelope/envelope.ts`, ~200 LOC) with HMAC handshake (`hello-interceptor.ts`, ~420 LOC), deadline + migration-gate interceptors, manual chunking for stream payloads, and binary-trailer carve-out for PTY bytes. It works, but it is a custom protocol with no schema language, no breaking-change detector, no codegen for non-TS clients, and no published wire surface. v0.4 retires it for **Connect over HTTP/2**, with **Protobuf v3** as the schema language and **`buf`** as the build/lint/breaking-change toolchain. The control socket (supervisor RPCs) is **not** changed in v0.4 — it stays on the v0.3 envelope, see §6.
+
+### TOC
+
+- 1. Wire choice: Connect (lock)
+- 2. Schema language: Protobuf v3 (lock)
+- 3. `proto/` directory layout
+- 4. `buf` toolchain + CI
+- 5. Codegen pipeline
+- 6. What does NOT move to Connect (control socket)
+- 7. Versioning + back-compat strategy
+- 8. Wire-level inheritances from v0.3 (carried forward)
+
+### 1. Wire choice: Connect
+
+**Decision (lock):** Connect-RPC, server via `@connectrpc/connect-node`, browser client via `@connectrpc/connect-web`, Electron renderer client via `@connectrpc/connect-node` over a custom IPC transport (chapter 03 §3).
+
+**Why:**
+1. Browser-friendly without an Envoy proxy (unlike grpc-web) — Connect speaks plain HTTP/2 / HTTP/1.1 + `application/proto` or `application/json`. Critical for the "Cloudflare Tunnel just works" path.
+2. Wire-compatible with Connect-Go, Connect-Swift, Connect-Kotlin — opens future native clients without protocol rewrite.
+3. Same schema language (Protobuf) as gRPC, so the `proto/` directory is portable to gRPC if we ever need it (we don't expect to).
+4. F4 spike (referenced in v0.3 §12) explicitly evaluated and locked Connect+Protobuf+buf over alternatives (gRPC, TypeSpec, tRPC, raw JSON).
+
+**Rejected alternatives:**
+- **gRPC-Web:** requires Envoy (or a proxy with gRPC-Web filter) to translate to gRPC. Cloudflare Tunnel doesn't translate. Rejected for v0.4.
+- **tRPC:** TS-only. Rules out future Swift / Kotlin / CLI-Go clients. Rejected.
+- **TypeSpec → OpenAPI/JSON:** no streaming model, weak for PTY-style server pushes. Rejected.
+- **WebSocket + JSON envelope (just keep what we have):** misses every reason to do v0.4 — no schema, no breaking-change detector, no codegen.
+
+**Half-duplex caveat:** Connect-Web in the browser is **half-duplex** over HTTP/2 (server-streaming yes; client-streaming and bidi no). v0.4 does not need bidi; PTY input is a unary message-per-keystroke (or per-keystroke-batch, see chapter 06 §3), and PTY output is server-stream. F4 spike confirmed this works for ccsm. If a future feature needs bidi (collaborative cursor sharing, etc.), revisit then; the daemon can serve full bidi to non-browser clients via Connect-Node without touching Connect-Web.
+
+### 2. Schema language: Protobuf v3
+
+**Decision (lock):** Protobuf syntax 3 (`syntax = "proto3";`).
+
+**Why:**
+1. `buf` toolchain is built around proto3.
+2. Proto3 default-values + missing-field semantics are well-understood; v0.4 uses explicit `optional` for nullable fields per protobuf 3.15+ to avoid the "is the value missing or zero?" trap.
+3. Reserved tags + reserved field names give a clean back-compat story (chapter 07 §4 version-skew).
+
+**Codegen targets:** TypeScript (consumed by renderer + web client) ships in v0.4. Swift + Kotlin codegen MAY be wired into `buf.gen.yaml` but their output is unused until v0.5+. Generating them keeps the schema honest (lint catches Swift-incompatible field names, etc.) without adding runtime dependencies in v0.4.
+
+### 3. `proto/` directory layout
+
+Located at the repo root (sibling of `daemon/`, `electron/`, `web/`).
+
+```
+proto/
+├── buf.yaml                         # buf module config
+├── buf.gen.yaml                     # codegen plugin pipeline
+├── buf.lock                         # dependency lock (well-known protos etc.)
+└── ccsm/
+    └── v1/
+        ├── core.proto               # versions, ping, OS info, paths-exist
+        ├── session.proto            # session list / state / activate / setName
+        ├── session_titles.proto     # SDK-summary get/rename/list
+        ├── pty.proto                # spawn / attach / detach / input / resize / kill / stream
+        ├── notify.proto             # flash sink, user-input markers
+        ├── settings.proto           # i18n, model preference, settings get/set
+        ├── updater.proto            # auto-update status / check / download / install
+        ├── import.proto             # importable-session scan, recent cwds
+        └── service.proto            # the umbrella `service Ccsm { rpc ... }` definition
+```
+
+**Why namespace `ccsm.v1`:** standard protobuf convention `<org>.<api-version>`. The `v1` prefix in the package path lets us ship a `v2` namespace later if a hard wire break is ever needed (hopefully never; chapter 07 covers field-level back-compat). `v1` ALSO is used in HTTP path routing per Connect convention: `POST /ccsm.v1.Ccsm/ListSessions`.
+
+**Why one umbrella service rather than one service per domain:** Connect routes per-method, not per-service. Splitting `service Session { rpc ... }` from `service Pty { rpc ... }` adds path noise (`/ccsm.v1.Session/...` vs `/ccsm.v1.Pty/...`) without functional benefit. The renderer's bridge files give us domain grouping at the TS layer; the wire is one service.
+
+**Per-domain `.proto` files (not one mega-file):** keeps blast radius of edits small. `pty.proto` changes don't show up in the diff for a `notify.proto` PR.
+
+### 4. `buf` toolchain + CI
+
+**Tools:** `buf` CLI (https://buf.build), pinned via `package.json` devDep `@bufbuild/buf` for cross-platform install. Plugins: `@bufbuild/protoc-gen-es` (TS code), `@bufbuild/protoc-gen-connect-es` (Connect TS service stubs).
+
+**`buf.yaml`** (key fields):
+```yaml
+version: v2
+modules:
+  - path: ccsm
+breaking:
+  use:
+    - FILE
+lint:
+  use:
+    - DEFAULT
+  except:
+    - PACKAGE_VERSION_SUFFIX  # we use ccsm.v1, not ccsm.v1alpha
+```
+
+**`buf.gen.yaml`:**
+```yaml
+version: v2
+plugins:
+  - local: protoc-gen-es
+    out: gen/ts
+    opt:
+      - target=ts
+  - local: protoc-gen-connect-es
+    out: gen/ts
+    opt:
+      - target=ts
+```
+
+**CI gates** (GitHub Actions, run on every PR touching `proto/**` or `gen/**`):
+1. `buf lint` — MUST pass (zero warnings, zero errors). Budget ≤5s.
+2. `buf breaking --against '.git#branch=working,subdir=proto'` — MUST pass against the **merge target** (`working`) branch tip when `proto/**` changes (skip when only `gen/**` changes — a regen with no `.proto` change cannot be wire-breaking). Detects wire-incompatible edits (deleted field, changed tag number, changed type, changed cardinality). Budget ≤15s. Separate **release-tag job** runs `buf breaking --against '.git#tag=v<previous>,subdir=proto'` at every `v*` tag to catch regressions across releases.
+3. `buf generate && git diff --exit-code gen/` — verifies vendored codegen matches what `buf generate` would produce. Catches "edited the .proto but forgot to regenerate" PRs. Budget ≤10s. When bumping codegen plugins, regenerate `gen/` in the same PR; CI compares against the bumped baseline.
+
+**Why baseline `working` not `main`:** PRs in this repo target `working`; the merge target IS the breaking-check baseline. A separate tag-time check catches release-to-release breaks. Comparing to `main` while merging to `working` produces drift (changes merged to `working` but not yet promoted to `main` would silently re-baseline the next PR).
+
+**Why fail PR on diff in `gen/`:** if the codegen output drifts from the `.proto`, downstream consumers will get type mismatches at build time. Forcing the diff to be clean keeps `gen/` as a deterministic projection of `proto/`. To prevent codegen-version flake, `@bufbuild/buf` and `@bufbuild/protoc-gen-es` MUST be pinned to **exact** patch versions in `package.json` (no `^`); CI caches the `buf` binary via `actions/cache` keyed on the lockfile.
+
+**Local developer flow:** `npm run proto:gen` (alias for `buf generate`) before committing. Pre-commit hook MAY enforce this; not blocking for v0.4 (CI catches it).
+
+#### 4.1 Intentional breaking changes (override mechanism)
+
+The `buf breaking` gate has an explicit override path so the team is never blocked from a needed wire-break (e.g. v0.5 retires a deprecated field, or a hot security fix requires removing a leaky field):
+
+- PR title MUST be prefixed `[proto-break]` to opt out of the standard `buf breaking` gate.
+- A `[proto-break]` PR MUST: (a) bump the namespace to `ccsm.v<N+1>`, AND (b) keep the `ccsm.v<N>` package generated alongside for one release cycle (allows old clients during deprecation window).
+- Deprecation window: previous namespace stays generated for **1 minor release** after introduction of the new namespace; removal in the release after.
+- Without the `[proto-break]` prefix, the standard `buf breaking` gate stays on (i.e. opt-out is explicit and reviewable).
+
+### 5. Codegen pipeline
+
+**Output dir:** `gen/ts/ccsm/v1/`. Vendored (committed). Consumers import from `@ccsm/proto-gen/v1` (a tiny package that just re-exports `gen/ts/`) so the import paths are stable even if the layout changes.
+
+**Why a wrapper package:** raw `gen/` paths are noisy (`gen/ts/ccsm/v1/pty_connect.js`). A package alias like `@ccsm/proto-gen` lets us reorganize internally without touching every consumer. The wrapper has no logic — pure re-export.
+
+**Type-only vs runtime:** the generated TS includes both types (request/response interfaces) and runtime (Connect service stubs, encoders/decoders). Renderer + web both bundle the runtime; daemon binds the same service stubs on the server side.
+
+**Tree-shaking:** `gen/ts/` MUST be ESM (Connect-ES default). Renderer/web bundlers (Vite) tree-shake unused RPC stubs out of the production bundle. Daemon (CJS via `@yao-pkg/pkg`) imports the full surface — pkg handles ESM-to-CJS interop.
+
+**Build sequencing:** `buf generate` runs in `npm run build` BEFORE `tsc` so daemon/renderer/web builds always see fresh stubs. CI also runs `buf generate` independently to catch drift.
+
+**Repo hygiene for vendored codegen:** to keep `gen/` from polluting routine PR review:
+- `.gitattributes` MUST mark `gen/** linguist-generated=true -diff` so GitHub collapses generated diffs by default.
+- Expected `gen/` size budget: <10 KLOC at v0.4.0. >30 KLOC = revisit the vendoring decision (drop to CI-regenerate-at-install).
+- **`pkg` ESM-interop spike (M1 prerequisite):** before M1 freezes the toolchain, run a spike that builds the daemon installer with the actual generated ESM Connect stubs through `@yao-pkg/pkg`. v0.3 packaging notes flag pkg ESM as fragile; if it chokes on the generated surface, fall back to the CI-only "regenerate at install" mode (skip vendoring, regen during `npm run build`). See chapter 09 M1 deliverables.
+
+### 6. What does NOT move to Connect (control socket stays on envelope)
+
+**Decision:** the **control socket** (a.k.a. supervisor transport, `daemon/src/sockets/control-socket.ts`, separate from `data-socket.ts`) keeps the v0.3 hand-rolled envelope. RPC allowlist unchanged: `/healthz`, `/stats`, `daemon.hello`, `daemon.shutdown`, `daemon.shutdownForUpgrade`. See `daemon/src/envelope/supervisor-rpcs.ts`.
+
+**Why deferred:** the supervisor surface is small (5 RPCs), used only locally between Electron-supervisor-child and daemon, and is on the critical path for daemon restart / upgrade. Re-platforming it adds risk to the lifecycle code that the user already depends on, with no user-visible benefit. Convert it in a later release (v0.5 housekeeping) if there's reason to.
+
+**Implication for the daemon process:** the daemon binds **two** transports:
+1. **Control socket** (`\\.\pipe\ccsm-sup` on Win, `~/.ccsm/daemon-sup.sock` on Mac/Linux): hand-rolled envelope, supervisor RPCs only.
+2. **Data socket** (`\\.\pipe\ccsm-daemon` on Win, `~/.ccsm/daemon.sock` on Mac/Linux): **Connect over HTTP/2** in v0.4 (was hand-rolled envelope in v0.3). All ~46 bridge RPCs (per chapter 03 §1 inventory) + future RPCs.
+
+Both transports inherit v0.3 §3.1.1 hardening: peer-cred verification, named-pipe ACL or 0700 socket mode, 16 MiB frame cap (HTTP/2 frame max). The remote ingress (Cloudflare Tunnel) terminates on the **data socket** only — supervisor RPCs are local-only forever.
+
+### 7. Versioning + back-compat strategy
+
+**Wire version negotiation:** Connect-RPC carries no native version handshake (HTTP/2 + content-type negotiation IS the handshake). v0.4 introduces a `Ping` RPC that returns `{ daemonVersion, protoVersion: "ccsm.v1" }`; clients call it on connect and surface a "daemon out of date" banner if `protoVersion` doesn't match expected. Hard version skew (e.g. client expects `v2`, daemon serves `v1`) is rejected at the renderer's boot probe.
+
+**Field-level back-compat:**
+- Adding a field to a message: **safe**, MUST get a fresh tag number.
+- Removing a field: **breaking**, MUST add `reserved <tag>;` to prevent reuse and bump the namespace if it's a serious break (we don't expect to do this in v0.4).
+- Renaming a field: **safe at wire level** (tag-numbered), but the codegen TS output changes — treated as a source-breaking change requiring all consumers to update in the same PR.
+- Changing a field type: **breaking**, requires `reserved <tag>;` + new field with new tag.
+
+**`buf breaking` enforces the wire-level rules automatically.** Source-breaking changes are caught by tsc.
+
+**Cross-version client/daemon matrix:**
+
+| Client | Daemon | Outcome |
+|---|---|---|
+| v0.3.x Electron + envelope | v0.4 daemon (Connect on data socket) | **Blocked.** Single installer for v0.4 ships matched Electron+daemon. Pre-v0.4 Electron probes data socket, gets HTTP/2 frame, fails handshake, surfaces `daemon.unreachable` banner. User must reinstall. |
+| v0.4 Electron | v0.3.x daemon | **Blocked.** v0.4 Electron speaks Connect; v0.3 daemon speaks envelope. Connect client times out; renderer surfaces `daemon.unreachable`. |
+| v0.4 web client | v0.4 daemon | **Supported.** |
+| v0.4 web client | v0.5+ daemon | **Supported via field-level back-compat.** Old web tab in user's browser may lack new fields; daemon defaults them. New web tab on next page load picks up the latest schema. |
+
+**Why no soft-fallback / dual-protocol on data socket:** complexity vs benefit. Single installer (matched versions) plus Cloudflare Pages serving the latest web bundle solves 99% of skew. The remaining 1% (user has a stale browser tab open during a daemon upgrade) is handled by the v1.Ping handshake + `daemon.unreachable` banner with a "reload" button.
+
+### 8. Wire-level inheritances from v0.3 (carried forward into Connect)
+
+The v0.3 hand-rolled envelope carried hardening rules that MUST survive the Connect swap. Connect over HTTP/2 inherits some natively; others MUST be re-implemented as Connect interceptors.
+
+| v0.3 mechanism | v0.4 path |
+|---|---|
+| 16 MiB frame cap | **Per-message** cap implemented via Connect-Node `readMaxBytes` option on every server route (HTTP/2 frame size is a separate transport setting we leave at Node default). Per-route caps:<br>- Default: 4 MiB.<br>- `SendPtyInput`: 1 MiB.<br>- `Db.save`: 16 MiB.<br>- `Importer.scanRecentCwds`: 4 MiB.<br>An interceptor logs (and rate-limits) requests within 10% of the cap so attack patterns surface in pino. The HTTP/2 server's `SETTINGS_MAX_FRAME_SIZE` is left at Node default 16 KiB; a single large message is reassembled across many DATA frames bounded by `readMaxBytes`. |
+| Per-frame deadline (`x-ccsm-deadline-ms`) | Connect interceptor on both client + server reading the same header. Default 30s; clamp at 120s per v0.3 §3.4.1.f. |
+| HMAC `daemon.hello` handshake | **Replaced** by Connect TLS-or-local-trust + Cloudflare Access JWT for remote. Local socket peer-cred (v0.3 §3.1.1) is the local trust boundary; HMAC was a same-machine secret check, redundant once peer-cred is enforced. |
+| Trace-id ULID per envelope | Connect interceptor generates ULID per request, propagates via `x-ccsm-trace-id` header. Pino logs include it. |
+| Migration-gate interceptor (block RPCs while SQLite migration in flight) | Re-implemented as Connect interceptor on the data socket. Same predicate (`isMigrationGated()`), same `MIGRATION_PENDING` error code. **Test seam:** when `process.env.NODE_ENV === 'test'`, the predicate is replaced by a value set via `__setMigrationGateForTest(boolean)` exported from the gate module; never exposed in production builds. Contract test (chapter 08 §3) forces the gate true, calls a gated RPC, asserts `MIGRATION_PENDING`. |
+| Stream chunk reassembly + 16 KiB sub-chunk rule | **Obsolete.** HTTP/2 native frame fragmentation handles this. Connect server-streams emit messages; HTTP/2 fragments them. No application-layer chunking needed. |
+| Binary-trailer carve-out for PTY bytes | Replaced by Protobuf `bytes` field on `PtyChunk`. No JSON round-trip; raw bytes on the wire. See chapter 06 §2. |
+| `streamId` allocation (odd client / even server) | **Obsolete.** HTTP/2 native stream ids on the daemon's HTTP/2 connection serve the same purpose. |
+| Pre-accept rate cap (50/sec) | Re-implemented at the daemon's `Http2Server.on('session', ...)` handler. |
+
+**Interceptor observability:** every interceptor that rejects a request (deadline exceeded, migration gate fired, JWT invalid, `readMaxBytes` exceeded) emits `pino.warn({ interceptor, method, traceId, reason })`. Same surface as v0.3 envelope interceptors. Heartbeat events (chapter 06 §4) are logged at debug level only to avoid log spam from the higher v0.4 request rate. Daemon log retention inherits v0.3's pino-roll cap (max 50 MB × 5 files = 250 MB ceiling, weekly rotation; per v0.3 frag-3.7) for both the Connect server log and `~/.ccsm/cloudflared.log`.
+
+**Local-vs-remote tag isolation (security-critical):** the JWT-validation interceptor fires only when the request arrived on the remote ingress (Cloudflare Tunnel-fronted TCP listener). Requests on the local socket carry a `localTransportKey` context value tagged at the listener and bypass JWT (chapter 05 §4 details the implementation). Contract test "JWT bypass tag isolation" (chapter 08 §3) MUST cover three sub-cases: (a) remote request without JWT → reject; (b) local request without JWT → accept; (c) local request that forges a `Cf-Access-Jwt-Assertion` header → header is ignored, JWT validation interceptor is not invoked, request is accepted on the local-tag basis (NOT spuriously validated against a mock JWKS).
+
+**Why drop HMAC for the local socket:** it was always belt-and-suspenders on top of peer-cred. Peer-cred (`SO_PEERCRED` on Unix, `GetNamedPipeClientProcessId` on Win, see v0.3 §3.1.1) cryptographically proves same-user-same-machine via the kernel. An HMAC handshake on top adds boot-nonce shenanigans (boot-nonce-precedence.ts, ~70 LOC) and a rotation story we'd have to carry forever. Dropping it removes ~500 LOC across `hmac.ts` + `hello-interceptor.ts` + `boot-nonce-precedence.ts` and matches the standard local-IPC trust model.
+
+**Threat model accepted by dropping HMAC:** v0.4 trusts every same-user local process. A same-user process (compromised dev tool, malicious VS Code extension, attacker with same-user code-exec) can issue arbitrary RPCs against the data socket: read PTY output streams (potentially containing user-typed credentials), enumerate sessions, issue settings RPCs (which after v0.5+ may surface OS-keychain-stored secrets such as the Cloudflare Tunnel token, GitHub OAuth artifacts, SDK API keys). This matches the ambient trust model of most desktop apps that hold credentials and rely on the OS user boundary, but does NOT match the harder model used by 1Password / SSH agent / GitHub CLI (which assume same-user processes can be hostile). Re-introducing HMAC (or a similar second-factor on the data socket) is on the v0.5 candidate list. Any post-v0.4 RPC that surfaces OS-keychain material MUST either gate on a freshly-prompted user confirmation or wait for the second-factor to land. Tracked in chapter 10 risks.
+
+**Why keep HMAC for the supervisor (control socket):** the supervisor stays on the envelope (per §6 above), so HMAC stays there too. No code deletion until the supervisor moves.
+
+#### 8.1 JWT validation policy (data socket remote ingress)
+
+The remote-ingress JWT validation interceptor (chapter 05 §4 implements; this section locks the policy fields) MUST configure `jose.jwtVerify` with these explicit options — library defaults are not acceptable because they shift across jose versions:
+
+- `algorithms: ['RS256']` — pin to the algorithm Cloudflare Access actually uses; reject any token signed with another alg even if the JWKS contains a key for it (defends against alg-confusion attacks).
+- `clockTolerance: 30` (seconds) — small skew tolerance between daemon clock and Cloudflare clock; explicit so a future jose default change doesn't silently widen it.
+- `requiredClaims: ['exp', 'iat', 'aud', 'iss', 'sub']` — every Access JWT carries these; missing any = reject.
+- `audience` MUST be the **per-application AUD** for this Access app (NOT a wildcard, NOT shared across the user's other Cloudflare Access apps). Cross-app AUD reuse would let an attacker who got a JWT for an unrelated Access app on the same team validate against this daemon.
+- `issuer` MUST be the team-specific Cloudflare Access issuer URL.
+- JWKS fetch timeout: 5s; fail-closed on timeout (do NOT allow the request through under JWKS unavailability).
+- JWKS unknown-`kid` policy: refresh JWKS at most once per 30s (jose `cooldownDuration: 30000`); on continued miss, fail-closed (do not retry-storm the JWKS endpoint and do not let the request through).
+- `iat` upper-bound check: reject tokens with `iat > now + clockTolerance` (token issued in the future indicates clock-skew attack or compromised CF signer).
+
+Contract test "JWT validation policy" (chapter 08 §3) MUST cover: missing required claim → reject; wrong AUD → reject; alg=HS256 token with key in JWKS → reject; token with `iat` 60s in the future → reject; JWKS endpoint unreachable for new `kid` → reject (NOT pass-through).
+
+### 9. Idempotency model
+
+Connect over HTTP/2 is at-least-once at the application layer when the supervisor respawns the daemon mid-RPC (chapter 07 §1). The client retries; the daemon may have already applied the write. Without an explicit policy, retries duplicate state mutations.
+
+Every RPC defined in `proto/ccsm/v1/` MUST be classified into one of three categories, declared in a `// idempotency:` comment on the RPC definition and reflected in the codegen TS docstring:
+
+1. **`naturally idempotent`** — repeated application produces the same end state. All read RPCs (`ListSessions`, `Ping`, etc.) plus last-write-wins setters (`SetActive`, `SetName`, `SaveSettings`, `Updater.SetChannel`). Client MAY retry freely.
+2. **`dedup-via-server-key`** — the request carries an explicit `string idempotency_key = 1;` field (ULID or UUID). Daemon dedups by key within a 60-second window (in-memory LRU sized for ~10k entries). Repeated submission with the same key returns the cached response. Applies to: `EnqueuePending`, `Notify.Flash`, `UserCwds.Push`, `Db.Save`, any RPC that mutates a queue or appends a row.
+3. **`non-idempotent — must-not-retry`** — repeated application changes monotonic state in a way the daemon cannot dedup. Client MUST surface error to the user and NOT auto-retry on transport failure. Applies to: `Pty.Spawn` (spawning twice creates two PTYs), any future "advance counter" RPC.
+
+`buf lint` MUST enforce that every RPC declaration carries an `// idempotency:` annotation. CI fails if a new RPC lands without one. Chapter 07 §1 daemon-crash recovery references this classification when deciding which RPCs are auto-retried by the bridge layer vs surfaced to the user.
+
+## 3. Bridge swap (ipcRenderer.invoke -> Connect client)
+
+### Context block
+
+The Electron renderer talks to the main process today via 5 preload bridge files (`electron/preload/bridges/ccsm{Core,Session,Pty,Notify,SessionTitles}.ts`) that expose `window.ccsm*` APIs. Each method is `ipcRenderer.invoke('channel', ...args)` (or `ipcRenderer.send` for fire-and-forget) plus a `contextBridge.exposeInMainWorld` registration. Main-process handlers live in `electron/ipc/*.ts` and dispatch into `electron/sessionTitles/`, `electron/notify/`, `electron/pty/`, etc. — most of which already moved to `daemon/` in v0.3, with Electron main now forwarding to the daemon over the v0.3 envelope.
+
+v0.4 cuts out the middle layer **for everything that crosses the daemon boundary**: the preload bridge calls a Connect client directly; the Connect client speaks to the daemon (local socket in Electron, Cloudflare Tunnel in web). Window-only / clipboard-only IPCs that legitimately belong to Electron main stay on `ipcRenderer`.
+
+### TOC
+
+- 1. Inventory of current bridges (RPCs, fire-and-forget, streams)
+- 2. What stays on `ipcRenderer` vs what moves to Connect
+- 3. Renderer → daemon transport in Electron (Connect-Node-over-Unix-socket)
+  - 3.1 Reconnect choreography
+  - 3.2 Preload transport security boundary
+  - 3.3 Structured logging on bridge-side failures
+  - 3.4 Local-transport-key smoke test
+- 4. Bridge surface stability rule
+- 5. Per-batch swap plan (PR boundaries)
+- 6. Migration semantics (no dual-transport during the swap)
+- 7. Test discipline per swap PR
+  - 7.1 Parity-test framework
+  - 7.2 Bridge adapter contract tests (survives M2)
+  - 7.3 Input coalescer unit test
+  - 7.4 PTY input size cap
+
+### 1. Inventory of current bridges
+
+**Terms (used throughout chapters 03/04):**
+- **Bridge file**: one of the 5 `electron/preload/bridges/*.ts` files (`ccsmCore`, `ccsmSession`, `ccsmPty`, `ccsmNotify`, `ccsmSessionTitles`).
+- **Bridge surface**: the public `window.ccsm*` API exposed by all bridge files together. This is what `src/` (the renderer) consumes.
+- **Bridge function**: one method on `window.ccsm*` (e.g. `window.ccsmPty.list()`).
+
+**Naming convention (v0.3 IPC → v0.4 Connect):** v0.3 IPC channel `<domain>:<verbCamel>` maps to proto RPC `<Verb><Domain>` (PascalCase service method) which generates TS client method `<verb><Domain>` (camelCase). Examples: `pty:list` → `ListPty` → `listPty`; `app:getVersion` → `GetAppVersion` → `getAppVersion`; `sessionTitles:listForProject` → `ListSessionTitlesForProject` → `listSessionTitlesForProject`. The bridge function's exported name (e.g. `list()`) is unchanged from v0.3 (per §4 stability rule); only the *internal* call swaps from `ipcRenderer.invoke('pty:list')` to `connectClient.listPty({})`.
+
+Counts as of `working` HEAD (2026-04-30):
+
+| Bridge file | Unary RPCs | Fire-and-forget (renderer→main) | Streams (main→renderer) |
+|---|---|---|---|
+| `ccsmCore.ts` | 17 (`db:load`, `db:save`, `app:getVersion`, `import:scan`, `import:recentCwds`, `app:userHome`, `app:userCwds:get/push`, `cwd:pick`, `settings:defaultModel`, `paths:exist`, `updates:status/check/download/install`, `updates:getAutoCheck/setAutoCheck`, `window:minimize/toggleMaximize/close/isMaximized`, `ccsm:get-system-locale`) | 1 (`ccsm:set-language`) | 4 (`updates:status`, `update:downloaded`, `window:maximizedChanged`, `window:beforeHide`/`window:afterShow`) |
+| `ccsmSession.ts` | 0 | 2 (`session:setActive`, `session:setName`) | 4 (`session:state`, `session:title`, `session:cwdRedirected`, `session:activate`) |
+| `ccsmPty.ts` | 9 (`pty:list/spawn/attach/detach/input/resize/kill/get/getBufferSnapshot/checkClaudeAvailable`) | 0 | 2 (`pty:data`, `pty:exit`) |
+| `ccsmNotify.ts` | 0 | 1 (`notify:userInput`) | 1 (`notify:flash`) |
+| `ccsmSessionTitles.ts` | 5 (`sessionTitles:get/rename/listForProject/enqueuePending/flushPending`) | 0 | 0 |
+
+**Totals:** 31 unary, 4 fire-and-forget, 11 streams = **46 cross-boundary calls**. (The "~22 IPC bridges" figure in the predecessor design doc was an undercount; v0.4 inventory is canonical going forward.)
+
+**Stream-count note (per R6):** `window:beforeHide` and `window:afterShow` are counted as **one paired signal stream** (they always fire together — hide-then-show on dock-hide / dock-show). Splitting them would yield 12 streams; the inventory uses the paired-signal convention (11). The pair is delivered over a single `streamWindowVisibility` server-stream when its underlying channels remain on `ipcRenderer` (per §2 they do, so the pairing is documentary only).
+
+### 2. What stays on `ipcRenderer` vs what moves to Connect
+
+**Stays on `ipcRenderer` (Electron-only, not in `proto/`):**
+
+| Channel | Why it stays |
+|---|---|
+| `window:minimize / toggleMaximize / close / isMaximized` | Electron `BrowserWindow` is renderer-process specific. Web client has no concept of "minimize the OS window". |
+| `window:maximizedChanged / window:beforeHide / window:afterShow` | Same — OS window state events. |
+| `ccsmPty.clipboard.{readText,writeText}` | Electron `clipboard` module; in web, use `navigator.clipboard` (different API surface). Bridge keeps its `clipboard.readText`/`writeText` methods; the implementation forks at build time (Electron uses `clipboard`, web uses `navigator.clipboard`). |
+| `cwd:pick` (folder picker) | Electron `dialog.showOpenDialog`. Web uses `<input type="file" webkitdirectory>` or just disables the picker. Bridge method present in both clients but the Electron impl is `ipcRenderer.invoke`, the web impl is a synthetic File-API wrapper. |
+
+**Moves to Connect (every other entry in §1's table).** The list above is exhaustive: `window:*`, the clipboard surface, and the cwd folder-picker are the only Electron-OS-bound items. Everything else is daemon-domain (sessions, PTY, settings, notify, updater, importable-session scan) and goes through the proto schema.
+
+**Why this split:** the rule is "if the data lives in the daemon, the call goes through Connect". Window chrome and OS dialogs live in Electron main and have no daemon counterpart. The web client can implement its own equivalents (or no-op them) using browser APIs. This keeps the proto schema focused on the actual product surface.
+
+**Updater special case:** the auto-updater (`updates:status/check/download/install`) **belongs to Electron** (it updates the Electron+daemon bundle). However, the **daemon also self-updates** (per v0.3 §3.1) via a separate `daemon-v*` poll-and-replace path. v0.4 keeps both:
+- The renderer's `updates:*` IPCs continue to talk to **Electron** main's `electron-updater` (via `ipcRenderer`) for the desktop app.
+- The web client cannot trigger an Electron-app update (it's running in a browser), so the entire `updates:*` surface in the bridge is **no-op'd** in the web build (returns `{ kind: 'idle' }` from `updatesStatus()`, etc.). Updater Settings rows render in **disabled state** (greyed control + tooltip "auto-update is only available in the desktop client") when `import.meta.env.VITE_TARGET === 'web'`. The DOM structure is preserved (rows still mount), so this is a per-row enabled-state fork, not a structural redesign of the Settings page. This conditional is one of the explicitly-permitted §4 `VITE_TARGET` exceptions (see §4 enumerated list).
+
+**Why no-op rather than remove:** the bridge surface stays identical (rule §4); only the implementation forks. Renderer code calling `window.ccsm.updatesStatus()` works in both clients without conditional code. Why disabled-state rather than hidden: preserves Settings page structure across targets so screenshots/walkthroughs/test selectors don't fork; the only target-specific behavior is the row's `disabled` attribute.
+
+### 3. Renderer → daemon transport in Electron (Connect-Node-over-Unix-socket)
+
+Connect's standard `createConnectTransport` speaks HTTP/2 to a hostname:port. Electron renderer → local daemon needs HTTP/2 over a **Unix domain socket** (Mac/Linux) or **named pipe** (Win). Node's `http2` supports both via `Http2Session` over an existing duplex stream.
+
+**Decision (lock):** custom Connect transport in `electron/connect/ipc-transport.ts` that:
+1. Opens a `net.Socket` to `~/.ccsm/daemon.sock` (Unix) or `\\.\pipe\ccsm-daemon` (Win).
+2. Wraps it in `http2.connect(url, { createConnection: () => socket })`.
+3. Hands the resulting `ClientHttp2Session` to Connect's transport adapter.
+4. Reuses one session across all RPCs (HTTP/2 multiplexing).
+
+**Why a custom transport:** Connect's stock browser/Node transports assume `http://host:port`. Local-IPC is its own beast. The custom transport is ~150 LOC and isolates the IPC concerns; the rest of the renderer code is unaware whether it's talking over a socket or over Cloudflare Tunnel.
+
+**Where it lives:** `electron/connect/ipc-transport.ts` (new). Imported by the **preload** script (which has Node access via `contextBridge`) and exposed through `window.ccsmTransport.create()` consumed by the bridges. The renderer-process bridges hold the Connect client; transport lives in preload to keep `net.Socket` access out of renderer code (CSP-friendly).
+
+**Connection lifecycle:**
+- On bridge install (`installCcsmCoreBridge`, etc.), the preload creates one Connect transport instance and passes it to all bridges. Single shared HTTP/2 session for all calls.
+- Reconnect: if the underlying socket errors (`ECONNRESET`, `EPIPE`), the transport tears down the HTTP/2 session and lazily re-establishes on next call. In-flight RPCs reject with a `unavailable` Connect error; bridges surface this as `BridgeTimeoutError` (existing v0.3 §3.7.5 surface) and the renderer's `useDaemonHealthBridge` shows the `daemon.unreachable` banner.
+- **Reconnect retry (burst phase):** exponential backoff capped at 5s, max 6 attempts in 30s, then surface `daemon.unreachable` per v0.3 §6.8.
+- **Reconnect retry (steady-state phase, per R3 P1-1):** after burst exhaustion, fall back to a 30s steady-state retry that continues indefinitely, matching the web client cadence (chapter 04 §6). The transport tracks a `phase: 'burst' | 'steady'` field; on first success the phase resets to `burst`. The renderer's `daemon.unreachable` banner MUST include a manual "Retry now" button that triggers an out-of-cycle reconnect attempt (cross-ref chapter 04 §6 surface — same UX in both clients).
+- **Injectable backoff clock (per R5 P1-3):** the transport accepts a `Clock` interface (`now()`, `setTimeout()`) at construction time. Production passes the real clock; tests pass a controllable fake clock so reconnect/backoff timing is deterministic. This makes the four boundary cases hermetically testable: (a) success on attempt N where N<6, (b) abandon to steady-state on N=6, (c) `ECONNRESET` triggers reconnect, (d) `EPIPE` triggers reconnect; plus (e) in-flight RPCs reject with `BridgeTimeoutError` not generic `unavailable`.
+
+#### 3.1 Reconnect choreography (per R3 P1-2)
+
+The single shared HTTP/2 session multiplexes all 31 unary RPCs and all 11 streams. When the session re-establishes after a reset, every active server-stream MUST re-subscribe and may demand a fresh snapshot (per chapter 06 §6 if the renderer's last-seen seq fell outside the daemon's ring buffer). Naively re-subscribing all streams in the same tick produces a snapshot storm: at N=20 sessions × ~3 streams/session = 60 snapshot RPCs hit the daemon's snapshot semaphore (v0.3 frag-3.5.1) simultaneously and serialize, freezing the UI for seconds.
+
+**Stagger rule:** stream re-subscribe is delayed by `jitter(50ms, 500ms)` keyed off `hash(sessionId) % 450 + 50`. Hash-keyed (not random) so re-subscribe ordering is deterministic across reconnects for the same session set — easier to reproduce bugs. Unary RPCs queued during reconnect are not staggered (they were already serialized on the renderer side).
+
+**Wall-clock budget:** at N=20 sessions the worst-case re-subscribe completes within 500ms + (snapshot semaphore queue × per-snapshot-cost). Cross-ref chapter 06 §6 fanout buffer sizing for the per-snapshot cost.
+
+**Idempotency precondition:** queued retries during the burst phase MUST be idempotent (chapter 02 §9 idempotency keys). Without this, a unary RPC that succeeded on the daemon but had its response dropped by the socket reset would be re-applied on retry.
+
+#### 3.2 Preload transport security boundary (per R2 P1-1)
+
+Connect-Node-in-preload runs with full Node privileges (HTTP/2 frame parser, Connect interceptors, optional `jose` for JWT verification on web — not Electron). A parser exploit in any of these → preload code-exec → bypass of `contextIsolation`. The transport MUST be hardened as follows:
+
+1. **Proxy-only contextBridge surface.** `window.ccsmTransport.create()` returns ONLY a thin proxy with primitive method signatures: `unary(serviceName: string, methodName: string, requestBytes: Uint8Array): Promise<Uint8Array>` and `stream(serviceName: string, methodName: string, requestBytes: Uint8Array): AsyncIterable<Uint8Array>`. No exposed properties referencing `net.Socket`, `Http2Session`, or any Node primitive.
+2. **All Connect machinery stays in preload.** Transport setup, HTTP/2 session management, interceptors, retry/reconnect logic — entirely in preload code. The renderer-side bridge files import generated Connect clients but bind them to the proxy from §3.2.1, never to a real Connect transport object.
+3. **Structured-clone-only payloads across the bridge.** All values crossing `contextBridge.exposeInMainWorld` are `Uint8Array` (proto-encoded request/response bytes) or plain JS objects. No closures, no class instances, no `Promise` chains that close over Node refs.
+4. **Audit checkpoint at M1.** M1 deliverable includes a security review of `electron/connect/ipc-transport.ts` confirming: no Node prototype/handle leaks via `contextBridge`, the proxy surface is exhaustively enumerated, and the renderer cannot reach any `net.Socket` / `Http2Session` instance through traversal of the proxy. Reviewer: security-auditor agent. Reference: Electron's "exposeInMainWorld safe patterns" doc.
+
+**Why this matters:** Electron's security model assumes minimal preload surface. Connect-in-preload is a substantial new attack surface; the proxy boundary is what keeps a hypothetical HTTP/2-frame-parser CVE contained to preload's sandbox rather than escalating to renderer RCE.
+
+#### 3.3 Structured logging on bridge-side failures (per R3 P2-1)
+
+When the bridge surfaces `BridgeTimeoutError` (or any Connect error code), it MUST emit a structured `console.warn` from preload context with shape `{ bridge: string, method: string, code: ConnectErrorCode, traceId?: string, retryAttempt?: number }`. The `traceId` is read from the Connect response's `x-ccsm-trace-id` header (chapter 02 §6 trace propagation) when present. This is the minimum diagnostic data needed to correlate "user reports random freeze" with daemon-side trace logs, and is a precondition for any future remote-error-capture integration.
+
+#### 3.4 Local-transport-key smoke test (per R3 P2-2)
+
+The `localTransportKey` request tag is what gates JWT bypass on the local-socket transport (chapter 05 §4). If a future refactor accidentally drops the tag, every Electron RPC fails `unauthenticated` and the desktop app is dead-on-arrival. The test plan (chapter 08 §3) MUST include two contract tests: (a) "local-socket request reaches handler with `localTransportKey=true`, JWT not required, succeeds" and (b) "remote-tagged request without JWT rejects with `unauthenticated`". These run on every CI build, not just M1.
+
+### 4. Bridge surface stability rule
+
+**Hard rule:** the public shape of `window.ccsm*` (every method name, parameter list, return type, and event subscription) **MUST NOT change** in v0.4. Renderer code (`src/`) is unmodified except for:
+- Build-time conditionals on `import.meta.env.VITE_TARGET` for the explicitly-enumerated Electron-only surfaces below.
+- TypeScript widening if the new return types (from generated proto) are structurally compatible but not literally `===` to the v0.3 hand-typed shapes.
+
+**Permitted `VITE_TARGET` conditionals (exhaustive enumeration — adding to this list requires a spec amendment):**
+1. **Window chrome controls** (`window:minimize/toggleMaximize/close/isMaximized` + `maximizedChanged/beforeHide/afterShow`) — the title-bar UI hides minimize/maximize/close buttons in `web` (browser provides them).
+2. **Folder picker** (`cwd:pick`) — the picker button in cwd-input renders `<input type="file" webkitdirectory>` in `web`, native dialog button in `electron`. Bridge function shape is unchanged.
+3. **Clipboard surface** (`ccsmPty.clipboard.{readText,writeText}`) — implementation forks at build time (Electron `clipboard` module vs `navigator.clipboard`). No renderer-visible difference.
+4. **Updater Settings rows** (per §2 "Updater special case") — render in disabled state with tooltip when `VITE_TARGET === 'web'`. DOM structure preserved; only the `disabled` attribute and tooltip text fork.
+
+Any other `import.meta.env.VITE_TARGET` reference in `src/` is a spec violation and MUST be flagged in PR review.
+
+**Why:** the renderer is shared between Electron and web. Diverging the bridge surface forces double-maintenance. v0.4 ships +frontend, not +features (chapter 01 G/A discipline).
+
+**Bridge-internal forks ARE allowed.** Inside `electron/preload/bridges/ccsmPty.ts`, the implementation of `list()` changes from `ipcRenderer.invoke('pty:list')` to `connectClient.listPty({}).then(r => r.sessions)`. The exported function signature is identical.
+
+**TypeScript codegen mismatch:** if the proto-generated request/response shapes aren't literally identical to the v0.3 types, the bridge file **adapts** at the boundary (e.g. v0.3 `pty:list` returns `unknown`; v0.4 returns `ListPtyResponse` whose `.sessions` is the same array). Adaptation lives in the bridge file; renderer unaffected.
+
+### 5. Per-batch swap plan (PR boundaries)
+
+Order: **read-only first, then write, then streams.** Within each tier, group by domain to keep diffs in one bridge file per PR.
+
+#### Batch A — read-only RPCs (lowest risk)
+
+| Bridge | RPCs | Proto file |
+|---|---|---|
+| ccsmCore | `app:getVersion`, `app:userHome`, `app:userCwds:get`, `settings:defaultModel`, `paths:exist`, `import:scan`, `import:recentCwds`, `ccsm:get-system-locale` | core.proto, settings.proto, import.proto |
+| ccsmSessionTitles | `sessionTitles:get`, `sessionTitles:listForProject` | session_titles.proto |
+| ccsmPty | `pty:list`, `pty:get`, `pty:checkClaudeAvailable`, `pty:getBufferSnapshot` | pty.proto |
+| ccsmCore (db) | `db:load` | core.proto |
+
+Why first: idempotent reads, no state mutation. Easy to compare v0.3 vs v0.4 outputs side-by-side in tests.
+
+#### Batch B — write RPCs (more risk)
+
+| Bridge | RPCs | Proto file |
+|---|---|---|
+| ccsmCore | `db:save`, `app:userCwds:push`, `cwd:pick` (Electron-side only — see §2), `updates:check/download/install/setAutoCheck`, `ccsm:set-language` | core.proto, settings.proto, updater.proto |
+| ccsmSession (signals) | `session:setActive`, `session:setName` | session.proto |
+| ccsmPty | `pty:spawn`, `pty:attach`, `pty:detach`, `pty:input`, `pty:resize`, `pty:kill` | pty.proto |
+| ccsmNotify | `notify:userInput` | notify.proto |
+| ccsmSessionTitles | `sessionTitles:rename`, `sessionTitles:enqueuePending`, `sessionTitles:flushPending` | session_titles.proto |
+
+Why second: state-mutating, narrower error model. v0.4 moves these one bridge-file at a time.
+
+#### Batch C — streams (highest risk)
+
+| Bridge | Streams | Proto file |
+|---|---|---|
+| ccsmPty | `pty:data`, `pty:exit` | pty.proto |
+| ccsmSession | `session:state`, `session:title`, `session:cwdRedirected`, `session:activate` | session.proto |
+| ccsmNotify | `notify:flash` | notify.proto |
+| ccsmCore | `updates:status`, `update:downloaded`, `window:maximizedChanged`, `window:beforeHide`, `window:afterShow` | (window:* stays on `ipcRenderer`); `updates:status` and `update:downloaded` move to updater.proto |
+
+Why last: server-streaming over HTTP/2 has the most novel failure modes (heartbeat, reconnect, seq replay). Tackled after the unary surface is proven stable.
+
+#### PR sizing
+
+- One PR per batch sub-row above (so ~4 PRs for Batch A, ~5 for Batch B, ~3 for Batch C). Total ~12 PRs across the swap.
+- Each PR includes: `proto/` definitions for its RPCs, `gen/ts/` regeneration, daemon-side handler bindings, bridge file changes, e2e probe.
+- PR is mergeable independently: bridge file commits both the new Connect impl and the Electron forwarding code (until M2 cuts the envelope). See §6.
+
+### 6. Migration semantics: NO dual-transport during the swap
+
+**Decision (lock):** during M1 (the bridge-swap milestone, chapter 09), each bridge file has **one** active transport per build. The bridge swap PR replaces the `ipcRenderer.invoke` line with the Connect call **and the corresponding daemon-side handler is wired to Connect at the same time**. There is no period where the same bridge function might invoke either transport at runtime.
+
+**Why:** dual-transport-with-feature-flag is the trap from v0.3 (frag-3.4.1.h discipline). Selecting transport at runtime doubles the test surface and creates ghost paths that survive past their useful life.
+
+**Per-PR mechanism:**
+1. PR adds proto definitions + regenerates `gen/ts/`.
+2. PR adds daemon-side Connect handler that delegates to the existing daemon module (no logic change in the module, just a new entry point).
+3. PR removes the v0.3 envelope handler for those RPCs from the daemon's data-socket dispatcher allowlist.
+4. PR rewrites the bridge file's `ipcRenderer.invoke` calls to Connect client calls.
+5. PR removes the corresponding Electron main-process `ipcMain.handle` registrations.
+6. PR updates / adds e2e probe.
+
+After all batch PRs land, the daemon's data-socket envelope handler has zero registered methods → the entire envelope path on the data socket is deleted in M2 (housekeeping). At that point: control socket = envelope, data socket = Connect, no overlap.
+
+**Why not all-at-once big-bang PR:** ~46 RPCs in one PR is unreviewable and a single bug grounds the whole release. Per-batch PRs keep blast radius bounded.
+
+### 7. Test discipline per swap PR
+
+Every bridge-swap PR MUST include:
+
+1. **Unit test on the daemon Connect handler:** call the handler in-process with a mock context, assert response shape matches proto.
+2. **Adapter parity test (deleted after M2 — but see §7.2 below):** for each swapped RPC, a temporary test asserts that Connect response and the corresponding v0.3 envelope response on the same input produce equivalent JS values. Test is gated by an env flag and removed when M2 deletes the envelope path.
+3. **E2E probe on the bridge function:** in the harness-agent / harness-perm e2e suite, exercise the bridge from a real renderer (Electron) AND from the web client harness. **Naming convention (per R5 P1-2):** every bridge-swap e2e case is named `bridge-swap-<bridge>-<rpc>` (e.g. `bridge-swap-ccsmPty-list`, `bridge-swap-ccsmCore-getVersion`). The PR worker invokes `npm run e2e:bridge -- --only=bridge-swap-<bridge>-<rpc>` and pastes output in PR body. Trust-CI-mode reviewer (per `feedback_trust_ci_mode`) verifies the case ID matches the swapped RPC. See chapter 08 §9 for the full naming registry.
+4. **Reverse-verify entry in PR body:** PR-body screenshot or output showing "before bridge swap, this RPC works; after, this RPC works; behavior identical".
+
+#### 7.1 Parity-test framework (per R5 P0-1)
+
+The parity tests are the load-bearing safety net during M1's 12 PRs. To prevent each PR from inventing its own definition of "equivalent" and producing a non-uniform safety net, M1's first PR MUST land a shared parity-test framework at `daemon/__tests__/parity/`:
+
+**Framework shape:**
+- `assertParity(envelopeResp, connectResp, opts: { ignoreFields?: string[]; coerce?: Record<string, (v: any) => any> }): void` — deep-equal with field-level ignore-list and per-field coercion (e.g. coerce v0.3 `unknown`-typed `pid: number | string` to `Number(v)` before compare).
+- **Input corpus:** golden fixtures at `daemon/__tests__/parity-corpus/<rpc>.json`. Each fixture file is a JSON array of `{ name, request, expectedV03Response, expectedV04Response, parityOpts }` cases. Fixtures are **recorded** (not hand-written) by running the v0.3 envelope path against a fresh seeded daemon under a `RECORD_PARITY=1` env flag — keeps fixtures honest and re-recordable when daemon-side data shapes shift.
+- **Non-determinism handling:** the `coerce` map MUST handle: timestamps (zero them out), ULIDs (regex-match `[0-9A-HJKMNP-TV-Z]{26}` not literal-equal), PIDs (zero them out), free-form ports (`>1024 && <65536` predicate not literal-equal). Per-RPC `parityOpts` declares which of these apply.
+- **Codegen-driven scaffold:** a generator at `scripts/gen-parity-scaffold.ts` reads the swap PR's modified proto file, enumerates RPCs, and asserts each has a parity-corpus entry — fails the PR if missing. This makes "every swapped RPC has parity coverage" mechanically enforceable.
+- **Equivalence semantics for type-widening cases:** when v0.3 returns `unknown` and v0.4 returns a typed shape (per §4 adaptation), parity is asserted on the structural projection: the framework normalizes both sides through the v0.4 type's parser, then compares. Documented per-RPC in the corpus file's `parityOpts.normalizationStrategy` field.
+
+#### 7.2 Bridge adapter contract tests (survives M2 — per R3 P1-3)
+
+Parity tests are deleted at M2 (envelope removed → nothing to compare against). To prevent the post-M2 "silent adapter regression" risk (proto field renamed → bridge maps to wrong renderer key → no test catches it), promote a subset of parity assertions to **enduring bridge adapter contract tests** at `electron/preload/bridges/__tests__/<bridge>.contract.test.ts`:
+
+- One assertion per bridge function: feed a known proto-typed response into the bridge's adapter logic, assert the resulting `window.ccsm*`-shaped value matches the v0.3-documented type.
+- These are NOT parity tests (no v0.3 envelope path involved post-M2). They are pure adapter unit tests against the v0.3 type contract.
+- `buf breaking` catches wire-level incompat; these contract tests catch post-wire adapter drift. Both layers required.
+- Cross-ref chapter 08 §3 for the test runner integration.
+
+#### 7.3 Input coalescer unit test (per R5 P1-1)
+
+The `pty:input` bridge wraps individual keystrokes in a 5ms coalescing window (per chapter 06 §3). Coalescer bugs are invisible until a user pastes 50 KB and gets character-by-character delivery. M1 first PR that touches `pty:input` MUST land a coalescer unit test at `electron/preload/bridges/__tests__/ccsmPty.coalescer.test.ts`:
+
+- Inject a fake RAF/timer clock.
+- Simulate N keystrokes within window W; assert ≤K RPCs emitted (where K = ceil(N × byteSize / 64KiB) — the per-RPC cap; see §7.4).
+- Simulate N keystrokes spanning multiple windows; assert each window flushes exactly once.
+- Assert no keystroke is lost across the boundary.
+- Assert the 256 KiB renderer-side buffer cap (chapter 06 §3) drops oldest keystrokes with a structured warn log when exceeded.
+
+#### 7.4 PTY input size cap (per R2 P2-1)
+
+`SendPtyInputRequest.data` MUST be capped at **64 KiB** server-side (daemon rejects with `invalid_argument` Connect error code if exceeded). Renderer-side coalescer (§7.3) chunks larger pastes into ≤64 KiB RPCs. The 16 MiB HTTP/2 frame cap (chapter 02 §8) is the absolute ceiling but 64 KiB is the per-RPC product cap. Why 64 KiB: matches typical OS pipe buffer (PIPE_BUF on Linux is 64 KiB, Win named pipe default is 64 KiB), so a single RPC fits one OS write — no partial-write semantics to model. Documented in `pty.proto` validation comment + chapter 07 §1 daemon-side validation.
+
+**Why parity tests are temporary:** they're a migration safety net, not a permanent invariant. Once the envelope handler is deleted, the enduring adapter contract tests (§7.2) take over.
+
+**Why an e2e on web during the swap (M1) before the web build is wired up:** the web client is `vite dev` against the local daemon from M1 onwards. Hitting the Connect surface from a real browser DOM during the swap catches CORS, content-type, and HTTP/2 negotiation issues early — those bite the web build (M3) hardest.
+
+## 4. Web client (Vite SPA + Cloudflare Pages)
+
+### Context block
+
+The web client is the user-visible payoff of v0.4. Goal: open `https://app.<author-domain>` from any browser, hit Cloudflare Access, sign in via GitHub, and reach the user's daemon over Cloudflare Tunnel. The SPA reuses the same `src/` React renderer code as Electron — same components, same Zustand stores, same xterm.js terminal — packaged through Vite into static assets and deployed to Cloudflare Pages on push to `main`.
+
+### TOC
+
+- 1. Workspace layout (`web/` package)
+- 2. Shared renderer packaging
+- 3. Vite configuration
+- 4. Build pipeline + Cloudflare Pages deploy
+- 5. Local development
+- 5.1. Transport-target injection (dev / test)
+- 6. Offline / unreachable UX
+- 6.5. Error reporting
+- 7. Browser compatibility target
+- 8. What's intentionally absent (no PWA, no service worker, no responsive redesign)
+- 8.1. Web client storage / CSP / third-party policy
+
+### 1. Workspace layout
+
+```
+ccsm/                              # repo root
+├── package.json                   # workspace root
+├── proto/                         # chapter 02
+├── gen/ts/                        # generated proto bindings
+├── daemon/                        # v0.3 daemon
+├── electron/                      # Electron main + preload
+├── src/                           # SHARED renderer (React, Zustand, xterm.js)
+├── web/                           # NEW — Vite SPA wrapper
+│   ├── package.json
+│   ├── vite.config.ts
+│   ├── index.html
+│   ├── src/
+│   │   ├── main.tsx               # SPA entry — mounts <App> from `src/App.tsx`
+│   │   ├── transport.ts           # Connect-Web transport, talks to daemon over Tunnel
+│   │   ├── bridges/               # web flavor of `electron/preload/bridges/*`
+│   │   │   ├── ccsmCore.ts        # imports same surface, swaps impl
+│   │   │   ├── ccsmSession.ts
+│   │   │   ├── ccsmPty.ts
+│   │   │   ├── ccsmNotify.ts
+│   │   │   └── ccsmSessionTitles.ts
+│   │   ├── platform/              # web-specific replacements
+│   │   │   ├── clipboard.ts       # navigator.clipboard wrapper
+│   │   │   ├── window-chrome.ts   # no-op window:* methods
+│   │   │   └── folder-picker.ts   # File-API directory picker (or no-op)
+│   │   └── auth/
+│   │       └── access-redirect.ts # detects 401 from CF Access, redirects browser
+│   └── public/
+│       └── favicon.ico
+└── ...
+```
+
+**Why a separate `web/` package vs. building from `electron/`:** Electron's preload script uses Node APIs (`contextBridge`, `electron.ipcRenderer`) that don't exist in browsers. Trying to share the preload would force conditional imports everywhere. A separate Vite entry point with its own preload-equivalent is cleaner.
+
+**Why `src/` is shared, not duplicated:** the renderer is the product. Forking it doubles maintenance and guarantees drift. The shared package is enforced by `web/tsconfig.json` `paths` mapping `@/*` → `../src/*` (same as Electron's tsconfig).
+
+### 2. Shared renderer packaging
+
+The shared renderer (`src/`) imports browser-safe APIs only. This is already largely true (renderer runs in Chromium-renderer process under Electron), with three exceptions that v0.4 fixes:
+
+1. **`process.platform` reads** — used in `src/` for "Cmd vs Ctrl" detection. Replace with a build-time `import.meta.env.VITE_PLATFORM` or runtime `navigator.platform` parse helper at `src/platform/getPlatform.ts`. Both Electron and web set `VITE_PLATFORM` at build time.
+2. **`window.ccsm.window.platform`** — exposed by `ccsmCore.ts` bridge. Web bridge returns `'web'` literal; renderer's keyboard-shortcut helper handles the new value as "fallback to platform-detection from `navigator.platform`".
+3. **Direct `electron.clipboard` reads** (rare, audit during M3) — none currently in `src/`; clipboard goes through `window.ccsmPty.clipboard.*` which is bridge-forked per chapter 03 §2.
+
+**Bridge installation in web:** `web/src/main.tsx` calls `installCcsmCoreBridge()`, etc. — same names as Electron preload, but the implementations live in `web/src/bridges/`. They expose `window.ccsm*` so `src/` code is identical across both clients.
+
+**Why mirror `installCcsm*Bridge` in web:** the renderer assumes `window.ccsm.foo` is available at module-evaluation time. Mirroring the install pattern means renderer init code (`src/index.tsx`) is unchanged.
+
+**Bundle size:** Vite + Rollup tree-shake the unused bits. The original v0.4-pre estimate of "~600 KB gzipped" undercounted runtimes; realistic v0.4.0 first-load is **~800-1100 KB gzipped** when honestly accounting for:
+
+- React + ReactDOM (~50 KB gz)
+- xterm.js + addons `-fit`, `-web-links` (~250 KB gz; `-search` is dropped to keep within budget)
+- `@connectrpc/connect` + `@connectrpc/connect-web` (~50 KB gz)
+- `@bufbuild/protobuf` runtime (~30 KB gz)
+- `gen/ts/` generated stubs for 46 RPCs (~70 KB gz)
+- App code: Zustand, i18n bundles, framer-motion, Radix primitives, the renderer itself (~400-500 KB gz; v0.3 renderer is unmeasured today)
+
+**M1 measurement spike (locked):** before chapter 09 M1 closes, run a one-day spike that bundles the current `src/` against the proto stubs and **measures**. Replace the §2 numbers above with `actual + 20% headroom` and lock that as the chapter 10 R10 CI gate threshold (rather than the speculative 800 KB). Cloudflare Pages serves with Brotli; effective wire size is ~70-75% of gzipped. First-load target: <2s on a 5 Mbps connection — **must be re-validated post-spike**.
+
+**Code-splitting policy:** the manual chunks in §3 split for **caching**, not lazy load. Session-list is the landing route and MUST NOT eagerly pull the terminal chunk; `xterm` and friends lazy-load on first navigation to a session. M3 deliverable confirms.
+
+**Renderer parity (Electron ↔ web):** "the renderer is the product" (above) is asserted as a goal, but drift creeps in via Electron-only conditionals, files imported by Electron but tree-shaken out of web, or divergent `tsconfig` `paths`. Chapter 08 adds a build-time **renderer-parity check** that diffs the imported file set from the Electron entry vs. the web entry; CI fails if any `src/**` file is reachable from one and not the other (allow-listed exceptions only). Slow drift won't survive M3 dogfood; CI catches it on the PR that introduces it.
+
+### 3. Vite configuration
+
+```ts
+// web/vite.config.ts
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '../src'),
+    },
+  },
+  define: {
+    'import.meta.env.VITE_TARGET': JSON.stringify('web'),
+    'import.meta.env.VITE_PLATFORM': JSON.stringify('web'),
+  },
+  server: {
+    port: 5174,
+    proxy: {
+      // dev-time: forward /ccsm.v1.* to local daemon over HTTP/2
+      // (custom middleware; see §5)
+    },
+  },
+  build: {
+    target: 'es2022',  // see §7
+    sourcemap: true,
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          xterm: ['xterm', 'xterm-addon-fit', 'xterm-addon-web-links'],
+          react: ['react', 'react-dom'],
+          connect: ['@connectrpc/connect', '@connectrpc/connect-web'],
+        },
+      },
+    },
+  },
+});
+```
+
+**Why `target: 'es2022'`:** Cloudflare Access blocks browsers older than ~2 years (see §7). ES2022 native (no transpile to ES2015) shrinks bundle ~15%.
+
+**Why manual chunks for xterm/react/connect:** these change rarely; splitting them into their own chunks lets the browser cache them across renderer-app updates.
+
+### 4. Build pipeline + Cloudflare Pages deploy
+
+**Build command:** `npm run build:web` runs:
+1. `buf generate` (regenerate proto bindings if stale)
+2. `tsc -b web` (type-check)
+3. `vite build` in `web/`
+
+Output: `web/dist/` — static HTML/JS/CSS.
+
+**Deploy:** Cloudflare Pages, GitHub integration. Pushes to `main` trigger a Pages build:
+```yaml
+# Configured via Cloudflare dashboard:
+build_command: npm run build:web
+build_output_directory: web/dist
+root_directory: /
+```
+
+PR previews: every PR gets a unique preview URL `https://<sha>.ccsm-app.pages.dev`. Useful for review without needing Tunnel.
+
+**Why GitHub-integration over `wrangler` from Actions:** less moving parts. Cloudflare has the GitHub OAuth already, builds in their environment, and serves the result. No CI secrets juggling.
+
+**Routing:** SPA fallback. `web/dist/_redirects` contains `/* /index.html 200` so client-side routes (`/sessions/:id`) resolve to the SPA shell.
+
+### 5. Local development
+
+Local dev needs three things running:
+1. Daemon (locally — `npm run daemon:dev`, watches + restarts on changes)
+2. Vite dev server for the web SPA (`npm run web:dev` → `http://localhost:5174`)
+3. (Optional) `cloudflared tunnel --url http://localhost:5174` to test the full Tunnel + Access path
+
+**Without Tunnel** (the common case during dev): the dev Vite server uses a custom middleware to proxy `/ccsm.v1.*` paths to the local daemon's HTTP/2 listener (data socket — but in dev mode, daemon also binds an explicit TCP listener `127.0.0.1:7878` for browser access; Unix-socket dev is impractical from a browser). Vite middleware translates incoming HTTP/1.1 (browser default to localhost) requests into HTTP/2 to the daemon.
+
+**Dev TCP listener — security model (BLOCKER fixes folded from R2/R3/R4/R5):** controlled by `CCSM_DAEMON_DEV_TCP=7878` env var **AND** a build-time symbol. The following are **MUST** requirements, not "MAY":
+
+1. **Build-time gate (not runtime):** the production daemon binary MUST NOT contain the dev-listener code path. Implemented via an esbuild/rollup `define` constant `__CCSM_DEV_TCP_ENABLED__` set to `false` for prod builds and `true` for dev. The dev-listener module is wrapped in `if (__CCSM_DEV_TCP_ENABLED__) { ... }` so Rollup tree-shakes it out of the prod bundle entirely. Runtime-only `process.env.NODE_ENV` checks are insufficient — the symbol stays in the binary and one mistakenly-set env var re-enables it.
+2. **Per-launch shared secret:** even in dev, the listener MUST require a per-launch random secret (printed to dev console at daemon start, sent by the SPA as an `X-CCSM-Dev-Secret` header). Raw `127.0.0.1` binding with no auth is unacceptable due to DNS rebinding (any browser tab on the dev box can reach `127.0.0.1:7878`).
+3. **Strict `Host` header validation:** the dev listener MUST reject any request whose `Host` header is not exactly `localhost:7878` or `127.0.0.1:7878` (HTTP 421 Misdirected Request). This defeats DNS rebinding from arbitrary websites.
+4. **Belt-and-suspenders prod assertion:** if a prod-built daemon ever observes `CCSM_DAEMON_DEV_TCP` set in its environment, it MUST log `pino.error("dev TCP listener requested in prod build — ignoring")` AND surface a Settings-pane red banner. The listener still does not bind.
+5. **CI smoke test (chapter 08):** L2 contract test on the prod-built daemon binary asserts `nc 127.0.0.1 7878` refuses connection regardless of `CCSM_DAEMON_DEV_TCP`. Listed as a chapter 09 M3 done-definition deliverable.
+
+The same `Host`-header validation and "no JWT-exempt routes" policy applies to the **production** TCP listener (chapter 05 §5) — see chapter 05's fixer pass for the prod-side hardening (R2-P0-2). This chapter only specifies the dev-listener mechanics.
+
+**Why a dev TCP listener at all:** browsers can't speak named-pipe / Unix-socket directly. The proper prod path goes through Cloudflare Tunnel which terminates HTTP/2 on the daemon's TCP listener — but that's what the daemon serves remote traffic on anyway. Reusing the same listener for dev keeps the code path symmetric.
+
+**Why not Vite proxy directly to the named pipe / Unix socket:** Node http2 over Unix socket is doable but proxy-from-Vite-to-named-pipe-on-Win is fragile. TCP is the simpler dev story.
+
+### 5.1. Transport-target injection (dev / test)
+
+The `web/src/transport.ts` module decides at runtime which base URL to talk to. Resolution order:
+
+1. `import.meta.env.VITE_DAEMON_BASE_URL` — set at Vite build/dev time (e.g. `VITE_DAEMON_BASE_URL=http://127.0.0.1:7878 npm run web:dev`). Used by `vite dev`, `vite preview`, and the chapter 08 e2e fixture. Single helper `getDaemonBaseUrl()` reads this.
+2. Otherwise: same-origin (`window.location.origin`) — production behavior, served from `app.<author-domain>` via Cloudflare Tunnel.
+
+The chapter 08 §5 web e2e fixture sets `VITE_DAEMON_BASE_URL=http://127.0.0.1:7878` plus the per-launch dev secret in a `<meta>` tag injected at fixture-build time, and the Connect transport reads both. No URL query params, no `window` globals — single, documented build-time mechanism.
+
+### 6. Offline / unreachable UX
+
+**Decision:** show **skeleton + retry banner**, with the banner copy varying by failure cause.
+
+When the web client's Connect transport sees a network or server error:
+1. Renderer's `useDaemonHealthBridge` hook (already exists from v0.3 §6.8) flips to `unreachable` state.
+2. UI shows a banner whose **copy depends on the Connect error code / HTTP status** so the user knows what to do (R3 P1-3 fold):
+   - `unauthenticated` (Cloudflare Access JWT expired / missing) → `auth.required` banner with a "Sign in again" link that triggers a top-level navigation to the Cloudflare Access redirect URL. Cross-ref chapter 07 §4.
+   - HTTP `502` / `503` / `504` from the edge (Cloudflare Tunnel down or daemon TCP listener unreachable from cloudflared) → `cloudflare.unreachable` banner with a link to the Cloudflare status page. Cross-ref chapter 05 §1.
+   - `unavailable` from the daemon (daemon process not running, just-restarted) → existing `daemon.unreachable` banner with "Retry" + "Reload page" buttons.
+   - Other network errors (browser is offline, DNS failure) → `network.offline` banner with "Check your connection" copy.
+   All four banner ids live in the existing surface registry from v0.3 §6.8; only the per-cause copy and CTA vary. The bridge surface for the banner is unchanged.
+3. Session list / terminal panes render their **skeleton** state (gray boxes, blinking cursor placeholder) — the existing skeleton from v0.3.
+4. `daemon.unreachable` banner: "Retry" button calls `transport.reconnect()`, "Reload page" button calls `window.location.reload()`. **Per-platform divergence:** the "Retry" button is shared with Electron (unchanged from v0.3 §6.8); the "Reload page" button is web-only (Electron has no equivalent — browser reload semantics differ from `BrowserWindow.reload()`). Per-platform conditional rendering at the button level; bridge surface unchanged.
+5. Auto-retry: exponential backoff capped at 30s (longer than Electron's 5s — web users often have flakier networks). Backoff is silent at debug-level; verbose Connect-Web reconnect noise is suppressed (see §6.5).
+
+**Decision: no offline-data caching in v0.4.** No service worker, no IndexedDB cache of session content. If the daemon is unreachable, the user sees skeleton. Period.
+
+**Why no caching:** stale data is worse than no data for a session/terminal product. A user seeing yesterday's transcript and thinking it's live is a real bug. Defer to v0.5+ if there's clear demand.
+
+**What about the JS bundle itself when offline?** Cloudflare Pages serves with two cache-policy tiers (locked in `web/public/_headers`):
+
+- `index.html`: `Cache-Control: no-cache, must-revalidate` so the user always gets the latest shell hash on each visit.
+- `/assets/*-[hash].*` (hashed/immutable bundles): `Cache-Control: public, max-age=31536000, immutable` — standard 1-year immutable caching for content-hashed assets. Returning users skip re-download until the hash changes.
+
+The browser caches the SPA shell, so even with no daemon connectivity the user sees the app chrome + skeleton + banner — not a blank page.
+
+### 6.5. Error reporting
+
+Production debugging requires a path for user-side errors back to the developer. Electron has `~/.ccsm/daemon.log`; the web client gets the equivalent via the daemon (R3 P1-1 fold).
+
+**Mechanism:**
+1. Web client installs `window.onerror` and `window.addEventListener('unhandledrejection', ...)` listeners at `web/src/main.tsx` boot.
+2. On error: post a `ReportClientError(message, stack, traceId, userAgent, url, ts)` RPC to the daemon. New RPC added to chapter 02 proto inventory and chapter 03 bridge surface (cross-file follow-up tagged for chapter 02/03 fixers).
+3. Daemon writes errors to `~/.ccsm/web-client-errors.log` with the same rotation policy as `daemon.log` (cross-ref v0.3 §10).
+4. Settings pane gains a hidden "Copy diagnostics" button (visible behind a `?debug=1` query) that copies the last 50 lines of web-client-errors.log to clipboard for paste-back.
+5. **No third-party telemetry** (Sentry, etc.) in v0.4 — daemon-side capture is the v0.4 floor; external services are a v0.5+ scope decision.
+
+**Console-noise discipline:** the Connect-Web transport is wrapped with a quiet error handler that logs expected reconnect classes (`unavailable`, network drops during backoff) at `console.debug`, reserving `console.error` for true uncaught crashes. Otherwise the dev console fills with scary red text during normal reconnects.
+
+**xterm.js client-side memory:** browser tabs open for days accumulate xterm scrollback in renderer memory (separate from daemon-side xterm-headless caps). Web client uses xterm.js's default scrollback limit (1000 lines) — same cap as Electron. Page reload clears it. If a user reports tab OOM after multi-day uptime, "reload the tab" is the documented mitigation.
+
+### 7. Browser compatibility target
+
+**Supported:** latest 2 versions of Chrome, Edge, Firefox, Safari (≥ 16), as of release date.
+
+**Why this set:** Cloudflare Access requires modern TLS + cookie handling; older browsers fail at the auth layer anyway. HTTP/2 is universal in modern browsers. ES2022 features (top-level await, class fields) are supported in this target.
+
+**Mobile browsers:** "best effort, not supported." iOS Safari ≥ 16 + Chrome on Android probably work (xterm.js renders, virtual keyboard captures input clumsily). Not in success criteria; not in regression-test scope. See N1 in chapter 01.
+
+**Polyfills:** none. If your browser doesn't have `Intl.DateTimeFormat` and `crypto.subtle`, you're out.
+
+### 8. What's intentionally absent
+
+**No Progressive Web App manifest** — `web/public/manifest.json` is omitted. Adding "install to home screen" is a v0.5+ decision; plumbing it requires icon assets, install-prompt UX, and PWA-specific testing.
+
+**No service worker** — no offline shell, no background sync, no push subscription. See §6 + N8 in chapter 01.
+
+**No SSR / no Cloudflare Workers route handlers** — pure static SPA. The daemon does all the dynamic work; Pages just serves bytes. This keeps Cloudflare-side cost at $0 (free Pages tier) and the architecture trivially debuggable.
+
+**No mobile-first responsive redesign** — A4 anti-goal in chapter 01. Layout works on a 1280×720+ viewport; below that, scrolls horizontally. Don't optimize for phones in v0.4.
+
+**No theme / appearance settings unique to web** — same dark/light theme as Electron, sourced from same Settings RPC. If `prefers-color-scheme` differs between desktop and laptop, that's the user's OS setting on each device — not a bug.
+
+### 8.1. Web client storage / CSP / third-party policy
+
+Three explicit prohibitions to foreclose foot-guns that would otherwise creep in via "harmless" future PRs (folded from R2 P1-1, P1-2, P1-3).
+
+**No persisted client-side storage of auth or RPC data (R2 P1-1):** the SPA MUST NOT persist any auth tokens, JWTs, JWT-derived data, or daemon RPC results to `localStorage`, `sessionStorage`, IndexedDB, Cache Storage, or any other browser persistent store. The JWT lives **only** in the `CF_Authorization` cookie (managed by Cloudflare; chapter 05 §3, chapter 07 §4). In-memory React/Zustand state is the only allowed cache. Rationale: any persisted secret is XSS-exfiltrate-able; xterm.js or a future rich-text component could ship an HTML-injection bug. A CI lint (`grep -r 'localStorage\|sessionStorage\|indexedDB\|caches\.' web/src src/` with allow-list of explicit exceptions) gates the rule on every PR.
+
+**Default Content Security Policy (R2 P1-2):** the SPA ships with a strict CSP enforced via `web/public/_headers` for Cloudflare Pages (and a duplicate `<meta http-equiv="Content-Security-Policy">` in `index.html` for `vite preview` and the e2e fixture). Locked starter:
+
+```text
+default-src 'self';
+script-src 'self';
+style-src 'self' 'unsafe-inline';   # xterm.js needs inline styles; verify in M3
+connect-src 'self' https://app.<author-domain>;
+img-src 'self' data:;
+font-src 'self';
+object-src 'none';
+base-uri 'self';
+frame-ancestors 'none';
+form-action 'self' https://*.cloudflareaccess.com;
+```
+
+Each directive verified against actual SPA needs in M3 before lock. If `'unsafe-inline'` for `style-src` proves avoidable, drop it. CSP is the primary mitigation against XSS post-exploit; missing it = no protection layer if any HTML-injection bug ships.
+
+**No third-party runtime resources (R2 P1-3):** the SPA MUST NOT load any runtime resource (font, script, stylesheet, image, iframe) from a non-same-origin URL. All assets bundled into `web/dist/`. No Google Fonts CDN, no analytics tags, no third-party CSS. Allow-list exception: the Cloudflare Access auth-redirect form-target (`https://*.cloudflareaccess.com`) — already in CSP `form-action`. CI gate parses the built `web/dist/index.html` and any `<link>`/`<script>`/`<img>` src; fail if any non-same-origin URL appears outside the allow-list. Rationale: forecloses supply-chain drift, privacy leaks (third-party CDN sees every page load), and CSP exceptions accumulating one PR at a time.
+
+## 5. Cloudflare layer (Tunnel + Access + JWT middleware)
+
+### Context block
+
+The web client lives on Cloudflare Pages. The user's daemon lives on their Windows box behind whatever NAT / firewall / dynamic IP that machine has. **Cloudflare Tunnel** stitches them together: the daemon (or a `cloudflared` sidecar) opens an outbound connection to Cloudflare; Cloudflare assigns a stable public hostname; HTTPS requests to that hostname are routed back over the tunnel. **Cloudflare Access** sits in front as a zero-trust authenticator: every request is intercepted, redirected to GitHub OAuth on first hit, and signed with a short-lived JWT. The daemon validates the JWT on every remote request; local-socket requests bypass it (peer-cred is the local trust boundary, see chapter 02 §8).
+
+**Terms in this chapter** (per R6 P1-3):
+
+**Tunnel-vs-binary one-liner (per R6 r2 P1):** "Cloudflare Tunnel" (capitalized) is the Cloudflare product/service that provides outbound-only secure ingress; `cloudflared` (code voice) is the daemon binary distributed by Cloudflare that implements a Tunnel client. The two are NOT interchangeable: docs reference the product by name, code references the binary by filename.
+
+- **Cloudflare Tunnel** (capitalized) — the Cloudflare product/service.
+- `cloudflared` (code voice) — the binary that runs locally as a sidecar.
+- *tunnel* (lowercase) — a single tunnel instance / outbound connection.
+- **Cloudflare Access** (capitalized) — the zero-trust authenticator product.
+- **JWKS** — JSON Web Key Set; Cloudflare's public-key endpoint for JWT signature verification.
+- **IdP** — Identity Provider (GitHub OAuth in our config).
+- **AUD** — JWT `aud` (audience) claim; Cloudflare Access app's unique tag.
+
+### TOC
+
+- 1. Cloudflare Tunnel (`cloudflared`)
+- 1.1 `cloudflared` binary supply chain
+- 1.2 Idle-session eviction (cross-ref ch06 §5, ch10 R5)
+- 2. Tunnel hostname strategy
+- 3. Cloudflare Access — application config
+- 4. JWT validation middleware on the daemon
+- 4.1 JWT validation policy locks (algorithm, claims, clock skew)
+- 4.2 JWT validation test matrix (cross-ref ch08 §3)
+- 5. Local vs remote ingress on the daemon
+- 6. Setup flow (first-time user)
+- 6.1 Secret-handling discipline (tunnel token + AUD)
+- 7. Cost (free tier all the way)
+- 8. Operational caveats
+- 9. Testability hooks
+
+### 1. Cloudflare Tunnel (`cloudflared`)
+
+**Decision (lock):** `cloudflared` runs as a **sidecar process spawned by the daemon** when remote access is enabled, not as a separate user-installed daemon. The daemon's binary bundle ships `cloudflared` for each platform (Win/Mac/Linux x64+ARM64) inside the package.
+
+**Why sidecar-spawned:**
+1. One install for the user — no "now install cloudflared separately".
+2. Daemon owns the tunnel lifecycle: starts on remote-enable, stops on remote-disable, restarts on tunnel crash.
+3. Bundling the binary means a known-good version (no "user has cloudflared 2019 from somewhere").
+
+**Spawn args** (presented as the actual TS args list the daemon uses, per R6 P2-1):
+
+```ts
+const args = [
+  'tunnel',
+  '--no-autoupdate',
+  '--protocol', 'http2',                  // see §8 for protocol rationale
+  '--url', 'http://127.0.0.1:7879',       // prod TCP listener (see §5; dev uses :7878)
+  '--metrics', '127.0.0.1:0',             // ephemeral port; daemon reads from spawn output
+  '--loglevel', 'info',                   // M4 dogfood; tighten to 'warn' post-stable
+  '--logfile', '~/.ccsm/cloudflared.log',
+  '--token', storedTunnelToken,           // SecureBuffer, see §6.1
+];
+child_process.spawn(cloudflaredPath, args, { detached: false });
+```
+
+The daemon's TCP listener binds `127.0.0.1:7879` only when remote-access is enabled (see §5). `cloudflared` proxies the public Tunnel hostname to that listener.
+
+**Tunnel auth model:** the user creates a tunnel via the Cloudflare dashboard (one-time, in the setup wizard, see §6) and the resulting **tunnel token** (a long string) is stored via the OS keychain (see §6.1 for the exact storage scheme). On daemon start, if remote-access is enabled, the token is fetched from the keychain and `cloudflared` is spawned.
+
+**Why not let the daemon create the tunnel itself via API:** Cloudflare's tunnel-create API requires an account-level API token, which the user would have to paste. The dashboard flow is one-time and uses the user's existing browser session. Less friction.
+
+**Tunnel token rotation:** if the user revokes the token in Cloudflare dashboard, the spawned `cloudflared` exits with auth error; daemon logs and surfaces a `cloudflare.unreachable` banner in the desktop UI (sticky; see §1 lifecycle below). User re-runs the setup wizard.
+
+**`cloudflared` lifecycle (with explicit recovery, per R3 P0-1 / R4 P1-1):**
+- Spawn: `child_process.spawn` with `detached: false` (dies with daemon). Spawn factory MUST be injectable (`spawnCloudflared = childProcess.spawn`) for tests (per R5 P1-1).
+- Health: poll `--metrics` HTTP endpoint every **60s** (per R4 P1-1; halved from initial 30s draft to reduce overhead); restart on 3 consecutive failures.
+- End-to-end probe (per R3 P1-3): every 60s, daemon issues an HTTPS `GET https://<tunnel-host>/healthz` to its own tunnel hostname (round-trip via Cloudflare edge). 3 consecutive failures flip the surface to `cloudflare.unreachable` even when `--metrics` reports green. Cost: ~one outbound HTTPS/min.
+- Restart backoff: exponential, capped at 60s, max 10 attempts in 30 minutes.
+- **After exhaustion (per R3 P0-1, R4 P1-1):** do NOT stop forever. Fall back to a **steady-state slow tick: 1 attempt per 5 min, indefinitely**. Reset to fast backoff on first success.
+- **Network-recovery trigger (per R3 P0-1):** subscribe to the OS network-up event (Win SENS, mac SCNetworkReachability, Linux NetworkManager DBus). On network-up, immediately restart the fast-backoff cycle (don't wait for the 5-min slow tick). When the network listener is unavailable (e.g. headless Linux without NM), fall back to slow-tick only — log the degraded mode at boot.
+- **User surface:** the `cloudflare.unreachable` banner (taxonomy in chapter 04 §6, failure list in chapter 07 §2) is **sticky** while the slow-tick is engaged, and exposes a "Retry now" button (forces an immediate fast cycle), the last-error message, and a "View log" link to `~/.ccsm/cloudflared.log`.
+- Logs: tee `cloudflared` stdout/stderr to `~/.ccsm/cloudflared.log` (rotated via pino-roll, same convention as daemon log per v0.3 frag-3.7). **Cap (per R3 P2-1):** 50 MB × 5 files. M4 dogfood uses `--loglevel info`; tighten to `warn` once stable.
+
+#### 1.1 `cloudflared` binary supply chain (per R2 P1-1, R5 P2-2)
+
+**Locks:**
+1. **Source (lock):** build script downloads `cloudflared` from the canonical Cloudflare release URL — `https://github.com/cloudflare/cloudflared/releases/download/<version>/cloudflared-<platform>-<arch>` (e.g. `cloudflared-windows-amd64.exe`).
+2. **Pinned version:** stored in `daemon/scripts/cloudflared-version.txt`. Renewal cadence: quarterly (cross-link chapter 10 R9).
+3. **Pinned SHA256:** stored in `daemon/scripts/cloudflared-checksums.json` (one entry per `<platform>-<arch>`). Build fails if downloaded SHA mismatches the pinned value.
+4. **Release-signature verification at build time:** Win uses `signtool verify /pa`; macOS uses `codesign --verify`; Linux verifies the GPG signature against Cloudflare's apt repo key. Build fails if signature does not verify.
+5. **Runtime SHA re-check (defense against post-installer tampering):** on first `cloudflared` spawn after daemon boot (before passing the token), daemon re-computes SHA256 of the bundled binary and compares against the pinned value from `cloudflared-checksums.json`. Mismatch = log + refuse to spawn + surface `cloudflare.unreachable` with reason `binary tampered`. Fail-closed.
+6. **Build-time version-binary cross-check (per R5 P2-2):** CI step runs `cloudflared --version` on the bundled binary and asserts the reported version matches `cloudflared-version.txt`. Catches "updated the version file but forgot to swap the binary" and vice versa.
+
+#### 1.2 Idle-session eviction (per R3 P1-2; cross-ref ch06 §5, ch10 R5)
+
+Auto-start daemon (chapter 01 G6) means the daemon runs 24/7 across multi-day intervals. Without an eviction policy, PTY headless buffers and per-subscriber fanout buffers hold memory indefinitely.
+
+**Policy (lock for v0.4):** a session with **zero subscribers AND no PTY output for 24h** is buffer-trimmed:
+- Scrollback drops from 10k lines to last **1k lines**.
+- Per-subscriber fanout buffer (1 MiB) is freed.
+- Session metadata (sid, cwd, name, exit status) persists in SQLite.
+
+**Re-attach behavior:** on re-subscribe, reconstruct from SQLite + fresh PTY state. Already-exited sessions show only the trimmed snapshot. Live sessions resume PTY output streaming from the trim point forward.
+
+**Implementation lives in chapter 06 §5.** This subsection states the policy lock so chapter 05 readers know remote-access doesn't accumulate indefinite buffers.
+
+### 2. Tunnel hostname strategy
+
+**Default (lock):** Cloudflare-assigned `<random>.cfargotunnel.com` hostname (ends up looking like `e3a9b2c1.cfargotunnel.com`). Auto-provisioned at tunnel-create time; no DNS configuration needed.
+
+**Custom domain (opt-in):** if the user owns a domain on Cloudflare DNS, they can route `daemon.<their-domain>` to the tunnel via a CNAME to `<tunnel-id>.cfargotunnel.com`. Configured via Cloudflare dashboard, not the daemon. Daemon's Settings UI just shows the active hostname read from `cloudflared`'s metrics endpoint.
+
+**Why default to the random hostname:** zero-config. The user gets remote access from the first session of the wizard with no domain purchase or DNS setup.
+
+**Why custom domain is opt-in only:** requires the user to own a domain. Can't be the default.
+
+**Hostname for the web SPA (Cloudflare Pages):** separate from the tunnel hostname. Pages assigns `<project>.pages.dev` (e.g. `ccsm-app.pages.dev`); the user MAY add a custom CNAME (e.g. `app.<their-domain>`) via Pages settings. Both Pages and Tunnel hostnames go behind Cloudflare Access (§3) — same Access policy covers both.
+
+### 3. Cloudflare Access — application config
+
+**Application** = a Cloudflare Access "self-hosted" application protecting the tunnel hostname AND the Pages hostname.
+
+**Identity provider:** GitHub OAuth (free, included).
+
+**Policy (locked, per R2 P0-2 — adds 2FA + tighter session):**
+
+```yaml
+include:
+  - emails: ["<author-github-email>"]      # placeholder; user fills in setup wizard
+require:
+  - identity_provider: github
+  - mfa:
+      provider: github                      # GitHub-side TOTP / WebAuthn
+session_duration: 8h                        # was 24h; reduced to limit replay window
+auto_redirect_to_identity: true
+```
+
+**Why GitHub OAuth IdP:** the project already requires GitHub for source code; reusing the identity is zero-friction. Cloudflare Access GitHub IdP is free and stable.
+
+**Why MFA required (R2 P0-2):** the JWT grants full PTY access on the user's primary workstation. "Logged into GitHub" alone is insufficient (single factor, GitHub session compromise = full RCE). MFA (GitHub-side TOTP or WebAuthn, surfaced via Cloudflare Access `require: mfa`) raises the bar to "GitHub session AND second factor".
+
+**Why `auto_redirect_to_identity`:** skips Access's "pick an IdP" page since there's only one. User clicks the URL → straight to GitHub login → straight back to the app.
+
+**Why 8h session (was 24h):** balance between "doesn't make me sign in every page load" and "stale device gets locked out reasonably soon". 8h ≈ workday; bounds the replay window if a JWT leaks.
+
+**Country gating (deferred):** `require: country_code` is a v0.5+ option once the author has a stable travel pattern documented. v0.4 omits to avoid lockout-during-travel. Why deferred: insufficient single-user data to pick a list.
+
+**Not surfaced in Settings (per R1 P2-2):** `session_duration`, MFA toggle, country gate are Cloudflare-side policy values, NOT v0.4 user-tunable settings. The user changes them in the Cloudflare dashboard if desired.
+
+**Multi-user later (N2 in chapter 01):** when the user opens this to friends, the policy gains more emails. v0.4 keeps it single-user.
+
+**Compromise recovery (per R2 P0-2):** if GitHub session compromise is suspected:
+1. Revoke the OAuth grant at `github.com/settings/applications`.
+2. Rotate the Access app secret in the Cloudflare dashboard.
+3. Revoke active sessions in Cloudflare Zero Trust → Sessions.
+4. Re-run setup wizard step 2 (re-paste team name + AUD; nothing else changes).
+
+**JWT delivery:** Cloudflare Access sets the JWT in:
+1. **`Cf-Access-Jwt-Assertion` HTTP request header** on every authenticated request (browser → daemon). This is what the daemon validates.
+2. **`CF_Authorization` cookie** on the user's browser, so the SPA itself doesn't need to manage the token.
+
+The web client treats the JWT as opaque — Cloudflare and the daemon handle issuance and validation respectively. No JWT parsing in the browser.
+
+### 4. JWT validation middleware on the daemon
+
+**Decision (lock):** Connect interceptor on the daemon's data-socket Connect server, applied **only when the request arrives via the remote (TCP/Tunnel) listener**, not the local socket.
+
+**Implementation:**
+
+```ts
+// daemon/src/connect/jwt-interceptor.ts (new)
+import { createRemoteJWKSet, jwtVerify } from 'jose';
+
+const cfTeamName = settings.cloudflare_team_name;     // from SQLite (§6)
+const cfAud      = settings.cloudflare_app_aud;       // from SQLite (§6)
+const JWKS_URL = `https://${cfTeamName}.cloudflareaccess.com/cdn-cgi/access/certs`;
+const ISSUER   = `https://${cfTeamName}.cloudflareaccess.com`;
+const AUDIENCE = cfAud;
+
+const jwks = createRemoteJWKSet(new URL(JWKS_URL), { cooldownDuration: 30000 });
+
+// in-process JWT result cache (per R4 P1-2): same cookie ⇒ many RPCs ⇒ one verify
+const verifyCache = new Map<string, { payload: JWTPayload; expMs: number }>();
+
+export const jwtInterceptor: Interceptor = (next) => async (req) => {
+  const transportType = req.contextValues.get(transportTypeKey); // positive enum (§5)
+  if (transportType === 'local-pipe') return next(req);          // local bypass
+  // fail-closed: untagged or 'remote-tcp' both require JWT
+  const token = req.header.get('Cf-Access-Jwt-Assertion');
+  if (!token) throw new ConnectError('missing access JWT', Code.Unauthenticated);
+
+  const cached = verifyCache.get(token);
+  const now = Date.now();
+  if (cached && cached.expMs > now) {
+    req.contextValues.set(jwtPayloadKey, cached.payload);
+    return next(req);
+  }
+
+  try {
+    const { payload } = await jwtVerify(token, jwks, {
+      issuer: ISSUER,
+      audience: AUDIENCE,
+      algorithms: ['RS256'],            // lock: Cloudflare uses RS256; reject 'none' / HS*
+      clockTolerance: '30s',            // tolerate Windows clock drift
+      requiredClaims: ['exp', 'iat', 'iss', 'aud', 'email'],
+    });
+    const expMs = (payload.exp ?? 0) * 1000;
+    verifyCache.set(token, { payload, expMs });
+    req.contextValues.set(jwtPayloadKey, payload);
+  } catch (err) {
+    throw new ConnectError(`invalid access JWT: ${err.message}`, Code.Unauthenticated);
+  }
+  return next(req);
+};
+```
+
+**Why `jose` library:** stable, well-audited, supports Cloudflare's JWKS format out of the box. Used by every other Node project doing JWT validation.
+
+**Why `createRemoteJWKSet` with caching:** the JWKS endpoint is hit on first request, cached, refreshed on key rotation (Cloudflare rotates keys ~yearly). 30s cooldown on miss prevents JWKS-fetch storms under load.
+
+**JWKS pre-warm at boot (per R3 P1-1, R4 P1-2):** daemon proactively fetches JWKS at startup with retry 1s → 30s exponential backoff. **Remote ingress refuses to bind until JWKS is cached.** If JWKS is still unfetchable after 5 min, log + retry every 5 min in background; remote ingress stays unbound. Avoids the "rejected requests vs closed listener" ambiguity for the client (clean ECONNREFUSED instead of "all requests fail unauthenticated").
+
+**Why fail-closed (no token = reject):** the only requests that should reach this middleware are remote (Tunnel) requests, which Cloudflare Access ALWAYS adds the header to. Missing header = either misconfiguration or attacker bypassing Access. Either way, reject.
+
+**Local bypass mechanism (per R2 P1-3):** transport type is a **positive enum** set by the listener at connection-accept time, NEVER read from a request header. Values: `'local-pipe'` (named-pipe / Unix-socket listener) or `'remote-tcp'` (TCP listener fronted by `cloudflared`). The JWT interceptor explicitly checks `transportType === 'local-pipe'` to bypass; **untagged requests fail closed** (treated as `'remote-tcp'` for safety). The JWT interceptor MUST be the first interceptor in the chain after transport-tagging, before any RPC handler.
+
+**Why a transport-level tag rather than per-listener interceptor:** simpler. One Connect server, one interceptor chain, one decision rule. The local listener and remote listener share handlers, transport tag differentiates.
+
+**Bootstrap (knowing `<team-name>` and `<aud>`):** the user provides these in the setup wizard (§6) and they're stored in `settings.cloudflare_team_name` + `settings.cloudflare_app_aud` in SQLite (team name is not a secret; AUD is sensitive but not equivalent to the tunnel token — see §6.1 for handling). Daemon reads at startup; remote ingress refuses to start if either is missing.
+
+**JWT claims used:** the daemon doesn't currently need the email claim for authorization (single user — if the JWT validates, you're authorized). Logged for audit (`pino.info({ jwt_email: payload.email, traceId })`). Multi-user (N2) adds per-claim authorization later.
+
+**Audit + new-IP alert (per R2 P0-2):** every JWT validation logs `{ jwt_email, jwt_iat, source_ip }` where `source_ip` comes from the `Cf-Connecting-Ip` header (set by Cloudflare; trusted because the only path to the TCP listener is via `cloudflared`). Daemon emits a desktop notification on **first-seen IP per session** ("New device signed in from <ip>; if this wasn't you, follow compromise recovery in Settings").
+
+#### 4.1 JWT validation policy locks
+
+These are duplicated here so chapter 05 is the canonical lock; chapter 02 §8 references this section (cross-ref R2 P1-2 / chapter 02 P1-2).
+
+| Policy | Value | Why |
+|---|---|---|
+| Algorithm allow-list | `['RS256']` | Cloudflare Access signs RS256; rejects `alg: none` / HS* / unexpected algs. |
+| Required claims | `exp`, `iat`, `iss`, `aud`, `email` | All five MUST be present and parsed; missing any = reject. |
+| `iss` check | `https://<team-name>.cloudflareaccess.com` (exact match) | Locks to this team's Access deployment. |
+| `aud` check | configured AUD (exact match, single value) | Prevents JWTs minted for OTHER apps under the same team from being accepted. |
+| `clockTolerance` | `30s` | Tolerates Windows machine clock drift. |
+| JWKS cache | `cooldownDuration: 30000` (30s) | Throttles JWKS refetch under JWKS-miss storms. |
+| In-process verify cache | TTL = `payload.exp - now` | Cookie-then-many-RPCs is dominant case; one verify per cookie. |
+| Verify perf budget | ≤ 5 ms p99 over 1000 calls | Measured in M4 dogfood gate. |
+
+**Daemon-side rate limit on JWT failures (per R2 P2-2 → promoted to lock here, since trivial and defense-in-depth):** per-source-IP failure cap of **10 failures in 60s → reject with HTTP 429 for the next 60s**. Source IP from `Cf-Connecting-Ip` header (trusted as above).
+
+#### 4.2 JWT validation test matrix (per R5 P0-1)
+
+The JWT interceptor IS the remote auth boundary. Negative tests are mandatory; chapter 08 §3 (contract tests) defines a `jwt-validation-matrix` test list with the cases below. Each case MUST result in `Code.Unauthenticated` and a specific log-tag for grep-ability.
+
+| Case | Expected | Log tag |
+|---|---|---|
+| Missing `Cf-Access-Jwt-Assertion` header | reject | `jwt.missing` |
+| Wrong `aud` (signed by same team, different app) | reject | `jwt.bad-aud` |
+| Wrong `iss` | reject | `jwt.bad-iss` |
+| Expired (`exp` < now − 30s tolerance) | reject | `jwt.expired` |
+| `alg: none` | reject | `jwt.alg-not-allowed` |
+| `alg: HS256` (signed with shared secret) | reject | `jwt.alg-not-allowed` |
+| Missing `kid` in header | reject | `jwt.kid-missing` |
+| Signed with attacker's RSA key | reject | `jwt.sig-invalid` |
+| JWKS endpoint unreachable | reject + ingress unbound (per §4 pre-warm rule) | `jwt.jwks-unreachable` |
+| JWKS rotation mid-request (token signed with old key just rotated out) | reject (after one re-fetch) | `jwt.kid-not-found` |
+| Local-pipe transport, no JWT | accept (bypass) | `jwt.local-bypass` |
+| Remote-TCP, valid JWT | accept | `jwt.ok` |
+| Remote-TCP, **header-spoofed `transportTypeKey`** | reject | `jwt.transport-spoof` |
+
+**Real-CF shape test (per R5 P1-3):** in addition to the mock JWKS matrix, chapter 08 §5 includes `web-jwt-realshape` — a checked-in JWT recorded once from a real Cloudflare Access deployment (sensitive claims redacted / regenerated). Re-record quarterly. This catches "Cloudflare changed the claim format" without depending on the live-network nightly (chapter 08 §7).
+
+**Per-PR vs nightly split:** mock-JWKS matrix runs every PR (fast, deterministic). Real-CF live-network probe runs nightly only. The recorded-shape test bridges the gap (per-PR + real claim shape).
+
+### 5. Local vs remote ingress on the daemon
+
+The daemon binds **three** listeners in v0.4:
+
+| Listener | Address | Auth | Purpose |
+|---|---|---|---|
+| Control socket | `\\.\pipe\ccsm-sup` (Win) / `~/.ccsm/daemon-sup.sock` (Unix) | peer-cred + HMAC (v0.3 carryover) | Supervisor RPCs (`/healthz`, `daemon.shutdown*`, etc.) |
+| Data socket (local) | `\\.\pipe\ccsm-daemon` (Win) / `~/.ccsm/daemon.sock` (Unix) | peer-cred (v0.3 §3.1.1) | Connect over HTTP/2 — Electron renderer talks here |
+| Data socket (remote, prod) | TCP `127.0.0.1:7879` (only when remote enabled) | Cloudflare Access JWT | Connect over HTTP/2 — `cloudflared` proxies external traffic here |
+
+**Dev TCP listener separate (per R4 P1-3):** chapter 04 §5's Vite-dev-mode TCP listener binds `127.0.0.1:7878` (unauth, dev-only). Prod cloudflared TCP binds `127.0.0.1:7879`. Different ports prevent `EADDRINUSE` collisions when a developer has both modes engaged. Daemon refuses to start the prod TCP listener if `CCSM_DAEMON_DEV_TCP=1` is set, AND refuses to start the dev TCP if remote-access is enabled — explicit mutual exclusion at startup with a clear error message.
+
+**Why bind TCP only when remote enabled:** least exposure. If the user never enables remote, no TCP socket is open, no `cloudflared` is running. Local-only mode = unchanged from v0.3 surface area.
+
+**TCP bind is `127.0.0.1`, never `0.0.0.0`:** all external traffic MUST go through `cloudflared`'s outbound connection. Binding `0.0.0.0` would expose the unauth'd Connect surface from the LAN.
+
+**Production TCP listener Host-header + no-JWT-exempt-routes lock (per R2 P0-2; ch04 §5 cross-refs this paragraph):**
+1. **Host-header binding (lock):** the prod TCP listener (`127.0.0.1:7879`) MUST validate the `Host` header on every incoming request equals `127.0.0.1:7879`, `localhost:7879`, or the configured `cloudflared`-set Host (the public Tunnel hostname `<random>.cfargotunnel.com` or the user's optional custom domain per §2). Any other value MUST be rejected with HTTP 421 Misdirected Request **before any handler or interceptor runs**. This defeats DNS rebinding attacks from any browser tab on the user's machine even if a future PR introduces a route that bypasses the JWT interceptor.
+2. **No JWT-exempt routes (hard rule):** the JWT interceptor (§4) MUST apply to **every** route on the remote TCP listener. There is no allowlist, no `/healthz`-style bypass, no per-method exemption. Adding any route that bypasses JWT on the prod TCP listener requires an explicit amendment to this chapter (chapter 05 §5) and the chapter 02 §8 threat model. The transport-tag local-bypass mechanism in §4 applies ONLY to the local-pipe listener; the prod TCP listener carries the `'remote-tcp'` transport tag and JWT validation is unconditional.
+3. **CI lint (gate):** a CI step greps the daemon's Connect server registration for any interceptor-skipping pattern on the prod TCP listener and fails the build on match. Mirrors the dev-listener gate in chapter 04 §5.
+
+**Why three listeners and not two:** the local data-socket and remote TCP serve identical Connect handlers but have different transport tags (per §4). One Http2Server per listener; both register the same Connect routes. Marginal extra code (~30 LOC).
+
+**Tunnel-side TLS:** terminated at Cloudflare. Daemon-to-`cloudflared` is plain HTTP over loopback (no TLS). Connection from Cloudflare edge to `cloudflared` (the outbound tunnel) is TLS, managed by `cloudflared`.
+
+### 6. Setup flow (first-time user)
+
+In v0.4, enabling remote access is a **one-time wizard** in Settings:
+
+1. User opens Electron Settings → "Remote access" pane.
+2. Toggle "Enable remote access" → wizard launches.
+3. Step 1: "Open Cloudflare dashboard, create a tunnel, paste the token here." (Link button opens browser to https://one.dash.cloudflare.com/tunnels.)
+4. Step 2: "Create an Access application protecting the tunnel hostname; paste team name + application AUD here." (Link button opens https://one.dash.cloudflare.com/access.)
+5. Step 3 (**optional, convenience-only — per R1 P1-1**): "(Optional) deploy the web client. Open this link to fork the ccsm Pages project, or enter your existing Pages URL." The wizard's success criterion is **steps 1+2 complete**; step 3 is a convenience link only and may be skipped. Pages deploy is documented end-to-end in chapter 04 §4 — the wizard link does not introduce a new product surface, just routes the user to that path.
+6. Daemon stores the tunnel token and AUD via the keychain channel (§6.1), team name in SQLite, restarts the remote ingress, spawns `cloudflared`, and shows the resolved tunnel hostname + Pages URL on the Settings pane.
+
+**Why a wizard, not a fully automated flow:** Cloudflare's account-level resources (tunnels, Access apps, Pages projects) require account-level API tokens that we'd otherwise need to ask the user to generate and paste in. A guided wizard with copy-paste is less powerful than automation but doesn't ask the user to give us a privileged API token.
+
+**Why three steps and not one:** each Cloudflare resource (Tunnel, Access app, Pages project) is independent in the dashboard. Trying to bundle them into one click would require account-API access. Three small copy-pastes are tractable.
+
+**v0.5+ improvement:** if the user grants an API token, we can auto-create all three. v0.4 doesn't ship that.
+
+**Idempotency:** re-running the wizard overwrites existing values. Daemon restarts the remote ingress on every save.
+
+**Disabling remote access:** Settings toggle → daemon stops `cloudflared`, closes the prod TCP listener. `cloudflared` outbound connection terminates; tunnel hostname returns 1033 ("Argo Tunnel error"). Resources stay in the Cloudflare account (tunnel + Access app + Pages); they just stop being routed to. **Disabling does NOT touch any local data socket, local PTY sessions, or Electron renderer state** (per R1 P2-1). The Electron client continues to operate exactly as before; only the web ingress is removed.
+
+**Wizard scope discipline (per R1 P1-1):** v0.4 ships the **minimum** wizard needed to capture the three values (tunnel token, team name, app AUD) and the optional Pages link. **No copy A/B testing, no inline-help video embedding, no progress animations beyond a basic spinner. UX iteration is a v0.5+ slice** if real users (not the author) onboard. Implementers and contributors MUST NOT add polish work to the wizard inside the v0.4 milestone.
+
+#### 6.1 Secret-handling discipline (per R2 P0-1)
+
+The tunnel token is a **long-lived high-stakes credential**: token compromise lets an attacker spawn their own `cloudflared` with the token and re-route the user's tunnel hostname to attacker-controlled infrastructure (DoS / phishing the user's own GitHub OAuth flow).
+
+**Storage scheme (lock):**
+1. **Tunnel token** is stored ONLY in the OS keychain. SQLite holds a non-secret pointer `cloudflare_token_keyring_id = "ccsm.tunnel.token"`. Daemon fetches from the keychain on demand; **never persists plaintext to SQLite or disk**.
+2. **CF AUD** is sensitive (allows replay-validation of intercepted JWTs against the wrong app); stored alongside the token in the keychain under `ccsm.access.aud`. Same fetch discipline.
+3. **Team name** is NOT a secret (visible in any Access redirect URL); stored plain in SQLite (`settings.cloudflare_team_name`).
+4. **Library:** `keytar` (or a current-maintained equivalent verified at implementation time — `keytar` is in unmaintained-warning state as of 2026-04; the implementation worker MUST verify and pick the live alternative if needed).
+
+**Per-OS backing store:**
+- Windows: Credential Manager (per-user scope; threat model per chapter 02 R2 — any same-user process can read it).
+- macOS: Keychain (per-user, login keychain; ACL pinned to the daemon binary signature).
+- Linux: `libsecret` (gnome-keyring or kwallet via D-Bus secret-service).
+
+**Linux-without-secret-service fallback:** if `libsecret` (or any working secret-service) is unavailable, **daemon refuses to enable remote access**. Surfaces an error in the wizard: "Remote access requires a desktop secret service (gnome-keyring or kwallet). Install + unlock one, then retry." **No plaintext fallback.** Documented for headless Linux: install `gnome-keyring`, unlock via `dbus-launch`, or accept that remote access requires a desktop session. (Headless Linux is N5 in chapter 01; this fallback rule is the explicit consequence of that N for v0.4.)
+
+**In-memory handling:**
+- Token + AUD held in a `SecureBuffer` (zeroed after use).
+- **Never written to logs**; pino redaction config explicitly redacts any field name matching `/(token|secret|jwt|aud|password|authorization)/i`. Lock here; configured in chapter 02's interceptor logging section.
+- **Never serialized to JSON** for IPC.
+- RPC handlers that "check whether a token exists" return a `boolean` (existence), never the value.
+
+**Setup-wizard secret-input channel:**
+- Settings UI uses `<input type="password">` with `autocomplete="off"` and `autocapitalize="off"`.
+- On submit, the value is sent via a **dedicated Connect RPC** (`SaveTunnelToken`, separate from the generic settings RPC) that:
+  - Immediately stores to the keychain.
+  - Zeroes the in-memory copy in main + renderer.
+  - Returns success/failure only — never the value.
+- Renderer **never re-reads** the value (the password input shows `••••••••` placeholder + a "Replace" button; replacing requires re-entry).
+- IPC bridge MUST NOT log this RPC's argument; instrumentation that mirrors all RPCs to a debug log MUST exclude `SaveTunnelToken` from the mirror.
+
+### 7. Cost
+
+All-Cloudflare, all-free-tier (with caveats — see §7.1):
+
+| Service | Free tier limit | Our usage |
+|---|---|---|
+| Tunnel | "Unlimited" bandwidth, 1 free tunnel per account | 1 tunnel |
+| Pages | 500 builds/month, unlimited static hosting | <30 builds/month expected |
+| Access | ≤50 users (≤3 zero-trust seats free; more on Free Plan) | 1 user |
+| DNS | unlimited | not used in default config (cfargotunnel) |
+
+**Total recurring cost: $0/month** for the v0.4 author / single-user case **assuming the bandwidth caveats below hold**.
+
+**When you'd start paying:**
+- More than 50 Access users → $7/user/month (Cloudflare Zero Trust Pay-As-You-Go). Far in the future.
+- Custom domain not on Cloudflare DNS → small annual registrar fee (independent of Cloudflare).
+- High build frequency → Pages charges $0.10 per 1000 builds beyond 500/month. Not realistic for this project.
+
+#### 7.1 Bandwidth caveat + spike requirement (per R4 P0-1)
+
+Cloudflare's "unlimited bandwidth" claim for Tunnel free tier is operationally true for typical traffic but the Zero Trust TOS includes an "abusive use" clause that has historically been triggered by **always-on, high-volume continuous streaming**. v0.4 streams PTY output 24/7 across multiple sessions × multi-client fanout × 90s heartbeats — exactly the always-on pattern that warrants verification.
+
+**Estimated monthly bandwidth (typical):**
+- Heartbeats: `90s heartbeat × 5 streams × ~50 bytes × 30 days` ≈ **0.7 MB/month** (negligible).
+- Idle PTY output: a few KB/day per session (prompt redraws).
+- Peak PTY output: bounded by user activity (compile output, large file `cat`, dev-server log streams). Bounded at ~10 MB per heavy session-day in practice.
+- **Order-of-magnitude estimate: 1–5 GB/month** for typical author use; well under any documented soft-limit Cloudflare has applied.
+
+**Pre-M4 spike requirement:** stand up a real free-tier Tunnel and stream PTY output continuously for **7 days at typical session load**. Measure aggregate bandwidth (PTY chunks) and confirm no Cloudflare warnings or rate-limits. Spike report committed to `docs/spikes/2026-05-cloudflare-tunnel-bandwidth.md` BEFORE M4 implementation begins.
+
+**Fallback plan (lock):** if free tier proves untenable post-spike or post-launch, switch to **paid Tunnel ($5/month base)**. Design-wise this is zero work — same Tunnel surface, just account billing flipped. User-facing change is "$0/month → $5/month"; document as a known cost-tier risk in chapter 10 R3 (which previously only worried about Access-tier risk; cross-link added).
+
+### 8. Operational caveats
+
+**CF Access free tier is "Cloudflare One Free" plan:** confirms ≤50 users + ≤3 zero-trust seats. As of 2026-04, this includes one IdP integration (GitHub fits) and unlimited app policies. Verify at activation time; surface a clear error in the wizard if Cloudflare changes the tier.
+
+**`cloudflared` uses outbound HTTPS only:** no inbound port required. Works through corporate NAT / mobile hotspot / Wi-Fi captive portal (after the captive portal is dismissed).
+
+**HTTP/2 over Tunnel (locked for v0.4):** Cloudflare Tunnel forwards HTTP/2 end-to-end (edge-to-cloudflared as HTTP/2; cloudflared-to-daemon as HTTP/1.1 OR HTTP/2 depending on cloudflared config). We force HTTP/2 by setting `--protocol http2` in `cloudflared` args. This matters for streaming (chapter 06).
+
+**Why not QUIC/HTTP/3 for v0.4 (per R4 P2-1):** `cloudflared`'s default `--protocol auto` will pick QUIC where available, which can shave a TCP handshake on cold connections (potentially 0-RTT). Server-streaming inside QUIC works in principle but our chapter 06 streaming patterns are validated against HTTP/2 only. Locking `http2` in v0.4 removes one variable for the M4 dogfood. **Spike in M4 (deferred):** try `--protocol auto` and compare cold-start latency; if QUIC works for streaming, drop the `--protocol http2` lock in v0.5.
+
+**Idle timeout = 100s:** Cloudflare WebSocket-equivalent (HTTP/2 stream) is killed after 100s of no traffic. We send a 90s heartbeat on every long-running stream. See chapter 06 §4.
+
+**Connection limits:** Cloudflare doesn't publish hard caps for free Tunnel HTTP/2 stream concurrency. ccsm typical session count is single-digit. Not a concern at v0.4 scale; covered by the bandwidth spike (§7.1) for confirmation.
+
+**Cloudflare outage:** if Cloudflare's edge or Access has an outage, the web client is unreachable. The local Electron client is unaffected (local socket). Document this as a known limitation; user has a fallback.
+
+**Geographic latency:** Cloudflare's anycast network terminates the user's request at the nearest edge. From the edge, traffic goes through the tunnel back to the user's home box. Worst-case round-trip: edge-to-home over the user's home upstream (typically 10-40ms in metro areas). Tolerable for terminal use.
+
+**`cloudflared --metrics` endpoint exposure (per R2 P2-1):** the `--metrics 127.0.0.1:0` ephemeral port is unauthenticated and exposes tunnel routing config to any same-user process. Bound to loopback only; hygiene-acceptable for v0.4 (info disclosure scope = tunnel stats, not RPC). v0.5 may switch to a Unix-domain socket where `cloudflared` supports it.
+
+### 9. Testability hooks
+
+This section lists the test hooks chapter 05's logic needs; chapter 08 owns the actual test layout.
+
+- **`spawnCloudflared` factory injectable** (per R5 P1-1): default `childProcess.spawn`; tests substitute a fake to drive the health/restart state machine.
+- **Injectable clock** for the health-poll + backoff state machine: tests advance the clock to assert (1 fail = no restart; 3 fail = restart; 10 attempts in 30 min = surface banner + slow-tick fallback; network-up event = immediate fast cycle).
+- **Injectable JWKS endpoint** for the JWT validation matrix (§4.2): mock JWKS server with controllable key rotation and reachability.
+- **Recorded real-CF JWT fixture** (per R5 P1-3): checked into `daemon/test/fixtures/cf-jwt-realshape.json`; re-recorded quarterly.
+- **TryCloudflare local-dev path (per R5 P1-2):** for contributors without a Cloudflare account, `cloudflared tunnel --url http://127.0.0.1:7879` (TryCloudflare ephemeral mode) creates a temporary `*.trycloudflare.com` hostname with **no Access protection**. Useful for tunnel-pipe smoke tests; **NOT for the JWT path** (no Access in front means no JWT). Chapter 08 §3 documents this as the no-account fallback for spawn/supervise contract tests; CI uses the real-account path via secret credentials.
+- **Stats counters (per R3 P2-2):** v0.4 carryover — `/stats` (control socket, supervisor RPC) gains counters for: connect-rpc requests/sec by method, JWT validation rejections/sec, `cloudflared` restart count, active stream count, fanout buffer total bytes. v0.5 adds a Prometheus `/metrics` endpoint.
+
+## 6. Streaming and multi-client coherence
+
+### Context block
+
+ccsm has 11 server-streaming surfaces (chapter 03 §1 inventory): PTY output, PTY exit, session state changes, session title updates, session cwd-redirected, session-activate, notify flash, updater status, updater downloaded, window-maximized-changed, window-before/after-show. The PTY stream is the most demanding (binary bytes, high throughput, multi-client coherence required); the rest are low-volume control streams. v0.4 carries v0.3's headless-buffer + seq-replay design forward (it was already lifted into the daemon; v0.4 just reframes it on top of Connect). The novel work is **(a)** mapping streams onto Connect server-streaming over HTTP/2, **(b)** keeping streams alive through Cloudflare's 100s idle timeout, and **(c)** ensuring desktop + web clients on the same session see a coherent view.
+
+### TOC
+
+- 1. Stream model: Connect server-streaming over HTTP/2
+- 2. PTY chunk message shape (binary bytes, no JSON re-encoding)
+- 3. PTY input model (unary message-per-keystroke-batch, not bidi stream)
+- 4. Heartbeat (90s) for Cloudflare 100s idle dodge
+- 5. Multi-client coherence (xterm-headless authoritative buffer)
+- 6. Reconnect + seq replay (`fromSeq`)
+- 7. Backpressure / drop-slowest (carryover from v0.3)
+- 8. Non-PTY streams (session state, notify flash, etc.)
+- 9. Testability seams (hermetic harness hooks)
+
+### Glossary (terminology key)
+
+- **Client** = an app instance (one Electron process, one browser tab). A client may hold many open streams.
+- **Subscriber** = one open server-stream RPC on one session by one client. One client subscribed to N sessions = N subscribers. Per-subscriber memory caps (§7) and the fanout registry (§5) are keyed by subscriber, not client.
+- **Connection** = the underlying HTTP/2 connection. One client typically uses one HTTP/2 connection multiplexing many subscribers.
+
+**Field-naming convention (proto ↔ TS):** proto fields use `snake_case` per Buf/Google style; `protoc-gen-es` codegen exposes them in TS as `camelCase` (proto `boot_nonce` → TS `bootNonce`; proto `session_id` → TS `sessionId`). RPC method names are PascalCase in proto and camelCase on the TS client (`rpc StreamPty(...)` → `client.streamPty(...)`).
+
+### 1. Stream model: Connect server-streaming over HTTP/2
+
+**Decision (lock):** every server-stream RPC is declared in `proto/` as `rpc Foo(FooRequest) returns (stream FooEvent);`. Connect over HTTP/2 carries it natively — one HTTP/2 stream per RPC call, server pushes message frames, client reads them as an async iterable.
+
+**Why server-streaming (not bidi):** Connect-Web is half-duplex (chapter 02 §1). Bidi requires server-side to support upgrade negotiation that browsers can't initiate. PTY input over a separate unary RPC (§3) avoids the bidi requirement entirely.
+
+**Stream lifecycle:**
+- Client opens stream via `client.streamPty({ sessionId, fromSeq?: 0 })`.
+- Server pushes `PtyEvent` messages until either: (a) client closes (e.g. user navigates away), (b) session exits (server pushes one final `PtyEvent { kind: EXIT }` then closes), or (c) network drops (HTTP/2 stream RST).
+- Client iterates: `for await (const evt of stream) { ... }`. Iterator throws on network drop; UI catches and triggers reconnect (§6).
+
+**Why one stream per (sessionId, client):** simplest mental model. Multi-session subscriptions are N parallel streams, not one fat stream with discriminators. HTTP/2 multiplexes them on the same connection at zero per-stream cost.
+
+**Why not Connect's `BidiStream` for input+output:** would force the daemon to keep a "client connection" object per session per client and route incoming PTY-input back to the right session. Unary input + server-streaming output is cleaner and scales identically (HTTP/2 handles N concurrent streams).
+
+**Per-session authorization hook (forward-compat for multi-user, chapter 01 N2):** every stream/RPC handler that takes a `session_id` MUST invoke `authorizeSessionAccess(jwtPayload, sessionId)` before delivering any data or accepting any input. v0.4 implementation is `return true` unconditionally (single-user model — only one authorized identity); v0.5+ replaces this hook with per-user/per-session ACL without changing call sites. The hook MUST be in place from M4 ship; chapter 08 contract test asserts the hook is invoked on `streamPty`, `SendPtyInput`, and `GetPtySnapshot`. This forecloses the foreseeable-soon gap where Cloudflare Access policy adds a second email and both users would otherwise see ALL sessions. Cross-ref: chapter 05 §4 (JWT interceptor populates `jwtPayload` in the request context — the hook's input source); chapter 01 N2 (multi-user enablement requires this hook to be made real).
+
+**Per-session subscriber cap (DoS / reconnect-storm guard, see also §7):** the fanout registry enforces `MAX_SUBSCRIBERS_PER_SESSION = 8` and a daemon-wide `MAX_TOTAL_SUBSCRIBERS = 64`. New `streamPty` subscribes beyond either cap are rejected with Connect `resource_exhausted`. This bounds the cost of a misbehaving SPA that opens-then-reopens streams in a loop.
+
+### 2. PTY chunk message shape
+
+`pty.proto`:
+```proto
+message PtyEvent {
+  uint64 seq = 1;                // monotonic per-session, set by daemon
+  uint64 boot_nonce = 2;         // daemon-process boot identity (chapter 07 §1)
+  oneof payload {
+    PtyChunk chunk = 10;          // most common: terminal output bytes
+    PtyExit exit = 11;            // session exit
+    PtyResize resize_ack = 12;    // ack of remote resize
+    PtyHeartbeat heartbeat = 13;  // 60-90s keepalive (§4)
+    PtySnapshot snapshot = 14;    // initial / forced re-snapshot payload (§5, §6)
+    PtyGap gap = 15;              // drop-slowest signal (§7) — client must re-snapshot
+  }
+}
+
+message PtyChunk {
+  bytes data = 1;                // raw terminal bytes (UTF-8 OR binary)
+}
+
+message PtyExit {
+  optional int32 code = 1;
+  optional int32 signal = 2;
+}
+
+message PtySnapshot {
+  bytes data = 1;                // serialized xterm-headless buffer (gzip wire-encoded)
+  bool truncated = 2;             // true if scrollback was truncated to fit cap (§5)
+  uint32 viewport_cols = 3;
+  uint32 viewport_rows = 4;
+}
+
+message PtyGap {
+  string reason = 1;             // "drop_slowest" | "boot_nonce_mismatch" | "fromSeq_too_old"
+}
+```
+
+**Why `bytes` (not `string`) for `data`:** Protobuf `string` requires valid UTF-8. Terminal bytes from `node-pty` may contain partial UTF-8 sequences across chunk boundaries. `bytes` accepts any sequence; client reassembles UTF-8 in xterm.js as today.
+
+**Why no JSON re-encoding:** v0.3 §3.4.1.c carved out a binary-trailer envelope to avoid `JSON.stringify(buffer)`. Protobuf `bytes` is binary natively — wire size = chunk size + ~5 bytes proto framing. ~30% reduction vs base64-in-JSON, ~5-30 ms saved per 64 KiB chunk per v0.3 measurement. M2 contract test measures `bytes-overhead-per-PTY-byte` for a representative compile-output workload and records it in the perf baseline (R4 P2-1 follow-up).
+
+**Why include `seq` and `boot_nonce` in every event:** seq for replay (§6); boot_nonce so the client detects "daemon restarted; my seq cursor is stale" and re-snapshots instead of asking for a seq the new daemon doesn't have.
+
+**Why `oneof` rather than separate stream RPCs:** keeps PTY events on one stream (one HTTP/2 stream, one client iterator). Adding new event kinds (e.g. v0.5 `OscClipboard` for OSC52 clipboard pass-through) is a `oneof` extension — additive, non-breaking.
+
+### 3. PTY input model: unary message-per-keystroke-batch
+
+PTY input is **NOT** a stream. Each input goes via:
+```proto
+rpc SendPtyInput(SendPtyInputRequest) returns (SendPtyInputResponse);
+
+message SendPtyInputRequest {
+  string session_id = 1;
+  bytes data = 2;
+}
+message SendPtyInputResponse {}
+```
+
+**Why unary:**
+- Connect-Web doesn't support client-streaming.
+- Per-keystroke unary RPCs over HTTP/2 are cheap (multiplexed on the existing connection, no new TCP/TLS handshake).
+- Daemon serializes inputs into the per-session PTY input queue in arrival order; clients can't reorder.
+
+**Batching at the renderer (v0.4 introduction; required by Connect-Web's unary input model):**
+
+**Provenance:** v0.3 sent each keystroke as a separate IPC envelope (no coalescing — local socket cost was negligible). v0.4 introduces input coalescing because per-keystroke unary RPCs over Cloudflare Tunnel pay a JWT-verify + interceptor + protobuf encode/decode cost per RPC, so paste-of-large-text without batching would saturate the tunnel. This is the smallest behavioral change consistent with the new transport.
+
+**Coalescing rule (lock, replaces the earlier 5ms-fixed-window proposal — R4 P1-2):** xterm.js fires `onData` per keystroke. The bridge wrapper coalesces by:
+- Flush when the input buffer has been **idle for ≥ 1 frame (16ms)**, OR
+- Flush when the buffer reaches **4 KB**, whichever comes first.
+
+This yields 1-2 RPCs for typical paste of `npm install` output (10s of KB) — far better than the 5-10 RPCs a 5ms window would produce — while keeping typing latency invisible (a single keystroke flushes after one frame of idle, ≤16 ms).
+
+**Why not a fixed 5ms window:** at 5ms, paste fires 5-10 RPCs because `onData` events are spread over 20-100ms by event-loop scheduling, AND every typing keystroke is its own batch (so 5ms does nothing for typing). Idle-detect + size cap is the right shape.
+
+**Daemon-side per-client rate cap:** `SendPtyInput` is rate-limited to 200 RPCs/sec per client (burst 1000); over-cap returns Connect `resource_exhausted`. Per-session PTY input queue is capped at 1 MiB; further input rejected with `resource_exhausted` until drained. (R2 P2-1 defense-in-depth against compromised clients.)
+
+**Backpressure on input:** if the daemon is slow to ack and the bridge's outbound queue exceeds 256 KiB, the bridge **holds further input** and shows an explicit "input throttled — daemon backpressure" banner in the terminal chrome. The bridge does NOT silently drop input. User can dismiss the banner; new input is held (not dropped) until the queue drains. Realistically input throughput is human-scale and never hits this.
+
+**Perf gate (M3 dogfood):** paste-50 KB latency target ≤ 200 ms first-byte-to-PTY-echo measured on a Cloudflare-Tunnel'd web client over typical broadband.
+
+### 4. Heartbeat (60-90s) for Cloudflare 100s idle dodge
+
+**Problem:** Cloudflare Tunnel kills HTTP/2 streams after 100s of no traffic in either direction. A user who opens a session, walks away for 2 minutes, comes back and types — without heartbeat, the stream is dead and they'd see no output.
+
+**Decision (lock):** the daemon emits a `PtyHeartbeat` event on every active PTY stream when it has been idle (no other event sent) for >60s, with a hard ceiling of 90s. 90s = comfortable margin under 100s. Same rule on every server-stream RPC (`oneof` member named `heartbeat`).
+
+```proto
+message PtyHeartbeat {
+  // empty — presence is the signal. seq + boot_nonce on PtyEvent
+  // wrapper carry the freshness info needed for liveness checks.
+}
+```
+
+**Heartbeat aggregation (R4 P1-1, lock):** heartbeat scheduling is **per-connection, not per-stream**. The daemon runs ONE timer per active HTTP/2 connection (= per client) ticking every 30s. On tick, it walks the connection's open streams; for each stream idle >60s it emits one heartbeat on that stream. K subscribers on one connection share one timer instead of K timers. This collapses the worst-case "5 sessions × 2 clients × 11 streams = 110 timers" down to "≤ K active connections" timers.
+
+Client-side liveness check is symmetric: one timer per HTTP/2 connection walks its streams and resets a per-stream `lastSeenAtMs` on every received message. Heartbeat budget cap: ≤500 bytes/min/active-client. Idle sessions consume zero (no traffic at all once last subscriber detaches).
+
+**Client-side liveness check:** the per-stream `lastSeenAtMs` is **reset on every received message** — chunk, exit, snapshot, gap, resize_ack, OR heartbeat. NOT only on heartbeat (a high-throughput stream doesn't emit heartbeats and must not falsely flag dead). If `now - lastSeenAtMs > 120s`, client treats stream as dead and triggers reconnect (§6). 120s = 90s heartbeat ceiling + 30s grace for network jitter.
+
+**Observability (R3 P1-2 follow-up):** the bridge logs every reconnect with a distinct trace category `stream_liveness_reconnect` carrying `{ sessionId, lastSeenAgeMs, lastEventKind, heartbeatsReceived, heartbeatsExpected }`. Daemon emits `pino.debug({ event: 'heartbeat_emitted', sessionId, connectionId, idleMs })` so dogfood can detect heartbeat storms and silent stream death without inferring from output shape. Per-stream "heartbeats received vs expected" counter is exposed via the daemon `/stats` endpoint (chapter 05).
+
+**Why server-driven heartbeat (not client ping):** Connect-Web has no client-streaming, so client can't push periodic pings on the same RPC. Server-driven is the only path on Connect-Web.
+
+**Why not an HTTP/2 PING frame:** Connect doesn't expose PING frame access; HTTP/2 PINGs are at the transport layer and don't reset the application's idle timer for this purpose. App-level heartbeat is the documented Cloudflare workaround.
+
+**Test-mode interval override (R5 P1-1):** all heartbeat intervals are read from env vars at daemon boot — `CCSM_HEARTBEAT_IDLE_MIN_MS` (default 60_000), `CCSM_HEARTBEAT_IDLE_MAX_MS` (default 90_000), `CCSM_HEARTBEAT_TICK_MS` (default 30_000), and the client-side liveness `CCSM_LIVENESS_TIMEOUT_MS` (default 120_000). E2E harness sets these to 60/90/30/120 *milliseconds* so the "stream-stays-alive-across-idle" case runs in <1s instead of >100s. See §9 and chapter 08 §5 (`web-heartbeat-survives-idle`).
+
+### 5. Multi-client coherence (xterm-headless authoritative buffer)
+
+**v0.3 already implemented this:** the daemon runs `xterm-headless` per session, maintains the authoritative terminal buffer, and serializes it on snapshot. PRs L4 PR-A..E (commits 49353a9, 9971733, 64b5248) landed it. v0.4 reuses unchanged.
+
+**Coherence guarantees:**
+1. **Buffer state** is the daemon's `xterm-headless` instance. PTY bytes from `node-pty` are written into it; xterm-headless processes ANSI escapes and updates its grid.
+2. **Each subscriber** (Electron, web, future client) on `streamPty(sessionId, fromSeq)` receives:
+   - First message: a synthetic `PtySnapshot` event (the serialized headless buffer up to `currentSeq`), if `fromSeq <= currentSeq - replayBufferDepth` or `fromSeq == 0`.
+   - Subsequent messages: live `PtyChunk` events with `seq > snapshotSeq`.
+3. **Inputs** from any client go through `SendPtyInput` → daemon's per-session PTY input queue → `node-pty` write. Single source of truth; no input merge conflict possible (a stream of bytes has total order in arrival).
+4. **Outputs** from `node-pty` are fanned out: written to xterm-headless (updates buffer) AND emitted on every active subscriber's stream with the same `seq`. Both clients see identical bytes in identical order.
+
+**Snapshot generation:** existing `pty.snapshotSemaphore` (v0.3 `daemon/src/pty/snapshot-semaphore.ts`) ensures only one serialize-buffer call runs at a time per session. Snapshot RPC `GetPtySnapshot(sessionId)` returns `{ snapshot: bytes, seq: uint64, bootNonce: uint64, truncated: bool }`. Clients call it on initial attach if they have no prior seq (or receive it inline as the first `PtySnapshot` event when the daemon force-snapshots, §6).
+
+**Snapshot size cap and truncation (R4 P0-1, lock):**
+- Snapshot RPC responses MUST be wire-compressed: Connect server sets `Content-Encoding: gzip` for `PtySnapshot` payloads (the `bytes` field is highly compressible — repeated empty cells, small ANSI palette).
+- **Hard cap: 2 MiB compressed.** If the serialized buffer exceeds 2 MiB even after gzip, the daemon truncates scrollback (oldest lines first) until under cap, sets `PtySnapshot.truncated = true`, keeps the visible viewport plus the most recent 1k lines minimum.
+- **Soft target: ≤ 500 KiB gzipped p95.** Measured in M4 dogfood gate.
+- Default scrollback in v0.4 is reduced from 10k to **5k lines** for new sessions (configurable via session settings; existing sessions keep their setting). Smaller default = lower steady-state snapshot cost without losing the "scroll back through last hour" workflow.
+- Snapshot RPC concurrency: at most **2 snapshots in flight daemon-wide**; further requests queue. Identical-session snapshot requests within a 1s window are deduplicated (one serialize, fan-out the result). Prevents the cascading-respawn scenario where N reconnecting clients peg the single-threaded Node event loop on serialize+gzip and starve `/healthz` (chapter 07 §1.5 mandates supervisor `/healthz` timeout > worst-case snapshot serialize time).
+
+**Replay buffer (per-session, R3 P0-1, lock):** separate from per-subscriber drop-slowest (§7). The daemon retains a per-session **ring buffer of the most recent 4 MiB of PTY events** (chunks + their seq numbers). Reconnect with `fromSeq` older than the ring tail ⇒ the daemon emits `PtyGap { reason: "fromSeq_too_old" }` followed by a `PtySnapshot` event. Ring depth in seconds is a function of session output rate: ~10s of seconds for a hot stream (compile output), hours for an idle shell. Math: at hot-stream 100 KiB/s the ring covers ~40s; at idle 100 B/s it covers ~12 hours. The 4 MiB number balances against §7's 1 MiB per-subscriber drop-slowest (4× headroom) and chapter 10 R5 daemon memory cap.
+
+The 256 KiB "replay budget" mentioned in §6 is the per-reconnect REPLAY-BURST cap (don't ship more than 256 KiB inline before just sending a snapshot). The 4 MiB ring buffer is the RETENTION cap (don't keep more than 4 MiB of replayable history per session). Both apply.
+
+**Why xterm-headless is authoritative (not raw byte log):** ANSI sequences are stateful (cursor position, color, mode bits). Two clients joining at different points see different "current state" if they each interpret raw bytes from a fixed point. The daemon-side headless terminal interprets once; clients receive either a serialized state OR live deltas from that state, never both diverging.
+
+**Concurrent inputs from desktop + web:** the daemon's PTY input queue is FIFO in receipt order. Two clients typing simultaneously interleave at character boundaries (just like two people typing on the same shell). This matches user expectations for a "shared session" model.
+
+**Lag asymmetry note:** Electron on local socket sees microsecond-latency input; web client over Cloudflare Tunnel sees 10-40ms RTT (chapter 05 §8). When both type "abc" simultaneously, Electron's keystrokes consistently land first in the daemon's PTY queue. This is intrinsic to the transport, not a bug, but the daemon exposes per-client input counters via `/stats` (cross-ref chapter 05 §5 stats endpoint) so user reports of "lost keystrokes" can be diagnosed: `inputs_received[clientId]` vs `inputs_acked[clientId]` per session lets dogfood tell daemon-side drop apart from xterm.js dedup or web-side queue overflow (R3 P1-3).
+
+**R1 framing (concurrent-input behavior is a v0.4 emergent property, not a feature change):** this concurrent-input behavior is observable only because v0.4 adds a second client. It is NOT a feature change to single-client behavior — Electron-only behavior is identical to v0.3. Documented as R14 in chapter 10.
+
+**Snapshot semaphore observability (R3 P2-1):** the daemon emits `pino.debug({ event: 'snapshot_queued', sessionId, queueDepth, waitMs })` on every snapshot request that queues behind the semaphore. Lets dogfood detect snapshot-storm scenarios (N tabs reconnecting) before they manifest as user-visible lag.
+
+### 6. Reconnect + seq replay (`fromSeq`)
+
+**Client-side flow on stream loss:**
+1. Stream iterator throws (network drop, daemon restart, Cloudflare idle kill not caught by heartbeat).
+2. Client retains last-seen `seq` for the session in memory (`lastSeenSeq[sessionId]`).
+3. After reconnect-backoff (exp 1s → 5s → 30s → ...), client opens new `streamPty({ sessionId, fromSeq: lastSeenSeq + 1 })`.
+4. Daemon checks: do I still have `boot_nonce` matching what client knew? Do I still have `seq >= fromSeq` in my fanout buffer?
+   - **Yes + yes:** replay events from `fromSeq` to `currentSeq`, then continue live stream.
+   - **No (boot_nonce mismatch — daemon restarted):** force re-snapshot. Stream first event is a `PtySnapshot` event (the serialized buffer subject to §5 truncation cap), seq is the daemon's current seq.
+   - **Boot_nonce match but `seq < fromSeq` in ring (gap; client missed too much):** force re-snapshot, same as above. Daemon emits `PtyGap { reason: "fromSeq_too_old" }` first so the client can show a "session resynced — some history may be missing if `truncated`" indicator.
+5. Client renders snapshot OR replays events into xterm.js, updates `lastSeenSeq`, resumes normal streaming.
+
+**Replay budget cap (carryover from v0.3 frag-3.4.1.b):** daemon ships at most 256 KiB of replay before declaring `gap: true` and forcing a fresh snapshot. Prevents nodemon-storm reconnect into a hot stream looping drop-and-resubscribe. (Distinct from the 4 MiB retention ring in §5 — see the "Both apply" note there.)
+
+**`boot_nonce` mismatch logging (R3 P2-2):** on boot_nonce mismatch the daemon emits `pino.info({ event: 'force_snapshot', sessionId, reason: 'boot_nonce_mismatch', clientBootNonce, currentBootNonce })`. From the user side a force-snapshot looks like a brief flicker; the log line gives root cause for debugging.
+
+**Why seq-based resume works for both clients:** it's a property of the daemon's fanout, not the transport. v0.3 designed it for the local socket; v0.4's Connect transport carries the seq numbers transparently in `PtyEvent.seq`.
+
+#### 6.1 Startup-race semantics (daemon mid-boot reconnect, R3 P1-1)
+
+After daemon crash + supervisor respawn, the daemon goes through SQLite migration (could take seconds), Connect server bind, and JWKS prefetch (chapter 05 §4). During this window, a reconnecting client lands on one of three observably-different states:
+
+| State | Connect status | Distinguisher | Client behavior |
+|---|---|---|---|
+| **Listener not bound yet** | TCP `ECONNREFUSED` / HTTP/2 connect fails | Network-layer error (no Connect headers) | Exp-backoff (1s → 5s → 30s, capped 30s); show "connecting…" banner |
+| **Migration pending** | `failed_precondition` with `Retry-After` header (chapter 02 §8 migration-gate interceptor) | Connect error code `failed_precondition` + `Retry-After: <seconds>` | Constant 2s backoff for up to 60s, then escalate to exp; show "starting up…" banner (NOT "unreachable") |
+| **JWKS not loaded (boot window)** | `unauthenticated` with header `X-CCSM-Boot: starting` | Header presence distinguishes from real JWT-expired (which omits this header) | Same as migration-pending: constant 2s for up to 60s with "starting up…" banner |
+| **JWT actually expired** | `unauthenticated` without `X-CCSM-Boot` header | No boot header | Trigger token refresh flow (chapter 05 §4) |
+
+The daemon emits `X-CCSM-Boot: starting` on every response during the boot window (until JWKS loaded AND migrations complete) so clients can distinguish "daemon is coming up" from real auth/protocol failures without tight-looping retries that thrash daemon during boot. Boot-window duration is logged (`pino.info({ event: 'boot_window_closed', durationMs })`).
+
+### 7. Backpressure / drop-slowest (carryover from v0.3)
+
+v0.3 `daemon/src/pty/drop-slowest.ts` enforces a 1 MiB per-subscriber buffer high-water mark. If a subscriber's outbound queue exceeds 1 MiB, the daemon drops events for that subscriber, emits a `PtyGap { reason: "drop_slowest" }` event, and forces re-snapshot on next event.
+
+v0.4 carries this forward unchanged at the daemon. The Connect transport's flow control (HTTP/2 stream window) interacts naturally: if the client doesn't read fast enough, HTTP/2 stops accepting writes from the daemon's stream handler, the buffer fills, drop-slowest fires.
+
+**Why keep drop-slowest at the application layer in addition to HTTP/2 flow control:** HTTP/2 windows are designed for fairness across streams on one connection, not for "one slow client should not balloon daemon memory". Application-layer drop is the safety net.
+
+**Web client implication:** a backgrounded browser tab throttles its event loop. Slow event consumption → drop-slowest fires → snapshot on tab refocus. Acceptable: user comes back, sees current state, no lost work (input queue is server-side; only display state is rebuilt).
+
+**Subscriber count caps (cross-ref §1):** the per-subscriber 1 MiB watermark protects daemon memory per subscriber but does nothing about subscriber COUNT. The fanout registry enforces `MAX_SUBSCRIBERS_PER_SESSION = 8` and `MAX_TOTAL_SUBSCRIBERS = 64` (§1) — together with drop-slowest these bound worst-case daemon memory at `8 × 1 MiB × N_sessions` for the per-subscriber buffers, plus `4 MiB × N_sessions` for the replay rings (§5).
+
+### 8. Non-PTY streams
+
+Same model, lower stakes:
+
+| Stream | Volume | Heartbeat needed? |
+|---|---|---|
+| `streamSessionStateChanges()` | 1-2 events/sec at most (state transitions) | Yes (idle for hours) |
+| `streamSessionTitleUpdates()` | <1 event/min | Yes |
+| `streamNotifyFlashes()` | 1-10 events/min | Yes |
+| `streamUpdaterStatus()` | sparse (download progress when active) | Yes |
+| `pty:exit` | One per session lifetime | Carried on the same `streamPty` stream |
+| `session:cwdRedirected` | Rare (import edge case) | Folded into `streamSessionStateChanges` as a state-change variant |
+| `session:activate` | User clicks notification | Folded into `streamNotifyFlashes` as a click event |
+| `window:*` | Electron-only, stays on `ipcRenderer` (chapter 03 §2) | n/a |
+
+**Why fold related streams:** fewer streams = fewer heartbeats + less per-stream overhead. The bridge surface (`onState`, `onTitle`, `onCwdRedirected`, `onActivate`) stays as separate listener-set fan-outs in the bridge file (per v0.3); the wire surface is the smaller folded set.
+
+**Discrimination via `oneof`:** same pattern as PTY events. `SessionEvent { oneof { state_change, title_update, cwd_redirected, ... } }`.
+
+**Heartbeat strategy:** every server-stream RPC has a `Heartbeat` member in its `oneof`. Daemon emits per the per-connection aggregation rule in §4. Same 120s client-side timeout. Test-mode interval overrides (§4) apply uniformly across PTY and non-PTY streams.
+
+#### 8.1 Folded-stream bridge contract (R1 P2-1)
+
+When the wire surface folds variants (e.g. `session:cwd_redirected` carried inside `SessionEvent.cwd_redirected` rather than its own RPC), the bridge MUST preserve the v0.3 listener-fan-out shape exactly:
+
+1. **Variant-exact dispatch.** The bridge MUST emit on `onCwdRedirected` listeners ONLY when the wire variant is `cwd_redirected`. It MUST NOT fire `onCwdRedirected` for any other variant of the folded stream (state_change, title_update, etc.). Same rule for `onActivate` vs `streamNotifyFlashes` variants.
+2. **No added latency.** Routing through a folded stream's discriminator MUST be synchronous (single switch on the `oneof` tag). No queuing, no microtask hop.
+3. **Payload-shape invariance.** The payload object the bridge passes to listeners MUST be bit-for-bit identical to the v0.3 payload shape (same fields, same types). Folding is wire-only; the bridge surface MUST stay v0.3-compatible.
+
+This contract is referenced from chapter 03 §4 (bridge surface stability rule) and is the regression check a future bridge-swap PR reviewer can grep for ("does the bridge emit `onCwdRedirected` on any non-cwd_redirected variant?"). Chapter 08 §3 contract test enforces all three rules.
+
+### 9. Testability seams (hermetic harness hooks)
+
+Stream correctness (replay, snapshot-vs-replay decision, drop-slowest, fanout cleanup, multi-client interleave) is the headline differentiator vs raw CLI and chapter 00 success-criterion #3/#4. Every behavior in §§4-7 MUST be hermetically testable in a fast harness (no real `node-pty`, no real Cloudflare, no 100s waits). This section locks the injection seams.
+
+**9.1 FakePty (chapter 08 §3 harness fixture).** A `FakePty` fixture replaces `node-pty` in tests. It emits a deterministic byte sequence keyed by test scenario name (e.g. `"compile-output-100kb"`, `"interleave-input-stress"`). Bytes-to-seq mapping is stable across runs (no timing jitter from real PTY data events). Daemon code branches on `process.env.CCSM_FAKE_PTY=1` at session-spawn to wire FakePty in.
+
+**9.2 Injectable boot_nonce.** Daemon exposes `__setBootNonceForTest(value: bigint)` (only present when `process.env.CCSM_TEST_HOOKS=1`). Lets tests simulate "daemon restart" by changing boot_nonce in-process without restarting the daemon. The replay-vs-snapshot decision then becomes deterministically assertable.
+
+**9.3 Injectable buffer sizes.**
+- `CCSM_TEST_REPLAY_RING_BYTES` (default 4 MiB; tests use 4 KiB to exercise ring-rollover in <1ms).
+- `CCSM_TEST_DROP_SLOWEST_BYTES` (default 1 MiB; tests use 8 KiB to exercise drop-slowest with a tiny producer).
+- `CCSM_TEST_REPLAY_BURST_BYTES` (default 256 KiB; tests use 2 KiB).
+- `CCSM_TEST_SNAPSHOT_CAP_BYTES` (default 2 MiB; tests use 16 KiB to exercise truncation).
+
+**9.4 Injectable heartbeat / liveness intervals.** Per §4: `CCSM_HEARTBEAT_IDLE_MIN_MS`, `CCSM_HEARTBEAT_IDLE_MAX_MS`, `CCSM_HEARTBEAT_TICK_MS`, `CCSM_LIVENESS_TIMEOUT_MS`. Default seconds; tests use the same numerals as milliseconds.
+
+**9.5 Snapshot-vs-replay decision is logged.** On every reconnect the daemon emits exactly one of:
+- `pino.debug({ event: 'reconnect_decision', sessionId, decision: 'replay', fromSeq, toSeq, bytes })`
+- `pino.debug({ event: 'reconnect_decision', sessionId, decision: 'snapshot', reason: 'boot_nonce_mismatch' | 'fromSeq_too_old' | 'gap_drop_slowest', bytes })`
+
+Tests assert on the log line directly via the structured-log capture sink, instead of trying to detect "did the client get a snapshot or replay?" from event shape (which is ambiguous for small replays).
+
+**9.6 Per-client input counters.** Per §5 lag-asymmetry note, daemon exposes `inputs_received[clientId, sessionId]` and `inputs_acked[clientId, sessionId]` via `/stats`. Multi-client tests can assert "sent N, acked N" without trying to read the PTY back through xterm.
+
+**9.7 Fanout subscriber tracking is observable.** Daemon exposes `getFanoutSubscriberCount(sessionId)` (only present when `CCSM_TEST_HOOKS=1`). Subscriber-leak test (chapter 08 §3) connects N clients, disconnects them across multiple modes (clean close, RST, idle-timeout, mid-stream-exception, force-snapshot-then-bail), asserts count returns to 0 within a bounded grace period.
+
+**9.8 E2E case set this enables (chapter 08 §3 / §5 / §6, R5 P1-1 / P1-2 / P1-3 / P1-4).** Locks the minimum hermetic test set:
+- `web-reconnect-exact-replay` (replay path with deterministic FakePty seq trail).
+- `web-reconnect-force-snapshot` (boot_nonce mismatch via `__setBootNonceForTest`).
+- `web-reconnect-fromSeq-too-old` (replay ring rollover via tiny `CCSM_TEST_REPLAY_RING_BYTES`).
+- `web-heartbeat-survives-idle` (idle longer than `CCSM_HEARTBEAT_IDLE_MAX_MS=90` ms, stream stays alive).
+- `web-liveness-timeout-triggers-reconnect` (silence > `CCSM_LIVENESS_TIMEOUT_MS=120` ms, client reconnects).
+- `drop-slowest-fires-and-recovers` (slow consumer fixture, asserts `PtyGap`, asserts snapshot recovers).
+- `fanout-subscriber-cleanup` (5 disconnect modes, asserts count=0 each time).
+- **Multi-client coherence (4 cases, expanded from one):**
+  - `simple-mirror`: Electron + web both attached, daemon echoes, both see identical bytes.
+  - `interleaved-input`: A and B both type 100 alternating bytes, snapshot of PTY queue matches FIFO arrival.
+  - `disconnect-while-other-active`: A disconnects mid-stream, B keeps streaming uninterrupted, fanout count drops by 1.
+  - `slow-client-doesnt-affect-fast-client`: A is slow (stalled reader), B is live; A trips drop-slowest, B's stream is unaffected.
+- `input-batching-coalesces-paste` (50 KB paste produces 1-2 RPCs, not 5-10; asserts the §3 16ms-idle-or-4KB rule).
+
+All cases run in ≤ 5s wall-clock each thanks to the injection seams; total stream-suite ≤ 60s. Reverse-verify discipline (`feedback_bug_fix_test_workflow`) is meaningful only because §9 makes the test deterministic.
+
+## 7. Error handling and edge cases
+
+### Context block
+
+v0.3 already covered the bulk of "daemon split" failure modes (daemon crash → respawn, SQLite locked → serialize writes, updater swap on Win → batch script). v0.4 adds three new failure surfaces: **(1)** Cloudflare layer failures (Tunnel down, Access misconfigured, JWT stale), **(2)** wire-protocol version skew between Electron + daemon during the bridge swap and afterward, **(3)** concurrent edits between desktop and web on the same session. This chapter covers all three plus carryover failures that change behavior under v0.4's Connect transport.
+
+### TOC
+
+- 1. Daemon-side failures (carryover + new)
+- 2. Cloudflare layer failures
+- 3. Network failures (web client specific)
+- 4. JWT lifecycle (stale mid-session, rotated keys)
+- 5. Wire-protocol version skew
+- 6. Concurrent multi-client semantics
+- 7. Web build failures (Pages deploy)
+- 8. Catastrophic failures (last-resort recovery)
+
+### 1. Daemon-side failures
+
+#### Daemon crash (carryover from v0.3, behavior unchanged)
+
+- Electron client: detect via control-socket `/healthz` poll; supervisor respawns daemon; renderer's `useDaemonHealthBridge` shows `daemon.unreachable` banner during the gap. Behavior unchanged.
+- Web client: Connect transport sees stream RST or `unavailable`; UI shows `daemon.unreachable` banner with "Retry" button; auto-retry every 5-30s exp backoff (chapter 04 §6).
+- **New in v0.4:** if daemon respawns with a new `boot_nonce`, both clients on next reconnect get a fresh PTY snapshot (chapter 06 §6) rather than a seq replay. No data loss; possibly a brief screen flicker as the buffer is re-rendered.
+
+#### SQLite locked (carryover, behavior unchanged)
+
+Daemon serializes all writes via `better-sqlite3` synchronous API. Long-running migrations block writes; v0.3 §6 migration-gate interceptor still applies on the data socket — it MUST be re-implemented as a Connect interceptor (chapter 02 §8).
+
+#### Daemon hangs (process alive, RPCs not progressing)
+
+- Connect deadline header (`x-ccsm-deadline-ms`, carryover from v0.3) caps every unary RPC at 30s default, 120s clamp.
+- Streams have no deadline; they rely on heartbeat (chapter 06 §4) for liveness.
+- If the daemon stops processing but stays alive, deadlines fire on unary RPCs and surface as `deadline_exceeded` Connect errors. Bridge wraps as `BridgeTimeoutError` (existing v0.3 §3.7.5 type). Three+ in 10s triggers a "daemon stuck" diagnostic toast (existing v0.3 surface).
+
+#### Daemon disk full (new edge case worth calling out)
+
+- SQLite write fails with `SQLITE_FULL`. Daemon's existing storage-full handler (v0.3 frag-8) surfaces a `storage.full` banner. v0.4: same banner reaches both Electron and web (it's in the renderer; both clients render it).
+- **In-flight RPC mapping (new in v0.4):** `SQLITE_FULL` MUST map to Connect `resource_exhausted` (not `internal`). The transactional write is rolled back so partial-row corruption is impossible.
+- **Bridge short-circuit:** once the daemon sets the `storage.full` flag, a Connect interceptor (chapter 02 §8 — add "storage-full short-circuit interceptor for write RPCs") rejects all subsequent **write** RPCs locally with `resource_exhausted` until the flag clears, so clients don't burn additional disk attempts. Read RPCs (PTY snapshot, list sessions, title stream) continue normally.
+- **Client behavior:** Bridge maps `resource_exhausted` to a non-retrying local error (different from `unavailable`, which auto-retries). UI surfaces the `storage.full` banner; user is expected to free disk before retry.
+- **Logger fallback under ENOSPC:** when the daemon detects ENOSPC on log writes, the pino transport switches to an in-memory ring buffer (last 1000 lines, replayed to disk once `storage.full` clears). Prevents the event loop from stalling on blocked writes and preserves the audit trail across the incident.
+- **Side-channel signal:** `storage.full` MUST be exposed in the control-socket `/healthz` response (e.g. `{"ok":false,"reason":"storage.full"}`) so the supervisor and the Electron health bridge can detect it without depending on disk-backed RPC paths.
+- **Testability:** chapter 08 §3 adds a contract test that injects a disk-full simulation hook (e.g. `daemon.__test_setStorageFull(true)`) and asserts (a) write RPCs return `resource_exhausted`, (b) read RPCs succeed, (c) `storage.full` event appears on the cross-client `streamSessionStateChanges` so the **web** client renders the banner (chapter 08 §5 case `web-disk-full-banner`).
+
+### 2. Cloudflare layer failures
+
+#### `cloudflared` process crashes
+
+- Daemon supervises (chapter 05 §1): exponential restart, capped at 60s, 10 attempts in 30 minutes, then surface `cloudflare.unreachable` banner.
+- During the outage: web client sees the Pages SPA loaded (cached in browser) with `daemon.unreachable` banner (it can't reach the tunnel). Local Electron is unaffected.
+- Recovery: when `cloudflared` reconnects, the tunnel hostname routes again; web client's auto-retry catches the next interval.
+
+#### Cloudflare Access misconfigured (e.g. wrong AUD claim)
+
+- Daemon's JWT interceptor rejects with `unauthenticated`. Web client sees auth error → redirects to Access flow → Cloudflare returns the user to the SPA → SPA reloads, retries, gets the same JWT → still `unauthenticated`. Loop.
+- **Client-side break-out (new in v0.4):** the SPA's transport interceptor MUST track redirect attempts in `sessionStorage` (counter + first-attempt timestamp). On the **3rd redirect within 30s**, the SPA aborts the redirect, clears the counter, and renders a `auth.looped` banner: "Authentication looped — check daemon log or Cloudflare Access policy" with a link to the diagnostics page (`/diagnostics`, surfaces the last 5 daemon JWT errors and a copy-able trace ID). Same break-out logic applies to JWT-expiry redirects (§4) since the failure shape is identical from the SPA's POV.
+- **In-app surface (new in v0.4):** when JWT failures classified as `aud_mismatch` exceed **5 per minute** at the daemon, daemon emits a `cloudflare.misconfigured` banner via `streamSessionStateChanges` (chapter 06 §8). Electron Settings UI renders "Cloudflare Access misconfigured: AUD mismatch — re-run setup wizard step 2" with the actual vs expected AUD shown. Banner clears once 5 minutes pass without a new mismatch.
+- **Log classification (new in v0.4):** daemon JWT-failure log line includes a `failure_class` field with one of `{ no_jwt, aud_mismatch, expired, invalid_sig, unknown }`. Each class has different semantics: `no_jwt` = Tunnel not behind Access (operator misconfig); `aud_mismatch` = Access app config drift; `expired` = normal session expiry (no banner); `invalid_sig` = JWKS rotation in flight or attack. The user-visible banner is rate-limited (per above); the **log line is NOT rate-limited** so defenders retain visibility into probe rates.
+- **Why a UI surface is appropriate now:** v0.3 logged-only because there was no remote ingress to misconfigure; v0.4 introduces the Cloudflare layer, so misconfig is now a first-class failure mode that warrants surfacing.
+- **Operator recovery:** user re-runs setup wizard step 2 (chapter 05 §3) with the correct AUD claim. Banner clears after 5 minutes of no further mismatches.
+
+#### Cloudflare Pages deploy fails
+
+- The web SPA bundle never reaches Pages. Users on `app.<domain>` see the **previous** deploy (Pages keeps the previous successful deploy live; failed deploys don't replace it). No user impact for existing users.
+- New users hitting a fresh deployment that failed: see Cloudflare Pages's "site not found" page. Edge case (this is the very first deploy).
+- **Mitigation:** GitHub Actions can mirror a `wrangler pages deploy` and surface failure on the PR. Lock-in for v0.4: no, rely on Cloudflare's GitHub integration's PR-status reporting.
+
+#### Cloudflare zone-wide outage
+
+- Cloudflare edge unavailable → both Tunnel and Pages affected.
+- Web client: navigation to `app.<domain>` fails at TCP connect. Browser shows generic network error. SPA never loads.
+- Local Electron: unaffected (local socket).
+- **Mitigation:** none in-app. Document as known limitation in user-facing README ("requires Cloudflare for remote access").
+
+### 3. Network failures (web client specific)
+
+#### Initial page load fails
+
+- Browser shows network error. SPA never loads. User retries page load.
+- No app-level mitigation. Could ship a static "still working on it" SSL-error page later — out of scope for v0.4.
+
+#### SPA loads but daemon unreachable
+
+- Connect transport's first RPC fails. `useDaemonHealthBridge` flips to `unreachable`. SPA shows skeleton + banner (chapter 04 §6).
+- Auto-retry: 1s → 2s → 5s → 15s → 30s exp backoff, indefinite. Per-RPC failures don't increment counter; only the bridge-level health probe does.
+
+#### Network drop mid-session (long PTY stream open)
+
+- Stream iterator throws. Bridge's stream consumer catches.
+- Reconnect attempt with `fromSeq = lastSeenSeq + 1` per chapter 06 §6.
+- If reconnect succeeds within ~30 minutes: replay or re-snapshot, continue. Seamless.
+- If reconnect succeeds after >30 minutes: fanout buffer at the daemon may have rolled past `fromSeq`. Force re-snapshot. User sees current state; lost-output is in the original PTY's history (visible in scrollback as part of the snapshot — xterm-headless preserves scrollback up to the configured limit, default 10k lines).
+- If session was killed during the drop: snapshot includes the exit message; UI marks session as exited.
+- **Snapshot bandwidth budget:** snapshot payload is gzip-compressed and capped per chapter 06 R4 P0-1 (compression + size cap with truncation marker). Over slow links the snapshot is still bounded; client renders a "scrollback truncated" marker if the cap fired.
+- **Future hybrid (deferred to v0.5):** when `fromSeq` is within ~1 MB of the buffer-edge, ship a partial replay + delta-snapshot rather than a full snapshot. Documented as the path; not implemented in v0.4 to keep M4 scope tight. Why deferred: full re-snapshot is correct and simple; hybrid is a perf optimization for the slow-link reconnect case.
+
+#### Browser tab backgrounded for >100s
+
+- Tab suspends or throttles event loop (Chrome aggressively throttles background tabs to ~1 Hz timer cap as of 2024+).
+- HTTP/2 stream may or may not be killed by Cloudflare (heartbeats from daemon keep edge happy, but the browser may ignore them if throttled). Client-side liveness check fires after 120s of no event per chapter 06 §4.
+- **Proactive pause (new in v0.4):** the web bridge MUST listen to the Page Visibility API. On `visibilitychange` → `hidden`, the bridge **closes** the active PTY stream cleanly (CANCEL frame, recording `lastSeenSeq`). On `visibilitychange` → `visible`, the bridge re-attaches with `fromSeq = lastSeenSeq + 1`. **Why:** prevents the daemon from accumulating bytes for a slow consumer (drop-slowest fires repeatedly otherwise → repeated multi-MB snapshot fetches on every tab refocus, the dominant laptop-user behavior).
+- On refocus: replay if `fromSeq` is in-buffer; snapshot as last resort (subject to the bandwidth budget above).
+- See chapter 06 §7 for the matching daemon-side fanout / drop-slowest description.
+
+#### Bandwidth-constrained network (slow mobile data)
+
+- HTTP/2 flow control + drop-slowest (chapter 06 §7) applies. Daemon drops events; client gets `gap=true`; re-snapshot on next event.
+- User experience: PTY output may "skip ahead" rather than scroll continuously. Acceptable for monitoring; less ideal for active typing.
+- **Not in scope:** adaptive quality (e.g. ASCII-only fallback). Future work.
+
+### 4. JWT lifecycle
+
+#### JWT expires mid-session
+
+- 24h Access session (chapter 05 §3). User has tab open >24h.
+- Next RPC the SPA makes returns `unauthenticated`.
+- SPA's transport interceptor catches this code, redirects browser to `https://<tunnel-hostname>/cdn-cgi/access/login/<aud>` (Cloudflare Access endpoint).
+- Cloudflare Access checks IdP session; if still valid (GitHub session lasts longer), re-issues JWT, redirects browser back to SPA.
+- SPA reloads; transport reconnects; PTY stream resumes via `fromSeq`.
+- **User experience:** brief redirect-spinner, then back to the same view. Should take <2s on a fresh GitHub session.
+- **Failure path (new in v0.4):** if Access re-issues a JWT the daemon STILL rejects (e.g. team-name changed in dashboard, daemon's stored team-name is stale, AUD drift), the redirect loops. The SPA's redirect-counter (see §2 break-out) catches this: 3 redirects within 30s → abort, render `auth.looped` banner with diagnostics link. Same break-out covers misconfig (§2) and stale-team-name (§4) symmetrically.
+- **Testability (new in v0.4):** chapter 08 §5 case `web-jwt-expiry` runs hermetically as follows. (a) Test harness mints a JWT signed by a test JWKS with `exp` 5s in future (no real CF Access). (b) Daemon is started with the test JWKS URL. (c) The SPA's transport interceptor exposes an `onAuthRedirect: (url: string) => void` injection hook so the test fixture can stub the navigation rather than actually redirecting the browser. (d) Test asserts the callback fires with the documented `https://<tunnel-hostname>/cdn-cgi/access/login/<aud>` URL pattern within 1s of `unauthenticated`. (e) A second variant asserts the redirect-counter break-out: stub the callback to immediately re-issue the same expired JWT, assert `auth.looped` banner appears after the 3rd attempt.
+
+#### JWT JWKS rotation
+
+- Cloudflare rotates signing keys ~yearly. New JWTs use new key.
+- Daemon's `createRemoteJWKSet` (jose lib) auto-refetches JWKS on signature-mismatch; subsequent validations succeed.
+- 30s cooldown means at most one re-fetch per 30s if many requests hit the rotation moment. Negligible.
+
+#### Cloudflare Access policy change (user removed from allowlist)
+
+- Next JWT issuance fails (Access blocks at IdP step). User sees Cloudflare's "you don't have access" page.
+- For a session already authenticated: existing 24h JWT still validates at the daemon until expiry. After expiry: the redirect to `/cdn-cgi/access/login` returns the "no access" page.
+- This is intended behavior — denying access to a removed user IS the feature.
+
+#### JWT replay (attacker steals JWT cookie)
+
+- Mitigations: HTTPS-only cookie, `Secure` + `HttpOnly` + `SameSite=Lax` flags (Cloudflare default).
+- Daemon doesn't track JWT-by-JWT to prevent replay (no nonce store). Single-user model: even if replayed, the only authorized user IS the attacker's-target. Multi-user (N2) would need a nonce/jti store.
+- **Audit trail (new in v0.4):** every authenticated RPC log line MUST include `Cf-Connecting-Ip` (origin IP from Cloudflare edge), `Cf-Ray` (request ID), `jwt_email`, `jwt_iat`, `jwt_jti` (if present), and `traceId`. The Cf-* headers are forwarded by Cloudflare through the tunnel and are only present on remote ingress (local Electron requests omit them, distinguishable). This gives the user an audit trail to confirm "was that me from my home IP, or someone else?" without requiring the daemon to maintain a nonce store. Cross-refs chapter 05 §4 (logging policy update) and chapter 10 A5.
+- **First-seen-IP banner (new in v0.4):** daemon tracks the set of `(jwt_email, src_ip)` pairs seen in the last 30 days (small SQLite table, MAX 1000 rows, evicted LRU). On a new pair, daemon emits a `auth.new_device` UI banner: "New sign-in: 203.0.113.5 (City, Country) — was this you?" with a "Yes" / "No, revoke" pair. "No, revoke" deep-links to the Cloudflare Zero Trust session-revocation flow. Geo lookup is best-effort using `Cf-IPCountry` header from Cloudflare; no MaxMind dependency.
+- **Recovery (updated in v0.4) — order matters:**
+  1. **First**, revoke active Access sessions in Cloudflare Zero Trust dashboard (Sessions → Revoke). This is **instant** and kills any in-flight stolen JWT, even before its 24h expiry.
+  2. Rotate Cloudflare Access app config (regenerates AUD; existing tokens become `aud_mismatch` immediately).
+  3. Revoke the GitHub OAuth grant (GitHub Settings → Applications); prevents Access from re-issuing on the attacker's IdP session.
+  4. (Optional) regenerate Tunnel credentials if there's any suspicion the tunnel token leaked.
+- **Why instant revoke is the lead step:** the previous spec listed GitHub OAuth revocation first, which only takes effect after the existing 24h JWT expires. CF session revocation is the only step that immediately invalidates an in-flight stolen cookie.
+
+### 5. Wire-protocol version skew
+
+#### Electron v0.3.x against daemon v0.4.0
+
+- v0.3.x Electron talks the hand-rolled envelope. v0.4 daemon's data socket talks Connect/HTTP/2.
+- v0.3.x Electron sends a length-prefixed JSON envelope; v0.4 daemon's HTTP/2 listener sees garbage prefix and rejects.
+- **Outcome:** Electron's bridge sees connection failure; surfaces `daemon.unreachable`.
+- **Recovery:** the v0.4 installer ships matched Electron+daemon. User must run installer. Document the upgrade path: "v0.4 is a wire-protocol change; users on v0.3 must run the installer (auto-update will handle this if enabled)."
+- **Testability (new in v0.4) — wire-skew compat smoke:** chapter 08 §3 adds a once-per-release CI test (`wire-skew-compat`) that boots a v0.3.x Electron probe against a v0.4 daemon container and asserts (a) the renderer surfaces `daemon.unreachable` within 10s, (b) the v0.4 daemon's HTTP/2 listener does NOT crash or leak file descriptors when fed envelope-style bytes (defensive: any HTTP/2 connection-preface parser bug would otherwise take down all v0.4 users), (c) clean rejection in daemon log with `failure_class=protocol_mismatch`. Symmetric reverse test (v0.4 Electron → v0.3 daemon) confirms the envelope listener also rejects cleanly.
+
+#### Electron v0.4 against daemon v0.3.x
+
+- Symmetric: v0.4 Electron sends Connect HTTP/2 PRI to v0.3 daemon's envelope listener. Envelope listener sees garbage, rejects.
+- Same `daemon.unreachable` surface. Same recovery (user runs installer).
+- **Why blocked rather than soft-fallback:** chapter 02 §7 — single installer for v0.4 ships matched versions. Soft fallback would require v0.4 Electron to detect the daemon version (chicken-and-egg: needs a version RPC the daemon would have to speak in both protocols) and dual-implement every bridge. Not worth the carrying cost.
+
+#### Web client v0.4 against daemon v0.5+
+
+- Field-level back-compat: protobuf reserved tags + new fields with new tag numbers (chapter 02 §7).
+- Old web tab from cached browser bundle: missing fields default to zero/empty; daemon handles gracefully. New web tab on next page load: fresh bundle from Pages, full schema.
+- **Acceptable failure:** if v0.5 introduces a feature requiring new client behavior (e.g. a new event in `oneof`), the old web tab silently ignores the new event variant. The new feature is not visible until the user reloads. Tolerable.
+
+#### Backwards-incompatible proto change (would-be wire break)
+
+- `buf breaking` CI check fails on the PR. PR cannot merge.
+- If the change is genuinely needed: explicit version bump (e.g. `ccsm.v2`). v0.4 doesn't anticipate this and treats it as a follow-up release lifecycle event.
+
+#### Web client SPA + daemon out of sync (intra-day)
+
+- User has SPA loaded at 9 AM; daemon updates to v0.4.1 at 10 AM with new RPC.
+- SPA at 9 AM doesn't call the new RPC, so no impact.
+- If v0.4.1 added a field to an existing message: SPA gracefully ignores. No impact.
+- If v0.4.1 made a wire-breaking change: blocked by `buf breaking` from being merged in the first place.
+
+### 6. Concurrent multi-client semantics
+
+#### Both clients type into the same session
+
+- PTY input flows: each client sends `SendPtyInput` independently. Daemon receives in TCP-arrival order, writes to PTY input queue in arrival order, `node-pty` writes in queue order.
+- **Result:** characters interleave at the byte boundary. Behavior matches "two people typing on the same shell"; not specifically a concurrency bug, but worth surfacing in docs.
+- **Not mitigated:** no UI to "lock" a session to one client. Out of scope; user can simply not type from two devices.
+
+#### Client A killed while Client B has stream open
+
+- Client A's stream closes (client-side disconnect). Daemon notices via HTTP/2 RST or stream end. Removes A from fanout.
+- Client B's stream continues unchanged.
+- Daemon's per-session state (PTY, buffer) is reference-counted by subscriber set; while B is attached, session lives. Last subscriber leaves → session is left running per v0.3 lifecycle (daemon owns sessions, not clients).
+
+#### Client B opens session that Client A is currently spawning
+
+- Client A: `SpawnPty(...)` in flight, hasn't returned yet.
+- Client B: `ListSessions()` won't see the new session until A's spawn completes (daemon registers session post-spawn).
+- Client B: `StreamPty(<sessionId>)` for an unknown sessionId returns `not_found`; client B retries on its next list-poll.
+- No corruption; just brief transient invisibility.
+
+#### Both clients rename the same session simultaneously
+
+- Each `RenameSession(sessionId, title)` is unary and serialized at the daemon (per-sid serialization, v0.3 §sessionTitles). Last-write-wins.
+- Title-change stream emits both events in serialization order. Both UIs converge to the second rename's value.
+- Acceptable; no corruption.
+
+### 7. Web build failures (Pages deploy)
+
+#### `buf generate` produces unexpected output
+
+- CI gate `git diff --exit-code gen/` fails. PR can't merge.
+- Developer regenerates locally, commits the diff.
+
+#### `vite build` fails on an `src/` change that was Electron-tested but not web-tested
+
+- CI runs `npm run build:web` on every PR; failure blocks merge.
+- Failure modes typically: imports a Node-only module (`fs`, `path`); references `process.platform` directly; uses an untranspiled feature.
+- v0.4 establishes that the Electron and Web build BOTH run on every PR (chapter 08).
+
+#### Pages deploy fails on `main`
+
+- Most likely cause: build environment difference (Node version, package install).
+- Cloudflare Pages keeps the previous deploy live; users unaffected.
+- Author sees deploy failure email from Cloudflare; investigates; pushes fix.
+
+### 8. Catastrophic failures (last-resort recovery)
+
+#### Daemon SQLite corrupted
+
+- v0.3 frag-8 covers migration / fresh-install path. v0.4 inherits.
+- Recovery: user deletes `~/.ccsm/db.sqlite`, daemon recreates fresh on next start. Sessions lost (the JSONL files are still in `~/.claude/projects/` so re-import works).
+
+#### Daemon binary corrupted (auto-update botched)
+
+- v0.3 frag-11 §11 + auto-update rollback (.bak path) covers this.
+- Recovery: user re-runs the installer.
+- **v0.4 re-validation (new):** v0.4 changes the install payload (bundles `cloudflared` ~20 MB plus larger build artifacts), so the v0.3 `.bak` rollback mechanism is NOT automatically inherited. M2 close (chapter 09 §7 post-M2 7-day dogfood gate) MUST include an explicit two-direction test:
+  1. Force update v0.4-rc1 → v0.4-rc2; assert daemon starts on rc2 and `cloudflared` is the rc2-bundled version.
+  2. Force ROLLBACK rc2 → rc1 via the `.bak` mechanism; assert daemon starts on rc1 and `cloudflared` is the rc1-bundled version.
+  Both must pass; if either fails, M2 doesn't close.
+- **"Rollback also failed" recovery (new in v0.4):** if both `.exe` and `.bak` are corrupted (catastrophic auto-update + power loss mid-swap), the user must run the installer manually from `C:\Users\Public\Desktop\CCSM-Setup.exe` (the location the build worker copies fresh installers to, per memory rule). User-facing docs (README + in-app "About" page) MUST cite this manual recovery path. As a fallback, the installer is also published on GitHub Releases with the corresponding tag.
+
+#### Cloudflare account compromised
+
+- Out of scope (this is a Cloudflare account security concern, not ccsm).
+- Mitigation guidance: enable 2FA on Cloudflare account; rotate API tokens periodically.
+
+#### Web SPA shipped with a critical bug
+
+- Cloudflare Pages: rollback to previous deploy via dashboard (one click).
+- Author can also `git revert` the bad commit and push; next CI deploy supersedes the bad one in ~2 min.
+
+## 8. Testing
+
+### Context block
+
+v0.3 ships ~30 e2e probes spanning Electron + daemon. v0.4 adds a wire-protocol surface (Connect+Protobuf), a new client (web), and a Cloudflare layer. Testing must catch wire-protocol regressions, web-vs-Electron divergence, multi-client coherence bugs, and Cloudflare-specific failure modes — without ballooning CI time. This chapter defines the test layers, what each layer covers, the CI shape, the test-data discipline, and the security gates around test-mode toggles.
+
+### TOC
+
+- 1. Test layer overview
+- 2. Layer 1 — proto + buf gates (CI)
+- 3. Layer 2 — daemon Connect handler unit + contract tests
+- 4. Layer 3 — Electron e2e against real daemon (existing v0.3 suite, unchanged surface)
+- 5. Layer 4 — Web e2e (Playwright on Cloudflare Pages preview)
+- 6. Layer 5 — Multi-client coherence test (Electron + web in parallel)
+- 7. Layer 6 — Cloudflare integration smoke (manual + scheduled + path-triggered)
+- 8. Reverse-verify discipline (per `feedback_bug_fix_test_workflow`) + test data discipline
+- 9. CI matrix + budgets + `--only` taxonomy + migration-window disable rule
+
+### 1. Test layer overview
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ L1 proto+buf gates    — every PR touching proto/ or gen/    │
+│ L2 daemon unit+contract — every PR touching daemon/         │
+│ L3 Electron e2e        — every PR touching electron/ or src/│
+│ L4 Web e2e             — every PR touching web/ or src/     │
+│ L5 Multi-client e2e    — every PR touching daemon/ or proto/│
+│ L6 Cloudflare smoke    — nightly + release tag + path-trig  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Discipline:** v0.4 inherits the trust-CI mode (`feedback_trust_ci_mode`): reviewers don't local-run e2e for every PR; manager merges based on CI rollup. Workers MUST local-run their PR's e2e (the specific `--only=<case>` per `feedback_local_e2e_only`) and paste output in PR body. Per `feedback_e2e_prefer_harness`: new cases default to extending `harness-agent` / `harness-perm` / `harness-ui`; standalone probes require justification.
+
+### 2. Layer 1 — proto + buf gates
+
+CI workflow `proto.yml`:
+
+```yaml
+on:
+  pull_request:
+    paths: ['proto/**', 'gen/**']
+jobs:
+  buf:
+    steps:
+      - run: npx buf lint
+      - run: npx buf breaking --against '.git#branch=working,subdir=proto'
+      - run: npx buf generate
+      - run: git diff --exit-code gen/
+```
+
+**What it catches:**
+- Style / lint regressions in `.proto`.
+- Wire-incompatible edits (deleted fields, changed tags, type changes).
+- Stale `gen/` (developer edited proto but didn't regenerate).
+
+**Runtime:** ~30s on GitHub-hosted runner. Cheap.
+
+**Skip-cascade:** if `proto.yml` fails, downstream `daemon-contract.yml` and `web-e2e.yml` are short-circuited via GitHub Actions `needs:` chains. No point running contract tests against a broken proto.
+
+### 3. Layer 2 — daemon Connect handler unit + contract tests
+
+**Unit tests** (vitest, in `daemon/src/__tests__/connect/`):
+- Each handler called in-process with a fake context. Assertions on response shape, error codes, side effects (DB rows, PTY state).
+- Inherits v0.3 daemon test infrastructure (in-memory SQLite, fake PTY).
+
+**Contract tests** (in `daemon/src/__tests__/connect-contract/`):
+- Spin up the real Connect server on an ephemeral Unix socket / named pipe.
+- Use a real Connect client (TS, generated from `proto/`) to call each RPC.
+- Assert wire-level behavior: streaming events delivered in order, deadline enforced, JWT bypass on local socket.
+- Pinpoints daemon-side regressions independent of the renderer.
+
+**Why both:** unit tests are fast (no IO); contract tests catch interceptor wiring mistakes (e.g. forgot to register the migration-gate interceptor on a new route). Both required.
+
+**One contract test per RPC — enforced by lint, not codegen.** Per R5 P0-1: `buf` has no stock plugin to emit per-RPC test stubs, and committing to a custom protoc plugin is out of scope for v0.4. Instead a small Node script `scripts/check-contract-tests.ts` runs in `proto.yml` after `buf generate`:
+
+1. Walks `gen/ts/**/*_connect.ts` and extracts each `service { rpc Foo (...) }` symbol.
+2. For each `<service>.<rpc>` pair, asserts a matching `daemon/src/__tests__/connect-contract/<service>__<rpc>.test.ts` file exists.
+3. Missing file → exits non-zero with the list of unmapped RPCs and a one-line stub template the developer can paste.
+
+This gives the same "every RPC has a contract test" guarantee that codegen would, with no custom plugin to maintain. The script is ~50 LOC and is itself unit-tested.
+
+**cloudflared lifecycle unit test** (per R3 P1-2): `daemon/src/__tests__/cloudflared/lifecycle.test.ts` mocks `child_process.spawn` and asserts:
+- Initial spawn + handshake.
+- Process exit at handshake → restart with backoff schedule (1s, 2s, 4s, 8s, 16s) per chapter 05 §1.
+- Repeated exit → exhaustion banner surfaces (per chapter 07 P0-1 fix).
+- Network-up event (mocked) after exhaustion → retry resumes from backoff slot 0.
+
+This covers the novel-in-v0.4 cloudflared supervisor without paying real-CF cost in CI.
+
+**Log-spam guard** (carry-forward concern from R3 P2-2 — folded as a fixture target inside the existing hot-session unit test rather than a separate L2 case): the `daemon/src/__tests__/connect/pty-input-stream.test.ts` already replays a 10s burst; it asserts `pino` line count stays below 100 lines for 10s of normal traffic. Catches accidental `debug→info` promotions on hot paths. (P2 originally; folded here because the guard is one assertion on an existing test.)
+
+### 4. Layer 3 — Electron e2e against real daemon
+
+**No surface change from v0.3.** The Electron e2e suite (`harness-agent`, `harness-perm`, `harness-ui`) drives the renderer, which talks to a spawned daemon. v0.4 changes the transport (Connect instead of envelope) but the renderer behavior is identical.
+
+**What changes operationally:**
+- Tests previously asserting on envelope-frame shape (if any — most don't) get rewritten to assert on Connect response.
+- Daemon spawned in-test now serves Connect on the data socket. Test harness has to wait for HTTP/2 readiness on the socket (small change; ~5 LOC in test helper).
+
+**E2E budget:** the v0.3 suite runs in ~6 minutes. v0.4 adds no probes here; budget unchanged.
+
+### 5. Layer 4 — Web e2e (Playwright on Cloudflare Pages preview)
+
+**New in v0.4.** Playwright suite in `web/e2e/`. Mirrors a subset of the Electron e2e cases:
+
+| Case | Scenario | Source |
+|---|---|---|
+| `web-list-sessions` | Load SPA, sign in (mocked Access JWT), assert session list renders | new |
+| `web-open-session` | Click session in list, assert PTY output appears | new |
+| `web-type-into-session` | Type a command, assert echo + output | new |
+| `web-reconnect` | Disconnect daemon mid-stream, reconnect, assert seq-replay continues | new |
+| `web-jwt-expiry` | Force JWT expiry, assert redirect-to-login flow | new |
+| `web-auth-bypass-blocked` | Strip JWT header, assert 401 from daemon | new |
+
+**Test daemon:** real daemon binary, spawned by Playwright fixture, listening on a localhost TCP port. **NO real Cloudflare Tunnel in CI** — too flaky, too slow, requires network secrets.
+
+**HTTP/2 in the test stack** (per R4 P1-2): `vite preview` serves HTTP/1.1 by default and would mask HTTP/2-specific behaviors (server-streaming framing, header compression, flow control) that v0.4 depends on end-to-end (chapter 02 §1, chapter 05 §8 forces `--protocol http2`). The web e2e harness therefore does NOT use `vite preview`; instead `web/e2e/serve-http2.ts` is a ~30 LOC Node `http2.createSecureServer` static-asset server using a self-signed dev cert (`@vitejs/plugin-basic-ssl` reused for the cert material). Playwright launches Chromium with `--ignore-certificate-errors` and navigates `https://localhost:4173/`. The daemon-side socket continues to speak HTTP/2 cleartext on the loopback TCP port; the browser↔static-server hop is now HTTP/2 over TLS, matching prod's browser↔CF-edge hop.
+
+**JWT mocking** (per R2 P1-1 — production-gated, scheme-restricted, log-warned):
+- Playwright fixture injects a **test-mode JWT** signed by a local test JWKS. Daemon reads `CCSM_DAEMON_TEST_JWKS_URL` to know where to fetch keys.
+- **Production-build gate (compile-time):** the env-var read is wrapped in `if (process.env.NODE_ENV !== 'production' && !IS_PACKAGED_BUILD)`. In a packaged release binary, the read returns `undefined` regardless of what the user sets. Even paranoid: if a packaged binary observes the env var set, it logs `pino.error({ test_mode: 'jwks_override', refused: true })` and refuses to start. Mirrors the chapter 04 §5 production-gate mechanism for the dev TCP listener.
+- **Scheme allow-list:** the URL MUST match `file://` or `http://127.0.0.1:*` / `http://localhost:*`. Any other scheme → daemon refuses to start with a clear error. Prevents attacker-hosted JWKS from being swapped in remotely.
+- **Startup banner:** when test-mode is active, daemon emits `pino.warn({ test_mode: 'jwks_override', jwks_url: <url> })` at startup and shows a banner on the dev console. Attacker can't silently flip it.
+- **Per-test fixture lifetime:** Playwright fixture sets the env var when spawning the daemon for a test, unsets it on teardown. Never set globally.
+
+**Why mock JWT vs. real Cloudflare:** real Cloudflare requires a real Cloudflare account, real GitHub OAuth round-trip, and is not deterministic. Mock JWKS gives the same code path on the daemon (jose verifies signature against JWKS) without external dependency.
+
+**Where Playwright runs:** GitHub Actions, headed Chromium. Web build served via the HTTP/2 server above on localhost:4173. Daemon on localhost:7878. Test browser navigates `https://localhost:4173/` (which the test fixture configures to talk to localhost:7878 via the dev-mode transport, not via cloudflared).
+
+**Runtime budget:** ~5 minutes for the 6 cases.
+
+**Cloudflare Pages preview e2e (separate, lighter)** (per R5 P1-2 — expanded from 1-case smoke to 4 cases): for each PR, Cloudflare Pages auto-deploys to a preview URL. A nightly cron runs against the latest preview URL:
+
+| Pages-smoke case | What it catches |
+|---|---|
+| `pages-loads` | SPA root returns 200 + JS bundle parses |
+| `pages-deeplink` | `/sessions/abc123` deep-link returns SPA shell (catches `_redirects` / SPA fallback breakage) |
+| `pages-signin-prompt` | Unauthenticated visitor sees sign-in prompt (catches blank-page deploys) |
+| `pages-version-banner` | Footer version string matches the commit SHA in the deploy metadata (catches stale-cache / wrong-build deploys) |
+
+The 4 cases share one Playwright context; runtime ~90s. Pages preview build itself (Cloudflare-managed, ~4-7 min cold) runs in addition and is documented as such in the CI budget below.
+
+### 6. Layer 5 — Multi-client coherence test
+
+**New in v0.4.** Single Playwright case `multi-client-pair` that:
+1. Spawns daemon.
+2. Spawns Electron client (using existing harness-agent fixture).
+3. Spawns web client (Playwright Chromium, mock JWT).
+4. From Electron: spawn a session, type "echo from electron".
+5. From web: open the same session.
+6. Assert: web sees the prior `echo from electron` line in its initial snapshot.
+7. From web: type "echo from web".
+8. Assert: Electron sees `echo from web` line within 500ms.
+9. Both clients close; daemon shutdown.
+
+**Why this case is its own thing:** it's the headline feature of v0.4 (multi-client). A regression here = product is broken even if individual clients work.
+
+**Daemon-crash variant** `multi-client-daemon-crash` (per R3 P1-3): exercises the chapter 06 §6 force-snapshot path:
+1. Spawn daemon, attach two clients (one Electron, one web), send PTY output through both.
+2. `kill -9` daemon PID.
+3. Supervisor (existing v0.3 mechanism) respawns daemon with new `boot_nonce`.
+4. Assert: both clients detect boot_nonce change, request fresh snapshot, and reconcile cleanly with no duplicated or dropped bytes in the rendered transcript.
+
+This validates chapter 06 §6 + chapter 07 §1 + chapter 05 §1 in one shot. (Cross-validation noted in R3 cross-file finding.)
+
+**Runtime budget:** ~2 minutes for the pair, +90s for the crash variant = ~3.5 min for L5 total.
+
+### 7. Layer 6 — Cloudflare integration smoke (manual + scheduled + path-triggered)
+
+**Cannot run on every PR** (requires real CF account, real tunnel, takes ~5 minutes including DNS warmup).
+
+**Schedule (per R3 P1-1 — adds path-triggered runs):**
+- Nightly cron.
+- Every release tag (`v0.4.*`).
+- **PR-time path-triggered:** any PR touching `daemon/src/connect/jwt-interceptor.ts`, `daemon/src/cloudflared/**`, or `daemon/src/sockets/runtime-root.ts`. The trigger is documented in `cf-smoke.yml`'s `paths:` filter. These are the only files where real-CF behavior diverges from mock-JWKS behavior; trading ~5 min on those PRs for tight feedback is the right call.
+
+**What it does:**
+1. Boot daemon on a CI worker with a real `cloudflared` connecting to a CI-only Tunnel (separate from the author's daemon).
+2. Boot Playwright Chromium with real CF Access cookie (CI service-token auth bypasses GitHub OAuth — Cloudflare Access supports this).
+3. Run the Layer 4 web e2e cases against the real Tunnel hostname.
+4. Verify JWT validation works end-to-end (real CF JWKS, real Access JWT).
+
+**Why service-token, not GitHub OAuth:** GitHub OAuth in CI requires either headless interactive login (impossible) or a stored refresh token (annoying to maintain). Cloudflare Access service tokens are designed for CI; daemon's JWT validation is Identity-Provider-agnostic (it just verifies signature and claims).
+
+**Service token security discipline** (per R2 P1-2):
+- **Scoping:** the CI service token is bound to a **separate Cloudflare Access application** protecting ONLY the CI tunnel. It has a different `AUD` claim from the author's production tunnel. A leaked CI token cannot reach the author's daemon — the daemon validates `AUD` and rejects mismatches.
+- **Storage:** `CF_ACCESS_CLIENT_ID` and `CF_ACCESS_CLIENT_SECRET` live in GitHub Secrets, masked in workflow logs (`::add-mask::`). Never echoed, never written to test artifacts. The `cf-smoke.yml` workflow declares `permissions: read-all` and uses a fine-grained PAT for any repo access it needs.
+- **Rotation:** every 90 days. A calendar reminder is recorded in chapter 11 references `[cross-file: see chapter 11]`. Rotation procedure: issue new token in CF Access dashboard, update GitHub Secret, retire old token within 24h.
+- **Audit:** failed-auth events on the CI tunnel surface in Cloudflare Access logs; nightly failures open a GitHub issue (existing failure-handling channel below).
+
+**Failure handling:** nightly failures open a GitHub issue (or post to author's notification channel); release-tag failures block the release; PR-time path-triggered failures block the PR.
+
+**Why not on every PR:** cost (CF builds), latency (5 min adds to PR cycle), and most PRs don't change Cloudflare-relevant code. The path trigger above narrows this to the small surface where the cost is justified.
+
+### 8. Reverse-verify discipline + test data discipline
+
+**Reverse-verify** (per `feedback_bug_fix_test_workflow`): every bug-fix PR shows the new test FAILING before the fix, PASSING after. Every feature PR shows the new test FAILING before the feature, PASSING after. PR body MUST include the test command + before/after output.
+
+Per `feedback_no_skipped_e2e`: zero hardcoded skips. `E2E_SKIP=` env var (user-overridable) is the only allowed skip mechanism.
+
+Per `feedback_e2e_prefer_harness`: new cases extend an existing harness file by default. New standalone probe = +30s baseline; reviewer requires PR-body justification.
+
+**Test data discipline** (per R5 P1-4):
+- **Fixture location:** all binary or large textual fixtures live under `<package>/__fixtures__/` (one per package). No fixtures committed under `__tests__/` directly.
+- **Golden-file update mechanism:** any test that compares against a golden file MUST support `UPDATE_FIXTURES=1 npm test` to regenerate. The diff is reviewed by the human reviewer in the PR; auto-regenerated fixtures are not auto-approved.
+- **Max fixture size:** 1 MB per file. Larger artifacts (e.g. PTY recordings) are checked in compressed and lazily decompressed in the test, OR kept out of git and fetched at test time from a known immutable URL.
+- **Anonymization rule:** fixtures MUST NOT contain real user paths (`C:\Users\<name>\...`, `/Users/<name>/...`, `/home/<name>/...`), real session UUIDs from the author's local store, real Cloudflare account IDs, or any token fragments. A pre-commit lint rule (`scripts/lint-fixtures.ts`) scans `__fixtures__/` against a deny-list of regexes and fails commit on hit.
+- **Wire-fixture provenance:** Connect/protobuf wire fixtures used by L2 contract tests are generated by `npm run gen:wire-fixtures` against a deterministic seed; provenance commit-message is required when refreshing them. Avoids the `project_dogfood_probe_store_schema` class of bug where tests baked in stale shape assumptions.
+
+### 9. CI matrix + budgets + `--only` taxonomy + migration-window disable rule
+
+#### 9.1 Workflow matrix
+
+| Workflow | Triggers | Runtime | Cost |
+|---|---|---|---|
+| `proto.yml` | PR touching `proto/`, `gen/` | ~30s | free |
+| `daemon-unit.yml` | PR touching `daemon/`, `proto/` | ~2 min | free |
+| `daemon-contract.yml` | PR touching `daemon/`, `proto/` (skipped if `proto.yml` failed) | ~2 min | free |
+| `electron-e2e.yml` | PR touching `electron/`, `src/`, `proto/` | ~6 min | runner mins |
+| `web-e2e.yml` | PR touching `web/`, `src/`, `proto/` | ~5 min | runner mins |
+| `multi-client-e2e.yml` | PR touching `daemon/`, `proto/`, `electron/`, `web/`, `src/` | ~3.5 min | runner mins |
+| `cf-smoke.yml` | nightly cron + release tag + path-triggered (jwt-interceptor / cloudflared / runtime-root) | ~5 min + setup | runner mins + minimal CF |
+| `pages-preview.yml` (Cloudflare-managed) | every PR | external (Pages build ~4-7 min cold) | free Pages tier; failure surfaces as **non-blocking** GitHub check (Pages env can be transient, per R3 P2-1) |
+
+#### 9.2 Wall-clock budget (per R4 P1-1)
+
+`daemon-unit.yml` and `daemon-contract.yml` are configured as **independent jobs**, not serial; `proto.yml` is a `needs:` predecessor of `daemon-contract.yml` only (skip-cascade), not of `daemon-unit.yml`.
+
+Worst-case happy-path serial sum: ~17 min. Realistic 95th-percentile wall-clock including GitHub Actions queue (0-5 min), Playwright flake retries (1-3% × 6 retry budget can double a single e2e run), and the Cloudflare Pages preview build running in parallel (4-7 min, often the long pole on web-only PRs):
+
+**PR-time CI budget (95th percentile, including queue + flake retry): ≤25 min wall-clock.** Tracked in chapter 09 dogfood gates `[cross-file: see chapter 09]`. Regressions past 25 min trigger a "CI cycle time" issue.
+
+#### 9.3 `--only=<case>` taxonomy (per R5 P1-1)
+
+Workers running local e2e per `feedback_local_e2e_only` need a one-line mapping from "what file did I touch" to "what `--only` flag do I pass". M2 has 12 PRs across 5 bridge files; ambiguity here costs throughput. The taxonomy is generated from the chapter 03 §1 RPC inventory `[cross-file: see chapter 03]` and lives in `scripts/e2e-only-map.json`:
+
+| RPC / Bridge | `npm run e2e --only=` | Layer |
+|---|---|---|
+| `ccsmAgents.list` | `agents-list` | L3 (harness-agent) |
+| `ccsmPermissions.evaluate` | `perm-evaluate` | L3 (harness-perm) |
+| `ccsmPty.spawn` | `pty-spawn` | L3 (harness-pty) |
+| `ccsmPty.input` | `pty-input` | L3 (harness-pty) |
+| `ccsmPty.subscribe` | `pty-subscribe` | L3 (harness-pty) + L5 (multi-client-pair) |
+| `ccsmSessions.list` | `sessions-list` | L3 + L4 (web-list-sessions) |
+| `ccsmSessions.snapshot` | `sessions-snapshot` | L3 + L5 (multi-client-daemon-crash) |
+| `ccsmEvents.subscribe` | `events-subscribe` | L2 contract + L5 |
+| ... (full list checked into `scripts/e2e-only-map.json`, validated against `gen/ts/` by a CI lint) | | |
+
+Worker PR template includes the line "`--only` ID(s) used: <list>". Reviewer checks the listed IDs cover the touched RPCs; mismatch → reject.
+
+#### 9.4 Migration-window CI tolerance + disable mechanism (per R5 P1-3)
+
+Per `feedback_migration_window_ci_tolerance`: during M1's bridge swap (chapter 09 `[cross-file: see chapter 09]`), parallel PRs across multiple bridges may produce CI rebase storms.
+
+**Disable mechanism (the only allowed form of "skip"):** a workflow MAY gate its top-level `jobs.*.if:` on `${{ vars.MIGRATION_WINDOW != 'true' }}`. The `MIGRATION_WINDOW` repository variable is set/unset by manager exactly once per window. This is NOT the same as `feedback_no_skipped_e2e`'s ban on hardcoded skips (which targets test-internal `it.skip(...)` calls); a workflow gate scoped by an explicit window variable is auditable, time-bounded, and reversible.
+
+**Allow-list of disable-eligible workflows:** `web-e2e.yml`, `multi-client-e2e.yml`, `electron-e2e.yml`. **Disable-forbidden:** `proto.yml`, `daemon-unit.yml`, `daemon-contract.yml`, `cf-smoke.yml` — these guard cross-cutting invariants that must never lapse.
+
+**Re-enable trigger:** M2 start. The `MIGRATION_WINDOW` variable MUST be unset within 24h of M2 start. A scheduled CI lint (`scripts/check-migration-window.ts`, runs daily) checks the variable against the M1 window dates declared in chapter 09 and opens an issue if the window has overstayed.
+
+**Make-up integration test:** at M2 start, a one-off `migration-window-makeup.yml` workflow runs the union of all disabled workflows against the post-merge `working` HEAD. Reviewer-approved before M2 PRs proceed. Any regression caught here blocks M2 until fixed.
+
+#### 9.5 Local commands
+
+`npm run e2e:web` runs the web suite locally (matches `web-e2e.yml`); `npm run e2e:multi` runs the multi-client cases (pair + crash variant); `npm run e2e -- --only=<id>` runs a single case per the taxonomy above. Worker self-test commands.
+
+## 9. Release slicing (M1-M4 inside v0.4)
+
+### Context block
+
+v0.4 covers protocol formalization + bridge swap + web client + Cloudflare layer. Shipping it as one big-bang release would mean weeks of "in progress" with nothing dogfoodable; per `feedback_dogfood_protocol`, every milestone must be independently dogfoodable. This chapter slices v0.4 into four milestones, each ~1-2 weeks of implementation, each producing a usable artifact.
+
+### TOC
+
+- 1. Milestone overview
+- 2. M1 — `proto/` locked + first bridge swapped end-to-end
+- 3. M2 — All bridges swapped, envelope deleted from data socket
+- 4. M3 — Web client functional (local-only, via dev TCP listener)
+- 5. M4 — Cloudflare wired, remote access live
+- 6. Release tagging + version bumps
+- 7. Dogfood gates between milestones
+- 8. Rollback strategy
+
+### 1. Milestone overview
+
+| Milestone | What ships | Dogfood signal | Estimate |
+|---|---|---|---|
+| **M1** | `proto/` schema, `buf` CI, ONE bridge swapped end-to-end (read-only RPC), Connect server on daemon's data socket alongside envelope | "I can call `app:getVersion` over Connect from the renderer; envelope still serves the rest." | ~25h |
+| **M2** | All ~46 bridge calls swapped to Connect; envelope handler deleted from data socket; control socket (supervisor) untouched | "Electron runs entirely on Connect for the data socket. No regression vs. v0.3." | ~30h |
+| **M3** | `web/` package built and runs on `vite dev` against local daemon (TCP listener); SPA mounts the renderer; basic flows work | "I can `vite dev` the web client locally and operate sessions." | ~25h |
+| **M4** | Cloudflare Tunnel + Access wired; web client deployed to Pages; JWT middleware on daemon; setup wizard | "I open `https://app.<domain>` from any network and use ccsm." | ~30h |
+
+**Total: ~110 hours.** ~3-4× the predecessor doc's "~30h v0.4 + ~30-50h v0.5" estimate (predecessor undercounted bridge-swap and CF wiring scope).
+
+> **Bridge count canonical: ~46.** This is the canonical inventory from chapter 03. If chapters 00/01/02 cite a smaller number (e.g. "~22"), those are stale and must be brought *up* to ~46 — do NOT bring chapter 09 *down*. [cross-file: see chapters 00, 01, 02 for the ~22 → ~46 corrections]
+
+> **Sub-batch naming convention.** Sub-batches use letter suffixes (`M2.A`, `M2.B`, `M2.C`); the trailing cleanup PR uses `.Z` to signal "final cleanup, run after all sibling sub-batches land." Only M2 has sub-batches in v0.4; M1/M3/M4 ship as single-milestone bundles.
+
+### 2. M1 — `proto/` locked + first bridge swapped end-to-end
+
+**Goal:** end-to-end Connect request travels from renderer → preload → daemon and back, with proto + buf CI enforcing schema. Pick the smallest read-only RPC for the swap (`app:getVersion`) so blast radius is minimal if anything is broken.
+
+#### Deliverables
+
+1. `proto/` directory with `buf.yaml`, `buf.gen.yaml`, `buf.lock`, and the umbrella `service Ccsm` definition with one method (`Ping` returning `{daemonVersion, protoVersion}`) plus the `core.proto` Version RPC.
+2. `gen/ts/` populated by `buf generate`.
+3. `@ccsm/proto-gen` wrapper package (chapter 02 §5).
+4. `buf` CI workflow live (`proto.yml`).
+5. Daemon: `@connectrpc/connect-node` Http2Server bound on the data socket alongside the existing envelope handler. Connect routes registered for `Ping` + `GetVersion`. JWT interceptor scaffolded but local-bypass enabled (no remote ingress yet).
+6. `electron/connect/ipc-transport.ts` — Connect transport over named pipe / Unix socket.
+7. Bridge `ccsmCore.getVersion()` calls Connect (instead of `ipcRenderer.invoke`).
+8. Daemon-side ipc handler for `app:getVersion` removed.
+9. Tests: L1 (`buf` gates), L2 (handler unit + contract for `GetVersion`, `Ping`), L3 (Electron e2e: launch app, assert version string visible) all green.
+
+#### Done definition
+
+- v0.4.0-rc1 installer builds.
+- Author runs the installer; everything works as v0.3 except `getVersion()` is now over Connect (verifiable in daemon log: `pino.info({transport: 'connect', method: 'GetVersion'})`).
+- 24h dogfood with no regressions.
+
+### 3. M2 — All bridges swapped
+
+**Goal:** complete the bridge swap. Every cross-daemon RPC goes over Connect; envelope handler on the data socket is deleted. Control socket (supervisor) unchanged.
+
+#### Sub-batches (PR boundaries from chapter 03 §5)
+
+- **M2.A:** Batch A read-only RPCs (4 sub-PRs).
+- **M2.B:** Batch B write RPCs (5 sub-PRs).
+- **M2.C:** Batch C streams (3 sub-PRs).
+- **M2.Z:** Cleanup PR — delete envelope handler from data socket; delete `electron/ipc/*` files for daemon-domain handlers; delete temporary parity tests; refactor.
+
+#### Deliverables
+
+1. ~12 bridge-swap PRs landed.
+2. `electron/preload/bridges/*.ts` files contain zero `ipcRenderer.invoke` calls for daemon-domain RPCs (window/clipboard/picker exempt per chapter 03 §2).
+3. Daemon's data-socket envelope handler deleted; data socket serves Connect only.
+4. Streaming heartbeat on every server-stream RPC (chapter 06 §4).
+5. Multi-client coherence test (L5) passes between two Electron instances on the same daemon (web is M3).
+6. Tests: full L1+L2+L3+L5 suite green.
+
+#### M2.Z preconditions (parity-test deletion gate)
+
+M2.Z is the irreversible point: once parity tests are deleted, regressions can no longer be A/B-compared against the envelope handler. M2.Z PR MUST NOT merge until ALL of the following hold:
+
+1. All 12 batch PRs (M2.A.1–4, M2.B.1–5, M2.C.1–3) are merged to `working`.
+2. Each batch PR's parity test ran green at merge time AND is still green on `working` HEAD.
+3. A final cross-bridge integration test (all ~46 RPCs exercised in one e2e session) passes on `working` HEAD.
+4. The post-M2 7-day dogfood window has CLOSED (i.e. parity tests survive the dogfood window — they are the safety net during it). M2.Z runs only after dogfood close, never during. [cross-file: see chapter 03 §6/§7 for the parity-test framework spec.]
+
+#### Done definition
+
+- v0.4.0-rc2 installer builds.
+- Author runs the installer; all v0.3 functionality works; no envelope code on data socket (verifiable: `grep -r 'envelope' daemon/src/sockets/data-socket.ts` returns nothing).
+- 1-week dogfood with no regressions.
+- **Force-update probe:** force-update from `v0.4.0-rc1` to `v0.4.0-rc2` succeeds on a test machine; force-rollback from rc2 to rc1 succeeds (manual installer step OK). [cross-file: see chapter 07 P1-3 for the auto-update force-test framework.]
+
+### 4. M3 — Web client functional (local-only)
+
+**Goal:** the web client renders and operates sessions, talking to the local daemon via the dev-mode TCP listener. No Cloudflare yet.
+
+#### Deliverables
+
+1. `web/` package per chapter 04 §1.
+2. `web/src/main.tsx` mounts shared `src/App.tsx`.
+3. `web/src/bridges/*` web flavor of preload bridges, calling Connect-Web against the dev TCP listener.
+4. `src/platform/getPlatform.ts` (or equivalent) — abstracts `process.platform` reads.
+5. **Dev TCP listener on daemon — locked production gate.** Spec is concrete; the worker has no choice of mechanism:
+   1. Dev TCP listener code lives in `daemon/src/dev/dev-tcp-listener.ts`.
+   2. The entire `daemon/src/dev/**` tree is excluded from production builds via `tsconfig.production.json` `exclude: ["src/dev/**"]`.
+   3. Daemon entry imports the dev listener via `await import(...)` gated on `process.env.CCSM_BUILD !== 'production'`. If `process.env.CCSM_BUILD === 'production'` AND a `daemon/src/dev/**` module is somehow loaded (transitively), the entry calls `assert.fail('dev module loaded in production')` and the daemon exits non-zero.
+   4. Activation env var is `CCSM_DAEMON_DEV_TCP=<port>`. In production builds the variable has no effect because the module is not present.
+   5. Listener requires a per-launch shared secret negotiated at daemon start (printed to dev console, consumed by the web dev bridge); see chapter 04 R2 P0-1 for the secret protocol.
+   6. **Banned mechanisms:** `process.env.NODE_ENV === 'development'` checks alone are insufficient (NODE_ENV is externally settable on a packaged binary and would be a trivial bypass) and MUST NOT be the gate.
+   7. L4 e2e test verifies: prod-build daemon binary refuses to bind even with `CCSM_DAEMON_DEV_TCP=7878` AND `NODE_ENV=development` set; dev-build daemon binary binds only when the per-launch secret is provided. [cross-file: see chapter 04 R2 P0-1 for the parallel lock.]
+6. `npm run web:dev` runs Vite + the web client; talks to a locally running daemon.
+7. Tests: L4 web e2e suite green (~6 cases). L5 multi-client e2e extended to include web client.
+8. `web/dist/` build artifact produced by `npm run build:web`. Cloudflare Pages NOT wired yet.
+9. **Web client error reporting wired.** New RPC `ReportClientError` exposed by the daemon; web client catches uncaught exceptions + unhandled promise rejections and posts them. Daemon writes them to `~/.ccsm/web-client-errors.log` (rotated). Hidden-settings "copy diagnostics" button packs the last N entries for paste into a bug report. Without this, the M3 dogfood gate has no telemetry to evaluate. [cross-file: see chapter 04 P1-1 for the error-reporting RPC contract.]
+
+#### Done definition
+
+- Author can run web client locally:
+  1. `npm run daemon:dev` → daemon binds dev TCP listener.
+  2. `npm run web:dev` → Vite dev server.
+  3. Open `http://localhost:5174` → SPA loads, sees session list, opens session, types into terminal.
+- Multi-client test (L5) passes: Electron and web on the same session see each other's input/output.
+- **Dogfood: 3 days OR 12 cumulative hours of active web-client use, whichever is later.** Must include:
+  - ≥1 backgrounded-tab session lasting >2h (catches throttled-tab reconnect bugs and leaked subscribers per chapter 06 §5).
+  - ≥1 multi-client session (Electron + web on the same session) lasting ≥1h.
+  - ≥1 reconnect after intentional network drop (toggle Wi-Fi off/on; web client must recover without reload).
+- 4-5 hours of typical interactive use is too thin a sample; the wider gate is what triggers the M3 risk gate fairly.
+
+**Risk gate before M4:** if M3 dogfood reveals significant UX gaps (e.g. xterm.js rendering glitches in browser, keyboard shortcut conflicts), pause M4 and address. Don't paper over with Cloudflare polish.
+
+**Feature-scope discovery during M3 dogfood:** if dogfood reveals desirable new features (better keyboard mappings for browsers, web-specific gestures, mobile-friendly chrome, etc.), file them as v0.5+ candidates. v0.4 does NOT extend feature scope based on M3 findings; it only fixes regressions and addresses gaps that block the +frontend deliverable.
+
+### 5. M4 — Cloudflare wired, remote access live
+
+**Goal:** the headline feature. Web client reachable from any network via Cloudflare Tunnel + Access; JWT validated by daemon.
+
+#### Deliverables
+
+1. `cloudflared` binaries bundled in installer (Win/Mac/Linux x64+ARM64). Installer drops them in app resources path.
+2. Daemon: `cloudflared` spawn/supervise logic (chapter 05 §1).
+3. Daemon: JWT validation interceptor on remote ingress (chapter 05 §4).
+4. **SQLite settings rows for tunnel token, CF team name, CF app AUD; encrypted at rest via OS keychain — locked scheme.** The encryption-at-rest scheme is fully defined in chapter 05 §1.X; M4 implements that lock without re-deciding. Summary of the lock: secrets live in the OS keychain only (Win Credential Manager, macOS Keychain, libsecret on Linux); SQLite stores ONLY a keyring pointer (account/service identifier), never the secret bytes; Linux fallback (no libsecret) is documented and surfaces a setup-wizard warning rather than silently downgrading; setup wizard handles missing-keychain and rotation flows per chapter 05. [cross-file: see chapter 05 R2 P0-1 for the binding lock.]
+5. Electron Settings UI: "Remote access" pane with the 3-step setup wizard (chapter 05 §6).
+6. Cloudflare Pages: GitHub integration set up; first deploy from `main` succeeds.
+7. **Auto-start at OS boot — bounded scope (tray IN scope per chapter 01 G6/A5).** A Settings toggle in the Remote access pane PLUS a single matching tray menu item (per chapter 01 G6 — "surfaced in tray menu (not just Settings)" — and chapter 01 A5 — "single Settings toggle + matching tray menu item"). Default OFF. Persists across reboots via the standard mechanism per chapter 01 G6 + R12 (Win startup folder shortcut, launchd `RunAtLoad`, systemd user unit). Explicitly NOT in scope for v0.4: first-run nudge, system-tray indicator for boot-state, OS notification on boot, scheduling, conditional auto-start. The tray menu item mirrors the Settings toggle and introduces no new states. [cross-file: see chapter 01 R1 P1-1 for the matched scope-narrowing language; the tray inclusion resolves the stage-4 r2 R1 P2 cross-chapter contradiction in favor of chapter 01 G6/A5.]
+8. `daemon.unreachable` and `cloudflare.unreachable` banners surface correctly.
+9. Tests: L6 Cloudflare smoke green on a CI tunnel + service-token JWT.
+10. Documentation: `docs/web-remote-setup.md` user guide.
+
+#### Done definition
+
+- v0.4.0 installer ready to ship.
+- Author runs setup wizard, gets `<random>.cfargotunnel.com` hostname, opens `https://app.<author-domain>` (or `<deploy>.pages.dev`) from a phone tether (cellular network), signs in with GitHub, sees session list, opens session, types in terminal, sees Electron desktop mirror the input.
+- 7-day dogfood per chapter 00 success criteria.
+- **Manual auto-start verification.** On a real Win box: flip the auto-start toggle ON, reboot, log in, observe daemon comes up before Electron launch, web client reachable within 30s of OS login. Result recorded in release notes for the `v0.4.0` tag. This is a manual test (reboots are not cheaply automatable in CI); chapter 08 §9 manual-checklist tracks it as a per-release gate. [cross-file: see chapter 00 success criterion #6 + chapter 08 §9.]
+- Release tag `v0.4.0` cut.
+
+### 6. Release tagging + version bumps
+
+| Tag | Trigger | Distribution |
+|---|---|---|
+| `v0.4.0-rc1` | M1 done | Local installer; not pushed to update channel |
+| `v0.4.0-rc2` | M2 done | Local installer; not pushed |
+| `v0.4.0-rc3` | M3 done | Local installer; web NOT yet on Pages |
+| `v0.4.0` | M4 done + 7-day dogfood passed | Push to update channel; Pages live |
+
+Tag prose is canonical `v0.4.0-rcN` (full semver); avoid the shorter `v0.4-rcN` form anywhere in the spec.
+
+**Why rcN tags during the milestones:** preserves "this is M2-complete" snapshot in git history. Useful if M3 hits trouble and we need to bisect or roll back.
+
+**Daemon binary tag:** `daemon-v0.4.0-rcN` matching the Electron tag. Single installer, lockstep versions (chapter 02 §7).
+
+#### Auto-update default for v0.4
+
+The v0.4.0 release ships with auto-update default-ON UNLESS the explicit reliability gate trips during M2 dogfood. The gate is binary, not judgment:
+
+> **Gate:** if ≥1 stuck-upgrade reproduction occurs during the M2 7-day dogfood window, auto-update for v0.4.0 ships default-OFF and requires user-initiated install. If 0 reproductions occur, auto-update ships default-ON.
+>
+> The author is the only dogfood user; ANY occurrence (n=1) trips the gate. No quorum, no severity ladder. Recorded in `docs/release-notes/v0.4.0.md` with a one-line citation of the dogfood log.
+
+Without this binary criterion, "serious problems" is a release-time judgment call and reliability bugs leak through. [cross-file: see chapter 10 R1 for the auto-update channel mechanics.]
+
+### 7. Dogfood gates between milestones
+
+Per `feedback_dogfood_protocol`: each milestone closure requires a dogfood window before the next milestone starts. Lengths:
+
+| Gate | Duration | What's tested |
+|---|---|---|
+| Post-M1 | 24h | Connect path doesn't break first RPC; no daemon crash |
+| Post-M2 | 7 days | Full Electron usage on Connect; multi-client (Electron+Electron) coherent; no regression vs v0.3 baseline; auto-update gate (§6) evaluated |
+| Post-M3 | 3 days OR 12 cumulative hours active use, whichever later | Web client operates sessions locally; matches Electron behavior; backgrounded-tab + reconnect probes per §4 done definition |
+| Post-M4 | 7 days | End-to-end remote access stable; auto-start works after OS reboot |
+
+**Dogfood failures during a gate:** open issues; if HIGH severity (data loss, crash loop), pause next milestone until fixed. Per `feedback_correctness_over_cost`: never skip an issue to advance the schedule.
+
+**Dogfood-gate stuck signal.** If a dogfood gate exceeds 2× its planned duration without closing (e.g. post-M2 still open at day 14, post-M3 still open at 24 cumulative hours of attempted use), escalate to the user. Either ship a hot-fix mid-gate to unstick the probe or pause the release and re-evaluate the milestone scope. Without this signal, a stale-mid-flight milestone (e.g. M3 done, M4 lingering for weeks while context evaporates) is invisible to the manager.
+
+**R1 sanity check (no scope creep) at every gate.** Before closing a milestone, the manager scans the milestone's PRs for any user-visible new surface that was NOT in the milestone's deliverables list — new bridge method, new UI component, new Settings row, new tray entry, new keyboard shortcut, new notification, new modal. Each MUST be traceable to a spec-listed deliverable; otherwise it is scope creep and gets reverted or deferred to v0.5+.
+
+**Pre-M4 security gate.** Between the post-M3 dogfood close and M4 start, dispatch a security-focused reviewer to audit:
+
+- (a) JWT interceptor implementation against chapter 05 §4 lock,
+- (b) keychain integration against chapter 05 §1.X,
+- (c) dev TCP listener prod-gate against §4 deliverable 5 of this chapter,
+- (d) `cloudflared` spawn-arg + binary supply-chain checks.
+
+Any HIGH-severity finding blocks M4 release until resolved. Process suggestion, not rigid; can be skipped only with explicit user sign-off recorded in the M4 plan.
+
+### 8. Rollback strategy
+
+**Within a milestone (post-PR-merge regression):**
+- Revert the offending PR. Re-run CI. Move on.
+- v0.3 → v0.4 transitions never roll back partial: all-or-nothing per milestone.
+
+**Cross-milestone (e.g. M3 dogfood reveals M2-merged bug):**
+- Fix forward in current branch; cherry-pick fix to a `release/v0.4.0-rcN-fix` branch if needed for an interim release.
+- Generally avoid: M2 dogfood was supposed to catch this. If it didn't, extend M2 dogfood.
+
+**Post-v0.4.0 release:**
+- Catastrophic regression: `v0.4.1` hot-fix release within 24h.
+- Cloudflare Pages: rollback to previous deploy via dashboard (one click, ~30s).
+- Auto-update: pinned channel until hotfix verified.
+- **Hotfix path probe (optional, recommended in M4 dogfood):** during the M4 7-day window, exercise the hotfix flow once — bump patch version on a throwaway tag, push to a test update channel, verify auto-update on a test machine picks it up. Confirms the hotfix path still works on v0.4 binaries before it is needed under pressure.
+
+**Schema-additive enforcement (no destructive migrations).** v0.4's "no downgrade-to-v0.3 rollback" assumption rests on SQLite migrations being purely additive. To prevent this from silently breaking, CI runs a **schema-additive lint** that parses every migration file in `daemon/src/db/migrations/` between the v0.3 baseline and the current HEAD and fails the build if any migration:
+
+- drops a table or column,
+- alters a column type,
+- adds a `NOT NULL` column without a default,
+- renames a column or table.
+
+A future PR that needs a destructive migration must first land an explicit "v0.5 schema break — downgrade no longer supported" announcement and version bump. Without this gate, a future PR could quietly break the implicit promise and a v0.4.x → v0.3 fallback could lose user data. [cross-file: see chapter 08 testing for the CI workflow specification.]
+
+**Why no "downgrade to v0.3" rollback path:** v0.4 changes the SQLite schema only additively (enforced by the lint above); v0.3 binary against v0.4 SQLite would work but lose any v0.4-only data. Acceptable; documented but not engineered as a one-click flow.
+
+## 10. Risks
+
+### Context block
+
+v0.4 introduces a published wire surface, a new client (web), and a third-party ingress (Cloudflare). Each adds a class of risk distinct from v0.3's daemon-split risks. This chapter inventories the risks, ranks them by impact × likelihood, and lists the pre-emptive mitigations baked into other chapters. Each risk has a "**Trigger:**" describing what symptom would surface it and a "**Mitigation:**" with the chapter cross-ref.
+
+### TOC
+
+- 1. Top risks (HIGH severity)
+- 2. Medium risks
+- 3. Low risks (acknowledged but not blocking)
+- 4. Risks the design explicitly accepts (no mitigation)
+
+### 1. Top risks (HIGH)
+
+#### R1. Daemon updater on Windows is finicky (carryover from v0.3 §10)
+
+**What:** daemon self-update on Win uses a process-replacing-itself pattern (write `daemon.exe.new`, batch-script swap on restart). Race conditions between Electron-spawned daemon and a running supervisor can produce a stuck-at-old-version state.
+
+**Trigger:** user reports "I'm on v0.4.1 but the tray menu shows v0.4.0 forever".
+
+**Mitigation:**
+- v0.3 already shipped this with a `.bak` rollback path; v0.4 inherits unchanged.
+- v0.4 dogfood gate post-M2 (7-day) explicitly tests the upgrade path (force-update from v0.4.0-rc1 to rc2 on the author's box).
+- If serious problems: pause auto-update default-OFF for v0.4; require user-initiated install. Tracked in chapter 09 §6.
+
+#### R2. Wire-protocol skew during the bridge swap
+
+**What:** during M1-M2 (bridge-swap milestone), some calls go over Connect, some over envelope. A bug in either path silently corrupts state.
+
+**Trigger:** unexplained behavior change after a bridge-swap PR; daemon log shows mixed transports for the same session.
+
+**Mitigation:**
+- Per-PR parity tests (chapter 03 §7): for each swapped RPC, temporary test asserts old vs new behavior identical. Removed at M2.
+- Per-batch ordering (read-only first → write → streams) limits blast radius (chapter 03 §5).
+- M2 cleanup PR (chapter 09 §3 M2.Z) deletes envelope handler from data socket — once done, ambiguity ends.
+
+#### R3. Cloudflare Access free tier policy change
+
+**What:** Cloudflare reduces free-tier user count, removes GitHub IdP from free, or rate-limits free apps. v0.4 stops working for the user.
+
+**Trigger:** Cloudflare blog post / dashboard notification; web client returns "upgrade required" page.
+
+**Mitigation:**
+- Chapter 05 §7 documents the free-tier dependency.
+- Chapter 05 §8 calls out "verify at activation time".
+- Fallback (not built into v0.4): swap IdP to a different one (Google OAuth, OIDC). The daemon's JWT validator is IdP-agnostic; only the wizard text + setup flow change.
+- Worst case: pay $7/user/month. Single user, $84/year. Annoying but tractable.
+
+#### R4. Connect-Web is half-duplex; future feature might need bidi
+
+**What:** v0.4 depends on Connect-Web's HTTP/2 capabilities. If a future feature legitimately needs client-streaming or bidi (e.g. collaborative cursor sharing in a v0.5+ shared-session feature), the web client cannot do it.
+
+**Trigger:** product-design conversation lands on a feature that requires bidi.
+
+**Mitigation:**
+- F4 spike confirmed v0.4 needs are satisfied by half-duplex (chapter 02 §1).
+- Workaround for future bidi need: split client→server data into many short unary RPCs (already the model for PTY input, chapter 06 §3). Works for most cases.
+- Hard case (real-time collab): consider WebTransport (Chrome 97+, Firefox-soon) or fallback to long-polling. Out of scope for v0.4.
+
+#### R5. xterm-headless memory caps under many idle sessions
+
+**What:** v0.3 sets default xterm-headless scrollback to 10k lines per session. With N sessions live and full scrollback, memory grows. Web client adds another subscriber to each session's fanout buffer (per-subscriber 1 MiB cap; chapter 06 §7). Multi-client amplifier: each subscriber adds 1 MiB cap × N streams × M sessions to the daemon's working set; a second web client doubles the per-session buffer footprint.
+
+**Trigger:** RSS > 500 MB after 7 days with realistic single-user load (5+ sessions, 1-2 web clients) warrants investigation. Hard fail at RSS > 1.5 GB after 7 days under typical usage (5-10 sessions, 1 web client open) — this trips R5 as a release-blocker for v0.4 and forces the eviction policy to ship.
+
+**Mitigation:**
+- v0.3 already enforces the per-subscriber 1 MiB cap (drop-slowest). Cross-ref chapter 06 R4 P0-2 (subscriber cap is the related upstream control).
+- v0.4 adds nothing here unless web introduces persistent extra subscribers.
+- v0.4 instrumentation (NEW): daemon samples RSS every 5 min, emits `pino.info({ event: 'rss_sample', rssBytes, sessionCount, subscriberCount })`, and exposes the latest sample on the `/stats` endpoint. Without instrumentation the dogfood gate is operationally vacuous.
+- Long-term mitigation: scrollback eviction policy for idle sessions. If R5 trips at the 1.5 GB threshold during dogfood, the eviction policy [cross-file: see chapter 05 §P1-2] becomes a v0.4 ship-gate item, not a v0.5 deferral.
+- v0.4 dogfood (post-M4 7-day) monitors the RSS trend with the thresholds above.
+
+#### R5b. Daemon JS event-loop saturation under multi-client streaming (NEW)
+
+**What:** Node.js is single-threaded for JS execution. The daemon executes on one event loop: HTTP/2 frame parsing (libuv thread is fine), Connect interceptor stack per RPC (JS), protobuf encode/decode for every PTY chunk and every keystroke (JS), xterm-headless ANSI parsing for every byte from `node-pty` (JS), pino log serialization (JS unless `pino.transport()`), JWT verify on every remote RPC (~1-2 ms per call, JS), and snapshot serialization (multi-MB CPU work, JS). Worst case: 5 sessions producing hot PTY output × 2 web clients each subscribed × a snapshot RPC mid-flight saturates the event loop. New incoming RPCs back up; the control-socket `/healthz` shares the same loop, so the supervisor sees a `/healthz` timeout, respawns the daemon, and a cascading failure ensues [cross-file: see chapter 06 R4 P0-2 and chapter 07].
+
+This is not theoretical: v0.3 already runs ANSI parsing in-process; v0.4 adds JWT + protobuf overhead atop the same loop.
+
+**Trigger:** event-loop lag (`perf_hooks.monitorEventLoopDelay`) p99 > 50 ms sustained over a 5-min window with 3+ active sessions, or `/healthz` timeout from supervisor coinciding with `/stats` showing >2 active streams.
+
+**Mitigation:**
+- v0.4 instruments event-loop delay using `perf_hooks.monitorEventLoopDelay` (cheap, built into Node) and exports p50/p99 on `/stats`.
+- Document worst-case session count in the user-facing tray "About" / health view.
+- Consider moving snapshot serialization to a `worker_thread` (defer to v0.5 unless dogfood R5b trips).
+- Cross-file: this risk crosses chapter 06 (streaming) and chapter 07 (failure modes). [cross-file: see chapter 06, chapter 07].
+
+#### R6. Same-user-local-process compromise of daemon (NEW — R2 P1-1)
+
+**What:** any process running as the daemon's user (compromised dev tool, malicious npm postinstall, exploited browser extension, drive-by binary) can connect to the local socket and exercise the full RPC surface — PTY input/output (= shell command execution), spawn commands, read settings including the Cloudflare tunnel token. v0.3 had an HMAC handshake on the local socket as a second line of defense; v0.4 drops it [cross-file: see chapter 02 §8 + chapter 02 R2 P1-1].
+
+**Trigger:** any local-malware report on a user's machine; unexplained daemon RPC activity in pino logs that doesn't correspond to a known client (Electron app, web tab, CLI helper).
+
+**Mitigation:**
+- Per chapter 02 R2 P1-1 lock: either restore HMAC on the local socket (recommended) or document acceptance and target re-introduction in v0.5. v0.4 inherits whichever lock chapter 02 ships with.
+- Local socket is bound to user-only filesystem permissions (Unix domain socket mode 0600, Windows named pipe with explicit user-SID ACL).
+- Daemon logs every authenticated local-RPC's PID + executable path (where the OS allows) for forensic correlation.
+
+#### R7. GitHub OAuth session compromise → daemon RCE (NEW — R2 P1-2)
+
+**What:** an attacker who acquires a valid GitHub session for the author's email gets a Cloudflare Access JWT (chapter 05 §3 includes-emails policy + 24 h sessions), then drives any RPC including PTY input. PTY input is shell command execution. This is the highest-impact remote-attack vector in v0.4 and was previously implicit; it must be ranked.
+
+**Trigger:** GitHub security advisory affecting the author's account; suspicious sign-in notification from GitHub or Cloudflare; unexplained PTY activity in daemon logs not matching user-driven sessions.
+
+**Mitigation:**
+- Per chapter 05 R2 P0-2 lock: require Cloudflare Access MFA on the GitHub-IdP rule, reduce session duration from 24 h to a tighter window, daemon-side IP audit on every authenticated RPC, documented compromise-recovery flow (revoke Cloudflare session, rotate tunnel credentials, rotate GitHub OAuth token) [cross-file: see chapter 05].
+- Daemon logs `{ event: 'rpc_authenticated', sourceIp, cfRayId, jwtIat, rpcName }` for every remote call so the user can audit "was this me?".
+- Tray menu surfaces a "recent remote sessions" view sourced from these logs (M4 deliverable).
+
+### 2. Medium risks
+
+#### R8. Cloudflare Tunnel hostname leak
+
+**What:** the auto-generated `<random>.cfargotunnel.com` hostname looks like a random string but is enumerable. If leaked (e.g. browser history, screen share), the hostname is visible. Cloudflare Access still requires JWT, so leak alone is not a breach — but it removes a layer of obscurity.
+
+**Trigger:** user shares a screen with the URL visible.
+
+**Mitigation:**
+- Cloudflare Access enforces auth on every request. Hostname-knowledge alone grants nothing.
+- Document in chapter 05 / setup wizard: "the hostname is one of two security layers; the other (Access) blocks unauthorized users."
+- Daemon-side detection (NEW): every rejected JWT attempt is logged at `pino.warn({ event: 'jwt_rejected', sourceIp, reason, traceId })`, providing a forensic trail so "was I being scanned / attacked?" is answerable post-incident. [cross-file: see chapter 02 §8 + chapter 05 §4 — both currently silent on rejection logging; this risk drives the requirement.]
+- Optional v0.5+: rotate hostname (delete and recreate tunnel). Out of scope for v0.4.
+
+#### R9. Browser tab kept open across daemon upgrade
+
+**What:** user has the web client open at version v0.4.0; daemon upgrades to v0.4.1 in the background. The open tab's bundle has stale proto types.
+
+**Trigger:** user notices a feature added in v0.4.1 doesn't appear in their open tab.
+
+**Mitigation:**
+- Field-level back-compat (chapter 02 §7) — old client gracefully ignores new fields.
+- `Ping` RPC returns daemon version; SPA MUST show a "new version available, refresh to update" banner if the version differs from the build-embedded version. Promoted from MAY-deferred to MUST for M4: this banner is the only mechanism by which the user can detect a stale build, and deferring it makes upgrade-window stale-tab behavior silently undetectable. Scope is small (Ping RPC + 5-line UI banner).
+- Worst case: user reloads the tab on next interaction; gets fresh bundle.
+
+#### R10. CSP / cross-origin issues in browser
+
+**What:** Cloudflare Access's auth-redirect flow involves cross-origin cookies and redirects. Browser CSP (Content Security Policy) configured incorrectly on either Pages or Tunnel could break the auth handshake.
+
+**Trigger:** sign-in works once but subsequent page loads fail with "blocked by CSP" or "third-party cookie blocked" console errors.
+
+**Mitigation:**
+- Use Cloudflare's documented Access SPA pattern (no custom CSP needed for the redirect flow if both origins are first-party to the user's view of `<their-domain>`).
+- M3 dogfood explicitly tests Safari + Chrome + Firefox (the major browsers each handle third-party cookies differently as of 2026).
+- If breakage: scope to one browser, document, advise alternate browser. Not a release blocker.
+
+#### R11. `cloudflared` binary supply chain
+
+**What:** daemon ships `cloudflared` binary in the installer. If `cloudflared` upstream is compromised (or our pinned version has a CVE), users are exposed.
+
+**Trigger:** Cloudflare publishes security advisory for `cloudflared`.
+
+**Mitigation:**
+- Pin `cloudflared` version in build script; version tracked in `daemon/scripts/cloudflared-version.txt` (or similar). Supply-chain pin uses SHA + signature verification per chapter 05 locked supply-chain story [cross-file: see chapter 05].
+- Quarterly review for security advisories.
+- Auto-update (separate from daemon auto-update) of `cloudflared` itself: NOT in v0.4. Defer.
+
+#### R12. SPA bundle size grows unchecked
+
+**What:** Vite bundle bloats over time as features are added (xterm addons, larger icon set, etc.). Web client first-load latency degrades.
+
+**Trigger:** deploy log shows bundle exceeds the locked threshold; users on slow connections complain.
+
+**Mitigation:**
+- Chapter 04 §2 sets target ~600 KB gzipped first-load.
+- CI lint: bundle-size check (`size-limit` package) on PRs touching `web/` or `src/`. The fail threshold is **not** pre-set at 800 KB; instead it is locked at M1 spike to `actual_first_build + 15%` so the gate cannot trip on day one and trigger a ritual relaxation [cross-file: see chapter 04 R4 P1-1]. A gate destined to be relaxed is worse than no gate.
+- Manual chunk splitting (chapter 04 §3) keeps cache-friendly chunks.
+
+### 3. Low risks (acknowledged, not blocking)
+
+#### R13. `buf` binary upgrade churn
+
+**What:** `buf` CLI gets breaking changes; CI gate breaks on a `buf` upgrade.
+
+**Trigger:** CI failure with "unknown lint rule" or similar.
+
+**Mitigation:** pin `buf` version in `package.json`. Routine maintenance.
+
+#### R14. Auto-start at OS boot conflicts with antivirus
+
+**What:** AV on Win flags the auto-start registry / startup-folder entry as suspicious.
+
+**Trigger:** user reports AV warning on first launch with auto-start enabled.
+
+**Mitigation:**
+- Default OFF (chapter 01 G6). Users opt in.
+- Use standard mechanisms (Win startup folder shortcut, not registry HKCU\Run) to minimize false-positive risk.
+
+#### R15. Installer size increases with `cloudflared` bundled
+
+**What:** `cloudflared` binary is ~30-40 MB per platform on Win/Mac/Linux. Per-platform installer grows accordingly.
+
+**Trigger:** installer download takes noticeably longer.
+
+**Mitigation:**
+- Acceptable cost. Per-platform installer was ~80 MB; will be ~110-120 MB. Negligible.
+- Alternative: download `cloudflared` on first remote-enable. Adds setup-wizard friction; not chosen.
+
+#### R16. Multi-client typing UX is confusing
+
+**What:** two clients on the same session: characters interleave. User might find this surprising.
+
+**Trigger:** user reports "I typed `cd` and the screen shows `cwed`".
+
+**Mitigation:**
+- Documentation note: "if you type from two devices simultaneously, output interleaves."
+- No UI lock in v0.4. If demand emerges, future feature (v0.5+).
+
+#### R17. Web client clipboard quirks
+
+**What:** `navigator.clipboard.writeText` requires user gesture in some browsers; differs from Electron's unrestricted access.
+
+**Trigger:** user clicks "copy" in web; nothing happens; no error visible.
+
+**Mitigation:**
+- Wrap copy/paste in try/catch; surface a toast on failure ("clipboard blocked by browser, please use Ctrl+C").
+- Defer to browser-standard behavior; don't fight it.
+
+### 4. Risks the design explicitly accepts
+
+#### A1. Cloudflare zone-wide outage = web client unreachable
+
+**Why accepted:** Cloudflare is the chosen ingress. Outages are rare. Local Electron is unaffected — that's the fallback.
+
+#### A2. Single-user only; no multi-tenant in v0.4
+
+**Why accepted:** chapter 01 N2. Designing for multi-tenant inflates v0.4 scope by weeks for zero immediate user benefit (single user, single GitHub email).
+
+#### A3. Web client has no offline mode
+
+**Why accepted:** chapter 04 §6 + N8. Stale data is worse than no data for this product.
+
+#### A4. Daemon must be reachable from Cloudflare = daemon must be running and online
+
+**Why accepted:** the user's machine is the source of truth. If it's offline, there's nothing to display. Auto-start at boot (G6) reduces "I forgot to start it" cases. Cloud-resident daemon (N4) is a different product.
+
+#### A5. JWT replay-mid-validity not prevented (no nonce/jti store), but the compromise is auditable
+
+**Why accepted:** single-user model — an attacker who has the JWT cookie has the same identity as the legitimate user from the daemon's authorization standpoint. The earlier framing ("no defense") masked an undetectable compromise; this version is honest about the consequence and the recovery path. The daemon logs every authenticated RPC's source IP + Cf-Ray + jwt-iat [cross-file: see chapter 07 R2 P1-2 + chapter 05 §4], so the user can audit "was this me?" after the fact. Cloudflare's session-revoke endpoint provides instant invalidation if compromise is suspected. The acceptance is therefore "no in-band prevention, but full post-hoc audit trail and fast revocation," not "no defense."
+
+## 11. References
+
+### Context block
+
+This spec stands on top of v0.3's daemon-split work and the predecessor all-in-one design doc. This chapter lists every external document, source file, spike report, and convention this spec depends on, with a one-line note on what each reference contributes.
+
+### TOC
+
+- 1. Predecessor design documents
+- 2. v0.3 source code (current daemon)
+- 3. v0.3 source code (current Electron / preload bridges)
+- 4. Renderer (shared between Electron and web)
+- 5. Spike reports
+- 6. External documentation (Cloudflare, Connect, buf)
+- 7. Memory / convention references (manager-level)
+- 8. Tool / dependency versions
+
+### 1. Predecessor design documents
+
+- **`docs/superpowers/specs/2026-04-30-web-remote-design.md`** — all-in-one v0.3+ daemon-split + web design. Authoritative for v0.3 architectural decisions; v0.4 lifts §3.4 (protocol), §3.6 (Cloudflare layer), §3.5 (PTY display strategy) and expands them.
+- **`docs/superpowers/specs/v0.3-daemon-split.md`** — v0.3-only consolidated spec. Source for socket addressing, peer-cred ACL, control-vs-data socket split (§3.1.1, §3.4.1.h).
+- **`docs/superpowers/specs/v0.3-design.md`** — earlier draft of v0.3.
+- **`docs/superpowers/specs/v0.3-fragments/frag-3.4.1-envelope-hardening.md`** — envelope hardening rules (frame cap, chunking, binary trailer). v0.4 inherits the security/perf intent and re-implements as Connect interceptors / native HTTP/2 features.
+- **`docs/superpowers/specs/v0.3-fragments/frag-3.5.1-pty-hardening.md`** — PTY subscribe contract, drop-slowest, snapshot semaphore. v0.4 inherits unchanged.
+- **`docs/superpowers/specs/v0.3-fragments/frag-3.7-dev-workflow.md`** — daemon-unreachable surface, reconnect canonical log names. v0.4 reuses surface registry.
+- **`docs/superpowers/specs/v0.3-fragments/frag-6-7-reliability-security.md`** — surface registry (§6.8), supervisor transport split. v0.4 cross-refs for the daemon-status banner.
+- **`docs/superpowers/specs/v0.3-fragments/frag-8-sqlite-migration.md`** — migration-gate semantics. v0.4 re-implements as Connect interceptor (chapter 02 §8).
+- **`docs/superpowers/specs/v0.3-fragments/frag-11-packaging.md`** — single-installer model, `@yao-pkg/pkg` lock, Win/Mac/Linux artifacts. v0.4 extends with `cloudflared` binary bundling (chapter 09 M4).
+
+### 2. v0.3 source code (daemon)
+
+| Path | What it provides | v0.4 impact |
+|---|---|---|
+| `daemon/src/index.ts` | Daemon entry point | M1: bind Connect HTTP/2 server alongside envelope on data socket |
+| `daemon/src/sockets/data-socket.ts` | Data-socket transport (hosts the round-2 security pre-accept rate cap labelled "T15" in `v0.3-design.md` §3.4.1.a) | M1-M2: Connect server replaces envelope handlers; pre-accept rate cap stays on the listener boundary |
+| `daemon/src/sockets/runtime-root.ts` | Listener selection / transport tagging | M4: tag local vs. remote requests for JWT bypass |
+| `daemon/src/dispatcher.ts` | RPC method router (control socket) | Unchanged in v0.4 (control socket stays envelope) |
+| `daemon/src/handlers/healthz.ts` | `/healthz` handler | Unchanged (control socket) |
+| `daemon/src/handlers/daemon-hello.ts` | HMAC handshake handler | Unchanged on control socket; HMAC dropped from data socket per chapter 02 §8 |
+| `daemon/src/envelope/envelope.ts` | Length-prefixed JSON envelope | Deleted from data socket in M2; kept on control socket |
+| `daemon/src/envelope/hello-interceptor.ts` | HMAC handshake interceptor | Same — control socket only after M2 |
+| `daemon/src/envelope/deadline-interceptor.ts` | `x-ccsm-deadline-ms` enforcement | Re-implemented as Connect interceptor (chapter 02 §8) |
+| `daemon/src/envelope/migration-gate-interceptor.ts` | Block RPCs during SQLite migration | Re-implemented as Connect interceptor |
+| `daemon/src/envelope/trace-id-map.ts` | ULID per-request | Re-implemented as Connect interceptor on data socket |
+| `daemon/src/envelope/chunk-reassembly.ts` | 16 KiB sub-chunk reassembly | Obsolete on data socket (HTTP/2 native frame fragmentation) |
+| `daemon/src/envelope/protocol-version.ts` | Frame version nibble validation | Obsolete on data socket |
+| `daemon/src/envelope/supervisor-rpcs.ts` | Allowlist for control socket RPCs | Unchanged |
+| `daemon/src/db/` | SQLite schema, migrations, boot orchestrator | Unchanged in v0.4 |
+| `daemon/src/pty/lifecycle.ts` | Per-session PTY spawn / exit | Unchanged |
+| `daemon/src/pty/fanout-registry.ts` | Per-session subscriber set + seq tracking | Carries forward; new subscribers from web client |
+| `daemon/src/pty/snapshot-semaphore.ts` | Serialize-buffer concurrency control | Unchanged |
+| `daemon/src/pty/drop-slowest.ts` | Per-subscriber 1 MiB watermark | Unchanged |
+| `daemon/src/pty/sigchld-reaper.ts` | Unix process reap | Unchanged |
+| `daemon/src/marker/` | Boot nonce / pid file | Unchanged; `boot_nonce` now also flows into Connect events (chapter 06 §2) |
+
+### 3. v0.3 source code (Electron / preload bridges)
+
+| Path | What it provides | v0.4 impact |
+|---|---|---|
+| `electron/preload/bridges/ccsmCore.ts` | `window.ccsm` (db, version, importable, settings, updater, window) | Bridge-swap M2 (Batches A + B); daemon-domain calls move to Connect |
+| `electron/preload/bridges/ccsmSession.ts` | `window.ccsmSession` (state, title, activate signals) | Bridge-swap M2 (Batches B + C streams) |
+| `electron/preload/bridges/ccsmPty.ts` | `window.ccsmPty` (spawn, attach, input, snapshot, data stream) | Bridge-swap M2 (Batches A + B + C); clipboard surface stays Electron |
+| `electron/preload/bridges/ccsmNotify.ts` | `window.ccsmNotify` (flash, user-input markers) | Bridge-swap M2 (Batch B + C) |
+| `electron/preload/bridges/ccsmSessionTitles.ts` | `window.ccsmSessionTitles` (SDK summary get/rename/list) | Bridge-swap M2 (Batches A + B) |
+| `electron/ipc/sessionIpc.ts` | Main-process handlers for session signals + sessionTitles | Removed in M2 cleanup PR (handlers move to daemon Connect) |
+| `electron/ipc/dbIpc.ts` | Main-process db:load/save handlers | Removed in M2 cleanup |
+| `electron/ipc/systemIpc.ts` | Main-process system info handlers | Mostly removed; clipboard/window subset stays |
+| `electron/ipc/utilityIpc.ts` | Misc | Audit per-handler in M2 cleanup |
+| `electron/ipc/windowIpc.ts` | Window-only IPCs (minimize/maximize/etc.) | Stays on `ipcRenderer` (chapter 03 §2) |
+| `electron/main.ts` | Main process entry | Reduced further: Connect transport setup; no per-bridge handler wiring |
+| `electron/sessionTitles/` | SDK wrapper logic | Lives on daemon now (already migrated in v0.3); v0.4 just ensures Connect handler delegates here |
+| `electron/notify/` | Notification pipeline | Same — daemon-side; Connect handler delegates |
+| `electron/security/ipcGuards.ts` | `fromMainFrame`, `isSafePath` | Still applies to remaining `ipcRenderer` handlers |
+
+### 4. Renderer (shared)
+
+| Path | What it provides | v0.4 impact |
+|---|---|---|
+| `src/App.tsx` | Top-level React component | Unchanged |
+| `src/index.tsx` | Renderer entry | Unchanged for Electron; shared by web entry `web/src/main.tsx` |
+| `src/stores/*` | Zustand stores | Unchanged |
+| `src/shared/sessionState.ts` | Canonical 3-state session vocabulary | Imported by proto-generated types in v0.4 (chapter 02 §7) |
+| `src/components/TerminalPane.tsx` (representative) | xterm.js host | Unchanged surface; consumes `window.ccsmPty` bridge unchanged |
+| `src/i18n/*` | Translation bundles | New keys for `cloudflare.unreachable`, setup wizard text |
+
+### 5. Spike reports
+
+- **F1 — Tauri vs Electron desktop:** `~/spike-reports/F1-tauri-desktop.md`. Decided against Tauri.
+- **F2 — Flutter all-platform:** `~/spike-reports/F2-flutter-all.md`. Decided against Flutter.
+- **F3 — iOS native vs cross-platform:** `~/spike-reports/F3-ios-stack.md`. Locked SwiftUI for v0.5+; v0.4 emits Swift codegen but doesn't use it.
+- **F4 — shared protocol layer:** `~/spike-reports/F4-shared-protocol.md`. Locked Connect+Protobuf+buf over gRPC, tRPC, TypeSpec.
+- v0.3 round-1 spikes A1-A4, B1-B4, C5, D6-D7: `~/spike-reports/`.
+- v0.3 review reports (security/perf/reliability): `~/spike-reports/v03-review-{security,perf,reliability,observability,devx,resource,ux,fwdcompat}.md` and round-2/round-3 variants.
+
+### 6. External documentation
+
+#### Cloudflare
+- Tunnel: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/
+- Access (Zero Trust): https://developers.cloudflare.com/cloudflare-one/identity/
+- GitHub IdP: https://developers.cloudflare.com/cloudflare-one/identity/idp-integration/github/
+- JWT validation (programmatic): https://developers.cloudflare.com/cloudflare-one/identity/authorization-cookie/validating-json/
+- Pages: https://developers.cloudflare.com/pages/
+- Pages GitHub integration: https://developers.cloudflare.com/pages/configuration/git-integration/
+- Service tokens (for CI): https://developers.cloudflare.com/cloudflare-one/identity/service-tokens/
+- Free tier limits: https://www.cloudflare.com/plans/zero-trust-services/
+
+#### Connect / Protobuf / buf
+- Connect-RPC docs: https://connectrpc.com/
+- Connect-ES (TypeScript): https://github.com/connectrpc/connect-es
+- Connect-Web: https://connectrpc.com/docs/web/getting-started
+- Connect-Node: https://connectrpc.com/docs/node/getting-started
+- Protobuf v3 language guide: https://protobuf.dev/programming-guides/proto3/
+- buf docs: https://buf.build/docs/
+- buf breaking-change rules: https://buf.build/docs/breaking/rules/
+- @bufbuild/protoc-gen-es: https://github.com/bufbuild/protobuf-es
+
+#### Other tooling
+- `@yao-pkg/pkg`: https://github.com/yao-pkg/pkg (locked daemon packager per `feedback_*` and frag-11)
+- `jose` (JWT verification): https://github.com/panva/jose
+- xterm.js + xterm-headless: https://xtermjs.org/
+- Vite: https://vite.dev/
+- Playwright: https://playwright.dev/
+
+### 7. Memory / convention references (manager-level)
+
+These are referenced by manager-level processes; cited here so a worker reading the spec knows the convention exists.
+
+- `feedback_dispatch_discipline.md`
+- `feedback_one_bug_one_worker.md`
+- `feedback_e2e_prefer_harness.md`
+- `feedback_local_e2e_only.md`
+- `feedback_trust_ci_mode.md`
+- `feedback_bug_fix_test_workflow.md`
+- `feedback_dogfood_protocol.md`
+- `feedback_correctness_over_cost.md`
+- `feedback_no_skipped_e2e.md`
+- `feedback_migration_window_ci_tolerance.md`
+- `project_direction_locked.md`
+- `feedback_taskcreate_no_id_prefix.md` (relevant during DAG seed in pipeline stage 7)
+
+### 8. Tool / dependency versions (locked at v0.4 spec time)
+
+| Dependency | Version | Reason |
+|---|---|---|
+| `@connectrpc/connect` | ^2.x (latest stable as of 2026-04) | Connect runtime |
+| `@connectrpc/connect-node` | ^2.x | Daemon Connect server |
+| `@connectrpc/connect-web` | ^2.x | Web client transport |
+| `@bufbuild/buf` | ^2.x | buf CLI as devDep |
+| `@bufbuild/protoc-gen-es` | ^2.x | TS message codegen |
+| `@bufbuild/protoc-gen-connect-es` | ^2.x | TS Connect service stubs |
+| `jose` | ^5.x | JWT validation |
+| `cloudflared` | bundled binary, version pinned in `daemon/scripts/cloudflared-version.txt` (latest stable as of release tag) | Cloudflare Tunnel sidecar |
+| Node | 22 LTS (matches v0.3) | Daemon + Electron main + build tools |
+| Vite | ^6.x | Web build |
+| Playwright | matches v0.3 | E2E |
+
+**Lock review at M4 close:** verify each version still latest stable; bump if needed before tagging `v0.4.0`.
+
+---
+
+## Changelog
+
+- **2026-05-01 (stage-5 merge):** Consolidated 12 chapter files into this single canonical document. Manager decision folded: R1 P2 cross-chapter contradiction (chapter 01 G6/A5 vs chapter 09 M4 #7) resolved in favor of "tray IS in v0.4 scope" — chapter 09 M4 deliverable #7 updated to include the tray menu item alongside the Settings toggle (matching chapter 01 G6 / A5 lock).
+- **2026-05-01 (stage-4 r2):** R1-R6 reviewers all APPROVE post fixer rounds #741 (testability/multi-client coherence expansion) and #742 (security/naming polish). Source chapter snapshot: `spec/2026-05-01-v0.4-web` @ a292ddb.
+- **2026-04-30..2026-05-01 (stages 1-4):** chapter authoring, two reviewer rounds with R1 (feature) / R2 (security) / R3 (reliability) / R4 (scalability) / R5 (testability) / R6 (naming), two fixer rounds (#741 / #742). All r2 reports archived under `c:/tmp/v04-r2-R{1..6}.md`.
+
+
+---
+
+## Appendix: implementation DAG
+
+**Location decision:** the DAG lives as an appendix of this consolidated spec rather than a separate file. Justification: the DAG cross-references this spec's chapters heavily ("see chapter 02 §4", "see chapter 09 M2.A") and reviewers/dispatch-managers benefit from one-document reads. A standalone DAG file would force tab-flipping for every task. PR body declares this choice.
+
+**Layer legend:**
+- **L1 — Protocol foundation.** `proto/`, `buf` toolchain, codegen pipeline, `gen/ts/`. Source-of-truth for every other layer.
+- **L2 — Daemon Connect server.** `daemon/src/connect/`, interceptors, JWT middleware, dev/prod TCP listeners, idempotency, supply-chain.
+- **L3 — Bridge swap.** `electron/connect/`, `electron/preload/bridges/*` rewrites, Connect-Node-over-IPC transport, parity tests, adapter contract tests.
+- **L4 — Web client.** `web/` package, Vite SPA, shared-renderer wiring, transport, platform-fork shims, error reporting, CSP/storage gates.
+- **L5 — Cloudflare layer.** `cloudflared` sidecar, supply-chain pinning, Tunnel/Access setup wizard, JWKS pre-warm, keychain secret-handling, auto-start.
+- **L6 — Testing / release gates.** L1-L6 e2e harness extensions (Playwright web suite, multi-client harness, cf-smoke, parity framework, schema-additive lint, perf gates, dogfood gates).
+
+**Mapping to chapter 09 milestones:**
+- **M1 (chapter 09 §2):** T01 → T08 (proto + buf + Connect server scaffold + first bridge end-to-end + parity framework).
+- **M2 (chapter 09 §3):** T09 → T16 (all bridge batches A/B/C, M2.Z cleanup, multi-client Electron+Electron coherence).
+- **M3 (chapter 09 §4):** T17 → T22 (web package, dev TCP listener, error reporting, web e2e, multi-client web added).
+- **M4 (chapter 09 §5):** T23 → T29 (cloudflared supply chain + supervise, JWT, keychain secrets, setup wizard, auto-start tray + Settings, CF smoke, release gates).
+- **Cross-cutting / parallelizable any time:** T30 → T34 (perf instrumentation, schema-additive lint, fixture lint, taxonomy generator, security audit checkpoints).
+
+### DAG task table (T01..T34)
+
+Each task: name, layer, scope, files-to-touch, deliverable, blockers (Tx that must merge first). Tasks within the same layer that touch disjoint files can dispatch in parallel; collisions are flagged in the hot-files registry below.
+
+#### M1 tasks (T01..T08)
+
+**T01. Proto module skeleton + buf toolchain + CI.**
+- Layer: L1.
+- Scope: create `proto/` directory with `buf.yaml`, `buf.gen.yaml`, `buf.lock`, namespace `ccsm.v1`, empty `service.proto` umbrella. Wire `buf lint` + `buf breaking --against working` + `buf generate && git diff --exit-code gen/` into a new `.github/workflows/proto.yml` (chapter 02 §4, chapter 08 §2). Pin `@bufbuild/buf` and `@bufbuild/protoc-gen-es` exact versions in root `package.json`.
+- Files: `proto/buf.yaml`, `proto/buf.gen.yaml`, `proto/buf.lock`, `proto/ccsm/v1/service.proto`, `package.json`, `.github/workflows/proto.yml`, `.gitattributes`.
+- Deliverable: `npm run proto:gen` succeeds; CI green on PR with no proto changes; CI fails on a deliberate-broken PR.
+- Blockers: none.
+
+**T02. Per-domain proto files (8 files) + RPC inventory + idempotency annotations.**
+- Layer: L1.
+- Scope: write the 8 per-domain `.proto` files (`core`, `session`, `session_titles`, `pty`, `notify`, `settings`, `updater`, `import`) per chapter 02 §3 layout. Every RPC declared in the umbrella service with the chapter 03 §1 inventory (31 unary + 4 fire-and-forget + 11 streams = 46). Every RPC carries `// idempotency: naturally idempotent | dedup-via-server-key | non-idempotent` annotation per chapter 02 §9. Add `buf lint` rule that fails on missing annotation.
+- Files: `proto/ccsm/v1/{core,session,session_titles,pty,notify,settings,updater,import}.proto`, `proto/ccsm/v1/service.proto` (umbrella), small Node script `scripts/check-idempotency-annotations.ts` invoked from `proto.yml`.
+- Deliverable: `buf generate` produces `gen/ts/ccsm/v1/*` for all 8 domains; idempotency-annotation lint passes; chapter 03 §1 inventory matches.
+- Blockers: T01.
+
+**T03. `@ccsm/proto-gen` wrapper package + tree-shaking verification.**
+- Layer: L1.
+- Scope: thin re-export package per chapter 02 §5. Verify ESM output, tree-shaking from a Vite test build. Configure `.gitattributes` for `gen/** linguist-generated=true -diff`.
+- Files: `gen/ts/index.ts` (or wrapper package `packages/proto-gen/`), `tsconfig.json` paths entry, root `package.json` workspaces.
+- Deliverable: both Electron-renderer and a sample Vite SPA can import `@ccsm/proto-gen/v1` and tree-shake unused stubs.
+- Blockers: T02.
+
+**T04. `pkg` ESM-interop spike (M1 prerequisite).**
+- Layer: L2.
+- Scope: per chapter 02 §5 final paragraph — build the daemon installer with the actual generated ESM Connect stubs through `@yao-pkg/pkg`. If pkg chokes, fall back to CI-only "regenerate at install" mode. One-day spike report committed to `docs/spikes/2026-05-pkg-esm-connect.md`.
+- Files: `docs/spikes/2026-05-pkg-esm-connect.md`, possibly `daemon/scripts/build-with-pkg.ts` adjustments.
+- Deliverable: spike report with go/no-go decision; if no-go, the report includes the fallback wiring plan.
+- Blockers: T03.
+
+**T05. Connect server bind on daemon data socket (alongside envelope).**
+- Layer: L2.
+- Scope: bind `@connectrpc/connect-node` Http2Server on the data socket alongside the existing envelope handler per chapter 09 §2 deliverable 5 + chapter 02 §1. Implement transport-tagging context (`'local-pipe'` vs `'remote-tcp'`) at listener accept time per chapter 05 §4. Wire the standard interceptor stack: trace-id, deadline, migration-gate, `readMaxBytes` (per-route caps from chapter 02 §8 table), pre-accept rate cap, structured pino logging.
+- Files: `daemon/src/connect/server.ts` (new), `daemon/src/connect/interceptors/{trace-id,deadline,migration-gate,read-max,rate-cap}.ts`, `daemon/src/sockets/data-socket.ts` (wire-in), `daemon/src/sockets/runtime-root.ts` (transport tag).
+- Deliverable: daemon binds Connect on the data socket; envelope still serves all v0.3 RPCs; no production behavior change yet.
+- Blockers: T03 (needs `gen/ts/`), T04 (needs pkg verdict).
+
+**T06. First bridge end-to-end: `getVersion` + `Ping` over Connect.**
+- Layer: L3.
+- Scope: per chapter 09 §2 deliverables 6-8 — implement `electron/connect/ipc-transport.ts` (Connect-Node-over-named-pipe / Unix-socket) with the proxy-only contextBridge surface per chapter 03 §3.2. Daemon registers `Ping` + `GetVersion` Connect handlers. Bridge `ccsmCore.getVersion()` swapped to Connect; daemon ipc handler for `app:getVersion` removed. Reconnect choreography per chapter 03 §3.1 (burst → steady-state, injectable Clock, hash-keyed jitter). Bridge-side structured log on failure per chapter 03 §3.3. Local-transport-key smoke test per chapter 03 §3.4.
+- Files: `electron/connect/ipc-transport.ts` (new), `electron/preload/bridges/ccsmCore.ts` (edit `getVersion`), `daemon/src/connect/handlers/{ping,version}.ts`, `electron/preload/transport-proxy.ts` (proxy boundary).
+- Deliverable: v0.4.0-rc1 installer; daemon log shows `transport=connect, method=GetVersion` on app launch; v0.3 functionality otherwise unchanged. 24h dogfood (post-M1 gate per chapter 09 §7).
+- Blockers: T05.
+
+**T07. Parity-test framework (M1 first PR — load-bearing for M2).**
+- Layer: L6.
+- Scope: per chapter 03 §7.1 — `assertParity()` with deep-equal + ignore-list + per-field coercion. Golden fixture corpus at `daemon/__tests__/parity-corpus/<rpc>.json`. `RECORD_PARITY=1` env to record fixtures from v0.3 envelope path. Codegen-driven scaffold `scripts/gen-parity-scaffold.ts` enforces every swapped RPC has a parity entry.
+- Files: `daemon/__tests__/parity/index.ts`, `daemon/__tests__/parity-corpus/.gitkeep`, `scripts/gen-parity-scaffold.ts`.
+- Deliverable: framework lands in M1 ahead of any Batch A bridge swap; one example parity test (`getVersion`) passes; missing-corpus PR fails the lint gate.
+- Blockers: T05 (needs Connect handler context).
+
+**T08. JWT interceptor scaffold + JWKS pre-warm + transport-tag bypass.**
+- Layer: L2.
+- Scope: per chapter 05 §4 — `daemon/src/connect/jwt-interceptor.ts` with `jose`, RS256 + required claims + AUD + issuer + clock tolerance + JWKS cooldown + verify cache (chapter 05 §4.1). JWKS pre-warm at boot with fast-then-slow backoff; remote ingress refuses to bind until JWKS cached. Transport-tag positive enum (`'local-pipe'` bypass; untagged fail-closed; chapter 05 §4 + chapter 02 §8). Local-bypass + audit log scaffolded; remote ingress not yet wired (T23). M1 audit checkpoint per chapter 03 §3.2 covers preload transport security boundary.
+- Files: `daemon/src/connect/jwt-interceptor.ts`, `daemon/src/connect/jwks.ts`, `daemon/src/connect/transport-tag.ts`.
+- Deliverable: interceptor in the chain; on a local-pipe request without JWT it accepts; mock-remote-tagged request without JWT rejects with `unauthenticated`; log tag `jwt.local-bypass` / `jwt.missing` per chapter 05 §4.2 matrix.
+- Blockers: T05, T07 (needs parity framework for the bypass test).
+
+#### M2 tasks (T09..T16)
+
+**T09. Bridge swap Batch A (read-only RPCs, 4 sub-PRs).**
+- Layer: L3.
+- Scope: per chapter 03 §5 Batch A and chapter 09 §3 sub-batch M2.A — 4 sub-PRs: (A.1) `ccsmCore` reads (`app:getVersion` already done in T06; remaining `app:userHome`, `app:userCwds:get`, `settings:defaultModel`, `paths:exist`, `import:scan`, `import:recentCwds`, `ccsm:get-system-locale`); (A.2) `ccsmSessionTitles` reads (`get`, `listForProject`); (A.3) `ccsmPty` reads (`pty:list`, `pty:get`, `pty:checkClaudeAvailable`, `pty:getBufferSnapshot`); (A.4) `ccsmCore.db:load`. Each PR: proto definitions, daemon Connect handler, bridge-file rewrite, electron `ipcMain.handle` removal, parity test using framework from T07, e2e probe per `--only=bridge-swap-<bridge>-<rpc>` taxonomy from chapter 03 §7 + chapter 08 §9.3.
+- Files (per sub-PR): one bridge file in `electron/preload/bridges/`, daemon `daemon/src/connect/handlers/<domain>.ts`, proto domain file, parity-corpus JSON, e2e probe in harness file.
+- Deliverable: 4 sub-PRs land; all parity tests green; e2e green per `--only` mapping.
+- Blockers: T07, T08. Sub-PRs internally serialized (one sub-PR per bridge file = hot-file collision); A.1/A.2/A.3/A.4 may run two-at-a-time if they touch disjoint files.
+
+**T10. Bridge swap Batch B (write RPCs, 5 sub-PRs).**
+- Layer: L3.
+- Scope: per chapter 03 §5 Batch B and chapter 09 §3 sub-batch M2.B — 5 sub-PRs: (B.1) `ccsmCore` writes (`db:save`, `app:userCwds:push`, `cwd:pick`-Electron-side, `updates:check/download/install/setAutoCheck`, `ccsm:set-language`); (B.2) `ccsmSession` signals (`session:setActive`, `session:setName`); (B.3) `ccsmPty` writes (`pty:spawn`, `pty:attach`, `pty:detach`, `pty:input`, `pty:resize`, `pty:kill`); (B.4) `ccsmNotify` (`notify:userInput`); (B.5) `ccsmSessionTitles` writes (`rename`, `enqueuePending`, `flushPending`). PTY input batches must include the input coalescer unit test (chapter 03 §7.3) and the 64 KiB cap (chapter 03 §7.4). Daemon-side per-client rate cap (200 RPC/sec, burst 1000) + per-session 1 MiB queue cap per chapter 06 §3.
+- Files: 5 bridge files (each in its own sub-PR), `daemon/src/connect/handlers/<domain>.ts` per domain, `electron/preload/bridges/__tests__/ccsmPty.coalescer.test.ts`.
+- Deliverable: 5 sub-PRs; parity tests green; coalescer test green; PTY-input cap rejects at 64 KiB+1.
+- Blockers: T09 (Batch A must be in to keep parity framework warm and avoid double-fixing transport bugs).
+
+**T11. Bridge swap Batch C (streams, 3 sub-PRs).**
+- Layer: L3.
+- Scope: per chapter 03 §5 Batch C and chapter 09 §3 sub-batch M2.C — 3 sub-PRs: (C.1) `ccsmPty` streams (`pty:data`, `pty:exit` folded into single `streamPty` server-stream per chapter 06 §1-2); (C.2) `ccsmSession` streams (`session:state`, `session:title`, `session:cwdRedirected`, `session:activate` folded into `streamSessionStateChanges` + `streamSessionTitleUpdates` per chapter 06 §8); (C.3) `ccsmNotify.notify:flash` + `ccsmCore` updater streams (`updates:status`, `update:downloaded`). Each stream PR includes per-connection heartbeat aggregation (chapter 06 §4), client-side liveness check (120s timeout), hash-keyed re-subscribe stagger (chapter 03 §3.1), folded-stream variant-exact dispatch (chapter 06 §8.1).
+- Files: bridge files (3 in 3 sub-PRs), `daemon/src/connect/handlers/streams/<domain>.ts`, fanout integration with existing `daemon/src/pty/fanout-registry.ts`.
+- Deliverable: 3 sub-PRs; streams deliver in order; heartbeats fire under harness `CCSM_HEARTBEAT_*_MS=ms` overrides; folded-stream contract test green.
+- Blockers: T10. Sub-PRs internally serialized per bridge file.
+
+**T12. M2.Z cleanup PR — delete envelope handler from data socket.**
+- Layer: L2/L3.
+- Scope: per chapter 09 §3 M2.Z preconditions — only after all 12 batch PRs merged AND post-M2 7-day dogfood window CLOSED. Delete envelope handlers from `daemon/src/sockets/data-socket.ts`; delete `electron/ipc/*.ts` files for daemon-domain handlers; delete temporary parity tests; promote a subset to enduring bridge adapter contract tests at `electron/preload/bridges/__tests__/<bridge>.contract.test.ts` per chapter 03 §7.2.
+- Files: `daemon/src/sockets/data-socket.ts`, `daemon/src/envelope/*.ts` (subset; control-socket files stay), `electron/ipc/dbIpc.ts`, `electron/ipc/sessionIpc.ts`, `electron/ipc/systemIpc.ts` (audit-trim), `electron/ipc/utilityIpc.ts`, `electron/preload/bridges/__tests__/*.contract.test.ts` (new).
+- Deliverable: `grep -r 'envelope' daemon/src/sockets/data-socket.ts` returns nothing; control-socket envelope code intact; adapter contract tests green.
+- Blockers: T09, T10, T11; gated on dogfood window close (manager release the gate, not a code task).
+
+**T13. Multi-client coherence (Electron + Electron) e2e harness.**
+- Layer: L6.
+- Scope: per chapter 09 §3 deliverable 5 — `multi-client-pair` Playwright case spawns two Electron instances on the same daemon, asserts both see identical PTY bytes after typing from each side. Hermetic — no real network, no Cloudflare. Uses test hooks `__setBootNonceForTest`, `getFanoutSubscriberCount`, `CCSM_TEST_*` env vars per chapter 06 §9.
+- Files: `daemon/__tests__/multi-client/pair.test.ts`, e2e harness `e2e/multi-client/electron-pair.spec.ts`, daemon test-hook exports gated on `CCSM_TEST_HOOKS=1`.
+- Deliverable: green case; subscriber-count returns to 0 after disconnect (5 modes per chapter 06 §9.7); auto-runs in `multi-client-e2e.yml` workflow per chapter 08 §9.1.
+- Blockers: T11 (needs streams).
+
+**T14. Replay buffer + drop-slowest + force-snapshot machinery (Connect-side).**
+- Layer: L2.
+- Scope: per chapter 06 §5-7 — wire the v0.3 `daemon/src/pty/{fanout-registry,snapshot-semaphore,drop-slowest}.ts` into the Connect stream handler. Per-session 4 MiB replay ring (chapter 06 §5); 256 KiB per-reconnect replay budget; force-snapshot on `boot_nonce` mismatch or `fromSeq_too_old`. `PtySnapshot.truncated` + 2 MiB compressed cap + 5k default scrollback. `MAX_SUBSCRIBERS_PER_SESSION = 8`, `MAX_TOTAL_SUBSCRIBERS = 64`. Idle-session eviction (24h zero-subscriber + zero-output → trim to 1k lines + free fanout buffer) per chapter 05 §1.2.
+- Files: `daemon/src/connect/streams/pty-stream.ts`, `daemon/src/pty/replay-ring.ts` (new, distinct from drop-slowest), `daemon/src/pty/snapshot-cap.ts`, `daemon/src/pty/idle-eviction.ts`.
+- Deliverable: hermetic e2e cases per chapter 06 §9.8 list (`web-reconnect-exact-replay`, `web-reconnect-force-snapshot`, `web-reconnect-fromSeq-too-old`, `drop-slowest-fires-and-recovers`, `fanout-subscriber-cleanup`) all green.
+- Blockers: T11.
+
+**T15. Storage-full short-circuit interceptor.**
+- Layer: L2.
+- Scope: per chapter 07 §1 — daemon's existing storage-full handler integrates with a Connect interceptor that maps `SQLITE_FULL` to `resource_exhausted`, short-circuits write RPCs while flag is set, allows reads. Logger fallback to in-memory ring buffer (1000 lines). Side-channel signal in `/healthz` (`{"ok":false,"reason":"storage.full"}`). Test hook `__test_setStorageFull(true)`.
+- Files: `daemon/src/connect/interceptors/storage-full.ts`, `daemon/src/handlers/healthz.ts` (extend), `daemon/src/log/pino-fallback.ts`.
+- Deliverable: contract test asserting (a) write RPCs return `resource_exhausted`, (b) reads succeed, (c) `storage.full` event on `streamSessionStateChanges`.
+- Blockers: T11 (needs streams).
+
+**T16. Wire-skew compat smoke (release-gate test).**
+- Layer: L6.
+- Scope: per chapter 07 §5 + chapter 08 §3 — `wire-skew-compat` once-per-release CI test boots v0.3.x Electron probe against v0.4 daemon container; asserts (a) renderer surfaces `daemon.unreachable` within 10s, (b) v0.4 daemon HTTP/2 listener doesn't crash / leak FDs, (c) clean rejection log with `failure_class=protocol_mismatch`. Symmetric reverse test.
+- Files: `e2e/wire-skew/v03-electron-vs-v04-daemon.spec.ts`, `e2e/wire-skew/v04-electron-vs-v03-daemon.spec.ts`, `.github/workflows/wire-skew-release.yml`.
+- Deliverable: workflow runs only on `v0.4.*` tag push; failure blocks release.
+- Blockers: T12.
+
+#### M3 tasks (T17..T22)
+
+**T17. `web/` package skeleton + Vite config + shared-renderer wiring.**
+- Layer: L4.
+- Scope: per chapter 04 §1-3 — `web/package.json`, `web/vite.config.ts` (manual chunks for xterm/react/connect), `web/src/main.tsx` mounting `src/App.tsx`, `web/src/platform/{clipboard,window-chrome,folder-picker}.ts` web-specific shims, `web/tsconfig.json` paths mapping. Bundle-size CI gate locked at M1 spike `actual + 15%` (T22 records; T17 wires the gate).
+- Files: `web/package.json`, `web/vite.config.ts`, `web/index.html`, `web/src/main.tsx`, `web/src/platform/*.ts`, `web/tsconfig.json`, `web/public/_headers`, `web/public/_redirects`.
+- Deliverable: `npm run build:web` produces `web/dist/`; `vite preview` serves the SPA shell against a stub transport.
+- Blockers: T03 (`@ccsm/proto-gen`).
+
+**T18. Web bridge files + Connect-Web transport + transport-target injection.**
+- Layer: L4.
+- Scope: per chapter 04 §1, 5.1 + chapter 03 §1 inventory — `web/src/bridges/{ccsmCore,ccsmSession,ccsmPty,ccsmNotify,ccsmSessionTitles}.ts` each implementing the same `window.ccsm*` surface as the Electron bridge but calling Connect-Web. `web/src/transport.ts` resolves daemon base URL via `import.meta.env.VITE_DAEMON_BASE_URL` first then `window.location.origin`. No `localStorage`/`sessionStorage`/`indexedDB`/`caches` usage (CI lint per chapter 04 §8.1). `src/platform/getPlatform.ts` shared helper.
+- Files: `web/src/bridges/*.ts`, `web/src/transport.ts`, `src/platform/getPlatform.ts`, `scripts/lint-web-storage.ts`, `.github/workflows/web-storage-lint.yml`.
+- Deliverable: web SPA loads `window.ccsm*` and can call Connect-Web against a stub daemon; storage-lint green.
+- Blockers: T11, T17.
+
+**T19. Dev TCP listener + production-build gate (build-time symbol).**
+- Layer: L2.
+- Scope: per chapter 04 §5 + chapter 09 §4 deliverable 5 — `daemon/src/dev/dev-tcp-listener.ts` with build-time `__CCSM_DEV_TCP_ENABLED__` define, per-launch shared secret printed to dev console, strict `Host` header validation (only `localhost:7878` / `127.0.0.1:7878`), prod-build assertion that exits non-zero if dev module loads. `tsconfig.production.json` excludes `daemon/src/dev/**`. CI smoke test asserts `nc 127.0.0.1 7878` refuses on prod-build.
+- Files: `daemon/src/dev/dev-tcp-listener.ts`, `daemon/src/index.ts` (gated import), `daemon/tsconfig.production.json`, `daemon/build/define-prod-symbol.ts`, `e2e/dev-tcp-prod-refuses.spec.ts`.
+- Deliverable: dev build binds and accepts secret; prod build does not bind; CI smoke green.
+- Blockers: T05.
+
+**T20. Web client error reporting (`ReportClientError` RPC).**
+- Layer: L4.
+- Scope: per chapter 04 §6.5 + chapter 09 §4 deliverable 8 — proto RPC `ReportClientError(message, stack, traceId, userAgent, url, ts)`; daemon writes to `~/.ccsm/web-client-errors.log` (pino-roll, 50 MB × 5 files); web `web/src/main.tsx` installs `window.onerror` + `unhandledrejection`; hidden `?debug=1` Settings "Copy diagnostics" button.
+- Files: `proto/ccsm/v1/core.proto` (extend), `daemon/src/connect/handlers/report-client-error.ts`, `web/src/main.tsx` (boot listeners), `src/components/Settings/CopyDiagnostics.tsx`.
+- Deliverable: web-side uncaught exception ends up in daemon log within 1s; "Copy diagnostics" copies last 50 lines.
+- Blockers: T18, T19.
+
+**T21. Web e2e suite (Playwright on HTTP/2 server, 6 cases).**
+- Layer: L6.
+- Scope: per chapter 08 §5 — `web/e2e/serve-http2.ts` (~30 LOC `http2.createSecureServer` with `@vitejs/plugin-basic-ssl` cert), Playwright fixture spawns daemon with `CCSM_DAEMON_TEST_JWKS_URL` (production-gated, scheme-restricted, log-warned per chapter 08 §5). 6 cases: `web-list-sessions`, `web-open-session`, `web-type-into-session`, `web-reconnect`, `web-jwt-expiry`, `web-auth-bypass-blocked`. `npm run e2e:web` script. Cloudflare Pages preview e2e (4 cases): `pages-loads`, `pages-deeplink`, `pages-signin-prompt`, `pages-version-banner`.
+- Files: `web/e2e/serve-http2.ts`, `web/e2e/{web-list-sessions,web-open-session,web-type-into-session,web-reconnect,web-jwt-expiry,web-auth-bypass-blocked}.spec.ts`, `web/e2e/pages-smoke/*.spec.ts`, `.github/workflows/web-e2e.yml`, `.github/workflows/pages-preview.yml`.
+- Deliverable: web-e2e workflow runs on every PR touching `web/` or `src/`; 6 cases green; budget ~5 min.
+- Blockers: T18, T19, T20.
+
+**T22. Multi-client coherence harness extended to web (4 cases).**
+- Layer: L6.
+- Scope: per chapter 06 §9.8 + chapter 08 §6 — extend T13's `multi-client-pair` to add `simple-mirror`, `interleaved-input`, `disconnect-while-other-active`, `slow-client-doesnt-affect-fast-client`. Plus `multi-client-daemon-crash` variant per chapter 08 §6 (kill -9 daemon, supervisor respawns, both clients reconcile via boot_nonce force-snapshot).
+- Files: `e2e/multi-client/*.spec.ts` (extend), reuse fanout subscriber tracking hook from T13.
+- Deliverable: full L5 case list green; total L5 budget ≤ 3.5 min.
+- Blockers: T13, T21.
+
+#### M4 tasks (T23..T29)
+
+**T23. `cloudflared` binary supply chain (download + pin + verify).**
+- Layer: L5.
+- Scope: per chapter 05 §1.1 + chapter 09 §5 deliverable 1 — `daemon/scripts/fetch-cloudflared.ts` downloads from canonical Cloudflare release URL, verifies pinned SHA256 from `daemon/scripts/cloudflared-checksums.json`, verifies signature (Win signtool / mac codesign / Linux GPG). CI step `cloudflared --version` cross-check vs `daemon/scripts/cloudflared-version.txt` per R5 P2-2. Runtime SHA re-check on first spawn per chapter 05 §1.1 #5.
+- Files: `daemon/scripts/fetch-cloudflared.ts`, `daemon/scripts/cloudflared-version.txt`, `daemon/scripts/cloudflared-checksums.json`, `daemon/src/cloudflared/runtime-sha-check.ts`, `.github/workflows/cloudflared-supply-chain.yml`.
+- Deliverable: build embeds `cloudflared` for all platforms; SHA mismatch in any phase = build/runtime failure with clear log.
+- Blockers: T04 (pkg verdict).
+
+**T24. `cloudflared` spawn / supervise / restart / network-up trigger.**
+- Layer: L5.
+- Scope: per chapter 05 §1 — `daemon/src/cloudflared/supervisor.ts` with injectable `spawnCloudflared` factory (R5 P1-1). Spawn args per chapter 05 §1 TS list. Health: 60s metrics poll, 60s self-tunnel HTTPS healthz probe. Backoff: exp capped 60s, max 10/30min, then steady-state 1 attempt per 5 min. Network-up trigger via Win SENS / mac SCNetworkReachability / Linux NetworkManager DBus (degraded slow-tick fallback). Sticky `cloudflare.unreachable` banner with "Retry now" + "View log".
+- Files: `daemon/src/cloudflared/supervisor.ts`, `daemon/src/cloudflared/health-probe.ts`, `daemon/src/cloudflared/network-watcher.ts`, `daemon/__tests__/cloudflared/lifecycle.test.ts` (chapter 08 §3 contract test).
+- Deliverable: lifecycle unit test asserts spawn → 3 fails → restart → exhaustion → slow-tick → network-up resumes.
+- Blockers: T23.
+
+**T25. Production TCP listener (`127.0.0.1:7879`) + Host header + no-JWT-exempt-routes.**
+- Layer: L2.
+- Scope: per chapter 05 §5 — third listener (`127.0.0.1:7879`, only when remote-access enabled). Host-header validation BEFORE any handler/interceptor (HTTP 421 on miss; allow-list `127.0.0.1:7879` / `localhost:7879` / configured CF Tunnel hostname). CI lint greps for any interceptor-skipping pattern on prod TCP listener. Mutual exclusion with dev TCP listener (refuses to start the other if one is engaged).
+- Files: `daemon/src/sockets/prod-tcp-listener.ts`, `daemon/src/sockets/host-header-validator.ts`, `.github/workflows/no-jwt-exempt-lint.yml`, `daemon/src/sockets/listener-mutex.ts`.
+- Deliverable: prod listener bound only when remote-enabled; 421 on bad Host; CI lint green; mutex enforced.
+- Blockers: T19, T08.
+
+**T26. JWT validation full enable (remote ingress live) + audit + new-IP banner + rate cap.**
+- Layer: L5.
+- Scope: per chapter 05 §4 + §4.1 + §4.2 — wire JWT interceptor into prod TCP listener with full claim policy (RS256, exact AUD, exact issuer, 30s clock tolerance, requiredClaims, JWKS pre-warm). Verify cache TTL = `payload.exp - now`. Per-source-IP failure cap (10 fails / 60s → HTTP 429 / 60s). Audit log `{ jwt_email, jwt_iat, source_ip, cf_ray, traceId }` on every authenticated RPC. First-seen-IP banner with revoke deep-link per chapter 05 §4 + chapter 07 §4. JWT validation matrix tests per chapter 05 §4.2 (13 cases) + recorded real-CF JWT shape fixture per chapter 05 §4.2 last paragraph.
+- Files: `daemon/src/connect/jwt-interceptor.ts` (extend T08), `daemon/src/connect/jwt-rate-limit.ts`, `daemon/src/audit/auth-log.ts`, `daemon/src/audit/first-seen-ip.ts` (LRU 1000 rows in SQLite), `src/components/AuthBanners/{NewDevice,AuthLooped}.tsx`, `daemon/test/fixtures/cf-jwt-realshape.json`, `daemon/__tests__/connect-contract/jwt-validation-matrix.test.ts`.
+- Deliverable: 13-case JWT matrix green; first-seen-IP banner fires on a synthetic new-IP test; per-IP rate cap returns 429 after 10 fails.
+- Blockers: T08, T25.
+
+**T27. Tunnel token + AUD secret-handling via OS keychain (locked scheme).**
+- Layer: L5.
+- Scope: per chapter 05 §6.1 + chapter 09 §5 deliverable 4 — keychain-only storage for tunnel token + AUD; SQLite stores keyring pointer only. `keytar` (or live alternative verified at impl time). Linux fallback: refuse remote access if no `libsecret`. SecureBuffer in-memory; pino redaction config for `/(token|secret|jwt|aud|password|authorization)/i`. Dedicated `SaveTunnelToken` RPC (zeroes after store, returns boolean only, never logged). Renderer shows `••••••••` placeholder + "Replace" button.
+- Files: `daemon/src/secrets/keychain.ts`, `daemon/src/secrets/secure-buffer.ts`, `daemon/src/secrets/pino-redact-config.ts`, `daemon/src/connect/handlers/save-tunnel-token.ts`, `proto/ccsm/v1/settings.proto` (extend), `src/components/Settings/RemoteAccess/SecretInput.tsx`.
+- Deliverable: token roundtrips through keychain; SQLite contains pointer only; pino redaction verified by log-grep test; Linux-without-libsecret refuses + surfaces wizard error.
+- Blockers: T26.
+
+**T28. Setup wizard (3-step) + Auto-start tray + Settings (TRAY IN SCOPE).**
+- Layer: L5.
+- Scope: per chapter 05 §6 + chapter 09 §5 deliverable 7 (consolidated tray-IN-scope decision) + chapter 01 G6 + A5 — Electron Settings → "Remote access" pane with 3-step wizard (tunnel token, team name + AUD, optional Pages link). Auto-start at OS boot toggle: Settings + matching tray menu item (single entry, mirrors Settings, no new states; default OFF). Win startup folder shortcut / launchd RunAtLoad / systemd `WantedBy=default.target`. Idempotent re-run; disable does not touch local data socket. Wizard scope discipline (no copy A/B testing, no inline help video, no progress animations beyond spinner). Manual auto-start verification on real Win box recorded in v0.4.0 release notes.
+- Files: `src/components/Settings/RemoteAccess/{Wizard,Step1Token,Step2Access,Step3Pages,AutoStartToggle}.tsx`, `electron/main.ts` (tray menu item), `electron/auto-start/{win,mac,linux}.ts`, `daemon/src/connect/handlers/{enable-remote,disable-remote}.ts`.
+- Deliverable: wizard captures three values, restarts remote ingress, shows resolved hostname; tray menu item present on Win/Mac/Linux; auto-start toggle persists across reboot (manual test).
+- Blockers: T24, T25, T26, T27.
+
+**T29. CF integration smoke workflow (cf-smoke.yml) + service-token rotation.**
+- Layer: L6.
+- Scope: per chapter 08 §7 — `cf-smoke.yml` triggered on (a) nightly cron, (b) release tag `v0.4.*`, (c) PR-time path-trigger on `daemon/src/connect/jwt-interceptor.ts`, `daemon/src/cloudflared/**`, `daemon/src/sockets/runtime-root.ts`. Boots real `cloudflared` against CI-only Tunnel; CI service token (separate AUD from prod). Service-token security per chapter 08 §7 (scoped, masked GH Secret, 90-day rotation, audit alert). Failure handling: nightly opens issue, release blocks tag, PR-time blocks PR.
+- Files: `.github/workflows/cf-smoke.yml`, `e2e/cf-smoke/{tunnel-handshake,real-jwt-verify}.spec.ts`, `docs/ops/cf-service-token-rotation.md`.
+- Deliverable: workflow runs on schedule + tag + path-trigger; service token rotation procedure documented; first nightly green.
+- Blockers: T28.
+
+#### Cross-cutting tasks (T30..T34) — parallelizable any time
+
+**T30. Daemon perf instrumentation + `/stats` counters.**
+- Layer: L2/L6.
+- Scope: per chapter 05 §9 + chapter 06 §5/§9 + chapter 10 R5/R5b — `perf_hooks.monitorEventLoopDelay` p50/p99 on `/stats`; RSS sampling every 5 min (`pino.info({ event: 'rss_sample', ... })`); `/stats` counters: connect-rpc requests/sec by method, JWT validation rejections/sec, `cloudflared` restart count, active stream count, fanout buffer total bytes, snapshot queue depth + wait-ms, `inputs_received[clientId, sessionId]`, `inputs_acked[clientId, sessionId]`. Heartbeats received-vs-expected per stream.
+- Files: `daemon/src/perf/{event-loop-delay,rss-sampler}.ts`, `daemon/src/handlers/stats.ts` (extend control-socket allowlist), `daemon/src/pty/fanout-registry.ts` (extend with input counters).
+- Deliverable: `/stats` returns full JSON; dogfood gate per chapter 10 R5 (RSS > 1.5 GB at 7d → ship-block) operationally verifiable.
+- Blockers: T05 (control socket carryover) — can dispatch parallel to T11+.
+
+**T31. Schema-additive migration lint.**
+- Layer: L6.
+- Scope: per chapter 09 §8 + chapter 08 — CI lint parses every migration in `daemon/src/db/migrations/` since v0.3 baseline; fails on drop-table/drop-column/alter-type/add-NOT-NULL-without-default/rename. Locks the "no destructive migrations in v0.4.x" implicit promise.
+- Files: `scripts/lint-schema-additive.ts`, `.github/workflows/schema-additive-lint.yml`.
+- Deliverable: lint green on `working` HEAD; deliberate-bad PR fails lint.
+- Blockers: none — can dispatch immediately after T01 ships its CI infrastructure.
+
+**T32. Test fixture lint (anonymization + size cap).**
+- Layer: L6.
+- Scope: per chapter 08 §8 — `scripts/lint-fixtures.ts` scans `__fixtures__/` against deny-list of regexes (`C:\\Users\\<name>`, `/Users/<name>`, `/home/<name>`, real session UUIDs from author's store, real CF account IDs, token fragments). Max 1 MB per fixture. Pre-commit hook + CI gate.
+- Files: `scripts/lint-fixtures.ts`, `.github/workflows/fixture-lint.yml`, `.git/hooks/pre-commit` template.
+- Deliverable: lint green; deliberate-bad fixture fails commit + CI.
+- Blockers: none.
+
+**T33. `--only=<case>` taxonomy generator + check.**
+- Layer: L6.
+- Scope: per chapter 08 §9.3 — `scripts/e2e-only-map.json` validated against `gen/ts/` by a CI lint per the table format (RPC → `--only` ID → layer). Worker PR template includes "`--only` ID(s) used: <list>" line; reviewer checks listed IDs cover the touched RPCs.
+- Files: `scripts/e2e-only-map.json`, `scripts/check-e2e-only-map.ts`, `.github/PULL_REQUEST_TEMPLATE.md` (extend).
+- Deliverable: lint green; PR template enforces the line.
+- Blockers: T02 (needs RPC inventory in `gen/ts/`).
+
+**T34. Pre-M4 security audit checkpoint + manual auto-start verification.**
+- Layer: L6.
+- Scope: per chapter 09 §7 — between post-M3 dogfood close and M4 start, dispatch a security-focused reviewer to audit (a) JWT interceptor vs chapter 05 §4 lock, (b) keychain integration vs chapter 05 §6.1, (c) dev TCP listener prod-gate vs chapter 09 §4 deliverable 5, (d) `cloudflared` spawn-arg + supply-chain checks. Plus the chapter 09 §5 manual auto-start verification recorded in `docs/release-notes/v0.4.0.md`. Plus the chapter 05 §7.1 7-day Cloudflare bandwidth spike result committed to `docs/spikes/2026-05-cloudflare-tunnel-bandwidth.md` BEFORE M4 start. Plus the chapter 04 §2 M1 bundle-size measurement spike committed to `docs/spikes/2026-05-web-bundle-size.md` and the size-limit threshold locked to `actual + 15%`.
+- Files: `docs/spikes/2026-05-cloudflare-tunnel-bandwidth.md`, `docs/spikes/2026-05-web-bundle-size.md`, `docs/release-notes/v0.4.0.md` (manual auto-start log), security audit report under `docs/security/2026-05-v0.4-pre-m4-audit.md`.
+- Deliverable: all four artifacts committed; any HIGH-severity audit finding blocks M4 until resolved.
+- Blockers: T17 (bundle size needs `web/` skeleton), T23-T28 (security audit needs the M4 code), T29 (CF smoke needs to be green to declare M4 ready).
+
+### Parallelism analysis
+
+**Serial bottlenecks (must merge in order):**
+- T01 → T02 → T03 → T04 → T05 (L1/L2 foundation; each strictly needs the previous).
+- T05 → T07 → T08 (Connect server → parity framework → JWT scaffold).
+- T09 → T10 → T11 (bridge swap batches A → B → C; each tier de-risks the next).
+- T11 → T12 (M2.Z cleanup must follow all 12 batch PRs + dogfood close).
+
+**Maximally parallel windows:**
+- After T05 lands: T07 + T08 + T30 + T31 + T32 can dispatch in parallel (different files, no collisions).
+- Within Batch A (T09): A.1, A.2, A.3, A.4 each touch a different bridge file and a different proto domain → 4 PRs in parallel safe.
+- Within Batch B (T10): same — 5 PRs in parallel safe (5 disjoint bridge files).
+- Within Batch C (T11): 3 PRs in parallel safe (3 disjoint bridge files).
+- After T17 lands: T18 + T19 + T20 + T21 each touch disjoint trees (`web/`, `daemon/src/dev/`, `web/src/main.tsx` + new RPC, `web/e2e/`) → 4 PRs in parallel safe with hot-file discipline below.
+- M4 phase: T23 + T31 + T32 + T33 can dispatch concurrently with T19/T20/T21 (no file collisions); T24-T28 are layered.
+- T30 (perf instrumentation), T31 (schema lint), T32 (fixture lint), T33 (taxonomy), T34 (audit checkpoints) are cross-cutting and can dispatch in any free worker slot any time after their prerequisites.
+
+**Maximum theoretical parallelism per phase:**
+- M1: 3 workers (T01 serial; then T02/T03 sequential; T04/T05/T07/T08 staggered).
+- M2 Batch A: 4 workers (one per sub-PR, hot-file-disjoint).
+- M2 Batch B: 5 workers.
+- M2 Batch C: 3 workers.
+- M3: 4 workers (T18/T19/T20/T21 after T17 lands).
+- M4: 5-6 workers (T23/T24/T25/T26/T27/T28 layered with T29 + cross-cutting).
+
+### Hot-files registry (avoid collisions per `feedback_dispatch_avoid_collisions.md`)
+
+Files where ≤1 worker may hold an open PR at a time. Worker prompts MUST list these as "do not touch unless this is your task" so independent PRs don't collide on rebase.
+
+**L1 (proto):**
+- `proto/ccsm/v1/service.proto` — umbrella service; every RPC-adding task touches it. **Workaround:** stage adds via per-domain `.proto` files; touch `service.proto` only at T02 (first inventory) and T11 (folded streams).
+- `gen/ts/**` — regenerated by every proto-touching PR; reviewer treats diff as authoritative-derived (linguist-generated).
+
+**L2 (daemon Connect server):**
+- `daemon/src/sockets/data-socket.ts` — listener wiring (T05), prod-TCP wiring (T25), envelope-deletion (T12). Strict serial across these.
+- `daemon/src/connect/server.ts` — interceptor chain order matters; only the JWT (T08, T26), storage-full (T15), migration-gate, etc. add to it. Reviewer enforces order: transport-tag → JWT → migration-gate → storage-full → deadline → trace-id → handler.
+- `daemon/src/index.ts` — daemon entry; wired by T05 + T19 + T24 + T25.
+
+**L3 (bridges):**
+- `electron/preload/bridges/ccsmCore.ts` — touched by T06, T09 (A.1), T10 (B.1), T11 (C.3 partial).
+- `electron/preload/bridges/ccsmPty.ts` — touched by T09 (A.3), T10 (B.3), T11 (C.1).
+- `electron/preload/bridges/ccsmSession.ts` — touched by T10 (B.2), T11 (C.2).
+- Strict serial WITHIN each bridge file across batches; parallel ACROSS bridge files within a batch is safe.
+- `electron/connect/ipc-transport.ts` — built once in T06; do not edit in M2 unless reconnect bug.
+
+**L4 (web client):**
+- `web/src/main.tsx` — touched by T17, T20. Schedule serial.
+- `web/src/transport.ts` — touched by T18 only.
+- `web/vite.config.ts` — touched by T17 (initial), T22 (multi-client harness setup if needed). Mostly serial.
+- `web/src/bridges/*.ts` — one per file, parallel-safe across files; reads `window.ccsm*` surface only.
+
+**L5 (Cloudflare):**
+- `daemon/src/cloudflared/supervisor.ts` — T24 only.
+- `daemon/src/connect/jwt-interceptor.ts` — T08 (scaffold), T26 (full enable). Strict serial.
+- `src/components/Settings/RemoteAccess/Wizard.tsx` — T28 only.
+
+**L6 (testing):**
+- `.github/workflows/proto.yml` — T01 (initial), T02 (idempotency lint), T31 (schema-additive lint), T32 (fixture lint). Coordinate edits.
+- `e2e/multi-client/*.spec.ts` — T13 (initial), T22 (extend). Serial.
+
+### Estimated worker count + wall-clock
+
+- **Total tasks: 34.**
+- **Maximum simultaneous workers (any phase): 6** (M4 cross-cutting peak).
+- **Serial bottleneck length:** T01 → T02 → T03 → T05 → T07 → T08 → T09(A.1) → T10(B.1) → T11(C.1) → T12 → T17 → T18 → T19 → T20 → T21 → T22 → T25 → T26 → T28 → T29 = 20 tasks on the critical path.
+- **Estimate range:** total work ~110h per chapter 09 §1 milestone estimates; with average 3-4 workers in parallel (limited by serial bottlenecks), wall-clock for the implementation phase is roughly ~30-40h compressed plus 4 dogfood gates (24h post-M1 + 7d post-M2 + 3d-or-12h post-M3 + 7d post-M4 ≈ 17 days of dogfood). Calendar ~3-4 weeks total, matching chapter 09 §1 "~110 hours" interpretation as effort-not-calendar.
+


### PR DESCRIPTION
## Summary

Stage-5 of #1049 spec-pipeline. Consolidates the 12 r2-clean chapters from `spec/2026-05-01-v0.4-web` into a single canonical `docs/superpowers/specs/2026-05-01-v0.4-web-design.md`. Adds implementation DAG appendix.

## Manager decisions folded into merge

- R1 P2 (tray scope cross-chapter contradiction): tray IS in v0.4 scope (per ch01 G6/A5); ch09 M4 deliverable #7 updated to reflect tray inclusion (single tray menu item mirroring the Settings toggle, no new states). Documented at the deliverable + in the changelog at the doc end.

## Stage-4 r2 status (all APPROVE)

- R1 feature — 12/12 APPROVE
- R2 security — clean post-#742
- R3 reliability — APPROVE, 3 P2 v0.5 deferrals (left as-is)
- R4 scalability — 12/12 APPROVE
- R5 testability — clean post-#741, 3 P2 nits left as v0.5
- R6 naming — clean post-#742

## DAG location

Appendix in the consolidated spec (not a separate file). Justification: the DAG cross-references chapters heavily ("see chapter 02 §4", "see chapter 09 M2.A") and one-document reads beat tab-flipping for reviewers and dispatch managers.

t = 34 tasks across 6 layers (L1 protocol, L2 daemon Connect server, L3 bridge swap, L4 web client, L5 Cloudflare, L6 testing/release gates). Mapping to chapter 09 milestones: M1 = T01..T08, M2 = T09..T16, M3 = T17..T22, M4 = T23..T29, cross-cutting = T30..T34.

Maximum simultaneous workers per phase: 3 (M1) → 5 (M2 Batch B) → 4 (M3) → 6 (M4 + cross-cutting peak).

Hot-files registry per `feedback_dispatch_avoid_collisions.md` is included in the appendix so future dispatch can avoid collisions on `daemon/src/sockets/data-socket.ts`, `daemon/src/connect/server.ts`, `electron/preload/bridges/ccsm{Core,Pty,Session}.ts`, `web/src/main.tsx`, `web/vite.config.ts`, etc.

## Doc shape

- Front matter: Status / Approved / Sources (with source commit SHA `a292ddb`).
- 12 sections (## 0 through ## 11) with original chapter content preserved verbatim; only headings shifted down by one level so the chapter title becomes `## N. <title>` and former H2 (`## TOC`) becomes H3 (`### TOC`), etc.
- Internal cross-refs continue to read "chapter NN §M"; readers resolve to `## NN.` in this doc.
- Final `## Changelog` records the stage-5 merge + the tray-scope manager decision + r2 sign-off + stage 1-4 history.
- `## Appendix: implementation DAG` follows the changelog with task table (T01..T34), parallelism analysis, and hot-files registry.

Source chapter directory `docs/superpowers/specs/v0.4-web-chapters/` is NOT added by this PR (the chapter branch is unmerged on `working` so there is nothing to delete; the consolidated file is the only addition).

## Test plan

- [ ] Manager reads consolidated spec front-to-back for content preservation (3174 lines, ~5-10 min).
- [ ] Manager confirms tray-scope edit at section "## 9. Release slicing" deliverable 7 reads "tray IN scope" and matches ch01 G6/A5 lock.
- [ ] Manager reviews DAG (T01..T34) for parallelism + blocker correctness, especially M2 Batch A/B/C sub-PR fan-out and M4 layered dependencies.
- [ ] After merge, manager creates 34 TaskCreate entries from DAG (per `feedback_taskcreate_no_id_prefix.md` discipline).

🤖 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>