### PR TITLE
feat(v0.4 T32): test fixture lint (anonymization + size cap)

### DIFF
--- a/.github/workflows/fixture-lint.yml
+++ b/.github/workflows/fixture-lint.yml
@@ -1,0 +1,21 @@
+name: fixture-lint
+on:
+  pull_request:
+    paths:
+      - '**/__fixtures__/**'
+      - '**/*.fixture.json'
+      - '**/test/fixtures/**'
+      - '**/__tests__/**/fixtures/**'
+      - 'scripts/lint-fixtures.ts'
+      - 'scripts/__test-uuids.txt'
+      - '.github/workflows/fixture-lint.yml'
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: npm ci
+      - run: npm run lint:fixtures

--- a/docs/dev/fixture-lint-pre-commit.md
+++ b/docs/dev/fixture-lint-pre-commit.md
@@ -1,0 +1,14 @@
+# Fixture lint pre-commit hook
+
+`scripts/lint-fixtures.ts` runs in CI on every PR that touches a fixture path. To
+catch violations earlier (before `git push`), opt in locally by symlinking the
+provided template into `.git/hooks/pre-commit`:
+
+```bash
+ln -sf ../../scripts/pre-commit-fixture-lint.sh .git/hooks/pre-commit
+```
+
+The hook only runs `npm run lint:fixtures` when the staged diff actually
+includes a fixture path, so unrelated commits stay fast. Disable any time by
+removing the symlink. The hook is intentionally not auto-installed by
+`postinstall` — pre-commit hooks are a per-developer choice.

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,11 +69,12 @@
         "autoprefixer": "^10.4.20",
         "concurrently": "^9.1.0",
         "css-loader": "^7.1.2",
-        "electron": "^41.3.0",
+        "electron": "41.3.0",
         "electron-builder": "^26.8.1",
         "eslint": "^9.17.0",
         "eslint-plugin-react": "^7.37.2",
         "eslint-plugin-react-hooks": "^5.1.0",
+        "glob": "^10.5.0",
         "html-webpack-plugin": "^5.6.3",
         "jsdom": "^29.0.2",
         "nodemon": "^3.1.14",
@@ -687,6 +688,28 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@electron/asar/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@electron/asar/node_modules/minimatch": {
@@ -2041,6 +2064,109 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/@isaacs/fs-minipass": {
@@ -3400,6 +3526,17 @@
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@prisma/instrumentation": {
       "version": "7.6.0",
@@ -8712,6 +8849,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -10099,6 +10243,36 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -10420,22 +10594,22 @@
       "license": "MIT"
     },
     "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
       },
-      "engines": {
-        "node": "*"
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -10486,27 +10660,29 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
-        "node": "*"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/global-agent": {
@@ -11920,6 +12096,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jake": {
@@ -13556,6 +13748,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/param-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -13667,6 +13866,30 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/path-to-regexp": {
       "version": "8.4.2",
@@ -15002,6 +15225,63 @@
         "rimraf": "bin.js"
       }
     },
+    "node_modules/rimraf/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/roarr": {
       "version": "2.15.4",
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
@@ -15973,6 +16253,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
@@ -16072,6 +16368,20 @@
       }
     },
     "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -18136,6 +18446,25 @@
       }
     },
     "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "build:daemon": "node -e \"require('fs').rmSync('daemon/dist-daemon',{recursive:true,force:true})\" && tsc -p daemon/tsconfig.json && node -e \"require('fs').writeFileSync('daemon/dist-daemon/package.json',JSON.stringify({type:'module'}))\"",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.electron.json && tsc --noEmit -p daemon/tsconfig.json",
     "lint": "eslint . --ext .ts,.tsx",
+    "lint:fixtures": "tsx scripts/lint-fixtures.ts",
     "test": "vitest run",
     "check:electron-pin": "node scripts/check-electron-pin.cjs",
     "pretest": "node scripts/check-electron-pin.cjs",
@@ -106,6 +107,7 @@
     "eslint": "^9.17.0",
     "eslint-plugin-react": "^7.37.2",
     "eslint-plugin-react-hooks": "^5.1.0",
+    "glob": "^10.5.0",
     "html-webpack-plugin": "^5.6.3",
     "jsdom": "^29.0.2",
     "nodemon": "^3.1.14",
@@ -139,10 +141,22 @@
     "afterPack": "scripts/after-pack.cjs",
     "afterSign": "scripts/after-sign.cjs",
     "extraResources": [
-      { "from": "daemon/native-staged", "to": "daemon/native" },
-      { "from": "daemon/sdk-staged", "to": "daemon/node_modules/@anthropic-ai/claude-agent-sdk" },
-      { "from": "daemon/deps-staged", "to": "daemon/node_modules" },
-      { "from": "node_modules/@anthropic-ai/claude-agent-sdk", "to": "sdk/claude-agent-sdk" }
+      {
+        "from": "daemon/native-staged",
+        "to": "daemon/native"
+      },
+      {
+        "from": "daemon/sdk-staged",
+        "to": "daemon/node_modules/@anthropic-ai/claude-agent-sdk"
+      },
+      {
+        "from": "daemon/deps-staged",
+        "to": "daemon/node_modules"
+      },
+      {
+        "from": "node_modules/@anthropic-ai/claude-agent-sdk",
+        "to": "sdk/claude-agent-sdk"
+      }
     ],
     "files": [
       "dist/**/*",
@@ -175,8 +189,14 @@
       "icon": "build/icon.ico",
       "artifactName": "${productName}-Setup-${version}-${arch}.${ext}",
       "extraResources": [
-        { "from": "daemon/dist/ccsm-daemon-staged.exe", "to": "daemon/ccsm-daemon.exe" },
-        { "from": "daemon/dist/ccsm-uninstall-helper.exe", "to": "daemon/ccsm-uninstall-helper.exe" }
+        {
+          "from": "daemon/dist/ccsm-daemon-staged.exe",
+          "to": "daemon/ccsm-daemon.exe"
+        },
+        {
+          "from": "daemon/dist/ccsm-uninstall-helper.exe",
+          "to": "daemon/ccsm-uninstall-helper.exe"
+        }
       ]
     },
     "nsis": {
@@ -212,7 +232,10 @@
       "gatekeeperAssess": false,
       "artifactName": "${productName}-${version}-${arch}.${ext}",
       "extraResources": [
-        { "from": "daemon/dist/ccsm-daemon-staged", "to": "daemon/ccsm-daemon" }
+        {
+          "from": "daemon/dist/ccsm-daemon-staged",
+          "to": "daemon/ccsm-daemon"
+        }
       ]
     },
     "dmg": {
@@ -245,7 +268,10 @@
       "icon": "build/icon.png",
       "artifactName": "${productName}-${version}-${arch}.${ext}",
       "extraResources": [
-        { "from": "daemon/dist/ccsm-daemon-staged", "to": "daemon/ccsm-daemon" }
+        {
+          "from": "daemon/dist/ccsm-daemon-staged",
+          "to": "daemon/ccsm-daemon"
+        }
       ]
     }
   }

--- a/scripts/__test-uuids.txt
+++ b/scripts/__test-uuids.txt
@@ -1,0 +1,7 @@
+# Allow-list of test session UUIDs that may appear in fixtures.
+# Format: one UUID per line. Lines starting with `#` are comments.
+# Add a UUID here when introducing a fictional fixture session id.
+00000000-0000-4000-8000-000000000000
+00000000-0000-4000-8000-000000000001
+11111111-1111-4111-8111-111111111111
+deadbeef-dead-4bee-8bee-deadbeefcafe

--- a/scripts/lint-fixtures.ts
+++ b/scripts/lint-fixtures.ts
@@ -1,0 +1,254 @@
+#!/usr/bin/env tsx
+/**
+ * Test fixture lint — anonymization + size cap.
+ *
+ * Per docs/superpowers/specs/2026-05-01-v0.4-web-design.md chapter 08 §8.
+ *
+ * Walks test fixture directories and scans each file for:
+ *   - Size cap: > 1 MiB → FAIL
+ *   - Real OS user paths (Windows / macOS / Linux)
+ *   - Real session UUIDs (any UUID v4 not in allow-list)
+ *   - Real Cloudflare account IDs (32 hex chars, flagged)
+ *   - JWT token fragments
+ *   - GitHub tokens
+ *   - AWS access keys
+ *
+ * Exit code 0 = clean, 1 = violations.
+ *
+ * Files under `**\/__fixtures__/anonymized/**` are exempt (intentionally
+ * anonymized examples used by tests).
+ *
+ * Allow-list of test UUIDs lives in scripts/__test-uuids.txt (one per line,
+ * `#` comments allowed). Add UUIDs there when introducing fictional fixtures.
+ */
+import { readFileSync, statSync, existsSync } from 'node:fs';
+import { resolve, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { globSync } from 'glob';
+
+const ONE_MIB = 1024 * 1024;
+
+const FIXTURE_GLOBS = [
+  '**/__fixtures__/**',
+  '**/*.fixture.json',
+  '**/test/fixtures/**',
+  '**/__tests__/**/fixtures/**',
+];
+
+// Glob patterns to ignore wholesale.
+const IGNORE = [
+  '**/node_modules/**',
+  '**/dist/**',
+  '**/dist-*/**',
+  '**/out/**',
+  '**/.git/**',
+  '**/coverage/**',
+  // Allow-listed anonymized examples — must be matched literally.
+  '**/__fixtures__/anonymized/**',
+];
+
+interface Violation {
+  file: string;
+  rule: string;
+  detail: string;
+}
+
+interface Rule {
+  name: string;
+  // If `failOnMatch` is true, presence is always a hard fail.
+  // If false, the match is reported as a violation only when not on allow-list.
+  failOnMatch: boolean;
+  pattern: RegExp;
+  // Optional per-match filter; return true to KEEP the match as a violation.
+  keep?: (match: string) => boolean;
+}
+
+function loadUuidAllowList(scriptDir: string): Set<string> {
+  const p = resolve(scriptDir, '__test-uuids.txt');
+  if (!existsSync(p)) return new Set();
+  const lines = readFileSync(p, 'utf8').split(/\r?\n/);
+  const out = new Set<string>();
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    out.add(line.toLowerCase());
+  }
+  return out;
+}
+
+function buildRules(uuidAllow: Set<string>): Rule[] {
+  return [
+    {
+      name: 'windows-user-path',
+      failOnMatch: true,
+      // C:\Users\<name>  (case-insensitive). Tolerate JSON-escaped form
+      // (`C:\\Users\\name`) so paths embedded in JSON fixtures are caught.
+      pattern: /[a-zA-Z]:\\{1,2}Users\\{1,2}[A-Za-z][A-Za-z0-9._-]*/gi,
+    },
+    {
+      name: 'macos-user-path',
+      failOnMatch: true,
+      pattern: /\/Users\/[A-Za-z][A-Za-z0-9._-]*/g,
+    },
+    {
+      name: 'linux-user-path',
+      failOnMatch: true,
+      pattern: /\/home\/[A-Za-z][A-Za-z0-9._-]*/g,
+    },
+    {
+      name: 'session-uuid',
+      failOnMatch: true,
+      pattern:
+        /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi,
+      keep: (m) => !uuidAllow.has(m.toLowerCase()),
+    },
+    {
+      name: 'cf-account-id',
+      failOnMatch: true,
+      // Must NOT be embedded in a longer hex run (e.g. file hashes).
+      // Use lookarounds for word-ish boundaries.
+      pattern: /(?<![0-9a-f])[0-9a-f]{32}(?![0-9a-f])/gi,
+    },
+    {
+      name: 'jwt-token',
+      failOnMatch: true,
+      pattern: /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g,
+    },
+    {
+      name: 'github-token',
+      failOnMatch: true,
+      pattern: /gh[pousr]_[A-Za-z0-9]{36,}/g,
+    },
+    {
+      name: 'aws-access-key',
+      failOnMatch: true,
+      pattern: /AKIA[0-9A-Z]{16}/g,
+    },
+  ];
+}
+
+function scanFile(absPath: string, rules: Rule[]): Violation[] {
+  const violations: Violation[] = [];
+  let st;
+  try {
+    st = statSync(absPath);
+  } catch {
+    return violations;
+  }
+  if (!st.isFile()) return violations;
+
+  if (st.size > ONE_MIB) {
+    violations.push({
+      file: absPath,
+      rule: 'size-cap',
+      detail: `${st.size} bytes (> ${ONE_MIB} bytes / 1 MiB)`,
+    });
+    // Don't scan content of huge files — already failing.
+    return violations;
+  }
+
+  let buf: Buffer;
+  try {
+    buf = readFileSync(absPath);
+  } catch {
+    return violations;
+  }
+  // Skip apparent binaries (NUL bytes in first 8 KiB).
+  const sniff = buf.subarray(0, 8192);
+  for (const b of sniff) {
+    if (b === 0) return violations;
+  }
+  const text = buf.toString('utf8');
+
+  for (const rule of rules) {
+    const matches = text.matchAll(rule.pattern);
+    const seen = new Set<string>();
+    for (const m of matches) {
+      const value = m[0];
+      if (rule.keep && !rule.keep(value)) continue;
+      if (seen.has(value)) continue;
+      seen.add(value);
+      violations.push({
+        file: absPath,
+        rule: rule.name,
+        detail: value,
+      });
+    }
+  }
+  return violations;
+}
+
+export interface LintOptions {
+  cwd: string;
+  scriptDir: string;
+  // Optional override of fixture globs (used by tests).
+  fixtureGlobs?: string[];
+  // Optional override of ignore globs (used by tests to drop the
+  // anonymized allow-list when verifying allow-list behavior).
+  ignore?: string[];
+}
+
+export interface LintResult {
+  scanned: number;
+  violations: Violation[];
+}
+
+export function lintFixtures(opts: LintOptions): LintResult {
+  const uuidAllow = loadUuidAllowList(opts.scriptDir);
+  const rules = buildRules(uuidAllow);
+  const globs = opts.fixtureGlobs ?? FIXTURE_GLOBS;
+  const ignore = opts.ignore ?? IGNORE;
+
+  const seen = new Set<string>();
+  for (const pattern of globs) {
+    const hits = globSync(pattern, {
+      cwd: opts.cwd,
+      ignore,
+      nodir: true,
+      absolute: true,
+      dot: false,
+    });
+    for (const h of hits) seen.add(h);
+  }
+
+  const violations: Violation[] = [];
+  for (const file of seen) {
+    violations.push(...scanFile(file, rules));
+  }
+  return { scanned: seen.size, violations };
+}
+
+function formatViolation(v: Violation, cwd: string): string {
+  const rel = relative(cwd, v.file).split(sep).join('/');
+  return `  [${v.rule}] ${rel}: ${v.detail}`;
+}
+
+function main(): void {
+  const cwd = process.cwd();
+  // scripts/lint-fixtures.ts → scriptDir = scripts/
+  const scriptDir = resolve(fileURLToPath(import.meta.url), '..');
+  const result = lintFixtures({ cwd, scriptDir });
+
+  if (result.violations.length === 0) {
+    process.stdout.write(
+      `lint-fixtures: scanned ${result.scanned} file(s), no violations.\n`,
+    );
+    process.exit(0);
+  }
+
+  process.stdout.write(
+    `lint-fixtures: scanned ${result.scanned} file(s), ${result.violations.length} violation(s):\n`,
+  );
+  for (const v of result.violations) {
+    process.stdout.write(formatViolation(v, cwd) + '\n');
+  }
+  process.exit(1);
+}
+
+// Only run main() when invoked as a script, not when imported by tests.
+const invokedDirectly =
+  import.meta.url === `file://${process.argv[1]}` ||
+  fileURLToPath(import.meta.url) === resolve(process.argv[1] ?? '');
+if (invokedDirectly) {
+  main();
+}

--- a/scripts/pre-commit-fixture-lint.sh
+++ b/scripts/pre-commit-fixture-lint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Optional pre-commit hook for fixture lint.
+#
+# Symlink this into .git/hooks/pre-commit to enable per developer:
+#   ln -sf ../../scripts/pre-commit-fixture-lint.sh .git/hooks/pre-commit
+#
+# See docs/dev/fixture-lint-pre-commit.md.
+set -e
+if git diff --cached --name-only | grep -qE '(__fixtures__|\.fixture\.json|test/fixtures|__tests__/.*/fixtures)'; then
+  npm run lint:fixtures
+fi

--- a/tests/scripts/lint-fixtures.test.ts
+++ b/tests/scripts/lint-fixtures.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Unit tests for scripts/lint-fixtures.ts.
+ *
+ * Each test builds a small filesystem under a tmp dir and invokes the
+ * exported `lintFixtures()` API. Walking the real fixture tree is also
+ * covered transitively by the CI workflow gate.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { lintFixtures } from '../../scripts/lint-fixtures';
+
+const SCRIPT_DIR = resolve(__dirname, '..', '..', 'scripts');
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'lint-fixtures-'));
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function write(relPath: string, content: string | Buffer): string {
+  const abs = join(tmpRoot, relPath);
+  mkdirSync(join(abs, '..'), { recursive: true });
+  writeFileSync(abs, content);
+  return abs;
+}
+
+describe('lint-fixtures', () => {
+  it('returns no violations for a clean small fixture', () => {
+    write(
+      'pkg/__fixtures__/good.json',
+      JSON.stringify({ hello: 'world', count: 42 }),
+    );
+    const result = lintFixtures({ cwd: tmpRoot, scriptDir: SCRIPT_DIR });
+    expect(result.scanned).toBeGreaterThanOrEqual(1);
+    expect(result.violations).toEqual([]);
+  });
+
+  it('flags Windows real-user paths', () => {
+    write(
+      'pkg/__fixtures__/winpath.json',
+      JSON.stringify({ p: 'C:\\Users\\realname\\Desktop\\foo.txt' }),
+    );
+    const result = lintFixtures({ cwd: tmpRoot, scriptDir: SCRIPT_DIR });
+    expect(result.violations.length).toBeGreaterThan(0);
+    const names = result.violations.map((v) => v.rule);
+    expect(names).toContain('windows-user-path');
+  });
+
+  it('flags JWT tokens', () => {
+    const jwt =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTYifQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+    write('pkg/__fixtures__/with-jwt.txt', `token=${jwt}`);
+    const result = lintFixtures({ cwd: tmpRoot, scriptDir: SCRIPT_DIR });
+    const names = result.violations.map((v) => v.rule);
+    expect(names).toContain('jwt-token');
+  });
+
+  it('flags fixtures larger than 1 MiB with a size message', () => {
+    // 1 MiB + 1 byte of plain ASCII so we hit the size check, not content.
+    const big = Buffer.alloc(1024 * 1024 + 1, 0x61); // 'a'
+    write('pkg/__fixtures__/huge.json', big);
+    const result = lintFixtures({ cwd: tmpRoot, scriptDir: SCRIPT_DIR });
+    const sizeViolations = result.violations.filter(
+      (v) => v.rule === 'size-cap',
+    );
+    expect(sizeViolations.length).toBe(1);
+    expect(sizeViolations[0].detail).toMatch(/bytes/);
+    expect(sizeViolations[0].detail).toMatch(/1 MiB/);
+  });
+
+  it('exempts files under __fixtures__/anonymized/ even with PII-looking text', () => {
+    write(
+      'pkg/__fixtures__/anonymized/example.json',
+      JSON.stringify({
+        winPath: 'C:\\Users\\realname\\code',
+        macPath: '/Users/realname/code',
+        token:
+          'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhYmMifQ.4wIPSF98PuB5QgCHRzU3qJrfOsRJM9HLR8MccWBpZJM',
+      }),
+    );
+    const result = lintFixtures({ cwd: tmpRoot, scriptDir: SCRIPT_DIR });
+    expect(result.violations).toEqual([]);
+  });
+
+  it('flags real-looking session UUIDs not in the allow-list', () => {
+    write(
+      'pkg/__fixtures__/uuid-bad.json',
+      JSON.stringify({ sessionId: 'a1b2c3d4-e5f6-4789-9abc-1234567890ab' }),
+    );
+    const result = lintFixtures({ cwd: tmpRoot, scriptDir: SCRIPT_DIR });
+    const names = result.violations.map((v) => v.rule);
+    expect(names).toContain('session-uuid');
+  });
+
+  it('accepts session UUIDs that appear in the allow-list', () => {
+    // Allow-listed in scripts/__test-uuids.txt.
+    write(
+      'pkg/__fixtures__/uuid-good.json',
+      JSON.stringify({ sessionId: '00000000-0000-4000-8000-000000000000' }),
+    );
+    const result = lintFixtures({ cwd: tmpRoot, scriptDir: SCRIPT_DIR });
+    const uuidViolations = result.violations.filter(
+      (v) => v.rule === 'session-uuid',
+    );
+    expect(uuidViolations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Implements **Task #1081 / v0.4 DAG T32** per `docs/superpowers/specs/2026-05-01-v0.4-web-design.md` chapter 08 §8: a deny-list lint over test fixture files plus a 1 MiB size cap, gated in CI and optionally as a local pre-commit hook.

## Files

- `scripts/lint-fixtures.ts` — main lint script (Node / tsx, ESM, exports `lintFixtures()` for tests).
- `scripts/__test-uuids.txt` — allow-list of fictional session UUIDs that may legitimately appear in fixtures.
- `scripts/pre-commit-fixture-lint.sh` — opt-in pre-commit hook template.
- `docs/dev/fixture-lint-pre-commit.md` — install instructions for the hook (one paragraph).
- `.github/workflows/fixture-lint.yml` — PR gate; runs on changes to fixture paths or the script.
- `tests/scripts/lint-fixtures.test.ts` — 7 vitest cases.
- `package.json` — adds `glob@^10` devDep and `lint:fixtures` script.

## Deny-list

Each rule below produces a violation (exit 1) when matched; `__fixtures__/anonymized/**` is exempt to allow intentionally-anonymized examples in tests.

| Rule | Pattern |
| --- | --- |
| `windows-user-path` | `[a-zA-Z]:\{1,2}Users\{1,2}<name>` (tolerates JSON-escaped form) |
| `macos-user-path` | `/Users/<name>` |
| `linux-user-path` | `/home/<name>` |
| `session-uuid` | UUID v4 not on `scripts/__test-uuids.txt` allow-list |
| `cf-account-id` | 32 hex chars with non-hex word boundaries |
| `jwt-token` | `eyJ...\....\....` |
| `github-token` | `gh[pousr]_[A-Za-z0-9]{36,}` |
| `aws-access-key` | `AKIA[0-9A-Z]{16}` |
| `size-cap` | file > 1 MiB |

Files with NUL bytes in the first 8 KiB are treated as binary and skipped (cap still applies).

## Reverse-verify

**Mutation A** — drop `windows-user-path` rule from the script:

```
 FAIL  tests/scripts/lint-fixtures.test.ts > lint-fixtures > flags Windows real-user paths
AssertionError: expected 0 to be greater than 0
 ❯ tests/scripts/lint-fixtures.test.ts:50:38
     48|     );
     49|     const result = lintFixtures({ cwd: tmpRoot, scriptDir: SCRIPT_DIR …
     50|     expect(result.violations.length).toBeGreaterThan(0);
       |                                      ^
 Test Files  1 failed (1)
      Tests  1 failed | 6 skipped (7)
```

Restored. Suite back to green.

**Mutation B** — gate the size-cap branch with `if (false && st.size > ONE_MIB)`:

```
 FAIL  tests/scripts/lint-fixtures.test.ts > lint-fixtures > flags fixtures larger than 1 MiB with a size message
AssertionError: expected +0 to be 1 // Object.is equality
- Expected
+ Received
- 1
+ 0
 ❯ tests/scripts/lint-fixtures.test.ts:72:35
     70|       (v) => v.rule === 'size-cap',
     71|     );
     72|     expect(sizeViolations.length).toBe(1);
       |                                   ^
 Test Files  1 failed (1)
      Tests  1 failed | 6 skipped (7)
```

Restored. Suite back to green.

## Current-HEAD violations

```
$ npm run lint:fixtures
lint-fixtures: scanned 0 file(s), no violations.
```

The repo currently has zero matching fixture files (v0.4 fixture work has not landed yet), so the gate goes green from day one. Per spec hard rule, **no existing files were touched** — any future violations introduced by other v0.4 PRs will be fixed in their own follow-ups, not here.

## Verification

- `npm run lint:fixtures` → exit 0, 0 files scanned.
- `npx vitest run tests/scripts/lint-fixtures.test.ts` → 7/7 passed.
- `npm run typecheck` → clean.

## Test plan

- [x] Unit: 7 vitest cases (good / win path / JWT / size cap / anonymized exemption / UUID disallowed / UUID allow-listed)
- [x] Reverse-verify A (drop win regex) → matching test FAILs
- [x] Reverse-verify B (drop size cap) → size-cap test FAILs
- [x] `npm run lint:fixtures` clean against working HEAD
- [x] `npm run typecheck` clean
- [ ] CI: `fixture-lint.yml` triggers and passes (verified once PR opens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>