### PR TITLE
feat(v0.4 T31): schema-additive migration lint

### DIFF
--- a/.github/workflows/schema-additive-lint.yml
+++ b/.github/workflows/schema-additive-lint.yml
@@ -1,0 +1,17 @@
+name: schema-additive-lint
+on:
+  pull_request:
+    paths:
+      - 'daemon/src/db/migrations/**'
+      - 'scripts/lint-schema-additive.ts'
+      - 'daemon/src/db/migrations/.v03-baseline'
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: npm ci
+      - run: npm run lint:schema-additive

--- a/daemon/src/db/migrations/.v03-baseline
+++ b/daemon/src/db/migrations/.v03-baseline
@@ -1,0 +1,15 @@
+# v0.3 migration baseline marker.
+#
+# The first non-empty, non-comment line below is the filename of the LAST
+# v0.3-era migration in this directory. The schema-additive lint
+# (`scripts/lint-schema-additive.ts`) only enforces additive rules on
+# migrations whose filenames sort AFTER this baseline.
+#
+# v0.3 shipped its schema as a single canonical SQL file
+# (`daemon/src/db/schema/v0.3.sql`) applied by the migration runner / fresh
+# install path; there are no per-step migration files in this directory
+# from the v0.3 era. Use the sentinel `__none__` to mean "no v0.3-era
+# migrations exist; every migration in this directory is post-baseline and
+# must be additive per docs/superpowers/specs/2026-05-01-v0.4-web-design.md
+# chapter 09 §8".
+__none__

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.electron.json && tsc --noEmit -p daemon/tsconfig.json",
     "lint": "eslint . --ext .ts,.tsx",
     "lint:fixtures": "tsx scripts/lint-fixtures.ts",
+    "lint:schema-additive": "tsx scripts/lint-schema-additive.ts",
     "test": "vitest run",
     "check:electron-pin": "node scripts/check-electron-pin.cjs",
     "pretest": "node scripts/check-electron-pin.cjs",

--- a/scripts/lint-schema-additive.ts
+++ b/scripts/lint-schema-additive.ts
@@ -1,0 +1,387 @@
+#!/usr/bin/env tsx
+/**
+ * Schema-additive migration lint.
+ *
+ * Per docs/superpowers/specs/2026-05-01-v0.4-web-design.md chapter 09 §8
+ * (schema-additive promise) and chapter 08 (lint workflows pattern), and
+ * DAG appendix T31.
+ *
+ * Walks every `.sql` migration in `daemon/src/db/migrations/` (recursive)
+ * AFTER the v0.3 baseline and fails if any contains a destructive change:
+ *
+ *   - DROP TABLE
+ *   - DROP COLUMN
+ *   - ALTER COLUMN ... TYPE / ALTER COLUMN ... SET DATA TYPE
+ *   - ADD COLUMN ... NOT NULL  WITHOUT a DEFAULT clause
+ *   - RENAME TABLE / RENAME COLUMN / ALTER TABLE ... RENAME ...
+ *
+ * Allowed: ADD TABLE, ADD COLUMN nullable, ADD COLUMN NOT NULL DEFAULT ...,
+ * ADD INDEX, ADD CHECK, CREATE TRIGGER (additive), etc.
+ *
+ * Baseline detection (first match wins):
+ *   1. `V03_BASELINE_MIGRATION` constant below (override),
+ *   2. `daemon/src/db/migrations/.v03-baseline` file (one filename, or the
+ *      sentinel `__none__` meaning "no v0.3-era migrations exist; every
+ *      migration in this directory is post-baseline").
+ *
+ * Exit code 0 = clean, 1 = violations.
+ */
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { resolve, relative, sep, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Optional override. When non-empty, takes precedence over the
+ * `.v03-baseline` file. Set this if you need to lock the baseline from the
+ * script itself (e.g. for an emergency CI patch). Use `__none__` to mean
+ * "no v0.3-era migrations exist".
+ */
+const V03_BASELINE_MIGRATION = '';
+
+const NO_BASELINE_SENTINEL = '__none__';
+
+interface Violation {
+  file: string;
+  line: number;
+  rule: string;
+  matched: string;
+  remediation: string;
+}
+
+interface Rule {
+  name: string;
+  /**
+   * Pattern is matched against each logical SQL statement (semicolon-split,
+   * comments stripped). The `lineFor` callback maps the matched substring
+   * back to a 1-based line number in the original file.
+   */
+  pattern: RegExp;
+  remediation: string;
+}
+
+const RULES: Rule[] = [
+  {
+    name: 'DROP TABLE',
+    pattern: /\bDROP\s+TABLE\b/i,
+    remediation:
+      'Schema changes must be additive in v0.4.x. Land a v0.5 schema-break announcement first; do not drop tables.',
+  },
+  {
+    name: 'DROP COLUMN',
+    pattern: /\bDROP\s+COLUMN\b/i,
+    remediation:
+      'Schema changes must be additive in v0.4.x. Stop writing the column instead of dropping it; reclaim the slot in v0.5.',
+  },
+  {
+    name: 'ALTER COLUMN type change',
+    // ALTER COLUMN <name> TYPE ...  /  ALTER COLUMN <name> SET DATA TYPE ...
+    pattern: /\bALTER\s+COLUMN\s+\S+\s+(?:SET\s+DATA\s+)?TYPE\b/i,
+    remediation:
+      'Add a new column with the desired type and dual-write; do not change a column type in place.',
+  },
+  {
+    name: 'ADD COLUMN NOT NULL without DEFAULT',
+    // Bare ADD COLUMN ... NOT NULL with no DEFAULT clause anywhere in the
+    // statement. The full-statement matcher below handles this.
+    pattern: /\bADD\s+COLUMN\b[\s\S]*?\bNOT\s+NULL\b/i,
+    remediation:
+      'Either drop NOT NULL or supply a DEFAULT so existing rows have a value: ADD COLUMN x INTEGER NOT NULL DEFAULT 0.',
+  },
+  {
+    name: 'RENAME (table or column)',
+    // RENAME TABLE ... / ALTER TABLE x RENAME TO ... / RENAME COLUMN ...
+    pattern: /\bRENAME\s+(?:TABLE\b|COLUMN\b|TO\b)/i,
+    remediation:
+      'Renames break v0.3 readers. Add a new table/column, dual-write, and remove the old name in v0.5.',
+  },
+];
+
+/**
+ * Strip SQL comments (-- line and /* block * /) but preserve line breaks so
+ * line numbers stay aligned with the original.
+ */
+function stripComments(sql: string): string {
+  let out = '';
+  let i = 0;
+  while (i < sql.length) {
+    const c = sql[i];
+    const next = sql[i + 1];
+    if (c === '-' && next === '-') {
+      // line comment
+      while (i < sql.length && sql[i] !== '\n') {
+        out += sql[i] === '\n' ? '\n' : ' ';
+        i++;
+      }
+    } else if (c === '/' && next === '*') {
+      i += 2;
+      while (i < sql.length && !(sql[i] === '*' && sql[i + 1] === '/')) {
+        out += sql[i] === '\n' ? '\n' : ' ';
+        i++;
+      }
+      i += 2; // skip closing */ if present
+    } else if (c === "'") {
+      out += c;
+      i++;
+      while (i < sql.length) {
+        out += sql[i];
+        if (sql[i] === "'" && sql[i + 1] !== "'") {
+          i++;
+          break;
+        }
+        if (sql[i] === "'" && sql[i + 1] === "'") {
+          out += sql[i + 1];
+          i += 2;
+          continue;
+        }
+        i++;
+      }
+    } else {
+      out += c;
+      i++;
+    }
+  }
+  return out;
+}
+
+interface Statement {
+  text: string;
+  /** 1-based line number where this statement starts in the original file. */
+  startLine: number;
+}
+
+function splitStatements(sql: string): Statement[] {
+  const cleaned = stripComments(sql);
+  const out: Statement[] = [];
+  let buf = '';
+  let startLine = 1;
+  let line = 1;
+  let pendingNewStmt = true;
+  for (let i = 0; i < cleaned.length; i++) {
+    const c = cleaned[i];
+    if (pendingNewStmt) {
+      if (/\S/.test(c)) {
+        startLine = line;
+        pendingNewStmt = false;
+      } else {
+        // Drop leading whitespace so line offsets within `buf` align with
+        // `startLine`.
+        if (c === '\n') line++;
+        continue;
+      }
+    }
+    if (c === ';') {
+      if (buf.trim().length > 0) {
+        out.push({ text: buf, startLine });
+      }
+      buf = '';
+      pendingNewStmt = true;
+    } else {
+      buf += c;
+    }
+    if (c === '\n') line++;
+  }
+  if (buf.trim().length > 0) {
+    out.push({ text: buf, startLine });
+  }
+  return out;
+}
+
+function lineOffsetWithin(text: string, matchIndex: number): number {
+  let n = 0;
+  for (let i = 0; i < matchIndex && i < text.length; i++) {
+    if (text[i] === '\n') n++;
+  }
+  return n;
+}
+
+function checkStatement(stmt: Statement, rule: Rule): Violation | null {
+  const m = rule.pattern.exec(stmt.text);
+  if (!m) return null;
+
+  if (rule.name === 'ADD COLUMN NOT NULL without DEFAULT') {
+    // Re-check the WHOLE statement: only fail when there is no DEFAULT clause.
+    if (/\bDEFAULT\b/i.test(stmt.text)) return null;
+  }
+
+  const line = stmt.startLine + lineOffsetWithin(stmt.text, m.index);
+  // Trim matched substring for readable output.
+  const matched = m[0].replace(/\s+/g, ' ').trim();
+  return {
+    file: '',
+    line,
+    rule: rule.name,
+    matched,
+    remediation: rule.remediation,
+  };
+}
+
+export function lintSqlText(sql: string): Omit<Violation, 'file'>[] {
+  const stmts = splitStatements(sql);
+  const out: Omit<Violation, 'file'>[] = [];
+  for (const stmt of stmts) {
+    for (const rule of RULES) {
+      const v = checkStatement(stmt, rule);
+      if (v) {
+        const { file: _ignored, ...rest } = v;
+        void _ignored;
+        out.push(rest);
+      }
+    }
+  }
+  return out;
+}
+
+function listSqlFiles(root: string): string[] {
+  const out: string[] = [];
+  if (!existsSync(root)) return out;
+  const stack: string[] = [root];
+  while (stack.length) {
+    const dir = stack.pop()!;
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const e of entries) {
+      const p = join(dir, e.name);
+      if (e.isDirectory()) {
+        stack.push(p);
+      } else if (e.isFile() && /\.sql$/i.test(e.name)) {
+        out.push(p);
+      }
+    }
+  }
+  return out.sort();
+}
+
+function readBaseline(
+  migrationsDir: string,
+  override: string,
+): { baseline: string; source: string } {
+  if (override.trim().length > 0) {
+    return { baseline: override.trim(), source: 'V03_BASELINE_MIGRATION' };
+  }
+  const baselineFile = join(migrationsDir, '.v03-baseline');
+  if (!existsSync(baselineFile)) {
+    throw new Error(
+      `lint-schema-additive: cannot find baseline. Expected ` +
+        `${baselineFile} (or set V03_BASELINE_MIGRATION in scripts/lint-schema-additive.ts).`,
+    );
+  }
+  const text = readFileSync(baselineFile, 'utf8');
+  // First non-empty, non-comment line is the baseline.
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    return { baseline: line, source: relative(process.cwd(), baselineFile) };
+  }
+  throw new Error(
+    `lint-schema-additive: ${baselineFile} contains no baseline filename ` +
+      `(use the sentinel "__none__" if there are no v0.3-era migrations).`,
+  );
+}
+
+export interface LintOptions {
+  cwd: string;
+  /** Absolute path to migrations dir. */
+  migrationsDir: string;
+  /** Override baseline; if empty, falls back to .v03-baseline file. */
+  baselineOverride?: string;
+}
+
+export interface LintResult {
+  baseline: string;
+  baselineSource: string;
+  scanned: number;
+  skipped: number;
+  violations: Violation[];
+}
+
+export function lintSchemaAdditive(opts: LintOptions): LintResult {
+  const { baseline, source } = readBaseline(
+    opts.migrationsDir,
+    opts.baselineOverride ?? '',
+  );
+
+  const allFiles = listSqlFiles(opts.migrationsDir);
+  const violations: Violation[] = [];
+  let scanned = 0;
+  let skipped = 0;
+
+  for (const abs of allFiles) {
+    const rel = relative(opts.migrationsDir, abs).split(sep).join('/');
+    // Filename order used for "since baseline".
+    if (baseline !== NO_BASELINE_SENTINEL && rel <= baseline) {
+      skipped++;
+      continue;
+    }
+    scanned++;
+    const sql = readFileSync(abs, 'utf8');
+    const fileViolations = lintSqlText(sql);
+    for (const v of fileViolations) {
+      violations.push({ ...v, file: abs });
+    }
+  }
+
+  return {
+    baseline,
+    baselineSource: source,
+    scanned,
+    skipped,
+    violations,
+  };
+}
+
+function formatViolation(v: Violation, cwd: string): string {
+  const rel = relative(cwd, v.file).split(sep).join('/');
+  return (
+    `  ${rel}:${v.line}  [${v.rule}]  ${v.matched}\n` +
+    `      hint: ${v.remediation}`
+  );
+}
+
+function main(): void {
+  const cwd = process.cwd();
+  const migrationsDir = resolve(cwd, 'daemon/src/db/migrations');
+  let result: LintResult;
+  try {
+    result = lintSchemaAdditive({
+      cwd,
+      migrationsDir,
+      baselineOverride: V03_BASELINE_MIGRATION,
+    });
+  } catch (e) {
+    process.stderr.write(`${(e as Error).message}\n`);
+    process.exit(1);
+    return;
+  }
+
+  if (result.violations.length === 0) {
+    process.stdout.write(
+      `lint-schema-additive: baseline=${result.baseline} ` +
+        `(via ${result.baselineSource}); ` +
+        `scanned ${result.scanned} migration(s) since baseline ` +
+        `(skipped ${result.skipped}); no violations.\n`,
+    );
+    process.exit(0);
+  }
+
+  process.stdout.write(
+    `lint-schema-additive: baseline=${result.baseline} ` +
+      `(via ${result.baselineSource}); ` +
+      `scanned ${result.scanned} migration(s) since baseline ` +
+      `(skipped ${result.skipped}); ${result.violations.length} violation(s):\n`,
+  );
+  for (const v of result.violations) {
+    process.stdout.write(formatViolation(v, cwd) + '\n');
+  }
+  process.exit(1);
+}
+
+const invokedDirectly =
+  import.meta.url === `file://${process.argv[1]}` ||
+  fileURLToPath(import.meta.url) === resolve(process.argv[1] ?? '');
+if (invokedDirectly) {
+  main();
+}

--- a/tests/scripts/lint-schema-additive.test.ts
+++ b/tests/scripts/lint-schema-additive.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Unit tests for scripts/lint-schema-additive.ts.
+ *
+ * Each test builds a small migrations tree under a tmp dir with an
+ * explicit `.v03-baseline` and invokes the exported `lintSchemaAdditive()`
+ * API. Walking the real `daemon/src/db/migrations/` tree is covered
+ * transitively by the CI workflow gate.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { lintSchemaAdditive } from '../../scripts/lint-schema-additive';
+
+let tmpRoot: string;
+let migrationsDir: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'lint-schema-additive-'));
+  migrationsDir = join(tmpRoot, 'migrations');
+  mkdirSync(migrationsDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function writeMigration(name: string, sql: string): string {
+  const abs = join(migrationsDir, name);
+  writeFileSync(abs, sql);
+  return abs;
+}
+
+function writeBaseline(content: string): void {
+  writeFileSync(join(migrationsDir, '.v03-baseline'), content);
+}
+
+describe('lint-schema-additive', () => {
+  it('exit 0: ADD TABLE is additive', () => {
+    writeBaseline('__none__');
+    writeMigration(
+      '0001_add_session_index.sql',
+      `CREATE TABLE sessions_v2 (
+         id TEXT PRIMARY KEY,
+         created_at INTEGER NOT NULL DEFAULT 0
+       );`,
+    );
+    const r = lintSchemaAdditive({ cwd: tmpRoot, migrationsDir });
+    expect(r.violations).toEqual([]);
+    expect(r.scanned).toBe(1);
+  });
+
+  it('exit 0: ADD COLUMN nullable is additive', () => {
+    writeBaseline('__none__');
+    writeMigration(
+      '0001_add_nullable_col.sql',
+      `ALTER TABLE sessions ADD COLUMN nickname TEXT;`,
+    );
+    const r = lintSchemaAdditive({ cwd: tmpRoot, migrationsDir });
+    expect(r.violations).toEqual([]);
+  });
+
+  it('exit 0: ADD COLUMN NOT NULL DEFAULT 0 is additive', () => {
+    writeBaseline('__none__');
+    writeMigration(
+      '0001_add_not_null_default.sql',
+      `ALTER TABLE sessions ADD COLUMN retries INTEGER NOT NULL DEFAULT 0;`,
+    );
+    const r = lintSchemaAdditive({ cwd: tmpRoot, migrationsDir });
+    expect(r.violations).toEqual([]);
+  });
+
+  it('exit 1: DROP TABLE flagged with file:line', () => {
+    writeBaseline('__none__');
+    const file = writeMigration(
+      '0001_drop_old.sql',
+      `-- destructive
+DROP TABLE old_sessions;`,
+    );
+    const r = lintSchemaAdditive({ cwd: tmpRoot, migrationsDir });
+    expect(r.violations.length).toBeGreaterThan(0);
+    const v = r.violations.find((x) => x.rule === 'DROP TABLE');
+    expect(v).toBeDefined();
+    expect(v!.file).toBe(file);
+    expect(v!.line).toBe(2);
+  });
+
+  it('exit 1: DROP COLUMN flagged', () => {
+    writeBaseline('__none__');
+    writeMigration(
+      '0001_drop_col.sql',
+      `ALTER TABLE sessions DROP COLUMN obsolete;`,
+    );
+    const r = lintSchemaAdditive({ cwd: tmpRoot, migrationsDir });
+    const names = r.violations.map((v) => v.rule);
+    expect(names).toContain('DROP COLUMN');
+  });
+
+  it('exit 1: ADD COLUMN NOT NULL without DEFAULT is flagged', () => {
+    writeBaseline('__none__');
+    writeMigration(
+      '0001_add_not_null.sql',
+      `ALTER TABLE sessions ADD COLUMN required_field TEXT NOT NULL;`,
+    );
+    const r = lintSchemaAdditive({ cwd: tmpRoot, migrationsDir });
+    const names = r.violations.map((v) => v.rule);
+    expect(names).toContain('ADD COLUMN NOT NULL without DEFAULT');
+  });
+
+  it('exit 1: RENAME COLUMN flagged', () => {
+    writeBaseline('__none__');
+    writeMigration(
+      '0001_rename.sql',
+      `ALTER TABLE sessions RENAME COLUMN old_name TO new_name;`,
+    );
+    const r = lintSchemaAdditive({ cwd: tmpRoot, migrationsDir });
+    const names = r.violations.map((v) => v.rule);
+    expect(names).toContain('RENAME (table or column)');
+  });
+
+  it('exit 1: ALTER COLUMN ... TYPE flagged', () => {
+    writeBaseline('__none__');
+    writeMigration(
+      '0001_alter_type.sql',
+      `ALTER TABLE sessions ALTER COLUMN created_at TYPE BIGINT;`,
+    );
+    const r = lintSchemaAdditive({ cwd: tmpRoot, migrationsDir });
+    const names = r.violations.map((v) => v.rule);
+    expect(names).toContain('ALTER COLUMN type change');
+  });
+
+  it('exit 0: migration before/at baseline is ignored regardless of content', () => {
+    writeBaseline('0099_last_v03.sql');
+    // This destructive file is at-or-before baseline → ignored.
+    writeMigration('0099_last_v03.sql', `DROP TABLE legacy;`);
+    // Confirm post-baseline files still get linted (sanity).
+    writeMigration(
+      '0100_post.sql',
+      `CREATE TABLE noted (id INTEGER PRIMARY KEY);`,
+    );
+    const r = lintSchemaAdditive({ cwd: tmpRoot, migrationsDir });
+    expect(r.violations).toEqual([]);
+    expect(r.skipped).toBe(1);
+    expect(r.scanned).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

CI lint that walks every `.sql` migration in `daemon/src/db/migrations/`
since the v0.3 baseline and fails on destructive changes. Locks the
"no destructive migrations in v0.4.x" implicit promise from chapter 09 §8
of the v0.4 web design spec, making a future PR that quietly drops a
column / renames a table / adds a NOT NULL without default a CI failure
rather than a silent v0.4.x → v0.3 data-loss vector.

Task: #1083 (v0.4 T31).

## Files

- `scripts/lint-schema-additive.ts` — tsx-runnable Node script.
- `daemon/src/db/migrations/.v03-baseline` — single-line baseline marker.
- `.github/workflows/schema-additive-lint.yml` — PR-trigger workflow.
- `tests/scripts/lint-schema-additive.test.ts` — 9 vitest cases.
- `package.json` — adds `lint:schema-additive` script.

## Baseline filename chosen

`__none__` (sentinel).

**Rationale:** v0.3 shipped its schema as a single canonical SQL file
(`daemon/src/db/schema/v0.3.sql`) applied by the migration runner / fresh
install path; there are zero per-step migration files in
`daemon/src/db/migrations/` from the v0.3 era (the directory itself is
created by this PR). The sentinel `__none__` makes the script treat
every migration in the directory as post-baseline and therefore subject
to the additive rules. When v0.4 lands its first per-step migration, no
baseline change is needed; when v0.5 wants to start a fresh post-break
schema, replace the sentinel with the filename of the last v0.4
migration.

## Deny-list (case-insensitive, per logical SQL statement)

| Rule | Pattern | Allowed escape hatch |
| --- | --- | --- |
| `DROP TABLE` | `\bDROP\s+TABLE\b` | none — must wait for v0.5 break |
| `DROP COLUMN` | `\bDROP\s+COLUMN\b` | stop writing the column instead |
| `ALTER COLUMN type change` | `\bALTER\s+COLUMN\s+\S+\s+(?:SET\s+DATA\s+)?TYPE\b` | add a new column with the new type and dual-write |
| `ADD COLUMN NOT NULL without DEFAULT` | `\bADD\s+COLUMN\b...\bNOT\s+NULL\b` and statement has no `DEFAULT` clause | `ADD COLUMN x INTEGER NOT NULL DEFAULT 0` |
| `RENAME (table or column)` | `\bRENAME\s+(?:TABLE\b|COLUMN\b|TO\b)` | additive new name + dual-write |

Allowed (not flagged): `ADD TABLE`, `ADD COLUMN nullable`, `ADD INDEX`,
`ADD CHECK`, `CREATE TRIGGER` additive.

The script splits files into logical statements (semicolon-delimited,
SQL line + block comments stripped, single-quoted literals respected),
matches each rule against each statement, and reports `file:line` plus a
remediation hint per violation. Comments containing the forbidden
keywords do not trigger the rule.

## Reverse-verify

Two mutations applied in turn, each confirms the corresponding test
goes RED. Restored after each, full suite then green.

### A. Disable DROP-TABLE detection

Mutation: replace `\bDROP\s+TABLE\b` with
`\bDROP\s+TABLE_DISABLED_FOR_REVERSE_VERIFY\b` so it can never match.

```
 FAIL  tests/scripts/lint-schema-additive.test.ts > lint-schema-additive > exit 1: DROP TABLE flagged with file:line
AssertionError: expected 0 to be greater than 0
 ❯ tests/scripts/lint-schema-additive.test.ts:81:33
     79|     );
     80|     const r = lintSchemaAdditive({ cwd: tmpRoot, migrationsDir });
     81|     expect(r.violations.length).toBeGreaterThan(0);
       |                                 ^

 Test Files  1 failed (1)
      Tests  1 failed | 8 passed (9)
```

### B. Disable NOT-NULL-without-DEFAULT detection

Mutation: replace the rule pattern with `__REVERSE_VERIFY_B_DISABLED__`
so it can never match.

```
 FAIL  tests/scripts/lint-schema-additive.test.ts > lint-schema-additive > exit 1: ADD COLUMN NOT NULL without DEFAULT is flagged
AssertionError: expected [] to include 'ADD COLUMN NOT NULL without DEFAULT'
 ❯ tests/scripts/lint-schema-additive.test.ts:107:19
    105|     const r = lintSchemaAdditive({ cwd: tmpRoot, migrationsDir });
    106|     const names = r.violations.map((v) => v.rule);
    107|     expect(names).toContain('ADD COLUMN NOT NULL without DEFAULT');
       |                   ^

 Test Files  1 failed (1)
      Tests  1 failed | 8 passed (9)
```

After restore, all 9/9 cases green.

## Current-HEAD lint result

```
$ npm run lint:schema-additive
lint-schema-additive: baseline=__none__ (via daemon\src\db\migrations\.v03-baseline); scanned 0 migration(s) since baseline (skipped 0); no violations.
```

Zero violations on `working` HEAD (no migrations exist yet).

## Verification

- `npx vitest run tests/scripts/lint-schema-additive.test.ts` → 9/9 green.
- `npm run typecheck` → clean.
- `npm run lint:schema-additive` → clean on HEAD.

## Test plan
- [x] 9 vitest cases (additive ADD TABLE / ADD COLUMN nullable / ADD COLUMN NOT NULL DEFAULT 0 / DROP TABLE / DROP COLUMN / ADD COLUMN NOT NULL without DEFAULT / RENAME COLUMN / ALTER COLUMN ... TYPE / migration before baseline ignored).
- [x] Reverse-verify A + B confirm tests catch the regressions they claim to.
- [x] CI workflow `schema-additive-lint` triggered by paths under `daemon/src/db/migrations/**`, `scripts/lint-schema-additive.ts`, `daemon/src/db/migrations/.v03-baseline`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>