### PR TITLE
feat(crash phase 4): first-run consent + send-last-crash button

### DIFF
--- a/daemon/src/index.ts
+++ b/daemon/src/index.ts
@@ -18,6 +18,15 @@ import { initDaemonSentry } from './sentry/init.js';
 const require = createRequire(import.meta.url);
 const DAEMON_VERSION = (require('../../package.json') as { version: string }).version;
 
+// Phase 4 consent gate parser. Mirrors the renderer-side `CrashConsent`
+// type. Anything other than the three known strings (or undefined) is
+// treated as `'pending'` — fail closed so a malformed env var never
+// silently enables upload.
+function parseDaemonConsent(raw: string | undefined): 'pending' | 'opted-in' | 'opted-out' {
+  if (raw === 'opted-in' || raw === 'opted-out' || raw === 'pending') return raw;
+  return 'pending';
+}
+
 const bootNonce = ulid();
 
 const logger = pino({
@@ -38,6 +47,7 @@ initDaemonSentry({
   dsn: process.env.CCSM_DAEMON_SENTRY_DSN ?? '',
   release: DAEMON_VERSION,
   bootNonce,
+  consent: parseDaemonConsent(process.env.CCSM_DAEMON_CRASH_CONSENT),
 });
 
 // Phase 1 crash observability (spec §5.2, plan Task 3):

--- a/daemon/src/sentry/init.ts
+++ b/daemon/src/sentry/init.ts
@@ -29,6 +29,13 @@ export interface DaemonSentryOpts {
   dsn: string;
   release: string;
   bootNonce: string;
+  /** Phase 4 consent gate. The supervisor forwards the user's
+   *  `crashUploadConsent` value via `CCSM_DAEMON_CRASH_CONSENT`. When this
+   *  is not `'opted-in'`, init early-returns (no SDK client created) — same
+   *  hard constraint as `electron/sentry/init.ts`. Local crash log writers
+   *  (phase 1 marker, phase 5 rolling log) are unaffected.
+   *  Defaults to `'pending'` when undefined to match the user-facing default. */
+  consent?: 'pending' | 'opted-in' | 'opted-out';
   /** Test seam — defaults to the real `@sentry/node` namespace. */
   sentry?: SentryLike;
 }
@@ -48,6 +55,11 @@ let active: SentryLike | undefined;
  * Returns `true` if init was performed, `false` if short-circuited.
  */
 export function initDaemonSentry(opts: DaemonSentryOpts): boolean {
+  // Phase 4 consent gate. Same semantics as electron/sentry/init.ts: only
+  // `'opted-in'` enables network upload; `'pending'` and `'opted-out'` are
+  // both no-ops. Default to `'pending'` so a missing env var fails closed.
+  const consent = opts.consent ?? 'pending';
+  if (consent !== 'opted-in') return false;
   const dsn = (opts.dsn ?? '').trim();
   if (!dsn || dsn === REDACTED) return false;
   const sentry: SentryLike = opts.sentry ?? (RealSentry as unknown as SentryLike);

--- a/electron/daemon/supervisor.ts
+++ b/electron/daemon/supervisor.ts
@@ -132,6 +132,10 @@ export interface SpawnDaemonOpts {
   runtimeRoot?: string;
   /** Override DSN (otherwise resolveDaemonSentryDsn). Mostly for tests. */
   dsn?: string;
+  /** Phase 4 consent — forwarded as `CCSM_DAEMON_CRASH_CONSENT`. The daemon
+   *  Sentry init early-returns when this is not `'opted-in'`, even if the
+   *  DSN is populated. Defaults to `'pending'` so a missing call fails closed. */
+  consent?: 'pending' | 'opted-in' | 'opted-out';
   /** Pass-through spawn options. `env` is merged on top of the baseline. */
   spawnOptions?: SpawnOptions;
   /** Test seam — defaults to node:child_process.spawn. */
@@ -145,13 +149,19 @@ export interface SpawnDaemonOpts {
  * being defined and apply its own short-circuit; this also lets a test assert
  * the supervisor wired the forwarding correctly without distinguishing
  * "didn't set" from "set to empty".
+ *
+ * `CCSM_DAEMON_CRASH_CONSENT` is also always set (defaults to `'pending'`)
+ * so the daemon never silently uploads when the user hasn't answered the
+ * first-run consent modal.
  */
 export function spawnDaemon(opts: SpawnDaemonOpts): ChildProcess {
   const dsn = opts.dsn ?? resolveDaemonSentryDsn();
+  const consent = opts.consent ?? 'pending';
   const spawnFn = opts.spawnFn ?? spawn;
   const baseEnv: NodeJS.ProcessEnv = {
     ...process.env,
     CCSM_DAEMON_SENTRY_DSN: dsn,
+    CCSM_DAEMON_CRASH_CONSENT: consent,
   };
   if (opts.runtimeRoot) baseEnv.CCSM_RUNTIME_ROOT = opts.runtimeRoot;
   const merged: SpawnOptions = {

--- a/electron/ipc/crashIncidents.ts
+++ b/electron/ipc/crashIncidents.ts
@@ -1,0 +1,182 @@
+// electron/ipc/crashIncidents.ts
+//
+// Phase 4 crash observability (spec §8, plan phase 4: send-last-crash).
+//
+// IPC surface:
+//   - `crash:get-last-incident`  → { id, ts, surface, alreadySent } | null
+//   - `crash:send-last-incident` → { ok: true; eventId? } | { ok: false; reason }
+//
+// Re-uploads the most recent incident dir (under the OS-specific crash root
+// resolved by `electron/crash/incident-dir.ts`) to Sentry via the
+// already-initialised main-process SDK from phase 2/3. Disable conditions:
+//
+//   - no incident on disk
+//   - already-sent marker (`<incident>/.uploaded`) present
+//   - Sentry was not initialised this run (consent != 'opted-in' OR DSN empty)
+//
+// We DO NOT re-route DSN selection — the existing main-proc Sentry init
+// owns the routing; this module only triggers `captureMessage` + attachment
+// upload, then writes the `.uploaded` marker on success.
+
+import type { IpcMain, IpcMainInvokeEvent } from 'electron';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as Sentry from '@sentry/electron/main';
+import { fromMainFrame } from '../security/ipcGuards';
+import { resolveCrashRoot } from '../crash/incident-dir';
+import { isCrashUploadAllowed } from '../prefs/crashConsent';
+
+export interface IncidentSummary {
+  id: string;
+  dirName: string;
+  ts: string;
+  surface: string;
+  alreadySent: boolean;
+}
+
+const UPLOADED_MARKER = '.uploaded';
+
+function listIncidents(crashRoot: string): { name: string; mtime: number }[] {
+  try {
+    return fs
+      .readdirSync(crashRoot)
+      .filter((n) => !n.startsWith('_') && !n.startsWith('.'))
+      .map((n) => {
+        const full = path.join(crashRoot, n);
+        try {
+          const stat = fs.statSync(full);
+          if (!stat.isDirectory()) return null;
+          return { name: n, mtime: stat.mtimeMs };
+        } catch {
+          return null;
+        }
+      })
+      .filter((x): x is { name: string; mtime: number } => x !== null)
+      .sort((a, b) => b.mtime - a.mtime);
+  } catch {
+    return [];
+  }
+}
+
+function readMeta(dir: string): { incidentId?: string; ts?: string; surface?: string } {
+  try {
+    const raw = fs.readFileSync(path.join(dir, 'meta.json'), 'utf8');
+    const parsed = JSON.parse(raw) as { incidentId?: string; ts?: string; surface?: string };
+    return parsed;
+  } catch {
+    return {};
+  }
+}
+
+/** Pure helper exported for tests. Returns the most recent incident summary
+ *  or null when the crash root is empty / unreadable. */
+export function getLastIncidentSummary(crashRoot: string): IncidentSummary | null {
+  const entries = listIncidents(crashRoot);
+  const top = entries[0];
+  if (!top) return null;
+  const dir = path.join(crashRoot, top.name);
+  const meta = readMeta(dir);
+  const alreadySent = fs.existsSync(path.join(dir, UPLOADED_MARKER));
+  return {
+    id: meta.incidentId ?? top.name,
+    dirName: top.name,
+    ts: meta.ts ?? new Date(top.mtime).toISOString(),
+    surface: meta.surface ?? 'unknown',
+    alreadySent,
+  };
+}
+
+interface SendResult {
+  ok: boolean;
+  eventId?: string;
+  reason?: string;
+}
+
+interface SentryShim {
+  captureMessage: (
+    msg: string,
+    hint?: { attachments?: Array<{ filename: string; data: Buffer | string; contentType?: string }> }
+  ) => string | undefined;
+  flush: (timeoutMs?: number) => Promise<boolean>;
+}
+
+const realSentry: SentryShim = Sentry as unknown as SentryShim;
+
+/** Pure helper exported for tests. Re-uploads the given incident dir via
+ *  Sentry's `captureMessage` + attachment hook. Writes the `.uploaded`
+ *  marker on success. The `sentry` parameter is a test seam; production
+ *  callers omit it and get the real `@sentry/electron/main` namespace. */
+export async function sendIncident(
+  dir: string,
+  sentry: SentryShim = realSentry
+): Promise<SendResult> {
+  if (!fs.existsSync(dir)) return { ok: false, reason: 'incident-not-found' };
+  if (fs.existsSync(path.join(dir, UPLOADED_MARKER))) {
+    return { ok: false, reason: 'already-sent' };
+  }
+  if (!isCrashUploadAllowed()) {
+    return { ok: false, reason: 'consent-not-granted' };
+  }
+
+  // Collect attachments from the incident dir. Skip the .uploaded marker
+  // (doesn't exist yet) and anything that fails to read.
+  const attachments: Array<{ filename: string; data: Buffer; contentType?: string }> = [];
+  try {
+    for (const name of fs.readdirSync(dir)) {
+      if (name === UPLOADED_MARKER) continue;
+      const full = path.join(dir, name);
+      try {
+        const stat = fs.statSync(full);
+        if (!stat.isFile()) continue;
+        // Cap any single attachment at 1 MB so we don't blow the Sentry
+        // envelope size. Crashpad dmps are usually well under this.
+        if (stat.size > 1024 * 1024) continue;
+        attachments.push({ filename: name, data: fs.readFileSync(full) });
+      } catch {
+        /* skip unreadable file */
+      }
+    }
+  } catch {
+    return { ok: false, reason: 'incident-read-failed' };
+  }
+
+  let eventId: string | undefined;
+  try {
+    eventId = sentry.captureMessage(`crash incident replay`, { attachments });
+    await sentry.flush(5000);
+  } catch (err) {
+    return { ok: false, reason: `sentry-error: ${(err as Error).message}` };
+  }
+
+  // Mark the incident as uploaded so the user can't double-send.
+  try {
+    fs.writeFileSync(
+      path.join(dir, UPLOADED_MARKER),
+      JSON.stringify({ ts: new Date().toISOString(), eventId: eventId ?? null }, null, 2),
+      'utf8'
+    );
+  } catch {
+    // Marker write failed; the upload still succeeded so we report ok.
+  }
+  return { ok: true, eventId };
+}
+
+export interface CrashIncidentsIpcDeps {
+  ipcMain: IpcMain;
+  /** Override for tests; defaults to resolveCrashRoot(). */
+  crashRoot?: string;
+}
+
+export function registerCrashIncidentsIpc(deps: CrashIncidentsIpcDeps): void {
+  const crashRoot = deps.crashRoot ?? resolveCrashRoot();
+  deps.ipcMain.handle('crash:get-last-incident', (e: IpcMainInvokeEvent) => {
+    if (!fromMainFrame(e)) return null;
+    return getLastIncidentSummary(crashRoot);
+  });
+  deps.ipcMain.handle('crash:send-last-incident', async (e: IpcMainInvokeEvent) => {
+    if (!fromMainFrame(e)) return { ok: false, reason: 'guard-rejected' };
+    const summary = getLastIncidentSummary(crashRoot);
+    if (!summary) return { ok: false, reason: 'incident-not-found' };
+    return sendIncident(path.join(crashRoot, summary.dirName));
+  });
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -113,6 +113,8 @@ import { registerDbIpc } from './ipc/dbIpc';
 import { registerSystemIpc } from './ipc/systemIpc';
 import { registerSessionIpc } from './ipc/sessionIpc';
 import { registerWindowIpc } from './ipc/windowIpc';
+import { registerCrashIncidentsIpc } from './ipc/crashIncidents';
+import { subscribeCrashConsentInvalidation } from './prefs/crashConsent';
 import {
   registerUtilityIpc,
   primeImportableCache,
@@ -229,6 +231,7 @@ app.whenReady().then(() => {
   // auto-persisted setting on first paint) reaches the cache subscribers.
   // See `tech-debt-12-functional-core.md` leak #5 / Task #818.
   subscribeCrashReportingInvalidation();
+  subscribeCrashConsentInvalidation();
   subscribeNotifyEnabledInvalidation();
   // Order is significant for systemIpc: it seeds the active i18n language
   // from the OS locale, so any subsequent producer that calls i18n.t()
@@ -263,6 +266,7 @@ app.whenReady().then(() => {
   });
   registerWindowIpc({ ipcMain });
   registerUtilityIpc({ ipcMain });
+  registerCrashIncidentsIpc({ ipcMain });
 
   installUpdaterIpc();
 

--- a/electron/prefs/__tests__/crashConsent.test.ts
+++ b/electron/prefs/__tests__/crashConsent.test.ts
@@ -1,0 +1,161 @@
+// Phase 4 crash observability — consent gate unit tests.
+//
+// Asserts:
+//   - Tri-state resolver: 'pending' / 'opted-in' / 'opted-out' round-trip.
+//   - Default = 'pending' when neither the new key nor legacy boolean is set.
+//   - Legacy fallback: opt-out boolean produces 'opted-out' so an upgrade
+//     never silently re-enables uploads for someone who already opted out.
+//   - `isCrashUploadAllowed()` is true ONLY for 'opted-in'.
+//   - Cache invalidates via stateSavedBus on either the new key or the
+//     legacy key (handles both write paths).
+//   - REVERSE-VERIFY: when the gate is removed (we drive
+//     `isCrashUploadAllowed()` to true via 'opted-in'), the assertion that
+//     blocks upload on opted-out FAILS — proving the gate is what stops it.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const stateStore = new Map<string, string | null>();
+
+vi.mock('../../db', () => ({
+  loadState: (key: string) => (stateStore.has(key) ? stateStore.get(key)! : null),
+  saveState: (key: string, value: string) => {
+    stateStore.set(key, value);
+  },
+}));
+
+beforeEach(() => {
+  stateStore.clear();
+  vi.resetModules();
+});
+
+describe('loadCrashConsent', () => {
+  it('defaults to pending when nothing is persisted', async () => {
+    const { loadCrashConsent } = await import('../crashConsent');
+    expect(loadCrashConsent()).toBe('pending');
+  });
+
+  it('returns opted-in when the key holds opted-in', async () => {
+    stateStore.set('crashUploadConsent', 'opted-in');
+    const { loadCrashConsent } = await import('../crashConsent');
+    expect(loadCrashConsent()).toBe('opted-in');
+  });
+
+  it('returns opted-out when the key holds opted-out', async () => {
+    stateStore.set('crashUploadConsent', 'opted-out');
+    const { loadCrashConsent } = await import('../crashConsent');
+    expect(loadCrashConsent()).toBe('opted-out');
+  });
+
+  it('falls back to opted-out when only the legacy boolean is set to true', async () => {
+    stateStore.set('crashReportingOptOut', 'true');
+    const { loadCrashConsent } = await import('../crashConsent');
+    expect(loadCrashConsent()).toBe('opted-out');
+  });
+
+  it('falls back to pending when only legacy boolean is false', async () => {
+    stateStore.set('crashReportingOptOut', 'false');
+    const { loadCrashConsent } = await import('../crashConsent');
+    // We deliberately do NOT silent-opt-in old users — false legacy still
+    // requires the user to answer the new modal.
+    expect(loadCrashConsent()).toBe('pending');
+  });
+
+  it('rejects bogus values and returns pending', async () => {
+    stateStore.set('crashUploadConsent', 'maybe-tomorrow');
+    const { loadCrashConsent } = await import('../crashConsent');
+    expect(loadCrashConsent()).toBe('pending');
+  });
+});
+
+describe('isCrashUploadAllowed', () => {
+  it('is false for pending (the user has not answered)', async () => {
+    const { isCrashUploadAllowed } = await import('../crashConsent');
+    expect(isCrashUploadAllowed()).toBe(false);
+  });
+
+  it('is false for opted-out', async () => {
+    stateStore.set('crashUploadConsent', 'opted-out');
+    const { isCrashUploadAllowed } = await import('../crashConsent');
+    expect(isCrashUploadAllowed()).toBe(false);
+  });
+
+  it('is true ONLY for opted-in', async () => {
+    stateStore.set('crashUploadConsent', 'opted-in');
+    const { isCrashUploadAllowed } = await import('../crashConsent');
+    expect(isCrashUploadAllowed()).toBe(true);
+  });
+});
+
+describe('subscribeCrashConsentInvalidation', () => {
+  it('invalidates the cache when the new key is rewritten', async () => {
+    stateStore.set('crashUploadConsent', 'opted-in');
+    const { loadCrashConsent, subscribeCrashConsentInvalidation } = await import('../crashConsent');
+    const { emitStateSaved, _resetStateSavedBusForTests } = await import(
+      '../../shared/stateSavedBus'
+    );
+    _resetStateSavedBusForTests();
+    const off = subscribeCrashConsentInvalidation();
+
+    expect(loadCrashConsent()).toBe('opted-in');
+    stateStore.set('crashUploadConsent', 'opted-out');
+    emitStateSaved('crashUploadConsent');
+    expect(loadCrashConsent()).toBe('opted-out');
+    off();
+  });
+
+  it('also invalidates when the legacy key is rewritten', async () => {
+    stateStore.set('crashUploadConsent', 'opted-in');
+    const { loadCrashConsent, subscribeCrashConsentInvalidation } = await import('../crashConsent');
+    const { emitStateSaved, _resetStateSavedBusForTests } = await import(
+      '../../shared/stateSavedBus'
+    );
+    _resetStateSavedBusForTests();
+    const off = subscribeCrashConsentInvalidation();
+    expect(loadCrashConsent()).toBe('opted-in');
+
+    // Renderer toggled the legacy opt-out from a downgrade scenario.
+    stateStore.delete('crashUploadConsent');
+    stateStore.set('crashReportingOptOut', 'true');
+    emitStateSaved('crashReportingOptOut');
+    expect(loadCrashConsent()).toBe('opted-out');
+    off();
+  });
+
+  it('ignores unrelated keys', async () => {
+    stateStore.set('crashUploadConsent', 'opted-in');
+    const { loadCrashConsent, subscribeCrashConsentInvalidation } = await import('../crashConsent');
+    const { emitStateSaved, _resetStateSavedBusForTests } = await import(
+      '../../shared/stateSavedBus'
+    );
+    _resetStateSavedBusForTests();
+    const off = subscribeCrashConsentInvalidation();
+    expect(loadCrashConsent()).toBe('opted-in');
+
+    stateStore.set('crashUploadConsent', 'opted-out');
+    emitStateSaved('notifyEnabled');
+    // No invalidation — cache still reports opted-in.
+    expect(loadCrashConsent()).toBe('opted-in');
+    off();
+  });
+});
+
+// Reverse-verify the gate by asserting the OPPOSITE outcome when consent is
+// flipped. If a future refactor accidentally drops the gate (e.g. always
+// returns true regardless of consent), the first assertion still passes BUT
+// the second assertion (consent=opted-out → blocked) flips and the test
+// FAILS. Documents the exact semantics the Sentry init relies on.
+describe('reverse-verify: gate behavior', () => {
+  it('opted-in passes AND opted-out blocks (both required for the gate to be real)', async () => {
+    stateStore.set('crashUploadConsent', 'opted-in');
+    const { isCrashUploadAllowed, _resetCrashConsentForTests } = await import('../crashConsent');
+    expect(isCrashUploadAllowed()).toBe(true);
+
+    _resetCrashConsentForTests();
+    stateStore.set('crashUploadConsent', 'opted-out');
+    expect(isCrashUploadAllowed()).toBe(false);
+
+    _resetCrashConsentForTests();
+    stateStore.set('crashUploadConsent', 'pending');
+    expect(isCrashUploadAllowed()).toBe(false);
+  });
+});

--- a/electron/prefs/crashConsent.ts
+++ b/electron/prefs/crashConsent.ts
@@ -1,0 +1,90 @@
+// Crash-upload consent (tri-state). Phase 4 crash observability
+// (spec §7, plan phase 4: first-run consent).
+//
+// Wire-shape: stored in app_state under `crashUploadConsent`. Three values:
+//
+//   - 'pending'    — user has not answered the first-run modal yet. Treated
+//                    as opt-OUT for upload purposes (no Sentry init) until
+//                    they answer.
+//   - 'opted-in'   — user clicked "Allow" in the modal or flipped the toggle
+//                    on in Settings. Sentry init runs; events flow.
+//   - 'opted-out'  — user clicked "Not now" or flipped the toggle off.
+//                    Sentry init early-returns; no SDK client created.
+//
+// Per the user's hard constraint: local crash logs (phase 1 collector) ALWAYS
+// write regardless of consent. This module only gates the *network upload*
+// path through Sentry init.
+//
+// Migration from the legacy `crashReportingOptOut` boolean: when no
+// consent row exists but the legacy opt-out row does, we materialise a
+// derived consent ('opted-out' when the legacy row is true, otherwise
+// 'pending' — we never silent-opt-in old users). The Settings toggle now
+// writes the consent key; the legacy key is left in place so a downgrade
+// stays safe.
+//
+// Cache + invalidation pattern mirrors `crashReporting.ts` so the renderer
+// toggle takes effect within one event without an app restart.
+
+import { loadState } from '../db';
+import { onStateSaved } from '../shared/stateSavedBus';
+import { CRASH_OPT_OUT_KEY } from './crashReporting';
+
+export const CRASH_CONSENT_KEY = 'crashUploadConsent';
+
+export type CrashConsent = 'pending' | 'opted-in' | 'opted-out';
+
+const VALID: ReadonlySet<string> = new Set(['pending', 'opted-in', 'opted-out']);
+
+let _cached: CrashConsent | undefined;
+
+function readRaw(): CrashConsent {
+  // Explicit consent row wins.
+  try {
+    const raw = loadState(CRASH_CONSENT_KEY);
+    if (raw && VALID.has(raw)) return raw as CrashConsent;
+  } catch {
+    /* fall through to legacy / default */
+  }
+  // Legacy fallback: respect a previously-set opt-out boolean so we don't
+  // silently start uploading for users who already opted out before phase 4.
+  try {
+    const legacy = loadState(CRASH_OPT_OUT_KEY);
+    if (legacy === 'true' || legacy === '1') return 'opted-out';
+  } catch {
+    /* swallow */
+  }
+  return 'pending';
+}
+
+/** Read the current consent state (cached). */
+export function loadCrashConsent(): CrashConsent {
+  if (_cached !== undefined) return _cached;
+  const value = readRaw();
+  _cached = value;
+  return value;
+}
+
+/** Drop the cached value; the next `loadCrashConsent()` re-reads from DB. */
+export function invalidateCrashConsentCache(): void {
+  _cached = undefined;
+}
+
+/** True iff the user has explicitly opted in. The Sentry init gate calls
+ *  this — `pending` and `opted-out` both block upload. */
+export function isCrashUploadAllowed(): boolean {
+  return loadCrashConsent() === 'opted-in';
+}
+
+/** Wire cache invalidation to the stateSavedBus. Call once during boot. */
+export function subscribeCrashConsentInvalidation(): () => void {
+  return onStateSaved((key) => {
+    if (key === CRASH_CONSENT_KEY || key === CRASH_OPT_OUT_KEY) {
+      invalidateCrashConsentCache();
+    }
+  });
+}
+
+/** Test-only reset of module-scope cache (not exported via index). */
+export function _resetCrashConsentForTests(): void {
+  _cached = undefined;
+}

--- a/electron/preload/bridges/ccsmCore.ts
+++ b/electron/preload/bridges/ccsmCore.ts
@@ -115,6 +115,25 @@ const api = {
   updatesGetAutoCheck: (): Promise<boolean> => ipcRenderer.invoke('updates:getAutoCheck'),
   updatesSetAutoCheck: (enabled: boolean): Promise<boolean> =>
     ipcRenderer.invoke('updates:setAutoCheck', enabled),
+
+  /**
+   * Phase 4 crash observability — surface the most recent on-disk incident
+   * to the Settings page so the user can re-upload via "Send last crash
+   * report". Returns `null` when no incident exists. `alreadySent` is true
+   * when a `.uploaded` marker is present in the incident dir (so the UI
+   * disables the button to prevent double-send).
+   */
+  crash: {
+    getLastIncident: (): Promise<{
+      id: string;
+      dirName: string;
+      ts: string;
+      surface: string;
+      alreadySent: boolean;
+    } | null> => ipcRenderer.invoke('crash:get-last-incident'),
+    sendLastIncident: (): Promise<{ ok: true; eventId?: string } | { ok: false; reason: string }> =>
+      ipcRenderer.invoke('crash:send-last-incident'),
+  },
   onUpdateStatus: (handler: (s: UpdateStatus) => void): (() => void) => {
     const wrap = (_e: IpcRendererEvent, payload: UpdateStatus) => handler(payload);
     ipcRenderer.on('updates:status', wrap);

--- a/electron/sentry/init.ts
+++ b/electron/sentry/init.ts
@@ -21,7 +21,7 @@
 
 import * as Sentry from '@sentry/electron/main';
 import { app } from 'electron';
-import { loadCrashReportingOptOut } from '../prefs/crashReporting';
+import { isCrashUploadAllowed, loadCrashConsent } from '../prefs/crashConsent';
 
 const REDACTED = '***REDACTED***';
 
@@ -44,6 +44,15 @@ function loadBuildInfo(): BuildInfo {
 }
 
 export function initSentry(): void {
+  // Phase 4 consent gate: when the user has not explicitly opted in, do NOT
+  // create the SDK client at all. This is the user's hard constraint —
+  // `pending` (first run, no answer yet) and `opted-out` both block upload.
+  // Local crash logs are unaffected (phase 1 collector writes regardless).
+  const consent = loadCrashConsent();
+  if (consent !== 'opted-in') {
+    console.info(`[sentry] crash upload consent=${consent} — Sentry off for surface=main.`);
+    return;
+  }
   const buildInfo = loadBuildInfo();
   const envDsn = process.env.SENTRY_DSN_MAIN?.trim() || process.env.SENTRY_DSN?.trim() || '';
   const dsn = envDsn || (buildInfo.sentryDsnMain ?? '').trim();
@@ -59,8 +68,7 @@ export function initSentry(): void {
     initialScope: { tags: { surface: 'main' } },
     beforeSend(event) {
       try {
-        const optOut = loadCrashReportingOptOut();
-        if (optOut) return null;
+        if (!isCrashUploadAllowed()) return null;
       } catch {
         /* fall through, send anyway */
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { AppSkeleton } from './components/AppSkeleton';
 import { TerminalPane } from './components/TerminalPane';
 import { ClaudeMissingGuide } from './components/ClaudeMissingGuide';
 import { SettingsDialog } from './components/SettingsDialog';
+import { CrashConsentModal } from './components/CrashConsentModal';
 import { CommandPalette } from './components/CommandPalette';
 import { ImportDialog } from './components/ImportDialog';
 import { ShortcutOverlay } from './components/ShortcutOverlay';
@@ -377,6 +378,7 @@ export default function App() {
           }
         />
         <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} />
+        <CrashConsentModal />
         <ImportDialog open={importOpen} onOpenChange={setImportOpen} />
         <CommandPalette
           open={paletteOpen}

--- a/src/components/CrashConsentModal.tsx
+++ b/src/components/CrashConsentModal.tsx
@@ -1,0 +1,114 @@
+// First-run crash-upload consent modal. Phase 4 crash observability
+// (spec §7, plan phase 4: first-run consent).
+//
+// Behavior contract:
+//   - Pops on first launch when persisted `crashUploadConsent === 'pending'`
+//     (the default, so a fresh install always sees it once).
+//   - Two buttons: "Allow" → 'opted-in', "Not now" → 'opted-out'. No
+//     "remind me later" — the user can flip later via Settings.
+//   - The body explicitly states local crash logs are saved regardless of
+//     the choice (the user's hard constraint surfaced in copy).
+//   - Persists via `window.ccsm.saveState('crashUploadConsent', ...)`. The
+//     main-process `subscribeCrashConsentInvalidation()` drops the cache on
+//     write so the gate takes effect on the next captured event.
+
+import React, { useEffect, useState } from 'react';
+import { Dialog, DialogContent } from './ui/Dialog';
+import { Button } from './ui/Button';
+import { useTranslation } from '../i18n/useTranslation';
+
+const CONSENT_KEY = 'crashUploadConsent';
+
+type Consent = 'pending' | 'opted-in' | 'opted-out';
+
+function isConsent(v: string | null | undefined): v is Consent {
+  return v === 'pending' || v === 'opted-in' || v === 'opted-out';
+}
+
+export function CrashConsentModal() {
+  const { t } = useTranslation('settings');
+  const [open, setOpen] = useState(false);
+  const [whatsSentOpen, setWhatsSentOpen] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const raw = await window.ccsm?.loadState(CONSENT_KEY);
+        if (cancelled) return;
+        const consent: Consent = isConsent(raw) ? raw : 'pending';
+        if (consent === 'pending') setOpen(true);
+      } catch {
+        /* db unreachable on boot — leave the modal closed; we'll re-prompt
+           next launch since nothing was persisted. */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const persist = (next: Consent) => {
+    setOpen(false);
+    void window.ccsm?.saveState(CONSENT_KEY, next);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) persist('opted-out'); }}>
+      <DialogContent
+        title={t('consentModal.title')}
+        width="480px"
+        hideClose={true}
+        // Block focus trap escape paths — the user must click one of the
+        // two buttons; closing via overlay click defaults to 'opted-out'
+        // (handled via onOpenChange above).
+        onEscapeKeyDown={(e) => e.preventDefault()}
+        onPointerDownOutside={(e) => e.preventDefault()}
+        data-crash-consent-modal
+      >
+        <div className="p-5 space-y-4">
+          <p className="text-chrome text-fg-secondary leading-relaxed">
+            {t('consentModal.body')}
+          </p>
+
+          <details
+            open={whatsSentOpen}
+            onToggle={(e) => setWhatsSentOpen((e.currentTarget as { open: boolean }).open)}
+            className="text-meta text-fg-tertiary"
+          >
+            <summary className="cursor-pointer select-none text-fg-secondary outline-none focus-visible:ring-2 focus-visible:ring-accent/60 rounded-sm">
+              {t('consentModal.whatsSent')}
+            </summary>
+            <ul className="mt-2 list-disc pl-5 space-y-1">
+              <li>{t('consentModal.whatsSentItem1')}</li>
+              <li>{t('consentModal.whatsSentItem2')}</li>
+              <li>{t('consentModal.whatsSentItem3')}</li>
+            </ul>
+          </details>
+
+          <div className="flex items-center justify-end gap-2 pt-2">
+            <Button
+              variant="secondary"
+              size="md"
+              onClick={() => persist('opted-out')}
+              data-crash-consent-not-now
+              autoFocus
+            >
+              {t('consentModal.notNow')}
+            </Button>
+            <Button
+              variant="primary"
+              size="md"
+              onClick={() => persist('opted-in')}
+              data-crash-consent-allow
+            >
+              {t('consentModal.allow')}
+            </Button>
+          </div>
+
+          <p className="text-meta text-fg-tertiary">{t('consentModal.footer')}</p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/settings/UpdatesPane.tsx
+++ b/src/components/settings/UpdatesPane.tsx
@@ -1,6 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { Check } from 'lucide-react';
-import * as Checkbox from '@radix-ui/react-checkbox';
 import { cn } from '../../lib/cn';
 import { Button } from '../ui/Button';
 import { Switch } from '../ui/Switch';
@@ -118,22 +116,38 @@ function formatBytes(n: number): string {
   return `${(n / 1024 / 1024).toFixed(1)} MB`;
 }
 
-// Persisted via the existing `db:save` / `db:load` IPC under the
-// `crashReportingOptOut` app_state key. We store the OPT-OUT flag (default
-// false → reporting ON) so a missing row means "send"; that matches the
-// reading logic in electron/main.ts so the two never disagree.
+// Phase 4 crash observability — tri-state consent (`pending` / `opted-in` /
+// `opted-out`) lives in app_state under `crashUploadConsent`. The legacy
+// `crashReportingOptOut` boolean is read by `electron/prefs/crashConsent.ts`
+// as a fallback so a previously-opted-out user stays opted-out across the
+// upgrade. The Settings switch below ONLY writes the new key.
+const CONSENT_KEY = 'crashUploadConsent';
+type Consent = 'pending' | 'opted-in' | 'opted-out';
+
 function CrashReportingField() {
   const { t } = useTranslation('settings');
-  const [optOut, setOptOut] = useState<boolean>(false);
+  const [consent, setConsent] = useState<Consent>('pending');
   const [hydrated, setHydrated] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
     void (async () => {
       try {
-        const raw = await window.ccsm?.loadState('crashReportingOptOut');
+        const raw = await window.ccsm?.loadState(CONSENT_KEY);
         if (cancelled) return;
-        setOptOut(raw === 'true' || raw === '1');
+        if (raw === 'opted-in' || raw === 'opted-out' || raw === 'pending') {
+          setConsent(raw);
+        } else {
+          // Legacy fallback: respect the old boolean if present so the
+          // toggle reflects the user's previous choice on first paint
+          // after upgrade.
+          const legacy = await window.ccsm?.loadState('crashReportingOptOut');
+          if (!cancelled && (legacy === 'true' || legacy === '1')) {
+            setConsent('opted-out');
+          } else {
+            setConsent('pending');
+          }
+        }
       } finally {
         if (!cancelled) setHydrated(true);
       }
@@ -144,45 +158,131 @@ function CrashReportingField() {
   }, []);
 
   const onChange = (sendReports: boolean) => {
-    // UI is "Send crash reports" (positive). Persisted key is the inverse.
-    const nextOptOut = !sendReports;
-    setOptOut(nextOptOut);
-    void window.ccsm?.saveState('crashReportingOptOut', String(nextOptOut));
+    const next: Consent = sendReports ? 'opted-in' : 'opted-out';
+    setConsent(next);
+    void window.ccsm?.saveState(CONSENT_KEY, next);
   };
 
-  const checked = !optOut;
+  const checked = consent === 'opted-in';
 
   return (
-    <label
-      className={cn(
-        'flex items-start gap-3 cursor-pointer select-none',
-        !hydrated && 'opacity-60'
-      )}
-    >
-      <Checkbox.Root
-        checked={checked}
-        disabled={!hydrated}
-        onCheckedChange={(v) => onChange(v === true)}
+    <Field label={t('crashReporting.consentLabel')} hint={t('crashReporting.consentHint')}>
+      <label
         className={cn(
-          'mt-[3px] h-3.5 w-3.5 shrink-0 rounded-sm border border-border-strong',
-          'data-[state=checked]:bg-accent data-[state=checked]:border-accent',
-          'outline-none focus-visible:ring-2 focus-visible:ring-accent/60',
-          'focus-visible:ring-offset-1 focus-visible:ring-offset-bg-app',
-          'transition-colors duration-150'
+          'inline-flex items-center gap-2 cursor-pointer select-none',
+          !hydrated && 'opacity-60'
         )}
       >
-        <Checkbox.Indicator className="flex items-center justify-center text-bg-app">
-          <Check size={10} strokeWidth={3} />
-        </Checkbox.Indicator>
-      </Checkbox.Root>
-      <div className="min-w-0 flex-1">
-        <div className="text-chrome font-medium text-fg-primary">
-          {t('crashReporting.label')}
-        </div>
-        <div className="text-meta text-fg-tertiary mt-0.5">
-          {t('crashReporting.description')}
-        </div>
-      </div>
-    </label>
+        <Switch
+          checked={checked}
+          disabled={!hydrated}
+          onCheckedChange={onChange}
+          aria-label={t('crashReporting.consentLabel')}
+          data-crash-consent-toggle
+        />
+        <span className="text-chrome text-fg-secondary">
+          {t('crashReporting.consentLabel')}
+        </span>
+      </label>
+      <SendLastCrashRow />
+    </Field>
+  );
+}
+
+interface IncidentSummary {
+  id: string;
+  dirName: string;
+  ts: string;
+  surface: string;
+  alreadySent: boolean;
+}
+
+type SendState =
+  | { kind: 'idle' }
+  | { kind: 'sending' }
+  | { kind: 'success' }
+  | { kind: 'error'; reason: string };
+
+function SendLastCrashRow() {
+  const { t } = useTranslation('settings');
+  const [incident, setIncident] = useState<IncidentSummary | null>(null);
+  const [hydrated, setHydrated] = useState(false);
+  const [send, setSend] = useState<SendState>({ kind: 'idle' });
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const got = (await window.ccsm?.crash?.getLastIncident()) ?? null;
+        if (!cancelled) setIncident(got);
+      } finally {
+        if (!cancelled) setHydrated(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const onClick = async () => {
+    if (!incident || send.kind === 'sending') return;
+    setSend({ kind: 'sending' });
+    const res = await window.ccsm?.crash?.sendLastIncident();
+    if (!res) {
+      setSend({ kind: 'error', reason: 'no-bridge' });
+      return;
+    }
+    if (res.ok) {
+      setSend({ kind: 'success' });
+      // Re-fetch to flip alreadySent so the button disables itself.
+      const refreshed = (await window.ccsm?.crash?.getLastIncident()) ?? null;
+      setIncident(refreshed);
+    } else {
+      setSend({ kind: 'error', reason: res.reason });
+    }
+  };
+
+  const disabled =
+    !hydrated ||
+    !incident ||
+    incident.alreadySent ||
+    send.kind === 'sending' ||
+    send.kind === 'success';
+
+  let status: string;
+  if (!hydrated) {
+    status = '';
+  } else if (!incident) {
+    status = t('crashReporting.sendLastNoCrash');
+  } else if (send.kind === 'success') {
+    status = t('crashReporting.sendLastSuccess');
+  } else if (send.kind === 'error') {
+    status = t('crashReporting.sendLastError', { reason: send.reason });
+  } else if (send.kind === 'sending') {
+    status = t('crashReporting.sendLastSending');
+  } else if (incident.alreadySent) {
+    status = t('crashReporting.sendLastAlreadySent');
+  } else {
+    status = t('crashReporting.sendLastReady', { ts: incident.ts, surface: incident.surface });
+  }
+
+  return (
+    <div className="mt-3 flex flex-col gap-2">
+      <Button
+        variant="secondary"
+        size="sm"
+        onClick={() => void onClick()}
+        disabled={disabled}
+        data-send-last-crash-button
+      >
+        {t('crashReporting.sendLast')}
+      </Button>
+      <span className="text-meta text-fg-tertiary" data-send-last-crash-status>
+        {status}
+      </span>
+      <span className="text-meta text-fg-tertiary">
+        {t('crashReporting.consentLocalNote')}
+      </span>
+    </div>
   );
 }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -86,6 +86,25 @@ declare global {
       onUpdateStatus: (handler: (s: UpdateStatus) => void) => () => void;
       onUpdateDownloaded: (handler: (info: { version: string }) => void) => () => void;
 
+      /**
+       * Phase 4 crash observability — most-recent on-disk incident summary
+       * + re-upload action backing the Settings "Send last crash report"
+       * button. The summary is null when no incident exists; `alreadySent`
+       * is true when the incident dir contains a `.uploaded` marker.
+       */
+      crash: {
+        getLastIncident: () => Promise<{
+          id: string;
+          dirName: string;
+          ts: string;
+          surface: string;
+          alreadySent: boolean;
+        } | null>;
+        sendLastIncident: () => Promise<
+          { ok: true; eventId?: string } | { ok: false; reason: string }
+        >;
+      };
+
       window: {
         minimize: () => Promise<void>;
         toggleMaximize: () => Promise<boolean>;

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -127,7 +127,32 @@ const en = {
     checkForUpdates: 'Check for updates',
     crashReporting: {
       label: 'Send crash reports to developer',
-      description: 'Recommended. Helps fix bugs you hit. No personal data sent.'
+      description: 'Recommended. Helps fix bugs you hit. No personal data sent.',
+      // Phase 4: tri-state consent UI + send-last-crash button. Local crash
+      // logs always write regardless of this toggle — see consentLocalNote.
+      consentLabel: 'Send anonymous crash reports',
+      consentHint:
+        'When on, ccsm uploads anonymous crash diagnostics so we can fix bugs. Local crash logs are saved on your computer either way.',
+      consentLocalNote: 'Local crash logs are always saved on your computer.',
+      sendLast: 'Send last crash report',
+      sendLastNoCrash: 'No recent crash report on this computer.',
+      sendLastAlreadySent: 'Last crash report already sent.',
+      sendLastReady: 'Last crash recorded {{ts}} ({{surface}}).',
+      sendLastSending: 'Sending…',
+      sendLastSuccess: 'Crash report sent. Thanks!',
+      sendLastError: 'Couldn’t send crash report: {{reason}}'
+    },
+    consentModal: {
+      title: 'Help improve ccsm',
+      body:
+        'When ccsm crashes we’d like to send anonymous diagnostics. Local crash logs are always saved to your computer regardless of this choice.',
+      whatsSent: 'What’s sent',
+      whatsSentItem1: 'Process info (version, platform, electron version)',
+      whatsSentItem2: 'Stack trace from the crash',
+      whatsSentItem3: 'No source code, no file contents, no personal data',
+      allow: 'Allow',
+      notNow: 'Not now',
+      footer: 'You can change this any time in Settings.'
     },
     notifications: {
       intro:

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -122,7 +122,30 @@ const zh: EnCatalog = {
     checkForUpdates: '检查更新',
     crashReporting: {
       label: '发送崩溃报告给开发者',
-      description: '推荐开启。帮助修复你遇到的 bug。不发送个人数据。'
+      description: '推荐开启。帮助修复你遇到的 bug。不发送个人数据。',
+      consentLabel: '发送匿名崩溃报告',
+      consentHint:
+        '开启后，ccsm 会上传匿名崩溃诊断数据帮助我们修复 bug。无论此项是否开启，本地崩溃日志都会保存在你的电脑上。',
+      consentLocalNote: '本地崩溃日志始终保存在你的电脑上。',
+      sendLast: '发送最近一次崩溃报告',
+      sendLastNoCrash: '本机没有最近的崩溃记录。',
+      sendLastAlreadySent: '最近一次崩溃报告已发送。',
+      sendLastReady: '最近一次崩溃记录于 {{ts}}（{{surface}}）。',
+      sendLastSending: '正在发送…',
+      sendLastSuccess: '崩溃报告已发送，感谢！',
+      sendLastError: '无法发送崩溃报告：{{reason}}'
+    },
+    consentModal: {
+      title: '帮助改进 ccsm',
+      body:
+        '当 ccsm 崩溃时，我们希望发送匿名诊断数据。无论你的选择如何，本地崩溃日志始终保存在你的电脑上。',
+      whatsSent: '会发送的内容',
+      whatsSentItem1: '进程信息（版本、平台、Electron 版本）',
+      whatsSentItem2: '崩溃时的调用栈',
+      whatsSentItem3: '不发送源代码、文件内容或任何个人数据',
+      allow: '允许',
+      notNow: '暂不',
+      footer: '你可以随时在“设置”中修改。'
     },
     notifications: {
       intro:

--- a/tests/daemon/sentry/init.test.ts
+++ b/tests/daemon/sentry/init.test.ts
@@ -33,21 +33,21 @@ beforeEach(() => {
 describe('initDaemonSentry', () => {
   it('returns false (no init) when DSN is empty string', () => {
     const { sentry, init } = makeSpy();
-    const ok = initDaemonSentry({ dsn: '', release: '0.3.0', bootNonce: 'BN', sentry });
+    const ok = initDaemonSentry({ dsn: '', release: '0.3.0', bootNonce: 'BN', consent: 'opted-in', sentry });
     expect(ok).toBe(false);
     expect(init).not.toHaveBeenCalled();
   });
 
   it('returns false when DSN is the redacted placeholder', () => {
     const { sentry, init } = makeSpy();
-    const ok = initDaemonSentry({ dsn: '***REDACTED***', release: '0.3.0', bootNonce: 'BN', sentry });
+    const ok = initDaemonSentry({ dsn: '***REDACTED***', release: '0.3.0', bootNonce: 'BN', consent: 'opted-in', sentry });
     expect(ok).toBe(false);
     expect(init).not.toHaveBeenCalled();
   });
 
   it('returns false when DSN is whitespace only', () => {
     const { sentry, init } = makeSpy();
-    const ok = initDaemonSentry({ dsn: '   ', release: '0.3.0', bootNonce: 'BN', sentry });
+    const ok = initDaemonSentry({ dsn: '   ', release: '0.3.0', bootNonce: 'BN', consent: 'opted-in', sentry });
     expect(ok).toBe(false);
     expect(init).not.toHaveBeenCalled();
   });
@@ -58,6 +58,7 @@ describe('initDaemonSentry', () => {
       dsn: 'https://x@y.ingest.sentry.io/1',
       release: '0.3.0',
       bootNonce: 'BN-XYZ',
+      consent: 'opted-in',
       sentry,
     });
     expect(ok).toBe(true);
@@ -69,10 +70,37 @@ describe('initDaemonSentry', () => {
     expect(arg.initialScope.tags.bootNonce).toBe('BN-XYZ');
   });
 
+  // Phase 4 consent gate.
+  it('returns false when consent is pending (default), even with valid DSN', () => {
+    const { sentry, init } = makeSpy();
+    const ok = initDaemonSentry({
+      dsn: 'https://x@y.ingest.sentry.io/1',
+      release: '0.3.0',
+      bootNonce: 'BN',
+      // consent omitted — defaults to 'pending'
+      sentry,
+    });
+    expect(ok).toBe(false);
+    expect(init).not.toHaveBeenCalled();
+  });
+
+  it('returns false when consent is opted-out, even with valid DSN', () => {
+    const { sentry, init } = makeSpy();
+    const ok = initDaemonSentry({
+      dsn: 'https://x@y.ingest.sentry.io/1',
+      release: '0.3.0',
+      bootNonce: 'BN',
+      consent: 'opted-out',
+      sentry,
+    });
+    expect(ok).toBe(false);
+    expect(init).not.toHaveBeenCalled();
+  });
+
   it('flushDaemonSentry swallows transport errors', async () => {
     const { sentry, flush } = makeSpy();
     flush.mockRejectedValueOnce(new Error('network down'));
-    initDaemonSentry({ dsn: 'https://x@y/1', release: '0', bootNonce: 'B', sentry });
+    initDaemonSentry({ dsn: 'https://x@y/1', release: '0', bootNonce: 'B', consent: 'opted-in', sentry });
     await expect(flushDaemonSentry(50)).resolves.toBeUndefined();
     expect(flush).toHaveBeenCalledWith(50);
   });
@@ -80,7 +108,7 @@ describe('initDaemonSentry', () => {
   it('captureDaemonException swallows transport errors', () => {
     const { sentry, captureException } = makeSpy();
     captureException.mockImplementationOnce(() => { throw new Error('boom'); });
-    initDaemonSentry({ dsn: 'https://x@y/1', release: '0', bootNonce: 'B', sentry });
+    initDaemonSentry({ dsn: 'https://x@y/1', release: '0', bootNonce: 'B', consent: 'opted-in', sentry });
     expect(() => captureDaemonException(new Error('x'))).not.toThrow();
     expect(captureException).toHaveBeenCalled();
   });

--- a/tests/electron/crash/local-write-with-opted-out.test.ts
+++ b/tests/electron/crash/local-write-with-opted-out.test.ts
@@ -1,0 +1,73 @@
+// tests/electron/crash/local-write-with-opted-out.test.ts
+//
+// Phase 4 hard-constraint regression: local crash logs MUST keep writing
+// regardless of `crashUploadConsent` value. Only the network-upload path
+// (Sentry init) is gated. This test belt-and-suspenders the contract by
+// driving a recordIncident with consent forced to 'opted-out' and asserting
+// the on-disk artifact is present.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+// Stub the consent module to opted-out so we prove the collector ignores it.
+vi.mock('../../../electron/prefs/crashConsent', () => ({
+  isCrashUploadAllowed: () => false,
+  loadCrashConsent: () => 'opted-out',
+}));
+
+import { startCrashCollector } from '../../../electron/crash/collector';
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ccsm-crash-local-test-'));
+});
+
+afterEach(() => {
+  try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch {}
+});
+
+describe('local crash log writer', () => {
+  it('writes the incident dir + meta.json even when consent is opted-out', () => {
+    const collector = startCrashCollector({
+      crashRoot: path.join(tmpRoot, 'crashes'),
+      dmpStaging: path.join(tmpRoot, 'crashes', '_dmp-staging'),
+      appVersion: '0.3.0-test',
+      electronVersion: '41.0.0',
+    });
+    const dir = collector.recordIncident({
+      surface: 'main',
+      error: { message: 'simulated crash', name: 'Error' },
+    });
+    expect(fs.existsSync(dir)).toBe(true);
+    expect(fs.existsSync(path.join(dir, 'meta.json'))).toBe(true);
+    expect(fs.existsSync(path.join(dir, 'README.txt'))).toBe(true);
+    const meta = JSON.parse(fs.readFileSync(path.join(dir, 'meta.json'), 'utf8'));
+    expect(meta.surface).toBe('main');
+    expect(meta.appVersion).toBe('0.3.0-test');
+  });
+
+  it('writes daemon-exit incidents with stderr/stdout tails when consent is opted-out', () => {
+    const collector = startCrashCollector({
+      crashRoot: path.join(tmpRoot, 'crashes'),
+      dmpStaging: path.join(tmpRoot, 'crashes', '_dmp-staging'),
+      appVersion: '0.3.0-test',
+      electronVersion: '41.0.0',
+    });
+    const dir = collector.recordIncident({
+      surface: 'daemon-exit',
+      exitCode: 70,
+      signal: null,
+      stderrTail: ['boot ok', 'crash: SIGSEGV'],
+      stdoutTail: ['hello world'],
+      bootNonce: 'BN-1',
+      lastTraceId: 'TR-1',
+    });
+    expect(fs.readFileSync(path.join(dir, 'stderr-tail.txt'), 'utf8'))
+      .toContain('crash: SIGSEGV');
+    expect(fs.readFileSync(path.join(dir, 'stdout-tail.txt'), 'utf8'))
+      .toContain('hello world');
+  });
+});

--- a/tests/electron/daemon/supervisor.sentry-forward.test.ts
+++ b/tests/electron/daemon/supervisor.sentry-forward.test.ts
@@ -89,6 +89,25 @@ describe('spawnDaemon DSN forwarding', () => {
     expect(calls[0]!.options.env.CUSTOM_KEY).toBe('custom-value');
     expect(calls[0]!.options.env).toHaveProperty('CCSM_DAEMON_SENTRY_DSN');
   });
+
+  // Phase 4 consent forwarding.
+  it('forwards CCSM_DAEMON_CRASH_CONSENT="pending" by default', () => {
+    const { fn, calls } = fakeSpawn();
+    spawnDaemon({ binary: '/fake/ccsm-daemon', spawnFn: fn });
+    expect(calls[0]!.options.env.CCSM_DAEMON_CRASH_CONSENT).toBe('pending');
+  });
+
+  it('forwards explicit consent value (opted-in)', () => {
+    const { fn, calls } = fakeSpawn();
+    spawnDaemon({ binary: '/fake/ccsm-daemon', consent: 'opted-in', spawnFn: fn });
+    expect(calls[0]!.options.env.CCSM_DAEMON_CRASH_CONSENT).toBe('opted-in');
+  });
+
+  it('forwards explicit consent value (opted-out)', () => {
+    const { fn, calls } = fakeSpawn();
+    spawnDaemon({ binary: '/fake/ccsm-daemon', consent: 'opted-out', spawnFn: fn });
+    expect(calls[0]!.options.env.CCSM_DAEMON_CRASH_CONSENT).toBe('opted-out');
+  });
 });
 
 describe('resolveDaemonSentryDsn', () => {

--- a/tests/electron/ipc/crashIncidents.test.ts
+++ b/tests/electron/ipc/crashIncidents.test.ts
@@ -1,0 +1,160 @@
+// tests/electron/ipc/crashIncidents.test.ts
+//
+// Phase 4 crash observability — "Send last crash report" IPC behaviour.
+// Verifies:
+//   * getLastIncidentSummary picks the newest incident dir
+//   * alreadySent reflects the `.uploaded` marker
+//   * sendIncident refuses when no incident found / already-sent / consent
+//     not granted
+//   * sendIncident calls captureMessage with attachments + writes the marker
+//     on success
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+// We mock the consent module so the test controls the gate.
+const consentRef = { allowed: true };
+vi.mock('../../../electron/prefs/crashConsent', () => ({
+  isCrashUploadAllowed: () => consentRef.allowed,
+}));
+
+// `electron` and `@sentry/electron/main` are pulled in transitively by
+// crashIncidents.ts but we never call into them in these unit tests
+// (sendIncident receives the SentryLike spy directly). Stub minimally.
+vi.mock('electron', () => ({ app: {} }));
+vi.mock('@sentry/electron/main', () => ({
+  captureMessage: vi.fn(),
+  flush: vi.fn().mockResolvedValue(true),
+}));
+
+import { getLastIncidentSummary, sendIncident } from '../../../electron/ipc/crashIncidents';
+
+let tmpRoot: string;
+
+function mkIncident(name: string, files: Record<string, string>, mtime?: number): string {
+  const dir = path.join(tmpRoot, name);
+  fs.mkdirSync(dir, { recursive: true });
+  for (const [fname, body] of Object.entries(files)) {
+    fs.writeFileSync(path.join(dir, fname), body, 'utf8');
+  }
+  if (mtime !== undefined) {
+    fs.utimesSync(dir, mtime / 1000, mtime / 1000);
+  }
+  return dir;
+}
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ccsm-crash-test-'));
+  consentRef.allowed = true;
+});
+
+describe('getLastIncidentSummary', () => {
+  it('returns null when crash root is empty', () => {
+    expect(getLastIncidentSummary(tmpRoot)).toBeNull();
+  });
+
+  it('returns null when crash root does not exist', () => {
+    expect(getLastIncidentSummary(path.join(tmpRoot, 'missing'))).toBeNull();
+  });
+
+  it('picks the newest incident dir by mtime', () => {
+    mkIncident('older', { 'meta.json': JSON.stringify({ incidentId: 'A', ts: '2026-04-30T00:00:00Z', surface: 'main' }) }, Date.now() - 10000);
+    mkIncident('newer', { 'meta.json': JSON.stringify({ incidentId: 'B', ts: '2026-05-01T00:00:00Z', surface: 'daemon-exit' }) }, Date.now());
+    const got = getLastIncidentSummary(tmpRoot);
+    expect(got?.id).toBe('B');
+    expect(got?.surface).toBe('daemon-exit');
+    expect(got?.alreadySent).toBe(false);
+  });
+
+  it('reports alreadySent=true when .uploaded marker exists', () => {
+    mkIncident('inc1', {
+      'meta.json': JSON.stringify({ incidentId: 'X', ts: '2026-05-01', surface: 'main' }),
+      '.uploaded': '{}',
+    });
+    const got = getLastIncidentSummary(tmpRoot);
+    expect(got?.alreadySent).toBe(true);
+  });
+
+  it('falls back to dir name when meta.json is missing/corrupt', () => {
+    mkIncident('inc-no-meta', { 'stderr-tail.txt': 'oops' });
+    const got = getLastIncidentSummary(tmpRoot);
+    expect(got?.id).toBe('inc-no-meta');
+    expect(got?.surface).toBe('unknown');
+  });
+
+  it('skips dotfiles and underscore-prefixed dirs (e.g. _dmp-staging)', () => {
+    fs.mkdirSync(path.join(tmpRoot, '_dmp-staging'), { recursive: true });
+    expect(getLastIncidentSummary(tmpRoot)).toBeNull();
+  });
+});
+
+describe('sendIncident', () => {
+  function makeFakeSentry() {
+    const captureMessage = vi.fn().mockReturnValue('event-123');
+    const flush = vi.fn().mockResolvedValue(true);
+    return { captureMessage, flush };
+  }
+
+  it('refuses when incident dir is missing', async () => {
+    const sentry = makeFakeSentry();
+    const res = await sendIncident(path.join(tmpRoot, 'nope'), sentry);
+    expect(res).toEqual({ ok: false, reason: 'incident-not-found' });
+    expect(sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('refuses when .uploaded marker already present', async () => {
+    const dir = mkIncident('inc1', {
+      'meta.json': '{}',
+      '.uploaded': '{}',
+    });
+    const sentry = makeFakeSentry();
+    const res = await sendIncident(dir, sentry);
+    expect(res).toEqual({ ok: false, reason: 'already-sent' });
+    expect(sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('refuses when consent is not granted', async () => {
+    consentRef.allowed = false;
+    const dir = mkIncident('inc1', { 'meta.json': '{}' });
+    const sentry = makeFakeSentry();
+    const res = await sendIncident(dir, sentry);
+    expect(res).toEqual({ ok: false, reason: 'consent-not-granted' });
+    expect(sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('uploads attachments and writes the .uploaded marker on success', async () => {
+    const dir = mkIncident('inc1', {
+      'meta.json': '{"incidentId":"X"}',
+      'stderr-tail.txt': 'last 200 lines\n',
+      'README.txt': 'human summary\n',
+    });
+    const sentry = makeFakeSentry();
+    const res = await sendIncident(dir, sentry);
+    expect(res.ok).toBe(true);
+    expect((res as { eventId: string }).eventId).toBe('event-123');
+    expect(sentry.captureMessage).toHaveBeenCalledTimes(1);
+    const hint = sentry.captureMessage.mock.calls[0]![1] as { attachments: Array<{ filename: string }> };
+    const names = hint.attachments.map((a) => a.filename).sort();
+    expect(names).toEqual(['README.txt', 'meta.json', 'stderr-tail.txt']);
+    expect(sentry.flush).toHaveBeenCalled();
+    // Marker written, so a second send is refused.
+    expect(fs.existsSync(path.join(dir, '.uploaded'))).toBe(true);
+    const second = await sendIncident(dir, makeFakeSentry());
+    expect(second).toEqual({ ok: false, reason: 'already-sent' });
+  });
+
+  it('caps attachment size at 1 MB so a giant dmp does not blow the envelope', async () => {
+    const dir = mkIncident('inc1', { 'meta.json': '{}' });
+    // Write a 2 MB file alongside.
+    const big = Buffer.alloc(2 * 1024 * 1024, 0);
+    fs.writeFileSync(path.join(dir, 'frontend.dmp'), big);
+    const sentry = makeFakeSentry();
+    await sendIncident(dir, sentry);
+    const hint = sentry.captureMessage.mock.calls[0]![1] as { attachments: Array<{ filename: string }> };
+    const names = hint.attachments.map((a) => a.filename);
+    expect(names).toContain('meta.json');
+    expect(names).not.toContain('frontend.dmp');
+  });
+});

--- a/tests/electron/sentry/init.test.ts
+++ b/tests/electron/sentry/init.test.ts
@@ -1,11 +1,12 @@
 // tests/electron/sentry/init.test.ts
 //
-// Phase 2 crash observability (spec §6, plan Task 7) — main-process Sentry
-// init. Verifies:
+// Phase 2 + Phase 4 crash observability — main-process Sentry init.
+// Verifies:
 //   * no-op when DSN env / build-info absent (OSS-fork leak prevention)
 //   * no-op when DSN is the literal `***REDACTED***` placeholder
 //   * init called with `tags.surface = 'main'` when DSN configured
 //   * SENTRY_DSN_MAIN takes precedence over the legacy SENTRY_DSN env
+//   * Phase 4 consent gate: pending / opted-out → no init even with valid DSN
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as SentryMain from '@sentry/electron/main';
@@ -14,8 +15,12 @@ vi.mock('@sentry/electron/main', () => ({ init: vi.fn() }));
 vi.mock('electron', () => ({
   app: { getVersion: () => '0.3.0-test', isPackaged: false },
 }));
-vi.mock('../../../electron/prefs/crashReporting', () => ({
-  loadCrashReportingOptOut: () => false,
+
+// Mutable consent stub — tests reach into this to flip the gate.
+const consentRef = { value: 'opted-in' as 'pending' | 'opted-in' | 'opted-out' };
+vi.mock('../../../electron/prefs/crashConsent', () => ({
+  loadCrashConsent: () => consentRef.value,
+  isCrashUploadAllowed: () => consentRef.value === 'opted-in',
 }));
 
 const init = SentryMain.init as unknown as ReturnType<typeof vi.fn>;
@@ -23,6 +28,7 @@ const init = SentryMain.init as unknown as ReturnType<typeof vi.fn>;
 beforeEach(() => {
   init.mockReset();
   vi.unstubAllEnvs();
+  consentRef.value = 'opted-in';
 });
 
 describe('initSentry (electron-main)', () => {
@@ -70,5 +76,33 @@ describe('initSentry (electron-main)', () => {
     const { initSentry } = await import('../../../electron/sentry/init');
     initSentry();
     expect(init.mock.calls[0]![0].dsn).toBe('https://winner@o0.ingest.sentry.io/3');
+  });
+
+  // Phase 4 consent gate.
+  it('returns early when consent is "pending", even with a valid DSN', async () => {
+    vi.stubEnv('SENTRY_DSN_MAIN', 'https://abc@o0.ingest.sentry.io/1');
+    consentRef.value = 'pending';
+    const { initSentry } = await import('../../../electron/sentry/init');
+    initSentry();
+    expect(init).not.toHaveBeenCalled();
+  });
+
+  it('returns early when consent is "opted-out", even with a valid DSN', async () => {
+    vi.stubEnv('SENTRY_DSN_MAIN', 'https://abc@o0.ingest.sentry.io/1');
+    consentRef.value = 'opted-out';
+    const { initSentry } = await import('../../../electron/sentry/init');
+    initSentry();
+    expect(init).not.toHaveBeenCalled();
+  });
+
+  // Reverse-verify: we drop the gate by forcing consent='opted-in' even
+  // though the real-world setting in this scenario would be 'opted-out'.
+  // The opposite assertion (init NOT called) flips and the test catches it.
+  it('reverse-verify: with the gate forced open, init runs (proves the gate is what stops it)', async () => {
+    vi.stubEnv('SENTRY_DSN_MAIN', 'https://abc@o0.ingest.sentry.io/1');
+    consentRef.value = 'opted-in';
+    const { initSentry } = await import('../../../electron/sentry/init');
+    initSentry();
+    expect(init).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## What landed (Task #1091, plan phase 4)

User-visible loop for crash observability:

- **First-run consent modal** (`src/components/CrashConsentModal.tsx`) — pops on first launch when `crashUploadConsent === 'pending'`. Two buttons: **Allow** (`opted-in`) / **Not now** (`opted-out`); a collapsible "What's sent" disclosure; explicit copy stating local crash logs are saved regardless. No "remind me later" — user flips later in Settings.
- **Tri-state consent prefs module** (`electron/prefs/crashConsent.ts`) — `pending` (default) / `opted-in` / `opted-out`, persisted under `crashUploadConsent` in `app_state`. Cache invalidates via `stateSavedBus` so the gate takes effect within one event without an app restart. Falls back to the legacy `crashReportingOptOut` boolean so an upgrade never silent-opt-ins users who previously opted out.
- **Sentry init gating** — `electron/sentry/init.ts` and `daemon/src/sentry/init.ts` both early-return when consent != `'opted-in'`. The renderer SDK has no DSN of its own — it forwards over the preload IPC bridge to main, which is now uninitialised under the gate. Per-process gating per task brief.
- **Supervisor forwarding** — `electron/daemon/supervisor.ts` always sets `CCSM_DAEMON_CRASH_CONSENT` env on the daemon child (defaults to `'pending'`), parallel to the existing `CCSM_DAEMON_SENTRY_DSN` forwarding.
- **Send last crash report** — Settings → Updates pane now hosts a tri-state consent toggle plus a "Send last crash report" button + status text. Re-uploads the most recent on-disk incident dir via `Sentry.captureMessage` with attachments, then writes a `.uploaded` marker so a double-send is refused. Disabled when no incident exists, when already sent, or when consent is not granted. Backed by two new IPC channels (`crash:get-last-incident`, `crash:send-last-incident`) implemented in `electron/ipc/crashIncidents.ts` and exposed on `window.ccsm.crash`.
- **i18n** (en + zh) — full sentence-case parity, no SCREAMING strings. Keys added under `settings:crashReporting.*` and `settings:consentModal.*`.

## Reverse-verify (FAIL→PASS for the consent gate)

Patched `electron/sentry/init.ts` to neutralise the gate (`if (false && consent !== 'opted-in')`) and reran `tests/electron/sentry/init.test.ts`:

```
 FAIL  tests/electron/sentry/init.test.ts > initSentry (electron-main) > returns early when consent is "pending", even with a valid DSN
 FAIL  tests/electron/sentry/init.test.ts > initSentry (electron-main) > returns early when consent is "opted-out", even with a valid DSN
 Test Files  1 failed (1)
      Tests  2 failed | 6 passed (8)
```

Restored the gate; same suite returns:

```
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

Same FAIL→PASS structure is exercised in `electron/prefs/__tests__/crashConsent.test.ts` (`reverse-verify: opted-in passes AND opted-out blocks`) and `tests/daemon/sentry/init.test.ts` (`returns false when consent is pending`, `returns false when consent is opted-out`).

## Local crash log behaviour with consent=opted-out

**Verified local logs still write.** New regression test `tests/electron/crash/local-write-with-opted-out.test.ts` mocks `isCrashUploadAllowed` to false / `loadCrashConsent` to `'opted-out'`, then drives `recordIncident` for both `surface: 'main'` and `surface: 'daemon-exit'`. Both produce the expected `meta.json`, `README.txt`, `stderr-tail.txt`, `stdout-tail.txt` artifacts under the temp crash root. The collector path in `electron/main.ts` (`crashReporter.start` + `startCrashCollector` + `wireCrashHandlers`) runs unconditionally and is not touched by this PR — the consent gate lives strictly in the Sentry init paths.

## i18n keys added (en + zh, both populated)

```
settings.crashReporting.consentLabel
settings.crashReporting.consentHint
settings.crashReporting.consentLocalNote
settings.crashReporting.sendLast
settings.crashReporting.sendLastNoCrash
settings.crashReporting.sendLastAlreadySent
settings.crashReporting.sendLastReady           (vars: ts, surface)
settings.crashReporting.sendLastSending
settings.crashReporting.sendLastSuccess
settings.crashReporting.sendLastError           (vars: reason)
settings.consentModal.title
settings.consentModal.body
settings.consentModal.whatsSent
settings.consentModal.whatsSentItem1
settings.consentModal.whatsSentItem2
settings.consentModal.whatsSentItem3
settings.consentModal.allow
settings.consentModal.notNow
settings.consentModal.footer
```

`tests/i18n-key-parity.test.ts` passes (parity enforced).

## Test plan

- [x] `electron/prefs/__tests__/crashConsent.test.ts` (new — 13 cases)
- [x] `tests/electron/ipc/crashIncidents.test.ts` (new — 11 cases)
- [x] `tests/electron/crash/local-write-with-opted-out.test.ts` (new — 2 cases, hard-constraint regression)
- [x] `tests/electron/sentry/init.test.ts` (extended with 3 consent-gate cases incl. reverse-verify)
- [x] `tests/daemon/sentry/init.test.ts` (extended with 2 consent-gate cases)
- [x] `tests/electron/daemon/supervisor.sentry-forward.test.ts` (extended with 3 `CCSM_DAEMON_CRASH_CONSENT` forwarding cases)
- [x] `npm run typecheck` — green
- [x] `npm run build` — green (1.2 MiB bundle, only existing perf warnings)
- [x] No new lint errors introduced (only the pre-existing `no-undef` set on test config + non-touched files)

Pre-existing test failures unrelated to this PR: `better-sqlite3` ABI mismatch on the local Node version (NODE_MODULE_VERSION 145 vs 137). These fail identically on `origin/working` HEAD and are an environment artifact, not a regression.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>