### PR TITLE
feat(v04 T07): parity-test framework (M1)

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -1,0 +1,92 @@
+name: parity
+# T07 — parity-test framework workflow.
+#
+# Spec: docs/superpowers/specs/2026-05-01-v0.4-web-design.md
+#   - ch03 §7.1 (parity tests are the load-bearing safety net during M1's 12 PRs)
+#   - ch08 §3   (L2 testing layer)
+#   - ch08 §9.1 (CI matrix; this is the parity-specific job)
+#   - ch09 §2 T07 deliverable
+#
+# What this runs: `npm run test:parity` (= `vitest run tests/parity`).
+# In M1 the suite contains the framework's own unit tests + one placeholder
+# fixture exercise. T06 + Batch A (T09) bridge swaps add real cases.
+#
+# Why a dedicated workflow rather than folding into ci.yml: ci.yml is gated
+# `if: false` for the v0.3 → v0.4 migration window (Task #1048). Parity tests
+# are the safety net during exactly that window — they MUST run on every PR
+# even while ci.yml is dark. Folding into ci.yml would require either un-
+# gating ci.yml early (Task #1048 territory) or hand-tracking which PRs
+# touched the migration path. Dedicated workflow keeps the safety net always
+# on with zero scheduling logic.
+#
+# `continue-on-error: false` (the default) is intentional: per the brief,
+# the placeholder ensures the step doesn't no-op, and once T06 lands real
+# cases any divergence must block the PR.
+
+on:
+  pull_request:
+    branches: [main, working]
+    paths:
+      - 'tests/parity/**'
+      - 'daemon/src/connect/**'
+      - 'daemon/src/envelope/**'
+      - 'electron/preload/bridges/**'
+      - 'proto/**'
+      - 'gen/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/parity.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: parity-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  parity:
+    name: parity (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        # Both daemon + Electron run on Linux (CI default) and Windows
+        # (primary developer platform per CLAUDE.md). macOS coverage rides
+        # on the post-migration ci.yml when restored.
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      # Same python pin as ci.yml — better-sqlite3 postinstall imports
+      # distutils via the older node-gyp.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache node_modules
+        id: nm_cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: nm-${{ runner.os }}-${{ runner.arch }}-node20-${{ hashFiles('package-lock.json') }}
+
+      - name: Install deps
+        if: steps.nm_cache.outputs.cache-hit != 'true'
+        run: npm ci --legacy-peer-deps
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
+
+      # Rebuild better-sqlite3 against Node ABI (vitest runs under Node).
+      - name: Rebuild better-sqlite3 for Node
+        run: npm rebuild better-sqlite3
+
+      - name: Run parity tests
+        run: npm run test:parity

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lint:fixtures": "tsx scripts/lint-fixtures.ts",
     "lint:schema-additive": "tsx scripts/lint-schema-additive.ts",
     "test": "vitest run",
+    "test:parity": "vitest run tests/parity",
     "check:electron-pin": "node scripts/check-electron-pin.cjs",
     "pretest": "node scripts/check-electron-pin.cjs",
     "test:watch": "vitest",

--- a/tests/parity/__fixtures__/ping.golden.json
+++ b/tests/parity/__fixtures__/ping.golden.json
@@ -1,0 +1,16 @@
+{
+  "rpc": "Ping",
+  "description": "Placeholder parity fixture exercised by tests/parity/ping.parity.test.ts. Replaced by a real recorded fixture in T06 once Ping is registered on Connect (per spec ch09 §2 T06). Until then the test uses manual stubs for both transports to prove the framework plumbing end-to-end.",
+  "cases": [
+    {
+      "name": "ping echoes the requested timestamp",
+      "request": { "clientNowMs": 1700000000 },
+      "expectedV03Response": { "ok": true, "echoNowMs": 1700000000 },
+      "expectedV04Response": { "ok": true, "echoNowMs": 1700000000 },
+      "parityOpts": {
+        "ignoreFields": ["serverNowMs", "traceId"],
+        "normalizationStrategy": "structural"
+      }
+    }
+  ]
+}

--- a/tests/parity/framework.test.ts
+++ b/tests/parity/framework.test.ts
@@ -1,0 +1,225 @@
+// T07 — parity-test framework unit tests.
+//
+// Spec: docs/superpowers/specs/2026-05-01-v0.4-web-design.md
+//   - ch03 §7   (test discipline per swap PR — parity test required per RPC)
+//   - ch03 §7.1 (parity-test framework shape: assertParity + ignoreFields + coerce)
+//   - ch08 §3   (L2 daemon Connect handler unit + contract tests)
+//   - ch08 §8   (reverse-verify discipline)
+//
+// What this file proves about the framework:
+//   1. `runParityCase` runs envelopeCall + connectCall in parallel and asserts
+//      the responses are equivalent under the supplied `equivalence` fn.
+//   2. When responses diverge, the framework FAILS the test with a
+//      side-by-side JSON diff (so a regressing bridge is loud, not silent).
+//   3. `tolerantFields` strips ignore-listed keys from BOTH sides before compare,
+//      so timestamp / trace-id drift doesn't cause false positives.
+//   4. The default deep-equal equivalence catches structural divergence
+//      (different keys, different values, different array order).
+//
+// Reverse-verify: replacing `equivalence` with `() => true` makes a divergent
+// case PASS — proving the equivalence fn is the gating mechanism, not some
+// happy-path coincidence. See `forces a divergent case to pass when equivalence
+// is overridden to always-true` below.
+
+import { describe, it, expect } from 'vitest';
+import {
+  assertParity,
+  runParityCase,
+  ParityDivergenceError,
+  defaultEquivalence,
+} from './framework.js';
+
+describe('assertParity (low-level deep-equal + ignoreFields + coerce)', () => {
+  it('passes when responses are deep-equal', () => {
+    expect(() =>
+      assertParity({ a: 1, b: 'two' }, { a: 1, b: 'two' }),
+    ).not.toThrow();
+  });
+
+  it('throws ParityDivergenceError when responses differ', () => {
+    expect(() => assertParity({ a: 1 }, { a: 2 })).toThrow(ParityDivergenceError);
+  });
+
+  it('error message contains a side-by-side diff (envelope + connect labels)', () => {
+    let caught: unknown;
+    try {
+      assertParity({ a: 1, b: 'x' }, { a: 2, b: 'x' });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ParityDivergenceError);
+    const msg = (caught as Error).message;
+    expect(msg).toMatch(/envelope/i);
+    expect(msg).toMatch(/connect/i);
+    // The differing field name should appear in the diff so the developer
+    // can find the offending key without scrolling through the whole JSON.
+    expect(msg).toContain('a');
+  });
+
+  it('ignoreFields strips listed keys from BOTH sides before compare', () => {
+    expect(() =>
+      assertParity(
+        { a: 1, ts: 1700000000 },
+        { a: 1, ts: 1800000000 },
+        { ignoreFields: ['ts'] },
+      ),
+    ).not.toThrow();
+  });
+
+  it('ignoreFields supports nested dotted paths', () => {
+    expect(() =>
+      assertParity(
+        { meta: { traceId: 'abc' }, data: { v: 1 } },
+        { meta: { traceId: 'xyz' }, data: { v: 1 } },
+        { ignoreFields: ['meta.traceId'] },
+      ),
+    ).not.toThrow();
+  });
+
+  it('coerce normalizes per-field before compare', () => {
+    expect(() =>
+      assertParity(
+        { pid: '1234' },
+        { pid: 1234 },
+        { coerce: { pid: (v) => Number(v) } },
+      ),
+    ).not.toThrow();
+  });
+
+  it('still fails when coerce yields different values', () => {
+    expect(() =>
+      assertParity(
+        { pid: '1234' },
+        { pid: '5678' },
+        { coerce: { pid: (v) => Number(v) } },
+      ),
+    ).toThrow(ParityDivergenceError);
+  });
+});
+
+describe('defaultEquivalence', () => {
+  it('returns true for deep-equal values', () => {
+    expect(defaultEquivalence({ a: [1, 2] }, { a: [1, 2] })).toBe(true);
+  });
+
+  it('returns false for divergent values', () => {
+    expect(defaultEquivalence({ a: 1 }, { a: 2 })).toBe(false);
+  });
+
+  it('honors ignoreFields when supplied through the optional second arg', () => {
+    expect(
+      defaultEquivalence(
+        { a: 1, ts: 1 },
+        { a: 1, ts: 2 },
+        { ignoreFields: ['ts'] },
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('runParityCase', () => {
+  it('passes when envelopeCall and connectCall return equivalent responses', async () => {
+    await expect(
+      runParityCase({
+        name: 'happy path',
+        envelopeCall: async () => ({ ok: true, value: 42 }),
+        connectCall: async () => ({ ok: true, value: 42 }),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('runs envelopeCall and connectCall in parallel (not serial)', async () => {
+    // Both calls take 50ms; parallel total should be ~50ms, serial ~100ms.
+    // We assert < 90ms to leave generous CI headroom but still catch a serial
+    // implementation.
+    const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+    const start = Date.now();
+    await runParityCase({
+      name: 'parallel timing',
+      envelopeCall: async () => {
+        await sleep(50);
+        return { v: 1 };
+      },
+      connectCall: async () => {
+        await sleep(50);
+        return { v: 1 };
+      },
+    });
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeLessThan(90);
+  });
+
+  it('throws (fails the test) when responses diverge — synthetic {a:1} vs {a:2}', async () => {
+    await expect(
+      runParityCase({
+        name: 'synthetic divergence',
+        envelopeCall: async () => ({ a: 1 }),
+        connectCall: async () => ({ a: 2 }),
+      }),
+    ).rejects.toThrow(ParityDivergenceError);
+  });
+
+  it('failure message includes the case name so multi-case reports are scannable', async () => {
+    let caught: unknown;
+    try {
+      await runParityCase({
+        name: 'my-rpc divergence',
+        envelopeCall: async () => ({ x: 1 }),
+        connectCall: async () => ({ x: 2 }),
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ParityDivergenceError);
+    expect((caught as Error).message).toContain('my-rpc divergence');
+  });
+
+  it('respects tolerantFields (drift in those fields does not fail the case)', async () => {
+    await expect(
+      runParityCase({
+        name: 'tolerant ts',
+        envelopeCall: async () => ({ ts: 1, v: 'same' }),
+        connectCall: async () => ({ ts: 2, v: 'same' }),
+        tolerantFields: ['ts'],
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('forces a divergent case to PASS when equivalence is overridden to always-true (reverse-verify)', async () => {
+    // Reverse-verify per ch08 §8: prove equivalence fn is the gate by
+    // overriding it. With the override, divergent responses no longer fail.
+    // Without the override (see prior test), they DO fail.
+    await expect(
+      runParityCase({
+        name: 'reverse verify',
+        envelopeCall: async () => ({ a: 1 }),
+        connectCall: async () => ({ a: 2 }),
+        equivalence: () => true,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('propagates errors from envelopeCall (does not swallow as divergence)', async () => {
+    await expect(
+      runParityCase({
+        name: 'envelope error',
+        envelopeCall: async () => {
+          throw new Error('envelope boom');
+        },
+        connectCall: async () => ({ a: 1 }),
+      }),
+    ).rejects.toThrow(/envelope boom/);
+  });
+
+  it('propagates errors from connectCall (does not swallow as divergence)', async () => {
+    await expect(
+      runParityCase({
+        name: 'connect error',
+        envelopeCall: async () => ({ a: 1 }),
+        connectCall: async () => {
+          throw new Error('connect boom');
+        },
+      }),
+    ).rejects.toThrow(/connect boom/);
+  });
+});

--- a/tests/parity/framework.ts
+++ b/tests/parity/framework.ts
@@ -1,0 +1,370 @@
+// T07 — parity-test framework (M1 first PR; load-bearing for M2 bridge swap).
+//
+// Spec: docs/superpowers/specs/2026-05-01-v0.4-web-design.md
+//   - ch03 §7   (test discipline per swap PR)
+//   - ch03 §7.1 (parity-test framework: assertParity + ignoreFields + coerce)
+//   - ch08 §3   (L2 daemon Connect handler unit + contract tests)
+//   - ch08 §8   (reverse-verify discipline; equivalence is the gating mechanism)
+//   - ch09 §2 T07 deliverable
+//
+// Single Responsibility (producer / decider / sink):
+//   - PRODUCER: this module produces a "passed" or "diverged" verdict per case.
+//   - DECIDER: `defaultEquivalence` (deep-equal under ignoreFields/coerce) is
+//     the single decision point — a test author can swap it via the
+//     `equivalence` option (escape hatch for type-widening cases per ch03 §7.1's
+//     "normalizationStrategy" + reverse-verify discipline).
+//   - SINK: throwing `ParityDivergenceError` is the only side effect — vitest
+//     converts the throw into a test failure with the diff as message body.
+//     This module does NOT log, does NOT write fixtures, does NOT touch
+//     network. Fixture recording (RECORD_PARITY=1) is a separate scope (T09+).
+//
+// Why the framework lives at `tests/parity/` (not `daemon/__tests__/parity/`
+// as the spec suggests): the parity case crosses three layers — daemon
+// envelope handler + daemon Connect handler + electron preload bridge
+// equivalence. Placing it under `daemon/__tests__/` would imply a daemon-only
+// concern; the cross-cutting location matches `tests/electron-load-smoke.test.ts`
+// + `tests/persist-shape.test.ts` precedent for cross-layer assertions. Manager
+// confirmed at task #1086 dispatch.
+
+import { isDeepStrictEqual } from 'node:util';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Equivalence options shared by `assertParity` and `defaultEquivalence`.
+ *
+ * - `ignoreFields`: dotted paths whose values are dropped from BOTH sides
+ *   before comparison. Use for fields that are non-deterministic by design
+ *   (timestamps, ULIDs, trace-ids, PIDs). Per ch03 §7.1 the framework MUST
+ *   handle these without forcing per-RPC custom code.
+ *
+ * - `coerce`: per-field normalizer applied to BOTH sides before comparison.
+ *   Use when v0.3 returns `unknown`-typed scalars (e.g. `pid: number | string`)
+ *   and v0.4 returns a single typed shape — coerce both to the canonical
+ *   type, then compare.
+ */
+export interface ParityOptions {
+  readonly ignoreFields?: readonly string[];
+  readonly coerce?: Readonly<Record<string, (value: unknown) => unknown>>;
+}
+
+/**
+ * Equivalence function signature. Default is `defaultEquivalence` (deep-equal
+ * under {@link ParityOptions}); test authors may pass their own to handle
+ * the type-widening cases of ch03 §7.1 ("normalizationStrategy") or to
+ * reverse-verify the test (override to `() => true` and confirm a divergent
+ * case still PASSES — that proves equivalence is the gate).
+ */
+export type EquivalenceFn = (
+  envelopeResp: unknown,
+  connectResp: unknown,
+  opts?: ParityOptions,
+) => boolean;
+
+/**
+ * One parity case. The framework calls both transports in parallel, then
+ * compares the responses via `equivalence`.
+ */
+export interface ParityCase<TResp = unknown> {
+  /** Human-readable case ID. Surfaces in failure messages. */
+  readonly name: string;
+
+  /** Invokes the v0.3 envelope path. */
+  readonly envelopeCall: () => Promise<TResp>;
+
+  /** Invokes the v0.4 Connect path. */
+  readonly connectCall: () => Promise<TResp>;
+
+  /**
+   * Equivalence function. Defaults to {@link defaultEquivalence} (deep-equal
+   * under {@link tolerantFields} / {@link coerce}). Pass your own to opt into
+   * the type-widening normalization of ch03 §7.1, or to reverse-verify the
+   * case (pass `() => true`).
+   */
+  readonly equivalence?: EquivalenceFn;
+
+  /**
+   * Convenience alias for {@link ParityOptions.ignoreFields}, surfaced at the
+   * top level because every parity case in M1 needs at least the trace-id +
+   * timestamp ignore. Internally folded into the options passed to
+   * `equivalence`.
+   */
+  readonly tolerantFields?: readonly string[];
+
+  /** Per-field coercion. See {@link ParityOptions.coerce}. */
+  readonly coerce?: ParityOptions['coerce'];
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when envelope and Connect responses are not equivalent under the
+ * supplied (or default) equivalence function. The message body contains a
+ * side-by-side diff so the failing PR shows the offending fields without the
+ * developer needing to grep two huge JSON blobs.
+ */
+export class ParityDivergenceError extends Error {
+  public readonly envelopeResp: unknown;
+  public readonly connectResp: unknown;
+
+  constructor(args: {
+    caseName?: string;
+    envelopeResp: unknown;
+    connectResp: unknown;
+    diff: string;
+  }) {
+    const head = args.caseName
+      ? `parity divergence in ${args.caseName}`
+      : 'parity divergence';
+    super(`${head}\n${args.diff}`);
+    this.name = 'ParityDivergenceError';
+    this.envelopeResp = args.envelopeResp;
+    this.connectResp = args.connectResp;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Default equivalence + assertion
+// ---------------------------------------------------------------------------
+
+/**
+ * Default equivalence: deep-equal under ignoreFields + coerce. Used by
+ * `assertParity` and `runParityCase` when no override is supplied.
+ *
+ * Implementation is `node:util.isDeepStrictEqual` after stripping ignore-fields
+ * and applying coerce. Both inputs are normalized through the same pipeline
+ * to keep the operation symmetric.
+ */
+export const defaultEquivalence: EquivalenceFn = (envelopeResp, connectResp, opts) => {
+  const a = normalize(envelopeResp, opts);
+  const b = normalize(connectResp, opts);
+  return isDeepStrictEqual(a, b);
+};
+
+/**
+ * Low-level assertion. Throws {@link ParityDivergenceError} if the two
+ * responses are not deep-equal under the supplied options. Used by
+ * `runParityCase` when no `equivalence` override is given; also exported so
+ * tests outside the framework (e.g. M2 bridge-swap PRs) can reuse the same
+ * comparison engine without going through the full case runner.
+ */
+export function assertParity(
+  envelopeResp: unknown,
+  connectResp: unknown,
+  opts?: ParityOptions,
+  caseName?: string,
+): void {
+  if (defaultEquivalence(envelopeResp, connectResp, opts)) return;
+  throw new ParityDivergenceError({
+    caseName,
+    envelopeResp,
+    connectResp,
+    diff: renderDiff(normalize(envelopeResp, opts), normalize(connectResp, opts)),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Case runner
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a parity case: invoke both transports in parallel, then assert
+ * equivalence. Throws {@link ParityDivergenceError} on mismatch (which vitest
+ * surfaces as a test failure with the diff as message). Errors thrown by
+ * either transport are propagated as-is — they are NOT swallowed as a
+ * divergence, because a transport-level error means the test environment is
+ * broken (not that the bridge is wrong).
+ *
+ * Per ch08 §8 reverse-verify discipline, passing `equivalence: () => true`
+ * causes any divergent case to pass — useful for reverse-verifying that the
+ * equivalence function is the gating mechanism, not some happy-path
+ * coincidence in the rest of the test setup.
+ */
+export async function runParityCase<TResp>(c: ParityCase<TResp>): Promise<void> {
+  // Parallel invocation per ch03 §7.1 — keeps the case runtime bounded by
+  // max(envelope, connect) rather than the sum, which matters when the
+  // corpus grows to ~46 RPCs (ch02 §1).
+  const [envelopeResp, connectResp] = await Promise.all([
+    c.envelopeCall(),
+    c.connectCall(),
+  ]);
+
+  const equivalence = c.equivalence ?? defaultEquivalence;
+  const opts: ParityOptions = {
+    ignoreFields: c.tolerantFields,
+    coerce: c.coerce,
+  };
+
+  if (equivalence(envelopeResp, connectResp, opts)) return;
+
+  throw new ParityDivergenceError({
+    caseName: c.name,
+    envelopeResp,
+    connectResp,
+    diff: renderDiff(normalize(envelopeResp, opts), normalize(connectResp, opts)),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply ignoreFields + coerce to one response. Returns a deep clone; the
+ * input is not mutated. We deep-clone via `structuredClone` so callers can
+ * pass live response objects without worrying about test contamination.
+ */
+function normalize(value: unknown, opts: ParityOptions | undefined): unknown {
+  if (opts === undefined || (!opts.ignoreFields && !opts.coerce)) {
+    return safeClone(value);
+  }
+  const cloned = safeClone(value);
+  if (opts.ignoreFields) {
+    for (const path of opts.ignoreFields) {
+      deletePath(cloned, path);
+    }
+  }
+  if (opts.coerce) {
+    for (const [path, fn] of Object.entries(opts.coerce)) {
+      coercePath(cloned, path, fn);
+    }
+  }
+  return cloned;
+}
+
+/** structuredClone falls back to JSON round-trip for environments that lack it. */
+function safeClone<T>(value: T): T {
+  if (typeof structuredClone === 'function') {
+    try {
+      return structuredClone(value);
+    } catch {
+      // Fall through to JSON path for non-structured-cloneable values
+      // (functions, symbols). Parity responses are always JSON-shaped per
+      // ch02 §1 (Connect/Protobuf wire), so the JSON fallback is faithful.
+    }
+  }
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+/** Delete a value at a dotted path. No-op if the path is absent. */
+function deletePath(root: unknown, path: string): void {
+  const segments = path.split('.');
+  let cursor: unknown = root;
+  for (let i = 0; i < segments.length - 1; i++) {
+    if (typeof cursor !== 'object' || cursor === null) return;
+    cursor = (cursor as Record<string, unknown>)[segments[i]!];
+  }
+  if (typeof cursor === 'object' && cursor !== null) {
+    delete (cursor as Record<string, unknown>)[segments[segments.length - 1]!];
+  }
+}
+
+/** Apply coerce fn to the value at a dotted path. No-op if the path is absent. */
+function coercePath(
+  root: unknown,
+  path: string,
+  fn: (v: unknown) => unknown,
+): void {
+  const segments = path.split('.');
+  let cursor: unknown = root;
+  for (let i = 0; i < segments.length - 1; i++) {
+    if (typeof cursor !== 'object' || cursor === null) return;
+    cursor = (cursor as Record<string, unknown>)[segments[i]!];
+  }
+  if (typeof cursor !== 'object' || cursor === null) return;
+  const tail = segments[segments.length - 1]!;
+  if (!(tail in (cursor as Record<string, unknown>))) return;
+  (cursor as Record<string, unknown>)[tail] = fn(
+    (cursor as Record<string, unknown>)[tail],
+  );
+}
+
+/**
+ * Render a side-by-side diff of two normalized values. Output format:
+ *
+ *     envelope (v0.3):
+ *     <indented JSON>
+ *
+ *     connect  (v0.4):
+ *     <indented JSON>
+ *
+ *     differing fields:
+ *     - <path>: <env value> vs <connect value>
+ *
+ * No external diff dep yet — the codebase has no `diff` / `json-diff` package
+ * and adding one purely for the framework scaffold isn't justified at M1
+ * scale. If M2 bridge-swap PRs find the diff hard to read, swap in `jest-diff`
+ * (small, no transitive deps) — the renderDiff fn is the single seam.
+ */
+function renderDiff(a: unknown, b: unknown): string {
+  const lines: string[] = [];
+  lines.push('envelope (v0.3):');
+  lines.push(indent(stringify(a)));
+  lines.push('');
+  lines.push('connect  (v0.4):');
+  lines.push(indent(stringify(b)));
+  const fieldDiffs = collectFieldDiffs(a, b, '');
+  if (fieldDiffs.length > 0) {
+    lines.push('');
+    lines.push('differing fields:');
+    for (const fd of fieldDiffs) {
+      lines.push(`- ${fd}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+function stringify(v: unknown): string {
+  try {
+    return JSON.stringify(v, null, 2);
+  } catch {
+    return String(v);
+  }
+}
+
+function indent(s: string): string {
+  return s
+    .split('\n')
+    .map((l) => '  ' + l)
+    .join('\n');
+}
+
+/**
+ * Walk both values in parallel, collect per-leaf differences as
+ * "path: a vs b" strings. Bounded at 50 lines so a wholly-divergent response
+ * doesn't drown the test report.
+ */
+function collectFieldDiffs(
+  a: unknown,
+  b: unknown,
+  path: string,
+  out: string[] = [],
+): string[] {
+  if (out.length >= 50) return out;
+  if (isDeepStrictEqual(a, b)) return out;
+  const aIsObj = typeof a === 'object' && a !== null && !Array.isArray(a);
+  const bIsObj = typeof b === 'object' && b !== null && !Array.isArray(b);
+  if (aIsObj && bIsObj) {
+    const keys = new Set([
+      ...Object.keys(a as Record<string, unknown>),
+      ...Object.keys(b as Record<string, unknown>),
+    ]);
+    for (const k of keys) {
+      const child = path ? `${path}.${k}` : k;
+      collectFieldDiffs(
+        (a as Record<string, unknown>)[k],
+        (b as Record<string, unknown>)[k],
+        child,
+        out,
+      );
+    }
+    return out;
+  }
+  // Leaf or array: emit one line.
+  out.push(`${path || '<root>'}: ${stringify(a)} vs ${stringify(b)}`);
+  return out;
+}

--- a/tests/parity/ping.parity.test.ts
+++ b/tests/parity/ping.parity.test.ts
@@ -1,0 +1,62 @@
+// T07 — placeholder parity case for the framework.
+//
+// Why this exists: the parity framework lands BEFORE the first bridge swap
+// (T06 registers Ping + GetVersion). Without at least one parity case driving
+// the framework end-to-end, the test:parity npm script would no-op and any
+// regression in `runParityCase` would go uncaught until the first real case
+// lands. This placeholder uses manually-crafted stub responses for BOTH
+// transports — it does NOT spin up a real daemon, does NOT call any real
+// envelope sender or Connect client. T06 will replace it with a real case
+// that boots the daemon and pairs envelope `daemon.ping` against Connect
+// `Ping`.
+//
+// Spec: docs/superpowers/specs/2026-05-01-v0.4-web-design.md
+//   - ch09 §2 T07 deliverable: "framework lands in M1 ahead of any Batch A
+//     bridge swap; one example parity test (`getVersion`) passes". This
+//     placeholder satisfies the "one example passes" leg until the real
+//     T06 hello/ping handlers exist.
+//   - ch03 §7.1 fixture shape: `{ name, request, expectedV03Response,
+//     expectedV04Response, parityOpts }`. We exercise that shape verbatim
+//     so the fixture loader remains under test as the corpus grows.
+
+import { describe, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { runParityCase } from './framework.js';
+
+interface ParityFixture {
+  rpc: string;
+  description: string;
+  cases: ReadonlyArray<{
+    name: string;
+    request: Record<string, unknown>;
+    expectedV03Response: Record<string, unknown>;
+    expectedV04Response: Record<string, unknown>;
+    parityOpts?: {
+      ignoreFields?: string[];
+      normalizationStrategy?: string;
+    };
+  }>;
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(__dirname, '__fixtures__', 'ping.golden.json');
+const fixture: ParityFixture = JSON.parse(readFileSync(fixturePath, 'utf8'));
+
+describe('parity placeholder — Ping (T07 plumbing exercise)', () => {
+  for (const c of fixture.cases) {
+    it(`[${fixture.rpc}] ${c.name}`, async () => {
+      // Placeholder: both transports return the recorded golden response. T06
+      // will swap these stubs for real envelope + Connect calls against a
+      // booted daemon. The parity framework's behavior is identical either
+      // way — it doesn't care what produced the bytes, only that they match.
+      await runParityCase({
+        name: `${fixture.rpc}/${c.name}`,
+        envelopeCall: async () => structuredClone(c.expectedV03Response),
+        connectCall: async () => structuredClone(c.expectedV04Response),
+        tolerantFields: c.parityOpts?.ignoreFields,
+      });
+    });
+  }
+});

--- a/tests/parity/transports.ts
+++ b/tests/parity/transports.ts
@@ -1,0 +1,112 @@
+// T07 — transport client helpers for parity cases.
+//
+// Spec: docs/superpowers/specs/2026-05-01-v0.4-web-design.md
+//   - ch02 §1   (Connect over HTTP/2)
+//   - ch02 §6   (data socket = HTTP/2; control socket stays envelope)
+//   - ch03 §7.1 (parity cases pair v0.3 envelope vs v0.4 Connect)
+//   - ch08 §3   (L2 contract tests use a real Connect client over the
+//                ephemeral data socket — same pattern reused here)
+//
+// State of the world at T07 (per task brief):
+//   - T05 (PR #752) merged: `createConnectDataServer` exists at
+//     `daemon/src/connect/server.ts`, dormant — no service handlers, no
+//     listener wiring on the data socket. T05.1 will wire it; until then
+//     callers boot their own Connect server in tests.
+//   - T06 (next PR) registers Ping + GetVersion handlers, builds the
+//     `electron/connect/ipc-transport.ts` client. Once T06 lands, the
+//     `connectClient(...)` factory below grows a code path that uses the
+//     T06 transport directly; until then it returns the bare HTTP/2 unary
+//     client, sufficient for any Connect handler T07's placeholder needs.
+//
+// Single Responsibility:
+//   - PRODUCER of clients (envelope + Connect). Knows about wire shapes only
+//     enough to construct the right transport. Does NOT decide equivalence
+//     (framework.ts), does NOT own daemon lifecycle (test files own that
+//     via vitest beforeAll/afterAll).
+
+import { createConnectTransport } from '@connectrpc/connect-node';
+import type { Transport } from '@connectrpc/connect';
+
+// ---------------------------------------------------------------------------
+// Envelope client (v0.3 path)
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of one envelope RPC call: the parsed JSON header plus the trailing
+ * binary payload (empty for pure-JSON RPCs). Mirrors the shape that
+ * `daemon/src/envelope/envelope.ts` decoders produce so test authors can
+ * assert against the same structure used by the production daemon code.
+ */
+export interface EnvelopeResponse<TJson = unknown> {
+  readonly header: TJson;
+  readonly payload: Buffer;
+}
+
+/**
+ * Envelope client signature. Test authors call it with the v0.3 method name
+ * (e.g. `'daemon.ping'`) and request body; it returns the response envelope.
+ *
+ * T07 ships the SHAPE of this helper but does NOT bind a concrete
+ * implementation: the v0.3 envelope sender lives inside the daemon test
+ * harness which is currently in flux (T12/T19 wave). Tests that need a real
+ * envelope round-trip should construct their own sender against the daemon
+ * fixture they boot in beforeAll, then pass it as the `envelopeCall` in
+ * `runParityCase`. M2 bridge-swap PRs (T09 onwards) will refactor this into
+ * a concrete `envelopeClient(socketPath)` factory once the daemon test
+ * harness stabilizes — placing that refactor here in T07 would prematurely
+ * lock the surface to a moving target.
+ */
+export type EnvelopeClient = (
+  method: string,
+  body: unknown,
+) => Promise<EnvelopeResponse>;
+
+/**
+ * Stub envelope client — returns the supplied `staticResponse`. Useful for
+ * the placeholder parity case (`tests/parity/ping.parity.test.ts`) and for
+ * unit tests of the framework itself. Real envelope clients land alongside
+ * the first real bridge swap (T06 + T09).
+ */
+export function stubEnvelopeClient(
+  staticResponses: Record<string, EnvelopeResponse>,
+): EnvelopeClient {
+  return async (method) => {
+    const r = staticResponses[method];
+    if (r === undefined) {
+      throw new Error(`stubEnvelopeClient: no stub registered for method ${method}`);
+    }
+    return r;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Connect client (v0.4 path)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a Connect transport pointing at a daemon Connect server bound on a
+ * loopback HTTP/2 endpoint. `baseUrl` is the `http://127.0.0.1:<port>` form
+ * returned by `createConnectDataServer.listen({ host, port: 0 })`.
+ *
+ * Uses HTTP/2 cleartext (`http2: true`) per ch02 §6 — the daemon's data
+ * socket runs HTTP/2 over the loopback transport (Unix socket / named pipe
+ * / dev TCP). TLS termination is the cloudflared edge's job (ch05), not the
+ * daemon's.
+ *
+ * Note on Unix socket / named pipe transport: `@connectrpc/connect-node`'s
+ * `createConnectTransport` accepts a `nodeOptions.socketPath`-style escape
+ * via the underlying `http2.connect` options. T05.1 will land the canonical
+ * socket-path wiring; until then tests bind the Connect server to an
+ * ephemeral loopback port (per `createConnectDataServer.listen`) and connect
+ * over TCP. That matches the `daemon/src/connect/__tests__/server.test.ts`
+ * pattern landed in T05.
+ */
+export function createConnectTransportForDaemon(opts: {
+  /** e.g. `http://127.0.0.1:54321` */
+  readonly baseUrl: string;
+}): Transport {
+  return createConnectTransport({
+    baseUrl: opts.baseUrl,
+    httpVersion: '2',
+  });
+}


### PR DESCRIPTION
## What landed

Task #1086 — v0.4 T07 L6 "parity-test framework (M1)". The framework that, for every Connect RPC, will verify the new bridge produces equivalent results to the v0.3 envelope-over-named-pipe handler.

Per spec ch03 §7.1, this is M1's load-bearing safety net for the 12 bridge-swap PRs that follow. Locking the framework here prevents each later PR from inventing its own definition of "equivalent" and producing a non-uniform safety net.

**Surface:**

- `runParityCase({ name, envelopeCall, connectCall, equivalence?, tolerantFields?, coerce? })` — vitest-compatible helper. Runs both transports in parallel; throws `ParityDivergenceError` with side-by-side JSON diff on mismatch.
- `assertParity(envelope, connect, opts?)` — low-level deep-equal with `ignoreFields` + per-field `coerce`. Matches the spec's `assertParity` shape.
- `defaultEquivalence` — `node:util.isDeepStrictEqual` under `ignoreFields`/`coerce` normalization. Single decision point per producer/decider/sink discipline.
- `transports.ts` — typed `EnvelopeClient` + Connect transport factory pointing at a daemon Connect server. Ships `stubEnvelopeClient` for the placeholder; concrete `envelopeClient` factory deferred until the daemon test harness stabilizes (T09 territory).

**Files:**

- `tests/parity/framework.ts` — runner + assertion + diff renderer (no external deps; `diff`/`json-diff` not in lockfile, deferred until M2 PR finds the diff hard to read)
- `tests/parity/framework.test.ts` — 18 unit tests
- `tests/parity/ping.parity.test.ts` — 1 placeholder fixture case
- `tests/parity/__fixtures__/ping.golden.json` — fixture in spec's `{ name, request, expectedV03Response, expectedV04Response, parityOpts }` shape
- `tests/parity/transports.ts` — Connect transport + stub envelope client
- `.github/workflows/parity.yml` — runs `npm run test:parity` on PRs touching `tests/parity/**`, daemon Connect/envelope, preload bridges, or `proto/**`. Independent of `ci.yml` (which is `if: false` for the v0.3→v0.4 migration window) so the safety net stays on.
- `package.json` — adds `npm run test:parity`

## Placeholder fixture explanation

The placeholder `tests/parity/ping.parity.test.ts` exercises `runParityCase` end-to-end with stub responses on both transports — the same recorded golden response on both sides, demonstrating the equivalence path passes. It does NOT spin up a daemon, does NOT call any real envelope sender or Connect client.

T06 (next PR) registers `Ping` + `GetVersion` Connect handlers and will replace this stub with a real case that boots the daemon, calls envelope `daemon.ping` and Connect `Ping`, and asserts equivalence under the framework. Until then this placeholder ensures the framework's plumbing is exercised by ≥1 case so `npm run test:parity` does not no-op.

The fixture file shape (`{ name, request, expectedV03Response, expectedV04Response, parityOpts }`) is the canonical shape from spec ch03 §7.1 — the loader is exercised here so it remains under test as the corpus grows in M2.

## Reverse-verify output

Captured locally per ch08 §8 reverse-verify discipline. Demonstrates the equivalence fn is the gating mechanism.

**Test 1 — divergent inputs WITHOUT override (expect FAIL):**

```
ParityDivergenceError: parity divergence in demo-divergence
envelope (v0.3):
  {
    "a": 1,
    "b": "x",
    "meta": { "version": "v0.3" }
  }

connect  (v0.4):
  {
    "a": 2,
    "b": "x",
    "meta": { "version": "v0.4" }
  }

differing fields:
- a: 1 vs 2
- meta.version: "v0.3" vs "v0.4"
```

→ FAILED as expected.

**Test 2 — same divergent inputs WITH `equivalence: () => true` override (expect PASS):**

→ PASSED as expected (override neutralized the gate). This is captured in the test `forces a divergent case to PASS when equivalence is overridden to always-true (reverse-verify)` and runs green in `npm run test:parity`.

## Test summary

- Local `npm run test:parity` (Windows 11): **2 files passed, 19 tests passed** in 2.6s
- Daemon Connect tests (`daemon/src/connect/__tests__`) re-run as smoke: **1 file, 13 tests passed** — no regression from T05.
- `npx tsc --noEmit -p tsconfig.json`: clean
- Lint: pre-existing repo errors unchanged; `tests/**` is globally eslint-ignored per `eslint.config.js`.

## T05 / T05.1 coordination note

Per task brief: T05 (PR #752) merged the dormant `createConnectDataServer` factory at `daemon/src/connect/server.ts` — no service handlers, no listener wiring on the data socket. T05.1 (the wiring task) has not yet landed.

This framework is **transport-agnostic** by design — `runParityCase` accepts arbitrary `envelopeCall` / `connectCall` async functions. Test files that need a real Connect round-trip will boot their own Connect server in `beforeAll` (per the existing `daemon/src/connect/__tests__/server.test.ts` pattern) until T05.1 lands the canonical socket wiring. The framework itself does NOT need T05.1 — only T06's first real RPC case does.

`tests/parity/transports.ts` exports `createConnectTransportForDaemon({ baseUrl })` for that boot pattern. Once T05.1 lands and exposes a stable `socketPath` form, that helper grows a path; today it speaks HTTP/2 over loopback TCP, matching the T05 server scaffold.

## CI workflow change summary

New: `.github/workflows/parity.yml`

- Triggers on PRs touching: `tests/parity/**`, `daemon/src/connect/**`, `daemon/src/envelope/**`, `electron/preload/bridges/**`, `proto/**`, `gen/**`, `package.json`, `package-lock.json`, the workflow file itself.
- Matrix: `ubuntu-latest` + `windows-latest` (developer's primary platform). macOS rides on the post-migration `ci.yml`.
- `continue-on-error: false` (default) — placeholder case ensures the step doesn't no-op; once T06 lands, divergence blocks the PR.
- Why dedicated workflow vs folding into `ci.yml`: `ci.yml` is `if: false` for the v0.3→v0.4 migration window per Task #1048. Parity tests must run on every PR during exactly that window — that's the whole point of the safety net. Dedicated workflow keeps the gate always on with zero scheduling logic.

## Spec deviations (flagged for reviewer)

1. **Test location:** spec says `daemon/__tests__/parity/`; PR uses `tests/parity/`. Per task brief: parity is a cross-cutting concern (daemon + electron + protocol), and `tests/` already hosts other cross-layer tests (`electron-load-smoke.test.ts`, `persist-shape.test.ts`). Manager confirmed at task #1086 dispatch.
2. **`scripts/gen-parity-scaffold.ts` deferred:** the codegen-driven scaffold from spec §7.1 (enforces "every swapped RPC has a parity-corpus entry") is meaningful only once T06 lands the first real RPC. Adding it before T06 would either no-op or fail spuriously. Should be added in any pre-T09 PR.
3. **`RECORD_PARITY=1` deferred:** same reason — fixture recording from the v0.3 envelope path requires real envelope handlers to record from. T06 + T09 add this.

## Test plan

- [x] `npm run test:parity` — 19/19 pass
- [x] Reverse-verify: divergent inputs without override → FAIL; with `equivalence: () => true` → PASS
- [x] Daemon Connect tests still pass (no regression from T05)
- [x] Typecheck clean
- [ ] CI workflow runs green on the PR