### PR TITLE
feat(v03 T59): release attestation — SHA + SLSA + minisign sidecars

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -324,6 +324,14 @@ jobs:
   # required and would be redundant). The `publish` job renames a copy to
   # `<artifact>.intoto.jsonl` for each installer so the README's
   # "verify your download" workflow stays one-pattern.
+  #
+  # `upload-assets: false` is intentional: we don't want the SLSA reusable
+  # workflow to push to a GitHub Release directly. Instead the downstream
+  # `publish` job downloads the provenance artifact, runs the sidecar-verify
+  # gate (every installer must have .sha256 + .minisig + .intoto.jsonl), and
+  # only then uploads to a draft Release via `softprops/action-gh-release`.
+  # This puts the verification step between provenance generation and
+  # release publication so a missing-sidecar bug can't ship.
   provenance:
     name: SLSA L3 provenance
     needs: attest
@@ -332,7 +340,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: ${{ needs.attest.outputs.hashes }}
       provenance-name: ccsm.intoto.jsonl
@@ -355,11 +363,13 @@ jobs:
       - name: Download SLSA provenance
         uses: actions/download-artifact@v4
         with:
-          # The SLSA generic generator exposes `provenance-download-name` as
-          # the workflow-run artifact name (distinct from `provenance-name`,
-          # which is the filename inside the artifact). Use the download name
-          # here so actions/download-artifact pulls the right artifact.
-          name: ${{ needs.provenance.outputs.provenance-download-name }}
+          # The SLSA generic generator's reusable workflow exposes
+          # `provenance-name` as both the artifact name uploaded to the
+          # workflow run and the filename inside it (they're set to the
+          # same string from the `provenance-name` input we pass above —
+          # `ccsm.intoto.jsonl`). Use that output here so this stays in
+          # sync if we ever rename the input.
+          name: ${{ needs.provenance.outputs.provenance-name }}
           path: dist-flat
 
       # Sidecar-verify gate: every installer must have all three sidecars

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,24 +195,224 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
-      # Only create/update the GitHub Release when this was a real tag push —
-      # `workflow_dispatch` dry-runs stop at the artifact upload above so we
-      # don't pollute the Releases tab with `v0.0.0-dryrun` entries.
+  # T59 (v0.3 frag-11 §11.4 + §11.4.1): release attestation — for every
+  # installer artifact we publish three sidecar files alongside it:
+  #   <artifact>.sha256          SHA-256 hash (integrity vs network corruption)
+  #   <artifact>.intoto.jsonl    SLSA L3 provenance attestation (authenticity vs
+  #                              compromised pipeline; signed by GitHub OIDC root
+  #                              via the SLSA reusable workflow)
+  #   <artifact>.minisig         Linux minisign signature (offline verifier on
+  #                              the daemon-only updater + initial-install path)
+  #
+  # The attest stage runs a single `release-publish`-style job that downloads
+  # every matrix leg's artifacts, computes SHA + minisign sidecars locally, then
+  # hands the SHA hashes to the SLSA reusable workflow which produces a single
+  # signed `*.intoto.jsonl`. The `publish` job verifies all three sidecars
+  # exist for every installer artifact (sidecar-verify gate) before uploading
+  # to the GitHub Release.
+  attest:
+    name: SHA + minisign sidecars
+    needs: build
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist-all
+
+      # Flatten dist-all/<matrix-name>/<files> -> dist-flat/<files> so sidecar
+      # filenames sit beside their parent. The SLSA generator + GitHub Release
+      # upload both want a single flat directory.
+      - name: Flatten artifact layout
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist-flat
+          find dist-all -type f \( \
+              -name '*.exe' -o -name '*.dmg' -o -name '*.zip' \
+              -o -name '*.AppImage' -o -name '*.deb' -o -name '*.rpm' \
+              -o -name 'latest*.yml' -o -name '*.blockmap' \
+            \) -exec cp -n {} dist-flat/ \;
+          ls -la dist-flat/
+
+      # Per-artifact .sha256 sidecar. Format matches `sha256sum` output so
+      # downstream verifiers can `sha256sum -c <file>.sha256`.
+      - name: Generate SHA-256 sidecars
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd dist-flat
+          for f in *.exe *.dmg *.zip *.AppImage *.deb *.rpm; do
+            [ -f "$f" ] || continue
+            sha256sum "$f" > "$f.sha256"
+            echo "wrote $f.sha256"
+          done
+
+      # Minisign signatures. Public key lives in repo at release-keys/minisign.pub
+      # (committed). Private key is provisioned via the MINISIGN_PRIVATE_KEY
+      # repo secret + MINISIGN_PASSWORD secret (see release-keys/README.md for
+      # rotation runbook). When the secret is absent we still write empty
+      # placeholder .minisig files so the sidecar-verify gate can distinguish
+      # "missing because unsigned" from "missing because forgotten" — and we
+      # warn loudly in the workflow log.
+      - name: Install minisign
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends minisign
+
+      - name: Generate minisign signatures
+        shell: bash
+        env:
+          MINISIGN_PRIVATE_KEY: ${{ secrets.MINISIGN_PRIVATE_KEY }}
+          MINISIGN_PASSWORD: ${{ secrets.MINISIGN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if [ -z "${MINISIGN_PRIVATE_KEY:-}" ]; then
+            echo "::warning title=Unsigned release::MINISIGN_PRIVATE_KEY secret not set. Writing placeholder .minisig files; the sidecar-verify gate will fail. See release-keys/README.md for provisioning."
+            cd dist-flat
+            for f in *.exe *.dmg *.zip *.AppImage *.deb *.rpm; do
+              [ -f "$f" ] || continue
+              : > "$f.minisig"
+            done
+            exit 0
+          fi
+          umask 077
+          KEY=$(mktemp)
+          printf '%s' "$MINISIGN_PRIVATE_KEY" > "$KEY"
+          cd dist-flat
+          for f in *.exe *.dmg *.zip *.AppImage *.deb *.rpm; do
+            [ -f "$f" ] || continue
+            echo "$MINISIGN_PASSWORD" | minisign -S -s "$KEY" -m "$f" -t "ccsm $GITHUB_REF_NAME"
+            echo "wrote $f.minisig"
+          done
+          shred -u "$KEY"
+
+      # Compute the SLSA hashes input. The SLSA reusable workflow expects a
+      # base64-encoded SHA256SUMS-format payload listing every subject we want
+      # provenance over (the installers themselves; sidecars are derivative).
+      - name: Compute SLSA hashes input
+        id: hash
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd dist-flat
+          HASHES=$( \
+            sha256sum *.exe *.dmg *.zip *.AppImage *.deb *.rpm 2>/dev/null \
+              | base64 -w0 \
+          )
+          echo "hashes=$HASHES" >> "$GITHUB_OUTPUT"
+
+      - name: Upload sidecars + installers
+        uses: actions/upload-artifact@v4
+        with:
+          name: ccsm-attested
+          path: dist-flat/**
+          if-no-files-found: error
+          retention-days: 14
+
+  # SLSA L3 provenance via the official reusable workflow. This produces a
+  # single signed `<workflow-name>.intoto.jsonl` whose subjects cover every
+  # installer artifact (one provenance file documents the entire release —
+  # this is the SLSA spec's canonical shape; per-artifact provenance is not
+  # required and would be redundant). The `publish` job renames a copy to
+  # `<artifact>.intoto.jsonl` for each installer so the README's
+  # "verify your download" workflow stays one-pattern.
+  provenance:
+    name: SLSA L3 provenance
+    needs: attest
+    if: needs.attest.outputs.hashes != ''
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    with:
+      base64-subjects: ${{ needs.attest.outputs.hashes }}
+      provenance-name: ccsm.intoto.jsonl
+      upload-assets: false
+
+  publish:
+    name: Sidecar-verify gate + GitHub Release upload
+    needs: [attest, provenance]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download attested artifacts + sidecars
+        uses: actions/download-artifact@v4
+        with:
+          name: ccsm-attested
+          path: dist-flat
+
+      - name: Download SLSA provenance
+        uses: actions/download-artifact@v4
+        with:
+          # The SLSA generic generator exposes `provenance-download-name` as
+          # the workflow-run artifact name (distinct from `provenance-name`,
+          # which is the filename inside the artifact). Use the download name
+          # here so actions/download-artifact pulls the right artifact.
+          name: ${{ needs.provenance.outputs.provenance-download-name }}
+          path: dist-flat
+
+      # Sidecar-verify gate: every installer must have all three sidecars
+      # present (and the minisig must be non-empty). This is the post-tag-push
+      # safety check that catches "someone commented out a sidecar step in a
+      # rebase" before we publish a release with missing attestations.
+      - name: Sidecar-verify gate
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd dist-flat
+          PROV=$(ls *.intoto.jsonl 2>/dev/null | head -n1 || true)
+          if [ -z "$PROV" ]; then
+            echo "::error title=Sidecar-verify failed::no *.intoto.jsonl SLSA provenance file present"
+            exit 1
+          fi
+          fail=0
+          for f in *.exe *.dmg *.zip *.AppImage *.deb *.rpm; do
+            [ -f "$f" ] || continue
+            if [ ! -s "$f.sha256" ]; then
+              echo "::error title=Sidecar-verify failed::$f missing or empty .sha256"; fail=1
+            fi
+            if [ ! -s "$f.minisig" ]; then
+              echo "::error title=Sidecar-verify failed::$f missing or empty .minisig"; fail=1
+            fi
+            # Materialize a per-artifact intoto.jsonl alias so the README's
+            # one-pattern verify command works for every download.
+            cp "$PROV" "$f.intoto.jsonl"
+          done
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::Refusing to publish release with missing sidecars."
+            exit 1
+          fi
+          echo "All installers have .sha256 + .minisig + .intoto.jsonl sidecars."
+          ls -la
+
       - name: Upload to GitHub Release (draft)
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
           draft: true
           generate_release_notes: true
           fail_on_unmatched_files: false
           files: |
-            release/*.exe
-            release/*.dmg
-            release/*.zip
-            release/*.AppImage
-            release/*.deb
-            release/*.rpm
-            release/latest*.yml
-            release/*.blockmap
+            dist-flat/*.exe
+            dist-flat/*.dmg
+            dist-flat/*.zip
+            dist-flat/*.AppImage
+            dist-flat/*.deb
+            dist-flat/*.rpm
+            dist-flat/latest*.yml
+            dist-flat/*.blockmap
+            dist-flat/*.sha256
+            dist-flat/*.minisig
+            dist-flat/*.intoto.jsonl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ Ships via GitHub Releases with delta updates. New versions install in the backgr
 | Linux (AppImage) | [ccsm-0.2.0.AppImage](https://github.com/Jiahui-Gu/ccsm/releases/download/v0.2.0/ccsm-0.2.0.AppImage) |
 | Linux (rpm) | [ccsm-0.2.0.x86_64.rpm](https://github.com/Jiahui-Gu/ccsm/releases/download/v0.2.0/ccsm-0.2.0.x86_64.rpm) |
 
+## Verify your download
+
+Every installer ships with three sidecar files in the same release. We
+recommend verifying at least the SHA before running unfamiliar installers,
+and the SLSA provenance for stronger authenticity guarantees.
+
+| Sidecar | What it proves | Verify with |
+|---------|----------------|-------------|
+| `<artifact>.sha256` | The file you downloaded matches the bytes we built | `sha256sum -c ccsm-Setup-0.3.0.exe.sha256` |
+| `<artifact>.intoto.jsonl` | The file was built by [this exact `release.yml` workflow](.github/workflows/release.yml) on `Jiahui-Gu/ccsm`, signed by GitHub's OIDC root (SLSA L3) | [`slsa-verifier verify-artifact ccsm-Setup-0.3.0.exe --provenance-path ccsm-Setup-0.3.0.exe.intoto.jsonl --source-uri github.com/Jiahui-Gu/ccsm`](https://github.com/slsa-framework/slsa-verifier) |
+| `<artifact>.minisig` | The file was signed by the ccsm release-signing key (offline-verifiable; used by the daemon-only updater) | `minisign -V -p release-keys/minisign.pub -m ccsm-Setup-0.3.0.exe` |
+
+The minisign public key lives at [`release-keys/minisign.pub`](release-keys/minisign.pub) — copy it once, verify any release. See [`release-keys/README.md`](release-keys/README.md) for the rotation runbook and the meaning of each sidecar in detail.
+
 ## How it works
 
 ccsm spawns the official `claude` binary as a PTY in Electron's main process and renders its output in a React surface. It reads `CLAUDE_CONFIG_DIR` so your existing CLI configuration — skills, agents, MCP servers, permissions — works untouched. ccsm doesn't parse or rewrite your config; it just gives the CLI a better window.

--- a/RELEASE_NOTES_TEMPLATE.md
+++ b/RELEASE_NOTES_TEMPLATE.md
@@ -1,0 +1,70 @@
+# ccsm vX.Y.Z — Release Notes Template
+
+> Replace `vX.Y.Z` everywhere, fill in the sections, delete the template
+> banner before publishing. Title format: `ccsm vX.Y.Z — <one-line theme>`.
+
+## Highlights
+
+- (1–3 user-facing bullets — what new thing can the user do?)
+
+## Changes
+
+### Features
+- (#NNN) ...
+
+### Fixes
+- (#NNN) ...
+
+### Internal / infrastructure
+- (#NNN) ...
+
+## Install
+
+| Platform | Download |
+|----------|----------|
+| Windows | `ccsm-Setup-X.Y.Z.exe` |
+| macOS (Intel) | `ccsm-X.Y.Z.dmg` |
+| macOS (Apple Silicon) | `ccsm-X.Y.Z-arm64.dmg` |
+| Linux (deb) | `ccsm_X.Y.Z_amd64.deb` |
+| Linux (AppImage) | `ccsm-X.Y.Z.AppImage` |
+| Linux (rpm) | `ccsm-X.Y.Z.x86_64.rpm` |
+
+## Verify your download
+
+Every installer in the table above is published with **three sidecar files**
+in this release:
+
+- **`<artifact>.sha256`** — SHA-256 hash. Verify integrity:
+  ```bash
+  sha256sum -c ccsm-Setup-X.Y.Z.exe.sha256
+  ```
+- **`<artifact>.intoto.jsonl`** — SLSA L3 build provenance, signed by GitHub's
+  OIDC root via the [`slsa-github-generator`](https://github.com/slsa-framework/slsa-github-generator)
+  reusable workflow. Verify authenticity end-to-end:
+  ```bash
+  slsa-verifier verify-artifact ccsm-Setup-X.Y.Z.exe \
+    --provenance-path ccsm-Setup-X.Y.Z.exe.intoto.jsonl \
+    --source-uri github.com/Jiahui-Gu/ccsm \
+    --source-tag vX.Y.Z
+  ```
+- **`<artifact>.minisig`** — minisign signature with the ccsm release-signing
+  key. Verify offline:
+  ```bash
+  minisign -V -p release-keys/minisign.pub -m ccsm-Setup-X.Y.Z.exe
+  ```
+  The public key is in the [repo](https://github.com/Jiahui-Gu/ccsm/blob/main/release-keys/minisign.pub).
+
+If any of these fail, **do not run the installer**; open an issue on the repo.
+
+## Known issues
+
+- (list, or "none known")
+
+## Upgrade notes
+
+- (breaking changes, config migrations, etc., or "drop-in upgrade")
+
+## Key rotation (only if applicable this release)
+
+- (see `release-keys/README.md`. Include old fingerprint + new fingerprint
+  if the minisign key was rotated for this release.)

--- a/release-keys/README.md
+++ b/release-keys/README.md
@@ -1,0 +1,87 @@
+# release-keys/
+
+Public keys + verification metadata for ccsm release artifacts.
+
+| File | Purpose |
+|------|---------|
+| `minisign.pub` | Public half of the ccsm release-signing minisign keypair. Used by `minisign -V` and the daemon-side updater verifier. **Currently a placeholder** — see "First-time keypair generation" below. |
+
+The matching **private** key is **never** committed. It lives only in the
+GitHub Actions repo secret `MINISIGN_PRIVATE_KEY` (with the unlock password
+in `MINISIGN_PASSWORD`). Both are referenced by `.github/workflows/release.yml`
+in the `attest` job.
+
+## Sidecar files produced per release
+
+For every installer artifact (`*.exe`, `*.dmg`, `*.AppImage`, `*.deb`,
+`*.rpm`, `*.zip`) the release workflow publishes three sidecar files:
+
+| Sidecar | Producer | Verify with |
+|---------|----------|-------------|
+| `<artifact>.sha256` | `sha256sum` step in the `attest` job | `sha256sum -c <artifact>.sha256` |
+| `<artifact>.intoto.jsonl` | `slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0` reusable workflow | [`slsa-verifier verify-artifact`](https://github.com/slsa-framework/slsa-verifier) — see README "Verify your download" |
+| `<artifact>.minisig` | `minisign -S` step in the `attest` job, signed with the key from `MINISIGN_PRIVATE_KEY` | `minisign -V -p release-keys/minisign.pub -m <artifact>` |
+
+The `publish` job in `.github/workflows/release.yml` runs a **sidecar-verify
+gate** that refuses to publish a draft release unless all three sidecars are
+present (and non-empty) for every installer.
+
+## First-time keypair generation (release-day ops, NOT in CI)
+
+Run this once on a trusted operator machine (offline preferred). The keypair
+is for ccsm release signing only — do not reuse personal minisign keys.
+
+```bash
+# 1. Generate a fresh keypair. You will be prompted for an unlock password —
+#    use a strong one and store it in a password manager. The password ALSO
+#    needs to be stored in the MINISIGN_PASSWORD repo secret (below).
+minisign -G -p ccsm-minisign.pub -s ccsm-minisign.key
+
+# 2. Commit ccsm-minisign.pub to this directory as `minisign.pub`, replacing
+#    the placeholder. Open a PR (this is the public half — safe to commit).
+cp ccsm-minisign.pub release-keys/minisign.pub
+
+# 3. Provision the private key as a GitHub Actions repo secret. The secret
+#    value is the FULL CONTENTS of ccsm-minisign.key (including the
+#    "untrusted comment:" header lines).
+gh secret set MINISIGN_PRIVATE_KEY --repo Jiahui-Gu/ccsm < ccsm-minisign.key
+
+# 4. Provision the unlock password as a separate secret.
+gh secret set MINISIGN_PASSWORD --repo Jiahui-Gu/ccsm
+# (paste password when prompted)
+
+# 5. Securely delete the on-disk private key. The repo secret + your password
+#    manager are now the only copies.
+shred -u ccsm-minisign.key
+```
+
+After step 5, the next tag push triggers `release.yml`, the `attest` job
+signs every installer, and the sidecar-verify gate passes.
+
+## Key rotation
+
+Rotation is required when:
+
+- A repo collaborator with `MINISIGN_PRIVATE_KEY` access leaves the project.
+- Suspected secret leak (CI log scrape, accidental `printenv`, etc.).
+- Scheduled rotation (recommended: yearly, but not yet enforced).
+
+Procedure:
+
+1. Generate a new keypair as in "First-time keypair generation" steps 1–2.
+2. Commit the new `minisign.pub` in a PR titled `release-keys: rotate minisign keypair (YYYY-MM-DD)`. Reference the rotation reason in the PR body.
+3. Update `MINISIGN_PRIVATE_KEY` + `MINISIGN_PASSWORD` repo secrets (steps 3–4).
+4. Tag a patch release (e.g. `v0.3.1`) so the new key is exercised end-to-end before any rotation reaches user-facing release notes.
+5. In the next user-facing release notes, document the rotation: "Release-signing key rotated on YYYY-MM-DD. Old fingerprint: `<sha256 of old minisign.pub>`. New fingerprint: `<sha256 of new minisign.pub>`."
+6. Securely delete the on-disk private key (step 5 of generation).
+
+The **old** public key MUST stay in git history (do not force-push to
+remove it). Users verifying older releases need the matching old public key
+to verify older `.minisig` files; the simplest path is `git log -- release-keys/minisign.pub` + checkout the historical revision.
+
+## Disaster: private key suspected leaked
+
+1. **Immediately revoke** the GitHub Actions secret: `gh secret delete MINISIGN_PRIVATE_KEY --repo Jiahui-Gu/ccsm`. Without the secret, the `attest` job writes empty `.minisig` files and the sidecar-verify gate fails closed — no further releases can ship signed with the compromised key.
+2. Open a high-priority issue on the repo describing the suspected leak.
+3. Run the rotation procedure above.
+4. Publish a security advisory (`gh api repos/Jiahui-Gu/ccsm/security-advisories -f summary='Release-signing key rotation' ...`) listing every release that was signed with the compromised key. Users should re-verify those releases against the historical public key (still valid for those specific binaries; the SLSA L3 attestation provides an independent authenticity check that does NOT depend on minisign).

--- a/release-keys/minisign.pub
+++ b/release-keys/minisign.pub
@@ -1,0 +1,11 @@
+untrusted comment: PLACEHOLDER — not a real ccsm minisign public key
+RWQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+
+# This file is a PLACEHOLDER. The real ccsm release-signing minisign public
+# key will be generated and committed during the v0.3 ship-day ops task
+# (see release-keys/README.md "First-time keypair generation"). Until then,
+# any minisign signature verified against this key will FAIL — which is the
+# intended state, because the matching MINISIGN_PRIVATE_KEY repo secret is
+# also unprovisioned.
+#
+# Do NOT replace this file by hand outside the documented rotation runbook.

--- a/scripts/sidecar-verify-gate.sh
+++ b/scripts/sidecar-verify-gate.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Local extract of the sidecar-verify gate from .github/workflows/release.yml
+# `publish` job. Run from a directory containing flattened release artifacts
+# + sidecars (same layout as the workflow's dist-flat). Exits non-zero on
+# missing sidecars; this mirrors the CI gate exactly so we can reverse-verify
+# locally without pushing a tag.
+#
+# Usage:
+#   cd <dir-with-installers-and-sidecars>
+#   bash scripts/sidecar-verify-gate.sh
+set -euo pipefail
+PROV=$(ls *.intoto.jsonl 2>/dev/null | head -n1 || true)
+if [ -z "$PROV" ]; then
+  echo "::error title=Sidecar-verify failed::no *.intoto.jsonl SLSA provenance file present"
+  exit 1
+fi
+fail=0
+for f in *.exe *.dmg *.zip *.AppImage *.deb *.rpm; do
+  [ -f "$f" ] || continue
+  if [ ! -s "$f.sha256" ]; then
+    echo "::error title=Sidecar-verify failed::$f missing or empty .sha256"; fail=1
+  fi
+  if [ ! -s "$f.minisig" ]; then
+    echo "::error title=Sidecar-verify failed::$f missing or empty .minisig"; fail=1
+  fi
+done
+if [ "$fail" -ne 0 ]; then
+  echo "::error::Refusing to publish release with missing sidecars."
+  exit 1
+fi
+echo "All installers have .sha256 + .minisig + .intoto.jsonl sidecars."


### PR DESCRIPTION
## Summary
Implements Task #1017 / v0.3 spec frag-11 §11.4 + §11.4.1 (Task 23b): every installer artifact published by `release.yml` now ships with three sidecar files alongside it — `<artifact>.sha256`, `<artifact>.intoto.jsonl` (SLSA L3), and `<artifact>.minisig`. A sidecar-verify gate in the new `publish` job refuses to publish a draft release if any sidecar is missing.

## Workflow file changes (`.github/workflows/release.yml`)
- `build` matrix job: unchanged except removal of the inline `Upload to GitHub Release` step (moved to new `publish` job).
- New `attest` job (ubuntu-latest):
  - Downloads all matrix artifacts; flattens to `dist-flat/`.
  - Generates per-artifact `.sha256` (sha256sum format).
  - Installs minisign; signs every installer with the key from `MINISIGN_PRIVATE_KEY` repo secret (warns + writes empty `.minisig` placeholders if secret absent — gate then catches it).
  - Computes base64 SHA256SUMS hashes input for SLSA generator; exposes as `outputs.hashes`.
- New `provenance` job: calls the official reusable workflow `slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0` (NOT a custom script) with the hashes input. Produces a single signed `ccsm.intoto.jsonl` whose subjects cover every installer.
- New `publish` job (tag push only):
  - Downloads the `ccsm-attested` artifact + the SLSA provenance artifact.
  - **Sidecar-verify gate** — refuses to publish if any installer is missing `.sha256`, `.minisig`, or if no `*.intoto.jsonl` is present. Aliases the single SLSA file to `<artifact>.intoto.jsonl` per installer so the README's one-pattern verify command works.
  - Uploads installers + all sidecars to the draft GitHub Release.

## Other changes
- `release-keys/minisign.pub` — placeholder (not a real key); replaced on release-day via the runbook.
- `release-keys/README.md` — runbook covering first-time keypair generation, rotation procedure, and suspected-leak response. Documents the `MINISIGN_PRIVATE_KEY` + `MINISIGN_PASSWORD` repo secrets.
- `RELEASE_NOTES_TEMPLATE.md` — references the three sidecar file types with verify commands.
- `README.md` — new "Verify your download" section pointing users at `sha256sum -c`, `slsa-verifier verify-artifact`, and `minisign -V`.
- `scripts/sidecar-verify-gate.sh` — local extract of the CI gate so reverse-verify can run without pushing a tag.

## Migration-window note
- `ci.yml` is `if: false` (gated for v0.3 migration per #1048).
- `release.yml` stays active per #1047 lock (release CI exempt). Verified by reading both YAML files; this PR only touches `release.yml`.

## Test plan
- [x] YAML parses: `python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` returns 5 jobs (`verify, build, attest, provenance, publish`).
- [x] Sidecar-verify gate reverse-verify (executed locally with fake `dist-flat`):
  - PASS path (all sidecars present, non-empty) → exit 0, log: `All installers have .sha256 + .minisig + .intoto.jsonl sidecars.`
  - FAIL: missing `.minisig` → exit 1, `::error::` line.
  - FAIL: empty `.minisig` (touch-created) → exit 1, `::error::` line (the `[ -s ]` test catches both).
  - FAIL: no `*.intoto.jsonl` → exit 1, `::error::` line.
- [ ] First real tag push will exercise the SLSA reusable workflow + minisign signing end-to-end. Cannot be tested locally; requires `MINISIGN_PRIVATE_KEY` + `MINISIGN_PASSWORD` repo secrets to be provisioned per `release-keys/README.md`.

## Runbook gaps to flag for release-day ops
1. **Keypair not yet generated.** `release-keys/minisign.pub` is a placeholder. The first time a release ships, an operator must run the "First-time keypair generation" steps in `release-keys/README.md` and merge the resulting `minisign.pub` BEFORE tagging.
2. **Repo secrets not provisioned.** `MINISIGN_PRIVATE_KEY` + `MINISIGN_PASSWORD` must be set via `gh secret set`. Until then, the `attest` job writes empty `.minisig` files and the sidecar-verify gate fails closed (intended).
3. **`slsa-verifier` not yet bundled.** Users following the README "Verify your download" section need to install `slsa-verifier` separately. v0.4 plan (per spec) bundles `@sigstore/verify` 1.x in the daemon for automatic verify-on-update; out of scope for T59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)