### PR TITLE
feat(crash phase 5): rolling log retention + renderer error forwarder

### DIFF
--- a/electron/crash/collector.ts
+++ b/electron/crash/collector.ts
@@ -28,10 +28,26 @@ export interface CollectorOpts {
   electronVersion: string;
 }
 
+export interface PruneOpts {
+  /** Legacy global cap — prune entries that are BOTH older than `maxAgeDays`
+   *  AND beyond the `maxCount` newest. Phase 1 contract. Optional now. */
+  maxCount?: number;
+  /** Legacy global age threshold (days). Pairs with `maxCount`. */
+  maxAgeDays?: number;
+  /** Phase 5 — keep the N newest incidents per surface (by mtime). When
+   *  omitted, only the legacy global cap applies. Default at the call site
+   *  is 20 (`crashLogRetention.maxPerSurface`). */
+  maxPerSurface?: number;
+  /** Phase 5 — never prune an incident that has NO `.uploaded` marker AND
+   *  whose mtime is younger than this many days, so the user can still send
+   *  it via the Help-menu re-upload button (phase 4). Default 7. */
+  protectUnsentYoungerThanDays?: number;
+}
+
 export interface CrashCollector {
   recordIncident(input: IncidentInput): string;
   flush(): Promise<void>;
-  pruneRetention(opts: { maxCount: number; maxAgeDays: number }): void;
+  pruneRetention(opts: PruneOpts): void;
 }
 
 export function startCrashCollector(opts: CollectorOpts): CrashCollector {
@@ -132,25 +148,76 @@ export function startCrashCollector(opts: CollectorOpts): CrashCollector {
     return lines.join('\n') + '\n';
   }
 
-  function pruneRetention({ maxCount, maxAgeDays }: { maxCount: number; maxAgeDays: number }): void {
-    const cutoff = Date.now() - maxAgeDays * 24 * 3600 * 1000;
-    let entries: { name: string; mtime: number }[];
+  function pruneRetention(pruneOpts: PruneOpts): void {
+    const { maxCount, maxAgeDays, maxPerSurface, protectUnsentYoungerThanDays } = pruneOpts;
+
+    interface Entry { name: string; full: string; mtime: number; surface: string | null; protected: boolean }
+
+    let entries: Entry[];
     try {
       entries = fs.readdirSync(opts.crashRoot)
-        .filter(n => !n.startsWith('_'))
-        .map(n => ({ name: n, mtime: fs.statSync(path.join(opts.crashRoot, n)).mtimeMs }))
-        .sort((a, b) => b.mtime - a.mtime); // newest first
+        .filter(n => !n.startsWith('_') && !n.startsWith('.'))
+        .map<Entry | null>((n) => {
+          const full = path.join(opts.crashRoot, n);
+          let stat: fs.Stats;
+          try { stat = fs.statSync(full); } catch { return null; }
+          if (!stat.isDirectory()) return null;
+          let surface: string | null = null;
+          try {
+            const meta = JSON.parse(fs.readFileSync(path.join(full, 'meta.json'), 'utf8')) as { surface?: string };
+            surface = meta.surface ?? null;
+          } catch {
+            // Incident dir without meta — treat as unknown-surface; still subject to global rules.
+          }
+          const isUploaded = fs.existsSync(path.join(full, '.uploaded'));
+          let protectedByWindow = false;
+          if (protectUnsentYoungerThanDays != null && !isUploaded) {
+            const cutoff = Date.now() - protectUnsentYoungerThanDays * 24 * 3600 * 1000;
+            if (stat.mtimeMs >= cutoff) protectedByWindow = true;
+          }
+          return { name: n, full, mtime: stat.mtimeMs, surface, protected: protectedByWindow };
+        })
+        .filter((x): x is Entry => x !== null);
     } catch {
       return;
     }
-    for (let i = 0; i < entries.length; i++) {
-      const e = entries[i]!;
-      const tooOld = e.mtime < cutoff;
-      const overCount = i >= maxCount;
-      // spec §10: keep last 20 OR 30 days, whichever is larger → prune only when BOTH conditions met
-      if (tooOld && overCount) {
-        try { fs.rmSync(path.join(opts.crashRoot, e.name), { recursive: true, force: true }); } catch {}
+
+    const toDelete = new Set<string>();
+
+    // Phase 1 / legacy global rule: prune entries that are BOTH older than
+    // maxAgeDays AND beyond the newest maxCount. Kept for backward-compat
+    // when callers don't pass maxPerSurface.
+    if (maxCount != null && maxAgeDays != null) {
+      const cutoff = Date.now() - maxAgeDays * 24 * 3600 * 1000;
+      const sorted = [...entries].sort((a, b) => b.mtime - a.mtime); // newest first
+      for (let i = 0; i < sorted.length; i++) {
+        const e = sorted[i]!;
+        if (i >= maxCount && e.mtime < cutoff && !e.protected) {
+          toDelete.add(e.full);
+        }
       }
+    }
+
+    // Phase 5 per-surface keep-N rule.
+    if (maxPerSurface != null) {
+      const bySurface = new Map<string, Entry[]>();
+      for (const e of entries) {
+        const key = e.surface ?? '__unknown__';
+        const arr = bySurface.get(key) ?? [];
+        arr.push(e);
+        bySurface.set(key, arr);
+      }
+      for (const arr of bySurface.values()) {
+        arr.sort((a, b) => b.mtime - a.mtime); // newest first
+        for (let i = maxPerSurface; i < arr.length; i++) {
+          const e = arr[i]!;
+          if (!e.protected) toDelete.add(e.full);
+        }
+      }
+    }
+
+    for (const full of toDelete) {
+      try { fs.rmSync(full, { recursive: true, force: true }); } catch { /* best-effort */ }
     }
   }
 

--- a/electron/ipc/rendererErrorForwarder.ts
+++ b/electron/ipc/rendererErrorForwarder.ts
@@ -1,0 +1,146 @@
+// electron/ipc/rendererErrorForwarder.ts
+//
+// Phase 5 crash observability — renderer-side error forwarder.
+//
+// The renderer installs window.onerror + window.onunhandledrejection (and
+// optionally console.error in dev builds) hooks that invoke this IPC. The
+// main process then routes the report through the phase-1 collector, which
+// writes a `surface: 'renderer'` incident under the standard crash root and
+// (when the phase-2/3 Sentry SDK is initialised + phase-4 consent allows)
+// forwards it to the renderer DSN.
+//
+// We don't open a separate Sentry init path here. The existing main-process
+// Sentry SDK (electron/sentry/init.ts) already auto-routes events from any
+// surface; @sentry/electron/renderer reports flow through the IPC bridge it
+// installs, but those only fire when the renderer SDK is actually imported.
+// This forwarder is the on-disk + main-routed safety net for crashes that
+// escape the renderer SDK or happen before its init runs.
+//
+// Hard constraints (phase 4 territory, NOT changed here):
+//   - local incident write happens regardless of consent state.
+//   - Sentry upload is gated by isCrashUploadAllowed() inside Sentry init.
+//
+// Rate-limiting: ≤ N events per W ms per renderer process (webContents.id),
+// to prevent a tight `console.error` loop from filling the disk. Excess
+// events are silently dropped; the dropped count is folded into the next
+// accepted incident's stderr-tail breadcrumb so we don't lose the signal.
+
+import type { IpcMain, IpcMainInvokeEvent } from 'electron';
+import { fromMainFrame } from '../security/ipcGuards';
+import type { CrashCollector, SerializedError } from '../crash/collector';
+
+export interface RendererErrorReport {
+  error: SerializedError;
+  /** 'window.onerror' | 'window.onunhandledrejection' | 'console.error' */
+  source: string;
+  /** Optional renderer-supplied breadcrumb (URL/path the error came from). */
+  url?: string;
+}
+
+export interface RendererErrorRateLimiter {
+  /** Returns true when the event is allowed; false when it was rate-limited. */
+  tryAcquire(processId: number): boolean;
+  /** How many events were silently dropped for this processId since the last
+   *  accepted event. Reading this value also resets it (one-shot drain). */
+  drainDroppedCount(processId: number): number;
+  /** Read-only peek for tests + diagnostics. */
+  getDroppedCount(processId: number): number;
+}
+
+interface RateLimiterOpts { windowMs: number; max: number }
+
+/** Sliding-window rate limiter. One bucket per renderer process. */
+export function createRendererErrorRateLimiter(opts: RateLimiterOpts): RendererErrorRateLimiter {
+  const stamps = new Map<number, number[]>();
+  const dropped = new Map<number, number>();
+
+  function pruneWindow(arr: number[], now: number): number[] {
+    const cutoff = now - opts.windowMs;
+    let i = 0;
+    while (i < arr.length && arr[i]! < cutoff) i++;
+    return i === 0 ? arr : arr.slice(i);
+  }
+
+  return {
+    tryAcquire(processId: number): boolean {
+      const now = Date.now();
+      const arr = pruneWindow(stamps.get(processId) ?? [], now);
+      if (arr.length >= opts.max) {
+        stamps.set(processId, arr);
+        dropped.set(processId, (dropped.get(processId) ?? 0) + 1);
+        return false;
+      }
+      arr.push(now);
+      stamps.set(processId, arr);
+      return true;
+    },
+    drainDroppedCount(processId: number): number {
+      const n = dropped.get(processId) ?? 0;
+      if (n > 0) dropped.set(processId, 0);
+      return n;
+    },
+    getDroppedCount(processId: number): number {
+      return dropped.get(processId) ?? 0;
+    },
+  };
+}
+
+export interface HandleDeps {
+  collector: CrashCollector;
+  limiter: RendererErrorRateLimiter;
+  processId: number;
+}
+
+export interface HandleResult { accepted: boolean; reason?: string }
+
+/** Pure handler used by the IPC wiring + tests. Records a renderer-surface
+ *  incident through the phase-1 collector and includes any drop-count
+ *  breadcrumb for events that were rate-limited since the last acceptance. */
+export function handleRendererErrorReport(report: RendererErrorReport, deps: HandleDeps): HandleResult {
+  const { collector, limiter, processId } = deps;
+  if (!limiter.tryAcquire(processId)) {
+    return { accepted: false, reason: 'rate-limited' };
+  }
+  const drops = limiter.drainDroppedCount(processId);
+  const breadcrumbs: string[] = [];
+  breadcrumbs.push(`renderer-error source=${report.source}`);
+  if (report.url) breadcrumbs.push(`renderer-error url=${report.url}`);
+  if (drops > 0) breadcrumbs.push(`renderer-error-drops=${drops}`);
+
+  collector.recordIncident({
+    surface: 'renderer',
+    error: {
+      name: report.error.name,
+      message: report.error.message,
+      stack: report.error.stack,
+    },
+    stderrTail: breadcrumbs,
+  });
+  return { accepted: true };
+}
+
+export interface RegisterRendererErrorIpcDeps {
+  ipcMain: IpcMain;
+  collector: CrashCollector;
+  /** Override for tests; defaults to a 10-event / 60-second sliding window. */
+  limiter?: RendererErrorRateLimiter;
+}
+
+const CHANNEL = 'crash:report-renderer-error';
+
+export function registerRendererErrorForwarderIpc(deps: RegisterRendererErrorIpcDeps): void {
+  const limiter = deps.limiter ?? createRendererErrorRateLimiter({ windowMs: 60_000, max: 10 });
+  deps.ipcMain.handle(CHANNEL, (e: IpcMainInvokeEvent, report: RendererErrorReport) => {
+    if (!fromMainFrame(e)) return { accepted: false, reason: 'guard-rejected' };
+    if (!report || typeof report !== 'object' || !report.error || typeof report.error.message !== 'string') {
+      return { accepted: false, reason: 'malformed' };
+    }
+    return handleRendererErrorReport(report, {
+      collector: deps.collector,
+      limiter,
+      processId: e.sender.id,
+    });
+  });
+}
+
+export const RENDERER_ERROR_IPC_CHANNEL = CHANNEL;

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -78,8 +78,17 @@ app.on('child-process-gone', (_e, details) => {
   });
 });
 
-// Best-effort retention pruning at boot.
-try { crashCollector.pruneRetention({ maxCount: 20, maxAgeDays: 30 }); } catch {}
+// Best-effort retention pruning at boot. Phase 5 layers per-surface keep-N
+// (default 20) on top of the legacy global cap, with a 7-day protect window
+// for unsent incidents so the user can still re-upload via "Send last crash".
+try {
+  crashCollector.pruneRetention({
+    maxCount: 20,
+    maxAgeDays: 30,
+    maxPerSurface: 20,
+    protectUnsentYoungerThanDays: 7,
+  });
+} catch {}
 
 // Exposed for supervisor wiring (Task 4) and downstream IPC fan-out.
 export function emitDaemonCrash(payload: { incidentId: string; exitCode: number | null; signal: string | null; bootNonce?: string; markerPresent: boolean }): void {
@@ -114,6 +123,7 @@ import { registerSystemIpc } from './ipc/systemIpc';
 import { registerSessionIpc } from './ipc/sessionIpc';
 import { registerWindowIpc } from './ipc/windowIpc';
 import { registerCrashIncidentsIpc } from './ipc/crashIncidents';
+import { registerRendererErrorForwarderIpc } from './ipc/rendererErrorForwarder';
 import { subscribeCrashConsentInvalidation } from './prefs/crashConsent';
 import {
   registerUtilityIpc,
@@ -267,6 +277,7 @@ app.whenReady().then(() => {
   registerWindowIpc({ ipcMain });
   registerUtilityIpc({ ipcMain });
   registerCrashIncidentsIpc({ ipcMain });
+  registerRendererErrorForwarderIpc({ ipcMain, collector: crashCollector });
 
   installUpdaterIpc();
 

--- a/electron/preload/bridges/ccsmCore.ts
+++ b/electron/preload/bridges/ccsmCore.ts
@@ -133,6 +133,22 @@ const api = {
     } | null> => ipcRenderer.invoke('crash:get-last-incident'),
     sendLastIncident: (): Promise<{ ok: true; eventId?: string } | { ok: false; reason: string }> =>
       ipcRenderer.invoke('crash:send-last-incident'),
+    /**
+     * Phase 5 — renderer error forwarder. Renderer hooks window.onerror /
+     * window.onunhandledrejection and forwards each event to the main-process
+     * collector, which records a `surface: 'renderer'` incident on disk
+     * (always) and forwards via Sentry (consent-gated, phase 4).
+     *
+     * The IPC is rate-limited at the main side (≤10/min per renderer process)
+     * so a tight error loop can't fill the disk. Excess events are silently
+     * dropped; the dropped count is folded into the next accepted incident.
+     */
+    reportRendererError: (report: {
+      error: { name?: string; message: string; stack?: string };
+      source: string;
+      url?: string;
+    }): Promise<{ accepted: boolean; reason?: string }> =>
+      ipcRenderer.invoke('crash:report-renderer-error', report),
   },
   onUpdateStatus: (handler: (s: UpdateStatus) => void): (() => void) => {
     const wrap = (_e: IpcRendererEvent, payload: UpdateStatus) => handler(payload);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ import '@fontsource-variable/jetbrains-mono';
 import App from './App';
 import { hydrateStore, type HydrationTrace } from './stores/store';
 import { flushNow, setPersistErrorHandler } from './stores/persist';
+import { installRendererErrorForwarder } from './lib/installRendererErrorForwarder';
 import './styles/global.css';
 
 // All knobs (DSN, environment, opt-out gating) live in the main process
@@ -20,6 +21,16 @@ import './styles/global.css';
 // bridge installed by @sentry/electron/preload.
 sentryInit({
   initialScope: { tags: { surface: 'renderer' } },
+});
+
+// Phase 5 crash observability — install renderer-side error forwarders that
+// route window.onerror + window.onunhandledrejection through the main-proc
+// collector, guaranteeing an on-disk `surface: 'renderer'` incident even
+// when the Sentry SDK is disabled (no DSN, or consent not granted).
+// console.error capture is dev-only; production stays focused on the two
+// real signals to keep the rate limit (≤10/min) signal-rich.
+installRendererErrorForwarder({
+  captureConsoleError: process.env.NODE_ENV !== 'production',
 });
 
 // Funnel silent persist failures (db locked, disk full, schema mismatch)

--- a/src/lib/installRendererErrorForwarder.ts
+++ b/src/lib/installRendererErrorForwarder.ts
@@ -1,0 +1,99 @@
+// src/lib/installRendererErrorForwarder.ts
+//
+// Phase 5 crash observability — renderer-side hooks for window.onerror and
+// window.onunhandledrejection (and, in dev builds only, console.error).
+// Forwards each event to the main process via the preload bridge so the
+// phase-1 collector records a `surface: 'renderer'` incident on disk
+// (regardless of consent) and the phase-2/3 Sentry SDK forwards it
+// (consent-gated, phase 4).
+//
+// We intentionally do NOT replace the renderer Sentry SDK's own
+// `window.onerror` interception — both can coexist (Sentry's runs first,
+// captures into its transport; ours runs after via the same global hook
+// and writes the on-disk incident). The two paths complement each other:
+// Sentry covers the "DSN configured + consent granted" upload path; this
+// forwarder covers the "always have something on disk" baseline.
+//
+// console.error is gated behind a dev-only flag because production logs are
+// noisy and a single misbehaving render path could trigger the rate limit
+// in seconds, masking the real signal we care about (uncaught throws).
+//
+// Rate-limiting lives on the main side (per-process). The renderer just
+// fires-and-forgets — even an excess of events at this end is cheap.
+
+interface CcsmCrashBridge {
+  reportRendererError: (report: {
+    error: { name?: string; message: string; stack?: string };
+    source: string;
+    url?: string;
+  }) => Promise<{ accepted: boolean; reason?: string }>;
+}
+
+interface CcsmAPI {
+  crash?: CcsmCrashBridge;
+}
+
+interface InstallOpts {
+  /** Capture console.error too. Off by default; turn on for dev builds. */
+  captureConsoleError?: boolean;
+}
+
+function serialize(input: unknown): { name?: string; message: string; stack?: string } {
+  if (input instanceof Error) {
+    return { name: input.name, message: input.message, stack: input.stack };
+  }
+  if (input && typeof input === 'object') {
+    try { return { message: JSON.stringify(input) }; } catch { return { message: String(input) }; }
+  }
+  return { message: String(input) };
+}
+
+/** Install renderer-side error forwarders. Returns a teardown function for
+ *  hot-reload / tests. Safe to call before the preload bridge is ready —
+ *  reports just bounce off until `window.ccsm.crash.reportRendererError`
+ *  resolves. */
+export function installRendererErrorForwarder(opts: InstallOpts = {}): () => void {
+  const w = window as unknown as { ccsm?: CcsmAPI };
+
+  function send(error: unknown, source: string, url?: string): void {
+    const bridge = w.ccsm?.crash;
+    if (!bridge?.reportRendererError) return;
+    try {
+      // Fire-and-forget; the main side rate-limits and never throws back.
+      void bridge.reportRendererError({ error: serialize(error), source, url });
+    } catch {
+      /* swallow — losing a forwarder report must not break the renderer */
+    }
+  }
+
+  const onErr = (event: Event): void => {
+    const e = event as Event & { error?: unknown; message?: string; filename?: string };
+    send(e.error ?? e.message ?? 'unknown error', 'window.onerror', e.filename || undefined);
+  };
+  const onRej = (event: Event): void => {
+    const e = event as Event & { reason?: unknown };
+    send(e.reason, 'window.onunhandledrejection');
+  };
+
+  window.addEventListener('error', onErr);
+  window.addEventListener('unhandledrejection', onRej);
+
+  let restoreConsole: (() => void) | null = null;
+  if (opts.captureConsoleError) {
+    const orig = console.error.bind(console);
+    console.error = (...args: unknown[]): void => {
+      try { orig(...args); } finally {
+        // Only forward Error-shaped first arg; arbitrary console.error('foo', 1)
+        // calls produce too much noise to be useful as crash incidents.
+        if (args[0] instanceof Error) send(args[0], 'console.error');
+      }
+    };
+    restoreConsole = () => { console.error = orig; };
+  }
+
+  return () => {
+    window.removeEventListener('error', onErr);
+    window.removeEventListener('unhandledrejection', onRej);
+    restoreConsole?.();
+  };
+}

--- a/tests/electron/crash/local-write-with-opted-out-renderer.test.ts
+++ b/tests/electron/crash/local-write-with-opted-out-renderer.test.ts
@@ -1,0 +1,53 @@
+// tests/electron/crash/local-write-with-opted-out-renderer.test.ts
+//
+// Phase 5 hard-constraint regression (mirror of phase 4 local-write test for
+// the renderer surface). Local crash logs MUST keep writing for renderer
+// errors regardless of `crashUploadConsent` value. Only the network-upload
+// path (Sentry) is gated.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+vi.mock('../../../electron/prefs/crashConsent', () => ({
+  isCrashUploadAllowed: () => false,
+  loadCrashConsent: () => 'opted-out',
+}));
+
+import { startCrashCollector } from '../../../electron/crash/collector';
+import {
+  handleRendererErrorReport,
+  createRendererErrorRateLimiter,
+} from '../../../electron/ipc/rendererErrorForwarder';
+
+let tmpRoot: string;
+beforeEach(() => { tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ccsm-crash-renderer-test-')); });
+afterEach(() => { try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch {} });
+
+describe('local crash log writer — renderer surface', () => {
+  it('writes the renderer incident dir + meta.json even when consent is opted-out', () => {
+    const collector = startCrashCollector({
+      crashRoot: path.join(tmpRoot, 'crashes'),
+      dmpStaging: path.join(tmpRoot, 'crashes', '_dmp-staging'),
+      appVersion: '0.3.0-test',
+      electronVersion: '41.0.0',
+    });
+    const limiter = createRendererErrorRateLimiter({ windowMs: 60_000, max: 10 });
+    const out = handleRendererErrorReport(
+      {
+        error: { name: 'ReferenceError', message: 'x is not defined', stack: 'at Renderer (app.tsx:10)' },
+        source: 'window.onerror',
+      },
+      { collector, limiter, processId: 1 }
+    );
+    expect(out.accepted).toBe(true);
+    const dirs = fs.readdirSync(path.join(tmpRoot, 'crashes')).filter((n) => !n.startsWith('_'));
+    expect(dirs.length).toBe(1);
+    const dir = path.join(tmpRoot, 'crashes', dirs[0]!);
+    expect(fs.existsSync(path.join(dir, 'meta.json'))).toBe(true);
+    const meta = JSON.parse(fs.readFileSync(path.join(dir, 'meta.json'), 'utf8'));
+    expect(meta.surface).toBe('renderer');
+    expect(meta.appVersion).toBe('0.3.0-test');
+  });
+});

--- a/tests/electron/crash/retention-per-surface.test.ts
+++ b/tests/electron/crash/retention-per-surface.test.ts
@@ -1,0 +1,188 @@
+// tests/electron/crash/retention-per-surface.test.ts
+//
+// Phase 5 retention: per-surface keep-N pruning + protected-window for
+// unsent-young incidents. Spec/plan §10 + phase-5 user prompt.
+//
+// Rules under test:
+//   - `maxPerSurface=N` keeps the N newest per surface (by mtime), prunes the
+//     rest within the same surface.
+//   - An incident is "protected" if it has NO `.uploaded` marker AND its
+//     mtime is younger than `protectUnsentYoungerThanDays`. Protected
+//     incidents are kept regardless of the count cap.
+//   - The legacy global `maxCount`/`maxAgeDays` behaviour is preserved when
+//     callers don't pass `maxPerSurface`.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { startCrashCollector } from '../../../electron/crash/collector';
+
+const SURFACES = ['main', 'renderer', 'daemon-exit', 'daemon-uncaught'] as const;
+type Surface = typeof SURFACES[number];
+
+let tmp: string;
+beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ccsm-coll-ret-')); });
+afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }); });
+
+function makeIncident(c: ReturnType<typeof startCrashCollector>, surface: Surface, ageDays: number, opts: { uploaded?: boolean } = {}): string {
+  const dir = c.recordIncident({ surface });
+  if (opts.uploaded) {
+    fs.writeFileSync(path.join(dir, '.uploaded'), JSON.stringify({ ts: new Date().toISOString() }), 'utf8');
+  }
+  // Backdate AFTER any helper-written files so the dir's mtime reflects ageDays
+  // rather than the most recent write inside the dir.
+  const t = (Date.now() - ageDays * 24 * 3600 * 1000) / 1000;
+  fs.utimesSync(dir, t, t);
+  return dir;
+}
+
+describe('crash retention — per-surface + protected-window', () => {
+  it('per-surface keep-N: 15 incidents per surface, N=10 → keeps 10 newest per surface', () => {
+    const c = startCrashCollector({
+      crashRoot: tmp,
+      dmpStaging: path.join(tmp, '_dmp-staging'),
+      appVersion: '0.3.0',
+      electronVersion: '41.3.0',
+    });
+    const dirs: Record<Surface, string[]> = { main: [], renderer: [], 'daemon-exit': [], 'daemon-uncaught': [] };
+    for (const s of SURFACES) {
+      for (let i = 0; i < 15; i++) {
+        // ageDays decreasing so dirs[*][14] is newest. All > protect window so none are protected unsent.
+        dirs[s].push(makeIncident(c, s, 30 - i, { uploaded: true }));
+      }
+    }
+    c.pruneRetention({ maxPerSurface: 10, protectUnsentYoungerThanDays: 7 });
+    for (const s of SURFACES) {
+      // The 5 oldest per surface should be gone; the 10 newest remain.
+      for (let i = 0; i < 5; i++) expect(fs.existsSync(dirs[s][i]!)).toBe(false);
+      for (let i = 5; i < 15; i++) expect(fs.existsSync(dirs[s][i]!)).toBe(true);
+    }
+  });
+
+  it('protected window: 15 incidents, N=10, with 2 unsent <7d → keeps 12', () => {
+    const c = startCrashCollector({
+      crashRoot: tmp,
+      dmpStaging: path.join(tmp, '_dmp-staging'),
+      appVersion: '0.3.0',
+      electronVersion: '41.3.0',
+    });
+    // 2 oldest are unsent + young (3 days); 13 others are uploaded + old.
+    const all: { dir: string; protected: boolean }[] = [];
+    for (let i = 0; i < 2; i++) all.push({ dir: makeIncident(c, 'main', 3 + i * 0.1, { uploaded: false }), protected: true });
+    for (let i = 0; i < 13; i++) all.push({ dir: makeIncident(c, 'main', 30 + i, { uploaded: true }), protected: false });
+
+    c.pruneRetention({ maxPerSurface: 10, protectUnsentYoungerThanDays: 7 });
+    const remaining = fs.readdirSync(tmp).filter(n => !n.startsWith('_') && !n.startsWith('.'));
+    // 10 newest by mtime + 2 protected = 12 (one of the protected may already be in the 10-newest set,
+    // depending on age; in this case the 2 protected ARE the 2 newest by mtime).
+    // 2 youngest by mtime are the protected (3-day-old); next-newest is 30-day uploaded.
+    // 10-newest set = 2 protected + 8 oldest-of-the-uploaded-cohort? No: newest first.
+    // Newest 10 = the 2 protected (3d) + the 8 newest of the uploaded (30..37 days).
+    // Then "2 unsent <7d" overlap with the newest-10 set → kept count = 10. So only 5 pruned,
+    // remaining = 10. But user spec text says "keeps 12" — that scenario is when the 2 protected
+    // are OLDER than the keep window. Recompute: make protected 2 also OLD-by-mtime (e.g. 60 days).
+    // Then newest-10 = 10 of the uploaded; 2 protected are extra. Keep 12.
+    expect(remaining.length).toBe(10);
+    for (const x of all.filter(a => a.protected)) expect(fs.existsSync(x.dir)).toBe(true);
+  });
+
+  it('protected window — 12 case: 2 unsent OLDER than keep window stay anyway', () => {
+    // 13 uploaded incidents (newer) + 2 unsent very-young (today) but their mtime is below the 13 newest.
+    // Setup: make the 13 uploaded be 1..13 days old; protected 2 are 0.1, 0.2 days old (newest).
+    // Then the 13 uploaded contains 10 newest of the uploaded-set. 2 protected are within the
+    // newest-10 already → kept count is 10 — same overlap problem.
+    //
+    // Real scenario per user prompt: protect prevents pruning of incidents the count rule WOULD
+    // otherwise prune. Construct: 15 uploaded incidents 1..15 days old. The 5 oldest (11..15 days)
+    // are slated for prune by N=10. Mark 2 of those slated-for-prune incidents as unsent and bump
+    // their mtime up to <7d so they become protected. Kept = 10 newest + 2 protected = 12.
+    const c = startCrashCollector({
+      crashRoot: tmp,
+      dmpStaging: path.join(tmp, '_dmp-staging'),
+      appVersion: '0.3.0',
+      electronVersion: '41.3.0',
+    });
+    const uploaded: string[] = [];
+    for (let i = 0; i < 13; i++) uploaded.push(makeIncident(c, 'main', 1 + i, { uploaded: true }));
+    // 2 protected — older than newest-10 boundary by uploaded-count BUT young per protect window.
+    // Use ageDays = 5 (below 7d protect window) and uploaded:false. Their mtime puts them in the
+    // newest-10 by mtime, but we can't avoid that with one surface. So instead bump 2 of the
+    // uploaded[] entries to unsent + age=5 to be in the slated-for-prune zone? Same problem.
+    //
+    // The clean construction: 15 incidents, ages 1..15 days, all uploaded except indices 10 + 11
+    // which are unsent (age 11d, 12d) — age > 7d → NOT protected. Keep 10 newest + 0 protected = 10.
+    // To get "keeps 12" we need 2 protected that the count rule would prune. That requires ages
+    // <7d for protection BUT be outside newest-10. Impossible in one surface unless we have ≥13
+    // incidents <7d. Use 12 incidents <7d (ages 0.1..6.5) + 3 uploaded older. Of the 12 young:
+    // 2 unsent (protected), 10 uploaded.
+    //
+    // Reset and rebuild.
+    fs.rmSync(tmp, { recursive: true, force: true });
+    fs.mkdirSync(tmp, { recursive: true });
+    const c2 = startCrashCollector({
+      crashRoot: tmp,
+      dmpStaging: path.join(tmp, '_dmp-staging'),
+      appVersion: '0.3.0',
+      electronVersion: '41.3.0',
+    });
+    const young: { dir: string; protected: boolean }[] = [];
+    // 10 uploaded young, ages 0.1..1.0d
+    for (let i = 0; i < 10; i++) young.push({ dir: makeIncident(c2, 'main', 0.1 + i * 0.1, { uploaded: true }), protected: false });
+    // 2 unsent young, ages 1.5d, 1.6d — slated for prune by count rule (slot 11+12) but protected.
+    young.push({ dir: makeIncident(c2, 'main', 1.5, { uploaded: false }), protected: true });
+    young.push({ dir: makeIncident(c2, 'main', 1.6, { uploaded: false }), protected: true });
+    // 3 uploaded old, ages 30..32d — slated for prune by count rule (slot 13..15), no protection.
+    const old: string[] = [];
+    for (let i = 0; i < 3; i++) old.push(makeIncident(c2, 'main', 30 + i, { uploaded: true }));
+
+    c2.pruneRetention({ maxPerSurface: 10, protectUnsentYoungerThanDays: 7 });
+
+    // The 2 protected MUST survive even though they're outside newest-10.
+    for (const y of young.filter(y => y.protected)) expect(fs.existsSync(y.dir)).toBe(true);
+    // The 10 newest uploaded survive.
+    for (const y of young.filter(y => !y.protected)) expect(fs.existsSync(y.dir)).toBe(true);
+    // The 3 old uploaded got pruned.
+    for (const o of old) expect(fs.existsSync(o)).toBe(false);
+
+    const remaining = fs.readdirSync(tmp).filter(n => !n.startsWith('_') && !n.startsWith('.'));
+    expect(remaining.length).toBe(12); // 10 newest + 2 protected
+  });
+
+  it('protected-window applies even when surface is over count cap (regression for unsent-young rule)', () => {
+    // 5 incidents in 'renderer' surface, all unsent + 2 days old. N=2. Protected window=7d.
+    // All 5 are protected → all 5 must survive (count cap is overridden by protection).
+    const c = startCrashCollector({
+      crashRoot: tmp,
+      dmpStaging: path.join(tmp, '_dmp-staging'),
+      appVersion: '0.3.0',
+      electronVersion: '41.3.0',
+    });
+    const dirs: string[] = [];
+    for (let i = 0; i < 5; i++) dirs.push(makeIncident(c, 'renderer', 1 + i * 0.1, { uploaded: false }));
+    c.pruneRetention({ maxPerSurface: 2, protectUnsentYoungerThanDays: 7 });
+    for (const d of dirs) expect(fs.existsSync(d)).toBe(true);
+  });
+
+  it('legacy global maxCount/maxAgeDays still works when maxPerSurface omitted', () => {
+    const c = startCrashCollector({
+      crashRoot: tmp,
+      dmpStaging: path.join(tmp, '_dmp-staging'),
+      appVersion: '0.3.0',
+      electronVersion: '41.3.0',
+    });
+    const dirs: string[] = [];
+    for (let i = 0; i < 21; i++) dirs.push(c.recordIncident({ surface: 'main' }));
+    const dayMs = 24 * 3600 * 1000;
+    const now = Date.now();
+    for (let i = 0; i < 21; i++) {
+      const ageDays = 31 - (i * (31 / 20));
+      const t = (now - ageDays * dayMs) / 1000;
+      fs.utimesSync(dirs[i]!, t, t);
+    }
+    c.pruneRetention({ maxCount: 20, maxAgeDays: 30 });
+    const remaining = fs.readdirSync(tmp).filter(n => !n.startsWith('_'));
+    expect(remaining.length).toBe(20);
+    expect(fs.existsSync(dirs[0]!)).toBe(false);
+  });
+});

--- a/tests/electron/ipc/rendererErrorForwarder.test.ts
+++ b/tests/electron/ipc/rendererErrorForwarder.test.ts
@@ -1,0 +1,92 @@
+// tests/electron/ipc/rendererErrorForwarder.test.ts
+//
+// Phase 5 renderer-error forwarder. Verifies the IPC handler:
+//   - calls collector.recordIncident with surface='renderer' on
+//     `crash:report-renderer-error`
+//   - rejects messages from a non-mainFrame sender (defense-in-depth)
+//   - applies a per-process rate limit (≤10/min) and counts dropped events.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  handleRendererErrorReport,
+  createRendererErrorRateLimiter,
+} from '../../../electron/ipc/rendererErrorForwarder';
+import type { CrashCollector } from '../../../electron/crash/collector';
+
+function makeCollector(): { rec: ReturnType<typeof vi.fn>; collector: CrashCollector } {
+  const rec = vi.fn().mockReturnValue('/tmp/x');
+  const collector: CrashCollector = {
+    recordIncident: rec,
+    flush: async () => {},
+    pruneRetention: () => {},
+  };
+  return { rec, collector };
+}
+
+describe('renderer error forwarder — IPC handler', () => {
+  it('records a renderer-surface incident with the renderer-supplied error', () => {
+    const { rec, collector } = makeCollector();
+    const limiter = createRendererErrorRateLimiter({ windowMs: 60_000, max: 10 });
+    const out = handleRendererErrorReport(
+      { error: { name: 'TypeError', message: 'oh no', stack: 'at foo' }, source: 'window.onerror' },
+      { collector, limiter, processId: 1 }
+    );
+    expect(out.accepted).toBe(true);
+    expect(rec).toHaveBeenCalledTimes(1);
+    const call = rec.mock.calls[0]![0];
+    expect(call.surface).toBe('renderer');
+    expect(call.error.name).toBe('TypeError');
+    expect(call.error.message).toBe('oh no');
+  });
+
+  it('drops events past the per-process rate-limit cap', () => {
+    const { rec, collector } = makeCollector();
+    const limiter = createRendererErrorRateLimiter({ windowMs: 60_000, max: 3 });
+    for (let i = 0; i < 5; i++) {
+      handleRendererErrorReport(
+        { error: { message: `err-${i}` }, source: 'window.onerror' },
+        { collector, limiter, processId: 42 }
+      );
+    }
+    expect(rec).toHaveBeenCalledTimes(3);
+    expect(limiter.getDroppedCount(42)).toBe(2);
+  });
+
+  it('rate-limit is per-process — different webContents IDs do not share a bucket', () => {
+    const { rec, collector } = makeCollector();
+    const limiter = createRendererErrorRateLimiter({ windowMs: 60_000, max: 2 });
+    for (let i = 0; i < 3; i++)
+      handleRendererErrorReport({ error: { message: 'a' }, source: 'window.onerror' }, { collector, limiter, processId: 1 });
+    for (let i = 0; i < 3; i++)
+      handleRendererErrorReport({ error: { message: 'b' }, source: 'window.onerror' }, { collector, limiter, processId: 2 });
+    expect(rec).toHaveBeenCalledTimes(4); // 2 per process
+    expect(limiter.getDroppedCount(1)).toBe(1);
+    expect(limiter.getDroppedCount(2)).toBe(1);
+  });
+
+  it('drop count is included in incident meta when transitioning into rate-limit', () => {
+    const { rec, collector } = makeCollector();
+    const limiter = createRendererErrorRateLimiter({ windowMs: 60_000, max: 2 });
+    handleRendererErrorReport({ error: { message: '1' }, source: 'window.onerror' }, { collector, limiter, processId: 7 });
+    handleRendererErrorReport({ error: { message: '2' }, source: 'window.onerror' }, { collector, limiter, processId: 7 });
+    handleRendererErrorReport({ error: { message: '3' }, source: 'window.onerror' }, { collector, limiter, processId: 7 });
+    handleRendererErrorReport({ error: { message: '4' }, source: 'window.onerror' }, { collector, limiter, processId: 7 });
+    expect(limiter.getDroppedCount(7)).toBe(2);
+    // Next accepted event after window slides should report the drop count via the meta extension.
+    // Simulate: jump time forward by faking a fresh limiter window.
+    const fakeNow = Date.now() + 70_000;
+    vi.spyOn(Date, 'now').mockReturnValue(fakeNow);
+    rec.mockClear();
+    const out = handleRendererErrorReport(
+      { error: { message: 'after window' }, source: 'window.onerror' },
+      { collector, limiter, processId: 7 }
+    );
+    vi.restoreAllMocks();
+    expect(out.accepted).toBe(true);
+    const call = rec.mock.calls[0]![0];
+    // recordIncident should be told about the drops via stderrTail (meta extension), as a single
+    // breadcrumb line. Verifies the producer did not silently lose the count.
+    expect(JSON.stringify(call)).toContain('renderer-error-drops=2');
+    expect(limiter.getDroppedCount(7)).toBe(0); // counter reset on flush
+  });
+});


### PR DESCRIPTION
Task #1094. Phase 5 of the crash-observability rollout (spec §10/§11, plan phase 5 retention + renderer forwarder slice).

## A. Per-surface retention with protected-window

Rules (extends `pruneRetention` in `electron/crash/collector.ts`):

- `maxPerSurface=N` (default **20**, wired into `electron/main.ts` boot) — keep the N newest incidents per surface (read from each incident's `meta.json`). Surfaces today: `main`, `renderer`, `gpu`, `helper`, `daemon-exit`, `daemon-uncaught`, `daemon-boot-crash` (per phase 1/3 incident schema).
- `protectUnsentYoungerThanDays=7` — never prune an incident that has NO `.uploaded` marker AND whose mtime is younger than 7 days. Rationale: phase-4's "Send last crash" button needs the dir to still be on disk for the user to re-upload; without this guard a chatty surface could push a young unsent incident off the keep-N list before the user ever sees the modal.
- Legacy global `maxCount`/`maxAgeDays` rule preserved (still called from boot for backward-compat with the phase-1 contract). Both rules now compute a single `toDelete` set so the protect-window applies uniformly.
- Pruning still runs once at electron-main boot, before any new collector writes (race-safe).

Future configurability hook: `crashLogRetention.maxPerSurface` is the spec'd setting key; for now the default is hard-coded in `main.ts` and a follow-up can surface it in Settings if the user ever wants to tune it.

## B. Renderer error forwarder

- IPC channel **`crash:report-renderer-error`** (`electron/ipc/rendererErrorForwarder.ts`).
- Renderer hooks `window.onerror` + `window.onunhandledrejection` (`src/lib/installRendererErrorForwarder.ts`); installed in `src/index.tsx` after the renderer Sentry SDK init so both can coexist.
- `console.error` capture is **dev-only** (gated on `process.env.NODE_ENV !== 'production'`) — production stays focused on the two real signals so the rate limit isn't burned by noisy debug logs. Production captures only window.onerror + window.onunhandledrejection.
- Rate-limit: **≤ 10 events / 60 s per renderer process** (`webContents.id` bucket). Excess events are silently dropped; the dropped count is folded into the next accepted incident's `stderrTail` as `renderer-error-drops=N` so the signal is preserved across the rate-limit boundary.
- Main routing: `handleRendererErrorReport` calls the existing phase-1 `recordIncident({ surface: 'renderer', ... })`. **No new Sentry init paths** — the existing main-proc Sentry SDK auto-routes by surface tag, and consent gating remains entirely in phase-4 territory (`isCrashUploadAllowed`).
- Defense-in-depth: IPC handler rejects messages from non-mainFrame senders via the existing `fromMainFrame` guard.

## Hard-constraint compliance

- **Phase 4 consent gate untouched.** Renderer incidents always write to disk regardless of consent (verified by `tests/electron/crash/local-write-with-opted-out-renderer.test.ts`, mirror of the phase-4 main-surface test).
- **Phase 2/3 Sentry routing untouched.** No new SDK init paths; no DSN-selection changes.
- **Protect window** prevents the user's "send last crash" button from ever finding a missing dir within 7 days of the incident.

## Reverse-verify (protect-window rule)

Temporarily disabled the `if (protectUnsentYoungerThanDays != null && !isUploaded)` branch in `collector.ts`:

```
× protected window — 12 case: 2 unsent OLDER than keep window stay anyway 233ms
× protected-window applies even when surface is over count cap (regression for unsent-young rule) 38ms
Tests  2 failed | 3 passed (5)
```

Restored the branch:

```
Test Files  1 passed (1)
     Tests  5 passed (5)
```

## Local-write-with-opted-out (renderer surface, phase-4 mirror)

`tests/electron/crash/local-write-with-opted-out-renderer.test.ts > local crash log writer — renderer surface > writes the renderer incident dir + meta.json even when consent is opted-out` — **PASS**.

## Test summary

- `tests/electron/crash/retention-per-surface.test.ts` — 5/5 pass (per-surface keep-N, two protected-window scenarios, count-cap-vs-protect interaction, legacy global rule regression).
- `tests/electron/ipc/rendererErrorForwarder.test.ts` — 4/4 pass (records renderer-surface incident, drops past cap, per-process bucket isolation, drop-count fold-in on next accepted event).
- `tests/electron/crash/local-write-with-opted-out-renderer.test.ts` — 1/1 pass.
- Existing crash suites (`collector.test.ts`, `local-write-with-opted-out.test.ts`, `crashIncidents.test.ts`) — all green.
- Typecheck: `npm run typecheck` clean.
- Lint: net **+1** error fixed vs. baseline (33 → 32; pre-existing errors all in unrelated files).

## i18n

No new UI strings — pure plumbing. No i18n keys added.

## Files

- `electron/crash/collector.ts` — extended `PruneOpts`, prune logic.
- `electron/main.ts` — boot-time prune call upgraded with per-surface + protect-window args; `registerRendererErrorForwarderIpc` wired.
- `electron/ipc/rendererErrorForwarder.ts` — new IPC handler + rate limiter.
- `electron/preload/bridges/ccsmCore.ts` — `ccsm.crash.reportRendererError` bridge.
- `src/lib/installRendererErrorForwarder.ts` — renderer-side hooks.
- `src/index.tsx` — install hook after Sentry init.
- 3 new test files.

## Test plan

- [x] Unit: per-surface retention prunes correctly; protected window respected.
- [x] Unit: renderer forwarder routes via IPC, recordIncident called with `surface: 'renderer'`.
- [x] Unit: rate-limit per process; drop-count fold-in.
- [x] Reverse-verify: disable protect window → tests FAIL; restore → PASS.
- [x] Regression: local renderer incident writes under `consent: opted-out`.
- [x] Typecheck (`npm run typecheck`).
- [ ] E2E probe — out of scope per task instructions ("No e2e probes — focus on unit tests").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>