### PR TITLE
test: 3 regression probes for previously-shipped bugs

### DIFF
--- a/tests/regression/import-dialog-focused-group.test.tsx
+++ b/tests/regression/import-dialog-focused-group.test.tsx
@@ -1,0 +1,164 @@
+// Regression: PR #510 (#607) — `fix(import): import targets focused
+// group`.
+//
+// Bug: `ImportDialog#doImport` always wrote new rows into the catch-all
+// "Imported" group. A user reading group "research" who hit Import had
+// to manually drag every new row out of "Imported" into "research".
+//
+// Fix: when `store.focusedGroupId` resolves to a normal group, route the
+// import there. Without a focus, fall back to the (created-on-demand)
+// "Imported" bucket. Also: the focused id is captured in `doImport`'s
+// closure, so a batch of N imported rows all land in the focused group
+// (the store clears `focusedGroupId` on each `importSession` call but
+// the closure already holds the original id).
+//
+// Existing coverage gap: the PR shipped with only a manual checklist —
+// no e2e probe and no unit test. The store slice tests
+// (`tests/stores/slices/sessionCrudSlice.test.ts`) exercise
+// `importSession` directly but never the dialog wiring that decides the
+// `groupId` argument from `focusedGroupId`. This file pins that wiring.
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, fireEvent, cleanup, waitFor, screen } from '@testing-library/react';
+import { ImportDialog } from '../../src/components/ImportDialog';
+import { useStore } from '../../src/stores/store';
+
+type Scannable = {
+  sessionId: string;
+  cwd: string;
+  title: string;
+  mtime: number;
+  projectDir: string;
+  model: string | null;
+};
+
+const fakeRows: Scannable[] = [
+  {
+    sessionId: 'imp-1',
+    cwd: '/work/proj-a',
+    title: 'session-a',
+    mtime: Date.now(),
+    projectDir: '/home/u/.claude/projects/proj-a',
+    model: null,
+  },
+  {
+    sessionId: 'imp-2',
+    cwd: '/work/proj-b',
+    title: 'session-b',
+    mtime: Date.now(),
+    projectDir: '/home/u/.claude/projects/proj-b',
+    model: null,
+  },
+];
+
+function installCcsmStub() {
+  (window as unknown as { ccsm: unknown }).ccsm = {
+    scanImportable: vi.fn().mockResolvedValue(fakeRows),
+  } as unknown as Window['ccsm'];
+}
+
+function clearCcsmStub() {
+  (window as unknown as { ccsm?: unknown }).ccsm = undefined;
+}
+
+afterEach(() => {
+  cleanup();
+  clearCcsmStub();
+});
+
+describe('PR #510 regression — ImportDialog targets focused group', () => {
+  beforeEach(() => {
+    installCcsmStub();
+  });
+
+  it('routes imports into focusedGroupId when set to a normal group', async () => {
+    const importSession = vi.fn();
+    const createGroup = vi.fn().mockReturnValue('g-imported-fallback');
+    const renameGroup = vi.fn();
+    useStore.setState({
+      sessions: [],
+      groups: [
+        { id: 'g-research', name: 'research', collapsed: false, kind: 'normal' },
+        { id: 'g-other', name: 'other', collapsed: false, kind: 'normal' },
+      ],
+      focusedGroupId: 'g-research',
+      importSession,
+      createGroup,
+      renameGroup,
+    });
+
+    render(<ImportDialog open onOpenChange={() => {}} />);
+    // Wait for scanImportable to resolve and rows to render.
+    await waitFor(() => {
+      expect(screen.getByText('session-a')).toBeInTheDocument();
+    });
+    // Select all then trigger import.
+    const selectAll = screen.getByRole('button', { name: /select all/i });
+    fireEvent.click(selectAll);
+    const importBtn = screen.getByRole('button', { name: /^import \d/i });
+    fireEvent.click(importBtn);
+
+    await waitFor(() => expect(importSession).toHaveBeenCalledTimes(2));
+    // Both rows must land in g-research, NOT in a created "Imported" bucket.
+    for (const call of importSession.mock.calls) {
+      expect(call[0].groupId).toBe('g-research');
+    }
+    // Fallback bucket creation must NOT have fired when a focused group exists.
+    expect(createGroup).not.toHaveBeenCalled();
+    expect(renameGroup).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the "Imported" bucket when focusedGroupId is null', async () => {
+    const importSession = vi.fn();
+    const createGroup = vi.fn().mockReturnValue('g-new-imported');
+    const renameGroup = vi.fn();
+    useStore.setState({
+      sessions: [],
+      groups: [{ id: 'g-default', name: 'Default', collapsed: false, kind: 'normal' }],
+      focusedGroupId: null,
+      importSession,
+      createGroup,
+      renameGroup,
+    });
+
+    render(<ImportDialog open onOpenChange={() => {}} />);
+    await waitFor(() => {
+      expect(screen.getByText('session-a')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /select all/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^import \d/i }));
+
+    await waitFor(() => expect(importSession).toHaveBeenCalledTimes(2));
+    // Imported bucket created on demand and used as the target groupId.
+    expect(createGroup).toHaveBeenCalledWith('Imported');
+    for (const call of importSession.mock.calls) {
+      expect(call[0].groupId).toBe('g-new-imported');
+    }
+  });
+
+  it('reuses an existing "Imported" group when present and unfocused', async () => {
+    const importSession = vi.fn();
+    const createGroup = vi.fn();
+    useStore.setState({
+      sessions: [],
+      groups: [{ id: 'g-imp-existing', name: 'Imported', collapsed: false, kind: 'normal' }],
+      focusedGroupId: null,
+      importSession,
+      createGroup,
+      renameGroup: vi.fn(),
+    });
+
+    render(<ImportDialog open onOpenChange={() => {}} />);
+    await waitFor(() => {
+      expect(screen.getByText('session-a')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /select all/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^import \d/i }));
+
+    await waitFor(() => expect(importSession).toHaveBeenCalledTimes(2));
+    expect(createGroup).not.toHaveBeenCalled();
+    for (const call of importSession.mock.calls) {
+      expect(call[0].groupId).toBe('g-imp-existing');
+    }
+  });
+});

--- a/tests/regression/no-false-ctrl-n-hint.test.tsx
+++ b/tests/regression/no-false-ctrl-n-hint.test.tsx
@@ -1,0 +1,120 @@
+// Regression: PR #601 (commit 15f86dd) — `fix(ui): remove false Ctrl+N
+// shortcut hints`.
+//
+// Bug: ShortcutOverlay row + CommandPalette command-list hint advertised
+// `Ctrl+N` for "New session" even though no Ctrl+N key handler exists in
+// App.tsx (only Ctrl+Shift+N is bound, for "New group"). Per user
+// 2026-04-30: ccsm intentionally won't add the shortcut, so the hints
+// have to stay gone. A future PR re-adding "Ctrl+N" / "⌘+N" labels (e.g.
+// during another shortcut sweep) would silently mislead users into
+// pressing a no-op key.
+//
+// Existing coverage gap: `tests/shortcut-overlay.test.tsx` asserts
+// >=6 kbd chips and that `Ctrl` appears at least once, but does NOT
+// assert that the standalone `Ctrl+N` (or `⌘+N`) combo is absent. The
+// CommandPalette's hint chip column is not tested at all for this.
+//
+// This file pins both surfaces so a regression in either fails loudly.
+import React, { useState } from 'react';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { render, screen, cleanup, within, fireEvent } from '@testing-library/react';
+import { ShortcutOverlay } from '../../src/components/ShortcutOverlay';
+import { CommandPalette } from '../../src/components/CommandPalette';
+import { useStore } from '../../src/stores/store';
+
+// Pattern matches `Ctrl+N` / `Ctrl + N` / `⌘+N` / `⌘ + N` etc., but does
+// NOT match the legitimate `Ctrl+Shift+N` / `⌘+Shift+N`. The textContent
+// concatenates row labels with no separator (e.g. "Ctrl+Shift+NNew
+// group"), so we use a negative-lookbehind for "Shift+" before the
+// modifier — and we don't anchor with \b after N because the next
+// character is often the start of an action label like "New group".
+const FALSE_NEW_SESSION_PATTERN = /(?<!Shift\+)(?:Ctrl|⌘)\s*\+\s*N(?![a-z])/;
+
+afterEach(() => cleanup());
+
+function ShortcutHarness() {
+  const [open, setOpen] = useState(true);
+  return <ShortcutOverlay open={open} onOpenChange={setOpen} />;
+}
+
+describe('PR #601 regression — no false Ctrl+N hint', () => {
+  describe('ShortcutOverlay', () => {
+    it('does not render a standalone Ctrl+N (or ⌘+N) row for "New session"', () => {
+      render(<ShortcutHarness />);
+      const dialog = screen.getByRole('dialog');
+      const text = dialog.textContent || '';
+      // Safety: legitimate Ctrl+Shift+N (New group) should still render
+      // — that proves the dialog actually mounted with shortcut rows and
+      // the negative assertion below isn't vacuous. The textContent has
+      // no whitespace between kbd chips, so the modifier+Shift+N pair
+      // appears as the literal "Ctrl+Shift+N" / "⌘+Shift+N". We don't
+      // anchor with \b after N because the next char is usually the
+      // start of an action label like "New group" (no boundary).
+      expect(text).toMatch(/(?:Ctrl|⌘)\+Shift\+N(?![a-z])/);
+      // Real check: the bare "Ctrl+N" / "⌘+N" combo must be gone.
+      expect(text).not.toMatch(FALSE_NEW_SESSION_PATTERN);
+
+      // Also pin the kbd chip granularity: NO row's kbd-chip group spells
+      // out exactly the modifier+N pair (without Shift). The PR removed
+      // a row that rendered 2 kbds: `Ctrl` and `N`.
+      const rows = within(dialog).getAllByRole('row');
+      for (const row of rows) {
+        const kbds = within(row)
+          .queryAllByText((_, el) => el?.tagName.toLowerCase() === 'kbd')
+          .map((el) => (el.textContent || '').trim());
+        // A "false Ctrl+N" row would contain exactly [Ctrl/⌘, N] with no
+        // intermediate Shift kbd. Reject that exact shape.
+        const isModN =
+          kbds.length === 2 &&
+          /^(Ctrl|⌘)$/.test(kbds[0]) &&
+          /^N$/.test(kbds[1]);
+        expect(isModN).toBe(false);
+      }
+    });
+  });
+
+  describe('CommandPalette', () => {
+    beforeEach(() => {
+      // CommandPalette reads sessions/groups/theme from the store. Seed an
+      // empty-ish state so the only commands present are the static ones
+      // (cmdNewGroup / cmdImport / cmdOpenSettings / cmdSwitchTheme).
+      useStore.setState({
+        sessions: [],
+        groups: [],
+        flashStates: {},
+        disconnectedSessions: {},
+      });
+      // jsdom lacks matchMedia which CommandPalette uses for theme.
+      if (!(window as { matchMedia?: unknown }).matchMedia) {
+        Object.defineProperty(window, 'matchMedia', {
+          writable: true,
+          value: vi.fn().mockImplementation(() => ({
+            matches: false,
+            media: '(prefers-color-scheme: dark)',
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+          })),
+        });
+      }
+    });
+
+    it('does not surface a Ctrl+N / ⌘+N hint chip on any command row', () => {
+      render(<CommandPalette open onOpenChange={() => {}} />);
+      const dialog = screen.getByRole('dialog');
+      // Type into the search box so commands surface as result rows
+      // (CommandPalette only renders results when a query is non-empty).
+      const search = within(dialog).getByPlaceholderText(/search/i) as HTMLInputElement;
+      fireEvent.change(search, { target: { value: 'new' } });
+
+      const text = dialog.textContent || '';
+      // Sanity: at least the "new group" command surfaces with its
+      // legitimate Ctrl+Shift+N / ⌘+Shift+N hint.
+      expect(text).toMatch(/(?:Ctrl|⌘)\s*\+?\s*Shift\s*\+\s*N\b/);
+      // Real check: no row offers a bare modifier+N hint.
+      expect(text).not.toMatch(FALSE_NEW_SESSION_PATTERN);
+    });
+  });
+});

--- a/tests/regression/session-name-bridge-cleanup.test.tsx
+++ b/tests/regression/session-name-bridge-cleanup.test.tsx
@@ -1,0 +1,126 @@
+// Regression: PR #520 (#613) — `fix(notify): clear sessionNamesFromRenderer
+// on session delete`.
+//
+// Bug: the renderer mirrors per-session `(sid, name)` pairs to main's
+// `sessionNamesFromRenderer` Map (via `ccsmSession.setName` IPC) so the
+// desktop-notify bridge can label OS toasts with the friendly name
+// instead of the bare UUID. Before the fix the renderer never emitted a
+// clearing call when a sid disappeared from the sessions array, so
+// main's map grew unbounded across the app lifetime (~50 bytes per
+// ever-created-then-deleted session). Audit #876 cluster H, follow-up
+// to PR #509.
+//
+// Fix lives in `src/app-effects/useSessionNameBridge.ts`: on each
+// `sessions` update, diff against a `prevSidsRef` snapshot and emit
+// `bridge.setName(staleSid, null)` for any sid no longer present.
+//
+// Existing coverage gap: the harness-real-cli probe
+// `notify-name-cleared-on-session-delete` covers the end-to-end path
+// against a real Electron + claude CLI (~30s). There is NO unit test
+// exercising the renderer-side cleanup logic in isolation, so a
+// refactor that moves the cleanup branch out of the effect (e.g.
+// "we'll let main GC by tracking unwatched events instead") would only
+// surface in a slow e2e run. This file pins the contract at the hook
+// boundary.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useSessionNameBridge } from '../../src/app-effects/useSessionNameBridge';
+
+type SessionLike = { id: string; name?: string | null };
+
+function installBridge() {
+  const setName = vi.fn();
+  (window as unknown as { ccsmSession: { setName: typeof setName } }).ccsmSession = {
+    setName,
+  };
+  return setName;
+}
+
+afterEach(() => {
+  (window as unknown as { ccsmSession?: unknown }).ccsmSession = undefined;
+});
+
+describe('PR #520 regression — useSessionNameBridge clears stale sids', () => {
+  let setName: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    setName = installBridge();
+  });
+
+  it('mirrors current (sid, name) pairs to main on first render', () => {
+    const sessions: SessionLike[] = [
+      { id: 'a', name: 'Alpha' },
+      { id: 'b', name: 'Beta' },
+    ];
+    renderHook(({ s }: { s: SessionLike[] }) => useSessionNameBridge(s), {
+      initialProps: { s: sessions },
+    });
+    expect(setName).toHaveBeenCalledWith('a', 'Alpha');
+    expect(setName).toHaveBeenCalledWith('b', 'Beta');
+    // No clearing calls on the first pass — the prev-snapshot is empty.
+    const clearCalls = setName.mock.calls.filter((c) => c[1] === null);
+    expect(clearCalls).toEqual([]);
+  });
+
+  it('emits setName(sid, null) for sids that disappear between renders', () => {
+    const initial: SessionLike[] = [
+      { id: 'a', name: 'Alpha' },
+      { id: 'b', name: 'Beta' },
+      { id: 'c', name: 'Gamma' },
+    ];
+    const after: SessionLike[] = [
+      { id: 'a', name: 'Alpha' },
+      // 'b' and 'c' deleted
+    ];
+    const { rerender } = renderHook(({ s }: { s: SessionLike[] }) => useSessionNameBridge(s), {
+      initialProps: { s: initial },
+    });
+    setName.mockClear();
+    rerender({ s: after });
+
+    // Surviving sid is re-pushed (idempotent in main).
+    expect(setName).toHaveBeenCalledWith('a', 'Alpha');
+    // Both deleted sids must receive an explicit null clear so main's
+    // sessionNamesFromRenderer Map drops them.
+    expect(setName).toHaveBeenCalledWith('b', null);
+    expect(setName).toHaveBeenCalledWith('c', null);
+  });
+
+  it('does NOT emit clears for sids that are still present', () => {
+    const sessions: SessionLike[] = [
+      { id: 'a', name: 'Alpha' },
+      { id: 'b', name: 'Beta' },
+    ];
+    const { rerender } = renderHook(({ s }: { s: SessionLike[] }) => useSessionNameBridge(s), {
+      initialProps: { s: sessions },
+    });
+    setName.mockClear();
+    // Re-render with the SAME sids but a renamed entry — no clears
+    // expected, only the rename pushes through.
+    rerender({ s: [{ id: 'a', name: 'Alpha-2' }, { id: 'b', name: 'Beta' }] });
+    const clearCalls = setName.mock.calls.filter((c) => c[1] === null);
+    expect(clearCalls).toEqual([]);
+    expect(setName).toHaveBeenCalledWith('a', 'Alpha-2');
+  });
+
+  it('handles a full delete-all transition (every sid cleared)', () => {
+    const initial: SessionLike[] = [
+      { id: 'a', name: 'Alpha' },
+      { id: 'b', name: 'Beta' },
+    ];
+    const { rerender } = renderHook(({ s }: { s: SessionLike[] }) => useSessionNameBridge(s), {
+      initialProps: { s: initial },
+    });
+    setName.mockClear();
+    rerender({ s: [] });
+    expect(setName).toHaveBeenCalledWith('a', null);
+    expect(setName).toHaveBeenCalledWith('b', null);
+  });
+
+  it('is a no-op when window.ccsmSession is unavailable (preload not wired)', () => {
+    (window as unknown as { ccsmSession?: unknown }).ccsmSession = undefined;
+    expect(() =>
+      renderHook(() => useSessionNameBridge([{ id: 'a', name: 'Alpha' }])),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Task #1044 — add permanent regression probes for 3 previously-shipped bug fixes that lacked dedicated test coverage. Per audit HIGH: bugs that already escaped once need machine-checked guards so they can't silently come back.

All 3 probes live as fast unit tests (vitest + RTL / `renderHook`) in `tests/regression/`. No new e2e probe was added — every chosen fix is small enough that a unit test exercises the exact decision branch the bug touched, with no Electron boot cost.

## The 3 bugs

| # | Fix PR | Issue | Surface | Coverage gap before this PR |
|---|---|---|---|---|
| 1 | #601 | #857 — false `Ctrl+N` hint advertised but no handler bound | `ShortcutOverlay` + `CommandPalette` | `tests/shortcut-overlay.test.tsx` only asserted `>=6` kbd chips and that `Ctrl` appears once; nothing pinned the *absence* of the bare `Ctrl+N` row. CommandPalette hint chips were untested. |
| 2 | #510 | #607 — Import session always dropped rows in catch-all "Imported" group, ignoring `focusedGroupId` | `ImportDialog#doImport` | PR shipped with manual checklist only. Slice tests cover `importSession` directly but never the dialog wiring that decides `groupId` from `focusedGroupId`. |
| 3 | #520 | #613 — `sessionNamesFromRenderer` map grew unbounded; renderer never emitted clearing IPC for deleted sids (audit #876 cluster H) | `useSessionNameBridge` (renderer hook) | The harness-real-cli probe `notify-name-cleared-on-session-delete` covers e2e against real Electron + claude (~30s); no unit test exercising the renderer-side cleanup loop in isolation. A refactor moving the cleanup branch out of the effect would only surface in a slow e2e run. |

## Harness vs standalone breakdown

All 3 probes are unit tests (vitest in `tests/regression/`), not e2e. Per memory rule "E2E 优先塞 harness — each independent probe = +30s test time", none of these bugs warrant a new probe slot:

- #601 + #510 are pure renderer state contracts (no Electron, no CLI).
- #520's e2e path is already covered by the existing harness-real-cli case; the gap was the *unit-level* contract on the hook.

Adding 3 vitest files keeps the e2e suite unchanged (zero added wall-clock).

## Reverse-verify (each probe FAILED with its corresponding fix temporarily reverted in-place; reverts are NOT in this PR)

- **#601 ShortcutOverlay** (re-added `{ keys: '${MOD} + N', ... }` row):
  ```
  AssertionError: expected '...Ctrl+NNew groupCtrl+Shift+NNew group...' not to match /(?<!Shift\+)(?:Ctrl|⌘)\s*\+\s*N(?![a-z])/
  ```
- **#601 CommandPalette** (changed `cmd:new-group` hint from `${MOD}Shift+N` to `${MOD}N`):
  ```
  AssertionError: expected 'Command paletteNew groupCtrl+N↑↓Navigate↵SelectEscClose' to match /(?:Ctrl|⌘)\s*\+?\s*Shift\s*\+\s*N\b/
  ```
- **#510 ImportDialog** (replaced `focusedGroupId` lookup with `undefined`):
  ```
  AssertionError: expected "g-imported-fallback" to be "g-research"
  ```
- **#520 useSessionNameBridge** (deleted the stale-sid cleanup loop):
  ```
  AssertionError: expected "vi.fn()" to be called with arguments: [ 'b', null ]
  Number of calls: 1   (only setName('a','Alpha') fired)
  ```
- **#520 full-delete-all transition** (same revert):
  ```
  AssertionError: expected "vi.fn()" to be called with arguments: [ 'a', null ]
  Number of calls: 0
  ```

After restoring all 4 production files via `git checkout`, the suite returns to **10/10 passing** in ~4s.

## Quality gates

- `npx vitest run tests/regression/` — 10/10 passing, ~4s wall.
- `npx tsc --noEmit` — clean.
- ESLint: `tests/**` is globally ignored by `eslint.config.js` (line 17), so no lint deltas apply to these files.

## Test plan
- [x] All 3 new probes pass on green tree
- [x] Reverse-verify FAIL output captured for each (above)
- [x] typecheck clean
- [x] lint scope confirmed (tests dir ignored by config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)