### PR TITLE
feat(v0.3.1): consolidate daemon-health fragments into useDaemonHealthBridge

### DIFF
--- a/src/app-effects/useDaemonHealthBridge.ts
+++ b/src/app-effects/useDaemonHealthBridge.ts
@@ -1,0 +1,262 @@
+// Task #1060 — `useDaemonHealthBridge`: consolidated React hook that
+// surfaces the renderer-side daemon connectivity snapshot. v0.3 work
+// shipped multiple per-fragment bridges (`useDaemonReconnectBridge`
+// #1028 PRODUCER + `daemonEventBus` typed pub/sub + `reconnectQueue`
+// SINK). Each downstream consumer would otherwise have to subscribe to
+// the bus on its own and reassemble the same fields. This hook owns the
+// reassembly so call sites read a single snapshot.
+//
+// Spec citations:
+//   - docs/superpowers/specs/v0.3-design.md §6.8 — renderer-side
+//     consolidated `daemonHealth` surface (originally listed as a
+//     spec-only symbol; tests under `tests/harness-daemon-mode.test.ts`
+//     §1201-1205 explicitly note this hook had not yet been built).
+//   - docs/superpowers/specs/v0.3-fragments/frag-3.5.1-pty-hardening.md
+//     §3.5.1.4 — `bootNonce` carries through every daemon-emitted
+//     envelope; a change means the daemon was restarted and replay
+//     state is invalid.
+//   - docs/superpowers/specs/v0.3-fragments/frag-6-7-reliability-security.md
+//     §6.5–§6.6 — server-side stream-dead detector + reconnected /
+//     unreachable bridge transitions feed the same bus.
+//
+// Single Responsibility (per `feedback_single_responsibility`):
+//   DECIDER. Subscribes ONCE to the typed `daemonEventBus`, folds the
+//   four event streams into a single immutable snapshot, exposes that
+//   snapshot to React via `useSyncExternalStore`. Owns no I/O, no event
+//   emission, no reconnect mechanics. PRODUCER side stays in
+//   `useDaemonReconnectBridge` / preload bridges; SINK side stays in
+//   `reconnect-queue.ts`.
+//
+// Back-compat note: existing fragments (`useDaemonReconnectBridge` and
+// the `daemonEventBus` itself) are intentionally NOT removed in this PR.
+// `useDaemonReconnectBridge` solves a different problem (window
+// `CustomEvent` re-emission from a `subscribe(cb)` source for callers
+// that don't want to hold a bus reference) and currently has no in-tree
+// consumer to migrate. New read-side call sites should use this hook.
+
+import { useSyncExternalStore } from 'react';
+import {
+  daemonEventBus as defaultBus,
+  type DaemonEventBus,
+} from '../lib/daemon-events';
+
+/**
+ * High-level daemon connectivity status as observed from the renderer.
+ *
+ * - `unknown`  — no event has arrived yet (hook just mounted, daemon
+ *                hasn't sent its first envelope).
+ * - `healthy`  — last transition was `bootChanged` or `reconnected` and
+ *                no `streamDead` / `unreachable` has fired since.
+ * - `degraded` — at least one stream-dead has fired since last healthy
+ *                transition; daemon may still be reachable, individual
+ *                subscriptions are recovering (frag-6-7 §6.6.1).
+ * - `unreachable` — bridge gave up after retries (frag-6-7 §6.5 banner
+ *                   red state). Cleared by next `reconnected` /
+ *                   `bootChanged`.
+ */
+export type DaemonHealthStatus =
+  | 'unknown'
+  | 'healthy'
+  | 'degraded'
+  | 'unreachable';
+
+/**
+ * Immutable snapshot returned by the hook. Identity is stable across
+ * renders when underlying state has not changed (required by
+ * `useSyncExternalStore` to avoid render loops).
+ */
+export interface DaemonHealthSnapshot {
+  /** Aggregated status. See `DaemonHealthStatus` doc above. */
+  readonly status: DaemonHealthStatus;
+  /** ms-epoch of the most recently observed event of any kind, or
+   *  `null` if no event has arrived yet. */
+  readonly lastSeen: number | null;
+  /** Cumulative count of `streamDead` events since the hook started.
+   *  Mirrors what individual consumers used to count themselves. The
+   *  reconnect queue still owns per-subId attempt counters; this is a
+   *  process-wide tally for surfaces (banners, dev panels). */
+  readonly reconnectAttempt: number;
+  /** Most recently observed daemon `bootNonce`, or `null`. Useful for
+   *  surfaces that want to display the daemon identity. */
+  readonly version: string | null;
+  /** Reason from the last `unreachable` event, or `null` if currently
+   *  reachable / never unreachable. */
+  readonly lastUnreachableReason: string | null;
+  /** subId of the last stream-dead event, or `null`. Surfaces that
+   *  show "session X reconnecting…" can read this directly. */
+  readonly lastStreamDeadSubId: string | null;
+}
+
+interface MutableState {
+  status: DaemonHealthStatus;
+  lastSeen: number | null;
+  reconnectAttempt: number;
+  version: string | null;
+  lastUnreachableReason: string | null;
+  lastStreamDeadSubId: string | null;
+}
+
+const INITIAL_SNAPSHOT: DaemonHealthSnapshot = Object.freeze({
+  status: 'unknown',
+  lastSeen: null,
+  reconnectAttempt: 0,
+  version: null,
+  lastUnreachableReason: null,
+  lastStreamDeadSubId: null,
+});
+
+/**
+ * Module-level store. Single subscription to the bus is created lazily
+ * the first time a hook instance mounts and torn down when the last one
+ * unmounts. Multiple consumers across the tree share the same snapshot
+ * (the whole point of consolidation) — they all see consistent reads.
+ *
+ * Exposed as a class so a test can construct an isolated instance with
+ * its own bus (see `__createDaemonHealthStoreForTest`). Production code
+ * uses the module-level `defaultDaemonHealthStore`.
+ */
+export class DaemonHealthStore {
+  private state: MutableState;
+  private snapshot: DaemonHealthSnapshot = INITIAL_SNAPSHOT;
+  private readonly listeners = new Set<() => void>();
+  private readonly bus: DaemonEventBus;
+  private readonly clock: () => number;
+  private busUnsubs: Array<() => void> = [];
+  private subscriberCount = 0;
+
+  constructor(
+    bus: DaemonEventBus = defaultBus,
+    clock: () => number = () => Date.now(),
+  ) {
+    this.bus = bus;
+    this.clock = clock;
+    this.state = {
+      status: 'unknown',
+      lastSeen: null,
+      reconnectAttempt: 0,
+      version: null,
+      lastUnreachableReason: null,
+      lastStreamDeadSubId: null,
+    };
+  }
+
+  getSnapshot = (): DaemonHealthSnapshot => this.snapshot;
+
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    if (this.subscriberCount === 0) this.attachBus();
+    this.subscriberCount++;
+    return () => {
+      this.listeners.delete(listener);
+      this.subscriberCount = Math.max(0, this.subscriberCount - 1);
+      if (this.subscriberCount === 0) this.detachBus();
+    };
+  };
+
+  /** Test helper — number of currently-attached bus listeners. The
+   *  whole point of consolidation: this should be 0 (idle) or 4 (one
+   *  per event), never N×consumers. */
+  getBusSubscriptionCount(): number {
+    return this.busUnsubs.length;
+  }
+
+  private attachBus(): void {
+    // SINGLE subscription path per event. Even with 50 components
+    // calling the hook, the bus sees exactly four `on()` calls total.
+    this.busUnsubs = [
+      this.bus.on('bootChanged', (e) => {
+        this.update((s) => {
+          s.version = e.bootNonce;
+          s.status = 'healthy';
+          s.lastUnreachableReason = null;
+          s.lastSeen = this.clock();
+        });
+      }),
+      this.bus.on('streamDead', (e) => {
+        this.update((s) => {
+          s.reconnectAttempt += 1;
+          s.lastStreamDeadSubId = e.subId;
+          // Don't downgrade from `unreachable` — that's a stronger
+          // signal until explicitly cleared by reconnected/bootChanged.
+          if (s.status !== 'unreachable') s.status = 'degraded';
+          s.lastSeen = this.clock();
+        });
+      }),
+      this.bus.on('reconnected', (e) => {
+        this.update((s) => {
+          s.version = e.bootNonce;
+          s.status = 'healthy';
+          s.lastUnreachableReason = null;
+          s.lastSeen = this.clock();
+        });
+      }),
+      this.bus.on('unreachable', (e) => {
+        this.update((s) => {
+          s.status = 'unreachable';
+          s.lastUnreachableReason = e.reason;
+          s.lastSeen = this.clock();
+        });
+      }),
+    ];
+  }
+
+  private detachBus(): void {
+    for (const u of this.busUnsubs) u();
+    this.busUnsubs = [];
+  }
+
+  private update(mutate: (s: MutableState) => void): void {
+    mutate(this.state);
+    this.snapshot = Object.freeze({
+      status: this.state.status,
+      lastSeen: this.state.lastSeen,
+      reconnectAttempt: this.state.reconnectAttempt,
+      version: this.state.version,
+      lastUnreachableReason: this.state.lastUnreachableReason,
+      lastStreamDeadSubId: this.state.lastStreamDeadSubId,
+    });
+    for (const l of Array.from(this.listeners)) {
+      try {
+        l();
+      } catch (err) {
+        // Mirrors `daemonEventBus.emit` defensiveness — never throw
+        // across React subscribers.
+        // eslint-disable-next-line no-console
+        console.error('[useDaemonHealthBridge] listener threw', err);
+      }
+    }
+  }
+}
+
+/** Production singleton, wired to the shared `daemonEventBus`. */
+export const defaultDaemonHealthStore = new DaemonHealthStore();
+
+/**
+ * React hook returning a stable, consolidated daemon-health snapshot.
+ *
+ * Usage:
+ *   const health = useDaemonHealthBridge();
+ *   if (health.status === 'unreachable') return <RedBanner ... />;
+ *
+ * Subscription model: regardless of how many components call this
+ * hook, the underlying `daemonEventBus` sees exactly one listener per
+ * event (four total). Lazy attach on first mount, detach when the last
+ * consumer unmounts — verified by `getBusSubscriptionCount()` in tests.
+ */
+export function useDaemonHealthBridge(
+  store: DaemonHealthStore = defaultDaemonHealthStore,
+): DaemonHealthSnapshot {
+  return useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot);
+}
+
+/**
+ * Test-only factory. Returns an isolated store wired to a caller-
+ * supplied bus + clock so unit tests can drive deterministic event
+ * sequences without touching the module-level singleton.
+ */
+export function __createDaemonHealthStoreForTest(
+  bus: DaemonEventBus,
+  clock: () => number = () => Date.now(),
+): DaemonHealthStore {
+  return new DaemonHealthStore(bus, clock);
+}

--- a/tests/app-effects/useDaemonHealthBridge.test.tsx
+++ b/tests/app-effects/useDaemonHealthBridge.test.tsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+  useDaemonHealthBridge,
+  __createDaemonHealthStoreForTest,
+  type DaemonHealthStore,
+} from '../../src/app-effects/useDaemonHealthBridge';
+import { DaemonEventBus } from '../../src/lib/daemon-events';
+
+describe('useDaemonHealthBridge', () => {
+  let bus: DaemonEventBus;
+  let store: DaemonHealthStore;
+  let now: number;
+
+  beforeEach(() => {
+    bus = new DaemonEventBus();
+    now = 1_000_000;
+    store = __createDaemonHealthStoreForTest(bus, () => now);
+  });
+
+  it('subscribes to bus exactly ONCE per event regardless of consumer count', () => {
+    // Render the hook from 5 independent consumers. Single bus
+    // subscription is the whole point of consolidation.
+    const r1 = renderHook(() => useDaemonHealthBridge(store));
+    const r2 = renderHook(() => useDaemonHealthBridge(store));
+    const r3 = renderHook(() => useDaemonHealthBridge(store));
+    const r4 = renderHook(() => useDaemonHealthBridge(store));
+    const r5 = renderHook(() => useDaemonHealthBridge(store));
+    // 4 = one listener per event (bootChanged/streamDead/reconnected/unreachable).
+    expect(store.getBusSubscriptionCount()).toBe(4);
+    r1.unmount();
+    r2.unmount();
+    r3.unmount();
+    r4.unmount();
+    expect(store.getBusSubscriptionCount()).toBe(4);
+    r5.unmount();
+    // Last consumer left → bus listeners detached.
+    expect(store.getBusSubscriptionCount()).toBe(0);
+  });
+
+  it('initial snapshot has unknown status and zeroed counters', () => {
+    const { result } = renderHook(() => useDaemonHealthBridge(store));
+    expect(result.current).toEqual({
+      status: 'unknown',
+      lastSeen: null,
+      reconnectAttempt: 0,
+      version: null,
+      lastUnreachableReason: null,
+      lastStreamDeadSubId: null,
+    });
+  });
+
+  it('exposes ALL fields on bootChanged: status=healthy, version, lastSeen', () => {
+    const { result } = renderHook(() => useDaemonHealthBridge(store));
+    act(() => {
+      now = 2_000_000;
+      bus.emit('bootChanged', { bootNonce: 'BOOT-A' });
+    });
+    expect(result.current.status).toBe('healthy');
+    expect(result.current.version).toBe('BOOT-A');
+    expect(result.current.lastSeen).toBe(2_000_000);
+    expect(result.current.reconnectAttempt).toBe(0);
+  });
+
+  it('streamDead bumps reconnectAttempt and downgrades status to degraded', () => {
+    const { result } = renderHook(() => useDaemonHealthBridge(store));
+    act(() => {
+      bus.emit('bootChanged', { bootNonce: 'BOOT-A' });
+    });
+    expect(result.current.status).toBe('healthy');
+    act(() => {
+      bus.emit('streamDead', { subId: 'sess-1', lastSeq: 10, reason: 'x' });
+    });
+    expect(result.current.status).toBe('degraded');
+    expect(result.current.reconnectAttempt).toBe(1);
+    expect(result.current.lastStreamDeadSubId).toBe('sess-1');
+    act(() => {
+      bus.emit('streamDead', { subId: 'sess-2', lastSeq: 5, reason: 'x' });
+    });
+    expect(result.current.reconnectAttempt).toBe(2);
+    expect(result.current.lastStreamDeadSubId).toBe('sess-2');
+  });
+
+  it('unreachable wins over degraded; reconnected restores to healthy', () => {
+    const { result } = renderHook(() => useDaemonHealthBridge(store));
+    act(() => {
+      bus.emit('streamDead', { subId: 's1', reason: 'x' });
+    });
+    expect(result.current.status).toBe('degraded');
+    act(() => {
+      bus.emit('unreachable', { reason: 'rpc gone' });
+    });
+    expect(result.current.status).toBe('unreachable');
+    expect(result.current.lastUnreachableReason).toBe('rpc gone');
+    // streamDead should NOT downgrade from unreachable.
+    act(() => {
+      bus.emit('streamDead', { subId: 's2', reason: 'x' });
+    });
+    expect(result.current.status).toBe('unreachable');
+    act(() => {
+      bus.emit('reconnected', { bootNonce: 'BOOT-B' });
+    });
+    expect(result.current.status).toBe('healthy');
+    expect(result.current.version).toBe('BOOT-B');
+    expect(result.current.lastUnreachableReason).toBeNull();
+  });
+
+  it('snapshot identity is stable when no event has fired since last read', () => {
+    const { result, rerender } = renderHook(() => useDaemonHealthBridge(store));
+    const first = result.current;
+    rerender();
+    rerender();
+    // No events → identical snapshot reference (required by
+    // useSyncExternalStore to avoid render loops).
+    expect(result.current).toBe(first);
+  });
+
+  it('all consumers see the same snapshot after one event', () => {
+    const r1 = renderHook(() => useDaemonHealthBridge(store));
+    const r2 = renderHook(() => useDaemonHealthBridge(store));
+    const r3 = renderHook(() => useDaemonHealthBridge(store));
+    act(() => {
+      bus.emit('bootChanged', { bootNonce: 'X' });
+    });
+    expect(r1.result.current.version).toBe('X');
+    expect(r2.result.current.version).toBe('X');
+    expect(r3.result.current.version).toBe('X');
+    // Identity is shared too — single source of truth.
+    expect(r1.result.current).toBe(r2.result.current);
+    expect(r2.result.current).toBe(r3.result.current);
+    r1.unmount();
+    r2.unmount();
+    r3.unmount();
+  });
+
+  it('cleans up on last unmount: no events delivered after teardown', () => {
+    const { result, unmount } = renderHook(() => useDaemonHealthBridge(store));
+    act(() => {
+      bus.emit('bootChanged', { bootNonce: 'A' });
+    });
+    expect(result.current.version).toBe('A');
+    unmount();
+    expect(store.getBusSubscriptionCount()).toBe(0);
+    // Emitting after teardown is a no-op for the store; nothing throws.
+    expect(() => bus.emit('bootChanged', { bootNonce: 'B' })).not.toThrow();
+  });
+
+  it('reverse-verify: returns initial snapshot when bus emits nothing', () => {
+    // Verifies the test's own discriminating power — without any bus
+    // emission, the snapshot fields stay at their initial values. If
+    // we accidentally inverted any default, this catches it.
+    const { result } = renderHook(() => useDaemonHealthBridge(store));
+    expect(result.current.status).toBe('unknown');
+    expect(result.current.lastSeen).toBeNull();
+    expect(result.current.reconnectAttempt).toBe(0);
+    expect(result.current.version).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Task #1060 — adds `useDaemonHealthBridge` (`src/app-effects/useDaemonHealthBridge.ts`), a consolidated React hook that surfaces daemon connectivity as a single typed snapshot. New read-side call sites should use this hook instead of subscribing to `daemonEventBus` per-consumer.

## Fragment inventory (before)

Searched `src/` and `electron/` for `useDaemon|daemonHealth|daemonStatus|daemonReconnect`:

| Module | Role | State / Slice | Subscribe path | Consumers (in-tree) |
|---|---|---|---|---|
| `src/lib/daemon-events.ts` (`DaemonEventBus`) | Typed pub/sub | 4 events: `bootChanged` / `streamDead` / `reconnected` / `unreachable` | n/a (it IS the bus) | `reconnect-queue.ts`, this PR |
| `src/lib/reconnect-queue.ts` (`ReconnectQueue`) | SINK | Active subs map + retry queue | `bus.on('bootChanged'\|'streamDead')` | preload bridge (not yet wired) |
| `src/app-effects/useDaemonReconnectBridge.ts` | PRODUCER | Last-seen `bootNonce` (useRef) | caller-supplied `subscribe(cb)` fn | none yet (T48 wiring pending) |

There was no consolidated **read-side** React hook. `electron/` had zero `useDaemon*` references.

## Design

The new hook lives at `src/app-effects/useDaemonHealthBridge.ts` (codebase convention is `src/app-effects/`, not `src/hooks/`, per the same Layer-1 reasoning that placed `useDaemonReconnectBridge` there). It owns a module-level `DaemonHealthStore` that subscribes ONCE to the typed `daemonEventBus` (4 listeners total — one per event), folds the four event streams into an immutable `DaemonHealthSnapshot { status, lastSeen, reconnectAttempt, version, lastUnreachableReason, lastStreamDeadSubId }`, and exposes it to React via `useSyncExternalStore`. Subscription is lazy (attached on first mount, detached on last unmount) so an idle renderer holds zero bus listeners. Status folding: `bootChanged`/`reconnected` → `healthy`, `streamDead` → `degraded` (unless already `unreachable`; always bumps `reconnectAttempt`), `unreachable` → sticky until `reconnected`/`bootChanged` clears it. A test-only `__createDaemonHealthStoreForTest(bus, clock)` factory lets unit tests drive deterministic event sequences against an isolated bus.

## Migration

| Fragment | Action | Reason |
|---|---|---|
| `daemonEventBus` (typed pub/sub) | Kept as-is | Underlying transport; the new hook is its first consolidated consumer. |
| `reconnect-queue.ts` | Kept as-is | Different role (SINK / actuator). 19 existing tests pass unchanged. |
| `useDaemonReconnectBridge` | Kept as-is | Different role (window CustomEvent re-emission from a `subscribe(cb)` source). No in-tree read-side consumer yet, so no migration is possible here without inventing one. 9 existing tests pass unchanged. |

**Migrated count: 0** (no existing read-side consumer to migrate; this is the first one).
**Deprecated count: 0** (no fragment is fully redundant; the existing ones serve distinct roles).

This matches the brief's "back-compat first — don't break existing call sites in this PR" constraint.

## Test plan

- [x] Unit (11 new tests in `tests/app-effects/useDaemonHealthBridge.test.tsx`):
  - Single bus subscription regardless of consumer count (5 consumers → 4 listeners; teardown → 0)
  - Initial snapshot fields (`unknown` / `null` / `0`)
  - All 4 event types update the right fields
  - Status precedence: `unreachable` is sticky over `degraded`; `reconnected` clears it
  - Snapshot identity stable across renders with no events
  - Shared snapshot across multiple consumers (single source of truth)
  - Clean teardown: post-unmount emissions are no-ops
- [x] Reverse-verify: temporarily disabled `attachBus()` subscriptions → 6/9 event-driven tests failed; restored → all pass
- [x] Existing fragment tests untouched: `useDaemonReconnectBridge` (9) + `reconnect-queue` (19) → green
- [x] `tsc --noEmit` clean

## Don'ts respected

- No fragment hooks deleted
- No IPC channel name changes
- No `connect/` or v0.4 code touched
- No render-tree changes (App.tsx untouched; new hook has zero in-tree call sites)