### PR TITLE
fix(v03 T48): wire fromBootNonce stamper into heartbeat envelope construction

### DIFF
--- a/daemon/src/pty/__tests__/heartbeat-envelope-owner.test.ts
+++ b/daemon/src/pty/__tests__/heartbeat-envelope-owner.test.ts
@@ -1,0 +1,200 @@
+// T48 wiring tests — heartbeat envelope owner.
+//
+// Asserts:
+//   1. Each scheduler tick produces one envelope per active subId
+//      shaped `{ kind: 'heartbeat', ts, bootNonce }`.
+//   2. The `bootNonce` field is the daemon-bound value (T48 stamper).
+//   3. The stamped nonce is IDENTICAL across all heartbeats from the
+//      same daemon process (one stamper, one nonce).
+//   4. A simulated daemon restart (fresh stamper with a fresh nonce)
+//      yields envelopes with the new nonce — proving the field is
+//      driven by the bound stamper, not a hard-coded literal.
+//   5. Reverse-verify negative: an owner built without the stamper
+//      wiring (a hand-rolled scheduler+push that omits stamp()) emits
+//      envelopes WITHOUT `bootNonce` — so the assertions actually
+//      catch a regression that drops the wiring.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createHeartbeatEnvelopeOwner,
+  type HeartbeatEnvelope,
+} from '../heartbeat-envelope-owner.js';
+import { createFromBootNonceStamper } from '../from-boot-nonce-stamper.js';
+import { createHeartbeatScheduler } from '../stream-heartbeat-scheduler.js';
+
+const NONCE_BOOT_A = '01HZZZBOOTNONCEAAAAAAAA';
+const NONCE_BOOT_B = '01HZZZBOOTNONCEBBBBBBBB';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('heartbeat-envelope-owner — construction guards', () => {
+  it('rejects missing push callback', () => {
+    expect(() =>
+      createHeartbeatEnvelopeOwner({
+        // @ts-expect-error — exercise runtime guard
+        push: undefined,
+        bootNonce: NONCE_BOOT_A,
+        intervalMs: 30_000,
+      }),
+    ).toThrow(TypeError);
+  });
+  it('rejects missing both bootNonce and stamper', () => {
+    expect(() =>
+      createHeartbeatEnvelopeOwner({
+        push: () => {},
+        intervalMs: 30_000,
+      }),
+    ).toThrow(/bootNonce or stamper is required/);
+  });
+  it('rejects passing both bootNonce and stamper', () => {
+    expect(() =>
+      createHeartbeatEnvelopeOwner({
+        push: () => {},
+        bootNonce: NONCE_BOOT_A,
+        stamper: createFromBootNonceStamper(NONCE_BOOT_B),
+        intervalMs: 30_000,
+      }),
+    ).toThrow(/either bootNonce or stamper, not both/);
+  });
+  it('rejects empty bootNonce (delegated to stamper)', () => {
+    expect(() =>
+      createHeartbeatEnvelopeOwner({
+        push: () => {},
+        bootNonce: '',
+        intervalMs: 30_000,
+      }),
+    ).toThrow(TypeError);
+  });
+});
+
+describe('heartbeat-envelope-owner — envelope shape + stamping', () => {
+  it('per tick: emits { kind: "heartbeat", ts, bootNonce } per active subId', () => {
+    const sent: Array<{ subId: string; env: HeartbeatEnvelope }> = [];
+    const owner = createHeartbeatEnvelopeOwner({
+      bootNonce: NONCE_BOOT_A,
+      intervalMs: 10_000,
+      push: (subId, env) => sent.push({ subId, env }),
+      // Force `ts` deterministic for the equality assertion below.
+      now: () => 1_700_000_001_234,
+    });
+    owner.start('sub-A');
+    owner.start('sub-B');
+    vi.advanceTimersByTime(10_000);
+
+    expect(sent).toHaveLength(2);
+    for (const { env } of sent) {
+      expect(env.kind).toBe('heartbeat');
+      expect(env.ts).toBe(1_700_000_001_234);
+      expect(env.bootNonce).toBe(NONCE_BOOT_A);
+    }
+    expect(sent.map((e) => e.subId).sort()).toEqual(['sub-A', 'sub-B']);
+    owner.stop('sub-A');
+    owner.stop('sub-B');
+  });
+
+  it('bootNonce is identical across heartbeats from same daemon process', () => {
+    const sent: HeartbeatEnvelope[] = [];
+    const owner = createHeartbeatEnvelopeOwner({
+      bootNonce: NONCE_BOOT_A,
+      intervalMs: 10_000,
+      push: (_subId, env) => sent.push(env),
+    });
+    owner.start('sub-1');
+    for (let i = 0; i < 5; i++) {
+      vi.advanceTimersByTime(10_000);
+    }
+    expect(sent).toHaveLength(5);
+    expect(sent.every((e) => e.bootNonce === NONCE_BOOT_A)).toBe(true);
+    expect(sent.some((e) => e.bootNonce === NONCE_BOOT_B)).toBe(false);
+    owner.stop('sub-1');
+  });
+
+  it('different bound nonces (simulated restart) yield different stamped values', () => {
+    const sentA: HeartbeatEnvelope[] = [];
+    const sentB: HeartbeatEnvelope[] = [];
+
+    const ownerA = createHeartbeatEnvelopeOwner({
+      bootNonce: NONCE_BOOT_A,
+      intervalMs: 10_000,
+      push: (_s, env) => sentA.push(env),
+    });
+    ownerA.start('sub-x');
+    vi.advanceTimersByTime(10_000);
+    ownerA.stop('sub-x');
+
+    const ownerB = createHeartbeatEnvelopeOwner({
+      bootNonce: NONCE_BOOT_B,
+      intervalMs: 10_000,
+      push: (_s, env) => sentB.push(env),
+    });
+    ownerB.start('sub-x');
+    vi.advanceTimersByTime(10_000);
+    ownerB.stop('sub-x');
+
+    expect(sentA).toHaveLength(1);
+    expect(sentB).toHaveLength(1);
+    expect(sentA[0]!.bootNonce).toBe(NONCE_BOOT_A);
+    expect(sentB[0]!.bootNonce).toBe(NONCE_BOOT_B);
+    expect(sentA[0]!.bootNonce).not.toBe(sentB[0]!.bootNonce);
+  });
+
+  it('accepts a pre-built stamper (single source of truth pattern)', () => {
+    const sent: HeartbeatEnvelope[] = [];
+    const sharedStamper = createFromBootNonceStamper(NONCE_BOOT_A);
+    const owner = createHeartbeatEnvelopeOwner({
+      stamper: sharedStamper,
+      intervalMs: 10_000,
+      push: (_s, env) => sent.push(env),
+    });
+    owner.start('sub-1');
+    vi.advanceTimersByTime(10_000);
+    owner.stop('sub-1');
+    expect(sent[0]!.bootNonce).toBe(NONCE_BOOT_A);
+    expect(sharedStamper.getBootNonce()).toBe(NONCE_BOOT_A);
+  });
+
+  it('updateInterval proxies to the underlying scheduler; bootNonce stays stamped', () => {
+    const sent: HeartbeatEnvelope[] = [];
+    const owner = createHeartbeatEnvelopeOwner({
+      bootNonce: NONCE_BOOT_A,
+      intervalMs: 30_000,
+      push: (_s, env) => sent.push(env),
+    });
+    owner.start('sub-1');
+    vi.advanceTimersByTime(30_000);
+    expect(sent).toHaveLength(1);
+    owner.updateInterval(5_000);
+    vi.advanceTimersByTime(5_000);
+    expect(sent).toHaveLength(2);
+    expect(sent.every((e) => e.bootNonce === NONCE_BOOT_A)).toBe(true);
+    owner.stop('sub-1');
+  });
+});
+
+// Reverse-verify: a hand-rolled wiring that BYPASSES the stamper produces
+// envelopes WITHOUT `bootNonce`. This proves the positive assertions
+// above actually depend on the stamper wiring.
+describe('heartbeat-envelope-owner — reverse-verify (skip-stamper bypass)', () => {
+  it('omitting stamper from sendHeartbeat produces envelopes WITHOUT bootNonce', () => {
+    const sent: Array<Record<string, unknown>> = [];
+    const sch = createHeartbeatScheduler({
+      intervalMs: 10_000,
+      sendHeartbeat: (subId) => {
+        const envelopeWithoutStamp = { kind: 'heartbeat', ts: 0 };
+        sent.push({ subId, ...envelopeWithoutStamp });
+      },
+    });
+    sch.start('sub-1');
+    vi.advanceTimersByTime(10_000);
+    expect(sent).toHaveLength(1);
+    expect('bootNonce' in sent[0]!).toBe(false);
+    sch.stop('sub-1');
+  });
+});

--- a/daemon/src/pty/heartbeat-envelope-owner.ts
+++ b/daemon/src/pty/heartbeat-envelope-owner.ts
@@ -1,0 +1,205 @@
+// T48 wiring — heartbeat envelope owner.
+//
+// Composes the T42 stream-heartbeat scheduler with the T48 fromBootNonce
+// stamper helper so heartbeat envelopes correctly carry the daemon's
+// per-boot nonce on every tick.
+//
+// Spec citations:
+//   - docs/superpowers/specs/v0.3-fragments/frag-3.5.1-pty-hardening.md
+//     §3.5.1.4 (line 101): "Daemon emits a `{ kind: 'heartbeat', ts,
+//     traceId, bootNonce }` envelope on every server-stream every
+//     `heartbeatMs`."
+//   - docs/superpowers/specs/v0.3-fragments/frag-6-7-reliability-security.md
+//     §6.5: `bootNonce` is the same camelCase ULID surfaced on
+//     `/healthz`, in `daemon.hello`, and on every PTY-stream heartbeat
+//     / chunk-frame envelope. Single source of truth =
+//     `daemon/src/index.ts` mints it via `ulid()` at module load.
+//
+// Single Responsibility (per `feedback_single_responsibility`):
+//   - PRODUCER role: the owner BUILDS the heartbeat envelope on every
+//     tick (per-subId). The envelope is the only thing this module
+//     constructs. The stamper attaches `bootNonce`; the owner attaches
+//     `kind: 'heartbeat'` + `ts`.
+//   - DECIDER role: NONE. The scheduler owns timing; the stamper owns
+//     the nonce; this module is pure composition.
+//   - SINK role: NONE. The owner does not write sockets — the wiring
+//     layer (data-socket transport / fanout broadcast) supplies the
+//     per-subId `push(envelope)` callback.
+//
+// Why this module exists (and is separate from the scheduler):
+//   - The scheduler is intentionally envelope-shape-agnostic
+//     (frag-3.5.1 §3.5.1.4 reservation: `sendHeartbeat` is INJECTED).
+//   - The stamper is a pure helper bound to one nonce.
+//   - Wiring the two together is the only place that knows BOTH (a) the
+//     daemon-bound nonce and (b) the heartbeat envelope contract.
+//   - Per `feedback_single_responsibility` we keep that knowledge in
+//     one named seam instead of inlining it at the daemon shell —
+//     so tests can assert "envelope shape × stamping × tick cadence"
+//     in isolation, without spinning a real dispatcher / transport.
+
+import {
+  createFromBootNonceStamper,
+  type BootNonce,
+  type FromBootNonceStamper,
+} from './from-boot-nonce-stamper.js';
+import {
+  createHeartbeatScheduler,
+  type HeartbeatScheduler,
+  type HeartbeatSchedulerOptions,
+  type SubscriberId,
+} from './stream-heartbeat-scheduler.js';
+
+/**
+ * The heartbeat envelope shape produced by the owner. Mirrors the
+ * frag-3.5.1 §3.5.1.4 line 101 wire contract:
+ *
+ *   { kind: 'heartbeat', ts, bootNonce }
+ *
+ * `traceId` from the spec line 101 quote is per-subscriber context that
+ * the wiring layer (data-socket transport) attaches at envelope-write
+ * time — heartbeats are not RPC requests with their own traceId; they
+ * piggyback the subscribe call's traceId. Keeping it OUT of the owner
+ * mirrors the scheduler's "no envelope encoding" non-goal.
+ *
+ * The `bootNonce` field is REQUIRED on the output (project convention:
+ * required > optional for wire fields the consumer must trust).
+ */
+export interface HeartbeatEnvelope {
+  readonly kind: 'heartbeat';
+  readonly ts: number;
+  readonly bootNonce: BootNonce;
+}
+
+/**
+ * Per-subId push callback supplied by the wiring layer (data-socket
+ * transport / fanout broadcast). Invoked once per scheduled tick with
+ * the freshly-stamped heartbeat envelope. Fire-and-forget — the owner
+ * does NOT inspect the return value (heartbeats are best-effort; the
+ * symmetric T44 stream-dead-detector handles missed liveness).
+ */
+export type PushHeartbeat = (subId: SubscriberId, envelope: HeartbeatEnvelope) => void;
+
+/**
+ * Construction options for the heartbeat envelope owner. Mirrors the
+ * scheduler's options minus `sendHeartbeat` (the owner provides its
+ * own `sendHeartbeat` to the underlying scheduler) plus the stamper
+ * inputs (either a bootNonce string OR a pre-built stamper instance,
+ * to support the daemon shell's "single source of truth" pattern
+ * where one stamper is shared with other PTY producers).
+ */
+export interface HeartbeatEnvelopeOwnerOptions
+  extends Omit<HeartbeatSchedulerOptions, 'sendHeartbeat'> {
+  /**
+   * Per-subId push callback. The wiring layer adapts this to its
+   * transport (e.g. `(subId, env) => fanoutRegistry.broadcast(subId, env)`
+   * or `(subId, env) => streamMap.get(subId)?.push(env)`).
+   */
+  readonly push: PushHeartbeat;
+
+  /**
+   * Daemon-bound boot nonce. Mutually exclusive with `stamper`. When
+   * supplied, the owner builds its own stamper internally via
+   * `createFromBootNonceStamper(bootNonce)`. Use this in the daemon
+   * shell when the owner is the sole consumer of the stamper.
+   */
+  readonly bootNonce?: BootNonce;
+
+  /**
+   * Pre-built stamper instance. Mutually exclusive with `bootNonce`.
+   * Use this when the daemon shell already constructed a stamper for
+   * other PTY producers (chunk fan-out, snapshot RPC) — sharing the
+   * same instance guarantees one nonce across all PTY emissions.
+   */
+  readonly stamper?: FromBootNonceStamper;
+}
+
+/**
+ * Public surface — start / stop heartbeats per subId, plus
+ * `updateInterval` proxied through to the underlying scheduler. Tests
+ * also get `running()` / `ticks()` via the same proxy so the existing
+ * scheduler test conventions carry over.
+ */
+export interface HeartbeatEnvelopeOwner {
+  start(subId: SubscriberId): void;
+  stop(subId: SubscriberId): void;
+  updateInterval(newMs: number): void;
+  running(): number;
+  ticks(): number;
+}
+
+/**
+ * Construct the owner. The daemon shell instantiates ONCE per daemon
+ * process at PTY stream wiring init time:
+ *
+ *   import { bootNonce } from './index.js';
+ *   const owner = createHeartbeatEnvelopeOwner({
+ *     bootNonce,
+ *     intervalMs: negotiatedHeartbeatMs,
+ *     push: (subId, env) => transport.pushToSub(subId, env),
+ *   });
+ *   transport.onSubscribe((subId) => owner.start(subId));
+ *   transport.onUnsubscribe((subId) => owner.stop(subId));
+ */
+export function createHeartbeatEnvelopeOwner(
+  opts: HeartbeatEnvelopeOwnerOptions,
+): HeartbeatEnvelopeOwner {
+  if (typeof opts.push !== 'function') {
+    throw new TypeError(
+      'heartbeat-envelope-owner: push callback is required',
+    );
+  }
+  if (opts.bootNonce !== undefined && opts.stamper !== undefined) {
+    throw new TypeError(
+      'heartbeat-envelope-owner: pass either bootNonce or stamper, not both',
+    );
+  }
+  if (opts.bootNonce === undefined && opts.stamper === undefined) {
+    throw new TypeError(
+      'heartbeat-envelope-owner: bootNonce or stamper is required',
+    );
+  }
+
+  // Resolve the stamper. Either branch yields a FromBootNonceStamper
+  // bound to ONE per-boot value — never null, never re-bound.
+  const stamper: FromBootNonceStamper =
+    opts.stamper ?? createFromBootNonceStamper(opts.bootNonce as BootNonce);
+
+  // Clock injection mirrors the scheduler's symmetry. We use it for the
+  // envelope `ts` field — NOT for tick scheduling (the scheduler's
+  // timer hooks own that). Defaults to `Date.now`.
+  const now = opts.now ?? Date.now;
+  const push = opts.push;
+
+  // The `sendHeartbeat` callback we hand to the scheduler is the actual
+  // wiring point: on every tick, build the envelope, stamp the nonce,
+  // and forward to the transport-supplied push.
+  function sendHeartbeat(subId: SubscriberId): void {
+    // Build the base envelope WITHOUT the nonce so the stamper has a
+    // single chosen seam to attach it. Order matters: the stamper's
+    // `stamp()` spreads the daemon-bound value LAST, so even if a
+    // future refactor accidentally pre-fills `bootNonce`, the daemon
+    // value wins (matches `boot-nonce-precedence.ts` posture).
+    const base = { kind: 'heartbeat' as const, ts: now() };
+    const envelope: HeartbeatEnvelope = stamper.stamp(base);
+    push(subId, envelope);
+  }
+
+  // Hand the composed sendHeartbeat to the underlying scheduler. The
+  // scheduler swallows throws on the per-tick path, so a bad transport
+  // for one subId cannot starve the others — same posture as the
+  // scheduler's hard non-goal note.
+  const scheduler: HeartbeatScheduler = createHeartbeatScheduler({
+    intervalMs: opts.intervalMs,
+    now: opts.now,
+    timers: opts.timers,
+    sendHeartbeat,
+  });
+
+  return {
+    start: (subId) => scheduler.start(subId),
+    stop: (subId) => scheduler.stop(subId),
+    updateInterval: (newMs) => scheduler.updateInterval(newMs),
+    running: () => scheduler.running(),
+    ticks: () => scheduler.ticks(),
+  };
+}


### PR DESCRIPTION
## Summary

Compose the T42 stream-heartbeat scheduler (PR #1003) with the T48 fromBootNonce stamper helper (PR #695) so heartbeat envelopes correctly carry the daemon's per-boot nonce.

The two modules shipped independently — the scheduler is intentionally envelope-shape-agnostic (its ``sendHeartbeat`` is INJECTED) and the stamper is a pure helper bound to one nonce. The wiring layer that knows BOTH the daemon-bound nonce and the heartbeat envelope contract was missing. This PR adds that seam.

Closes Task #1054.

## Changes

- **New: ``daemon/src/pty/heartbeat-envelope-owner.ts``** — composes scheduler + stamper.
  - Accepts either a ``bootNonce`` string or a pre-built stamper (single-source-of-truth pattern when daemon shell shares one stamper across PTY producers — chunk fan-out, snapshot RPC, heartbeats).
  - Builds ``{ kind: 'heartbeat', ts }`` per scheduler tick, runs it through ``stamper.stamp()`` so ``{ ..., bootNonce }`` lands on the wire (matches frag-3.5.1 §3.5.1.4 line 101 contract).
  - Proxies ``start`` / ``stop`` / ``updateInterval`` / ``running`` / ``ticks`` to the underlying scheduler.
- **New: ``daemon/src/pty/__tests__/heartbeat-envelope-owner.test.ts``** — 10 cases.

## Wiring point

``daemon/src/pty/heartbeat-envelope-owner.ts:172`` — the ``sendHeartbeat`` closure handed to ``createHeartbeatScheduler``:

```ts
function sendHeartbeat(subId: SubscriberId): void {
  const base = { kind: 'heartbeat' as const, ts: now() };
  const envelope: HeartbeatEnvelope = stamper.stamp(base);
  push(subId, envelope);
}
```

## Test plan

- [x] ``npx vitest run heartbeat-envelope-owner`` — 10/10 passed.
- [x] ``npx vitest run daemon/src/pty`` — 189 passed / 14 skipped (no regressions).
- [x] Daemon typecheck clean (``tsc --noEmit -p daemon/tsconfig.json``).
- [x] ESLint clean on new files.
- [x] **Reverse-verify**: temporarily replaced ``stamper.stamp(base)`` with ``base as unknown as HeartbeatEnvelope`` (skip stamper) → 5 positive ``bootNonce`` assertions failed (per-tick shape, identical-across-heartbeats, simulated-restart, shared-stamper, updateInterval). Restored — back to 10/10 green. Confirms the stamper call is load-bearing.

## Non-goals (per task spec)

- No changes to the stamper helper API.
- No changes to the scheduler API.
- No changes to ``PtySubscribeFrame`` type or the envelope wire format.
- No touches to v0.4 ``connect/`` code.
- No ``make:*`` or e2e (per task instructions).