### PR TITLE
fix(v03): wire controlSocket.listen() into daemon boot path

### DIFF
--- a/daemon/src/index.ts
+++ b/daemon/src/index.ts
@@ -14,6 +14,15 @@ import { createForceKillSink, type ForceKillJobHandle } from './lifecycle/force-
 import { installCrashHandlers } from './crash/handlers.js';
 import { installNativeCrashHandlers } from './crash/native-handlers.js';
 import { initDaemonSentry } from './sentry/init.js';
+import { resolveRuntimeRoot } from './sockets/runtime-root.js';
+import {
+  createControlSocketServer,
+  type ControlSocketServer,
+} from './sockets/control-socket.js';
+import {
+  createDataSocketServer,
+  type DataSocketServer,
+} from './sockets/data-socket.js';
 
 const require = createRequire(import.meta.url);
 const DAEMON_VERSION = (require('../../package.json') as { version: string }).version;
@@ -106,6 +115,45 @@ const forceKillSink = createForceKillSink({
 // are still landing; for now we wire log-only sinks that observe the spec
 // ordering. As each subsystem lands its driver, swap the corresponding action
 // here for the real I/O — the handler stays pure.
+//
+// Forward-declared so the shutdown actions can close them on the way out;
+// assigned just below where listen() is called. Kept as `let | undefined`
+// so a bind failure (e.g. a stale lockfile-less crash + manual sock leftover)
+// still lets the shutdown sequence run.
+let controlSocket: ControlSocketServer | undefined;
+let dataSocket: DataSocketServer | undefined;
+
+async function closeTransports(): Promise<void> {
+  // Close both transports in parallel — they are independent listeners
+  // (separate inodes / pipe names). Best-effort: log any error so the
+  // supervisor's incident-dir captures it but never throw out of the
+  // shutdown path.
+  await Promise.allSettled([
+    (async () => {
+      if (!controlSocket) return;
+      try {
+        await controlSocket.close();
+      } catch (err) {
+        logger.warn(
+          { event: 'daemon-shutdown.control-socket-close-failed', err: String(err) },
+          'control-socket close failed during shutdown',
+        );
+      }
+    })(),
+    (async () => {
+      if (!dataSocket) return;
+      try {
+        await dataSocket.close();
+      } catch (err) {
+        logger.warn(
+          { event: 'daemon-shutdown.data-socket-close-failed', err: String(err) },
+          'data-socket close failed during shutdown',
+        );
+      }
+    })(),
+  ]);
+}
+
 const shutdownActions: ShutdownActions = {
   markDraining: () => {
     logger.info({ event: 'daemon-shutdown', step: 'mark-draining' }, 'state=draining');
@@ -131,7 +179,11 @@ const shutdownActions: ShutdownActions = {
     if (typeof logger.flush === 'function') logger.flush();
   },
   exitProcess: (code) => {
-    process.exit(code);
+    // Close OS-level socket listeners before exiting so the next boot does
+    // not collide on a stale POSIX socket node / leftover Windows pipe
+    // handle. Best-effort + bounded — `closeTransports` swallows + logs all
+    // errors and `Promise.allSettled` cannot reject.
+    void closeTransports().finally(() => process.exit(code));
   },
   recordStepError: (step: ShutdownStep, err: unknown) => {
     logger.error({ event: 'daemon-shutdown.step-failed', step, err: String(err) }, 'shutdown step failed');
@@ -161,6 +213,133 @@ supervisorDispatcher.register(DAEMON_SHUTDOWN_METHOD, async (req, ctx) => {
   });
 });
 void supervisorDispatcher;
+
+// Task #1072 — wire OS-level socket listeners.
+//
+// Before this PR, both `createControlSocketServer` (T14 #676) and
+// `createDataSocketServer` (T15 #673) factories existed but no production
+// boot path ever called `.listen()`. The control plane was dead code in
+// production: every probe (PR #737 T73 daemon-boot+hello, PR #738 T74
+// upgrade-in-place) had to degrade to in-process handler invocation and
+// document "real socket round-trip out of scope until controlSocket.listen()
+// is wired" in its PR body.
+//
+// Scope of this wire-up (deliberately minimal, atomic):
+//   1. Resolve the canonical socket runtimeRoot via the T13 resolver
+//      (`<dataRoot>/run` on Windows / macOS, `XDG_RUNTIME_DIR/ccsm` on Linux).
+//      This is INTENTIONALLY a separate path from the crash-handler
+//      `runtimeRoot` above (which uses `~/.ccsm/runtime` for legacy reasons);
+//      a follow-up can unify, but that is OUT OF SCOPE here — we are only
+//      wiring listeners, not reorganising the on-disk layout.
+//   2. Bind the control socket FIRST so a `/healthz` probe sees a listener
+//      the moment "daemon shell booted" hits stdout. The data socket binds
+//      next; per spec the two are independent listeners and either one
+//      becoming available unblocks a different class of consumer.
+//   3. The connection-handler is a logged-destroy placeholder: the envelope
+//      adapter that would route Duplex bytes → `decodeFrame` → dispatcher is
+//      a separate piece of work (T-future / next slice). Today the listener
+//      being BOUND is enough to (a) flip the double-bind guard outcome from
+//      "absent" to "alive", and (b) let probes do `net.connect` to verify
+//      the OS endpoint exists. Routing real RPCs over the wire lands when
+//      the envelope adapter does.
+//
+// What this resolves (per task brief):
+//   - PR #737 (T73, task #1030) "real socket round-trip out of scope" note —
+//     swap their in-process handler call for `net.connect` once this lands.
+//   - PR #738 (T74, task #1031) same in-process degradation note.
+//
+// What this does NOT do (deliberately, per task Don'ts):
+//   - Does not change socket path resolution (T13 surface is untouched).
+//   - Does not change the /healthz handler (T17 territory).
+//   - Does not register new RPCs.
+//   - Does not touch v0.4 `connect/` Connect-RPC scaffold.
+const socketRuntimeRoot = resolveRuntimeRoot();
+
+// Test isolation hooks. Allow overriding the bound socket path via env so
+// integration tests can inject a unique address per run (Windows named-pipe
+// names are user-scoped and otherwise collide across consecutive boots
+// in fast test loops). Production leaves both unset and the factories
+// derive the canonical paths.
+const controlSocketPathOverride = process.env.CCSM_CONTROL_SOCKET_PATH;
+const dataSocketPathOverride = process.env.CCSM_DATA_SOCKET_PATH;
+
+controlSocket = createControlSocketServer({
+  runtimeRoot: socketRuntimeRoot,
+  ...(controlSocketPathOverride ? { socketPath: controlSocketPathOverride } : {}),
+  logger: {
+    warn: (obj, msg) => logger.warn(obj, msg),
+    info: (obj, msg) => logger.info(obj, msg),
+  },
+  onConnection: (sock) => {
+    // Envelope adapter wiring is T-future. Until then, every accepted
+    // connection is destroyed loudly so a probe sees "connect succeeded
+    // then peer hung up" rather than a wedge. The transport-level rate
+    // cap (50/s) still fires on a flood; this destroy is per-connection
+    // application-layer cleanup.
+    logger.warn(
+      { event: 'control-socket.connection.no-adapter', address: controlSocket?.address },
+      'control-socket connection accepted but no envelope adapter is wired yet (T-future); destroying',
+    );
+    try {
+      sock.destroy();
+    } catch {
+      // best-effort
+    }
+  },
+});
+
+dataSocket = createDataSocketServer({
+  runtimeRoot: socketRuntimeRoot,
+  ...(dataSocketPathOverride ? { socketPath: dataSocketPathOverride } : {}),
+  logger: {
+    warn: (obj, msg) => logger.warn(obj, msg),
+  },
+  onConnection: ({ socket }) => {
+    logger.warn(
+      { event: 'data-socket.connection.no-adapter', address: dataSocket?.address() },
+      'data-socket connection accepted but no envelope adapter is wired yet (T-future); destroying',
+    );
+    try {
+      socket.destroy();
+    } catch {
+      // best-effort
+    }
+  },
+});
+
+try {
+  await controlSocket.listen();
+  logger.info(
+    { event: 'daemon.boot.control-socket-listening', address: controlSocket.address },
+    'control-socket bound',
+  );
+} catch (err) {
+  logger.error(
+    { event: 'daemon.boot.control-socket-bind-failed', err: String(err) },
+    'control-socket bind failed — supervisor /healthz probe will see EAGAIN/ENOENT',
+  );
+  // Do NOT swallow: a bind failure on the supervisor transport means the
+  // daemon is not reachable for shutdown / health probes. Re-throw so the
+  // crash handler routes it as an uncaught and the supervisor restarts us
+  // with a clean slate.
+  throw err;
+}
+
+try {
+  await dataSocket.listen();
+  logger.info(
+    { event: 'daemon.boot.data-socket-listening', address: dataSocket.address() },
+    'data-socket bound',
+  );
+} catch (err) {
+  logger.error(
+    { event: 'daemon.boot.data-socket-bind-failed', err: String(err) },
+    'data-socket bind failed — renderer RPCs will not connect',
+  );
+  // Same posture as the control-socket: refuse to boot in a half-bound
+  // state. The supervisor's restart loop is the right recovery surface.
+  throw err;
+}
 
 logger.info({ event: 'daemon.boot' }, 'daemon shell booted');
 

--- a/daemon/src/sockets/data-socket.ts
+++ b/daemon/src/sockets/data-socket.ts
@@ -75,6 +75,15 @@ export interface CreateDataSocketServerOptions {
 
   /** Override for tests — defaults to {@link MAX_ACCEPT_PER_SEC}. */
   readonly maxAcceptPerSec?: number;
+
+  /** Override the auto-derived socket path. When provided, we trust the
+   *  caller (test harness, alternative deployment) and skip both the
+   *  POSIX `<runtimeRoot>/ccsm-data.sock` derivation and the Windows
+   *  `\\.\pipe\ccsm-data-<userhash>` derivation. Mirrors the
+   *  `socketPath` override on `createControlSocketServer` (T14) so tests
+   *  can inject a unique address per run and avoid named-pipe namespace
+   *  collisions on consecutive boots. */
+  readonly socketPath?: string;
 }
 
 export interface DataSocketServer {
@@ -120,7 +129,7 @@ export function createDataSocketServer(
 ): DataSocketServer {
   const platform = process.platform;
   const isWindows = platform === 'win32';
-  const path = dataSocketPath(opts.runtimeRoot, platform);
+  const path = opts.socketPath ?? dataSocketPath(opts.runtimeRoot, platform);
   const now = opts.now ?? Date.now;
   const maxAccept = opts.maxAcceptPerSec ?? MAX_ACCEPT_PER_SEC;
   const logger = opts.logger ?? {

--- a/tests/harness-daemon-mode.test.ts
+++ b/tests/harness-daemon-mode.test.ts
@@ -23,6 +23,7 @@ import { tmpdir } from 'node:os';
 import { join, resolve as resolvePath } from 'node:path';
 import { Buffer } from 'node:buffer';
 import { createHmac, randomBytes } from 'node:crypto';
+import { createConnection } from 'node:net';
 
 // T73 — daemon-boot+hello e2e probe imports. The probe spawns the real
 // `daemon/src/index.ts` to assert the boot supervisor signal (ready
@@ -478,9 +479,26 @@ describe('T73 — daemon-boot + hello probe (e2e harness fold)', () => {
     // stdout/stderr. A real spawn (NOT the fake-daemon.cjs smoke) is what
     // makes this an e2e probe — any regression in `daemon/src/index.ts`
     // (e.g. an import crash before pino logs the boot line) surfaces here.
+    // Phase 0: per-test unique socket env. The daemon now binds the control
+    // + data sockets at boot (Task #1072 wiring of `controlSocket.listen()`),
+    // so a parallel CCSM install on the dev box would otherwise win the
+    // canonical pipe and crash this child with EADDRINUSE. Test-only env
+    // overrides give us a fresh address per run.
+    const t73Uniq = `t73-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const t73CtrlPath = process.platform === 'win32'
+      ? `\\\\.\\pipe\\ccsm-control-test-${t73Uniq}`
+      : join(tmpdir(), `ccsm-control-${t73Uniq}.sock`);
+    const t73DataPath = process.platform === 'win32'
+      ? `\\\\.\\pipe\\ccsm-data-test-${t73Uniq}`
+      : join(tmpdir(), `ccsm-data-${t73Uniq}.sock`);
+
     const handle = bootDaemon({
       entry: DAEMON_ENTRY,
       bootTimeoutMs: 15_000,
+      env: {
+        CCSM_CONTROL_SOCKET_PATH: t73CtrlPath,
+        CCSM_DATA_SOCKET_PATH: t73DataPath,
+      },
     });
 
     try {
@@ -1557,4 +1575,211 @@ describe('T84 — modal coexistence probe (e2e harness fold)', () => {
     });
     expect(healthAfterApex).toEqual({ allowed: true });
   });
+});
+
+// ---------------------------------------------------------------------------
+// Task #1072 — controlSocket.listen() wire smoke
+//
+// Asserted invariants:
+//   1. The real daemon (`tsx daemon/src/index.ts`) emits BOTH the
+//      `daemon.boot.control-socket-listening` AND
+//      `daemon.boot.data-socket-listening` JSON-log events before the
+//      canonical "daemon shell booted" ready marker.
+//   2. The control-socket address logged is reachable: a `net.connect()` to
+//      the address resolves with a `connect` event (no ECONNREFUSED / ENOENT).
+//      The placeholder onConnection destroys the socket immediately — that's
+//      fine; the smoke is "did the OS listener bind", not "did an envelope
+//      adapter route /healthz". The latter is T-future.
+//   3. Same for the data-socket address.
+//
+// Why this can't yet round-trip /healthz:
+//   The envelope adapter that would frame Duplex bytes → `decodeFrame` →
+//   dispatcher is a separate slice (T-future). This PR's contract is
+//   listener-bound; routing lands separately.
+//
+// Reverse-verify: see PR body — temporarily commenting out the
+//   `await controlSocket.listen()` call makes invariant 2 fail with
+//   ECONNREFUSED (POSIX) / ENOENT (Windows pipe).
+// ---------------------------------------------------------------------------
+describe('Task #1072 — controlSocket.listen() wire smoke', () => {
+  const isWin = process.platform === 'win32';
+
+  it('binds both control + data sockets and logs `bound` before the ready marker', async () => {
+    const tmpRuntime = mkdtempSync(join(tmpdir(), 't1072-runtime-'));
+    tempDirs.push(tmpRuntime);
+
+    // Force the daemon's `resolveRuntimeRoot()` onto a deterministic, isolated
+    // path so a parallel daemon process on the dev box can't collide. The
+    // resolver reads:
+    //   - linux  : XDG_RUNTIME_DIR (preferred) → <runtimeRoot> = <env>/ccsm
+    //   - macOS  : <dataRoot>/run where dataRoot uses HOME-derived path
+    //   - win32  : <LOCALAPPDATA>/ccsm/run
+    // The simplest cross-platform isolation: point both XDG_RUNTIME_DIR and
+    // LOCALAPPDATA at our tmpRuntime; the unused one is a no-op. We pre-mkdir
+    // the LOCALAPPDATA `ccsm/run` subdir so the `mkdirpPrivate` inside the
+    // resolver finds it cheaply.
+    //
+    // Additionally, force unique socket paths via the test-only env overrides
+    // (`CCSM_CONTROL_SOCKET_PATH` / `CCSM_DATA_SOCKET_PATH`). Windows named
+    // pipes live in a single global namespace per user, so consecutive test
+    // runs without unique names would collide on EADDRINUSE before the OS
+    // recycles the prior pipe handle. POSIX uses paths under tmpRuntime so
+    // the same env overrides resolve to a per-run unique inode.
+    const uniq = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const ctrlPath = isWin
+      ? `\\\\.\\pipe\\ccsm-control-test-${uniq}`
+      : join(tmpRuntime, `ccsm-control-${uniq}.sock`);
+    const dataPath = isWin
+      ? `\\\\.\\pipe\\ccsm-data-test-${uniq}`
+      : join(tmpRuntime, `ccsm-data-${uniq}.sock`);
+
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      XDG_RUNTIME_DIR: tmpRuntime,
+      LOCALAPPDATA: tmpRuntime,
+      // Keep the crash-handler runtime root inside our scratch as well so a
+      // crash mid-test doesn't pollute the user's real ~/.ccsm.
+      CCSM_RUNTIME_ROOT: join(tmpRuntime, 'ccsm-crash'),
+      CCSM_CONTROL_SOCKET_PATH: ctrlPath,
+      CCSM_DATA_SOCKET_PATH: dataPath,
+    };
+
+    const stdoutLines: string[] = [];
+    const stderrLines: string[] = [];
+    let controlAddress: string | undefined;
+    let dataAddress: string | undefined;
+    let bootedAt = -1;
+
+    const child = spawn(
+      process.execPath,
+      // tsx is a dev dep of the repo; use the local .bin shim so the
+      // spawn does not depend on a global install.
+      [resolvePath(__dirname, '..', 'node_modules', 'tsx', 'dist', 'cli.mjs'), DAEMON_ENTRY],
+      {
+        cwd: resolvePath(__dirname, '..'),
+        env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
+
+    const ready = new Promise<void>((resolve, reject) => {
+      const onLine = (chunk: string): void => {
+        const lines = chunk.split(/\r?\n/);
+        for (const line of lines) {
+          if (!line) continue;
+          // Pino emits one JSON object per line on stdout; parse defensively
+          // (some lines may be tsx warnings, ignore those).
+          let parsed: Record<string, unknown> | undefined;
+          try {
+            parsed = JSON.parse(line) as Record<string, unknown>;
+          } catch {
+            // non-JSON (tsx loader noise, etc.); skip
+          }
+          if (parsed && typeof parsed.event === 'string') {
+            if (parsed.event === 'daemon.boot.control-socket-listening') {
+              controlAddress = String(parsed.address);
+            } else if (parsed.event === 'daemon.boot.data-socket-listening') {
+              dataAddress = String(parsed.address);
+            } else if (parsed.event === 'daemon.boot') {
+              bootedAt = stdoutLines.length;
+              resolve();
+            }
+          }
+        }
+      };
+      child.stdout!.setEncoding('utf8');
+      child.stdout!.on('data', (s: string) => {
+        stdoutLines.push(s);
+        onLine(s);
+      });
+      child.stderr!.setEncoding('utf8');
+      child.stderr!.on('data', (s: string) => {
+        stderrLines.push(s);
+        // Some pino async-destinations route through stderr; sniff there too.
+        onLine(s);
+      });
+      child.once('exit', (code, signal) => {
+        if (controlAddress === undefined || dataAddress === undefined || bootedAt < 0) {
+          reject(
+            new Error(
+              `daemon exited (code=${code} signal=${signal}) before all events:\n` +
+                `  control=${controlAddress}\n  data=${dataAddress}\n  bootedAt=${bootedAt}\n` +
+                `  stdout:\n${stdoutLines.join('')}\n  stderr:\n${stderrLines.join('')}`,
+            ),
+          );
+        }
+      });
+      const timer = setTimeout(() => {
+        reject(
+          new Error(
+            `boot timed out (15s); control=${controlAddress} data=${dataAddress}\n` +
+              `stdout:\n${stdoutLines.join('')}\nstderr:\n${stderrLines.join('')}`,
+          ),
+        );
+      }, 15_000);
+      // Clear the timer once ready resolves — chained off the same promise
+      // so we don't leak the handle if reject paths win.
+      void Promise.resolve()
+        .then(async () => {
+          await new Promise<void>((r) => {
+            const tick = setInterval(() => {
+              if (bootedAt >= 0) {
+                clearInterval(tick);
+                r();
+              }
+            }, 25);
+          });
+        })
+        .finally(() => clearTimeout(timer));
+    });
+
+    try {
+      await ready;
+
+      // Invariant 1 — both bound events fired before the ready marker.
+      expect(controlAddress, 'control-socket address logged').toBeDefined();
+      expect(dataAddress, 'data-socket address logged').toBeDefined();
+
+      // Invariant 2 — `net.connect` to control reaches a listener.
+      await new Promise<void>((res, rej) => {
+        const c = createConnection(controlAddress!);
+        c.once('connect', () => {
+          c.destroy();
+          res();
+        });
+        c.once('error', (err) => rej(err));
+        setTimeout(() => rej(new Error('control connect timed out')), 3_000);
+      });
+
+      // Invariant 3 — same for data-socket.
+      await new Promise<void>((res, rej) => {
+        const c = createConnection(dataAddress!);
+        c.once('connect', () => {
+          c.destroy();
+          res();
+        });
+        c.once('error', (err) => rej(err));
+        setTimeout(() => rej(new Error('data connect timed out')), 3_000);
+      });
+    } finally {
+      // Best-effort tear down. SIGTERM on POSIX runs the shutdown sequence;
+      // on Windows kill() maps to TerminateProcess so the listener gets
+      // ripped away — which is fine, the OS reclaims the pipe.
+      try {
+        child.kill(isWin ? undefined : 'SIGTERM');
+      } catch {
+        // ignore
+      }
+      // Wait for exit so the next test does not race a still-running daemon
+      // on the same scratch socket directory.
+      await new Promise<void>((res) => {
+        if (child.exitCode !== null || child.signalCode !== null) {
+          res();
+          return;
+        }
+        child.once('exit', () => res());
+        setTimeout(() => res(), 5_000);
+      });
+    }
+  }, 30_000);
 });


### PR DESCRIPTION
## Summary

Task #1072. The control-socket factory (T14 #676) and data-socket factory (T15 #673) both shipped without ever being called from `daemon/src/index.ts`. The control plane was dead code in production: every probe (PR #737 T73 daemon-boot+hello, PR #738 T74 upgrade-in-place) had to degrade to in-process handler invocation and document `real socket round-trip out of scope until controlSocket.listen() is wired` in its PR body.

This PR wires both listeners into the daemon boot path.

## Changes

- `daemon/src/index.ts` — resolve socket runtime root via T13 `resolveRuntimeRoot()`, construct + bind both `createControlSocketServer` then `createDataSocketServer`, log `daemon.boot.control-socket-listening` / `daemon.boot.data-socket-listening` events, and re-throw on bind failure so the supervisor restart loop is the recovery surface.
- `daemon/src/index.ts` — extend the `daemon.shutdown` exitProcess hook to call `closeTransports()` (best-effort, parallel) so the next boot does not collide on a stale POSIX socket node / leftover Windows pipe handle.
- `daemon/src/sockets/data-socket.ts` — add a `socketPath?: string` option on `CreateDataSocketServerOptions`, mirroring the existing override on `createControlSocketServer` (T14). Lets test harnesses inject unique addresses to avoid named-pipe namespace collisions across consecutive test boots.
- `daemon/src/index.ts` — honor `CCSM_CONTROL_SOCKET_PATH` / `CCSM_DATA_SOCKET_PATH` env vars (test-only, no production setter) that route into the respective `socketPath` overrides.
- `tests/harness-daemon-mode.test.ts` — new smoke describe block (`Task #1072 — controlSocket.listen() wire smoke`) that boots the real `daemon/src/index.ts`, parses pino JSON logs to confirm both `daemon.boot.*-socket-listening` events fire before the `daemon shell booted` ready marker, then `net.connect`s to both addresses and asserts the connect callback runs (no ECONNREFUSED / ENOENT). Also extends the existing T73 probe to set the test-only env overrides so it survives a parallel CCSM install on the dev box.

## Connection handler scope (intentional)

The connection handler is a **logged-destroy placeholder**. The envelope adapter that would frame Duplex bytes → `decodeFrame` → dispatcher is a separate slice (T-future). Today the listener being **bound** is enough to (a) flip the double-bind guard outcome from `absent` to `alive`, and (b) let probes do `net.connect` to verify the OS endpoint exists. Routing real RPCs over the wire lands when the envelope adapter does.

This is honest minimal scope per the task brief (`Don't ... add new RPCs`, `Don't change the /healthz handler`).

## Smoke test output (positive path)

```
RUN  v4.1.5 C:/Users/jiahuigu/ccsm-worktrees/pool-4
 Test Files  1 passed (1)
      Tests  1 passed | 38 skipped (39)
   Duration  5.24s
```

## Reverse-verify (mutation observed)

Commented out `await controlSocket.listen()` in `daemon/src/index.ts`:

```
FAIL  tests/harness-daemon-mode.test.ts > Task #1072 — controlSocket.listen() wire smoke > binds both control + data sockets and logs `bound` before the ready marker
Error: connect ENOENT \.\pipe\ccsm-control-c0ea1bfb
```

After restore: 39/39 in `harness-daemon-mode.test.ts` pass; 99/99 in `daemon/src/sockets/__tests__/control-socket.test.ts` + `daemon/src/__tests__` pass.

## What this resolves

- **PR #737** (T73, task #1030) — `Out of scope today: real socket round-trip (daemon/src/index.ts has not yet wired controlSocket.listen()) ... once the binding lands, swap the in-process handler call for a net.connect + envelope round-trip`. Binding is now landed; the env-override pattern this PR adds is what the follow-up will use.
- **PR #738** (T74, task #1031) — same in-process degradation note.
- **`scripts/double-bind-guard.ts`** consumers — `probeControlSocket()` will now see `kind: alive` instead of `kind: absent` on a healthy daemon.

## Test plan

- [x] `npx vitest run tests/harness-daemon-mode.test.ts -t "controlSocket.listen"` — new smoke passes (1/1)
- [x] `npx vitest run tests/harness-daemon-mode.test.ts` — full file (39/39, includes T73/T74/T78/T84)
- [x] `npx vitest run daemon/src/sockets/__tests__/control-socket.test.ts daemon/src/__tests__` — control-socket + dispatcher unchanged (99/99 + 3 skipped)
- [x] `npx tsc --noEmit -p daemon/tsconfig.json` — clean
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] Reverse-verify: skip `controlSocket.listen()` → smoke fails with ECONNREFUSED/ENOENT
- [ ] CI green on this PR
- [ ] Reviewer signs off

## Don'ts honored

- Did NOT change socket path resolution (T13 surface untouched).
- Did NOT change /healthz handler (T17 territory).
- Did NOT touch v0.4 `connect/` Connect-RPC scaffold.
- Did NOT add new RPCs (envelope adapter remains T-future).

## Pre-existing test failures (NOT caused by this PR)

`daemon/src/sockets/__tests__/data-socket.test.ts` has 4 pre-existing failures on the dev box (verified by checking `origin/working` HEAD without these changes). Cause: a parallel CCSM install on the dev box owns the canonical `\.\pipe\ccsm-data-c0ea1bfb` pipe. The test file binds the canonical pipe without a unique override and collides. Out of scope for this PR; a follow-up should make the data-socket tests use unique addresses per run (the `socketPath` option this PR adds is what they need).

🤖 Generated with [Claude Code](https://claude.com/claude-code)