### PR TITLE
release-keys: real minisign public key (T59 follow-up)

### DIFF
--- a/release-keys/minisign.pub
+++ b/release-keys/minisign.pub
@@ -1,11 +1,2 @@
-untrusted comment: PLACEHOLDER — not a real ccsm minisign public key
-RWQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-
-# This file is a PLACEHOLDER. The real ccsm release-signing minisign public
-# key will be generated and committed during the v0.3 ship-day ops task
-# (see release-keys/README.md "First-time keypair generation"). Until then,
-# any minisign signature verified against this key will FAIL — which is the
-# intended state, because the matching MINISIGN_PRIVATE_KEY repo secret is
-# also unprovisioned.
-#
-# Do NOT replace this file by hand outside the documented rotation runbook.
+untrusted comment: minisign public key D1146C005BA0E1F3
+RWTz4aBbAGwU0RyPzS5uDEFeoFoLMCxaFMhjMYPAyYYK5pbHvKNREKIX


### PR DESCRIPTION
Replaces the placeholder shipped in PR #759 (T59 release attestation).

Public key fingerprint: `RWTz4aBbAGwU0RyPzS5uDEFeoFoLMCxaFMhjMYPAyYYK5pbHvKNREKIX`

## Companion ops (separate from this PR)

- [x] Generate keypair offline (`minisign -G`)
- [x] Commit `minisign.pub` (this PR)
- [ ] `gh secret set MINISIGN_PRIVATE_KEY` (repo owner, post-merge)
- [ ] `gh secret set MINISIGN_PASSWORD` (repo owner, post-merge)
- [ ] Securely delete on-disk `ccsm-minisign.key`

After this PR merges and the two secrets are set, release.yml `attest` job will sign every installer and the sidecar-verify gate will pass.
