### PR TITLE
fix(v03): wire spawnDaemon() into electron/main.ts boot path

### DIFF
--- a/electron/daemon/bootDaemon.ts
+++ b/electron/daemon/bootDaemon.ts
@@ -1,0 +1,242 @@
+// electron/daemon/bootDaemon.ts
+//
+// v0.3 Task 4 (frag-6-7 §6.1) — Electron-main boot wire for `spawnDaemon()`.
+//
+// Single Responsibility: SINK. Owns the boot-time decision tree:
+//   1. Dev mode (`CCSM_DAEMON_DEV=1`)? → skip entirely. nodemon owns the
+//      daemon lifecycle in dev (frag-3.7 §3.7.6.a "Supervisor active? NO").
+//   2. Probe the control socket. Already-alive → skip spawn (attach to the
+//      existing daemon — re-opening Electron must reuse the surviving
+//      daemon process per the v0.3 dogfood metric "daemon survives quit").
+//   3. Otherwise spawn the production daemon binary, **detached + unref()**
+//      so the OS does NOT tear it down when Electron quits. v0.3 explicitly
+//      requires daemon survival across Electron restarts (frag-6-7 §6.1
+//      Spawn-or-attach + dogfood metric #1).
+//
+// Notes:
+//   - This is the minimal boot-path wire. Full `daemonSupervisor.start()`
+//     (lock-file probe, healthz heartbeat, crash-loop detection, .bak
+//     rollback) is Task 7 / a separate PR. Task 4 (this file) just ensures
+//     the daemon child exists; the existing connect-probe is enough to
+//     honor the double-bind guard during the v0.3 ship.
+//   - The connect-probe + control-socket path computation here mirrors
+//     `scripts/double-bind-guard.ts` byte-for-byte. We intentionally do NOT
+//     import from `scripts/` (which is outside `tsconfig.electron.json`) or
+//     from `daemon/src/` (which is a separate workspace bundle) — both
+//     stay zero-dep relative to electron-main. A drift-guard test pins
+//     this mirror against `daemon/src/sockets/control-socket.ts`.
+
+import { connect, type Socket } from 'node:net';
+import { homedir, hostname, userInfo } from 'node:os';
+import { createHash } from 'node:crypto';
+import { posix, win32 } from 'node:path';
+import { spawnDaemon } from './supervisor';
+
+// ---------------------------------------------------------------------------
+// Pure path resolution (mirror of scripts/double-bind-guard.ts).
+// ---------------------------------------------------------------------------
+
+function joinFor(platform: NodeJS.Platform, ...parts: string[]): string {
+  return platform === 'win32' ? win32.join(...parts) : posix.join(...parts);
+}
+
+export function resolveDataRoot(
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+): string {
+  if (platform === 'win32') {
+    const local = env.LOCALAPPDATA;
+    if (local && local.length > 0) return win32.join(local, 'ccsm');
+    return win32.join(homedir(), 'AppData', 'Local', 'ccsm');
+  }
+  if (platform === 'darwin') {
+    return joinFor(platform, homedir(), 'Library', 'Application Support', 'ccsm');
+  }
+  const xdgData = env.XDG_DATA_HOME;
+  if (xdgData && xdgData.length > 0) return joinFor(platform, xdgData, 'ccsm');
+  return joinFor(platform, homedir(), '.local', 'share', 'ccsm');
+}
+
+export function resolveRuntimeRoot(
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+): string {
+  if (platform === 'linux') {
+    const xdgRuntime = env.XDG_RUNTIME_DIR;
+    if (xdgRuntime && xdgRuntime.length > 0) return joinFor(platform, xdgRuntime, 'ccsm');
+  }
+  return joinFor(platform, resolveDataRoot(platform, env), 'run');
+}
+
+export function resolveControlSocketPath(
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+): string {
+  if (platform === 'win32') {
+    const ui = userInfo();
+    const tag = `${ui.username}@${hostname()}`;
+    const userhash = createHash('sha256').update(tag).digest('hex').slice(0, 8);
+    return `\\\\.\\pipe\\ccsm-control-${userhash}`;
+  }
+  return posix.join(resolveRuntimeRoot(platform, env), 'ccsm-control.sock');
+}
+
+// ---------------------------------------------------------------------------
+// Connect-probe (pure decider; never throws).
+// ---------------------------------------------------------------------------
+
+export type ProbeOutcome =
+  | { kind: 'alive'; socketPath: string }
+  | { kind: 'absent'; socketPath: string; reason: string }
+  | { kind: 'zombie'; socketPath: string; reason: string };
+
+export interface ProbeOptions {
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+  connector?: (socketPath: string) => Socket;
+}
+
+export function probeControlSocket(opts: ProbeOptions = {}): Promise<ProbeOutcome> {
+  const platform = opts.platform ?? process.platform;
+  const env = opts.env ?? process.env;
+  const timeoutMs = opts.timeoutMs ?? 500;
+  const socketPath = resolveControlSocketPath(platform, env);
+
+  return new Promise<ProbeOutcome>((resolve) => {
+    const sock = opts.connector ? opts.connector(socketPath) : connect(socketPath);
+    let settled = false;
+    const finish = (outcome: ProbeOutcome): void => {
+      if (settled) return;
+      settled = true;
+      try { sock.destroy(); } catch { /* ignore */ }
+      resolve(outcome);
+    };
+    const timer = setTimeout(() => {
+      finish({ kind: 'zombie', socketPath, reason: `no connect verdict within ${timeoutMs}ms` });
+    }, timeoutMs);
+    timer.unref?.();
+    sock.once('connect', () => { clearTimeout(timer); finish({ kind: 'alive', socketPath }); });
+    sock.once('error', (err: NodeJS.ErrnoException) => {
+      clearTimeout(timer);
+      finish({ kind: 'absent', socketPath, reason: err.code ?? err.message ?? 'unknown' });
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Production daemon binary resolver.
+// ---------------------------------------------------------------------------
+
+/**
+ * Production binary path (mirror of frag-11 §11.2). Packaged builds resolve
+ * via `process.resourcesPath`; unpackaged Electron runs that are NOT in
+ * `CCSM_DAEMON_DEV=1` mode return null (caller skips spawn — there's no
+ * sensible binary to run, and dev mode is owned by nodemon anyway).
+ */
+export function resolveDaemonBinary(opts: {
+  isPackaged: boolean;
+  resourcesPath: string;
+  platform?: NodeJS.Platform;
+}): string | null {
+  if (!opts.isPackaged) return null;
+  const platform = opts.platform ?? process.platform;
+  const ext = platform === 'win32' ? '.exe' : '';
+  return joinFor(platform, opts.resourcesPath, 'daemon', `ccsm-daemon${ext}`);
+}
+
+// ---------------------------------------------------------------------------
+// Boot orchestrator (sink).
+// ---------------------------------------------------------------------------
+
+export interface BootDaemonDeps {
+  /** `app.isPackaged` mirror so this module stays Electron-free for tests. */
+  isPackaged: boolean;
+  /** `process.resourcesPath` mirror (only read when isPackaged). */
+  resourcesPath: string;
+  /** Defaults to process.env. */
+  env?: NodeJS.ProcessEnv;
+  /** Test seam — bypass the connect probe. */
+  probe?: typeof probeControlSocket;
+  /** Test seam — bypass the actual spawn. */
+  spawn?: typeof spawnDaemon;
+  /** Test seam — log sink (stderr by default). */
+  log?: (line: string) => void;
+}
+
+export type BootDaemonOutcome =
+  | { kind: 'skipped-dev' }
+  | { kind: 'skipped-already-alive'; socketPath: string }
+  | { kind: 'skipped-no-binary'; reason: string }
+  | { kind: 'spawned'; pid: number | undefined; binary: string }
+  | { kind: 'spawn-failed'; binary: string; reason: string };
+
+/**
+ * Boot-time wire. Honors:
+ *   - dev short-circuit (`CCSM_DAEMON_DEV=1` → no-op; nodemon owns it)
+ *   - double-bind guard (alive socket → no second spawn; we attach later)
+ *   - daemon-survives-Electron-quit (spawn detached + child.unref())
+ *
+ * Always resolves; never throws. Failures degrade to a logged outcome so
+ * Electron boot continues even if the daemon binary is missing or crashes
+ * immediately — the renderer's existing not-connected UX surfaces it.
+ */
+export async function bootDaemon(deps: BootDaemonDeps): Promise<BootDaemonOutcome> {
+  const env = deps.env ?? process.env;
+  const log = deps.log ?? ((line: string) => process.stderr.write(`${line}\n`));
+  const tag = '[boot-daemon]';
+
+  if (env.CCSM_DAEMON_DEV === '1') {
+    log(`${tag} CCSM_DAEMON_DEV=1, nodemon owns daemon lifecycle, skipping spawn`);
+    return { kind: 'skipped-dev' };
+  }
+
+  const probeFn = deps.probe ?? probeControlSocket;
+  const outcome = await probeFn({ env });
+  if (outcome.kind === 'alive') {
+    log(`${tag} daemon already bound at ${outcome.socketPath}, attaching (no spawn)`);
+    return { kind: 'skipped-already-alive', socketPath: outcome.socketPath };
+  }
+  if (outcome.kind === 'zombie') {
+    log(`${tag} WARN: control socket at ${outcome.socketPath} appears wedged (${outcome.reason}); spawning anyway`);
+  } else {
+    log(`${tag} no daemon at ${outcome.socketPath} (${outcome.reason}), spawning`);
+  }
+
+  const binary = resolveDaemonBinary({
+    isPackaged: deps.isPackaged,
+    resourcesPath: deps.resourcesPath,
+  });
+  if (!binary) {
+    const reason = 'unpackaged Electron without CCSM_DAEMON_DEV=1; no daemon binary available';
+    log(`${tag} ${reason} — skipping spawn (use npm run dev for nodemon-managed daemon)`);
+    return { kind: 'skipped-no-binary', reason };
+  }
+
+  const spawnFn = deps.spawn ?? spawnDaemon;
+  try {
+    const child = spawnFn({
+      binary,
+      // Detach + unref so the daemon survives Electron quit. v0.3 dogfood
+      // metric #1: re-opening Electron must reuse the existing daemon.
+      // `windowsHide: true` prevents a console flash on Windows when the
+      // daemon binary is launched from a GUI Electron process.
+      spawnOptions: {
+        detached: true,
+        stdio: 'ignore',
+        windowsHide: true,
+      },
+    });
+    // Detach the child from the parent's reference set so Node won't keep
+    // the event loop alive on the child's behalf and (more importantly)
+    // won't propagate Electron's exit to the daemon. The OS-level detach
+    // still depends on `detached: true` above.
+    try { child.unref(); } catch { /* ignore */ }
+    log(`${tag} spawned daemon pid=${child.pid ?? '?'} binary=${binary} (detached)`);
+    return { kind: 'spawned', pid: child.pid, binary };
+  } catch (err) {
+    const reason = (err as Error)?.message ?? String(err);
+    log(`${tag} ERROR: spawn failed for ${binary}: ${reason}`);
+    return { kind: 'spawn-failed', binary, reason };
+  }
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -35,6 +35,7 @@ import { createTray, type TrayController } from './tray/createTray';
 import { startCrashCollector } from './crash/collector';
 import { resolveCrashRoot } from './crash/incident-dir';
 import { wireCrashHandlers } from './main-crash-wiring';
+import { bootDaemon } from './daemon/bootDaemon';
 
 // Phase 1 crash observability (spec §5.1, plan Task 2):
 //   * crashReporter.start with empty submitURL + uploadToServer:false enables
@@ -234,6 +235,21 @@ app.whenReady().then(() => {
   }
 
   initDb();
+
+  // ─────────────────────── daemon spawn-or-attach (Task 4 / frag-6-7 §6.1) ──
+  // Fire-and-forget. The wire honors three constraints:
+  //   1. CCSM_DAEMON_DEV=1 → no-op (nodemon owns daemon lifecycle in dev).
+  //   2. Existing daemon already bound to control socket → skip spawn,
+  //      attach to it (re-opening Electron must reuse the surviving daemon
+  //      per v0.3 dogfood metric #1).
+  //   3. Spawn detached + unref so the daemon SURVIVES Electron quit.
+  // Outcome is logged; renderer's existing not-connected UX surfaces any
+  // failure. Full supervisor.start() (lock-file probe, healthz, crash-loop,
+  // .bak rollback) lands in Task 7.
+  void bootDaemon({
+    isPackaged: app.isPackaged,
+    resourcesPath: process.resourcesPath,
+  });
 
   // ─────────────────────────── IPC registration ──────────────────────────
   // Wire prefs cache invalidation to the stateSavedBus BEFORE registering

--- a/tests/electron/daemon/bootDaemon.test.ts
+++ b/tests/electron/daemon/bootDaemon.test.ts
@@ -1,0 +1,254 @@
+// tests/electron/daemon/bootDaemon.test.ts
+//
+// v0.3 Task 4 (frag-6-7 §6.1) — Electron-main boot wire for spawnDaemon().
+//
+// Covers the decision tree:
+//   - dev short-circuit (CCSM_DAEMON_DEV=1 → no spawn)
+//   - alive socket → no spawn (double-bind guard / re-attach)
+//   - absent socket + packaged → spawn detached
+//   - absent socket + unpackaged + no dev env → skip (no binary)
+//   - zombie socket → spawn anyway (best-effort)
+//   - resolveDaemonBinary path shape (Win / POSIX)
+// Plus a drift guard pinning resolveControlSocketPath against the daemon
+// implementation (mirrors tests/double-bind-guard.test.ts §drift-guard).
+
+import { describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import {
+  bootDaemon,
+  probeControlSocket,
+  resolveControlSocketPath,
+  resolveDaemonBinary,
+  resolveRuntimeRoot,
+} from '../../../electron/daemon/bootDaemon';
+
+class FakeSocket extends EventEmitter {
+  destroyed = false;
+  destroy(): void {
+    this.destroyed = true;
+  }
+}
+
+function fakeSpawnHandle(): { fn: any; calls: any[] } {
+  const calls: any[] = [];
+  const fn = (opts: any) => {
+    calls.push(opts);
+    const child: any = new EventEmitter();
+    child.pid = 4242;
+    child.unref = () => {};
+    return child;
+  };
+  return { fn, calls };
+}
+
+describe('bootDaemon decision tree', () => {
+  it('CCSM_DAEMON_DEV=1 → skipped-dev (no probe, no spawn)', async () => {
+    const probe = vi.fn();
+    const spawn = vi.fn();
+    const logs: string[] = [];
+    const out = await bootDaemon({
+      isPackaged: true,
+      resourcesPath: '/fake/resources',
+      env: { CCSM_DAEMON_DEV: '1' },
+      probe: probe as any,
+      spawn: spawn as any,
+      log: (l) => logs.push(l),
+    });
+    expect(out).toEqual({ kind: 'skipped-dev' });
+    expect(probe).not.toHaveBeenCalled();
+    expect(spawn).not.toHaveBeenCalled();
+    expect(logs.join('\n')).toMatch(/CCSM_DAEMON_DEV=1.*nodemon/);
+  });
+
+  it('alive socket → skipped-already-alive (no spawn)', async () => {
+    const probe = vi.fn().mockResolvedValue({ kind: 'alive', socketPath: '/tmp/sock' });
+    const spawn = vi.fn();
+    const out = await bootDaemon({
+      isPackaged: true,
+      resourcesPath: '/fake/resources',
+      env: {},
+      probe: probe as any,
+      spawn: spawn as any,
+      log: () => {},
+    });
+    expect(out).toEqual({ kind: 'skipped-already-alive', socketPath: '/tmp/sock' });
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('absent socket + packaged → spawned (detached, unref called)', async () => {
+    const probe = vi.fn().mockResolvedValue({
+      kind: 'absent', socketPath: '/tmp/sock', reason: 'ENOENT',
+    });
+    const { fn: spawnFn, calls } = fakeSpawnHandle();
+    const out = await bootDaemon({
+      isPackaged: true,
+      resourcesPath: '/fake/resources',
+      env: {},
+      probe: probe as any,
+      spawn: spawnFn as any,
+      log: () => {},
+    });
+    expect(out.kind).toBe('spawned');
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.binary).toMatch(/[\\/]fake[\\/]resources[\\/]daemon[\\/]ccsm-daemon/);
+    expect(calls[0]!.spawnOptions.detached).toBe(true);
+    expect(calls[0]!.spawnOptions.stdio).toBe('ignore');
+    expect(calls[0]!.spawnOptions.windowsHide).toBe(true);
+  });
+
+  it('absent socket + unpackaged + no dev env → skipped-no-binary', async () => {
+    const probe = vi.fn().mockResolvedValue({
+      kind: 'absent', socketPath: '/tmp/sock', reason: 'ENOENT',
+    });
+    const spawn = vi.fn();
+    const out = await bootDaemon({
+      isPackaged: false,
+      resourcesPath: '',
+      env: {},
+      probe: probe as any,
+      spawn: spawn as any,
+      log: () => {},
+    });
+    expect(out.kind).toBe('skipped-no-binary');
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('zombie socket → spawn anyway (best-effort, log WARN)', async () => {
+    const probe = vi.fn().mockResolvedValue({
+      kind: 'zombie', socketPath: '/tmp/sock', reason: 'no connect verdict within 500ms',
+    });
+    const { fn: spawnFn, calls } = fakeSpawnHandle();
+    const logs: string[] = [];
+    const out = await bootDaemon({
+      isPackaged: true,
+      resourcesPath: '/fake/resources',
+      env: {},
+      probe: probe as any,
+      spawn: spawnFn as any,
+      log: (l) => logs.push(l),
+    });
+    expect(out.kind).toBe('spawned');
+    expect(calls).toHaveLength(1);
+    expect(logs.join('\n')).toMatch(/WARN.*wedged.*spawning anyway/);
+  });
+
+  it('spawn throws → spawn-failed (does not propagate)', async () => {
+    const probe = vi.fn().mockResolvedValue({
+      kind: 'absent', socketPath: '/tmp/sock', reason: 'ENOENT',
+    });
+    const spawn = vi.fn().mockImplementation(() => {
+      throw new Error('ENOENT spawn ccsm-daemon');
+    });
+    const out = await bootDaemon({
+      isPackaged: true,
+      resourcesPath: '/fake/resources',
+      env: {},
+      probe: probe as any,
+      spawn: spawn as any,
+      log: () => {},
+    });
+    expect(out.kind).toBe('spawn-failed');
+    if (out.kind === 'spawn-failed') {
+      expect(out.reason).toMatch(/ENOENT/);
+    }
+  });
+});
+
+describe('resolveDaemonBinary', () => {
+  it('Windows packaged: <resources>/daemon/ccsm-daemon.exe', () => {
+    const got = resolveDaemonBinary({
+      isPackaged: true,
+      resourcesPath: 'C:\\Program Files\\ccsm\\resources',
+      platform: 'win32',
+    });
+    expect(got).toMatch(/ccsm-daemon\.exe$/);
+    expect(got).toContain('daemon');
+  });
+  it('macOS packaged: <resources>/daemon/ccsm-daemon (no ext)', () => {
+    const got = resolveDaemonBinary({
+      isPackaged: true,
+      resourcesPath: '/Applications/CCSM.app/Contents/Resources',
+      platform: 'darwin',
+    });
+    expect(got).toBe('/Applications/CCSM.app/Contents/Resources/daemon/ccsm-daemon');
+  });
+  it('Linux packaged: <resources>/daemon/ccsm-daemon', () => {
+    const got = resolveDaemonBinary({
+      isPackaged: true,
+      resourcesPath: '/opt/ccsm/resources',
+      platform: 'linux',
+    });
+    expect(got).toBe('/opt/ccsm/resources/daemon/ccsm-daemon');
+  });
+  it('unpackaged returns null', () => {
+    expect(
+      resolveDaemonBinary({ isPackaged: false, resourcesPath: '', platform: 'linux' }),
+    ).toBeNull();
+  });
+});
+
+describe('probeControlSocket (smoke; full matrix lives in tests/double-bind-guard.test.ts mirror)', () => {
+  it('connect → alive', async () => {
+    const sock = new FakeSocket();
+    const p = probeControlSocket({
+      platform: 'linux',
+      env: { XDG_RUNTIME_DIR: '/run/user/1000' },
+      timeoutMs: 100,
+      connector: () => sock as any,
+    });
+    setImmediate(() => sock.emit('connect'));
+    const out = await p;
+    expect(out.kind).toBe('alive');
+    expect(out.socketPath).toBe('/run/user/1000/ccsm/ccsm-control.sock');
+    expect(sock.destroyed).toBe(true);
+  });
+
+  it('error → absent with err.code reason', async () => {
+    const sock = new FakeSocket();
+    const p = probeControlSocket({
+      platform: 'linux',
+      env: { XDG_DATA_HOME: '/xdg' },
+      timeoutMs: 100,
+      connector: () => sock as any,
+    });
+    setImmediate(() => {
+      const err = new Error('boom') as NodeJS.ErrnoException;
+      err.code = 'ECONNREFUSED';
+      sock.emit('error', err);
+    });
+    const out = await p;
+    expect(out.kind).toBe('absent');
+    if (out.kind === 'absent') expect(out.reason).toBe('ECONNREFUSED');
+  });
+
+  it('no event → zombie after timeout', async () => {
+    const sock = new FakeSocket();
+    const p = probeControlSocket({
+      platform: 'linux',
+      env: { XDG_DATA_HOME: '/xdg' },
+      timeoutMs: 20,
+      connector: () => sock as any,
+    });
+    const out = await p;
+    expect(out.kind).toBe('zombie');
+  });
+});
+
+describe('drift guard against daemon/src/sockets/* (mirror)', () => {
+  it('matches defaultControlSocketPath across (platform, env) cases', async () => {
+    const { defaultControlSocketPath } = await import(
+      '../../../daemon/src/sockets/control-socket.js'
+    );
+    const cases: Array<{ platform: NodeJS.Platform; env: NodeJS.ProcessEnv }> = [
+      { platform: 'linux', env: { XDG_RUNTIME_DIR: '/run/user/1000' } },
+      { platform: 'linux', env: { XDG_DATA_HOME: '/xdg/data' } },
+      { platform: 'darwin', env: {} },
+      { platform: 'win32', env: { LOCALAPPDATA: 'C:\\Users\\u\\AppData\\Local' } },
+    ];
+    for (const { platform, env } of cases) {
+      const ours = resolveControlSocketPath(platform, env);
+      const theirs = defaultControlSocketPath(platform, resolveRuntimeRoot(platform, env));
+      expect(ours).toBe(theirs);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Second half of PR #767 (controlSocket.listen wire). Completes Task 4 in `frag-6-7-reliability-security.md` §6.1 — without this wire Electron runs the legacy in-process ptyHost and the daemon split is non-functional. P0 v0.3 ship blocker discovered by Task #13 dev-mode dogfood.

- New `electron/daemon/bootDaemon.ts` — pure SINK module owning the boot-time decision tree.
- `electron/main.ts` — one fire-and-forget call inside `app.whenReady()`.

## Decision tree

1. `CCSM_DAEMON_DEV=1` → no-op. nodemon owns the daemon lifecycle in dev (`frag-3.7 §3.7.6.a` "Supervisor active? NO").
2. **Probe the control socket.** Already-alive → skip spawn, attach to the existing daemon. Honors the existing double-bind guard (mirror of `scripts/double-bind-guard.ts`; drift-locked by a dedicated test against `daemon/src/sockets/control-socket.ts`).
3. Otherwise spawn the production binary (`<resourcesPath>/daemon/ccsm-daemon` per `frag-11 §11.2`) **detached + `child.unref()`** so the daemon SURVIVES Electron quit. Re-opening Electron must reuse the surviving daemon per v0.3 dogfood metric #1.

## Why this is safe wrt shutdown

- The child handle is never retained — main.ts can't accidentally kill the daemon at quit.
- `detached: true` + `child.unref()` is the canonical Node survival pattern (matches `frag-3.7` Task 7 spec: `detached: !process.env.CCSM_DAEMON_DEV`).
- The existing `killAllPtySessions()` teardown only touches in-process pty children, not the daemon child.

## Scope

This is the **minimal wire** that makes the daemon present at all. Full `daemonSupervisor.start()` (lock-file probe, healthz heartbeat, crash-loop detection, `.bak` rollback) is Task 7 / a future PR.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.electron.json` — clean
- [x] `npx tsc -p tsconfig.electron.json && node -e "require('./dist/electron/daemon/bootDaemon.js')"` — "require-load OK" (no `ERR_REQUIRE_ESM`)
- [x] `npx vitest run tests/electron/daemon/ tests/double-bind-guard.test.ts` — 53/53 pass (14 new)
- [x] New tests cover: dev short-circuit, alive→skip, absent+packaged→spawn detached, absent+unpackaged→skip-no-binary, zombie→spawn anyway, spawn-throws→spawn-failed, binary path shape (Win/macOS/Linux), drift guard against `daemon/src/sockets/control-socket.ts`.
- [ ] Live `npm run dev` smoke + `taskkill electron` daemon-survives check — best done by reviewer in a fresh Electron run; covered by existing harness-daemon-mode.test.ts at the integration layer.

## Coordination

- Depends on PR #767 for `controlSocket.listen()` on the daemon side. Order does not matter for merge — neither half is functional alone, both need each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)