### PR TITLE
fix(dev): kill stale daemon on nodemon restart to prevent stray leak

### DIFF
--- a/daemon/src/index.ts
+++ b/daemon/src/index.ts
@@ -11,6 +11,7 @@ import {
   type ShutdownStep,
 } from './handlers/daemon-shutdown.js';
 import { createForceKillSink, type ForceKillJobHandle } from './lifecycle/force-kill.js';
+import { startDevParentWatchdog } from './lifecycle/dev-parent-watchdog.js';
 import { installCrashHandlers } from './crash/handlers.js';
 import { installNativeCrashHandlers } from './crash/native-handlers.js';
 import { initDaemonSentry } from './sentry/init.js';
@@ -351,3 +352,45 @@ function shutdownFromSignal(signal: 'SIGTERM' | 'SIGINT'): void {
 }
 process.on('SIGTERM', () => shutdownFromSignal('SIGTERM'));
 process.on('SIGINT', () => shutdownFromSignal('SIGINT'));
+
+// B9 (Task #25) — dev-mode parent-PID watchdog.
+//
+// In `CCSM_DAEMON_DEV=1` (npm run dev), nodemon owns the daemon
+// lifecycle but its SIGTERM does not always propagate through the tsx
+// wrapper to this Node process — especially on Windows, where Node has
+// no real SIGTERM. Without this watchdog the daemon survives nodemon's
+// kill, the next file save spawns a fresh daemon, and `tasklist` /
+// `ps` shows N stray PIDs after a few reloads.
+//
+// Production stays untouched: the supervisor (electron/daemon/
+// supervisor.ts) intentionally keeps the daemon alive past Electron
+// exit (v0.3 dogfood criterion #1). This block is gated on
+// `CCSM_DAEMON_DEV` so it can never engage in a packaged build.
+if (process.env.CCSM_DAEMON_DEV === '1') {
+  const ppid = process.ppid;
+  if (ppid && ppid > 0) {
+    startDevParentWatchdog({
+      ppid,
+      onParentGone: () => {
+        logger.info(
+          { event: 'daemon.dev.parent-gone', ppid },
+          'dev parent (nodemon/tsx) exited, self-terminating to prevent stray leak',
+        );
+        // Fire the same shutdown path so transports release their bind
+        // slots before exit. exitProcess(0) closes sockets then calls
+        // process.exit(0).
+        void daemonShutdownHandler.handle({ reason: 'SIGTERM' }, { bootNonce });
+      },
+      onUnknown: (probedPpid) => {
+        logger.warn(
+          { event: 'daemon.dev.parent-probe-unknown', ppid: probedPpid },
+          'dev parent probe returned non-ESRCH error; assuming alive',
+        );
+      },
+    });
+    logger.info(
+      { event: 'daemon.dev.parent-watchdog-armed', ppid },
+      'dev parent watchdog armed (B9)',
+    );
+  }
+}

--- a/daemon/src/lifecycle/__tests__/dev-parent-watchdog.test.ts
+++ b/daemon/src/lifecycle/__tests__/dev-parent-watchdog.test.ts
@@ -1,0 +1,145 @@
+// B9 (Task #25) — dev-mode parent watchdog tests.
+//
+// Reverse-verify pairing (per dev.md §2 phase-4): with the watchdog
+// removed from `daemon/src/index.ts`, the integration-style "parent
+// gone → onParentGone fires" test would still pass at the unit level
+// (this file tests the module in isolation). The reverse-verify
+// against the actual leak lives in scripts/check-no-stray-daemon.mjs
+// (Task brief step 5: simulate 5 nodemon restart cycles, count
+// surviving PIDs == 1).
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  checkParent,
+  startDevParentWatchdog,
+} from '../dev-parent-watchdog.js';
+
+describe('checkParent (pure decider)', () => {
+  it('returns "alive" when kill(ppid, 0) succeeds', () => {
+    const kill = vi.fn();
+    expect(checkParent(1234, { kill })).toBe('alive');
+    expect(kill).toHaveBeenCalledWith(1234, 0);
+  });
+
+  it('returns "gone" on ESRCH', () => {
+    const kill = vi.fn(() => {
+      const err = new Error('No such process') as NodeJS.ErrnoException;
+      err.code = 'ESRCH';
+      throw err;
+    });
+    expect(checkParent(9999, { kill })).toBe('gone');
+  });
+
+  it('returns "unknown" on EPERM (do NOT self-kill on transient perms)', () => {
+    const kill = vi.fn(() => {
+      const err = new Error('Operation not permitted') as NodeJS.ErrnoException;
+      err.code = 'EPERM';
+      throw err;
+    });
+    expect(checkParent(42, { kill })).toBe('unknown');
+  });
+
+  it('returns "unknown" on errors with no .code', () => {
+    const kill = vi.fn(() => {
+      throw new Error('mystery');
+    });
+    expect(checkParent(42, { kill })).toBe('unknown');
+  });
+});
+
+describe('startDevParentWatchdog', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('polls at the configured interval and fires onParentGone exactly once on ESRCH', () => {
+    let aliveTicks = 3;
+    const kill = vi.fn((_pid: number, _signal: 0) => {
+      if (aliveTicks > 0) {
+        aliveTicks--;
+        return;
+      }
+      const err = new Error('ESRCH') as NodeJS.ErrnoException;
+      err.code = 'ESRCH';
+      throw err;
+    });
+    const onParentGone = vi.fn();
+
+    startDevParentWatchdog({
+      ppid: 5555,
+      intervalMs: 100,
+      onParentGone,
+      kill,
+    });
+
+    // Tick #1, #2, #3 — parent alive.
+    vi.advanceTimersByTime(300);
+    expect(onParentGone).not.toHaveBeenCalled();
+
+    // Tick #4 — parent gone.
+    vi.advanceTimersByTime(100);
+    expect(onParentGone).toHaveBeenCalledTimes(1);
+
+    // Subsequent ticks must not re-fire (idempotency: timer was cleared).
+    vi.advanceTimersByTime(1000);
+    expect(onParentGone).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT fire onParentGone when probe returns "unknown" (EPERM)', () => {
+    const kill = vi.fn(() => {
+      const err = new Error('EPERM') as NodeJS.ErrnoException;
+      err.code = 'EPERM';
+      throw err;
+    });
+    const onParentGone = vi.fn();
+    const onUnknown = vi.fn();
+
+    startDevParentWatchdog({
+      ppid: 7777,
+      intervalMs: 50,
+      onParentGone,
+      onUnknown,
+      kill,
+    });
+
+    vi.advanceTimersByTime(500);
+    expect(onParentGone).not.toHaveBeenCalled();
+    // onUnknown is rate-limited to once even across many ticks.
+    expect(onUnknown).toHaveBeenCalledTimes(1);
+    expect(onUnknown).toHaveBeenCalledWith(7777);
+  });
+
+  it('handle.stop() halts polling without firing onParentGone', () => {
+    const kill = vi.fn();
+    const onParentGone = vi.fn();
+    const handle = startDevParentWatchdog({
+      ppid: 1,
+      intervalMs: 100,
+      onParentGone,
+      kill,
+    });
+
+    vi.advanceTimersByTime(250);
+    expect(kill).toHaveBeenCalled();
+    const callsBeforeStop = kill.mock.calls.length;
+
+    handle.stop();
+    vi.advanceTimersByTime(1000);
+    expect(kill.mock.calls.length).toBe(callsBeforeStop);
+    expect(onParentGone).not.toHaveBeenCalled();
+  });
+
+  it('uses default 500ms interval when none provided', () => {
+    const kill = vi.fn();
+    const onParentGone = vi.fn();
+    startDevParentWatchdog({ ppid: 1, onParentGone, kill });
+
+    vi.advanceTimersByTime(499);
+    expect(kill).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(kill).toHaveBeenCalledTimes(1);
+  });
+});

--- a/daemon/src/lifecycle/dev-parent-watchdog.ts
+++ b/daemon/src/lifecycle/dev-parent-watchdog.ts
@@ -1,0 +1,156 @@
+// B9 — dev-mode parent-PID watchdog.
+//
+// Problem (Task #25):
+//   In `npm run dev`, nodemon restarts the daemon when daemon/src files
+//   change. nodemon sends SIGTERM to its tsx child, but on Windows the
+//   signal does not reliably propagate through the tsx wrapper to the
+//   actual node grandchild (Node on Windows has no real SIGTERM; tsx
+//   spawns its own subprocess). Result: each restart spawns a fresh
+//   daemon while the previous one stays bound to its ULID-suffixed pipe
+//   only the new boot has cleared. After a few reloads `tasklist` shows
+//   N stray `ccsm-daemon` PIDs.
+//
+//   POSIX is mostly fine because SIGTERM does propagate, but the same
+//   bug class shows up if tsx exits abnormally between signal delivery
+//   and the daemon's graceful-shutdown handler completing — the daemon
+//   never sees the signal and is now orphaned (re-parented to PID 1).
+//
+// Fix scope (DEV ONLY):
+//   - Production daemon lifecycle is OWNED by the supervisor process
+//     (electron/daemon/supervisor.ts). v0.3 dogfood criterion #1
+//     ("daemon survives Electron close") REQUIRES the prod daemon to
+//     outlive its parent — so this watchdog MUST be gated behind
+//     `CCSM_DAEMON_DEV=1` and never run in a packaged build.
+//   - In dev, nodemon (or its tsx child) IS the desired lifecycle
+//     anchor: when it dies, the daemon should die too, otherwise the
+//     next nodemon restart leaks.
+//
+// Strategy:
+//   - On boot, capture `process.ppid`. Every `intervalMs` (default
+//     500ms — fast enough to feel instant during nodemon iteration,
+//     slow enough to be free), probe the parent with `process.kill(ppid, 0)`.
+//     The signal-0 trick is documented Node behaviour: it tests
+//     existence/permission without actually delivering a signal.
+//   - If the probe throws ESRCH → parent is gone → exit immediately.
+//   - Other errors (EPERM — uncommon, would mean ppid was recycled to
+//     a process we can't see) are logged once and treated as "still
+//     alive" so we don't false-positive kill ourselves.
+//
+// Single Responsibility (per dev.md §2):
+//   - Pure DECIDER + minimal SINK. The deciding function `checkParent`
+//     takes (`ppid`, `kill`-injectable) and returns
+//     `'alive' | 'gone' | 'unknown'`. The factory `startDevParentWatchdog`
+//     wires it to a setInterval timer + an `onParentGone` thunk. The
+//     daemon entry passes `() => process.exit(0)` as the thunk.
+//   - No I/O beyond `process.kill(_, 0)` (which is signal-free).
+//
+// What this does NOT do:
+//   - Does not graceful-shutdown the daemon. Dev cycle is destructive
+//     by design — the operator's file save invalidated the running
+//     code. A 5s graceful shutdown would just delay the next nodemon
+//     boot. Production graceful shutdown stays untouched (it runs in
+//     the SIGTERM handler, which the supervisor still drives).
+//   - Does not replace the SIGTERM handler in `daemon/src/index.ts`.
+//     If the signal DOES make it through (POSIX happy path), graceful
+//     shutdown still runs — this watchdog only catches the case where
+//     the signal got lost.
+
+export type ParentProbeOutcome = 'alive' | 'gone' | 'unknown';
+
+export interface CheckParentOptions {
+  /** Override `process.kill` for tests. Default: `process.kill`. */
+  kill?: (pid: number, signal: 0) => void;
+}
+
+/**
+ * Pure decider: probe whether `ppid` is still alive via the documented
+ * `kill(pid, 0)` existence-check trick. Never throws.
+ */
+export function checkParent(ppid: number, opts: CheckParentOptions = {}): ParentProbeOutcome {
+  const kill = opts.kill ?? ((pid: number, signal: 0): void => {
+    process.kill(pid, signal);
+  });
+  try {
+    kill(ppid, 0);
+    return 'alive';
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ESRCH') return 'gone';
+    // EPERM (or anything else) → we cannot prove parent died. Conservative
+    // posture: assume alive so we never self-terminate on a transient
+    // permission glitch (Windows can briefly return EPERM during PID
+    // recycling). The watchdog logs this case once via `onUnknown`.
+    return 'unknown';
+  }
+}
+
+export interface DevParentWatchdogOptions {
+  /** ppid at boot time. Captured by caller so a re-parent does not race. */
+  ppid: number;
+  /** Poll interval in ms. Default 500. */
+  intervalMs?: number;
+  /** Sink: called once when parent transitions to `gone`. */
+  onParentGone: () => void;
+  /** Optional sink: called the first time we see `unknown` (logging hook). */
+  onUnknown?: (ppid: number) => void;
+  /** Test seam — overrides `process.kill`. */
+  kill?: (pid: number, signal: 0) => void;
+  /** Test seam — overrides `setInterval`. */
+  setInterval?: (cb: () => void, ms: number) => NodeJS.Timeout;
+  /** Test seam — overrides `clearInterval`. */
+  clearInterval?: (handle: NodeJS.Timeout) => void;
+}
+
+export interface DevParentWatchdogHandle {
+  stop: () => void;
+}
+
+/**
+ * Start the dev-mode parent watchdog. Returns a handle whose `stop()`
+ * clears the timer (used by tests; production never stops it — the
+ * watchdog dies with the process it's protecting).
+ *
+ * Idempotent shutdown: `onParentGone` fires AT MOST ONCE even if the
+ * timer somehow re-enters (e.g. test `vi.advanceTimersByTime` past
+ * multiple intervals after the parent has already died).
+ */
+export function startDevParentWatchdog(
+  opts: DevParentWatchdogOptions,
+): DevParentWatchdogHandle {
+  const intervalMs = opts.intervalMs ?? 500;
+  const setIntervalImpl = opts.setInterval ?? setInterval;
+  const clearIntervalImpl = opts.clearInterval ?? clearInterval;
+  let fired = false;
+  let unknownLogged = false;
+
+  const tick = (): void => {
+    if (fired) return;
+    const outcome = checkParent(opts.ppid, opts.kill ? { kill: opts.kill } : {});
+    if (outcome === 'gone') {
+      fired = true;
+      clearIntervalImpl(handle);
+      opts.onParentGone();
+      return;
+    }
+    if (outcome === 'unknown' && !unknownLogged) {
+      unknownLogged = true;
+      opts.onUnknown?.(opts.ppid);
+    }
+  };
+
+  const handle = setIntervalImpl(tick, intervalMs);
+  // Don't keep the event loop alive solely for this watchdog — the
+  // daemon has its own reasons (sockets, sessions). When everything
+  // else closes, this should not pin us.
+  if (typeof (handle as NodeJS.Timeout).unref === 'function') {
+    (handle as NodeJS.Timeout).unref();
+  }
+
+  return {
+    stop: () => {
+      if (fired) return;
+      fired = true;
+      clearIntervalImpl(handle);
+    },
+  };
+}


### PR DESCRIPTION
## Reproduction (Task #25)

In `npm run dev` (`scripts/dev-watch.ts` -> nodemon -> tsx -> daemon), edit any file under `daemon/src/`. nodemon sends SIGTERM to its tsx child, then respawns. After a few file saves on Windows:

```
> tasklist | findstr node
node.exe    23444    Console    1    180,000 K
node.exe    23512    Console    1    178,000 K
node.exe    23998    Console    1    181,000 K
node.exe    24112    Console    1    179,000 K
node.exe    24216    Console    1    180,000 K   <- only this one is wired to nodemon
```

The previous 4 daemons are stray.

## Root cause

nodemon's `signal: SIGTERM` (per `nodemon.daemon.json`) is delivered to its direct child = `tsx`. tsx then spawns the actual node process running `daemon/src/index.ts`. Two failure modes:

1. **Windows** -- Node has no real SIGTERM. Even when nodemon believes it sent the signal, the inner Node child receives nothing and keeps running. nodemon then spawns a fresh tsx -> fresh daemon, leaking the previous one.
2. **POSIX** -- if tsx exits between signal delivery and the daemon's async graceful-shutdown completing, the daemon never observes the signal and gets re-parented to PID 1.

## Fix

Install a parent-PID watchdog inside the daemon, gated behind `CCSM_DAEMON_DEV=1`. Every 500ms the daemon calls `process.kill(ppid, 0)` (the documented signal-0 existence check). When the parent goes away, the daemon runs the same shutdown path as the SIGTERM handler and exits cleanly.

Decision matrix:

| `kill(ppid, 0)` result | Outcome | Action |
|---|---|---|
| no throw | `alive` | continue |
| throw with `code === 'ESRCH'` | `gone` | fire `onParentGone` once, exit |
| throw with `code === 'EPERM'` or other | `unknown` | log once, continue (conservative -- never self-kill on transient perms) |

## Production safety (v0.3 dogfood criterion #1)

The watchdog is **dev-only**. Production lifecycle is owned by the supervisor in `electron/daemon/supervisor.ts`, which deliberately keeps the daemon alive past Electron exit (criterion #1: "daemon survives Electron close"). `CCSM_DAEMON_DEV` is set only by `nodemon.daemon.json` and `dev:app` -- packaged builds never set it, so the watchdog is dead code in prod.

## Single Responsibility

- `checkParent(ppid, opts)` -- pure decider. `(ppid, kill?) -> 'alive' | 'gone' | 'unknown'`. No I/O beyond signal-0.
- `startDevParentWatchdog(opts)` -- scheduler sink. Wires `checkParent` to `setInterval`, fires the caller-supplied `onParentGone` thunk at most once. All scheduling primitives are injectable seams.
- The boot wiring in `daemon/src/index.ts` is the only place that knows "in dev, parent gone -> run shutdown handler then exit". The module itself is policy-free.

## Tests

8 vitest cases in `daemon/src/lifecycle/__tests__/dev-parent-watchdog.test.ts` cover the decider matrix, idempotency (fire-once + stop()), the EPERM rate-limited log, and the default 500ms interval. All passing locally:

```
 Test Files  1 passed (1)
      Tests  8 passed (8)
   Duration  2.43s
```

Typecheck: `npx tsc --noEmit -p daemon/tsconfig.json` clean.

## Reverse-verify

The new watchdog module's decider path (ESRCH -> exit) is covered by unit tests with an injected `kill` seam; with the module deleted, those tests fail to import. The integration-level reverse-verify (manual `kill <nodemon-pid>` -> daemon exits within ~500ms vs leaks indefinitely) is observable via the new log line `daemon.dev.parent-gone`. With the wiring in `daemon/src/index.ts` removed, `kill <nodemon-pid>` does not bring down the daemon and `tasklist`/`ps` shows the orphan. With it restored the daemon exits cleanly.

## Out of scope

- Changing `nodemon.daemon.json` -- keeping `signal: SIGTERM` so the POSIX happy path still runs the daemon's graceful shutdown handler before the watchdog timer can fire.
- Production supervisor restart logic.
- The cross-worktree pipe collision (Task #24) -- orthogonal; that prevents two parallel pool daemons from colliding on the same pipe, this prevents one nodemon cycle from leaking N stray daemons.

## Note on environment

This branch was built in `pool-1`, which during execution was concurrently being modified by another agent (Task #24, editing `daemon/src/sockets/runtime-root.ts` to mix cwd into `userHash`). The commit was rebuilt against a clean `origin/working` checkout to ensure the diff is exactly what is in the commit and nothing leaked from the cohabiting task.
