### PR TITLE
feat(daemon): envelope adapter for v0.3 IPC framing

### DIFF
--- a/daemon/src/envelope/__tests__/adapter.test.ts
+++ b/daemon/src/envelope/__tests__/adapter.test.ts
@@ -1,0 +1,352 @@
+// Daemon-side envelope adapter tests (Task #28 / B7a).
+//
+// Test cases cover the four spec-mandated scenarios from the task brief:
+//   1. Framing happy path (well-formed frame -> dispatcher -> reply byte-equal
+//      decodes back to `{ id, ok: true, value, ack_source }`).
+//   2. Truncated read (one frame split across multiple `data` events;
+//      dispatcher only fires once after the second chunk arrives).
+//   3. Oversized message (header claiming > 16 MiB -> synthetic
+//      `envelope_too_large` reply with `id: 0` + socket destroyed).
+//   4. Malformed JSON header (valid framing, garbage header bytes -> synthetic
+//      `schema_violation` reply + socket destroyed).
+//
+// Plus a small clutch of safety tests: schema-violation on missing routing
+// fields; dispatcher rejections passed through; multiple frames in one chunk
+// are all dispatched.
+//
+// Spec citations:
+//   - frag-3.4.1 §3.4.1.a (oversize rejection sequence)
+//   - frag-3.4.1 §3.4.1.c (header schema)
+//   - frag-3.4.1 §3.4.1.d (schema_violation + destroy)
+
+import { describe, expect, it, vi } from 'vitest';
+import { Buffer } from 'node:buffer';
+import { PassThrough } from 'node:stream';
+
+import { mountEnvelopeAdapter } from '../adapter.js';
+import { decodeFrame, encodeFrame, ENVELOPE_LIMITS } from '../envelope.js';
+import type { Dispatcher, DispatchResult } from '../../dispatcher.js';
+
+// ---------------------------------------------------------------------------
+// Test harness
+// ---------------------------------------------------------------------------
+
+/**
+ * A minimal Duplex stand-in: writes from the adapter land in `outbound`,
+ * `feed()` simulates inbound `data` events, and `destroy()` flips a flag.
+ *
+ * Using two `PassThrough`s would also work but a thin shim keeps assertions
+ * direct (we look at `outbound[0]` rather than awaiting `data` events on a
+ * second stream).
+ */
+function makeFakeSocket(): {
+  socket: PassThrough & { destroyedByAdapter: boolean };
+  feed: (b: Buffer) => void;
+  outbound: Buffer[];
+  destroyed: () => boolean;
+} {
+  const sock = new PassThrough() as PassThrough & { destroyedByAdapter: boolean };
+  sock.destroyedByAdapter = false;
+  const outbound: Buffer[] = [];
+  // Capture writes by overriding write to push the chunks into outbound.
+  // (PassThrough would otherwise loop them back to the readable side and
+  // the adapter would re-parse its own replies.)
+  sock.write = ((chunk: unknown) => {
+    outbound.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+    return true;
+  }) as typeof sock.write;
+  const origDestroy = sock.destroy.bind(sock);
+  sock.destroy = ((err?: Error) => {
+    sock.destroyedByAdapter = true;
+    return origDestroy(err);
+  }) as typeof sock.destroy;
+  return {
+    socket: sock,
+    feed: (b: Buffer) => sock.emit('data', b),
+    outbound,
+    destroyed: () => sock.destroyedByAdapter,
+  };
+}
+
+/** Build a stub dispatcher whose `dispatch` returns `result` and records calls. */
+function makeStubDispatcher(
+  result: DispatchResult | ((m: string, r: unknown) => DispatchResult | Promise<DispatchResult>),
+): {
+  dispatcher: Pick<Dispatcher, 'dispatch'>;
+  calls: { method: string; req: unknown }[];
+} {
+  const calls: { method: string; req: unknown }[] = [];
+  const dispatcher: Pick<Dispatcher, 'dispatch'> = {
+    dispatch: vi.fn(async (method, req) => {
+      calls.push({ method, req });
+      return typeof result === 'function' ? result(method, req) : result;
+    }),
+  };
+  return { dispatcher, calls };
+}
+
+const okResult: DispatchResult = { ok: true, value: { hello: 'world' }, ack_source: 'handler' };
+const silentLogger = { warn: vi.fn() };
+
+function buildJsonFrame(header: object): Buffer {
+  return encodeFrame({ headerJson: Buffer.from(JSON.stringify(header), 'utf8') });
+}
+
+function decodeJsonHeader(frame: Buffer): Record<string, unknown> {
+  const d = decodeFrame(frame);
+  return JSON.parse(d.headerJson.toString('utf8')) as Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Happy path
+// ---------------------------------------------------------------------------
+
+describe('mountEnvelopeAdapter — happy path', () => {
+  it('decodes one well-formed frame, dispatches, and writes the encoded reply', async () => {
+    const { socket, feed, outbound, destroyed } = makeFakeSocket();
+    const { dispatcher, calls } = makeStubDispatcher(okResult);
+
+    mountEnvelopeAdapter({ socket, dispatcher, logger: silentLogger });
+
+    const frame = buildJsonFrame({
+      id: 42,
+      method: '/healthz',
+      payloadType: 'json',
+      payloadLen: 0,
+      traceId: '01HZZZTESTULIDXXXXXXXXXXXX',
+    });
+    feed(frame);
+
+    // Let the microtask queue drain so the dispatcher promise resolves.
+    await new Promise((r) => setImmediate(r));
+
+    expect(calls.length).toBe(1);
+    expect(calls[0]!.method).toBe('/healthz');
+    expect(outbound.length).toBe(1);
+    const reply = decodeJsonHeader(outbound[0]!);
+    expect(reply.id).toBe(42);
+    expect(reply.ok).toBe(true);
+    expect(reply.value).toEqual({ hello: 'world' });
+    expect(reply.ack_source).toBe('handler');
+    expect(destroyed()).toBe(false);
+  });
+
+  it('handles multiple frames in a single chunk', async () => {
+    const { socket, feed, outbound } = makeFakeSocket();
+    const { dispatcher, calls } = makeStubDispatcher(okResult);
+    mountEnvelopeAdapter({ socket, dispatcher, logger: silentLogger });
+
+    const a = buildJsonFrame({ id: 1, method: '/healthz', payloadType: 'json', payloadLen: 0 });
+    const b = buildJsonFrame({ id: 2, method: '/stats', payloadType: 'json', payloadLen: 0 });
+    feed(Buffer.concat([a, b]));
+    await new Promise((r) => setImmediate(r));
+
+    expect(calls.map((c) => c.method)).toEqual(['/healthz', '/stats']);
+    expect(outbound.length).toBe(2);
+    expect(decodeJsonHeader(outbound[0]!).id).toBe(1);
+    expect(decodeJsonHeader(outbound[1]!).id).toBe(2);
+  });
+
+  it('forwards dispatcher error replies as { ok:false, error } envelopes without destroying', async () => {
+    const { socket, feed, outbound, destroyed } = makeFakeSocket();
+    const errResult: DispatchResult = {
+      ok: false,
+      error: { code: 'NOT_ALLOWED', method: 'session.list', message: 'forbidden' },
+    };
+    const { dispatcher } = makeStubDispatcher(errResult);
+    mountEnvelopeAdapter({ socket, dispatcher, logger: silentLogger });
+
+    feed(buildJsonFrame({ id: 7, method: 'session.list', payloadType: 'json', payloadLen: 0 }));
+    await new Promise((r) => setImmediate(r));
+
+    expect(outbound.length).toBe(1);
+    const reply = decodeJsonHeader(outbound[0]!);
+    expect(reply.id).toBe(7);
+    expect(reply.ok).toBe(false);
+    expect((reply.error as { code: string }).code).toBe('NOT_ALLOWED');
+    // Errors do NOT destroy — only protocol violations do.
+    expect(destroyed()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Truncated read
+// ---------------------------------------------------------------------------
+
+describe('mountEnvelopeAdapter — truncated read', () => {
+  it('does not dispatch until the second chunk arrives', async () => {
+    const { socket, feed, outbound } = makeFakeSocket();
+    const { dispatcher, calls } = makeStubDispatcher(okResult);
+    mountEnvelopeAdapter({ socket, dispatcher, logger: silentLogger });
+
+    const frame = buildJsonFrame({ id: 99, method: '/healthz', payloadType: 'json', payloadLen: 0 });
+    // Split midway through the header bytes — neither half is a complete frame.
+    const split = Math.floor(frame.length / 2);
+    feed(frame.subarray(0, split));
+    await new Promise((r) => setImmediate(r));
+
+    expect(calls.length).toBe(0);
+    expect(outbound.length).toBe(0);
+
+    feed(frame.subarray(split));
+    await new Promise((r) => setImmediate(r));
+
+    expect(calls.length).toBe(1);
+    expect(calls[0]!.method).toBe('/healthz');
+    expect(outbound.length).toBe(1);
+    expect(decodeJsonHeader(outbound[0]!).id).toBe(99);
+  });
+
+  it('handles a one-byte-at-a-time trickle without crashing', async () => {
+    const { socket, feed, outbound } = makeFakeSocket();
+    const { dispatcher, calls } = makeStubDispatcher(okResult);
+    mountEnvelopeAdapter({ socket, dispatcher, logger: silentLogger });
+
+    const frame = buildJsonFrame({ id: 5, method: '/healthz', payloadType: 'json', payloadLen: 0 });
+    for (let i = 0; i < frame.length; i++) {
+      feed(frame.subarray(i, i + 1));
+    }
+    await new Promise((r) => setImmediate(r));
+
+    expect(calls.length).toBe(1);
+    expect(outbound.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Oversized message
+// ---------------------------------------------------------------------------
+
+describe('mountEnvelopeAdapter — oversized message', () => {
+  it('writes synthetic envelope_too_large reply with id: 0 and destroys the socket', async () => {
+    const { socket, feed, outbound, destroyed } = makeFakeSocket();
+    const { dispatcher, calls } = makeStubDispatcher(okResult);
+    const logger = { warn: vi.fn() };
+    mountEnvelopeAdapter({ socket, dispatcher, logger, peerPid: 12345 });
+
+    // Hand-craft a 4-byte prefix declaring 16 MiB + 1 byte payload (just the
+    // prefix is enough — the cap-check fires before any body bytes are read).
+    const oversize = ENVELOPE_LIMITS.MAX_PAYLOAD_BYTES + 1;
+    const header = Buffer.alloc(4);
+    // Nibble 0x0 (v0.3) in high bits, length in low 28 bits.
+    header.writeUInt32BE(((0x0 & 0x0f) << 28) | (oversize & 0x0fffffff), 0);
+    feed(header);
+    await new Promise((r) => setImmediate(r));
+
+    expect(calls.length).toBe(0);
+    expect(outbound.length).toBe(1);
+    const reply = decodeJsonHeader(outbound[0]!);
+    expect(reply.id).toBe(0);
+    expect(reply.ok).toBe(false);
+    expect((reply.error as { code: string }).code).toBe('envelope_too_large');
+    expect(destroyed()).toBe(true);
+    // Forensic warn line emitted with peerPid + len per spec §3.4.1.a.
+    const warnedOversize = (
+      logger.warn.mock.calls as Array<[Record<string, unknown>, string]>
+    ).some(([obj, msg]) => msg === 'envelope_oversize' && obj.peerPid === 12345 && obj.len === oversize);
+    expect(warnedOversize).toBe(true);
+  });
+
+  it('rejects unknown frame-version nibble before the cap-check (spec §3.4.1.a step 2)', async () => {
+    const { socket, feed, outbound, destroyed } = makeFakeSocket();
+    const { dispatcher, calls } = makeStubDispatcher(okResult);
+    mountEnvelopeAdapter({ socket, dispatcher, logger: silentLogger });
+
+    // Nibble 0x1 (would be v0.4 protobuf) against a v0.3 daemon: reject with
+    // UNSUPPORTED_FRAME_VERSION even if the masked length looks fine.
+    const header = Buffer.alloc(4);
+    header.writeUInt32BE(((0x1 & 0x0f) << 28) | (16 & 0x0fffffff), 0);
+    feed(header);
+    await new Promise((r) => setImmediate(r));
+
+    expect(calls.length).toBe(0);
+    expect(outbound.length).toBe(1);
+    const reply = decodeJsonHeader(outbound[0]!);
+    expect((reply.error as { code: string }).code).toBe('UNSUPPORTED_FRAME_VERSION');
+    expect(destroyed()).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Malformed JSON header
+// ---------------------------------------------------------------------------
+
+describe('mountEnvelopeAdapter — malformed JSON', () => {
+  it('writes schema_violation reply and destroys the socket on garbage header bytes', async () => {
+    const { socket, feed, outbound, destroyed } = makeFakeSocket();
+    const { dispatcher, calls } = makeStubDispatcher(okResult);
+    mountEnvelopeAdapter({ socket, dispatcher, logger: silentLogger });
+
+    // Build a syntactically valid frame whose header bytes are not JSON.
+    const garbage = Buffer.from('not json at all', 'utf8');
+    const frame = encodeFrame({ headerJson: garbage });
+    feed(frame);
+    await new Promise((r) => setImmediate(r));
+
+    expect(calls.length).toBe(0);
+    expect(outbound.length).toBe(1);
+    const reply = decodeJsonHeader(outbound[0]!);
+    expect(reply.id).toBe(0);
+    expect((reply.error as { code: string }).code).toBe('schema_violation');
+    expect(destroyed()).toBe(true);
+  });
+
+  it('rejects a header that parses as JSON but is missing routing fields', async () => {
+    const { socket, feed, outbound, destroyed } = makeFakeSocket();
+    const { dispatcher, calls } = makeStubDispatcher(okResult);
+    mountEnvelopeAdapter({ socket, dispatcher, logger: silentLogger });
+
+    // Valid JSON, missing `method` (and id type wrong).
+    feed(buildJsonFrame({ id: 'not-a-number', foo: 'bar' }));
+    await new Promise((r) => setImmediate(r));
+
+    expect(calls.length).toBe(0);
+    expect(outbound.length).toBe(1);
+    const reply = decodeJsonHeader(outbound[0]!);
+    expect((reply.error as { code: string }).code).toBe('schema_violation');
+    expect(destroyed()).toBe(true);
+  });
+
+  it('rejects a header missing `method` while echoing back a valid `id`', async () => {
+    const { socket, feed, outbound, destroyed } = makeFakeSocket();
+    const { dispatcher } = makeStubDispatcher(okResult);
+    mountEnvelopeAdapter({ socket, dispatcher, logger: silentLogger });
+
+    feed(buildJsonFrame({ id: 33 }));
+    await new Promise((r) => setImmediate(r));
+
+    expect(outbound.length).toBe(1);
+    const reply = decodeJsonHeader(outbound[0]!);
+    expect(reply.id).toBe(33);
+    expect((reply.error as { code: string }).code).toBe('schema_violation');
+    expect(destroyed()).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dispatcher exception handling
+// ---------------------------------------------------------------------------
+
+describe('mountEnvelopeAdapter — handler exceptions', () => {
+  it('emits an INTERNAL error reply when the dispatcher throws (non-typed)', async () => {
+    const { socket, feed, outbound, destroyed } = makeFakeSocket();
+    const dispatcher: Pick<Dispatcher, 'dispatch'> = {
+      dispatch: vi.fn(async () => {
+        throw new Error('boom');
+      }),
+    };
+    const logger = { warn: vi.fn() };
+    mountEnvelopeAdapter({ socket, dispatcher, logger });
+
+    feed(buildJsonFrame({ id: 17, method: '/healthz', payloadType: 'json', payloadLen: 0 }));
+    await new Promise((r) => setImmediate(r));
+
+    expect(outbound.length).toBe(1);
+    const reply = decodeJsonHeader(outbound[0]!);
+    expect(reply.id).toBe(17);
+    expect((reply.error as { code: string }).code).toBe('INTERNAL');
+    // Socket NOT destroyed — handler exception is a per-call failure, not a
+    // protocol violation. The connection stays usable for the next RPC.
+    expect(destroyed()).toBe(false);
+  });
+});

--- a/daemon/src/envelope/adapter.ts
+++ b/daemon/src/envelope/adapter.ts
@@ -1,0 +1,382 @@
+// Daemon-side envelope adapter (B7a — Task #28).
+//
+// Bridges raw Duplex sockets (control-socket / data-socket transports) to the
+// pure {@link Dispatcher} via length-prefixed JSON envelope framing per spec
+// frag-3.4.1 §3.4.1.a (frame-version nibble + 16 MiB cap), §3.4.1.c (header
+// + payload split), §3.4.1.d (schema validation hook = JSON-parse + minimum
+// routing-field shape check).
+//
+// Spec citations:
+//   - docs/superpowers/specs/v0.3-fragments/frag-3.4.1-envelope-hardening.md
+//     §3.4.1.a frame-header parsing order (already enforced by `decodeFrame`).
+//     §3.4.1.a oversize rejection sequence: warn -> write synthetic
+//                `{ id: 0, error: { code: "envelope_too_large", ... } }` reply
+//                (best-effort) -> `socket.destroy()`.
+//     §3.4.1.c header schema (`id` + `method` + `payloadType` + `payloadLen`).
+//     §3.4.1.d malformed/unknown-shape header -> `{ id, error: { code:
+//                "schema_violation" } }` -> `socket.destroy()`.
+//   - PR-context: scope is the wire-up gap noted in `daemon/src/index.ts`
+//     (lines ~270-305) "Envelope adapter wiring is T-future". This adapter is
+//     that wiring. It is intentionally MINIMAL: it owns framing + dispatch +
+//     reply; the dispatcher (`daemon/src/dispatcher.ts`) owns method routing,
+//     and the per-handler / per-interceptor work (HMAC, deadline, hello-gate,
+//     migration-gate, trace-id fan-out) is composed into the dispatcher by
+//     other tasks. This module knows nothing about those.
+//
+// Single Responsibility (producer / decider / sink, per dev contract §2):
+//   - PRODUCER: socket `data` events. Accumulates bytes in a per-connection
+//     buffer until at least one full frame is available.
+//   - DECIDER: `decodeFrame` (pure) + `JSON.parse(headerJson)` + minimum
+//     routing-field validation. Decides the frame is well-formed enough to
+//     dispatch; otherwise emits the appropriate error envelope.
+//   - SINK: writes the reply envelope back to the socket (`socket.write`).
+//     Never mutates dispatcher state, never owns timers.
+//
+// What this module deliberately does NOT do (out of scope per Task #28):
+//   - Binary trailer round-trip in either direction. Reply payload is JSON-
+//     only in v0.3.x today (no daemon->client handler returns binary). The
+//     decode side preserves the trailer Buffer and forwards it to handlers via
+//     `req.payload` so a future binary handler can consume it; reply encoding
+//     stays pure-JSON. When binary replies arrive we'll extend `writeReply` —
+//     no rework on this side.
+//   - HMAC handshake / hello-gate / migration-gate / interceptor pipeline.
+//     Those are layered into the dispatcher by their own modules
+//     (`hello-interceptor.ts`, `migration-gate-interceptor.ts`,
+//     `deadline-interceptor.ts`, `hmac.ts`).
+//   - Per-stream chunking, fan-out caching, header-skeleton fast path
+//     (§3.4.1.b / §3.4.1.c hot-path optimizations). All v0.4-relevant; v0.3
+//     unblocks #27 (Electron envelope migration) without these.
+//   - Connect-RPC / HTTP/2. Lives in `connect/server.ts`; wholly separate
+//     transport.
+
+import { Buffer } from 'node:buffer';
+import type { Duplex } from 'node:stream';
+
+import { decodeFrame, encodeFrame, EnvelopeError, ENVELOPE_LIMITS } from './envelope.js';
+import type { Dispatcher, DispatchContext } from '../dispatcher.js';
+
+// ---------------------------------------------------------------------------
+// Inbound header shape (minimum routing fields — §3.4.1.c subset)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimum-shape inbound envelope header, post-`JSON.parse`. The full spec
+ * §3.4.1.c shape includes `payloadType`, `payloadLen`, `stream`, `traceId`,
+ * `headers` etc.; the adapter only inspects fields it needs to route and
+ * reply. Unknown fields are forwarded to the dispatcher untouched (handlers
+ * own per-method validation, §3.4.1.d).
+ */
+interface InboundHeader {
+  /** RPC id; non-negative integer. `0` is reserved for synthetic error replies
+   *  emitted by the adapter (per §3.4.1.a oversize-reply rule). */
+  id: number;
+  /** RPC method name (literal — see §3.4.1.h literal-vs-namespace lock). */
+  method: string;
+  /** Optional Crockford ULID; the dispatcher / handlers may consume it. The
+   *  adapter does NOT validate the ULID regex (that's the trace-id interceptor
+   *  per §3.4.1.c round-3 CC-2). */
+  traceId?: string;
+}
+
+/** Minimal type guard for the routing fields above. Returns `false` for any
+ *  non-object, missing `id`/`method`, or wrong-typed fields — those become
+ *  `schema_violation` per §3.4.1.d. */
+function isWellFormedHeader(v: unknown): v is InboundHeader {
+  if (v === null || typeof v !== 'object') return false;
+  const o = v as Record<string, unknown>;
+  if (typeof o.id !== 'number' || !Number.isInteger(o.id) || o.id < 0) return false;
+  if (typeof o.method !== 'string' || o.method.length === 0) return false;
+  if (o.traceId !== undefined && typeof o.traceId !== 'string') return false;
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Reply envelope helpers
+// ---------------------------------------------------------------------------
+
+/** Build a `{ id, ok: true, value }` reply. Pure-JSON header, empty trailer. */
+function encodeOkReply(id: number, value: unknown, ackSource: 'handler' | 'dispatcher'): Buffer {
+  const header = {
+    id,
+    ok: true as const,
+    value,
+    ack_source: ackSource,
+    payloadType: 'json' as const,
+    payloadLen: 0,
+  };
+  return encodeFrame({
+    headerJson: Buffer.from(JSON.stringify(header), 'utf8'),
+  });
+}
+
+/** Build a `{ id, ok: false, error: { code, message } }` reply. */
+function encodeErrorReply(
+  id: number,
+  code: string,
+  message: string,
+  extras?: Record<string, unknown>,
+): Buffer {
+  const error: Record<string, unknown> = { code, message };
+  if (extras) {
+    for (const [k, v] of Object.entries(extras)) error[k] = v;
+  }
+  const header = {
+    id,
+    ok: false as const,
+    error,
+    payloadType: 'json' as const,
+    payloadLen: 0,
+  };
+  return encodeFrame({
+    headerJson: Buffer.from(JSON.stringify(header), 'utf8'),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Adapter mount surface
+// ---------------------------------------------------------------------------
+
+/**
+ * Logger surface used by the adapter for forensic warn lines. Mirrors the
+ * shape `data-socket.ts` / `control-socket.ts` already accept so callers can
+ * pass the same pino child.
+ */
+export interface AdapterLogger {
+  warn(obj: Record<string, unknown>, msg: string): void;
+}
+
+export interface MountEnvelopeAdapterOptions {
+  /** Pre-accepted Duplex socket (one per connection). Adapter takes ownership
+   *  of the `data` / `error` / `close` listeners; caller MUST NOT register
+   *  competing parsers. */
+  readonly socket: Duplex;
+  /** Pure dispatcher (supervisor-plane on control-socket, data-plane on
+   *  data-socket). The adapter calls `dispatcher.dispatch(method, value, ctx)`
+   *  per inbound frame. */
+  readonly dispatcher: Pick<Dispatcher, 'dispatch'>;
+  /** Best-effort warn sink. Defaults to a `console.warn` adapter so the
+   *  module works in tests without the daemon's pino child. */
+  readonly logger?: AdapterLogger;
+  /** Optional forensic peer-pid (from §3.1.1 peer-cred lookup) for the
+   *  `envelope_oversize` warn line per §3.4.1.a. */
+  readonly peerPid?: number;
+  /** Optional forensic peer label (e.g. `'control-socket'` / `'data-socket'`)
+   *  for log correlation. */
+  readonly peer?: string;
+}
+
+/**
+ * Mount the envelope adapter onto a freshly-accepted socket. Returns nothing —
+ * the adapter installs its own listeners and lives until the socket closes.
+ *
+ * Behavior summary:
+ *   - Accumulates inbound bytes; loops `decodeFrame` until the buffer is short
+ *     of a full frame (truncated reads are normal — wait for more data).
+ *   - On any other `EnvelopeError` (oversize, unsupported version, corrupt
+ *     headerLen): warn + best-effort error reply with `id: 0` + destroy.
+ *   - On malformed JSON header (`JSON.parse` throws): warn + `schema_violation`
+ *     reply (best-effort, `id: 0` because we cannot trust any field) + destroy.
+ *   - On a well-formed header that fails `isWellFormedHeader`: warn +
+ *     `schema_violation` reply + destroy.
+ *   - On a well-formed header: dispatch to `dispatcher.dispatch(method, value,
+ *     ctx)`. The `value` forwarded to handlers is the parsed header itself
+ *     (JSON-frame mode) or `{ ...header, payload }` (binary-frame mode — the
+ *     trailer is exposed as `payload` so a future binary handler can consume
+ *     it). Reply encoded as `{ id, ok, value | error }`.
+ */
+export function mountEnvelopeAdapter(opts: MountEnvelopeAdapterOptions): void {
+  const { socket, dispatcher, peerPid, peer } = opts;
+  const logger = opts.logger ?? defaultLogger();
+
+  // Per-connection buffer accumulator. We use Buffer.concat over a small array
+  // so a slow trickle of 1-byte writes does not become quadratic; for v0.3
+  // dogfood load (<= a few subscribers) this is comfortably within budget.
+  const pending: Buffer[] = [];
+  let pendingBytes = 0;
+  let destroyed = false;
+
+  function destroy(reason: string, extras?: Record<string, unknown>): void {
+    if (destroyed) return;
+    destroyed = true;
+    logger.warn(
+      { event: 'envelope-adapter.destroy', reason, peer, peerPid, ...(extras ?? {}) },
+      `envelope adapter destroying socket: ${reason}`,
+    );
+    try {
+      socket.destroy();
+    } catch {
+      // best-effort
+    }
+  }
+
+  function tryWrite(buf: Buffer): void {
+    // Best-effort reply per §3.4.1.a — never throw out of the adapter on a
+    // half-closed write. The `socket.destroy()` that follows is the
+    // authoritative cleanup; this write is an *advisory* error frame.
+    try {
+      socket.write(buf);
+    } catch {
+      // swallow — the socket is already going away
+    }
+  }
+
+  function processBuffer(): void {
+    // Loop until the buffer is too short for a full frame OR we destroy.
+    while (!destroyed && pendingBytes >= ENVELOPE_LIMITS.PREFIX_LEN) {
+      const head = pending.length === 1 ? pending[0]! : Buffer.concat(pending, pendingBytes);
+      // Re-coalesce the pending list to a single chunk for slicing.
+      if (pending.length !== 1) {
+        pending.length = 0;
+        pending.push(head);
+      }
+
+      let decoded: ReturnType<typeof decodeFrame>;
+      try {
+        decoded = decodeFrame(head);
+      } catch (err) {
+        if (err instanceof EnvelopeError) {
+          if (err.code === 'truncated_frame') {
+            // Wait for more bytes — this is the happy "partial read" path.
+            return;
+          }
+          // Oversize / unsupported nibble / corrupt header length — synthetic
+          // reply per §3.4.1.a then destroy. Reply MUST use id: 0 because we
+          // cannot trust any header field on a frame we couldn't decode.
+          if (err.code === 'envelope_too_large') {
+            logger.warn(
+              { event: 'envelope-adapter.envelope_oversize', peer, peerPid, len: err.len },
+              'envelope_oversize',
+            );
+          }
+          tryWrite(
+            encodeErrorReply(
+              0,
+              err.code,
+              err.message,
+              err.nibble !== undefined ? { nibble: err.nibble } : undefined,
+            ),
+          );
+          destroy(err.code, { len: err.len, nibble: err.nibble });
+          return;
+        }
+        // Unknown decode error — fail closed.
+        destroy('decode_threw', { err: String(err) });
+        return;
+      }
+
+      // Compute total bytes consumed by this frame: 4-byte prefix +
+      // 2-byte headerLen field + headerJson + payload.
+      const frameLen =
+        ENVELOPE_LIMITS.PREFIX_LEN +
+        ENVELOPE_LIMITS.HEADER_LEN_FIELD +
+        decoded.headerJson.length +
+        decoded.payload.length;
+
+      // Slice the consumed bytes off `head` and keep the remainder for the
+      // next iteration. Subarray is zero-copy; we only allocate when the next
+      // `data` event arrives and we re-coalesce.
+      if (frameLen >= head.length) {
+        pending.length = 0;
+        pendingBytes = 0;
+      } else {
+        const remainder = head.subarray(frameLen);
+        pending.length = 0;
+        pending.push(remainder);
+        pendingBytes = remainder.length;
+      }
+
+      // Parse + validate header. Either failure -> schema_violation + destroy.
+      let headerObj: unknown;
+      try {
+        headerObj = JSON.parse(decoded.headerJson.toString('utf8'));
+      } catch {
+        tryWrite(encodeErrorReply(0, 'schema_violation', 'malformed JSON header'));
+        destroy('schema_violation_parse');
+        return;
+      }
+      if (!isWellFormedHeader(headerObj)) {
+        // We may know `id` if it parsed but failed shape — best-effort echo.
+        const maybeId =
+          headerObj && typeof headerObj === 'object' && typeof (headerObj as { id?: unknown }).id === 'number'
+            ? (headerObj as { id: number }).id
+            : 0;
+        tryWrite(
+          encodeErrorReply(maybeId, 'schema_violation', 'header missing required routing fields'),
+        );
+        destroy('schema_violation_shape');
+        return;
+      }
+
+      // Dispatch. `value` forwarded to handlers includes the trailer when
+      // present so a future binary handler can consume it; the dispatcher
+      // itself treats it as opaque.
+      const requestValue: unknown =
+        decoded.payload.length > 0 ? { ...headerObj, payload: decoded.payload } : headerObj;
+
+      const ctx: DispatchContext =
+        headerObj.traceId !== undefined ? { traceId: headerObj.traceId } : {};
+
+      const id = headerObj.id;
+      const method = headerObj.method;
+
+      // Fire-and-forget — handlers may take time. Per spec §3.4.1.b unary
+      // frames may interleave between sub-chunks, so per-connection FIFO is
+      // NOT required for correctness. Dispatch async and let promises race.
+      void dispatcher.dispatch(method, requestValue, ctx).then(
+        (result) => {
+          if (destroyed) return;
+          if (result.ok) {
+            tryWrite(encodeOkReply(id, result.value, result.ack_source));
+          } else {
+            tryWrite(
+              encodeErrorReply(id, result.error.code, result.error.message, {
+                method: result.error.method,
+              }),
+            );
+          }
+        },
+        (err: unknown) => {
+          if (destroyed) return;
+          // Handler threw (non-stub). Surface as INTERNAL — handlers SHOULD
+          // throw typed errors but we cannot guarantee discipline at this
+          // boundary. The synthetic reply lets the caller fail their RPC
+          // promise instead of timing out.
+          tryWrite(encodeErrorReply(id, 'INTERNAL', String(err)));
+          logger.warn(
+            { event: 'envelope-adapter.handler_threw', peer, peerPid, method, err: String(err) },
+            'handler threw outside the dispatcher contract',
+          );
+        },
+      );
+    }
+  }
+
+  socket.on('data', (chunk: Buffer) => {
+    if (destroyed) return;
+    pending.push(chunk);
+    pendingBytes += chunk.length;
+    processBuffer();
+  });
+
+  socket.on('error', (err: Error) => {
+    // Surface but do not throw out — caller may have its own listener.
+    logger.warn(
+      { event: 'envelope-adapter.socket_error', peer, peerPid, err: String(err) },
+      'socket error',
+    );
+  });
+
+  socket.on('close', () => {
+    destroyed = true;
+    pending.length = 0;
+    pendingBytes = 0;
+  });
+}
+
+function defaultLogger(): AdapterLogger {
+  return {
+    warn: (obj, msg) => {
+      console.warn(`${msg} ${JSON.stringify(obj)}`);
+    },
+  };
+}

--- a/daemon/src/index.ts
+++ b/daemon/src/index.ts
@@ -3,7 +3,8 @@ import pino from 'pino';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { createRequire } from 'node:module';
-import { createSupervisorDispatcher } from './dispatcher.js';
+import { createSupervisorDispatcher, createDataDispatcher } from './dispatcher.js';
+import { mountEnvelopeAdapter } from './envelope/adapter.js';
 import {
   createDaemonShutdownHandler,
   DAEMON_SHUTDOWN_METHOD,
@@ -214,6 +215,17 @@ supervisorDispatcher.register(DAEMON_SHUTDOWN_METHOD, async (req, ctx) => {
 });
 void supervisorDispatcher;
 
+// Task #28 / B7a — daemon-side envelope adapter.
+//
+// Per-plane dispatchers consumed by the envelope adapter mounted on each
+// accepted connection (control-socket -> supervisor plane, data-socket ->
+// data plane). The data dispatcher is bare today; per-method handlers are
+// wired by their owning task slices. The adapter forwards UNKNOWN_METHOD
+// cleanly for any method not yet registered, so this slice is safe to ship
+// before the handlers do.
+const dataDispatcher = createDataDispatcher();
+void dataDispatcher;
+
 // Task #1072 — wire OS-level socket listeners.
 //
 // Before this PR, both `createControlSocketServer` (T14 #676) and
@@ -270,21 +282,19 @@ controlSocket = createControlSocketServer({
     warn: (obj, msg) => logger.warn(obj, msg),
     info: (obj, msg) => logger.info(obj, msg),
   },
-  onConnection: (sock) => {
-    // Envelope adapter wiring is T-future. Until then, every accepted
-    // connection is destroyed loudly so a probe sees "connect succeeded
-    // then peer hung up" rather than a wedge. The transport-level rate
-    // cap (50/s) still fires on a flood; this destroy is per-connection
-    // application-layer cleanup.
-    logger.warn(
-      { event: 'control-socket.connection.no-adapter', address: controlSocket?.address },
-      'control-socket connection accepted but no envelope adapter is wired yet (T-future); destroying',
-    );
-    try {
-      sock.destroy();
-    } catch {
-      // best-effort
-    }
+  onConnection: (sock, peer) => {
+    // Task #28 / B7a -- envelope adapter wires Duplex bytes into the
+    // supervisor dispatcher. Adapter owns per-connection buffer
+    // accumulation, frame decode (envelope/envelope.ts), schema validation
+    // of the routing fields (id, method), and the socket.destroy() +
+    // synthetic error reply on protocol violation per spec §3.4.1.a/d.
+    mountEnvelopeAdapter({
+      socket: sock,
+      dispatcher: supervisorDispatcher,
+      logger: { warn: (obj, msg) => logger.warn(obj, msg) },
+      peer: 'control-socket',
+      ...(peer?.pid !== undefined ? { peerPid: peer.pid } : {}),
+    });
   },
 });
 
@@ -294,16 +304,14 @@ dataSocket = createDataSocketServer({
   logger: {
     warn: (obj, msg) => logger.warn(obj, msg),
   },
-  onConnection: ({ socket }) => {
-    logger.warn(
-      { event: 'data-socket.connection.no-adapter', address: dataSocket?.address() },
-      'data-socket connection accepted but no envelope adapter is wired yet (T-future); destroying',
-    );
-    try {
-      socket.destroy();
-    } catch {
-      // best-effort
-    }
+  onConnection: ({ socket, peer }) => {
+    mountEnvelopeAdapter({
+      socket,
+      dispatcher: dataDispatcher,
+      logger: { warn: (obj, msg) => logger.warn(obj, msg) },
+      peer: 'data-socket',
+      ...(peer?.pid !== undefined ? { peerPid: peer.pid } : {}),
+    });
   },
 });
 


### PR DESCRIPTION
## Summary

Wire the daemon-side envelope adapter that bridges raw `Duplex` sockets (control-socket / data-socket) to the pure `Dispatcher`. Closes the "Envelope adapter wiring is T-future" placeholder noted in `daemon/src/index.ts`.

**Spec**: [`docs/superpowers/specs/v0.3-fragments/frag-3.4.1-envelope-hardening.md`](https://github.com/Jiahui-Gu/ccsm/blob/working/docs/superpowers/specs/v0.3-fragments/frag-3.4.1-envelope-hardening.md)
- §3.4.1.a frame-version nibble + 16 MiB cap rejection sequence
- §3.4.1.c length-prefixed JSON envelope routing fields
- §3.4.1.d `schema_violation` reply + `socket.destroy()`

**Unblocks**: Task #27 (Electron-side envelope migration). Together they close out the daemon-split RPC migration ahead of v0.3 merge.

## Scope (intentionally minimal)

- **New** `daemon/src/envelope/adapter.ts` — `mountEnvelopeAdapter({ socket, dispatcher, logger, peer, peerPid })`. Per-connection buffer accumulation, `decodeFrame` loop, header schema check (`id`/`method`), dispatch + reply encoding. Pure producer/decider/sink split per dev contract §2.
- **New** `daemon/src/envelope/__tests__/adapter.test.ts` — 11 unit tests (see Test plan).
- **`daemon/src/index.ts`** — replace the `destroy with warn` placeholder for both sockets. Control-socket dispatches into `supervisorDispatcher`; data-socket gets a fresh `createDataDispatcher()` (handlers register later via T17–T21 / data-plane RPC slices).

## Out of scope (other slices own these)

- HMAC handshake / hello-gate / migration-gate / deadline / trace-id interceptors — they compose into the dispatcher via their own modules (`hello-interceptor.ts`, `migration-gate-interceptor.ts`, `deadline-interceptor.ts`, `hmac.ts`).
- Binary trailer round-trip in *replies* (no v0.3 daemon RPC returns binary yet); inbound trailers are preserved and forwarded to handlers.
- Per-stream chunking, fan-out caching, header-skeleton fast path (§3.4.1.b / §3.4.1.c hot-path optimizations) — v0.4 territory.

## Test plan

Local: `npx vitest run daemon/src/envelope/__tests__/adapter.test.ts` → `Test Files 1 passed (1) | Tests 11 passed (11)`.
Local: `npx tsc --noEmit -p daemon/tsconfig.json` → clean.
Local: `npx eslint daemon/src/envelope/adapter.ts daemon/src/envelope/__tests__/adapter.test.ts daemon/src/index.ts` → clean.

Cases covered:
- [x] Framing happy path (single frame → dispatch → reply round-trip byte-equal)
- [x] Multiple frames in one chunk all dispatch in order
- [x] Dispatcher error replies forwarded as `{ ok: false, error }` without destroying
- [x] Truncated read: split mid-header, dispatcher only fires after second chunk
- [x] One-byte-at-a-time trickle handled
- [x] Oversized message (16 MiB + 1) → synthetic `envelope_too_large` reply with `id: 0`, socket destroyed, `envelope_oversize` warn line carries `peerPid` + `len`
- [x] Unsupported frame-version nibble rejected before cap-check (spec §3.4.1.a step 2 ordering)
- [x] Malformed JSON header → `schema_violation` reply with `id: 0` + destroy
- [x] Header parses but missing routing fields → `schema_violation` + destroy
- [x] Schema-violation echoes valid `id` when only `method` is missing
- [x] Dispatcher-thrown exception surfaces as `INTERNAL` reply WITHOUT destroying socket (per-call failure ≠ protocol violation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)