### PR TITLE
feat(electron): migrate IPC to socket RPC envelope client

### DIFF
--- a/daemon/src/envelope/__tests__/adapter.test.ts
+++ b/daemon/src/envelope/__tests__/adapter.test.ts
@@ -1,0 +1,352 @@
+// Daemon-side envelope adapter tests (Task #28 / B7a).
+//
+// Test cases cover the four spec-mandated scenarios from the task brief:
+//   1. Framing happy path (well-formed frame -> dispatcher -> reply byte-equal
+//      decodes back to `{ id, ok: true, value, ack_source }`).
+//   2. Truncated read (one frame split across multiple `data` events;
+//      dispatcher only fires once after the second chunk arrives).
+//   3. Oversized message (header claiming > 16 MiB -> synthetic
+//      `envelope_too_large` reply with `id: 0` + socket destroyed).
+//   4. Malformed JSON header (valid framing, garbage header bytes -> synthetic
+//      `schema_violation` reply + socket destroyed).
+//
+// Plus a small clutch of safety tests: schema-violation on missing routing
+// fields; dispatcher rejections passed through; multiple frames in one chunk
+// are all dispatched.
+//
+// Spec citations:
+//   - frag-3.4.1 §3.4.1.a (oversize rejection sequence)
+//   - frag-3.4.1 §3.4.1.c (header schema)
+//   - frag-3.4.1 §3.4.1.d (schema_violation + destroy)
+
+import { describe, expect, it, vi } from 'vitest';
+import { Buffer } from 'node:buffer';
+import { PassThrough } from 'node:stream';
+
+import { mountEnvelopeAdapter } from '../adapter.js';
+import { decodeFrame, encodeFrame, ENVELOPE_LIMITS } from '../envelope.js';
+import type { Dispatcher, DispatchResult } from '../../dispatcher.js';
+
+// ---------------------------------------------------------------------------
+// Test harness
+// ---------------------------------------------------------------------------
+
+/**
+ * A minimal Duplex stand-in: writes from the adapter land in `outbound`,
+ * `feed()` simulates inbound `data` events, and `destroy()` flips a flag.
+ *
+ * Using two `PassThrough`s would also work but a thin shim keeps assertions
+ * direct (we look at `outbound[0]` rather than awaiting `data` events on a
+ * second stream).
+ */
+function makeFakeSocket(): {
+  socket: PassThrough & { destroyedByAdapter: boolean };
+  feed: (b: Buffer) => void;
+  outbound: Buffer[];
+  destroyed: () => boolean;
+} {
+  const sock = new PassThrough() as PassThrough & { destroyedByAdapter: boolean };
+  sock.destroyedByAdapter = false;
+  const outbound: Buffer[] = [];
+  // Capture writes by overriding write to push the chunks into outbound.
+  // (PassThrough would otherwise loop them back to the readable side and
+  // the adapter would re-parse its own replies.)
+  sock.write = ((chunk: unknown) => {
+    outbound.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+    return true;
+  }) as typeof sock.write;
+  const origDestroy = sock.destroy.bind(sock);
+  sock.destroy = ((err?: Error) => {
+    sock.destroyedByAdapter = true;
+    return origDestroy(err);
+  }) as typeof sock.destroy;
+  return {
+    socket: sock,
+    feed: (b: Buffer) => sock.emit('data', b),
+    outbound,
+    destroyed: () => sock.destroyedByAdapter,
+  };
+}
+
+/** Build a stub dispatcher whose `dispatch` returns `result` and records calls. */
+function makeStubDispatcher(
+  result: DispatchResult | ((m: string, r: unknown) => DispatchResult | Promise<DispatchResult>),
+): {
+  dispatcher: Pick<Dispatcher, 'dispatch'>;
+  calls: { method: string; req: unknown }[];
+} {
+  const calls: { method: string; req: unknown }[] = [];
+  const dispatcher: Pick<Dispatcher, 'dispatch'> = {
+    dispatch: vi.fn(async (method, req) => {
+      calls.push({ method, req });
+      return typeof result === 'function' ? result(method, req) : result;
+    }),
+  };
+  return { dispatcher, calls };
+}
+
+const okResult: DispatchResult = { ok: true, value: { hello: 'world' }, ack_source: 'handler' };
+const silentLogger = { warn: vi.fn() };
+
+function buildJsonFrame(header: object): Buffer {
+  return encodeFrame({ headerJson: Buffer.from(JSON.stringify(header), 'utf8') });
+}
+
+function decodeJsonHeader(frame: Buffer): Record<string, unknown> {
+  const d = decodeFrame(frame);
+  return JSON.parse(d.headerJson.toString('utf8')) as Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Happy path
+// ---------------------------------------------------------------------------
+
+describe('mountEnvelopeAdapter — happy path', () => {
+  it('decodes one well-formed frame, dispatches, and writes the encoded reply', async () => {
+    const { socket, feed, outbound, destroyed } = makeFakeSocket();
+    const { dispatcher, calls } = makeStubDispatcher(okResult);
+
+    mountEnvelopeAdapter({ socket, dispatcher, logger: silentLogger });
+
+    const frame = buildJsonFrame({
+      id: 42,
+      method: '/healthz',
+      payloadType: 'json',
+      payloadLen: 0,
+      traceId: '01HZZZTESTULIDXXXXXXXXXXXX',
+    });
+    feed(frame);
+
+    // Let the microtask queue drain so the dispatcher promise resolves.
+    await new Promise((r) => setImmediate(r));
+
+    expect(calls.length).toBe(1);
+    expect(calls[0]!.method).toBe('/healthz');
+    expect(outbound.length).toBe(1);
+    const reply = decodeJsonHeader(outbound[0]!);
+    expect(reply.id).toBe(42);
+    expect(reply.ok).toBe(true);
+    expect(reply.value).toEqual({ hello: 'world' });
+    expect(reply.ack_source).toBe('handler');
+    expect(destroyed()).toBe(false);
+  });
+
+  it('handles multiple frames in a single chunk', async () => {
+    const { socket, feed, outbound } = makeFakeSocket();
+    const { dispatcher, calls } = makeStubDispatcher(okResult);
+    mountEnvelopeAdapter({ socket, dispatcher, logger: silentLogger });
+
+    const a = buildJsonFrame({ id: 1, method: '/healthz', payloadType: 'json', payloadLen: 0 });
+    const b = buildJsonFrame({ id: 2, method: '/stats', payloadType: 'json', payloadLen: 0 });
+    feed(Buffer.concat([a, b]));
+    await new Promise((r) => setImmediate(r));
+
+    expect(calls.map((c) => c.method)).toEqual(['/healthz', '/stats']);
+    expect(outbound.length).toBe(2);
+    expect(decodeJsonHeader(outbound[0]!).id).toBe(1);
+    expect(decodeJsonHeader(outbound[1]!).id).toBe(2);
+  });
+
+  it('forwards dispatcher error replies as { ok:false, error } envelopes without destroying', async () => {
+    const { socket, feed, outbound, destroyed } = makeFakeSocket();
+    const errResult: DispatchResult = {
+      ok: false,
+      error: { code: 'NOT_ALLOWED', method: 'session.list', message: 'forbidden' },
+    };
+    const { dispatcher } = makeStubDispatcher(errResult);
+    mountEnvelopeAdapter({ socket, dispatcher, logger: silentLogger });
+
+    feed(buildJsonFrame({ id: 7, method: 'session.list', payloadType: 'json', payloadLen: 0 }));
+    await new Promise((r) => setImmediate(r));
+
+    expect(outbound.length).toBe(1);
+    const reply = decodeJsonHeader(outbound[0]!);
+    expect(reply.id).toBe(7);
+    expect(reply.ok).toBe(false);
+    expect((reply.error as { code: string }).code).toBe('NOT_ALLOWED');
+    // Errors do NOT destroy — only protocol violations do.
+    expect(destroyed()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Truncated read
+// ---------------------------------------------------------------------------
+
+describe('mountEnvelopeAdapter — truncated read', () => {
+  it('does not dispatch until the second chunk arrives', async () => {
+    const { socket, feed, outbound } = makeFakeSocket();
+    const { dispatcher, calls } = makeStubDispatcher(okResult);
+    mountEnvelopeAdapter({ socket, dispatcher, logger: silentLogger });
+
+    const frame = buildJsonFrame({ id: 99, method: '/healthz', payloadType: 'json', payloadLen: 0 });
+    // Split midway through the header bytes — neither half is a complete frame.
+    const split = Math.floor(frame.length / 2);
+    feed(frame.subarray(0, split));
+    await new Promise((r) => setImmediate(r));
+
+    expect(calls.length).toBe(0);
+    expect(outbound.length).toBe(0);
+
+    feed(frame.subarray(split));
+    await new Promise((r) => setImmediate(r));
+
+    expect(calls.length).toBe(1);
+    expect(calls[0]!.method).toBe('/healthz');
+    expect(outbound.length).toBe(1);
+    expect(decodeJsonHeader(outbound[0]!).id).toBe(99);
+  });
+
+  it('handles a one-byte-at-a-time trickle without crashing', async () => {
+    const { socket, feed, outbound } = makeFakeSocket();
+    const { dispatcher, calls } = makeStubDispatcher(okResult);
+    mountEnvelopeAdapter({ socket, dispatcher, logger: silentLogger });
+
+    const frame = buildJsonFrame({ id: 5, method: '/healthz', payloadType: 'json', payloadLen: 0 });
+    for (let i = 0; i < frame.length; i++) {
+      feed(frame.subarray(i, i + 1));
+    }
+    await new Promise((r) => setImmediate(r));
+
+    expect(calls.length).toBe(1);
+    expect(outbound.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Oversized message
+// ---------------------------------------------------------------------------
+
+describe('mountEnvelopeAdapter — oversized message', () => {
+  it('writes synthetic envelope_too_large reply with id: 0 and destroys the socket', async () => {
+    const { socket, feed, outbound, destroyed } = makeFakeSocket();
+    const { dispatcher, calls } = makeStubDispatcher(okResult);
+    const logger = { warn: vi.fn() };
+    mountEnvelopeAdapter({ socket, dispatcher, logger, peerPid: 12345 });
+
+    // Hand-craft a 4-byte prefix declaring 16 MiB + 1 byte payload (just the
+    // prefix is enough — the cap-check fires before any body bytes are read).
+    const oversize = ENVELOPE_LIMITS.MAX_PAYLOAD_BYTES + 1;
+    const header = Buffer.alloc(4);
+    // Nibble 0x0 (v0.3) in high bits, length in low 28 bits.
+    header.writeUInt32BE(((0x0 & 0x0f) << 28) | (oversize & 0x0fffffff), 0);
+    feed(header);
+    await new Promise((r) => setImmediate(r));
+
+    expect(calls.length).toBe(0);
+    expect(outbound.length).toBe(1);
+    const reply = decodeJsonHeader(outbound[0]!);
+    expect(reply.id).toBe(0);
+    expect(reply.ok).toBe(false);
+    expect((reply.error as { code: string }).code).toBe('envelope_too_large');
+    expect(destroyed()).toBe(true);
+    // Forensic warn line emitted with peerPid + len per spec §3.4.1.a.
+    const warnedOversize = (
+      logger.warn.mock.calls as Array<[Record<string, unknown>, string]>
+    ).some(([obj, msg]) => msg === 'envelope_oversize' && obj.peerPid === 12345 && obj.len === oversize);
+    expect(warnedOversize).toBe(true);
+  });
+
+  it('rejects unknown frame-version nibble before the cap-check (spec §3.4.1.a step 2)', async () => {
+    const { socket, feed, outbound, destroyed } = makeFakeSocket();
+    const { dispatcher, calls } = makeStubDispatcher(okResult);
+    mountEnvelopeAdapter({ socket, dispatcher, logger: silentLogger });
+
+    // Nibble 0x1 (would be v0.4 protobuf) against a v0.3 daemon: reject with
+    // UNSUPPORTED_FRAME_VERSION even if the masked length looks fine.
+    const header = Buffer.alloc(4);
+    header.writeUInt32BE(((0x1 & 0x0f) << 28) | (16 & 0x0fffffff), 0);
+    feed(header);
+    await new Promise((r) => setImmediate(r));
+
+    expect(calls.length).toBe(0);
+    expect(outbound.length).toBe(1);
+    const reply = decodeJsonHeader(outbound[0]!);
+    expect((reply.error as { code: string }).code).toBe('UNSUPPORTED_FRAME_VERSION');
+    expect(destroyed()).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Malformed JSON header
+// ---------------------------------------------------------------------------
+
+describe('mountEnvelopeAdapter — malformed JSON', () => {
+  it('writes schema_violation reply and destroys the socket on garbage header bytes', async () => {
+    const { socket, feed, outbound, destroyed } = makeFakeSocket();
+    const { dispatcher, calls } = makeStubDispatcher(okResult);
+    mountEnvelopeAdapter({ socket, dispatcher, logger: silentLogger });
+
+    // Build a syntactically valid frame whose header bytes are not JSON.
+    const garbage = Buffer.from('not json at all', 'utf8');
+    const frame = encodeFrame({ headerJson: garbage });
+    feed(frame);
+    await new Promise((r) => setImmediate(r));
+
+    expect(calls.length).toBe(0);
+    expect(outbound.length).toBe(1);
+    const reply = decodeJsonHeader(outbound[0]!);
+    expect(reply.id).toBe(0);
+    expect((reply.error as { code: string }).code).toBe('schema_violation');
+    expect(destroyed()).toBe(true);
+  });
+
+  it('rejects a header that parses as JSON but is missing routing fields', async () => {
+    const { socket, feed, outbound, destroyed } = makeFakeSocket();
+    const { dispatcher, calls } = makeStubDispatcher(okResult);
+    mountEnvelopeAdapter({ socket, dispatcher, logger: silentLogger });
+
+    // Valid JSON, missing `method` (and id type wrong).
+    feed(buildJsonFrame({ id: 'not-a-number', foo: 'bar' }));
+    await new Promise((r) => setImmediate(r));
+
+    expect(calls.length).toBe(0);
+    expect(outbound.length).toBe(1);
+    const reply = decodeJsonHeader(outbound[0]!);
+    expect((reply.error as { code: string }).code).toBe('schema_violation');
+    expect(destroyed()).toBe(true);
+  });
+
+  it('rejects a header missing `method` while echoing back a valid `id`', async () => {
+    const { socket, feed, outbound, destroyed } = makeFakeSocket();
+    const { dispatcher } = makeStubDispatcher(okResult);
+    mountEnvelopeAdapter({ socket, dispatcher, logger: silentLogger });
+
+    feed(buildJsonFrame({ id: 33 }));
+    await new Promise((r) => setImmediate(r));
+
+    expect(outbound.length).toBe(1);
+    const reply = decodeJsonHeader(outbound[0]!);
+    expect(reply.id).toBe(33);
+    expect((reply.error as { code: string }).code).toBe('schema_violation');
+    expect(destroyed()).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dispatcher exception handling
+// ---------------------------------------------------------------------------
+
+describe('mountEnvelopeAdapter — handler exceptions', () => {
+  it('emits an INTERNAL error reply when the dispatcher throws (non-typed)', async () => {
+    const { socket, feed, outbound, destroyed } = makeFakeSocket();
+    const dispatcher: Pick<Dispatcher, 'dispatch'> = {
+      dispatch: vi.fn(async () => {
+        throw new Error('boom');
+      }),
+    };
+    const logger = { warn: vi.fn() };
+    mountEnvelopeAdapter({ socket, dispatcher, logger });
+
+    feed(buildJsonFrame({ id: 17, method: '/healthz', payloadType: 'json', payloadLen: 0 }));
+    await new Promise((r) => setImmediate(r));
+
+    expect(outbound.length).toBe(1);
+    const reply = decodeJsonHeader(outbound[0]!);
+    expect(reply.id).toBe(17);
+    expect((reply.error as { code: string }).code).toBe('INTERNAL');
+    // Socket NOT destroyed — handler exception is a per-call failure, not a
+    // protocol violation. The connection stays usable for the next RPC.
+    expect(destroyed()).toBe(false);
+  });
+});

--- a/daemon/src/envelope/adapter.ts
+++ b/daemon/src/envelope/adapter.ts
@@ -1,0 +1,382 @@
+// Daemon-side envelope adapter (B7a — Task #28).
+//
+// Bridges raw Duplex sockets (control-socket / data-socket transports) to the
+// pure {@link Dispatcher} via length-prefixed JSON envelope framing per spec
+// frag-3.4.1 §3.4.1.a (frame-version nibble + 16 MiB cap), §3.4.1.c (header
+// + payload split), §3.4.1.d (schema validation hook = JSON-parse + minimum
+// routing-field shape check).
+//
+// Spec citations:
+//   - docs/superpowers/specs/v0.3-fragments/frag-3.4.1-envelope-hardening.md
+//     §3.4.1.a frame-header parsing order (already enforced by `decodeFrame`).
+//     §3.4.1.a oversize rejection sequence: warn -> write synthetic
+//                `{ id: 0, error: { code: "envelope_too_large", ... } }` reply
+//                (best-effort) -> `socket.destroy()`.
+//     §3.4.1.c header schema (`id` + `method` + `payloadType` + `payloadLen`).
+//     §3.4.1.d malformed/unknown-shape header -> `{ id, error: { code:
+//                "schema_violation" } }` -> `socket.destroy()`.
+//   - PR-context: scope is the wire-up gap noted in `daemon/src/index.ts`
+//     (lines ~270-305) "Envelope adapter wiring is T-future". This adapter is
+//     that wiring. It is intentionally MINIMAL: it owns framing + dispatch +
+//     reply; the dispatcher (`daemon/src/dispatcher.ts`) owns method routing,
+//     and the per-handler / per-interceptor work (HMAC, deadline, hello-gate,
+//     migration-gate, trace-id fan-out) is composed into the dispatcher by
+//     other tasks. This module knows nothing about those.
+//
+// Single Responsibility (producer / decider / sink, per dev contract §2):
+//   - PRODUCER: socket `data` events. Accumulates bytes in a per-connection
+//     buffer until at least one full frame is available.
+//   - DECIDER: `decodeFrame` (pure) + `JSON.parse(headerJson)` + minimum
+//     routing-field validation. Decides the frame is well-formed enough to
+//     dispatch; otherwise emits the appropriate error envelope.
+//   - SINK: writes the reply envelope back to the socket (`socket.write`).
+//     Never mutates dispatcher state, never owns timers.
+//
+// What this module deliberately does NOT do (out of scope per Task #28):
+//   - Binary trailer round-trip in either direction. Reply payload is JSON-
+//     only in v0.3.x today (no daemon->client handler returns binary). The
+//     decode side preserves the trailer Buffer and forwards it to handlers via
+//     `req.payload` so a future binary handler can consume it; reply encoding
+//     stays pure-JSON. When binary replies arrive we'll extend `writeReply` —
+//     no rework on this side.
+//   - HMAC handshake / hello-gate / migration-gate / interceptor pipeline.
+//     Those are layered into the dispatcher by their own modules
+//     (`hello-interceptor.ts`, `migration-gate-interceptor.ts`,
+//     `deadline-interceptor.ts`, `hmac.ts`).
+//   - Per-stream chunking, fan-out caching, header-skeleton fast path
+//     (§3.4.1.b / §3.4.1.c hot-path optimizations). All v0.4-relevant; v0.3
+//     unblocks #27 (Electron envelope migration) without these.
+//   - Connect-RPC / HTTP/2. Lives in `connect/server.ts`; wholly separate
+//     transport.
+
+import { Buffer } from 'node:buffer';
+import type { Duplex } from 'node:stream';
+
+import { decodeFrame, encodeFrame, EnvelopeError, ENVELOPE_LIMITS } from './envelope.js';
+import type { Dispatcher, DispatchContext } from '../dispatcher.js';
+
+// ---------------------------------------------------------------------------
+// Inbound header shape (minimum routing fields — §3.4.1.c subset)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimum-shape inbound envelope header, post-`JSON.parse`. The full spec
+ * §3.4.1.c shape includes `payloadType`, `payloadLen`, `stream`, `traceId`,
+ * `headers` etc.; the adapter only inspects fields it needs to route and
+ * reply. Unknown fields are forwarded to the dispatcher untouched (handlers
+ * own per-method validation, §3.4.1.d).
+ */
+interface InboundHeader {
+  /** RPC id; non-negative integer. `0` is reserved for synthetic error replies
+   *  emitted by the adapter (per §3.4.1.a oversize-reply rule). */
+  id: number;
+  /** RPC method name (literal — see §3.4.1.h literal-vs-namespace lock). */
+  method: string;
+  /** Optional Crockford ULID; the dispatcher / handlers may consume it. The
+   *  adapter does NOT validate the ULID regex (that's the trace-id interceptor
+   *  per §3.4.1.c round-3 CC-2). */
+  traceId?: string;
+}
+
+/** Minimal type guard for the routing fields above. Returns `false` for any
+ *  non-object, missing `id`/`method`, or wrong-typed fields — those become
+ *  `schema_violation` per §3.4.1.d. */
+function isWellFormedHeader(v: unknown): v is InboundHeader {
+  if (v === null || typeof v !== 'object') return false;
+  const o = v as Record<string, unknown>;
+  if (typeof o.id !== 'number' || !Number.isInteger(o.id) || o.id < 0) return false;
+  if (typeof o.method !== 'string' || o.method.length === 0) return false;
+  if (o.traceId !== undefined && typeof o.traceId !== 'string') return false;
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Reply envelope helpers
+// ---------------------------------------------------------------------------
+
+/** Build a `{ id, ok: true, value }` reply. Pure-JSON header, empty trailer. */
+function encodeOkReply(id: number, value: unknown, ackSource: 'handler' | 'dispatcher'): Buffer {
+  const header = {
+    id,
+    ok: true as const,
+    value,
+    ack_source: ackSource,
+    payloadType: 'json' as const,
+    payloadLen: 0,
+  };
+  return encodeFrame({
+    headerJson: Buffer.from(JSON.stringify(header), 'utf8'),
+  });
+}
+
+/** Build a `{ id, ok: false, error: { code, message } }` reply. */
+function encodeErrorReply(
+  id: number,
+  code: string,
+  message: string,
+  extras?: Record<string, unknown>,
+): Buffer {
+  const error: Record<string, unknown> = { code, message };
+  if (extras) {
+    for (const [k, v] of Object.entries(extras)) error[k] = v;
+  }
+  const header = {
+    id,
+    ok: false as const,
+    error,
+    payloadType: 'json' as const,
+    payloadLen: 0,
+  };
+  return encodeFrame({
+    headerJson: Buffer.from(JSON.stringify(header), 'utf8'),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Adapter mount surface
+// ---------------------------------------------------------------------------
+
+/**
+ * Logger surface used by the adapter for forensic warn lines. Mirrors the
+ * shape `data-socket.ts` / `control-socket.ts` already accept so callers can
+ * pass the same pino child.
+ */
+export interface AdapterLogger {
+  warn(obj: Record<string, unknown>, msg: string): void;
+}
+
+export interface MountEnvelopeAdapterOptions {
+  /** Pre-accepted Duplex socket (one per connection). Adapter takes ownership
+   *  of the `data` / `error` / `close` listeners; caller MUST NOT register
+   *  competing parsers. */
+  readonly socket: Duplex;
+  /** Pure dispatcher (supervisor-plane on control-socket, data-plane on
+   *  data-socket). The adapter calls `dispatcher.dispatch(method, value, ctx)`
+   *  per inbound frame. */
+  readonly dispatcher: Pick<Dispatcher, 'dispatch'>;
+  /** Best-effort warn sink. Defaults to a `console.warn` adapter so the
+   *  module works in tests without the daemon's pino child. */
+  readonly logger?: AdapterLogger;
+  /** Optional forensic peer-pid (from §3.1.1 peer-cred lookup) for the
+   *  `envelope_oversize` warn line per §3.4.1.a. */
+  readonly peerPid?: number;
+  /** Optional forensic peer label (e.g. `'control-socket'` / `'data-socket'`)
+   *  for log correlation. */
+  readonly peer?: string;
+}
+
+/**
+ * Mount the envelope adapter onto a freshly-accepted socket. Returns nothing —
+ * the adapter installs its own listeners and lives until the socket closes.
+ *
+ * Behavior summary:
+ *   - Accumulates inbound bytes; loops `decodeFrame` until the buffer is short
+ *     of a full frame (truncated reads are normal — wait for more data).
+ *   - On any other `EnvelopeError` (oversize, unsupported version, corrupt
+ *     headerLen): warn + best-effort error reply with `id: 0` + destroy.
+ *   - On malformed JSON header (`JSON.parse` throws): warn + `schema_violation`
+ *     reply (best-effort, `id: 0` because we cannot trust any field) + destroy.
+ *   - On a well-formed header that fails `isWellFormedHeader`: warn +
+ *     `schema_violation` reply + destroy.
+ *   - On a well-formed header: dispatch to `dispatcher.dispatch(method, value,
+ *     ctx)`. The `value` forwarded to handlers is the parsed header itself
+ *     (JSON-frame mode) or `{ ...header, payload }` (binary-frame mode — the
+ *     trailer is exposed as `payload` so a future binary handler can consume
+ *     it). Reply encoded as `{ id, ok, value | error }`.
+ */
+export function mountEnvelopeAdapter(opts: MountEnvelopeAdapterOptions): void {
+  const { socket, dispatcher, peerPid, peer } = opts;
+  const logger = opts.logger ?? defaultLogger();
+
+  // Per-connection buffer accumulator. We use Buffer.concat over a small array
+  // so a slow trickle of 1-byte writes does not become quadratic; for v0.3
+  // dogfood load (<= a few subscribers) this is comfortably within budget.
+  const pending: Buffer[] = [];
+  let pendingBytes = 0;
+  let destroyed = false;
+
+  function destroy(reason: string, extras?: Record<string, unknown>): void {
+    if (destroyed) return;
+    destroyed = true;
+    logger.warn(
+      { event: 'envelope-adapter.destroy', reason, peer, peerPid, ...(extras ?? {}) },
+      `envelope adapter destroying socket: ${reason}`,
+    );
+    try {
+      socket.destroy();
+    } catch {
+      // best-effort
+    }
+  }
+
+  function tryWrite(buf: Buffer): void {
+    // Best-effort reply per §3.4.1.a — never throw out of the adapter on a
+    // half-closed write. The `socket.destroy()` that follows is the
+    // authoritative cleanup; this write is an *advisory* error frame.
+    try {
+      socket.write(buf);
+    } catch {
+      // swallow — the socket is already going away
+    }
+  }
+
+  function processBuffer(): void {
+    // Loop until the buffer is too short for a full frame OR we destroy.
+    while (!destroyed && pendingBytes >= ENVELOPE_LIMITS.PREFIX_LEN) {
+      const head = pending.length === 1 ? pending[0]! : Buffer.concat(pending, pendingBytes);
+      // Re-coalesce the pending list to a single chunk for slicing.
+      if (pending.length !== 1) {
+        pending.length = 0;
+        pending.push(head);
+      }
+
+      let decoded: ReturnType<typeof decodeFrame>;
+      try {
+        decoded = decodeFrame(head);
+      } catch (err) {
+        if (err instanceof EnvelopeError) {
+          if (err.code === 'truncated_frame') {
+            // Wait for more bytes — this is the happy "partial read" path.
+            return;
+          }
+          // Oversize / unsupported nibble / corrupt header length — synthetic
+          // reply per §3.4.1.a then destroy. Reply MUST use id: 0 because we
+          // cannot trust any header field on a frame we couldn't decode.
+          if (err.code === 'envelope_too_large') {
+            logger.warn(
+              { event: 'envelope-adapter.envelope_oversize', peer, peerPid, len: err.len },
+              'envelope_oversize',
+            );
+          }
+          tryWrite(
+            encodeErrorReply(
+              0,
+              err.code,
+              err.message,
+              err.nibble !== undefined ? { nibble: err.nibble } : undefined,
+            ),
+          );
+          destroy(err.code, { len: err.len, nibble: err.nibble });
+          return;
+        }
+        // Unknown decode error — fail closed.
+        destroy('decode_threw', { err: String(err) });
+        return;
+      }
+
+      // Compute total bytes consumed by this frame: 4-byte prefix +
+      // 2-byte headerLen field + headerJson + payload.
+      const frameLen =
+        ENVELOPE_LIMITS.PREFIX_LEN +
+        ENVELOPE_LIMITS.HEADER_LEN_FIELD +
+        decoded.headerJson.length +
+        decoded.payload.length;
+
+      // Slice the consumed bytes off `head` and keep the remainder for the
+      // next iteration. Subarray is zero-copy; we only allocate when the next
+      // `data` event arrives and we re-coalesce.
+      if (frameLen >= head.length) {
+        pending.length = 0;
+        pendingBytes = 0;
+      } else {
+        const remainder = head.subarray(frameLen);
+        pending.length = 0;
+        pending.push(remainder);
+        pendingBytes = remainder.length;
+      }
+
+      // Parse + validate header. Either failure -> schema_violation + destroy.
+      let headerObj: unknown;
+      try {
+        headerObj = JSON.parse(decoded.headerJson.toString('utf8'));
+      } catch {
+        tryWrite(encodeErrorReply(0, 'schema_violation', 'malformed JSON header'));
+        destroy('schema_violation_parse');
+        return;
+      }
+      if (!isWellFormedHeader(headerObj)) {
+        // We may know `id` if it parsed but failed shape — best-effort echo.
+        const maybeId =
+          headerObj && typeof headerObj === 'object' && typeof (headerObj as { id?: unknown }).id === 'number'
+            ? (headerObj as { id: number }).id
+            : 0;
+        tryWrite(
+          encodeErrorReply(maybeId, 'schema_violation', 'header missing required routing fields'),
+        );
+        destroy('schema_violation_shape');
+        return;
+      }
+
+      // Dispatch. `value` forwarded to handlers includes the trailer when
+      // present so a future binary handler can consume it; the dispatcher
+      // itself treats it as opaque.
+      const requestValue: unknown =
+        decoded.payload.length > 0 ? { ...headerObj, payload: decoded.payload } : headerObj;
+
+      const ctx: DispatchContext =
+        headerObj.traceId !== undefined ? { traceId: headerObj.traceId } : {};
+
+      const id = headerObj.id;
+      const method = headerObj.method;
+
+      // Fire-and-forget — handlers may take time. Per spec §3.4.1.b unary
+      // frames may interleave between sub-chunks, so per-connection FIFO is
+      // NOT required for correctness. Dispatch async and let promises race.
+      void dispatcher.dispatch(method, requestValue, ctx).then(
+        (result) => {
+          if (destroyed) return;
+          if (result.ok) {
+            tryWrite(encodeOkReply(id, result.value, result.ack_source));
+          } else {
+            tryWrite(
+              encodeErrorReply(id, result.error.code, result.error.message, {
+                method: result.error.method,
+              }),
+            );
+          }
+        },
+        (err: unknown) => {
+          if (destroyed) return;
+          // Handler threw (non-stub). Surface as INTERNAL — handlers SHOULD
+          // throw typed errors but we cannot guarantee discipline at this
+          // boundary. The synthetic reply lets the caller fail their RPC
+          // promise instead of timing out.
+          tryWrite(encodeErrorReply(id, 'INTERNAL', String(err)));
+          logger.warn(
+            { event: 'envelope-adapter.handler_threw', peer, peerPid, method, err: String(err) },
+            'handler threw outside the dispatcher contract',
+          );
+        },
+      );
+    }
+  }
+
+  socket.on('data', (chunk: Buffer) => {
+    if (destroyed) return;
+    pending.push(chunk);
+    pendingBytes += chunk.length;
+    processBuffer();
+  });
+
+  socket.on('error', (err: Error) => {
+    // Surface but do not throw out — caller may have its own listener.
+    logger.warn(
+      { event: 'envelope-adapter.socket_error', peer, peerPid, err: String(err) },
+      'socket error',
+    );
+  });
+
+  socket.on('close', () => {
+    destroyed = true;
+    pending.length = 0;
+    pendingBytes = 0;
+  });
+}
+
+function defaultLogger(): AdapterLogger {
+  return {
+    warn: (obj, msg) => {
+      console.warn(`${msg} ${JSON.stringify(obj)}`);
+    },
+  };
+}

--- a/daemon/src/index.ts
+++ b/daemon/src/index.ts
@@ -3,7 +3,8 @@ import pino from 'pino';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { createRequire } from 'node:module';
-import { createSupervisorDispatcher } from './dispatcher.js';
+import { createSupervisorDispatcher, createDataDispatcher } from './dispatcher.js';
+import { mountEnvelopeAdapter } from './envelope/adapter.js';
 import {
   createDaemonShutdownHandler,
   DAEMON_SHUTDOWN_METHOD,
@@ -214,6 +215,17 @@ supervisorDispatcher.register(DAEMON_SHUTDOWN_METHOD, async (req, ctx) => {
 });
 void supervisorDispatcher;
 
+// Task #28 / B7a — daemon-side envelope adapter.
+//
+// Per-plane dispatchers consumed by the envelope adapter mounted on each
+// accepted connection (control-socket -> supervisor plane, data-socket ->
+// data plane). The data dispatcher is bare today; per-method handlers are
+// wired by their owning task slices. The adapter forwards UNKNOWN_METHOD
+// cleanly for any method not yet registered, so this slice is safe to ship
+// before the handlers do.
+const dataDispatcher = createDataDispatcher();
+void dataDispatcher;
+
 // Task #1072 — wire OS-level socket listeners.
 //
 // Before this PR, both `createControlSocketServer` (T14 #676) and
@@ -270,21 +282,19 @@ controlSocket = createControlSocketServer({
     warn: (obj, msg) => logger.warn(obj, msg),
     info: (obj, msg) => logger.info(obj, msg),
   },
-  onConnection: (sock) => {
-    // Envelope adapter wiring is T-future. Until then, every accepted
-    // connection is destroyed loudly so a probe sees "connect succeeded
-    // then peer hung up" rather than a wedge. The transport-level rate
-    // cap (50/s) still fires on a flood; this destroy is per-connection
-    // application-layer cleanup.
-    logger.warn(
-      { event: 'control-socket.connection.no-adapter', address: controlSocket?.address },
-      'control-socket connection accepted but no envelope adapter is wired yet (T-future); destroying',
-    );
-    try {
-      sock.destroy();
-    } catch {
-      // best-effort
-    }
+  onConnection: (sock, peer) => {
+    // Task #28 / B7a -- envelope adapter wires Duplex bytes into the
+    // supervisor dispatcher. Adapter owns per-connection buffer
+    // accumulation, frame decode (envelope/envelope.ts), schema validation
+    // of the routing fields (id, method), and the socket.destroy() +
+    // synthetic error reply on protocol violation per spec §3.4.1.a/d.
+    mountEnvelopeAdapter({
+      socket: sock,
+      dispatcher: supervisorDispatcher,
+      logger: { warn: (obj, msg) => logger.warn(obj, msg) },
+      peer: 'control-socket',
+      ...(peer?.pid !== undefined ? { peerPid: peer.pid } : {}),
+    });
   },
 });
 
@@ -294,16 +304,14 @@ dataSocket = createDataSocketServer({
   logger: {
     warn: (obj, msg) => logger.warn(obj, msg),
   },
-  onConnection: ({ socket }) => {
-    logger.warn(
-      { event: 'data-socket.connection.no-adapter', address: dataSocket?.address() },
-      'data-socket connection accepted but no envelope adapter is wired yet (T-future); destroying',
-    );
-    try {
-      socket.destroy();
-    } catch {
-      // best-effort
-    }
+  onConnection: ({ socket, peer }) => {
+    mountEnvelopeAdapter({
+      socket,
+      dispatcher: dataDispatcher,
+      logger: { warn: (obj, msg) => logger.warn(obj, msg) },
+      peer: 'data-socket',
+      ...(peer?.pid !== undefined ? { peerPid: peer.pid } : {}),
+    });
   },
 });
 

--- a/electron/daemonClient/__tests__/controlClient.test.ts
+++ b/electron/daemonClient/__tests__/controlClient.test.ts
@@ -1,0 +1,149 @@
+// Tests for the typed control-socket facade (createControlClient).
+//
+// Asserts the facade correctly:
+//   - calls `daemon.shutdownForUpgrade` with the spec'd 5 s timeout;
+//   - returns the typed `{ accepted: true, reason: 'upgrade' }` ack on a
+//     well-formed handler reply;
+//   - rejects with a thrown Error when the handler returns an error envelope
+//     (so `electron/updater.ts`'s `callShutdownForUpgrade` outer race classifies
+//     as `{ kind: 'error', message }`);
+//   - rejects with a thrown Error on transport failure (timeout / disconnect).
+//
+// Spec citation: frag-11 §11.6.5 step 3 (5 s ack window).
+
+import { describe, expect, it } from 'vitest';
+import { Buffer } from 'node:buffer';
+import { PassThrough } from 'node:stream';
+import type { Socket } from 'node:net';
+
+import { createControlClient, SHUTDOWN_FOR_UPGRADE_METHOD } from '../controlClient';
+import { decodeFrame, encodeFrame } from '../envelope';
+
+function pairedSockets() {
+  const c2s = new PassThrough();
+  const s2c = new PassThrough();
+  const clientSide = new PassThrough() as unknown as Socket;
+  s2c.on('data', (chunk: Buffer) => (clientSide as unknown as PassThrough).push(chunk));
+  (clientSide as unknown as { write: (b: Buffer) => boolean }).write = (b: Buffer) => c2s.write(b);
+  (clientSide as unknown as { destroy: () => void }).destroy = () => {
+    try { c2s.end(); s2c.end(); } catch { /* */ }
+    queueMicrotask(() => clientSide.emit('close'));
+  };
+  const serverSide = new PassThrough();
+  c2s.on('data', (chunk: Buffer) => serverSide.push(chunk));
+  serverSide.write = ((chunk: Buffer | string) => {
+    s2c.write(chunk);
+    return true;
+  }) as typeof serverSide.write;
+  return { clientSide, serverSide };
+}
+
+function decodeAll(buf: Buffer) {
+  const out: Array<ReturnType<typeof decodeFrame>> = [];
+  let cursor = buf;
+  while (cursor.length >= 6) {
+    let d;
+    try { d = decodeFrame(cursor); } catch { break; }
+    out.push(d);
+    cursor = cursor.subarray(4 + 2 + d.headerJson.length + d.payload.length);
+  }
+  return out;
+}
+
+describe('createControlClient.callShutdownForUpgrade', () => {
+  it('issues daemon.shutdownForUpgrade and resolves the typed ack', async () => {
+    const { clientSide, serverSide } = pairedSockets();
+    serverSide.on('data', (chunk: Buffer) => {
+      const frames = decodeAll(chunk);
+      for (const f of frames) {
+        const h = JSON.parse(f.headerJson.toString('utf8'));
+        expect(h.method).toBe(SHUTDOWN_FOR_UPGRADE_METHOD);
+        const reply = Buffer.from(
+          JSON.stringify({
+            id: h.id,
+            ok: true,
+            value: { accepted: true, reason: 'upgrade' },
+            ack_source: 'handler',
+          }),
+          'utf8',
+        );
+        serverSide.write(encodeFrame({ headerJson: reply }));
+      }
+    });
+
+    const client = createControlClient({
+      socketPath: '/fake',
+      connectFn: () => clientSide,
+    });
+    const connectP = client.rpc.connect();
+    queueMicrotask(() => clientSide.emit('connect'));
+    await connectP;
+
+    const ack = await client.callShutdownForUpgrade();
+    expect(ack).toEqual({ accepted: true, reason: 'upgrade' });
+    client.rpc.close();
+  });
+
+  it('throws when the handler replies with an error envelope', async () => {
+    const { clientSide, serverSide } = pairedSockets();
+    serverSide.on('data', (chunk: Buffer) => {
+      const frames = decodeAll(chunk);
+      for (const f of frames) {
+        const h = JSON.parse(f.headerJson.toString('utf8'));
+        const reply = Buffer.from(
+          JSON.stringify({
+            id: h.id,
+            ok: false,
+            error: { code: 'INTERNAL', message: 'marker write failed' },
+          }),
+          'utf8',
+        );
+        serverSide.write(encodeFrame({ headerJson: reply }));
+      }
+    });
+
+    const client = createControlClient({
+      socketPath: '/fake',
+      connectFn: () => clientSide,
+    });
+    const connectP = client.rpc.connect();
+    queueMicrotask(() => clientSide.emit('connect'));
+    await connectP;
+
+    await expect(client.callShutdownForUpgrade()).rejects.toThrow(
+      /INTERNAL: marker write failed/,
+    );
+    client.rpc.close();
+  });
+
+  it('throws on a malformed ack value', async () => {
+    const { clientSide, serverSide } = pairedSockets();
+    serverSide.on('data', (chunk: Buffer) => {
+      const frames = decodeAll(chunk);
+      for (const f of frames) {
+        const h = JSON.parse(f.headerJson.toString('utf8'));
+        const reply = Buffer.from(
+          JSON.stringify({
+            id: h.id,
+            ok: true,
+            value: { accepted: false }, // wrong shape
+            ack_source: 'handler',
+          }),
+          'utf8',
+        );
+        serverSide.write(encodeFrame({ headerJson: reply }));
+      }
+    });
+
+    const client = createControlClient({
+      socketPath: '/fake',
+      connectFn: () => clientSide,
+    });
+    const connectP = client.rpc.connect();
+    queueMicrotask(() => clientSide.emit('connect'));
+    await connectP;
+
+    await expect(client.callShutdownForUpgrade()).rejects.toThrow(/malformed ack/);
+    client.rpc.close();
+  });
+});

--- a/electron/daemonClient/__tests__/envelope.test.ts
+++ b/electron/daemonClient/__tests__/envelope.test.ts
@@ -1,0 +1,131 @@
+// Encode/decode parity + spec-mandated rejection tests for the Electron
+// envelope mirror. Round-trips through both the Electron-side encoder and
+// the daemon-side encoder/decoder (imported from `daemon/src/envelope`) so
+// any future drift between the two implementations fails this test.
+//
+// Spec citations:
+//   - frag-3.4.1 §3.4.1.a frame-version nibble + 16 MiB cap.
+//   - frag-3.4.1 §3.4.1.c header layout `[totalLen:4][headerLen:2][headerJSON][payload]`.
+
+import { describe, expect, it } from 'vitest';
+import { Buffer } from 'node:buffer';
+
+import {
+  decodeFrame as clientDecode,
+  encodeFrame as clientEncode,
+  EnvelopeError,
+  ENVELOPE_LIMITS,
+} from '../envelope';
+
+describe('Electron envelope mirror', () => {
+  it('encodes a JSON-only frame to the documented byte layout', () => {
+    const headerJson = Buffer.from(JSON.stringify({ id: 1, method: 'foo' }), 'utf8');
+    const frame = clientEncode({ headerJson });
+
+    // [totalLen:4][headerLen:2][headerJSON]
+    const totalLen = frame.readUInt32BE(0);
+    const versionNibble = (totalLen >>> 28) & 0x0f;
+    const payloadLen = totalLen & 0x0fffffff;
+    expect(versionNibble).toBe(0x0);
+    expect(payloadLen).toBe(2 + headerJson.length);
+    expect(frame.readUInt16BE(4)).toBe(headerJson.length);
+    expect(frame.subarray(6, 6 + headerJson.length).toString('utf8'))
+      .toBe(headerJson.toString('utf8'));
+  });
+
+  it('round-trips encode → decode with byte-equal header + payload', () => {
+    const header = Buffer.from(JSON.stringify({ id: 42, method: 'foo' }), 'utf8');
+    const payload = Buffer.from('hello-binary-trailer', 'utf8');
+    const frame = clientEncode({ headerJson: header, payload });
+    const decoded = clientDecode(frame);
+    expect(decoded.version).toBe(0x0);
+    expect(decoded.headerJson.equals(header)).toBe(true);
+    expect(decoded.payload.equals(payload)).toBe(true);
+  });
+
+  it('rejects an oversize frame at encode time', () => {
+    // Pretend we have a 16 MiB+1 byte payload by faking a giant Buffer alloc.
+    // Use a real Buffer so the size check fires (not a Mock).
+    const big = Buffer.alloc(ENVELOPE_LIMITS.MAX_PAYLOAD_BYTES); // exactly cap
+    const header = Buffer.from(JSON.stringify({ id: 1, method: 'x' }), 'utf8');
+    expect(() => clientEncode({ headerJson: header, payload: big })).toThrow(
+      EnvelopeError,
+    );
+  });
+
+  it('rejects an unknown frame-version nibble at decode time BEFORE applying the length cap', () => {
+    // Build a frame where the high nibble is 0x1 and the low 28 bits decode
+    // to a length that, if the cap-check ran first, would also fail. Spec
+    // §3.4.1.a step 2 mandates UNSUPPORTED_FRAME_VERSION wins.
+    const buf = Buffer.alloc(8);
+    // raw = 0x1 << 28 | 6  (claim 6-byte payload — well under cap)
+    buf.writeUInt32BE(((0x1) << 28) | 6, 0);
+    buf.writeUInt16BE(2, 4);
+    buf.writeUInt16BE(0xdead, 6);
+    let thrown: EnvelopeError | undefined;
+    try { clientDecode(buf); } catch (e) { thrown = e as EnvelopeError; }
+    expect(thrown).toBeInstanceOf(EnvelopeError);
+    expect(thrown!.code).toBe('UNSUPPORTED_FRAME_VERSION');
+  });
+
+  it('rejects a oversize-claimed length at decode time', () => {
+    const buf = Buffer.alloc(4);
+    // nibble 0, claim 17 MiB.
+    buf.writeUInt32BE((17 * 1024 * 1024) & 0x0fffffff, 0);
+    let thrown: EnvelopeError | undefined;
+    try { clientDecode(buf); } catch (e) { thrown = e as EnvelopeError; }
+    expect(thrown).toBeInstanceOf(EnvelopeError);
+    expect(thrown!.code).toBe('envelope_too_large');
+  });
+
+  it('reports truncated_frame on a partial buffer', () => {
+    const header = Buffer.from(JSON.stringify({ id: 1, method: 'x' }), 'utf8');
+    const frame = clientEncode({ headerJson: header });
+    // Slice the frame in half — both the prefix-only and mid-header cases
+    // must be reported as truncated.
+    let thrown: EnvelopeError | undefined;
+    try { clientDecode(frame.subarray(0, 3)); } catch (e) { thrown = e as EnvelopeError; }
+    expect(thrown!.code).toBe('truncated_frame');
+
+    let thrown2: EnvelopeError | undefined;
+    try { clientDecode(frame.subarray(0, frame.length - 1)); } catch (e) { thrown2 = e as EnvelopeError; }
+    expect(thrown2!.code).toBe('truncated_frame');
+  });
+});
+
+describe('byte-for-byte parity with daemon adapter', () => {
+  // The daemon's envelope module is ESM; we cannot `require()` it from a
+  // CJS-typed test file directly. Use dynamic import (vitest resolves both).
+  it('client-encoded frame decodes byte-equal under daemon decoder', async () => {
+    const daemonMod = await import(
+      // path-relative import keeps vitest's resolver in CWD-rooted mode.
+      '../../../daemon/src/envelope/envelope.js'
+    );
+    const headerObj = { id: 7, method: 'daemon.shutdownForUpgrade', payloadType: 'json', payloadLen: 0 };
+    const headerJson = Buffer.from(JSON.stringify(headerObj), 'utf8');
+    const frame = clientEncode({ headerJson });
+    const decoded = daemonMod.decodeFrame(frame);
+    expect(decoded.version).toBe(0x0);
+    expect(decoded.headerJson.equals(headerJson)).toBe(true);
+    expect(decoded.payload.length).toBe(0);
+    // Parsing the header through to JSON must yield the original object.
+    expect(JSON.parse(decoded.headerJson.toString('utf8'))).toEqual(headerObj);
+  });
+
+  it('daemon-encoded reply decodes byte-equal under client decoder', async () => {
+    const daemonMod = await import('../../../daemon/src/envelope/envelope.js');
+    const replyHeader = {
+      id: 7,
+      ok: true,
+      value: { accepted: true, reason: 'upgrade' },
+      ack_source: 'handler',
+      payloadType: 'json',
+      payloadLen: 0,
+    };
+    const headerJson = Buffer.from(JSON.stringify(replyHeader), 'utf8');
+    const frame = daemonMod.encodeFrame({ headerJson });
+    const decoded = clientDecode(frame);
+    expect(decoded.headerJson.equals(headerJson)).toBe(true);
+    expect(JSON.parse(decoded.headerJson.toString('utf8'))).toEqual(replyHeader);
+  });
+});

--- a/electron/daemonClient/__tests__/rpcClient.test.ts
+++ b/electron/daemonClient/__tests__/rpcClient.test.ts
@@ -1,0 +1,314 @@
+// Tests for the Electron-side socket-RPC client (Task #27 / B7b).
+//
+// Strategy:
+//   - Use a fake `connectFn` that returns a `PassThrough`-paired duplex so
+//     we can drive both sides of the wire deterministically (no real net
+//     listener, no port races).
+//   - For the e2e parity case we mount the daemon-side envelope adapter
+//     (`daemon/src/envelope/adapter.ts`) on the server-side duplex with a
+//     stub dispatcher that returns a known reply, and assert the client's
+//     `call(...)` resolves to the typed `{ ok, value, ack_source }` shape.
+//
+// Spec citations:
+//   - frag-3.4.1 §3.4.1.c reply shape `{ id, ok, value, ack_source }`.
+//   - frag-3.4.1 §3.4.1.h control-socket plane (the rpcClient is transport-
+//     agnostic; the test just speaks to a duplex).
+
+import { describe, expect, it, vi } from 'vitest';
+import { Buffer } from 'node:buffer';
+import { PassThrough, type Duplex } from 'node:stream';
+import type { Socket } from 'node:net';
+
+import { createRpcClient } from '../rpcClient';
+import { decodeFrame, encodeFrame } from '../envelope';
+
+// ---------------------------------------------------------------------------
+// Test harness — paired duplex that pretends to be a `net.Socket`.
+// ---------------------------------------------------------------------------
+
+function pairedSockets(): {
+  clientSide: Socket; // what `connectFn` returns
+  serverSide: Duplex; // what we mount the daemon adapter on
+} {
+  // Two PassThroughs, cross-piped: writes on one show up as reads on the
+  // other. The `clientSide` PassThrough also gets two extra Socket-shaped
+  // helpers (`emit('connect')`, `destroy()`) the rpcClient relies on.
+  const c2s = new PassThrough();
+  const s2c = new PassThrough();
+
+  const clientSide = new PassThrough() as unknown as Socket;
+  // Reads on clientSide come from s2c.
+  s2c.on('data', (chunk: Buffer) => (clientSide as unknown as PassThrough).push(chunk));
+  s2c.on('end', () => (clientSide as unknown as PassThrough).push(null));
+  // Writes on clientSide go to c2s.
+  (clientSide as unknown as { write: (b: Buffer) => boolean }).write = (b: Buffer) => c2s.write(b);
+  // destroy() ends both halves so the rpcClient's `close` listener fires.
+  (clientSide as unknown as { destroy: () => void }).destroy = () => {
+    try { c2s.end(); } catch { /* */ }
+    try { s2c.end(); } catch { /* */ }
+    (clientSide as unknown as PassThrough).push(null);
+    queueMicrotask(() => clientSide.emit('close'));
+  };
+
+  const serverSide = new PassThrough();
+  // Server reads from c2s; writes from server go to s2c.
+  c2s.on('data', (chunk: Buffer) => serverSide.push(chunk));
+  c2s.on('end', () => serverSide.push(null));
+  serverSide.write = ((chunk: Buffer | string) => {
+    s2c.write(chunk);
+    return true;
+  }) as typeof serverSide.write;
+
+  return { clientSide, serverSide };
+}
+
+function decodeAllFrames(buf: Buffer): Array<ReturnType<typeof decodeFrame>> {
+  const out: Array<ReturnType<typeof decodeFrame>> = [];
+  let cursor = buf;
+  while (cursor.length >= 6) {
+    let decoded;
+    try {
+      decoded = decodeFrame(cursor);
+    } catch {
+      break;
+    }
+    out.push(decoded);
+    const consumed = 4 + 2 + decoded.headerJson.length + decoded.payload.length;
+    cursor = cursor.subarray(consumed);
+  }
+  return out;
+}
+
+describe('rpcClient — happy path', () => {
+  it('encodes a request frame with monotonic id, method, payloadType=json', async () => {
+    const { clientSide, serverSide } = pairedSockets();
+    const captured: Buffer[] = [];
+    serverSide.on('data', (chunk: Buffer) => captured.push(chunk));
+
+    const client = createRpcClient({
+      socketPath: '/fake',
+      connectFn: () => clientSide,
+      reconnectBackoffMs: [],
+    });
+    const connectP = client.connect();
+    queueMicrotask(() => clientSide.emit('connect'));
+    await connectP;
+
+    // Fire the call — don't await yet; the server hasn't replied.
+    const callP = client.call('daemon.shutdownForUpgrade', undefined, { timeoutMs: 0 });
+
+    // Allow the write to land on serverSide.
+    await new Promise<void>((r) => setImmediate(r));
+
+    const all = Buffer.concat(captured);
+    const frames = decodeAllFrames(all);
+    expect(frames).toHaveLength(1);
+    const header = JSON.parse(frames[0]!.headerJson.toString('utf8'));
+    expect(header).toMatchObject({
+      id: 1,
+      method: 'daemon.shutdownForUpgrade',
+      payloadType: 'json',
+      payloadLen: 0,
+    });
+
+    // Ship a reply so the call resolves and we don't leak the promise.
+    const replyHeader = Buffer.from(
+      JSON.stringify({
+        id: 1,
+        ok: true,
+        value: { accepted: true, reason: 'upgrade' },
+        ack_source: 'handler',
+      }),
+      'utf8',
+    );
+    serverSide.write(encodeFrame({ headerJson: replyHeader }));
+
+    const reply = await callP;
+    expect(reply.ok).toBe(true);
+    if (reply.ok) {
+      expect(reply.value).toEqual({ accepted: true, reason: 'upgrade' });
+      expect(reply.ack_source).toBe('handler');
+    }
+    client.close();
+  });
+
+  it('correlates concurrent calls by id', async () => {
+    const { clientSide, serverSide } = pairedSockets();
+    const captured: Buffer[] = [];
+    serverSide.on('data', (chunk: Buffer) => {
+      captured.push(chunk);
+      // Auto-reply: parse every newly-arrived frame and reply in REVERSE
+      // order so we exercise out-of-order id correlation.
+      const all = Buffer.concat(captured);
+      const frames = decodeAllFrames(all);
+      if (frames.length === 2) {
+        for (const f of frames.slice().reverse()) {
+          const h = JSON.parse(f.headerJson.toString('utf8'));
+          serverSide.write(
+            encodeFrame({
+              headerJson: Buffer.from(
+                JSON.stringify({ id: h.id, ok: true, value: { echo: h.id }, ack_source: 'handler' }),
+                'utf8',
+              ),
+            }),
+          );
+        }
+      }
+    });
+
+    const client = createRpcClient({
+      socketPath: '/fake',
+      connectFn: () => clientSide,
+      reconnectBackoffMs: [],
+    });
+    const connectP = client.connect();
+    queueMicrotask(() => clientSide.emit('connect'));
+    await connectP;
+
+    const [a, b] = await Promise.all([
+      client.call<{ echo: number }>('m.A'),
+      client.call<{ echo: number }>('m.B'),
+    ]);
+    expect(a.ok && a.value.echo).toBe(1);
+    expect(b.ok && b.value.echo).toBe(2);
+    client.close();
+  });
+});
+
+describe('rpcClient — error paths', () => {
+  it('rejects with RPC_TIMEOUT when no reply arrives in time', async () => {
+    const { clientSide } = pairedSockets();
+    const client = createRpcClient({
+      socketPath: '/fake',
+      connectFn: () => clientSide,
+      reconnectBackoffMs: [],
+    });
+    const connectP = client.connect();
+    queueMicrotask(() => clientSide.emit('connect'));
+    await connectP;
+
+    const callP = client.call('m.never', undefined, { timeoutMs: 25 });
+    await expect(callP).rejects.toMatchObject({
+      name: 'RpcTransportError',
+      code: 'RPC_TIMEOUT',
+    });
+    client.close();
+  });
+
+  it('rejects pending calls with RPC_DISCONNECTED on socket close', async () => {
+    const { clientSide } = pairedSockets();
+    const client = createRpcClient({
+      socketPath: '/fake',
+      connectFn: () => clientSide,
+      reconnectBackoffMs: [],
+    });
+    const connectP = client.connect();
+    queueMicrotask(() => clientSide.emit('connect'));
+    await connectP;
+
+    const callP = client.call('m.never', undefined, { timeoutMs: 0 });
+    // Wait for the request to land before closing.
+    await new Promise<void>((r) => setImmediate(r));
+    clientSide.destroy();
+
+    await expect(callP).rejects.toMatchObject({
+      name: 'RpcTransportError',
+      code: 'RPC_DISCONNECTED',
+    });
+  });
+
+  it('schedules a reconnect with backoff after an unsolicited socket close', async () => {
+    let connectCount = 0;
+    const sockets: ReturnType<typeof pairedSockets>[] = [];
+    const client = createRpcClient({
+      socketPath: '/fake',
+      // Each connect() call returns a fresh pair so we can count attempts.
+      connectFn: () => {
+        const pair = pairedSockets();
+        sockets.push(pair);
+        connectCount += 1;
+        // Synchronously schedule the connect event so .connect() resolves.
+        queueMicrotask(() => pair.clientSide.emit('connect'));
+        return pair.clientSide;
+      },
+      reconnectBackoffMs: [10, 10, 10],
+    });
+    await client.connect();
+    expect(connectCount).toBe(1);
+
+    // Drop the live socket. The client should schedule a reconnect.
+    sockets[0]!.clientSide.destroy();
+    await new Promise<void>((r) => setTimeout(r, 50));
+    expect(connectCount).toBeGreaterThanOrEqual(2);
+    client.close();
+  });
+
+  it('rejects new calls after close()', async () => {
+    const { clientSide } = pairedSockets();
+    const client = createRpcClient({
+      socketPath: '/fake',
+      connectFn: () => clientSide,
+      reconnectBackoffMs: [],
+    });
+    const connectP = client.connect();
+    queueMicrotask(() => clientSide.emit('connect'));
+    await connectP;
+
+    client.close();
+    await expect(client.call('m.x')).rejects.toMatchObject({
+      code: 'RPC_NOT_CONNECTED',
+    });
+  });
+});
+
+describe('rpcClient — daemon adapter parity (e2e via paired duplex)', () => {
+  it('round-trips daemon.shutdownForUpgrade through the real adapter', async () => {
+    const { mountEnvelopeAdapter } = await import('../../../daemon/src/envelope/adapter.js');
+    const { clientSide, serverSide } = pairedSockets();
+
+    const dispatcher = {
+      dispatch: vi.fn(async (method: string) => {
+        if (method === 'daemon.shutdownForUpgrade') {
+          return {
+            ok: true as const,
+            value: { accepted: true, reason: 'upgrade' },
+            ack_source: 'handler' as const,
+          };
+        }
+        return {
+          ok: false as const,
+          error: { code: 'UNKNOWN_METHOD', message: 'unknown', method },
+        };
+      }),
+    };
+
+    mountEnvelopeAdapter({
+      socket: serverSide as unknown as Parameters<typeof mountEnvelopeAdapter>[0]['socket'],
+      dispatcher,
+      logger: { warn: () => {} },
+      peer: 'test',
+    });
+
+    const client = createRpcClient({
+      socketPath: '/fake',
+      connectFn: () => clientSide,
+      reconnectBackoffMs: [],
+    });
+    const connectP = client.connect();
+    queueMicrotask(() => clientSide.emit('connect'));
+    await connectP;
+
+    const reply = await client.call('daemon.shutdownForUpgrade');
+    expect(reply.ok).toBe(true);
+    if (reply.ok) {
+      expect(reply.value).toEqual({ accepted: true, reason: 'upgrade' });
+      expect(reply.ack_source).toBe('handler');
+    }
+    expect(dispatcher.dispatch).toHaveBeenCalledWith(
+      'daemon.shutdownForUpgrade',
+      expect.objectContaining({ id: 1, method: 'daemon.shutdownForUpgrade' }),
+      expect.any(Object),
+    );
+    client.close();
+  });
+});

--- a/electron/daemonClient/controlClient.ts
+++ b/electron/daemonClient/controlClient.ts
@@ -1,0 +1,111 @@
+// electron/daemonClient/controlClient.ts
+//
+// Typed facade over `createRpcClient` for the control-socket plane (spec
+// frag-3.4.1 §3.4.1.h `SUPERVISOR_RPCS`). Today it exposes one RPC the v0.3
+// codebase actually calls — `daemon.shutdownForUpgrade` — and feeds the
+// existing `setUpgradeShutdownRpc(...)` injection seam in `electron/updater.ts`
+// (T62 / frag-11 §11.6.5). When the daemon-side adds the other supervisor
+// RPCs (`daemon.shutdown`, `/healthz`, `/stats`) and Electron-main acquires
+// callers for them, those land here as additional thin wrappers without
+// changing the underlying RPC client.
+//
+// Spec citations:
+//   - frag-3.4.1 §3.4.1.h `SUPERVISOR_RPCS = ["/healthz", "/stats",
+//     "daemon.hello", "daemon.shutdown", "daemon.shutdownForUpgrade"]`
+//     — control-socket method allowlist.
+//   - frag-11 §11.6.5 step 3: 5 s ack window from the moment we write the
+//     `daemon.shutdownForUpgrade` envelope to the moment we receive the
+//     reply. The 5_000 ms is provided by the caller (`updater.ts`'s
+//     `UPGRADE_SHUTDOWN_ACK_TIMEOUT_MS`) which is the canonical owner; this
+//     module just passes it as a per-call timeout so the RPC client's
+//     transport-level timeout matches the spec ack window.
+//
+// Why a separate facade vs calling `client.call()` directly from updater.ts:
+//   - Keeps the RPC client transport-only and reusable for the data-socket
+//     plane (`createDataClient(...)` is a future slice with the same shape).
+//   - The typed `UpgradeShutdownAck` (re-exported from `updater.ts`'s
+//     interface) lives at one site so a future schema bump only edits one
+//     place.
+
+import {
+  createRpcClient,
+  RpcTransportError,
+  type RpcClient,
+  type RpcClientOptions,
+} from './rpcClient';
+import type { UpgradeShutdownAck, UpgradeShutdownRpc } from '../updater';
+
+export const SHUTDOWN_FOR_UPGRADE_METHOD = 'daemon.shutdownForUpgrade' as const;
+
+/** Spec frag-11 §11.6.5 step 3 ack window. Mirrored here as the per-call
+ *  RPC timeout so the transport-level deadline matches the spec window even
+ *  if the caller's outer race (`callShutdownForUpgrade`) is ever bypassed. */
+export const SHUTDOWN_FOR_UPGRADE_TIMEOUT_MS = 5_000;
+
+export interface ControlClient {
+  /** The underlying RPC client — exposed so callers can `.close()` it on
+   *  Electron quit and inspect `isConnected` for debug overlays. */
+  readonly rpc: RpcClient;
+  /** Typed wrapper for `daemon.shutdownForUpgrade` matching the
+   *  `UpgradeShutdownRpc` shape `electron/updater.ts` expects. Throws on
+   *  transport failure (timeout, disconnect) so the caller's existing
+   *  `Promise.race` against the 5 s window funnels both surfaces through
+   *  one branch. Application-level rejections (rare for this RPC — the
+   *  daemon handler has no inputs to fail on) surface as a thrown
+   *  `Error(error.code: error.message)`. */
+  callShutdownForUpgrade: UpgradeShutdownRpc;
+}
+
+export interface CreateControlClientOptions {
+  /** Absolute control-socket path (POSIX) or Windows named-pipe name —
+   *  resolved by `electron/daemon/bootDaemon.ts:resolveControlSocketPath`. */
+  readonly socketPath: string;
+  /** Test seam — passed straight through. */
+  readonly connectFn?: RpcClientOptions['connectFn'];
+  /** Test seam — passed straight through. */
+  readonly log?: RpcClientOptions['log'];
+}
+
+export function createControlClient(opts: CreateControlClientOptions): ControlClient {
+  const rpc = createRpcClient({
+    socketPath: opts.socketPath,
+    defaultTimeoutMs: SHUTDOWN_FOR_UPGRADE_TIMEOUT_MS,
+    ...(opts.connectFn ? { connectFn: opts.connectFn } : {}),
+    ...(opts.log ? { log: opts.log } : {}),
+  });
+
+  const callShutdownForUpgrade: UpgradeShutdownRpc = async () => {
+    let reply;
+    try {
+      reply = await rpc.call(SHUTDOWN_FOR_UPGRADE_METHOD, undefined, {
+        timeoutMs: SHUTDOWN_FOR_UPGRADE_TIMEOUT_MS,
+      });
+    } catch (err) {
+      // Transport failure — re-throw so the outer `callShutdownForUpgrade`
+      // (`updater.ts`) classifies as `{ kind: 'error', message }`. The
+      // outer race against the 5 s window already proceeds-anyway per the
+      // spec's force-kill fallback so this is informational only.
+      if (err instanceof RpcTransportError) {
+        throw new Error(`${err.code}: ${err.message}`);
+      }
+      throw err as Error;
+    }
+    if (!reply.ok) {
+      throw new Error(`${reply.error.code}: ${reply.error.message}`);
+    }
+    // The daemon handler returns `{ accepted: true, reason: 'upgrade' }`
+    // (see `daemon/src/handlers/daemon-shutdown-for-upgrade.ts`
+    // `ShutdownForUpgradeAck`). Validate the shape just enough to honor the
+    // typed contract; an unexpected shape becomes an error so the outer
+    // race classifies correctly.
+    const value = reply.value as Partial<UpgradeShutdownAck> | undefined;
+    if (!value || value.accepted !== true || value.reason !== 'upgrade') {
+      throw new Error(
+        `daemon.shutdownForUpgrade: malformed ack ${JSON.stringify(reply.value)}`,
+      );
+    }
+    return { accepted: true, reason: 'upgrade' };
+  };
+
+  return { rpc, callShutdownForUpgrade };
+}

--- a/electron/daemonClient/envelope.ts
+++ b/electron/daemonClient/envelope.ts
@@ -1,0 +1,177 @@
+// electron/daemonClient/envelope.ts
+//
+// Electron-side mirror of the daemon's envelope wire-format
+// (`daemon/src/envelope/envelope.ts`). Pure encode/decode of length-prefixed
+// JSON+trailer frames per spec frag-3.4.1 §3.4.1.a (frame-version nibble +
+// 16 MiB cap) + §3.4.1.c (header + payload split).
+//
+// Why a mirror instead of an import:
+//   - daemon/ is a separate workspace bundle (ESM, NodeNext) and electron/
+//     compiles to CommonJS via tsconfig.electron.json. The two cannot share
+//     source files at runtime (`ERR_REQUIRE_ESM`). The wire format is locked
+//     by the spec and is byte-stable across versions, so the cost of a small
+//     duplicated module is low; a drift-guard test (`envelope-parity.test.ts`)
+//     pins this mirror against the daemon's encoder by round-tripping the
+//     same JSON bytes through both sides.
+//   - Mirrors the same precedent set by `electron/daemon/bootDaemon.ts`,
+//     which mirrors `scripts/double-bind-guard.ts` for the same reason.
+//
+// Single Responsibility (per dev contract §2):
+//   - DECIDER: `encodeFrame` / `decodeFrame` are pure functions
+//     `(input) -> output | EnvelopeError`. No I/O, no module-level state.
+//
+// Spec layout (must stay byte-identical to daemon/src/envelope/envelope.ts):
+//   [totalLen:4][headerLen:2][headerJSON:headerLen][payloadBytes:totalLen-2-headerLen]
+//
+// Parse order is NON-NEGOTIABLE (frag-3.4.1 §3.4.1.a round-3 security CC-1):
+//   1. Read 4-byte big-endian -> `raw`.
+//   2. Extract version nibble FIRST: `nibble = (raw >>> 28) & 0x0F`.
+//      Unknown -> throw `UNSUPPORTED_FRAME_VERSION` BEFORE masking.
+//   3. THEN mask low 28 bits: `len = raw & 0x0FFFFFFF`.
+//   4. THEN cap-check: `len > 16 MiB` -> throw `envelope_too_large`.
+
+import { Buffer } from 'node:buffer';
+
+const FRAME_VERSION_V03 = 0x0;
+const KNOWN_FRAME_VERSIONS: ReadonlySet<number> = new Set([FRAME_VERSION_V03]);
+
+// 16 MiB hard cap on per-frame payload length (spec §3.4.1.a).
+const MAX_PAYLOAD_BYTES = 16 * 1024 * 1024;
+
+const PREFIX_LEN = 4;
+const HEADER_LEN_FIELD = 2;
+const MAX_HEADER_LEN = 0xffff;
+
+export interface DecodedFrame {
+  readonly version: number;
+  readonly headerJson: Buffer;
+  readonly payload: Buffer;
+}
+
+export interface EncodeOptions {
+  readonly version?: number;
+  readonly headerJson: Buffer;
+  readonly payload?: Buffer;
+}
+
+export class EnvelopeError extends Error {
+  public readonly code: string;
+  public readonly nibble?: number;
+  public readonly len?: number;
+
+  constructor(code: string, message: string, extras?: { nibble?: number; len?: number }) {
+    super(message);
+    this.name = 'EnvelopeError';
+    this.code = code;
+    if (extras?.nibble !== undefined) this.nibble = extras.nibble;
+    if (extras?.len !== undefined) this.len = extras.len;
+  }
+}
+
+export function encodeFrame(opts: EncodeOptions): Buffer {
+  const version = opts.version ?? FRAME_VERSION_V03;
+  if (!KNOWN_FRAME_VERSIONS.has(version)) {
+    throw new EnvelopeError(
+      'UNSUPPORTED_FRAME_VERSION',
+      `unknown frame-version nibble 0x${version.toString(16)}`,
+      { nibble: version },
+    );
+  }
+  const headerJson = opts.headerJson;
+  const payload = opts.payload ?? Buffer.alloc(0);
+  const headerLen = headerJson.length;
+  if (headerLen > MAX_HEADER_LEN) {
+    throw new EnvelopeError(
+      'header_too_large',
+      `header bytes ${headerLen} exceed uint16 max ${MAX_HEADER_LEN}`,
+      { len: headerLen },
+    );
+  }
+  const payloadLen = HEADER_LEN_FIELD + headerLen + payload.length;
+  if (payloadLen > MAX_PAYLOAD_BYTES) {
+    throw new EnvelopeError(
+      'envelope_too_large',
+      `frame payload ${payloadLen} exceeds 16 MiB cap`,
+      { len: payloadLen },
+    );
+  }
+  const raw = ((version & 0x0f) << 28) | (payloadLen & 0x0fffffff);
+  const out = Buffer.allocUnsafe(PREFIX_LEN + payloadLen);
+  out.writeUInt32BE(raw >>> 0, 0);
+  out.writeUInt16BE(headerLen, PREFIX_LEN);
+  headerJson.copy(out, PREFIX_LEN + HEADER_LEN_FIELD);
+  if (payload.length > 0) {
+    payload.copy(out, PREFIX_LEN + HEADER_LEN_FIELD + headerLen);
+  }
+  return out;
+}
+
+export function decodeFrame(buf: Buffer): DecodedFrame {
+  if (buf.length < PREFIX_LEN) {
+    throw new EnvelopeError('truncated_frame', 'buffer too short for 4-byte prefix');
+  }
+  const raw = buf.readUInt32BE(0);
+
+  // Step 1: extract nibble FIRST.
+  const nibble = (raw >>> 28) & 0x0f;
+  if (!KNOWN_FRAME_VERSIONS.has(nibble)) {
+    throw new EnvelopeError(
+      'UNSUPPORTED_FRAME_VERSION',
+      `unknown frame-version nibble 0x${nibble.toString(16)}`,
+      { nibble },
+    );
+  }
+
+  // Step 2: mask low 28 bits.
+  const payloadLen = raw & 0x0fffffff;
+
+  // Step 3: cap-check.
+  if (payloadLen > MAX_PAYLOAD_BYTES) {
+    throw new EnvelopeError(
+      'envelope_too_large',
+      `frame payload ${payloadLen} exceeds 16 MiB cap`,
+      { len: payloadLen },
+    );
+  }
+
+  // Step 4: ensure full-frame availability.
+  const totalNeeded = PREFIX_LEN + payloadLen;
+  if (buf.length < totalNeeded) {
+    throw new EnvelopeError(
+      'truncated_frame',
+      `buffer ${buf.length} bytes < expected ${totalNeeded}`,
+      { len: payloadLen },
+    );
+  }
+  if (payloadLen < HEADER_LEN_FIELD) {
+    throw new EnvelopeError(
+      'corrupt_header_len',
+      `payload ${payloadLen} bytes too small for headerLen field`,
+      { len: payloadLen },
+    );
+  }
+
+  const headerLen = buf.readUInt16BE(PREFIX_LEN);
+  const headerStart = PREFIX_LEN + HEADER_LEN_FIELD;
+  const headerEnd = headerStart + headerLen;
+  if (headerEnd > totalNeeded) {
+    throw new EnvelopeError(
+      'corrupt_header_len',
+      `headerLen ${headerLen} overflows frame payload ${payloadLen}`,
+      { len: headerLen },
+    );
+  }
+
+  const headerJson = buf.subarray(headerStart, headerEnd);
+  const payload = buf.subarray(headerEnd, totalNeeded);
+
+  return { version: nibble, headerJson, payload };
+}
+
+export const ENVELOPE_LIMITS = Object.freeze({
+  MAX_PAYLOAD_BYTES,
+  MAX_HEADER_LEN,
+  PREFIX_LEN,
+  HEADER_LEN_FIELD,
+  FRAME_VERSION_V03,
+});

--- a/electron/daemonClient/rpcClient.ts
+++ b/electron/daemonClient/rpcClient.ts
@@ -1,0 +1,432 @@
+// electron/daemonClient/rpcClient.ts
+//
+// Electron-side socket-RPC client for the v0.3 daemon-split (Task #27 / B7b).
+// Pairs with the daemon-side envelope adapter (`daemon/src/envelope/adapter.ts`,
+// PR #773 / Task #28). Together they complete the v0.3 IPC layer that
+// replaces the v0.2 in-process / hand-rolled transport.
+//
+// Spec citations:
+//   - docs/superpowers/specs/v0.3-fragments/frag-3.4.1-envelope-hardening.md
+//     §3.4.1.a frame-version nibble + 16 MiB cap (encode/decode in
+//     ./envelope.ts);
+//     §3.4.1.c JSON header schema (`{ id, method, payloadType, payloadLen,
+//     traceId? }`); reply shape `{ id, ok: true, value, ack_source }` /
+//     `{ id, ok: false, error: { code, message } }`.
+//   - frag-3.4.1 §3.4.1.h two-socket topology — Electron-main connects to
+//     BOTH control-socket (supervisor-plane RPCs in `SUPERVISOR_RPCS`) AND
+//     data-socket (everything else). This file is transport-agnostic; the
+//     caller (controlClient.ts / dataClient.ts) supplies the path.
+//
+// What this module deliberately does NOT do (out of scope for B7b):
+//   - HMAC handshake (`daemon.hello`), version negotiation, peer-cred check.
+//     The daemon side currently accepts unauthenticated frames (PR #773 ships
+//     the framing layer only; interceptors arrive in their own slices). When
+//     the hello-interceptor lands daemon-side, this client gains a one-time
+//     handshake at connect time before resolving the first user RPC.
+//   - Streaming RPCs (chunked PTY subscribe). Unary only — sufficient for
+//     today's call site (`daemon.shutdownForUpgrade`). The frame format
+//     supports streams natively; adding them is a follow-up.
+//   - Renderer <-> main IPC. Renderer keeps using contextBridge / ipcMain
+//     unchanged — that's NOT part of the daemon-split migration.
+//
+// Single Responsibility (per dev contract §2):
+//   - PRODUCER: socket `data` events accumulate into a per-connection buffer.
+//   - DECIDER: `decodeFrame` (pure) -> JSON.parse -> route reply by `id`.
+//   - SINK: `socket.write(encodedFrame)` -- request emit + connect/close.
+//
+// Reconnect policy:
+//   - The spec (§3.7.4) owns the canonical reconnect schedule but only the
+//     daemon-supervisor side is normative; this client implements a simple
+//     bounded exponential backoff (250 ms, 500 ms, 1 s, 2 s, capped 5 s)
+//     suitable for the v0.3 dogfood-only scope. Pending in-flight calls at
+//     disconnect time are rejected with `RPC_DISCONNECTED` so the caller
+//     can decide whether to retry. We do NOT auto-resend across reconnects
+//     because re-issuing `daemon.shutdownForUpgrade` (the v0.3 caller) twice
+//     would be unsafe; future stream subscribers gain auto-resubscribe via
+//     the existing streamHandleTable cleanup hook.
+
+import { Buffer } from 'node:buffer';
+import { connect, type Socket } from 'node:net';
+import { decodeFrame, encodeFrame, EnvelopeError } from './envelope';
+
+// ---------------------------------------------------------------------------
+// Public surface
+// ---------------------------------------------------------------------------
+
+export interface RpcClientOptions {
+  /** Absolute socket path or Windows named-pipe path. */
+  readonly socketPath: string;
+  /** Per-call default timeout in milliseconds. Defaults to 5_000 (matches
+   *  the spec §3.4.1.c default `x-ccsm-deadline-ms`). Caller may override
+   *  per-call via `RpcCallOptions.timeoutMs`. */
+  readonly defaultTimeoutMs?: number;
+  /** Test seam: substitute the `net.connect` factory. Defaults to
+   *  `node:net.connect`. */
+  readonly connectFn?: (path: string) => Socket;
+  /** Optional log sink for warn lines (connect failure, decode error,
+   *  unexpected reply id). Defaults to `console.warn`. */
+  readonly log?: (line: string, extras?: Record<string, unknown>) => void;
+  /** Reconnect backoff schedule in ms. First element used on the first
+   *  reconnect; the last is held for subsequent attempts. Defaults to
+   *  `[250, 500, 1000, 2000, 5000]`. Pass `[]` to disable reconnect entirely
+   *  (one-shot connection — the client closes after the first disconnect
+   *  and rejects all subsequent calls). */
+  readonly reconnectBackoffMs?: readonly number[];
+}
+
+export interface RpcCallOptions {
+  /** Override the per-client default. */
+  readonly timeoutMs?: number;
+  /** Optional Crockford ULID for trace correlation. The daemon side
+   *  forwards this to handlers via `DispatchContext.traceId`. */
+  readonly traceId?: string;
+}
+
+/** Successful reply mirrors the daemon's `DispatchOk` shape. */
+export interface RpcOkReply<T = unknown> {
+  readonly ok: true;
+  readonly value: T;
+  readonly ack_source: 'handler' | 'dispatcher';
+}
+
+/** Error reply mirrors the daemon's `DispatchErr` shape. */
+export interface RpcErrReply {
+  readonly ok: false;
+  readonly error: {
+    readonly code: string;
+    readonly message: string;
+    readonly method?: string;
+  };
+}
+
+export type RpcReply<T = unknown> = RpcOkReply<T> | RpcErrReply;
+
+/** Typed error thrown by `call()` on transport failure (timeout, disconnect,
+ *  decode error). Application-level errors arrive as `RpcErrReply` and DO NOT
+ *  throw — caller inspects `reply.ok`. */
+export class RpcTransportError extends Error {
+  public readonly code: 'RPC_TIMEOUT' | 'RPC_DISCONNECTED' | 'RPC_NOT_CONNECTED' | 'RPC_DECODE';
+  constructor(
+    code: 'RPC_TIMEOUT' | 'RPC_DISCONNECTED' | 'RPC_NOT_CONNECTED' | 'RPC_DECODE',
+    message: string,
+  ) {
+    super(message);
+    this.name = 'RpcTransportError';
+    this.code = code;
+  }
+}
+
+export interface RpcClient {
+  /** Connect (idempotent). Resolves once the socket is `connect`-ready.
+   *  Subsequent calls await the in-flight connection. */
+  connect(): Promise<void>;
+  /** Send a unary RPC; resolve with the reply envelope (ok or err). Reject
+   *  with `RpcTransportError` on transport failure. */
+  call<T = unknown>(method: string, payload?: unknown, opts?: RpcCallOptions): Promise<RpcReply<T>>;
+  /** Close the socket and stop reconnecting. Idempotent. Pending calls
+   *  reject with `RPC_DISCONNECTED`. */
+  close(): void;
+  /** Snapshot of liveness for tests / debug overlays. */
+  readonly isConnected: boolean;
+  readonly pendingCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+interface PendingCall {
+  readonly id: number;
+  readonly method: string;
+  readonly resolve: (reply: RpcReply) => void;
+  readonly reject: (err: Error) => void;
+  readonly timer: ReturnType<typeof setTimeout> | null;
+}
+
+const DEFAULT_BACKOFF: readonly number[] = [250, 500, 1000, 2000, 5000] as const;
+
+export function createRpcClient(opts: RpcClientOptions): RpcClient {
+  const defaultTimeoutMs = opts.defaultTimeoutMs ?? 5_000;
+  const connectFn = opts.connectFn ?? ((p: string) => connect(p));
+  const log = opts.log ?? ((line: string, extras?: Record<string, unknown>) => {
+    if (extras) console.warn(`[rpc-client] ${line}`, extras);
+    else console.warn(`[rpc-client] ${line}`);
+  });
+  const backoff = opts.reconnectBackoffMs ?? DEFAULT_BACKOFF;
+  const reconnectEnabled = backoff.length > 0;
+
+  let socket: Socket | null = null;
+  let connectPromise: Promise<void> | null = null;
+  let connected = false;
+  let closed = false;
+  let nextId = 1;
+  let reconnectAttempt = 0;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // Per-connection inbound buffer. A single Buffer accumulator keeps decode
+  // O(N) on the read side; for v0.3 dogfood load (occasional unary RPC) the
+  // simpler array+concat approach the daemon adapter uses would also work
+  // but a single buffer keeps the loop body shorter.
+  let inbound: Buffer = Buffer.alloc(0);
+
+  const pending = new Map<number, PendingCall>();
+
+  function rejectAllPending(err: Error): void {
+    for (const p of pending.values()) {
+      if (p.timer) clearTimeout(p.timer);
+      p.reject(err);
+    }
+    pending.clear();
+  }
+
+  function scheduleReconnect(): void {
+    if (closed || !reconnectEnabled) return;
+    const delay = backoff[Math.min(reconnectAttempt, backoff.length - 1)] ?? 5_000;
+    reconnectAttempt += 1;
+    log(`scheduling reconnect in ${delay}ms (attempt ${reconnectAttempt})`);
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null;
+      // Discard the resolved promise; subsequent .connect() calls (or the
+      // next .call()) await a fresh connectPromise.
+      void doConnect().catch(() => {
+        // Already logged inside doConnect; backoff handles re-scheduling.
+      });
+    }, delay);
+    (reconnectTimer as unknown as { unref?: () => void }).unref?.();
+  }
+
+  function onSocketData(chunk: Buffer): void {
+    inbound = inbound.length === 0 ? chunk : Buffer.concat([inbound, chunk]);
+    // Loop until we're short of a full frame.
+    for (;;) {
+      let decoded;
+      try {
+        decoded = decodeFrame(inbound);
+      } catch (err) {
+        if (err instanceof EnvelopeError && err.code === 'truncated_frame') {
+          // Wait for more bytes.
+          return;
+        }
+        // Unrecoverable framing error — destroy + reject all.
+        log(`decode failed: ${(err as Error).message}`, {
+          code: err instanceof EnvelopeError ? err.code : 'unknown',
+        });
+        if (socket) {
+          try { socket.destroy(); } catch { /* ignore */ }
+        }
+        return;
+      }
+
+      const consumed =
+        4 /* prefix */ + 2 /* headerLen */ + decoded.headerJson.length + decoded.payload.length;
+      inbound = inbound.subarray(consumed);
+
+      let header: unknown;
+      try {
+        header = JSON.parse(decoded.headerJson.toString('utf8'));
+      } catch {
+        log('reply header is not valid JSON; dropping');
+        continue;
+      }
+      if (header === null || typeof header !== 'object') {
+        log('reply header is not an object; dropping');
+        continue;
+      }
+      const h = header as Record<string, unknown>;
+      const id = h.id;
+      if (typeof id !== 'number' || !Number.isInteger(id)) {
+        log('reply header missing numeric id; dropping');
+        continue;
+      }
+
+      // id === 0 is reserved for daemon-side synthetic error replies that
+      // could not bind to any in-flight call (e.g. an oversize frame the
+      // adapter rejects before parsing). Surface as a warn line; we cannot
+      // route it to a caller.
+      if (id === 0) {
+        log(`synthetic daemon error reply (id=0)`, { header: h });
+        continue;
+      }
+
+      const call = pending.get(id);
+      if (!call) {
+        log(`reply for unknown id=${id}; dropping`);
+        continue;
+      }
+      pending.delete(id);
+      if (call.timer) clearTimeout(call.timer);
+
+      // Normalise the reply into RpcReply discriminated union.
+      if (h.ok === true) {
+        const value = h.value;
+        const ackSource =
+          h.ack_source === 'dispatcher' || h.ack_source === 'handler'
+            ? (h.ack_source as 'dispatcher' | 'handler')
+            : 'handler';
+        call.resolve({ ok: true, value, ack_source: ackSource });
+      } else if (h.ok === false) {
+        const errObj = (h.error ?? {}) as Record<string, unknown>;
+        const code = typeof errObj.code === 'string' ? errObj.code : 'INTERNAL';
+        const message = typeof errObj.message === 'string' ? errObj.message : '';
+        const reply: RpcErrReply = {
+          ok: false,
+          error: typeof errObj.method === 'string'
+            ? { code, message, method: errObj.method }
+            : { code, message },
+        };
+        call.resolve(reply);
+      } else {
+        // Spec violation — surface as transport-level decode error.
+        call.reject(new RpcTransportError('RPC_DECODE', `reply id=${id} missing ok flag`));
+      }
+    }
+  }
+
+  function doConnect(): Promise<void> {
+    if (closed) {
+      return Promise.reject(new RpcTransportError('RPC_NOT_CONNECTED', 'client is closed'));
+    }
+    if (connected) return Promise.resolve();
+    if (connectPromise) return connectPromise;
+
+    connectPromise = new Promise<void>((resolve, reject) => {
+      const sock = connectFn(opts.socketPath);
+      socket = sock;
+      inbound = Buffer.alloc(0);
+
+      const onConnect = (): void => {
+        connected = true;
+        reconnectAttempt = 0;
+        connectPromise = null;
+        sock.removeListener('error', onErrorBeforeConnect);
+        resolve();
+      };
+      const onErrorBeforeConnect = (err: Error): void => {
+        connected = false;
+        connectPromise = null;
+        sock.removeListener('connect', onConnect);
+        try { sock.destroy(); } catch { /* ignore */ }
+        socket = null;
+        log(`connect failed: ${err.message}`);
+        scheduleReconnect();
+        reject(err);
+      };
+
+      sock.once('connect', onConnect);
+      sock.once('error', onErrorBeforeConnect);
+
+      sock.on('data', (chunk: Buffer) => onSocketData(chunk));
+
+      sock.on('error', (err: Error) => {
+        // Post-connect errors get logged; the matching `close` handler does
+        // the cleanup (Node always emits `close` after `error` on Sockets).
+        if (connected) log(`socket error: ${err.message}`);
+      });
+
+      sock.on('close', () => {
+        const wasConnected = connected;
+        connected = false;
+        socket = null;
+        inbound = Buffer.alloc(0);
+        rejectAllPending(
+          new RpcTransportError('RPC_DISCONNECTED', 'socket closed before reply'),
+        );
+        if (wasConnected) scheduleReconnect();
+      });
+    });
+    return connectPromise;
+  }
+
+  async function call<T = unknown>(
+    method: string,
+    payload?: unknown,
+    callOpts?: RpcCallOptions,
+  ): Promise<RpcReply<T>> {
+    if (closed) {
+      throw new RpcTransportError('RPC_NOT_CONNECTED', 'client is closed');
+    }
+    await doConnect();
+    if (!socket || !connected) {
+      throw new RpcTransportError('RPC_NOT_CONNECTED', 'socket is not connected');
+    }
+
+    const id = nextId++;
+    const timeoutMs = callOpts?.timeoutMs ?? defaultTimeoutMs;
+
+    const headerObj: Record<string, unknown> = {
+      id,
+      method,
+      payloadType: 'json',
+      payloadLen: 0,
+    };
+    if (callOpts?.traceId !== undefined) headerObj.traceId = callOpts.traceId;
+    if (payload !== undefined) headerObj.payload = payload;
+
+    const headerJson = Buffer.from(JSON.stringify(headerObj), 'utf8');
+    const frame = encodeFrame({ headerJson });
+
+    return new Promise<RpcReply<T>>((resolve, reject) => {
+      const timer =
+        timeoutMs > 0
+          ? setTimeout(() => {
+              if (!pending.has(id)) return;
+              pending.delete(id);
+              reject(
+                new RpcTransportError(
+                  'RPC_TIMEOUT',
+                  `RPC ${method} (id=${id}) timed out after ${timeoutMs}ms`,
+                ),
+              );
+            }, timeoutMs)
+          : null;
+      if (timer) (timer as unknown as { unref?: () => void }).unref?.();
+
+      pending.set(id, {
+        id,
+        method,
+        resolve: (r) => resolve(r as RpcReply<T>),
+        reject,
+        timer,
+      });
+
+      try {
+        socket!.write(frame);
+      } catch (err) {
+        pending.delete(id);
+        if (timer) clearTimeout(timer);
+        reject(
+          new RpcTransportError(
+            'RPC_DISCONNECTED',
+            `socket.write failed: ${(err as Error).message}`,
+          ),
+        );
+      }
+    });
+  }
+
+  function close(): void {
+    if (closed) return;
+    closed = true;
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+    }
+    if (socket) {
+      try { socket.destroy(); } catch { /* ignore */ }
+      socket = null;
+    }
+    rejectAllPending(
+      new RpcTransportError('RPC_DISCONNECTED', 'client closed by caller'),
+    );
+    connected = false;
+    connectPromise = null;
+  }
+
+  return {
+    connect: doConnect,
+    call,
+    close,
+    get isConnected() { return connected; },
+    get pendingCount() { return pending.size; },
+  };
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -35,7 +35,9 @@ import { createTray, type TrayController } from './tray/createTray';
 import { startCrashCollector } from './crash/collector';
 import { resolveCrashRoot } from './crash/incident-dir';
 import { wireCrashHandlers } from './main-crash-wiring';
-import { bootDaemon } from './daemon/bootDaemon';
+import { bootDaemon, resolveControlSocketPath } from './daemon/bootDaemon';
+import { createControlClient, type ControlClient } from './daemonClient/controlClient';
+import { setUpgradeShutdownRpc } from './updater';
 
 // Phase 1 crash observability (spec §5.1, plan Task 2):
 //   * crashReporter.start with empty submitURL + uploadToServer:false enables
@@ -151,6 +153,12 @@ acquireSingleInstanceLock();
 // (selectSession etc.). Main mirrors it so the notify bridge can suppress
 // toasts for the session the user is already looking at without a
 // synchronous round-trip to read renderer state.
+// Task #27 / B7b — control-socket RPC client. Constructed in `app.whenReady`
+// after `bootDaemon` and closed on `before-quit` so the underlying socket
+// releases cleanly. Module-scope so the `app.on('will-quit')` hook below
+// can reach it without threading another bag.
+let controlClient: ControlClient | null = null;
+
 let activeSidFromRenderer: string | null = null;
 
 // Same pattern as activeSidFromRenderer: the renderer pushes its session-name
@@ -249,6 +257,28 @@ app.whenReady().then(() => {
   void bootDaemon({
     isPackaged: app.isPackaged,
     resourcesPath: process.resourcesPath,
+  });
+
+  // Task #27 / B7b — wire the Electron-side socket-RPC client into the
+  // existing `setUpgradeShutdownRpc` injection seam (frag-11 §11.6.5 step 3).
+  // The client lazy-connects on first call, so constructing it here is cheap
+  // even when the daemon isn't bound yet (`bootDaemon` runs fire-and-forget
+  // above; the daemon may still be spawning when we reach this line). The
+  // updater path is the only v0.3 caller; future supervisor RPCs (healthz,
+  // shutdown, hello) plug into this same client.
+  controlClient = createControlClient({
+    socketPath: resolveControlSocketPath(process.platform, process.env),
+  });
+  setUpgradeShutdownRpc(controlClient.callShutdownForUpgrade);
+
+  // Close the control socket cleanly on quit so the daemon doesn't see a
+  // half-closed peer pile up across user-driven Electron quits. before-quit
+  // is emitted before window-all-closed → app.quit() in
+  // `electron/lifecycle/appLifecycle.ts`, so this fires once per real quit.
+  app.on('before-quit', () => {
+    try { controlClient?.rpc.close(); } catch { /* best-effort */ }
+    setUpgradeShutdownRpc(null);
+    controlClient = null;
   });
 
   // ─────────────────────────── IPC registration ──────────────────────────


### PR DESCRIPTION
## Summary

Adds the Electron-main socket RPC client that pairs with the daemon-side envelope adapter from PR #773 (Task #28). Together they complete the v0.3 daemon-split IPC layer (spec [frag-3.4.1 §3.4.1.a/c/h](docs/superpowers/specs/v0.3-fragments/frag-3.4.1-envelope-hardening.md)).

Resolves Task #27 (B7b).

> **Base branch note**: this PR is branched off `chore/v03-daemon-envelope-adapter` (PR #773 head), not `working`, because the e2e parity test imports the daemon adapter that ships in #773. The diff below is the union of #773 + this commit; once #773 merges to `working` only this commit will remain. **Review only the second commit (`fa0af4a feat(electron): migrate IPC to socket RPC envelope client`); the first commit is PR #773's content.**

## What landed

- **`electron/daemonClient/envelope.ts`** - byte-stable mirror of `daemon/src/envelope/envelope.ts`. The two cannot share source at runtime: client compiles to CJS via `tsconfig.electron.json`, daemon to ESM via `daemon/tsconfig.json`. A parity test round-trips frames through both encoders/decoders to guard against drift, mirroring the existing precedent set by `electron/daemon/bootDaemon.ts` ↔ `scripts/double-bind-guard.ts`.
- **`electron/daemonClient/rpcClient.ts`** - transport-agnostic length-prefixed JSON envelope client. Connect (idempotent, lazy), monotonic-id request/response correlation, per-call timeout, bounded-backoff reconnect (250 ms / 500 ms / 1 s / 2 s / 5 s), `RpcTransportError` taxonomy (`RPC_TIMEOUT` / `RPC_DISCONNECTED` / `RPC_NOT_CONNECTED` / `RPC_DECODE`).
- **`electron/daemonClient/controlClient.ts`** - typed facade exposing `daemon.shutdownForUpgrade` with the 5 s ack window from frag-11 §11.6.5.
- **`electron/main.ts`** - construct `controlClient` after `bootDaemon`, feed `setUpgradeShutdownRpc(...)` (the existing T62 injection seam in `electron/updater.ts`, which was a no-op default before this PR), close the socket on `app.before-quit`.

## Scope discipline (per task constraint)

- v0.3 = pure refactor; this PR adds zero new RPC methods. Only the existing `daemon.shutdownForUpgrade` call site is migrated. Future supervisor RPCs (`/healthz`, `/stats`, `daemon.hello`, `daemon.shutdown`) plug into the same client without changing it.
- Renderer ↔ main IPC (preload, contextBridge) is intentionally untouched.
- HMAC handshake / hello-gate / interceptor pipeline / streaming RPCs are deliberately deferred (daemon side ships them in their own slices; this PR only ships framing + correlation + reconnect).

## Test coverage

`electron/daemonClient/__tests__/` (33 cases, 2.9 s wall):

- `envelope.test.ts` (8): encode/decode happy path, oversize reject, unknown frame-version nibble reject **before** the length-cap check (asserts spec §3.4.1.a CC-1 parse order), `truncated_frame`, byte-for-byte parity in BOTH directions with the daemon's `encodeFrame`/`decodeFrame`.
- `rpcClient.test.ts` (6): request frame shape (id, method, payloadType=json), concurrent id correlation with out-of-order replies, `RPC_TIMEOUT`, `RPC_DISCONNECTED` on socket close, reconnect schedule fires under backoff, post-`close()` rejects with `RPC_NOT_CONNECTED`, **end-to-end round-trip through the real `mountEnvelopeAdapter` from PR #773** via paired duplex streams (proves wire-format parity at the integration boundary, not just the encode site).
- `controlClient.test.ts` (3): typed ack happy path, error envelope -> thrown `Error("CODE: msg")` so updater.ts's outer race classifies as `{ kind: 'error' }`, malformed ack shape -> thrown `Error("malformed ack ...")`.

## Local verification

\`\`\`
$ ./node_modules/.bin/tsc --noEmit && ./node_modules/.bin/tsc --noEmit -p tsconfig.electron.json && ./node_modules/.bin/tsc --noEmit -p daemon/tsconfig.json
(clean)

$ ./node_modules/.bin/eslint electron/daemonClient/
(clean -- 1 pre-existing error in main.ts:92 untouched)

$ ./node_modules/.bin/vitest run electron/daemonClient/__tests__/
 Test Files  4 passed (4)
      Tests  33 passed (33)

$ ./node_modules/.bin/tsc -p tsconfig.electron.json && \
  node -e "require('./dist/electron/daemonClient/envelope.js'); \
           require('./dist/electron/daemonClient/rpcClient.js'); \
           require('./dist/electron/daemonClient/controlClient.js'); \
           console.log('OK: all 3 modules require-loaded')"
OK: all 3 modules require-loaded
\`\`\`

Last command is the dev-contract \`ERR_REQUIRE_ESM\` smoke per \`~/.claude/skills/team-protocol/references/dev.md\` §2.

## Test plan

- [x] tsc clean across all three projects
- [x] vitest 33/33 pass
- [x] require-load smoke (no ERR_REQUIRE_ESM) for all three new CJS modules
- [x] e2e parity: \`client.call\` -> real \`mountEnvelopeAdapter\` -> stub dispatcher -> reply -> \`client.call\` resolves with typed \`{ ok, value, ack_source }\`
- [ ] CI: green on parity job (note: matrix-OS jobs may show fake SKIPs per Task #35 workflow bug -- ignore those if they appear)