### PR TITLE
fix(dev): isolate daemon pipe per worktree

### DIFF
--- a/daemon/src/sockets/__tests__/control-socket.test.ts
+++ b/daemon/src/sockets/__tests__/control-socket.test.ts
@@ -96,6 +96,35 @@ describe('defaultControlSocketPath', () => {
     const b = defaultControlSocketPath('win32', 'C:\\x');
     expect(a).toBe(b);
   });
+
+  // -------------------------------------------------------------------------
+  // B10 cross-worktree pipe collision fix: when env.CCSM_DAEMON_DEV === '1'
+  // the Windows pipe userhash MUST fold in cwd so two dev daemons launched
+  // from different git worktrees on the same host get distinct pipe names.
+  // Production env keeps the canonical username@hostname seed.
+  // -------------------------------------------------------------------------
+  it('Windows + CCSM_DAEMON_DEV=1: pipe name differs from production for same user/host', () => {
+    const prod = defaultControlSocketPath('win32', 'C:\\x', {});
+    const dev = defaultControlSocketPath('win32', 'C:\\x', { CCSM_DAEMON_DEV: '1' });
+    expect(prod).not.toBe(dev);
+    // Both still match shape \\.\pipe\ccsm-control-<8 hex>
+    expect(dev.startsWith('\\\\.\\pipe\\ccsm-control-')).toBe(true);
+    expect(dev.slice('\\\\.\\pipe\\ccsm-control-'.length)).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it('Windows + CCSM_DAEMON_DEV=1: deterministic for the same cwd', () => {
+    const a = defaultControlSocketPath('win32', 'C:\\x', { CCSM_DAEMON_DEV: '1' });
+    const b = defaultControlSocketPath('win32', 'C:\\x', { CCSM_DAEMON_DEV: '1' });
+    expect(a).toBe(b);
+  });
+
+  it('POSIX path is unaffected by dev gate (only Windows pipe namespace collides)', () => {
+    // POSIX uses runtimeRoot directly; dev mode is irrelevant.
+    const prod = defaultControlSocketPath('linux', '/r', {});
+    const dev = defaultControlSocketPath('linux', '/r', { CCSM_DAEMON_DEV: '1' });
+    expect(prod).toBe(dev);
+    expect(prod).toBe('/r/ccsm-control.sock');
+  });
 });
 
 describe('createControlSocketServer — listen + accept', () => {

--- a/daemon/src/sockets/__tests__/data-socket.test.ts
+++ b/daemon/src/sockets/__tests__/data-socket.test.ts
@@ -63,6 +63,30 @@ describe('dataSocketPath', () => {
     expect(b).toBe('\\\\.\\pipe\\ccsm-data-bbbbbbbb');
     expect(a).not.toBe(b);
   });
+
+  // -------------------------------------------------------------------------
+  // B10 cross-worktree pipe collision fix: in dev mode the auto-derived
+  // Windows pipe userhash must fold in cwd. Production env keeps the
+  // canonical username@hostname seed (single-bind across Electron restarts).
+  // -------------------------------------------------------------------------
+  it('Windows + CCSM_DAEMON_DEV=1: auto-derived pipe differs from production', () => {
+    const prod = dataSocketPath('C:\\x', 'win32', undefined, {});
+    const dev = dataSocketPath('C:\\x', 'win32', undefined, { CCSM_DAEMON_DEV: '1' });
+    expect(prod).not.toBe(dev);
+    expect(dev).toMatch(/^\\\\\.\\pipe\\ccsm-data-[0-9a-f]{8}$/);
+  });
+
+  it('Windows + CCSM_DAEMON_DEV=1: hashOverride still wins over the dev-mode auto-derive', () => {
+    const got = dataSocketPath('C:\\x', 'win32', 'deadbeef', { CCSM_DAEMON_DEV: '1' });
+    expect(got).toBe('\\\\.\\pipe\\ccsm-data-deadbeef');
+  });
+
+  it('POSIX path is unaffected by dev gate', () => {
+    const prod = dataSocketPath('/r', 'linux', undefined, {});
+    const dev = dataSocketPath('/r', 'linux', undefined, { CCSM_DAEMON_DEV: '1' });
+    expect(prod).toBe(dev);
+    expect(prod).toBe(join('/r', 'ccsm-data.sock'));
+  });
 });
 
 describe('createDataSocketServer — basic transport', () => {

--- a/daemon/src/sockets/__tests__/runtime-root.test.ts
+++ b/daemon/src/sockets/__tests__/runtime-root.test.ts
@@ -197,4 +197,76 @@ describe('userHash', () => {
     // Same call twice — process identity is fixed for the test run.
     expect(userHash()).toBe(h);
   });
+
+  // -------------------------------------------------------------------------
+  // Dev-mode cwd-mix gate (B10 cross-worktree pipe collision fix). When
+  // `env.CCSM_DAEMON_DEV === '1'` the seed folds in `cwd` so two dev daemons
+  // spawned from different git worktrees on the same Windows host bind to
+  // distinct named pipes. Production gate stays canonical so the packaged
+  // installer keeps single-bind semantics across Electron restarts (frag-6-7
+  // §6.1 dogfood metric #1).
+  // -------------------------------------------------------------------------
+  describe('CCSM_DAEMON_DEV cwd-mix gate', () => {
+    it('production env: same (user, host) yields the same hash regardless of cwd', () => {
+      const a = userHash({
+        username: 'alice',
+        host: 'workstation',
+        cwd: '/repo/worktree-a',
+        env: {},
+      });
+      const b = userHash({
+        username: 'alice',
+        host: 'workstation',
+        cwd: '/repo/worktree-b',
+        env: {},
+      });
+      expect(a).toBe(b);
+    });
+
+    it('dev env: same (user, host, cwd) yields the same hash (deterministic)', () => {
+      const env = { CCSM_DAEMON_DEV: '1' };
+      const a = userHash({ username: 'alice', host: 'host', cwd: '/a', env });
+      const b = userHash({ username: 'alice', host: 'host', cwd: '/a', env });
+      expect(a).toBe(b);
+    });
+
+    it('dev env: distinct cwds yield distinct hashes (per-worktree isolation)', () => {
+      const env = { CCSM_DAEMON_DEV: '1' };
+      const a = userHash({ username: 'alice', host: 'host', cwd: '/repo/pool-3', env });
+      const b = userHash({ username: 'alice', host: 'host', cwd: '/repo/pool-5', env });
+      expect(a).not.toBe(b);
+    });
+
+    it('dev hash differs from production hash for the same (user, host)', () => {
+      const prod = userHash({ username: 'alice', host: 'host', cwd: '/x', env: {} });
+      const dev = userHash({
+        username: 'alice',
+        host: 'host',
+        cwd: '/x',
+        env: { CCSM_DAEMON_DEV: '1' },
+      });
+      expect(dev).not.toBe(prod);
+    });
+
+    it('dev gate is strict on the literal "1" sentinel (does NOT fire on "true" / "0" / unset)', () => {
+      const base = { username: 'alice', host: 'host', cwd: '/wt' };
+      const prod = userHash({ ...base, env: {} });
+      expect(userHash({ ...base, env: { CCSM_DAEMON_DEV: 'true' } })).toBe(prod);
+      expect(userHash({ ...base, env: { CCSM_DAEMON_DEV: '0' } })).toBe(prod);
+      expect(userHash({ ...base, env: { CCSM_DAEMON_DEV: '' } })).toBe(prod);
+      expect(userHash({ ...base, env: { CCSM_DAEMON_DEV: '1' } })).not.toBe(prod);
+    });
+
+    it('falls back to process.cwd() when cwd opt is omitted (dev mode)', () => {
+      const env = { CCSM_DAEMON_DEV: '1' };
+      const explicit = userHash({
+        username: 'alice',
+        host: 'host',
+        cwd: process.cwd(),
+        env,
+      });
+      const implicit = userHash({ username: 'alice', host: 'host', env });
+      expect(explicit).toBe(implicit);
+    });
+  });
 });

--- a/daemon/src/sockets/control-socket.ts
+++ b/daemon/src/sockets/control-socket.ts
@@ -41,8 +41,7 @@ import {
 } from 'node:net';
 import { unlinkSync, statSync, chmodSync } from 'node:fs';
 import { dirname, posix } from 'node:path';
-import { hostname, userInfo } from 'node:os';
-import { createHash } from 'node:crypto';
+import { userHash } from './runtime-root.js';
 
 /** Pre-accept rate cap, per spec §3.4.1.a (round-2 security T15). Counted
  *  PER LISTENER — control-socket and data-socket each have their own bucket. */
@@ -126,16 +125,21 @@ export interface ControlSocketServer {
  *           short SHA-256 of `username@hostname` (8 hex chars — spec is
  *           silent on width; 32 bits of entropy is plenty for a same-host
  *           same-user collision space and keeps the pipe name short).
+ *
+ *  Dev mode: when `env.CCSM_DAEMON_DEV === '1'` the userhash is computed
+ *  over `username@hostname#cwd` (delegated to `userHash()` in
+ *  `runtime-root.ts`). This isolates concurrent dev daemons spawned from
+ *  different git worktrees on the same host. Production keeps the
+ *  canonical `username@hostname` shape so the packaged Electron app can
+ *  attach to the surviving daemon across re-opens (frag-6-7 §6.1).
  */
 export function defaultControlSocketPath(
   platform: NodeJS.Platform,
   runtimeRoot: string,
+  env: NodeJS.ProcessEnv = process.env,
 ): string {
   if (platform === 'win32') {
-    const ui = userInfo();
-    const tag = `${ui.username}@${hostname()}`;
-    const userhash = createHash('sha256').update(tag).digest('hex').slice(0, 8);
-    return `\\\\.\\pipe\\ccsm-control-${userhash}`;
+    return `\\\\.\\pipe\\ccsm-control-${userHash({ env })}`;
   }
   // POSIX: explicitly use forward-slash join so a Windows-host test forcing
   // `platform: 'linux'` still yields a POSIX-shaped path (the on-disk

--- a/daemon/src/sockets/data-socket.ts
+++ b/daemon/src/sockets/data-socket.ts
@@ -105,14 +105,21 @@ export interface DataSocketServer {
  *             so the userhash suffix prevents bind collisions on multi-user
  *             hosts — Citrix / RDS / shared workstations. Spec:
  *             v0.3-design.md L267+L272, frag-3.4.1 L237.)
+ *
+ *   Dev mode: when `env.CCSM_DAEMON_DEV === '1'` the userhash is computed
+ *   over `username@hostname#cwd` (delegated to `userHash()` in
+ *   `runtime-root.ts`) so concurrent dev daemons spawned from different
+ *   git worktrees do NOT collide on bind. Production keeps the canonical
+ *   `username@hostname` shape.
  */
 export function dataSocketPath(
   runtimeRoot: string,
   platform: NodeJS.Platform = process.platform,
   hashOverride?: string,
+  env: NodeJS.ProcessEnv = process.env,
 ): string {
   if (platform === 'win32') {
-    const tag = hashOverride ?? userHash();
+    const tag = hashOverride ?? userHash({ env });
     return `\\\\.\\pipe\\ccsm-data-${tag}`;
   }
   return join(runtimeRoot, 'ccsm-data.sock');

--- a/daemon/src/sockets/runtime-root.ts
+++ b/daemon/src/sockets/runtime-root.ts
@@ -110,18 +110,38 @@ export function resolveRuntimeRoot(opts: ResolveRuntimeRootOptions = {}): string
  *       user could win the bind race against the daemon, leaving the
  *       §3.4.1.g HMAC handshake as the only imposter defense.
  *
- * Definition: lowercase first 8 hex chars of SHA-256(`<username>@<hostname>`).
- * Pure / deterministic / no I/O. Same OS user on the same host always yields
- * the same value; distinct usernames or hostnames yield (overwhelmingly)
- * distinct values.
+ * Definition (production):
+ *     lowercase first 8 hex chars of SHA-256(`<username>@<hostname>`).
+ * Definition (dev mode, `CCSM_DAEMON_DEV=1` in env):
+ *     lowercase first 8 hex chars of SHA-256(`<username>@<hostname>#<cwd>`).
+ *     This isolates the named-pipe / socket path per git worktree so two
+ *     concurrent dev daemons (e.g. running from `~/ccsm-worktrees/pool-3`
+ *     and `~/ccsm-worktrees/pool-5`) do NOT collide on bind. Production
+ *     installer flow keeps the canonical `username@hostname` shape so
+ *     re-opening the packaged Electron app continues to attach to the
+ *     surviving daemon (frag-6-7 §6.1 dogfood metric #1).
+ *
+ * Pure / deterministic / no I/O. Same inputs always yield the same value;
+ * distinct inputs yield (overwhelmingly) distinct values.
  *
  * Sibling helper to `resolveRuntimeRoot()` so T14 (control-socket) and T15
- * (data-socket) can share a single source of truth — T14's existing private
- * implementation can be refactored later to import this.
+ * (data-socket) can share a single source of truth.
  */
-export function userHash(opts: { username?: string; host?: string } = {}): string {
+export function userHash(
+  opts: {
+    username?: string;
+    host?: string;
+    cwd?: string;
+    env?: NodeJS.ProcessEnv;
+  } = {},
+): string {
   const username = opts.username ?? userInfo().username;
   const host = opts.host ?? hostname();
-  const digest = createHash('sha256').update(`${username}@${host}`).digest('hex');
+  const env = opts.env ?? process.env;
+  const devMode = env.CCSM_DAEMON_DEV === '1';
+  const seed = devMode
+    ? `${username}@${host}#${opts.cwd ?? process.cwd()}`
+    : `${username}@${host}`;
+  const digest = createHash('sha256').update(seed).digest('hex');
   return digest.slice(0, 8).toLowerCase();
 }

--- a/electron/daemon/bootDaemon.ts
+++ b/electron/daemon/bootDaemon.ts
@@ -34,6 +34,12 @@ import { spawnDaemon } from './supervisor';
 
 // ---------------------------------------------------------------------------
 // Pure path resolution (mirror of scripts/double-bind-guard.ts).
+//
+// Dev mode (`CCSM_DAEMON_DEV=1`): the Windows userhash is computed over
+// `username@hostname#cwd` so concurrent dev daemons spawned from different
+// git worktrees do NOT collide on the named-pipe namespace. Production keeps
+// the canonical `username@hostname` shape so the packaged installer can
+// re-attach across Electron restarts (frag-6-7 §6.1 dogfood metric #1).
 // ---------------------------------------------------------------------------
 
 function joinFor(platform: NodeJS.Platform, ...parts: string[]): string {
@@ -74,8 +80,11 @@ export function resolveControlSocketPath(
 ): string {
   if (platform === 'win32') {
     const ui = userInfo();
-    const tag = `${ui.username}@${hostname()}`;
-    const userhash = createHash('sha256').update(tag).digest('hex').slice(0, 8);
+    const seed =
+      env.CCSM_DAEMON_DEV === '1'
+        ? `${ui.username}@${hostname()}#${process.cwd()}`
+        : `${ui.username}@${hostname()}`;
+    const userhash = createHash('sha256').update(seed).digest('hex').slice(0, 8);
     return `\\\\.\\pipe\\ccsm-control-${userhash}`;
   }
   return posix.join(resolveRuntimeRoot(platform, env), 'ccsm-control.sock');

--- a/scripts/double-bind-guard.ts
+++ b/scripts/double-bind-guard.ts
@@ -98,15 +98,26 @@ export function resolveRuntimeRoot(
   return joinFor(platform, resolveDataRoot(platform, env), 'run');
 }
 
-/** Mirror of daemon/src/sockets/control-socket.ts::defaultControlSocketPath. */
+/** Mirror of daemon/src/sockets/control-socket.ts::defaultControlSocketPath.
+ *
+ *  Dev mode: when `env.CCSM_DAEMON_DEV === '1'` the Windows userhash is
+ *  computed over `username@hostname#cwd` so two dev daemons spawned from
+ *  different git worktrees on the same host do NOT collide on the
+ *  named-pipe namespace. Production (and any non-dev consumer) keeps the
+ *  canonical `username@hostname` shape so the packaged Electron app
+ *  re-attaches to the surviving daemon across restarts (frag-6-7 §6.1).
+ */
 export function resolveControlSocketPath(
   platform: NodeJS.Platform,
   env: NodeJS.ProcessEnv,
 ): string {
   if (platform === 'win32') {
     const ui = userInfo();
-    const tag = `${ui.username}@${hostname()}`;
-    const userhash = createHash('sha256').update(tag).digest('hex').slice(0, 8);
+    const seed =
+      env.CCSM_DAEMON_DEV === '1'
+        ? `${ui.username}@${hostname()}#${process.cwd()}`
+        : `${ui.username}@${hostname()}`;
+    const userhash = createHash('sha256').update(seed).digest('hex').slice(0, 8);
     return `\\\\.\\pipe\\ccsm-control-${userhash}`;
   }
   return posix.join(resolveRuntimeRoot(platform, env), 'ccsm-control.sock');

--- a/tests/double-bind-guard.test.ts
+++ b/tests/double-bind-guard.test.ts
@@ -106,7 +106,7 @@ describe('resolveControlSocketPath', () => {
       }),
     ).toBe('/run/user/1000/ccsm/ccsm-control.sock');
   });
-  it('Windows: \\\\.\\pipe\\ccsm-control-<userhash>', () => {
+  it('Windows: \\\\.\\pipe\\ccsm-control-<userhash> (production seed = username@hostname)', () => {
     const got = resolveControlSocketPath('win32', {
       LOCALAPPDATA: 'C:\\x',
     });
@@ -114,6 +114,21 @@ describe('resolveControlSocketPath', () => {
     const tag = `${ui.username}@${hostname()}`;
     const expectHash = createHash('sha256').update(tag).digest('hex').slice(0, 8);
     expect(got).toBe(`\\\\.\\pipe\\ccsm-control-${expectHash}`);
+  });
+
+  it('Windows + CCSM_DAEMON_DEV=1: pipe name folds in cwd (per-worktree isolation)', () => {
+    const got = resolveControlSocketPath('win32', {
+      LOCALAPPDATA: 'C:\\x',
+      CCSM_DAEMON_DEV: '1',
+    });
+    const ui = userInfo();
+    const tag = `${ui.username}@${hostname()}#${process.cwd()}`;
+    const expectHash = createHash('sha256').update(tag).digest('hex').slice(0, 8);
+    expect(got).toBe(`\\\\.\\pipe\\ccsm-control-${expectHash}`);
+    // Production-shape (no dev gate) must differ — proves dev gate actually
+    // changed the seed.
+    const prod = resolveControlSocketPath('win32', { LOCALAPPDATA: 'C:\\x' });
+    expect(got).not.toBe(prod);
   });
 });
 
@@ -290,11 +305,52 @@ describe('drift guard against daemon/src/sockets/*', () => {
       { platform: 'linux', env: { XDG_DATA_HOME: '/xdg/data' } },
       { platform: 'darwin', env: {} },
       { platform: 'win32', env: { LOCALAPPDATA: 'C:\\Users\\u\\AppData\\Local' } },
+      // B10 dev gate: cwd-mix path must mirror byte-for-byte too.
+      { platform: 'win32', env: { LOCALAPPDATA: 'C:\\x', CCSM_DAEMON_DEV: '1' } },
+      { platform: 'linux', env: { XDG_RUNTIME_DIR: '/run/user/1000', CCSM_DAEMON_DEV: '1' } },
     ];
     for (const { platform, env } of cases) {
       const ours = resolveControlSocketPath(platform, env);
-      const theirs = defaultControlSocketPath(platform, resolveRuntimeRoot(platform, env));
+      const theirs = defaultControlSocketPath(platform, resolveRuntimeRoot(platform, env), env);
       expect(ours).toBe(theirs);
+    }
+  });
+
+  // B10 cross-worktree pipe collision fix.
+  it('Windows + CCSM_DAEMON_DEV=1: pipe path varies with process.cwd() (per-worktree)', () => {
+    const env = { LOCALAPPDATA: 'C:\\x', CCSM_DAEMON_DEV: '1' };
+    const realCwd = process.cwd;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (process as any).cwd = () => 'C:/Users/x/ccsm-worktrees/pool-3';
+      const a = resolveControlSocketPath('win32', env);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (process as any).cwd = () => 'C:/Users/x/ccsm-worktrees/pool-5';
+      const b = resolveControlSocketPath('win32', env);
+      expect(a).not.toBe(b);
+      const prod = resolveControlSocketPath('win32', { LOCALAPPDATA: 'C:\\x' });
+      expect(a).not.toBe(prod);
+      expect(b).not.toBe(prod);
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (process as any).cwd = realCwd;
+    }
+  });
+
+  it('Windows production env: pipe path is invariant under cwd changes', () => {
+    const env = { LOCALAPPDATA: 'C:\\x' };
+    const realCwd = process.cwd;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (process as any).cwd = () => 'C:/Users/x/ccsm-worktrees/pool-3';
+      const a = resolveControlSocketPath('win32', env);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (process as any).cwd = () => 'C:/Users/x/ccsm-worktrees/pool-5';
+      const b = resolveControlSocketPath('win32', env);
+      expect(a).toBe(b);
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (process as any).cwd = realCwd;
     }
   });
 });

--- a/tests/electron/daemon/bootDaemon.test.ts
+++ b/tests/electron/daemon/bootDaemon.test.ts
@@ -244,11 +244,49 @@ describe('drift guard against daemon/src/sockets/* (mirror)', () => {
       { platform: 'linux', env: { XDG_DATA_HOME: '/xdg/data' } },
       { platform: 'darwin', env: {} },
       { platform: 'win32', env: { LOCALAPPDATA: 'C:\\Users\\u\\AppData\\Local' } },
+      // B10 dev gate: byte-identical mirror in dev mode too.
+      { platform: 'win32', env: { LOCALAPPDATA: 'C:\\x', CCSM_DAEMON_DEV: '1' } },
+      { platform: 'linux', env: { XDG_RUNTIME_DIR: '/run/user/1000', CCSM_DAEMON_DEV: '1' } },
     ];
     for (const { platform, env } of cases) {
       const ours = resolveControlSocketPath(platform, env);
-      const theirs = defaultControlSocketPath(platform, resolveRuntimeRoot(platform, env));
+      const theirs = defaultControlSocketPath(platform, resolveRuntimeRoot(platform, env), env);
       expect(ours).toBe(theirs);
+    }
+  });
+
+  // B10: per-worktree pipe isolation. Same env shape, different cwd → different
+  // Windows pipe path. Implemented by mocking process.cwd() so the test does
+  // not depend on the test runner's actual working directory.
+  it('Windows + CCSM_DAEMON_DEV=1: pipe path varies with process.cwd() (per-worktree)', () => {
+    const env = { LOCALAPPDATA: 'C:\\x', CCSM_DAEMON_DEV: '1' };
+    const realCwd = process.cwd;
+    try {
+      (process as any).cwd = () => 'C:/Users/x/ccsm-worktrees/pool-3';
+      const a = resolveControlSocketPath('win32', env);
+      (process as any).cwd = () => 'C:/Users/x/ccsm-worktrees/pool-5';
+      const b = resolveControlSocketPath('win32', env);
+      expect(a).not.toBe(b);
+      // And both differ from the production seed.
+      const prod = resolveControlSocketPath('win32', { LOCALAPPDATA: 'C:\\x' });
+      expect(a).not.toBe(prod);
+      expect(b).not.toBe(prod);
+    } finally {
+      (process as any).cwd = realCwd;
+    }
+  });
+
+  it('Windows production env: pipe path is invariant under cwd changes (single-bind across Electron restart)', () => {
+    const env = { LOCALAPPDATA: 'C:\\x' };
+    const realCwd = process.cwd;
+    try {
+      (process as any).cwd = () => 'C:/Users/x/ccsm-worktrees/pool-3';
+      const a = resolveControlSocketPath('win32', env);
+      (process as any).cwd = () => 'C:/Users/x/ccsm-worktrees/pool-5';
+      const b = resolveControlSocketPath('win32', env);
+      expect(a).toBe(b);
+    } finally {
+      (process as any).cwd = realCwd;
     }
   });
 });


### PR DESCRIPTION
## Symptom

Two concurrent dev daemons launched from different git worktrees (e.g.
`~/ccsm-worktrees/pool-3` and `~/ccsm-worktrees/pool-5`) collide on the
Windows named-pipe namespace because the userhash is computed solely from
`username@hostname` — same user + same host = same pipe = `EADDRINUSE` on
the second `nodemon` boot. Single-process v0.2 never tripped this; the
v0.3 daemon-split made the pipe a per-host singleton that surfaces the
collision.

## Fix

Gate `userHash` on `CCSM_DAEMON_DEV=1`. In dev mode, fold `process.cwd()`
into the SHA-256 seed:

  - prod  : `SHA-256("username@hostname").slice(0,8)`
  - dev   : `SHA-256("username@hostname#cwd").slice(0,8)`

Production install path is byte-identical to before — packaged Electron
launches the daemon binary without `CCSM_DAEMON_DEV` set, so the canonical
pipe name is preserved and frag-6-7 §6.1 dogfood metric #1
("daemon survives Electron quit / single-bind across re-open") is
unaffected.

## Sites touched (all 5 mirror byte-identically)

  - `daemon/src/sockets/runtime-root.ts` — `userHash()` (single source of truth, accepts `env` + `cwd` opts)
  - `daemon/src/sockets/control-socket.ts` — `defaultControlSocketPath()` now delegates to `userHash()` and accepts `env`
  - `daemon/src/sockets/data-socket.ts` — `dataSocketPath()` threads `env` through
  - `electron/daemon/bootDaemon.ts` — `resolveControlSocketPath` mirror gated on `env.CCSM_DAEMON_DEV === '1'`
  - `scripts/double-bind-guard.ts` — `resolveControlSocketPath` mirror gated on `env.CCSM_DAEMON_DEV === '1'`

## Dev-gate semantics

Strict `'1'` sentinel only — `'true'`, `'0'`, `''`, undefined all fall
through to the production seed. UT pins this so a stray `CCSM_DAEMON_DEV=true`
in someone's shell does not silently change the pipe path.

## UT coverage

  - `daemon/src/sockets/__tests__/runtime-root.test.ts`: 6 new cases — dev determinism, per-cwd isolation, prod invariance under cwd, dev != prod, sentinel strictness, `process.cwd()` fallback.
  - `daemon/src/sockets/__tests__/control-socket.test.ts`: 3 new cases — Windows dev != prod, dev determinism, POSIX unaffected.
  - `daemon/src/sockets/__tests__/data-socket.test.ts`: 3 new cases — Windows dev != prod, hashOverride still wins, POSIX unaffected.
  - `tests/electron/daemon/bootDaemon.test.ts`: drift-guard matrix extended with 2 dev cases; new per-cwd-mock tests showing distinct worktrees → distinct pipes (dev) but identical pipes (prod).
  - `tests/double-bind-guard.test.ts`: same drift-guard extension; same per-cwd-mock tests; existing Windows test split into prod-shape + new dev-gate sub-test.

## Local verification

```
npx vitest run daemon/src/sockets/__tests__/
  Test Files  5 passed (5)
  Tests       86 passed | 7 skipped (93)

npx vitest run tests/electron/daemon/bootDaemon.test.ts tests/double-bind-guard.test.ts
  Test Files  2 passed (2)
  Tests       39 passed (39)

npx tsc -p daemon/tsconfig.json --noEmit          # clean
npx tsc -p tsconfig.electron.json --noEmit        # clean
```

## Scope notes

  - v0.3 = pure refactor; this is a daemon-split migration patch (the bug
    only exists because v0.3 split the daemon out as a long-lived sibling
    process — v0.2 single-process never had it). In scope.
  - Lint / typecheck / e2e CI jobs may still be SKIPPED on this PR
    pending PR #765 — this is the existing v0.3 CI posture, not a regression
    from this change.