### PR TITLE
fix(v0.3): release.yml minisign sidecar must skip when secret unset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,10 +258,11 @@ jobs:
       # Minisign signatures. Public key lives in repo at release-keys/minisign.pub
       # (committed). Private key is provisioned via the MINISIGN_PRIVATE_KEY
       # repo secret + MINISIGN_PASSWORD secret (see release-keys/README.md for
-      # rotation runbook). When the secret is absent we still write empty
-      # placeholder .minisig files so the sidecar-verify gate can distinguish
-      # "missing because unsigned" from "missing because forgotten" — and we
-      # warn loudly in the workflow log.
+      # rotation runbook). When the secret is absent we skip sidecar generation
+      # entirely and the publish job's sidecar-verify gate skips its minisig
+      # check accordingly — matching the v0.3 ship-intent "placeholder-safe"
+      # rule (frag-11 §11.5(5): "MUST continue unsigned if absent") and the
+      # Apple/signtool steps' existing fall-back-to-unsigned behaviour.
       - name: Install minisign
         run: |
           sudo apt-get update -qq
@@ -275,12 +276,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${MINISIGN_PRIVATE_KEY:-}" ]; then
-            echo "::warning title=Unsigned release::MINISIGN_PRIVATE_KEY secret not set. Writing placeholder .minisig files; the sidecar-verify gate will fail. See release-keys/README.md for provisioning."
-            cd dist-flat
-            for f in *.exe *.dmg *.zip *.AppImage *.deb *.rpm; do
-              [ -f "$f" ] || continue
-              : > "$f.minisig"
-            done
+            echo "::warning title=Unsigned release::MINISIGN_PRIVATE_KEY secret not set. Skipping .minisig sidecar generation; the publish job's sidecar-verify gate will skip its minisig check. See release-keys/README.md for provisioning."
             exit 0
           fi
           umask 077
@@ -376,8 +372,16 @@ jobs:
       # present (and the minisig must be non-empty). This is the post-tag-push
       # safety check that catches "someone commented out a sidecar step in a
       # rebase" before we publish a release with missing attestations.
+      #
+      # Placeholder-safe: when MINISIGN_PRIVATE_KEY is unset (e.g. forks, or
+      # repos that haven't provisioned a minisign keypair yet), the attest job
+      # skips writing .minisig sidecars. Mirror that here by skipping the
+      # minisig portion of the gate so unsigned releases can still publish —
+      # spec frag-11 §11.5(5): "MUST continue unsigned if absent".
       - name: Sidecar-verify gate
         shell: bash
+        env:
+          MINISIGN_PRIVATE_KEY: ${{ secrets.MINISIGN_PRIVATE_KEY }}
         run: |
           set -euo pipefail
           cd dist-flat
@@ -386,13 +390,19 @@ jobs:
             echo "::error title=Sidecar-verify failed::no *.intoto.jsonl SLSA provenance file present"
             exit 1
           fi
+          if [ -z "${MINISIGN_PRIVATE_KEY:-}" ]; then
+            check_minisig=0
+            echo "::warning title=Unsigned release::MINISIGN_PRIVATE_KEY secret not set; skipping .minisig sidecar verification."
+          else
+            check_minisig=1
+          fi
           fail=0
           for f in *.exe *.dmg *.zip *.AppImage *.deb *.rpm; do
             [ -f "$f" ] || continue
             if [ ! -s "$f.sha256" ]; then
               echo "::error title=Sidecar-verify failed::$f missing or empty .sha256"; fail=1
             fi
-            if [ ! -s "$f.minisig" ]; then
+            if [ "$check_minisig" -eq 1 ] && [ ! -s "$f.minisig" ]; then
               echo "::error title=Sidecar-verify failed::$f missing or empty .minisig"; fail=1
             fi
             # Materialize a per-artifact intoto.jsonl alias so the README's
@@ -403,7 +413,11 @@ jobs:
             echo "::error::Refusing to publish release with missing sidecars."
             exit 1
           fi
-          echo "All installers have .sha256 + .minisig + .intoto.jsonl sidecars."
+          if [ "$check_minisig" -eq 1 ]; then
+            echo "All installers have .sha256 + .minisig + .intoto.jsonl sidecars."
+          else
+            echo "All installers have .sha256 + .intoto.jsonl sidecars (minisig skipped — secret unset)."
+          fi
           ls -la
 
       - name: Upload to GitHub Release (draft)

--- a/release-keys/README.md
+++ b/release-keys/README.md
@@ -23,8 +23,12 @@ For every installer artifact (`*.exe`, `*.dmg`, `*.AppImage`, `*.deb`,
 | `<artifact>.minisig` | `minisign -S` step in the `attest` job, signed with the key from `MINISIGN_PRIVATE_KEY` | `minisign -V -p release-keys/minisign.pub -m <artifact>` |
 
 The `publish` job in `.github/workflows/release.yml` runs a **sidecar-verify
-gate** that refuses to publish a draft release unless all three sidecars are
-present (and non-empty) for every installer.
+gate** that refuses to publish a draft release unless `.sha256` + `.intoto.jsonl`
+sidecars are present (and non-empty) for every installer. The `.minisig` check
+is only enforced when the `MINISIGN_PRIVATE_KEY` secret is set; when unset,
+the `attest` job skips minisig generation and the gate skips its minisig check
+so unsigned releases can still publish (frag-11 §11.5(5): "MUST continue
+unsigned if absent").
 
 ## First-time keypair generation (release-day ops, NOT in CI)
 
@@ -81,7 +85,7 @@ to verify older `.minisig` files; the simplest path is `git log -- release-keys/
 
 ## Disaster: private key suspected leaked
 
-1. **Immediately revoke** the GitHub Actions secret: `gh secret delete MINISIGN_PRIVATE_KEY --repo Jiahui-Gu/ccsm`. Without the secret, the `attest` job writes empty `.minisig` files and the sidecar-verify gate fails closed — no further releases can ship signed with the compromised key.
+1. **Immediately revoke** the GitHub Actions secret: `gh secret delete MINISIGN_PRIVATE_KEY --repo Jiahui-Gu/ccsm`. Without the secret, the `attest` job skips `.minisig` sidecar generation and subsequent releases ship unsigned (the `publish` job's sidecar-verify gate skips its minisig check) until a fresh keypair is provisioned per the rotation procedure below. Releases keep flowing — they just lose the offline minisign verification path until rotation completes.
 2. Open a high-priority issue on the repo describing the suspected leak.
 3. Run the rotation procedure above.
 4. Publish a security advisory (`gh api repos/Jiahui-Gu/ccsm/security-advisories -f summary='Release-signing key rotation' ...`) listing every release that was signed with the compromised key. Users should re-verify those releases against the historical public key (still valid for those specific binaries; the SLSA L3 attestation provides an independent authenticity check that does NOT depend on minisign).


### PR DESCRIPTION
## Summary

P0 ship blocker. Resolves #53.

The `attest` job in `.github/workflows/release.yml` wrote empty `.minisig` placeholder files when `MINISIGN_PRIVATE_KEY` was absent, and the `publish` job's sidecar-verify gate hard-failed on `[ ! -s "$f.minisig" ]`. Net effect: any release without the minisign secret provisioned (forks, self-hosters, or `Jiahui-Gu/ccsm` before keypair generation) could not publish a draft release at all.

This contradicted:
- spec frag-11 §11.5(5): "MUST continue unsigned if absent"
- v0.3 ship-intent: "placeholder-safe (缺 secret 自动 skip 输出 unsigned installer)"
- the workflow's own Apple/signtool steps, which already fall back to unsigned when their secrets are missing

## Fix (option (a) per task brief — minimal, matches existing pattern)

- `attest` job, "Generate minisign signatures": when `MINISIGN_PRIVATE_KEY` is unset, log a warning and `exit 0` without writing any `.minisig` files (was: write empty placeholder `.minisig` per artifact).
- `publish` job, "Sidecar-verify gate": at top of step, branch on the same secret. Unset → skip the `.minisig` portion of the gate, log a warning, continue. Set → preserve the existing fail-loud check (missing or empty `.minisig` still fails the build, so a real signing regression is still caught).
- `release-keys/README.md`: drop the two stale "writes empty `.minisig` / fails closed" sentences in the sidecar overview and the leak-disaster runbook so docs match the new behaviour.

The `.sha256` + `.intoto.jsonl` checks remain unconditional — those sidecars are produced from the artifacts themselves and don't depend on any secret, so a missing one is always a real bug.

## Test plan

`act` is not available in the Windows worktree environment, so I extracted the publish-gate's bash logic verbatim into a local script and ran it against fake `dist-flat` fixtures (two installers + provenance + sha256, optional minisig). Four scenarios covered the full truth table:

| # | Scenario | Expected | Actual |
|---|----------|----------|--------|
| 1 | secret unset, no `.minisig` sidecars (placeholder-safe path — was the bug) | exit 0 | exit 0 |
| 2 | secret set, `.minisig` sidecars missing | exit 1 (fail-loud) | exit 1 |
| 3 | secret set, valid non-empty `.minisig` sidecars (real-sign happy path) | exit 0 | exit 0 |
| 4 | secret set, empty `.minisig` sidecars (sabotage detection) | exit 1 (fail-loud) | exit 1 |

Sample outputs:

Scenario 1 (the bug — now passes):
```
::warning title=Unsigned release::MINISIGN_PRIVATE_KEY secret not set; skipping .minisig sidecar verification.
All installers have .sha256 + .intoto.jsonl sidecars (minisig skipped — secret unset).
exit=0
```

Scenario 2 (regression — fail-loud preserved):
```
::error title=Sidecar-verify failed::fake.exe missing or empty .minisig
::error title=Sidecar-verify failed::fake.dmg missing or empty .minisig
::error::Refusing to publish release with missing sidecars.
exit=1
```

Additional checks:
- [x] YAML parses: `python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` → "YAML OK"
- [x] All four bash logic scenarios behave as expected
- [ ] Workflow dry-run via `workflow_dispatch` against a branch with no `MINISIGN_PRIVATE_KEY` configured (not done locally — would need to merge first or push branch trigger; left to reviewer/release-day ops if they want extra confidence)

## References

- spec: `docs/superpowers/specs/v0.3-fragments/frag-11-packaging.md` §11.5(5) + §11.6
- ship intent: `~/.claude/projects/C--Users-jiahuigu/memory/project_v03_ship_intent.md` — placeholder-safe