### PR TITLE
chore(v0.3): reconcile installer-size-guard.yml header comment with active behavior

### DIFF
--- a/.github/workflows/installer-size-guard.yml
+++ b/.github/workflows/installer-size-guard.yml
@@ -2,13 +2,13 @@ name: installer-size-guard
 
 # Task #1015 (T58) — Installer size CI guard.
 #
+# ACTIVE: enforces installer size baseline per frag-11-packaging.md §11.5(6).
+# Was temporarily relaxed during the v0.3 migration but is now active.
+#
 # Builds the installer for each OS and runs scripts/check-installer-size.mjs
 # against the artifact. FAILS if size exceeds the absolute per-extension
 # ceiling from frag-11-packaging.md §11.5(6) OR if size grew >10% vs the
 # baseline in installer/size-baseline.json (>5% emits a warning).
-#
-# DISABLED for the v0.3 migration window per Task #1047 (mirrors ci.yml /
-# e2e.yml gating). Will be re-enabled by Task #1048.
 
 on:
   pull_request:


### PR DESCRIPTION
P1 doc/code consistency. Resolves #61.

## Problem

`.github/workflows/installer-size-guard.yml` header comment claimed:

> DISABLED for the v0.3 migration window per Task #1047 (mirrors ci.yml /
> e2e.yml gating). Will be re-enabled by Task #1048.

But the YAML is not actually disabled:
- `on:` still triggers on `pull_request` to `[main, working]` and `workflow_dispatch`.
- The `size-guard` matrix job has no `if: false` / no skip guard.
- All steps (build, installer pack, `node scripts/check-installer-size.mjs --dir release`) run normally.

So readers see "DISABLED" but CI actually enforces the gate. Ambiguous and misleading.

## Fix

Per spec frag-11-packaging.md §11.5(6) the installer size baseline is a ship gate, so the workflow must stay active. Updated the header comment to reflect reality:

- Removed the `DISABLED ... Will be re-enabled by Task #1048` claim.
- Added `ACTIVE: enforces installer size baseline per frag-11-packaging.md §11.5(6). Was temporarily relaxed during the v0.3 migration but is now active.`

No behavioral change — only the header comment was edited. No jobs/steps/triggers were modified.

## Audit of disabled steps

Checked the full file for `if: false`, commented-out triggers, or other latent disables — none found. The workflow runs end-to-end as written.