### PR TITLE
fix(v0.3): expand crash scrub redact list (token/secret/API key)

### DIFF
--- a/daemon/src/crash/__tests__/scrub.test.ts
+++ b/daemon/src/crash/__tests__/scrub.test.ts
@@ -1,0 +1,111 @@
+// daemon/src/crash/__tests__/scrub.test.ts
+//
+// Task #60 — daemon-surface crash-scrub coverage. Daemon redactSecrets() is a
+// deliberate mirror of electron/crash/scrub.ts; both must be kept in sync.
+// The test below covers both the pure scrubber and the installCrashHandlers()
+// integration (marker-JSON write redacts secrets from err.stack).
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { redactSecrets } from '../scrub';
+import { installCrashHandlers } from '../handlers';
+
+describe('daemon redactSecrets (Task #60)', () => {
+  it('(a) redacts Authorization: Bearer <token> in stack-trace strings', () => {
+    const stack = 'Error: boom\n  at fetch (Authorization: Bearer sk-ant-deadbeef)\n  at run (foo.ts:1:1)';
+    const out = redactSecrets(stack);
+    expect(out).toContain('Authorization: <REDACTED>');
+    expect(out).not.toContain('sk-ant-deadbeef');
+  });
+  it('(b) redacts ANTHROPIC_API_KEY=sk-xxx env-style assignments', () => {
+    const line = 'spawn failed: ANTHROPIC_API_KEY=sk-ant-api-7777 PATH=/usr/bin node main.js';
+    const out = redactSecrets(line);
+    expect(out).toContain('ANTHROPIC_API_KEY=<REDACTED>');
+    expect(out).not.toContain('sk-ant-api-7777');
+    expect(out).toContain('PATH=/usr/bin');
+  });
+  it('(c) redacts object property obj.daemonSecret value', () => {
+    const obj = { daemonSecret: 'super-sekret-value', ok: 'safe' };
+    const out = redactSecrets(obj);
+    expect(out.daemonSecret).toBe('<REDACTED>');
+    expect(out.ok).toBe('safe');
+  });
+  it('also redacts helloNonceHmac + nested *.secret + Cookie', () => {
+    const obj = {
+      daemon: { secret: 'leak1', port: 9000 },
+      helloNonceHmac: 'leak2',
+      headers: 'Cookie: sid=abcd',
+    };
+    const out = redactSecrets(obj);
+    expect((out.daemon as any).secret).toBe('<REDACTED>');
+    expect((out.daemon as any).port).toBe(9000);
+    expect(out.helloNonceHmac).toBe('<REDACTED>');
+    expect(out.headers).toContain('Cookie: <REDACTED>');
+  });
+});
+
+describe('installCrashHandlers writes redacted marker (Task #60)', () => {
+  let runtimeRoot: string;
+  beforeEach(() => {
+    runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ccsm-daemon-crash-'));
+  });
+  afterEach(() => {
+    try { fs.rmSync(runtimeRoot, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+
+  function fakeLogger(): any {
+    return { fatal: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+  }
+
+  it('redacts Authorization header + ANTHROPIC_API_KEY from err.stack before writing marker', () => {
+    const proc = new EventEmitter() as unknown as NodeJS.Process;
+    (proc as any).exit = vi.fn(); // prevent real exit(70) — handler calls it
+    const logger = fakeLogger();
+    installCrashHandlers({
+      logger,
+      bootNonce: 'BOOT123',
+      runtimeRoot,
+      getLastTraceId: () => 'trace-abc',
+      processRef: proc,
+    });
+
+    const err = new Error('boot failure: ANTHROPIC_API_KEY=sk-ant-XYZ');
+    err.stack = 'Error: boot failure\n  at fetch (Authorization: Bearer sk-ant-zzz)\n  ANTHROPIC_API_KEY=sk-ant-XYZ';
+    (proc as unknown as EventEmitter).emit('uncaughtException', err);
+
+    const markerPath = path.join(runtimeRoot, 'crash', 'BOOT123.json');
+    expect(fs.existsSync(markerPath)).toBe(true);
+    const raw = fs.readFileSync(markerPath, 'utf8');
+    // (a) Authorization
+    expect(raw).toContain('Authorization: <REDACTED>');
+    expect(raw).not.toContain('sk-ant-zzz');
+    // (b) ANTHROPIC_API_KEY env-style
+    expect(raw).toContain('ANTHROPIC_API_KEY=<REDACTED>');
+    expect(raw).not.toContain('sk-ant-XYZ');
+    // sanity: lastTraceId still recorded
+    expect(raw).toContain('trace-abc');
+  });
+
+  it('(c) redacts daemonSecret embedded as JSON property in stack', () => {
+    const proc = new EventEmitter() as unknown as NodeJS.Process;
+    (proc as any).exit = vi.fn();
+    const logger = fakeLogger();
+    installCrashHandlers({
+      logger,
+      bootNonce: 'BOOT456',
+      runtimeRoot,
+      getLastTraceId: () => undefined,
+      processRef: proc,
+    });
+
+    const err = new Error('config: {"daemonSecret":"super-sekret-9"}');
+    err.stack = 'Error: config: {"daemonSecret":"super-sekret-9"}\n  at boot';
+    (proc as unknown as EventEmitter).emit('uncaughtException', err);
+
+    const raw = fs.readFileSync(path.join(runtimeRoot, 'crash', 'BOOT456.json'), 'utf8');
+    expect(raw).not.toContain('super-sekret-9');
+    expect(raw).toContain('<REDACTED>');
+  });
+});

--- a/daemon/src/crash/handlers.ts
+++ b/daemon/src/crash/handlers.ts
@@ -2,6 +2,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type pino from 'pino';
+import { redactSecrets } from './scrub.js';
 
 export interface InstallOpts {
   logger: pino.Logger;
@@ -30,7 +31,11 @@ export function installCrashHandlers(opts: InstallOpts): void {
 
   function record(kind: MarkerV1['kind'], errLike: unknown): void {
     const err = errLike instanceof Error ? errLike : new Error(String(errLike));
-    const marker: MarkerV1 = {
+    // Redact secrets from message + stack BEFORE constructing the marker.
+    // err.message / err.stack can contain Authorization headers, env-style
+    // ANTHROPIC_API_KEY=..., or daemon.secret values surfaced by an HMAC
+    // misconfiguration error path. See frag-6-7 §6.6.3.
+    const marker: MarkerV1 = redactSecrets<MarkerV1>({
       schemaVersion: 1,
       bootNonce: opts.bootNonce,
       ts: new Date().toISOString(),
@@ -39,9 +44,9 @@ export function installCrashHandlers(opts: InstallOpts): void {
       message: err.message,
       stack: err.stack,
       lastTraceId: opts.getLastTraceId(),
-    };
+    });
     try {
-      opts.logger.fatal({ event: 'daemon.crash', kind, err: { message: err.message, stack: err.stack } });
+      opts.logger.fatal({ event: 'daemon.crash', kind, err: redactSecrets({ message: err.message, stack: err.stack }) });
       fs.writeFileSync(markerPath, JSON.stringify(marker, null, 2), 'utf8');
     } catch (e) {
       try { opts.logger.fatal({ event: 'daemon.crash.write_failed', err: String(e) }); } catch {}

--- a/daemon/src/crash/scrub.ts
+++ b/daemon/src/crash/scrub.ts
@@ -1,0 +1,67 @@
+// daemon/src/crash/scrub.ts
+//
+// Daemon-side mirror of electron/crash/scrub.ts redactSecrets().
+//
+// We deliberately DO NOT cross-import between daemon/ and electron/. Daemon is
+// a separate build target / process. Keep the redact list + regex patterns in
+// sync with electron/crash/scrub.ts; if you change one, change the other and
+// add a UT in both suites. Source of truth: docs/superpowers/specs/
+// v0.3-fragments/frag-6-7-reliability-security.md §6.6 + §6.6.3.
+
+const REDACTED = '<REDACTED>';
+
+const SECRET_KEY_NAMES = new Set<string>([
+  'apikey',
+  'token',
+  'authorization',
+  'cookie',
+  'anthropic_api_key',
+  'daemonsecret',
+  'installsecret',
+  'pingsecret',
+  'hellononce',
+  'clienthellononce',
+  'hellononcehmac',
+  'secret',
+]);
+
+function isSecretKey(key: string): boolean {
+  const lk = key.toLowerCase();
+  if (SECRET_KEY_NAMES.has(lk)) return true;
+  if (lk.endsWith('.secret') || lk.endsWith('.apikey')) return true;
+  if (/_(SECRET|TOKEN|API_KEY)$/i.test(key)) return true;
+  return false;
+}
+
+const HEADER_RE = /\b(Authorization|Cookie|Proxy-Authorization|X-Api-Key)(\s*[:=]\s*)([^\r\n,;]+)/gi;
+const ENV_RE = /\b((?:ANTHROPIC_API_KEY|[A-Z][A-Z0-9_]*_(?:SECRET|TOKEN|API_KEY)|daemonSecret|installSecret|pingSecret|helloNonce|clientHelloNonce|helloNonceHmac))=([^\s'"]+)/g;
+const JSON_PROP_RE = /"(apiKey|token|authorization|cookie|ANTHROPIC_API_KEY|daemonSecret|installSecret|pingSecret|helloNonce|clientHelloNonce|helloNonceHmac|secret)"(\s*:\s*)"([^"\\]*(?:\\.[^"\\]*)*)"/gi;
+
+function redactString(s: string): string {
+  if (!s) return s;
+  return s
+    .replace(HEADER_RE, (_m, name: string, sep: string) => `${name}${sep}${REDACTED}`)
+    .replace(ENV_RE, (_m, name: string) => `${name}=${REDACTED}`)
+    .replace(JSON_PROP_RE, (_m, name: string, sep: string) => `"${name}"${sep}"${REDACTED}"`);
+}
+
+export function redactSecrets<T>(input: T): T {
+  const seen = new WeakSet<object>();
+  function walk(v: unknown): unknown {
+    if (typeof v === 'string') return redactString(v);
+    if (v == null || typeof v !== 'object') return v;
+    if (seen.has(v as object)) return '[Circular]';
+    seen.add(v as object);
+    if (Array.isArray(v)) return v.map(walk);
+    const out: Record<string, unknown> = {};
+    for (const [k, vv] of Object.entries(v as Record<string, unknown>)) {
+      if (isSecretKey(k)) {
+        out[k] = REDACTED;
+      } else {
+        out[k] = walk(vv);
+      }
+    }
+    return out;
+  }
+  return walk(input) as T;
+}

--- a/electron/crash/collector.ts
+++ b/electron/crash/collector.ts
@@ -4,7 +4,7 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import { ulid } from 'ulid';
 import { createIncidentDir, writeMeta, writeReadme, IncidentMeta } from './incident-dir';
-import { scrubHomePath } from './scrub';
+import { scrubHomePath, redactSecrets } from './scrub';
 
 export interface SerializedError { message: string; stack?: string; name?: string }
 
@@ -88,20 +88,25 @@ export function startCrashCollector(opts: CollectorOpts): CrashCollector {
     const dir = createIncidentDir(opts.crashRoot, id);
     const ts = new Date().toISOString();
 
+    // Apply both home-path scrub AND secret redact (frag-6-7 §6.6.3) before
+    // any crash artifact lands on disk. redactSecrets covers Authorization /
+    // Cookie headers, ANTHROPIC_API_KEY=... env-style assignments, and
+    // structured *.secret / *.apiKey property names that may appear in
+    // stack traces or stderr tails.
     if (input.stderrTail) {
       fs.writeFileSync(path.join(dir, 'stderr-tail.txt'),
-        input.stderrTail.map(scrubHomePath).join('\n') + '\n', 'utf8');
+        input.stderrTail.map(line => redactSecrets(scrubHomePath(line))).join('\n') + '\n', 'utf8');
     }
     if (input.stdoutTail) {
       fs.writeFileSync(path.join(dir, 'stdout-tail.txt'),
-        input.stdoutTail.map(scrubHomePath).join('\n') + '\n', 'utf8');
+        input.stdoutTail.map(line => redactSecrets(scrubHomePath(line))).join('\n') + '\n', 'utf8');
     }
     if (input.error) {
       fs.writeFileSync(path.join(dir, 'error.json'),
         JSON.stringify({
           name: input.error.name,
-          message: scrubHomePath(input.error.message ?? ''),
-          stack: input.error.stack ? scrubHomePath(input.error.stack) : undefined,
+          message: redactSecrets(scrubHomePath(input.error.message ?? '')),
+          stack: input.error.stack ? redactSecrets(scrubHomePath(input.error.stack)) : undefined,
         }, null, 2), 'utf8');
     }
 

--- a/electron/crash/scrub.ts
+++ b/electron/crash/scrub.ts
@@ -1,7 +1,22 @@
 // electron/crash/scrub.ts
+//
+// Crash-time secret/PII scrubbing. Used by:
+//   - electron/crash/collector.ts before writing error.json + stderr/stdout-tail
+//   - electron/ipc/rendererErrorForwarder.ts via collector for renderer crashes
+//
+// The daemon ships its own copy of redactSecrets() at daemon/src/crash/scrub.ts
+// (deliberate duplication — daemon is a separate process / build target and we
+// do NOT cross-import between electron/ and daemon/src/). Keep the two lists in
+// sync; if you change one, change the other and add a UT in both suites.
+//
+// Source of truth for the redact list: docs/superpowers/specs/v0.3-fragments/
+// frag-6-7-reliability-security.md §6.6.3 + §6.6 secret-redaction list.
 import * as os from 'node:os';
 
-const ALLOW = /^(NODE_ENV|CCSM_.*|ELECTRON_.*)$/;
+// CCSM_DAEMON_SECRET intentionally excluded — it carries the daemon HMAC
+// secret and must never appear in crash dumps. Keep this list narrow; any
+// new CCSM_* var carrying a secret MUST be omitted explicitly here too.
+const ALLOW = /^(NODE_ENV|CCSM_(?!DAEMON_SECRET\b).*|ELECTRON_.*)$/;
 
 export function scrubHomePath(s: string): string {
   const home = os.homedir();
@@ -16,4 +31,90 @@ export function redactEnv(env: NodeJS.ProcessEnv): Record<string, string> {
     if (v != null && ALLOW.test(k)) out[k] = v;
   }
   return out;
+}
+
+// ---- Secret redaction (frag-6-7 §6.6 + §6.6.3) -----------------------------
+
+const REDACTED = '<REDACTED>';
+
+// Object property names whose value must always be redacted, case-insensitive.
+// Matches both exact names and any property whose name ENDS WITH ".secret" or
+// ".apiKey" (e.g. obj.daemon.secret, obj.foo.apiKey).
+const SECRET_KEY_NAMES = new Set<string>([
+  'apikey',
+  'token',
+  'authorization',
+  'cookie',
+  'anthropic_api_key',
+  'daemonsecret',
+  'installsecret',
+  'pingsecret',
+  'hellononce',
+  'clienthellononce',
+  'hellononcehmac',
+  'secret',
+]);
+
+function isSecretKey(key: string): boolean {
+  const lk = key.toLowerCase();
+  if (SECRET_KEY_NAMES.has(lk)) return true;
+  // suffix matches for "*.secret" / "*.apiKey" style nested keys flattened
+  // to a single property name (e.g. "daemon.secret" used as key).
+  if (lk.endsWith('.secret') || lk.endsWith('.apikey')) return true;
+  // Also catch ALL_CAPS env-shaped keys ending in _SECRET / _TOKEN / _API_KEY.
+  if (/_(SECRET|TOKEN|API_KEY)$/i.test(key)) return true;
+  return false;
+}
+
+// String-level patterns: stack traces / log lines / stderr tails arrive as
+// strings, so we have to scrub by regex too.
+//
+// Patterns (each replaced with `<NAME>: <REDACTED>` or `<KEY>=<REDACTED>`):
+//   1. HTTP-ish header lines:  Authorization: Bearer xxx   |   Cookie: foo=bar
+//   2. env-style assignments:  ANTHROPIC_API_KEY=sk-xxx    |   FOO_TOKEN=xxx
+//   3. JSON-ish quoted props:  "daemonSecret":"xxx"        |   "token": "xxx"
+const HEADER_RE = /\b(Authorization|Cookie|Proxy-Authorization|X-Api-Key)(\s*[:=]\s*)([^\r\n,;]+)/gi;
+const ENV_RE = /\b((?:ANTHROPIC_API_KEY|[A-Z][A-Z0-9_]*_(?:SECRET|TOKEN|API_KEY)|daemonSecret|installSecret|pingSecret|helloNonce|clientHelloNonce|helloNonceHmac))=([^\s'"]+)/g;
+const JSON_PROP_RE = /"(apiKey|token|authorization|cookie|ANTHROPIC_API_KEY|daemonSecret|installSecret|pingSecret|helloNonce|clientHelloNonce|helloNonceHmac|secret)"(\s*:\s*)"([^"\\]*(?:\\.[^"\\]*)*)"/gi;
+
+function redactString(s: string): string {
+  if (!s) return s;
+  return s
+    .replace(HEADER_RE, (_m, name: string, sep: string) => `${name}${sep}${REDACTED}`)
+    .replace(ENV_RE, (_m, name: string) => `${name}=${REDACTED}`)
+    .replace(JSON_PROP_RE, (_m, name: string, sep: string) => `"${name}"${sep}"${REDACTED}"`);
+}
+
+/**
+ * Recursively redact secrets from a string or JSON-shaped value.
+ *
+ * - Strings are scanned for header/env/JSON-property patterns.
+ * - Objects: any property whose name matches the secret key set has its value
+ *   replaced with `<REDACTED>` regardless of type. Other properties are
+ *   recursed into.
+ * - Arrays are recursed element-wise.
+ * - Other primitives (number, boolean, null, undefined) pass through unchanged.
+ *
+ * Cycles are guarded with a visited set; cycle nodes are replaced with the
+ * string `[Circular]` so we never crash a crash-handler.
+ */
+export function redactSecrets<T>(input: T): T {
+  const seen = new WeakSet<object>();
+  function walk(v: unknown): unknown {
+    if (typeof v === 'string') return redactString(v);
+    if (v == null || typeof v !== 'object') return v;
+    if (seen.has(v as object)) return '[Circular]';
+    seen.add(v as object);
+    if (Array.isArray(v)) return v.map(walk);
+    const out: Record<string, unknown> = {};
+    for (const [k, vv] of Object.entries(v as Record<string, unknown>)) {
+      if (isSecretKey(k)) {
+        out[k] = REDACTED;
+      } else {
+        out[k] = walk(vv);
+      }
+    }
+    return out;
+  }
+  return walk(input) as T;
 }

--- a/electron/ipc/rendererErrorForwarder.ts
+++ b/electron/ipc/rendererErrorForwarder.ts
@@ -28,6 +28,7 @@
 import type { IpcMain, IpcMainInvokeEvent } from 'electron';
 import { fromMainFrame } from '../security/ipcGuards';
 import type { CrashCollector, SerializedError } from '../crash/collector';
+import { redactSecrets } from '../crash/scrub';
 
 export interface RendererErrorReport {
   error: SerializedError;
@@ -109,12 +110,16 @@ export function handleRendererErrorReport(report: RendererErrorReport, deps: Han
 
   collector.recordIncident({
     surface: 'renderer',
+    // Redact secrets at the main-side trust boundary (frag-6-7 §6.6.3).
+    // We do this in main rather than in renderer so a compromised renderer
+    // can't bypass scrubbing by skipping the call. The collector also runs
+    // scrubHomePath on top of these strings.
     error: {
       name: report.error.name,
-      message: report.error.message,
-      stack: report.error.stack,
+      message: redactSecrets(report.error.message),
+      stack: report.error.stack ? redactSecrets(report.error.stack) : undefined,
     },
-    stderrTail: breadcrumbs,
+    stderrTail: breadcrumbs.map(b => redactSecrets(b)),
   });
   return { accepted: true };
 }

--- a/tests/electron/crash/scrub.test.ts
+++ b/tests/electron/crash/scrub.test.ts
@@ -1,6 +1,6 @@
 // tests/electron/crash/scrub.test.ts
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { scrubHomePath, redactEnv } from '../../../electron/crash/scrub';
+import { scrubHomePath, redactEnv, redactSecrets } from '../../../electron/crash/scrub';
 
 vi.mock('node:os', async () => {
   const actual = await vi.importActual<typeof import('node:os')>('node:os');
@@ -35,5 +35,71 @@ describe('redactEnv', () => {
       SECRET: 's',
     });
     expect(out).toEqual({ NODE_ENV: 'production', CCSM_FOO: 'x', ELECTRON_RUN_AS_NODE: '1' });
+  });
+  // Task #60 — CCSM_DAEMON_SECRET previously slipped through the CCSM_*
+  // allowlist. It must now be excluded so daemon HMAC secrets never land in
+  // crash-meta env snapshots. See frag-6-7 §6.6.3.
+  it('excludes CCSM_DAEMON_SECRET even though it matches CCSM_*', () => {
+    const out = redactEnv({
+      CCSM_DAEMON_SECRET: 'super-sekret',
+      CCSM_OTHER: 'ok',
+    });
+    expect(out).toEqual({ CCSM_OTHER: 'ok' });
+    expect(out.CCSM_DAEMON_SECRET).toBeUndefined();
+  });
+});
+
+// Task #60 — three canonical secret patterns must be redacted to <REDACTED>
+// across all three crash surfaces. This is the electron/main suite.
+describe('redactSecrets (electron main surface)', () => {
+  it('(a) redacts Authorization: Bearer <token> in stack-trace strings', () => {
+    const stack = 'Error: boom\n  at fetch (Authorization: Bearer sk-ant-1234567890abcdef)\n  at run (foo.ts:1:1)';
+    const out = redactSecrets(stack);
+    expect(out).toContain('Authorization: <REDACTED>');
+    expect(out).not.toContain('sk-ant-1234567890abcdef');
+    expect(out).not.toContain('Bearer ');
+  });
+  it('(b) redacts ANTHROPIC_API_KEY=sk-xxx env-style assignments', () => {
+    const line = 'spawn failed: ANTHROPIC_API_KEY=sk-ant-api-9999 PATH=/usr/bin node main.js';
+    const out = redactSecrets(line);
+    expect(out).toContain('ANTHROPIC_API_KEY=<REDACTED>');
+    expect(out).not.toContain('sk-ant-api-9999');
+    expect(out).toContain('PATH=/usr/bin');
+  });
+  it('(c) redacts object property obj.daemonSecret value', () => {
+    const obj = { daemonSecret: 'super-sekret-value', ok: 'safe' };
+    const out = redactSecrets(obj);
+    expect(out.daemonSecret).toBe('<REDACTED>');
+    expect(out.ok).toBe('safe');
+  });
+  it('also redacts nested *.secret keys + helloNonceHmac + Cookie header', () => {
+    const obj = {
+      daemon: { secret: 'leak-me', port: 9000 },
+      helloNonceHmac: 'xx',
+      headers: 'Cookie: sid=abcd; other=1',
+      authorization: 'Bearer leak2',
+    };
+    const out = redactSecrets(obj);
+    expect((out.daemon as any).secret).toBeDefined();
+    // daemon.secret is a nested object property; the inner "secret" key is in
+    // the SECRET_KEY_NAMES set so it MUST be redacted.
+    expect((out.daemon as any).secret).toBe('<REDACTED>');
+    expect((out.daemon as any).port).toBe(9000);
+    expect(out.helloNonceHmac).toBe('<REDACTED>');
+    expect(out.headers).toContain('Cookie: <REDACTED>');
+    expect(out.authorization).toBe('<REDACTED>');
+  });
+  it('handles cycles without throwing', () => {
+    const a: any = { x: 1 };
+    a.self = a;
+    const out = redactSecrets(a);
+    expect(out.x).toBe(1);
+    expect(out.self).toBe('[Circular]');
+  });
+  it('passes primitives through unchanged', () => {
+    expect(redactSecrets(42)).toBe(42);
+    expect(redactSecrets(null)).toBeNull();
+    expect(redactSecrets(undefined)).toBeUndefined();
+    expect(redactSecrets(true)).toBe(true);
   });
 });

--- a/tests/electron/ipc/rendererErrorForwarder.scrub.test.ts
+++ b/tests/electron/ipc/rendererErrorForwarder.scrub.test.ts
@@ -1,0 +1,87 @@
+// tests/electron/ipc/rendererErrorForwarder.scrub.test.ts
+//
+// Task #60 — renderer-surface crash-scrub coverage. The renderer error
+// forwarder receives an untrusted RendererErrorReport from the renderer and
+// hands it to the phase-1 collector. Per frag-6-7 §6.6.3 the secret redact
+// must happen BEFORE the report reaches the collector, so a compromised /
+// out-of-date renderer can never bypass the scrubber.
+import { describe, it, expect, vi } from 'vitest';
+import {
+  handleRendererErrorReport,
+  createRendererErrorRateLimiter,
+  type RendererErrorReport,
+} from '../../../electron/ipc/rendererErrorForwarder';
+import type { CrashCollector, IncidentInput } from '../../../electron/crash/collector';
+
+function makeCollectorSpy(): { collector: CrashCollector; calls: IncidentInput[] } {
+  const calls: IncidentInput[] = [];
+  const collector: CrashCollector = {
+    recordIncident: (input: IncidentInput): string => {
+      calls.push(input);
+      return '/tmp/fake-incident';
+    },
+    flush: vi.fn(async () => {}),
+    pruneRetention: vi.fn(),
+  };
+  return { collector, calls };
+}
+
+describe('rendererErrorForwarder secret redaction (Task #60)', () => {
+  function runWith(report: RendererErrorReport): IncidentInput {
+    const { collector, calls } = makeCollectorSpy();
+    const limiter = createRendererErrorRateLimiter({ windowMs: 60_000, max: 100 });
+    const res = handleRendererErrorReport(report, { collector, limiter, processId: 1 });
+    expect(res.accepted).toBe(true);
+    expect(calls.length).toBe(1);
+    return calls[0]!;
+  }
+
+  it('(a) redacts Authorization: Bearer in error.stack', () => {
+    const incident = runWith({
+      source: 'window.onerror',
+      error: {
+        message: 'fetch failed',
+        stack: 'Error: fetch failed\n  at fetch (Authorization: Bearer sk-ant-zzz)',
+        name: 'Error',
+      },
+    });
+    expect(incident.error?.stack).toContain('Authorization: <REDACTED>');
+    expect(incident.error?.stack).not.toContain('sk-ant-zzz');
+  });
+
+  it('(b) redacts ANTHROPIC_API_KEY=sk-xxx in error.message', () => {
+    const incident = runWith({
+      source: 'window.onerror',
+      error: {
+        message: 'env leaked: ANTHROPIC_API_KEY=sk-ant-leak-9 boot failed',
+        name: 'Error',
+      },
+    });
+    expect(incident.error?.message).toContain('ANTHROPIC_API_KEY=<REDACTED>');
+    expect(incident.error?.message).not.toContain('sk-ant-leak-9');
+  });
+
+  it('(c) redacts daemonSecret-style property in JSON-shaped error message', () => {
+    const incident = runWith({
+      source: 'window.onunhandledrejection',
+      error: {
+        message: 'rejection: {"daemonSecret":"super-sekret","other":"ok"}',
+        name: 'Error',
+      },
+    });
+    expect(incident.error?.message).toContain('"daemonSecret":"<REDACTED>"');
+    expect(incident.error?.message).not.toContain('super-sekret');
+    expect(incident.error?.message).toContain('"other":"ok"');
+  });
+
+  it('also redacts breadcrumbs (stderrTail) when url contains a secret', () => {
+    const incident = runWith({
+      source: 'window.onerror',
+      url: 'https://api.example.com/?ANTHROPIC_API_KEY=sk-ant-uuu',
+      error: { message: 'oops', name: 'Error' },
+    });
+    const tail = (incident.stderrTail ?? []).join('\n');
+    expect(tail).not.toContain('sk-ant-uuu');
+    expect(tail).toContain('ANTHROPIC_API_KEY=<REDACTED>');
+  });
+});


### PR DESCRIPTION
P1 security. Resolves #60 per spec frag-6-7 §6.6.3.

## Problem

Three concrete leaks of secrets into on-disk crash artifacts:

1. `electron/crash/scrub.ts` only exported `scrubHomePath` + an env allowlist `CCSM_DAEMON_SECRET` was matched by the `CCSM_*` glob and survived `redactEnv`. Stack traces / stderr-tail strings were never scanned for `Authorization: Bearer ...`, `ANTHROPIC_API_KEY=...`, or `daemonSecret`-style payloads.
2. `daemon/src/crash/handlers.ts` wrote `err.message` + `err.stack` straight into the marker JSON with no scrub at all.
3. `electron/ipc/rendererErrorForwarder.ts` forwarded renderer-supplied error strings to the collector unscrubbed.

Net: any error path that surfaces the daemon HMAC secret, an Anthropic API key, or a Bearer token would persist that secret to `<crashRoot>` and (when consent allowed) ship it to Sentry.

## Change

- `electron/crash/scrub.ts` adds `redactSecrets(input)` — recursively walks strings + JSON-shaped values; replaces secret-named property values with `<REDACTED>` and substitutes `Authorization` / `Cookie` / `X-Api-Key` headers, env-style `KEY=value` assignments, and JSON quoted properties.
- `redactEnv` excludes `CCSM_DAEMON_SECRET` from the `CCSM_*` allowlist via negative lookahead.
- `daemon/src/crash/scrub.ts` is a deliberate mirror of `redactSecrets` for the daemon process. We do NOT cross-import between `electron/` and `daemon/` (separate build targets / processes); both copies must stay in sync. Header comments call this out explicitly.
- Three call sites rewired:
  - `electron/crash/collector.ts` redacts `error.json` + `stderr-tail.txt` + `stdout-tail.txt` (in addition to existing `scrubHomePath`).
  - `electron/ipc/rendererErrorForwarder.ts` redacts at the main-side trust boundary so a compromised renderer cannot bypass scrubbing.
  - `daemon/src/crash/handlers.ts` redacts marker JSON + the `daemon.crash` log line.

## Redact list (frag-6-7 §6.6 + §6.6.3)

Property names (case-insensitive, exact + `*.secret` / `*.apiKey` suffix + `*_SECRET`/`*_TOKEN`/`*_API_KEY` suffix): `apiKey`, `token`, `authorization`, `cookie`, `ANTHROPIC_API_KEY`, `daemonSecret`, `installSecret`, `pingSecret`, `helloNonce`, `clientHelloNonce`, `helloNonceHmac`, `secret`.

String patterns: `Authorization|Cookie|Proxy-Authorization|X-Api-Key: <value>`, `<ENV_NAME>=<value>` for the env-shaped names above, and `"<name>":"<value>"` JSON-property form.

## Tests — three surface suites, three canonical patterns each

Each suite asserts (a) `Authorization: Bearer <token>`, (b) `ANTHROPIC_API_KEY=sk-xxx`, (c) `obj.daemonSecret = "xxx"` are all replaced with `<REDACTED>`:

- `tests/electron/crash/scrub.test.ts` (electron main): pure scrubber + extended `redactEnv` exclusion of `CCSM_DAEMON_SECRET` + nested `*.secret` + cycle-safety + primitive passthrough.
- `tests/electron/ipc/rendererErrorForwarder.scrub.test.ts` (renderer): asserts the IPC handler hands a redacted `IncidentInput` to the collector for `error.message` / `error.stack` / breadcrumb URL.
- `daemon/src/crash/__tests__/scrub.test.ts` (daemon): pure scrubber + integration test wiring `installCrashHandlers` against a tmpdir `runtimeRoot`, emitting an `uncaughtException` with leaky stack, then reading the on-disk marker JSON and asserting the secret is absent + `<REDACTED>` is present.

## Verification

- `npm run typecheck` PASS (root + electron + daemon).
- Targeted vitest: `tests/electron/crash/scrub.test.ts tests/electron/ipc/rendererErrorForwarder.scrub.test.ts daemon/src/crash/__tests__/scrub.test.ts` -> 20/20 PASS in 2.6s.
- Broader crash test set (collector, supervisor.crash, main.crash-handlers, ipc/crashIncidents, prefs/crashConsent, crashReporting, daemon/lifecycle/crash-loop-skip, plus the 3 new suites) -> 48/48 PASS.
- Electron require-load smoke on rebuilt artifacts: `node -e "require('./dist/electron/crash/scrub.js'); require('./dist/electron/crash/collector.js'); require('./dist/electron/ipc/rendererErrorForwarder.js')"` -> OK (no `ERR_REQUIRE_ESM`).
- Lint: clean on all changed files.

## Spec gaps observed

None. Redact list lifted verbatim from frag-6-7 §6.6 (with the `*.secret` / `*.apiKey` suffix glob applied as nested-key matching since we walk JS objects, not pino paths). The spec calls for pino path-based redaction in the logger; this PR is the orthogonal crash-artifact-write scrubber. The `imposterSecret` / `clientImposterSecret` fields the spec mentions as historically present are no longer in the wire schema (HMAC-of-nonce handshake), so they are not in the new list either.

## Out of scope

- pino logger redact paths (separate concern, frag-6-7 §6.6 logger surface — not §6.6.3 crash-dump surface).
- Lint hook asserting no logger call site passes resolved `daemon.secret` value (frag-6-7 §6.6 sec-S4 follow-up).