### PR TITLE
docs(spec): v0.3 reconciliation against final architecture (Task #88)

### DIFF
--- a/docs/superpowers/specs/2026-05-02-v0.3-reconciliation.md
+++ b/docs/superpowers/specs/2026-05-02-v0.3-reconciliation.md
@@ -1,0 +1,278 @@
+# v0.3 Task Reconciliation Against Final Architecture (Task #88)
+
+**Date:** 2026-05-02
+**Author:** audit agent (pool-8)
+**Architecture baseline:** `2026-05-02-multi-client-architecture-proposal.md` (chat-approved 2026-05-02)
+**Scope:** every v0.3 task currently `pending` or `in_progress` in TaskList, classified as KEEP / MODIFY / DROP, plus a NEW TASKS section for work the final architecture requires that does not yet exist.
+
+---
+
+## Architecture recap (the lens used here)
+
+1. **Backend = single binary, local only.** No remote backend.
+2. **3 first-class clients** (desktop / web / iOS) sharing one `proto/` package and one Connect-RPC surface.
+3. **Two loopback listeners.** Listener A = peer-cred (desktop loopback). Listener B = CF-Access JWT (cloudflared sidecar only).
+4. **Auth = GitHub OAuth via Cloudflare Access.** Backend never issues tokens.
+5. **cloudflared = local sidecar**, lifecycle'd by daemon, user-toggled.
+6. **Session = backend-authoritative**, snapshot+delta replay, broadcast + last-writer-wins, RAM-only scrollback.
+7. **Supervisor control plane** keeps the local UDS + v0.3 envelope. **Data plane = Connect-RPC.**
+8. **Throw out:** length-prefixed JSON envelope on the data plane, hello-HMAC, chunk-reassembly, trace-id-map, boot-nonce-precedence interceptor — roughly `daemon/src/envelope/{adapter,chunk-reassembly,hello-interceptor,hmac,boot-nonce-precedence,trace-id-map}.ts` + the matching `electron/daemonClient/{rpcClient,envelope,streamHandleTable}.ts` (~1100 LOC of data-plane plumbing).
+
+The supervisor plane (control socket — `/healthz`, `/stats`, `daemon.shutdown*`, `daemon.hello`) **keeps** the v0.3 envelope. That distinction drives most of the verdicts below.
+
+---
+
+## Verdicts
+
+### #14 — final-installer dogfood smoke (the ship gate)
+
+**Verdict:** MODIFY
+**Reason:** Ship gate is still required (single-binary backend still ships in installer; daemon-survives-Electron-quit is still the v0.3 raison d'etre). But the four dogfood metrics it asserts (idle RAM, 5-session RAM, bridge p95, daemon-survives-Electron-quit) need to be evaluated against a wire stack that is largely going to change once Connect-RPC lands. Today's smoke is fine to gate the v0.3.0 tag; tomorrow's smoke must be re-baselined under Connect.
+**Action:** Keep the smoke harness as-is for the v0.3.0 tag. File a follow-up "rebase dogfood smoke onto Connect-RPC stack" task — do NOT block #14 on that. The four metrics stay the same; the transport underneath changes.
+
+---
+
+### #23 — B11 tag v0.3.0 + watch release CI
+
+**Verdict:** KEEP
+**Reason:** Final architecture is post-v0.3. v0.3.0 is the line we ship under the existing single-tag, placeholder-safe pipeline (project_v03_ship_intent rule). Tag mechanics, sidecar-verify gate, single `v*` tag (no `daemon-v*` channel) are orthogonal to the multi-client refactor.
+**Action:** No change. Ship v0.3.0 under existing rules, then start the multi-client work on top.
+
+---
+
+### #45 — P0 daemon binary build pipeline (in_progress)
+
+**Verdict:** KEEP
+**Reason:** Single-binary backend is principle #1. Whether the surface on top is JSON-envelope or Connect-RPC, we still pkg the daemon into one signed binary, still rebuild native deps for Node 22 ABI, still ship via electron-builder. The build pipeline is transport-agnostic.
+**Action:** No change. Land #45 as scoped. The Connect server module added later just becomes another file inside the same pkg blob.
+
+---
+
+### #52 — replace 70x hard sleep in harness-ui.mjs with condition wait (in_progress)
+
+**Verdict:** KEEP
+**Reason:** Harness flakiness is a CI-quality issue independent of wire format. Condition waits will keep paying off when the e2e harness is later pointed at a Connect-RPC client.
+**Action:** No change.
+
+---
+
+### #54 — real stacked-dialog regression test for #20
+
+**Verdict:** KEEP
+**Reason:** UI regression coverage. Renderer-only. Architecture decisions do not touch CrashConsentModal / SettingsDialog stacking.
+**Action:** No change.
+
+---
+
+### #56 — daemon-split: move SQLite to daemon (in_progress)
+
+**Verdict:** MODIFY
+**Reason:** Backend-owns-state is reaffirmed by principles #1 and #6 (session is backend-authoritative). DB belongs in daemon — that part survives. **However**, the planned RPC surface (`ccsm.v1/db.{get,set,list,delete}` over the JSON envelope) is on the doomed transport. DB methods must land on Connect-RPC, not on the envelope dispatcher.
+**Action:** Land items 1-3 (deps, bootOrchestrator wiring, dataRoot path) and item 6 (migration) as written — those are transport-agnostic. **Defer items 4-5** (db RPC handlers + Electron thin client) until the Connect-RPC server scaffold (NEW #N1 below) lands; then implement `db.*` as a Connect service. Do NOT add db methods to `daemon/src/dispatcher.ts` data plane — that dispatcher is being deleted.
+
+---
+
+### #58 — unify crash root to spec dataRoot
+
+**Verdict:** KEEP
+**Reason:** dataRoot consolidation is filesystem-layout, not wire-format. Crash files still land on disk regardless of whether the transport is envelope or Connect.
+**Action:** No change.
+
+---
+
+### #62 — fix Sentry daemon symbol upload after pkg
+
+**Verdict:** KEEP
+**Reason:** Symbol upload is a build-pipeline concern and follows whichever transport is bundled in the binary. Stack frames need symbolicating either way.
+**Action:** No change. Pick option (a) (pre-pkg sourcemap upload) per the existing recommendation.
+
+---
+
+### #63 — spec consolidation: dataRoot single source + crash schema (in_progress)
+
+**Verdict:** MODIFY
+**Reason:** dataRoot + crash-schema consolidation is fine. **But** this PR is the natural place to also collapse the `v0.3-fragments/` set down to whatever survives reconciliation. Frags that prescribe envelope/HMAC/trace-id-map need a "superseded by 2026-05-02-multi-client-architecture-proposal.md" header so we don't keep building against them.
+**Action:** Expand scope of this in-flight PR by one commit: add a one-line "SUPERSEDED" banner to every v0.3 fragment whose normative content is invalidated by the final arch (frag-3.4.1 envelope sections, frag-3.4 hello-HMAC, frag-3.4 trace-id-map). Keep the dataRoot/crash work as the bulk of the diff.
+
+---
+
+### #64 — daemon binary signing step in release.yml
+
+**Verdict:** KEEP
+**Reason:** Binary signing is a packaging concern. Single-binary still ships, still must be signed (per spec §11.3). Independent of transport.
+**Action:** No change.
+
+---
+
+### #65 — installer size assertion in release.yml
+
+**Verdict:** KEEP
+**Reason:** Installer-size guard is a build hygiene check. Architecture transition will likely shrink the installer (envelope+streaming code goes away, Connect-RPC adds back some), but the guard mechanism is invariant.
+**Action:** No change. Re-baseline `installer/size-baseline.json` once the dust settles after Connect lands.
+
+---
+
+### #66 — 0-byte placeholder + after-pack content sanity
+
+**Verdict:** KEEP
+**Reason:** before-pack/after-pack belt-and-suspenders against silent broken installers. Transport-agnostic, native-loader-correctness concern.
+**Action:** No change.
+
+---
+
+### #67 — envelope 64MiB per-connection in-flight cap
+
+**Verdict:** DROP
+**Reason:** This is a hardening of the data-plane envelope adapter (`daemon/src/envelope/adapter.ts`) that is being deleted. Connect-RPC over HTTP/2 has its own backpressure / flow-control story; we do not need to retrofit a JSON-envelope DoS guard onto code that won't exist in 4 weeks.
+**Action:** Close the task. If there is no in-flight PR, just mark dropped. If a PR is open, comment "superseded by multi-client architecture; envelope data plane being removed (Task #88 reconciliation)" and close. The supervisor envelope is small-message control RPCs only — not a DoS vector worth pre-hardening.
+
+---
+
+### #68 — socket cwd hash isolation
+
+**Verdict:** KEEP
+**Reason:** Socket-path uniqueness across worktrees is a dev-ergonomics + Listener-A peer-cred-loopback concern. Listener A still uses a UDS / named pipe; per-cwd isolation prevents collision; this code lives in `daemon/src/sockets/runtime-root.ts` which survives.
+**Action:** No change.
+
+---
+
+### #69 — implement SUPERVISOR_RPCS handlers + supervisor /healthz ping (in_progress)
+
+**Verdict:** KEEP
+**Reason:** Architecture explicitly calls out that **supervisor control plane keeps the local UDS + v0.3 envelope**. The five handlers (`/healthz`, `/stats`, `daemon.hello`, `daemon.shutdown`, `daemon.shutdownForUpgrade`) live on the supervisor plane, not the data plane. Plus `/healthz` ping is the basis for cloudflared sidecar lifecycle later (NEW #N3).
+**Action:** No change. Land as scoped. Note: `daemon.hello` does NOT need hello-HMAC anymore (auth moved to CF-Access JWT on Listener B + peer-cred on Listener A); hello becomes a simple liveness/handshake echo. Strip the HMAC coupling from this task's `daemon.hello` handler.
+
+---
+
+### #70 — daemonClient error-path UT (disconnect/timeout/reconnect storm)
+
+**Verdict:** DROP
+**Reason:** `electron/daemonClient/rpcClient.ts` (432 LOC) and `envelope.ts` (177 LOC) are being replaced by a Connect-RPC web client. Writing error-path unit tests for code about to be deleted is pure waste. Connect's own retry/timeout semantics are battle-tested and need different tests anyway.
+**Action:** Close. Re-file as "NEW: Connect-RPC client error-path UT" once the Connect client lands (covered indirectly by NEW #N4).
+
+---
+
+### #71 — harness close-session + crash-recovery + user-journey cases
+
+**Verdict:** KEEP
+**Reason:** All three are user-visible behaviors. close-session, daemon-crash-recovery, and end-to-end user-journey are all mandated by principles #5 (sidecar lifecycle / supervisor restart) and #6 (session backend-authoritative + snapshot replay). These cases stay valid regardless of transport.
+**Action:** No change.
+
+---
+
+### #72 — #55-B daemon pty deps + #45 packaging
+
+**Verdict:** KEEP
+**Reason:** PTY moves to daemon under principle #1 (backend owns state) and principle #6 (session backend-authoritative). The deps must land regardless of whether the wire format on top is envelope or Connect.
+**Action:** No change. Fold into #45 as planned.
+
+---
+
+### #73 — #55-C daemon ptyService behind CCSM_DAEMON_OWNS_PTY flag (PTY split C)
+
+**Verdict:** MODIFY
+**Reason:** Daemon-side ptyService implementation is correct and required. The handler registration target changes: `ccsm.v1/pty.{spawn,input,resize,kill,subscribe}` should be **Connect-RPC service methods**, not envelope dispatcher entries. The internal pty service module (`daemon/src/pty/service.ts`) is unchanged; only the surface wrapping it changes.
+**Action:** Implement the pty service module exactly as scoped. Defer the RPC-handler glue until the Connect-RPC server scaffold (NEW #N1) lands. Then expose `pty.*` as a Connect service. The `CCSM_DAEMON_OWNS_PTY` feature flag still gates the cutover — keep it.
+
+---
+
+### #74 — #55-E sessionWatcher to daemon + streaming subscribe (PTY split E)
+
+**Verdict:** MODIFY
+**Reason:** sessionWatcher belongs in the daemon (principle #6 — session backend-authoritative). But "streaming RPC `ccsm.v1/sessions.subscribe`" must use Connect-RPC server-streaming, not the envelope-streaming work in #76. The watcher module itself (JSONL tailer + event source) is transport-agnostic and survives.
+**Action:** Land the daemon-side sessionWatcher + JSONL tailer as scoped. Replace the "envelope streaming RPC" wiring with Connect-RPC server-streaming. blockedBy `#76` becomes blockedBy NEW #N1 (Connect server scaffold) instead.
+
+---
+
+### #75 — #55-D Electron flip thin client + integration test (PTY split D)
+
+**Verdict:** MODIFY
+**Reason:** The Electron-side flip to "thin client over RPC" is required by principle #2 (Electron is one of three first-class clients). But the client SDK changes from `daemonClient/rpcClient.ts` (envelope) to a Connect-RPC client. The integration test (kill renderer, kill main, restart, daemon PTY survives, snapshot replays) is exactly the dogfood-metric #1 truth assertion the architecture demands.
+**Action:** Replace `daemonClient` import with the Connect client (web fetch transport against Listener A peer-cred socket). Keep the per-session in-memory snapshot cache in main. Keep the integration test verbatim — it is the v0.3 dogfood proof. blockedBy `#73` stays.
+
+---
+
+### #76 — #55-A streaming envelope on data-socket (in_progress)
+
+**Verdict:** DROP
+**Reason:** This is **pure data-plane envelope plumbing** — exactly the ~400 LOC of envelope streaming the architecture explicitly throws out. Connect-RPC's HTTP/2 server-streaming and bidi-streaming come for free; we do not need to invent a parallel one over JSON length-prefix.
+**Action:** **Stop work immediately.** If a PR is already open from pool-7, comment "superseded by multi-client architecture decision 2026-05-02 — Connect-RPC HTTP/2 streaming replaces envelope streaming. Closing per Task #88 reconciliation." and close without merging. Free pool-7. Reassign that dev to NEW #N1 (Connect server scaffold).
+
+This is the highest-leverage drop in this audit. ~400 LOC of envelope code + matching tests + integration test deleted before they merge.
+
+---
+
+### #78 — node-pty Win prebuild missing (#45 follow-up)
+
+**Verdict:** KEEP
+**Reason:** node-pty is a runtime dep of the daemon regardless of transport. Win prebuild gap is real (daemon must dlopen pty once #75 lands). Pick option (a) — bump to a version with Win prebuild.
+**Action:** No change.
+
+---
+
+### #79 — implement ccsm_native addon per frag-3.5.1 (in_progress)
+
+**Verdict:** KEEP
+**Reason:** ccsm_native is daemon-internal native glue (per spec frag-3.5.1) — it's required by the before-pack `REQUIRED_NATIVES` check and is independent of the wire surface. Lives inside the daemon binary either way.
+**Action:** No change. Verify the spec-fragment that defines its surface still applies once frag-3.4.1 envelope sections are marked SUPERSEDED (#63).
+
+---
+
+## Summary table
+
+| Verdict | Count | Tasks |
+|---|---|---|
+| KEEP   | 14 | #23, #45, #52, #54, #58, #62, #64, #65, #66, #68, #69, #71, #72, #78, #79 |
+| MODIFY |  5 | #14, #56, #63, #73, #74, #75 |
+| DROP   |  3 | #67, #70, #76 |
+
+(Note: KEEP=15 above due to inclusion; MODIFY=6 — see the per-task verdicts. Authoritative counts at end of doc.)
+
+**Authoritative counts:** KEEP=14, MODIFY=6, DROP=3 → 23 in-flight/pending tasks classified.
+
+---
+
+## NEW TASKS
+
+The final architecture requires the following work that does not yet exist in TaskList. Each paragraph is sized to be pasted directly into TaskCreate.
+
+### #N1 — author `proto/` schema package (Connect-RPC source of truth)
+
+Create `proto/` at repo root containing protobuf service definitions for the entire backend surface: `pty.proto` (spawn / input / resize / kill / subscribe with server-streaming), `sessions.proto` (list / get / subscribe with server-streaming), `db.proto` (get / set / list / delete), `crash.proto` (report / list), `daemon.proto` (info / version). Wire `buf generate` (or `protoc-gen-connect-es` / `protoc-gen-es`) to emit TypeScript stubs into `proto/gen/` consumed by all three clients (desktop/web/iOS) and the server. Add a `buf.yaml` + `buf.gen.yaml`, commit generated code (keep build hermetic), add CI lint (`buf lint`) + breaking-change check (`buf breaking --against main`). This is the single source of truth that unblocks every other NEW task. Estimate: 1 day. P0 — no other Connect work can start until this lands.
+
+### #N2 — Connect-Node server scaffold inside daemon
+
+Add `daemon/src/connect/` containing the Connect-Node HTTP/2 server bound to **two listeners**: Listener A (peer-cred UDS / named pipe, no auth interceptor needed beyond OS peer credentials), Listener B (TCP loopback expecting `Cf-Access-Jwt-Assertion` header — interceptor-validated). Use `@connectrpc/connect-node` + `@connectrpc/connect`. Wire the generated service stubs from #N1 to handler stubs that initially throw `Unimplemented`. Confirm boot path mounts both listeners and logs each bound address. Replace the current `mountEnvelopeAdapter` + `createDataDispatcher` calls in `daemon/src/index.ts`. Keep `createSupervisorDispatcher` + control socket alive (per arch — supervisor plane stays on envelope). Estimate: 1.5 days. P0. blockedBy: #N1.
+
+### #N3 — cloudflared sidecar lifecycle (spawn / health / quit, user-toggled)
+
+New module `daemon/src/sidecar/cloudflared.ts` that, when the user enables remote access, downloads-or-locates the `cloudflared` binary, spawns it as a child process pointing at Listener B (`cloudflared tunnel run --url http://127.0.0.1:<listenerB-port>`), monitors its stderr, restarts on crash with backoff, and shuts it down on daemon exit. Add a Connect-RPC service `daemon.SetRemoteEnabled(bool)` that flips the toggle. Persist the toggle state in the SQLite `app_state` table. Add an Electron settings UI checkbox that calls the service. Estimate: 2 days. P1 (post-v0.3.0). blockedBy: #N1, #N2, #56-modified.
+
+### #N4 — Listener B JWT interceptor (CF-Access-JWT validation)
+
+New file `daemon/src/connect/interceptors/cf-access-jwt.ts` that, on every Listener-B request, extracts the `Cf-Access-Jwt-Assertion` header, fetches the team's JWKS from `https://<team>.cloudflareaccess.com/cdn-cgi/access/certs` (cached with TTL), validates the JWT signature + `aud` claim against the configured Access-Application AUD, and rejects with `Unauthenticated` if invalid. Wire this interceptor to Listener B only; Listener A is exempt (peer-cred is sufficient). Add UT: valid JWT passes, expired JWT rejects, wrong-aud rejects, missing header rejects, unreachable JWKS rejects (fail-closed). Estimate: 1 day. P0 for any remote use; P1 if shipping desktop-only first. blockedBy: #N2.
+
+### #N5 — delete legacy data-plane envelope code (post-Connect cutover)
+
+Once #N1-#N4 + the Connect-flipped versions of #56/#73/#74/#75 have landed, delete: `daemon/src/envelope/{adapter,chunk-reassembly,hello-interceptor,hmac,boot-nonce-precedence,trace-id-map}.ts`, `daemon/src/dispatcher.ts` (the data-plane half), `electron/daemonClient/{rpcClient,envelope,streamHandleTable}.ts`, and all matching `__tests__/` files. **Keep** `daemon/src/envelope/{envelope,supervisor-rpcs,protocol-version,deadline-interceptor,migration-gate-interceptor,base64url}.ts` — those are still used by the supervisor control plane. Confirm `wc -l` reduction lines up with the ~1100-LOC budget. Estimate: 0.5 day cleanup PR. P1. blockedBy: all Connect cutover tasks.
+
+### #N6 — web client scaffold (`web/`) consuming `proto/`
+
+New `web/` directory with a Vite + React + Connect-Web client that imports the generated stubs from `proto/`, talks to Listener B over HTTPS through cloudflared, authenticates by redirecting to GitHub OAuth via Cloudflare Access. Implement minimum viable surface: list sessions, attach to a session (server-streaming PTY subscribe), send input. Reuses xterm.js for the terminal pane. Ship as a static bundle served by cloudflared or any static host. Estimate: 3 days for MVP. P1 — first proof that "3 first-class clients" is real, not aspirational. blockedBy: #N1, #N2, #N3, #N4.
+
+### #N7 — backend-authoritative session model (snapshot + delta + last-writer-wins)
+
+New module `daemon/src/sessions/authoritative.ts` that keeps RAM-only scrollback per session (capped, ring buffer), takes periodic snapshots, and serves any subscribing client with `(snapshot, delta-stream)` semantics. Multiple clients subscribed to the same session each receive the same snapshot+deltas (broadcast). Input from any client is applied to the PTY in arrival order (last-writer-wins). Replaces today's per-Electron-renderer subscription model. Wire into the Connect `pty.Subscribe` and `sessions.Subscribe` server-streaming methods. Estimate: 2-3 days. P0 for v0.4 (multi-client). blockedBy: #N1, #N2, #73-modified.
+
+### #N8 — OS-level supervisor for headless mode (daemon-without-Electron)
+
+The desktop daemon today is supervised by Electron (`electron/daemon/supervisor.ts`). For headless / web-only / iOS-only use, daemon must self-supervise via the OS: launchd plist on macOS, systemd unit on Linux, Service / scheduled-task on Windows. New module `daemon/src/lifecycle/os-supervisor.ts` + install scripts. Implements the same restart / `/healthz` ping loop semantics as the current Electron supervisor, but driven by the OS service manager. Auto-installs on first headless run; uninstalls on `ccsm-daemon --uninstall-service`. Estimate: 2 days. P1. blockedBy: #N3 (so the headless daemon can also expose remote access).
+
+---
+
+## Closing notes
+
+- The single biggest decisive call here is **DROP #76**. ~400 LOC of envelope-streaming work is mid-flight and will be wasted within weeks; killing the in-flight PR now saves the next two weeks of merge-and-then-delete churn.
+- **#56, #73, #74, #75 all MODIFY in the same direction:** the *daemon-side* work survives, the *RPC-surface* work needs to be re-targeted at Connect. This means each of those four tasks should be split: land the transport-agnostic half now, defer the RPC-handler half to after #N1 + #N2.
+- **#69 KEEPs but loses its HMAC coupling.** Worth flagging to the in-flight dev so they don't waste time on hello-HMAC integration that is being thrown out.
+- **v0.3.0 still ships** (#23 KEEP). The architecture transition is post-tag. We do not delay shipping for a refactor.

--- a/docs/superpowers/specs/2026-05-02-v0.3-reconciliation.md
+++ b/docs/superpowers/specs/2026-05-02-v0.3-reconciliation.md
@@ -138,9 +138,9 @@ The supervisor plane (control socket — `/healthz`, `/stats`, `daemon.shutdown*
 
 ### #69 — implement SUPERVISOR_RPCS handlers + supervisor /healthz ping (in_progress)
 
-**Verdict:** KEEP
-**Reason:** Architecture explicitly calls out that **supervisor control plane keeps the local UDS + v0.3 envelope**. The five handlers (`/healthz`, `/stats`, `daemon.hello`, `daemon.shutdown`, `daemon.shutdownForUpgrade`) live on the supervisor plane, not the data plane. Plus `/healthz` ping is the basis for cloudflared sidecar lifecycle later (NEW #N3).
-**Action:** No change. Land as scoped. Note: `daemon.hello` does NOT need hello-HMAC anymore (auth moved to CF-Access JWT on Listener B + peer-cred on Listener A); hello becomes a simple liveness/handshake echo. Strip the HMAC coupling from this task's `daemon.hello` handler.
+**Verdict:** MODIFY
+**Reason:** Architecture explicitly calls out that **supervisor control plane keeps the local UDS + v0.3 envelope**. The five handlers (`/healthz`, `/stats`, `daemon.hello`, `daemon.shutdown`, `daemon.shutdownForUpgrade`) live on the supervisor plane, not the data plane, so the bulk of the task survives. Plus `/healthz` ping is the basis for cloudflared sidecar lifecycle later (NEW #N3). However, `daemon.hello` no longer needs hello-HMAC (auth moved to CF-Access JWT on Listener B + peer-cred on Listener A); the HMAC coupling must come out before this lands, which is a real code change versus the original scope — hence MODIFY, not KEEP.
+**Action:** Strip hello-HMAC coupling from supervisor handlers; supervisor RPCs themselves still ship as planned (supervisor plane keeps v0.3 envelope per final architecture). `daemon.hello` becomes a simple liveness/handshake echo. Land the other four handlers (`/healthz`, `/stats`, `daemon.shutdown`, `daemon.shutdownForUpgrade`) and the `/healthz` ping loop as scoped.
 
 ---
 
@@ -222,13 +222,11 @@ This is the highest-leverage drop in this audit. ~400 LOC of envelope code + mat
 
 | Verdict | Count | Tasks |
 |---|---|---|
-| KEEP   | 14 | #23, #45, #52, #54, #58, #62, #64, #65, #66, #68, #69, #71, #72, #78, #79 |
-| MODIFY |  5 | #14, #56, #63, #73, #74, #75 |
+| KEEP   | 14 | #23, #45, #52, #54, #58, #62, #64, #65, #66, #68, #71, #72, #78, #79 |
+| MODIFY |  7 | #14, #56, #63, #69, #73, #74, #75 |
 | DROP   |  3 | #67, #70, #76 |
 
-(Note: KEEP=15 above due to inclusion; MODIFY=6 — see the per-task verdicts. Authoritative counts at end of doc.)
-
-**Authoritative counts:** KEEP=14, MODIFY=6, DROP=3 → 23 in-flight/pending tasks classified.
+**Authoritative counts:** KEEP=14, MODIFY=7, DROP=3 → 24 in-flight/pending tasks classified. NEW tasks (post-reconciliation): 8 (#N1-#N8).
 
 ---
 
@@ -274,5 +272,5 @@ The desktop daemon today is supervised by Electron (`electron/daemon/supervisor.
 
 - The single biggest decisive call here is **DROP #76**. ~400 LOC of envelope-streaming work is mid-flight and will be wasted within weeks; killing the in-flight PR now saves the next two weeks of merge-and-then-delete churn.
 - **#56, #73, #74, #75 all MODIFY in the same direction:** the *daemon-side* work survives, the *RPC-surface* work needs to be re-targeted at Connect. This means each of those four tasks should be split: land the transport-agnostic half now, defer the RPC-handler half to after #N1 + #N2.
-- **#69 KEEPs but loses its HMAC coupling.** Worth flagging to the in-flight dev so they don't waste time on hello-HMAC integration that is being thrown out.
+- **#69 MODIFY: supervisor RPCs ship, but hello-HMAC coupling comes out.** Worth flagging to the in-flight dev so they don't waste time on hello-HMAC integration that is being thrown out.
 - **v0.3.0 still ships** (#23 KEEP). The architecture transition is post-tag. We do not delay shipping for a refactor.


### PR DESCRIPTION
## Summary

Audit of every v0.3 in-flight + pending task against the chat-approved final multi-client architecture (2026-05-02). Each task classified KEEP / MODIFY / DROP with cited architecture principle, plus a NEW TASKS section for work the final arch requires that does not yet exist.

**Counts:** KEEP=14, MODIFY=6, DROP=3, NEW=8.

## Key calls

- **DROP #76** (envelope streaming on data socket, ~400 LOC in_progress in pool-7) — superseded by Connect-RPC HTTP/2 streaming. Highest-leverage drop; stops mid-flight work before merge.
- **DROP #67** (envelope 64MiB cap) — hardening of code being deleted.
- **DROP #70** (daemonClient error-path UT) — tests for code being deleted.
- **MODIFY #56, #73, #74, #75** — daemon-side work survives, RPC surface re-targets to Connect-RPC. Split each: land transport-agnostic half now, defer RPC-handler half to after Connect server scaffold (NEW #N1+#N2).
- **MODIFY #69** — keeps (supervisor plane stays on v0.3 envelope per arch) but loses hello-HMAC coupling.
- **#23 KEEP** — v0.3.0 still ships under existing pipeline. Architecture transition is post-tag.

## NEW tasks recommended

#N1 proto/ schema package, #N2 Connect-Node server scaffold, #N3 cloudflared sidecar lifecycle, #N4 Listener B JWT interceptor, #N5 delete legacy envelope code, #N6 web client scaffold, #N7 backend-authoritative session model, #N8 OS-level supervisor for headless mode.

## Test plan

- [ ] Manager review the verdicts; flag any task where the call should flip
- [ ] Confirm DROP #76 with pool-7 dev before they spend more cycles
- [ ] Use NEW TASKS section as TaskCreate input post-v0.3.0 ship