### PR TITLE
feat(v0.3): unify crash root to spec dataRoot (Task #58 / Audit 2 F1)

### DIFF
--- a/electron/crash/incident-dir.ts
+++ b/electron/crash/incident-dir.ts
@@ -23,15 +23,85 @@ export interface IncidentMeta {
   };
 }
 
-export function resolveCrashRoot(localAppData?: string): string {
-  if (process.platform === 'win32') {
-    const base = localAppData ?? process.env.LOCALAPPDATA ?? path.join(os.homedir(), 'AppData', 'Local');
-    return path.join(base, 'CCSM', 'crashes');
+/**
+ * Options for the data-root / crash-root resolvers. Mirrors the daemon-side
+ * `PathProvider` shape (`daemon/src/db/ensure-data-dir.ts`) so both processes
+ * compute the same path from the same inputs.
+ *
+ * `env.CCSM_DATA_ROOT`, when set + non-empty, overrides everything: per spec
+ * frag-11 §11.6 the data root is per-user, but tests + dogfood need to inject
+ * a tmpdir without touching `%LOCALAPPDATA%` / `~/Library/...`.
+ */
+export interface DataRootProvider {
+  platform?: NodeJS.Platform;
+  home?: string;
+  env?: Readonly<Record<string, string | undefined>>;
+}
+
+/**
+ * Resolve the OS-native v0.3 data root per frag-11 §11.6 (manager-locked
+ * single source). Lowercase `ccsm`; uppercase `CCSM` is the legacy v0.2 path
+ * (frag-8 §8.1) and MUST NOT be reintroduced (Task #58 / Audit 2 F1).
+ *
+ *   Win  : %LOCALAPPDATA%\ccsm
+ *   mac  : ~/Library/Application Support/ccsm
+ *   Linux: $XDG_DATA_HOME/ccsm  (when set + absolute)
+ *          else ~/.local/share/ccsm
+ *
+ * Override: when `env.CCSM_DATA_ROOT` is set + non-empty it wins. Tests use
+ * this to point all three crash surfaces (electron-main, renderer-forwarded,
+ * daemon-via-supervisor-adoption) at the same tmpdir.
+ *
+ * Pure: no fs access. Mirrors `daemon/src/db/ensure-data-dir.ts`
+ * `resolveDataRoot()` so electron + daemon agree on the same path.
+ */
+export function resolveDataRoot(provider: DataRootProvider = {}): string {
+  const platform = provider.platform ?? process.platform;
+  const home = provider.home ?? os.homedir();
+  const env = provider.env ?? process.env;
+  const override = env.CCSM_DATA_ROOT;
+  if (override && override.length > 0) return override;
+  if (platform === 'win32') {
+    const local = env.LOCALAPPDATA;
+    const root = local && local.length > 0 ? local : path.join(home, 'AppData', 'Local');
+    return path.join(root, 'ccsm');
   }
-  if (process.platform === 'darwin') {
-    return path.join(os.homedir(), 'Library', 'Application Support', 'CCSM', 'crashes');
+  if (platform === 'darwin') {
+    return path.join(home, 'Library', 'Application Support', 'ccsm');
   }
-  return path.join(os.homedir(), '.local', 'share', 'CCSM', 'crashes');
+  const xdg = env.XDG_DATA_HOME;
+  if (xdg && xdg.length > 0 && (xdg.startsWith('/') || /^[A-Za-z]:[\\/]/.test(xdg))) {
+    return path.join(xdg, 'ccsm');
+  }
+  return path.join(home, '.local', 'share', 'ccsm');
+}
+
+/**
+ * Single source of truth for the crash-incident root. Spec frag-6-7 §6.6.3
+ * (per PR #784 spec consolidation) defines a single per-user
+ * `<dataRoot>/crashes/` bucket containing one timestamped sub-directory per
+ * incident; the `surface:` field inside `meta.json` discriminates electron-
+ * main vs renderer-forwarded vs daemon-adopted crashes (NOT a per-surface
+ * subdir split — the surface is metadata, not a path component).
+ *
+ * Used by:
+ *   - `electron/main.ts` (electron-main crashes + render/child-process-gone)
+ *   - `electron/ipc/rendererErrorForwarder.ts` (renderer-forwarded reports,
+ *     transitively via the collector instance constructed in `main.ts`)
+ *   - `electron/daemon/supervisor.ts` `attachCrashCapture` (daemon crashes
+ *     adopted into the same bucket, with `<runtimeRoot>/crash/<bootNonce>.json`
+ *     marker folded in as `daemon-marker.json`)
+ *
+ * The historical `localAppData` parameter is preserved as a thin shim so
+ * callers from the prior API don't break; new code should pass a full
+ * `DataRootProvider` (or omit) instead.
+ */
+export function resolveCrashRoot(localAppDataOrProvider?: string | DataRootProvider): string {
+  if (typeof localAppDataOrProvider === 'string') {
+    const env = { ...process.env, LOCALAPPDATA: localAppDataOrProvider };
+    return path.join(resolveDataRoot({ env }), 'crashes');
+  }
+  return path.join(resolveDataRoot(localAppDataOrProvider), 'crashes');
 }
 
 function pad(n: number, w = 2): string { return String(n).padStart(w, '0'); }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -44,9 +44,12 @@ import { setUpgradeShutdownRpc } from './updater';
 //     Electron's native minidump generation into the staging dir without any
 //     network upload. The collector adopts dmps from staging into the
 //     incident dir on the next recordIncident call.
-//   * resolveCrashRoot picks %LOCALAPPDATA%\CCSM\crashes (win32) /
-//     ~/Library/Application Support/CCSM/crashes (darwin) /
-//     ~/.local/share/CCSM/crashes (linux).
+//   * resolveCrashRoot picks %LOCALAPPDATA%\ccsm\crashes (win32) /
+//     ~/Library/Application Support/ccsm/crashes (darwin) /
+//     ~/.local/share/ccsm/crashes (linux) per frag-11 §11.6 (manager-locked
+//     single dataRoot, lowercase `ccsm`). Test override: `CCSM_DATA_ROOT`
+//     env var redirects all 3 surfaces (electron-main, renderer-forwarded,
+//     daemon-via-supervisor-adoption) to the same root (Task #58).
 //   * wireCrashHandlers installs uncaughtException + unhandledRejection that
 //     route through the collector, replacing the prior console.error-only
 //     handlers so every escaped throw leaves a recoverable artifact.

--- a/tests/electron/crash/incident-dir.test.ts
+++ b/tests/electron/crash/incident-dir.test.ts
@@ -30,9 +30,13 @@ describe('incident-dir', () => {
     expect(read.surface).toBe('daemon-exit');
   });
 
-  it('resolveCrashRoot returns OS-appropriate path', () => {
+  it('resolveCrashRoot returns OS-appropriate path with lowercase ccsm', () => {
     const root = resolveCrashRoot();
-    expect(root).toContain('CCSM');
+    // Per frag-11 §11.6 manager lock the data root is lowercase `ccsm`.
+    // Uppercase `CCSM` is the legacy v0.2 path (frag-8 §8.1) and MUST NOT
+    // appear in v0.3 crash paths (Task #58 / Audit 2 F1 — single dataRoot).
+    expect(root).toContain('ccsm');
+    expect(root).not.toContain(path.sep + 'CCSM' + path.sep);
     expect(root).toContain('crashes');
   });
 });

--- a/tests/electron/crash/unified-crash-root.test.ts
+++ b/tests/electron/crash/unified-crash-root.test.ts
@@ -1,0 +1,115 @@
+// Task #58 / Audit 2 F1 — verify the single `resolveCrashRoot()` helper is
+// the single source of truth for ALL crash surfaces (electron-main,
+// renderer-forwarded, daemon-via-supervisor-adoption) and that they all
+// follow the spec dataRoot AND honor the `CCSM_DATA_ROOT` test override.
+//
+// Spec refs:
+//   - frag-11 §11.6 (data root canonical paths, lowercase `ccsm`)
+//   - frag-6-7 §6.6.3 + design doc 2026-05-01-crash-observability §10
+//     (single `<dataRoot>/crashes/` bucket; surface in `meta.json`, NOT a
+//     per-surface subdir split)
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+import { resolveCrashRoot, resolveDataRoot } from '../../../electron/crash/incident-dir';
+import { startCrashCollector } from '../../../electron/crash/collector';
+import {
+  handleRendererErrorReport,
+  createRendererErrorRateLimiter,
+} from '../../../electron/ipc/rendererErrorForwarder';
+
+let tmp: string;
+beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ccsm-task58-')); });
+afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }); });
+
+describe('Task #58 — unified crash root', () => {
+  it('resolveCrashRoot returns <dataRoot>/crashes (single bucket, lowercase ccsm)', () => {
+    const root = resolveCrashRoot({ env: { CCSM_DATA_ROOT: tmp } });
+    expect(root).toBe(path.join(tmp, 'crashes'));
+  });
+
+  it('CCSM_DATA_ROOT env override redirects all 3 surfaces to the same root', () => {
+    // Surface 1: the exported helper itself (used by ipc/crashIncidents.ts +
+    // by electron/main.ts to construct the collector + by the supervisor
+    // adoption path).
+    const helperRoot = resolveCrashRoot({ env: { CCSM_DATA_ROOT: tmp } });
+
+    // Surface 2 + 3: a single collector instance is shared across
+    //   (a) electron-main (`recordIncident` from `wireCrashHandlers`), and
+    //   (b) renderer-forwarded reports (`handleRendererErrorReport`).
+    // Both must therefore land under the same root that the helper resolved.
+    // The supervisor's daemon-crash adoption path also calls
+    // `recordIncident` on this same collector instance (see
+    // electron/daemon/supervisor.ts attachCrashCapture), so a unified
+    // collector instance => unified root for all 3 surfaces.
+    const collector = startCrashCollector({
+      crashRoot: helperRoot,
+      dmpStaging: path.join(helperRoot, '_dmp-staging'),
+      appVersion: '0.3.0',
+      electronVersion: '41.3.0',
+    });
+
+    // (a) electron-main surface
+    const mainDir = collector.recordIncident({
+      surface: 'main',
+      error: { message: 'electron-main crash', name: 'Error' },
+    });
+
+    // (b) renderer-forwarded surface (via the IPC handler)
+    const limiter = createRendererErrorRateLimiter({ windowMs: 60_000, max: 10 });
+    const result = handleRendererErrorReport(
+      { error: { message: 'renderer crash', name: 'Error' }, source: 'window.onerror' },
+      { collector, limiter, processId: 1 },
+    );
+    expect(result.accepted).toBe(true);
+    const dirs = fs.readdirSync(helperRoot).filter(n => !n.startsWith('_'));
+    expect(dirs.length).toBeGreaterThanOrEqual(2);
+    for (const d of dirs) {
+      const meta = JSON.parse(fs.readFileSync(path.join(helperRoot, d, 'meta.json'), 'utf8'));
+      expect(['main', 'renderer']).toContain(meta.surface);
+      // Every incident dir is a direct child of the SAME crash root — no
+      // per-surface subdir split (spec frag-6-7 §6.6.3 + design doc §10).
+      expect(path.dirname(path.join(helperRoot, d))).toBe(helperRoot);
+    }
+
+    // (c) daemon-via-supervisor adoption pathway — supervisor calls
+    //     collector.recordIncident({ surface: 'daemon-exit', ... }) with
+    //     a markerPath argument; that incident dir lands under the same
+    //     root. We simulate the call directly here (the supervisor wiring
+    //     itself is covered by tests/electron/daemon/supervisor.crash-adoption.test.ts).
+    const daemonDir = collector.recordIncident({
+      surface: 'daemon-exit',
+      exitCode: 70,
+      signal: null,
+      bootNonce: '01ARZ3',
+    });
+
+    expect(path.dirname(mainDir)).toBe(helperRoot);
+    expect(path.dirname(daemonDir)).toBe(helperRoot);
+
+    // Surface assertion: every incident dir we created sits under
+    // `${CCSM_DATA_ROOT}/crashes/` — the env override propagated to all
+    // three surfaces by virtue of the single helper.
+    const dataRoot = resolveDataRoot({ env: { CCSM_DATA_ROOT: tmp } });
+    expect(dataRoot).toBe(tmp);
+    expect(helperRoot).toBe(path.join(tmp, 'crashes'));
+  });
+
+  it('default platform fallbacks all use lowercase `ccsm` (no legacy CCSM)', () => {
+    // Empty env so the override doesn't fire; provider injects platform.
+    const win = resolveCrashRoot({ platform: 'win32', home: 'C:\\Users\\u', env: { LOCALAPPDATA: 'C:\\Users\\u\\AppData\\Local' } });
+    const mac = resolveCrashRoot({ platform: 'darwin', home: '/Users/u', env: {} });
+    const lin = resolveCrashRoot({ platform: 'linux', home: '/home/u', env: {} });
+    for (const r of [win, mac, lin]) {
+      expect(r).toContain('ccsm');
+      expect(r.toLowerCase()).toContain('crashes');
+      // Defense in depth: the literal segment `/CCSM/` (or `\CCSM\`) must
+      // not appear — that's the legacy v0.2 capital-CCSM path which frag-11
+      // §11.6 retired for v0.3.
+      expect(r.includes(path.sep + 'CCSM' + path.sep)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
Resolves Task #58 / Audit 2 F1.

## Summary

- Single `resolveCrashRoot()` helper backed by a shared `resolveDataRoot()` (mirroring the daemon-side resolver in `daemon/src/db/ensure-data-dir.ts`). All electron-side callsites (`electron/main.ts`, `electron/ipc/crashIncidents.ts`, `electron/ipc/rendererErrorForwarder.ts` via the shared collector instance, `electron/daemon/supervisor.ts` adoption pathway) resolve to the **same** `<dataRoot>/crashes/` root.
- Path was using uppercase `CCSM` (legacy v0.2 path per frag-8 §8.1) instead of lowercase `ccsm` (frag-11 §11.6 r12 manager-locked single source). Now lowercase everywhere; defense-in-depth assertions in tests forbid reintroduction.
- New `CCSM_DATA_ROOT` env var overrides OS defaults so tests + dogfood can redirect all 3 surfaces to a tmpdir without touching `%LOCALAPPDATA%` / `~/Library/...`.

## Layer-1 push-back vs the original task brief

The brief asked for a `<dataRoot>/crashes/{electron,daemon,renderer}/` per-surface subdir split. **The just-merged spec consolidation (PR #784 + design doc `docs/superpowers/specs/2026-05-01-crash-observability-design.md` §10) defines a single `<dataRoot>/crashes/` bucket with timestamped per-incident subdirs and `surface:` recorded inside `meta.json` — NOT a per-surface path split.** The brief explicitly said "if PR #784 is in flight, defer to its definition", so this PR follows the spec model. Implementing the brief verbatim would have contradicted the freshly-merged spec consolidation.

## Files changed

- `electron/crash/incident-dir.ts` — added `resolveDataRoot()` (mirror of daemon resolver) + rewrote `resolveCrashRoot()` to delegate to it. Lowercase `ccsm`. `CCSM_DATA_ROOT` env override. Old `(localAppData?: string)` signature preserved as a thin shim for back-compat.
- `electron/main.ts` — comment updated to reflect lowercase + env override.
- `tests/electron/crash/incident-dir.test.ts` — flipped assertion from uppercase `CCSM` to lowercase `ccsm` + forbid the legacy segment.
- `tests/electron/crash/unified-crash-root.test.ts` (new) — 3 tests covering (a) `<dataRoot>/crashes` single bucket, (b) `CCSM_DATA_ROOT` redirects all 3 surfaces (main, renderer-forwarded, daemon-via-supervisor-adoption) to the same root, (c) every platform default uses lowercase `ccsm`.

## Out of scope

- **Daemon's `<runtimeRoot>/crash/<bootNonce>.json` marker** is unchanged. It is a transient artifact written by `daemon/src/crash/handlers.ts` on uncaughtException, then adopted by the supervisor into the unified `<dataRoot>/crashes/<incident>/daemon-marker.json`. Touching the marker path would break adoption (covered by `tests/electron/daemon/supervisor.crash-adoption.test.ts`, still green).
- **SQLite path resolution** untouched (Task #56 owns that).
- **Migration of old `CCSM/crashes/` dirs**: per task brief explicitly out of scope. Old dirs are left in place; new crashes go to the new path.

## Verification

```
npx vitest run tests/electron/crash tests/electron/daemon/supervisor.crash-adoption.test.ts tests/daemon/crash
  → Test Files  12 passed (12)
        Tests  45 passed (45)

npx tsc -p tsconfig.json --noEmit         → clean
npx tsc -p tsconfig.electron.json         → clean (full build)
npx eslint <changed files>                → clean
node -e "require('./dist/electron/crash/incident-dir.js')" → OK exports: resolveDataRoot,resolveCrashRoot,...
```

## Test plan

- [x] All 3 surfaces resolve to the same root by default
- [x] `CCSM_DATA_ROOT` env override propagates to all 3 surfaces
- [x] Lowercase `ccsm` on all platforms; uppercase `CCSM` forbidden
- [x] No regression in existing crash-collector / supervisor-adoption / daemon-handler tests
- [x] Compiled module loads without `ERR_REQUIRE_ESM`