### PR TITLE
fix(v0.3): Sentry daemon symbol upload after pkg (audit 3 F1, Task #62)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,12 +173,19 @@ jobs:
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
 
       # Phase 3 crash observability (spec §5.4 / §6, plan Task 10).
-      # Symbol upload to the three per-surface Sentry projects. The
+      # Symbol upload to the per-surface Sentry projects. The
       # afterAllArtifactBuild hook already fires inside electron-builder
       # above; this step is a belt-and-suspenders re-run so a workflow
       # change to skip the hook (e.g. `--publish=onTag`) doesn't silently
       # drop symbol uploads. Skipped when SENTRY_AUTH_TOKEN is unset
       # (PR / fork builds, dry-runs without the release secret plugged in).
+      #
+      # Post-pkg layout (audit 3 F1 / PR #781): the daemon source-of-truth
+      # for sourcemaps is `daemon/dist-daemon-bundle/index.cjs(.map)` (the
+      # esbuild CJS bundle pkg ingests) PLUS the raw tsc emit at
+      # `daemon/dist-daemon/`. Daemon native symbols (.node + .pdb / dSYM)
+      # are picked up from `daemon/native/<platform>-<arch>/`. The script
+      # auto-discovers all of these, so this step needs no extra inputs.
       - name: Upload symbols to Sentry
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/scripts/sentry-upload-symbols.cjs
+++ b/scripts/sentry-upload-symbols.cjs
@@ -6,11 +6,28 @@
 // Uploads source maps + JS bundles + native debug-info files (dSYM on macOS,
 // .pdb on Windows) to the three per-surface Sentry projects:
 //
-//   * SENTRY_PROJECT_RENDERER   <- dist/renderer/   (source maps + bundles)
-//   * SENTRY_PROJECT_MAIN       <- dist/electron/   (source maps + bundles)
+//   * SENTRY_PROJECT_RENDERER   <- dist/renderer/                  (source maps + bundles)
+//   * SENTRY_PROJECT_MAIN       <- dist/electron/                  (source maps + bundles)
 //                                  + native dSYM/.pdb from electron-builder
 //                                    artifact dirs (Crashpad symbolication)
-//   * SENTRY_PROJECT_DAEMON     <- daemon/dist/     (source maps + bundles)
+//   * SENTRY_PROJECT_DAEMON     <- daemon/dist-daemon-bundle/      (CJS bundle + sourcemap
+//                                                                   that pkg actually ingests,
+//                                                                   per frag-11 §11.1 step 3 +
+//                                                                   docs/spikes/2026-05-pkg-esm-connect.md)
+//                                  <- daemon/dist-daemon/          (raw tsc emit + .js.map —
+//                                                                   fallback so stack frames
+//                                                                   that point inside esbuild's
+//                                                                   pre-bundle resolve too)
+//                                  + native debug-files from
+//                                    daemon/native/<platform>-<arch>/ (.node + .pdb /
+//                                                                      dSYM next to .node)
+//
+// Frag-11 §11.x post-pkg layout note: the prior `daemon/dist/` JS dir was
+// retired by PR #781 — that path now holds the pkg-produced binary
+// (`ccsm-daemon-${platform}-${arch}${ext}`), not source maps. Stack traces
+// raised from inside the daemon binary at runtime resolve via the bundle
+// sourcemap, so we MUST point Sentry at the pre-pkg JS+map dirs above, not
+// at `daemon/dist/`. (Audit 3 F1.)
 //
 // Skips silently when SENTRY_AUTH_TOKEN is unset (local dev / OSS forks).
 // Idempotent + version-keyed: re-running on the same release is a no-op
@@ -149,13 +166,43 @@ async function runUpload({ buildResult, env = process.env, execImpl } = {}) {
   });
 
   // 3. Daemon source maps + JS bundles → SENTRY_PROJECT_DAEMON.
-  uploadSourcemaps({
-    dir: path.join(REPO_ROOT, 'daemon', 'dist'),
-    release,
-    project: env.SENTRY_PROJECT_DAEMON,
-    env: baseEnv,
-    execImpl: exec,
-  });
+  //    Post-pkg (PR #781 / frag-11 §11.1 step 3) the JS daemon source-of-truth
+  //    is the esbuild CJS bundle at `daemon/dist-daemon-bundle/index.cjs`
+  //    (+ `index.cjs.map`). That's what pkg ingests and what the runtime
+  //    binary's stack frames map back to. We also upload `daemon/dist-daemon/`
+  //    (raw tsc emit) so frames that survive bundling — or any future
+  //    `--keep-names` mappings — can also resolve.
+  for (const subdir of ['dist-daemon-bundle', 'dist-daemon']) {
+    uploadSourcemaps({
+      dir: path.join(REPO_ROOT, 'daemon', subdir),
+      release,
+      project: env.SENTRY_PROJECT_DAEMON,
+      env: baseEnv,
+      execImpl: exec,
+    });
+  }
+
+  // 3b. Daemon native debug-info → SENTRY_PROJECT_DAEMON.
+  //     `daemon/native/<platform>-<arch>/` holds the Node 22 ABI rebuilds of
+  //     better-sqlite3 / node-pty / ccsm_native (.node files; on Windows
+  //     node-gyp emits .pdb sidecars next to them, on macOS ccsm_native is
+  //     built with `-g` so the dSYM lives alongside the .node). sentry-cli
+  //     debug-files upload walks the dir and ingests every recognized DIF
+  //     format, so stack traces from native daemon crashes (e.g. winjob /
+  //     pdeathsig / pipeAcl) symbolicate against the daemon project.
+  const daemonNativeRoot = path.join(REPO_ROOT, 'daemon', 'native');
+  if (fs.existsSync(daemonNativeRoot) && env.SENTRY_PROJECT_DAEMON) {
+    const archDirs = fs
+      .readdirSync(daemonNativeRoot, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => path.join(daemonNativeRoot, d.name));
+    uploadNativeDif({
+      artifactDirs: archDirs,
+      project: env.SENTRY_PROJECT_DAEMON,
+      env: baseEnv,
+      execImpl: exec,
+    });
+  }
 
   // 4. Native debug-info (Crashpad symbolication) → SENTRY_PROJECT_MAIN.
   // electron-builder produces dSYM bundles (macOS) and .pdb files (Windows)

--- a/tests/scripts/sentry-upload-symbols.test.ts
+++ b/tests/scripts/sentry-upload-symbols.test.ts
@@ -60,11 +60,14 @@ describe('sentry-upload-symbols', () => {
       }
     }
     // The script uses repo-relative paths; existing `dist/renderer`,
-    // `dist/electron`, `daemon/dist` may or may not be present in the
-    // worker checkout — create them if absent and clean up after.
+    // `dist/electron`, `daemon/dist-daemon-bundle`, `daemon/dist-daemon`,
+    // and `daemon/native/<arch>/` may or may not be present in the worker
+    // checkout — create them if absent and clean up after.
     ensureDir(path.join(repoRoot, 'dist', 'renderer'));
     ensureDir(path.join(repoRoot, 'dist', 'electron'));
-    ensureDir(path.join(repoRoot, 'daemon', 'dist'));
+    ensureDir(path.join(repoRoot, 'daemon', 'dist-daemon-bundle'));
+    ensureDir(path.join(repoRoot, 'daemon', 'dist-daemon'));
+    ensureDir(path.join(repoRoot, 'daemon', 'native', 'linux-x64'));
 
     try {
       const calls: { file: string; args: string[]; project?: string }[] = [];
@@ -89,13 +92,19 @@ describe('sentry-upload-symbols', () => {
       expect(projectsCalled.has('p-main')).toBe(true);
       expect(projectsCalled.has('p-dae')).toBe(true);
 
-      // Source-map calls reference upload-sourcemaps.
+      // Source-map calls reference upload-sourcemaps. Post-pkg the daemon
+      // contributes TWO sourcemap dirs (dist-daemon-bundle + dist-daemon)
+      // alongside renderer + electron, so >=4.
       const sourceMapCalls = calls.filter((c) => c.args.includes('upload-sourcemaps'));
-      expect(sourceMapCalls.length).toBeGreaterThanOrEqual(3);
-      // Native dif call uses debug-files upload, scoped to project_main.
+      expect(sourceMapCalls.length).toBeGreaterThanOrEqual(4);
+      // Native dif call uses debug-files upload, scoped to project_main
+      // (Crashpad / electron-builder artifact dirs) AND project_daemon
+      // (daemon/native/<platform>-<arch>/ .node sidecars).
       const nativeCalls = calls.filter((c) => c.args.includes('debug-files'));
-      expect(nativeCalls.length).toBeGreaterThanOrEqual(1);
-      expect(nativeCalls.every((c) => c.project === 'p-main')).toBe(true);
+      expect(nativeCalls.length).toBeGreaterThanOrEqual(2);
+      const nativeProjects = new Set(nativeCalls.map((c) => c.project));
+      expect(nativeProjects.has('p-main')).toBe(true);
+      expect(nativeProjects.has('p-dae')).toBe(true);
     } finally {
       for (const p of created) {
         try { fs.rmSync(p, { recursive: true, force: true }); } catch { /* ignore */ }


### PR DESCRIPTION
## Summary

PR #781 (Task 20 / frag-11 §11.1) repurposed `daemon/dist/` from JS+sourcemap output to the pkg binary output dir (`ccsm-daemon-${platform}-${arch}${ext}`). The Sentry symbol upload script kept pointing the daemon project at `daemon/dist/`, so post-#781 the daemon source-of-truth bundle and native debug-info were never uploaded — daemon stack traces would land in Sentry **unsymbolicated**.

This PR (Task #62, audit 3 F1) repoints daemon symbol upload at the actual post-pkg artifact layout:

- **JS sourcemaps**: upload from BOTH `daemon/dist-daemon-bundle/` (esbuild CJS that pkg ingests; runtime stack frames map back to this) AND `daemon/dist-daemon/` (raw tsc emit; safety net).
- **Native symbols**: NEW upload of `daemon/native/<platform>-<arch>/` to `SENTRY_PROJECT_DAEMON` so `.node` + `.pdb` / dSYM sidecars from the Node 22 ABI rebuild (better-sqlite3, node-pty, ccsm_native — winjob/pdeathsig/pipeAcl) symbolicate against the daemon project.
- `release.yml` step comment updated to document the post-pkg layout. **Per task scope: no other release.yml changes.** Task #64 (signing) and Task #65 (installer-size guards) untouched.

## Files

- `scripts/sentry-upload-symbols.cjs` — daemon dir + new daemon-side native dif loop.
- `tests/scripts/sentry-upload-symbols.test.ts` — assert both daemon sourcemap dirs upload + daemon-project native dif call exists.
- `.github/workflows/release.yml` — comment-only update on the `Upload symbols to Sentry` step.

## Reverse-verify (dev.md §2 phase 4)

```
$ git stash push scripts/sentry-upload-symbols.cjs   # remove fix only, keep test
$ vitest run tests/scripts/sentry-upload-symbols.test.ts
  → FAIL: expected projectsCalled.has('p-dae') to be true (received false)

$ git stash pop                                       # restore fix
$ vitest run tests/scripts/sentry-upload-symbols.test.ts
  → PASS: 3/3 (220ms)
```

## Test plan

- [x] `vitest run tests/scripts/sentry-upload-symbols.test.ts` → 3/3 pass
- [x] `npm run lint` → 0 errors (warnings unchanged)
- [x] `npm run typecheck` → clean (root + electron + daemon configs)
- [x] `release.yml` YAML parse → OK
- [x] Reverse-verify confirms test catches regression
- [ ] Manual smoke (post-merge): trigger `workflow_dispatch` release dry-run with `SENTRY_AUTH_TOKEN` set in fork; confirm `[sentry-upload-symbols] project=<daemon-project>` log lines reference `daemon/dist-daemon-bundle/`, `daemon/dist-daemon/`, and `daemon/native/<platform>-<arch>/` — and that a synthetic stack trace from inside the packaged daemon resolves to TS source in the Sentry UI.

## Spec / audit refs

- `docs/superpowers/specs/v0.3-fragments/frag-11-packaging.md` §11.1 (post-pkg artifact layout)
- Audit 3 F1 (daemon symbol upload broken after pkg)
- PR #781 (#45 — daemon binary build pipeline that introduced the layout change)