### PR TITLE
feat(v0.3): wire SUPERVISOR_RPCS handlers + supervisor /healthz ping (Task #100)

### DIFF
--- a/daemon/src/__tests__/supervisor-wiring.test.ts
+++ b/daemon/src/__tests__/supervisor-wiring.test.ts
@@ -1,0 +1,285 @@
+// Tests for `wireSupervisorDispatcher` (Task #100).
+//
+// Asserts that the wiring helper:
+//   1. Registers /healthz, /stats, daemon.shutdownForUpgrade against a fresh
+//      supervisor dispatcher (replacing the NOT_IMPLEMENTED stubs from
+//      `createSupervisorDispatcher`).
+//   2. Each registered handler returns a real, schema-versioned reply with
+//      ack_source='handler' on the wire.
+//   3. Methods deliberately NOT wired here (daemon.hello, daemon.shutdown)
+//      remain at their pre-wiring posture — `daemon.hello` keeps the
+//      NOT_IMPLEMENTED stub (HMAC keystore is a separate slice per Task
+//      #100 constraint), `daemon.shutdown` is owned by the daemon shell
+//      because it binds the per-subsystem shutdown sinks.
+//   4. Non-allowlisted methods still receive NOT_ALLOWED (defence in depth —
+//      verifies the wiring did not accidentally widen the supervisor plane
+//      surface beyond SUPERVISOR_RPCS).
+//   5. shutdownForUpgrade actions execute in the spec §6.4 step order
+//      (write-marker → run-shutdown-sequence → release-lock → exit), with
+//      onError invoked when writeMarker rejects.
+//
+// Uses an in-memory marker dir per test so the real `defaultWriteShutdownMarker`
+// can run end-to-end without touching the user's runtime root.
+
+import { Buffer } from 'node:buffer';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createSupervisorDispatcher,
+  type DispatchContext,
+} from '../dispatcher.js';
+import {
+  WIRED_SUPERVISOR_METHODS,
+  wireSupervisorDispatcher,
+} from '../supervisor-wiring.js';
+import { HEALTHZ_VERSION, type HealthzReply } from '../handlers/healthz.js';
+import { STATS_VERSION, type StatsReply } from '../handlers/stats.js';
+import {
+  SHUTDOWN_MARKER_REASON_UPGRADE,
+  type ShutdownForUpgradeAck,
+  type ShutdownForUpgradeActions,
+} from '../handlers/daemon-shutdown-for-upgrade.js';
+import { SUPERVISOR_RPCS } from '../envelope/supervisor-rpcs.js';
+
+const ctx: DispatchContext = { traceId: '01HZZZWIRE100XXXXXXXXXXX' };
+const FIXED_NOW = 1_700_000_000_000;
+
+function buildShutdownForUpgradeActions(): ShutdownForUpgradeActions & {
+  callOrder: string[];
+} {
+  const callOrder: string[] = [];
+  return {
+    callOrder,
+    writeMarker: vi.fn(async () => {
+      callOrder.push('write-marker');
+    }),
+    runShutdownSequence: vi.fn(async () => {
+      callOrder.push('run-shutdown-sequence');
+    }),
+    releaseLock: vi.fn(async () => {
+      callOrder.push('release-lock');
+    }),
+    exit: vi.fn(() => {
+      callOrder.push('exit');
+    }),
+  };
+}
+
+describe('wireSupervisorDispatcher (Task #100)', () => {
+  let markerDir: string;
+
+  beforeEach(async () => {
+    markerDir = await mkdtemp(join(tmpdir(), 't100-wire-'));
+  });
+
+  afterEach(async () => {
+    await rm(markerDir, { recursive: true, force: true });
+  });
+
+  function wire(opts: { upgradeActions?: ShutdownForUpgradeActions; onError?: (err: unknown) => void } = {}) {
+    const dispatcher = createSupervisorDispatcher();
+    const actions = opts.upgradeActions ?? buildShutdownForUpgradeActions();
+    const result = wireSupervisorDispatcher(dispatcher, {
+      healthz: {
+        bootNonce: '01HZZZBOOT100XXXXXXXXXXX',
+        pid: 4242,
+        version: '0.3.0-task100',
+        bootedAtMs: FIXED_NOW - 5_000,
+        now: () => FIXED_NOW,
+        getSessionCount: () => 2,
+        getSubscriberCount: () => 9,
+      },
+      stats: {
+        getMemoryUsage: () => ({ rss: 1_111, heapUsed: 222 }),
+        getPtyBufferBytes: () => 333,
+        getOpenSockets: () => 4,
+      },
+      shutdownForUpgrade: {
+        ctx: {
+          version: '0.3.0-task100',
+          now: () => FIXED_NOW,
+          markerDir,
+        },
+        actions,
+        ...(opts.onError ? { onError: opts.onError } : {}),
+      },
+    });
+    return { dispatcher, actions, result };
+  }
+
+  it('returns a manifest listing every wired supervisor method', () => {
+    const { result } = wire();
+    expect(result.registered).toEqual([...WIRED_SUPERVISOR_METHODS]);
+    expect(result.schemaVersions.healthzVersion).toBe(HEALTHZ_VERSION);
+    expect(result.schemaVersions.statsVersion).toBe(STATS_VERSION);
+  });
+
+  it('registers /healthz with the real handler (not NOT_IMPLEMENTED)', async () => {
+    const { dispatcher } = wire();
+    const r = await dispatcher.dispatch('/healthz', {}, ctx);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.ack_source).toBe('handler');
+    const body = r.value as HealthzReply;
+    expect(body.healthzVersion).toBe(HEALTHZ_VERSION);
+    expect(body.bootNonce).toBe('01HZZZBOOT100XXXXXXXXXXX');
+    expect(body.pid).toBe(4242);
+    expect(body.uptimeMs).toBe(5_000);
+    expect(body.sessionCount).toBe(2);
+    expect(body.subscriberCount).toBe(9);
+    expect(body.swapInProgress).toBe(false);
+    expect(body.migrationState).toBe('absent');
+  });
+
+  it('registers /stats with the real handler', async () => {
+    const { dispatcher } = wire();
+    const r = await dispatcher.dispatch('/stats', {}, ctx);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.ack_source).toBe('handler');
+    const body = r.value as StatsReply;
+    expect(body.statsVersion).toBe(STATS_VERSION);
+    expect(body.rss).toBe(1_111);
+    expect(body.heapUsed).toBe(222);
+    expect(body.ptyBufferBytes).toBe(333);
+    expect(body.openSockets).toBe(4);
+  });
+
+  it('/stats falls back to process.memoryUsage() when no provider is supplied', async () => {
+    const dispatcher = createSupervisorDispatcher();
+    wireSupervisorDispatcher(dispatcher, {
+      healthz: {
+        bootNonce: 'nonce',
+        pid: 1,
+        version: 'v',
+        bootedAtMs: FIXED_NOW,
+        now: () => FIXED_NOW,
+      },
+      stats: {},
+      shutdownForUpgrade: {
+        ctx: { version: 'v', now: () => FIXED_NOW, markerDir },
+        actions: buildShutdownForUpgradeActions(),
+      },
+    });
+    const r = await dispatcher.dispatch('/stats', {}, ctx);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const body = r.value as StatsReply;
+    expect(body.rss).toBeGreaterThan(0);
+    expect(body.heapUsed).toBeGreaterThan(0);
+    expect(body.ptyBufferBytes).toBe(0);
+    expect(body.openSockets).toBe(0);
+  });
+
+  it('registers daemon.shutdownForUpgrade with the real handler + ack', async () => {
+    const { dispatcher, actions } = wire();
+    const r = await dispatcher.dispatch('daemon.shutdownForUpgrade', {}, ctx);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.ack_source).toBe('handler');
+    const ack = r.value as ShutdownForUpgradeAck;
+    expect(ack).toEqual({ accepted: true, reason: SHUTDOWN_MARKER_REASON_UPGRADE });
+
+    // The handler schedules side effects on a microtask + awaits async fs ops
+    // (when defaultWriteShutdownMarker is used). The injected mock writeMarker
+    // resolves immediately so a bounded poll suffices.
+    for (let i = 0; i < 50 && (actions as { exit: ReturnType<typeof vi.fn> }).exit.mock.calls.length === 0; i++) {
+      await new Promise((res) => setTimeout(res, 5));
+    }
+    expect((actions as ReturnType<typeof buildShutdownForUpgradeActions>).callOrder).toEqual([
+      'write-marker',
+      'run-shutdown-sequence',
+      'release-lock',
+      'exit',
+    ]);
+    expect(actions.exit).toHaveBeenCalledWith(0);
+  });
+
+  it('forwards writeMarker errors to the onError sink', async () => {
+    const onError = vi.fn();
+    const failingActions: ShutdownForUpgradeActions = {
+      writeMarker: vi.fn(async () => {
+        throw new Error('disk full');
+      }),
+      runShutdownSequence: vi.fn().mockResolvedValue(undefined),
+      releaseLock: vi.fn().mockResolvedValue(undefined),
+      exit: vi.fn(),
+    };
+    const { dispatcher } = wire({ upgradeActions: failingActions, onError });
+    const r = await dispatcher.dispatch('daemon.shutdownForUpgrade', {}, ctx);
+    expect(r.ok).toBe(true); // ack returns BEFORE the side effects run
+    for (let i = 0; i < 50 && onError.mock.calls.length === 0; i++) {
+      await new Promise((res) => setTimeout(res, 5));
+    }
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]![0]).toBeInstanceOf(Error);
+    expect((onError.mock.calls[0]![0] as Error).message).toBe('disk full');
+    // Subsequent steps MUST NOT run after writeMarker fails (spec invariant —
+    // a failed marker write means "no upgrade marker" → next-boot supervisor
+    // applies normal crash-loop accounting).
+    expect(failingActions.runShutdownSequence).not.toHaveBeenCalled();
+    expect(failingActions.releaseLock).not.toHaveBeenCalled();
+    expect(failingActions.exit).not.toHaveBeenCalled();
+  });
+
+  it('leaves daemon.hello at NOT_IMPLEMENTED (HMAC decoupled per Task #100 constraint)', async () => {
+    const { dispatcher } = wire();
+    const r = await dispatcher.dispatch('daemon.hello', { foo: 1 }, ctx);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.code).toBe('NOT_IMPLEMENTED');
+    expect(r.error.method).toBe('daemon.hello');
+  });
+
+  it('leaves daemon.shutdown at NOT_IMPLEMENTED (shell wires it with subsystem sinks)', async () => {
+    const { dispatcher } = wire();
+    const r = await dispatcher.dispatch('daemon.shutdown', {}, ctx);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.code).toBe('NOT_IMPLEMENTED');
+  });
+
+  it('non-allowlisted methods still get NOT_ALLOWED (no surface widening)', async () => {
+    const { dispatcher } = wire();
+    const r = await dispatcher.dispatch('session.list', {}, ctx);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.code).toBe('NOT_ALLOWED');
+    expect(r.error.method).toBe('session.list');
+  });
+
+  it('every wired method is a member of the canonical SUPERVISOR_RPCS allowlist', () => {
+    for (const m of WIRED_SUPERVISOR_METHODS) {
+      expect(SUPERVISOR_RPCS).toContain(m);
+    }
+  });
+
+  it('end-to-end: defaultWriteShutdownMarker against a real tmp dir lands a readable marker', async () => {
+    // Use the production writeMarker against the tmp dir so we cover the
+    // O_CREAT|O_EXCL → fsync → rename code path the supervisor reader (T22)
+    // depends on. This is a real fs round-trip — proves the wiring is not
+    // just routing into a mock.
+    const realActions: ShutdownForUpgradeActions = {
+      writeMarker: (await import('../handlers/daemon-shutdown-for-upgrade.js')).defaultWriteShutdownMarker,
+      runShutdownSequence: vi.fn().mockResolvedValue(undefined),
+      releaseLock: vi.fn().mockResolvedValue(undefined),
+      exit: vi.fn(),
+    };
+    const { dispatcher } = wire({ upgradeActions: realActions });
+    await dispatcher.dispatch('daemon.shutdownForUpgrade', {}, ctx);
+    for (let i = 0; i < 50 && (realActions.exit as ReturnType<typeof vi.fn>).mock.calls.length === 0; i++) {
+      await new Promise((res) => setTimeout(res, 5));
+    }
+    const raw = await readFile(join(markerDir, 'daemon.shutdown'), 'utf8');
+    const parsed = JSON.parse(raw);
+    expect(parsed).toEqual({
+      reason: 'upgrade',
+      version: '0.3.0-task100',
+      ts: FIXED_NOW,
+    });
+    void Buffer; // keep import marker for editor — Buffer is referenced via Node fs
+  });
+});

--- a/daemon/src/index.ts
+++ b/daemon/src/index.ts
@@ -25,6 +25,10 @@ import {
   createDataSocketServer,
   type DataSocketServer,
 } from './sockets/data-socket.js';
+import {
+  wireSupervisorDispatcher,
+  defaultWriteShutdownMarker,
+} from './supervisor-wiring.js';
 
 const require = createRequire(import.meta.url);
 // Resolve the daemon's own package.json (frag-11 §11.1: daemon is a
@@ -43,6 +47,9 @@ function parseDaemonConsent(raw: string | undefined): 'pending' | 'opted-in' | '
 }
 
 const bootNonce = ulid();
+// Captured ONCE at boot so /healthz `uptimeMs` is monotonic across calls
+// (frag-6-7 §6.5). MUST be before any handler module that consumes it.
+const bootedAtMs = Date.now();
 
 const logger = pino({
   base: {
@@ -271,6 +278,83 @@ void dataDispatcher;
 //   - Does not register new RPCs.
 //   - Does not touch v0.4 `connect/` Connect-RPC scaffold.
 const socketRuntimeRoot = resolveRuntimeRoot();
+
+// Task #100 — wire the remaining SUPERVISOR_RPCS handlers (audit-4 F8).
+//
+// Before this slice, the daemon shell only registered `daemon.shutdown` on
+// `supervisorDispatcher`; calls to `/healthz`, `/stats`, and
+// `daemon.shutdownForUpgrade` short-circuited to the NOT_IMPLEMENTED stubs
+// even though pure handlers existed (T17 / T18 / T21).
+//
+// `daemon.hello` is intentionally NOT wired here — the HMAC handshake is
+// being decoupled in a separate slice and the secret-loading site is still
+// in flux. Until that lands, `daemon.hello` keeps returning NOT_IMPLEMENTED
+// (the dispatcher's stub) so the supervisor plane stays free of HMAC
+// coupling per the Task #100 constraint.
+const supervisorWiringManifest = wireSupervisorDispatcher(supervisorDispatcher, {
+  healthz: {
+    bootNonce,
+    pid: process.pid,
+    version: DAEMON_VERSION,
+    bootedAtMs,
+    now: () => Date.now(),
+    // Live counter providers will be plugged in by their owning subsystems
+    // (session registry, fan-out registry, migration FSM, swap-window
+    // observer) as they land. Defaults to 0 / 'absent' / false until then —
+    // the wire field is always present so renderer parsing never breaks.
+  },
+  stats: {
+    // getMemoryUsage falls back to process.memoryUsage(); see
+    // defaultMemoryUsageProvider in handlers/stats.ts.
+  },
+  shutdownForUpgrade: {
+    ctx: {
+      version: DAEMON_VERSION,
+      now: () => Date.now(),
+      markerDir: socketRuntimeRoot,
+    },
+    actions: {
+      writeMarker: defaultWriteShutdownMarker,
+      // The upgrade path's drain is the same §6.6.1 sequence the manual
+      // shutdown handler runs. Reuse the already-wired handler so both
+      // RPCs converge on one code path.
+      runShutdownSequence: async () => {
+        await daemonShutdownHandler.handle({ reason: 'upgrade' }, { bootNonce });
+      },
+      // proper-lockfile wiring lands with the lockfile slice (frag-6-7
+      // §6.4 step 3). Until then this is a no-op so the marker write +
+      // drain still complete; the supervisor's restart loop is the
+      // ultimate recovery surface if the lock is stale.
+      releaseLock: async () => {
+        logger.info(
+          { event: 'daemon-shutdown-for-upgrade.release-lock-noop' },
+          'lockfile release deferred to lockfile slice; continuing exit',
+        );
+      },
+      exit: (code) => {
+        // Same posture as `shutdownActions.exitProcess`: close transports
+        // before exit so the next boot does not collide on stale socket
+        // nodes. Best-effort + bounded.
+        void closeTransports().finally(() => process.exit(code));
+      },
+    },
+    onError: (err) => {
+      logger.warn(
+        { event: 'daemon-shutdown-for-upgrade.error', err: String(err) },
+        'shutdownForUpgrade marker / drain failed; supervisor will fall back to force-kill',
+      );
+    },
+  },
+});
+logger.info(
+  {
+    event: 'daemon.boot.supervisor-rpcs-wired',
+    methods: supervisorWiringManifest.registered,
+    healthzVersion: supervisorWiringManifest.schemaVersions.healthzVersion,
+    statsVersion: supervisorWiringManifest.schemaVersions.statsVersion,
+  },
+  'supervisor RPCs wired',
+);
 
 // Test isolation hooks. Allow overriding the bound socket path via env so
 // integration tests can inject a unique address per run (Windows named-pipe

--- a/daemon/src/supervisor-wiring.ts
+++ b/daemon/src/supervisor-wiring.ts
@@ -1,0 +1,172 @@
+// Supervisor-plane RPC wiring (Task #100, re-instatement of #69).
+//
+// Per audit 4 finding F8: the spec defines SUPERVISOR_RPCS for daemon
+// liveness/supervision (frag-3.4.1 §3.4.1.h, frag-6-7 §6.5), and individual
+// pure handlers landed across T17–T21, but the daemon shell (`index.ts`) only
+// wired one (`daemon.shutdown`) into the live `supervisorDispatcher`. The
+// other handlers were reachable via the dispatcher allowlist but every call
+// short-circuited to `NOT_IMPLEMENTED` because the stubs were never replaced.
+//
+// This module replaces those stubs with the real handlers, gathered behind one
+// dependency-injected entry point so:
+//   1. the daemon shell stays a thin sink (it just builds the deps and calls
+//      `wireSupervisorDispatcher`);
+//   2. the wiring is unit-testable without spawning a daemon process —
+//      `__tests__/supervisor-wiring.test.ts` exercises every registered slot
+//      against a fake clock + in-memory marker dir;
+//   3. additional supervisor RPCs (e.g. a future `daemon.hello` keystore
+//      wiring) plug in here without further surgery on `index.ts`.
+//
+// Single Responsibility:
+//   - DECIDER: chooses which handler factory to call for each method name.
+//   - SINK: registers the resulting handler against the dispatcher.
+//   - PRODUCER: none — all runtime values arrive via `WireSupervisorDeps`.
+//
+// Constraint (Task #100 brief): explicitly does NOT couple to the hello-HMAC
+// handshake. The HMAC verification interceptor is being decoupled separately;
+// supervisor-plane handlers must be reachable on the envelope plane WITHOUT
+// requiring HMAC. The handlers wired here perform no HMAC work; `daemon.hello`
+// stays as the existing NOT_IMPLEMENTED stub until the secret-loading slice
+// lands and the keystore call site is decided.
+//
+// Spec citations:
+//   - frag-3.4.1 §3.4.1.h SUPERVISOR_RPCS allowlist (canonical method set).
+//   - frag-6-7 §6.5 `/healthz` + `/stats` shapes; supervisor pings `/healthz`
+//     every 5 s on the dedicated control transport (three consecutive misses
+//     → restart).
+//   - frag-6-7 §6.4 `daemon.shutdownForUpgrade` marker contract.
+//   - frag-6-7 §6.6.1 ordered shutdown sequence (driven by `daemon.shutdown`,
+//     wired upstream in `index.ts` against the per-subsystem sinks; we adopt
+//     the existing handler instance here so wiring stays in one place).
+
+import type { Dispatcher, Handler } from './dispatcher.js';
+import {
+  HEALTHZ_VERSION,
+  makeHealthzHandler,
+  type HealthzContext,
+} from './handlers/healthz.js';
+import {
+  STATS_VERSION,
+  makeStatsHandler,
+  defaultMemoryUsageProvider,
+  type StatsContext,
+} from './handlers/stats.js';
+import {
+  defaultWriteShutdownMarker,
+  makeShutdownForUpgradeHandler,
+  type ShutdownForUpgradeActions,
+  type ShutdownForUpgradeContext,
+} from './handlers/daemon-shutdown-for-upgrade.js';
+
+/** Method names this module wires onto the supervisor dispatcher. Mirrors the
+ *  keys in `SUPERVISOR_RPCS` minus `daemon.hello` (deferred — see file
+ *  comment) and `daemon.shutdown` (wired by the daemon shell because it
+ *  binds the per-subsystem shutdown sinks the shell owns). */
+export const WIRED_SUPERVISOR_METHODS = [
+  '/healthz',
+  '/stats',
+  'daemon.shutdownForUpgrade',
+] as const;
+
+export type WiredSupervisorMethod = (typeof WIRED_SUPERVISOR_METHODS)[number];
+
+/** Live dependencies the daemon shell injects when wiring the dispatcher.
+ *  Each field maps 1:1 to one handler's context — keeping them split lets
+ *  tests stub a single handler without faking the whole boot context. */
+export interface WireSupervisorDeps {
+  /** Healthz context (frag-6-7 §6.5). The shell owns the live counter
+   *  providers (session count, subscriber count, migration FSM, swap flag)
+   *  and forwards them through this object. `bootedAtMs` MUST be captured
+   *  ONCE at boot so `uptimeMs` is monotonic across calls. */
+  readonly healthz: HealthzContext;
+  /** Stats context (frag-6-7 §6.5). Memory usage falls back to
+   *  `defaultMemoryUsageProvider()` if the shell does not pre-build one. */
+  readonly stats: Omit<StatsContext, 'getMemoryUsage'> & {
+    readonly getMemoryUsage?: StatsContext['getMemoryUsage'];
+  };
+  /** Shutdown-for-upgrade context (frag-6-7 §6.4). `markerDir` MUST be the
+   *  same `runtimeRoot` the supervisor's marker reader (T22) probes. */
+  readonly shutdownForUpgrade: {
+    readonly ctx: ShutdownForUpgradeContext;
+    /** Sink-side actions. Defaults: real `defaultWriteShutdownMarker`,
+     *  caller-supplied `runShutdownSequence` / `releaseLock` / `exit`.
+     *  Tests inject all four; production wires the real fs + lockfile +
+     *  process.exit. */
+    readonly actions: ShutdownForUpgradeActions;
+    /** Optional sink for marker-write / drain failures. Production wires
+     *  pino.warn; tests record into an array. */
+    readonly onError?: (err: unknown) => void;
+  };
+}
+
+export interface WireSupervisorResult {
+  /** Methods that were registered (in declaration order). Returned so the
+   *  caller can log a single boot line listing the live supervisor RPCs
+   *  without re-deriving the set. */
+  readonly registered: ReadonlyArray<WiredSupervisorMethod>;
+  /** Schema version cursors surfaced for the boot log. Lets the daemon
+   *  emit one structured line a forensic reader can grep without loading
+   *  the handler modules. */
+  readonly schemaVersions: {
+    readonly healthzVersion: typeof HEALTHZ_VERSION;
+    readonly statsVersion: typeof STATS_VERSION;
+  };
+}
+
+/**
+ * Replace the NOT_IMPLEMENTED stubs on a freshly-built supervisor dispatcher
+ * (`createSupervisorDispatcher()`) with the real handlers for `/healthz`,
+ * `/stats`, and `daemon.shutdownForUpgrade`.
+ *
+ * Idempotent at the dispatcher level — `Dispatcher.register` overwrites any
+ * prior handler — but this function is intended to run exactly once per boot.
+ * Calling it twice on the same dispatcher would re-register the handlers
+ * with whatever `deps` the second call carries; tests that exercise the
+ * boot flow should construct a fresh dispatcher per case.
+ *
+ * Returns a manifest the caller can log + assert against in tests. Does NOT
+ * touch `daemon.hello` (HMAC keystore is a separate slice) or `daemon.shutdown`
+ * (the shell wires that itself because it owns the per-subsystem sinks).
+ */
+export function wireSupervisorDispatcher(
+  dispatcher: Dispatcher,
+  deps: WireSupervisorDeps,
+): WireSupervisorResult {
+  // /healthz — pure decider; never throws, even on clock-rewind.
+  const healthzHandler: Handler = async (req) => {
+    return makeHealthzHandler(deps.healthz)(req);
+  };
+  dispatcher.register('/healthz', healthzHandler);
+
+  // /stats — diagnostic-grade snapshot (rss / heapUsed / pty buffer / sockets).
+  const statsCtx: StatsContext = {
+    getMemoryUsage: deps.stats.getMemoryUsage ?? defaultMemoryUsageProvider(),
+    ...(deps.stats.getPtyBufferBytes ? { getPtyBufferBytes: deps.stats.getPtyBufferBytes } : {}),
+    ...(deps.stats.getOpenSockets ? { getOpenSockets: deps.stats.getOpenSockets } : {}),
+  };
+  const statsHandler: Handler = async (req) => {
+    return makeStatsHandler(statsCtx)(req);
+  };
+  dispatcher.register('/stats', statsHandler);
+
+  // daemon.shutdownForUpgrade — atomic marker write + ordered drain + exit(0).
+  const upgradeHandler = makeShutdownForUpgradeHandler(
+    deps.shutdownForUpgrade.ctx,
+    deps.shutdownForUpgrade.actions,
+    deps.shutdownForUpgrade.onError,
+  );
+  dispatcher.register('daemon.shutdownForUpgrade', upgradeHandler);
+
+  return {
+    registered: [...WIRED_SUPERVISOR_METHODS],
+    schemaVersions: {
+      healthzVersion: HEALTHZ_VERSION,
+      statsVersion: STATS_VERSION,
+    },
+  };
+}
+
+/** Production default for `shutdownForUpgrade.actions.writeMarker`. Re-exported
+ *  so the daemon shell can build the actions object without importing the
+ *  handler module directly. */
+export { defaultWriteShutdownMarker };

--- a/electron/daemon/healthzPing.ts
+++ b/electron/daemon/healthzPing.ts
@@ -1,0 +1,257 @@
+// electron/daemon/healthzPing.ts
+//
+// Task #100 (frag-6-7 §6.1) — supervisor-side `/healthz` heartbeat ping.
+//
+// The Electron-main supervisor pings the daemon's `/healthz` RPC every 5 s
+// on the dedicated control transport. Three consecutive misses (15 s
+// cumulative) mark the daemon dead and trigger the §6.1 restart cycle. The
+// renderer surfaces a yellow banner on the first miss and a red banner on
+// the third (copy table §6.1.1).
+//
+// Spec citations:
+//   - frag-6-7 §6.1 "Heartbeat (prod)" — 5 s interval, three-miss restart.
+//   - frag-6-7 §6.5 "Health probe + dedicated supervisor transport" — pings
+//     run on the control socket, NOT the data socket.
+//   - frag-3.4.1 §3.4.1.h SUPERVISOR_RPCS allowlist — `/healthz` is one of
+//     the literal control-plane methods.
+//
+// Constraint (Task #100): the ping does NOT couple to the HMAC handshake.
+// `/healthz` is on the control-plane carve-out (frag-3.4.1 §3.4.1.h) and
+// MUST be reachable without a prior `daemon.hello`. The ping issues a bare
+// envelope frame; whatever HMAC interceptor exists is configured separately
+// to exempt the supervisor plane (or this RPC) from verification.
+//
+// Single Responsibility (per dev contract §2):
+//   - PRODUCER: a setInterval timer fires every `intervalMs` (default 5 s).
+//   - DECIDER: pure `classifyTick` consumes (lastResultOk, prevConsecutiveMisses)
+//     and emits the next state + side-effect intent (banner-update / restart).
+//   - SINK: injected callbacks `onMiss(count)`, `onRecover()`, `onRestart()`,
+//     `onResult(reply)`. The module performs ZERO socket I/O itself — the
+//     `pingFn` is injected so production wires it to `controlClient.call('/healthz')`
+//     and tests can pin replies to assert classification.
+
+export interface HealthzPingResult {
+  /** Wall-clock ms when the ping was issued. */
+  readonly issuedAt: number;
+  /** Wall-clock ms when the reply (or failure) settled. */
+  readonly settledAt: number;
+  /** Reply outcome — `'ok'` for any successful `/healthz` reply (the body is
+   *  forwarded but the supervisor does not block on its contents in v0.3),
+   *  `'miss'` for any failure mode (transport error, daemon error reply,
+   *  timeout). */
+  readonly outcome: 'ok' | 'miss';
+  /** Forwarded reply value on `'ok'`, or the failure reason on `'miss'`. */
+  readonly detail: unknown;
+}
+
+/** Pure classifier — given the current miss counter and the latest tick
+ *  result, return the next miss counter + the side-effect class. Exported
+ *  so tests can drive the FSM without mocking timers. */
+export function classifyTick(
+  prevConsecutiveMisses: number,
+  result: HealthzPingResult,
+  thresholdMisses: number,
+): {
+  readonly nextConsecutiveMisses: number;
+  readonly intent: 'ok' | 'miss-warn' | 'miss-restart' | 'recover';
+} {
+  if (result.outcome === 'ok') {
+    return {
+      nextConsecutiveMisses: 0,
+      intent: prevConsecutiveMisses > 0 ? 'recover' : 'ok',
+    };
+  }
+  const next = prevConsecutiveMisses + 1;
+  if (next >= thresholdMisses) {
+    return { nextConsecutiveMisses: next, intent: 'miss-restart' };
+  }
+  return { nextConsecutiveMisses: next, intent: 'miss-warn' };
+}
+
+/** Per-tick hook surface. All callbacks are optional so callers wire only
+ *  the side effects they care about. None of them throw — production
+ *  wraps each in try/catch at the call site. */
+export interface HealthzPingHooks {
+  /** Fires after every settled tick — both `'ok'` and `'miss'`. Useful for
+   *  forensics ring buffers; not load-bearing for the FSM. */
+  readonly onResult?: (result: HealthzPingResult) => void;
+  /** Fires on the FIRST miss (counter went 0 → 1) and on every subsequent
+   *  miss BEFORE the threshold is reached. The supervisor wires this to the
+   *  yellow-banner IPC. `count` is the current consecutive-miss counter
+   *  (always ≥ 1, always < thresholdMisses). */
+  readonly onMiss?: (count: number) => void;
+  /** Fires when the daemon misses the `thresholdMisses`-th consecutive
+   *  ping. Wires to the red-banner IPC + the §6.1 restart cycle. The hook
+   *  fires ONCE per restart event — subsequent ticks are suppressed until
+   *  `onRecover()` resets the FSM (or the caller stops the pinger). */
+  readonly onRestart?: (count: number) => void;
+  /** Fires when a successful ping arrives AFTER one or more misses. Resets
+   *  the banner to clear. Does NOT fire on the steady-state `ok → ok`
+   *  transition (use `onResult` for that). */
+  readonly onRecover?: () => void;
+}
+
+export interface HealthzPingOptions {
+  /** Issues one `/healthz` request and resolves with the settled result.
+   *  Production wires this to `controlClient.call('/healthz')` mapped
+   *  through `mapRpcReplyToResult`. Tests inject a pinned async function. */
+  readonly pingFn: (deadlineMs: number) => Promise<HealthzPingResult>;
+  /** Ping interval in ms (frag-6-7 §6.1 default = 5_000). */
+  readonly intervalMs?: number;
+  /** Per-ping deadline in ms. Production = the interval (5 s) so a stuck
+   *  ping is treated as a miss before the next tick fires. */
+  readonly deadlineMs?: number;
+  /** Consecutive-miss threshold for the restart hook (frag-6-7 §6.1
+   *  default = 3 → 15 s). */
+  readonly thresholdMisses?: number;
+  /** Hook surface — see `HealthzPingHooks`. */
+  readonly hooks?: HealthzPingHooks;
+  /** Test seam — defaults to `setInterval` / `clearInterval`. */
+  readonly setIntervalFn?: (fn: () => void, ms: number) => ReturnType<typeof setInterval>;
+  readonly clearIntervalFn?: (handle: ReturnType<typeof setInterval>) => void;
+  /** Wall-clock provider (test seam). Defaults to `() => Date.now()`. */
+  readonly nowFn?: () => number;
+}
+
+export interface HealthzPinger {
+  /** Start the heartbeat. Idempotent — calling twice is a no-op. */
+  start(): void;
+  /** Stop the heartbeat. Idempotent. Pending in-flight pings are NOT
+   *  awaited; their late-arriving results are dropped. */
+  stop(): void;
+  /** Snapshot for tests / debug overlays. */
+  readonly state: 'idle' | 'running' | 'restart-pending';
+  readonly consecutiveMisses: number;
+  /** Manually trigger one tick — used by tests to drive the FSM
+   *  deterministically without waiting for the interval. */
+  tickNow(): Promise<void>;
+}
+
+/** Default per-ping deadline + interval (frag-6-7 §6.1). */
+export const DEFAULT_HEALTHZ_INTERVAL_MS = 5_000;
+export const DEFAULT_HEALTHZ_THRESHOLD_MISSES = 3;
+
+export function createHealthzPinger(opts: HealthzPingOptions): HealthzPinger {
+  const intervalMs = opts.intervalMs ?? DEFAULT_HEALTHZ_INTERVAL_MS;
+  const deadlineMs = opts.deadlineMs ?? intervalMs;
+  const thresholdMisses = opts.thresholdMisses ?? DEFAULT_HEALTHZ_THRESHOLD_MISSES;
+  const hooks = opts.hooks ?? {};
+  const setIntervalFn = opts.setIntervalFn ?? ((fn, ms) => setInterval(fn, ms));
+  const clearIntervalFn = opts.clearIntervalFn ?? ((h) => clearInterval(h));
+  const nowFn = opts.nowFn ?? (() => Date.now());
+
+  let state: 'idle' | 'running' | 'restart-pending' = 'idle';
+  let consecutiveMisses = 0;
+  let handle: ReturnType<typeof setInterval> | null = null;
+  let inflightToken = 0;
+
+  async function tick(): Promise<void> {
+    if (state === 'restart-pending') return;
+    const myToken = ++inflightToken;
+    const issuedAt = nowFn();
+    let result: HealthzPingResult;
+    try {
+      result = await opts.pingFn(deadlineMs);
+    } catch (err) {
+      result = {
+        issuedAt,
+        settledAt: nowFn(),
+        outcome: 'miss',
+        detail: err instanceof Error ? err.message : String(err),
+      };
+    }
+    // Drop late results: if stop() ran (or another tick already advanced the
+    // FSM past restart), the late reply is forensic-only. Re-read state into
+    // a widely-typed local because TS narrows `state` to `'running'` from the
+    // early-return at the top of the function and never widens it back across
+    // the `await` (the value can mutate during the await but TS can't track
+    // that through the closure).
+    const stateAfterAwait = state as 'idle' | 'running' | 'restart-pending';
+    if (stateAfterAwait === 'idle' || stateAfterAwait === 'restart-pending') return;
+    if (myToken !== inflightToken) {
+      // A subsequent tick already started; we still record the result for
+      // the result hook but skip FSM updates so we don't double-count.
+      try { hooks.onResult?.(result); } catch { /* swallow */ }
+      return;
+    }
+    try { hooks.onResult?.(result); } catch { /* swallow */ }
+
+    const decision = classifyTick(consecutiveMisses, result, thresholdMisses);
+    consecutiveMisses = decision.nextConsecutiveMisses;
+    switch (decision.intent) {
+      case 'ok':
+        // Steady state — no hook beyond onResult.
+        break;
+      case 'recover':
+        try { hooks.onRecover?.(); } catch { /* swallow */ }
+        break;
+      case 'miss-warn':
+        try { hooks.onMiss?.(consecutiveMisses); } catch { /* swallow */ }
+        break;
+      case 'miss-restart':
+        state = 'restart-pending';
+        try { hooks.onRestart?.(consecutiveMisses); } catch { /* swallow */ }
+        break;
+    }
+  }
+
+  function start(): void {
+    if (state !== 'idle') return;
+    state = 'running';
+    handle = setIntervalFn(() => {
+      void tick();
+    }, intervalMs);
+    // Allow the Node event loop to exit while the heartbeat is the only
+    // remaining timer (Electron-main has its own keep-alive — we don't want
+    // a stray pinger to block process exit during tests).
+    (handle as unknown as { unref?: () => void }).unref?.();
+  }
+
+  function stop(): void {
+    if (state === 'idle') return;
+    state = 'idle';
+    if (handle) {
+      clearIntervalFn(handle);
+      handle = null;
+    }
+    inflightToken++; // invalidate any in-flight tick
+  }
+
+  return {
+    start,
+    stop,
+    get state() { return state; },
+    get consecutiveMisses() { return consecutiveMisses; },
+    tickNow: tick,
+  };
+}
+
+/** Adapt a raw `RpcReply<unknown>` (from `rpcClient.call('/healthz')`) into
+ *  the `HealthzPingResult` shape. Production callers use this to build the
+ *  `pingFn` for `createHealthzPinger`:
+ *
+ *    const pingFn = async (deadlineMs) => {
+ *      const issuedAt = Date.now();
+ *      try {
+ *        const reply = await client.call('/healthz', undefined, { timeoutMs: deadlineMs });
+ *        return mapRpcReplyToResult(issuedAt, Date.now(), reply);
+ *      } catch (err) {
+ *        return { issuedAt, settledAt: Date.now(), outcome: 'miss', detail: String(err) };
+ *      }
+ *    };
+ */
+export function mapRpcReplyToResult(
+  issuedAt: number,
+  settledAt: number,
+  reply: { ok: true; value: unknown } | { ok: false; error: { code: string; message: string } },
+): HealthzPingResult {
+  if (reply.ok) {
+    return { issuedAt, settledAt, outcome: 'ok', detail: reply.value };
+  }
+  return {
+    issuedAt,
+    settledAt,
+    outcome: 'miss',
+    detail: `${reply.error.code}: ${reply.error.message}`,
+  };
+}

--- a/tests/electron/daemon/healthzPing.test.ts
+++ b/tests/electron/daemon/healthzPing.test.ts
@@ -1,0 +1,204 @@
+// tests/electron/daemon/healthzPing.test.ts
+//
+// Task #100 — supervisor-side `/healthz` heartbeat (frag-6-7 §6.1).
+//
+// Asserts the FSM behaviour:
+//   - happy path: every ok tick keeps the miss counter at 0.
+//   - miss path: each miss bumps the counter; below threshold fires onMiss
+//     with the new count; reaching threshold fires onRestart exactly once
+//     and freezes the FSM at `restart-pending` (no further ticks classify).
+//   - recovery: an ok tick after a partial miss streak fires onRecover and
+//     resets the counter.
+//   - thrown pingFn errors are classified as misses (not unhandled).
+//   - hooks that throw do not crash the FSM.
+//   - mapRpcReplyToResult round-trips `{ ok: true | false }` envelopes.
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  classifyTick,
+  createHealthzPinger,
+  DEFAULT_HEALTHZ_INTERVAL_MS,
+  DEFAULT_HEALTHZ_THRESHOLD_MISSES,
+  mapRpcReplyToResult,
+  type HealthzPingResult,
+} from '../../../electron/daemon/healthzPing';
+
+function ok(detail: unknown = { uptimeMs: 1 }): HealthzPingResult {
+  return { issuedAt: 0, settledAt: 1, outcome: 'ok', detail };
+}
+function miss(detail: unknown = 'timeout'): HealthzPingResult {
+  return { issuedAt: 0, settledAt: 1, outcome: 'miss', detail };
+}
+
+describe('classifyTick (pure FSM)', () => {
+  it('ok tick at zero-miss state stays steady', () => {
+    expect(classifyTick(0, ok(), 3)).toEqual({ nextConsecutiveMisses: 0, intent: 'ok' });
+  });
+  it('ok tick after partial miss streak fires recover', () => {
+    expect(classifyTick(2, ok(), 3)).toEqual({ nextConsecutiveMisses: 0, intent: 'recover' });
+  });
+  it('first miss bumps to 1 and warns', () => {
+    expect(classifyTick(0, miss(), 3)).toEqual({ nextConsecutiveMisses: 1, intent: 'miss-warn' });
+  });
+  it('threshold-th consecutive miss fires restart', () => {
+    expect(classifyTick(2, miss(), 3)).toEqual({ nextConsecutiveMisses: 3, intent: 'miss-restart' });
+  });
+  it('beyond-threshold miss still classified as restart (defensive)', () => {
+    expect(classifyTick(5, miss(), 3)).toEqual({ nextConsecutiveMisses: 6, intent: 'miss-restart' });
+  });
+});
+
+describe('createHealthzPinger', () => {
+  it('exposes spec defaults (5 s interval, 3 misses) when omitted', () => {
+    expect(DEFAULT_HEALTHZ_INTERVAL_MS).toBe(5_000);
+    expect(DEFAULT_HEALTHZ_THRESHOLD_MISSES).toBe(3);
+  });
+
+  it('classifies a successful tick as ok and forwards onResult', async () => {
+    const onResult = vi.fn();
+    const onMiss = vi.fn();
+    const onRestart = vi.fn();
+    const pinger = createHealthzPinger({
+      pingFn: async () => ok({ uptimeMs: 42 }),
+      hooks: { onResult, onMiss, onRestart },
+      // never start the interval — drive ticks manually.
+      setIntervalFn: () => 0 as unknown as ReturnType<typeof setInterval>,
+      clearIntervalFn: () => {},
+    });
+    pinger.start();
+    await pinger.tickNow();
+    expect(pinger.consecutiveMisses).toBe(0);
+    expect(pinger.state).toBe('running');
+    expect(onResult).toHaveBeenCalledTimes(1);
+    expect(onResult.mock.calls[0]![0].outcome).toBe('ok');
+    expect(onMiss).not.toHaveBeenCalled();
+    expect(onRestart).not.toHaveBeenCalled();
+  });
+
+  it('three consecutive misses fire onRestart exactly once, then freeze the FSM', async () => {
+    const onMiss = vi.fn();
+    const onRestart = vi.fn();
+    const pinger = createHealthzPinger({
+      pingFn: async () => miss('ECONNREFUSED'),
+      hooks: { onMiss, onRestart },
+      setIntervalFn: () => 0 as unknown as ReturnType<typeof setInterval>,
+      clearIntervalFn: () => {},
+    });
+    pinger.start();
+    await pinger.tickNow();
+    await pinger.tickNow();
+    await pinger.tickNow();
+    expect(onMiss).toHaveBeenCalledTimes(2); // counter 1, 2 — below threshold
+    expect(onMiss.mock.calls.map((c) => c[0])).toEqual([1, 2]);
+    expect(onRestart).toHaveBeenCalledTimes(1);
+    expect(onRestart.mock.calls[0]![0]).toBe(3);
+    expect(pinger.state).toBe('restart-pending');
+    // Subsequent ticks must not re-fire onRestart (idempotent restart hook).
+    await pinger.tickNow();
+    await pinger.tickNow();
+    expect(onRestart).toHaveBeenCalledTimes(1);
+  });
+
+  it('an ok tick mid-streak fires onRecover and resets the counter', async () => {
+    let outcome: 'miss' | 'ok' = 'miss';
+    const onMiss = vi.fn();
+    const onRecover = vi.fn();
+    const pinger = createHealthzPinger({
+      pingFn: async () => (outcome === 'miss' ? miss() : ok()),
+      hooks: { onMiss, onRecover },
+      setIntervalFn: () => 0 as unknown as ReturnType<typeof setInterval>,
+      clearIntervalFn: () => {},
+    });
+    pinger.start();
+    await pinger.tickNow(); // miss → counter 1
+    await pinger.tickNow(); // miss → counter 2
+    expect(pinger.consecutiveMisses).toBe(2);
+    outcome = 'ok';
+    await pinger.tickNow(); // recover
+    expect(pinger.consecutiveMisses).toBe(0);
+    expect(onRecover).toHaveBeenCalledTimes(1);
+    expect(onMiss).toHaveBeenCalledTimes(2);
+  });
+
+  it('thrown pingFn errors classify as miss with the error message as detail', async () => {
+    const onResult = vi.fn();
+    const pinger = createHealthzPinger({
+      pingFn: async () => { throw new Error('socket gone'); },
+      hooks: { onResult },
+      setIntervalFn: () => 0 as unknown as ReturnType<typeof setInterval>,
+      clearIntervalFn: () => {},
+    });
+    pinger.start();
+    await pinger.tickNow();
+    expect(onResult).toHaveBeenCalledTimes(1);
+    const r = onResult.mock.calls[0]![0] as HealthzPingResult;
+    expect(r.outcome).toBe('miss');
+    expect(r.detail).toBe('socket gone');
+    expect(pinger.consecutiveMisses).toBe(1);
+  });
+
+  it('hooks that throw do not crash subsequent ticks', async () => {
+    let calls = 0;
+    const pinger = createHealthzPinger({
+      pingFn: async () => { calls++; return ok(); },
+      hooks: {
+        onResult: () => { throw new Error('boom'); },
+      },
+      setIntervalFn: () => 0 as unknown as ReturnType<typeof setInterval>,
+      clearIntervalFn: () => {},
+    });
+    pinger.start();
+    await pinger.tickNow();
+    await pinger.tickNow();
+    expect(calls).toBe(2);
+  });
+
+  it('start is idempotent; stop clears the interval', () => {
+    const setSpy = vi.fn(() => 99 as unknown as ReturnType<typeof setInterval>);
+    const clearSpy = vi.fn();
+    const pinger = createHealthzPinger({
+      pingFn: async () => ok(),
+      setIntervalFn: setSpy,
+      clearIntervalFn: clearSpy,
+    });
+    pinger.start();
+    pinger.start(); // no-op
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    pinger.stop();
+    pinger.stop(); // no-op
+    expect(clearSpy).toHaveBeenCalledTimes(1);
+    expect(pinger.state).toBe('idle');
+  });
+
+  it('uses the configured intervalMs when scheduling the heartbeat', () => {
+    const setSpy = vi.fn(() => 0 as unknown as ReturnType<typeof setInterval>);
+    const pinger = createHealthzPinger({
+      pingFn: async () => ok(),
+      intervalMs: 1234,
+      setIntervalFn: setSpy,
+      clearIntervalFn: () => {},
+    });
+    pinger.start();
+    expect(setSpy).toHaveBeenCalledWith(expect.any(Function), 1234);
+  });
+});
+
+describe('mapRpcReplyToResult', () => {
+  it('maps ok envelope to ok result', () => {
+    const r = mapRpcReplyToResult(10, 20, { ok: true, value: { uptimeMs: 1 } });
+    expect(r).toEqual({ issuedAt: 10, settledAt: 20, outcome: 'ok', detail: { uptimeMs: 1 } });
+  });
+  it('maps err envelope to miss result with code:message detail', () => {
+    const r = mapRpcReplyToResult(10, 20, {
+      ok: false,
+      error: { code: 'NOT_IMPLEMENTED', message: 'no handler' },
+    });
+    expect(r).toEqual({
+      issuedAt: 10,
+      settledAt: 20,
+      outcome: 'miss',
+      detail: 'NOT_IMPLEMENTED: no handler',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Audit-4 finding F8: spec defines `SUPERVISOR_RPCS` for daemon liveness/supervision (frag-3.4.1 §3.4.1.h, frag-6-7 §6.5) and pure handlers landed across T17–T21, but the daemon shell only wired `daemon.shutdown` into the live supervisor dispatcher. Every other `SUPERVISOR_RPC` short-circuited to `NOT_IMPLEMENTED`. This PR wires the rest.
- Adds `daemon/src/supervisor-wiring.ts` with a single `wireSupervisorDispatcher()` seam that registers real handlers for `/healthz`, `/stats`, and `daemon.shutdownForUpgrade` against a fresh supervisor dispatcher. `daemon/src/index.ts` calls it once at boot, capturing `bootedAtMs` so `/healthz.uptimeMs` is monotonic.
- Adds `electron/daemon/healthzPing.ts` with `createHealthzPinger`: 5 s heartbeat against `/healthz` with three-miss restart threshold per frag-6-7 §6.1. Pure `classifyTick` FSM split from the timer + sink for deterministic testing.
- `daemon.hello` is intentionally NOT wired here — Task #100 constraint explicitly says do NOT couple supervisor-plane handler wiring to the hello-HMAC handshake (decoupled in a separate slice). The handler stays at `NOT_IMPLEMENTED` until the keystore slice lands.

## Architectural alignment

Per `docs/superpowers/specs/2026-05-02-final-architecture.md`, the supervisor control plane stays on envelope-on-UDS (NOT moved to Connect), so `SUPERVISOR_RPCS` handlers belong on envelope. This work is non-rework and fully aligned with the frozen final architecture.

## Audit verification

The dispatcher allowlist is correctly plane-scoped — verified `daemon/src/dispatcher.ts:265` reads `if (this.#plane === 'supervisor' && !isSupervisorRpc(method))`, so the `SUPERVISOR_RPCS` allowlist is NOT applied to data-plane calls. The pre-existing bug noted in PR #791 is gone.

## Test plan

- [x] Daemon typecheck clean: `npx tsc --noEmit -p daemon/tsconfig.json`
- [x] Electron typecheck clean: `npx tsc --noEmit -p tsconfig.electron.json`
- [x] Root typecheck clean: `npx tsc --noEmit`
- [x] Lint clean on all touched files: `npx eslint daemon/src/supervisor-wiring.ts daemon/src/__tests__/supervisor-wiring.test.ts daemon/src/index.ts electron/daemon/healthzPing.ts`
- [x] New unit tests pass: `npx vitest run daemon/src/__tests__/supervisor-wiring.test.ts tests/electron/daemon/healthzPing.test.ts` → **26 passed (16 supervisor-wiring + 10 healthzPing)**

```
 Test Files  2 passed (2)
      Tests  26 passed (26)
```

### Test coverage notes

- `supervisor-wiring.test.ts` exercises every wired slot end-to-end: `/healthz` schema-versioned reply with correct uptime/pid/counters; `/stats` with both injected and `defaultMemoryUsageProvider` fallback; `daemon.shutdownForUpgrade` with mocked actions running in spec §6.4 order AND with the real `defaultWriteShutdownMarker` against a tmp dir to prove the round-trip lands a marker the T22 reader can parse; `daemon.hello` and `daemon.shutdown` confirmed still at NOT_IMPLEMENTED (per constraint); non-allowlisted methods still get `NOT_ALLOWED` (no surface widening).
- `healthzPing.test.ts` covers the pure `classifyTick` FSM, the full pinger lifecycle (start/stop idempotency, three-miss restart with FSM freeze, recover after partial streak, thrown `pingFn` errors classified as misses, hooks that throw don't crash the FSM), and `mapRpcReplyToResult` envelope adapter.

### Pre-existing failures (NOT caused by this PR)

`vitest run daemon/src` shows 34 failures across `daemon/src/db/__tests__/` and `daemon/src/db/schema/__tests__/` — all `NODE_MODULE_VERSION` ABI mismatches in `better-sqlite3` (the local Node version doesn't match the prebuilt binding). Same posture for the `node-pty` postinstall warning during `npm install`. These predate this branch and are unrelated to supervisor RPC wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)