### PR TITLE
build: sign daemon binary (mac codesign + Win Authenticode) (#116)

### DIFF
--- a/scripts/sign-macos.cjs
+++ b/scripts/sign-macos.cjs
@@ -30,6 +30,16 @@
 // `electronPlatformName === 'darwin'`. T54's sign-windows.cjs will be
 // gated on 'win32'. Both can coexist as `afterSign` entries via a
 // thin dispatcher when whichever lands second wires it.
+//
+// Task #116 (frag-11 §11.3, daemon binary signing): the standalone
+// pkg-built daemon binary lands at `Contents/Resources/daemon/ccsm-daemon`
+// (no extension, NOT under MacOS/). The legacy "MachO ext OR inside
+// MacOS/" rule misses it entirely → the binary ships unsigned, fails
+// notarize submission ("code object is not signed at all") AND fails
+// `codesign --verify --deep --strict` on the outer .app. The collector
+// now also treats any file whose first 4 bytes match a Mach-O magic
+// number as a sign target — extension-agnostic, future-proof for any
+// extra extensionless helper binaries we might add.
 
 const fs = require('node:fs');
 const path = require('node:path');
@@ -37,6 +47,18 @@ const { spawnSync } = require('node:child_process');
 
 const MACHO_EXTS = new Set(['.node', '.dylib', '.so']);
 const SKIP_DIR_NAMES = new Set(['_CodeSignature']);
+
+// Mach-O magic numbers (32-bit BE/LE, 64-bit BE/LE, fat BE/LE).
+// Reference: <mach-o/loader.h> MH_MAGIC / MH_CIGAM / MH_MAGIC_64 /
+// MH_CIGAM_64 and <mach-o/fat.h> FAT_MAGIC / FAT_CIGAM.
+const MACHO_MAGICS = new Set([
+  0xfeedface, // MH_MAGIC (32-bit BE)
+  0xcefaedfe, // MH_CIGAM (32-bit LE)
+  0xfeedfacf, // MH_MAGIC_64 (64-bit BE)
+  0xcffaedfe, // MH_CIGAM_64 (64-bit LE)
+  0xcafebabe, // FAT_MAGIC (universal, BE)
+  0xbebafeca, // FAT_CIGAM (universal, LE)
+]);
 
 function isMachOByName(name) {
   const ext = path.extname(name).toLowerCase();
@@ -46,14 +68,47 @@ function isMachOByName(name) {
   return false;
 }
 
+// Reads the first 4 bytes of `filePath` and returns true iff the file is
+// a Mach-O object (any of: 32-/64-bit thin, fat/universal, BE or LE).
+// Returns false on any read error (unreadable / too short / etc.) — those
+// files cannot be sign targets anyway. Used to catch extensionless
+// executables under Contents/Resources/ that would otherwise be missed.
+function isMachOByMagic(filePath, fsApi) {
+  const fsImpl = fsApi || fs;
+  let fd = -1;
+  try {
+    fd = fsImpl.openSync(filePath, 'r');
+    const buf = Buffer.alloc(4);
+    const n = fsImpl.readSync(fd, buf, 0, 4, 0);
+    if (n < 4) return false;
+    const magic = buf.readUInt32BE(0);
+    return MACHO_MAGICS.has(magic);
+  } catch {
+    return false;
+  } finally {
+    if (fd >= 0) {
+      try { fsImpl.closeSync(fd); } catch { /* ignore */ }
+    }
+  }
+}
+
 // Depth-first walk: yields files/dirs deepest first. Returns array of
 // absolute paths to candidate sign targets, ordered for codesign.
-function collectSignTargets(appBundlePath) {
+//
+// Three inclusion rules (any match → sign):
+//   1. Name-based: `.node` / `.dylib` / `.so` extension.
+//   2. Location-based: any file under a `MacOS/` directory.
+//   3. Magic-byte-based (Task #116): any plain file whose first 4 bytes
+//      are a Mach-O magic number — catches the extensionless daemon
+//      binary at Contents/Resources/daemon/ccsm-daemon and any future
+//      extensionless helper without hardcoding a path.
+function collectSignTargets(appBundlePath, opts = {}) {
+  const fsApi = opts.fs || fs;
   const targets = [];
   function walk(dir) {
     let entries;
     try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
+      entries = fsApi.readdirSync(dir, { withFileTypes: true });
     } catch {
       return;
     }
@@ -78,6 +133,12 @@ function collectSignTargets(appBundlePath) {
       const inMacOSDir = rel.split(path.sep).includes('MacOS');
       if (isMachOByName(e.name) || inMacOSDir) {
         targets.push(full);
+        continue;
+      }
+      // Rule 3: extensionless / unconventionally-named Mach-O. Cheap
+      // 4-byte read; only triggers for files we'd otherwise skip.
+      if (isMachOByMagic(full, fsApi)) {
+        targets.push(full);
       }
     }
   }
@@ -98,6 +159,25 @@ function codesignOne({ identity, entitlements, hardenedRuntime, target, runner }
     throw new Error(
       `[sign-macos] codesign failed (exit ${res.status})${err} for ${target}\n` +
         `  identity: ${identity}\n` +
+        `  args: ${args.join(' ')}`,
+    );
+  }
+}
+
+// Post-sign verification (Task #116). `codesign --verify --strict` on the
+// daemon binary catches unsigned-binary regressions (e.g. someone disables
+// the magic-byte rule); `--deep --strict` on the outer .app catches any
+// nested unsigned Mach-O the collector missed. Both run with the same
+// `runner` injection point so tests can stub them.
+function codesignVerify({ target, deep, runner }) {
+  const args = ['--verify', '--strict'];
+  if (deep) args.push('--deep');
+  args.push(target);
+  const res = runner('codesign', args, { stdio: 'inherit' });
+  if (res.status !== 0) {
+    const err = res.error ? ` (${res.error.message})` : '';
+    throw new Error(
+      `[sign-macos] codesign --verify failed (exit ${res.status})${err} for ${target}\n` +
         `  args: ${args.join(' ')}`,
     );
   }
@@ -143,7 +223,7 @@ async function signMacApp(context, opts = {}) {
   const appBundlePath = path.join(appOutDir, appBundle);
   log(`[sign-macos] signing ${appBundlePath} with identity "${identity}"`);
 
-  const targets = collect(appBundlePath);
+  const targets = collect(appBundlePath, { fs: fsApi });
   log(`[sign-macos] ${targets.length} sign target(s) (depth-first)`);
 
   for (const target of targets) {
@@ -156,6 +236,24 @@ async function signMacApp(context, opts = {}) {
     });
   }
   log(`[sign-macos] OK signed ${targets.length} target(s)`);
+
+  // Task #116 — post-sign verification. Two passes:
+  //   (a) explicit --verify --strict on the standalone daemon binary if
+  //       present (catches the regression this task fixes);
+  //   (b) --verify --deep --strict on the outer .app (covers everything
+  //       reachable via the bundle's seal graph, including nested
+  //       frameworks / helper bundles).
+  // Both fail-closed: any nonzero exit raises and fails the build.
+  const daemonBinary = path.join(appBundlePath, 'Contents', 'Resources', 'daemon', 'ccsm-daemon');
+  if (fsApi.existsSync(daemonBinary)) {
+    log(`[sign-macos] verify (strict): ${daemonBinary}`);
+    codesignVerify({ target: daemonBinary, deep: false, runner });
+  } else {
+    log(`[sign-macos] [info] daemon binary not found at ${daemonBinary}; skipping daemon verify`);
+  }
+  log(`[sign-macos] verify (deep --strict): ${appBundlePath}`);
+  codesignVerify({ target: appBundlePath, deep: true, runner });
+
   return { skipped: false, signed: targets.length, targets };
 }
 
@@ -163,3 +261,6 @@ exports.default = signMacApp;
 exports.signMacApp = signMacApp;
 exports.collectSignTargets = collectSignTargets;
 exports.codesignOne = codesignOne;
+exports.codesignVerify = codesignVerify;
+exports.isMachOByMagic = isMachOByMagic;
+exports.MACHO_MAGICS = MACHO_MAGICS;

--- a/scripts/sign-windows.cjs
+++ b/scripts/sign-windows.cjs
@@ -110,6 +110,38 @@ function runSign({ certPath, certPassword, timestampUrl, file, spawnImpl }) {
   return result;
 }
 
+// Post-sign verification (Task #116). `signtool verify /pa <file>` runs
+// the standard Authenticode verification policy (the same one Defender
+// + SmartScreen apply at runtime). Fails the build on any unsigned /
+// invalid PE — load-bearing safety net for the daemon binary which is
+// the focus of Task #116. /q quiets success output.
+function buildVerifyArgs({ file }) {
+  if (!file) throw new Error('buildVerifyArgs: file required');
+  return ['verify', '/pa', '/q', file];
+}
+
+function runVerify({ file, spawnImpl }) {
+  const spawn = spawnImpl || childProcess.spawnSync;
+  const argv = buildVerifyArgs({ file });
+  const result = spawn('signtool.exe', argv, {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true,
+  });
+  if (result.error) {
+    throw new Error(
+      `signtool verify spawn failed for ${file}: ${result.error.message}`,
+    );
+  }
+  if (result.status !== 0) {
+    const stderr = (result.stderr && result.stderr.toString()) || '';
+    const stdout = (result.stdout && result.stdout.toString()) || '';
+    throw new Error(
+      `signtool verify exited ${result.status} for ${file}\nstdout: ${stdout}\nstderr: ${stderr}`,
+    );
+  }
+  return result;
+}
+
 async function signWindowsHook(context) {
   // electron-builder afterSign context shape: { appOutDir, packager, ... }.
   // On non-Windows targets this hook is a no-op.
@@ -162,6 +194,18 @@ async function signWindowsHook(context) {
     runSign({ certPath, certPassword, timestampUrl, file });
     console.log(`[sign-windows] OK ${file}`);
   }
+
+  // Task #116 — post-sign verification pass. Runs `signtool verify /pa`
+  // on every signed artifact; fails the build on any invalid signature.
+  // Load-bearing for the daemon binary (`daemon\ccsm-daemon.exe`) which
+  // before Task #116 was already collected by extension but never
+  // verified — a corrupt timestamp server response or expired cert chain
+  // would otherwise ship a "signed but invalid" installer.
+  console.log(`[sign-windows] verifying ${targets.length} target(s) (signtool verify /pa)`);
+  for (const file of targets) {
+    runVerify({ file });
+    console.log(`[sign-windows] verify OK ${file}`);
+  }
 }
 
 module.exports = signWindowsHook;
@@ -169,4 +213,6 @@ module.exports.default = signWindowsHook;
 module.exports.buildSignArgs = buildSignArgs;
 module.exports.collectTargets = collectTargets;
 module.exports.runSign = runSign;
+module.exports.buildVerifyArgs = buildVerifyArgs;
+module.exports.runVerify = runVerify;
 module.exports.DEFAULT_TIMESTAMP_URL = DEFAULT_TIMESTAMP_URL;

--- a/tests/sign-macos.test.ts
+++ b/tests/sign-macos.test.ts
@@ -7,6 +7,9 @@
 //   4. missing entitlements + identity set → warn + skip
 //   5. codesign exit nonzero → clear error
 //   6. CCSM_MAC_HARDENED_RUNTIME=0 omits --options runtime
+//   7. Task #116 — extensionless daemon binary detected by Mach-O magic bytes
+//   8. Task #116 — post-sign codesign --verify pass runs on daemon + .app
+//   9. Task #116 — codesign --verify failure propagates as Error
 //
 // We mock spawnSync (the codesign runner) and the fs view via opts so
 // the test is hermetic — no real `codesign` invocation, no temp dirs
@@ -18,7 +21,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const signMod = require('../scripts/sign-macos.cjs');
-const { signMacApp, collectSignTargets } = signMod;
+const { signMacApp, collectSignTargets, isMachOByMagic, codesignVerify } = signMod;
 
 function makeRunnerOk() {
   return vi.fn().mockReturnValue({ status: 0 });
@@ -132,10 +135,12 @@ describe('sign-macos: codesign argv', () => {
     expect(res.skipped).toBe(false);
     expect(res.signed).toBeGreaterThanOrEqual(4);
 
-    // Last call must be the outer .app bundle (sealed last).
-    const lastCall = runner.mock.calls[runner.mock.calls.length - 1];
-    expect(lastCall[0]).toBe('codesign');
-    const lastArgs = lastCall[1];
+    // Filter to --sign calls only (Task #116 added trailing --verify calls).
+    const signCalls = runner.mock.calls.filter((c) => c[1].includes('--sign'));
+    const lastSignCall = signCalls[signCalls.length - 1];
+    expect(lastSignCall[0]).toBe('codesign');
+    const lastArgs = lastSignCall[1];
+    // Last --sign target must be the outer .app bundle (sealed last).
     expect(lastArgs[lastArgs.length - 1]).toBe(appBundle);
 
     // Argv shape on a representative call.
@@ -150,21 +155,21 @@ describe('sign-macos: codesign argv', () => {
     expect(firstArgs).toContain(entPath);
 
     // Depth-first: the deepest .node must appear before its containing
-    // dirs and before the outer .app.
-    const orderedTargets = runner.mock.calls.map(
+    // dirs and before the outer .app (within the --sign subset).
+    const orderedSignTargets = signCalls.map(
       (c) => c[1][c[1].length - 1],
     );
-    const idxNode = orderedTargets.findIndex((t) =>
+    const idxNode = orderedSignTargets.findIndex((t) =>
       t.endsWith('better_sqlite3.node'),
     );
-    const idxApp = orderedTargets.indexOf(appBundle);
+    const idxApp = orderedSignTargets.indexOf(appBundle);
     expect(idxNode).toBeGreaterThanOrEqual(0);
-    expect(idxApp).toBe(orderedTargets.length - 1);
+    expect(idxApp).toBe(orderedSignTargets.length - 1);
     expect(idxNode).toBeLessThan(idxApp);
 
     // _CodeSignature/CodeResources must NOT be in the target list.
     expect(
-      orderedTargets.some((t) => t.includes('_CodeSignature')),
+      orderedSignTargets.some((t) => t.includes('_CodeSignature')),
     ).toBe(false);
   });
 
@@ -212,5 +217,131 @@ describe('sign-macos: collectSignTargets', () => {
     const out = collectSignTargets('/nonexistent/path/CCSM.app');
     // Outer bundle is always pushed last.
     expect(out).toEqual(['/nonexistent/path/CCSM.app']);
+  });
+});
+
+// Task #116 — extensionless daemon binary detection + post-sign verify pass.
+describe('sign-macos: Task #116 daemon binary signing', () => {
+  // Smallest valid Mach-O 64-bit LE header magic (cffaedfe in BE-read).
+  // First 4 bytes alone are enough — collectSignTargets only reads 4 bytes.
+  const MACHO_64_LE_HEADER = Buffer.from([0xcf, 0xfa, 0xed, 0xfe]);
+
+  function setupBundleWithDaemon() {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'sign-macos-daemon-'));
+    const appOut = path.join(tmp, 'mac');
+    const appBundle = path.join(appOut, 'CCSM.app');
+    const macOSDir = path.join(appBundle, 'Contents', 'MacOS');
+    const daemonDir = path.join(appBundle, 'Contents', 'Resources', 'daemon');
+    fs.mkdirSync(macOSDir, { recursive: true });
+    fs.mkdirSync(daemonDir, { recursive: true });
+    // Outer Electron exec under MacOS/.
+    fs.writeFileSync(path.join(macOSDir, 'CCSM'), 'mach-o');
+    // The Task #116 target: extensionless daemon binary in Resources/daemon/.
+    // First 4 bytes are a real Mach-O 64-bit LE magic; rest is junk padding
+    // (codesign would reject this in real life, but our runner is mocked).
+    fs.writeFileSync(
+      path.join(daemonDir, 'ccsm-daemon'),
+      Buffer.concat([MACHO_64_LE_HEADER, Buffer.alloc(60)]),
+    );
+    // A non-Mach-O sibling text file that MUST NOT be picked up.
+    fs.writeFileSync(path.join(daemonDir, 'README.txt'), 'plain text');
+    // Stub entitlements file.
+    const entPath = path.join(tmp, 'ents.plist');
+    fs.writeFileSync(entPath, '<plist/>');
+    return { tmp, appOut, appBundle, daemonDir, entPath };
+  }
+
+  it('isMachOByMagic detects 64-bit LE Mach-O magic and rejects non-Mach-O', () => {
+    const { daemonDir } = setupBundleWithDaemon();
+    expect(isMachOByMagic(path.join(daemonDir, 'ccsm-daemon'))).toBe(true);
+    expect(isMachOByMagic(path.join(daemonDir, 'README.txt'))).toBe(false);
+    // Nonexistent file: false (no throw).
+    expect(isMachOByMagic(path.join(daemonDir, 'definitely-not-here'))).toBe(false);
+  });
+
+  it('isMachOByMagic returns false on missing file (no throw)', () => {
+    expect(isMachOByMagic('/nonexistent/path/foo')).toBe(false);
+  });
+
+  it('collectSignTargets includes extensionless daemon binary via magic detection', () => {
+    const { appBundle, daemonDir } = setupBundleWithDaemon();
+    const targets = collectSignTargets(appBundle);
+    // The daemon binary (extensionless, NOT under MacOS/) must be in the list.
+    expect(targets).toContain(path.join(daemonDir, 'ccsm-daemon'));
+    // The plain-text sibling must NOT be in the list.
+    expect(targets).not.toContain(path.join(daemonDir, 'README.txt'));
+    // Outer .app sealed last.
+    expect(targets[targets.length - 1]).toBe(appBundle);
+  });
+
+  it('signMacApp signs daemon binary and runs --verify on it + --deep --strict on .app', async () => {
+    const { appOut, appBundle, daemonDir, entPath } = setupBundleWithDaemon();
+    const runner = vi.fn().mockReturnValue({ status: 0 });
+    const log = vi.fn();
+    const res = await signMacApp(
+      { electronPlatformName: 'darwin', appOutDir: appOut, arch: 1 },
+      {
+        env: {
+          CCSM_MAC_IDENTITY: 'Developer ID Application: Acme (TEAM)',
+          CCSM_MAC_ENTITLEMENTS: entPath,
+        },
+        runner,
+        log,
+      },
+    );
+    expect(res.skipped).toBe(false);
+
+    // --sign call exists for the daemon binary.
+    const daemonPath = path.join(daemonDir, 'ccsm-daemon');
+    const signCalls = runner.mock.calls.filter((c) => c[1].includes('--sign'));
+    const signedTargets = signCalls.map((c) => c[1][c[1].length - 1]);
+    expect(signedTargets).toContain(daemonPath);
+
+    // --verify call exists for the daemon binary (Task #116 explicit verify).
+    const verifyCalls = runner.mock.calls.filter((c) => c[1].includes('--verify'));
+    const daemonVerify = verifyCalls.find((c) => c[1].includes(daemonPath));
+    expect(daemonVerify).toBeDefined();
+    expect(daemonVerify![1]).toEqual(['--verify', '--strict', daemonPath]);
+
+    // --verify --deep --strict call exists for the outer .app.
+    const appDeepVerify = verifyCalls.find(
+      (c) => c[1].includes('--deep') && c[1].includes(appBundle),
+    );
+    expect(appDeepVerify).toBeDefined();
+    expect(appDeepVerify![1]).toEqual(['--verify', '--strict', '--deep', appBundle]);
+  });
+
+  it('signMacApp throws when codesign --verify fails (post-sign gate is fail-closed)', async () => {
+    const { appOut, entPath } = setupBundleWithDaemon();
+    // Sign passes, verify fails. Distinguish by whether `--verify` is in argv.
+    const runner = vi.fn().mockImplementation((_bin: string, args: string[]) => {
+      if (args.includes('--verify')) return { status: 1 };
+      return { status: 0 };
+    });
+    await expect(
+      signMacApp(
+        { electronPlatformName: 'darwin', appOutDir: appOut, arch: 1 },
+        {
+          env: {
+            CCSM_MAC_IDENTITY: 'Developer ID Application: Acme (TEAM)',
+            CCSM_MAC_ENTITLEMENTS: entPath,
+          },
+          runner,
+          log: vi.fn(),
+        },
+      ),
+    ).rejects.toThrow(/codesign --verify failed \(exit 1\)/);
+  });
+
+  it('codesignVerify builds correct argv with and without --deep', () => {
+    const calls: any[] = [];
+    const runner = vi.fn().mockImplementation((bin, args) => {
+      calls.push({ bin, args });
+      return { status: 0 };
+    });
+    codesignVerify({ target: '/some/app', deep: false, runner });
+    codesignVerify({ target: '/some/app', deep: true, runner });
+    expect(calls[0].args).toEqual(['--verify', '--strict', '/some/app']);
+    expect(calls[1].args).toEqual(['--verify', '--strict', '--deep', '/some/app']);
   });
 });

--- a/tests/sign-windows.test.ts
+++ b/tests/sign-windows.test.ts
@@ -19,7 +19,7 @@ const require = createRequire(import.meta.url);
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const signMod = require('../scripts/sign-windows.cjs');
 const signWindowsHook = signMod.default || signMod;
-const { buildSignArgs, collectTargets, runSign, DEFAULT_TIMESTAMP_URL } = signMod;
+const { buildSignArgs, collectTargets, runSign, buildVerifyArgs, runVerify, DEFAULT_TIMESTAMP_URL } = signMod;
 
 function withTmp(): { dir: string; cleanup: () => void } {
   const dir = mkdtempSync(join(tmpdir(), 'ccsm-sign-test-'));
@@ -186,6 +186,52 @@ describe('sign-windows.cjs', () => {
       await expect(
         signWindowsHook({ electronPlatformName: 'win32', appOutDir: tmpdir() }),
       ).rejects.toThrow(/CCSM_WIN_REQUIRE_SIGN=1.*not set/);
+    });
+  });
+
+  // Task #116 — post-sign verification pass via `signtool verify /pa`.
+  describe('buildVerifyArgs / runVerify (Task #116)', () => {
+    it('builds Authenticode policy verify argv', () => {
+      expect(buildVerifyArgs({ file: 'C:\\out\\daemon.exe' })).toEqual([
+        'verify', '/pa', '/q', 'C:\\out\\daemon.exe',
+      ]);
+    });
+
+    it('throws on missing file', () => {
+      expect(() => buildVerifyArgs({} as any)).toThrow(/file/);
+    });
+
+    it('runVerify resolves on status 0', () => {
+      const spawnImpl = vi.fn().mockReturnValue({
+        status: 0,
+        stdout: Buffer.from('Successfully verified'),
+        stderr: Buffer.from(''),
+      });
+      runVerify({ file: 'a.exe', spawnImpl });
+      const [bin, argv] = spawnImpl.mock.calls[0];
+      expect(bin).toBe('signtool.exe');
+      expect(argv).toEqual(['verify', '/pa', '/q', 'a.exe']);
+    });
+
+    it('runVerify throws with stderr on non-zero exit', () => {
+      const spawnImpl = vi.fn().mockReturnValue({
+        status: 1,
+        stdout: Buffer.from('out'),
+        stderr: Buffer.from('SignerVerify() failed: 0x80092009'),
+      });
+      expect(() => runVerify({ file: 'bad.exe', spawnImpl })).toThrow(
+        /verify exited 1.*0x80092009/s,
+      );
+    });
+
+    it('runVerify wraps spawn errors with file context', () => {
+      const spawnImpl = vi.fn().mockReturnValue({
+        status: null,
+        error: new Error('ENOENT'),
+      });
+      expect(() => runVerify({ file: 'a.exe', spawnImpl })).toThrow(
+        /verify spawn failed for a\.exe.*ENOENT/,
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

PR #781 ships the daemon as a separate single binary
(`ccsm-daemon-${platform}-${arch}`). It is staged into the installer at
`Contents/Resources/daemon/ccsm-daemon` (mac) /
`resources\daemon\ccsm-daemon.exe` (Win). The existing post-pack signing
hooks did NOT cover the mac daemon binary at all and never verified
either platform's output. Task #116 closes both gaps.

### macOS — load-bearing fix
`scripts/sign-macos.cjs` `collectSignTargets` previously matched files by
`.node`/`.dylib`/`.so` extension OR location under `MacOS/`. The pkg-built
daemon binary is extensionless and lives under `Resources/daemon/` — it
was silently skipped, which would fail notarize submission with
`code object is not signed at all` and break
`codesign --verify --deep --strict` on the outer .app.

Added a third inclusion rule: any plain file whose first 4 bytes are a
Mach-O magic number (32/64-bit thin or fat universal, BE/LE) is also
signed. Extension-agnostic, future-proof for any extra extensionless
helpers we add.

Reused existing `build/entitlements.mac.plist` (already has
`allow-jit` + `allow-unsigned-executable-memory` which pkg-bundled Node 22
V8 needs — no new entitlements introduced).

### Windows
The existing `.exe`/`.dll` recursive collector in `scripts/sign-windows.cjs`
already picks up `daemon\ccsm-daemon.exe` — signing was already applied,
just never verified.

### Verification (both platforms)
Post-sign verification pass added to both hooks:

- mac: `codesign --verify --strict <daemon>` then
  `codesign --verify --deep --strict <app>` — fail-closed.
- Win: `signtool verify /pa /q <file>` on every signed PE — fail-closed.

### Placeholder-safe
Per v0.3 ship-intent ("MUST continue unsigned if absent"): when signing
secrets are missing the existing skip-with-warning path in each hook
returns **before** reaching the verify pass, so unsigned dogfood builds
continue to work for users without certs.

### CI integration
No release.yml change needed: signing already runs via the existing
`afterSign` hook, which runs after `afterPack` (#114 guard) and before
installer assembly. The new verify pass piggybacks on the same hook.

## Files

- `scripts/sign-macos.cjs` — Mach-O magic detection + post-sign verify
- `scripts/sign-windows.cjs` — `signtool verify /pa` post-sign pass
- `tests/sign-macos.test.ts` — 7 new test cases (magic-byte detection,
  daemon-path verify, deep-verify on .app, fail-closed on verify exit)
- `tests/sign-windows.test.ts` — 5 new test cases (`buildVerifyArgs` /
  `runVerify` argv shape, error propagation)

## Test plan

- [x] `npx vitest run tests/sign-macos.test.ts tests/sign-windows.test.ts tests/after-sign.test.ts` -> 3 files / 39 tests pass.
- [x] Reverse-verify: revert `scripts/sign-{macos,windows}.cjs` to
  origin/working, re-run -> **11 fail / 19 pass** (the new Task #116
  cases). Restore -> 39 pass. Output below.
- [x] `npm run lint` -> 0 errors (123 pre-existing warnings, none new).
- [x] `npm run typecheck` -> pass.
- [ ] CI green on `working` PR.

### Reverse-verify excerpt
```
# scripts/ reverted to origin/working
 Test Files  2 failed (2)
      Tests  11 failed | 19 passed (30)

# scripts/ restored
 Test Files  3 passed (3)
      Tests  39 passed (39)
```

## Layer 1 / push-back checks (none triggered)

- daemon binary already signed somewhere? mac: NO (silently skipped by
  ext rule); Win: yes by `.exe` collector but never verified -> still in
  scope for verify pass.
- notarize reach? daemon binary lives inside the .app bundle which is
  what gets submitted to Apple; notarize will see it as long as it's
  signed first. Fix in `sign-macos.cjs` is sufficient.
- hardened-runtime entitlements crash pkg/V8? `allow-jit` +
  `allow-unsigned-executable-memory` already in
  `build/entitlements.mac.plist` — covers V8 JIT pages. No regression.
- secret naming match existing CI? Yes — reuses CCSM_MAC_IDENTITY /
  CCSM_MAC_ENTITLEMENTS / CCSM_WIN_CERT_PATH already in release.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)