### PR TITLE
ccsm-native: scaffold N-API addon (frag-3.5.1 §3.5.1.1, #109)

### DIFF
--- a/.github/workflows/ccsm-native.yml
+++ b/.github/workflows/ccsm-native.yml
@@ -1,0 +1,133 @@
+name: ccsm-native
+
+# Build + load-smoke the in-tree N-API helper on the v0.3 platform
+# matrix. Spec: docs/superpowers/specs/v0.3-fragments/frag-3.5.1-pty-hardening.md
+# §3.5.1.1 + §3.5.1.6.
+#
+# We pin Node to `daemon/.nvmrc` (the daemon's locked target) so the
+# .node we produce here matches the ABI the daemon will dlopen at
+# runtime — same single-source-of-truth rule frag-11 §11.5(0a) /
+# Task 20f locked in.
+#
+# This workflow is intentionally separate from the main `ci` job so:
+#   - main CI lint/typecheck/test stays fast (no node-gyp on every PR)
+#   - matrix changes here don't reshuffle the main verify path
+#   - the daemon-side smoke (loadCcsmNative on the freshly built
+#     artifact) runs against the actual binary, not a JS fake.
+
+on:
+  pull_request:
+    branches: [main, working]
+    paths:
+      - 'daemon/native/ccsm_native/**'
+      - 'daemon/src/native/**'
+      - 'daemon/.nvmrc'
+      - 'scripts/build-ccsm-native.cjs'
+      - 'eslint-rules/no-direct-native-import.js'
+      - '.github/workflows/ccsm-native.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ccsm-native-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-smoke:
+    name: build + smoke (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # Pin the daemon Node target via daemon/.nvmrc — same source of
+      # truth used by scripts/build-ccsm-native.cjs and frag-11.
+      - name: Setup Node (from daemon/.nvmrc)
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: daemon/.nvmrc
+          cache: 'npm'
+
+      - name: Setup Python (node-gyp)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      # node-gyp on Windows needs the MSVC build tools shipped with
+      # the GitHub-hosted windows-latest image. No extra install
+      # required; we just verify the toolchain is there before we
+      # spend time on the addon build.
+      - name: Verify toolchain
+        shell: bash
+        run: |
+          node --version
+          npm --version
+          python --version
+          which node-gyp || npx node-gyp --version || true
+
+      # We only need the addon's own deps (node-addon-api headers).
+      # Install via the dedicated build script which also runs node-gyp.
+      - name: Build ccsm_native
+        run: npm run build:ccsm-native
+        env:
+          # Force node-gyp to download fresh headers if cache is cold.
+          npm_config_build_from_source: 'true'
+
+      - name: Verify artifact present
+        shell: bash
+        run: |
+          ARCH=$(node -p "process.arch")
+          PLAT=$(node -p "process.platform")
+          OUT="daemon/native/${PLAT}-${ARCH}/ccsm_native.node"
+          if [ ! -f "$OUT" ]; then
+            echo "FATAL: ccsm_native.node not at $OUT" >&2
+            exit 1
+          fi
+          ls -lah "$OUT"
+          echo "CCSM_NATIVE_NODE=$PWD/$OUT" >> "$GITHUB_ENV"
+
+      # Install the root project's deps (vitest, typescript, etc.) so
+      # we can run the load-smoke test against the freshly built
+      # artifact. We skip native rebuilds via ELECTRON_SKIP_BINARY_DOWNLOAD
+      # and `--ignore-scripts` is intentionally NOT used: we DO want
+      # better-sqlite3's postinstall to run on Linux (other matrix
+      # legs may need it for unrelated tests we trigger below). On
+      # Windows the postinstall sometimes fails on a fresh checkout
+      # because node-pty's submodule scripts need git-bash; we tolerate
+      # that here because the only test we run cares about ccsm_native.
+      - name: Install root deps
+        run: npm ci --legacy-peer-deps
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
+        continue-on-error: ${{ matrix.os == 'windows-latest' }}
+
+      # Smoke: load the built .node via the production loader shim.
+      # The vitest filter limits us to the loader's __tests__ tree so
+      # we don't pay the full daemon-tests wall-clock here.
+      - name: Smoke (loadCcsmNative real artifact)
+        shell: bash
+        run: |
+          npx vitest run daemon/src/native/__tests__/index.test.ts --reporter=verbose
+        env:
+          CCSM_NATIVE_NODE: ${{ env.CCSM_NATIVE_NODE }}
+
+      # Lint: prove the no-direct-native-import rule is wired and
+      # green on the daemon tree (no other file requires the .node).
+      - name: Lint (no-direct-native-import)
+        run: npx eslint daemon/src --ext .ts
+
+      # Upload the .node so a downstream job (or release.yml in the
+      # future) can consume it. For now this is observability — we
+      # want to see the per-platform sizes drift over time.
+      - name: Upload ccsm_native.node
+        uses: actions/upload-artifact@v4
+        with:
+          name: ccsm_native-${{ runner.os }}-${{ runner.arch }}
+          path: daemon/native/*/ccsm_native.node
+          if-no-files-found: error
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,20 @@ docs/screenshots/dogfood-happy-path/
 daemon/dist/
 daemon/dist-daemon/
 daemon/dist-daemon-bundle/
-daemon/native/
+# Ignore rebuild output dirs (`daemon/native/<platform>-<arch>/`,
+# created by scripts/electron-rebuild-natives.cjs and
+# scripts/build-ccsm-native.cjs). The in-tree ccsm_native source dir
+# (frag-3.5.1 §3.5.1.1) MUST be tracked, so we do NOT ignore the
+# whole `daemon/native/` tree — we ignore the per-platform output
+# directories and the addon's build/node_modules instead.
+daemon/native/win32-x64/
+daemon/native/win32-arm64/
+daemon/native/linux-x64/
+daemon/native/linux-arm64/
+daemon/native/darwin-x64/
+daemon/native/darwin-arm64/
+daemon/native/ccsm_native/build/
+daemon/native/ccsm_native/node_modules/
 daemon/native-staged/
 daemon/sdk-staged/
 daemon/deps-staged/

--- a/daemon/native/ccsm_native/README.md
+++ b/daemon/native/ccsm_native/README.md
@@ -1,0 +1,144 @@
+# ccsm_native
+
+In-tree N-API helper for the CCSM daemon.
+
+## Spec
+
+- `docs/superpowers/specs/v0.3-fragments/frag-3.5.1-pty-hardening.md`
+  - §3.5.1.1   Win JobObject wiring
+  - §3.5.1.1.a Native binding swap interface (lockin-P0-2)
+  - §3.5.1.2   POSIX process group + SIGCHLD wiring
+  - §3.5.1.6   Win named-pipe ACL hardening
+- `docs/superpowers/specs/v0.3-fragments/frag-11-packaging.md`
+  - §11.1 rebuild-native-for-node.cjs
+  - §11.4 SHA256SUMS / signing of `ccsm_native.node`
+
+## What it is
+
+One single `.node` carrying five export surfaces:
+
+| Surface     | Win32                                                        | Linux                            | Darwin                          |
+|-------------|--------------------------------------------------------------|----------------------------------|---------------------------------|
+| `winjob`    | `Create/SetInformation/Assign/TerminateJobObject`            | ENOSYS                           | ENOSYS                          |
+| `pipeAcl`   | `SetSecurityInfo` + `PIPE_REJECT_REMOTE_CLIENTS`             | ENOSYS                           | ENOSYS                          |
+| `pdeathsig` | ENOSYS                                                       | `prctl(PR_SET_PDEATHSIG)`        | ENOSYS                          |
+| `peerCred`  | `GetNamedPipeClientProcessId` + `OpenProcessTokenUserSid`    | `getsockopt(SO_PEERCRED)`        | `getpeereid`                    |
+| `sigchld`   | ENOSYS                                                       | `uv_signal_t(SIGCHLD)` + `waitpid(WNOHANG)` | same as Linux       |
+
+Surfaces marked ENOSYS throw `Error { code: 'ENOSYS' }` at the binding
+boundary so a misconfigured call site fails loud — never silently
+no-ops at the native layer. The JS-side decider modules
+(`daemon/src/pty/*.ts`, `daemon/src/sockets/peer-cred-verify.ts`)
+provide platform-aware no-op stubs at the wrapper layer where
+appropriate.
+
+## How to build
+
+From repo root:
+
+```bash
+npm run build:ccsm-native
+```
+
+This installs `node-addon-api` inside `daemon/native/ccsm_native/`,
+runs `node-gyp rebuild` against the Node version in `daemon/.nvmrc`
+(currently 22.11.0), and copies the resulting `ccsm_native.node`
+into `daemon/native/<platform>-<arch>/`, where the daemon-side
+loader (`daemon/src/native/index.ts`) resolves it.
+
+The release build path runs the same logic from
+`scripts/electron-rebuild-natives.cjs` (frag-11 §11.1) which
+additionally rebuilds `better-sqlite3` for the daemon's Node ABI.
+
+## How to use it from JS
+
+NEVER `require('ccsm_native.node')` directly. The custom ESLint rule
+`no-direct-native-import` enforces this — see frag-3.5.1 §3.5.1.1.a
+("No call site in `daemon/src/pty/**` or `daemon/src/socket/**` may
+import `ccsm_native.node` directly").
+
+Always go through the loader shim:
+
+```ts
+import { native } from '../native/index.js';
+
+// e.g. JobObject ownership
+const job = createJobObject({ deps: native().winjob });
+
+// e.g. pipe ACL hardening
+applyPipeAcl(pipePath, { deps: native().pipeAcl });
+
+// e.g. peer-cred verification
+const verdict = verifyPeerCred(socket, { expectedSid }, {
+  deps: native().peerCred,
+});
+```
+
+## Per-platform availability
+
+The loader shim at `daemon/src/native/index.ts` narrows the surface
+by `process.platform` so consumers can check by `typeof` whether a
+method is available:
+
+```ts
+if (typeof native().peerCred.getsockoptPeerCred === 'function') {
+  // we are on Linux
+}
+```
+
+The C++ stub files (`*_stub.cc`) register the same method names that
+the real implementations register, so even a misconfigured call site
+on the wrong platform gets a thrown ENOSYS error rather than a
+JavaScript "x is not a function" TypeError.
+
+## Why N-API and not koffi or shellouts
+
+Per frag-3.5.1 §3.5.1.1.a "Vendor-risk acknowledgement" + open-question 1:
+N-API was picked for compile-time symbol guarantees, zero runtime
+overhead, and ABI stability across Node major versions (NAPI 8 covers
+Node 16.6+). The `NativeBinding` swap interface is single-file
+swappable to koffi or any other FFI in v0.4 if maintenance burden
+becomes an issue.
+
+Shellout fallbacks (`taskkill`, `icacls`, etc.) are intentionally NOT
+implemented as a degraded path, because the spec contracts (e.g.
+`KILL_ON_JOB_CLOSE` requires the kernel to act when the daemon
+crashes — there is no chance to spawn a process from a dying
+daemon) cannot be honoured by shellouts.
+
+## Lifetime + handle ownership
+
+Per §3.5.1.1 "Lifetime", the JobObject HANDLE is allocated once at
+daemon boot and held for the daemon's whole life. The OS closes it
+on process exit, which is the trigger for `KILL_ON_JOB_CLOSE`. The
+binding therefore returns the HANDLE as a `Napi::External<void>`
+with a no-op finalizer — JS GC tracks the wrapper but never frees
+the underlying HANDLE. The JS-side `JobObjectHandle` abstraction in
+`daemon/src/pty/win-jobobject.ts` is the only authority over its
+logical lifetime.
+
+## Acceptance tests
+
+Per frag-3.5.1 §3.5.1.6:
+
+- "Native binding accessed only through `daemon/src/native/index.ts`;
+  lint `no-direct-native-import` passes on full daemon tree."
+  — see CI workflow `.github/workflows/ccsm-native.yml` which runs
+  `npx eslint daemon/src --ext .ts` after building the addon.
+
+- "Unit: `winjob.create()` + `winjob.assign(job, fakePid)` round-trip;
+  `assign` of dead pid throws `EINVAL`."
+  — covered indirectly by `daemon/src/pty/__tests__/win-jobobject.test.ts`
+  (existing) which exercises the `JobObjectHandle` against the
+  injected `NativeWinjobDeps` shape that this binding implements.
+
+- "Unit: SIGCHLD handler reaps a synthetic forked child within 50ms
+  via `waitpid(pid, WNOHANG)` (per-PID, not `waitpid(-1)`)."
+  — covered indirectly by `daemon/src/pty/__tests__/sigchld-reaper.test.ts`
+  (existing) against the `SigchldReaperDeps` shape this binding
+  implements via the JS-side `subscribe` -> `onSigchld` adapter.
+
+The .node itself is smoke-tested by
+`daemon/src/native/__tests__/index.test.ts` when run with
+`CCSM_NATIVE_NODE=<path>` env (CI matrix sets this; local runs
+without the env skip the dlopen tests cleanly).

--- a/daemon/native/ccsm_native/binding.gyp
+++ b/daemon/native/ccsm_native/binding.gyp
@@ -1,0 +1,97 @@
+{
+  # ccsm_native — in-tree N-API helper for the CCSM daemon.
+  #
+  # Spec:
+  #   docs/superpowers/specs/v0.3-fragments/frag-3.5.1-pty-hardening.md
+  #     §3.5.1.1   "Win JobObject wiring (data layer)"
+  #     §3.5.1.1.a "Native binding swap interface (lockin-P0-2)"
+  #     §3.5.1.2   "POSIX process group + SIGCHLD wiring (data layer)"
+  #     §3.5.1.6   "Win named-pipe ACL hardening"
+  #   docs/superpowers/specs/v0.3-fragments/frag-11-packaging.md
+  #     §11.1     "rebuild-native-for-node.cjs ... ccsm_native"
+  #     §11.4     "ccsm_native.node ships + signs"
+  #
+  # One single .node carrying five export surfaces (winjob, pipeAcl,
+  # pdeathsig, peerCred, sigchld). Per-platform translation units stub
+  # the surfaces that are not native to that OS by throwing an Error
+  # carrying `code: 'ENOSYS'` so the JS layer's "MUST throw on the
+  # wrong platform" contract is honoured.
+  #
+  # NAPI version pin: NAPI 8 covers Node 16.6+ / Electron 17+. We are
+  # explicit about it so a future Node target bump (currently
+  # daemon/.nvmrc = 22.11.0) does not silently change ABI assumptions.
+  'targets': [
+    {
+      'target_name': 'ccsm_native',
+      'sources': [
+        'src/ccsm_native.cc',
+      ],
+      'include_dirs': [
+        "<!(node -p \"require('node-addon-api').include_dir\")",
+      ],
+      'defines': [
+        # node-addon-api: opt out of C++ exceptions; we surface errors
+        # via napi_throw_error so the dlopen path stays exception-free
+        # regardless of the host's compile flags.
+        'NAPI_DISABLE_CPP_EXCEPTIONS',
+        'NODE_ADDON_API_DISABLE_DEPRECATED',
+        'NAPI_VERSION=8',
+      ],
+      'cflags!': ['-fno-exceptions'],
+      'cflags_cc!': ['-fno-exceptions'],
+      'msvs_settings': {
+        'VCCLCompilerTool': {
+          'ExceptionHandling': 0,
+          'AdditionalOptions': ['/utf-8'],
+        },
+      },
+      'conditions': [
+        ['OS=="win"', {
+          'sources': [
+            'src/winjob_win.cc',
+            'src/pipeacl_win.cc',
+            'src/peercred_win.cc',
+            'src/pdeathsig_stub.cc',
+            'src/sigchld_stub.cc',
+          ],
+          'libraries': [
+            '-lAdvapi32.lib',
+            '-lKernel32.lib',
+          ],
+          'defines': [
+            '_HAS_EXCEPTIONS=0',
+            'WIN32_LEAN_AND_MEAN',
+            'NOMINMAX',
+            'UNICODE',
+            '_UNICODE',
+          ],
+        }],
+        ['OS=="linux"', {
+          'sources': [
+            'src/winjob_stub.cc',
+            'src/pipeacl_stub.cc',
+            'src/peercred_linux.cc',
+            'src/pdeathsig_linux.cc',
+            'src/sigchld_unix.cc',
+          ],
+          'cflags_cc': ['-fexceptions', '-std=c++17'],
+        }],
+        ['OS=="mac"', {
+          'sources': [
+            'src/winjob_stub.cc',
+            'src/pipeacl_stub.cc',
+            'src/peercred_darwin.cc',
+            'src/pdeathsig_stub.cc',
+            'src/sigchld_unix.cc',
+          ],
+          'xcode_settings': {
+            'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+            'CLANG_CXX_LIBRARY': 'libc++',
+            'CLANG_CXX_LANGUAGE_STANDARD': 'c++17',
+            'MACOSX_DEPLOYMENT_TARGET': '11.0',
+          },
+        }],
+      ],
+    },
+  ],
+}

--- a/daemon/native/ccsm_native/package.json
+++ b/daemon/native/ccsm_native/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "ccsm_native",
+  "version": "0.3.0",
+  "private": true,
+  "description": "In-tree N-API helper for CCSM daemon (winjob + pipeAcl + pdeathsig + peerCred + sigchld). Spec: docs/superpowers/specs/v0.3-fragments/frag-3.5.1-pty-hardening.md §3.5.1.1.",
+  "main": "index.js",
+  "scripts": {
+    "install": "node-gyp rebuild",
+    "rebuild": "node-gyp rebuild"
+  },
+  "gypfile": true,
+  "dependencies": {
+    "node-addon-api": "^8.5.0"
+  }
+}

--- a/daemon/native/ccsm_native/src/ccsm_native.cc
+++ b/daemon/native/ccsm_native/src/ccsm_native.cc
@@ -1,0 +1,84 @@
+// ccsm_native — N-API entry point.
+//
+// Spec: docs/superpowers/specs/v0.3-fragments/frag-3.5.1-pty-hardening.md
+//   §3.5.1.1.a   "Native binding swap interface (lockin-P0-2)"
+//
+// Single-responsibility: this translation unit is the napi `Init`
+// dispatcher. It owns NO syscall logic — it forwards to per-surface
+// `Register*` functions implemented in surface-specific .cc files.
+// Every surface's per-platform implementation lives in either
+// <surface>_<platform>.cc (real impl) or <surface>_stub.cc (throws
+// `code: 'ENOSYS'` so the JS layer's "MUST throw on the wrong
+// platform" contract is honoured at the binding layer too — no
+// surface ever silently no-ops at the native level).
+//
+// Export shape (consumed by `daemon/src/native/index.ts` shim):
+//
+//   {
+//     winjob:   { create(): JobHandle, assign(h, pid), terminate(h, code) },
+//     pipeAcl:  { applyOwnerOnly(pipePath: string): void },
+//     pdeathsig:{ armSelf(signal: number): void },
+//     peerCred: {
+//       getNamedPipeClientProcessId(socket): number,   // win32 only
+//       openProcessTokenUserSid(pid): string,          // win32 only
+//       getsockoptPeerCred(socket): { uid, gid, pid }, // linux only
+//       getpeereid(socket): { uid, gid },              // darwin only
+//     },
+//     sigchld:  {
+//       subscribe(handler: () => void): () => void,    // POSIX only
+//       waitpid(pid: number): WaitpidResult,           // POSIX only
+//     },
+//   }
+//
+// Per-platform availability is documented in the per-surface header
+// `surfaces.h`. The JS shim narrows the type at runtime by
+// `process.platform`.
+
+#include <napi.h>
+
+#include "surfaces.h"
+
+namespace ccsm_n {
+
+Napi::Object Init(Napi::Env env, Napi::Object exports) {
+  Napi::Object winjob = Napi::Object::New(env);
+  RegisterWinjob(env, winjob);
+  exports.Set("winjob", winjob);
+
+  Napi::Object pipeAcl = Napi::Object::New(env);
+  RegisterPipeAcl(env, pipeAcl);
+  exports.Set("pipeAcl", pipeAcl);
+
+  Napi::Object pdeathsig = Napi::Object::New(env);
+  RegisterPdeathsig(env, pdeathsig);
+  exports.Set("pdeathsig", pdeathsig);
+
+  Napi::Object peerCred = Napi::Object::New(env);
+  RegisterPeerCred(env, peerCred);
+  exports.Set("peerCred", peerCred);
+
+  Napi::Object sigchld = Napi::Object::New(env);
+  RegisterSigchld(env, sigchld);
+  exports.Set("sigchld", sigchld);
+
+  // Cheap version probe so the JS shim can sanity-check the loaded
+  // .node matches the expected ABI shape. Bumped manually whenever
+  // the export surface changes.
+  exports.Set("bindingVersion", Napi::String::New(env, "0.3.0"));
+
+  return exports;
+}
+
+}  // namespace ccsm_n
+
+// File-scope shim — NODE_API_MODULE concatenates `__napi_` with the
+// regfunc token, which forbids qualified names like `ccsm_n::Init`.
+// We expose `InitModule` at the global namespace and forward into the
+// namespaced implementation. Spec note: keeping the implementation in
+// the namespace preserves single-responsibility (file-scope shim is
+// the only piece that touches macros).
+static Napi::Object InitModule(Napi::Env env, Napi::Object exports) {
+  return ccsm_n::Init(env, exports);
+}
+
+NODE_API_MODULE(ccsm_native, InitModule)

--- a/daemon/native/ccsm_native/src/pdeathsig_linux.cc
+++ b/daemon/native/ccsm_native/src/pdeathsig_linux.cc
@@ -1,0 +1,59 @@
+// pdeathsig — Linux PR_SET_PDEATHSIG self-arm.
+//
+// Spec: frag-3.5.1 §3.5.1.2 (POSIX process group + SIGCHLD wiring).
+//
+// One export: `armSelf(signal: number): void`. The Linux kernel
+// signals the calling process with `signal` when its parent dies.
+// Per spec, the daemon arms its OWN children right after fork (the
+// node-pty spawn hook); but since we run inside the daemon process
+// and node-pty does not currently expose a post-fork pre-exec hook
+// in JS-land, the practical wiring documented in spec §3.5.1.2
+// "Linux PDEATHSIG" is to arm pdeathsig **on the parent's behalf
+// inside the child** — which from the binding's POV is the same
+// syscall called from the calling thread.
+//
+// In v0.3 we expose `armSelf(signal)` so the call site can be
+// `prctl(PR_SET_PDEATHSIG, SIGTERM)` from whichever context is
+// appropriate (the JS-side wrapper documents which one it is).
+
+#include <sys/prctl.h>
+#include <errno.h>
+#include <string.h>
+
+#include <string>
+
+#include "surfaces.h"
+
+namespace ccsm_n {
+
+namespace {
+
+Napi::Value PdeathsigArmSelf(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 1 || !info[0].IsNumber()) {
+    Napi::TypeError::New(env, "pdeathsig.armSelf(signal: number)")
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  int sig = info[0].As<Napi::Number>().Int32Value();
+  if (prctl(PR_SET_PDEATHSIG, sig, 0, 0, 0) != 0) {
+    int err = errno;
+    Napi::Error e = Napi::Error::New(
+        env,
+        std::string("prctl(PR_SET_PDEATHSIG) failed: ") + strerror(err));
+    e.Set("code", Napi::String::New(env, "EPRCTL"));
+    e.Set("errno", Napi::Number::New(env, err));
+    e.ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  return env.Undefined();
+}
+
+}  // namespace
+
+void RegisterPdeathsig(Napi::Env env, Napi::Object exports) {
+  exports.Set("armSelf",
+              Napi::Function::New(env, PdeathsigArmSelf, "armSelf"));
+}
+
+}  // namespace ccsm_n

--- a/daemon/native/ccsm_native/src/pdeathsig_stub.cc
+++ b/daemon/native/ccsm_native/src/pdeathsig_stub.cc
@@ -1,0 +1,22 @@
+// pdeathsig — non-Linux stub. Throws ENOSYS on macOS / Windows. The
+// macOS analogue (kqueue NOTE_EXIT) is documented in spec §3.5.1.2
+// "macOS parent-watch" as deferred — the v0.3 path relies on the
+// supervisor's cold-restart pgid-SIGKILL sweep.
+
+#include "surfaces.h"
+
+namespace ccsm_n {
+
+void RegisterPdeathsig(Napi::Env env, Napi::Object exports) {
+  exports.Set(
+      "armSelf",
+      Napi::Function::New(
+          env,
+          [](const Napi::CallbackInfo& i) {
+            ThrowEnosys(i.Env(), "pdeathsig", "armSelf");
+            return i.Env().Null();
+          },
+          "armSelf"));
+}
+
+}  // namespace ccsm_n

--- a/daemon/native/ccsm_native/src/peercred_darwin.cc
+++ b/daemon/native/ccsm_native/src/peercred_darwin.cc
@@ -1,0 +1,90 @@
+// peerCred — Darwin / macOS getpeereid.
+//
+// Spec: frag-3.4.1 §3.4.1.j, v0.3-design §3.1.1.
+//
+// One Darwin export: `getpeereid(socket): { uid, gid }`. Extracts the
+// underlying fd from `socket._handle.fd` and calls `getpeereid(fd,
+// &uid, &gid)`. Note: getpeereid does NOT return a pid; callers (the
+// `verifyPeerCred` decider) MUST treat `peer.pid` as undefined on
+// this platform.
+
+#include <sys/types.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+
+#include <string>
+
+#include "surfaces.h"
+
+namespace ccsm_n {
+
+namespace {
+
+int ExtractFdFromSocket(Napi::Env env, const Napi::Value& v) {
+  if (!v.IsObject()) {
+    Napi::TypeError::New(env, "peerCred: socket arg must be a net.Socket")
+        .ThrowAsJavaScriptException();
+    return -1;
+  }
+  Napi::Object sock = v.As<Napi::Object>();
+  Napi::Value handleVal = sock.Get("_handle");
+  if (!handleVal.IsObject()) {
+    Napi::TypeError::New(env,
+                         "peerCred: socket._handle missing (socket destroyed?)")
+        .ThrowAsJavaScriptException();
+    return -1;
+  }
+  Napi::Value fdVal = handleVal.As<Napi::Object>().Get("fd");
+  if (!fdVal.IsNumber()) {
+    Napi::TypeError::New(env,
+                         "peerCred: socket._handle.fd missing or non-numeric")
+        .ThrowAsJavaScriptException();
+    return -1;
+  }
+  int fd = fdVal.As<Napi::Number>().Int32Value();
+  if (fd < 0) {
+    Napi::Error e = Napi::Error::New(env, "peerCred: socket fd is closed (-1)");
+    e.Set("code", Napi::String::New(env, "EBADF"));
+    e.ThrowAsJavaScriptException();
+    return -1;
+  }
+  return fd;
+}
+
+Napi::Value GetpeereidFn(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 1) {
+    Napi::TypeError::New(env, "peerCred.getpeereid(socket)")
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  int fd = ExtractFdFromSocket(env, info[0]);
+  if (fd < 0) return env.Null();
+
+  uid_t uid = 0;
+  gid_t gid = 0;
+  if (getpeereid(fd, &uid, &gid) != 0) {
+    int err = errno;
+    Napi::Error e = Napi::Error::New(
+        env, std::string("getpeereid failed: ") + strerror(err));
+    e.Set("code", Napi::String::New(env, "EGETPEEREID"));
+    e.Set("errno", Napi::Number::New(env, err));
+    e.ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  Napi::Object out = Napi::Object::New(env);
+  out.Set("uid", Napi::Number::New(env, static_cast<double>(uid)));
+  out.Set("gid", Napi::Number::New(env, static_cast<double>(gid)));
+  return out;
+}
+
+}  // namespace
+
+void RegisterPeerCred(Napi::Env env, Napi::Object exports) {
+  exports.Set("getpeereid",
+              Napi::Function::New(env, GetpeereidFn, "getpeereid"));
+}
+
+}  // namespace ccsm_n

--- a/daemon/native/ccsm_native/src/peercred_linux.cc
+++ b/daemon/native/ccsm_native/src/peercred_linux.cc
@@ -1,0 +1,99 @@
+// peerCred — Linux SO_PEERCRED.
+//
+// Spec: frag-3.4.1 §3.4.1.j, v0.3-design §3.1.1.
+//
+// One Linux export: `getsockoptPeerCred(socket): { uid, gid, pid }`.
+// Extracts the underlying fd from `socket._handle.fd` (libuv stores
+// the fd as a JS number on the handle object) and calls
+// `getsockopt(fd, SOL_SOCKET, SO_PEERCRED)`.
+
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+
+#include <string>
+
+#include "surfaces.h"
+
+namespace ccsm_n {
+
+namespace {
+
+int ExtractFdFromSocket(Napi::Env env, const Napi::Value& v) {
+  if (!v.IsObject()) {
+    Napi::TypeError::New(env, "peerCred: socket arg must be a net.Socket")
+        .ThrowAsJavaScriptException();
+    return -1;
+  }
+  Napi::Object sock = v.As<Napi::Object>();
+  Napi::Value handleVal = sock.Get("_handle");
+  if (!handleVal.IsObject()) {
+    Napi::TypeError::New(env,
+                         "peerCred: socket._handle missing (socket destroyed?)")
+        .ThrowAsJavaScriptException();
+    return -1;
+  }
+  Napi::Value fdVal = handleVal.As<Napi::Object>().Get("fd");
+  if (!fdVal.IsNumber()) {
+    Napi::TypeError::New(env,
+                         "peerCred: socket._handle.fd missing or non-numeric")
+        .ThrowAsJavaScriptException();
+    return -1;
+  }
+  int fd = fdVal.As<Napi::Number>().Int32Value();
+  if (fd < 0) {
+    Napi::Error e = Napi::Error::New(env, "peerCred: socket fd is closed (-1)");
+    e.Set("code", Napi::String::New(env, "EBADF"));
+    e.ThrowAsJavaScriptException();
+    return -1;
+  }
+  return fd;
+}
+
+Napi::Value GetsockoptPeerCredFn(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 1) {
+    Napi::TypeError::New(env, "peerCred.getsockoptPeerCred(socket)")
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  int fd = ExtractFdFromSocket(env, info[0]);
+  if (fd < 0) return env.Null();
+
+  struct ucred cred;
+  socklen_t len = sizeof(cred);
+  if (getsockopt(fd, SOL_SOCKET, SO_PEERCRED, &cred, &len) != 0) {
+    int err = errno;
+    Napi::Error e = Napi::Error::New(
+        env,
+        std::string("getsockopt(SO_PEERCRED) failed: ") + strerror(err));
+    e.Set("code", Napi::String::New(env, "EGETSOCKOPT"));
+    e.Set("errno", Napi::Number::New(env, err));
+    e.ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  Napi::Object out = Napi::Object::New(env);
+  out.Set("uid", Napi::Number::New(env, static_cast<double>(cred.uid)));
+  out.Set("gid", Napi::Number::New(env, static_cast<double>(cred.gid)));
+  out.Set("pid", Napi::Number::New(env, static_cast<double>(cred.pid)));
+  return out;
+}
+
+}  // namespace
+
+void RegisterPeerCred(Napi::Env env, Napi::Object exports) {
+  exports.Set("getsockoptPeerCred",
+              Napi::Function::New(env, GetsockoptPeerCredFn,
+                                  "getsockoptPeerCred"));
+  // Win32-only and darwin-only methods are NOT registered on Linux —
+  // the JS shim narrows by `process.platform`. If a misconfigured
+  // call site reaches for `getNamedPipeClientProcessId` on Linux it
+  // gets `undefined` (calling it throws JS-side TypeError, which the
+  // peer-cred-verify decider already catches and converts to a clear
+  // "wire ccsm_native (frag-11)" error).
+}
+
+}  // namespace ccsm_n

--- a/daemon/native/ccsm_native/src/peercred_win.cc
+++ b/daemon/native/ccsm_native/src/peercred_win.cc
@@ -1,0 +1,197 @@
+// peerCred — Win32 named-pipe peer identity (SID).
+//
+// Spec: frag-3.4.1 §3.4.1.j, v0.3-design §3.1.1.
+//
+// Two exports for Win:
+//
+//   getNamedPipeClientProcessId(socket): number
+//      socket._handle.fd  →  HANDLE  →  GetNamedPipeClientProcessId
+//
+//   openProcessTokenUserSid(pid: number): string
+//      OpenProcess(QUERY_LIMITED_INFORMATION) →
+//      OpenProcessToken(TOKEN_QUERY) →
+//      GetTokenInformation(TokenUser) →
+//      ConvertSidToStringSidW
+//
+// Socket handle extraction note:
+//
+// The spec docstring on `daemon/src/sockets/peer-cred-verify.ts` says
+// "the binding extracts the OS handle via `socket._handle.fd` (or the
+// equivalent N-API accessor)". libuv pipes expose their HANDLE on
+// `socket._handle.fd` as a number whose value is the raw HANDLE bit
+// pattern (libuv internal contract; uv_pipe_t.handle is HANDLE). We
+// validate the number is non-negative and a finite integer and cast.
+// The JS shim is the only legitimate caller and is the one place that
+// owns this assumption.
+
+#include <windows.h>
+#include <sddl.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "surfaces.h"
+
+namespace ccsm_n {
+
+namespace {
+
+HANDLE ExtractHandleFromSocket(Napi::Env env, const Napi::Value& v) {
+  if (!v.IsObject()) {
+    Napi::TypeError::New(env, "peerCred: socket arg must be a net.Socket")
+        .ThrowAsJavaScriptException();
+    return INVALID_HANDLE_VALUE;
+  }
+  Napi::Object sock = v.As<Napi::Object>();
+  Napi::Value handleVal = sock.Get("_handle");
+  if (!handleVal.IsObject()) {
+    Napi::TypeError::New(env,
+                         "peerCred: socket._handle missing (socket destroyed?)")
+        .ThrowAsJavaScriptException();
+    return INVALID_HANDLE_VALUE;
+  }
+  Napi::Value fdVal = handleVal.As<Napi::Object>().Get("fd");
+  if (!fdVal.IsNumber()) {
+    Napi::TypeError::New(env,
+                         "peerCred: socket._handle.fd missing or non-numeric")
+        .ThrowAsJavaScriptException();
+    return INVALID_HANDLE_VALUE;
+  }
+  // libuv stores HANDLE bit pattern in the JS number; on 32-bit Node the
+  // upper 32 bits are zero. We accept up to int64 (fd may be -1 sentinel
+  // on a closed handle, which we treat as INVALID_HANDLE_VALUE).
+  int64_t raw = fdVal.As<Napi::Number>().Int64Value();
+  if (raw < 0) {
+    Napi::Error e = Napi::Error::New(env,
+                                     "peerCred: socket fd is closed (-1)");
+    e.Set("code", Napi::String::New(env, "EBADF"));
+    e.ThrowAsJavaScriptException();
+    return INVALID_HANDLE_VALUE;
+  }
+  return reinterpret_cast<HANDLE>(static_cast<intptr_t>(raw));
+}
+
+Napi::Value GetNamedPipeClientProcessIdFn(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 1) {
+    Napi::TypeError::New(env,
+                         "peerCred.getNamedPipeClientProcessId(socket)")
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  HANDLE pipe = ExtractHandleFromSocket(env, info[0]);
+  if (pipe == INVALID_HANDLE_VALUE) return env.Null();
+
+  ULONG pid = 0;
+  if (!GetNamedPipeClientProcessId(pipe, &pid)) {
+    DWORD err = GetLastError();
+    Napi::Error e = Napi::Error::New(
+        env, std::string("GetNamedPipeClientProcessId failed: code=") +
+                 std::to_string(err));
+    e.Set("code", Napi::String::New(env, "EWINAPI"));
+    e.Set("winErr", Napi::Number::New(env, static_cast<double>(err)));
+    e.ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  return Napi::Number::New(env, static_cast<double>(pid));
+}
+
+Napi::Value OpenProcessTokenUserSidFn(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 1 || !info[0].IsNumber()) {
+    Napi::TypeError::New(env,
+                         "peerCred.openProcessTokenUserSid(pid: number)")
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  DWORD pid = static_cast<DWORD>(info[0].As<Napi::Number>().Uint32Value());
+
+  HANDLE proc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+  if (proc == nullptr) {
+    DWORD err = GetLastError();
+    Napi::Error e = Napi::Error::New(
+        env, std::string("OpenProcess(pid=") + std::to_string(pid) +
+                 ") failed: code=" + std::to_string(err));
+    e.Set("code", Napi::String::New(env, "EWINAPI"));
+    e.Set("winErr", Napi::Number::New(env, static_cast<double>(err)));
+    e.ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  HANDLE token = nullptr;
+  if (!OpenProcessToken(proc, TOKEN_QUERY, &token)) {
+    DWORD err = GetLastError();
+    CloseHandle(proc);
+    Napi::Error e = Napi::Error::New(
+        env, std::string("OpenProcessToken failed: code=") + std::to_string(err));
+    e.Set("code", Napi::String::New(env, "EWINAPI"));
+    e.Set("winErr", Napi::Number::New(env, static_cast<double>(err)));
+    e.ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  CloseHandle(proc);
+
+  DWORD tuLen = 0;
+  GetTokenInformation(token, TokenUser, nullptr, 0, &tuLen);
+  if (tuLen == 0) {
+    DWORD err = GetLastError();
+    CloseHandle(token);
+    Napi::Error e = Napi::Error::New(
+        env,
+        std::string("GetTokenInformation(size) failed: code=") + std::to_string(err));
+    e.Set("code", Napi::String::New(env, "EWINAPI"));
+    e.Set("winErr", Napi::Number::New(env, static_cast<double>(err)));
+    e.ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  std::vector<BYTE> tuBuf(tuLen);
+  if (!GetTokenInformation(token, TokenUser, tuBuf.data(), tuLen, &tuLen)) {
+    DWORD err = GetLastError();
+    CloseHandle(token);
+    Napi::Error e = Napi::Error::New(
+        env, std::string("GetTokenInformation failed: code=") + std::to_string(err));
+    e.Set("code", Napi::String::New(env, "EWINAPI"));
+    e.Set("winErr", Napi::Number::New(env, static_cast<double>(err)));
+    e.ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  CloseHandle(token);
+
+  PSID userSid = reinterpret_cast<TOKEN_USER*>(tuBuf.data())->User.Sid;
+  LPWSTR sidStr = nullptr;
+  if (!ConvertSidToStringSidW(userSid, &sidStr)) {
+    DWORD err = GetLastError();
+    Napi::Error e = Napi::Error::New(
+        env, std::string("ConvertSidToStringSid failed: code=") +
+                 std::to_string(err));
+    e.Set("code", Napi::String::New(env, "EWINAPI"));
+    e.Set("winErr", Napi::Number::New(env, static_cast<double>(err)));
+    e.ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  // sidStr is LPWSTR (UTF-16); convert to UTF-8 std::string for JS.
+  int needed = WideCharToMultiByte(CP_UTF8, 0, sidStr, -1, nullptr, 0,
+                                   nullptr, nullptr);
+  std::string out(static_cast<size_t>(needed > 0 ? needed - 1 : 0), '\0');
+  if (needed > 0) {
+    WideCharToMultiByte(CP_UTF8, 0, sidStr, -1, out.data(), needed,
+                        nullptr, nullptr);
+  }
+  LocalFree(sidStr);
+  return Napi::String::New(env, out);
+}
+
+}  // namespace
+
+void RegisterPeerCred(Napi::Env env, Napi::Object exports) {
+  exports.Set(
+      "getNamedPipeClientProcessId",
+      Napi::Function::New(env, GetNamedPipeClientProcessIdFn,
+                          "getNamedPipeClientProcessId"));
+  exports.Set("openProcessTokenUserSid",
+              Napi::Function::New(env, OpenProcessTokenUserSidFn,
+                                  "openProcessTokenUserSid"));
+}
+
+}  // namespace ccsm_n

--- a/daemon/native/ccsm_native/src/pipeacl_stub.cc
+++ b/daemon/native/ccsm_native/src/pipeacl_stub.cc
@@ -1,0 +1,19 @@
+// pipeAcl — non-Win32 stub. Throws ENOSYS.
+
+#include "surfaces.h"
+
+namespace ccsm_n {
+
+void RegisterPipeAcl(Napi::Env env, Napi::Object exports) {
+  exports.Set(
+      "applyOwnerOnly",
+      Napi::Function::New(
+          env,
+          [](const Napi::CallbackInfo& i) {
+            ThrowEnosys(i.Env(), "pipeAcl", "applyOwnerOnly");
+            return i.Env().Null();
+          },
+          "applyOwnerOnly"));
+}
+
+}  // namespace ccsm_n

--- a/daemon/native/ccsm_native/src/pipeacl_win.cc
+++ b/daemon/native/ccsm_native/src/pipeacl_win.cc
@@ -1,0 +1,200 @@
+// pipeAcl — Win32 named-pipe DACL hardening.
+//
+// Spec: frag-3.5.1 §3.5.1.6 + frag-6-7 §7.M1.
+//
+// One export: `applyOwnerOnly(pipePath: string): void`. The five
+// syscalls listed in `daemon/src/pty/pipe-acl.ts` (token query, ACL
+// build, deny ACEs for BUILTIN\Users + ANONYMOUS LOGON, set DACL,
+// PIPE_REJECT_REMOTE_CLIENTS) all happen inside this single call so
+// JS never observes an intermediate-DACL state.
+
+#include <windows.h>
+#include <aclapi.h>
+#include <sddl.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "surfaces.h"
+
+namespace ccsm_n {
+
+namespace {
+
+struct LocalDeleter {
+  void operator()(void* p) const noexcept {
+    if (p != nullptr) ::LocalFree(p);
+  }
+};
+
+template <typename T>
+using LocalPtr = std::unique_ptr<T, LocalDeleter>;
+
+// Convert a UTF-8 std::string to a UTF-16 std::wstring suitable for
+// CreateFileW / pipe APIs. Empty input yields empty output.
+std::wstring Utf8ToWide(const std::string& s) {
+  if (s.empty()) return std::wstring();
+  int needed = MultiByteToWideChar(CP_UTF8, 0, s.data(),
+                                   static_cast<int>(s.size()), nullptr, 0);
+  std::wstring out(static_cast<size_t>(needed), L'\0');
+  MultiByteToWideChar(CP_UTF8, 0, s.data(), static_cast<int>(s.size()),
+                      out.data(), needed);
+  return out;
+}
+
+// ThrowWinErr: convert a Win32 error code into a JS Error with
+// `code: 'EWINAPI'`. Returns env.Null() so callers can `return`.
+Napi::Value ThrowWinErr(Napi::Env env, const char* op, DWORD err) {
+  Napi::Error e = Napi::Error::New(
+      env,
+      std::string("pipeAcl.") + op + " failed: code=" + std::to_string(err));
+  e.Set("code", Napi::String::New(env, "EWINAPI"));
+  e.Set("winErr", Napi::Number::New(env, static_cast<double>(err)));
+  e.ThrowAsJavaScriptException();
+  return env.Null();
+}
+
+Napi::Value PipeAclApplyOwnerOnly(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 1 || !info[0].IsString()) {
+    Napi::TypeError::New(env, "pipeAcl.applyOwnerOnly(pipePath: string)")
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  std::string pipePath = info[0].As<Napi::String>().Utf8Value();
+  std::wstring wpipe = Utf8ToWide(pipePath);
+
+  // Open the pipe with WRITE_DAC so SetSecurityInfo can replace the
+  // DACL. The pipe must already exist (created by `net.Server.listen`).
+  HANDLE pipe = CreateFileW(wpipe.c_str(),
+                            WRITE_DAC | READ_CONTROL,
+                            FILE_SHARE_READ | FILE_SHARE_WRITE,
+                            nullptr,
+                            OPEN_EXISTING,
+                            0,
+                            nullptr);
+  if (pipe == INVALID_HANDLE_VALUE) {
+    return ThrowWinErr(env, "CreateFile(pipe)", GetLastError());
+  }
+
+  // 1. Resolve current process user SID.
+  HANDLE token = nullptr;
+  if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &token)) {
+    DWORD err = GetLastError();
+    CloseHandle(pipe);
+    return ThrowWinErr(env, "OpenProcessToken", err);
+  }
+  DWORD tuLen = 0;
+  GetTokenInformation(token, TokenUser, nullptr, 0, &tuLen);
+  if (tuLen == 0) {
+    DWORD err = GetLastError();
+    CloseHandle(token);
+    CloseHandle(pipe);
+    return ThrowWinErr(env, "GetTokenInformation(size)", err);
+  }
+  std::vector<BYTE> tuBuf(tuLen);
+  if (!GetTokenInformation(token, TokenUser, tuBuf.data(), tuLen, &tuLen)) {
+    DWORD err = GetLastError();
+    CloseHandle(token);
+    CloseHandle(pipe);
+    return ThrowWinErr(env, "GetTokenInformation", err);
+  }
+  CloseHandle(token);
+  PSID userSid = reinterpret_cast<TOKEN_USER*>(tuBuf.data())->User.Sid;
+
+  // 2. Build BUILTIN\Users + ANONYMOUS LOGON SIDs for explicit deny.
+  PSID usersSid = nullptr;
+  PSID anonSid = nullptr;
+  SID_IDENTIFIER_AUTHORITY ntAuth = SECURITY_NT_AUTHORITY;
+  if (!AllocateAndInitializeSid(&ntAuth, 2,
+                                SECURITY_BUILTIN_DOMAIN_RID,
+                                DOMAIN_ALIAS_RID_USERS, 0, 0, 0, 0, 0, 0,
+                                &usersSid)) {
+    DWORD err = GetLastError();
+    CloseHandle(pipe);
+    return ThrowWinErr(env, "AllocateSid(Users)", err);
+  }
+  if (!AllocateAndInitializeSid(&ntAuth, 1,
+                                SECURITY_ANONYMOUS_LOGON_RID,
+                                0, 0, 0, 0, 0, 0, 0,
+                                &anonSid)) {
+    DWORD err = GetLastError();
+    FreeSid(usersSid);
+    CloseHandle(pipe);
+    return ThrowWinErr(env, "AllocateSid(Anonymous)", err);
+  }
+
+  // 3. Build a fresh DACL with one allow + two deny ACEs.
+  EXPLICIT_ACCESSW eas[3];
+  ZeroMemory(eas, sizeof(eas));
+  eas[0].grfAccessPermissions = GENERIC_READ | GENERIC_WRITE;
+  eas[0].grfAccessMode = SET_ACCESS;
+  eas[0].grfInheritance = NO_INHERITANCE;
+  eas[0].Trustee.TrusteeForm = TRUSTEE_IS_SID;
+  eas[0].Trustee.TrusteeType = TRUSTEE_IS_USER;
+  eas[0].Trustee.ptstrName = reinterpret_cast<LPWSTR>(userSid);
+
+  eas[1].grfAccessPermissions = GENERIC_ALL;
+  eas[1].grfAccessMode = DENY_ACCESS;
+  eas[1].grfInheritance = NO_INHERITANCE;
+  eas[1].Trustee.TrusteeForm = TRUSTEE_IS_SID;
+  eas[1].Trustee.TrusteeType = TRUSTEE_IS_GROUP;
+  eas[1].Trustee.ptstrName = reinterpret_cast<LPWSTR>(usersSid);
+
+  eas[2].grfAccessPermissions = GENERIC_ALL;
+  eas[2].grfAccessMode = DENY_ACCESS;
+  eas[2].grfInheritance = NO_INHERITANCE;
+  eas[2].Trustee.TrusteeForm = TRUSTEE_IS_SID;
+  eas[2].Trustee.TrusteeType = TRUSTEE_IS_USER;
+  eas[2].Trustee.ptstrName = reinterpret_cast<LPWSTR>(anonSid);
+
+  PACL acl = nullptr;
+  DWORD setErr = SetEntriesInAclW(3, eas, nullptr, &acl);
+  FreeSid(usersSid);
+  FreeSid(anonSid);
+  if (setErr != ERROR_SUCCESS) {
+    CloseHandle(pipe);
+    return ThrowWinErr(env, "SetEntriesInAcl", setErr);
+  }
+  LocalPtr<ACL> aclGuard(acl);
+
+  // 4. Apply the new DACL to the pipe handle.
+  DWORD si = SetSecurityInfo(pipe, SE_KERNEL_OBJECT,
+                             DACL_SECURITY_INFORMATION |
+                                 PROTECTED_DACL_SECURITY_INFORMATION,
+                             nullptr, nullptr, acl, nullptr);
+  if (si != ERROR_SUCCESS) {
+    CloseHandle(pipe);
+    return ThrowWinErr(env, "SetSecurityInfo", si);
+  }
+
+  // 5. Reject remote clients on the pipe state.
+  DWORD pipeMode = PIPE_REJECT_REMOTE_CLIENTS;
+  // SetNamedPipeHandleState's first parameter must be a pipe state
+  // word. We do NOT change PIPE_READMODE_*; pass a value of 0 to
+  // mean "don't change" via NULL pointer below.
+  if (!SetNamedPipeHandleState(pipe, &pipeMode, nullptr, nullptr)) {
+    DWORD err = GetLastError();
+    // SetNamedPipeHandleState returning ERROR_ACCESS_DENIED on a pipe
+    // we just hardened the DACL of is the expected "we already locked
+    // ourselves out of mode-change" state and is not fatal; the DACL
+    // is already applied. We surface anything else as a hard error.
+    if (err != ERROR_ACCESS_DENIED) {
+      CloseHandle(pipe);
+      return ThrowWinErr(env, "SetNamedPipeHandleState", err);
+    }
+  }
+
+  CloseHandle(pipe);
+  return env.Undefined();
+}
+
+}  // namespace
+
+void RegisterPipeAcl(Napi::Env env, Napi::Object exports) {
+  exports.Set("applyOwnerOnly",
+              Napi::Function::New(env, PipeAclApplyOwnerOnly, "applyOwnerOnly"));
+}
+
+}  // namespace ccsm_n

--- a/daemon/native/ccsm_native/src/sigchld_stub.cc
+++ b/daemon/native/ccsm_native/src/sigchld_stub.cc
@@ -1,0 +1,31 @@
+// sigchld — non-POSIX stub (Win32). SIGCHLD does not exist on
+// Windows; PTY exit is observed via node-pty's `onExit` (which polls
+// `GetExitCodeProcess`) + the JobObject path (winjob_win.cc).
+// Throws ENOSYS on every call.
+
+#include "surfaces.h"
+
+namespace ccsm_n {
+
+void RegisterSigchld(Napi::Env env, Napi::Object exports) {
+  exports.Set(
+      "subscribe",
+      Napi::Function::New(
+          env,
+          [](const Napi::CallbackInfo& i) {
+            ThrowEnosys(i.Env(), "sigchld", "subscribe");
+            return i.Env().Null();
+          },
+          "subscribe"));
+  exports.Set(
+      "waitpid",
+      Napi::Function::New(
+          env,
+          [](const Napi::CallbackInfo& i) {
+            ThrowEnosys(i.Env(), "sigchld", "waitpid");
+            return i.Env().Null();
+          },
+          "waitpid"));
+}
+
+}  // namespace ccsm_n

--- a/daemon/native/ccsm_native/src/sigchld_unix.cc
+++ b/daemon/native/ccsm_native/src/sigchld_unix.cc
@@ -1,0 +1,193 @@
+// sigchld — POSIX SIGCHLD subscription + per-PID waitpid.
+//
+// Spec: frag-3.5.1 §3.5.1.2 (POSIX process group + SIGCHLD wiring).
+//
+// Two POSIX exports:
+//
+//   subscribe(handler: () => void): () => void
+//      Wraps `uv_signal_t` against the Node event loop so SIGCHLD
+//      delivery surfaces as a normal libuv callback (no
+//      async-signal-safety concerns from a sigaction callback). The
+//      returned function detaches the subscription.
+//
+//   waitpid(pid: number): { state, exitCode?, signal? }
+//      `waitpid(pid, &status, WNOHANG)`. Per spec: per-PID scope,
+//      WNOHANG mandatory, never reaps PIDs the daemon does not own.
+//
+// Why uv_signal_t and not sigaction directly: the libuv handle does
+// the right thing with multiple subscribers (we install one), runs
+// the callback on the event loop thread (so calling into JS is
+// safe), and is tested against signal coalescing inside libuv. The
+// JS-side `installSigchldReaper` (T38) iterates registered PIDs on
+// every callback exactly because POSIX coalesces SIGCHLD — we
+// preserve that contract.
+
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <signal.h>
+#include <errno.h>
+#include <string.h>
+
+#include <memory>
+#include <string>
+
+#include <uv.h>
+
+#include "surfaces.h"
+
+namespace ccsm_n {
+
+namespace {
+
+// One subscription = one uv_signal_t + one persistent JS callback.
+// The daemon installs this exactly once at boot per spec; we permit
+// multiple concurrent subscriptions (e.g. tests) by tracking each in
+// its own heap-allocated holder.
+struct Sub {
+  uv_signal_t handle{};
+  Napi::FunctionReference cb;
+  bool detached = false;
+};
+
+void OnSigchld(uv_signal_t* h, int /*signum*/) {
+  auto* sub = static_cast<Sub*>(h->data);
+  if (sub == nullptr || sub->detached) return;
+  if (sub->cb.IsEmpty()) return;
+  Napi::Env env = sub->cb.Env();
+  Napi::HandleScope scope(env);
+  // The JS callback is `() => void` per spec — pure producer; any
+  // throw bubbles to the libuv loop's unhandled-error sink.
+  sub->cb.Call({});
+}
+
+void OnCloseFreeSub(uv_handle_t* h) {
+  auto* sub = static_cast<Sub*>(h->data);
+  delete sub;
+}
+
+Napi::Value SubscribeFn(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 1 || !info[0].IsFunction()) {
+    Napi::TypeError::New(env, "sigchld.subscribe(handler: () => void)")
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  uv_loop_t* loop = nullptr;
+  napi_status st = napi_get_uv_event_loop(env, &loop);
+  if (st != napi_ok || loop == nullptr) {
+    Napi::Error::New(env, "sigchld.subscribe: napi_get_uv_event_loop failed")
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  auto sub = std::make_unique<Sub>();
+  sub->cb = Napi::Persistent(info[0].As<Napi::Function>());
+  sub->handle.data = sub.get();
+
+  if (uv_signal_init(loop, &sub->handle) != 0) {
+    Napi::Error::New(env, "sigchld.subscribe: uv_signal_init failed")
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  if (uv_signal_start(&sub->handle, OnSigchld, SIGCHLD) != 0) {
+    uv_close(reinterpret_cast<uv_handle_t*>(&sub->handle),
+             [](uv_handle_t* h) {
+               auto* s = static_cast<Sub*>(h->data);
+               delete s;
+             });
+    sub.release();  // freed in the close cb
+    Napi::Error::New(env, "sigchld.subscribe: uv_signal_start failed")
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  // Don't let the signal handle keep the event loop alive on its
+  // own. The daemon has plenty of other refs (server, timers); this
+  // matches the contract that the reaper does not by itself prevent
+  // process exit.
+  uv_unref(reinterpret_cast<uv_handle_t*>(&sub->handle));
+
+  Sub* raw = sub.release();
+
+  // Returned `detach` closure. Closing the handle is async (uv runs
+  // the close cb on the next loop tick) so we mark `detached` first
+  // to swallow any in-flight callbacks.
+  auto detachFn = Napi::Function::New(
+      env, [raw](const Napi::CallbackInfo& cbInfo) -> Napi::Value {
+        Napi::Env e = cbInfo.Env();
+        if (raw->detached) return e.Undefined();
+        raw->detached = true;
+        // Stop the signal first so no new callbacks fire, then close.
+        uv_signal_stop(&raw->handle);
+        uv_close(reinterpret_cast<uv_handle_t*>(&raw->handle),
+                 OnCloseFreeSub);
+        // raw is freed inside OnCloseFreeSub — do NOT touch it after.
+        return e.Undefined();
+      },
+      "detach");
+  return detachFn;
+}
+
+Napi::Value WaitpidFn(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 1 || !info[0].IsNumber()) {
+    Napi::TypeError::New(env, "sigchld.waitpid(pid: number)")
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  pid_t pid = static_cast<pid_t>(info[0].As<Napi::Number>().Int32Value());
+
+  int status = 0;
+  pid_t r = ::waitpid(pid, &status, WNOHANG);
+  Napi::Object out = Napi::Object::New(env);
+  if (r == 0) {
+    out.Set("state", Napi::String::New(env, "no-state-change"));
+    return out;
+  }
+  if (r < 0) {
+    // ECHILD = "no such child or already reaped"; per the JS-side
+    // contract this maps to `no-state-change` (the reaper treats
+    // both kernel outcomes as "nothing to do for this pid right
+    // now"). Other errnos (EINVAL, EINTR) bubble.
+    if (errno == ECHILD) {
+      out.Set("state", Napi::String::New(env, "no-state-change"));
+      return out;
+    }
+    int err = errno;
+    Napi::Error e = Napi::Error::New(
+        env, std::string("waitpid failed: ") + strerror(err));
+    e.Set("code", Napi::String::New(env, "EWAITPID"));
+    e.Set("errno", Napi::Number::New(env, err));
+    e.ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  // r > 0  →  exited. Decode status.
+  out.Set("state", Napi::String::New(env, "exited"));
+  if (WIFEXITED(status)) {
+    out.Set("exitCode",
+            Napi::Number::New(env, static_cast<double>(WEXITSTATUS(status))));
+  } else if (WIFSIGNALED(status)) {
+    int sig = WTERMSIG(status);
+    out.Set("exitCode", Napi::Number::New(env, 0));
+    const char* name = strsignal(sig);
+    out.Set("signal",
+            name != nullptr
+                ? Napi::Value(Napi::String::New(env, name))
+                : Napi::Value(Napi::Number::New(env, sig)));
+  } else {
+    // Stopped/continued etc. — treat as no-state-change. waitpid
+    // without WUNTRACED/WCONTINUED won't actually surface these.
+    out.Set("state", Napi::String::New(env, "no-state-change"));
+  }
+  return out;
+}
+
+}  // namespace
+
+void RegisterSigchld(Napi::Env env, Napi::Object exports) {
+  exports.Set("subscribe",
+              Napi::Function::New(env, SubscribeFn, "subscribe"));
+  exports.Set("waitpid", Napi::Function::New(env, WaitpidFn, "waitpid"));
+}
+
+}  // namespace ccsm_n

--- a/daemon/native/ccsm_native/src/surfaces.h
+++ b/daemon/native/ccsm_native/src/surfaces.h
@@ -1,0 +1,32 @@
+// Surface registration headers.
+//
+// Each `Register*(env, exports)` function attaches the JS-visible
+// methods of one surface onto the supplied object. Per-platform
+// translation units provide either the real implementation or a stub
+// that throws `Error { code: 'ENOSYS' }` on call.
+
+#pragma once
+
+#include <napi.h>
+
+namespace ccsm_n {
+
+void RegisterWinjob(Napi::Env env, Napi::Object exports);
+void RegisterPipeAcl(Napi::Env env, Napi::Object exports);
+void RegisterPdeathsig(Napi::Env env, Napi::Object exports);
+void RegisterPeerCred(Napi::Env env, Napi::Object exports);
+void RegisterSigchld(Napi::Env env, Napi::Object exports);
+
+// Helper: throw a JS Error with `code: 'ENOSYS'` so the JS shim can
+// branch on `err.code === 'ENOSYS'` deterministically. Not a fatal.
+inline void ThrowEnosys(Napi::Env env, const char* surface, const char* op) {
+  Napi::Error err = Napi::Error::New(
+      env,
+      std::string(surface) + "." + op + ": ENOSYS (not supported on this platform)");
+  err.Set("code", Napi::String::New(env, "ENOSYS"));
+  err.Set("surface", Napi::String::New(env, surface));
+  err.Set("op", Napi::String::New(env, op));
+  err.ThrowAsJavaScriptException();
+}
+
+}  // namespace ccsm_n

--- a/daemon/native/ccsm_native/src/winjob_stub.cc
+++ b/daemon/native/ccsm_native/src/winjob_stub.cc
@@ -1,0 +1,45 @@
+// winjob — non-Win32 stub. Throws ENOSYS on every call.
+//
+// The JS shim narrows by `process.platform` and never calls these on
+// POSIX in production. The stub exists so a misconfigured call site
+// fails loud (with `code: 'ENOSYS'`) instead of silently no-oping at
+// the binding boundary.
+
+#include "surfaces.h"
+
+namespace ccsm_n {
+
+namespace {
+
+Napi::Value Enosys(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  ThrowEnosys(env, "winjob",
+              info.Length() > 0 && info[0].IsString()
+                  ? info[0].As<Napi::String>().Utf8Value().c_str()
+                  : "<call>");
+  return env.Null();
+}
+
+}  // namespace
+
+void RegisterWinjob(Napi::Env env, Napi::Object exports) {
+  // We register the same names the Win32 build registers so a
+  // platform-confused JS caller gets a function reference, calls it,
+  // and observes the ENOSYS throw — instead of getting `undefined`
+  // and a cryptic "x is not a function" TypeError.
+  exports.Set("create", Napi::Function::New(env, [](const Napi::CallbackInfo& i) {
+                ThrowEnosys(i.Env(), "winjob", "create");
+                return i.Env().Null();
+              }, "create"));
+  exports.Set("assign", Napi::Function::New(env, [](const Napi::CallbackInfo& i) {
+                ThrowEnosys(i.Env(), "winjob", "assign");
+                return i.Env().Null();
+              }, "assign"));
+  exports.Set("terminate",
+              Napi::Function::New(env, [](const Napi::CallbackInfo& i) {
+                ThrowEnosys(i.Env(), "winjob", "terminate");
+                return i.Env().Null();
+              }, "terminate"));
+}
+
+}  // namespace ccsm_n

--- a/daemon/native/ccsm_native/src/winjob_win.cc
+++ b/daemon/native/ccsm_native/src/winjob_win.cc
@@ -1,0 +1,150 @@
+// winjob — Win32 JobObject helpers.
+//
+// Spec: frag-3.5.1 §3.5.1.1 (Win JobObject wiring).
+//
+// Three syscalls collapsed to three N-API exports:
+//
+//   create()                   -> external pointer (HANDLE)
+//      CreateJobObjectW(NULL, NULL)
+//      SetInformationJobObject(JobObjectExtendedLimitInformation,
+//        { LimitFlags: KILL_ON_JOB_CLOSE | BREAKAWAY_OK })
+//
+//   assign(handle, pid)        -> void
+//      OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, false, pid)
+//      AssignProcessToJobObject(handle, processHandle)
+//      CloseHandle(processHandle)
+//
+//   terminate(handle, code)    -> void
+//      TerminateJobObject(handle, code)
+//
+// Handle lifetime: per §3.5.1.1 "Lifetime", the JobObject HANDLE is
+// allocated once at daemon boot and held for the daemon's whole life
+// — the OS closes it on process exit, which is the trigger for
+// `KILL_ON_JOB_CLOSE`. We therefore return the raw HANDLE to JS as
+// an external pointer (uint64 buffer) and provide NO `close()` /
+// `dispose()` export. JS wraps the lifetime via the `JobObjectHandle`
+// abstraction in `daemon/src/pty/win-jobobject.ts`.
+
+#include <windows.h>
+
+#include "surfaces.h"
+
+namespace ccsm_n {
+
+namespace {
+
+// Externals are wrapped in a Napi::External<HANDLE> so the GC tracks
+// them but never frees the underlying HANDLE (finalizer is a no-op
+// per the lifetime contract above). Using External instead of a
+// uint64 BigInt keeps a JS-side sanity-check trivial: the value is
+// not a number, not a string, and instanceof Object — easy to
+// distinguish from accidental misuse.
+void NoopFinalize(Napi::Env, HANDLE) {
+  // intentionally empty — see file header
+}
+
+Napi::Value WinjobCreate(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  HANDLE job = CreateJobObjectW(nullptr, nullptr);
+  if (job == nullptr) {
+    DWORD err = GetLastError();
+    Napi::Error e = Napi::Error::New(
+        env, "CreateJobObjectW failed: code=" + std::to_string(err));
+    e.Set("code", Napi::String::New(env, "EWINAPI"));
+    e.Set("winErr", Napi::Number::New(env, static_cast<double>(err)));
+    e.ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  JOBOBJECT_EXTENDED_LIMIT_INFORMATION info_eli;
+  ZeroMemory(&info_eli, sizeof(info_eli));
+  info_eli.BasicLimitInformation.LimitFlags =
+      JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE | JOB_OBJECT_LIMIT_BREAKAWAY_OK;
+
+  if (!SetInformationJobObject(job, JobObjectExtendedLimitInformation,
+                               &info_eli, sizeof(info_eli))) {
+    DWORD err = GetLastError();
+    CloseHandle(job);
+    Napi::Error e = Napi::Error::New(
+        env, "SetInformationJobObject failed: code=" + std::to_string(err));
+    e.Set("code", Napi::String::New(env, "EWINAPI"));
+    e.Set("winErr", Napi::Number::New(env, static_cast<double>(err)));
+    e.ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  return Napi::External<void>::New(env, job, NoopFinalize);
+}
+
+Napi::Value WinjobAssign(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 2 || !info[0].IsExternal() || !info[1].IsNumber()) {
+    Napi::TypeError::New(env,
+                         "winjob.assign(handle: External, pid: number)")
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  HANDLE job = info[0].As<Napi::External<void>>().Data();
+  DWORD pid = static_cast<DWORD>(info[1].As<Napi::Number>().Uint32Value());
+
+  HANDLE proc = OpenProcess(
+      PROCESS_SET_QUOTA | PROCESS_TERMINATE, FALSE, pid);
+  if (proc == nullptr) {
+    DWORD err = GetLastError();
+    Napi::Error e = Napi::Error::New(
+        env, "OpenProcess failed for pid=" + std::to_string(pid) +
+                 " code=" + std::to_string(err));
+    e.Set("code", Napi::String::New(env, "EWINAPI"));
+    e.Set("winErr", Napi::Number::New(env, static_cast<double>(err)));
+    e.ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  BOOL ok = AssignProcessToJobObject(job, proc);
+  DWORD err = ok ? 0 : GetLastError();
+  CloseHandle(proc);
+  if (!ok) {
+    Napi::Error e = Napi::Error::New(
+        env, "AssignProcessToJobObject failed for pid=" +
+                 std::to_string(pid) + " code=" + std::to_string(err));
+    e.Set("code", Napi::String::New(env, "EWINAPI"));
+    e.Set("winErr", Napi::Number::New(env, static_cast<double>(err)));
+    e.ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  return env.Undefined();
+}
+
+Napi::Value WinjobTerminate(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 2 || !info[0].IsExternal() || !info[1].IsNumber()) {
+    Napi::TypeError::New(env,
+                         "winjob.terminate(handle: External, exitCode: number)")
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  HANDLE job = info[0].As<Napi::External<void>>().Data();
+  UINT code = static_cast<UINT>(info[1].As<Napi::Number>().Uint32Value());
+
+  if (!TerminateJobObject(job, code)) {
+    DWORD err = GetLastError();
+    Napi::Error e = Napi::Error::New(
+        env, "TerminateJobObject failed: code=" + std::to_string(err));
+    e.Set("code", Napi::String::New(env, "EWINAPI"));
+    e.Set("winErr", Napi::Number::New(env, static_cast<double>(err)));
+    e.ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  return env.Undefined();
+}
+
+}  // namespace
+
+void RegisterWinjob(Napi::Env env, Napi::Object exports) {
+  exports.Set("create", Napi::Function::New(env, WinjobCreate, "create"));
+  exports.Set("assign", Napi::Function::New(env, WinjobAssign, "assign"));
+  exports.Set("terminate",
+              Napi::Function::New(env, WinjobTerminate, "terminate"));
+}
+
+}  // namespace ccsm_n

--- a/daemon/src/native/__tests__/index.test.ts
+++ b/daemon/src/native/__tests__/index.test.ts
@@ -1,0 +1,219 @@
+// daemon/src/native/__tests__/index.test.ts
+//
+// Smoke + behavior tests for the ccsm_native loader shim.
+//
+// What we test:
+//   1. CcsmNativeMissingError surfaces when no .node is resolvable
+//      (the default loader path on a host that has not built the
+//      addon — e.g. CI matrix legs without the build step).
+//   2. `loadCcsmNative([explicit path])` succeeds when handed a real
+//      .node — validated by the per-platform CI leg via the
+//      env-driven `CCSM_NATIVE_NODE` skip below.
+//   3. `IsBindingMissingError` discriminates correctly.
+//   4. `__setNativeForTests` + `native()` round-trip works (used by
+//      future consumer wire-up tests).
+//   5. Per-platform export shape: peerCred has the right method set
+//      for the host's platform; the wrong-platform methods are
+//      undefined.
+//   6. Sigchld adapter renames `subscribe` -> `onSigchld` so the
+//      `SigchldReaperDeps` contract from `pty/sigchld-reaper.ts` is
+//      honoured by the production wiring.
+//
+// We do NOT test the C++ surfaces themselves here; those have
+// dedicated tests at the consumer layer (peer-cred-verify.test.ts,
+// win-jobobject.test.ts, pipe-acl.test.ts) which inject fakes that
+// match the binding contract. The CI matrix's `build` step is what
+// proves the binding compiles + dlopens; this file proves the JS
+// shim does the right adaptation.
+
+import { describe, expect, it, beforeEach } from 'vitest';
+
+import {
+  CcsmNativeMissingError,
+  IsBindingMissingError,
+  loadCcsmNative,
+  native,
+  __resetNativeCacheForTests,
+  __setNativeForTests,
+  type NativeBinding,
+} from '../index.js';
+
+beforeEach(() => {
+  __resetNativeCacheForTests();
+});
+
+describe('loadCcsmNative — missing artifact', () => {
+  it('throws CcsmNativeMissingError when no candidate path resolves', () => {
+    expect(() =>
+      loadCcsmNative([
+        '/definitely/not/a/real/path/ccsm_native.node',
+        '/also/not/real/ccsm_native.node',
+      ]),
+    ).toThrow(CcsmNativeMissingError);
+  });
+
+  it('error message names the last attempted path + frag-3.5.1 hint', () => {
+    let caught: unknown = null;
+    try {
+      loadCcsmNative(['/nope/one.node', '/nope/two.node']);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CcsmNativeMissingError);
+    const e = caught as CcsmNativeMissingError;
+    expect(e.message).toMatch(/two\.node/);
+    expect(e.message).toMatch(/in-tree N-API helper/);
+    expect(e.resolvedFrom).toBe('/nope/two.node');
+  });
+});
+
+describe('IsBindingMissingError', () => {
+  it('matches CcsmNativeMissingError instances', () => {
+    const e = new CcsmNativeMissingError('/x', new Error('boom'));
+    expect(IsBindingMissingError(e)).toBe(true);
+  });
+  it('rejects ordinary errors', () => {
+    expect(IsBindingMissingError(new Error('x'))).toBe(false);
+    expect(IsBindingMissingError({ code: 'ENOSYS' })).toBe(false);
+    expect(IsBindingMissingError(null)).toBe(false);
+    expect(IsBindingMissingError(undefined)).toBe(false);
+  });
+});
+
+describe('native() singleton + test seam', () => {
+  it('returns the injected binding without touching the loader', () => {
+    const fake: NativeBinding = {
+      bindingVersion: 'test-0',
+      winjob: {
+        create: () => ({}),
+        assign: () => {},
+        terminate: () => {},
+      },
+      pipeAcl: { applyOwnerOnly: () => {} },
+      pdeathsig: { armSelf: () => {} },
+      peerCred: {},
+      sigchld: {
+        onSigchld: () => () => {},
+        waitpid: () => ({ state: 'no-state-change' }),
+      },
+    };
+    __setNativeForTests(fake);
+    expect(native()).toBe(fake);
+    expect(native()).toBe(fake);  // cached
+  });
+
+  it('caches the missing-binding error so repeat calls do not re-load', () => {
+    // We can only deterministically exercise the error-cache path by
+    // forcing a known-bad load via the explicit path overload. The
+    // error-cache itself is internal to the module-level `native()`
+    // accessor, so we exercise that path indirectly via two calls of
+    // `loadCcsmNative` and assert each independently throws the
+    // marker class. The same cache logic in `native()` is covered by
+    // the singleton round-trip test above.
+    expect(() => loadCcsmNative(['/nope/x.node'])).toThrow(
+      CcsmNativeMissingError,
+    );
+    expect(() => loadCcsmNative(['/nope/x.node'])).toThrow(
+      CcsmNativeMissingError,
+    );
+  });
+});
+
+// CCSM_NATIVE_NODE is set by the CI matrix to the path of the just-
+// built .node so we can prove the dlopen path round-trips on a real
+// artifact. Locally / in PR-time CI without the build step this is
+// unset and the test is skipped (expected — see frag-3.5.1 §3.5.1.6
+// "binding accessed only through `daemon/src/native/index.ts`").
+const realBindingPath = process.env.CCSM_NATIVE_NODE;
+
+describe.skipIf(!realBindingPath)(
+  'loadCcsmNative — real .node (CI matrix only)',
+  () => {
+    it('dlopens the artifact and exposes the expected shape', () => {
+      const b = loadCcsmNative([realBindingPath as string]);
+      expect(typeof b.bindingVersion).toBe('string');
+      expect(b.bindingVersion.length).toBeGreaterThan(0);
+      // Surfaces present on every platform (stub or real):
+      expect(typeof b.winjob.create).toBe('function');
+      expect(typeof b.winjob.assign).toBe('function');
+      expect(typeof b.winjob.terminate).toBe('function');
+      expect(typeof b.pipeAcl.applyOwnerOnly).toBe('function');
+      expect(typeof b.pdeathsig.armSelf).toBe('function');
+    });
+
+    it('peerCred shape matches process.platform', () => {
+      const b = loadCcsmNative([realBindingPath as string]);
+      if (process.platform === 'win32') {
+        expect(typeof b.peerCred.getNamedPipeClientProcessId).toBe('function');
+        expect(typeof b.peerCred.openProcessTokenUserSid).toBe('function');
+        expect(b.peerCred.getsockoptPeerCred).toBeUndefined();
+        expect(b.peerCred.getpeereid).toBeUndefined();
+      } else if (process.platform === 'linux') {
+        expect(typeof b.peerCred.getsockoptPeerCred).toBe('function');
+        expect(b.peerCred.getNamedPipeClientProcessId).toBeUndefined();
+        expect(b.peerCred.openProcessTokenUserSid).toBeUndefined();
+        expect(b.peerCred.getpeereid).toBeUndefined();
+      } else if (process.platform === 'darwin') {
+        expect(typeof b.peerCred.getpeereid).toBe('function');
+        expect(b.peerCred.getNamedPipeClientProcessId).toBeUndefined();
+        expect(b.peerCred.openProcessTokenUserSid).toBeUndefined();
+        expect(b.peerCred.getsockoptPeerCred).toBeUndefined();
+      }
+    });
+
+    it('non-native surfaces throw ENOSYS, not silent no-op', () => {
+      const b = loadCcsmNative([realBindingPath as string]);
+      if (process.platform !== 'win32') {
+        // winjob.create on POSIX must throw with code: 'ENOSYS' so a
+        // misconfigured Win-only call site fails loud.
+        let err: unknown = null;
+        try {
+          b.winjob.create();
+        } catch (e) {
+          err = e;
+        }
+        expect(err).toBeInstanceOf(Error);
+        expect((err as { code?: string }).code).toBe('ENOSYS');
+
+        // pipeAcl.applyOwnerOnly on POSIX same.
+        let err2: unknown = null;
+        try {
+          b.pipeAcl.applyOwnerOnly('/tmp/dummy.pipe');
+        } catch (e) {
+          err2 = e;
+        }
+        expect((err2 as { code?: string } | null)?.code).toBe('ENOSYS');
+      }
+      if (process.platform !== 'linux') {
+        let err: unknown = null;
+        try {
+          b.pdeathsig.armSelf(15);
+        } catch (e) {
+          err = e;
+        }
+        expect((err as { code?: string } | null)?.code).toBe('ENOSYS');
+      }
+      if (process.platform === 'win32') {
+        // sigchld.waitpid on win32 must throw ENOSYS at the JS-side
+        // adapter (the .node stub also throws ENOSYS, but the JS
+        // adapter intercepts to provide the same error shape with a
+        // useful message).
+        let err: unknown = null;
+        try {
+          b.sigchld.waitpid(1);
+        } catch (e) {
+          err = e;
+        }
+        expect((err as { code?: string } | null)?.code).toBe('ENOSYS');
+      }
+    });
+
+    it('on POSIX, sigchld.waitpid(1) returns no-state-change (init)', () => {
+      if (process.platform === 'win32') return;
+      // pid 1 is init / systemd; we are NOT its parent, so waitpid
+      // returns ECHILD which the binding maps to no-state-change.
+      const r = loadCcsmNative([realBindingPath as string]).sigchld.waitpid(1);
+      expect(r.state).toBe('no-state-change');
+    });
+  },
+);

--- a/daemon/src/native/__tests__/no-direct-native-import.test.ts
+++ b/daemon/src/native/__tests__/no-direct-native-import.test.ts
@@ -1,0 +1,89 @@
+// Unit tests for the custom ESLint rule no-direct-native-import.
+//
+// We exercise the rule via ESLint's RuleTester against synthetic
+// import / require expressions instead of running eslint over real
+// fixture files (cleaner, no fs touchpoints, no ignore-list
+// complications).
+
+// Unit tests for the custom ESLint rule no-direct-native-import.
+//
+// We exercise the rule via ESLint's RuleTester against synthetic
+// import / require expressions instead of running eslint over real
+// fixture files (cleaner, no fs touchpoints, no ignore-list
+// complications).
+//
+// RuleTester.run calls `describe`/`it` internally so it MUST run at
+// module top level, not inside another describe/it.
+
+import { RuleTester } from 'eslint';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '..', '..', '..', '..');
+const require = createRequire(import.meta.url);
+const rule = require(
+  path.join(repoRoot, 'eslint-rules', 'no-direct-native-import.js'),
+);
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('no-direct-native-import', rule, {
+  valid: [
+    {
+      // arbitrary non-native import
+      code: "import x from './foo.js';",
+      filename: 'daemon/src/pty/win-jobobject.ts',
+    },
+    {
+      // require of a non-.node thing
+      code: "const x = require('./bar');",
+      filename: 'daemon/src/pty/win-jobobject.ts',
+    },
+    {
+      // shim file IS allowed to load .node
+      code: "const x = require('./build/Release/ccsm_native.node');",
+      filename: 'daemon/src/native/index.ts',
+    },
+    {
+      code: "import x from './build/Release/ccsm_native.node';",
+      filename: 'daemon/src/native/impl/napi.ts',
+    },
+  ],
+  invalid: [
+    {
+      code: "import x from './ccsm_native.node';",
+      filename: 'daemon/src/pty/lifecycle.ts',
+      errors: [{ messageId: 'directImport' }],
+    },
+    {
+      code: "const x = require('./build/Release/ccsm_native.node');",
+      filename: 'daemon/src/sockets/control-socket.ts',
+      errors: [{ messageId: 'directImport' }],
+    },
+    {
+      code: "const path = require.resolve('../native/ccsm_native.node');",
+      filename: 'daemon/src/pty/fanout-registry.ts',
+      errors: [{ messageId: 'directImport' }],
+    },
+    {
+      // any path containing ccsm_native (including index re-exports
+      // typed as ccsm_native/something)
+      code: "import x from '../ccsm_native/binding';",
+      filename: 'daemon/src/pty/win-jobobject.ts',
+      errors: [{ messageId: 'directImport' }],
+    },
+    {
+      // dynamic import
+      code: "const m = await import('./ccsm_native.node');",
+      filename: 'daemon/src/pty/lifecycle.ts',
+      errors: [{ messageId: 'directImport' }],
+    },
+  ],
+});

--- a/daemon/src/native/index.ts
+++ b/daemon/src/native/index.ts
@@ -1,0 +1,307 @@
+// daemon/src/native/index.ts — single import seat for ccsm_native.
+//
+// Spec: docs/superpowers/specs/v0.3-fragments/frag-3.5.1-pty-hardening.md
+//   §3.5.1.1.a "Native binding swap interface (lockin-P0-2)"
+//
+//   "All call sites go through a TypeScript interface, never the raw
+//    `.node` exports."
+//   "No call site in `daemon/src/pty/**` or `daemon/src/socket/**`
+//    may import `ccsm_native.node` directly."
+//
+// This module is the ONLY place in the daemon allowed to load the
+// .node binary. The custom ESLint rule `no-direct-native-import`
+// (registered in `eslint.config.js`) enforces it.
+//
+// What this module exports:
+//   - `native: NativeBinding`            — the swap interface
+//   - `loadCcsmNative()`                 — explicit loader (test seam)
+//   - `IsBindingMissingError(err)`       — type guard for missing-binary
+//
+// What it does NOT do:
+//   - logging (consumers are pure deciders/sinks; logging belongs to
+//     the top-level daemon entry)
+//   - retries (the loader is synchronous; if the .node fails to load
+//     the daemon must fail boot, not enter a degraded state — per
+//     frag-3.5.1 §3.5.1.6 acceptance "lint passes on full daemon
+//     tree" implies the binding is present at runtime)
+
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import type { Socket } from 'node:net';
+
+import type { NativePeerCredDeps } from '../sockets/peer-cred-verify.js';
+import type {
+  NativeWinjobDeps,
+  JobHandle,
+} from '../pty/win-jobobject.js';
+import type { NativePipeAclDeps } from '../pty/pipe-acl.js';
+import type {
+  SigchldReaperDeps,
+  WaitpidResult,
+} from '../pty/sigchld-reaper.js';
+
+// ---------------------------------------------------------------------------
+// Public swap interface (the spec's `NativeBinding`).
+// ---------------------------------------------------------------------------
+
+/**
+ * Linux PR_SET_PDEATHSIG self-arm. Documented in
+ * `daemon/src/pty/sigchld-reaper.ts` and frag-3.5.1 §3.5.1.2.
+ * Throws `Error { code: 'ENOSYS' }` on non-Linux.
+ */
+export interface NativePdeathsigDeps {
+  armSelf(signal: number): void;
+}
+
+/**
+ * The full surface set, as seen by the daemon. Each surface is the
+ * same shape consumed by its respective decider module:
+ *
+ *   - peerCred  : `NativePeerCredDeps` (sockets/peer-cred-verify.ts)
+ *   - winjob    : `NativeWinjobDeps`   (pty/win-jobobject.ts)
+ *   - pipeAcl   : `NativePipeAclDeps`  (pty/pipe-acl.ts)
+ *   - pdeathsig : `NativePdeathsigDeps` (above; consumed inside the
+ *                 daemon process — typically right before node-pty
+ *                 spawn — to arm SIGTERM-on-parent-exit on Linux)
+ *   - sigchld   : `SigchldReaperDeps`  (pty/sigchld-reaper.ts)
+ *
+ * Per frag-3.5.1 §3.5.1.1.a "Implementations live in
+ * `daemon/src/native/impl/napi.ts` (default — wraps
+ * `ccsm_native.node`) and a future `daemon/src/native/impl/koffi.ts`
+ * (deferred). Swap is a single-file edit in `loadBinding()`."
+ */
+export interface NativeBinding {
+  peerCred: NativePeerCredDeps;
+  winjob: NativeWinjobDeps;
+  pipeAcl: NativePipeAclDeps;
+  pdeathsig: NativePdeathsigDeps;
+  sigchld: SigchldReaperDeps;
+  /** Embedded build-time version string from the .node (sanity probe). */
+  bindingVersion: string;
+}
+
+// ---------------------------------------------------------------------------
+// .node loader (production path).
+// ---------------------------------------------------------------------------
+
+/**
+ * Raw shape of `ccsm_native.node` exports. Mirrors the C++
+ * `Init` function in `daemon/native/ccsm_native/src/ccsm_native.cc`.
+ * Kept private — callers consume the typed `NativeBinding` instead.
+ */
+interface RawNativeModule {
+  bindingVersion: string;
+  winjob: {
+    create(): JobHandle;
+    assign(handle: JobHandle, pid: number): void;
+    terminate(handle: JobHandle, exitCode: number): void;
+  };
+  pipeAcl: {
+    applyOwnerOnly(pipePath: string): void;
+  };
+  pdeathsig: {
+    armSelf(signal: number): void;
+  };
+  peerCred: {
+    getNamedPipeClientProcessId?(socket: Socket): number;
+    openProcessTokenUserSid?(pid: number): string;
+    getsockoptPeerCred?(socket: Socket): {
+      uid: number;
+      gid: number;
+      pid: number;
+    };
+    getpeereid?(socket: Socket): { uid: number; gid: number };
+  };
+  sigchld: {
+    subscribe(handler: () => void): () => void;
+    waitpid(pid: number): WaitpidResult;
+  };
+}
+
+/** Marker error class so callers can `if (IsBindingMissingError(e))`. */
+export class CcsmNativeMissingError extends Error {
+  override readonly name = 'CcsmNativeMissingError';
+  readonly resolvedFrom: string;
+  override readonly cause: unknown;
+  constructor(resolvedFrom: string, cause: unknown) {
+    super(
+      `ccsm_native.node could not be loaded from "${resolvedFrom}". ` +
+        `This is the in-tree N-API helper from ` +
+        `daemon/native/ccsm_native/. Build it with ` +
+        `\`npm run rebuild:natives\` or run the CI ` +
+        `\`ccsm-native\` workflow. ` +
+        `Underlying error: ${cause instanceof Error ? cause.message : String(cause)}`,
+    );
+    this.resolvedFrom = resolvedFrom;
+    this.cause = cause;
+  }
+}
+
+export function IsBindingMissingError(
+  e: unknown,
+): e is CcsmNativeMissingError {
+  return e instanceof CcsmNativeMissingError;
+}
+
+/**
+ * Resolve the per-platform `.node` artifact path. The rebuild script
+ * (`scripts/electron-rebuild-natives.cjs`) writes to
+ * `daemon/native/<platform>-<arch>/ccsm_native.node`; the dev path
+ * (`node-gyp rebuild` invoked directly inside
+ * `daemon/native/ccsm_native/`) writes to
+ * `daemon/native/ccsm_native/build/Release/ccsm_native.node`.
+ *
+ * We try both, in order. The first hit wins.
+ */
+function candidatePaths(): string[] {
+  // ESM-safe __dirname: this file is `daemon/src/native/index.ts`,
+  // which compiles to `daemon/dist-daemon/native/index.js`. From
+  // there we walk up to the daemon root, then into `native/`.
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  // From daemon/dist-daemon/native/  →  daemon/  is two levels up.
+  const daemonRoot = path.resolve(here, '..', '..');
+  const platformArch = `${process.platform}-${process.arch}`;
+  return [
+    path.join(daemonRoot, 'native', platformArch, 'ccsm_native.node'),
+    path.join(
+      daemonRoot,
+      'native',
+      'ccsm_native',
+      'build',
+      'Release',
+      'ccsm_native.node',
+    ),
+  ];
+}
+
+/**
+ * Synchronous loader. Tries each candidate path; the first that loads
+ * cleanly wins. Throws `CcsmNativeMissingError` if every candidate
+ * fails. Intended to be called once at daemon boot.
+ *
+ * Test seam: callers may pass an explicit `paths` override to load a
+ * .node from a custom location (e.g. CI smoke test).
+ */
+export function loadCcsmNative(
+  paths: string[] = candidatePaths(),
+): NativeBinding {
+  // createRequire so this ESM module can `require` a CJS .node
+  // without relying on the host bundler.
+  const req = createRequire(import.meta.url);
+  let lastErr: unknown = null;
+  let lastTried = '';
+  for (const p of paths) {
+    try {
+      lastTried = p;
+      const mod = req(p) as RawNativeModule;
+      return adaptRaw(mod);
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+  throw new CcsmNativeMissingError(lastTried, lastErr);
+}
+
+function adaptRaw(raw: RawNativeModule): NativeBinding {
+  // Per-platform narrowing. We attach only the methods that the
+  // platform's binding actually implements — the other methods stay
+  // `undefined` so the `verifyPeerCred` decider's existing
+  // "deps missing -> wire ccsm_native (frag-11)" branch catches a
+  // misconfigured call site cleanly. (The Win/POSIX stub .cc files
+  // already throw ENOSYS if anyone reaches them anyway; this is
+  // belt-and-braces.)
+  const peerCred: NativePeerCredDeps = {};
+  if (process.platform === 'win32') {
+    peerCred.getNamedPipeClientProcessId =
+      raw.peerCred.getNamedPipeClientProcessId;
+    peerCred.openProcessTokenUserSid = raw.peerCred.openProcessTokenUserSid;
+  } else if (process.platform === 'linux') {
+    peerCred.getsockoptPeerCred = raw.peerCred.getsockoptPeerCred;
+  } else if (process.platform === 'darwin') {
+    peerCred.getpeereid = raw.peerCred.getpeereid;
+  }
+
+  const sigchld: SigchldReaperDeps =
+    process.platform === 'win32'
+      ? // Win has no SIGCHLD; consumers MUST guard with
+        // `process.platform !== 'win32'` per the JS-side contract,
+        // so these throw the same way the .cc stub does.
+        {
+          onSigchld: () => {
+            throw enosys('sigchld.onSigchld');
+          },
+          waitpid: () => {
+            throw enosys('sigchld.waitpid');
+          },
+        }
+      : {
+          // Spec: `onSigchld(handler) -> detach`. The .node export
+          // is named `subscribe` (clearer in the C++ context); the
+          // adapter renames so the JS-side contract from
+          // `sigchld-reaper.ts` is honoured verbatim.
+          onSigchld: (handler) => raw.sigchld.subscribe(handler),
+          waitpid: (pid) => raw.sigchld.waitpid(pid),
+        };
+
+  return {
+    bindingVersion: raw.bindingVersion,
+    winjob: raw.winjob,
+    pipeAcl: raw.pipeAcl,
+    pdeathsig: raw.pdeathsig,
+    peerCred,
+    sigchld,
+  };
+}
+
+function enosys(op: string): Error {
+  const e = new Error(`${op}: ENOSYS (not supported on this platform)`);
+  (e as Error & { code?: string }).code = 'ENOSYS';
+  return e;
+}
+
+// ---------------------------------------------------------------------------
+// Lazy singleton.
+// ---------------------------------------------------------------------------
+
+let cached: NativeBinding | null = null;
+
+/**
+ * Lazy-loaded singleton accessor. The first call resolves the
+ * binding; subsequent calls return the same instance. Throws
+ * `CcsmNativeMissingError` on first-call failure; caches the throw
+ * so subsequent calls re-throw without re-trying the dlopen (which
+ * would not change outcome and would multiply boot-time noise).
+ */
+let cachedError: CcsmNativeMissingError | null = null;
+export function native(): NativeBinding {
+  if (cached !== null) return cached;
+  if (cachedError !== null) throw cachedError;
+  try {
+    cached = loadCcsmNative();
+    return cached;
+  } catch (err) {
+    if (err instanceof CcsmNativeMissingError) {
+      cachedError = err;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Test-only: reset the cached singleton. Production code never calls
+ * this. Tests use it to swap in fakes between cases.
+ */
+export function __resetNativeCacheForTests(): void {
+  cached = null;
+  cachedError = null;
+}
+
+/**
+ * Test-only: inject a pre-built `NativeBinding` (used to exercise the
+ * `native()` accessor without a real .node present).
+ */
+export function __setNativeForTests(b: NativeBinding | null): void {
+  cached = b;
+  cachedError = null;
+}

--- a/eslint-rules/no-direct-native-import.js
+++ b/eslint-rules/no-direct-native-import.js
@@ -1,0 +1,96 @@
+// no-direct-native-import — custom ESLint rule for ccsm.
+//
+// Spec: docs/superpowers/specs/v0.3-fragments/frag-3.5.1-pty-hardening.md
+//   §3.5.1.1.a:
+//     "No call site in `daemon/src/pty/**` or `daemon/src/socket/**`
+//      may import `ccsm_native.node` directly."
+//
+// We extend the spec's intent to all of `daemon/src/**` EXCEPT the
+// loader shim itself (`daemon/src/native/**`) — the shim is the one
+// allowed seat. Any other file that `import`s or `require`s a
+// .node — or specifically a path containing `ccsm_native` — is a
+// rule violation.
+//
+// Single-responsibility: this rule is a pure DECIDER over the AST.
+// It produces one `report({ messageId })` per violating node, no
+// auto-fix (the fix is a refactor: route through
+// `daemon/src/native/index.ts`'s `native()` accessor).
+
+'use strict';
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Forbid direct loads of ccsm_native.node or any .node binary outside daemon/src/native/. Per frag-3.5.1 §3.5.1.1.a, every native call must go through the daemon/src/native/index.ts swap interface.',
+      recommended: false,
+    },
+    schema: [],
+    messages: {
+      directImport:
+        'Direct native-binding load detected ({{spec}}). Per frag-3.5.1 §3.5.1.1.a, route through daemon/src/native/index.ts (`native()` / `loadCcsmNative()`) instead.',
+    },
+  },
+  create(context) {
+    const filename = context.filename ?? context.getFilename();
+    // The shim is the only file allowed to load the .node directly.
+    // Normalize separators for cross-platform path matching. We accept
+    // the substring `daemon/src/native/` with or without a leading
+    // slash so unit-test filenames (passed without an absolute prefix)
+    // and real filesystem paths both round-trip.
+    const norm = filename.replace(/\\/g, '/');
+    if (
+      norm.includes('/daemon/src/native/') ||
+      norm.startsWith('daemon/src/native/')
+    ) {
+      return {};
+    }
+
+    function checkSpec(specNode, raw) {
+      if (typeof raw !== 'string') return;
+      // Two patterns we care about:
+      //   1. anything ending in `.node`           — direct dlopen
+      //   2. anything containing `ccsm_native`    — even via require.resolve
+      const isDotNode = raw.endsWith('.node');
+      const isCcsmNative = raw.includes('ccsm_native');
+      if (isDotNode || isCcsmNative) {
+        context.report({
+          node: specNode,
+          messageId: 'directImport',
+          data: { spec: raw },
+        });
+      }
+    }
+
+    return {
+      ImportDeclaration(node) {
+        checkSpec(node.source, node.source.value);
+      },
+      ImportExpression(node) {
+        if (node.source && node.source.type === 'Literal') {
+          checkSpec(node.source, node.source.value);
+        }
+      },
+      CallExpression(node) {
+        // require('...'), require.resolve('...'), createRequire(...)('...')
+        const callee = node.callee;
+        const isRequire =
+          (callee.type === 'Identifier' && callee.name === 'require') ||
+          (callee.type === 'MemberExpression' &&
+            callee.object &&
+            callee.object.type === 'Identifier' &&
+            callee.object.name === 'require' &&
+            callee.property &&
+            callee.property.type === 'Identifier' &&
+            callee.property.name === 'resolve');
+        if (!isRequire) return;
+        const arg = node.arguments && node.arguments[0];
+        if (arg && arg.type === 'Literal') {
+          checkSpec(arg, arg.value);
+        }
+      },
+    };
+  },
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,18 @@ import tseslint from '@typescript-eslint/eslint-plugin';
 import tsparser from '@typescript-eslint/parser';
 import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
+import { createRequire } from 'node:module';
+
+// Local custom rule: no-direct-native-import (frag-3.5.1 §3.5.1.1.a).
+// Loaded via createRequire so the .js (CJS) rule module works under
+// the ESM flat config without a package boundary.
+const require = createRequire(import.meta.url);
+const noDirectNativeImport = require('./eslint-rules/no-direct-native-import.js');
+const ccsmLocalPlugin = {
+  rules: {
+    'no-direct-native-import': noDirectNativeImport,
+  },
+};
 
 export default [
   {
@@ -16,6 +28,7 @@ export default [
       'scripts/**',
       'tests/**',
       'docs/**',
+      'eslint-rules/**',
       'webpack.config.js',
       'postcss.config.js',
       'eslint.config.js'
@@ -85,12 +98,16 @@ export default [
     plugins: {
       '@typescript-eslint': tseslint,
       react,
-      'react-hooks': reactHooks
+      'react-hooks': reactHooks,
+      'ccsm-local': ccsmLocalPlugin
     },
     rules: {
       ...tseslint.configs.recommended.rules,
       ...react.configs.recommended.rules,
       ...reactHooks.configs.recommended.rules,
+      // Custom: forbid direct .node / ccsm_native loads outside the
+      // loader shim. Spec frag-3.5.1 §3.5.1.1.a.
+      'ccsm-local/no-direct-native-import': 'error',
       // React 17+ JSX transform — no need to import React in scope.
       'react/react-in-jsx-scope': 'off',
       'react/prop-types': 'off',

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "make:linux": "npm run build && electron-builder --linux --publish never",
     "build:icon": "electron scripts/build-icon.cjs",
     "rebuild:natives": "node scripts/electron-rebuild-natives.cjs",
+    "build:ccsm-native": "node scripts/build-ccsm-native.cjs",
     "build:uninstall-helper": "cd installer/uninstall-helper && pkg . --target node22-win-x64 --output ../../daemon/dist/ccsm-uninstall-helper.exe --compress GZip",
     "postinstall": "node scripts/postinstall.mjs",
     "proto:gen": "cd proto && buf generate"

--- a/scripts/build-ccsm-native.cjs
+++ b/scripts/build-ccsm-native.cjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+// scripts/build-ccsm-native.cjs
+//
+// Spec: docs/superpowers/specs/v0.3-fragments/frag-3.5.1-pty-hardening.md
+//   §3.5.1.1   "Built artifact name (P0 packaging contract):
+//              daemon/native/<platform>-<arch>/ccsm_native.node"
+//
+// Convenience wrapper that:
+//   1. installs node-addon-api inside daemon/native/ccsm_native/ (no-op
+//      if already present)
+//   2. runs `node-gyp rebuild` against daemon/.nvmrc Node target
+//   3. copies the built .node into daemon/native/<platform>-<arch>/
+//      so the daemon-side `loadCcsmNative()` shim resolves it.
+//
+// Used by the CI matrix (`ccsm-native.yml`) AND by developers who
+// only want the addon built (without rebuilding better-sqlite3 +
+// node-pty, which `npm run rebuild:natives` also touches).
+//
+// Single-responsibility: this script is a SINK (build side effect).
+// English-only logging.
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+const addonDir = path.join(repoRoot, 'daemon', 'native', 'ccsm_native');
+const nvmrcPath = path.join(repoRoot, 'daemon', '.nvmrc');
+
+if (!fs.existsSync(addonDir)) {
+  console.error(`[build:ccsm-native] FATAL: ${addonDir} missing.`);
+  process.exit(1);
+}
+if (!fs.existsSync(nvmrcPath)) {
+  console.error(`[build:ccsm-native] FATAL: ${nvmrcPath} missing.`);
+  process.exit(1);
+}
+const NODE_TARGET = fs.readFileSync(nvmrcPath, 'utf8').trim();
+if (!/^\d+\.\d+\.\d+$/.test(NODE_TARGET)) {
+  console.error(
+    `[build:ccsm-native] FATAL: daemon/.nvmrc must be semver, got "${NODE_TARGET}".`,
+  );
+  process.exit(1);
+}
+
+const platformArch = `${process.platform}-${process.arch}`;
+const outDir = path.join(repoRoot, 'daemon', 'native', platformArch);
+fs.mkdirSync(outDir, { recursive: true });
+
+console.log(`[build:ccsm-native] platform=${platformArch}`);
+console.log(`[build:ccsm-native] NODE_TARGET=${NODE_TARGET}`);
+console.log(`[build:ccsm-native] addon dir=${addonDir}`);
+
+// Step 1: install node-addon-api locally (creates node_modules in
+// the addon dir if needed). We use --no-package-lock to avoid
+// committing a per-platform lockfile to a directory that lives
+// inside daemon/native/ (which is gitignored except for the addon
+// source — see .gitignore).
+const isWin = process.platform === 'win32';
+const npmCmd = isWin ? 'npm.cmd' : 'npm';
+const ngypCmd = isWin ? 'node-gyp.cmd' : 'node-gyp';
+
+console.log('[build:ccsm-native] step 1/3: install node-addon-api');
+const installRes = spawnSync(
+  npmCmd,
+  [
+    'install',
+    '--no-audit',
+    '--no-fund',
+    '--no-package-lock',
+    '--ignore-scripts',
+  ],
+  { cwd: addonDir, stdio: 'inherit', shell: isWin },
+);
+if (installRes.status !== 0) {
+  console.error(
+    `[build:ccsm-native] FATAL: npm install failed (exit ${installRes.status})`,
+  );
+  process.exit(installRes.status || 1);
+}
+
+// Step 2: node-gyp rebuild against the daemon Node target.
+console.log(
+  `[build:ccsm-native] step 2/3: node-gyp rebuild --target=${NODE_TARGET}`,
+);
+const buildRes = spawnSync(
+  ngypCmd,
+  [
+    'rebuild',
+    `--target=${NODE_TARGET}`,
+    '--runtime=node',
+    '--dist-url=https://nodejs.org/dist',
+  ],
+  { cwd: addonDir, stdio: 'inherit', shell: isWin },
+);
+if (buildRes.status !== 0) {
+  console.error(
+    `[build:ccsm-native] FATAL: node-gyp rebuild failed (exit ${buildRes.status})`,
+  );
+  process.exit(buildRes.status || 1);
+}
+
+// Step 3: copy the built .node into daemon/native/<platform-arch>/.
+const built = path.join(addonDir, 'build', 'Release', 'ccsm_native.node');
+if (!fs.existsSync(built)) {
+  console.error(`[build:ccsm-native] FATAL: expected artifact missing: ${built}`);
+  process.exit(1);
+}
+const dst = path.join(outDir, 'ccsm_native.node');
+fs.copyFileSync(built, dst);
+console.log(`[build:ccsm-native] step 3/3: copied -> ${dst}`);
+console.log('[build:ccsm-native] OK');


### PR DESCRIPTION
## Why

Four merged consumers (sigchld-reaper #674, win-jobobject #681, peer-cred-verify #684, pipe-acl #687) ship as DI-only modules whose `loadDefaultDeps()` throws a "frag-11 / ccsm_native pointer" until this addon lands. This PR is that landing.

Spec: `docs/superpowers/specs/v0.3-fragments/frag-3.5.1-pty-hardening.md` §3.5.1.1 (Win JobObject), §3.5.1.1.a (NativeBinding swap interface), §3.5.1.2 (POSIX SIGCHLD wiring), §3.5.1.6 (Win pipe ACL hardening) + `frag-11-packaging.md` §11.1 (ccsm_native rebuild step).

Manager confirmed N-API path (option 1) over koffi after a brief STOP/REVERSE — see manager turn for context.

## What

One single `.node` carrying five export surfaces per the spec:

| Surface     | Win32                            | Linux                       | Darwin                |
|-------------|----------------------------------|-----------------------------|-----------------------|
| `winjob`    | JobObject + KILL_ON_JOB_CLOSE    | ENOSYS                      | ENOSYS                |
| `pipeAcl`   | atomic 5-step DACL hardening     | ENOSYS                      | ENOSYS                |
| `pdeathsig` | ENOSYS                           | `prctl(PR_SET_PDEATHSIG)`   | ENOSYS                |
| `peerCred`  | `GetNamedPipeClientProcessId`+SID| `getsockopt(SO_PEERCRED)`   | `getpeereid`          |
| `sigchld`   | ENOSYS                           | `uv_signal_t`+`waitpid`     | same as Linux         |

Surfaces unavailable on a host throw `Error { code: 'ENOSYS' }` at the binding boundary so a misconfigured call site fails loud (never silently no-ops at the native layer).

### Files added

- `daemon/native/ccsm_native/binding.gyp` + `package.json` + `src/*.cc`+`surfaces.h`
- `daemon/src/native/index.ts` — `NativeBinding` interface + `native()` singleton loader. The ONLY file allowed to load the `.node` directly per §3.5.1.1.a.
- `eslint-rules/no-direct-native-import.js` — custom ESLint rule enforcing the §3.5.1.1.a contract. Wired into `eslint.config.js`.
- `scripts/build-ccsm-native.cjs` — convenience builder (`npm run build:ccsm-native`) that node-gyp rebuilds against `daemon/.nvmrc` Node target and copies into `daemon/native/<platform>-<arch>/`.
- `.github/workflows/ccsm-native.yml` — CI matrix (ubuntu/macos/windows) that builds the addon, smoke-tests the loader against the real artifact, and lints.

### Files changed

- `eslint.config.js` — register `ccsm-local/no-direct-native-import` plugin/rule.
- `.gitignore` — narrow `daemon/native/` ignore to per-platform output dirs only; keep addon source tracked. Build outputs (`build/`, `node_modules/`) re-ignored.
- `package.json` — add `npm run build:ccsm-native` script.

### Why N-API and not koffi

Per frag-3.5.1 §3.5.1.1.a + open-q-1: N-API picked for compile-time symbol guarantees, zero runtime overhead, and ABI stability across Node majors (NAPI 8). The `NativeBinding` swap interface is single-file swappable to koffi or any other FFI in v0.4 if maintenance burden becomes an issue — no consumer code changes required.

## Test plan

Local Win 11 25H2 (this dev box) results:

- [x] `npm run lint` — 0 errors (123 pre-existing warnings unchanged)
- [x] `npx tsc --noEmit -p daemon/tsconfig.json` — clean
- [x] `npm run build:ccsm-native` — OK against Node 22.11.0 with VS2026 MSVC toolchain
- [x] `npx vitest run daemon/src/native/__tests__/` — 15 pass, 4 CI-only skipped (the dlopen tests run when CCSM_NATIVE_NODE env is set)
- [x] Real artifact load smoke (`CCSM_NATIVE_NODE=daemon/native/win32-x64/ccsm_native.node`) — 10/10 pass: peerCred shape matches win32, winjob callable, POSIX surfaces throw `code: 'ENOSYS'` as contracted
- [x] Existing consumer tests (`peer-cred-verify` + `win-jobobject` + `pipe-acl` + `sigchld-reaper`) — 47 pass / 0 regressions. Their `loadDefaultDeps` "throws frag-11 pointer" tests still pass because production wiring routes through `native()`, not through the per-file default loaders.
- [x] Lint rule reverse-verify: 5 invalid cases (direct `.node` import, `require`, `require.resolve`, `ccsm_native` path substring, dynamic import) all reported. 4 valid cases (non-native imports, shim-internal loads) all silent.

CI matrix `ccsm-native.yml` will run the same gates on ubuntu-latest + macos-latest + windows-latest.

### Reverse-verify on the namespace fix

The first build attempt failed because `NODE_API_MODULE(ccsm_native, ccsm_native::Init)` is a token-pasting macro that cannot accept qualified names. The fix routes through a file-scope `InitModule` shim that forwards into the `ccsm_n` namespace. Build succeeds with the shim; without it the build fails with `'__napi_ccsm_n': is not a class or namespace name`.

## Cross-fragment / cross-task notes

- frag-11 §11.1: artifact name `ccsm_native.node` and output path `daemon/native/<platform>-<arch>/` are honoured by `scripts/build-ccsm-native.cjs`. The existing `scripts/electron-rebuild-natives.cjs` already references the in-tree dir; this PR is what makes that reference resolve.
- Task #104 (Connect server scaffold): peer-cred-verify wiring is now ready via `native().peerCred` — task #104 can consume the loader shim instead of duplicating native code.

## Pre-existing failures NOT caused by this PR

`daemon/src/db/__tests__/boot-orchestrator.test.ts` and `daemon/src/db/__tests__/migrate-v02-to-v03.test.ts` fail on this dev box due to a `better-sqlite3` Node-vs-Electron ABI mismatch (the same environmental issue called out in `.github/workflows/ci.yml` at the "Rebuild better-sqlite3 against Node" step). Verified pre-existing on `origin/working` baseline before any of my changes were applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)