### PR TITLE
chore: v0.3 task #126 daemon pkg block补 (frag-11 §11.1)

### DIFF
--- a/daemon/package.json
+++ b/daemon/package.json
@@ -7,9 +7,19 @@
   "bin": "dist-daemon-bundle/index.cjs",
   "scripts": {
     "build": "tsc -p tsconfig.json && node -e \"require('fs').writeFileSync('dist-daemon/package.json',JSON.stringify({type:'module'}))\"",
-    "package": "pkg . --out-path dist --no-bytecode --public-packages \"*\" --public"
+    "package": "pkg . --out-path dist --no-bytecode --public-packages \"*\" --public",
+    "package:win-x64": "pkg . --targets node22-win-x64 --out-path dist --no-bytecode --public-packages \"*\" --public",
+    "package:macos-x64": "pkg . --targets node22-macos-x64 --out-path dist --no-bytecode --public-packages \"*\" --public",
+    "package:macos-arm64": "pkg . --targets node22-macos-arm64 --out-path dist --no-bytecode --public-packages \"*\" --public",
+    "package:linux-x64": "pkg . --targets node22-linux-x64 --out-path dist --no-bytecode --public-packages \"*\" --public"
   },
   "pkg": {
+    "targets": [
+      "node22-win-x64",
+      "node22-macos-x64",
+      "node22-macos-arm64",
+      "node22-linux-x64"
+    ],
     "scripts": [
       "dist-daemon-bundle/index.cjs"
     ],


### PR DESCRIPTION
## Summary
- Verified PR #781 already added daemon binary build pipeline; `daemon/.nvmrc=22.11.0` correct, `pkg.assets` per-arch glob correct.
- Gap补: added explicit `pkg.targets` array (4 targets: node22-{win-x64,macos-x64,macos-arm64,linux-x64}) per frag-11 §11.1 spec example.
- Gap补: added per-arch `scripts.package:{win-x64,macos-x64,macos-arm64,linux-x64}` entries for direct local invocation; existing generic `package` script preserved.

Round-3 P1-7 unchanged: CI matrix legs still drive `--targets node22-${PLATFORM}-${ARCH}` via `scripts/build-daemon-bin.cjs` so each binary embeds only its own arch's `.node` files. The package.json `pkg.targets` array is purely a manifest/default for tooling; CLI `--targets` overrides per leg.

Zero-rework: identical config carries into v0.4 daemon ship.

## Test plan
- [x] `node -e` JSON parse on daemon/package.json passes
- [ ] Local `npm run package:win-x64 -w @ccsm/daemon` (skipped — no clean checkout / native rebuild here; CI matrix exercises real build via build-daemon-bin.cjs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)