### PR TITLE
ci: v0.3 task #134 aggregate SHA256SUMS.txt + SLSA subject-paths (frag-11 §11.4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,6 +282,34 @@ jobs:
             echo "wrote $f.sha256"
           done
 
+      # Task #134 (frag-11 §11.4): aggregate SHA256SUMS.txt covering every
+      # release artifact (installers + auto-update yml + blockmaps). One file,
+      # `sha256sum -c SHA256SUMS.txt` compatible (LF-terminated lines of
+      # `<hex>  <filename>`), so a user can verify the full release in a
+      # single command instead of fetching N per-artifact .sha256 sidecars.
+      # We deliberately exclude derivative sidecars (.sha256, .minisig,
+      # .intoto.jsonl) — verifying them against themselves is meaningless and
+      # causes recursion if this file is regenerated.
+      - name: Generate aggregate SHA256SUMS.txt
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd dist-flat
+          # Stable order so the file is reproducible across runs.
+          : > SHA256SUMS.txt
+          for f in $(ls *.exe *.dmg *.zip *.AppImage *.deb *.rpm latest*.yml *.blockmap 2>/dev/null | LC_ALL=C sort -u); do
+            [ -f "$f" ] || continue
+            sha256sum "$f" >> SHA256SUMS.txt
+          done
+          echo "--- SHA256SUMS.txt ---"
+          cat SHA256SUMS.txt
+          # Sanity: must be non-empty and parse cleanly via sha256sum -c.
+          if [ ! -s SHA256SUMS.txt ]; then
+            echo "::error title=Aggregate SHA256SUMS.txt empty::no release artifacts matched"
+            exit 1
+          fi
+          sha256sum -c --status SHA256SUMS.txt
+
       # Minisign signatures. Public key lives in repo at release-keys/minisign.pub
       # (committed). Private key is provisioned via the MINISIGN_PRIVATE_KEY
       # repo secret + MINISIGN_PASSWORD secret (see release-keys/README.md for
@@ -315,11 +343,24 @@ jobs:
             echo "$MINISIGN_PASSWORD" | minisign -S -s "$KEY" -m "$f" -t "ccsm $GITHUB_REF_NAME"
             echo "wrote $f.minisig"
           done
+          # Task #134: also sign the aggregate SHA256SUMS.txt so a verifier
+          # can authenticate the whole-release hash list with one minisig
+          # check (`minisign -V -p minisign.pub -m SHA256SUMS.txt`) before
+          # running `sha256sum -c SHA256SUMS.txt` against their downloads.
+          if [ -f SHA256SUMS.txt ]; then
+            echo "$MINISIGN_PASSWORD" | minisign -S -s "$KEY" -m SHA256SUMS.txt -t "ccsm $GITHUB_REF_NAME"
+            echo "wrote SHA256SUMS.txt.minisig"
+          fi
           shred -u "$KEY"
 
       # Compute the SLSA hashes input. The SLSA reusable workflow expects a
       # base64-encoded SHA256SUMS-format payload listing every subject we want
       # provenance over (the installers themselves; sidecars are derivative).
+      # Task #134 (frag-11 §11.4): also enumerate SHA256SUMS.txt as a SLSA
+      # subject so the provenance attests not just each installer but also
+      # the aggregate hash list — preventing a tamperer from swapping
+      # SHA256SUMS.txt for one that points at malicious binaries with valid
+      # hashes. (.minisig / .intoto.jsonl / per-file .sha256 stay derivative.)
       - name: Compute SLSA hashes input
         id: hash
         shell: bash
@@ -327,7 +368,7 @@ jobs:
           set -euo pipefail
           cd dist-flat
           HASHES=$( \
-            sha256sum *.exe *.dmg *.zip *.AppImage *.deb *.rpm 2>/dev/null \
+            sha256sum *.exe *.dmg *.zip *.AppImage *.deb *.rpm SHA256SUMS.txt 2>/dev/null \
               | base64 -w0 \
           )
           echo "hashes=$HASHES" >> "$GITHUB_OUTPUT"
@@ -424,6 +465,19 @@ jobs:
             check_minisig=1
           fi
           fail=0
+          # Task #134: aggregate SHA256SUMS.txt is mandatory and must verify
+          # cleanly with `sha256sum -c` against the artifacts we're about to
+          # publish — catches "someone uploaded a stale hash list".
+          if [ ! -s SHA256SUMS.txt ]; then
+            echo "::error title=Sidecar-verify failed::SHA256SUMS.txt missing or empty"; fail=1
+          else
+            if ! sha256sum -c --status SHA256SUMS.txt; then
+              echo "::error title=Sidecar-verify failed::SHA256SUMS.txt does not verify against artifacts"; fail=1
+            fi
+            if [ "$check_minisig" -eq 1 ] && [ ! -s SHA256SUMS.txt.minisig ]; then
+              echo "::error title=Sidecar-verify failed::SHA256SUMS.txt missing or empty .minisig"; fail=1
+            fi
+          fi
           for f in *.exe *.dmg *.zip *.AppImage *.deb *.rpm; do
             [ -f "$f" ] || continue
             if [ ! -s "$f.sha256" ]; then
@@ -441,9 +495,9 @@ jobs:
             exit 1
           fi
           if [ "$check_minisig" -eq 1 ]; then
-            echo "All installers have .sha256 + .minisig + .intoto.jsonl sidecars."
+            echo "All installers have .sha256 + .minisig + .intoto.jsonl sidecars; SHA256SUMS.txt + .minisig present and verified."
           else
-            echo "All installers have .sha256 + .intoto.jsonl sidecars (minisig skipped — secret unset)."
+            echo "All installers have .sha256 + .intoto.jsonl sidecars; SHA256SUMS.txt present and verified (minisig skipped — secret unset)."
           fi
           ls -la
 
@@ -465,5 +519,6 @@ jobs:
             dist-flat/*.sha256
             dist-flat/*.minisig
             dist-flat/*.intoto.jsonl
+            dist-flat/SHA256SUMS.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Task #134 (frag-11 §11.4): publish a single aggregate `SHA256SUMS.txt` per release so users can verify the whole release with one command, and bind it into the existing SLSA L3 + minisign attest chain so it can't be silently swapped.

## Changes (release.yml `attest` job)

- **New step `Generate aggregate SHA256SUMS.txt`** (after the per-artifact `.sha256` step): writes `dist-flat/SHA256SUMS.txt` covering installers (`*.exe *.dmg *.zip *.AppImage *.deb *.rpm`) plus auto-update metadata (`latest*.yml`, `*.blockmap`). Stable LC_ALL=C sort order for reproducibility. Format is `sha256sum`-compatible (`<hex>  <filename>` per line); self-verified via `sha256sum -c --status` before upload. Derivative sidecars (`.sha256`, `.minisig`, `.intoto.jsonl`) are excluded.
- **`Generate minisign signatures`** also signs `SHA256SUMS.txt` -> `SHA256SUMS.txt.minisig`. Placeholder-safe: skipped when `MINISIGN_PRIVATE_KEY` is unset, mirroring the existing per-installer minisig behaviour (frag-11 §11.5(5)).
- **`Compute SLSA hashes input`** now appends `SHA256SUMS.txt` to the `sha256sum` list base64-encoded into `base64-subjects` for the `slsa-github-generator` reusable workflow. The aggregate file is therefore an attested SLSA subject — an attacker rewriting `SHA256SUMS.txt` to point at malicious binaries would invalidate the provenance.

## Changes (release.yml `publish` job)

- **Sidecar-verify gate** now asserts:
  - `SHA256SUMS.txt` exists and is non-empty.
  - `sha256sum -c --status SHA256SUMS.txt` succeeds against the downloaded artifacts (catches stale/corrupt aggregate files).
  - When minisig is enabled, `SHA256SUMS.txt.minisig` is present and non-empty.
- **GitHub Release upload** globs include `dist-flat/SHA256SUMS.txt` (existing `*.minisig` glob already covers `SHA256SUMS.txt.minisig`; existing `*.intoto.jsonl` glob already covers SLSA provenance).

## Affected release artifacts (per draft Release after this lands)

- New: `SHA256SUMS.txt`, `SHA256SUMS.txt.minisig` (when signed)
- Unchanged: per-installer `.sha256`, `.minisig`, `.intoto.jsonl` sidecars, installers themselves, auto-update yml + blockmaps.

## Test plan

- [ ] yaml syntax: `python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` passes (verified locally).
- [ ] On next `workflow_dispatch` dry-run / tag push, confirm `attest` job logs show `--- SHA256SUMS.txt ---` block followed by clean `sha256sum -c` exit and (when secret set) `wrote SHA256SUMS.txt.minisig`.
- [ ] Confirm `publish` sidecar-verify gate logs the new "SHA256SUMS.txt + .minisig present and verified" success line and Release draft contains both files.
- [ ] Manual verify: `minisign -V -p release-keys/minisign.pub -m SHA256SUMS.txt && sha256sum -c SHA256SUMS.txt` against downloaded assets succeeds.