### PR TITLE
ci: v0.3 task #135 Node 22 + daemon test job (frag-11 §11.5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Node
+      - name: Setup Node (from daemon/.nvmrc)
+        # Single-source-of-truth: daemon/.nvmrc pins the daemon Node
+        # target (currently 22.11.0). All workflows read from it so a
+        # bump there propagates everywhere — frag-11 §11.5 + Task #135.
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version-file: daemon/.nvmrc
           cache: 'npm'
 
       # Linux native builds for better-sqlite3 need python + build tools; the
@@ -57,7 +60,11 @@ jobs:
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: nm-${{ runner.os }}-${{ runner.arch }}-node20-${{ hashFiles('package-lock.json') }}
+          # Cache key includes BOTH the root lockfile (workspace deps live
+          # here) AND daemon/package-lock.json if/when it appears, so a
+          # daemon-local lockfile change also busts the cache. `node22`
+          # tracks daemon/.nvmrc — bump in lockstep when .nvmrc bumps.
+          key: nm-${{ runner.os }}-${{ runner.arch }}-node22-${{ hashFiles('package-lock.json', 'daemon/package-lock.json') }}
 
       - name: Install deps
         if: steps.nm_cache.outputs.cache-hit != 'true'
@@ -88,6 +95,18 @@ jobs:
 
       - name: Test
         run: npm test
+
+      # Task #135 (frag-11 §11.5) — dedicated daemon-only test job.
+      # The root `npm test` above already includes daemon tests via the
+      # vitest `include` glob, but a daemon-only re-run gives us a
+      # focused signal when only daemon code changes break and keeps
+      # the daemon test surface auditable as a first-class CI gate.
+      # Runs on Linux only to keep the matrix wall-clock flat — the
+      # daemon code is platform-agnostic and the cross-OS coverage
+      # already comes from the main `npm test` matrix above.
+      - name: Test (daemon only)
+        if: matrix.os == 'ubuntu-latest'
+        run: npx vitest run daemon
 
       # Tech-debt R6 (Task #802) — coverage roll-out. Run only on Linux to
       # keep the matrix lean (coverage instrumentation roughly doubles

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,7 +34,7 @@ jobs:
           python-version: '3.11'
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version-file: daemon/.nvmrc
           cache: 'npm'
       # Cache node_modules directly — same rationale as ci.yml: `npm ci`
       # is the dominant Windows CI cost. Cache hit skips install entirely
@@ -61,14 +61,14 @@ jobs:
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: nm-e2e-${{ runner.os }}-${{ runner.arch }}-node20-${{ hashFiles('package-lock.json') }}
+          key: nm-e2e-${{ runner.os }}-${{ runner.arch }}-node22-${{ hashFiles('package-lock.json', 'daemon/package-lock.json') }}
       - name: Cache Electron binary
         uses: actions/cache@v4
         with:
           path: |
             ~/.cache/electron
             ~/.cache/electron-builder
-          key: electron-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: electron-${{ runner.os }}-${{ hashFiles('package-lock.json', 'daemon/package-lock.json') }}
       - name: Install deps
         if: steps.nm_cache.outputs.cache-hit != 'true'
         run: npm ci --legacy-peer-deps

--- a/.github/workflows/fixture-lint.yml
+++ b/.github/workflows/fixture-lint.yml
@@ -16,6 +16,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version-file: daemon/.nvmrc
       - run: npm ci
       - run: npm run lint:fixtures

--- a/.github/workflows/installer-size-guard.yml
+++ b/.github/workflows/installer-size-guard.yml
@@ -51,7 +51,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version-file: daemon/.nvmrc
           cache: 'npm'
 
       - uses: actions/setup-python@v5

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version-file: daemon/.nvmrc
           cache: 'npm'
 
       # Same python pin as ci.yml — better-sqlite3 postinstall imports
@@ -76,7 +76,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: nm-${{ runner.os }}-${{ runner.arch }}-node20-${{ hashFiles('package-lock.json') }}
+          key: nm-${{ runner.os }}-${{ runner.arch }}-node22-${{ hashFiles('package-lock.json', 'daemon/package-lock.json') }}
 
       - name: Install deps
         if: steps.nm_cache.outputs.cache-hit != 'true'

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -14,7 +14,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version-file: daemon/.nvmrc
       - run: npm ci
       - run: npx buf lint
         working-directory: proto

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version-file: daemon/.nvmrc
           cache: 'npm'
       - uses: actions/setup-python@v5
         with:
@@ -45,6 +45,11 @@ jobs:
       - run: npm run typecheck
       - run: npm run build
       - run: npm test
+      # Task #135 (frag-11 §11.5) — daemon-only test gate. Pinned Node
+      # comes from daemon/.nvmrc above so this exercises the daemon
+      # surface against its locked Node target before we ship.
+      - name: Test (daemon only)
+        run: npx vitest run daemon
 
   build:
     name: build (${{ matrix.os }})
@@ -80,7 +85,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version-file: daemon/.nvmrc
           cache: 'npm'
 
       - uses: actions/setup-python@v5
@@ -93,7 +98,7 @@ jobs:
           path: |
             ~/.cache/electron
             ~/.cache/electron-builder
-          key: electron-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: electron-${{ runner.os }}-${{ hashFiles('package-lock.json', 'daemon/package-lock.json') }}
 
       - name: Install deps
         run: npm ci --legacy-peer-deps

--- a/.github/workflows/schema-additive-lint.yml
+++ b/.github/workflows/schema-additive-lint.yml
@@ -12,6 +12,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version-file: daemon/.nvmrc
       - run: npm ci
       - run: npm run lint:schema-additive


### PR DESCRIPTION
## Summary

Task #135 / frag-11 §11.5 — unify CI Node target via `daemon/.nvmrc`
(22.11.0) and add a daemon-only test gate.

- All `actions/setup-node@v4` blocks across every workflow now read
  `node-version-file: daemon/.nvmrc` — single source of truth, one
  bump propagates everywhere, no more `'20'` vs `'22'` drift.
- `node_modules` cache keys: label bumped `node20` → `node22` and
  `hashFiles(...)` now covers BOTH root `package-lock.json` AND
  `daemon/package-lock.json` (forward-compatible — if daemon ever
  ships its own lockfile a change to it busts the cache).
- `ci.yml` lint+typecheck+test job (Linux leg) and `release.yml`
  verify job both gain a dedicated daemon-only test step:
  `npx vitest run daemon`.

## Workflow files changed

- `.github/workflows/ci.yml` — setup-node → .nvmrc, cache key node22
  + daemon lockfile, **new daemon-only `Test (daemon only)` step**
- `.github/workflows/e2e.yml` — setup-node → .nvmrc, both cache keys
  (`nm-e2e-*`, `electron-*`) updated
- `.github/workflows/fixture-lint.yml` — setup-node → .nvmrc
- `.github/workflows/installer-size-guard.yml` — setup-node → .nvmrc
- `.github/workflows/parity.yml` — setup-node → .nvmrc, cache key
  bumped + daemon lockfile
- `.github/workflows/proto.yml` — setup-node → .nvmrc
- `.github/workflows/release.yml` — both setup-node blocks → .nvmrc,
  electron cache key updated, **new daemon-only `Test (daemon only)`
  step in verify job**
- `.github/workflows/schema-additive-lint.yml` — setup-node → .nvmrc

(`.github/workflows/ccsm-native.yml` was already pinned to
`daemon/.nvmrc` — left untouched.)

## Test plan

- [x] `python -c "yaml.safe_load(...)"` over all 11 workflow files: parse OK
- [ ] On PR: `ci` job picks up Node 22 from `daemon/.nvmrc` and the
      new `Test (daemon only)` step runs `npx vitest run daemon`
- [ ] On PR: `e2e`, `parity`, `installer-size-guard` all resolve
      Node 22 via `daemon/.nvmrc`
- [ ] On next release tag: `verify` job runs daemon-only test step
      after `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)