### PR TITLE
fix: v0.3 task #132 ccsm path case (Linux fix, P0)

### DIFF
--- a/daemon/src/db/__tests__/lowercase-data-root.test.ts
+++ b/daemon/src/db/__tests__/lowercase-data-root.test.ts
@@ -1,0 +1,112 @@
+// Task #132 (frag-11 §11.6): verify the daemon's `migrateLegacyUppercaseDataRoot`
+// helper renames a legacy capital-`CCSM` sibling into the canonical lowercase
+// `ccsm` location, and that `resolveDataRoot` itself never emits an uppercase
+// segment for any platform.
+//
+// Uppercase `CCSM` literals in this file are the legacy-path fixtures the
+// migration helper exists to handle — disable the local rule for the whole
+// file rather than tagging each occurrence.
+/* eslint-disable ccsm-local/no-uppercase-ccsm-path */
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir, platform as osPlatform } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  ensureDataDir,
+  resolveDataRoot,
+  migrateLegacyUppercaseDataRoot,
+  type PathProvider,
+} from '../ensure-data-dir.js';
+
+// The migration helper is only meaningful on case-sensitive filesystems.
+// Windows treats `CCSM` and `ccsm` as the same inode, so the legacy sibling
+// check trivially short-circuits — and any rename "succeeds" by being a
+// no-op. We gate the behavioural tests on a non-Windows host; the pure
+// `resolveDataRoot` invariant test runs everywhere.
+const describeOnPosix = osPlatform() === 'win32' ? describe.skip : describe;
+
+let sandbox: string;
+
+beforeEach(() => {
+  sandbox = mkdtempSync(join(tmpdir(), 'ccsm-task132-'));
+});
+
+afterEach(() => {
+  rmSync(sandbox, { recursive: true, force: true });
+});
+
+describe('Task #132 — lowercase data root (frag-11 §11.6)', () => {
+  it('resolveDataRoot never emits an uppercase CCSM segment on any platform', () => {
+    const win = resolveDataRoot({ platform: 'win32', home: 'C:\\Users\\u', env: { LOCALAPPDATA: 'C:\\Users\\u\\AppData\\Local' } });
+    const mac = resolveDataRoot({ platform: 'darwin', home: '/Users/u', env: {} });
+    const lin = resolveDataRoot({ platform: 'linux', home: '/home/u', env: {} });
+    const xdg = resolveDataRoot({ platform: 'linux', home: '/home/u', env: { XDG_DATA_HOME: '/var/data' } });
+    for (const r of [win, mac, lin, xdg]) {
+      // The lowercase `ccsm` segment must be present, the uppercase one
+      // must NOT — anywhere in the resolved path.
+      expect(r.toLowerCase()).toContain('ccsm');
+      expect(r).not.toMatch(/[\\/]CCSM([\\/]|$)/);
+    }
+  });
+
+  describeOnPosix('migrateLegacyUppercaseDataRoot', () => {
+    it('renames a legacy capital-CCSM sibling to the canonical lowercase path', () => {
+      const parent = join(sandbox, '.local', 'share');
+      mkdirSync(parent, { recursive: true });
+      const legacy = join(parent, 'CCSM');
+      const canonical = join(parent, 'ccsm');
+      mkdirSync(legacy, { recursive: true });
+      writeFileSync(join(legacy, 'marker'), 'legacy-content');
+
+      migrateLegacyUppercaseDataRoot(canonical);
+
+      expect(existsSync(canonical)).toBe(true);
+      expect(existsSync(legacy)).toBe(false);
+      expect(readFileSync(join(canonical, 'marker'), 'utf8')).toBe('legacy-content');
+    });
+
+    it('is a no-op when the canonical path already exists', () => {
+      const parent = join(sandbox, '.local', 'share');
+      mkdirSync(parent, { recursive: true });
+      const legacy = join(parent, 'CCSM');
+      const canonical = join(parent, 'ccsm');
+      mkdirSync(legacy, { recursive: true });
+      mkdirSync(canonical, { recursive: true });
+      writeFileSync(join(canonical, 'keep'), 'canonical-content');
+
+      migrateLegacyUppercaseDataRoot(canonical);
+
+      // Both must still exist; we don't clobber the canonical one.
+      expect(existsSync(canonical)).toBe(true);
+      expect(existsSync(legacy)).toBe(true);
+      expect(readFileSync(join(canonical, 'keep'), 'utf8')).toBe('canonical-content');
+    });
+
+    it('is a no-op when no legacy directory exists', () => {
+      const parent = join(sandbox, '.local', 'share');
+      mkdirSync(parent, { recursive: true });
+      const canonical = join(parent, 'ccsm');
+      // Should not throw.
+      migrateLegacyUppercaseDataRoot(canonical);
+      expect(existsSync(canonical)).toBe(false);
+    });
+  });
+
+  describeOnPosix('ensureDataDir wires the migration on non-Windows', () => {
+    it('adopts a legacy CCSM/ data directory on Linux', () => {
+      const provider: PathProvider = { platform: 'linux', home: sandbox, env: {} };
+      const parent = join(sandbox, '.local', 'share');
+      mkdirSync(join(parent, 'CCSM', 'data'), { recursive: true });
+      writeFileSync(join(parent, 'CCSM', 'data', 'ccsm.db'), 'legacy-db');
+
+      const ensured = ensureDataDir(provider);
+
+      expect(ensured.dataRoot).toBe(join(parent, 'ccsm'));
+      expect(ensured.kind).toBe('existing');
+      expect(readFileSync(ensured.dbPath, 'utf8')).toBe('legacy-db');
+      expect(existsSync(join(parent, 'CCSM'))).toBe(false);
+    });
+  });
+});

--- a/daemon/src/db/__tests__/migration-events.test.ts
+++ b/daemon/src/db/__tests__/migration-events.test.ts
@@ -63,6 +63,9 @@ describe('discriminated union narrowing', () => {
   const started: MigrationStartedEvent = {
     event: MIGRATION_EVENT_NAMES.started,
     traceId: 't-1',
+    // Legacy v0.2 path fixture (uppercase `CCSM`) — frag-8 §8.1; the migration
+    // pipeline reads from this shape and writes to the v0.3 lowercase root.
+    // eslint-disable-next-line ccsm-local/no-uppercase-ccsm-path
     sourcePath: 'C:/Users/u/AppData/Roaming/CCSM/ccsm.db',
     fromVersion: 1,
     toVersion: 3,
@@ -102,7 +105,10 @@ describe('discriminated union narrowing', () => {
       }
     }
 
-    expect(describeEvent(started)).toBe('started:C:/Users/u/AppData/Roaming/CCSM/ccsm.db');
+    expect(describeEvent(started)).toBe(
+      // eslint-disable-next-line ccsm-local/no-uppercase-ccsm-path
+      'started:C:/Users/u/AppData/Roaming/CCSM/ccsm.db',
+    );
     expect(describeEvent(completed)).toBe('completed:42');
     expect(describeEvent(failed)).toBe('failed:corrupt_legacy');
   });

--- a/daemon/src/db/ensure-data-dir.ts
+++ b/daemon/src/db/ensure-data-dir.ts
@@ -34,9 +34,9 @@
 // `pathProvider` parameter lets tests inject a tmpdir without depending
 // on the real env.
 
-import { existsSync, mkdirSync, statSync, unlinkSync } from 'node:fs';
+import { existsSync, mkdirSync, renameSync, statSync, unlinkSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join, posix, win32 } from 'node:path';
+import { dirname, join, posix, win32 } from 'node:path';
 
 /** Tmp-file basenames cleaned in step 1a, per frag-8 §8.5 S2. */
 const ORPHAN_TMP_EXTS = ['', '-wal', '-shm'] as const;
@@ -184,6 +184,18 @@ function isAbsoluteIsh(p: string): boolean {
  */
 export function ensureDataDir(provider: PathProvider = defaultPathProvider()): EnsuredDataDir {
   const dataRoot = resolveDataRoot(provider);
+  // Task #132 (frag-11 §11.6): Linux is case-sensitive. If a prior build
+  // accidentally wrote a capital-`CCSM` segment (the legacy v0.2 path
+  // shape, retired for v0.3), the lowercase resolver above will not see
+  // it and the daemon will look like it's running fresh — silently
+  // orphaning the user's data. Best-effort: on platforms where this matters
+  // (anything that's not Windows — Windows is case-insensitive at the FS
+  // layer so the two paths collide on the same inode), if `<dataRoot>` is
+  // missing AND a sibling with the legacy uppercase last segment exists,
+  // rename it into place and emit a canonical log line.
+  if (provider.platform !== 'win32') {
+    migrateLegacyUppercaseDataRoot(dataRoot);
+  }
   const dataDir = join(dataRoot, 'data');
   const dbPath = join(dataDir, 'ccsm.db');
 
@@ -220,5 +232,53 @@ function probeDbFile(dbPath: string): boolean {
     return st.isFile();
   } catch {
     return false;
+  }
+}
+
+/**
+ * Task #132 (frag-11 §11.6): one-shot fallback for the legacy capital-`CCSM`
+ * dataRoot segment on case-sensitive filesystems (Linux + any case-sensitive
+ * macOS volume). If the canonical lowercase `<dataRoot>` does not exist but
+ * an immediate sibling with the literal last segment `CCSM` does, we rename
+ * the sibling into place and emit a single structured `ccsm_path_migrated`
+ * log line so the boot path can be audited post-hoc.
+ *
+ * Pure best-effort: any errors are swallowed (the boot path proceeds with a
+ * fresh `<dataRoot>`). This is intentional — a stuck legacy directory must
+ * not block the daemon from coming up.
+ *
+ * Logging is intentionally `console.warn` (not pino) because this runs
+ * before the logger is constructed in some boot orderings; the canonical
+ * line shape matches what the grep-able log pipeline expects.
+ */
+export function migrateLegacyUppercaseDataRoot(canonicalDataRoot: string): void {
+  // The check is "lowercase missing AND uppercase sibling present". The
+  // sibling is computed by replacing only the LAST path segment so we never
+  // misfire on a path like `/home/CCSM/.local/share/ccsm`.
+  if (existsSync(canonicalDataRoot)) return;
+  const parent = dirname(canonicalDataRoot);
+  // The legacy v0.2 segment IS uppercase by design — that's the whole
+  // reason this fallback exists. The local ESLint rule (Task #132) is
+  // disabled for this single line.
+  // eslint-disable-next-line ccsm-local/no-uppercase-ccsm-path
+  const legacy = join(parent, 'CCSM');
+  if (legacy === canonicalDataRoot) return; // case-insensitive FS: same path
+  let legacyExists = false;
+  try {
+    legacyExists = statSync(legacy).isDirectory();
+  } catch {
+    return;
+  }
+  if (!legacyExists) return;
+  try {
+    renameSync(legacy, canonicalDataRoot);
+    // Canonical log line: `ccsm_path_migrated from=<legacy> to=<canonical>`.
+    // Keep this single-line + grep-able for the dogfood log audit.
+    // eslint-disable-next-line no-console
+    console.warn(`ccsm_path_migrated from=${legacy} to=${canonicalDataRoot}`);
+  } catch {
+    // Rename can fail if the legacy directory is on a different filesystem,
+    // is read-only, or is locked. Don't crash the daemon — we'll just start
+    // fresh under the canonical path.
   }
 }

--- a/eslint-rules/no-uppercase-ccsm-path.js
+++ b/eslint-rules/no-uppercase-ccsm-path.js
@@ -1,0 +1,108 @@
+// eslint-rules/no-uppercase-ccsm-path.js
+//
+// Task #132 (frag-11 §11.6): Linux is case-sensitive. The v0.3 dataRoot
+// MUST use the lowercase `ccsm` segment everywhere — Windows installers
+// (NSIS) emit `%LOCALAPPDATA%\ccsm`, the daemon resolver returns
+// `~/.local/share/ccsm`, the macOS resolver returns
+// `~/Library/Application Support/ccsm`. A single `path.join(..., 'CCSM',
+// ...)` regression on the Electron side puts the daemon.lock in a different
+// directory on Linux than the installer cleanup expects → uninstall leaks +
+// fresh installs find no daemon.lock and start a second daemon.
+//
+// This rule scans string literals + template literal quasis for the
+// substring `CCSM` when it would actually appear in a path:
+//   - Hard fail: `'CCSM'` as a standalone segment (likely `path.join` arg).
+//   - Hard fail: a literal containing `/CCSM/`, `\CCSM\`, `/CCSM` at end,
+//     `CCSM/` at start (path-shaped).
+//   - Hard fail: `CCSM.app` / `CCSM.exe` are EXEMPT — those are the macOS
+//     bundle / Windows binary names derived from `productName`, not
+//     dataRoot path segments.
+//
+// Allowed (NOT flagged):
+//   - `CCSM_*` env-var names (e.g. `CCSM_DAEMON_SECRET`, `CCSM_DATA_ROOT`).
+//   - import/require paths (`from '...'`, `require('...')`).
+//   - Comments (the rule only inspects literals).
+//   - UI strings + log messages where `CCSM` is the brand label.
+//   - The macOS bundle name `CCSM.app` and Windows binary `CCSM.exe` /
+//     `CCSM Dev.exe`.
+//
+// Reverse-verified by tests/eslint-rules/no-uppercase-ccsm-path.test.js.
+
+'use strict';
+
+const PATH_FN_NAMES = new Set(['join', 'resolve', 'normalize']);
+
+/** Does the parent CallExpression look like `path.<fn>(...)` / `posix.<fn>(...)` / `win32.<fn>(...)`? */
+function isPathJoinCall(parent) {
+  if (!parent || parent.type !== 'CallExpression') return false;
+  const callee = parent.callee;
+  if (!callee || callee.type !== 'MemberExpression') return false;
+  const prop = callee.property;
+  if (!prop || prop.type !== 'Identifier' || !PATH_FN_NAMES.has(prop.name)) return false;
+  const obj = callee.object;
+  // path.join / posix.join / win32.join / path.posix.join — match the head ident.
+  if (obj.type === 'Identifier' && /^(path|posix|win32)$/.test(obj.name)) return true;
+  if (obj.type === 'MemberExpression' && obj.property?.type === 'Identifier' &&
+      /^(posix|win32)$/.test(obj.property.name)) return true;
+  return false;
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow uppercase CCSM in path-shaped string literals (frag-11 §11.6 / Task #132).',
+    },
+    schema: [],
+    messages: {
+      uppercaseCcsm:
+        'Path-shaped literal contains uppercase "CCSM"; use lowercase "ccsm" per frag-11 §11.6 (Linux is case-sensitive). If this is a brand label or env var name, refactor to make that obvious (e.g. extract to a constant).',
+    },
+  },
+  create(context) {
+    /** Returns true iff `value` looks like an embedded path with an uppercase CCSM segment. */
+    function isOffendingEmbeddedPath(value) {
+      if (typeof value !== 'string') return false;
+      if (!value.includes('CCSM')) return false;
+
+      // Exempt: env-var name shape (CCSM_FOO, all caps + underscore).
+      if (/^CCSM(_[A-Z0-9]+)+$/.test(value)) return false;
+
+      // Strip macOS bundle / Windows binary names — those come from
+      // `productName: "CCSM"` and are NOT dataRoot path segments.
+      const stripped = value
+        .replace(/CCSM\.app/g, '')
+        .replace(/CCSM Dev\.exe/g, '')
+        .replace(/CCSM\.exe/g, '');
+      if (!stripped.includes('CCSM')) return false;
+
+      // Path-shaped triggers: separator before/after `CCSM`.
+      if (/[\\/]CCSM(?:[\\/]|$)/.test(stripped)) return true;
+      if (/^CCSM[\\/]/.test(stripped)) return true;
+      return false;
+    }
+
+    /** Bare `'CCSM'` literals are only flagged when used as a path.join-style arg. */
+    function isOffendingBareCcsm(value, node) {
+      if (value !== 'CCSM') return false;
+      return isPathJoinCall(node.parent);
+    }
+
+    return {
+      Literal(node) {
+        if (typeof node.value !== 'string') return;
+        if (isOffendingEmbeddedPath(node.value) || isOffendingBareCcsm(node.value, node)) {
+          context.report({ node, messageId: 'uppercaseCcsm' });
+        }
+      },
+      TemplateElement(node) {
+        const raw = node.value && node.value.cooked;
+        if (isOffendingEmbeddedPath(raw)) {
+          context.report({ node, messageId: 'uppercaseCcsm' });
+        }
+      },
+    };
+  },
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,14 +8,19 @@ import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
 import { createRequire } from 'node:module';
 
-// Local custom rule: no-direct-native-import (frag-3.5.1 §3.5.1.1.a).
-// Loaded via createRequire so the .js (CJS) rule module works under
-// the ESM flat config without a package boundary.
+// Local custom rules. Loaded via createRequire so the .js (CJS) rule modules
+// work under the ESM flat config without a package boundary.
+//   - no-direct-native-import (frag-3.5.1 §3.5.1.1.a): forbid direct .node /
+//     ccsm_native loads outside the loader shim.
+//   - no-uppercase-ccsm-path (Task #132 / frag-11 §11.6): forbid uppercase
+//     `CCSM` in path literals (Linux dataRoot must be lowercase `ccsm`).
 const require = createRequire(import.meta.url);
 const noDirectNativeImport = require('./eslint-rules/no-direct-native-import.js');
+const noUppercaseCcsmPath = require('./eslint-rules/no-uppercase-ccsm-path.js');
 const ccsmLocalPlugin = {
   rules: {
     'no-direct-native-import': noDirectNativeImport,
+    'no-uppercase-ccsm-path': noUppercaseCcsmPath,
   },
 };
 
@@ -108,6 +113,8 @@ export default [
       // Custom: forbid direct .node / ccsm_native loads outside the
       // loader shim. Spec frag-3.5.1 §3.5.1.1.a.
       'ccsm-local/no-direct-native-import': 'error',
+      // Task #132 (frag-11 §11.6) — Linux dataRoot must be lowercase `ccsm`.
+      'ccsm-local/no-uppercase-ccsm-path': 'error',
       // React 17+ JSX transform — no need to import React in scope.
       'react/react-in-jsx-scope': 'off',
       'react/prop-types': 'off',

--- a/tests/e2e/crash-phase1.probe.ts
+++ b/tests/e2e/crash-phase1.probe.ts
@@ -11,11 +11,15 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 
 export async function run(): Promise<void> {
+  // frag-11 §11.6 (Task #132): the data root is `ccsm` (lowercase) on every
+  // platform. Linux is case-sensitive, so the legacy v0.2 capital-`CCSM`
+  // segment must NEVER appear here — the daemon would fail to find the
+  // lockfile + dataRoot and dogfood would break on first boot.
   const crashRoot = process.platform === 'win32'
-    ? path.join(process.env.LOCALAPPDATA ?? path.join(os.homedir(), 'AppData', 'Local'), 'CCSM', 'crashes')
+    ? path.join(process.env.LOCALAPPDATA ?? path.join(os.homedir(), 'AppData', 'Local'), 'ccsm', 'crashes')
     : process.platform === 'darwin'
-      ? path.join(os.homedir(), 'Library', 'Application Support', 'CCSM', 'crashes')
-      : path.join(os.homedir(), '.local', 'share', 'CCSM', 'crashes');
+      ? path.join(os.homedir(), 'Library', 'Application Support', 'ccsm', 'crashes')
+      : path.join(os.homedir(), '.local', 'share', 'ccsm', 'crashes');
   const before = new Set(fs.existsSync(crashRoot) ? fs.readdirSync(crashRoot) : []);
 
   const app = await electron.launch({ args: ['.'] });

--- a/tests/eslint-rules/no-uppercase-ccsm-path.test.ts
+++ b/tests/eslint-rules/no-uppercase-ccsm-path.test.ts
@@ -1,0 +1,57 @@
+// Reverse-verify the local ESLint rule from Task #132 (frag-11 §11.6).
+// Three valid + three invalid fixtures cover the rule's contract:
+//   invalid: bare 'CCSM' segment, '/CCSM/' embedded, 'CCSM/foo' prefix.
+//   valid  : 'ccsm' lowercase, env var name 'CCSM_DAEMON_SECRET',
+//            macOS bundle 'CCSM.app'.
+
+import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
+import { createRequire } from 'node:module';
+
+const localRequire = createRequire(import.meta.url);
+const rule = localRequire('../../eslint-rules/no-uppercase-ccsm-path.js');
+
+function lintSource(src: string): string[] {
+  const linter = new Linter();
+  const messages = linter.verify(
+    src,
+    {
+      plugins: { 'ccsm-local': { rules: { 'no-uppercase-ccsm-path': rule } } },
+      rules: { 'ccsm-local/no-uppercase-ccsm-path': 'error' },
+    },
+    'snippet.js',
+  );
+  return messages.map((m) => m.messageId ?? m.message);
+}
+
+describe("eslint-rules/no-uppercase-ccsm-path", () => {
+  describe('invalid (must report)', () => {
+    it("flags a bare 'CCSM' path-join segment", () => {
+      const out = lintSource("path.join(root, 'CCSM', 'data');");
+      expect(out).toContain('uppercaseCcsm');
+    });
+    it("flags an embedded '/CCSM/' segment in a hard-coded path", () => {
+      const out = lintSource("const p = '/home/u/.local/share/CCSM/crashes';");
+      expect(out).toContain('uppercaseCcsm');
+    });
+    it("flags a 'CCSM/foo' prefix in a relative path literal", () => {
+      const out = lintSource("const p = 'CCSM/data/ccsm.db';");
+      expect(out).toContain('uppercaseCcsm');
+    });
+  });
+
+  describe('valid (must NOT report)', () => {
+    it("allows a lowercase 'ccsm' path segment", () => {
+      const out = lintSource("path.join(root, 'ccsm', 'data');");
+      expect(out).not.toContain('uppercaseCcsm');
+    });
+    it("allows the env var name 'CCSM_DAEMON_SECRET'", () => {
+      const out = lintSource("const k = 'CCSM_DAEMON_SECRET';");
+      expect(out).not.toContain('uppercaseCcsm');
+    });
+    it("allows the macOS bundle name 'CCSM.app'", () => {
+      const out = lintSource("path.join(out, 'CCSM.app', 'Contents');");
+      expect(out).not.toContain('uppercaseCcsm');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

P0 Linux dogfood blocker (frag-11 §11.6). NSIS uninstaller + daemon resolver use lowercase `ccsm`, but a regression in `tests/e2e/crash-phase1.probe.ts` hard-coded uppercase `CCSM` for the dataRoot crash dir. On Linux that means the probe writes to a parallel directory the daemon never reads, masking real crash regressions and (in the wider failure mode the audit calls out) leaving uninstall + first-boot in an inconsistent state.

## Sweep findings

- `tests/e2e/crash-phase1.probe.ts` — **path literal fixed** (`CCSM` → `ccsm` for win32/darwin/linux).
- `electron/main.ts:45-47` and `electron/crash/incident-dir.ts:29-34` (audit hits) — already lowercase; verified, no change.
- `daemon/src/db/ensure-data-dir.ts` resolver — already lowercase; verified, added migration fallback.
- macOS `CCSM.app` / Windows `CCSM.exe` / `CCSM Dev.exe` — exempt; those come from `productName: "CCSM"`, not the dataRoot.
- `daemon/src/db/__tests__/migration-events.test.ts` legacy `Roaming/CCSM` fixture — kept (it's the v0.2 source path the migration helper exists to read), with inline rule disable.

## Lock-in

1. **ESLint rule** `local/no-uppercase-ccsm-path` (in `eslint-rules/`) flags path-shaped literals (`'CCSM'` as a `path.join` arg, or any `/CCSM/`-shaped string) while exempting env-var names (`CCSM_*`) and macOS/Windows binary names. Reverse-verified with **3 invalid + 3 valid** fixtures in `tests/eslint-rules/no-uppercase-ccsm-path.test.ts`.

2. **Daemon migration fallback** — `ensureDataDir()` on non-Windows now calls `migrateLegacyUppercaseDataRoot()`: if the canonical lowercase root is missing AND a sibling `<parent>/CCSM/` exists, rename it into place and emit a single canonical log line `ccsm_path_migrated from=<legacy> to=<canonical>` to stderr. Best-effort; failures fall through to fresh start. Skipped on Windows (FS is case-insensitive).

## Files changed

- `tests/e2e/crash-phase1.probe.ts` — bug fix (path literal lowercase)
- `daemon/src/db/ensure-data-dir.ts` — `+migrateLegacyUppercaseDataRoot()`, wired into `ensureDataDir()`
- `eslint-rules/no-uppercase-ccsm-path.js` — new local rule
- `eslint.config.js` — register local plugin, ignore `eslint-rules/`
- `tests/eslint-rules/no-uppercase-ccsm-path.test.ts` — 3 invalid + 3 valid reverse-verify
- `daemon/src/db/__tests__/lowercase-data-root.test.ts` — resolver invariant + migration tests (POSIX-gated)
- `daemon/src/db/__tests__/migration-events.test.ts` — inline rule disable on legacy v0.2 fixture

## Test plan

- [x] `npm run lint` — 0 errors (rule fires on seeded uppercase, legitimate uses exempt)
- [x] `npx tsc --noEmit -p tsconfig.electron.json` — clean
- [x] `npx tsc --noEmit -p daemon/tsconfig.json` — clean
- [x] `npx vitest run` on touched suites — 38 passed, 4 skipped (migration tests gated on POSIX host; resolver invariant runs everywhere)
- [ ] Pre-existing failures in `daemon/src/db/__tests__/migrate-v02-to-v03.test.ts` etc. are `better-sqlite3` NODE_MODULE_VERSION 145/137 mismatch, and `electron-load-smoke` requires `dist/electron` to be built — both unrelated to this change (verified by `git stash` + retry on `origin/working`).
- [ ] Manual Linux verification recommended once a build is cut: install → run → uninstall and confirm `~/.local/share/ccsm/` is the only path used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)