### PR TITLE
test: v0.3 task #128 control-socket /stats p99 isolation (frag-3.4.1)

### DIFF
--- a/daemon/src/__tests__/control-socket-isolation.test.ts
+++ b/daemon/src/__tests__/control-socket-isolation.test.ts
@@ -1,0 +1,416 @@
+// Task #128 — control-socket /healthz p99 isolation under data-socket load.
+//
+// Spec citation:
+//   docs/superpowers/specs/v0.3-fragments/frag-3.4.1-envelope-hardening.md
+//   line 284: "saturated data socket does not delay control-socket /healthz
+//   p99 by >5 ms".
+//
+// Why this exists
+// ---------------
+// frag-3.4.1 §3.4.1.h splits the daemon's RPC surface into two transports:
+// the control socket (supervisor RPCs only — /healthz, /stats, daemon.hello,
+// daemon.shutdown, daemon.shutdownForUpgrade) and the data socket (every
+// other RPC, including high-throughput ptySubscribe streams). The split
+// exists precisely so a runaway data-plane producer cannot starve the
+// supervisor's liveness probe. If a saturated data socket inflated /healthz
+// p99 by more than 5 ms, three consecutive missed probes inside the §6.5
+// 15 s window would restart the daemon — turning a busy session into an
+// unrecoverable boot loop.
+//
+// Test strategy
+// -------------
+// Pure in-process integration: spin up real net.createServer transports
+// (control + data) on per-test temp socket paths, mount the real envelope
+// adapter on each accepted connection, register the real /healthz handler
+// on a real supervisor dispatcher, and drive a real data-plane handler
+// (registered for this test only) that simulates a streaming-load workload.
+// We deliberately do NOT spawn the daemon binary — pkg builds are slow and
+// the binary's only contribution to this isolation property is the wiring
+// already covered above.
+//
+// Phases:
+//   1. Baseline: 200 sequential /healthz roundtrips with the data socket idle.
+//      Capture every roundtrip latency in ms and compute p99.
+//   2. Loaded: while N concurrent data-socket clients hammer the data plane
+//      with large frames for 5 s, run another 200 /healthz roundtrips on the
+//      control socket and compute p99.
+//   3. Assert (loaded p99) - (baseline p99) < 5 ms per the spec citation.
+//
+// "Real socket, no mock" is honoured: the control + data servers are real
+// net.Server instances; the client is a real net.connect; the envelope
+// adapter is the production module; the dispatcher is the production module.
+// Only the data-plane handler is test-local (the production data-plane RPCs
+// land in later slices — but the wire-level framing is identical, so this
+// test exercises the exact event-loop path the production handlers will).
+//
+// The test is marked slow via a long testTimeout because the loaded phase
+// runs for ~5 s of wall clock by spec — well within vitest's default suite
+// budget but above a single-test default.
+
+import { Buffer } from 'node:buffer';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createConnection, type Socket } from 'node:net';
+import { performance } from 'node:perf_hooks';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createControlSocketServer, type ControlSocketServer } from '../sockets/control-socket.js';
+import { createDataSocketServer, type DataSocketServer } from '../sockets/data-socket.js';
+import { mountEnvelopeAdapter } from '../envelope/adapter.js';
+import { decodeFrame, encodeFrame, ENVELOPE_LIMITS, EnvelopeError } from '../envelope/envelope.js';
+import { createSupervisorDispatcher, createDataDispatcher } from '../dispatcher.js';
+import { makeHealthzHandler, type HealthzReply } from '../handlers/healthz.js';
+
+const isWin = process.platform === 'win32';
+
+// ---------------------------------------------------------------------------
+// Per-test fixture wiring
+// ---------------------------------------------------------------------------
+
+let scratch: string;
+const startedServers: Array<{ close: () => Promise<void> }> = [];
+const openedSockets: Socket[] = [];
+
+beforeEach(() => {
+  scratch = mkdtempSync(join(tmpdir(), 'ccsm-control-isolation-'));
+});
+
+afterEach(async () => {
+  for (const s of openedSockets) {
+    try { s.destroy(); } catch { /* ignore */ }
+  }
+  openedSockets.length = 0;
+  for (const s of startedServers) {
+    try { await s.close(); } catch { /* ignore */ }
+  }
+  startedServers.length = 0;
+  try { rmSync(scratch, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+function uniqueAddress(kind: 'control' | 'data'): string {
+  if (isWin) {
+    const tag = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    return `\\\\.\\pipe\\ccsm-${kind}-isolation-${tag}`;
+  }
+  return join(scratch, `ccsm-${kind}.sock`);
+}
+
+// ---------------------------------------------------------------------------
+// Wire helpers — real envelope frames on a real Duplex.
+// ---------------------------------------------------------------------------
+
+interface PendingCall {
+  resolve: (value: unknown) => void;
+  reject: (err: Error) => void;
+}
+
+/**
+ * Tiny connection-side client that frames RPC requests, parses replies, and
+ * resolves per-id promises. Identical wire format to the production daemon
+ * adapter (same `encodeFrame` / `decodeFrame`); simply lives on the client
+ * end of the pipe so the test can issue real roundtrips.
+ */
+class FramedClient {
+  readonly socket: Socket;
+  private nextId = 1;
+  private pending: Map<number, PendingCall> = new Map();
+  private buf: Buffer = Buffer.alloc(0);
+  private closed = false;
+
+  constructor(socket: Socket) {
+    this.socket = socket;
+    socket.on('data', (chunk: Buffer) => this.onData(chunk));
+    socket.on('close', () => {
+      this.closed = true;
+      for (const p of this.pending.values()) {
+        p.reject(new Error('socket closed'));
+      }
+      this.pending.clear();
+    });
+    socket.on('error', () => {
+      // Surface via pending call rejection on subsequent close; nothing else.
+    });
+  }
+
+  private onData(chunk: Buffer): void {
+    this.buf = this.buf.length === 0 ? chunk : Buffer.concat([this.buf, chunk]);
+    while (this.buf.length >= ENVELOPE_LIMITS.PREFIX_LEN) {
+      let decoded: ReturnType<typeof decodeFrame>;
+      try {
+        decoded = decodeFrame(this.buf);
+      } catch (err) {
+        if (err instanceof EnvelopeError && err.code === 'truncated_frame') {
+          return;
+        }
+        throw err;
+      }
+      const frameLen =
+        ENVELOPE_LIMITS.PREFIX_LEN +
+        ENVELOPE_LIMITS.HEADER_LEN_FIELD +
+        decoded.headerJson.length +
+        decoded.payload.length;
+      this.buf = this.buf.subarray(frameLen);
+      const headerObj = JSON.parse(decoded.headerJson.toString('utf8')) as {
+        id: number;
+        ok: boolean;
+        value?: unknown;
+        error?: { code: string; message: string };
+      };
+      const pending = this.pending.get(headerObj.id);
+      if (!pending) continue;
+      this.pending.delete(headerObj.id);
+      if (headerObj.ok) {
+        pending.resolve(headerObj.value);
+      } else {
+        pending.reject(
+          new Error(`${headerObj.error?.code ?? 'UNKNOWN'}: ${headerObj.error?.message ?? ''}`),
+        );
+      }
+    }
+  }
+
+  call(method: string, args: Record<string, unknown> = {}, payload?: Buffer): Promise<unknown> {
+    if (this.closed) return Promise.reject(new Error('client closed'));
+    const id = this.nextId++;
+    const header = { id, method, payloadType: payload && payload.length > 0 ? 'binary' : 'json', payloadLen: payload?.length ?? 0, ...args };
+    const frame = encodeFrame({
+      headerJson: Buffer.from(JSON.stringify(header), 'utf8'),
+      ...(payload ? { payload } : {}),
+    });
+    return new Promise<unknown>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.socket.write(frame);
+    });
+  }
+
+  destroy(): void {
+    this.closed = true;
+    try { this.socket.destroy(); } catch { /* ignore */ }
+  }
+}
+
+function clientConnect(addr: string): Promise<Socket> {
+  return new Promise<Socket>((resolve, reject) => {
+    const s = createConnection(addr);
+    openedSockets.push(s);
+    s.once('connect', () => resolve(s));
+    s.once('error', reject);
+  });
+}
+
+async function newClient(addr: string): Promise<FramedClient> {
+  const sock = await clientConnect(addr);
+  return new FramedClient(sock);
+}
+
+// ---------------------------------------------------------------------------
+// Statistics
+// ---------------------------------------------------------------------------
+
+function percentile(samplesMs: number[], p: number): number {
+  if (samplesMs.length === 0) return Number.NaN;
+  const sorted = [...samplesMs].sort((a, b) => a - b);
+  // Nearest-rank percentile (deterministic across implementations).
+  const rank = Math.ceil((p / 100) * sorted.length);
+  const idx = Math.min(sorted.length - 1, Math.max(0, rank - 1));
+  return sorted[idx]!;
+}
+
+// ---------------------------------------------------------------------------
+// Test
+// ---------------------------------------------------------------------------
+
+describe('control-socket /healthz p99 isolation under data-socket load (frag-3.4.1 line 284)', () => {
+  // CURRENT STATE — daemon FAILS this assertion today (see PR body for measured
+  // numbers). The control + data dispatchers share a single Node event loop;
+  // saturating the data-socket envelope adapter with binary frames blocks
+  // /healthz dispatch on the same loop. `it.fails` is the regression-marker
+  // pattern: vitest treats this as PASS only while the assertion fails. The
+  // moment frag-3.4.1 line 284 starts holding (worker_thread isolation, async
+  // yields in the adapter, or data-plane process split — whichever the fix
+  // task chooses), this `.fails` will go red and force the assertion be
+  // flipped back to the unconditional `it()` form. That is intentional — it
+  // makes the spec gap visible in CI without leaving the suite red.
+  //
+  // Follow-up task (split per dev contract "如果 fail, split 出 N15-fix 子
+  // task"): event-loop isolation between supervisor and data planes.
+  // Candidate fixes — worker_thread for binary frame parsing OR setImmediate
+  // yield inside `processBuffer` between frames OR child-process data plane.
+  it.fails(
+    'saturated data socket does not delay control-socket /healthz p99 by >5 ms',
+    async () => {
+      // -------- Wire control + data servers with real adapters + dispatchers
+      const supervisorDispatcher = createSupervisorDispatcher();
+      const bootedAtMs = Date.now();
+      supervisorDispatcher.register(
+        '/healthz',
+        makeHealthzHandler({
+          bootNonce: '01HZZZISOLATIONXXXXXXXXXXX',
+          pid: process.pid,
+          version: '0.3.0-isolation-test',
+          bootedAtMs,
+          now: () => Date.now(),
+        }),
+      );
+
+      const dataDispatcher = createDataDispatcher();
+      // Test-local data-plane RPC: simulates the per-frame work a real
+      // streaming handler would do (parse incoming binary, allocate a reply,
+      // hand back). The point is to keep the daemon's event loop genuinely
+      // busy so any cross-plane interference would surface here.
+      let dataReqCount = 0;
+      dataDispatcher.register('test.dataLoad', async (req: unknown) => {
+        dataReqCount += 1;
+        // Touch the binary payload so V8 cannot optimise it away.
+        let acc = 0;
+        const r = req as { payload?: Buffer };
+        if (r?.payload && Buffer.isBuffer(r.payload)) {
+          // Sample every 4 KiB — keeps the work O(payloadLen / 4096) which
+          // matches the cost a real binary handler would incur (frame walk).
+          for (let i = 0; i < r.payload.length; i += 4096) {
+            acc = (acc + r.payload[i]!) | 0;
+          }
+        }
+        return { ok: true, acc };
+      });
+
+      const controlAddr = uniqueAddress('control');
+      const dataAddr = uniqueAddress('data');
+
+      const control: ControlSocketServer = createControlSocketServer({
+        runtimeRoot: scratch,
+        socketPath: controlAddr,
+        // Disable rate cap for this test — the cap is a separate concern
+        // (#15 round-2 security) and would otherwise drop our 200-shot probe
+        // when bursts collide with the 50/sec ceiling.
+        maxAcceptPerSec: 100_000,
+        onConnection: (sock) => {
+          mountEnvelopeAdapter({ socket: sock, dispatcher: supervisorDispatcher });
+        },
+      });
+      startedServers.push(control);
+      await control.listen();
+
+      const data: DataSocketServer = createDataSocketServer({
+        runtimeRoot: scratch,
+        socketPath: dataAddr,
+        maxAcceptPerSec: 100_000,
+        onConnection: ({ socket }) => {
+          mountEnvelopeAdapter({ socket, dispatcher: dataDispatcher });
+        },
+      });
+      startedServers.push(data);
+      await data.listen();
+
+      // -------- Phase 1: BASELINE /healthz p99 (no data load)
+      const ctlClientBaseline = await newClient(controlAddr);
+      const baseline: number[] = [];
+      // Warmup — JIT + first connection cost should not pollute the sample.
+      for (let i = 0; i < 20; i++) {
+        await ctlClientBaseline.call('/healthz');
+      }
+      for (let i = 0; i < 200; i++) {
+        const t0 = performance.now();
+        const reply = (await ctlClientBaseline.call('/healthz')) as HealthzReply;
+        const t1 = performance.now();
+        baseline.push(t1 - t0);
+        expect(reply.healthzVersion).toBe(1);
+      }
+      ctlClientBaseline.destroy();
+
+      // -------- Phase 2: LOADED /healthz p99 (data socket saturated)
+      // Spawn data-plane producers that hammer the data socket with sizable
+      // binary frames for 5 s. We use multiple concurrent connections to
+      // exercise the multiplex path (ptySubscribe-style fan-in). 256 KiB per
+      // frame is a realistic order of magnitude for a busy PTY burst —
+      // smaller frames understate event-loop pressure; bigger frames hit the
+      // 16 MiB envelope cap (and would dwarf any real workload).
+      const dataLoadEndAt = Date.now() + 5_000;
+      const PRODUCER_COUNT = 4;
+      const PAYLOAD_BYTES = 256 * 1024;
+      const producerPayload = Buffer.alloc(PAYLOAD_BYTES, 0xab);
+      const producers: FramedClient[] = [];
+      for (let p = 0; p < PRODUCER_COUNT; p++) {
+        producers.push(await newClient(dataAddr));
+      }
+
+      // Each producer keeps a small in-flight pipeline so the daemon side
+      // is genuinely back-to-back busy (a strict lockstep client/server
+      // ping-pong would idle the loop between roundtrips and let /healthz
+      // sneak through a quiet window — that would pass the assertion for
+      // the wrong reason).
+      const PIPELINE_DEPTH = 4;
+      const producerLoops: Promise<void>[] = [];
+      for (const prod of producers) {
+        producerLoops.push((async () => {
+          while (Date.now() < dataLoadEndAt) {
+            const inflight: Promise<unknown>[] = [];
+            for (let i = 0; i < PIPELINE_DEPTH; i++) {
+              inflight.push(prod.call('test.dataLoad', {}, producerPayload).catch(() => null));
+            }
+            await Promise.all(inflight);
+          }
+        })());
+      }
+
+      // While the data plane is hot, run the loaded /healthz probe campaign
+      // on a fresh control connection. We use a fresh connection so the
+      // baseline-warmup state of the previous client cannot bias either
+      // sample. Brief stagger so the producers reach steady-state load.
+      await new Promise((r) => setTimeout(r, 100));
+
+      const ctlClientLoaded = await newClient(controlAddr);
+      // Warmup again on the loaded connection.
+      for (let i = 0; i < 20; i++) {
+        await ctlClientLoaded.call('/healthz');
+      }
+      const loaded: number[] = [];
+      // Spread the 200 probes across the remaining load window so the sample
+      // covers the full saturated period (not just a 100 ms burst at start).
+      const probeIntervalMs = Math.max(
+        1,
+        Math.floor((dataLoadEndAt - Date.now() - 200) / 200),
+      );
+      for (let i = 0; i < 200; i++) {
+        const t0 = performance.now();
+        const reply = (await ctlClientLoaded.call('/healthz')) as HealthzReply;
+        const t1 = performance.now();
+        loaded.push(t1 - t0);
+        expect(reply.healthzVersion).toBe(1);
+        if (probeIntervalMs > 0) {
+          await new Promise((r) => setTimeout(r, probeIntervalMs));
+        }
+      }
+      ctlClientLoaded.destroy();
+
+      // Wait for producers to wind down, then tear down.
+      await Promise.all(producerLoops);
+      for (const p of producers) p.destroy();
+
+      // -------- Assert
+      const baselineP99 = percentile(baseline, 99);
+      const loadedP99 = percentile(loaded, 99);
+      const baselineP50 = percentile(baseline, 50);
+      const loadedP50 = percentile(loaded, 50);
+      const delta = loadedP99 - baselineP99;
+
+      // Ship the measured numbers in CI logs so manager can read p99 deltas
+      // without re-running.
+      console.log(
+        `[control-socket-isolation] dataReqs=${dataReqCount} ` +
+          `baseline p50=${baselineP50.toFixed(2)}ms p99=${baselineP99.toFixed(2)}ms ` +
+          `loaded p50=${loadedP50.toFixed(2)}ms p99=${loadedP99.toFixed(2)}ms ` +
+          `delta=${delta.toFixed(2)}ms (budget <5ms)`,
+      );
+
+      // Sanity: data load actually ran (otherwise the assertion is vacuous).
+      expect(dataReqCount).toBeGreaterThan(50);
+
+      // The headline assertion from frag-3.4.1 line 284.
+      expect(delta).toBeLessThan(5);
+    },
+    // 30 s test budget — load phase is 5 s wall clock + setup/teardown.
+    30_000,
+  );
+});


### PR DESCRIPTION
## Summary

Adds the regression-marker test for **frag-3.4.1 line 284** spec assertion:

> "saturated data socket does not delay control-socket /healthz p99 by >5 ms"

Real socket roundtrip (no mock): real `net.createServer` control + data transports on per-test temp paths, real `mountEnvelopeAdapter` on each accepted connection, real `createSupervisorDispatcher` + `createDataDispatcher`, real `makeHealthzHandler`. Only the data-plane handler is test-local (`test.dataLoad` — touches its binary payload to keep V8 honest); production data-plane RPCs land in later slices but ride the same event-loop / framing path so this measurement transfers.

Test geometry:
- Baseline: 200 sequential `/healthz` calls, data socket idle → p99
- Loaded:   4 producers x 256 KiB binary frames x 4-deep pipeline x 5 s wall clock, 200 `/healthz` calls staggered across the load window → p99
- Assert: `(loaded p99) - (baseline p99) < 5 ms`

## Measured numbers (this run, Windows 11, Node default)

| | p50 | p99 |
|---|---|---|
| baseline | 0.15 ms | 0.38 ms |
| loaded | 3.09 ms | **37.47 ms** |
| delta | — | **37.10 ms (budget <5 ms — VIOLATES spec by 32 ms)** |

Data-plane request count during the loaded phase: **2336** (sanity: load actually ran).

## Status: regression marker

Daemon currently **FAILS** the spec assertion. The supervisor and data dispatchers share a single Node event loop; saturating the data-socket envelope adapter with binary frames blocks `/healthz` dispatch on the same loop. The two-socket topology (frag-3.4.1 §3.4.1.h) provides surface-area isolation (auth/access control), not CPU isolation.

To keep the suite green while pinning the violation, the test uses `it.fails(...)`. Vitest treats this as PASS only while the inner assertion fails; the moment isolation lands, `.fails` will go red and force the assertion be flipped to unconditional `it()`. The spec gap is therefore visible in CI without leaving the suite red.

## Follow-up (N15-fix candidate)

Event-loop isolation between supervisor and data planes. Candidates:
- `worker_thread` for envelope parsing (data plane only — supervisor stays on main loop)
- `setImmediate` yield inside `processBuffer` between frames in `daemon/src/envelope/adapter.ts` (cheap; may not be enough)
- Child-process data plane (heaviest)

## Test plan

- [x] `npx tsc -p daemon/tsconfig.json --noEmit` clean
- [x] `npx eslint daemon/src/__tests__/control-socket-isolation.test.ts` clean
- [x] `npx vitest run daemon/src/__tests__/control-socket-isolation.test.ts` green (1 expected fail)
- [x] Real socket roundtrip — no mocks; real `net.connect` clients; real envelope frames

🤖 Generated with [Claude Code](https://claude.com/claude-code)