### PR TITLE
feat: v0.3 task #129 envelope trace + metrics interceptor (frag-3.4.1 §3.4.1.f)

### DIFF
--- a/daemon/src/envelope/__tests__/metrics-interceptor.test.ts
+++ b/daemon/src/envelope/__tests__/metrics-interceptor.test.ts
@@ -1,0 +1,162 @@
+// Tests for metrics-interceptor.ts (frag-3.4.1 §3.4.1.f "metrics" slot).
+//
+// Coverage:
+//   - 10 calls round-trip → requests counter == 10, errors == 1 when one of
+//     them recorded an error (task-brief assertion).
+//   - per-method isolation; per-code error breakdown.
+//   - histogram bucketing: samples land in the smallest bucket whose `le`
+//     bound covers them; oversized samples land in `+Inf`.
+//   - snapshot deep-frozen so handlers cannot mutate the live registry.
+//   - Prometheus formatter emits a counter+histogram block per method and
+//     escapes label values.
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  HISTOGRAM_BUCKETS_MS,
+  MetricsRegistry,
+} from '../metrics-interceptor.js';
+
+describe('MetricsRegistry — request / error counters', () => {
+  it('counts 10 requests and 1 error end-to-end', () => {
+    const reg = new MetricsRegistry();
+    for (let i = 0; i < 10; i += 1) {
+      reg.recordRequest('ccsm.v1/healthz');
+    }
+    reg.recordError('ccsm.v1/healthz', 'INTERNAL');
+    const snap = reg.snapshot();
+    expect(snap['ccsm.v1/healthz']?.requests).toBe(10);
+    expect(snap['ccsm.v1/healthz']?.errors).toBe(1);
+    expect(snap['ccsm.v1/healthz']?.errorsByCode).toEqual({ INTERNAL: 1 });
+  });
+
+  it('keeps per-method counters isolated', () => {
+    const reg = new MetricsRegistry();
+    reg.recordRequest('ccsm.v1/healthz');
+    reg.recordRequest('ccsm.v1/daemon.hello');
+    reg.recordRequest('ccsm.v1/daemon.hello');
+    reg.recordError('ccsm.v1/daemon.hello', 'hello_replay');
+    const snap = reg.snapshot();
+    expect(snap['ccsm.v1/healthz']?.requests).toBe(1);
+    expect(snap['ccsm.v1/healthz']?.errors).toBe(0);
+    expect(snap['ccsm.v1/daemon.hello']?.requests).toBe(2);
+    expect(snap['ccsm.v1/daemon.hello']?.errors).toBe(1);
+    expect(snap['ccsm.v1/daemon.hello']?.errorsByCode).toEqual({ hello_replay: 1 });
+  });
+
+  it('breaks errors down by code when supplied', () => {
+    const reg = new MetricsRegistry();
+    reg.recordError('m', 'INTERNAL');
+    reg.recordError('m', 'INTERNAL');
+    reg.recordError('m', 'MIGRATION_PENDING');
+    reg.recordError('m'); // unkeyed — total bumps but no code sub-counter
+    const snap = reg.snapshot();
+    expect(snap['m']?.errors).toBe(4);
+    expect(snap['m']?.errorsByCode).toEqual({ INTERNAL: 2, MIGRATION_PENDING: 1 });
+  });
+});
+
+describe('MetricsRegistry — duration histogram', () => {
+  it('places samples in the smallest covering bucket', () => {
+    const reg = new MetricsRegistry();
+    reg.recordDuration('m', 0); // <= 1
+    reg.recordDuration('m', 3); // <= 5
+    reg.recordDuration('m', 50); // <= 50
+    reg.recordDuration('m', 99); // <= 100
+    const snap = reg.snapshot();
+    const buckets = snap['m']?.durationBuckets ?? [];
+    // HISTOGRAM_BUCKETS_MS = [1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000, 120000]
+    const idxLe1 = HISTOGRAM_BUCKETS_MS.indexOf(1);
+    const idxLe5 = HISTOGRAM_BUCKETS_MS.indexOf(5);
+    const idxLe50 = HISTOGRAM_BUCKETS_MS.indexOf(50);
+    const idxLe100 = HISTOGRAM_BUCKETS_MS.indexOf(100);
+    expect(buckets[idxLe1]).toBe(1);
+    expect(buckets[idxLe5]).toBe(1);
+    expect(buckets[idxLe50]).toBe(1);
+    expect(buckets[idxLe100]).toBe(1);
+    expect(snap['m']?.durationCount).toBe(4);
+    expect(snap['m']?.durationSumMs).toBe(0 + 3 + 50 + 99);
+  });
+
+  it('lands oversize samples in the +Inf bucket', () => {
+    const reg = new MetricsRegistry();
+    reg.recordDuration('m', 999_999);
+    const snap = reg.snapshot();
+    const buckets = snap['m']?.durationBuckets ?? [];
+    expect(buckets[buckets.length - 1]).toBe(1);
+    expect(snap['m']?.durationCount).toBe(1);
+  });
+
+  it('clamps negative durations to 0', () => {
+    const reg = new MetricsRegistry();
+    reg.recordDuration('m', -10);
+    const snap = reg.snapshot();
+    expect(snap['m']?.durationSumMs).toBe(0);
+    // Sample lands in the first bucket (<= 1).
+    expect(snap['m']?.durationBuckets[0]).toBe(1);
+  });
+});
+
+describe('MetricsRegistry — snapshot immutability', () => {
+  it('returns a deep-frozen object', () => {
+    const reg = new MetricsRegistry();
+    reg.recordRequest('m');
+    const snap = reg.snapshot();
+    expect(Object.isFrozen(snap)).toBe(true);
+    expect(Object.isFrozen(snap['m'])).toBe(true);
+    expect(Object.isFrozen(snap['m']?.errorsByCode)).toBe(true);
+    expect(Object.isFrozen(snap['m']?.durationBuckets)).toBe(true);
+  });
+
+  it('snapshot does not reflect post-snapshot mutations (defensive copy)', () => {
+    const reg = new MetricsRegistry();
+    reg.recordRequest('m');
+    const snap = reg.snapshot();
+    reg.recordRequest('m');
+    expect(snap['m']?.requests).toBe(1);
+    expect(reg.snapshot()['m']?.requests).toBe(2);
+  });
+});
+
+describe('MetricsRegistry — Prometheus exposition', () => {
+  it('emits HELP/TYPE blocks and method-keyed series', () => {
+    const reg = new MetricsRegistry();
+    reg.recordRequest('ccsm.v1/healthz');
+    reg.recordRequest('ccsm.v1/healthz');
+    reg.recordError('ccsm.v1/healthz', 'INTERNAL');
+    reg.recordDuration('ccsm.v1/healthz', 7);
+    const text = reg.formatPrometheus();
+    expect(text).toContain('# TYPE ccsm_envelope_requests_total counter');
+    expect(text).toContain('ccsm_envelope_requests_total{method="ccsm.v1/healthz"} 2');
+    expect(text).toContain('# TYPE ccsm_envelope_errors_total counter');
+    expect(text).toContain(
+      'ccsm_envelope_errors_total{method="ccsm.v1/healthz",code=""} 1',
+    );
+    expect(text).toContain(
+      'ccsm_envelope_errors_total{method="ccsm.v1/healthz",code="INTERNAL"} 1',
+    );
+    expect(text).toContain('# TYPE ccsm_envelope_duration_ms histogram');
+    expect(text).toContain('ccsm_envelope_duration_ms_count{method="ccsm.v1/healthz"} 1');
+    expect(text).toContain('ccsm_envelope_duration_ms_sum{method="ccsm.v1/healthz"} 7');
+    expect(text).toContain('le="+Inf"');
+    expect(text.endsWith('\n')).toBe(true);
+  });
+
+  it('escapes special characters in label values', () => {
+    const reg = new MetricsRegistry();
+    reg.recordError('quote"method', 'has\nnewline');
+    const text = reg.formatPrometheus();
+    expect(text).toContain('quote\\"method');
+    expect(text).toContain('has\\nnewline');
+  });
+});
+
+describe('MetricsRegistry — reset', () => {
+  it('drops all per-method counters', () => {
+    const reg = new MetricsRegistry();
+    reg.recordRequest('m');
+    reg.recordError('m', 'X');
+    reg.reset();
+    expect(reg.snapshot()).toEqual({});
+  });
+});

--- a/daemon/src/envelope/__tests__/trace-interceptor.test.ts
+++ b/daemon/src/envelope/__tests__/trace-interceptor.test.ts
@@ -1,0 +1,191 @@
+// Tests for trace-interceptor.ts (frag-3.4.1 §3.4.1.f "trace" slot).
+//
+// Coverage:
+//   - resolveTraceId: caller-supplied wins; empty / whitespace falls through
+//     to the minter; minted id uses 32-char hex (16-byte) format.
+//   - startTrace + formatCompletionLog: deterministic durationMs computation
+//     under an injected clock; Math.max guard against non-monotonic clock.
+//   - runWithTrace: round-trip propagates traceId into the handler context;
+//     completion log lands once on success and once on throw with code
+//     'INTERNAL'; thrown error rethrown unchanged.
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  defaultMintTraceId,
+  formatCompletionLog,
+  resolveTraceId,
+  runWithTrace,
+  startTrace,
+  TRACE_ID_BYTES,
+  TRACE_LOG_EVENT,
+  type TraceCompletionLog,
+} from '../trace-interceptor.js';
+
+describe('resolveTraceId', () => {
+  it('returns the caller-supplied traceId when present', () => {
+    const out = resolveTraceId({ traceId: '01HZZZCALLERTRACEID0001' }, () => 'minted');
+    expect(out).toBe('01HZZZCALLERTRACEID0001');
+  });
+
+  it('mints a fresh id when the envelope omits traceId', () => {
+    const out = resolveTraceId({}, () => 'minted-stub');
+    expect(out).toBe('minted-stub');
+  });
+
+  it('mints when the supplied traceId is the empty string', () => {
+    const out = resolveTraceId({ traceId: '' }, () => 'minted-stub');
+    expect(out).toBe('minted-stub');
+  });
+
+  it('mints when the supplied traceId is whitespace-only', () => {
+    const out = resolveTraceId({ traceId: '   ' }, () => 'minted-stub');
+    expect(out).toBe('minted-stub');
+  });
+
+  it('mints when traceId is null (defensive — JSON.parse can produce null)', () => {
+    const out = resolveTraceId({ traceId: null }, () => 'minted-stub');
+    expect(out).toBe('minted-stub');
+  });
+
+  it('default minter produces 32-char hex (16 bytes)', () => {
+    const id = defaultMintTraceId();
+    expect(id).toMatch(/^[0-9a-f]+$/);
+    expect(id).toHaveLength(TRACE_ID_BYTES * 2);
+  });
+
+  it('default minter is non-deterministic (entropy check)', () => {
+    const a = defaultMintTraceId();
+    const b = defaultMintTraceId();
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('startTrace + formatCompletionLog', () => {
+  it('records start time from the injected clock', () => {
+    const span = startTrace('ccsm.v1/healthz', 'trace-a', () => 1000);
+    expect(span).toEqual({ method: 'ccsm.v1/healthz', traceId: 'trace-a', startedMs: 1000 });
+  });
+
+  it('computes durationMs from start to completion clock reading', () => {
+    const span = startTrace('ccsm.v1/healthz', 'trace-a', () => 1000);
+    const log = formatCompletionLog(span, 'ok', () => 1042);
+    expect(log).toEqual<TraceCompletionLog>({
+      event: TRACE_LOG_EVENT,
+      method: 'ccsm.v1/healthz',
+      traceId: 'trace-a',
+      durationMs: 42,
+      code: 'ok',
+    });
+  });
+
+  it('clamps negative duration to 0 (non-monotonic clock guard)', () => {
+    const span = startTrace('ccsm.v1/healthz', 'trace-a', () => 5000);
+    const log = formatCompletionLog(span, 'ok', () => 4000);
+    expect(log.durationMs).toBe(0);
+  });
+
+  it('passes through arbitrary error code strings', () => {
+    const span = startTrace('ccsm.v1/x', 'trace-z', () => 0);
+    const log = formatCompletionLog(span, 'MIGRATION_PENDING', () => 7);
+    expect(log.code).toBe('MIGRATION_PENDING');
+  });
+});
+
+describe('runWithTrace — round-trip', () => {
+  it('propagates the resolved traceId into the handler context', async () => {
+    const sink: TraceCompletionLog[] = [];
+    let seenTraceId = '';
+    const out = await runWithTrace<string>({
+      envelope: { traceId: 'caller-trace-1' },
+      method: 'ccsm.v1/daemon.hello',
+      handler: async (ctx) => {
+        seenTraceId = ctx.traceId;
+        return { value: 'hello-reply' };
+      },
+      sink: (r) => sink.push(r),
+      clock: stepClock([100, 105]),
+    });
+    expect(out).toBe('hello-reply');
+    expect(seenTraceId).toBe('caller-trace-1');
+    expect(sink).toEqual([
+      {
+        event: TRACE_LOG_EVENT,
+        method: 'ccsm.v1/daemon.hello',
+        traceId: 'caller-trace-1',
+        durationMs: 5,
+        code: 'ok',
+      },
+    ]);
+  });
+
+  it('mints a traceId when the envelope omits one and propagates the same id to the log', async () => {
+    const sink: TraceCompletionLog[] = [];
+    let seenTraceId = '';
+    await runWithTrace<number>({
+      envelope: {},
+      method: 'ccsm.v1/healthz',
+      handler: async (ctx) => {
+        seenTraceId = ctx.traceId;
+        return { value: 1 };
+      },
+      sink: (r) => sink.push(r),
+      mintTraceId: () => 'minted-xyz',
+      clock: stepClock([10, 20]),
+    });
+    expect(seenTraceId).toBe('minted-xyz');
+    expect(sink).toHaveLength(1);
+    expect(sink[0]?.traceId).toBe('minted-xyz');
+  });
+
+  it('records completion log THEN rethrows on handler failure with code=INTERNAL', async () => {
+    const sink: TraceCompletionLog[] = [];
+    const boom = new Error('handler exploded');
+    await expect(
+      runWithTrace<never>({
+        envelope: { traceId: 'caller-trace-2' },
+        method: 'ccsm.v1/daemon.shutdown',
+        handler: async () => {
+          throw boom;
+        },
+        sink: (r) => sink.push(r),
+        clock: stepClock([200, 250]),
+      }),
+    ).rejects.toBe(boom);
+    expect(sink).toEqual([
+      {
+        event: TRACE_LOG_EVENT,
+        method: 'ccsm.v1/daemon.shutdown',
+        traceId: 'caller-trace-2',
+        durationMs: 50,
+        code: 'INTERNAL',
+      },
+    ]);
+  });
+
+  it('honours a handler-supplied non-ok code without throwing', async () => {
+    const sink: TraceCompletionLog[] = [];
+    await runWithTrace<null>({
+      envelope: { traceId: 't' },
+      method: 'ccsm.v1/daemon.hello',
+      handler: async () => ({ value: null, code: 'NOT_IMPLEMENTED' }),
+      sink: (r) => sink.push(r),
+      clock: stepClock([0, 1]),
+    });
+    expect(sink[0]?.code).toBe('NOT_IMPLEMENTED');
+  });
+});
+
+/**
+ * Build a deterministic clock stub that yields successive readings on each
+ * call. The trace pipeline reads the clock at most twice per RPC (start +
+ * completion); tests pass a 2-element array and assert the resulting span.
+ */
+function stepClock(readings: readonly number[]): () => number {
+  let i = 0;
+  return () => {
+    const v = readings[Math.min(i, readings.length - 1)];
+    i += 1;
+    return v as number;
+  };
+}

--- a/daemon/src/envelope/metrics-interceptor.ts
+++ b/daemon/src/envelope/metrics-interceptor.ts
@@ -1,0 +1,232 @@
+// L1 envelope metrics interceptor (spec §3.4.1.f built-in interceptor list —
+// slot "metrics", LAST in the chain, runs after trace / hello / deadline /
+// migrationGate so a request rejected by an upstream interceptor still
+// increments the appropriate counter via its own `recordError(method, code)`
+// call site).
+//
+// Spec citations:
+//   - docs/superpowers/specs/v0.3-fragments/frag-3.4.1-envelope-hardening.md
+//     §3.4.1.f built-in interceptor list ("metrics" — per-method counters).
+//   - Same fragment §3.4.1.h SUPERVISOR_RPCS list — `/stats` is an existing
+//     supervisor RPC; the metrics snapshot produced here is the data backing
+//     that endpoint (handler wiring is out of scope for this module — the
+//     handler queries `MetricsRegistry.snapshot()` / `formatPrometheus()`).
+//
+// Single Responsibility (producer / decider / sink):
+//   - This module owns ONE thing: an in-memory per-method counter table.
+//     - `recordRequest(method)`               — bump request counter.
+//     - `recordError(method, code?)`          — bump error counter (optionally
+//                                              per error-code sub-counter).
+//     - `recordDuration(method, durationMs)`  — push into the per-method
+//                                              histogram bucket array.
+//     - `snapshot()`                          — read-only structured snapshot.
+//     - `formatPrometheus()`                  — text-exposition for `/metrics`.
+//     - `reset()`                             — test-facing wipe.
+//   - It does NOT read the wall-clock (caller passes pre-computed durationMs
+//     from the trace span), does NOT subscribe to any event bus, does NOT
+//     spawn timers, does NOT touch the network. The HTTP / envelope handler
+//     that surfaces `/stats` calls `formatPrometheus()` synchronously.
+
+/**
+ * Histogram bucket boundaries in milliseconds. Bucket `i` counts samples with
+ * `durationMs <= HISTOGRAM_BUCKETS_MS[i]`; the implicit `+Inf` bucket is the
+ * total request count (Prometheus convention). Boundaries cover the v0.3
+ * envelope deadline range [100 ms .. 120 s] plus sub-100 ms cells for fast
+ * supervisor RPCs (`/healthz`).
+ */
+export const HISTOGRAM_BUCKETS_MS: readonly number[] = [
+  1, 5, 10, 25, 50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000, 30_000, 120_000,
+] as const;
+
+/** Per-method counter snapshot (read-only). */
+export interface MethodCounters {
+  readonly requests: number;
+  readonly errors: number;
+  /**
+   * Errors bucketed by wire code (`'hello_required'`, `'MIGRATION_PENDING'`,
+   * `'INTERNAL'`, etc.). Kept as a plain object so JSON serialisation in
+   * `/stats` is one line; ordering is insertion-order which is fine for
+   * forensic dumps.
+   */
+  readonly errorsByCode: Readonly<Record<string, number>>;
+  /**
+   * Histogram bucket counts aligned with {@link HISTOGRAM_BUCKETS_MS}. Length
+   * is `HISTOGRAM_BUCKETS_MS.length + 1`; the trailing entry is the `+Inf`
+   * bucket (samples larger than any defined boundary).
+   */
+  readonly durationBuckets: readonly number[];
+  /** Sum of all observed `durationMs` samples. Prometheus convention. */
+  readonly durationSumMs: number;
+  /** Count of `recordDuration` calls. Equals sum of `durationBuckets` entries. */
+  readonly durationCount: number;
+}
+
+/** Full registry snapshot, keyed by method name. */
+export type MetricsSnapshot = Readonly<Record<string, MethodCounters>>;
+
+interface MutableMethodCounters {
+  requests: number;
+  errors: number;
+  errorsByCode: Map<string, number>;
+  durationBuckets: number[];
+  durationSumMs: number;
+  durationCount: number;
+}
+
+/**
+ * Per-method in-memory counter table. One instance per daemon process; the
+ * supervisor wires it into the envelope dispatcher (and into the `/stats`
+ * handler). Tests instantiate a fresh registry per case for isolation.
+ *
+ * Concurrency note: Node's event loop is single-threaded, so `recordX` calls
+ * are atomic by construction. No locking needed.
+ */
+export class MetricsRegistry {
+  private readonly methods = new Map<string, MutableMethodCounters>();
+
+  private getOrCreate(method: string): MutableMethodCounters {
+    let entry = this.methods.get(method);
+    if (entry === undefined) {
+      entry = {
+        requests: 0,
+        errors: 0,
+        errorsByCode: new Map(),
+        // +1 for the `+Inf` bucket.
+        durationBuckets: new Array(HISTOGRAM_BUCKETS_MS.length + 1).fill(0),
+        durationSumMs: 0,
+        durationCount: 0,
+      };
+      this.methods.set(method, entry);
+    }
+    return entry;
+  }
+
+  /** Bump the per-method request counter. Call once per inbound envelope. */
+  recordRequest(method: string): void {
+    this.getOrCreate(method).requests += 1;
+  }
+
+  /**
+   * Bump the per-method error counter (and optionally a per-code sub-counter).
+   * Pass `code` for finer breakdown in the snapshot — omit when the caller
+   * only knows that *something* failed.
+   */
+  recordError(method: string, code?: string): void {
+    const entry = this.getOrCreate(method);
+    entry.errors += 1;
+    if (code !== undefined && code !== '') {
+      entry.errorsByCode.set(code, (entry.errorsByCode.get(code) ?? 0) + 1);
+    }
+  }
+
+  /**
+   * Push a `durationMs` observation into the histogram. Negative values are
+   * clamped to 0 (cf. {@link formatCompletionLog} which does the same on a
+   * non-monotonic clock).
+   */
+  recordDuration(method: string, durationMs: number): void {
+    const entry = this.getOrCreate(method);
+    const sample = Math.max(0, durationMs);
+    entry.durationSumMs += sample;
+    entry.durationCount += 1;
+    let placed = false;
+    for (let i = 0; i < HISTOGRAM_BUCKETS_MS.length; i += 1) {
+      if (sample <= (HISTOGRAM_BUCKETS_MS[i] as number)) {
+        entry.durationBuckets[i] = (entry.durationBuckets[i] as number) + 1;
+        placed = true;
+        break;
+      }
+    }
+    if (!placed) {
+      // +Inf bucket.
+      const last = entry.durationBuckets.length - 1;
+      entry.durationBuckets[last] = (entry.durationBuckets[last] as number) + 1;
+    }
+  }
+
+  /**
+   * Read-only snapshot for `/stats` (JSON) consumers. Deep-frozen so a buggy
+   * handler cannot mutate the live registry through the snapshot reference.
+   */
+  snapshot(): MetricsSnapshot {
+    const out: Record<string, MethodCounters> = {};
+    for (const [method, entry] of this.methods) {
+      const errorsByCode: Record<string, number> = {};
+      for (const [code, count] of entry.errorsByCode) {
+        errorsByCode[code] = count;
+      }
+      out[method] = Object.freeze({
+        requests: entry.requests,
+        errors: entry.errors,
+        errorsByCode: Object.freeze(errorsByCode),
+        durationBuckets: Object.freeze(entry.durationBuckets.slice()),
+        durationSumMs: entry.durationSumMs,
+        durationCount: entry.durationCount,
+      });
+    }
+    return Object.freeze(out);
+  }
+
+  /**
+   * Format the registry as Prometheus text-exposition v0.0.4. Suitable for
+   * `/metrics` HTTP endpoint output. Three families per method:
+   *   - `ccsm_envelope_requests_total{method="..."}`
+   *   - `ccsm_envelope_errors_total{method="...",code="..."}`
+   *   - `ccsm_envelope_duration_ms_bucket{method="...",le="..."}` (+ _sum / _count)
+   */
+  formatPrometheus(): string {
+    const lines: string[] = [];
+    lines.push('# HELP ccsm_envelope_requests_total Total envelope requests by method.');
+    lines.push('# TYPE ccsm_envelope_requests_total counter');
+    for (const [method, entry] of this.methods) {
+      lines.push(`ccsm_envelope_requests_total{method="${escapeLabel(method)}"} ${entry.requests}`);
+    }
+    lines.push('# HELP ccsm_envelope_errors_total Total envelope errors by method and code.');
+    lines.push('# TYPE ccsm_envelope_errors_total counter');
+    for (const [method, entry] of this.methods) {
+      // Always emit a `code=""` aggregate so dashboards have a stable series
+      // even on methods that have never failed.
+      lines.push(
+        `ccsm_envelope_errors_total{method="${escapeLabel(method)}",code=""} ${entry.errors}`,
+      );
+      for (const [code, count] of entry.errorsByCode) {
+        lines.push(
+          `ccsm_envelope_errors_total{method="${escapeLabel(method)}",code="${escapeLabel(code)}"} ${count}`,
+        );
+      }
+    }
+    lines.push('# HELP ccsm_envelope_duration_ms Envelope handler duration in milliseconds.');
+    lines.push('# TYPE ccsm_envelope_duration_ms histogram');
+    for (const [method, entry] of this.methods) {
+      let cumulative = 0;
+      for (let i = 0; i < HISTOGRAM_BUCKETS_MS.length; i += 1) {
+        cumulative += entry.durationBuckets[i] as number;
+        lines.push(
+          `ccsm_envelope_duration_ms_bucket{method="${escapeLabel(method)}",le="${HISTOGRAM_BUCKETS_MS[i] as number}"} ${cumulative}`,
+        );
+      }
+      cumulative += entry.durationBuckets[entry.durationBuckets.length - 1] as number;
+      lines.push(
+        `ccsm_envelope_duration_ms_bucket{method="${escapeLabel(method)}",le="+Inf"} ${cumulative}`,
+      );
+      lines.push(
+        `ccsm_envelope_duration_ms_sum{method="${escapeLabel(method)}"} ${entry.durationSumMs}`,
+      );
+      lines.push(
+        `ccsm_envelope_duration_ms_count{method="${escapeLabel(method)}"} ${entry.durationCount}`,
+      );
+    }
+    // Prometheus exposition requires a trailing newline.
+    return `${lines.join('\n')}\n`;
+  }
+
+  /** Test-facing wipe — drops all per-method counters. */
+  reset(): void {
+    this.methods.clear();
+  }
+}
+
+/** Escape Prometheus label-value characters per text-exposition spec. */
+function escapeLabel(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
+}

--- a/daemon/src/envelope/trace-interceptor.ts
+++ b/daemon/src/envelope/trace-interceptor.ts
@@ -1,0 +1,195 @@
+// L1 envelope trace interceptor (spec §3.4.1.f built-in interceptor list — slot
+// "trace", before deadline / migrationGate / metrics).
+//
+// Spec citations:
+//   - docs/superpowers/specs/v0.3-fragments/frag-3.4.1-envelope-hardening.md
+//     §3.4.1.f bullet "trace": every envelope MUST carry a `traceId`; when the
+//     caller omits it, the interceptor mints a fresh one and attaches it to the
+//     per-request context so downstream interceptors / handler logs / pino
+//     child loggers can fan it through. On completion the interceptor emits a
+//     canonical log line `envelope_trace { method, traceId, durationMs, code }`
+//     so a grep over the daemon log file reconstructs every RPC's span.
+//   - Same fragment §3.4.1.c reserved-fields list (`traceId` is an envelope
+//     header field; Crockford ULID when caller-supplied, but the interceptor
+//     accepts any non-empty string so a pre-existing trace propagated by a
+//     v0.5 web client survives unchanged).
+//
+// Single Responsibility (producer / decider / sink discipline):
+//   - This module is a PURE DECIDER plus a single deterministic SINK callback.
+//     It exposes:
+//       - `resolveTraceId(envelope)`         — pick existing traceId or mint one.
+//       - `startTrace(method, traceId, now)` — open a per-call span (records
+//                                              start ms via injected clock).
+//       - `formatCompletionLog(span, code)`  — build the canonical completion
+//                                              record (does NOT write to a sink).
+//       - `runWithTrace(...)`                — convenience wrapper that ties
+//                                              the three together and invokes
+//                                              the caller-supplied logger sink
+//                                              exactly once on completion.
+//   - It does NOT own a logger instance, does NOT touch wall-clock directly
+//     (the clock is injected so tests are deterministic), does NOT mutate
+//     the envelope, and does NOT swallow handler errors (errors propagate to
+//     the caller after the completion log is recorded).
+
+import { randomBytes } from 'node:crypto';
+
+/**
+ * Length of an interceptor-minted trace id. Spec §3.4.1.c canonical format is
+ * a Crockford ULID (26 chars) when the CLIENT supplies one; for daemon-minted
+ * fallbacks we use a 16-byte (32-char) hex string per the task brief — easy
+ * to grep, no ulid dep churn, and visually distinct from a client ULID so a
+ * future audit can tell who minted the id.
+ */
+export const TRACE_ID_BYTES = 16;
+
+/**
+ * Canonical name of the completion log event. Stable across versions —
+ * dashboards / alerts grep on the literal string per spec §3.4.1.f.
+ */
+export const TRACE_LOG_EVENT = 'envelope_trace';
+
+/** Minimum envelope shape this interceptor reads. Header field per §3.4.1.c. */
+export interface TraceEnvelopeView {
+  /** Optional caller-supplied traceId. Empty string treated as absent. */
+  readonly traceId?: string | null;
+}
+
+/** Injected wall-clock. Defaults to `Date.now`; tests pass a deterministic stub. */
+export type ClockMs = () => number;
+
+/** In-flight span returned by {@link startTrace}. Opaque to callers. */
+export interface TraceSpan {
+  readonly method: string;
+  readonly traceId: string;
+  readonly startedMs: number;
+}
+
+/** Canonical completion log record (spec §3.4.1.f). */
+export interface TraceCompletionLog {
+  readonly event: typeof TRACE_LOG_EVENT;
+  readonly method: string;
+  readonly traceId: string;
+  readonly durationMs: number;
+  /**
+   * Wire-level outcome code:
+   *   - `'ok'`                      — handler resolved successfully.
+   *   - any envelope reject code    — `'hello_required'`, `'MIGRATION_PENDING'`,
+   *                                   `'deadline_invalid'`, `'INTERNAL'`, etc.
+   *
+   * Kept as a free-form string because the v0.3 envelope reject vocabulary
+   * spans multiple interceptors and a handful of dispatcher codes; a closed
+   * union here would force a churn every time a new interceptor lands.
+   */
+  readonly code: string;
+}
+
+/** Sink that consumes the completion log. Implementations: pino.info, console.log, in-mem buffer. */
+export type TraceLogSink = (record: TraceCompletionLog) => void;
+
+/**
+ * Pick the caller-supplied traceId or mint a 16-byte hex id. Empty / whitespace
+ * strings are treated as absent so a client that sets `traceId: ""` does not
+ * silently disable tracing.
+ *
+ * Pure modulo `randomBytes` (system entropy); the caller may inject `mintTraceId`
+ * to make the function fully deterministic in tests.
+ */
+export function resolveTraceId(
+  envelope: TraceEnvelopeView,
+  mintTraceId: () => string = defaultMintTraceId,
+): string {
+  const supplied = envelope.traceId;
+  if (typeof supplied === 'string' && supplied.trim().length > 0) {
+    return supplied;
+  }
+  return mintTraceId();
+}
+
+/** Default 16-byte hex minter. Safe-by-default; tests inject deterministic stubs. */
+export function defaultMintTraceId(): string {
+  return randomBytes(TRACE_ID_BYTES).toString('hex');
+}
+
+/**
+ * Open a per-call span. Records the start time via the injected clock so
+ * `formatCompletionLog` can compute `durationMs` without re-reading the clock
+ * inconsistently across paths.
+ */
+export function startTrace(
+  method: string,
+  traceId: string,
+  now: ClockMs = Date.now,
+): TraceSpan {
+  return { method, traceId, startedMs: now() };
+}
+
+/**
+ * Build the canonical completion record. Pure — does NOT write to a sink.
+ * Caller passes the `code` (`'ok'` for handler success or the wire-level
+ * reject/error code) plus the `now()` reading captured at completion.
+ */
+export function formatCompletionLog(
+  span: TraceSpan,
+  code: string,
+  now: ClockMs = Date.now,
+): TraceCompletionLog {
+  // Math.max guards against a non-monotonic clock (e.g. NTP slew during a
+  // long-running unary RPC) producing a negative durationMs in the log.
+  const durationMs = Math.max(0, now() - span.startedMs);
+  return {
+    event: TRACE_LOG_EVENT,
+    method: span.method,
+    traceId: span.traceId,
+    durationMs,
+    code,
+  };
+}
+
+/**
+ * Convenience wrapper that ties resolve / start / format / sink together for
+ * the common dispatcher path. Returns the handler's resolved value (or
+ * re-throws its error AFTER recording the completion log so the trace span is
+ * never lost on the error path).
+ *
+ * The caller passes:
+ *   - `envelope`   — the inbound envelope view (for traceId pickup).
+ *   - `method`     — the wire-literal RPC name.
+ *   - `handler`    — async fn that receives `{ traceId }` (so a pino child can
+ *                    bind the trace id) and resolves with `{ value, code }`.
+ *                    `code` defaults to `'ok'` on resolve; on throw the wrapper
+ *                    fills `'INTERNAL'`. A handler that wants to surface a more
+ *                    specific code (e.g. `'NOT_IMPLEMENTED'`) returns
+ *                    `{ value, code: 'NOT_IMPLEMENTED' }` without throwing.
+ *   - `sink`       — completion log sink (pino.info / console.log / test stub).
+ *   - `clock`      — optional injected clock; defaults to `Date.now`.
+ *   - `mintTraceId`— optional injected minter; defaults to crypto.randomBytes.
+ */
+export interface RunWithTraceArgs<T> {
+  readonly envelope: TraceEnvelopeView;
+  readonly method: string;
+  readonly handler: (ctx: { readonly traceId: string }) => Promise<{
+    readonly value: T;
+    readonly code?: string;
+  }>;
+  readonly sink: TraceLogSink;
+  readonly clock?: ClockMs;
+  readonly mintTraceId?: () => string;
+}
+
+export async function runWithTrace<T>(args: RunWithTraceArgs<T>): Promise<T> {
+  const { envelope, method, handler, sink } = args;
+  const clock = args.clock ?? Date.now;
+  const traceId = resolveTraceId(envelope, args.mintTraceId);
+  const span = startTrace(method, traceId, clock);
+
+  try {
+    const result = await handler({ traceId });
+    sink(formatCompletionLog(span, result.code ?? 'ok', clock));
+    return result.value;
+  } catch (err) {
+    // Record the failure span THEN rethrow — sink-before-throw guarantees the
+    // trace line lands even if the caller's catch swallows the error.
+    sink(formatCompletionLog(span, 'INTERNAL', clock));
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the two missing built-in envelope interceptors (trace + metrics) so frag-3.4.1 §3.4.1.f ships a complete control-plane interceptor list.

Frag-3.4.1 §3.4.1.f built-in chain (canonical install order, control plane only):
1. `helloInterceptor`         — pre-existing (`hello-interceptor.ts`)
2. `traceInterceptor`         — NEW (`trace-interceptor.ts`)
3. `deadlineInterceptor`      — pre-existing (`deadline-interceptor.ts`)
4. `migrationGateInterceptor` — pre-existing (`migration-gate-interceptor.ts`)
5. `metricsInterceptor`       — NEW (`metrics-interceptor.ts`, runs LAST)

### Implementation
- `daemon/src/envelope/trace-interceptor.ts` — pure decider + sink callback. `resolveTraceId` picks a caller-supplied envelope `traceId` or mints a 16-byte hex fallback (32-char). `startTrace` + `formatCompletionLog` open a per-call span and emit the canonical `envelope_trace { method, traceId, durationMs, code }` log record. `runWithTrace` is the convenience wrapper for the dispatcher; sink-before-throw on the error path guarantees the trace line lands even when the handler explodes.
- `daemon/src/envelope/metrics-interceptor.ts` — `MetricsRegistry` keeps per-method `requests` / `errors` (with per-code breakdown) plus a duration histogram (buckets: 1, 5, 10, 25, 50, 100, 250, 500, 1k, 2.5k, 5k, 10k, 30k, 120k ms + `+Inf`). `snapshot()` returns a deep-frozen view for the supervisor `/stats` JSON; `formatPrometheus()` emits text-exposition v0.0.4 for a future `/metrics` endpoint. Zero clock / network / timer dependencies.
- 26 vitest cases (16 trace + 10 metrics): traceId round-trip propagation (caller-supplied + minted), completion log on success and on handler throw (`code: 'INTERNAL'`), the brief's `10 calls -> requests == 10, 1 error -> errors == 1` assertion, histogram bucketing + `+Inf` overflow, snapshot immutability + defensive copy, Prometheus label escaping.

Control plane only — Connect-RPC data plane untouched per zero-rework rule (the v0.4 supervisor still uses envelope, so these interceptors carry forward without modification).

## Test plan
- [x] `vitest run daemon/src/envelope/__tests__/trace-interceptor.test.ts daemon/src/envelope/__tests__/metrics-interceptor.test.ts` — 26/26 green
- [x] `tsc -p daemon/tsconfig.json --noEmit` — clean
- [x] `eslint` on the four new files — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)