### PR TITLE
feat: v0.3 task #123 daemon lockfile (frag-6-7 §6.4)

### DIFF
--- a/daemon/src/index.ts
+++ b/daemon/src/index.ts
@@ -13,6 +13,14 @@ import {
 } from './handlers/daemon-shutdown.js';
 import { createForceKillSink, type ForceKillJobHandle } from './lifecycle/force-kill.js';
 import { startDevParentWatchdog } from './lifecycle/dev-parent-watchdog.js';
+import {
+  acquireDaemonLock,
+  LockfileBusyError,
+  LockfileFatalError,
+  LOCKFILE_FATAL_EXIT_CODE,
+  type LockHandle,
+} from './lifecycle/lockfile.js';
+import { resolveDataRoot } from './db/ensure-data-dir.js';
 import { installCrashHandlers } from './crash/handlers.js';
 import { installNativeCrashHandlers } from './crash/native-handlers.js';
 import { initDaemonSentry } from './sentry/init.js';
@@ -97,6 +105,32 @@ installCrashHandlers({
 // `daemon/src/crash/native-handlers.ts` for the deferred-WER rationale.
 installNativeCrashHandlers({ runtimeRoot, bootNonce });
 
+// Task #123 — daemon single-instance lockfile (frag-6-7 §6.4).
+//
+// Acquired BEFORE any data-dir or socket work so:
+//   1. A second daemon spawned by a racing supervisor exits cleanly via
+//      `LockfileBusyError` instead of half-binding sockets and
+//      half-touching the data dir (frag-8 §8.3 step 1a's orphan-tmp
+//      unlink is only safe under single-instance enforcement).
+//   2. EROFS / read-only mount surfaces as a clear `lockfile_erofs_fatal`
+//      log + exit(78) BEFORE pino's async destination buffers anything
+//      we cannot flush.
+//
+// Forward-declared so:
+//   - The `daemon.shutdownForUpgrade` handler's `releaseLock` action
+//     (frag-6-7 §6.4 step 4) can release the same handle the boot path
+//     acquired (swap-lock contract).
+//   - The `closeTransports`-then-exit shutdown chain can release on
+//     planned exit so the next boot doesn't see a stale `.lock` dir.
+//
+// The acquire itself runs inside the same async IIFE that boots the
+// listeners (below) — first step. A throw there propagates through the
+// crash handler so a fatal lockfile error gets the same forensic
+// treatment as any other boot failure.
+const dataRoot =
+  process.env.CCSM_DATA_ROOT ?? resolveDataRoot();
+let lockHandle: LockHandle | undefined;
+
 // T25 — force-kill fallback wiring. The reaper-PID set (T38) and the
 // JobObject handle (T39) are owned by the per-spawn wiring that lands
 // alongside the real ptyService. Until those wires are in, the
@@ -161,6 +195,21 @@ async function closeTransports(): Promise<void> {
         logger.warn(
           { event: 'daemon-shutdown.data-socket-close-failed', err: String(err) },
           'data-socket close failed during shutdown',
+        );
+      }
+    })(),
+    // Release the daemon-singleton lockfile so the next boot does not
+    // see a stale `daemon.lock.lock` directory and have to walk the
+    // stale-PID steal path. `release()` is idempotent — the upgrade
+    // handler may have already invoked it via the swap-lock contract.
+    (async () => {
+      if (!lockHandle) return;
+      try {
+        await lockHandle.release();
+      } catch (err) {
+        logger.warn(
+          { event: 'daemon-shutdown.lockfile-release-failed', err: String(err) },
+          'daemon.lock release failed during shutdown',
         );
       }
     })(),
@@ -321,15 +370,32 @@ const supervisorWiringManifest = wireSupervisorDispatcher(supervisorDispatcher, 
       runShutdownSequence: async () => {
         await daemonShutdownHandler.handle({ reason: 'upgrade' }, { bootNonce });
       },
-      // proper-lockfile wiring lands with the lockfile slice (frag-6-7
-      // §6.4 step 3). Until then this is a no-op so the marker write +
-      // drain still complete; the supervisor's restart loop is the
-      // ultimate recovery surface if the lock is stale.
+      // frag-6-7 §6.4 step 4 (swap-lock contract): release the SAME
+      // `daemon.lock` the boot path acquired so the supervisor's binary
+      // swap window cannot race a fresh-daemon-boot for the bin/
+      // directory. If the handle is undefined (acquire deferred /
+      // skipped — e.g. test override env), fall back to a no-op log
+      // line so the marker write + drain still complete.
       releaseLock: async () => {
-        logger.info(
-          { event: 'daemon-shutdown-for-upgrade.release-lock-noop' },
-          'lockfile release deferred to lockfile slice; continuing exit',
-        );
+        if (!lockHandle) {
+          logger.info(
+            { event: 'daemon-shutdown-for-upgrade.release-lock-noop' },
+            'lockfile not held; continuing exit',
+          );
+          return;
+        }
+        try {
+          await lockHandle.release();
+          logger.info(
+            { event: 'daemon-shutdown-for-upgrade.release-lock' },
+            'daemon.lock released for upgrade swap window',
+          );
+        } catch (err) {
+          logger.warn(
+            { event: 'daemon-shutdown-for-upgrade.release-lock-failed', err: String(err) },
+            'daemon.lock release failed; supervisor will retry-or-steal on next boot',
+          );
+        }
       },
       exit: (code) => {
         // Same posture as `shutdownActions.exitProcess`: close transports
@@ -412,6 +478,51 @@ dataSocket = createDataSocketServer({
 // re-throws to the crash handler; signal handlers below are still
 // registered synchronously at module evaluation time.
 void (async (): Promise<void> => {
+  // Step 1 (frag-6-7 §6.4): acquire the daemon-singleton lockfile
+  // BEFORE binding sockets / touching the data dir. A racing second
+  // daemon throws `LockfileBusyError` here and exits non-zero; an
+  // EROFS / read-only mount throws `LockfileFatalError` → exit(78)
+  // (sysexits.h EX_CONFIG). Stale-PID recovery is internal to
+  // `acquireDaemonLock`.
+  try {
+    lockHandle = await acquireDaemonLock({
+      dataRoot,
+      logger: {
+        info: (obj, msg) => logger.info(obj, msg),
+        warn: (obj, msg) => logger.warn(obj, msg),
+        error: (obj, msg) => logger.error(obj, msg),
+      },
+    });
+  } catch (err) {
+    if (err instanceof LockfileBusyError) {
+      // Pre-pino-flush stderr line per frag-6-7 §6.4 "Lockfile
+      // create-fail policy" — surfaces even if pino's async dest
+      // hasn't drained.
+      process.stderr.write(
+        `daemon.lock held by live PID ${err.holderPid}; another daemon is running\n`,
+      );
+      logger.error(
+        { event: 'lockfile_busy', holder_pid: err.holderPid, path: err.path },
+        'daemon already running; exiting',
+      );
+      // Exit code 75 (sysexits.h EX_TEMPFAIL) — supervisor's
+      // spawn-or-attach (§6.1) treats this as "attach to existing
+      // holder" rather than entering the crash-loop counter.
+      process.exit(75);
+    }
+    if (err instanceof LockfileFatalError) {
+      process.stderr.write(
+        `daemon lockfile site unwritable (${err.code}) at ${err.path}; refusing to boot\n`,
+      );
+      // The acquire path already emitted `lockfile_erofs_fatal`. Exit
+      // EX_CONFIG (78) — supervisor surfaces the configuration-error
+      // modal rather than retry.
+      process.exit(LOCKFILE_FATAL_EXIT_CODE);
+    }
+    // Unknown error → re-throw into the crash handler.
+    throw err;
+  }
+
   try {
     await controlSocket.listen();
     logger.info(

--- a/daemon/src/lifecycle/__tests__/lockfile.test.ts
+++ b/daemon/src/lifecycle/__tests__/lockfile.test.ts
@@ -1,0 +1,461 @@
+// Task #123 — daemon lockfile tests.
+//
+// Coverage:
+//   1. `probeHolderProcess` pure decider: alive / gone / unknown
+//      (POSIX kill(0) seam + Windows seam).
+//   2. `acquireDaemonLock` against a real tmp dataRoot:
+//      a. fresh acquire emits `lockfile_acquired` with PID + datarootMs.
+//      b. release lets a second acquire succeed cleanly.
+//      c. concurrent acquire (same process) → second call throws
+//         `LockfileBusyError` with the live holder's PID.
+//      d. stale-PID steal: pre-seed `daemon.lock.lock` dir + a PID
+//         payload pointing to a dead process → acquire emits
+//         `lockfile_steal` and succeeds.
+//      e. EROFS-class fatal: stub proper-lockfile to throw EROFS →
+//         `lockfile_erofs_fatal` log + `LockfileFatalError` thrown.
+//   3. Cross-process e2e (real daemon-vs-daemon race) via two child
+//      Node processes that both call `acquireDaemonLock`. The second
+//      MUST exit with `LockfileBusyError` while the first still holds.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+import {
+  acquireDaemonLock,
+  DAEMON_LOCK_FILENAME,
+  LOCKFILE_FATAL_EXIT_CODE,
+  LockfileBusyError,
+  LockfileFatalError,
+  probeHolderProcess,
+} from '../lockfile.js';
+
+// ---------------------------------------------------------------------------
+// 1. probeHolderProcess
+// ---------------------------------------------------------------------------
+
+describe('probeHolderProcess (pure decider)', () => {
+  it('returns "alive" when kill(pid, 0) succeeds (POSIX path)', () => {
+    const kill = vi.fn();
+    expect(probeHolderProcess(1234, { kill, platform: 'linux' })).toBe('alive');
+    expect(kill).toHaveBeenCalledWith(1234, 0);
+  });
+
+  it('returns "gone" on ESRCH', () => {
+    const kill = vi.fn(() => {
+      const err = new Error('No such process') as NodeJS.ErrnoException;
+      err.code = 'ESRCH';
+      throw err;
+    });
+    expect(probeHolderProcess(9999, { kill, platform: 'linux' })).toBe('gone');
+  });
+
+  it('returns "unknown" on EPERM (do NOT steal a lock we cannot signal)', () => {
+    const kill = vi.fn(() => {
+      const err = new Error('Operation not permitted') as NodeJS.ErrnoException;
+      err.code = 'EPERM';
+      throw err;
+    });
+    expect(probeHolderProcess(42, { kill, platform: 'linux' })).toBe('unknown');
+  });
+
+  it('routes through the Windows seam when one is provided', () => {
+    const probeWindows = vi.fn().mockReturnValue('gone' as const);
+    expect(probeHolderProcess(99, { platform: 'win32', probeWindows })).toBe('gone');
+    expect(probeWindows).toHaveBeenCalledWith(99);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. acquireDaemonLock — single-process integration against real fs
+// ---------------------------------------------------------------------------
+
+interface CapturedLog {
+  readonly level: 'info' | 'warn' | 'error';
+  readonly obj: Record<string, unknown>;
+  readonly msg: string;
+}
+
+function makeRecorder(): {
+  logger: {
+    info: (obj: Record<string, unknown>, msg: string) => void;
+    warn: (obj: Record<string, unknown>, msg: string) => void;
+    error: (obj: Record<string, unknown>, msg: string) => void;
+  };
+  records: CapturedLog[];
+} {
+  const records: CapturedLog[] = [];
+  return {
+    records,
+    logger: {
+      info: (obj, msg) => {
+        records.push({ level: 'info', obj, msg });
+      },
+      warn: (obj, msg) => {
+        records.push({ level: 'warn', obj, msg });
+      },
+      error: (obj, msg) => {
+        records.push({ level: 'error', obj, msg });
+      },
+    },
+  };
+}
+
+describe('acquireDaemonLock — real fs', () => {
+  let dataRoot: string;
+
+  beforeEach(() => {
+    dataRoot = mkdtempSync(join(tmpdir(), 'ccsm-lockfile-test-'));
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(dataRoot, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  });
+
+  it('acquires fresh lock and emits `lockfile_acquired` with PID + path', async () => {
+    const { logger, records } = makeRecorder();
+    const handle = await acquireDaemonLock({ dataRoot, logger });
+    try {
+      expect(handle.path).toBe(join(dataRoot, DAEMON_LOCK_FILENAME));
+      expect(handle.pid).toBe(process.pid);
+
+      const acquired = records.find((r) => r.obj['event'] === 'lockfile_acquired');
+      expect(acquired).toBeDefined();
+      expect(acquired?.obj['pid']).toBe(process.pid);
+      expect(acquired?.obj['path']).toBe(handle.path);
+      expect(typeof acquired?.obj['datarootMs']).toBe('number');
+
+      // PID payload is on disk for the next-boot stale-recovery probe.
+      const payload = readFileSync(handle.path, 'utf8').trim();
+      expect(Number.parseInt(payload, 10)).toBe(process.pid);
+    } finally {
+      await handle.release();
+    }
+  });
+
+  it('release()-then-reacquire works (idempotent baseline)', async () => {
+    const { logger } = makeRecorder();
+    const first = await acquireDaemonLock({ dataRoot, logger });
+    await first.release();
+    // Second release is a no-op (idempotent).
+    await first.release();
+
+    const second = await acquireDaemonLock({ dataRoot, logger });
+    await second.release();
+  });
+
+  it('second acquire while first is still held throws LockfileBusyError with the holder PID', async () => {
+    const { logger } = makeRecorder();
+    const first = await acquireDaemonLock({ dataRoot, logger });
+    try {
+      // The holder PID written to disk = process.pid (us). The probe
+      // will find us alive and refuse the steal.
+      await expect(acquireDaemonLock({ dataRoot, logger })).rejects.toBeInstanceOf(
+        LockfileBusyError,
+      );
+
+      // Inspect the typed fields on a fresh attempt for stricter
+      // assertions.
+      try {
+        await acquireDaemonLock({ dataRoot, logger });
+        expect.unreachable('expected LockfileBusyError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(LockfileBusyError);
+        expect((err as LockfileBusyError).holderPid).toBe(process.pid);
+        expect((err as LockfileBusyError).path).toBe(first.path);
+      }
+    } finally {
+      await first.release();
+    }
+  });
+
+  it('steals a stale lock when the holder PID is gone (emits `lockfile_steal`)', async () => {
+    // Pre-seed the lockfile site exactly as a crashed prior daemon would
+    // have left it: PID payload pointing to a definitely-dead PID, plus
+    // the proper-lockfile `.lock` mkdir already in place.
+    mkdirSync(dataRoot, { recursive: true });
+    const lockPath = join(dataRoot, DAEMON_LOCK_FILENAME);
+    writeFileSync(lockPath, '999999\n'); // unlikely-to-exist PID
+    mkdirSync(`${lockPath}.lock`); // simulates proper-lockfile's mkdir
+
+    const { logger, records } = makeRecorder();
+    const handle = await acquireDaemonLock({
+      dataRoot,
+      logger,
+      deps: {
+        // Force the probe to report 'gone' regardless of whether PID
+        // 999999 actually exists on the test host (CI VMs sometimes
+        // recycle PIDs into very high numbers).
+        probeOptions: {
+          platform: 'linux',
+          kill: () => {
+            const err = new Error('No such process') as NodeJS.ErrnoException;
+            err.code = 'ESRCH';
+            throw err;
+          },
+        },
+      },
+    });
+
+    try {
+      const steal = records.find((r) => r.obj['event'] === 'lockfile_steal');
+      expect(steal).toBeDefined();
+      expect(steal?.obj['stale_pid']).toBe(999999);
+      expect(steal?.level).toBe('warn');
+
+      // After steal, our PID is the new payload.
+      expect(readFileSync(handle.path, 'utf8').trim()).toBe(`${process.pid}`);
+    } finally {
+      await handle.release();
+    }
+  });
+
+  it('does NOT steal a lock when the holder PID is alive', async () => {
+    mkdirSync(dataRoot, { recursive: true });
+    const lockPath = join(dataRoot, DAEMON_LOCK_FILENAME);
+    writeFileSync(lockPath, '424242\n');
+    mkdirSync(`${lockPath}.lock`);
+
+    const { logger } = makeRecorder();
+    await expect(
+      acquireDaemonLock({
+        dataRoot,
+        logger,
+        deps: {
+          probeOptions: {
+            platform: 'linux',
+            kill: () => {
+              // Holder is alive — kill(0) returns successfully.
+            },
+          },
+        },
+      }),
+    ).rejects.toBeInstanceOf(LockfileBusyError);
+  });
+
+  it('emits `lockfile_erofs_fatal` and throws LockfileFatalError on EROFS', async () => {
+    const { logger, records } = makeRecorder();
+    // Stub proper-lockfile to throw EROFS on the lock attempt — the
+    // most realistic way to simulate a read-only mount on any OS
+    // (real EROFS injection requires elevated privileges).
+    const stubProper = {
+      lock: vi.fn(async () => {
+        const err = new Error('read-only file system') as NodeJS.ErrnoException;
+        err.code = 'EROFS';
+        throw err;
+      }),
+      unlock: vi.fn(async () => {}),
+      check: vi.fn(async () => false),
+    };
+
+    await expect(
+      acquireDaemonLock({
+        dataRoot,
+        logger,
+        deps: { properLockfile: stubProper },
+      }),
+    ).rejects.toBeInstanceOf(LockfileFatalError);
+
+    const fatal = records.find((r) => r.obj['event'] === 'lockfile_erofs_fatal');
+    expect(fatal).toBeDefined();
+    expect(fatal?.level).toBe('error');
+    expect(fatal?.obj['code']).toBe('EROFS');
+    expect(LOCKFILE_FATAL_EXIT_CODE).toBe(78); // sysexits.h EX_CONFIG sanity
+  });
+
+  it('exposes the LockfileBusyError holderPid even when steal racer wins', async () => {
+    // After a steal attempt, if a third party re-acquires before we
+    // can, the second ELOCKED MUST surface as Busy (not infinite loop).
+    mkdirSync(dataRoot, { recursive: true });
+    const lockPath = join(dataRoot, DAEMON_LOCK_FILENAME);
+    writeFileSync(lockPath, '555555\n');
+    mkdirSync(`${lockPath}.lock`);
+
+    const { logger } = makeRecorder();
+    // Simulate: first lock() throws ELOCKED (stale dir is there);
+    // unlock() succeeds; second lock() throws ELOCKED again (a racer
+    // re-mkdir'd between unlock + retry).
+    let lockCalls = 0;
+    const stubProper = {
+      lock: vi.fn(async () => {
+        lockCalls += 1;
+        const err = new Error('ELOCKED') as NodeJS.ErrnoException;
+        err.code = 'ELOCKED';
+        throw err;
+      }),
+      unlock: vi.fn(async () => {}),
+      check: vi.fn(async () => true),
+    };
+
+    await expect(
+      acquireDaemonLock({
+        dataRoot,
+        logger,
+        deps: {
+          properLockfile: stubProper,
+          probeOptions: {
+            platform: 'linux',
+            kill: () => {
+              const err = new Error('No such process') as NodeJS.ErrnoException;
+              err.code = 'ESRCH';
+              throw err;
+            },
+          },
+        },
+      }),
+    ).rejects.toBeInstanceOf(LockfileBusyError);
+    // Acquire path: first lock (ELOCKED) → probe says gone → unlock →
+    // retry second lock (ELOCKED again) → give up via stealAttempted
+    // guard. Two lock attempts total.
+    expect(lockCalls).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Cross-process race: two real Node processes contend for the same lock
+// ---------------------------------------------------------------------------
+
+describe('acquireDaemonLock — cross-process race', () => {
+  let dataRoot: string;
+
+  beforeEach(() => {
+    dataRoot = mkdtempSync(join(tmpdir(), 'ccsm-lockfile-xproc-'));
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(dataRoot, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  });
+
+  it('second daemon process exits busy while first holds the lock', () => {
+    // Compile-time path to the lockfile module via the daemon
+    // tsconfig outDir is not built in test mode. We resolve it via
+    // tsx so the spawned children compile on the fly.
+    const repoRoot = process.cwd();
+    const lockfileSrc = join(
+      repoRoot,
+      'daemon',
+      'src',
+      'lifecycle',
+      'lockfile.ts',
+    ).replace(/\\/g, '\\\\');
+
+    // Child A: acquires the lock, writes "ACQUIRED" + its PID to stdout,
+    // then sleeps for `holdMs` ms before releasing.
+    const holdScriptA = `
+      const { acquireDaemonLock } = require(${JSON.stringify(lockfileSrc)});
+      const noopLogger = { info: () => {}, warn: () => {}, error: () => {} };
+      (async () => {
+        const handle = await acquireDaemonLock({
+          dataRoot: ${JSON.stringify(dataRoot)},
+          logger: noopLogger,
+        });
+        process.stdout.write('ACQUIRED:' + handle.pid + '\\n');
+        await new Promise((r) => setTimeout(r, 10000));
+        await handle.release();
+        process.exit(0);
+      })().catch((err) => {
+        process.stderr.write('A_FAIL:' + (err && err.name) + ':' + (err && err.message) + '\\n');
+        process.exit(1);
+      });
+    `;
+
+    // Child B: tries to acquire, expects LockfileBusyError, prints
+    // "BUSY:<holderPid>" and exits 75.
+    const holdScriptB = `
+      const { acquireDaemonLock, LockfileBusyError } = require(${JSON.stringify(lockfileSrc)});
+      const noopLogger = { info: () => {}, warn: () => {}, error: () => {} };
+      (async () => {
+        try {
+          const handle = await acquireDaemonLock({
+            dataRoot: ${JSON.stringify(dataRoot)},
+            logger: noopLogger,
+          });
+          process.stdout.write('UNEXPECTED_ACQUIRE:' + handle.pid + '\\n');
+          await handle.release();
+          process.exit(0);
+        } catch (err) {
+          if (err instanceof LockfileBusyError) {
+            process.stdout.write('BUSY:' + err.holderPid + '\\n');
+            process.exit(75);
+          }
+          process.stderr.write('B_OTHER:' + (err && err.name) + ':' + (err && err.message) + '\\n');
+          process.exit(2);
+        }
+      })();
+    `;
+
+    const tsx = require.resolve('tsx/cli');
+
+    // Launch A in the background by spawning it with no `wait`, then
+    // launch B synchronously after a brief delay to ensure A grabbed
+    // the lock. We use spawnSync for both — A is given a tmp script
+    // file path we can detach via `detached + unref` semantics inside
+    // the child itself; simpler: launch A async then wait for its
+    // ACQUIRED line via a shared marker file.
+
+    const markerPath = join(dataRoot, 'A_READY');
+    const holdScriptAWithMarker = holdScriptA.replace(
+      "process.stdout.write('ACQUIRED:' + handle.pid + '\\n');",
+      "process.stdout.write('ACQUIRED:' + handle.pid + '\\n');" +
+        "require('fs').writeFileSync(" + JSON.stringify(markerPath) + ", String(handle.pid));",
+    );
+
+    // spawn A as a backgrounded child via Node's child_process.spawn
+    // (not spawnSync) so we don't block on its 1.5s sleep.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { spawn } = require('node:child_process') as typeof import('node:child_process');
+    const childA = spawn(
+      process.execPath,
+      [tsx, '--eval', holdScriptAWithMarker],
+      { stdio: 'pipe' },
+    );
+
+    // Wait up to 20s for A to write its marker file. Polling is fine —
+    // this is a single-shot test, not a hot path. The window is generous
+    // because tsx cold-start under parallel-test CPU pressure can take
+    // 5-10s on slow Windows runners.
+    const start = Date.now();
+    let aReady = false;
+    while (Date.now() - start < 20_000) {
+      try {
+        readFileSync(markerPath, 'utf8');
+        aReady = true;
+        break;
+      } catch {
+        // sleep 50ms by spinning a sync sleep — vitest's fake timers
+        // would mask real wall-clock here.
+        const until = Date.now() + 50;
+        // eslint-disable-next-line no-empty
+        while (Date.now() < until) {}
+      }
+    }
+
+    expect(aReady, 'child A failed to acquire the lock within 5s').toBe(true);
+
+    // Now run B synchronously and verify it exits 75 with BUSY.
+    const resB = spawnSync(process.execPath, [tsx, '--eval', holdScriptB], {
+      encoding: 'utf8',
+      timeout: 10_000,
+    });
+
+    // Clean up A regardless of outcome so the test exits cleanly.
+    try {
+      childA.kill();
+    } catch {
+      // best-effort
+    }
+
+    expect(resB.status, `B stderr=${resB.stderr}`).toBe(75);
+    expect(resB.stdout).toMatch(/^BUSY:\d+/m);
+  }, 60_000);
+});

--- a/daemon/src/lifecycle/lockfile.ts
+++ b/daemon/src/lifecycle/lockfile.ts
@@ -1,0 +1,451 @@
+// Task #123 — daemon single-instance lockfile (`<dataRoot>/daemon.lock`).
+//
+// Spec refs:
+//   - frag-6-7 §6.4 "Single-instance + last-known-good rollback":
+//       * Lockfile path = `<dataRoot>/daemon.lock`, acquired via
+//         `proper-lockfile` with `O_EXCL` create + PID write.
+//       * Lockfile MUST be acquired BEFORE `ensureDataDir()` / migration
+//         (round-3 reliability P0-R4 ordering — frag-8 §8.3 step 1
+//         depends on this; the orphan-tmp unlink in §8.3 step 1a is only
+//         safe when single-daemon is enforced).
+//       * Stale-PID recovery: Win uses `OpenProcess`-equivalent probe,
+//         POSIX uses `kill(pid, 0)` ESRCH. If the holder PID is dead,
+//         steal the lock with one warn line.
+//       * Create-fail policy: any non-EEXIST error (EROFS, ENOSPC,
+//         noexec) → daemon refuses to boot; no silent fall-back.
+//   - frag-6-7 §6.4 step 4 (swap-lock): the `daemon.shutdownForUpgrade`
+//     handler releases the SAME lock as part of its drain so the
+//     supervisor's swap window cannot race a fresh-daemon-boot for the
+//     bin/ directory.
+//
+// Single Responsibility (per repo memory `feedback_single_responsibility.md`):
+//   - PRODUCER: `<dataRoot>` path (caller-supplied — same resolver
+//     `resolveDataRoot()` from `daemon/src/db/ensure-data-dir.ts`).
+//   - DECIDER: `probeHolderProcess(pid)` returns
+//     `'alive' | 'gone' | 'unknown'` from a kill(0) / OpenProcess probe.
+//     Pure (no I/O beyond the syscall itself). Mirrors the
+//     `dev-parent-watchdog`'s `checkParent` shape so future consolidation
+//     stays cheap.
+//   - SINK: `acquireDaemonLock({ dataRoot, ... })` performs the
+//     mkdir + atomic-acquire + PID-write + stale-recovery + log emit
+//     dance. Returns a `LockHandle` with `release()`. Idempotent
+//     release.
+//
+// What this module does NOT do:
+//   - Does NOT decide WHEN to acquire — the daemon entry (`index.ts`)
+//     calls it FIRST in the boot sequence, before `ensureDataDir`.
+//   - Does NOT call `process.exit` directly. EROFS / IO-fatal cases
+//     log + throw a typed error; the entry process maps to exit 78.
+//     This keeps the module testable (tests catch the throw, no
+//     real exit).
+//   - Does NOT touch the §6.4 binary swap path — the upgrade handler
+//     receives the `LockHandle.release` thunk and invokes it as part
+//     of its own drain.
+//
+// Forward-compat (v0.4):
+//   - The lockfile lives under `<dataRoot>` which is stable across
+//     v0.3/v0.4 (frag-11 §11.6 path table is locked). The module
+//     surface (acquire / release / probe) is the final shape — no
+//     "v0.4 will replace this" placeholders.
+
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+// proper-lockfile has no `@types/` package and ships pure CJS. Declare
+// the minimal surface we use locally so the rest of the file stays
+// strictly typed. The full surface is documented in the package README.
+interface ProperLockfile {
+  lock: (
+    file: string,
+    options: {
+      readonly realpath?: boolean;
+      readonly stale?: number;
+      readonly retries?: number;
+      readonly lockfilePath?: string;
+    },
+  ) => Promise<() => Promise<void>>;
+  unlock: (
+    file: string,
+    options: { readonly realpath?: boolean; readonly lockfilePath?: string },
+  ) => Promise<void>;
+  check: (
+    file: string,
+    options: { readonly realpath?: boolean; readonly lockfilePath?: string },
+  ) => Promise<boolean>;
+}
+
+// Lazy-required so tests can stub via the deps seam below without
+// triggering the real CJS load when only the pure decider is exercised.
+function defaultProperLockfile(): ProperLockfile {
+  return require('proper-lockfile') as ProperLockfile;
+}
+
+/** Filename under `<dataRoot>`. Exported so tests + the upgrade handler
+ *  can derive the same path without re-stating the literal. */
+export const DAEMON_LOCK_FILENAME = 'daemon.lock' as const;
+
+/** Recommended exit code on EROFS-class fatal (sysexits.h: EX_CONFIG = 78,
+ *  "configuration error"). Exported so the daemon entry can map without
+ *  re-stating the literal. */
+export const LOCKFILE_FATAL_EXIT_CODE = 78 as const;
+
+/** Outcome of probing the holder process. Mirrors `dev-parent-watchdog`'s
+ *  `ParentProbeOutcome` shape for future consolidation. */
+export type HolderProbeOutcome = 'alive' | 'gone' | 'unknown';
+
+export interface ProbeHolderOptions {
+  /** Override `process.kill` for tests. POSIX path. */
+  readonly kill?: (pid: number, signal: 0) => void;
+  /** Test seam — overrides `process.platform`. */
+  readonly platform?: NodeJS.Platform;
+  /**
+   * Windows-side probe seam. Returns:
+   *   - `'alive'` when `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION,
+   *     false, pid)` returns a non-NULL handle.
+   *   - `'gone'` when GetLastError = ERROR_INVALID_PARAMETER (pid does
+   *     not exist) or ERROR_ACCESS_DENIED with no handle.
+   *   - `'unknown'` when the helper cannot be loaded or returns an
+   *     unexpected error.
+   *
+   * Production default uses `process.kill(pid, 0)` on Windows too —
+   * Node maps it through `OpenProcess(PROCESS_TERMINATE)` internally
+   * which is sufficient for an existence check. The seam exists so a
+   * future N-API helper (when the §7.M1 ACL helper lands) can swap in
+   * `PROCESS_QUERY_LIMITED_INFORMATION` for a less-privileged check.
+   */
+  readonly probeWindows?: (pid: number) => HolderProbeOutcome;
+}
+
+/**
+ * Pure decider: is the holder PID still alive?
+ *
+ * - POSIX: `process.kill(pid, 0)` — signal 0 is the documented existence
+ *   check. ESRCH = process gone, EPERM = process exists but we cannot
+ *   signal it (still alive, conservative posture: do NOT steal).
+ * - Windows: `process.kill(pid, 0)` maps through `OpenProcess`. If the
+ *   PID is gone the call throws ESRCH; if it exists but belongs to
+ *   another user/session, it throws EPERM. Same conservative branch as
+ *   POSIX — only ESRCH counts as "gone" / steal-eligible.
+ *
+ * Never throws.
+ */
+export function probeHolderProcess(
+  pid: number,
+  opts: ProbeHolderOptions = {},
+): HolderProbeOutcome {
+  const platform = opts.platform ?? process.platform;
+  if (platform === 'win32' && opts.probeWindows) {
+    return opts.probeWindows(pid);
+  }
+  const kill =
+    opts.kill ??
+    ((p: number, signal: 0): void => {
+      process.kill(p, signal);
+    });
+  try {
+    kill(pid, 0);
+    return 'alive';
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ESRCH') return 'gone';
+    // EPERM (POSIX) or any other code → treat as alive. Conservative:
+    // never steal a lock from a process we merely cannot signal — that
+    // would corrupt state if the holder is still actively writing.
+    return 'unknown';
+  }
+}
+
+/** Structured-log sink used by the acquire path. Matches pino's
+ *  `(obj, msg)` signature so the entry process can pass `logger.info` /
+ *  `logger.warn` / `logger.error` directly. */
+export interface LockLogger {
+  info: (obj: Record<string, unknown>, msg: string) => void;
+  warn: (obj: Record<string, unknown>, msg: string) => void;
+  error: (obj: Record<string, unknown>, msg: string) => void;
+}
+
+/** Test seam for swapping the proper-lockfile surface and the clock. */
+export interface LockDeps {
+  readonly properLockfile?: ProperLockfile;
+  /** Override `Date.now()` so the `datarootMs` log field is deterministic. */
+  readonly now?: () => number;
+  /** Override `process.pid` so tests can simulate alternative holder PIDs. */
+  readonly pid?: number;
+  /** Override probe behaviour (forwarded to `probeHolderProcess`). */
+  readonly probeOptions?: ProbeHolderOptions;
+}
+
+export interface AcquireDaemonLockOptions {
+  /** OS-native data root (output of `resolveDataRoot()` from
+   *  `daemon/src/db/ensure-data-dir.ts`). Lockfile is created at
+   *  `<dataRoot>/daemon.lock`. */
+  readonly dataRoot: string;
+  readonly logger: LockLogger;
+  readonly deps?: LockDeps;
+}
+
+/** Returned by `acquireDaemonLock`. `release()` is idempotent: a second
+ *  call resolves immediately without touching the fs, so the upgrade
+ *  handler + the `index.ts` shutdown path can both wire it without
+ *  coordinating. */
+export interface LockHandle {
+  /** Absolute path to the lockfile (`<dataRoot>/daemon.lock`). */
+  readonly path: string;
+  /** PID written to the lockfile (== `process.pid` in production). */
+  readonly pid: number;
+  release: () => Promise<void>;
+}
+
+/** Typed error class used for the EROFS-class fatal branch. The daemon
+ *  entry catches this and maps to `process.exit(LOCKFILE_FATAL_EXIT_CODE)`
+ *  after a final stderr line — keeps the module pure (no exit calls). */
+export class LockfileFatalError extends Error {
+  public readonly code: string;
+  public readonly path: string;
+  public override readonly cause: unknown;
+  constructor(message: string, params: { code: string; path: string; cause: unknown }) {
+    super(message);
+    this.name = 'LockfileFatalError';
+    this.code = params.code;
+    this.path = params.path;
+    this.cause = params.cause;
+  }
+}
+
+/** Typed error class for "lock is held by a live PID" — the second
+ *  daemon's expected exit reason. Caller maps to a non-zero exit. */
+export class LockfileBusyError extends Error {
+  public readonly path: string;
+  public readonly holderPid: number;
+  constructor(path: string, holderPid: number) {
+    super(`daemon.lock held by live PID ${holderPid} at ${path}`);
+    this.name = 'LockfileBusyError';
+    this.path = path;
+    this.holderPid = holderPid;
+  }
+}
+
+/**
+ * Acquire `<dataRoot>/daemon.lock`. Performs (in order):
+ *
+ *   1. `mkdirSync(dataRoot, { recursive: true, mode: 0o700 })` — the
+ *      data root MUST exist before proper-lockfile can mkdir its
+ *      `.lock` sibling. The `data/` subdir is NOT created here; that's
+ *      `ensureDataDir()`'s job (which runs AFTER lock acquire per
+ *      r3-rel P0-R4 ordering).
+ *   2. Touch `daemon.lock` (writeFile-empty if absent) so
+ *      proper-lockfile's `realpath: true` default doesn't ENOENT.
+ *      We pass `realpath: false` anyway — both are belt-and-suspenders.
+ *   3. `properLockfile.lock(daemon.lock, { realpath: false, retries: 0 })`.
+ *      The mkdir of `daemon.lock.lock` is the atomic gate (POSIX +
+ *      Windows both make `mkdir` atomic w.r.t. existence checks).
+ *   4. On success: write `${pid}\n` to `daemon.lock` (the file content
+ *      is the steal-recovery payload), emit `lockfile_acquired`, return
+ *      the handle.
+ *   5. On `ELOCKED`: read PID from `daemon.lock`, `probeHolderProcess`.
+ *      If `'gone'`: emit `lockfile_steal`, force-unlock via
+ *      `properLockfile.unlock(...)`, retry ONCE. Cap at one retry to
+ *      avoid an infinite steal loop if two dead-holder racers keep
+ *      re-creating the file.
+ *      If `'alive'` or `'unknown'`: throw `LockfileBusyError`.
+ *   6. On `EROFS` / `EACCES` / `ENOSPC` / `EPERM` (read-only mount,
+ *      permission denied, disk full): emit `lockfile_erofs_fatal`,
+ *      throw `LockfileFatalError`.
+ */
+export async function acquireDaemonLock(
+  options: AcquireDaemonLockOptions,
+): Promise<LockHandle> {
+  const { dataRoot, logger } = options;
+  const properLockfile = options.deps?.properLockfile ?? defaultProperLockfile();
+  const now = options.deps?.now ?? Date.now;
+  const pid = options.deps?.pid ?? process.pid;
+  const probeOptions = options.deps?.probeOptions ?? {};
+
+  const lockPath = join(dataRoot, DAEMON_LOCK_FILENAME);
+  const startedAt = now();
+
+  // Step 1: ensure dataRoot exists. Mode 0o700 only applies to NEWLY
+  // created directories on POSIX; pre-existing dirs keep their mode.
+  // EROFS surfaces here first on a read-only mount.
+  try {
+    mkdirSync(dataRoot, { recursive: true, mode: 0o700 });
+  } catch (err) {
+    return raiseFatalIfReadOnly(err, lockPath, logger, startedAt, now);
+  }
+
+  // Step 2: touch the lock target file. proper-lockfile needs it to
+  // exist so its `mkdir(file + '.lock')` has a sibling to anchor.
+  // We tolerate a pre-existing file (idempotent) since the previous
+  // boot's PID payload may still be sitting there — the stale-recovery
+  // path will overwrite it after acquire.
+  try {
+    if (!existsSync(lockPath)) {
+      writeFileSync(lockPath, '', { mode: 0o600 });
+    }
+  } catch (err) {
+    return raiseFatalIfReadOnly(err, lockPath, logger, startedAt, now);
+  }
+
+  // Step 3 + 5: try acquire, on ELOCKED branch into stale-PID recovery.
+  let stealAttempted = false;
+  while (true) {
+    let release: () => Promise<void>;
+    try {
+      release = await properLockfile.lock(lockPath, {
+        realpath: false,
+        retries: 0,
+      });
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'ELOCKED') {
+        if (stealAttempted) {
+          // Already stole once; the new holder won the race fair and
+          // square. Surface as busy to the caller.
+          const holderPid = readHolderPidSafe(lockPath) ?? 0;
+          throw new LockfileBusyError(lockPath, holderPid);
+        }
+        const holderPidOrNull = readHolderPidSafe(lockPath);
+        // Unparseable / empty PID payload = the holder crashed mid-write
+        // before stamping its PID. Treat as gone (steal-eligible) without
+        // attempting the syscall probe — calling `process.kill` with a
+        // bogus value (negative / 0) has dangerous semantics on POSIX
+        // (broadcasts to process group).
+        const outcome: HolderProbeOutcome =
+          holderPidOrNull === null
+            ? 'gone'
+            : probeHolderProcess(holderPidOrNull, probeOptions);
+        const holderPid = holderPidOrNull ?? 0;
+        if (outcome === 'gone') {
+          // Stale lock: steal it. Log first so a forensic timeline
+          // exists even if the unlock or retry below throws.
+          logger.warn(
+            {
+              event: 'lockfile_steal',
+              stale_pid: holderPid,
+              datarootMs: now() - startedAt,
+              path: lockPath,
+            },
+            'stealing stale daemon lock',
+          );
+          // Best-effort steal: directly rmdir the `.lock` sibling dir.
+          // We cannot call `properLockfile.unlock` here because it
+          // refuses with ENOTACQUIRED unless we registered the lock in
+          // its in-memory map (which only happens on a successful
+          // `lock()`). Direct rmdir matches what proper-lockfile itself
+          // does internally during its own stale-recovery branch.
+          const staleLockDir = `${lockPath}.lock`;
+          try {
+            rmSync(staleLockDir, { recursive: true, force: true });
+          } catch {
+            // Swallow — the retry will resurface any real failure as
+            // a fresh ELOCKED that the `stealAttempted` guard handles.
+          }
+          stealAttempted = true;
+          continue;
+        }
+        // 'alive' or 'unknown' → second daemon must back off. The
+        // supervisor's spawn-or-attach (§6.1) treats this exit code as
+        // "attach to existing".
+        throw new LockfileBusyError(lockPath, holderPid);
+      }
+      // Non-ELOCKED: EROFS / ENOSPC / EACCES / EPERM all hit here.
+      return raiseFatalIfReadOnly(err, lockPath, logger, startedAt, now);
+    }
+
+    // Step 4: write PID payload. Crash here = stale lock with empty
+    // payload; the next boot's stale-recovery path treats unparseable
+    // PID as `'gone'` (see `readHolderPidSafe`) and steals.
+    try {
+      writeFileSync(lockPath, `${pid}\n`, { mode: 0o600 });
+    } catch (err) {
+      // PID write failed (extremely rare — we already created the file
+      // above). Release the lock dir so the next boot can retry, then
+      // route through the EROFS-fatal path so the supervisor surfaces
+      // a clear error rather than silently holding a stale-payload lock.
+      try {
+        await release();
+      } catch {
+        // best-effort
+      }
+      return raiseFatalIfReadOnly(err, lockPath, logger, startedAt, now);
+    }
+
+    logger.info(
+      {
+        event: 'lockfile_acquired',
+        pid,
+        path: lockPath,
+        datarootMs: now() - startedAt,
+      },
+      'daemon lockfile acquired',
+    );
+
+    let released = false;
+    return {
+      path: lockPath,
+      pid,
+      release: async (): Promise<void> => {
+        if (released) return;
+        released = true;
+        await release();
+      },
+    };
+  }
+}
+
+/** Best-effort read of the PID payload from `daemon.lock`. Returns `null`
+ *  when the file is unreadable / empty / corrupt — the caller's
+ *  stale-recovery path treats `null` as steal-eligible (the file payload
+ *  is written non-atomically with the lock acquire so a partial-write
+ *  here means the holder crashed mid-write). Returning `null` instead
+ *  of a sentinel PID prevents accidentally calling `process.kill(0, 0)`
+ *  (POSIX: broadcasts to the entire process group) or
+ *  `process.kill(-1, 0)` (POSIX: signals every process the caller can
+ *  reach). */
+function readHolderPidSafe(lockPath: string): number | null {
+  try {
+    const raw = readFileSync(lockPath, 'utf8').trim();
+    const n = Number.parseInt(raw, 10);
+    if (Number.isFinite(n) && n > 0) return n;
+  } catch {
+    // ENOENT / EACCES — fall through.
+  }
+  return null;
+}
+
+/** Map filesystem errors that indicate a non-recoverable lockfile site
+ *  (read-only mount, permission denied, disk full) into a typed fatal
+ *  + structured log line. Other error codes re-throw as-is so the
+ *  caller's stack trace is preserved for debugging. */
+function raiseFatalIfReadOnly(
+  err: unknown,
+  lockPath: string,
+  logger: LockLogger,
+  startedAt: number,
+  now: () => number,
+): never {
+  const code = (err as NodeJS.ErrnoException).code ?? 'UNKNOWN';
+  if (code === 'EROFS' || code === 'EACCES' || code === 'EPERM' || code === 'ENOSPC') {
+    logger.error(
+      {
+        event: 'lockfile_erofs_fatal',
+        code,
+        path: lockPath,
+        datarootMs: now() - startedAt,
+        err: String(err),
+      },
+      'daemon lockfile site is unwritable; refusing to boot',
+    );
+    throw new LockfileFatalError(
+      `daemon lockfile site unwritable (${code}) at ${lockPath}`,
+      { code, path: lockPath, cause: err },
+    );
+  }
+  // Unknown error — surface to the caller's crash handler with full
+  // context so a fresh failure mode does not get silently classified
+  // as fatal.
+  throw err;
+}


### PR DESCRIPTION
## Summary

Implements `<dataRoot>/daemon.lock` single-instance enforcement per frag-6-7 §6.4 + audit gap.

- **`daemon/src/lifecycle/lockfile.ts`** (new) — `acquireDaemonLock({ dataRoot, logger })` returns a `LockHandle { path, pid, release }`. Uses `proper-lockfile` for the atomic `mkdir(daemon.lock.lock)` gate; PID payload written to `daemon.lock` itself for stale-recovery. `probeHolderProcess(pid)` is a pure decider mirroring `dev-parent-watchdog.checkParent`.
- **Boot order** (`daemon/src/index.ts`) — lockfile acquired as the FIRST step in the boot async IIFE, BEFORE socket bind / data-dir touch. A racing second daemon throws `LockfileBusyError` → exit 75 (EX_TEMPFAIL, supervisor `spawn-or-attach` interprets as "attach"). EROFS / EACCES / EPERM / ENOSPC at the lockfile site → `lockfile_erofs_fatal` log line + exit 78 (EX_CONFIG).
- **Stale-PID steal** —
  - **POSIX**: `process.kill(holderPid, 0)`. `ESRCH` → steal with `lockfile_steal` warn line.
  - **Windows**: same `process.kill(pid, 0)` (Node maps internally through `OpenProcess`); `ESRCH` → steal. A `probeWindows` seam exists for a future N-API helper that uses `PROCESS_QUERY_LIMITED_INFORMATION` for a less-privileged check (lands with the §7.M1 ACL helper).
  - Unparseable PID payload (holder crashed mid-write) is steal-eligible without ever calling `process.kill(0)` / `kill(-1)` (which have dangerous broadcast semantics on POSIX).
  - One-shot steal cap via `stealAttempted` guard prevents an infinite loop if two dead-holder racers keep re-mkdir'ing.
- **Swap-lock contract (frag-6-7 §6.4 step 4)** — `daemon.shutdownForUpgrade.releaseLock` action now invokes `lockHandle.release()` instead of the prior no-op stub, so the supervisor's binary-swap window cannot race a fresh-daemon-boot for `bin/`. The same release runs in the SIGTERM-driven `closeTransports` path so a planned exit clears the lock.

## Canonical log lines

- `lockfile_acquired { pid, path, datarootMs }`
- `lockfile_steal { stale_pid, datarootMs, path }`
- `lockfile_erofs_fatal { code, path, datarootMs, err }`

## Test plan

- [x] `daemon/src/lifecycle/__tests__/lockfile.test.ts` — 12 tests, all green:
  - `probeHolderProcess` pure decider (alive / gone / unknown / Windows seam).
  - Real-fs acquire / release / re-acquire / pid-payload assertion.
  - Stale-PID steal emits `lockfile_steal` and overwrites the PID payload.
  - Live-PID holder is NOT stolen (LockfileBusyError instead).
  - EROFS via stub → `lockfile_erofs_fatal` + `LockfileFatalError`.
  - One-shot steal cap (racer re-acquires before us → Busy, no loop).
  - **Cross-process e2e**: spawns two real Node processes via tsx; second exits 75 with `BUSY:<holderPid>` while first holds.
- [x] `npx tsc --noEmit -p daemon/tsconfig.json` clean.
- [x] `npm run typecheck` clean (renderer + electron + daemon).
- [x] `npx eslint` clean on all touched files.

## Unblocks

- **#139 HMAC keystore** — `daemon.secret` rotation needs single-instance enforcement so the rotate window cannot race a second binder.
- **#148 supervisor probe** — frag-6-7 §6.1 spawn-or-attach can now use lockfile-as-gate vs unreliable Win named-pipe `PIPE_UNLIMITED_INSTANCES` probe.
- **#105 SQLite migration** — frag-8 §8.3 step 1a's unconditional `unlink(ccsm.db.migrating[-wal][-shm])` orphan cleanup is only safe under guaranteed single-daemon.

## Out of scope

- Wiring `acquireDaemonLock` into a future `bootDb()` ordering (lockfile → secret → ensureDataDir) — secret-loader and `bootDb` invocation in `index.ts` are separate slices.
- Replacing `process.kill(pid, 0)` with a real `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION)` N-API helper — lands with §7.M1 pipe-ACL helper which shares the same dependency cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)