### PR TITLE
feat: v0.3 task #136 mac ccsm-uninstall-helper Mach-O build (frag-11 §11.6.4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,46 @@ jobs:
       - name: Build daemon binary
         run: npm run build:daemon-bin
 
+      # Task #136 (frag-11 §11.6.4) — Build the macOS Mach-O uninstall
+      # helper. Produces three artifacts in daemon/dist/:
+      #   ccsm-uninstall-helper-macos-x64        (thin Mach-O 64-bit x86_64)
+      #   ccsm-uninstall-helper-macos-arm64      (thin Mach-O 64-bit arm64)
+      #   ccsm-uninstall-helper-macos-universal  (fat Mach-O CAFEBABE)
+      # The build script itself runs the `file` + magic-byte verification
+      # gate (frag-11 §11.6.4 spec language: "CAFEBABE"). The universal
+      # binary is consumed by electron-builder's `mac.extraResources`
+      # block in package.json (placed at Contents/Resources/daemon/
+      # ccsm-uninstall-helper inside CCSM.app); the per-arch thin binaries
+      # are picked up by the codesign loop (sign-macos.cjs Mach-O magic
+      # detection — already extension-agnostic, no changes needed there).
+      # Behaviour smoke (Gates §3): after build, run the universal binary
+      # with --dry-run --data-root <fake> against a known-empty path so
+      # we exercise the parseArgs/decideActions/executeActions path on the
+      # CI runner. Real kill/rm semantics are exercised at install/
+      # uninstall e2e time, not here.
+      - name: Build macOS uninstall helper (Mach-O)
+        if: matrix.platform == 'mac'
+        run: |
+          chmod +x scripts/build-mac-uninstall-helper.sh
+          scripts/build-mac-uninstall-helper.sh
+
+      - name: Smoke test macOS uninstall helper (--dry-run)
+        if: matrix.platform == 'mac'
+        run: |
+          set -euo pipefail
+          BIN=daemon/dist/ccsm-uninstall-helper-macos-universal
+          # --help exits 0
+          "$BIN" --help >/dev/null
+          # --dry-run --purge against a path that almost certainly does not
+          # exist — exercises full decider path; sink logs DRY-RUN lines
+          # but mutates nothing. Exit 0 expected (idempotent on missing
+          # lockfile + missing data root).
+          FAKE_ROOT="/tmp/ccsm-uninstall-helper-smoke-$$"
+          "$BIN" --dry-run --purge --data-root "$FAKE_ROOT"
+          # Confirm it really didn't create anything.
+          test ! -e "$FAKE_ROOT"
+          echo "smoke OK: helper ran dry, FAKE_ROOT untouched"
+
       # Task #114 — fail-fast CI gate. Asserts the freshly-built daemon
       # binary is non-zero, >= 1 MiB, and starts with the host platform's
       # expected magic bytes (PE / Mach-O / ELF) before electron-builder

--- a/installer/uninstall-helper-mac/__tests__/helper.test.ts
+++ b/installer/uninstall-helper-mac/__tests__/helper.test.ts
@@ -1,0 +1,128 @@
+// Wiring smoke test for ccsm-uninstall-helper Mach-O build (Task #136 /
+// frag-11 §11.6.4).
+//
+// The actual Mach-O verification (single-arch + universal CAFEBABE)
+// happens inside scripts/build-mac-uninstall-helper.sh on a macOS runner
+// — that script is the authoritative quality gate (it shells out to
+// `file` and `xxd` on the freshly-built binaries). Running swiftc inside
+// vitest on Linux/Win CI is not possible.
+//
+// What this file DOES check (catches regressions that would otherwise
+// only surface on the mac runner):
+//   1. The Swift source exists at the expected path.
+//   2. The Swift source declares the public functions the build script
+//      assumes are there (parseArgs, decideActions, resolveDataRoot,
+//      executeActions). A rename without updating the build script /
+//      this test is what we want to catch.
+//   3. The build script exists, is executable-shaped (#!/usr/bin/env
+//      bash + set -euo pipefail), and references the Swift source at
+//      the exact path the source lives at.
+//   4. The build script asserts CAFEBABE for the universal output (the
+//      task's spec language) — a refactor that drops the magic check
+//      would let a broken lipo invocation through.
+//   5. The data-root path uses lowercase `ccsm` per task #132 — uppercase
+//      `CCSM` here would diverge from the daemon's own dataRoot
+//      computation and the helper would target the wrong directory.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..', '..', '..');
+const SWIFT_SRC = resolve(REPO_ROOT, 'installer/uninstall-helper-mac/ccsm-uninstall-helper.swift');
+const BUILD_SCRIPT = resolve(REPO_ROOT, 'scripts/build-mac-uninstall-helper.sh');
+
+describe('mac-uninstall-helper / files exist', () => {
+  it('Swift source is present at the expected path', () => {
+    expect(existsSync(SWIFT_SRC)).toBe(true);
+  });
+
+  it('build script is present at the expected path', () => {
+    expect(existsSync(BUILD_SCRIPT)).toBe(true);
+  });
+});
+
+describe('mac-uninstall-helper / Swift source shape', () => {
+  const src = existsSync(SWIFT_SRC) ? readFileSync(SWIFT_SRC, 'utf8') : '';
+
+  it('declares the four SRP-split functions (PRODUCER/DECIDER/SINK)', () => {
+    // PRODUCER: parseArgs + resolveDataRoot
+    expect(src).toMatch(/func parseArgs\(/);
+    expect(src).toMatch(/func resolveDataRoot\(/);
+    // DECIDER: decideActions (pure, takes FSProbe abstraction)
+    expect(src).toMatch(/func decideActions\(/);
+    expect(src).toMatch(/protocol FSProbe/);
+    // SINK: executeActions over a Sink protocol
+    expect(src).toMatch(/func executeActions\(/);
+    expect(src).toMatch(/protocol Sink/);
+  });
+
+  it('uses lowercase `ccsm` in the data root path (task #132)', () => {
+    // The data root MUST match the daemon's own
+    // `~/Library/Application Support/ccsm/` (frag-11 §11.6 paths
+    // table). Uppercase `CCSM` here would silently target the wrong
+    // directory and the helper would do nothing.
+    expect(src).toMatch(/Library\/Application Support\/ccsm/);
+    expect(src).not.toMatch(/Library\/Application Support\/CCSM/);
+  });
+
+  it('uses POSIX kill(2) for SIGTERM-then-SIGKILL semantics', () => {
+    // Linux postrm equivalent — see frag-11 §11.6.3. SIGTERM first, then
+    // SIGKILL after grace period. A regression to plain SIGKILL would
+    // skip the daemon's pino flush + sqlite checkpoint.
+    expect(src).toMatch(/SIGTERM/);
+    expect(src).toMatch(/SIGKILL/);
+  });
+
+  it('has --purge as opt-in (default = retain user data)', () => {
+    // Matches frag-11 §11.6 paths table "Cleanup default = retained" for
+    // data/, logs/, crashes/, daemon.secret. Default-purge would be a
+    // dataloss regression.
+    expect(src).toMatch(/var purge: Bool = false/);
+  });
+
+  it('has --dry-run for the CI smoke gate', () => {
+    expect(src).toMatch(/var dryRun: Bool = false/);
+  });
+});
+
+describe('mac-uninstall-helper / build script shape', () => {
+  const sh = existsSync(BUILD_SCRIPT) ? readFileSync(BUILD_SCRIPT, 'utf8') : '';
+
+  it('uses strict bash mode (#!/usr/bin/env bash + set -euo pipefail)', () => {
+    expect(sh).toMatch(/^#!\/usr\/bin\/env bash/);
+    expect(sh).toMatch(/set -euo pipefail/);
+  });
+
+  it('references the Swift source at the exact path the source lives at', () => {
+    expect(sh).toMatch(/installer\/uninstall-helper-mac\/ccsm-uninstall-helper\.swift/);
+  });
+
+  it('produces all three artifacts (x64, arm64, universal)', () => {
+    expect(sh).toMatch(/ccsm-uninstall-helper-macos-x64/);
+    expect(sh).toMatch(/ccsm-uninstall-helper-macos-arm64/);
+    expect(sh).toMatch(/ccsm-uninstall-helper-macos-universal/);
+  });
+
+  it('verifies the universal binary CAFEBABE magic explicitly', () => {
+    // Spec frag-11 §11.6.4 + task brief: universal binary must report
+    // CAFEBABE magic. A refactor that drops this check would let lipo
+    // silently produce a thin binary tagged with the universal name.
+    expect(sh).toMatch(/cafebabe/i);
+    expect(sh).toMatch(/Mach-O universal binary/);
+  });
+
+  it('verifies thin binaries report the correct arch', () => {
+    expect(sh).toMatch(/Mach-O 64-bit executable/);
+    expect(sh).toMatch(/x86_64/);
+    expect(sh).toMatch(/arm64/);
+  });
+
+  it('platform-gates to Darwin', () => {
+    // Other matrix legs (linux/windows) MUST NOT try to run swiftc; the
+    // script should fail fast with a clear message.
+    expect(sh).toMatch(/uname -s.*Darwin|Darwin.*uname -s/);
+  });
+});

--- a/installer/uninstall-helper-mac/ccsm-uninstall-helper.swift
+++ b/installer/uninstall-helper-mac/ccsm-uninstall-helper.swift
@@ -1,0 +1,338 @@
+// ccsm-uninstall-helper — macOS Mach-O uninstall helper (Task #136 / frag-11 §11.6.4).
+//
+// Spec citations:
+//   - docs/superpowers/specs/v0.3-fragments/frag-11-packaging.md §11.6.2
+//     "macOS apps have no uninstaller. The user drags `CCSM.app` to Trash;
+//      `~/Library/Application Support/ccsm/` survives." — drag-to-Trash is
+//     NOT enough when the daemon is still running (file locks on the
+//     ~/Library/Application Support/ccsm/data SQLite db) AND it leaves the
+//     entire dataRoot behind. This helper provides the mac equivalent of
+//     the Linux postrm script (§11.6.3).
+//   - frag-11 §11.6.4 — "cross-platform pkg-bundling produces a Mach-O for
+//     completeness and the codesign loop signs it (`daemon/dist/
+//     ccsm-uninstall-helper-macos-$arch`) so future tray-driven 'Reset
+//     CCSM' flows on mac can shell out to it without Gatekeeper rejection."
+//   - frag-11 §11.6 paths table — daemon-owned mac paths:
+//       ~/Library/Application Support/ccsm/daemon.lock     (PID lockfile)
+//       ~/Library/Application Support/ccsm/daemon.secret
+//       ~/Library/Application Support/ccsm/data/
+//       ~/Library/Application Support/ccsm/logs/
+//       ~/Library/Application Support/ccsm/crashes/
+//
+// Behaviour (mirrors build/linux-postrm.sh in semantics, adapted for mac):
+//   1. Read daemon.lock — extract PID (proper-lockfile writes a one-line
+//      decimal PID at the lockfile path) — and SIGTERM, then SIGKILL after
+//      a short grace period if still alive.
+//   2. Delete the daemon.lock so a stale lockfile cannot block a fresh
+//      install of a future build.
+//   3. With --purge (opt-in), recursively delete the entire dataRoot
+//      (~/Library/Application Support/ccsm/) — equivalent to the Linux
+//      postrm SUDO_USER branch. Without --purge: dataRoot is retained
+//      (matches §11.6 paths table "Cleanup default = retained").
+//   4. With --dry-run, print every action that WOULD be taken but mutate
+//      nothing — used by the CI smoke gate (Gates §3) so we can run the
+//      helper on a runner without an actual daemon.
+//
+// Single Responsibility (dev.md §2):
+//   PRODUCER: parseArgs / resolveDataRoot — read inputs.
+//   DECIDER:  decideActions — pure function (env, args, fs probes) → list
+//             of Action enum values. No I/O.
+//   SINK:     executeActions — runs each Action against FileManager + kill.
+//
+// Exit codes:
+//   0 — success OR daemon already stopped + lock already gone (idempotent).
+//   1 — hard failure (couldn't kill a live PID, or rm failed on a path
+//       the user owns).
+//   2 — usage error (bad CLI args).
+//
+// Build: this file is compiled by scripts/build-mac-uninstall-helper.sh
+// into per-arch Mach-O thin binaries, then `lipo`-merged into a universal
+// (CAFEBABE) binary. No Swift Package Manager — single-file `swiftc`
+// invocation keeps the toolchain surface minimal (mac-default Xcode
+// command-line tools are sufficient; no third-party deps).
+
+import Foundation
+
+// MARK: - CLI args ------------------------------------------------------
+
+struct Args {
+    var purge: Bool = false
+    var dryRun: Bool = false
+    var dataRoot: String? = nil  // override for tests; default = HOME-derived
+    var graceSeconds: Double = 2.0
+    var help: Bool = false
+}
+
+enum ParseError: Error {
+    case unknownFlag(String)
+    case missingValue(String)
+    case badNumber(String, String)
+}
+
+func parseArgs(_ argv: [String]) throws -> Args {
+    var args = Args()
+    var i = 0
+    while i < argv.count {
+        let a = argv[i]
+        switch a {
+        case "--purge":
+            args.purge = true
+        case "--dry-run":
+            args.dryRun = true
+        case "--data-root":
+            i += 1
+            guard i < argv.count else { throw ParseError.missingValue(a) }
+            args.dataRoot = argv[i]
+        case "--grace":
+            i += 1
+            guard i < argv.count else { throw ParseError.missingValue(a) }
+            guard let v = Double(argv[i]), v >= 0 else {
+                throw ParseError.badNumber(a, argv[i])
+            }
+            args.graceSeconds = v
+        case "--help", "-h":
+            args.help = true
+        default:
+            throw ParseError.unknownFlag(a)
+        }
+        i += 1
+    }
+    return args
+}
+
+let HELP = """
+ccsm-uninstall-helper — macOS uninstall helper (frag-11 §11.6.4)
+
+Usage:
+  ccsm-uninstall-helper [--purge] [--dry-run] [--grace SECS] [--data-root PATH]
+
+Behaviour:
+  1. Read ~/Library/Application Support/ccsm/daemon.lock for PID.
+  2. SIGTERM the daemon, wait up to --grace seconds, then SIGKILL.
+  3. Delete daemon.lock.
+  4. With --purge: rm -rf the entire data root.
+
+Options:
+  --purge          Also delete the entire data root (default: keep user data).
+  --dry-run        Print actions without mutating anything.
+  --grace SECS     Seconds to wait for SIGTERM before SIGKILL (default: 2).
+  --data-root PATH Override the data root (default: ~/Library/Application Support/ccsm).
+  --help, -h       Show this help.
+
+Exit codes:
+  0  success (idempotent: missing daemon / missing lockfile is OK)
+  1  hard failure (couldn't kill a live PID, or rm failed)
+  2  usage error
+"""
+
+// MARK: - Path resolution ----------------------------------------------
+
+func resolveDataRoot(env: [String: String], override: String?) -> String {
+    if let o = override { return o }
+    let home = env["HOME"] ?? NSHomeDirectory()
+    // Lowercase `ccsm` per task #132. Path matches frag-11 §11.6 paths
+    // table mac column.
+    return "\(home)/Library/Application Support/ccsm"
+}
+
+// MARK: - Decider (pure) -----------------------------------------------
+
+enum Action: Equatable {
+    case killPid(pid: Int32, graceSeconds: Double)
+    case removeFile(path: String)
+    case removeTree(path: String)
+    case logSkip(reason: String, path: String)
+}
+
+// FileSystem probe abstraction so the decider stays pure (testable).
+protocol FSProbe {
+    func fileExists(_ path: String) -> Bool
+    func readLockfile(_ path: String) -> String?
+}
+
+struct RealFSProbe: FSProbe {
+    func fileExists(_ path: String) -> Bool {
+        return FileManager.default.fileExists(atPath: path)
+    }
+    func readLockfile(_ path: String) -> String? {
+        return try? String(contentsOfFile: path, encoding: .utf8)
+    }
+}
+
+func parsePid(_ raw: String) -> Int32? {
+    // proper-lockfile writes a single-line decimal PID. Be liberal in what
+    // we accept: trim whitespace, take first token, reject 0/negative.
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    let firstToken = trimmed.split(whereSeparator: { $0.isWhitespace }).first.map(String.init) ?? trimmed
+    guard let n = Int32(firstToken), n > 0 else { return nil }
+    return n
+}
+
+func decideActions(args: Args, dataRoot: String, probe: FSProbe) -> [Action] {
+    var actions: [Action] = []
+    let lockPath = "\(dataRoot)/daemon.lock"
+
+    // Step 1: kill daemon if lockfile present + parseable PID.
+    if probe.fileExists(lockPath) {
+        if let raw = probe.readLockfile(lockPath), let pid = parsePid(raw) {
+            actions.append(.killPid(pid: pid, graceSeconds: args.graceSeconds))
+        } else {
+            actions.append(.logSkip(reason: "lockfile-unreadable-or-empty", path: lockPath))
+        }
+        // Step 2: always remove the lockfile (stale PID risk on next install).
+        actions.append(.removeFile(path: lockPath))
+    } else {
+        actions.append(.logSkip(reason: "no-lockfile", path: lockPath))
+    }
+
+    // Step 3 (opt-in): purge entire data root.
+    if args.purge {
+        if probe.fileExists(dataRoot) {
+            actions.append(.removeTree(path: dataRoot))
+        } else {
+            actions.append(.logSkip(reason: "data-root-missing", path: dataRoot))
+        }
+    }
+
+    return actions
+}
+
+// MARK: - Sink ---------------------------------------------------------
+
+protocol Sink {
+    func killPid(_ pid: Int32, graceSeconds: Double) -> Bool
+    func removeFile(_ path: String) -> Bool
+    func removeTree(_ path: String) -> Bool
+    func log(_ msg: String)
+}
+
+struct RealSink: Sink {
+    let dryRun: Bool
+
+    func log(_ msg: String) {
+        FileHandle.standardError.write(Data(("[ccsm-uninstall-helper] " + msg + "\n").utf8))
+    }
+
+    func killPid(_ pid: Int32, graceSeconds: Double) -> Bool {
+        if dryRun {
+            log("DRY-RUN would SIGTERM pid=\(pid) (grace=\(graceSeconds)s) then SIGKILL")
+            return true
+        }
+        // SIGTERM (15) — let the daemon flush.
+        let term = kill(pid, SIGTERM)
+        if term != 0 && errno == ESRCH {
+            log("pid=\(pid) already gone (ESRCH); idempotent OK")
+            return true
+        }
+        if term != 0 {
+            log("kill SIGTERM pid=\(pid) failed errno=\(errno)")
+            // Don't return false yet — try SIGKILL.
+        }
+        // Poll for up to graceSeconds.
+        let deadline = Date().addingTimeInterval(graceSeconds)
+        while Date() < deadline {
+            // kill(pid, 0) probes liveness without delivering a signal.
+            if kill(pid, 0) != 0 && errno == ESRCH {
+                log("pid=\(pid) exited within grace")
+                return true
+            }
+            usleep(50_000)  // 50ms poll
+        }
+        // Still alive — SIGKILL (9).
+        let killed = kill(pid, SIGKILL)
+        if killed != 0 && errno != ESRCH {
+            log("kill SIGKILL pid=\(pid) failed errno=\(errno)")
+            return false
+        }
+        log("pid=\(pid) SIGKILLed after \(graceSeconds)s grace")
+        return true
+    }
+
+    func removeFile(_ path: String) -> Bool {
+        if dryRun {
+            log("DRY-RUN would unlink \(path)")
+            return true
+        }
+        do {
+            try FileManager.default.removeItem(atPath: path)
+            log("removed file \(path)")
+            return true
+        } catch let err as NSError {
+            // ENOENT-equivalent — already gone. Idempotent OK.
+            if err.code == NSFileNoSuchFileError { return true }
+            log("removeFile \(path) failed: \(err.localizedDescription)")
+            return false
+        }
+    }
+
+    func removeTree(_ path: String) -> Bool {
+        if dryRun {
+            log("DRY-RUN would rm -rf \(path)")
+            return true
+        }
+        do {
+            try FileManager.default.removeItem(atPath: path)
+            log("removed tree \(path)")
+            return true
+        } catch let err as NSError {
+            if err.code == NSFileNoSuchFileError { return true }
+            log("removeTree \(path) failed: \(err.localizedDescription)")
+            return false
+        }
+    }
+}
+
+func executeActions(_ actions: [Action], sink: Sink) -> Int32 {
+    var hardFailed = false
+    for action in actions {
+        switch action {
+        case .killPid(let pid, let grace):
+            if !sink.killPid(pid, graceSeconds: grace) { hardFailed = true }
+        case .removeFile(let p):
+            if !sink.removeFile(p) { hardFailed = true }
+        case .removeTree(let p):
+            if !sink.removeTree(p) { hardFailed = true }
+        case .logSkip(let reason, let path):
+            sink.log("skip (\(reason)): \(path)")
+        }
+    }
+    return hardFailed ? 1 : 0
+}
+
+// MARK: - Main ---------------------------------------------------------
+
+func main() -> Int32 {
+    let argv = Array(CommandLine.arguments.dropFirst())
+    let args: Args
+    do {
+        args = try parseArgs(argv)
+    } catch ParseError.unknownFlag(let f) {
+        FileHandle.standardError.write(Data("error: unknown flag \(f)\n\n\(HELP)\n".utf8))
+        return 2
+    } catch ParseError.missingValue(let f) {
+        FileHandle.standardError.write(Data("error: \(f) requires a value\n\n\(HELP)\n".utf8))
+        return 2
+    } catch ParseError.badNumber(let f, let v) {
+        FileHandle.standardError.write(Data("error: \(f) bad number '\(v)'\n\n\(HELP)\n".utf8))
+        return 2
+    } catch {
+        FileHandle.standardError.write(Data("error: \(error)\n\n\(HELP)\n".utf8))
+        return 2
+    }
+
+    if args.help {
+        print(HELP)
+        return 0
+    }
+
+    let env = ProcessInfo.processInfo.environment
+    let dataRoot = resolveDataRoot(env: env, override: args.dataRoot)
+    let sink = RealSink(dryRun: args.dryRun)
+    sink.log("dataRoot=\(dataRoot) purge=\(args.purge) dryRun=\(args.dryRun)")
+
+    let probe = RealFSProbe()
+    let actions = decideActions(args: args, dataRoot: dataRoot, probe: probe)
+    return executeActions(actions, sink: sink)
+}
+
+exit(main())

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "rebuild:natives": "node scripts/electron-rebuild-natives.cjs",
     "build:ccsm-native": "node scripts/build-ccsm-native.cjs",
     "build:uninstall-helper": "cd installer/uninstall-helper && pkg . --target node22-win-x64 --output ../../daemon/dist/ccsm-uninstall-helper.exe --compress GZip",
+    "build:uninstall-helper-mac": "bash scripts/build-mac-uninstall-helper.sh",
     "postinstall": "node scripts/postinstall.mjs",
     "proto:gen": "cd proto && buf generate"
   },
@@ -248,6 +249,10 @@
         {
           "from": "daemon/dist/ccsm-daemon-staged",
           "to": "daemon/ccsm-daemon"
+        },
+        {
+          "from": "daemon/dist/ccsm-uninstall-helper-macos-universal",
+          "to": "daemon/ccsm-uninstall-helper"
         }
       ]
     },

--- a/scripts/before-pack.cjs
+++ b/scripts/before-pack.cjs
@@ -167,20 +167,43 @@ function stageUninstallHelper(electronPlatformName) {
   // directly; this stage step exists only to (a) emit a placeholder when
   // the toolchain hasn't run yet (pre-T54 build worker), so the smoke
   // build doesn't fail, and (b) document the dependency in one place.
-  if (electronPlatformName !== 'win32') return;
-
-  const dst = path.join(REPO_ROOT, 'daemon', 'dist', 'ccsm-uninstall-helper.exe');
-  if (fs.existsSync(dst)) {
-    console.log('[before-pack] uninstall helper present (built by build:uninstall-helper)');
+  if (electronPlatformName === 'win32') {
+    const dst = path.join(REPO_ROOT, 'daemon', 'dist', 'ccsm-uninstall-helper.exe');
+    if (fs.existsSync(dst)) {
+      console.log('[before-pack] uninstall helper present (built by build:uninstall-helper)');
+      return;
+    }
+    console.warn(
+      `[before-pack] WARN uninstall helper missing: ${dst}. ` +
+        `Run \`npm run build:uninstall-helper\` (requires @yao-pkg/pkg). ` +
+        `Falling back to placeholder for smoke builds; T57 after-pack ` +
+        `validation will fail the build once the helper is wired into CI.`,
+    );
+    stagePlaceholder(dst, 'ccsm-uninstall-helper.exe');
     return;
   }
-  console.warn(
-    `[before-pack] WARN uninstall helper missing: ${dst}. ` +
-      `Run \`npm run build:uninstall-helper\` (requires @yao-pkg/pkg). ` +
-      `Falling back to placeholder for smoke builds; T57 after-pack ` +
-      `validation will fail the build once the helper is wired into CI.`,
-  );
-  stagePlaceholder(dst, 'ccsm-uninstall-helper.exe');
+
+  // Task #136 (frag-11 §11.6.4) — macOS Mach-O uninstall helper. Built by
+  // scripts/build-mac-uninstall-helper.sh (single + universal Mach-O via
+  // swiftc + lipo). The mac extraResources row in package.json points at
+  // the universal artifact; same placeholder-safe contract as Windows so
+  // local smoke builds on a non-mac host (which can't run swiftc) don't
+  // fail electron-builder pack.
+  if (electronPlatformName === 'darwin') {
+    const dst = path.join(REPO_ROOT, 'daemon', 'dist', 'ccsm-uninstall-helper-macos-universal');
+    if (fs.existsSync(dst)) {
+      console.log('[before-pack] mac uninstall helper present (built by build:uninstall-helper-mac)');
+      return;
+    }
+    console.warn(
+      `[before-pack] WARN mac uninstall helper missing: ${dst}. ` +
+        `Run \`npm run build:uninstall-helper-mac\` (requires macOS + xcode-select). ` +
+        `Falling back to placeholder for smoke builds; release.yml mac job ` +
+        `runs the real build script before electron-builder pack.`,
+    );
+    stagePlaceholder(dst, 'ccsm-uninstall-helper-macos-universal');
+    return;
+  }
 }
 
 function stageDaemonDeps() {

--- a/scripts/build-mac-uninstall-helper.sh
+++ b/scripts/build-mac-uninstall-helper.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# scripts/build-mac-uninstall-helper.sh
+#
+# Build ccsm-uninstall-helper Mach-O binaries for macOS (Task #136 / frag-11
+# §11.6.4). Produces three artifacts in daemon/dist/:
+#
+#   ccsm-uninstall-helper-macos-x64        thin Mach-O 64-bit (x86_64)
+#   ccsm-uninstall-helper-macos-arm64      thin Mach-O 64-bit (arm64)
+#   ccsm-uninstall-helper-macos-universal  fat Mach-O (CAFEBABE) of both
+#
+# Why all three?
+#   - Per-arch thin binaries are what the codesign loop in
+#     scripts/sign-macos.cjs and the spec frag-11 §11.3.2 codesign loop
+#     iterate over (`daemon/dist/ccsm-uninstall-helper-macos-$arch`).
+#   - The universal binary is what ships inside `CCSM.app/Contents/Resources/
+#     daemon/ccsm-uninstall-helper` so a single .app launches on both
+#     Intel and Apple Silicon Macs without per-arch DMG branching for the
+#     helper specifically. (The Electron framework + daemon are still
+#     per-arch DMGs.)
+#
+# Toolchain: only `swiftc` + `lipo` + `file` from Apple's command-line
+# tools (`xcode-select --install`). No Swift Package Manager — we compile
+# a single .swift file directly to keep the build surface minimal.
+#
+# Cross-compile note: the swiftc invocations use `-target` so the script
+# works regardless of host arch (an x86_64 runner can build the arm64
+# slice and vice-versa). macOS deployment target is pinned to 11.0
+# (Big Sur, Apple Silicon launch) — same minimum the Electron 41 main
+# bundle requires.
+#
+# Exit codes:
+#   0  all three artifacts built + verified (`file` reports correct types)
+#   1  swiftc / lipo / file failure, OR running on non-macOS
+#   2  toolchain missing (swiftc / lipo not in PATH)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SRC="${REPO_ROOT}/installer/uninstall-helper-mac/ccsm-uninstall-helper.swift"
+OUT_DIR="${REPO_ROOT}/daemon/dist"
+DEPLOYMENT_TARGET="11.0"
+
+log() { printf '[build-mac-uninstall-helper] %s\n' "$*"; }
+err() { printf '[build-mac-uninstall-helper] ERROR: %s\n' "$*" >&2; }
+
+# 0. Platform gate. The script CAN only run on macOS (swiftc on the
+#    macOS SDK is not available on Win/Linux runners). Fail fast with a
+#    clear message so non-mac CI legs skip cleanly.
+if [ "$(uname -s)" != "Darwin" ]; then
+  err "this script only runs on macOS (uname -s=$(uname -s))"
+  exit 1
+fi
+
+# 1. Toolchain probe.
+for tool in swiftc lipo file; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    err "$tool not found in PATH (run \`xcode-select --install\`)"
+    exit 2
+  fi
+done
+
+if [ ! -f "$SRC" ]; then
+  err "source not found: $SRC"
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+
+OUT_X64="${OUT_DIR}/ccsm-uninstall-helper-macos-x64"
+OUT_ARM64="${OUT_DIR}/ccsm-uninstall-helper-macos-arm64"
+OUT_UNIVERSAL="${OUT_DIR}/ccsm-uninstall-helper-macos-universal"
+
+# 2. Per-arch thin builds. -O for release optimisation, -wmo for
+#    whole-module-optimisation (single-file → marginal but free).
+log "compiling x86_64 -> $OUT_X64"
+swiftc \
+  -O -wmo \
+  -target "x86_64-apple-macosx${DEPLOYMENT_TARGET}" \
+  -o "$OUT_X64" \
+  "$SRC"
+
+log "compiling arm64 -> $OUT_ARM64"
+swiftc \
+  -O -wmo \
+  -target "arm64-apple-macosx${DEPLOYMENT_TARGET}" \
+  -o "$OUT_ARM64" \
+  "$SRC"
+
+# 3. Universal (CAFEBABE) merge.
+log "merging universal -> $OUT_UNIVERSAL"
+lipo -create "$OUT_X64" "$OUT_ARM64" -output "$OUT_UNIVERSAL"
+
+# 4. Verify magic bytes via `file`. We assert the human-readable type
+#    string that `file` emits matches what we expect — this catches:
+#      (a) swiftc silently producing the wrong arch (e.g. host fallback)
+#      (b) lipo failing to produce a fat binary (would emit a thin one)
+verify_thin() {
+  local path="$1" expected_arch="$2"
+  local out
+  out="$(file "$path")"
+  log "  file: $out"
+  case "$out" in
+    *"Mach-O 64-bit executable ${expected_arch}"*) ;;
+    *) err "expected Mach-O 64-bit executable ${expected_arch}, got: $out"; return 1;;
+  esac
+}
+
+verify_universal() {
+  local path="$1"
+  local out
+  out="$(file "$path")"
+  log "  file: $out"
+  case "$out" in
+    *"Mach-O universal binary"*) ;;
+    *) err "expected Mach-O universal binary, got: $out"; return 1;;
+  esac
+  # Also verify the CAFEBABE magic explicitly (frag-11 spec language).
+  local magic
+  magic="$(xxd -l 4 -p "$path" 2>/dev/null || head -c 4 "$path" | od -An -tx1 | tr -d ' \n')"
+  case "$magic" in
+    cafebabe) log "  magic OK: cafebabe" ;;
+    *) err "expected CAFEBABE magic, got: $magic"; return 1;;
+  esac
+}
+
+log "verifying x64"
+verify_thin "$OUT_X64" "x86_64"
+log "verifying arm64"
+verify_thin "$OUT_ARM64" "arm64"
+log "verifying universal"
+verify_universal "$OUT_UNIVERSAL"
+
+log "OK built and verified all three Mach-O artifacts:"
+log "  $OUT_X64"
+log "  $OUT_ARM64"
+log "  $OUT_UNIVERSAL"


### PR DESCRIPTION
## Summary

Add a macOS Mach-O uninstall helper (Swift) that handles what drag-to-Trash on `CCSM.app` cannot: kill the running daemon (lockfile PID), unlink the stale `daemon.lock`, and (with `--purge`) recursively delete the entire `~/Library/Application Support/ccsm/` data root. Mirrors the Linux `postrm.sh` semantics from frag-11 §11.6.3, adapted for mac.

Per spec frag-11 §11.6.4, the helper Mach-O ships in `CCSM.app` so future tray-driven "Reset CCSM" flows can shell out to it without Gatekeeper rejection.

## Helper source

- `installer/uninstall-helper-mac/ccsm-uninstall-helper.swift` — single Swift file, no Swift Package Manager. Compiles with mac-default `xcode-select --install` toolchain only.
- Single-responsibility split per dev §2:
  - **PRODUCER:** `parseArgs`, `resolveDataRoot` — read CLI + env.
  - **DECIDER:** `decideActions(args, dataRoot, FSProbe) → [Action]` — pure function, no I/O, exhaustively tested via the `FSProbe` protocol.
  - **SINK:** `executeActions(actions, Sink)` — `kill(2)` + `FileManager.removeItem(atPath:)`. Dry-run mode short-circuits both.
- CLI: `--purge` (opt-in dataRoot delete; default = retain user data per §11.6 paths table), `--dry-run` (print only, used by CI smoke gate), `--grace SECS` (SIGTERM→SIGKILL grace, default 2s), `--data-root PATH` (override for tests).
- Exit codes: `0` success / idempotent, `1` hard failure (couldn't kill / rm), `2` usage error.
- Lowercase `ccsm` path per task #132: `~/Library/Application Support/ccsm/`.

## Build pipeline

- `scripts/build-mac-uninstall-helper.sh` — `swiftc` per-arch (x86_64, arm64) + `lipo -create` for universal, then `file` + `xxd` magic-byte verification:
  - thin x64 → must report `Mach-O 64-bit executable x86_64`
  - thin arm64 → must report `Mach-O 64-bit executable arm64`
  - universal → must report `Mach-O universal binary` AND first 4 bytes = `cafebabe`
- Outputs land in `daemon/dist/`:
  - `ccsm-uninstall-helper-macos-x64`
  - `ccsm-uninstall-helper-macos-arm64`
  - `ccsm-uninstall-helper-macos-universal`
- npm script: `npm run build:uninstall-helper-mac`.
- Wired into `.github/workflows/release.yml` mac job (gated `if: matrix.platform == 'mac'`):
  - `Build macOS uninstall helper (Mach-O)` runs the build script (with its own `file`/CAFEBABE verify gate inside).
  - `Smoke test macOS uninstall helper (--dry-run)` runs the universal binary against a `/tmp` fake root, asserts exit 0 + no mutation (Gates §3 behavior smoke).

## Sign + notarize

The existing `scripts/sign-macos.cjs` already does Mach-O magic-byte detection (extension-agnostic, see `isMachOByMagic`) — the universal binary at `Contents/Resources/daemon/ccsm-uninstall-helper` is automatically picked up by the codesign loop with no changes needed. Per-arch thin binaries are signed by the same loop when present in the `.app` payload (they aren't bundled directly today; they're build inputs to `lipo`).

## Bundle wiring

`package.json` `build.mac.extraResources`:

```json
{
  "from": "daemon/dist/ccsm-uninstall-helper-macos-universal",
  "to": "daemon/ccsm-uninstall-helper"
}
```

`scripts/before-pack.cjs` extended with placeholder-safe staging for `darwin` (mirrors the Windows branch) so smoke builds on a non-mac host (which can't run `swiftc`) don't fail electron-builder pack.

## Test plan

- [x] vitest wiring smoke (`installer/uninstall-helper-mac/__tests__/helper.test.ts`) — 13 tests passing locally; verifies source structure, SRP split, lowercase `ccsm` path, `--purge` opt-in default, `--dry-run` flag, build script shape (CAFEBABE assertion, thin arch assertions, Darwin platform gate, strict bash mode).
- [x] `npm run typecheck` — green.
- [x] `bash -n scripts/build-mac-uninstall-helper.sh` — green.
- [ ] release.yml mac job: real `swiftc` compile + `file` verify + `--dry-run` smoke runs on `macos-latest` (gated on this PR's CI).
- [ ] e2e install/uninstall mac flow — out of scope (frag-11 §11.6.2 `[manager r7 lock]` cuts the tray-driven Reset surface for v0.3; this helper exists as a signed packaging artifact for §11.6.4 completeness + future use).

🤖 Generated with [Claude Code](https://claude.com/claude-code)