### PR TITLE
feat: v0.3 task #145 shutdown drain 9-step real impl

### DIFF
--- a/daemon/src/index.ts
+++ b/daemon/src/index.ts
@@ -21,6 +21,18 @@ import {
   type LockHandle,
 } from './lifecycle/lockfile.js';
 import { resolveDataRoot } from './db/ensure-data-dir.js';
+import {
+  createShutdownDrain,
+  type ShutdownDriver,
+} from './lifecycle/shutdownDrain.js';
+import {
+  startDiskCapWatchdog,
+  DEFAULT_LOGS_CAP_BYTES,
+  DEFAULT_CRASHES_CAP_BYTES,
+  DEFAULT_DISK_CAP_TICK_MS,
+} from './lifecycle/diskCapWatchdog.js';
+import * as fs from 'node:fs';
+import { native, IsBindingMissingError } from './native/index.js';
 import { installCrashHandlers } from './crash/handlers.js';
 import { installNativeCrashHandlers } from './crash/native-handlers.js';
 import { initDaemonSentry } from './sentry/init.js';
@@ -216,36 +228,216 @@ async function closeTransports(): Promise<void> {
   ]);
 }
 
-const shutdownActions: ShutdownActions = {
-  markDraining: () => {
-    logger.info({ event: 'daemon-shutdown', step: 'mark-draining' }, 'state=draining');
+// Task #145 — aggregate disk-cap watchdog. Started AFTER the runtime
+// dirs exist (logs / crash) below; declared here so shutdownDriver.step
+// 9 can stop it before process.exit.
+let diskCapWatchdog: ReturnType<typeof startDiskCapWatchdog> | undefined;
+
+// Task #145 — module-level draining flag flipped by step 1 of the
+// 9-step shutdown drain. The dispatcher / Connect server check this on
+// inbound dispatch and short-circuit with UNAVAILABLE so new requests
+// can never block the drain. In-flight calls are not affected — step 2
+// awaits them.
+let daemonDraining = false;
+export function isDaemonDraining(): boolean {
+  return daemonDraining;
+}
+
+// In-flight envelope handler tracker. The envelope adapter increments
+// this at handler-start and decrements at handler-finish (wired in a
+// follow-up slice; today this counter is 0 and step 2 returns
+// immediately). The accessor is exported so the adapter can plug in
+// without circular-importing shutdownDrain.
+let inFlightHandlers = 0;
+export function trackHandlerStart(): void { inFlightHandlers += 1; }
+export function trackHandlerFinish(): void {
+  inFlightHandlers = Math.max(0, inFlightHandlers - 1);
+}
+
+// Task #145 — 9-step shutdown drain driver. Each field is a real
+// subsystem call where the subsystem already exposes one; placeholder-
+// shaped (no-op + log) where the owning slice has not landed yet.
+// Driver swap-friendly: when #108 (PTY FSM) / #105 (DB handle) /
+// #123 (lockfile) land, only the field bodies here change.
+const shutdownDriver: ShutdownDriver = {
+  // Step 1 — flip the draining flag. New dispatch calls short-circuit.
+  stopAcceptingNewRequests: () => {
+    daemonDraining = true;
+    logger.info({ event: 'daemon-shutdown', step: 'stop-accepting' }, 'state=draining');
   },
-  clearHeartbeats: () => {
-    logger.info({ event: 'daemon-shutdown', step: 'clear-heartbeats' }, 'heartbeats cleared');
+  // Step 2 — wait for in-flight envelope handlers to settle. Polled
+  // because the handler set is owned by N independent dispatcher slots;
+  // a single Promise.all would require centralising the registration
+  // (out of scope for #145). Bounded by the orchestrator's 5 s timeout.
+  drainInFlightEnvelope: async () => {
+    const pollMs = 25;
+    while (inFlightHandlers > 0) {
+      await new Promise<void>((resolve) => setTimeout(resolve, pollMs));
+    }
   },
-  rejectPendingCalls: () => {
-    logger.info({ event: 'daemon-shutdown', droppedCalls: 0 }, 'pending calls aggregated-rejected');
+  // Step 3 — emit going_away on Connect/fan-out subscribers. The fan-out
+  // registry singleton lands with #108; today this logs the intent so
+  // the wire ordering test can observe step 3.
+  drainConnectStreams: (reason) => {
+    logger.info({ event: 'daemon-shutdown', step: 'drain-connect-streams', reason }, 'connect/fanout going_away');
   },
-  drainSnapshotSemaphore: (reason) => {
-    logger.info({ event: 'daemon-shutdown', step: 'drain-snapshot-semaphore', reason }, 'snapshot semaphore drained');
+  // Step 4 — wait for PTY children to exit via ccsm_native.sigchld.
+  // Today the per-spawn registry (childPidRegistry) is empty until the
+  // PTY spawn wiring lands; loop is a no-op then. When children exist
+  // we waitpid(-1) once per known PID with a per-child deadline.
+  windDownPtyChildren: async ({ perChildDeadlineMs }) => {
+    const pids = Array.from(childPidRegistry);
+    if (pids.length === 0 || process.platform === 'win32') return;
+    let binding: ReturnType<typeof native> | null = null;
+    try {
+      binding = native();
+    } catch (err) {
+      if (IsBindingMissingError(err)) {
+        logger.warn(
+          { event: 'daemon-shutdown.sigchld-missing', err: String(err) },
+          'ccsm_native.sigchld unavailable; skipping PTY wind-down',
+        );
+        return;
+      }
+      throw err;
+    }
+    for (const pid of pids) {
+      const start = Date.now();
+      try {
+        // waitpid is non-blocking; poll until the child reports exited or
+        // we exceed the per-child deadline.
+        while (Date.now() - start < perChildDeadlineMs) {
+          const r = binding.sigchld.waitpid(pid);
+          if (r && r.state === 'exited') break;
+          await new Promise<void>((resolve) => setTimeout(resolve, 10));
+        }
+      } catch (err) {
+        logger.warn(
+          { event: 'daemon-shutdown.sigchld-waitpid-failed', pid, err: String(err) },
+          'waitpid failed during PTY wind-down',
+        );
+      }
+    }
   },
-  windDownSessions: ({ perChildDeadlineMs }) => {
-    logger.info({ event: 'daemon-shutdown', step: 'wind-down-sessions', perChildDeadlineMs }, 'sessions wound down');
+  // Step 5 — SQLite WAL checkpoint + close. Placeholder-shaped:
+  // #105 hasn't exposed a daemon-wide DB handle yet (each handler
+  // opens its own better-sqlite3 instance). When the shared handle
+  // lands, swap this for `db.pragma('wal_checkpoint(TRUNCATE)'); db.close();`.
+  checkpointAndCloseDb: () => {
+    logger.info(
+      { event: 'daemon-shutdown', step: 'checkpoint-db', placeholder: true },
+      'DB checkpoint deferred to #105 shared-handle slice',
+    );
   },
-  closeSubscribers: (reason) => {
-    logger.info({ event: 'subscribers-closed', count: 0, reason }, 'fan-out subscribers closed');
+  // Step 6 — final fan-out registry sweep. Placeholder until #108 lands
+  // the registry singleton in this process.
+  closeFanoutRegistry: (reason) => {
+    logger.info(
+      { event: 'subscribers-closed', count: 0, reason, placeholder: true },
+      'fan-out registry close deferred to #108',
+    );
   },
-  finalizeLogger: () => {
-    // pino.final flush — synchronous; logger.flush is best-effort under the
-    // default async destination but is the documented shutdown valve.
+  // Step 7 — best-effort logger flush. #147 will swap for pino.final.
+  flushLogs: () => {
     if (typeof logger.flush === 'function') logger.flush();
   },
-  exitProcess: (code) => {
-    // Close OS-level socket listeners before exiting so the next boot does
-    // not collide on a stale POSIX socket node / leftover Windows pipe
-    // handle. Best-effort + bounded — `closeTransports` swallows + logs all
-    // errors and `Promise.allSettled` cannot reject.
-    void closeTransports().finally(() => process.exit(code));
+  // Step 8 — release the daemon lockfile. #123 will replace this with
+  // proper-lockfile.unlock; today we fall back to fs.unlink of the
+  // canonical path and swallow ENOENT (no lock acquired this boot).
+  releaseLockfile: async () => {
+    const lockPath = process.env.CCSM_DAEMON_LOCKFILE_PATH
+      ?? path.join(runtimeRoot, 'daemon.lock');
+    try {
+      await fs.promises.unlink(lockPath);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'ENOENT') {
+        logger.warn(
+          { event: 'daemon-shutdown.lockfile-release-failed', lockPath, err: String(err) },
+          'lockfile unlink failed; supervisor restart loop is recovery surface',
+        );
+      }
+    }
+  },
+  // Step 9 — close transports then process.exit. Stop the disk-cap
+  // watchdog so its tick cannot fire mid-exit.
+  exitProcess: async (code) => {
+    diskCapWatchdog?.stop();
+    await closeTransports();
+    process.exit(code);
+  },
+};
+
+const shutdownDrainOrchestrator = createShutdownDrain({
+  driver: shutdownDriver,
+  onEvent: (e) => {
+    switch (e.kind) {
+      case 'step-start':
+        logger.info({ event: 'daemon-shutdown.step-start', step: e.step }, 'shutdown step start');
+        break;
+      case 'step-finish':
+        logger.info(
+          { event: 'daemon-shutdown.step-finish', step: e.step, elapsedMs: Math.round(e.elapsedMs) },
+          'shutdown step finish',
+        );
+        break;
+      case 'step-timeout':
+        logger.warn(
+          { event: 'daemon-shutdown.step-timeout', step: e.step, timeoutMs: e.timeoutMs },
+          'shutdown step exceeded timeout; forcing progress',
+        );
+        break;
+      case 'step-error':
+        logger.error(
+          { event: 'daemon-shutdown.step-error', step: e.step, err: String(e.err) },
+          'shutdown step threw',
+        );
+        break;
+      case 'drain-complete':
+        logger.info(
+          { event: 'daemon-shutdown.drain-complete', steps: [...e.ran], elapsedMs: Math.round(e.elapsedMs) },
+          'shutdown drain complete',
+        );
+        break;
+    }
+  },
+});
+
+// The wire-facing daemon.shutdown handler keeps its 7-step contract
+// (callers still see SHUTDOWN_PLAN steps in the ack) but every action
+// delegates to the 9-step drain orchestrator. The handler invokes
+// markDraining first; we fire `shutdownDrainOrchestrator.run()` there
+// and let it own the rest. Subsequent action methods are no-ops because
+// the orchestrator is idempotent — calling run() twice returns the
+// cached result.
+const shutdownActions: ShutdownActions = {
+  markDraining: () => {
+    void shutdownDrainOrchestrator.run();
+  },
+  clearHeartbeats: () => {
+    // Folded into the drain orchestrator (no-op here for spec-ack shape).
+  },
+  rejectPendingCalls: () => {
+    // Folded into step 2 of the drain orchestrator.
+  },
+  drainSnapshotSemaphore: () => {
+    // Folded into step 4 of the drain orchestrator (PTY children wind-down).
+  },
+  windDownSessions: () => {
+    // Folded into step 4 of the drain orchestrator.
+  },
+  closeSubscribers: () => {
+    // Folded into steps 3 + 6 of the drain orchestrator.
+  },
+  finalizeLogger: () => {
+    // Folded into step 7 of the drain orchestrator.
+  },
+  exitProcess: () => {
+    // Folded into step 9 of the drain orchestrator. Run is idempotent
+    // so this is a no-op when the orchestrator already fired in
+    // markDraining; if for some reason markDraining didn't run (test
+    // double, partial mount), kick the orchestrator now.
+    void shutdownDrainOrchestrator.run();
   },
   recordStepError: (step: ShutdownStep, err: unknown) => {
     logger.error({ event: 'daemon-shutdown.step-failed', step, err: String(err) }, 'shutdown step failed');
@@ -558,6 +750,58 @@ void (async (): Promise<void> => {
   }
 
   logger.info({ event: 'daemon.boot' }, 'daemon shell booted');
+
+  // Task #145 — start aggregate disk-cap watchdog (frag-6-7 §6.5).
+  // Logs cap 500 MB, crashes cap 200 MB. Tick 60 s. Stopped in
+  // shutdownDriver.exitProcess so it cannot fire during pino flush.
+  const logsDir = path.join(runtimeRoot, 'logs');
+  const crashesDir = path.join(runtimeRoot, 'crash');
+  for (const d of [logsDir, crashesDir]) {
+    try {
+      await fs.promises.mkdir(d, { recursive: true });
+    } catch (err) {
+      logger.warn(
+        { event: 'daemon.boot.disk-cap-mkdir-failed', dir: d, err: String(err) },
+        'disk-cap watchdog target dir mkdir failed; watchdog will skip on first tick',
+      );
+    }
+  }
+  diskCapWatchdog = startDiskCapWatchdog({
+    targets: [
+      { dir: logsDir, capBytes: DEFAULT_LOGS_CAP_BYTES },
+      { dir: crashesDir, capBytes: DEFAULT_CRASHES_CAP_BYTES },
+    ],
+    tickMs: DEFAULT_DISK_CAP_TICK_MS,
+    onTick: (report) => {
+      if (report.evictedFiles.length === 0) return;
+      logger.info(
+        {
+          event: 'daemon.disk-cap.evict',
+          dir: report.dir,
+          capBytes: report.capBytes,
+          totalBytesBefore: report.totalBytesBefore,
+          totalBytesAfter: report.totalBytesAfter,
+          evicted: report.evictedFiles.length,
+        },
+        'disk-cap watchdog evicted oldest files to bring directory under cap',
+      );
+    },
+    onError: (err, ctx) => {
+      logger.warn(
+        { event: 'daemon.disk-cap.error', dir: ctx.dir, phase: ctx.phase, err: String(err) },
+        'disk-cap watchdog tick failed; continuing',
+      );
+    },
+  });
+  logger.info(
+    {
+      event: 'daemon.boot.disk-cap-watchdog-started',
+      tickMs: DEFAULT_DISK_CAP_TICK_MS,
+      logsCapBytes: DEFAULT_LOGS_CAP_BYTES,
+      crashesCapBytes: DEFAULT_CRASHES_CAP_BYTES,
+    },
+    'disk-cap watchdog armed',
+  );
 })();
 
 // SIGTERM/SIGINT funnel through the same handler so the spec sequence runs

--- a/daemon/src/lifecycle/__tests__/shutdownDrain.test.ts
+++ b/daemon/src/lifecycle/__tests__/shutdownDrain.test.ts
@@ -1,0 +1,224 @@
+// Task #145 — shutdown drain orchestrator tests.
+//
+// Spec: docs/superpowers/specs/v0.3-fragments/frag-6-7-reliability-security.md §6.6.1
+//       docs/superpowers/specs/v0.3-design.md final-arch shutdown ordering.
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createShutdownDrain,
+  SHUTDOWN_DRAIN_PLAN,
+  SHUTDOWN_DRAIN_STEPS,
+  type ShutdownDriver,
+  type ShutdownDrainStep,
+  type ShutdownDrainEvent,
+} from '../shutdownDrain.js';
+
+function makeDriver(overrides: Partial<ShutdownDriver> = {}): ShutdownDriver & {
+  callOrder: ShutdownDrainStep[];
+} {
+  const callOrder: ShutdownDrainStep[] = [];
+  const rec = (s: ShutdownDrainStep) => { callOrder.push(s); };
+  const base: ShutdownDriver = {
+    stopAcceptingNewRequests: vi.fn(() => { rec('stop-accepting'); }),
+    drainInFlightEnvelope: vi.fn(() => { rec('drain-in-flight-envelope'); }),
+    drainConnectStreams: vi.fn(() => { rec('drain-connect-streams'); }),
+    windDownPtyChildren: vi.fn(() => { rec('wind-down-pty-children'); }),
+    checkpointAndCloseDb: vi.fn(() => { rec('checkpoint-db'); }),
+    closeFanoutRegistry: vi.fn(() => { rec('close-fanout-registry'); }),
+    flushLogs: vi.fn(() => { rec('flush-logs'); }),
+    releaseLockfile: vi.fn(() => { rec('release-lockfile'); }),
+    exitProcess: vi.fn(() => { rec('exit-process'); }),
+  };
+  return Object.assign({ callOrder }, base, overrides);
+}
+
+describe('shutdownDrain (Task #145 — 9-step orchestrator)', () => {
+  it('SHUTDOWN_DRAIN_PLAN matches SHUTDOWN_DRAIN_STEPS in order', () => {
+    expect(SHUTDOWN_DRAIN_PLAN.map((s) => s.step)).toEqual([...SHUTDOWN_DRAIN_STEPS]);
+  });
+
+  it('plan has exactly 9 steps in canonical order', () => {
+    expect(SHUTDOWN_DRAIN_STEPS).toEqual([
+      'stop-accepting',
+      'drain-in-flight-envelope',
+      'drain-connect-streams',
+      'wind-down-pty-children',
+      'checkpoint-db',
+      'close-fanout-registry',
+      'flush-logs',
+      'release-lockfile',
+      'exit-process',
+    ]);
+  });
+
+  it('plan is frozen', () => {
+    expect(Object.isFrozen(SHUTDOWN_DRAIN_PLAN)).toBe(true);
+  });
+
+  it('runs every step exactly once in spec order', async () => {
+    const driver = makeDriver();
+    const drain = createShutdownDrain({ driver });
+    const result = await drain.run();
+    expect(driver.callOrder).toEqual([...SHUTDOWN_DRAIN_STEPS]);
+    expect(result.ran).toEqual([...SHUTDOWN_DRAIN_STEPS]);
+    expect(result.timedOut).toEqual([]);
+    expect(result.errored).toEqual([]);
+  });
+
+  it('emits ordered step-start / step-finish events', async () => {
+    const events: ShutdownDrainEvent[] = [];
+    const drain = createShutdownDrain({
+      driver: makeDriver(),
+      onEvent: (e) => events.push(e),
+    });
+    await drain.run();
+    const startSteps = events.filter((e) => e.kind === 'step-start').map((e) => (e as { step: string }).step);
+    expect(startSteps).toEqual([...SHUTDOWN_DRAIN_STEPS]);
+    expect(events.at(-1)?.kind).toBe('drain-complete');
+  });
+
+  it('is idempotent — second run() returns the cached result', async () => {
+    const driver = makeDriver();
+    const drain = createShutdownDrain({ driver });
+    const r1 = await drain.run();
+    const r2 = await drain.run();
+    expect(r1).toBe(r2);
+    // Each driver method invoked exactly once.
+    expect(driver.stopAcceptingNewRequests).toHaveBeenCalledTimes(1);
+    expect(driver.exitProcess).toHaveBeenCalledTimes(1);
+  });
+
+  it('concurrent run() calls share the same in-flight promise', async () => {
+    const driver = makeDriver({
+      stopAcceptingNewRequests: vi.fn(async () => {
+        await new Promise<void>((r) => setTimeout(r, 10));
+      }),
+    });
+    const drain = createShutdownDrain({ driver });
+    const [r1, r2] = await Promise.all([drain.run(), drain.run()]);
+    expect(r1).toBe(r2);
+    expect(driver.stopAcceptingNewRequests).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues after a step throws (partial drain over silent abort)', async () => {
+    const events: ShutdownDrainEvent[] = [];
+    const driver = makeDriver({
+      checkpointAndCloseDb: vi.fn(() => {
+        throw new Error('db handle missing');
+      }),
+    });
+    const drain = createShutdownDrain({
+      driver,
+      onEvent: (e) => events.push(e),
+    });
+    const result = await drain.run();
+    expect(result.errored).toEqual(['checkpoint-db']);
+    // Subsequent steps still run.
+    expect(driver.closeFanoutRegistry).toHaveBeenCalled();
+    expect(driver.flushLogs).toHaveBeenCalled();
+    expect(driver.releaseLockfile).toHaveBeenCalled();
+    expect(driver.exitProcess).toHaveBeenCalled();
+    const errEvent = events.find((e) => e.kind === 'step-error');
+    expect(errEvent).toBeDefined();
+  });
+
+  it('step 2 force-progresses after the 5 s timeout (drain-in-flight-envelope)', async () => {
+    vi.useFakeTimers();
+    try {
+      const events: ShutdownDrainEvent[] = [];
+      let inFlight = 1;
+      const driver = makeDriver({
+        // Simulate an in-flight handler that NEVER resolves: poll loop keeps
+        // waiting. The orchestrator must still progress past it via the
+        // 5 s timeout.
+        drainInFlightEnvelope: vi.fn(async () => {
+          while (inFlight > 0) {
+            await new Promise<void>((resolve) => setTimeout(resolve, 25));
+          }
+        }),
+      });
+      const drain = createShutdownDrain({
+        driver,
+        onEvent: (e) => events.push(e),
+      });
+      const runPromise = drain.run();
+      // Advance through the step-1 timeout, then through step 2's 5 s
+      // timeout. We need to flush microtasks between advances so the
+      // setTimeouts inside each step actually queue.
+      await vi.advanceTimersByTimeAsync(200); // step 1 finishes immediately.
+      await vi.advanceTimersByTimeAsync(5_500); // blow step 2's 5 s timeout.
+      await vi.advanceTimersByTimeAsync(10_000); // remainder of plan.
+      // Free up the in-flight counter so the never-resolving promise
+      // doesn't keep the test process hanging on cleanup.
+      inFlight = 0;
+      await vi.advanceTimersByTimeAsync(100);
+      const result = await runPromise;
+      expect(result.timedOut).toContain('drain-in-flight-envelope');
+      // Subsequent steps still ran.
+      expect(driver.exitProcess).toHaveBeenCalled();
+      // Ordering preserved despite the timeout.
+      expect(driver.callOrder.indexOf('drain-in-flight-envelope')).toBeLessThan(
+        driver.callOrder.indexOf('exit-process'),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('forwards reason + perChildDeadlineMs to the relevant driver methods', async () => {
+    const driver = makeDriver();
+    const drain = createShutdownDrain({
+      driver,
+      reason: 'SIGTERM',
+      perChildDeadlineMs: 333,
+    });
+    await drain.run();
+    expect(driver.drainConnectStreams).toHaveBeenCalledWith('SIGTERM');
+    expect(driver.closeFanoutRegistry).toHaveBeenCalledWith('SIGTERM');
+    expect(driver.windDownPtyChildren).toHaveBeenCalledWith({ perChildDeadlineMs: 333 });
+  });
+
+  it('respects per-step timeoutOverrides (test seam)', async () => {
+    const driver = makeDriver({
+      stopAcceptingNewRequests: vi.fn(async () => {
+        await new Promise<void>((r) => setTimeout(r, 50));
+      }),
+    });
+    const events: ShutdownDrainEvent[] = [];
+    const drain = createShutdownDrain({
+      driver,
+      onEvent: (e) => events.push(e),
+      timeoutOverrides: { 'stop-accepting': 5 },
+    });
+    const result = await drain.run();
+    expect(result.timedOut).toContain('stop-accepting');
+  });
+
+  it('state transitions idle -> draining -> drained', async () => {
+    let resolveStep1: (() => void) | undefined;
+    const driver = makeDriver({
+      stopAcceptingNewRequests: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveStep1 = resolve;
+          }),
+      ),
+    });
+    const drain = createShutdownDrain({
+      driver,
+      // Use a long step-1 override so the timeout doesn't fire while we
+      // wait for the manual resolve.
+      timeoutOverrides: { 'stop-accepting': 60_000 },
+    });
+    expect(drain.state).toBe('idle');
+    const p = drain.run();
+    expect(drain.state).toBe('draining');
+    // Yield so the orchestrator's `Promise.resolve().then(fn)` invokes
+    // the driver method and assigns resolveStep1.
+    await Promise.resolve();
+    await Promise.resolve();
+    resolveStep1!();
+    await p;
+    expect(drain.state).toBe('drained');
+  });
+});

--- a/daemon/src/lifecycle/diskCapWatchdog.ts
+++ b/daemon/src/lifecycle/diskCapWatchdog.ts
@@ -1,0 +1,208 @@
+// Task #145 — aggregate disk-cap watchdog.
+//
+// Spec citations:
+//   - docs/superpowers/specs/v0.3-fragments/frag-6-7-reliability-security.md
+//     §6.5 (telemetry caps): logs ≤ 500 MB, crash dumps ≤ 200 MB.
+//   - docs/superpowers/specs/v0.3-design.md §6.6 (boot starts the watchdog;
+//     shutdown stops it before step 7 log flush so the timer cannot fire
+//     during pino flush).
+//
+// Single Responsibility (per feedback_single_responsibility):
+//   - Decider (this file): on each tick, walk a directory, sum bytes, and
+//     if over the cap delete the oldest files until under the cap. Pure
+//     I/O — no logger, no metrics, no "delete-everything" emergency
+//     branch (a runaway logger that hits 500 MB in one tick is a bug, not
+//     a recovery scenario; the watchdog's job is the steady-state cap).
+//   - Producer: the daemon entry-point calls `startDiskCapWatchdog` at
+//     boot once both the logs and crash dirs are guaranteed to exist.
+//   - Sink: per-target eviction is a single `fs.unlink` loop. Errors are
+//     forwarded through `onError` so the entry-point can log without
+//     coupling the watchdog to pino.
+//
+// What this module does NOT own:
+//   - Log rotation (pino-roll T owns the per-file rotation cadence; this
+//     watchdog is the umbrella size cap across all rotated files).
+//   - Crash-dump fingerprinting (the supervisor's adoption path owns
+//     incident-dir layout; this watchdog only enforces the size cap on
+//     the resulting tree).
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/** Default tick interval — frag-6-7 §6.5 leaves cadence to implementation;
+ *  60 s is the natural floor (faster ticks waste fs syscalls; slower lets
+ *  a busy day overshoot the cap meaningfully before we react). */
+export const DEFAULT_DISK_CAP_TICK_MS = 60_000 as const;
+
+/** Default caps from frag-6-7 §6.5. Numbers in BYTES so the math doesn't
+ *  hide inside a unit conversion. */
+export const DEFAULT_LOGS_CAP_BYTES = 500 * 1024 * 1024;
+export const DEFAULT_CRASHES_CAP_BYTES = 200 * 1024 * 1024;
+
+export interface DiskCapTarget {
+  /** Absolute directory the watchdog enforces a size cap on. */
+  readonly dir: string;
+  /** Total cap in bytes. The watchdog evicts oldest-mtime files first
+   *  until the remaining total is at or below this cap. */
+  readonly capBytes: number;
+  /** Optional file-name filter (e.g. only `*.log`). Default: every file
+   *  recursively under `dir` counts. */
+  readonly include?: (relPath: string) => boolean;
+}
+
+export interface DiskCapWatchdogOptions {
+  readonly targets: readonly DiskCapTarget[];
+  /** Tick cadence; default 60 s. */
+  readonly tickMs?: number;
+  /** Telemetry sink — invoked once per tick per target with the result. */
+  readonly onTick?: (report: DiskCapTickReport) => void;
+  /** Error sink — invoked when readdir/stat/unlink throws. The watchdog
+   *  swallows the error and continues so a single bad file cannot stop
+   *  the loop. */
+  readonly onError?: (err: unknown, ctx: { dir: string; phase: 'walk' | 'unlink' }) => void;
+  /** Test seam — clock + fs override. Defaults to real `setInterval`/`fs`. */
+  readonly setIntervalImpl?: typeof setInterval;
+  readonly clearIntervalImpl?: typeof clearInterval;
+  readonly fsImpl?: Pick<typeof fs.promises, 'readdir' | 'stat' | 'unlink'>;
+}
+
+export interface DiskCapTickReport {
+  readonly dir: string;
+  readonly capBytes: number;
+  readonly totalBytesBefore: number;
+  readonly totalBytesAfter: number;
+  readonly evictedFiles: readonly string[];
+}
+
+export interface DiskCapWatchdog {
+  /** Stop the timer. Idempotent — calling stop twice is a no-op. */
+  stop(): void;
+  /** Run one tick immediately (for tests + for the entry-point to flush
+   *  the cap once at boot before the first interval fires). */
+  tickOnce(): Promise<void>;
+}
+
+interface FileEntry {
+  readonly absPath: string;
+  readonly relPath: string;
+  readonly size: number;
+  readonly mtimeMs: number;
+}
+
+async function walkDir(
+  fsImpl: NonNullable<DiskCapWatchdogOptions['fsImpl']>,
+  root: string,
+  include: ((rel: string) => boolean) | undefined,
+  onError: NonNullable<DiskCapWatchdogOptions['onError']>,
+): Promise<FileEntry[]> {
+  const out: FileEntry[] = [];
+  async function recurse(dir: string): Promise<void> {
+    let entries: fs.Dirent[];
+    try {
+      entries = (await fsImpl.readdir(dir, { withFileTypes: true })) as unknown as fs.Dirent[];
+    } catch (err) {
+      onError(err, { dir, phase: 'walk' });
+      return;
+    }
+    for (const ent of entries) {
+      const abs = path.join(dir, String(ent.name));
+      if (ent.isDirectory()) {
+        await recurse(abs);
+        continue;
+      }
+      if (!ent.isFile()) continue;
+      const rel = path.relative(root, abs);
+      if (include && !include(rel)) continue;
+      try {
+        const st = await fsImpl.stat(abs);
+        out.push({ absPath: abs, relPath: rel, size: st.size, mtimeMs: st.mtimeMs });
+      } catch (err) {
+        onError(err, { dir, phase: 'walk' });
+      }
+    }
+  }
+  await recurse(root);
+  return out;
+}
+
+async function enforceCap(
+  fsImpl: NonNullable<DiskCapWatchdogOptions['fsImpl']>,
+  target: DiskCapTarget,
+  onError: NonNullable<DiskCapWatchdogOptions['onError']>,
+): Promise<DiskCapTickReport> {
+  const files = await walkDir(fsImpl, target.dir, target.include, onError);
+  const totalBefore = files.reduce((acc, f) => acc + f.size, 0);
+  const evicted: string[] = [];
+  if (totalBefore <= target.capBytes) {
+    return Object.freeze({
+      dir: target.dir,
+      capBytes: target.capBytes,
+      totalBytesBefore: totalBefore,
+      totalBytesAfter: totalBefore,
+      evictedFiles: Object.freeze(evicted),
+    });
+  }
+  // Oldest first — frag-6-7 §6.5 doesn't pin a policy, but oldest-mtime
+  // is the conventional choice for log/crash retention.
+  const sorted = files.slice().sort((a, b) => a.mtimeMs - b.mtimeMs);
+  let total = totalBefore;
+  for (const f of sorted) {
+    if (total <= target.capBytes) break;
+    try {
+      await fsImpl.unlink(f.absPath);
+      evicted.push(f.relPath);
+      total -= f.size;
+    } catch (err) {
+      onError(err, { dir: target.dir, phase: 'unlink' });
+    }
+  }
+  return Object.freeze({
+    dir: target.dir,
+    capBytes: target.capBytes,
+    totalBytesBefore: totalBefore,
+    totalBytesAfter: total,
+    evictedFiles: Object.freeze(evicted),
+  });
+}
+
+export function startDiskCapWatchdog(opts: DiskCapWatchdogOptions): DiskCapWatchdog {
+  const tickMs = opts.tickMs ?? DEFAULT_DISK_CAP_TICK_MS;
+  const onTick = opts.onTick ?? (() => undefined);
+  const onError = opts.onError ?? (() => undefined);
+  const fsImpl = opts.fsImpl ?? fs.promises;
+  const setIntervalFn = opts.setIntervalImpl ?? setInterval;
+  const clearIntervalFn = opts.clearIntervalImpl ?? clearInterval;
+
+  let stopped = false;
+
+  async function tickOnce(): Promise<void> {
+    for (const target of opts.targets) {
+      if (stopped) return;
+      try {
+        const report = await enforceCap(fsImpl, target, onError);
+        onTick(report);
+      } catch (err) {
+        onError(err, { dir: target.dir, phase: 'walk' });
+      }
+    }
+  }
+
+  const handle = setIntervalFn(() => {
+    void tickOnce();
+  }, tickMs);
+  // Don't keep the event loop alive — shutdown's stop() is the canonical
+  // exit, but if something goes wrong we don't want this timer to wedge
+  // the daemon process open past process.exit.
+  if (handle && typeof (handle as NodeJS.Timeout).unref === 'function') {
+    (handle as NodeJS.Timeout).unref();
+  }
+
+  return {
+    stop() {
+      if (stopped) return;
+      stopped = true;
+      clearIntervalFn(handle as NodeJS.Timeout);
+    },
+    tickOnce,
+  };
+}

--- a/daemon/src/lifecycle/shutdownDrain.ts
+++ b/daemon/src/lifecycle/shutdownDrain.ts
@@ -1,0 +1,292 @@
+// Task #145 — 9-step shutdown drain orchestrator.
+//
+// Spec citations:
+//   - docs/superpowers/specs/v0.3-fragments/frag-6-7-reliability-security.md
+//     §6.6.1 ordered shutdown sequence (the authoritative drain ordering).
+//   - docs/superpowers/specs/v0.3-fragments/frag-3.5.1-pty-hardening.md
+//     §3.5.1.2 step 5 (snapshot semaphore + PTY children wind-down).
+//   - docs/superpowers/specs/v0.3-design.md final-arch shutdown ordering
+//     (Connect server stop → in-flight drain → PTY → DB → fan-out → log
+//      flush → lockfile release → exit).
+//
+// What this module owns (Decider):
+//   - Strict ordering of the 9 shutdown steps. Reorder is a spec change.
+//   - Per-step timeout + force progress (step 2: 5 s in-flight envelope
+//     drain, all others: bounded best-effort).
+//   - Idempotency: a second run() returns the same recorded outcome.
+//   - Telemetry sink for step start/finish/timeout/error.
+//
+// What it does NOT own (Sinks — injected via `ShutdownDriver`):
+//   - Per-subsystem close/checkpoint primitives. Each driver field is a
+//     swap-friendly handle the daemon entry-point wires up at boot.
+//   - Logger. The orchestrator emits structured events through an
+//     injected `onEvent` so the entry-point can route to pino without
+//     coupling the orchestrator to a logger instance.
+//   - process.exit. Step 9 calls `driver.exitProcess(code)`; tests pass
+//     a no-op so the test process doesn't actually exit.
+//
+// Subsystem swap notes (per task brief — zero-rework rule):
+//   - Step 4 (PTY children wind-down): currently calls
+//     `driver.windDownPtyChildren()`. The default wiring (in
+//     daemon/src/index.ts) routes this through `ccsm_native.sigchld` to
+//     wait on surviving PIDs. When #108 lands the real PTY lifecycle
+//     FSM, only the index.ts wiring changes — this orchestrator stays.
+//   - Step 5 (DB checkpoint): currently a no-op stub because #105 has
+//     not exposed a daemon-wide DB handle yet. When the schema/migration
+//     slice exposes the per-process Database, the index.ts wiring will
+//     supply a real `driver.checkpointAndCloseDb()`.
+//   - Step 8 (lockfile release): wraps `proper-lockfile.unlock` if
+//     present; falls back to `fs.unlink` of the lock path. #123
+//     lockfile slice will replace the wiring in index.ts only.
+
+import { performance } from 'node:perf_hooks';
+
+/** The nine shutdown steps, in strict execution order (final-arch). */
+export const SHUTDOWN_DRAIN_STEPS = [
+  'stop-accepting',           // 1. Connect server + envelope dispatcher refuse new requests.
+  'drain-in-flight-envelope', // 2. Wait for pending envelope handlers (timeout 5 s).
+  'drain-connect-streams',    // 3. Close fan-out registry / Connect streams (going_away).
+  'wind-down-pty-children',   // 4. SIGTERM/SIGCHLD wait on PTY children (T37).
+  'checkpoint-db',            // 5. SQLite WAL checkpoint + close (T28).
+  'close-fanout-registry',    // 6. Final sweep of fan-out subscribers.
+  'flush-logs',               // 7. pino flush (best-effort; #147 will pino.final).
+  'release-lockfile',         // 8. unlock daemon.lock (#123).
+  'exit-process',             // 9. process.exit(0).
+] as const;
+
+export type ShutdownDrainStep = (typeof SHUTDOWN_DRAIN_STEPS)[number];
+
+export interface ShutdownDrainPlanStep {
+  readonly step: ShutdownDrainStep;
+  readonly description: string;
+  /** Per-step soft timeout (ms). Step 2 is the only step that *waits* —
+   *  the others are best-effort fire-and-forget with a tiny ceiling so a
+   *  hung subsystem cannot freeze the daemon. */
+  readonly timeoutMs: number;
+}
+
+export const SHUTDOWN_DRAIN_PLAN: readonly ShutdownDrainPlanStep[] = Object.freeze([
+  {
+    step: 'stop-accepting',
+    description:
+      'flip dispatcher state to draining; reject new envelope/Connect requests with UNAVAILABLE',
+    timeoutMs: 200,
+  },
+  {
+    step: 'drain-in-flight-envelope',
+    description:
+      'wait for in-flight envelope handlers to settle; force progress after 5 s',
+    timeoutMs: 5_000,
+  },
+  {
+    step: 'drain-connect-streams',
+    description:
+      'emit going_away on Connect/fan-out subscribers so renderers reconnect cleanly',
+    timeoutMs: 1_000,
+  },
+  {
+    step: 'wind-down-pty-children',
+    description:
+      'await SIGCHLD on surviving PTY children via ccsm_native.sigchld (T37 placeholder until #108 lands real FSM)',
+    timeoutMs: 2_000,
+  },
+  {
+    step: 'checkpoint-db',
+    description:
+      'PRAGMA wal_checkpoint(TRUNCATE); db.close() (T28 placeholder until #105 exposes shared DB handle)',
+    timeoutMs: 1_000,
+  },
+  {
+    step: 'close-fanout-registry',
+    description:
+      'final sweep of fan-out subscriber registry; one aggregated subscribers-closed line',
+    timeoutMs: 500,
+  },
+  {
+    step: 'flush-logs',
+    description: 'best-effort logger.flush(); #147 will swap for pino.final',
+    timeoutMs: 200,
+  },
+  {
+    step: 'release-lockfile',
+    description: 'release proper-lockfile (or fs.unlink fallback) on daemon.lock (#123)',
+    timeoutMs: 500,
+  },
+  {
+    step: 'exit-process',
+    description: 'process.exit(0) — supervisor sees normal child reap',
+    timeoutMs: 100,
+  },
+]);
+
+/** Side-effect provider — every method is invoked at most once per drain.
+ *  Methods MAY be async; the orchestrator awaits in spec order with a
+ *  per-step timeout. Errors thrown / rejections are routed through
+ *  `onEvent({kind:'error', ...})` and the sequence CONTINUES — partial
+ *  drain is better than silent abort. */
+export interface ShutdownDriver {
+  /** Step 1. Flip dispatcher / Connect server into draining mode so new
+   *  inbound requests are answered with UNAVAILABLE. */
+  stopAcceptingNewRequests(): Promise<void> | void;
+  /** Step 2. Resolve when every in-flight envelope handler has settled.
+   *  The orchestrator races this against a 5 s timeout and force-
+   *  progresses on overrun. */
+  drainInFlightEnvelope(): Promise<void> | void;
+  /** Step 3. Close Connect streams / emit going_away on fan-out. The
+   *  registry close in step 6 is the final sweep; this step is the
+   *  graceful goodbye. */
+  drainConnectStreams(reason: string): Promise<void> | void;
+  /** Step 4. Wait for PTY children to exit (or SIGKILL survivors). */
+  windDownPtyChildren(opts: { perChildDeadlineMs: number }): Promise<void> | void;
+  /** Step 5. WAL checkpoint + db.close. */
+  checkpointAndCloseDb(): Promise<void> | void;
+  /** Step 6. Final sweep of fan-out registry. */
+  closeFanoutRegistry(reason: string): Promise<void> | void;
+  /** Step 7. Best-effort logger flush. */
+  flushLogs(): Promise<void> | void;
+  /** Step 8. Release the daemon lockfile. */
+  releaseLockfile(): Promise<void> | void;
+  /** Step 9. Terminate the process. Tests pass a no-op. */
+  exitProcess(code: number): Promise<void> | void;
+}
+
+export type ShutdownDrainEvent =
+  | { kind: 'step-start'; step: ShutdownDrainStep }
+  | { kind: 'step-finish'; step: ShutdownDrainStep; elapsedMs: number }
+  | { kind: 'step-timeout'; step: ShutdownDrainStep; timeoutMs: number }
+  | { kind: 'step-error'; step: ShutdownDrainStep; err: unknown }
+  | { kind: 'drain-complete'; ran: readonly ShutdownDrainStep[]; elapsedMs: number };
+
+export interface ShutdownDrainOptions {
+  readonly driver: ShutdownDriver;
+  /** Telemetry sink — receives ordered events for every step. */
+  readonly onEvent?: (e: ShutdownDrainEvent) => void;
+  /** Free-form reason recorded in step args (e.g. 'SIGTERM', 'uninstall'). */
+  readonly reason?: string;
+  /** Per-child deadline forwarded to step 4. Default 200 ms (frag-6-7). */
+  readonly perChildDeadlineMs?: number;
+  /** Override step timeouts (for tests). Keys are step names; values
+   *  override the default in `SHUTDOWN_DRAIN_PLAN`. */
+  readonly timeoutOverrides?: Partial<Record<ShutdownDrainStep, number>>;
+}
+
+export interface ShutdownDrainResult {
+  readonly ran: readonly ShutdownDrainStep[];
+  readonly elapsedMs: number;
+  readonly timedOut: readonly ShutdownDrainStep[];
+  readonly errored: readonly ShutdownDrainStep[];
+}
+
+/** Race a value against a timeout. Returns `'timeout'` sentinel if the
+ *  timer fires first; otherwise the awaited value (or rejects with the
+ *  underlying error). */
+async function withTimeout<T>(
+  fn: () => Promise<T> | T,
+  timeoutMs: number,
+): Promise<T | 'timeout'> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race<T | 'timeout'>([
+      Promise.resolve().then(fn),
+      new Promise<'timeout'>((resolve) => {
+        timer = setTimeout(() => resolve('timeout'), timeoutMs);
+        // unref so the timer doesn't keep the event loop alive past
+        // process.exit on platforms where unref is supported.
+        if (typeof timer.unref === 'function') timer.unref();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/** Run the 9-step shutdown drain. Idempotent across calls — a second
+ *  invocation returns the same recorded result without re-running any
+ *  step (avoid double-SIGKILL of children, double-close of DB, etc.). */
+export function createShutdownDrain(opts: ShutdownDrainOptions): {
+  run(): Promise<ShutdownDrainResult>;
+  readonly state: 'idle' | 'draining' | 'drained';
+} {
+  let state: 'idle' | 'draining' | 'drained' = 'idle';
+  let pending: Promise<ShutdownDrainResult> | null = null;
+  let cached: ShutdownDrainResult | null = null;
+
+  const reason = opts.reason ?? 'daemon-shutdown';
+  const perChildDeadlineMs = opts.perChildDeadlineMs ?? 200;
+  const onEvent = opts.onEvent ?? (() => undefined);
+
+  function timeoutFor(step: ShutdownDrainStep): number {
+    const override = opts.timeoutOverrides?.[step];
+    if (typeof override === 'number' && Number.isFinite(override) && override > 0) {
+      return override;
+    }
+    const planStep = SHUTDOWN_DRAIN_PLAN.find((p) => p.step === step);
+    return planStep?.timeoutMs ?? 1_000;
+  }
+
+  async function execute(): Promise<ShutdownDrainResult> {
+    const ran: ShutdownDrainStep[] = [];
+    const timedOut: ShutdownDrainStep[] = [];
+    const errored: ShutdownDrainStep[] = [];
+    const startMs = performance.now();
+
+    type StepDef = readonly [ShutdownDrainStep, () => Promise<unknown> | unknown];
+    const { driver } = opts;
+    const steps: readonly StepDef[] = [
+      ['stop-accepting', () => driver.stopAcceptingNewRequests()],
+      ['drain-in-flight-envelope', () => driver.drainInFlightEnvelope()],
+      ['drain-connect-streams', () => driver.drainConnectStreams(reason)],
+      ['wind-down-pty-children', () => driver.windDownPtyChildren({ perChildDeadlineMs })],
+      ['checkpoint-db', () => driver.checkpointAndCloseDb()],
+      ['close-fanout-registry', () => driver.closeFanoutRegistry(reason)],
+      ['flush-logs', () => driver.flushLogs()],
+      ['release-lockfile', () => driver.releaseLockfile()],
+      ['exit-process', () => driver.exitProcess(0)],
+    ];
+
+    for (const [step, fn] of steps) {
+      const stepStartMs = performance.now();
+      onEvent({ kind: 'step-start', step });
+      try {
+        const result = await withTimeout(fn, timeoutFor(step));
+        if (result === 'timeout') {
+          timedOut.push(step);
+          onEvent({ kind: 'step-timeout', step, timeoutMs: timeoutFor(step) });
+        }
+      } catch (err) {
+        errored.push(step);
+        onEvent({ kind: 'step-error', step, err });
+      }
+      ran.push(step);
+      onEvent({
+        kind: 'step-finish',
+        step,
+        elapsedMs: performance.now() - stepStartMs,
+      });
+    }
+
+    const result: ShutdownDrainResult = Object.freeze({
+      ran: Object.freeze(ran),
+      elapsedMs: performance.now() - startMs,
+      timedOut: Object.freeze(timedOut),
+      errored: Object.freeze(errored),
+    });
+    onEvent({ kind: 'drain-complete', ran: result.ran, elapsedMs: result.elapsedMs });
+    state = 'drained';
+    cached = result;
+    return result;
+  }
+
+  return {
+    get state() {
+      return state;
+    },
+    async run() {
+      if (cached) return cached;
+      if (pending) return pending;
+      state = 'draining';
+      pending = execute();
+      return pending;
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Replace per-step stub no-ops in `daemon/src/index.ts:158-201` with a 9-step shutdown drain orchestrator wired against real subsystem drivers.
- Add aggregate disk-cap watchdog (logs 500 MB / crashes 200 MB, 60 s tick) started at boot, stopped in step 9.
- Wire-facing `daemon.shutdown` handler keeps its 7-step ack contract; its actions delegate to the new orchestrator (idempotent via shared `run()`).

## 9-step ordering (final-arch + frag-3.5.1 §3.5.1.2)

| # | Step | Driver wiring |
|---|------|---------------|
| 1 | `stop-accepting` | flips module `daemonDraining` flag; dispatchers/Connect server check `isDaemonDraining()` and short-circuit with UNAVAILABLE |
| 2 | `drain-in-flight-envelope` | polls `inFlightHandlers` counter (envelope adapter wires `trackHandlerStart/Finish`); orchestrator force-progresses after 5 s timeout |
| 3 | `drain-connect-streams` | emits going_away log line on Connect/fan-out (placeholder until #108 registry singleton lands; structure stays) |
| 4 | `wind-down-pty-children` | iterates `childPidRegistry`, calls `native().sigchld.waitpid(pid)` per child with `perChildDeadlineMs=200` (no-op when registry empty / on Win32 / when binding missing) |
| 5 | `checkpoint-db` | **placeholder** — logs `placeholder: true`; awaits #105 shared-DB handle to swap for `db.pragma('wal_checkpoint(TRUNCATE)'); db.close();` |
| 6 | `close-fanout-registry` | **placeholder** — emits aggregated `subscribers-closed` line; awaits #108 registry singleton |
| 7 | `flush-logs` | `logger.flush()` best-effort; #147 swaps for `pino.final` |
| 8 | `release-lockfile` | `fs.promises.unlink(<runtimeRoot>/daemon.lock)` with ENOENT swallow; #123 will swap for `proper-lockfile.unlock` |
| 9 | `exit-process` | stops disk-cap watchdog, awaits `closeTransports()`, calls `process.exit(0)` |

## Disk-cap watchdog
- New `daemon/src/lifecycle/diskCapWatchdog.ts`: walks each target dir, sums sizes, evicts oldest-mtime files until under cap. Errors per-file are swallowed via `onError` so one bad file cannot stall the loop.
- Started in `daemon/src/index.ts` after the boot completes; targets `<runtimeRoot>/logs` (500 MB) and `<runtimeRoot>/crash` (200 MB) at 60 s cadence.
- Stopped in step 9 of shutdown so its tick cannot fire during pino flush.

## Files
- `daemon/src/lifecycle/shutdownDrain.ts` (new) — 9-step orchestrator with per-step timeout, idempotent `run()`, structured event sink.
- `daemon/src/lifecycle/diskCapWatchdog.ts` (new) — aggregate disk-cap timer.
- `daemon/src/lifecycle/__tests__/shutdownDrain.test.ts` (new) — 12 tests covering ordering, idempotency, partial drain on error, **timeout force-progress test using `vi.useFakeTimers()` to verify step 2 force-progresses past a never-resolving handler at the 5 s mark**.
- `daemon/src/index.ts` — wires the new orchestrator + watchdog; existing `daemon.shutdown` actions delegate to `shutdownDrainOrchestrator.run()` (idempotent across signal/RPC paths).

## Zero-rework posture
- 7-step `daemon-shutdown.ts` handler / its tests / its wire ack are untouched.
- Driver fields are the swap surface for #105 / #108 / #123 / #147 — none of them require the orchestrator skeleton to change.

## Test plan
- [x] `npm run typecheck` — green (root + electron + daemon tsconfigs).
- [x] `npm run lint` — 0 errors (warnings pre-existing).
- [x] `npx vitest run daemon/src/lifecycle/__tests__/shutdownDrain.test.ts` — 12 passed.
- [x] `npx vitest run daemon/src/handlers/__tests__/daemon-shutdown.test.ts daemon/src/lifecycle/` — 79 passed (existing daemon-shutdown handler tests untouched).
- [ ] Manual smoke: SIGTERM the dev daemon and verify the 9 ordered `daemon-shutdown.step-{start,finish}` log lines.

(34 unrelated `daemon/src/db/schema/__tests__/v0.3.test.ts` failures from missing `better-sqlite3` native bindings on this CI sandbox — environmental, present on `working` HEAD too.)