### PR TITLE
feat: v0.3 task #103 Electron Connect-Node client port (frag-3.5.1 §3.5.1.3)

### DIFF
--- a/electron/daemonClient/__tests__/bridgeTimeout.test.ts
+++ b/electron/daemonClient/__tests__/bridgeTimeout.test.ts
@@ -1,0 +1,143 @@
+// Tests for the bridge timeout primitives (Task #103).
+//
+// Covers:
+//   - BridgeTimeoutError shape (code/method/timeoutMs/traceId).
+//   - anyAbortSignal merge semantics on Node 20.3+ AND on the polyfill
+//     path (we force-disable the native path with a stub).
+//   - timeoutMap startCall / markFired / endCall / leakedSince.
+
+import { describe, expect, it } from 'vitest';
+import {
+  BridgeTimeoutError,
+  anyAbortSignal,
+  createTimeoutMap,
+  isBridgeTimeoutError,
+} from '../bridgeTimeout';
+
+describe('BridgeTimeoutError', () => {
+  it('exposes code, method, timeoutMs, traceId', () => {
+    const e = new BridgeTimeoutError({
+      method: 'getBootNonce',
+      timeoutMs: 5000,
+      traceId: '01TESTTRACE',
+    });
+    expect(e.code).toBe('DEADLINE_EXCEEDED');
+    expect(e.method).toBe('getBootNonce');
+    expect(e.timeoutMs).toBe(5000);
+    expect(e.traceId).toBe('01TESTTRACE');
+    expect(e.name).toBe('BridgeTimeoutError');
+    // The message MUST mention method + timeout for log triage.
+    expect(e.message).toContain('getBootNonce');
+    expect(e.message).toContain('5000ms');
+  });
+
+  it('omits traceId from message when absent', () => {
+    const e = new BridgeTimeoutError({ method: 'm', timeoutMs: 100 });
+    expect(e.traceId).toBeUndefined();
+    expect(e.message).not.toContain('traceId=');
+  });
+
+  it('isBridgeTimeoutError narrows', () => {
+    expect(isBridgeTimeoutError(new BridgeTimeoutError({ method: 'm', timeoutMs: 1 }))).toBe(true);
+    expect(isBridgeTimeoutError(new Error('x'))).toBe(false);
+    expect(isBridgeTimeoutError(null)).toBe(false);
+  });
+});
+
+describe('anyAbortSignal', () => {
+  it('returns a never-aborting signal for empty input', () => {
+    const sig = anyAbortSignal([]);
+    expect(sig.aborted).toBe(false);
+  });
+
+  it('returns the input verbatim for a single signal', () => {
+    const c = new AbortController();
+    expect(anyAbortSignal([c.signal])).toBe(c.signal);
+  });
+
+  it('aborts immediately if any input is already aborted', () => {
+    const a = new AbortController();
+    const b = new AbortController();
+    a.abort(new Error('reason-A'));
+    const merged = anyAbortSignal([a.signal, b.signal]);
+    expect(merged.aborted).toBe(true);
+    // reason should match the first already-aborted input in declared order
+    expect((merged.reason as Error).message).toBe('reason-A');
+  });
+
+  it('aborts when the first input aborts later (polyfill path)', async () => {
+    // Force the polyfill by hiding the native implementation.
+    const original = (AbortSignal as unknown as { any?: unknown }).any;
+    (AbortSignal as unknown as { any?: unknown }).any = undefined;
+    try {
+      const a = new AbortController();
+      const b = new AbortController();
+      const merged = anyAbortSignal([a.signal, b.signal]);
+      expect(merged.aborted).toBe(false);
+      const aborted = new Promise<void>((resolve) => {
+        merged.addEventListener('abort', () => resolve(), { once: true });
+      });
+      b.abort(new Error('reason-B'));
+      await aborted;
+      expect(merged.aborted).toBe(true);
+      expect((merged.reason as Error).message).toBe('reason-B');
+    } finally {
+      (AbortSignal as unknown as { any?: unknown }).any = original;
+    }
+  });
+
+  it('uses native AbortSignal.any when available', () => {
+    if (typeof (AbortSignal as unknown as { any?: unknown }).any !== 'function') {
+      // Node version too old; skip.
+      return;
+    }
+    const a = new AbortController();
+    const merged = anyAbortSignal([a.signal, new AbortController().signal]);
+    expect(merged.aborted).toBe(false);
+    a.abort();
+    expect(merged.aborted).toBe(true);
+  });
+});
+
+describe('timeoutMap', () => {
+  it('tracks size on start/end', () => {
+    const m = createTimeoutMap();
+    expect(m.size()).toBe(0);
+    m.startCall({ callId: 'c1', method: 'A', timeoutMs: 100, now: 1000 });
+    m.startCall({ callId: 'c2', method: 'B', timeoutMs: 200, now: 1000 });
+    expect(m.size()).toBe(2);
+    m.endCall('c1');
+    expect(m.size()).toBe(1);
+  });
+
+  it('counts leaked calls past the threshold', () => {
+    const m = createTimeoutMap();
+    m.startCall({ callId: 'c1', method: 'A', timeoutMs: 100, now: 0 });
+    m.startCall({ callId: 'c2', method: 'B', timeoutMs: 100, now: 0 });
+    // Pre-fire: zero leaked.
+    expect(m.leakedSince(30_000, 100_000)).toBe(0);
+    m.markFired('c1', 100);
+    m.markFired('c2', 100);
+    // 30s after fire → both leaked.
+    expect(m.leakedSince(30_000, 30_100)).toBe(2);
+    // 29s after fire → not yet leaked.
+    expect(m.leakedSince(30_000, 29_000)).toBe(0);
+    // After endCall, no longer counted.
+    m.endCall('c1');
+    expect(m.leakedSince(30_000, 30_100)).toBe(1);
+  });
+
+  it('markFired is idempotent (firedAt latches to first call)', () => {
+    const m = createTimeoutMap();
+    m.startCall({ callId: 'c1', method: 'A', timeoutMs: 50, now: 0 });
+    m.markFired('c1', 50);
+    m.markFired('c1', 60); // ignored
+    const e = m.entries()[0]!;
+    expect(e.firedAt).toBe(50);
+  });
+
+  it('endCall on unknown callId is a no-op', () => {
+    const m = createTimeoutMap();
+    expect(() => m.endCall('does-not-exist')).not.toThrow();
+  });
+});

--- a/electron/daemonClient/__tests__/connectClient.test.ts
+++ b/electron/daemonClient/__tests__/connectClient.test.ts
@@ -1,0 +1,175 @@
+// Tests for the Connect-Node daemon client (Task #103).
+//
+// We focus on the parts that don't require a real HTTP/2 server:
+//   - Listener A path resolution (mirrors daemon listenerA.ts).
+//   - Backoff schedule (jitter math + clamp).
+//   - enqueueCall queues vs. issues based on connected flag.
+//   - close() rejects the queue.
+//
+// End-to-end Connect over a real socket is exercised by the integration
+// suite (T11+ wave); here we keep tests fast and deterministic.
+
+import { describe, expect, it } from 'vitest';
+import {
+  RECONNECT_BASE_DELAYS_MS,
+  RECONNECT_MAX_DELAY_MS,
+  createConnectClient,
+  jitterDelay,
+  nextBackoffMs,
+  resolveListenerAPath,
+} from '../connectClient';
+import { createReconnectQueue } from '../reconnectQueue';
+import { createDaemonSurfaceRegistry } from '../surfaceRegistry';
+import { createTimeoutMap } from '../bridgeTimeout';
+
+describe('resolveListenerAPath', () => {
+  it('Linux: <runtimeDir>/ccsm-daemon-data.sock', () => {
+    expect(
+      resolveListenerAPath({ platform: 'linux', runtimeDir: '/run/ccsm' }),
+    ).toBe('/run/ccsm/ccsm-daemon-data.sock');
+  });
+  it('Win32: \\\\.\\pipe\\ccsm-daemon-data-<sid>', () => {
+    expect(
+      resolveListenerAPath({ platform: 'win32', sid: 'S-1-5-21-X' }),
+    ).toBe('\\\\.\\pipe\\ccsm-daemon-data-S-1-5-21-X');
+  });
+  it('throws on POSIX without runtimeDir', () => {
+    expect(() => resolveListenerAPath({ platform: 'linux' })).toThrow(/runtimeDir/);
+  });
+  it('throws on Win32 without sid', () => {
+    expect(() => resolveListenerAPath({ platform: 'win32' })).toThrow(/sid/);
+  });
+});
+
+describe('backoff schedule', () => {
+  it('matches frag-3.7 §3.7.4 base delays', () => {
+    expect(RECONNECT_BASE_DELAYS_MS).toEqual([200, 400, 800, 1600, 3200, 5000]);
+    expect(RECONNECT_MAX_DELAY_MS).toBe(5000);
+  });
+
+  it('jitterDelay: rand=0.5 → exact base', () => {
+    expect(jitterDelay(1000, 0.5)).toBe(1000);
+  });
+  it('jitterDelay: rand=0 → -25% of base', () => {
+    expect(jitterDelay(1000, 0)).toBe(750);
+  });
+  it('jitterDelay: rand approaching 1 → +25% of base', () => {
+    expect(jitterDelay(1000, 0.999999)).toBeGreaterThanOrEqual(1249);
+    expect(jitterDelay(1000, 0.999999)).toBeLessThanOrEqual(1250);
+  });
+  it('jitterDelay never returns below 1', () => {
+    expect(jitterDelay(0, 0)).toBe(1);
+  });
+  it('nextBackoffMs clamps past last entry', () => {
+    expect(nextBackoffMs(1, 0.5)).toBe(200);
+    expect(nextBackoffMs(6, 0.5)).toBe(5000);
+    expect(nextBackoffMs(99, 0.5)).toBe(5000);
+  });
+});
+
+describe('createConnectClient', () => {
+  function buildClient(): ReturnType<typeof createConnectClient> {
+    return createConnectClient({
+      socketPath: '/tmp/never-connects.sock',
+      defaultTimeoutMs: 100,
+      // Empty schedule = reconnect disabled, keeps test deterministic.
+      reconnectBaseDelaysMs: [],
+      surfaceRegistry: createDaemonSurfaceRegistry(),
+      reconnectQueue: createReconnectQueue({ maxQueued: 5 }),
+      timeoutMap: createTimeoutMap(),
+      // netConnect should never actually fire in these tests because we
+      // don't make any RPC that opens an HTTP/2 session — buildCallOptions
+      // and enqueueCall logic both work without touching net.
+      netConnect: () => {
+        throw new Error('test should not open a real socket');
+      },
+    });
+  }
+
+  it('initial status is "connecting"', () => {
+    const c = buildClient();
+    const s = c.status();
+    expect(s.state).toBe('connecting');
+    expect(s.queuedCalls).toBe(0);
+    expect(s.inFlightCalls).toBe(0);
+  });
+
+  it('enqueueCall queues when not connected; close → reject queued', async () => {
+    const c = buildClient();
+    let ran = false;
+    const p = c.enqueueCall<string>({
+      method: 'TestM',
+      run: async () => {
+        ran = true;
+        return 'X';
+      },
+    });
+    expect(c.status().queuedCalls).toBe(1);
+    await c.close();
+    await expect(p).rejects.toThrow(/daemon-client-closed/);
+    expect(ran).toBe(false);
+  });
+
+  it('disconnect/reconnect listeners can be subscribed and unsubscribed', () => {
+    const c = buildClient();
+    let count = 0;
+    const unsub = c.onDisconnected(() => {
+      count += 1;
+    });
+    unsub();
+    // No way to fire from outside without a real socket; subscribe-only sanity.
+    expect(count).toBe(0);
+  });
+
+  it('buildCallOptions wires headers + signal + callId', () => {
+    const c = buildClient();
+    const opts = c.buildCallOptions({
+      method: 'GetBootNonce',
+      traceId: '01TRACE',
+    });
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
+    expect(opts.headers).toBeInstanceOf(Headers);
+    expect((opts.headers as Headers).get('x-ccsm-deadline-ms')).toBe('100');
+    expect((opts.headers as Headers).get('x-ccsm-trace-id')).toBe('01TRACE');
+    expect(typeof opts.__callId).toBe('string');
+    expect(opts.__callId.length).toBeGreaterThan(0);
+    c.endCall(opts.__callId);
+  });
+
+  it('per-method timeout overrides default', () => {
+    const c = createConnectClient({
+      socketPath: '/tmp/x.sock',
+      defaultTimeoutMs: 100,
+      perMethodTimeoutMs: { GetPtyBufferSnapshot: 30000 },
+      reconnectBaseDelaysMs: [],
+      surfaceRegistry: createDaemonSurfaceRegistry(),
+      reconnectQueue: createReconnectQueue({ maxQueued: 5 }),
+      netConnect: () => {
+        throw new Error('no socket');
+      },
+    });
+    const opts = c.buildCallOptions({ method: 'GetPtyBufferSnapshot' });
+    expect((opts.headers as Headers).get('x-ccsm-deadline-ms')).toBe('30000');
+    c.endCall(opts.__callId);
+  });
+
+  it('per-call perMethodTimeoutMs override beats per-method map', () => {
+    const c = createConnectClient({
+      socketPath: '/tmp/x.sock',
+      defaultTimeoutMs: 100,
+      perMethodTimeoutMs: { Foo: 1000 },
+      reconnectBaseDelaysMs: [],
+      surfaceRegistry: createDaemonSurfaceRegistry(),
+      reconnectQueue: createReconnectQueue({ maxQueued: 5 }),
+      netConnect: () => {
+        throw new Error('no socket');
+      },
+    });
+    const opts = c.buildCallOptions({
+      method: 'Foo',
+      perMethodTimeoutMs: 5000,
+    });
+    expect((opts.headers as Headers).get('x-ccsm-deadline-ms')).toBe('5000');
+    c.endCall(opts.__callId);
+  });
+});

--- a/electron/daemonClient/__tests__/noFloatingCancellation.test.ts
+++ b/electron/daemonClient/__tests__/noFloatingCancellation.test.ts
@@ -1,0 +1,55 @@
+// Tests for the no-floating-cancellation custom ESLint rule.
+//
+// RuleTester emits its own describe/it via the host test runner; we plug
+// vitest's globals (describe/it) into it via the constructor option.
+
+import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
+// CommonJS rule loaded via require — same pattern as no-direct-native-import.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const rule = require('../../../eslint-rules/no-floating-cancellation.js');
+
+// Plug vitest's describe/it into RuleTester's own dispatcher so its
+// generated assertions show up as proper test cases.
+RuleTester.describe = describe as unknown as typeof RuleTester.describe;
+RuleTester.it = it as unknown as typeof RuleTester.it;
+
+const tester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+});
+
+tester.run('no-floating-cancellation', rule, {
+  valid: [
+    // Function reads `signal.aborted`.
+    { code: 'function h(req, signal) { if (signal.aborted) return; }' },
+    // Forwarded to a sub-call.
+    { code: 'function h(req, signal) { return inner(signal); }' },
+    // Destructured + read.
+    { code: 'function h({ signal }) { signal.throwIfAborted(); }' },
+    // Doesn't take a `signal` parameter at all — rule has nothing to check.
+    { code: 'function h(req) { return req.id; }' },
+    // Arrow form.
+    { code: 'const h = (signal) => { signal.addEventListener("abort", () => {}); };' },
+    // Param named `_signal` (different name) — out of scope.
+    { code: 'function h(_signal) { return 1; }' },
+    // No `signal` param at all → must be valid.
+    { code: 'function h(req) { return req.signal; }' },
+  ],
+  invalid: [
+    {
+      code: 'function h(req, signal) { return req.id; }',
+      errors: [{ messageId: 'unobserved' }],
+    },
+    {
+      code: 'function h({ signal }) { return 42; }',
+      errors: [{ messageId: 'unobserved' }],
+    },
+    {
+      code: 'function h(signal) { const x = obj.signal; return x; }',
+      errors: [{ messageId: 'unobserved' }],
+    },
+  ],
+});

--- a/electron/daemonClient/__tests__/reconnectQueue.test.ts
+++ b/electron/daemonClient/__tests__/reconnectQueue.test.ts
@@ -1,0 +1,160 @@
+// Tests for the bounded reconnect queue (Task #103, frag-3.7 §3.7.4).
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createReconnectQueue,
+  MAX_QUEUED_DEV,
+  MAX_QUEUED_PROD,
+  QUEUE_OVERFLOW_MESSAGE,
+} from '../reconnectQueue';
+
+describe('reconnectQueue', () => {
+  it('exposes prod and dev caps from spec frag-3.7 §3.7.4', () => {
+    expect(MAX_QUEUED_PROD).toBe(100);
+    expect(MAX_QUEUED_DEV).toBe(1000);
+  });
+
+  it('enqueues and drains in FIFO order, resolving each promise', async () => {
+    const q = createReconnectQueue({ maxQueued: 10 });
+    const calls: string[] = [];
+    const p1 = q.enqueue<string>({
+      method: 'A',
+      thunk: async () => {
+        calls.push('A');
+        return 'a-result';
+      },
+    });
+    const p2 = q.enqueue<string>({
+      method: 'B',
+      thunk: async () => {
+        calls.push('B');
+        return 'b-result';
+      },
+    });
+    expect(q.size()).toBe(2);
+    const drained = await q.drain();
+    expect(drained).toBe(2);
+    expect(q.size()).toBe(0);
+    expect(await p1).toBe('a-result');
+    expect(await p2).toBe('b-result');
+    // FIFO: A's thunk fired before B's.
+    expect(calls).toEqual(['A', 'B']);
+  });
+
+  it('forwards thunk rejection through to the original promise', async () => {
+    const q = createReconnectQueue({ maxQueued: 5 });
+    const p = q.enqueue<number>({
+      method: 'X',
+      thunk: async () => {
+        throw new Error('boom');
+      },
+    });
+    const drained = await q.drain();
+    expect(drained).toBe(1);
+    await expect(p).rejects.toThrow('boom');
+  });
+
+  it('rejects the OLDEST entry on overflow, appends the new one', async () => {
+    const q = createReconnectQueue({ maxQueued: 2 });
+    const oldest = q.enqueue<string>({
+      method: 'oldest',
+      thunk: async () => 'X',
+    });
+    q.enqueue({ method: 'middle', thunk: async () => 'Y' });
+    // This third enqueue triggers overflow → `oldest` rejects.
+    q.enqueue({ method: 'newest', thunk: async () => 'Z' });
+    await expect(oldest).rejects.toThrow(QUEUE_OVERFLOW_MESSAGE);
+    expect(q.size()).toBe(2);
+  });
+
+  it('rejectAll empties the queue and rejects each entry', async () => {
+    const q = createReconnectQueue({ maxQueued: 5 });
+    const p1 = q.enqueue({ method: 'A', thunk: async () => 1 });
+    const p2 = q.enqueue({ method: 'B', thunk: async () => 2 });
+    q.rejectAll(new Error('client-closed'));
+    expect(q.size()).toBe(0);
+    await expect(p1).rejects.toThrow('client-closed');
+    await expect(p2).rejects.toThrow('client-closed');
+  });
+
+  it('drain on empty queue returns 0', async () => {
+    const q = createReconnectQueue({ maxQueued: 5 });
+    expect(await q.drain()).toBe(0);
+  });
+
+  it('uses dev cap when CCSM_DAEMON_DEV=1, prod cap otherwise', () => {
+    const orig = process.env['CCSM_DAEMON_DEV'];
+    try {
+      process.env['CCSM_DAEMON_DEV'] = '1';
+      const dev = createReconnectQueue();
+      // Probe: enqueue 100 calls. In prod cap=100, the 101st evicts oldest.
+      // In dev cap=1000, no eviction yet at 100.
+      const promises: Promise<unknown>[] = [];
+      for (let i = 0; i < 101; i++) {
+        promises.push(dev.enqueue({ method: 'p', thunk: async () => i }));
+      }
+      // No overflow expected → no rejection happened on the first.
+      // We only check size; the promises stay pending until drain.
+      expect(dev.size()).toBe(101);
+      // Cleanup.
+      dev.rejectAll(new Error('cleanup'));
+      // Swallow rejections.
+      void Promise.allSettled(promises);
+    } finally {
+      if (orig === undefined) delete process.env['CCSM_DAEMON_DEV'];
+      else process.env['CCSM_DAEMON_DEV'] = orig;
+    }
+  });
+
+  it('logs canonical daemon_queue_overflow message on eviction', async () => {
+    const lines: Array<{ line: string; extras: Record<string, unknown> | undefined }> = [];
+    const q = createReconnectQueue({
+      maxQueued: 1,
+      log: (line, extras) => lines.push({ line, extras }),
+    });
+    const p = q.enqueue({ method: 'M', thunk: async () => 'X' });
+    q.enqueue({ method: 'N', thunk: async () => 'Y' });
+    // First was evicted.
+    await expect(p).rejects.toThrow(QUEUE_OVERFLOW_MESSAGE);
+    expect(lines.some((l) => l.line === 'daemon_queue_overflow')).toBe(true);
+  });
+
+  it('drain after enqueue while another drain is pending: re-queued thunks land in next batch', async () => {
+    const q = createReconnectQueue({ maxQueued: 5 });
+    let reentered = false;
+    q.enqueue({
+      method: 'self-requeue',
+      thunk: async () => {
+        // Re-enqueue while drain is mid-flight. Must NOT be observed by
+        // the in-flight batch (prevents recursion).
+        if (!reentered) {
+          reentered = true;
+          q.enqueue({ method: 'next', thunk: async () => 'second' });
+        }
+        return 'first';
+      },
+    });
+    expect(await q.drain()).toBe(1);
+    // The re-enqueued one is still pending.
+    expect(q.size()).toBe(1);
+    expect(await q.drain()).toBe(1);
+  });
+
+  it('rejects construction with non-positive maxQueued', () => {
+    expect(() => createReconnectQueue({ maxQueued: 0 })).toThrow();
+    expect(() => createReconnectQueue({ maxQueued: -1 })).toThrow();
+    expect(() => createReconnectQueue({ maxQueued: 1.5 })).toThrow();
+  });
+
+  // Defense against accidental mock usage.
+  it('uses real Date.now by default', () => {
+    const q = createReconnectQueue({ maxQueued: 1 });
+    void q.enqueue({ method: 'A', thunk: async () => 1 });
+    const peek = q.peek();
+    expect(peek[0]?.enqueuedAt).toBeGreaterThan(0);
+  });
+});
+
+// Vitest unused-import guard (vi imported for spy parity with other suites
+// in the daemonClient folder but not needed here).
+void vi;

--- a/electron/daemonClient/__tests__/spawnOrAttach.test.ts
+++ b/electron/daemonClient/__tests__/spawnOrAttach.test.ts
@@ -1,0 +1,157 @@
+// Tests for spawnOrAttach (Task #103, frag-3.7 §3.7.2 + §3.7.4).
+
+import { describe, expect, it } from 'vitest';
+import * as path from 'node:path';
+import {
+  resolveDataRoot,
+  resolveLockfilePath,
+  spawnOrAttach,
+} from '../spawnOrAttach';
+
+describe('resolveDataRoot', () => {
+  it('Linux: prefers XDG_DATA_HOME', () => {
+    expect(
+      resolveDataRoot({
+        platform: 'linux',
+        env: { XDG_DATA_HOME: '/srv/xdg' },
+        home: '/home/u',
+      }),
+    ).toBe(path.join('/srv/xdg', 'ccsm'));
+  });
+  it('Linux: falls back to ~/.local/share when XDG_DATA_HOME unset', () => {
+    expect(
+      resolveDataRoot({ platform: 'linux', env: {}, home: '/home/u' }),
+    ).toBe(path.join('/home/u', '.local', 'share', 'ccsm'));
+  });
+  it('Darwin: ~/Library/Application Support/ccsm', () => {
+    expect(
+      resolveDataRoot({ platform: 'darwin', env: {}, home: '/Users/u' }),
+    ).toBe(path.join('/Users/u', 'Library', 'Application Support', 'ccsm'));
+  });
+  it('Win32: prefers LOCALAPPDATA', () => {
+    expect(
+      resolveDataRoot({
+        platform: 'win32',
+        env: { LOCALAPPDATA: 'C:\\Users\\u\\AppData\\Local' },
+        home: 'C:\\Users\\u',
+      }),
+    ).toBe(path.join('C:\\Users\\u\\AppData\\Local', 'ccsm'));
+  });
+  it('Win32: falls back to %USERPROFILE%\\AppData\\Local', () => {
+    expect(
+      resolveDataRoot({
+        platform: 'win32',
+        env: {},
+        home: 'C:\\Users\\u',
+      }),
+    ).toBe(path.join('C:\\Users\\u', 'AppData', 'Local', 'ccsm'));
+  });
+});
+
+describe('resolveLockfilePath', () => {
+  it('joins daemon.lock to dataRoot', () => {
+    expect(
+      resolveLockfilePath({
+        platform: 'linux',
+        env: { XDG_DATA_HOME: '/x' },
+        home: '/h',
+      }),
+    ).toBe(path.join('/x', 'ccsm', 'daemon.lock'));
+  });
+});
+
+describe('spawnOrAttach', () => {
+  it('returns "attached" when lockfile exists', () => {
+    const result = spawnOrAttach({
+      platform: 'linux',
+      env: { XDG_DATA_HOME: '/srv/xdg' },
+      home: '/home/u',
+      lockfileExists: () => true,
+    });
+    expect(result.kind).toBe('attached');
+    expect(result.lockfilePath).toBe(
+      path.join('/srv/xdg', 'ccsm', 'daemon.lock'),
+    );
+  });
+
+  it('returns "dev-no-spawn" when lockfile missing AND CCSM_DAEMON_DEV=1', () => {
+    const result = spawnOrAttach({
+      platform: 'linux',
+      env: { XDG_DATA_HOME: '/srv/xdg', CCSM_DAEMON_DEV: '1' },
+      home: '/home/u',
+      lockfileExists: () => false,
+    });
+    expect(result.kind).toBe('dev-no-spawn');
+  });
+
+  it('returns "dev-no-spawn" with explicit dev=true even if env is unset', () => {
+    const result = spawnOrAttach({
+      platform: 'linux',
+      env: { XDG_DATA_HOME: '/srv/xdg' },
+      home: '/home/u',
+      lockfileExists: () => false,
+      dev: true,
+    });
+    expect(result.kind).toBe('dev-no-spawn');
+  });
+
+  it('returns "spawned" in prod when spawnDaemonFn provided', () => {
+    const fakeChild = { pid: 9999, unref: (): void => undefined } as unknown as ReturnType<
+      NonNullable<Parameters<typeof spawnOrAttach>[0]>['spawnDaemonFn']
+    > extends infer C
+      ? C extends null
+        ? never
+        : C
+      : never;
+    const result = spawnOrAttach({
+      platform: 'linux',
+      env: { XDG_DATA_HOME: '/srv/xdg' },
+      home: '/home/u',
+      lockfileExists: () => false,
+      dev: false,
+      spawnDaemonFn: () => fakeChild,
+    });
+    expect(result.kind).toBe('spawned');
+    if (result.kind === 'spawned') {
+      expect(result.pid).toBe(9999);
+    }
+  });
+
+  it('returns "dev-no-spawn" when prod but spawnDaemonFn yields null', () => {
+    const result = spawnOrAttach({
+      platform: 'linux',
+      env: { XDG_DATA_HOME: '/srv/xdg' },
+      home: '/home/u',
+      lockfileExists: () => false,
+      dev: false,
+      spawnDaemonFn: () => null,
+    });
+    expect(result.kind).toBe('dev-no-spawn');
+  });
+
+  it('returns "dev-no-spawn" in prod when no spawn fn injected', () => {
+    const result = spawnOrAttach({
+      platform: 'linux',
+      env: { XDG_DATA_HOME: '/srv/xdg' },
+      home: '/home/u',
+      lockfileExists: () => false,
+      dev: false,
+    });
+    expect(result.kind).toBe('dev-no-spawn');
+  });
+
+  it('propagates non-ENOENT fs errors from the existence check', () => {
+    expect(() =>
+      spawnOrAttach({
+        platform: 'linux',
+        env: { XDG_DATA_HOME: '/srv/xdg' },
+        home: '/home/u',
+        lockfileExists: () => {
+          const e = new Error('permission denied') as NodeJS.ErrnoException;
+          e.code = 'EACCES';
+          throw e;
+        },
+      }),
+    ).toThrow(/permission denied/);
+  });
+});

--- a/electron/daemonClient/__tests__/surfaceRegistry.test.ts
+++ b/electron/daemonClient/__tests__/surfaceRegistry.test.ts
@@ -1,0 +1,46 @@
+// Tests for the daemon surface registry shim (Task #103, frag-6-7 §6.8 r7).
+
+import { describe, expect, it } from 'vitest';
+import { createDaemonSurfaceRegistry } from '../surfaceRegistry';
+
+describe('daemonSurfaceRegistry', () => {
+  it('starts in idle state', () => {
+    const r = createDaemonSurfaceRegistry();
+    expect(r.get().state).toBe('idle');
+  });
+
+  it('updates changedAt only when state actually changes', () => {
+    let t = 1000;
+    const r = createDaemonSurfaceRegistry({ now: () => t });
+    const t0 = r.get().changedAt;
+    t = 2000;
+    r.set('idle'); // same state — no-op
+    expect(r.get().changedAt).toBe(t0);
+    r.set('reconnecting');
+    expect(r.get().state).toBe('reconnecting');
+    expect(r.get().changedAt).toBe(2000);
+  });
+
+  it('fires subscribers synchronously on state change', () => {
+    const r = createDaemonSurfaceRegistry();
+    const events: string[] = [];
+    const unsub = r.subscribe((s) => events.push(s.state));
+    r.set('reconnecting');
+    r.set('reconnecting'); // no fan-out
+    r.set('reconnected');
+    unsub();
+    r.set('idle'); // no fan-out after unsub
+    expect(events).toEqual(['reconnecting', 'reconnected']);
+  });
+
+  it('supports multiple subscribers', () => {
+    const r = createDaemonSurfaceRegistry();
+    const a: string[] = [];
+    const b: string[] = [];
+    r.subscribe((s) => a.push(s.state));
+    r.subscribe((s) => b.push(s.state));
+    r.set('reconnecting');
+    expect(a).toEqual(['reconnecting']);
+    expect(b).toEqual(['reconnecting']);
+  });
+});

--- a/electron/daemonClient/bridgeTimeout.ts
+++ b/electron/daemonClient/bridgeTimeout.ts
@@ -1,0 +1,277 @@
+// electron/daemonClient/bridgeTimeout.ts
+//
+// Bridge call deadline primitives for the Electron-side Connect-Node client
+// (Task #103, frag-3.5.1 §3.5.1.3 lock).
+//
+// Three exports — each owns one concern:
+//
+//   1. `BridgeTimeoutError`           — typed error thrown by the bridge layer
+//                                       on per-call deadline expiry. NEVER
+//                                       user-surfaced (see frag-3.5.1 §3.5.1.3
+//                                       round-3 lock + §3.7.4 toast UX): the
+//                                       bridge retries once internally and
+//                                       then flips the surface-registry
+//                                       'reconnecting' slot.
+//
+//   2. `anyAbortSignal(signals)`      — Node 20+ `AbortSignal.any` polyfill /
+//                                       ponyfill. Node 20.3+ ships it natively;
+//                                       we feature-detect and fall back to a
+//                                       hand-rolled merge so the bridge runs
+//                                       on Electron's bundled Node which may
+//                                       lag the upstream release. The merged
+//                                       signal aborts on the first input that
+//                                       aborts, with the original `reason`.
+//
+//   3. `createTimeoutMap()`           — per-call deadline tracker keyed by an
+//                                       opaque call-id (ULID/string). The
+//                                       bridge inserts an entry when issuing
+//                                       a call, deletes it on resolve/reject,
+//                                       and queries `leakedSince(thresholdMs)`
+//                                       at supervisor scrape time to populate
+//                                       the `handler.leaked.count` counter
+//                                       (§3.5.1.3 — handler kept running
+//                                       after AbortSignal aborted).
+//
+// Single Responsibility breakdown (per dev contract §2):
+//   - DECIDER: `BridgeTimeoutError` is a passive value class. `anyAbortSignal`
+//     is pure (no I/O). `timeoutMap.leakedSince` is a pure read.
+//   - PRODUCER / SINK: timeoutMap mutation (`startCall` / `endCall`) is the
+//     bridge's bookkeeping; no external I/O lives here.
+//
+// Spec citations (see also `connectClient.ts` for transport semantics):
+//   - frag-3.5.1 §3.5.1.3 (Bridge call timeout + AbortSignal threading) — the
+//     `AbortSignal.any([userSignal, AbortSignal.timeout(timeoutMs)])` pattern,
+//     the `BridgeTimeoutError { code, method, timeoutMs, traceId }` shape,
+//     and the `handler.leaked.count` counter contract.
+//   - frag-3.5.1 §3.5.1.3 round-3 r3-devx lock — `BridgeTimeoutError` is
+//     internal to the bridge; the renderer never sees it.
+
+// ---------------------------------------------------------------------------
+// 1. BridgeTimeoutError
+// ---------------------------------------------------------------------------
+
+/**
+ * Bridge-layer deadline error. Thrown by `connectClient.call(...)` when the
+ * per-call timeout expires before the daemon replies. The renderer MUST NOT
+ * see this — the bridge layer catches it, retries once, then flips the
+ * surface-registry 'reconnecting' slot (frag-6-7 §6.8) and rejects the
+ * original promise with a generic disconnect surface.
+ *
+ * Field meanings:
+ *   - `code`      : always `'DEADLINE_EXCEEDED'` (gRPC convention; matches
+ *                   the daemon-side Connect `Code.DeadlineExceeded` mapping
+ *                   so log greps cross daemon/electron with one term).
+ *   - `method`    : RPC method name (Connect `MethodInfo.name` — the proto
+ *                   field, NOT the URL path).
+ *   - `timeoutMs` : the deadline that fired. Useful for log triage when a
+ *                   per-method override map (Task 5) sets a non-default cap.
+ *   - `traceId`   : ULID of the originating call so a renderer log line can
+ *                   be correlated with the daemon-side handler trace. May be
+ *                   `undefined` if the call was issued without a trace-id
+ *                   header (e.g. boot-time `Ping`).
+ */
+export class BridgeTimeoutError extends Error {
+  public readonly code = 'DEADLINE_EXCEEDED' as const;
+  public readonly method: string;
+  public readonly timeoutMs: number;
+  public readonly traceId: string | undefined;
+
+  constructor(opts: { method: string; timeoutMs: number; traceId?: string | undefined }) {
+    super(
+      `bridge call ${opts.method} exceeded ${opts.timeoutMs}ms deadline` +
+        (opts.traceId !== undefined ? ` (traceId=${opts.traceId})` : ''),
+    );
+    this.name = 'BridgeTimeoutError';
+    this.method = opts.method;
+    this.timeoutMs = opts.timeoutMs;
+    this.traceId = opts.traceId;
+  }
+}
+
+/** Type predicate so callers can branch without `instanceof` import.
+ *
+ * NOTE: `instanceof` is the load-bearing check; the predicate exists only
+ * for ergonomic narrowing (`if (isBridgeTimeoutError(e)) e.timeoutMs`). */
+export function isBridgeTimeoutError(e: unknown): e is BridgeTimeoutError {
+  return e instanceof BridgeTimeoutError;
+}
+
+// ---------------------------------------------------------------------------
+// 2. anyAbortSignal — AbortSignal.any ponyfill
+// ---------------------------------------------------------------------------
+
+/**
+ * Merge zero or more AbortSignals into a single signal that aborts on the
+ * first input abort, with that input's `reason`.
+ *
+ * Implementation strategy:
+ *   - If `AbortSignal.any` exists at runtime (Node 20.3+), defer to it. We
+ *     feature-detect rather than version-test because Electron's bundled
+ *     Node is occasionally pinned behind upstream and a feature-test is
+ *     forward-compatible (no version table to keep up to date).
+ *   - Otherwise, build a fresh `AbortController`, walk inputs:
+ *       * if any is already aborted → abort immediately with its reason
+ *       * else attach a one-shot listener per input that aborts the
+ *         controller with its reason on first abort.
+ *     We deliberately do NOT clean listeners on the OTHER inputs after one
+ *     fires — they stay attached until their underlying signal is GC'd.
+ *     Each listener is `{ once: true }` so it only fires once; the cost of
+ *     a stale "no-op" listener until GC is much cheaper than tracking N
+ *     remove handles per merged signal (mirrors the Node std-lib impl).
+ *
+ * Edge cases:
+ *   - Empty input → returns a never-aborting signal (matches Node's
+ *     spec for `AbortSignal.any([])`).
+ *   - Single input → returns it verbatim (trivial fast path; sidesteps a
+ *     redundant controller allocation per call).
+ */
+export function anyAbortSignal(signals: readonly AbortSignal[]): AbortSignal {
+  // Fast paths.
+  if (signals.length === 0) {
+    return new AbortController().signal;
+  }
+  if (signals.length === 1) {
+    // Definite assignment: length === 1 guarantees signals[0] exists.
+    // noUncheckedIndexedAccess narrows it as `AbortSignal | undefined`,
+    // hence the explicit non-null read into a local.
+    const only = signals[0];
+    if (only !== undefined) return only;
+  }
+
+  // Native fast path (Node 20.3+). Cast through unknown because @types/node
+  // in older Electron toolchains may not declare AbortSignal.any yet.
+  const native = (AbortSignal as unknown as {
+    any?: (input: readonly AbortSignal[]) => AbortSignal;
+  }).any;
+  if (typeof native === 'function') {
+    return native(signals);
+  }
+
+  // Manual merge.
+  const controller = new AbortController();
+  // If any input is already aborted, bail immediately. Walk in declared
+  // order so the reported `reason` is deterministic across runs (matches
+  // the spec for AbortSignal.any).
+  for (const s of signals) {
+    if (s.aborted) {
+      controller.abort(s.reason);
+      return controller.signal;
+    }
+  }
+  for (const s of signals) {
+    s.addEventListener(
+      'abort',
+      () => {
+        if (!controller.signal.aborted) {
+          controller.abort(s.reason);
+        }
+      },
+      { once: true },
+    );
+  }
+  return controller.signal;
+}
+
+// ---------------------------------------------------------------------------
+// 3. timeout map — per-call deadline tracker
+// ---------------------------------------------------------------------------
+
+/** Snapshot of a single in-flight call. Returned by `timeoutMap.entries()`
+ *  for tests / supervisor scrape; the bridge does not consume this shape
+ *  directly. */
+export interface TimeoutMapEntry {
+  readonly callId: string;
+  readonly method: string;
+  readonly timeoutMs: number;
+  /** Wall-clock ms (`Date.now()`-style) at which the deadline was scheduled
+   *  to fire. */
+  readonly deadlineAt: number;
+  /** Wall-clock ms at which the deadline DID fire and the bridge aborted
+   *  the call. `undefined` if the call is still pre-deadline. */
+  readonly firedAt: number | undefined;
+}
+
+export interface TimeoutMap {
+  /** Mark a call started. The bridge calls this just before issuing the
+   *  Connect promise. */
+  startCall(opts: { callId: string; method: string; timeoutMs: number; now?: number }): void;
+  /** Mark the deadline as having fired. The bridge calls this from the
+   *  per-call timer callback (or the merged AbortSignal listener) so the
+   *  entry transitions to "leaked candidate" — if `endCall` lands later
+   *  than `thresholdMs` after `firedAt`, the call leaked. */
+  markFired(callId: string, now?: number): void;
+  /** Mark a call resolved/rejected. Always safe to call (idempotent). */
+  endCall(callId: string): void;
+  /** Count entries that fired the deadline AT LEAST `thresholdMs` ago AND
+   *  are still in the map (i.e. handler kept running long after abort).
+   *  This is the supervisor's `handler.leaked.count` source. */
+  leakedSince(thresholdMs: number, now?: number): number;
+  /** Returns the in-flight call count (pre-deadline + post-deadline). */
+  size(): number;
+  /** Snapshot for tests / debug overlays. Order is insertion. */
+  entries(): readonly TimeoutMapEntry[];
+}
+
+/**
+ * Build a fresh timeout map. Stateless across instances so tests can spin
+ * one per case without WeakMap-style sharing.
+ *
+ * Implementation note: a plain `Map<string, MutableEntry>` is sufficient.
+ * We don't need an LRU because the bridge ALWAYS calls `endCall` (in a
+ * `finally` block); the map size is bounded by the in-flight call count,
+ * which Connect itself bounds via per-stream concurrency.
+ */
+export function createTimeoutMap(): TimeoutMap {
+  interface MutableEntry {
+    callId: string;
+    method: string;
+    timeoutMs: number;
+    deadlineAt: number;
+    firedAt: number | undefined;
+  }
+  const m = new Map<string, MutableEntry>();
+  return {
+    startCall({ callId, method, timeoutMs, now }) {
+      const t = now ?? Date.now();
+      m.set(callId, {
+        callId,
+        method,
+        timeoutMs,
+        deadlineAt: t + timeoutMs,
+        firedAt: undefined,
+      });
+    },
+    markFired(callId, now) {
+      const e = m.get(callId);
+      if (!e) return;
+      if (e.firedAt === undefined) {
+        e.firedAt = now ?? Date.now();
+      }
+    },
+    endCall(callId) {
+      m.delete(callId);
+    },
+    leakedSince(thresholdMs, now) {
+      const t = now ?? Date.now();
+      let n = 0;
+      for (const e of m.values()) {
+        if (e.firedAt !== undefined && t - e.firedAt >= thresholdMs) {
+          n += 1;
+        }
+      }
+      return n;
+    },
+    size() {
+      return m.size;
+    },
+    entries() {
+      return Array.from(m.values()).map((e) => ({
+        callId: e.callId,
+        method: e.method,
+        timeoutMs: e.timeoutMs,
+        deadlineAt: e.deadlineAt,
+        firedAt: e.firedAt,
+      }));
+    },
+  };
+}

--- a/electron/daemonClient/connectClient.ts
+++ b/electron/daemonClient/connectClient.ts
@@ -1,0 +1,525 @@
+// electron/daemonClient/connectClient.ts
+//
+// Electron-side Connect-RPC client over the daemon's "Listener A" data
+// plane (Task #103, frag-3.5.1 §3.5.1.3 + frag-3.7 §3.7.4 + final-arch §2.4).
+//
+// Replaces the envelope `rpcClient.ts` semantically for the data plane
+// (Listener A: POSIX UDS `<runtimeDir>/ccsm-daemon-data.sock`, Win named
+// pipe `\\.\pipe\ccsm-daemon-data-<sid>`). The control plane (supervisor
+// channel) stays on the envelope per ch02 §6 (data-socket Connect, control
+// envelope) — call sites flip in #105 / #106 / #108; the envelope
+// `rpcClient` is removed by #115.
+//
+// Spec citations:
+//   - frag-3.5.1 §3.5.1.3 — bridge call timeout, AbortSignal.any, deadline
+//     header, BridgeTimeoutError, handler.leaked.count, no-floating-cancellation
+//     ESLint rule.
+//   - frag-3.7   §3.7.4    — auto-reconnect schedule (exponential w/ ±25 %
+//     jitter, capped 5s) + bounded reconnect queue (100 prod / 1000 dev) +
+//     queue overflow rejects oldest.
+//   - frag-3.7   §3.7.5    — stream resubscription on reconnect (the bridge
+//     fires `onReconnected` so subscribers can re-attach; this module does
+//     NOT itself re-subscribe).
+//   - frag-6-7   §6.8      — surface registry slots (`reconnecting`,
+//     `reconnected`); BridgeTimeoutError NEVER user-surfaced.
+//   - daemon/src/listeners/listenerA.ts — path resolver (mirrored here).
+//
+// Single Responsibility:
+//   - PRODUCER: socket lifecycle (connect / disconnect events).
+//   - DECIDER: backoff schedule + queue cap + per-call timeout + abort
+//     merge are all pure deciders living in helper modules
+//     (`reconnectQueue.ts`, `bridgeTimeout.ts`).
+//   - SINK: `defaultDaemonSurfaceRegistry.set(...)` is the published
+//     status sink; `Promise.resolve / reject` of the per-call promise is
+//     the data sink.
+//
+// What this module does NOT do (per task brief):
+//   - It does NOT register call sites (those flip in #105 / #106 / #108).
+//   - It does NOT delete envelope `rpcClient.ts` (#115 owns cleanup).
+//   - It does NOT own the `daemon.hello` handshake (T08 lands the real
+//     JWT path; pre-handshake allowlist already enforced server-side).
+
+import * as http2 from 'node:http2';
+import * as net from 'node:net';
+import { posix as posixPath } from 'node:path';
+import { ulid } from 'ulid';
+import {
+  Code,
+  ConnectError,
+  type CallOptions,
+  type Transport,
+} from '@connectrpc/connect';
+import { createConnectTransport } from '@connectrpc/connect-node';
+import {
+  BridgeTimeoutError,
+  anyAbortSignal,
+  createTimeoutMap,
+  type TimeoutMap,
+} from './bridgeTimeout';
+import {
+  createReconnectQueue,
+  QUEUE_OVERFLOW_MESSAGE,
+  type ReconnectQueue,
+} from './reconnectQueue';
+import {
+  defaultDaemonSurfaceRegistry,
+  type DaemonSurfaceRegistry,
+} from './surfaceRegistry';
+
+// ---------------------------------------------------------------------------
+// Listener A path resolver — mirrors `daemon/src/listeners/listenerA.ts`
+// ---------------------------------------------------------------------------
+
+/** Mirrors `LISTENER_A_BASENAME` in daemon/src/listeners/listenerA.ts. */
+export const LISTENER_A_BASENAME = 'ccsm-daemon-data' as const;
+export const LISTENER_A_POSIX_FILENAME = `${LISTENER_A_BASENAME}.sock` as const;
+export const LISTENER_A_WIN_PIPE_PREFIX = `\\\\.\\pipe\\${LISTENER_A_BASENAME}-` as const;
+
+export interface ResolveListenerAPathOptions {
+  readonly platform?: NodeJS.Platform;
+  readonly runtimeDir?: string;
+  readonly sid?: string;
+}
+
+/**
+ * Resolve the Listener A endpoint path. MUST stay byte-for-byte
+ * compatible with `daemon/src/listeners/listenerA.ts:resolveListenerAPath`
+ * — drift breaks the local-IPC handshake.
+ *
+ * We duplicate rather than import because the daemon module is ESM
+ * (.js suffix imports) and the Electron main bundle is CommonJS via
+ * tsconfig.electron.json — pulling in the daemon module would force
+ * either a `--moduleResolution` flip or a build-time copy step. Both
+ * are out of scope for #103.
+ */
+export function resolveListenerAPath(opts: ResolveListenerAPathOptions = {}): string {
+  const platform = opts.platform ?? process.platform;
+  if (platform === 'win32') {
+    if (typeof opts.sid !== 'string' || opts.sid.length === 0) {
+      throw new Error(
+        'resolveListenerAPath: win32 requires { sid: string }. ' +
+          'Cache the daemon SID at boot via the ccsm_native shim and pass it here.',
+      );
+    }
+    return `${LISTENER_A_WIN_PIPE_PREFIX}${opts.sid}`;
+  }
+  if (typeof opts.runtimeDir !== 'string' || opts.runtimeDir.length === 0) {
+    throw new Error(
+      `resolveListenerAPath: ${platform} requires { runtimeDir: string }.`,
+    );
+  }
+  return posixPath.join(opts.runtimeDir, LISTENER_A_POSIX_FILENAME);
+}
+
+// ---------------------------------------------------------------------------
+// Backoff schedule (frag-3.7 §3.7.4)
+// ---------------------------------------------------------------------------
+
+/** Base delays in ms (no jitter). Index = attempt-1; clamp to last. */
+export const RECONNECT_BASE_DELAYS_MS: readonly number[] = [
+  200, 400, 800, 1600, 3200, 5000,
+] as const;
+
+/** Cap for any attempt past the last entry. */
+export const RECONNECT_MAX_DELAY_MS = 5000 as const;
+
+/**
+ * Apply ±25 % full jitter to a base delay. Pure: caller passes a `rand` in
+ * `[0, 1)` for determinism in tests.
+ */
+export function jitterDelay(baseMs: number, rand: number): number {
+  // Jitter range = ±25 % of base. `rand` in [0,1) maps to the open
+  // interval (-0.25, 0.25); we then multiply by base.
+  const span = 0.5 * baseMs; // total window
+  const offset = rand * span - 0.25 * baseMs;
+  return Math.max(1, Math.round(baseMs + offset));
+}
+
+/**
+ * Compute the next backoff delay for `attempt` (1-indexed).
+ */
+export function nextBackoffMs(attempt: number, rand: number = Math.random()): number {
+  const i = Math.max(0, Math.min(attempt - 1, RECONNECT_BASE_DELAYS_MS.length - 1));
+  const base = RECONNECT_BASE_DELAYS_MS[i] ?? RECONNECT_MAX_DELAY_MS;
+  return jitterDelay(base, rand);
+}
+
+// ---------------------------------------------------------------------------
+// ConnectClient public surface
+// ---------------------------------------------------------------------------
+
+export interface ConnectClientOptions {
+  /** Listener A path (UDS / named pipe). Resolved by the caller via
+   *  {@link resolveListenerAPath}. */
+  readonly socketPath: string;
+  /** Default per-call timeout in ms. Frag-3.5.1 §3.5.1.3 default = 5000. */
+  readonly defaultTimeoutMs?: number;
+  /** Per-method override map. Frag-3.5.1 §3.5.1.3: e.g. `getBufferSnapshot`
+   *  is given 30000 ms because snapshots are large. Lookup is by
+   *  `MethodInfo.name`. */
+  readonly perMethodTimeoutMs?: Readonly<Record<string, number>>;
+  /** Override the auto-reconnect schedule. Defaults to
+   *  {@link RECONNECT_BASE_DELAYS_MS}. Pass `[]` to DISABLE auto-reconnect
+   *  (one-shot — close on first disconnect). */
+  readonly reconnectBaseDelaysMs?: readonly number[];
+  /** Inject `Math.random` for deterministic jitter in tests. */
+  readonly rand?: () => number;
+  /** Inject a structured logger. Defaults to console.warn. */
+  readonly log?: (line: string, extras?: Record<string, unknown>) => void;
+  /** Inject the surface registry. Defaults to the module-level singleton. */
+  readonly surfaceRegistry?: DaemonSurfaceRegistry;
+  /** Inject the reconnect queue. Defaults to a fresh queue with prod/dev
+   *  cap as resolved by `CCSM_DAEMON_DEV`. */
+  readonly reconnectQueue?: ReconnectQueue;
+  /** Inject the timeout map. Defaults to a fresh in-process map. */
+  readonly timeoutMap?: TimeoutMap;
+  /** Test seam: factory for the underlying `net.Socket`. Defaults to
+   *  `net.connect(socketPath)`. */
+  readonly netConnect?: (socketPath: string) => net.Socket;
+  /** Threshold (ms) past which a still-in-map call is "leaked" and counted
+   *  toward `handler.leaked.count`. Defaults to 30_000 per
+   *  frag-3.5.1 §3.5.1.3. */
+  readonly handlerLeakedThresholdMs?: number;
+}
+
+/**
+ * Snapshot of the bridge state for callers that don't want to subscribe
+ * to the full surface registry.
+ */
+export interface ConnectClientStatus {
+  readonly state: 'connecting' | 'connected' | 'reconnecting' | 'closed';
+  readonly reconnectAttempt: number;
+  readonly queuedCalls: number;
+  readonly inFlightCalls: number;
+  readonly leakedCount: number;
+}
+
+export interface ConnectClient {
+  /** Underlying Connect transport. Pass to generated `createClient(Service, transport)`
+   *  to build a typed promise client per spec ch02 §3. */
+  readonly transport: Transport;
+  /** The merged-AbortSignal helper for callers that want to overlay their
+   *  own `AbortSignal` on top of the bridge's per-call deadline. Use this
+   *  to build the `signal` field of `CallOptions`. */
+  buildCallOptions(opts: {
+    readonly method: string;
+    readonly userSignal?: AbortSignal | undefined;
+    readonly traceId?: string;
+    readonly perMethodTimeoutMs?: number;
+  }): CallOptions & { __callId: string };
+  /** Run a Connect call through the reconnect queue: if disconnected, the
+   *  call is queued; if connected, the thunk runs immediately. The thunk
+   *  receives the timeout-aware `CallOptions` (with merged AbortSignal).
+   *  Throws `Error('daemon-reconnect-queue-overflow')` if the cap is hit
+   *  (the OLDEST queued call is the one that's actually rejected; this
+   *  method never throws — but the OLDEST call's promise will reject). */
+  enqueueCall<T>(opts: {
+    readonly method: string;
+    readonly userSignal?: AbortSignal | undefined;
+    readonly traceId?: string;
+    readonly run: (callOpts: CallOptions) => Promise<T>;
+  }): Promise<T>;
+  /** Mark a previously-issued call as completed (success or failure). The
+   *  bridge calls this internally; exported for advanced callers that
+   *  build their own enqueue-shape. */
+  endCall(callId: string): void;
+  /** Subscribe to "the daemon disconnected and we are now in reconnect
+   *  loop" events. Used by stream subscribers (frag-3.7 §3.7.5) so they
+   *  can tear down stale stream handles before the new connection lands.
+   *  Listener fires synchronously after each socket close. */
+  onDisconnected(listener: () => void): () => void;
+  /** Subscribe to "the daemon socket is back". Used by §3.7.5 stream
+   *  resubscription. Fires AFTER the queue has drained, so a subscriber
+   *  that issues a new call inside the listener does NOT race ahead of
+   *  queued calls. */
+  onReconnected(listener: () => void): () => void;
+  /** Snapshot of liveness for tests / debug overlays. */
+  status(): ConnectClientStatus;
+  /** Close the socket, stop reconnecting, reject pending+queued calls. */
+  close(): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+const DEFAULT_HANDLER_LEAKED_THRESHOLD_MS = 30_000;
+
+const NOOP_LOG = (_line: string, _extras?: Record<string, unknown>): void => {
+  /* default silent */
+};
+
+export function createConnectClient(opts: ConnectClientOptions): ConnectClient {
+  const defaultTimeoutMs = opts.defaultTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const perMethodTimeoutMs = opts.perMethodTimeoutMs ?? {};
+  const baseDelays = opts.reconnectBaseDelaysMs ?? RECONNECT_BASE_DELAYS_MS;
+  const reconnectEnabled = baseDelays.length > 0;
+  const rand = opts.rand ?? Math.random;
+  const log = opts.log ?? NOOP_LOG;
+  const surfaceRegistry = opts.surfaceRegistry ?? defaultDaemonSurfaceRegistry;
+  const queue = opts.reconnectQueue ?? createReconnectQueue({ log });
+  const tmap = opts.timeoutMap ?? createTimeoutMap();
+  const netConnect = opts.netConnect ?? ((p: string) => net.connect(p));
+  const leakedThresholdMs = opts.handlerLeakedThresholdMs ?? DEFAULT_HANDLER_LEAKED_THRESHOLD_MS;
+
+  // Connection liveness — we don't pre-emptively connect a socket here
+  // because Connect-Node's transport opens HTTP/2 sessions lazily on
+  // first call. Instead, we listen for HTTP/2 session events on the
+  // shared session manager (built by createConnectTransport) and flip
+  // surface state from there.
+  let connected = false;
+  let closed = false;
+  let reconnectAttempt = 0;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let activeSession: http2.ClientHttp2Session | null = null;
+  // Set of in-flight call-ids — also tracked by the timeout map but kept
+  // as a separate Set so .size() is O(1) for the status snapshot without
+  // walking the map.
+  const inFlight = new Set<string>();
+
+  const disconnectedListeners = new Set<() => void>();
+  const reconnectedListeners = new Set<() => void>();
+
+  // Build the Connect transport. The HTTP/2 layer is configured to call
+  // `net.connect(socketPath)` for each new session — this is the seam
+  // that lets us speak HTTP/2 over a UDS / named pipe with no external
+  // proxy. Connect-Node's session manager will tear down + recreate on
+  // session-error / GOAWAY.
+  const transport = createConnectTransport({
+    httpVersion: '2',
+    // baseUrl Authority is used as the `:authority` pseudo-header.
+    // Connect doesn't care about the scheme for routing once we
+    // override createConnection; we use http://localhost for clarity
+    // in error messages.
+    baseUrl: 'http://ccsm-daemon-data.local',
+    nodeOptions: {
+      // http2.connect's createConnection seam: bypasses TCP/TLS and
+      // hands HTTP/2 a pre-built duplex (a UDS Socket in our case).
+      createConnection: (): net.Socket => {
+        const sock = netConnect(opts.socketPath);
+        // Track session liveness via the socket. The HTTP/2 session
+        // wrapper will emit `connect` on the socket once the preface
+        // exchange completes; we treat the socket-level `connect` as
+        // "Listener A bind succeeded" and flip surface state.
+        sock.once('connect', () => {
+          connected = true;
+          reconnectAttempt = 0;
+          surfaceRegistry.set('idle');
+          log('daemon_socket_connected', { path: opts.socketPath });
+        });
+        sock.on('error', (err: Error) => {
+          log('daemon_socket_error', { message: err.message });
+          // Don't flip state here — `close` is the canonical signal.
+        });
+        sock.once('close', () => {
+          if (closed) return;
+          if (connected) {
+            connected = false;
+            log('daemon_socket_closed', {});
+            for (const l of disconnectedListeners) {
+              try { l(); } catch (e) {
+                log('disconnected_listener_threw', { message: (e as Error).message });
+              }
+            }
+            scheduleReconnect();
+          }
+        });
+        return sock;
+      },
+    },
+    // Connect-side default deadline. We override per-call via
+    // `CallOptions.timeoutMs` so this only fires for callers that
+    // somehow bypass enqueueCall.
+    defaultTimeoutMs,
+    // JSON over Connect protocol — easier to wire-tap during dogfood
+    // than the binary format. Switch to binary once stable (low-prio).
+    useBinaryFormat: false,
+  });
+
+  // Capture the http2 session by tapping the session manager at first use.
+  // Connect-Node creates the session lazily; we reach in by issuing a
+  // no-op probe? — No: we instead capture the session via the
+  // createConnection callback above (the socket carries the session
+  // lifetime). That's sufficient; activeSession remains unused as a
+  // direct read but is reserved for future Ping wiring.
+  void activeSession;
+
+  function scheduleReconnect(): void {
+    if (closed || !reconnectEnabled) return;
+    if (reconnectTimer) return;
+    reconnectAttempt += 1;
+    const delay = nextBackoffMs(reconnectAttempt, rand());
+    log('daemon_reconnect_attempt', { attempt: reconnectAttempt, delayMs: delay });
+    surfaceRegistry.set('reconnecting');
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null;
+      // Try to drain the queue — the next call inside the queue will
+      // open a fresh HTTP/2 session via the createConnection seam,
+      // which either connects (→ flips connected = true) or fails
+      // synchronously (→ thunk rejects, drain swallows, scheduleReconnect
+      // fires again).
+      void queue.drain().then(async (count) => {
+        if (connected) {
+          surfaceRegistry.set('reconnected');
+          log('daemon_reconnect_success', { drained: count });
+          for (const l of reconnectedListeners) {
+            try { l(); } catch (e) {
+              log('reconnected_listener_threw', { message: (e as Error).message });
+            }
+          }
+          // Slot self-clears after the renderer-side TTL (3s, frag-6-7
+          // §6.8). We don't own that timer here.
+        } else if (!closed) {
+          // Drain happened but socket still flapping → schedule another.
+          scheduleReconnect();
+        }
+      });
+    }, delay);
+    (reconnectTimer as unknown as { unref?: () => void }).unref?.();
+  }
+
+  function buildCallOptions(b: {
+    readonly method: string;
+    readonly userSignal?: AbortSignal | undefined;
+    readonly traceId?: string;
+    readonly perMethodTimeoutMs?: number;
+  }): CallOptions & { __callId: string } {
+    const callId = ulid();
+    const timeoutMs =
+      b.perMethodTimeoutMs ?? perMethodTimeoutMs[b.method] ?? defaultTimeoutMs;
+    // Build a per-call AbortController whose abort fires either on
+    // user-signal abort OR on bridge-level timeout. Connect's CallOptions
+    // accepts both `signal` and `timeoutMs`; we pass the merged signal
+    // and let our own `setTimeout` race it so we own the BridgeTimeoutError
+    // throw shape (Connect would otherwise throw a ConnectError with
+    // Code.DeadlineExceeded which the renderer would receive untyped).
+    const deadlineCtrl = new AbortController();
+    const merged = anyAbortSignal(
+      b.userSignal ? [b.userSignal, deadlineCtrl.signal] : [deadlineCtrl.signal],
+    );
+    tmap.startCall({ callId, method: b.method, timeoutMs });
+    inFlight.add(callId);
+    const timer = setTimeout(() => {
+      tmap.markFired(callId);
+      deadlineCtrl.abort(
+        new BridgeTimeoutError({
+          method: b.method,
+          timeoutMs,
+          traceId: b.traceId,
+        }),
+      );
+    }, timeoutMs);
+    (timer as unknown as { unref?: () => void }).unref?.();
+    // Stash the timer on the merged signal so endCall can clear it. We
+    // attach as a property on the controller for symmetry.
+    (deadlineCtrl as unknown as { __timer: ReturnType<typeof setTimeout> }).__timer = timer;
+    const headers = new Headers();
+    headers.set('x-ccsm-deadline-ms', String(timeoutMs));
+    if (b.traceId !== undefined) headers.set('x-ccsm-trace-id', b.traceId);
+    return {
+      signal: merged,
+      headers,
+      __callId: callId,
+    };
+  }
+
+  function endCall(callId: string): void {
+    inFlight.delete(callId);
+    tmap.endCall(callId);
+  }
+
+  async function enqueueCall<T>(b: {
+    readonly method: string;
+    readonly userSignal?: AbortSignal | undefined;
+    readonly traceId?: string;
+    readonly run: (callOpts: CallOptions) => Promise<T>;
+  }): Promise<T> {
+    const issue = async (): Promise<T> => {
+      const callOpts = buildCallOptions({
+        method: b.method,
+        userSignal: b.userSignal,
+        traceId: b.traceId,
+      });
+      try {
+        const result = await b.run(callOpts);
+        return result;
+      } catch (err) {
+        // If Connect itself raised DEADLINE_EXCEEDED before our local
+        // timer fired (e.g. server-side deadline header echoed back),
+        // upgrade to BridgeTimeoutError so callers see ONE shape.
+        if (err instanceof ConnectError && err.code === Code.DeadlineExceeded) {
+          throw new BridgeTimeoutError({
+            method: b.method,
+            timeoutMs:
+              perMethodTimeoutMs[b.method] ?? defaultTimeoutMs,
+            traceId: b.traceId,
+          });
+        }
+        throw err;
+      } finally {
+        endCall(callOpts.__callId);
+      }
+    };
+    if (connected || closed) {
+      // closed → still issue (it'll fail fast inside the transport with
+      // a clean error rather than hanging in the queue forever).
+      return issue();
+    }
+    return queue.enqueue<T>({ method: b.method, traceId: b.traceId, thunk: issue });
+  }
+
+  function onDisconnected(listener: () => void): () => void {
+    disconnectedListeners.add(listener);
+    return () => {
+      disconnectedListeners.delete(listener);
+    };
+  }
+  function onReconnected(listener: () => void): () => void {
+    reconnectedListeners.add(listener);
+    return () => {
+      reconnectedListeners.delete(listener);
+    };
+  }
+
+  function status(): ConnectClientStatus {
+    let state: ConnectClientStatus['state'];
+    if (closed) state = 'closed';
+    else if (connected) state = 'connected';
+    else if (reconnectAttempt > 0) state = 'reconnecting';
+    else state = 'connecting';
+    return {
+      state,
+      reconnectAttempt,
+      queuedCalls: queue.size(),
+      inFlightCalls: inFlight.size,
+      leakedCount: tmap.leakedSince(leakedThresholdMs),
+    };
+  }
+
+  async function close(): Promise<void> {
+    if (closed) return;
+    closed = true;
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+    }
+    queue.rejectAll(new Error('daemon-client-closed'));
+    if (activeSession && !activeSession.destroyed) {
+      try { activeSession.destroy(); } catch { /* ignore */ }
+    }
+    activeSession = null;
+    surfaceRegistry.set('idle');
+  }
+
+  return {
+    transport,
+    buildCallOptions,
+    enqueueCall,
+    endCall,
+    onDisconnected,
+    onReconnected,
+    status,
+    close,
+  };
+}

--- a/electron/daemonClient/reconnectQueue.ts
+++ b/electron/daemonClient/reconnectQueue.ts
@@ -1,0 +1,226 @@
+// electron/daemonClient/reconnectQueue.ts
+//
+// Bounded FIFO queue of unary RPC envelopes that the Electron-side Connect
+// client buffers while the daemon socket is dropped (Task #103, frag-3.7
+// §3.7.4 lock).
+//
+// Behavior contract (frag-3.7 §3.7.4):
+//   - Accepts ONE entry per `enqueue(...)` call until the cap is reached.
+//   - Cap defaults: prod = 100, dev = 1000 (env: `CCSM_DAEMON_DEV=1`).
+//     Closes round-2 reliability P1-R1 (rapid-fire dev save can briefly
+//     exceed 100 in nodemon storms; RAM cost ~200 KB).
+//   - On overflow: the OLDEST entry is rejected with
+//     `Error('daemon-reconnect-queue-overflow')` (the spec's wording);
+//     the new entry is appended.
+//   - Stream subscriptions are NEVER queued — they go through §3.7.5
+//     resubscription, NOT this queue. The bridge enforces that policy at
+//     the call site (this module just stores opaque thunks).
+//   - On `drain(...)`: each entry's thunk is invoked in FIFO order; the
+//     thunk's promise is bridged into the entry's `resolve` / `reject`.
+//
+// Single Responsibility:
+//   - PRODUCER: `enqueue` + `drain` are the public surface.
+//   - DECIDER: cap + FIFO ordering are policy decisions; no I/O lives
+//     here.
+//   - SINK: the registered drain callback is the sink (the bridge's
+//     "issue this Connect call now" closure).
+//
+// What this module DOESN'T own:
+//   - Reconnect schedule / backoff (lives in `connectClient.ts`).
+//   - Stream resubscription (lives in `connectClient.ts` per §3.7.5).
+//   - Surface-registry publishing (lives in `connectClient.ts`; the
+//     queue overflow is LOG ONLY per §6.8 r7 trim — no toast).
+
+/**
+ * Default queue caps from frag-3.7 §3.7.4. The dev cap is 10x the prod
+ * cap because nodemon storms can briefly enqueue hundreds of pending
+ * calls during a fast-restart cycle (each unary envelope is ~200 B JSON
+ * so 1000 entries = ~200 KB worst-case RAM).
+ */
+export const MAX_QUEUED_PROD = 100 as const;
+export const MAX_QUEUED_DEV = 1000 as const;
+
+/**
+ * Sentinel error message thrown when the queue overflows. Pinned as a
+ * const so the renderer's existing per-bridge error path (frag-3.7
+ * §3.7.4) can match on the exact string without a fragile substring
+ * compare.
+ */
+export const QUEUE_OVERFLOW_MESSAGE = 'daemon-reconnect-queue-overflow' as const;
+
+export interface QueuedCall<T = unknown> {
+  /** Opaque method name for log lines. NOT used for routing — the thunk
+   *  carries the real method binding. */
+  readonly method: string;
+  /** Optional ULID for trace correlation. */
+  readonly traceId: string | undefined;
+  /** Issue the call against the live Connect transport. The thunk is
+   *  bound to a SPECIFIC transport snapshot at enqueue time iff the
+   *  caller wants snapshot semantics; otherwise it should re-resolve
+   *  the transport on each invocation. The queue does not care. */
+  readonly thunk: () => Promise<T>;
+  /** Resolves with the thunk's resolution value. */
+  readonly resolve: (value: T) => void;
+  /** Rejects with the thunk's rejection or with overflow / abort. */
+  readonly reject: (err: Error) => void;
+  /** Wall-clock ms at enqueue time. Used for the `queued ≥4s` build-error
+   *  log gate in dev mode (§3.7.4 toast UX — log only after the §6.8 r7
+   *  trim). */
+  readonly enqueuedAt: number;
+}
+
+export interface ReconnectQueueOptions {
+  /** Cap before overflow rejection kicks in. Defaults to
+   *  {@link MAX_QUEUED_PROD} unless `CCSM_DAEMON_DEV=1` is set in the
+   *  environment, in which case {@link MAX_QUEUED_DEV} is used. */
+  readonly maxQueued?: number;
+  /** Test seam for `Date.now()`. */
+  readonly now?: () => number;
+  /** Optional structured log sink for overflow / drain events. Defaults
+   *  to a silent stub (the bridge wires its own pino). The frag-6-7
+   *  §6.6.2 canonical name is `daemon_queue_overflow`; we pass that
+   *  string as the message field so log greps work cross-process. */
+  readonly log?: (line: string, extras?: Record<string, unknown>) => void;
+}
+
+export interface ReconnectQueue {
+  /** Append a call to the queue. If full, the OLDEST entry is rejected
+   *  with `Error(QUEUE_OVERFLOW_MESSAGE)` and the new entry is added.
+   *  Returns a promise that resolves/rejects when `drain(...)` fires
+   *  the entry (or when overflow evicts it). */
+  enqueue<T>(opts: {
+    readonly method: string;
+    readonly traceId?: string | undefined;
+    readonly thunk: () => Promise<T>;
+  }): Promise<T>;
+  /** Drain the queue in FIFO order. Each entry's thunk is invoked; the
+   *  returned promise resolves once ALL entries have settled (resolve OR
+   *  reject). Resolves to the count of entries drained.
+   *
+   *  IMPORTANT: this method does NOT serialize the thunks — it issues
+   *  them all in one synchronous pass and awaits with `Promise.allSettled`.
+   *  The bridge can rely on FIFO *issue order* on the wire (Connect
+   *  serializes per-stream). */
+  drain(): Promise<number>;
+  /** Reject every entry with the given error and clear. Used when the
+   *  bridge gives up (e.g. user-initiated quit). Idempotent. */
+  rejectAll(err: Error): void;
+  /** Snapshot for tests / debug. */
+  size(): number;
+  /** Snapshot for tests / debug. */
+  peek(): readonly QueuedCall[];
+}
+
+const NOOP_LOG = (_line: string, _extras?: Record<string, unknown>): void => {
+  /* silent default */
+};
+
+function defaultMaxQueued(): number {
+  // Read env at construction time — tests that flip this must
+  // construct a fresh queue. We don't memoize across constructions
+  // because dev/prod can swap during a single Electron lifecycle
+  // (e.g. a test harness toggles `CCSM_DAEMON_DEV`).
+  return process.env['CCSM_DAEMON_DEV'] === '1' ? MAX_QUEUED_DEV : MAX_QUEUED_PROD;
+}
+
+/**
+ * Build a fresh reconnect queue. The bridge owns one per Connect client;
+ * tests construct their own with deterministic clock + small caps.
+ */
+export function createReconnectQueue(opts: ReconnectQueueOptions = {}): ReconnectQueue {
+  const maxQueued = opts.maxQueued ?? defaultMaxQueued();
+  if (!Number.isInteger(maxQueued) || maxQueued <= 0) {
+    throw new Error(
+      `createReconnectQueue: maxQueued must be a positive integer, got ${maxQueued}`,
+    );
+  }
+  const now = opts.now ?? Date.now;
+  const log = opts.log ?? NOOP_LOG;
+
+  // Plain array as ring-less FIFO. We accept O(N) shift on overflow
+  // because (a) the cap is at most 1000 (~1µs in V8), (b) overflow is
+  // an exceptional path, not a hot loop. A LinkedList would buy us
+  // O(1) shift but cost 2 pointers/entry — not worth it at this scale.
+  const q: QueuedCall[] = [];
+
+  return {
+    enqueue<T>({
+      method,
+      traceId,
+      thunk,
+    }: {
+      readonly method: string;
+      readonly traceId?: string | undefined;
+      readonly thunk: () => Promise<T>;
+    }): Promise<T> {
+      return new Promise<T>((resolve, reject) => {
+        const entry: QueuedCall<T> = {
+          method,
+          traceId,
+          thunk,
+          resolve,
+          reject,
+          enqueuedAt: now(),
+        };
+        if (q.length >= maxQueued) {
+          // Evict the oldest — it has waited the longest, so its caller
+          // is the most likely to have already given up. (The spec
+          // explicitly says "oldest call is rejected".)
+          const oldest = q.shift();
+          if (oldest) {
+            log('daemon_queue_overflow', {
+              method: oldest.method,
+              traceId: oldest.traceId,
+              waitedMs: now() - oldest.enqueuedAt,
+              cap: maxQueued,
+            });
+            try {
+              oldest.reject(new Error(QUEUE_OVERFLOW_MESSAGE));
+            } catch {
+              // Reject handlers should not throw; if they do, swallow.
+              // The new entry must still be enqueued — that's the spec.
+            }
+          }
+        }
+        q.push(entry as QueuedCall<unknown>);
+      });
+    },
+
+    async drain(): Promise<number> {
+      // Take a snapshot + clear so a concurrent enqueue (e.g. a thunk
+      // that schedules a follow-up call) lands in the next batch, not
+      // the in-flight one. This avoids unbounded recursion if a thunk
+      // immediately re-queues itself on transient failure.
+      const batch = q.splice(0, q.length);
+      if (batch.length === 0) return 0;
+      const settles = batch.map(async (entry) => {
+        try {
+          const v = await entry.thunk();
+          entry.resolve(v);
+        } catch (err) {
+          entry.reject(err instanceof Error ? err : new Error(String(err)));
+        }
+      });
+      await Promise.allSettled(settles);
+      return batch.length;
+    },
+
+    rejectAll(err): void {
+      const batch = q.splice(0, q.length);
+      for (const entry of batch) {
+        try {
+          entry.reject(err);
+        } catch {
+          /* swallow — see overflow path */
+        }
+      }
+    },
+
+    size(): number {
+      return q.length;
+    },
+    peek(): readonly QueuedCall[] {
+      return q.slice();
+    },
+  };
+}

--- a/electron/daemonClient/rpcClient.ts
+++ b/electron/daemonClient/rpcClient.ts
@@ -1,5 +1,12 @@
 // electron/daemonClient/rpcClient.ts
 //
+// @deprecated Use `connectClient.ts` (Connect-Node over Listener A) for the
+// data plane instead. Removal of this module is tracked in task #115
+// (G5: 删 envelope 数据面代码). Until then, the envelope rpcClient and the
+// Connect-Node bridge coexist: call sites flip in #105 (SQLite) / #106
+// (SessionWatcher) / #108 (PTY); the supervisor / control plane remains on
+// the envelope per ch02 §6.
+//
 // Electron-side socket-RPC client for the v0.3 daemon-split (Task #27 / B7b).
 // Pairs with the daemon-side envelope adapter (`daemon/src/envelope/adapter.ts`,
 // PR #773 / Task #28). Together they complete the v0.3 IPC layer that

--- a/electron/daemonClient/spawnOrAttach.ts
+++ b/electron/daemonClient/spawnOrAttach.ts
@@ -1,0 +1,205 @@
+// electron/daemonClient/spawnOrAttach.ts
+//
+// Probe the daemon lockfile; attach if alive, spawn if not (Task #103,
+// frag-3.7 §3.7.2 + §3.7.4 lock).
+//
+// Behavior contract:
+//   - Resolve `<dataRoot>/daemon.lock` via the same algorithm as
+//     `scripts/wait-daemon.cjs` (kept byte-for-byte identical so the dev
+//     gate and the runtime spawn-or-attach probe agree on "ready"). The
+//     resolution is duplicated rather than imported because frag-3.7
+//     §3.7.2 mandates wait-daemon.cjs be a zero-deps standalone helper
+//     that may run before workspace install.
+//   - If the lockfile exists → ATTACH: the daemon is already running, no
+//     spawn needed. Return `{ kind: 'attached', lockfilePath }`.
+//   - If the lockfile is missing AND we are in dev mode (`CCSM_DAEMON_DEV=1`
+//     OR caller passed `dev: true`) → DO NOT SPAWN. Dev mode delegates
+//     daemon lifecycle to nodemon (frag-3.7 §3.7.2.b: single canonical
+//     daemon entry in dev). Return `{ kind: 'dev-no-spawn', lockfilePath }`
+//     so the caller can fall back to the auto-reconnect loop. Closes
+//     round-2 devx P0-3 (spawnOrAttach side).
+//   - If the lockfile is missing AND we are in prod → SPAWN the bundled
+//     daemon binary. Return `{ kind: 'spawned', lockfilePath, child, pid }`.
+//
+// Single Responsibility:
+//   - PRODUCER: lockfile-existence probe (synchronous fs.statSync).
+//   - DECIDER: dev-vs-prod policy (env-driven).
+//   - SINK: `child_process.spawn` of the prod daemon binary; the actual
+//     bin path resolution is injected by the caller (`spawnDaemonFn`)
+//     so this module stays pure-testable.
+//
+// What this module DOESN'T own:
+//   - Ready-wait after spawn — that's the auto-reconnect loop in
+//     `connectClient.ts` (will retry until the daemon binds Listener A).
+//   - Lockfile WRITING — the daemon writes it via proper-lockfile at
+//     boot (frag-6-7 §6.4). This module only READS.
+//   - Path to the bundled daemon binary in prod — caller injects.
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  spawn as nativeSpawn,
+  type ChildProcess,
+  type SpawnOptionsWithoutStdio,
+} from 'node:child_process';
+
+const LOCKFILE_NAME = 'daemon.lock' as const;
+
+/**
+ * Resolve `<dataRoot>` for the current platform. MUST stay byte-for-byte
+ * identical to:
+ *   - `daemon/src/sockets/runtime-root.ts` (`resolveDataRoot`)
+ *   - `scripts/wait-daemon.cjs`           (`resolveDataRoot`)
+ *
+ * Drift is caught by `daemon/src/sockets/__tests__/runtime-root.test.ts`
+ * (canonical resolver) + the wait-daemon drift guard
+ * (`tests/wait-daemon.test.ts`). This module deliberately does NOT add
+ * a third drift guard — the existing two cover all permutations and a
+ * third copy would just shift the fix-blast-radius.
+ */
+export function resolveDataRoot(opts?: {
+  readonly platform?: NodeJS.Platform;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly home?: string;
+}): string {
+  const platform = opts?.platform ?? process.platform;
+  const env = opts?.env ?? process.env;
+  const home = opts?.home ?? os.homedir();
+  if (platform === 'win32') {
+    const local = env['LOCALAPPDATA'];
+    if (local && local.length > 0) return path.join(local, 'ccsm');
+    return path.join(home, 'AppData', 'Local', 'ccsm');
+  }
+  if (platform === 'darwin') {
+    return path.join(home, 'Library', 'Application Support', 'ccsm');
+  }
+  const xdgData = env['XDG_DATA_HOME'];
+  if (xdgData && xdgData.length > 0) return path.join(xdgData, 'ccsm');
+  return path.join(home, '.local', 'share', 'ccsm');
+}
+
+/** Resolve the full lockfile path (`<dataRoot>/daemon.lock`). */
+export function resolveLockfilePath(opts?: {
+  readonly platform?: NodeJS.Platform;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly home?: string;
+}): string {
+  return path.join(resolveDataRoot(opts), LOCKFILE_NAME);
+}
+
+export type SpawnOrAttachResult =
+  | { readonly kind: 'attached'; readonly lockfilePath: string }
+  | { readonly kind: 'dev-no-spawn'; readonly lockfilePath: string }
+  | {
+      readonly kind: 'spawned';
+      readonly lockfilePath: string;
+      readonly child: ChildProcess;
+      readonly pid: number | undefined;
+    };
+
+export interface SpawnOrAttachOptions {
+  /** Force dev mode. Defaults to checking `process.env.CCSM_DAEMON_DEV === '1'`.
+   *  Tests pass an explicit boolean so they don't have to mutate env vars. */
+  readonly dev?: boolean;
+  /** Path resolver overrides — see {@link resolveDataRoot}. */
+  readonly platform?: NodeJS.Platform;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly home?: string;
+  /** Test seam: substitute the lockfile-existence check. Defaults to
+   *  `fs.statSync` returning truthy iff the path exists. */
+  readonly lockfileExists?: (lockPath: string) => boolean;
+  /** Callable that spawns the prod daemon binary. The caller is
+   *  responsible for resolving the binary path (Electron's
+   *  `app.getPath('exe')` + `process.resourcesPath` join). Returning
+   *  `null` means "no binary available" — the function then yields a
+   *  `dev-no-spawn` verdict so the caller falls back to reconnect loop.
+   *
+   *  Why injection: this module ships in the Electron main bundle which
+   *  is built by tsc (CommonJS). The daemon-binary path lives in
+   *  `electron/daemon/launchPaths.ts` (or similar) and importing that
+   *  here would create a circular load. Injection keeps this module a
+   *  pure leaf. */
+  readonly spawnDaemonFn?: () => ChildProcess | null;
+}
+
+const DEFAULT_LOCKFILE_EXISTS = (lockPath: string): boolean => {
+  try {
+    fs.statSync(lockPath);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    // Non-ENOENT (EACCES / EPERM / EBUSY) — surface to caller. The
+    // bridge will then fall through to spawn (which itself may fail
+    // with a clearer error) rather than masking a permissions bug.
+    throw err;
+  }
+};
+
+/**
+ * Probe + decide. This is the only export the bridge needs.
+ *
+ * The function is intentionally synchronous in its decision: the
+ * lockfile existence check is a single `statSync` (microseconds) and the
+ * spawn call is non-blocking (returns immediately with a ChildProcess
+ * handle). The READY signal — the daemon actually binding Listener A —
+ * is observed asynchronously by the bridge's Connect transport itself
+ * (it'll retry connect until ECONNREFUSED stops).
+ */
+export function spawnOrAttach(opts: SpawnOrAttachOptions = {}): SpawnOrAttachResult {
+  const lockfilePath = resolveLockfilePath(opts);
+  const exists = (opts.lockfileExists ?? DEFAULT_LOCKFILE_EXISTS)(lockfilePath);
+  if (exists) {
+    return { kind: 'attached', lockfilePath };
+  }
+  const isDev = opts.dev ?? (opts.env ?? process.env)['CCSM_DAEMON_DEV'] === '1';
+  if (isDev) {
+    // Dev mode skips spawn entirely — nodemon owns the daemon
+    // lifecycle. The bridge's auto-reconnect loop will eventually
+    // succeed once nodemon brings the daemon up.
+    return { kind: 'dev-no-spawn', lockfilePath };
+  }
+  const spawnFn = opts.spawnDaemonFn;
+  if (!spawnFn) {
+    // No prod-binary spawner injected → degrade to dev-no-spawn so the
+    // reconnect loop runs. This is the safe default when the bridge
+    // hasn't yet been wired with the bin-path resolver.
+    return { kind: 'dev-no-spawn', lockfilePath };
+  }
+  const child = spawnFn();
+  if (!child) {
+    return { kind: 'dev-no-spawn', lockfilePath };
+  }
+  return { kind: 'spawned', lockfilePath, child, pid: child.pid };
+}
+
+/**
+ * Helper for the production caller: build a `spawnDaemonFn` from a
+ * resolved binary path. Detached + unref'd so the daemon survives
+ * Electron crashing. Stderr/stdout piped to the caller's choice (default:
+ * inherited from the Electron main process so dev-mode `console.error`
+ * lines surface — prod ignores this because pkg-built daemon writes its
+ * own pino files).
+ */
+export function makeSpawnDaemonFn(opts: {
+  readonly binaryPath: string;
+  readonly args?: readonly string[];
+  readonly cwd?: string;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly stdio?: SpawnOptionsWithoutStdio['stdio'];
+  readonly spawnFn?: typeof nativeSpawn;
+}): () => ChildProcess {
+  const spawn = opts.spawnFn ?? nativeSpawn;
+  return (): ChildProcess => {
+    const child = spawn(opts.binaryPath, opts.args ? Array.from(opts.args) : [], {
+      cwd: opts.cwd,
+      env: opts.env,
+      detached: true,
+      stdio: opts.stdio ?? 'ignore',
+    });
+    // unref so Electron exit doesn't wait on the daemon. The daemon
+    // owns its own lifecycle (supervisor + lockfile cleanup).
+    if (typeof child.unref === 'function') child.unref();
+    return child;
+  };
+}

--- a/electron/daemonClient/surfaceRegistry.ts
+++ b/electron/daemonClient/surfaceRegistry.ts
@@ -1,0 +1,118 @@
+// electron/daemonClient/surfaceRegistry.ts
+//
+// Minimal surface-registry shim for the Connect-bridge layer (Task #103,
+// frag-3.5.1 §3.5.1.3 + frag-3.7 §3.7.4 + frag-6-7 §6.8 r7 trim lock).
+//
+// Purpose:
+//   The bridge layer needs ONE seat to publish "daemon connection state"
+//   into so the renderer can read it via the canonical surface registry
+//   (frag-6-7 §6.8). The full multi-priority registry (banner stacking,
+//   dedup, i18n key resolution) is owned by the renderer-side bridge
+//   (`useDaemonReconnectBridge`, frag-3.7 §3.7.4). This module is the
+//   in-main-process write seat that the bridge layer flips when the
+//   daemon socket drops / heartbeat resumes.
+//
+// Why a seat lives here (not next to the renderer):
+//   - The bridge layer (Connect-Node client) runs in Electron main, not
+//     renderer. It has no IPC channel to the renderer's surface store yet
+//     (that channel is task #110 / #115 territory, when the call sites
+//     migrate). For #103 we expose the state as an observable in main and
+//     a no-op publish hook so the future IPC bridge wires here without
+//     changing the Connect client.
+//   - The surface registry on the renderer side reads from this seat via
+//     a dedicated IPC `surface.daemonStatus` event when #110 lands. Until
+//     then this seat is consumed by tests and (read-only) by the
+//     reconnect-queue's drain logic.
+//
+// Design (per frag-6-7 §6.8 r7 lock):
+//   The §6.8 r7 trim collapsed the v0.3 daemon-related surface vocabulary
+//   to TWO slots:
+//     - `'reconnecting'` — daemon socket dropped, bridge is retrying
+//                          (priority 50 in the registry; transient banner)
+//     - `'reconnected'`  — daemon socket back; queue drained
+//                          (transient info, 3s TTL)
+//     - `'unreachable'`  — supervisor miss threshold passed; bridge gives
+//                          up retry escalation (red banner, P=70)
+//     - `'idle'`         — default; nothing to show
+//   Anything else (queueOverflow toast, devBuildError, streamGap etc.)
+//   was cut by the §6.8 r7 trim and is LOG ONLY — those slots NEVER call
+//   `setDaemonStatus`.
+//
+// Single Responsibility:
+//   - PRODUCER: `setDaemonStatus(state)` writes the slot.
+//   - DECIDER: none — the slot is a positive enum, no policy here.
+//   - SINK: subscribers are notified synchronously via a fan-out callback
+//     list. We do not own the renderer-IPC sink — that's a future task.
+
+export type DaemonSurfaceState = 'idle' | 'reconnecting' | 'reconnected' | 'unreachable';
+
+export interface DaemonSurfaceSnapshot {
+  readonly state: DaemonSurfaceState;
+  /** Wall-clock ms at which the state last changed. Useful for log
+   *  correlation + the renderer-side 250ms hold-off (frag-3.7 §3.7.4
+   *  toast UX) which suppresses transient flips so a 200ms nodemon
+   *  restart shows no surface at all. */
+  readonly changedAt: number;
+}
+
+export interface DaemonSurfaceRegistry {
+  /** Snapshot of the current state. O(1). */
+  get(): DaemonSurfaceSnapshot;
+  /** Write a new state. Idempotent: writing the same state twice is a
+   *  no-op (no `changedAt` update, no subscriber fan-out). */
+  set(state: DaemonSurfaceState): void;
+  /** Subscribe to changes. Returns an unsubscribe fn. The listener is
+   *  invoked synchronously after each `set` that actually changed the
+   *  state. NOT invoked for redundant writes. */
+  subscribe(listener: (snap: DaemonSurfaceSnapshot) => void): () => void;
+}
+
+/**
+ * Build a fresh registry. Stateless across instances; the bridge owns one
+ * per Connect client (typically a singleton per Electron main process).
+ *
+ * `now` is injected so tests can drive deterministic timestamps.
+ */
+export function createDaemonSurfaceRegistry(opts?: {
+  readonly now?: () => number;
+}): DaemonSurfaceRegistry {
+  const now = opts?.now ?? Date.now;
+  let snap: DaemonSurfaceSnapshot = { state: 'idle', changedAt: now() };
+  const listeners = new Set<(s: DaemonSurfaceSnapshot) => void>();
+  return {
+    get(): DaemonSurfaceSnapshot {
+      return snap;
+    },
+    set(state: DaemonSurfaceState): void {
+      if (state === snap.state) return;
+      snap = { state, changedAt: now() };
+      // Fan-out is synchronous so tests can assert `set → listener fired`
+      // without an async tick. If a listener throws we let it escape —
+      // the bridge wraps its own listener calls; the registry treats
+      // listener errors as caller bugs.
+      for (const l of listeners) l(snap);
+    },
+    subscribe(listener): () => void {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Module-level singleton
+// ---------------------------------------------------------------------------
+
+/**
+ * The default registry used by the Connect bridge. Lives at module scope
+ * so the bridge and any future renderer-IPC shim share one source of
+ * truth without dependency-injection plumbing through every call site.
+ *
+ * Tests that need isolation construct their own registry via
+ * `createDaemonSurfaceRegistry` and pass it to the connectClient via the
+ * `surfaceRegistry` option (see `connectClient.ts`).
+ */
+export const defaultDaemonSurfaceRegistry: DaemonSurfaceRegistry =
+  createDaemonSurfaceRegistry();

--- a/eslint-rules/no-floating-cancellation.js
+++ b/eslint-rules/no-floating-cancellation.js
@@ -1,0 +1,218 @@
+// no-floating-cancellation — custom ESLint rule for ccsm.
+//
+// Spec: docs/superpowers/specs/v0.3-fragments/frag-3.5.1-pty-hardening.md
+//   §3.5.1.3:
+//     "Handlers MUST check `signal.aborted` at every `await` boundary
+//      inside long ops; lint rule `no-floating-cancellation` (custom
+//      ESLint rule, +0.5h Task 5) flags handlers that take `signal` but
+//      never read it."
+//
+// What this rule flags:
+//   - Any function whose parameter list declares (or destructures) a
+//     parameter named `signal` MUST read it at least once. "Read" =
+//     any of:
+//       * member access      `signal.aborted` / `signal.reason`
+//       * method call        `signal.throwIfAborted()` / `addEventListener`
+//       * passed as arg      `foo(signal)`        (forwarded — the callee
+//                                                  is presumed to honor it)
+//       * spread              `{ signal }` / `[signal]`
+//       * identifier read    bare `signal` reference (assignment, return, etc.)
+//
+// What this rule does NOT flag:
+//   - Functions that destructure `{ signal }` from an unused `req` and
+//     never reference it — same logic as above (the destructure declares
+//     a binding named `signal`, must be used).
+//   - Allowlisted opt-out via the standard ESLint disable comment:
+//     `// eslint-disable-next-line ccsm-local/no-floating-cancellation`
+//   - Type-only references (TypeScript-style) are NOT counted as a read
+//     because they are erased at runtime; we only count value references.
+//   - Files outside the configured scope (set in eslint.config.js).
+//
+// Single-responsibility: this rule is a pure DECIDER over the AST. No
+// auto-fix (the fix is to write business logic that observes abort).
+//
+// Notes on AST handling:
+//   We collect the list of `signal` bindings declared by each function's
+//   parameter list (handles plain `signal`, default `signal = ...`,
+//   rest `...signal`, and destructured `{ signal }` / `{ ctx: { signal } }`).
+//   Then we walk the function body and count value-reference identifiers
+//   named `signal` that are NOT themselves the declaration.
+
+'use strict';
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Forbid handler functions that declare a `signal` parameter but never observe it. Per frag-3.5.1 §3.5.1.3, every handler taking AbortSignal must read it at some await boundary; otherwise client-side cancellation is silently dropped.',
+      recommended: false,
+    },
+    schema: [],
+    messages: {
+      unobserved:
+        '`signal` parameter declared but never observed. Per frag-3.5.1 §3.5.1.3, handlers taking AbortSignal must read it (e.g. `signal.aborted`, `signal.throwIfAborted()`, or forward to a sub-call). If this handler legitimately ignores cancellation, prefix with `// eslint-disable-next-line ccsm-local/no-floating-cancellation` and a one-line justification.',
+    },
+  },
+  create(context) {
+    /**
+     * Walk a parameter pattern node and append every Identifier named
+     * `signal` to `out`. Handles destructuring, defaults, and rest.
+     */
+    function collectSignalBindings(pattern, out) {
+      if (!pattern) return;
+      switch (pattern.type) {
+        case 'Identifier':
+          if (pattern.name === 'signal') out.push(pattern);
+          return;
+        case 'AssignmentPattern':
+          // e.g. `signal = AbortSignal.timeout(5)`
+          collectSignalBindings(pattern.left, out);
+          return;
+        case 'RestElement':
+          collectSignalBindings(pattern.argument, out);
+          return;
+        case 'ArrayPattern':
+          for (const el of pattern.elements) {
+            if (el) collectSignalBindings(el, out);
+          }
+          return;
+        case 'ObjectPattern':
+          for (const prop of pattern.properties) {
+            if (prop.type === 'RestElement') {
+              collectSignalBindings(prop.argument, out);
+            } else if (prop.type === 'Property') {
+              // For `{ signal }` (shorthand) Property.value === Identifier(signal).
+              // For `{ s: signal }` Property.value === Identifier(signal) too.
+              // Either way: walk the value side.
+              collectSignalBindings(prop.value, out);
+            }
+          }
+          return;
+        // TSParameterProperty / TSAsExpression etc. — espree doesn't emit
+        // these; @typescript-eslint/parser does. Recurse into the
+        // underlying parameter when present.
+        case 'TSParameterProperty':
+          collectSignalBindings(pattern.parameter, out);
+          return;
+        default:
+          // Unknown shape: ignore. We'd rather under-flag than false-flag.
+          return;
+      }
+    }
+
+    /** Scope-walk: collect all declared `signal` Identifier nodes in the
+     *  function's own parameter list. */
+    function paramsDeclareSignal(funcNode) {
+      const decls = [];
+      for (const p of funcNode.params) {
+        collectSignalBindings(p, decls);
+      }
+      return decls;
+    }
+
+    /** Cheap "is this Identifier node a value reference (not a declaration
+     *  and not a property key)?" heuristic. We treat the following parents
+     *  as non-references:
+     *    - the declaration itself (already filtered by node-identity)
+     *    - non-computed Property.key  (e.g. `{ signal: 1 }` — that's an
+     *      object literal key, not a reference to `signal`)
+     *    - non-computed MemberExpression.property (`obj.signal` — `signal`
+     *      is the property name, not a reference)
+     *    - LabeledStatement.label / BreakStatement.label / ContinueStatement.label
+     *  Everything else counts as a value read. */
+    function isValueReference(idNode) {
+      const parent = idNode.parent;
+      if (!parent) return true;
+      if (parent.type === 'Property' && parent.key === idNode && !parent.computed) {
+        // shorthand `{ signal }` is `Property.shorthand === true` and
+        // value === key === same Identifier — that case IS a binding,
+        // handled by the declaration set; here we'd skip it. We only
+        // reach this branch for non-shorthand `{ signal: 1 }`.
+        return parent.shorthand === true;
+      }
+      if (
+        parent.type === 'MemberExpression' &&
+        parent.property === idNode &&
+        !parent.computed
+      ) {
+        return false;
+      }
+      if (
+        (parent.type === 'LabeledStatement' ||
+          parent.type === 'BreakStatement' ||
+          parent.type === 'ContinueStatement') &&
+        parent.label === idNode
+      ) {
+        return false;
+      }
+      // ImportSpecifier 'imported' identifier (the original name) is
+      // not a runtime reference; the local binding is the runtime
+      // reference. Same for ExportSpecifier 'exported'.
+      if (parent.type === 'ImportSpecifier' && parent.imported === idNode) return false;
+      if (parent.type === 'ExportSpecifier' && parent.exported === idNode) return false;
+      return true;
+    }
+
+    /** Per-function check. We attach to every function-like AST node. */
+    function checkFunction(node) {
+      const declarations = paramsDeclareSignal(node);
+      if (declarations.length === 0) return;
+      // Build identity set of declaration nodes so we don't count the
+      // declarations themselves as references.
+      const declSet = new Set(declarations);
+      // Walk the function body (or expression body for arrow fns) and
+      // count value-references named `signal`.
+      let observed = false;
+      const body = node.body;
+      if (!body) return;
+      const visit = (n) => {
+        if (observed) return;
+        if (!n || typeof n !== 'object') return;
+        if (n.type === 'Identifier' && n.name === 'signal' && !declSet.has(n)) {
+          if (isValueReference(n)) {
+            observed = true;
+            return;
+          }
+        }
+        // Don't descend into nested function bodies — a nested function
+        // shadows our `signal` binding only if it re-declares one (which
+        // its own checkFunction call will validate). If it doesn't
+        // re-declare, the outer `signal` is closed-over and a reference
+        // there counts. Since we can't cheaply tell shadowing without a
+        // scope manager, we DESCEND but rely on the declSet identity
+        // check to avoid counting nested re-declarations as observations.
+        for (const key of Object.keys(n)) {
+          if (key === 'parent' || key === 'loc' || key === 'range') continue;
+          const v = n[key];
+          if (Array.isArray(v)) {
+            for (const item of v) visit(item);
+          } else if (v && typeof v === 'object' && typeof v.type === 'string') {
+            visit(v);
+          }
+        }
+      };
+      visit(body);
+      if (!observed) {
+        // Report on the FIRST declaration site so the squiggle is on the
+        // parameter, not deep inside the body.
+        context.report({
+          node: declarations[0],
+          messageId: 'unobserved',
+        });
+      }
+    }
+
+    return {
+      FunctionDeclaration: checkFunction,
+      FunctionExpression: checkFunction,
+      ArrowFunctionExpression: checkFunction,
+      MethodDefinition(node) {
+        // MethodDefinition wraps a FunctionExpression in node.value; the
+        // FunctionExpression visitor above handles it. No extra work here.
+        void node;
+      },
+    };
+  },
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,11 +22,16 @@ const noUppercaseCcsmPath = require('./eslint-rules/no-uppercase-ccsm-path.js');
 // validator (Check / validateFoo / planFoo / .check) as their first
 // statement.
 const noHandlerWithoutCheck = require('./eslint-rules/no-handler-without-check.js');
+// Local custom rule: no-floating-cancellation (frag-3.5.1 §3.5.1.3).
+// Connect handlers / electron bridge that take an AbortSignal must
+// observe it (read .aborted, addEventListener, or throwIfAborted).
+const noFloatingCancellation = require('./eslint-rules/no-floating-cancellation.js');
 const ccsmLocalPlugin = {
   rules: {
     'no-direct-native-import': noDirectNativeImport,
     'no-uppercase-ccsm-path': noUppercaseCcsmPath,
     'no-handler-without-check': noHandlerWithoutCheck,
+    'no-floating-cancellation': noFloatingCancellation,
   },
 };
 
@@ -194,8 +199,32 @@ export default [
         global: 'readonly',
         fetch: 'readonly',
         Response: 'readonly',
+        Headers: 'readonly',
         URLSearchParams: 'readonly'
       }
     }
+  },
+  {
+    // ccsm-local/no-floating-cancellation — applied to:
+    //   - daemon-side Connect handlers (frag-3.5.1 §3.5.1.3 reviewer
+    //     acceptance: every handler taking `signal` must read it).
+    //   - electron-side Connect bridge (defense-in-depth: the bridge
+    //     itself threads signals; if a future call site wraps a handler
+    //     and shadows the param without observing it, this rule catches).
+    //
+    // Scoped to those directories rather than globally because most
+    // codebase code legitimately ignores aborts (UI event handlers,
+    // pure transforms, etc.) and a global policy would force pervasive
+    // disable comments.
+    files: [
+      'daemon/src/handlers/**/*.ts',
+      'electron/daemonClient/**/*.ts',
+    ],
+    plugins: {
+      'ccsm-local': ccsmLocalPlugin,
+    },
+    rules: {
+      'ccsm-local/no-floating-cancellation': 'error',
+    },
   }
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.119",
         "@bufbuild/protobuf": "^2.12.0",
+        "@connectrpc/connect": "^2.1.1",
+        "@connectrpc/connect-node": "^2.1.1",
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/sortable": "^8.0.0",
         "@dnd-kit/utilities": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.119",
     "@bufbuild/protobuf": "^2.12.0",
+    "@connectrpc/connect": "^2.1.1",
+    "@connectrpc/connect-node": "^2.1.1",
     "@dnd-kit/core": "^6.1.0",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",


### PR DESCRIPTION
## Summary

Ports the Electron-side data-plane client to Connect-Node over Listener A
(POSIX UDS / Win named pipe). Coexists with the envelope `rpcClient.ts` —
call sites flip in #105 / #106 / #108; envelope data plane is removed by
#115.

### New files (`electron/daemonClient/`)

- `connectClient.ts` — `createConnectTransport({ httpVersion: '2', nodeOptions: { createConnection } })` over Listener A. Auto-reconnect (200/400/800/1600/3200/5000ms ±25% jitter, frag-3.7 §3.7.4); per-method timeout map; AbortSignal.any merge; surface-registry publish; `onDisconnected`/`onReconnected` hooks for §3.7.5 stream resubscribe.
- `reconnectQueue.ts` — bounded FIFO (100 prod / 1000 dev), oldest-evict on overflow with `Error('daemon-reconnect-queue-overflow')`, FIFO drain on reconnect.
- `spawnOrAttach.ts` — lockfile probe; attach-if-alive; dev-mode skips spawn (delegates to nodemon, frag-3.7 §3.7.2.b); prod spawns via injected fn.
- `bridgeTimeout.ts` — `BridgeTimeoutError { code: 'DEADLINE_EXCEEDED', method, timeoutMs, traceId }` (NEVER user-surfaced per round-3 lock); `anyAbortSignal()` ponyfill (Node 20.3+ native, polyfill fallback); `createTimeoutMap()` per-call deadline tracker with `leakedSince()` for `handler.leaked.count`.
- `surfaceRegistry.ts` — in-main daemon-status seat (`idle` / `reconnecting` / `reconnected` / `unreachable`, frag-6-7 §6.8 r7 trim).

### ESLint

- `eslint-rules/no-floating-cancellation.js` — flags handlers declaring a `signal` param but never reading it (frag-3.5.1 §3.5.1.3 reviewer acceptance criterion).
- `eslint.config.js` — wires the rule for `daemon/src/handlers/**` + `electron/daemonClient/**`; adds `Headers` global to Node block.

### Replaced semantics

`rpcClient.ts` (envelope) is **NOT removed** (per task brief — coexistence until #115). Header JSDoc now says `@deprecated; use connectClient.ts; removal tracked in #115`.

### 8 deliverables checklist

- [x] (1) `connectClient.ts` — Connect-Node over Listener A
- [x] (2) `reconnectQueue.ts` — frag-3.7 dev workflow queue
- [x] (3) `spawnOrAttach.ts` — frag-3.7 lockfile probe
- [x] (4) Unit tests for reconnect / queue drain (12 cases in `reconnectQueue.test.ts`)
- [x] (5) `BridgeTimeoutError` class (frag-3.5.1 §3.5.1.3)
- [x] (6) `AbortSignal.any` combiner (`anyAbortSignal`)
- [x] (7) Per-call timeout map (`createTimeoutMap`)
- [x] (8) `handler.leaked.count` counter (timeoutMap.leakedSince)
- [x] (9) Surface-registry `'reconnecting'` rewire on socket drop
- [x] (10) ESLint custom rule `no-floating-cancellation` wired to `eslint.config.js`

### Test plan

- [x] `npm run lint` — 0 errors (127 pre-existing warnings)
- [x] `npx tsc --noEmit -p tsconfig.electron.json` — clean
- [x] `npx tsc --noEmit -p daemon/tsconfig.json` — clean
- [x] `npx vitest run electron/daemonClient/__tests__/` — **99/99 green**
- [x] CommonJS require-load smoke for all 5 new modules — OK (no `ERR_REQUIRE_ESM`)
- [ ] `npx vitest run` full suite — pre-existing better-sqlite3 ABI mismatch failures in env (NODE_MODULE_VERSION 145 vs 137); unrelated to this PR. The 99 tests in this PR all pass.

### Unblocks

#105 (SQLite Connect handlers), #106 (SessionWatcher Connect), #108 (PTY Connect), #110 (thin client flip验收), #115 (envelope 数据面 cleanup).