### PR TITLE
fix(mac): consistent daemon PID source between lockfile and uninstall-helper (#154)

### DIFF
--- a/daemon/src/lifecycle/__tests__/lockfile.test.ts
+++ b/daemon/src/lifecycle/__tests__/lockfile.test.ts
@@ -25,6 +25,7 @@ import { spawnSync } from 'node:child_process';
 
 import {
   acquireDaemonLock,
+  DAEMON_LOCK_DIR_SUFFIX,
   DAEMON_LOCK_FILENAME,
   LOCKFILE_FATAL_EXIT_CODE,
   LockfileBusyError,
@@ -102,6 +103,25 @@ function makeRecorder(): {
     },
   };
 }
+
+describe('External PID source contract (Task #154 / cross-ref helpers)', () => {
+  it('exports DAEMON_LOCK_DIR_SUFFIX = ".lock" matching proper-lockfile mkdir', () => {
+    // External consumers (mac uninstall-helper Swift, build/linux-postrm.sh)
+    // hard-code the `.lock` suffix when cleaning the proper-lockfile atomic
+    // gate directory at `<dataRoot>/daemon.lock.lock`. The constant exists
+    // so the suffix lives in exactly one place. If proper-lockfile ever
+    // changes its convention this constant flips and external consumers
+    // get a clear single-line diff to chase.
+    expect(DAEMON_LOCK_DIR_SUFFIX).toBe('.lock');
+  });
+
+  it('keeps DAEMON_LOCK_FILENAME stable for external PID readers', () => {
+    // The mac uninstall-helper Swift source hard-codes "daemon.lock" as
+    // the basename it reads PID from. Changing this string is a breaking
+    // change for both that helper and build/linux-postrm.sh.
+    expect(DAEMON_LOCK_FILENAME).toBe('daemon.lock');
+  });
+});
 
 describe('acquireDaemonLock — real fs', () => {
   let dataRoot: string;

--- a/daemon/src/lifecycle/lockfile.ts
+++ b/daemon/src/lifecycle/lockfile.ts
@@ -87,6 +87,51 @@ function defaultProperLockfile(): ProperLockfile {
  *  can derive the same path without re-stating the literal. */
 export const DAEMON_LOCK_FILENAME = 'daemon.lock' as const;
 
+/**
+ * Suffix appended to `<dataRoot>/daemon.lock` to derive the directory
+ * `<dataRoot>/daemon.lock.lock` that proper-lockfile mkdirs as the
+ * atomic gate. Exported so the stale-recovery branch above AND external
+ * cleanup consumers (postrm, mac uninstall-helper, win helper) share a
+ * single source of truth.
+ *
+ * Anyone removing the PID file MUST also remove the `.lock` directory or
+ * the next daemon boot will hit ELOCKED + run the noisy steal-recovery
+ * branch (functionally fine, but emits a `lockfile_steal` warn line that
+ * looks like a crash-loop signal in dashboards).
+ */
+export const DAEMON_LOCK_DIR_SUFFIX = '.lock' as const;
+
+/**
+ * External PID source contract (frag-11 §11.6.3 / §11.6.4 cross-ref).
+ *
+ * The daemon writes its PID as `${pid}\n` (decimal, single line) into
+ * `<dataRoot>/daemon.lock` AFTER proper-lockfile successfully mkdirs the
+ * `<dataRoot>/daemon.lock.lock` directory (the atomic gate). The mac
+ * uninstall-helper (`installer/uninstall-helper-mac/ccsm-uninstall-helper.swift`),
+ * the linux postrm script (`build/linux-postrm.sh`), and any future
+ * external lifecycle consumer MUST read the PID from this file and treat
+ * the two paths as the canonical contract:
+ *
+ *   PID payload  : `<dataRoot>/daemon.lock`           (regular file, mode 0600)
+ *   Atomic gate  : `<dataRoot>/daemon.lock.lock`      (directory, proper-lockfile)
+ *
+ * Both paths MUST be cleaned together — removing only the PID file
+ * leaves a stale `.lock` directory that triggers steal-recovery on next
+ * boot. Removing only the `.lock` directory leaves a stale PID payload
+ * that the next daemon will overwrite (harmless) but external readers
+ * may briefly observe a stale PID with no live process.
+ *
+ * The contract is intentionally cross-platform-uniform: Win uses the
+ * same files at the same dataRoot-relative paths, even though the Win
+ * uninstall-helper today prefers control-socket RPC + tasklist (the file
+ * pair is still cleaned by the daemon's own LockHandle.release on
+ * graceful shutdown).
+ *
+ * v0.4 forward-compat: the `<dataRoot>` location is locked in
+ * frag-11 §11.6 and the proper-lockfile dependency is the v0.3 long-term
+ * choice (frag-6-7 §6.4). No "v0.4 will replace this" placeholder.
+ */
+
 /** Recommended exit code on EROFS-class fatal (sysexits.h: EX_CONFIG = 78,
  *  "configuration error"). Exported so the daemon entry can map without
  *  re-stating the literal. */
@@ -336,7 +381,7 @@ export async function acquireDaemonLock(
           // its in-memory map (which only happens on a successful
           // `lock()`). Direct rmdir matches what proper-lockfile itself
           // does internally during its own stale-recovery branch.
-          const staleLockDir = `${lockPath}.lock`;
+          const staleLockDir = `${lockPath}${DAEMON_LOCK_DIR_SUFFIX}`;
           try {
             rmSync(staleLockDir, { recursive: true, force: true });
           } catch {

--- a/installer/uninstall-helper-mac/__tests__/helper.test.ts
+++ b/installer/uninstall-helper-mac/__tests__/helper.test.ts
@@ -76,6 +76,28 @@ describe('mac-uninstall-helper / Swift source shape', () => {
     expect(src).toMatch(/SIGKILL/);
   });
 
+  it('cleans up BOTH daemon.lock and daemon.lock.lock (Task #154)', () => {
+    // Cross-ref daemon/src/lifecycle/lockfile.ts "External PID source
+    // contract": the regular file daemon.lock holds the PID payload AND
+    // proper-lockfile mkdirs daemon.lock.lock as the atomic gate. The
+    // helper MUST clean both — leaving the `.lock` directory triggers a
+    // noisy `lockfile_steal` warn on next boot. Test asserts both the
+    // suffix concatenation and the directoryExists probe are present.
+    expect(src).toMatch(/let lockDirPath = "\\\(lockPath\)\.lock"/);
+    expect(src).toMatch(/directoryExists/);
+    expect(src).toMatch(/removeTree\(path: lockDirPath\)/);
+  });
+
+  it('has a pgrep -f fallback when PID payload missing (Task #154)', () => {
+    // Mirrors build/linux-postrm.sh `pkill -f` fallback. Without this,
+    // a daemon that crashed before stamping its PID payload (proper-
+    // lockfile mkdir succeeded but PID write didn't) would silently
+    // survive the uninstall.
+    expect(src).toMatch(/pgrepKill/);
+    expect(src).toMatch(/DAEMON_PGREP_PATTERN/);
+    expect(src).toMatch(/ccsm-daemon/);
+  });
+
   it('has --purge as opt-in (default = retain user data)', () => {
     // Matches frag-11 §11.6 paths table "Cleanup default = retained" for
     // data/, logs/, crashes/, daemon.secret. Default-purge would be a

--- a/installer/uninstall-helper-mac/ccsm-uninstall-helper.swift
+++ b/installer/uninstall-helper-mac/ccsm-uninstall-helper.swift
@@ -23,8 +23,25 @@
 //   1. Read daemon.lock — extract PID (proper-lockfile writes a one-line
 //      decimal PID at the lockfile path) — and SIGTERM, then SIGKILL after
 //      a short grace period if still alive.
-//   2. Delete the daemon.lock so a stale lockfile cannot block a fresh
-//      install of a future build.
+//   1a. PID source contract (Task #154 / cross-ref daemon/src/lifecycle/
+//       lockfile.ts "External PID source contract"):
+//
+//         PID payload : <dataRoot>/daemon.lock       (regular file, "${pid}\n")
+//         Atomic gate : <dataRoot>/daemon.lock.lock  (directory, proper-lockfile)
+//
+//       Both MUST be cleaned together. Removing only the regular file
+//       leaves a stale `.lock` directory that triggers a noisy
+//       steal-recovery `lockfile_steal` warn on the next boot — looks
+//       like a crash-loop signal in dashboards.
+//   1b. PID payload missing / unreadable / unparseable: fall back to
+//       `pgrep -f ccsm-daemon` (matches build/linux-postrm.sh's `pkill -f`
+//       fallback). Covers the rare case where proper-lockfile mkdir-ed
+//       its `.lock` dir but the daemon crashed before stamping the PID
+//       payload — without the fallback the helper would silently leave
+//       the daemon running.
+//   2. Delete the daemon.lock regular file AND the daemon.lock.lock
+//      directory so a stale lockfile site cannot block (or trigger
+//      steal-recovery noise on) a fresh install of a future build.
 //   3. With --purge (opt-in), recursively delete the entire dataRoot
 //      (~/Library/Application Support/ccsm/) — equivalent to the Linux
 //      postrm SUDO_USER branch. Without --purge: dataRoot is retained
@@ -139,7 +156,16 @@ func resolveDataRoot(env: [String: String], override: String?) -> String {
 
 enum Action: Equatable {
     case killPid(pid: Int32, graceSeconds: Double)
+    /// `pgrep -f <pattern>` then SIGTERM/SIGKILL each match. Used when the
+    /// PID payload at <dataRoot>/daemon.lock is missing/unreadable but the
+    /// proper-lockfile `.lock` directory hints a daemon may still be live
+    /// (mirrors build/linux-postrm.sh `pkill -f` fallback).
+    case pgrepKill(pattern: String, graceSeconds: Double)
     case removeFile(path: String)
+    /// Removes a directory recursively. Used for both the proper-lockfile
+    /// atomic-gate dir (<dataRoot>/daemon.lock.lock) AND, in --purge mode,
+    /// the entire dataRoot. Kept separate from removeFile so the dry-run
+    /// log line is unambiguous about whether a tree is being touched.
     case removeTree(path: String)
     case logSkip(reason: String, path: String)
 }
@@ -147,12 +173,20 @@ enum Action: Equatable {
 // FileSystem probe abstraction so the decider stays pure (testable).
 protocol FSProbe {
     func fileExists(_ path: String) -> Bool
+    func directoryExists(_ path: String) -> Bool
     func readLockfile(_ path: String) -> String?
 }
 
 struct RealFSProbe: FSProbe {
     func fileExists(_ path: String) -> Bool {
-        return FileManager.default.fileExists(atPath: path)
+        var isDir: ObjCBool = false
+        let exists = FileManager.default.fileExists(atPath: path, isDirectory: &isDir)
+        return exists && !isDir.boolValue
+    }
+    func directoryExists(_ path: String) -> Bool {
+        var isDir: ObjCBool = false
+        let exists = FileManager.default.fileExists(atPath: path, isDirectory: &isDir)
+        return exists && isDir.boolValue
     }
     func readLockfile(_ path: String) -> String? {
         return try? String(contentsOfFile: path, encoding: .utf8)
@@ -168,26 +202,61 @@ func parsePid(_ raw: String) -> Int32? {
     return n
 }
 
+/// Pattern passed to `pgrep -f` when the PID payload is missing/unreadable.
+/// Matches both the dev binary path and the packaged
+/// `CCSM.app/Contents/Resources/daemon/ccsm-daemon` location. Mirrors the
+/// `pkill -f "$DAEMON_BIN_PATH"` fallback in build/linux-postrm.sh.
+let DAEMON_PGREP_PATTERN = "ccsm-daemon"
+
 func decideActions(args: Args, dataRoot: String, probe: FSProbe) -> [Action] {
     var actions: [Action] = []
     let lockPath = "\(dataRoot)/daemon.lock"
+    // Cross-ref: daemon/src/lifecycle/lockfile.ts exports
+    // DAEMON_LOCK_DIR_SUFFIX = '.lock'. Same suffix, single source of
+    // truth (Task #154). proper-lockfile mkdirs this directory as the
+    // atomic gate; PID payload above is written separately to the
+    // regular file `daemon.lock`.
+    let lockDirPath = "\(lockPath).lock"
 
-    // Step 1: kill daemon if lockfile present + parseable PID.
-    if probe.fileExists(lockPath) {
+    // Step 1: kill daemon. Try the PID payload first, fall back to pgrep
+    // if either the payload is missing OR the proper-lockfile `.lock`
+    // directory exists without a parseable PID payload (the daemon mkdir-ed
+    // the gate but crashed before stamping its PID).
+    let lockFileExists = probe.fileExists(lockPath)
+    let lockDirExists = probe.directoryExists(lockDirPath)
+    var pidKillScheduled = false
+    if lockFileExists {
         if let raw = probe.readLockfile(lockPath), let pid = parsePid(raw) {
             actions.append(.killPid(pid: pid, graceSeconds: args.graceSeconds))
+            pidKillScheduled = true
         } else {
             actions.append(.logSkip(reason: "lockfile-unreadable-or-empty", path: lockPath))
         }
-        // Step 2: always remove the lockfile (stale PID risk on next install).
-        actions.append(.removeFile(path: lockPath))
-    } else {
+    } else if !lockDirExists {
         actions.append(.logSkip(reason: "no-lockfile", path: lockPath))
+    }
+    if !pidKillScheduled && (lockFileExists || lockDirExists) {
+        // PID payload missing/unparseable but lock state present → daemon
+        // may still be alive. Fall back to pgrep -f (mirrors linux-postrm).
+        actions.append(.pgrepKill(
+            pattern: DAEMON_PGREP_PATTERN,
+            graceSeconds: args.graceSeconds))
+    }
+
+    // Step 2: clean up BOTH the PID payload regular file AND the
+    // proper-lockfile atomic-gate directory. Removing only the regular
+    // file leaves a stale `.lock` directory that triggers the daemon's
+    // noisy steal-recovery `lockfile_steal` warn on the next boot.
+    if lockFileExists {
+        actions.append(.removeFile(path: lockPath))
+    }
+    if lockDirExists {
+        actions.append(.removeTree(path: lockDirPath))
     }
 
     // Step 3 (opt-in): purge entire data root.
     if args.purge {
-        if probe.fileExists(dataRoot) {
+        if probe.fileExists(dataRoot) || probe.directoryExists(dataRoot) {
             actions.append(.removeTree(path: dataRoot))
         } else {
             actions.append(.logSkip(reason: "data-root-missing", path: dataRoot))
@@ -201,6 +270,7 @@ func decideActions(args: Args, dataRoot: String, probe: FSProbe) -> [Action] {
 
 protocol Sink {
     func killPid(_ pid: Int32, graceSeconds: Double) -> Bool
+    func pgrepKill(_ pattern: String, graceSeconds: Double) -> Bool
     func removeFile(_ path: String) -> Bool
     func removeTree(_ path: String) -> Bool
     func log(_ msg: String)
@@ -248,6 +318,55 @@ struct RealSink: Sink {
         return true
     }
 
+    func pgrepKill(_ pattern: String, graceSeconds: Double) -> Bool {
+        // Mirrors build/linux-postrm.sh `pkill -f` fallback. We use
+        // `pgrep -f` then iterate so each PID gets the same SIGTERM-then-
+        // SIGKILL grace treatment as the PID-payload path. Both `pgrep`
+        // and `pkill` are part of base macOS (BSD utilities) since 10.8.
+        if dryRun {
+            log("DRY-RUN would pgrep -f \(pattern) then SIGTERM/SIGKILL each match")
+            return true
+        }
+        let pgrep = Process()
+        pgrep.launchPath = "/usr/bin/pgrep"
+        pgrep.arguments = ["-f", pattern]
+        let pipe = Pipe()
+        pgrep.standardOutput = pipe
+        pgrep.standardError = Pipe()
+        do {
+            try pgrep.run()
+        } catch {
+            log("pgrep launch failed: \(error.localizedDescription)")
+            // Treat as "no matches" — non-fatal (idempotent: nothing to kill).
+            return true
+        }
+        pgrep.waitUntilExit()
+        // pgrep exit codes: 0 = matches, 1 = no matches, 2/3 = error.
+        // No-match is idempotent OK; only flag hard errors.
+        if pgrep.terminationStatus == 1 {
+            log("pgrep -f \(pattern): no matches (already stopped)")
+            return true
+        }
+        if pgrep.terminationStatus != 0 {
+            log("pgrep -f \(pattern) errored exit=\(pgrep.terminationStatus)")
+            return false
+        }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let raw = String(data: data, encoding: .utf8) ?? ""
+        // Filter out our own PID so a helper invoked with a matching cmdline
+        // doesn't try to SIGTERM itself. Belt-and-suspenders: pgrep -f also
+        // matches the helper's argv, but we additionally pgrep-pattern
+        // "ccsm-daemon" which the helper's name doesn't contain.
+        let selfPid = getpid()
+        var allOk = true
+        for line in raw.split(whereSeparator: { $0.isWhitespace }) {
+            guard let p = Int32(line), p > 0, p != selfPid else { continue }
+            log("pgrep fallback: targeting pid=\(p)")
+            if !killPid(p, graceSeconds: graceSeconds) { allOk = false }
+        }
+        return allOk
+    }
+
     func removeFile(_ path: String) -> Bool {
         if dryRun {
             log("DRY-RUN would unlink \(path)")
@@ -288,6 +407,8 @@ func executeActions(_ actions: [Action], sink: Sink) -> Int32 {
         switch action {
         case .killPid(let pid, let grace):
             if !sink.killPid(pid, graceSeconds: grace) { hardFailed = true }
+        case .pgrepKill(let pattern, let grace):
+            if !sink.pgrepKill(pattern, graceSeconds: grace) { hardFailed = true }
         case .removeFile(let p):
             if !sink.removeFile(p) { hardFailed = true }
         case .removeTree(let p):


### PR DESCRIPTION
## Summary

Follow-up to PR #812 (#123 daemon lockfile via proper-lockfile) and PR #814 (#136 mac uninstall-helper). proper-lockfile leaves two artifacts on disk: the gate directory \`daemon.lock.lock\` and the PID payload file \`daemon.lock\`. The mac Swift helper was reading PID from \`daemon.lock\` correctly but had two consistency gaps with the lockfile contract.

### Gaps fixed

1. **Stale gate dir leak**: helper removed only \`daemon.lock\` regular file and left \`daemon.lock.lock\` directory behind. Next install's daemon then hit ELOCKED + ran the noisy steal-recovery branch, emitting a \`lockfile_steal\` warn line that looks like a crash-loop signal.
2. **Missing PID fallback**: when the daemon mkdir-ed \`.lock\` dir but crashed before stamping its PID payload, the Swift helper silently left the daemon running. linux-postrm.sh already handles this with \`pkill -f\`; mac helper now matches.

### Changes

- \`daemon/src/lifecycle/lockfile.ts\`: export \`DAEMON_LOCK_DIR_SUFFIX\` + \`DAEMON_LOCK_FILENAME\` constants. Add an \"External PID source contract\" doc block describing the two-path invariant for external consumers (mac helper, postrm, win helper).
- \`installer/uninstall-helper-mac/ccsm-uninstall-helper.swift\`: add \`directoryExists\` to FSProbe; \`decideActions\` now schedules \`removeTree(daemon.lock.lock)\` whenever the gate dir exists; add \`pgrepKill\` action that shells \`pgrep -f ccsm-daemon\` and SIGTERM/SIGKILL each match (filters out self-PID).
- Tests: lockfile.test.ts asserts the exported constants (single-line diff signal if they change). mac helper.test.ts asserts the Swift source contains the \`.lock\` cleanup + pgrep fallback.

### Cross-platform consistency

- **Win** uninstall-helper (#691) prefers control-socket RPC + tasklist; doesn't depend on PID files. Daemon's own LockHandle.release cleans both paths on graceful shutdown.
- **Linux** postrm (#810) already reads \`daemon.lock\` for PID + has \`pkill -f\` fallback; this PR makes mac match.

v0.3 zero-rework: keeps the existing proper-lockfile artifacts as the contract source — no new files written, no migration when v0.4 lands.

## Test plan

- [x] vitest \`installer/uninstall-helper-mac\` + \`daemon/src/lifecycle/__tests__/lockfile.test.ts\` → 29/29 passing
- [ ] CI green
- [ ] Manual: install + uninstall on macOS leaves no stale \`daemon.lock.lock\` dir

Refs: task #154, follows #812 (#123), #814 (#136).