### PR TITLE
fix(ci): unblock vitest config from std-env ESM

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,5 +1,11 @@
 import { defineConfig } from 'vitest/config';
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// ESM equivalent of __dirname — required because this file is loaded as ESM
+// (`.mts`) so vitest's config loader can resolve ESM-only deps such as
+// `std-env` (pulled in transitively by vitest 4.x / pino).
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   resolve: {


### PR DESCRIPTION
## Root cause
vitest 4.x's config loader pulls `std-env` (ESM-only) through its transitive dep graph; loading `vitest.config.ts` as CJS triggered `ERR_REQUIRE_ESM` on every `lint + typecheck + test` job across all platforms.

## Fix
Rename `vitest.config.ts` -> `vitest.config.mts` so the loader imports it as ESM (vitest auto-detects `.mts`). `__dirname` is replaced with the standard `import.meta.url` + `fileURLToPath` idiom so the proto-gen path aliases keep resolving identically. Smallest blast radius — no `"type": "module"` flip, no dep pin, no production code touched.

## Unblocks
PR #819, PR #820, and any future branch off `working`.

## Local verification
- `npx vitest run daemon/src/envelope/` -> 220 passed (config loads without ERR_REQUIRE_ESM)
- `npm run lint` -> only pre-existing `daemon/src/index.ts` `resolveDataRoot` redeclare error remains (unrelated, baseline on `working`)
- `npm run typecheck` -> same pre-existing baseline error in `daemon/src/index.ts`

Task #155.