### PR TITLE
fix(daemon): remove duplicate resolveDataRoot import (P0 unblock CI)

### DIFF
--- a/daemon/src/index.ts
+++ b/daemon/src/index.ts
@@ -21,7 +21,6 @@ import {
   LOCKFILE_FATAL_EXIT_CODE,
   type LockHandle,
 } from './lifecycle/lockfile.js';
-import { resolveDataRoot } from './db/ensure-data-dir.js';
 import {
   createShutdownDrain,
   type ShutdownDriver,


### PR DESCRIPTION
Removes duplicate import causing no-redeclare lint error + TS2300 on `working`. Unblocks PR #819, #820, #821, #822, #823.