### PR TITLE
fix(ci): pin @exodus/bytes to last CJS version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2375,24 +2375,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@exodus/bytes": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
-      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@noble/hashes": "^1.8.0 || ^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@noble/hashes": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@fastify/otel": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/@fastify/otel/-/otel-0.18.0.tgz",
@@ -12475,6 +12457,24 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-encoding-sniffer/node_modules/@exodus/bytes": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.13.0.tgz",
+      "integrity": "sha512-VnfL2lS43Z9F8li1faMH9hDZwqfrF5JvOePmrF8oESfo0ijaujnT81zYtienQRpoFa+FJbq0E5rrnMWEW73gOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -13772,6 +13772,24 @@
       },
       "peerDependenciesMeta": {
         "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/@exodus/bytes": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.13.0.tgz",
+      "integrity": "sha512-VnfL2lS43Z9F8li1faMH9hDZwqfrF5JvOePmrF8oESfo0ijaujnT81zYtienQRpoFa+FJbq0E5rrnMWEW73gOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
           "optional": true
         }
       }
@@ -20613,6 +20631,24 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/whatwg-url/node_modules/@exodus/bytes": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.13.0.tgz",
+      "integrity": "sha512-VnfL2lS43Z9F8li1faMH9hDZwqfrF5JvOePmrF8oESfo0ijaujnT81zYtienQRpoFa+FJbq0E5rrnMWEW73gOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -143,6 +143,9 @@
     "webpack-cli": "^6.0.1",
     "webpack-dev-server": "^5.2.0"
   },
+  "overrides": {
+    "@exodus/bytes": "1.13.0"
+  },
   "build": {
     "appId": "com.ccsm.app",
     "productName": "CCSM",


### PR DESCRIPTION
Root cause: @exodus/bytes 1.14.0+ went ESM-only. html-encoding-sniffer (jsdom transitive) does require() of it -> ERR_REQUIRE_ESM -> vitest worker fails to start. Pinning via npm overrides until upstream is fixed.