### PR TITLE
fix(ci): vitest pool=threads (#174 Plan E)

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -16,6 +16,19 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
+    // Force threads pool (#174 Plan E): the default `forks` pool spawns
+    // child Node processes that re-import every transitive dep. Under
+    // Node 22 strict require, html-encoding-sniffer (ESM, pulled in via
+    // @exodus/bytes) blows up at worker boot. `threads` runs tests in
+    // worker_threads inside the parent process which already has the
+    // ESM module graph wired up, dodging the strict-require error.
+    pool: 'threads',
+    poolOptions: {
+      threads: {
+        singleThread: false,
+        isolate: true,
+      },
+    },
     include: [
       'tests/**/*.test.ts',
       'tests/**/*.test.tsx',


### PR DESCRIPTION
## Summary
- Force vitest `pool: 'threads'` (was default `forks`) to dodge `html-encoding-sniffer` ESM strict-require error under Node 22 CI workers.
- Threads pool runs tests in `worker_threads` inside the parent vitest process — the ESM module graph is already wired by Vite's loader, so the strict-require boundary that breaks `forks` does not apply.

## Why forks broke
Vitest 4.x defaults to `forks`, which spawns child Node processes per worker. Each child re-imports the full transitive dep graph. Under Node 22's stricter `require(esm)` rules, `html-encoding-sniffer` (ESM-only, pulled in via `@exodus/bytes` -> jsdom's whatwg-encoding) throws `ERR_REQUIRE_ESM` at worker boot, killing every test file.

## Test plan
- [x] Local `npx vitest run` on Node 22: 0 ESM errors. (Remaining failures are unrelated `better-sqlite3` ABI mismatch on dev box; CI rebuilds native modules.)
- [ ] CI green on this PR.

Refs #174.