### PR TITLE
fix(ci): vitest deps.inline @exodus/bytes (#173 Plan F)

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -14,8 +14,18 @@ export default defineConfig({
       '@ccsm/proto-gen': path.resolve(__dirname, 'gen/ts/index.ts'),
     },
   },
+  // Pre-bundle ESM-only deps as CJS so the jsdom transitive `require()`
+  // chain (jsdom → html-encoding-sniffer → @exodus/bytes etc.) doesn't
+  // hit `ERR_REQUIRE_ESM` under Node 22. See task #173 / Plan F.
+  // In Vitest 3+/4.x this lives at `test.server.deps.inline` (the old
+  // top-level `deps.inline` is deprecated).
   test: {
     environment: 'jsdom',
+    server: {
+      deps: {
+        inline: ['@exodus/bytes', 'html-encoding-sniffer'],
+      },
+    },
     include: [
       'tests/**/*.test.ts',
       'tests/**/*.test.tsx',


### PR DESCRIPTION
## Summary
- Adds `test.server.deps.inline` for `@exodus/bytes` and `html-encoding-sniffer` so vitest pre-bundles these ESM-only deps as CJS, avoiding `ERR_REQUIRE_ESM` from the jsdom transitive `require()` chain under Node 22.
- Task #173 / Plan F. CI was broken by `@exodus/bytes` ESM being `require()`-d by `html-encoding-sniffer` -> `whatwg-encoding` -> jsdom under Node 22.

## Test plan
- [x] Local `npx vitest run`: zero `ERR_REQUIRE_ESM` / `@exodus/bytes` / `html-encoding-sniffer` errors. Remaining failures (57) are unrelated `better-sqlite3` native-module ABI mismatch on local box (Node 24 vs binary built for Node 22) and do not occur in CI.
- [ ] CI green on `fix/v03-vitest-deps-optimizer`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>