### PR TITLE
ci: add 10min job timeout to all workflows except release.build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-    timeout-minutes: 20
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/main-source-guard.yml
+++ b/.github/workflows/main-source-guard.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   check-source:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Reject non-working source
         run: |

--- a/.github/workflows/pr-no-silent-drops.yml
+++ b/.github/workflows/pr-no-silent-drops.yml
@@ -30,6 +30,7 @@ permissions:
 jobs:
   no-silent-drops:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout PR head with full history
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
   verify:
     name: lint + typecheck + test
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- Adds job-level `timeout-minutes: 10` to `ci.yml`, `main-source-guard.yml`, `pr-no-silent-drops.yml`, and `release.yml`'s `verify` job
- Lowers `e2e.yml` from 20min → 10min
- `release.yml`'s `build` job (Electron 3-platform packaging) is intentionally left untouched — 10min unlikely to be enough

## Why
Previously only `e2e` had an explicit timeout. A hung job on the other 4 workflows could burn the GitHub default (6h) before being killed.

## Test plan
- [ ] CI green on this PR
- [ ] Confirm no in-flight job legitimately runs >10min

🤖 Generated with [Claude Code](https://claude.com/claude-code)