### PR TITLE
ci: drop docs/** and **.md from paths-ignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches: [main, working]
     paths-ignore:
-      - '**.md'
-      - 'docs/**'
       - 'LICENSE'
       - '.gitignore'
   workflow_dispatch:


### PR DESCRIPTION
## Problem

`.github/workflows/ci.yml` had `paths-ignore` covering `**.md` and `docs/**`, so docs-only PRs do **not** trigger the `lint + typecheck + test (ubuntu/macos/windows)` jobs.

But branch protection on `working` lists those exact contexts as **required status checks** with `enforce_admins=true`. When a required context never reports, GitHub treats it as missing, not as "skipped success" — so a docs-only PR is permanently un-mergeable, and admins cannot override.

PR #843 (pure docs deletion) is currently stuck in this deadlock.

## Fix

Drop `'**.md'` and `'docs/**'` from `paths-ignore`. CI now runs on docs PRs too — turnaround is a few seconds with caches warm, and it eliminates the structural deadlock.

`'LICENSE'` and `'.gitignore'` are kept since changes there genuinely don't need full CI and are not common enough to deadlock real PRs.

## Diff

```yaml
     paths-ignore:
-      - '**.md'
-      - 'docs/**'
       - 'LICENSE'
       - '.gitignore'
```

Refs: PR #843