### PR TITLE
ci: use paths-filter so docs-only PRs auto-pass required checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [main, working]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'LICENSE'
-      - '.gitignore'
   workflow_dispatch:
 
 concurrency:
@@ -18,8 +13,27 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '!docs/**'
+              - '!**.md'
+              - '!LICENSE'
+              - '!.gitignore'
+
   lint-typecheck-test:
     name: lint + typecheck + test (${{ matrix.os }})
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Problem

The current \`ci.yml\` uses top-level \`paths-ignore\` to skip CI on docs-only PRs:

\`\`\`yaml
on:
  pull_request:
    paths-ignore:
      - '**.md'
      - 'docs/**'
      - 'LICENSE'
      - '.gitignore'
\`\`\`

This causes a **branch protection deadlock** for docs-only PRs (see #843):

- GitHub's \`paths-ignore\` prevents the workflow from being **triggered at all**.
- Required status checks listed in branch protection (\`lint + typecheck + test (ubuntu-latest)\` etc.) therefore **never appear** on the PR.
- Branch protection waits forever for checks that will never be reported → PR cannot be merged.

This is GitHub's documented behavior: a job skipped via \`if:\` reports status \`Success\` and satisfies required checks, but a workflow that's never triggered produces no checks at all.

## Fix

Standard pattern used by Kubernetes, Next.js, and the GitHub Docs repo:

1. Remove \`paths-ignore\` so the workflow always fires on PRs.
2. Add a tiny \`changes\` job using \`dorny/paths-filter@v3\` that emits a boolean \`code\` output (true when any non-docs file changed).
3. Gate the heavy \`lint-typecheck-test\` matrix with \`needs: changes\` + \`if: needs.changes.outputs.code == 'true'\`.

When the matrix is skipped via \`if:\`, GitHub auto-reports each required check as success — so docs-only PRs unblock cleanly.

## Critical preservation

- Matrix job \`name:\` left **byte-identical** (\`lint + typecheck + test (\${{ matrix.os }})\`) so branch protection's required-check string matching keeps working.
- Other workflows (\`pr-no-silent-drops\`, \`e2e\`, \`release\`, \`main-source-guard\`) untouched — they're either lightweight or scoped differently.

## Self-validation

This PR touches \`.github/workflows/ci.yml\` (not a doc), so the \`changes\` filter resolves \`code=true\` and the matrix runs. CI on this very PR is the live regression test for the change.

Refs: #843