### PR TITLE
feat(tools): T10.1 check-migration-locks.sh + migration-lock.spec

### DIFF
--- a/packages/daemon/test/db/migration-lock.spec.ts
+++ b/packages/daemon/test/db/migration-lock.spec.ts
@@ -20,12 +20,15 @@
 
 import { createHash } from 'node:crypto';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
 // Paths are resolved relative to the daemon package root (parent of test/).
-// __dirname under vitest points at this file's directory.
+// Project is ESM (no CommonJS `__dirname`); derive it from `import.meta.url`.
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 const DAEMON_ROOT = resolve(__dirname, '..', '..');
 const MIGRATIONS_DIR = join(DAEMON_ROOT, 'src', 'db', 'migrations');
 const LOCKED_TS_PATH = join(DAEMON_ROOT, 'src', 'db', 'locked.ts');
@@ -47,9 +50,12 @@ describe.skipIf(!lockedTsExists)('migration-lock (runtime self-check)', () => {
   // spec to one particular export style — Task #56 picks the shape; this
   // spec just needs (filename, sha256) pairs.
   const lockedSrc = readFileSync(LOCKED_TS_PATH, 'utf8');
+  // Strip `//` line comments so a stale commented-out hash (e.g. left during
+  // a migration rename) does not produce a false-positive match below.
+  const lockedSrcStripped = lockedSrc.replace(/\/\/.*$/gm, '');
   const entryRe = /['"]([0-9]{3}_[A-Za-z0-9_-]+\.sql)['"]\s*[:,]\s*['"]([0-9a-fA-F]{64})['"]/g;
   const recorded = new Map<string, string>();
-  for (const m of lockedSrc.matchAll(entryRe)) {
+  for (const m of lockedSrcStripped.matchAll(entryRe)) {
     recorded.set(m[1], m[2].toLowerCase());
   }
 

--- a/packages/daemon/test/db/migration-lock.spec.ts
+++ b/packages/daemon/test/db/migration-lock.spec.ts
@@ -1,0 +1,85 @@
+// packages/daemon/test/db/migration-lock.spec.ts
+//
+// FOREVER-STABLE per docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+// chapter 15 §3 item #4 + chapter 07 §4. The runtime self-check side of the
+// migration immutability lock: at boot the daemon will compute SHA256s of its
+// bundled migration files and assert against `MIGRATION_LOCKS` exported from
+// `packages/daemon/src/db/locked.ts`. This spec runs the same comparison
+// in-process so the invariant fails CI before it can fail production.
+//
+// Two-tier safety net (see ch07 §4):
+//   - tools/check-migration-locks.sh — compares against the GitHub release body
+//     of v0.3.0 (the immutable witness)
+//   - this spec — compares against `MIGRATION_LOCKS` in locked.ts (the
+//     in-process self-check the daemon runs at boot)
+//
+// `locked.ts` is created later by Task #56 (T5.4 migration runner). Until then
+// this whole describe block auto-skips via `describe.skipIf`. No other tests
+// exist in `packages/daemon/test/` yet (T0.1 / PR #848 created the empty
+// daemon package skeleton); this file is forward-compatible with that wiring.
+
+import { createHash } from 'node:crypto';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+// Paths are resolved relative to the daemon package root (parent of test/).
+// __dirname under vitest points at this file's directory.
+const DAEMON_ROOT = resolve(__dirname, '..', '..');
+const MIGRATIONS_DIR = join(DAEMON_ROOT, 'src', 'db', 'migrations');
+const LOCKED_TS_PATH = join(DAEMON_ROOT, 'src', 'db', 'locked.ts');
+
+function sha256OfFile(path: string): string {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+// Skip the entire suite until locked.ts lands. We deliberately do not try to
+// dynamically import locked.ts here — vitest evaluates the import graph eagerly
+// and a missing module would surface as a hard error before describe.skipIf
+// runs. Instead we read it as text and parse the MIGRATION_LOCKS entries.
+const lockedTsExists = existsSync(LOCKED_TS_PATH);
+
+describe.skipIf(!lockedTsExists)('migration-lock (runtime self-check)', () => {
+  // Parse `MIGRATION_LOCKS` entries from locked.ts source text. We accept
+  // either object-literal form (`'<file>': '<hex>'`) or a Map/array form
+  // with the same string pair shape. Source-text parsing avoids pinning this
+  // spec to one particular export style — Task #56 picks the shape; this
+  // spec just needs (filename, sha256) pairs.
+  const lockedSrc = readFileSync(LOCKED_TS_PATH, 'utf8');
+  const entryRe = /['"]([0-9]{3}_[A-Za-z0-9_-]+\.sql)['"]\s*[:,]\s*['"]([0-9a-fA-F]{64})['"]/g;
+  const recorded = new Map<string, string>();
+  for (const m of lockedSrc.matchAll(entryRe)) {
+    recorded.set(m[1], m[2].toLowerCase());
+  }
+
+  it('locked.ts declares at least one MIGRATION_LOCKS entry', () => {
+    expect(recorded.size).toBeGreaterThan(0);
+  });
+
+  it('every recorded migration file exists on disk', () => {
+    for (const filename of recorded.keys()) {
+      const path = join(MIGRATIONS_DIR, filename);
+      expect(existsSync(path), `${filename} missing at ${path}`).toBe(true);
+    }
+  });
+
+  it('every recorded SHA256 matches the on-disk file', () => {
+    for (const [filename, expected] of recorded) {
+      const path = join(MIGRATIONS_DIR, filename);
+      const actual = sha256OfFile(path);
+      expect(actual, `SHA256 mismatch for ${filename}`).toBe(expected);
+    }
+  });
+
+  it('every on-disk migration file has a recorded lock', () => {
+    // Inverse direction — guards against a developer adding a migration
+    // without locking it. Only checks files matching the v0.3 naming pattern
+    // (`NNN_<name>.sql`) so unrelated fixtures, if any, do not trip it.
+    if (!existsSync(MIGRATIONS_DIR)) return;
+    const onDisk = readdirSync(MIGRATIONS_DIR).filter((f) => /^[0-9]{3}_.+\.sql$/.test(f));
+    for (const filename of onDisk) {
+      expect(recorded.has(filename), `${filename} on disk but not in MIGRATION_LOCKS`).toBe(true);
+    }
+  });
+});

--- a/tools/check-migration-locks.sh
+++ b/tools/check-migration-locks.sh
@@ -54,6 +54,11 @@ if [ "$GH_STATUS" -ne 0 ] || [ -z "$RELEASE_BODY" ]; then
   exit 0
 fi
 
+# Strip CRLF — `gh release view` on Windows runners (Git Bash) can return
+# release bodies with `\r\n` line endings; POSIX `[[:space:]]` matching of
+# `\r` varies across awk implementations (mawk vs gawk), so normalize early.
+RELEASE_BODY="$(printf '%s' "$RELEASE_BODY" | tr -d '\r')"
+
 # --- pick a sha256 implementation -------------------------------------------
 # Prints the hex digest of the file passed as $1 to stdout, nothing else.
 sha256_of() {

--- a/tools/check-migration-locks.sh
+++ b/tools/check-migration-locks.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# tools/check-migration-locks.sh
+#
+# FOREVER-STABLE per docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+# chapter 15 §3 item #4 + chapter 07 §4. Do not change behavior without bumping
+# the design doc and routing through manager — every v0.4+ PR runs this.
+#
+# What it does:
+#   1. Fetch the v0.3 GitHub release body via `gh release view v0.3.0`. The
+#      release tag is the immutable witness — NOT the `main` branch, NOT
+#      `packages/daemon/src/db/locked.ts`. If the release does not exist yet
+#      (pre-tag), the script exits 0 with a note. The lock is only meaningful
+#      AFTER v0.3 ships.
+#   2. Parse the `### Migration locks` section to extract `(filename → sha256)`
+#      pairs. Lines look like:  001_initial.sql  <64-hex>
+#   3. For every recorded pair, recompute SHA256 of the file at HEAD under
+#      packages/daemon/src/db/migrations/ and compare. Any mismatch / missing
+#      v0.3-vintage file is a hard failure (exit 1).
+#   4. If packages/daemon/src/db/locked.ts exists, also assert MIGRATION_LOCKS
+#      entries match the release body (catches the "edit migration + edit
+#      locked.ts together" attack path; locked.ts is the runtime self-check,
+#      release body is the source of truth). locked.ts is created later by
+#      Task #56 (T5.4 migration runner) — its absence is NOT a failure here.
+#
+# Compatibility: bash 3.2+, runs on Linux/macOS GHA runners and Git Bash on
+# Windows. Uses sha256sum if available, else shasum -a 256, else node:crypto
+# fallback. No new npm deps.
+
+set -euo pipefail
+
+RELEASE_TAG="v0.3.0"
+MIGRATIONS_DIR="packages/daemon/src/db/migrations"
+LOCKED_TS="packages/daemon/src/db/locked.ts"
+
+log() { printf '[check-migration-locks] %s\n' "$*" >&2; }
+fail() { log "FAIL: $*"; exit 1; }
+
+# --- gh availability --------------------------------------------------------
+if ! command -v gh >/dev/null 2>&1; then
+  fail "gh CLI not found on PATH (required to fetch release body)"
+fi
+
+# --- fetch release body, handle pre-tag gracefully --------------------------
+# `gh release view` exits non-zero when the release does not exist; capture
+# both stdout and exit status without `set -e` aborting us.
+set +e
+RELEASE_BODY="$(gh release view "$RELEASE_TAG" --json body --jq .body 2>/dev/null)"
+GH_STATUS=$?
+set -e
+
+if [ "$GH_STATUS" -ne 0 ] || [ -z "$RELEASE_BODY" ]; then
+  log "note: release $RELEASE_TAG does not exist yet (pre-tag); skipping lock check"
+  log "this script becomes meaningful AFTER v0.3 ships — see design ch15 §3 #4"
+  exit 0
+fi
+
+# --- pick a sha256 implementation -------------------------------------------
+# Prints the hex digest of the file passed as $1 to stdout, nothing else.
+sha256_of() {
+  local f="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$f" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$f" | awk '{print $1}'
+  elif command -v node >/dev/null 2>&1; then
+    node -e "const c=require('node:crypto');const fs=require('node:fs');const h=c.createHash('sha256');h.update(fs.readFileSync(process.argv[1]));process.stdout.write(h.digest('hex'));" "$f"
+  else
+    fail "no sha256 implementation available (need sha256sum, shasum, or node)"
+  fi
+}
+
+# --- parse `### Migration locks` block --------------------------------------
+# Block format (one entry per line, separator is whitespace):
+#
+#   ### Migration locks
+#
+#   001_initial.sql  <64 hex chars>
+#   002_<name>.sql   <64 hex chars>
+#
+# We extract everything after the heading until the next `###` heading or EOF,
+# then keep lines that look like `<filename>.sql <64-hex>`.
+LOCKS_BLOCK="$(printf '%s\n' "$RELEASE_BODY" \
+  | awk '
+      /^### Migration locks[[:space:]]*$/ { in_block = 1; next }
+      in_block && /^###[[:space:]]/ { in_block = 0 }
+      in_block { print }
+    ')"
+
+if [ -z "$LOCKS_BLOCK" ]; then
+  fail "release $RELEASE_TAG body has no '### Migration locks' section"
+fi
+
+# Filter to valid `<file>.sql <sha>` rows.
+LOCK_ENTRIES="$(printf '%s\n' "$LOCKS_BLOCK" \
+  | awk '{
+      # Accept "<name>.sql <64hex>" possibly with leading whitespace /
+      # markdown bullets (`-`). Tolerate backticks around the filename.
+      gsub(/^[[:space:]]*[-*][[:space:]]*/, "", $0);
+      gsub(/`/, "", $0);
+      if (NF >= 2 && $1 ~ /\.sql$/ && $2 ~ /^[0-9a-fA-F]{64}$/) {
+        print $1, tolower($2);
+      }
+    }')"
+
+if [ -z "$LOCK_ENTRIES" ]; then
+  fail "release $RELEASE_TAG '### Migration locks' section has no parseable entries"
+fi
+
+# --- compare each entry against the local file ------------------------------
+MISMATCH=0
+TOTAL=0
+while IFS= read -r entry; do
+  [ -z "$entry" ] && continue
+  TOTAL=$((TOTAL + 1))
+  filename="${entry%% *}"
+  expected="${entry##* }"
+  path="$MIGRATIONS_DIR/$filename"
+
+  if [ ! -f "$path" ]; then
+    log "MISMATCH: $filename — locked at release but missing in tree ($path)"
+    MISMATCH=$((MISMATCH + 1))
+    continue
+  fi
+
+  actual="$(sha256_of "$path")"
+  if [ "$actual" != "$expected" ]; then
+    log "MISMATCH: $filename"
+    log "  expected: $expected"
+    log "  actual:   $actual"
+    MISMATCH=$((MISMATCH + 1))
+  fi
+done <<EOF
+$LOCK_ENTRIES
+EOF
+
+# --- cross-check locked.ts (if it exists) -----------------------------------
+# locked.ts is created by Task #56 (T5.4). It exports a `MIGRATION_LOCKS`
+# const mapping filename → sha256. We grep for `"<filename>": "<sha>"` (or
+# single-quoted) and assert it matches the release body. Absence is fine.
+if [ -f "$LOCKED_TS" ]; then
+  while IFS= read -r entry; do
+    [ -z "$entry" ] && continue
+    filename="${entry%% *}"
+    expected="${entry##* }"
+    # Match either `'001_initial.sql': 'hex'` or `"001_initial.sql": "hex"`,
+    # with arbitrary whitespace. Quote-style mixing is tolerated.
+    if ! grep -Eiq "['\"]${filename}['\"][[:space:]]*:[[:space:]]*['\"]${expected}['\"]" "$LOCKED_TS"; then
+      log "MISMATCH: $filename — locked.ts MIGRATION_LOCKS does not match release body"
+      log "  expected entry: '$filename': '$expected'"
+      MISMATCH=$((MISMATCH + 1))
+    fi
+  done <<EOF
+$LOCK_ENTRIES
+EOF
+else
+  log "note: $LOCKED_TS does not exist yet (Task #56 / T5.4 will land it); skipping locked.ts cross-check"
+fi
+
+# --- summary ----------------------------------------------------------------
+if [ "$MISMATCH" -gt 0 ]; then
+  fail "$MISMATCH of $TOTAL migration lock(s) failed verification"
+fi
+
+log "OK: all $TOTAL migration lock(s) verified against release $RELEASE_TAG"
+exit 0


### PR DESCRIPTION
## Summary

Delivers Task #127 — both artifacts of the v0.3 migration immutability lock per design [ch15 §3 #4](../blob/working/docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md) and ch07 §4. **Both are FOREVER-STABLE** — every v0.4+ PR runs them forever; behavior is locked, no future-version drift expected.

- `tools/check-migration-locks.sh` — bash, runs in CI:
  - `gh release view v0.3.0 --json body --jq .body` to fetch the release notes (the immutable witness — not `main`, not `locked.ts`).
  - Parses the `### Migration locks` block (tolerates plain rows, markdown bullets, and backtick-wrapped filenames).
  - Recomputes SHA256 of every recorded `packages/daemon/src/db/migrations/*.sql` and fails on any mismatch or missing v0.3-vintage file.
  - If `packages/daemon/src/db/locked.ts` is present, also asserts `MIGRATION_LOCKS` matches the release body (catches the "edit migration + edit locked.ts together" attack path).
  - **Pre-tag** (no v0.3 release exists yet) **the script no-ops with a note and exits 0** — per spec it's only meaningful AFTER the freeze.
  - **Pre-locked.ts** (Task #56 / T5.4 hasn't landed yet) the locked.ts cross-check is silently skipped.
  - Cross-platform: tries `sha256sum` → `shasum -a 256` → `node:crypto` fallback. Runs on Linux/macOS GHA runners and Git Bash on Windows. **No new npm deps** (per dev §1 no-wheel-reinvention).
- `packages/daemon/test/db/migration-lock.spec.ts` — vitest spec, runtime self-check side:
  - Uses `describe.skipIf(!existsSync(LOCKED_TS_PATH))` to auto-skip cleanly until Task #56 lands `locked.ts`.
  - Once `locked.ts` exists, asserts every recorded SHA256 matches the on-disk migration file AND that no on-disk `NNN_*.sql` is missing a lock entry.
  - Reads `locked.ts` as source text and parses `MIGRATION_LOCKS` entries with a regex — does NOT pin to a specific export shape, so Task #56 (T5.4) is free to choose object literal vs `Map`.

## Scope notes

- Per task prompt and dev protocol §1, this PR does **not** scaffold `packages/daemon/src/db/locked.ts` — that is owned by Task #56 (T5.4 migration runner).
- Does **not** create migration files — none exist in v0.3 yet.
- Branched off `origin/working` to avoid stepping on PR #848 (T0.1 monorepo skeleton, in review). Touches only `tools/` and a brand-new `packages/daemon/test/db/` path so rebase is trivial when #848 merges.
- The vitest spec is not yet in `vitest.config.ts`'s `include` glob — that wiring will come with the daemon test suite (Task #56 era). Until then the file sits dormant on disk; that's intentional and matches the skip-cleanly-until-locked.ts.land semantic.

## Test plan

- [x] Pre-tag local run: `bash tools/check-migration-locks.sh` exits 0 with the "release v0.3.0 does not exist yet" note (verified in this worktree).
- [x] Awk parser unit-tested inline against a synthetic release body containing plain, bullet, and backtick-wrapped entries — extracts exactly the expected `(filename, sha256)` pairs.
- [x] Spec regex unit-tested against a synthetic `MIGRATION_LOCKS` literal mixing single and double quotes — extracts exactly the expected entries.
- [ ] Post-tag CI integration: deferred to ch11 §6 wiring (separate task) — script is invoked but lacks a real release until v0.3 ships.
- [ ] Spec runs green: deferred until Task #56 lands `locked.ts` AND the daemon vitest config picks up `packages/daemon/test/**`.

## Round-2 fixes (review @ comment 4364603992)

- **P0-1**: ESM `__dirname` (lint red on all 3 OS) → `fileURLToPath(import.meta.url)`.
- **P1-3**: CRLF from `gh release view` on Windows runners → `tr -d '\r'`.
- **P1-4**: Spec regex false-positive on commented-out lines → strip `//` line comments before regex pass.

### Reverse-verify evidence

#### P0-1 — `__dirname` ESM fix

**Pre-fix** (lint with original spec, exit=1):

```text
$ npx eslint packages/daemon/test/db/migration-lock.spec.ts

C:\Users\jiahuigu\ccsm-worktrees\pool-5\packages\daemon\test\db\migration-lock.spec.ts
  29:29  error  '__dirname' is not defined  no-undef

✖ 1 problem (1 error, 0 warnings)
```

**Post-fix** (same command, exit=0): no output (eslint clean).

#### P1-4 — strip `//` comments before regex

Test fixture: `packages/daemon/src/db/locked.ts` carrying a real entry plus a stale commented-out hash for the same filename.

```ts
export const MIGRATION_LOCKS = {
  '001_initial.sql': '710c13f01b8dcacaf2d7dea092f69d75f7de164245e36a3a73b2e4f3a548d444',
  // OLD STALE HASH from a prior rename (commented out, MUST be ignored):
  // '001_initial.sql': 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
} as const;
```

**Pre-fix** (regex matches commented-out hash; Map.set overwrites real entry; exit=1):

```text
 ❯ packages/daemon/test/db/migration-lock.spec.ts (4 tests | 1 failed) 13ms
   × every recorded SHA256 matches the on-disk file 9ms

⎯⎯⎯ Failed Tests 1 ⎯⎯⎯

 FAIL  packages/daemon/test/db/migration-lock.spec.ts > migration-lock (runtime self-check) > every recorded SHA256 matches the on-disk file
AssertionError: SHA256 mismatch for 001_initial.sql: expected '710c13f01b8dcacaf2d7dea092f69d75f7de1…' to be 'deadbeefdeadbeefdeadbeefdeadbeefdeadb…'

Expected: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
Received: "710c13f01b8dcacaf2d7dea092f69d75f7de164245e36a3a73b2e4f3a548d444"

 Test Files  1 failed (1)
      Tests  1 failed | 3 passed (4)
```

**Post-fix** (same fixture, comment-stripping in place; exit=0):

```text
 RUN  v4.1.5

 Test Files  1 passed (1)
      Tests  4 passed (4)
   Duration  527ms
```

(Reverse-verify run via a temporary `vitest.config` whose `include` covers `packages/daemon/test/**` — current root config does not yet include that glob; that wiring lands with Task #56 per Scope notes above. Fixtures (`packages/daemon/src/db/locked.ts`, `001_initial.sql`) were created locally only and are NOT committed.)

## References

- Task #127
- Design [ch15 §3 #4](../blob/working/docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md) — forever-stable invariant
- Design ch07 §4 — migration story / two-tier lock rationale
- Design ch11 §6 — CI integration (downstream task)
- Task #56 / T5.4 — owns `packages/daemon/src/db/locked.ts` and the migration runner
- PR #848 — T0.1 monorepo skeleton (in review; this branch rebases clean against it)
