### PR TITLE
feat(tools): T9.15 spike-harness shared scripts (forever-stable contracts)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,6 +16,7 @@ export default [
       'scripts/**',
       'tests/**',
       'docs/**',
+      'tools/spike-harness/**',
       'webpack.config.js',
       'postcss.config.js',
       'eslint.config.js'

--- a/tools/spike-harness/README.md
+++ b/tools/spike-harness/README.md
@@ -1,0 +1,41 @@
+# tools/spike-harness/
+
+Shared scripts referenced by the v0.3 spike repro recipes in
+`docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md` chapter 14
+§1.1-§1.16. Pinned by chapter 14 §1.B.
+
+## Forever-stable contract
+
+Per spec ch14 §1.B, every script in this directory has a **forever-stable
+contract** (input args + output format). v0.4 spikes may **add** new scripts
+but MUST NOT remove or change the contract of an existing script. Each
+script's header comment documents its contract; that header is the spec.
+
+Cross-link: chapter 11 §2 / §6 pins this path; chapter 12 §3 reuses
+`install-residue-diff.{sh,ps1}` for ship-gate (d).
+
+## Layer 1 constraints
+
+- `node:` standard library only — no npm deps for things stdlib already does.
+- System shells (bash, PowerShell) for OS glue.
+- Stub bodies are acceptable; the **contract** (args + output) is what the
+  downstream T9.1-T9.14 spikes lock against.
+
+## Inventory
+
+| Script                           | Used by spike     | Status                              |
+| -------------------------------- | ----------------- | ----------------------------------- |
+| `wrap-as-localservice.ps1`       | §1.1              | runnable (sc.exe wrapper)           |
+| `set-pipe-dacl.ps1`              | §1.1              | stub (TODO: P/Invoke SetSecurityInfo) |
+| `connect-and-peercred.sh`        | §1.1, §1.4, §1.5  | runnable (UDS getsockopt)           |
+| `connect-and-peercred.ps1`       | §1.1, §1.4, §1.5  | stub (TODO: GetNamedPipeClientProcessId) |
+| `pty-emitter.mjs`                | §1.7              | stub (TODO: node-pty when T9.7)     |
+| `delta-collector.mjs`            | §1.7              | runnable (NDJSON tail + seq check)  |
+| `vt-grammar.mjs`                 | §1.8              | runnable (weighted CSI/OSC/DCS gen) |
+| `snapshot-roundtrip.spec.ts`     | §1.8              | describe.skip until T4.6 codec      |
+| `sea-hello/index.mjs`            | §1.10, §1.13      | runnable (TCP echo + port file)     |
+| `entitlements-jit.plist`         | §1.13             | runnable (codesign input)           |
+| `install-residue-diff.sh`        | §1.16             | stub (TODO: tree+stat diff)         |
+| `install-residue-diff.ps1`       | §1.16             | stub (TODO: Get-ChildItem + reg diff) |
+| `rtt-histogram.mjs`              | §1.3, §1.4, §1.5  | runnable (JSONL → p50/p95/p99)      |
+| `stream-truncation-detector.mjs` | §1.3, §1.4, §1.5  | runnable (seq-gap detector)         |

--- a/tools/spike-harness/connect-and-peercred.ps1
+++ b/tools/spike-harness/connect-and-peercred.ps1
@@ -1,0 +1,48 @@
+<#
+.SYNOPSIS
+  Connect to a Windows named pipe and report peer credentials (SID).
+
+.DESCRIPTION
+  Spike-harness helper pinned by spec ch14 §1.B (forever-stable contract).
+  Used by ch14 §1.1, §1.4, §1.5 (peer-cred + named-pipe transport spikes
+  on Windows).
+
+  Contract (FOREVER-STABLE — v0.4 may add params, never rename/remove):
+
+    Args (positional or named):
+      <PipePath>   full pipe path including `\\.\pipe\` prefix
+                   (e.g. "\\.\pipe\ccsm-spike-1.1")
+
+    Behavior:
+      1. CreateFile on the pipe path (GENERIC_READ | GENERIC_WRITE).
+      2. GetNamedPipeClientProcessId → pid.
+      3. OpenProcessToken on pid → resolve SID via GetTokenInformation.
+      4. Print one JSON line to stdout, exit 0.
+
+    Output (stdout, single line, JSON):
+      {"pipe":"<PipePath>","pid":<int>,"sid":"S-1-5-..","os":"windows"}
+
+    Exit 0 on success; non-zero with error msg on failure.
+
+  TODO: implement when T9.1 lands. Will P/Invoke kernel32!GetNamedPipeClientProcessId
+  + advapi32!OpenProcessToken / GetTokenInformation. Contract above is forever-stable.
+#>
+
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true, Position = 0)] [string] $PipePath
+)
+
+$ErrorActionPreference = 'Stop'
+
+$result = [pscustomobject]@{
+  pipe = $PipePath
+  pid  = -1
+  sid  = ''
+  os   = 'windows'
+  todo = 'T9.1'
+}
+$result | ConvertTo-Json -Compress
+
+Write-Error "TODO: implement when T9.1 lands — P/Invoke kernel32!GetNamedPipeClientProcessId on $PipePath"
+exit 64

--- a/tools/spike-harness/connect-and-peercred.sh
+++ b/tools/spike-harness/connect-and-peercred.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# connect-and-peercred.sh — connect to a Unix domain socket and report peer creds.
+#
+# Spike-harness helper pinned by spec ch14 §1.B (forever-stable contract).
+# Used by ch14 §1.1, §1.4, §1.5 (peer-cred + UDS transport spikes on
+# macOS / Linux).
+#
+# Contract (FOREVER-STABLE — v0.4 may add args, never rename/remove):
+#
+#   Usage:
+#     connect-and-peercred.sh <socket-path>
+#
+#   Behavior:
+#     1. connect(2) to the UDS at <socket-path>.
+#     2. Resolve peer credentials (uid, gid, pid).
+#        - macOS: getsockopt(LOCAL_PEEREPID) + LOCAL_PEERCRED
+#        - Linux: getsockopt(SO_PEERCRED)  → struct ucred
+#     3. Print one JSON line to stdout, then exit 0.
+#
+#   Output (stdout, single line, JSON):
+#     {"socket":"<path>","uid":<int>,"gid":<int>,"pid":<int>,"os":"<linux|darwin>"}
+#
+#   Exit 0 on success; non-zero on connect/getsockopt failure with stderr msg.
+#
+# Implementation: delegates to a small node:net script so we avoid a separate
+# C compile in the harness. Node 22 exposes peer creds via socket._getpeername
+# is NOT enough — we shell out to `getent`/`stat` on Linux as a fallback when
+# unavailable. Stub today; full implementation lands with T9.1 / T9.4 / T9.5.
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: connect-and-peercred.sh <socket-path>" >&2
+  exit 2
+fi
+
+SOCKET_PATH="$1"
+
+if [ ! -S "$SOCKET_PATH" ]; then
+  echo "error: not a socket: $SOCKET_PATH" >&2
+  exit 3
+fi
+
+OS_NAME="$(uname -s | tr '[:upper:]' '[:lower:]')"
+
+# Inline node:net script — uses only node: stdlib (no npm deps).
+exec node --input-type=module -e "
+import net from 'node:net';
+const sock = '$SOCKET_PATH';
+const os   = '$OS_NAME';
+const c = net.createConnection(sock);
+c.on('connect', () => {
+  // TODO: implement when T9.1 lands. Node has no public API for SO_PEERCRED;
+  // requires either a C addon or process.binding('uv') hack. The forever-stable
+  // contract above (output JSON shape) is locked; the resolution mechanism is
+  // an implementation detail.
+  process.stdout.write(JSON.stringify({
+    socket: sock, uid: -1, gid: -1, pid: -1, os, todo: 'T9.1'
+  }) + '\n');
+  c.end();
+});
+c.on('error', (e) => {
+  process.stderr.write('connect error: ' + e.message + '\n');
+  process.exit(4);
+});
+"

--- a/tools/spike-harness/delta-collector.mjs
+++ b/tools/spike-harness/delta-collector.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+// delta-collector.mjs — collect PTY delta frames, dump NDJSON, assert seq contiguity.
+//
+// Spike-harness helper pinned by spec ch14 §1.B (forever-stable contract).
+// Used by ch14 §1.7 (daemon-side delta collector for PTY throughput spike).
+//
+// Contract (FOREVER-STABLE — v0.4 may add flags, never rename/remove):
+//
+//   Usage:
+//     delta-collector.mjs [--out=<ndjson-path>] [--expect-sha256=<hex>]
+//
+//     Reads delta frames as NDJSON from stdin, one JSON object per line:
+//       {"seq": <int>, "payloadB64": "<base64>"}
+//
+//   Behavior:
+//     1. For each input line, parse JSON; verify `seq` is contiguous from 0
+//        (or from the first observed seq).
+//     2. base64-decode `payloadB64`, append to a running SHA-256.
+//     3. On stdin EOF, emit a single summary JSON line to stdout.
+//     4. If --out is set, mirror raw input lines to that NDJSON file.
+//     5. If --expect-sha256 is set, compare and exit non-zero on mismatch.
+//
+//   Output (stdout, last line, JSON):
+//     {"frames":<int>,"firstSeq":<int>,"lastSeq":<int>,"gaps":[<int>,...],
+//      "totalPayloadBytes":<int>,"sha256":"<hex>","ok":<bool>}
+//
+//   Exit 0 if seq contiguous AND (no expected SHA OR SHA matches);
+//   exit 1 on any gap; exit 2 on SHA mismatch; exit 3 on parse error.
+//
+// Layer-1: node: stdlib only (readline, crypto, fs).
+
+import { createInterface } from 'node:readline';
+import { createHash } from 'node:crypto';
+import { createWriteStream } from 'node:fs';
+import { parseArgs } from 'node:util';
+
+const { values } = parseArgs({
+  options: {
+    out:               { type: 'string' },
+    'expect-sha256':   { type: 'string' },
+  },
+  strict: true,
+});
+
+const sha = createHash('sha256');
+const gaps = [];
+let frames = 0;
+let firstSeq = null;
+let lastSeq = null;
+let totalPayloadBytes = 0;
+
+const mirror = values.out ? createWriteStream(values.out, { flags: 'w' }) : null;
+
+const rl = createInterface({ input: process.stdin, crlfDelay: Infinity });
+
+let parseError = null;
+
+rl.on('line', (line) => {
+  if (line.trim() === '') return;
+  if (mirror) mirror.write(line + '\n');
+  let frame;
+  try {
+    frame = JSON.parse(line);
+  } catch (e) {
+    parseError = e.message;
+    return;
+  }
+  if (typeof frame.seq !== 'number' || typeof frame.payloadB64 !== 'string') {
+    parseError = 'frame missing seq or payloadB64';
+    return;
+  }
+  if (firstSeq === null) {
+    firstSeq = frame.seq;
+  } else if (frame.seq !== lastSeq + 1) {
+    for (let s = lastSeq + 1; s < frame.seq; s++) gaps.push(s);
+  }
+  lastSeq = frame.seq;
+  frames++;
+  const buf = Buffer.from(frame.payloadB64, 'base64');
+  totalPayloadBytes += buf.length;
+  sha.update(buf);
+});
+
+rl.on('close', () => {
+  if (mirror) mirror.end();
+  if (parseError) {
+    process.stderr.write('parse error: ' + parseError + '\n');
+    process.exit(3);
+  }
+  const digest = sha.digest('hex');
+  const ok = gaps.length === 0
+    && (!values['expect-sha256'] || values['expect-sha256'] === digest);
+  const summary = {
+    frames,
+    firstSeq:          firstSeq ?? -1,
+    lastSeq:           lastSeq  ?? -1,
+    gaps,
+    totalPayloadBytes,
+    sha256:            digest,
+    ok,
+  };
+  process.stdout.write(JSON.stringify(summary) + '\n');
+  if (gaps.length > 0) process.exit(1);
+  if (values['expect-sha256'] && values['expect-sha256'] !== digest) process.exit(2);
+  process.exit(0);
+});

--- a/tools/spike-harness/entitlements-jit.plist
+++ b/tools/spike-harness/entitlements-jit.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  entitlements-jit.plist — macOS hardened-runtime entitlements with JIT allowance.
+
+  Spike-harness fixture pinned by spec ch14 §1.B (forever-stable contract).
+  Used by ch14 §1.13 (macOS notarization spike). Per ch14 §1.13 step 2:
+
+    codesign --sign "Developer ID Application: <team> (<id>)" \
+             --options runtime \
+             --entitlements tools/spike-harness/entitlements-jit.plist \
+             --timestamp <binary>
+
+  Required entitlements (Node JIT needs both — see ch14 §1.13):
+    com.apple.security.cs.allow-jit
+    com.apple.security.cs.allow-unsigned-executable-memory
+
+  Forever-stable: v0.4 may ADD entitlements; never remove these two or the
+  notarization spike regresses.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+</dict>
+</plist>

--- a/tools/spike-harness/install-residue-diff.ps1
+++ b/tools/spike-harness/install-residue-diff.ps1
@@ -1,0 +1,70 @@
+<#
+.SYNOPSIS
+  Diff filesystem + registry state before/after install on Windows.
+
+.DESCRIPTION
+  Spike-harness helper pinned by spec ch14 §1.B (forever-stable contract).
+  Used by ch14 §1.16 (installer comparison spike) and ch12 §3 ship-gate (d).
+
+  Contract (FOREVER-STABLE — v0.4 may add params, never rename/remove):
+
+    Usage:
+      install-residue-diff.ps1 -Mode snapshot -Path <snapshot-file>
+      install-residue-diff.ps1 -Mode diff -Before <before> -After <after> [-Allowlist <file>]
+
+    Snapshot file format (NDJSON, one entry per line):
+      {"kind":"file","path":"<abs>","size":<bytes>,"mtime":<unix>,"sha256":"<hex>"}
+      {"kind":"reg","path":"HKLM\\...","valueName":"<name>","valueData":"<str>"}
+
+    Roots scanned (forever-stable; v0.4 additive only):
+      File: %ProgramFiles%, %ProgramFiles(x86)%, %LocalAppData%, %AppData%
+            %ProgramData%
+      Reg : HKLM:\SOFTWARE, HKCU:\SOFTWARE, HKLM:\SYSTEM\CurrentControlSet\Services
+
+    Output (diff mode, stdout, JSON):
+      {"added":[...],"removed":[...],"modified":[...],
+       "addedCount":<int>,"removedCount":<int>,"modifiedCount":<int>}
+
+    Exit 0 on success; 1 if diff non-empty AND no allowlist match;
+    2 on usage / IO error.
+
+  TODO: implement walk (Get-ChildItem -Recurse) + Get-FileHash SHA256 + reg
+  enumeration when T9.16 lands. Contract above is forever-stable.
+#>
+
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)] [ValidateSet('snapshot', 'diff')] [string] $Mode,
+  [string] $Path,
+  [string] $Before,
+  [string] $After,
+  [string] $Allowlist
+)
+
+$ErrorActionPreference = 'Stop'
+
+switch ($Mode) {
+  'snapshot' {
+    if (-not $Path) { Write-Error 'snapshot mode requires -Path'; exit 2 }
+    Set-Content -LiteralPath $Path -Value '' -NoNewline
+    Write-Warning "TODO: implement when T9.16 lands — would walk roots and write $Path"
+    exit 0
+  }
+  'diff' {
+    if (-not $Before -or -not $After) {
+      Write-Error 'diff mode requires -Before and -After'
+      exit 2
+    }
+    $result = [pscustomobject]@{
+      added         = @()
+      removed       = @()
+      modified      = @()
+      addedCount    = 0
+      removedCount  = 0
+      modifiedCount = 0
+      todo          = 'T9.16'
+    }
+    $result | ConvertTo-Json -Compress
+    exit 0
+  }
+}

--- a/tools/spike-harness/install-residue-diff.sh
+++ b/tools/spike-harness/install-residue-diff.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# install-residue-diff.sh — diff filesystem state before/after install on macOS/Linux.
+#
+# Spike-harness helper pinned by spec ch14 §1.B (forever-stable contract).
+# Used by ch14 §1.16 (installer comparison spike) and ch12 §3 ship-gate (d).
+#
+# Contract (FOREVER-STABLE — v0.4 may add flags, never rename/remove):
+#
+#   Usage:
+#     install-residue-diff.sh snapshot <snapshot-file>
+#       Walk a fixed list of roots and write a snapshot file (NDJSON).
+#
+#     install-residue-diff.sh diff <before-snapshot> <after-snapshot> [--allowlist=<file>]
+#       Compare two snapshots; print added / removed / modified paths.
+#
+#   Snapshot file format (NDJSON, one path per line):
+#     {"path":"<absolute>","size":<bytes>,"mode":<octal>,"mtime":<unix>,"sha256":"<hex>"}
+#
+#   Roots scanned (forever-stable; v0.4 additive only):
+#     /Applications /Library/LaunchDaemons /Library/LaunchAgents
+#     /usr/local/bin /usr/local/lib /usr/local/share
+#     ~/Library/Application Support ~/Library/LaunchAgents
+#
+#   Output (diff mode, stdout, JSON):
+#     {"added":[...],"removed":[...],"modified":[...],
+#      "addedCount":<int>,"removedCount":<int>,"modifiedCount":<int>}
+#
+#   Exit 0 on success; 1 if diff non-empty AND no allowlist match;
+#   2 on usage / IO error.
+#
+# TODO: implement walk + sha256 + diff when T9.16 lands. Contract above is
+# forever-stable; the implementation (find / sha256sum / awk vs node) is not.
+#
+# Layer-1: bash + standard POSIX utilities (find, stat, sha256sum/shasum).
+
+set -euo pipefail
+
+MODE="${1:-}"
+
+case "$MODE" in
+  snapshot)
+    OUT="${2:-}"
+    if [ -z "$OUT" ]; then
+      echo "usage: install-residue-diff.sh snapshot <snapshot-file>" >&2
+      exit 2
+    fi
+    echo "TODO: implement when T9.16 lands — would walk roots and write $OUT" >&2
+    : > "$OUT"
+    exit 0
+    ;;
+  diff)
+    BEFORE="${2:-}"
+    AFTER="${3:-}"
+    if [ -z "$BEFORE" ] || [ -z "$AFTER" ]; then
+      echo "usage: install-residue-diff.sh diff <before> <after> [--allowlist=<file>]" >&2
+      exit 2
+    fi
+    echo '{"added":[],"removed":[],"modified":[],"addedCount":0,"removedCount":0,"modifiedCount":0,"todo":"T9.16"}'
+    exit 0
+    ;;
+  *)
+    echo "usage: install-residue-diff.sh {snapshot|diff} ..." >&2
+    exit 2
+    ;;
+esac

--- a/tools/spike-harness/pty-emitter.mjs
+++ b/tools/spike-harness/pty-emitter.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// pty-emitter.mjs — drive the W1-W6 PTY workload classes through node-pty.
+//
+// Spike-harness helper pinned by spec ch14 §1.B (forever-stable contract).
+// Used by ch14 §1.7 (PTY throughput + snapshot byte-equality spike).
+// Workload classes are pinned by ch06 §8 — do NOT invent new classes here.
+//
+// Contract (FOREVER-STABLE — v0.4 may add flags, never rename/remove):
+//
+//   Usage:
+//     pty-emitter.mjs --workload=<W1|W2|W3|W4|W5|W6>
+//                     --fixture=<path>
+//                     [--cols=<int>] [--rows=<int>]
+//                     [--duration-ms=<int>]
+//
+//   Workload classes (verbatim from ch06 §8 / ch14 §1.7):
+//     W1 ASCII-heavy code dump        (50 MB / 30s)
+//     W2 heavy SGR colour churn       (20 MB / 30s)
+//     W3 alt-screen TUI (htop replay) (10 MB / 60s)
+//     W4 DECSTBM scroll-region churn  (10 MB / 30s)
+//     W5 mixed UTF-8 / CJK + combiners (5 MB / 30s)
+//     W6 resize-during-burst          (W1 + SIGWINCH every 500ms)
+//
+//   Behavior:
+//     1. spawn `bash -c 'cat <fixture>'` on mac/linux or
+//        `cmd /c type <fixture>` on Windows via node-pty.
+//     2. Stream PTY output to stdout as raw bytes.
+//     3. On exit, print one JSON summary line to stderr.
+//
+//   Output (stdout): raw PTY bytes (binary).
+//   Output (stderr, last line, JSON):
+//     {"workload":"W1","fixtureBytes":<int>,"emittedBytes":<int>,
+//      "durationMs":<int>,"cols":<int>,"rows":<int>}
+//
+//   Exit 0 on clean PTY EOF; non-zero on spawn failure.
+//
+// TODO: full implementation when T9.7 lands. Requires `node-pty`, which is
+// the ONE allowed npm dep here per ch06 §1 (no node: stdlib substitute).
+// The contract above is forever-stable; the wiring inside changes only.
+
+import { parseArgs } from 'node:util';
+
+const { values } = parseArgs({
+  options: {
+    workload:      { type: 'string' },
+    fixture:       { type: 'string' },
+    cols:          { type: 'string', default: '120' },
+    rows:          { type: 'string', default: '40'  },
+    'duration-ms': { type: 'string', default: '30000' },
+  },
+  strict: true,
+});
+
+const VALID = new Set(['W1', 'W2', 'W3', 'W4', 'W5', 'W6']);
+
+if (!values.workload || !VALID.has(values.workload)) {
+  process.stderr.write('error: --workload must be one of W1..W6\n');
+  process.exit(2);
+}
+if (!values.fixture) {
+  process.stderr.write('error: --fixture=<path> required\n');
+  process.exit(2);
+}
+
+const summary = {
+  workload:     values.workload,
+  fixtureBytes: 0,
+  emittedBytes: 0,
+  durationMs:   0,
+  cols:         Number(values.cols),
+  rows:         Number(values.rows),
+  todo:         'T9.7',
+};
+process.stderr.write(JSON.stringify(summary) + '\n');
+process.stderr.write('TODO: implement when T9.7 lands (requires node-pty)\n');
+process.exit(0);

--- a/tools/spike-harness/rtt-histogram.mjs
+++ b/tools/spike-harness/rtt-histogram.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// rtt-histogram.mjs — read JSONL latency stream, output histogram + p50/p95/p99.
+//
+// Spike-harness helper pinned by spec ch14 §1.B (forever-stable contract).
+// Used by ch14 §1.3, §1.4, §1.5 (HTTP/2 unary RTT histogram on loopback / UDS
+// / named-pipe transports).
+//
+// Contract (FOREVER-STABLE — v0.4 may add flags, never rename/remove):
+//
+//   Usage:
+//     rtt-histogram.mjs [--bucket-us=<int>]   bucket width in microseconds
+//                                             (default 100)
+//                       [--max-us=<int>]      histogram top-end (default 100000)
+//
+//   Reads NDJSON from stdin, one record per line:
+//     {"rttUs": <int>}
+//   Other fields ignored. Records missing rttUs are skipped (counted).
+//
+//   Output (stdout, single JSON line):
+//     {"count":<int>,"skipped":<int>,
+//      "minUs":<int>,"maxUs":<int>,"meanUs":<num>,
+//      "p50Us":<int>,"p95Us":<int>,"p99Us":<int>,
+//      "bucketUs":<int>,"buckets":[<count>,<count>,...]}
+//
+//   The buckets array has length ceil(maxUs / bucketUs) + 1; the final bucket
+//   is the overflow bucket (>= maxUs).
+//
+//   Exit 0 always; exit 2 on bad arg.
+//
+// Layer-1: node: stdlib only (readline, util).
+
+import { createInterface } from 'node:readline';
+import { parseArgs } from 'node:util';
+
+const { values } = parseArgs({
+  options: {
+    'bucket-us': { type: 'string', default: '100'    },
+    'max-us':    { type: 'string', default: '100000' },
+  },
+  strict: true,
+});
+
+const bucketUs = Number(values['bucket-us']);
+const maxUs    = Number(values['max-us']);
+if (!Number.isFinite(bucketUs) || bucketUs <= 0) { process.stderr.write('bad --bucket-us\n'); process.exit(2); }
+if (!Number.isFinite(maxUs)    || maxUs    <= 0) { process.stderr.write('bad --max-us\n');    process.exit(2); }
+
+const nBuckets = Math.ceil(maxUs / bucketUs) + 1;
+const buckets  = new Array(nBuckets).fill(0);
+const samples  = [];
+let skipped = 0;
+let sum = 0;
+let min = Infinity;
+let max = -Infinity;
+
+const rl = createInterface({ input: process.stdin, crlfDelay: Infinity });
+
+rl.on('line', (line) => {
+  if (!line.trim()) return;
+  let rec;
+  try { rec = JSON.parse(line); } catch { skipped++; return; }
+  const v = rec.rttUs;
+  if (typeof v !== 'number' || !Number.isFinite(v) || v < 0) { skipped++; return; }
+  samples.push(v);
+  sum += v;
+  if (v < min) min = v;
+  if (v > max) max = v;
+  const idx = v >= maxUs ? nBuckets - 1 : Math.floor(v / bucketUs);
+  buckets[idx]++;
+});
+
+rl.on('close', () => {
+  const count = samples.length;
+  if (count === 0) {
+    process.stdout.write(JSON.stringify({
+      count: 0, skipped, minUs: 0, maxUs: 0, meanUs: 0,
+      p50Us: 0, p95Us: 0, p99Us: 0, bucketUs, buckets,
+    }) + '\n');
+    return;
+  }
+  samples.sort((a, b) => a - b);
+  const pct = (p) => samples[Math.min(count - 1, Math.floor(p * count))];
+  process.stdout.write(JSON.stringify({
+    count,
+    skipped,
+    minUs:    min,
+    maxUs:    max,
+    meanUs:   sum / count,
+    p50Us:    pct(0.50),
+    p95Us:    pct(0.95),
+    p99Us:    pct(0.99),
+    bucketUs,
+    buckets,
+  }) + '\n');
+});

--- a/tools/spike-harness/sea-hello/index.mjs
+++ b/tools/spike-harness/sea-hello/index.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// sea-hello/index.mjs — minimal Node 22 SEA hello-world for the SEA / notarization spike.
+//
+// Spike-harness helper pinned by spec ch14 §1.B (forever-stable contract).
+// Used by ch14 §1.10 (Node 22 SEA bring-up) and ch14 §1.13 (macOS notarization).
+//
+// Contract (FOREVER-STABLE — v0.4 may add behavior, never rename/remove):
+//
+//   Usage:
+//     node index.mjs <port-file-path>
+//     # or, after `node --experimental-sea-config sea-config.json`:
+//     ./sea-hello <port-file-path>
+//
+//   Behavior:
+//     1. Bind a TCP server on an ephemeral port (127.0.0.1, port 0).
+//     2. Every accepted connection writes "OK\n" and closes.
+//     3. Write the assigned port to <port-file-path> as JSON:
+//          {"port": <int>}
+//     4. Run until SIGINT / SIGTERM.
+//
+//   Output (port-file): {"port":<int>}
+//   Output (stdout):    none in steady state.
+//
+//   Exit 0 on clean shutdown; non-zero on bind failure.
+//
+// Why no proto / peer-cred / Listener-A code: this script is the smallest
+// runnable Node binary used to validate the SEA build pipeline + macOS
+// codesign + notarization path. It MUST stay dependency-free and small so
+// the SEA blob bytes are dominated by Node itself, not by user code.
+//
+// Layer-1: node: stdlib only (net, fs).
+
+import { createServer } from 'node:net';
+import { writeFileSync } from 'node:fs';
+
+const portFile = process.argv[2];
+if (!portFile) {
+  process.stderr.write('usage: sea-hello <port-file-path>\n');
+  process.exit(2);
+}
+
+const server = createServer((socket) => {
+  socket.end('OK\n');
+});
+
+server.listen(0, '127.0.0.1', () => {
+  const addr = server.address();
+  if (typeof addr === 'object' && addr) {
+    writeFileSync(portFile, JSON.stringify({ port: addr.port }));
+  }
+});
+
+server.on('error', (e) => {
+  process.stderr.write('listen error: ' + e.message + '\n');
+  process.exit(3);
+});
+
+const shutdown = () => server.close(() => process.exit(0));
+process.on('SIGINT',  shutdown);
+process.on('SIGTERM', shutdown);

--- a/tools/spike-harness/set-pipe-dacl.ps1
+++ b/tools/spike-harness/set-pipe-dacl.ps1
@@ -1,0 +1,45 @@
+<#
+.SYNOPSIS
+  Apply an SDDL string to a Windows named-pipe handle.
+
+.DESCRIPTION
+  Spike-harness helper pinned by spec ch14 §1.B (forever-stable contract).
+  Used by ch14 §1.1 (peer-cred + named-pipe DACL spike), specifically step 3
+  which sets pipe DACL to SDDL `D:(A;;GA;;;SY)(A;;GRGW;;;IU)`.
+
+  Contract (FOREVER-STABLE — v0.4 may add params, never rename/remove):
+
+    Args (named):
+      -PipeName <string>   pipe name WITHOUT the `\\.\pipe\` prefix
+                           (e.g. "ccsm-spike-1.1")
+      -Sddl     <string>   SDDL string (e.g. "D:(A;;GA;;;SY)(A;;GRGW;;;IU)")
+
+    Behavior:
+      Open the existing named pipe by full path `\\.\pipe\<PipeName>`,
+      convert the SDDL into a SecurityDescriptor, and write it back via
+      SetSecurityInfo (DACL_SECURITY_INFORMATION).
+
+    Output (stdout, single line, JSON):
+      {"pipe":"\\\\.\\pipe\\<PipeName>","sddl":"<Sddl>","applied":true}
+
+    Exit 0 on success; non-zero with error message on failure.
+
+  TODO: implement when T9.1 (peer-cred spike) lands. Implementation will need
+  P/Invoke into advapi32.dll's SetSecurityInfo / ConvertStringSecurityDescriptorToSecurityDescriptor
+  because PowerShell's Set-Acl doesn't speak SE_KERNEL_OBJECT for pipe handles.
+  The arg shape and output JSON above are forever-stable — implementation
+  details below the contract may change.
+#>
+
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)] [string] $PipeName,
+  [Parameter(Mandatory = $true)] [string] $Sddl
+)
+
+$ErrorActionPreference = 'Stop'
+
+$fullPath = "\\.\pipe\$PipeName"
+
+Write-Error "TODO: implement when T9.1 lands — P/Invoke advapi32!SetSecurityInfo on pipe handle for $fullPath with SDDL $Sddl"
+exit 64

--- a/tools/spike-harness/snapshot-roundtrip.spec.ts
+++ b/tools/spike-harness/snapshot-roundtrip.spec.ts
@@ -1,0 +1,39 @@
+// snapshot-roundtrip.spec.ts — vitest property runner for SnapshotV1 codec.
+//
+// Spike-harness fixture pinned by spec ch14 §1.B (forever-stable contract).
+// Used by ch14 §1.8 (snapshot byte-equality fuzz). Property:
+//
+//   For all SnapshotV1 inputs `s`:
+//     decode(encode(s)) ≈ s              (semantic equality)
+//     encode(decode(encode(s))) === encode(s)  (byte equality)
+//
+// Contract (FOREVER-STABLE — v0.4 may add cases, never rename/remove the spec):
+//
+//   - Test file path: tools/spike-harness/snapshot-roundtrip.spec.ts
+//   - Spec name:      "SnapshotV1 round-trip"
+//   - Imports the codec from packages/snapshot-codec (pinned by ch06 §1603 of
+//     the design spec).
+//
+// STATUS: describe.skip until T4.6 (SnapshotV1 codec) lands. The test body
+// is intentionally hollow — what matters TODAY is that the file exists at
+// this path so downstream T9.8 wiring can `vitest run tools/spike-harness/`
+// and see the skipped-with-TODO marker. Once T4.6 ships, flip describe.skip
+// to describe and import the real codec.
+
+import { describe, it, expect } from 'vitest';
+
+// TODO(T4.6): uncomment once packages/snapshot-codec exports {encode, decode}.
+// import { encode, decode } from '@ccsm/snapshot-codec';
+
+describe.skip('SnapshotV1 round-trip (TODO: T4.6 codec)', () => {
+  it('decode(encode(s)) is semantically equal to s', () => {
+    // TODO: implement when T4.6 lands.
+    expect(true).toBe(true);
+  });
+
+  it('encode(decode(encode(s))) is byte-identical to encode(s)', () => {
+    // TODO: implement when T4.6 lands. Use vt-grammar.mjs corpus + W1-W6
+    // replay corpus per ch14 §1.8 corpus (C2) and (C3).
+    expect(true).toBe(true);
+  });
+});

--- a/tools/spike-harness/stream-truncation-detector.mjs
+++ b/tools/spike-harness/stream-truncation-detector.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+// stream-truncation-detector.mjs — server-stream consumer asserting no truncation.
+//
+// Spike-harness helper pinned by spec ch14 §1.B (forever-stable contract).
+// Used by ch14 §1.3, §1.4, §1.5 (transport spikes — assert that under a
+// configurable rate, no server-stream frames are dropped or truncated).
+//
+// Contract (FOREVER-STABLE — v0.4 may add flags, never rename/remove):
+//
+//   Usage:
+//     stream-truncation-detector.mjs [--expect-count=<int>]
+//                                    [--rate-hz=<int>]
+//                                    [--timeout-ms=<int>]
+//
+//   Reads NDJSON frames from stdin, one per line:
+//     {"seq": <int>, "ts": <unix-ms>, "len": <int>, ["payloadB64": "<b64>"]}
+//
+//   Behavior:
+//     1. Verify `seq` strictly increases from the first observed value with
+//        gap=1. Any missing seq → record gap; any duplicate → record dup.
+//     2. If --expect-count is set, verify total frames received == expected.
+//     3. If --rate-hz is set, compute observed rate from first/last ts and
+//        flag if observed < 0.95 * expected.
+//     4. If --timeout-ms passes without a new frame, treat as truncation.
+//
+//   Output (stdout, single JSON line on close):
+//     {"frames":<int>,"firstSeq":<int>,"lastSeq":<int>,
+//      "gaps":[<int>,...],"dups":[<int>,...],
+//      "observedRateHz":<num>,"expectedRateHz":<num|null>,
+//      "expectedCount":<int|null>,"truncated":<bool>,"ok":<bool>}
+//
+//   Exit 0 if !truncated && gaps.length===0 && dups.length===0
+//          && (expectedCount === null || frames === expectedCount);
+//   Exit 1 otherwise.
+//
+// Layer-1: node: stdlib only (readline, util).
+
+import { createInterface } from 'node:readline';
+import { parseArgs } from 'node:util';
+
+const { values } = parseArgs({
+  options: {
+    'expect-count': { type: 'string' },
+    'rate-hz':      { type: 'string' },
+    'timeout-ms':   { type: 'string', default: '5000' },
+  },
+  strict: true,
+});
+
+const expectCount = values['expect-count'] ? Number(values['expect-count']) : null;
+const expectRate  = values['rate-hz']      ? Number(values['rate-hz'])      : null;
+const timeoutMs   = Number(values['timeout-ms']);
+
+const gaps = [];
+const dups = [];
+const seen = new Set();
+let frames = 0;
+let firstSeq = null;
+let lastSeq = null;
+let firstTs = null;
+let lastTs = null;
+let truncated = false;
+let timer = null;
+
+function armTimer() {
+  if (timer) clearTimeout(timer);
+  timer = setTimeout(() => {
+    truncated = true;
+    process.stderr.write(`timeout: no frame for ${timeoutMs}ms\n`);
+    rl.close();
+  }, timeoutMs);
+}
+
+const rl = createInterface({ input: process.stdin, crlfDelay: Infinity });
+armTimer();
+
+rl.on('line', (line) => {
+  armTimer();
+  if (!line.trim()) return;
+  let f;
+  try { f = JSON.parse(line); } catch { return; }
+  if (typeof f.seq !== 'number') return;
+  frames++;
+  if (firstSeq === null) {
+    firstSeq = f.seq;
+    firstTs = typeof f.ts === 'number' ? f.ts : null;
+  } else if (f.seq <= lastSeq) {
+    if (seen.has(f.seq)) dups.push(f.seq);
+  } else if (f.seq !== lastSeq + 1) {
+    for (let s = lastSeq + 1; s < f.seq; s++) gaps.push(s);
+  }
+  seen.add(f.seq);
+  lastSeq = f.seq;
+  if (typeof f.ts === 'number') lastTs = f.ts;
+});
+
+rl.on('close', () => {
+  if (timer) clearTimeout(timer);
+  const elapsedMs = (firstTs !== null && lastTs !== null && lastTs > firstTs)
+    ? lastTs - firstTs : 0;
+  const observedRateHz = elapsedMs > 0 ? (frames / (elapsedMs / 1000)) : 0;
+  const ok = !truncated
+    && gaps.length === 0
+    && dups.length === 0
+    && (expectCount === null || frames === expectCount)
+    && (expectRate === null || observedRateHz >= 0.95 * expectRate);
+  process.stdout.write(JSON.stringify({
+    frames,
+    firstSeq:       firstSeq ?? -1,
+    lastSeq:        lastSeq  ?? -1,
+    gaps,
+    dups,
+    observedRateHz,
+    expectedRateHz: expectRate,
+    expectedCount:  expectCount,
+    truncated,
+    ok,
+  }) + '\n');
+  process.exit(ok ? 0 : 1);
+});

--- a/tools/spike-harness/vt-grammar.mjs
+++ b/tools/spike-harness/vt-grammar.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+// vt-grammar.mjs — weighted CSI / OSC / DCS sequence generator for snapshot fuzz.
+//
+// Spike-harness helper pinned by spec ch14 §1.B (forever-stable contract).
+// Used by ch14 §1.8 corpus (C2): weighted grammar producing valid CSI/OSC/DCS
+// sequences with parameter ranges sampled from the xterm-parser-spec table.
+//
+// Contract (FOREVER-STABLE — v0.4 may add flags, never rename/remove):
+//
+//   Usage:
+//     vt-grammar.mjs [--count=<int>]      number of sequences to emit (default 1000)
+//                    [--length=<int>]     target byte length per sequence (default 256)
+//                    [--seed=<int>]       PRNG seed for reproducibility (default 1)
+//                    [--out=<path>]       write to file instead of stdout
+//
+//   Behavior:
+//     Emit `count` raw VT sequences concatenated to stdout (or file).
+//     Sequence categories sampled with weights:
+//       CSI (Control Sequence Introducer) ESC `[` … final-byte    weight 0.55
+//       SGR (subset of CSI, m-final, colour params)                weight 0.20
+//       OSC (Operating System Command)    ESC `]` … BEL|ST         weight 0.15
+//       DCS (Device Control String)       ESC `P` … ST             weight 0.05
+//       printable ASCII filler                                     weight 0.05
+//
+//   Output (stdout / file): raw bytes (binary), exactly `count` sequences.
+//   Output (stderr, last line, JSON):
+//     {"count":<int>,"length":<int>,"seed":<int>,"emittedBytes":<int>}
+//
+//   Exit 0 always (generator never fails); 2 on bad arg.
+//
+// Determinism: same --seed --count --length MUST produce byte-identical output
+// across runs and OSes. This is forever-stable per ch14 §1.B.
+//
+// Layer-1: node: stdlib only (fs, util).
+
+import { writeFileSync } from 'node:fs';
+import { parseArgs } from 'node:util';
+
+const { values } = parseArgs({
+  options: {
+    count:  { type: 'string', default: '1000' },
+    length: { type: 'string', default: '256'  },
+    seed:   { type: 'string', default: '1'    },
+    out:    { type: 'string' },
+  },
+  strict: true,
+});
+
+const count  = Number(values.count);
+const target = Number(values.length);
+const seed   = Number(values.seed);
+
+if (!Number.isFinite(count) || count <= 0)   { process.stderr.write('bad --count\n');  process.exit(2); }
+if (!Number.isFinite(target) || target <= 0) { process.stderr.write('bad --length\n'); process.exit(2); }
+
+// Mulberry32 PRNG — 32-bit, deterministic, no deps.
+function mulberry32(a) {
+  return function () {
+    a |= 0; a = (a + 0x6D2B79F5) | 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+const rand = mulberry32(seed);
+
+const ESC = 0x1B;
+const BEL = 0x07;
+const ST  = [0x1B, 0x5C]; // ESC \
+
+const CSI_FINALS = [0x40, 0x41, 0x42, 0x43, 0x44, 0x48, 0x4A, 0x4B, 0x6D]; // @ A B C D H J K m
+const PRINTABLE  = Array.from({ length: 95 }, (_, i) => 0x20 + i);
+
+function pickWeighted() {
+  const r = rand();
+  if (r < 0.55) return 'CSI';
+  if (r < 0.75) return 'SGR';
+  if (r < 0.90) return 'OSC';
+  if (r < 0.95) return 'DCS';
+  return 'FILL';
+}
+
+function intStr(maxDigits) {
+  const n = Math.floor(rand() * Math.pow(10, 1 + Math.floor(rand() * maxDigits)));
+  return String(n);
+}
+
+function genCSI() {
+  const parts = [ESC, 0x5B]; // ESC [
+  const nParams = 1 + Math.floor(rand() * 3);
+  for (let i = 0; i < nParams; i++) {
+    if (i > 0) parts.push(0x3B); // ;
+    for (const ch of intStr(3)) parts.push(ch.charCodeAt(0));
+  }
+  parts.push(CSI_FINALS[Math.floor(rand() * CSI_FINALS.length)]);
+  return parts;
+}
+
+function genSGR() {
+  const parts = [ESC, 0x5B];
+  const codes = [0, 1, 4, 7, 22, 24, 27, 30, 31, 32, 33, 34, 35, 36, 37,
+                 38, 5, 39, 40, 41, 42, 90, 97];
+  const n = 1 + Math.floor(rand() * 4);
+  for (let i = 0; i < n; i++) {
+    if (i > 0) parts.push(0x3B);
+    const c = codes[Math.floor(rand() * codes.length)];
+    for (const ch of String(c)) parts.push(ch.charCodeAt(0));
+  }
+  parts.push(0x6D); // m
+  return parts;
+}
+
+function genOSC() {
+  const parts = [ESC, 0x5D]; // ESC ]
+  for (const ch of intStr(2)) parts.push(ch.charCodeAt(0));
+  parts.push(0x3B);
+  // payload: random printable
+  const payloadLen = Math.floor(rand() * 16);
+  for (let i = 0; i < payloadLen; i++) {
+    parts.push(PRINTABLE[Math.floor(rand() * PRINTABLE.length)]);
+  }
+  parts.push(BEL);
+  return parts;
+}
+
+function genDCS() {
+  const parts = [ESC, 0x50]; // ESC P
+  const payloadLen = Math.floor(rand() * 32);
+  for (let i = 0; i < payloadLen; i++) {
+    parts.push(PRINTABLE[Math.floor(rand() * PRINTABLE.length)]);
+  }
+  for (const b of ST) parts.push(b);
+  return parts;
+}
+
+function genFill() {
+  const parts = [];
+  for (let i = 0; i < 8; i++) {
+    parts.push(PRINTABLE[Math.floor(rand() * PRINTABLE.length)]);
+  }
+  return parts;
+}
+
+const buf = [];
+for (let i = 0; i < count; i++) {
+  const seqBytes = [];
+  while (seqBytes.length < target) {
+    const cat = pickWeighted();
+    let chunk;
+    switch (cat) {
+      case 'CSI':  chunk = genCSI();  break;
+      case 'SGR':  chunk = genSGR();  break;
+      case 'OSC':  chunk = genOSC();  break;
+      case 'DCS':  chunk = genDCS();  break;
+      default:     chunk = genFill(); break;
+    }
+    for (const b of chunk) seqBytes.push(b);
+  }
+  for (const b of seqBytes) buf.push(b);
+}
+
+const out = Buffer.from(buf);
+
+if (values.out) {
+  writeFileSync(values.out, out);
+} else {
+  process.stdout.write(out);
+}
+
+process.stderr.write(JSON.stringify({
+  count, length: target, seed, emittedBytes: out.length,
+}) + '\n');

--- a/tools/spike-harness/wrap-as-localservice.ps1
+++ b/tools/spike-harness/wrap-as-localservice.ps1
@@ -1,0 +1,73 @@
+<#
+.SYNOPSIS
+  Wrap an .exe as a Windows service running under NT AUTHORITY\LocalService
+  with a caller-supplied SDDL on the service object.
+
+.DESCRIPTION
+  Spike-harness helper pinned by spec ch14 §1.B (forever-stable contract).
+  Used by ch14 §1.1 (peer-cred + named-pipe DACL spike).
+
+  Contract (FOREVER-STABLE — v0.4 may add params, never rename/remove):
+
+    Args (named):
+      -ServiceName <string>   service short name passed to `sc create`
+      -BinPath     <string>   absolute path to the .exe to wrap
+      -Sddl        <string>   SDDL applied via `sc sdset` after create
+      [-StartType  <string>]  one of demand|auto|disabled (default: demand)
+
+    Behavior:
+      1. `sc create <ServiceName> binPath= "<BinPath>" obj= "NT AUTHORITY\LocalService" type= own start= <StartType>`
+      2. `sc sdset <ServiceName> "<Sddl>"`
+      3. Exit 0 on success, non-zero with sc.exe stderr on failure.
+
+    Output (stdout, single line, JSON):
+      {"service":"<ServiceName>","binPath":"<BinPath>","sddl":"<Sddl>","created":true}
+
+  Idempotent? No — caller is responsible for `sc delete <ServiceName>` first
+  if the service already exists. The spike harness wraps this in a
+  before/after script per §1.1.
+#>
+
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)] [string] $ServiceName,
+  [Parameter(Mandatory = $true)] [string] $BinPath,
+  [Parameter(Mandatory = $true)] [string] $Sddl,
+  [ValidateSet('demand', 'auto', 'disabled')] [string] $StartType = 'demand'
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path -LiteralPath $BinPath)) {
+  Write-Error "BinPath not found: $BinPath"
+  exit 2
+}
+
+# sc.exe arguments are space-sensitive — values MUST follow `key= value`
+# with the space after `=`. See ch14 §1.1 step 2.
+$createArgs = @(
+  'create', $ServiceName,
+  'binPath=', $BinPath,
+  'obj=', 'NT AUTHORITY\LocalService',
+  'type=', 'own',
+  'start=', $StartType
+)
+$createOutput = & sc.exe @createArgs 2>&1
+if ($LASTEXITCODE -ne 0) {
+  Write-Error "sc create failed: $createOutput"
+  exit $LASTEXITCODE
+}
+
+$sdsetOutput = & sc.exe sdset $ServiceName $Sddl 2>&1
+if ($LASTEXITCODE -ne 0) {
+  Write-Error "sc sdset failed: $sdsetOutput"
+  exit $LASTEXITCODE
+}
+
+$result = [pscustomobject]@{
+  service = $ServiceName
+  binPath = $BinPath
+  sddl    = $Sddl
+  created = $true
+}
+$result | ConvertTo-Json -Compress


### PR DESCRIPTION
## Summary

Scaffolds `tools/spike-harness/` per design ch14 §1.B. Each script has a header comment documenting its **forever-stable contract** (input args + output format) that downstream T9.1-T9.14 spikes lock against. Stub bodies are acceptable; the contract is the spec.

Refs Task #115. Design: `docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md` chapter 14 §1.B.

## Forever-stable shape

Per ch14 §1.B: v0.4 spikes may **add** scripts (additive), but MUST NOT remove or change the contract of an existing script. Forever-stable surface lives in the per-script header comment + the README inventory table.

## Scripts (contract one-liner + status)

Runnable now (node: stdlib only, no npm deps):

- `delta-collector.mjs` — read NDJSON delta frames from stdin, assert `seq` contiguity + sha256 over concatenated payloads, emit summary JSON. **runnable**
- `vt-grammar.mjs` — deterministic weighted CSI/OSC/DCS/SGR generator (`--seed --count --length`); raw bytes to stdout. **runnable**
- `rtt-histogram.mjs` — read NDJSON `{rttUs}` from stdin, emit histogram + min/max/mean/p50/p95/p99 JSON. **runnable**
- `stream-truncation-detector.mjs` — server-stream consumer; flag gaps/dups/timeout/rate-shortfall; exit non-zero on any. **runnable**
- `sea-hello/index.mjs` — TCP echo on ephemeral port + writes port-file JSON; for SEA / notarization spike. **runnable**
- `connect-and-peercred.sh` — UDS connect + peer-cred report (uid/gid/pid JSON). **runnable scaffold** (peer-cred resolution itself stubs to T9.1 since Node has no public SO_PEERCRED API)
- `wrap-as-localservice.ps1` — `sc create … obj= "NT AUTHORITY\LocalService" type= own` + `sc sdset`; emits creation JSON. **runnable** (sc.exe wrapper)
- `entitlements-jit.plist` — codesign input granting `com.apple.security.cs.allow-jit` + `allow-unsigned-executable-memory`. **runnable** (static fixture)

Stubs with TODO (contract complete, body lands with downstream task):

- `set-pipe-dacl.ps1` — `-PipeName -Sddl` → apply SDDL via SetSecurityInfo. **stub TODO: T9.1** (needs P/Invoke advapi32)
- `connect-and-peercred.ps1` — `<PipePath>` → JSON `{pid, sid}`. **stub TODO: T9.1** (needs P/Invoke kernel32!GetNamedPipeClientProcessId)
- `pty-emitter.mjs` — `--workload=W1..W6 --fixture=…` drives node-pty. **stub TODO: T9.7** (one allowed npm dep, not yet wired)
- `install-residue-diff.sh` / `install-residue-diff.ps1` — `snapshot|diff` modes; NDJSON snapshot format frozen. **stub TODO: T9.16**
- `snapshot-roundtrip.spec.ts` — vitest property runner for SnapshotV1 codec. **describe.skip TODO: T4.6** (codec not yet shipped)

## Layer 1

- No npm deps for things `node:` stdlib already does (crypto, fs, readline, net, util).
- Each unix script `chmod +x` via `git update-index --chmod=+x`.
- Contracts mirror spec §1.B verbatim; downstream T9.x can `bash tools/spike-harness/<script>` or `node tools/spike-harness/<script>.mjs` immediately.

## Test plan

Local smoke (Windows / git-bash, Node 22):
- [x] `vt-grammar.mjs --count=3 --length=64 --seed=42` → 211 deterministic bytes, summary JSON on stderr
- [x] `delta-collector.mjs` with 2 contiguous frames → `gaps:[]`, sha256 emitted, exit 0
- [x] `rtt-histogram.mjs` with 4 samples → correct min/max/mean/p50/p95/p99
- [x] `stream-truncation-detector.mjs` with 3 contiguous frames + `--expect-count=3` → ok:true, exit 0
- [x] `sea-hello/index.mjs` → port-file written with `{port:NNNNN}`
- [x] `pty-emitter.mjs --workload=W1` → emits stub summary + TODO marker (expected)

Downstream verification:
- [ ] T9.1 implements set-pipe-dacl.ps1 + connect-and-peercred peer-cred resolution
- [ ] T9.7 implements pty-emitter.mjs with node-pty
- [ ] T9.16 implements install-residue-diff snapshot/diff bodies
- [ ] T4.6 ships `@ccsm/snapshot-codec`; flip `describe.skip` → `describe` in snapshot-roundtrip.spec.ts