### PR TITLE
feat(monorepo): T0.3 tsconfig.base.json + per-package extends

### DIFF
--- a/packages/daemon/tsconfig.json
+++ b/packages/daemon/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/electron/tsconfig.json
+++ b/packages/electron/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/proto/tsconfig.json
+++ b/packages/proto/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  }
+}


### PR DESCRIPTION
## Summary

Implements Task #13 ([T0.3] monorepo: tsconfig.base.json + per-package tsconfig.json extends), per spec `docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md` chapter 11 §2.

Adds a shared TypeScript config at the repo root and a per-package `tsconfig.json` for each of `packages/{daemon,electron,proto}/` that `extends: "../../tsconfig.base.json"`.

## Files (4 new)

- `tsconfig.base.json` — strict, `target=ES2022`, `module=NodeNext`, `moduleResolution=NodeNext`, `skipLibCheck`, `declaration`+`declarationMap`, `sourceMap`, `isolatedModules`, plus the usual `esModuleInterop`/`forceConsistentCasingInFileNames`/`resolveJsonModule`.
- `packages/daemon/tsconfig.json` — extends base, adds `outDir=dist`, `rootDir=src`, `include: ["src/**/*"]`.
- `packages/electron/tsconfig.json` — extends base, adds `outDir=dist`, `rootDir=src`, `jsx=react-jsx` (renderer code), `include: ["src/**/*"]`.
- `packages/proto/tsconfig.json` — extends base, `noEmit=true` (output comes from buf-codegen in T0.5, not tsc).

## Layer 1 / scope notes

- **Did NOT touch root v0.2 `tsconfig.json`.** It scopes the existing electron app under `src/` and uses bundler-mode resolution + `noEmit`. The new `tsconfig.base.json` is a SEPARATE file consumed only by `packages/*` via `extends`, exactly as described in the spec's repo tree (lines 2710 / 2726 / 2741). The two files do not conflict because they target disjoint source trees.
- No new deps. `typescript@^5.7.2` is already in root `package.json`.
- No `@types/*` added — packages have no source yet; types come per-package later.

## Test plan

- [x] `git diff --stat` against `working` shows exactly the 4 new files, nothing else.
- [x] Each package's tsconfig parses cleanly via `node_modules/.bin/tsc --noEmit -p .` — only emits `TS18003 No inputs were found` (expected: no source files yet), which is the no-source-files error, not a config error. Configs are parseable.
- [ ] CI green on `working` base.

## References

- Task #13
- Spec: `docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md` chapter 11 §2 (monorepo layout)