### PR TITLE
feat(monorepo): T0.4 ESLint flat config + per-package no-restricted-imports

### DIFF
--- a/packages/daemon/eslint.config.js
+++ b/packages/daemon/eslint.config.js
@@ -1,0 +1,38 @@
+// @ccsm/daemon ESLint flat config — extends repo root config and adds
+// per-package boundary rules per design spec ch11 §5.
+//
+// Boundary intent (spec ch11 §5 / ch15 §1 invariant 11):
+//   - Daemon is headless. UI deps (electron / react / react-dom) and the
+//     sibling @ccsm/electron package are forbidden imports.
+//   - Daemon may consume @ccsm/proto, but only the GENERATED Connect-RPC
+//     code under packages/proto/gen/**, not the raw .proto sources under
+//     packages/proto/src/**.
+//
+// Downstream tasks plug additional custom rules onto this same config:
+//   - Task #29 (T1.9) adds `ccsm/no-listener-slot-mutation`
+//     (listener-A descriptor slot mutability lint).
+import rootConfig from '../../eslint.config.js';
+
+export default [
+  ...rootConfig,
+  {
+    rules: {
+      'no-restricted-imports': ['error', {
+        patterns: [
+          {
+            group: ['@ccsm/electron', '@ccsm/electron/*'],
+            message: '@ccsm/daemon MUST NOT import from @ccsm/electron (chapter 11 §5).'
+          },
+          {
+            group: ['electron', 'electron/*', 'react', 'react-dom'],
+            message: '@ccsm/daemon is headless — UI deps forbidden (chapter 11 §5).'
+          },
+          {
+            group: ['@ccsm/proto/src/*', '@ccsm/proto/src'],
+            message: '@ccsm/daemon may only import generated Connect-RPC code from @ccsm/proto/gen/**, not raw .proto sources (chapter 11 §5).'
+          }
+        ]
+      }]
+    }
+  }
+];

--- a/packages/electron/eslint.config.js
+++ b/packages/electron/eslint.config.js
@@ -1,0 +1,52 @@
+// @ccsm/electron ESLint flat config — extends repo root config and adds
+// per-package boundary rules per design spec ch11 §5 + ch12 §4.1.
+//
+// Boundary intent:
+//   - Electron is the thin client. It MUST NOT import @ccsm/daemon source
+//     directly; the only sanctioned cross-package surface is the generated
+//     Connect-RPC client under @ccsm/proto/gen/**.
+//   - Native modules (node-pty, better-sqlite3, etc.) belong in the daemon,
+//     never the renderer/main process (chapter 11 §5).
+//   - F3 backstop for ship-gate (a) (chapter 12 §4.1): forbid named
+//     imports of `ipcMain`, `ipcRenderer`, `contextBridge` from `electron`.
+//     The substring grep in tools/lint-no-ipc.sh is the cheap fast layer;
+//     this AST-aware ESLint rule catches renamed/aliased imports
+//     (e.g. `import { ipcMain as M } from "electron"`) the grep cannot.
+//     Sanctioned exceptions go through tools/.no-ipc-allowlist (currently
+//     descriptor preload only — see chapter 08 §5).
+//
+// Downstream tasks plug additional custom rules onto this same config:
+//   - Task #70 (T6.6) adds `ccsm/no-electron-ipc-call`
+//     (forbid runtime ipc.* calls beyond the import-level check below).
+import rootConfig from '../../eslint.config.js';
+
+export default [
+  ...rootConfig,
+  {
+    rules: {
+      'no-restricted-imports': ['error', {
+        paths: [
+          {
+            name: 'electron',
+            importNames: ['ipcMain', 'ipcRenderer', 'contextBridge'],
+            message: 'v0.3 forbids ipcMain / ipcRenderer / contextBridge — see chapter 08 §5; sanctioned exceptions go through tools/.no-ipc-allowlist (descriptor preload only).'
+          }
+        ],
+        patterns: [
+          {
+            group: ['@ccsm/daemon', '@ccsm/daemon/*'],
+            message: '@ccsm/electron MUST NOT import from @ccsm/daemon — only @ccsm/proto/gen/** Connect-RPC clients are allowed (chapter 11 §5).'
+          },
+          {
+            group: ['node-pty', 'better-sqlite3'],
+            message: 'Native modules belong in @ccsm/daemon, not the renderer/main (chapter 11 §5).'
+          },
+          {
+            group: ['@ccsm/proto/src/*', '@ccsm/proto/src'],
+            message: '@ccsm/electron may only import generated Connect-RPC code from @ccsm/proto/gen/**, not raw .proto sources (chapter 11 §5).'
+          }
+        ]
+      }]
+    }
+  }
+];

--- a/packages/proto/eslint.config.js
+++ b/packages/proto/eslint.config.js
@@ -1,0 +1,24 @@
+// @ccsm/proto ESLint flat config — extends repo root config and adds
+// per-package boundary rules per design spec ch11 §5.
+//
+// Boundary intent: @ccsm/proto is the leaf package. It defines schemas and
+// generated Connect-RPC code; it MUST NOT import from any other internal
+// @ccsm/* package (no cycles, no runtime coupling). Generated code under
+// packages/proto/gen/** is allowed to depend only on @bufbuild/* runtime.
+import rootConfig from '../../eslint.config.js';
+
+export default [
+  ...rootConfig,
+  {
+    rules: {
+      'no-restricted-imports': ['error', {
+        patterns: [
+          {
+            group: ['@ccsm/daemon', '@ccsm/daemon/*', '@ccsm/electron', '@ccsm/electron/*'],
+            message: '@ccsm/proto is a leaf package — it MUST NOT import from any other @ccsm/* package (chapter 11 §5).'
+          }
+        ]
+      }]
+    }
+  }
+];


### PR DESCRIPTION
## Summary

Implements **Task #14** ([T0.4] monorepo: ESLint flat config + per-package no-restricted-imports rules).

Adds three flat-config files (one per workspace package) that extend the existing repo-root `eslint.config.js` and layer per-package boundary rules per design spec ch11 §5 + ch12 §4.1.

- `packages/daemon/eslint.config.js` — forbids importing from `@ccsm/electron`, raw `electron` / `react` / `react-dom` UI deps, and `packages/proto/src/**` (only `packages/proto/gen/**` Connect-RPC code allowed).
- `packages/electron/eslint.config.js` — forbids importing `@ccsm/daemon`, native modules (`node-pty`, `better-sqlite3`), `packages/proto/src/**`, AND named imports of `ipcMain` / `ipcRenderer` / `contextBridge` from `"electron"`. The IPC import block is the **F3 backstop for ship-gate (a)** (ch12 §4.1) — the AST-aware companion to the substring grep in `tools/lint-no-ipc.sh`, catching renamed/aliased imports the grep cannot (e.g. `import { ipcMain as M } from "electron"`).
- `packages/proto/eslint.config.js` — proto is the leaf; forbids importing any other `@ccsm/*` package.

## Layer 1 / scope notes

- Uses only the built-in `no-restricted-imports` rule. **No new ESLint plugins, no new dependencies.** Root v0.2 already pins `eslint ^9.17`, which supports flat config natively.
- **Root `eslint.config.js` is left untouched.** Each per-package config is picked up by ESLint's nearest-config resolution when lint runs from inside that package (`pnpm -r run lint`).
- No `package.json` changes; per-package `lint` scripts will land with the pnpm/Turborepo wiring task.
- Custom `ccsm/*` rules are NOT scaffolded here — this PR only sets up the framework. They plug onto the same configs in downstream tasks:
  - **Task #29 (T1.9)**: `ccsm/no-listener-slot-mutation` plugs into `packages/daemon/eslint.config.js`.
  - **Task #70 (T6.6)**: `ccsm/no-electron-ipc-call` plugs into `packages/electron/eslint.config.js` (the runtime call check that complements the import-level block already added here).

## Test plan

- [x] `cd packages/daemon && npx eslint --print-config src/index.ts` resolves cleanly and prints the expected `no-restricted-imports` rule body.
- [x] Same for `packages/electron` (verified `paths` block contains `electron` + `ipcMain`/`ipcRenderer`/`contextBridge` and `patterns` block contains `@ccsm/daemon`, `node-pty`, `better-sqlite3`).
- [x] Same for `packages/proto` (verified `patterns` block forbids `@ccsm/daemon` + `@ccsm/electron`).
- [x] Root `npm run lint` (v0.2 lint job) still passes — 0 errors, only pre-existing warnings.
- [x] `git diff --stat` shows exactly the 3 new `packages/*/eslint.config.js` files; no other changes.
- [ ] CI lint job green on push.

## References

- Design spec: `docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md`
  - Chapter 11 §5 (per-package boundary lint).
  - Chapter 12 §4.1 (ship-gate (a) — no-IPC grep + ESLint backstop).
  - Chapter 15 §1 invariant 11 (bypass-of-`lint:no-ipc` enforcement mechanism).