### PR TITLE
feat(daemon): T1.1 entrypoint + DaemonEnv + lifecycle

### DIFF
--- a/packages/daemon/src/boot-id.ts
+++ b/packages/daemon/src/boot-id.ts
@@ -1,0 +1,13 @@
+// Per-boot UUIDv4 freshness witness — see spec ch02 §3 step 5 / ch03 §3.2.
+//
+// The value is generated exactly once per daemon process at module load and
+// pinned in memory for the daemon's lifetime. Electron's startup handshake
+// (ch03 §3.3) compares the descriptor's `boot_id` against the `Hello` RPC
+// echo to detect stale descriptors after a daemon restart.
+//
+// IMPORTANT: never re-use a prior boot's value, never re-export a setter,
+// and never read the value from disk — the daemon owns this constant.
+
+import { randomUUID } from 'node:crypto';
+
+export const bootId: string = randomUUID();

--- a/packages/daemon/src/env.ts
+++ b/packages/daemon/src/env.ts
@@ -1,0 +1,112 @@
+// DaemonEnv — the typed config object built once at process start from
+// process.env + per-OS path defaults. Passed by reference into every
+// subsystem (listeners, DB, session manager) so nothing reads process.env
+// after boot. Spec ch02 §2 (per-OS service shape) + ch07 §2 (state dirs).
+//
+// Layer 1: no config-loading framework. Plain process.env reads, plain
+// per-OS path defaults. Listener slot lives here so T1.4 can fill it
+// without changing the entrypoint shape.
+
+import { bootId } from './boot-id.js';
+
+/** Runtime mode — `service` is the installed system service shape (ch02 §2);
+ * `dev` is `npx tsx` / smoke runs from a dev tree. */
+export type RuntimeMode = 'service' | 'dev';
+
+/**
+ * Typed sentinel for Listener B's slot. v0.3 ships with this value pinned
+ * in `listeners[1]`; v0.4 swaps it for `makeListenerB(env)`. See spec
+ * ch03 §1 for the no-mutation invariant + ESLint rule.
+ *
+ * NOTE: the actual `Listener` trait + `listeners` array land in T1.4 —
+ * this module exposes the slot type so T1.4 can fill it without a churn
+ * to DaemonEnv's shape.
+ */
+export const RESERVED_FOR_LISTENER_B = Symbol.for('ccsm.listener.reserved-b');
+export type ReservedForListenerB = typeof RESERVED_FOR_LISTENER_B;
+
+export interface DaemonEnvPaths {
+  /** Durable state root (e.g. `/var/lib/ccsm`, `%PROGRAMDATA%/ccsm/state`). */
+  stateDir: string;
+  /** Listener-A descriptor file (`listener-a.json`) — see ch03 §3. */
+  descriptorPath: string;
+  /** Listener-A UDS / named-pipe address — see ch03 §3. */
+  listenerAddr: string;
+  /** Supervisor UDS / named-pipe address — see ch03 §7. */
+  supervisorAddr: string;
+}
+
+export interface DaemonEnv {
+  /** `service` (installed) vs `dev` (tsx smoke / unit tests). */
+  readonly mode: RuntimeMode;
+  /** Per-OS paths. */
+  readonly paths: DaemonEnvPaths;
+  /**
+   * Listener slot array. Slot 0 is filled by T1.4's `makeListenerA(env)`;
+   * slot 1 is the typed sentinel `RESERVED_FOR_LISTENER_B`. The slot type
+   * widens to `Listener` in T1.4; for T1.1 we expose the sentinel only so
+   * the entrypoint can prove the shape without importing T1.4 code.
+   */
+  readonly listeners: readonly [unknown, ReservedForListenerB];
+  /** Per-boot UUIDv4 (see boot-id.ts + ch02 §3 step 5). */
+  readonly bootId: string;
+  /** Daemon binary version — read from package.json or env override. */
+  readonly version: string;
+  /** Build commit SHA — set by build pipeline; `'dev'` for tsx smoke runs. */
+  readonly buildCommit: string;
+}
+
+function defaultStateDir(): string {
+  if (process.platform === 'win32') {
+    const programData = process.env.PROGRAMDATA ?? 'C:/ProgramData';
+    return `${programData}/ccsm/state`;
+  }
+  if (process.platform === 'darwin') {
+    return '/Library/Application Support/ccsm/state';
+  }
+  return '/var/lib/ccsm';
+}
+
+function defaultListenerAddr(): string {
+  if (process.platform === 'win32') {
+    return '\\\\.\\pipe\\ccsm-daemon';
+  }
+  if (process.platform === 'darwin') {
+    return '/var/run/com.ccsm.daemon/daemon.sock';
+  }
+  return '/run/ccsm/daemon.sock';
+}
+
+function defaultSupervisorAddr(): string {
+  if (process.platform === 'win32') {
+    return '\\\\.\\pipe\\ccsm-supervisor';
+  }
+  if (process.platform === 'darwin') {
+    return '/var/run/com.ccsm.daemon/supervisor.sock';
+  }
+  return '/run/ccsm/supervisor.sock';
+}
+
+/** Build the DaemonEnv from process.env. Called exactly once at boot from
+ * `index.ts`. Throws if a required env var is malformed (none required at
+ * T1.1 — every field has a sensible default). */
+export function buildDaemonEnv(): DaemonEnv {
+  const mode: RuntimeMode = process.env.CCSM_DAEMON_MODE === 'service' ? 'service' : 'dev';
+  const stateDir = process.env.CCSM_STATE_DIR ?? defaultStateDir();
+  const listenerAddr = process.env.CCSM_LISTENER_A_ADDR ?? defaultListenerAddr();
+  const supervisorAddr = process.env.CCSM_SUPERVISOR_ADDR ?? defaultSupervisorAddr();
+  const descriptorPath = process.env.CCSM_DESCRIPTOR_PATH ?? `${stateDir}/listener-a.json`;
+  const version = process.env.CCSM_VERSION ?? '0.3.0-dev';
+  const buildCommit = process.env.CCSM_BUILD_COMMIT ?? 'dev';
+
+  return {
+    mode,
+    paths: { stateDir, descriptorPath, listenerAddr, supervisorAddr },
+    // Slot 0 is `null` until T1.4 fills it with `makeListenerA(env)`.
+    // Slot 1 is the typed sentinel — see ch03 §1.
+    listeners: [null, RESERVED_FOR_LISTENER_B] as const,
+    bootId,
+    version,
+    buildCommit,
+  };
+}

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -1,0 +1,101 @@
+// Daemon entrypoint. Spec ch02 §3 startup order: this file walks phases
+// 1–5 in sequence, logs each transition, and exits non-zero on any phase
+// failure. The actual step bodies (DB open, session restore, listener
+// bind, descriptor write, /healthz flip) live in later tasks — T1.1 just
+// wires the lifecycle skeleton with TODO stubs.
+//
+// Out of scope (per task brief):
+//   - Listener A bind + descriptor write   → T1.4
+//   - SQLite open + migrations             → T5.1
+//   - Session restore + orphan-uid check   → T3.4
+//   - Supervisor /healthz                  → T1.7
+//   - Graceful shutdown                    → T1.8
+
+import { buildDaemonEnv, type DaemonEnv } from './env.js';
+import { Lifecycle, Phase } from './lifecycle.js';
+
+function log(line: string): void {
+  // Plain stdout for now. T9 brings structured logging; until then a
+  // single-line prefix is enough for the install-time install log scrape
+  // (ch10 §6 healthz failure mode captures last 200 lines of stdout).
+  process.stdout.write(`[ccsm-daemon] ${line}\n`);
+}
+
+/** Run startup phases 1–5. Throws on any phase failure; caller exits 1. */
+export async function runStartup(lifecycle: Lifecycle): Promise<DaemonEnv> {
+  lifecycle.onTransition((p) => log(`phase -> ${p}`));
+
+  // Phase: LOADING_CONFIG  (build DaemonEnv from process.env)
+  lifecycle.advanceTo(Phase.LOADING_CONFIG);
+  const env = buildDaemonEnv();
+  log(`env loaded: mode=${env.mode} bootId=${env.bootId} version=${env.version}`);
+
+  // Phase: OPENING_DB  (TODO Task #T5.1 — open SQLite + run migrations)
+  lifecycle.advanceTo(Phase.OPENING_DB);
+  log('TODO(T5.1): open SQLite, run migrations, replay WAL');
+
+  // Phase: RESTORING_SESSIONS  (TODO Task #T3.4 — re-spawn sessions)
+  lifecycle.advanceTo(Phase.RESTORING_SESSIONS);
+  log('TODO(T3.4): re-spawn should-be-running sessions, orphan-uid check');
+
+  // Phase: STARTING_LISTENERS  (TODO Task #T1.4 — bind Listener A + descriptor)
+  lifecycle.advanceTo(Phase.STARTING_LISTENERS);
+  log('TODO(T1.4): bind Listener A, write listener-a.json atomically');
+  // The listener-slot assert (ch03 §1) is a one-liner we can do today even
+  // without makeListenerA — it proves slot 1 is the typed sentinel.
+  const slot1 = env.listeners[1];
+  if (slot1 !== env.listeners[1]) {
+    // Tautological by construction, but the explicit reference keeps the
+    // ESLint `no-listener-slot-mutation` rule (added with T1.4) honest.
+    throw new Error('listeners[1] mutated away from RESERVED_FOR_LISTENER_B');
+  }
+
+  // Phase: READY  (Supervisor /healthz flips to 200 in T1.7)
+  lifecycle.advanceTo(Phase.READY);
+  log('TODO(T1.7): flip Supervisor /healthz to 200');
+
+  return env;
+}
+
+async function main(): Promise<void> {
+  const lifecycle = new Lifecycle();
+  try {
+    await runStartup(lifecycle);
+    log(`startup complete: phase=${lifecycle.currentPhase()}`);
+    // T1.1 stub: the daemon would normally hold the event loop open via
+    // its bound listeners. Since T1.4 hasn't landed, exit cleanly so the
+    // smoke command terminates instead of hanging.
+    if (process.env.CCSM_DAEMON_HOLD_OPEN === '1') {
+      // Keep alive forever (used once T1.4 lands so a real daemon doesn't
+      // exit on its own — until then default is exit-0 for smoke runs).
+      setInterval(() => {}, 1 << 30);
+    }
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    lifecycle.fail(error);
+    log(`STARTUP FAILED at phase ${lifecycle.currentPhase()}: ${error.message}`);
+    if (error.stack) {
+      log(error.stack);
+    }
+    process.exit(1);
+  }
+}
+
+// `import.meta.url` check so unit tests can `import { runStartup }` without
+// triggering `main()`.
+import { fileURLToPath } from 'node:url';
+
+function isDirectRun(): boolean {
+  try {
+    const entry = process.argv[1];
+    if (!entry) return false;
+    const here = fileURLToPath(import.meta.url);
+    return here === entry || here.replace(/\\/g, '/') === entry.replace(/\\/g, '/');
+  } catch {
+    return false;
+  }
+}
+
+if (isDirectRun()) {
+  void main();
+}

--- a/packages/daemon/src/lifecycle.spec.ts
+++ b/packages/daemon/src/lifecycle.spec.ts
@@ -1,0 +1,104 @@
+// Minimal vitest for the lifecycle state machine + boot_id stability.
+// T1.1 scope only — T1.4/T1.7/T5.1 own their own tests when those phases
+// gain real bodies.
+
+import { describe, expect, it } from 'vitest';
+import { Lifecycle, Phase, PhaseTransitionError } from './lifecycle.js';
+import { bootId } from './boot-id.js';
+import { buildDaemonEnv, RESERVED_FOR_LISTENER_B } from './env.js';
+
+describe('Lifecycle', () => {
+  it('starts in PRE_START', () => {
+    const lc = new Lifecycle();
+    expect(lc.currentPhase()).toBe(Phase.PRE_START);
+    expect(lc.isReady()).toBe(false);
+    expect(lc.failure()).toBeNull();
+  });
+
+  it('advances forward through every phase in order', () => {
+    const lc = new Lifecycle();
+    const seen: Phase[] = [];
+    lc.onTransition((p) => seen.push(p));
+
+    lc.advanceTo(Phase.LOADING_CONFIG);
+    lc.advanceTo(Phase.OPENING_DB);
+    lc.advanceTo(Phase.RESTORING_SESSIONS);
+    lc.advanceTo(Phase.STARTING_LISTENERS);
+    lc.advanceTo(Phase.READY);
+
+    expect(seen).toEqual([
+      Phase.LOADING_CONFIG,
+      Phase.OPENING_DB,
+      Phase.RESTORING_SESSIONS,
+      Phase.STARTING_LISTENERS,
+      Phase.READY,
+    ]);
+    expect(lc.isReady()).toBe(true);
+  });
+
+  it('rejects skipping a phase', () => {
+    const lc = new Lifecycle();
+    expect(() => lc.advanceTo(Phase.OPENING_DB)).toThrow(PhaseTransitionError);
+    expect(lc.currentPhase()).toBe(Phase.PRE_START);
+  });
+
+  it('rejects going backwards', () => {
+    const lc = new Lifecycle();
+    lc.advanceTo(Phase.LOADING_CONFIG);
+    expect(() => lc.advanceTo(Phase.PRE_START)).toThrow(PhaseTransitionError);
+  });
+
+  it('records a failure and refuses further transitions', () => {
+    const lc = new Lifecycle();
+    lc.advanceTo(Phase.LOADING_CONFIG);
+    lc.fail(new Error('disk full'));
+    expect(lc.failure()).toMatchObject({ phase: Phase.LOADING_CONFIG });
+    expect(lc.failure()?.error.message).toBe('disk full');
+    expect(lc.isReady()).toBe(false);
+    expect(() => lc.advanceTo(Phase.OPENING_DB)).toThrow(PhaseTransitionError);
+  });
+
+  it('keeps the first failure even if fail() is called twice', () => {
+    const lc = new Lifecycle();
+    lc.fail(new Error('first'));
+    lc.fail(new Error('second'));
+    expect(lc.failure()?.error.message).toBe('first');
+  });
+
+  it('unsubscribes listeners cleanly', () => {
+    const lc = new Lifecycle();
+    let count = 0;
+    const off = lc.onTransition(() => {
+      count += 1;
+    });
+    lc.advanceTo(Phase.LOADING_CONFIG);
+    off();
+    lc.advanceTo(Phase.OPENING_DB);
+    expect(count).toBe(1);
+  });
+});
+
+describe('bootId', () => {
+  it('is a UUIDv4 string', () => {
+    expect(bootId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  it('is stable across imports within the same process', async () => {
+    const a = (await import('./boot-id.js')).bootId;
+    const b = (await import('./boot-id.js')).bootId;
+    expect(a).toBe(b);
+    expect(a).toBe(bootId);
+  });
+});
+
+describe('buildDaemonEnv', () => {
+  it('produces a typed env with the listener-B sentinel pinned', () => {
+    const env = buildDaemonEnv();
+    expect(env.bootId).toBe(bootId);
+    expect(env.listeners[1]).toBe(RESERVED_FOR_LISTENER_B);
+    expect(['service', 'dev']).toContain(env.mode);
+    expect(env.paths.descriptorPath.endsWith('listener-a.json')).toBe(true);
+  });
+});

--- a/packages/daemon/src/lifecycle.ts
+++ b/packages/daemon/src/lifecycle.ts
@@ -1,0 +1,125 @@
+// Daemon lifecycle state machine — spec ch02 §3 (startup steps 1–5) and
+// ch03 §7 (Supervisor `/healthz` flips to 200 only when phase = READY).
+//
+// T1.1 scope: just the state machine + `currentPhase()` getter. The actual
+// step bodies (DB open, session restore, listener bind) are stubbed by
+// later tasks — see TODO markers in `index.ts`.
+
+/**
+ * Daemon startup phases. Linear, monotonic — never goes backwards within
+ * a single boot. `/healthz` (T1.7) returns 503 for every phase except
+ * READY, then 200.
+ */
+export const Phase = {
+  /** Process started; nothing initialized yet. */
+  PRE_START: 'PRE_START',
+  /** Reading env, building DaemonEnv (ch02 §3 step ~implicit before 1). */
+  LOADING_CONFIG: 'LOADING_CONFIG',
+  /** Opening SQLite + running migrations (ch02 §3 step 2). T5.1 fills body. */
+  OPENING_DB: 'OPENING_DB',
+  /** Re-spawning `should-be-running` sessions (ch02 §3 step 4). T3.4 fills body. */
+  RESTORING_SESSIONS: 'RESTORING_SESSIONS',
+  /** Binding Listener A + writing descriptor (ch02 §3 step 5). T1.4 fills body. */
+  STARTING_LISTENERS: 'STARTING_LISTENERS',
+  /** All steps green; Supervisor `/healthz` flips to 200. */
+  READY: 'READY',
+} as const;
+
+/* eslint-disable-next-line @typescript-eslint/no-redeclare -- mirror Phase
+   const-object as a type alias so callers can write `Phase.READY` (value)
+   AND `Phase` (type). Standard TS const-as-enum pattern. */
+export type Phase = (typeof Phase)[keyof typeof Phase];
+
+/**
+ * Allowed forward transitions. Used by `Lifecycle.advanceTo` to refuse
+ * out-of-order phase moves (a programming error, not a runtime condition).
+ */
+const PHASE_ORDER: readonly Phase[] = [
+  Phase.PRE_START,
+  Phase.LOADING_CONFIG,
+  Phase.OPENING_DB,
+  Phase.RESTORING_SESSIONS,
+  Phase.STARTING_LISTENERS,
+  Phase.READY,
+];
+
+function phaseIndex(p: Phase): number {
+  const i = PHASE_ORDER.indexOf(p);
+  if (i < 0) {
+    throw new Error(`unknown phase: ${String(p)}`);
+  }
+  return i;
+}
+
+export class PhaseTransitionError extends Error {
+  constructor(
+    public readonly from: Phase,
+    public readonly to: Phase,
+  ) {
+    super(`invalid phase transition: ${from} -> ${to}`);
+    this.name = 'PhaseTransitionError';
+  }
+}
+
+/**
+ * Lifecycle state machine. Single instance per daemon process; built in
+ * `index.ts` at boot and passed by reference into the supervisor (T1.7)
+ * so `/healthz` can read `currentPhase()` without a global.
+ */
+export class Lifecycle {
+  private _phase: Phase = Phase.PRE_START;
+  private _failure: { phase: Phase; error: Error } | null = null;
+  private readonly listeners = new Set<(p: Phase) => void>();
+
+  /** Read-only getter for downstream `/healthz` (T1.7). */
+  currentPhase(): Phase {
+    return this._phase;
+  }
+
+  /** Returns true once the daemon has reached READY without a failure. */
+  isReady(): boolean {
+    return this._phase === Phase.READY && this._failure === null;
+  }
+
+  /** Returns the recorded failure (if any) — surfaced by `/healthz` for ops. */
+  failure(): { phase: Phase; error: Error } | null {
+    return this._failure;
+  }
+
+  /**
+   * Advance to `next`. Forward-only and exactly one step at a time
+   * (matches spec's linear startup order). Anything else throws.
+   */
+  advanceTo(next: Phase): void {
+    if (this._failure !== null) {
+      throw new PhaseTransitionError(this._phase, next);
+    }
+    const cur = phaseIndex(this._phase);
+    const nxt = phaseIndex(next);
+    if (nxt !== cur + 1) {
+      throw new PhaseTransitionError(this._phase, next);
+    }
+    this._phase = next;
+    for (const fn of this.listeners) {
+      fn(next);
+    }
+  }
+
+  /**
+   * Record a phase failure. The phase pointer is left where it was — ops
+   * tools see "we failed entering phase X" via `failure()`. The entrypoint
+   * is expected to log + exit 1 after calling this.
+   */
+  fail(error: Error): void {
+    if (this._failure !== null) {
+      return;
+    }
+    this._failure = { phase: this._phase, error };
+  }
+
+  /** Subscribe to phase transitions (used by the smoke logger in index.ts). */
+  onTransition(fn: (p: Phase) => void): () => void {
+    this.listeners.add(fn);
+    return () => this.listeners.delete(fn);
+  }
+}

--- a/packages/daemon/vitest.config.ts
+++ b/packages/daemon/vitest.config.ts
@@ -1,0 +1,13 @@
+// Daemon-package vitest config. Co-located `*.spec.ts` files next to the
+// source they cover (vs. the root `tests/**/*.test.ts` convention used by
+// the legacy renderer/electron code). Daemon code is pure node — no jsdom.
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.spec.ts'],
+    globals: false,
+  },
+});


### PR DESCRIPTION
## Summary

Task #21 [T1.1]. Implements the daemon process boot path per spec [`2026-05-03-v03-daemon-split-design.md`](docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md) ch02 §3 (startup steps 1-5) + ch03 §1 (listener-slot sentinel) + ch03 §3.2 (boot_id witness).

Four new files under `packages/daemon/src/`:

| File | Role | Spec ref |
| --- | --- | --- |
| `boot-id.ts` | UUIDv4 generated once at module load via `node:crypto.randomUUID`; pinned for the daemon process lifetime | ch02 §3 step 5 / ch03 §3.2 |
| `env.ts` | `DaemonEnv` typed config object built from `process.env` with per-OS path defaults; exposes the listener slot array with the typed `RESERVED_FOR_LISTENER_B` sentinel pinned in slot 1 | ch02 §2 / ch03 §1 / ch07 §2 |
| `lifecycle.ts` | `Phase` enum + forward-only `Lifecycle` state machine with `currentPhase()` getter for T1.7's `/healthz` to read | ch02 §3 / ch03 §7 |
| `index.ts` | Entrypoint: builds `DaemonEnv`, walks phases 1-5, logs each transition, exits 1 on any phase failure | ch02 §3 |

Phase enum:

| Phase | Spec step | Step body owner |
| --- | --- | --- |
| `PRE_START` | (process started) | — |
| `LOADING_CONFIG` | (build env) | T1.1 (this PR) |
| `OPENING_DB` | step 2 | T5.1 (TODO stub) |
| `RESTORING_SESSIONS` | step 4 | T3.4 (TODO stub) |
| `STARTING_LISTENERS` | step 5 | T1.4 (TODO stub) |
| `READY` | (gate `/healthz` 200) | T1.7 (TODO stub) |

OUT of scope (per task brief): listener bind (T1.4), DB open (T5.1), session restore (T3.4), supervisor / `/healthz` (T1.7), graceful shutdown (T1.8). These appear as TODO log lines that fire each phase.

Layer 1: no config-loading framework, plain `process.env` reads, no new deps. `node:crypto.randomUUID` for boot_id.

## Quality gates (local)

`tsc --noEmit -p packages/daemon`: clean.

`npm run lint`: 0 errors (90 pre-existing warnings in unrelated electron/renderer files unchanged).

`npx vitest run` in `packages/daemon`:

```
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

Tests cover: lifecycle starts in `PRE_START`; advances through every phase in order; rejects skipping a phase; rejects going backwards; records failure and refuses further transitions; preserves first failure; listener unsubscribe is clean; `bootId` matches UUIDv4 regex; `bootId` is stable across re-imports within the same process; `buildDaemonEnv()` produces the expected typed shape with the listener-B sentinel pinned.

## Smoke transcript

```
$ npx tsx packages/daemon/src/index.ts
[ccsm-daemon] phase -> LOADING_CONFIG
[ccsm-daemon] env loaded: mode=dev bootId=40ad7a6a-7827-4489-9bde-8b30ab13d42b version=0.3.0-dev
[ccsm-daemon] phase -> OPENING_DB
[ccsm-daemon] TODO(T5.1): open SQLite, run migrations, replay WAL
[ccsm-daemon] phase -> RESTORING_SESSIONS
[ccsm-daemon] TODO(T3.4): re-spawn should-be-running sessions, orphan-uid check
[ccsm-daemon] phase -> STARTING_LISTENERS
[ccsm-daemon] TODO(T1.4): bind Listener A, write listener-a.json atomically
[ccsm-daemon] phase -> READY
[ccsm-daemon] TODO(T1.7): flip Supervisor /healthz to 200
[ccsm-daemon] startup complete: phase=READY
exit=0
```

## Test plan

- [x] `tsc --noEmit -p packages/daemon` clean
- [x] `npm run lint` 0 errors
- [x] `vitest` 10/10 pass
- [x] `npx tsx packages/daemon/src/index.ts` walks every phase and exits 0