### PR TITLE
feat(proto): T0.5 buf.gen.yaml v2 + connect-es codegen

### DIFF
--- a/packages/proto/.gitignore
+++ b/packages/proto/.gitignore
@@ -1,0 +1,13 @@
+# Override root .gitignore's broad `gen/` rule so we can keep placeholder
+# .gitkeep files for the per-language gen subdirs (per spec ch11 §4 layout).
+# We must un-ignore the directory itself before negating individual files.
+!gen/
+!gen/go/
+!gen/swift/
+!gen/go/.gitkeep
+!gen/swift/.gitkeep
+
+# But keep generated TypeScript output untracked. It is regenerated from
+# src/**.proto via `pnpm --filter @ccsm/proto run gen` and gated in CI by
+# T0.8 (generated-code-up-to-date check).
+gen/ts/

--- a/packages/proto/buf.gen.yaml
+++ b/packages/proto/buf.gen.yaml
@@ -1,0 +1,27 @@
+# Buf code generation config (schema v2).
+# See specs/2026-05-03-v03-daemon-split-design.md ch11 §4 for the layout.
+#
+# What this generates:
+#   - TypeScript Connect-ES bindings (messages + service descriptors) into
+#     packages/proto/gen/ts/. Consumed by @ccsm/daemon (server) and
+#     @ccsm/electron (client) via @connectrpc/connect at runtime.
+#
+# What is intentionally NOT generated yet (placeholders only):
+#   - Go bindings  → packages/proto/gen/go/.gitkeep   (T0.x: Go daemon TBD)
+#   - Swift bindings → packages/proto/gen/swift/.gitkeep (T0.x: iOS client TBD)
+#
+# Regenerate locally:
+#   pnpm --filter @ccsm/proto run gen
+#
+# CI gate: T0.8 wires `pnpm gen` + `git diff --exit-code` so PRs cannot land
+# stale generated code. `buf breaking` is a separate gate (T0.7).
+version: v2
+plugins:
+  # @bufbuild/protoc-gen-es v2 generates both message types and service
+  # descriptors. Connect-ES consumes the generated GenService directly via
+  # @connectrpc/connect — no separate connect-es plugin needed.
+  - local: protoc-gen-es
+    out: gen/ts
+    opt:
+      - target=ts
+      - import_extension=js

--- a/packages/proto/buf.yaml
+++ b/packages/proto/buf.yaml
@@ -1,0 +1,9 @@
+# Buf module config (schema v2). Declares the proto module root so
+# `buf generate` can discover .proto files and resolve `ccsm/v1/*.proto`
+# imports.
+#
+# Lint / breaking-change rules are intentionally NOT configured here yet —
+# they land in T0.7 (`buf breaking` CI gate). buf.lock lands in T0.6.
+version: v2
+modules:
+  - path: src

--- a/packages/proto/gen/go/.gitkeep
+++ b/packages/proto/gen/go/.gitkeep
@@ -1,0 +1,3 @@
+# Placeholder. Go bindings will land in a later task once the Go daemon
+# implementation begins (see specs/2026-05-03-v03-daemon-split-design.md
+# ch11 §4). For v0.3 the daemon is TS-only.

--- a/packages/proto/gen/swift/.gitkeep
+++ b/packages/proto/gen/swift/.gitkeep
@@ -1,0 +1,3 @@
+# Placeholder. Swift bindings will land when the iOS client work begins
+# (see specs/2026-05-03-v03-daemon-split-design.md ch11 §4). For v0.3 there
+# is no iOS surface.

--- a/packages/proto/package.json
+++ b/packages/proto/package.json
@@ -2,5 +2,13 @@
   "name": "@ccsm/proto",
   "version": "0.0.0",
   "private": true,
-  "description": "CCSM proto definitions and generated Connect-RPC code. Skeleton only; implementation lands in subsequent T0.x / T1.x tasks per design spec ch11."
+  "description": "CCSM proto definitions and generated Connect-RPC code. Skeleton only; implementation lands in subsequent T0.x / T1.x tasks per design spec ch11.",
+  "scripts": {
+    "clean": "node -e \"require('fs').rmSync('gen/ts',{recursive:true,force:true})\"",
+    "gen": "buf generate"
+  },
+  "devDependencies": {
+    "@bufbuild/buf": "^1.50.0",
+    "@bufbuild/protoc-gen-es": "^2.2.3"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,7 +227,14 @@ importers:
 
   packages/electron: {}
 
-  packages/proto: {}
+  packages/proto:
+    devDependencies:
+      '@bufbuild/buf':
+        specifier: ^1.50.0
+        version: 1.69.0
+      '@bufbuild/protoc-gen-es':
+        specifier: ^2.2.3
+        version: 2.12.0(@bufbuild/protobuf@2.12.0)
 
 packages:
 
@@ -347,6 +354,69 @@ packages:
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
+
+  '@bufbuild/buf-darwin-arm64@1.69.0':
+    resolution: {integrity: sha512-q7086l1PRS0fUn/IYef7WUAq5PEPIxCh3AVZZdObdOAA9C77ES7CYBSTWH3oEJHVElv1KPVVqvGmOC+G78HuXg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@bufbuild/buf-darwin-x64@1.69.0':
+    resolution: {integrity: sha512-ihM+lr0tahgLVbQvp5jhYS6T1cpydEX3TbJvAfePLJBCTrsXFMwKt1WIDjpSHIPHQABcqL9BuNnbs8r1+7E1MA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@bufbuild/buf-linux-aarch64@1.69.0':
+    resolution: {integrity: sha512-4twJF1ehcPRBvgA2g2yIG/3ViZ3SrElqCqGjXHp+U4RfjHV249j8kzVj08mvI1t0kv8Rbm8JECYqkxcYnKyuRA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@bufbuild/buf-linux-armv7@1.69.0':
+    resolution: {integrity: sha512-zfbYrfPjOBp1Dxj+9avW05NWzGwLUTInfslhgWVbq61DYLegX6UW12hVk5xS/C5D0IlfIDfJUXEeTsHImigQTQ==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@bufbuild/buf-linux-x64@1.69.0':
+    resolution: {integrity: sha512-mt/hJesHK62TlsSJPwBpRIC/OzWTlgaRmyjC8QF+T6+IbFwiwz1E3ZBCfNECEa2HW4ma8HbugpJyCBbUSA+z/Q==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@bufbuild/buf-win32-arm64@1.69.0':
+    resolution: {integrity: sha512-IlMSIdCWvllwenbLlrWEH2YHQwCqmONKZYv4MXj56v6TvCWCTbYlaF5ZFP+xFAHToHp1OrFc+rwUqCt7ElBbHg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@bufbuild/buf-win32-x64@1.69.0':
+    resolution: {integrity: sha512-wpKZLXUF/w85g4ZL9XqQqm33cfw2NRjiidSX5EVFMx4rDp7cnAUv3+PTwZvEPriqJEihnOJ5JCozsxjiWqSX7Q==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@bufbuild/buf@1.69.0':
+    resolution: {integrity: sha512-hWk7cW6Z/7g6jpybePaf15QUUFd2+s4lJCeaAkBeo3tWPGoSgNJaJdMqIUy2y99uYy4yMjq9GYmjc5dSrfIn5A==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  '@bufbuild/protobuf@2.12.0':
+    resolution: {integrity: sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==}
+
+  '@bufbuild/protoc-gen-es@2.12.0':
+    resolution: {integrity: sha512-d9htF6jEkSwPbp9d/vSmZOBF7eeG18AvTMKmVg4I23afnrQOxL2w3WOXa9TaufMCyu24QakEUb4vux8apI5e7A==}
+    engines: {node: '>=20'}
+    hasBin: true
+    peerDependencies:
+      '@bufbuild/protobuf': 2.12.0
+    peerDependenciesMeta:
+      '@bufbuild/protobuf':
+        optional: true
+
+  '@bufbuild/protoplugin@2.12.0':
+    resolution: {integrity: sha512-ORlDITp8AFUXzIhLRoMCG+ud+D3MPKWb5HQXBoskMMnjeyEjE1H1qLonVNPyOr8lkx3xSfYUo8a0dvOZJVAzow==}
 
   '@csstools/color-helpers@6.0.2':
     resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
@@ -1888,6 +1958,11 @@ packages:
   '@typescript-eslint/visitor-keys@8.59.1':
     resolution: {integrity: sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript/vfs@1.6.4':
+    resolution: {integrity: sha512-PJFXFS4ZJKiJ9Qiuix6Dz/OwEIqHD7Dme1UwZhTK11vR+5dqW2ACbdndWQexBzCx+CPuMe5WBYQWCsFyGlQLlQ==}
+    peerDependencies:
+      typescript: '*'
 
   '@vitest/coverage-v8@4.1.5':
     resolution: {integrity: sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==}
@@ -5070,6 +5145,11 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
+  typescript@5.4.5:
+    resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -5578,6 +5658,55 @@ snapshots:
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
+
+  '@bufbuild/buf-darwin-arm64@1.69.0':
+    optional: true
+
+  '@bufbuild/buf-darwin-x64@1.69.0':
+    optional: true
+
+  '@bufbuild/buf-linux-aarch64@1.69.0':
+    optional: true
+
+  '@bufbuild/buf-linux-armv7@1.69.0':
+    optional: true
+
+  '@bufbuild/buf-linux-x64@1.69.0':
+    optional: true
+
+  '@bufbuild/buf-win32-arm64@1.69.0':
+    optional: true
+
+  '@bufbuild/buf-win32-x64@1.69.0':
+    optional: true
+
+  '@bufbuild/buf@1.69.0':
+    optionalDependencies:
+      '@bufbuild/buf-darwin-arm64': 1.69.0
+      '@bufbuild/buf-darwin-x64': 1.69.0
+      '@bufbuild/buf-linux-aarch64': 1.69.0
+      '@bufbuild/buf-linux-armv7': 1.69.0
+      '@bufbuild/buf-linux-x64': 1.69.0
+      '@bufbuild/buf-win32-arm64': 1.69.0
+      '@bufbuild/buf-win32-x64': 1.69.0
+
+  '@bufbuild/protobuf@2.12.0': {}
+
+  '@bufbuild/protoc-gen-es@2.12.0(@bufbuild/protobuf@2.12.0)':
+    dependencies:
+      '@bufbuild/protoplugin': 2.12.0
+    optionalDependencies:
+      '@bufbuild/protobuf': 2.12.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@bufbuild/protoplugin@2.12.0':
+    dependencies:
+      '@bufbuild/protobuf': 2.12.0
+      '@typescript/vfs': 1.6.4(typescript@5.4.5)
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@csstools/color-helpers@6.0.2': {}
 
@@ -7330,6 +7459,13 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.59.1
       eslint-visitor-keys: 5.0.1
+
+  '@typescript/vfs@1.6.4(typescript@5.4.5)':
+    dependencies:
+      debug: 4.4.3
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
     dependencies:
@@ -10945,6 +11081,8 @@ snapshots:
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
+
+  typescript@5.4.5: {}
 
   typescript@5.9.3: {}
 


### PR DESCRIPTION
## Scope (Task #12 / T0.5, design spec ch11 §4)

Wires up Connect-RPC TypeScript codegen for `packages/proto`. Layout:

```
packages/proto/
  buf.yaml          # module config (path: src)
  buf.gen.yaml      # codegen config (v2, plugin: protoc-gen-es)
  src/ccsm/v1/*.proto   # authored in T0.11
  gen/ts/**         # generated, gitignored, regenerated via `pnpm gen`
  gen/go/.gitkeep   # placeholder, Go bindings TBD
  gen/swift/.gitkeep # placeholder, iOS bindings TBD
```

## What gets generated

Modern Connect-ES guidance: `@bufbuild/protoc-gen-es` v2 emits both message
types AND service descriptors (`GenService`) — no separate
`protoc-gen-connect-es` plugin needed. Connect-ES consumes `GenService`
directly via `@connectrpc/connect` at runtime.

Verified locally: `pnpm --filter @ccsm/proto run gen` produces 8
`*_pb.ts` files including `SessionService`, `PtyService`,
`SupervisorService`, `NotifyService`, `SettingsService`, `CrashService`,
`DraftService` as `GenService` descriptors plus all message types.

`import_extension=js` ensures NodeNext ESM resolution works.

## Files

- `packages/proto/buf.yaml` — module path: `src`
- `packages/proto/buf.gen.yaml` — v2, single plugin (`protoc-gen-es`, `target=ts`)
- `packages/proto/.gitignore` — overrides root `gen/` to keep go/swift gitkeeps visible while excluding `gen/ts/**`
- `packages/proto/gen/{go,swift}/.gitkeep` — placeholders per spec ch11 §4 layout
- `packages/proto/package.json` — adds `gen` / `clean` scripts and devDeps `@bufbuild/buf`, `@bufbuild/protoc-gen-es`
- `pnpm-lock.yaml` — updated for new devDeps

## Deferred (separate tasks)

- `buf.lock` — T0.6
- CI gen-up-to-date gate (`pnpm gen && git diff --exit-code`) — T0.8
- `buf breaking` / `buf lint` rule tightening — T0.7
- Go and Swift codegen plugins — TBD with daemon-go / iOS client work

## How to regenerate locally

```bash
pnpm install
pnpm --filter @ccsm/proto run gen
# gen/ts/** is gitignored; never commit it
```

## Verification done

- `pnpm install` clean
- `pnpm --filter @ccsm/proto run gen` emits 8 `*_pb.ts` files with `GenService` descriptors
- `npm run lint` — 0 errors (warnings only)
- `npm run typecheck` — passes
- `git status` after gen: only intended files staged; `gen/ts/**` correctly gitignored