### PR TITLE
feat(daemon): T1.2 Listener trait + 2-slot array + sentinel

### DIFF
--- a/packages/daemon/src/listeners/__tests__/array.spec.ts
+++ b/packages/daemon/src/listeners/__tests__/array.spec.ts
@@ -1,0 +1,79 @@
+// Spec for the 2-slot listener tuple + sentinel + startup assert.
+// Covers spec ch03 §1 (Listener trait shape + slot 1 invariant).
+
+import { describe, expect, it } from 'vitest';
+import {
+  RESERVED_FOR_LISTENER_B,
+  assertSlot1Reserved,
+  type ListenerSlots,
+} from '../array.js';
+import type { BindDescriptor, Listener } from '../types.js';
+
+function makeFakeListener(id: string): Listener {
+  let started = false;
+  return {
+    id,
+    async start() {
+      started = true;
+    },
+    async stop() {
+      started = false;
+    },
+    descriptor(): BindDescriptor {
+      if (!started) {
+        throw new Error('descriptor() called before start()');
+      }
+      return { kind: 'uds', path: `/tmp/${id}.sock` };
+    },
+  };
+}
+
+describe('RESERVED_FOR_LISTENER_B sentinel', () => {
+  it('is a Symbol with the canonical registry key', () => {
+    expect(typeof RESERVED_FOR_LISTENER_B).toBe('symbol');
+    expect(RESERVED_FOR_LISTENER_B).toBe(Symbol.for('ccsm.listener.reserved-b'));
+  });
+
+  it('is reference-equal across imports (single source of truth)', async () => {
+    const fromArray = (await import('../array.js')).RESERVED_FOR_LISTENER_B;
+    const fromTypes = (await import('../types.js')).RESERVED_FOR_LISTENER_B;
+    const fromEnv = (await import('../../env.js')).RESERVED_FOR_LISTENER_B;
+    expect(fromArray).toBe(RESERVED_FOR_LISTENER_B);
+    expect(fromTypes).toBe(RESERVED_FOR_LISTENER_B);
+    expect(fromEnv).toBe(RESERVED_FOR_LISTENER_B);
+  });
+});
+
+describe('ListenerSlots tuple shape', () => {
+  it('accepts a real Listener at slot 0 and the sentinel at slot 1', () => {
+    const a = makeFakeListener('listener-a');
+    const slots: ListenerSlots = [a, RESERVED_FOR_LISTENER_B];
+    expect(slots).toHaveLength(2);
+    expect(slots[0]).toBe(a);
+    expect(slots[1]).toBe(RESERVED_FOR_LISTENER_B);
+  });
+});
+
+describe('assertSlot1Reserved', () => {
+  it('passes when slot 1 is the sentinel (happy path)', () => {
+    const a = makeFakeListener('listener-a');
+    const slots: readonly [unknown, unknown] = [a, RESERVED_FOR_LISTENER_B];
+    expect(() => assertSlot1Reserved(slots)).not.toThrow();
+  });
+
+  it('throws when slot 1 has been swapped to a real listener (failure path)', () => {
+    const a = makeFakeListener('listener-a');
+    const b = makeFakeListener('listener-b');
+    const slots: readonly [unknown, unknown] = [a, b];
+    expect(() => assertSlot1Reserved(slots)).toThrow(
+      /listeners\[1\] is not RESERVED_FOR_LISTENER_B/,
+    );
+  });
+
+  it('throws when slot 1 is null / undefined / a stray symbol', () => {
+    const a = makeFakeListener('listener-a');
+    expect(() => assertSlot1Reserved([a, null])).toThrow();
+    expect(() => assertSlot1Reserved([a, undefined])).toThrow();
+    expect(() => assertSlot1Reserved([a, Symbol.for('ccsm.listener.reserved-b.OOPS')])).toThrow();
+  });
+});

--- a/packages/daemon/src/listeners/array.ts
+++ b/packages/daemon/src/listeners/array.ts
@@ -1,0 +1,44 @@
+// 2-slot listener tuple + startup assert — spec ch03 §1.
+//
+// v0.3 ships exactly one active listener (Listener A); slot 1 is pinned
+// to the typed sentinel `RESERVED_FOR_LISTENER_B` so v0.4 can swap in
+// `makeListenerB(env)` without rippling shape changes through every
+// caller. The closed 2-tuple shape is enforced statically by
+// `ListenerSlots`; the runtime assert (`assertSlot1Reserved`) is the
+// gate the entrypoint calls during phase STARTING_LISTENERS to refuse
+// boot if anything snuck a real listener into slot 1 before v0.4.
+//
+// SRP: this module is the slot-shape decider. No I/O, no factories.
+// The Listener A factory lives in T1.4; the no-mutation ESLint rule
+// lives in T1.9.
+
+import { RESERVED_FOR_LISTENER_B, type ReservedForListenerB, type Listener } from './types.js';
+
+/**
+ * The exact shape of `DaemonEnv.listeners` once T1.4 lands. Slot 0 is a
+ * real Listener; slot 1 stays as the typed sentinel until v0.4.
+ */
+export type ListenerSlots = readonly [Listener, Listener | ReservedForListenerB];
+
+/**
+ * Startup assert — throws if slot 1 has been swapped away from the
+ * `RESERVED_FOR_LISTENER_B` sentinel. Called from the entrypoint during
+ * phase STARTING_LISTENERS so any v0.4-style two-listener boot fails
+ * fast with a clear message instead of silently activating Listener B
+ * before its v0.4 spec lands.
+ *
+ * NOTE: this is a runtime backstop. The compile-time guard is the
+ * `ListenerSlots` tuple shape; the lint-time guard is T1.9's
+ * `no-listener-slot-mutation` rule. All three layers exist by design.
+ */
+export function assertSlot1Reserved(
+  slots: readonly [unknown, unknown],
+): asserts slots is readonly [unknown, ReservedForListenerB] {
+  if (slots[1] !== RESERVED_FOR_LISTENER_B) {
+    throw new Error(
+      'listeners[1] is not RESERVED_FOR_LISTENER_B — Listener B activation is a v0.4 change (spec ch03 §1).',
+    );
+  }
+}
+
+export { RESERVED_FOR_LISTENER_B, type ReservedForListenerB } from './types.js';

--- a/packages/daemon/src/listeners/types.ts
+++ b/packages/daemon/src/listeners/types.ts
@@ -1,0 +1,68 @@
+// Listener trait + BindDescriptor closed-enum union — spec ch03 §1
+// (Listener trait shape) + §1a (BindDescriptor closed enum).
+//
+// T1.2 scope: types + sentinel surface only. The concrete Listener A
+// factory (T1.4), HTTP/2 transports (T1.5), and the ESLint
+// `no-listener-slot-mutation` rule (T1.9) all live in separate tasks.
+//
+// Layer 1 / SRP: this module is pure type declarations — no runtime
+// behavior, no side effects. The Listener trait is a small surface
+// (start / stop / descriptor) and intentionally does not mention
+// transport details — those belong to BindDescriptor.
+
+/**
+ * Closed-enum union of every transport shape the daemon will ever bind.
+ * Adding a new variant is a deliberate spec change (ch03 §1a) — the
+ * closed shape lets `switch (d.kind)` typecheck exhaustively in
+ * downstream consumers (descriptor writer T1.4, ops tooling).
+ *
+ * Variants:
+ *   - `uds`        : POSIX Unix Domain Socket (Linux / macOS).
+ *   - `namedPipe`  : Windows named pipe (`\\.\pipe\<name>`).
+ *   - `loopbackTcp`: 127.0.0.1 / ::1 TCP — dev / debug only.
+ *   - `tls`        : TLS-over-TCP — reserved for v0.4 Listener B.
+ */
+export type BindDescriptor =
+  | { readonly kind: 'uds'; readonly path: string }
+  | { readonly kind: 'namedPipe'; readonly pipeName: string }
+  | { readonly kind: 'loopbackTcp'; readonly host: '127.0.0.1' | '::1'; readonly port: number }
+  | {
+      readonly kind: 'tls';
+      readonly host: string;
+      readonly port: number;
+      /** PEM-encoded server certificate path. */
+      readonly certPath: string;
+      /** PEM-encoded private key path. */
+      readonly keyPath: string;
+    };
+
+/**
+ * Listener trait — the shape every transport listener must satisfy.
+ * Spec ch03 §1.
+ *
+ * Lifecycle: callers construct via a factory (e.g. `makeListenerA(env)`
+ * in T1.4), then `start()` once during phase STARTING_LISTENERS, and
+ * `stop()` exactly once during graceful shutdown (T1.8). Calling
+ * `start()` twice or `stop()` before `start()` is a programming error
+ * — implementations may throw.
+ *
+ * `descriptor()` returns the bind shape AFTER a successful `start()`
+ * (port may be ephemeral until the OS assigns it). Calling before
+ * `start()` is a programming error.
+ */
+export interface Listener {
+  /** Stable id used in logs / descriptor file (`listener-a`, `listener-b`). */
+  readonly id: string;
+  /** Bind the transport. Idempotent-fail: throws on second call. */
+  start(): Promise<void>;
+  /** Tear down the transport. Idempotent: safe to call after a failed start. */
+  stop(): Promise<void>;
+  /** Resolved bind descriptor (only valid after `start()`). */
+  descriptor(): BindDescriptor;
+}
+
+// Re-export the sentinel from env.ts so listener-array consumers have a
+// single import surface (`./listeners/types`) without reaching back into
+// the env module. The sentinel itself was minted in T1.1 (env.ts) so the
+// DaemonEnv shape could pin slot 1 without depending on T1.2 code.
+export { RESERVED_FOR_LISTENER_B, type ReservedForListenerB } from '../env.js';


### PR DESCRIPTION
## Scope (Task #28 / T1.2)

Spec refs: ch03 §1 (Listener trait shape) + §1a (BindDescriptor closed enum).

- `packages/daemon/src/listeners/types.ts` — `Listener` interface (`id` + `start` / `stop` / `descriptor`) and the `BindDescriptor` closed-enum union (`uds` / `namedPipe` / `loopbackTcp` / `tls`). Sentinel re-exported from `env.ts` (single source of truth, minted in T1.1).
- `packages/daemon/src/listeners/array.ts` — `ListenerSlots` tuple `[Listener, Listener | ReservedForListenerB]` + `assertSlot1Reserved` startup gate. Throws if slot 1 was swapped away from the sentinel.
- `packages/daemon/src/listeners/__tests__/array.spec.ts` — covers sentinel identity (`Symbol.for` + cross-module ref equality), tuple shape, and `assertSlot1Reserved` happy + failure paths.

## Out of scope (per task brief)

- Listener A factory → Task T1.4
- HTTP/2 transports → Task T1.5
- `no-listener-slot-mutation` ESLint rule → Task T1.9

## Quality gates (local, Windows / pnpm)

- `pnpm exec eslint packages/daemon/src/listeners` — clean
- `cd packages/daemon && pnpm exec tsc --noEmit` — clean
- `cd packages/daemon && pnpm exec vitest run` — 16/16 pass (9 lifecycle + 6 listener-array, plus 1 buildDaemonEnv check)

## Reverse-verify (assert gate is load-bearing)

Stash the assert (replace `slots[1] !== RESERVED_FOR_LISTENER_B` with `false` in `array.ts`) → spec FAILS:

```text
 FAIL  src/listeners/__tests__/array.spec.ts > assertSlot1Reserved > throws when slot 1 has been swapped to a real listener (failure path)
AssertionError: expected [Function] to throw an error

 FAIL  src/listeners/__tests__/array.spec.ts > assertSlot1Reserved > throws when slot 1 is null / undefined / a stray symbol
AssertionError: expected [Function] to throw an error

 Test Files  1 failed (1)
      Tests  2 failed | 4 passed (6)
```

Restore the assert → spec PASSES:

```text
 Test Files  1 passed (1)
      Tests  6 passed (6)
   Duration  828ms
```

Both failure cases collapse the moment the gate weakens, confirming the assert is the only thing producing the error — i.e. the test would catch a real regression of the v0.4-listener-B-too-early bug.