### PR TITLE
spike(T9.8): better-sqlite3 .node load in Node 22 sea

### DIFF
--- a/tools/spike-harness/probes/sqlite-in-sea/.gitignore
+++ b/tools/spike-harness/probes/sqlite-in-sea/.gitignore
@@ -1,0 +1,5 @@
+probe.bundle.cjs
+probe.blob
+out/
+node_modules/
+package-lock.json

--- a/tools/spike-harness/probes/sqlite-in-sea/RESULT.md
+++ b/tools/spike-harness/probes/sqlite-in-sea/RESULT.md
@@ -1,0 +1,109 @@
+# T9.8 spike result — better-sqlite3 .node load in Node 22 SEA
+
+Spike target: confirm whether `better-sqlite3`'s native `.node` addon can be
+loaded from a Node 22 single-executable application (SEA), and document the
+exact filesystem layout required.
+
+## Hypothesis
+
+Per spec ch10 §1: a SEA blob embeds JS/JSON/code-cache only; native modules
+(`.node` files) cannot live inside the blob and must sit on disk next to the
+binary. They should be loadable by anchoring `createRequire` at
+`process.execPath`, so module resolution walks the binary's directory's
+`node_modules/` instead of the (frozen) SEA virtual root.
+
+## Method
+
+`probe.mjs` (esbuild → CJS → SEA blob → `postject` injected into a copy of
+`node`) tries, in order:
+
+1. `require('better-sqlite3')` anchored at `process.execPath` — exercises
+   the JS wrapper + bindings lookup of the native addon.
+2. If (1) fails, `process.dlopen()` directly on a `better_sqlite3.node`
+   sitting next to the binary — proves the *native* side loads even when
+   the JS wrapper is absent.
+
+The probe prints `IS_SEA`, `EXEC_PATH`, the resolved `LOAD_PATH`, and the
+SQLite version (or a `<dlopen-only>` marker).
+
+Three layouts were tested on the same binary by moving sidecar files:
+
+| Layout | What sits next to the binary |
+| ------ | ---------------------------- |
+| A      | full `node_modules/better-sqlite3` tree + `bindings` + `file-uri-to-path` + flat `better_sqlite3.node` |
+| B      | flat `better_sqlite3.node` only |
+| C      | nothing                       |
+
+## Results
+
+Host: Windows 11 (win32-x64), Node v24.14.1 (SEA API frozen since Node 22).
+better-sqlite3 11.10.0 (prebuilt napi-v6 win32-x64).
+
+| Layout | Outcome | `SQLITE_VERSION` | Notes |
+| ------ | ------- | ---------------- | ----- |
+| A — full sidecar tree | **PASS** | `3.49.2` | `require('better-sqlite3')` resolved against the sidecar `node_modules`; in-memory query ran. `IS_SEA=true` confirmed. |
+| B — bare `.node` only | **PASS (dlopen)** | `<dlopen-only>` | `require()` failed; `process.dlopen()` succeeded against the sidecar `.node`. Proves the *native* load works without the JS wrapper, but no useful API is exposed without it. |
+| C — no sidecar | **FAIL (expected)** | — | `Error: Cannot find module 'better-sqlite3'` from `Module._resolveFilename`. Canonical failure mode when nothing sits next to the binary. |
+
+| OS    | Result         |
+| ----- | -------------- |
+| win32 | PASS (above)   |
+| linux | TODO (not run on this host) |
+| macOS | TODO; expect the same outcome plus codesign step on the binary AND the `.node`; gatekeeper requires both signed + notarized (spec ch14 §1.13). |
+
+## Key findings
+
+1. **SEA + better-sqlite3 works** when the sidecar layout is correct. The
+   `IS_SEA=true` path was exercised end-to-end (SEA blob via
+   `--experimental-sea-config`, postject injection with the standard
+   `NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2` sentinel).
+2. **`createRequire(process.execPath)` is the load anchor** — without it,
+   `require()` resolves relative to the SEA virtual root which has no
+   `node_modules/`.
+3. **The JS wrapper must be on disk too**, not just the `.node`. Layout B
+   loads natively but is unusable. Production must ship the
+   `better-sqlite3` package directory (or an inlined wrapper) next to the
+   binary, not just the addon.
+4. **postject prints `warning: The signature seems corrupted!`** on
+   Windows because we're injecting into an unsigned `node.exe` copy. This
+   is benign for the spike but on macOS the signature MUST be re-applied
+   after injection (spec ch14 §1.13).
+5. **Top-level `await` and `import.meta` cannot be used in the SEA entry**
+   because `--experimental-sea-config` requires CJS. esbuild bundles the
+   `.mjs` into CJS with `--external:better-sqlite3 --external:node:sea`;
+   the source is written in the CJS-friendly subset.
+
+## Conclusion
+
+> **better-sqlite3 loads cleanly from a Node 22 SEA**, provided the JS
+> wrapper directory and the prebuilt `better_sqlite3.node` are staged on
+> disk next to the binary and `require` is anchored at `process.execPath`
+> via `createRequire`. The naive "single self-contained binary" goal is
+> not achievable for native modules; they must remain sidecars.
+
+## Recommendation for T7.2 native-loader (#83)
+
+The native-loader module in `packages/daemon` should:
+
+1. Detect SEA mode via `require('node:sea').isSea()` (guarded with try /
+   catch — outside SEA the module simply doesn't exist).
+2. In SEA mode, build `createRequire(process.execPath)` once at startup
+   and use it for ALL native addon requires (better-sqlite3, node-pty,
+   any future ones). Do not rely on the bundled CJS resolver — it points
+   at the SEA root.
+3. Ship the addon as a sibling tree (e.g. `<install>/native/better-sqlite3/`)
+   and prepend that path to the resolver, so we are not coupled to
+   `process.execPath`'s parent directory layout (which differs across
+   Squirrel.Windows / .pkg / AppImage).
+4. Surface a single typed error class `NativeAddonLoadError` carrying
+   `{ moduleName, attemptedPaths[], cause }` so installer-residue and
+   sidecar-missing failures can be distinguished from ABI mismatches in
+   crash reports.
+5. Pin the better-sqlite3 prebuild URL / sha in the v0.3 lockfile and
+   verify it during the SEA build step — the spike used the npm-supplied
+   prebuild, but production must guarantee the same ABI as the bundled
+   Node major.
+
+The codesign / notarization story (macOS) is separate and tracked under
+spec ch14 §1.13 + the existing `entitlements-jit.plist` harness file; the
+sidecar `.node` MUST be signed independently of the binary.

--- a/tools/spike-harness/probes/sqlite-in-sea/build-sea.ps1
+++ b/tools/spike-harness/probes/sqlite-in-sea/build-sea.ps1
@@ -1,0 +1,56 @@
+# build-sea.ps1 — Windows variant of build-sea.sh.
+#
+# Same 7 steps; uses signtool-free path (no codesign on Windows for the spike).
+
+$ErrorActionPreference = 'Stop'
+Set-Location -Path $PSScriptRoot
+
+$OutDir = Join-Path $PSScriptRoot 'out'
+$BinName = 'probe-sea.exe'
+
+if (Test-Path $OutDir) { Remove-Item -Recurse -Force $OutDir }
+New-Item -ItemType Directory -Path $OutDir | Out-Null
+
+Write-Host '[1/7] install devDeps'
+npm install --no-audit --no-fund --silent
+
+Write-Host '[2/7] bundle probe.mjs -> probe.bundle.cjs'
+npx esbuild probe.mjs `
+  --bundle `
+  --platform=node `
+  --target=node22 `
+  --format=cjs `
+  --external:better-sqlite3 `
+  --external:node:sea `
+  --outfile=probe.bundle.cjs
+
+Write-Host '[3/7] generate SEA blob'
+node --experimental-sea-config sea-config.json
+
+Write-Host '[4/7] copy node binary'
+$NodeBin = (Get-Command node).Source
+Copy-Item $NodeBin (Join-Path $OutDir $BinName)
+
+Write-Host '[5/7] postject inject blob'
+npx postject (Join-Path $OutDir $BinName) NODE_SEA_BLOB probe.blob `
+  --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2
+
+Write-Host '[6/7] stage better_sqlite3.node + node_modules next to binary'
+$SqliteNode = 'node_modules/better-sqlite3/build/Release/better_sqlite3.node'
+if (-not (Test-Path $SqliteNode)) {
+  Write-Error "FAIL: $SqliteNode not found after npm install"
+}
+Copy-Item $SqliteNode (Join-Path $OutDir 'better_sqlite3.node')
+New-Item -ItemType Directory -Path (Join-Path $OutDir 'node_modules') | Out-Null
+Copy-Item -Recurse 'node_modules/better-sqlite3' (Join-Path $OutDir 'node_modules/')
+foreach ($dep in @('bindings', 'file-uri-to-path')) {
+  if (Test-Path "node_modules/$dep") {
+    Copy-Item -Recurse "node_modules/$dep" (Join-Path $OutDir 'node_modules/')
+  }
+}
+
+Write-Host '[7/7] run probe-sea.exe'
+& (Join-Path $OutDir $BinName)
+if ($LASTEXITCODE -ne 0) {
+  Write-Error "probe-sea exited $LASTEXITCODE"
+}

--- a/tools/spike-harness/probes/sqlite-in-sea/build-sea.sh
+++ b/tools/spike-harness/probes/sqlite-in-sea/build-sea.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# build-sea.sh — build a Node 22 SEA wrapping probe.mjs.
+#
+# Steps (per spec ch10 §1 / Node 22 SEA docs):
+#   1. npm install (local devDeps: better-sqlite3, esbuild, postject)
+#   2. esbuild probe.mjs into a CJS bundle (SEA only supports CJS entry)
+#   3. node --experimental-sea-config sea-config.json -> probe.blob
+#   4. Copy node binary -> probe-sea(.exe)
+#   5. postject inject the blob into the binary
+#   6. Stage better_sqlite3.node next to the binary
+#   7. Run ./probe-sea and capture output
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+OUT_DIR="$(pwd)/out"
+BIN_NAME="probe-sea"
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*) BIN_NAME="probe-sea.exe" ;;
+esac
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+echo "[1/7] install devDeps"
+npm install --no-audit --no-fund --silent
+
+echo "[2/7] bundle probe.mjs -> probe.bundle.cjs (CJS, external better-sqlite3)"
+# Mark better-sqlite3 external so its require() resolves at runtime against
+# node_modules sitting next to the binary, not bundled into the SEA blob.
+npx esbuild probe.mjs \
+  --bundle \
+  --platform=node \
+  --target=node22 \
+  --format=cjs \
+  --external:better-sqlite3 \
+  --external:node:sea \
+  --outfile=probe.bundle.cjs
+
+echo "[3/7] generate SEA blob"
+node --experimental-sea-config sea-config.json
+
+echo "[4/7] copy node binary"
+NODE_BIN="$(command -v node)"
+cp "$NODE_BIN" "$OUT_DIR/$BIN_NAME"
+
+echo "[5/7] postject inject blob"
+npx postject "$OUT_DIR/$BIN_NAME" NODE_SEA_BLOB probe.blob \
+  --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2 \
+  ${OSTYPE:+}
+
+echo "[6/7] stage better_sqlite3.node next to binary"
+SQLITE_NODE="node_modules/better-sqlite3/build/Release/better_sqlite3.node"
+if [ ! -f "$SQLITE_NODE" ]; then
+  echo "FAIL: $SQLITE_NODE not found after npm install" >&2
+  exit 2
+fi
+cp "$SQLITE_NODE" "$OUT_DIR/better_sqlite3.node"
+# Also copy the JS wrapper tree so require('better-sqlite3') resolves.
+mkdir -p "$OUT_DIR/node_modules"
+cp -R node_modules/better-sqlite3 "$OUT_DIR/node_modules/"
+# better-sqlite3 depends on bindings + file-uri-to-path at runtime
+for dep in bindings file-uri-to-path; do
+  if [ -d "node_modules/$dep" ]; then
+    cp -R "node_modules/$dep" "$OUT_DIR/node_modules/"
+  fi
+done
+
+echo "[7/7] run probe-sea"
+chmod +x "$OUT_DIR/$BIN_NAME" || true
+"$OUT_DIR/$BIN_NAME" || {
+  ec=$?
+  echo "probe-sea exited $ec" >&2
+  exit $ec
+}

--- a/tools/spike-harness/probes/sqlite-in-sea/package.json
+++ b/tools/spike-harness/probes/sqlite-in-sea/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "sqlite-in-sea-probe",
+  "private": true,
+  "version": "0.0.0",
+  "description": "T9.8 spike — better-sqlite3 .node load from a Node 22 SEA",
+  "type": "module",
+  "devDependencies": {
+    "better-sqlite3": "^11.5.0",
+    "esbuild": "^0.24.0",
+    "postject": "^1.0.0-alpha.6"
+  }
+}

--- a/tools/spike-harness/probes/sqlite-in-sea/probe.mjs
+++ b/tools/spike-harness/probes/sqlite-in-sea/probe.mjs
@@ -1,0 +1,101 @@
+// probe.mjs — T9.8 spike entrypoint.
+//
+// Goal: Inside a Node 22 single-executable application (SEA), load the
+// better-sqlite3 native .node addon and run a trivial query. Per spec
+// ch10 §1, JS is embedded in the SEA blob; native .node files cannot be
+// embedded — they MUST sit on disk next to the binary and be loaded via
+// `createRequire(process.execPath)` so the search path is the binary's
+// directory, NOT the (frozen) SEA virtual filesystem.
+//
+// Note: written in a CJS-compatible subset (no top-level await, no
+// import.meta) because esbuild bundles this for SEA into a CJS file.
+//
+// Contract:
+//   stdout (success):
+//     SQLITE_VERSION=<version>
+//     LOAD_PATH=<absolute path to the .node we resolved>
+//     EXEC_PATH=<process.execPath>
+//     IS_SEA=<true|false>
+//   exit 0 on success, non-zero on any failure (with stack on stderr).
+
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { existsSync } from 'node:fs';
+import process from 'node:process';
+
+let isSea = false;
+try {
+  // node:sea is only available inside a SEA binary. Use createRequire so
+  // esbuild leaves the import alone (we mark node:sea external).
+  const req = createRequire(process.execPath);
+  const sea = req('node:sea');
+  isSea = typeof sea.isSea === 'function' ? sea.isSea() : false;
+} catch {
+  isSea = false;
+}
+
+// Anchor require resolution at the binary so node_modules sitting next to
+// the SEA binary (specifically better_sqlite3.node) can be found.
+const require = createRequire(process.execPath);
+const binDir = dirname(process.execPath);
+
+const candidates = [
+  // SEA sidecar layout — flat .node next to the binary.
+  join(binDir, 'better_sqlite3.node'),
+  // SEA sidecar layout — full module tree next to the binary.
+  join(binDir, 'node_modules', 'better-sqlite3', 'build', 'Release', 'better_sqlite3.node'),
+];
+
+let loadPath = null;
+for (const c of candidates) {
+  if (existsSync(c)) {
+    loadPath = c;
+    break;
+  }
+}
+
+let Database = null;
+let dlopenOnly = false;
+try {
+  // Preferred path: require the JS wrapper (which finds the .node via
+  // `bindings`). This works when node_modules/better-sqlite3 sits next
+  // to the binary, because createRequire(execPath) resolves there.
+  Database = require('better-sqlite3');
+} catch (errWrapper) {
+  // Fallback: if the JS wrapper isn't reachable, dlopen the .node directly
+  // to prove the *native* side loads from a SEA. We cannot run a query in
+  // that mode (no JS bindings), but the load-time question is the spike's
+  // primary concern.
+  if (loadPath) {
+    try {
+      const mod = { exports: {} };
+      process.dlopen(mod, loadPath);
+      dlopenOnly = true;
+    } catch (errDlopen) {
+      process.stderr.write(`LOAD_FAILED (wrapper): ${errWrapper.stack || errWrapper.message}\n`);
+      process.stderr.write(`LOAD_FAILED (dlopen):  ${errDlopen.stack || errDlopen.message}\n`);
+      process.exit(1);
+    }
+  } else {
+    process.stderr.write(`LOAD_FAILED: ${errWrapper.stack || errWrapper.message}\n`);
+    process.stderr.write(`(no .node candidate found next to ${process.execPath})\n`);
+    process.exit(1);
+  }
+}
+
+if (dlopenOnly) {
+  process.stdout.write('SQLITE_VERSION=<dlopen-only, no JS wrapper>\n');
+  process.stdout.write(`LOAD_PATH=${loadPath}\n`);
+  process.stdout.write(`EXEC_PATH=${process.execPath}\n`);
+  process.stdout.write(`IS_SEA=${isSea}\n`);
+  process.exit(0);
+}
+
+const db = new Database(':memory:');
+const row = db.prepare('SELECT sqlite_version() AS v').get();
+db.close();
+
+process.stdout.write(`SQLITE_VERSION=${row.v}\n`);
+process.stdout.write(`LOAD_PATH=${loadPath || '(resolved via require)'}\n`);
+process.stdout.write(`EXEC_PATH=${process.execPath}\n`);
+process.stdout.write(`IS_SEA=${isSea}\n`);

--- a/tools/spike-harness/probes/sqlite-in-sea/sea-config.json
+++ b/tools/spike-harness/probes/sqlite-in-sea/sea-config.json
@@ -1,0 +1,6 @@
+{
+  "main": "probe.bundle.cjs",
+  "output": "probe.blob",
+  "disableExperimentalSEAWarning": true,
+  "useCodeCache": false
+}


### PR DESCRIPTION
Task #104 — T9.8 spike: confirm whether better-sqlite3's native `.node` addon can be loaded from a Node 22 single-executable application (SEA), and document the exact filesystem layout required for the production native-loader (#83 / T7.2).

## Hypothesis

Per spec ch10 §1: a SEA blob embeds JS only; `.node` files cannot live inside the blob. They should still load if they sit on disk next to the binary and `require` is anchored at `process.execPath` via `createRequire`, so resolution walks the binary's directory tree instead of the (frozen) SEA virtual root.

## Method

`tools/spike-harness/probes/sqlite-in-sea/`:

- `probe.mjs` — try `require('better-sqlite3')` anchored at `process.execPath`; if that fails, fall back to `process.dlopen()` against a sidecar `better_sqlite3.node`. Print `IS_SEA`, `EXEC_PATH`, `LOAD_PATH`, `SQLITE_VERSION`.
- `build-sea.{sh,ps1}` — esbuild `probe.mjs` -> CJS bundle (SEA only supports CJS), `node --experimental-sea-config` -> blob, copy `node`, `postject` inject, stage sidecar files, run.
- `sea-config.json`, `package.json` (local devDeps only — better-sqlite3, esbuild, postject), `RESULT.md` (full findings + T7.2 recommendation), `.gitignore` (out/ + node_modules/).

Three sidecar layouts were exercised on the same SEA binary by moving files around.

## Results

Host: Windows 11 x64, Node v24.14.1 (SEA API frozen since Node 22), better-sqlite3 11.10.0.

| OS | Layout | Outcome | SQLITE_VERSION | Notes |
| --- | --- | --- | --- | --- |
| win32 | A — full `node_modules/better-sqlite3` tree + `bindings` + `file-uri-to-path` next to binary | **PASS** | 3.49.2 | `require('better-sqlite3')` resolved against the sidecar `node_modules`; in-memory query ran. `IS_SEA=true`. |
| win32 | B — bare `better_sqlite3.node` only | **PASS (dlopen)** | `<dlopen-only>` | `require()` failed; `process.dlopen()` succeeded. Native side loads, but JS wrapper is unusable. |
| win32 | C — no sidecar | **FAIL (expected)** | — | `Error: Cannot find module 'better-sqlite3'` from `Module._resolveFilename`. |
| linux | — | **TODO** | — | Not run on this host. |
| macOS | — | **TODO** | — | Expect same outcome plus codesign of binary AND sidecar `.node`; gatekeeper requires both signed + notarized (ch14 §1.13). |

## Conclusion

**better-sqlite3 loads cleanly from a Node 22 SEA**, provided:
1. The JS wrapper directory **and** the prebuilt `better_sqlite3.node` are staged on disk next to the binary.
2. `require` is anchored at `process.execPath` via `createRequire(process.execPath)` — without this, `require()` resolves relative to the SEA virtual root which has no `node_modules/`.

The naive "single self-contained binary" goal is not achievable for native modules; they must remain sidecars.

## Recommendation for T7.2 native-loader (#83)

1. Detect SEA via `require('node:sea').isSea()` (try/catch — module absent outside SEA).
2. Build `createRequire(process.execPath)` once at startup; route all native addon requires through it.
3. Ship native addons under a known sibling path (e.g. `<install>/native/<addon>/`) and prepend to the resolver, so we are not coupled to `process.execPath`'s parent directory layout (which differs across Squirrel.Windows / .pkg / AppImage).
4. Surface `NativeAddonLoadError { moduleName, attemptedPaths[], cause }` so installer-residue / sidecar-missing failures are distinguishable from ABI mismatches in crash reports.
5. Pin the better-sqlite3 prebuild URL + sha in the v0.3 lockfile and verify during the SEA build step (production must match the bundled Node major's ABI exactly).

macOS codesign / notarization story is separate — the sidecar `.node` MUST be signed independently of the binary (ch14 §1.13 + existing `entitlements-jit.plist`).

## Scope guard

- No changes to `packages/daemon` or any production source.
- No additions to root `package.json`; the probe ships a local devDep `package.json` ignored by all repo build/test pipelines.
- `tools/spike-harness/**` is already eslint-ignored (per `eslint.config.js`).
- `tools/lint-no-ipc.sh` only scans `packages/electron/src/`; no allowlist edit required.

## Test plan

- [ ] Reviewer can re-run on linux/macOS by `cd tools/spike-harness/probes/sqlite-in-sea && bash build-sea.sh` and append rows to the results table in `RESULT.md`.
- [x] Windows run captured (terminal output recorded in commit message + RESULT.md).
- [x] Three layouts (A/B/C) verified on Windows.