### PR TITLE
feat(daemon): T1.6 connection-descriptor atomic writer (listener-a.json v1)

### DIFF
--- a/packages/daemon/src/listeners/__tests__/descriptor.spec.ts
+++ b/packages/daemon/src/listeners/__tests__/descriptor.spec.ts
@@ -1,0 +1,141 @@
+// Spec for the listener-A connection-descriptor atomic writer.
+// Spec ref: ch03 §3.1 (atomic write tmp+fsync+rename) + §3.2 (v1 schema).
+//
+// We exercise four invariants the spec calls out by name:
+//   1. write/read roundtrip — JSON parse echoes the payload byte-equivalent.
+//   2. atomicity — `<path>.tmp` is gone after writeDescriptor resolves
+//      (rename(2) succeeded, no orphan temp file).
+//   3. boot_id present in the on-disk JSON (Electron's freshness witness).
+//   4. version === 1 in the on-disk JSON (forever-stable schema marker).
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import * as fsPromises from 'node:fs/promises';
+import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  type DescriptorV1,
+  descriptorTmpPath,
+  removeDescriptor,
+  writeDescriptor,
+} from '../descriptor.js';
+
+const SAMPLE: DescriptorV1 = {
+  version: 1,
+  transport: 'KIND_UDS',
+  address: '/run/ccsm/daemon.sock',
+  tlsCertFingerprintSha256: null,
+  supervisorAddress: '/run/ccsm/supervisor.sock',
+  boot_id: '550e8400-e29b-41d4-a716-446655440000',
+  daemon_pid: 1234,
+  listener_addr: '/run/ccsm/daemon.sock',
+  protocol_version: 1,
+  bind_unix_ms: 1714600000000,
+};
+
+describe('writeDescriptor (atomic listener-a.json)', () => {
+  let dir: string;
+  let path: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'ccsm-descriptor-'));
+    path = join(dir, 'listener-a.json');
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('roundtrips: written bytes parse back to an equal payload', async () => {
+    await writeDescriptor(path, SAMPLE);
+    const raw = await readFile(path, 'utf8');
+    const parsed = JSON.parse(raw) as DescriptorV1;
+    expect(parsed).toEqual(SAMPLE);
+  });
+
+  it('is atomic: <path>.tmp is gone after a successful write', async () => {
+    await writeDescriptor(path, SAMPLE);
+    const tmp = descriptorTmpPath(path);
+    await expect(stat(tmp)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('emits boot_id in the on-disk JSON (freshness witness)', async () => {
+    await writeDescriptor(path, SAMPLE);
+    const parsed = JSON.parse(await readFile(path, 'utf8')) as DescriptorV1;
+    expect(parsed.boot_id).toBe(SAMPLE.boot_id);
+    expect(parsed.boot_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  it('emits version === 1 in the on-disk JSON (schema marker)', async () => {
+    await writeDescriptor(path, SAMPLE);
+    const parsed = JSON.parse(await readFile(path, 'utf8')) as {
+      version: unknown;
+      protocol_version: unknown;
+    };
+    expect(parsed.version).toBe(1);
+    expect(parsed.protocol_version).toBe(1);
+  });
+
+  it('refuses to clobber a stale .tmp left from a previous crashed boot', async () => {
+    // Simulate a crashed prior boot: a .tmp file exists at the destination
+    // tmp path. The wx open flag must surface this loudly rather than
+    // silently merge / overwrite.
+    const tmp = descriptorTmpPath(path);
+    await writeFile(tmp, 'stale\n', 'utf8');
+    await expect(writeDescriptor(path, SAMPLE)).rejects.toMatchObject({
+      code: 'EEXIST',
+    });
+  });
+
+  it('fsyncs the temp fd before rename (durability gate)', async () => {
+    // Spec ch03 §3.1 step 2 mandates fsync(2) on the temp fd between write
+    // and rename so the bytes are durable BEFORE the rename becomes visible.
+    // We verify by patching FileHandle.prototype.sync (vitest can't spy on
+    // the ESM namespace export, so prototype patching is the cheapest seam).
+    // Removing `await fh.sync()` in descriptor.ts makes this assertion fail
+    // (reverse-verify).
+    const probeFh = await fsPromises.open(join(dir, '.probe'), 'w');
+    const FileHandleProto = Object.getPrototypeOf(probeFh) as {
+      sync: (this: unknown) => Promise<void>;
+    };
+    await probeFh.close();
+
+    const syncCalls: string[] = [];
+    const originalSync = FileHandleProto.sync;
+    FileHandleProto.sync = async function patchedSync(this: unknown) {
+      syncCalls.push('sync');
+      return originalSync.call(this);
+    };
+    try {
+      await writeDescriptor(path, SAMPLE);
+      expect(syncCalls.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      FileHandleProto.sync = originalSync;
+    }
+  });
+});
+
+describe('removeDescriptor', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'ccsm-descriptor-rm-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('is idempotent on a missing file (no throw)', async () => {
+    await expect(removeDescriptor(join(dir, 'nope.json'))).resolves.toBeUndefined();
+  });
+
+  it('removes an existing descriptor file', async () => {
+    const path = join(dir, 'listener-a.json');
+    await writeDescriptor(path, SAMPLE);
+    await removeDescriptor(path);
+    await expect(stat(path)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+});

--- a/packages/daemon/src/listeners/descriptor.ts
+++ b/packages/daemon/src/listeners/descriptor.ts
@@ -1,0 +1,161 @@
+// Listener-A connection descriptor — atomic writer + v1 schema.
+//
+// Spec ch03 §3.1 (atomic write discipline: tmp + fsync + rename) and
+// §3.2 (descriptor v1 schema, forever-stable). The daemon writes this
+// JSON file exactly once per boot at a per-OS path so Electron can
+// rendezvous with the bound Listener A and verify freshness via the
+// embedded `boot_id` (ch03 §3.3 handshake).
+//
+// Scope (T1.6):
+//   - DescriptorV1 type + payload shape (transport / address / boot_id / etc.)
+//   - writeDescriptor(path, payload) — write JSON to `<path>.tmp`, fsync the
+//     fd, then rename(2) over `<path>`. Rename is atomic on every supported
+//     FS, so Electron never observes a torn file.
+//   - removeDescriptor(path) — best-effort unlink (used by tests / shutdown
+//     paths that explicitly want the file gone; spec ch03 §3.1 step 5 says
+//     orphan files between boots are NORMAL, so daemon graceful shutdown
+//     does NOT call this).
+//
+// Out of scope (deliberately deferred):
+//   - JSON Schema validator file → Task #125 (T10.4).
+//   - makeListenerA factory + listener slot wiring → T1.4.
+//   - Per-OS state-dir paths → Task #57 (T5.3); this module accepts an
+//     absolute path argument and is path-agnostic.
+
+import { open as fsOpen, rename, unlink } from 'node:fs/promises';
+import { dirname, basename, join } from 'node:path';
+
+/**
+ * Closed enum of supported transports. Stringified identically into the
+ * descriptor's `transport` field. Spec ch03 §1a — additions in v0.4 ship
+ * under a NEW descriptor file, never as new values in this enum.
+ */
+export type DescriptorTransport =
+  | 'KIND_UDS'
+  | 'KIND_NAMED_PIPE'
+  | 'KIND_TCP_LOOPBACK_H2C'
+  | 'KIND_TCP_LOOPBACK_H2_TLS';
+
+/**
+ * v1 descriptor payload. Forever-stable — v0.4+ additions go in NEW
+ * top-level optional fields, never as enum widenings or type changes
+ * (spec ch03 §3.2 + ch15 §3 forbidden-pattern 8).
+ *
+ * Field semantics (verbatim from spec ch03 §3.2):
+ *   - version            literal `1` (bumps only on wire-incompatible breaks)
+ *   - transport          closed enum from §1a
+ *   - address            bind address; format depends on transport
+ *   - tlsCertFingerprintSha256
+ *                        SHA-256 of the listener's self-signed cert when
+ *                        transport === 'KIND_TCP_LOOPBACK_H2_TLS'; null
+ *                        otherwise
+ *   - supervisorAddress  Supervisor UDS / named-pipe path (UDS-only — spec §7)
+ *   - boot_id            per-boot UUIDv4 (freshness witness; ch02 §3 step 5)
+ *   - daemon_pid         observability only — Electron MUST NOT auth on this
+ *   - listener_addr      duplicate of `address` for grep-friendly logs
+ *   - protocol_version   `1` for v0.3; bumps only on wire-incompatible change
+ *   - bind_unix_ms       daemon process start time, observability only
+ *
+ * NOTE on field naming: snake_case matches the spec table verbatim and the
+ * proto wire convention from ch04. Keep both spellings together so the
+ * reverse-grep from `listener-a.json` to this type stays one hop.
+ */
+export interface DescriptorV1 {
+  readonly version: 1;
+  readonly transport: DescriptorTransport;
+  readonly address: string;
+  readonly tlsCertFingerprintSha256: string | null;
+  readonly supervisorAddress: string;
+  readonly boot_id: string;
+  readonly daemon_pid: number;
+  readonly listener_addr: string;
+  readonly protocol_version: 1;
+  readonly bind_unix_ms: number;
+}
+
+/** Suffix used for the in-flight temp file. Kept in the same directory as
+ * the destination so `rename(2)` stays within one filesystem (atomic). */
+export const DESCRIPTOR_TMP_SUFFIX = '.tmp';
+
+/** Compute the temp-file path used by `writeDescriptor`. Exposed so tests
+ * can assert the temp file is gone after a successful write. */
+export function descriptorTmpPath(finalPath: string): string {
+  // Same directory as final path so rename(2) is intra-FS (atomic). Adding
+  // the suffix to the basename (rather than the dir) keeps the temp file
+  // co-located with the descriptor for ops grep (`ls listener-a*`).
+  return join(dirname(finalPath), `${basename(finalPath)}${DESCRIPTOR_TMP_SUFFIX}`);
+}
+
+/**
+ * Write the descriptor atomically. Spec ch03 §3.1 sequence:
+ *   1. write JSON to `<path>.tmp` in the same directory;
+ *   2. fsync(2) the temp fd (so the bytes are durable BEFORE the rename
+ *      becomes visible — otherwise a crash between rename and fsync could
+ *      leave a zero-byte descriptor that survives reboot);
+ *   3. rename(2) `<path>.tmp` -> `<path>` (atomic on every supported FS,
+ *      including NTFS via MoveFileExW(MOVEFILE_REPLACE_EXISTING) which is
+ *      what libuv's uv_fs_rename uses on Windows).
+ *
+ * Throws on any I/O failure; caller is responsible for logging + lifecycle
+ * fail() (spec ch02 §3 — descriptor write is part of phase STARTING_LISTENERS,
+ * so a failure here aborts boot before /healthz can flip to 200).
+ */
+export async function writeDescriptor(
+  path: string,
+  payload: DescriptorV1,
+): Promise<void> {
+  const tmpPath = descriptorTmpPath(path);
+  // Pretty-print with a trailing newline — `cat listener-a.json` from an
+  // operator shell is the primary debugging tool; the 2-space indent is
+  // wire-stable irrelevant (Electron's JSON.parse ignores whitespace).
+  const json = `${JSON.stringify(payload, null, 2)}\n`;
+
+  // `wx` = O_WRONLY|O_CREAT|O_EXCL — fail if a stale temp file exists.
+  // A leftover .tmp from a prior crashed boot is suspect; refusing to
+  // overwrite makes the failure mode loud rather than silently producing
+  // a possibly-merged descriptor.
+  const fh = await fsOpen(tmpPath, 'wx', 0o644);
+  try {
+    await fh.writeFile(json, 'utf8');
+    // fsync the fd, NOT the directory. Per spec §3.1 we need the bytes on
+    // disk BEFORE the rename becomes visible; fsync on the fd forces the
+    // file's data + metadata. Directory-level fsync (for the rename itself)
+    // is a future hardening item not required by the spec for v0.3.
+    await fh.sync();
+  } finally {
+    await fh.close();
+  }
+
+  // rename(2) is atomic across same-FS. If this throws, the .tmp file is
+  // left behind for forensic inspection — caller decides whether to
+  // unlink it (we do NOT here, because losing the tmp on a flaky FS
+  // would erase the only diagnostic).
+  await rename(tmpPath, path);
+}
+
+/**
+ * Remove the descriptor file. Best-effort: missing-file is NOT an error
+ * (idempotent for test cleanup paths). Any other I/O error is rethrown.
+ *
+ * Spec ch03 §3.1 step 5: the daemon does NOT call this on graceful
+ * shutdown — orphan descriptor files between boots are normal and the
+ * boot_id mismatch check handles them. This export exists for tests
+ * and for the rare admin-tool teardown path.
+ */
+export async function removeDescriptor(path: string): Promise<void> {
+  try {
+    await unlink(path);
+  } catch (err) {
+    if (isEnoent(err)) return;
+    throw err;
+  }
+}
+
+function isEnoent(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code: unknown }).code === 'ENOENT'
+  );
+}


### PR DESCRIPTION
## Summary

Task #30 (T1.6). Implements the listener-A connection-descriptor module the daemon hands to Electron for rendezvous.

**Files:**
- `packages/daemon/src/listeners/descriptor.ts` — DescriptorV1 type + `writeDescriptor` (tmp + fsync + rename) + `removeDescriptor`.
- `packages/daemon/src/listeners/__tests__/descriptor.spec.ts` — 8 tests (roundtrip, atomicity, boot_id present, version=1, stale-tmp refusal, fsync-before-rename, removeDescriptor idempotent + happy path).

## Spec refs

- ch03 §3.1 — atomic write discipline (write `<path>.tmp`, `fsync(2)`, `rename(2)`; rename atomic on every supported FS).
- ch03 §3.2 — DescriptorV1 schema (forever-stable; `version`, `transport`, `address`, `tlsCertFingerprintSha256`, `supervisorAddress`, `boot_id`, `daemon_pid`, `listener_addr`, `protocol_version`, `bind_unix_ms`).

## Out of scope (deferred per task brief)

- JSON Schema validator file → Task #125 (T10.4).
- `makeListenerA` factory + listener slot wiring → T1.4.
- Per-OS state-dir paths → Task #57 (T5.3); writer accepts an absolute path argument and is path-agnostic.

## Local quality gates

```
npx vitest run         → 18 passed (2 files)  [includes 8 new descriptor tests]
npx tsc --noEmit       → clean
npx eslint .../daemon/src → clean
```

## Reverse-verify (stash fsync line)

Stashed `await fh.sync()` in `descriptor.ts` line 124 → `fsyncs the temp fd before rename (durability gate)` test FAILS as designed:

```
FAIL  src/listeners/__tests__/descriptor.spec.ts > writeDescriptor (atomic listener-a.json) > fsyncs the temp fd before rename (durability gate)
AssertionError: expected 0 to be greater than or equal to 1
 ❯ src/listeners/__tests__/descriptor.spec.ts:113:32
    113|       expect(syncCalls.length).toBeGreaterThanOrEqual(1);
Test Files  1 failed | 1 passed (2)
     Tests  1 failed | 17 passed (18)
```

Restored fsync line → all 18 tests PASS again. Reverse-verify proves the fsync invariant is testable, not vacuous.

## Test plan

- [x] write/read roundtrip yields equal payload
- [x] `<path>.tmp` is gone after successful write (rename atomicity)
- [x] `boot_id` present in on-disk JSON (UUIDv4 shape)
- [x] `version === 1` and `protocol_version === 1`
- [x] stale `<path>.tmp` from prior crashed boot triggers EEXIST (no silent merge)
- [x] `fh.sync()` called between write and rename (reverse-verified)
- [x] `removeDescriptor` is idempotent on missing file + removes existing