### PR TITLE
feat(daemon): T5.1 better-sqlite3 wrapper + PRAGMA boot-time config

### DIFF
--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -3,5 +3,16 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "description": "CCSM daemon (headless RPC server). Skeleton only; implementation lands in subsequent T0.x / T1.x tasks per design spec ch11."
+  "description": "CCSM daemon (headless RPC server). Skeleton only; implementation lands in subsequent T0.x / T1.x tasks per design spec ch11.",
+  "scripts": {
+    "lint": "eslint src --ext .ts",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "better-sqlite3": "^12.9.0"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.12"
+  }
 }

--- a/packages/daemon/src/db/__tests__/sqlite.spec.ts
+++ b/packages/daemon/src/db/__tests__/sqlite.spec.ts
@@ -1,0 +1,87 @@
+// packages/daemon/src/db/__tests__/sqlite.spec.ts
+//
+// Verifies that `openDatabase()` applies every PRAGMA spec'd in
+// docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md ch07 §3
+// at boot time, by reading each value back via `db.pragma()` after the
+// wrapper returns.
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { BOOT_PRAGMAS, openDatabase, type SqliteDatabase } from '../sqlite.js';
+
+describe('openDatabase (T5.1 — ch07 §1/§3)', () => {
+  let tmpDir: string;
+  let dbPath: string;
+  let db: SqliteDatabase | null = null;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'ccsm-daemon-sqlite-'));
+    dbPath = join(tmpDir, 'test.db');
+  });
+
+  afterEach(() => {
+    if (db) {
+      try {
+        db.close();
+      } catch {
+        // best-effort
+      }
+      db = null;
+    }
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('opens the database file', () => {
+    db = openDatabase(dbPath);
+    expect(db.open).toBe(true);
+    expect(db.name).toBe(dbPath);
+  });
+
+  it('applies journal_mode = WAL', () => {
+    db = openDatabase(dbPath);
+    // `pragma('journal_mode', { simple: true })` returns the bare value.
+    const mode = db.pragma('journal_mode', { simple: true });
+    expect(String(mode).toLowerCase()).toBe(BOOT_PRAGMAS.journal_mode);
+  });
+
+  it('applies synchronous = NORMAL (1)', () => {
+    db = openDatabase(dbPath);
+    // SQLite reports synchronous as an integer: OFF=0, NORMAL=1, FULL=2, EXTRA=3.
+    const sync = db.pragma('synchronous', { simple: true });
+    expect(sync).toBe(1);
+  });
+
+  it('applies foreign_keys = ON (1)', () => {
+    db = openDatabase(dbPath);
+    const fk = db.pragma('foreign_keys', { simple: true });
+    expect(fk).toBe(1);
+  });
+
+  it('applies busy_timeout = 5000', () => {
+    db = openDatabase(dbPath);
+    const bt = db.pragma('busy_timeout', { simple: true });
+    expect(bt).toBe(BOOT_PRAGMAS.busy_timeout);
+  });
+
+  it('applies journal_size_limit = 64 MiB (67108864)', () => {
+    db = openDatabase(dbPath);
+    const limit = db.pragma('journal_size_limit', { simple: true });
+    expect(limit).toBe(BOOT_PRAGMAS.journal_size_limit);
+  });
+
+  it('BOOT_PRAGMAS constant matches spec values', () => {
+    // Lock the constants — if the spec ever changes these, this assertion
+    // forces the wrapper, the constant, and this test to update together.
+    expect(BOOT_PRAGMAS).toEqual({
+      journal_mode: 'wal',
+      synchronous: 'NORMAL',
+      foreign_keys: 'ON',
+      busy_timeout: 5000,
+      journal_size_limit: 67108864,
+    });
+  });
+});

--- a/packages/daemon/src/db/sqlite.ts
+++ b/packages/daemon/src/db/sqlite.ts
@@ -1,0 +1,89 @@
+// packages/daemon/src/db/sqlite.ts
+//
+// Thin wrapper around `better-sqlite3` that opens a database and applies the
+// canonical boot-time PRAGMAs spec'd in
+// docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+//   - chapter 07 §1 (storage choice: SQLite via better-sqlite3, sync driver)
+//   - chapter 07 §3 (PRAGMA list applied at boot AFTER opening the connection
+//     but BEFORE running migrations)
+//
+// Scope (Task #54 / T5.1): driver + PRAGMAs only. The migration runner
+// (T5.4 / Task #56), the 001_initial.sql schema (T5.2 / Task #55), and the
+// WAL discipline + shutdown checkpoint (T5.6 / Task #58) all land in
+// separate tasks and MUST NOT be added here.
+
+import Database, { type Database as BetterSqlite3Database } from 'better-sqlite3';
+
+/**
+ * Re-exported `better-sqlite3` Database type. Callers should import this
+ * symbol rather than reaching into `better-sqlite3` directly so that the
+ * daemon has a single typed surface for the driver (eases future swap or
+ * patch-pinning).
+ */
+export type SqliteDatabase = BetterSqlite3Database;
+
+/**
+ * Boot-time PRAGMA values (ch07 §3). Frozen so callers can assert against
+ * the same constants the wrapper applies — tests in `__tests__/sqlite.spec.ts`
+ * rely on this.
+ */
+export const BOOT_PRAGMAS = Object.freeze({
+  /** WAL mode is mandatory for the daemon's reader/writer concurrency model. */
+  journal_mode: 'wal',
+  /** NORMAL is the default per ch07 §3; configurable per Settings in T-later. */
+  synchronous: 'NORMAL',
+  /** ON enables FK enforcement — required by the v0.3 schema. */
+  foreign_keys: 'ON',
+  /** 5000 ms — bounds writer-contention waits (ch07 §3). */
+  busy_timeout: 5000,
+  /** 64 MiB cap on -wal file growth (ch07 §3 / §5 WAL discipline). */
+  journal_size_limit: 67108864,
+} as const);
+
+export interface OpenDatabaseOptions {
+  /** Open the database read-only. Used by the boot integrity-check path
+   *  (ch07 §4 step 1). Defaults to `false` (read/write). */
+  readonly?: boolean;
+}
+
+/**
+ * Open a SQLite database at `path` and apply the canonical boot-time
+ * PRAGMAs from ch07 §3.
+ *
+ * Order matters per spec: PRAGMAs are applied **after** the connection is
+ * open and **before** any migration / schema work. `journal_mode = WAL` is
+ * applied first because subsequent PRAGMAs implicitly assume WAL semantics
+ * (notably `journal_size_limit`).
+ *
+ * On any PRAGMA failure the connection is closed before re-throwing so the
+ * caller never sees a half-configured handle.
+ *
+ * @param path Filesystem path to the database file. Use `':memory:'` for
+ *   in-process tests (still receives the full PRAGMA suite — the wrapper
+ *   does not special-case it).
+ * @param options Optional read-only flag (used by integrity-check path).
+ */
+export function openDatabase(path: string, options: OpenDatabaseOptions = {}): SqliteDatabase {
+  const db: SqliteDatabase = new Database(path, {
+    readonly: options.readonly ?? false,
+  });
+
+  try {
+    // WAL must come first — other PRAGMAs (journal_size_limit) assume it.
+    db.pragma(`journal_mode = ${BOOT_PRAGMAS.journal_mode}`);
+    db.pragma(`synchronous = ${BOOT_PRAGMAS.synchronous}`);
+    db.pragma(`foreign_keys = ${BOOT_PRAGMAS.foreign_keys}`);
+    db.pragma(`busy_timeout = ${BOOT_PRAGMAS.busy_timeout}`);
+    db.pragma(`journal_size_limit = ${BOOT_PRAGMAS.journal_size_limit}`);
+  } catch (err) {
+    // Don't leak a half-configured handle on PRAGMA failure.
+    try {
+      db.close();
+    } catch {
+      // best-effort
+    }
+    throw err;
+  }
+
+  return db;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,7 +223,15 @@ importers:
         specifier: ^5.2.0
         version: 5.2.3(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.106.2)
 
-  packages/daemon: {}
+  packages/daemon:
+    dependencies:
+      better-sqlite3:
+        specifier: ^12.9.0
+        version: 12.9.0
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.12
+        version: 7.6.13
 
   packages/electron: {}
 


### PR DESCRIPTION
## Scope (Task #54 / T5.1)

Add a thin `better-sqlite3` wrapper for the daemon that applies the canonical
boot-time PRAGMAs from spec ch07 §3 the moment the connection opens.

- `packages/daemon/src/db/sqlite.ts` — `openDatabase(path, options?)` wrapper. Applies in order: `journal_mode = WAL`, `synchronous = NORMAL`, `foreign_keys = ON`, `busy_timeout = 5000`, `journal_size_limit = 67108864` (64 MiB).
- Exports typed `SqliteDatabase` (re-export of `better-sqlite3` `Database`) so the rest of the daemon imports a single typed surface.
- Frozen `BOOT_PRAGMAS` constant exported alongside so callers (and the spec test) can assert against the same values the wrapper applies.
- Closes the connection on PRAGMA failure to avoid leaking a half-configured handle.

## Spec refs

- ch07 §1 — storage choice: SQLite via `better-sqlite3`, sync driver, WAL mode
- ch07 §3 — full PRAGMA list applied at boot **after** opening, **before** migrations

## Out of scope (explicitly NOT touched here)

| Item | Owner |
|---|---|
| `001_initial.sql` schema | Task #55 / T5.2 |
| Migration runner | Task #56 / T5.4 |
| WAL discipline + shutdown checkpoint | Task #58 / T5.6 |

## Test

`packages/daemon/src/db/__tests__/sqlite.spec.ts` — opens a temp DB and verifies each PRAGMA value via `db.pragma(name, { simple: true })` reads. 7 cases (open file + 5 PRAGMAs + frozen-constant shape lock). All pass locally.

## Dep choice note

Spec text named "latest 11.x" but root `package.json` already pins `better-sqlite3 ^12.9.0` at the workspace root. Adding `^11.7.0` to `@ccsm/daemon` caused pnpm to install a duplicate native module which then failed `electron-rebuild` on Windows postinstall. Aligning the daemon dep to `^12.9.0` lets pnpm dedupe to a single native install. 12.x is API-compatible with 11.x for the surface used here (`new Database`, `db.pragma`, `db.close`). If a downgrade is preferred, happy to revisit.

## Local quality gates (Windows, Node 24)

- `pnpm --filter @ccsm/daemon typecheck` — pass
- `pnpm --filter @ccsm/daemon lint`      — pass
- `pnpm --filter @ccsm/daemon test`      — 17/17 pass (incl. existing migration-lock spec, still skipped per design)

## Windows native-rebuild note

On this host `pnpm install` completes but the better-sqlite3 binding it leaves under `node_modules/.pnpm/.../build/Release/` was compiled for the Electron ABI (NODE_MODULE_VERSION 145). To run the daemon vitest suite against plain Node 24 (NODE_MODULE_VERSION 137), one extra rebuild was needed:

```
cd node_modules/.pnpm/better-sqlite3@12.9.0/node_modules/better-sqlite3
npx node-gyp rebuild --release
```

CI runs Node 20 with matching prebuilds and should not hit this. Documented here per task instructions in case CI does hit it.