### PR TITLE
spike(T9.4): Node 22 http2 over UDS — smoke + 1h soak harness

### DIFF
--- a/tools/spike-harness/README.md
+++ b/tools/spike-harness/README.md
@@ -39,3 +39,5 @@ Cross-link: chapter 11 §2 / §6 pins this path; chapter 12 §3 reuses
 | `install-residue-diff.ps1`       | §1.16             | stub (TODO: Get-ChildItem + reg diff) |
 | `rtt-histogram.mjs`              | §1.3, §1.4, §1.5  | runnable (JSONL → p50/p95/p99)      |
 | `stream-truncation-detector.mjs` | §1.3, §1.4, §1.5  | runnable (seq-gap detector)         |
+| `probes/uds-h2c/{server,client}.mjs` | §1.4 (T9.4)   | runnable on darwin/linux; win32 skip |
+| `probes/uds-h2c/run.sh`          | §1.4 (T9.4)       | smoke (60s) + 1h soak driver        |

--- a/tools/spike-harness/probes/uds-h2c/RESULT.md
+++ b/tools/spike-harness/probes/uds-h2c/RESULT.md
@@ -1,0 +1,42 @@
+# T9.4 spike — Node 22 http2 (h2c) over UDS
+
+**Status:** smoke harness landed; 1h soak deferred to self-hosted runner per spec ch10 + Task #16 (T0.10).
+
+**Platform:** authored from `MINGW64_NT-10.0-26200` (Windows). On win32 the harness short-circuits with exit 2 (`run.sh` skip + `server.mjs`/`client.mjs` guard) — UDS path semantics differ on Windows; the parallel named-pipe spike (T9.5) covers that transport. Smoke + 1h soak on darwin / linux are scheduled for the self-hosted runners pinned by T0.10.
+
+## Files
+
+- `server.mjs` — http2 (cleartext h2c) server bound to `/tmp/ccsm-spike.sock`, single `/ping → pong` route, SIGTERM-safe socket unlink.
+- `client.mjs` — http2 client over UDS (via `net.connect` factory passed to `http2.connect`), 10 req/sec, configurable duration, p50/p95/p99 + RSS delta + per-minute fd snapshot (`/proc/self/fd` on linux, `null` on darwin), `verdict: PASS|FAIL`.
+- `run.sh` — orchestrates server start → client soak → teardown (kill TERM-then-KILL, unlink socket); pipes RTT NDJSON through existing `tools/spike-harness/rtt-histogram.mjs`.
+
+## Smoke verification on this host (win32)
+
+```
+$ bash tools/spike-harness/probes/uds-h2c/run.sh
+uds-h2c spike: skipped on MINGW64_NT-10.0-26200 (win32 — use named-pipe spike)
+exit=2
+```
+
+`node --check` passes for both `.mjs` files; `bash -n run.sh` passes; `pnpm lint` = 0 errors (the harness directory is in eslint `ignores`, but Node syntax-check is sufficient for stdlib-only scripts per `tools/spike-harness/README.md` Layer-1 constraint).
+
+## Decision criterion (encoded in client.mjs)
+
+A run is **PASS** iff all three hold over the full duration:
+
+1. error rate ≤ **1 %** (`errors / sent`)
+2. RSS climb ≤ **50 MB** (`process.memoryUsage().rss` end − start)
+3. fd count climb ≤ **5** between first and last `/proc/self/fd` snapshot (linux only; macOS lacks an equivalent cheap probe so the criterion is skipped there and we lean on RSS as the leak proxy)
+
+Any FAIL exits 3 from the client (and from `run.sh`).
+
+## Recommendation for ch03 §4 transport choice (darwin/linux)
+
+Pending the 1h soak on real CI hardware, the harness is structured so a green run is sufficient evidence to lock **option A (h2c-over-UDS)** as the v0.3 Listener-A transport on darwin/linux, matching the spec's "peer-cred-trusted local socket" requirement (no TLS overhead, no port allocation, peer-cred via `getsockopt` already covered by `connect-and-peercred.sh`).
+
+If the soak shows fd / RSS climb, the fallback is option C (loopback-TCP + JWT) — already covered by T9.3's harness — at the cost of giving up peer-cred bypass on Listener A.
+
+## Follow-ups
+
+- T0.10 (#16): wire this `run.sh` into the self-hosted darwin + linux runners with `SPIKE_DURATION_SEC=3600`. Capture `summary.json` + `histogram.json` as build artifacts.
+- T9.5: parallel named-pipe spike on win32 (out of scope here; this spike's win32 skip is intentional).

--- a/tools/spike-harness/probes/uds-h2c/client.mjs
+++ b/tools/spike-harness/probes/uds-h2c/client.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+// client.mjs — http2 (h2c) client over UDS, sustained-traffic soak driver.
+//
+// Spike T9.4: drives N req/sec against server.mjs for SPIKE_DURATION_SEC
+// seconds (default 60 smoke; 3600 = 1h soak). Records p50/p95/p99 RTT,
+// error count, and fd count snapshots every 60s.
+//
+// Forever-stable contract:
+//
+//   Usage:
+//     client.mjs [--socket=<path>]   default /tmp/ccsm-spike.sock
+//                [--rate=<n>]        req/sec, default 10
+//                [--duration=<sec>]  overrides SPIKE_DURATION_SEC
+//
+//   Env:
+//     SPIKE_DURATION_SEC   default 60 (smoke). 3600 = 1h soak.
+//
+//   Output (stdout, single trailing JSON line):
+//     {"durationSec":<num>,"sent":<int>,"ok":<int>,"errors":<int>,
+//      "p50Us":<int>,"p95Us":<int>,"p99Us":<int>,
+//      "rssStartBytes":<int>,"rssEndBytes":<int>,"rssDeltaBytes":<int>,
+//      "fdSnapshots":[{"tSec":<int>,"fdCount":<int|null>}],
+//      "verdict":"PASS"|"FAIL","verdictReason":"<str>"}
+//
+//   Per-request RTT lines (NDJSON) go to stderr so they can be piped to
+//   rtt-histogram.mjs without polluting the summary.
+//
+//   Exit codes: 0 PASS; 3 FAIL (errors > 1%, RSS > 50MB, or fd leak > 5);
+//               2 bad arg; 1 connect failure.
+//
+// Layer-1: node: stdlib only.
+
+import { connect } from 'node:http2';
+import * as net from 'node:net';
+import { parseArgs } from 'node:util';
+import { readdirSync } from 'node:fs';
+import { platform } from 'node:os';
+
+if (platform() === 'win32') {
+  process.stderr.write('uds-h2c client: win32 unsupported\n');
+  process.exit(2);
+}
+
+const { values } = parseArgs({
+  options: {
+    socket:   { type: 'string', default: '/tmp/ccsm-spike.sock' },
+    rate:     { type: 'string', default: '10' },
+    duration: { type: 'string' },
+  },
+  strict: true,
+});
+
+const socketPath = values.socket;
+const rate = Number(values.rate);
+const durationSec = Number(values.duration ?? process.env.SPIKE_DURATION_SEC ?? '60');
+if (!Number.isFinite(rate) || rate <= 0) { process.stderr.write('bad --rate\n'); process.exit(2); }
+if (!Number.isFinite(durationSec) || durationSec <= 0) { process.stderr.write('bad --duration\n'); process.exit(2); }
+
+const session = connect('http://localhost', {
+  createConnection: () => net.connect(socketPath),
+});
+
+session.on('error', (err) => {
+  process.stderr.write(`session error: ${err.message}\n`);
+});
+
+await new Promise((resolve, reject) => {
+  const t = setTimeout(() => reject(new Error('connect timeout')), 5000);
+  session.once('connect', () => { clearTimeout(t); resolve(); });
+  session.once('error', (e) => { clearTimeout(t); reject(e); });
+}).catch((e) => {
+  process.stderr.write(`failed to connect: ${e.message}\n`);
+  process.exit(1);
+});
+
+const samples = [];
+let sent = 0;
+let ok = 0;
+let errors = 0;
+const fdSnapshots = [];
+const rssStart = process.memoryUsage().rss;
+
+function fdCount() {
+  // Linux only: /proc/self/fd. macOS/other: return null.
+  try {
+    return readdirSync('/proc/self/fd').length;
+  } catch {
+    return null;
+  }
+}
+
+function snapshot(tSec) {
+  fdSnapshots.push({ tSec, fdCount: fdCount() });
+}
+snapshot(0);
+
+function doRequest() {
+  const start = process.hrtime.bigint();
+  sent++;
+  const req = session.request({ ':method': 'GET', ':path': '/ping' });
+  let body = '';
+  req.setEncoding('utf8');
+  req.on('data', (chunk) => { body += chunk; });
+  req.on('end', () => {
+    const rttUs = Number((process.hrtime.bigint() - start) / 1000n);
+    if (body === 'pong') {
+      ok++;
+      samples.push(rttUs);
+      process.stderr.write(JSON.stringify({ rttUs }) + '\n');
+    } else {
+      errors++;
+    }
+  });
+  req.on('error', () => { errors++; });
+  req.end();
+}
+
+const intervalMs = 1000 / rate;
+const startMs = Date.now();
+const endMs = startMs + durationSec * 1000;
+
+const reqTimer = setInterval(() => {
+  if (Date.now() >= endMs) return;
+  doRequest();
+}, intervalMs);
+
+const snapTimer = setInterval(() => {
+  const tSec = Math.round((Date.now() - startMs) / 1000);
+  snapshot(tSec);
+}, 60_000);
+
+await new Promise((resolve) => setTimeout(resolve, durationSec * 1000));
+clearInterval(reqTimer);
+clearInterval(snapTimer);
+
+// Drain in-flight (cap 2s).
+await new Promise((resolve) => setTimeout(resolve, Math.min(2000, intervalMs * 5)));
+
+snapshot(durationSec);
+
+session.close();
+
+samples.sort((a, b) => a - b);
+const pct = (p) => samples.length === 0 ? 0 : samples[Math.min(samples.length - 1, Math.floor(p * samples.length))];
+const rssEnd = process.memoryUsage().rss;
+const rssDelta = rssEnd - rssStart;
+
+// Verdict thresholds:
+//   - error rate <= 1%
+//   - RSS climb <= 50 MB
+//   - if /proc/self/fd available, fd count delta <= 5 (no leak)
+const errRatio = sent === 0 ? 1 : errors / sent;
+let verdict = 'PASS';
+let verdictReason = 'thresholds met';
+if (errRatio > 0.01) {
+  verdict = 'FAIL';
+  verdictReason = `error ratio ${(errRatio * 100).toFixed(2)}% > 1%`;
+} else if (rssDelta > 50 * 1024 * 1024) {
+  verdict = 'FAIL';
+  verdictReason = `RSS climbed ${rssDelta} bytes > 50MB`;
+} else {
+  const linuxFds = fdSnapshots.filter((s) => s.fdCount !== null);
+  if (linuxFds.length >= 2) {
+    const fdDelta = linuxFds[linuxFds.length - 1].fdCount - linuxFds[0].fdCount;
+    if (fdDelta > 5) {
+      verdict = 'FAIL';
+      verdictReason = `fd count climbed by ${fdDelta} > 5 (leak)`;
+    }
+  }
+}
+
+process.stdout.write(JSON.stringify({
+  durationSec,
+  sent,
+  ok,
+  errors,
+  p50Us: pct(0.50),
+  p95Us: pct(0.95),
+  p99Us: pct(0.99),
+  rssStartBytes: rssStart,
+  rssEndBytes: rssEnd,
+  rssDeltaBytes: rssDelta,
+  fdSnapshots,
+  verdict,
+  verdictReason,
+}) + '\n');
+
+process.exit(verdict === 'PASS' ? 0 : 3);

--- a/tools/spike-harness/probes/uds-h2c/run.sh
+++ b/tools/spike-harness/probes/uds-h2c/run.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# run.sh — launch UDS h2c server, run client soak, tear down.
+#
+# Spike T9.4: smoke (60s default) or 1h soak via SPIKE_DURATION_SEC=3600.
+# Skips on win32 (UDS path semantics differ — use named-pipe spike instead).
+#
+# Forever-stable contract:
+#
+#   Usage:
+#     run.sh
+#
+#   Env:
+#     SPIKE_DURATION_SEC   default 60. Forwarded to client.mjs.
+#     SPIKE_SOCKET         default /tmp/ccsm-spike.sock
+#
+#   Output:
+#     - server stdout/stderr -> $SPIKE_LOG_DIR/server.log (default /tmp)
+#     - client RTT NDJSON   -> $SPIKE_LOG_DIR/rtt.ndjson
+#     - client summary JSON -> $SPIKE_LOG_DIR/summary.json + stdout
+#     - rtt-histogram JSON  -> $SPIKE_LOG_DIR/histogram.json + stdout
+#
+#   Exit codes: 0 PASS; 3 FAIL (forwarded from client); 2 unsupported OS;
+#               1 server start failure.
+
+set -euo pipefail
+
+OS_NAME="$(uname -s)"
+case "$OS_NAME" in
+  Linux|Darwin) ;;
+  MINGW*|MSYS*|CYGWIN*|Windows_NT)
+    echo "uds-h2c spike: skipped on $OS_NAME (win32 — use named-pipe spike)" >&2
+    exit 2
+    ;;
+  *)
+    echo "uds-h2c spike: unsupported OS $OS_NAME" >&2
+    exit 2
+    ;;
+esac
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+HARNESS_DIR="$(cd "$HERE/.." && pwd)"
+SOCKET="${SPIKE_SOCKET:-/tmp/ccsm-spike.sock}"
+LOG_DIR="${SPIKE_LOG_DIR:-/tmp}"
+DURATION="${SPIKE_DURATION_SEC:-60}"
+
+SERVER_LOG="$LOG_DIR/uds-h2c-server.log"
+RTT_NDJSON="$LOG_DIR/uds-h2c-rtt.ndjson"
+SUMMARY="$LOG_DIR/uds-h2c-summary.json"
+HISTOGRAM="$LOG_DIR/uds-h2c-histogram.json"
+
+# Teardown: kill server, unlink socket. Idempotent (also covered by server's
+# own SIGTERM handler).
+SERVER_PID=""
+cleanup() {
+  if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" 2>/dev/null; then
+    kill -TERM "$SERVER_PID" 2>/dev/null || true
+    # Wait up to 2s for graceful exit.
+    for _ in 1 2 3 4; do
+      if ! kill -0 "$SERVER_PID" 2>/dev/null; then break; fi
+      sleep 0.5
+    done
+    if kill -0 "$SERVER_PID" 2>/dev/null; then
+      kill -KILL "$SERVER_PID" 2>/dev/null || true
+    fi
+  fi
+  if [ -S "$SOCKET" ]; then
+    rm -f "$SOCKET" || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+# Stale-socket guard (server unlinks too, belt-and-braces).
+[ -S "$SOCKET" ] && rm -f "$SOCKET"
+
+echo "starting server (socket=$SOCKET)" >&2
+node "$HERE/server.mjs" --socket="$SOCKET" >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+# Wait up to 5s for "listening" line.
+for _ in $(seq 1 50); do
+  if grep -q "^listening " "$SERVER_LOG" 2>/dev/null; then
+    break
+  fi
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo "server died during startup; log:" >&2
+    cat "$SERVER_LOG" >&2
+    exit 1
+  fi
+  sleep 0.1
+done
+
+if ! grep -q "^listening " "$SERVER_LOG" 2>/dev/null; then
+  echo "server did not become ready in 5s; log:" >&2
+  cat "$SERVER_LOG" >&2
+  exit 1
+fi
+
+echo "running client (duration=${DURATION}s, rate=10/s)" >&2
+set +e
+SPIKE_DURATION_SEC="$DURATION" node "$HERE/client.mjs" --socket="$SOCKET" --rate=10 \
+  >"$SUMMARY" 2>"$RTT_NDJSON"
+CLIENT_EXIT=$?
+set -e
+
+echo "--- summary ---"
+cat "$SUMMARY"
+
+# Feed RTT lines through the existing histogram helper.
+if [ -s "$RTT_NDJSON" ]; then
+  node "$HARNESS_DIR/rtt-histogram.mjs" <"$RTT_NDJSON" >"$HISTOGRAM"
+  echo "--- histogram ---"
+  cat "$HISTOGRAM"
+fi
+
+exit "$CLIENT_EXIT"

--- a/tools/spike-harness/probes/uds-h2c/server.mjs
+++ b/tools/spike-harness/probes/uds-h2c/server.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+// server.mjs — Node 22 http2 (h2c) server bound to a Unix Domain Socket.
+//
+// Spike T9.4: confirm http2 over UDS is viable on darwin + linux for the
+// v0.3 daemon-split transport (per spec ch03 §4 transport options A1-A4,
+// option "h2c-UDS"). Cross-link: docs/superpowers/specs/2026-05-02-final-
+// architecture.md (Listener A = peer-cred-trusted local socket).
+//
+// Forever-stable contract (per spike-harness/README.md §"Forever-stable"):
+//
+//   Usage:
+//     server.mjs [--socket=<path>]   default /tmp/ccsm-spike.sock
+//
+//   Behavior:
+//     - createSecureServer is NOT used; this is plaintext h2c (cleartext)
+//       since the transport is a same-UID local socket.
+//     - Listens on the UDS path. Removes any stale socket file first.
+//     - Routes:
+//         GET /ping  -> 200, body "pong"
+//         anything else -> 404
+//     - On SIGTERM / SIGINT: graceful close, unlink socket, exit 0.
+//     - Prints "listening <path>\n" to stdout once ready.
+//
+//   Exit codes: 0 clean shutdown; 2 bad arg; 1 fatal listen error.
+//
+// Layer-1: node: stdlib only (http2, fs, net, util).
+
+import { createServer } from 'node:http2';
+import { existsSync, unlinkSync } from 'node:fs';
+import { parseArgs } from 'node:util';
+import { platform } from 'node:os';
+
+if (platform() === 'win32') {
+  process.stderr.write('uds-h2c server: win32 unsupported (use named pipe spike instead)\n');
+  process.exit(2);
+}
+
+const { values } = parseArgs({
+  options: { socket: { type: 'string', default: '/tmp/ccsm-spike.sock' } },
+  strict: true,
+});
+
+const socketPath = values.socket;
+
+if (existsSync(socketPath)) {
+  try { unlinkSync(socketPath); } catch (e) {
+    process.stderr.write(`failed to unlink stale socket: ${e.message}\n`);
+    process.exit(1);
+  }
+}
+
+const server = createServer();
+
+server.on('stream', (stream, headers) => {
+  const path = headers[':path'];
+  const method = headers[':method'];
+  if (method === 'GET' && path === '/ping') {
+    stream.respond({ ':status': 200, 'content-type': 'text/plain' });
+    stream.end('pong');
+    return;
+  }
+  stream.respond({ ':status': 404 });
+  stream.end();
+});
+
+server.on('error', (err) => {
+  process.stderr.write(`server error: ${err.message}\n`);
+});
+
+let shuttingDown = false;
+function shutdown(sig) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  process.stderr.write(`got ${sig}, shutting down\n`);
+  server.close(() => {
+    try { if (existsSync(socketPath)) unlinkSync(socketPath); } catch { /* ignore */ }
+    process.exit(0);
+  });
+  // Hard timeout so a stuck client can't pin the spike.
+  setTimeout(() => process.exit(0), 2000).unref();
+}
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT',  () => shutdown('SIGINT'));
+
+server.listen(socketPath, () => {
+  process.stdout.write(`listening ${socketPath}\n`);
+});


### PR DESCRIPTION
## Summary

Spike harness for **T9.4** (Task #106): confirm Node 22's `http2` module sustains traffic over a Unix Domain Socket on darwin + linux without socket reset, fd leak, or RSS climb. Smoke (60s @ 10 req/s) is local; the 1-hour soak runs on the self-hosted runner per spec ch10 + Task #16 (T0.10).

New files under `tools/spike-harness/probes/uds-h2c/`:
- `server.mjs` — http2 (cleartext h2c) server bound to `/tmp/ccsm-spike.sock`, `/ping → pong`, SIGTERM-safe socket unlink.
- `client.mjs` — http2-over-UDS client (`net.connect` factory passed to `http2.connect`), 10 req/s, p50/p95/p99 RTT, RSS delta, per-minute `/proc/self/fd` snapshots (linux only — null on darwin), self-emits `verdict: PASS|FAIL`.
- `run.sh` — server up → client soak → teardown (TERM-then-KILL, unlink); pipes RTT NDJSON through the existing `rtt-histogram.mjs`.
- `RESULT.md` — smoke verdict + decision criterion + ch03 §4 transport recommendation.

## Decision criterion

PASS iff over the full duration:
1. error rate ≤ **1%**
2. RSS climb ≤ **50 MB**
3. fd-count delta ≤ **5** (linux `/proc/self/fd`; macOS skips this and leans on RSS)

The client exits 3 on FAIL, so CI can gate without parsing summary JSON.

## Recommendation for ch03 §4

A green 1h soak is sufficient evidence to lock **option A (h2c-over-UDS)** as the v0.3 Listener-A transport on darwin/linux: no TLS overhead, no port allocation, peer-cred via `getsockopt` is already covered by `connect-and-peercred.sh`. Fallback if soak regresses: option C (loopback-TCP + JWT, harness in T9.3) at the cost of giving up peer-cred bypass.

## Smoke verification on this host (win32)

```
$ bash tools/spike-harness/probes/uds-h2c/run.sh
uds-h2c spike: skipped on MINGW64_NT-10.0-26200 (win32 — use named-pipe spike)
exit=2
```

Win32 is skipped at every layer (run.sh, server.mjs, client.mjs) — UDS path semantics differ on Windows; the parallel **T9.5** named-pipe spike covers that transport.

## Local quality gates

- `node --check` on both `.mjs` files: pass
- `bash -n run.sh`: pass
- `pnpm lint`: 0 errors (harness dir is in eslint `ignores` per `tools/spike-harness/README.md` Layer-1; stdlib-only scripts pass `node --check`)

## Test plan

- [ ] Self-hosted darwin runner: `SPIKE_DURATION_SEC=3600 bash tools/spike-harness/probes/uds-h2c/run.sh` — expect PASS, p99 < 1ms, RSS delta < 10MB.
- [ ] Self-hosted linux runner: same command — expect PASS, fd delta == 0, RSS delta < 10MB.
- [ ] Land artifact upload (summary.json + histogram.json) under T0.10 (#16).

Refs: Task #106, spec ch03 §4 (transport options A1-A4), `docs/superpowers/specs/2026-05-02-final-architecture.md` (Listener A = peer-cred-trusted local socket).