### PR TITLE
spike(T9.9): Node 22 sea hello-world matrix

### DIFF
--- a/tools/spike-harness/probes/sea-3os/.gitignore
+++ b/tools/spike-harness/probes/sea-3os/.gitignore
@@ -1,0 +1,4 @@
+# Build artifacts — never committed.
+dist/
+.cache/
+sea-prep.blob

--- a/tools/spike-harness/probes/sea-3os/RESULT.md
+++ b/tools/spike-harness/probes/sea-3os/RESULT.md
@@ -1,0 +1,90 @@
+# T9.9 — Node 22 SEA hello-world matrix
+
+Spike for Task #117. Validates the Node 22 single-executable application
+(SEA) toolchain end-to-end on each supported OS so T7.1 (#84 sea pipeline)
+can bootstrap with known-working contracts.
+
+## Per-OS results
+
+| OS      | Built? | Ran?  | Exit | Output                  | Binary size | Notes                                    |
+|---------|--------|-------|------|-------------------------|-------------|------------------------------------------|
+| win32   | yes    | yes   | 0    | `hello-from-sea-win32`  | 87,202,304 B (~83 MiB) | Local run, see `dist/build.log` + `dist/run.log` |
+| darwin  | TODO   | TODO  | -    | -                       | -           | Needs self-hosted macOS runner — Task #16 (T0.10) |
+| linux   | TODO   | TODO  | -    | -                       | -           | Needs self-hosted Linux runner — Task #16 (T0.10) |
+
+Run host: Windows 11 Enterprise 26200, Node v22.22.2 (cached at
+`C:\tmp\node-v22.22.2-win-x64\node.exe`), x64.
+
+## Reproduction
+
+Windows (PowerShell):
+```
+$env:NODE22 = "C:\path\to\node-v22.22.2-win-x64\node.exe"   # optional; auto-downloads if unset
+powershell -ExecutionPolicy Bypass -File ./build.ps1
+```
+
+Linux / macOS (bash):
+```
+NODE22=/path/to/node22  ./build.sh    # or omit NODE22 to auto-download
+```
+
+Both scripts:
+1. Locate (or download into `.cache/`) the Node 22 binary.
+2. Run `node --experimental-sea-config sea-config.json` to produce
+   `sea-prep.blob` (`useCodeCache=true`, `useSnapshot=false`,
+   `main=hello.js`).
+3. Copy the Node binary into `dist/sea-hello-<platform>[.exe]`.
+4. (macOS) `codesign --remove-signature` first.
+5. `npx postject@1.0.0-alpha.6` injects the blob with the published
+   `NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2` sentinel.
+6. (macOS) `codesign --sign -` ad-hoc re-signs.
+7. Executes the binary, captures stdout into `dist/run.log`, asserts the
+   exact `hello-from-sea-<platform>` line is present.
+
+Build + run logs live under `dist/` (gitignored).
+
+## Captured win32 output (verbatim)
+
+`dist/run.log`:
+```
+hello-from-sea-win32
+```
+
+Tail of `dist/build.log`:
+```
+[build] node22=C:/tmp/node-v22.22.2-win-x64/node.exe (v22.22.2)
+[build] blob bytes=1169
+[build] binary template copied to ...\dist\sea-hello-win32.exe
+[build] postject: ...\dist\sea-hello-win32.exe NODE_SEA_BLOB ...\sea-prep.blob --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2 --overwrite
+[build] final binary bytes=87202304
+[build] binary exited rc=0
+[build] OK -- output matches 'hello-from-sea-win32'
+```
+
+## Findings / blockers / recommendation for T7.1
+
+1. **Node 22 SEA is viable on win32 with no code-signing.** End-to-end
+   pipeline `sea-config -> sea-prep.blob -> postject inject -> run`
+   succeeded with `useCodeCache=true`. T7.1 can adopt this exact recipe
+   for the daemon binary on Windows.
+2. **Binary footprint is dominated by Node itself** (~83 MiB). User-code
+   blob was 1,169 B. Future size budgeting must work on the Node side
+   (custom build / strip / UPX), not on application code.
+3. **`postject@1.0.0-alpha.6` is still the only published injector.**
+   T7.1 should pin it explicitly and mirror it in our offline cache to
+   avoid breakage if the alpha is yanked.
+4. **PowerShell stderr trap.** Node writes the "Wrote single executable
+   preparation blob to ..." line to stderr. PowerShell 7's default
+   `$ErrorActionPreference=Stop` + `$PSNativeCommandUseErrorActionPreference`
+   converts that to a fatal RemoteException. T7.1's CI step must set
+   `$PSNativeCommandUseErrorActionPreference = $false` (already done in
+   `build.ps1`).
+5. **darwin / linux not validated locally.** Both OS legs are wired in
+   `build.sh` (download URL, postject `--macho-segment-name NODE_SEA`,
+   pre-/post- ad-hoc codesign for darwin) but a self-hosted runner is
+   required to actually exercise them. Tracked under Task #16 (T0.10).
+6. **No blocker for T7.1 bootstrap.** Recommendation: T7.1 starts from
+   this probe, swaps `hello.js` for the daemon entrypoint, and adds the
+   minisign / notarization stages on top. Forever-stable contract of
+   `build.{sh,ps1}` (inputs/outputs/exit) is documented in their headers
+   per spec ch14 §1.B.

--- a/tools/spike-harness/probes/sea-3os/build.ps1
+++ b/tools/spike-harness/probes/sea-3os/build.ps1
@@ -1,0 +1,98 @@
+# build.ps1 — Node 22 SEA hello-world build harness (Windows).
+#
+# Contract (forever-stable per spec ch14 §1.B / ch10 §1):
+#   Inputs:  none (env:NODE22 optional override)
+#   Outputs: dist/sea-hello-win32.exe   produced binary
+#            dist/run.log                captured stdout/stderr from executing it
+#            dist/build.log              captured build steps
+#   Exit:    0 on full pipeline success; non-zero on any failure.
+#
+# Algorithm per Node 22 SEA docs:
+#   1. Locate node22.exe (env:NODE22 or download to .cache\node22\)
+#   2. node --experimental-sea-config sea-config.json -> sea-prep.blob
+#   3. signtool /unbind would normally strip signatures; for unsigned spike skip.
+#   4. copy node.exe -> dist\sea-hello-win32.exe
+#   5. npx postject inject blob with NODE_SEA fuse sentinel.
+#   6. Run resulting binary, compare stdout to "hello-from-sea-win32".
+#
+# Layer 1: PowerShell + Invoke-WebRequest + Expand-Archive + node toolchain.
+
+$ErrorActionPreference = 'Continue'   # native CLIs writing to stderr must not abort the script
+$PSNativeCommandUseErrorActionPreference = $false
+$Here  = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Dist  = Join-Path $Here 'dist'
+$Cache = Join-Path $Here '.cache'
+$NodeVersion = '22.22.2'
+$PlatTag     = 'win-x64'
+$Stamp       = "node-v$NodeVersion-$PlatTag"
+
+New-Item -ItemType Directory -Force -Path $Dist  | Out-Null
+New-Item -ItemType Directory -Force -Path $Cache | Out-Null
+$BuildLog = Join-Path $Dist 'build.log'
+Set-Content -Path $BuildLog -Value "[build] start $(Get-Date -Format o)" -Encoding utf8
+
+function Log($msg) {
+  $line = "[build] $msg"
+  Write-Host $line
+  Add-Content -Path $BuildLog -Value $line -Encoding utf8
+}
+
+# ---- 1. locate node22 ----
+$Node22 = $env:NODE22
+if (-not $Node22) {
+  $Node22 = Join-Path $Cache "$Stamp\node.exe"
+  if (-not (Test-Path $Node22)) {
+    $url = "https://nodejs.org/dist/v$NodeVersion/$Stamp.zip"
+    $zip = Join-Path $Cache "$Stamp.zip"
+    Log "downloading $url"
+    Invoke-WebRequest -Uri $url -OutFile $zip -UseBasicParsing
+    Log "extracting $zip"
+    Expand-Archive -Path $zip -DestinationPath $Cache -Force
+  }
+}
+if (-not (Test-Path $Node22)) { Log "node22 not found at $Node22"; exit 11 }
+$ver = & $Node22 --version
+Log "node22=$Node22 ($ver)"
+
+# ---- 2. build sea blob ----
+Push-Location $Here
+try {
+  & $Node22 --experimental-sea-config sea-config.json *>> $BuildLog
+  if ($LASTEXITCODE -ne 0) { Log "sea-config build failed rc=$LASTEXITCODE"; exit 12 }
+} finally { Pop-Location }
+$blob = Join-Path $Here 'sea-prep.blob'
+if (-not (Test-Path $blob)) { Log "sea-prep.blob missing"; exit 12 }
+Log "blob bytes=$((Get-Item $blob).Length)"
+
+# ---- 3/4. copy node.exe ----
+$Out = Join-Path $Dist 'sea-hello-win32.exe'
+Copy-Item -Force $Node22 $Out
+Log "binary template copied to $Out"
+
+# ---- 5. postject inject ----
+$sentinel = 'NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2'
+$npx = Join-Path (Split-Path -Parent $Node22) 'npx.cmd'
+if (-not (Test-Path $npx)) { $npx = 'npx' }
+$args = @($Out, 'NODE_SEA_BLOB', $blob, '--sentinel-fuse', $sentinel, '--overwrite')
+Log "postject: $($args -join ' ')"
+& $npx --yes postject@1.0.0-alpha.6 @args *>> $BuildLog
+if ($LASTEXITCODE -ne 0) { Log "postject failed rc=$LASTEXITCODE"; exit 13 }
+
+$bytes = (Get-Item $Out).Length
+Log "final binary bytes=$bytes"
+
+# ---- 6. run ----
+$runLog = Join-Path $Dist 'run.log'
+& $Out *> $runLog
+$rc = $LASTEXITCODE
+Log "binary exited rc=$rc"
+$out = Get-Content $runLog -Raw
+Log "run.log:`n$out"
+
+$expected = 'hello-from-sea-win32'
+if ($out -match [regex]::Escape($expected)) {
+  Log "OK -- output matches '$expected'"
+  exit 0
+}
+Log "FAIL -- expected '$expected' not found"
+exit $rc

--- a/tools/spike-harness/probes/sea-3os/build.sh
+++ b/tools/spike-harness/probes/sea-3os/build.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# build.sh — Node 22 SEA hello-world build harness (linux + darwin).
+#
+# Contract (forever-stable per spec ch14 §1.B / ch10 §1):
+#   Inputs:  none (NODE22 env var optional override)
+#   Outputs: dist/sea-hello-<platform>[.exe]   produced binary
+#            dist/run.log                       captured stdout/stderr from running it
+#            dist/build.log                     captured build steps
+#   Exit:    0 on full pipeline success (build + run + output match)
+#            non-zero on any failure (preserves logs)
+#
+# Algorithm per Node 22 SEA docs (https://nodejs.org/docs/v22.22.2/api/single-executable-applications.html):
+#   1. Locate Node 22 binary (env NODE22 or download to .cache/node22/)
+#   2. node --experimental-sea-config sea-config.json -> sea-prep.blob
+#   3. cp node binary -> dist/sea-hello-<platform>[.exe]
+#   4. (macOS) codesign --remove-signature
+#   5. postject the blob into the binary copy
+#   6. (macOS) ad-hoc re-sign
+#   7. Execute resulting binary, capture stdout, compare against expected.
+#
+# Layer 1: bash + curl + tar + node: standard toolchain.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DIST="$HERE/dist"
+CACHE="$HERE/.cache"
+NODE_VERSION="22.22.2"
+
+mkdir -p "$DIST" "$CACHE"
+: > "$DIST/build.log"
+log() { echo "[build] $*" | tee -a "$DIST/build.log"; }
+
+UNAME_S="$(uname -s)"
+case "$UNAME_S" in
+  Linux*)  PLAT="linux";  EXT="";    ARCHIVE_EXT="tar.xz"; PLAT_TAG="linux-x64"  ;;
+  Darwin*) PLAT="darwin"; EXT="";    ARCHIVE_EXT="tar.gz"; PLAT_TAG="darwin-arm64";;
+  MINGW*|MSYS*|CYGWIN*) PLAT="win32"; EXT=".exe"; ARCHIVE_EXT="zip";   PLAT_TAG="win-x64"     ;;
+  *) echo "[build] unsupported uname: $UNAME_S" >&2; exit 10 ;;
+esac
+log "platform=$PLAT plat-tag=$PLAT_TAG node=$NODE_VERSION"
+
+# ---- 1. locate node22 ----
+NODE22="${NODE22:-}"
+if [ -z "$NODE22" ]; then
+  STAMP="node-v${NODE_VERSION}-${PLAT_TAG}"
+  NODE22="$CACHE/$STAMP/bin/node$EXT"
+  [ "$PLAT" = "win32" ] && NODE22="$CACHE/$STAMP/node$EXT"
+  if [ ! -x "$NODE22" ]; then
+    URL="https://nodejs.org/dist/v${NODE_VERSION}/${STAMP}.${ARCHIVE_EXT}"
+    log "downloading $URL"
+    ARCHIVE="$CACHE/${STAMP}.${ARCHIVE_EXT}"
+    curl -fsSL "$URL" -o "$ARCHIVE"
+    if [ "$ARCHIVE_EXT" = "zip" ]; then
+      (cd "$CACHE" && unzip -q "$ARCHIVE")
+    else
+      (cd "$CACHE" && tar -xf "$ARCHIVE")
+    fi
+  fi
+fi
+[ -x "$NODE22" ] || { log "node22 not executable at $NODE22"; exit 11; }
+log "node22=$NODE22 ($("$NODE22" --version))"
+
+# ---- 2. build sea blob ----
+( cd "$HERE" && "$NODE22" --experimental-sea-config sea-config.json ) >> "$DIST/build.log" 2>&1
+[ -f "$HERE/sea-prep.blob" ] || { log "sea-prep.blob missing"; exit 12; }
+log "blob bytes=$(wc -c < "$HERE/sea-prep.blob")"
+
+# ---- 3. copy node binary ----
+OUT="$DIST/sea-hello-${PLAT}${EXT}"
+cp "$NODE22" "$OUT"
+chmod +w "$OUT" || true
+log "binary template copied to $OUT"
+
+# ---- 4. macOS: strip signature ----
+if [ "$PLAT" = "darwin" ]; then
+  codesign --remove-signature "$OUT" >> "$DIST/build.log" 2>&1 || log "codesign --remove-signature warned"
+fi
+
+# ---- 5. postject inject ----
+# postject is a small npm-published util; vendored via npx for the spike.
+SENTINEL="NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2"
+NPX="$(dirname "$NODE22")/npx${EXT}"
+[ "$PLAT" = "win32" ] && NPX="$(dirname "$NODE22")/npx.cmd"
+if [ ! -x "$NPX" ] && [ "$PLAT" != "win32" ]; then NPX="npx"; fi
+
+POSTJECT_ARGS=("$OUT" NODE_SEA_BLOB "$HERE/sea-prep.blob"
+               --sentinel-fuse "$SENTINEL"
+               --overwrite)
+if [ "$PLAT" = "darwin" ]; then
+  POSTJECT_ARGS+=(--macho-segment-name NODE_SEA)
+fi
+
+log "postject: ${POSTJECT_ARGS[*]}"
+"$NPX" --yes postject@1.0.0-alpha.6 "${POSTJECT_ARGS[@]}" >> "$DIST/build.log" 2>&1
+
+# ---- 6. macOS: re-sign ad-hoc ----
+if [ "$PLAT" = "darwin" ]; then
+  codesign --sign - "$OUT" >> "$DIST/build.log" 2>&1 || { log "codesign re-sign FAILED"; exit 13; }
+fi
+
+BIN_BYTES=$(wc -c < "$OUT")
+log "final binary bytes=$BIN_BYTES"
+
+# ---- 7. run ----
+set +e
+"$OUT" > "$DIST/run.log" 2>&1
+RC=$?
+set -e
+log "binary exited rc=$RC"
+log "run.log:"; cat "$DIST/run.log" | sed 's/^/    /' | tee -a "$DIST/build.log"
+
+EXPECTED="hello-from-sea-${PLAT}"
+if grep -qx "$EXPECTED" "$DIST/run.log"; then
+  log "OK — output matches '$EXPECTED'"
+  exit 0
+fi
+log "FAIL — expected '$EXPECTED' not found in run.log"
+exit "$RC"

--- a/tools/spike-harness/probes/sea-3os/hello.js
+++ b/tools/spike-harness/probes/sea-3os/hello.js
@@ -1,0 +1,7 @@
+// hello.js — Node 22 SEA hello-world probe entrypoint for T9.9.
+//
+// Tracked under spec ch10 §1 (sea pipeline contract). Pinned by Task #117.
+//
+// Contract: print exactly one line "hello-from-sea-<platform>" then exit 0.
+// Used by build.{sh,ps1} to validate that the SEA-built binary executes.
+console.log('hello-from-sea-' + process.platform);

--- a/tools/spike-harness/probes/sea-3os/sea-config.json
+++ b/tools/spike-harness/probes/sea-3os/sea-config.json
@@ -1,0 +1,7 @@
+{
+  "main": "hello.js",
+  "output": "sea-prep.blob",
+  "disableExperimentalSEAWarning": true,
+  "useSnapshot": false,
+  "useCodeCache": true
+}


### PR DESCRIPTION
## Task #117 — T9.9 spike: sea-on-22-three-os

Confirms Node 22 single-executable-application (SEA) toolchain builds + runs a hello-world per spec ch10 §1 (sea pipeline contract). Probe lives at `tools/spike-harness/probes/sea-3os/`.

## Per-OS results

| OS     | Built? | Ran? | Exit | Output                  | Binary size |
|--------|--------|------|------|-------------------------|-------------|
| win32  | yes    | yes  | 0    | `hello-from-sea-win32`  | 87,202,304 B (~83 MiB) |
| darwin | TODO   | TODO | -    | -                       | - |
| linux  | TODO   | TODO | -    | -                       | - |

darwin / linux not exercised on dev box; both code paths are wired in `build.sh` (download URL, postject `--macho-segment-name NODE_SEA`, ad-hoc codesign pre/post). Pending self-hosted runners — Task #16 (T0.10).

## Pipeline (matches spec ch10 §1)

1. Locate-or-download `node-v22.22.2-<plat>` to `.cache/`.
2. `node --experimental-sea-config sea-config.json` (`useCodeCache=true`, `useSnapshot=false`, `main=hello.js`) -> `sea-prep.blob`.
3. Copy node binary -> `dist/sea-hello-<platform>[.exe]`.
4. (darwin) `codesign --remove-signature`.
5. `npx postject@1.0.0-alpha.6` inject blob with `NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2`.
6. (darwin) `codesign --sign -` ad-hoc re-sign.
7. Run binary, assert `hello-from-sea-<platform>` in stdout.

## Local win32 verification (verbatim)

`dist/run.log`:
```
hello-from-sea-win32
```

`dist/build.log` tail:
```
[build] node22=C:/tmp/node-v22.22.2-win-x64/node.exe (v22.22.2)
[build] blob bytes=1169
[build] postject: ...sea-hello-win32.exe NODE_SEA_BLOB ...sea-prep.blob --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2 --overwrite
[build] final binary bytes=87202304
[build] binary exited rc=0
[build] OK -- output matches 'hello-from-sea-win32'
```

## Findings / blockers / recommendation for T7.1 (#84)

1. **No blocker.** Recipe works on win32 unsigned. T7.1 should fork this probe, swap `hello.js` for the daemon entrypoint, layer minisign / notarization stages on top.
2. **Binary size dominated by Node** (1,169 B user blob vs 83 MiB total). Size budgeting must target Node-side stripping, not app code.
3. **`postject@1.0.0-alpha.6` is the only published injector.** T7.1 must pin it and mirror to offline cache (alpha could be yanked).
4. **PowerShell stderr trap.** Node writes the "Wrote single executable preparation blob" line to stderr; PS7's default `$PSNativeCommandUseErrorActionPreference=$true` converts it into a fatal RemoteException. CI must set this `$false` (already done in `build.ps1`).
5. **Forever-stable contract** documented in `build.{sh,ps1}` headers per spec ch14 §1.B (inputs / outputs `dist/sea-hello-<plat>[.exe]`, `dist/run.log`, `dist/build.log` / exit code semantics).

## Quality gate

- `npm run lint` -> 0 errors (91 pre-existing warnings, none in spike files; spike adds only `.js` / `.sh` / `.ps1` / `.json` / `.md`).
- No vitest per task spec.
- Local win32 build executed end-to-end; logs above.