### PR TITLE
feat(daemon): T7.1 Node 22 sea pipeline (esbuild + postject)

### DIFF
--- a/packages/daemon/build/__tests__/sea-config.spec.ts
+++ b/packages/daemon/build/__tests__/sea-config.spec.ts
@@ -1,0 +1,76 @@
+// packages/daemon/build/__tests__/sea-config.spec.ts
+//
+// Lightweight JSON-shape gate for the Node 22 sea pipeline. Spec ch10 §1
+// pins specific sea-config flags; if these drift the daemon either fails
+// to build (good — caught at build time) or builds a binary with the wrong
+// runtime characteristics (bad — useCodeCache / useSnapshot mistakes can
+// silently regress startup latency or break native-module init). This test
+// catches the latter at unit-test time.
+//
+// Per task brief: a full sea integration test is intentionally NOT run in
+// CI because the build is heavy (esbuild + node copy + postject). This
+// spec is the cheapest forever-stable contract we can keep green.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const CONFIG_PATH = path.resolve(__dirname, '../sea-config.json');
+
+interface SeaConfig {
+  main: string;
+  output: string;
+  disableExperimentalSEAWarning: boolean;
+  useCodeCache: boolean;
+  useSnapshot: boolean;
+}
+
+function loadConfig(): SeaConfig {
+  const raw = readFileSync(CONFIG_PATH, 'utf8');
+  return JSON.parse(raw) as SeaConfig;
+}
+
+describe('packages/daemon/build/sea-config.json (spec ch10 §1)', () => {
+  it('parses as JSON', () => {
+    expect(() => loadConfig()).not.toThrow();
+  });
+
+  it('main points to the esbuild bundle output (CJS, CWD-relative to package dir)', () => {
+    const cfg = loadConfig();
+    expect(cfg.main).toBe('dist/bundle.cjs');
+  });
+
+  it('output is the sea-prep.blob staging path (CWD-relative to package dir)', () => {
+    const cfg = loadConfig();
+    expect(cfg.output).toBe('dist/sea-prep.blob');
+  });
+
+  it('useCodeCache is true (spec: faster startup)', () => {
+    expect(loadConfig().useCodeCache).toBe(true);
+  });
+
+  it('useSnapshot is false (spec: snapshot complicates native-module init in v0.3)', () => {
+    expect(loadConfig().useSnapshot).toBe(false);
+  });
+
+  it('disableExperimentalSEAWarning is true (no stderr noise in service logs)', () => {
+    expect(loadConfig().disableExperimentalSEAWarning).toBe(true);
+  });
+
+  it('contains no unexpected top-level keys (forever-stable shape)', () => {
+    const cfg = loadConfig() as unknown as Record<string, unknown>;
+    const allowed = new Set([
+      'main',
+      'output',
+      'disableExperimentalSEAWarning',
+      'useCodeCache',
+      'useSnapshot',
+    ]);
+    for (const key of Object.keys(cfg)) {
+      expect(allowed.has(key), `unexpected sea-config key: ${key}`).toBe(true);
+    }
+  });
+});

--- a/packages/daemon/build/build-sea.ps1
+++ b/packages/daemon/build/build-sea.ps1
@@ -1,0 +1,76 @@
+# packages/daemon/build/build-sea.ps1
+# Spec ch10 §1 — build the daemon as a Node 22 Single Executable Application
+# on Windows (counterpart to build-sea.sh).
+#
+# Pipeline mirrors build-sea.sh: tsc -> esbuild bundle -> node sea-config ->
+# copy node.exe -> postject NODE_SEA_BLOB. Code-signing (T7.3 / task #82) is
+# OUT OF SCOPE; native (.node) modules are external (T7.2 / task #83).
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$Here    = Split-Path -Parent $MyInvocation.MyCommand.Path
+$PkgDir  = (Resolve-Path (Join-Path $Here '..')).Path
+$DistDir = Join-Path $PkgDir 'dist'
+$SeaCfg  = Join-Path $Here   'sea-config.json'
+
+function Step($msg) { Write-Host "[build-sea] $msg" }
+
+# Step 1: tsc compile.
+Step 'tsc compile'
+Push-Location $PkgDir
+try {
+  pnpm run build
+  if ($LASTEXITCODE -ne 0) { throw "pnpm run build exited $LASTEXITCODE" }
+
+  if (-not (Test-Path (Join-Path $DistDir 'index.js'))) {
+    throw 'dist/index.js missing after tsc'
+  }
+
+  # Step 2: esbuild bundle.
+  Step 'esbuild bundle'
+  npx --yes esbuild dist/index.js `
+    --bundle `
+    --platform=node `
+    --target=node22 `
+    --format=cjs `
+    --outfile=dist/bundle.cjs `
+    --external:better-sqlite3 `
+    --external:node-pty `
+    --external:*.node
+  if ($LASTEXITCODE -ne 0) { throw "esbuild exited $LASTEXITCODE" }
+
+  # Step 3: sea-config -> blob.
+  Step 'node --experimental-sea-config'
+  node --experimental-sea-config $SeaCfg
+  if ($LASTEXITCODE -ne 0) { throw "node --experimental-sea-config exited $LASTEXITCODE" }
+  if (-not (Test-Path (Join-Path $DistDir 'sea-prep.blob'))) {
+    throw 'dist/sea-prep.blob missing after sea-config'
+  }
+
+  # Step 4: copy node.exe.
+  $NodePath = (Get-Command node).Source
+  $Target   = Join-Path $DistDir 'ccsm-daemon.exe'
+  Step "copy node.exe -> $Target"
+  Copy-Item -Force $NodePath $Target
+
+  # Step 5: postject. Note: on signed node.exe Windows binaries, postject
+  # requires --overwrite to strip the existing signature. Spec ch10 §1
+  # leaves the strip + sign step to T7.3 (task #82); we just inject.
+  Step 'postject inject NODE_SEA_BLOB'
+  npx --yes postject `
+    $Target `
+    NODE_SEA_BLOB `
+    (Join-Path $DistDir 'sea-prep.blob') `
+    --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2 `
+    --overwrite
+  if ($LASTEXITCODE -ne 0) { throw "postject exited $LASTEXITCODE" }
+
+  Step "done -> $Target"
+  Step '(code-signing handled by T7.3 / task #82, not invoked here)'
+}
+finally {
+  Pop-Location
+}

--- a/packages/daemon/build/build-sea.sh
+++ b/packages/daemon/build/build-sea.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# packages/daemon/build/build-sea.sh
+# Spec ch10 §1 — build the daemon as a Node 22 Single Executable Application.
+#
+# Pipeline:
+#   1. tsc -> dist/*.js (handled by upstream `pnpm --filter @ccsm/daemon run build`)
+#   2. esbuild bundles dist/index.js + pure-JS deps into a single CJS file
+#      (dist/bundle.cjs). Native (.node) modules are intentionally NOT bundled
+#      — sea cannot embed them; T7.2 (task #83) wires the sibling-dir
+#      native-loader. For T7.1 we mark them as `external` and expect
+#      build-time absence to surface as a runtime ERR_MODULE_NOT_FOUND
+#      until #83 lands.
+#   3. node --experimental-sea-config sea-config.json -> dist/sea-prep.blob
+#   4. copy current node binary -> dist/ccsm-daemon
+#   5. npx postject ... NODE_SEA_BLOB ... -> single executable
+#
+# Code-signing (T7.3 / task #82) is OUT OF SCOPE here.
+#
+# macOS fallback: if a downstream signing/notarization step rejects the bare
+# sea binary (spike `[macos-notarization-sea]` per spec ch10 §1 / §3), the
+# fallback path produces an `.app-wrapped` node binary directory at
+# dist/Ccsm.app/Contents/MacOS/ccsm-daemon (a real `node` interpreter +
+# bundle.cjs + a minimal Info.plist) — NOT a sea binary. This script
+# generates the `.app`-wrapped layout when invoked with `--app-wrapped`.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PKG_DIR="$(cd "$HERE/.." && pwd)"
+DIST_DIR="$PKG_DIR/dist"
+SEA_CONFIG="$HERE/sea-config.json"
+
+APP_WRAPPED=0
+for arg in "$@"; do
+  case "$arg" in
+    --app-wrapped) APP_WRAPPED=1 ;;
+    *) echo "unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+OS="$(uname -s)"
+case "$OS" in
+  Linux)  PLATFORM=linux ;;
+  Darwin) PLATFORM=mac ;;
+  *) echo "build-sea.sh: unsupported OS '$OS' (use build-sea.ps1 on Windows)" >&2; exit 2 ;;
+esac
+
+# Step 1: tsc compile (idempotent — fast no-op if already built).
+echo "[build-sea] tsc compile"
+( cd "$PKG_DIR" && pnpm run build )
+
+if [[ ! -f "$DIST_DIR/index.js" ]]; then
+  echo "[build-sea] dist/index.js missing after tsc — aborting" >&2
+  exit 1
+fi
+
+# Step 2: esbuild bundle. `--platform=node` + `--format=cjs` so sea's main
+# can `require()` it. Native modules (.node) are external (per T7.2 plan).
+echo "[build-sea] esbuild bundle"
+( cd "$PKG_DIR" && npx --yes esbuild dist/index.js \
+  --bundle \
+  --platform=node \
+  --target=node22 \
+  --format=cjs \
+  --outfile=dist/bundle.cjs \
+  --external:better-sqlite3 \
+  --external:node-pty \
+  --external:*.node )
+
+# macOS .app-wrapped fallback short-circuits sea — we just stage `node` and
+# the bundle into a .app directory. Caller (T7.3 or release pipeline) is
+# responsible for codesigning the .app.
+if [[ "$PLATFORM" == "mac" && "$APP_WRAPPED" -eq 1 ]]; then
+  echo "[build-sea] mac fallback: producing .app-wrapped node bundle"
+  APP="$DIST_DIR/Ccsm.app"
+  rm -rf "$APP"
+  mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
+  cp "$(command -v node)" "$APP/Contents/MacOS/ccsm-daemon"
+  cp "$DIST_DIR/bundle.cjs" "$APP/Contents/Resources/bundle.cjs"
+  cat > "$APP/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleExecutable</key><string>ccsm-daemon</string>
+  <key>CFBundleIdentifier</key><string>com.ccsm.daemon</string>
+  <key>CFBundleName</key><string>ccsm-daemon</string>
+  <key>CFBundlePackageType</key><string>APPL</string>
+  <key>CFBundleShortVersionString</key><string>0.0.0</string>
+  <key>CFBundleVersion</key><string>0</string>
+  <key>LSMinimumSystemVersion</key><string>14.0</string>
+</dict>
+</plist>
+PLIST
+  echo "[build-sea] mac .app-wrapped layout written to $APP"
+  exit 0
+fi
+
+# Step 3: sea-config -> blob.
+echo "[build-sea] node --experimental-sea-config"
+( cd "$PKG_DIR" && node --experimental-sea-config "$SEA_CONFIG" )
+
+if [[ ! -f "$DIST_DIR/sea-prep.blob" ]]; then
+  echo "[build-sea] dist/sea-prep.blob missing after sea-config — aborting" >&2
+  exit 1
+fi
+
+# Step 4: copy current node binary as the carrier.
+TARGET="$DIST_DIR/ccsm-daemon"
+echo "[build-sea] copy node -> $TARGET"
+cp "$(command -v node)" "$TARGET"
+chmod +w "$TARGET"
+
+# Step 5: postject the blob.
+echo "[build-sea] postject inject NODE_SEA_BLOB"
+POSTJECT_ARGS=(
+  "$TARGET"
+  NODE_SEA_BLOB
+  "$DIST_DIR/sea-prep.blob"
+  --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2
+)
+if [[ "$PLATFORM" == "mac" ]]; then
+  POSTJECT_ARGS+=(--macho-segment-name NODE_SEA)
+fi
+( cd "$PKG_DIR" && npx --yes postject "${POSTJECT_ARGS[@]}" )
+
+echo "[build-sea] done -> $TARGET"
+echo "[build-sea] (code-signing handled by T7.3 / task #82, not invoked here)"

--- a/packages/daemon/build/sea-config.json
+++ b/packages/daemon/build/sea-config.json
@@ -1,0 +1,7 @@
+{
+  "main": "dist/bundle.cjs",
+  "output": "dist/sea-prep.blob",
+  "disableExperimentalSEAWarning": true,
+  "useCodeCache": true,
+  "useSnapshot": false
+}

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -5,9 +5,12 @@
   "type": "module",
   "description": "CCSM daemon (headless RPC server). Skeleton only; implementation lands in subsequent T0.x / T1.x tasks per design spec ch11.",
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"eslint-plugins/**/*.{js,ts}\"",
-    "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint \"src/**/*.ts\" \"eslint-plugins/**/*.{js,ts}\" \"build/**/*.ts\"",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit",
+    "test": "vitest run",
+    "build:sea:posix": "bash build/build-sea.sh",
+    "build:sea:win": "powershell -ExecutionPolicy Bypass -File build/build-sea.ps1"
   },
   "dependencies": {
     "better-sqlite3": "^12.9.0"

--- a/packages/daemon/tsconfig.test.json
+++ b/packages/daemon/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true
+  },
+  "include": ["src/**/*", "build/**/*.ts"]
+}

--- a/packages/daemon/vitest.config.ts
+++ b/packages/daemon/vitest.config.ts
@@ -10,7 +10,12 @@ export default defineConfig({
     // `eslint-plugins/**` holds the local ESLint plugin source + its
     // RuleTester suite (e.g. T1.9 ccsm/no-listener-slot-mutation). They
     // are not under `src/` because they are tooling, not daemon runtime.
-    include: ['src/**/*.spec.ts', 'eslint-plugins/**/*.spec.ts'],
+    // `build/**` holds the SEA build pipeline tooling + tests (T7.1).
+    include: [
+      'src/**/*.spec.ts',
+      'build/**/*.spec.ts',
+      'eslint-plugins/**/*.spec.ts',
+    ],
     globals: false,
   },
 });


### PR DESCRIPTION
## Scope (Task #84)

Per spec [ch10 §1](docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md): Node 22 Single Executable Application pipeline for the daemon.

- `packages/daemon/build/sea-config.json` — `useCodeCache=true`, `useSnapshot=false`, `disableExperimentalSEAWarning=true`, `main=dist/bundle.cjs`, `output=dist/sea-prep.blob`.
- `packages/daemon/build/build-sea.sh` (linux/mac) and `build-sea.ps1` (windows): `pnpm run build` (tsc) -> `npx esbuild` bundle (CJS, node22, externals: `better-sqlite3`, `node-pty`, `*.node`) -> `node --experimental-sea-config` -> copy `node` binary -> `npx postject` inject `NODE_SEA_BLOB` with sentinel fuse (and `--macho-segment-name NODE_SEA` on macOS).
- macOS notarization fallback (`--app-wrapped`, ch10 §1 / §3 spike `[macos-notarization-sea]`): produces `dist/Ccsm.app/Contents/MacOS/ccsm-daemon` (real `node` interpreter + `bundle.cjs` + minimal `Info.plist`) instead of the bare sea binary.
- `packages/daemon/build/__tests__/sea-config.spec.ts` — JSON-shape gate (forever-stable contract). Heavy sea integration intentionally NOT in CI per task brief.
- `packages/daemon/package.json` scripts: `build` / `typecheck` / `lint` / `test` / `build:sea:posix` / `build:sea:win`.
- `vitest.config.ts` `include` extended to `build/**/*.spec.ts`; `tsconfig.test.json` added so the build-dir spec is typechecked.

## Out of scope (other tasks)

- Native (`.node`) sibling-dir loader -> T7.2 (Task #83). Marked `--external` in esbuild; runtime `ERR_MODULE_NOT_FOUND` until #83 lands.
- Code signing (`signtool` / `codesign` / notarize) -> T7.3 (Task #82).

## Local verification (Win 11 25H2, Node 22)

- ``pnpm --filter @ccsm/daemon run lint`` -> clean
- ``pnpm --filter @ccsm/daemon run typecheck`` -> clean
- ``pnpm --filter @ccsm/daemon run test`` -> 17 passed (incl. `sea-config.spec.ts`)
- ``powershell build/build-sea.ps1`` -> `dist/ccsm-daemon.exe` (~87 MB) built end-to-end (esbuild 7.4 KB bundle -> `sea-prep.blob` -> postject inject OK). Binary executes (`./dist/ccsm-daemon.exe` exit=0). postject prints the expected `signature seems corrupted` warning because T7.3 has not signed the carrier `node.exe` yet.

Linux/macOS shell variant not yet manually verified (Windows-only dev env). Mac fallback `.app-wrapped` path is code-only at this point — will be exercised in T7.3 / release pipeline.