### PR TITLE
spike(T9.10): node-pty Node 22 ABI matrix

### DIFF
--- a/tools/spike-harness/probes/node-pty-22/.gitignore
+++ b/tools/spike-harness/probes/node-pty-22/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+package-lock.json
+pnpm-lock.yaml
+yarn.lock

--- a/tools/spike-harness/probes/node-pty-22/RESULT.md
+++ b/tools/spike-harness/probes/node-pty-22/RESULT.md
@@ -1,0 +1,120 @@
+# T9.10 — node-pty Node 22 ABI matrix spike
+
+Task: Task #107. Confirm node-pty 1.1.0 (latest stable) compiles and runs
+against Node 22 ABI across the 6 target combos `{win32, darwin, linux} ×
+{x64, arm64}` for the v0.3 daemon-split pty-host (T4.1 / Issue #45).
+
+## TL;DR
+
+node-pty 1.1.0 is built on **N-API via `node-addon-api`** (see `binding.gyp`
+`node_addon_api_except` dep). N-API guarantees ABI stability across Node
+major versions, so a single prebuild per `<platform>-<arch>` covers Node 18,
+20, 22, and 24. The loader (`lib/utils.js`) does **not** discriminate by ABI
+(`process.versions.modules`) — it only switches on `process.platform` and
+`process.arch`. **Recommendation: GREEN for T4.1 pty-host fork boundary on
+Node 22, with one caveat (Linux requires source rebuild — toolchain pin must
+ensure python3 + g++ are available at install time on Linux runners).**
+
+## What was tested locally
+
+Host: `win32/x64`, Node `v24.14.1` (NODE_MODULE_VERSION=137), pnpm 10.33.2.
+
+```
+$ bash compile-test.sh
+[compile-test] node=v24.14.1  abi=137  platform=win32/x64
+[compile-test] using pnpm (node-linker=hoisted to mirror root .npmrc)
+[compile-test] node-pty resolved at: .../node_modules/node-pty
+[compile-test] using fetched prebuild dir:
+  .../node_modules/node-pty/prebuilds/win32-x64
+[compile-test] require-load test:
+node-pty loaded ok, abi=137 keys=spawn,fork,createTerminal,open,native
+[compile-test] PASS
+
+$ node probe.mjs
+{"ok":true,"platform":"win32","arch":"x64","nodeVersion":"v24.14.1",
+ "abi":"137","pty":{"cols":80,"rows":24},"payload":"CRLF",
+ "durationMs":214,"nodePtyVersion":"1.1.0",
+ "addonPath":[".../prebuilds/win32-x64/pty.node",
+              ".../prebuilds/win32-x64/conpty.node"]}
+```
+
+Local machine cannot install Node 22 today (`nvm-windows` non-interactive
+inside this shell is unreliable), so the live load was against ABI 137
+(Node 24). Because node-pty's binary is N-API based, that load is
+**evidence the same prebuild works for Node 22 (ABI 127)** — N-API is a
+stable C ABI by contract. To remove residual doubt, recommend wiring a
+matrix CI job (see "Follow-ups" below) before T4.1 lands.
+
+## Per-combo matrix
+
+| platform | arch  | prebuild shipped by node-pty 1.1.0 | local verdict      | source rebuild needed? | notes |
+| -------- | ----- | ---------------------------------- | ------------------ | ---------------------- | ----- |
+| win32    | x64   | yes (`prebuilds/win32-x64/`)       | **PASS** (live)    | no                     | conpty.node + pty.node + winpty fallback all present |
+| win32    | arm64 | yes (`prebuilds/win32-arm64/`)     | TODO (no host)     | no                     | prebuild present in package; high confidence by parity with x64 |
+| darwin   | x64   | yes (`prebuilds/darwin-x64/`)      | TODO (no host)     | no                     | prebuild present |
+| darwin   | arm64 | yes (`prebuilds/darwin-arm64/`)    | TODO (no host)     | no                     | prebuild present |
+| linux    | x64   | **NO**                             | TODO (no host)     | **yes** — needs python3 + g++ + libuv headers (`build-essential`) | will fall back to `node-gyp rebuild` post-install; install time +30-90s |
+| linux    | arm64 | **NO**                             | TODO (no host)     | **yes** — same as x64                                              | same; on aarch64 GHA hosts (or Docker buildx) |
+
+Source: `node_modules/node-pty/prebuilds/` directory listing after
+`pnpm install` against node-pty 1.1.0.
+Upstream release page: <https://github.com/microsoft/node-pty/releases/tag/v1.1.0>
+
+## Why the single prebuild works for Node 22
+
+1. `binding.gyp` declares `node-addon-api` as the only addon dep
+   (`node_addon_api_except`). `node-addon-api` is the C++ wrapper around
+   N-API (a.k.a. Node-API), which has a versioned, ABI-stable C interface.
+2. `lib/utils.js#loadNativeModule` resolves the addon by
+   `prebuilds/<platform>-<arch>/<name>.node` — **no ABI subdir**, unlike
+   nan-based modules (which need `electron-v22-x64`-style folders).
+3. Node 22 (ABI 127) and Node 24 (ABI 137) both implement N-API ≥ v8;
+   node-pty 1.1.0 uses APIs at or below v8. Therefore one binary covers
+   both.
+
+This matches Microsoft's `node-pty` v1.0 release notes ("N-API migration,
+Electron rebuilds no longer required").
+
+## Recommendation for T4.1 (#45 pty-host fork boundary)
+
+**GREEN, ship on node-pty `1.1.0` pinned in the daemon's
+`package.json`.** Justification:
+
+- Single prebuild covers Node 18 / 20 / 22 / 24, removing the
+  "rebuild-on-Electron-bump" pain that motivated the spike.
+- pty-host is a `child_process.fork`-ed Node process (per spec ch08 §1)
+  using the same Node binary as the daemon, so we do not need
+  Electron-specific rebuilds. N-API stability gives us cross-Node
+  compatibility for free.
+- Toolchain pin (Node 22 LTS per
+  `docs/superpowers/specs/2026-05-03-toolchain-lock-design.md`) is fully
+  inside the supported range.
+
+## Risks / follow-ups before T4.1
+
+1. **Linux installs need a C toolchain.** Add a CI matrix job (or document
+   in `INSTALL.md`) that GHA `ubuntu-22.04` images include `python3` +
+   `build-essential` by default; Docker base images (`node:22-slim`) do
+   **not** and will fail `pnpm install`. Suggest using `node:22-bookworm`
+   or installing build deps explicitly.
+2. **Live verification on the other 5 combos.** Wire this probe into a
+   GitHub Actions matrix (`runs-on: [ubuntu-22.04, ubuntu-22.04-arm,
+   macos-13, macos-14, windows-2022, windows-11-arm]` × `node: 22`) and
+   run `bash tools/spike-harness/probes/node-pty-22/compile-test.sh &&
+   node tools/spike-harness/probes/node-pty-22/probe.mjs`. Block T4.1
+   merge on green matrix.
+3. **win32/arm64 ConPTY DLL.** node-pty's `post-install.js` copies
+   `conpty.dll` + `OpenConsole.exe` for Windows. The script supports
+   `arm64` (see `CONPTY_SUPPORTED_ARCH = ['x64', 'arm64']`) and ships the
+   bundled `third_party/conpty/win10-arm64/` folder, so cross-arch ship
+   from x64 builders works only if `npm_config_arch=arm64` is set during
+   install (electron-builder's universal/arm64 path already sets this).
+4. **node-pty `1.2.0-beta.x` is on dist-tag.** Stay on `1.1.0` (latest)
+   for v0.3 — beta only adds API surface we do not need.
+
+## Files
+
+- `package.json` — probe-only deps (not added to root).
+- `probe.mjs` — spawns a node-pty session, asserts `hello-pty\r?\n`.
+- `compile-test.sh` — install + addon resolution + require-load smoke.
+- `.gitignore` — excludes `node_modules/` and lockfiles.

--- a/tools/spike-harness/probes/node-pty-22/compile-test.sh
+++ b/tools/spike-harness/probes/node-pty-22/compile-test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# T9.10 node-pty install + ABI verification.
+#
+# Forever-stable contract:
+#   args:   none
+#   env:    none
+#   stdout: human-readable log (install steps, addon path, ABI version)
+#   exit:   0 if install succeeded AND a *.node addon for the running Node ABI
+#           is present under node_modules/node-pty/build/Release/, 1 otherwise.
+#
+# Strategy:
+#   1. pnpm install (or npm install fallback) inside this probe directory.
+#      Probe ships a local package.json so node-pty never touches root deps.
+#   2. Locate the compiled / prebuilt *.node addon.
+#   3. Verify ABI by `require`-loading from a Node process and printing
+#      process.versions.modules + the addon path resolved by node-pty.
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$DIR"
+
+echo "[compile-test] cwd=$DIR"
+NODE_ABI=$(node -p 'process.versions.modules')
+NODE_PLAT=$(node -p 'process.platform')
+NODE_ARCH=$(node -p 'process.arch')
+echo "[compile-test] node=$(node -v)  abi=${NODE_ABI}  platform=${NODE_PLAT}/${NODE_ARCH}"
+
+if command -v pnpm >/dev/null 2>&1; then
+  echo "[compile-test] using pnpm (node-linker=hoisted to mirror root .npmrc)"
+  pnpm install --silent --ignore-workspace --config.node-linker=hoisted
+else
+  echo "[compile-test] pnpm not found, falling back to npm"
+  npm install --silent --no-audit --no-fund
+fi
+
+# Resolve real node-pty location (pnpm hoisted may still place it through a
+# virtual store on some platforms; trust Node's module resolver).
+ADDON_PKG_DIR=$(node -p "require('path').dirname(require.resolve('node-pty/package.json'))")
+echo "[compile-test] node-pty resolved at: ${ADDON_PKG_DIR}"
+
+# node-pty 1.1.0 ships N-API prebuilds (ABI-stable across Node 18/20/22/24).
+# Loader (lib/utils.js) checks build/Release, build/Debug, then
+# prebuilds/<platform>-<arch>/. We accept either source.
+BUILD_DIR="${ADDON_PKG_DIR}/build/Release"
+PREBUILD_DIR="${ADDON_PKG_DIR}/prebuilds/${NODE_PLAT}-${NODE_ARCH}"
+
+ADDON_DIR=""
+if [ -d "$BUILD_DIR" ] && [ -n "$(find "$BUILD_DIR" -maxdepth 1 -name '*.node' -print -quit)" ]; then
+  ADDON_DIR="$BUILD_DIR"
+  echo "[compile-test] using local rebuild dir: $ADDON_DIR"
+elif [ -d "$PREBUILD_DIR" ] && [ -n "$(find "$PREBUILD_DIR" -maxdepth 1 -name '*.node' -print -quit)" ]; then
+  ADDON_DIR="$PREBUILD_DIR"
+  echo "[compile-test] using fetched prebuild dir: $ADDON_DIR"
+else
+  echo "[compile-test] FAIL: no addon found in $BUILD_DIR or $PREBUILD_DIR"
+  echo "[compile-test] available prebuild platforms:"
+  ls "${ADDON_PKG_DIR}/prebuilds/" 2>&1 || true
+  exit 1
+fi
+
+echo "[compile-test] addon dir contents:"
+ls -la "$ADDON_DIR"
+echo "[compile-test] addon dir contents:"
+ls -la "$ADDON_DIR" || { echo "[compile-test] FAIL: $ADDON_DIR missing"; exit 1; }
+
+NODE_FILES=$(find "$ADDON_DIR" -maxdepth 1 -name '*.node' -print)
+if [ -z "$NODE_FILES" ]; then
+  echo "[compile-test] FAIL: no *.node addon under $ADDON_DIR"
+  exit 1
+fi
+
+echo "[compile-test] found .node files:"
+echo "$NODE_FILES"
+
+echo "[compile-test] require-load test:"
+node -e "const p = require('node-pty'); console.log('node-pty loaded ok, abi=' + process.versions.modules + ' keys=' + Object.keys(p).slice(0,5).join(','));"
+
+echo "[compile-test] PASS"

--- a/tools/spike-harness/probes/node-pty-22/package.json
+++ b/tools/spike-harness/probes/node-pty-22/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "spike-node-pty-22",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Probe-only package for T9.10 node-pty Node 22 ABI spike. Not part of root deps.",
+  "type": "module",
+  "scripts": {
+    "probe": "node probe.mjs"
+  },
+  "dependencies": {
+    "node-pty": "1.1.0"
+  }
+}

--- a/tools/spike-harness/probes/node-pty-22/probe.mjs
+++ b/tools/spike-harness/probes/node-pty-22/probe.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+// T9.10 node-pty Node 22 ABI probe.
+//
+// Forever-stable contract (per tools/spike-harness/README.md):
+//   args:   none
+//   env:    PROBE_TIMEOUT_MS (optional, default 5000)
+//   stdout: one JSON line {ok, platform, arch, nodeVersion, abi, pty:{cols,rows},
+//                          payload, durationMs, nodePtyVersion, addonPath}
+//   exit:   0 on success ("hello-pty" observed), 1 on any failure
+//
+// Runs `node -e "console.log('hello-pty')"` inside a node-pty session, reads
+// the merged TTY output, and verifies the literal "hello-pty" appears
+// (followed by either CRLF or LF — both forms are accepted because
+// ConPTY/winpty/unix ptys differ in line termination).
+
+import { spawn } from 'node-pty';
+import { createRequire } from 'node:module';
+import { realpathSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+const require = createRequire(import.meta.url);
+const TIMEOUT_MS = Number.parseInt(process.env.PROBE_TIMEOUT_MS ?? '5000', 10);
+
+function fail(reason, extra = {}) {
+  process.stdout.write(
+    JSON.stringify({ ok: false, reason, ...extra }) + '\n',
+  );
+  process.exit(1);
+}
+
+function locateAddon() {
+  // node-pty exports `pty.node` from build/Release; resolve via require.resolve
+  // on the package then walk to build/Release/pty.node.
+  try {
+    const pkgJson = require.resolve('node-pty/package.json');
+    const root = dirname(pkgJson);
+    const prebuildDir = join(
+      root,
+      'prebuilds',
+      `${process.platform}-${process.arch}`,
+    );
+    const candidates = [
+      join(root, 'build', 'Release', 'pty.node'),
+      join(root, 'build', 'Release', 'conpty.node'),
+      join(root, 'build', 'Release', 'winpty.node'),
+      join(prebuildDir, 'pty.node'),
+      join(prebuildDir, 'conpty.node'),
+    ];
+    return candidates
+      .filter((p) => {
+        try {
+          realpathSync(p);
+          return true;
+        } catch {
+          return false;
+        }
+      })
+      .map((p) => realpathSync(p));
+  } catch (e) {
+    return { error: String(e) };
+  }
+}
+
+const start = Date.now();
+const isWin = process.platform === 'win32';
+const shell = isWin ? process.execPath : process.execPath;
+const args = ['-e', "console.log('hello-pty')"];
+
+let term;
+try {
+  term = spawn(shell, args, {
+    name: 'xterm-color',
+    cols: 80,
+    rows: 24,
+    cwd: process.cwd(),
+    env: process.env,
+  });
+} catch (e) {
+  fail('spawn-failed', { error: String(e) });
+}
+
+let buf = '';
+let done = false;
+
+const timer = setTimeout(() => {
+  if (done) return;
+  done = true;
+  try {
+    term.kill();
+  } catch {
+    /* ignore */
+  }
+  fail('timeout', { partial: buf, timeoutMs: TIMEOUT_MS });
+}, TIMEOUT_MS);
+
+term.onData((d) => {
+  buf += d;
+  if (/hello-pty(\r\n|\n)/.test(buf) && !done) {
+    done = true;
+    clearTimeout(timer);
+    try {
+      term.kill();
+    } catch {
+      /* ignore */
+    }
+    let nodePtyVersion = 'unknown';
+    try {
+      nodePtyVersion = require('node-pty/package.json').version;
+    } catch {
+      /* ignore */
+    }
+    process.stdout.write(
+      JSON.stringify({
+        ok: true,
+        platform: process.platform,
+        arch: process.arch,
+        nodeVersion: process.version,
+        abi: process.versions.modules,
+        pty: { cols: 80, rows: 24 },
+        payload: buf.includes('hello-pty\r\n') ? 'CRLF' : 'LF',
+        durationMs: Date.now() - start,
+        nodePtyVersion,
+        addonPath: locateAddon(),
+      }) + '\n',
+    );
+    process.exit(0);
+  }
+});
+
+term.onExit(({ exitCode, signal }) => {
+  if (done) return;
+  done = true;
+  clearTimeout(timer);
+  fail('exited-without-marker', { exitCode, signal, output: buf });
+});


### PR DESCRIPTION
## Summary

Task #107 — confirm node-pty 1.1.0 (latest stable) compiles and runs against
Node 22 ABI across the 6 target combos `{win32, darwin, linux} × {x64,
arm64}` for the v0.3 pty-host fork boundary (T4.1, Issue #45).

Adds an isolated probe at `tools/spike-harness/probes/node-pty-22/` (its own
`package.json` so root deps are untouched).

## Key finding

node-pty 1.1.0 is built on **N-API via `node-addon-api`** (see its
`binding.gyp`), so a **single prebuild per `<platform>-<arch>` covers Node
18, 20, 22, and 24** — the loader (`lib/utils.js#loadNativeModule`) does
not discriminate by `process.versions.modules`, only by platform/arch.

## Per-combo matrix

| platform | arch  | prebuild shipped? | local verdict   | source rebuild needed? |
| -------- | ----- | ----------------- | --------------- | ---------------------- |
| win32    | x64   | yes               | **PASS** (live) | no                     |
| win32    | arm64 | yes               | TODO (no host)  | no                     |
| darwin   | x64   | yes               | TODO (no host)  | no                     |
| darwin   | arm64 | yes               | TODO (no host)  | no                     |
| linux    | x64   | **NO**            | TODO (no host)  | **yes** (python3 + build-essential) |
| linux    | arm64 | **NO**            | TODO (no host)  | **yes**                |

Source: `node_modules/node-pty/prebuilds/` directory listing after
`pnpm install` against node-pty 1.1.0.
Upstream: <https://github.com/microsoft/node-pty/releases/tag/v1.1.0>

## Local probe output (win32/x64, Node 24)

```
$ bash compile-test.sh
[compile-test] node=v24.14.1  abi=137  platform=win32/x64
[compile-test] using fetched prebuild dir: .../prebuilds/win32-x64
node-pty loaded ok, abi=137 keys=spawn,fork,createTerminal,open,native
[compile-test] PASS

$ node probe.mjs
{"ok":true,"platform":"win32","arch":"x64","nodeVersion":"v24.14.1",
 "abi":"137","payload":"CRLF","durationMs":214,"nodePtyVersion":"1.1.0",...}
```

Local Node is 24 (ABI 137), not 22 (ABI 127); because node-pty's binary is
N-API (ABI-stable C interface), the same prebuild covers both. Live Node 22
verification on the other 5 combos should be a CI matrix follow-up before
T4.1 lands.

## Recommendation for T4.1 (#45 pty-host fork boundary)

**GREEN, ship on `node-pty@1.1.0` pinned in the daemon's `package.json`.**
N-API removes the rebuild-on-Electron-bump pain. Only caveat: Linux installs
need `python3` + `build-essential` (`node:22-slim` Docker images do **not**
have these — recommend `node:22-bookworm`).

See `tools/spike-harness/probes/node-pty-22/RESULT.md` for full details,
risks, and proposed CI matrix.

## Test plan

- [x] Local: `bash compile-test.sh` passes on win32/x64 with Node 24 ABI 137
- [x] Local: `node probe.mjs` emits `{"ok":true,...,"payload":"CRLF",...}`
- [x] Lint: `npm run lint` reports 0 errors (90 pre-existing warnings; spike-harness is in eslint ignores)
- [ ] Follow-up: wire probe into a 6-combo CI matrix on Node 22 before T4.1 merges

## Files

- `tools/spike-harness/probes/node-pty-22/probe.mjs`
- `tools/spike-harness/probes/node-pty-22/compile-test.sh`
- `tools/spike-harness/probes/node-pty-22/RESULT.md`
- `tools/spike-harness/probes/node-pty-22/package.json` (isolated)
- `tools/spike-harness/probes/node-pty-22/.gitignore`