### PR TITLE
feat(proto): T2.1 TS Connect-es client+server stubs (re-export all 7 services)

### DIFF
--- a/packages/proto/package.json
+++ b/packages/proto/package.json
@@ -3,12 +3,19 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "description": "CCSM proto definitions and generated Connect-RPC code. Skeleton only; implementation lands in subsequent T0.x / T1.x tasks per design spec ch11.",
+  "description": "CCSM proto definitions and generated Connect-RPC code. T2.1 re-exports the seven v0.3 services + common types via src/index.ts so consumers can `import { SessionService } from '@ccsm/proto'`.",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
   "scripts": {
     "clean": "node -e \"require('fs').rmSync('gen/ts',{recursive:true,force:true})\"",
     "gen": "buf generate",
     "lock": "node scripts/lock.mjs",
     "lock-check": "node scripts/lock-check.mjs",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run --config vitest.config.ts"
   },
   "dependencies": {
@@ -16,6 +23,8 @@
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.50.0",
-    "@bufbuild/protoc-gen-es": "^2.2.3"
+    "@bufbuild/protoc-gen-es": "^2.2.3",
+    "@connectrpc/connect": "^2.1.1",
+    "@connectrpc/connect-node": "^2.1.1"
   }
 }

--- a/packages/proto/src/index.ts
+++ b/packages/proto/src/index.ts
@@ -1,0 +1,33 @@
+// @ccsm/proto — public surface for v0.3 Connect-RPC bindings.
+//
+// This re-exports the generated TypeScript bindings under
+// `gen/ts/ccsm/v1/*_pb.ts` so consumers can write:
+//
+//   import { SessionService } from '@ccsm/proto';
+//
+// Connect-ES v2 derives both the client (`createClient(SessionService, transport)`)
+// and the server (`router.service(SessionService, impl)`) from the same
+// `GenService` descriptor — there is no separate `protoc-gen-connect-es`
+// generator. See specs/2026-05-03-v03-daemon-split-design.md ch04 §1.
+//
+// `gen/ts/` is gitignored (regenerated via `pnpm --filter @ccsm/proto run gen`,
+// CI-gated by T0.8). All seven v0.3 services are re-exported here. The
+// `common.proto` file declares no service — only shared types/enums.
+//
+// Wildcard re-exports keep this surface minimal and self-updating: any
+// new message / enum / service added to a `.proto` file becomes available
+// at `@ccsm/proto` after `pnpm gen`, with no edits required here.
+
+// Common shared types (no service): Principal, LocalUser, RequestMeta,
+// ErrorDetail, SessionState enum, ...
+export * from '../gen/ts/ccsm/v1/common_pb.js';
+
+// Service modules — each exports a `*Service: GenService<...>` descriptor
+// alongside its request/response message types.
+export * from '../gen/ts/ccsm/v1/session_pb.js';
+export * from '../gen/ts/ccsm/v1/pty_pb.js';
+export * from '../gen/ts/ccsm/v1/crash_pb.js';
+export * from '../gen/ts/ccsm/v1/settings_pb.js';
+export * from '../gen/ts/ccsm/v1/notify_pb.js';
+export * from '../gen/ts/ccsm/v1/draft_pb.js';
+export * from '../gen/ts/ccsm/v1/supervisor_pb.js';

--- a/packages/proto/tsconfig.json
+++ b/packages/proto/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": true,
+    "rootDir": ".",
+    "allowImportingTsExtensions": false,
     "types": ["node"]
   },
   "include": ["src/**/*", "test/**/*", "gen/ts/**/*", "vitest.config.ts"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,6 +247,12 @@ importers:
       '@bufbuild/protoc-gen-es':
         specifier: ^2.2.3
         version: 2.12.0(@bufbuild/protobuf@2.12.0)
+      '@connectrpc/connect':
+        specifier: ^2.1.1
+        version: 2.1.1(@bufbuild/protobuf@2.12.0)
+      '@connectrpc/connect-node':
+        specifier: ^2.1.1
+        version: 2.1.1(@bufbuild/protobuf@2.12.0)(@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.12.0))
 
 packages:
 
@@ -429,6 +435,18 @@ packages:
 
   '@bufbuild/protoplugin@2.12.0':
     resolution: {integrity: sha512-ORlDITp8AFUXzIhLRoMCG+ud+D3MPKWb5HQXBoskMMnjeyEjE1H1qLonVNPyOr8lkx3xSfYUo8a0dvOZJVAzow==}
+
+  '@connectrpc/connect-node@2.1.1':
+    resolution: {integrity: sha512-s3TfsI1XF+n+1z6MBS9rTnFsxxR4Rw5wmdEnkQINli81ESGxcsfaEet8duzq8LVuuCupmhUsgpRo0Nv9pZkufg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.7.0
+      '@connectrpc/connect': 2.1.1
+
+  '@connectrpc/connect@2.1.1':
+    resolution: {integrity: sha512-JzhkaTvM73m2K1URT6tv53k2RwngSmCXLZJgK580qNQOXRzZRR/BCMfZw3h+90JpnG6XksP5bYT+cz0rpUzUWQ==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.7.0
 
   '@csstools/color-helpers@6.0.2':
     resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
@@ -5719,6 +5737,15 @@ snapshots:
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
+
+  '@connectrpc/connect-node@2.1.1(@bufbuild/protobuf@2.12.0)(@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.12.0))':
+    dependencies:
+      '@bufbuild/protobuf': 2.12.0
+      '@connectrpc/connect': 2.1.1(@bufbuild/protobuf@2.12.0)
+
+  '@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.12.0)':
+    dependencies:
+      '@bufbuild/protobuf': 2.12.0
 
   '@csstools/color-helpers@6.0.2': {}
 


### PR DESCRIPTION
## Scope

Task #31 [T2.1] — expose the seven v0.3 Connect-RPC services through `@ccsm/proto` so downstream daemon (#32 T2.2) and electron client (#33 T2.3) can simply `import { SessionService } from '@ccsm/proto'`.

Connect-ES v2 (locked in by T0.5, PR #859 a1f943f) derives both the client (`createClient(SessionService, transport)`) and the server (`router.service(SessionService, impl)`) from the same `GenService` descriptor emitted by `@bufbuild/protoc-gen-es` v2 — there is no separate `protoc-gen-connect-es` plugin in this stack. This PR is the thin re-export layer that publishes those descriptors.

## Surface (`packages/proto/src/index.ts`)

Wildcard re-exports, one line per generated file:

- `common_pb.js`     — `Principal`, `LocalUser`, `RequestMeta`, `ErrorDetail`, `SessionState` enum (no service)
- `session_pb.js`    — `SessionService` + Hello/List/Get/Create/Destroy/Watch/Rename/GetTitle types
- `pty_pb.js`        — `PtyService`
- `crash_pb.js`      — `CrashService`
- `settings_pb.js`   — `SettingsService`
- `notify_pb.js`     — `NotifyService`
- `draft_pb.js`      — `DraftService`
- `supervisor_pb.js` — `SupervisorService`

Confirmed zero export-name collisions across the 8 files.

## Other changes

- `packages/proto/package.json`:
  - `type: module`, `exports: { ".": { types: "./src/index.ts", default: "./src/index.ts" } }` so workspace consumers resolve the re-export directly without a build step.
  - `@bufbuild/protobuf` ^2.2.3 promoted to runtime `dependencies` (every generated `*_pb.ts` imports `@bufbuild/protobuf` and `@bufbuild/protobuf/codegenv2`).
  - `@connectrpc/connect` ^2.1.1 + `@connectrpc/connect-node` ^2.1.1 added as `devDependencies` (footprint check per task brief — consumers in T2.2 / T2.3 declare their own runtime dep).
  - Added `typecheck` script.
- `packages/proto/tsconfig.json`: `include` now covers `gen/ts/**/*` so the generated surface is type-checked together with the index re-export. `rootDir: .` so `src` and `gen` share one project root.

## Verification

```
$ pnpm --filter @ccsm/proto run gen
> buf generate          # emits 8 *_pb.ts files
$ git diff --exit-code -- packages/proto/gen
                         # clean — codegen reproducible

$ pnpm --filter @ccsm/proto run typecheck
> tsc --noEmit           # clean

$ pnpm run typecheck     # root
> tsc --noEmit && tsc --noEmit -p tsconfig.electron.json
                         # clean
```

Scratch consumer (deleted post-verification) imported all 7 `*Service` descriptors + `SessionState` enum + `Principal` type from `@ccsm/proto` and compiled clean under `--module nodenext --strict`.

## Out of scope

- ConnectRouter wiring → Task #32 (T2.2, daemon side).
- Hello RPC behavior → Task #33 (T2.3).
- Contract tests → Task #27 (T0.12).

## Test plan

- [x] `pnpm --filter @ccsm/proto run gen` reproducible (no diff)
- [x] `pnpm --filter @ccsm/proto run typecheck` clean
- [x] Root `pnpm run typecheck` clean
- [x] Scratch consumer typecheck of all 7 services + common types — clean