### PR TITLE
feat(proto): T0.6 lock.json + lock/lock-check scripts (SHA256 per .proto)

### DIFF
--- a/packages/proto/lock.json
+++ b/packages/proto/lock.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "files": {
+    "src/ccsm/v1/common.proto": "7e06b7b67fe1f4a75852392238e565bb6ba8081964cba3656cedaaaad2ee5102",
+    "src/ccsm/v1/crash.proto": "d7133746b30daaa20041d0309a196e08ba87f4ab68ee5ffc0a3175a0dc041ce9",
+    "src/ccsm/v1/draft.proto": "895e426a34ea4d9f1743049149c64214a5d4af866f4381f98b998a49acac7946",
+    "src/ccsm/v1/notify.proto": "2332a47efa90c6b3e982964c7bda4489aff16b599ea6da59a85e4f4f408d878d",
+    "src/ccsm/v1/pty.proto": "430658cf93fecac7e53e49b63735aa9962b0fe7ff03a4c2398a681167e828d60",
+    "src/ccsm/v1/session.proto": "ab3e9a70f20fdfadb7c64ef7aa37b89d324d14aaa150a7d7938e30de9ca68467",
+    "src/ccsm/v1/settings.proto": "2894f3dc91a912f269994686dc58596229fed359e63f4389d10c9840a328e173",
+    "src/ccsm/v1/supervisor.proto": "d6018cc763f8097ce2df097865ee59b7fdecee84f9fe8b784a563b4709b9f1d5"
+  }
+}

--- a/packages/proto/package.json
+++ b/packages/proto/package.json
@@ -7,6 +7,8 @@
   "scripts": {
     "clean": "node -e \"require('fs').rmSync('gen/ts',{recursive:true,force:true})\"",
     "gen": "buf generate",
+    "lock": "node scripts/lock.mjs",
+    "lock-check": "node scripts/lock-check.mjs",
     "test": "vitest run --config vitest.config.ts"
   },
   "dependencies": {

--- a/packages/proto/scripts/lock-check.mjs
+++ b/packages/proto/scripts/lock-check.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+// packages/proto/scripts/lock-check.mjs
+//
+// Verify packages/proto/lock.json matches the on-disk SHA256 of every
+// packages/proto/src/**/*.proto. Exits 0 on match, 1 on any drift, with a
+// human-readable diff covering three categories:
+//   - mismatch    (file exists on disk and in lock.json, hashes differ)
+//   - missing in lock  (.proto on disk, no entry in lock.json)
+//   - extra in lock    (entry in lock.json, .proto missing on disk)
+//
+// Pair with scripts/lock.mjs (`pnpm --filter @ccsm/proto run lock`) to
+// regenerate after intentional schema changes.
+
+import { createHash } from 'node:crypto';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const PROTO_ROOT = resolve(__dirname, '..');
+const SRC_DIR = join(PROTO_ROOT, 'src');
+const LOCK_PATH = join(PROTO_ROOT, 'lock.json');
+
+function walkProtos(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const abs = join(dir, entry);
+    const st = statSync(abs);
+    if (st.isDirectory()) out.push(...walkProtos(abs));
+    else if (st.isFile() && entry.endsWith('.proto')) out.push(abs);
+  }
+  return out;
+}
+
+function toPosix(p) {
+  return p.split(sep).join('/');
+}
+
+function sha256OfFile(path) {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+function main() {
+  let lock;
+  try {
+    lock = JSON.parse(readFileSync(LOCK_PATH, 'utf8'));
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(`lock-check: failed to read ${LOCK_PATH}: ${err.message}`);
+    process.exit(1);
+  }
+  if (!lock || typeof lock !== 'object' || lock.version !== 1 || !lock.files) {
+    // eslint-disable-next-line no-console
+    console.error(`lock-check: ${LOCK_PATH} is not a valid v1 lock (expected { version: 1, files: {...} })`);
+    process.exit(1);
+  }
+
+  const onDisk = new Map();
+  for (const abs of walkProtos(SRC_DIR)) {
+    const rel = toPosix(relative(PROTO_ROOT, abs));
+    onDisk.set(rel, sha256OfFile(abs));
+  }
+  const recorded = new Map(Object.entries(lock.files));
+
+  const mismatches = [];
+  const missingInLock = [];
+  const extraInLock = [];
+
+  for (const [rel, sha] of onDisk) {
+    if (!recorded.has(rel)) missingInLock.push(rel);
+    else if (recorded.get(rel) !== sha) mismatches.push({ rel, expected: recorded.get(rel), actual: sha });
+  }
+  for (const rel of recorded.keys()) {
+    if (!onDisk.has(rel)) extraInLock.push(rel);
+  }
+
+  if (mismatches.length === 0 && missingInLock.length === 0 && extraInLock.length === 0) {
+    // eslint-disable-next-line no-console
+    console.log(`lock-check: OK (${onDisk.size} .proto files match lock.json)`);
+    process.exit(0);
+  }
+
+  // eslint-disable-next-line no-console
+  console.error('lock-check: FAIL — packages/proto/lock.json drift detected');
+  for (const { rel, expected, actual } of mismatches) {
+    // eslint-disable-next-line no-console
+    console.error(`  mismatch: ${rel}\n    expected ${expected}\n    actual   ${actual}`);
+  }
+  for (const rel of missingInLock) {
+    // eslint-disable-next-line no-console
+    console.error(`  missing in lock: ${rel}`);
+  }
+  for (const rel of extraInLock) {
+    // eslint-disable-next-line no-console
+    console.error(`  extra in lock:   ${rel}`);
+  }
+  // eslint-disable-next-line no-console
+  console.error('\nRun `pnpm --filter @ccsm/proto run lock` to regenerate after intentional changes.');
+  process.exit(1);
+}
+
+main();

--- a/packages/proto/scripts/lock-check.mjs
+++ b/packages/proto/scripts/lock-check.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* global console, process */
 // packages/proto/scripts/lock-check.mjs
 //
 // Verify packages/proto/lock.json matches the on-disk SHA256 of every
@@ -46,12 +47,10 @@ function main() {
   try {
     lock = JSON.parse(readFileSync(LOCK_PATH, 'utf8'));
   } catch (err) {
-    // eslint-disable-next-line no-console
     console.error(`lock-check: failed to read ${LOCK_PATH}: ${err.message}`);
     process.exit(1);
   }
   if (!lock || typeof lock !== 'object' || lock.version !== 1 || !lock.files) {
-    // eslint-disable-next-line no-console
     console.error(`lock-check: ${LOCK_PATH} is not a valid v1 lock (expected { version: 1, files: {...} })`);
     process.exit(1);
   }
@@ -76,26 +75,20 @@ function main() {
   }
 
   if (mismatches.length === 0 && missingInLock.length === 0 && extraInLock.length === 0) {
-    // eslint-disable-next-line no-console
     console.log(`lock-check: OK (${onDisk.size} .proto files match lock.json)`);
     process.exit(0);
   }
 
-  // eslint-disable-next-line no-console
   console.error('lock-check: FAIL — packages/proto/lock.json drift detected');
   for (const { rel, expected, actual } of mismatches) {
-    // eslint-disable-next-line no-console
     console.error(`  mismatch: ${rel}\n    expected ${expected}\n    actual   ${actual}`);
   }
   for (const rel of missingInLock) {
-    // eslint-disable-next-line no-console
     console.error(`  missing in lock: ${rel}`);
   }
   for (const rel of extraInLock) {
-    // eslint-disable-next-line no-console
     console.error(`  extra in lock:   ${rel}`);
   }
-  // eslint-disable-next-line no-console
   console.error('\nRun `pnpm --filter @ccsm/proto run lock` to regenerate after intentional changes.');
   process.exit(1);
 }

--- a/packages/proto/scripts/lock.mjs
+++ b/packages/proto/scripts/lock.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+// packages/proto/scripts/lock.mjs
+//
+// Regenerate packages/proto/lock.json from packages/proto/src/**/*.proto.
+//
+// Walks the src tree, computes SHA256 of each .proto file (raw bytes — no
+// normalization, hash is over the exact on-disk content), and writes the
+// result to lock.json sorted by relative POSIX path. Pair with lock-check.mjs
+// (CI / pre-commit) to detect unintended schema drift.
+//
+// Usage: pnpm --filter @ccsm/proto run lock
+
+import { createHash } from 'node:crypto';
+import { readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const PROTO_ROOT = resolve(__dirname, '..');
+const SRC_DIR = join(PROTO_ROOT, 'src');
+const LOCK_PATH = join(PROTO_ROOT, 'lock.json');
+
+function walkProtos(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const abs = join(dir, entry);
+    const st = statSync(abs);
+    if (st.isDirectory()) out.push(...walkProtos(abs));
+    else if (st.isFile() && entry.endsWith('.proto')) out.push(abs);
+  }
+  return out;
+}
+
+function toPosix(p) {
+  return p.split(sep).join('/');
+}
+
+function sha256OfFile(path) {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+function main() {
+  const files = walkProtos(SRC_DIR);
+  const entries = {};
+  for (const abs of files) {
+    const rel = toPosix(relative(PROTO_ROOT, abs));
+    entries[rel] = sha256OfFile(abs);
+  }
+  // Sort keys for deterministic output.
+  const sorted = Object.fromEntries(
+    Object.keys(entries)
+      .sort()
+      .map((k) => [k, entries[k]])
+  );
+  const lock = { version: 1, files: sorted };
+  writeFileSync(LOCK_PATH, JSON.stringify(lock, null, 2) + '\n', 'utf8');
+  // eslint-disable-next-line no-console
+  console.log(`wrote ${LOCK_PATH} (${Object.keys(sorted).length} files)`);
+}
+
+main();

--- a/packages/proto/scripts/lock.mjs
+++ b/packages/proto/scripts/lock.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* global console */
 // packages/proto/scripts/lock.mjs
 //
 // Regenerate packages/proto/lock.json from packages/proto/src/**/*.proto.
@@ -55,7 +56,6 @@ function main() {
   );
   const lock = { version: 1, files: sorted };
   writeFileSync(LOCK_PATH, JSON.stringify(lock, null, 2) + '\n', 'utf8');
-  // eslint-disable-next-line no-console
   console.log(`wrote ${LOCK_PATH} (${Object.keys(sorted).length} files)`);
 }
 

--- a/packages/proto/test/lock-script.spec.ts
+++ b/packages/proto/test/lock-script.spec.ts
@@ -1,0 +1,146 @@
+// packages/proto/test/lock-script.spec.ts
+//
+// Integrity tests for scripts/lock.mjs and scripts/lock-check.mjs.
+//
+// Strategy: build a throw-away "mini proto package" in a temp directory that
+// mirrors the real layout (`src/**/*.proto` + `lock.json` + `scripts/*.mjs`).
+// We copy the real scripts in and exercise them via `node`. This avoids
+// mocking node:fs and gives us the same end-to-end behaviour CI sees.
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const PROTO_ROOT = resolve(__dirname, '..');
+const REAL_LOCK_SCRIPT = join(PROTO_ROOT, 'scripts', 'lock.mjs');
+const REAL_LOCK_CHECK_SCRIPT = join(PROTO_ROOT, 'scripts', 'lock-check.mjs');
+
+interface ScratchPkg {
+  root: string;
+  lockPath: string;
+  protoA: string;
+  protoB: string;
+}
+
+function makeScratchPkg(): ScratchPkg {
+  const root = mkdtempSync(join(tmpdir(), 'ccsm-proto-lock-'));
+  mkdirSync(join(root, 'src', 'ccsm', 'v1'), { recursive: true });
+  mkdirSync(join(root, 'scripts'), { recursive: true });
+  // Two trivial proto fixtures — content is irrelevant; only the SHA matters.
+  const protoA = join(root, 'src', 'ccsm', 'v1', 'a.proto');
+  const protoB = join(root, 'src', 'ccsm', 'v1', 'b.proto');
+  writeFileSync(protoA, 'syntax = "proto3";\npackage ccsm.v1;\nmessage A {}\n');
+  writeFileSync(protoB, 'syntax = "proto3";\npackage ccsm.v1;\nmessage B {}\n');
+  // Copy the real scripts so we exercise the production code path verbatim.
+  cpSync(REAL_LOCK_SCRIPT, join(root, 'scripts', 'lock.mjs'));
+  cpSync(REAL_LOCK_CHECK_SCRIPT, join(root, 'scripts', 'lock-check.mjs'));
+  return {
+    root,
+    lockPath: join(root, 'lock.json'),
+    protoA,
+    protoB,
+  };
+}
+
+function runNode(script: string, cwd: string): { stdout: string; stderr: string; code: number } {
+  try {
+    const stdout = execFileSync(process.execPath, [script], { cwd, stdio: ['ignore', 'pipe', 'pipe'] }).toString();
+    return { stdout, stderr: '', code: 0 };
+  } catch (err) {
+    const e = err as { status?: number; stdout?: Buffer; stderr?: Buffer };
+    return {
+      stdout: e.stdout ? e.stdout.toString() : '',
+      stderr: e.stderr ? e.stderr.toString() : '',
+      code: typeof e.status === 'number' ? e.status : 1,
+    };
+  }
+}
+
+function sha256(buf: Buffer | string): string {
+  return createHash('sha256').update(buf).digest('hex');
+}
+
+describe('packages/proto lock scripts', () => {
+  let pkg: ScratchPkg;
+
+  beforeEach(() => {
+    pkg = makeScratchPkg();
+  });
+
+  afterEach(() => {
+    rmSync(pkg.root, { recursive: true, force: true });
+  });
+
+  it('lock.mjs writes a v1 lock.json sorted by POSIX path with correct SHA256s', () => {
+    const r = runNode(join(pkg.root, 'scripts', 'lock.mjs'), pkg.root);
+    expect(r.code, `lock.mjs failed: ${r.stderr}`).toBe(0);
+
+    const lock = JSON.parse(readFileSync(pkg.lockPath, 'utf8'));
+    expect(lock.version).toBe(1);
+
+    const keys = Object.keys(lock.files);
+    expect(keys).toEqual(['src/ccsm/v1/a.proto', 'src/ccsm/v1/b.proto']);
+    // Confirm sort order survived (sorted ascending).
+    expect([...keys].sort()).toEqual(keys);
+
+    expect(lock.files['src/ccsm/v1/a.proto']).toBe(sha256(readFileSync(pkg.protoA)));
+    expect(lock.files['src/ccsm/v1/b.proto']).toBe(sha256(readFileSync(pkg.protoB)));
+  });
+
+  it('lock-check.mjs exits 0 when lock.json matches the on-disk protos', () => {
+    runNode(join(pkg.root, 'scripts', 'lock.mjs'), pkg.root);
+    const r = runNode(join(pkg.root, 'scripts', 'lock-check.mjs'), pkg.root);
+    expect(r.code, `lock-check should pass on a fresh lock; stderr=${r.stderr}`).toBe(0);
+    expect(r.stdout).toMatch(/lock-check: OK \(2 \.proto files match lock\.json\)/);
+  });
+
+  it('lock-check.mjs exits 1 with mismatch diff when a .proto SHA changes (tamper detection)', () => {
+    runNode(join(pkg.root, 'scripts', 'lock.mjs'), pkg.root);
+    // Tamper with one proto byte after lock generation.
+    writeFileSync(pkg.protoA, 'syntax = "proto3";\npackage ccsm.v1;\nmessage A { string x = 1; }\n');
+
+    const r = runNode(join(pkg.root, 'scripts', 'lock-check.mjs'), pkg.root);
+    expect(r.code).toBe(1);
+    expect(r.stderr).toMatch(/lock-check: FAIL/);
+    expect(r.stderr).toMatch(/mismatch: src\/ccsm\/v1\/a\.proto/);
+    expect(r.stderr).toMatch(/expected [0-9a-f]{64}/);
+    expect(r.stderr).toMatch(/actual\s+[0-9a-f]{64}/);
+  });
+
+  it('lock-check.mjs reports "missing in lock" when a new .proto appears without re-lock', () => {
+    runNode(join(pkg.root, 'scripts', 'lock.mjs'), pkg.root);
+    // Add a brand-new proto after lock — should be flagged as missing-in-lock.
+    writeFileSync(
+      join(pkg.root, 'src', 'ccsm', 'v1', 'c.proto'),
+      'syntax = "proto3";\npackage ccsm.v1;\nmessage C {}\n'
+    );
+
+    const r = runNode(join(pkg.root, 'scripts', 'lock-check.mjs'), pkg.root);
+    expect(r.code).toBe(1);
+    expect(r.stderr).toMatch(/missing in lock: src\/ccsm\/v1\/c\.proto/);
+  });
+
+  it('lock-check.mjs reports "extra in lock" when a recorded .proto is deleted from disk', () => {
+    runNode(join(pkg.root, 'scripts', 'lock.mjs'), pkg.root);
+    rmSync(pkg.protoB);
+
+    const r = runNode(join(pkg.root, 'scripts', 'lock-check.mjs'), pkg.root);
+    expect(r.code).toBe(1);
+    expect(r.stderr).toMatch(/extra in lock:\s+src\/ccsm\/v1\/b\.proto/);
+  });
+
+  it('lock-check.mjs rejects a malformed (non-v1) lock.json', () => {
+    runNode(join(pkg.root, 'scripts', 'lock.mjs'), pkg.root);
+    writeFileSync(pkg.lockPath, JSON.stringify({ version: 999, files: {} }));
+    const r = runNode(join(pkg.root, 'scripts', 'lock-check.mjs'), pkg.root);
+    expect(r.code).toBe(1);
+    expect(r.stderr).toMatch(/not a valid v1 lock/);
+  });
+});

--- a/packages/proto/vitest.config.ts
+++ b/packages/proto/vitest.config.ts
@@ -1,5 +1,7 @@
 // @ccsm/proto vitest config — co-located contract tests under
-// `test/contract/*.spec.ts` per design spec ch04 §7.1 (T0.12).
+// `test/contract/*.spec.ts` per design spec ch04 §7.1 (T0.12), plus
+// the T0.6 lock-script integrity test at `test/lock-script.spec.ts`
+// covering scripts/lock.mjs and scripts/lock-check.mjs.
 //
 // Why a separate config:
 //   The root `vitest.config.ts` restricts `include` to `tests/**` and
@@ -18,7 +20,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['test/**/*.spec.ts'],
+    include: ['src/**/*.spec.ts', 'test/**/*.spec.ts'],
     globals: false,
   },
 });


### PR DESCRIPTION
Task #19 — T0.6. Adds a SHA256 integrity lock over packages/proto/src/**/*.proto so any unintended schema drift is caught locally and (in T0.8) in CI.

## Scope (per design spec ch11 §4 lock.json semantics)

- packages/proto/lock.json — v1 shape: { version: 1, files: { '<rel-posix>': '<sha256>' } }, keys sorted ascending. Initial generation covers the 8 .proto files shipped by T0.11.
- packages/proto/scripts/lock.mjs — walks src/, hashes each .proto with node:crypto, writes lock.json sorted (deterministic).
- packages/proto/scripts/lock-check.mjs — recomputes SHAs, exits 1 with a diff on drift. Reports three categories:
  - mismatch (file on disk and in lock, hashes differ — also prints expected/actual)
  - missing in lock (.proto on disk not in lock.json)
  - extra in lock (entry in lock.json with no on-disk file)
- packages/proto/package.json — adds lock / lock-check / test scripts; sets type: module.
- packages/proto/vitest.config.ts — node env, picks up test/**/*.spec.ts.
- packages/proto/test/lock-script.spec.ts — 6 vitest cases. Builds a throw-away mini proto package in a tmpdir, copies the REAL scripts in, and exec's them via node:child_process. Covers: sort+hash output, happy path, tamper detection, missing-in-lock, extra-in-lock, malformed v1 rejection. (No fs mocking — end-to-end behaviour identical to CI.)

Out of scope (intentional, separate tasks):
- CI workflow integration — T0.8 (#17).
- Top-level proto/lock.spec.ts in the unit suite — T10.2 (#123).

## How to regenerate after intentional schema changes

```
pnpm --filter @ccsm/proto run lock
git add packages/proto/lock.json
```

Then commit alongside the .proto change. Until that re-lock lands, lock-check (and CI from T0.8 onward) will fail.

## Local quality gates

- `pnpm --filter @ccsm/proto run test` — 6/6 pass.
- `pnpm --filter @ccsm/proto run lock-check` — OK (8 .proto files match lock.json).
- `npx tsc --noEmit` (in packages/proto) — clean.
- `npx eslint packages/proto/test/lock-script.spec.ts packages/proto/vitest.config.ts` — clean.

## Reverse-verify (alter a .proto byte → lock-check fails; revert → passes)

Tampered (appended a comment to packages/proto/src/ccsm/v1/common.proto):
```
> @ccsm/proto@0.0.0 lock-check
> node scripts/lock-check.mjs

lock-check: FAIL — packages/proto/lock.json drift detected
  mismatch: src/ccsm/v1/common.proto
    expected 7e06b7b67fe1f4a75852392238e565bb6ba8081964cba3656cedaaaad2ee5102
    actual   48d6e433c3666766467122f340d3235143f012ec5727ff885ddf08c0d84731c3

Run `pnpm --filter @ccsm/proto run lock` to regenerate after intentional changes.
ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @ccsm/proto@0.0.0 lock-check: `node scripts/lock-check.mjs`
Exit status 1
```

Reverted:
```
> @ccsm/proto@0.0.0 lock-check
> node scripts/lock-check.mjs

lock-check: OK (8 .proto files match lock.json)
```