### PR TITLE
feat(proto): T0.12 contract test suite (4 forever-stable specs)

### DIFF
--- a/packages/proto/package.json
+++ b/packages/proto/package.json
@@ -2,10 +2,15 @@
   "name": "@ccsm/proto",
   "version": "0.0.0",
   "private": true,
+  "type": "module",
   "description": "CCSM proto definitions and generated Connect-RPC code. Skeleton only; implementation lands in subsequent T0.x / T1.x tasks per design spec ch11.",
   "scripts": {
     "clean": "node -e \"require('fs').rmSync('gen/ts',{recursive:true,force:true})\"",
-    "gen": "buf generate"
+    "gen": "buf generate",
+    "test": "vitest run --config vitest.config.ts"
+  },
+  "dependencies": {
+    "@bufbuild/protobuf": "^2.12.0"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.50.0",

--- a/packages/proto/test/contract/error-detail-roundtrip.spec.ts
+++ b/packages/proto/test/contract/error-detail-roundtrip.spec.ts
@@ -1,0 +1,120 @@
+// T0.12 contract test #4 — ErrorDetail round-trip for all v0.3 standard codes.
+//
+// Closes design spec ch04 §7.1 #4 (`proto/error-detail-roundtrip.spec.ts`).
+//
+// What it pins (forever-stable):
+//
+//   1. The four standard `ErrorDetail.code` strings v0.3 ships are
+//      forever-stable — neither the spelling nor the wire shape may
+//      change. v0.4+ may ADD new codes; existing codes MUST NOT be
+//      renamed, removed, or repurposed (per ch04 §8 additivity rule).
+//
+//        - `daemon.starting`        — ch02 §5 (UNAVAILABLE during boot)
+//        - `version.client_too_old` — ch04 §3 (Hello negotiation)
+//        - `request.missing_id`     — ch04 §2 (RequestMeta validation)
+//        - `session.not_owned`      — ch05 §5 (per-RPC enforcement matrix)
+//
+//   2. ErrorDetail encoding is byte-stable: serialize -> deserialize ->
+//      re-serialize MUST produce a buffer byte-identical to the first
+//      serialization. This is the canonical-encoding guarantee Connect
+//      relies on for `details` propagation through Connect's error
+//      envelope.
+//
+//   3. The `extra` map (string -> string) round-trips for representative
+//      payloads: `daemon_proto_version`, `session_id`, `principal`.
+//
+// Out of scope (NOT a behavior test): this file does NOT exercise
+// ConnectError attachment / extraction (that lives at the Connect
+// transport layer; T2.x). This is a CONTRACT shape + byte-stability
+// test for the underlying message.
+
+import { describe, expect, it } from 'vitest';
+import { create, toBinary, fromBinary, toJson, fromJson } from '@bufbuild/protobuf';
+import { ErrorDetailSchema } from '../../gen/ts/ccsm/v1/common_pb.js';
+
+// The 4 forever-stable v0.3 standard codes called out in the task scope.
+// Drift detection: renaming any of these strings here MUST also rename them
+// at the call sites (daemon middleware, Electron client error handlers).
+const STANDARD_CODES = [
+  {
+    code: 'daemon.starting',
+    message: 'Daemon is still starting; retry in 200ms.',
+    extra: {},
+  },
+  {
+    code: 'version.client_too_old',
+    message: 'Client proto_min_version exceeds daemon proto_version.',
+    extra: { daemon_proto_version: '1' },
+  },
+  {
+    code: 'request.missing_id',
+    message: 'request_id is required and must be a non-empty UUIDv4.',
+    extra: {},
+  },
+  {
+    code: 'session.not_owned',
+    message: 'Session is owned by a different principal.',
+    extra: { session_id: '01HXYZ123ABCDEFGHJKMNPQRSTV', principal: 'local-user:1000' },
+  },
+] as const;
+
+describe('ErrorDetail round-trip — standard codes (ch04 §7.1 #4)', () => {
+  for (const fixture of STANDARD_CODES) {
+    it(`code "${fixture.code}" serializes -> deserializes -> re-serializes byte-identical`, () => {
+      const detail = create(ErrorDetailSchema, {
+        code: fixture.code,
+        message: fixture.message,
+        extra: { ...fixture.extra },
+      });
+
+      // First binary serialization.
+      const bytes1 = toBinary(ErrorDetailSchema, detail);
+
+      // Decode and assert every field survived intact.
+      const decoded = fromBinary(ErrorDetailSchema, bytes1);
+      expect(decoded.code).toBe(fixture.code);
+      expect(decoded.message).toBe(fixture.message);
+      // `extra` is a map<string,string>. Compare as an object snapshot.
+      expect({ ...decoded.extra }).toEqual({ ...fixture.extra });
+
+      // Re-serialize the decoded value. The bytes MUST be byte-identical
+      // to the first encoding — proto3 canonical-encoding contract for
+      // a message with no unset optional fields.
+      const bytes2 = toBinary(ErrorDetailSchema, decoded);
+      expect(Buffer.from(bytes2).equals(Buffer.from(bytes1))).toBe(true);
+    });
+  }
+
+  it('JSON round-trip preserves code + message + extra map for all standard codes', () => {
+    for (const fixture of STANDARD_CODES) {
+      const detail = create(ErrorDetailSchema, {
+        code: fixture.code,
+        message: fixture.message,
+        extra: { ...fixture.extra },
+      });
+      const json = toJson(ErrorDetailSchema, detail);
+      const decoded = fromJson(ErrorDetailSchema, json);
+      expect(decoded.code).toBe(fixture.code);
+      expect(decoded.message).toBe(fixture.message);
+      expect({ ...decoded.extra }).toEqual({ ...fixture.extra });
+    }
+  });
+
+  it('extra map preserves multiple entries with arbitrary string values (open key set)', () => {
+    const detail = create(ErrorDetailSchema, {
+      code: 'session.not_owned',
+      message: 'Cross-principal access denied.',
+      extra: {
+        session_id: '01HXYZ123',
+        principal: 'local-user:1000',
+        attempted_by: 'local-user:1001',
+        rpc: 'SessionService.GetSession',
+      },
+    });
+    const decoded = fromBinary(ErrorDetailSchema, toBinary(ErrorDetailSchema, detail));
+    expect(Object.keys(decoded.extra).sort()).toEqual(
+      ['attempted_by', 'principal', 'rpc', 'session_id'],
+    );
+    expect(decoded.extra['rpc']).toBe('SessionService.GetSession');
+  });
+});

--- a/packages/proto/test/contract/open-string-tolerance.spec.ts
+++ b/packages/proto/test/contract/open-string-tolerance.spec.ts
@@ -1,0 +1,112 @@
+// T0.12 contract test #1 — open-string-set tolerance.
+//
+// Closes design spec ch04 §7.1 #1 (`proto/open-string-tolerance.spec.ts` —
+// renamed for the per-task suite layout under `test/contract/`).
+//
+// What it pins (forever-stable):
+//
+//   1. Proto3 unknown-field semantics: a JSON payload that names a field
+//      not declared in the schema parses cleanly when `ignoreUnknownFields:
+//      true` is set, and the known fields round-trip unchanged through the
+//      generated codec. This is the wire-level guarantee behind the
+//      "open string set" rule for `Settings.ui_prefs` keys, `CrashEntry.source`
+//      values, and `HelloRequest.client_kind` values: producers may emit
+//      values from a wider set than v0.3 declares, and v0.3 consumers MUST
+//      tolerate them rather than reject the whole message.
+//
+//   2. Open-string-set FIELDS (declared as `string`, not enum, on purpose):
+//      `HelloRequest.client_kind` accepts any UTF-8 string — including ones
+//      v0.3 does not enumerate (`"electron" | "web" | "ios"`). v0.4+ adding
+//      a new client kind (e.g. `"cli"`) MUST NOT require a proto bump or
+//      break existing daemons. Same shape rule for `Settings.ui_prefs` map
+//      values: arbitrary client-defined dotted-path keys are accepted.
+//
+// Out of scope (NOT a behavior test): this file does NOT assert daemon
+// branches on `client_kind` (forbidden by ch15 §3 — separately tested by
+// the lint rule referenced in spec ch15) and does NOT assert the daemon
+// rejects unknown ENUM values (different rule; enums are closed in v0.3).
+// This is a CONTRACT shape test only.
+
+import { describe, expect, it } from 'vitest';
+import { create, fromJson, toBinary, fromBinary, toJson } from '@bufbuild/protobuf';
+import { SettingsSchema } from '../../gen/ts/ccsm/v1/settings_pb.js';
+import { HelloRequestSchema } from '../../gen/ts/ccsm/v1/session_pb.js';
+import { RequestMetaSchema } from '../../gen/ts/ccsm/v1/common_pb.js';
+
+describe('open-string-set tolerance (ch04 §7.1 #1)', () => {
+  it('Settings JSON with an unknown field parses (ignoreUnknownFields=true) and known fields round-trip', () => {
+    // Authored as raw JSON so the unknown field cannot be normalized away
+    // by the generated TypeScript types. `futureOnlyKnob` is a v0.4+
+    // hypothetical field that MUST NOT cause a v0.3 consumer to fail.
+    const rawJson = {
+      uiPrefs: {
+        'appearance.theme': 'dark',
+        'composer.fontSizePx': '14',
+      },
+      detectedClaudeDefaultModel: 'claude-sonnet-4',
+      futureOnlyKnob: 'should-be-ignored-by-v03',
+      anotherFutureKnob: { nested: 'also-ignored' },
+    };
+
+    // Without ignoreUnknownFields, proto3 JSON parser MUST reject. This is
+    // the proto3 default contract — confirms the codec is compliant.
+    expect(() => fromJson(SettingsSchema, rawJson)).toThrow();
+
+    // With ignoreUnknownFields: true, the message parses and known fields
+    // are populated correctly. This is the "tolerant consumer" path the
+    // open-string-set rule depends on.
+    const parsed = fromJson(SettingsSchema, rawJson, { ignoreUnknownFields: true });
+    expect(parsed.uiPrefs['appearance.theme']).toBe('dark');
+    expect(parsed.uiPrefs['composer.fontSizePx']).toBe('14');
+    expect(parsed.detectedClaudeDefaultModel).toBe('claude-sonnet-4');
+
+    // Known fields round-trip through binary unchanged.
+    const bytes = toBinary(SettingsSchema, parsed);
+    const decoded = fromBinary(SettingsSchema, bytes);
+    expect(decoded.uiPrefs['appearance.theme']).toBe('dark');
+    expect(decoded.uiPrefs['composer.fontSizePx']).toBe('14');
+    expect(decoded.detectedClaudeDefaultModel).toBe('claude-sonnet-4');
+  });
+
+  it('HelloRequest.client_kind accepts arbitrary UTF-8 (open string set, not enum)', () => {
+    // v0.3 publishes `{electron, web, ios}` but the field MUST tolerate any
+    // string — see ch04 §3 (Hello). This is the wire guarantee that v0.4+
+    // can ship a new client kind without a proto bump.
+    const exotic = ['electron', 'web', 'ios', 'cli', 'plugin-vscode', '未来客户端', '🚀'];
+    for (const kind of exotic) {
+      const meta = create(RequestMetaSchema, {
+        requestId: '11111111-1111-4111-8111-111111111111',
+        clientVersion: '0.3.0',
+        clientSendUnixMs: 1730000000000n,
+      });
+      const msg = create(HelloRequestSchema, {
+        meta,
+        clientKind: kind,
+        protoMinVersion: 1,
+      });
+      const bytes = toBinary(HelloRequestSchema, msg);
+      const decoded = fromBinary(HelloRequestSchema, bytes);
+      expect(decoded.clientKind).toBe(kind);
+      // JSON also round-trips unchanged.
+      const json = toJson(HelloRequestSchema, decoded);
+      expect((json as { clientKind: string }).clientKind).toBe(kind);
+    }
+  });
+
+  it('Settings.ui_prefs map accepts arbitrary dotted-path keys (open key set)', () => {
+    // Per ch04 §6 — the `ui_prefs` map keys are open; clients own the
+    // schema for their own keys; daemon does NOT validate value shape.
+    const settings = create(SettingsSchema, {
+      uiPrefs: {
+        'appearance.theme': 'dark',
+        'composer.fontSizePx': '14',
+        'notify.enabled': 'true',
+        'v04.web.someFutureKey': '{"nested":"json-encoded-value"}',
+      },
+    });
+    const bytes = toBinary(SettingsSchema, settings);
+    const decoded = fromBinary(SettingsSchema, bytes);
+    expect(decoded.uiPrefs['v04.web.someFutureKey']).toBe('{"nested":"json-encoded-value"}');
+    expect(Object.keys(decoded.uiPrefs).length).toBe(4);
+  });
+});

--- a/packages/proto/test/contract/request-id-roundtrip.spec.ts
+++ b/packages/proto/test/contract/request-id-roundtrip.spec.ts
@@ -1,0 +1,106 @@
+// T0.12 contract test #3 — RequestMeta.request_id round-trip.
+//
+// Closes design spec ch04 §7.1 #3 (`proto/request-meta-validation.spec.ts`
+// — renamed for the per-task suite layout under `test/contract/`).
+//
+// What it pins (forever-stable):
+//
+//   1. `RequestMeta.request_id` round-trips through the generated codec
+//      unchanged for both empty and non-empty values. The wire shape
+//      itself does NOT enforce non-empty — proto3 string fields default
+//      to "" — so the daemon-side validation rule ("empty request_id ->
+//      INVALID_ARGUMENT + ErrorDetail.code = `request.missing_id`") MUST
+//      be implemented in middleware, not at the proto level. This test
+//      pins both ends of that contract:
+//
+//        a) shape: empty `request_id` IS a representable wire value
+//           (otherwise middleware could not distinguish "not sent" from
+//           "sent as empty");
+//        b) shape: non-empty `request_id` round-trips byte-for-byte;
+//        c) data: the canonical INVALID_ARGUMENT code string used by the
+//           middleware-to-be (T2.4 #37) is `"request.missing_id"`.
+//
+//   2. The `client_version` and `client_send_unix_ms` siblings on the
+//      same `RequestMeta` round-trip too — they share the same forever-
+//      stable contract (every RPC carries them; ch04 §2).
+//
+// Out of scope (NOT a behavior test): this file does NOT install any
+// Connect interceptor, does NOT call any RPC, does NOT exercise the
+// rejection path. The middleware is T2.4 #37. This is a CONTRACT shape
+// test for the data the middleware will consume.
+
+import { describe, expect, it } from 'vitest';
+import { create, toBinary, fromBinary, toJson, fromJson } from '@bufbuild/protobuf';
+import { RequestMetaSchema, ErrorDetailSchema } from '../../gen/ts/ccsm/v1/common_pb.js';
+
+describe('RequestMeta.request_id round-trip (ch04 §7.1 #3)', () => {
+  it('non-empty request_id round-trips byte-for-byte through binary codec', () => {
+    const original = create(RequestMetaSchema, {
+      requestId: '7f3c1d8e-2b94-4f01-a5c6-d9e8b2a107c4',
+      clientVersion: '0.3.0',
+      clientSendUnixMs: 1730000000123n,
+    });
+    const bytes = toBinary(RequestMetaSchema, original);
+    const decoded = fromBinary(RequestMetaSchema, bytes);
+    expect(decoded.requestId).toBe('7f3c1d8e-2b94-4f01-a5c6-d9e8b2a107c4');
+    expect(decoded.clientVersion).toBe('0.3.0');
+    expect(decoded.clientSendUnixMs).toBe(1730000000123n);
+
+    // Re-serialize and assert the bytes are stable (canonical encoding).
+    const reBytes = toBinary(RequestMetaSchema, decoded);
+    expect(Buffer.from(reBytes).equals(Buffer.from(bytes))).toBe(true);
+  });
+
+  it('empty request_id is a representable wire value (middleware-detectable)', () => {
+    // Critical: proto3 string defaults to "" with implicit presence. The
+    // daemon middleware MUST be able to observe "" and reject — meaning
+    // the wire MUST allow it through. If a future schema change ever gates
+    // request_id at the proto layer (e.g., `optional` + presence check),
+    // the daemon's INVALID_ARGUMENT code path is bypassed and clients see
+    // a less-actionable error. This test fences that change.
+    const empty = create(RequestMetaSchema, {
+      requestId: '',
+      clientVersion: '0.3.0',
+      clientSendUnixMs: 1730000000000n,
+    });
+    const bytes = toBinary(RequestMetaSchema, empty);
+    const decoded = fromBinary(RequestMetaSchema, bytes);
+    expect(decoded.requestId).toBe('');
+    // JSON round-trip too — empty proto3 string omitted from JSON by default
+    // and parses back to empty.
+    const json = toJson(RequestMetaSchema, decoded);
+    const reparsed = fromJson(RequestMetaSchema, json);
+    expect(reparsed.requestId).toBe('');
+  });
+
+  it('JSON round-trip preserves request_id in both directions', () => {
+    const original = create(RequestMetaSchema, {
+      requestId: 'abc-DEF-123',
+      clientVersion: '1.2.3-rc.4',
+      clientSendUnixMs: 9007199254740991n,
+    });
+    const json = toJson(RequestMetaSchema, original);
+    const decoded = fromJson(RequestMetaSchema, json);
+    expect(decoded.requestId).toBe('abc-DEF-123');
+    expect(decoded.clientVersion).toBe('1.2.3-rc.4');
+    expect(decoded.clientSendUnixMs).toBe(9007199254740991n);
+  });
+
+  it('canonical "request.missing_id" ErrorDetail is byte-stable (the rejection contract)', () => {
+    // The middleware will emit this exact ErrorDetail on empty request_id
+    // (per the comment block in src/ccsm/v1/common.proto attached to
+    // RequestMeta.request_id). Pinning the shape now means T2.4 #37 cannot
+    // accidentally drift the code string.
+    const detail = create(ErrorDetailSchema, {
+      code: 'request.missing_id',
+      message: 'request_id is required and must be a non-empty UUIDv4.',
+      extra: {},
+    });
+    const bytes = toBinary(ErrorDetailSchema, detail);
+    const decoded = fromBinary(ErrorDetailSchema, bytes);
+    expect(decoded.code).toBe('request.missing_id');
+    expect(decoded.message).toContain('request_id');
+    // Bytes are canonical — re-encoding produces the same buffer.
+    expect(Buffer.from(toBinary(ErrorDetailSchema, decoded)).equals(Buffer.from(bytes))).toBe(true);
+  });
+});

--- a/packages/proto/test/contract/version-negotiation.spec.ts
+++ b/packages/proto/test/contract/version-negotiation.spec.ts
@@ -1,0 +1,141 @@
+// T0.12 contract test #2 — version negotiation truth-table (shape).
+//
+// Closes design spec ch04 §7.1 #2 (`proto/proto-min-version-truth-table.spec.ts`
+// — renamed for the per-task suite layout under `test/contract/`).
+//
+// What it pins (forever-stable):
+//
+//   1. The DATA SHAPE the negotiation contract is built on:
+//      - `HelloRequest` carries `proto_min_version: int32`.
+//      - `HelloResponse` carries `proto_version: int32` (and NOT a
+//        `min_compatible_client` — version negotiation is one-directional
+//        per ch04 §3 / ch02 §6).
+//      - Failure mode is encoded via `ErrorDetail.code` strings:
+//        `"version.client_too_old"` (with `extra["daemon_proto_version"]`)
+//        and (symmetric inverse, valid for client-side decision logic)
+//        `"version.server_too_old"`.
+//
+//   2. The pure decision function used by both sides — given
+//      `(clientMin, serverProtoVersion, clientMaxKnown)` it returns
+//      `success | client_too_old | server_too_old`. The truth-table here
+//      is forever-stable; v0.4 may NOT change the verdict for any row.
+//
+// Out of scope (NOT a behavior test): this file does NOT call a Hello
+// RPC, does NOT exercise daemon dispatch, does NOT reach Connect-RPC.
+// Those land in T2.3 #33 (Hello handler). This is a CONTRACT shape +
+// pure-decider test only.
+
+import { describe, expect, it } from 'vitest';
+import { create, toBinary, fromBinary } from '@bufbuild/protobuf';
+import { HelloRequestSchema, HelloResponseSchema } from '../../gen/ts/ccsm/v1/session_pb.js';
+import { RequestMetaSchema, ErrorDetailSchema } from '../../gen/ts/ccsm/v1/common_pb.js';
+
+// Pure decider mirroring the contract wording in ch04 §3 + ch02 §6.
+// Both client and daemon implementations MUST produce these verdicts.
+type Verdict = 'success' | 'version.client_too_old' | 'version.server_too_old';
+function negotiate(args: {
+  clientMin: number;
+  clientMaxKnown: number;
+  serverProtoVersion: number;
+}): Verdict {
+  const { clientMin, clientMaxKnown, serverProtoVersion } = args;
+  if (serverProtoVersion < clientMin) return 'version.client_too_old';
+  if (serverProtoVersion > clientMaxKnown) return 'version.server_too_old';
+  return 'success';
+}
+
+function meta() {
+  return create(RequestMetaSchema, {
+    requestId: '22222222-2222-4222-8222-222222222222',
+    clientVersion: '0.3.0',
+    clientSendUnixMs: 1730000000000n,
+  });
+}
+
+describe('version negotiation contract (ch04 §7.1 #2 / ch04 §3)', () => {
+  it('HelloRequest data shape: carries proto_min_version (int32) only', () => {
+    const req = create(HelloRequestSchema, {
+      meta: meta(),
+      clientKind: 'electron',
+      protoMinVersion: 1,
+    });
+    const bytes = toBinary(HelloRequestSchema, req);
+    const decoded = fromBinary(HelloRequestSchema, bytes);
+    expect(decoded.protoMinVersion).toBe(1);
+    expect(decoded.clientKind).toBe('electron');
+    // Sanity: round-trip preserves zero (proto3 default) too.
+    const zero = create(HelloRequestSchema, { meta: meta(), clientKind: 'electron', protoMinVersion: 0 });
+    const zeroBytes = toBinary(HelloRequestSchema, zero);
+    expect(fromBinary(HelloRequestSchema, zeroBytes).protoMinVersion).toBe(0);
+  });
+
+  it('HelloResponse data shape: carries proto_version + listener_id, NOT min_compatible_client', () => {
+    const resp = create(HelloResponseSchema, {
+      meta: meta(),
+      daemonVersion: '0.3.0',
+      protoVersion: 1,
+      listenerId: 'A',
+    });
+    const decoded = fromBinary(HelloResponseSchema, toBinary(HelloResponseSchema, resp));
+    expect(decoded.protoVersion).toBe(1);
+    expect(decoded.daemonVersion).toBe('0.3.0');
+    expect(decoded.listenerId).toBe('A');
+    // Mechanical proof that `min_compatible_client` is not a field on the
+    // generated message — version negotiation is one-directional.
+    expect('minCompatibleClient' in decoded).toBe(false);
+    // listener_id is open string set (see ch04 §3 — "B" in v0.4, "C" in v0.5+).
+    const b = create(HelloResponseSchema, { meta: meta(), daemonVersion: '0.4.0', protoVersion: 2, listenerId: 'B' });
+    expect(fromBinary(HelloResponseSchema, toBinary(HelloResponseSchema, b)).listenerId).toBe('B');
+  });
+
+  it('truth-table: success / client_too_old / server_too_old verdicts are forever-stable', () => {
+    // Each row is (clientMin, clientMaxKnown, serverProtoVersion, verdict).
+    // Locked at v0.3; v0.4 MUST NOT change any verdict.
+    const rows: Array<[number, number, number, Verdict]> = [
+      // Exact match.
+      [1, 1, 1, 'success'],
+      // Server within client's known range (min..max).
+      [1, 3, 2, 'success'],
+      [1, 3, 3, 'success'],
+      // Server too old — client minimum exceeds what daemon serves.
+      [2, 5, 1, 'version.client_too_old'],
+      [3, 3, 2, 'version.client_too_old'],
+      // Server too new — daemon serves a version newer than client knows.
+      [1, 2, 3, 'version.server_too_old'],
+      [1, 1, 2, 'version.server_too_old'],
+      // Edge: client wants only a single version equal to server.
+      [2, 2, 2, 'success'],
+    ];
+    for (const [clientMin, clientMaxKnown, serverProtoVersion, expected] of rows) {
+      const got = negotiate({ clientMin, clientMaxKnown, serverProtoVersion });
+      expect(got, `row clientMin=${clientMin} max=${clientMaxKnown} server=${serverProtoVersion}`).toBe(expected);
+    }
+  });
+
+  it('ErrorDetail shape carries the negotiation failure codes (data shape only)', () => {
+    // Exercises the CONTRACT that Hello rejection surfaces a structured
+    // ErrorDetail with `code = "version.client_too_old"` and
+    // `extra["daemon_proto_version"]`. The actual ConnectError attachment
+    // path is T2.3 #33; this file pins only the proto shape consumed there.
+    const detail = create(ErrorDetailSchema, {
+      code: 'version.client_too_old',
+      message: 'Daemon serves proto v1; client minimum is v3.',
+      extra: { daemon_proto_version: '1' },
+    });
+    const decoded = fromBinary(ErrorDetailSchema, toBinary(ErrorDetailSchema, detail));
+    expect(decoded.code).toBe('version.client_too_old');
+    expect(decoded.extra['daemon_proto_version']).toBe('1');
+
+    // Symmetric inverse — same shape, used by client-side upgrade logic
+    // when the daemon advertises a newer proto_version than the client
+    // knows about. Not emitted by daemon over the wire today but the
+    // string is reserved at the contract level for symmetry / discoverability.
+    const inverse = create(ErrorDetailSchema, {
+      code: 'version.server_too_old',
+      message: 'Client knows proto up to v2; daemon serves v3.',
+      extra: { client_max_known: '2' },
+    });
+    const inverseDecoded = fromBinary(ErrorDetailSchema, toBinary(ErrorDetailSchema, inverse));
+    expect(inverseDecoded.code).toBe('version.server_too_old');
+  });
+});

--- a/packages/proto/tsconfig.json
+++ b/packages/proto/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    "types": ["node"]
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "test/**/*", "gen/ts/**/*", "vitest.config.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/proto/vitest.config.ts
+++ b/packages/proto/vitest.config.ts
@@ -1,0 +1,24 @@
+// @ccsm/proto vitest config — co-located contract tests under
+// `test/contract/*.spec.ts` per design spec ch04 §7.1 (T0.12).
+//
+// Why a separate config:
+//   The root `vitest.config.ts` restricts `include` to `tests/**` and
+//   `electron/**` and pulls in jsdom + a heavy setup file. Proto contract
+//   tests are pure node — no DOM, no setup — and must not pay the jsdom
+//   startup cost. Same pattern as `tools/vitest.config.ts` and
+//   `packages/daemon/vitest.config.ts`.
+//
+//   Run with:
+//     pnpm --filter @ccsm/proto test
+//   or:
+//     npx vitest run --config packages/proto/vitest.config.ts
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/**/*.spec.ts'],
+    globals: false,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,10 @@ importers:
   packages/electron: {}
 
   packages/proto:
+    dependencies:
+      '@bufbuild/protobuf':
+        specifier: ^2.12.0
+        version: 2.12.0
     devDependencies:
       '@bufbuild/buf':
         specifier: ^1.50.0


### PR DESCRIPTION
## Scope

T0.12 — adds 4 named contract spec files under `packages/proto/test/contract/` per design spec ch04 §7.1 (forever-stable contract enforcement). Each spec pins a wire-shape guarantee that v0.4+ MUST NOT regress. CONTRACT shape tests only; explicitly NOT behavior tests for Hello RPC (T2.3 #33) or RequestMeta middleware (T2.4 #37).

## Spec files

- `open-string-tolerance.spec.ts` — proto3 unknown-field tolerance via `fromJson` with `ignoreUnknownFields`; open-string-set fields (`HelloRequest.client_kind`, `Settings.ui_prefs` map keys) accept arbitrary UTF-8 / dotted-path keys. Closes ch04 §7.1 #1.
- `version-negotiation.spec.ts` — `HelloRequest.proto_min_version` + `HelloResponse.proto_version` data shape; mechanically asserts NO `min_compatible_client` field exists (one-directional negotiation per ch04 §3 / ch02 §6); pure-decider truth-table for `success` / `version.client_too_old` / `version.server_too_old` verdicts; `ErrorDetail` shape carries the negotiation codes. Closes ch04 §7.1 #2.
- `request-id-roundtrip.spec.ts` — `RequestMeta.request_id` round-trips empty + non-empty through binary + JSON; canonical `"request.missing_id"` `ErrorDetail` byte-stable. Empty is intentionally a representable wire value so middleware (T2.4 #37) can detect it. Closes ch04 §7.1 #3.
- `error-detail-roundtrip.spec.ts` — All 4 standard codes (`daemon.starting`, `version.client_too_old`, `request.missing_id`, `session.not_owned`) serialize → deserialize → re-serialize byte-identical; `extra` map preserves arbitrary string keys. Closes ch04 §7.1 #4.

## Wiring

- `packages/proto/package.json` — `type=module`, `test` script, `@bufbuild/protobuf` runtime dep.
- `packages/proto/vitest.config.ts` — per-package config (node env, `test/**/*.spec.ts`, no globals, no setup), same pattern as `tools/vitest.config.ts` and `packages/daemon/vitest.config.ts`.
- `packages/proto/tsconfig.json` — includes `test/` + `gen/ts/` + node types.

## Quality gates

```
$ pnpm --filter @ccsm/proto test
 Test Files  4 passed (4)
      Tests  17 passed (17)
   Duration  1.06s

$ npm run lint   # 0 errors (warnings on gen/** are pre-existing)
$ npm run typecheck   # clean
```

## Reverse-verify (per dev §2 phase-4)

Altered the generated PB shape: renamed `string code = 1;` → `string code_renamed = 1;` in `src/ccsm/v1/common.proto`, regenerated via `pnpm gen`, re-ran tests:

```
 Test Files  3 failed | 1 passed (4)
      Tests  7 failed | 10 passed (17)

 AssertionError: expected undefined to be 'version.client_too_old'
   ❯ test/contract/version-negotiation.spec.ts:126:26
       expect(decoded.code).toBe('version.client_too_old');
                            ^
```

Reverted the proto change, regenerated, re-ran:

```
 Test Files  4 passed (4)
      Tests  17 passed (17)
   Duration  923ms
```

Confirms the suite catches contract drift mechanically (not coincidentally).

## Out of scope

- Hello RPC dispatch / version-negotiation server logic — T2.3 #33.
- RequestMeta middleware (empty request_id rejection path) — T2.4 #37.
- CI wiring of `pnpm --filter @ccsm/proto test` — follow-up (T10.6 / T10.1 wiring is also pending; root `npm test` does not currently invoke per-package vitest configs).

## Spec ref

`docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md` ch04 §7.1 (the file is currently absent from `working` after spec consolidation; recovered for design reference from commit `2aa48b7`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)