### PR TITLE
feat(daemon): T1.9 ESLint rule ccsm/no-listener-slot-mutation (v0.3 slot-1 immutability)

### DIFF
--- a/packages/daemon/eslint-plugins/__tests__/no-listener-slot-mutation.spec.ts
+++ b/packages/daemon/eslint-plugins/__tests__/no-listener-slot-mutation.spec.ts
@@ -1,0 +1,96 @@
+// Spec for the local ESLint plugin `ccsm/no-listener-slot-mutation`.
+// Covers spec ch03 §1 (slot 1 immutability) + ch11 §5 (lint-time guard).
+//
+// We use ESLint's built-in `RuleTester` (no @typescript-eslint/rule-tester
+// dependency). The rule is purely syntactic — it inspects identifier
+// names and member-access shape — so the default espree parser is enough
+// for the JS-shaped fixtures below. A small @typescript-eslint/parser
+// suite at the bottom proves the rule works on TS source as it appears
+// in `packages/daemon/src/**/*.ts`.
+
+import { describe, it } from 'vitest';
+import { RuleTester } from 'eslint';
+import tsparser from '@typescript-eslint/parser';
+import { rule } from '../ccsm-no-listener-slot-mutation.js';
+
+const tester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+});
+
+const tsTester = new RuleTester({
+  languageOptions: {
+    parser: tsparser,
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+});
+
+describe('ccsm/no-listener-slot-mutation', () => {
+  it('runs RuleTester (default parser)', () => {
+    tester.run('no-listener-slot-mutation', rule, {
+      valid: [
+        // 1. Slot 0 write is fine — only slot 1 is reserved.
+        { code: 'const slots = [a, b]; slots[0] = makeListenerA();' },
+        // 2. Reading slot 1 is allowed (assertSlot1Reserved does this).
+        { code: 'const slots = [a, b]; if (slots[1] !== SENTINEL) {}' },
+        // 3. Assigning to a non-listener array is unrelated.
+        { code: 'const queue = []; queue[1] = 42; queue.push(1);' },
+        // 4. Mutating method on a non-listener identifier is unrelated.
+        { code: 'const items = []; items.push(x); items.splice(0, 1);' },
+        // 5. Method call that is not a mutator on a listener tuple is OK.
+        { code: 'const listeners = [a, b]; listeners.map(l => l.id);' },
+      ],
+      invalid: [
+        // 1. Direct slot-1 write on `listeners`.
+        {
+          code: 'const listeners = [a, b]; listeners[1] = makeListenerB();',
+          errors: [{ messageId: 'slotAssign' }],
+        },
+        // 2. Direct slot-1 write on `slots` (heuristic name match).
+        {
+          code: 'const slots = [a, b]; slots[1] = realB;',
+          errors: [{ messageId: 'slotAssign' }],
+        },
+        // 3. Mutating `push` on a listener-named array.
+        {
+          code: 'const listenerSlots = [a, b]; listenerSlots.push(c);',
+          errors: [{ messageId: 'mutatingCall', data: { method: 'push' } }],
+        },
+        // 4. Mutating `splice` on a listener tuple via property chain.
+        {
+          code: 'env.listeners.splice(1, 1, makeListenerB());',
+          errors: [{ messageId: 'mutatingCall', data: { method: 'splice' } }],
+        },
+        // 5. Computed-index symbolic write — conservative match.
+        {
+          code: 'const listeners = [a, b]; const i = 1; listeners[i] = b2;',
+          errors: [{ messageId: 'slotAssign' }],
+        },
+      ],
+    });
+  });
+
+  it('runs RuleTester (typescript-eslint parser)', () => {
+    tsTester.run('no-listener-slot-mutation', rule, {
+      valid: [
+        // TS-typed slot 0 write.
+        {
+          code: 'const slots: readonly [unknown, unknown] = [a, b]; const s = slots as any; s[0] = x;',
+        },
+        // TS file in listener-b.ts is whitelisted at flat-config layer,
+        // not via parser; here we just prove the rule still rejects
+        // the same pattern when run directly (whitelist is a config
+        // concern verified in the eslint.config.js wiring).
+      ],
+      invalid: [
+        {
+          code: 'const listeners: any[] = []; listeners[1] = bListener as any;',
+          errors: [{ messageId: 'slotAssign' }],
+        },
+      ],
+    });
+  });
+});

--- a/packages/daemon/eslint-plugins/ccsm-no-listener-slot-mutation.js
+++ b/packages/daemon/eslint-plugins/ccsm-no-listener-slot-mutation.js
@@ -1,0 +1,148 @@
+// Local ESLint plugin: ccsm/no-listener-slot-mutation
+//
+// Spec ch03 §1 (Listener trait + 2-slot tuple invariant) and ch11 §5
+// (per-package boundary rules / lint-time guards). v0.3 ships exactly
+// one active listener — slot 0 is Listener A; slot 1 is pinned to the
+// `RESERVED_FOR_LISTENER_B` typed sentinel. The compile-time guard is
+// the `ListenerSlots` readonly tuple shape (T1.2). The runtime guard
+// is `assertSlot1Reserved` (T1.2). This module is the lint-time guard:
+// it forbids any source-level write that would alter slot 1 (or
+// otherwise mutate the listener-array shape) before v0.4 lands the
+// real Listener B factory.
+//
+// Whitelist: the rule is bypassed by the per-package flat config for
+// `**/listener-b.ts` — the single v0.4 file that is *expected* to
+// publish a real listener into slot 1. The bypass lives in
+// `packages/daemon/eslint.config.js` (flat-config `files`/`ignores`
+// override) rather than as a rule option, so the bypass surface is
+// auditable as a single grep target.
+//
+// Conservative heuristic: the rule fires only when the LHS object
+// identifier name plausibly refers to a listener tuple. Matching is
+// case-insensitive against the substrings "listener" or "slot". This
+// avoids false positives on unrelated arrays while catching every
+// realistic naming used in the daemon (`listeners`, `listenerSlots`,
+// `daemonEnv.listeners`, `slots`, `env.listeners`, …).
+//
+// SRP: this module is a pure decider — it inspects AST nodes and
+// reports. No I/O, no factories, no fixers. Auto-fix is intentionally
+// not provided: every match here is a design-level violation that a
+// human must justify (or the file must move under the listener-b.ts
+// whitelist).
+
+const LISTENER_NAME_RE = /listener|slot/i;
+
+/**
+ * Walks a MemberExpression's object chain to find a leaf identifier
+ * name. Handles `slots`, `env.listeners`, `this.listenerSlots`, and
+ * `daemonEnv.listeners[1]` style chains.
+ */
+function leafIdentifierName(node) {
+  let cursor = node;
+  while (cursor) {
+    if (cursor.type === 'Identifier') return cursor.name;
+    if (cursor.type === 'MemberExpression') {
+      // Prefer the rightmost property name when it is a non-computed
+      // identifier (e.g. `env.listeners` -> "listeners"). Otherwise
+      // recurse into the object side.
+      if (!cursor.computed && cursor.property && cursor.property.type === 'Identifier') {
+        return cursor.property.name;
+      }
+      cursor = cursor.object;
+      continue;
+    }
+    if (cursor.type === 'ThisExpression') return 'this';
+    if (cursor.type === 'ChainExpression') {
+      cursor = cursor.expression;
+      continue;
+    }
+    return null;
+  }
+  return null;
+}
+
+function looksLikeListenerArray(objectNode) {
+  const name = leafIdentifierName(objectNode);
+  if (!name) return false;
+  return LISTENER_NAME_RE.test(name);
+}
+
+/** True for `MemberExpression` of shape `<obj>[1]` (computed numeric 1). */
+function isSlot1Access(node) {
+  if (node.type !== 'MemberExpression') return false;
+  if (!node.computed) return false;
+  const p = node.property;
+  if (!p) return false;
+  // Literal 1
+  if (p.type === 'Literal' && p.value === 1) return true;
+  // Identifier (computed but symbolic) — be conservative and flag it
+  // when the array name looks like a listener tuple, since the index
+  // expression could resolve to slot 1 at runtime.
+  if (p.type === 'Identifier') return true;
+  // UnaryExpression like -0 etc. — ignore.
+  return false;
+}
+
+const MUTATING_METHODS = new Set([
+  'push',
+  'pop',
+  'shift',
+  'unshift',
+  'splice',
+  'fill',
+  'copyWithin',
+  'sort',
+  'reverse',
+]);
+
+const rule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Forbid source-level mutation of the daemon listener tuple (slot 1 is reserved for v0.4 Listener B). Spec ch03 §1.',
+      recommended: true,
+    },
+    messages: {
+      slotAssign:
+        'Assignment to listener tuple slot is forbidden in v0.3 — slot 1 is pinned to RESERVED_FOR_LISTENER_B until v0.4 (spec ch03 §1). Listener B activation is the only exception and must live in `listener-b.ts`.',
+      mutatingCall:
+        'Calling `{{method}}()` on a listener tuple mutates the closed 2-slot shape (spec ch03 §1). Treat the tuple as readonly; reconstruct via factory if you really mean to change it.',
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      AssignmentExpression(node) {
+        const left = node.left;
+        if (!left || left.type !== 'MemberExpression') return;
+        if (!isSlot1Access(left)) return;
+        if (!looksLikeListenerArray(left.object)) return;
+        context.report({ node, messageId: 'slotAssign' });
+      },
+      CallExpression(node) {
+        const callee = node.callee;
+        if (!callee || callee.type !== 'MemberExpression') return;
+        if (callee.computed) return;
+        if (!callee.property || callee.property.type !== 'Identifier') return;
+        if (!MUTATING_METHODS.has(callee.property.name)) return;
+        if (!looksLikeListenerArray(callee.object)) return;
+        context.report({
+          node,
+          messageId: 'mutatingCall',
+          data: { method: callee.property.name },
+        });
+      },
+    };
+  },
+};
+
+const plugin = {
+  meta: { name: 'ccsm-no-listener-slot-mutation', version: '0.1.0' },
+  rules: {
+    'no-listener-slot-mutation': rule,
+  },
+};
+
+export default plugin;
+export { rule };

--- a/packages/daemon/eslint.config.js
+++ b/packages/daemon/eslint.config.js
@@ -8,14 +8,22 @@
 //     code under packages/proto/gen/**, not the raw .proto sources under
 //     packages/proto/src/**.
 //
-// Downstream tasks plug additional custom rules onto this same config:
-//   - Task #29 (T1.9) adds `ccsm/no-listener-slot-mutation`
-//     (listener-A descriptor slot mutability lint).
+// Custom rules:
+//   - Task #29 (T1.9) `ccsm/no-listener-slot-mutation` — forbids
+//     source-level mutation of the listener 2-tuple (slot 1 is pinned to
+//     RESERVED_FOR_LISTENER_B until v0.4). The rule is bypassed for
+//     `**/listener-b.ts` (the single v0.4 file allowed to publish into
+//     slot 1) via a trailing override block. Bypass surface is grep-able
+//     here so reviewers can audit it as a single point.
 import rootConfig from '../../eslint.config.js';
+import ccsmPlugin from './eslint-plugins/ccsm-no-listener-slot-mutation.js';
 
 export default [
   ...rootConfig,
   {
+    plugins: {
+      ccsm: ccsmPlugin,
+    },
     rules: {
       'no-restricted-imports': ['error', {
         patterns: [
@@ -31,8 +39,18 @@ export default [
             group: ['@ccsm/proto/src/*', '@ccsm/proto/src'],
             message: '@ccsm/daemon may only import generated Connect-RPC code from @ccsm/proto/gen/**, not raw .proto sources (chapter 11 §5).'
           }
-        ]
-      }]
-    }
-  }
+        ],
+      }],
+      'ccsm/no-listener-slot-mutation': 'error',
+    },
+  },
+  {
+    // v0.4 carve-out: the Listener B factory is the single file allowed
+    // to publish a real listener into slot 1. Keep the bypass narrow —
+    // any other file matching this glob would be a spec violation.
+    files: ['**/listener-b.ts'],
+    rules: {
+      'ccsm/no-listener-slot-mutation': 'off',
+    },
+  },
 ];

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "CCSM daemon (headless RPC server). Skeleton only; implementation lands in subsequent T0.x / T1.x tasks per design spec ch11.",
   "scripts": {
-    "lint": "eslint src --ext .ts",
+    "lint": "eslint \"src/**/*.ts\" \"eslint-plugins/**/*.{js,ts}\"",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/packages/daemon/vitest.config.ts
+++ b/packages/daemon/vitest.config.ts
@@ -7,7 +7,10 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['src/**/*.spec.ts'],
+    // `eslint-plugins/**` holds the local ESLint plugin source + its
+    // RuleTester suite (e.g. T1.9 ccsm/no-listener-slot-mutation). They
+    // are not under `src/` because they are tooling, not daemon runtime.
+    include: ['src/**/*.spec.ts', 'eslint-plugins/**/*.spec.ts'],
     globals: false,
   },
 });


### PR DESCRIPTION
## Scope

Spec ch03 §1 (Listener trait + 2-slot tuple invariant) and ch11 §5 (per-package boundary rules / lint-time guards). Task #29.

The compile-time guard for slot-1 immutability is the `ListenerSlots` readonly tuple shape (T1.2). The runtime guard is `assertSlot1Reserved` (T1.2). This PR adds the **lint-time** guard: any source-level write that would mutate the listener tuple before v0.4 is flagged at lint.

## Rule shape

`packages/daemon/eslint-plugins/ccsm-no-listener-slot-mutation.js` exports a single rule that fires on:

1. **`AssignmentExpression`** whose left is a `MemberExpression` with a computed index (numeric literal `1` OR a symbolic identifier — conservative) on an object whose leaf identifier name matches `/listener|slot/i`. Catches `listeners[1] = ...`, `slots[1] = ...`, `env.listeners[1] = ...`, `listenerSlots[i] = ...`.
2. **`CallExpression`** whose callee is a non-computed `MemberExpression` with property in `{push, pop, shift, unshift, splice, fill, copyWithin, sort, reverse}` and the same heuristic-named object. Catches `listeners.push(b)`, `env.listeners.splice(...)`, etc.

Heuristic name match is case-insensitive on `listener`/`slot` substrings — covers every realistic naming used in daemon (`listeners`, `listenerSlots`, `slots`, `env.listeners`, `daemonEnv.listeners`) without false positives on unrelated arrays. Pure decider: no I/O, no auto-fix (every match is a design-level violation that needs human justification or the file must move under the listener-b.ts whitelist).

## listener-b.ts bypass mechanism

Implemented as a **trailing flat-config override block** in `packages/daemon/eslint.config.js`:

```js
{
  files: ['**/listener-b.ts'],
  rules: { 'ccsm/no-listener-slot-mutation': 'off' },
}
```

This is the only file allowed to publish a real Listener B into slot 1 — landing in v0.4. The bypass is grep-able as a single point so reviewers can audit it. Verified with a temporary `src/listeners/listener-b.ts` fixture containing `listenerSlots[1] = realB` — lint exits 0 (rule bypassed). Removed before commit.

## Reverse-verify

Baseline: `pnpm --filter @ccsm/daemon run lint` exits 0 against the existing src tree (no slot-1 writes today).

**Inject violation** — appended to `packages/daemon/src/listeners/array.ts`:

```ts
declare const fakeListener: Listener;
const slots: [Listener, Listener | ReservedForListenerB] = [fakeListener, RESERVED_FOR_LISTENER_B];
slots[1] = fakeListener;
```

Lint output:

```
C:\Users\jiahuigu\ccsm-worktrees\pool-4\packages\daemon\src\listeners\array.ts
  49:1  error  Assignment to listener tuple slot is forbidden in v0.3 — slot 1 is pinned to RESERVED_FOR_LISTENER_B until v0.4 (spec ch03 §1). Listener B activation is the only exception and must live in `listener-b.ts`  ccsm/no-listener-slot-mutation

✖ 1 problem (1 error, 0 warnings)
EXIT=1
```

**Remove fixture** (restore `array.ts`):

```
EXIT=0
```

## Quality gates (local, win32)

- `pnpm --filter @ccsm/daemon run lint` → exit 0
- `pnpm --filter @ccsm/daemon run test` → 3 files, 18 tests passed (10 lifecycle + 6 array + 2 rule-tester suites)
- `tsc --noEmit` (daemon) → exit 0

## Out of scope (per task brief)

- T10.3 `array-shape.spec.ts` is task #118.
- Listener A factory is T1.4; HTTP/2 transports are T1.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)