### PR TITLE
feat(electron/security): safeOpenUrl scheme allowlist (T6.9, Task #72)

### DIFF
--- a/electron/security/__tests__/safeOpenUrl.test.ts
+++ b/electron/security/__tests__/safeOpenUrl.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock `electron` before importing the SUT so the `shell` import resolves to
+// our spy. vitest hoists `vi.mock` above imports automatically.
+const openExternal = vi.fn(async (_url: string) => {});
+vi.mock('electron', () => ({
+  shell: {
+    openExternal: (url: string) => openExternal(url),
+  },
+}));
+
+import { safeOpenUrl, isSafeUrl, UnsafeUrlError } from '../safeOpenUrl';
+
+beforeEach(() => {
+  openExternal.mockClear();
+});
+
+describe('isSafeUrl', () => {
+  it('accepts https://', () => {
+    expect(isSafeUrl('https://example.com')).toBe(true);
+  });
+  it('accepts http://', () => {
+    expect(isSafeUrl('http://example.com/path?q=1#frag')).toBe(true);
+  });
+  it('rejects file://', () => {
+    expect(isSafeUrl('file:///etc/passwd')).toBe(false);
+  });
+  it('rejects javascript:', () => {
+    expect(isSafeUrl('javascript:alert(1)')).toBe(false);
+  });
+  it('rejects custom schemes', () => {
+    expect(isSafeUrl('vscode://settings')).toBe(false);
+    expect(isSafeUrl('slack://open')).toBe(false);
+    expect(isSafeUrl('mailto:a@b.com')).toBe(false);
+    expect(isSafeUrl('data:text/html,<script>1</script>')).toBe(false);
+  });
+  it('rejects malformed URLs', () => {
+    expect(isSafeUrl('not a url')).toBe(false);
+    expect(isSafeUrl('://broken')).toBe(false);
+  });
+  it('rejects empty / non-string', () => {
+    expect(isSafeUrl('')).toBe(false);
+    expect(isSafeUrl(undefined)).toBe(false);
+    expect(isSafeUrl(null)).toBe(false);
+    expect(isSafeUrl(42)).toBe(false);
+    expect(isSafeUrl({})).toBe(false);
+  });
+  it('is case-insensitive on the scheme (URL parser normalizes)', () => {
+    expect(isSafeUrl('HTTPS://example.com')).toBe(true);
+    expect(isSafeUrl('Http://example.com')).toBe(true);
+  });
+});
+
+describe('safeOpenUrl', () => {
+  it('forwards https:// URLs to shell.openExternal', async () => {
+    await safeOpenUrl('https://example.com/');
+    expect(openExternal).toHaveBeenCalledTimes(1);
+    expect(openExternal).toHaveBeenCalledWith('https://example.com/');
+  });
+
+  it('forwards http:// URLs to shell.openExternal', async () => {
+    await safeOpenUrl('http://example.com/path');
+    expect(openExternal).toHaveBeenCalledTimes(1);
+    expect(openExternal).toHaveBeenCalledWith('http://example.com/path');
+  });
+
+  it('rejects file:// without calling shell.openExternal', async () => {
+    await expect(safeOpenUrl('file:///etc/passwd')).rejects.toBeInstanceOf(UnsafeUrlError);
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+
+  it('rejects javascript: without calling shell.openExternal', async () => {
+    await expect(safeOpenUrl('javascript:alert(1)')).rejects.toBeInstanceOf(UnsafeUrlError);
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+
+  it('rejects custom schemes (vscode://, slack://, mailto:)', async () => {
+    for (const url of ['vscode://settings', 'slack://open', 'mailto:a@b.com']) {
+      openExternal.mockClear();
+      await expect(safeOpenUrl(url)).rejects.toBeInstanceOf(UnsafeUrlError);
+      expect(openExternal).not.toHaveBeenCalled();
+    }
+  });
+
+  it('rejects data: URLs', async () => {
+    await expect(safeOpenUrl('data:text/html,<script>1</script>')).rejects.toBeInstanceOf(
+      UnsafeUrlError,
+    );
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed URLs', async () => {
+    await expect(safeOpenUrl('not a url')).rejects.toBeInstanceOf(UnsafeUrlError);
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+
+  it('rejects empty string', async () => {
+    await expect(safeOpenUrl('')).rejects.toBeInstanceOf(UnsafeUrlError);
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-string inputs', async () => {
+    for (const v of [undefined, null, 42, {}, []]) {
+      openExternal.mockClear();
+      await expect(safeOpenUrl(v as unknown)).rejects.toBeInstanceOf(UnsafeUrlError);
+      expect(openExternal).not.toHaveBeenCalled();
+    }
+  });
+
+  it('UnsafeUrlError exposes url + scheme for callers', async () => {
+    try {
+      await safeOpenUrl('vscode://settings');
+      throw new Error('expected throw');
+    } catch (e) {
+      expect(e).toBeInstanceOf(UnsafeUrlError);
+      const err = e as UnsafeUrlError;
+      expect(err.url).toBe('vscode://settings');
+      expect(err.scheme).toBe('vscode:');
+      expect(err.name).toBe('UnsafeUrlError');
+    }
+  });
+
+  it('propagates shell.openExternal rejections unchanged', async () => {
+    openExternal.mockRejectedValueOnce(new Error('boom'));
+    await expect(safeOpenUrl('https://example.com')).rejects.toThrow('boom');
+  });
+});

--- a/electron/security/safeOpenUrl.ts
+++ b/electron/security/safeOpenUrl.ts
@@ -1,0 +1,76 @@
+// Scheme-allowlisted wrapper around Electron's `shell.openExternal` (Task #72,
+// T6.9 — spec: docs/superpowers/specs/2026-05-03-v03-daemon-split
+// /ch08-electron-renderer.md §9).
+//
+// `shell.openExternal` will happily hand a `file://`, `javascript:`, or
+// arbitrary custom-scheme URL straight to the OS-registered protocol handler,
+// which on every desktop platform is a code-execution primitive in disguise:
+//
+//   - `file://`     → opens local files / shares (UNC-style on Windows leaks
+//                     NTLM creds to attacker-chosen hosts; on macOS/Linux
+//                     reveals files the user never intended to expose).
+//   - `javascript:` → silently dropped by Chromium today, but historical
+//                     regressions have re-enabled it; not worth trusting.
+//   - custom (`vscode:`, `slack:`, `ms-cxh:`, ...) → triggers whatever the
+//                     user has registered, often with attacker-controlled
+//                     command-line arguments.
+//
+// All renderer-supplied URLs MUST flow through `safeOpenUrl`. Direct
+// `shell.openExternal(...)` calls in `electron/**` are forbidden — see the
+// repo lint check in CI.
+//
+// The allowlist is deliberately tight: only `http:` and `https:`. If a future
+// feature legitimately needs another scheme (e.g. `mailto:` from a help link)
+// it should be added here with a code comment explaining why, not bypassed at
+// the call site.
+
+import { shell } from 'electron';
+
+const ALLOWED_SCHEMES = new Set(['http:', 'https:']);
+
+export class UnsafeUrlError extends Error {
+  readonly url: string;
+  readonly scheme: string | null;
+  constructor(url: string, scheme: string | null, reason: string) {
+    super(`safeOpenUrl: refusing to open ${url} (${reason})`);
+    this.name = 'UnsafeUrlError';
+    this.url = url;
+    this.scheme = scheme;
+  }
+}
+
+// Pure decider: does this URL string belong to the allowlist? Exposed for
+// unit tests and for callers that want to validate-without-opening (e.g. to
+// gray out a "Open in browser" menu item before the user clicks).
+export function isSafeUrl(raw: unknown): raw is string {
+  if (typeof raw !== 'string' || raw.length === 0) return false;
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return false;
+  }
+  return ALLOWED_SCHEMES.has(parsed.protocol);
+}
+
+// Sink: validate, then delegate to `shell.openExternal`. Throws
+// `UnsafeUrlError` synchronously on a rejected URL so callers can surface the
+// failure (toast, logger, telemetry) rather than silently dropping the click.
+//
+// Returns the same `Promise<void>` as `shell.openExternal` so callers that
+// `await` it for sequencing keep working.
+export async function safeOpenUrl(raw: unknown): Promise<void> {
+  if (typeof raw !== 'string' || raw.length === 0) {
+    throw new UnsafeUrlError(String(raw), null, 'not a non-empty string');
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new UnsafeUrlError(raw, null, 'not a parseable URL');
+  }
+  if (!ALLOWED_SCHEMES.has(parsed.protocol)) {
+    throw new UnsafeUrlError(raw, parsed.protocol, `scheme ${parsed.protocol} not in allowlist`);
+  }
+  await shell.openExternal(raw);
+}


### PR DESCRIPTION
## Summary

Task #72 [T6.9]. Adds `electron/security/safeOpenUrl.ts`, a thin scheme-allowlisted wrapper around `shell.openExternal`. Only `http:` and `https:` are forwarded; `file://`, `javascript:`, `data:`, and arbitrary custom protocol handlers (`vscode://`, `slack://`, `mailto:`, ...) throw an `UnsafeUrlError` synchronously with the offending `url` + `scheme` attached for caller logging.

Spec reference (`docs/superpowers/specs/2026-05-03-v03-daemon-split/ch08-electron-renderer.md` §9) is not yet on disk in this branch; followed the documented intent from the task description. Module placed at `electron/security/safeOpenUrl.ts` rather than the spec's `packages/electron/src/main/...` because the actual repo layout has no `packages/` prefix and the security folder already hosts the analogous `ipcGuards.ts` module.

## Files

- `electron/security/safeOpenUrl.ts` (new) — `safeOpenUrl`, `isSafeUrl`, `UnsafeUrlError`.
- `electron/security/__tests__/safeOpenUrl.test.ts` (new) — 19 unit tests; mocks `electron.shell` via `vi.mock`.

## Replacing direct `shell.openExternal` callers

Grep confirms no direct caller in `electron/**` today:

```
$ rg "shell\.openExternal" electron/
(no matches)
```

The only references in the repo are a comment in `electron/window/createWindow.ts:206` and the `electron` stub in `tests/fixtures/electronStub.cjs:106`. Nothing to migrate; this lands as defense-in-depth for upcoming renderer "Open in browser" features.

## Test plan

- [x] `npx vitest run electron/security/__tests__/safeOpenUrl.test.ts` -> 19 passed
- [x] `npx eslint electron/security/safeOpenUrl.ts electron/security/__tests__/safeOpenUrl.test.ts` -> clean
- [x] `npx tsc --noEmit -p tsconfig.electron.json` -> clean
- [x] Require-load smoke (per dev.md §2 for new `electron/**` modules):
      `npx tsc -p tsconfig.electron.json && node -e "...require('./dist/electron/security/safeOpenUrl.js')..."` -> `OK loaded: [ 'UnsafeUrlError', 'isSafeUrl', 'safeOpenUrl' ]`

## Notes for reviewer

- `URL` parser normalizes scheme case, so `HTTPS://` and `Http://` are accepted (covered by test).
- `shell.openExternal` rejections propagate unchanged so callers can distinguish "OS launcher failed" from "we refused to launch".
- Allowlist is a `Set` constant at module scope — adding a future scheme (e.g. `mailto:` from a help link) is a one-line change with a code comment.