### PR TITLE
feat(daemon): T1.3 peer-cred auth interceptor (UDS / named-pipe / loopback-TCP)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -77,6 +77,13 @@ export default [
         requestAnimationFrame: 'readonly',
         cancelAnimationFrame: 'readonly',
         ResizeObserver: 'readonly',
+        // Web platform globals available in Node 22+ (used by daemon
+        // RPC code, e.g. T1.3 auth interceptor) and the Electron main
+        // process. Browser code already has these via the DOM lib.
+        Headers: 'readonly',
+        Request: 'readonly',
+        Response: 'readonly',
+        fetch: 'readonly',
         // `NodeJS` namespace is also referenced from renderer-side .d.ts
         // files (e.g. cliBridge.d.ts) that mirror preload types — keep it
         // available alongside browser globals.
@@ -148,6 +155,11 @@ export default [
         global: 'readonly',
         fetch: 'readonly',
         Response: 'readonly',
+        // `Headers` and `Request` are Node 22+ web-platform globals on
+        // par with `fetch` / `Response`; daemon RPC code uses `Headers`
+        // for Connect-RPC interop (T1.3 auth interceptor).
+        Headers: 'readonly',
+        Request: 'readonly',
         URLSearchParams: 'readonly'
       }
     }

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -13,6 +13,8 @@
     "build:sea:win": "powershell -ExecutionPolicy Bypass -File build/build-sea.ps1"
   },
   "dependencies": {
+    "@bufbuild/protobuf": "^2.12.0",
+    "@connectrpc/connect": "^2.1.1",
     "better-sqlite3": "^12.9.0"
   },
   "devDependencies": {

--- a/packages/daemon/src/auth/__tests__/interceptor.spec.ts
+++ b/packages/daemon/src/auth/__tests__/interceptor.spec.ts
@@ -1,0 +1,261 @@
+// Tests for the peer-cred Connect interceptor + the pure derivePrincipal
+// decision table. We drive the interceptor with a synthetic request /
+// next-fn pair so the tests stay decoupled from any HTTP/2 server
+// adapter (which lands in T1.5). Spec refs: ch03 §1, §5; ch05 §2, §3.
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  Code,
+  ConnectError,
+  createContextValues,
+  type StreamRequest,
+  type StreamResponse,
+  type UnaryRequest,
+  type UnaryResponse,
+} from '@connectrpc/connect';
+import {
+  PRINCIPAL_KEY,
+  TEST_BEARER_TOKEN,
+  derivePrincipal,
+  peerCredAuthInterceptor,
+} from '../interceptor.js';
+import { PEER_INFO_KEY, type PeerInfo } from '../peer-info.js';
+
+// ---- derivePrincipal: pure decision table ---------------------------------
+
+describe('derivePrincipal', () => {
+  it('UDS uid → local-user:<uid> with empty displayName', () => {
+    const p = derivePrincipal({ transport: 'uds', uid: 1000, gid: 100, pid: 1 });
+    expect(p).toEqual({ kind: 'local-user', uid: '1000', displayName: '' });
+  });
+
+  it('UDS uid 0 (root) is accepted — kernel-vouched, not a privilege check', () => {
+    // This module derives identity, NOT authorization. Spec ch05 §3 says
+    // uid MUST resolve; root is a valid uid. The supervisor admin
+    // allowlist (T1.7) is the place that restricts who may call /shutdown.
+    const p = derivePrincipal({ transport: 'uds', uid: 0, gid: 0, pid: 1 });
+    expect(p.uid).toBe('0');
+  });
+
+  it('UDS rejects negative uid (impossible from kernel; defensive)', () => {
+    expect(() => derivePrincipal({ transport: 'uds', uid: -1, gid: 0, pid: 1 })).toThrow(
+      ConnectError,
+    );
+  });
+
+  it('UDS rejects non-integer uid (defensive against addon bugs)', () => {
+    expect(() =>
+      derivePrincipal({ transport: 'uds', uid: 1.5, gid: 0, pid: 1 } as PeerInfo),
+    ).toThrow(/invalid uid/);
+  });
+
+  it('namedPipe SID → local-user:<sid> with the looked-up displayName', () => {
+    const sid = 'S-1-5-21-1111-2222-3333-1001';
+    const p = derivePrincipal({ transport: 'namedPipe', sid, displayName: 'JDOE' });
+    expect(p).toEqual({ kind: 'local-user', uid: sid, displayName: 'JDOE' });
+  });
+
+  it('namedPipe rejects empty SID with Unauthenticated', () => {
+    try {
+      derivePrincipal({ transport: 'namedPipe', sid: '', displayName: '' });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConnectError);
+      expect((err as ConnectError).code).toBe(Code.Unauthenticated);
+    }
+  });
+
+  it('loopbackTcp with the canonical test bearer token → local-user:test', () => {
+    const p = derivePrincipal({
+      transport: 'loopbackTcp',
+      bearerToken: TEST_BEARER_TOKEN,
+      remoteAddress: '127.0.0.1',
+      remotePort: 12345,
+    });
+    expect(p).toEqual({ kind: 'local-user', uid: 'test', displayName: 'test' });
+  });
+
+  it('loopbackTcp with a wrong bearer token → Unauthenticated', () => {
+    try {
+      derivePrincipal({
+        transport: 'loopbackTcp',
+        bearerToken: 'not-the-token',
+        remoteAddress: '127.0.0.1',
+        remotePort: 1,
+      });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConnectError);
+      expect((err as ConnectError).code).toBe(Code.Unauthenticated);
+    }
+  });
+
+  it('loopbackTcp with no bearer token → Unauthenticated (no anonymous loopback path)', () => {
+    expect(() =>
+      derivePrincipal({
+        transport: 'loopbackTcp',
+        bearerToken: null,
+        remoteAddress: '127.0.0.1',
+        remotePort: 1,
+      }),
+    ).toThrow(ConnectError);
+  });
+});
+
+// ---- peerCredAuthInterceptor: end-to-end behavior --------------------------
+
+/** Connect's `Interceptor` is `(next: AnyFn) => AnyFn` where AnyFn handles
+ * either a UnaryRequest or a StreamRequest. To satisfy the generic type
+ * the mock `next` we feed the interceptor MUST accept the union; build a
+ * tiny helper so each test stays readable. */
+type AnyReq = UnaryRequest | StreamRequest;
+type AnyResp = UnaryResponse | StreamResponse;
+function makeNext(): ReturnType<typeof vi.fn<(r: AnyReq) => Promise<AnyResp>>> {
+  return vi.fn(
+    async (r: AnyReq): Promise<AnyResp> => ({
+      stream: false,
+      service: r.service,
+      method: r.method as UnaryResponse['method'],
+      header: new Headers(),
+      trailer: new Headers(),
+      message: {} as never,
+    }),
+  );
+}
+
+/** Minimal synthetic UnaryRequest skeleton — only the contextValues + the
+ * shape needed by the interceptor are populated. The interceptor never
+ * looks at `service` / `method` / `header` etc., so we leave them as
+ * placeholder casts; the call shape is tested, not Connect's framing. */
+function makeReq(peer: PeerInfo): UnaryRequest {
+  const ctx = createContextValues();
+  ctx.set(PEER_INFO_KEY, peer);
+  return {
+    stream: false,
+    contextValues: ctx,
+    header: new Headers(),
+    // Fields below are required by the type but unused by the interceptor.
+    service: {} as UnaryRequest['service'],
+    method: {} as UnaryRequest['method'],
+    requestMethod: 'POST',
+    url: 'http://test/x',
+    signal: new AbortController().signal,
+    message: {} as never,
+  };
+}
+
+describe('peerCredAuthInterceptor', () => {
+  it('publishes a Principal under PRINCIPAL_KEY and continues the chain (UDS)', async () => {
+    const req = makeReq({ transport: 'uds', uid: 1000, gid: 100, pid: 42 });
+    const next = makeNext();
+
+    await peerCredAuthInterceptor(next)(req);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    const principal = req.contextValues.get(PRINCIPAL_KEY);
+    expect(principal).toEqual({ kind: 'local-user', uid: '1000', displayName: '' });
+  });
+
+  it('publishes a Principal for a Windows named-pipe peer', async () => {
+    const sid = 'S-1-5-21-1004336348-1177238915-682003330-1001';
+    const req = makeReq({ transport: 'namedPipe', sid, displayName: 'jdoe' });
+    const next = makeNext();
+
+    await peerCredAuthInterceptor(next)(req);
+
+    expect(req.contextValues.get(PRINCIPAL_KEY)).toEqual({
+      kind: 'local-user',
+      uid: sid,
+      displayName: 'jdoe',
+    });
+  });
+
+  it('accepts the test bearer token over loopback TCP and emits the test principal', async () => {
+    const req = makeReq({
+      transport: 'loopbackTcp',
+      bearerToken: TEST_BEARER_TOKEN,
+      remoteAddress: '127.0.0.1',
+      remotePort: 33333,
+    });
+    const next = makeNext();
+
+    await peerCredAuthInterceptor(next)(req);
+
+    expect(req.contextValues.get(PRINCIPAL_KEY)).toEqual({
+      kind: 'local-user',
+      uid: 'test',
+      displayName: 'test',
+    });
+  });
+
+  it('rejects a loopback request without the bearer token (Unauthenticated, no handler called)', async () => {
+    const req = makeReq({
+      transport: 'loopbackTcp',
+      bearerToken: null,
+      remoteAddress: '127.0.0.1',
+      remotePort: 1,
+    });
+    const next = makeNext();
+
+    await expect(peerCredAuthInterceptor(next)(req)).rejects.toMatchObject({
+      code: Code.Unauthenticated,
+    });
+    expect(next).not.toHaveBeenCalled();
+    // Critically: PRINCIPAL_KEY remains the null sentinel so a leaky
+    // handler still observes the unauthenticated state explicitly.
+    expect(req.contextValues.get(PRINCIPAL_KEY)).toBeNull();
+  });
+
+  it('rejects a loopback request with a wrong token', async () => {
+    const req = makeReq({
+      transport: 'loopbackTcp',
+      bearerToken: 'sneaky',
+      remoteAddress: '127.0.0.1',
+      remotePort: 1,
+    });
+    await expect(peerCredAuthInterceptor(makeNext())(req)).rejects.toMatchObject({
+      code: Code.Unauthenticated,
+    });
+  });
+
+  it('rejects when the transport adapter forgot to set PEER_INFO_KEY (sentinel default)', async () => {
+    // Build a request WITHOUT calling makeReq — leave PEER_INFO_KEY at
+    // its NO_PEER_INFO default. Spec ch05 §2: there is no "no principal"
+    // code path; the interceptor must reject before the handler runs.
+    const ctx = createContextValues();
+    const req: UnaryRequest = {
+      stream: false,
+      contextValues: ctx,
+      header: new Headers(),
+      service: {} as UnaryRequest['service'],
+      method: {} as UnaryRequest['method'],
+      requestMethod: 'POST',
+      url: 'http://test/x',
+      signal: new AbortController().signal,
+      message: {} as never,
+    };
+    const next = makeNext();
+
+    await expect(peerCredAuthInterceptor(next)(req)).rejects.toMatchObject({
+      code: Code.Unauthenticated,
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('translates a non-ConnectError throw into ConnectError(Unauthenticated)', async () => {
+    // Force derivePrincipal to fail with a plain Error by feeding an
+    // unknown transport via cast; the interceptor must wrap it into a
+    // ConnectError. (Negative uid throws a ConnectError already; this
+    // path covers the non-ConnectError wrap branch.)
+    const req = makeReq({
+      transport: 'mystery' as 'uds',
+      uid: 1,
+      gid: 1,
+      pid: 1,
+    } as PeerInfo);
+
+    await expect(peerCredAuthInterceptor(makeNext())(req)).rejects.toMatchObject({
+      code: Code.Unauthenticated,
+    });
+  });
+});

--- a/packages/daemon/src/auth/__tests__/peer-cred.spec.ts
+++ b/packages/daemon/src/auth/__tests__/peer-cred.spec.ts
@@ -1,0 +1,109 @@
+// Tests for the per-OS peer-cred extractors. The extractors are
+// transport adapters' producers — pure (modulo the injected lookup
+// callback) so we exercise them with mock callbacks instead of real
+// sockets. Spec refs: ch03 §5 derivation mechanism table; ch05 §3
+// derivation rules per transport.
+
+import { describe, expect, it } from 'vitest';
+import {
+  extractLoopbackTcpPeer,
+  extractNamedPipePeerCred,
+  extractUdsPeerCred,
+  unsupportedNamedPipeLookup,
+  unsupportedUdsLookup,
+} from '../peer-cred.js';
+
+// We never actually pass a real net.Socket to the extractors — the
+// injected `lookup` callback is the only consumer of the socket arg, and
+// our tests inject mocks. Cast through `unknown` to satisfy the type.
+const FAKE_SOCKET = {} as unknown as Parameters<typeof extractUdsPeerCred>[0];
+
+describe('extractUdsPeerCred', () => {
+  it('returns a uds-tagged PeerInfo from the lookup callback', () => {
+    const result = extractUdsPeerCred(FAKE_SOCKET, () => ({ uid: 1000, gid: 100, pid: 4321 }));
+    expect(result).toEqual({ transport: 'uds', uid: 1000, gid: 100, pid: 4321 });
+  });
+
+  it('passes through a null pid (macOS LOCAL_PEERPID may be unavailable)', () => {
+    const result = extractUdsPeerCred(FAKE_SOCKET, () => ({ uid: 501, gid: 20, pid: null }));
+    expect(result.pid).toBeNull();
+  });
+
+  it('throws via the unsupported default when no lookup is wired', () => {
+    expect(() => extractUdsPeerCred(FAKE_SOCKET)).toThrow(/UDS peer-cred lookup not wired/);
+    expect(() => unsupportedUdsLookup(FAKE_SOCKET)).toThrow();
+  });
+
+  it('propagates a syscall failure (kernel rejects getsockopt)', () => {
+    expect(() =>
+      extractUdsPeerCred(FAKE_SOCKET, () => {
+        throw new Error('ENOTCONN');
+      }),
+    ).toThrow(/ENOTCONN/);
+  });
+});
+
+describe('extractNamedPipePeerCred', () => {
+  it('returns a namedPipe-tagged PeerInfo with SID + display name', () => {
+    const sid = 'S-1-5-21-1111-2222-3333-1001';
+    const result = extractNamedPipePeerCred(FAKE_SOCKET, () => ({
+      sid,
+      displayName: 'JDOE',
+    }));
+    expect(result).toEqual({ transport: 'namedPipe', sid, displayName: 'JDOE' });
+  });
+
+  it('allows an empty display name (best-effort lookup, spec ch05 §2)', () => {
+    const sid = 'S-1-5-21-9-9-9-1001';
+    const result = extractNamedPipePeerCred(FAKE_SOCKET, () => ({ sid, displayName: '' }));
+    expect(result.displayName).toBe('');
+  });
+
+  it('rejects an empty SID — uid MUST resolve (spec ch05 §3)', () => {
+    expect(() =>
+      extractNamedPipePeerCred(FAKE_SOCKET, () => ({ sid: '', displayName: 'X' })),
+    ).toThrow(/empty SID/);
+  });
+
+  it('throws via the unsupported default when no lookup is wired', () => {
+    expect(() => extractNamedPipePeerCred(FAKE_SOCKET)).toThrow(
+      /Named-pipe peer-cred lookup not wired/,
+    );
+    expect(() => unsupportedNamedPipeLookup(FAKE_SOCKET)).toThrow();
+  });
+});
+
+describe('extractLoopbackTcpPeer', () => {
+  it('parses a Bearer token from the Authorization header', () => {
+    const headers = new Headers({ Authorization: 'Bearer test-token' });
+    const result = extractLoopbackTcpPeer(headers, '127.0.0.1', 54871);
+    expect(result).toEqual({
+      transport: 'loopbackTcp',
+      bearerToken: 'test-token',
+      remoteAddress: '127.0.0.1',
+      remotePort: 54871,
+    });
+  });
+
+  it('matches the Bearer scheme case-insensitively (RFC 6750 §2.1)', () => {
+    const headers = new Headers({ Authorization: 'bEaReR test-token' });
+    expect(extractLoopbackTcpPeer(headers, '::1', 1).bearerToken).toBe('test-token');
+  });
+
+  it('returns bearerToken=null when the header is absent', () => {
+    const result = extractLoopbackTcpPeer(new Headers(), '127.0.0.1', 1234);
+    expect(result.bearerToken).toBeNull();
+  });
+
+  it('returns bearerToken=null for a non-Bearer scheme (e.g. Basic)', () => {
+    const headers = new Headers({ Authorization: 'Basic dXNlcjpwdw==' });
+    expect(extractLoopbackTcpPeer(headers, '127.0.0.1', 1234).bearerToken).toBeNull();
+  });
+
+  it('preserves diagnostic remoteAddress / remotePort regardless of auth outcome', () => {
+    const headers = new Headers();
+    const result = extractLoopbackTcpPeer(headers, '10.0.0.5', 65535);
+    expect(result.remoteAddress).toBe('10.0.0.5');
+    expect(result.remotePort).toBe(65535);
+  });
+});

--- a/packages/daemon/src/auth/__tests__/principal.spec.ts
+++ b/packages/daemon/src/auth/__tests__/principal.spec.ts
@@ -1,0 +1,34 @@
+// Tests for the principal model — pure functions, exhaustive switch.
+// Spec refs: ch05 §1 Principal model + principalKey format.
+
+import { describe, expect, it } from 'vitest';
+import { principalKey, type Principal } from '../principal.js';
+
+describe('principalKey', () => {
+  it('formats a linux uid principal as "local-user:<uid>"', () => {
+    const p: Principal = { kind: 'local-user', uid: '1000', displayName: 'jdoe' };
+    expect(principalKey(p)).toBe('local-user:1000');
+  });
+
+  it('formats a Windows SID principal verbatim (SID already string-form)', () => {
+    const p: Principal = {
+      kind: 'local-user',
+      uid: 'S-1-5-21-1004336348-1177238915-682003330-1001',
+      displayName: 'JDOE',
+    };
+    expect(principalKey(p)).toBe(
+      'local-user:S-1-5-21-1004336348-1177238915-682003330-1001',
+    );
+  });
+
+  it('formats the test loopback principal as "local-user:test"', () => {
+    const p: Principal = { kind: 'local-user', uid: 'test', displayName: 'test' };
+    expect(principalKey(p)).toBe('local-user:test');
+  });
+
+  it('does NOT include displayName in the key (advisory only — spec ch05 §1)', () => {
+    const a: Principal = { kind: 'local-user', uid: '1000', displayName: 'Alice' };
+    const b: Principal = { kind: 'local-user', uid: '1000', displayName: 'Bob' };
+    expect(principalKey(a)).toBe(principalKey(b));
+  });
+});

--- a/packages/daemon/src/auth/index.ts
+++ b/packages/daemon/src/auth/index.ts
@@ -1,0 +1,51 @@
+// @ccsm/daemon auth subsystem — peer-cred authentication for Listener A.
+//
+// Spec refs:
+//   - ch03 §1 Listener trait + AuthMiddleware composition.
+//   - ch03 §5 per-transport mechanism table.
+//   - ch05 §1-§3 Principal model, single-principal invariant, derivation
+//     rules per transport.
+//
+// Public surface (consumed by T1.4 makeListenerA + T1.5 transport adapters):
+//   - `Principal` / `principalKey` — discriminated union mirroring the
+//     proto oneof, plus the canonical `owner_id` formatter.
+//   - `PeerInfo` + `PEER_INFO_KEY` — transport adapters write per-call peer
+//     credentials onto the Connect contextValues under this key.
+//   - `peerCredAuthInterceptor` + `PRINCIPAL_KEY` — the interceptor reads
+//     `PEER_INFO_KEY`, derives a `Principal`, publishes it under
+//     `PRINCIPAL_KEY`, throws Unauthenticated on failure.
+//   - `extractUdsPeerCred` / `extractNamedPipePeerCred` /
+//     `extractLoopbackTcpPeer` — per-OS extractor helpers transport
+//     adapters call at accept-time to build a `PeerInfo`.
+//
+// `derivePrincipal` is exported for unit-test reuse (decision table is
+// tested independently of the Connect interceptor plumbing).
+
+export type { Principal } from './principal.js';
+export { principalKey } from './principal.js';
+export type {
+  PeerInfo,
+  UdsPeerCred,
+  NamedPipePeerCred,
+  LoopbackTcpPeer,
+} from './peer-info.js';
+export { PEER_INFO_KEY, NO_PEER_INFO } from './peer-info.js';
+export type {
+  UdsLookup,
+  UdsLookupResult,
+  NamedPipeLookup,
+  NamedPipeLookupResult,
+} from './peer-cred.js';
+export {
+  extractUdsPeerCred,
+  extractNamedPipePeerCred,
+  extractLoopbackTcpPeer,
+  unsupportedUdsLookup,
+  unsupportedNamedPipeLookup,
+} from './peer-cred.js';
+export {
+  PRINCIPAL_KEY,
+  TEST_BEARER_TOKEN,
+  derivePrincipal,
+  peerCredAuthInterceptor,
+} from './interceptor.js';

--- a/packages/daemon/src/auth/interceptor.ts
+++ b/packages/daemon/src/auth/interceptor.ts
@@ -1,0 +1,198 @@
+// Connect-RPC peer-cred auth interceptor — derives `ctx.principal` from
+// the `PeerInfo` deposited on the request's `contextValues` by the HTTP/2
+// server adapter. Single decider for v0.3's only authn mechanism.
+//
+// Spec refs:
+//   - ch03 §1 Listener trait + AuthMiddleware shape (`before(...)` chain).
+//   - ch03 §5 per-transport mechanism table.
+//   - ch05 §2 the daemon does NOT have a "no principal" code path — every
+//     handler reads `ctx.principal` and assumes it is set; the interceptor
+//     throws `Unauthenticated` *before* any handler runs if derivation
+//     fails. This invariant is the security baseline.
+//   - ch05 §3 derivation rules per transport.
+//
+// SRP: this module is a *decider*. It does not perform any I/O, does not
+// touch the socket, does not call out to the OS. The OS-specific syscalls
+// live in `./peer-cred.ts` extractors; this file just maps the resulting
+// `PeerInfo` discriminated union onto the matching `Principal` shape, sets
+// the `Principal` on `contextValues`, and either continues the call chain
+// or throws.
+//
+// Layering rationale (Connect-RPC interceptor vs. AuthMiddleware trait):
+// the spec ch03 §1 `AuthMiddleware.before(...)` shape is a v0.4-friendly
+// abstraction for *composing* auth links (peer-cred → JWT). For v0.3's
+// single-link chain on Listener A, a Connect interceptor is the correct
+// concrete realization: Connect already routes interceptor errors as
+// `ConnectError` to the transport, and the contextValues mechanism is the
+// blessed way to plumb per-call data into handlers. v0.4's JWT validator
+// will be a second interceptor in the same array (`[peerCredAuthInterceptor,
+// jwtValidatorInterceptor]`), composed left-to-right, matching the
+// spec's `authChain[0]` then `authChain[1]` order.
+
+import {
+  Code,
+  ConnectError,
+  createContextKey,
+  type Interceptor,
+} from '@connectrpc/connect';
+import { PEER_INFO_KEY, type PeerInfo } from './peer-info.js';
+import type { Principal } from './principal.js';
+
+/**
+ * The single forever-stable bearer token that loopback-TCP callers MUST
+ * supply during dev / test. Matches the spec's intent that loopback is NOT
+ * production transport (spec ch03 §4 — UDS/named-pipe are the production
+ * picks; loopback is fallback gated behind MUST-SPIKE) and the manager's
+ * T1.3 scope of "Authorization: Bearer test-token; principal=test".
+ *
+ * Constant kept narrow: a single value, not a configurable allowlist. v0.4
+ * will rip out the loopback path entirely once Listener B (TLS+JWT) lands;
+ * any production loopback caller before then would be a mistake the test
+ * token catches in code review.
+ */
+export const TEST_BEARER_TOKEN = 'test-token';
+
+/** Principal for authenticated test-token loopback callers. Matches the
+ * spec's discriminator (`local-user`) so handlers see no special case;
+ * `uid: 'test'` is the canonical owner_id segment (`local-user:test`). */
+const TEST_PRINCIPAL: Principal = {
+  kind: 'local-user',
+  uid: 'test',
+  displayName: 'test',
+};
+
+/**
+ * Connect contextValues key under which the interceptor publishes the
+ * derived `Principal`. Handlers read it via
+ * `req.contextValues.get(PRINCIPAL_KEY)`.
+ *
+ * Default is `null` — but the interceptor THROWS before any handler runs
+ * if derivation fails, so a handler that observes `null` here is a wiring
+ * bug (the interceptor was not installed). The null sentinel is the
+ * cheapest way to make that bug throw a NullPointer-style runtime error
+ * at the first deref instead of silently treating the call as anonymous.
+ */
+export const PRINCIPAL_KEY = createContextKey<Principal | null>(null, {
+  description: 'ccsm.daemon.auth.principal',
+});
+
+/**
+ * Derive a `Principal` from a `PeerInfo`. Pure function; no I/O. Throws
+ * `ConnectError(Unauthenticated)` if the `PeerInfo` does not carry enough
+ * information to produce a principal (spec ch05 §3 `uid MUST resolve`).
+ *
+ * Exported separately from `peerCredAuthInterceptor` so unit tests can
+ * exercise the derivation table without going through the Connect
+ * interceptor plumbing.
+ */
+export function derivePrincipal(peer: PeerInfo): Principal {
+  switch (peer.transport) {
+    case 'uds': {
+      // Linux / macOS UDS: kernel-vouched uid via SO_PEERCRED /
+      // LOCAL_PEERCRED. Numeric uid stringified per spec ch05 §3.
+      // displayName lookup (getpwuid_r / dscl) is best-effort and lives
+      // in T1.5 alongside the native addon — for T1.3 we leave it empty
+      // (spec ch05 §3 explicitly allows empty when lookup fails).
+      if (!Number.isInteger(peer.uid) || peer.uid < 0) {
+        throw new ConnectError(
+          'invalid uid from UDS peer-cred',
+          Code.Unauthenticated,
+        );
+      }
+      return { kind: 'local-user', uid: String(peer.uid), displayName: '' };
+    }
+    case 'namedPipe': {
+      // Windows: ImpersonateNamedPipeClient → SID. SID-as-string is the
+      // canonical form for `LocalUser.uid` per spec ch05 §3 — no separate
+      // `sid` field on the principal (spec ch03 §5 commentary).
+      if (peer.sid === '') {
+        throw new ConnectError(
+          'empty SID from named-pipe peer-cred',
+          Code.Unauthenticated,
+        );
+      }
+      return { kind: 'local-user', uid: peer.sid, displayName: peer.displayName };
+    }
+    case 'loopbackTcp': {
+      // Test-only path: spec ch03 §4 lists loopback as a MUST-SPIKE
+      // fallback; v0.3 production is UDS / named-pipe. We accept exactly
+      // one stable bearer token (TEST_BEARER_TOKEN) so unit tests + smoke
+      // harnesses can drive the daemon without standing up a UDS. Any
+      // other shape (missing token, wrong token, wrong scheme) is a hard
+      // Unauthenticated — there is intentionally no "anonymous loopback"
+      // path (spec ch05 §2 invariant).
+      if (peer.bearerToken !== TEST_BEARER_TOKEN) {
+        throw new ConnectError(
+          'loopback transport requires test bearer token',
+          Code.Unauthenticated,
+        );
+      }
+      return TEST_PRINCIPAL;
+    }
+    default: {
+      const _exhaustive: never = peer;
+      throw new ConnectError(
+        `unknown peer-info transport: ${String((_exhaustive as { transport: string }).transport)}`,
+        Code.Unauthenticated,
+      );
+    }
+  }
+}
+
+/**
+ * The Connect interceptor. Composed into the server's interceptor list
+ * during T1.4's `makeListenerA` factory; runs FIRST in the chain so every
+ * downstream interceptor + handler can rely on `PRINCIPAL_KEY` being set.
+ *
+ * Behavior:
+ *  1. Read `PEER_INFO_KEY` from `req.contextValues`. If the transport
+ *     adapter forgot to populate it (sentinel default) → Unauthenticated.
+ *  2. Derive `Principal` via `derivePrincipal`. Throws translate to
+ *     `ConnectError(Unauthenticated)` directly if not already.
+ *  3. Stash the principal under `PRINCIPAL_KEY` and continue the chain.
+ *
+ * Errors thrown here surface to the client as Connect's standard
+ * `Unauthenticated` code; spec ch05 §3 / ch03 §5 say "Electron handles by
+ * reconnecting" — the interceptor does not retry, log, or otherwise
+ * decorate the failure beyond the spec's required code.
+ */
+export const peerCredAuthInterceptor: Interceptor = (next) => async (req) => {
+  const peer = req.contextValues.get(PEER_INFO_KEY);
+
+  // Detect the sentinel default — the transport adapter forgot to set
+  // PEER_INFO_KEY for this request. Spec ch05 §2: there is no "no
+  // principal" code path; reject before any handler can read context.
+  // We compare on the `bearerToken === null && remoteAddress === ''`
+  // shape rather than reference-equality with `NO_PEER_INFO` because
+  // contextValues clones the default on each get in some Connect
+  // versions (defensive — works regardless of the runtime's behavior).
+  if (
+    peer.transport === 'loopbackTcp' &&
+    peer.bearerToken === null &&
+    peer.remoteAddress === '' &&
+    peer.remotePort === 0
+  ) {
+    throw new ConnectError(
+      'transport did not provide peer credentials',
+      Code.Unauthenticated,
+    );
+  }
+
+  let principal: Principal;
+  try {
+    principal = derivePrincipal(peer);
+  } catch (err) {
+    // Re-throw ConnectError as-is (already typed); wrap any other throw
+    // (e.g., a native-addon syscall failure that bubbled up from an
+    // earlier extractor that deferred its lookup) into Unauthenticated
+    // so the wire surface stays uniform.
+    if (err instanceof ConnectError) throw err;
+    throw new ConnectError(
+      err instanceof Error ? err.message : 'peer-cred derivation failed',
+      Code.Unauthenticated,
+    );
+  }
+
+  req.contextValues.set(PRINCIPAL_KEY, principal);
+  return next(req);
+};

--- a/packages/daemon/src/auth/peer-cred.ts
+++ b/packages/daemon/src/auth/peer-cred.ts
@@ -1,0 +1,164 @@
+// Per-OS peer-credential extractors — derive a `PeerInfo` from an
+// already-accepted Node socket. Used by the HTTP/2 server adapter (T1.5)
+// the moment a connection is accepted, BEFORE the request reaches any
+// Connect handler.
+//
+// Spec refs:
+//   - ch03 §5 per-transport mechanism table.
+//   - ch05 §3 derivation rules table.
+//
+// SRP: each function in this module is a *producer* — given a socket plus
+// the transport kind it was bound on, it returns a `PeerInfo` (or throws).
+// The functions do NOT touch Connect, do NOT touch handlers, do NOT mutate
+// shared state. The interceptor (./interceptor.ts) is the lone decider
+// that turns `PeerInfo` into a `Principal`.
+//
+// Layer 1 — repo-internal alternatives checked:
+//   - Node's `net.Socket` exposes no SO_PEERCRED helper. There is no
+//     `net.Socket.getPeerCredentials()` API.
+//   - The `unix-dgram` / `unix-socket-credentials` npm packages are
+//     unmaintained and ship native add-ons; introducing one is a
+//     dependency burden when the only consumer is daemon-internal.
+//   - The minimal native FFI required (single `getsockopt(2)` per accept)
+//     fits a tiny addon that T1.5 will land alongside the HTTP/2-over-UDS
+//     transport (the right place — the addon needs the same toolchain as
+//     the http2 server). T1.3 defines the *interface* the addon will
+//     satisfy and an injection seam so T1.5 can plug in the syscall
+//     without re-shaping consumer code.
+//
+// Concretely: each extractor accepts a `lookup` callback that performs the
+// OS-specific syscall. T1.5 will provide a real implementation backed by
+// the native addon; T1.3 ships a default `unsupported` implementation that
+// throws `OperationUnsupported` so missing wiring fails loud at boot
+// instead of silently degrading to a "no principal" path (forbidden by
+// spec ch05 §2 — the daemon does NOT have a "no principal" code path).
+
+import type { Socket } from 'node:net';
+import type { LoopbackTcpPeer, NamedPipePeerCred, UdsPeerCred } from './peer-info.js';
+
+/**
+ * Result of an OS-level peer-cred lookup on a UDS socket. Returned by the
+ * `udsLookup` callback that T1.5's native addon will provide. Plain shape
+ * (no `PeerInfo` discriminator) so the addon stays unaware of the auth
+ * module's wire vocabulary.
+ */
+export interface UdsLookupResult {
+  readonly uid: number;
+  readonly gid: number;
+  /** May be `null` on macOS — see `peer-info.ts` UdsPeerCred docs. */
+  readonly pid: number | null;
+}
+
+/**
+ * Result of a named-pipe peer-cred lookup (Windows). `displayName` is
+ * best-effort: empty string when `LookupAccountSid` cannot resolve the
+ * SID (orphan SIDs from deleted local accounts).
+ */
+export interface NamedPipeLookupResult {
+  readonly sid: string;
+  readonly displayName: string;
+}
+
+/** Synchronous syscall callback contract for UDS peer-cred lookup. */
+export type UdsLookup = (socket: Socket) => UdsLookupResult;
+
+/** Synchronous syscall callback contract for named-pipe peer-cred lookup. */
+export type NamedPipeLookup = (socket: Socket) => NamedPipeLookupResult;
+
+/**
+ * Default UDS lookup — throws `OperationUnsupported` so a transport that
+ * forgot to wire T1.5's addon fails loud at the first connection rather
+ * than silently rejecting every caller as `Unauthenticated` (which would
+ * still be safe but would confuse operators chasing "why does nobody
+ * connect"). The error message names the seam so the fix is one grep away.
+ */
+export const unsupportedUdsLookup: UdsLookup = () => {
+  throw new Error(
+    'UDS peer-cred lookup not wired — provide a `UdsLookup` callback to extractUdsPeerCred (T1.5 native addon).',
+  );
+};
+
+/** Default named-pipe lookup — same fail-loud philosophy as `unsupportedUdsLookup`. */
+export const unsupportedNamedPipeLookup: NamedPipeLookup = () => {
+  throw new Error(
+    'Named-pipe peer-cred lookup not wired — provide a `NamedPipeLookup` callback to extractNamedPipePeerCred (T1.5 native addon).',
+  );
+};
+
+/**
+ * Extract UDS peer credentials from an accepted socket. Spec ch03 §5
+ * (linux: `getsockopt(SO_PEERCRED)`; macOS: `getsockopt(LOCAL_PEERCRED)`).
+ *
+ * Throws (typically the addon's own error) if the kernel rejects the
+ * syscall — e.g., the peer process exited between accept(2) and
+ * getsockopt(2). Caller (the interceptor) translates the throw into a
+ * Connect `Unauthenticated` error.
+ */
+export function extractUdsPeerCred(
+  socket: Socket,
+  lookup: UdsLookup = unsupportedUdsLookup,
+): UdsPeerCred {
+  const { uid, gid, pid } = lookup(socket);
+  return { transport: 'uds', uid, gid, pid };
+}
+
+/**
+ * Extract named-pipe peer credentials from an accepted socket on Windows.
+ * Spec ch03 §5 / ch05 §3: `ImpersonateNamedPipeClient` + `OpenThreadToken`
+ * + `GetTokenInformation(TokenUser)` → SID; `LookupAccountSid` for the
+ * advisory display name.
+ *
+ * Returns the SID as a string in canonical Windows form (`S-1-5-21-...`).
+ * `displayName` may be empty (best-effort, never used for authorization
+ * per spec ch05 §2).
+ */
+export function extractNamedPipePeerCred(
+  socket: Socket,
+  lookup: NamedPipeLookup = unsupportedNamedPipeLookup,
+): NamedPipePeerCred {
+  const { sid, displayName } = lookup(socket);
+  if (sid === '') {
+    // Empty SID is a derivation failure (the kernel would never return
+    // this; an addon bug or mocked lookup that returned it must not be
+    // accepted as a valid principal — spec ch05 §3 `uid MUST resolve`).
+    throw new Error('named-pipe lookup returned empty SID');
+  }
+  return { transport: 'namedPipe', sid, displayName };
+}
+
+/**
+ * Extract loopback-TCP peer "credentials" from request headers. The
+ * loopback transport is dev/test only in v0.3 (Listener A binds UDS or
+ * named-pipe in production; loopback is a fallback the brief explicitly
+ * gates behind a MUST-SPIKE — see spec ch03 §4). For T1.3 we accept a
+ * stable test bearer token; T1.5 may upgrade this to PID-based synthesis
+ * if the spike forces loopback into production.
+ *
+ * `headers` is the standard WHATWG `Headers` instance the HTTP/2 adapter
+ * already has on the request; `remoteAddress` / `remotePort` come from
+ * the underlying `net.Socket` for diagnostics.
+ */
+export function extractLoopbackTcpPeer(
+  headers: Headers,
+  remoteAddress: string,
+  remotePort: number,
+): LoopbackTcpPeer {
+  const authz = headers.get('authorization');
+  let bearerToken: string | null = null;
+  if (authz !== null) {
+    // Match `Bearer <token>` case-insensitively per RFC 6750 §2.1, but
+    // the token itself is case-sensitive. We do NOT trim the token —
+    // any internal whitespace is part of the token and a mismatch should
+    // (intentionally) reject it.
+    const match = /^Bearer\s+(.+)$/i.exec(authz);
+    if (match !== null) {
+      bearerToken = match[1] ?? null;
+    }
+  }
+  return {
+    transport: 'loopbackTcp',
+    bearerToken,
+    remoteAddress,
+    remotePort,
+  };
+}

--- a/packages/daemon/src/auth/peer-info.ts
+++ b/packages/daemon/src/auth/peer-info.ts
@@ -1,0 +1,112 @@
+// PeerInfo — the transport-neutral envelope produced by per-OS peer-cred
+// extractors and consumed by the auth interceptor (./interceptor.ts).
+//
+// Spec refs:
+//   - ch03 §1 PeerInfo shape (`uds?` / `loopback?`).
+//   - ch03 §5 per-transport derivation mechanism.
+//   - ch05 §3 derivation rules table.
+//
+// The envelope is a closed discriminated union via the `transport` tag.
+// One field is populated per accepted connection; the others are absent.
+// The HTTP/2 server adapter (T1.5) inspects the underlying socket on each
+// connection and writes a `PeerInfo` into the Connect `contextValues` under
+// `PEER_INFO_KEY`. The interceptor reads it back, derives a `Principal`,
+// and stores the `Principal` under `PRINCIPAL_KEY` for downstream handlers.
+//
+// Why a tagged union and not separate `uds`/`loopback`/`namedPipe` optional
+// fields: the spec lists three concrete transports (UDS, named pipe,
+// loopback TCP). Forgetting to populate exactly one is a bug; an
+// optional-field shape silently degrades to "no principal" instead of
+// throwing — discriminated union forces the producer to pick a variant.
+
+import { createContextKey } from '@connectrpc/connect';
+
+/**
+ * UDS peer credentials — produced by `getsockopt(SO_PEERCRED)` on linux
+ * and `getsockopt(LOCAL_PEERCRED)` on macOS. The kernel returns the uid /
+ * gid of the process that owns the connecting end of the socket at
+ * connect-time; this is race-free relative to the accept call (the kernel
+ * snapshots the credentials when the connection is established).
+ *
+ * `pid` is not always available on macOS (xucred carries `cr_uid` but the
+ * peer pid requires `LOCAL_PEERPID` as a separate `getsockopt`); leave it
+ * `null` rather than fabricating zero. Callers MUST NOT rely on `pid` for
+ * authorization — only `uid` is the security principal (spec ch03 §5).
+ */
+export interface UdsPeerCred {
+  readonly transport: 'uds';
+  readonly uid: number;
+  readonly gid: number;
+  readonly pid: number | null;
+}
+
+/**
+ * Windows named-pipe peer credentials — produced by
+ * `ImpersonateNamedPipeClient` + `OpenThreadToken` +
+ * `GetTokenInformation(TokenUser)`. The SID is the security identifier of
+ * the user account that owns the connecting process; `LookupAccountSid`
+ * resolves it to a display name (best-effort, may fail for orphan SIDs
+ * from deleted local accounts — empty string in that case).
+ *
+ * SID-as-string form is the canonical Windows representation (e.g.,
+ * `S-1-5-21-...-1001`). Spec ch05 §3 pins this as the `uid` value for
+ * the `local-user` principal on Windows — there is no separate `sid`
+ * field on the `Principal` type, by design (spec ch03 §5 commentary).
+ */
+export interface NamedPipePeerCred {
+  readonly transport: 'namedPipe';
+  readonly sid: string;
+  readonly displayName: string;
+}
+
+/**
+ * Loopback TCP peer "credentials" — for v0.3 this is purely a development /
+ * test transport (Listener A goes UDS / named-pipe in production). The
+ * spec ch03 §5 PID-based synthesis path (`GetExtendedTcpTable` /
+ * `/proc/net/tcp`) is deferred to T1.5 if loopback ever becomes a
+ * production fallback. For T1.3 we accept a stable test bearer token in
+ * the `Authorization` header so unit tests + smoke harnesses can exercise
+ * the interceptor without standing up a UDS or named pipe.
+ *
+ * `bearerToken` is the raw value extracted from the `Authorization: Bearer
+ * <token>` request header by the transport adapter. The interceptor checks
+ * it against a single forever-stable test value; any mismatch (or absence)
+ * is rejected with `Unauthenticated` exactly like a failed peer-cred
+ * lookup. The test principal uses `kind: 'local-user'` with `uid: 'test'`
+ * so it threads through the same `principalKey` pipeline (`local-user:test`)
+ * as any other caller — no special-case in handlers.
+ */
+export interface LoopbackTcpPeer {
+  readonly transport: 'loopbackTcp';
+  readonly bearerToken: string | null;
+  /** Useful for diagnostics only; not authoritative. */
+  readonly remoteAddress: string;
+  readonly remotePort: number;
+}
+
+/** Closed discriminated union of every peer-info shape v0.3 accepts. */
+export type PeerInfo = UdsPeerCred | NamedPipePeerCred | LoopbackTcpPeer;
+
+/**
+ * Sentinel value for "no peer info was provided by the transport adapter".
+ * The interceptor treats this exactly like a derivation failure (throws
+ * Unauthenticated). The default-value mechanism is the only safe shape:
+ * Connect's `contextValues.get` requires a default, and we do NOT want
+ * `undefined` to thread silently into a handler that forgot to check.
+ */
+export const NO_PEER_INFO: PeerInfo = {
+  transport: 'loopbackTcp',
+  bearerToken: null,
+  remoteAddress: '',
+  remotePort: 0,
+};
+
+/**
+ * Connect contextValues key under which the HTTP/2 server adapter writes
+ * the per-connection `PeerInfo`. Read by `peerCredAuthInterceptor`.
+ * Symbol identity is process-local — exporting the key from a single module
+ * keeps producers and consumers in lockstep.
+ */
+export const PEER_INFO_KEY = createContextKey<PeerInfo>(NO_PEER_INFO, {
+  description: 'ccsm.daemon.auth.peerInfo',
+});

--- a/packages/daemon/src/auth/principal.ts
+++ b/packages/daemon/src/auth/principal.ts
@@ -1,0 +1,65 @@
+// Principal — in-process discriminated union for the entity an RPC call is
+// attributed to. Mirrors the proto `Principal` oneof from
+// `packages/proto/src/ccsm/v1/common.proto` (forever-stable wire schema —
+// spec ch04 §2). v0.3 ships exactly one variant (`local-user`); v0.4 adds
+// `cf-access` as a NEW variant of the discriminated union — the existing
+// `local-user` shape MUST NOT change.
+//
+// Spec refs:
+//   - ch05 §1 Principal model (TypeScript shape).
+//   - ch05 §2 v0.3 single-principal invariant.
+//   - ch05 §3 derivation rules per transport (consumed by the per-OS
+//     extractors under ./peer-info/).
+//
+// SRP: this module is pure type declarations + a single `principalKey` pure
+// function. No I/O, no transport awareness. The interceptor (./interceptor.ts)
+// reads `PeerInfo` from the Connect contextValues and emits a `Principal`;
+// downstream handlers only ever read `Principal` from the same contextValues
+// surface — they do NOT see `PeerInfo`.
+
+/**
+ * The set of principal kinds the daemon recognises.
+ *
+ * v0.3 — only `local-user`.
+ * v0.4 — adds `cf-access` (NEW oneof variant on the wire); plumbed through
+ *        the same `Principal` discriminated union, no field renames.
+ *
+ * Forever-stable string literal: the discriminator value is the same string
+ * used as the `kind:` prefix in `principalKey` (spec ch05 §1).
+ */
+export type Principal = {
+  readonly kind: 'local-user';
+  /**
+   * OS-native identifier rendered as a string. Numeric uid on linux/mac,
+   * full SID string on Windows (spec ch05 §2). Always non-empty when the
+   * extractor succeeds; empty `uid` is treated as a derivation failure.
+   */
+  readonly uid: string;
+  /**
+   * OS-reported display name. Best-effort; empty string when lookup fails.
+   * Advisory only — never used for authorization (spec ch05 §2).
+   */
+  readonly displayName: string;
+};
+
+/**
+ * Canonical string used as the `owner_id` column value in SQLite. Format is
+ * `<kind>:<identifier>` and is forever-stable: v0.3 rows for
+ * `local-user:1000` (linux uid) or `local-user:S-1-5-21-...` (Windows SID)
+ * remain valid forever (spec ch05 §1 + ch07 §3).
+ *
+ * Pure function: total over the closed `Principal` union; the `switch`
+ * exhaustiveness check forces an update here when a new kind is added in
+ * v0.4. The fallthrough `_exhaustive` cast is the standard
+ * never-narrowing trick that makes the compiler reject an unhandled kind.
+ */
+export function principalKey(p: Principal): string {
+  switch (p.kind) {
+    case 'local-user':
+      return `local-user:${p.uid}`;
+    default: {
+      const _exhaustive: never = p.kind;
+      throw new Error(`unhandled principal kind: ${String(_exhaustive)}`);
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,6 +225,12 @@ importers:
 
   packages/daemon:
     dependencies:
+      '@bufbuild/protobuf':
+        specifier: ^2.12.0
+        version: 2.12.0
+      '@connectrpc/connect':
+        specifier: ^2.1.1
+        version: 2.1.1(@bufbuild/protobuf@2.12.0)
       better-sqlite3:
         specifier: ^12.9.0
         version: 12.9.0


### PR DESCRIPTION
## Summary

Implements Task #22 (T1.3): Connect-RPC peer-cred authentication middleware
that derives `ctx.principal` from per-transport peer credentials, per spec
ch03 §5 + ch05 §3.

Ships 5 modules under `packages/daemon/src/auth/`:

- **`principal.ts`** — `Principal` discriminated union mirroring the proto
  `LocalUser` oneof + `principalKey()` canonical formatter.
- **`peer-info.ts`** — `PeerInfo` tagged union (`uds` | `namedPipe` |
  `loopbackTcp`) + `PEER_INFO_KEY` Connect contextValues key.
- **`peer-cred.ts`** — per-OS extractors. OS-specific syscalls
  (`SO_PEERCRED`, `ImpersonateNamedPipeClient` + `GetTokenInformation`)
  are injected via callback so T1.5's native addon can plug in without
  re-shaping callers. Default callbacks throw `OperationUnsupported` so
  missing wiring fails loud at the first connection (no silent
  degradation to anonymous).
- **`interceptor.ts`** — `peerCredAuthInterceptor` + `derivePrincipal`
  pure decision table. Reads `PEER_INFO_KEY`, publishes `PRINCIPAL_KEY`,
  throws `ConnectError(Unauthenticated)` if derivation fails.
- **`index.ts`** — public surface.

Loopback-TCP requires `Authorization: Bearer test-token` and emits
`principal=local-user:test`. Spec ch03 §4 lists loopback as a
MUST-SPIKE fallback (production picks UDS / named-pipe); the bearer is
a stable dev-only seam, not a production authn — v0.4's Listener B
(TLS+JWT) replaces loopback entirely. Per spec ch05 §2 invariant, the
interceptor rejects when the transport adapter forgot to set
`PEER_INFO_KEY` so a wiring bug never silently downgrades a call to
anonymous.

## Spec compliance matrix

| Transport          | Spec ch03 §5 mechanism                                              | Implementation |
| ------------------ | ------------------------------------------------------------------- | -------------- |
| UDS (linux)        | `getsockopt(SO_PEERCRED)` -> uid                                    | `extractUdsPeerCred(socket, lookup)` -> `{uid, gid, pid}` -> `local-user:<uid>` |
| UDS (mac)          | `getsockopt(LOCAL_PEERCRED)` -> xucred -> uid                       | same callback contract; addon supplies the platform syscall |
| Named pipe (win)   | `ImpersonateNamedPipeClient` + `OpenThreadToken` + `GetTokenInformation(TokenUser)` | `extractNamedPipePeerCred(socket, lookup)` -> `{sid, displayName}` -> `local-user:<SID>` |
| Loopback TCP       | (test-only per task scope)                                          | `extractLoopbackTcpPeer(headers, addr, port)` -> `Bearer test-token` -> `local-user:test`; any other shape rejected |

`displayName` is best-effort and never used for authorization (spec
ch05 §2). UDS extractor leaves it empty for v0.3; T1.5 may add the
`getpwuid_r` / `dscl` lookup alongside the addon.

## Why a Connect interceptor (not the spec's `AuthMiddleware.before` shape)

Spec ch03 §1 sketches an `AuthMiddleware` interface as the v0.4-friendly
composition primitive. For v0.3's single-link chain on Listener A, a
Connect interceptor is the correct *concrete realization*: Connect's
contextValues mechanism is the blessed way to plumb per-call data into
handlers, and interceptor errors become `ConnectError` on the wire
without bespoke translation. v0.4's JWT validator slots in as a second
interceptor in the same array (`[peerCred, jwt]`), composed left-to-right
per spec ch03 §2 chain-order rule. Trait shape is preserved by `Listener`
already exposing the auth slot.

## Out of scope (deliberately)

- `makeListenerA` wiring (T1.4): the interceptor will be added to the
  ConnectRouter's interceptor list there; this PR ships the building
  block, not the wire-up.
- HTTP/2 server adapter that populates `PEER_INFO_KEY` at accept-time
  (T1.5) — the native addon for `SO_PEERCRED` / `NamedPipeImpersonate`
  ships alongside the http2 server, not here.
- Supervisor admin allowlist (T1.7): consumes the same `Principal`
  shape but enforces uid/SID membership separately.

## Test plan

- [x] `pnpm --filter @ccsm/daemon typecheck` — green
- [x] `pnpm --filter @ccsm/daemon lint` — green
- [x] `npx vitest run src/auth/` — 33 cases passed across 3 spec files
  (principal / peer-cred / interceptor)
- [ ] CI: lint + typecheck + test on ubuntu / macos / windows runners
- [ ] CI: no-silent-drops + paths-filter

### Tests added

- `src/auth/__tests__/principal.spec.ts` — `principalKey` invariants
  (linux uid, Windows SID, test loopback, displayName excluded from key).
- `src/auth/__tests__/peer-cred.spec.ts` — extractor behavior with
  mocked lookups; case-insensitive Bearer parsing per RFC 6750 §2.1;
  empty-SID rejection; unsupported-default fail-loud.
- `src/auth/__tests__/interceptor.spec.ts` — full derivation table for
  all transports, end-to-end interceptor (sets PRINCIPAL_KEY, throws on
  missing peer info, wraps non-ConnectError throws into Unauthenticated).

### Local sqlite test note

The pre-existing `src/db/__tests__/sqlite.spec.ts` cases fail on this
Windows dev box with `NODE_MODULE_VERSION` mismatch on better-sqlite3
(built against 145, runtime 137). Reproduces on `origin/working`
without these changes. CI rebuilds the addon per-OS so the green on
PR #873 (the most recent merge) covers the same path.

### Test directory location

Manager prompt suggested `packages/daemon/test/auth/`; the daemon's
vitest config (`include: ['src/**/*.spec.ts', 'build/**/*.spec.ts',
'eslint-plugins/**/*.spec.ts']`) requires `src/**/*.spec.ts` co-location
to actually run, matching T1.2 / T1.6 convention. Tests are at
`src/auth/__tests__/` accordingly.

## Repo touch-ups

- `packages/daemon/package.json`: add `@connectrpc/connect@^2.1.1` +
  `@bufbuild/protobuf@^2.12.0` as runtime deps. `@ccsm/proto` already
  pinned the same versions in pnpm-lock; the daemon importer block
  in pnpm-lock.yaml updates accordingly.
- `eslint.config.js`: add `Headers` / `Request` / `Response` / `fetch`
  to the global ts/tsx globals (Node 22+ web-platform globals; the
  electron block already had `fetch` / `Response`).