### PR TITLE
spike(T9.5): Node 22 http2 over Windows named pipe

### DIFF
--- a/tools/spike-harness/README.md
+++ b/tools/spike-harness/README.md
@@ -41,3 +41,5 @@ Cross-link: chapter 11 §2 / §6 pins this path; chapter 12 §3 reuses
 | `stream-truncation-detector.mjs` | §1.3, §1.4, §1.5  | runnable (seq-gap detector)         |
 | `probes/uds-h2c/{server,client}.mjs` | §1.4 (T9.4)   | runnable on darwin/linux; win32 skip |
 | `probes/uds-h2c/run.sh`          | §1.4 (T9.4)       | smoke (60s) + 1h soak driver        |
+| `probes/win-h2-named-pipe/{server,client}.mjs` | §1.5 (T9.5) | runnable on win32; non-win32 skip |
+| `probes/win-h2-named-pipe/run.sh` | §1.5 (T9.5)      | smoke (60s) + 1h soak driver        |

--- a/tools/spike-harness/probes/win-h2-named-pipe/PROBE-RESULT.md
+++ b/tools/spike-harness/probes/win-h2-named-pipe/PROBE-RESULT.md
@@ -1,0 +1,69 @@
+# T9.5 spike — Node 22 http2 (h2c) over Windows named pipe
+
+**Status:** smoke harness landed, **viability confirmed on win32**; 1h soak deferred to self-hosted Windows runner per spec ch10 + Task #16 (T0.10).
+
+**Platform authored on:** `MINGW64_NT-10.0-26200` (Windows 11), Node v24.14.1 (forward-compat with the v22 target pinned by `@types/node ^22.10.0`). On non-win32 hosts the harness short-circuits with exit 2 (`run.sh` skip + `server.mjs` / `client.mjs` guard); the parallel UDS spike (T9.4) covers darwin / linux.
+
+## Why this spike exists
+
+Per spec ch14 §1.5 phase 0.5: "must resolve before A4 transport pick on Windows". Open question = does Node's `http2` module actually function when its underlying duplex is a Windows named pipe (kernel object surfaced through libuv as a `net.Socket`), as opposed to a TCP socket or UDS? If yes, win32 can run the same h2c-over-Listener-A design as darwin/linux without a TLS jump or loopback-TCP fallback. If no, A4 has to fall back to option C (loopback-TCP + JWT) on Windows only.
+
+## Files
+
+- `server.mjs` — `net.createServer().listen('\\?\pipe\ccsm-spike')` accepts pipe clients and bridges each accepted `net.Socket` into an `http2.createServer()` instance via `http2.emit('connection', sock)`. Single `GET /ping → pong` route. Win32-guarded; SIGTERM / SIGINT / SIGBREAK clean shutdown (named pipes have no FS residue to unlink).
+- `client.mjs` — `http2.connect('http://localhost', { createConnection: () => net.connect(pipePath) })`, 10 req/sec, configurable duration, p50/p95/p99 + RSS delta + per-minute handle snapshot via `process._getActiveHandles().length` (the closest Windows analogue to the linux `/proc/self/fd` probe used in T9.4). Emits a single trailing summary JSON line + per-request RTT NDJSON on stderr; `verdict: PASS|FAIL`.
+- `run.sh` — orchestrates server start → client soak → teardown (TERM-then-KILL); pipes RTT NDJSON through the existing `tools/spike-harness/rtt-histogram.mjs` helper (PR #851 / commit ab9b173). Win32-only.
+
+Layer-1 constraints (per `tools/spike-harness/README.md`): node: stdlib only — `http2`, `net`, `os`, `util`. Zero npm deps added.
+
+## Smoke verification on this host (win32)
+
+5-second smoke at 10 req/sec, run from `~/ccsm-worktrees/pool-14`:
+
+```
+$ SPIKE_DURATION_SEC=5 SPIKE_LOG_DIR=/tmp/winh2 \
+    bash tools/spike-harness/probes/win-h2-named-pipe/run.sh
+starting server (pipe=\\?\pipe\ccsm-spike)
+running client (duration=5s, rate=10/s)
+--- summary ---
+{"durationSec":5,"sent":45,"ok":45,"errors":0,
+ "p50Us":977,"p95Us":1413,"p99Us":8212,
+ "rssStartBytes":46968832,"rssEndBytes":48619520,"rssDeltaBytes":1650688,
+ "handleSnapshots":[{"tSec":0,"handleCount":1},{"tSec":5,"handleCount":1}],
+ "verdict":"PASS","verdictReason":"thresholds met"}
+exit=0
+```
+
+`node --check` passes for both `.mjs` files; `bash -n run.sh` passes.
+
+Key numbers from the smoke:
+
+- **45/45 ok, 0 errors** — http2 over named pipe round-trips end-to-end. The h2c HEADERS / DATA / END_STREAM frames flow through the libuv pipe surface without truncation.
+- **p50 = 977 us, p95 = 1.41 ms, p99 = 8.2 ms** — same order of magnitude as the UDS spike's expected envelope; the named-pipe path is not a perf cliff.
+- **RSS delta = +1.65 MB, handle delta = 0** — no leak in 5 s. (The 5 s window is too short to draw a leak conclusion; that is what the 1 h soak on a self-hosted Windows runner is for. But it does rule out an obvious per-request handle leak.)
+
+## Decision criterion (encoded in client.mjs, parity with T9.4)
+
+A run is **PASS** iff all three hold over the full duration:
+
+1. error rate ≤ **1 %** (`errors / sent`)
+2. RSS climb ≤ **50 MB** (`process.memoryUsage().rss` end − start)
+3. active-handle count climb ≤ **5** between first and last `process._getActiveHandles()` snapshot
+
+Any FAIL exits 3 from the client (and from `run.sh`).
+
+`process._getActiveHandles` is undocumented but has been a stable Node-core API since v18 and is the closest cheap analogue to `/proc/self/fd` on Windows. The probe tolerates its absence (returns `null`, then the leak criterion is skipped and we lean on RSS as on macOS in T9.4).
+
+## Recommendation for ch14 §1.5 / A4 transport pick on Windows
+
+The smoke run answers the phase-0.5 viability question **affirmatively**: Node 22+ `http2` operates correctly over a Windows named pipe via the standard `createConnection` injection used by the UDS spike. There is no need for a TLS jump or a loopback-TCP fallback solely because of platform.
+
+Pending the 1 h soak on real Windows CI hardware, the recommendation is to lock **option A (h2c-over-named-pipe)** as the v0.3 Listener-A transport on win32, mirroring the darwin/linux `h2c-over-UDS` choice from T9.4. Peer-cred on the Windows side is supplied by `connect-and-peercred.ps1` (`GetNamedPipeClientProcessId` — currently a stub, separate task) and pipe DACL hardening by `set-pipe-dacl.ps1` (also stub).
+
+If the soak shows handle / RSS climb on Windows specifically, the fallback is option C (loopback-TCP + JWT) — already covered by T9.3's harness — at the cost of giving up peer-cred bypass on Listener A on Windows only.
+
+## Follow-ups
+
+- **T0.10 (#16)**: wire this `run.sh` into a self-hosted Windows runner with `SPIKE_DURATION_SEC=3600`. Capture `summary.json` + `histogram.json` as build artifacts. Required before the A4 lock-in can be ratified.
+- **`connect-and-peercred.ps1`**: still a stub per `tools/spike-harness/README.md` inventory. Needs a real `GetNamedPipeClientProcessId` P/Invoke implementation to validate Listener-A peer-cred on win32 once this transport is locked.
+- **`set-pipe-dacl.ps1`**: still a stub. Needs `SetSecurityInfo` P/Invoke for the same-user DACL gating that makes Listener A trustworthy without TLS.

--- a/tools/spike-harness/probes/win-h2-named-pipe/client.mjs
+++ b/tools/spike-harness/probes/win-h2-named-pipe/client.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+// client.mjs — http2 (h2c) client over a Windows named pipe, sustained-
+// traffic soak driver.
+//
+// Spike T9.5: drives N req/sec against server.mjs for SPIKE_DURATION_SEC
+// seconds (default 60 smoke; 3600 = 1h soak). Records p50/p95/p99 RTT,
+// error count, and handle count snapshots every 60s. Win32-only.
+//
+// Forever-stable contract:
+//
+//   Usage:
+//     client.mjs [--pipe=<name>]    default ccsm-spike (resolved to
+//                                   \\?\pipe\<name>)
+//                [--rate=<n>]       req/sec, default 10
+//                [--duration=<sec>] overrides SPIKE_DURATION_SEC
+//
+//   Env:
+//     SPIKE_DURATION_SEC   default 60 (smoke). 3600 = 1h soak.
+//
+//   Output (stdout, single trailing JSON line):
+//     {"durationSec":<num>,"sent":<int>,"ok":<int>,"errors":<int>,
+//      "p50Us":<int>,"p95Us":<int>,"p99Us":<int>,
+//      "rssStartBytes":<int>,"rssEndBytes":<int>,"rssDeltaBytes":<int>,
+//      "handleSnapshots":[{"tSec":<int>,"handleCount":<int|null>}],
+//      "verdict":"PASS"|"FAIL","verdictReason":"<str>"}
+//
+//   Per-request RTT lines (NDJSON) go to stderr so they can be piped to
+//   rtt-histogram.mjs without polluting the summary.
+//
+//   Exit codes: 0 PASS; 3 FAIL (errors > 1%, RSS > 50MB, or handle leak
+//               > 5); 2 unsupported OS / bad arg; 1 connect failure.
+//
+// Note: there is no /proc/self/fd on Windows. We approximate "no leak" by
+// sampling process._getActiveHandles().length — a Node-internal but stable-
+// in-practice probe — and by the RSS-climb threshold. This matches the
+// UDS spike's macOS path (where /proc is also absent and RSS carries the
+// leak signal).
+//
+// Layer-1: node: stdlib only.
+
+import { connect } from 'node:http2';
+import * as net from 'node:net';
+import { parseArgs } from 'node:util';
+import { platform } from 'node:os';
+
+if (platform() !== 'win32') {
+  process.stderr.write('win-h2-named-pipe client: only supported on win32\n');
+  process.exit(2);
+}
+
+const { values } = parseArgs({
+  options: {
+    pipe:     { type: 'string', default: 'ccsm-spike' },
+    rate:     { type: 'string', default: '10' },
+    duration: { type: 'string' },
+  },
+  strict: true,
+});
+
+function resolvePipePath(input) {
+  if (input.startsWith('\\\\?\\pipe\\') || input.startsWith('\\\\.\\pipe\\')) {
+    return input;
+  }
+  return `\\\\?\\pipe\\${input}`;
+}
+const pipePath = resolvePipePath(values.pipe);
+const rate = Number(values.rate);
+const durationSec = Number(values.duration ?? process.env.SPIKE_DURATION_SEC ?? '60');
+if (!Number.isFinite(rate) || rate <= 0) { process.stderr.write('bad --rate\n'); process.exit(2); }
+if (!Number.isFinite(durationSec) || durationSec <= 0) { process.stderr.write('bad --duration\n'); process.exit(2); }
+
+const session = connect('http://localhost', {
+  createConnection: () => net.connect(pipePath),
+});
+
+session.on('error', (err) => {
+  process.stderr.write(`session error: ${err.message}\n`);
+});
+
+await new Promise((resolve, reject) => {
+  const t = setTimeout(() => reject(new Error('connect timeout')), 5000);
+  session.once('connect', () => { clearTimeout(t); resolve(); });
+  session.once('error', (e) => { clearTimeout(t); reject(e); });
+}).catch((e) => {
+  process.stderr.write(`failed to connect: ${e.message}\n`);
+  process.exit(1);
+});
+
+const samples = [];
+let sent = 0;
+let ok = 0;
+let errors = 0;
+const handleSnapshots = [];
+const rssStart = process.memoryUsage().rss;
+
+function handleCount() {
+  // process._getActiveHandles is undocumented but has been a stable
+  // Node-core probe across v18/v20/v22/v24. We tolerate its absence.
+  try {
+    if (typeof process._getActiveHandles === 'function') {
+      return process._getActiveHandles().length;
+    }
+  } catch { /* fall through */ }
+  return null;
+}
+
+function snapshot(tSec) {
+  handleSnapshots.push({ tSec, handleCount: handleCount() });
+}
+snapshot(0);
+
+function doRequest() {
+  const start = process.hrtime.bigint();
+  sent++;
+  const req = session.request({ ':method': 'GET', ':path': '/ping' });
+  let body = '';
+  req.setEncoding('utf8');
+  req.on('data', (chunk) => { body += chunk; });
+  req.on('end', () => {
+    const rttUs = Number((process.hrtime.bigint() - start) / 1000n);
+    if (body === 'pong') {
+      ok++;
+      samples.push(rttUs);
+      process.stderr.write(JSON.stringify({ rttUs }) + '\n');
+    } else {
+      errors++;
+    }
+  });
+  req.on('error', () => { errors++; });
+  req.end();
+}
+
+const intervalMs = 1000 / rate;
+const startMs = Date.now();
+const endMs = startMs + durationSec * 1000;
+
+const reqTimer = setInterval(() => {
+  if (Date.now() >= endMs) return;
+  doRequest();
+}, intervalMs);
+
+const snapTimer = setInterval(() => {
+  const tSec = Math.round((Date.now() - startMs) / 1000);
+  snapshot(tSec);
+}, 60_000);
+
+await new Promise((resolve) => setTimeout(resolve, durationSec * 1000));
+clearInterval(reqTimer);
+clearInterval(snapTimer);
+
+// Drain in-flight (cap 2s).
+await new Promise((resolve) => setTimeout(resolve, Math.min(2000, intervalMs * 5)));
+
+snapshot(durationSec);
+
+session.close();
+
+samples.sort((a, b) => a - b);
+const pct = (p) => samples.length === 0 ? 0 : samples[Math.min(samples.length - 1, Math.floor(p * samples.length))];
+const rssEnd = process.memoryUsage().rss;
+const rssDelta = rssEnd - rssStart;
+
+// Verdict thresholds (parity with T9.4 uds-h2c):
+//   - error rate <= 1%
+//   - RSS climb <= 50 MB
+//   - if _getActiveHandles available, handle delta <= 5 (no leak)
+const errRatio = sent === 0 ? 1 : errors / sent;
+let verdict = 'PASS';
+let verdictReason = 'thresholds met';
+if (errRatio > 0.01) {
+  verdict = 'FAIL';
+  verdictReason = `error ratio ${(errRatio * 100).toFixed(2)}% > 1%`;
+} else if (rssDelta > 50 * 1024 * 1024) {
+  verdict = 'FAIL';
+  verdictReason = `RSS climbed ${rssDelta} bytes > 50MB`;
+} else {
+  const haveHandles = handleSnapshots.filter((s) => s.handleCount !== null);
+  if (haveHandles.length >= 2) {
+    const hDelta = haveHandles[haveHandles.length - 1].handleCount - haveHandles[0].handleCount;
+    if (hDelta > 5) {
+      verdict = 'FAIL';
+      verdictReason = `handle count climbed by ${hDelta} > 5 (leak)`;
+    }
+  }
+}
+
+process.stdout.write(JSON.stringify({
+  durationSec,
+  sent,
+  ok,
+  errors,
+  p50Us: pct(0.50),
+  p95Us: pct(0.95),
+  p99Us: pct(0.99),
+  rssStartBytes: rssStart,
+  rssEndBytes: rssEnd,
+  rssDeltaBytes: rssDelta,
+  handleSnapshots,
+  verdict,
+  verdictReason,
+}) + '\n');
+
+process.exit(verdict === 'PASS' ? 0 : 3);

--- a/tools/spike-harness/probes/win-h2-named-pipe/run.sh
+++ b/tools/spike-harness/probes/win-h2-named-pipe/run.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# run.sh — launch Windows named-pipe h2c server, run client soak, tear down.
+#
+# Spike T9.5: smoke (60s default) or 1h soak via SPIKE_DURATION_SEC=3600.
+# Win32-only (named pipes are a Windows kernel object). On non-win32 hosts
+# the harness short-circuits with exit 2 (use uds-h2c spike there).
+#
+# Forever-stable contract:
+#
+#   Usage:
+#     run.sh
+#
+#   Env:
+#     SPIKE_DURATION_SEC   default 60. Forwarded to client.mjs.
+#     SPIKE_PIPE           default ccsm-spike (resolved to \\?\pipe\<name>
+#                          inside server.mjs / client.mjs).
+#     SPIKE_LOG_DIR        default $TMP / $TEMP / /tmp.
+#
+#   Output:
+#     - server stdout/stderr -> $SPIKE_LOG_DIR/win-h2-named-pipe-server.log
+#     - client RTT NDJSON   -> $SPIKE_LOG_DIR/win-h2-named-pipe-rtt.ndjson
+#     - client summary JSON -> $SPIKE_LOG_DIR/win-h2-named-pipe-summary.json + stdout
+#     - rtt-histogram JSON  -> $SPIKE_LOG_DIR/win-h2-named-pipe-histogram.json + stdout
+#
+#   Exit codes: 0 PASS; 3 FAIL (forwarded from client); 2 unsupported OS;
+#               1 server start failure.
+
+set -euo pipefail
+
+OS_NAME="$(uname -s)"
+case "$OS_NAME" in
+  MINGW*|MSYS*|CYGWIN*|Windows_NT) ;;
+  Linux|Darwin)
+    echo "win-h2-named-pipe spike: skipped on $OS_NAME (use uds-h2c spike instead)" >&2
+    exit 2
+    ;;
+  *)
+    echo "win-h2-named-pipe spike: unsupported OS $OS_NAME" >&2
+    exit 2
+    ;;
+esac
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+HARNESS_DIR="$(cd "$HERE/../.." && pwd)"
+PIPE_NAME="${SPIKE_PIPE:-ccsm-spike}"
+LOG_DIR="${SPIKE_LOG_DIR:-${TMP:-${TEMP:-/tmp}}}"
+DURATION="${SPIKE_DURATION_SEC:-60}"
+
+SERVER_LOG="$LOG_DIR/win-h2-named-pipe-server.log"
+RTT_NDJSON="$LOG_DIR/win-h2-named-pipe-rtt.ndjson"
+SUMMARY="$LOG_DIR/win-h2-named-pipe-summary.json"
+HISTOGRAM="$LOG_DIR/win-h2-named-pipe-histogram.json"
+
+# Teardown: kill server. Named pipes have no FS residue to unlink.
+SERVER_PID=""
+cleanup() {
+  if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" 2>/dev/null; then
+    kill -TERM "$SERVER_PID" 2>/dev/null || true
+    for _ in 1 2 3 4; do
+      if ! kill -0 "$SERVER_PID" 2>/dev/null; then break; fi
+      sleep 0.5
+    done
+    if kill -0 "$SERVER_PID" 2>/dev/null; then
+      kill -KILL "$SERVER_PID" 2>/dev/null || true
+    fi
+  fi
+}
+trap cleanup EXIT INT TERM
+
+echo "starting server (pipe=\\\\?\\pipe\\$PIPE_NAME)" >&2
+node "$HERE/server.mjs" --pipe="$PIPE_NAME" >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+# Wait up to 5s for "listening" line.
+for _ in $(seq 1 50); do
+  if grep -q "^listening " "$SERVER_LOG" 2>/dev/null; then
+    break
+  fi
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo "server died during startup; log:" >&2
+    cat "$SERVER_LOG" >&2
+    exit 1
+  fi
+  sleep 0.1
+done
+
+if ! grep -q "^listening " "$SERVER_LOG" 2>/dev/null; then
+  echo "server did not become ready in 5s; log:" >&2
+  cat "$SERVER_LOG" >&2
+  exit 1
+fi
+
+echo "running client (duration=${DURATION}s, rate=10/s)" >&2
+set +e
+SPIKE_DURATION_SEC="$DURATION" node "$HERE/client.mjs" --pipe="$PIPE_NAME" --rate=10 \
+  >"$SUMMARY" 2>"$RTT_NDJSON"
+CLIENT_EXIT=$?
+set -e
+
+echo "--- summary ---"
+cat "$SUMMARY"
+
+# Feed RTT lines through the existing histogram helper.
+if [ -s "$RTT_NDJSON" ]; then
+  node "$HARNESS_DIR/rtt-histogram.mjs" <"$RTT_NDJSON" >"$HISTOGRAM"
+  echo "--- histogram ---"
+  cat "$HISTOGRAM"
+fi
+
+exit "$CLIENT_EXIT"

--- a/tools/spike-harness/probes/win-h2-named-pipe/server.mjs
+++ b/tools/spike-harness/probes/win-h2-named-pipe/server.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+// server.mjs — Node 22 http2 (h2c) server bound to a Windows named pipe.
+//
+// Spike T9.5: confirm http2 over a Windows named pipe is viable for the
+// v0.3 daemon-split transport on win32 (parallel to T9.4 UDS spike, which
+// is the darwin/linux companion). Cross-link: spec ch14 §1.5 phase 0.5
+// (must resolve before A4 transport pick on Windows) and
+// docs/superpowers/specs/2026-05-02-final-architecture.md (Listener A =
+// peer-cred-trusted local socket).
+//
+// Forever-stable contract (per spike-harness/README.md §"Forever-stable"):
+//
+//   Usage:
+//     server.mjs [--pipe=<name>]   default ccsm-spike
+//                                  Resolved to \\?\pipe\<name> internally;
+//                                  pass either a bare name or a full
+//                                  \\.\pipe\... / \\?\pipe\... path.
+//
+//   Behavior:
+//     - createSecureServer is NOT used; this is plaintext h2c (cleartext)
+//       since the transport is a same-user local pipe with DACL gating
+//       (see set-pipe-dacl.ps1 for the Listener A hardening).
+//     - net.createServer().listen(<pipe path>) — Node maps this to
+//       CreateNamedPipe(W) via libuv on win32. The Duplex stream surfaced
+//       to http2 is a net.Socket, just like the UDS case.
+//     - Routes:
+//         GET /ping  -> 200, body "pong"
+//         anything else -> 404
+//     - On SIGTERM / SIGINT / Ctrl+Break: graceful close, exit 0. Named
+//       pipes do not leave a filesystem residue, so no unlink is needed.
+//     - Prints "listening <pipe path>\n" to stdout once ready.
+//
+//   Exit codes: 0 clean shutdown; 2 unsupported OS / bad arg; 1 fatal
+//               listen error.
+//
+// Layer-1: node: stdlib only (http2, net, util, os).
+
+import { createServer as createHttp2Server } from 'node:http2';
+import { createServer as createNetServer } from 'node:net';
+import { parseArgs } from 'node:util';
+import { platform } from 'node:os';
+
+if (platform() !== 'win32') {
+  process.stderr.write('win-h2-named-pipe server: only supported on win32 (use uds-h2c on darwin/linux)\n');
+  process.exit(2);
+}
+
+const { values } = parseArgs({
+  options: { pipe: { type: 'string', default: 'ccsm-spike' } },
+  strict: true,
+});
+
+// Accept bare name, \\.\pipe\name, or \\?\pipe\name. Normalize to the
+// \\?\pipe\ prefix Node + libuv expect on win32.
+function resolvePipePath(input) {
+  if (input.startsWith('\\\\?\\pipe\\') || input.startsWith('\\\\.\\pipe\\')) {
+    return input;
+  }
+  return `\\\\?\\pipe\\${input}`;
+}
+const pipePath = resolvePipePath(values.pipe);
+
+const h2 = createHttp2Server();
+
+h2.on('stream', (stream, headers) => {
+  const path = headers[':path'];
+  const method = headers[':method'];
+  if (method === 'GET' && path === '/ping') {
+    stream.respond({ ':status': 200, 'content-type': 'text/plain' });
+    stream.end('pong');
+    return;
+  }
+  stream.respond({ ':status': 404 });
+  stream.end();
+});
+
+h2.on('error', (err) => {
+  process.stderr.write(`http2 server error: ${err.message}\n`);
+});
+
+// Bridge a raw net server (which actually owns the named pipe) into the
+// http2 server by handing each accepted Socket to http2 via emit('connection').
+// This mirrors how http2.createServer().listen() works on TCP/UDS, but
+// keeps us in full control of the underlying transport surface for the
+// pipe case so we can confirm the Duplex contract is honored.
+const net = createNetServer((sock) => {
+  h2.emit('connection', sock);
+});
+
+net.on('error', (err) => {
+  process.stderr.write(`pipe listen error: ${err.message}\n`);
+  process.exit(1);
+});
+
+let shuttingDown = false;
+function shutdown(sig) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  process.stderr.write(`got ${sig}, shutting down\n`);
+  net.close(() => {
+    h2.close(() => process.exit(0));
+  });
+  // Hard timeout so a stuck client can't pin the spike.
+  setTimeout(() => process.exit(0), 2000).unref();
+}
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT',  () => shutdown('SIGINT'));
+// Ctrl+Break on Windows surfaces as SIGBREAK.
+process.on('SIGBREAK', () => shutdown('SIGBREAK'));
+
+net.listen(pipePath, () => {
+  process.stdout.write(`listening ${pipePath}\n`);
+});


### PR DESCRIPTION
Task #105 [T9.5] — phase-0.5 viability probe per spec ch14 §1.5: must
resolve before A4 transport pick on Windows. Parallel to T9.4 uds-h2c
(darwin/linux). Reuses `tools/spike-harness/` shared scripts (PR #851
ab9b173).

## Outcome (smoke verdict: PASS)

5s smoke at 10 req/sec on `MINGW64_NT-10.0-26200`, Node v24.14.1:

```
sent=45 ok=45 errors=0
p50=977us p95=1413us p99=8212us
RSS Δ=+1.65MB  handles Δ=0
verdict=PASS
```

Node `http2` round-trips end-to-end over a Windows named pipe via the
standard `createConnection` injection used by T9.4. No truncation, no
obvious per-request handle leak. Full numbers and recommendation in
`tools/spike-harness/probes/win-h2-named-pipe/PROBE-RESULT.md`.

## Files added

- `tools/spike-harness/probes/win-h2-named-pipe/server.mjs` — h2c server
  listening on `\?\pipe\<name>` via `net.createServer().listen()`,
  bridging accepted Sockets into `http2.createServer()` with
  `emit('connection', sock)`. GET /ping → pong. Win32-guarded.
- `tools/spike-harness/probes/win-h2-named-pipe/client.mjs` — h2c client
  via `http2.connect` with a `createConnection` factory that does
  `net.connect(pipePath)`. 10 req/sec soak driver, p50/p95/p99 +
  RSS delta + active-handle snapshots, PASS/FAIL verdict with parity
  thresholds vs T9.4.
- `tools/spike-harness/probes/win-h2-named-pipe/run.sh` — smoke (60s)
  + 1h soak orchestrator. Pipes RTT NDJSON through existing
  `tools/spike-harness/rtt-histogram.mjs`.
- `tools/spike-harness/probes/win-h2-named-pipe/PROBE-RESULT.md` —
  outcome doc.
- `tools/spike-harness/README.md` — inventory entry.

## Layer-1 compliance

`node:` stdlib only (`http2`, `net`, `os`, `util`). Zero npm deps. Bash
runner uses standard POSIX-on-MINGW shell. Mirrors T9.4 uds-h2c
contract (forever-stable script args + output) for downstream parity.

## Quality gates run locally

- `node --check server.mjs` — OK
- `node --check client.mjs` — OK
- `bash -n run.sh` — OK
- 5s smoke run via `run.sh` — exit 0, verdict PASS, histogram emitted

(eslint / typecheck do not apply; spike-harness is in eslint `ignores`
per `tools/spike-harness/README.md` Layer-1 constraint, and the probe
is stdlib `.mjs` outside the TypeScript build.)

## Recommendation

Lock **option A (h2c-over-named-pipe)** as the v0.3 Listener-A transport
on win32, mirroring T9.4's UDS choice on darwin/linux. Pending the 1h
soak on a self-hosted Windows runner (Task #16 / T0.10) before the A4
ratification. Fallback if soak shows leak: option C (loopback-TCP + JWT,
already covered by T9.3).

## Out of scope (filed as follow-ups in PROBE-RESULT.md)

- Real `GetNamedPipeClientProcessId` impl in `connect-and-peercred.ps1`
  (currently a stub).
- Real `SetSecurityInfo` DACL impl in `set-pipe-dacl.ps1` (currently a
  stub).
- 1h soak on self-hosted Windows runner.