### PR TITLE
spike(macos-notarization-sea): probe scaffolding for T9.12 (#111)

### DIFF
--- a/tools/spike-harness/README.md
+++ b/tools/spike-harness/README.md
@@ -43,3 +43,5 @@ Cross-link: chapter 11 §2 / §6 pins this path; chapter 12 §3 reuses
 | `probes/uds-h2c/run.sh`          | §1.4 (T9.4)       | smoke (60s) + 1h soak driver        |
 | `probes/win-h2-named-pipe/{server,client}.mjs` | §1.5 (T9.5) | runnable on win32; non-win32 skip |
 | `probes/win-h2-named-pipe/run.sh` | §1.5 (T9.5)      | smoke (60s) + 1h soak driver        |
+| `probes/macos-notarization-sea/notarize.sh` | §1.13 (T9.12) | gated on Apple Dev ID cert (ops prereq) |
+| `probes/macos-notarization-sea/Info.plist`  | §1.13 (T9.12) | sample bundle metadata for Mach-O notarization |

--- a/tools/spike-harness/probes/macos-notarization-sea/Info.plist
+++ b/tools/spike-harness/probes/macos-notarization-sea/Info.plist
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Info.plist — sample bundle metadata for the macOS notarization spike (T9.12).
+
+  Spike-harness fixture pinned by spec ch14 §1.13 (forever-stable contract).
+  Used by `notarize.sh` as the embedded `__info_plist` section that Apple's
+  `codesign --options runtime` + `notarytool submit` pipeline requires on a
+  Mach-O Node SEA binary that runs *outside* a `.app` bundle.
+
+  Why a flat Mach-O (not an .app):
+    The v0.3 daemon (T7.1) ships as a single SEA Node binary launched by the
+    Electron app via `child_process.spawn`. There is no `.app` wrapper around
+    the daemon. Apple still requires Info.plist data for notarization of the
+    Mach-O — the recipe is to inject this plist as a `__TEXT,__info_plist`
+    section at codesign time using `--identifier`, `--info-plist`, or via
+    `ld -sectcreate` at link time. We use the codesign route because we do
+    not control Node's link.
+
+  Required keys (per Apple TN3147 + notarytool 2025 reqs):
+    CFBundleIdentifier         — must match the codesign identifier and be
+                                 reverse-DNS scoped to a domain you control.
+    CFBundleName               — short display name (used in console.app).
+    CFBundleVersion            — monotonic build number string.
+    CFBundleShortVersionString — semver-ish marketing version.
+    CFBundleExecutable         — the Mach-O binary's basename on disk.
+    CFBundlePackageType        — APPL for executables; required for stapling.
+    LSMinimumSystemVersion     — min macOS; matches Node 22's minimum (11.0).
+
+  Forever-stable: v0.4 may bump CFBundleVersion / CFBundleShortVersionString
+  or ADD keys (e.g. NSHumanReadableCopyright). Never remove the seven keys
+  above or notarization regresses.
+
+  Placeholder values (`<TEAM_ID>`, `<VERSION>`) are substituted by the build
+  pipeline; this file is the SAMPLE / contract, not the shipped artifact.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleIdentifier</key>
+  <string>com.ccsm.daemon</string>
+
+  <key>CFBundleName</key>
+  <string>ccsm-daemon</string>
+
+  <key>CFBundleExecutable</key>
+  <string>ccsm-daemon</string>
+
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+
+  <key>CFBundleShortVersionString</key>
+  <string>0.3.0</string>
+
+  <key>CFBundleVersion</key>
+  <string>1</string>
+
+  <key>LSMinimumSystemVersion</key>
+  <string>11.0</string>
+</dict>
+</plist>

--- a/tools/spike-harness/probes/macos-notarization-sea/PROBE-RESULT.md
+++ b/tools/spike-harness/probes/macos-notarization-sea/PROBE-RESULT.md
@@ -1,0 +1,208 @@
+# T9.12 — macOS notarization for Node 22 SEA (hardened runtime + JIT)
+
+Spike for Task #111. Pinned by spec ch14 §1.13.
+
+Validates the Apple codesign + notarization recipe for the v0.3 daemon's
+SEA-built Node 22 binary so that, on macOS, T7.1 (sea pipeline, Issue #84)
+can ship a Gatekeeper-approved daemon executable that still has a working
+JIT (V8 needs `allow-jit` + `allow-unsigned-executable-memory` under the
+hardened runtime).
+
+## TL;DR
+
+- Probe scaffolding + entitlements + Info.plist sample landed.
+- **Phase 0 of the notarization pipeline is BLOCKED** on the
+  `Apple Dev ID Application` certificate prerequisite (ops gate, see below).
+- All probe code paths, gating, and recipe steps are pinned in this PR so
+  that as soon as the cert is provisioned + a notarytool keychain profile is
+  stored, `bash notarize.sh` can run unattended on a `macos-latest` runner
+  without further code changes.
+
+## Per-OS results
+
+| OS      | Built? | Signed? | Notarized? | Stapled? | spctl OK? | Notes                                              |
+|---------|--------|---------|------------|----------|-----------|----------------------------------------------------|
+| darwin  | TODO   | TODO    | TODO       | TODO     | TODO      | **Blocked on Apple Dev ID cert (ops gate)**        |
+| win32   | n/a    | n/a     | n/a        | n/a      | n/a       | macOS-only step                                    |
+| linux   | n/a    | n/a     | n/a        | n/a      | n/a       | macOS-only step                                    |
+
+Run host attempted: `MINGW64_NT-10.0-26200` (Windows 11). The probe's gate
+check fired correctly:
+
+```
+$ bash tools/spike-harness/probes/macos-notarization-sea/notarize.sh
+[notarize] GATE: non-darwin host (MINGW64_NT-10.0-26200); macOS notarization requires macOS.
+exit 20
+```
+
+That confirms the probe fails fast (exit 20 = gate not satisfied) without
+attempting anything destructive on a non-macOS host.
+
+## Files in this probe
+
+| File                   | Role                                                                 |
+|------------------------|----------------------------------------------------------------------|
+| `notarize.sh`          | End-to-end pipeline: codesign + notarytool submit + staple + spctl.  |
+| `Info.plist`           | Bundle metadata embedded into the Mach-O at codesign time.           |
+| `PROBE-RESULT.md`      | This file. Documents gate, recipe, and follow-ups.                   |
+
+The hardened-runtime entitlements file is **not duplicated here**; it is the
+shared, forever-stable fixture at `tools/spike-harness/entitlements-jit.plist`
+(spec ch14 §1.B). `notarize.sh` references it via relative path
+`../../entitlements-jit.plist`. Duplicating it would split the contract.
+
+The SEA binary itself is **not produced here**; it is the output of the
+T9.9 sibling probe `tools/spike-harness/probes/sea-3os/build.sh` running on
+darwin. `notarize.sh` consumes its absolute path via `$SEA_BINARY`.
+
+## Reproduction (once the gate is satisfied)
+
+On a `macos-latest` host with Xcode 13+ and a populated keychain:
+
+```bash
+# 1) Build the SEA binary first (T9.9 sibling probe).
+bash tools/spike-harness/probes/sea-3os/build.sh
+SEA_BIN="$PWD/tools/spike-harness/probes/sea-3os/dist/sea-hello-darwin"
+
+# 2) Configure Apple credentials (one-time per host).
+xcrun notarytool store-credentials ccsm-notary \
+      --apple-id "<release-bot@yourdomain>" \
+      --team-id  "XXXXXXXXXX" \
+      --password "<app-specific-password>"
+
+# 3) Run the notarization probe.
+APPLE_TEAM_ID=XXXXXXXXXX \
+APPLE_SIGNING_IDENTITY="Developer ID Application: Acme Co (XXXXXXXXXX)" \
+APPLE_NOTARY_PROFILE=ccsm-notary \
+SEA_BINARY="$SEA_BIN" \
+bash tools/spike-harness/probes/macos-notarization-sea/notarize.sh
+```
+
+Expected on success: `dist/<binary>.signed` produced, `dist/notarize.log`
+shows `OK — signed+notarized binary at …`, exit 0.
+
+## Recipe — exact codesign + notarytool invocation
+
+Pinned in `notarize.sh`; reproduced here for spec / review purposes.
+
+```bash
+codesign --sign "$APPLE_SIGNING_IDENTITY" \
+         --options runtime \
+         --entitlements ../../entitlements-jit.plist \
+         --identifier "$BUNDLE_ID" \
+         --timestamp \
+         --force \
+         "$SEA_BINARY"
+
+ditto -c -k --keepParent "$SEA_BINARY" dist/submit.zip
+
+xcrun notarytool submit dist/submit.zip \
+      --keychain-profile "$APPLE_NOTARY_PROFILE" \
+      --wait \
+      --output-format json
+# assert .status == "Accepted"
+
+xcrun stapler staple "$SEA_BINARY" || true   # bare Mach-O can't embed ticket;
+                                               # ticket lives on Apple's CDN.
+spctl --assess --type execute --verbose=4 "$SEA_BINARY"
+```
+
+### Why these flags
+
+- `--options runtime` — opts the binary into the **hardened runtime**, which
+  Apple requires for notarization. Without it, `notarytool submit` returns
+  `Invalid` with `"The executable does not have the hardened runtime
+  enabled."`
+- `--entitlements ../../entitlements-jit.plist` — grants `allow-jit` and
+  `allow-unsigned-executable-memory`. Both are required by V8 inside Node;
+  omitting `allow-unsigned-executable-memory` causes V8 startup to crash
+  with `EXC_BAD_ACCESS (SIGKILL Code Signature Invalid)` on first JIT
+  emit. Source: Apple TN3127 + Node v22.x macOS build notes.
+- `--timestamp` — embeds a secure timestamp from Apple's TSA. Mandatory for
+  notarization; submissions without it are rejected.
+- `--identifier "$BUNDLE_ID"` — must match `CFBundleIdentifier` in the
+  embedded Info.plist or `notarytool` rejects with `"Bundle ID mismatch"`.
+- `ditto -c -k --keepParent` — `notarytool` only accepts `.zip`, `.dmg`, or
+  `.pkg`. A bare Mach-O is rejected with `"Asset has unsupported format"`.
+- `--wait --output-format json` — synchronous + machine-parseable so CI can
+  fail fast on `status != Accepted` without polling.
+- `stapler staple` is best-effort: a bare Mach-O has no `__TEXT,__notarize`
+  section to staple a ticket into, so the ticket is served from Apple's CDN
+  on first launch. We rely on `spctl --assess` to confirm Gatekeeper
+  accepts the binary post-notarization.
+
+## Gate / blockers
+
+### Hard blocker (phase 0): Apple Developer ID Application certificate
+
+`notarize.sh` exits **20** until **all** of the following are true:
+
+1. **Apple Developer Program enrollment** for the org account that will
+   sign + ship `ccsm`. ($99 USD/yr; 1-3 business days for new enrollments.)
+2. **`Developer ID Application` certificate** issued from
+   <https://developer.apple.com/account/resources/certificates/list> and
+   imported into the macOS runner's login keychain (or a dedicated
+   keychain pinned by the build job). This is the cert whose CN appears as
+   `APPLE_SIGNING_IDENTITY` (e.g. `Developer ID Application: Acme Co (XXXXXXXXXX)`).
+3. **App-specific password** generated at <https://appleid.apple.com> for
+   the Apple ID that owns the team, and stored in the runner's keychain via:
+   ```
+   xcrun notarytool store-credentials ccsm-notary \
+         --apple-id "<release-bot@yourdomain>" \
+         --team-id  "XXXXXXXXXX" \
+         --password "<app-specific-password>"
+   ```
+4. **`APPLE_TEAM_ID`**, **`APPLE_SIGNING_IDENTITY`**, **`APPLE_NOTARY_PROFILE`**,
+   **`SEA_BINARY`** env vars set in the CI job.
+5. A `macos-latest` runner with Xcode 13+ (`xcrun --find notarytool`
+   resolves) — GitHub-hosted `macos-13` and `macos-14` images both qualify.
+
+This is an **ops prereq**, not a code task. Per the task description: "ops
+prereq (Apple Dev ID cert) blocks phase 0." File the ops ticket against
+whoever owns the Apple Developer account; this PR cannot unblock it.
+
+### Soft considerations
+
+- **Self-hosted vs. GitHub-hosted macOS runners.** GitHub-hosted runners are
+  ephemeral, so credentials must be injected per job from GitHub secrets +
+  written into a temp keychain. Long-term we may prefer a self-hosted
+  runner (Task #16 / T0.10) so the Dev ID cert lives on disk and survives
+  reboots; tradeoff is maintenance.
+- **App-specific password rotation.** Apple expires app-specific passwords
+  if unused for 12 months; release pipeline should fail loudly (exit 22)
+  rather than silently re-emit unsigned binaries.
+- **Stapling on bare Mach-O.** As noted, the ticket lives on Apple's CDN. If
+  v0.4 wraps the daemon in a `.app` bundle (e.g. for LaunchAgent install),
+  `stapler staple` will start succeeding and offline-first launch will
+  benefit. No code change needed in this probe — `stapler staple … || true`
+  already tolerates both shapes.
+
+## Recommendation for T7.1 (#84 sea pipeline)
+
+**GREEN to wire `notarize.sh` in as the post-build step on the macOS leg of
+T7.1**, gated on a non-empty `APPLE_SIGNING_IDENTITY` env var so that:
+
+- Local devs running `build.sh` without Apple credentials get an unsigned
+  binary (warned, not failed).
+- CI jobs with secrets configured produce a notarized, Gatekeeper-clean
+  binary in one shot.
+- The hardened-runtime entitlements stay co-located in
+  `tools/spike-harness/entitlements-jit.plist` (forever-stable per ch14
+  §1.B), preventing drift between the spike and the shipping pipeline.
+
+Live execution remains TODO behind the ops gate above.
+
+## Follow-ups
+
+1. **Ops:** open a separate ticket to provision the `Developer ID
+   Application` cert + notarytool keychain profile on the macOS runner.
+   Cite this probe as the consumer.
+2. **CI wiring (T7.1 / T0.10):** add a job that runs `bash
+   tools/spike-harness/probes/macos-notarization-sea/notarize.sh` on
+   `macos-latest` after the SEA build, with secrets piped through env.
+   Block T7.1 macOS green on `notarize.sh` exit 0.
+3. **Re-record this file** with real `notarytool` output (`status:
+   Accepted`, submission id, log URL, `spctl --assess` line) on first
+   successful run; update the per-OS table.
+4. **Consider `.app` wrapping** for v0.4 if we want offline-first first-run
+   (stapled ticket vs. CDN fetch). Not on the v0.3 critical path.

--- a/tools/spike-harness/probes/macos-notarization-sea/notarize.sh
+++ b/tools/spike-harness/probes/macos-notarization-sea/notarize.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# notarize.sh — Notarize a Node 22 SEA binary with hardened runtime + JIT (T9.12).
+#
+# Spike for Task #111. Pinned by spec ch14 §1.13.
+#
+# Contract (forever-stable per ch14 §1.B):
+#   Inputs (env):
+#     APPLE_TEAM_ID            — 10-char Apple Developer team identifier
+#     APPLE_SIGNING_IDENTITY   — exact `security find-identity` line, e.g.
+#                                "Developer ID Application: Acme Co (XXXXXXXXXX)"
+#     APPLE_NOTARY_PROFILE     — `xcrun notarytool store-credentials` keychain
+#                                profile name holding Apple ID + app-specific pw
+#     SEA_BINARY               — absolute path to the SEA-built Node binary
+#                                (produced by ../sea-3os/build.sh)
+#   Inputs (files, sibling to this script):
+#     ../../entitlements-jit.plist   — canonical hardened-runtime entitlements
+#                                      (allow-jit + allow-unsigned-executable-memory)
+#     Info.plist                     — bundle metadata for the Mach-O
+#
+#   Outputs:
+#     dist/<basename>.signed         — signed + notarized + stapled Mach-O
+#     dist/notarize.log              — full pipeline log
+#     dist/notarytool-submission.json — `notarytool submit --output-format json`
+#
+#   Exit:
+#     0   — sign + submit + Accepted + staple all succeeded; binary verifies.
+#     20  — gate not satisfied (missing env / non-darwin / missing toolchain).
+#     21  — codesign failed.
+#     22  — notarytool submit failed or returned non-Accepted status.
+#     23  — staple / verify failed.
+#
+# Algorithm (per Apple TN3147 + `notarytool` 2025 docs):
+#   0. Gate: refuse on non-darwin or when any required env var is unset.
+#      This is the documented Apple Dev ID cert prerequisite (see PROBE-RESULT.md).
+#   1. codesign --sign "$APPLE_SIGNING_IDENTITY" --options runtime
+#               --entitlements ../../entitlements-jit.plist
+#               --identifier "$BUNDLE_ID"
+#               --info-plist Info.plist
+#               --timestamp --force
+#               "$SEA_BINARY"
+#   2. ditto -c -k --keepParent "$SEA_BINARY" dist/submit.zip
+#      (notarytool requires zip / dmg / pkg input; bare Mach-O is rejected)
+#   3. xcrun notarytool submit dist/submit.zip
+#               --keychain-profile "$APPLE_NOTARY_PROFILE"
+#               --wait --output-format json
+#               > dist/notarytool-submission.json
+#      Assert .status == "Accepted".
+#   4. xcrun stapler staple "$SEA_BINARY" || true   # bare Mach-O cannot be
+#      stapled; the notarization ticket lives in Apple's CDN. We instead
+#      verify with `spctl -a -vv -t install` to confirm Gatekeeper is happy.
+#   5. codesign --verify --deep --strict --verbose=2 "$SEA_BINARY"
+#      spctl --assess --type execute --verbose=4 "$SEA_BINARY"
+#
+# Layer 1: bash + Apple's bundled `codesign` / `xcrun notarytool` / `stapler`
+# / `spctl` / `ditto`. No npm deps.
+#
+# This probe DOES NOT RUN until the Apple Dev ID cert + notarytool keychain
+# profile gate is satisfied (see PROBE-RESULT.md §"Gate / blockers").
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DIST="$HERE/dist"
+ENTITLEMENTS="$HERE/../../entitlements-jit.plist"
+INFO_PLIST="$HERE/Info.plist"
+
+mkdir -p "$DIST"
+: > "$DIST/notarize.log"
+log() { echo "[notarize] $*" | tee -a "$DIST/notarize.log"; }
+
+# ---- 0. gate ----
+if [ "$(uname -s)" != "Darwin" ]; then
+  log "GATE: non-darwin host ($(uname -s)); macOS notarization requires macOS."
+  exit 20
+fi
+
+MISSING=()
+[ -n "${APPLE_TEAM_ID:-}" ]           || MISSING+=("APPLE_TEAM_ID")
+[ -n "${APPLE_SIGNING_IDENTITY:-}" ]  || MISSING+=("APPLE_SIGNING_IDENTITY")
+[ -n "${APPLE_NOTARY_PROFILE:-}" ]    || MISSING+=("APPLE_NOTARY_PROFILE")
+[ -n "${SEA_BINARY:-}" ]              || MISSING+=("SEA_BINARY")
+if [ ${#MISSING[@]} -gt 0 ]; then
+  log "GATE: missing required env: ${MISSING[*]}"
+  log "      See PROBE-RESULT.md §'Gate / blockers' for the cert provisioning steps."
+  exit 20
+fi
+
+for tool in codesign xcrun ditto spctl; do
+  command -v "$tool" >/dev/null 2>&1 || { log "GATE: missing tool: $tool"; exit 20; }
+done
+xcrun --find notarytool >/dev/null 2>&1 || { log "GATE: notarytool not in xcrun (need Xcode 13+)"; exit 20; }
+xcrun --find stapler    >/dev/null 2>&1 || { log "GATE: stapler not in xcrun"; exit 20; }
+
+[ -f "$ENTITLEMENTS" ] || { log "GATE: entitlements plist missing at $ENTITLEMENTS"; exit 20; }
+[ -f "$INFO_PLIST" ]   || { log "GATE: Info.plist missing at $INFO_PLIST"; exit 20; }
+[ -f "$SEA_BINARY" ]   || { log "GATE: SEA_BINARY does not exist: $SEA_BINARY"; exit 20; }
+
+BUNDLE_ID="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$INFO_PLIST")"
+BIN_BASENAME="$(basename "$SEA_BINARY")"
+log "team=$APPLE_TEAM_ID identity=$APPLE_SIGNING_IDENTITY profile=$APPLE_NOTARY_PROFILE"
+log "binary=$SEA_BINARY ($(stat -f %z "$SEA_BINARY") bytes) bundle-id=$BUNDLE_ID"
+
+# ---- 1. codesign with hardened runtime + JIT entitlements ----
+log "step 1: codesign --options runtime + JIT entitlements"
+codesign --sign "$APPLE_SIGNING_IDENTITY" \
+         --options runtime \
+         --entitlements "$ENTITLEMENTS" \
+         --identifier "$BUNDLE_ID" \
+         --timestamp \
+         --force \
+         "$SEA_BINARY" >> "$DIST/notarize.log" 2>&1 || { log "FAIL step 1: codesign"; exit 21; }
+
+# Verify the signature locally before submitting (cheap fail-fast).
+codesign --verify --deep --strict --verbose=2 "$SEA_BINARY" >> "$DIST/notarize.log" 2>&1 \
+  || { log "FAIL step 1 verify: codesign --verify"; exit 21; }
+
+# ---- 2. zip for notarytool ----
+log "step 2: ditto -> dist/submit.zip"
+SUBMIT_ZIP="$DIST/submit.zip"
+rm -f "$SUBMIT_ZIP"
+ditto -c -k --keepParent "$SEA_BINARY" "$SUBMIT_ZIP"
+
+# ---- 3. notarytool submit --wait ----
+log "step 3: notarytool submit --wait"
+SUBMISSION_JSON="$DIST/notarytool-submission.json"
+xcrun notarytool submit "$SUBMIT_ZIP" \
+      --keychain-profile "$APPLE_NOTARY_PROFILE" \
+      --wait \
+      --output-format json \
+      > "$SUBMISSION_JSON" 2>> "$DIST/notarize.log" \
+      || { log "FAIL step 3: notarytool submit (see $SUBMISSION_JSON)"; exit 22; }
+
+STATUS="$(/usr/bin/python3 -c "import json,sys;print(json.load(open(sys.argv[1])).get('status',''))" "$SUBMISSION_JSON")"
+log "notarytool status=$STATUS"
+if [ "$STATUS" != "Accepted" ]; then
+  log "FAIL step 3: notarization status='$STATUS' (expected Accepted)"
+  log "Pull full log:  xcrun notarytool log <id> --keychain-profile $APPLE_NOTARY_PROFILE"
+  exit 22
+fi
+
+# ---- 4. staple (best-effort on bare Mach-O) + 5. spctl assess ----
+log "step 4: stapler staple (may warn for bare Mach-O — ticket lives on Apple CDN)"
+xcrun stapler staple "$SEA_BINARY" >> "$DIST/notarize.log" 2>&1 || \
+  log "  (stapler warned; bare Mach-O cannot embed ticket — verifying via spctl instead)"
+
+log "step 5: spctl --assess"
+if ! spctl --assess --type execute --verbose=4 "$SEA_BINARY" >> "$DIST/notarize.log" 2>&1; then
+  log "FAIL step 5: spctl assess rejected the binary"
+  exit 23
+fi
+
+cp "$SEA_BINARY" "$DIST/${BIN_BASENAME}.signed"
+log "OK — signed+notarized binary at $DIST/${BIN_BASENAME}.signed"
+exit 0


### PR DESCRIPTION
## Summary

Lands T9.12 macOS notarization spike scaffolding under `tools/spike-harness/probes/macos-notarization-sea/` per spec ch14 §1.13. Refactor-only; no runtime/product code touched.

- `notarize.sh` — codesign (`--options runtime` + `--entitlements ../../entitlements-jit.plist` + `--timestamp`) -> `ditto` zip -> `xcrun notarytool submit --wait` -> `stapler staple` -> `spctl --assess`. Forever-stable contract per ch14 §1.B documented in the script header (inputs, outputs, exit codes 0/20/21/22/23).
- `Info.plist` — sample bundle metadata (the seven keys notarytool requires) embedded into the bare Mach-O at codesign time.
- `PROBE-RESULT.md` — documents the **ops gate (Apple Developer Program enrollment + `Developer ID Application` certificate + notarytool keychain profile)** blocking phase 0, plus the full reproduction recipe for when the gate is satisfied.
- `tools/spike-harness/README.md` inventory updated.

The hardened-runtime entitlements are **not duplicated** here; the probe references the canonical forever-stable `tools/spike-harness/entitlements-jit.plist` (allow-jit + allow-unsigned-executable-memory) via relative path, so the contract stays single-sourced.

## Layer 1 notes

- No new deps (Apple's bundled `codesign` / `xcrun notarytool` / `stapler` / `spctl` / `ditto`; bash for glue).
- No reinventing the wheel — the recipe is straight from Apple TN3127/TN3147 and the `notarytool` 2025 docs.
- Probe is gated and refuses to run unless every prereq is satisfied (exit 20), so it cannot accidentally damage a binary on a misconfigured host.

## Local verification

Bash syntax check + gate dry-run on the Windows host:

```
$ bash -n tools/spike-harness/probes/macos-notarization-sea/notarize.sh
OK-syntax
$ bash tools/spike-harness/probes/macos-notarization-sea/notarize.sh
[notarize] GATE: non-darwin host (MINGW64_NT-10.0-26200); macOS notarization requires macOS.
EXIT=20
```

Gate fires correctly (exit 20 = gate not satisfied) without attempting any destructive step. Live `darwin` run remains TODO behind the ops prereq documented in `PROBE-RESULT.md` §"Gate / blockers".

## Test plan

- [ ] Ops provisions the Apple `Developer ID Application` certificate + `xcrun notarytool store-credentials ccsm-notary` on a `macos-latest` runner.
- [ ] On that runner, run `bash tools/spike-harness/probes/sea-3os/build.sh` (T9.9 sibling) to produce the SEA Node 22 binary.
- [ ] Run `APPLE_TEAM_ID=… APPLE_SIGNING_IDENTITY=… APPLE_NOTARY_PROFILE=ccsm-notary SEA_BINARY=… bash tools/spike-harness/probes/macos-notarization-sea/notarize.sh`.
- [ ] Confirm `notarytool` returns `status: Accepted`, `spctl --assess` exits 0, and `dist/<binary>.signed` is produced.
- [ ] Re-record `PROBE-RESULT.md` with the real submission id + log.

Spec: ch14 §1.13. Task: #111 (T9.12).