### PR TITLE
spike(T9.3): Win 11 25H2 loopback HTTP/2 cleartext probe

### DIFF
--- a/tools/spike-harness/README.md
+++ b/tools/spike-harness/README.md
@@ -43,3 +43,5 @@ Cross-link: chapter 11 §2 / §6 pins this path; chapter 12 §3 reuses
 | `probes/uds-h2c/run.sh`          | §1.4 (T9.4)       | smoke (60s) + 1h soak driver        |
 | `probes/win-h2-named-pipe/{server,client}.mjs` | §1.5 (T9.5) | runnable on win32; non-win32 skip |
 | `probes/win-h2-named-pipe/run.sh` | §1.5 (T9.5)      | smoke (60s) + 1h soak driver        |
+| `probes/loopback-h2c-on-25h2/{server,client}.mjs` | §1.3 (T9.3) | runnable on win32; non-win32 skip |
+| `probes/loopback-h2c-on-25h2/run.sh` | §1.3 (T9.3)   | smoke (60s) + 1h soak driver (Win 11 25H2) |

--- a/tools/spike-harness/probes/loopback-h2c-on-25h2/RESULT.md
+++ b/tools/spike-harness/probes/loopback-h2c-on-25h2/RESULT.md
@@ -1,0 +1,91 @@
+# T9.3 spike — Win 11 25H2 loopback HTTP/2 cleartext (h2c)
+
+**Status:** smoke harness landed and verified GREEN on Win 11 25H2 (build
+26200). 1h soak deferred to self-hosted Windows runner per spec ch10 +
+Task #16 (T0.10).
+
+**Why this spike exists:** ch14 §1.3 phase 0.5 — before we lock the
+transport-pick row in ch14 §1.A matrix, we must rule out the risk that the
+Win 11 25H2 networking stack (new TCP/IP fast path + reorganized loopback
+driver) breaks plaintext HTTP/2 on `127.0.0.1`. Listener B
+(`127.0.0.1:PORT_TUNNEL`, h2c upstream of `cloudflared`) does not work if
+that assumption fails. This probe is the Windows counterpart to the
+`uds-h2c` spike (T9.4), which covers darwin/linux.
+
+## Files
+
+- `server.mjs` — `node:http2` cleartext server bound to `127.0.0.1`
+  ephemeral port; routes `GET /ping → pong` (unary RTT) and
+  `GET /stream?n=&hz=` (server-streaming NDJSON for
+  `stream-truncation-detector.mjs`); writes the kernel-assigned port to a
+  port-file; SIGTERM-safe.
+- `client.mjs` — `node:http2` client over loopback TCP (port discovered via
+  `--port-file` or passed via `--port`); 10 req/sec, configurable duration;
+  per-request RTT NDJSON to stderr, summary JSON to stdout; verdict
+  `PASS`/`FAIL`. Drops the `/proc/self/fd` snapshot (Windows has no
+  equivalent cheap probe and `lsof`/`handle.exe` would break the
+  stdlib-only Layer 1 constraint); RSS climb is the leak proxy.
+- `run.sh` — orchestrates server start → client soak → teardown; pipes RTT
+  NDJSON through the existing `tools/spike-harness/rtt-histogram.mjs`.
+  win32-only (skip exit 2 on non-win32 — `uds-h2c` covers those).
+
+## Smoke verification on this host (Win 11 25H2, build 26200)
+
+```
+$ ver
+Microsoft Windows [Version 10.0.26200.8246]
+
+$ SPIKE_DURATION_SEC=10 bash tools/spike-harness/probes/loopback-h2c-on-25h2/run.sh
+starting server (host=127.0.0.1, ephemeral port -> /tmp/ccsm-loopback-h2c-port)
+running client (duration=10s, rate=10/s)
+--- summary ---
+{"durationSec":10,"sent":91,"ok":91,"errors":0,
+ "p50Us":1096,"p95Us":1545,"p99Us":8546,
+ "rssStartBytes":50847744,"rssEndBytes":50925568,"rssDeltaBytes":77824,
+ "verdict":"PASS","verdictReason":"thresholds met"}
+--- histogram ---
+{"count":91,"skipped":0,"minUs":804,"maxUs":8546,"meanUs":1204.5,
+ "p50Us":1096,"p95Us":1545,"p99Us":8546,"bucketUs":100,"buckets":[...]}
+exit=0
+```
+
+`node --check` passes for both `.mjs` files; `bash -n run.sh` passes.
+
+## Decision criterion (encoded in client.mjs)
+
+A run is **PASS** iff both hold over the full duration:
+
+1. error rate ≤ **1 %** (`errors / sent`)
+2. RSS climb ≤ **50 MB** (`process.memoryUsage().rss` end − start)
+
+Any FAIL exits 3 from the client (and from `run.sh`).
+
+## Recommendation for ch14 §1.A transport choice (win32)
+
+The 10-second smoke on real Win 11 25H2 hardware (build 26200) shows the
+loopback h2c path is healthy: zero errors, p50 ~1.1 ms, p95 ~1.5 ms, RSS
+delta ~76 KB across 91 unary round-trips. **The ch14 §1.3 phase 0.5 risk
+is retired** — Win 11 25H2 does not break loopback HTTP/2 cleartext, and
+the transport-pick row in ch14 §1.A may proceed under the assumption that
+**Listener B = `127.0.0.1:PORT_TUNNEL` over h2c** is viable on Windows, on
+parity with darwin/linux (covered by `uds-h2c` smoke).
+
+The 1h soak on a self-hosted Windows runner (T0.10) remains the gate before
+we declare the row final, but this smoke is sufficient to unblock downstream
+T9.x design choices that depend on that row.
+
+## Reuse vs. greenfield
+
+This probe deliberately mirrors the `uds-h2c` (T9.4) shape so a single set
+of operator runbooks and verdict thresholds covers both transports. The
+shared helpers `rtt-histogram.mjs` and `stream-truncation-detector.mjs` are
+reused as-is (per ch14 §1.B forever-stable contract). No new npm deps; the
+probe is `node:` stdlib only.
+
+## Follow-ups
+
+- T0.10 (#16): wire this `run.sh` into the self-hosted Win 11 25H2 runner
+  with `SPIKE_DURATION_SEC=3600`. Capture `loopback-h2c-summary.json` +
+  `loopback-h2c-histogram.json` as build artifacts.
+- T9.5: parallel named-pipe spike (UDS replacement for Windows Listener A)
+  is independent of this probe; this spike only covers Listener B.

--- a/tools/spike-harness/probes/loopback-h2c-on-25h2/client.mjs
+++ b/tools/spike-harness/probes/loopback-h2c-on-25h2/client.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+// client.mjs — http2 (h2c) client over loopback TCP, sustained-traffic soak driver.
+//
+// Spike T9.3 (ch14 §1.3 phase 0.5): drives N req/sec against server.mjs for
+// SPIKE_DURATION_SEC seconds (default 60 smoke; 3600 = 1h soak). Records
+// p50/p95/p99 RTT, error count, and RSS delta. Per-RTT NDJSON goes to stderr
+// for piping through tools/spike-harness/rtt-histogram.mjs.
+//
+// Forever-stable contract:
+//
+//   Usage:
+//     client.mjs [--host=<addr>]      default 127.0.0.1
+//                [--port=<int>]       required if --port-file not given
+//                [--port-file=<path>] read port from this file if --port absent
+//                [--rate=<n>]         req/sec, default 10
+//                [--duration=<sec>]   overrides SPIKE_DURATION_SEC
+//
+//   Env:
+//     SPIKE_DURATION_SEC   default 60 (smoke). 3600 = 1h soak.
+//
+//   Output (stdout, single trailing JSON line):
+//     {"durationSec":<num>,"sent":<int>,"ok":<int>,"errors":<int>,
+//      "p50Us":<int>,"p95Us":<int>,"p99Us":<int>,
+//      "rssStartBytes":<int>,"rssEndBytes":<int>,"rssDeltaBytes":<int>,
+//      "verdict":"PASS"|"FAIL","verdictReason":"<str>"}
+//
+//   Per-request RTT lines (NDJSON) go to stderr so they can be piped to
+//   rtt-histogram.mjs without polluting the summary.
+//
+//   Exit codes: 0 PASS; 3 FAIL (errors > 1% or RSS climb > 50 MB);
+//               2 bad arg / unsupported OS; 1 connect failure.
+//
+// Layer-1: node: stdlib only.
+
+import { connect } from 'node:http2';
+import { parseArgs } from 'node:util';
+import { readFileSync } from 'node:fs';
+import { platform, tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+if (platform() !== 'win32') {
+  process.stderr.write(`loopback-h2c-on-25h2 client: non-win32 (${platform()}) — skipped\n`);
+  process.exit(2);
+}
+
+const { values } = parseArgs({
+  options: {
+    host:        { type: 'string', default: '127.0.0.1' },
+    port:        { type: 'string' },
+    'port-file': { type: 'string', default: join(tmpdir(), 'ccsm-loopback-h2c-port') },
+    rate:        { type: 'string', default: '10' },
+    duration:    { type: 'string' },
+  },
+  strict: true,
+});
+
+const host = values.host;
+let port = values.port !== undefined ? Number(values.port) : NaN;
+if (!Number.isFinite(port)) {
+  try {
+    port = Number(readFileSync(values['port-file'], 'utf8').trim());
+  } catch (e) {
+    process.stderr.write(`failed to read --port-file ${values['port-file']}: ${e.message}\n`);
+    process.exit(2);
+  }
+}
+if (!Number.isFinite(port) || port <= 0 || port > 65535) {
+  process.stderr.write('bad --port / --port-file content\n');
+  process.exit(2);
+}
+
+const rate = Number(values.rate);
+const durationSec = Number(values.duration ?? process.env.SPIKE_DURATION_SEC ?? '60');
+if (!Number.isFinite(rate) || rate <= 0) { process.stderr.write('bad --rate\n'); process.exit(2); }
+if (!Number.isFinite(durationSec) || durationSec <= 0) { process.stderr.write('bad --duration\n'); process.exit(2); }
+
+const session = connect(`http://${host}:${port}`);
+
+session.on('error', (err) => {
+  process.stderr.write(`session error: ${err.message}\n`);
+});
+
+await new Promise((resolve, reject) => {
+  const t = setTimeout(() => reject(new Error('connect timeout')), 5000);
+  session.once('connect', () => { clearTimeout(t); resolve(); });
+  session.once('error',   (e) => { clearTimeout(t); reject(e); });
+}).catch((e) => {
+  process.stderr.write(`failed to connect: ${e.message}\n`);
+  process.exit(1);
+});
+
+const samples = [];
+let sent = 0;
+let ok = 0;
+let errors = 0;
+const rssStart = process.memoryUsage().rss;
+
+function doRequest() {
+  const start = process.hrtime.bigint();
+  sent++;
+  const req = session.request({ ':method': 'GET', ':path': '/ping' });
+  let body = '';
+  req.setEncoding('utf8');
+  req.on('data', (chunk) => { body += chunk; });
+  req.on('end', () => {
+    const rttUs = Number((process.hrtime.bigint() - start) / 1000n);
+    if (body === 'pong') {
+      ok++;
+      samples.push(rttUs);
+      process.stderr.write(JSON.stringify({ rttUs }) + '\n');
+    } else {
+      errors++;
+    }
+  });
+  req.on('error', () => { errors++; });
+  req.end();
+}
+
+const intervalMs = 1000 / rate;
+const startMs = Date.now();
+const endMs = startMs + durationSec * 1000;
+
+const reqTimer = setInterval(() => {
+  if (Date.now() >= endMs) return;
+  doRequest();
+}, intervalMs);
+
+await new Promise((resolve) => setTimeout(resolve, durationSec * 1000));
+clearInterval(reqTimer);
+
+// Drain in-flight (cap 2s).
+await new Promise((resolve) => setTimeout(resolve, Math.min(2000, intervalMs * 5)));
+
+session.close();
+
+samples.sort((a, b) => a - b);
+const pct = (p) => samples.length === 0 ? 0 : samples[Math.min(samples.length - 1, Math.floor(p * samples.length))];
+const rssEnd = process.memoryUsage().rss;
+const rssDelta = rssEnd - rssStart;
+
+// Verdict thresholds (mirrors uds-h2c probe; fd-snapshot dropped — Windows
+// has no equivalent cheap probe and lsof / handle.exe would break Layer-1
+// stdlib-only constraint):
+//   - error rate <= 1 %
+//   - RSS climb <= 50 MB
+const errRatio = sent === 0 ? 1 : errors / sent;
+let verdict = 'PASS';
+let verdictReason = 'thresholds met';
+if (errRatio > 0.01) {
+  verdict = 'FAIL';
+  verdictReason = `error ratio ${(errRatio * 100).toFixed(2)}% > 1%`;
+} else if (rssDelta > 50 * 1024 * 1024) {
+  verdict = 'FAIL';
+  verdictReason = `RSS climbed ${rssDelta} bytes > 50MB`;
+}
+
+process.stdout.write(JSON.stringify({
+  durationSec,
+  sent,
+  ok,
+  errors,
+  p50Us: pct(0.50),
+  p95Us: pct(0.95),
+  p99Us: pct(0.99),
+  rssStartBytes: rssStart,
+  rssEndBytes:   rssEnd,
+  rssDeltaBytes: rssDelta,
+  verdict,
+  verdictReason,
+}) + '\n');
+
+process.exit(verdict === 'PASS' ? 0 : 3);

--- a/tools/spike-harness/probes/loopback-h2c-on-25h2/run.sh
+++ b/tools/spike-harness/probes/loopback-h2c-on-25h2/run.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# run.sh — launch loopback-h2c (h2c on 127.0.0.1) server, run client soak, tear down.
+#
+# Spike T9.3 (ch14 §1.3 phase 0.5): smoke (60s default) or 1h soak via
+# SPIKE_DURATION_SEC=3600. **win32 only** — this probe exists to catch
+# Win 11 25H2 networking-stack regressions on loopback h2c. On non-win32
+# the harness short-circuits with exit 2 (uds-h2c covers darwin/linux per
+# T9.4).
+#
+# Forever-stable contract:
+#
+#   Usage:
+#     run.sh
+#
+#   Env:
+#     SPIKE_DURATION_SEC   default 60. Forwarded to client.mjs.
+#     SPIKE_HOST           default 127.0.0.1.
+#     SPIKE_PORT_FILE      default $TMP/ccsm-loopback-h2c-port.
+#     SPIKE_LOG_DIR        default $TMP.
+#
+#   Output:
+#     - server stdout/stderr -> $SPIKE_LOG_DIR/loopback-h2c-server.log
+#     - client RTT NDJSON   -> $SPIKE_LOG_DIR/loopback-h2c-rtt.ndjson
+#     - client summary JSON -> $SPIKE_LOG_DIR/loopback-h2c-summary.json + stdout
+#     - rtt-histogram JSON  -> $SPIKE_LOG_DIR/loopback-h2c-histogram.json + stdout
+#
+#   Exit codes: 0 PASS; 3 FAIL (forwarded from client); 2 unsupported OS;
+#               1 server start failure.
+
+set -euo pipefail
+
+OS_NAME="$(uname -s)"
+case "$OS_NAME" in
+  MINGW*|MSYS*|CYGWIN*|Windows_NT) ;;
+  *)
+    echo "loopback-h2c-on-25h2 spike: skipped on $OS_NAME (win32-only probe; darwin/linux use uds-h2c)" >&2
+    exit 2
+    ;;
+esac
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+HARNESS_DIR="$(cd "$HERE/../.." && pwd)"
+
+# Normalize $TMP across MSYS/Git Bash/Cygwin.
+DEFAULT_TMP="${TMP:-${TEMP:-/tmp}}"
+HOST="${SPIKE_HOST:-127.0.0.1}"
+PORT_FILE="${SPIKE_PORT_FILE:-$DEFAULT_TMP/ccsm-loopback-h2c-port}"
+LOG_DIR="${SPIKE_LOG_DIR:-$DEFAULT_TMP}"
+DURATION="${SPIKE_DURATION_SEC:-60}"
+
+mkdir -p "$LOG_DIR"
+
+SERVER_LOG="$LOG_DIR/loopback-h2c-server.log"
+RTT_NDJSON="$LOG_DIR/loopback-h2c-rtt.ndjson"
+SUMMARY="$LOG_DIR/loopback-h2c-summary.json"
+HISTOGRAM="$LOG_DIR/loopback-h2c-histogram.json"
+
+SERVER_PID=""
+cleanup() {
+  if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" 2>/dev/null; then
+    kill -TERM "$SERVER_PID" 2>/dev/null || true
+    for _ in 1 2 3 4; do
+      if ! kill -0 "$SERVER_PID" 2>/dev/null; then break; fi
+      sleep 0.5
+    done
+    if kill -0 "$SERVER_PID" 2>/dev/null; then
+      kill -KILL "$SERVER_PID" 2>/dev/null || true
+    fi
+  fi
+  if [ -f "$PORT_FILE" ]; then
+    rm -f "$PORT_FILE" || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+# Stale port-file guard (server overwrites too, belt-and-braces).
+[ -f "$PORT_FILE" ] && rm -f "$PORT_FILE"
+
+echo "starting server (host=$HOST, ephemeral port -> $PORT_FILE)" >&2
+node "$HERE/server.mjs" --host="$HOST" --port=0 --port-file="$PORT_FILE" \
+  >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+# Wait up to 5s for "listening" line.
+for _ in $(seq 1 50); do
+  if grep -q "^listening " "$SERVER_LOG" 2>/dev/null; then
+    break
+  fi
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo "server died during startup; log:" >&2
+    cat "$SERVER_LOG" >&2
+    exit 1
+  fi
+  sleep 0.1
+done
+
+if ! grep -q "^listening " "$SERVER_LOG" 2>/dev/null; then
+  echo "server did not become ready in 5s; log:" >&2
+  cat "$SERVER_LOG" >&2
+  exit 1
+fi
+
+echo "running client (duration=${DURATION}s, rate=10/s)" >&2
+set +e
+SPIKE_DURATION_SEC="$DURATION" node "$HERE/client.mjs" \
+  --host="$HOST" --port-file="$PORT_FILE" --rate=10 \
+  >"$SUMMARY" 2>"$RTT_NDJSON"
+CLIENT_EXIT=$?
+set -e
+
+echo "--- summary ---"
+cat "$SUMMARY"
+
+# Feed RTT lines through the existing histogram helper.
+if [ -s "$RTT_NDJSON" ]; then
+  node "$HARNESS_DIR/rtt-histogram.mjs" <"$RTT_NDJSON" >"$HISTOGRAM"
+  echo "--- histogram ---"
+  cat "$HISTOGRAM"
+fi
+
+exit "$CLIENT_EXIT"

--- a/tools/spike-harness/probes/loopback-h2c-on-25h2/server.mjs
+++ b/tools/spike-harness/probes/loopback-h2c-on-25h2/server.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+// server.mjs — Node 22 http2 (h2c) server bound to 127.0.0.1 (loopback TCP).
+//
+// Spike T9.3 (ch14 §1.3 phase 0.5): confirm Win 11 25H2 still allows plaintext
+// HTTP/2 (h2c) on a loopback TCP listener with no third-party LSP/firewall
+// hook breaking it. This unblocks the transport pick row in ch14 §1.A matrix
+// (Listener B = `127.0.0.1:PORT_TUNNEL`, h2c upstream of cloudflared) by
+// retiring the "what if 25H2's new networking stack drops h2c on loopback"
+// risk before we commit to that wire format.
+//
+// This probe is the Windows counterpart to the uds-h2c spike (T9.4): same
+// server/client/run shape, swapping UDS for loopback TCP, and gating on
+// win32.
+//
+// Forever-stable contract (per spike-harness/README.md §"Forever-stable"):
+//
+//   Usage:
+//     server.mjs [--host=<addr>] [--port=<int>] [--port-file=<path>]
+//                  default host 127.0.0.1; port 0 (ephemeral); port-file
+//                  defaults to $TMP/ccsm-loopback-h2c-port.
+//
+//   Behavior:
+//     - createSecureServer is NOT used; this is plaintext h2c (cleartext)
+//       per ch14 §1.3 phase 0.5 — the loopback TCP listener is consumed
+//       only by the local cloudflared sidecar (Listener B) and gated by
+//       JWT validation at the listener boundary.
+//     - Listens on host:port (port 0 → kernel-assigned).
+//     - Writes the chosen port to <port-file> as a single line, then prints
+//       "listening <host>:<port>\n" to stdout.
+//     - Routes:
+//         GET  /ping     -> 200, body "pong"           (unary RTT probe)
+//         GET  /stream?n=<int>&hz=<int>  -> 200, server-streaming NDJSON
+//             frames (one per line) of the form
+//                 {"seq":<int>,"ts":<unix-ms>,"len":<int>}
+//             until n frames sent at hz frames/sec, then end. Defaults
+//             n=1000, hz=100. Compatible with stream-truncation-detector.mjs.
+//         anything else  -> 404
+//     - On SIGTERM / SIGINT: graceful close, remove port-file, exit 0.
+//
+//   Exit codes: 0 clean shutdown; 2 bad arg / unsupported OS; 1 fatal listen
+//               error.
+//
+// Layer-1: node: stdlib only (http2, fs, util, os, path).
+
+import { createServer } from 'node:http2';
+import { existsSync, unlinkSync, writeFileSync } from 'node:fs';
+import { parseArgs } from 'node:util';
+import { platform, tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+if (platform() !== 'win32') {
+  process.stderr.write(`loopback-h2c-on-25h2 server: non-win32 (${platform()}) — skipped\n`);
+  process.exit(2);
+}
+
+const { values } = parseArgs({
+  options: {
+    host:        { type: 'string', default: '127.0.0.1' },
+    port:        { type: 'string', default: '0' },
+    'port-file': { type: 'string', default: join(tmpdir(), 'ccsm-loopback-h2c-port') },
+  },
+  strict: true,
+});
+
+const host = values.host;
+const port = Number(values.port);
+const portFile = values['port-file'];
+if (!Number.isFinite(port) || port < 0 || port > 65535) {
+  process.stderr.write('bad --port\n');
+  process.exit(2);
+}
+
+const server = createServer();
+
+server.on('stream', (stream, headers) => {
+  const path = headers[':path'] ?? '';
+  const method = headers[':method'];
+  if (method === 'GET' && path === '/ping') {
+    stream.respond({ ':status': 200, 'content-type': 'text/plain' });
+    stream.end('pong');
+    return;
+  }
+  if (method === 'GET' && path.startsWith('/stream')) {
+    const qs = path.includes('?') ? path.slice(path.indexOf('?') + 1) : '';
+    const params = new URLSearchParams(qs);
+    const n  = Math.max(1, Math.min(1_000_000, Number(params.get('n')  ?? '1000') | 0));
+    const hz = Math.max(1, Math.min(100_000,   Number(params.get('hz') ?? '100')  | 0));
+    stream.respond({ ':status': 200, 'content-type': 'application/x-ndjson' });
+    let seq = 0;
+    const intervalMs = 1000 / hz;
+    const tick = setInterval(() => {
+      if (stream.destroyed || stream.closed) { clearInterval(tick); return; }
+      const line = JSON.stringify({ seq, ts: Date.now(), len: 0 }) + '\n';
+      stream.write(line);
+      seq++;
+      if (seq >= n) {
+        clearInterval(tick);
+        stream.end();
+      }
+    }, intervalMs);
+    stream.on('close', () => clearInterval(tick));
+    return;
+  }
+  stream.respond({ ':status': 404 });
+  stream.end();
+});
+
+server.on('error', (err) => {
+  process.stderr.write(`server error: ${err.message}\n`);
+});
+
+let shuttingDown = false;
+function shutdown(sig) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  process.stderr.write(`got ${sig}, shutting down\n`);
+  server.close(() => {
+    try { if (existsSync(portFile)) unlinkSync(portFile); } catch { /* ignore */ }
+    process.exit(0);
+  });
+  // Hard timeout so a stuck client can't pin the spike.
+  setTimeout(() => process.exit(0), 2000).unref();
+}
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT',  () => shutdown('SIGINT'));
+
+server.listen({ host, port }, () => {
+  const addr = server.address();
+  if (!addr || typeof addr === 'string') {
+    process.stderr.write('failed to read server address\n');
+    process.exit(1);
+  }
+  try {
+    writeFileSync(portFile, String(addr.port));
+  } catch (e) {
+    process.stderr.write(`failed to write port-file ${portFile}: ${e.message}\n`);
+    process.exit(1);
+  }
+  process.stdout.write(`listening ${addr.address}:${addr.port}\n`);
+});


### PR DESCRIPTION
## Summary

Task #108. Lands `tools/spike-harness/probes/loopback-h2c-on-25h2/` — the Windows-side counterpart to the `uds-h2c` (T9.4) probe. Resolves ch14 §1.3 phase 0.5 (does Win 11 25H2 still allow plaintext HTTP/2 on a `127.0.0.1` listener) before the transport-pick row in ch14 §1.A is locked.

- `server.mjs` — `node:http2` cleartext server on `127.0.0.1` ephemeral port; `/ping` (unary) + `/stream?n=&hz=` (server-streaming NDJSON, compatible with `stream-truncation-detector.mjs`); SIGTERM-safe; port written to a port-file.
- `client.mjs` — `node:http2` client; 10 req/s soak, configurable duration; per-RTT NDJSON to stderr, summary JSON to stdout; verdict thresholds mirror `uds-h2c` (error rate ≤ 1 %, RSS climb ≤ 50 MB; the `/proc/self/fd` snapshot is dropped on Windows since stdlib has no equivalent and `lsof`/`handle.exe` would break Layer 1).
- `run.sh` — orchestrates start → soak → teardown; pipes RTT NDJSON through the existing `tools/spike-harness/rtt-histogram.mjs`. **win32-only** (skip exit 2 elsewhere — `uds-h2c` covers darwin/linux).
- `RESULT.md` — spike notes + recommendation for ch14 §1.A.
- `README.md` — inventory row added.

## Local verification (Win 11 25H2, build 26200)

```
$ ver
Microsoft Windows [Version 10.0.26200.8246]

$ node --check server.mjs && node --check client.mjs && bash -n run.sh && echo OK
OK

$ SPIKE_DURATION_SEC=10 bash tools/spike-harness/probes/loopback-h2c-on-25h2/run.sh
starting server (host=127.0.0.1, ephemeral port -> /tmp/ccsm-loopback-h2c-port)
running client (duration=10s, rate=10/s)
--- summary ---
{"durationSec":10,"sent":91,"ok":91,"errors":0,
 "p50Us":1096,"p95Us":1545,"p99Us":8546,
 "rssStartBytes":50847744,"rssEndBytes":50925568,"rssDeltaBytes":77824,
 "verdict":"PASS","verdictReason":"thresholds met"}
--- histogram ---
{"count":91,"skipped":0,"minUs":804,"maxUs":8546,"meanUs":1204.5,
 "p50Us":1096,"p95Us":1545,"p99Us":8546,"bucketUs":100,"buckets":[...]}
exit=0
```

Verdict: **PASS**. The ch14 §1.3 phase 0.5 risk is retired — Win 11 25H2 does not break loopback h2c, so the transport-pick row in ch14 §1.A may proceed under the assumption that Listener B = `127.0.0.1:PORT_TUNNEL` over h2c is viable on Windows on parity with darwin/linux.

## Layer 1 / reuse

- `node:` stdlib only (`http2`, `fs`, `os`, `path`, `util`). No npm deps.
- Reuses `tools/spike-harness/rtt-histogram.mjs` (forever-stable per ch14 §1.B).
- Mirrors the `uds-h2c` (T9.4) shape so a single set of operator runbooks and verdict thresholds covers both transports.
- `tools/spike-harness/**` is in `eslint.config.js` ignores per existing precedent; `node --check` + `bash -n` are sufficient.

## Test plan

- [x] `node --check` for both `.mjs` files (PASS)
- [x] `bash -n run.sh` (PASS)
- [x] 10 s smoke on real Win 11 25H2 hardware (PASS, 91/91 ok)
- [ ] T0.10 (#16): wire `run.sh` into the self-hosted Win 11 25H2 runner with `SPIKE_DURATION_SEC=3600` for the 1 h soak.

## Cross-links

- Task #108 — this spike.
- Task #16 (T0.10) — self-hosted runner that will exercise the 1 h soak.
- T9.4 / `uds-h2c` — sibling probe for darwin/linux.