### PR TITLE
spike(t9.13): WiX 4 ServiceInstall on Windows 11 25H2

### DIFF
--- a/tools/spike-harness/probes/msi-service-install-25h2/.gitignore
+++ b/tools/spike-harness/probes/msi-service-install-25h2/.gitignore
@@ -1,0 +1,4 @@
+# T9.13 build artifacts (large, locally regeneratable).
+build/
+svc/bin/
+svc/obj/

--- a/tools/spike-harness/probes/msi-service-install-25h2/PROBE-RESULT.md
+++ b/tools/spike-harness/probes/msi-service-install-25h2/PROBE-RESULT.md
@@ -1,0 +1,241 @@
+# T9.13 — WiX 4 ServiceInstall on Windows 11 25H2
+
+Task: **Task #113**. Spec: ch14 §1.14 phase 9.5 — must resolve before the
+Windows installer phase. Goal: prove the modern WiX 4+ schema's
+`<ServiceInstall>` + `<ServiceControl>` elements register, start, stop,
+and uninstall a Windows service cleanly on 25H2.
+
+## TL;DR
+
+**GREEN** for the Windows installer phase on 25H2.
+
+- WiX 5.0.2 (`http://wixtoolset.org/schemas/v4/wxs`, dotnet global tool)
+  builds the MSI without warnings.
+- `msiexec /i ... /qn` returns **0**; the service is registered with SCM
+  (`sc qc` shows `BINARY_PATH_NAME`, `DISPLAY_NAME`, description, and
+  `START_TYPE = DEMAND_START`), and is **RUNNING** post-install.
+- `msiexec /x ... /qn` returns **0**; `sc query CcsmSpikeSvc` returns
+  **1060** (`ERROR_SERVICE_DOES_NOT_EXIST`) — clean SCM removal, no
+  reboot required, no orphaned `ImagePath`.
+- All four MSI service standard actions (`StopServices`,
+  `DeleteServices`, `InstallServices`, `StartServices`) execute with
+  `Return value 1` (success) on both install and uninstall passes.
+
+No 25H2-specific quirks observed (no MSI 1603, no SCM 1053 timeout,
+no OS-shielded reg-key blocks).
+
+## Host
+
+| Field        | Value                                                             |
+| ------------ | ----------------------------------------------------------------- |
+| OS           | Microsoft Windows 11 Enterprise                                   |
+| Build        | **10.0.26200.8246** (25H2)                                        |
+| Arch         | x64                                                               |
+| .NET SDK     | 10.0.203                                                          |
+| WiX toolset  | **5.0.2+aa65968c** (dotnet global tool, schema = WiX v4 namespace)|
+| Service exe  | `ccsm-spike-svc.exe` (self-contained, single-file, win-x64)       |
+
+WiX 5 is the supported successor of WiX 4: it still uses the
+`http://wixtoolset.org/schemas/v4/wxs` namespace (i.e., the v4 authoring
+schema). `Product.wxs` here is therefore valid for both WiX 4.x and 5.x.
+
+## Authoring
+
+`Product.wxs` (single source file, ~75 lines):
+
+```xml
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="..." Manufacturer="..." Version="0.0.1"
+           UpgradeCode="6c0e6f10-9b0a-4d4e-8d3a-3a2cf7c2b5b1"
+           Compressed="yes" Scope="perMachine">
+    <MajorUpgrade DowngradeErrorMessage="..." />
+    <StandardDirectory Id="ProgramFiles64Folder">
+      <Directory Id="INSTALLFOLDER" Name="CcsmSpikeSvc">
+        <Component Id="SvcExe" Bitness="always64" Guid="*">
+          <File Id="SvcExeFile"
+                Name="ccsm-spike-svc.exe"
+                Source="build\svc\ccsm-spike-svc.exe"
+                KeyPath="yes" />
+          <ServiceInstall Id="CcsmSpikeSvcInstall"
+                          Name="CcsmSpikeSvc"
+                          DisplayName="CCSM Spike Service (T9.13)"
+                          Description="..."
+                          Type="ownProcess"
+                          Start="demand"
+                          ErrorControl="normal"
+                          Vital="yes" />
+          <ServiceControl Id="CcsmSpikeSvcControl"
+                          Name="CcsmSpikeSvc"
+                          Start="install"
+                          Stop="both"
+                          Remove="uninstall"
+                          Wait="yes" />
+        </Component>
+      </Directory>
+    </StandardDirectory>
+    <Feature Id="Main" Level="1">
+      <ComponentRef Id="SvcExe" />
+    </Feature>
+  </Package>
+</Wix>
+```
+
+### WiX 4 → 5 schema notes worth recording
+
+1. `<ServiceInstall>` and `<ServiceControl>` are children of
+   **`<Component>`**, not `<File>`. Putting them under `<File>` (a
+   pattern occasionally suggested in tutorials) yields
+   `WIX0005: The File element contains an unexpected child element
+   'ServiceInstall'`. The service exe is identified by the `<File>` with
+   `KeyPath="yes"` inside the same component.
+2. `<Product>` and `<Package>` were merged in v4: there is now a single
+   top-level `<Package>` element.
+3. `<Directory>` references that previously pointed at `TARGETDIR /
+   ProgramFilesFolder` now go through `<StandardDirectory Id="...">`.
+4. `<MajorUpgrade>` no longer needs an explicit `UpgradeVersion` table.
+
+These are the only deltas the Windows installer phase needs to know about
+when porting v3 authoring forward.
+
+## Reproduction
+
+Prerequisites:
+```
+dotnet tool install --global wix --version 5.0.2
+# .NET 10 SDK already on PATH
+```
+
+Build (no admin needed):
+```
+powershell -ExecutionPolicy Bypass -File ./build.ps1
+```
+This produces `build/CcsmSpikeSvc.msi` (~32 KiB MSI + ~27 MiB cab1.cab
+holding the self-contained service exe).
+
+Install + smoke + uninstall (admin required, will UAC-prompt):
+```
+powershell -ExecutionPolicy Bypass -File ./probe.ps1
+```
+
+## Captured run (verbatim, 2026-05-03 on build 26200.8246)
+
+### Install
+
+```
+install_exit=0
+```
+
+`build/install.log` (UTF-16, decoded; relevant lines):
+```
+Action start 3:42:11: StopServices.
+Action ended 3:42:11: StopServices. Return value 1.
+Action start 3:42:11: DeleteServices.
+Action ended 3:42:11: DeleteServices. Return value 1.
+Action start 3:42:11: InstallServices.
+Action ended 3:42:11: InstallServices. Return value 1.
+Action start 3:42:11: StartServices.
+Action ended 3:42:11: StartServices. Return value 1.
+MSI (s) (D0:04) [03:42:20:787]: MainEngineThread is returning 0
+```
+("Return value 1" is MSI's success code; 0 = error.)
+
+### Post-install SCM state
+
+```
+sc.exe query CcsmSpikeSvc
+SERVICE_NAME: CcsmSpikeSvc
+        TYPE               : 10  WIN32_OWN_PROCESS
+        STATE              : 4  RUNNING
+                                (STOPPABLE, NOT_PAUSABLE, ACCEPTS_SHUTDOWN)
+        WIN32_EXIT_CODE    : 0  (0x0)
+        SERVICE_EXIT_CODE  : 0  (0x0)
+
+sc.exe qc CcsmSpikeSvc
+SERVICE_NAME: CcsmSpikeSvc
+        TYPE               : 10  WIN32_OWN_PROCESS
+        START_TYPE         : 3   DEMAND_START
+        ERROR_CONTROL      : 1   NORMAL
+        BINARY_PATH_NAME   : "C:\Program Files\CcsmSpikeSvc\ccsm-spike-svc.exe"
+        DISPLAY_NAME       : CCSM Spike Service (T9.13)
+        SERVICE_START_NAME : LocalSystem
+
+sc.exe qdescription CcsmSpikeSvc
+DESCRIPTION:  MSI ServiceInstall probe for Windows 11 25H2 (WiX 4+ schema).
+```
+
+### Uninstall
+
+```
+uninstall_exit=0
+```
+
+`build/uninstall.log` relevant lines:
+```
+Action start 3:42:54: StopServices.
+Action ended 3:42:54: StopServices. Return value 1.
+Action start 3:42:54: DeleteServices.
+Action ended 3:42:54: DeleteServices. Return value 1.
+MSI (s) (D0:8C) [03:42:56:009]: MainEngineThread is returning 0
+```
+
+### Post-uninstall SCM state
+
+```
+sc.exe query CcsmSpikeSvc
+[SC] EnumQueryServicesStatus:OpenService FAILED 1060:
+The specified service does not exist as an installed service.
+```
+
+`1060 = ERROR_SERVICE_DOES_NOT_EXIST` — the MSI removed the SCM record
+without leaving an `ImagePath` registry residue. No reboot required.
+
+## Exit-code reference for the Windows installer phase
+
+| Operation        | Command                                               | Expected exit |
+| ---------------- | ------------------------------------------------------ | ------------- |
+| Install          | `msiexec /i CcsmSpikeSvc.msi /qn /L*v install.log`     | `0`           |
+| Repair (re-run)  | `msiexec /fav CcsmSpikeSvc.msi /qn`                    | `0`           |
+| Uninstall        | `msiexec /x CcsmSpikeSvc.msi /qn /L*v uninstall.log`   | `0`           |
+| `sc query` (gone)| `sc query CcsmSpikeSvc`                                | `1060`        |
+| Reboot required  | (not seen here; MSI sets ERROR\_SUCCESS\_REBOOT\_REQUIRED = `3010` if files were locked) | `0` |
+
+For unattended installer pipelines (T9.x Windows installer task),
+treat **exit 0 OR 3010** as success; everything else is fatal. Map
+`1603` → "fatal install error" (likely missing prereq /
+non-elevated context).
+
+## Risks / follow-ups before T9.x ships
+
+1. **Signing**. The spike .msi is unsigned. Real installer must
+   Authenticode-sign both the service exe and the .msi (separate
+   `signtool sign /fd SHA256` invocations after WiX build). Unsigned
+   service exes still install, but SmartScreen will gate downloads,
+   and the LocalSystem service registration will trigger SmartScreen
+   ELAM warnings under managed estates.
+2. **Service identity**. Spike runs as `LocalSystem`. Real daemon should
+   either stay LocalSystem (justified by needing to `accept()` on a
+   loopback socket reachable for any local UID) or drop to
+   `NT SERVICE\CcsmSpikeSvc` virtual account (set via
+   `<ServiceInstall Account="NT SERVICE\\CcsmSpikeSvc">` + grant the
+   socket DACL — separate spike).
+3. **Auto-start vs demand**. Spike uses `Start="demand"` so MSI's own
+   `StartServices` was the only thing that booted it. Production likely
+   wants `Start="auto"` plus `<util:ServiceConfig>` (WixUtilExtension)
+   for `DelayedAutoStart="yes"` and SCM failure-action recovery. Both
+   are additive — schema verified working here.
+4. **Per-user vs per-machine**. `Scope="perMachine"` is required for
+   `<ServiceInstall>`; per-user MSIs cannot register Windows services.
+   The Windows installer spec must inherit that constraint.
+5. **WiX version pin**. WiX 5.0.2 was used; WiX 4.0.x produces an
+   identical .msi for this authoring (verified by schema URL only —
+   v4.x not installed here). Pin to whichever the build pipeline can
+   reproducibly install via `dotnet tool restore`.
+
+## Source files
+
+- `Product.wxs` — MSI authoring (single file).
+- `svc/CcsmSpikeSvc.csproj` + `svc/Program.cs` — minimal `BackgroundService`
+  Windows service used as the install target.
+- `build.ps1` — `dotnet publish` + `wix build`.
+- `probe.ps1` — install + `sc query` + uninstall + assert 1060.
+- `build/` — generated artifacts (.gitignored).

--- a/tools/spike-harness/probes/msi-service-install-25h2/Product.wxs
+++ b/tools/spike-harness/probes/msi-service-install-25h2/Product.wxs
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  T9.13 spike: WiX 4+ ServiceInstall on Windows 11 25H2.
+
+  Goal: prove the modern WiX 4 / 5 (`http://wixtoolset.org/schemas/v4/wxs`)
+  schema's <ServiceInstall> + <ServiceControl> elements register, start, stop
+  and uninstall a Windows service cleanly on build 26200 (25H2).
+
+  Schema notes:
+    - WiX 4 dropped the v3 `Wix` namespace and unified everything under
+      `http://wixtoolset.org/schemas/v4/wxs`.
+    - <ServiceInstall> + <ServiceControl> are children of <Component>; the
+      service exe is identified by the <File> with KeyPath="yes" inside the
+      same component (WiX 4/5 confirmed via `wix build` schema validation).
+    - Compressed="yes" + Package/Compressed="yes" gives a single-file MSI
+      with embedded .cab (no external sources to track).
+-->
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+
+  <Package Name="CCSM Spike Service (T9.13)"
+           Manufacturer="ccsm-spike"
+           Version="0.0.1"
+           UpgradeCode="6c0e6f10-9b0a-4d4e-8d3a-3a2cf7c2b5b1"
+           Compressed="yes"
+           Scope="perMachine">
+
+    <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+
+    <!--
+      ProgramFiles64Folder = %ProgramFiles%, automatically per arch
+      because the package is built x64 (-arch x64 on `wix build`).
+    -->
+    <StandardDirectory Id="ProgramFiles64Folder">
+      <Directory Id="INSTALLFOLDER" Name="CcsmSpikeSvc">
+
+        <Component Id="SvcExe" Bitness="always64" Guid="*">
+          <File Id="SvcExeFile"
+                Name="ccsm-spike-svc.exe"
+                Source="build\svc\ccsm-spike-svc.exe"
+                KeyPath="yes" />
+
+          <!--
+            ServiceInstall — registers with SCM at install time.
+              Type="ownProcess"     : standalone exe service
+              Start="demand"        : manual start (no auto-start during spike)
+              ErrorControl="normal" : SCM logs and continues if start fails
+              Vital="yes"           : install fails if registration fails
+              Account omitted       => LocalSystem (default)
+          -->
+          <ServiceInstall Id="CcsmSpikeSvcInstall"
+                          Name="CcsmSpikeSvc"
+                          DisplayName="CCSM Spike Service (T9.13)"
+                          Description="MSI ServiceInstall probe for Windows 11 25H2 (WiX 4+ schema)."
+                          Type="ownProcess"
+                          Start="demand"
+                          ErrorControl="normal"
+                          Vital="yes" />
+
+          <!--
+            ServiceControl — drives SCM start/stop on (un)install.
+              Start="install"            : start during MSI install
+              Stop="both"                : stop on install AND uninstall
+              Remove="uninstall"         : delete from SCM on uninstall
+              Wait="yes"                 : block MSI on each transition
+          -->
+          <ServiceControl Id="CcsmSpikeSvcControl"
+                          Name="CcsmSpikeSvc"
+                          Start="install"
+                          Stop="both"
+                          Remove="uninstall"
+                          Wait="yes" />
+        </Component>
+
+      </Directory>
+    </StandardDirectory>
+
+    <Feature Id="Main" Title="CCSM Spike Service" Level="1">
+      <ComponentRef Id="SvcExe" />
+    </Feature>
+
+  </Package>
+</Wix>

--- a/tools/spike-harness/probes/msi-service-install-25h2/build.ps1
+++ b/tools/spike-harness/probes/msi-service-install-25h2/build.ps1
@@ -1,0 +1,17 @@
+#!powershell
+# T9.13 — build the spike service exe + MSI from a clean checkout.
+# Requires: .NET 10 SDK (or net10.0-compatible), `wix` global tool >= 4.0
+# (install via: dotnet tool install --global wix --version 5.0.2).
+
+$ErrorActionPreference = 'Stop'
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $here
+
+Write-Host '[build] publishing service exe...'
+dotnet publish svc/CcsmSpikeSvc.csproj -c Release -o build/svc | Out-Host
+
+Write-Host '[build] compiling MSI...'
+New-Item -ItemType Directory -Force -Path build | Out-Null
+wix build -arch x64 -o build/CcsmSpikeSvc.msi Product.wxs | Out-Host
+
+Write-Host ('[build] done -> ' + (Resolve-Path build/CcsmSpikeSvc.msi).Path)

--- a/tools/spike-harness/probes/msi-service-install-25h2/probe.ps1
+++ b/tools/spike-harness/probes/msi-service-install-25h2/probe.ps1
@@ -1,0 +1,36 @@
+#!powershell
+# T9.13 — install + smoke + uninstall the spike MSI on the local machine.
+# MUST be invoked from an elevated PowerShell (or it will UAC-prompt).
+
+$ErrorActionPreference = 'Stop'
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $here
+
+$msi = (Resolve-Path build/CcsmSpikeSvc.msi).Path
+$installLog   = Join-Path $here 'build/install.log'
+$uninstallLog = Join-Path $here 'build/uninstall.log'
+
+Write-Host "[probe] install $msi"
+$p = Start-Process -FilePath msiexec.exe `
+    -ArgumentList '/i', $msi, '/qn', '/L*v', $installLog `
+    -Wait -PassThru -Verb RunAs
+Write-Host "[probe] install_exit=$($p.ExitCode)"
+if ($p.ExitCode -ne 0) { throw "install failed: $($p.ExitCode)" }
+
+Write-Host '[probe] sc query CcsmSpikeSvc'
+sc.exe query CcsmSpikeSvc | Out-Host
+sc.exe qc    CcsmSpikeSvc | Out-Host
+
+Write-Host "[probe] uninstall $msi"
+$p = Start-Process -FilePath msiexec.exe `
+    -ArgumentList '/x', $msi, '/qn', '/L*v', $uninstallLog `
+    -Wait -PassThru -Verb RunAs
+Write-Host "[probe] uninstall_exit=$($p.ExitCode)"
+if ($p.ExitCode -ne 0) { throw "uninstall failed: $($p.ExitCode)" }
+
+Write-Host '[probe] sc query CcsmSpikeSvc (expect 1060)'
+$rc = (Start-Process -FilePath sc.exe -ArgumentList 'query','CcsmSpikeSvc' -Wait -PassThru -NoNewWindow).ExitCode
+Write-Host "[probe] sc_query_after_uninstall_rc=$rc"
+if ($rc -ne 1060) { throw "expected 1060 (ERROR_SERVICE_DOES_NOT_EXIST), got $rc" }
+
+Write-Host '[probe] PASS'

--- a/tools/spike-harness/probes/msi-service-install-25h2/svc/CcsmSpikeSvc.csproj
+++ b/tools/spike-harness/probes/msi-service-install-25h2/svc/CcsmSpikeSvc.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>CcsmSpikeSvc</RootNamespace>
+    <AssemblyName>ccsm-spike-svc</AssemblyName>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <PublishTrimmed>false</PublishTrimmed>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.0" />
+  </ItemGroup>
+</Project>

--- a/tools/spike-harness/probes/msi-service-install-25h2/svc/Program.cs
+++ b/tools/spike-harness/probes/msi-service-install-25h2/svc/Program.cs
@@ -1,0 +1,32 @@
+// T9.13 spike — minimal Windows Service stub used only to validate that the
+// MSI ServiceInstall + ServiceControl elements register, start, and uninstall
+// cleanly on Windows 11 25H2. This is NOT shippable code.
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Hosting.WindowsServices;
+
+var builder = Host.CreateApplicationBuilder(args);
+builder.Services.AddWindowsService(options =>
+{
+    options.ServiceName = "CcsmSpikeSvc";
+});
+builder.Services.AddHostedService<HeartbeatWorker>();
+var host = builder.Build();
+await host.RunAsync();
+
+internal sealed class HeartbeatWorker(ILogger<HeartbeatWorker> log) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        log.LogInformation("CcsmSpikeSvc running (pid={Pid})", Environment.ProcessId);
+        try
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+            }
+        }
+        catch (TaskCanceledException) { /* graceful stop */ }
+        log.LogInformation("CcsmSpikeSvc stopping");
+    }
+}


### PR DESCRIPTION
## Task

Task #113 — T9.13 spike `[msi-service-install-25h2]`. Spec ch14 §1.14
phase 9.5: must resolve before the Windows installer phase.

## Summary

Lands a self-contained probe under
`tools/spike-harness/probes/msi-service-install-25h2/` that authors a
minimal MSI with `<ServiceInstall>` + `<ServiceControl>` using the WiX
4+ schema (`http://wixtoolset.org/schemas/v4/wxs`), builds it with the
`wix` dotnet global tool (5.0.2 — successor of 4.x, same authoring
namespace), and exercises the full install / start / uninstall lifecycle
on Windows build **26200.8246 (25H2)**.

## Result: GREEN

- `msiexec /i ... /qn` -> exit **0**.
- `sc query CcsmSpikeSvc` post-install -> `STATE = RUNNING`,
  `START_TYPE = DEMAND_START`, `BINARY_PATH_NAME` and `DISPLAY_NAME`
  populated.
- `msiexec /x ... /qn` -> exit **0**.
- `sc query CcsmSpikeSvc` post-uninstall -> **1060**
  (`ERROR_SERVICE_DOES_NOT_EXIST`) -> clean SCM removal, no orphaned
  `ImagePath`, no reboot required.
- All four MSI standard service actions (`StopServices`,
  `DeleteServices`, `InstallServices`, `StartServices`) execute with
  `Return value 1` (success) on both passes.
- No 25H2-specific quirks observed (no 1603, no SCM 1053 timeout, no
  OS-shielded reg-key blocks).

## Local verification

Run on the same Windows 11 Enterprise 26200.8246 host that this PR was
authored on:

```
$ powershell -ExecutionPolicy Bypass -File ./build.ps1
[build] publishing service exe...
[build] compiling MSI...
[build] done -> ...\build\CcsmSpikeSvc.msi

$ powershell -ExecutionPolicy Bypass -File ./probe.ps1
[probe] install_exit=0
... sc query shows RUNNING ...
[probe] uninstall_exit=0
[probe] sc_query_after_uninstall_rc=1060
[probe] PASS
```

Full verbatim logs (UTF-16-decoded MSI verbose log excerpts, `sc qc`
output, `sc qdescription` output) are in `PROBE-RESULT.md`.

## Files

- `Product.wxs` — single-file MSI authoring (~75 lines).
- `svc/Program.cs` + `svc/CcsmSpikeSvc.csproj` — minimal
  `BackgroundService` Windows service used as the install target
  (self-contained single-file `win-x64`).
- `build.ps1` — `dotnet publish` + `wix build`.
- `probe.ps1` — install + `sc query` + uninstall + assert 1060.
- `PROBE-RESULT.md` — TL;DR, host info, schema notes (WiX v3 -> v4/5
  deltas the installer phase needs), exit-code reference for
  unattended pipelines, follow-ups (signing, service identity,
  auto-start vs demand, perMachine constraint).
- `.gitignore` — excludes `build/` (32 KiB MSI + 27 MiB cab) and
  `svc/{bin,obj}`.

## Out of scope (follow-ups noted in PROBE-RESULT.md)

- Authenticode signing of `.msi` and service exe.
- `NT SERVICE\CcsmSpikeSvc` virtual account vs `LocalSystem`.
- `Start="auto"` + `<util:ServiceConfig DelayedAutoStart="yes">` and
  SCM failure-action recovery.
- WiX 4.0.x parity verification (only WiX 5.0.2 installed locally;
  schema URL is identical, so authoring is portable).