### PR TITLE
spike(t9.2): macOS UDS cross-user reachability probe (no FDA)

### DIFF
--- a/tools/spike-harness/README.md
+++ b/tools/spike-harness/README.md
@@ -43,3 +43,5 @@ Cross-link: chapter 11 §2 / §6 pins this path; chapter 12 §3 reuses
 | `probes/uds-h2c/run.sh`          | §1.4 (T9.4)       | smoke (60s) + 1h soak driver        |
 | `probes/win-h2-named-pipe/{server,client}.mjs` | §1.5 (T9.5) | runnable on win32; non-win32 skip |
 | `probes/win-h2-named-pipe/run.sh` | §1.5 (T9.5)      | smoke (60s) + 1h soak driver        |
+| `probes/macos-uds-cross-user/{server,client}.mjs` | §1.2 (T9.2) | runnable on darwin; linux/win32 skip |
+| `probes/macos-uds-cross-user/run.sh` | §1.2 (T9.2)   | bind-path × cross-user matrix driver |

--- a/tools/spike-harness/probes/macos-uds-cross-user/PROBE-RESULT.md
+++ b/tools/spike-harness/probes/macos-uds-cross-user/PROBE-RESULT.md
@@ -1,0 +1,155 @@
+# T9.2 spike — macOS UDS cross-user reachability without Full Disk Access
+
+**Status:** smoke harness landed; live darwin matrix capture deferred to a
+self-hosted macOS runner with a pre-provisioned secondary local user
+(see "Follow-ups" below). Authored on Windows (`MINGW64_NT-10.0-26200`);
+on non-darwin hosts the harness short-circuits (`run.sh` exits 2, both
+`server.mjs` and `client.mjs` exit 2 on `win32`). The decision matrix in
+this document is the **spec-derived** verdict that the live runner is
+expected to confirm; any divergence the runner observes overrides this
+file and must trigger a follow-up before listener-A wiring proceeds on
+darwin.
+
+Spec anchor: ch14 §1.2 phase 0.5 — "macOS UDS cross-user reachability
+without Full Disk Access; must resolve before listener-A wiring on
+macOS." Listener-A is defined in
+`docs/superpowers/specs/2026-05-02-final-architecture.md` line 87 as the
+"peer-cred-trusted local socket (UDS / named pipe). JWT bypass.
+Same-UID processes only." The cross-user probe quantifies what happens
+when that same-UID assumption is violated by a process running under a
+different local account.
+
+## Files
+
+- `server.mjs` — UDS line-echo server (`net.createServer`), `chmod 0666`
+  on bind so any cross-user denial is attributable to TCC/FDA rather
+  than POSIX permission bits. SIGTERM-safe socket unlink. Stdlib only.
+- `client.mjs` — single-shot `connect()` probe, classifies the outcome
+  as `OK`/`EACCES`/`EPERM`/`ENOENT`/`ECONNREFUSED`/`ETIMEDOUT`/`OTHER`
+  and emits one JSON summary line. Designed to be invoked under
+  `sudo -n -u <user>` for the cross-user leg.
+- `run.sh` — iterates a 6-path candidate matrix, starts the server as
+  the invoking user, runs the client both same-user and (if
+  `SPIKE_SECONDARY_USER` is set) cross-user, then writes
+  `macos-uds-cross-user-matrix.ndjson` + `macos-uds-cross-user-summary.json`
+  to `$SPIKE_LOG_DIR` (default `/tmp`).
+
+## How to run on a real darwin host
+
+```bash
+# Required: a second local user whose login shell can be sudo'd into
+# without a password prompt. Suggested: `dscl . -create /Users/ccsmprobe`
+# + a NOPASSWD sudoers entry scoped to /usr/local/bin/node.
+SPIKE_SECONDARY_USER=ccsmprobe \
+  bash tools/spike-harness/probes/macos-uds-cross-user/run.sh
+```
+
+Then re-render the "Live capture" section below from
+`/tmp/macos-uds-cross-user-summary.json`.
+
+## Verdict legend
+
+The driver assigns one of four verdicts per (path, leg) row:
+
+| Verdict | Meaning | Implication for listener-A |
+| --- | --- | --- |
+| `FDA-FREE` | `connect()` succeeds without any TCC grant. | Path is safe for cross-user listener-A *if* peer-cred check rejects the connection at the application layer (the kernel already lets the connect through, so application-level UID enforcement is mandatory). |
+| `FDA-REQUIRED` | Path lives under a TCC-protected scope (`~/Library/...`, `~/Documents`, etc.) and the cross-user `connect()` returns `EPERM` / `EACCES` / `ENOENT`. | Cross-user reach is *blocked by the OS by default*, but a user who has granted FDA to the connecting binary (Terminal, an IDE, another Electron app) bypasses the block. Treat as defence-in-depth, never as the primary boundary. |
+| `UNREACHABLE` | Bind failed, or peer connect timed out / hit an unexpected errno. | Don't pick this path. |
+| `SKIPPED` | `SPIKE_SECONDARY_USER` was unset, so the cross-user leg wasn't run. | Re-run on a real darwin host. |
+
+## Decision matrix (spec-derived; confirm with live capture)
+
+Same-user leg is expected to be `OK`/`FDA-FREE` for every path the
+primary user can bind. Cross-user verdicts below assume the connecting
+user has **no** FDA grant, which is the worst-case for the daemon
+(any other state is strictly more permissive).
+
+| Bind path | tccProtected | Cross-user verdict (no FDA) | Cross-user with FDA on connector | Recommended for listener-A? |
+| --- | :---: | --- | --- | --- |
+| `/tmp/<sock>` | no | `FDA-FREE` (kernel allows; only POSIX perms gate) | same | candidate, but `/tmp` is world-writable and the socket can be `unlink()`'d by anyone; reject |
+| `/private/tmp/<sock>` | no | identical to `/tmp/<sock>` (alias) | same | reject for the same reason |
+| `/Users/Shared/<sock>` | no | `FDA-FREE` | same | candidate; `/Users/Shared` is the documented Apple-blessed cross-user spot, mode `1777`, not TCC-fenced. Pair with `chmod 0600` + peer-cred to keep it same-UID-only |
+| `~/Library/Caches/<sock>` | yes | `FDA-REQUIRED` (TCC denies cross-user `connect()`) | `OK` (FDA bypasses TCC) | **recommended** for listener-A: same-UID processes connect freely, cross-user processes are kernel-blocked unless the *user* has explicitly granted FDA, which is a deliberate choice. Defence-in-depth on top of peer-cred, not a replacement for it |
+| `~/Library/Application Support/<sock>` | yes | `FDA-REQUIRED` | `OK` | acceptable; `~/Library/Caches` preferred because Caches is documented as expendable (matches v0.3 "daemon socket can be re-bound on restart") |
+| `~/Documents/<sock>` | yes | `FDA-REQUIRED` (Documents is a TCC-fenced "user data" location) | `OK` | reject — semantically wrong (sockets are not user documents) and triggers a TCC prompt cascade for any app that opens the file picker there |
+
+## Recommendation feeding listener-A wiring
+
+1. **Bind path on darwin: `~/Library/Caches/ccsm/daemon.sock`** (resolved
+   from `$HOME` at daemon start, `mkdir -p` the parent with `0700`,
+   `chmod 0600` on the socket). This delivers two layers:
+   - POSIX: `0600` rejects every non-`euid==daemon-uid` connect with
+     `EACCES` at the kernel.
+   - TCC: even if the user widens permissions later, the parent path
+     sits inside `~/Library`, so a cross-user connector still needs FDA
+     to reach it. FDA is a deliberate user grant; we don't have to
+     defend against the user explicitly opting in.
+2. **Application-layer peer-cred check is still mandatory.** TCC and
+   POSIX perms are defence-in-depth. The daemon must call
+   `getsockopt(LOCAL_PEERCRED, ...)` on every accepted UDS connection
+   and drop anything whose `uid` ≠ daemon's `euid`. The
+   `tools/spike-harness/connect-and-peercred.sh` helper (T9.1's
+   contract) is the reference implementation.
+3. **Do NOT bind under `/tmp`, `/private/tmp`, or `/Users/Shared`** for
+   listener-A. Even with `0600` they sit outside any TCC fence; a stale
+   socket file from a prior run can be `unlink()`'d by any local user,
+   creating a reliable bind-squat race window during daemon restart.
+   `~/Library/Caches` closes that race because the parent itself is
+   `0700`-by-default and TCC-fenced.
+4. **Do NOT rely on FDA as the primary boundary.** A user with FDA on
+   their daily-driver Terminal (very common on developer machines)
+   would bypass the TCC layer; the POSIX `0600` + peer-cred check is
+   what actually keeps cross-user processes out.
+
+This pins the macOS half of the listener-A transport choice; the linux
+counterpart (T9.4 `uds-h2c`) already locks `option A (h2c-over-UDS)` on
+linux pending its own 1h soak.
+
+## Live capture (TODO — populate from real darwin run)
+
+Schema for the matrix file (one JSON object per line):
+
+```json
+{"path":"/tmp/ccsm-spike-…","leg":"same-user","tccProtected":false,
+ "outcome":"OK","errno":null,"rttMs":1,"verdict":"FDA-FREE"}
+```
+
+Schema for the summary file:
+
+```json
+{ "rows": 12,
+  "counts": { "FDA-FREE": N, "FDA-REQUIRED": M, "UNREACHABLE": K, "SKIPPED": 0 },
+  "byPath": { "<path>": { "same-user": {...}, "cross-user": {...} } } }
+```
+
+Once captured, paste the `summary.json` `byPath` block here and confirm
+the verdict column above row-for-row. Any `UNREACHABLE` or any
+divergence from the spec-derived table escalates to manager before
+listener-A wiring proceeds.
+
+## Smoke verification on this host (win32)
+
+```
+$ bash tools/spike-harness/probes/macos-uds-cross-user/run.sh
+macos-uds-cross-user: skipped on MINGW64_NT-10.0-26200 (UDS path semantics differ)
+exit=2
+```
+
+`node --check` passes for both `.mjs` files; `bash -n run.sh` passes;
+the harness directory is in eslint `ignores` per
+`tools/spike-harness/README.md` Layer-1 constraint, so syntax-check is
+the gate.
+
+## Follow-ups
+
+- T0.10 (#16): provision a secondary local user (`ccsmprobe`) on the
+  self-hosted darwin runner with a `NOPASSWD` sudoers entry scoped to
+  `node` only; wire `run.sh` into the runner with `SPIKE_SECONDARY_USER=
+  ccsmprobe`. Capture `matrix.ndjson` + `summary.json` as build
+  artifacts and update the "Live capture" section.
+- Open question for T9.x (peer-cred): whether `getsockopt(LOCAL_PEERCRED)`
+  on darwin returns the *connecting* process's `euid` or its `ruid`. The
+  daemon must reject suid-promoted connectors; this affects the test
+  matrix shape, not the bind-path choice. Track separately so this spike
+  doesn't grow.

--- a/tools/spike-harness/probes/macos-uds-cross-user/client.mjs
+++ b/tools/spike-harness/probes/macos-uds-cross-user/client.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+// client.mjs — single-shot UDS connect probe.
+//
+// Spike T9.2 (spec ch14 §1.2 phase 0.5): connect() to a UDS path, send one
+// line, read the echo, classify the outcome. Designed to be invoked under
+// `sudo -u <other-user>` so the probe driver can quantify cross-user
+// reachability with and without TCC/FDA grants.
+//
+// Forever-stable contract:
+//
+//   Usage:
+//     client.mjs --socket=<path> [--timeout-ms=<n>] [--message=<str>]
+//
+//   Output (stdout, single trailing JSON line):
+//     {"socket":<path>,"euid":<int>,"egid":<int>,
+//      "outcome":"OK"|"EACCES"|"EPERM"|"ENOENT"|"ECONNREFUSED"|"ETIMEDOUT"|"OTHER",
+//      "errno":<str|null>,"message":<str|null>,
+//      "rttMs":<int|null>,"reply":<str|null>}
+//
+//   Exit codes:
+//     0 OK (echo round-trip succeeded)
+//     3 connect/read failure (any non-OK outcome — still emits JSON)
+//     2 bad arg or unsupported OS
+//
+//   The driver script (run.sh) classifies EPERM as the TCC/FDA signal on
+//   darwin (kernel returns EPERM when sandbox/TCC blocks UDS connect under
+//   protected paths like ~/Library/...). EACCES is the POSIX-perm signal.
+//
+// Layer-1: node: stdlib only.
+
+import { connect } from 'node:net';
+import { parseArgs } from 'node:util';
+import { platform } from 'node:os';
+
+if (platform() === 'win32') {
+  process.stderr.write('macos-uds-cross-user client: win32 unsupported\n');
+  process.exit(2);
+}
+
+const { values } = parseArgs({
+  options: {
+    socket:       { type: 'string' },
+    'timeout-ms': { type: 'string', default: '3000' },
+    message:      { type: 'string', default: 'hello' },
+  },
+  strict: true,
+});
+
+if (!values.socket) {
+  process.stderr.write('--socket=<path> required\n');
+  process.exit(2);
+}
+
+const socketPath = values.socket;
+const timeoutMs = Number(values['timeout-ms']);
+if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+  process.stderr.write('bad --timeout-ms\n');
+  process.exit(2);
+}
+const message = values.message;
+
+const euid = typeof process.geteuid === 'function' ? process.geteuid() : -1;
+const egid = typeof process.getegid === 'function' ? process.getegid() : -1;
+
+function classify(err) {
+  if (!err) return 'OK';
+  switch (err.code) {
+    case 'EACCES':        return 'EACCES';
+    case 'EPERM':         return 'EPERM';
+    case 'ENOENT':        return 'ENOENT';
+    case 'ECONNREFUSED':  return 'ECONNREFUSED';
+    case 'ETIMEDOUT':     return 'ETIMEDOUT';
+    default:              return 'OTHER';
+  }
+}
+
+function emit(outcome, err, rttMs, reply) {
+  const line = JSON.stringify({
+    socket: socketPath,
+    euid,
+    egid,
+    outcome,
+    errno: err ? (err.code ?? null) : null,
+    message: err ? (err.message ?? null) : null,
+    rttMs,
+    reply,
+  });
+  process.stdout.write(line + '\n');
+  process.exit(outcome === 'OK' ? 0 : 3);
+}
+
+const start = process.hrtime.bigint();
+const sock = connect(socketPath);
+let settled = false;
+let buf = '';
+
+const timer = setTimeout(() => {
+  if (settled) return;
+  settled = true;
+  try { sock.destroy(); } catch { /* ignore */ }
+  emit('ETIMEDOUT', { code: 'ETIMEDOUT', message: `no reply within ${timeoutMs}ms` }, null, null);
+}, timeoutMs);
+
+sock.setEncoding('utf8');
+sock.on('connect', () => {
+  sock.write(`${message}\n`);
+});
+sock.on('data', (chunk) => { buf += chunk; });
+sock.on('end', () => {
+  if (settled) return;
+  settled = true;
+  clearTimeout(timer);
+  const rttMs = Number((process.hrtime.bigint() - start) / 1_000_000n);
+  if (buf.startsWith(`ack:`)) {
+    emit('OK', null, rttMs, buf.trimEnd());
+  } else {
+    emit('OTHER', { code: 'EPROTO', message: `unexpected reply: ${JSON.stringify(buf)}` }, rttMs, buf);
+  }
+});
+sock.on('error', (err) => {
+  if (settled) return;
+  settled = true;
+  clearTimeout(timer);
+  emit(classify(err), err, null, null);
+});

--- a/tools/spike-harness/probes/macos-uds-cross-user/run.sh
+++ b/tools/spike-harness/probes/macos-uds-cross-user/run.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+# run.sh — iterate macOS UDS bind-path candidates, classify cross-user
+# reachability with and without Full Disk Access (FDA).
+#
+# Spike T9.2 (spec ch14 §1.2 phase 0.5): must resolve before listener-A
+# wiring on macOS. The question: does v0.3's daemon need to bind its
+# Listener-A UDS under a path that requires the *connecting* process to
+# hold an FDA grant, and conversely which paths are reachable cross-user
+# WITHOUT FDA at all?
+#
+# Forever-stable contract:
+#
+#   Usage:
+#     run.sh
+#
+#   Env:
+#     SPIKE_SECONDARY_USER   if set, run client.mjs as this local user via
+#                            `sudo -n -u <user>` for the cross-user leg.
+#                            Required for the cross-user verdict; if unset
+#                            the script still emits the same-user matrix
+#                            and marks every cross-user row as SKIPPED.
+#     SPIKE_LOG_DIR          default /tmp. Where matrix.ndjson + server
+#                            logs land.
+#     SPIKE_BIND_MODE        chmod applied to the UDS after bind. Default
+#                            0666 (perm-permissive, so EPERM in the
+#                            cross-user leg is attributable to TCC/FDA
+#                            rather than POSIX).
+#
+#   Output:
+#     - $SPIKE_LOG_DIR/macos-uds-cross-user-matrix.ndjson  one row per
+#       (path, leg) combination. Schema:
+#         {"path":<str>,"leg":"same-user"|"cross-user","tccProtected":
+#          <bool>,"outcome":<see client.mjs>,"errno":<str|null>,
+#          "rttMs":<int|null>,"verdict":"FDA-FREE"|"FDA-REQUIRED"|
+#          "UNREACHABLE"|"SKIPPED"}
+#     - $SPIKE_LOG_DIR/macos-uds-cross-user-summary.json  aggregate
+#       counts grouped by verdict; printed to stdout too.
+#
+#   Exit codes:
+#     0  matrix collected; PROBE-RESULT.md should be regenerated from it.
+#     2  unsupported OS (only darwin is in scope; linux exits 2 because
+#        the FDA question doesn't apply, win32 exits 2 because UDS path
+#        semantics differ — see uds-h2c probe).
+#     1  server failed to start at any path (real bug, not a verdict).
+
+set -euo pipefail
+
+OS_NAME="$(uname -s)"
+case "$OS_NAME" in
+  Darwin) ;;
+  Linux)
+    echo "macos-uds-cross-user: skipped on Linux (FDA is a darwin TCC concept)" >&2
+    exit 2
+    ;;
+  MINGW*|MSYS*|CYGWIN*|Windows_NT)
+    echo "macos-uds-cross-user: skipped on $OS_NAME (UDS path semantics differ)" >&2
+    exit 2
+    ;;
+  *)
+    echo "macos-uds-cross-user: unsupported OS $OS_NAME" >&2
+    exit 2
+    ;;
+esac
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+LOG_DIR="${SPIKE_LOG_DIR:-/tmp}"
+SECONDARY_USER="${SPIKE_SECONDARY_USER:-}"
+BIND_MODE="${SPIKE_BIND_MODE:-0666}"
+
+MATRIX="$LOG_DIR/macos-uds-cross-user-matrix.ndjson"
+SUMMARY="$LOG_DIR/macos-uds-cross-user-summary.json"
+SERVER_LOG="$LOG_DIR/macos-uds-cross-user-server.log"
+
+: > "$MATRIX"
+: > "$SERVER_LOG"
+
+PRIMARY_USER="$(id -un)"
+HOME_DIR="$HOME"
+
+# Candidate matrix. Each row is "path|tccProtected".
+# tccProtected reflects Apple's documented TCC scopes (per
+# developer.apple.com/documentation/security/protecting-user-data-with-app-
+# sandbox + sandbox-exec(1) man page): ~/Library/{Application Support,
+# Containers,Preferences,Caches} are TCC-fenced; ~/Documents,Downloads,
+# Desktop are TCC-fenced for Application Data; /Users/Shared, /tmp,
+# /private/tmp, /var/run (= /private/var/run) are NOT TCC-fenced for
+# UDS connect() in the documented sandbox profile.
+#
+# /var/run is noted but skipped at runtime if not writable as $PRIMARY_USER
+# (it requires root to bind on default macOS).
+TS="$(date +%s)"
+SUFFIX="ccsm-spike-$TS-$$"
+
+CANDIDATES=(
+  "/tmp/$SUFFIX.sock|false"
+  "/private/tmp/$SUFFIX.sock|false"
+  "/Users/Shared/$SUFFIX.sock|false"
+  "$HOME_DIR/Library/Caches/$SUFFIX.sock|true"
+  "$HOME_DIR/Library/Application Support/$SUFFIX.sock|true"
+  "$HOME_DIR/Documents/$SUFFIX.sock|true"
+)
+
+# Pre-create parent dirs we own. /tmp + /private/tmp + /Users/Shared exist
+# system-wide. ~/Library/Caches and ~/Library/Application Support exist for
+# any account; ~/Documents likewise. We only mkdir -p the .sock's parent
+# defensively in case a fresh user account is missing one.
+for row in "${CANDIDATES[@]}"; do
+  path="${row%%|*}"
+  parent="$(dirname "$path")"
+  if [ ! -d "$parent" ]; then
+    mkdir -p "$parent" 2>/dev/null || true
+  fi
+done
+
+# server_pid for cleanup.
+SERVER_PID=""
+ACTIVE_SOCKET=""
+cleanup() {
+  if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" 2>/dev/null; then
+    kill -TERM "$SERVER_PID" 2>/dev/null || true
+    for _ in 1 2 3 4; do
+      kill -0 "$SERVER_PID" 2>/dev/null || break
+      sleep 0.25
+    done
+    kill -0 "$SERVER_PID" 2>/dev/null && kill -KILL "$SERVER_PID" 2>/dev/null || true
+  fi
+  if [ -n "$ACTIVE_SOCKET" ] && [ -S "$ACTIVE_SOCKET" ]; then
+    rm -f "$ACTIVE_SOCKET" || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+start_server() {
+  local socket="$1"
+  ACTIVE_SOCKET="$socket"
+  [ -S "$socket" ] && rm -f "$socket"
+  echo "=== starting server at $socket ===" >>"$SERVER_LOG"
+  node "$HERE/server.mjs" --socket="$socket" --mode="$BIND_MODE" \
+    >>"$SERVER_LOG" 2>>"$SERVER_LOG" &
+  SERVER_PID=$!
+  # Wait up to 3s for "listening" on this path.
+  for _ in $(seq 1 30); do
+    if grep -q "^listening $socket\$" "$SERVER_LOG" 2>/dev/null; then
+      return 0
+    fi
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+      return 1
+    fi
+    sleep 0.1
+  done
+  return 1
+}
+
+stop_server() {
+  if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" 2>/dev/null; then
+    kill -TERM "$SERVER_PID" 2>/dev/null || true
+    for _ in 1 2 3 4; do
+      kill -0 "$SERVER_PID" 2>/dev/null || break
+      sleep 0.25
+    done
+    kill -0 "$SERVER_PID" 2>/dev/null && kill -KILL "$SERVER_PID" 2>/dev/null || true
+  fi
+  SERVER_PID=""
+  if [ -n "$ACTIVE_SOCKET" ] && [ -S "$ACTIVE_SOCKET" ]; then
+    rm -f "$ACTIVE_SOCKET" || true
+  fi
+  ACTIVE_SOCKET=""
+}
+
+# verdict_for tccProtected outcome (echo to stdout)
+verdict_for() {
+  local tcc="$1"
+  local outcome="$2"
+  if [ "$outcome" = "OK" ]; then
+    echo "FDA-FREE"
+  elif [ "$tcc" = "true" ] && { [ "$outcome" = "EPERM" ] || [ "$outcome" = "EACCES" ] || [ "$outcome" = "ENOENT" ]; }; then
+    # TCC-fenced parent + permission/visibility denial = FDA needed for the
+    # connecting process. ENOENT shows up here because TCC can hide the
+    # path from a non-granted peer rather than return EPERM (per Apple's
+    # sandbox-exec docs on file-read-data deny-with-no-such-file).
+    echo "FDA-REQUIRED"
+  else
+    echo "UNREACHABLE"
+  fi
+}
+
+run_client_leg() {
+  local path="$1"
+  local leg="$2"      # same-user|cross-user
+  local tcc="$3"      # true|false
+  local raw=""
+  if [ "$leg" = "same-user" ]; then
+    raw="$(node "$HERE/client.mjs" --socket="$path" --timeout-ms=3000 --message="probe-$leg" 2>/dev/null || true)"
+  else
+    if [ -z "$SECONDARY_USER" ]; then
+      printf '{"path":%s,"leg":"cross-user","tccProtected":%s,"outcome":"SKIPPED","errno":null,"rttMs":null,"verdict":"SKIPPED"}\n' \
+        "$(json_str "$path")" "$tcc" >>"$MATRIX"
+      return
+    fi
+    # sudo -n: never prompt. -u: target user. We do NOT use -H so HOME
+    # stays the *primary* user's home — the probe is checking whether
+    # user-B can connect to user-A's socket, not whether user-B's own
+    # ~/Library is reachable.
+    raw="$(sudo -n -u "$SECONDARY_USER" node "$HERE/client.mjs" --socket="$path" --timeout-ms=3000 --message="probe-$leg" 2>/dev/null || true)"
+  fi
+
+  if [ -z "$raw" ]; then
+    printf '{"path":%s,"leg":%s,"tccProtected":%s,"outcome":"OTHER","errno":"NO_OUTPUT","rttMs":null,"verdict":"UNREACHABLE"}\n' \
+      "$(json_str "$path")" "$(json_str "$leg")" "$tcc" >>"$MATRIX"
+    return
+  fi
+
+  # Parse JSON via node (jq not assumed present in spike-harness Layer-1).
+  local enriched
+  enriched="$(node -e '
+    const raw = process.argv[1];
+    const tcc = process.argv[2] === "true";
+    const leg = process.argv[3];
+    let row;
+    try { row = JSON.parse(raw); } catch (e) {
+      console.log(JSON.stringify({ outcome: "OTHER", errno: "PARSE", rttMs: null }));
+      process.exit(0);
+    }
+    function verdict(tcc, outcome) {
+      if (outcome === "OK") return "FDA-FREE";
+      if (tcc && (outcome === "EPERM" || outcome === "EACCES" || outcome === "ENOENT")) return "FDA-REQUIRED";
+      return "UNREACHABLE";
+    }
+    console.log(JSON.stringify({
+      path: row.socket,
+      leg,
+      tccProtected: tcc,
+      outcome: row.outcome,
+      errno: row.errno,
+      rttMs: row.rttMs,
+      verdict: verdict(tcc, row.outcome),
+    }));
+  ' "$raw" "$tcc" "$leg")"
+  echo "$enriched" >>"$MATRIX"
+}
+
+# Tiny JSON string encoder (handles backslash + double-quote; paths on
+# darwin don't contain control chars in our matrix).
+json_str() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  printf '"%s"' "$s"
+}
+
+echo "primary user: $PRIMARY_USER" >&2
+if [ -n "$SECONDARY_USER" ]; then
+  echo "secondary user: $SECONDARY_USER (cross-user leg ENABLED)" >&2
+else
+  echo "secondary user: <unset> (cross-user leg SKIPPED — set SPIKE_SECONDARY_USER to enable)" >&2
+fi
+
+for row in "${CANDIDATES[@]}"; do
+  path="${row%%|*}"
+  tcc="${row##*|}"
+
+  echo "--- candidate: $path (tccProtected=$tcc) ---" >&2
+
+  if ! start_server "$path"; then
+    echo "  server bind failed — recording UNREACHABLE for both legs" >&2
+    bind_err="$(tail -n 5 "$SERVER_LOG" | tr '\n' ' ' | sed 's/"/\\"/g')"
+    printf '{"path":%s,"leg":"same-user","tccProtected":%s,"outcome":"OTHER","errno":"BIND_FAIL","rttMs":null,"verdict":"UNREACHABLE","bindError":"%s"}\n' \
+      "$(json_str "$path")" "$tcc" "$bind_err" >>"$MATRIX"
+    printf '{"path":%s,"leg":"cross-user","tccProtected":%s,"outcome":"OTHER","errno":"BIND_FAIL","rttMs":null,"verdict":"UNREACHABLE","bindError":"%s"}\n' \
+      "$(json_str "$path")" "$tcc" "$bind_err" >>"$MATRIX"
+    stop_server
+    continue
+  fi
+
+  run_client_leg "$path" "same-user" "$tcc"
+  run_client_leg "$path" "cross-user" "$tcc"
+  stop_server
+done
+
+# Aggregate.
+node -e '
+  const fs = require("node:fs");
+  const lines = fs.readFileSync(process.argv[1], "utf8").split("\n").filter(Boolean);
+  const counts = { "FDA-FREE": 0, "FDA-REQUIRED": 0, "UNREACHABLE": 0, "SKIPPED": 0 };
+  const byPath = {};
+  for (const l of lines) {
+    let r; try { r = JSON.parse(l); } catch { continue; }
+    counts[r.verdict] = (counts[r.verdict] ?? 0) + 1;
+    byPath[r.path] = byPath[r.path] ?? {};
+    byPath[r.path][r.leg] = { outcome: r.outcome, errno: r.errno, verdict: r.verdict };
+  }
+  const summary = { rows: lines.length, counts, byPath };
+  fs.writeFileSync(process.argv[2], JSON.stringify(summary, null, 2) + "\n");
+  console.log(JSON.stringify(summary, null, 2));
+' "$MATRIX" "$SUMMARY"
+
+echo "matrix:  $MATRIX" >&2
+echo "summary: $SUMMARY" >&2
+exit 0

--- a/tools/spike-harness/probes/macos-uds-cross-user/server.mjs
+++ b/tools/spike-harness/probes/macos-uds-cross-user/server.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+// server.mjs — minimal UDS echo server for cross-user reachability probe.
+//
+// Spike T9.2 (spec ch14 §1.2 phase 0.5): determine, on macOS, which UDS
+// bind paths are reachable from a *different local user* WITHOUT Full Disk
+// Access (FDA) being granted to the connecting process. Result feeds the
+// listener-A wiring decision (peer-cred-trusted local socket) on darwin.
+//
+// This server intentionally does NOT speak h2c — the question being probed
+// is "can the peer connect() at all" and "what does TCC do to it", not
+// throughput. A trivial line protocol keeps the failure surface obvious:
+// any non-OK exit is attributable to bind/permission/TCC, not framing.
+//
+// Forever-stable contract:
+//
+//   Usage:
+//     server.mjs --socket=<path> [--mode=<octal>]
+//
+//   Behavior:
+//     - bind(socket); on success, chmod to --mode (default 0666 so the
+//       cross-user probe can isolate TCC effects from POSIX perms).
+//     - For each connection: read one line, echo "ack:<line>\n", close.
+//     - SIGTERM/SIGINT: close listener, unlink socket, exit 0.
+//     - On bind failure: print one JSON line to stderr and exit 1.
+//     - Prints "listening <path>\n" to stdout once ready.
+//
+//   Exit codes: 0 clean shutdown; 1 bind/listen failure; 2 bad arg or
+//               unsupported OS.
+//
+// Layer-1: node: stdlib only (net, fs, util, os).
+
+import { createServer } from 'node:net';
+import { existsSync, unlinkSync, chmodSync } from 'node:fs';
+import { parseArgs } from 'node:util';
+import { platform } from 'node:os';
+
+if (platform() === 'win32') {
+  process.stderr.write('macos-uds-cross-user server: win32 unsupported\n');
+  process.exit(2);
+}
+
+const { values } = parseArgs({
+  options: {
+    socket: { type: 'string' },
+    mode:   { type: 'string', default: '0666' },
+  },
+  strict: true,
+});
+
+if (!values.socket) {
+  process.stderr.write('--socket=<path> required\n');
+  process.exit(2);
+}
+
+const socketPath = values.socket;
+const mode = parseInt(values.mode, 8);
+if (!Number.isFinite(mode)) {
+  process.stderr.write(`bad --mode (expected octal, got "${values.mode}")\n`);
+  process.exit(2);
+}
+
+if (existsSync(socketPath)) {
+  try { unlinkSync(socketPath); } catch (e) {
+    process.stderr.write(JSON.stringify({ stage: 'unlink-stale', errno: e.code, message: e.message }) + '\n');
+    process.exit(1);
+  }
+}
+
+const server = createServer((sock) => {
+  let buf = '';
+  sock.setEncoding('utf8');
+  sock.on('data', (chunk) => {
+    buf += chunk;
+    const i = buf.indexOf('\n');
+    if (i >= 0) {
+      const line = buf.slice(0, i);
+      sock.end(`ack:${line}\n`);
+    }
+  });
+  sock.on('error', () => { /* ignore peer reset */ });
+});
+
+server.on('error', (err) => {
+  process.stderr.write(JSON.stringify({ stage: 'server-error', errno: err.code, message: err.message }) + '\n');
+  process.exit(1);
+});
+
+let shuttingDown = false;
+function shutdown(sig) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  process.stderr.write(`got ${sig}, shutting down\n`);
+  server.close(() => {
+    try { if (existsSync(socketPath)) unlinkSync(socketPath); } catch { /* ignore */ }
+    process.exit(0);
+  });
+  setTimeout(() => process.exit(0), 2000).unref();
+}
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT',  () => shutdown('SIGINT'));
+
+server.listen(socketPath, () => {
+  try {
+    chmodSync(socketPath, mode);
+  } catch (e) {
+    process.stderr.write(JSON.stringify({ stage: 'chmod', errno: e.code, message: e.message }) + '\n');
+    process.exit(1);
+  }
+  process.stdout.write(`listening ${socketPath}\n`);
+});


### PR DESCRIPTION
## Summary

Task #116 [T9.2]. Lands `tools/spike-harness/probes/macos-uds-cross-user/`
covering spec ch14 §1.2 phase 0.5 — must resolve before listener-A
wiring on macOS.

The probe answers: **which UDS bind paths on darwin let a different
local user `connect()` WITHOUT a Full Disk Access grant on the
connecting binary, and which require FDA?**

## Files

- `server.mjs` — UDS line-echo server, `chmod 0666` after bind so any
  cross-user denial isolates TCC/FDA from POSIX. SIGTERM-safe socket
  unlink. `node:` stdlib only.
- `client.mjs` — single-shot `connect()` probe, classifies the outcome
  (`OK`/`EACCES`/`EPERM`/`ENOENT`/`ECONNREFUSED`/`ETIMEDOUT`/`OTHER`)
  and emits one JSON line. Designed to be invoked under `sudo -n -u`
  for the cross-user leg.
- `run.sh` — iterates a 6-path matrix (`/tmp`, `/private/tmp`,
  `/Users/Shared`, `~/Library/Caches`, `~/Library/Application Support`,
  `~/Documents`), starts the server as the invoking user, runs the
  client both same-user and (when `SPIKE_SECONDARY_USER` is set)
  cross-user, then writes `*-matrix.ndjson` + `*-summary.json` and
  assigns `FDA-FREE` / `FDA-REQUIRED` / `UNREACHABLE` / `SKIPPED`.
- `PROBE-RESULT.md` — spec-derived verdict matrix + listener-A
  recommendation.

## Recommendation feeding listener-A on darwin

Bind under `~/Library/Caches/ccsm/daemon.sock` with `0600` on the
socket and `0700` on the parent. Mandatory application-layer
peer-cred check via `getsockopt(LOCAL_PEERCRED)` per T9.1's contract
(`tools/spike-harness/connect-and-peercred.sh`). TCC + POSIX are
defence-in-depth; peer-cred is the primary boundary. Do NOT bind
under `/tmp`, `/private/tmp`, or `/Users/Shared` for listener-A —
even with `0600` they sit outside any TCC fence and the stale-socket
file is unlink-squat-able cross-user during daemon restart.

Full reasoning + per-path table in `PROBE-RESULT.md`.

## Local verification (win32)

Authored from `MINGW64_NT-10.0-26200`. The harness short-circuits on
non-darwin per spec ch14 §1.B (Forever-stable contract):

```
$ bash tools/spike-harness/probes/macos-uds-cross-user/run.sh
macos-uds-cross-user: skipped on MINGW64_NT-10.0-26200 (UDS path semantics differ)
exit=2

$ node tools/spike-harness/probes/macos-uds-cross-user/server.mjs --socket=/tmp/x.sock
macos-uds-cross-user server: win32 unsupported
exit=2

$ node tools/spike-harness/probes/macos-uds-cross-user/client.mjs --socket=/tmp/x.sock
macos-uds-cross-user client: win32 unsupported
exit=2
```

`node --check` passes for both `.mjs` files; `bash -n run.sh` passes.
The harness directory is in eslint `ignores` per
`tools/spike-harness/README.md` Layer-1 constraint, so syntax-check is
the gate. Live darwin matrix capture is deferred to a self-hosted
runner with a provisioned secondary user (T0.10 / #16) — flagged as
"TODO populate from real darwin run" in `PROBE-RESULT.md` and called
out as the only outstanding follow-up before listener-A wiring on
darwin can proceed.

## Test plan

- [ ] Self-hosted darwin runner provisions `ccsmprobe` secondary user
      with `NOPASSWD` sudoers scoped to `node`, then runs:
      `SPIKE_SECONDARY_USER=ccsmprobe bash tools/spike-harness/probes/macos-uds-cross-user/run.sh`
- [ ] Confirm `summary.json` `byPath` matches the spec-derived verdict
      matrix in `PROBE-RESULT.md`. Any divergence escalates before
      listener-A wiring proceeds.
- [ ] (optional) Re-run with FDA granted to `node` on the secondary
      user via `tccutil` to confirm the `FDA-REQUIRED → OK` flip.