### PR TITLE
test(e2e): T8.3 sigkill-reattach (ship-gate b)

### DIFF
--- a/packages/electron/test/e2e/helpers/kill.spec.ts
+++ b/packages/electron/test/e2e/helpers/kill.spec.ts
@@ -1,0 +1,124 @@
+// Smoke test for the per-OS kill helper used by ship-gate (b)
+// (`sigkill-reattach.spec.ts`) and ship-gate (c) (`pty-soak-reconnect.spec.ts`).
+//
+// PURPOSE
+// -------
+// The kill helper is the single load-bearing primitive shared by both
+// gates: if it silently no-ops on any of the three target OSes, the gate
+// passes vacuously (the daemon never actually dies, so of course Electron
+// "reattaches"). This spec is the regression backstop:
+//
+//   stash kill.ts body → smoke MUST FAIL
+//   restore            → smoke MUST PASS
+//
+// Reviewers reproduce this in PR #T8.3 review and gate the merge on the
+// reverse-verify output appearing in the PR body.
+//
+// SCOPE
+// -----
+// Pure helper unit-style spec. Does NOT spawn a daemon, Electron, or
+// Playwright — those wait on the dependencies enumerated in
+// `sigkill-reattach.spec.ts` (T1.4 listener, T6.2 transport bridge,
+// SnapshotV1 encoder, claude-sim fixture). This spec uses a tiny Node
+// subprocess (`node -e "setInterval..."`) as a generic "long-running PID"
+// stand-in so the kill primitive itself is exercised on every PR run, on
+// every OS, in < 200 ms total.
+
+import { describe, it, expect } from 'vitest';
+import { spawn } from 'node:child_process';
+import { platform } from 'node:os';
+
+import { killByPid, pidIsAlive, waitForPidDead } from './kill.js';
+
+/**
+ * Spawn a long-running detached child that does nothing but hold the event
+ * loop open via `setInterval`. Returns the PID immediately.
+ *
+ * `detached: true` on POSIX puts the child in its own process group so
+ * `kill -KILL` doesn't bleed into the test runner's group. `windowsHide`
+ * keeps Windows from flashing a console window during CI.
+ */
+function spawnLongLived(): number {
+  const child = spawn(
+    process.execPath,
+    ['-e', 'setInterval(() => {}, 1 << 30)'],
+    {
+      detached: true,
+      windowsHide: true,
+      stdio: 'ignore',
+    },
+  );
+  // Unref so the test runner can exit cleanly even if the kill is broken
+  // (the test will still fail loudly via the `waitForPidDead` assertion;
+  // unref just prevents the runner from hanging on a zombie reference).
+  child.unref();
+  if (typeof child.pid !== 'number') {
+    throw new Error('spawnLongLived: child.pid was undefined — spawn failed silently');
+  }
+  return child.pid;
+}
+
+describe('kill helper — per-OS sigkill primitive (ship-gate (b)/(c) prerequisite)', () => {
+  it('killByPid hard-kills a long-running subprocess on the current OS', async () => {
+    const pid = spawnLongLived();
+
+    // Pre-condition: the subprocess MUST be alive immediately after spawn.
+    // If this fails, the test environment is broken (e.g. node binary
+    // missing) — not a kill helper regression. Fail loud so reviewers can
+    // distinguish.
+    expect(pidIsAlive(pid)).toBe(true);
+
+    // Act: deliver the OS-native uncatchable kill.
+    const result = killByPid(pid);
+
+    // Post-condition 1: kill command itself reported success.
+    expect(result.delivered).toBe(true);
+    expect(result.exitCode).toBe(0);
+
+    // Post-condition 2: the PID is observed dead within the budget. This
+    // is THE assertion that flips between PASS and FAIL when the kill
+    // helper body is stashed — a no-op killByPid leaves the process
+    // alive, waitForPidDead returns false, this expect throws.
+    const dead = await waitForPidDead(pid, { timeoutMs: 5000 });
+    expect(dead).toBe(true);
+  });
+
+  it('killByPid rejects non-positive PIDs without spawning anything', () => {
+    // Negative / zero / non-integer PIDs would, on Windows, get passed to
+    // taskkill and produce confusing errors; on POSIX, kill -KILL 0 sends
+    // to every process in the calling process group (catastrophic).
+    // Defense-in-depth: refuse at the helper boundary.
+    expect(() => killByPid(0)).toThrow(TypeError);
+    expect(() => killByPid(-1)).toThrow(TypeError);
+    expect(() => killByPid(1.5)).toThrow(TypeError);
+    expect(() => killByPid(Number.NaN)).toThrow(TypeError);
+  });
+
+  it('pidIsAlive returns false for an obviously-dead PID', () => {
+    // Spawn + kill + wait so we KNOW the PID is reaped, then probe.
+    // Using a freshly-reaped PID rather than e.g. PID 999999 avoids the
+    // (very rare) collision where the OS recycled that PID for an
+    // unrelated process between calls.
+    const pid = spawnLongLived();
+    expect(pidIsAlive(pid)).toBe(true);
+    killByPid(pid);
+    // Spin briefly until the OS releases the PID — POSIX zombies linger
+    // until reaped; here the parent (this test) is not the parent of the
+    // detached child, so the init reaper handles it within a few ms.
+    return waitForPidDead(pid, { timeoutMs: 5000 }).then((dead) => {
+      expect(dead).toBe(true);
+      expect(pidIsAlive(pid)).toBe(false);
+    });
+  });
+
+  it('reports the running platform so CI logs prove cross-OS coverage', () => {
+    // Not a behavior assertion — a log-only sentinel so the GitHub Actions
+    // matrix run for each OS leaves a grep-able trail proving the kill
+    // helper actually executed on that OS (not silently skipped via some
+    // outer guard). Reviewers can grep for "kill-helper-os=" across the
+    // three matrix logs to confirm coverage.
+    const os = platform();
+    console.log(`[ship-gate-b] kill-helper-os=${os}`);
+    expect(['linux', 'darwin', 'win32']).toContain(os);
+  });
+});

--- a/packages/electron/test/e2e/helpers/kill.ts
+++ b/packages/electron/test/e2e/helpers/kill.ts
@@ -1,0 +1,193 @@
+// Per-OS hard-kill helper for ship-gate (b) (`sigkill-reattach.spec.ts`) and
+// ship-gate (c) (`pty-soak-reconnect.spec.ts`).
+//
+// CONTRACT (FOREVER-STABLE — design spec ch12 §4.2 step 3 / ch08 §7 step 4)
+// -------------------------------------------------------------------------
+// Given a numeric OS PID, deliver the platform's *non-catchable* termination
+// signal so the target process cannot install a SIGTERM handler that masks
+// the failure mode the ship-gate is designed to catch:
+//
+//   - linux  → `kill -KILL <pid>`     (SIGKILL, signal 9, uncatchable)
+//   - darwin → `kill -KILL <pid>`     (SIGKILL, identical semantics to linux)
+//   - win32  → `taskkill /F /T /PID <pid>`
+//             (`/F` = forced; `/T` = also kill the descendant tree, since
+//             Windows has no "process group" the way POSIX does — this is
+//             the closest equivalent to POSIX `kill(-pgid, SIGKILL)` and is
+//             what the ch12 §4.2 contract requires for the daemon-subprocess
+//             variant where the daemon owns child `claude` PTYs.)
+//
+// WHY NOT `process.kill(pid, 'SIGKILL')`
+// --------------------------------------
+// Node's libuv `process.kill` works on POSIX but on Windows it ignores the
+// signal name and unconditionally calls `TerminateProcess`, which is `/F`
+// equivalent for the *target only* — descendants survive, defeating the
+// "daemon owns claude PTYs that must die with it" branch of ch12 §4.2 §step
+// 4. Going through `taskkill /F /T` makes the tree-kill semantics explicit
+// and identical between the per-PR (subprocess daemon) and nightly
+// (service-installed daemon) variants. The cost is one `child_process.spawn`
+// per kill — negligible at the call rate of these e2e gates (≤ a handful per
+// run).
+//
+// REVERSE-VERIFY HOOK (load-bearing for ship-gate (b) PR review)
+// --------------------------------------------------------------
+// `kill.spec.ts` contains a smoke test that:
+//   1. Spawns a long-running detached subprocess (`node -e "setInterval..."`).
+//   2. Asserts the PID is alive via `pidIsAlive()`.
+//   3. Calls `killByPid()` and waits for the PID to disappear.
+//   4. Asserts the PID is dead.
+//
+// PR reviewers MUST be able to reproduce: stash the body of `killByPid()`
+// (replace with a no-op) → smoke test FAILS at step 4. Restore → PASSES.
+// This is what the design spec calls "byte-equality without this passes
+// vacuously" — for the kill helper, the analog is "the gate without an
+// effective killer passes vacuously when the kill is silently dropped".
+
+import { spawnSync } from 'node:child_process';
+import { platform } from 'node:os';
+
+/**
+ * Result envelope returned by {@link killByPid}. Wrapping rather than
+ * throwing keeps caller code in the spec body straight-line — the spec
+ * pre-conditions (process MUST be alive before kill) and post-conditions
+ * (process MUST be dead within timeout after kill) are asserted via
+ * `expect(...)` against the explicit fields, not via try/catch flow.
+ */
+export interface KillResult {
+  /** True iff the OS reported the kill command exit-code 0. */
+  readonly delivered: boolean;
+  /** Raw exit code of the underlying `kill` / `taskkill` invocation. */
+  readonly exitCode: number | null;
+  /** Stderr of the underlying invocation (truncated to 4 KiB for log sanity). */
+  readonly stderr: string;
+}
+
+/**
+ * Hard-kill a process by PID using the platform's uncatchable termination
+ * primitive. See file header for the per-OS contract.
+ *
+ * Synchronous on purpose: the caller (sigkill-reattach.spec.ts step 3) needs
+ * a strict happens-before edge between "kill issued" and the subsequent
+ * `pidIsAlive()` poll loop — an async kill would race the poll and produce
+ * spurious "still alive" false positives that masquerade as ship-gate
+ * regressions.
+ */
+export function killByPid(pid: number): KillResult {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    throw new TypeError(`killByPid: pid must be a positive integer, got ${String(pid)}`);
+  }
+
+  const os = platform();
+  let result: ReturnType<typeof spawnSync>;
+
+  if (os === 'win32') {
+    // /F = force, /T = tree-kill descendants. PID is passed via /PID (not as
+    // a positional arg) so it doesn't get confused with image-name modes.
+    result = spawnSync(
+      'taskkill',
+      ['/F', '/T', '/PID', String(pid)],
+      { encoding: 'utf8', windowsHide: true },
+    );
+  } else if (os === 'linux' || os === 'darwin') {
+    // `kill -KILL` (vs `kill -9`) makes the signal name explicit; both are
+    // identical semantics on every supported libc but the long form survives
+    // shell aliasing and reads cleaner in CI logs.
+    result = spawnSync(
+      'kill',
+      ['-KILL', String(pid)],
+      { encoding: 'utf8' },
+    );
+  } else {
+    throw new Error(
+      `killByPid: unsupported platform "${os}" — ship-gate (b) only targets linux/darwin/win32 per design spec ch12 §4.2.`,
+    );
+  }
+
+  const stderrRaw: unknown = result.stderr;
+  const stderr = (typeof stderrRaw === 'string' ? stderrRaw : '').slice(0, 4096);
+  return {
+    delivered: result.status === 0,
+    exitCode: result.status,
+    stderr,
+  };
+}
+
+/**
+ * Probe whether a PID is currently alive without delivering any signal.
+ *
+ * - POSIX: `process.kill(pid, 0)` is the canonical zero-signal liveness
+ *   probe — it returns void if the PID exists *and* the caller has
+ *   permission to signal it, throws ESRCH if it doesn't exist, throws EPERM
+ *   if it exists but is not signalable. For ship-gate (b) we treat EPERM as
+ *   alive (the daemon process is signalable by the test process by
+ *   construction; an EPERM on our own subprocess would be a Node bug).
+ * - Windows: `process.kill(pid, 0)` is unimplemented as a probe (libuv
+ *   always TerminateProcess's), so we shell out to `tasklist /FI "PID eq N"`
+ *   and grep the output. `tasklist` exits 0 in both alive and dead cases;
+ *   the differentiator is whether the output contains the PID. We also
+ *   accept the localized "INFO: No tasks are running" sentinel as "dead".
+ */
+export function pidIsAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    throw new TypeError(`pidIsAlive: pid must be a positive integer, got ${String(pid)}`);
+  }
+
+  if (platform() === 'win32') {
+    const result = spawnSync(
+      'tasklist',
+      ['/FI', `PID eq ${String(pid)}`, '/NH'],
+      { encoding: 'utf8', windowsHide: true },
+    );
+    if (result.status !== 0) {
+      // tasklist itself failed (rare: the binary is core OS). Treat as
+      // unknown → false to avoid hanging the spec, but do not silently
+      // swallow: the stderr will surface in the spec failure message.
+      return false;
+    }
+    // `encoding: 'utf8'` makes stdout a string at runtime, but the
+    // spawnSync return type is the union `string | Buffer` — narrow
+    // explicitly so a future change to the encoding option doesn't silently
+    // start grepping byte buffers as JS strings.
+    const stdoutRaw: unknown = result.stdout;
+    const out: string = typeof stdoutRaw === 'string' ? stdoutRaw : '';
+    // PID column is whitespace-padded; require it on a word boundary so PID
+    // 12 doesn't match PID 1234.
+    const re = new RegExp(`(^|\\s)${pid}(\\s|$)`, 'm');
+    return re.test(out);
+  }
+
+  // POSIX
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ESRCH') return false;
+    if (code === 'EPERM') return true;
+    // Unexpected error — bubble it so the spec sees the real cause.
+    throw err;
+  }
+}
+
+/**
+ * Poll {@link pidIsAlive} until it reports `false` or the timeout elapses.
+ * Returns true iff the PID was observed dead within the budget.
+ *
+ * Default budget is 5000 ms (well below the 30 s vitest hookTimeout); poll
+ * interval is 50 ms — short enough that a clean SIGKILL on a healthy POSIX
+ * box is observed within ≤ 2 ticks, long enough that the poll loop adds
+ * < 0.5 % CPU to a CI runner.
+ */
+export async function waitForPidDead(
+  pid: number,
+  options: { timeoutMs?: number; pollIntervalMs?: number } = {},
+): Promise<boolean> {
+  const timeoutMs = options.timeoutMs ?? 5000;
+  const pollIntervalMs = options.pollIntervalMs ?? 50;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (!pidIsAlive(pid)) return true;
+    await new Promise((r) => setTimeout(r, pollIntervalMs));
+  }
+  return !pidIsAlive(pid);
+}

--- a/packages/electron/test/e2e/sigkill-reattach.spec.ts
+++ b/packages/electron/test/e2e/sigkill-reattach.spec.ts
@@ -1,0 +1,327 @@
+// T8.3 — Ship-gate (b): daemon survives Electron SIGKILL.
+//
+// Canonical path locked by design spec ch12 §4.2 (single source of truth):
+//   "packages/electron/test/e2e/sigkill-reattach.spec.ts (Playwright for
+//    Electron + per-OS kill helper)"
+//
+// Cross-references:
+//   - ch08 §7 step 4: lists this exact path as the "runtime gate (b)" harness.
+//   - ch13 phase 11(b): release procedure invokes this spec.
+//   - `packages/electron/test/e2e/pty-soak-reconnect.spec.ts` (T8.5) waits
+//     on the T8.3 marker (this file's existence) before un-skipping.
+//
+// THIS FILE is the single source of truth for ship-gate (b)'s test name and
+// path; any divergence in 00-brief.md or chapter 08 is a documentation bug.
+//
+// ----------------------------------------------------------------------------
+// PURPOSE
+// ----------------------------------------------------------------------------
+// Verify the chapter 02 process-boundary contract end-to-end on a real
+// Electron instance: the daemon runs in a separate OS process (not a fused
+// Worker thread); when the Electron main PID is hard-killed via the per-OS
+// kill helper (`./helpers/kill.ts`), the daemon and its `claude` PTY
+// subprocesses survive; relaunching Electron reattaches each session and
+// receives deltas continuing from the recorded `last_applied_seq` with
+// SnapshotV1 byte-equality (chapter 06 §2 / §5).
+//
+// The byte-equality leg is what makes this gate non-vacuous: a seq-only
+// gate passes when the wire is corrupt-but-monotonic, which is precisely
+// the regression class the gate exists to catch (brief §11(b) "no data
+// loss").
+//
+// ----------------------------------------------------------------------------
+// VARIANTS (ch12 §4.2)
+// ----------------------------------------------------------------------------
+//   Per-PR (default)
+//     - Subprocess daemon spawned by this spec (`spawn(process.execPath,
+//       ['-e', "require('@ccsm/daemon').main()"], { detached: true })` on
+//       POSIX; `+ CREATE_NEW_PROCESS_GROUP` on Windows).
+//     - The in-process Worker variant is FORBIDDEN — see §FORBIDDEN
+//       SHORTCUTS below.
+//     - Runs on the standard `lint-typecheck-test` matrix (ubuntu / macos
+//       / windows GitHub-hosted runners).
+//     - Wall-clock target: ≤ 30 s.
+//
+//   Nightly (CCSM_E2E_SERVICE=1)
+//     - Service-installed daemon (Windows: SCM `ccsm-daemon` service;
+//       macOS: `launchctl bootstrap system/com.ccsm.daemon`; Linux:
+//       `systemctl start ccsm-daemon`). Service installation is performed
+//       OUT OF BAND by the runner image; this spec only attaches to the
+//       already-running service via the descriptor file.
+//     - Skipped on per-PR runs to keep PR CI fast and to avoid requiring
+//       sudo / Administrator on GitHub-hosted runners.
+//     - Runs on the `self-hosted-soak-*` runner labels (chapter 11 §6 /
+//       chapter 12 §4.3 for the runner provisioning contract).
+//
+// ----------------------------------------------------------------------------
+// 7-STEP IMPLEMENTATION OUTLINE (ch12 §4.2 + ch08 §7)
+// ----------------------------------------------------------------------------
+// 1. Boot daemon.
+//    Per-PR: spawn subprocess in its own process group. Capture PID + the
+//    descriptor path written to `state-dir/listener-a.json`. Wait for the
+//    Supervisor `/healthz` to flip to 200 (chapter 02 §3 phase READY).
+//    Nightly: skip the spawn; read the descriptor file written by the
+//    service-installed daemon at the canonical OS-specific path
+//    (`%ProgramData%\ccsm\listener-a.json` / `/var/lib/ccsm/listener-a.json`
+//    / `~/Library/Application Support/ccsm/listener-a.json`).
+//
+// 2. Launch Electron via `_electron.launch()` (Playwright). The renderer
+//    creates 3 PTY sessions through the Connect transport bridge (ch08
+//    §4); for each, attach the `PtyService.Attach` server-stream and apply
+//    the first 100 deltas into a client-side xterm-headless `Terminal`
+//    instance. Record (a) the last applied seq per session and (b) the
+//    `runtime_pid` from `Session.runtime_pid` (ch04 §3 — this field was
+//    added to the v0.3 freeze precisely for this gate's step 4).
+//
+// 3. Hard-kill the Electron main PID via `killByPid(electronMainPid)`
+//    (`./helpers/kill.ts`). On POSIX this is `kill -KILL <pid>` of the
+//    Electron PID; the daemon, in a SEPARATE process group from step 1,
+//    is unaffected. On Windows this is `taskkill /F /T /PID <pid>` which
+//    tree-kills the Electron renderer + helper processes; the daemon, NOT
+//    in Electron's tree by construction, survives.
+//
+// 4. Verify daemon liveness:
+//    (a) Supervisor `/healthz` still returns 200 (loopback HTTP).
+//    (b) For each session, the recorded `runtime_pid` is still alive via
+//        `pidIsAlive(runtimePid)` from the kill helper.
+//    Both must hold. If either fails, the gate is RED — file a P0.
+//
+// 5. Relaunch Electron via Playwright (fresh `_electron.launch()`). Wait
+//    for the renderer's `Hello` RPC to complete; then call
+//    `SessionService.ListSessions` and assert all 3 recorded session IDs
+//    are present.
+//
+// 6. For each session, call `PtyService.Attach` with `since_seq =
+//    recordedLastSeq[id]`. Per ch06 §5:
+//      - if gap < DELTA_RETENTION_SEQS (currently 4096): the server sends
+//        deltas only, no `snapshot` frame; client applies in-place to its
+//        retained xterm-headless Terminal.
+//      - if gap >= DELTA_RETENTION_SEQS: the server sends a `snapshot`
+//        frame followed by tail deltas; client rebuilds from scratch.
+//    Both branches MUST converge to the same byte-equality result in
+//    step 7. Assert no gaps and no duplicate seqs along the way.
+//
+// 7. **Byte-equality "no data loss" assertion** (ch12 §4.2 step 7):
+//      - Daemon side: call `PtyService.GetSnapshot` (ch04 §4) for each
+//        session; this serializes the daemon's xterm-headless terminal
+//        state via the SnapshotV1 encoder (ch06 §2). Capture as
+//        `daemonSnap[id]: Uint8Array`.
+//      - Client side: serialize the renderer-side xterm-headless Terminal
+//        (after applying every received delta from step 2 + step 6) via
+//        the SAME SnapshotV1 encoder. Capture as `clientSnap[id]:
+//        Uint8Array`.
+//      - Assert `Buffer.compare(daemonSnap[id], clientSnap[id]) === 0`
+//        for every session. This is the same comparator gate (c) uses;
+//        gate (b) reuses it as a 30-second variant. Per ch12 §4.2:
+//        "Allowed deviation: zero."
+//
+// ----------------------------------------------------------------------------
+// FORBIDDEN SHORTCUTS (reviewer MUST reject any PR that takes these)
+// ----------------------------------------------------------------------------
+// 1. **In-process Worker daemon** is forbidden. `taskkill /F /IM
+//    electron.exe` (and `kill -9` of the Electron PID group on POSIX) can
+//    reap a fused daemon Worker thread, masking the very failure mode the
+//    gate exists to catch. The subprocess variant is mandatory for per-PR;
+//    the service-installed variant is mandatory for nightly. Per ch12 §4.2.
+//
+// 2. **Closing the Connect channel instead of killing the Electron PID**
+//    is forbidden. The point is to verify process-death survival, not
+//    graceful RPC teardown. Channel close cannot exercise the OS-level
+//    process-group separation that ch02 §6 requires.
+//
+// 3. **Comparing rendered text instead of SnapshotV1 bytes** is forbidden.
+//    Rendered-text equality is the spike `[snapshot-roundtrip-fidelity]`
+//    *fallback* (ch14 §1.8); using it pre-emptively silently downgrades
+//    ship-gate (b) from STRICT_BYTE to RENDERED_EQUIVALENT.
+//
+// 4. **Substituting `process.kill(pid, 'SIGKILL')` on Windows** is
+//    forbidden. libuv ignores the signal name on Windows and calls
+//    `TerminateProcess` on the target only; descendants survive,
+//    defeating the tree-kill semantics ch12 §4.2 requires. Use
+//    `killByPid` from `./helpers/kill.ts` which routes through
+//    `taskkill /F /T` on Windows. The kill helper has its own smoke test
+//    in `./helpers/kill.spec.ts` with reverse-verify hook.
+//
+// 5. **Skipping byte-equality on the grounds that "seq-continuation is
+//    enough"** is forbidden. A monotonic-but-corrupt wire passes the
+//    seq check; brief §11(b) "no data loss" requires byte-equality.
+//
+// ----------------------------------------------------------------------------
+// SKIP CONTRACT (load-bearing — same pattern as T8.5 pty-soak-reconnect)
+// ----------------------------------------------------------------------------
+// The full 7-step body is `describe.skipIf(...)`'d until ALL of the
+// following dependencies land. Each dependency has a checked-in marker (a
+// file path probed via `node:fs.existsSync`) so the skip flips
+// automatically — no follow-up "remember to un-skip" dev work. The skip
+// reason is asserted by a dedicated self-check `describe` block so a
+// silent flip (marker check removed without wiring the implementation)
+// shows up as a failing test rather than a vacuously-green skip.
+//
+//   T1.4  — Listener A bind + descriptor write
+//           marker: `packages/daemon/src/listeners/listener-a.ts`
+//           Without it the daemon never writes `listener-a.json`, so the
+//           Electron renderer has no transport descriptor to read.
+//
+//   T6.2  — Electron-side Connect-RPC transport bridge
+//           marker: `packages/electron/src/rpc/transport.ts` exists AND
+//                   exports `createDaemonTransport`.
+//           Without it the renderer has no Connect transport to drive
+//           `SessionService.Create` / `PtyService.Attach`.
+//
+//   ch06 §2 SnapshotV1 encoder
+//           marker: `packages/daemon/src/pty/snapshot-v1.ts`
+//           The byte-equality assertion in step 7 IS the gate; without
+//           the encoder there is no comparator.
+//
+//   T8.7  — `claude-sim` deterministic workload fixture
+//           marker: `packages/daemon/test/fixtures/claude-sim/bin/claude-sim`
+//                   (or `.exe` on win32)
+//           Step 2 needs a workload that exercises the ch12 §4.3
+//           workload-class table; substituting a hand-rolled echo loop
+//           would make step 7 byte-equality pass vacuously on toy bytes.
+//
+//   T6.6 / T8.x  — Playwright `_electron.launch()` boilerplate
+//           marker: `packages/electron/test/e2e/_fixtures/launch.ts`
+//           Once landed, the per-PR spawn-daemon-as-subprocess + launch-
+//           electron + per-OS-killer plumbing moves into a shared fixture
+//           consumed by both this file and `pty-soak-reconnect.spec.ts`.
+//           Until then the single `it.skip` below is the entire executable
+//           surface so the file type-checks and the path is locked.
+//
+// When all five markers are present AND the env override is unset, the
+// suite runs. The `CCSM_E2E_SERVICE=1` env var additionally gates the
+// nightly service-installed variant (default per-PR variant uses the
+// subprocess daemon).
+//
+// ----------------------------------------------------------------------------
+// REVERSE-VERIFY (PR review checkpoint)
+// ----------------------------------------------------------------------------
+// The kill helper at `./helpers/kill.ts` IS reverse-verifiable today via
+// `./helpers/kill.spec.ts`:
+//   1. Stash the body of `killByPid()` (replace with a no-op return).
+//   2. Run `pnpm --filter @ccsm/electron test`. The kill helper smoke
+//      MUST FAIL at the `waitForPidDead` post-condition.
+//   3. Restore. Run again. MUST PASS.
+// Both outputs are pasted in the PR body for review.
+
+import { describe, it, expect } from 'vitest';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Compile-time import to keep the kill helper in the test graph and ensure
+// the helper smoke spec is co-located with the file that depends on it.
+// The `void` cast prevents tree-shaking from dropping the import in
+// future bundler-mediated builds.
+import * as killHelper from './helpers/kill.js';
+void killHelper;
+
+// __dirname is not available under NodeNext ESM; derive from import.meta.url.
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = join(__filename, '..');
+
+// Repo root = packages/electron/test/e2e/<this> -> ../../../../
+const REPO_ROOT = join(__dirname, '..', '..', '..', '..');
+
+// ---------------------------------------------------------------------------
+// Skip-marker resolution (synchronous, top-of-module)
+// ---------------------------------------------------------------------------
+// Each marker is a path on disk. Probe via `node:fs.existsSync` (sync,
+// cheap) instead of dynamic `import()` so a missing module does not throw
+// during test collection.
+
+const T1_4_LISTENER_A_MARKER = join(
+  REPO_ROOT, 'packages', 'daemon', 'src', 'listeners', 'listener-a.ts',
+);
+const T6_2_TRANSPORT_MARKER = join(
+  REPO_ROOT, 'packages', 'electron', 'src', 'rpc', 'transport.ts',
+);
+const SNAPSHOT_V1_ENCODER_MARKER = join(
+  REPO_ROOT, 'packages', 'daemon', 'src', 'pty', 'snapshot-v1.ts',
+);
+const T8_7_CLAUDE_SIM_MARKER_POSIX = join(
+  REPO_ROOT, 'packages', 'daemon', 'test', 'fixtures', 'claude-sim', 'bin', 'claude-sim',
+);
+const T8_7_CLAUDE_SIM_MARKER_WIN = T8_7_CLAUDE_SIM_MARKER_POSIX + '.exe';
+const PLAYWRIGHT_FIXTURE_MARKER = join(
+  REPO_ROOT, 'packages', 'electron', 'test', 'e2e', '_fixtures', 'launch.ts',
+);
+
+const MISSING_MARKERS: string[] = [];
+if (!existsSync(T1_4_LISTENER_A_MARKER)) MISSING_MARKERS.push('T1.4 Listener A');
+if (!existsSync(T6_2_TRANSPORT_MARKER)) MISSING_MARKERS.push('T6.2 transport bridge');
+if (!existsSync(SNAPSHOT_V1_ENCODER_MARKER)) MISSING_MARKERS.push('SnapshotV1 encoder (ch06 §2)');
+if (
+  !existsSync(T8_7_CLAUDE_SIM_MARKER_POSIX) &&
+  !existsSync(T8_7_CLAUDE_SIM_MARKER_WIN)
+) {
+  MISSING_MARKERS.push('T8.7 claude-sim fixture');
+}
+if (!existsSync(PLAYWRIGHT_FIXTURE_MARKER)) {
+  MISSING_MARKERS.push('Playwright _electron.launch fixture');
+}
+
+const SKIP_OVERRIDE = process.env.CCSM_SKIP_E2E_SIGKILL_REATTACH === '1';
+const SHOULD_SKIP = MISSING_MARKERS.length > 0 || SKIP_OVERRIDE;
+
+const SKIP_REASON = SKIP_OVERRIDE
+  ? 'CCSM_SKIP_E2E_SIGKILL_REATTACH=1 (manual override)'
+  : `awaiting dependencies: ${MISSING_MARKERS.join(', ')}`;
+
+// Service-installed variant gate. Default per-PR runs use the subprocess
+// daemon; nightly runs on `self-hosted-soak-*` runners set
+// `CCSM_E2E_SERVICE=1` to opt into the service variant.
+const SERVICE_VARIANT = process.env.CCSM_E2E_SERVICE === '1';
+
+// `describe.skipIf(...)` keeps the suite present in the report (so CI can
+// observe the skip count + reason) while preventing any of its lifecycle
+// hooks from running. Vitest 4.x supports `skipIf` natively.
+describe.skipIf(SHOULD_SKIP)(
+  `T8.3 sigkill-reattach — ship-gate (b) [${SERVICE_VARIANT ? 'service-installed' : 'subprocess'}]`,
+  () => {
+    it(
+      'daemon survives Electron SIGKILL; reattach yields SnapshotV1 byte-equal terminal state',
+      async () => {
+        // Implementation lands once the markers above resolve. See the
+        // 7-step IMPLEMENTATION OUTLINE in this file's header comment.
+        //
+        // The TODO is intentional: a real test body that imports a missing
+        // T6.2 transport / Playwright fixture would fail collection BEFORE
+        // `describe.skipIf` could run. Keeping the body trivial preserves
+        // the "1 skipped" CI signal through the dependency-landing window.
+        expect(SHOULD_SKIP).toBe(false); // unreachable while skipped
+        throw new Error(
+          'T8.3 implementation pending — see header comment §IMPLEMENTATION OUTLINE.',
+        );
+      },
+    );
+  },
+);
+
+// When SHOULD_SKIP is true, the only assertion that runs is the meta-check
+// below: it locks the skip *reason* into the test report so a silent flip
+// (e.g. someone removes the marker check without wiring the implementation)
+// is visible as a failing test rather than a quietly-passing skip. This
+// mirrors the pattern in `pty-soak-reconnect.spec.ts` (T8.5).
+describe('T8.3 sigkill-reattach — skip-marker self-check', () => {
+  it('reports a stable skip reason while dependencies are pending', () => {
+    if (SHOULD_SKIP) {
+      expect(SKIP_REASON).toMatch(/awaiting dependencies|manual override/);
+      console.log(`[T8.3] suite skipped — ${SKIP_REASON}`);
+    } else {
+      // All markers resolved AND no manual override: the main suite above
+      // MUST be running. If this branch is taken, that's the contract.
+      expect(MISSING_MARKERS).toEqual([]);
+    }
+  });
+
+  it('exposes the per-OS kill helper for downstream specs (T8.5 reuse)', () => {
+    // Sanity-check the helper API surface the spec body in step 3-4 uses.
+    // This also documents the load-bearing exports for code-search; if
+    // someone deletes one of these, this test fails immediately rather
+    // than waiting for the deps to land and the main suite to flake.
+    expect(typeof killHelper.killByPid).toBe('function');
+    expect(typeof killHelper.pidIsAlive).toBe('function');
+    expect(typeof killHelper.waitForPidDead).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary

Task #93 [T8.3] — adds the canonical Electron-side ship-gate (b) harness at the spec-locked path `packages/electron/test/e2e/sigkill-reattach.spec.ts` (single source of truth: design spec ch12 §4.2; cross-references ch08 §7 and ch13 phase 11(b)). Also ships the per-OS hard-kill helper (`./helpers/kill.ts`) that ship-gate (b) and ship-gate (c) (T8.5 `pty-soak-reconnect.spec.ts`, PR #878) both depend on.

## Files

- `packages/electron/test/e2e/sigkill-reattach.spec.ts` — locked path; full 7-step IMPLEMENTATION OUTLINE in header; subprocess/service variant matrix; 5-marker skip-gate (T8.5-style); skip-marker self-check.
- `packages/electron/test/e2e/helpers/kill.ts` — `killByPid` (per-OS), `pidIsAlive` (POSIX `kill(pid,0)` / Windows `tasklist`), `waitForPidDead` (poll loop).
- `packages/electron/test/e2e/helpers/kill.spec.ts` — reverse-verifiable smoke test for the kill helper. Spawns a `node -e "setInterval..."` subprocess, asserts `killByPid` reaps it within 5s.

## Variants (ch12 §4.2)

- **Per-PR (default)**: subprocess daemon spawned in its own process group; runs on standard `lint-typecheck-test` matrix.
- **Nightly (`CCSM_E2E_SERVICE=1`)**: service-installed daemon; runs on `self-hosted-soak-*` runners.

## Skip-marker contract

The full 7-step body is `describe.skipIf(...)`'d until ALL of the following dependencies land. Each dependency is a `node:fs.existsSync` probe so the skip flips automatically — no follow-up un-skip dev work:

- T1.4 — `packages/daemon/src/listeners/listener-a.ts` (descriptor write)
- T6.2 — `packages/electron/src/rpc/transport.ts` (Connect transport bridge)
- ch06 §2 — `packages/daemon/src/pty/snapshot-v1.ts` (encoder)
- T8.7 — `packages/daemon/test/fixtures/claude-sim/bin/claude-sim[.exe]`
- Playwright fixture — `packages/electron/test/e2e/_fixtures/launch.ts`

A second `describe` self-checks the skip reason so a silent flip (marker removed without wiring) shows up as a failing test, not a vacuously-green skip. Same pattern as PR #878.

## Forbidden shortcuts (locked in spec header)

1. In-process Worker daemon (would let `taskkill /F /IM electron.exe` reap the daemon).
2. Closing the Connect channel instead of killing the Electron PID.
3. Comparing rendered text instead of SnapshotV1 bytes (would silently downgrade STRICT_BYTE → RENDERED_EQUIVALENT).
4. `process.kill(pid, 'SIGKILL')` on Windows (libuv ignores signal name; no descendant tree-kill).
5. Skipping byte-equality on the grounds that "seq-continuation is enough".

## Reverse-verify (the load-bearing checkpoint)

Stash `killByPid` body to a no-op (`return { delivered: true, exitCode: 0, stderr: '' }`) and re-run:

```
$ pnpm --filter @ccsm/electron exec vitest run kill
 ❯ test/e2e/helpers/kill.spec.ts:83:18
     81|     // alive, waitForPidDead returns false, this expect throws.
     82|     const dead = await waitForPidDead(pid, { timeoutMs: 5000 });
     83|     expect(dead).toBe(true);
       |                  ^
 FAIL  test/e2e/helpers/kill.spec.ts > pidIsAlive returns false for an obviously-dead PID
AssertionError: expected false to be true
 Test Files  1 failed | 1 passed (2)
      Tests  2 failed | 4 passed | 1 skipped (7)
```

Restore:

```
$ pnpm --filter @ccsm/electron exec vitest run kill
 RUN  v4.1.5 C:/Users/jiahuigu/ccsm-worktrees/pool-7/packages/electron
 Test Files  2 passed (2)
      Tests  6 passed | 1 skipped (7)
```

Both behaviors confirmed locally on Windows (the OS-of-the-test-runner is logged via `kill-helper-os=` so the cross-OS GitHub Actions matrix produces a grep-able audit trail).

## Local verification (Windows, this worktree)

```
$ npx vitest run
 Test Files  3 passed (3)
      Tests  7 passed | 2 skipped (9)
   Duration  2.58s

$ npx tsc -p tsconfig.test.json --noEmit
(clean)

$ npx eslint test/**/*.ts
(clean)

$ pnpm --filter @ccsm/electron exec vitest run sigkill-reattach
 Test Files  1 passed (1)
      Tests  2 passed | 1 skipped (3)
```

The 2 skips: (a) the main 7-step body (awaiting dependencies); (b) the T8.5 `pty-soak-reconnect` body (awaiting same set + T8.4 daemon soak). Both are intentional and tracked by `describe.skipIf` self-check.

## Ship-gate (b) checklist

- [x] Canonical path `packages/electron/test/e2e/sigkill-reattach.spec.ts` locked
- [x] Per-OS kill helper at `test/e2e/helpers/kill.ts` (linux/darwin `kill -KILL`; win `taskkill /F /T`)
- [x] Subprocess daemon variant scaffolded; service-installed variant gated by `CCSM_E2E_SERVICE=1`
- [x] Byte-equality assertion via SnapshotV1 documented in IMPLEMENTATION OUTLINE step 7
- [x] Forever-stable: skip-marker pattern flips automatically as deps land; no rewrite scheduled for v0.4
- [x] Reverse-verify hook at `test/e2e/helpers/kill.spec.ts`; outputs above
- [x] T8.5 `pty-soak-reconnect.spec.ts` skip-marker for "T8.3 fixtures" now resolves (it probes this file's existence)
- [ ] (Pending downstream tasks) flip skip when T1.4 / T6.2 / SnapshotV1 / claude-sim / Playwright fixture all land

## Spec references

- ch12 §4.2 — ship-gate (b) canonical path, 7-step contract, variant matrix, "Allowed deviation: zero"
- ch08 §7 — runtime gate (b) cross-reference to this exact path
- ch13 phase 11(b) — release procedure invokes this spec
- ch04 §3 — `Session.runtime_pid` (added in v0.3 freeze precisely for step 4)
- ch06 §5 — reattach branch on retention window (delta-only vs snapshot+tail)

## Hotfile guard

Did NOT touch `packages/daemon/vitest.config.ts` (held by other in-flight PRs) and did NOT touch `packages/electron/vitest.config.ts` (existing `test/**/*.spec.ts` glob already discovers the new specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)