### PR TITLE
test(daemon): T8.13 bench suite skeleton

### DIFF
--- a/packages/daemon/test/bench/README.md
+++ b/packages/daemon/test/bench/README.md
@@ -1,0 +1,42 @@
+# Daemon nightly bench suite (T8.13)
+
+Per design spec ch12 §7. These files measure advisory perf numbers for the
+daemon. They are wired to vitest's `bench` API and run via:
+
+```
+npx vitest bench --config packages/daemon/vitest.bench.config.ts --run
+```
+
+from the daemon package root, or with the explicit dir filter:
+
+```
+npx vitest bench --config packages/daemon/vitest.bench.config.ts --run \
+  packages/daemon/test/bench/
+```
+
+## Files
+
+| File | Measures | Status | Blocker |
+| --- | --- | --- | --- |
+| `cold-start.bench.ts` | spawn -> /healthz green (ms) | skipped | T1.7 (healthz flip) |
+| `hello-rtt.bench.ts` | Hello RPC round-trip p50/p99 | skipped | Task #33 (Hello impl) |
+| `sendinput-rtt.bench.ts` | SendInput -> first echo back | skipped | Task #53 (SendInput impl) |
+| `snapshot-encode.bench.ts` | SnapshotV1 encode bytes/sec | skipped | Task #46 (snapshot encoder) |
+| `rss.bench.ts` | resident-set memory after warmup | skipped | T1.7 + #33 (need running daemon) |
+
+Each `bench.skip` entry has a `TODO(Task #N)` referencing the blocker. As infra
+lands, the implementing task flips `bench.skip` -> `bench` in the same PR
+(no stranded skeletons).
+
+## Why everything is skipped today
+
+Per Layer 1 / dev protocol §1: harness shape is the deliverable for T8.13.
+Real numbers come once the upstream RPCs ship. `vitest bench --run` against
+this directory must START without throwing — that's the only quality gate
+this PR is on the hook for.
+
+## Gating
+
+All numbers here are **advisory**. The one blocking perf gate is SendInput
+p99, and that is enforced by the dedicated soak harness (Task #92), not by
+this bench suite.

--- a/packages/daemon/test/bench/cold-start.bench.ts
+++ b/packages/daemon/test/bench/cold-start.bench.ts
@@ -1,0 +1,30 @@
+// packages/daemon/test/bench/cold-start.bench.ts
+//
+// T8.13 — daemon cold-start latency: spawn(daemon) -> GET /healthz returns
+// 200 with {ready: true}. Wall-clock ms, single-shot per iteration.
+//
+// SKIPPED until T1.7 lands (Supervisor /healthz flip to 200). Today the
+// daemon's `runStartup` walks the lifecycle but never binds the supervisor
+// HTTP server, so there is no endpoint to poll. The READY phase is logged
+// but the readiness contract is half-built.
+//
+// When T1.7 lands: flip `bench.skip` -> `bench`, remove the TODO line, and
+// fill in the spawn/poll harness. Suggested shape:
+//   1. spawn `node dist/index.js` with a temp state-dir env
+//   2. tight-poll GET http://127.0.0.1:<port>/healthz every 5ms with 5s budget
+//   3. record (firstReadyAt - spawnAt) ms
+//   4. SIGTERM the child, await exit, then teardown temp state-dir
+//
+// Cold-start is measured per-iteration (no warmup re-use): the whole point
+// is process spawn + module load + DB open + listener bind. tinybench
+// `iterations` should be small (e.g. 5) since each shot is ~hundreds of ms.
+
+import { bench, describe } from 'vitest';
+
+describe('daemon cold-start', () => {
+  bench.skip('spawn -> /healthz green (ms)', async () => {
+    // TODO(T1.7): implement once Supervisor /healthz returns 200 on READY.
+    // Blocked on: packages/daemon/src/index.ts "TODO(T1.7): flip Supervisor /healthz to 200".
+    throw new Error('not implemented — blocked on T1.7');
+  });
+});

--- a/packages/daemon/test/bench/hello-rtt.bench.ts
+++ b/packages/daemon/test/bench/hello-rtt.bench.ts
@@ -1,0 +1,29 @@
+// packages/daemon/test/bench/hello-rtt.bench.ts
+//
+// T8.13 — Hello RPC round-trip latency. Single client, sequential calls,
+// p50/p99 reported by tinybench's built-in samples histogram.
+//
+// SKIPPED until Task #33 lands the SessionService.Hello server impl. The
+// proto definition exists at packages/proto/src/ccsm/v1/session.proto
+// (rpc Hello(HelloRequest) returns (HelloResponse)) but no daemon-side
+// handler is registered yet — see packages/daemon/src/index.ts phase log
+// for the missing listener bind.
+//
+// When Task #33 lands: flip `bench.skip` -> `bench`, spin up the daemon
+// in-process (or via the same Connect-RPC test harness as
+// test/integration/rpc/clients-transport-matrix.spec.ts), construct a
+// PromiseClient<typeof SessionService>, and call `client.hello({})` in a
+// tight loop inside the bench fn. tinybench measures wall time per call;
+// p50/p99 fall out of the resulting histogram.
+//
+// Numbers are advisory; this is for trend tracking, not a ship gate.
+
+import { bench, describe } from 'vitest';
+
+describe('Hello RPC round-trip', () => {
+  bench.skip('client.hello() RTT', async () => {
+    // TODO(Task #33): implement once SessionService.Hello handler is wired.
+    // Blocked on: SessionService.Hello server registration in daemon RPC stack.
+    throw new Error('not implemented — blocked on Task #33');
+  });
+});

--- a/packages/daemon/test/bench/rss.bench.ts
+++ b/packages/daemon/test/bench/rss.bench.ts
@@ -1,0 +1,37 @@
+// packages/daemon/test/bench/rss.bench.ts
+//
+// T8.13 — daemon resident-set memory after warmup. Spawns the daemon,
+// runs a representative warmup workload (N sessions opened, M Hello
+// calls, K SendInput bytes), then samples `process.memoryUsage().rss`
+// of the daemon child via the supervisor /diag endpoint (or via
+// direct platform-specific RSS read of the child pid).
+//
+// SKIPPED today because the daemon doesn't yet have:
+//   - A way to be queried for RSS post-warmup (T1.7 supervisor needs
+//     a /diag or /metrics endpoint, or we read pid RSS externally).
+//   - The warmup workload primitives: Hello (Task #33) + SendInput
+//     (Task #53) + session open.
+//
+// This is technically a "value", not a "rate" bench — tinybench wants
+// time-per-op samples. Pattern: bench fn does the warmup + RSS sample
+// once per iter (iterations: 3-5), and we read RSS values from a
+// side-channel (e.g. write to a temp file each iter, post-process
+// offline). Alternative: report RSS in the bench stdout via
+// console.log and have the nightly job grep for it.
+//
+// When unblocked: flip `bench.skip` -> `bench`, decide on the
+// side-channel format (likely a `bench-rss.jsonl` next to the
+// vitest output for the nightly scraper to pick up).
+
+import { bench, describe } from 'vitest';
+
+describe('daemon RSS after warmup', () => {
+  bench.skip('rss bytes after N-session warmup', async () => {
+    // TODO(T1.7 + Task #33 + Task #53): implement once daemon can be
+    // spawned and exercised end-to-end. Blocked on:
+    //   - T1.7        supervisor /healthz so we know warmup is done
+    //   - Task #33    Hello RPC for warmup traffic
+    //   - Task #53    SendInput RPC for warmup traffic
+    throw new Error('not implemented — blocked on T1.7 + Task #33 + Task #53');
+  });
+});

--- a/packages/daemon/test/bench/sendinput-rtt.bench.ts
+++ b/packages/daemon/test/bench/sendinput-rtt.bench.ts
@@ -1,0 +1,32 @@
+// packages/daemon/test/bench/sendinput-rtt.bench.ts
+//
+// T8.13 — SendInput end-to-end round-trip: client writes 1 byte via
+// SendInput, daemon forwards to pty-host, pty echoes, daemon streams the
+// echo frame back to the client. Measured wall-clock per byte.
+//
+// This is the *advisory* counterpart to the SendInput soak ship-gate
+// (Task #92, gate-c). The soak harness owns the binding p99 SLO; this
+// bench only records the same number outside of the soak so trend
+// regressions show up between releases without waiting for a 1h soak.
+//
+// SKIPPED until Task #53 lands the SendInput RPC handler + pty-host
+// echo wiring. Today packages/daemon/src/pty-host/host.ts has the
+// child fork lifecycle but no input-forward path — see child.ts comment
+// "xterm-headless import / Terminal init — lands with T4.6 (codec)".
+//
+// When Task #53 lands: flip `bench.skip` -> `bench`. Suggested shape:
+//   1. spawn a session running `cat` (or `node -e "process.stdin.pipe(process.stdout)"`)
+//   2. open a server-stream Snapshot/Frame subscription
+//   3. for each iter: write 1 byte via SendInput, await first frame
+//      whose payload contains that byte, record (now - sentAt) ms
+
+import { bench, describe } from 'vitest';
+
+describe('SendInput round-trip (echo)', () => {
+  bench.skip('SendInput -> first echo frame', async () => {
+    // TODO(Task #53): implement once SendInput handler + pty echo wiring lands.
+    // Blocked on: SendInput RPC + pty-host input forwarding.
+    // See also Task #92 for the binding p99 SLO (this bench is advisory).
+    throw new Error('not implemented — blocked on Task #53');
+  });
+});

--- a/packages/daemon/test/bench/snapshot-encode.bench.ts
+++ b/packages/daemon/test/bench/snapshot-encode.bench.ts
@@ -1,0 +1,32 @@
+// packages/daemon/test/bench/snapshot-encode.bench.ts
+//
+// T8.13 — SnapshotV1 encode throughput in bytes/sec. Pure-CPU bench:
+// build a representative terminal snapshot (e.g. 80x24 with mixed
+// SGR runs and unicode), serialize it via the SnapshotV1 encoder,
+// divide bytes-out / wall-time.
+//
+// SKIPPED until Task #46 lands the SnapshotV1 encoder. The proto wire
+// shape exists in packages/proto/src/ccsm/v1/, but the daemon-side
+// encoder (xterm-headless terminal -> SnapshotV1 message) is part of
+// the codec task (T4.6 / Task #46 in the manager queue).
+//
+// When Task #46 lands: flip `bench.skip` -> `bench`. Suggested shape:
+//   1. once per bench run (setup, not per-iter): build a fixed
+//      xterm-headless Terminal pre-populated with a representative
+//      buffer (mixed SGR, scrollback ~1000 lines, some unicode).
+//   2. per iter: call `encodeSnapshotV1(term)` and record bytesOut.
+//   3. report `bytesOut / sample.mean` outside vitest as a derived
+//      metric (or use bench.opts.iterations to size the report).
+//
+// This is pure CPU — no daemon process needed. Easiest of the five
+// to wire up once the encoder exists.
+
+import { bench, describe } from 'vitest';
+
+describe('SnapshotV1 encode throughput', () => {
+  bench.skip('encode 80x24 terminal snapshot', () => {
+    // TODO(Task #46): implement once SnapshotV1 encoder lands.
+    // Blocked on: snapshot encoder (xterm-headless Terminal -> SnapshotV1 message).
+    throw new Error('not implemented — blocked on Task #46');
+  });
+});

--- a/packages/daemon/vitest.bench.config.ts
+++ b/packages/daemon/vitest.bench.config.ts
@@ -1,0 +1,34 @@
+// Daemon bench config (T8.13). Separate from the main `vitest.config.ts`
+// to keep `npm test` fast and CI-deterministic — bench files run via
+// `vitest bench --config vitest.bench.config.ts --run packages/daemon/test/bench/`
+// on the nightly schedule (design spec ch12 §7).
+//
+// Why a separate config (not just relying on auto-discovery):
+//   - The main `vitest.config.ts` pins `include: ['**/*.spec.ts']` — `bench.ts`
+//     files would NOT be picked up there even though vitest's default
+//     discovery includes them. Adding `*.bench.ts` to the main include
+//     would surface bench files inside `vitest run` which we explicitly
+//     do not want (bench runs are wall-clock heavy and noisy in CI).
+//   - Bench needs different reporter defaults (verbose stdout for the
+//     nightly job to scrape p50/p99 numbers) than spec runs.
+//
+// Numbers are advisory in this config; the only blocking gate is
+// SendInput p99 which is enforced by the soak harness (Task #92), not
+// here. This file is the "where do we record numbers" half — actual
+// gating lives with the soak ship-gate.
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/bench/**/*.bench.ts'],
+    // Vitest bench uses tinybench under the hood — leave its defaults
+    // (iterations / time / warmup) alone unless a specific bench file
+    // overrides them inline. Defaults: time=500ms, warmupTime=100ms.
+    benchmark: {
+      reporters: ['default'],
+    },
+    globals: false,
+  },
+});


### PR DESCRIPTION
## Task

Task #97 [T8.13] — packages/daemon/test/bench/ nightly bench suite skeleton (cold-start, hello-rtt, sendinput-rtt, snapshot-encode, rss). Per design spec ch12 §7.

## Layer 1

OK — proceeding. Grepped first; no existing `*.bench.ts` under packages/daemon. Per dev protocol §1, the deliverable is the **harness shape**, not real numbers; upstream RPCs (Hello / SendInput / Snapshot encode / supervisor /healthz) are not yet implemented, so all five benches ship as `bench.skip` with TODO comments referencing blocker task IDs. When each blocker lands, that task's PR flips `bench.skip` -> `bench` in the same PR (no stranded skeletons).

## Bench files: real vs skipped

| File | Status | Blocker |
| --- | --- | --- |
| `cold-start.bench.ts` | skipped | T1.7 (Supervisor /healthz flip to 200) |
| `hello-rtt.bench.ts` | skipped | Task #33 (Hello RPC server impl) |
| `sendinput-rtt.bench.ts` | skipped | Task #53 (SendInput RPC + pty echo wiring) |
| `snapshot-encode.bench.ts` | skipped | Task #46 (SnapshotV1 encoder) |
| `rss.bench.ts` | skipped | T1.7 + Task #33 + Task #53 (need running daemon + warmup traffic) |

All advisory per ch12 §7. The only blocking perf gate is SendInput p99, enforced by the soak harness (Task #92, gate-c) — not by this bench suite.

## Files added

- `packages/daemon/test/bench/cold-start.bench.ts`
- `packages/daemon/test/bench/hello-rtt.bench.ts`
- `packages/daemon/test/bench/sendinput-rtt.bench.ts`
- `packages/daemon/test/bench/snapshot-encode.bench.ts`
- `packages/daemon/test/bench/rss.bench.ts`
- `packages/daemon/test/bench/README.md` — status table + how-to-run
- `packages/daemon/vitest.bench.config.ts` — separate config so bench files are NOT picked up by `npm test`

## Constraint compliance

- `packages/daemon/vitest.config.ts` — **not touched** (hotfile). The existing config pins `include: ['**/*.spec.ts']`, so `*.bench.ts` files are naturally excluded from `vitest run`. The new `vitest.bench.config.ts` is a fresh file (no hotfile mutex).
- `packages/daemon/package.json` scripts — **not touched**. The nightly workflow invokes `npx vitest bench --config packages/daemon/vitest.bench.config.ts --run` directly; no package script needed for T8.13's deliverable.

## Naming note

Spec ch12 §7 table refers to bench files as `bench/cold-start.spec.ts` etc. Task brief and vitest convention both use `*.bench.ts` for files using the `bench()` API (separates from `test()` files cleanly, matches tinybench convention, makes nightly-vs-PR runs trivially filterable by include glob). I followed the brief.

## Quality gates (local)

```
pnpm --filter @ccsm/daemon lint        OK (no errors)
pnpm --filter @ccsm/proto gen          OK
pnpm --filter @ccsm/daemon typecheck   OK (clean after proto gen)
npx vitest bench --config vitest.bench.config.ts --run
  -> all 5 bench files loaded, all 5 reported [skipped] as designed
  -> 0 errors during discovery / startup
```

The smoke run output (excerpt):
```
RUN  v4.1.5 packages/daemon
↓ test/bench/cold-start.bench.ts > daemon cold-start
   ↓ spawn -> /healthz green (ms) [skipped]
↓ test/bench/hello-rtt.bench.ts > Hello RPC round-trip
   ↓ client.hello() RTT [skipped]
↓ test/bench/sendinput-rtt.bench.ts > SendInput round-trip (echo)
   ↓ SendInput -> first echo frame [skipped]
↓ test/bench/snapshot-encode.bench.ts > SnapshotV1 encode throughput
   ↓ encode 80x24 terminal snapshot [skipped]
↓ test/bench/rss.bench.ts > daemon RSS after warmup
   ↓ rss bytes after N-session warmup [skipped]
```

Per task brief: bench files don't need to "pass" — `vitest bench --run` must START without throwing. Confirmed.