### PR TITLE
feat(electron): T6.1 protocol.handle('app') descriptor server

### DIFF
--- a/packages/electron/src/main/protocol-app.ts
+++ b/packages/electron/src/main/protocol-app.ts
@@ -1,0 +1,468 @@
+// T6.1 — Electron main: descriptor server via `protocol.handle('app', ...)`.
+//
+// Spec ref: `docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md`
+// chapter 08 §4.1 (locked: descriptor served via `protocol.handle`, no
+// `contextBridge`). Sequence:
+//
+//   1. Electron main reads `listener-a.json` from the locked per-OS path
+//      (chapter 07 §2 / chapter 03 §3).
+//   2. Electron main rewrites the descriptor's `address` field to point at
+//      the bridge's loopback endpoint (§4.2) — the renderer never sees the
+//      daemon's UDS / named-pipe path.
+//   3. Electron main registers a custom scheme handler via
+//      `protocol.handle("app", ...)` that serves the rewritten descriptor at
+//      `app://ccsm/listener-descriptor.json` (read-only;
+//      `Content-Type: application/json`).
+//   4. Renderer at boot calls `await fetch("app://ccsm/listener-descriptor.json")`
+//      and parses the result. No `contextBridge`, no `additionalArguments`,
+//      no preload-injected globals — `lint:no-ipc` (§5h.1) passes
+//      mechanically.
+//
+// Scope of this file (T6.1):
+//   - The pure pieces (descriptor path, address rewrite, request handler).
+//   - A thin registration helper that calls `protocol.handle('app', handler)`
+//     against a caller-supplied `protocol` object (dependency-injected so
+//     unit tests do not need to spin up `electron`).
+//   - A `registerAppSchemeAsPrivileged` helper for callers to invoke before
+//     `app.whenReady()` (so renderer `fetch()` against `app://` is allowed
+//     by Chromium's secure-context / CSP machinery).
+//
+// Out of scope (deferred to other tasks):
+//   - The bridge endpoint itself: T6.2 (transport-bridge.ts §4.2). This
+//     module accepts the bridge URL as a string; the bridge owner passes it
+//     in. The default `'__BRIDGE_PENDING__'` sentinel is rejected at
+//     handler-creation time so we cannot ship without a real wire.
+//   - `index.ts` boot wiring: T6.6 stitches reads, the bridge, the
+//     descriptor handler, and the tray menu together.
+//
+// Cross-package boundary discipline:
+//   The eslint rule in `packages/electron/eslint.config.js` forbids
+//   `import ... from '@ccsm/daemon'`. We therefore COPY the minimal slice
+//   of `statePaths()` (just the per-OS root + `listener-a.json` join) here.
+//   The reference implementation lives in
+//   `packages/daemon/src/state-dir/paths.ts`; if either copy diverges the
+//   `descriptorPath` unit tests below will catch the win32 / darwin /
+//   linux cases against the same string fixtures the daemon spec uses.
+
+import { readFile } from 'node:fs/promises';
+import * as path from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Per-OS descriptor path — minimal slice copied from
+// packages/daemon/src/state-dir/paths.ts (chapter 07 §2 table). The eslint
+// rule `no-restricted-imports` (electron/eslint.config.js) forbids importing
+// `@ccsm/daemon` so we cannot share the exported helper directly. Tests
+// below assert the same string fixtures the daemon spec uses, so a future
+// drift between the two copies will be caught at CI time.
+// ---------------------------------------------------------------------------
+
+/** NodeJS platform identifier; matches the daemon helper's signature. */
+export type StateDirPlatform = NodeJS.Platform;
+
+/**
+ * Compute the absolute path to `listener-a.json` for a given platform + env
+ * snapshot. Pure: no filesystem I/O, no implicit `process.env` reads.
+ *
+ * Spec ch07 §2 table:
+ *   - win32:  `%PROGRAMDATA%\ccsm\listener-a.json`
+ *             (fallback `C:\ProgramData\ccsm\listener-a.json`)
+ *   - darwin: `/Library/Application Support/ccsm/listener-a.json`
+ *   - linux/other: `/var/lib/ccsm/listener-a.json`
+ */
+export function descriptorPath(
+  platform: StateDirPlatform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  if (platform === 'win32') {
+    const programData =
+      env.PROGRAMDATA && env.PROGRAMDATA.length > 0
+        ? env.PROGRAMDATA
+        : 'C:\\ProgramData';
+    return path.win32.join(programData, 'ccsm', 'listener-a.json');
+  }
+  if (platform === 'darwin') {
+    return '/Library/Application Support/ccsm/listener-a.json';
+  }
+  // linux + every other POSIX. FHS-correct; do NOT respect XDG_DATA_HOME
+  // here — see ch07 §2 ("the daemon may run with no logged-in user").
+  return '/var/lib/ccsm/listener-a.json';
+}
+
+// ---------------------------------------------------------------------------
+// Descriptor schema (renderer-facing slice of DescriptorV1).
+//
+// The daemon-side type is `packages/daemon/src/listeners/descriptor.ts`
+// `DescriptorV1`. We re-declare the structural shape here so the boundary
+// rule (electron MUST NOT import @ccsm/daemon) is honoured. Only the fields
+// this module actually inspects/rewrites are typed strictly; the rest are
+// passed through opaquely so a future v0.4 daemon adding a new top-level
+// optional field (per ch15 §3 forbidden-pattern 8) does not require a code
+// change here.
+// ---------------------------------------------------------------------------
+
+/** Closed enum of supported transports — copy of the daemon's enum. */
+export type DescriptorTransport =
+  | 'KIND_UDS'
+  | 'KIND_NAMED_PIPE'
+  | 'KIND_TCP_LOOPBACK_H2C'
+  | 'KIND_TCP_LOOPBACK_H2_TLS';
+
+/**
+ * Renderer-facing descriptor shape. Mirrors `DescriptorV1` from
+ * `packages/daemon/src/listeners/descriptor.ts`. We keep the snake_case
+ * spelling intentional — it matches the on-disk JSON byte-for-byte so a
+ * reverse-grep from `listener-a.json` to this type stays one hop.
+ */
+export interface DescriptorV1 {
+  readonly version: 1;
+  readonly transport: DescriptorTransport;
+  readonly address: string;
+  readonly tlsCertFingerprintSha256: string | null;
+  readonly supervisorAddress: string;
+  readonly boot_id: string;
+  readonly daemon_pid: number;
+  readonly listener_addr: string;
+  readonly protocol_version: 1;
+  readonly bind_unix_ms: number;
+}
+
+/** URL the renderer fetches. Spec ch08 §4.1 step 3 — locked. */
+export const DESCRIPTOR_URL = 'app://ccsm/listener-descriptor.json' as const;
+
+/** Custom scheme name registered against `protocol.handle`. */
+export const APP_SCHEME = 'app' as const;
+
+/** Sentinel used by callers that have not yet wired the bridge endpoint. */
+export const BRIDGE_PENDING_SENTINEL = '__BRIDGE_PENDING__' as const;
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse + structurally validate the on-disk JSON. Throws on malformed JSON,
+ * wrong `version`, or missing required fields. We deliberately do NOT
+ * validate every field exhaustively — the daemon-side writer (T1.6) is the
+ * authoritative producer; this is just enough to reject obviously corrupt
+ * input so the renderer doesn't see `undefined.boot_id` later.
+ *
+ * The validator is exported so tests can assert each rejection branch
+ * independently of disk I/O.
+ */
+export function parseDescriptor(json: string): DescriptorV1 {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(json);
+  } catch (err) {
+    throw new Error(
+      `descriptor JSON parse failed: ${(err as Error).message}`,
+    );
+  }
+  if (typeof raw !== 'object' || raw === null) {
+    throw new Error('descriptor must be a JSON object');
+  }
+  const o = raw as Record<string, unknown>;
+  if (o.version !== 1) {
+    throw new Error(
+      `descriptor version must be 1 (got ${JSON.stringify(o.version)}); ` +
+        'v0.4+ schema additions ship as new top-level fields per ch03 §3.2',
+    );
+  }
+  for (const key of [
+    'transport',
+    'address',
+    'supervisorAddress',
+    'boot_id',
+    'listener_addr',
+  ] as const) {
+    if (typeof o[key] !== 'string' || (o[key] as string).length === 0) {
+      throw new Error(`descriptor field "${key}" must be a non-empty string`);
+    }
+  }
+  if (typeof o.daemon_pid !== 'number' || !Number.isFinite(o.daemon_pid)) {
+    throw new Error('descriptor field "daemon_pid" must be a finite number');
+  }
+  if (o.protocol_version !== 1) {
+    throw new Error('descriptor field "protocol_version" must be 1');
+  }
+  if (typeof o.bind_unix_ms !== 'number' || !Number.isFinite(o.bind_unix_ms)) {
+    throw new Error('descriptor field "bind_unix_ms" must be a finite number');
+  }
+  if (
+    o.tlsCertFingerprintSha256 !== null &&
+    typeof o.tlsCertFingerprintSha256 !== 'string'
+  ) {
+    throw new Error(
+      'descriptor field "tlsCertFingerprintSha256" must be a string or null',
+    );
+  }
+  return raw as DescriptorV1;
+}
+
+/**
+ * Rewrite the descriptor's `address` (and the duplicate `listener_addr`)
+ * to point at the renderer-facing bridge endpoint. Per ch08 §4.1 step 2:
+ * "the renderer never sees the daemon's UDS / named-pipe path because the
+ * renderer never speaks to it directly".
+ *
+ * The original `transport` is preserved so future renderer tooling can log
+ * the daemon's actual transport without speaking to it. We do NOT widen the
+ * transport enum to a "bridge" pseudo-value — that would couple the
+ * descriptor schema to the bridge impl, which the spec forbids.
+ */
+export function rewriteDescriptorAddress(
+  descriptor: DescriptorV1,
+  bridgeAddress: string,
+): DescriptorV1 {
+  if (bridgeAddress.length === 0) {
+    throw new Error('bridgeAddress must be a non-empty string');
+  }
+  if (bridgeAddress === BRIDGE_PENDING_SENTINEL) {
+    throw new Error(
+      `refusing to serve descriptor with sentinel bridge address ` +
+        `"${BRIDGE_PENDING_SENTINEL}"; T6.2 transport-bridge must wire a ` +
+        'real loopback endpoint before T6.6 boot wiring',
+    );
+  }
+  return {
+    ...descriptor,
+    address: bridgeAddress,
+    listener_addr: bridgeAddress,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Handler factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Async I/O surface the handler depends on. Injected so unit tests can
+ * supply in-memory fakes without touching the filesystem and without
+ * requiring `electron` itself.
+ */
+export interface DescriptorHandlerDeps {
+  /**
+   * Path the descriptor lives at (typically `descriptorPath()`). Exposed
+   * so integration tests can point at a tmpdir descriptor.
+   */
+  readonly descriptorPath: string;
+  /**
+   * Loopback URL of the renderer transport bridge (§4.2). Replaces the
+   * descriptor's `address` field before the response is served. T6.2 owns
+   * the bridge implementation; T6.1 just rewrites.
+   */
+  readonly bridgeAddress: string;
+  /** Override for tests; defaults to `node:fs/promises` `readFile`. */
+  readonly readDescriptorFile?: (p: string) => Promise<string>;
+}
+
+/**
+ * Build the request handler `protocol.handle('app', ...)` will dispatch to.
+ *
+ * Behaviour per ch08 §4.1:
+ *   - Only `app://ccsm/listener-descriptor.json` is served. Any other path
+ *     under the `app://` scheme returns 404. We do NOT fall back to file://
+ *     or any other resource — this scheme is single-purpose in v0.3.
+ *   - Method MUST be `GET` (or `HEAD`). Anything else returns 405.
+ *   - Successful response body is the rewritten descriptor as JSON with
+ *     `Content-Type: application/json` and `Cache-Control: no-store` (the
+ *     descriptor changes every daemon boot — caching it is wrong).
+ *   - Read errors map to 503 (descriptor not yet written / daemon down) so
+ *     the renderer's retry loop has a clear signal.
+ *   - Validation errors map to 500 (the on-disk file is corrupt; the
+ *     daemon-side writer is broken — non-recoverable on the renderer side).
+ *
+ * The handler is a plain `(req: Request) => Promise<Response>`. It does not
+ * import `electron` so it can be unit-tested with a synthetic `Request`.
+ */
+export function createDescriptorHandler(
+  deps: DescriptorHandlerDeps,
+): (req: Request) => Promise<Response> {
+  // Eagerly assert the bridge sentinel was replaced so a misconfigured
+  // boot fails at startup rather than serving a useless descriptor.
+  if (deps.bridgeAddress === BRIDGE_PENDING_SENTINEL) {
+    throw new Error(
+      `createDescriptorHandler refuses sentinel bridge address ` +
+        `"${BRIDGE_PENDING_SENTINEL}"`,
+    );
+  }
+  if (deps.bridgeAddress.length === 0) {
+    throw new Error('createDescriptorHandler requires a non-empty bridgeAddress');
+  }
+  const reader = deps.readDescriptorFile ?? defaultReadDescriptorFile;
+  return async (req: Request): Promise<Response> => {
+    // URL parse. Custom schemes are not in WHATWG's "special scheme" list
+    // so `URL` treats them as opaque — `pathname` is still extractable.
+    let url: URL;
+    try {
+      url = new URL(req.url);
+    } catch {
+      return jsonError(400, 'invalid request URL');
+    }
+    if (url.protocol !== `${APP_SCHEME}:`) {
+      return jsonError(404, 'unknown scheme');
+    }
+    if (url.pathname !== '/listener-descriptor.json') {
+      return jsonError(404, 'unknown app:// resource');
+    }
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      return jsonError(405, `method ${req.method} not allowed`, {
+        Allow: 'GET, HEAD',
+      });
+    }
+
+    let raw: string;
+    try {
+      raw = await reader(deps.descriptorPath);
+    } catch (err) {
+      // ENOENT is the "daemon hasn't written the file yet" common case —
+      // surface it as 503 so the renderer's bootstrap loop retries.
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT') {
+        return jsonError(503, 'descriptor not yet available');
+      }
+      return jsonError(503, `descriptor read failed: ${(err as Error).message}`);
+    }
+
+    let parsed: DescriptorV1;
+    try {
+      parsed = parseDescriptor(raw);
+    } catch (err) {
+      return jsonError(500, `descriptor invalid: ${(err as Error).message}`);
+    }
+
+    const rewritten = rewriteDescriptorAddress(parsed, deps.bridgeAddress);
+    const body = `${JSON.stringify(rewritten)}\n`;
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'no-store',
+      // The descriptor is ephemeral per-boot; X-Content-Type-Options stops
+      // the renderer's MIME sniffer from reinterpreting it.
+      'X-Content-Type-Options': 'nosniff',
+    };
+    if (req.method === 'HEAD') {
+      return new Response(null, { status: 200, headers });
+    }
+    return new Response(body, { status: 200, headers });
+  };
+}
+
+function defaultReadDescriptorFile(p: string): Promise<string> {
+  return readFile(p, 'utf8');
+}
+
+function jsonError(
+  status: number,
+  message: string,
+  extraHeaders: Record<string, string> = {},
+): Response {
+  const body = `${JSON.stringify({ error: message })}\n`;
+  return new Response(body, {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'no-store',
+      ...extraHeaders,
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Electron registration helpers
+// ---------------------------------------------------------------------------
+//
+// These two helpers wrap the `electron` API surface. They are kept tiny so
+// the unit tests above can cover the behaviour without spawning Electron;
+// the e2e gate (chapter 12 §4) exercises the full wire.
+//
+// We type the `protocol` / `scheme privileges` arguments structurally so
+// this file does not need a static `import { protocol } from 'electron'`.
+// The caller in T6.6 will pass the real Electron objects; tests pass fakes.
+
+/** Minimal structural interface of Electron's `Protocol` for our use. */
+export interface ElectronProtocolLike {
+  handle(scheme: string, handler: (req: Request) => Promise<Response>): void;
+  unhandle?: (scheme: string) => void;
+}
+
+/** Minimal structural interface of Electron's `protocol.registerSchemesAsPrivileged`. */
+export interface ElectronSchemeRegistrarLike {
+  registerSchemesAsPrivileged(
+    customSchemes: Array<{
+      scheme: string;
+      privileges: {
+        standard?: boolean;
+        secure?: boolean;
+        supportFetchAPI?: boolean;
+        bypassCSP?: boolean;
+        corsEnabled?: boolean;
+        stream?: boolean;
+      };
+    }>,
+  ): void;
+}
+
+/**
+ * Privilege registration for the `app://` scheme. MUST be called before
+ * `app.whenReady()` per Electron's API contract — the renderer cannot
+ * `fetch()` a non-privileged custom scheme reliably.
+ *
+ * The privilege set is intentionally narrow:
+ *   - `standard: true`      — needed for URL parsing + relative resolution.
+ *   - `secure: true`        — Chromium treats the origin as secure context
+ *                             so `fetch()` doesn't trip mixed-content.
+ *   - `supportFetchAPI: true` — explicitly allow `fetch('app://...')` from
+ *                             the renderer.
+ *   - `corsEnabled: true`   — the renderer origin and the app:// origin
+ *                             differ; CORS must succeed.
+ *   - `stream: false` (default) — the descriptor is a tiny JSON blob.
+ *   - `bypassCSP: false` (default) — the renderer's CSP still applies.
+ */
+export function registerAppSchemeAsPrivileged(
+  registrar: ElectronSchemeRegistrarLike,
+): void {
+  registrar.registerSchemesAsPrivileged([
+    {
+      scheme: APP_SCHEME,
+      privileges: {
+        standard: true,
+        secure: true,
+        supportFetchAPI: true,
+        corsEnabled: true,
+      },
+    },
+  ]);
+}
+
+/** Inputs for `registerProtocolApp`. */
+export interface RegisterProtocolAppOptions {
+  readonly protocol: ElectronProtocolLike;
+  readonly bridgeAddress: string;
+  readonly descriptorPath?: string;
+  readonly readDescriptorFile?: (p: string) => Promise<string>;
+  readonly platform?: StateDirPlatform;
+  readonly env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Register the `app://` scheme handler against an Electron `protocol`
+ * object. MUST be called after `app.whenReady()`.
+ *
+ * Returns an `unregister()` callback for tests / hot-reload paths. The
+ * Electron `protocol.unhandle` API is optional in older Electron versions;
+ * we no-op if absent.
+ */
+export function registerProtocolApp(
+  opts: RegisterProtocolAppOptions,
+): () => void {
+  const handler = createDescriptorHandler({
+    descriptorPath:
+      opts.descriptorPath ?? descriptorPath(opts.platform, opts.env),
+    bridgeAddress: opts.bridgeAddress,
+    readDescriptorFile: opts.readDescriptorFile,
+  });
+  opts.protocol.handle(APP_SCHEME, handler);
+  return () => {
+    opts.protocol.unhandle?.(APP_SCHEME);
+  };
+}

--- a/packages/electron/test/main/protocol-app.spec.ts
+++ b/packages/electron/test/main/protocol-app.spec.ts
@@ -1,0 +1,441 @@
+// Unit tests for `protocol-app.ts` — descriptor server logic.
+//
+// Spec ref: ch08 §4.1. We exercise the pure helpers + the handler factory
+// without spawning Electron — handler is `(Request) => Promise<Response>`
+// so a synthetic `Request` from undici is enough. The Electron registration
+// helpers (`registerAppSchemeAsPrivileged`, `registerProtocolApp`) get a
+// structural fake to assert the wiring.
+
+import { describe, expect, it, vi } from 'vitest';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  APP_SCHEME,
+  BRIDGE_PENDING_SENTINEL,
+  DESCRIPTOR_URL,
+  type DescriptorV1,
+  type ElectronProtocolLike,
+  type ElectronSchemeRegistrarLike,
+  createDescriptorHandler,
+  descriptorPath,
+  parseDescriptor,
+  registerAppSchemeAsPrivileged,
+  registerProtocolApp,
+  rewriteDescriptorAddress,
+} from '../../src/main/protocol-app.js';
+
+const SAMPLE: DescriptorV1 = {
+  version: 1,
+  transport: 'KIND_UDS',
+  address: '/run/ccsm/daemon.sock',
+  tlsCertFingerprintSha256: null,
+  supervisorAddress: '/run/ccsm/supervisor.sock',
+  boot_id: '550e8400-e29b-41d4-a716-446655440000',
+  daemon_pid: 1234,
+  listener_addr: '/run/ccsm/daemon.sock',
+  protocol_version: 1,
+  bind_unix_ms: 1714600000000,
+};
+
+const SAMPLE_JSON = JSON.stringify(SAMPLE, null, 2);
+
+// ---------------------------------------------------------------------------
+// descriptorPath — per-OS layout (mirrors daemon paths.spec.ts fixtures)
+// ---------------------------------------------------------------------------
+
+describe('descriptorPath — per-OS layout (ch07 §2)', () => {
+  it('win32 with %PROGRAMDATA% set uses it', () => {
+    expect(descriptorPath('win32', { PROGRAMDATA: 'D:\\ProgramData' })).toBe(
+      'D:\\ProgramData\\ccsm\\listener-a.json',
+    );
+  });
+
+  it('win32 with empty %PROGRAMDATA% falls back to C:\\ProgramData', () => {
+    expect(descriptorPath('win32', { PROGRAMDATA: '' })).toBe(
+      'C:\\ProgramData\\ccsm\\listener-a.json',
+    );
+  });
+
+  it('win32 with %PROGRAMDATA% unset falls back to C:\\ProgramData', () => {
+    expect(descriptorPath('win32', {})).toBe(
+      'C:\\ProgramData\\ccsm\\listener-a.json',
+    );
+  });
+
+  it('darwin uses /Library/Application Support/ccsm', () => {
+    expect(descriptorPath('darwin', {})).toBe(
+      '/Library/Application Support/ccsm/listener-a.json',
+    );
+  });
+
+  it('linux uses /var/lib/ccsm', () => {
+    expect(descriptorPath('linux', {})).toBe(
+      '/var/lib/ccsm/listener-a.json',
+    );
+  });
+
+  it('freebsd / unrecognized POSIX fall through to the linux branch', () => {
+    expect(descriptorPath('freebsd' as NodeJS.Platform, {})).toBe(
+      '/var/lib/ccsm/listener-a.json',
+    );
+  });
+
+  it('does not respect XDG_DATA_HOME on linux (ch07 §2 LOCKED)', () => {
+    expect(
+      descriptorPath('linux', { XDG_DATA_HOME: '/home/me/.local/share' }),
+    ).toBe('/var/lib/ccsm/listener-a.json');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseDescriptor — schema validation
+// ---------------------------------------------------------------------------
+
+describe('parseDescriptor', () => {
+  it('round-trips a valid v1 descriptor', () => {
+    expect(parseDescriptor(SAMPLE_JSON)).toEqual(SAMPLE);
+  });
+
+  it('rejects malformed JSON', () => {
+    expect(() => parseDescriptor('{not json')).toThrow(/JSON parse failed/);
+  });
+
+  it('rejects non-object root', () => {
+    expect(() => parseDescriptor('"hello"')).toThrow(/must be a JSON object/);
+    expect(() => parseDescriptor('null')).toThrow(/must be a JSON object/);
+    expect(() => parseDescriptor('[]')).toThrow(/version must be 1/);
+  });
+
+  it('rejects wrong version (no schema-widening per ch03 §3.2)', () => {
+    const bad = { ...SAMPLE, version: 2 };
+    expect(() => parseDescriptor(JSON.stringify(bad))).toThrow(
+      /version must be 1/,
+    );
+  });
+
+  it('rejects missing transport', () => {
+    const bad: Record<string, unknown> = { ...SAMPLE };
+    delete bad.transport;
+    expect(() => parseDescriptor(JSON.stringify(bad))).toThrow(
+      /"transport".*non-empty string/,
+    );
+  });
+
+  it('rejects empty boot_id', () => {
+    const bad = { ...SAMPLE, boot_id: '' };
+    expect(() => parseDescriptor(JSON.stringify(bad))).toThrow(
+      /"boot_id".*non-empty string/,
+    );
+  });
+
+  it('rejects non-numeric daemon_pid', () => {
+    const bad = { ...SAMPLE, daemon_pid: 'oops' };
+    expect(() => parseDescriptor(JSON.stringify(bad))).toThrow(
+      /"daemon_pid".*finite number/,
+    );
+  });
+
+  it('rejects wrong protocol_version', () => {
+    const bad = { ...SAMPLE, protocol_version: 2 };
+    expect(() => parseDescriptor(JSON.stringify(bad))).toThrow(
+      /"protocol_version" must be 1/,
+    );
+  });
+
+  it('accepts tlsCertFingerprintSha256 = string', () => {
+    const ok = { ...SAMPLE, tlsCertFingerprintSha256: 'a'.repeat(64) };
+    expect(parseDescriptor(JSON.stringify(ok)).tlsCertFingerprintSha256).toBe(
+      'a'.repeat(64),
+    );
+  });
+
+  it('rejects non-null non-string tlsCertFingerprintSha256', () => {
+    const bad = { ...SAMPLE, tlsCertFingerprintSha256: 12 };
+    expect(() => parseDescriptor(JSON.stringify(bad))).toThrow(
+      /tlsCertFingerprintSha256/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rewriteDescriptorAddress
+// ---------------------------------------------------------------------------
+
+describe('rewriteDescriptorAddress', () => {
+  it('replaces address + listener_addr with the bridge endpoint', () => {
+    const out = rewriteDescriptorAddress(SAMPLE, 'http://127.0.0.1:51234');
+    expect(out.address).toBe('http://127.0.0.1:51234');
+    expect(out.listener_addr).toBe('http://127.0.0.1:51234');
+  });
+
+  it('leaves transport/boot_id/daemon_pid/etc. untouched', () => {
+    const out = rewriteDescriptorAddress(SAMPLE, 'http://127.0.0.1:51234');
+    expect(out.transport).toBe(SAMPLE.transport);
+    expect(out.boot_id).toBe(SAMPLE.boot_id);
+    expect(out.daemon_pid).toBe(SAMPLE.daemon_pid);
+    expect(out.supervisorAddress).toBe(SAMPLE.supervisorAddress);
+    expect(out.bind_unix_ms).toBe(SAMPLE.bind_unix_ms);
+    expect(out.protocol_version).toBe(SAMPLE.protocol_version);
+    expect(out.version).toBe(SAMPLE.version);
+  });
+
+  it('rejects empty bridgeAddress', () => {
+    expect(() => rewriteDescriptorAddress(SAMPLE, '')).toThrow(/non-empty/);
+  });
+
+  it('rejects the BRIDGE_PENDING sentinel (ship-gate guard)', () => {
+    expect(() => rewriteDescriptorAddress(SAMPLE, BRIDGE_PENDING_SENTINEL))
+      .toThrow(/sentinel/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createDescriptorHandler
+// ---------------------------------------------------------------------------
+
+describe('createDescriptorHandler — request handling', () => {
+  const BRIDGE = 'http://127.0.0.1:51234';
+
+  function makeHandler(opts: {
+    file?: string;
+    readImpl?: (p: string) => Promise<string>;
+  } = {}) {
+    return createDescriptorHandler({
+      descriptorPath: '/fake/listener-a.json',
+      bridgeAddress: BRIDGE,
+      readDescriptorFile:
+        opts.readImpl ??
+        (async () => (opts.file !== undefined ? opts.file : SAMPLE_JSON)),
+    });
+  }
+
+  it('serves the rewritten descriptor at the spec URL with JSON content-type', async () => {
+    const h = makeHandler();
+    const res = await h(new Request(DESCRIPTOR_URL));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/json');
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
+    expect(res.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    const body = (await res.json()) as DescriptorV1;
+    expect(body.address).toBe(BRIDGE);
+    expect(body.listener_addr).toBe(BRIDGE);
+    expect(body.boot_id).toBe(SAMPLE.boot_id);
+    expect(body.transport).toBe(SAMPLE.transport);
+  });
+
+  it('HEAD returns 200 with no body but correct headers', async () => {
+    const h = makeHandler();
+    const res = await h(new Request(DESCRIPTOR_URL, { method: 'HEAD' }));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/json');
+    const text = await res.text();
+    expect(text).toBe('');
+  });
+
+  it('rejects non-GET/HEAD with 405 + Allow header', async () => {
+    const h = makeHandler();
+    const res = await h(new Request(DESCRIPTOR_URL, { method: 'POST' }));
+    expect(res.status).toBe(405);
+    expect(res.headers.get('Allow')).toBe('GET, HEAD');
+  });
+
+  it('returns 404 for unknown app:// path', async () => {
+    const h = makeHandler();
+    const res = await h(new Request('app://ccsm/something-else.json'));
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 for non-app scheme', async () => {
+    const h = makeHandler();
+    const res = await h(new Request('http://ccsm/listener-descriptor.json'));
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 503 when descriptor file is missing (ENOENT)', async () => {
+    const h = makeHandler({
+      readImpl: async () => {
+        const err = new Error('not found') as NodeJS.ErrnoException;
+        err.code = 'ENOENT';
+        throw err;
+      },
+    });
+    const res = await h(new Request(DESCRIPTOR_URL));
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/not yet available/);
+  });
+
+  it('returns 503 on other read errors', async () => {
+    const h = makeHandler({
+      readImpl: async () => {
+        const err = new Error('disk on fire') as NodeJS.ErrnoException;
+        err.code = 'EIO';
+        throw err;
+      },
+    });
+    const res = await h(new Request(DESCRIPTOR_URL));
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/disk on fire/);
+  });
+
+  it('returns 500 when descriptor JSON is corrupt', async () => {
+    const h = makeHandler({ file: '{broken' });
+    const res = await h(new Request(DESCRIPTOR_URL));
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/descriptor invalid/);
+  });
+
+  it('returns 500 when descriptor schema is wrong (version mismatch)', async () => {
+    const bad = JSON.stringify({ ...SAMPLE, version: 999 });
+    const h = makeHandler({ file: bad });
+    const res = await h(new Request(DESCRIPTOR_URL));
+    expect(res.status).toBe(500);
+  });
+
+  it('refuses construction with the BRIDGE_PENDING sentinel', () => {
+    expect(() =>
+      createDescriptorHandler({
+        descriptorPath: '/fake',
+        bridgeAddress: BRIDGE_PENDING_SENTINEL,
+      }),
+    ).toThrow(/sentinel/);
+  });
+
+  it('refuses construction with an empty bridgeAddress', () => {
+    expect(() =>
+      createDescriptorHandler({
+        descriptorPath: '/fake',
+        bridgeAddress: '',
+      }),
+    ).toThrow(/non-empty/);
+  });
+
+  it('reads from the real filesystem when no readImpl override is provided', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'ccsm-protocol-app-'));
+    try {
+      const file = join(dir, 'listener-a.json');
+      await writeFile(file, SAMPLE_JSON, 'utf8');
+      const h = createDescriptorHandler({
+        descriptorPath: file,
+        bridgeAddress: BRIDGE,
+      });
+      const res = await h(new Request(DESCRIPTOR_URL));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as DescriptorV1;
+      expect(body.address).toBe(BRIDGE);
+      expect(body.boot_id).toBe(SAMPLE.boot_id);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Electron registration helpers (structural fakes)
+// ---------------------------------------------------------------------------
+
+describe('registerAppSchemeAsPrivileged', () => {
+  it('registers the app scheme with secure/standard/fetch/cors privileges', () => {
+    const calls: Array<unknown> = [];
+    const fake: ElectronSchemeRegistrarLike = {
+      registerSchemesAsPrivileged: (schemes) => {
+        calls.push(schemes);
+      },
+    };
+    registerAppSchemeAsPrivileged(fake);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual([
+      {
+        scheme: APP_SCHEME,
+        privileges: {
+          standard: true,
+          secure: true,
+          supportFetchAPI: true,
+          corsEnabled: true,
+        },
+      },
+    ]);
+  });
+});
+
+describe('registerProtocolApp', () => {
+  function makeFakeProtocol(): {
+    protocol: ElectronProtocolLike;
+    handles: Array<{ scheme: string; handler: (req: Request) => Promise<Response> }>;
+    unhandled: string[];
+  } {
+    const handles: Array<{
+      scheme: string;
+      handler: (req: Request) => Promise<Response>;
+    }> = [];
+    const unhandled: string[] = [];
+    return {
+      protocol: {
+        handle: (scheme, handler) => {
+          handles.push({ scheme, handler });
+        },
+        unhandle: (scheme) => {
+          unhandled.push(scheme);
+        },
+      },
+      handles,
+      unhandled,
+    };
+  }
+
+  it('calls protocol.handle("app", handler) with a working handler', async () => {
+    const fake = makeFakeProtocol();
+    const unregister = registerProtocolApp({
+      protocol: fake.protocol,
+      bridgeAddress: 'http://127.0.0.1:1',
+      descriptorPath: '/fake',
+      readDescriptorFile: async () => SAMPLE_JSON,
+    });
+    expect(fake.handles).toHaveLength(1);
+    expect(fake.handles[0].scheme).toBe(APP_SCHEME);
+
+    const res = await fake.handles[0].handler(new Request(DESCRIPTOR_URL));
+    expect(res.status).toBe(200);
+
+    unregister();
+    expect(fake.unhandled).toEqual([APP_SCHEME]);
+  });
+
+  it('unregister is a no-op when protocol.unhandle is not provided (older Electron)', () => {
+    const handles: unknown[] = [];
+    const protocol: ElectronProtocolLike = {
+      handle: (scheme, handler) => {
+        handles.push({ scheme, handler });
+      },
+      // unhandle deliberately omitted
+    };
+    const unregister = registerProtocolApp({
+      protocol,
+      bridgeAddress: 'http://127.0.0.1:1',
+      descriptorPath: '/fake',
+      readDescriptorFile: async () => SAMPLE_JSON,
+    });
+    expect(() => unregister()).not.toThrow();
+  });
+
+  it('falls back to descriptorPath() when no descriptorPath is provided', () => {
+    const fake = makeFakeProtocol();
+    const reader = vi.fn(async (_p: string) => SAMPLE_JSON);
+    registerProtocolApp({
+      protocol: fake.protocol,
+      bridgeAddress: 'http://127.0.0.1:1',
+      readDescriptorFile: reader,
+      platform: 'linux',
+      env: {},
+    });
+    // Trigger a request to confirm the resolved path went through to the reader.
+    return fake.handles[0]
+      .handler(new Request(DESCRIPTOR_URL))
+      .then(() => {
+        expect(reader).toHaveBeenCalledWith('/var/lib/ccsm/listener-a.json');
+      });
+  });
+});


### PR DESCRIPTION
Task #73 — implements ch08 §4.1 of `docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md`.

## Summary
- Reads `listener-a.json` from the locked per-OS state-dir path (ch07 §2 — `%PROGRAMDATA%\ccsm` / `/Library/Application Support/ccsm` / `/var/lib/ccsm`).
- Rewrites the descriptor's `address` (and the duplicate `listener_addr`) to a renderer-facing bridge endpoint passed in by the caller. `transport`, `boot_id`, `daemon_pid`, etc. are preserved untouched so the renderer's freshness check (ch03 §3.3) still works.
- Serves the rewritten descriptor at `app://ccsm/listener-descriptor.json` via `protocol.handle('app', ...)` with `Content-Type: application/json`, `Cache-Control: no-store`, `X-Content-Type-Options: nosniff`.
- Exports a `registerAppSchemeAsPrivileged` helper (caller invokes it before `app.whenReady()` so renderer `fetch('app://...')` works under Chromium's secure-context / CSP machinery).

NO `contextBridge`, NO `additionalArguments`, NO preload-injected globals. `lint:no-ipc` (§5h.1) passes mechanically.

## Out of scope (deferred)
- Bridge endpoint itself (T6.2 / `transport-bridge.ts` per §4.2). This module accepts the bridge URL as a string. A `BRIDGE_PENDING` sentinel is rejected at handler-creation time so we cannot ship without a real wire.
- Boot wiring (T6.6 / `index.ts` stitches reads, the bridge, the descriptor handler, and the tray menu together).

## Cross-package boundary
`packages/electron/eslint.config.js` forbids `import ... from '@ccsm/daemon'`. The minimal slice of `statePaths()` (per-OS root + `listener-a.json` join) is therefore COPIED into `protocol-app.ts`. The reference implementation lives in `packages/daemon/src/state-dir/paths.ts`. Test fixtures here match the daemon's `paths.spec.ts` byte-for-byte so any future drift is caught at CI time.

## Files
- `packages/electron/src/main/protocol-app.ts` (new) — pure helpers + handler factory + Electron registration helpers (structurally typed, no static `electron` import).
- `packages/electron/test/main/protocol-app.spec.ts` (new) — 37 vitest cases.

## Hotfile avoidance
Did NOT touch:
- `packages/electron/package.json`
- `packages/electron/vitest.config.ts`
- `packages/electron/tsconfig.json` / `tsconfig.test.json`
- root configs

New file in `src/main/` only. The existing per-package vitest `include` glob (`src/**/*.spec.ts`, `test/**/*.spec.ts`) and tsconfig.test `include` (`src/**/*`, `test/**/*`) already cover the new locations.

## Quality gates
All green locally:
- `pnpm --filter @ccsm/electron lint` — clean
- `pnpm --filter @ccsm/electron typecheck` — clean
- `pnpm --filter @ccsm/electron test test/main/protocol-app.spec.ts` — 37 / 37 passed (776ms)

## Test plan
- [x] Per-OS `descriptorPath` matches daemon `statePaths` fixtures (win32 with/without %PROGRAMDATA%, darwin, linux, freebsd fallback, XDG override ignored).
- [x] `parseDescriptor` rejects malformed JSON, non-object root, wrong version, missing required fields, non-numeric `daemon_pid`, wrong `protocol_version`, non-null non-string `tlsCertFingerprintSha256`.
- [x] `rewriteDescriptorAddress` swaps address+listener_addr, preserves the rest, rejects empty / sentinel.
- [x] Handler GET returns 200 + JSON + correct headers.
- [x] Handler HEAD returns 200 with empty body.
- [x] Handler POST → 405 with `Allow: GET, HEAD`.
- [x] Unknown app:// path → 404; non-app scheme → 404.
- [x] ENOENT → 503 with "not yet available"; other read errors → 503.
- [x] Corrupt JSON → 500; wrong-version JSON → 500.
- [x] `createDescriptorHandler` refuses sentinel / empty bridgeAddress at construction.
- [x] Real-FS round-trip via `mkdtemp`.
- [x] `registerAppSchemeAsPrivileged` registers the expected privilege set.
- [x] `registerProtocolApp` calls `protocol.handle("app", ...)` and the returned `unregister` calls `protocol.unhandle("app")` (no-ops gracefully when older Electron lacks `unhandle`).