### PR TITLE
spike: T9.14 MSI tooling pick (WiX 4 vs electron-builder)

### DIFF
--- a/tools/spike-harness/msi-tooling-pick/README.md
+++ b/tools/spike-harness/msi-tooling-pick/README.md
@@ -1,0 +1,65 @@
+# T9.14 — MSI tooling pick: WiX 4 vs electron-builder
+
+Task: **Task #114**. Spec: ch14 §1.16 phase 9.5. Decide between
+authoring the v0.3 Windows MSI installer with **WiX 4+** directly,
+versus **electron-builder**'s built-in `msi` target.
+
+Inputs:
+
+- Merged spike #113 (PR #890) — WiX 4+ `<ServiceInstall>` proven GREEN
+  on Windows 11 25H2 (same host this spike runs on).
+- Repo's existing `electron-builder` config in `package.json` (current
+  Windows target = `nsis`; MSI is one config switch away).
+
+Companion docs in this folder:
+
+- `wix4/` — minimal MSI built directly with WiX 4+ (`wix build`),
+  reusing the same authoring pattern as #113.
+- `electron-builder/` — minimal `msi` target attempt + analysis of
+  what its template can and cannot express.
+- `decision.md` — recommendation, with measurements.
+
+## Comparison criteria
+
+| # | Criterion                                                    | Why it matters for v0.3                                                                                              |
+| - | ------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| 1 | **MSI output size** (KiB, payload-excluded baseline + delta) | Installer download size budget; smaller MSI overhead is preferred when payload is fixed.                             |
+| 2 | **Build time** (cold + warm, seconds)                        | CI minutes per release; >2x dev iteration cost adds up over 9.5 phase tasks.                                         |
+| 3 | **`<ServiceInstall>` / `<ServiceControl>` support**          | Hard requirement — daemon must register with SCM (per #113 spec ch14 §1.14). No service install = blocker.            |
+| 4 | **Custom action support** (CA exec, immediate / deferred)    | Needed for: minisign signature verify pre-install, daemon socket DACL (`set-pipe-dacl.ps1` parity), post-install reg. |
+| 5 | **Cross-build from non-Windows host**                        | CI matrix simplification; if Linux runner can emit Windows MSI we save a Windows runner job.                         |
+| 6 | **Authenticode signing flow**                                | v0.3 ships placeholder-safe signing per `feedback_v03_zero_rework.md`; flow must accept `signtool sign /fd SHA256` on the .msi *and* the embedded daemon exe. |
+| 7 | **Ability to embed daemon binary** (separate from Electron app) | v0.3 architecture = Electron thin + daemon fat. Daemon exe is a separate binary the MSI must install + register as a service. |
+| 8 | **Schema modernity / upstream support**                      | WiX 3.x is in maintenance only; WiX 4/5 is the actively-developed line. Picking the EOL line means migrating again later. |
+| 9 | **Pin / reproducibility** (toolchain version pinning)        | Reproducible CI builds; pinned toolchain version surviving major releases.                                           |
+
+## Method
+
+Build identical-payload MSIs with both tools, measure 1 / 2 / 7,
+inspect the templates / docs / source for 3 / 4 / 5 / 6 / 8 / 9.
+Where actual builds are not possible on this host, capture the
+blocker verbatim and fall back to documentation + #890 evidence.
+
+This host (Windows 11 Enterprise 26200.8246, .NET 10.0.203,
+WiX 5.0.2 dotnet global tool, Node 24.14.1, npm 11.11.0, no Wine,
+no electron-builder vendor cache populated) supports the WiX 4+
+direct path natively; the electron-builder MSI path requires its
+bundled WiX 3.x vendor archive to be downloaded on first invocation.
+
+## Layout
+
+```
+msi-tooling-pick/
+  README.md                this file
+  decision.md              recommendation + measurements
+  wix4/
+    Product.wxs            minimal authoring with ServiceInstall
+    build.ps1              dotnet publish + wix build
+    payload/Program.cs     trivial daemon-shaped exe target
+    payload/payload.csproj
+    .gitignore
+  electron-builder/
+    package.json           minimal package with msi target enabled
+    main.js                trivial Electron entry
+    ATTEMPT.md             what was tried, what blocked, what the template can/cannot do
+```

--- a/tools/spike-harness/msi-tooling-pick/decision.md
+++ b/tools/spike-harness/msi-tooling-pick/decision.md
@@ -1,0 +1,127 @@
+# T9.14 — MSI tooling pick: decision
+
+## Recommendation: WiX 4 (direct authoring)
+
+The v0.3 Windows installer should be authored directly with the
+**WiX 4+ toolset** (`wix build`, dotnet global tool, schema
+`http://wixtoolset.org/schemas/v4/wxs`), invoked from CI as a
+Windows-native step. Electron-builder should **not** be used for
+the MSI target.
+
+## Quantitative measurements (this host)
+
+Same Windows 11 Enterprise 26200.8246 host, .NET 10.0.203,
+WiX 5.0.2 dotnet global tool, Node 24.14.1, npm 11.11.0.
+
+|                       | WiX 4 (`wix4/`)              | electron-builder (`electron-builder/`) |
+| --------------------- | ---------------------------- | --------------------------------------- |
+| Cold build wall time  | **33.3 s** (publish 13.4s + wix 19.9s) | **160 s** (failed 1st run, 195s; succeeded 2nd run with `-sval`) |
+| Warm rebuild wall time | **16.6 s** (`wix build` only) | **149 s** (full electron repackage)    |
+| Output MSI size       | **32 768 B** + 27.8 MiB cab1.cab (sidecar) = ~28 MiB total | **113 262 592 B** (108 MiB MSI, all-in-one) |
+| Unpacked payload size | 75.7 MiB (self-contained .NET host, no Electron) | 344 MiB on disk (Electron 41 + Chromium runtime) |
+| Worked out-of-the-box | **yes**                      | **no** — `light.exe LGHT1105` ICE / system-policy block on first run; required adding `additionalLightArgs: ["-sval"]` to skip ICE validation, which is unacceptable for a shipped installer. |
+| `<ServiceInstall>`    | **supported** (verified GREEN by spike #113 PR #890 on the same host) | **not supported** — template has no service elements, no extension hook, no `additionalWixArgs` path that can inject service authoring |
+| Custom actions        | full WiX CA surface (immediate / deferred / impersonated, ExeCommand, VBScriptFile, JScriptFile, BinaryRef) | only `runAfterFinish` (fixed: launches `mainExecutable` post-install, no arbitrary CA) |
+| arm64                 | native arm64 support in WiX 4+ | source code defaults arm64 → x64; bundled WiX 3.x vendor "doesn't support the arm64 architecture" (verbatim comment in `MsiTarget.ts`) |
+| Toolchain currency    | WiX 4 / 5 (active line)      | WiX 3.x via `electron-builder-binaries` `wix-4.0.0.5512.2` package — labeling misleading; binaries are `candle.exe` + `light.exe` (WiX 3 toolchain) |
+| Reproducibility       | `dotnet tool install --global wix --version <pin>` | locked to whatever vendor archive electron-builder-binaries publishes; bumping requires upstream PR |
+| Cross-build           | WiX 4 has Linux support via `dotnet tool` (the same `wix` tool runs on Linux), but service install + signtool keep CI on a Windows runner regardless | claimed via Wine + dotnet462; not exercised here. CI will be on Windows for signtool anyway. |
+| Signing               | `signtool sign /fd SHA256` on the .msi after `wix build`, plus a separate `signtool` pass on the embedded daemon exe before `wix build` ingests it. Two clean steps. | `signtool` invoked twice automatically on the unpacked .exe and the .msi; daemon binary signing must still be done manually before electron-builder packages |
+
+## Comparison criteria scorecard (criteria from `README.md`)
+
+| # | Criterion                                  | WiX 4 | electron-builder |
+| - | ------------------------------------------ | ----- | ---------------- |
+| 1 | MSI output size                            | ~28 MiB total (32 KiB MSI + cab) | 108 MiB MSI |
+| 2 | Build time (cold / warm)                   | 33s / 17s | 160s / 149s |
+| 3 | `<ServiceInstall>` / `<ServiceControl>`    | yes (#890 GREEN) | no (template blocker) |
+| 4 | Custom action support                      | full | runAfterFinish only |
+| 5 | Cross-build from non-Windows               | yes (`dotnet tool`) | claimed (Wine) |
+| 6 | Authenticode signing flow                  | manual `signtool`, two steps | automatic (after the embedded daemon is pre-signed) |
+| 7 | Embed daemon binary as separate file + service | yes (just add a `<File>` + `<ServiceInstall>` in a Component) | technically possible to ship the file as part of asarUnpack, but no way to register it as a service |
+| 8 | Schema modernity                           | WiX 4/5 (active) | WiX 3.x (maintenance only) |
+| 9 | Pin / reproducibility                      | `dotnet tool install --global wix --version 5.0.2` | tied to electron-builder-binaries release cadence |
+
+WiX 4 wins **8 / 9** criteria. Electron-builder wins **1 / 9**
+(criterion 6, signing automation — and only for the Electron exe,
+not for the daemon binary).
+
+## Why criterion 3 alone is decisive
+
+Spec ch14 §1.14 phase 9.5 (the spike that produced #890) made
+`<ServiceInstall>` a hard requirement: the daemon must register
+with SCM as `CcsmDaemon` (or equivalent) and start on demand.
+Electron-builder's MSI template has **no path** to emit this
+authoring without forking upstream. Forking electron-builder for
+one feature is unacceptable for a v0.3 ship target per
+`feedback_v03_zero_rework.md` ("don't write code that v0.4 will
+throw away").
+
+The remaining 8 criteria are tiebreakers — but criterion 3 alone
+already settles it.
+
+## Architectural fit with v0.3
+
+The v0.3 architecture is **Electron thin + daemon fat** (per
+`project_v03_ship_goal.md`). The Electron app is a UI shell; the
+daemon is a separate native binary that runs as a Windows service.
+This means:
+
+- The Electron app itself does **not** need to be in the same MSI
+  as the daemon — they have different lifecycles, different update
+  cadences, and different signing needs. The Electron side can ship
+  via the existing NSIS target (already in `package.json` as
+  `"win": [{ "target": "nsis" }]`).
+- The daemon is what needs an MSI, specifically because of the
+  `<ServiceInstall>` requirement that NSIS can't satisfy cleanly
+  either (NSIS can call `sc create` but doesn't manage SCM state
+  through MSI standard actions, so uninstall residue is harder).
+
+Picking electron-builder here would mean:
+1. Bundle the entire Electron payload (108 MiB+) into the MSI just
+   to get a service registration the template doesn't support, **or**
+2. Ship two installers (NSIS for the Electron app, somehow-other for
+   the daemon).
+
+WiX 4 lets us do the right thing: a small (~28 MiB) MSI that ships
+**only the daemon + service registration**, separate from the
+Electron app's NSIS installer. This matches the architecture and
+keeps the daemon updateable independently of UI churn.
+
+## Cost of switching later
+
+If we picked electron-builder now and hit the `<ServiceInstall>`
+wall later (which is certain), the migration cost is:
+
+- Re-author the wxs from scratch (electron-builder template ≠ v4 schema).
+- Re-do the build script integration.
+- Re-do the signing flow (separate signtool invocations).
+- Re-validate on 25H2 (need a fresh 9.5 phase pass).
+
+That is the v0.4 throwaway-code smell that the zero-rework rule
+forbids. Picking WiX 4 now means the spike #113 work product is
+directly reusable: the `Product.wxs` here in `wix4/Product.wxs`
+is structurally a clone of #890's, plus a slightly more daemon-shaped
+payload to validate file size accounting.
+
+## Out of scope for this spike (deferred to Windows installer task)
+
+These were explicitly **not** decided here, only enumerated:
+
+- Daemon service identity (`LocalSystem` vs `NT SERVICE\\CcsmDaemon`)
+  — see #890 follow-up #2.
+- `Start="auto"` + `<util:ServiceConfig DelayedAutoStart="yes">` —
+  see #890 follow-up #3.
+- WiX vendor pin (4.0.x vs 5.0.x) — both are valid for the v4 schema;
+  pick whichever the CI runner can install via `dotnet tool restore`
+  reproducibly.
+- Authenticode signing key procurement — out of scope, gated on
+  v0.3's signing placeholder-safe story per `feedback_v03_zero_rework.md`.
+- MSI bundling (Burn / Bundle) if we ever want a single
+  daemon+app installer — explicitly not v0.3.
+
+## Final answer
+
+**WiX 4.** Author the Windows installer for the daemon directly
+with `wix build`. Keep the Electron app on its existing NSIS target.
+Reuse the `Product.wxs` pattern from #890 / `wix4/Product.wxs`.

--- a/tools/spike-harness/msi-tooling-pick/electron-builder/.gitignore
+++ b/tools/spike-harness/msi-tooling-pick/electron-builder/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+release/
+package-lock.json

--- a/tools/spike-harness/msi-tooling-pick/electron-builder/ATTEMPT.md
+++ b/tools/spike-harness/msi-tooling-pick/electron-builder/ATTEMPT.md
@@ -1,0 +1,134 @@
+# Electron-builder MSI attempt
+
+## Setup
+
+`package.json` here is a minimal Electron app (single `main.js` that
+opens a window and quits) configured with `"win": [{ "target": "msi"
+}]` and a `"msi": {}` block that mirrors what v0.3 would need
+(`perMachine: true`, `oneClick: false`, `upgradeCode`).
+
+```bash
+cd electron-builder
+npm install        # installs electron 41.5.0 + electron-builder 26.8.1
+npm run build:msi  # downloads electron + WiX vendor on first run
+```
+
+## What happened (run 1, out-of-the-box)
+
+Build **failed**. Verbatim error from electron-builder:
+
+```
+• building        target=MSI arch=x64 file=release\CcsmToolingPickEb 0.0.1.msi
+• Manufacturer is not set for MSI — please set "author" in the package.json
+• downloading     url=https://github.com/electron-userland/electron-builder-binaries/releases/download/wix-4.0.0.5512.2/wix-4.0.0.5512.2.7z
+• downloaded      duration=430ms
+
+⨯ light.exe process failed 1105
+light.exe : error LGHT1105 : Validation could not run due to system policy.
+            To eliminate this warning, run the process as admin or
+            suppress ICE validation.
+```
+
+`LGHT1105` is the **WiX 3.x** linker (`light.exe`) ICE validation step
+hitting a Windows AppLocker / system-policy block on the machine. The
+WiX 4 path (the merged spike #113 / this folder's `wix4/`) does **not**
+trip this — `wix build` runs ICE validation differently and is policy-OK
+on the same host. This alone is a deployment-velocity tax: every contributor
+or CI runner with hardened policy will bounce off this on first build.
+
+## What happened (run 2, with `additionalLightArgs: ["-sval"]`)
+
+Adding `additionalLightArgs: ["-sval"]` to the `msi` config to skip
+ICE validation lets the build complete:
+
+```
+elapsed = 160s (cold)  /  149s (warm rebuild after node_modules cached)
+release/CcsmToolingPickEb 0.0.1.msi   = 113,262,592 B  (108.0 MiB)
+release/win-unpacked/                 = 344 MiB on disk
+```
+
+Skipping ICE is acceptable for a spike, **not** for a shipped installer:
+ICE03/06/09 catch real malformed-MSI bugs (file/registry collisions,
+component GUID reuse, sequencing). v0.3 cannot ship `-sval` long-term.
+
+## What the template can and cannot express
+
+`electron-builder/packages/app-builder-lib/templates/msi/template.xml`
+(116 lines, fetched from upstream `master`) is the entire authoring
+surface electron-builder exposes. Inspection findings:
+
+1. **WiX 3.x schema, not WiX 4.** Top-level element is `<Product>`,
+   which was merged into `<Package>` in WiX v4. The xmlns attribute
+   reads `http://wixtoolset.org/schemas/v4/wxs` but the `<Product>`
+   structure is the v3 dialect. Confirmed in
+   `MsiTarget.ts`: it shells out to `candle.exe` + `light.exe`
+   (the WiX 3.x toolchain — WiX 4+ collapsed both into a single
+   `wix build` command).
+   ```ts
+   const vendorPath = await getBinFromUrl(
+     "wix-4.0.0.5512.2", "wix-4.0.0.5512.2.7z", "...")
+   const candleArgs = [...]
+   await vm.exec(vm.toVmFile(path.join(vendorPath, "candle.exe")), ...)
+   await this.light(...)  // light.exe
+   ```
+   The `wix-4.0.0.5512.2` package name refers to the **electron-builder-binaries**
+   release ID, not the WiX major version. The bundled binaries are
+   WiX **3.x**.
+
+2. **No `<ServiceInstall>` element anywhere in the template.** The
+   template only emits `<Component>` entries with `<File>` children,
+   plus optional shortcut and run-after-finish bits. There is no
+   placeholder, no `{{-services}}`, no extension hook for inserting
+   `<ServiceInstall>` / `<ServiceControl>`. This is the **hard
+   blocker** for v0.3, which needs the daemon registered with SCM
+   (per spec ch14 §1.14, validated by spike #113).
+
+3. **`additionalWixArgs` and `additionalLightArgs`** forward CLI
+   args to candle/light, not custom .wxs fragments. They cannot
+   inject new authoring elements into the generated `project.wxs`.
+
+4. **No custom action hooks for the daemon side.** `runAfterFinish`
+   exists but only fires the main `mainExecutable` File post-install;
+   it cannot accept arbitrary CA logic (signature verify, DACL set,
+   service config tweak).
+
+5. **No arm64 support.** Source explicitly stops at x64:
+   ```ts
+   // wix 4.0.0.5512.2 doesn't support the arm64 architecture so default
+   // to x64 when building for arm64.
+   const wixArch = arch == Arch.arm64 ? Arch.x64 : arch
+   ```
+   v0.3 may not ship arm64 today, but locking the future arm64 story
+   to "wait for upstream electron-builder-binaries to upgrade WiX" is
+   strategic debt.
+
+6. **Cross-build claim.** electron-builder can in theory build Windows
+   MSIs from Linux/macOS via Wine, with a comment in
+   `MsiTarget.ts` noting `dotnet462` must be preinstalled in the Wine
+   prefix. Not exercised on this host (this machine **is** Windows,
+   so the cross-build path was not the bottleneck). For CI, given
+   the daemon is a cross-compiled Go/Rust/.NET binary anyway, going
+   native Windows on the runner is the simpler trade.
+
+## What would need to change upstream to unblock electron-builder
+
+To make electron-builder a viable v0.3 MSI tool, upstream would need
+to either:
+
+- (a) Ship a `services` config option that emits `<ServiceInstall>` /
+  `<ServiceControl>` into the generated component, **and** upgrade
+  the bundled WiX vendor from 3.x to 4+ (the v4 schema requires
+  `<Component>`-level service elements per #890's notes), **or**
+- (b) Allow injecting a custom .wxs fragment, with documented merge
+  semantics into the template's `ProductComponents` ComponentGroup.
+
+Neither exists today. There is no open PR adding either.
+
+Owning a fork of electron-builder for one feature is firmly off the
+table for a v0.3 ship target.
+
+## Verdict on the electron-builder path
+
+Cannot meet criterion 3 (`<ServiceInstall>`) without forking upstream.
+Hard blocker. Other dimensions (build time, signing flow, ICE policy)
+are tractable but become moot.

--- a/tools/spike-harness/msi-tooling-pick/electron-builder/main.js
+++ b/tools/spike-harness/msi-tooling-pick/electron-builder/main.js
@@ -1,0 +1,10 @@
+// Trivial Electron entry. The MSI tooling pick spike does not need a
+// real UI — the comparison is about the installer toolchain, not the
+// app code. Window opens, immediately quits.
+const { app, BrowserWindow } = require("electron");
+
+app.whenReady().then(() => {
+  const w = new BrowserWindow({ width: 320, height: 200, show: false });
+  w.loadURL("about:blank");
+  app.quit();
+});

--- a/tools/spike-harness/msi-tooling-pick/electron-builder/package.json
+++ b/tools/spike-harness/msi-tooling-pick/electron-builder/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "ccsm-msi-tooling-pick-eb",
+  "version": "0.0.1",
+  "description": "Minimal electron-builder MSI target attempt for T9.14",
+  "main": "main.js",
+  "private": true,
+  "scripts": {
+    "build:msi": "electron-builder --win msi --x64 --publish never"
+  },
+  "build": {
+    "appId": "com.ccsm.toolingpick",
+    "productName": "CcsmToolingPickEb",
+    "asar": true,
+    "files": [
+      "main.js",
+      "package.json"
+    ],
+    "directories": {
+      "output": "release"
+    },
+    "win": {
+      "target": [
+        { "target": "msi", "arch": ["x64"] }
+      ]
+    },
+    "msi": {
+      "oneClick": false,
+      "perMachine": true,
+      "createDesktopShortcut": false,
+      "createStartMenuShortcut": false,
+      "warningsAsErrors": true,
+      "upgradeCode": "8d2f3a64-1e9b-4c13-bf8a-2b4a7c11d030",
+      "additionalLightArgs": ["-sval"]
+    }
+  },
+  "devDependencies": {
+    "electron": "^41.3.0",
+    "electron-builder": "^26.8.1"
+  }
+}

--- a/tools/spike-harness/msi-tooling-pick/wix4/.gitignore
+++ b/tools/spike-harness/msi-tooling-pick/wix4/.gitignore
@@ -1,0 +1,3 @@
+build/
+payload/bin/
+payload/obj/

--- a/tools/spike-harness/msi-tooling-pick/wix4/Product.wxs
+++ b/tools/spike-harness/msi-tooling-pick/wix4/Product.wxs
@@ -1,0 +1,37 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="CCSM MSI Tooling Pick (T9.14 WiX 4)"
+           Manufacturer="CCSM"
+           Version="0.0.1"
+           UpgradeCode="2c5e0b48-0e2b-4d61-9f3c-7a9e3d2e4c10"
+           Compressed="yes"
+           Scope="perMachine">
+    <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+    <StandardDirectory Id="ProgramFiles64Folder">
+      <Directory Id="INSTALLFOLDER" Name="CcsmToolingPick">
+        <Component Id="DaemonExe" Bitness="always64" Guid="*">
+          <File Id="DaemonExeFile"
+                Name="ccsm-daemon-shape.exe"
+                Source="build\payload\ccsm-daemon-shape.exe"
+                KeyPath="yes" />
+          <ServiceInstall Id="CcsmToolingPickInstall"
+                          Name="CcsmToolingPickSvc"
+                          DisplayName="CCSM Tooling Pick (T9.14)"
+                          Description="MSI tooling pick spike (WiX 4 path)."
+                          Type="ownProcess"
+                          Start="demand"
+                          ErrorControl="normal"
+                          Vital="yes" />
+          <ServiceControl Id="CcsmToolingPickControl"
+                          Name="CcsmToolingPickSvc"
+                          Start="install"
+                          Stop="both"
+                          Remove="uninstall"
+                          Wait="yes" />
+        </Component>
+      </Directory>
+    </StandardDirectory>
+    <Feature Id="Main" Level="1">
+      <ComponentRef Id="DaemonExe" />
+    </Feature>
+  </Package>
+</Wix>

--- a/tools/spike-harness/msi-tooling-pick/wix4/build.ps1
+++ b/tools/spike-harness/msi-tooling-pick/wix4/build.ps1
@@ -1,0 +1,31 @@
+$ErrorActionPreference = "Stop"
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $here
+
+$build = Join-Path $here "build"
+$payload = Join-Path $build "payload"
+if (Test-Path $build) { Remove-Item -Recurse -Force $build }
+New-Item -ItemType Directory -Force -Path $payload | Out-Null
+
+Write-Host "[wix4] publishing payload..."
+$tPayload = Measure-Command {
+  dotnet publish (Join-Path $here "payload/payload.csproj") `
+    -c Release `
+    -o $payload `
+    --nologo `
+    -v q | Out-Null
+}
+
+Write-Host "[wix4] compiling MSI..."
+$msi = Join-Path $build "CcsmToolingPick.msi"
+$tWix = Measure-Command {
+  & wix build (Join-Path $here "Product.wxs") -o $msi | Out-Null
+}
+
+$msiSize = (Get-Item $msi).Length
+$exeSize = (Get-Item (Join-Path $payload "ccsm-daemon-shape.exe")).Length
+Write-Host "[wix4] done"
+Write-Host "[wix4] payload exe bytes: $exeSize"
+Write-Host "[wix4] msi bytes: $msiSize"
+Write-Host "[wix4] dotnet publish seconds: $($tPayload.TotalSeconds)"
+Write-Host "[wix4] wix build seconds: $($tWix.TotalSeconds)"

--- a/tools/spike-harness/msi-tooling-pick/wix4/payload/Program.cs
+++ b/tools/spike-harness/msi-tooling-pick/wix4/payload/Program.cs
@@ -1,0 +1,23 @@
+using System.Threading;
+using Microsoft.Extensions.Hosting;
+
+// Tiny daemon-shaped target exe so the MSI has a real <File> to install
+// and a real ServiceInstall target. Hosting + BackgroundService keeps
+// the binary shape similar to a real Windows service host (so size/build
+// numbers are not misleading vs. a hello-world that the SCM cannot start).
+var builder = Host.CreateApplicationBuilder(args);
+builder.Services.AddHostedService<DaemonShape>();
+var app = builder.Build();
+app.Run();
+
+internal sealed class DaemonShape : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            try { await Task.Delay(Timeout.Infinite, ct); }
+            catch (TaskCanceledException) { }
+        }
+    }
+}

--- a/tools/spike-harness/msi-tooling-pick/wix4/payload/payload.csproj
+++ b/tools/spike-harness/msi-tooling-pick/wix4/payload/payload.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>ccsm-daemon-shape</AssemblyName>
+    <RootNamespace>CcsmDaemonShape</RootNamespace>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PublishTrimmed>false</PublishTrimmed>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Task

Task #114 — T9.14 spike `[msi-tooling-pick]`. Spec ch14 §1.16 phase 9.5.

Decide between WiX 4+ direct authoring and electron-builder's built-in
`msi` target for the v0.3 Windows installer, given the merged
ServiceInstall spike #113 (PR #890).

## Layout

`tools/spike-harness/msi-tooling-pick/`:
- `README.md` — comparison criteria + method.
- `wix4/` — minimal MSI built directly with WiX 4+ (`wix build`),
  same authoring pattern as #890 plus a daemon-shaped self-contained
  .NET payload for size accounting.
- `electron-builder/` — minimal `msi` target attempt + `ATTEMPT.md`
  documenting what blocked, what the upstream template can / cannot
  express, and the relevant `MsiTarget.ts` source-level findings.
- `decision.md` — final recommendation with measurements.

## Measurements (this host: Win 11 25H2 26200.8246)

|                       | WiX 4 (`wix4/`)      | electron-builder              |
| --------------------- | -------------------- | ----------------------------- |
| Cold build wall time  | **33.3 s**           | **160 s** (after `-sval` workaround for LGHT1105) |
| Warm rebuild wall time | **16.6 s**          | **149 s**                     |
| Output MSI size       | **32 KiB** + 27.8 MiB cab = ~28 MiB total | **108 MiB** (one-shot) |
| Out-of-the-box        | yes                  | **no** — `light.exe LGHT1105` ICE / system-policy block on first run |
| `<ServiceInstall>`    | **yes** (verified GREEN by #890 on the same host) | **no** — template has no service authoring, no extension hook |
| arm64                 | yes                  | no (electron-builder-binaries vendor stuck on WiX 3.x without arm64) |
| Toolchain             | WiX 4 / 5 (active)   | WiX 3.x via `electron-builder-binaries` `wix-4.0.0.5512.2` (binaries are `candle.exe` + `light.exe` — version label is misleading) |

Full breakdown in `decision.md`. Source-level finding: electron-builder's
upstream MSI template (`packages/app-builder-lib/templates/msi/template.xml`,
116 lines) emits a WiX 3 `<Product>` and has no `<ServiceInstall>`
placeholder — neither `additionalWixArgs` nor `additionalLightArgs`
can inject service authoring. Forking electron-builder for one feature
violates the v0.3 zero-rework rule.

## Layer 1

OK. PR #890 is definitive on WiX 4 viability but does not by itself
resolve the v0.4-throwaway question of whether to **use** WiX 4
directly vs go through electron-builder. This spike answers that.
The criterion-3 result (electron-builder cannot emit `<ServiceInstall>`)
would have been enough to decide on docs alone, but the actual
side-by-side build run produced unexpected supporting evidence
(LGHT1105 ICE block, 5x build time, 4x MSI size) that strengthens
the recommendation.

## Quality gates

- No bash scripts in deliverable (build is `.ps1`); shellcheck N/A.
- No `.markdownlint*` config in repo; markdownlint N/A.
- WiX 4 build run on this host: **green**, MSI emitted, sizes / times
  in `decision.md` are real measurements not estimates.
- Electron-builder build run on this host: failed once (LGHT1105),
  succeeded once with `additionalLightArgs: ["-sval"]` workaround.
  Both runs documented verbatim in `electron-builder/ATTEMPT.md`.

## Recommendation

**WiX 4**

Author the v0.3 Windows installer for the daemon directly with
`wix build` (dotnet global tool, schema `http://wixtoolset.org/schemas/v4/wxs`).
Reuse the authoring pattern from #890 / `wix4/Product.wxs`. Keep
the Electron app on its existing NSIS target — daemon and app
ship as separate installers, matching the v0.3 thin-Electron +
fat-daemon architecture.