### PR TITLE
feat(electron): T7.7 electron-builder config (mac pkg+dmg, linux deb+rpm)

### DIFF
--- a/packages/electron/build/README.md
+++ b/packages/electron/build/README.md
@@ -1,0 +1,17 @@
+# build/ — electron-builder buildResources
+
+This directory holds icons, entitlements, and other static assets consumed
+by `electron-builder` (configured in `../electron-builder.yml`).
+
+For v0.3 the directory exists as a placeholder: real assets land in T7.3
+(#82) and the corresponding signing/notarization tasks. Files expected
+later:
+
+- `icon.icns` — macOS app icon
+- `icon.png`  — Linux app icon (512x512 PNG)
+- `entitlements.mac.plist` — hardened-runtime entitlements (notarization)
+- `background.png` (optional) — DMG background art
+
+`electron-builder` resolves these by name from `directories.buildResources`
+(`build/` here). Do not commit large binary assets without first checking
+they are needed; placeholders are fine until T7.3.

--- a/packages/electron/electron-builder.yml
+++ b/packages/electron/electron-builder.yml
@@ -1,0 +1,93 @@
+# electron-builder config for the @ccsm/electron thin client (v0.3).
+#
+# Spec ref: docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+# chapter 10 §4 ("Electron build"), RESCOPED per Task #114 / PR #903 finding:
+#
+#   * Win MSI is NOT built by electron-builder. It is authored directly with
+#     WiX 4 (see PR #903 decision: electron-builder bundles a WiX 3.x
+#     toolchain via `electron-builder-binaries`, has no `<ServiceInstall>`
+#     hook, and `additionalWixArgs` cannot inject service authoring).
+#   * Therefore this config intentionally OMITS a `win:` target. Future
+#     Win packaging work happens in a dedicated WiX 4 task, separately.
+#
+# Targets shipped here:
+#   * macOS  -> pkg + dmg (per ch10 §5.2 — pkg is the LaunchDaemon installer,
+#              dmg is the drag-to-Applications surface)
+#   * Linux  -> deb + rpm (per ch10 §5.3 — fpm-equivalent via electron-builder)
+#
+# Renderer is purely UI + Connect-RPC client (ch10 §4 "Electron does NOT
+# bundle native modules at runtime in v0.3"). No node-pty, no
+# better-sqlite3, no electron-rebuild step.
+
+appId: com.ccsm.app
+productName: CCSM
+copyright: Copyright (c) 2026 Jiahui Gu
+
+# v0.3: no native modules in the renderer process. Disable npmRebuild so
+# electron-builder doesn't try to rebuild dependencies that aren't there.
+npmRebuild: false
+asar: true
+
+# Pin the Electron version explicitly so electron-builder doesn't try to
+# resolve `electron` from this package's node_modules (it isn't a direct
+# dep of @ccsm/electron yet — the binary lives in the workspace root for
+# now). Bump in lockstep with the root devDep.
+electronVersion: "41.5.0"
+
+directories:
+  buildResources: build
+  output: release
+
+files:
+  - dist/**/*
+  - package.json
+  - "!**/*.map"
+  - "!**/*.ts"
+  - "!**/__tests__/**"
+  - "!**/tests/**"
+  - "!test/**"
+
+# NOTE: no `win:` block. Windows MSI is authored directly with WiX 4 in
+# a separate pipeline (PR #903 decision). Do not re-add a `win:` target
+# here without revisiting that spike.
+
+mac:
+  category: public.app-category.developer-tools
+  hardenedRuntime: true
+  gatekeeperAssess: false
+  artifactName: ${productName}-${version}-${arch}.${ext}
+  target:
+    - target: pkg
+      arch:
+        - x64
+        - arm64
+    - target: dmg
+      arch:
+        - x64
+        - arm64
+
+pkg:
+  # Installer-level bits owned by the daemon pkg are out of scope here;
+  # this pkg installs only the Electron .app bundle. Daemon/LaunchDaemon
+  # registration ships in a separate pkg per ch10 §5.2.
+  allowAnywhere: false
+  allowCurrentUserHome: false
+  allowRootDirectory: true
+
+dmg:
+  writeUpdateInfo: false
+
+linux:
+  category: Development
+  maintainer: Jiahui Gu <noreply@ccsm.dev>
+  synopsis: CCSM (Claude Code Session Manager) — group-first manager for many Claude Code sessions
+  artifactName: ${productName}-${version}-${arch}.${ext}
+  target:
+    - target: deb
+      arch:
+        - x64
+        - arm64
+    - target: rpm
+      arch:
+        - x64
+        - arm64

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -4,9 +4,19 @@
   "private": true,
   "type": "module",
   "description": "CCSM Electron thin client. Skeleton only; implementation lands in subsequent T0.x / T1.x tasks per design spec ch11.",
+  "author": {
+    "name": "Jiahui Gu",
+    "email": "noreply@ccsm.dev"
+  },
+  "main": "dist/main/protocol-app.js",
   "scripts": {
     "lint": "eslint \"test/**/*.ts\"",
     "typecheck": "tsc -p tsconfig.test.json --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "build:mac": "electron-builder --mac --config electron-builder.yml",
+    "build:linux": "electron-builder --linux --config electron-builder.yml"
+  },
+  "devDependencies": {
+    "electron-builder": "^26.8.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,7 +254,11 @@ importers:
         specifier: ^8.20.0
         version: 8.20.0
 
-  packages/electron: {}
+  packages/electron:
+    devDependencies:
+      electron-builder:
+        specifier: ^26.8.1
+        version: 26.8.1(electron-builder-squirrel-windows@26.8.1)
 
   packages/proto:
     dependencies:


### PR DESCRIPTION
## Task

Task #85 — T7.7. Spec ch10 §4 of
`docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md`,
**rescoped per Task #114 / PR #903**.

## Layer 1

OK. The new `@ccsm/electron` workspace package needs its own
`electron-builder` config (the root v0.2 build at top-level `package.json`
is the legacy monolith and stays put). For v0.3 the renderer is purely
UI + Connect-RPC client, so packaging is dramatically simpler than the
v0.2 build (no native rebuild, no node-pty in renderer).

## Changes

- **`packages/electron/electron-builder.yml`** — new file. Targets:
  - macOS: `pkg` + `dmg`, x64 + arm64 (per ch10 §5.2)
  - Linux: `deb` + `rpm`, x64 + arm64 (per ch10 §5.3)
  - **No `win:` block** — see below.
  - `npmRebuild: false`, `asar: true`, `electronVersion: 41.5.0`
    (pinned to match the workspace-root devDep).
- **`packages/electron/package.json`** — adds `electron-builder@^26.8.1`
  as devDep, `author` field, `main` entry, plus scripts `build:mac` and
  `build:linux`. **No `build:win`** for now.
- **`packages/electron/build/README.md`** — placeholder for icons /
  entitlements; real assets land with T7.3 (#82) signing work.
- **`pnpm-lock.yaml`** — regenerated by `pnpm install`.

## Why no `win:` target

PR #903 (Task #114, spike `[msi-tooling-pick]`) decided in favour of
authoring the v0.3 Windows MSI **directly with WiX 4**, not via
electron-builder, because:

1. electron-builder bundles a WiX **3.x** toolchain via
   `electron-builder-binaries` (no arm64 support).
2. Its upstream MSI template has **no `<ServiceInstall>` placeholder**
   and neither `additionalWixArgs` nor `additionalLightArgs` can inject
   service authoring — fork-required.
3. Side-by-side build measurements: WiX 4 = 33.3 s cold / ~28 MiB,
   electron-builder = 160 s cold / 108 MiB.

The Win MSI lives in a separate WiX 4 pipeline (future task). The
electron-builder.yml file calls this out in a header comment so future
contributors don't re-add the `win:` block by reflex.

## Quality gates (local)

```
pnpm install                                          -> clean
pnpm --filter @ccsm/electron lint                     -> clean (eslint OK)
pnpm --filter @ccsm/electron typecheck                -> clean (tsc OK)
npx electron-builder --linux --dir --config \
    packages/electron/electron-builder.yml            -> config parses,
    electron 41.5.0 downloaded, packaging proceeds to expected stop:

      Application entry file "dist\main\protocol-app.js" in the
      "...\release\linux-unpacked\resources\app.asar" is corrupted:
      Error: "dist\main\protocol-app.js" was not found in this archive
```

The "missing main entry" stop is expected — `dist/main/protocol-app.js`
is produced by the renderer/main build that lands in the actual
implementation tasks (T6.x / T7.3 #82). The task brief explicitly
allows stopping here as long as the config validates.

## Out of scope (intentional)

- Real macOS notarization / signing (T7.3 #82).
- Real CI build of mac/linux artifacts (T7.3 #82).
- Win MSI authoring (separate WiX 4 task, per PR #903 decision).
- Icons / `entitlements.mac.plist` (placeholders only; T7.3).
- Renderer/main TypeScript build pipeline (separate T6.x tasks).

## Hotfile note

Touched `packages/electron/package.json` (allowed: new dep) and root
`pnpm-lock.yaml` (regen). No other in-flight PR holds these per the
manager's prompt.