### PR TITLE
daemon(T5.10): crash-raw.ndjson appender + boot replay

### DIFF
--- a/packages/daemon/src/crash/raw-appender.ts
+++ b/packages/daemon/src/crash/raw-appender.ts
@@ -1,0 +1,367 @@
+// packages/daemon/src/crash/raw-appender.ts
+//
+// Crash-raw NDJSON appender + boot-replay.
+//
+// Spec refs:
+//   - docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+//     ch07 §2 (state directory layout — `crash-raw.ndjson` location, frozen
+//     per OS) and ch09 §2 (storage schema — locked NDJSON line shape with
+//     `owner_id` required; boot-replay → dedup by id → import into
+//     `crash_log` → truncate file).
+//   - ch09 §1 owner_id attribution: `'daemon-self'` sentinel for daemon-side
+//     crashes; principalKey for session-attributable crashes.
+//   - ch09 §6.2 silent-loss safety modes covered by
+//     `test/crash/crash-raw-recovery.spec.ts`:
+//       (a) partial line at EOF, (b) file missing, (c) file present but
+//       empty, (d) malformed entries, (e) truncation race.
+//
+// SRP / API surface (deliberately minimal — Layer 1 foundation for #62
+// capture handlers and #64 retention pruner):
+//
+//   * `appendCrashRaw(path, entry)` — sink. Append one NDJSON line + fsync.
+//     Open-flush-close per call. Designed for the FATAL path where the
+//     daemon may exit microseconds later — every byte must hit the disk.
+//   * `replayCrashRawOnBoot({ path, db })` — boot orchestrator: read all
+//     parseable lines, INSERT-OR-IGNORE into `crash_log` (dedup by id),
+//     fsync the DB page cache, THEN truncate the file. Order matters:
+//     truncate AFTER successful import so a crash mid-replay loses nothing.
+//
+// Out of scope (owned by other tasks — DO NOT touch from here):
+//   - Capture handlers (uncaughtException, sqlite_op, claude_exit, ...)  → T5.11 / Task #62
+//   - Retention pruner (10000 rows / 90 days)                             → T5.12 / Task #64
+//   - Coalescer / write batching                                          → T5.6 / Task #58
+//   - Schema (`crash_log` columns)                                        → frozen by #876
+//   - State path constants (`crashRaw`)                                   → owned by state-dir/paths.ts (T5.3)
+
+import {
+  closeSync,
+  fsyncSync,
+  openSync,
+  readFileSync,
+  truncateSync,
+  writeSync,
+} from 'node:fs';
+
+import type { SqliteDatabase } from '../db/sqlite.js';
+
+// ---------------------------------------------------------------------------
+// Line shape — locked by spec ch09 §2. Adding fields is forbidden in v0.3
+// (forever-stable per the §7 v0.4 delta: "Unchanged: ... NDJSON line shape").
+// ---------------------------------------------------------------------------
+
+/**
+ * One crash event as it appears (a) on the NDJSON wire format and (b) as a
+ * row in the `crash_log` table. Field order in the spec example:
+ *
+ *   {"id":"01H...","ts_ms":...,"source":"sqlite_open","summary":"...",
+ *    "detail":"...","labels":{...},"owner_id":"daemon-self"}
+ *
+ * `owner_id` is REQUIRED (not optional) — `'daemon-self'` for daemon-side
+ * crashes, principalKey (e.g. `'unix-user:1000'`) for session-attributable
+ * ones. The sentinel is NOT a valid principalKey (no colon) — see ch09 §1.
+ */
+export interface CrashRawEntry {
+  /** ULID, lexicographically time-ordered. PRIMARY KEY in `crash_log`. */
+  readonly id: string;
+  /** Event time in unix ms. */
+  readonly ts_ms: number;
+  /** Open string set per ch09 §1 — `sqlite_open`, `claude_exit`, ... */
+  readonly source: string;
+  /** Short human description; goes into `crash_log.summary`. */
+  readonly summary: string;
+  /** Long detail (stack trace, last stderr bytes, ...); `crash_log.detail`. */
+  readonly detail: string;
+  /** Free-form key/value labels; serialised into `crash_log.labels_json`. */
+  readonly labels: Readonly<Record<string, string>>;
+  /** principalKey or `'daemon-self'` sentinel. NOT NULL in `crash_log`. */
+  readonly owner_id: string;
+}
+
+// ---------------------------------------------------------------------------
+// Appender — synchronous, open-flush-close per call. Used by the FATAL path
+// where the daemon may exit immediately after.
+// ---------------------------------------------------------------------------
+
+/**
+ * Append one NDJSON entry to `path` and fsync. Synchronous on purpose:
+ *
+ *   - The append is invoked from `process.on('uncaughtException', ...)` and
+ *     similar fatal hooks (T5.11) where Node's event loop may already be
+ *     in tear-down. Async APIs that defer to the next tick can lose data.
+ *   - `O_APPEND` (`'a'` mode) gives atomic append on POSIX for writes
+ *     ≤ PIPE_BUF (4 KiB). Our serialised line + `\n` is well under that
+ *     for every realistic crash payload (we don't bound it here, but if a
+ *     line ever exceeds it the filesystem still serialises by design).
+ *   - On Windows, the runtime's `'a'` flag maps to `FILE_APPEND_DATA`
+ *     access right; the OS serialises appends.
+ *
+ * The function `fsyncSync` after the write so the entry survives a power
+ * loss / hard kill that follows the appender call. Fsync errors are
+ * propagated — the FATAL caller will then write a structured-log line and
+ * exit; better to surface "we tried and failed" than silently lose the
+ * event.
+ *
+ * Concurrent append safety: callers running in different threads / workers
+ * must each call `appendCrashRaw` themselves. The kernel's `O_APPEND`
+ * semantics keep individual line-writes intact; we never read-modify-write.
+ */
+export function appendCrashRaw(path: string, entry: CrashRawEntry): void {
+  const line = `${serialiseEntry(entry)}\n`;
+  // 0o600: file is created on first append; matches the state-dir 0o700 dir
+  // mode (only the daemon's service account reads it). No-op on win32 (the
+  // installer manages DACLs per ch10 §5).
+  const fd = openSync(path, 'a', 0o600);
+  try {
+    writeSync(fd, line);
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/**
+ * Serialise an entry to a single JSON object string with no embedded
+ * newlines. We do NOT pretty-print and we do NOT allow `entry.labels` to be
+ * `undefined` (the schema requires `labels_json NOT NULL DEFAULT '{}'` —
+ * the wire shape mirrors that with `{}`).
+ *
+ * `JSON.stringify` already escapes embedded newlines inside string values,
+ * so the resulting line is guaranteed not to contain `\n` except the one
+ * we append in `appendCrashRaw`. This is what makes the file recoverable
+ * line-by-line on boot.
+ */
+function serialiseEntry(entry: CrashRawEntry): string {
+  // Object literal order matches the spec example for human readability;
+  // JSON readers don't care about field order, but a future grep / `jq`
+  // session by an operator does.
+  return JSON.stringify({
+    id: entry.id,
+    ts_ms: entry.ts_ms,
+    source: entry.source,
+    summary: entry.summary,
+    detail: entry.detail,
+    labels: entry.labels,
+    owner_id: entry.owner_id,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Boot-replay — silent-loss safe.
+// ---------------------------------------------------------------------------
+
+export interface ReplayResult {
+  /** How many parseable lines we read from the file. */
+  readonly linesRead: number;
+  /** How many were inserted (i.e. not already present in `crash_log`). */
+  readonly inserted: number;
+  /** How many were dropped because they failed JSON / shape validation. */
+  readonly malformed: number;
+  /** True when the file was missing (boot before any fatal append). */
+  readonly fileMissing: boolean;
+}
+
+export interface ReplayOpts {
+  /** Path to `state/crash-raw.ndjson` — typically `statePaths().crashRaw`. */
+  readonly path: string;
+  /** Open `crash_log` SQLite handle (PRAGMAs already applied). */
+  readonly db: SqliteDatabase;
+}
+
+/**
+ * Replay the NDJSON file into `crash_log`, then truncate the file.
+ *
+ * Order is load-bearing for silent-loss safety (ch09 §6.2 case (e) —
+ * "truncation race"):
+ *
+ *   1. Read the whole file into memory (it's bounded by daemon-fatal
+ *      events between two boots — typically empty or a handful of lines;
+ *      a pathological loop is bounded by retention §3, separate task #64).
+ *   2. Skip the trailing partial line if any (no `\n` terminator) — case
+ *      (a). Such a line is by definition mid-write at the previous fatal;
+ *      we cannot trust it. The spec's "fsync where appropriate" guidance
+ *      means complete lines are durable; partial lines are the cost of
+ *      ungraceful exit, accepted.
+ *   3. Parse each remaining line. Malformed lines (case (d)) are counted
+ *      and skipped — never throw mid-replay; one corrupt line must not
+ *      block the dozen good ones behind it.
+ *   4. INSERT OR IGNORE within a single IMMEDIATE transaction. The unique
+ *      `id` PRIMARY KEY gives us O(1) dedup against rows already imported
+ *      by a previous incomplete replay (case (e) — daemon killed between
+ *      INSERT and TRUNCATE).
+ *   5. fsync the DB checkpoint via `pragma('wal_checkpoint(FULL)')` BEFORE
+ *      truncating. Otherwise the import could live in WAL only and a
+ *      power loss after truncate but before next checkpoint would lose
+ *      every imported row.
+ *   6. Truncate the file to 0 bytes. We do NOT delete it — keeping the
+ *      inode stable means open file handles in the appender (if any
+ *      racy pre-existing fd exists from another process) keep working,
+ *      and avoids a TOCTOU window between unlink and recreate. Truncate
+ *      is one syscall.
+ *
+ * Cases (b) "file missing" and (c) "empty file" both return early with
+ * `inserted=0, malformed=0`.
+ */
+export function replayCrashRawOnBoot(opts: ReplayOpts): ReplayResult {
+  const { path, db } = opts;
+
+  let raw: Buffer;
+  try {
+    raw = readFileSync(path);
+  } catch (err) {
+    if (isENOENT(err)) {
+      // Case (b): file missing. First-ever boot, or a previous boot replay
+      // ran on a system where the truncate raced with an unlink (we don't
+      // unlink, but a future op might).
+      return { linesRead: 0, inserted: 0, malformed: 0, fileMissing: true };
+    }
+    throw err;
+  }
+
+  if (raw.length === 0) {
+    // Case (c): file present but empty. Steady-state between fatals.
+    return { linesRead: 0, inserted: 0, malformed: 0, fileMissing: false };
+  }
+
+  // Case (a): drop trailing partial line if no terminator. We split on
+  // '\n' and discard the last segment ONLY if the file does not end with
+  // '\n'. A clean-exit producer always writes the trailing '\n'.
+  const text = raw.toString('utf8');
+  const segments = text.split('\n');
+  const endsWithNewline = text.endsWith('\n');
+  // After split, a trailing '\n' produces a final '' segment we always
+  // discard. A missing trailing '\n' produces a final partial we also
+  // discard. Either way we drop the last segment when it would be a
+  // partial — pop the empty AND pop the partial.
+  if (endsWithNewline) {
+    segments.pop(); // drop the '' produced by trailing '\n'
+  } else {
+    segments.pop(); // drop the partial line
+  }
+
+  const entries: CrashRawEntry[] = [];
+  let malformed = 0;
+  for (const seg of segments) {
+    if (seg.length === 0) {
+      // Blank line (e.g. two consecutive '\n'). Not malformed per se but
+      // not an entry either — skip silently.
+      continue;
+    }
+    const parsed = tryParseEntry(seg);
+    if (parsed === null) {
+      malformed++;
+      continue;
+    }
+    entries.push(parsed);
+  }
+
+  // Step 4: INSERT OR IGNORE inside one IMMEDIATE transaction. We skip the
+  // INSERT pass entirely when there are no entries — saves a transaction
+  // round-trip on the steady-state "file present but empty" path that
+  // already early-returned above; also saves it when every line was
+  // malformed.
+  let inserted = 0;
+  if (entries.length > 0) {
+    const insertStmt = db.prepare(
+      // labels_json maps from CrashRawEntry.labels via JSON.stringify.
+      // INSERT OR IGNORE => dedup on PRIMARY KEY (id).
+      `INSERT OR IGNORE INTO crash_log
+         (id, ts_ms, source, summary, detail, labels_json, owner_id)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    );
+    const txn = db.transaction((rows: readonly CrashRawEntry[]) => {
+      let count = 0;
+      for (const e of rows) {
+        const info = insertStmt.run(
+          e.id,
+          e.ts_ms,
+          e.source,
+          e.summary,
+          e.detail,
+          JSON.stringify(e.labels),
+          e.owner_id,
+        );
+        if (info.changes === 1) count++;
+      }
+      return count;
+    });
+    // BEGIN IMMEDIATE so a concurrent reader (none expected at boot, but
+    // be defensive) can't sneak between our SELECT-implicit dedup check
+    // and the INSERT.
+    inserted = (txn as unknown as (rows: readonly CrashRawEntry[]) => number)(entries);
+  }
+
+  // Step 5: force durability of the inserts to the main DB file BEFORE we
+  // truncate the NDJSON. WAL checkpoint(FULL) blocks until the WAL frames
+  // are merged into the main file and the main file is fsynced (with
+  // synchronous=NORMAL — see db/sqlite.ts BOOT_PRAGMAS). Without this, a
+  // crash between truncate and the next implicit checkpoint loses rows.
+  db.pragma('wal_checkpoint(FULL)');
+
+  // Step 6: truncate to 0 bytes. Synchronous; we want the metadata flush
+  // before returning. Errors propagate — caller logs via the supervisor
+  // structured-log path.
+  truncateSync(path, 0);
+
+  return {
+    linesRead: entries.length + malformed,
+    inserted,
+    malformed,
+    fileMissing: false,
+  };
+}
+
+/**
+ * Parse + minimally validate one NDJSON line. Returns `null` (NOT throws)
+ * for any failure — the replay loop counts and skips. Validation is shape
+ * only: required fields present and of correct primitive type. We do NOT
+ * validate `id` is a ULID, `ts_ms` is plausible, or `source` is in the
+ * §1 known set — all three are open by spec (ULID is a hint, source is an
+ * open string set, ts_ms can legally be 0 in tests). The DB schema's
+ * `NOT NULL` constraints catch anything truly broken at insert time.
+ */
+function tryParseEntry(line: string): CrashRawEntry | null {
+  let obj: unknown;
+  try {
+    obj = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (typeof obj !== 'object' || obj === null) return null;
+  const o = obj as Record<string, unknown>;
+  if (typeof o.id !== 'string' || o.id.length === 0) return null;
+  if (typeof o.ts_ms !== 'number' || !Number.isFinite(o.ts_ms)) return null;
+  if (typeof o.source !== 'string' || o.source.length === 0) return null;
+  if (typeof o.summary !== 'string') return null;
+  if (typeof o.detail !== 'string') return null;
+  if (typeof o.owner_id !== 'string' || o.owner_id.length === 0) return null;
+  // labels: object of string→string. Missing → coerce to {} (file
+  // generated by an older daemon should still replay; v0.3 is the
+  // baseline, but be defensive).
+  let labels: Record<string, string> = {};
+  if (o.labels !== undefined) {
+    if (typeof o.labels !== 'object' || o.labels === null) return null;
+    const lo = o.labels as Record<string, unknown>;
+    for (const k of Object.keys(lo)) {
+      const v = lo[k];
+      if (typeof v !== 'string') return null;
+      labels[k] = v;
+    }
+  }
+  return {
+    id: o.id,
+    ts_ms: o.ts_ms,
+    source: o.source,
+    summary: o.summary,
+    detail: o.detail,
+    labels,
+    owner_id: o.owner_id,
+  };
+}
+
+function isENOENT(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    (err as { code?: unknown }).code === 'ENOENT'
+  );
+}

--- a/packages/daemon/test/crash/crash-raw-recovery.spec.ts
+++ b/packages/daemon/test/crash/crash-raw-recovery.spec.ts
@@ -1,0 +1,359 @@
+// packages/daemon/test/crash/crash-raw-recovery.spec.ts
+//
+// Boot-replay recovery for crash-raw.ndjson — covers the silent-loss
+// failure modes called out by spec ch09 §6.2:
+//   (a) partial line at end of file (producer killed mid-write)
+//   (b) file missing (first-ever boot)
+//   (c) file present but empty (steady-state)
+//   (d) malformed entries (non-JSON, missing fields)
+//   (e) truncation race (daemon killed during truncate, i.e. between
+//       INSERT and TRUNCATE — replay must be idempotent)
+//
+// Plus the headline acceptance test from the task description:
+//   "append 100 entries → kill before flush → boot → all 100 appear in
+//    crash table once."
+// We exercise this by spawning a child that synchronously appends 100
+// entries and SIGKILLs itself before the process exit hooks run, then
+// calling replayCrashRawOnBoot in the parent and asserting 100 distinct
+// rows in `crash_log`.
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { openDatabase, type SqliteDatabase } from '../../src/db/sqlite.js';
+import {
+  appendCrashRaw,
+  replayCrashRawOnBoot,
+  type CrashRawEntry,
+} from '../../src/crash/raw-appender.js';
+
+// ---------------------------------------------------------------------------
+// Test fixtures: a fresh tmp dir per test holding the NDJSON file + a
+// :memory: SQLite DB seeded with the `crash_log` table from the v0.3
+// baseline schema (columns mirrored from migrations/001_initial.sql §87).
+// We don't run the migration runner here — that's a separate task's
+// concern; we just need the table shape to match production.
+// ---------------------------------------------------------------------------
+
+const CRASH_LOG_DDL = `
+  CREATE TABLE crash_log (
+    id          TEXT PRIMARY KEY,
+    ts_ms       INTEGER NOT NULL,
+    source      TEXT NOT NULL,
+    summary     TEXT NOT NULL,
+    detail      TEXT NOT NULL,
+    labels_json TEXT NOT NULL DEFAULT '{}',
+    owner_id    TEXT NOT NULL DEFAULT 'daemon-self'
+  );
+`;
+
+interface Fixture {
+  dir: string;
+  ndjsonPath: string;
+  dbPath: string;
+  db: SqliteDatabase;
+}
+
+function setup(): Fixture {
+  const dir = mkdtempSync(path.join(tmpdir(), 'ccsm-crashraw-'));
+  const ndjsonPath = path.join(dir, 'crash-raw.ndjson');
+  const dbPath = path.join(dir, 'sessions.db');
+  const db = openDatabase(dbPath);
+  db.exec(CRASH_LOG_DDL);
+  return { dir, ndjsonPath, dbPath, db };
+}
+
+function teardown(fx: Fixture): void {
+  try {
+    fx.db.close();
+  } catch {
+    // ignore — tests may have closed already
+  }
+  rmSync(fx.dir, { recursive: true, force: true });
+}
+
+let fx: Fixture;
+beforeEach(() => {
+  fx = setup();
+});
+afterEach(() => {
+  teardown(fx);
+});
+
+function makeEntry(i: number, overrides: Partial<CrashRawEntry> = {}): CrashRawEntry {
+  return {
+    id: `01H000000000000000000000${String(i).padStart(2, '0')}`,
+    ts_ms: 1_714_600_000_000 + i,
+    source: 'sqlite_open',
+    summary: `crash #${i}`,
+    detail: `stack trace lines for #${i}\nframe1\nframe2`,
+    labels: { iter: String(i) },
+    owner_id: 'daemon-self',
+    ...overrides,
+  };
+}
+
+function rowCount(db: SqliteDatabase): number {
+  const row = db.prepare('SELECT COUNT(*) AS n FROM crash_log').get() as { n: number };
+  return row.n;
+}
+
+// ---------------------------------------------------------------------------
+// Headline acceptance: 100 entries → child SIGKILL → replay → 100 rows.
+// ---------------------------------------------------------------------------
+
+describe('crash-raw appender + replay', () => {
+  it('100 entries appended in a child SIGKILLed before normal exit replay into crash_log exactly once', () => {
+    // The child writes 100 entries via the same `appendCrashRaw` we ship.
+    // After write 100 it raises SIGKILL on itself — no `process.exit`,
+    // no atexit, no fs.close beyond what each appendCrashRaw call already
+    // did. This exercises the "kill before flush" property: every entry
+    // fsynced inside the appender must survive.
+    //
+    // We invoke the child by piping a small JS program into `node --input-type=module`.
+    // No build step needed; the program inlines `fs` calls equivalent to
+    // appendCrashRaw so we don't depend on the daemon's TS being compiled
+    // for the test host. We also assert the byte-for-byte line shape
+    // matches `appendCrashRaw` by additionally writing one entry from the
+    // parent and diffing.
+
+    const child = `
+      import { closeSync, fsyncSync, openSync, writeSync } from 'node:fs';
+      const ndjsonPath = ${JSON.stringify(fx.ndjsonPath)};
+      function append(entry) {
+        const line = JSON.stringify(entry) + '\\n';
+        const fd = openSync(ndjsonPath, 'a', 0o600);
+        try { writeSync(fd, line); fsyncSync(fd); } finally { closeSync(fd); }
+      }
+      for (let i = 0; i < 100; i++) {
+        append({
+          id: '01H000000000000000000000' + String(i).padStart(2, '0'),
+          ts_ms: 1714600000000 + i,
+          source: 'sqlite_open',
+          summary: 'crash #' + i,
+          detail: 'stack trace lines for #' + i + '\\nframe1\\nframe2',
+          labels: { iter: String(i) },
+          owner_id: 'daemon-self',
+        });
+      }
+      process.kill(process.pid, 'SIGKILL');
+    `;
+
+    const result = spawnSync(
+      process.execPath,
+      ['--input-type=module', '-e', child],
+      { stdio: 'pipe' },
+    );
+    // SIGKILL: signal field is 'SIGKILL' on POSIX; on Windows, signals are
+    // emulated and the child exits with a nonzero status. Either way the
+    // file should already hold 100 fsynced lines.
+    expect(result.status === null || result.status !== 0).toBe(true);
+
+    // Verify file holds 100 newline-terminated lines.
+    const fileBytes = readFileSync(fx.ndjsonPath, 'utf8');
+    const lines = fileBytes.split('\n').filter((l) => l.length > 0);
+    expect(lines).toHaveLength(100);
+
+    // Boot replay.
+    const r = replayCrashRawOnBoot({ path: fx.ndjsonPath, db: fx.db });
+    expect(r.linesRead).toBe(100);
+    expect(r.inserted).toBe(100);
+    expect(r.malformed).toBe(0);
+    expect(r.fileMissing).toBe(false);
+    expect(rowCount(fx.db)).toBe(100);
+
+    // File truncated to 0 bytes after successful import.
+    expect(statSync(fx.ndjsonPath).size).toBe(0);
+
+    // Idempotence: re-running replay on the now-empty file changes nothing.
+    const r2 = replayCrashRawOnBoot({ path: fx.ndjsonPath, db: fx.db });
+    expect(r2.inserted).toBe(0);
+    expect(rowCount(fx.db)).toBe(100);
+  });
+
+  // -------------------------------------------------------------------------
+  // ch09 §6.2 case (a): partial line at EOF.
+  // -------------------------------------------------------------------------
+  it('drops a trailing partial line and imports the complete prefix', () => {
+    appendCrashRaw(fx.ndjsonPath, makeEntry(1));
+    appendCrashRaw(fx.ndjsonPath, makeEntry(2));
+    // Simulate a producer killed mid-write: append a partial JSON object
+    // with no trailing newline. This must NOT crash the replay and must
+    // NOT be inserted.
+    writeFileSync(fx.ndjsonPath, '{"id":"partial","ts_ms":1', { flag: 'a' });
+
+    const r = replayCrashRawOnBoot({ path: fx.ndjsonPath, db: fx.db });
+    expect(r.linesRead).toBe(2);
+    expect(r.inserted).toBe(2);
+    expect(r.malformed).toBe(0);
+    expect(rowCount(fx.db)).toBe(2);
+  });
+
+  // -------------------------------------------------------------------------
+  // ch09 §6.2 case (b): file missing.
+  // -------------------------------------------------------------------------
+  it('returns fileMissing=true and inserts nothing when the file does not exist', () => {
+    const r = replayCrashRawOnBoot({ path: fx.ndjsonPath, db: fx.db });
+    expect(r.fileMissing).toBe(true);
+    expect(r.inserted).toBe(0);
+    expect(rowCount(fx.db)).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // ch09 §6.2 case (c): file present but empty.
+  // -------------------------------------------------------------------------
+  it('returns 0/0 and does not error on an empty file', () => {
+    writeFileSync(fx.ndjsonPath, '');
+    const r = replayCrashRawOnBoot({ path: fx.ndjsonPath, db: fx.db });
+    expect(r.fileMissing).toBe(false);
+    expect(r.linesRead).toBe(0);
+    expect(r.inserted).toBe(0);
+    expect(r.malformed).toBe(0);
+    expect(rowCount(fx.db)).toBe(0);
+    // Truncate is a no-op on already-empty file; must remain empty.
+    expect(statSync(fx.ndjsonPath).size).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // ch09 §6.2 case (d): malformed entries (non-JSON, missing fields).
+  // -------------------------------------------------------------------------
+  it('skips malformed lines (non-JSON, missing fields) without blocking valid ones', () => {
+    appendCrashRaw(fx.ndjsonPath, makeEntry(1));
+    // Non-JSON garbage line.
+    writeFileSync(fx.ndjsonPath, 'not even json\n', { flag: 'a' });
+    // JSON but missing required fields.
+    writeFileSync(fx.ndjsonPath, '{"id":"x"}\n', { flag: 'a' });
+    // JSON with wrong type for a required field.
+    writeFileSync(
+      fx.ndjsonPath,
+      '{"id":"y","ts_ms":"not a number","source":"s","summary":"","detail":"","owner_id":"daemon-self"}\n',
+      { flag: 'a' },
+    );
+    appendCrashRaw(fx.ndjsonPath, makeEntry(2));
+
+    const r = replayCrashRawOnBoot({ path: fx.ndjsonPath, db: fx.db });
+    expect(r.malformed).toBe(3);
+    expect(r.inserted).toBe(2);
+    expect(rowCount(fx.db)).toBe(2);
+  });
+
+  // -------------------------------------------------------------------------
+  // ch09 §6.2 case (e): truncation race. Daemon killed AFTER inserting
+  // some rows but BEFORE truncating. Re-replay must dedup and not double-
+  // import; should still inserted=0 the second time around because the
+  // first call's INSERT OR IGNORE already landed those rows.
+  // -------------------------------------------------------------------------
+  it('idempotent across crash-after-insert-before-truncate (PRIMARY KEY dedup)', () => {
+    for (let i = 1; i <= 5; i++) appendCrashRaw(fx.ndjsonPath, makeEntry(i));
+
+    // Simulate the first replay's INSERT pass landing but the truncate
+    // never happening: insert all rows directly into crash_log, then run
+    // replayCrashRawOnBoot (file is still full). The replay should
+    // INSERT-OR-IGNORE → 0 new inserts → then truncate the file.
+    const insertStmt = fx.db.prepare(
+      `INSERT INTO crash_log (id, ts_ms, source, summary, detail, labels_json, owner_id)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    );
+    for (let i = 1; i <= 5; i++) {
+      const e = makeEntry(i);
+      insertStmt.run(
+        e.id,
+        e.ts_ms,
+        e.source,
+        e.summary,
+        e.detail,
+        JSON.stringify(e.labels),
+        e.owner_id,
+      );
+    }
+    expect(rowCount(fx.db)).toBe(5);
+    // Sanity: file still has 5 lines waiting to be replayed.
+    expect(readFileSync(fx.ndjsonPath, 'utf8').split('\n').filter(Boolean)).toHaveLength(5);
+
+    const r = replayCrashRawOnBoot({ path: fx.ndjsonPath, db: fx.db });
+    expect(r.linesRead).toBe(5);
+    expect(r.inserted).toBe(0); // all dedup'd by PRIMARY KEY
+    expect(r.malformed).toBe(0);
+    expect(rowCount(fx.db)).toBe(5); // still exactly 5
+    // File truncated this time around.
+    expect(statSync(fx.ndjsonPath).size).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // owner_id required + carried through unchanged (ch09 §1 attribution).
+  // -------------------------------------------------------------------------
+  it('carries owner_id verbatim — daemon-self sentinel and principalKey both round-trip', () => {
+    appendCrashRaw(
+      fx.ndjsonPath,
+      makeEntry(1, { owner_id: 'daemon-self', source: 'sqlite_open' }),
+    );
+    appendCrashRaw(
+      fx.ndjsonPath,
+      makeEntry(2, { owner_id: 'unix-user:1000', source: 'claude_exit' }),
+    );
+    appendCrashRaw(
+      fx.ndjsonPath,
+      makeEntry(3, {
+        owner_id: 'win-sid:S-1-5-21-1234567890-1234567890-1234567890-1001',
+        source: 'pty_eof',
+      }),
+    );
+
+    const r = replayCrashRawOnBoot({ path: fx.ndjsonPath, db: fx.db });
+    expect(r.inserted).toBe(3);
+
+    const rows = fx.db
+      .prepare('SELECT id, source, owner_id FROM crash_log ORDER BY id')
+      .all() as Array<{ id: string; source: string; owner_id: string }>;
+    expect(rows).toHaveLength(3);
+    expect(rows[0]?.owner_id).toBe('daemon-self');
+    expect(rows[1]?.owner_id).toBe('unix-user:1000');
+    expect(rows[2]?.owner_id).toBe(
+      'win-sid:S-1-5-21-1234567890-1234567890-1234567890-1001',
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Line shape locked: the wire JSON for an appended entry parses to the
+  // exact field set in spec ch09 §2 example, no extras.
+  // -------------------------------------------------------------------------
+  it('emits exactly the spec ch09 §2 line shape (no extra fields, all required present)', () => {
+    appendCrashRaw(fx.ndjsonPath, makeEntry(7));
+    const text = readFileSync(fx.ndjsonPath, 'utf8').trim();
+    const obj = JSON.parse(text) as Record<string, unknown>;
+    expect(Object.keys(obj).sort()).toEqual(
+      ['detail', 'id', 'labels', 'owner_id', 'source', 'summary', 'ts_ms'].sort(),
+    );
+    expect(obj.owner_id).toBe('daemon-self');
+  });
+
+  // -------------------------------------------------------------------------
+  // Sanity: appendCrashRaw + node child line shape are byte-identical.
+  // Locks the wire so a future refactor of `serialiseEntry` cannot drift
+  // away from JSON.stringify of the literal field-ordered object.
+  // -------------------------------------------------------------------------
+  it('parent-process append line is byte-identical to a child node script', () => {
+    const entry = makeEntry(42);
+    appendCrashRaw(fx.ndjsonPath, entry);
+    const parentLine = readFileSync(fx.ndjsonPath, 'utf8');
+
+    const childPath = path.join(fx.dir, 'child-out.ndjson');
+    const childScript = `
+      import { closeSync, fsyncSync, openSync, writeSync } from 'node:fs';
+      const e = ${JSON.stringify(entry)};
+      const line = JSON.stringify({
+        id: e.id, ts_ms: e.ts_ms, source: e.source, summary: e.summary,
+        detail: e.detail, labels: e.labels, owner_id: e.owner_id,
+      }) + '\\n';
+      const fd = openSync(${JSON.stringify(childPath)}, 'a', 0o600);
+      try { writeSync(fd, line); fsyncSync(fd); } finally { closeSync(fd); }
+    `;
+    execFileSync(process.execPath, ['--input-type=module', '-e', childScript]);
+    const childLine = readFileSync(childPath, 'utf8');
+    expect(parentLine).toBe(childLine);
+  });
+});


### PR DESCRIPTION
Closes Task #59. Layer 1 foundation for #62 (capture handlers) and #64 (retention pruner).

## Spec refs

- ch07 §2 — `crash-raw.ndjson` path is owned by `state-dir/paths.ts` (already merged in #862; this PR only consumes `statePaths().crashRaw`).
- ch09 §2 — line shape locked: `{id, ts_ms, source, summary, detail, labels, owner_id}`. `owner_id` is REQUIRED per #882 Principal model; daemon-side crashes use the `'daemon-self'` sentinel, session-attributable ones carry the session principalKey.
- ch09 §6.2 — silent-loss recovery cases (a)–(e) covered by `test/crash/crash-raw-recovery.spec.ts`.

## API surface (deliberately minimal — Layer 1 contract)

- `appendCrashRaw(path, entry)` — synchronous: open + writeSync + fsyncSync + closeSync per call. Designed for FATAL hooks (`uncaughtException`, `sqlite_open`, `migration`, `watchdog_miss`) where the daemon may exit microseconds later. `O_APPEND` keeps concurrent appends from interleaving on POSIX; Windows runtime maps `'a'` to `FILE_APPEND_DATA`.
- `replayCrashRawOnBoot({path, db})` — read all parseable lines, INSERT OR IGNORE into `crash_log` (PRIMARY KEY dedup), `wal_checkpoint(FULL)` for durability, THEN truncate the file to 0 bytes.
  - Truncate AFTER successful import + checkpoint is load-bearing for ch09 §6.2 case (e) — daemon killed between INSERT and TRUNCATE must be idempotent on next boot.

## Out of scope (boundaries respected)

- `src/sqlite/wrapper`     — owned by T5.6 #58
- `src/supervisor`         — owned by #23
- `crash_log` schema       — frozen by #876
- `src/crash/sources.ts`   — owned by T5.11 #62

## Tests (`test/crash/crash-raw-recovery.spec.ts`, 9 cases, all passing)

- **Headline acceptance** (from task description): 100 entries appended in a child SIGKILL'd before any clean-exit hooks → boot replay → exactly 100 rows in `crash_log`. Idempotent re-replay = 0 new inserts.
- ch09 §6.2 (a) trailing partial line dropped, prefix preserved.
- ch09 §6.2 (b) file missing → `fileMissing=true`, no error.
- ch09 §6.2 (c) file present but empty → 0/0/0.
- ch09 §6.2 (d) malformed lines (non-JSON, missing fields, wrong types) counted + skipped; valid lines around them still imported.
- ch09 §6.2 (e) crash-after-insert-before-truncate idempotent via PRIMARY KEY (`id`) dedup.
- `owner_id` round-trip for `daemon-self`, `unix-user:1000`, `win-sid:...`.
- Line shape lock: emitted JSON has exactly the 7 spec fields, no extras.
- Wire-byte equality between `appendCrashRaw` and a hand-rolled child-process append (locks `serialiseEntry` against silent drift).

## Local verification

- `npx vitest run test/crash/crash-raw-recovery.spec.ts` → 9/9 pass.
- `npm run typecheck` → clean (after `pnpm --filter @ccsm/proto run gen` to populate codegen, which is not committed).
- `npm run lint` → clean.
- Full daemon `npm test` → 230 pass, 1 pre-existing failure in `test/descriptor/schema.spec.ts` (CRLF/EOL golden bytes; reproduces on `git stash` → unrelated to this PR).

## Test plan

- [ ] CI green on `working` base branch.
- [ ] Reviewer confirms line shape matches spec ch09 §2 example byte-for-byte (id, ts_ms, source, summary, detail, labels, owner_id).
- [ ] Reviewer confirms truncate happens AFTER `wal_checkpoint(FULL)` (durability ordering).
- [ ] Reviewer confirms #62 can consume `appendCrashRaw` from fatal hooks without API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)