### PR TITLE
daemon(T1.4): Listener A factory + bind variants

### DIFF
--- a/packages/daemon/src/listeners/__tests__/factory.spec.ts
+++ b/packages/daemon/src/listeners/__tests__/factory.spec.ts
@@ -1,0 +1,264 @@
+// Spec for the Listener A factory — `makeListenerA(env)`. Covers spec
+// ch03 §1 (Listener trait lifecycle: start once / stop idempotent /
+// descriptor only after start) and §2 (factory shape).
+//
+// Real-socket assertions: we exercise the `defaultBindHook` end-to-end
+// for `loopbackTcp` (works on every platform) and for `uds` on POSIX
+// (skipped on win32 where UDS path semantics differ — the named-pipe
+// branch is exercised via `BindHook` injection on every host).
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  LISTENER_A_ID,
+  defaultBindHook,
+  makeListenerA,
+  type BindHook,
+  type BoundTransport,
+} from '../factory.js';
+import type { DaemonEnv } from '../../env.js';
+import { RESERVED_FOR_LISTENER_B } from '../../env.js';
+import type { BindDescriptor } from '../types.js';
+
+const POSIX = process.platform !== 'win32';
+
+function envWith(listenerAddr: string): DaemonEnv {
+  return {
+    mode: 'dev',
+    paths: {
+      stateDir: '/tmp/ccsm-state',
+      descriptorPath: '/tmp/ccsm-state/listener-a.json',
+      listenerAddr,
+      supervisorAddr: '/tmp/ccsm-state/supervisor.sock',
+    },
+    listeners: [null, RESERVED_FOR_LISTENER_B] as const,
+    bootId: '550e8400-e29b-41d4-a716-446655440000',
+    version: '0.3.0-dev',
+    buildCommit: 'dev',
+  };
+}
+
+/** A minimal `BindHook` that records the descriptor it was called with
+ * and returns a fake `BoundTransport`. Used to exercise the factory's
+ * trait wiring without touching real sockets (so tests pass on every
+ * platform). */
+function fakeHook(): BindHook & { calls: BindDescriptor[]; stops: number } {
+  const calls: BindDescriptor[] = [];
+  let stops = 0;
+  const hook = (async (descriptor: BindDescriptor): Promise<BoundTransport> => {
+    calls.push(descriptor);
+    // For loopback, simulate the OS assigning a real port if input was 0.
+    const resolved: BindDescriptor =
+      descriptor.kind === 'loopbackTcp' && descriptor.port === 0
+        ? { kind: 'loopbackTcp', host: descriptor.host, port: 49152 }
+        : descriptor;
+    return {
+      descriptor: resolved,
+      async stop() {
+        stops += 1;
+      },
+    };
+  }) as BindHook & { calls: BindDescriptor[]; stops: number };
+  Object.defineProperty(hook, 'calls', { value: calls });
+  Object.defineProperty(hook, 'stops', {
+    get(): number {
+      return stops;
+    },
+  });
+  return hook;
+}
+
+describe('makeListenerA — trait shape (T1.2 contract)', () => {
+  it('returns a Listener with the canonical id', () => {
+    const env = envWith('/tmp/x.sock');
+    const listener = makeListenerA(env, {
+      bindHook: fakeHook(),
+      platform: 'linux',
+    });
+    expect(listener.id).toBe(LISTENER_A_ID);
+    expect(listener.id).toBe('listener-a');
+  });
+
+  it('start() then descriptor() returns the resolved descriptor', async () => {
+    const env = envWith('/tmp/y.sock');
+    const hook = fakeHook();
+    const listener = makeListenerA(env, { bindHook: hook, platform: 'linux' });
+    await listener.start();
+    expect(listener.descriptor()).toEqual({ kind: 'uds', path: '/tmp/y.sock' });
+    expect(hook.calls).toHaveLength(1);
+    await listener.stop();
+  });
+
+  it('descriptor() before start() throws (programming error per spec ch03 §1)', () => {
+    const env = envWith('/tmp/z.sock');
+    const listener = makeListenerA(env, {
+      bindHook: fakeHook(),
+      platform: 'linux',
+    });
+    expect(() => listener.descriptor()).toThrow(/before start/);
+  });
+
+  it('start() twice throws (idempotent-fail per spec ch03 §1)', async () => {
+    const env = envWith('/tmp/a.sock');
+    const listener = makeListenerA(env, {
+      bindHook: fakeHook(),
+      platform: 'linux',
+    });
+    await listener.start();
+    await expect(listener.start()).rejects.toThrow(/start\(\) called twice/);
+    await listener.stop();
+  });
+
+  it('stop() before start() is a no-op (idempotent per spec ch03 §1)', async () => {
+    const env = envWith('/tmp/b.sock');
+    const hook = fakeHook();
+    const listener = makeListenerA(env, { bindHook: hook, platform: 'linux' });
+    await expect(listener.stop()).resolves.toBeUndefined();
+    expect(hook.stops).toBe(0);
+  });
+
+  it('stop() twice is a no-op on the second call', async () => {
+    const env = envWith('/tmp/c.sock');
+    const hook = fakeHook();
+    const listener = makeListenerA(env, { bindHook: hook, platform: 'linux' });
+    await listener.start();
+    await listener.stop();
+    await listener.stop();
+    expect(hook.stops).toBe(1);
+  });
+});
+
+describe('makeListenerA — transport pick wiring (per-OS)', () => {
+  it('linux: pick is forwarded to bindHook as kind=uds', async () => {
+    const env = envWith('/tmp/uds-linux.sock');
+    const hook = fakeHook();
+    await makeListenerA(env, { bindHook: hook, platform: 'linux' }).start();
+    expect(hook.calls[0]).toEqual({ kind: 'uds', path: '/tmp/uds-linux.sock' });
+  });
+
+  it('darwin: pick is forwarded to bindHook as kind=uds', async () => {
+    const env = envWith('/var/run/com.ccsm.daemon/daemon.sock');
+    const hook = fakeHook();
+    await makeListenerA(env, { bindHook: hook, platform: 'darwin' }).start();
+    expect(hook.calls[0]).toEqual({
+      kind: 'uds',
+      path: '/var/run/com.ccsm.daemon/daemon.sock',
+    });
+  });
+
+  it('win32: pick is forwarded to bindHook as kind=namedPipe', async () => {
+    const env = envWith('\\\\.\\pipe\\ccsm-daemon');
+    const hook = fakeHook();
+    await makeListenerA(env, { bindHook: hook, platform: 'win32' }).start();
+    expect(hook.calls[0]).toEqual({
+      kind: 'namedPipe',
+      pipeName: '\\\\.\\pipe\\ccsm-daemon',
+    });
+  });
+
+  it('CCSM_LISTENER_A_FORCE_LOOPBACK=1: pick becomes loopbackTcp with ephemeral port', async () => {
+    const saved = process.env.CCSM_LISTENER_A_FORCE_LOOPBACK;
+    process.env.CCSM_LISTENER_A_FORCE_LOOPBACK = '1';
+    try {
+      const env = envWith('/tmp/ignored.sock');
+      const hook = fakeHook();
+      await makeListenerA(env, { bindHook: hook, platform: 'linux' }).start();
+      expect(hook.calls[0]).toEqual({
+        kind: 'loopbackTcp',
+        host: '127.0.0.1',
+        port: 0,
+      });
+    } finally {
+      if (saved === undefined) delete process.env.CCSM_LISTENER_A_FORCE_LOOPBACK;
+      else process.env.CCSM_LISTENER_A_FORCE_LOOPBACK = saved;
+    }
+  });
+});
+
+describe('makeListenerA — start() failure surfacing', () => {
+  it('start() rejects when bindHook rejects', async () => {
+    const env = envWith('/tmp/fail.sock');
+    const failHook: BindHook = async () => {
+      throw new Error('bind failed: EADDRINUSE');
+    };
+    const listener = makeListenerA(env, {
+      bindHook: failHook,
+      platform: 'linux',
+    });
+    await expect(listener.start()).rejects.toThrow(/EADDRINUSE/);
+    // Per spec ch03 §1 stop() is safe after a failed start().
+    await expect(listener.stop()).resolves.toBeUndefined();
+  });
+});
+
+describe('defaultBindHook — loopbackTcp end-to-end', () => {
+  it('binds an ephemeral port and resolves the descriptor with the real port', async () => {
+    const bound = await defaultBindHook({
+      kind: 'loopbackTcp',
+      host: '127.0.0.1',
+      port: 0,
+    });
+    try {
+      expect(bound.descriptor.kind).toBe('loopbackTcp');
+      if (bound.descriptor.kind === 'loopbackTcp') {
+        expect(bound.descriptor.host).toBe('127.0.0.1');
+        expect(bound.descriptor.port).toBeGreaterThan(0);
+        expect(bound.descriptor.port).not.toBe(0);
+      }
+    } finally {
+      await bound.stop();
+    }
+  });
+
+  it('stop() is idempotent', async () => {
+    const bound = await defaultBindHook({
+      kind: 'loopbackTcp',
+      host: '127.0.0.1',
+      port: 0,
+    });
+    await bound.stop();
+    await expect(bound.stop()).resolves.toBeUndefined();
+  });
+});
+
+describe.skipIf(!POSIX)('defaultBindHook — uds end-to-end (POSIX only)', () => {
+  let dir: string;
+  let sockPath: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'ccsm-listener-a-'));
+    sockPath = join(dir, 'daemon.sock');
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('binds a UDS at the given path', async () => {
+    const bound = await defaultBindHook({ kind: 'uds', path: sockPath });
+    try {
+      expect(bound.descriptor).toEqual({ kind: 'uds', path: sockPath });
+      const st = await stat(sockPath);
+      // Different OS / FS report `isSocket()` differently — what
+      // matters is that something exists at the path post-bind.
+      expect(st).toBeDefined();
+    } finally {
+      await bound.stop();
+    }
+  });
+
+  it('removes a stale leftover socket file before bind (no EADDRINUSE)', async () => {
+    // Simulate a crashed-daemon leftover with an arbitrary file at the
+    // path; a real UDS file or a regular file both block `bind(2)` with
+    // EADDRINUSE on POSIX, so the cleanup must handle both.
+    await writeFile(sockPath, 'leftover');
+    const bound = await defaultBindHook({ kind: 'uds', path: sockPath });
+    try {
+      expect(bound.descriptor).toEqual({ kind: 'uds', path: sockPath });
+    } finally {
+      await bound.stop();
+    }
+  });
+});

--- a/packages/daemon/src/listeners/__tests__/transport-pick.spec.ts
+++ b/packages/daemon/src/listeners/__tests__/transport-pick.spec.ts
@@ -1,0 +1,99 @@
+// Spec for the Listener A transport picker — pure decider per spec
+// ch03 §4 (transport pick) + §1a (closed BindDescriptor enum).
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { pickTransportForListenerA } from '../transport-pick.js';
+import type { DaemonEnv } from '../../env.js';
+import { RESERVED_FOR_LISTENER_B } from '../../env.js';
+
+function envWith(listenerAddr: string): DaemonEnv {
+  return {
+    mode: 'dev',
+    paths: {
+      stateDir: '/tmp/ccsm-state',
+      descriptorPath: '/tmp/ccsm-state/listener-a.json',
+      listenerAddr,
+      supervisorAddr: '/tmp/ccsm-state/supervisor.sock',
+    },
+    listeners: [null, RESERVED_FOR_LISTENER_B] as const,
+    bootId: '550e8400-e29b-41d4-a716-446655440000',
+    version: '0.3.0-dev',
+    buildCommit: 'dev',
+  };
+}
+
+describe('pickTransportForListenerA', () => {
+  let savedForce: string | undefined;
+
+  beforeEach(() => {
+    savedForce = process.env.CCSM_LISTENER_A_FORCE_LOOPBACK;
+    delete process.env.CCSM_LISTENER_A_FORCE_LOOPBACK;
+  });
+
+  afterEach(() => {
+    if (savedForce === undefined) {
+      delete process.env.CCSM_LISTENER_A_FORCE_LOOPBACK;
+    } else {
+      process.env.CCSM_LISTENER_A_FORCE_LOOPBACK = savedForce;
+    }
+  });
+
+  it('picks UDS on linux (A1 default)', () => {
+    const env = envWith('/run/ccsm/daemon.sock');
+    const desc = pickTransportForListenerA(env, 'linux');
+    expect(desc).toEqual({ kind: 'uds', path: '/run/ccsm/daemon.sock' });
+  });
+
+  it('picks UDS on darwin (A1 default)', () => {
+    const env = envWith('/var/run/com.ccsm.daemon/daemon.sock');
+    const desc = pickTransportForListenerA(env, 'darwin');
+    expect(desc).toEqual({
+      kind: 'uds',
+      path: '/var/run/com.ccsm.daemon/daemon.sock',
+    });
+  });
+
+  it('picks named-pipe on win32 (A4 default)', () => {
+    const env = envWith('\\\\.\\pipe\\ccsm-daemon');
+    const desc = pickTransportForListenerA(env, 'win32');
+    expect(desc).toEqual({
+      kind: 'namedPipe',
+      pipeName: '\\\\.\\pipe\\ccsm-daemon',
+    });
+  });
+
+  it('honours CCSM_LISTENER_A_FORCE_LOOPBACK=1 on every platform (A2 fallback)', () => {
+    process.env.CCSM_LISTENER_A_FORCE_LOOPBACK = '1';
+    const env = envWith('/run/ccsm/daemon.sock');
+    for (const platform of ['linux', 'darwin', 'win32'] as const) {
+      const desc = pickTransportForListenerA(env, platform);
+      expect(desc).toEqual({ kind: 'loopbackTcp', host: '127.0.0.1', port: 0 });
+    }
+  });
+
+  it('ignores CCSM_LISTENER_A_FORCE_LOOPBACK values other than literal "1"', () => {
+    const env = envWith('/run/ccsm/daemon.sock');
+    for (const v of ['true', 'yes', '0', '', 'TRUE']) {
+      process.env.CCSM_LISTENER_A_FORCE_LOOPBACK = v;
+      const desc = pickTransportForListenerA(env, 'linux');
+      expect(desc.kind).toBe('uds');
+    }
+  });
+
+  it('forwards env.paths.listenerAddr verbatim (single source of truth)', () => {
+    const custom = '/tmp/ccsm-test-override.sock';
+    const env = envWith(custom);
+    const desc = pickTransportForListenerA(env, 'linux');
+    expect(desc).toEqual({ kind: 'uds', path: custom });
+  });
+
+  it('never returns the tls variant in v0.3 (reserved for v0.4 Listener B)', () => {
+    const env = envWith('/run/ccsm/daemon.sock');
+    for (const platform of ['linux', 'darwin', 'win32'] as const) {
+      const desc = pickTransportForListenerA(env, platform);
+      expect(desc.kind).not.toBe('tls');
+    }
+    process.env.CCSM_LISTENER_A_FORCE_LOOPBACK = '1';
+    expect(pickTransportForListenerA(env, 'linux').kind).not.toBe('tls');
+  });
+});

--- a/packages/daemon/src/listeners/factory.ts
+++ b/packages/daemon/src/listeners/factory.ts
@@ -1,0 +1,297 @@
+// Listener A factory — `makeListenerA(env)` returns a `Listener` that, on
+// `start()`, binds the chosen transport (UDS / named-pipe / loopback-TCP).
+// Spec ch03 §2 (Listener A instantiation) + §4 (transport pick).
+//
+// SRP layering — three roles, kept separate:
+//   - decider: `pickTransportForListenerA(env, platform)` (transport-pick.ts)
+//     returns a `BindDescriptor`. Pure.
+//   - sink: `defaultBindHook` (this file) calls `net.Server.listen()` once.
+//     Single I/O surface.
+//   - producer: `makeListenerA` returns the `Listener` trait shape (T1.2).
+//     The trait's `descriptor()` method is the producer of the resolved
+//     `BindDescriptor` (post-`start()`, with the ephemeral loopback port
+//     filled in).
+//
+// Layer 1 — alternatives checked:
+//   - The `Listener` trait shape is FIXED by T1.2 (PR #860 merged); we
+//     fill it, we do NOT redesign. `start(): Promise<void>` and
+//     `stop(): Promise<void>` stay parameter-less; the `(router)`-shaped
+//     start signature in spec ch03 §1 is the v0.4-friendly future shape
+//     that T1.5 (HTTP/2 transport adapter) will introduce when it
+//     attaches the actual Connect router on top of this socket. T1.4's
+//     scope ends at the bound `net.Server`.
+//   - `node:net` (`net.createServer().listen({ path }|{ port, host })`)
+//     is the standard library primitive for both UDS and TCP. No need
+//     for a third-party socket lib.
+//   - We do NOT re-export the `BindDescriptor` here — it lives in
+//     `./types.ts`. Re-exporting would multiply the import surface and
+//     make `grep` for "where is BindDescriptor defined?" ambiguous.
+//
+// What this file is NOT:
+//   - HTTP/2 server attach (that's T1.5).
+//   - Connect-RPC router wiring (T1.5 + T2.x).
+//   - peer-cred middleware install (T1.3 ships the interceptor; T1.5
+//     attaches it to the http2 server).
+//   - Descriptor file write (T1.6 / `descriptor.ts` already shipped).
+//
+// We DO publish a `BindHook` injection seam so T1.5 can swap the plain
+// `net.Server` bind for an `http2.createServer({createConnection})`
+// without re-shaping this factory.
+
+import { createServer, type Server } from 'node:net';
+import { unlink, stat } from 'node:fs/promises';
+import type { DaemonEnv } from '../env.js';
+import { pickTransportForListenerA, type NodePlatform } from './transport-pick.js';
+import type { BindDescriptor, Listener } from './types.js';
+
+/** Stable id for Listener A, recorded in logs and the descriptor file. */
+export const LISTENER_A_ID = 'listener-a' as const;
+
+/**
+ * Result of a successful bind. The factory's `descriptor()` reads from
+ * this — for `loopbackTcp` the `port` may differ from the input pick
+ * (the OS assigns when input is `0`).
+ *
+ * Plain shape (no `Listener` discriminator) so `BindHook` callers stay
+ * unaware of the trait vocabulary; this is the *sink*'s output, not the
+ * *producer*'s.
+ */
+export interface BoundTransport {
+  /** The resolved bind descriptor (loopback port is filled in here). */
+  readonly descriptor: BindDescriptor;
+  /** Tear down the bound transport. Idempotent — safe to call twice. */
+  stop(): Promise<void>;
+}
+
+/**
+ * The bind seam. Default implementation (`defaultBindHook`) opens a
+ * plain `net.Server`; T1.5 injects an http2-aware variant when it
+ * lands. Returning a `BoundTransport` (not just a `Server`) lets the
+ * hook own the resolved descriptor — the http2 hook can promote
+ * `kind: 'loopbackTcp'` to `kind: 'tls'` etc. without the factory
+ * caring.
+ *
+ * Errors during bind MUST reject the returned promise; the factory
+ * surfaces them as a `start()` rejection so phase STARTING_LISTENERS
+ * fails fast (spec ch02 §3 step 5 — descriptor write is gated on a
+ * successful bind).
+ */
+export type BindHook = (descriptor: BindDescriptor) => Promise<BoundTransport>;
+
+/**
+ * Default bind hook — opens a `net.Server`, no protocol on top. Use this
+ * for v0.3 smoke runs and unit tests. T1.5 will provide an http2-aware
+ * hook with the same signature.
+ *
+ * For UDS: deletes a stale `<path>` if it exists (a leftover socket from
+ * a previous crashed daemon is the single most common cause of
+ * `EADDRINUSE` on POSIX UDS — the socket file persists across crashes
+ * because the kernel does NOT garbage-collect it). The unlink is
+ * conditional: we `stat` first and skip if the path does not exist;
+ * any other stat error rethrows untouched.
+ *
+ * For named pipes / loopback TCP: no pre-bind cleanup is required.
+ * Named pipes are kernel objects with no FS leftover; loopback TCP
+ * with `port: 0` is collision-free by construction.
+ */
+export const defaultBindHook: BindHook = async (descriptor) => {
+  const server = createServer();
+
+  if (descriptor.kind === 'uds') {
+    await removeStaleUdsPath(descriptor.path);
+  }
+
+  await listenOnce(server, descriptor);
+
+  const resolved = resolveBoundDescriptor(server, descriptor);
+
+  return {
+    descriptor: resolved,
+    stop: () => closeServer(server, descriptor),
+  };
+};
+
+/**
+ * Construct Listener A. Pure — no I/O. The chosen transport, the bind
+ * hook, and the platform string are all overridable so tests can drive
+ * every branch without touching real sockets.
+ *
+ * @param env       The daemon env (read-only after boot per env.ts).
+ * @param overrides Optional injection seams for tests / T1.5.
+ * @returns         A `Listener` whose `start()` binds the transport.
+ */
+export function makeListenerA(
+  env: DaemonEnv,
+  overrides: {
+    readonly bindHook?: BindHook;
+    readonly platform?: NodePlatform;
+  } = {},
+): Listener {
+  const platform = overrides.platform ?? process.platform;
+  const bindHook = overrides.bindHook ?? defaultBindHook;
+  const planned = pickTransportForListenerA(env, platform);
+
+  // Mutable state guarded by the trait contract (start exactly once,
+  // stop exactly once — spec ch03 §1 lifecycle). All state is local to
+  // this closure; there is no module-level mutable state.
+  let bound: BoundTransport | null = null;
+  let started = false;
+  let stopped = false;
+
+  const trait: Listener = {
+    id: LISTENER_A_ID,
+
+    async start(): Promise<void> {
+      if (started) {
+        // Spec ch03 §1: "Idempotent-fail: throws on second call."
+        throw new Error(`${LISTENER_A_ID}: start() called twice`);
+      }
+      started = true;
+      bound = await bindHook(planned);
+    },
+
+    async stop(): Promise<void> {
+      // Spec ch03 §1: "Idempotent: safe to call after a failed start."
+      // We tolerate stop-before-start (no bound) and double-stop.
+      if (stopped) return;
+      stopped = true;
+      const b = bound;
+      bound = null;
+      if (b !== null) {
+        await b.stop();
+      }
+    },
+
+    descriptor(): BindDescriptor {
+      if (bound === null) {
+        // Spec ch03 §1: "Calling before start() is a programming error."
+        throw new Error(`${LISTENER_A_ID}: descriptor() called before start()`);
+      }
+      return bound.descriptor;
+    },
+  };
+
+  return trait;
+}
+
+/* ------------------------------------------------------------------ */
+/* Internal helpers                                                    */
+/* ------------------------------------------------------------------ */
+
+/** `server.listen(...)` as a promise. Rejects on `'error'`, resolves on
+ * `'listening'`. Removes both listeners on whichever fires first so a
+ * late `error` after `listening` does not leak into the unhandled
+ * rejection channel. */
+function listenOnce(server: Server, descriptor: BindDescriptor): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onError = (err: Error): void => {
+      server.removeListener('listening', onListening);
+      reject(err);
+    };
+    const onListening = (): void => {
+      server.removeListener('error', onError);
+      resolve();
+    };
+    server.once('error', onError);
+    server.once('listening', onListening);
+
+    switch (descriptor.kind) {
+      case 'uds':
+        server.listen({ path: descriptor.path });
+        return;
+      case 'namedPipe':
+        // Node treats a Windows named-pipe path identically to a UDS
+        // path: `server.listen({ path })` where `path` matches
+        // `\\.\pipe\<name>`. Same `net.Server.listen` API; only the
+        // string shape differs.
+        server.listen({ path: descriptor.pipeName });
+        return;
+      case 'loopbackTcp':
+        server.listen({ host: descriptor.host, port: descriptor.port });
+        return;
+      case 'tls':
+        // Reserved for v0.4 Listener B per ch03 §1a; the v0.3 picker
+        // never returns this variant. Throwing here makes a future
+        // mis-pick fail loud at start() time instead of silently
+        // binding nothing.
+        reject(new Error(`${LISTENER_A_ID}: tls bind not supported in v0.3`));
+        return;
+    }
+  });
+}
+
+/** Resolve the post-bind descriptor. For `loopbackTcp` with `port: 0`,
+ * substitute the OS-assigned port. For UDS / named pipe, the descriptor
+ * is unchanged (the OS does not rewrite the path). */
+function resolveBoundDescriptor(
+  server: Server,
+  planned: BindDescriptor,
+): BindDescriptor {
+  if (planned.kind !== 'loopbackTcp') {
+    return planned;
+  }
+  const addr = server.address();
+  if (addr === null || typeof addr === 'string') {
+    // `string` shape happens for UDS-bound servers; we are in the
+    // `loopbackTcp` branch so this is unreachable in practice. Fall
+    // back to the planned descriptor rather than throw — the bind
+    // already succeeded so callers should still get a usable shape.
+    return planned;
+  }
+  return {
+    kind: 'loopbackTcp',
+    host: planned.host,
+    port: addr.port,
+  };
+}
+
+/** `server.close()` as a promise. Resolves even if the server was never
+ * listening (matches the spec's "stop is idempotent" contract). */
+function closeServer(server: Server, descriptor: BindDescriptor): Promise<void> {
+  return new Promise((resolve) => {
+    if (!server.listening) {
+      resolve();
+      return;
+    }
+    server.close(() => {
+      // Best-effort UDS cleanup so the next boot does not stumble over
+      // a leftover socket file. We ignore errors — a missing file is
+      // fine, and a permission error means an operator is responsible
+      // for cleanup, not us.
+      if (descriptor.kind === 'uds') {
+        unlink(descriptor.path).catch(() => {
+          /* swallow — see comment above */
+        });
+      }
+      resolve();
+    });
+  });
+}
+
+/** Remove a stale UDS socket file before bind. No-op if the path does
+ * not exist; rethrows on any error other than ENOENT. */
+async function removeStaleUdsPath(path: string): Promise<void> {
+  try {
+    await stat(path);
+  } catch (err) {
+    if (isEnoent(err)) return;
+    throw err;
+  }
+  // Path exists; try to unlink. If the unlink fails with ENOENT (race
+  // between stat and unlink) treat it as success.
+  try {
+    await unlink(path);
+  } catch (err) {
+    if (isEnoent(err)) return;
+    throw err;
+  }
+}
+
+function isEnoent(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code: unknown }).code === 'ENOENT'
+  );
+}

--- a/packages/daemon/src/listeners/transport-pick.ts
+++ b/packages/daemon/src/listeners/transport-pick.ts
@@ -1,0 +1,121 @@
+// Listener A transport picker — pure decider that maps `(platform, env)`
+// to a `BindDescriptor`. Spec ch03 §4 (transport pick A1-A4) plus the
+// per-OS rationale from ch02 §2 (per-OS service shape).
+//
+// Pick rules (matches spec §4 + spike outcomes from
+// `tools/spike-harness/probes/{uds-h2c, win-h2-named-pipe,
+// loopback-h2c-on-25h2}/RESULT.md`):
+//   - linux / darwin:  default A1 (UDS h2c) — `kind: 'uds'`
+//   - win32:           default A4 (named pipe h2) — `kind: 'namedPipe'`
+//   - any platform with `CCSM_LISTENER_A_FORCE_LOOPBACK=1`:
+//                      A2 (loopback h2c) — `kind: 'loopbackTcp'` — for
+//                      dev / smoke runs that cannot use a UDS (CI Docker
+//                      with no /run mount, IDE remote dev container, etc.).
+//
+// SRP: this module is a *decider* — pure function `(env, platform) →
+// BindDescriptor`. No I/O, no side effects, no socket bind. The actual
+// bind happens in `factory.ts` when `start()` runs.
+//
+// Layer 1 — repo-internal alternatives checked:
+//   - `env.ts` `defaultListenerAddr()` already encodes the per-OS path
+//     defaults; we *reuse* `env.paths.listenerAddr` directly rather than
+//     re-deriving paths here. This keeps a single source of truth: any
+//     future override (e.g. `CCSM_LISTENER_A_ADDR=/tmp/ccsm.sock`) flows
+//     through env.ts and is picked up here transparently.
+//   - The closed-enum `BindDescriptor` from `./types.ts` (T1.2) is the
+//     contract; this module returns one of its four variants. The
+//     `'tls'` variant (A3 fallback) is reserved for v0.4 Listener B per
+//     ch03 §1a — v0.3 picks never produce it.
+
+import type { DaemonEnv } from '../env.js';
+import type { BindDescriptor } from './types.js';
+
+/** NodeJS platform string. Re-exported as a type for testability — the
+ * picker takes it as a parameter so unit tests can exercise every branch
+ * on a single host without mocking `process.platform`. */
+export type NodePlatform = NodeJS.Platform;
+
+/** Loopback host pin. v0.3 always uses `127.0.0.1` (IPv4 loopback) — the
+ * spec ch03 §1a closed enum does not cover `::1` for v0.3 and Connect
+ * client transport factories key on the same string. */
+const LOOPBACK_HOST = '127.0.0.1' as const;
+
+/**
+ * Loopback fallback port — `0` asks the OS for an ephemeral port. The
+ * picker returns `0` here; the factory resolves the actual bound port
+ * via `server.address()` after `start()` and exposes it through
+ * `descriptor()` (which is the contract Electron reads via the
+ * descriptor file, where the resolved port is recorded).
+ *
+ * Rationale: hard-coding a port number would (a) collide on dev
+ * machines running multiple daemon instances and (b) require firewall
+ * carve-outs on Win 11 even for loopback (Defender's loopback exemption
+ * is not absolute on every profile). Ephemeral + descriptor-file-based
+ * rendezvous is the spec's design for this exact reason.
+ */
+const EPHEMERAL_PORT = 0;
+
+/**
+ * Parse the loopback-fallback override from env. Returns `true` only when
+ * the env var is exactly `'1'` (case-sensitive) — anything else (`'true'`,
+ * `'yes'`, `'0'`, missing) is `false`. The strict check matches every
+ * other env-flag idiom in this package and prevents accidental opt-ins
+ * from common shell-typos like `CCSM_LISTENER_A_FORCE_LOOPBACK=true`.
+ */
+function forceLoopback(): boolean {
+  return process.env.CCSM_LISTENER_A_FORCE_LOOPBACK === '1';
+}
+
+/**
+ * Pick the transport for Listener A on this host.
+ *
+ * @param env       The daemon env (provides `paths.listenerAddr`).
+ * @param platform  NodeJS platform string (`process.platform`).
+ * @returns         A `BindDescriptor` whose `kind` is `'uds'` |
+ *                  `'namedPipe'` | `'loopbackTcp'` per spec ch03 §1a.
+ *
+ * Spec ch03 §4 maps:
+ *   - A1 (UDS h2c)            → linux / darwin default
+ *   - A2 (loopback h2c)       → CCSM_LISTENER_A_FORCE_LOOPBACK=1, OR fallback
+ *   - A3 (loopback h2 + TLS)  → reserved for v0.4 Listener B (NOT picked here)
+ *   - A4 (named-pipe h2)      → win32 default
+ *
+ * The factory consumes this descriptor unchanged; the descriptor writer
+ * (T1.6) maps the lowercase `kind` to the uppercase `transport` enum
+ * stringified into `listener-a.json`.
+ */
+export function pickTransportForListenerA(
+  env: DaemonEnv,
+  platform: NodePlatform,
+): BindDescriptor {
+  // Operator override: forces loopback regardless of OS. Used by smoke
+  // harnesses that cannot rely on UDS / named-pipe (e.g. running the
+  // daemon inside a container without a writable `/run`).
+  if (forceLoopback()) {
+    return {
+      kind: 'loopbackTcp',
+      host: LOOPBACK_HOST,
+      port: EPHEMERAL_PORT,
+    };
+  }
+
+  if (platform === 'win32') {
+    // A4: named pipe. `env.paths.listenerAddr` is already the
+    // `\\.\pipe\ccsm-daemon` shape on win32 (set by `defaultListenerAddr`
+    // in env.ts), so we forward it verbatim. Per-user pipe naming
+    // (`\\.\pipe\ccsm-<sid>`) is a v0.3.x hardening item; the env-var
+    // override path covers it today.
+    return {
+      kind: 'namedPipe',
+      pipeName: env.paths.listenerAddr,
+    };
+  }
+
+  // A1: UDS. `env.paths.listenerAddr` is the OS-appropriate UDS path
+  // (e.g. `/var/run/com.ccsm.daemon/daemon.sock` on darwin,
+  // `/run/ccsm/daemon.sock` on linux).
+  return {
+    kind: 'uds',
+    path: env.paths.listenerAddr,
+  };
+}


### PR DESCRIPTION
## Summary

Task #24 [T1.4] — implements the Listener A factory and per-OS transport picker behind the closed `BindDescriptor` enum from T1.2.

- **`packages/daemon/src/listeners/transport-pick.ts`** — pure decider `pickTransportForListenerA(env, platform): BindDescriptor`. Per spec ch03 §4:
  - linux / darwin → A1 (UDS h2c) `kind: 'uds'`
  - win32 → A4 (named pipe h2) `kind: 'namedPipe'`
  - `CCSM_LISTENER_A_FORCE_LOOPBACK=1` (any OS) → A2 (loopback h2c) `kind: 'loopbackTcp'`, ephemeral port
  - v0.3 never returns the `'tls'` variant (reserved for v0.4 Listener B per ch03 §1a).
  - Forwards `env.paths.listenerAddr` verbatim — `env.ts` stays the single source of truth for per-OS path defaults.

- **`packages/daemon/src/listeners/factory.ts`** — `makeListenerA(env): Listener` fills the trait shipped in PR #860 (T1.2) without redesign:
  - `id = 'listener-a'`
  - `start()` binds the planned `BindDescriptor` via an injectable `BindHook`; throws on second call (spec ch03 §1).
  - `stop()` closes the bound transport; idempotent and safe before `start()`.
  - `descriptor()` returns the resolved `BindDescriptor` (loopback ephemeral port filled in post-bind via `server.address()`).
  - `defaultBindHook` opens a plain `net.Server`. For UDS it removes a stale socket file before bind (the #1 cause of `EADDRINUSE` on POSIX). T1.5 will inject an http2-aware `BindHook` with the same signature; T1.4's scope ends at the bound socket — no router attach.

## Layer 1 verification

The Listener trait is fixed by T1.2 (PR #860 merged). I filled it; I did not redesign. The `start(router)` shape from spec ch03 §1 is the v0.4-friendly future shape that T1.5 introduces with the HTTP/2 transport adapter — keeping `start(): Promise<void>` here matches the shipped `types.ts`.

Reused existing exports: `Listener`, `BindDescriptor` from `./types.ts`; `DaemonEnv`, `RESERVED_FOR_LISTENER_B` from `../env.ts`; `node:net.createServer` from stdlib (no new deps). No new module-level mutable state.

## Out of scope (deliberately deferred)

- HTTP/2 server attach + Connect-RPC router wiring → **T1.5**
- peer-cred middleware install (PR #884 already shipped the interceptor; T1.5 attaches it) → **T1.5**
- `listener-a.json` descriptor write → **T1.6** (shipped, PR #863)
- `DaemonEnv.listeners[0]` wire-up at `index.ts` startup site → owned by T1.7 supervisor work in flight (Task #23) — staying out of `index.ts` per task brief.

## Test plan

Local gates on Windows host:
- [x] `pnpm --filter @ccsm/daemon typecheck` — pass
- [x] `pnpm --filter @ccsm/daemon lint` — pass
- [x] `pnpm --filter @ccsm/daemon vitest run src/listeners` — **34 passed | 2 skipped (36)**, 4 files. Skips are POSIX-only UDS bind cases that don't run on win32.

Pre-existing failures elsewhere (`src/db/__tests__/sqlite.spec.ts`, `test/sqlite/coalescer.spec.ts`, `test/descriptor/schema.spec.ts`) are caused by a `better-sqlite3` `NODE_MODULE_VERSION` mismatch in this dev shell + an unrelated descriptor-schema golden. None of these touch the listeners subtree; CI Linux runners with a clean `pnpm install` will pass them.

Tests cover:
- transport-pick: every per-OS branch, env override (strict `'1'` check), env path forwarding, `'tls'` never returned in v0.3.
- factory trait shape: id constant, `start()` then `descriptor()` round-trip, `descriptor()` before `start()` throws, double-`start()` throws, `stop()` before `start()` is no-op, double-`stop()` calls hook once.
- factory transport wiring: linux / darwin / win32 / `CCSM_LISTENER_A_FORCE_LOOPBACK=1` each forward the right `BindDescriptor` to the hook.
- factory failure surfacing: `start()` rejects when the hook rejects; `stop()` after failed `start()` is safe.
- `defaultBindHook` end-to-end: loopback ephemeral port resolution, idempotent `stop()`, and (POSIX-only) UDS bind including stale-socket cleanup.

## Spec refs

- ch03 §1 (Listener trait), §1a (BindDescriptor closed enum), §2 (factory shape), §4 (transport pick A1-A4)
- Spike outcomes: `tools/spike-harness/probes/{uds-h2c, win-h2-named-pipe, loopback-h2c-on-25h2}/RESULT.md`

Closes Task #24.