### PR TITLE
daemon(T1.5): HTTP/2 transport adapters (h2c-UDS / h2c-loopback / h2-named-pipe / h2-TLS)

### DIFF
--- a/packages/daemon/src/transport/__tests__/h2-named-pipe.spec.ts
+++ b/packages/daemon/src/transport/__tests__/h2-named-pipe.spec.ts
@@ -1,0 +1,103 @@
+// h2-named-pipe adapter spec — exercises bind / address / close on a
+// real Windows named pipe. Spec ch03 §4 A4. Skipped off-win32 (the
+// adapter throws by design — exercised separately).
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { createServer, connect as h2connect, type ClientHttp2Session } from 'node:http2';
+import { connect as netConnect } from 'node:net';
+import { platform } from 'node:os';
+
+import { bindH2NamedPipe, normalizePipePath } from '../h2-named-pipe.js';
+import type { BoundTransport } from '../types.js';
+
+const isWin = platform() === 'win32';
+const describeWin = isWin ? describe : describe.skip;
+
+let bound: BoundTransport | null = null;
+let h2client: ClientHttp2Session | null = null;
+
+afterEach(async () => {
+  if (h2client) {
+    h2client.destroy();
+    h2client = null;
+  }
+  if (bound) {
+    await bound.close();
+    bound = null;
+  }
+});
+
+function freshPipeName(): string {
+  // Per-test unique name to avoid cross-test interference.
+  const id = `${process.pid}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+  return `ccsm-test-${id}`;
+}
+
+describe('normalizePipePath', () => {
+  it('passes through \\\\?\\pipe\\... unchanged', () => {
+    expect(normalizePipePath('\\\\?\\pipe\\foo')).toBe('\\\\?\\pipe\\foo');
+  });
+  it('passes through \\\\.\\pipe\\... unchanged', () => {
+    expect(normalizePipePath('\\\\.\\pipe\\foo')).toBe('\\\\.\\pipe\\foo');
+  });
+  it('prefixes a bare name with \\\\?\\pipe\\', () => {
+    expect(normalizePipePath('foo')).toBe('\\\\?\\pipe\\foo');
+  });
+});
+
+describeWin('bindH2NamedPipe (win32)', () => {
+  it('binds an http2 server to a named pipe and surfaces it via address()', async () => {
+    const server = createServer();
+    const pipe = freshPipeName();
+    bound = await bindH2NamedPipe(server, { pipeName: pipe });
+    const addr = bound.address();
+    expect(addr).toEqual({ kind: 'namedPipe', pipeName: `\\\\?\\pipe\\${pipe}` });
+  });
+
+  it('serves an end-to-end h2 request over the pipe', async () => {
+    const server = createServer();
+    server.on('stream', (stream, headers) => {
+      if (headers[':path'] === '/ping') {
+        stream.respond({ ':status': 200 });
+        stream.end('pong');
+      } else {
+        stream.respond({ ':status': 404 });
+        stream.end();
+      }
+    });
+    const pipe = freshPipeName();
+    bound = await bindH2NamedPipe(server, { pipeName: pipe });
+    const pipePath = `\\\\?\\pipe\\${pipe}`;
+
+    h2client = h2connect('http://localhost', {
+      createConnection: () => netConnect(pipePath),
+    });
+    const body = await new Promise<string>((resolve, reject) => {
+      const req = h2client!.request({ ':path': '/ping' });
+      const chunks: Buffer[] = [];
+      req.on('data', (c: Buffer) => chunks.push(c));
+      req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+      req.on('error', reject);
+      req.end();
+    });
+    expect(body).toBe('pong');
+  });
+
+  it('close() is idempotent', async () => {
+    const server = createServer();
+    const pipe = freshPipeName();
+    bound = await bindH2NamedPipe(server, { pipeName: pipe });
+    await bound.close();
+    await expect(bound.close()).resolves.toBeUndefined();
+    bound = null;
+  });
+});
+
+describe('bindH2NamedPipe (POSIX guard)', () => {
+  it.skipIf(isWin)('throws synchronously on POSIX with a routing-hint message', async () => {
+    const server = createServer();
+    await expect(bindH2NamedPipe(server, { pipeName: 'never-binds' })).rejects.toThrow(
+      /win32-only/,
+    );
+  });
+});

--- a/packages/daemon/src/transport/__tests__/h2-tls.spec.ts
+++ b/packages/daemon/src/transport/__tests__/h2-tls.spec.ts
@@ -1,0 +1,180 @@
+// h2-TLS adapter spec — exercises cert fingerprint computation +
+// bind / address / close on a real loopback TLS listener with a
+// transient self-signed cert. Spec ch03 §4 A3.
+
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  createSecureServer,
+  connect as h2connect,
+  type ClientHttp2Session,
+} from 'node:http2';
+import { createHash, X509Certificate } from 'node:crypto';
+import { execSync } from 'node:child_process';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { bindH2Tls, computeCertFingerprint } from '../h2-tls.js';
+import type { BoundTransport } from '../types.js';
+
+let bound: BoundTransport | null = null;
+let h2client: ClientHttp2Session | null = null;
+
+afterEach(async () => {
+  if (h2client) {
+    h2client.destroy();
+    h2client = null;
+  }
+  if (bound) {
+    await bound.close();
+    bound = null;
+  }
+});
+
+// Mint a self-signed cert at MODULE LOAD time (synchronous) so
+// `it.skipIf(!HAVE_CERT)` evaluates correctly at collect time.
+//
+// Path: shell out to `openssl req` if openssl is on PATH; otherwise
+// skip every test in this suite. The skip path is acceptable per
+// spec ch03 §4 A3 — A3 is the last-resort transport, exercised in
+// dev / CI where openssl is ubiquitous. Production cert provisioning
+// is the installer's job (T7.5), not this adapter's.
+let TEST_CERT_PEM = '';
+let TEST_KEY_PEM = '';
+let TEST_CERT_FINGERPRINT = '';
+let HAVE_CERT = false;
+
+try {
+  execSync('openssl version', { stdio: 'ignore' });
+  const dir = mkdtempSync(join(tmpdir(), 'ccsm-h2-tls-'));
+  const keyPath = join(dir, 'key.pem');
+  const certPath = join(dir, 'cert.pem');
+  execSync(
+    `openssl req -x509 -newkey rsa:2048 -nodes -keyout "${keyPath}" -out "${certPath}" -days 3650 -subj "/CN=localhost" -addext "subjectAltName=IP:127.0.0.1"`,
+    { stdio: 'ignore' },
+  );
+  TEST_KEY_PEM = readFileSync(keyPath, 'utf8');
+  TEST_CERT_PEM = readFileSync(certPath, 'utf8');
+  const cert = new X509Certificate(TEST_CERT_PEM);
+  TEST_CERT_FINGERPRINT = createHash('sha256').update(cert.raw).digest('hex');
+  HAVE_CERT = true;
+} catch {
+  HAVE_CERT = false;
+}
+
+describe('computeCertFingerprint', () => {
+  it.skipIf(!HAVE_CERT)('matches the SHA-256 of the DER form of the cert', () => {
+    const fp = computeCertFingerprint(TEST_CERT_PEM);
+    expect(fp).toBe(TEST_CERT_FINGERPRINT);
+    expect(fp).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it.skipIf(!HAVE_CERT)('accepts a Buffer in addition to a string', () => {
+    const buf = Buffer.from(TEST_CERT_PEM, 'utf8');
+    expect(computeCertFingerprint(buf)).toBe(TEST_CERT_FINGERPRINT);
+  });
+});
+
+describe('bindH2Tls', () => {
+  it.skipIf(!HAVE_CERT)(
+    'binds an ephemeral 127.0.0.1 TLS port and surfaces port + fingerprint',
+    async () => {
+      const server = createSecureServer({
+        cert: TEST_CERT_PEM,
+        key: TEST_KEY_PEM,
+        allowHTTP1: false,
+      });
+      bound = await bindH2Tls(server, {
+        host: '127.0.0.1',
+        port: 0,
+        cert: TEST_CERT_PEM,
+        key: TEST_KEY_PEM,
+      });
+      const addr = bound.address();
+      expect(addr.kind).toBe('tls');
+      if (addr.kind !== 'tls') throw new Error('unreachable');
+      expect(addr.host).toBe('127.0.0.1');
+      expect(addr.port).toBeGreaterThan(0);
+      expect(addr.certFingerprintSha256).toBe(TEST_CERT_FINGERPRINT);
+    },
+  );
+
+  it.skipIf(!HAVE_CERT)(
+    'serves an end-to-end h2 request with the pinned cert',
+    async () => {
+      const server = createSecureServer({
+        cert: TEST_CERT_PEM,
+        key: TEST_KEY_PEM,
+        allowHTTP1: false,
+      });
+      server.on('stream', (stream, headers) => {
+        if (headers[':path'] === '/ping') {
+          stream.respond({ ':status': 200 });
+          stream.end('pong');
+        } else {
+          stream.respond({ ':status': 404 });
+          stream.end();
+        }
+      });
+      bound = await bindH2Tls(server, {
+        host: '127.0.0.1',
+        port: 0,
+        cert: TEST_CERT_PEM,
+        key: TEST_KEY_PEM,
+      });
+      const addr = bound.address();
+      if (addr.kind !== 'tls') throw new Error('unreachable');
+
+      h2client = h2connect(`https://127.0.0.1:${addr.port}`, {
+        ca: TEST_CERT_PEM,
+        servername: 'localhost',
+      });
+      const body = await new Promise<string>((resolve, reject) => {
+        const req = h2client!.request({ ':path': '/ping' });
+        const chunks: Buffer[] = [];
+        req.on('data', (c: Buffer) => chunks.push(c));
+        req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+        req.on('error', reject);
+        req.end();
+      });
+      expect(body).toBe('pong');
+    },
+  );
+
+  it.skipIf(!HAVE_CERT)('rejects non-loopback host at runtime', async () => {
+    const server = createSecureServer({ cert: TEST_CERT_PEM, key: TEST_KEY_PEM });
+    await expect(
+      bindH2Tls(server, {
+        host: '0.0.0.0' as '127.0.0.1',
+        port: 0,
+        cert: TEST_CERT_PEM,
+        key: TEST_KEY_PEM,
+      }),
+    ).rejects.toThrow(/MUST be 127\.0\.0\.1/);
+  });
+
+  it.skipIf(!HAVE_CERT)('rejects out-of-range port', async () => {
+    const server = createSecureServer({ cert: TEST_CERT_PEM, key: TEST_KEY_PEM });
+    await expect(
+      bindH2Tls(server, {
+        host: '127.0.0.1',
+        port: 70_000,
+        cert: TEST_CERT_PEM,
+        key: TEST_KEY_PEM,
+      }),
+    ).rejects.toThrow(/port out of range/);
+  });
+
+  it.skipIf(!HAVE_CERT)('close() is idempotent', async () => {
+    const server = createSecureServer({ cert: TEST_CERT_PEM, key: TEST_KEY_PEM });
+    bound = await bindH2Tls(server, {
+      host: '127.0.0.1',
+      port: 0,
+      cert: TEST_CERT_PEM,
+      key: TEST_KEY_PEM,
+    });
+    await bound.close();
+    await expect(bound.close()).resolves.toBeUndefined();
+    bound = null;
+  });
+});

--- a/packages/daemon/src/transport/__tests__/h2c-loopback.spec.ts
+++ b/packages/daemon/src/transport/__tests__/h2c-loopback.spec.ts
@@ -1,0 +1,87 @@
+// h2c-loopback adapter spec — exercises bind / address / close on a
+// real ephemeral 127.0.0.1 listener. Spec ch03 §4 A2.
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { createServer } from 'node:http2';
+import { connect as h2connect, type ClientHttp2Session } from 'node:http2';
+
+import { bindH2cLoopback } from '../h2c-loopback.js';
+import type { BoundTransport } from '../types.js';
+
+let bound: BoundTransport | null = null;
+let h2client: ClientHttp2Session | null = null;
+
+afterEach(async () => {
+  if (h2client) {
+    h2client.destroy();
+    h2client = null;
+  }
+  if (bound) {
+    await bound.close();
+    bound = null;
+  }
+});
+
+describe('bindH2cLoopback', () => {
+  it('binds an ephemeral 127.0.0.1 port and surfaces it via address()', async () => {
+    const server = createServer();
+    bound = await bindH2cLoopback(server, { host: '127.0.0.1', port: 0 });
+    const addr = bound.address();
+    expect(addr.kind).toBe('loopback');
+    if (addr.kind !== 'loopback') throw new Error('unreachable');
+    expect(addr.host).toBe('127.0.0.1');
+    expect(addr.port).toBeGreaterThan(0);
+    expect(addr.port).toBeLessThan(65536);
+  });
+
+  it('serves an end-to-end h2c request to a stream handler', async () => {
+    const server = createServer();
+    server.on('stream', (stream, headers) => {
+      const path = headers[':path'];
+      if (path === '/ping') {
+        stream.respond({ ':status': 200, 'content-type': 'text/plain' });
+        stream.end('pong');
+        return;
+      }
+      stream.respond({ ':status': 404 });
+      stream.end();
+    });
+    bound = await bindH2cLoopback(server, { host: '127.0.0.1', port: 0 });
+    const addr = bound.address();
+    if (addr.kind !== 'loopback') throw new Error('unreachable');
+
+    h2client = h2connect(`http://127.0.0.1:${addr.port}`);
+    const body = await new Promise<string>((resolve, reject) => {
+      const req = h2client!.request({ ':path': '/ping' });
+      const chunks: Buffer[] = [];
+      req.on('data', (c: Buffer) => chunks.push(c));
+      req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+      req.on('error', reject);
+      req.end();
+    });
+    expect(body).toBe('pong');
+  });
+
+  it('rejects non-loopback host at runtime', async () => {
+    const server = createServer();
+    await expect(
+      bindH2cLoopback(server, { host: '0.0.0.0' as '127.0.0.1', port: 0 }),
+    ).rejects.toThrow(/MUST be 127\.0\.0\.1/);
+  });
+
+  it('rejects out-of-range port', async () => {
+    const server = createServer();
+    await expect(
+      bindH2cLoopback(server, { host: '127.0.0.1', port: 70_000 }),
+    ).rejects.toThrow(/port out of range/);
+  });
+
+  it('close() is idempotent', async () => {
+    const server = createServer();
+    bound = await bindH2cLoopback(server, { host: '127.0.0.1', port: 0 });
+    await bound.close();
+    // Second call returns the same Promise — must NOT throw.
+    await expect(bound.close()).resolves.toBeUndefined();
+    bound = null; // already closed; afterEach skip
+  });
+});

--- a/packages/daemon/src/transport/__tests__/h2c-uds.spec.ts
+++ b/packages/daemon/src/transport/__tests__/h2c-uds.spec.ts
@@ -1,0 +1,138 @@
+// h2c-UDS adapter spec — exercises bind / address / close on a real
+// UDS path. Spec ch03 §4 A1. Skipped on win32 (the adapter throws by
+// design — exercised separately).
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { createServer, connect as h2connect, type ClientHttp2Session } from 'node:http2';
+import { mkdtempSync, existsSync, writeFileSync, unlinkSync } from 'node:fs';
+import { tmpdir, platform } from 'node:os';
+import { join } from 'node:path';
+import { connect as netConnect } from 'node:net';
+
+import { bindH2cUds } from '../h2c-uds.js';
+import type { BoundTransport } from '../types.js';
+
+const isWin = platform() === 'win32';
+const describePosix = isWin ? describe.skip : describe;
+
+let bound: BoundTransport | null = null;
+let h2client: ClientHttp2Session | null = null;
+
+afterEach(async () => {
+  if (h2client) {
+    h2client.destroy();
+    h2client = null;
+  }
+  if (bound) {
+    await bound.close();
+    bound = null;
+  }
+});
+
+function freshSocketPath(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'ccsm-h2c-uds-'));
+  return join(dir, 'daemon.sock');
+}
+
+describePosix('bindH2cUds (POSIX)', () => {
+  it('binds an http2 server to a UDS path and surfaces it via address()', async () => {
+    const server = createServer();
+    const path = freshSocketPath();
+    bound = await bindH2cUds(server, { path });
+    const addr = bound.address();
+    expect(addr).toEqual({ kind: 'uds', path });
+    expect(existsSync(path)).toBe(true);
+  });
+
+  it('serves an end-to-end h2c request over UDS', async () => {
+    const server = createServer();
+    server.on('stream', (stream, headers) => {
+      if (headers[':path'] === '/ping') {
+        stream.respond({ ':status': 200 });
+        stream.end('pong');
+      } else {
+        stream.respond({ ':status': 404 });
+        stream.end();
+      }
+    });
+    const path = freshSocketPath();
+    bound = await bindH2cUds(server, { path });
+
+    h2client = h2connect('http://localhost', {
+      createConnection: () => netConnect(path),
+    });
+    const body = await new Promise<string>((resolve, reject) => {
+      const req = h2client!.request({ ':path': '/ping' });
+      const chunks: Buffer[] = [];
+      req.on('data', (c: Buffer) => chunks.push(c));
+      req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+      req.on('error', reject);
+      req.end();
+    });
+    expect(body).toBe('pong');
+  });
+
+  it('unlinks a stale socket inode before bind', async () => {
+    const path = freshSocketPath();
+    // Create a server, bind, close (leaves no socket if close cleans up
+    // — but a crashed daemon would leave one; simulate by binding then
+    // killing with a fresh server that we never close).
+    const first = createServer();
+    const firstBound = await bindH2cUds(first, { path });
+    expect(existsSync(path)).toBe(true);
+    // Don't gracefully close first — simulate the inode being left
+    // behind. Forcefully close the underlying server but skip our
+    // adapter's unlink by calling raw close.
+    await new Promise<void>((resolve) => first.close(() => resolve()));
+    // If the platform leaves the inode, our adapter must clean it.
+    // If close() already removed it, recreate to simulate the crash case.
+    if (!existsSync(path)) {
+      writeFileSync(path, ''); // not a socket; should NOT be touched
+      // Our adapter MUST NOT delete a regular file at the bind path —
+      // bind should fail loud (EADDRINUSE / ENOTSOCK).
+      const second = createServer();
+      await expect(bindH2cUds(second, { path })).rejects.toThrow();
+      unlinkSync(path);
+      // Now write a real (fake) socket-like test — we cannot easily
+      // create a UDS inode without binding, so just trust the lstat
+      // check by binding twice in a row through our adapter.
+      const third = createServer();
+      bound = await bindH2cUds(third, { path });
+    } else {
+      // Inode survives. Re-bind via adapter — must succeed by
+      // unlinking the stale socket.
+      const second = createServer();
+      bound = await bindH2cUds(second, { path });
+    }
+    void firstBound;
+    expect(existsSync(path)).toBe(true);
+  });
+
+  it('removes the socket file on close()', async () => {
+    const server = createServer();
+    const path = freshSocketPath();
+    bound = await bindH2cUds(server, { path });
+    expect(existsSync(path)).toBe(true);
+    await bound.close();
+    bound = null;
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it('close() is idempotent', async () => {
+    const server = createServer();
+    const path = freshSocketPath();
+    bound = await bindH2cUds(server, { path });
+    await bound.close();
+    await expect(bound.close()).resolves.toBeUndefined();
+    bound = null;
+  });
+});
+
+describe('bindH2cUds (win32 guard)', () => {
+  it.skipIf(!isWin)('throws synchronously on win32 with a routing-hint message', async () => {
+    const server = createServer();
+    await expect(bindH2cUds(server, { path: '/tmp/should-not-bind' })).rejects.toThrow(
+      /POSIX-only/,
+    );
+  });
+});

--- a/packages/daemon/src/transport/h2-named-pipe.ts
+++ b/packages/daemon/src/transport/h2-named-pipe.ts
@@ -1,0 +1,114 @@
+// h2 over Windows named pipe — spec ch03 §4 option A4.
+//
+// Preferred Listener A transport on Windows when MUST-SPIKE
+// [win-h2-named-pipe] passes (it has — see
+// tools/spike-harness/probes/win-h2-named-pipe). Idiomatic Windows
+// path: `LocalService` daemon binds `\\.\pipe\ccsm-<sid>` with a DACL
+// allowing the per-user Electron to connect, and the per-pipe peer SID
+// (resolved by T1.7 via `ImpersonateNamedPipeClient`) is the authn
+// boundary.
+//
+// Why a `net.Server` bridge instead of `http2.createServer().listen(pipe)`:
+// Node's libuv pipe accept surface yields `net.Socket` Duplexes, but
+// `http2.createServer().listen(pipe)` historically emits stream-state
+// errors on Windows pipes when the peer closes uncleanly (the spike
+// reproduces this). The bridge pattern — dedicate a `net.Server` to
+// the pipe and `emit('connection', socket)` into the http2 server —
+// keeps the http2 layer ignorant of the underlying transport surface,
+// matching spike `win-h2-named-pipe/server.mjs` 1:1.
+//
+// Adapter contract: rejects non-win32 calls (the factory MUST route
+// other OSes to `h2c-uds`). Normalizes the pipe name (accepts bare
+// name, `\\.\pipe\<name>`, or `\\?\pipe\<name>`) to the `\\?\pipe\`
+// form Node + libuv expect.
+//
+// DACL handling: NOT this adapter's job. The factory / installer sets
+// the pipe DACL (T1.4 / T7.5); this adapter is the bind primitive.
+//
+// Layer 1: node: stdlib only (`node:net`, `node:os`).
+
+import { createServer as createNetServer, type Server as NetServer } from 'node:net';
+import { platform } from 'node:os';
+
+import type {
+  BoundAddress,
+  BoundTransport,
+  H2cServer,
+  NamedPipeBindSpec,
+} from './types.js';
+
+/** Normalize a pipe name to `\\?\pipe\<name>`. Accepts bare names and
+ *  the two prefix forms. Per spike `win-h2-named-pipe/server.mjs`. */
+export function normalizePipePath(input: string): string {
+  if (input.startsWith('\\\\?\\pipe\\') || input.startsWith('\\\\.\\pipe\\')) {
+    return input;
+  }
+  return `\\\\?\\pipe\\${input}`;
+}
+
+/**
+ * Bind the supplied http2 server to a Windows named pipe via a
+ * dedicated `net.Server` bridge. Resolves once the bridge is
+ * `listening`.
+ *
+ * Throws synchronously on non-win32 — the factory MUST route to
+ * `bindH2cUds` instead.
+ */
+export async function bindH2NamedPipe(
+  server: H2cServer,
+  spec: NamedPipeBindSpec,
+): Promise<BoundTransport> {
+  if (platform() !== 'win32') {
+    throw new Error(
+      'h2-named-pipe transport is win32-only; POSIX must use h2c-UDS (spec ch03 §4 A1).',
+    );
+  }
+
+  const pipePath = normalizePipePath(spec.pipeName);
+
+  // Bridge: every accepted pipe socket is forwarded to the http2
+  // server as a `connection` event. The http2 server then drives the
+  // SETTINGS frame exchange + multiplexing on the Duplex surface,
+  // identically to the UDS / loopback paths.
+  const bridge: NetServer = createNetServer((sock) => {
+    server.emit('connection', sock);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const onError = (err: Error): void => {
+      bridge.removeListener('listening', onListening);
+      reject(err);
+    };
+    const onListening = (): void => {
+      bridge.removeListener('error', onError);
+      resolve();
+    };
+    bridge.once('error', onError);
+    bridge.once('listening', onListening);
+    bridge.listen(pipePath);
+  });
+
+  const address = (): BoundAddress => ({ kind: 'namedPipe', pipeName: pipePath });
+
+  let closed = false;
+  let closePromise: Promise<void> | null = null;
+  const close = async (): Promise<void> => {
+    if (closed) return closePromise ?? Promise.resolve();
+    closed = true;
+    closePromise = new Promise<void>((resolve, reject) => {
+      // Close the BRIDGE (the only thing we own that holds the pipe
+      // handle). The http2 server was never `listen()`ed directly —
+      // we feed it sockets via `emit('connection')` — so calling
+      // `server.close()` would throw `Server is not running`. The
+      // http2 sessions ride on the bridged Duplex sockets and end
+      // when those sockets end.
+      bridge.close((bridgeErr) => {
+        if (bridgeErr) reject(bridgeErr);
+        else resolve();
+      });
+    });
+    return closePromise;
+  };
+
+  return { address, close };
+}

--- a/packages/daemon/src/transport/h2-tls.ts
+++ b/packages/daemon/src/transport/h2-tls.ts
@@ -1,0 +1,117 @@
+// h2 over loopback TLS — spec ch03 §4 option A3.
+//
+// Last-resort Listener A transport: only used when h2c is unsupported
+// by a future Connect server pin or when an OS hardens loopback
+// against plaintext h2c. v0.3 ships this adapter so the descriptor
+// writer (T1.6) and the Electron transport factory (T2.x) have the
+// `KIND_TCP_LOOPBACK_H2_TLS` code path exercised by tests, even
+// though no spec'd OS picks it as the default.
+//
+// TLS is "self-signed local cert" per spec ch03 §4 A3 — Electron pins
+// the cert's SHA-256 fingerprint via the descriptor's
+// `tlsCertFingerprintSha256` field (spec ch03 §3.2) rather than
+// trusting any OS root store. The adapter therefore EXPOSES the
+// fingerprint (computed from the supplied cert PEM) as part of
+// `BoundAddress` so the descriptor writer can pin it without re-
+// parsing the cert.
+//
+// Cert provisioning: NOT this adapter's job. The installer / startup
+// code mints + rotates the self-signed cert (spec ch10 §3 referenced
+// from ch03 §4 A3); this adapter is the bind primitive that consumes
+// the resulting PEM bytes.
+//
+// Layer 1: node: stdlib only (`node:crypto`, `node:tls` indirectly via
+// the `Http2SecureServer` the caller built with `http2.createSecureServer`).
+
+import { createHash, X509Certificate } from 'node:crypto';
+
+import type {
+  BoundAddress,
+  BoundTransport,
+  H2TlsServer,
+  TlsBindSpec,
+} from './types.js';
+
+/**
+ * Compute the SHA-256 fingerprint of a PEM-encoded X.509 cert as a
+ * lowercase hex string with no separators (matches the descriptor
+ * field's contract — spec ch03 §3.2).
+ *
+ * Fingerprint is over the DER-encoded cert (the standard cert pinning
+ * input), not the PEM bytes — `X509Certificate.raw` is the DER form.
+ */
+export function computeCertFingerprint(certPem: string | Buffer): string {
+  // X509Certificate accepts PEM or DER; `.raw` always returns DER.
+  const cert = new X509Certificate(certPem);
+  return createHash('sha256').update(cert.raw).digest('hex');
+}
+
+/**
+ * Bind the supplied http2 secure server to `spec.host:spec.port`.
+ * Resolves once `listening` fires.
+ *
+ * The cert + key supplied via `spec` are assumed to already be installed
+ * on the server (the caller built the `Http2SecureServer` with them).
+ * We re-derive the fingerprint here from `spec.cert` so the
+ * `BoundAddress.certFingerprintSha256` reflects the actual cert in use
+ * — there is no ambient API on `Http2SecureServer` to read the bound
+ * cert back, and inferring it via TLS-context introspection is brittle.
+ */
+export async function bindH2Tls(
+  server: H2TlsServer,
+  spec: TlsBindSpec,
+): Promise<BoundTransport> {
+  if (spec.host !== '127.0.0.1') {
+    throw new Error(
+      `h2-TLS host MUST be 127.0.0.1 (got ${String(spec.host)}); spec ch03 §1a closed enum.`,
+    );
+  }
+  if (!Number.isInteger(spec.port) || spec.port < 0 || spec.port > 65535) {
+    throw new Error(`h2-TLS port out of range: ${spec.port}`);
+  }
+
+  const fingerprint = computeCertFingerprint(spec.cert);
+
+  await new Promise<void>((resolve, reject) => {
+    const onError = (err: Error): void => {
+      server.removeListener('listening', onListening);
+      reject(err);
+    };
+    const onListening = (): void => {
+      server.removeListener('error', onError);
+      resolve();
+    };
+    server.once('error', onError);
+    server.once('listening', onListening);
+    server.listen({ host: spec.host, port: spec.port });
+  });
+
+  const addr = server.address();
+  if (addr === null || typeof addr === 'string') {
+    throw new Error('http2 secure server.address() returned unexpected shape after listen');
+  }
+  const boundPort = addr.port;
+
+  const address = (): BoundAddress => ({
+    kind: 'tls',
+    host: '127.0.0.1',
+    port: boundPort,
+    certFingerprintSha256: fingerprint,
+  });
+
+  let closed = false;
+  let closePromise: Promise<void> | null = null;
+  const close = async (): Promise<void> => {
+    if (closed) return closePromise ?? Promise.resolve();
+    closed = true;
+    closePromise = new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+    return closePromise;
+  };
+
+  return { address, close };
+}

--- a/packages/daemon/src/transport/h2c-loopback.ts
+++ b/packages/daemon/src/transport/h2c-loopback.ts
@@ -1,0 +1,97 @@
+// h2c over loopback TCP — spec ch03 §4 option A2.
+//
+// Default Listener A transport for win32 if the named-pipe spike (A4)
+// fails, and the universal fallback for darwin / linux if the UDS
+// spike (A1) regresses. Plaintext h2c on `127.0.0.1` is safe-ish
+// against remote attackers (loopback is not routable) but DNS
+// rebinding is a hazard for browser clients — the daemon mitigates by
+// checking peer-cred (T1.7) on every accepted connection, not by
+// trusting the loopback address.
+//
+// Spike reference: tools/spike-harness/probes/loopback-h2c-on-25h2 —
+// confirmed Win 11 25H2 + Defender Firewall accept loopback h2c with
+// no third-party LSP intercept. This adapter mirrors the spike's
+// `server.mjs`: bind to `127.0.0.1`, port `0` for ephemeral, surface
+// the kernel-assigned port via `address()`.
+//
+// Adapter contract: synchronous-throw on missing host enforcement
+// (MUST be `127.0.0.1` — see types.ts), then async listen. The
+// `BoundTransport.address()` reflects the RESOLVED port (post-listen),
+// not the requested port — the descriptor writer (T1.6) consumes this
+// to populate `listener-a.json` with the actual bound port.
+//
+// Layer 1: node: stdlib only (`node:net`-derived `address()` parsing).
+
+import type {
+  BoundAddress,
+  BoundTransport,
+  H2cServer,
+  LoopbackBindSpec,
+} from './types.js';
+
+/**
+ * Bind the supplied http2 server to `spec.host:spec.port`. Resolves
+ * once `listening` fires; the resolved address (with kernel-assigned
+ * port if `spec.port === 0`) is captured for `address()`.
+ */
+export async function bindH2cLoopback(
+  server: H2cServer,
+  spec: LoopbackBindSpec,
+): Promise<BoundTransport> {
+  // Defensive: the type system already constrains host to '127.0.0.1'
+  // but adapters are an OS boundary so we re-check at runtime.
+  if (spec.host !== '127.0.0.1') {
+    throw new Error(
+      `h2c-loopback host MUST be 127.0.0.1 (got ${String(spec.host)}); spec ch03 §1a closed enum.`,
+    );
+  }
+  if (!Number.isInteger(spec.port) || spec.port < 0 || spec.port > 65535) {
+    throw new Error(`h2c-loopback port out of range: ${spec.port}`);
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const onError = (err: Error): void => {
+      server.removeListener('listening', onListening);
+      reject(err);
+    };
+    const onListening = (): void => {
+      server.removeListener('error', onError);
+      resolve();
+    };
+    server.once('error', onError);
+    server.once('listening', onListening);
+    server.listen({ host: spec.host, port: spec.port });
+  });
+
+  // Snapshot the address NOW — once the server is listening the
+  // address is stable; reading it lazily from `server.address()` after
+  // close() returns null, which would break observability hooks that
+  // grab `address()` post-close for logging.
+  const addr = server.address();
+  if (addr === null || typeof addr === 'string') {
+    throw new Error('http2 server.address() returned unexpected shape after listen');
+  }
+  const boundPort = addr.port;
+
+  const address = (): BoundAddress => ({
+    kind: 'loopback',
+    host: '127.0.0.1',
+    port: boundPort,
+  });
+
+  let closed = false;
+  let closePromise: Promise<void> | null = null;
+  const close = async (): Promise<void> => {
+    if (closed) return closePromise ?? Promise.resolve();
+    closed = true;
+    closePromise = new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+    return closePromise;
+  };
+
+  return { address, close };
+}

--- a/packages/daemon/src/transport/h2c-uds.ts
+++ b/packages/daemon/src/transport/h2c-uds.ts
@@ -1,0 +1,118 @@
+// h2c over Unix Domain Socket — spec ch03 §4 option A1.
+//
+// Default Listener A transport for darwin / linux when MUST-SPIKE
+// [uds-h2c-on-darwin-and-linux] passes (it has — see
+// tools/spike-harness/probes/uds-h2c). Plaintext h2c is safe over a
+// same-UID UDS because the socket itself is OS-level access-controlled
+// (mode 0660, group `ccsm` / `_ccsm` per spec ch03 §3 / §7); peer-cred
+// (T1.7) is the authn boundary, not TLS.
+//
+// Adapter contract: takes a pre-built `Http2Server` (the listener layer
+// owns server construction + `connectNodeAdapter` wiring), binds it to
+// the supplied UDS path, and returns a `BoundTransport` whose
+// `address()` returns the resolved `kind: 'uds'` shape. `close()` is
+// idempotent and unlinks the socket file on the way out (a stale
+// daemon.sock would block the next boot's bind).
+//
+// Win32 is rejected at runtime — Windows uses the `h2-named-pipe`
+// adapter instead. The factory (T1.4) routes by OS; this adapter
+// throws if called on the wrong platform so a misrouting bug fails
+// loud at boot rather than silently producing an `EAFNOSUPPORT`-style
+// libuv error.
+//
+// Stale-socket policy: if the supplied path already exists as a
+// socket file (residue from a crashed prior boot), we unlink it
+// before bind. This matches the spike (`uds-h2c/server.mjs`) and the
+// LaunchDaemon / systemd convention — the OS supervisor restarts the
+// daemon on crash and the new boot must not be blocked by an
+// orphan inode. We do NOT unlink anything that is NOT a socket
+// (regular files / dirs at the path are a misconfiguration, not
+// recoverable here).
+//
+// Layer 1: node: stdlib only (`node:fs`, `node:net`).
+
+import { existsSync, lstatSync, unlinkSync } from 'node:fs';
+import { platform } from 'node:os';
+
+import type {
+  BoundAddress,
+  BoundTransport,
+  H2cServer,
+  UdsBindSpec,
+} from './types.js';
+
+/**
+ * Bind the supplied http2 server to a UDS at `spec.path`. Resolves once
+ * the underlying `net.Server` is `listening`.
+ *
+ * Throws synchronously on win32 — UDS bind is POSIX-only; the factory
+ * MUST route Windows to `h2-named-pipe` instead.
+ */
+export async function bindH2cUds(
+  server: H2cServer,
+  spec: UdsBindSpec,
+): Promise<BoundTransport> {
+  if (platform() === 'win32') {
+    throw new Error(
+      'h2c-UDS transport is POSIX-only; Windows must use h2-named-pipe (spec ch03 §4 A4).',
+    );
+  }
+
+  // Stale-socket cleanup. lstat (NOT stat) so a symlink to a regular
+  // file does not get clobbered — only an actual socket inode is
+  // removable. Anything else is a misconfiguration that should fail
+  // loud at the listen() call below.
+  if (existsSync(spec.path)) {
+    const st = lstatSync(spec.path);
+    if (st.isSocket()) {
+      unlinkSync(spec.path);
+    }
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const onError = (err: Error): void => {
+      server.removeListener('listening', onListening);
+      reject(err);
+    };
+    const onListening = (): void => {
+      server.removeListener('error', onError);
+      resolve();
+    };
+    server.once('error', onError);
+    server.once('listening', onListening);
+    server.listen(spec.path);
+  });
+
+  let closed = false;
+  let closePromise: Promise<void> | null = null;
+
+  const address = (): BoundAddress => ({ kind: 'uds', path: spec.path });
+
+  const close = async (): Promise<void> => {
+    if (closed) return closePromise ?? Promise.resolve();
+    closed = true;
+    closePromise = new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        // Best-effort socket file cleanup. Spec ch03 §3.1 says orphan
+        // descriptor FILES between boots are normal; that rule is
+        // about `listener-a.json`, not about the socket inode. The
+        // bind path itself we do remove because the next boot's
+        // `bindH2cUds` would otherwise have to detect + unlink it
+        // again — better to leave the FS clean if we shut down
+        // cooperatively.
+        try {
+          if (existsSync(spec.path) && lstatSync(spec.path).isSocket()) {
+            unlinkSync(spec.path);
+          }
+        } catch {
+          /* ignore — close() success is what matters */
+        }
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+    return closePromise;
+  };
+
+  return { address, close };
+}

--- a/packages/daemon/src/transport/index.ts
+++ b/packages/daemon/src/transport/index.ts
@@ -1,0 +1,22 @@
+// HTTP/2 transport adapter barrel — single import surface for the
+// factory (T1.4) and tests. Re-exports the four adapters + their
+// shared types; no runtime logic of its own.
+//
+// Spec ch03 §4 — A1/A2/A3/A4.
+
+export type {
+  BoundAddress,
+  BoundTransport,
+  H2cServer,
+  H2TlsServer,
+  LoopbackBindSpec,
+  NamedPipeBindSpec,
+  TlsBindSpec,
+  TransportAdapter,
+  UdsBindSpec,
+} from './types.js';
+
+export { bindH2cUds } from './h2c-uds.js';
+export { bindH2cLoopback } from './h2c-loopback.js';
+export { bindH2NamedPipe, normalizePipePath } from './h2-named-pipe.js';
+export { bindH2Tls, computeCertFingerprint } from './h2-tls.js';

--- a/packages/daemon/src/transport/types.ts
+++ b/packages/daemon/src/transport/types.ts
@@ -1,0 +1,122 @@
+// HTTP/2 transport adapters — common shape (spec ch03 §4 transport options
+// A1-A4: h2c-UDS / h2c-loopback / h2-named-pipe / h2-TLS).
+//
+// T1.5 scope: pure transport binding adapters. Each adapter takes a
+// pre-built `http2.Http2Server` (or `Http2SecureServer` for TLS) and
+// binds it to an OS-specific socket address. No factory glue lives in
+// this module — the per-OS switch (which adapter to instantiate) lives
+// in T1.4's `makeListenerA` factory, deliberately so that swapping
+// between A1/A2/A3/A4 is a 2-file diff (factory + descriptor writer)
+// per spec ch03 §4 zero-rework rule.
+//
+// SRP: each adapter is a `sink` that wires the server's `connection`
+// event onto a concrete OS socket. No protocol decisions, no auth, no
+// peer-cred resolution — those are the listener's concern (T1.4 / T1.7).
+//
+// Layer 1: node: stdlib only (`node:http2`, `node:net`, `node:tls`,
+// `node:fs`). No third-party transport library — Connect-RPC consumes
+// the resulting `Http2Server` directly via `@connectrpc/connect-node`'s
+// `connectNodeAdapter` (wired by T1.4, not here).
+
+import type { Http2Server, Http2SecureServer } from 'node:http2';
+
+/**
+ * Bind specs — narrow, per-adapter input shapes. Each adapter accepts
+ * exactly one shape; the factory (T1.4) chooses which adapter to call
+ * based on the per-OS BindDescriptor in `DaemonEnv`.
+ *
+ * Shapes mirror the BindDescriptor closed enum (listeners/types.ts) but
+ * are intentionally separate types to keep the transport layer
+ * decoupled from the listener-trait module — adapters here never
+ * import from `../listeners/`.
+ */
+export interface UdsBindSpec {
+  /** Filesystem path of the UDS (e.g. `/run/ccsm/daemon.sock`). */
+  readonly path: string;
+}
+
+export interface LoopbackBindSpec {
+  /** Loopback host. v0.3 always `127.0.0.1`; IPv6 ::1 reserved for v0.4. */
+  readonly host: '127.0.0.1';
+  /** Port number. `0` requests an ephemeral kernel-assigned port. */
+  readonly port: number;
+}
+
+export interface NamedPipeBindSpec {
+  /** Named-pipe path. Bare name (`ccsm-<sid>`) or full
+   *  `\\.\pipe\<name>` / `\\?\pipe\<name>` accepted; adapter normalizes. */
+  readonly pipeName: string;
+}
+
+export interface TlsBindSpec {
+  /** Loopback host. v0.3 always `127.0.0.1`. */
+  readonly host: '127.0.0.1';
+  /** Port number. `0` requests an ephemeral kernel-assigned port. */
+  readonly port: number;
+  /** PEM-encoded server certificate. */
+  readonly cert: string | Buffer;
+  /** PEM-encoded private key. */
+  readonly key: string | Buffer;
+}
+
+/**
+ * Resolved address surface returned by every adapter after `bind()`.
+ *
+ * Discriminated by `kind` so the factory + descriptor writer can pick
+ * the address shape exhaustively. The transport adapter is the SOLE
+ * source of truth for the bound address (loopback ports may be
+ * ephemeral; UDS paths may be canonicalized; TLS exposes the cert
+ * fingerprint for descriptor pinning per spec ch03 §3.2 / §4 A3).
+ */
+export type BoundAddress =
+  | { readonly kind: 'uds'; readonly path: string }
+  | { readonly kind: 'namedPipe'; readonly pipeName: string }
+  | { readonly kind: 'loopback'; readonly host: '127.0.0.1'; readonly port: number }
+  | {
+      readonly kind: 'tls';
+      readonly host: '127.0.0.1';
+      readonly port: number;
+      /** SHA-256 hex fingerprint of the server cert (lowercase, no
+       *  separators). Pinned by Electron per spec ch03 §3.2. */
+      readonly certFingerprintSha256: string;
+    };
+
+/**
+ * The handle a transport adapter returns after a successful `bind()`.
+ *
+ * Lifecycle: `address()` is callable any time after `bind()` resolves;
+ * `close()` is idempotent and resolves once the underlying socket is
+ * fully torn down (both the OS-level listener AND any in-flight
+ * sessions are drained or destroyed). Calling `close()` twice is a
+ * no-op that returns the same Promise.
+ */
+export interface BoundTransport {
+  /** Resolved bind address. Stable for the lifetime of the binding. */
+  address(): BoundAddress;
+  /** Stop accepting new connections; tear down the underlying socket. */
+  close(): Promise<void>;
+}
+
+/**
+ * Adapter contract — every transport variant exports a `bind(server,
+ * spec)` of this exact shape. The factory (T1.4) keys on the OS / spike
+ * outcome to pick which adapter to import.
+ *
+ * The `server` argument is whatever http2 server kind the adapter
+ * accepts — h2c adapters take a plaintext `Http2Server`, the TLS
+ * adapter takes an `Http2SecureServer`. Each adapter's exported
+ * `bind` narrows this generically.
+ */
+export type TransportAdapter<S, Spec> = (
+  server: S,
+  spec: Spec,
+) => Promise<BoundTransport>;
+
+/**
+ * h2c-only server kind — used by UDS / loopback / named-pipe adapters.
+ * Re-exported so the factory has a single import surface.
+ */
+export type H2cServer = Http2Server;
+
+/** TLS server kind — used by the TLS adapter only. */
+export type H2TlsServer = Http2SecureServer;


### PR DESCRIPTION
Task #26 — spec ch03 §4 (transport options A1–A4).

## Summary
Add `packages/daemon/src/transport/` — four uniform-shape HTTP/2 server transport adapters. Each adapter takes a pre-built http2 server and a narrow bind spec and returns a `BoundTransport { address(), close() }`. The per-OS factory switch lives only in T1.4's `makeListenerA` (Task #24) so swapping A1↔A2↔A3↔A4 is a 2-file diff (zero-rework rule, ch15).

Adapters:
- `h2c-uds.ts` — POSIX UDS bind w/ stale-socket cleanup (A1, mac/linux). Reuses `tools/spike-harness/probes/uds-h2c`.
- `h2c-loopback.ts` — `127.0.0.1` ephemeral-port bind (A2, win fallback). Reuses `loopback-h2c-on-25h2`.
- `h2-named-pipe.ts` — Windows named-pipe via `net.Server` bridge (A4, win). Reuses `win-h2-named-pipe`.
- `h2-tls.ts` — loopback TLS + SHA-256 cert fingerprint surfaced via `BoundAddress` (A3, fallback).

Spike code shape preserved 1:1 — the spike-validated wire shape (createServer + listen + connection routing) is what ships, not a re-derivation.

## Scope guardrail
- Stays inside `packages/daemon/src/transport/`.
- Does NOT touch `src/listeners/` (#24 owns) or `src/supervisor/` (#23 owns).
- No factory glue, no descriptor writer, no peer-cred — those are #24 / T1.6 / T1.7.

## Test plan (TDD)
Co-located `src/transport/__tests__/*.spec.ts`. End-to-end h2/h2c handshake against an ephemeral server for each adapter, plus adapter-routing guards (UDS rejects win32, named-pipe rejects POSIX, loopback/TLS reject non-`127.0.0.1`).

Local run on Windows (this PR's runner OS):
```
$ npx vitest run src/transport
 Test Files  4 passed (4)
      Tests  19 passed | 6 skipped (25)
```
6 skips = the POSIX-only UDS specs (skipped via `describe.skip` on win32; the win32-guard test exercises the throw path).

## Pre-existing daemon errors NOT caused by this PR
`npm run typecheck` and `npm test` surface unrelated failures:
- `test/integration/rpc/clients-transport-matrix.spec.ts` references missing `@ccsm/proto` exports (proto codegen artifacts not present in this worktree).
- `src/db/__tests__/sqlite.spec.ts` + `test/sqlite/coalescer.spec.ts` fail with `NODE_MODULE_VERSION` mismatch on `better-sqlite3` (native module ABI vs runner Node).
- `test/descriptor/schema.spec.ts` golden-file mismatch (separate task).

Confirmed pre-existing by stashing and re-running on `origin/working`.

## Layer 1 notes
- Reused existing spike code shapes rather than re-deriving — A1/A2/A4 wire shapes are exactly what passed MUST-SPIKE validation.
- Did not pull in any third-party transport library; node `http2` + `net` + `tls` are sufficient for v0.3 (Connect-RPC consumes the resulting `Http2Server` directly via `@connectrpc/connect-node` in T1.4).
- Did not invent a fingerprint pinning scheme — used Node's `X509Certificate.raw` (DER) + SHA-256, which is the standard pinning input matching the spec ch03 §3.2 descriptor field semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)