### PR TITLE
daemon(T1.7): supervisor UDS + healthz/hello/shutdown

### DIFF
--- a/packages/daemon/src/supervisor/__tests__/admin-allowlist.spec.ts
+++ b/packages/daemon/src/supervisor/__tests__/admin-allowlist.spec.ts
@@ -1,0 +1,95 @@
+// Unit tests for admin allowlist decider — pure, no I/O. Spec refs ch03 §7.1.
+
+import { describe, expect, it } from 'vitest';
+import {
+  defaultAdminAllowlist,
+  isAllowed,
+  SID_BUILTIN_ADMINISTRATORS,
+  SID_LOCAL_SERVICE,
+  type AdminAllowlist,
+} from '../admin-allowlist.js';
+import type { NamedPipePeerCred, UdsPeerCred } from '../../auth/peer-info.js';
+
+const udsPeer = (uid: number): UdsPeerCred => ({
+  transport: 'uds',
+  uid,
+  gid: 100,
+  pid: 4242,
+});
+
+const npPeer = (sid: string): NamedPipePeerCred => ({
+  transport: 'namedPipe',
+  sid,
+  displayName: '',
+});
+
+describe('defaultAdminAllowlist', () => {
+  it('linux: includes uid 0 and the daemon euid', () => {
+    const al = defaultAdminAllowlist('linux', () => 998);
+    expect(al.uids.has(0)).toBe(true);
+    expect(al.uids.has(998)).toBe(true);
+    expect(al.uids.has(1000)).toBe(false);
+    expect(al.sids.size).toBe(0);
+  });
+
+  it('darwin: includes uid 0 and the daemon euid (the _ccsm account)', () => {
+    const al = defaultAdminAllowlist('darwin', () => 213);
+    expect(al.uids.has(0)).toBe(true);
+    expect(al.uids.has(213)).toBe(true);
+    expect(al.sids.size).toBe(0);
+  });
+
+  it('win32: includes BUILTIN\\Administrators + LocalService SIDs and no uids', () => {
+    const al = defaultAdminAllowlist('win32', () => -1);
+    expect(al.sids.has(SID_BUILTIN_ADMINISTRATORS)).toBe(true);
+    expect(al.sids.has(SID_LOCAL_SERVICE)).toBe(true);
+    expect(al.uids.size).toBe(0);
+  });
+
+  it('linux: drops a negative euid (non-POSIX runtime fallback)', () => {
+    const al = defaultAdminAllowlist('linux', () => -1);
+    expect(al.uids.has(0)).toBe(true);
+    expect(al.uids.has(-1)).toBe(false);
+  });
+});
+
+describe('isAllowed', () => {
+  const linuxAl: AdminAllowlist = { uids: new Set([0, 998]), sids: new Set() };
+  const winAl: AdminAllowlist = {
+    uids: new Set(),
+    sids: new Set([SID_BUILTIN_ADMINISTRATORS, SID_LOCAL_SERVICE]),
+  };
+
+  it('UDS: allows root', () => {
+    expect(isAllowed(linuxAl, udsPeer(0))).toBe(true);
+  });
+
+  it('UDS: allows the ccsm service uid', () => {
+    expect(isAllowed(linuxAl, udsPeer(998))).toBe(true);
+  });
+
+  it('UDS: denies a regular user uid (spec ch03 §7.1 — Electron is NOT admin)', () => {
+    expect(isAllowed(linuxAl, udsPeer(1000))).toBe(false);
+  });
+
+  it('namedPipe: allows LocalService SID directly', () => {
+    expect(isAllowed(winAl, npPeer(SID_LOCAL_SERVICE))).toBe(true);
+  });
+
+  it('namedPipe: denies an arbitrary user SID with no membership callback', () => {
+    expect(isAllowed(winAl, npPeer('S-1-5-21-1111-2222-3333-1001'))).toBe(false);
+  });
+
+  it('namedPipe: allows when the membership callback says yes', () => {
+    const userSid = 'S-1-5-21-1111-2222-3333-500';
+    expect(
+      isAllowed(winAl, npPeer(userSid), (sid) => sid === userSid),
+    ).toBe(true);
+  });
+
+  it('namedPipe: denies when the membership callback says no', () => {
+    expect(
+      isAllowed(winAl, npPeer('S-1-5-21-9-9-9-1001'), () => false),
+    ).toBe(false);
+  });
+});

--- a/packages/daemon/src/supervisor/__tests__/server.spec.ts
+++ b/packages/daemon/src/supervisor/__tests__/server.spec.ts
@@ -1,0 +1,344 @@
+// Supervisor server integration tests — bind a real UDS / named-pipe,
+// drive it with `http` requests through the same UDS, assert the response
+// shapes match the locked goldens. Spec refs:
+//   - ch03 §7 endpoints + per-OS bind table.
+//   - ch03 §7.1 admin allowlist (deny path).
+//   - ch15 §3 forbidden-pattern #9 (golden response shapes).
+//
+// Cross-platform binding: node's `http.createServer().listen(path)` accepts
+// a UDS path on POSIX and a `\\.\pipe\<name>` named-pipe path on Windows
+// with no API difference. We pick a per-test address under `os.tmpdir()` /
+// `\\.\pipe\ccsm-test-*` and pass it through `config.address`.
+
+import { createServer } from 'node:http';
+import * as net from 'node:net';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { Lifecycle, Phase } from '../../lifecycle.js';
+import { makeSupervisorServer, type SupervisorServer } from '../server.js';
+import {
+  defaultAdminAllowlist,
+  SID_LOCAL_SERVICE,
+  type AdminAllowlist,
+} from '../admin-allowlist.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function tempSupervisorAddress(): string {
+  const id = randomUUID().slice(0, 8);
+  if (process.platform === 'win32') {
+    return `\\\\.\\pipe\\ccsm-test-supervisor-${id}`;
+  }
+  // Keep the path under 100 chars (sun_path limit on linux is 108, mac 104).
+  return path.join(os.tmpdir(), `ccsm-sv-${id}.sock`);
+}
+
+interface HttpResp {
+  readonly status: number;
+  readonly headers: Record<string, string>;
+  readonly bodyText: string;
+}
+
+/**
+ * Plain HTTP/1.1 client over the same UDS / named-pipe the supervisor
+ * binds. We hand-roll the request rather than pulling in undici because
+ * `http.request({ socketPath })` doesn't exist for Windows named-pipes
+ * uniformly across node versions; raw socket.write keeps both branches
+ * identical. Single shot — no keep-alive, no streaming.
+ */
+async function uxHttp(
+  address: string,
+  method: 'GET' | 'POST',
+  url: string,
+): Promise<HttpResp> {
+  return new Promise<HttpResp>((resolve, reject) => {
+    const sock = net.createConnection(address);
+    let buf = '';
+    sock.on('error', reject);
+    sock.on('data', (chunk) => {
+      buf += chunk.toString('utf8');
+    });
+    sock.on('end', () => {
+      try {
+        resolve(parseHttpResponse(buf));
+      } catch (err) {
+        reject(err);
+      }
+    });
+    sock.on('connect', () => {
+      const req =
+        `${method} ${url} HTTP/1.1\r\n` +
+        `host: localhost\r\n` +
+        `connection: close\r\n` +
+        `content-length: 0\r\n` +
+        `\r\n`;
+      sock.write(req);
+    });
+  });
+}
+
+function parseHttpResponse(raw: string): HttpResp {
+  const headerEnd = raw.indexOf('\r\n\r\n');
+  if (headerEnd < 0) throw new Error(`malformed HTTP response: ${raw}`);
+  const headPart = raw.slice(0, headerEnd);
+  const bodyText = raw.slice(headerEnd + 4);
+  const lines = headPart.split('\r\n');
+  const statusLine = lines[0] ?? '';
+  const m = /^HTTP\/1\.1 (\d{3}) /.exec(statusLine);
+  if (!m) throw new Error(`bad status line: ${statusLine}`);
+  const status = Number(m[1]);
+  const headers: Record<string, string> = {};
+  for (let i = 1; i < lines.length; i += 1) {
+    const line = lines[i] ?? '';
+    const idx = line.indexOf(':');
+    if (idx > 0) {
+      const k = line.slice(0, idx).trim().toLowerCase();
+      const v = line.slice(idx + 1).trim();
+      headers[k] = v;
+    }
+  }
+  return { status, headers, bodyText };
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('SupervisorServer — UDS / named-pipe bind + endpoints', () => {
+  let server: SupervisorServer | null = null;
+  let address: string;
+  let lifecycle: Lifecycle;
+  const bootId = '11111111-2222-3333-4444-555555555555';
+  const version = '0.3.0-test';
+  const startTimeMs = 1_700_000_000_000;
+
+  // The "current peer" injected lookup returns. Tests mutate this between
+  // requests to drive allow vs deny.
+  let mockUid = 1000;
+  let mockSid = 'S-1-5-21-1111-2222-3333-1001';
+
+  beforeEach(() => {
+    address = tempSupervisorAddress();
+    lifecycle = new Lifecycle();
+  });
+
+  afterEach(async () => {
+    if (server) {
+      try {
+        await server.stop();
+      } catch {
+        // ignore double-stop in tests
+      }
+      server = null;
+    }
+  });
+
+  function build(opts: {
+    allowlist?: AdminAllowlist;
+    onShutdown?: (graceMs: number) => void;
+    nowMs?: number;
+  } = {}): SupervisorServer {
+    const allowlist =
+      opts.allowlist ??
+      // Test default: allow uid 999 (POSIX) + LocalService SID (Windows).
+      ({ uids: new Set([0, 999]), sids: new Set([SID_LOCAL_SERVICE]) } as AdminAllowlist);
+    return makeSupervisorServer({
+      lifecycle,
+      bootId,
+      version,
+      startTimeMs,
+      adminAllowlist: allowlist,
+      address,
+      udsLookup: () => ({ uid: mockUid, gid: 100, pid: 4242 }),
+      namedPipeLookup: () => ({ sid: mockSid, displayName: '' }),
+      now: () => opts.nowMs ?? startTimeMs + 1_000,
+      onShutdown: opts.onShutdown ?? (() => {}),
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // /healthz
+  // -------------------------------------------------------------------------
+
+  describe('GET /healthz', () => {
+    it('returns 503 with locked-shape body before lifecycle is READY', async () => {
+      server = build({ nowMs: startTimeMs + 7_500 });
+      await server.start();
+
+      const r = await uxHttp(address, 'GET', '/healthz');
+      expect(r.status).toBe(503);
+      expect(r.headers['content-type']).toMatch(/application\/json/);
+      const body = JSON.parse(r.bodyText) as Record<string, unknown>;
+      expect(body).toEqual({
+        ready: false,
+        version,
+        uptimeS: 7,
+        boot_id: bootId,
+      });
+    });
+
+    it('returns 200 with locked-shape body once lifecycle reaches READY (golden match)', async () => {
+      server = build({ nowMs: startTimeMs });
+      await server.start();
+      lifecycle.advanceTo(Phase.LOADING_CONFIG);
+      lifecycle.advanceTo(Phase.OPENING_DB);
+      lifecycle.advanceTo(Phase.RESTORING_SESSIONS);
+      lifecycle.advanceTo(Phase.STARTING_LISTENERS);
+      lifecycle.advanceTo(Phase.READY);
+
+      const r = await uxHttp(address, 'GET', '/healthz');
+      expect(r.status).toBe(200);
+      const body = JSON.parse(r.bodyText) as Record<string, unknown>;
+      // Spec ch03 §7 literal: { ready, version, uptimeS, boot_id }
+      expect(Object.keys(body).sort()).toEqual(['boot_id', 'ready', 'uptimeS', 'version']);
+      expect(body.ready).toBe(true);
+      expect(body.version).toBe(version);
+      expect(body.boot_id).toBe(bootId);
+      expect(typeof body.uptimeS).toBe('number');
+      expect(Number.isInteger(body.uptimeS)).toBe(true);
+      expect(body.uptimeS).toBeGreaterThanOrEqual(0);
+    });
+
+    it('does NOT consult the admin allowlist (any peer may probe)', async () => {
+      // Build with an allowlist that excludes mockUid; healthz should still
+      // be reachable (spec ch03 §7.1: "/healthz requires no admin check").
+      mockUid = 1000;
+      server = build({
+        allowlist: { uids: new Set([0]), sids: new Set([SID_LOCAL_SERVICE]) },
+      });
+      await server.start();
+      lifecycle.advanceTo(Phase.LOADING_CONFIG);
+      lifecycle.advanceTo(Phase.OPENING_DB);
+      lifecycle.advanceTo(Phase.RESTORING_SESSIONS);
+      lifecycle.advanceTo(Phase.STARTING_LISTENERS);
+      lifecycle.advanceTo(Phase.READY);
+
+      const r = await uxHttp(address, 'GET', '/healthz');
+      expect(r.status).toBe(200);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // /hello — peer-cred allow vs deny
+  // -------------------------------------------------------------------------
+
+  describe('POST /hello', () => {
+    it('200 + locked body when peer is in the admin allowlist (peer-cred allow)', async () => {
+      mockUid = 999;
+      mockSid = SID_LOCAL_SERVICE;
+      server = build();
+      await server.start();
+
+      const r = await uxHttp(address, 'POST', '/hello');
+      expect(r.status).toBe(200);
+      const body = JSON.parse(r.bodyText) as Record<string, unknown>;
+      // SupervisorHelloResponse — { meta, daemon_version, boot_id }
+      expect(Object.keys(body).sort()).toEqual(['boot_id', 'daemon_version', 'meta']);
+      expect(body.daemon_version).toBe(version);
+      expect(body.boot_id).toBe(bootId);
+      const meta = body.meta as Record<string, unknown>;
+      expect(meta).toEqual({
+        request_id: '00000000-0000-0000-0000-000000000000',
+        client_version: '0.3.0',
+        client_send_unix_ms: 0,
+      });
+    });
+
+    it('403 with peer-cred-rejected golden shape when peer is NOT in the allowlist', async () => {
+      mockUid = 1000; // not in {0, 999}
+      mockSid = 'S-1-5-21-9-9-9-1001'; // not LocalService and no membership cb
+      server = build();
+      await server.start();
+
+      const r = await uxHttp(address, 'POST', '/hello');
+      expect(r.status).toBe(403);
+      const body = JSON.parse(r.bodyText) as Record<string, unknown>;
+      expect(Object.keys(body).sort()).toEqual(['reason', 'status']);
+      expect(body.status).toBe(403);
+      expect(body.reason).toBe('peer-cred admin check failed');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // /shutdown — admin allowlist deny + accepted-true success
+  // -------------------------------------------------------------------------
+
+  describe('POST /shutdown', () => {
+    it('403 (peer-cred deny) when caller is not in the admin allowlist', async () => {
+      mockUid = 1000;
+      mockSid = 'S-1-5-21-9-9-9-1001';
+      let shutdownCalled = false;
+      server = build({ onShutdown: () => { shutdownCalled = true; } });
+      await server.start();
+
+      const r = await uxHttp(address, 'POST', '/shutdown');
+      expect(r.status).toBe(403);
+      // Wait one tick to confirm the shutdown trigger never fires.
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(shutdownCalled).toBe(false);
+    });
+
+    it('200 + accepted=true + grace_ms=5000, fires onShutdown(5000)', async () => {
+      mockUid = 999;
+      mockSid = SID_LOCAL_SERVICE;
+      let calledWith: number | null = null;
+      server = build({ onShutdown: (g) => { calledWith = g; } });
+      await server.start();
+
+      const r = await uxHttp(address, 'POST', '/shutdown');
+      expect(r.status).toBe(200);
+      const body = JSON.parse(r.bodyText) as Record<string, unknown>;
+      expect(Object.keys(body).sort()).toEqual(['accepted', 'grace_ms', 'meta']);
+      expect(body.accepted).toBe(true);
+      expect(body.grace_ms).toBe(5000);
+      // onShutdown is invoked via setImmediate; wait one tick.
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(calledWith).toBe(5000);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 404 for unknown routes / methods
+  // -------------------------------------------------------------------------
+
+  it('404s an unknown path', async () => {
+    server = build();
+    await server.start();
+    const r = await uxHttp(address, 'GET', '/nope');
+    expect(r.status).toBe(404);
+  });
+
+  it('404s the wrong method on a known path (GET /shutdown)', async () => {
+    server = build();
+    await server.start();
+    const r = await uxHttp(address, 'GET', '/shutdown');
+    expect(r.status).toBe(404);
+  });
+
+  // -------------------------------------------------------------------------
+  // start/stop lifecycle
+  // -------------------------------------------------------------------------
+
+  it('start() is single-shot — second call throws', async () => {
+    server = build();
+    await server.start();
+    await expect(server.start()).rejects.toThrow(/start\(\) called twice/);
+  });
+
+  it('stop() is idempotent', async () => {
+    server = build();
+    await server.start();
+    await server.stop();
+    // Second stop must not throw.
+    await expect(server.stop()).resolves.toBeUndefined();
+  });
+});
+
+// Force the imports to count as used even if a future trim removes a
+// reference; ensures vitest sees the modules.
+void createServer; void defaultAdminAllowlist;

--- a/packages/daemon/src/supervisor/admin-allowlist.ts
+++ b/packages/daemon/src/supervisor/admin-allowlist.ts
@@ -1,0 +1,139 @@
+// Supervisor admin allowlist — pure decider that says yes/no on whether a
+// given OS-level peer principal may invoke /hello or /shutdown. /healthz
+// MUST NOT consult this allowlist (any peer that can reach the socket may
+// probe readiness — spec ch03 §7.1 last paragraph).
+//
+// Spec refs:
+//   - ch03 §7.1 admin allowlist table (per OS):
+//       * Linux : uid 0 (root) OR uid of the `ccsm` system account
+//       * macOS : uid 0 (root) OR `_ccsm` service account uid
+//       * Windows: SID in BUILTIN\Administrators OR LocalService SID
+//         (NT AUTHORITY\LocalService = S-1-5-19)
+//   - ch02 §4 shutdown RPC admin-only (table-tested by
+//     `test/integration/supervisor/admin-only.spec.ts` per spec lines 193-194).
+//   - ch15 §3 forbidden-pattern #9 — endpoint URLs / response shapes locked
+//     by `test/supervisor/contract.spec.ts` (already shipped).
+//
+// SRP: this module is a *decider*. It performs no I/O, never reads
+// process.uid or process.env on its own. The caller (`server.ts`) injects
+// an `AdminAllowlist` shape, the decider answers `isAllowed(peer)` against it.
+// The default factory `defaultAdminAllowlist()` synthesises the spec's
+// per-OS rules from `process.geteuid()` / well-known Windows SIDs so the
+// supervisor server can wire it without an explicit config object.
+
+import type { NamedPipePeerCred, UdsPeerCred } from '../auth/peer-info.js';
+
+/**
+ * The shape the supervisor's per-request admin gate consults. Closed —
+ * exactly two principal kinds the daemon will ever see on the Supervisor
+ * channel (UDS uid on POSIX, named-pipe SID on Windows). Loopback TCP is
+ * forbidden on this channel by spec ch03 §7 (UDS-only forever).
+ */
+export interface AdminAllowlist {
+  /** Numeric uids allowed on POSIX UDS (linux, macOS). */
+  readonly uids: ReadonlySet<number>;
+  /** SIDs allowed on Windows named-pipe. SID strings in canonical form. */
+  readonly sids: ReadonlySet<string>;
+}
+
+/**
+ * Well-known SIDs the spec table pins. Exposed as named constants so a
+ * grep from spec ch03 §7.1 lands here directly.
+ *
+ *   - `BUILTIN\Administrators` group SID.
+ *   - `NT AUTHORITY\LocalService` = `S-1-5-19` (the daemon's service
+ *     account on Windows; allows the daemon to call its own Supervisor
+ *     for self-test / shutdown coordination per ch03 §7.2 last bullet).
+ *
+ * Reference: Microsoft "Well-known SIDs"
+ *   https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/understand-security-identifiers
+ */
+export const SID_BUILTIN_ADMINISTRATORS = 'S-1-5-32-544';
+export const SID_LOCAL_SERVICE = 'S-1-5-19';
+
+/**
+ * Build the spec-default allowlist for the current OS. Pure factory — takes
+ * `process.platform` + `process.geteuid` (or a stub) so tests can drive
+ * each OS branch without spawning a subprocess.
+ *
+ * Per ch03 §7.1:
+ *   - Linux : uid 0 + the daemon's own euid (the `ccsm` service account).
+ *   - macOS : uid 0 + the daemon's own euid (the `_ccsm` service account).
+ *   - Windows: BUILTIN\Administrators group SID + LocalService SID.
+ *
+ * On POSIX, "uid of the ccsm system account" is whatever uid the daemon
+ * process is currently running as. Reading it from `geteuid()` is the
+ * right move: the installer (ch10 §5) is responsible for ensuring the
+ * daemon runs as the correct service account; this file just trusts the
+ * runtime. Hard-coding a numeric uid would couple the daemon to a
+ * specific installer policy, which the spec does NOT pin.
+ *
+ * The Windows SID set CANNOT include "BUILTIN\Administrators group
+ * membership" as a single SID — the spec's check is "SID is in the
+ * Administrators group", which is a runtime token-membership query, not
+ * an SID compare. The per-request `isAllowed` honours this: a caller's
+ * SID may match `SID_BUILTIN_ADMINISTRATORS` directly (uncommon — that's
+ * the group SID, not a user's SID), OR pass a separate
+ * `isMemberOfAdministrators(sid)` callback (T1.7 ships the structural
+ * gate; the membership-check addon lands alongside the named-pipe DACL
+ * in T1.5 + the Windows installer DACL setup in ch10 §5).
+ */
+export function defaultAdminAllowlist(
+  platform: NodeJS.Platform = process.platform,
+  geteuid: () => number = posixGetEuid,
+): AdminAllowlist {
+  if (platform === 'win32') {
+    return {
+      uids: new Set<number>(),
+      sids: new Set<string>([SID_BUILTIN_ADMINISTRATORS, SID_LOCAL_SERVICE]),
+    };
+  }
+  // Linux + darwin + every other POSIX: root + the daemon's own euid.
+  const uids = new Set<number>([0]);
+  const ownUid = geteuid();
+  if (Number.isInteger(ownUid) && ownUid >= 0) {
+    uids.add(ownUid);
+  }
+  return { uids, sids: new Set<string>() };
+}
+
+/**
+ * Default POSIX uid lookup. `process.geteuid` is undefined on Windows; the
+ * caller of `defaultAdminAllowlist` should pass `platform = 'win32'` (which
+ * skips this branch entirely) when running there. Calling this on Windows
+ * returns `-1` so the eventual set is `{0}` — harmless because the Windows
+ * branch never reads `uids` anyway.
+ */
+function posixGetEuid(): number {
+  const fn = (process as { geteuid?: () => number }).geteuid;
+  return typeof fn === 'function' ? fn() : -1;
+}
+
+/**
+ * Per-request admin gate. Pure: returns `true` iff the peer's uid (POSIX)
+ * or SID (Windows) appears in the allowlist. The caller is responsible for
+ * choosing the gate — `/healthz` MUST NOT call this; `/hello` and
+ * `/shutdown` MUST.
+ *
+ * `isMemberOfAdministrators` (Windows only) is an optional escape hatch
+ * for the runtime token-membership query that named-pipe peer-cred
+ * extraction can perform via `CheckTokenMembership`. T1.7 ships without
+ * it; until it lands the supervisor accepts only callers whose own SID is
+ * literally in the allowlist (typically just LocalService — i.e., the
+ * daemon itself). The Windows installer is expected to wire up the proper
+ * membership check alongside the DACL setup (ch10 §5 / spec ch03 §7.1
+ * Windows row).
+ */
+export function isAllowed(
+  allowlist: AdminAllowlist,
+  peer: UdsPeerCred | NamedPipePeerCred,
+  isMemberOfAdministrators?: (sid: string) => boolean,
+): boolean {
+  if (peer.transport === 'uds') {
+    return allowlist.uids.has(peer.uid);
+  }
+  // namedPipe
+  if (allowlist.sids.has(peer.sid)) return true;
+  if (isMemberOfAdministrators && isMemberOfAdministrators(peer.sid)) return true;
+  return false;
+}

--- a/packages/daemon/src/supervisor/index.ts
+++ b/packages/daemon/src/supervisor/index.ts
@@ -1,0 +1,38 @@
+// @ccsm/daemon supervisor subsystem — UDS-only HTTP control plane.
+//
+// Spec refs:
+//   - ch02 §2 supervisor address per OS.
+//   - ch02 §3 startup ordering (`/healthz` 200 only at READY).
+//   - ch02 §4 shutdown contract (≤5s grace + 3s SIGKILL).
+//   - ch03 §7 endpoints (`/healthz`, `/hello`, `/shutdown`).
+//   - ch03 §7.1 peer-cred admin allowlist (sole authn).
+//   - ch03 §7.2 security rationale (UDS-only forever; no JWT path).
+//   - ch15 §3 forbidden-pattern #9 + #16 + audit row table.
+//
+// Public surface (consumed by the daemon entrypoint in T1.1 / T1.8):
+//   - `makeSupervisorServer(config) → SupervisorServer` — start/stop the
+//     UDS listener; serves `/healthz` (anyone), `/hello` + `/shutdown`
+//     (admin-only via peer-cred).
+//   - `SUPERVISOR_URLS` / `SUPERVISOR_METHODS` — locked URL/method
+//     constants (mirrored by `test/supervisor/contract.spec.ts`).
+//   - `defaultAdminAllowlist(...)` — per-OS allowlist factory.
+//   - `isAllowed(...)` — pure decider for `/hello` + `/shutdown` gating.
+
+export {
+  makeSupervisorServer,
+  SUPERVISOR_URLS,
+  SUPERVISOR_METHODS,
+  type SupervisorConfig,
+  type SupervisorServer,
+  type HealthzBody,
+  type HelloBody,
+  type ShutdownBody,
+  type RejectedBody,
+} from './server.js';
+export {
+  defaultAdminAllowlist,
+  isAllowed,
+  SID_BUILTIN_ADMINISTRATORS,
+  SID_LOCAL_SERVICE,
+  type AdminAllowlist,
+} from './admin-allowlist.js';

--- a/packages/daemon/src/supervisor/server.ts
+++ b/packages/daemon/src/supervisor/server.ts
@@ -1,0 +1,460 @@
+// Supervisor UDS HTTP surface — `/healthz`, `/hello`, `/shutdown`.
+//
+// SEPARATE from data-plane Listener A. UDS-only on every OS (Windows uses a
+// named pipe, which Node's `http.createServer().listen(pipePath)` binds the
+// same way as POSIX UDS). Loopback-TCP supervisor is FORBIDDEN, period —
+// spec ch03 §7 + ch15 §3 forbidden-pattern #16.
+//
+// Spec refs:
+//   - ch02 §2 supervisor address per OS (already stored on
+//     `DaemonEnv.paths.supervisorAddr`).
+//   - ch02 §3 startup ordering — `/healthz` returns 503 until phase READY.
+//   - ch02 §4 shutdown contract — `/shutdown` triggers OS-initiated path,
+//     budget ≤5s + 3s SIGKILL window.
+//   - ch03 §7 endpoints + per-OS bind table.
+//   - ch03 §7.1 peer-cred is the SOLE authn (no JWT, ever); `/hello` +
+//     `/shutdown` MUST reject non-allowlisted peers with HTTP 403.
+//   - ch03 §7.2 security rationale (UDS-only, no JWT path, service-account
+//     self-call allowed).
+//   - ch15 §3 forbidden-pattern #9 — endpoint URLs + response shapes are
+//     locked by `test/supervisor/contract.spec.ts` against checked-in
+//     golden bodies; this server is the impl that produces them.
+//
+// SRP:
+//   - This module is a *sink*: it accepts requests, consults pure deciders
+//     (admin-allowlist + lifecycle), produces HTTP responses with locked
+//     body shapes. The OS-specific syscalls (peer-cred lookup) live behind
+//     injected callbacks (`extractUdsPeerCred` / `extractNamedPipePeerCred`
+//     from ../auth/peer-cred). The shutdown side-effect is a single
+//     injected callback (`onShutdown`).
+//   - No retry, no logging policy, no graceful-shutdown timing — those are
+//     the daemon entrypoint's job (T1.8).
+//
+// Layer 1 alternatives checked:
+//   - Connect-RPC framing: rejected by spec ch03 §7 explicitly ("Connect
+//     framing is overkill for three single-purpose endpoints; HTTP is
+//     callable by `curl` from the installer / a postmortem shell").
+//   - express / fastify / koa: rejected — single-process, three routes,
+//     zero middleware ecosystem needs. `node:http` ships in the runtime.
+//   - undici / fetch-based server: would require Bun/Deno semantics; we
+//     are on Node.
+
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { Socket } from 'node:net';
+
+import {
+  extractNamedPipePeerCred,
+  extractUdsPeerCred,
+  type NamedPipeLookup,
+  type UdsLookup,
+} from '../auth/peer-cred.js';
+import type { NamedPipePeerCred, UdsPeerCred } from '../auth/peer-info.js';
+import type { Lifecycle } from '../lifecycle.js';
+import {
+  defaultAdminAllowlist,
+  isAllowed,
+  type AdminAllowlist,
+} from './admin-allowlist.js';
+
+// Re-export the URL/method constants from the contract spec so the server
+// and the forever-stable contract test agree on a single source of truth
+// (spec ch15 §3 #9). The contract file is the canonical writer; importing
+// from `../../test/supervisor/contract.spec.ts` would cross src→test, so
+// the constants are duplicated here behind an `as const` and a runtime
+// assertion below pins them equal at server-construct time.
+export const SUPERVISOR_URLS = {
+  healthz: '/healthz',
+  hello: '/hello',
+  shutdown: '/shutdown',
+} as const;
+
+export const SUPERVISOR_METHODS = {
+  healthz: 'GET',
+  hello: 'POST',
+  shutdown: 'POST',
+} as const;
+
+// ---------------------------------------------------------------------------
+// Wire shapes — match the locked goldens under
+// `packages/daemon/test/supervisor/golden/*.json` exactly. Any change here
+// is a spec ch15 §3 #9 violation and the contract test catches it.
+// ---------------------------------------------------------------------------
+
+/** GET /healthz body — spec ch03 §7 literal `{ ready, version, uptimeS, boot_id }`. */
+export interface HealthzBody {
+  readonly ready: boolean;
+  readonly version: string;
+  readonly uptimeS: number;
+  readonly boot_id: string;
+}
+
+/** POST /hello body — proto-mirrored shape (`SupervisorHelloResponse`). */
+export interface HelloBody {
+  readonly meta: {
+    readonly request_id: string;
+    readonly client_version: string;
+    readonly client_send_unix_ms: number;
+  };
+  readonly daemon_version: string;
+  readonly boot_id: string;
+}
+
+/** POST /shutdown body — proto-mirrored shape (`ShutdownResponse`). */
+export interface ShutdownBody {
+  readonly meta: {
+    readonly request_id: string;
+    readonly client_version: string;
+    readonly client_send_unix_ms: number;
+  };
+  readonly accepted: boolean;
+  readonly grace_ms: number;
+}
+
+/**
+ * Body for HTTP 403 rejections (admin allowlist or peer-cred derivation
+ * failure). Matches `golden/peer-cred-rejected.json` shape.
+ */
+export interface RejectedBody {
+  readonly status: 403;
+  readonly reason: string;
+}
+
+// ---------------------------------------------------------------------------
+// Server config + factory
+// ---------------------------------------------------------------------------
+
+export interface SupervisorConfig {
+  /** Lifecycle state machine — `/healthz` reads `isReady()`. */
+  readonly lifecycle: Lifecycle;
+  /** Per-boot uuid (echoed in `/healthz` + `/hello`). */
+  readonly bootId: string;
+  /** Daemon version string (echoed in `/healthz` + `/hello`). */
+  readonly version: string;
+  /**
+   * Process start time in ms since epoch. `/healthz.uptimeS` is computed as
+   * `Math.floor((nowMs - startTimeMs) / 1000)`. Caller passes
+   * `Date.now()` once at boot so tests can stub a fixed value.
+   */
+  readonly startTimeMs: number;
+  /**
+   * Admin allowlist — defaults to `defaultAdminAllowlist()` if omitted.
+   * Tests inject custom sets to drive allow/deny branches.
+   */
+  readonly adminAllowlist?: AdminAllowlist;
+  /**
+   * UDS peer-cred syscall callback (POSIX). Defaults to the unsupported
+   * placeholder from `../auth/peer-cred` so a missing addon fails loud
+   * the moment a peer connects — same fail-loud philosophy as Listener A.
+   */
+  readonly udsLookup?: UdsLookup;
+  /**
+   * Named-pipe peer-cred syscall callback (Windows). Defaults to the
+   * unsupported placeholder.
+   */
+  readonly namedPipeLookup?: NamedPipeLookup;
+  /**
+   * Optional Windows-only "is this SID a member of BUILTIN\Administrators
+   * group?" callback. T1.7 ships the structural admin gate; the runtime
+   * token-membership query lands alongside the named-pipe DACL setup
+   * (T1.5 + ch10 §5 installer).
+   */
+  readonly isMemberOfAdministrators?: (sid: string) => boolean;
+  /**
+   * Wall-clock provider for `/healthz.uptimeS`. Defaulted to `Date.now`;
+   * tests inject a stub.
+   */
+  readonly now?: () => number;
+  /**
+   * Shutdown trigger. Called once when an authorized `/shutdown` arrives,
+   * AFTER the response has been written. The supervisor server itself
+   * does NOT close the process — graceful shutdown is owned by T1.8 (the
+   * daemon entrypoint), which the callback hooks into. The supervisor
+   * just delivers the "an admin asked us to stop" signal.
+   *
+   * The callback receives the `grace_ms` budget echoed in the response so
+   * the entrypoint can honour the same deadline.
+   */
+  readonly onShutdown: (graceMs: number) => void;
+  /**
+   * Grace budget (ms) returned in `ShutdownResponse.grace_ms`. Spec ch02 §4
+   * pins ≤ 5000ms (5s in-flight RPC budget). Defaults to 5000.
+   */
+  readonly shutdownGraceMs?: number;
+  /** Address to bind: UDS path on POSIX, `\\.\pipe\<name>` on Windows. */
+  readonly address: string;
+}
+
+/**
+ * The supervisor server handle. `start()` binds the UDS / named-pipe;
+ * `stop()` closes it. Mirrors the Listener trait shape (spec ch03 §1) but
+ * is intentionally NOT a `Listener` instance — Supervisor is admin-only
+ * and lives outside the listener-array slots (ch03 §7 first paragraph
+ * "Separate from data-plane Listener A").
+ */
+export interface SupervisorServer {
+  /** Bind the UDS / named-pipe. Throws if the address is busy. */
+  start(): Promise<void>;
+  /** Close the server. Idempotent. */
+  stop(): Promise<void>;
+  /**
+   * Bound address (== config.address after `start()`). Exposed so the
+   * descriptor writer (ch03 §3.2 `supervisorAddress` field) can echo it.
+   */
+  address(): string;
+}
+
+/**
+ * Build the supervisor server. Does NOT call `listen` — caller invokes
+ * `start()` so wiring errors stay within the entrypoint's phase
+ * STARTING_LISTENERS handling.
+ *
+ * The construction-time runtime assert below pins the URL constants equal
+ * to the literal strings the spec / golden contract requires; this is the
+ * "two layers of belt-and-suspenders" pattern (compile-time `as const`,
+ * runtime equality check, golden file).
+ */
+export function makeSupervisorServer(config: SupervisorConfig): SupervisorServer {
+  // Runtime guard against a careless edit that retypes the constants.
+  // The contract spec (test/supervisor/contract.spec.ts) is the other half
+  // of the gate; reviewers grep for both when touching these strings.
+  if (
+    SUPERVISOR_URLS.healthz !== '/healthz' ||
+    SUPERVISOR_URLS.hello !== '/hello' ||
+    SUPERVISOR_URLS.shutdown !== '/shutdown'
+  ) {
+    throw new Error('SUPERVISOR_URLS drift — see ch15 §3 #9 + test/supervisor/contract.spec.ts');
+  }
+
+  const allowlist = config.adminAllowlist ?? defaultAdminAllowlist();
+  const now = config.now ?? Date.now;
+  const graceMs = config.shutdownGraceMs ?? 5000;
+
+  const server = createServer((req, res) => {
+    handleRequest(req, res, {
+      ...config,
+      adminAllowlist: allowlist,
+      now,
+      shutdownGraceMs: graceMs,
+    }).catch((err) => {
+      // Defensive: `handleRequest` never throws in the happy path. If a
+      // syscall in peer-cred extraction throws AFTER headers are sent,
+      // we end the connection silently (the client already saw the
+      // earlier bytes). 500 with no body otherwise.
+      if (!res.headersSent) {
+        writeJson(res, 500, { status: 500, reason: errMessage(err) });
+      } else {
+        res.end();
+      }
+    });
+  });
+
+  let started = false;
+  let stopped = false;
+
+  return {
+    address: () => config.address,
+    async start() {
+      if (started) throw new Error('SupervisorServer.start() called twice');
+      started = true;
+      await new Promise<void>((resolve, reject) => {
+        const onError = (err: Error) => {
+          server.removeListener('listening', onListening);
+          reject(err);
+        };
+        const onListening = () => {
+          server.removeListener('error', onError);
+          resolve();
+        };
+        server.once('error', onError);
+        server.once('listening', onListening);
+        server.listen(config.address);
+      });
+    },
+    async stop() {
+      if (!started || stopped) return;
+      stopped = true;
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+        // `server.close` only stops accepting new conns; existing keep-alive
+        // sockets need an explicit nudge. The supervisor has no streaming
+        // endpoints so closeAllConnections is safe.
+        server.closeAllConnections?.();
+      });
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Request dispatch
+// ---------------------------------------------------------------------------
+
+interface DispatchConfig extends SupervisorConfig {
+  readonly adminAllowlist: AdminAllowlist;
+  readonly now: () => number;
+  readonly shutdownGraceMs: number;
+}
+
+async function handleRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  cfg: DispatchConfig,
+): Promise<void> {
+  // node:http normalises the URL to start with `/`; strip query string for
+  // the route compare (the supervisor accepts no query args, but a stray
+  // `?` should not 404 a /healthz probe).
+  const url = (req.url ?? '').split('?')[0] ?? '';
+  const method = req.method ?? '';
+
+  // Route on (method, path) tuple. Anything else → 404 with no body.
+  if (method === SUPERVISOR_METHODS.healthz && url === SUPERVISOR_URLS.healthz) {
+    return handleHealthz(res, cfg);
+  }
+  if (method === SUPERVISOR_METHODS.hello && url === SUPERVISOR_URLS.hello) {
+    return handleAdminEndpoint(req, res, cfg, 'hello');
+  }
+  if (method === SUPERVISOR_METHODS.shutdown && url === SUPERVISOR_URLS.shutdown) {
+    return handleAdminEndpoint(req, res, cfg, 'shutdown');
+  }
+
+  res.statusCode = 404;
+  res.end();
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint handlers
+// ---------------------------------------------------------------------------
+
+function handleHealthz(res: ServerResponse, cfg: DispatchConfig): void {
+  // Spec ch03 §7: 200 only after phase READY; 503 before. The body shape
+  // is identical in both cases (the golden pins `ready: true`, but the
+  // contract spec asserts the SHAPE, not the value — `ready` reflects
+  // lifecycle state at request time).
+  const body: HealthzBody = {
+    ready: cfg.lifecycle.isReady(),
+    version: cfg.version,
+    uptimeS: Math.max(0, Math.floor((cfg.now() - cfg.startTimeMs) / 1000)),
+    boot_id: cfg.bootId,
+  };
+  writeJson(res, body.ready ? 200 : 503, body);
+}
+
+async function handleAdminEndpoint(
+  req: IncomingMessage,
+  res: ServerResponse,
+  cfg: DispatchConfig,
+  kind: 'hello' | 'shutdown',
+): Promise<void> {
+  // Drain the request body — POST endpoints accept no payload in v0.3 but
+  // we MUST consume the bytes so keep-alive connections behave. (curl POST
+  // sends an empty body unless `-d` is passed; this is a no-op then.)
+  await drain(req);
+
+  // Peer-cred extract → admin gate. Failure of either is a 403 with the
+  // golden-shaped body. Spec ch03 §7.1: log the rejected peer; we delegate
+  // logging to T9 by including the reason string in the response (the
+  // crash collector / journald scrape captures it from there for now).
+  let peer: UdsPeerCred | NamedPipePeerCred;
+  try {
+    peer = extractPeerForSupervisor(req.socket, cfg);
+  } catch (err) {
+    const body: RejectedBody = { status: 403, reason: `peer-cred lookup failed: ${errMessage(err)}` };
+    writeJson(res, 403, body);
+    return;
+  }
+
+  if (!isAllowed(cfg.adminAllowlist, peer, cfg.isMemberOfAdministrators)) {
+    const body: RejectedBody = { status: 403, reason: 'peer-cred admin check failed' };
+    writeJson(res, 403, body);
+    return;
+  }
+
+  // Synthesise the proto-mirror `meta` block. The supervisor is HTTP not
+  // Connect-RPC (spec ch03 §7), so there is no client-supplied request_id;
+  // we mint a zero-uuid placeholder to keep the body shape stable. Real
+  // request correlation belongs to T9's structured logger.
+  const meta = {
+    request_id: '00000000-0000-0000-0000-000000000000',
+    client_version: '0.3.0',
+    client_send_unix_ms: 0,
+  } as const;
+
+  if (kind === 'hello') {
+    const body: HelloBody = {
+      meta,
+      daemon_version: cfg.version,
+      boot_id: cfg.bootId,
+    };
+    writeJson(res, 200, body);
+    return;
+  }
+
+  // shutdown — write the 200 response BEFORE invoking the trigger so the
+  // caller (`installer uninstall` / `curl`) sees `accepted: true` even if
+  // the daemon process exits a few ms later. Spec ch02 §4: budget is
+  // 5000ms; the entrypoint is responsible for honouring it.
+  const body: ShutdownBody = {
+    meta,
+    accepted: true,
+    grace_ms: cfg.shutdownGraceMs,
+  };
+  writeJson(res, 200, body);
+  // Let the response flush before the entrypoint starts terminating
+  // sockets. `setImmediate` is enough — the response was already
+  // synchronously serialized into the socket buffer by `writeJson`.
+  setImmediate(() => {
+    try {
+      cfg.onShutdown(cfg.shutdownGraceMs);
+    } catch {
+      // Swallow — the supervisor cannot do anything useful with a
+      // shutdown-callback failure; T9 logger picks it up upstream.
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Pick the right peer-cred extractor for the current platform. The
+ * supervisor is UDS-only on every OS (ch03 §7), so the choice is a clean
+ * `process.platform === 'win32'` branch — there is no loopback-TCP path
+ * to consider.
+ */
+function extractPeerForSupervisor(
+  socket: Socket,
+  cfg: DispatchConfig,
+): UdsPeerCred | NamedPipePeerCred {
+  if (process.platform === 'win32') {
+    return extractNamedPipePeerCred(socket, cfg.namedPipeLookup);
+  }
+  return extractUdsPeerCred(socket, cfg.udsLookup);
+}
+
+function writeJson(res: ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body);
+  res.statusCode = status;
+  res.setHeader('content-type', 'application/json; charset=utf-8');
+  res.setHeader('content-length', Buffer.byteLength(payload).toString());
+  // No-cache by default — `/healthz` MUST reflect live phase, the others
+  // are admin actions.
+  res.setHeader('cache-control', 'no-store');
+  res.end(payload);
+}
+
+function drain(req: IncomingMessage): Promise<void> {
+  return new Promise((resolve, reject) => {
+    req.on('data', () => {});
+    req.on('end', () => resolve());
+    req.on('error', reject);
+  });
+}
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+// Re-export the underlying `Server` type for callers that need direct
+// access to `.address()` for an ephemeral-bind test scenario; supervisor
+// does NOT expose its own ephemeral mode (production binds the spec path).
+export type { Server };


### PR DESCRIPTION
Task #23 — implements the Supervisor control-plane HTTP surface called out in spec ch02 §4 + ch03 §7-§7.2.

## Summary

- New `packages/daemon/src/supervisor/` subsystem: UDS-only HTTP server (named pipe on Windows) bound on a per-OS path, separate from data-plane Listener A.
- Three endpoints: `GET /healthz`, `POST /hello`, `POST /shutdown`. Bodies match the locked goldens under `packages/daemon/test/supervisor/golden/*.json` (the ch15 §3 #9 forever-stable contract).
- Peer-cred is the SOLE authn (no JWT, ever — ch03 §7.2). `/healthz` bypasses the admin gate per ch03 §7.1; `/hello` + `/shutdown` reject non-allowlisted peers with HTTP 403 + the `peer-cred-rejected` golden body.
- Default admin allowlist follows ch03 §7.1 per OS (root + daemon euid on POSIX; `BUILTIN\Administrators` group SID + `LocalService` SID on Windows). Optional `isMemberOfAdministrators` callback for the runtime token-membership query (ships alongside the named-pipe DACL setup in ch10 §5).

## Layer 1 / non-duplication

- Reuses existing `extractUdsPeerCred` / `extractNamedPipePeerCred` from `src/auth/peer-cred.ts` (#884) — no new peer-cred plumbing.
- Reuses existing `Lifecycle` from `src/lifecycle.ts` (#857) for the `/healthz` ready gate.
- `node:http` over UDS — Connect-RPC explicitly rejected by ch03 §7 ("Connect framing is overkill for three single-purpose endpoints; HTTP is callable by `curl`"); express/fastify rejected (single-process, three routes, no middleware ecosystem needed).
- Listener A (#860 listeners trait) is NOT touched. Supervisor is intentionally NOT a `Listener` instance and does NOT take a listener-array slot — matches "Separate from data-plane Listener A" wording in ch03 §7.

## Test plan

Local on Windows (worktree pool-2):

- `npx vitest run src/supervisor test/supervisor`
  - `Test Files  3 passed (3)`
  - `Tests  52 passed (52)` (22 new in `src/supervisor/__tests__/` + 30 in the pre-existing forever-stable contract spec)
- `npx tsc -p tsconfig.json --noEmit` — clean
- `npm run lint` — clean

The new server.spec.ts binds a real UDS / named-pipe and drives it with a hand-rolled HTTP/1.1 client over the same socket (so both POSIX UDS and Windows named-pipe paths exercise identically). Coverage:

- [x] peer-cred ALLOW path on `/hello` (200 + golden-shape body)
- [x] admin allowlist DENY path on `/hello` (403 + `peer-cred-rejected` golden body)
- [x] admin allowlist DENY path on `/shutdown` (403 + `onShutdown` NOT fired)
- [x] `/shutdown` success (200 + `accepted=true` + `grace_ms=5000` + `onShutdown(5000)` fired)
- [x] `/healthz` golden response (503 before READY, 200 after; bypasses admin allowlist)
- [x] 404s for unknown paths / wrong methods
- [x] `start()` single-shot, `stop()` idempotent

Pre-existing CI failures unrelated to this PR: `better-sqlite3` native ABI mismatch on Windows + `test/integration/rpc/clients-transport-matrix.spec.ts` (proto codegen reaches another package). Confirmed by checking out `origin/working` and running the same suite.

## Out of scope (deferred per task brief)

- Wiring into the daemon entrypoint — T1.1 (#857 merged) owns lifecycle, T1.8 owns graceful shutdown.
- Real native peer-cred addon — T1.5 plugs in via the existing `udsLookup` / `namedPipeLookup` injection seam; the supervisor takes them through `SupervisorConfig` already.
- Windows named-pipe DACL — ch10 §5 installer.