### PR TITLE
electron(T6.3): typed Connect clients + React Query hook layer

### DIFF
--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -16,7 +16,18 @@
     "build:mac": "electron-builder --mac --config electron-builder.yml",
     "build:linux": "electron-builder --linux --config electron-builder.yml"
   },
+  "dependencies": {
+    "@ccsm/proto": "workspace:*",
+    "@connectrpc/connect": "^2.1.1",
+    "@connectrpc/connect-web": "^2.1.1",
+    "@tanstack/react-query": "^5.62.0",
+    "react": "^18.3.1"
+  },
   "devDependencies": {
-    "electron-builder": "^26.8.1"
+    "@bufbuild/protobuf": "^2.12.0",
+    "@testing-library/react": "^16.1.0",
+    "@types/react": "^18.3.1",
+    "electron-builder": "^26.8.1",
+    "happy-dom": "^15.11.7"
   }
 }

--- a/packages/electron/src/rpc/clients.ts
+++ b/packages/electron/src/rpc/clients.ts
@@ -1,0 +1,99 @@
+// T6.3 — Typed Connect-RPC clients factory.
+//
+// Spec ref: `docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md`
+// chapter 08 §5 step 2a + §6.2.
+//
+// Single responsibility: given a Connect `Transport`, produce one typed
+// Connect-ES client per service exported from `@ccsm/proto`. Nothing in this
+// file constructs a transport — that lives in `packages/electron/src/main/`
+// (T6.2 transport-bridge wires the loopback http2 endpoint; the renderer
+// builds a `connect-web` transport against the bridge URL it pulls from
+// `app://ccsm/listener-descriptor.json`). Keeping construction out of this
+// module is the seam that lets v0.4 web/iOS reuse the SAME hook layer
+// (`queries.ts`) over a different transport without touching this file.
+//
+// The seven services come from spec ch04 §1 / @ccsm/proto README — every
+// service the v0.3 daemon ships. New RPCs land additively in their existing
+// service per ch04 §8: this factory automatically picks them up because it
+// only references the `*Service` GenService descriptor; method-level surface
+// is generated, not enumerated here.
+//
+// Cross-package boundary: `@ccsm/electron` imports the public surface of
+// `@ccsm/proto` (which re-exports `gen/ts/ccsm/v1/*_pb.js`). The eslint rule
+// in `packages/electron/eslint.config.js` forbids importing
+// `@ccsm/proto/src/*` directly — we use the package export only.
+
+import { createClient, type Client, type Transport } from '@connectrpc/connect';
+import {
+  CrashService,
+  DraftService,
+  NotifyService,
+  PtyService,
+  SessionService,
+  SettingsService,
+  SupervisorService,
+} from '@ccsm/proto';
+
+/**
+ * Bundle of typed clients for every service in `@ccsm/proto`. Field names
+ * mirror the lower-camel form of each service so consumers read naturally
+ * (`clients.session.listSessions(...)`).
+ *
+ * The shape is forever-stable per ch08 §6.2: v0.4 web/iOS clients share or
+ * duplicate this surface; either is fine because the named services are the
+ * coupling point. Adding a NEW service in v0.4 is an additive field on this
+ * record — existing call sites keep typechecking.
+ */
+export interface CcsmClients {
+  readonly session: Client<typeof SessionService>;
+  readonly pty: Client<typeof PtyService>;
+  readonly crash: Client<typeof CrashService>;
+  readonly settings: Client<typeof SettingsService>;
+  readonly notify: Client<typeof NotifyService>;
+  readonly draft: Client<typeof DraftService>;
+  readonly supervisor: Client<typeof SupervisorService>;
+}
+
+/**
+ * Build a typed Connect client per service against a single shared
+ * `Transport`. The returned object is plain — no caching, no lazy init,
+ * because `createClient` is itself a thin wrapper that only stores the
+ * descriptor + transport. Callers that need to swap the transport (e.g.,
+ * the renderer's reconnect path after a `Hello` failure) build a new
+ * bundle; the cost is negligible.
+ *
+ * @param transport — Connect `Transport` instance constructed by the caller.
+ *                    Renderer (Electron v0.3): `connect-web`'s
+ *                    `createConnectTransport({ baseUrl: bridgeUrl })`.
+ *                    Tests: any `Transport` impl (the included unit test
+ *                    uses a synthetic transport that records calls).
+ */
+export function createClients(transport: Transport): CcsmClients {
+  return {
+    session: createClient(SessionService, transport),
+    pty: createClient(PtyService, transport),
+    crash: createClient(CrashService, transport),
+    settings: createClient(SettingsService, transport),
+    notify: createClient(NotifyService, transport),
+    draft: createClient(DraftService, transport),
+    supervisor: createClient(SupervisorService, transport),
+  };
+}
+
+/**
+ * Re-export the service descriptors so callers that need raw access (e.g.,
+ * the hook layer in `queries.ts` for cache-key derivation) can import from
+ * one place rather than reaching back into `@ccsm/proto` directly. Also
+ * lets the eslint boundary rule keep `@ccsm/proto` as the only sanctioned
+ * proto entrypoint — downstream code only imports `./clients` / `./queries`.
+ */
+export {
+  CrashService,
+  DraftService,
+  NotifyService,
+  PtyService,
+  SessionService,
+  SettingsService,
+  SupervisorService,
+};
+export type { Client, Transport };

--- a/packages/electron/src/rpc/queries.ts
+++ b/packages/electron/src/rpc/queries.ts
@@ -1,0 +1,532 @@
+// T6.3 — React Query hook layer over Connect-ES clients.
+//
+// Spec ref: `docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md`
+// chapter 08 §6.2 ("React Query renderer state layer").
+//
+// Forever-stable surface (per ch08 §6.2 + ch15 §3 zero-rework):
+//   - Unary RPCs:          `use<MethodName>(input?, options?)`         → useQuery-shaped result
+//   - Server-stream RPCs:  `useWatch<MethodName>(input?, options?)`    → same {data, error, isPending} shape
+//   - Mutations:           `use<MethodName>Mutation(options?)`         → useMutation-shaped result
+//
+// All hooks return the canonical React Query result shape so v0.4 web/iOS
+// can mechanically port. v0.4 web client may either move this file to
+// `packages/shared-renderer/` (additive) or duplicate it; either is fine
+// because the abstraction shape is locked. v0.4 iOS uses native SwiftUI
+// state but maps "one hook per RPC" to a parallel Swift module.
+//
+// Implementation strategy:
+//   - Two small generic factories (`makeUnaryHook`, `makeWatchHook`) build
+//     hooks from a `(clients, input) => Promise|AsyncIterable` selector.
+//     This avoids 30+ near-identical hook bodies AND keeps every RPC strongly
+//     typed end-to-end (selector inference flows the message types from
+//     `@ccsm/proto` through to the hook return).
+//   - A `<ClientsProvider>` injects the typed clients bundle into context.
+//     Hooks read it via `useClients()`. Tests can mock by wrapping with a
+//     custom provider (no module-level singletons — multi-instance Electron
+//     windows / web tabs / iOS scenes each get their own clients).
+//   - Cache keys are derived as `[serviceName, methodName, input]` — same
+//     shape across all hooks so devtools / cache invalidation stay uniform.
+//
+// What this file deliberately does NOT do:
+//   - Construct a `Transport` (lives in main per ch08 §4.2 / T6.2).
+//   - Build the `QueryClient` instance (the renderer entry wires that once).
+//   - Implement reconnect/backoff (ch08 §6 has the locked schedule; React
+//     Query's `retry` + `retryDelay` express it; specifics land at the boot
+//     wiring site so the policy is tunable per-environment).
+//   - Wrap `Hello` boot-time verification (T6.6 boot wiring owns it; the
+//     unary hook surface is reused there).
+
+import * as React from 'react';
+import {
+  useMutation,
+  useQuery,
+  type UseMutationOptions,
+  type UseMutationResult,
+  type UseQueryOptions,
+  type UseQueryResult,
+} from '@tanstack/react-query';
+
+import {
+  CrashService,
+  DraftService,
+  NotifyService,
+  PtyService,
+  SessionService,
+  SettingsService,
+  SupervisorService,
+  type CcsmClients,
+} from './clients.js';
+
+// ---------------------------------------------------------------------------
+// Context — clients DI
+// ---------------------------------------------------------------------------
+
+const ClientsContext = React.createContext<CcsmClients | null>(null);
+
+/**
+ * Provider that injects a `CcsmClients` bundle (built once at boot from the
+ * descriptor + transport). Wrap the renderer tree with one of these inside
+ * `<QueryClientProvider>`. Tests pass a synthetic bundle here.
+ */
+export function ClientsProvider(props: {
+  readonly clients: CcsmClients;
+  readonly children?: React.ReactNode;
+}): React.ReactElement {
+  return React.createElement(
+    ClientsContext.Provider,
+    { value: props.clients },
+    props.children,
+  );
+}
+
+/**
+ * Read the clients bundle from context. Throws if no provider is mounted —
+ * a missing provider is a programming error (you forgot to wrap the tree),
+ * not a runtime condition to swallow.
+ */
+export function useClients(): CcsmClients {
+  const ctx = React.useContext(ClientsContext);
+  if (ctx === null) {
+    throw new Error(
+      '[ccsm/rpc/queries] useClients() called outside <ClientsProvider>; ' +
+        'wrap the renderer tree with <ClientsProvider clients={createClients(transport)}> ' +
+        'inside <QueryClientProvider>.',
+    );
+  }
+  return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Cache-key shape — uniform across all hooks
+// ---------------------------------------------------------------------------
+
+/**
+ * Cache key shape: `['ccsm', serviceName, methodName, input?]`. Uniform so
+ * React Query devtools group by service, and so callers can invalidate all
+ * queries for a service via `queryClient.invalidateQueries({ queryKey: ['ccsm', 'session'] })`.
+ *
+ * The `input` slot is the request message (or the explicit `null` sentinel
+ * when an RPC takes no meaningful input — empty-message RPCs still serialize
+ * to `{}` so the key is stable across calls).
+ */
+export type CcsmQueryKey = readonly [
+  'ccsm',
+  serviceName: string,
+  methodName: string,
+  input: unknown,
+];
+
+export function buildCcsmQueryKey(
+  serviceName: string,
+  methodName: string,
+  input: unknown,
+): CcsmQueryKey {
+  // Normalize undefined → null so JSON.stringify-based key equality matches.
+  return ['ccsm', serviceName, methodName, input ?? null];
+}
+
+// ---------------------------------------------------------------------------
+// Generic factories
+// ---------------------------------------------------------------------------
+
+/**
+ * Selector type: pulls a unary client method and invokes it. Generic over
+ * the input/output message shapes so each hook keeps its proto-derived
+ * types end-to-end without manual annotation.
+ */
+type UnarySelector<TInput, TOutput> = (
+  clients: CcsmClients,
+  input: TInput,
+  signal: globalThis.AbortSignal,
+) => Promise<TOutput>;
+
+/**
+ * Build a typed `useFoo(input, options)` hook from a unary selector. The
+ * caller supplies the service + method names (used for the cache key) and
+ * the selector closure. Type inference flows: `(input) => clients.session.listSessions(input)`
+ * yields `useListSessions(input): UseQueryResult<ListSessionsResponse, ConnectError>`
+ * with no further annotation.
+ */
+export function makeUnaryHook<TInput, TOutput>(
+  serviceName: string,
+  methodName: string,
+  selector: UnarySelector<TInput, TOutput>,
+): (
+  input: TInput,
+  options?: Omit<
+    UseQueryOptions<TOutput, Error, TOutput, CcsmQueryKey>,
+    'queryKey' | 'queryFn'
+  >,
+) => UseQueryResult<TOutput, Error> {
+  return function useUnary(input, options) {
+    const clients = useClients();
+    return useQuery<TOutput, Error, TOutput, CcsmQueryKey>({
+      queryKey: buildCcsmQueryKey(serviceName, methodName, input),
+      queryFn: ({ signal }) => selector(clients, input, signal),
+      ...options,
+    });
+  };
+}
+
+/**
+ * Mutation factory — same selector signature, returns a `useMutation` hook.
+ * Used for write RPCs where the caller drives invocation imperatively
+ * (e.g., `useRenameSessionMutation().mutate({ sessionId, name })`).
+ */
+type MutationSelector<TInput, TOutput> = (
+  clients: CcsmClients,
+  input: TInput,
+) => Promise<TOutput>;
+
+export function makeMutationHook<TInput, TOutput>(
+  selector: MutationSelector<TInput, TOutput>,
+): (
+  options?: UseMutationOptions<TOutput, Error, TInput>,
+) => UseMutationResult<TOutput, Error, TInput> {
+  return function useMutationHook(options) {
+    const clients = useClients();
+    return useMutation<TOutput, Error, TInput>({
+      mutationFn: (input) => selector(clients, input),
+      ...options,
+    });
+  };
+}
+
+/**
+ * Server-stream selector: returns the AsyncIterable directly from the proto
+ * client (Connect-ES v2 server-stream methods return `AsyncIterable<Out>`).
+ */
+type WatchSelector<TInput, TOutput> = (
+  clients: CcsmClients,
+  input: TInput,
+  signal: globalThis.AbortSignal,
+) => AsyncIterable<TOutput>;
+
+/**
+ * Build a typed `useWatchFoo(input, options)` hook from a server-stream
+ * selector. Surface-shape parity with unary hooks (`{data, error, isPending}`)
+ * so downstream UI doesn't branch on RPC kind.
+ *
+ * Behaviour:
+ *   - Subscribes on mount via an `AbortController`-backed `for await` loop.
+ *   - Each yielded message replaces `data` (the renderer typically wants
+ *     the latest event; ordered-history needs are met by the server-side
+ *     replay/seq machinery from ch04, not by accumulating events here).
+ *   - On unmount, aborts the controller — Connect cancels the underlying
+ *     stream and the `for await` loop exits cleanly.
+ *   - Any thrown error sets `error` and stops the loop; the caller can
+ *     remount (changing the `enabled` option) to retry. Reconnect/backoff
+ *     policy is enforced at the transport / boot wiring layer (ch08 §6).
+ *
+ * The state shape mirrors `UseQueryResult` minus the React Query-specific
+ * fields that don't apply to a stream (no `refetch`, no `isFetching`).
+ */
+export interface UseWatchResult<TOutput> {
+  readonly data: TOutput | undefined;
+  readonly error: Error | null;
+  readonly isPending: boolean;
+}
+
+export interface UseWatchOptions {
+  /** When false, the hook does not subscribe. Default: true. */
+  readonly enabled?: boolean;
+}
+
+export function makeWatchHook<TInput, TOutput>(
+  // Service / method names are accepted for parity with `makeUnaryHook` and
+  // future cache integration (e.g., pushing events into a query key); the
+  // current implementation does not use them but keeping the signature
+  // uniform avoids a churn at v0.4 hookup time.
+  _serviceName: string,
+  _methodName: string,
+  selector: WatchSelector<TInput, TOutput>,
+): (input: TInput, options?: UseWatchOptions) => UseWatchResult<TOutput> {
+  return function useWatchHook(input, options) {
+    const clients = useClients();
+    const enabled = options?.enabled ?? true;
+    const [data, setData] = React.useState<TOutput | undefined>(undefined);
+    const [error, setError] = React.useState<Error | null>(null);
+    const [isPending, setIsPending] = React.useState<boolean>(enabled);
+
+    // Stable JSON of input for effect dependency — the input object identity
+    // changes every render even when contents don't, and we cannot rely on
+    // structural equality in deps.
+    const inputKey = React.useMemo(() => JSON.stringify(input ?? null), [input]);
+
+    React.useEffect(() => {
+      if (!enabled) {
+        setIsPending(false);
+        return undefined;
+      }
+      let cancelled = false;
+      const controller = new AbortController();
+      setIsPending(true);
+      setError(null);
+
+      (async () => {
+        try {
+          const stream = selector(clients, input, controller.signal);
+          for await (const msg of stream) {
+            if (cancelled) break;
+            setData(msg);
+            setIsPending(false);
+          }
+        } catch (err) {
+          if (cancelled) return;
+          setError(err instanceof Error ? err : new Error(String(err)));
+          setIsPending(false);
+        }
+      })();
+
+      return () => {
+        cancelled = true;
+        controller.abort();
+      };
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [clients, inputKey, enabled]);
+
+    return { data, error, isPending };
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Per-RPC named hooks — one per spec ch08 §6.2
+//
+// Each block groups by service. The factory pattern keeps every hook a
+// one-liner; type inference handles the rest. Adding a new RPC in v0.4 is
+// "add one line below" — the proto regen exposes the method on the client,
+// the selector picks it up, the hook is named per the convention.
+// ---------------------------------------------------------------------------
+
+// --- SessionService ---
+
+export const useHello = makeUnaryHook(
+  'session',
+  'hello',
+  (c, input: Parameters<CcsmClients['session']['hello']>[0], signal) =>
+    c.session.hello(input, { signal }),
+);
+
+export const useListSessions = makeUnaryHook(
+  'session',
+  'listSessions',
+  (c, input: Parameters<CcsmClients['session']['listSessions']>[0], signal) =>
+    c.session.listSessions(input, { signal }),
+);
+
+export const useGetSession = makeUnaryHook(
+  'session',
+  'getSession',
+  (c, input: Parameters<CcsmClients['session']['getSession']>[0], signal) =>
+    c.session.getSession(input, { signal }),
+);
+
+export const useCreateSessionMutation = makeMutationHook(
+  (c, input: Parameters<CcsmClients['session']['createSession']>[0]) =>
+    c.session.createSession(input),
+);
+
+export const useDestroySessionMutation = makeMutationHook(
+  (c, input: Parameters<CcsmClients['session']['destroySession']>[0]) =>
+    c.session.destroySession(input),
+);
+
+export const useWatchSessions = makeWatchHook(
+  'session',
+  'watchSessions',
+  (c, input: Parameters<CcsmClients['session']['watchSessions']>[0], signal) =>
+    c.session.watchSessions(input, { signal }),
+);
+
+export const useRenameSessionMutation = makeMutationHook(
+  (c, input: Parameters<CcsmClients['session']['renameSession']>[0]) =>
+    c.session.renameSession(input),
+);
+
+export const useGetSessionTitle = makeUnaryHook(
+  'session',
+  'getSessionTitle',
+  (c, input: Parameters<CcsmClients['session']['getSessionTitle']>[0], signal) =>
+    c.session.getSessionTitle(input, { signal }),
+);
+
+export const useListProjectSessions = makeUnaryHook(
+  'session',
+  'listProjectSessions',
+  (
+    c,
+    input: Parameters<CcsmClients['session']['listProjectSessions']>[0],
+    signal,
+  ) => c.session.listProjectSessions(input, { signal }),
+);
+
+export const useListImportableSessions = makeUnaryHook(
+  'session',
+  'listImportableSessions',
+  (
+    c,
+    input: Parameters<CcsmClients['session']['listImportableSessions']>[0],
+    signal,
+  ) => c.session.listImportableSessions(input, { signal }),
+);
+
+export const useImportSessionMutation = makeMutationHook(
+  (c, input: Parameters<CcsmClients['session']['importSession']>[0]) =>
+    c.session.importSession(input),
+);
+
+// --- PtyService ---
+//
+// PtyService.Attach is server-stream + carries the snapshot as the first
+// frame (per ch08 §3 mapping for `pty:getBufferSnapshot`). Renderer terminal
+// consumes via `useWatchAttach` and discriminates `frame.kind`.
+
+export const useWatchAttach = makeWatchHook(
+  'pty',
+  'attach',
+  (c, input: Parameters<CcsmClients['pty']['attach']>[0], signal) =>
+    c.pty.attach(input, { signal }),
+);
+
+export const useSendInputMutation = makeMutationHook(
+  (c, input: Parameters<CcsmClients['pty']['sendInput']>[0]) =>
+    c.pty.sendInput(input),
+);
+
+export const useResizeMutation = makeMutationHook(
+  (c, input: Parameters<CcsmClients['pty']['resize']>[0]) =>
+    c.pty.resize(input),
+);
+
+export const useAckPtyMutation = makeMutationHook(
+  (c, input: Parameters<CcsmClients['pty']['ackPty']>[0]) =>
+    c.pty.ackPty(input),
+);
+
+export const useCheckClaudeAvailable = makeUnaryHook(
+  'pty',
+  'checkClaudeAvailable',
+  (
+    c,
+    input: Parameters<CcsmClients['pty']['checkClaudeAvailable']>[0],
+    signal,
+  ) => c.pty.checkClaudeAvailable(input, { signal }),
+);
+
+// --- CrashService ---
+
+export const useGetCrashLog = makeUnaryHook(
+  'crash',
+  'getCrashLog',
+  (c, input: Parameters<CcsmClients['crash']['getCrashLog']>[0], signal) =>
+    c.crash.getCrashLog(input, { signal }),
+);
+
+export const useWatchCrashLog = makeWatchHook(
+  'crash',
+  'watchCrashLog',
+  (c, input: Parameters<CcsmClients['crash']['watchCrashLog']>[0], signal) =>
+    c.crash.watchCrashLog(input, { signal }),
+);
+
+export const useWatchRawCrashLog = makeWatchHook(
+  'crash',
+  'getRawCrashLog',
+  (c, input: Parameters<CcsmClients['crash']['getRawCrashLog']>[0], signal) =>
+    c.crash.getRawCrashLog(input, { signal }),
+);
+
+// --- SettingsService ---
+
+export const useGetSettings = makeUnaryHook(
+  'settings',
+  'getSettings',
+  (c, input: Parameters<CcsmClients['settings']['getSettings']>[0], signal) =>
+    c.settings.getSettings(input, { signal }),
+);
+
+export const useUpdateSettingsMutation = makeMutationHook(
+  (c, input: Parameters<CcsmClients['settings']['updateSettings']>[0]) =>
+    c.settings.updateSettings(input),
+);
+
+// --- NotifyService ---
+
+export const useWatchNotifyEvents = makeWatchHook(
+  'notify',
+  'watchNotifyEvents',
+  (
+    c,
+    input: Parameters<CcsmClients['notify']['watchNotifyEvents']>[0],
+    signal,
+  ) => c.notify.watchNotifyEvents(input, { signal }),
+);
+
+export const useMarkUserInputMutation = makeMutationHook(
+  (c, input: Parameters<CcsmClients['notify']['markUserInput']>[0]) =>
+    c.notify.markUserInput(input),
+);
+
+export const useSetActiveSidMutation = makeMutationHook(
+  (c, input: Parameters<CcsmClients['notify']['setActiveSid']>[0]) =>
+    c.notify.setActiveSid(input),
+);
+
+export const useSetFocusedMutation = makeMutationHook(
+  (c, input: Parameters<CcsmClients['notify']['setFocused']>[0]) =>
+    c.notify.setFocused(input),
+);
+
+// --- DraftService ---
+
+export const useGetDraft = makeUnaryHook(
+  'draft',
+  'getDraft',
+  (c, input: Parameters<CcsmClients['draft']['getDraft']>[0], signal) =>
+    c.draft.getDraft(input, { signal }),
+);
+
+export const useUpdateDraftMutation = makeMutationHook(
+  (c, input: Parameters<CcsmClients['draft']['updateDraft']>[0]) =>
+    c.draft.updateDraft(input),
+);
+
+// --- SupervisorService ---
+
+export const useHealthCheck = makeUnaryHook(
+  'supervisor',
+  'healthCheck',
+  (
+    c,
+    input: Parameters<CcsmClients['supervisor']['healthCheck']>[0],
+    signal,
+  ) => c.supervisor.healthCheck(input, { signal }),
+);
+
+export const useSupervisorHello = makeUnaryHook(
+  'supervisor',
+  'supervisorHello',
+  (
+    c,
+    input: Parameters<CcsmClients['supervisor']['supervisorHello']>[0],
+    signal,
+  ) => c.supervisor.supervisorHello(input, { signal }),
+);
+
+export const useShutdownMutation = makeMutationHook(
+  (c, input: Parameters<CcsmClients['supervisor']['shutdown']>[0]) =>
+    c.supervisor.shutdown(input),
+);
+
+// Service descriptor re-export sentinels keep the eslint-allowed import
+// surface ergonomic for downstream code that needs raw descriptors (e.g.,
+// custom prefetch helpers built outside the hook layer).
+export {
+  CrashService,
+  DraftService,
+  NotifyService,
+  PtyService,
+  SessionService,
+  SettingsService,
+  SupervisorService,
+};

--- a/packages/electron/test/rpc/clients-and-queries.spec.ts
+++ b/packages/electron/test/rpc/clients-and-queries.spec.ts
@@ -1,0 +1,163 @@
+// T6.3 — minimal vitest covering one client + one hook.
+//
+// @vitest-environment happy-dom
+//
+// Why happy-dom (per-spec, not the shared config): the renderHook + React
+// effects path needs a DOM. Other specs in this package are pure-Node
+// (descriptor parsers, e2e drivers) so the per-package vitest.config.ts
+// stays `environment: 'node'` and we opt-in here only.
+//
+// Spec ref: ch08 §5 step 2a/2b + §6.2.
+//
+// Why minimal: the dev-protocol "minimal vitest for one client + one hook"
+// brief — broader coverage lands at T6.6 boot wiring (full RPC integration)
+// and at the e2e gates (ship-gate (b) sigkill-reattach, T8.5 pty-soak).
+// This spec exercises the contract:
+//   1. `createClients(transport)` produces objects whose method calls are
+//      forwarded to the supplied Transport (the Connect descriptor wiring
+//      is correct).
+//   2. `useListSessions()` reads from `<ClientsProvider>` context, calls the
+//      session client, and surfaces the response under React Query's
+//      `data` / `isPending` / `error` shape (the hook surface is wired).
+//
+// Both checks use a synthetic Transport (no real wire, no @ccsm/proto codegen
+// runtime requirement beyond the descriptor). This keeps the test cheap and
+// pure-Node — no electron, no daemon, no jsdom.
+
+import { create } from '@bufbuild/protobuf';
+import { type Transport } from '@connectrpc/connect';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  ListSessionsResponseSchema,
+  SessionService,
+} from '@ccsm/proto';
+import { createClients } from '../../src/rpc/clients.js';
+import { ClientsProvider, useListSessions } from '../../src/rpc/queries.js';
+
+/**
+ * Build a Transport stub whose `unary` returns the supplied response message
+ * for every method, recording each call. Connect-ES v2 routes both service
+ * and method info through the single `method: DescMethodUnary` arg —
+ * `method.parent.typeName` carries the service identity.
+ */
+function makeStubTransport(response: unknown): {
+  transport: Transport;
+  calls: Array<{ service: string; method: string; input: unknown }>;
+} {
+  const calls: Array<{ service: string; method: string; input: unknown }> = [];
+  const transport: Transport = {
+    async unary(method, _signal, _timeoutMs, _header, input, _ctxValues) {
+      calls.push({
+        service: method.parent.typeName,
+        method: method.name,
+        input,
+      });
+      return {
+        service: method.parent,
+        method,
+        stream: false as const,
+        header: new Headers(),
+        message: response as never,
+        trailer: new Headers(),
+      };
+    },
+    async stream() {
+      throw new Error('stream not used in this test');
+    },
+  };
+  return { transport, calls };
+}
+
+describe('createClients', () => {
+  it('produces typed clients that route through the supplied Transport', async () => {
+    const response = create(ListSessionsResponseSchema, { sessions: [] });
+    const { transport, calls } = makeStubTransport(response);
+    const clients = createClients(transport);
+
+    // The bundle is shaped per CcsmClients — every service field is present.
+    expect(typeof clients.session.listSessions).toBe('function');
+    expect(typeof clients.pty.sendInput).toBe('function');
+    expect(typeof clients.crash.getCrashLog).toBe('function');
+    expect(typeof clients.settings.getSettings).toBe('function');
+    expect(typeof clients.notify.markUserInput).toBe('function');
+    expect(typeof clients.draft.getDraft).toBe('function');
+    expect(typeof clients.supervisor.healthCheck).toBe('function');
+
+    // Calling a client method dispatches into the Transport with the right
+    // service+method descriptors — the wiring contract this file owns.
+    const result = await clients.session.listSessions({});
+    expect(result.sessions).toEqual([]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].service).toBe(SessionService.typeName);
+    expect(calls[0].method).toBe('ListSessions');
+  });
+});
+
+describe('useListSessions', () => {
+  it('reads clients from <ClientsProvider> and surfaces the response', async () => {
+    const response = create(ListSessionsResponseSchema, { sessions: [] });
+    const { transport, calls } = makeStubTransport(response);
+    const clients = createClients(transport);
+
+    // Fresh QueryClient per test; disable retries so a hypothetical failure
+    // surfaces immediately instead of looping.
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    function Wrapper({ children }: { children: React.ReactNode }) {
+      return React.createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        React.createElement(
+          ClientsProvider,
+          { clients },
+          children,
+        ),
+      );
+    }
+
+    const { result } = renderHook(() => useListSessions({}), {
+      wrapper: Wrapper,
+    });
+
+    // Initial render — fetch in-flight, no data yet.
+    expect(result.current.isPending).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(false);
+    });
+
+    // Wired correctly: data flows from the stub through the hook surface.
+    expect(result.current.error).toBeNull();
+    expect(result.current.data?.sessions).toEqual([]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('ListSessions');
+  });
+
+  it('throws a clear error when used without <ClientsProvider>', () => {
+    // useClients() (called by useListSessions) should throw with a guidance
+    // message rather than silently returning undefined — a missing provider
+    // is a programming error and we want it to scream.
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    function Wrapper({ children }: { children: React.ReactNode }) {
+      return React.createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        children,
+      );
+    }
+    // React 18 logs the thrown error; silence it for test output cleanliness.
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    expect(() =>
+      renderHook(() => useListSessions({}), { wrapper: Wrapper }),
+    ).toThrow(/ClientsProvider/);
+    errSpy.mockRestore();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,7 +212,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.2))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(happy-dom@15.11.7)(jsdom@29.1.1)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.2))
       wait-on:
         specifier: ^8.0.1
         version: 8.0.5
@@ -258,10 +258,38 @@ importers:
         version: 8.20.0
 
   packages/electron:
+    dependencies:
+      '@ccsm/proto':
+        specifier: workspace:*
+        version: link:../proto
+      '@connectrpc/connect':
+        specifier: ^2.1.1
+        version: 2.1.1(@bufbuild/protobuf@2.12.0)
+      '@connectrpc/connect-web':
+        specifier: ^2.1.1
+        version: 2.1.1(@bufbuild/protobuf@2.12.0)(@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.12.0))
+      '@tanstack/react-query':
+        specifier: ^5.62.0
+        version: 5.100.8(react@18.3.1)
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
     devDependencies:
+      '@bufbuild/protobuf':
+        specifier: ^2.12.0
+        version: 2.12.0
+      '@testing-library/react':
+        specifier: ^16.1.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/react':
+        specifier: ^18.3.1
+        version: 18.3.28
       electron-builder:
         specifier: ^26.8.1
         version: 26.8.1(electron-builder-squirrel-windows@26.8.1)
+      happy-dom:
+        specifier: ^15.11.7
+        version: 15.11.7
 
   packages/proto:
     dependencies:
@@ -467,6 +495,12 @@ packages:
   '@connectrpc/connect-node@2.1.1':
     resolution: {integrity: sha512-s3TfsI1XF+n+1z6MBS9rTnFsxxR4Rw5wmdEnkQINli81ESGxcsfaEet8duzq8LVuuCupmhUsgpRo0Nv9pZkufg==}
     engines: {node: '>=20'}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.7.0
+      '@connectrpc/connect': 2.1.1
+
+  '@connectrpc/connect-web@2.1.1':
+    resolution: {integrity: sha512-J8317Q2MaFRCT1jzVR1o06bZhDIBmU0UAzWx6xOIXzOq8+k71/+k7MUF7AwcBUX+34WIvbm5syRgC5HXQA8fOg==}
     peerDependencies:
       '@bufbuild/protobuf': ^2.7.0
       '@connectrpc/connect': 2.1.1
@@ -1786,6 +1820,14 @@ packages:
   '@tailwindcss/postcss@4.2.4':
     resolution: {integrity: sha512-wgAVj6nUWAolAu8YFvzT2cTBIElWHkjZwFYovF+xsqKsW2ADxM/X2opxj5NsF/qVccAOjRNe8X2IdPzMsWyHTg==}
 
+  '@tanstack/query-core@5.100.8':
+    resolution: {integrity: sha512-ceYwSFOqjPwET5TA6IOYxzxlGc0ekyH/gfOtWkP0PX43rzX9bxW48Iuw8KAduKCToi4rJAQ6nRy2kAe8gszdmg==}
+
+  '@tanstack/react-query@5.100.8':
+    resolution: {integrity: sha512-iNNEekixXU5vtAGKKZX2lx3jTooG5yNY+kv0wSgEdEYG0Mj0JM5bcuQtC35ZAP3nDopT6jciUK3xeX65U7AnfA==}
+    peerDependencies:
+      react: ^18 || ^19
+
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
@@ -2957,6 +2999,10 @@ packages:
   entities@2.2.0:
     resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
 
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
@@ -3396,6 +3442,10 @@ packages:
 
   handle-thing@2.0.1:
     resolution: {integrity: sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==}
+
+  happy-dom@15.11.7:
+    resolution: {integrity: sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==}
+    engines: {node: '>=18.0.0'}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -5458,6 +5508,10 @@ packages:
   wbuf@1.7.3:
     resolution: {integrity: sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==}
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
@@ -5523,6 +5577,10 @@ packages:
   websocket-extensions@0.1.4:
     resolution: {integrity: sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==}
     engines: {node: '>=0.8.0'}
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
 
   whatwg-mimetype@5.0.0:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
@@ -5818,6 +5876,11 @@ snapshots:
       - supports-color
 
   '@connectrpc/connect-node@2.1.1(@bufbuild/protobuf@2.12.0)(@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.12.0))':
+    dependencies:
+      '@bufbuild/protobuf': 2.12.0
+      '@connectrpc/connect': 2.1.1(@bufbuild/protobuf@2.12.0)
+
+  '@connectrpc/connect-web@2.1.1(@bufbuild/protobuf@2.12.0)(@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.12.0))':
     dependencies:
       '@bufbuild/protobuf': 2.12.0
       '@connectrpc/connect': 2.1.1(@bufbuild/protobuf@2.12.0)
@@ -7268,6 +7331,13 @@ snapshots:
       postcss: 8.5.13
       tailwindcss: 4.2.4
 
+  '@tanstack/query-core@5.100.8': {}
+
+  '@tanstack/react-query@5.100.8(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-core': 5.100.8
+      react: 18.3.1
+
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -7619,7 +7689,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.2))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(happy-dom@15.11.7)(jsdom@29.1.1)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.2))
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -8676,6 +8746,8 @@ snapshots:
 
   entities@2.2.0: {}
 
+  entities@4.5.0: {}
+
   entities@8.0.0: {}
 
   env-paths@2.2.1: {}
@@ -9274,6 +9346,12 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   handle-thing@2.0.1: {}
+
+  happy-dom@15.11.7:
+    dependencies:
+      entities: 4.5.0
+      webidl-conversions: 7.0.0
+      whatwg-mimetype: 3.0.0
 
   has-bigints@1.1.0: {}
 
@@ -11329,7 +11407,7 @@ snapshots:
       jiti: 2.6.1
       terser: 5.46.2
 
-  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.2)):
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(happy-dom@15.11.7)(jsdom@29.1.1)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.2)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.2))
@@ -11355,6 +11433,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@types/node': 22.19.17
       '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
+      happy-dom: 15.11.7
       jsdom: 29.1.1
     transitivePeerDependencies:
       - msw
@@ -11383,6 +11462,8 @@ snapshots:
   wbuf@1.7.3:
     dependencies:
       minimalistic-assert: 1.0.1
+
+  webidl-conversions@7.0.0: {}
 
   webidl-conversions@8.0.1: {}
 
@@ -11506,6 +11587,8 @@ snapshots:
       websocket-extensions: 0.1.4
 
   websocket-extensions@0.1.4: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   whatwg-mimetype@5.0.0: {}
 


### PR DESCRIPTION
## Summary

Task #67 — implements ch08 §5 step 2a/2b + §6.2 of the v0.3 daemon-split spec.

- `packages/electron/src/rpc/clients.ts` — `createClients(transport)` factory producing one typed Connect-ES client per service exported from `@ccsm/proto` (session, pty, crash, settings, notify, draft, supervisor — all seven from #869).
- `packages/electron/src/rpc/queries.ts` — forever-stable React Query hook layer per ch08 §6.2:
  - `use<MethodName>(input?, options?)` for unary RPCs
  - `useWatch<MethodName>(input?, options?)` for server-stream RPCs
  - `use<MethodName>Mutation(options?)` for write RPCs
  - Hooks return the canonical React Query result shape so v0.4 web/iOS can mechanically port (either share the file via `packages/shared-renderer/` or duplicate — abstraction is locked).
- `<ClientsProvider>` injects the clients bundle via React context (no module-level singletons; multi-window/tab/scene safe).
- Server-stream hook: subscribes via `AbortController`-backed `for-await` on mount; aborts on unmount; surfaces `{data, error, isPending}` for shape-parity with unary hooks.
- Cache key shape: `['ccsm', serviceName, methodName, input]` uniform across all hooks (devtools grouping + service-level invalidation).

## Boundary discipline (ch11 §5)

- Imports `@ccsm/proto` package surface only — never `@ccsm/proto/src/*` raw protos (eslint-enforced).
- No `@ccsm/daemon` imports.
- No `electron` import — transport is DI'd from main (#68 / T6.2 wires the loopback bridge endpoint).
- No `ipcMain` / `ipcRenderer` / `contextBridge` references — clean against the lint:no-ipc gate.

## Layer 1 notes

- Confirmed #869 (PR merged 2026-05-03) ships all seven `*Service` GenService descriptors via `@ccsm/proto`.
- Confirmed `packages/electron/src/rpc/` does not yet exist (no scope conflict).
- Did NOT touch `packages/electron/src/main/` (#68 owns transport-bridge), `eslint.config.js` (T8.2 merged), or hotfile fields beyond adding missing deps.
- Adopted Connect-ES v2 client API (`createClient(GenService, transport)` — no separate connect-es codegen needed) per `@ccsm/proto/README.md`.
- Generic factory + per-RPC named exports keeps the surface DRY but conformant to spec ("one hook per method, named `useFoo`/`useWatchFoo`").
- React Query 5 (the only version compatible with React 18.3 + the locked `useQuery` shape) — checked: not previously declared in workspace, added under `dependencies`.

## Deps added (none were previously declared)

- dependencies: `@ccsm/proto` (workspace), `@connectrpc/connect`, `@connectrpc/connect-web`, `@tanstack/react-query`, `react`
- devDependencies: `@bufbuild/protobuf`, `@testing-library/react`, `@types/react`, `happy-dom`

## Test

`packages/electron/test/rpc/clients-and-queries.spec.ts` — minimal vitest per dev-protocol "one client + one hook" brief:

1. `createClients` — synthetic Transport records calls; `clients.session.listSessions({})` dispatches with the right service+method descriptors.
2. `useListSessions` — wired through `<ClientsProvider>` + `<QueryClientProvider>`; data flows from stub through hook surface; `isPending` → `false` on completion.
3. `useClients()` outside provider — throws a guidance error (missing-provider is a programming error; must scream rather than return undefined).

## Verification (local)

```
$ pnpm --filter @ccsm/electron test
 Test Files  6 passed (6)
      Tests  53 passed | 2 skipped (55)

$ pnpm --filter @ccsm/electron typecheck
(clean)

$ pnpm -r run typecheck   # proto + daemon + electron
(clean)

$ pnpm exec eslint packages/electron/src packages/electron/test
(clean)
```

## Test plan

- [ ] CI: `pnpm -r run typecheck` green
- [ ] CI: `pnpm --filter @ccsm/electron test` green (3 new + 50 existing pass; 2 skipped pre-existing)
- [ ] CI: `lint:no-ipc` green (no Electron IPC symbols in either new file)
- [ ] Reviewer: confirm hook abstraction shape matches ch08 §6.2 freeze and is ready for v0.4 web/iOS reuse (no Electron-specific assumptions in `queries.ts` / `clients.ts`).
- [ ] Downstream T6.6 boot wiring: construct `connect-web` transport against descriptor's bridge URL, build clients via `createClients(transport)`, wrap renderer tree with `<QueryClientProvider><ClientsProvider clients=...>...`.