### PR TITLE
daemon(T5.4): migration runner + SHA256 lock self-check

### DIFF
--- a/packages/daemon/src/db/__tests__/locked.spec.ts
+++ b/packages/daemon/src/db/__tests__/locked.spec.ts
@@ -1,0 +1,56 @@
+// packages/daemon/src/db/__tests__/locked.spec.ts
+//
+// Unit test for `MIGRATION_LOCKS` (T5.4 / Task #56). Spec ch07 §4.
+//
+// This complements the FOREVER-STABLE test at
+// `packages/daemon/test/db/migration-lock.spec.ts` (which parses locked.ts
+// as text). This co-located spec imports the typed export directly and
+// verifies:
+//   - every entry's SHA256 matches the on-disk file's bytes
+//   - versions are unique and strictly increasing in declaration order
+//   - filenames match the `NNN_<name>.sql` convention from ch07 §4
+
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+import { MIGRATION_LOCKS } from '../locked.js';
+import { migrationFilePath } from '../migrations/runner.js';
+
+describe('MIGRATION_LOCKS (T5.4 — ch07 §4)', () => {
+  it('has at least one entry', () => {
+    expect(MIGRATION_LOCKS.length).toBeGreaterThan(0);
+  });
+
+  it('every recorded SHA256 matches the on-disk file', () => {
+    for (const lock of MIGRATION_LOCKS) {
+      const path = migrationFilePath(lock.filename);
+      const actual = createHash('sha256').update(readFileSync(path)).digest('hex');
+      expect(actual, `SHA256 mismatch for ${lock.filename}`).toBe(lock.sha256);
+    }
+  });
+
+  it('versions are unique and strictly increasing in declaration order', () => {
+    const seen = new Set<number>();
+    let prev = 0;
+    for (const lock of MIGRATION_LOCKS) {
+      expect(seen.has(lock.version), `duplicate version ${lock.version}`).toBe(false);
+      seen.add(lock.version);
+      expect(lock.version).toBeGreaterThan(prev);
+      prev = lock.version;
+    }
+  });
+
+  it('filenames follow the NNN_<name>.sql convention', () => {
+    for (const lock of MIGRATION_LOCKS) {
+      expect(lock.filename).toMatch(/^[0-9]{3}_[A-Za-z0-9_-]+\.sql$/);
+    }
+  });
+
+  it('sha256 entries are 64 lowercase hex chars', () => {
+    for (const lock of MIGRATION_LOCKS) {
+      expect(lock.sha256).toMatch(/^[0-9a-f]{64}$/);
+    }
+  });
+});

--- a/packages/daemon/src/db/locked.ts
+++ b/packages/daemon/src/db/locked.ts
@@ -1,0 +1,67 @@
+// packages/daemon/src/db/locked.ts
+//
+// FOREVER-STABLE per docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+// chapter 07 §4 (migration immutability) + chapter 15 §3 item #4. Runtime
+// self-check side of the two-tier safety net:
+//
+//   - tools/check-migration-locks.sh — compares against the v0.3.0 GitHub
+//     release body (the immutable witness, source of truth).
+//   - this file — the daemon at boot computes SHA256s of bundled migration
+//     files via `runner.ts` and asserts each matches the entry below.
+//     packages/daemon/test/db/migration-lock.spec.ts is the in-process spec
+//     that fails CI before this fails production.
+//
+// Path lives at `src/db/locked.ts` (NOT `src/db/migrations/locked.ts`) to
+// match the path baked into `tools/check-migration-locks.sh` (FOREVER-STABLE
+// from Task #127 / PR #849) and `packages/daemon/test/db/migration-lock.spec.ts`
+// (Task #55). The design doc text in ch07 §4 mentions the migrations/ subpath
+// — that wording is stale; the canonical path is the one CI consumes.
+//
+// Adding a migration:
+//   1. Land the new SQL file under `packages/daemon/src/db/migrations/`.
+//   2. Append a new entry below — version monotonically increases.
+//   3. CI's check-migration-locks.sh ensures locked.ts agrees with the
+//      release body; the runtime self-check ensures bundled SQL agrees with
+//      this file. Both must pass.
+//
+// Editing an existing entry:
+//   - Permitted ONLY before the v0.3.0 tag exists. After tag, every entry
+//     here is frozen forever; a fix is a new migration file with a new row.
+
+/**
+ * One migration's lock metadata. `version` is the integer row written to
+ * `schema_migrations.version` once the file applies cleanly. `filename` is
+ * the basename under `packages/daemon/src/db/migrations/`. `sha256` is the
+ * lowercase hex SHA-256 of the file's bytes (no normalization — exact bytes
+ * including the trailing newline).
+ */
+export interface MigrationLock {
+  readonly version: number;
+  readonly filename: string;
+  readonly sha256: string;
+}
+
+/**
+ * Filename → SHA256 record. Source-of-truth literal — every other shape
+ * exported below is derived from this. The literal-pair form on one line
+ * is REQUIRED by `tools/check-migration-locks.sh` (a regex of the form
+ * `['"]<filename>['"]\s*:\s*['"]<sha>['"]` greps this file). The same form
+ * is required by `packages/daemon/test/db/migration-lock.spec.ts`. Do NOT
+ * reshape into multi-line object literals — that would break both consumers.
+ */
+const MIGRATION_HASHES = {
+  '001_initial.sql': '70838422d5fdc82e39818e8722f365ee789f340951485547545c9de5200a128d',
+} as const;
+
+/**
+ * Ordered list of locked migrations. Iteration order is application order —
+ * the runner walks this list, applies any whose `version` is greater than
+ * the current `schema_migrations.version`, and asserts SHA256 of each
+ * already-applied row matches the entry below.
+ *
+ * Versions are explicit (not derived from filename prefix) so a future
+ * rename / squash never silently shifts a row.
+ */
+export const MIGRATION_LOCKS: readonly MigrationLock[] = [
+  { version: 1, filename: '001_initial.sql', sha256: MIGRATION_HASHES['001_initial.sql'] },
+] as const;

--- a/packages/daemon/src/db/migrations/__tests__/runner.spec.ts
+++ b/packages/daemon/src/db/migrations/__tests__/runner.spec.ts
@@ -1,0 +1,184 @@
+// packages/daemon/src/db/migrations/__tests__/runner.spec.ts
+//
+// Unit tests for the migration runner (T5.4 / Task #56). Spec ch07 §4.
+//
+// Coverage:
+//   - empty DB → applies every lock in MIGRATION_LOCKS, schema_migrations
+//     ends with one row per applied version
+//   - already-applied DB → no rows applied, alreadyApplied list populated
+//   - partial DB (existing rows + a new pending lock) → only the unapplied
+//     row gets inserted; existing rows are NOT re-applied
+//   - SHA256 mismatch on an already-applied row → throws
+//     MigrationLockMismatchError, schema_migrations untouched
+//   - SHA256 mismatch on a pending row → throws BEFORE any SQL exec runs
+
+import { createHash } from 'node:crypto';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { MIGRATION_LOCKS, type MigrationLock } from '../../locked.js';
+import { openDatabase, type SqliteDatabase } from '../../sqlite.js';
+
+import {
+  MigrationLockMismatchError,
+  migrationFilePath,
+  runMigrations,
+} from '../runner.js';
+
+function sha256(path: string): string {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+describe('runMigrations (T5.4 — ch07 §4)', () => {
+  let tmpDir: string;
+  let dbPath: string;
+  let db: SqliteDatabase | null = null;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'ccsm-migration-runner-'));
+    dbPath = join(tmpDir, 'test.db');
+  });
+
+  afterEach(() => {
+    if (db) {
+      try {
+        db.close();
+      } catch {
+        // best-effort
+      }
+      db = null;
+    }
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('applies every lock against an empty database', () => {
+    db = openDatabase(dbPath);
+    const result = runMigrations(db);
+
+    expect(result.applied.map((m) => m.version)).toEqual(MIGRATION_LOCKS.map((m) => m.version));
+    expect(result.alreadyApplied).toEqual([]);
+
+    const rows = db.prepare('SELECT version FROM schema_migrations ORDER BY version').all() as {
+      version: number;
+    }[];
+    expect(rows.map((r) => r.version)).toEqual(MIGRATION_LOCKS.map((m) => m.version));
+  });
+
+  it('is idempotent on a fully-applied database', () => {
+    db = openDatabase(dbPath);
+    runMigrations(db);
+
+    const second = runMigrations(db);
+    expect(second.applied).toEqual([]);
+    expect(second.alreadyApplied.map((m) => m.version)).toEqual(
+      MIGRATION_LOCKS.map((m) => m.version),
+    );
+  });
+
+  it('applies only the pending remainder when partially applied', () => {
+    // Drop a synthetic 999_*.sql into the real migrations dir for the
+    // duration of this test (and remove it in finally). The runner's file
+    // resolver is fixed to that dir, so this is the simplest path to
+    // exercise multi-lock partial-apply semantics without a fixture
+    // injection seam in the runner. Using version 999 avoids any clash
+    // with future real migrations.
+    const realDir = dirname(migrationFilePath('001_initial.sql'));
+    const synthSql = 'CREATE TABLE synth_partial (k INTEGER PRIMARY KEY);\n';
+    const synthPath = join(realDir, '999_synth_partial.sql');
+    const synthSha = createHash('sha256').update(synthSql).digest('hex');
+    writeFileSync(synthPath, synthSql);
+
+    try {
+      db = openDatabase(dbPath);
+      // First call: empty DB, real locks only — applies the real 001.
+      const first = runMigrations(db);
+      expect(first.applied.length).toBe(MIGRATION_LOCKS.length);
+
+      // Second call: extended lock list — runner skips 001 (alreadyApplied)
+      // and applies the synthetic 999.
+      const customLocks: MigrationLock[] = [
+        ...MIGRATION_LOCKS,
+        { version: 999, filename: '999_synth_partial.sql', sha256: synthSha },
+      ];
+      const partial = runMigrations(db, customLocks);
+      expect(partial.alreadyApplied.map((m) => m.version)).toEqual(
+        MIGRATION_LOCKS.map((m) => m.version),
+      );
+      expect(partial.applied.map((m) => m.version)).toEqual([999]);
+
+      const versions = (
+        db.prepare('SELECT version FROM schema_migrations ORDER BY version').all() as {
+          version: number;
+        }[]
+      ).map((r) => r.version);
+      expect(versions).toEqual([...MIGRATION_LOCKS.map((m) => m.version), 999]);
+
+      // Sanity: the synth table exists.
+      const tableRows = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='synth_partial'")
+        .all() as { name: string }[];
+      expect(tableRows.map((r) => r.name)).toEqual(['synth_partial']);
+    } finally {
+      rmSync(synthPath, { force: true });
+    }
+  });
+
+  it('aborts when an already-applied migration on disk has a mismatched SHA256', () => {
+    db = openDatabase(dbPath);
+    runMigrations(db);
+
+    // Swap the lock list to claim a different SHA for the existing 001 row.
+    const tampered: MigrationLock[] = MIGRATION_LOCKS.map((m) => ({
+      ...m,
+      sha256: 'deadbeef'.repeat(8), // 64-char fake hex
+    }));
+
+    expect(() => runMigrations(db!, tampered)).toThrow(MigrationLockMismatchError);
+
+    // schema_migrations rows untouched (no extra inserts, no deletions).
+    const versions = (
+      db.prepare('SELECT version FROM schema_migrations ORDER BY version').all() as {
+        version: number;
+      }[]
+    ).map((r) => r.version);
+    expect(versions).toEqual(MIGRATION_LOCKS.map((m) => m.version));
+  });
+
+  it('aborts BEFORE applying when a pending migration has a mismatched SHA256', () => {
+    db = openDatabase(dbPath);
+
+    const tampered: MigrationLock[] = MIGRATION_LOCKS.map((m) => ({
+      ...m,
+      sha256: '0'.repeat(64),
+    }));
+
+    expect(() => runMigrations(db!, tampered)).toThrow(MigrationLockMismatchError);
+
+    // schema_migrations is created by migration 001 itself, so after a
+    // pending-mismatch abort on a fresh DB the table does not exist yet.
+    const tableExists = db
+      .prepare("SELECT 1 FROM sqlite_master WHERE type='table' AND name='schema_migrations'")
+      .get();
+    expect(tableExists).toBeUndefined();
+  });
+
+  it('error carries filename + expected/actual SHA for log-scrape friendliness', () => {
+    db = openDatabase(dbPath);
+    const tampered: MigrationLock[] = [
+      { version: 1, filename: '001_initial.sql', sha256: 'a'.repeat(64) },
+    ];
+    try {
+      runMigrations(db, tampered);
+      expect.unreachable('runMigrations should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(MigrationLockMismatchError);
+      const e = err as MigrationLockMismatchError;
+      expect(e.filename).toBe('001_initial.sql');
+      expect(e.expectedSha256).toBe('a'.repeat(64));
+      expect(e.actualSha256).toBe(sha256(migrationFilePath('001_initial.sql')));
+    }
+  });
+});

--- a/packages/daemon/src/db/migrations/runner.ts
+++ b/packages/daemon/src/db/migrations/runner.ts
@@ -1,0 +1,174 @@
+// packages/daemon/src/db/migrations/runner.ts
+//
+// Migration runner. Spec ch07 §4 (forward-only migrations + immutability lock).
+//
+// Responsibilities:
+//   1. Ensure `schema_migrations` table exists (bootstrap-safe).
+//   2. SELF-CHECK: for every row already in `schema_migrations`, verify the
+//      bundled file's SHA256 matches the entry in MIGRATION_LOCKS. Mismatch
+//      = abort startup with an explicit error (ch07 §4 immutability lock —
+//      "v0.3 migration files are immutable after v0.3 ships"). The release
+//      body of v0.3.0 is the source of truth (cross-checked in CI by
+//      tools/check-migration-locks.sh); this self-check guards against a
+//      tampered or corrupted bundled file post-install.
+//   3. Determine pending migrations (lock entries whose `version` exceeds
+//      `MAX(schema_migrations.version)`). Apply them in order, each in a
+//      transaction that wraps the SQL exec + `INSERT INTO schema_migrations`
+//      so a partial apply rolls back atomically.
+//
+// Bundled-file resolution: migrations live alongside this file under
+// `packages/daemon/src/db/migrations/`. The runner reads them via
+// `import.meta.url` so a SEA-bundled binary that ships them as snapshot
+// resources still resolves correctly relative to the compiled source.
+//
+// Out of scope here:
+//   - Driver / PRAGMAs (T5.1, packages/daemon/src/db/sqlite.ts).
+//   - WAL discipline / checkpoints (T5.6).
+//   - v0.2 → v0.3 user-data migration (one-shot installer-driven; ch07 §4.5).
+
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { SqliteDatabase } from '../sqlite.js';
+
+import { MIGRATION_LOCKS, type MigrationLock } from '../locked.js';
+
+const MIGRATIONS_DIR = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Result of a single `runMigrations()` call. `applied` lists the migrations
+ * that this call applied (in order). `alreadyApplied` lists the migrations
+ * that were already present in `schema_migrations` and passed the SHA256
+ * self-check. Useful for logging at boot.
+ */
+export interface MigrationRunResult {
+  readonly applied: readonly MigrationLock[];
+  readonly alreadyApplied: readonly MigrationLock[];
+}
+
+/**
+ * Custom error class — thrown when the SHA256 of a bundled migration file
+ * does not match the locked value. Caller (daemon entrypoint) treats this
+ * as a hard startup failure; the daemon must not advance past
+ * `OPENING_DB`. Message format is intentionally explicit (filename,
+ * expected, actual) so the install-log scrape (ch10 §6) surfaces the
+ * exact mismatch without grepping multiple lines.
+ */
+export class MigrationLockMismatchError extends Error {
+  constructor(
+    public readonly filename: string,
+    public readonly expectedSha256: string,
+    public readonly actualSha256: string,
+  ) {
+    super(
+      `migration lock mismatch for ${filename}: expected sha256=${expectedSha256}, actual=${actualSha256}. ` +
+        `This file is FOREVER-STABLE per design ch07 §4; a mismatch means the bundled migration was tampered ` +
+        `with post-build or the lock entry in src/db/locked.ts is wrong. Refuse to boot.`,
+    );
+    this.name = 'MigrationLockMismatchError';
+  }
+}
+
+/**
+ * Resolve the absolute path of a bundled migration file. Exported for tests
+ * (so they can build expected SHAs without re-deriving the directory).
+ */
+export function migrationFilePath(filename: string): string {
+  return join(MIGRATIONS_DIR, filename);
+}
+
+function sha256OfFile(path: string): string {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+function ensureMigrationsTable(_db: SqliteDatabase): void {
+  // Intentional no-op. Migration 001 creates `schema_migrations` itself
+  // (see 001_initial.sql); pre-creating it here would collide with that
+  // CREATE TABLE on a fresh DB. We leave this helper as a named no-op so
+  // any future caller's intent reads correctly. The "is it there?" probe
+  // lives in `readAppliedVersions`.
+  void _db;
+}
+
+interface AppliedRow {
+  version: number;
+}
+
+function readAppliedVersions(db: SqliteDatabase): Set<number> {
+  // The `schema_migrations` table is created by migration 001 itself
+  // (see 001_initial.sql) — we deliberately do NOT pre-create it here, so
+  // that 001 can run its `CREATE TABLE schema_migrations` without a
+  // "table already exists" collision. On a brand-new DB the table is
+  // absent; treat that as "no rows applied".
+  const exists = db
+    .prepare("SELECT 1 FROM sqlite_master WHERE type='table' AND name='schema_migrations'")
+    .get();
+  if (exists === undefined) {
+    return new Set();
+  }
+  const rows = db.prepare('SELECT version FROM schema_migrations').all() as AppliedRow[];
+  return new Set(rows.map((r) => r.version));
+}
+
+/**
+ * Apply all unapplied migrations (in lock order) and verify already-applied
+ * ones against MIGRATION_LOCKS.
+ *
+ * Algorithm:
+ *   1. Ensure `schema_migrations` exists.
+ *   2. Read applied versions.
+ *   3. For each lock in order:
+ *      a. If applied: SHA256-verify the bundled file matches the lock; throw
+ *         MigrationLockMismatchError on mismatch.
+ *      b. If unapplied: read the file, SHA256-verify it matches the lock
+ *         (so we never APPLY a tampered file either), then in a single
+ *         transaction `db.exec(sql)` + INSERT the schema_migrations row.
+ *
+ * A note on transactions: better-sqlite3's `db.transaction(fn)` wraps `fn`
+ * in BEGIN/COMMIT (and ROLLBACK on throw). We use it so a SQL failure mid-
+ * migration leaves `schema_migrations` unchanged — next boot retries from
+ * the same starting point.
+ */
+export function runMigrations(
+  db: SqliteDatabase,
+  locks: readonly MigrationLock[] = MIGRATION_LOCKS,
+): MigrationRunResult {
+  ensureMigrationsTable(db);
+
+  const appliedVersions = readAppliedVersions(db);
+
+  const applied: MigrationLock[] = [];
+  const alreadyApplied: MigrationLock[] = [];
+
+  // Sort defensively in case a future caller hands us an out-of-order list;
+  // the canonical MIGRATION_LOCKS is already version-ordered.
+  const orderedLocks = [...locks].sort((a, b) => a.version - b.version);
+
+  for (const lock of orderedLocks) {
+    const path = migrationFilePath(lock.filename);
+    const actualSha = sha256OfFile(path);
+    if (actualSha !== lock.sha256) {
+      throw new MigrationLockMismatchError(lock.filename, lock.sha256, actualSha);
+    }
+
+    if (appliedVersions.has(lock.version)) {
+      alreadyApplied.push(lock);
+      continue;
+    }
+
+    const sql = readFileSync(path, 'utf8');
+    const apply = db.transaction(() => {
+      db.exec(sql);
+      db.prepare('INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)').run(
+        lock.version,
+        Date.now(),
+      );
+    });
+    apply();
+    applied.push(lock);
+  }
+
+  return { applied, alreadyApplied };
+}

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -11,6 +11,11 @@
 //   - Supervisor /healthz                  → T1.7
 //   - Graceful shutdown                    → T1.8
 
+import { mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import { runMigrations } from './db/migrations/runner.js';
+import { openDatabase, type SqliteDatabase } from './db/sqlite.js';
 import { buildDaemonEnv, type DaemonEnv } from './env.js';
 import { Lifecycle, Phase } from './lifecycle.js';
 
@@ -30,9 +35,31 @@ export async function runStartup(lifecycle: Lifecycle): Promise<DaemonEnv> {
   const env = buildDaemonEnv();
   log(`env loaded: mode=${env.mode} bootId=${env.bootId} version=${env.version}`);
 
-  // Phase: OPENING_DB  (TODO Task #T5.1 — open SQLite + run migrations)
+  // Phase: OPENING_DB  (T5.1 sqlite wrapper + T5.4 migration runner)
   lifecycle.advanceTo(Phase.OPENING_DB);
-  log('TODO(T5.1): open SQLite, run migrations, replay WAL');
+  const dbPath = join(env.paths.stateDir, 'ccsm.db');
+  // Ensure parent dir exists — installer normally creates stateDir, but
+  // dev/smoke runs may point CCSM_STATE_DIR at a brand-new tmp dir.
+  mkdirSync(dirname(dbPath), { recursive: true });
+  const db: SqliteDatabase = openDatabase(dbPath);
+  try {
+    const migrationResult = runMigrations(db);
+    log(
+      `db opened at ${dbPath}: applied=${migrationResult.applied
+        .map((m) => m.version)
+        .join(',')} alreadyApplied=${migrationResult.alreadyApplied
+        .map((m) => m.version)
+        .join(',')}`,
+    );
+  } catch (err) {
+    // Close the handle so we don't leak it on a startup-abort path.
+    try {
+      db.close();
+    } catch {
+      // best-effort
+    }
+    throw err;
+  }
 
   // Phase: RESTORING_SESSIONS  (TODO Task #T3.4 — re-spawn sessions)
   lifecycle.advanceTo(Phase.RESTORING_SESSIONS);


### PR DESCRIPTION
## Summary

Implements the v0.3 SQLite migration runner with the FOREVER-STABLE SHA256 self-check side of the migration immutability lock (design spec ch07 §4 + ch15 §3 #4).

- `packages/daemon/src/db/locked.ts` — exports `MIGRATION_LOCKS` (ordered list of `{version, filename, sha256}`). Path lives at `src/db/locked.ts` to match `tools/check-migration-locks.sh` (PR #849, FOREVER-STABLE) and `packages/daemon/test/db/migration-lock.spec.ts` (PR for #55). The design doc text mentioning `migrations/locked.ts` is stale; the canonical path is the one CI consumes. The literal-pair shape `'<filename>': '<sha>'` in the underlying `MIGRATION_HASHES` record satisfies the grep in the bash script.
- `packages/daemon/src/db/migrations/runner.ts` — applies pending migrations in version order inside a per-migration transaction; SHA256-verifies every lock entry against the bundled file (both already-applied AND pending) before touching the DB; throws `MigrationLockMismatchError` on mismatch with explicit `filename` / `expectedSha256` / `actualSha256` fields for log-scrape friendliness.
- `packages/daemon/src/index.ts` — wires the runner into the `OPENING_DB` lifecycle phase (replaces the T5.1 TODO stub), `mkdirSync`s the parent so dev/smoke runs with a brand-new `CCSM_STATE_DIR` work, closes the handle on startup-abort.
- Reuses `tools/check-migration-locks.sh` from PR #849 unchanged. Verified the pre-tag exit-0 path runs cleanly.

## 001_initial.sql sha256

`70838422d5fdc82e39818e8722f365ee789f340951485547545c9de5200a128d` — exact bytes from PR #876 (T5.2 / Task #55), no normalization.

## Tests

- `src/db/migrations/__tests__/runner.spec.ts` — empty DB / idempotent / partial (synthetic 999 lock added to extend the real list) / mismatch on already-applied row / mismatch on pending row aborts before SQL exec / error-shape contract.
- `src/db/__tests__/locked.spec.ts` — SHA256 matches on-disk file; versions monotonic and unique; filenames follow `NNN_<name>.sql`; sha256 entries are 64 lowercase hex.
- The existing `test/db/migration-lock.spec.ts` (FOREVER-STABLE, was auto-skipping before) now runs and passes 4/4.

## Quality gates (local)

- `pnpm lint` — pass (daemon + electron + proto)
- `pnpm --filter @ccsm/daemon run typecheck` — pass
- `pnpm --filter @ccsm/daemon test` — 11 new tests pass + 4 forever-stable migration-lock tests pass. The lone failure (`test/descriptor/schema.spec.ts` golden-bytes diff) is a pre-existing CRLF-on-Windows issue unrelated to this PR (verified by reverting locally — same single failure on the bare `working` HEAD).
- `bash tools/check-migration-locks.sh` — exits 0 with the documented "pre-tag" note (expected; the script becomes meaningful only after v0.3.0 ships).

## Test plan

- [x] Empty DB applies all locks
- [x] Already-applied DB is a no-op
- [x] Partial DB applies only the new tail
- [x] SHA256 mismatch on already-applied row aborts
- [x] SHA256 mismatch on pending row aborts before any exec
- [x] Error carries filename + expected/actual SHA
- [x] Runner table-bootstrap does not collide with `001_initial.sql`'s own `CREATE TABLE schema_migrations`
- [x] FOREVER-STABLE migration-lock spec passes
- [x] check-migration-locks.sh recognizes the new locked.ts path