### PR TITLE
electron(T6.7): renderer Hello + boot_id verification + reconnect backoff

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -48,6 +48,8 @@ export default [
         crypto: 'readonly',
         URL: 'readonly',
         AbortController: 'readonly',
+        AbortSignal: 'readonly',
+        DOMException: 'readonly',
         KeyboardEvent: 'readonly',
         CustomEvent: 'readonly',
         Event: 'readonly',

--- a/packages/daemon/test/integration/pty-soak-shared.ts
+++ b/packages/daemon/test/integration/pty-soak-shared.ts
@@ -1,5 +1,4 @@
 // packages/daemon/test/integration/pty-soak-shared.ts
-/* global AbortSignal */
 //
 // Shared driver for the two PTY soak harnesses:
 //   - pty-soak-1h.spec.ts   — ship-gate (c) per chapter 12 §4.3 (60 min, nightly).

--- a/packages/electron/src/renderer/connection/hello.ts
+++ b/packages/electron/src/renderer/connection/hello.ts
@@ -1,0 +1,307 @@
+// T6.7 — Renderer Hello flow + boot_id verification.
+//
+// Spec ref: docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+// chapter 02 §3 (startup ordering) + chapter 03 §3.3 (Hello-echo boot_id
+// verification) + chapter 08 §6 (renderer error contract).
+//
+// Sequence (one connect attempt):
+//
+//   1. Re-read the descriptor from `app://ccsm/listener-descriptor.json`
+//      (NOT a cached in-memory copy — the spec at ch03 §3.3 step 5 is
+//      explicit: every reconnect re-reads the file so a daemon restart
+//      with a new boot_id is detected on the very first attempt).
+//   2. Build a Connect transport against the descriptor's `address`
+//      (the bridge endpoint the main process injected per ch08 §4.1+§4.2).
+//   3. Construct typed clients via `createClients` from T6.3.
+//   4. Call `SessionService.Hello` with the renderer's `proto_min_version`.
+//      This is the FIRST RPC over the connection per ch03 §3.3 step 3.
+//   5. On `FAILED_PRECONDITION` → version mismatch; surface as the
+//      blocking-modal-worthy error (caller decides UX). NOT retried.
+//   6. On any other Connect error → throw; caller's reconnect loop
+//      backs off and retries from step 1.
+//   7. On success → resolve with `{ descriptorBootId, daemonVersion,
+//      protoVersion, principal, listenerId }`. The caller compares the
+//      `descriptorBootId` against the previously-pinned value to detect a
+//      daemon restart (boot_id mismatch → invalidate all React Query
+//      caches + surface "reconnected after daemon restart" toast).
+//
+// boot_id sourcing — important distinction from the spec narrative:
+//
+//   The spec at ch03 §3.3 step 4 reads "if the descriptor's boot_id does
+//   NOT equal the Hello response's boot_id, ...". As of v0.3 freeze, the
+//   proto `HelloResponse` (session.proto) does NOT carry a `boot_id` field
+//   — only `daemon_version` / `proto_version` / `principal` / `listener_id`.
+//   The `boot_id` lives in `SupervisorHelloResponse` (UDS-only, not reachable
+//   from the renderer per ch02 §4) and on disk in `listener-a.json` / served
+//   to renderer via `app://ccsm/listener-descriptor.json` per ch08 §4.1.
+//
+//   The spec intent (lines 386-388) is "renderer detects daemon restart on
+//   reconnect". The mechanism this module implements:
+//     - On every reconnect we re-fetch the descriptor URL. Electron main's
+//       `protocol.handle('app', ...)` reads the on-disk file fresh on every
+//       request (Cache-Control: no-store; see protocol-app.ts), so the
+//       renderer sees the current daemon's boot_id every time.
+//     - A successful Hello against the descriptor's address proves the
+//       daemon at that address is reachable + version-compatible.
+//     - If the freshly-read descriptorBootId differs from the previously-
+//       pinned one, the daemon restarted — caller invalidates caches.
+//   Foreign-process spoofing (ch03 §3.3 sub-bullet "Foreign process bound
+//   to the recorded address") is detected at the bridge layer for UDS /
+//   named-pipe (peer-cred middleware on Listener A; ch03 §4) and at the
+//   transport-bridge `:authority` enforcement for loopback-TCP. A foreign
+//   process speaking Connect-RPC on the daemon's port but NOT serving
+//   `SessionService.Hello` would surface as a Connect `Unimplemented` /
+//   `Unavailable` error — caught by the reconnect driver, retried from
+//   re-reading the descriptor.
+//
+//   When proto v2+ adds `HelloResponse.boot_id` (additive, ch15 §3
+//   forever-stable rule allows new fields), this module flips one line —
+//   `descriptorBootId` becomes `helloResponse.bootId` — without changing
+//   the public surface. The `HelloResult` field is named `bootId` precisely
+//   so the call site doesn't care which side produced it.
+
+import { create } from '@bufbuild/protobuf';
+import { ConnectError, Code, type Transport } from '@connectrpc/connect';
+import { PROTO_VERSION } from '@ccsm/proto';
+import { HelloRequestSchema } from '@ccsm/proto';
+
+import { createClients } from '../../rpc/clients.js';
+import type { DescriptorV1 } from '../../main/protocol-app.js';
+
+/**
+ * Renderer's minimum acceptable daemon `proto_version`. Embedded at build
+ * time per ch02 §6 (one-directional version negotiation: client decides).
+ *
+ * v0.3: 1. Bumped in lockstep with proto-breaking changes per ch11 §7.
+ * Sourced from `@ccsm/proto`'s `PROTO_VERSION` so a single bump propagates
+ * everywhere.
+ */
+export const RENDERER_PROTO_MIN_VERSION = PROTO_VERSION;
+
+/** `client_kind` value the renderer self-identifies as in `HelloRequest`. */
+export const RENDERER_CLIENT_KIND = 'electron' as const;
+
+/** Result of a successful Hello. */
+export interface HelloResult {
+  /**
+   * The boot_id pinned for this connection's lifetime. Sourced from the
+   * descriptor (see file header — proto HelloResponse does not carry it
+   * in v0.3). Caller compares against previously-pinned value to detect
+   * daemon restart.
+   */
+  readonly bootId: string;
+  /** Daemon semver, e.g. "0.3.0". Surface in About / status UI. */
+  readonly daemonVersion: string;
+  /** Daemon's wire protocol minor; >= RENDERER_PROTO_MIN_VERSION on success. */
+  readonly protoVersion: number;
+  /** Listener id the daemon served the Hello on; v0.3 always "A". */
+  readonly listenerId: string;
+}
+
+/**
+ * Thrown when the daemon rejects the renderer's `proto_min_version`. Carries
+ * the daemon's reported version so the caller's UI can display the actual
+ * upgrade ask. Not retried by the reconnect driver (`shouldRetry` returns
+ * false for this class).
+ */
+export class HelloVersionMismatchError extends Error {
+  override readonly name = 'HelloVersionMismatchError';
+  constructor(
+    readonly daemonProtoVersion: number | null,
+    readonly clientMinVersion: number,
+    readonly daemonVersion: string | null,
+    cause?: unknown,
+  ) {
+    super(
+      `daemon proto_version ${
+        daemonProtoVersion ?? '<unknown>'
+      } incompatible with this Electron build (min ${clientMinVersion})`,
+    );
+    if (cause !== undefined) {
+      (this as { cause?: unknown }).cause = cause;
+    }
+  }
+}
+
+/**
+ * Thrown when the descriptor URL fetch / parse fails. The renderer's
+ * reconnect driver retries this class (it usually means descriptor not yet
+ * served because main's `protocol.handle` is still wiring up).
+ */
+export class DescriptorFetchError extends Error {
+  override readonly name = 'DescriptorFetchError';
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    if (cause !== undefined) {
+      (this as { cause?: unknown }).cause = cause;
+    }
+  }
+}
+
+/** Dependencies for `performHello` — every external surface is injected. */
+export interface PerformHelloDeps {
+  /**
+   * Re-fetch the descriptor from `app://ccsm/listener-descriptor.json`.
+   * Returns the parsed descriptor. Tests inject a fake.
+   *
+   * Default (production): `defaultFetchDescriptor()` below — uses the global
+   * `fetch` against `DESCRIPTOR_URL` from `protocol-app.ts`.
+   */
+  readonly fetchDescriptor: () => Promise<DescriptorV1>;
+  /**
+   * Build a Connect `Transport` from the descriptor. Caller-injected so the
+   * renderer's `connect-web` import lives at the boot site (T6.6) and tests
+   * can supply a stub transport that records calls.
+   */
+  readonly buildTransport: (descriptor: DescriptorV1) => Transport;
+  /** Renderer's proto floor; defaults to `RENDERER_PROTO_MIN_VERSION`. */
+  readonly protoMinVersion?: number;
+  /** `client_kind`; defaults to `RENDERER_CLIENT_KIND`. */
+  readonly clientKind?: string;
+  /** AbortSignal to cancel the Hello mid-flight. */
+  readonly signal?: AbortSignal;
+}
+
+/**
+ * One-shot Hello attempt. The reconnect driver calls this per attempt.
+ *
+ * Throws on:
+ *   - DescriptorFetchError: descriptor URL unreachable / unparseable.
+ *   - HelloVersionMismatchError: daemon rejected with FailedPrecondition,
+ *     OR daemon's reported `protoVersion < RENDERER_PROTO_MIN_VERSION`.
+ *   - ConnectError (any other code): transport / daemon error; caller
+ *     should back off and retry.
+ */
+export async function performHello(
+  deps: PerformHelloDeps,
+): Promise<HelloResult> {
+  const protoMinVersion = deps.protoMinVersion ?? RENDERER_PROTO_MIN_VERSION;
+  const clientKind = deps.clientKind ?? RENDERER_CLIENT_KIND;
+
+  // (1) Re-read descriptor — never trust an in-memory cached copy across
+  // reconnects (spec ch03 §3.3 step 5).
+  let descriptor: DescriptorV1;
+  try {
+    descriptor = await deps.fetchDescriptor();
+  } catch (err) {
+    throw new DescriptorFetchError(
+      `failed to fetch descriptor: ${(err as Error).message ?? String(err)}`,
+      err,
+    );
+  }
+
+  // (2) Build transport + clients fresh against the descriptor's bridge
+  // address. `createClients` is cheap (no I/O), so building per-attempt
+  // costs nothing and keeps the post-reconnect state pristine.
+  const transport = deps.buildTransport(descriptor);
+  const clients = createClients(transport);
+
+  // (3) Call Hello as the first RPC.
+  const request = create(HelloRequestSchema, {
+    clientKind,
+    protoMinVersion,
+  });
+
+  let response;
+  try {
+    response = await clients.session.hello(request, { signal: deps.signal });
+  } catch (err) {
+    // FailedPrecondition (Code 9) on Hello = version mismatch per ch02 §6
+    // + ch08 §6. Surface as a typed non-retryable error so the call site
+    // can render the blocking modal. Any other Connect code → rethrow as-is
+    // for the reconnect driver to handle (default: retry).
+    if (err instanceof ConnectError && err.code === Code.FailedPrecondition) {
+      // Best-effort extraction of the daemon's reported version from
+      // `ErrorDetail.extra["daemon_proto_version"]` per ch04 §2 / ch02 §6.
+      // If extraction fails we still surface the mismatch with `null`.
+      const daemonProtoVersion = extractDaemonProtoVersion(err);
+      throw new HelloVersionMismatchError(
+        daemonProtoVersion,
+        protoMinVersion,
+        null,
+        err,
+      );
+    }
+    throw err;
+  }
+
+  // (4) Defensive client-side floor check. Belt + suspenders: the daemon
+  // SHOULD have rejected if `protoVersion < protoMinVersion`, but if a
+  // misconfigured daemon returned 200 we still detect the mismatch here.
+  if (response.protoVersion < protoMinVersion) {
+    throw new HelloVersionMismatchError(
+      response.protoVersion,
+      protoMinVersion,
+      response.daemonVersion,
+    );
+  }
+
+  return {
+    bootId: descriptor.boot_id,
+    daemonVersion: response.daemonVersion,
+    protoVersion: response.protoVersion,
+    listenerId: response.listenerId,
+  };
+}
+
+/**
+ * Extract `extra["daemon_proto_version"]` from a FailedPrecondition error.
+ * Returns `null` if the daemon did not include the structured detail (older
+ * daemon, or transport stripped trailers). Pure helper, no side effects.
+ */
+function extractDaemonProtoVersion(err: ConnectError): number | null {
+  // ConnectError.metadata is a Headers; the structured detail (per ch04 §2)
+  // travels in the trailers. We do not parse the binary `error_details_pb`
+  // here to keep this module dep-light — the call site can render the raw
+  // error if richer detail is needed. v0.4 may add a parsed-detail accessor
+  // when it ships the cf-access principal switcher; until then `null` is
+  // honest about not knowing.
+  void err;
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Default descriptor fetcher
+// ---------------------------------------------------------------------------
+
+/**
+ * Default `fetchDescriptor` impl — runs against the global `fetch` and the
+ * locked `DESCRIPTOR_URL`. Lives here (not in the call site) so tests of
+ * call-site code can pass `defaultFetchDescriptor` if they want the real
+ * path, while unit tests of `performHello` inject a fake.
+ */
+export async function defaultFetchDescriptor(): Promise<DescriptorV1> {
+  // Imported lazily so this module loads without a window in pure-Node unit
+  // tests that never reach the default path.
+  const { DESCRIPTOR_URL } = await import('../../main/protocol-app.js');
+  const res = await fetch(DESCRIPTOR_URL);
+  if (!res.ok) {
+    throw new DescriptorFetchError(
+      `descriptor URL ${DESCRIPTOR_URL} returned HTTP ${res.status}`,
+    );
+  }
+  const text = await res.text();
+  // Avoid importing the parser (it asserts every field) — the main process
+  // already validated; trust the structurally-typed JSON. This keeps the
+  // renderer free of `node:fs` / `node:path` transitive deps.
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (err) {
+    throw new DescriptorFetchError(
+      `descriptor URL returned non-JSON: ${(err as Error).message}`,
+      err,
+    );
+  }
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    typeof (parsed as { boot_id?: unknown }).boot_id !== 'string' ||
+    typeof (parsed as { address?: unknown }).address !== 'string'
+  ) {
+    throw new DescriptorFetchError(
+      'descriptor URL returned malformed payload (missing boot_id/address)',
+    );
+  }
+  return parsed as DescriptorV1;
+}

--- a/packages/electron/src/renderer/connection/reconnect.ts
+++ b/packages/electron/src/renderer/connection/reconnect.ts
@@ -1,0 +1,133 @@
+// T6.7 — Reconnect backoff schedule + driver.
+//
+// Spec ref: docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+// chapter 08 §6 (renderer error-handling contract). The locked policy this
+// task ships is the *renderer-boot* schedule, distinct from the per-stream
+// backoff in ch08 §6 (`min(30s, 500ms * 2^attempt + jitter)`).
+//
+// This file owns the boot-side schedule the manager prompt locks:
+//   100ms → 200 → 400 → 800 → 1.6s → 3.2s → 5s (cap)
+//
+// Cap = 5000ms. Reset = on every successful Hello (the call site clears
+// `attempt` to 0). This schedule is bursty-friendly (catches a daemon that
+// finished restarting in the first second) without becoming a tight loop.
+//
+// SRP: pure decider (`nextDelayMs`) + a thin driver (`runWithReconnect`)
+// that performs a single attempt, sleeps via injected `sleep`, and retries.
+// No I/O besides whatever the caller's `attempt` does. No React, no Connect
+// imports — those live in `hello.ts` / `use-connection.tsx`.
+
+/**
+ * Locked schedule per the T6.7 manager brief. Index 0 = first reconnect
+ * delay. Anything past the table is capped at the last entry.
+ *
+ * Frozen so a future regression is loud at unit-test time
+ * (`backoff.spec.ts` asserts the exact values).
+ */
+export const RECONNECT_SCHEDULE_MS: readonly number[] = [
+  100, 200, 400, 800, 1600, 3200, 5000,
+] as const;
+
+/** Cap (last entry of the schedule). Exposed so callers can sanity-check. */
+export const RECONNECT_CAP_MS = 5000 as const;
+
+/**
+ * Pure decider: given an `attempt` index (0 = the first reconnect, NOT the
+ * initial connect), return the delay in milliseconds before that attempt.
+ *
+ * `attempt < 0` is treated as 0; large `attempt` values clamp to the cap.
+ */
+export function nextDelayMs(attempt: number): number {
+  if (attempt <= 0) return RECONNECT_SCHEDULE_MS[0];
+  if (attempt >= RECONNECT_SCHEDULE_MS.length) return RECONNECT_CAP_MS;
+  return RECONNECT_SCHEDULE_MS[attempt];
+}
+
+/** Promise-based sleep. Honors AbortSignal so callers can cancel cleanly. */
+export function sleepMs(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException('Aborted', 'AbortError'));
+      return;
+    }
+    const t = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = (): void => {
+      clearTimeout(t);
+      reject(new DOMException('Aborted', 'AbortError'));
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+/** Options for `runWithReconnect`. */
+export interface RunWithReconnectOpts<T> {
+  /**
+   * Single-attempt operation (typically `performHello`). MUST throw on
+   * disconnect / transport error so the driver knows to back off; MUST
+   * resolve on success.
+   */
+  readonly attempt: (attemptIndex: number) => Promise<T>;
+  /**
+   * Decide whether a thrown error should trigger a retry. Default: every
+   * thrown error retries (matches the spec — boot path waits forever for a
+   * daemon to come up, surfacing the §6.1 cold-start modal at 8 s).
+   *
+   * Return `false` for fatal errors (e.g., version mismatch) so the driver
+   * surfaces them to the caller instead of looping silently.
+   */
+  readonly shouldRetry?: (err: unknown, attemptIndex: number) => boolean;
+  /**
+   * Notification hook fired before each sleep — the call site uses this to
+   * surface "Reconnecting..." UI. Receives the upcoming delay in ms.
+   */
+  readonly onBackoff?: (delayMs: number, attemptIndex: number) => void;
+  /** AbortSignal cancels both pending sleep and inflight attempt callbacks. */
+  readonly signal?: AbortSignal;
+  /**
+   * Sleep override — defaults to `sleepMs`. Tests inject a fake-timer-aware
+   * sleep so vitest can advance timers deterministically.
+   */
+  readonly sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
+  /**
+   * Delay-schedule override — defaults to `nextDelayMs`. Tests use this to
+   * assert the exact schedule emitted; production callers leave it default.
+   */
+  readonly delayFor?: (attemptIndex: number) => number;
+}
+
+/**
+ * Drive the reconnect loop. Calls `attempt(0)`; on fatal-not-retried error
+ * rejects; on retried error sleeps `nextDelayMs(0)` and calls `attempt(1)`;
+ * etc., until success or aborted. Returns whatever the successful attempt
+ * resolves to.
+ */
+export async function runWithReconnect<T>(
+  opts: RunWithReconnectOpts<T>,
+): Promise<T> {
+  const sleep = opts.sleep ?? sleepMs;
+  const delayFor = opts.delayFor ?? nextDelayMs;
+  const shouldRetry = opts.shouldRetry ?? (() => true);
+  let attemptIdx = 0;
+  // Loop until success or aborted; rethrow non-retried errors immediately.
+  // No upper bound on attempts — the spec's behaviour is "retry forever; a
+  // user-facing modal appears after 8 s of unsuccessful Hello attempts" (ch08
+  // §6.1). Aborting the signal is the only way to exit the loop without a
+  // success.
+  for (;;) {
+    if (opts.signal?.aborted) {
+      throw new DOMException('Aborted', 'AbortError');
+    }
+    try {
+      return await opts.attempt(attemptIdx);
+    } catch (err) {
+      if (!shouldRetry(err, attemptIdx)) throw err;
+      const delay = delayFor(attemptIdx);
+      opts.onBackoff?.(delay, attemptIdx);
+      await sleep(delay, opts.signal);
+      attemptIdx += 1;
+    }
+  }
+}

--- a/packages/electron/src/renderer/connection/use-connection.tsx
+++ b/packages/electron/src/renderer/connection/use-connection.tsx
@@ -1,0 +1,285 @@
+// T6.7 — React Context + hook for the renderer's daemon connection.
+//
+// Spec ref: docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+// chapter 08 §6 (renderer error contract) + §6.1 (cold-start UX) + ch03
+// §3.3 (boot_id verification).
+//
+// Responsibilities (sink-side wiring only — pure logic lives in
+// `hello.ts` + `reconnect.ts`):
+//
+//   1. On mount: drive `runWithReconnect(performHello, ...)` until the
+//      first Hello succeeds. State machine starts in `connecting`.
+//   2. On success: pin the `bootId` for the connection lifetime; flip
+//      state to `connected`. Build the `CcsmClients` bundle once and
+//      expose it via context. (T6.6 boot wiring composes this provider
+//      INSIDE the existing `<ClientsProvider>` from T6.3 — see
+//      `react-entry-example.tsx` siblings of this file.)
+//   3. On `HelloVersionMismatchError`: flip to `version-mismatch`; do
+//      NOT loop. Caller's UI renders the blocking modal per ch08 §6.
+//   4. On any other error: keep retrying via the backoff schedule;
+//      surface "Reconnecting..." via state.
+//   5. On reconnect (transport dropped): re-call `performHello`. If the
+//      new `bootId` differs from the pinned one → daemon restarted →
+//      invalidate ALL React Query caches (`queryClient.invalidateQueries(
+//      { queryKey: ['ccsm'] })` per T6.3 cache-key shape) AND fire the
+//      `onDaemonRestart` callback so the call site can show the
+//      "reconnected after daemon restart" toast.
+//   6. On unmount: abort the in-flight attempt + the backoff sleep.
+//
+// Why a hook + context, not a Zustand store: T6.3 already pins React
+// Context as the DI seam (`<ClientsProvider>` / `useClients`); adding a
+// store here would be a second source of truth for "is the daemon up".
+// One mechanism, audited by the existing useClients() guard.
+//
+// Single responsibility:
+//   - producer: the connection state events (state transitions).
+//   - decider: deferred to `hello.ts` / `reconnect.ts` (pure).
+//   - sink: React state setters + queryClient.invalidateQueries.
+//
+// What this file deliberately does NOT do:
+//   - Build the Connect transport (caller injects `buildTransport`; T6.6
+//     stitches in `connect-web`'s `createConnectTransport`).
+//   - Construct `QueryClient` (renderer entry owns it).
+//   - Render the cold-start modal or toast (the call site does — this
+//     hook surfaces state; UX renders it).
+
+import * as React from 'react';
+import type { Transport } from '@connectrpc/connect';
+import { useQueryClient, type QueryClient } from '@tanstack/react-query';
+
+import {
+  performHello,
+  HelloVersionMismatchError,
+  type HelloResult,
+  type PerformHelloDeps,
+} from './hello.js';
+import { runWithReconnect } from './reconnect.js';
+import type { DescriptorV1 } from '../../main/protocol-app.js';
+
+/** Discriminated state of the renderer ↔ daemon connection. */
+export type ConnectionState =
+  | { readonly kind: 'connecting'; readonly attempt: number }
+  | {
+      readonly kind: 'connected';
+      readonly bootId: string;
+      readonly daemonVersion: string;
+      readonly protoVersion: number;
+      readonly listenerId: string;
+    }
+  | {
+      readonly kind: 'reconnecting';
+      readonly attempt: number;
+      readonly nextDelayMs: number;
+      readonly previousBootId: string | null;
+    }
+  | {
+      readonly kind: 'version-mismatch';
+      readonly daemonProtoVersion: number | null;
+      readonly clientMinVersion: number;
+    };
+
+/** Events emitted by the connection driver — used by the toast surface. */
+export interface ConnectionEvents {
+  /** Daemon's boot_id changed across a reconnect → caches were nuked. */
+  readonly onDaemonRestart?: (params: {
+    readonly previousBootId: string;
+    readonly currentBootId: string;
+  }) => void;
+  /** First successful Hello after mount. Useful for telemetry. */
+  readonly onConnected?: (result: HelloResult) => void;
+  /** Each backoff schedule tick. Useful for "Reconnecting..." banner. */
+  readonly onBackoff?: (delayMs: number, attempt: number) => void;
+}
+
+/** Public hook return — what consumers read. */
+export interface UseConnectionResult {
+  readonly state: ConnectionState;
+  /** Force an immediate reconnect (resets attempt counter). */
+  readonly retryNow: () => void;
+}
+
+const ConnectionContext = React.createContext<UseConnectionResult | null>(null);
+
+/** Read the connection state from context. Throws if no provider mounted. */
+export function useConnection(): UseConnectionResult {
+  const ctx = React.useContext(ConnectionContext);
+  if (ctx === null) {
+    throw new Error(
+      '[ccsm/renderer/connection] useConnection() called outside ' +
+        '<ConnectionProvider>; wrap renderer tree with one inside ' +
+        '<QueryClientProvider>.',
+    );
+  }
+  return ctx;
+}
+
+/** Props for `<ConnectionProvider>`. */
+export interface ConnectionProviderProps {
+  /** Build a Connect transport from the latest descriptor. */
+  readonly buildTransport: (descriptor: DescriptorV1) => Transport;
+  /** Override descriptor fetch; defaults to `defaultFetchDescriptor`. */
+  readonly fetchDescriptor?: PerformHelloDeps['fetchDescriptor'];
+  /** Toast / telemetry hooks. */
+  readonly events?: ConnectionEvents;
+  /** Override the `QueryClient` (defaults to nearest `useQueryClient()`). */
+  readonly queryClient?: QueryClient;
+  readonly children?: React.ReactNode;
+}
+
+/**
+ * Drive the renderer ↔ daemon connection lifecycle. Renders children
+ * unconditionally — the call site reads `useConnection()` to decide
+ * whether to show the cold-start modal / "Reconnecting..." banner /
+ * the real UI.
+ *
+ * Why unconditional render: the renderer's `<App>` typically has UI that
+ * is ALWAYS visible (window chrome, settings) regardless of daemon
+ * status. Gating render here would prevent that. The blocking-modal UX
+ * from ch08 §6.1 is a portal layered on top, not a tree replacement.
+ */
+export function ConnectionProvider(
+  props: ConnectionProviderProps,
+): React.ReactElement {
+  // Resolve the QueryClient at render time so tests can pass an explicit one.
+  // The hook MUST be called unconditionally per react-hooks rules; we
+  // discriminate after the call.
+  const ctxQueryClient = useQueryClient();
+  const queryClient = props.queryClient ?? ctxQueryClient;
+
+  const [state, setState] = React.useState<ConnectionState>({
+    kind: 'connecting',
+    attempt: 0,
+  });
+
+  // Pin the bootId across reconnects so we can detect daemon restart.
+  // Stored in a ref because changes here MUST NOT trigger re-render — only
+  // the resulting setState calls do.
+  const pinnedBootIdRef = React.useRef<string | null>(null);
+
+  // Trigger ref — bumping forces the effect to re-run (used by retryNow).
+  const [retryToken, setRetryToken] = React.useState(0);
+
+  // Stash mutable callbacks in a ref so the effect doesn't re-run when the
+  // caller passes inline closures.
+  const eventsRef = React.useRef(props.events);
+  eventsRef.current = props.events;
+
+  const buildTransportRef = React.useRef(props.buildTransport);
+  buildTransportRef.current = props.buildTransport;
+
+  const fetchDescriptorRef = React.useRef(props.fetchDescriptor);
+  fetchDescriptorRef.current = props.fetchDescriptor;
+
+  React.useEffect(() => {
+    const controller = new AbortController();
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const result = await runWithReconnect<HelloResult>({
+          signal: controller.signal,
+          shouldRetry: (err) => !(err instanceof HelloVersionMismatchError),
+          onBackoff: (delayMs, attemptIdx) => {
+            if (cancelled) return;
+            // attemptIdx is the index that JUST failed; the next attempt is
+            // attemptIdx + 1. Surface the upcoming wait so the UI banner
+            // can render "Reconnecting in Xs..." accurately.
+            setState({
+              kind: 'reconnecting',
+              attempt: attemptIdx + 1,
+              nextDelayMs: delayMs,
+              previousBootId: pinnedBootIdRef.current,
+            });
+            eventsRef.current?.onBackoff?.(delayMs, attemptIdx);
+          },
+          attempt: async (attemptIdx) => {
+            if (cancelled) throw new DOMException('Aborted', 'AbortError');
+            // First attempt of a fresh mount/retry: state is 'connecting';
+            // subsequent failures will have flipped via onBackoff already.
+            if (attemptIdx === 0) {
+              setState({ kind: 'connecting', attempt: 0 });
+            }
+            const fetchDescriptor =
+              fetchDescriptorRef.current ??
+              (await import('./hello.js')).defaultFetchDescriptor;
+            return performHello({
+              fetchDescriptor,
+              buildTransport: buildTransportRef.current,
+              signal: controller.signal,
+            });
+          },
+        });
+
+        if (cancelled) return;
+
+        // (5) boot_id mismatch detection. `pinnedBootIdRef.current` is
+        // null on the FIRST successful connect (no prior to compare against).
+        const previousBootId = pinnedBootIdRef.current;
+        pinnedBootIdRef.current = result.bootId;
+
+        if (previousBootId !== null && previousBootId !== result.bootId) {
+          // Daemon restarted between our last connect and this one. Per
+          // T6.3 cache-key shape: every CCSM hook keys under `['ccsm', ...]`.
+          // Invalidating that prefix nukes ALL cached daemon state in one
+          // call so stale data (PIDs, session lists, settings) cannot be
+          // served from the previous daemon's view.
+          queryClient.invalidateQueries({ queryKey: ['ccsm'] });
+          eventsRef.current?.onDaemonRestart?.({
+            previousBootId,
+            currentBootId: result.bootId,
+          });
+        }
+
+        setState({
+          kind: 'connected',
+          bootId: result.bootId,
+          daemonVersion: result.daemonVersion,
+          protoVersion: result.protoVersion,
+          listenerId: result.listenerId,
+        });
+        eventsRef.current?.onConnected?.(result);
+      } catch (err) {
+        if (cancelled) return;
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+        if (err instanceof HelloVersionMismatchError) {
+          setState({
+            kind: 'version-mismatch',
+            daemonProtoVersion: err.daemonProtoVersion,
+            clientMinVersion: err.clientMinVersion,
+          });
+          return;
+        }
+        // Should be unreachable — runWithReconnect's default `shouldRetry`
+        // only stops on the version-mismatch class above. Defensive log.
+        // eslint-disable-next-line no-console
+        console.error(
+          '[ccsm/renderer/connection] runWithReconnect surfaced unexpected error:',
+          err,
+        );
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+    // queryClient identity is stable across renders inside one
+    // QueryClientProvider; retryToken bump forces a fresh attempt loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [retryToken, queryClient]);
+
+  const retryNow = React.useCallback(() => {
+    setRetryToken((n) => n + 1);
+  }, []);
+
+  const value = React.useMemo<UseConnectionResult>(
+    () => ({ state, retryNow }),
+    [state, retryNow],
+  );
+
+  return React.createElement(
+    ConnectionContext.Provider,
+    { value },
+    props.children,
+  );
+}

--- a/packages/electron/test/renderer/connection/hello.spec.ts
+++ b/packages/electron/test/renderer/connection/hello.spec.ts
@@ -1,0 +1,167 @@
+// T6.7 — Hello + version-mismatch + boot_id surfacing UT.
+//
+// Spec ref: ch03 §3.3 (boot_id verification) + ch08 §6 (version mismatch
+// error contract).
+
+import { create } from '@bufbuild/protobuf';
+import { ConnectError, Code, type Transport } from '@connectrpc/connect';
+import { describe, expect, it, vi } from 'vitest';
+
+import { HelloResponseSchema, SessionService } from '@ccsm/proto';
+import {
+  performHello,
+  HelloVersionMismatchError,
+  DescriptorFetchError,
+  RENDERER_PROTO_MIN_VERSION,
+} from '../../../src/renderer/connection/hello.js';
+import type { DescriptorV1 } from '../../../src/main/protocol-app.js';
+
+function makeDescriptor(bootId: string): DescriptorV1 {
+  return {
+    version: 1,
+    transport: 'KIND_TCP_LOOPBACK_H2C',
+    address: '127.0.0.1:1',
+    tlsCertFingerprintSha256: null,
+    supervisorAddress: 'unused',
+    boot_id: bootId,
+    daemon_pid: 1,
+    listener_addr: '127.0.0.1:1',
+    protocol_version: 1,
+    bind_unix_ms: 0,
+  };
+}
+
+function makeStubTransport(
+  responder: (method: string) => unknown,
+): { transport: Transport; calls: string[] } {
+  const calls: string[] = [];
+  const transport: Transport = {
+    async unary(method, _signal, _timeoutMs, _header, _input, _ctxValues) {
+      calls.push(method.name);
+      const response = responder(method.name);
+      if (response instanceof Error) throw response;
+      return {
+        service: method.parent,
+        method,
+        stream: false as const,
+        header: new Headers(),
+        message: response as never,
+        trailer: new Headers(),
+      };
+    },
+    async stream() {
+      throw new Error('stream not used');
+    },
+  };
+  return { transport, calls };
+}
+
+describe('performHello', () => {
+  it('resolves with descriptor boot_id + daemon version on success', async () => {
+    const helloResp = create(HelloResponseSchema, {
+      daemonVersion: '0.3.0',
+      protoVersion: RENDERER_PROTO_MIN_VERSION,
+      listenerId: 'A',
+    });
+    const { transport, calls } = makeStubTransport(() => helloResp);
+
+    const result = await performHello({
+      fetchDescriptor: async () => makeDescriptor('boot-A'),
+      buildTransport: () => transport,
+    });
+
+    expect(result.bootId).toBe('boot-A');
+    expect(result.daemonVersion).toBe('0.3.0');
+    expect(result.protoVersion).toBe(RENDERER_PROTO_MIN_VERSION);
+    expect(result.listenerId).toBe('A');
+    expect(calls).toEqual(['Hello']);
+  });
+
+  it('treats Connect FailedPrecondition as a version mismatch (non-retryable)',
+    async () => {
+      const { transport } = makeStubTransport(() => {
+        return new ConnectError(
+          'client too old',
+          Code.FailedPrecondition,
+        );
+      });
+
+      await expect(
+        performHello({
+          fetchDescriptor: async () => makeDescriptor('boot-A'),
+          buildTransport: () => transport,
+        }),
+      ).rejects.toBeInstanceOf(HelloVersionMismatchError);
+    });
+
+  it('treats daemon protoVersion < client floor as version mismatch', async () => {
+    const helloResp = create(HelloResponseSchema, {
+      daemonVersion: '0.2.0',
+      protoVersion: 0, // below floor of 1
+      listenerId: 'A',
+    });
+    const { transport } = makeStubTransport(() => helloResp);
+
+    await expect(
+      performHello({
+        fetchDescriptor: async () => makeDescriptor('boot-A'),
+        buildTransport: () => transport,
+        protoMinVersion: 1,
+      }),
+    ).rejects.toBeInstanceOf(HelloVersionMismatchError);
+  });
+
+  it('propagates Unavailable as a regular Connect error (caller retries)',
+    async () => {
+      const { transport } = makeStubTransport(() => {
+        return new ConnectError('daemon down', Code.Unavailable);
+      });
+
+      const promise = performHello({
+        fetchDescriptor: async () => makeDescriptor('boot-A'),
+        buildTransport: () => transport,
+      });
+      await expect(promise).rejects.toBeInstanceOf(ConnectError);
+      await expect(promise).rejects.not.toBeInstanceOf(HelloVersionMismatchError);
+    });
+
+  it('wraps descriptor fetch failures as DescriptorFetchError', async () => {
+    const { transport } = makeStubTransport(() => null);
+    await expect(
+      performHello({
+        fetchDescriptor: async () => {
+          throw new Error('fetch failed');
+        },
+        buildTransport: () => transport,
+      }),
+    ).rejects.toBeInstanceOf(DescriptorFetchError);
+  });
+
+  it('re-fetches descriptor on every call (no in-memory caching)', async () => {
+    // Spec ch03 §3.3 step 5: every reconnect re-reads the file. This test
+    // proves performHello does not memoize the fetcher.
+    const helloResp = create(HelloResponseSchema, {
+      daemonVersion: '0.3.0',
+      protoVersion: RENDERER_PROTO_MIN_VERSION,
+      listenerId: 'A',
+    });
+    const { transport } = makeStubTransport(() => helloResp);
+    const fetchDescriptor = vi
+      .fn<() => Promise<DescriptorV1>>()
+      .mockResolvedValueOnce(makeDescriptor('boot-A'))
+      .mockResolvedValueOnce(makeDescriptor('boot-B'));
+
+    const r1 = await performHello({ fetchDescriptor, buildTransport: () => transport });
+    const r2 = await performHello({ fetchDescriptor, buildTransport: () => transport });
+
+    expect(r1.bootId).toBe('boot-A');
+    expect(r2.bootId).toBe('boot-B');
+    expect(fetchDescriptor).toHaveBeenCalledTimes(2);
+  });
+
+  // Sanity: assert the proto wire surface this module relies on hasn't drifted.
+  it('uses SessionService.Hello (asserts wire shape, not transport impl)', () => {
+    expect(SessionService.method.hello).toBeDefined();
+    expect(SessionService.method.hello.name).toBe('Hello');
+  });
+});

--- a/packages/electron/test/renderer/connection/reconnect.spec.ts
+++ b/packages/electron/test/renderer/connection/reconnect.spec.ts
@@ -1,0 +1,135 @@
+// T6.7 — Reconnect schedule UT.
+//
+// Spec ref: chapter 08 §6 (renderer error contract). The boot-side schedule
+// locked by the T6.7 brief: 100 → 200 → 400 → 800 → 1600 → 3200ms cap 5000.
+//
+// Why pure UT (not e2e): the schedule is a pure decider with no React /
+// Connect surface. Vitest fake timers prove the driver actually waits the
+// right amount; an e2e would test nothing this UT cannot already prove.
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+import {
+  RECONNECT_SCHEDULE_MS,
+  RECONNECT_CAP_MS,
+  nextDelayMs,
+  runWithReconnect,
+} from '../../../src/renderer/connection/reconnect.js';
+
+describe('nextDelayMs (pure decider)', () => {
+  it('matches the locked schedule 100/200/400/800/1600/3200/5000', () => {
+    expect(RECONNECT_SCHEDULE_MS).toEqual([100, 200, 400, 800, 1600, 3200, 5000]);
+    expect(RECONNECT_CAP_MS).toBe(5000);
+    for (let i = 0; i < RECONNECT_SCHEDULE_MS.length; i += 1) {
+      expect(nextDelayMs(i)).toBe(RECONNECT_SCHEDULE_MS[i]);
+    }
+  });
+
+  it('caps anything past the schedule at 5000ms', () => {
+    expect(nextDelayMs(7)).toBe(5000);
+    expect(nextDelayMs(99)).toBe(5000);
+    expect(nextDelayMs(1_000_000)).toBe(5000);
+  });
+
+  it('treats negative attempts as the first delay', () => {
+    expect(nextDelayMs(-1)).toBe(100);
+    expect(nextDelayMs(-100)).toBe(100);
+  });
+});
+
+describe('runWithReconnect (driver)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('resolves immediately on first-attempt success', async () => {
+    const attempt = vi.fn(async () => 'ok');
+    const promise = runWithReconnect<string>({ attempt });
+    await expect(promise).resolves.toBe('ok');
+    expect(attempt).toHaveBeenCalledTimes(1);
+    expect(attempt).toHaveBeenCalledWith(0);
+  });
+
+  it('emits the locked schedule on consecutive failures', async () => {
+    const seen: number[] = [];
+    let calls = 0;
+    const attempt = vi.fn(async (idx: number) => {
+      calls += 1;
+      if (calls < 5) throw new Error('flaky');
+      return idx;
+    });
+    // Inject a fake sleep that records the delay and resolves synchronously
+    // — this avoids vitest fake-timer / await-microtask interleaving.
+    const sleep = vi.fn(async (ms: number) => {
+      seen.push(ms);
+    });
+
+    const result = await runWithReconnect<number>({ attempt, sleep });
+    expect(result).toBe(4);
+    // 4 failures → 4 backoffs at indices 0,1,2,3 → delays 100/200/400/800.
+    expect(seen).toEqual([100, 200, 400, 800]);
+    expect(attempt).toHaveBeenCalledTimes(5);
+  });
+
+  it('caps schedule at 5000ms once past the table', async () => {
+    const seen: number[] = [];
+    let calls = 0;
+    const attempt = vi.fn(async () => {
+      calls += 1;
+      if (calls < 10) throw new Error('flaky');
+      return 'ok';
+    });
+    const sleep = vi.fn(async (ms: number) => {
+      seen.push(ms);
+    });
+
+    await runWithReconnect<string>({ attempt, sleep });
+    // Indices 0..8 map to the schedule; once exhausted (idx>=7), cap kicks in.
+    expect(seen).toEqual([100, 200, 400, 800, 1600, 3200, 5000, 5000, 5000]);
+  });
+
+  it('does NOT retry when shouldRetry returns false (version mismatch path)',
+    async () => {
+      const fatal = new Error('FAILED_PRECONDITION');
+      const attempt = vi.fn(async () => { throw fatal; });
+      const sleep = vi.fn();
+      await expect(
+        runWithReconnect({ attempt, sleep, shouldRetry: () => false }),
+      ).rejects.toBe(fatal);
+      expect(attempt).toHaveBeenCalledTimes(1);
+      expect(sleep).not.toHaveBeenCalled();
+    });
+
+  it('honors AbortSignal — aborts during sleep', async () => {
+    const ctl = new AbortController();
+    const attempt = vi.fn(async () => {
+      throw new Error('try-again');
+    });
+    const sleep = vi.fn(async () => {
+      // Abort while "sleeping" so the next loop iteration trips the
+      // signal.aborted check.
+      ctl.abort();
+    });
+    const promise = runWithReconnect({ attempt, sleep, signal: ctl.signal });
+    await expect(promise).rejects.toMatchObject({ name: 'AbortError' });
+    // First attempt ran; sleep ran once; next iteration tripped aborted.
+    expect(attempt).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onBackoff with delay + attempt index', async () => {
+    let calls = 0;
+    const attempt = vi.fn(async () => {
+      calls += 1;
+      if (calls < 3) throw new Error('flaky');
+      return null;
+    });
+    const sleep = vi.fn();
+    const onBackoff = vi.fn();
+    await runWithReconnect({ attempt, sleep, onBackoff });
+    expect(onBackoff).toHaveBeenNthCalledWith(1, 100, 0);
+    expect(onBackoff).toHaveBeenNthCalledWith(2, 200, 1);
+  });
+});

--- a/packages/electron/test/renderer/connection/use-connection.spec.tsx
+++ b/packages/electron/test/renderer/connection/use-connection.spec.tsx
@@ -72,8 +72,8 @@ function wrapper(queryClient: QueryClient, props: {
           fetchDescriptor: props.fetchDescriptor,
           buildTransport: props.buildTransport,
           events: props.events,
-          children,
         },
+        children,
       ),
     );
   };

--- a/packages/electron/test/renderer/connection/use-connection.spec.tsx
+++ b/packages/electron/test/renderer/connection/use-connection.spec.tsx
@@ -1,0 +1,211 @@
+// T6.7 — ConnectionProvider / useConnection: boot_id mismatch → cache nuke,
+// version mismatch surfacing.
+//
+// @vitest-environment happy-dom
+//
+// Spec ref: ch03 §3.3 + ch08 §6.
+
+import { create } from '@bufbuild/protobuf';
+import { ConnectError, Code, type Transport } from '@connectrpc/connect';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { HelloResponseSchema } from '@ccsm/proto';
+import {
+  ConnectionProvider,
+  useConnection,
+  type ConnectionEvents,
+} from '../../../src/renderer/connection/use-connection.js';
+import type { DescriptorV1 } from '../../../src/main/protocol-app.js';
+
+function makeDescriptor(bootId: string): DescriptorV1 {
+  return {
+    version: 1,
+    transport: 'KIND_TCP_LOOPBACK_H2C',
+    address: '127.0.0.1:1',
+    tlsCertFingerprintSha256: null,
+    supervisorAddress: 'unused',
+    boot_id: bootId,
+    daemon_pid: 1,
+    listener_addr: '127.0.0.1:1',
+    protocol_version: 1,
+    bind_unix_ms: 0,
+  };
+}
+
+function makeStubTransport(
+  responder: () => unknown,
+): Transport {
+  return {
+    async unary(method, _signal, _timeoutMs, _header, _input, _ctxValues) {
+      const r = responder();
+      if (r instanceof Error) throw r;
+      return {
+        service: method.parent,
+        method,
+        stream: false as const,
+        header: new Headers(),
+        message: r as never,
+        trailer: new Headers(),
+      };
+    },
+    async stream() {
+      throw new Error('stream not used');
+    },
+  };
+}
+
+function wrapper(queryClient: QueryClient, props: {
+  fetchDescriptor: () => Promise<DescriptorV1>;
+  buildTransport: () => Transport;
+  events?: ConnectionEvents;
+}) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      React.createElement(
+        ConnectionProvider,
+        {
+          fetchDescriptor: props.fetchDescriptor,
+          buildTransport: props.buildTransport,
+          events: props.events,
+          children,
+        },
+      ),
+    );
+  };
+}
+
+describe('useConnection — first connect', () => {
+  it('flips to "connected" with the descriptor boot_id on success', async () => {
+    const helloResp = create(HelloResponseSchema, {
+      daemonVersion: '0.3.0',
+      protoVersion: 1,
+      listenerId: 'A',
+    });
+    const queryClient = new QueryClient();
+    const onConnected = vi.fn();
+    const Wrapper = wrapper(queryClient, {
+      fetchDescriptor: async () => makeDescriptor('boot-X'),
+      buildTransport: () => makeStubTransport(() => helloResp),
+      events: { onConnected },
+    });
+    const { result } = renderHook(() => useConnection(), { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(result.current.state.kind).toBe('connected');
+    });
+    if (result.current.state.kind !== 'connected') throw new Error('not connected');
+    expect(result.current.state.bootId).toBe('boot-X');
+    expect(result.current.state.daemonVersion).toBe('0.3.0');
+    expect(result.current.state.listenerId).toBe('A');
+    expect(onConnected).toHaveBeenCalledTimes(1);
+  });
+
+  it('flips to "version-mismatch" on FailedPrecondition (no infinite loop)',
+    async () => {
+      const queryClient = new QueryClient();
+      const Wrapper = wrapper(queryClient, {
+        fetchDescriptor: async () => makeDescriptor('boot-X'),
+        buildTransport: () =>
+          makeStubTransport(() =>
+            new ConnectError('client too old', Code.FailedPrecondition),
+          ),
+      });
+      const { result } = renderHook(() => useConnection(), { wrapper: Wrapper });
+
+      await waitFor(() => {
+        expect(result.current.state.kind).toBe('version-mismatch');
+      });
+      if (result.current.state.kind !== 'version-mismatch') {
+        throw new Error('expected version-mismatch');
+      }
+      expect(result.current.state.clientMinVersion).toBeGreaterThan(0);
+    });
+});
+
+describe('useConnection — boot_id mismatch on reconnect', () => {
+  it('invalidates ["ccsm"] queries when boot_id changes across retryNow()',
+    async () => {
+      let bootSequence = ['boot-A', 'boot-B'];
+      let bootIdx = 0;
+      const helloResp = create(HelloResponseSchema, {
+        daemonVersion: '0.3.0',
+        protoVersion: 1,
+        listenerId: 'A',
+      });
+      const queryClient = new QueryClient();
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+      const onDaemonRestart = vi.fn();
+
+      const Wrapper = wrapper(queryClient, {
+        fetchDescriptor: async () => {
+          const id = bootSequence[bootIdx];
+          bootIdx = Math.min(bootIdx + 1, bootSequence.length - 1);
+          return makeDescriptor(id);
+        },
+        buildTransport: () => makeStubTransport(() => helloResp),
+        events: { onDaemonRestart },
+      });
+
+      const { result } = renderHook(() => useConnection(), { wrapper: Wrapper });
+
+      // First connect — pins boot-A. No invalidation yet.
+      await waitFor(() => {
+        expect(result.current.state.kind).toBe('connected');
+      });
+      expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ['ccsm'] });
+      expect(onDaemonRestart).not.toHaveBeenCalled();
+
+      // Force a reconnect — descriptor now reports boot-B → daemon restarted.
+      result.current.retryNow();
+
+      await waitFor(() => {
+        if (result.current.state.kind !== 'connected') return;
+        expect(result.current.state.bootId).toBe('boot-B');
+      });
+
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['ccsm'] });
+      expect(onDaemonRestart).toHaveBeenCalledWith({
+        previousBootId: 'boot-A',
+        currentBootId: 'boot-B',
+      });
+    });
+
+  it('does NOT invalidate when boot_id is unchanged across reconnect',
+    async () => {
+      const helloResp = create(HelloResponseSchema, {
+        daemonVersion: '0.3.0',
+        protoVersion: 1,
+        listenerId: 'A',
+      });
+      const queryClient = new QueryClient();
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+      const Wrapper = wrapper(queryClient, {
+        fetchDescriptor: async () => makeDescriptor('boot-stable'),
+        buildTransport: () => makeStubTransport(() => helloResp),
+      });
+
+      const { result } = renderHook(() => useConnection(), { wrapper: Wrapper });
+      await waitFor(() => {
+        expect(result.current.state.kind).toBe('connected');
+      });
+      result.current.retryNow();
+      await waitFor(() => {
+        if (result.current.state.kind !== 'connected') return;
+        expect(result.current.state.bootId).toBe('boot-stable');
+      });
+      expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ['ccsm'] });
+    });
+});
+
+describe('useConnection — provider guard', () => {
+  it('throws a clear error when used without <ConnectionProvider>', () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    expect(() => renderHook(() => useConnection())).toThrow(/ConnectionProvider/);
+    errSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Task #75. Spec ref: docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md ch03 §3.3 (boot_id verification) + ch08 §6 (renderer error contract) + ch08 §6.1 (cold-start UX).

## Summary

- `src/renderer/connection/reconnect.ts` — pure decider for the locked boot reconnect schedule (100/200/400/800/1600/3200ms cap 5000ms) plus `runWithReconnect` driver. `shouldRetry` hook lets callers mark a class as fatal (used for version mismatch).
- `src/renderer/connection/hello.ts` — `performHello(deps)` re-fetches the descriptor on every attempt (spec ch03 §3.3 step 5), builds clients via T6.3 `createClients()`, calls `SessionService.Hello`, treats Connect `FailedPrecondition` as typed `HelloVersionMismatchError` (non-retryable). Defensive client-side proto-floor check.
- `src/renderer/connection/use-connection.tsx` — `<ConnectionProvider>` + `useConnection()` hook. State machine: `connecting` → `connected` → `reconnecting` → `connected` (or `version-mismatch` terminal). On bootId change across reconnect, calls `queryClient.invalidateQueries({ queryKey: ['ccsm'] })` per T6.3 cache-key shape and fires `onDaemonRestart` event for the toast. `retryNow()` powers the ch08 §6.1 cold-start modal.

## Design notes

**boot_id sourcing — important divergence from spec narrative.** Spec ch03 §3.3 step 4 reads "if the descriptor's boot_id does NOT equal the Hello response's boot_id...". As of v0.3 freeze, proto `HelloResponse` (`packages/proto/src/ccsm/v1/session.proto`) does NOT carry a `boot_id` field — it's only on `SupervisorHelloResponse` (UDS-only, unreachable from renderer per ch02 §4) and in the on-disk descriptor.

Mechanism implemented:
- Every reconnect re-fetches `app://ccsm/listener-descriptor.json`.
- Electron main's `protocol.handle('app', ...)` reads from disk on every request with `Cache-Control: no-store` (verified in `src/main/protocol-app.ts`), so the renderer sees the current daemon's `boot_id` every time.
- Successful Hello against the descriptor's address proves the daemon is reachable + version-compatible; descriptor `boot_id` change across reconnect → daemon restarted → cache nuke + toast.
- Foreign-process spoofing on the bind address is blocked at the bridge layer (peer-cred middleware on Listener A for UDS / named-pipe; `:authority` enforcement for loopback-TCP).

When proto v2+ adds `HelloResponse.boot_id` (additive per ch15 §3 forever-stable rule), `hello.ts` flips one line — the public `HelloResult.bootId` field is named precisely so call sites do not care which side produced it.

## Wiring

`<ConnectionProvider>` is composed by Task #70 (T6.6) boot wiring around `<ClientsProvider>`/`<QueryClientProvider>` in the renderer entry. No renderer entry file exists yet (T6.6 owns it); shipping a stub here would conflict with #70.

Depends on:
- PR #915 (T6.3): `createClients`, `<ClientsProvider>` — used by `performHello`.
- PR #911 (T6.2): `transport-bridge` — supplies the bridge URL the descriptor exposes; `buildTransport` is injected by T6.6 boot.
- PR #898 (T6.1): `protocol-app.ts` `DescriptorV1` shape + `DESCRIPTOR_URL`.

## Test plan (vitest UT — pure, no electron / no daemon)

- [x] `test/renderer/connection/reconnect.spec.ts` — schedule equality (100/200/400/800/1600/3200/5000), cap past schedule, `shouldRetry: false` is non-retryable, AbortSignal cancels mid-sleep, `onBackoff` event shape.
- [x] `test/renderer/connection/hello.spec.ts` — success returns descriptor `bootId`, `FailedPrecondition` → `HelloVersionMismatchError`, daemon `protoVersion < floor` → `HelloVersionMismatchError`, `Unavailable` propagates as ConnectError (caller retries), descriptor fetch failure wrapped as `DescriptorFetchError`, descriptor re-fetched per attempt (no in-memory cache).
- [x] `test/renderer/connection/use-connection.spec.tsx` — connected state with bootId pin + `onConnected` fired, `version-mismatch` terminal (no infinite loop), bootId mismatch across `retryNow()` invalidates `['ccsm']` queries + fires `onDaemonRestart`, unchanged bootId does NOT invalidate, missing-provider guard throws clear error.

## Local quality gates (all green)

```
pnpm lint                                    -> 0 errors / 0 warnings
pnpm --filter @ccsm/electron run typecheck   -> pass
pnpm --filter @ccsm/electron test            -> 95 pass / 2 pre-existing skipped
```