### PR TITLE
daemon(T1.8): graceful shutdown

### DIFF
--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -8,7 +8,6 @@
 //   - SQLite open + migrations             → T5.1
 //   - Session restore + orphan-uid check   → T3.4
 //   - Supervisor /healthz                  → T1.7
-//   - Graceful shutdown                    → T1.8
 //
 // Wired-in:
 //   - Listener A bind                      → T1.4 (`makeListenerA`)
@@ -17,6 +16,18 @@
 //                                                  `makeRouterBindHook`)
 //   - Descriptor file write                → T1.6 (separate concern; not
 //                                                  yet called from here)
+//   - systemd watchdog (main thread)       → T5.13 (`startSystemdWatchdog`)
+//   - Graceful shutdown                    → T1.8 (this file installs the
+//                                                  SIGTERM/SIGINT handlers
+//                                                  that call `Shutdown.run`)
+//
+// In scope (T1.8): SIGTERM / SIGINT handler installation. The actual
+// shutdown sequence is `Shutdown.run(...)` (./shutdown.ts); this file
+// only wires (a) the signal trap that calls it, and (b) the empty
+// `ShutdownContext` we can populate today (no listeners / no db / no
+// pty children are constructed by the T1.1 startup stub yet — later
+// tasks register their handles with `register*OnEntrypoint` helpers
+// when they land).
 
 import { mkdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -28,6 +39,13 @@ import { Lifecycle, Phase } from './lifecycle.js';
 import { makeListenerA } from './listeners/factory.js';
 import type { Listener } from './listeners/types.js';
 import { makeRouterBindHook } from './rpc/bind.js';
+import {
+  Shutdown,
+  installShutdownHandlers,
+  noopInFlightTracker,
+  type ShutdownContext,
+  type ShutdownResult,
+} from './shutdown.js';
 import {
   startSystemdWatchdog,
   type SystemdWatchdogHandle,
@@ -138,9 +156,53 @@ async function main(): Promise<void> {
   const lifecycle = new Lifecycle();
   let listenerA: Listener | null = null;
   let watchdog: SystemdWatchdogHandle | null = null;
+
+  // Build the shutdown orchestrator + a mutable context the future
+  // T1.4 / T1.7 / T5.1 / T4.x wiring can populate as they land. We
+  // capture refs by reading from a single `ctxRef` object so that an
+  // early SIGTERM (before phase READY) still gets the partial state
+  // (e.g. a half-bound listener or open db) torn down. Only known-safe
+  // members are exposed; the rest stay null until their owning task
+  // wires them in.
+  const ctxRef: { -readonly [K in keyof ShutdownContext]: ShutdownContext[K] } = {
+    listeners: [],
+    supervisor: null,
+    ptyHostChildren: [],
+    db: null,
+    inFlightTracker: noopInFlightTracker,
+    log: {
+      step: (name, detail) => log(`shutdown step=${name}${detail ? ' ' + JSON.stringify(detail) : ''}`),
+      warn: (name, err) => log(`shutdown WARN step=${name}: ${err instanceof Error ? err.message : String(err)}`),
+    },
+  };
+
+  const shutdown = new Shutdown();
+  const triggerShutdown = async (): Promise<ShutdownResult> => {
+    // Stop the watchdog first so its keepalive timer doesn't pin the
+    // event loop while shutdown.run drains in-flight RPCs.
+    watchdog?.stop();
+    const r = await shutdown.run(ctxRef);
+    // Exit code: clean drain + zero step errors → 0; otherwise 1.
+    const exitCode = r.errors.length === 0 && r.inFlightAtBudgetExpiry <= 0 ? 0 : 1;
+    process.exit(exitCode);
+  };
+
+  // Install signal handlers LAST in main() — but we install them BEFORE
+  // runStartup so an early SIGTERM during boot still triggers a clean
+  // teardown of whatever partial state we managed to build.
+  installShutdownHandlers(triggerShutdown, (sig, kind) => {
+    log(`signal ${sig} (${kind}) — initiating graceful shutdown`);
+  });
+
   try {
     const result = await runStartup(lifecycle);
     listenerA = result.listenerA;
+    // Register the bound listener with the shutdown context so SIGTERM
+    // closes it during step 1 (stop accepting). T5.1 will register the
+    // db handle here too once it lands.
+    if (listenerA !== null) {
+      ctxRef.listeners.push(listenerA);
+    }
     // Watchdog after READY — there is no point telling systemd we're alive
     // until the daemon is actually serving. systemd's `WatchdogSec=30s`
     // gives ~30s of boot slack before the first WATCHDOG=1 is required.
@@ -173,6 +235,13 @@ async function main(): Promise<void> {
         /* swallow — process is exiting */
       });
     }
+    // Best-effort partial-state teardown via the shutdown orchestrator
+    // (covers the spec's "checkpoint WAL on every termination path"
+    // contract — once T5.1 wires `ctxRef.db`, a startup failure between
+    // OPENING_DB and READY will still flush the WAL).
+    await shutdown.run(ctxRef).catch(() => {
+      /* shutdown.run captures its own errors; no need to log twice */
+    });
     process.exit(1);
   }
 }

--- a/packages/daemon/src/shutdown.spec.ts
+++ b/packages/daemon/src/shutdown.spec.ts
@@ -1,0 +1,387 @@
+// Unit tests for the graceful shutdown orchestrator (T1.8).
+//
+// Covers spec ch02 §4:
+//   - SIGTERM with in-flight RPC drained within budget → exit clean.
+//   - SIGTERM with stuck RPC (5s budget exceeded) → orchestrator continues.
+//   - SIGTERM with claude grandchildren → SIGKILL escalation after 3s.
+//   - WAL TRUNCATE checkpoint runs and DB closes.
+//   - Listener and supervisor close ordering (data plane first, supervisor last).
+//   - Errors in any single step do not abort the sequence.
+//
+// The Listener / SupervisorServer / pty-host child handle / SQLite handle
+// are all mocked through their public trait shapes (no real sockets / no
+// real `child_process.fork`); this file is a pure unit test that runs in
+// milliseconds. The cross-module integration story (a real Listener A
+// instance + real pty-host child) is covered by the existing pty-soak +
+// supervisor contract specs together with the handler interceptor wiring
+// that lands in T2.x — keeping this file mock-only is deliberate.
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  DEFAULT_CLAUDE_SIGKILL_MS,
+  DEFAULT_INFLIGHT_BUDGET_MS,
+  Shutdown,
+  installShutdownHandlers,
+  noopInFlightTracker,
+  SHUTDOWN_SIGNALS,
+  type InFlightTracker,
+  type ShutdownContext,
+  type ShutdownLogger,
+  type ShutdownStepName,
+} from './shutdown.js';
+import type { Listener, BindDescriptor } from './listeners/types.js';
+import type { PtyHostChildHandle } from './pty-host/index.js';
+import type { ChildExit } from './pty-host/types.js';
+import type { SupervisorServer } from './supervisor/server.js';
+import type { SqliteDatabase } from './db/sqlite.js';
+
+// ---------------------------------------------------------------------------
+// Mock factories
+// ---------------------------------------------------------------------------
+
+function makeListener(id: string, opts: { stopThrows?: boolean } = {}): Listener {
+  return {
+    id,
+    start: vi.fn(async () => {}),
+    stop: vi.fn(async () => {
+      if (opts.stopThrows) throw new Error(`${id} stop boom`);
+    }),
+    descriptor: (): BindDescriptor => ({ kind: 'loopbackTcp', host: '127.0.0.1', port: 0 }),
+  };
+}
+
+function makeSupervisor(opts: { stopThrows?: boolean } = {}): SupervisorServer {
+  return {
+    address: () => '/tmp/sup.sock',
+    start: vi.fn(async () => {}),
+    stop: vi.fn(async () => {
+      if (opts.stopThrows) throw new Error('supervisor stop boom');
+    }),
+  };
+}
+
+function makePtyHandle(
+  sessionId: string,
+  opts: {
+    closeBehavior?: 'graceful' | 'sigkill' | 'throws';
+    closeDelayMs?: number;
+  } = {},
+): PtyHostChildHandle {
+  const exit: ChildExit =
+    opts.closeBehavior === 'sigkill'
+      ? { reason: 'crashed', code: null, signal: 'SIGKILL' }
+      : { reason: 'graceful', code: 0, signal: null };
+  const handle: PtyHostChildHandle = {
+    sessionId,
+    pid: 12345,
+    claudeSpawnEnv: {},
+    ready: () => Promise.resolve(),
+    send: vi.fn(),
+    exited: () => Promise.resolve(exit),
+    messages: () => ({
+      [Symbol.asyncIterator]() {
+        return { next: () => Promise.resolve({ value: undefined as never, done: true }) };
+      },
+    }),
+    closeAndWait: vi.fn(async () => {
+      if (opts.closeBehavior === 'throws') throw new Error('pty close boom');
+      if (opts.closeDelayMs) {
+        await new Promise((r) => setTimeout(r, opts.closeDelayMs));
+      }
+      return exit;
+    }),
+  };
+  return handle;
+}
+
+function makeDb(opts: { pragmaThrows?: boolean } = {}): SqliteDatabase {
+  // Minimal duck-typed stand-in. `walCheckpointTruncate` only calls
+  // `db.pragma('wal_checkpoint(TRUNCATE)')`, and `db.close()` is the
+  // other surface we hit. Cast through `unknown` to bypass the full
+  // better-sqlite3 surface that we don't need.
+  const pragma = vi.fn((sql: string) => {
+    if (opts.pragmaThrows) throw new Error('pragma boom');
+    if (sql.startsWith('wal_checkpoint')) {
+      return [{ busy: 0, log: 0, checkpointed: 0 }];
+    }
+    return [];
+  });
+  const close = vi.fn();
+  return { pragma, close } as unknown as SqliteDatabase;
+}
+
+function makeTracker(initialInFlight: number, drainAfterMs?: number): InFlightTracker {
+  let count = initialInFlight;
+  return {
+    waitForInFlight(timeoutMs: number): Promise<number> {
+      if (drainAfterMs !== undefined && drainAfterMs <= timeoutMs) {
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            count = 0;
+            resolve(0);
+          }, drainAfterMs);
+        });
+      }
+      return new Promise((resolve) => {
+        setTimeout(() => resolve(count), timeoutMs);
+      });
+    },
+  };
+}
+
+function makeRecordingLogger(): ShutdownLogger & { events: Array<[string, ShutdownStepName]> } {
+  const events: Array<[string, ShutdownStepName]> = [];
+  return {
+    events,
+    step(name) {
+      events.push(['step', name]);
+    },
+    warn(name) {
+      events.push(['warn', name]);
+    },
+  };
+}
+
+function baseCtx(over: Partial<ShutdownContext> = {}): ShutdownContext {
+  return {
+    listeners: [],
+    supervisor: null,
+    ptyHostChildren: [],
+    db: null,
+    inFlightTracker: noopInFlightTracker,
+    ...over,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Shutdown.run() — ordered sequence', () => {
+  it('returns clean result when nothing is wired (entrypoint pre-OPENING_DB failure path)', async () => {
+    const sd = new Shutdown();
+    const r = await sd.run(baseCtx());
+    expect(r.errors).toHaveLength(0);
+    expect(r.inFlightAtBudgetExpiry).toBe(0);
+    expect(r.ptyExits).toHaveLength(0);
+    expect(r.walCheckpointBusy).toBeNull();
+    expect(sd.isDone()).toBe(true);
+  });
+
+  it('stops every listener and the supervisor (data-plane first, supervisor last)', async () => {
+    const log = makeRecordingLogger();
+    const lA = makeListener('listener-a');
+    const sup = makeSupervisor();
+    const sd = new Shutdown();
+    await sd.run(baseCtx({ listeners: [lA], supervisor: sup, log }));
+    expect(lA.stop).toHaveBeenCalledTimes(1);
+    expect(sup.stop).toHaveBeenCalledTimes(1);
+    // Step ordering: stop-accepting → drain-rpc → close-pty → wal/db → supervisor-close → done.
+    const stepOrder = log.events.filter((e) => e[0] === 'step').map((e) => e[1]);
+    const stopIdx = stepOrder.indexOf('stop-accepting');
+    const supIdx = stepOrder.indexOf('supervisor-close');
+    const doneIdx = stepOrder.indexOf('done');
+    expect(stopIdx).toBeGreaterThanOrEqual(0);
+    expect(supIdx).toBeGreaterThan(stopIdx);
+    expect(doneIdx).toBeGreaterThan(supIdx);
+  });
+
+  it('drains in-flight RPC within budget and reports zero', async () => {
+    const tracker = makeTracker(3, /* drainAfterMs */ 20);
+    const sd = new Shutdown();
+    const r = await sd.run(baseCtx({ inFlightTracker: tracker, inFlightBudgetMs: 200 }));
+    expect(r.inFlightAtBudgetExpiry).toBe(0);
+    expect(r.errors).toHaveLength(0);
+  });
+
+  it('continues past stuck RPC when budget exceeded (5s spec budget)', async () => {
+    // Tracker that never drains — promise resolves with the still-pending count.
+    const tracker = makeTracker(2, /* drainAfterMs */ undefined);
+    const sd = new Shutdown();
+    const r = await sd.run(baseCtx({ inFlightTracker: tracker, inFlightBudgetMs: 30 }));
+    expect(r.inFlightAtBudgetExpiry).toBe(2);
+    // Sequence still completed.
+    expect(sd.isDone()).toBe(true);
+  });
+
+  it('default budgets match spec ch02 §4 (5s + 3s)', () => {
+    expect(DEFAULT_INFLIGHT_BUDGET_MS).toBe(5_000);
+    expect(DEFAULT_CLAUDE_SIGKILL_MS).toBe(3_000);
+  });
+});
+
+describe('Shutdown.run() — pty children (SIGTERM → SIGKILL after 3s)', () => {
+  it('calls closeAndWait with the spec-locked claude SIGKILL window', async () => {
+    const child = makePtyHandle('s1');
+    const sd = new Shutdown();
+    await sd.run(baseCtx({ ptyHostChildren: [child] }));
+    expect(child.closeAndWait).toHaveBeenCalledWith(DEFAULT_CLAUDE_SIGKILL_MS);
+  });
+
+  it('honours a caller-supplied claudeSigkillMs override', async () => {
+    const child = makePtyHandle('s1');
+    const sd = new Shutdown();
+    await sd.run(baseCtx({ ptyHostChildren: [child], claudeSigkillMs: 100 }));
+    expect(child.closeAndWait).toHaveBeenCalledWith(100);
+  });
+
+  it('classifies a SIGKILL exit as reason=sigkill (not "crashed")', async () => {
+    const child = makePtyHandle('s1', { closeBehavior: 'sigkill' });
+    const sd = new Shutdown();
+    const r = await sd.run(baseCtx({ ptyHostChildren: [child] }));
+    expect(r.ptyExits).toEqual([
+      { sessionId: 's1', reason: 'sigkill', code: null, signal: 'SIGKILL' },
+    ]);
+  });
+
+  it('records per-child closeAndWait throws into errors array but continues', async () => {
+    const c1 = makePtyHandle('s1', { closeBehavior: 'throws' });
+    const c2 = makePtyHandle('s2');
+    const sd = new Shutdown();
+    const r = await sd.run(baseCtx({ ptyHostChildren: [c1, c2] }));
+    expect(r.errors.some(([step]) => step === 'close-pty-children')).toBe(true);
+    expect(c2.closeAndWait).toHaveBeenCalled();
+    // s1 still appears in ptyExits as a synthesised crashed entry.
+    const s1 = r.ptyExits.find((e) => e.sessionId === 's1');
+    expect(s1?.reason).toBe('crashed');
+  });
+
+  it('fans out child closes in parallel (not sequentially)', async () => {
+    const c1 = makePtyHandle('s1', { closeDelayMs: 40 });
+    const c2 = makePtyHandle('s2', { closeDelayMs: 40 });
+    const sd = new Shutdown();
+    const t0 = Date.now();
+    await sd.run(baseCtx({ ptyHostChildren: [c1, c2] }));
+    const elapsed = Date.now() - t0;
+    // Sequential would be ~80ms; parallel should finish well under 70ms.
+    expect(elapsed).toBeLessThan(70);
+  });
+});
+
+describe('Shutdown.run() — WAL checkpoint + DB close', () => {
+  it('runs walCheckpointTruncate then db.close when a db is present', async () => {
+    const db = makeDb();
+    const sd = new Shutdown();
+    const r = await sd.run(baseCtx({ db }));
+    expect(db.pragma).toHaveBeenCalledWith('wal_checkpoint(TRUNCATE)');
+    expect(db.close).toHaveBeenCalledTimes(1);
+    expect(r.walCheckpointBusy).toBe(false);
+  });
+
+  it('skips checkpoint + close when db is null (pre-OPENING_DB failure path)', async () => {
+    const sd = new Shutdown();
+    const r = await sd.run(baseCtx({ db: null }));
+    expect(r.walCheckpointBusy).toBeNull();
+  });
+
+  it('records pragma failure into errors but still attempts db.close()', async () => {
+    const db = makeDb({ pragmaThrows: true });
+    const sd = new Shutdown();
+    const r = await sd.run(baseCtx({ db }));
+    expect(r.errors.some(([s]) => s === 'wal-checkpoint')).toBe(true);
+    expect(db.close).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('Shutdown.run() — error containment + idempotency', () => {
+  it('captures listener stop throws but proceeds through every later step', async () => {
+    const lA = makeListener('listener-a', { stopThrows: true });
+    const sup = makeSupervisor();
+    const db = makeDb();
+    const child = makePtyHandle('s1');
+    const sd = new Shutdown();
+    const r = await sd.run(baseCtx({ listeners: [lA], supervisor: sup, db, ptyHostChildren: [child] }));
+    expect(r.errors.some(([s]) => s === 'stop-accepting')).toBe(true);
+    expect(child.closeAndWait).toHaveBeenCalled();
+    expect(db.close).toHaveBeenCalled();
+    expect(sup.stop).toHaveBeenCalled();
+  });
+
+  it('captures supervisor stop throws into errors', async () => {
+    const sup = makeSupervisor({ stopThrows: true });
+    const sd = new Shutdown();
+    const r = await sd.run(baseCtx({ supervisor: sup }));
+    expect(r.errors.some(([s]) => s === 'supervisor-close')).toBe(true);
+  });
+
+  it('is idempotent: second concurrent run() returns the same result without re-firing side effects', async () => {
+    const lA = makeListener('listener-a');
+    const sd = new Shutdown();
+    const ctx = baseCtx({ listeners: [lA] });
+    const [r1, r2] = await Promise.all([sd.run(ctx), sd.run(ctx)]);
+    expect(r1).toBe(r2);
+    expect(lA.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('is idempotent: third sequential run() also returns the cached result', async () => {
+    const lA = makeListener('listener-a');
+    const sd = new Shutdown();
+    await sd.run(baseCtx({ listeners: [lA] }));
+    await sd.run(baseCtx({ listeners: [lA] }));
+    expect(lA.stop).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('installShutdownHandlers', () => {
+  // We mock process.exit during these cases — the handler's
+  // second-signal escape hatch calls it, which would otherwise crash
+  // the vitest worker. The mock is restored at the end of each case.
+  function mockExit(): { restore: () => void; calls: number[] } {
+    const calls: number[] = [];
+    const orig = process.exit;
+    (process as { exit: (code?: number) => never }).exit = ((code?: number): never => {
+      calls.push(code ?? 0);
+      return undefined as never;
+    }) as never;
+    return {
+      calls,
+      restore() {
+        (process as { exit: typeof orig }).exit = orig;
+      },
+    };
+  }
+
+  it('triggers exactly once on first signal and is removable after dispose', async () => {
+    const trigger = vi.fn(() => Promise.resolve());
+    const dispose = installShutdownHandlers(trigger, undefined, ['SIGUSR2']);
+    process.emit('SIGUSR2', 'SIGUSR2');
+    await new Promise((r) => setImmediate(r));
+    expect(trigger).toHaveBeenCalledTimes(1);
+    // After dispose() the handler is gone — emit again to verify.
+    dispose();
+    process.emit('SIGUSR2', 'SIGUSR2');
+    expect(trigger).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports first signal kind to the onSignal callback', async () => {
+    const trigger = vi.fn(() => Promise.resolve());
+    const onSignal = vi.fn();
+    const dispose = installShutdownHandlers(trigger, onSignal, ['SIGUSR2']);
+    process.emit('SIGUSR2', 'SIGUSR2');
+    await new Promise((r) => setImmediate(r));
+    expect(onSignal).toHaveBeenCalledWith('SIGUSR2', 'first');
+    dispose();
+  });
+
+  it('reports second signal kind on a re-emit and forces exit(1)', async () => {
+    const exitMock = mockExit();
+    const trigger = vi.fn(() => new Promise<void>(() => {})); // never resolves
+    const onSignal = vi.fn();
+    const dispose = installShutdownHandlers(trigger, onSignal, ['SIGUSR2']);
+    process.emit('SIGUSR2', 'SIGUSR2');
+    await new Promise((r) => setImmediate(r));
+    process.emit('SIGUSR2', 'SIGUSR2');
+    // Wait long enough for the 50ms grace timer to fire.
+    await new Promise((r) => setTimeout(r, 80));
+    expect(onSignal).toHaveBeenCalledWith('SIGUSR2', 'second');
+    expect(exitMock.calls).toContain(1);
+    dispose();
+    exitMock.restore();
+  });
+
+  it('exports SIGTERM + SIGINT as the default shutdown signal set', () => {
+    expect(SHUTDOWN_SIGNALS).toContain('SIGTERM' as NodeJS.Signals);
+    expect(SHUTDOWN_SIGNALS).toContain('SIGINT' as NodeJS.Signals);
+  });
+});

--- a/packages/daemon/src/shutdown.ts
+++ b/packages/daemon/src/shutdown.ts
@@ -1,0 +1,472 @@
+// Daemon graceful shutdown — spec ch02 §4 (shutdown order).
+//
+// T1.8 scope: orchestrate the shutdown sequence triggered by SIGTERM /
+// SIGINT (POSIX), Windows `SERVICE_CONTROL_STOP`, OR an authorized
+// `/shutdown` RPC on the Supervisor UDS (see ch03 §7 + supervisor.ts
+// `onShutdown` callback).
+//
+// Spec ch02 §4 ordering — all steps below execute in this exact order;
+// each step is best-effort (a failure logs + continues so the process
+// still exits within the budget):
+//
+//   1. **Stop accepting** — close every Listener (data-plane). New
+//      Connect-RPC connects fail with ECONNREFUSED; in-flight calls
+//      keep their socket and continue. Supervisor server is closed
+//      LAST (after the data plane drains) so a stuck shutdown can
+//      still be diagnosed via `/healthz` if a third party (e.g. the
+//      installer's wait loop) is polling.
+//   2. **Drain RPC** — wait for in-flight unary RPCs up to
+//      `inFlightBudgetMs = 5000`. Streaming RPCs are signalled to abort
+//      at step 1's listener close; we do NOT wait for client-side
+//      cleanup of bidi streams (the spec phrases this as "send `aborted`
+//      and close" — Listener close already closes the http2 sessions).
+//   3. **SIGTERM claude children** — for every running pty-host child,
+//      ask it to forward `SIGTERM` to its `claude` CLI grandchild.
+//      The pty-host child receives a `{kind:'close'}` IPC message which
+//      it already knows how to handle (see pty-host/host.ts
+//      `closeAndWait` — which is the "send close, escalate to SIGKILL
+//      after timeout" primitive we re-use here).
+//   4. **SIGKILL after 3s** — `closeAndWait(3000)` already escalates to
+//      SIGKILL when the pty-host child does not exit; that covers both
+//      the child AND its `claude` grandchild because killing the child
+//      reaps `claude` automatically (pty-host/host.ts header comment).
+//   5. **Close pty-host children** — `closeAndWait` resolves with the
+//      exit outcome regardless; we just await all of them.
+//   6. **Checkpoint WAL** — `walCheckpointTruncate(db)` flushes the
+//      WAL frames into the main DB and truncates the `-wal` file to
+//      zero bytes so the next boot starts from a clean state
+//      (db/sqlite.ts header comment + ch07 §5).
+//   7. **Close DB** — `db.close()`. better-sqlite3 is synchronous so
+//      this is a single call.
+//   8. **Exit** — the caller (entrypoint) decides exit code 0/1; the
+//      orchestrator returns a result describing what happened so the
+//      entrypoint can pick.
+//
+// SRP layering:
+//   - **decider** — `Shutdown.run()` orchestrates the ordered sequence
+//     of awaits. It calls injected callables for every side effect; it
+//     does NOT itself open / close / kill anything.
+//   - **sinks** — every step's actual side effect is supplied by the
+//     caller as an injected dependency: `listenerStop()`, `supervisorStop()`,
+//     `closeAndKillPty(handle)`, `walCheckpoint(db)`, `dbClose(db)`.
+//     This keeps the shutdown module pure (testable without real
+//     sockets/sqlite/forks) and matches the spec's "structural
+//     containment" theme: each subsystem owns its own teardown
+//     primitive; the orchestrator only sequences them.
+//   - **producers** — none in this module.
+//
+// Layer 1 — alternatives checked:
+//   - `npm:graceful-shutdown` / `terminus` / `lightship` — generic
+//     web-server shutdown helpers; none model our ordered staircase
+//     (RPC drain → claude SIGTERM/KILL → WAL → DB) and none expose a
+//     hook between "stop listeners" and "kill child processes". A
+//     wrapper around them would invert control such that we'd still
+//     write all our hooks; net cost: same code + a dep.
+//   - Re-using `closeAndWait` from `pty-host/host.ts` — yes, we re-use
+//     it. The existing helper already implements steps 3+4 (send close
+//     + escalate to SIGKILL after timeout) for a single child; we just
+//     fan it out across all running children with `Promise.all`.
+//   - Building a per-RPC tracker here — no. The Connect-RPC handler
+//     wiring is T2.x's surface; we accept an `inFlightTracker` shape
+//     so when T2.x lands its handler interceptor it can register here
+//     without us re-shaping the orchestrator. The tracker shape is
+//     intentionally minimal (one method: `waitForInFlight(timeoutMs)`)
+//     to keep the seam narrow.
+//
+// What this file is NOT:
+//   - Signal-handler installation — `installShutdownHandlers(...)` is
+//     a thin convenience but the daemon entrypoint owns the decision
+//     of *which* signals trigger shutdown. Tests bypass it entirely.
+//   - The `/shutdown` RPC handler — that lives in supervisor/server.ts
+//     `onShutdown` callback; the entrypoint wires the callback to call
+//     `Shutdown.run()`.
+//   - Crash-time fast exit — uncaught exceptions / OOM go through
+//     crash collector (T5.10), NOT through this module. Graceful
+//     shutdown assumes the lifecycle is healthy enough to drain.
+
+import type { SqliteDatabase } from './db/sqlite.js';
+import { walCheckpointTruncate } from './db/sqlite.js';
+import type { Listener } from './listeners/types.js';
+import type { PtyHostChildHandle } from './pty-host/index.js';
+import type { SupervisorServer } from './supervisor/server.js';
+
+// ---------------------------------------------------------------------------
+// Spec-locked timing budgets (ch02 §4)
+// ---------------------------------------------------------------------------
+
+/** In-flight unary RPC drain budget (ms). Spec ch02 §4 "≤5s budget". */
+export const DEFAULT_INFLIGHT_BUDGET_MS = 5_000;
+/** SIGTERM → SIGKILL escalation window for `claude` grandchildren (ms). Spec ch02 §4 "SIGKILL after 3s". */
+export const DEFAULT_CLAUDE_SIGKILL_MS = 3_000;
+
+// ---------------------------------------------------------------------------
+// In-flight RPC tracker — shape only (T2.x wires the impl)
+// ---------------------------------------------------------------------------
+
+/**
+ * Tracks the count of in-flight unary RPCs. The Connect-RPC handler
+ * interceptor (T2.x) increments on each request entry and decrements on
+ * response completion; the orchestrator awaits `waitForInFlight()` to
+ * know when the drain budget can be released early.
+ *
+ * v0.3 ships the shape so T1.8's orchestrator surface is stable; T2.x's
+ * interceptor populates the impl. Until then the entrypoint can pass
+ * `noopInFlightTracker` and the budget acts as a fixed-time pause.
+ */
+export interface InFlightTracker {
+  /**
+   * Resolve when the in-flight count reaches zero, OR when `timeoutMs`
+   * elapses (whichever is first). Returns the observed count at the
+   * moment the promise settled — `0` if drained, `>0` if budget exceeded.
+   * MUST NOT throw under normal operation.
+   */
+  waitForInFlight(timeoutMs: number): Promise<number>;
+}
+
+/**
+ * No-op tracker for callers that have not yet wired RPC counting (and
+ * for unit tests of unrelated paths). Resolves with `0` immediately,
+ * regardless of `timeoutMs`. Spec ch02 §4 still requires the budget
+ * pause when in-flight is unknown; the entrypoint achieves that by
+ * either passing a real tracker OR by *not* using this no-op for
+ * production paths. Documented loud here so a careless T2.x grep
+ * doesn't ship the no-op into production.
+ */
+export const noopInFlightTracker: InFlightTracker = {
+  waitForInFlight(): Promise<number> {
+    return Promise.resolve(0);
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Shutdown context + result
+// ---------------------------------------------------------------------------
+
+/**
+ * Caller-supplied dependencies. Every field is a pure function /
+ * already-constructed handle so the orchestrator can be unit-tested by
+ * passing mocks for each.
+ */
+export interface ShutdownContext {
+  /** Data-plane listeners (Listener A; future Listener B in v0.4). Closed in step 1. */
+  readonly listeners: ReadonlyArray<Listener>;
+  /** Supervisor UDS server. Closed AFTER data-plane (so `/healthz` survives the drain window). */
+  readonly supervisor: SupervisorServer | null;
+  /**
+   * Snapshot of currently running pty-host children. The orchestrator
+   * does not own the registry — caller passes an array so mid-shutdown
+   * spawn races are the caller's concern (v0.3 entrypoint will freeze
+   * the session manager BEFORE calling `run()`).
+   */
+  readonly ptyHostChildren: ReadonlyArray<PtyHostChildHandle>;
+  /** SQLite handle. `null` if the daemon failed before phase OPENING_DB. */
+  readonly db: SqliteDatabase | null;
+  /** RPC in-flight tracker. Pass `noopInFlightTracker` if RPC layer is not wired. */
+  readonly inFlightTracker: InFlightTracker;
+  /** Optional structured logger. Defaults to the no-op logger; entrypoint passes a real one. */
+  readonly log?: ShutdownLogger;
+  /** Override the in-flight RPC drain budget (ms). Defaults to 5000. */
+  readonly inFlightBudgetMs?: number;
+  /** Override the SIGTERM→SIGKILL claude grandchild window (ms). Defaults to 3000. */
+  readonly claudeSigkillMs?: number;
+}
+
+/** Per-step log surface. Lets T9 (structured logger) plug in without
+ *  this module knowing about log levels / json shapes. */
+export interface ShutdownLogger {
+  step(name: ShutdownStepName, detail?: Record<string, unknown>): void;
+  warn(name: ShutdownStepName, err: unknown, detail?: Record<string, unknown>): void;
+}
+
+const noopLogger: ShutdownLogger = {
+  step(): void {},
+  warn(): void {},
+};
+
+/** Names of the ordered steps; useful for logs and tests. */
+export type ShutdownStepName =
+  | 'stop-accepting'
+  | 'drain-rpc'
+  | 'close-pty-children'
+  | 'wal-checkpoint'
+  | 'db-close'
+  | 'supervisor-close'
+  | 'done';
+
+/**
+ * Result returned from `Shutdown.run()`. Surfaces enough to let the
+ * entrypoint decide between exit 0 (clean drain) and exit 1 (budget
+ * exceeded or step error) without re-deriving anything from logs.
+ */
+export interface ShutdownResult {
+  /**
+   * Number of unary RPCs still in flight when the drain budget elapsed.
+   * `0` means clean drain; `>0` means the budget was exceeded (the
+   * orchestrator continues anyway so the process exits within the
+   * total ch02 §4 budget).
+   */
+  readonly inFlightAtBudgetExpiry: number;
+  /** Pty-host child exit outcomes (one per handle in `ctx.ptyHostChildren`). */
+  readonly ptyExits: ReadonlyArray<{
+    readonly sessionId: string;
+    readonly reason: 'graceful' | 'crashed' | 'sigkill';
+    readonly code: number | null;
+    readonly signal: NodeJS.Signals | null;
+  }>;
+  /** Whether the WAL TRUNCATE checkpoint reported `busy === 0`. `null` if no DB was open. */
+  readonly walCheckpointBusy: boolean | null;
+  /**
+   * Per-step errors caught by the orchestrator. Empty array on a fully
+   * clean shutdown. Each entry is `[stepName, error]`. Spec ch02 §4
+   * does not stop the sequence on a single step failure — the daemon
+   * MUST exit, even messily.
+   */
+  readonly errors: ReadonlyArray<readonly [ShutdownStepName, Error]>;
+  /** Total elapsed milliseconds from `run()` entry to return. */
+  readonly elapsedMs: number;
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrator
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the full shutdown sequence per spec ch02 §4. Returns a structured
+ * result; never throws (every step's failure is captured into
+ * `result.errors` so the caller's exit decision is data-driven).
+ *
+ * Idempotent: `run()` may be called multiple times concurrently; the
+ * second + later calls return a `done`-shaped result without repeating
+ * any side effect. The internal latch is per-`Shutdown` instance, NOT
+ * a module-level singleton — tests construct their own instance per case.
+ */
+export class Shutdown {
+  private done: ShutdownResult | null = null;
+  private inProgress: Promise<ShutdownResult> | null = null;
+
+  async run(ctx: ShutdownContext): Promise<ShutdownResult> {
+    if (this.done !== null) return this.done;
+    if (this.inProgress !== null) return this.inProgress;
+    this.inProgress = this.runOnce(ctx).then((r) => {
+      this.done = r;
+      this.inProgress = null;
+      return r;
+    });
+    return this.inProgress;
+  }
+
+  /** Reports whether `run()` has completed. Useful for `/healthz` sentinel. */
+  isDone(): boolean {
+    return this.done !== null;
+  }
+
+  private async runOnce(ctx: ShutdownContext): Promise<ShutdownResult> {
+    const log = ctx.log ?? noopLogger;
+    const startedAt = Date.now();
+    const errors: Array<readonly [ShutdownStepName, Error]> = [];
+    const inFlightBudget = ctx.inFlightBudgetMs ?? DEFAULT_INFLIGHT_BUDGET_MS;
+    const claudeSigkill = ctx.claudeSigkillMs ?? DEFAULT_CLAUDE_SIGKILL_MS;
+
+    // ---- Step 1: stop accepting new connects on every data-plane listener.
+    log.step('stop-accepting', { count: ctx.listeners.length });
+    for (const l of ctx.listeners) {
+      try {
+        await l.stop();
+      } catch (err) {
+        errors.push(['stop-accepting', toError(err)]);
+        log.warn('stop-accepting', err, { id: l.id });
+      }
+    }
+
+    // ---- Step 2: drain in-flight unary RPCs (≤ budget).
+    log.step('drain-rpc', { budgetMs: inFlightBudget });
+    let inFlightAtBudgetExpiry = 0;
+    try {
+      inFlightAtBudgetExpiry = await ctx.inFlightTracker.waitForInFlight(inFlightBudget);
+    } catch (err) {
+      // Tracker promised never to throw, but if a buggy impl does we
+      // log + treat as "budget exceeded with unknown count".
+      errors.push(['drain-rpc', toError(err)]);
+      inFlightAtBudgetExpiry = -1;
+    }
+
+    // ---- Steps 3+4+5: SIGTERM claude children, escalate to SIGKILL after 3s,
+    //                   await all exits.
+    log.step('close-pty-children', {
+      count: ctx.ptyHostChildren.length,
+      sigkillAfterMs: claudeSigkill,
+    });
+    const ptyExits: ShutdownResult['ptyExits'] = await Promise.all(
+      ctx.ptyHostChildren.map(async (h) => {
+        try {
+          const exit = await h.closeAndWait(claudeSigkill);
+          return {
+            sessionId: h.sessionId,
+            // `closeAndWait` returns `{reason: 'graceful' | 'crashed', ...}`;
+            // when it had to SIGKILL the signal will be 'SIGKILL' so we
+            // re-classify here for the orchestrator's external surface.
+            reason:
+              exit.signal === 'SIGKILL'
+                ? ('sigkill' as const)
+                : (exit.reason as 'graceful' | 'crashed'),
+            code: exit.code,
+            signal: exit.signal,
+          };
+        } catch (err) {
+          errors.push(['close-pty-children', toError(err)]);
+          return {
+            sessionId: h.sessionId,
+            reason: 'crashed' as const,
+            code: null,
+            signal: null,
+          };
+        }
+      }),
+    );
+
+    // ---- Step 6: WAL checkpoint TRUNCATE.
+    let walCheckpointBusy: boolean | null = null;
+    if (ctx.db !== null) {
+      log.step('wal-checkpoint');
+      try {
+        const r = walCheckpointTruncate(ctx.db);
+        walCheckpointBusy = r.busy === 1;
+      } catch (err) {
+        errors.push(['wal-checkpoint', toError(err)]);
+        log.warn('wal-checkpoint', err);
+      }
+    }
+
+    // ---- Step 7: close DB.
+    if (ctx.db !== null) {
+      log.step('db-close');
+      try {
+        ctx.db.close();
+      } catch (err) {
+        errors.push(['db-close', toError(err)]);
+        log.warn('db-close', err);
+      }
+    }
+
+    // ---- Last: close the supervisor (so external `/healthz` polling
+    //            survives the drain window).
+    if (ctx.supervisor !== null) {
+      log.step('supervisor-close');
+      try {
+        await ctx.supervisor.stop();
+      } catch (err) {
+        errors.push(['supervisor-close', toError(err)]);
+        log.warn('supervisor-close', err);
+      }
+    }
+
+    log.step('done', { elapsedMs: Date.now() - startedAt, errorCount: errors.length });
+
+    return {
+      inFlightAtBudgetExpiry,
+      ptyExits,
+      walCheckpointBusy,
+      errors,
+      elapsedMs: Date.now() - startedAt,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Signal-handler convenience (entrypoint plumbing)
+// ---------------------------------------------------------------------------
+
+/** Signals that should trigger graceful shutdown on POSIX (Windows uses
+ *  SERVICE_CONTROL_STOP which Node surfaces as SIGINT under most service
+ *  managers; SIGTERM is included for parity with `kill <pid>`). */
+export const SHUTDOWN_SIGNALS: ReadonlyArray<NodeJS.Signals> = ['SIGTERM', 'SIGINT'];
+
+/**
+ * Install one-shot signal handlers that invoke `trigger()` exactly once,
+ * regardless of how many signals fire. Returns a disposer that removes
+ * the handlers (used by tests to avoid leaking listeners across cases).
+ *
+ * The handler is one-shot because spec ch02 §4 requires ordered cleanup;
+ * a second SIGTERM mid-shutdown should NOT restart the sequence (it
+ * would double-close listeners). A second SIGINT from an impatient
+ * operator does, however, trigger `process.exit(1)` to bypass any
+ * stuck step — see `forceExitOnSecondSignal` below.
+ *
+ * @param trigger    Called once on first signal; should return the
+ *                   `Shutdown.run()` promise so the second-signal
+ *                   force-exit can race it.
+ * @param onSignal   Optional notification (signal name) for logging
+ *                   layers. Fires on EVERY signal (including the second).
+ */
+export function installShutdownHandlers(
+  trigger: () => Promise<unknown>,
+  onSignal?: (sig: NodeJS.Signals, kind: 'first' | 'second') => void,
+  signals: ReadonlyArray<NodeJS.Signals> = SHUTDOWN_SIGNALS,
+): () => void {
+  let fired = false;
+  let runPromise: Promise<unknown> | null = null;
+  let forceExitTimer: NodeJS.Timeout | null = null;
+
+  const handler = (sig: NodeJS.Signals): void => {
+    if (!fired) {
+      fired = true;
+      onSignal?.(sig, 'first');
+      try {
+        runPromise = trigger();
+      } catch (err) {
+        // `trigger` should never throw synchronously (it awaits run());
+        // if it does, log via stderr so the operator sees the failure.
+        process.stderr.write(`[ccsm-daemon] shutdown trigger threw: ${String(err)}\n`);
+      }
+      return;
+    }
+    onSignal?.(sig, 'second');
+    forceExitTimer = forceExitOnSecondSignal(runPromise);
+  };
+
+  for (const sig of signals) {
+    process.on(sig, handler);
+  }
+  return () => {
+    for (const sig of signals) {
+      process.removeListener(sig, handler);
+    }
+    // Cancel any pending force-exit timer so tests + clean disposers
+    // don't leave a 50ms `process.exit` landmine in the event loop.
+    if (forceExitTimer !== null) {
+      clearTimeout(forceExitTimer);
+      forceExitTimer = null;
+    }
+  };
+}
+
+/**
+ * Second-signal escape hatch — if a step is stuck (e.g. a misbehaving
+ * pty-host child that won't even die on SIGKILL because it's blocked
+ * in an uninterruptable syscall), the operator's second Ctrl-C should
+ * exit the process within ~50ms. We give the in-progress run one final
+ * 50ms tick to finish gracefully, then `process.exit(1)`.
+ *
+ * Returns the scheduled timer (if any) so the caller can clearTimeout
+ * it during disposer cleanup.
+ */
+function forceExitOnSecondSignal(runPromise: Promise<unknown> | null): NodeJS.Timeout | null {
+  if (runPromise === null) {
+    process.exit(1);
+    return null;
+  }
+  const grace = setTimeout(() => process.exit(1), 50);
+  void runPromise.finally(() => {
+    clearTimeout(grace);
+    process.exit(1);
+  });
+  return grace;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function toError(x: unknown): Error {
+  return x instanceof Error ? x : new Error(String(x));
+}


### PR DESCRIPTION
## Summary

Implements graceful shutdown orchestrator per spec ch02 §4 (Task #25).

**Order**: stop accepting → drain RPC (5s budget) → SIGTERM claude children → SIGKILL after 3s → close pty-host children → WAL checkpoint TRUNCATE → close DB → close Supervisor (last so `/healthz` survives the drain window).

**Files**:
- `packages/daemon/src/shutdown.ts` (NEW) — `Shutdown.run(ctx)` orchestrator + `installShutdownHandlers` SIGTERM/SIGINT wiring + `InFlightTracker` shape (T2.x interceptor populates impl).
- `packages/daemon/src/shutdown.spec.ts` (NEW) — 21 unit tests covering every spec branch.
- `packages/daemon/src/index.ts` — wires the orchestrator + signal handlers; mutable `ctxRef` so later tasks (T1.4 listener, T5.1 db, T4.x pty children) register their handles as they land.

## Design notes

- **SRP**: `shutdown.ts` is a pure decider. Every side effect is an injected sink (`Listener.stop`, `SupervisorServer.stop`, `PtyHostChildHandle.closeAndWait`, `walCheckpointTruncate`, `db.close`). Test seam = the same trait shapes (#28 / Listener trait, supervisor server trait).
- **Re-use, not re-invent**: `walCheckpointTruncate` from #58 (`packages/daemon/src/db/sqlite.ts`); `PtyHostChildHandle.closeAndWait` (already implements SIGTERM→SIGKILL escalation). The orchestrator only sequences them.
- **Error containment**: each step's failure is captured into `ShutdownResult.errors`; the sequence never aborts mid-way (spec ch02 §4 requires the daemon to exit even messily).
- **Idempotent**: concurrent + sequential `run()` calls return the cached result; no side effect re-fires.
- **Second-signal escape hatch**: a second SIGTERM/SIGINT triggers `process.exit(1)` after a 50ms grace; disposer cancels the timer for clean teardown.

## Layer 1

- Considered `npm:terminus`/`lightship` — none model our ordered staircase, would still need every hook. Skipped.
- Considered building per-RPC tracker here — out of scope; T2.x owns the Connect interceptor wiring. Shipped the `InFlightTracker` shape so the seam is stable.

## Test plan

Local unit tests (`pnpm --filter @ccsm/daemon exec vitest run src/shutdown.spec.ts`):

```
 Test Files  1 passed (1)
      Tests  21 passed (21)
   Duration  2.05s

 ✓ Shutdown.run() — ordered sequence (5)
   ✓ returns clean result when nothing is wired
   ✓ stops every listener and the supervisor (data-plane first, supervisor last)
   ✓ drains in-flight RPC within budget and reports zero
   ✓ continues past stuck RPC when budget exceeded (5s spec budget)
   ✓ default budgets match spec ch02 §4 (5s + 3s)
 ✓ Shutdown.run() — pty children (SIGTERM → SIGKILL after 3s) (5)
   ✓ calls closeAndWait with the spec-locked claude SIGKILL window
   ✓ honours a caller-supplied claudeSigkillMs override
   ✓ classifies a SIGKILL exit as reason=sigkill (not "crashed")
   ✓ records per-child closeAndWait throws into errors but continues
   ✓ fans out child closes in parallel (not sequentially)
 ✓ Shutdown.run() — WAL checkpoint + DB close (3)
   ✓ runs walCheckpointTruncate then db.close when a db is present
   ✓ skips checkpoint + close when db is null (pre-OPENING_DB failure path)
   ✓ records pragma failure into errors but still attempts db.close()
 ✓ Shutdown.run() — error containment + idempotency (4)
   ✓ captures listener stop throws but proceeds through every later step
   ✓ captures supervisor stop throws into errors
   ✓ is idempotent: second concurrent run() returns the same result
   ✓ is idempotent: third sequential run() also returns the cached result
 ✓ installShutdownHandlers (4)
   ✓ triggers exactly once on first signal and is removable after dispose
   ✓ reports first signal kind to the onSignal callback
   ✓ reports second signal kind on a re-emit and forces exit(1)
   ✓ exports SIGTERM + SIGINT as the default shutdown signal set
```

Quality gates (all pass):
- `pnpm lint` — pass (workspace).
- `pnpm --filter @ccsm/daemon run typecheck` — pass.
- `pnpm --filter @ccsm/daemon test` — 339 pass / 21 of mine + 318 pre-existing. One pre-existing failure on Windows (`test/descriptor/schema.spec.ts` CRLF golden mismatch) is unrelated to this PR — confirmed by checking out origin/working and re-running the same case (same failure). CI on Linux will pass.

## Scope notes

- **Not** wired into a running daemon yet because no listeners/db/pty children are constructed by the T1.1 startup stub. Later tasks (T1.4 listener, T5.1 db, T4.x pty) populate `ctxRef` as they land.
- **Not** wired to the Supervisor `/shutdown` RPC `onShutdown` callback yet — that wiring lives in the entrypoint when the supervisor server is constructed (currently a TODO at the entrypoint's STARTING_LISTENERS phase). One-line addition when supervisor instantiation lands.