### PR TITLE
test(T8.10): integration spec family (peer-cred / version / crash / settings)

### DIFF
--- a/packages/daemon/test/integration/crash-getlog.spec.ts
+++ b/packages/daemon/test/integration/crash-getlog.spec.ts
@@ -1,0 +1,339 @@
+// packages/daemon/test/integration/crash-getlog.spec.ts
+//
+// T8.10 — integration spec: CrashService.GetCrashLog returns historical
+// entries with `since_unix_ms`-based pagination.
+//
+// Spec ch12 §3:
+//   "crash-getlog.spec.ts — CrashService.GetCrashLog happy path (returns
+//    latest N rows); error path (`NotFound` for unknown id)."
+//
+// Spec ch04 §5 (CrashService.GetCrashLog) — request shape:
+//   `int32 limit` (daemon caps at 1000), `int64 since_unix_ms` (0 == no
+//   lower bound), `OwnerFilter owner_filter`. The cursor mechanism is
+//   the (since_unix_ms, ts_unix_ms) pair: callers paginate by feeding the
+//   last received entry's `ts_unix_ms` back as `since_unix_ms` on the
+//   next call. This is the v0.3 contract — `next_page_token`-style
+//   opaque cursors are NOT in the wire schema (forever-stable).
+//
+// Out of scope:
+//   - The real CrashManager + DB-backed log (T5.11 / Task #62) — this
+//     spec stands in an in-memory store keyed by ts. The wire shape
+//     under test is independent of how the rows are persisted.
+//   - The owner_filter row-level enforcement is also exercised here
+//     (caller's principalKey + daemon-self default per ch04 §5).
+//
+// Error path note on the spec's "NotFound for unknown id" wording: the
+// `GetCrashLog` RPC takes no `id` field — it returns a *page* of entries.
+// Spec ch04 §5 only ships GetCrashLog and WatchCrashLog (+ GetRawCrashLog).
+// The "NotFound by id" error path the ch12 §3 prose mentions does not map
+// to any current proto field, so we cover the closest contract surface
+// the schema allows: a paged query whose `since_unix_ms` is past the
+// most recent entry returns an empty page (NOT a NotFound — empty list
+// is the canonical "no rows match" signal in proto3 collections, and
+// surfacing NotFound for an empty page would be a forbidden semantic
+// (returning an error for a valid-but-empty result). The actual NotFound
+// path lives in `crash-getentry.spec.ts` if/when a GetCrashEntry(id) RPC
+// is added in v0.4 — currently absent from the proto.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { create } from '@bufbuild/protobuf';
+import type { HandlerContext } from '@connectrpc/connect';
+
+import {
+  CrashEntrySchema,
+  CrashService,
+  type GetCrashLogRequest,
+  GetCrashLogResponseSchema,
+  OwnerFilter,
+} from '@ccsm/proto';
+
+import {
+  PRINCIPAL_KEY,
+  principalKey,
+} from '../../src/auth/index.js';
+import type { CrashRawEntry } from '../../src/crash/raw-appender.js';
+import {
+  TEST_PRINCIPAL_KEY,
+  newRequestMeta,
+  startHarness,
+  type Harness,
+} from './harness.js';
+
+// ---------------------------------------------------------------------------
+// In-memory crash store stand-in (mirrors the columns DB-backed crash_log
+// will hold per migrations/001_initial.sql crash_log table).
+// ---------------------------------------------------------------------------
+
+interface StoredEntry extends CrashRawEntry {}
+
+class CrashStore {
+  private readonly rows: StoredEntry[] = [];
+
+  /** Append in arbitrary order; query returns DESC by ts. */
+  insert(...entries: StoredEntry[]): void {
+    this.rows.push(...entries);
+  }
+
+  /**
+   * Mirror of the daemon-side query:
+   *   SELECT * FROM crash_log
+   *   WHERE ts_ms >= ? AND owner_id IN (?, 'daemon-self')
+   *   ORDER BY ts_ms DESC
+   *   LIMIT MIN(?, 1000)
+   */
+  query(args: {
+    sinceUnixMs: number;
+    limit: number;
+    ownerFilter: OwnerFilter;
+    callerKey: string;
+  }): StoredEntry[] {
+    const { sinceUnixMs, limit, ownerFilter, callerKey } = args;
+    const cap = Math.min(limit > 0 ? limit : 1000, 1000);
+    return this.rows
+      .filter((r) => r.ts_ms >= sinceUnixMs)
+      .filter((r) => {
+        if (ownerFilter === OwnerFilter.ALL) return true;
+        // OWN: caller's principalKey OR daemon-self sentinel.
+        return r.owner_id === callerKey || r.owner_id === 'daemon-self';
+      })
+      .sort((a, b) => b.ts_ms - a.ts_ms)
+      .slice(0, cap);
+  }
+}
+
+// Per spec: daemon caps `limit` at 1000.
+const SERVER_LIMIT_CAP = 1000;
+
+function toProtoEntry(raw: StoredEntry) {
+  return create(CrashEntrySchema, {
+    id: raw.id,
+    tsUnixMs: BigInt(raw.ts_ms),
+    source: raw.source,
+    summary: raw.summary,
+    detail: raw.detail,
+    labels: { ...raw.labels },
+    ownerId: raw.owner_id,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Bring up.
+// ---------------------------------------------------------------------------
+
+let harness: Harness;
+let store: CrashStore;
+
+beforeEach(async () => {
+  store = new CrashStore();
+  harness = await startHarness({
+    setup(router) {
+      router.service(CrashService, {
+        async getCrashLog(req: GetCrashLogRequest, ctx: HandlerContext) {
+          const principal = ctx.values.get(PRINCIPAL_KEY);
+          if (principal === null) {
+            throw new Error('principal not set on context');
+          }
+          const callerKey = principalKey(principal);
+          const rows = store.query({
+            sinceUnixMs: Number(req.sinceUnixMs),
+            limit: req.limit > 0 ? req.limit : SERVER_LIMIT_CAP,
+            ownerFilter: req.ownerFilter,
+            callerKey,
+          });
+          return create(GetCrashLogResponseSchema, {
+            meta: newRequestMeta(),
+            entries: rows.map(toProtoEntry),
+          });
+        },
+      });
+    },
+  });
+});
+
+afterEach(async () => {
+  await harness.stop();
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures: 25 entries across multiple sources / owners / timestamps so
+// the pagination assertion is non-trivial.
+// ---------------------------------------------------------------------------
+
+function seedFixtures(): StoredEntry[] {
+  const entries: StoredEntry[] = [];
+  // Interleave caller + daemon-self + foreign-owner entries.
+  for (let i = 0; i < 25; i++) {
+    const owner =
+      i % 5 === 0
+        ? 'daemon-self'
+        : i % 5 === 1
+          ? 'local-user:9999'
+          : TEST_PRINCIPAL_KEY;
+    entries.push({
+      id: `01HZ0TESTGETLOG${String(i).padStart(11, '0')}`,
+      ts_ms: 1_700_000_000_000 + i * 1000,
+      source: i % 2 === 0 ? 'sqlite_op' : 'claude_exit',
+      summary: `summary ${i}`,
+      detail: `detail ${i}`,
+      labels: { i: String(i) },
+      owner_id: owner,
+    });
+  }
+  return entries;
+}
+
+// ---------------------------------------------------------------------------
+// The spec.
+// ---------------------------------------------------------------------------
+
+describe('crash-getlog (ch12 §3 / ch04 §5)', () => {
+  it('returns the latest N rows in DESC ts order, scoped to OWN by default', async () => {
+    const fixtures = seedFixtures();
+    store.insert(...fixtures);
+
+    const client = harness.makeClient(CrashService);
+    const res = await client.getCrashLog({
+      meta: newRequestMeta(),
+      limit: 5,
+      sinceUnixMs: BigInt(0),
+      ownerFilter: OwnerFilter.UNSPECIFIED, // == OWN per ch04 §5
+    });
+
+    expect(res.entries).toHaveLength(5);
+    // DESC ts order is the contract (newest first).
+    for (let i = 1; i < res.entries.length; i++) {
+      expect(res.entries[i - 1].tsUnixMs).toBeGreaterThan(res.entries[i].tsUnixMs);
+    }
+    // OWN scope: every entry's owner is the caller OR daemon-self. NO
+    // foreign-owner entries leak through.
+    for (const e of res.entries) {
+      expect([TEST_PRINCIPAL_KEY, 'daemon-self']).toContain(e.ownerId);
+    }
+  });
+
+  it('honors since_unix_ms cursor: a higher floor returns only newer entries', async () => {
+    const fixtures = seedFixtures();
+    store.insert(...fixtures);
+
+    const client = harness.makeClient(CrashService);
+
+    // Page 1: latest 3 entries (no floor).
+    const page1 = await client.getCrashLog({
+      meta: newRequestMeta(),
+      limit: 3,
+      sinceUnixMs: BigInt(0),
+      ownerFilter: OwnerFilter.OWN,
+    });
+    expect(page1.entries.length).toBeGreaterThan(0);
+    expect(page1.entries.length).toBeLessThanOrEqual(3);
+
+    // Spec ch04 §5: `since_unix_ms` is a >= floor. Re-querying with a
+    // floor SET to the newest entry's ts MUST return that entry plus any
+    // newer ones (none, in this case — we used the newest as the floor).
+    const newestTs = page1.entries[0].tsUnixMs;
+    const refetch = await client.getCrashLog({
+      meta: newRequestMeta(),
+      limit: 100,
+      sinceUnixMs: newestTs,
+      ownerFilter: OwnerFilter.OWN,
+    });
+    // Every refetched entry's ts MUST be >= the floor we sent.
+    for (const e of refetch.entries) {
+      expect(e.tsUnixMs >= newestTs).toBe(true);
+    }
+    // The newest entry itself is included (>= semantics, not >).
+    const refetchedIds = new Set(refetch.entries.map((e) => e.id));
+    expect(refetchedIds.has(page1.entries[0].id)).toBe(true);
+
+    // A floor strictly greater than the newest entry returns an empty
+    // page — pins the upper-bound semantics so a future change to <=
+    // (forbidden) is caught.
+    const beyond = await client.getCrashLog({
+      meta: newRequestMeta(),
+      limit: 100,
+      sinceUnixMs: newestTs + BigInt(1),
+      ownerFilter: OwnerFilter.OWN,
+    });
+    expect(beyond.entries).toHaveLength(0);
+
+    // The unbounded query (floor=0, limit=100) is a superset of page1.
+    const all = await client.getCrashLog({
+      meta: newRequestMeta(),
+      limit: 100,
+      sinceUnixMs: BigInt(0),
+      ownerFilter: OwnerFilter.OWN,
+    });
+    const allIds = new Set(all.entries.map((e) => e.id));
+    for (const e of page1.entries) {
+      expect(allIds.has(e.id)).toBe(true);
+    }
+  });
+
+  it('limit is capped at 1000 server-side (ch04 §5)', async () => {
+    // Insert >1000 entries; request limit=10000; server returns at most
+    // 1000. Pin this so a v0.4 PR that loosens the cap silently is
+    // caught here (spec ch04 §5: forever-stable cap).
+    const many: StoredEntry[] = [];
+    for (let i = 0; i < 1500; i++) {
+      many.push({
+        id: `01HZ0CAP${String(i).padStart(18, '0')}`,
+        ts_ms: i,
+        source: 'sqlite_op',
+        summary: 's',
+        detail: 'd',
+        labels: {},
+        owner_id: TEST_PRINCIPAL_KEY,
+      });
+    }
+    store.insert(...many);
+
+    const client = harness.makeClient(CrashService);
+    const res = await client.getCrashLog({
+      meta: newRequestMeta(),
+      limit: 10000,
+      sinceUnixMs: BigInt(0),
+      ownerFilter: OwnerFilter.OWN,
+    });
+    expect(res.entries.length).toBeLessThanOrEqual(SERVER_LIMIT_CAP);
+  });
+
+  it('empty result is an empty entries array, NOT NotFound (ch04 §5)', async () => {
+    // Empty store: query returns an empty `entries` list with the
+    // standard `RequestMeta`. NotFound would be a wire-level error and
+    // is not the right code for "no matching rows" (forbidden by the
+    // proto3 collection convention — empty repeated field is the
+    // canonical empty-result signal).
+    const client = harness.makeClient(CrashService);
+    const res = await client.getCrashLog({
+      meta: newRequestMeta(),
+      limit: 100,
+      sinceUnixMs: BigInt(0),
+      ownerFilter: OwnerFilter.OWN,
+    });
+    expect(res.entries).toHaveLength(0);
+  });
+
+  it('ALL filter is broader than OWN (forever-stable v0.4 hook); v0.3 daemon may policy-restrict', async () => {
+    // The proto allows ALL; v0.3 daemon's authorization layer SHOULD
+    // restrict it to admin principals (ch04 §5). The wire shape here
+    // pins the row-set difference: ALL returns >= OWN's count when the
+    // store has foreign-owner entries.
+    const fixtures = seedFixtures();
+    store.insert(...fixtures);
+
+    const client = harness.makeClient(CrashService);
+    const own = await client.getCrashLog({
+      meta: newRequestMeta(),
+      limit: 1000,
+      sinceUnixMs: BigInt(0),
+      ownerFilter: OwnerFilter.OWN,
+    });
+    const all = await client.getCrashLog({
+      meta: newRequestMeta(),
+      limit: 1000,
+      sinceUnixMs: BigInt(0),
+      ownerFilter: OwnerFilter.ALL,
+    });
+    expect(all.entries.length).toBeGreaterThanOrEqual(own.entries.length);
+  });
+});

--- a/packages/daemon/test/integration/crash-stream.spec.ts
+++ b/packages/daemon/test/integration/crash-stream.spec.ts
@@ -1,0 +1,415 @@
+// packages/daemon/test/integration/crash-stream.spec.ts
+//
+// T8.10 — integration spec: CrashService.WatchCrashLog streams CrashEntry
+// events from an in-memory CrashManager.
+//
+// Spec ch12 §3:
+//   "crash-stream.spec.ts — CrashService.WatchCrashLog happy path:
+//    trigger every capture source via test hooks; assert each emitted."
+//
+// Spec ch04 §5 (CrashService) + ch09 §1 (capture sources, open string set):
+//   v0.3 source enum is open-string; this spec exercises a representative
+//   set covering the categories called out in ch09 §1 (sqlite_op,
+//   uncaught_exception, claude_exit, supervisor_shutdown, ...). Adding a
+//   new source in v0.4+ does NOT require changing this spec — the assertion
+//   is "every event the CrashManager emits reaches the client", not "the
+//   client receives a specific finite set of source strings".
+//
+// Out of scope:
+//   - The real CrashManager + capture sources (T5.11 / Task #62) — this
+//     spec stands in a tiny in-memory event bus that emits the same
+//     `CrashRawEntry` shape T5.11 will produce.
+//   - The owner-scoped filter (`OwnerFilter.OWN` vs `ALL`) — covered in
+//     a separate `crash-watch-owner-filter.spec.ts` (T8.x); here we
+//     assert the OWN default delivers events whose owner matches the
+//     caller, plus the `daemon-self` sentinel which OWN includes by
+//     definition (ch12 §3 / ch09 §1).
+//
+// SRP:
+//   - Producer: a `CrashEventBus` (in-test, ~30 lines) that emits
+//     `CrashRawEntry` rows when its `emit()` is called.
+//   - Decider: the `WatchCrashLog` handler (in-test) — converts emitted
+//     events into the proto `CrashEntry` shape and pushes them through
+//     the async generator.
+//   - Sink: the client side `for-await-of` collects events; `afterEach`
+//     stops the harness and unblocks the generator.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { create } from '@bufbuild/protobuf';
+import type { HandlerContext } from '@connectrpc/connect';
+
+import {
+  CrashEntrySchema,
+  CrashService,
+  OwnerFilter,
+  type WatchCrashLogRequest,
+} from '@ccsm/proto';
+
+import {
+  PRINCIPAL_KEY,
+  principalKey,
+} from '../../src/auth/index.js';
+import type { CrashRawEntry } from '../../src/crash/raw-appender.js';
+import {
+  TEST_PRINCIPAL_KEY,
+  newRequestMeta,
+  startHarness,
+  type Harness,
+} from './harness.js';
+
+// ---------------------------------------------------------------------------
+// In-memory CrashManager stand-in.
+//
+// Why a tiny bus and not a stub T5.11 module: T5.11 owns persistence +
+// capture-source registration. The stream contract under test is purely
+// "events flow from emit() to subscribers". Reusing T5.11 here would
+// couple this spec to whatever shape that PR lands; a 30-line bus keeps
+// the assertion focused on the wire layer.
+// ---------------------------------------------------------------------------
+
+interface CrashSubscriber {
+  push(entry: CrashRawEntry): void;
+  end(): void;
+}
+
+class CrashEventBus {
+  private readonly subscribers = new Set<CrashSubscriber>();
+  private readonly waiters: Array<() => void> = [];
+
+  subscribe(sub: CrashSubscriber): () => void {
+    this.subscribers.add(sub);
+    // Wake anyone waiting for the subscriber count to be > 0.
+    while (this.waiters.length > 0) {
+      this.waiters.shift()!();
+    }
+    return () => {
+      this.subscribers.delete(sub);
+    };
+  }
+
+  /** Resolves the next time `subscribe` is called. Used by tests so they
+   *  can `await bus.waitForSubscriber()` BEFORE emitting events the
+   *  stream is supposed to deliver — eliminates the 10ms-sleep race. */
+  waitForSubscriber(): Promise<void> {
+    if (this.subscribers.size > 0) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      this.waiters.push(resolve);
+    });
+  }
+
+  emit(entry: CrashRawEntry): void {
+    for (const sub of this.subscribers) {
+      sub.push(entry);
+    }
+  }
+
+  closeAll(): void {
+    for (const sub of this.subscribers) {
+      sub.end();
+    }
+    this.subscribers.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: one event per representative capture source from ch09 §1. The
+// `daemon-self` sentinel is explicit — OWN filter MUST surface
+// daemon-self events alongside the caller's principal-attributed events
+// (ch04 §5 OWNER_FILTER_OWN definition).
+// ---------------------------------------------------------------------------
+
+function fixtureEntries(callerPrincipal: string): CrashRawEntry[] {
+  // Use deterministic ULIDs so the assertion is order-stable. The first
+  // 10 chars are time-derived in a real ULID; here we synthesize them so
+  // each test run produces the same lexicographic order.
+  return [
+    {
+      id: '01HZ0TESTSQLITEOPEN0000000A',
+      ts_ms: 1_700_000_000_000,
+      source: 'sqlite_op',
+      summary: 'sqlite OPEN failed: SQLITE_BUSY',
+      detail: 'at db.open\n  at boot',
+      labels: { op: 'open' },
+      owner_id: 'daemon-self',
+    },
+    {
+      id: '01HZ0TESTUNCAUGHTEXC00000B',
+      ts_ms: 1_700_000_001_000,
+      source: 'uncaught_exception',
+      summary: 'TypeError: cannot read x of undefined',
+      detail: 'TypeError: cannot read x of undefined\n    at handler',
+      labels: {},
+      owner_id: 'daemon-self',
+    },
+    {
+      id: '01HZ0TESTCLAUDEEXITED000C',
+      ts_ms: 1_700_000_002_000,
+      source: 'claude_exit',
+      summary: 'claude SDK exited code=137',
+      detail: 'SIGKILL',
+      labels: { session_id: 'sess-x', pid: '4242' },
+      owner_id: callerPrincipal,
+    },
+    {
+      id: '01HZ0TESTSUPERVISORDOWND',
+      ts_ms: 1_700_000_003_000,
+      source: 'supervisor_shutdown',
+      summary: 'graceful shutdown via /shutdown',
+      detail: 'reason=installer',
+      labels: { reason: 'installer' },
+      owner_id: 'daemon-self',
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Convert raw entry → proto CrashEntry. Mirrors the encoder T5.11 will
+// own (ch04 §5 wire shape, ch09 §1 owner_id contract).
+// ---------------------------------------------------------------------------
+
+function toProtoEntry(raw: CrashRawEntry) {
+  return create(CrashEntrySchema, {
+    id: raw.id,
+    tsUnixMs: BigInt(raw.ts_ms),
+    source: raw.source,
+    summary: raw.summary,
+    detail: raw.detail,
+    labels: { ...raw.labels },
+    ownerId: raw.owner_id,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Bring up + tear down — fresh bus per test so cross-test leftover events
+// cannot leak.
+// ---------------------------------------------------------------------------
+
+let harness: Harness;
+let bus: CrashEventBus;
+
+beforeEach(async () => {
+  bus = new CrashEventBus();
+  harness = await startHarness({
+    setup(router) {
+      router.service(CrashService, {
+        async *watchCrashLog(req: WatchCrashLogRequest, ctx: HandlerContext) {
+          const principal = ctx.values.get(PRINCIPAL_KEY);
+          if (principal === null) {
+            throw new Error('principal not set on context');
+          }
+          const callerKey = principalKey(principal);
+          const ownerFilter = req.ownerFilter;
+
+          // Pump pattern: subscribe to the bus, push entries onto a
+          // queue, yield from the queue inside the generator. Keeps
+          // back-pressure aligned with the consumer's pull rate.
+          const queue: CrashRawEntry[] = [];
+          let resolveNext: (() => void) | null = null;
+          let ended = false;
+
+          const unsubscribe = bus.subscribe({
+            push(entry) {
+              // OWN filter: include entries owned by the caller OR the
+              // daemon-self sentinel (ch04 §5 OWNER_FILTER_OWN
+              // definition).
+              const ownsIt =
+                entry.owner_id === callerKey ||
+                entry.owner_id === 'daemon-self';
+              const passesFilter =
+                ownerFilter === OwnerFilter.ALL ? true : ownsIt;
+              if (passesFilter) {
+                queue.push(entry);
+                if (resolveNext) {
+                  resolveNext();
+                  resolveNext = null;
+                }
+              }
+            },
+            end() {
+              ended = true;
+              if (resolveNext) {
+                resolveNext();
+                resolveNext = null;
+              }
+            },
+          });
+
+          // Honor the abort signal so afterEach's harness.stop() unblocks
+          // the generator and the test does not hang.
+          ctx.signal.addEventListener('abort', () => {
+            ended = true;
+            unsubscribe();
+            if (resolveNext) {
+              resolveNext();
+              resolveNext = null;
+            }
+          });
+
+          try {
+            while (!ended || queue.length > 0) {
+              if (queue.length === 0) {
+                await new Promise<void>((resolve) => {
+                  resolveNext = resolve;
+                });
+                continue;
+              }
+              const entry = queue.shift()!;
+              yield toProtoEntry(entry);
+            }
+          } finally {
+            unsubscribe();
+          }
+        },
+      });
+    },
+  });
+});
+
+afterEach(async () => {
+  bus.closeAll();
+  await harness.stop();
+});
+
+// ---------------------------------------------------------------------------
+// The spec.
+// ---------------------------------------------------------------------------
+
+describe('crash-stream (ch12 §3 / ch04 §5 / ch09 §1)', () => {
+  it('every emitted CrashRawEntry surfaces as a CrashEntry on the stream (OWN filter)', async () => {
+    const client = harness.makeClient(CrashService);
+    const entries = fixtureEntries(TEST_PRINCIPAL_KEY);
+
+    // Start the stream first; emit AFTER the subscriber registers so
+    // back-fill semantics are not under test (that is GetCrashLog's job
+    // — covered by crash-getlog.spec.ts).
+    const stream = client.watchCrashLog({
+      meta: newRequestMeta(),
+      ownerFilter: OwnerFilter.OWN,
+    });
+
+    const collected: Array<{ id: string; source: string; ownerId: string }> = [];
+    const collector = (async () => {
+      for await (const ev of stream) {
+        collected.push({
+          id: ev.id,
+          source: ev.source,
+          ownerId: ev.ownerId,
+        });
+        if (collected.length === entries.length) {
+          break;
+        }
+      }
+    })();
+
+    // Wait for the server-side subscription before emitting — eliminates
+    // the race where the stream generator hasn't subscribed yet.
+    await bus.waitForSubscriber();
+    for (const e of entries) bus.emit(e);
+
+    await collector;
+
+    // Order-preserving assertion: emit order MUST equal receive order
+    // for a single stream (ch04 §5 streaming contract).
+    expect(collected).toEqual(
+      entries.map((e) => ({
+        id: e.id,
+        source: e.source,
+        ownerId: e.owner_id,
+      })),
+    );
+
+    // Cross-source coverage: the spec's "trigger every capture source via
+    // test hooks; assert each emitted" demand. We pin a known set so the
+    // PR diff surfaces if a source is renamed silently in v0.4.
+    const sources = new Set(collected.map((c) => c.source));
+    expect(sources).toEqual(
+      new Set(['sqlite_op', 'uncaught_exception', 'claude_exit', 'supervisor_shutdown']),
+    );
+  });
+
+  it('OWN filter passes daemon-self sentinel entries even when caller is not "daemon-self"', async () => {
+    // Spec ch04 §5: OWNER_FILTER_OWN includes `owner_id == 'daemon-self'`
+    // alongside `owner_id == principalKey(ctx.principal)`. Daemon-side
+    // crashes are surfaced to the local user so the user can see "the
+    // daemon crashed" in the renderer.
+    const client = harness.makeClient(CrashService);
+
+    const stream = client.watchCrashLog({
+      meta: newRequestMeta(),
+      ownerFilter: OwnerFilter.OWN,
+    });
+
+    const collected: string[] = [];
+    const collector = (async () => {
+      for await (const ev of stream) {
+        collected.push(ev.ownerId);
+        if (collected.length === 2) break;
+      }
+    })();
+
+    await bus.waitForSubscriber();
+    bus.emit({
+      id: '01HZ0TESTDAEMONSELF000001',
+      ts_ms: 1,
+      source: 'sqlite_op',
+      summary: 's',
+      detail: 'd',
+      labels: {},
+      owner_id: 'daemon-self',
+    });
+    bus.emit({
+      id: '01HZ0TESTDAEMONSELF000002',
+      ts_ms: 2,
+      source: 'sqlite_op',
+      summary: 's',
+      detail: 'd',
+      labels: {},
+      owner_id: TEST_PRINCIPAL_KEY,
+    });
+
+    await collector;
+    expect(collected).toEqual(['daemon-self', TEST_PRINCIPAL_KEY]);
+  });
+
+  it('OWN filter drops events owned by other principals', async () => {
+    const client = harness.makeClient(CrashService);
+
+    const stream = client.watchCrashLog({
+      meta: newRequestMeta(),
+      ownerFilter: OwnerFilter.OWN,
+    });
+
+    const collected: string[] = [];
+    const collector = (async () => {
+      for await (const ev of stream) {
+        collected.push(ev.id);
+        if (collected.length === 1) break;
+      }
+    })();
+
+    await bus.waitForSubscriber();
+    // First entry is for a different principal — MUST be filtered out.
+    bus.emit({
+      id: '01HZ0TESTOTHERPRINCIPAL01',
+      ts_ms: 1,
+      source: 'sqlite_op',
+      summary: 's',
+      detail: 'd',
+      labels: {},
+      owner_id: 'local-user:9999',
+    });
+    // Second entry is for the caller — MUST be the only one received.
+    bus.emit({
+      id: '01HZ0TESTSELFOWNED000001',
+      ts_ms: 2,
+      source: 'sqlite_op',
+      summary: 's',
+      detail: 'd',
+      labels: {},
+      owner_id: TEST_PRINCIPAL_KEY,
+    });
+
+    await collector;
+    expect(collected).toEqual(['01HZ0TESTSELFOWNED000001']);
+  });
+});

--- a/packages/daemon/test/integration/harness.ts
+++ b/packages/daemon/test/integration/harness.ts
@@ -1,0 +1,259 @@
+// packages/daemon/test/integration/harness.ts
+//
+// Shared in-process Connect harness for the integration spec family
+// (T8.10 — peer-cred-rejection, version-mismatch, crash-stream,
+// crash-getlog, settings-roundtrip, settings-error).
+//
+// What this harness owns:
+//   - Spin up an h2c (HTTP/2 cleartext) Connect server on an ephemeral
+//     127.0.0.1 port.
+//   - Wire the daemon's `peerCredAuthInterceptor` (T1.3 / src/auth) so
+//     `ctx.principal` is populated for every handler under test.
+//   - Inject the per-connection `PeerInfo` into the Connect contextValues
+//     using the loopback-TCP "Authorization: Bearer test-token" path —
+//     the canonical Listener-A test seam (T1.5 will replace this with the
+//     UDS / named-pipe peer-cred extractors).
+//   - Hand every spec a typed Connect client + the principalKey of the
+//     authenticated caller.
+//
+// What this harness does NOT own:
+//   - Any RPC handler — each spec wires its own service implementation
+//     into the router (the SessionService Hello handler, the SettingsService
+//     impls, the CrashService stream, etc.). Handlers are deliberately
+//     spec-scoped so each .spec.ts file remains the single source of
+//     truth for what its RPC's contract is.
+//   - The descriptor file / Listener factory (T1.4) — those land in
+//     T1.4 / T1.5 and pull this harness's transport bring-up into a real
+//     production code path. Until then, the harness is the moral
+//     equivalent of a Listener-A test seam (spec ch12 §3 names this
+//     pattern: "daemon runs in-process (not service-installed) on an
+//     ephemeral port / temp UDS path").
+//   - SQLite / state-dir bring-up — settings-roundtrip.spec.ts uses
+//     `openDatabase(':memory:')` directly and seeds the `settings` table
+//     itself; harness stays storage-agnostic.
+//
+// Why a dedicated harness vs. inlining the bring-up in each spec:
+//   - SRP: every spec that needs an authenticated Connect client today
+//     would otherwise duplicate ~80 lines of http2 + interceptor wiring.
+//     One place to change when T1.5 lands the real PeerInfo injector.
+//   - Avoids re-inventing the existing rpc/clients-transport-matrix.spec.ts
+//     pattern: that file owns the multi-transport matrix (which
+//     deliberately bypasses the auth interceptor — it tests transports,
+//     not auth). T8.10 specs need the auth chain in the loop, so the
+//     harness composes the interceptor on top.
+
+import * as http2 from 'node:http2';
+import { randomUUID } from 'node:crypto';
+import { create } from '@bufbuild/protobuf';
+import {
+  type Client,
+  type ConnectRouter,
+  type Interceptor,
+  createClient,
+} from '@connectrpc/connect';
+import {
+  connectNodeAdapter,
+  createConnectTransport,
+} from '@connectrpc/connect-node';
+import type { DescService } from '@bufbuild/protobuf';
+
+import {
+  PEER_INFO_KEY,
+  TEST_BEARER_TOKEN,
+  peerCredAuthInterceptor,
+  type PeerInfo,
+} from '../../src/auth/index.js';
+import { RequestMetaSchema } from '@ccsm/proto';
+
+// ---------------------------------------------------------------------------
+// Per-test bring-up shape — returned by `startHarness` and consumed by the
+// spec's beforeEach/afterEach pair.
+// ---------------------------------------------------------------------------
+
+export interface Harness {
+  /** Authority of the server (`http://127.0.0.1:<port>`). */
+  readonly baseUrl: string;
+  /** Tear down the server + close any open http2 sessions. */
+  readonly stop: () => Promise<void>;
+  /**
+   * Make a Connect client for a given service descriptor. Each call
+   * returns a fresh client bound to the harness's transport — cheap, so
+   * specs that need multiple service clients can call this several times.
+   * The caller (loopback) is the canonical test principal `local-user:test`.
+   */
+  readonly makeClient: <T extends DescService>(desc: T) => Client<T>;
+  /**
+   * Make a client whose underlying transport sends NO Authorization header.
+   * The Connect call will reject with `Unauthenticated` at the
+   * interceptor layer before the handler runs. Used by the
+   * peer-cred-rejection spec.
+   */
+  readonly makeUnauthenticatedClient: <T extends DescService>(desc: T) => Client<T>;
+  /**
+   * Make a client whose Authorization header carries an arbitrary bearer
+   * value (e.g., a non-allowlisted user's token). Forces the
+   * `derivePrincipal` failure path under loopback-TCP transport. The
+   * peer-cred-rejection spec uses this for the wrong-token case.
+   */
+  readonly makeClientWithBearer: <T extends DescService>(
+    desc: T,
+    bearer: string,
+  ) => Client<T>;
+}
+
+// ---------------------------------------------------------------------------
+// Service-impl injection helper. Each spec passes a function that takes the
+// router and registers its handlers; the harness composes the interceptor
+// chain identically across all specs.
+// ---------------------------------------------------------------------------
+
+export type RouterSetup = (router: ConnectRouter) => void;
+
+export interface StartOptions {
+  /**
+   * Wire one or more service impls into the router. Called once at start.
+   * Specs typically pass a single arrow that calls `router.service(...)`
+   * for each service they exercise.
+   */
+  readonly setup: RouterSetup;
+  /**
+   * Optional extra server-side interceptors (after the peer-cred
+   * interceptor). Most specs leave this empty; T1.7's request-meta
+   * validator will be added here once it lands. Order matches Connect's
+   * left-to-right composition.
+   */
+  readonly extraInterceptors?: readonly Interceptor[];
+}
+
+// ---------------------------------------------------------------------------
+// PeerInfo injection — the test seam.
+//
+// The real Listener-A path (T1.5) reads peer credentials from the OS the
+// moment a connection is accepted. For the in-process harness we stand in
+// the loopback-TCP variant of `PeerInfo` because:
+//   1. h2c-loopback is the only universally-supported transport (UDS is
+//      POSIX-only, named pipe is Windows-only — see clients-transport-
+//      matrix.spec.ts skip rules);
+//   2. the daemon's `peerCredAuthInterceptor` already understands the
+//      bearer-token shape of `LoopbackTcpPeer` (TEST_BEARER_TOKEN), so we
+//      get the real interceptor decision-table in the loop without
+//      mocking it out.
+//
+// This is the explicit "mocked peer-cred middleware" path called out in
+// spec ch12 §3 peer-cred-rejection: the OS-syscall path (real second uid)
+// is gated on a self-hosted Ubuntu runner with `useradd ccsm-test-other`;
+// the matrix legs use the bearer-token mock to validate the auth chain.
+// ---------------------------------------------------------------------------
+
+const peerInfoFromHeaderInterceptor: Interceptor = (next) => async (req) => {
+  const authz = req.header.get('authorization');
+  let bearerToken: string | null = null;
+  if (authz !== null) {
+    const match = /^Bearer\s+(.+)$/i.exec(authz);
+    if (match !== null) {
+      bearerToken = match[1] ?? null;
+    }
+  }
+  const peer: PeerInfo = {
+    transport: 'loopbackTcp',
+    bearerToken,
+    remoteAddress: '127.0.0.1',
+    remotePort: 0,
+  };
+  req.contextValues.set(PEER_INFO_KEY, peer);
+  return next(req);
+};
+
+// ---------------------------------------------------------------------------
+// startHarness — the public entry point.
+// ---------------------------------------------------------------------------
+
+export async function startHarness(opts: StartOptions): Promise<Harness> {
+  const interceptors: Interceptor[] = [
+    // 1. inject PeerInfo from the request's Authorization header (replaces
+    //    the OS peer-cred extractor for in-process tests).
+    peerInfoFromHeaderInterceptor,
+    // 2. derive Principal from PeerInfo and stash on PRINCIPAL_KEY. Throws
+    //    Unauthenticated before any handler if derivation fails.
+    peerCredAuthInterceptor,
+    // 3. spec-supplied extras (e.g., request-meta validator).
+    ...(opts.extraInterceptors ?? []),
+  ];
+
+  const handler = connectNodeAdapter({
+    routes: opts.setup,
+    interceptors,
+  });
+
+  const server = http2.createServer({}, handler);
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    // OS-assigned ephemeral port — concurrent test files do not collide.
+    server.listen(0, '127.0.0.1', () => {
+      server.removeListener('error', reject);
+      resolve();
+    });
+  });
+  const addr = server.address();
+  if (!addr || typeof addr === 'string' || typeof addr.port !== 'number') {
+    throw new Error('harness: loopback listen returned no port');
+  }
+  const baseUrl = `http://127.0.0.1:${addr.port}`;
+
+  function clientWithAuth<T extends DescService>(
+    desc: T,
+    authzValue: string | null,
+  ): Client<T> {
+    const transport = createConnectTransport({
+      httpVersion: '2',
+      baseUrl,
+      // Inject the Authorization header on every call. We use a Connect
+      // client interceptor so the header is set per RPC, before Connect
+      // frames the request — this matches how a real Electron client
+      // would attach an auth header.
+      interceptors: [
+        (next) => async (req) => {
+          if (authzValue !== null) {
+            req.header.set('authorization', authzValue);
+          }
+          return next(req);
+        },
+      ],
+    });
+    return createClient(desc, transport);
+  }
+
+  return {
+    baseUrl,
+    stop: async () => {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+        // Hard timeout so a hung client connection does not pin teardown.
+        setTimeout(() => resolve(), 1000).unref();
+      });
+    },
+    makeClient: (desc) => clientWithAuth(desc, `Bearer ${TEST_BEARER_TOKEN}`),
+    makeUnauthenticatedClient: (desc) => clientWithAuth(desc, null),
+    makeClientWithBearer: (desc, bearer) =>
+      clientWithAuth(desc, `Bearer ${bearer}`),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Convenience: build a `RequestMeta` with a non-empty UUID. Every RPC
+// requires one (ch04 §2 — empty request_id → InvalidArgument
+// `request.missing_id`). Specs use this to keep test bodies short.
+// ---------------------------------------------------------------------------
+
+export function newRequestMeta() {
+  return create(RequestMetaSchema, {
+    requestId: randomUUID(),
+    clientVersion: '0.3.0-test',
+    clientSendUnixMs: BigInt(Date.now()),
+  });
+}
+
+// Re-export the principalKey of the canonical loopback test caller — specs
+// that assert owner_id matches the caller use this to avoid hardcoding the
+// string in two places.
+export const TEST_PRINCIPAL_KEY = 'local-user:test';

--- a/packages/daemon/test/integration/peer-cred-rejection.spec.ts
+++ b/packages/daemon/test/integration/peer-cred-rejection.spec.ts
@@ -1,0 +1,270 @@
+// packages/daemon/test/integration/peer-cred-rejection.spec.ts
+//
+// T8.10 — integration spec: peer-cred rejection.
+//
+// Spec ch12 §3 names this file as the lock for the TWO peer-cred failure
+// scenarios (ch03 §5 + ch05 §4):
+//
+//   (a) peer-cred resolution failure: middleware cannot resolve the
+//       calling pid → `Unauthenticated`.
+//   (b) peer-cred resolves but owner mismatch: caller's `principalKey`
+//       differs from the session's `owner_id` → `PermissionDenied`.
+//
+// Platform requirement (verbatim from ch12 §3):
+//
+//   "the OS-syscall path (real second uid binding) requires two real
+//    users; runner constraints — runs only on `matrix.os == 'ubuntu-22.04'`
+//    self-hosted runner with a pre-provisioned second account
+//    (`ccsm-test-other`) created via `useradd` in postinst; on `macos-*`
+//    and `windows-*` matrix legs, the test runs against the **mocked
+//    peer-cred middleware** (validates the auth chain but not the OS
+//    syscall) and is marked `requiresRealPeerCred=false`."
+//
+// We honor that gate exactly. The `CCSM_TEST_SECOND_USER` env var (set by
+// the self-hosted runner's pre-step to `ccsm-test-other`) flips the
+// (a)+(b) cases to use the OS-syscall variant; absent / non-linux, the
+// cases use the in-process `peerCredAuthInterceptor` driven by a
+// loopback-TCP `PeerInfo` mock — same auth chain, mocked transport.
+//
+// Why we do not also need a real second-user case for (b): owner_id
+// mismatch is a `derivePrincipal` outcome (it lands a `local-user:<uid>`
+// principal that does not match the session's recorded `owner_id`). The
+// OS syscall produces the same `LocalUser` shape the mock produces; the
+// authorization decision lives entirely in TypeScript downstream of the
+// principal. Spec ch12 §3 does not require a real-second-user run for the
+// authorization decision — it requires it for the syscall plumbing path
+// itself, which T1.5 owns.
+//
+// SRP:
+//   - Producer: `harness.ts` builds the http2 + Connect + interceptor
+//     stack; this file declares fixed handlers per case.
+//   - Decider: `derivePrincipal` (real, in the loop via the harness's
+//     interceptors) + a tiny ownership check (in-test) that mirrors the
+//     `assertOwnership` truth table T1.6 will land.
+//   - Sink: `afterEach` stops the harness; no other side effects.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { create } from '@bufbuild/protobuf';
+import {
+  Code,
+  ConnectError,
+  type HandlerContext,
+} from '@connectrpc/connect';
+
+import {
+  ErrorDetailSchema,
+  GetSessionResponseSchema,
+  LocalUserSchema,
+  PrincipalSchema,
+  SessionSchema,
+  SessionService,
+  SessionState,
+} from '@ccsm/proto';
+
+import { PRINCIPAL_KEY, principalKey } from '../../src/auth/index.js';
+import {
+  TEST_PRINCIPAL_KEY,
+  newRequestMeta,
+  startHarness,
+  type Harness,
+} from './harness.js';
+
+// ---------------------------------------------------------------------------
+// Platform / env gate per spec ch12 §3.
+// ---------------------------------------------------------------------------
+
+const REAL_PEER_CRED =
+  process.platform === 'linux' && Boolean(process.env['CCSM_TEST_SECOND_USER']);
+
+// ---------------------------------------------------------------------------
+// Fixture session — owner is a Principal whose principalKey is NOT the
+// loopback test principal (`local-user:test`). Used by the (b)
+// ownership-mismatch case.
+// ---------------------------------------------------------------------------
+
+const FIXTURE_SESSION_ID = 'sess-01HZ0000000000000000000099';
+const FIXTURE_OWNER_UID = '9999';
+const FIXTURE_SESSION_OWNER_KEY = `local-user:${FIXTURE_OWNER_UID}`;
+
+// ---------------------------------------------------------------------------
+// Handler that enforces session ownership against the request's principal.
+// This stands in for T1.6's `assertOwnership(ctx.principal, session)`. The
+// truth table is intentionally minimal (one row, one mismatch) — the unit
+// `auth.spec.ts` covers the full table; this integration test asserts the
+// *wire surface* (PermissionDenied + structured ErrorDetail.code).
+// ---------------------------------------------------------------------------
+
+function getSessionEnforcingOwnership(_req: unknown, ctx: HandlerContext) {
+  const principal = ctx.values.get(PRINCIPAL_KEY);
+  if (principal === null) {
+    // Defensive: peerCredAuthInterceptor MUST have set this before we
+    // reach a handler. If it didn't, fail loud (Internal not Unauthenticated
+    // — treating null here as an auth pass would mask a wiring bug).
+    throw new ConnectError(
+      'principal not set on context — interceptor wiring bug',
+      Code.Internal,
+    );
+  }
+  const callerKey = principalKey(principal);
+  if (callerKey !== FIXTURE_SESSION_OWNER_KEY) {
+    // Spec ch05 §4: owner mismatch → PermissionDenied with structured
+    // detail naming the session_id + the caller's principal so the
+    // client can render an unambiguous error to the user.
+    throw new ConnectError(
+      `session ${FIXTURE_SESSION_ID} is owned by a different principal`,
+      Code.PermissionDenied,
+      undefined,
+      [
+        {
+          desc: ErrorDetailSchema,
+          value: {
+            code: 'session.not_owned',
+            message: 'Session is owned by a different principal.',
+            extra: {
+              session_id: FIXTURE_SESSION_ID,
+              principal: callerKey,
+            },
+          },
+        },
+      ],
+    );
+  }
+  return create(GetSessionResponseSchema, {
+    meta: newRequestMeta(),
+    session: create(SessionSchema, {
+      id: FIXTURE_SESSION_ID,
+      state: SessionState.RUNNING,
+      cwd: '/tmp/fixture',
+      owner: create(PrincipalSchema, {
+        kind: {
+          case: 'localUser',
+          value: create(LocalUserSchema, {
+            uid: FIXTURE_OWNER_UID,
+            displayName: '',
+          }),
+        },
+      }),
+      createdUnixMs: BigInt(0),
+      lastActiveUnixMs: BigInt(0),
+    }),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Bring up + tear down once per test (each test gets a fresh ephemeral
+// port so cross-test client state cannot leak).
+// ---------------------------------------------------------------------------
+
+let harness: Harness;
+
+beforeEach(async () => {
+  harness = await startHarness({
+    setup(router) {
+      router.service(SessionService, {
+        getSession: getSessionEnforcingOwnership,
+      });
+    },
+  });
+});
+
+afterEach(async () => {
+  await harness.stop();
+});
+
+// ---------------------------------------------------------------------------
+// (a) peer-cred resolution failure → Unauthenticated.
+//
+// Mocked variant: an unauthenticated client (no Authorization header) hits
+// the loopback transport. The harness's bearer-token extraction returns
+// `null`; `derivePrincipal` rejects with `Code.Unauthenticated` BEFORE
+// the handler runs. This validates the auth chain plumbing (the
+// interceptor is in the chain in the right order) without the OS syscall.
+//
+// Real variant: when CCSM_TEST_SECOND_USER is set, T1.5's UDS extractor
+// covers the syscall path; for v0.3 T1.5 may not be merged when this
+// spec runs, so the it.todo() reserves the real-syscall slot. CI on
+// ubuntu-22.04 self-hosted will re-include once T1.5 ships.
+// ---------------------------------------------------------------------------
+
+describe('peer-cred-rejection (a) — resolution failure → Unauthenticated', () => {
+  it('mocked: client without bearer token is rejected before any handler runs', async () => {
+    const client = harness.makeUnauthenticatedClient(SessionService);
+    try {
+      await client.getSession({
+        meta: newRequestMeta(),
+        sessionId: FIXTURE_SESSION_ID,
+      });
+      expect.fail('expected Unauthenticated');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConnectError);
+      const ce = err as ConnectError;
+      expect(ce.code).toBe(Code.Unauthenticated);
+    }
+  });
+
+  it('mocked: client with a wrong bearer token is rejected with Unauthenticated', async () => {
+    // Loopback transport accepts exactly TEST_BEARER_TOKEN; any other
+    // value (including a plausible-looking one) must be rejected.
+    const client = harness.makeClientWithBearer(SessionService, 'not-the-token');
+    try {
+      await client.getSession({
+        meta: newRequestMeta(),
+        sessionId: FIXTURE_SESSION_ID,
+      });
+      expect.fail('expected Unauthenticated');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConnectError);
+      expect((err as ConnectError).code).toBe(Code.Unauthenticated);
+    }
+  });
+
+  // Real-syscall variant — gated on the self-hosted Ubuntu runner with a
+  // second uid pre-provisioned per ch12 §3. Marked `it.todo` for matrix
+  // legs where REAL_PEER_CRED is false so the spec output explicitly
+  // surfaces the gap; once T1.5 (peer-cred extractor) lands, the
+  // CCSM_TEST_SECOND_USER leg of CI re-enables this with `it.runIf`.
+  if (REAL_PEER_CRED) {
+    it.todo(
+      'real: bind UDS as ccsm-test-other; assert SO_PEERCRED-derived uid mismatches the daemon owner; expect Unauthenticated',
+    );
+  } else {
+    it.todo(
+      `real: skipped (REAL_PEER_CRED=false on ${process.platform}); requires linux self-hosted + CCSM_TEST_SECOND_USER`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// (b) peer-cred resolves but owner mismatch → PermissionDenied.
+//
+// The interceptor produces `local-user:test`; the fixture session's
+// owner_id is `local-user:9999`. Handler raises PermissionDenied with
+// `ErrorDetail.code = "session.not_owned"` so the client can render a
+// stable error string regardless of locale.
+// ---------------------------------------------------------------------------
+
+describe('peer-cred-rejection (b) — owner mismatch → PermissionDenied', () => {
+  it('caller is local-user:test, session owned by local-user:9999 → PermissionDenied with session.not_owned detail', async () => {
+    const client = harness.makeClient(SessionService);
+    try {
+      await client.getSession({
+        meta: newRequestMeta(),
+        sessionId: FIXTURE_SESSION_ID,
+      });
+      expect.fail('expected PermissionDenied');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConnectError);
+      const ce = err as ConnectError;
+      expect(ce.code).toBe(Code.PermissionDenied);
+      // The structured detail is the contract — Electron client maps
+      // `session.not_owned` to a localized "session belongs to another
+      // user" toast. Locale-free `code` is the load-bearing surface.
+      const details = ce.findDetails(ErrorDetailSchema);
+      expect(details).toHaveLength(1);
+      const detail = details[0];
+      expect(detail.code).toBe('session.not_owned');
+      expect(detail.extra['session_id']).toBe(FIXTURE_SESSION_ID);
+      expect(detail.extra['principal']).toBe(TEST_PRINCIPAL_KEY);
+    }
+  });
+});

--- a/packages/daemon/test/integration/settings-error.spec.ts
+++ b/packages/daemon/test/integration/settings-error.spec.ts
@@ -1,0 +1,395 @@
+// packages/daemon/test/integration/settings-error.spec.ts
+//
+// T8.10 — integration spec: SettingsService error paths.
+//
+// Spec ch12 §3:
+//   "settings-error.spec.ts — SettingsService error paths: Update with
+//    invalid schema returns `InvalidArgument`; Get on unknown key
+//    returns `NotFound`."
+//
+// Spec ch04 §6 (SettingsService) — error contract:
+//   - Empty `RequestMeta.request_id` → `InvalidArgument` with
+//     `ErrorDetail.code = "request.missing_id"` (ch04 §2 / F7).
+//   - SETTINGS_SCOPE_PRINCIPAL on v0.3 → `InvalidArgument` (per ch04 §6
+//     comment "rejected with InvalidArgument in v0.3").
+//   - Out-of-range CrashRetention values (max_entries > 10000 or
+//     max_age_days > 90) → `InvalidArgument` per the ch04 §6 caps.
+//   - Negative geometry (cols/rows <= 0) → `InvalidArgument`.
+//
+// Note on the spec's "Get on unknown key returns NotFound" wording: the
+// `GetSettings` RPC has no `key` field — it returns the *entire* Settings
+// for a scope. There is no "get one key" RPC in the v0.3 proto. The
+// closest contract surface is `Get` on a non-GLOBAL/non-UNSPECIFIED
+// scope (e.g., `SETTINGS_SCOPE_PRINCIPAL` in v0.3, which is the only
+// other valid enum value) — which returns `InvalidArgument`, not
+// `NotFound`, because the scope itself is wire-rejected before any
+// row lookup. We pin both surfaces and document the divergence from the
+// ch12 §3 prose: NotFound-by-key would require a new RPC the proto does
+// not declare, and adding it here would be schema drift the spec freeze
+// forbids (ch04 §1 "field numbers MUST NOT be reused or renumbered").
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { create } from '@bufbuild/protobuf';
+import type { HandlerContext } from '@connectrpc/connect';
+import { Code, ConnectError } from '@connectrpc/connect';
+
+import {
+  CrashRetentionSchema,
+  ErrorDetailSchema,
+  type GetSettingsRequest,
+  GetSettingsResponseSchema,
+  PtyGeometrySchema,
+  SettingsScope,
+  SettingsSchema,
+  SettingsService,
+  type UpdateSettingsRequest,
+  UpdateSettingsResponseSchema,
+} from '@ccsm/proto';
+
+import { newRequestMeta, startHarness, type Harness } from './harness.js';
+
+// ---------------------------------------------------------------------------
+// Caps from ch04 §6.
+// ---------------------------------------------------------------------------
+
+const CRASH_RETENTION_MAX_ENTRIES_CAP = 10000;
+const CRASH_RETENTION_MAX_AGE_DAYS_CAP = 90;
+
+// ---------------------------------------------------------------------------
+// Validating handler. Mirrors the validation T6.x's real handler will
+// own; the contract under test is the wire-level error code + the
+// structured ErrorDetail attached.
+// ---------------------------------------------------------------------------
+
+function validateSettings(s: ReturnType<typeof create<typeof SettingsSchema>>) {
+  // PtyGeometry — cols/rows must be > 0 if set (any non-positive cell
+  // count is meaningless; daemon would crash xterm-headless construction).
+  if (s.defaultGeometry !== undefined) {
+    const { cols, rows } = s.defaultGeometry;
+    if (cols <= 0 || rows <= 0) {
+      throw new ConnectError(
+        `default_geometry must be positive (got ${cols}x${rows})`,
+        Code.InvalidArgument,
+        undefined,
+        [
+          {
+            desc: ErrorDetailSchema,
+            value: {
+              code: 'settings.invalid_geometry',
+              message: 'PtyGeometry cols and rows must both be > 0.',
+              extra: {
+                cols: String(cols),
+                rows: String(rows),
+              },
+            },
+          },
+        ],
+      );
+    }
+  }
+  // CrashRetention — daemon caps at 10000 entries / 90 days (ch04 §6).
+  if (s.crashRetention !== undefined) {
+    const { maxEntries, maxAgeDays } = s.crashRetention;
+    if (
+      maxEntries < 0 ||
+      maxEntries > CRASH_RETENTION_MAX_ENTRIES_CAP ||
+      maxAgeDays < 0 ||
+      maxAgeDays > CRASH_RETENTION_MAX_AGE_DAYS_CAP
+    ) {
+      throw new ConnectError(
+        `crash_retention out of range`,
+        Code.InvalidArgument,
+        undefined,
+        [
+          {
+            desc: ErrorDetailSchema,
+            value: {
+              code: 'settings.crash_retention_out_of_range',
+              message:
+                'CrashRetention.max_entries must be 0..10000; max_age_days must be 0..90.',
+              extra: {
+                max_entries: String(maxEntries),
+                max_age_days: String(maxAgeDays),
+                max_entries_cap: String(CRASH_RETENTION_MAX_ENTRIES_CAP),
+                max_age_days_cap: String(CRASH_RETENTION_MAX_AGE_DAYS_CAP),
+              },
+            },
+          },
+        ],
+      );
+    }
+  }
+}
+
+function rejectV04Scope(scope: SettingsScope): void {
+  if (scope === SettingsScope.PRINCIPAL) {
+    // ch04 §6: "v0.3 daemon honors only SETTINGS_SCOPE_GLOBAL;
+    // SETTINGS_SCOPE_PRINCIPAL is rejected with InvalidArgument in v0.3."
+    throw new ConnectError(
+      'SETTINGS_SCOPE_PRINCIPAL is not supported in v0.3',
+      Code.InvalidArgument,
+      undefined,
+      [
+        {
+          desc: ErrorDetailSchema,
+          value: {
+            code: 'settings.scope_unsupported',
+            message:
+              'v0.3 daemon honors only SETTINGS_SCOPE_GLOBAL; PRINCIPAL is v0.4+.',
+            extra: { scope: String(scope) },
+          },
+        },
+      ],
+    );
+  }
+}
+
+function validateRequestMeta(meta: { requestId: string } | undefined): void {
+  if (!meta || meta.requestId === '') {
+    // ch04 §2 / F7: empty request_id MUST be rejected with
+    // InvalidArgument + ErrorDetail.code "request.missing_id". The
+    // daemon's request-meta interceptor will own this in T1.7; we
+    // validate at the handler edge here so the integration assertion
+    // is meaningful before T1.7 lands.
+    throw new ConnectError(
+      'request_id is required and must be a non-empty UUIDv4',
+      Code.InvalidArgument,
+      undefined,
+      [
+        {
+          desc: ErrorDetailSchema,
+          value: {
+            code: 'request.missing_id',
+            message: 'request_id is required and must be a non-empty UUIDv4.',
+            extra: {},
+          },
+        },
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Bring up.
+// ---------------------------------------------------------------------------
+
+let harness: Harness;
+
+beforeEach(async () => {
+  harness = await startHarness({
+    setup(router) {
+      router.service(SettingsService, {
+        async getSettings(req: GetSettingsRequest, _ctx: HandlerContext) {
+          validateRequestMeta(req.meta);
+          rejectV04Scope(req.scope);
+          // Stub: empty Settings. Error-path spec doesn't exercise the
+          // happy path (covered by settings-roundtrip.spec.ts).
+          return create(GetSettingsResponseSchema, {
+            meta: newRequestMeta(),
+            settings: create(SettingsSchema, {}),
+            effectiveScope: SettingsScope.GLOBAL,
+          });
+        },
+        async updateSettings(req: UpdateSettingsRequest, _ctx: HandlerContext) {
+          validateRequestMeta(req.meta);
+          rejectV04Scope(req.scope);
+          if (!req.settings) {
+            throw new ConnectError(
+              'settings is required',
+              Code.InvalidArgument,
+              undefined,
+              [
+                {
+                  desc: ErrorDetailSchema,
+                  value: {
+                    code: 'settings.missing_payload',
+                    message: 'UpdateSettingsRequest.settings is required.',
+                    extra: {},
+                  },
+                },
+              ],
+            );
+          }
+          validateSettings(req.settings);
+          return create(UpdateSettingsResponseSchema, {
+            meta: newRequestMeta(),
+            settings: req.settings,
+            effectiveScope: SettingsScope.GLOBAL,
+          });
+        },
+      });
+    },
+  });
+});
+
+afterEach(async () => {
+  await harness.stop();
+});
+
+// ---------------------------------------------------------------------------
+// The spec.
+// ---------------------------------------------------------------------------
+
+describe('settings-error (ch12 §3 / ch04 §6)', () => {
+  it('Update with non-positive PtyGeometry → InvalidArgument + settings.invalid_geometry', async () => {
+    const client = harness.makeClient(SettingsService);
+    try {
+      await client.updateSettings({
+        meta: newRequestMeta(),
+        settings: create(SettingsSchema, {
+          defaultGeometry: create(PtyGeometrySchema, { cols: 0, rows: 24 }),
+        }),
+        scope: SettingsScope.GLOBAL,
+      });
+      expect.fail('expected InvalidArgument');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConnectError);
+      const ce = err as ConnectError;
+      expect(ce.code).toBe(Code.InvalidArgument);
+      const detail = ce.findDetails(ErrorDetailSchema)[0];
+      expect(detail.code).toBe('settings.invalid_geometry');
+      expect(detail.extra['cols']).toBe('0');
+    }
+  });
+
+  it('Update with CrashRetention.max_entries > 10000 → InvalidArgument', async () => {
+    const client = harness.makeClient(SettingsService);
+    try {
+      await client.updateSettings({
+        meta: newRequestMeta(),
+        settings: create(SettingsSchema, {
+          crashRetention: create(CrashRetentionSchema, {
+            maxEntries: 10001,
+            maxAgeDays: 30,
+          }),
+        }),
+        scope: SettingsScope.GLOBAL,
+      });
+      expect.fail('expected InvalidArgument');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConnectError);
+      const ce = err as ConnectError;
+      expect(ce.code).toBe(Code.InvalidArgument);
+      const detail = ce.findDetails(ErrorDetailSchema)[0];
+      expect(detail.code).toBe('settings.crash_retention_out_of_range');
+      // Cap values are part of the contract — clients show the cap to
+      // the user in the validation error UI.
+      expect(detail.extra['max_entries_cap']).toBe('10000');
+      expect(detail.extra['max_age_days_cap']).toBe('90');
+    }
+  });
+
+  it('Update with CrashRetention.max_age_days > 90 → InvalidArgument', async () => {
+    const client = harness.makeClient(SettingsService);
+    try {
+      await client.updateSettings({
+        meta: newRequestMeta(),
+        settings: create(SettingsSchema, {
+          crashRetention: create(CrashRetentionSchema, {
+            maxEntries: 1000,
+            maxAgeDays: 91,
+          }),
+        }),
+        scope: SettingsScope.GLOBAL,
+      });
+      expect.fail('expected InvalidArgument');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConnectError);
+      expect((err as ConnectError).code).toBe(Code.InvalidArgument);
+    }
+  });
+
+  it('Update with empty request_id → InvalidArgument + request.missing_id', async () => {
+    // ch04 §2 / F7: every RPC validates request_id. Use a low-level
+    // build that explicitly sets an empty string (newRequestMeta would
+    // generate a UUID).
+    const client = harness.makeClient(SettingsService);
+    try {
+      await client.updateSettings({
+        meta: { requestId: '', clientVersion: '0.3.0-test', clientSendUnixMs: BigInt(0) },
+        settings: create(SettingsSchema, {}),
+        scope: SettingsScope.GLOBAL,
+      });
+      expect.fail('expected InvalidArgument');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConnectError);
+      const ce = err as ConnectError;
+      expect(ce.code).toBe(Code.InvalidArgument);
+      const detail = ce.findDetails(ErrorDetailSchema)[0];
+      expect(detail.code).toBe('request.missing_id');
+    }
+  });
+
+  it('Get with empty request_id → InvalidArgument + request.missing_id', async () => {
+    const client = harness.makeClient(SettingsService);
+    try {
+      await client.getSettings({
+        meta: { requestId: '', clientVersion: '0.3.0-test', clientSendUnixMs: BigInt(0) },
+        scope: SettingsScope.GLOBAL,
+      });
+      expect.fail('expected InvalidArgument');
+    } catch (err) {
+      expect((err as ConnectError).code).toBe(Code.InvalidArgument);
+      const detail = (err as ConnectError).findDetails(ErrorDetailSchema)[0];
+      expect(detail.code).toBe('request.missing_id');
+    }
+  });
+
+  it('Update with SETTINGS_SCOPE_PRINCIPAL → InvalidArgument (v0.3 rejects v0.4 scope)', async () => {
+    const client = harness.makeClient(SettingsService);
+    try {
+      await client.updateSettings({
+        meta: newRequestMeta(),
+        settings: create(SettingsSchema, {}),
+        scope: SettingsScope.PRINCIPAL,
+      });
+      expect.fail('expected InvalidArgument');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConnectError);
+      const ce = err as ConnectError;
+      expect(ce.code).toBe(Code.InvalidArgument);
+      const detail = ce.findDetails(ErrorDetailSchema)[0];
+      expect(detail.code).toBe('settings.scope_unsupported');
+    }
+  });
+
+  it('Get with SETTINGS_SCOPE_PRINCIPAL → InvalidArgument (v0.3 rejects v0.4 scope)', async () => {
+    // Documented divergence from ch12 §3 prose ("NotFound for unknown key"):
+    // GetSettings has no per-key surface; the closest unknown-target
+    // surface is the v0.4 PRINCIPAL scope, which is wire-rejected with
+    // InvalidArgument BEFORE any row lookup. NotFound would require a
+    // GetSettingsByKey RPC the proto does not declare.
+    const client = harness.makeClient(SettingsService);
+    try {
+      await client.getSettings({
+        meta: newRequestMeta(),
+        scope: SettingsScope.PRINCIPAL,
+      });
+      expect.fail('expected InvalidArgument');
+    } catch (err) {
+      expect((err as ConnectError).code).toBe(Code.InvalidArgument);
+    }
+  });
+
+  it('Update with an empty (no-fields-set) Settings is a no-op (NOT InvalidArgument)', async () => {
+    // Spec ch04 §6 / F7: PARTIAL update by field presence. A Settings
+    // with no fields set means "do not change anything" — daemon MUST
+    // accept it and return the unchanged post-merge view. Pin this so a
+    // future stricter validation cannot quietly reject the no-op shape
+    // (Electron clients send empty Settings as a "round-trip my view"
+    // sanity ping).
+    //
+    // Note: the wire format always carries a Settings message instance
+    // for this RPC — the request schema does not mark `settings` as
+    // optional. Truly absent (undefined) is not reachable from a
+    // generated client. We test the canonical no-op shape instead.
+    const client = harness.makeClient(SettingsService);
+    const res = await client.updateSettings({
+      meta: newRequestMeta(),
+      settings: create(SettingsSchema, {}),
+      scope: SettingsScope.GLOBAL,
+    });
+    expect(res.effectiveScope).toBe(SettingsScope.GLOBAL);
+    expect(res.settings).toBeDefined();
+  });
+});

--- a/packages/daemon/test/integration/settings-roundtrip.spec.ts
+++ b/packages/daemon/test/integration/settings-roundtrip.spec.ts
@@ -1,0 +1,474 @@
+// packages/daemon/test/integration/settings-roundtrip.spec.ts
+//
+// T8.10 — integration spec: SettingsService.UpdateSettings +
+// GetSettings round-trip with DB persistence via the #54 sqlite wrapper.
+//
+// Spec ch12 §3:
+//   "settings-roundtrip.spec.ts — SettingsService.Update + Get happy
+//    path: round-trip equal."
+//
+// Spec ch04 §6 (SettingsService) + ch07 §3 (settings table):
+//   - UpdateSettings has PARTIAL UPDATE semantics: daemon REPLACES only
+//     the fields whose proto3 presence bit is set; absent fields are
+//     LEFT AT THEIR CURRENT VALUE. Round-trip means: send Update, get
+//     back the post-merge Settings; subsequent GetSettings returns the
+//     same merged Settings.
+//   - The DB row shape is `(scope, key, value)` PRIMARY KEY (scope, key);
+//     v0.3 daemon writes `scope = 'global'`. SETTINGS_SCOPE_PRINCIPAL is
+//     rejected with InvalidArgument (covered by settings-error.spec.ts).
+//   - Security-sensitive keys (`claude_binary_path`) are NOT in the
+//     proto schema — the boundary is mechanical (no field exists). So
+//     this spec only round-trips fields the proto allows.
+//
+// SRP:
+//   - Producer: SQLite via the daemon's `openDatabase` wrapper (#54
+//     T5.1) using `:memory:`. The wrapper applies the canonical boot
+//     PRAGMAs; settings round-trip in WAL mode end-to-end.
+//   - Decider: a `SettingsStore` class (in-test, ~80 lines) that
+//     encodes Settings → JSON-per-key DB rows, and the inverse for
+//     Get. Mirrors the encoding T6.x will own.
+//   - Sink: SettingsService handlers wired into the harness; client-
+//     side assertions on the post-merge Settings.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { create } from '@bufbuild/protobuf';
+import type { HandlerContext } from '@connectrpc/connect';
+import { Code, ConnectError } from '@connectrpc/connect';
+
+import {
+  CrashRetentionSchema,
+  type GetSettingsRequest,
+  GetSettingsResponseSchema,
+  PtyGeometrySchema,
+  SettingsScope,
+  SettingsSchema,
+  SettingsService,
+  type UpdateSettingsRequest,
+  UpdateSettingsResponseSchema,
+} from '@ccsm/proto';
+
+import { openDatabase, type SqliteDatabase } from '../../src/db/sqlite.js';
+import { newRequestMeta, startHarness, type Harness } from './harness.js';
+
+// ---------------------------------------------------------------------------
+// SQLite seed: minimal `settings` table that mirrors the schema in
+// migrations/001_initial.sql. Keep the DDL local to this spec — running
+// the migration runner here would couple T8.10 to T5.4 (Task #56).
+// ---------------------------------------------------------------------------
+
+const SETTINGS_DDL = `
+  CREATE TABLE IF NOT EXISTS settings (
+    scope TEXT NOT NULL,
+    key   TEXT NOT NULL,
+    value TEXT NOT NULL,
+    PRIMARY KEY (scope, key)
+  );
+`;
+
+// Forever-stable v0.3 scope literal (ch07 §3).
+const SCOPE_GLOBAL = 'global';
+
+// Forever-stable v0.3 settings key vocabulary. Each proto field maps to a
+// dotted-path key; map<string,string> ui_prefs entries land under
+// `ui.<original-dotted-path>`. Pin the vocabulary here so a v0.4 PR that
+// renames a key trips the round-trip equality assertion.
+const KEYS = {
+  defaultGeometry: 'pty.default_geometry',
+  crashRetention: 'crash.retention',
+  uiPrefsPrefix: 'ui.',
+  detectedClaudeDefaultModel: 'claude.detected_default_model',
+  userHomePath: 'user.home_path',
+  locale: 'locale',
+  sentryEnabled: 'crash.sentry_enabled',
+} as const;
+
+// ---------------------------------------------------------------------------
+// Encoder / decoder — proto Settings <-> per-key JSON rows.
+//
+// Keep this module-local (not a daemon export) so changes to the daemon's
+// own encoder do not silently coast through this spec. T6.x will own the
+// production encoder; this stand-in pins the wire round-trip irrespective
+// of how the daemon serializes internally.
+// ---------------------------------------------------------------------------
+
+interface SettingsLike {
+  defaultGeometry?: { cols: number; rows: number };
+  crashRetention?: { maxEntries: number; maxAgeDays: number };
+  uiPrefs: { [key: string]: string };
+  detectedClaudeDefaultModel: string;
+  userHomePath: string;
+  locale: string;
+  sentryEnabled: boolean;
+}
+
+class SettingsStore {
+  constructor(private readonly db: SqliteDatabase) {}
+
+  /** Read all keys under the given scope and project them into a
+   * SettingsLike shape. Missing keys map to proto defaults. */
+  read(scope: string): SettingsLike {
+    const rows = this.db
+      .prepare<[string], { key: string; value: string }>(
+        'SELECT key, value FROM settings WHERE scope = ?',
+      )
+      .all(scope);
+
+    const out: SettingsLike = {
+      uiPrefs: {},
+      detectedClaudeDefaultModel: '',
+      userHomePath: '',
+      locale: '',
+      sentryEnabled: true, // proto default per ch04 §6 / settings.proto
+    };
+    for (const row of rows) {
+      if (row.key === KEYS.defaultGeometry) {
+        out.defaultGeometry = JSON.parse(row.value);
+      } else if (row.key === KEYS.crashRetention) {
+        out.crashRetention = JSON.parse(row.value);
+      } else if (row.key === KEYS.detectedClaudeDefaultModel) {
+        out.detectedClaudeDefaultModel = JSON.parse(row.value);
+      } else if (row.key === KEYS.userHomePath) {
+        out.userHomePath = JSON.parse(row.value);
+      } else if (row.key === KEYS.locale) {
+        out.locale = JSON.parse(row.value);
+      } else if (row.key === KEYS.sentryEnabled) {
+        out.sentryEnabled = JSON.parse(row.value);
+      } else if (row.key.startsWith(KEYS.uiPrefsPrefix)) {
+        out.uiPrefs[row.key.slice(KEYS.uiPrefsPrefix.length)] = JSON.parse(
+          row.value,
+        );
+      }
+    }
+    return out;
+  }
+
+  /**
+   * PARTIAL update per spec ch04 §6 / F7. Only fields with proto3 presence
+   * bit set are written. Absent fields are LEFT ALONE (no DELETE).
+   * `ui_prefs` map merge semantics: keys in the incoming map are upserted;
+   * keys absent from the incoming map are LEFT in the DB (additive merge).
+   */
+  partialUpdate(scope: string, patch: Partial<SettingsLike>): SettingsLike {
+    const upsert = this.db.prepare<[string, string, string]>(
+      'INSERT INTO settings (scope, key, value) VALUES (?, ?, ?) ' +
+        'ON CONFLICT(scope, key) DO UPDATE SET value = excluded.value',
+    );
+    if (patch.defaultGeometry !== undefined) {
+      upsert.run(scope, KEYS.defaultGeometry, JSON.stringify(patch.defaultGeometry));
+    }
+    if (patch.crashRetention !== undefined) {
+      upsert.run(scope, KEYS.crashRetention, JSON.stringify(patch.crashRetention));
+    }
+    if (patch.uiPrefs !== undefined) {
+      for (const [k, v] of Object.entries(patch.uiPrefs)) {
+        upsert.run(scope, `${KEYS.uiPrefsPrefix}${k}`, JSON.stringify(v));
+      }
+    }
+    if (patch.detectedClaudeDefaultModel !== undefined) {
+      upsert.run(
+        scope,
+        KEYS.detectedClaudeDefaultModel,
+        JSON.stringify(patch.detectedClaudeDefaultModel),
+      );
+    }
+    if (patch.userHomePath !== undefined) {
+      upsert.run(scope, KEYS.userHomePath, JSON.stringify(patch.userHomePath));
+    }
+    if (patch.locale !== undefined) {
+      upsert.run(scope, KEYS.locale, JSON.stringify(patch.locale));
+    }
+    if (patch.sentryEnabled !== undefined) {
+      upsert.run(scope, KEYS.sentryEnabled, JSON.stringify(patch.sentryEnabled));
+    }
+    return this.read(scope);
+  }
+}
+
+// Convert the in-memory SettingsLike to the proto Settings shape used by
+// GetSettingsResponse / UpdateSettingsResponse.
+function toProtoSettings(s: SettingsLike) {
+  return create(SettingsSchema, {
+    defaultGeometry: s.defaultGeometry
+      ? create(PtyGeometrySchema, s.defaultGeometry)
+      : undefined,
+    crashRetention: s.crashRetention
+      ? create(CrashRetentionSchema, s.crashRetention)
+      : undefined,
+    uiPrefs: { ...s.uiPrefs },
+    detectedClaudeDefaultModel: s.detectedClaudeDefaultModel,
+    userHomePath: s.userHomePath,
+    locale: s.locale,
+    sentryEnabled: s.sentryEnabled,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Bring up.
+// ---------------------------------------------------------------------------
+
+let harness: Harness;
+let db: SqliteDatabase;
+let store: SettingsStore;
+
+beforeEach(async () => {
+  // openDatabase from #54 — exercises the canonical boot PRAGMAs even on
+  // :memory:. This is the path the production daemon takes; we stay on
+  // it so the round-trip exercises the same SQL surface (WAL, FK, etc.).
+  db = openDatabase(':memory:');
+  db.exec(SETTINGS_DDL);
+  store = new SettingsStore(db);
+
+  harness = await startHarness({
+    setup(router) {
+      router.service(SettingsService, {
+        async getSettings(req: GetSettingsRequest, _ctx: HandlerContext) {
+          // v0.3 daemon honors only SCOPE_GLOBAL (ch04 §6); other scopes
+          // are rejected by settings-error.spec.ts. Here we map any
+          // UNSPECIFIED to GLOBAL per the proto comment.
+          if (
+            req.scope !== SettingsScope.UNSPECIFIED &&
+            req.scope !== SettingsScope.GLOBAL
+          ) {
+            throw new ConnectError(
+              'unsupported scope in v0.3',
+              Code.InvalidArgument,
+            );
+          }
+          const settings = store.read(SCOPE_GLOBAL);
+          return create(GetSettingsResponseSchema, {
+            meta: newRequestMeta(),
+            settings: toProtoSettings(settings),
+            effectiveScope: SettingsScope.GLOBAL,
+          });
+        },
+
+        async updateSettings(req: UpdateSettingsRequest, _ctx: HandlerContext) {
+          if (
+            req.scope !== SettingsScope.UNSPECIFIED &&
+            req.scope !== SettingsScope.GLOBAL
+          ) {
+            throw new ConnectError(
+              'unsupported scope in v0.3',
+              Code.InvalidArgument,
+            );
+          }
+          const incoming = req.settings;
+          if (!incoming) {
+            throw new ConnectError(
+              'settings is required',
+              Code.InvalidArgument,
+            );
+          }
+          // Translate the proto presence semantics to a partial patch.
+          // Note: scalar fields without proto3 `optional` (locale,
+          // userHomePath, ...) are always present on the wire; we treat
+          // their incoming value as authoritative (no presence bit means
+          // "client always sends a value, even if empty"). The
+          // partial-update semantics are F7 (ch04 §6) for the OPTIONAL
+          // fields only: defaultGeometry, crashRetention. ui_prefs map
+          // merges additively per the F6 doc on Settings.ui_prefs.
+          const patch: Partial<SettingsLike> = {
+            // Always-present scalars — caller controls.
+            detectedClaudeDefaultModel: incoming.detectedClaudeDefaultModel,
+            userHomePath: incoming.userHomePath,
+            locale: incoming.locale,
+            sentryEnabled: incoming.sentryEnabled,
+          };
+          if (incoming.defaultGeometry !== undefined) {
+            patch.defaultGeometry = {
+              cols: incoming.defaultGeometry.cols,
+              rows: incoming.defaultGeometry.rows,
+            };
+          }
+          if (incoming.crashRetention !== undefined) {
+            patch.crashRetention = {
+              maxEntries: incoming.crashRetention.maxEntries,
+              maxAgeDays: incoming.crashRetention.maxAgeDays,
+            };
+          }
+          if (Object.keys(incoming.uiPrefs).length > 0) {
+            patch.uiPrefs = { ...incoming.uiPrefs };
+          }
+
+          const merged = store.partialUpdate(SCOPE_GLOBAL, patch);
+          return create(UpdateSettingsResponseSchema, {
+            meta: newRequestMeta(),
+            settings: toProtoSettings(merged),
+            effectiveScope: SettingsScope.GLOBAL,
+          });
+        },
+      });
+    },
+  });
+});
+
+afterEach(async () => {
+  await harness.stop();
+  db.close();
+});
+
+// ---------------------------------------------------------------------------
+// The spec.
+// ---------------------------------------------------------------------------
+
+describe('settings-roundtrip (ch12 §3 / ch04 §6 / ch07 §3)', () => {
+  it('Update then Get returns the same Settings (full payload, GLOBAL scope)', async () => {
+    const client = harness.makeClient(SettingsService);
+
+    const payload = create(SettingsSchema, {
+      defaultGeometry: create(PtyGeometrySchema, { cols: 120, rows: 40 }),
+      crashRetention: create(CrashRetentionSchema, {
+        maxEntries: 5000,
+        maxAgeDays: 30,
+      }),
+      uiPrefs: {
+        'appearance.theme': 'dark',
+        'composer.fontSizePx': '14',
+        'notify.enabled': 'true',
+      },
+      detectedClaudeDefaultModel: 'claude-sonnet-4',
+      userHomePath: '/home/test',
+      locale: 'en-US',
+      sentryEnabled: false,
+    });
+
+    const upd = await client.updateSettings({
+      meta: newRequestMeta(),
+      settings: payload,
+      scope: SettingsScope.GLOBAL,
+    });
+    expect(upd.effectiveScope).toBe(SettingsScope.GLOBAL);
+
+    // Update response carries the post-merge Settings (F7 round-trip
+    // requirement). Spot-check the load-bearing fields.
+    expect(upd.settings?.defaultGeometry?.cols).toBe(120);
+    expect(upd.settings?.defaultGeometry?.rows).toBe(40);
+    expect(upd.settings?.crashRetention?.maxEntries).toBe(5000);
+    expect(upd.settings?.crashRetention?.maxAgeDays).toBe(30);
+    expect(upd.settings?.uiPrefs).toEqual({
+      'appearance.theme': 'dark',
+      'composer.fontSizePx': '14',
+      'notify.enabled': 'true',
+    });
+    expect(upd.settings?.detectedClaudeDefaultModel).toBe('claude-sonnet-4');
+    expect(upd.settings?.userHomePath).toBe('/home/test');
+    expect(upd.settings?.locale).toBe('en-US');
+    expect(upd.settings?.sentryEnabled).toBe(false);
+
+    // Subsequent GetSettings returns the persisted view byte-for-byte.
+    const get = await client.getSettings({
+      meta: newRequestMeta(),
+      scope: SettingsScope.GLOBAL,
+    });
+    expect(get.effectiveScope).toBe(SettingsScope.GLOBAL);
+    expect(get.settings).toEqual(upd.settings);
+  });
+
+  it('UNSPECIFIED scope is treated as GLOBAL on both Get and Update (ch04 §6 default)', async () => {
+    const client = harness.makeClient(SettingsService);
+
+    const upd = await client.updateSettings({
+      meta: newRequestMeta(),
+      settings: create(SettingsSchema, {
+        locale: 'zh-CN',
+        sentryEnabled: true,
+      }),
+      scope: SettingsScope.UNSPECIFIED,
+    });
+    expect(upd.effectiveScope).toBe(SettingsScope.GLOBAL);
+    expect(upd.settings?.locale).toBe('zh-CN');
+
+    const get = await client.getSettings({
+      meta: newRequestMeta(),
+      scope: SettingsScope.UNSPECIFIED,
+    });
+    expect(get.effectiveScope).toBe(SettingsScope.GLOBAL);
+    expect(get.settings?.locale).toBe('zh-CN');
+  });
+
+  it('partial Update preserves untouched OPTIONAL fields (F7 ch04 §6)', async () => {
+    const client = harness.makeClient(SettingsService);
+
+    // Step 1: set both defaultGeometry and crashRetention.
+    await client.updateSettings({
+      meta: newRequestMeta(),
+      settings: create(SettingsSchema, {
+        defaultGeometry: create(PtyGeometrySchema, { cols: 80, rows: 24 }),
+        crashRetention: create(CrashRetentionSchema, {
+          maxEntries: 100,
+          maxAgeDays: 7,
+        }),
+      }),
+      scope: SettingsScope.GLOBAL,
+    });
+
+    // Step 2: update ONLY crashRetention; defaultGeometry must be
+    // preserved by the partial-update semantics.
+    const upd = await client.updateSettings({
+      meta: newRequestMeta(),
+      settings: create(SettingsSchema, {
+        crashRetention: create(CrashRetentionSchema, {
+          maxEntries: 9999,
+          maxAgeDays: 90,
+        }),
+        // defaultGeometry intentionally omitted.
+      }),
+      scope: SettingsScope.GLOBAL,
+    });
+
+    // Post-merge Settings carries BOTH the new crashRetention AND the
+    // preserved defaultGeometry — the F7 contract.
+    expect(upd.settings?.crashRetention?.maxEntries).toBe(9999);
+    expect(upd.settings?.crashRetention?.maxAgeDays).toBe(90);
+    expect(upd.settings?.defaultGeometry?.cols).toBe(80);
+    expect(upd.settings?.defaultGeometry?.rows).toBe(24);
+  });
+
+  it('ui_prefs map merges additively across Updates (F6 ch04 §6)', async () => {
+    const client = harness.makeClient(SettingsService);
+
+    await client.updateSettings({
+      meta: newRequestMeta(),
+      settings: create(SettingsSchema, {
+        uiPrefs: { 'appearance.theme': 'light' },
+      }),
+      scope: SettingsScope.GLOBAL,
+    });
+    const upd2 = await client.updateSettings({
+      meta: newRequestMeta(),
+      settings: create(SettingsSchema, {
+        uiPrefs: { 'composer.fontSizePx': '16' },
+      }),
+      scope: SettingsScope.GLOBAL,
+    });
+
+    // Both keys are present after the second update.
+    expect(upd2.settings?.uiPrefs).toEqual({
+      'appearance.theme': 'light',
+      'composer.fontSizePx': '16',
+    });
+  });
+
+  it('persisted rows survive a daemon-side Get after Update — DB-backed, not in-memory', async () => {
+    const client = harness.makeClient(SettingsService);
+
+    await client.updateSettings({
+      meta: newRequestMeta(),
+      settings: create(SettingsSchema, {
+        userHomePath: '/Users/test',
+      }),
+      scope: SettingsScope.GLOBAL,
+    });
+
+    // Read directly from the DB (bypass Connect) — the row must be in
+    // the `settings` table with `scope = 'global'`. Pins that the
+    // round-trip is not faking persistence with an in-process map.
+    const row = db
+      .prepare<[string, string], { value: string }>(
+        'SELECT value FROM settings WHERE scope = ? AND key = ?',
+      )
+      .get(SCOPE_GLOBAL, KEYS.userHomePath);
+    expect(row).toBeDefined();
+    expect(JSON.parse(row!.value)).toBe('/Users/test');
+  });
+});

--- a/packages/daemon/test/integration/version-mismatch.spec.ts
+++ b/packages/daemon/test/integration/version-mismatch.spec.ts
@@ -1,0 +1,180 @@
+// packages/daemon/test/integration/version-mismatch.spec.ts
+//
+// T8.10 — integration spec: SessionService.Hello version negotiation
+// (error path).
+//
+// Spec ch12 §3:
+//   "version-mismatch.spec.ts — SessionService.Hello error path:
+//    `proto_min_version` higher than daemon's; assert `FailedPrecondition`
+//    with structured detail."
+//
+// Spec ch04 §3 (proto-min-version negotiation contract): when the
+// client's `HelloRequest.proto_min_version` exceeds the daemon's
+// `PROTO_VERSION`, the daemon MUST reject the handshake with
+// `Code.FailedPrecondition` and attach an `ErrorDetail` with the
+// forever-stable code `version.client_too_old` and an `extra` map carrying
+// the daemon's actual `proto_version`. The client uses the structured
+// detail (not the human message) to drive an upgrade prompt.
+//
+// Out of scope:
+//   - The unit truth-table for proto-min-version negotiation lives in
+//     `@ccsm/proto`'s `proto-min-version-truth-table.spec.ts` (ch12 §2).
+//     This integration spec asserts only the *wire surface*: ConnectError
+//     code + the byte shape of the attached ErrorDetail.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { create } from '@bufbuild/protobuf';
+import { Code, ConnectError } from '@connectrpc/connect';
+
+import {
+  ErrorDetailSchema,
+  HelloResponseSchema,
+  PROTO_VERSION,
+  SessionService,
+} from '@ccsm/proto';
+
+import { newRequestMeta, startHarness, type Harness } from './harness.js';
+
+// ---------------------------------------------------------------------------
+// Hello handler that enforces the proto-min-version contract. T2.2's real
+// SessionService impl will own this; we stand in a minimal contract-shape
+// version here so the wire assertion is meaningful even before T2.2 lands.
+// Once T2.2 ships, the harness wiring stays the same and the handler can
+// be replaced with the real implementation.
+// ---------------------------------------------------------------------------
+
+function helloEnforcingVersion(req: {
+  protoMinVersion: number;
+  clientKind: string;
+}) {
+  if (req.protoMinVersion > PROTO_VERSION) {
+    // Spec ch04 §3: structured ErrorDetail.code MUST be
+    // `version.client_too_old` and `extra.daemon_proto_version` MUST
+    // be the daemon's PROTO_VERSION as a decimal string. Electron's
+    // upgrade-prompt UX reads this map keys directly.
+    throw new ConnectError(
+      `client requires proto v${req.protoMinVersion}; daemon serves v${PROTO_VERSION}`,
+      Code.FailedPrecondition,
+      undefined,
+      [
+        {
+          desc: ErrorDetailSchema,
+          value: {
+            code: 'version.client_too_old',
+            message: 'Client proto_min_version exceeds daemon proto_version.',
+            extra: {
+              daemon_proto_version: String(PROTO_VERSION),
+              client_proto_min_version: String(req.protoMinVersion),
+            },
+          },
+        },
+      ],
+    );
+  }
+  return create(HelloResponseSchema, {
+    meta: newRequestMeta(),
+    daemonVersion: '0.3.0-test',
+    protoVersion: PROTO_VERSION,
+    listenerId: 'A',
+  });
+}
+
+let harness: Harness;
+
+beforeEach(async () => {
+  harness = await startHarness({
+    setup(router) {
+      router.service(SessionService, {
+        hello: helloEnforcingVersion,
+      });
+    },
+  });
+});
+
+afterEach(async () => {
+  await harness.stop();
+});
+
+// ---------------------------------------------------------------------------
+// Happy-path control: proto_min_version <= PROTO_VERSION succeeds. Pinned
+// alongside the error path so the rejection assertion cannot pass
+// vacuously by, e.g., the handler always throwing.
+// ---------------------------------------------------------------------------
+
+describe('version-mismatch (ch04 §3)', () => {
+  it('proto_min_version equal to daemon PROTO_VERSION succeeds', async () => {
+    const client = harness.makeClient(SessionService);
+    const res = await client.hello({
+      meta: newRequestMeta(),
+      clientKind: 'electron',
+      protoMinVersion: PROTO_VERSION,
+    });
+    expect(res.protoVersion).toBe(PROTO_VERSION);
+    expect(res.daemonVersion).toBe('0.3.0-test');
+    expect(res.listenerId).toBe('A');
+  });
+
+  it('proto_min_version below daemon PROTO_VERSION succeeds (forever-additive contract)', async () => {
+    const client = harness.makeClient(SessionService);
+    const res = await client.hello({
+      meta: newRequestMeta(),
+      clientKind: 'electron',
+      protoMinVersion: Math.max(0, PROTO_VERSION - 1),
+    });
+    expect(res.protoVersion).toBe(PROTO_VERSION);
+  });
+
+  // -----------------------------------------------------------------------
+  // The error path the spec names.
+  // -----------------------------------------------------------------------
+
+  it('proto_min_version above daemon PROTO_VERSION → FailedPrecondition + version.client_too_old detail', async () => {
+    const client = harness.makeClient(SessionService);
+    const tooHigh = PROTO_VERSION + 1;
+    try {
+      await client.hello({
+        meta: newRequestMeta(),
+        clientKind: 'electron',
+        protoMinVersion: tooHigh,
+      });
+      expect.fail('expected FailedPrecondition');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConnectError);
+      const ce = err as ConnectError;
+      expect(ce.code).toBe(Code.FailedPrecondition);
+
+      // Structured detail is the load-bearing surface for the
+      // Electron-side upgrade-prompt UX. Spec ch04 §3 + ch04 §7.1 #4.
+      const details = ce.findDetails(ErrorDetailSchema);
+      expect(details).toHaveLength(1);
+      const detail = details[0];
+      expect(detail.code).toBe('version.client_too_old');
+      // The exact daemon proto_version value is the contract — Electron
+      // shows the user "daemon supports up to v<N>".
+      expect(detail.extra['daemon_proto_version']).toBe(String(PROTO_VERSION));
+      expect(detail.extra['client_proto_min_version']).toBe(String(tooHigh));
+    }
+  });
+
+  it('extreme client min-version still produces the same structured error code', async () => {
+    // Defensive: a client that requests v999 (the v0.4 / v0.5 minor we
+    // have not shipped) MUST receive the same `version.client_too_old`
+    // code so the Electron upgrade prompt is uniform regardless of how
+    // far ahead the client thinks it is.
+    const client = harness.makeClient(SessionService);
+    try {
+      await client.hello({
+        meta: newRequestMeta(),
+        clientKind: 'electron',
+        protoMinVersion: 999,
+      });
+      expect.fail('expected FailedPrecondition');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConnectError);
+      const ce = err as ConnectError;
+      expect(ce.code).toBe(Code.FailedPrecondition);
+      const detail = ce.findDetails(ErrorDetailSchema)[0];
+      expect(detail.code).toBe('version.client_too_old');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Task #99 — adds the 6 ch12 §3 integration specs the v0.3 RPC surface freeze requires, plus a shared `harness.ts` that wires the real `peerCredAuthInterceptor` (T1.3) on top of an in-process h2c Connect server.

Files (all under `packages/daemon/test/integration/`):
- `harness.ts` — shared in-process Connect bring-up; loopback-TCP bearer-token is the test seam for the OS peer-cred extractor (T1.5).
- `peer-cred-rejection.spec.ts` — (a) Unauthenticated when transport cannot resolve principal; (b) PermissionDenied with structured `session.not_owned` ErrorDetail when caller's principalKey != session owner. OS-syscall variant guarded behind `process.platform === 'linux' && CCSM_TEST_SECOND_USER` per ch12 §3.
- `version-mismatch.spec.ts` — Hello with `proto_min_version > PROTO_VERSION` → FailedPrecondition + `version.client_too_old` ErrorDetail carrying `daemon_proto_version`.
- `crash-stream.spec.ts` — WatchCrashLog streams CrashEntry events covering every ch09 §1 capture source category (sqlite_op / uncaught_exception / claude_exit / supervisor_shutdown). OWN filter includes `daemon-self` sentinel; foreign-owner entries dropped.
- `crash-getlog.spec.ts` — GetCrashLog with `since_unix_ms` cursor; server-side `limit` cap at 1000 (ch04 §5); empty result is empty entries (NOT NotFound — proto3 collection convention).
- `settings-roundtrip.spec.ts` — Update + Get round-trip via the #54 `openDatabase` wrapper on `:memory:`; partial-update preserves untouched OPTIONAL fields (F7); `ui_prefs` map merges additively (F6); persisted rows survive a direct DB read (proves DB-backed, not in-memory).
- `settings-error.spec.ts` — InvalidArgument + structured ErrorDetail for: empty `request_id` (`request.missing_id`), out-of-range `crash_retention`, non-positive geometry, `SETTINGS_SCOPE_PRINCIPAL` (v0.4 scope rejected on v0.3).

## Notes / divergences from ch12 §3 prose

Documented in spec body comments inside each file:

- **"NotFound for unknown id" on GetCrashLog** — the proto's `GetCrashLogRequest` has no `id` field; closest contract surfaces are exercised instead (empty-entries result + ALL-vs-OWN filter shape). Adding `GetCrashEntry(id)` would be schema drift the spec freeze forbids.
- **"NotFound for unknown key" on GetSettings** — same shape: `GetSettingsRequest` has no `key` field; covered as InvalidArgument on the v0.4 `SETTINGS_SCOPE_PRINCIPAL` value (the only other valid enum value v0.3 daemon rejects).

## Handler stand-ins

Each spec inlines a minimal handler that enforces the relevant contract. Real handlers land later:
- `SessionService.{Hello, GetSession}` → T2.2 (#32, dispatched in parallel)
- `CrashService.{WatchCrashLog, GetCrashLog}` → T5.11 / Task #62
- `SettingsService.{GetSettings, UpdateSettings}` → T6.x

When the real handlers ship, the harness wiring stays unchanged and the in-spec stand-ins can be replaced with the real impl. The contract under test (wire codes + ErrorDetail shapes) is identical.

`it.todo` placeholder reserved for the real-second-user OS-syscall variant of peer-cred-rejection (T1.5 may not be merged when this lands; CI re-enables once T1.5 + the ubuntu-22.04 self-hosted runner with `useradd ccsm-test-other` ship).

## Test plan

- [x] `pnpm lint` — pass
- [x] `pnpm --filter @ccsm/daemon run typecheck` — pass
- [x] `pnpm --filter @ccsm/daemon test test/integration` — 6 new spec files pass (300+ assertions across 30 it() blocks)
- [x] Pre-existing `test/descriptor/schema.spec.ts` CRLF-vs-LF golden failure verified unrelated by stashing this branch's changes and re-running on plain `origin/working` — same failure (Windows-only, golden written with LF, comparator reads CRLF).