### PR TITLE
daemon(T2.5): structured ErrorDetail emitter + standard codes

### DIFF
--- a/packages/daemon/src/rpc/errors.ts
+++ b/packages/daemon/src/rpc/errors.ts
@@ -1,0 +1,152 @@
+// Single source of truth for ErrorDetail emission on the daemon side.
+// Spec ch02 §3 / §6, ch04 §2.
+//
+// T2.5 scope: a tiny, pure-decider module that
+//   1. enumerates the v0.3 forever-stable `ErrorDetail.code` strings as a
+//      closed string-literal union, so call sites cannot drift;
+//   2. maps each standard code to its forever-stable Connect `Code`
+//      mapping (ch02 §5 `daemon.starting` → UNAVAILABLE; ch04 §3
+//      `version.client_too_old` → FAILED_PRECONDITION; ch04 §2 / §7.1
+//      `request.missing_id` → INVALID_ARGUMENT; ch05 §4 / §5
+//      `session.not_owned` → PERMISSION_DENIED);
+//   3. exposes one builder + one thrower so handlers write
+//
+//        throwError('session.not_owned', undefined, { session_id });
+//
+//      instead of hand-rolling `new ConnectError(..., Code.X, undefined,
+//      [{ desc: ErrorDetailSchema, value: { code, message, extra } }])`
+//      at every call site.
+//
+// SRP: pure decider only. NO I/O, NO logging, NO global state. Callers
+// (handlers, middleware) own the side effect of throwing into Connect.
+// `throwError` is sugar over `buildError` — `buildError` returns a
+// `ConnectError` so handlers that need to attach the error to a stream
+// or wrap it can use the value form.
+//
+// Forever-stable surface (per spec ch04 §2 / §8 additivity rule):
+//   - The 4 codes below MUST NOT be renamed, removed, or repurposed in
+//     any v0.3.x patch. v0.4+ may ADD new codes by extending the
+//     `STANDARD_ERROR_MAP` table; the closed-enum type widens
+//     automatically (it is derived from `keyof typeof`).
+//   - Connect code mappings MUST NOT change for an existing string code
+//     once it ships — Electron / web / iOS clients branch on the pair
+//     `(connect_code, error_detail.code)`.
+//
+// Layer 1 — alternatives checked:
+//   - Hand-rolling ConnectError at each handler: 30+ call sites would
+//     drift on the code-string spelling and on the Connect-code mapping
+//     (ch04 §7.1 #4 round-trip test pins the strings, but doesn't pin
+//     the daemon emission). Single source of truth is cheaper than
+//     spec-test-drift.
+//   - Generating the table from proto: ErrorDetail is a free-form
+//     message in `common.proto` (the codes are documentation-only); the
+//     proto file deliberately does NOT enumerate codes (open set per
+//     ch04 §2). The TS-side closed enum is the v0.3 emission contract,
+//     not the wire contract.
+//   - Reusing a third-party "structured error" lib (e.g. @bufbuild
+//     google.rpc.Status helpers): Connect-ES v2's `OutgoingDetail`
+//     shape `{ desc, value }` is already the canonical attach point.
+//     A wrapper adds zero value over a 5-line helper.
+
+import { Code, ConnectError } from '@connectrpc/connect';
+import { ErrorDetailSchema } from '@ccsm/proto';
+
+/**
+ * Forever-stable v0.3 standard `ErrorDetail.code` → Connect `Code`
+ * mapping. Each row pins the spec section that locks both the string
+ * code and the Connect code, so a reviewer can grep one identifier and
+ * find the source of truth.
+ *
+ * Adding a new row in v0.4+: append only. Renaming or removing a row is
+ * a breaking change at the wire level (`buf breaking` won't catch it
+ * because the strings live in TS, not in `common.proto` — reviewers
+ * MUST treat this table like a forever-stable proto enum).
+ */
+export const STANDARD_ERROR_MAP = {
+  // ch02 §5 — Listener A connect during boot (Supervisor /healthz 503).
+  'daemon.starting': Code.Unavailable,
+  // ch04 §3 — Hello negotiation: client.proto_min_version > daemon.proto_version.
+  'version.client_too_old': Code.FailedPrecondition,
+  // ch04 §2 / §7.1 — RequestMeta validation: empty request_id.
+  'request.missing_id': Code.InvalidArgument,
+  // ch05 §4 / §5 — per-RPC ownership enforcement matrix.
+  'session.not_owned': Code.PermissionDenied,
+} as const satisfies Record<string, Code>;
+
+/**
+ * Closed string-literal union of v0.3 standard `ErrorDetail.code`
+ * values. ts-only typecheck enforces that `throwError` / `buildError`
+ * cannot be called with an arbitrary string (drift detection).
+ *
+ * Derived from `STANDARD_ERROR_MAP` so adding a row in the table
+ * widens the type automatically — there is no second list to keep in
+ * sync.
+ */
+export type StandardErrorCode = keyof typeof STANDARD_ERROR_MAP;
+
+/**
+ * Default human-readable messages per code. Used when a caller does
+ * NOT pass a `message` override. Strings are advisory (UI may show);
+ * they are NOT a wire contract — the wire contract is the code string.
+ *
+ * Kept aligned with `packages/proto/test/contract/error-detail-roundtrip.spec.ts`
+ * so the contract test's fixture messages match what the daemon emits
+ * by default. Drift here is harmless on the wire but helps reviewers
+ * verify the round-trip test reflects real daemon behavior.
+ */
+const DEFAULT_MESSAGES: Record<StandardErrorCode, string> = {
+  'daemon.starting': 'Daemon is still starting; retry in 200ms.',
+  'version.client_too_old':
+    'Client proto_min_version exceeds daemon proto_version.',
+  'request.missing_id':
+    'request_id is required and must be a non-empty UUIDv4.',
+  'session.not_owned': 'Session is owned by a different principal.',
+};
+
+/**
+ * Construct a `ConnectError` carrying an `ErrorDetail` proto in the
+ * Connect-ES v2 outgoing-details slot. Returns the value so callers
+ * that need to attach the error to a stream (e.g. server-streaming
+ * RPCs that emit then close-with-error) can use it without throwing.
+ *
+ * Most call sites should use `throwError` instead.
+ *
+ * @param code     Standard error code (closed enum).
+ * @param message  Optional human override; defaults to `DEFAULT_MESSAGES[code]`.
+ * @param extra    Optional `map<string,string>` payload (e.g.
+ *                 `{ session_id, principal, daemon_proto_version }`).
+ *                 Keys are open per ch04 §7.1; reviewers SHOULD reuse
+ *                 existing key names where possible.
+ */
+export function buildError(
+  code: StandardErrorCode,
+  message?: string,
+  extra?: Readonly<Record<string, string>>,
+): ConnectError {
+  const connectCode = STANDARD_ERROR_MAP[code];
+  const humanMessage = message ?? DEFAULT_MESSAGES[code];
+  return new ConnectError(humanMessage, connectCode, undefined, [
+    {
+      desc: ErrorDetailSchema,
+      value: {
+        code,
+        message: humanMessage,
+        extra: extra ? { ...extra } : {},
+      },
+    },
+  ]);
+}
+
+/**
+ * Throw a `ConnectError` carrying an `ErrorDetail` for the given
+ * standard code. The return type is `never` so TypeScript narrows
+ * control flow at the call site (e.g. `if (!s) throwError(...)` makes
+ * `s` non-nullable below).
+ */
+export function throwError(
+  code: StandardErrorCode,
+  message?: string,
+  extra?: Readonly<Record<string, string>>,
+): never {
+  throw buildError(code, message, extra);
+}

--- a/packages/daemon/test/rpc/errors.spec.ts
+++ b/packages/daemon/test/rpc/errors.spec.ts
@@ -1,0 +1,233 @@
+// T2.5 — daemon emission contract for ErrorDetail + Connect code mapping.
+//
+// Sibling to `packages/proto/test/contract/error-detail-roundtrip.spec.ts`
+// (T0.12 #4): the proto-side test pins the WIRE shape of `ErrorDetail`;
+// this test pins the DAEMON-SIDE EMISSION — i.e. the closed enum of
+// standard codes, the Connect `Code` mapping per code, and the
+// invariant that `buildError` / `throwError` attach an `ErrorDetail`
+// proto in the Connect-ES v2 outgoing-details slot so client-side
+// `findDetails(ErrorDetailSchema)` can extract it after a round-trip.
+//
+// Spec refs:
+//   - ch02 §5      `daemon.starting`        → UNAVAILABLE
+//   - ch04 §3      `version.client_too_old` → FAILED_PRECONDITION
+//   - ch04 §2 / §7.1 `request.missing_id`   → INVALID_ARGUMENT
+//   - ch05 §4 / §5 `session.not_owned`      → PERMISSION_DENIED
+//
+// The tests round-trip ErrorDetail through proto encode/decode (since
+// in this unit context we don't have a Connect transport — that path
+// is exercised by the proto-side round-trip test) and assert the
+// decoded `code` / `message` / `extra` survive intact. Combined with
+// `findDetails` (used here directly because we have the
+// `OutgoingDetail` array in memory), this is the local equivalent of
+// the wire round-trip.
+
+import { describe, expect, it, expectTypeOf } from 'vitest';
+import { Code, ConnectError } from '@connectrpc/connect';
+import { fromBinary, toBinary } from '@bufbuild/protobuf';
+import { ErrorDetailSchema, type ErrorDetail } from '@ccsm/proto';
+
+import {
+  STANDARD_ERROR_MAP,
+  buildError,
+  throwError,
+  type StandardErrorCode,
+} from '../../src/rpc/errors.js';
+
+// ---------------------------------------------------------------------------
+// Forever-stable mapping table — duplicated here intentionally as the
+// "expected" side of the contract. If a v0.4 patch reorders or
+// remaps an existing row in `STANDARD_ERROR_MAP`, this test fails.
+// Adding a NEW code in `STANDARD_ERROR_MAP` MUST be paired with a new
+// row here (the `keyof` exhaustiveness assertion at the bottom of the
+// file enforces that mechanically).
+// ---------------------------------------------------------------------------
+const EXPECTED: ReadonlyArray<{
+  code: StandardErrorCode;
+  connectCode: Code;
+  defaultMessageContains: string;
+}> = [
+  {
+    code: 'daemon.starting',
+    connectCode: Code.Unavailable,
+    defaultMessageContains: 'starting',
+  },
+  {
+    code: 'version.client_too_old',
+    connectCode: Code.FailedPrecondition,
+    defaultMessageContains: 'proto_min_version',
+  },
+  {
+    code: 'request.missing_id',
+    connectCode: Code.InvalidArgument,
+    defaultMessageContains: 'request_id',
+  },
+  {
+    code: 'session.not_owned',
+    connectCode: Code.PermissionDenied,
+    defaultMessageContains: 'principal',
+  },
+];
+
+/**
+ * Decode the single ErrorDetail proto from a ConnectError's outgoing
+ * details slot. The Connect-ES v2 typing models outgoing details as
+ * `{ desc, value }` objects (NOT yet encoded to bytes); we round-trip
+ * through `toBinary` / `fromBinary` so the test exercises the proto
+ * shape end-to-end and would catch a regression where `buildError`
+ * starts emitting an init-shape that fails to encode.
+ */
+function decodeAttachedDetail(err: ConnectError): ErrorDetail {
+  expect(err.details.length).toBe(1);
+  const d = err.details[0]!;
+  // Outgoing details have shape { desc, value } (init shape, not bytes).
+  expect('desc' in d).toBe(true);
+  // narrow to outgoing
+  const outgoing = d as { desc: typeof ErrorDetailSchema; value: unknown };
+  expect(outgoing.desc).toBe(ErrorDetailSchema);
+  // The init `value` may not be a fully-constructed Message yet — encode
+  // and decode to get a normalized `ErrorDetail` instance.
+  // Build a real message via the schema so toBinary accepts it.
+  const bytes = toBinary(
+    ErrorDetailSchema,
+    // create() not strictly required here — buildError already passes
+    // a plain init object; we materialize it via fromBinary on a freshly
+    // encoded buffer using the message-init friendly path:
+    {
+      $typeName: 'ccsm.v1.ErrorDetail',
+      ...(outgoing.value as object),
+    } as ErrorDetail,
+  );
+  return fromBinary(ErrorDetailSchema, bytes);
+}
+
+describe('rpc/errors — STANDARD_ERROR_MAP coverage', () => {
+  it('exposes exactly the four v0.3 forever-stable codes', () => {
+    // Keys snapshot — sorted for stability. Adding a v0.4 code MUST
+    // update this assertion explicitly (review-gate, NOT auto-passing).
+    expect(Object.keys(STANDARD_ERROR_MAP).sort()).toEqual(
+      [
+        'daemon.starting',
+        'request.missing_id',
+        'session.not_owned',
+        'version.client_too_old',
+      ],
+    );
+  });
+
+  for (const fixture of EXPECTED) {
+    it(`maps "${fixture.code}" → Connect Code ${Code[fixture.connectCode]}`, () => {
+      expect(STANDARD_ERROR_MAP[fixture.code]).toBe(fixture.connectCode);
+    });
+  }
+});
+
+describe('rpc/errors — buildError / throwError emit ConnectError + ErrorDetail', () => {
+  for (const fixture of EXPECTED) {
+    it(`buildError("${fixture.code}") → ConnectError with matching code + attached ErrorDetail`, () => {
+      const err = buildError(fixture.code);
+
+      expect(err).toBeInstanceOf(ConnectError);
+      expect(err.code).toBe(fixture.connectCode);
+
+      const detail = decodeAttachedDetail(err);
+      expect(detail.code).toBe(fixture.code);
+      // Default message is non-empty and references something
+      // recognizable (the per-code default lives in errors.ts).
+      expect(detail.message.length).toBeGreaterThan(0);
+      expect(detail.message.toLowerCase()).toContain(
+        fixture.defaultMessageContains.toLowerCase(),
+      );
+      // No extra by default.
+      expect(Object.keys(detail.extra)).toEqual([]);
+    });
+
+    it(`throwError("${fixture.code}") throws the same shape`, () => {
+      let thrown: unknown;
+      try {
+        throwError(fixture.code);
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toBeInstanceOf(ConnectError);
+      const err = thrown as ConnectError;
+      expect(err.code).toBe(fixture.connectCode);
+      const detail = decodeAttachedDetail(err);
+      expect(detail.code).toBe(fixture.code);
+    });
+  }
+
+  it('honors the optional message override', () => {
+    const err = buildError('session.not_owned', 'custom message');
+    expect(err.rawMessage).toBe('custom message');
+    const detail = decodeAttachedDetail(err);
+    expect(detail.message).toBe('custom message');
+  });
+
+  it('round-trips the extra map (open string keys per ch04 §7.1)', () => {
+    const err = buildError('session.not_owned', undefined, {
+      session_id: '01HXYZ123',
+      principal: 'local-user:1000',
+    });
+    const detail = decodeAttachedDetail(err);
+    expect({ ...detail.extra }).toEqual({
+      session_id: '01HXYZ123',
+      principal: 'local-user:1000',
+    });
+  });
+
+  it('attaches extra for version.client_too_old (daemon_proto_version per ch04 §3)', () => {
+    const err = buildError('version.client_too_old', undefined, {
+      daemon_proto_version: '1',
+    });
+    const detail = decodeAttachedDetail(err);
+    expect(detail.extra['daemon_proto_version']).toBe('1');
+  });
+
+  it('does not mutate the caller-supplied extra map', () => {
+    const extra = { session_id: 'sid-1' };
+    const err = buildError('session.not_owned', undefined, extra);
+    const detail = decodeAttachedDetail(err);
+    detail.extra['injected'] = 'x';
+    expect(extra).toEqual({ session_id: 'sid-1' });
+  });
+});
+
+describe('rpc/errors — ts-only typecheck enforces the closed code enum', () => {
+  it('StandardErrorCode is exactly the four v0.3 codes', () => {
+    expectTypeOf<StandardErrorCode>().toEqualTypeOf<
+      | 'daemon.starting'
+      | 'version.client_too_old'
+      | 'request.missing_id'
+      | 'session.not_owned'
+    >();
+  });
+
+  it('buildError rejects non-standard code at compile time', () => {
+    // Type-only assertion — never invoke the call (the value would
+    // throw at runtime because there is no entry in STANDARD_ERROR_MAP
+    // for these strings; that's the whole point of the closed enum).
+    // The `// @ts-expect-error` directives below are the actual
+    // assertion: they fail the typecheck if the closed enum ever
+    // widens to accept an arbitrary string.
+    const _checkRejection = (): void => {
+      // @ts-expect-error — "session.not_found" is NOT a v0.3 standard
+      // code (it's mentioned in ch04 §7.1 as a representative *example*
+      // for the round-trip test, but is not in the v0.3 emission set).
+      buildError('session.not_found');
+      // @ts-expect-error — open-set arbitrary string is rejected.
+      buildError('arbitrary.string');
+      // @ts-expect-error — throwError shares the same closed enum.
+      throwError('not.a.code');
+    };
+    // Reference the symbol so eslint's no-unused-vars doesn't complain
+    // and so vitest registers the test as having an expectation.
+    expect(typeof _checkRejection).toBe('function');
+  });
+
+  it('STANDARD_ERROR_MAP value type is Connect Code', () => {
+    expectTypeOf(STANDARD_ERROR_MAP['daemon.starting']).toEqualTypeOf<
+      typeof Code.Unavailable
+    >();
+  });
+});


### PR DESCRIPTION
## Summary

Closes Task #39 [T2.5]. Single source of truth for ErrorDetail emission at `packages/daemon/src/rpc/errors.ts`, so daemon handlers stop hand-rolling `new ConnectError(..., Code.X, undefined, [{ desc: ErrorDetailSchema, value: { code, message, extra }}])` at every call site and cannot drift on either the code spelling or the Connect code mapping.

### `packages/daemon/src/rpc/errors.ts`

- `STANDARD_ERROR_MAP` — closed table mapping the four v0.3 forever-stable `ErrorDetail.code` strings to their forever-stable Connect `Code`:
  - `daemon.starting` -> `Code.Unavailable` (spec ch02 §5)
  - `version.client_too_old` -> `Code.FailedPrecondition` (spec ch04 §3)
  - `request.missing_id` -> `Code.InvalidArgument` (spec ch04 §2 / §7.1)
  - `session.not_owned` -> `Code.PermissionDenied` (spec ch05 §4 / §5)
- `StandardErrorCode` — closed string-literal union derived from the map via `keyof typeof`, so the type and the table cannot drift.
- `buildError(code, message?, extra?) -> ConnectError` — attaches the ErrorDetail proto in the Connect-ES v2 outgoing-details slot.
- `throwError(code, message?, extra?): never` — sugar over `buildError`.
- Pure decider only (no I/O, no logging, no state). Default human messages are aligned with `packages/proto/test/contract/error-detail-roundtrip.spec.ts` fixtures.

### `packages/daemon/test/rpc/errors.spec.ts` (20 cases)

- Each standard code maps to the spec-pinned Connect Code.
- `buildError` / `throwError` emit `ConnectError` with the correct code and attach an `ErrorDetail` proto whose `code` / `message` / `extra` survive an encode-decode round-trip.
- Optional message override; `extra` map round-trips multi-key payloads including the `daemon_proto_version` key called out in ch04 §3.
- Caller-supplied `extra` is not mutated by callee.
- ts-only typecheck (`expectTypeOf` + `// @ts-expect-error`) pins `StandardErrorCode` to the four codes and rejects open-set strings at compile time.

## Test plan

Local validation (Windows, pool-11):

```
$ npx vitest run test/rpc/errors.spec.ts
 Test Files  1 passed (1)
      Tests  20 passed (20)
   Duration  1.05s

$ pnpm lint     # clean
$ pnpm typecheck  # clean (tsc -p tsconfig.json + tsconfig.test.json)
```

Reverse-verify (mutate `STANDARD_ERROR_MAP['session.not_owned']` to `Code.NotFound`):

```
 Test Files  1 failed (1)
      Tests  3 failed | 17 passed (20)
```

Restored mapping passes 20/20 again.

- [ ] CI green on `working`